### PR TITLE
fix(agents): keep Windows Cursor startup prompts out of argv (#8793)

### DIFF
--- a/src/renderer/src/components/right-sidebar/runSourceControlAgentActionStart.test.ts
+++ b/src/renderer/src/components/right-sidebar/runSourceControlAgentActionStart.test.ts
@@ -18,6 +18,10 @@ vi.mock('@/lib/launch-agent-in-new-tab', () => ({
   launchAgentInNewTab: mocks.launchAgentInNewTab
 }))
 
+vi.mock('@/lib/new-workspace', () => ({
+  CLIENT_PLATFORM: 'win32'
+}))
+
 vi.mock('sonner', () => ({
   toast: { error: mocks.toastError }
 }))
@@ -285,6 +289,33 @@ describe('runSourceControlAgentActionStart', () => {
         agent: 'cursor',
         promptDelivery: 'submit-after-ready',
         launchPlatform: 'win32'
+      })
+    )
+  })
+
+  it('uses the Windows client platform when launchPlatform is omitted', async () => {
+    mocks.launchAgentInNewTab.mockReturnValue({
+      tabId: 'tab-1',
+      startupPlan: {} as never,
+      pasteDraftAfterLaunch: true,
+      promptDeliveryResult: Promise.resolve({ delivered: true, failureNotified: false })
+    })
+
+    await expect(
+      runSourceControlAgentActionStart(
+        buildArgs({
+          selectedAgent: 'cursor',
+          promptDelivery: 'auto-submit',
+          launchPlatform: undefined
+        })
+      )
+    ).resolves.toBe(true)
+
+    expect(mocks.launchAgentInNewTab).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: 'cursor',
+        promptDelivery: 'submit-after-ready',
+        launchPlatform: undefined
       })
     )
   })

--- a/src/renderer/src/components/right-sidebar/runSourceControlAgentActionStart.test.ts
+++ b/src/renderer/src/components/right-sidebar/runSourceControlAgentActionStart.test.ts
@@ -262,6 +262,33 @@ describe('runSourceControlAgentActionStart', () => {
     expect(mocks.toastError).not.toHaveBeenCalled()
   })
 
