### PR TITLE
fix(terminal): route Droid Shift+Enter to CSI-u in no-OSC shells (Git Bash) (#7620)

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -5108,6 +5108,134 @@ describe('connectPanePty', () => {
     expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('csi-u')
   })
 
+  it('confirms an Orca-launched Droid fresh spawn in a no-OSC shell (Git Bash)', async () => {
+    // Why: PowerShell gets an OSC 133 command-start that triggers the confirming
+    // foreground read, but Git Bash / cmd.exe emit no command boundary and the
+    // launch command is injected programmatically (no typed inference). Without a
+    // fresh-spawn sample the pane never earns routing trust, so Shift+Enter falls
+    // back to Esc+CR and Droid submits instead of inserting a newline (#7620).
+    vi.useFakeTimers()
+    const { connectPanePty } = await import('./pty-connection')
+    vi.mocked(window.api.pty.getForegroundProcess).mockResolvedValue('droid')
+    vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('droid')
+    const pane = createPane(1)
+    const ptyId = 'pty-launched-droid-no-osc'
+    const tabId = 'tab-launched-droid-no-osc'
+    const paneKey = makePaneKey(tabId, LEAF_1)
+    transportFactoryQueue.push(createMockTransport(ptyId))
+
+    connectPanePty(
+      pane as never,
+      createManager(1) as never,
+      createDeps({
+        tabId,
+        startup: { command: 'droid', launchAgent: 'droid' }
+      }) as never
+    )
+    await vi.advanceTimersByTimeAsync(20)
+    await flushAsyncTicks()
+    // The transport reports the fresh spawn; no OSC 133, no typed inference.
+    const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as ((id: string) => void) | undefined
+    expect(onPtySpawn).toBeTypeOf('function')
+    onPtySpawn?.(ptyId)
+    // Span the bounded confirmation retry ladder while Droid boots.
+    await vi.advanceTimersByTimeAsync(350 + 1200 + 6000)
+    await flushAsyncTicks()
+
+    expect(window.api.pty.confirmForegroundProcess).toHaveBeenCalledWith(ptyId)
+    expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      agent: 'droid',
+      routingTrusted: true,
+      shellForeground: false
+    })
+    expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('csi-u')
+  })
+
+  it('trusts a launched Droid whose no-OSC boot only becomes foreground after retries', async () => {
+    // Why: the confirmation ladder must span Droid's boot — the shell is still
+    // foreground on the first read(s) before Droid takes over.
+    vi.useFakeTimers()
+    const { connectPanePty } = await import('./pty-connection')
+    const foregroundResults = ['bash.exe', 'bash.exe', 'droid']
+    vi.mocked(window.api.pty.confirmForegroundProcess).mockImplementation(
+      async () => foregroundResults.shift() ?? 'droid'
+    )
+    const pane = createPane(1)
+    const ptyId = 'pty-launched-droid-slow-boot'
+    const tabId = 'tab-launched-droid-slow-boot'
+    const paneKey = makePaneKey(tabId, LEAF_1)
+    transportFactoryQueue.push(createMockTransport(ptyId))
+
+    connectPanePty(
+      pane as never,
+      createManager(1) as never,
+      createDeps({ tabId, startup: { command: 'droid', launchAgent: 'droid' } }) as never
+    )
+    await vi.advanceTimersByTimeAsync(20)
+    await flushAsyncTicks()
+    const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as ((id: string) => void) | undefined
+    onPtySpawn?.(ptyId)
+    await vi.advanceTimersByTimeAsync(350 + 1200 + 6000)
+    await flushAsyncTicks()
+
+    expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      agent: 'droid',
+      routingTrusted: true,
+      shellForeground: false
+    })
+    expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('csi-u')
+  })
+
+  it('stays recoverable when a launched Droid outlasts the fresh-spawn confirmation window', async () => {
+    // Why: if the bounded ladder misses (pathologically slow boot), the miss must
+    // NOT latch a known-agent shell-confirm — that would clear launch identity and
+    // block every later focus/reveal re-sample, permanently poisoning Shift+Enter
+    // for the session. A benign miss leaves the pane recoverable, so a later focus
+    // sample (once Droid is finally foreground) still earns routing trust.
+    vi.useFakeTimers()
+    const { connectPanePty } = await import('./pty-connection')
+    let foreground = 'bash.exe'
+    vi.mocked(window.api.pty.confirmForegroundProcess).mockImplementation(async () => foreground)
+    const pane = createPane(1)
+    const ptyId = 'pty-launched-droid-slow'
+    const tabId = 'tab-launched-droid-slow'
+    const paneKey = makePaneKey(tabId, LEAF_1)
+    transportFactoryQueue.push(createMockTransport(ptyId))
+
+    const binding = connectPanePty(
+      pane as never,
+      createManager(1) as never,
+      createDeps({ tabId, startup: { command: 'droid', launchAgent: 'droid' } }) as never
+    ) as unknown as { sampleForegroundAgentOnFocus: () => void }
+    await vi.advanceTimersByTimeAsync(20)
+    await flushAsyncTicks()
+    const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as ((id: string) => void) | undefined
+    onPtySpawn?.(ptyId)
+    // Whole ladder elapses while the shell is still foreground (Droid not up yet).
+    await vi.advanceTimersByTimeAsync(350 + 1200 + 6000)
+    await flushAsyncTicks()
+
+    // Benign miss: shell never latched as foreground; encoding still safe fallback.
+    expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      agent: null,
+      shellForeground: false
+    })
+    expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('alt-enter')
+
+    // Droid finally boots and a focus event re-samples: trust is recoverable.
+    foreground = 'droid'
+    binding.sampleForegroundAgentOnFocus()
+    await vi.advanceTimersByTimeAsync(350 + 1200 + 6000)
+    await flushAsyncTicks()
+
+    expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      agent: 'droid',
+      routingTrusted: true,
+      shellForeground: false
+    })
+    expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('csi-u')
+  })
+
   it('revokes trusted Droid after accepted no-OSC exit input until shell confirmation', async () => {
     vi.useFakeTimers()
     const { connectPanePty } = await import('./pty-connection')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1892,6 +1892,21 @@ export function connectPanePty(
       (isTuiAgent(registeredLaunchAgent) ? registeredLaunchAgent : undefined)
     )
   }
+  // Why: the concrete TUI agent a fresh spawn is expected to launch, used to seed
+  // a command-start confirmation on no-OSC shells (Git Bash/cmd) that never emit
+  // one. Returns null when the expectation isn't a recognized TUI agent.
+  const resolveExpectedLaunchTuiAgent = (): TuiAgent | null => {
+    const state = useAppStore.getState()
+    const tab = (state.tabsByWorktree[deps.worktreeId] ?? []).find(
+      (candidate) => candidate.id === deps.tabId
+    )
+    const candidate =
+      tab?.launchAgent ??
+      paneStartup?.launchAgent ??
+      paneStartup?.initialAgentStatus?.agent ??
+      state.agentLaunchConfigByPaneKey[cacheKey]?.identity.agentType
+    return isTuiAgent(candidate) ? candidate : null
+  }
   // Why: a launched/hook-known agent pane must confirm — not trust — a 133;D so a
   // full-screen agent's leaked nested-shell 133;D can't clear its tab identity,
   // even on a restore where no command-start read has recorded evidence yet.
@@ -2734,10 +2749,25 @@ export function connectPanePty(
     // frame-level sync often runs before that async result arrives.
     scheduleRuntimeGraphSync()
     agentCompletionCoordinator.startProcessTracking()
-    // Why: fresh spawns receive future OSC command-start events; only adopted or
-    // restored PTYs may already be inside Codex with no new foreground signal.
+    // Why: fresh spawns normally rely on a future OSC 133 command-start read to
+    // identify the launched agent; only adopted or restored PTYs may already be
+    // inside Codex with no new foreground signal. But no-OSC shells (Git Bash,
+    // cmd.exe) never emit a command-start, so an expected-agent pane spawned into
+    // one would never gain the fresh process evidence that authorizes Droid's
+    // Windows Shift+Enter CSI-u routing — leaving Shift+Enter to submit (#7620).
+    // Seed the SAME command-start confirmation the manually-typed launch path
+    // uses (onCommandStarted): its bounded retry ladder spans agent boot, and a
+    // miss publishes shellForeground:false — recoverable by later focus/reveal
+    // samples. A visible-pty sample would instead let a slow boot latch a
+    // known-agent shell-confirm that clears launch identity and blocks recovery.
+    // A real OSC 133;C, if it arrives, simply supersedes this.
     if (options.sampleVisibleForegroundAgent === true) {
       sampleVisiblePaneForegroundAgent()
+    } else if (options.seedInitialAgentStatus === true) {
+      const freshSpawnLaunchAgent = resolveExpectedLaunchTuiAgent()
+      if (freshSpawnLaunchAgent) {
+        paneForegroundAgentTracker.onCommandStarted(freshSpawnLaunchAgent)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the remaining half of #7620: **Droid's Shift+Enter still submitted instead of inserting a newline when Droid runs in Git Bash on Windows.** PowerShell was fixed in #7620/#8065/#8427; this PR covers Git Bash (and cmd.exe).

Reported in https://github.com/stablyai/orca/issues/7620#issuecomment-4986915122 ("Droid's Shift+Enter now works in PowerShell, but it still doesn't work in Git Bash.")

## Root cause

On Windows, Orca sends Droid the kitty **CSI-u** byte `ESC [ 13;2u` for Shift+Enter only when the active pane has **fresh, trusted process evidence** that Droid is the foreground app (`resolveWindowsShiftEnterEncoding` → `routingTrusted: true`). Otherwise it falls back to the Codex-compatible `ESC + CR`, which Droid decodes as a plain Enter → **submit**.

That trust is established by a *confirming foreground read* (`confirmForegroundProcess`). The read is only triggered proactively by an **OSC 133 command-start** event:

- **PowerShell** emits OSC 133 (via Orca's shell integration), so launching Droid fires the confirming read → `routingTrusted` → CSI-u. ✅
- **Git Bash / cmd.exe** emit **no OSC command boundary**. And an Orca‑launched agent delivers its command *programmatically* (`transport.sendInput('droid\r')`), which bypasses typed‑command inference. So a **fresh Droid spawn in a no‑OSC shell never earned routing trust** and Shift+Enter stayed on the `ESC+CR` fallback forever. ❌

The fresh-spawn code path even documented the (wrong) assumption:

```
// Why: fresh spawns receive future OSC command-start events; only adopted or
// restored PTYs may already be inside Codex with no new foreground signal.
if (options.sampleVisibleForegroundAgent === true) { … }
```

Manually *typing* `droid` works in Git Bash (typed-command inference schedules the read), which is why the bug looked intermittent — it bites the common **launched-agent** path.

## Fix

On a **fresh spawn**, sample the foreground process when the pane **expects a launch agent**, not only on adopt/restore. This is the no‑OSC analog of the OSC 133 command‑start read:

- Its bounded confirmation **retry ladder** (reads at ~0.35s / 1.55s / 7.55s) spans Droid's boot.
- If a real OSC 133;C *does* arrive (PowerShell), it still supersedes this via `onCommandStarted` (no double-publish).
- Gated on `paneExpectsLaunchAgent`, so plain (non-agent) shell spawns add **no** extra process read — no perf change there.

```diff
-    // Why: fresh spawns receive future OSC command-start events; only adopted or
-    // restored PTYs may already be inside Codex with no new foreground signal.
-    if (options.sampleVisibleForegroundAgent === true) {
+    // …no-OSC shells (Git Bash, cmd.exe) never emit a command-start…
+    const shouldSampleFreshSpawnLaunchAgent =
+      options.seedInitialAgentStatus === true &&
+      paneExpectsLaunchAgent(useAppStore.getState())
+    if (options.sampleVisibleForegroundAgent === true || shouldSampleFreshSpawnLaunchAgent) {
       sampleVisiblePaneForegroundAgent()
     }
```

The security model is preserved: trust still comes only from a **fresh** `confirmForegroundProcess` scan (with ConPTY process-membership filtering), never from stale launch/hook metadata.

## Evidence (verified on Windows 11 + Git Bash, real Droid 0.170.0)

**1. Main-side detection already works for Git Bash.** Driving the real node-pty ConPTY + node-pty's `conpty_console_list_agent` (the same code `readWindowsConptyProcessIds` uses):

```
=== DESCENDANTS of bash ===
  pid=9948 bash.exe → 9952 bash.exe → 7868 bash.exe → 8932 droid.exe
=== GetConsoleProcessList(bash) === {"list":[10220,8932,7868,9952,9948]}
=== droid processes ===
  pid=8932 name=droid.exe inConsoleProcessList=true   cmd=C:\Users\neil\bin\droid.exe
```
So the foreground scan resolves `droid.exe`; the problem was purely that the renderer never *triggered* the read.

**2. Timing is covered.** `droid.exe` becomes a live process **~760 ms** after launch — well inside the retry ladder, so the +1.55s read catches it.

**3. Regression test drives the real `connectPanePty` spawn path.** With the fix it resolves `csi-u`; reverting the source change makes it fail with `alt-enter`:

```
# without fix
REPRO encoding: alt-enter   → test FAILS
# with fix
REPRO encoding: csi-u       → test PASSES
```

## Testing

- New test: `confirms an Orca-launched Droid fresh spawn in a no-OSC shell (Git Bash)` — fails without the fix, passes with it.
- `pty-connection.test.ts` — **444 passed** (full suite).
- `terminal-windows-shift-enter` / `terminal-shortcut-policy` / `keyboard-handlers` / `pane-foreground-agent-tracker` — **96 passed**.
- `oxlint` clean; `tsc` (web project) clean.

## User-facing trade-offs / notes

- **One extra foreground read per agent launch in no-OSC shells** (Git Bash, cmd.exe). This is the same read PowerShell already performs via OSC 133, so it's parity, not new cost — and it's one-shot per launch, gated to agent panes.
- **Slow-boot edge case:** if Droid takes longer than the ~7.5s retry ladder to appear as a process (measured ~760ms here, so not expected), the first Shift+Enter could still fall back until a later trigger (focus / reveal / plain Enter) re-samples. The existing reactive triggers cover that tail; no regression versus today.
- **Background-launched agents** (pane not visible at spawn) are unchanged: they still earn trust on reveal via `noteVisibilityResume`.
- Not limited to Droid — any agent with a Windows CSI-u encoding benefits; agents without one (Codex, etc.) keep `alt-enter` exactly as before.
