### PR TITLE
fix(ai-vault): discover Antigravity CLI sessions

### DIFF
--- a/src/main/ai-vault/remote-session-scanner-discovery.ts
+++ b/src/main/ai-vault/remote-session-scanner-discovery.ts
@@ -1,0 +1,157 @@
+import { extname } from 'node:path'
+import type { AiVaultAgent, AiVaultScanIssue } from '../../shared/ai-vault-types'
+import type { ExecutionHostId } from '../../shared/execution-host'
+import type { FileStat, IFilesystemProvider } from '../providers/types'
+import type { RemoteHostPlatform } from '../ssh/ssh-remote-platform'
+import { joinRemotePath } from '../ssh/ssh-remote-platform'
+import { partitionSubagentTranscriptPaths } from './session-scanner-subagent-transcripts'
+import type { FileWithMtime } from './session-scanner-types'
+import { errorMessage } from './session-scanner-values'
+import type {
+  RemoteScannerContext,
+  RemoteSessionCandidate,
+  RemoteSessionSource
+} from './remote-session-scanner-types'
+
+const REMOTE_DISCOVERY_CONCURRENCY = 8
+
+export async function discoverRemoteSourceCandidates(args: {
+  source: RemoteSessionSource
+  context: RemoteScannerContext
+  issues: AiVaultScanIssue[]
+}): Promise<RemoteSessionCandidate[]> {
+  const walked = args.source.fixedChildFileSegments
+    ? await listRemoteFixedChildFiles(args.source, args.context.provider, args.context.hostPlatform)
+    : await walkRemoteSessionFiles(args.source, args.context.provider, args.context.hostPlatform)
+  const partition = args.source.collectSubagentSiblingCounts
+    ? partitionSubagentTranscriptPaths(walked)
+    : null
+  const paths = partition ? partition.sessionFilePaths : walked
+  const files = await mapDiscoveryConcurrently(paths, (path) =>
+    statRemoteFile(
+      args.context.provider,
+      path,
+      args.source.agent,
+      args.context.executionHostId,
+      args.issues,
+      Boolean(args.source.fixedChildFileSegments)
+    )
+  )
+  return files
+    .filter((file): file is FileWithMtime => Boolean(file))
+    .map((file) => ({
+      source: args.source,
+      file,
+      subagentTranscriptCount: partition?.subagentTranscriptCounts.get(file.path) ?? 0
+    }))
+}
+
+async function listRemoteFixedChildFiles(
+  source: RemoteSessionSource,
+  provider: IFilesystemProvider,
+  hostPlatform: RemoteHostPlatform
+): Promise<string[]> {
+  let entries
+  try {
+    entries = await provider.readDir(source.rootDir)
+  } catch {
+    return []
+  }
+  const segments = source.fixedChildFileSegments ?? []
+  // Why: Antigravity's transcript path is fixed. Constructing it avoids three
+  // serialized SSH readDir round trips for every conversation directory.
+  return entries
+    .filter((entry) => entry.isDirectory && !entry.isSymlink)
+    .map((entry) => joinRemotePath(hostPlatform, source.rootDir, entry.name, ...segments))
+    .filter((path) => source.filePredicate?.(path) ?? true)
+}
+
+async function walkRemoteSessionFiles(
+  source: RemoteSessionSource,
+  provider: IFilesystemProvider,
+  hostPlatform: RemoteHostPlatform,
+  dirPath = source.rootDir,
+  depth = 0
+): Promise<string[]> {
+  let entries
+  try {
+    entries = await provider.readDir(dirPath)
+  } catch {
+    return []
+  }
+
+  const extensions = new Set(source.extensions)
+  const files: string[] = []
+  for (const entry of entries) {
+    const fullPath = joinRemotePath(hostPlatform, dirPath, entry.name)
+    if (
+      entry.isDirectory &&
+      !entry.isSymlink &&
+      (source.directoryPredicate?.(entry.name, depth) ?? true)
+    ) {
+      files.push(
+        ...(await walkRemoteSessionFiles(source, provider, hostPlatform, fullPath, depth + 1))
+      )
+      continue
+    }
+    if (
+      !entry.isSymlink &&
+      extensions.has(extname(entry.name).toLowerCase()) &&
+      (source.filePredicate?.(fullPath) ?? true)
+    ) {
+      files.push(fullPath)
+    }
+  }
+  return files
+}
+
+async function statRemoteFile(
+  provider: IFilesystemProvider,
+  path: string,
+  agent: AiVaultAgent,
+  executionHostId: ExecutionHostId,
+  issues: AiVaultScanIssue[],
+  missingIsExpected: boolean
+): Promise<FileWithMtime | null> {
+  try {
+    const stat = await provider.stat(path)
+    const mtimeMs = remoteStatMtimeMs(stat)
+    return { path, mtimeMs, modifiedAt: new Date(mtimeMs).toISOString() }
+  } catch (err) {
+    if (!missingIsExpected || !isMissingRemoteFileError(err)) {
+      issues.push({ executionHostId, agent, path, message: errorMessage(err) })
+    }
+    return null
+  }
+}
+
+function isMissingRemoteFileError(err: unknown): boolean {
+  const code =
+    err && typeof err === 'object' && 'code' in err && typeof err.code === 'string'
+      ? err.code
+      : null
+  if (code === 'ENOENT' || code === 'ENOTDIR') {
+    return true
+  }
+  // Relay/provider boundaries can preserve only the underlying Node error text.
+  return /(?:^|[\s:])(ENOENT|ENOTDIR)(?=[\s:]|$)/.test(errorMessage(err))
+}
+
+function remoteStatMtimeMs(stat: FileStat): number {
+  if (typeof stat.mtimeMs === 'number' && Number.isFinite(stat.mtimeMs)) {
+    return stat.mtimeMs
+  }
+  return stat.mtime > 10_000_000_000 ? stat.mtime : stat.mtime * 1000
+}
+
+async function mapDiscoveryConcurrently<T, U>(
+  items: readonly T[],
+  mapper: (item: T) => Promise<U>
+): Promise<U[]> {
+  const results: U[] = []
+  for (let index = 0; index < items.length; index += REMOTE_DISCOVERY_CONCURRENCY) {
+    const batch = items.slice(index, index + REMOTE_DISCOVERY_CONCURRENCY)
+    results.push(...(await Promise.all(batch.map(mapper))))
+  }
+  return results
+}

--- a/src/main/ai-vault/remote-session-scanner-discovery.ts
+++ b/src/main/ai-vault/remote-session-scanner-discovery.ts
@@ -2,7 +2,6 @@ import { extname } from 'node:path'
 import type { AiVaultAgent, AiVaultScanIssue } from '../../shared/ai-vault-types'
 import type { ExecutionHostId } from '../../shared/execution-host'
 import type { FileStat, IFilesystemProvider } from '../providers/types'
-import type { RemoteHostPlatform } from '../ssh/ssh-remote-platform'
 import { joinRemotePath } from '../ssh/ssh-remote-platform'
 import { partitionSubagentTranscriptPaths } from './session-scanner-subagent-transcripts'
 import type { FileWithMtime } from './session-scanner-types'
