### PR TITLE
Persist AI Vault view options

### DIFF
--- a/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
@@ -20,12 +20,7 @@ import {
   getRestorableAiVaultScope,
   normalizeAiVaultScopeForContext
 } from './ai-vault-scope-state'
-import {
-  countAiVaultViewAdjustments,
-  DEFAULT_AI_VAULT_GROUP,
-  DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS,
-  DEFAULT_AI_VAULT_SORT
-} from './ai-vault-view-defaults'
+import { countAiVaultViewAdjustments } from './ai-vault-view-defaults'
 import { buildAiVaultProjectContext } from './ai-vault-session-projects'
 import {
   resolveAiVaultSessionResumeActions,
@@ -35,14 +30,7 @@ import { useAiVaultSessionLaunchActions } from './ai-vault-session-launch-action
 import { useAiVaultSessionWorktreeMap } from './ai-vault-session-worktree'
 import { openAiVaultSessionLogInOrca } from './ai-vault-session-log-open'
 import { useAiVaultOriginalPaneActions } from './ai-vault-original-pane-actions'
-import {
-  AI_VAULT_AGENTS,
-  type AiVaultAgent,
-  type AiVaultGroup,
-  type AiVaultScope,
-  type AiVaultSession,
-  type AiVaultSort
-} from '../../../../shared/ai-vault-types'
+import type { AiVaultScope, AiVaultSession } from '../../../../shared/ai-vault-types'
 import { translate } from '@/i18n/i18n'
 import { AiVaultPanelHeader } from './AiVaultPanelHeader'
 import { AiVaultSessionVirtualList } from './AiVaultSessionVirtualList'
@@ -52,6 +40,7 @@ import {
   buildRuntimeAiVaultHostScopeOptions,
   useAiVaultExecutionHostScope
 } from './ai-vault-host-scope'
+import { usePersistedAiVaultViewOptions } from './use-persisted-ai-vault-view-options'
 
 export default function AiVaultPanel(): React.JSX.Element {
   const activeWorktreeId = useActiveWorktreeId()
@@ -74,11 +63,19 @@ export default function AiVaultPanel(): React.JSX.Element {
   const { getOriginalPaneTarget, getSessionLiveState, jumpToOriginalPane, jumpToWorktree } =
     useAiVaultOriginalPaneActions()
   const [query, setQuery] = useState('')
+  // Why: scope depends on current workspace/project availability, so only stable view options persist.
   const [scope, setScope] = useState<AiVaultScope>(DEFAULT_AI_VAULT_SCOPE)
-  const [sort, setSort] = useState<AiVaultSort>(DEFAULT_AI_VAULT_SORT)
-  const [group, setGroup] = useState<AiVaultGroup>(DEFAULT_AI_VAULT_GROUP)
-  const [hideEmptySessions, setHideEmptySessions] = useState(DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS)
-  const [agents, setAgents] = useState<AiVaultAgent[]>([...AI_VAULT_AGENTS])
+  const {
+    agents,
+    sort,
+    group,
+    hideEmptySessions,
+    setSort,
+    setGroup,
+    setHideEmptySessions,
+    setAgentEnabled,
+    resetViewOptions
+  } = usePersistedAiVaultViewOptions()
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set())
   const userChangedScopeRef = useRef(false)
   const preferredScopeRef = useRef<AiVaultScope>(DEFAULT_AI_VAULT_SCOPE)
@@ -280,23 +277,6 @@ export default function AiVaultPanel(): React.JSX.Element {
       sessionWorktreeById
     ]
   )
-
-  const setAgentEnabled = useCallback((agent: AiVaultAgent, enabled: boolean) => {
-    setAgents((current) => {
-      if (enabled) {
-        return current.includes(agent) ? current : [...current, agent]
-      }
-      const next = current.filter((entry) => entry !== agent)
-      return next.length > 0 ? next : current
-    })
-  }, [])
-
-  const resetViewOptions = useCallback(() => {
-    setAgents([...AI_VAULT_AGENTS])
-    setSort(DEFAULT_AI_VAULT_SORT)
-    setGroup(DEFAULT_AI_VAULT_GROUP)
-    setHideEmptySessions(DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS)
-  }, [])
 
   const handleScopeChange = useCallback((nextScope: AiVaultScope) => {
     preferredScopeRef.current = nextScope

--- a/src/renderer/src/components/right-sidebar/ai-vault-view-options-persistence.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-view-options-persistence.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AI_VAULT_AGENTS } from '../../../../shared/ai-vault-types'
+import {
+  AI_VAULT_VIEW_OPTIONS_STORAGE_KEY,
+  createDefaultAiVaultViewOptions,
+  enabledAiVaultAgents,
+  normalizeAiVaultViewOptions,
+  readAiVaultViewOptions,
+  writeAiVaultViewOptions
+} from './ai-vault-view-options-persistence'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('AI Vault view option persistence', () => {
+  it('uses the documented defaults when no stored value exists', () => {
+    const storage = { getItem: vi.fn(() => null), setItem: vi.fn() }
+
+    expect(readAiVaultViewOptions(storage)).toEqual(createDefaultAiVaultViewOptions())
+  })
+
+  it('normalizes malformed fields and removes unknown or duplicate agents', () => {
+    expect(
+      normalizeAiVaultViewOptions({
+        disabledAgents: ['codex', 'unknown', 'codex', 7],
+        sort: 'invalid',
+        group: 'agent',
+        hideEmptySessions: 'yes'
+      })
+    ).toEqual({
+      disabledAgents: ['codex'],
+      sort: 'updated',
+      group: 'agent',
+      hideEmptySessions: false
+    })
+  })
+
+  it('preserves every valid sort, group, and boolean value', () => {
+    expect(
+      normalizeAiVaultViewOptions({
+        disabledAgents: [],
+        sort: 'updated',
+        group: 'project',
+        hideEmptySessions: false
+      })
+    ).toEqual({
+      disabledAgents: [],
+      sort: 'updated',
+      group: 'project',
+      hideEmptySessions: false
+    })
+    expect(
+      normalizeAiVaultViewOptions({
+        disabledAgents: [],
+        sort: 'created',
+        group: 'folder',
+        hideEmptySessions: true
+      })
+    ).toEqual({
+      disabledAgents: [],
+      sort: 'created',
+      group: 'folder',
+      hideEmptySessions: true
+    })
+    expect(normalizeAiVaultViewOptions({ group: 'agent' }).group).toBe('agent')
+  })
+
+  it('falls back to all enabled when stored state disables the whole catalog', () => {
+    const normalized = normalizeAiVaultViewOptions({
+      disabledAgents: [...AI_VAULT_AGENTS],
+      sort: 'created',
+      group: 'folder',
+      hideEmptySessions: true
+    })
+
+    expect(normalized.disabledAgents).toEqual([])
+    expect(enabledAiVaultAgents(normalized.disabledAgents)).toEqual([...AI_VAULT_AGENTS])
+  })
+
+  it('falls back safely when JSON or storage access is unavailable', () => {
+    const malformed = { getItem: vi.fn(() => '{not-json'), setItem: vi.fn() }
+    const unavailable = {
+      getItem: vi.fn(() => {
+        throw new Error('blocked')
+      }),
+      setItem: vi.fn()
+    }
+
+    expect(readAiVaultViewOptions(malformed)).toEqual(createDefaultAiVaultViewOptions())
+    expect(readAiVaultViewOptions(unavailable)).toEqual(createDefaultAiVaultViewOptions())
+    expect(readAiVaultViewOptions(null)).toEqual(createDefaultAiVaultViewOptions())
+  })
+
+  it('falls back when the renderer storage getter is blocked', () => {
+    const blockedWindow = {}
+    Object.defineProperty(blockedWindow, 'localStorage', {
+      get: () => {
+        throw new Error('blocked')
+      }
+    })
+    vi.stubGlobal('window', blockedWindow)
+
+    expect(readAiVaultViewOptions()).toEqual(createDefaultAiVaultViewOptions())
+    expect(writeAiVaultViewOptions(createDefaultAiVaultViewOptions())).toBe(false)
+  })
+
+  it('writes a normalized, versioned per-client value', () => {
+    const storage = { getItem: vi.fn(() => null), setItem: vi.fn() }
+
+    expect(
+      writeAiVaultViewOptions(
+        {
+          disabledAgents: ['codex'],
+          sort: 'created',
+          group: 'folder',
+          hideEmptySessions: true
+        },
+        storage
+      )
+    ).toBe(true)
+    expect(storage.setItem).toHaveBeenCalledWith(
+      AI_VAULT_VIEW_OPTIONS_STORAGE_KEY,
+      JSON.stringify({
+        disabledAgents: ['codex'],
+        sort: 'created',
+        group: 'folder',
+        hideEmptySessions: true
+      })
+    )
+  })
+
+  it('reports failed storage writes without throwing', () => {
+    const storage = {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(() => {
+        throw new Error('quota exceeded')
+      })
+    }
+
+    expect(writeAiVaultViewOptions(createDefaultAiVaultViewOptions(), storage)).toBe(false)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/ai-vault-view-options-persistence.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-view-options-persistence.ts
@@ -1,0 +1,114 @@
+import {
+  AI_VAULT_AGENTS,
+  type AiVaultAgent,
+  type AiVaultGroup,
+  type AiVaultSort
+} from '../../../../shared/ai-vault-types'
+import {
+  DEFAULT_AI_VAULT_GROUP,
+  DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS,
+  DEFAULT_AI_VAULT_SORT
+} from './ai-vault-view-defaults'
+
+export const AI_VAULT_VIEW_OPTIONS_STORAGE_KEY = 'orca.aiVault.viewOptions.v1'
+
+export type AiVaultViewOptions = {
+  disabledAgents: AiVaultAgent[]
+  sort: AiVaultSort
+  group: AiVaultGroup
+  hideEmptySessions: boolean
+}
+
+type AiVaultViewOptionsStorage = {
+  getItem: (key: string) => string | null
+  setItem: (key: string, value: string) => void
+}
+
+export function createDefaultAiVaultViewOptions(): AiVaultViewOptions {
+  return {
+    disabledAgents: [],
+    sort: DEFAULT_AI_VAULT_SORT,
+    group: DEFAULT_AI_VAULT_GROUP,
+    hideEmptySessions: DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS
+  }
+}
+
+export function enabledAiVaultAgents(disabledAgents: readonly AiVaultAgent[]): AiVaultAgent[] {
+  const disabled = new Set<AiVaultAgent>(disabledAgents)
+  return AI_VAULT_AGENTS.filter((agent) => !disabled.has(agent))
+}
+
+function isAiVaultSort(value: unknown): value is AiVaultSort {
+  return value === 'updated' || value === 'created'
+}
+
+function isAiVaultGroup(value: unknown): value is AiVaultGroup {
+  return value === 'project' || value === 'folder' || value === 'agent'
+}
+
+export function normalizeAiVaultViewOptions(value: unknown): AiVaultViewOptions {
+  const record = value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
+  const catalog = new Set<string>(AI_VAULT_AGENTS)
+  const normalizedDisabledAgents = Array.isArray(record.disabledAgents)
+    ? [...new Set(record.disabledAgents)].filter(
+        (agent): agent is AiVaultAgent => typeof agent === 'string' && catalog.has(agent)
+      )
+    : []
+  // Why: a stale catalog or hand-edited value must not leave the panel with no selectable agents.
+  const disabledAgents =
+    normalizedDisabledAgents.length < AI_VAULT_AGENTS.length ? normalizedDisabledAgents : []
+
+  return {
+    disabledAgents,
+    sort: isAiVaultSort(record.sort) ? record.sort : DEFAULT_AI_VAULT_SORT,
+    group: isAiVaultGroup(record.group) ? record.group : DEFAULT_AI_VAULT_GROUP,
+    hideEmptySessions:
+      typeof record.hideEmptySessions === 'boolean'
+        ? record.hideEmptySessions
+        : DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS
+  }
+}
+
+function getRendererStorage(): AiVaultViewOptionsStorage | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+export function readAiVaultViewOptions(
+  storage: AiVaultViewOptionsStorage | null = getRendererStorage()
+): AiVaultViewOptions {
+  if (!storage) {
+    return createDefaultAiVaultViewOptions()
+  }
+  try {
+    const raw = storage.getItem(AI_VAULT_VIEW_OPTIONS_STORAGE_KEY)
+    return raw ? normalizeAiVaultViewOptions(JSON.parse(raw)) : createDefaultAiVaultViewOptions()
+  } catch {
+    return createDefaultAiVaultViewOptions()
+  }
+}
+
+export function writeAiVaultViewOptions(
+  options: AiVaultViewOptions,
+  storage: AiVaultViewOptionsStorage | null = getRendererStorage()
+): boolean {
+  if (!storage) {
+    return false
+  }
+  try {
+    // Why: view preferences are per client, so desktop and mobile must not overwrite each other.
+    storage.setItem(
+      AI_VAULT_VIEW_OPTIONS_STORAGE_KEY,
+      JSON.stringify(normalizeAiVaultViewOptions(options))
+    )
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/renderer/src/components/right-sidebar/use-persisted-ai-vault-view-options.test.tsx
+++ b/src/renderer/src/components/right-sidebar/use-persisted-ai-vault-view-options.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AI_VAULT_AGENTS } from '../../../../shared/ai-vault-types'
+import { AI_VAULT_VIEW_OPTIONS_STORAGE_KEY } from './ai-vault-view-options-persistence'
+import { usePersistedAiVaultViewOptions } from './use-persisted-ai-vault-view-options'
+
+beforeEach(() => {
+  window.localStorage.removeItem(AI_VAULT_VIEW_OPTIONS_STORAGE_KEY)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  window.localStorage.removeItem(AI_VAULT_VIEW_OPTIONS_STORAGE_KEY)
+})
+
+describe('usePersistedAiVaultViewOptions', () => {
+  it('restores view options when the panel remounts', () => {
+    const first = renderHook(() => usePersistedAiVaultViewOptions())
+
+    act(() => {
+      first.result.current.setAgentEnabled('codex', false)
+      first.result.current.setSort('created')
+      first.result.current.setGroup('folder')
+      first.result.current.setHideEmptySessions(true)
+    })
+    first.unmount()
+
+    const restored = renderHook(() => usePersistedAiVaultViewOptions())
+    expect(restored.result.current.agents).not.toContain('codex')
+    expect(restored.result.current.sort).toBe('created')
+    expect(restored.result.current.group).toBe('folder')
+    expect(restored.result.current.hideEmptySessions).toBe(true)
+  })
+
+  it('keeps at least one agent enabled', () => {
+    const hook = renderHook(() => usePersistedAiVaultViewOptions())
+    const lastEnabled = AI_VAULT_AGENTS[0]
+
+    act(() => {
+      for (const agent of AI_VAULT_AGENTS.slice(1)) {
+        hook.result.current.setAgentEnabled(agent, false)
+      }
+    })
+    expect(hook.result.current.agents).toEqual([lastEnabled])
+
+    act(() => hook.result.current.setAgentEnabled(lastEnabled, false))
+    expect(hook.result.current.agents).toEqual([lastEnabled])
+  })
+
+  it('keeps in-memory options usable when persistence fails', () => {
+    const setItem = vi.spyOn(window.localStorage, 'setItem').mockImplementation(() => {
+      throw new Error('quota exceeded')
+    })
+    const hook = renderHook(() => usePersistedAiVaultViewOptions())
+
+    act(() => hook.result.current.setSort('created'))
+
+    expect(setItem).toHaveBeenCalled()
+    expect(hook.result.current.sort).toBe('created')
+  })
+
+  it('resets every persisted option to its default', () => {
+    const hook = renderHook(() => usePersistedAiVaultViewOptions())
+    act(() => {
+      hook.result.current.setAgentEnabled('codex', false)
+      hook.result.current.setSort('created')
+      hook.result.current.setGroup('agent')
+      hook.result.current.setHideEmptySessions(true)
+      hook.result.current.resetViewOptions()
+    })
+
+    expect(hook.result.current.agents).toEqual([...AI_VAULT_AGENTS])
+    expect(hook.result.current.sort).toBe('updated')
+    expect(hook.result.current.group).toBe('project')
+    expect(hook.result.current.hideEmptySessions).toBe(false)
+
+    hook.unmount()
+    const restored = renderHook(() => usePersistedAiVaultViewOptions())
+    expect(restored.result.current.agents).toEqual([...AI_VAULT_AGENTS])
+    expect(restored.result.current.sort).toBe('updated')
+    expect(restored.result.current.group).toBe('project')
+    expect(restored.result.current.hideEmptySessions).toBe(false)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/use-persisted-ai-vault-view-options.ts
+++ b/src/renderer/src/components/right-sidebar/use-persisted-ai-vault-view-options.ts
@@ -1,0 +1,99 @@
+import { useCallback, useMemo, useRef, useState } from 'react'
+import type { AiVaultAgent, AiVaultGroup, AiVaultSort } from '../../../../shared/ai-vault-types'
+import {
+  createDefaultAiVaultViewOptions,
+  enabledAiVaultAgents,
+  readAiVaultViewOptions,
+  writeAiVaultViewOptions,
+  type AiVaultViewOptions
+} from './ai-vault-view-options-persistence'
+
+type AiVaultViewOptionsUpdate = (current: AiVaultViewOptions) => AiVaultViewOptions
+
+export function usePersistedAiVaultViewOptions(): {
+  agents: AiVaultAgent[]
+  sort: AiVaultSort
+  group: AiVaultGroup
+  hideEmptySessions: boolean
+  setSort: (sort: AiVaultSort) => void
+  setGroup: (group: AiVaultGroup) => void
+  setHideEmptySessions: (hide: boolean) => void
+  setAgentEnabled: (agent: AiVaultAgent, enabled: boolean) => void
+  resetViewOptions: () => void
+} {
+  const [options, setOptions] = useState<AiVaultViewOptions>(() => readAiVaultViewOptions())
+  // Why: menu actions may batch before a render, so every persistence write must build on
+  // the immediately preceding action instead of the last rendered options.
+  const optionsRef = useRef(options)
+
+  const updateOptions = useCallback((update: AiVaultViewOptionsUpdate) => {
+    const current = optionsRef.current
+    const candidate = update(current)
+    if (candidate === current) {
+      return
+    }
+    // Why: setters map valid state to valid state, so persist the candidate directly.
+    // Re-normalizing here would re-allocate disabledAgents on every sort/group change and
+    // needlessly recompute the session filter; writeAiVaultViewOptions still normalizes what it stores.
+    optionsRef.current = candidate
+    setOptions(candidate)
+    writeAiVaultViewOptions(candidate)
+  }, [])
+
+  const setSort = useCallback(
+    (sort: AiVaultSort) =>
+      updateOptions((current) => (current.sort === sort ? current : { ...current, sort })),
+    [updateOptions]
+  )
+  const setGroup = useCallback(
+    (group: AiVaultGroup) =>
+      updateOptions((current) => (current.group === group ? current : { ...current, group })),
+    [updateOptions]
+  )
+  const setHideEmptySessions = useCallback(
+    (hideEmptySessions: boolean) =>
+      updateOptions((current) =>
+        current.hideEmptySessions === hideEmptySessions
+          ? current
+          : { ...current, hideEmptySessions }
+      ),
+    [updateOptions]
+  )
+  const setAgentEnabled = useCallback(
+    (agent: AiVaultAgent, enabled: boolean) => {
+      updateOptions((current) => {
+        const isDisabled = current.disabledAgents.includes(agent)
+        if (enabled === !isDisabled) {
+          return current
+        }
+        const disabledAgents = enabled
+          ? current.disabledAgents.filter((entry) => entry !== agent)
+          : [...current.disabledAgents, agent]
+        return enabledAiVaultAgents(disabledAgents).length > 0
+          ? { ...current, disabledAgents }
+          : current
+      })
+    },
+    [updateOptions]
+  )
+  const resetViewOptions = useCallback(
+    () => updateOptions(() => createDefaultAiVaultViewOptions()),
+    [updateOptions]
+  )
+
+  const agents = useMemo(
+    () => enabledAiVaultAgents(options.disabledAgents),
+    [options.disabledAgents]
+  )
+  return {
+    agents,
+    sort: options.sort,
+    group: options.group,
+    hideEmptySessions: options.hideEmptySessions,
+    setSort,
+    setGroup,
+    setHideEmptySessions,
+    setAgentEnabled,
+    resetViewOptions
+  }
+}


### PR DESCRIPTION
## Summary

Persist AI Vault view options in the renderer so sort, grouping, hidden-agent selections, and hide-empty-session state survive remounts and app restarts. The panel now reads and writes normalized per-client view state, while keeping scope selection transient.

## Screenshots

- No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Reviewed the persistence flow for regression risk around malformed storage, empty agent catalogs, write failures, and remount behavior. Verified the hook keeps at least one agent enabled, normalizes stored data, and falls back safely when `localStorage` is unavailable or blocked.

Cross-platform compatibility was checked for macOS, Linux, and Windows. This change is renderer-only and does not alter keyboard shortcuts, shortcut labels, filesystem path handling, shell behavior, or Electron menu accelerators.

## Security Audit

Reviewed input handling and storage boundaries for unsafe persistence or injection risk. Stored view options are normalized before use and before writeback, unknown fields are ignored, and storage failures fail closed without throwing. No command execution, auth, secret, IPC, or path-handling changes were introduced.

## Notes

- `scope` remains session/transient because it depends on workspace and project availability.
- View persistence is isolated to the renderer and uses a versioned localStorage key for the current client.