### PR TITLE
Add full-size viewing for Mermaid diagrams in Markdown preview

### DIFF
--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -699,6 +699,38 @@
   max-width: 100%;
   height: auto;
 }
+.mermaid-preview-wrapper {
+  position: relative;
+}
+.mermaid-preview-expand-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: 4px;
+  cursor: pointer;
+  color: var(--muted-foreground);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.mermaid-preview-wrapper:hover .mermaid-preview-expand-btn,
+.mermaid-preview-wrapper:focus-within .mermaid-preview-expand-btn {
+  opacity: 1;
+}
+.mermaid-preview-expand-btn:hover {
+  background: var(--accent);
+  color: var(--foreground);
+}
+@media (hover: none) {
+  .mermaid-preview-expand-btn {
+    opacity: 1;
+  }
+}
 .mermaid-error {
   color: var(--color-warning, #d29922);
   font-size: 0.85em;

--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -707,6 +707,7 @@
   top: 8px;
   right: 8px;
   opacity: 0;
+  pointer-events: none;
   transition: opacity 0.15s ease;
   background: none;
   border: 1px solid transparent;
@@ -721,6 +722,7 @@
 .mermaid-preview-wrapper:hover .mermaid-preview-expand-btn,
 .mermaid-preview-wrapper:focus-within .mermaid-preview-expand-btn {
   opacity: 1;
+  pointer-events: auto;
 }
 .mermaid-preview-expand-btn:hover {
   background: var(--accent);
@@ -729,6 +731,7 @@
 @media (hover: none) {
   .mermaid-preview-expand-btn {
     opacity: 1;
+    pointer-events: auto;
   }
 }
 .mermaid-error {

--- a/src/renderer/src/components/editor/MarkdownPreview.mermaid-full-size.test.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.mermaid-full-size.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const storeState = {
+  openFile: vi.fn(),
+  activateMarkdownLink: vi.fn(),
+  openMarkdownPreview: vi.fn(),
+  setMarkdownViewMode: vi.fn(),
+  markdownFrontmatterVisible: {},
+  setPendingEditorReveal: vi.fn(),
+  addDiffComment: vi.fn(),
+  deleteDiffComment: vi.fn(),
+  updateDiffComment: vi.fn(),
+  clearDeliveredDiffComments: vi.fn(),
+  keybindings: {},
+  worktreesByRepo: {},
+  repos: [],
+  folderWorkspaces: [],
+  projectGroups: [],
+  openFiles: [],
+  activeFileIdByWorktree: {},
+  settings: { openLinksInApp: true },
+  editorFontZoomLevel: 0
+}
+
+vi.mock('@/store', () => {
+  const useAppStore = Object.assign(
+    (selector: (s: typeof storeState) => unknown) => selector(storeState),
+    { getState: () => storeState }
+  )
+  return { useAppStore }
+})
+vi.mock('@/store/slices/worktree-helpers', () => ({ findWorktreeById: () => null }))
+vi.mock('@/runtime/runtime-rpc-client', () => ({
+  settingsForRuntimeOwner: (settings: unknown) => settings
+}))
+vi.mock('@/runtime/runtime-file-client', () => ({
+  statRuntimePath: vi.fn(async () => ({ isDirectory: false }))
+}))
+vi.mock('@/lib/connection-context', () => ({ getConnectionIdForFile: () => null }))
+vi.mock('@/lib/connection-owner-resolution', () => ({
+  createConnectionIdForFileSelector: () => () => null
+}))
+vi.mock('@/i18n/i18n', () => ({ translate: (_key: string, fallback: string) => fallback }))
+vi.mock('./useLocalImageSrc', () => ({ useLocalImageSrc: (src?: string) => src }))
+vi.mock('./MermaidBlock', () => ({
+  default: ({ content }: { content: string }) => <div data-testid="mermaid-block">{content}</div>
+}))
+vi.mock('./CodeBlockCopyButton', () => ({
+  default: ({ children }: { children: ReactNode }) => (
+    <div data-testid="code-block-copy">{children}</div>
+  )
+}))
+vi.mock('../diff-comments/DiffCommentCard', () => ({ DiffCommentCard: () => null }))
+vi.mock('./NotesSendMenu', () => ({ NotesSendMenu: () => null }))
+vi.mock('./MarkdownTableOfContentsPanel', () => ({ MarkdownTableOfContentsPanel: () => null }))
+
+import MarkdownPreview from './MarkdownPreview'
+
+const DOC = [
+  '```mermaid',
+  'flowchart LR',
+  'A[Start] --> B{Decision}',
+  'B -->|yes| C[Ship]',
+  'B -->|no| D[Retry]',
+  '```',
+  '',
+  '```ts',
+  "console.log('keep pre route')",
+  '```'
+].join('\n')
+
+describe('MarkdownPreview Mermaid full-size affordance', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+      configurable: true
+    })
+    ;(window as unknown as { api: unknown }).api = {
+      shell: { openUrl: vi.fn(), openFileUri: vi.fn(), pathExists: vi.fn(async () => true) },
+      ui: { writeClipboardText: vi.fn(async () => true) }
+    }
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+  })
+
+  function render(): void {
+    act(() => {
+      root.render(
+        <MarkdownPreview
+          content={DOC}
+          filePath="/repo/docs/README.md"
+          sourceWorktreeId="wt-1"
+          scrollCacheKey="test-key"
+        />
+      )
+    })
+  }
+
+  it('keeps Mermaid outside pre and leaves normal code in the copy route', () => {
+    render()
+
+    const mermaid = container.querySelector('[data-testid="mermaid-block"]')
+    expect(mermaid).not.toBeNull()
+    expect(mermaid?.closest('pre')).toBeNull()
+
+    const codeBlocks = Array.from(container.querySelectorAll('[data-testid="code-block-copy"]'))
+    expect(codeBlocks.length).toBeGreaterThan(0)
+    expect(
+      codeBlocks.some((block) => block.textContent?.includes("console.log('keep pre route')"))
+    ).toBe(true)
+    expect(container.querySelectorAll('button[aria-label="Open full size"]')).toHaveLength(1)
+  })
+
+  it('opens a dialog with the same Mermaid source', () => {
+    render()
+
+    const trigger = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Open full size"]'
+    )
+    expect(trigger).not.toBeNull()
+
+    act(() => {
+      trigger?.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }))
+    })
+
+    const dialog = document.body.querySelector('[data-slot="dialog-content"]')
+    expect(dialog).not.toBeNull()
+    expect(document.body.querySelectorAll('[data-testid="mermaid-block"]')).toHaveLength(2)
+    expect(dialog?.textContent).toContain('flowchart LR')
+  })
+})

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -61,7 +61,7 @@ import {
 import { absolutePathToFileUri, resolveMarkdownLinkTarget } from './markdown-internal-links'
 import { useLocalImageSrc } from './useLocalImageSrc'
 import CodeBlockCopyButton from './CodeBlockCopyButton'
-import MermaidBlock from './MermaidBlock'
+import MermaidPreviewBlock from './MermaidPreviewBlock'
 import {
   applyMarkdownPreviewSearchHighlights,
   clearMarkdownPreviewSearchHighlights,
@@ -1619,7 +1619,11 @@ export default function MarkdownPreview({
       code: ({ className, children, ...props }) => {
         if (/language-mermaid/.test(className || '')) {
           return (
-            <MermaidBlock content={String(children).trimEnd()} isDark={isDark} htmlLabels={false} />
+            <MermaidPreviewBlock
+              content={String(children).trimEnd()}
+              isDark={isDark}
+              htmlLabels={false}
+            />
           )
         }
         return (
@@ -1630,12 +1634,12 @@ export default function MarkdownPreview({
       },
       // Why: Wrap <pre> blocks with a positioned container so a copy button can
       // overlay the code block. Mermaid diagrams are detected and passed through
-      // unwrapped — MermaidBlock renders via useEffect/innerHTML, not React children,
+      // unwrapped — MermaidPreviewBlock renders MermaidBlock via useEffect/innerHTML, not React children,
       // so CodeBlockCopyButton's extractText() would copy an empty string, and a
       // <div> inside <pre> produces invalid HTML.
       pre: ({ node, children, ...props }) => {
         const child = React.Children.toArray(children)[0]
-        if (React.isValidElement(child) && child.type === MermaidBlock) {
+        if (React.isValidElement(child) && child.type === MermaidPreviewBlock) {
           return <>{children}</>
         }
         return wrapAnnotatedBlock(

--- a/src/renderer/src/components/editor/MermaidPreviewBlock.tsx
+++ b/src/renderer/src/components/editor/MermaidPreviewBlock.tsx
@@ -1,0 +1,64 @@
+import { Maximize2 } from 'lucide-react'
+import { useState, type JSX } from 'react'
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
+import { translate } from '@/i18n/i18n'
+import MermaidBlock from './MermaidBlock'
+
+type MermaidPreviewBlockProps = {
+  content: string
+  isDark: boolean
+  htmlLabels?: boolean
+}
+
+export default function MermaidPreviewBlock({
+  content,
+  isDark,
+  htmlLabels
+}: MermaidPreviewBlockProps): JSX.Element {
+  const [isOpen, setIsOpen] = useState(false)
+  const openLabel = translate(
+    'auto.components.editor.MermaidPreviewBlock.98c6dc1f8b',
+    'Open full size'
+  )
+
+  return (
+    <>
+      <div className="mermaid-preview-wrapper">
+        <MermaidBlock content={content} isDark={isDark} htmlLabels={htmlLabels} />
+        <button
+          type="button"
+          className="mermaid-preview-expand-btn"
+          aria-label={openLabel}
+          title={openLabel}
+          onClick={() => setIsOpen(true)}
+        >
+          <Maximize2 size={14} />
+        </button>
+      </div>
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogContent className="top-1/2 left-1/2 flex h-[80vh] w-[85vw] max-w-[85vw] -translate-x-1/2 -translate-y-1/2 flex-col gap-0 overflow-hidden border border-border/60 bg-background p-0 shadow-2xl sm:max-w-[85vw]">
+          <DialogTitle className="sr-only">{openLabel}</DialogTitle>
+          <DialogDescription className="sr-only">
+            {translate(
+              'auto.components.editor.MermaidPreviewBlock.907bf1c86a',
+              'Full-size Mermaid diagram preview'
+            )}
+          </DialogDescription>
+          <div className="min-h-0 flex-1 overflow-auto bg-muted/20 scrollbar-editor">
+            <div className="mermaid-viewer-canvas">
+              <MermaidBlock content={content} isDark={isDark} htmlLabels={htmlLabels} />
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center justify-between border-t border-border/60 bg-background/95 px-3 py-2 text-xs text-muted-foreground">
+            <div>
+              {translate(
+                'auto.components.editor.MermaidPreviewBlock.3c6c89f5fb',
+                'Press Esc to close'
+              )}
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11983,6 +11983,11 @@
         },
         "richMarkdownSourceOwningCutFeedback": {
           "selectLessContent": "Select less content or use code mode to cut preserved HTML citations."
+        },
+        "MermaidPreviewBlock": {
+          "98c6dc1f8b": "Open full size",
+          "907bf1c86a": "Full-size Mermaid diagram preview",
+          "3c6c89f5fb": "Press Esc to close"
         }
       },
       "diff": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11983,6 +11983,11 @@
         },
         "richMarkdownSourceOwningCutFeedback": {
           "selectLessContent": "Selecciona menos contenido o usa el modo de código para cortar citas HTML conservadas."
+        },
+        "MermaidPreviewBlock": {
+          "98c6dc1f8b": "Open full size",
+          "907bf1c86a": "Full-size Mermaid diagram preview",
+          "3c6c89f5fb": "Press Esc to close"
         }
       },
       "diff": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11983,6 +11983,11 @@
         },
         "richMarkdownSourceOwningCutFeedback": {
           "selectLessContent": "保持されたHTML引用を切り取るには、選択範囲を小さくするかコードモードを使用してください。"
+        },
+        "MermaidPreviewBlock": {
+          "98c6dc1f8b": "Open full size",
+          "907bf1c86a": "Full-size Mermaid diagram preview",
+          "3c6c89f5fb": "Press Esc to close"
         }
       },
       "diff": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11983,6 +11983,11 @@
         },
         "richMarkdownSourceOwningCutFeedback": {
           "selectLessContent": "보존된 HTML 인용을 잘라내려면 더 적은 콘텐츠를 선택하거나 코드 모드를 사용하세요."
+        },
+        "MermaidPreviewBlock": {
+          "98c6dc1f8b": "Open full size",
+          "907bf1c86a": "Full-size Mermaid diagram preview",
+          "3c6c89f5fb": "Press Esc to close"
         }
       },
       "diff": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11983,6 +11983,11 @@
         },
         "richMarkdownSourceOwningCutFeedback": {
           "selectLessContent": "请选择较少的内容，或使用代码模式剪切保留的 HTML 引用。"
+        },
+        "MermaidPreviewBlock": {
+          "98c6dc1f8b": "Open full size",
+          "907bf1c86a": "Full-size Mermaid diagram preview",
+          "3c6c89f5fb": "Press Esc to close"
         }
       },
       "diff": {

--- a/tests/e2e/markdown-mermaid-full-size.spec.ts
+++ b/tests/e2e/markdown-mermaid-full-size.spec.ts
@@ -75,6 +75,16 @@ test.describe('Markdown Mermaid full-size preview', () => {
         )
         .toBe(1)
 
+      const previewWrapper = orcaPage.locator('.mermaid-preview-wrapper')
+      const previewBox = await previewWrapper.boundingBox()
+      expect(previewBox).not.toBeNull()
+      if (!previewBox) {
+        throw new Error('Expected Mermaid preview wrapper bounds before click target check')
+      }
+
+      await orcaPage.mouse.click(previewBox.x + previewBox.width - 6, previewBox.y + 6)
+      await expect(orcaPage.getByRole('dialog', { name: 'Open full size' })).toHaveCount(0)
+
       const openButton = orcaPage.getByRole('button', { name: 'Open full size' })
       await expect(openButton).toBeVisible()
       await openButton.click()

--- a/tests/e2e/markdown-mermaid-full-size.spec.ts
+++ b/tests/e2e/markdown-mermaid-full-size.spec.ts
@@ -1,0 +1,100 @@
+import path from 'node:path'
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  cleanupMarkdownFixture,
+  createMarkdownFixture,
+  getActiveWorktreeContext
+} from './helpers/markdown-ordered-list-exit'
+
+const MERMAID_MARKDOWN = [
+  '# Mermaid preview',
+  '',
+  '```mermaid',
+  'flowchart LR',
+  '  Draft[Draft] --> Review[Review]',
+  '  Review --> Ship[Ship]',
+  '```',
+  ''
+].join('\n')
+
+test.describe('Markdown Mermaid full-size preview', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await orcaPage.setViewportSize({ width: 1440, height: 900 })
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+  })
+
+  test('opens a full-size Mermaid dialog from markdown preview', async ({ orcaPage }, testInfo) => {
+    const context = await getActiveWorktreeContext(orcaPage)
+    let filePath: string | null = null
+
+    try {
+      filePath = await createMarkdownFixture(
+        context,
+        'mermaid-full-size',
+        testInfo.workerIndex,
+        MERMAID_MARKDOWN
+      )
+      const relativePath = path.relative(context.rootPath, filePath)
+
+      await orcaPage.evaluate(
+        ({ filePath, relativePath, worktreeId }) => {
+          const store = window.__store
+          if (!store) {
+            throw new Error('window.__store is not available')
+          }
+
+          store.getState().openMarkdownPreview({
+            filePath,
+            relativePath,
+            worktreeId,
+            language: 'markdown'
+          })
+        },
+        { filePath, relativePath, worktreeId: context.worktreeId }
+      )
+
+      await expect(orcaPage.locator('.markdown-preview')).toBeVisible()
+
+      await expect
+        .poll(
+          async () =>
+            orcaPage.evaluate(() => document.querySelectorAll('.mermaid-preview-wrapper').length),
+          { timeout: 15_000, message: 'Expected markdown preview to render one Mermaid block' }
+        )
+        .toBe(1)
+
+      await expect
+        .poll(
+          async () =>
+            orcaPage.evaluate(
+              () => document.querySelectorAll('.mermaid-preview-wrapper .mermaid-block svg').length
+            ),
+          { timeout: 15_000, message: 'Expected inline Mermaid preview SVG to render' }
+        )
+        .toBe(1)
+
+      const openButton = orcaPage.getByRole('button', { name: 'Open full size' })
+      await expect(openButton).toBeVisible()
+      await openButton.click()
+
+      const dialog = orcaPage.getByRole('dialog', { name: 'Open full size' })
+      await expect(dialog).toBeVisible()
+      await expect(dialog).toContainText('Press Esc to close')
+
+      await expect
+        .poll(
+          async () =>
+            orcaPage.evaluate(() => document.querySelectorAll('.mermaid-block svg').length),
+          { timeout: 15_000, message: 'Expected inline and dialog Mermaid SVG renders' }
+        )
+        .toBeGreaterThanOrEqual(2)
+
+      await orcaPage.keyboard.press('Escape')
+      await expect(dialog).toBeHidden()
+    } finally {
+      await cleanupMarkdownFixture(filePath)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Add an `Open full size` action to Mermaid diagrams rendered in Markdown preview.
- Route Markdown-preview Mermaid fences through a dedicated wrapper that preserves the existing inline render, keeps non-Mermaid fenced code on the copy-button path, and remounts the same sanitized `MermaidBlock` inside a large dialog.
- Add focused renderer and headless Electron coverage for the preview action and dialog flow.

Closes #8731.

## Screenshots

No screenshot is attached. The UI flow is covered by a headless Electron E2E run for this change. The `Open full size` action on Mermaid diagrams in Markdown preview opens the diagram in a large dialog.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/MarkdownPreview.mermaid-full-size.test.tsx` - passed; covers Markdown preview Mermaid detection, `<pre>` bypass, and dialog remount behavior.
- `pnpm exec oxlint src/renderer/src/components/editor/MermaidPreviewBlock.tsx src/renderer/src/components/editor/MarkdownPreview.tsx src/renderer/src/components/editor/MarkdownPreview.mermaid-full-size.test.tsx` - passed; covers the renderer changes and unit test.
- `pnpm exec oxfmt --check src/renderer/src/components/editor/MermaidPreviewBlock.tsx src/renderer/src/components/editor/MarkdownPreview.tsx src/renderer/src/components/editor/MarkdownPreview.mermaid-full-size.test.tsx src/renderer/src/assets/markdown-preview.css` - passed; covers formatting for the touched renderer files.
- `pnpm run typecheck:web` - passed; covers the renderer code path and new component wiring.
- `pnpm run sync:localization-catalog` - passed; generated the new locale keys for the dialog copy.
- `pnpm run verify:localization-catalog` - passed; verifies catalog structure after the new strings landed.
- `pnpm run verify:localization-coverage` - passed; verifies the generated locale coverage remains complete.
- `pnpm exec oxlint --config config/oxlint-react-doctor.json src/renderer/src/components/editor/MermaidPreviewBlock.tsx src/renderer/src/components/editor/MarkdownPreview.tsx src/renderer/src/components/editor/MarkdownPreview.mermaid-full-size.test.tsx` - passed; covers React-specific lint on the touched renderer files.
- `SKIP_BUILD=1 npx playwright test tests/e2e/markdown-mermaid-full-size.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1` - passed; covers the Markdown preview affordance and full-size dialog in hidden-window Electron without headful UI interaction.

## AI Review Report

Reviewed the final diff against the Markdown-preview ownership boundary and the Mermaid rendering path. The change is limited to Markdown preview fences in `MarkdownPreview`, adds a wrapper component that remounts the existing sanitized `MermaidBlock`, and keeps standalone `.mmd` or `.mermaid` viewer behavior untouched. The `<pre>` special case now keys off `MermaidPreviewBlock`, which preserves copy-button behavior for ordinary fenced code and keeps invalid `<div>`-inside-`<pre>` output off the Mermaid path.

Keyboard and modal behavior were reviewed through the renderer test and the headless Electron E2E. The trigger is a real button with an accessible name, the dialog exposes the same label, and Escape closes it. The change does not touch SSH, remote-runtime routing, shells, terminals, supported agents, provider integrations, or persisted workspace state. Cross-platform risk is low because the new behavior stays inside renderer-only React, CSS, and localization paths that already ship on macOS, Linux, and Windows.

## Security Audit

Reviewed the new path for HTML and command surface changes. The dialog reuses `MermaidBlock`, which already sanitizes Mermaid SVG output with DOMPurify and keeps `htmlLabels={false}` on the Markdown-preview path. No new HTML injection path, IPC surface, filesystem access, browser navigation, subprocess, authentication, secret handling, SSH behavior, or dependency was added.

## Notes

The shipped change is narrower than the original proposal draft. This PR adds a full-size dialog for Markdown-preview Mermaid fences only; it does not add zoom controls, panning state, export, or any changes to rich-editor Mermaid blocks or standalone Mermaid file viewing.

## ELI5

Mermaid diagrams in Markdown preview get an “Open full size” action. You can view a large, readable version in a dialog without leaving the preview.
