### PR TITLE
fix(onboarding): skip Computer Use setup when macOS helper app is unavailable

### DIFF
--- a/src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts
+++ b/src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts
@@ -274,6 +274,39 @@ describe('onboarding feature setup runner', () => {
     expect(deps.clipboardWrites).toEqual([])
   })
 
+  it('skips openSetup and warns when the macOS Computer Use helper app is unavailable', async () => {
+    // Why: getComputerUsePermissionStatus reports helperUnavailableReason with
+    // all permissions set to not-granted when the helper app is missing (e.g.
+    // a dev build that never ran `pnpm build:computer-macos`). The runner must
+    // not call openSetup in that case, or the IPC handler throws.
+    const unavailableStatus: ComputerUsePermissionStatusResult = {
+      platform: 'darwin',
+      helperAppPath: null,
+      helperUnavailableReason: 'Orca Computer Use.app was not found',
+      permissions: [
+        { id: 'accessibility', status: 'not-granted' },
+        { id: 'screenshots', status: 'not-granted' }
+      ]
+    }
+    const openComputerUsePermissionSetup = vi.fn(async () => OPENED_COMPUTER_USE_SETUP)
+    const deps = createDeps({
+      getComputerUsePermissionStatus: vi.fn(async () => unavailableStatus),
+      openComputerUsePermissionSetup
+    })
+
+    const result = await runOnboardingFeatureSetup(
+      { browserUse: true, computerUse: true, orchestration: true, linearTickets: true },
+      deps
+    )
+
+    expect(result.computerUsePermissionsOpened).toBe(false)
+    expect(openComputerUsePermissionSetup).not.toHaveBeenCalled()
+    expect(result.warnings).toContainEqual({
+      featureId: 'computerUse',
+      message: 'Orca Computer Use.app was not found'
+    })
+  })
+
   it('shows CLI registration context before installing a missing CLI during onboarding', async () => {
     const staleStatus: CliInstallStatus = {
       ...INSTALLED_CLI_STATUS,

--- a/src/renderer/src/components/onboarding/onboarding-feature-setup.ts
+++ b/src/renderer/src/components/onboarding/onboarding-feature-setup.ts
@@ -251,12 +251,24 @@ export async function runOnboardingFeatureSetup(
   if (selection.computerUse) {
     try {
       const status = await deps.getComputerUsePermissionStatus()
-      const needsMacPermissions =
-        status.platform === 'darwin' &&
-        status.permissions.some((permission) => permission.status !== 'granted')
-      if (needsMacPermissions) {
-        await deps.openComputerUsePermissionSetup()
-        computerUsePermissionsOpened = true
+      // Why: when the macOS helper app is missing (e.g. dev builds without
+      // `pnpm build:computer-macos`), the status reports all permissions as
+      // not-granted alongside a helperUnavailableReason. Without this guard we
+      // would call openSetup, which throws an IPC handler error instead of
+      // degrading gracefully.
+      if (status.helperUnavailableReason) {
+        warnings.push({
+          featureId: 'computerUse',
+          message: status.helperUnavailableReason
+        })
+      } else {
+        const needsMacPermissions =
+          status.platform === 'darwin' &&
+          status.permissions.some((permission) => permission.status !== 'granted')
+        if (needsMacPermissions) {
+          await deps.openComputerUsePermissionSetup()
+          computerUsePermissionsOpened = true
+        }
       }
     } catch (error) {
       warnings.push({


### PR DESCRIPTION
# fix(onboarding): skip Computer Use setup when macOS helper app is unavailable

## Summary

Fixes onboarding triggering an alarming main-process IPC error when a user completes Computer Use onboarding on a build where the macOS Computer Use helper app is missing.

## ELI5

If the little macOS helper program that powers Computer Use isn't installed, onboarding used to hit an error behind the scenes. Now it just quietly shows a warning and moves on.

## Root cause & fix

When the macOS Computer Use helper app can't be found, `getComputerUsePermissionStatus` returns `helperUnavailableReason` set with all permissions `not-granted`. The onboarding runner only inspected the permissions, so it still called `openSetup`, which throws `RuntimeClientError: Orca Computer Use.app was not found` in the `computerUsePermissions:openSetup` IPC handler and logs a main-process error. The fix guards on `helperUnavailableReason` first: it records the reason as an onboarding warning and skips `openSetup`, so onboarding degrades gracefully.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- Rebase clean onto `main` (base `7ab601487c`, head `d3bcbc0873`).
- Full suite on branch: **10/10 pass**.
- Reverting only the fix (`onboarding-feature-setup.ts`) to `origin/main` makes the regression test **fail (1 failed / 9 passed)** — the test `"skips openSetup and warns when the macOS Computer Use helper app is unavailable"` asserts `result.computerUsePermissionsOpened` is `false`; reverted it becomes `true` (`expected true to be false` at line 302).
- Backend premise verified: `macos-computer-use-permission-status.ts` returns `createUnavailablePermissionStatus('Orca Computer Use.app was not found', null)` when the helper path can't resolve, matching the guarded status and warning string.
- Lint clean (`oxlint` on the changed file — no findings).

```
STEP 2a — TEST ON BRANCH:  Test Files 1 passed (1) | Tests 10 passed (10)
STEP 2b — FAIL WHEN FIX REVERTED:  Tests 1 failed | 9 passed
  failing test: "skips openSetup and warns when the macOS Computer Use helper app is unavailable"
  assertion: expected true to be false (result.computerUsePermissionsOpened) at line 302
```

## Trade-offs

None — pure fix.

## Regression risk

Zero. Only the buggy branch changes: the new guard short-circuits solely when `helperUnavailableReason` is set, which `getComputerUsePermissionStatus` populates only on macOS. Linux/Windows return `helperUnavailableReason: null` and fall through to the unchanged `platform === 'darwin'` path. The passing suite plus the revert-fails test prove the intended behavior.

_Credit to original author @morluto. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved._
