### PR TITLE
feat(sidebar): keep the default branch visible when sleeping workspaces are hidden (#8873)

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.test.tsx
@@ -1,0 +1,312 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ReactI18Next from 'react-i18next'
+import type { Repo, Worktree } from '../../../shared/types'
+import { useAppStore } from '@/store'
+import type { AppState } from '@/store/types'
+import WorktreeJumpPalette from './WorktreeJumpPalette'
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactI18Next>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key })
+  }
+})
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    message: vi.fn()
+  }
+}))
+
+vi.mock('@/hooks/useSettingsNavigationMetadata', () => ({
+  useSettingsNavigationMetadata: () => []
+}))
+
+vi.mock('@/components/sidebar/StatusIndicator', () => ({
+  default: () => <span data-status-indicator="true" />
+}))
+
+vi.mock('@/components/repo/RepoBadgeLabel', () => ({
+  RepoBadgeMark: () => <span data-repo-badge-mark="true" />
+}))
+
+vi.mock('@/components/cmd-j/palette-host-badge', () => ({
+  getPaletteHostBadge: () => null
+}))
+
+vi.mock('@/components/ui/command', async () => {
+  const React = await import('react')
+  return {
+    CommandDialog: ({ children, open }: { children: React.ReactNode; open?: boolean }) =>
+      open ? <div data-command-dialog="true">{children}</div> : null,
+    CommandInput: ({
+      value,
+      onValueChange,
+      placeholder
+    }: {
+      value?: string
+      onValueChange?: (next: string) => void
+      placeholder?: string
+    }) => {
+      setCommandQuery = onValueChange ?? null
+      return (
+        <input
+          data-command-input="true"
+          placeholder={placeholder}
+          value={value}
+          onChange={(event) => onValueChange?.(event.currentTarget.value)}
+        />
+      )
+    },
+    CommandList: React.forwardRef(function CommandList(
+      { children }: { children: React.ReactNode },
+      ref: React.ForwardedRef<HTMLDivElement>
+    ) {
+      return (
+        <div ref={ref} data-command-list="true">
+          {children}
+        </div>
+      )
+    }),
+    CommandEmpty: ({ children }: { children: React.ReactNode }) => (
+      <div data-command-empty="true">{children}</div>
+    ),
+    CommandItem: ({
+      children,
+      onSelect,
+      value
+    }: {
+      children: React.ReactNode
+      onSelect?: (value: string) => void
+      value?: string
+    }) => (
+      <button data-command-item={value ?? ''} onClick={() => onSelect?.(value ?? '')} type="button">
+        {children}
+      </button>
+    )
+  }
+})
+
+const initialAppState = useAppStore.getInitialState()
+let testRoot: Root
+let testContainer: HTMLDivElement
+let setCommandQuery: ((next: string) => void) | null = null
+
+function makeRepo(): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repos/repo-1',
+    displayName: 'Repo 1',
+    badgeColor: '#000000',
+    addedAt: 0
+  }
+}
+
+function makeWorktree(
+  id: string,
+  displayName: string,
+  overrides: Partial<Worktree> = {}
+): Worktree {
+  return {
+    id,
+    repoId: 'repo-1',
+    path: `/tmp/${id}`,
+    head: 'abc123',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: false,
+    displayName,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+async function renderPalette(overrides: Partial<AppState>): Promise<void> {
+  useAppStore.setState({
+    activeModal: 'worktree-palette',
+    activeWorktreeId: null,
+    repos: [makeRepo()],
+    tabsByWorktree: {},
+    browserTabsByWorktree: {},
+    browserPagesByWorkspace: {},
+    unifiedTabsByWorktree: {},
+    hideDefaultBranchWorkspace: false,
+    hideAutomationGeneratedWorkspaces: false,
+    lastVisitedAtByWorktreeId: {},
+    ...overrides
+  } as Partial<AppState>)
+
+  await act(async () => {
+    testRoot.render(<WorktreeJumpPalette />)
+  })
+  await flushEffects()
+}
+
+function getWorktreeRows(): string[] {
+  return [...testContainer.querySelectorAll<HTMLElement>('[data-command-item^="worktree:"]')].map(
+    (node) => node.textContent ?? ''
+  )
+}
+
+describe('WorktreeJumpPalette', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    setCommandQuery = null
+    useAppStore.setState(initialAppState, true)
+    testContainer = document.createElement('div')
+    document.body.appendChild(testContainer)
+    testRoot = createRoot(testContainer)
+  })
+
+  afterEach(async () => {
+    await act(async () => {
+      testRoot.unmount()
+    })
+    document.body.replaceChildren()
+    useAppStore.setState(initialAppState, true)
+  })
+
+  it('keeps an inactive default-branch workspace visible when sleeping workspaces are hidden', async () => {
+    const defaultBranch = makeWorktree('default-branch', 'Default branch workspace', {
+      isMainWorktree: true,
+      branch: 'refs/heads/main'
+    })
+    const feature = makeWorktree('feature', 'Feature workspace', {
+      branch: 'refs/heads/feature'
+    })
+    const folderMain = makeWorktree('folder-main', 'Folder workspace', {
+      isMainWorktree: true,
+      branch: ''
+    })
+
+    await renderPalette({
+      worktreesByRepo: { 'repo-1': [defaultBranch, feature, folderMain] },
+      showSleepingWorkspaces: false
+    })
+
+    expect(testContainer.textContent).toContain('Default branch workspace')
+    expect(testContainer.textContent).not.toContain('Feature workspace')
+    expect(testContainer.textContent).not.toContain('Folder workspace')
+  })
+
+  it('keeps the explicit default-branch filter authoritative', async () => {
+    const defaultBranch = makeWorktree('default-branch', 'Default branch workspace', {
+      isMainWorktree: true,
+      branch: 'refs/heads/main'
+    })
+
+    await renderPalette({
+      worktreesByRepo: { 'repo-1': [defaultBranch] },
+      showSleepingWorkspaces: false,
+      hideDefaultBranchWorkspace: true
+    })
+
+    expect(testContainer.textContent).not.toContain('Default branch workspace')
+  })
+
+  it('keeps an active non-default workspace visible when sleeping workspaces are hidden', async () => {
+    const defaultBranch = makeWorktree('default-branch', 'Default branch workspace', {
+      isMainWorktree: true,
+      branch: 'refs/heads/main'
+    })
+    const feature = makeWorktree('feature', 'Feature workspace', {
+      branch: 'refs/heads/feature'
+    })
+    const folderMain = makeWorktree('folder-main', 'Folder workspace', {
+      isMainWorktree: true,
+      branch: ''
+    })
+
+    await renderPalette({
+      worktreesByRepo: { 'repo-1': [defaultBranch, feature, folderMain] },
+      showSleepingWorkspaces: false,
+      browserTabsByWorktree: {
+        feature: [{ id: 'browser-tab-1' }]
+      }
+    })
+
+    expect(testContainer.textContent).toContain('Feature workspace')
+    expect(testContainer.textContent).toContain('Default branch workspace')
+    expect(testContainer.textContent).not.toContain('Folder workspace')
+  })
+
+  it('keeps the show-sleeping baseline and empty-query ordering intact', async () => {
+    const defaultBranch = makeWorktree('default-branch', 'Default branch workspace', {
+      isMainWorktree: true,
+      branch: 'refs/heads/main'
+    })
+    const feature = makeWorktree('feature', 'Feature workspace', {
+      branch: 'refs/heads/feature'
+    })
+    const folderMain = makeWorktree('folder-main', 'Folder workspace', {
+      isMainWorktree: true,
+      branch: ''
+    })
+
+    await renderPalette({
+      worktreesByRepo: { 'repo-1': [defaultBranch, feature, folderMain] },
+      showSleepingWorkspaces: true,
+      lastVisitedAtByWorktreeId: {
+        feature: 300,
+        'default-branch': 200,
+        'folder-main': 100
+      }
+    })
+
+    expect(getWorktreeRows()).toEqual([
+      expect.stringContaining('Feature workspace'),
+      expect.stringContaining('Default branch workspace'),
+      expect.stringContaining('Folder workspace')
+    ])
+  })
+
+  it('keeps typed-query results on the full non-archived scope', async () => {
+    const defaultBranch = makeWorktree('default-branch', 'Default branch workspace', {
+      isMainWorktree: true,
+      branch: 'refs/heads/main'
+    })
+    const feature = makeWorktree('feature', 'Feature workspace', {
+      branch: 'refs/heads/feature'
+    })
+
+    await renderPalette({
+      worktreesByRepo: { 'repo-1': [defaultBranch, feature] },
+      showSleepingWorkspaces: false
+    })
+
+    expect(testContainer.textContent).not.toContain('Feature workspace')
+
+    expect(setCommandQuery).not.toBeNull()
+
+    await act(async () => {
+      setCommandQuery?.('Feature')
+    })
+    await flushEffects()
+
+    expect(testContainer.textContent).toContain('Feature workspace')
+  })
+})

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -121,6 +121,19 @@ import { isGitRepoKind } from '../../../shared/repo-kind'
 import { buildTaskSourceContextFromRepo } from '../../../shared/task-source-context'
 import { translate } from '@/i18n/i18n'
 
