### PR TITLE
fix: preserve terminal scroll across ADE tab switches

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -2290,7 +2290,7 @@ function Terminal(): React.JSX.Element | null {
       ) : null}
 
       {!effectiveActiveLayout && !anyMountedWorktreeHasLayout && (
-        <>
+        <div className="relative flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden">
           {/* Why: split-group layouts render their own terminal/browser/editor
               surfaces through TabGroupPanel plus stable overlay layers.
               Keeping the legacy workspace-level panes mounted underneath
@@ -2309,20 +2309,28 @@ function Terminal(): React.JSX.Element | null {
               startFreshSpawn → new PTY. That respawn is exactly what flips
               getWorktreeStatus back to 'active' and re-lights the sidebar
               dot green moments after the user clicked Shutdown. */}
-          {/* Terminal panes container - hidden when editor tab active */}
+          {/* Terminal panes container — keep laid out under editor/browser so
+              xterm scroll position survives tab switches (display:none resets it). */}
           <div
-            className={`relative flex-1 min-h-0 overflow-hidden ${
-              // Why: only hide the terminal container when another tab type has
-              // content to display. Hiding unconditionally for non-terminal types
+            className={`absolute inset-0 min-h-0 overflow-hidden ${
+              // Why: only park the terminal container when another tab type has
+              // content to display. Parking unconditionally for non-terminal types
               // causes a blank screen when activeTabType is stale (e.g. 'editor'
               // with no files after session restore). The terminal stays visible
               // as a fallback until another surface is ready.
+              // Why opacity instead of `hidden`: display:none zeroes xterm's
+              // viewport before resume can restore scroll on tab return.
               (activeTabType === 'editor' && worktreeFiles.length > 0) ||
               (activeTabType === 'browser' && worktreeBrowserTabs.length > 0) ||
               activeTabType === 'simulator'
-                ? 'hidden'
+                ? 'opacity-0 pointer-events-none'
                 : ''
             }`}
+            aria-hidden={
+              (activeTabType === 'editor' && worktreeFiles.length > 0) ||
+              (activeTabType === 'browser' && worktreeBrowserTabs.length > 0) ||
+              activeTabType === 'simulator'
+            }
           >
             {workspaceSurfaces
               .filter((workspace) => mountedWorktreeIdsRef.current.has(workspace.id))
@@ -2455,17 +2463,19 @@ function Terminal(): React.JSX.Element | null {
           </div>
 
           {renderedActiveWorktreeId && activeTabType === 'editor' && worktreeFiles.length > 0 && (
-            <Suspense
-              fallback={
-                <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
-                  {translate('auto.components.Terminal.5c1d2a32bb', 'Loading editor...')}
-                </div>
-              }
-            >
-              <EditorPanel />
-            </Suspense>
+            <div className="absolute inset-0">
+              <Suspense
+                fallback={
+                  <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
+                    {translate('auto.components.Terminal.5c1d2a32bb', 'Loading editor...')}
+                  </div>
+                }
+              >
+                <EditorPanel />
+              </Suspense>
+            </div>
           )}
-        </>
+        </div>
       )}
 
       {/* Save confirmation dialog */}

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -23,6 +23,7 @@ import type {
 import TerminalSearch from '@/components/TerminalSearch'
 import type { PtyTransport } from './pty-transport'
 import { fitPanes, isWindowsUserAgent } from './pane-helpers'
+import { resolveTerminalTabSurfaceStyle } from './terminal-tab-visibility-style'
 import { getConnectionId, getConnectionIdFromState } from '@/lib/connection-context'
 import {
   getExplicitRuntimeEnvironmentIdForWorktree,
@@ -1855,8 +1856,8 @@ export default function TerminalPane({
     isActive,
     isVisible,
     isWorktreeActive,
-    // Why: hidden startup probes are opacity-hidden but measurable; ordinary
-    // hidden tabs are display:none and refit on visibility resume instead.
+    // Why: hidden startup probes and intra-worktree tab hides stay opacity-hidden
+    // but laid out; only inactive worktree surfaces use display:none.
     isSyncFitEnabled: isRendererVisible || shouldMeasureHiddenStartup,
     paneCount,
     managerRef,
@@ -2935,18 +2936,25 @@ export default function TerminalPane({
     }) ?? (titleUsesLightSurface ? '#ffffff' : '#000000')
 
   const terminalContentVisible = isVisible || shouldMeasureHiddenStartup
-  const hiddenStartupStyle: CSSProperties = shouldMeasureHiddenStartup
-    ? { opacity: 0, pointerEvents: 'none' }
-    : {}
+  const tabSurfaceStyle = resolveTerminalTabSurfaceStyle({
+    isVisible,
+    isWorktreeActive,
+    shouldMeasureHiddenStartup
+  })
+  const hiddenStartupStyle: CSSProperties =
+    tabSurfaceStyle.opacity === 0
+      ? { opacity: 0, pointerEvents: 'none' }
+      : {}
   const terminalContainerStyle: CSSProperties = {
     // Why: split groups can keep one terminal visible in an unfocused group so
     // users still see its output while typing elsewhere. Hiding on `isActive`
     // blanked the previously focused pane and exposed the white group body.
-    display: terminalContentVisible ? 'flex' : 'none',
+    // Why: intra-worktree tab hides keep flex layout (opacity 0) so xterm does
+    // not lose scroll position the way `display: none` does on tab return.
+    ...tabSurfaceStyle,
     // Why: split divider lines intentionally overdraw inside the pane tree.
     // `hidden` reliably clips that pseudo-element paint at the terminal body.
     overflow: 'hidden',
-    ...hiddenStartupStyle,
     ['--orca-terminal-divider-color' as string]:
       effectiveAppearance?.dividerColor ?? DEFAULT_TERMINAL_DIVIDER_DARK,
     ['--orca-terminal-divider-color-strong' as string]: normalizeColor(

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
@@ -1,3 +1,4 @@
+import { resolveTerminalTabSurfaceStyle } from './terminal-tab-visibility-style'
 import { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useShallow } from 'zustand/react/shallow'
@@ -176,6 +177,11 @@ const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
     }
   }, [anchorName, isVisible, measuredFallbackRect])
 
+  const tabSurfaceStyle = resolveTerminalTabSurfaceStyle({
+    isVisible,
+    isWorktreeActive,
+    shouldMeasureHiddenStartup
+  })
   const style: React.CSSProperties = useMemo(
     () =>
       anchorName && shouldUseCssAnchorPositioning()
@@ -186,9 +192,7 @@ const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
             left: `anchor(${anchorName} left)`,
             width: `anchor-size(${anchorName} width)`,
             height: `anchor-size(${anchorName} height)`,
-            display: isVisible || shouldMeasureHiddenStartup ? 'flex' : 'none',
-            opacity: isVisible ? 1 : 0,
-            pointerEvents: isVisible ? 'auto' : 'none'
+            ...tabSurfaceStyle
           }
         : anchorName
           ? {
@@ -200,9 +204,7 @@ const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
               left: measuredFallbackRect?.left ?? 0,
               width: measuredFallbackRect?.width ?? '100%',
               height: measuredFallbackRect?.height ?? 'calc(100% - 32px)',
-              display: isVisible || shouldMeasureHiddenStartup ? 'flex' : 'none',
-              opacity: isVisible ? 1 : 0,
-              pointerEvents: isVisible ? 'auto' : 'none'
+              ...tabSurfaceStyle
             }
           : {
               position: 'absolute',
@@ -213,7 +215,7 @@ const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
               display: 'none',
               pointerEvents: 'none'
             },
-    [anchorName, isVisible, measuredFallbackRect, shouldMeasureHiddenStartup]
+    [anchorName, measuredFallbackRect, tabSurfaceStyle]
   )
   const focusGroup = useCallback(() => {
     if (groupId !== undefined && onFocusOwningGroup) {

--- a/src/renderer/src/components/terminal-pane/terminal-tab-visibility-style.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-tab-visibility-style.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isTerminalTabSurfaceLaidOut,
+  resolveTerminalTabSurfaceStyle
+} from './terminal-tab-visibility-style'
+
+describe('resolveTerminalTabSurfaceStyle', () => {
+  it('keeps the active tab fully laid out', () => {
+    expect(
+      resolveTerminalTabSurfaceStyle({
+        isVisible: true,
+        isWorktreeActive: true,
+        shouldMeasureHiddenStartup: false
+      })
+    ).toEqual({ display: 'flex' })
+  })
+
+  it('keeps layout with opacity when another tab in the same worktree is active', () => {
+    const style = resolveTerminalTabSurfaceStyle({
+      isVisible: false,
+      isWorktreeActive: true,
+      shouldMeasureHiddenStartup: false
+    })
+    expect(style).toEqual({ display: 'flex', opacity: 0, pointerEvents: 'none' })
+    expect(isTerminalTabSurfaceLaidOut(style)).toBe(true)
+  })
+
+  it('keeps layout for hidden startup measurement', () => {
+    expect(
+      resolveTerminalTabSurfaceStyle({
+        isVisible: false,
+        isWorktreeActive: false,
+        shouldMeasureHiddenStartup: true
+      })
+    ).toEqual({ display: 'flex', opacity: 0, pointerEvents: 'none' })
+  })
+
+  it('collapses only when the worktree surface itself is inactive', () => {
+    const style = resolveTerminalTabSurfaceStyle({
+      isVisible: false,
+      isWorktreeActive: false,
+      shouldMeasureHiddenStartup: false
+    })
+    expect(style).toEqual({ display: 'none', pointerEvents: 'none' })
+    expect(isTerminalTabSurfaceLaidOut(style)).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-tab-visibility-style.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-tab-visibility-style.ts
@@ -1,0 +1,35 @@
+import type { CSSProperties } from 'react'
+
+export type TerminalTabSurfaceVisibility = {
+  isVisible: boolean
+  isWorktreeActive: boolean
+  shouldMeasureHiddenStartup: boolean
+}
+
+export type TerminalTabSurfaceStyle = Pick<CSSProperties, 'display' | 'opacity' | 'pointerEvents'>
+
+/**
+ * Decide how a mounted terminal surface is hidden.
+ *
+ * Why: `display: none` zeroes xterm's viewport before hide/resume effects can
+ * capture scroll, so returning to the tab jumps to the top. Intra-worktree tab
+ * switches (and startup measurement) keep layout via opacity instead; only a
+ * fully inactive worktree surface uses `display: none`.
+ */
+export function resolveTerminalTabSurfaceStyle({
+  isVisible,
+  isWorktreeActive,
+  shouldMeasureHiddenStartup
+}: TerminalTabSurfaceVisibility): TerminalTabSurfaceStyle {
+  if (isVisible) {
+    return { display: 'flex' }
+  }
+  if (shouldMeasureHiddenStartup || isWorktreeActive) {
+    return { display: 'flex', opacity: 0, pointerEvents: 'none' }
+  }
+  return { display: 'none', pointerEvents: 'none' }
+}
+
+export function isTerminalTabSurfaceLaidOut(style: TerminalTabSurfaceStyle): boolean {
+  return style.display === 'flex'
+}


### PR DESCRIPTION
## Summary
- Inactive terminal tabs no longer use `display: none` while the worktree stays active; they stay laid out with `opacity: 0` so xterm keeps its viewport.
- Legacy terminal surface under editor/browser tabs uses the same opacity park instead of Tailwind `hidden`, which was resetting scroll when switching e.g. PowerShell ↔ file tabs.
- Adds `resolveTerminalTabSurfaceStyle` + unit tests for the visibility policy.

## Screenshots
No visual change (opacity-hidden inactive tabs should look the same). Behavior change: scroll position is preserved after switching top ADE tabs and returning.

## Testing
- [x] Added unit tests for `resolveTerminalTabSurfaceStyle`
- [ ] `pnpm lint` (local sparse checkout / deps not fully installed on this machine)
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- Manual repro expected: scroll a terminal up → switch to another titlebar tab (terminal or editor) → switch back → viewport should stay put (Windows ADE).

## AI Review Report
Checked Windows Electron tab hide/show path: `display: none` applied in render before hide effects capture scroll, so remembered viewport became line 0. Verified overlay + legacy `Terminal.tsx` containers both needed the opacity park. Cross-platform: CSS opacity/`pointer-events` behavior is shared on macOS/Linux/Windows; no shortcut/path/shell changes.

## Security Audit
No input handling, command execution, path, auth, secrets, dependency, or IPC changes.

## Notes
Related to scroll-reset reports such as #7118 / tab-switch UX; OMP file-tab case remains #8715 / #8783.

## ELI5

Switching away from a terminal tab and back reset your scroll position. Hidden terminals stay laid out (just invisible) so xterm keeps where you were reading.