@@ -21,8 +20,8 @@ export async function discoverRemoteSourceCandidates(args: {
   issues: AiVaultScanIssue[]
 }): Promise<RemoteSessionCandidate[]> {
   const walked = args.source.fixedChildFileSegments
-    ? await listRemoteFixedChildFiles(args.source, args.context.provider, args.context.hostPlatform)
-    : await walkRemoteSessionFiles(args.source, args.context.provider, args.context.hostPlatform)
+    ? await listRemoteFixedChildFiles(args.source, args.context, args.issues)
+    : await walkRemoteSessionFiles(args.source, args.context, args.issues)
   const partition = args.source.collectSubagentSiblingCounts
     ? partitionSubagentTranscriptPaths(walked)
     : null
@@ -48,13 +47,14 @@ export async function discoverRemoteSourceCandidates(args: {
 
 async function listRemoteFixedChildFiles(
   source: RemoteSessionSource,
-  provider: IFilesystemProvider,
-  hostPlatform: RemoteHostPlatform
+  context: RemoteScannerContext,
+  issues: AiVaultScanIssue[]
 ): Promise<string[]> {
   let entries
   try {
-    entries = await provider.readDir(source.rootDir)
-  } catch {
+    entries = await context.provider.readDir(source.rootDir)
+  } catch (err) {
+    recordRemoteDirectoryIssue(source, context.executionHostId, issues, source.rootDir, err)
     return []
   }
   const segments = source.fixedChildFileSegments ?? []
@@ -62,36 +62,35 @@ async function listRemoteFixedChildFiles(
   // serialized SSH readDir round trips for every conversation directory.
   return entries
     .filter((entry) => entry.isDirectory && !entry.isSymlink)
-    .map((entry) => joinRemotePath(hostPlatform, source.rootDir, entry.name, ...segments))
+    .map((entry) => joinRemotePath(context.hostPlatform, source.rootDir, entry.name, ...segments))
     .filter((path) => source.filePredicate?.(path) ?? true)
 }
 
 async function walkRemoteSessionFiles(
   source: RemoteSessionSource,
-  provider: IFilesystemProvider,
-  hostPlatform: RemoteHostPlatform,
+  context: RemoteScannerContext,
+  issues: AiVaultScanIssue[],
   dirPath = source.rootDir,
   depth = 0
 ): Promise<string[]> {
   let entries
   try {
-    entries = await provider.readDir(dirPath)
-  } catch {
+    entries = await context.provider.readDir(dirPath)
+  } catch (err) {
+    recordRemoteDirectoryIssue(source, context.executionHostId, issues, dirPath, err)
     return []
   }
 
   const extensions = new Set(source.extensions)
   const files: string[] = []
   for (const entry of entries) {
-    const fullPath = joinRemotePath(hostPlatform, dirPath, entry.name)
+    const fullPath = joinRemotePath(context.hostPlatform, dirPath, entry.name)
     if (
       entry.isDirectory &&
       !entry.isSymlink &&
       (source.directoryPredicate?.(entry.name, depth) ?? true)
     ) {
-      files.push(
-        ...(await walkRemoteSessionFiles(source, provider, hostPlatform, fullPath, depth + 1))
-      )
+      files.push(...(await walkRemoteSessionFiles(source, context, issues, fullPath, depth + 1)))
       continue
     }
     if (
@@ -118,14 +117,26 @@ async function statRemoteFile(
     const mtimeMs = remoteStatMtimeMs(stat)
     return { path, mtimeMs, modifiedAt: new Date(mtimeMs).toISOString() }
   } catch (err) {
-    if (!missingIsExpected || !isMissingRemoteFileError(err)) {
+    if (!missingIsExpected || !isMissingRemotePathError(err)) {
       issues.push({ executionHostId, agent, path, message: errorMessage(err) })
     }
     return null
   }
 }
 
-function isMissingRemoteFileError(err: unknown): boolean {
+function recordRemoteDirectoryIssue(
+  source: RemoteSessionSource,
+  executionHostId: ExecutionHostId,
+  issues: AiVaultScanIssue[],
+  path: string,
+  err: unknown
+): void {
+  if (!isMissingRemotePathError(err)) {
+    issues.push({ executionHostId, agent: source.agent, path, message: errorMessage(err) })
+  }
+}
+
+function isMissingRemotePathError(err: unknown): boolean {
   const code =
     err && typeof err === 'object' && 'code' in err && typeof err.code === 'string'
       ? err.code

--- a/src/main/ai-vault/remote-session-scanner-sources.ts
+++ b/src/main/ai-vault/remote-session-scanner-sources.ts
@@ -1,6 +1,8 @@
 import type { AiVaultAgent, AiVaultSession } from '../../shared/ai-vault-types'
 import type { RemoteHostPlatform } from '../ssh/ssh-remote-platform'
 import { joinRemotePath } from '../ssh/ssh-remote-platform'
+import { parseAntigravitySessionContent } from './session-scanner-antigravity-parser'
+import { isAntigravityTranscriptPath } from './session-scanner-antigravity-paths'
 import { parseCodexSessionContent } from './session-scanner-codex-parser'
 import { parseDevinSessionContent } from './session-scanner-devin-parser'
 import { parseDroidSessionContent } from './session-scanner-droid-parser'
@@ -49,6 +51,7 @@ export function remoteSessionSources(
       // top-level sessions carrying the parent's sessionId.
       collectSubagentSiblingCounts: true
     },
+    remoteAntigravitySource(remoteHome, hostPlatform),
     source(
       'gemini',
       remoteHome,
@@ -108,6 +111,30 @@ export function remoteSessionSources(
   ]
 }
 
+function remoteAntigravitySource(
+  remoteHome: string,
+  hostPlatform: RemoteHostPlatform
+): RemoteSessionSource {
+  const cliRoot = joinRemotePath(hostPlatform, remoteHome, '.gemini', 'antigravity-cli')
+  const historyPath = joinRemotePath(hostPlatform, cliRoot, 'history.jsonl')
+  return {
+    agent: 'antigravity',
+    rootDir: joinRemotePath(hostPlatform, cliRoot, 'brain'),
+    extensions: ['.jsonl'],
+    filePredicate: isAntigravityTranscriptPath,
+    fixedChildFileSegments: ['.system_generated', 'logs', 'transcript.jsonl'],
+    parse: async (file, content, context) => {
+      const session = await parseAntigravitySessionContent(
+        file,
+        content,
+        context.hostPlatform.os,
+        parserOptions(context)
+      )
+      return session ? context.antigravityWorkspaceResolver.enrich(session, historyPath) : null
+    }
+  }
+}
+
 function source(
   agent: AiVaultAgent,
   remoteHome: string,
@@ -115,13 +142,15 @@ function source(
   segments: readonly string[],
   extensions: readonly string[],
   parseContent: RemoteContentParser,
-  filePredicate?: (path: string) => boolean
+  filePredicate?: (path: string) => boolean,
+  directoryPredicate?: (name: string, depth: number) => boolean
 ): RemoteSessionSource {
   return {
     agent,
     rootDir: joinRemotePath(hostPlatform, remoteHome, ...segments),
     extensions,
     filePredicate,
+    directoryPredicate,
     parse: (file, content, context) =>
       Promise.resolve(parseContent(file, content, context.hostPlatform.os, parserOptions(context)))
   }

--- a/src/main/ai-vault/remote-session-scanner-types.ts
+++ b/src/main/ai-vault/remote-session-scanner-types.ts
@@ -3,12 +3,14 @@ import type { ExecutionHostId } from '../../shared/execution-host'
 import type { IFilesystemProvider } from '../providers/types'
 import type { RemoteHostPlatform } from '../ssh/ssh-remote-platform'
 import type { FileWithMtime } from './session-scanner-types'
+import type { AntigravityWorkspaceResolver } from './session-scanner-antigravity-history'
 
 export type RemoteScannerContext = {
   provider: IFilesystemProvider
   executionHostId: ExecutionHostId
   hostPlatform: RemoteHostPlatform
   titleCaches: Map<string, Promise<Map<string, string>>>
+  antigravityWorkspaceResolver: AntigravityWorkspaceResolver
 }
 
 export type RemoteParserOptions = {
@@ -21,6 +23,10 @@ export type RemoteSessionSource = {
   rootDir: string
   extensions: readonly string[]
   filePredicate?: (path: string) => boolean
+  // Depth 0 denotes a direct child of rootDir.
+  directoryPredicate?: (name: string, depth: number) => boolean
+  // A canonical file directly beneath every top-level session directory.
+  fixedChildFileSegments?: readonly string[]
   // Claude layout: count `<session>/subagents/*.jsonl` siblings from the walked
   // listing and drop them from candidates instead of indexing them as sessions.
   collectSubagentSiblingCounts?: boolean

--- a/src/main/ai-vault/remote-session-scanner.test.ts
+++ b/src/main/ai-vault/remote-session-scanner.test.ts
@@ -6,13 +6,20 @@ import { scanRemoteAiVaultSessions } from './remote-session-scanner'
 
 class MemoryRemoteProvider implements IFilesystemProvider {
   private readonly files = new Map<string, { content: string; mtimeMs: number }>()
+  private readonly statErrors = new Map<string, Error>()
+  readonly readDirPaths: string[] = []
 
   addFile(path: string, content: string, mtimeMs: number): void {
     this.files.set(normalize(path), { content, mtimeMs })
   }
 
+  failStat(path: string, error: Error): void {
+    this.statErrors.set(normalize(path), error)
+  }
+
   async readDir(dirPath: string): Promise<DirEntry[]> {
     const dir = normalize(dirPath)
+    this.readDirPaths.push(dir)
     const prefix = dir.endsWith('/') ? dir : `${dir}/`
     const entries = new Map<string, DirEntry>()
     for (const path of this.files.keys()) {
@@ -45,6 +52,10 @@ class MemoryRemoteProvider implements IFilesystemProvider {
   }
 
   async stat(filePath: string): Promise<FileStat> {
+    const statError = this.statErrors.get(normalize(filePath))
+    if (statError) {
+      throw statError
+    }
     const file = this.files.get(normalize(filePath))
     if (!file) {
       throw new Error(`ENOENT: ${filePath}`)
@@ -201,6 +212,132 @@ describe('scanRemoteAiVaultSessions', () => {
     })
   })
 
+  it('parses only canonical Antigravity transcripts on SSH hosts', async () => {
+    const provider = new MemoryRemoteProvider()
+    const sessionId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+    const logsDir = `/home/ada/.gemini/antigravity-cli/brain/${sessionId}/.system_generated/logs`
+    provider.addFile(
+      `${logsDir}/transcript.jsonl`,
+      jsonLines([
+        {
+          source: 'USER_EXPLICIT',
+          type: 'USER_INPUT',
+          created_at: '2026-07-15T11:39:10Z',
+          content: '<USER_REQUEST>Fix remote Antigravity history</USER_REQUEST>'
+        },
+        {
+          source: 'MODEL',
+          type: 'PLANNER_RESPONSE',
+          created_at: '2026-07-15T11:39:12Z',
+          content: 'Done'
+        }
+      ]),
+      50
+    )
+    provider.addFile(`${logsDir}/transcript_full.jsonl`, 'duplicate', 51)
+    provider.addFile(
+      `/home/ada/.gemini/antigravity-cli/brain/${sessionId}/artifacts/task.jsonl`,
+      'not a transcript',
+      52
+    )
+    provider.addFile(
+      '/home/ada/.gemini/antigravity-cli/history.jsonl',
+      jsonLines([
+        {
+          display: 'Fix remote Antigravity history',
+          timestamp: Date.parse('2026-07-15T11:39:10.100Z'),
+          workspace: '/home/ada/project'
+        }
+      ]),
+      53
+    )
+
+    const result = await scanRemoteAiVaultSessions({
+      provider,
+      executionHostId: 'ssh:dev-box',
+      remoteHome: '/home/ada',
+      hostPlatform: getRemoteHostPlatform('linux-x64'),
+      scopePaths: ['/home/ada/project']
+    })
+
+    expect(result.issues).toEqual([])
+    expect(result.sessions).toHaveLength(1)
+    expect(result.sessions[0]).toMatchObject({
+      executionHostId: 'ssh:dev-box',
+      executionHostPlatform: 'linux',
+      agent: 'antigravity',
+      sessionId,
+      title: 'Fix remote Antigravity history',
+      cwd: '/home/ada/project',
+      messageCount: 2,
+      resumeCommand: `agy --conversation '${sessionId}'`,
+      filePath: `${logsDir}/transcript.jsonl`
+    })
+    expect(
+      provider.readDirPaths.filter((path) =>
+        path.startsWith('/home/ada/.gemini/antigravity-cli/brain')
+      )
+    ).toEqual(['/home/ada/.gemini/antigravity-cli/brain'])
+  })
+
+  it('keeps Antigravity SSH discovery to one listing as the session store grows', async () => {
+    const provider = new MemoryRemoteProvider()
+    const brainDir = '/home/ada/.gemini/antigravity-cli/brain'
+    for (let index = 0; index < 40; index++) {
+      provider.addFile(
+        `${brainDir}/session-${index}/.system_generated/logs/transcript.jsonl`,
+        jsonLines([
+          {
+            source: 'USER_EXPLICIT',
+            type: 'USER_INPUT',
+            created_at: `2026-07-15T11:39:${String(index).padStart(2, '0')}Z`,
+            content: `<USER_REQUEST>Remote session ${index}</USER_REQUEST>`
+          }
+        ]),
+        100 + index
+      )
+    }
+
+    const result = await scanRemoteAiVaultSessions({
+      provider,
+      executionHostId: 'ssh:dev-box',
+      remoteHome: '/home/ada',
+      hostPlatform: getRemoteHostPlatform('linux-x64')
+    })
+
+    expect(result.issues).toEqual([])
+    expect(result.sessions).toHaveLength(40)
+    expect(provider.readDirPaths.filter((path) => path.startsWith(brainDir))).toEqual([brainDir])
+  })
+
+  it('ignores missing canonical Antigravity transcripts but reports other stat failures', async () => {
+    const provider = new MemoryRemoteProvider()
+    const brainDir = '/home/ada/.gemini/antigravity-cli/brain'
+    provider.addFile(`${brainDir}/missing-session/artifacts/task.jsonl`, 'artifact', 1)
+    const deniedTranscript = `${brainDir}/denied-session/.system_generated/logs/transcript.jsonl`
+    provider.addFile(deniedTranscript, 'unreadable', 2)
+    provider.failStat(
+      deniedTranscript,
+      new Error(`EACCES: permission denied, stat '${deniedTranscript}'`)
+    )
+
+    const result = await scanRemoteAiVaultSessions({
+      provider,
+      executionHostId: 'ssh:dev-box',
+      remoteHome: '/home/ada',
+      hostPlatform: getRemoteHostPlatform('linux-x64')
+    })
+
+    expect(result.sessions).toEqual([])
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        agent: 'antigravity',
+        path: deniedTranscript,
+        message: expect.stringContaining('EACCES')
+      })
+    ])
+  })
+
   it('excludes Claude subagent transcripts from remote scans', async () => {
     const provider = new MemoryRemoteProvider()
     provider.addFile(
@@ -355,6 +492,49 @@ describe('scanRemoteAiVaultSessions', () => {
     expect(result.sessions[0]?.resumeCommand).toBe(
       'cmd /d /s /c "cd /d ""C:/repo/app"" && set ""CODEX_HOME=C:/Users/Ada/.codex"" && codex resume ""win-session"""'
     )
+  })
+
+  it('loads Antigravity workspace history with Windows remote paths', async () => {
+    const provider = new MemoryRemoteProvider()
+    const sessionId = 'dddddddd-eeee-4fff-8aaa-bbbbbbbbbbbb'
+    provider.addFile(
+      `C:/Users/Ada/.gemini/antigravity-cli/brain/${sessionId}/.system_generated/logs/transcript.jsonl`,
+      jsonLines([
+        {
+          source: 'USER_EXPLICIT',
+          type: 'USER_INPUT',
+          created_at: '2026-07-15T11:39:10.000Z',
+          content: '<USER_REQUEST>Windows Antigravity title</USER_REQUEST>'
+        }
+      ]),
+      30
+    )
+    provider.addFile(
+      'C:/Users/Ada/.gemini/antigravity-cli/history.jsonl',
+      jsonLines([
+        {
+          display: 'Windows Antigravity title',
+          timestamp: Date.parse('2026-07-15T11:39:10.100Z'),
+          workspace: 'C:/repo/app'
+        }
+      ]),
+      31
+    )
+
+    const result = await scanRemoteAiVaultSessions({
+      provider,
+      executionHostId: 'ssh:win-box',
+      remoteHome: 'C:/Users/Ada',
+      hostPlatform: getRemoteHostPlatform('win32-x64')
+    })
+
+    expect(result.issues).toEqual([])
+    expect(result.sessions[0]).toMatchObject({
+      agent: 'antigravity',
+      sessionId,
+      cwd: 'C:/repo/app',
+      executionHostPlatform: 'win32'
+    })
   })
 
   it('continues past skipped candidates to fill the remote scan limit', async () => {

--- a/src/main/ai-vault/remote-session-scanner.test.ts
+++ b/src/main/ai-vault/remote-session-scanner.test.ts
@@ -6,6 +6,7 @@ import { scanRemoteAiVaultSessions } from './remote-session-scanner'
 
 class MemoryRemoteProvider implements IFilesystemProvider {
   private readonly files = new Map<string, { content: string; mtimeMs: number }>()
+  private readonly readDirErrors = new Map<string, Error>()
   private readonly statErrors = new Map<string, Error>()
   readonly readDirPaths: string[] = []
 
@@ -17,9 +18,17 @@ class MemoryRemoteProvider implements IFilesystemProvider {
     this.statErrors.set(normalize(path), error)
   }
 
+  failReadDir(path: string, error: Error): void {
+    this.readDirErrors.set(normalize(path), error)
+  }
+
   async readDir(dirPath: string): Promise<DirEntry[]> {
     const dir = normalize(dirPath)
     this.readDirPaths.push(dir)
+    const readDirError = this.readDirErrors.get(dir)
+    if (readDirError) {
+      throw readDirError
+    }
     const prefix = dir.endsWith('/') ? dir : `${dir}/`
     const entries = new Map<string, DirEntry>()
     for (const path of this.files.keys()) {
@@ -336,6 +345,58 @@ describe('scanRemoteAiVaultSessions', () => {
         message: expect.stringContaining('EACCES')
       })
     ])
+  })
+
+  it('reports non-missing fixed and recursive remote directory failures', async () => {
+    const provider = new MemoryRemoteProvider()
+    const brainDir = '/home/ada/.gemini/antigravity-cli/brain'
+    const claudeProjectDir = '/home/ada/.claude/projects/repo'
+    provider.addFile(`${claudeProjectDir}/session.jsonl`, 'unreadable', 1)
+    provider.failReadDir(brainDir, new Error(`EACCES: permission denied, scandir '${brainDir}'`))
+    provider.failReadDir(
+      claudeProjectDir,
+      new Error(`ECONNRESET: connection lost while reading '${claudeProjectDir}'`)
+    )
+
+    const result = await scanRemoteAiVaultSessions({
+      provider,
+      executionHostId: 'ssh:dev-box',
+      remoteHome: '/home/ada',
+      hostPlatform: getRemoteHostPlatform('linux-x64')
+    })
+
+    expect(result.sessions).toEqual([])
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          agent: 'antigravity',
+          path: brainDir,
+          message: expect.stringContaining('EACCES')
+        }),
+        expect.objectContaining({
+          agent: 'claude',
+          path: claudeProjectDir,
+          message: expect.stringContaining('ECONNRESET')
+        })
+      ])
+    )
+    expect(result.issues).toHaveLength(2)
+  })
+
+  it('keeps missing optional remote directories silent', async () => {
+    const provider = new MemoryRemoteProvider()
+    const brainDir = '/home/ada/.gemini/antigravity-cli/brain'
+    provider.failReadDir(brainDir, new Error(`ENOENT: no such directory, scandir '${brainDir}'`))
+
+    const result = await scanRemoteAiVaultSessions({
+      provider,
+      executionHostId: 'ssh:dev-box',
+      remoteHome: '/home/ada',
+      hostPlatform: getRemoteHostPlatform('linux-x64')
+    })
+
+    expect(result.sessions).toEqual([])
+    expect(result.issues).toEqual([])
   })
 
   it('excludes Claude subagent transcripts from remote scans', async () => {

--- a/src/main/ai-vault/remote-session-scanner.ts
+++ b/src/main/ai-vault/remote-session-scanner.ts
@@ -1,25 +1,18 @@
-import { extname } from 'node:path'
 import type {
-  AiVaultAgent,
   AiVaultListResult,
   AiVaultScanIssue,
   AiVaultSession
 } from '../../shared/ai-vault-types'
 import { isPathInsideOrEqual } from '../../shared/cross-platform-path'
 import type { ExecutionHostId } from '../../shared/execution-host'
-import type { FileStat, IFilesystemProvider } from '../providers/types'
+import type { IFilesystemProvider } from '../providers/types'
 import type { RemoteHostPlatform } from '../ssh/ssh-remote-platform'
-import { joinRemotePath } from '../ssh/ssh-remote-platform'
 import { sessionSortTime } from './session-scanner-accumulator'
-import { partitionSubagentTranscriptPaths } from './session-scanner-subagent-transcripts'
-import type { FileWithMtime } from './session-scanner-types'
+import { createAntigravityWorkspaceResolver } from './session-scanner-antigravity-history'
 import { errorMessage } from './session-scanner-values'
+import { discoverRemoteSourceCandidates } from './remote-session-scanner-discovery'
 import { remoteSessionSources } from './remote-session-scanner-sources'
-import type {
-  RemoteScannerContext,
-  RemoteSessionCandidate,
-  RemoteSessionSource
-} from './remote-session-scanner-types'
+import type { RemoteScannerContext, RemoteSessionCandidate } from './remote-session-scanner-types'
 
 const DEFAULT_REMOTE_SCAN_LIMIT = 1000
 const REMOTE_SCAN_CONCURRENCY = 8
@@ -39,7 +32,15 @@ export async function scanRemoteAiVaultSessions(args: {
     provider: args.provider,
     executionHostId: args.executionHostId,
     hostPlatform: args.hostPlatform,
-    titleCaches: new Map()
+    titleCaches: new Map(),
+    antigravityWorkspaceResolver: createAntigravityWorkspaceResolver(async (historyPath) => {
+      try {
+        const read = await args.provider.readFile(historyPath)
+        return read.isBinary ? null : read.content
+      } catch {
+        return null
+      }
+    })
   }
   const candidates = (
     await mapRemoteScanConcurrently(
@@ -71,70 +72,6 @@ export async function scanRemoteAiVaultSessions(args: {
     issues,
     scannedAt: new Date().toISOString()
   }
-}
-
-async function discoverRemoteSourceCandidates(args: {
-  source: RemoteSessionSource
-  context: RemoteScannerContext
-  issues: AiVaultScanIssue[]
-}): Promise<RemoteSessionCandidate[]> {
-  const walked = await walkRemoteSessionFiles(
-    args.source,
-    args.context.provider,
-    args.context.hostPlatform
-  )
-  const partition = args.source.collectSubagentSiblingCounts
-    ? partitionSubagentTranscriptPaths(walked)
-    : null
-  const paths = partition ? partition.sessionFilePaths : walked
-  const files = await mapRemoteScanConcurrently(paths, (path) =>
-    statRemoteFile(
-      args.context.provider,
-      path,
-      args.source.agent,
-      args.context.executionHostId,
-      args.issues
-    )
-  )
-  return files
-    .filter((file): file is FileWithMtime => Boolean(file))
-    .map((file) => ({
-      source: args.source,
-      file,
-      subagentTranscriptCount: partition?.subagentTranscriptCounts.get(file.path) ?? 0
-    }))
-}
-
-async function walkRemoteSessionFiles(
-  source: RemoteSessionSource,
-  provider: IFilesystemProvider,
-  hostPlatform: RemoteHostPlatform,
-  dirPath = source.rootDir
-): Promise<string[]> {
-  let entries
-  try {
-    entries = await provider.readDir(dirPath)
-  } catch {
-    return []
-  }
-
-  const extensions = new Set(source.extensions)
-  const files: string[] = []
-  for (const entry of entries) {
-    const fullPath = joinRemotePath(hostPlatform, dirPath, entry.name)
-    if (entry.isDirectory && !entry.isSymlink) {
-      files.push(...(await walkRemoteSessionFiles(source, provider, hostPlatform, fullPath)))
-      continue
-    }
-    if (
-      !entry.isSymlink &&
-      extensions.has(extname(entry.name).toLowerCase()) &&
-      (source.filePredicate?.(fullPath) ?? true)
-    ) {
-      files.push(fullPath)
-    }
-  }
-  return files
 }
 
 async function parseRemoteSessionCandidates(args: {
@@ -252,30 +189,6 @@ function isRemoteSessionInScope(session: AiVaultSession, scopePaths: readonly st
 
 function normalizeRemoteScopePaths(scopePaths: readonly string[]): string[] {
   return scopePaths.map((scopePath) => scopePath.trim()).filter(Boolean)
-}
-
-async function statRemoteFile(
-  provider: IFilesystemProvider,
-  path: string,
-  agent: AiVaultAgent,
-  executionHostId: ExecutionHostId,
-  issues: AiVaultScanIssue[]
-): Promise<FileWithMtime | null> {
-  try {
-    const stat = await provider.stat(path)
-    const mtimeMs = remoteStatMtimeMs(stat)
-    return { path, mtimeMs, modifiedAt: new Date(mtimeMs).toISOString() }
-  } catch (err) {
-    issues.push({ executionHostId, agent, path, message: errorMessage(err) })
-    return null
-  }
-}
-
-function remoteStatMtimeMs(stat: FileStat): number {
-  if (typeof stat.mtimeMs === 'number' && Number.isFinite(stat.mtimeMs)) {
-    return stat.mtimeMs
-  }
-  return stat.mtime > 10_000_000_000 ? stat.mtime : stat.mtime * 1000
 }
 
 function canStopParsingRemoteSessions(

--- a/src/main/ai-vault/session-scanner-agent-parser.ts
+++ b/src/main/ai-vault/session-scanner-agent-parser.ts
@@ -1,5 +1,6 @@
 import type { AiVaultSession } from '../../shared/ai-vault-types'
 import { parseDevinSessionFile } from './session-scanner-devin-parser'
+import { parseAntigravitySessionFile } from './session-scanner-antigravity-parser'
 import { parseDroidSessionFile } from './session-scanner-droid-parser'
 import { parseGrokSessionFile } from './session-scanner-grok-parser'
 import { parseMessageGraphSessionFile, parseRovoSessionFile } from './session-scanner-graph-parsers'
@@ -37,6 +38,8 @@ export async function parseAgentSessionFile(
       return parseCodexSessionFile(candidate.file, platform, candidate.codexHome)
     case 'gemini':
       return parseGeminiSessionFile(candidate.file, platform)
+    case 'antigravity':
+      return parseAntigravitySessionFile(candidate.file, platform)
     case 'copilot':
       return parseCopilotSessionFile(candidate.file, platform)
     case 'cursor':

--- a/src/main/ai-vault/session-scanner-antigravity-fixtures.ts
+++ b/src/main/ai-vault/session-scanner-antigravity-fixtures.ts
@@ -1,0 +1,35 @@
+import type { IncrementalAgentFixture } from './session-scanner-incremental-fixtures'
+
+export function antigravityFixture(): IncrementalAgentFixture {
+  const record = (source: string, type: string, content: string, createdAt: string) =>
+    JSON.stringify({ source, type, content, created_at: createdAt })
+  return {
+    agent: 'antigravity',
+    fileName: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/.system_generated/logs/transcript.jsonl',
+    seedLines: [
+      record(
+        'USER_EXPLICIT',
+        'USER_INPUT',
+        '<USER_REQUEST>antigravity seed question</USER_REQUEST>',
+        '2026-05-01T10:00:00.000Z'
+      ),
+      record('MODEL', 'PLANNER_RESPONSE', 'antigravity seed answer', '2026-05-01T10:00:30.000Z')
+    ],
+    appendLines: [
+      record(
+        'USER',
+        'REQUEST',
+        '<USER_REQUEST>antigravity follow-up</USER_REQUEST>',
+        '2026-05-01T10:01:00.000Z'
+      )
+    ],
+    truncatedLines: [
+      record(
+        'USER_EXPLICIT',
+        'USER_INPUT',
+        '<USER_REQUEST>antigravity rewritten</USER_REQUEST>',
+        '2026-05-01T10:00:00.000Z'
+      )
+    ]
+  }
+}

--- a/src/main/ai-vault/session-scanner-antigravity-history.ts
+++ b/src/main/ai-vault/session-scanner-antigravity-history.ts
@@ -1,0 +1,77 @@
+import type { AiVaultSession } from '../../shared/ai-vault-types'
+import { normalizeTitleText, parseJsonObject } from './session-scanner-values'
+
+const HISTORY_MATCH_WINDOW_MS = 2_000
+
+type AntigravityHistoryEntry = {
+  timestampMs: number
+  workspace: string
+}
+
+type AntigravityHistoryIndex = Map<string, AntigravityHistoryEntry[]>
+
+export type AntigravityWorkspaceResolver = {
+  enrich(session: AiVaultSession, historyPath: string): Promise<AiVaultSession>
+}
+
+export function createAntigravityWorkspaceResolver(
+  readHistory: (historyPath: string) => Promise<string | null>
+): AntigravityWorkspaceResolver {
+  const indexes = new Map<string, Promise<AntigravityHistoryIndex>>()
+
+  return {
+    async enrich(session, historyPath) {
+      if (session.agent !== 'antigravity' || session.cwd) {
+        return session
+      }
+      let index = indexes.get(historyPath)
+      if (!index) {
+        index = readHistory(historyPath).then(indexAntigravityHistory)
+        indexes.set(historyPath, index)
+      }
+      const workspace = findAntigravityWorkspace(session, await index)
+      return workspace ? { ...session, cwd: workspace } : session
+    }
+  }
+}
+
+function indexAntigravityHistory(content: string | null): AntigravityHistoryIndex {
+  const index: AntigravityHistoryIndex = new Map()
+  for (const line of content?.split(/\r?\n/) ?? []) {
+    const record = parseJsonObject(line)
+    const display = typeof record?.display === 'string' ? normalizeTitleText(record.display) : null
+    const workspace = typeof record?.workspace === 'string' ? record.workspace.trim() : ''
+    const timestampMs = typeof record?.timestamp === 'number' ? record.timestamp : Number.NaN
+    if (!display || !workspace || !Number.isFinite(timestampMs)) {
+      continue
+    }
+    const entries = index.get(display) ?? []
+    entries.push({ timestampMs, workspace })
+    index.set(display, entries)
+  }
+  return index
+}
+
+function findAntigravityWorkspace(
+  session: AiVaultSession,
+  index: AntigravityHistoryIndex
+): string | null {
+  // Why: truncated titles are not prompt identities; long worker prompts often
+  // share the same 96-character prefix across unrelated workspaces.
+  if (session.title.endsWith('...')) {
+    return null
+  }
+  const firstTitledUserTimestamp = session.previewMessages.find(
+    (message) => message.role === 'user' && normalizeTitleText(message.text) === session.title
+  )?.timestamp
+  const promptTimestampMs = Date.parse(firstTitledUserTimestamp ?? session.createdAt ?? '')
+  if (!Number.isFinite(promptTimestampMs)) {
+    return null
+  }
+  const matches = (index.get(session.title) ?? []).filter(
+    (entry) => Math.abs(entry.timestampMs - promptTimestampMs) <= HISTORY_MATCH_WINDOW_MS
+  )
+  // Why: history rows have no conversation id. A unique prompt/time match is
+  // evidence for cwd; ambiguity must stay unknown instead of crossing projects.
+  return matches.length === 1 ? (matches[0]?.workspace ?? null) : null
+}

--- a/src/main/ai-vault/session-scanner-antigravity-history.ts
+++ b/src/main/ai-vault/session-scanner-antigravity-history.ts
@@ -1,5 +1,5 @@
 import type { AiVaultSession } from '../../shared/ai-vault-types'
-import { normalizeTitleText, parseJsonObject } from './session-scanner-values'
+import { normalizeTitleText, parseJsonObject, timestampMs } from './session-scanner-values'
 
 const HISTORY_MATCH_WINDOW_MS = 2_000
 
@@ -41,12 +41,12 @@ function indexAntigravityHistory(content: string | null): AntigravityHistoryInde
     const record = parseJsonObject(line)
     const display = typeof record?.display === 'string' ? normalizeTitleText(record.display) : null
     const workspace = typeof record?.workspace === 'string' ? record.workspace.trim() : ''
-    const timestampMs = typeof record?.timestamp === 'number' ? record.timestamp : Number.NaN
-    if (!display || !workspace || !Number.isFinite(timestampMs)) {
+    const entryTimestampMs = timestampMs(record?.timestamp)
+    if (!display || !workspace || !Number.isFinite(entryTimestampMs)) {
       continue
     }
     const entries = index.get(display) ?? []
-    entries.push({ timestampMs, workspace })
+    entries.push({ timestampMs: entryTimestampMs, workspace })
     index.set(display, entries)
   }
   return index
@@ -64,7 +64,7 @@ function findAntigravityWorkspace(
   const firstTitledUserTimestamp = session.previewMessages.find(
     (message) => message.role === 'user' && normalizeTitleText(message.text) === session.title
   )?.timestamp
-  const promptTimestampMs = Date.parse(firstTitledUserTimestamp ?? session.createdAt ?? '')
+  const promptTimestampMs = timestampMs(firstTitledUserTimestamp ?? session.createdAt)
   if (!Number.isFinite(promptTimestampMs)) {
     return null
   }

--- a/src/main/ai-vault/session-scanner-antigravity-parser.test.ts
+++ b/src/main/ai-vault/session-scanner-antigravity-parser.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import { parseAntigravitySessionContent } from './session-scanner-antigravity-parser'
+import type { FileWithMtime } from './session-scanner-types'
+import { jsonLines } from './session-scanner-test-fixtures'
+
+const SESSION_ID = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+
+describe('Antigravity AI Vault parser', () => {
+  it('parses the established transcript contract without leaking metadata wrappers', async () => {
+    const session = await parseAntigravitySessionContent(
+      file(
+        `/home/ada/.gemini/antigravity-cli/brain/${SESSION_ID}/.system_generated/logs/transcript.jsonl`
+      ),
+      jsonLines([
+        {
+          step_index: 0,
+          source: 'USER_EXPLICIT',
+          type: 'USER_INPUT',
+          status: 'DONE',
+          created_at: '2026-07-15T11:39:10Z',
+          content:
+            '<USER_REQUEST>\nFix the vault adapter\n</USER_REQUEST>\n<ADDITIONAL_METADATA>ignored</ADDITIONAL_METADATA>'
+        },
+        {
+          step_index: 1,
+          source: 'SYSTEM',
+          type: 'CONVERSATION_HISTORY',
+          created_at: '2026-07-15T11:39:11Z'
+        },
+        {
+          step_index: 2,
+          source: 'MODEL',
+          type: 'PLANNER_RESPONSE',
+          status: 'DONE',
+          created_at: '2026-07-15T11:39:12Z',
+          content: 'The adapter is ready.'
+        },
+        {
+          step_index: 3,
+          source: 'SYSTEM',
+          type: 'CHECKPOINT',
+          created_at: '2026-07-15T11:39:14Z',
+          content: 'internal checkpoint'
+        }
+      ]),
+      'linux'
+    )
+
+    expect(session).toMatchObject({
+      agent: 'antigravity',
+      sessionId: SESSION_ID,
+      title: 'Fix the vault adapter',
+      cwd: null,
+      model: null,
+      createdAt: '2026-07-15T11:39:10.000Z',
+      updatedAt: '2026-07-15T11:39:14.000Z',
+      messageCount: 2,
+      resumeCommand: `agy --conversation '${SESSION_ID}'`
+    })
+    expect(session?.previewMessages).toEqual([
+      {
+        role: 'user',
+        text: 'Fix the vault adapter',
+        timestamp: '2026-07-15T11:39:10.000Z'
+      },
+      {
+        role: 'assistant',
+        text: 'The adapter is ready.',
+        timestamp: '2026-07-15T11:39:12.000Z'
+      }
+    ])
+  })
+
+  it('derives the conversation id from Windows paths and quotes the resume command', async () => {
+    const session = await parseAntigravitySessionContent(
+      file(
+        `C:\\Users\\Ada\\.gemini\\antigravity-cli\\brain\\${SESSION_ID}\\.system_generated\\logs\\transcript.jsonl`
+      ),
+      jsonLines([
+        {
+          source: 'USER',
+          type: 'REQUEST',
+          created_at: '2026-07-15T11:39:10Z',
+          content: 'Windows prompt'
+        }
+      ]),
+      'win32'
+    )
+
+    expect(session).toMatchObject({
+      sessionId: SESSION_ID,
+      title: 'Windows prompt',
+      resumeCommand: `agy --conversation "${SESSION_ID}"`
+    })
+  })
+
+  it('rejects files outside the targeted Antigravity transcript layout', async () => {
+    await expect(
+      parseAntigravitySessionContent(
+        file('/home/ada/.gemini/antigravity-cli/brain/transcript.jsonl'),
+        jsonLines([{ source: 'USER', type: 'REQUEST', content: 'Not a conversation transcript' }])
+      )
+    ).resolves.toBeNull()
+  })
+})
+
+function file(path: string): FileWithMtime {
+  return {
+    path,
+    mtimeMs: Date.parse('2026-07-15T11:39:14Z'),
+    modifiedAt: '2026-07-15T11:39:14.000Z',
+    sizeBytes: 1
+  }
+}

--- a/src/main/ai-vault/session-scanner-antigravity-parser.ts
+++ b/src/main/ai-vault/session-scanner-antigravity-parser.ts
@@ -1,0 +1,120 @@
+import { createReadStream } from 'node:fs'
+import { createInterface } from 'node:readline'
+import type { AiVaultSession } from '../../shared/ai-vault-types'
+import type { ExecutionHostId } from '../../shared/execution-host'
+import {
+  accumulatorFoldResumeState,
+  addPreviewMessage,
+  createAccumulator,
+  updateTimeline
+} from './session-scanner-accumulator'
+import { antigravityConversationIdFromTranscriptPath } from './session-scanner-antigravity-paths'
+import type {
+  FileWithMtime,
+  ResumableSessionParseState,
+  SessionAccumulator
+} from './session-scanner-types'
+import { extractString, normalizeTitleText, parseJsonObject } from './session-scanner-values'
+
+type ParserSessionOptions = {
+  executionHostId?: ExecutionHostId
+  executionHostPlatform?: NodeJS.Platform | null
+}
+
+export async function parseAntigravitySessionFile(
+  file: FileWithMtime,
+  platform: NodeJS.Platform = process.platform
+): Promise<AiVaultSession | null> {
+  const lines = createInterface({
+    input: createReadStream(file.path, { encoding: 'utf-8' }),
+    crlfDelay: Infinity
+  })
+  return parseAntigravitySessionLines({ file, lines, platform })
+}
+
+export async function parseAntigravitySessionContent(
+  file: FileWithMtime,
+  content: string,
+  platform: NodeJS.Platform = process.platform,
+  options: ParserSessionOptions = {}
+): Promise<AiVaultSession | null> {
+  return parseAntigravitySessionLines({
+    file,
+    lines: content.split(/\r?\n/),
+    platform,
+    options
+  })
+}
+
+export function createAntigravitySessionResumeState(
+  file: FileWithMtime
+): ResumableSessionParseState {
+  const sessionId = antigravityConversationIdFromTranscriptPath(file.path) ?? ''
+  // Why: the transcript has no cwd/model fields. Workspace enrichment is a
+  // separate, conservative history join; protobuf/SQLite blobs are unstable.
+  return accumulatorFoldResumeState(
+    createAccumulator({ agent: 'antigravity', file, sessionId }),
+    consumeAntigravityRecordLine
+  )
+}
+
+async function parseAntigravitySessionLines(args: {
+  file: FileWithMtime
+  lines: AsyncIterable<string> | Iterable<string>
+  platform: NodeJS.Platform
+  options?: ParserSessionOptions
+}): Promise<AiVaultSession | null> {
+  const state = createAntigravitySessionResumeState(args.file)
+  for await (const line of args.lines) {
+    state.consumeLine(line)
+  }
+  return state.finalize(args.platform, args.options)
+}
+
+function consumeAntigravityRecordLine(accumulator: SessionAccumulator, line: string): void {
+  const record = parseJsonObject(line)
+  if (!record) {
+    return
+  }
+
+  updateTimeline(accumulator, record.created_at)
+  const source = extractString(record.source)
+  const type = extractString(record.type)
+  const content = extractString(record.content)
+
+  if (
+    (source === 'USER_EXPLICIT' || source === 'USER') &&
+    (type === 'USER_INPUT' || type === 'REQUEST')
+  ) {
+    const request = extractAntigravityUserRequest(content ?? '')
+    if (!request) {
+      return
+    }
+    accumulator.messageCount++
+    accumulator.title ??= normalizeTitleText(request)
+    addPreviewMessage(accumulator, { role: 'user', text: request, timestamp: record.created_at })
+    return
+  }
+
+  if (source === 'MODEL' && type === 'PLANNER_RESPONSE' && content) {
+    accumulator.messageCount++
+    addPreviewMessage(accumulator, {
+      role: 'assistant',
+      text: content,
+      timestamp: record.created_at
+    })
+  }
+}
+
+function extractAntigravityUserRequest(content: string): string | null {
+  const opener = '<USER_REQUEST>'
+  const startIndex = content.indexOf(opener)
+  if (startIndex === -1) {
+    return extractString(content)
+  }
+  const bodyStart = startIndex + opener.length
+  const endIndex = content.indexOf('</USER_REQUEST>', bodyStart)
+  return extractString(
+    endIndex === -1 ? content.slice(bodyStart) : content.slice(bodyStart, endIndex)
+  )
+}

--- a/src/main/ai-vault/session-scanner-antigravity-paths.ts
+++ b/src/main/ai-vault/session-scanner-antigravity-paths.ts
@@ -1,0 +1,42 @@
+import { dirname, join } from 'node:path'
+
+const ANTIGRAVITY_TRANSCRIPT_FILE = 'transcript.jsonl'
+const ANTIGRAVITY_SYSTEM_DIR = '.system_generated'
+const ANTIGRAVITY_LOGS_DIR = 'logs'
+
+export function antigravityConversationIdFromTranscriptPath(filePath: string): string | null {
+  const segments = pathSegments(filePath)
+  const transcriptIndex = segments.length - 1
+  if (
+    segments[transcriptIndex] !== ANTIGRAVITY_TRANSCRIPT_FILE ||
+    segments[transcriptIndex - 1] !== ANTIGRAVITY_LOGS_DIR ||
+    segments[transcriptIndex - 2] !== ANTIGRAVITY_SYSTEM_DIR
+  ) {
+    return null
+  }
+  return segments[transcriptIndex - 3] ?? null
+}
+
+export function isAntigravityTranscriptPath(filePath: string): boolean {
+  return antigravityConversationIdFromTranscriptPath(filePath) !== null
+}
+
+export function shouldDescendAntigravityBrainDirectory(name: string, depth: number): boolean {
+  // Why: brain entries contain large artifact trees; only the fixed transcript
+  // chain is part of the resumable conversation contract.
+  if (depth === 0) {
+    return true
+  }
+  if (depth === 1) {
+    return name === ANTIGRAVITY_SYSTEM_DIR
+  }
+  return depth === 2 && name === ANTIGRAVITY_LOGS_DIR
+}
+
+export function antigravityHistoryPathForBrainDir(brainDir: string): string {
+  return join(dirname(brainDir), 'history.jsonl')
+}
+
+function pathSegments(filePath: string): string[] {
+  return filePath.split(/[\\/]+/).filter(Boolean)
+}

--- a/src/main/ai-vault/session-scanner-antigravity-source.test.ts
+++ b/src/main/ai-vault/session-scanner-antigravity-source.test.ts
@@ -1,0 +1,167 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { filterAiVaultSessions } from '../../shared/ai-vault-session-filters'
+import { AI_VAULT_AGENTS } from '../../shared/ai-vault-types'
+import { scanAiVaultSessions } from './session-scanner'
+import {
+  isolatedScanRoots,
+  writeAntigravityHistory,
+  writeAntigravityTranscript
+} from './session-scanner-test-fixtures'
+
+const tempRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('Antigravity AI Vault discovery', () => {
+  it('discovers canonical transcripts from WSL homes without indexing sibling artifacts', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-antigravity-wsl-'))
+    tempRoots.push(root)
+    const roots = isolatedScanRoots(root)
+    const wslHome = join(root, 'wsl-home')
+    const sessionId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+    const transcriptPath = await writeAntigravityTranscript(
+      join(wslHome, '.gemini', 'antigravity-cli', 'brain'),
+      sessionId,
+      [
+        {
+          source: 'USER_EXPLICIT',
+          type: 'USER_INPUT',
+          created_at: '2026-07-15T11:39:10Z',
+          content: '<USER_REQUEST>Index the WSL conversation</USER_REQUEST>'
+        }
+      ]
+    )
+    await writeFile(join(dirname(transcriptPath), 'transcript_full.jsonl'), 'duplicate')
+    await writeAntigravityHistory(join(wslHome, '.gemini', 'antigravity-cli', 'brain'), [
+      {
+        display: 'Index the WSL conversation',
+        timestamp: Date.parse('2026-07-15T11:39:10.100Z'),
+        workspace: '/home/ada/project'
+      }
+    ])
+
+    const result = await scanAiVaultSessions({
+      ...roots,
+      wslHomeDirs: [wslHome],
+      platform: 'linux'
+    })
+
+    expect(result.issues).toEqual([])
+    expect(result.sessions).toHaveLength(1)
+    expect(result.sessions[0]).toMatchObject({
+      agent: 'antigravity',
+      sessionId,
+      title: 'Index the WSL conversation',
+      cwd: '/home/ada/project',
+      resumeCommand: `agy --conversation '${sessionId}'`,
+      filePath: transcriptPath
+    })
+  })
+
+  it('uses a unique history match in the default workspace view', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-antigravity-workspace-'))
+    tempRoots.push(root)
+    const roots = isolatedScanRoots(root)
+    const sessionId = 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff'
+    const workspace = join(root, 'active-workspace')
+    await writeAntigravityTranscript(roots.antigravityBrainDir, sessionId, [
+      {
+        source: 'USER_EXPLICIT',
+        type: 'USER_INPUT',
+        created_at: '2026-07-15T11:39:10.000Z',
+        content: '<USER_REQUEST>ORCA_8742_REPRO</USER_REQUEST>'
+      }
+    ])
+
+    const beforeHistory = await scanAiVaultSessions({ ...roots, platform: 'darwin' })
+    expect(beforeHistory.sessions[0]?.cwd).toBeNull()
+
+    await writeAntigravityHistory(roots.antigravityBrainDir, [
+      {
+        display: 'ORCA_8742_REPRO',
+        timestamp: Date.parse('2026-07-15T11:39:10.100Z'),
+        workspace
+      }
+    ])
+    // The transcript is unchanged, so this also covers history refresh after a
+    // cached incremental parse has already been stored.
+    const result = await scanAiVaultSessions({ ...roots, platform: 'darwin' })
+
+    expect(result.sessions[0]?.cwd).toBe(workspace)
+    expect(
+      filterAiVaultSessions(result.sessions, {
+        query: '',
+        agents: AI_VAULT_AGENTS,
+        scope: 'workspace',
+        sort: 'updated',
+        activeWorktreePaths: [workspace],
+        hideEmptySessions: true
+      }).map((session) => session.sessionId)
+    ).toEqual([sessionId])
+  })
+
+  it('keeps workspace unknown when matching history rows are ambiguous', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-antigravity-ambiguous-'))
+    tempRoots.push(root)
+    const roots = isolatedScanRoots(root)
+    const sessionId = 'cccccccc-dddd-4eee-8fff-aaaaaaaaaaaa'
+    await writeAntigravityTranscript(roots.antigravityBrainDir, sessionId, [
+      {
+        source: 'USER_EXPLICIT',
+        type: 'USER_INPUT',
+        created_at: '2026-07-15T11:39:10.000Z',
+        content: '<USER_REQUEST>Repeated prompt</USER_REQUEST>'
+      }
+    ])
+    await writeAntigravityHistory(roots.antigravityBrainDir, [
+      {
+        display: 'Repeated prompt',
+        timestamp: Date.parse('2026-07-15T11:39:09.900Z'),
+        workspace: '/repo/one'
+      },
+      {
+        display: 'Repeated prompt',
+        timestamp: Date.parse('2026-07-15T11:39:10.100Z'),
+        workspace: '/repo/two'
+      }
+    ])
+
+    const result = await scanAiVaultSessions({ ...roots, platform: 'linux' })
+
+    expect(result.sessions[0]?.cwd).toBeNull()
+  })
+
+  it('does not join workspace from a colliding truncated prompt title', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-antigravity-long-title-'))
+    tempRoots.push(root)
+    const roots = isolatedScanRoots(root)
+    const sessionId = 'eeeeeeee-ffff-4aaa-8bbb-cccccccccccc'
+    const commonPrefix = 'shared worker preamble '.repeat(7)
+    await writeAntigravityTranscript(roots.antigravityBrainDir, sessionId, [
+      {
+        source: 'USER_EXPLICIT',
+        type: 'USER_INPUT',
+        created_at: '2026-07-15T11:39:10.000Z',
+        content: `<USER_REQUEST>${commonPrefix}workspace A</USER_REQUEST>`
+      }
+    ])
+    await writeAntigravityHistory(roots.antigravityBrainDir, [
+      {
+        display: `${commonPrefix}workspace B`,
+        timestamp: Date.parse('2026-07-15T11:39:10.100Z'),
+        workspace: '/repo/wrong'
+      }
+    ])
+
+    const result = await scanAiVaultSessions({ ...roots, platform: 'linux' })
+
+    expect(result.sessions[0]?.title).toHaveLength(96)
+    expect(result.sessions[0]?.title).toMatch(/\.\.\.$/)
+    expect(result.sessions[0]?.cwd).toBeNull()
+  })
+})

--- a/src/main/ai-vault/session-scanner-antigravity-source.test.ts
+++ b/src/main/ai-vault/session-scanner-antigravity-source.test.ts
@@ -40,7 +40,7 @@ describe('Antigravity AI Vault discovery', () => {
     await writeAntigravityHistory(join(wslHome, '.gemini', 'antigravity-cli', 'brain'), [
       {
         display: 'Index the WSL conversation',
-        timestamp: Date.parse('2026-07-15T11:39:10.100Z'),
+        timestamp: Date.parse('2026-07-15T11:39:10.100Z') / 1000,
         workspace: '/home/ada/project'
       }
     ])

--- a/src/main/ai-vault/session-scanner-antigravity-sources.ts
+++ b/src/main/ai-vault/session-scanner-antigravity-sources.ts
@@ -1,0 +1,34 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
+import {
+  isAntigravityTranscriptPath,
+  shouldDescendAntigravityBrainDirectory
+} from './session-scanner-antigravity-paths'
+import { discoverFiles } from './session-scanner-discovery'
+import type { AiVaultScanOptions, SessionFileDiscovery } from './session-scanner-types'
+
+const ANTIGRAVITY_BRAIN_DIR = join(homedir(), '.gemini', 'antigravity-cli', 'brain')
+
+export function antigravityDiscoveries(
+  options: AiVaultScanOptions,
+  wslHomeDirs: readonly string[],
+  limit: number,
+  issues: AiVaultScanIssue[]
+): Promise<SessionFileDiscovery>[] {
+  const rootDirs = [
+    options.antigravityBrainDir ?? ANTIGRAVITY_BRAIN_DIR,
+    ...wslHomeDirs.map((homeDir) => join(homeDir, '.gemini', 'antigravity-cli', 'brain'))
+  ]
+  return rootDirs.map((rootDir) =>
+    discoverFiles({
+      rootDir,
+      limit,
+      agent: 'antigravity',
+      issues,
+      extensions: ['.jsonl'],
+      filePredicate: isAntigravityTranscriptPath,
+      directoryPredicate: shouldDescendAntigravityBrainDirectory
+    })
+  )
+}

--- a/src/main/ai-vault/session-scanner-codex-workers.test.ts
+++ b/src/main/ai-vault/session-scanner-codex-workers.test.ts
@@ -106,6 +106,7 @@ describe('scanAiVaultSessions Codex worker sessions', () => {
       claudeProjectsDir: join(root, 'claude-projects'),
       codexSessionsDir,
       geminiSessionsDir: join(root, 'gemini-sessions'),
+      antigravityBrainDir: join(root, 'antigravity-brain'),
       copilotSessionsDir: join(root, 'copilot-sessions'),
       cursorProjectsDir: join(root, 'cursor-projects'),
       opencodeStorageDir: join(root, 'opencode-storage'),

--- a/src/main/ai-vault/session-scanner-discovery.ts
+++ b/src/main/ai-vault/session-scanner-discovery.ts
@@ -11,7 +11,7 @@ export async function discoverFiles(args: {
   issues: AiVaultScanIssue[]
   extensions: string[]
   filePredicate?: (path: string) => boolean
-  directoryPredicate?: (name: string) => boolean
+  directoryPredicate?: (name: string, depth: number) => boolean
 }): Promise<SessionFileDiscovery> {
   const paths = await walkSessionFiles(args.rootDir, args.agent, args.issues, {
     extensions: new Set(args.extensions),
@@ -70,10 +70,11 @@ export async function walkSessionFiles(
   options: {
     extensions: Set<string>
     filePredicate?: (path: string) => boolean
-    // Return false to skip descending into a directory (matched by its name),
-    // so pruned subtrees are never stat'd or parsed.
-    directoryPredicate?: (name: string) => boolean
-  }
+    // Return false to skip descending into a directory; depth 0 is a child of
+    // rootDir, so pruned subtrees are never stat'd or parsed.
+    directoryPredicate?: (name: string, depth: number) => boolean
+  },
+  depth = 0
 ): Promise<string[]> {
   let entries
   try {
@@ -88,8 +89,8 @@ export async function walkSessionFiles(
     if (entry.isDirectory()) {
       // Skip whole subtrees an agent never wants (e.g. subagent transcripts),
       // avoiding the readdir cost of descending into them.
-      if (options.directoryPredicate?.(entry.name) ?? true) {
-        files.push(...(await walkSessionFiles(fullPath, agent, issues, options)))
+      if (options.directoryPredicate?.(entry.name, depth) ?? true) {
+        files.push(...(await walkSessionFiles(fullPath, agent, issues, options, depth + 1)))
       }
       continue
     }

--- a/src/main/ai-vault/session-scanner-incremental-fixtures.ts
+++ b/src/main/ai-vault/session-scanner-incremental-fixtures.ts
@@ -1,5 +1,6 @@
 import type { AiVaultAgent } from '../../shared/ai-vault-types'
 
+import { antigravityFixture } from './session-scanner-antigravity-fixtures'
 import { codexFixture } from './session-scanner-codex-fixtures'
 
 // Line builders for the incremental-parse differential tests: each agent gets
@@ -286,6 +287,7 @@ export function allIncrementalAgentFixtures(): IncrementalAgentFixture[] {
     openclawFixture(),
     piFixture(),
     ompFixture(),
-    geminiJsonlFixture()
+    geminiJsonlFixture(),
+    antigravityFixture()
   ]
 }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
@@ -23,6 +23,7 @@ function isolatedScanRoots(root: string) {
     claudeProjectsDir: join(root, 'claude-projects'),
     codexSessionsDir: join(root, 'codex-sessions'),
     geminiSessionsDir: join(root, 'gemini-sessions'),
+    antigravityBrainDir: join(root, 'antigravity-brain'),
     copilotSessionsDir: join(root, 'copilot-sessions'),
     cursorProjectsDir: join(root, 'cursor-projects'),
     opencodeStorageDir: join(root, 'opencode-storage'),

--- a/src/main/ai-vault/session-scanner-parse-cache-agents.test.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache-agents.test.ts
@@ -1,6 +1,6 @@
 import { appendFile, mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { parseAgentSessionFile } from './session-scanner-agent-parser'
 import {
@@ -55,6 +55,7 @@ describe.each(allIncrementalAgentFixtures())('incremental parse parity: $agent',
   it('reuses unchanged files, resumes appends, and matches cold parses exactly', async () => {
     const root = await makeTempDir()
     const path = join(root, fixture.fileName)
+    await mkdir(dirname(path), { recursive: true })
     await writeFile(path, `${fixture.seedLines.join('\n')}\n`)
 
     const stats = createSessionParseStats()
@@ -87,6 +88,7 @@ describe.each(allIncrementalAgentFixtures())('incremental parse parity: $agent',
   it('includes a trailing unterminated line without double-counting it later', async () => {
     const root = await makeTempDir()
     const path = join(root, fixture.fileName)
+    await mkdir(dirname(path), { recursive: true })
     const lastSeedLine = fixture.seedLines.at(-1)
     const headLines = fixture.seedLines.slice(0, -1)
     await writeFile(path, `${[...headLines, ''].join('\n')}${lastSeedLine}`)
@@ -106,6 +108,7 @@ describe.each(allIncrementalAgentFixtures())('incremental parse parity: $agent',
   it('tolerates a mid-write truncated trailing line and never double-counts it', async () => {
     const root = await makeTempDir()
     const path = join(root, fixture.fileName)
+    await mkdir(dirname(path), { recursive: true })
     // A writer caught mid-record: the trailing line is invalid JSON.
     await writeFile(path, `${fixture.seedLines.join('\n')}\n{"type":"user","mess`)
 

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -1,6 +1,7 @@
 import { createReadStream } from 'node:fs'
 import { open } from 'node:fs/promises'
 import type { AiVaultSession } from '../../shared/ai-vault-types'
+import { createAntigravitySessionResumeState } from './session-scanner-antigravity-parser'
 import { parseAgentSessionFile } from './session-scanner-agent-parser'
 import { createCodexSessionResumeState } from './session-scanner-codex-parser'
 import { createDroidSessionResumeState } from './session-scanner-droid-parser'
@@ -67,6 +68,8 @@ function resumableStateFactoryFor(
       return candidate.file.path.endsWith('.jsonl')
         ? () => createGeminiJsonlSessionResumeState(candidate.file)
         : null
+    case 'antigravity':
+      return () => createAntigravitySessionResumeState(candidate.file)
     case 'devin':
     case 'grok':
     case 'hermes':

--- a/src/main/ai-vault/session-scanner-scope.test.ts
+++ b/src/main/ai-vault/session-scanner-scope.test.ts
@@ -19,6 +19,7 @@ function scopedScanOptions(claudeProjectsDir: string, extra: Partial<AiVaultScan
     claudeProjectsDir,
     codexSessionsDir: '/nonexistent/codex',
     geminiSessionsDir: '/nonexistent/gemini',
+    antigravityBrainDir: '/nonexistent/antigravity',
     copilotSessionsDir: '/nonexistent/copilot',
     cursorProjectsDir: '/nonexistent/cursor',
     opencodeStorageDir: '/nonexistent/opencode',

--- a/src/main/ai-vault/session-scanner-source-discovery.ts
+++ b/src/main/ai-vault/session-scanner-source-discovery.ts
@@ -9,6 +9,7 @@ import { opencodeDiscoveries } from './session-scanner-opencode-sources'
 import type { AiVaultScanOptions, SessionFileDiscovery } from './session-scanner-types'
 import { normalizeAgentSessionsDir } from './session-scanner-values'
 import { resolveGrokSessionsDir } from '../../shared/grok-session-paths'
+import { antigravityDiscoveries } from './session-scanner-antigravity-sources'
 
 const CLAUDE_PROJECTS_DIR = join(homedir(), '.claude', 'projects')
 export const DEFAULT_CODEX_HOME_DIR = join(homedir(), '.codex')
@@ -124,6 +125,7 @@ function standardDiscoveries(
   issues: AiVaultScanIssue[]
 ): Promise<SessionFileDiscovery>[] {
   return [
+    ...antigravityDiscoveries(options, wslHomeDirs, limit, issues),
     ...sessionRootDirs(options.geminiSessionsDir ?? GEMINI_SESSIONS_DIR, wslHomeDirs, [
       '.gemini',
       'tmp'

--- a/src/main/ai-vault/session-scanner-test-fixtures.ts
+++ b/src/main/ai-vault/session-scanner-test-fixtures.ts
@@ -6,6 +6,7 @@ export function isolatedScanRoots(root: string) {
     claudeProjectsDir: join(root, 'claude-projects'),
     codexSessionsDir: join(root, 'codex-sessions'),
     geminiSessionsDir: join(root, 'gemini-sessions'),
+    antigravityBrainDir: join(root, 'antigravity-brain'),
     copilotSessionsDir: join(root, 'copilot-sessions'),
     cursorProjectsDir: join(root, 'cursor-projects'),
     opencodeStorageDir: join(root, 'opencode-storage'),
@@ -33,4 +34,38 @@ export function jsonLines(records: unknown[]): string {
 export async function writeJsonlFile(filePath: string, records: unknown[]): Promise<void> {
   await mkdir(dirname(filePath), { recursive: true })
   await writeFile(filePath, jsonLines(records))
+}
+
+export async function writeAntigravityTranscript(
+  brainDir: string,
+  sessionId: string,
+  records: unknown[]
+): Promise<string> {
+  const transcriptPath = join(brainDir, sessionId, '.system_generated', 'logs', 'transcript.jsonl')
+  await writeJsonlFile(transcriptPath, records)
+  return transcriptPath
+}
+
+export function writeAntigravityHistory(brainDir: string, records: unknown[]): Promise<void> {
+  return writeJsonlFile(join(dirname(brainDir), 'history.jsonl'), records)
+}
+
+export function writeAntigravityScannerFixture(
+  brainDir: string,
+  sessionId: string
+): Promise<string> {
+  return writeAntigravityTranscript(brainDir, sessionId, [
+    {
+      source: 'USER_EXPLICIT',
+      type: 'USER_INPUT',
+      created_at: '2026-05-01T10:02:30.000Z',
+      content: '<USER_REQUEST>Antigravity title</USER_REQUEST>'
+    },
+    {
+      source: 'MODEL',
+      type: 'PLANNER_RESPONSE',
+      created_at: '2026-05-01T10:02:31.000Z',
+      content: 'Done'
+    }
+  ])
 }

--- a/src/main/ai-vault/session-scanner-types.ts
+++ b/src/main/ai-vault/session-scanner-types.ts
@@ -12,6 +12,7 @@ export type AiVaultScanOptions = {
   additionalCodexSessionsDirs?: readonly string[]
   wslHomeDirs?: readonly string[]
   geminiSessionsDir?: string
+  antigravityBrainDir?: string
   copilotSessionsDir?: string
   cursorProjectsDir?: string
   opencodeStorageDir?: string
@@ -52,6 +53,7 @@ export type SessionFileCandidate = {
   agent: AiVaultAgent
   file: FileWithMtime
   codexHome: string | null
+  antigravityHistoryPath?: string
 }
 
 export type SessionFileDiscovery = {

--- a/src/main/ai-vault/session-scanner.test.ts
+++ b/src/main/ai-vault/session-scanner.test.ts
@@ -4,7 +4,11 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { AI_VAULT_AGENTS } from '../../shared/ai-vault-types'
 import { scanAiVaultSessions } from './session-scanner'
-import { isolatedScanRoots, jsonLines } from './session-scanner-test-fixtures'
+import {
+  isolatedScanRoots,
+  jsonLines,
+  writeAntigravityScannerFixture
+} from './session-scanner-test-fixtures'
 
 let tempRoots: string[] = []
 
@@ -423,6 +427,9 @@ describe('scanAiVaultSessions', () => {
       })
     )
 
+    const antigravitySessionId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+    await writeAntigravityScannerFixture(roots.antigravityBrainDir, antigravitySessionId)
+
     await mkdir(roots.copilotSessionsDir, { recursive: true })
     await writeFile(
       join(roots.copilotSessionsDir, 'copilot-session.jsonl'),
@@ -718,11 +725,7 @@ describe('scanAiVaultSessions', () => {
       ])
     )
 
-    const result = await scanAiVaultSessions({
-      ...roots,
-      platform: 'darwin',
-      limit: 20
-    })
+    const result = await scanAiVaultSessions({ ...roots, platform: 'darwin', limit: 20 })
 
     expect(result.issues).toEqual([])
     expect(new Set(result.sessions.map((session) => session.agent))).toEqual(
@@ -739,6 +742,7 @@ describe('scanAiVaultSessions', () => {
       `cd '/tmp/codex' && CODEX_HOME='${root}' codex resume 'codex-session'`
     )
     expect(commandByAgent.get('gemini')).toBe("gemini --resume 'gemini-session'")
+    expect(commandByAgent.get('antigravity')).toBe(`agy --conversation '${antigravitySessionId}'`)
     expect(commandByAgent.get('copilot')).toBe(
       "cd '/tmp/copilot' && copilot --resume='copilot-session'"
     )

--- a/src/main/ai-vault/session-scanner.ts
+++ b/src/main/ai-vault/session-scanner.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises'
 import type {
   AiVaultListResult,
   AiVaultScanIssue,
@@ -6,6 +7,11 @@ import type {
 import { LOCAL_EXECUTION_HOST_ID, type ExecutionHostId } from '../../shared/execution-host'
 import { withSpan } from '../observability/tracer'
 import { sessionSortTime } from './session-scanner-accumulator'
+import {
+  createAntigravityWorkspaceResolver,
+  type AntigravityWorkspaceResolver
+} from './session-scanner-antigravity-history'
+import { antigravityHistoryPathForBrainDir } from './session-scanner-antigravity-paths'
 import { codexHomeForSessionsDir } from './session-scanner-codex-paths'
 import {
   createSessionParseStats,
@@ -54,6 +60,7 @@ export async function scanAiVaultSessions(
     const executionHostId = options.executionHostId ?? LOCAL_EXECUTION_HOST_ID
     const issues: AiVaultScanIssue[] = []
     const parseStats = createSessionParseStats()
+    const antigravityWorkspaceResolver = createAntigravityWorkspaceResolver(readOptionalTextFile)
     const discoveries = await discoverAiVaultSessionSources({ options, limitPerAgent, issues })
 
     const candidates = discoveries
@@ -65,7 +72,11 @@ export async function scanAiVaultSessions(
             codexHome:
               discovery.agent === 'codex'
                 ? codexHomeForSessionsDir(discovery.rootDir, DEFAULT_CODEX_HOME_DIR)
-                : null
+                : null,
+            antigravityHistoryPath:
+              discovery.agent === 'antigravity'
+                ? antigravityHistoryPathForBrainDir(discovery.rootDir)
+                : undefined
           })
         )
       )
@@ -77,7 +88,8 @@ export async function scanAiVaultSessions(
       platform,
       executionHostId,
       issues,
-      parseStats
+      parseStats,
+      antigravityWorkspaceResolver
     })
 
     const cappedSessions = parsedSessions
@@ -175,6 +187,7 @@ async function parseSessionCandidates(args: {
   executionHostId: ExecutionHostId
   issues: AiVaultScanIssue[]
   parseStats: SessionParseStats
+  antigravityWorkspaceResolver?: AntigravityWorkspaceResolver
 }): Promise<AiVaultSession[]> {
   const sessions: AiVaultSession[] = []
   let index = 0
@@ -190,7 +203,13 @@ async function parseSessionCandidates(args: {
     const batch = args.candidates.slice(index, index + batchSize)
     const results = await Promise.all(
       batch.map((candidate) =>
-        parseSessionCandidate(candidate, args.platform, args.executionHostId, args.parseStats)
+        parseSessionCandidate(
+          candidate,
+          args.platform,
+          args.executionHostId,
+          args.parseStats,
+          args.antigravityWorkspaceResolver
+        )
       )
     )
 
@@ -213,10 +232,14 @@ async function parseSessionCandidate(
   candidate: SessionFileCandidate,
   platform: NodeJS.Platform,
   executionHostId: ExecutionHostId,
-  parseStats: SessionParseStats
+  parseStats: SessionParseStats,
+  antigravityWorkspaceResolver?: AntigravityWorkspaceResolver
 ): Promise<SessionParseResult> {
   try {
-    const session = await parseAgentSessionFileCached(candidate, platform, parseStats)
+    let session = await parseAgentSessionFileCached(candidate, platform, parseStats)
+    if (session && candidate.antigravityHistoryPath && antigravityWorkspaceResolver) {
+      session = await antigravityWorkspaceResolver.enrich(session, candidate.antigravityHistoryPath)
+    }
     return {
       session: session ? withSessionExecutionHost(session, executionHostId) : null,
       issue: null
@@ -231,6 +254,14 @@ async function parseSessionCandidate(
         message: errorMessage(err)
       }
     }
+  }
+}
+
+async function readOptionalTextFile(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, 'utf-8')
+  } catch {
+    return null
   }
 }
 

--- a/src/shared/ai-vault-resume-command.test.ts
+++ b/src/shared/ai-vault-resume-command.test.ts
@@ -3,6 +3,17 @@ import { describe, expect, it } from 'vitest'
 import { buildAiVaultResumeCommand } from './ai-vault-types'
 
 describe('buildAiVaultResumeCommand', () => {
+  it('uses Antigravity conversation ids instead of Gemini resume flags', () => {
+    expect(
+      buildAiVaultResumeCommand({
+        agent: 'antigravity',
+        sessionId: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+        cwd: '/repo/app',
+        platform: 'darwin'
+      })
+    ).toBe("cd '/repo/app' && agy --conversation 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'")
+  })
+
   it('builds a self-contained cmd wrapper when no live shell is known', () => {
     expect(
       buildAiVaultResumeCommand({

--- a/src/shared/ai-vault-types.ts
+++ b/src/shared/ai-vault-types.ts
@@ -15,6 +15,7 @@ export const AI_VAULT_AGENTS = [
   'omp',
   'cursor',
   'gemini',
+  'antigravity',
   'rovo',
   'copilot',
   'opencode',
@@ -43,6 +44,7 @@ export const AI_VAULT_AGENT_LABELS = {
   omp: 'OMP',
   cursor: 'Cursor',
   gemini: 'Gemini',
+  antigravity: 'Antigravity',
   rovo: 'Rovo Dev',
   copilot: 'GitHub Copilot',
   opencode: 'OpenCode',
@@ -323,6 +325,8 @@ function buildAgentResumeInvocation(
     // but the `--resume <arg>` invocation form is identical to the others here.
     case 'omp':
       return `${baseCommand} --resume ${sessionArg}`
+    case 'antigravity':
+      return `${baseCommand} --conversation ${sessionArg}`
   }
 }
 


### PR DESCRIPTION
## Summary

Antigravity saves resumable chats in a different folder and format from Gemini. AI Vault was looking in Gemini's store, so real Antigravity conversations were invisible. This adds a dedicated adapter that reads Antigravity's canonical transcript and resumes it with Antigravity's own command.

- add first-class Antigravity CLI session discovery and parsing
- support local, WSL, SSH, Windows-remote, and runtime-host scanning
- build verified `agy --conversation <id>` resume commands
- recover workspace only from a unique, safe Antigravity history match
- avoid serialized per-conversation SSH directory traversal

Fixes #8742.

## Screenshots

Disposable real Antigravity 1.1.2 conversation containing `ORCA_8742_REPRO_20260715T113313Z`:

![Real marked Antigravity conversation](https://github.com/user-attachments/assets/f835f63f-e9d7-415e-ba00-e64e1f20f700)

The packaged AI Vault UI and scanner did not contain that conversation:

![Packaged AI Vault omission](https://github.com/user-attachments/assets/816f3604-4496-43fb-a25b-63845d65f837)

With this change, the scanner finds the exact conversation UUID, parses its user and assistant turns, emits the verified resume command, and returns it through the production default Workspace filter. The real store scan found 89 Antigravity sessions with zero scan issues.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — not run in full; 29 AI Vault test files / 171 tests passed
- [ ] `pnpm build` — not needed for this scanner-only change
- [x] Added high-quality parser, discovery, incremental-cache, ambiguity, long-prefix collision, WSL, Linux SSH, Windows SSH, remote scaling, and remote error tests

## AI Review Report

Three independent review loops challenged the design rather than only checking consistency. They found and drove fixes for:

- sessions being hidden by the default Workspace scope when CWD was unknown
- unsafe CWD attribution for long prompts sharing a truncated prefix
- hundreds of serialized SSH directory-listing requests
- over-broad suppression of remote stat failures

CodeRabbit then identified two valid follow-ups: non-missing remote directory-listing failures now surface as scan issues, and Antigravity history timestamps now use the scanner's canonical seconds/milliseconds/ISO parser. Its generic docstring-coverage suggestion was not adopted because this repository asks comments to document only non-obvious reasons.

Cross-platform review explicitly covered macOS, Linux, Windows, WSL, SSH paths, remote host path joining, shell quoting, runtime schemas, and Antigravity resume commands. This PR does not change keyboard shortcuts, shortcut labels, or Electron UI behavior.

## Security Audit

- JSONL input is parsed defensively; malformed and incomplete records are ignored
- only the canonical `brain/<id>/.system_generated/logs/transcript.jsonl` path is indexed; artifact trees and duplicate full transcripts are excluded
- workspace enrichment requires one unique short prompt/time match and refuses ambiguous or truncated identities, preventing cross-project attribution
- resume arguments continue through the existing platform-aware quoting path; no shell strings are built from history metadata
- remote traversal ignores symlinks, bounds stat concurrency, suppresses only expected `ENOENT`/`ENOTDIR`, and reports permission, connection, and provider failures
- no auth, secret, dependency, or IPC contract changes

No follow-up security work is required.

## Notes

AI Vault previously scanned `~/.gemini/tmp` and routed those files through the Gemini parser. Antigravity instead stores one canonical transcript at:

```text
~/.gemini/antigravity-cli/brain/<conversation-id>/.system_generated/logs/transcript.jsonl
```

Pointing the Gemini parser at that store produced malformed duplicate zero-turn rows with incorrect IDs and resume commands.

Antigravity's canonical transcript does not include stable workspace or model fields. `history.jsonl` has workspace data but no conversation ID, so enrichment is deliberately conservative. Sessions with missing, ambiguous, old, or ellipsized prompt history remain visible under **All sessions** with an unknown location rather than appearing in the wrong workspace.

Model remains blank because the observed model metadata exists only inside version-specific protobuf/SQLite blobs. Decoding that private format would be less stable than leaving unavailable metadata empty.