+  it('maps followup-path auto-submit launches onto submit-after-ready', async () => {
+    mocks.launchAgentInNewTab.mockReturnValue({
+      tabId: 'tab-1',
+      startupPlan: {} as never,
+      pasteDraftAfterLaunch: true,
+      promptDeliveryResult: Promise.resolve({ delivered: true, failureNotified: false })
+    })
+
+    await expect(
+      runSourceControlAgentActionStart(
+        buildArgs({
+          selectedAgent: 'cursor',
+          promptDelivery: 'auto-submit',
+          launchPlatform: 'win32'
+        })
+      )
+    ).resolves.toBe(true)
+
+    expect(mocks.launchAgentInNewTab).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: 'cursor',
+        promptDelivery: 'submit-after-ready',
+        launchPlatform: 'win32'
+      })
+    )
+  })
+
   it('keeps injected onStart successes immediate', async () => {
     const onStart = vi.fn().mockResolvedValue(true)
 

--- a/src/renderer/src/components/right-sidebar/runSourceControlAgentActionStart.ts
+++ b/src/renderer/src/components/right-sidebar/runSourceControlAgentActionStart.ts
@@ -13,6 +13,7 @@ import { toast } from 'sonner'
 import { translate } from '@/i18n/i18n'
 import { sourceControlActionRecipeMatchesTarget } from './source-control-action-recipe-match'
 import { resolveSourceControlAgentSaveTarget } from './source-control-agent-action-dialog-support'
+import { getTuiAgentPromptInjectionMode } from '../../../../shared/tui-agent-config'
 
 type RunSourceControlAgentActionStartArgs = {
   selectedAgent: TuiAgent
@@ -84,6 +85,12 @@ export async function runSourceControlAgentActionStart({
     launchAcceptedNotified = true
     onLaunchAccepted?.()
   }
+  const effectivePromptDelivery =
+    promptDelivery === 'auto-submit' &&
+    launchPlatform &&
+    getTuiAgentPromptInjectionMode(selectedAgent, launchPlatform) === 'stdin-after-start'
+      ? 'submit-after-ready'
+      : promptDelivery
   if (onStart) {
     launched = await onStart({
       agent: selectedAgent,
@@ -100,7 +107,7 @@ export async function runSourceControlAgentActionStart({
       groupId: groupId ?? worktreeId,
       prompt: trimmedCommandInput,
       agentArgs,
-      promptDelivery,
+      promptDelivery: effectivePromptDelivery,
       launchPlatform,
       launchSource
     })

--- a/src/renderer/src/components/right-sidebar/runSourceControlAgentActionStart.ts
+++ b/src/renderer/src/components/right-sidebar/runSourceControlAgentActionStart.ts
@@ -1,5 +1,6 @@
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import { launchAgentInNewTab } from '@/lib/launch-agent-in-new-tab'
+import { CLIENT_PLATFORM } from '@/lib/new-workspace'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { Repo } from '../../../../shared/repo-types'
 import type { TuiAgent } from '../../../../shared/tui-agent'
@@ -87,8 +88,8 @@ export async function runSourceControlAgentActionStart({
   }
   const effectivePromptDelivery =
     promptDelivery === 'auto-submit' &&
-    launchPlatform &&
-    getTuiAgentPromptInjectionMode(selectedAgent, launchPlatform) === 'stdin-after-start'
+    getTuiAgentPromptInjectionMode(selectedAgent, launchPlatform ?? CLIENT_PLATFORM) ===
+      'stdin-after-start'
       ? 'submit-after-ready'
       : promptDelivery
   if (onStart) {

--- a/src/renderer/src/lib/launch-agent-background-session.test.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.test.ts
@@ -540,27 +540,30 @@ describe('launchAgentBackgroundSession', () => {
     )
   })
 
-  it('submits prompts for stdin-after-start agents in background mode', async () => {
-    const { launchAgentBackgroundSession } = await import('./launch-agent-background-session')
+  it.each([
+    ['aider', 'run the automation', "aider '--yes-always'", null],
+    ['cursor', 'fix the startup path', "cursor-agent '--yolo'", 'win32']
+  ] as const)(
+    'submits %s startup prompts after ready in background mode',
+    async (agent, prompt, command, platform) => {
+      if (platform) {
+        mockGetAgentLaunchPlatformForRepo.mockReturnValue(platform)
+      }
+      const { launchAgentBackgroundSession } = await import('./launch-agent-background-session')
 
-    await launchAgentBackgroundSession({
-      agent: 'aider',
-      worktreeId: 'wt-1',
-      prompt: 'run the automation'
-    })
+      await launchAgentBackgroundSession({ agent, worktreeId: 'wt-1', prompt })
 
-    expect(mockSpawn).toHaveBeenCalledWith(
-      expect.objectContaining({ command: "aider '--yes-always'" })
-    )
-    expect(mockPasteDraftWhenAgentReady).toHaveBeenCalledWith(
-      expect.objectContaining({
-        tabId: expectReservedAgentBackgroundTabId(mockSpawn),
-        content: 'run the automation',
-        agent: 'aider',
-        submit: true
-      })
-    )
-  })
+      expect(mockSpawn).toHaveBeenCalledWith(expect.objectContaining({ command }))
+      expect(mockPasteDraftWhenAgentReady).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tabId: expectReservedAgentBackgroundTabId(mockSpawn),
+          content: prompt,
+          agent,
+          submit: true
+        })
+      )
+    }
+  )
 
   it('passes Hermes automation prompts through the native startup query', async () => {
     const { launchAgentBackgroundSession } = await import('./launch-agent-background-session')

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -12,6 +12,7 @@ import {
   resolveTuiAgentLaunchEnv
 } from '../../../shared/tui-agent-launch-defaults'
 import { requireTuiAgentConfig } from '../../../shared/require-tui-agent-config'
+import { getTuiAgentPromptInjectionMode } from '../../../shared/tui-agent-config'
 import { resolveAgentBackgroundLaunchHost } from '@/lib/agent-background-session-launch-host'
 import { makePaneKey } from '../../../shared/stable-pane-id'
 import {
@@ -82,8 +83,8 @@ export async function launchAgentBackgroundSession(
   })
   const trimmedPrompt = prompt?.trim() ?? ''
   const hasPrompt = trimmedPrompt.length > 0
-  const isFollowupPath = requireTuiAgentConfig(agent).promptInjectionMode === 'stdin-after-start'
-
+  const isFollowupPath =
+    getTuiAgentPromptInjectionMode(agent, launchPlatform) === 'stdin-after-start'
   const pasteDraftAfterLaunch = hasPrompt && isFollowupPath ? trimmedPrompt : null
   const startupPlan = buildAgentStartupPlan({
     agent,

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -85,6 +85,7 @@ export async function launchAgentBackgroundSession(
   const hasPrompt = trimmedPrompt.length > 0
   const isFollowupPath =
     getTuiAgentPromptInjectionMode(agent, launchPlatform) === 'stdin-after-start'
+
   const pasteDraftAfterLaunch = hasPrompt && isFollowupPath ? trimmedPrompt : null
   const startupPlan = buildAgentStartupPlan({
     agent,

--- a/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
@@ -173,6 +173,12 @@ describe('launchAgentInNewTab', () => {
     mockPasteDraftWhenAgentReady.mockResolvedValue(true)
   })
 
+  // Enable native-chat routing on top of the beforeEach default settings.
+  const enableNativeChat = () => {
+    store.settings.experimentalNativeChat = true
+    store.settings.openAgentTabsInChatByDefault = true
+  }
+
   it('stamps the launched agent on the new tab for immediate provider icon bootstrap', async () => {
     const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
 
@@ -212,15 +218,31 @@ describe('launchAgentInNewTab', () => {
     )
   })
 
+  it('routes Windows Cursor startup prompts after ready', async () => {
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    launchAgentInNewTab({
+      agent: 'cursor',
+      worktreeId: 'wt-1',
+      prompt: 'fix the startup path',
+      launchPlatform: 'win32'
+    })
+
+    expect(mockQueueTabStartupCommand).toHaveBeenCalledWith(
+      'tab-1',
+      expect.objectContaining({ command: "cursor-agent '--yolo'" })
+    )
+    expect(mockPasteDraftWhenAgentReady).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'fix the startup path',
+        agent: 'cursor',
+        submit: false
+      })
+    )
+  })
+
   it('opens supported submit-after-ready launches in chat and seeds a launch prompt echo', async () => {
-    store.settings = {
-      agentCmdOverrides: {},
-      agentDefaultArgs: {},
-      agentDefaultEnv: {},
-      activeRuntimeEnvironmentId: null,
-      experimentalNativeChat: true,
-      openAgentTabsInChatByDefault: true
-    }
+    enableNativeChat()
     const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
 
     launchAgentInNewTab({
@@ -249,14 +271,7 @@ describe('launchAgentInNewTab', () => {
   })
 
   it('opens local Grok submit-after-ready launches in native chat', async () => {
-    store.settings = {
-      agentCmdOverrides: {},
-      agentDefaultArgs: {},
-      agentDefaultEnv: {},
-      activeRuntimeEnvironmentId: null,
-      experimentalNativeChat: true,
-      openAgentTabsInChatByDefault: true
-    }
+    enableNativeChat()
     const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
 
     launchAgentInNewTab({
@@ -280,14 +295,7 @@ describe('launchAgentInNewTab', () => {
   })
 
   it('keeps Model-A SSH Grok launches in terminal mode', async () => {
-    store.settings = {
-      agentCmdOverrides: {},
-      agentDefaultArgs: {},
-      agentDefaultEnv: {},
-      activeRuntimeEnvironmentId: null,
-      experimentalNativeChat: true,
-      openAgentTabsInChatByDefault: true
-    }
+    enableNativeChat()
     store.repos = [{ id: 'repo-1', connectionId: 'ssh-target-1', path: '/repo' }]
     const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
 
@@ -495,14 +503,8 @@ describe('launchAgentInNewTab', () => {
 
   it('propagates the default chat mode to paired web runtime launches', async () => {
     mockIsWebRuntimeSessionActive.mockReturnValue(true)
-    store.settings = {
-      agentCmdOverrides: {},
-      agentDefaultArgs: {},
-      agentDefaultEnv: {},
-      activeRuntimeEnvironmentId: 'web-runtime',
-      experimentalNativeChat: true,
-      openAgentTabsInChatByDefault: true
-    }
+    store.settings.activeRuntimeEnvironmentId = 'web-runtime'
+    enableNativeChat()
     const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
 
     launchAgentInNewTab({ agent: 'codex', worktreeId: 'wt-1' })

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -21,7 +21,7 @@ import {
   resolveTuiAgentLaunchEnv
 } from '../../../shared/tui-agent-launch-defaults'
 import { resolveLocalWindowsAgentStartupShell } from '../../../shared/windows-terminal-shell'
-import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
+import { getTuiAgentPromptInjectionMode } from '../../../shared/tui-agent-config'
 import { repoIsRemote } from '../../../shared/agent-launch-remote'
 import { seedCommandCodeSubmittedPromptStatus } from '@/lib/command-code-prompt-status-seed'
 import type { TuiAgent } from '../../../shared/tui-agent'
@@ -109,7 +109,8 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
   const agentEnv = resolveTuiAgentLaunchEnv(agent, store.settings?.agentDefaultEnv)
   const trimmedPrompt = prompt?.trim() ?? ''
   const hasPrompt = trimmedPrompt.length > 0
-  const isFollowupPath = TUI_AGENT_CONFIG[agent].promptInjectionMode === 'stdin-after-start'
+  const isFollowupPath =
+    getTuiAgentPromptInjectionMode(agent, resolvedLaunchPlatform) === 'stdin-after-start'
   // Why: the remote host can't infer this client's draft/default view choice, so decide it here for paired tabs too.
   const viewModePromptDelivery =
     hasPrompt && isFollowupPath && promptDelivery === 'auto-submit' ? 'draft' : promptDelivery

--- a/src/renderer/src/lib/source-control-agent-action-plan.test.ts
+++ b/src/renderer/src/lib/source-control-agent-action-plan.test.ts
@@ -42,6 +42,20 @@ describe('planSourceControlAgentActionLaunch', () => {
     expect(result.ok && result.caveat).toContain('PATH')
   })
 
+  it('routes Windows Cursor source-control prompts after ready', () => {
+    const result = planSourceControlAgentActionLaunch({
+      agent: 'cursor',
+      commandInput: 'Fix checks',
+      promptDelivery: 'auto-submit',
+      detectedAgents: ['cursor'],
+      platform: 'win32'
+    })
+
+    expect(result.ok && result.delivery).toBe('paste-submit')
+    expect(result.ok && result.plan.launchCommand).toBe('cursor-agent')
+    expect(result.ok && result.plan.launchCommand).not.toContain('Fix checks')
+  })
+
   it('includes per-action CLI arguments in submit-after-ready launch plans', () => {
     const result = planSourceControlAgentActionLaunch({
       agent: 'codex',

--- a/src/renderer/src/lib/source-control-agent-action-plan.ts
+++ b/src/renderer/src/lib/source-control-agent-action-plan.ts
@@ -5,7 +5,7 @@ import {
   type AgentStartupPlan
 } from '@/lib/tui-agent-startup'
 import { CLIENT_PLATFORM } from '@/lib/new-workspace'
-import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
+import { getTuiAgentPromptInjectionMode } from '../../../shared/tui-agent-config'
 import { isTuiAgentEnabled } from '../../../shared/tui-agent-selection'
 import type { TuiAgent } from '../../../shared/tui-agent'
 import { translate } from '@/i18n/i18n'
@@ -154,7 +154,7 @@ export function planSourceControlAgentActionLaunch(args: {
       })
       delivery = 'draft-paste'
     }
-  } else if (TUI_AGENT_CONFIG[agent].promptInjectionMode === 'stdin-after-start') {
+  } else if (getTuiAgentPromptInjectionMode(agent, platform) === 'stdin-after-start') {
     startupPlan = buildAgentStartupPlan({
       agent,
       prompt: '',
@@ -166,7 +166,7 @@ export function planSourceControlAgentActionLaunch(args: {
       sessionOptions: args.sessionOptions,
       allowEmptyPromptLaunch: true
     })
-    delivery = 'draft-paste'
+    delivery = args.promptDelivery === 'auto-submit' ? 'paste-submit' : 'draft-paste'
   } else {
     startupPlan = buildAgentStartupPlan({
       agent,

--- a/src/shared/terminal-quick-commands.test.ts
+++ b/src/shared/terminal-quick-commands.test.ts
@@ -333,6 +333,10 @@ describe('terminal quick commands', () => {
     expect(supportsTerminalAgentQuickCommand('aider')).toBe(false)
     expect(supportsTerminalAgentQuickCommand('not-real')).toBe(false)
   })
+
+  it('keeps Cursor quick-command support with the Windows override', () => {
+    expect(supportsTerminalAgentQuickCommand('cursor')).toBe(true)
+  })
 })
 
 describe('flattenTerminalQuickCommand', () => {

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -30,6 +30,7 @@ export type TuiAgentConfig = {
   launchCmdByPlatform?: Partial<Record<NodeJS.Platform, string>>
   expectedProcess: string
   promptInjectionMode: AgentPromptInjectionMode
+  promptInjectionModeByPlatform?: Partial<Record<NodeJS.Platform, AgentPromptInjectionMode>>
   /** Option terminator required before positional prompts that may look like CLI syntax. */
   argvPromptSeparator?: '--'
   /** Native CLI flag that seeds the input without submitting (e.g. Claude's `--prefill <text>`); preferred over the paste-after-ready path. */
@@ -253,6 +254,8 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     launchCmd: 'cursor-agent',
     expectedProcess: 'cursor-agent',
     promptInjectionMode: 'argv',
+    // Why: installed Windows cursor-agent resolves to a .cmd shim that rejects argv prompts (#8793); deliver after start instead.
+    promptInjectionModeByPlatform: { win32: 'stdin-after-start' },
     // Why: first-launch trust menu swallows the bracketed paste; pre-write the .workspace-trusted marker so it skips (agent-trust-presets.ts).
     preflightTrust: 'cursor'
   },
@@ -340,6 +343,14 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
 
 export function isTuiAgent(value: unknown): value is TuiAgent {
   return typeof value === 'string' && Object.hasOwn(TUI_AGENT_CONFIG, value)
+}
+
+export function getTuiAgentPromptInjectionMode(
+  agent: TuiAgent,
+  platform: NodeJS.Platform
+): AgentPromptInjectionMode {
+  const config = TUI_AGENT_CONFIG[agent]
+  return config.promptInjectionModeByPlatform?.[platform] ?? config.promptInjectionMode
 }
 
 export function getTuiAgentDetectCommands(config: TuiAgentConfig): string[] {

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -74,6 +74,19 @@ describe('tui agent startup plans', () => {
     expect(plan?.followupPrompt).toBeNull()
   })
 
+  it('keeps empty Windows Cursor launches clean with no synthetic followup', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'cursor',
+      prompt: '',
+      cmdOverrides: {},
+      platform: 'win32',
+      allowEmptyPromptLaunch: true
+    })
+
+    expect(plan?.launchCommand).toBe('cursor-agent')
+    expect(plan?.followupPrompt).toBeNull()
+  })
+
   it('keeps other Windows argv agents on argv', () => {
     const plan = buildAgentStartupPlan({
       agent: 'codex',

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -49,6 +49,43 @@ describe('draft prefill teardown ordering (#14975)', () => {
 })
 
 describe('tui agent startup plans', () => {
+  it('keeps Windows Cursor startup prompts out of argv', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'cursor',
+      prompt: '  fix the startup path  ',
+      cmdOverrides: {},
+      platform: 'win32'
+    })
+
+    expect(plan?.launchCommand).toBe('cursor-agent')
+    expect(plan?.launchCommand).not.toContain('fix the startup path')
+    expect(plan?.followupPrompt).toBe('fix the startup path')
+  })
+
+  it('keeps non-Windows Cursor startup prompts in argv', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'cursor',
+      prompt: 'fix the startup path',
+      cmdOverrides: {},
+      platform: 'linux'
+    })
+
+    expect(plan?.launchCommand).toContain('fix the startup path')
+    expect(plan?.followupPrompt).toBeNull()
+  })
+
+  it('keeps other Windows argv agents on argv', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'codex',
+      prompt: 'fix the startup path',
+      cmdOverrides: {},
+      platform: 'win32'
+    })
+
+    expect(plan?.launchCommand).toContain('fix the startup path')
+    expect(plan?.followupPrompt).toBeNull()
+  })
+
   it.each(['powershell', 'cmd'] as const)(
     'keeps the established invalid-quote error on %s',
     (shell) => {

--- a/src/shared/tui-agent-startup.ts
+++ b/src/shared/tui-agent-startup.ts
@@ -12,7 +12,7 @@ import {
   resolveStartupShell,
   type AgentStartupShell
 } from './tui-agent-startup-shell'
-import { TUI_AGENT_CONFIG } from './tui-agent-config'
+import { getTuiAgentPromptInjectionMode, TUI_AGENT_CONFIG } from './tui-agent-config'
 import type { StartupCommandDelivery } from './codex-startup-delivery'
 import { buildSleepingAgentLaunchConfig } from './sleeping-agent-launch-config'
 import { planHermesStartupQuery } from './hermes-startup-query'
@@ -60,7 +60,8 @@ export function buildAgentStartupPlan(args: {
   const shell = resolveStartupShell(platform, args.shell)
   const trimmedPrompt = prompt.trim()
   const config = TUI_AGENT_CONFIG[agent]
-  const usesQuery = config.promptInjectionMode === 'hermes-query' && Boolean(trimmedPrompt)
+  const promptInjectionMode = getTuiAgentPromptInjectionMode(agent, platform)
+  const usesQuery = promptInjectionMode === 'hermes-query' && Boolean(trimmedPrompt)
   const baseCommand = resolveAgentLaunchCommand({
     agent,
     cmdOverrides,
@@ -80,7 +81,6 @@ export function buildAgentStartupPlan(args: {
     // session restores its own state and must retain only explicit user args.
     agentCommand: baseCommand.commandWithoutSessionOptions
   })
-
   if (!trimmedPrompt) {
     if (!allowEmptyPromptLaunch) {
       return null
@@ -97,12 +97,10 @@ export function buildAgentStartupPlan(args: {
   }
 
   const quotedPrompt = quoteStartupArg(trimmedPrompt, shell)
-
-  if (config.promptInjectionMode === 'argv') {
-    const promptSeparator = config.argvPromptSeparator ? ` ${config.argvPromptSeparator}` : ''
+  if (promptInjectionMode === 'argv') {
     return {
       agent,
-      launchCommand: `${baseCommand.command}${promptSeparator} ${quotedPrompt}`,
+      launchCommand: `${baseCommand.command}${config.argvPromptSeparator ? ` ${config.argvPromptSeparator}` : ''} ${quotedPrompt}`,
       expectedProcess: config.expectedProcess,
       followupPrompt: null,
       launchConfig,
@@ -112,7 +110,7 @@ export function buildAgentStartupPlan(args: {
     }
   }
 
-  if (config.promptInjectionMode === 'flag-prompt') {
+  if (promptInjectionMode === 'flag-prompt') {
     return {
       agent,
       launchCommand: `${baseCommand.command} --prompt ${quotedPrompt}`,
@@ -124,7 +122,7 @@ export function buildAgentStartupPlan(args: {
     }
   }
 
-  if (config.promptInjectionMode === 'hermes-query') {
+  if (promptInjectionMode === 'hermes-query') {
     const queryPlan = planHermesStartupQuery({
       baseCommand: baseCommand.command,
       agentArgs: args.agentArgs,
@@ -139,8 +137,6 @@ export function buildAgentStartupPlan(args: {
     }
     return {
       agent,
-      // Why: Hermes owns readiness and submission for `chat --query`; Orca
-      // only bounds and quotes the native invocation before starting the TUI.
       launchCommand: queryPlan.command,
       expectedProcess: config.expectedProcess,
       followupPrompt: null,
@@ -150,7 +146,7 @@ export function buildAgentStartupPlan(args: {
     }
   }
 
-  if (config.promptInjectionMode === 'flag-prompt-interactive') {
+  if (promptInjectionMode === 'flag-prompt-interactive') {
     return {
       agent,
       launchCommand: `${baseCommand.command} --prompt-interactive ${quotedPrompt}`,
@@ -162,7 +158,7 @@ export function buildAgentStartupPlan(args: {
     }
   }
 
-  if (config.promptInjectionMode === 'flag-interactive') {
+  if (promptInjectionMode === 'flag-interactive') {
     return {
       agent,
       launchCommand: `${baseCommand.command} -i ${quotedPrompt}`,

--- a/src/shared/tui-agent-startup.ts
+++ b/src/shared/tui-agent-startup.ts
@@ -81,6 +81,7 @@ export function buildAgentStartupPlan(args: {
     // session restores its own state and must retain only explicit user args.
     agentCommand: baseCommand.commandWithoutSessionOptions
   })
+
   if (!trimmedPrompt) {
     if (!allowEmptyPromptLaunch) {
       return null
@@ -97,10 +98,12 @@ export function buildAgentStartupPlan(args: {
   }
 
   const quotedPrompt = quoteStartupArg(trimmedPrompt, shell)
+
   if (promptInjectionMode === 'argv') {
+    const promptSeparator = config.argvPromptSeparator ? ` ${config.argvPromptSeparator}` : ''
     return {
       agent,
-      launchCommand: `${baseCommand.command}${config.argvPromptSeparator ? ` ${config.argvPromptSeparator}` : ''} ${quotedPrompt}`,
+      launchCommand: `${baseCommand.command}${promptSeparator} ${quotedPrompt}`,
       expectedProcess: config.expectedProcess,
       followupPrompt: null,
       launchConfig,
@@ -137,6 +140,8 @@ export function buildAgentStartupPlan(args: {
     }
     return {
       agent,
+      // Why: Hermes owns readiness and submission for `chat --query`; Orca
+      // only bounds and quotes the native invocation before starting the TUI.
       launchCommand: queryPlan.command,
       expectedProcess: config.expectedProcess,
       followupPrompt: null,


### PR DESCRIPTION
## Summary

- Keep Windows Cursor startup prompts out of argv by switching only Windows Cursor launches onto the existing post-start delivery path.
- Route the startup-plan builder and the current renderer launch consumers through one shared prompt-mode resolver so Windows Cursor behavior stays consistent everywhere that launches it.

Closes #8793.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/runSourceControlAgentActionStart.test.ts` - passed; 1 file and 8 tests passed.
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/tui-agent-startup.test.ts src/renderer/src/lib/launch-agent-in-new-tab.test.ts src/renderer/src/lib/launch-agent-background-session.test.ts src/renderer/src/lib/source-control-agent-action-plan.test.ts src/renderer/src/components/right-sidebar/runSourceControlAgentActionStart.test.ts src/shared/terminal-quick-commands.test.ts` - passed; 6 files and 156 tests passed.
- `pnpm run typecheck:node` - passed.
- `pnpm exec oxlint src/renderer/src/components/right-sidebar/runSourceControlAgentActionStart.ts src/renderer/src/components/right-sidebar/runSourceControlAgentActionStart.test.ts` - passed.

## AI Review Report

The final diff keeps the owner in shared TUI config, adds a Windows-only Cursor prompt-mode override, routes the startup-plan builder plus the new-tab, background, source-control preview, and source-control live-launch handoff through the shared resolver, and leaves quick-command support on the default static mode. The live source-control handoff resolves omitted platform context with the same `CLIENT_PLATFORM` fallback as the preview before mapping `auto-submit` to `submit-after-ready`. Focused proofs cover the Windows Cursor startup regression, empty Windows Cursor startup preservation, non-Windows Cursor preservation, Windows non-Cursor negative space, each renderer launch path, the live source-control handoff, and quick-command preservation.

## Security Audit

The change adds no subprocesses, no auth surface, and no new path parsing. It narrows Windows Cursor startup prompt delivery away from argv and reuses Orca's existing post-ready prompt delivery path instead of introducing a platform-specific launcher workaround or command discovery branch.

## Notes

This target is intentionally about TUI startup, worktree launch, and related renderer launch surfaces. It does not change commit-message generation or generic Windows batch-safety policy.
</content>

## ELI5

On Windows, Cursor’s startup prompt was stuffed into command-line arguments and could break launch. The prompt is delivered after start, the same safer path other agents already use.