+function shouldKeepEmptyQueryWorktreeVisible(
+  worktree: Pick<Worktree, 'isMainWorktree' | 'branch'>,
+  showSleepingWorkspaces: boolean,
+  hideDefaultBranchWorkspace: boolean,
+  isInactive: boolean
+): boolean {
+  return (
+    showSleepingWorkspaces ||
+    !isInactive ||
+    (!hideDefaultBranchWorkspace && isDefaultBranchWorkspace(worktree))
+  )
+}
+
 type WorktreePaletteItem = {
   id: string
   type: 'worktree'
@@ -508,13 +521,17 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
           return false
         }
         if (
-          !showSleepingWorkspaces &&
-          isInactiveWorkspace(
-            worktree.id,
-            tabsByWorktree,
-            ptyIdsByTabId,
-            browserTabsByWorktree,
-            worktreeIdsWithLiveAgent
+          !shouldKeepEmptyQueryWorktreeVisible(
+            worktree,
+            showSleepingWorkspaces,
+            hideDefaultBranchWorkspace,
+            isInactiveWorkspace(
+              worktree.id,
+              tabsByWorktree,
+              ptyIdsByTabId,
+              browserTabsByWorktree,
+              worktreeIdsWithLiveAgent
+            )
           )
         ) {
           return false

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -260,6 +260,49 @@ describe('computeVisibleWorktreeIds', () => {
     expect(result).toEqual([folder.id])
   })
 
+  it('keeps an inactive default branch visible when sleeping is hidden', () => {
+    const main = makeWorktree('main')
+    main.isMainWorktree = true
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [main] },
+      [main.id],
+      visibleOptions({ showSleepingWorkspaces: false })
+    )
+
+    expect(result).toEqual([main.id])
+  })
+
+  it('keeps non-default sleeping workspaces and folder-mode mains hidden', () => {
+    const main = makeWorktree('main')
+    main.isMainWorktree = true
+    const feature = makeWorktree('feature')
+    const folder = makeWorktree('folder')
+    folder.isMainWorktree = true
+    folder.branch = ''
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [main, feature, folder] },
+      [main.id, feature.id, folder.id],
+      visibleOptions({ showSleepingWorkspaces: false })
+    )
+
+    expect(result).toEqual([main.id])
+  })
+
+  it('keeps the explicit default-branch filter authoritative while sleeping is hidden', () => {
+    const main = makeWorktree('main')
+    main.isMainWorktree = true
+
+    const result = computeVisibleWorktreeIds(
+      { repo1: [main] },
+      [main.id],
+      visibleOptions({ showSleepingWorkspaces: false, hideDefaultBranchWorkspace: true })
+    )
+
+    expect(result).toEqual([])
+  })
+
   it('filters worktrees to a selected SSH host scope', () => {
     const local = makeWorktree('local', 'repo1')
     const remote = makeWorktree('remote', 'repo2')

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -21,7 +21,9 @@ import {
  * pipeline (computeVisibleWorktreeIds) and the Cmd+J jump palette. Keeping
  * the definition in one place prevents the two surfaces from drifting.
  */
-export function isDefaultBranchWorkspace(worktree: Worktree): boolean {
+export function isDefaultBranchWorkspace(
+  worktree: Pick<Worktree, 'isMainWorktree' | 'branch'>
+): boolean {
   return worktree.isMainWorktree && worktree.branch.trim() !== ''
 }
 
@@ -176,7 +178,8 @@ export function computeVisibleWorktreeIds(
           opts.ptyIdsByTabId,
           opts.browserTabsByWorktree,
           opts.worktreeIdsWithLiveAgent
-        )
+        ) ||
+        (!opts.hideDefaultBranchWorkspace && isDefaultBranchWorkspace(w))
     )
   }
 

--- a/tests/e2e/default-branch-visibility.spec.ts
+++ b/tests/e2e/default-branch-visibility.spec.ts
@@ -1,0 +1,205 @@
+import { mkdirSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { worktreeRow } from './worktree-row-locators'
+
+const RENDER_LINT_PATH = process.env.PR_RENDER_LINT_PATH
+const RENDER_ARTIFACT_DIR = process.env.PR_RENDER_ARTIFACT_DIR
+const CAPTURE_RENDER_PROOF = Boolean(RENDER_LINT_PATH && RENDER_ARTIFACT_DIR)
+const RENDER_LINT_SOURCE =
+  CAPTURE_RENDER_PROOF && RENDER_LINT_PATH ? readFileSync(RENDER_LINT_PATH, 'utf8') : null
+const RENDER_SWEEP = [
+  { width: 1280, height: 800, suffix: '' },
+  { width: 1024, height: 768, suffix: '-1024' },
+  { width: 800, height: 600, suffix: '-800' }
+]
+
+type SidebarVisibilityScenario = {
+  defaultBranchId: string
+  featureId: string
+}
+
+function sidebar(page: Parameters<typeof test>[0]['orcaPage']) {
+  return page.locator('[data-worktree-sidebar]').first()
+}
+
+function afterShotPath(suffix: string): string {
+  return resolve(RENDER_ARTIFACT_DIR!, `orca-PR-TARGET-8873-after${suffix}.png`)
+}
+
+async function collectRenderViolations(
+  page: Parameters<typeof test>[0]['orcaPage'],
+  scopeSelector: string
+): Promise<unknown[]> {
+  return page.evaluate(
+    ({ source, scopeSelector }) => {
+      const collect = new Function(
+        'selector',
+        'options',
+        `var module = { exports: {} }; var exports = module.exports; ${source}; return collectRenderViolations(selector, options);`
+      ) as (selector: string, options: Record<string, unknown>) => unknown[]
+      return collect(scopeSelector, {
+        checks: ['overlap', 'clip', 'container-escape', 'raw-string', 'a11y']
+      })
+    },
+    { source: RENDER_LINT_SOURCE, scopeSelector }
+  )
+}
+
+async function captureRenderProof(
+  page: Parameters<typeof test>[0]['orcaPage'],
+  defaultBranchRow: ReturnType<typeof worktreeRow>,
+  featureRow: ReturnType<typeof worktreeRow>
+): Promise<void> {
+  if (!CAPTURE_RENDER_PROOF) {
+    return
+  }
+
+  mkdirSync(RENDER_ARTIFACT_DIR!, { recursive: true })
+  const lintResults: Record<string, unknown[]> = {}
+  for (const sweep of RENDER_SWEEP) {
+    await page.setViewportSize({ width: sweep.width, height: sweep.height })
+    await expect(defaultBranchRow).toBeVisible()
+    await expect(featureRow).toHaveCount(0)
+    const violations = await collectRenderViolations(page, '[data-worktree-sidebar]')
+    lintResults[`${sweep.width}`] = violations
+    await sidebar(page).screenshot({ path: afterShotPath(sweep.suffix) })
+  }
+  console.log(`render lint ${JSON.stringify(lintResults)}`)
+}
+
+async function seedSidebarVisibilityScenario(
+  page: Parameters<typeof test>[0]['orcaPage']
+): Promise<SidebarVisibilityScenario> {
+  return page.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+
+    const state = store.getState()
+    const repo = state.repos[0]
+    if (!repo) {
+      throw new Error('Sidebar visibility E2E needs a seeded repo')
+    }
+
+    const currentWorktree = (state.worktreesByRepo[repo.id] ?? [])[0]
+    if (!currentWorktree) {
+      throw new Error('Sidebar visibility E2E needs a seeded worktree')
+    }
+
+    const defaultBranchId = 'e2e-default-branch-visibility-main'
+    const featureId = 'e2e-default-branch-visibility-feature'
+    const currentId = currentWorktree.id
+
+    store.setState((current) => ({
+      worktreesByRepo: {
+        ...current.worktreesByRepo,
+        [repo.id]: [
+          {
+            ...currentWorktree,
+            id: currentId,
+            displayName: 'Current workspace',
+            isMainWorktree: false,
+            branch: 'refs/heads/current',
+            lastActivityAt: 3
+          },
+          {
+            ...currentWorktree,
+            id: defaultBranchId,
+            displayName: 'Default branch workspace',
+            isMainWorktree: true,
+            branch: 'refs/heads/main',
+            lastActivityAt: 2
+          },
+          {
+            ...currentWorktree,
+            id: featureId,
+            displayName: 'Feature workspace',
+            isMainWorktree: false,
+            branch: 'refs/heads/feature',
+            lastActivityAt: 1
+          }
+        ]
+      },
+      tabsByWorktree: {
+        ...current.tabsByWorktree,
+        [defaultBranchId]: [],
+        [featureId]: []
+      },
+      browserTabsByWorktree: {
+        ...current.browserTabsByWorktree,
+        [defaultBranchId]: [],
+        [featureId]: []
+      }
+    }))
+
+    const nextState = store.getState()
+    nextState.setActiveView('terminal')
+    nextState.setSidebarOpen(true)
+    nextState.setGroupBy('none')
+    nextState.setSortBy('recent')
+    nextState.setShowActiveOnly(false)
+    nextState.setFilterRepoIds([])
+
+    return { defaultBranchId, featureId }
+  })
+}
+
+test.describe('Default branch visibility', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+  })
+
+  test('keeps the default branch visible when sleeping workspaces are hidden', async ({
+    orcaPage
+  }) => {
+    const { defaultBranchId, featureId } = await seedSidebarVisibilityScenario(orcaPage)
+    const defaultBranchRow = worktreeRow(orcaPage, defaultBranchId)
+    const featureRow = worktreeRow(orcaPage, featureId)
+
+    await expect
+      .poll(() =>
+        orcaPage.evaluate(
+          ({ defaultBranchId, featureId }) => {
+            const state = window.__store?.getState()
+            state?.setShowSleepingWorkspaces(false)
+            state?.setHideDefaultBranchWorkspace(false)
+            const featureTabs = state?.tabsByWorktree[featureId] ?? []
+            return {
+              defaultBranchTabs: state?.tabsByWorktree[defaultBranchId]?.length ?? 0,
+              featureBrowserTabs: state?.browserTabsByWorktree[featureId]?.length ?? 0,
+              featureHasLivePty: featureTabs.some(
+                (tab) => (state?.ptyIdsByTabId[tab.id] ?? []).length > 0
+              ),
+              featureTabs: featureTabs.length,
+              hideDefaultBranchWorkspace: state?.hideDefaultBranchWorkspace ?? null,
+              showSleepingWorkspaces: state?.showSleepingWorkspaces ?? null
+            }
+          },
+          { defaultBranchId, featureId }
+        )
+      )
+      .toEqual({
+        defaultBranchTabs: 0,
+        featureBrowserTabs: 0,
+        featureHasLivePty: false,
+        featureTabs: 0,
+        hideDefaultBranchWorkspace: false,
+        showSleepingWorkspaces: false
+      })
+
+    await expect(defaultBranchRow).toBeVisible()
+    await expect(defaultBranchRow).toContainText('Default branch workspace')
+    await expect(featureRow).toHaveCount(0)
+    await captureRenderProof(orcaPage, defaultBranchRow, featureRow)
+
+    await orcaPage.evaluate(() => {
+      window.__store?.getState().setHideDefaultBranchWorkspace(true)
+    })
+
+    await expect(defaultBranchRow).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
## Summary

- Keep the inactive default-branch workspace visible when `Hide sleeping` is enabled and `Hide default branch` is disabled.
- Preserve the explicit `Hide default branch` filter and keep non-default sleeping workspaces hidden.
- Keep the empty-query jump palette aligned with the sidebar so both visibility surfaces treat the default branch the same way.

Closes #8873.

## Screenshots

No screenshot is attached. The change was exercised headlessly at 1280x800, 1024x768, and 800x600 with Playwright/Electron. The render-lint sweep reports accessible-name and clip findings from the sidebar's existing 1px hidden controls, but these findings predate this change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- Passed: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/visible-worktrees.test.ts`, 40 tests.
- Passed: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/WorktreeJumpPalette.test.tsx`, 5 tests.
- Passed: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/visible-worktrees.test.ts src/renderer/src/components/WorktreeJumpPalette.test.tsx`, 45 tests.
- Passed: `pnpm run typecheck:web`.
- Passed: `pnpm exec oxlint src/renderer/src/components/sidebar/visible-worktrees.ts src/renderer/src/components/sidebar/visible-worktrees.test.ts src/renderer/src/components/WorktreeJumpPalette.tsx src/renderer/src/components/WorktreeJumpPalette.test.tsx tests/e2e/default-branch-visibility.spec.ts`.
- Passed: `pnpm exec oxfmt --check src/renderer/src/components/sidebar/visible-worktrees.ts src/renderer/src/components/sidebar/visible-worktrees.test.ts src/renderer/src/components/WorktreeJumpPalette.tsx src/renderer/src/components/WorktreeJumpPalette.test.tsx tests/e2e/default-branch-visibility.spec.ts`.
- Passed: `pnpm exec electron-vite build --mode e2e`.
- Passed: `pnpm exec playwright test tests/e2e/default-branch-visibility.spec.ts --config tests/playwright.config.ts --project electron-headless`.
- Base regression runs on `origin/main @ 69c14fadceee8218858759890481b0b606caae55` failed the new sidebar cases with `2 failed | 38 passed (40)`, failed the old palette behavior with `1 failed | 3 passed (4)`, and failed the headless sidebar proof because the default-branch row was absent; the head reruns passed, with the palette widened to 5 focused cases and the combined focused suite widened to 45 cases.

## AI Review Report

Implementation review covers default-branch exemption correctness, non-default sleeping negative space, explicit filter precedence, preserved sidebar ordering and lineage stages, and empty-query jump-palette parity. The change stays renderer-only and does not add terminal, shell, SSH, provider, IPC, persisted-state, or runtime-state behavior.

## Security Audit

The change is a renderer-side visibility predicate only. Review verified that it adds no new input parsing, IPC, path handling, auth, secrets, command execution, or filesystem surfaces.

## Notes

- Toggle labels, persisted state, and settings surfaces stay unchanged.
- Folder-mode main workspaces with no branch stay outside the exemption.
- The sidebar and Cmd+J surfaces now share the same default-branch sleeping exception, and the palette proof is behavioral rather than helper-based.

## ELI5

With “Hide sleeping” on, the default-branch workspace no longer disappears unless you also hide the default branch. Sleeping feature worktrees stay hidden; the main branch stays easy to find.
