### PR TITLE
fix(native-chat): Codex effective skill inventory를 autocomplete SSOT로 사용

### DIFF
--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -3,6 +3,8 @@ import type { Store } from '../persistence'
 import { discoverSkills } from '../skills/discovery'
 import type { SkillDiscoveryResult, SkillDiscoveryTarget } from '../../shared/skills'
 import { getDefaultWslDistro, getWslHome } from '../wsl'
+import { adaptCodexEffectiveSkills } from '../skills/codex-effective-skill-adapter'
+import { codexSkillInventory } from '../skills/codex-skill-inventory-service'
 
 type SkillDiscoveryRuntimeTarget =
   | { runtime: 'host' }
@@ -32,6 +34,27 @@ function getSkillDiscoveryRuntimeTarget(
 }
 
 export function registerSkillsHandlers(store: Store): void {
+  const subscribers = new Set<Electron.WebContents>()
+  codexSkillInventory.on('changed', () => {
+    for (const webContents of subscribers) {
+      if (webContents.isDestroyed()) {
+        subscribers.delete(webContents)
+      } else {
+        webContents.send('skills:codex-changed')
+      }
+    }
+  })
+  ipcMain.handle('skills:list-codex', async (event, cwd: string, forceReload = false) => {
+    const normalizedCwd = cwd.trim()
+    if (!normalizedCwd) {
+      throw new Error('Codex skill inventory requires a working directory.')
+    }
+    if (!subscribers.has(event.sender)) {
+      subscribers.add(event.sender)
+      event.sender.once('destroyed', () => subscribers.delete(event.sender))
+    }
+    return adaptCodexEffectiveSkills(await codexSkillInventory.list(normalizedCwd, forceReload))
+  })
   ipcMain.handle(
     'skills:discover',
     async (_event, target?: SkillDiscoveryTarget): Promise<SkillDiscoveryResult> => {

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -44,17 +44,22 @@ export function registerSkillsHandlers(store: Store): void {
       }
     }
   })
-  ipcMain.handle('skills:list-codex', async (event, cwd: string, forceReload = false) => {
-    const normalizedCwd = cwd.trim()
-    if (!normalizedCwd) {
-      throw new Error('Codex skill inventory requires a working directory.')
+  ipcMain.handle(
+    'skills:list-codex',
+    async (event, cwd: string, forceReload = false, codexHome?: string) => {
+      const normalizedCwd = cwd.trim()
+      if (!normalizedCwd) {
+        throw new Error('Codex skill inventory requires a working directory.')
+      }
+      if (!subscribers.has(event.sender)) {
+        subscribers.add(event.sender)
+        event.sender.once('destroyed', () => subscribers.delete(event.sender))
+      }
+      return adaptCodexEffectiveSkills(
+        await codexSkillInventory.list(normalizedCwd, forceReload, codexHome)
+      )
     }
-    if (!subscribers.has(event.sender)) {
-      subscribers.add(event.sender)
-      event.sender.once('destroyed', () => subscribers.delete(event.sender))
-    }
-    return adaptCodexEffectiveSkills(await codexSkillInventory.list(normalizedCwd, forceReload))
-  })
+  )
   ipcMain.handle(
     'skills:discover',
     async (_event, target?: SkillDiscoveryTarget): Promise<SkillDiscoveryResult> => {

--- a/src/main/runtime/rpc/methods/skills.test.ts
+++ b/src/main/runtime/rpc/methods/skills.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest'
+import { codexSkillInventory } from '../../../skills/codex-skill-inventory-service'
+import { SKILL_METHODS } from './skills'
+
+describe('skills.codexSubscribe', () => {
+  it('streams app-server watcher invalidation and removes the listener on cleanup', async () => {
+    const method = SKILL_METHODS.find((candidate) => candidate.name === 'skills.codexSubscribe')
+    if (!method || !('stream' in method)) {
+      throw new Error('skills.codexSubscribe must be streaming')
+    }
+    let cleanup = (): void => {}
+    const emit = vi.fn()
+    const running = method.handler(
+      undefined,
+      {
+        runtime: {
+          registerSubscriptionCleanup: (_id: string, nextCleanup: () => void) => {
+            cleanup = nextCleanup
+          }
+        } as never,
+        connectionId: 'connection-1'
+      },
+      emit
+    )
+    codexSkillInventory.emit('changed')
+    expect(emit).toHaveBeenCalledWith({ type: 'changed' })
+    cleanup()
+    await running
+    emit.mockClear()
+    codexSkillInventory.emit('changed')
+    expect(emit).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/runtime/rpc/methods/skills.ts
+++ b/src/main/runtime/rpc/methods/skills.ts
@@ -1,9 +1,16 @@
 import { z } from 'zod'
 import { defineMethod, type RpcMethod } from '../core'
 import { discoverSkills } from '../../../skills/discovery'
+import { codexSkillInventory } from '../../../skills/codex-skill-inventory-service'
+import { adaptCodexEffectiveSkills } from '../../../skills/codex-effective-skill-adapter'
 
 const SkillDiscoveryParams = z.object({
   cwd: z.string().optional().nullable()
+})
+
+const CodexSkillListParams = z.object({
+  cwd: z.string().min(1),
+  forceReload: z.boolean().optional()
 })
 
 export const SKILL_METHODS: RpcMethod[] = [
@@ -16,5 +23,13 @@ export const SKILL_METHODS: RpcMethod[] = [
         ? discoverSkills({ repos: [], cwd })
         : discoverSkills({ repos: runtime.listRepos() })
     }
+  }),
+  defineMethod({
+    name: 'skills.codexList',
+    params: CodexSkillListParams,
+    handler: async (params) =>
+      adaptCodexEffectiveSkills(
+        await codexSkillInventory.list(params.cwd, params.forceReload ?? false)
+      )
   })
 ]

--- a/src/main/runtime/rpc/methods/skills.ts
+++ b/src/main/runtime/rpc/methods/skills.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { defineMethod, type RpcMethod } from '../core'
+import { defineMethod, defineStreamingMethod, type RpcAnyMethod } from '../core'
 import { discoverSkills } from '../../../skills/discovery'
 import { codexSkillInventory } from '../../../skills/codex-skill-inventory-service'
 import { adaptCodexEffectiveSkills } from '../../../skills/codex-effective-skill-adapter'
@@ -10,10 +10,13 @@ const SkillDiscoveryParams = z.object({
 
 const CodexSkillListParams = z.object({
   cwd: z.string().min(1),
-  forceReload: z.boolean().optional()
+  forceReload: z.boolean().optional(),
+  codexHome: z.string().optional()
 })
 
-export const SKILL_METHODS: RpcMethod[] = [
+let skillSubscriptionSequence = 0
+
+export const SKILL_METHODS: RpcAnyMethod[] = [
   defineMethod({
     name: 'skills.discover',
     params: SkillDiscoveryParams,
@@ -29,7 +32,28 @@ export const SKILL_METHODS: RpcMethod[] = [
     params: CodexSkillListParams,
     handler: async (params) =>
       adaptCodexEffectiveSkills(
-        await codexSkillInventory.list(params.cwd, params.forceReload ?? false)
+        await codexSkillInventory.list(params.cwd, params.forceReload ?? false, params.codexHome)
       )
+  }),
+  defineStreamingMethod({
+    name: 'skills.codexSubscribe',
+    params: null,
+    handler: async (_params, { runtime, connectionId }, emit) => {
+      await new Promise<void>((resolve) => {
+        const onChanged = (): void => emit({ type: 'changed' })
+        codexSkillInventory.on('changed', onChanged)
+        const id = `skills-${connectionId ?? 'inproc'}-${++skillSubscriptionSequence}`
+        runtime.registerSubscriptionCleanup(
+          id,
+          () => {
+            codexSkillInventory.off('changed', onChanged)
+            emit({ type: 'end' })
+            resolve()
+          },
+          connectionId
+        )
+        emit({ type: 'ready' })
+      })
+    }
   })
 ]

--- a/src/main/skills/codex-effective-skill-adapter.test.ts
+++ b/src/main/skills/codex-effective-skill-adapter.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { adaptCodexEffectiveSkills } from './codex-effective-skill-adapter'
+import type { CodexEffectiveSkill } from '../../shared/skills'
+
+function skill(overrides: Partial<CodexEffectiveSkill> = {}): CodexEffectiveSkill {
+  return {
+    name: 'plugin:search',
+    description: 'Search',
+    path: '/home/.codex/plugins/cache/plugin/2.0.0/skills/search/SKILL.md',
+    scope: 'user',
+    enabled: true,
+    ...overrides
+  }
+}
+
+describe('adaptCodexEffectiveSkills', () => {
+  it('excludes disabled and uninstalled cache entries because only effective entries are adapted', () => {
+    const result = adaptCodexEffectiveSkills([
+      skill({ enabled: false }),
+      skill({ name: 'plugin:active' })
+    ])
+    expect(result.map((entry) => entry.name)).toEqual(['plugin:active'])
+  })
+
+  it('preserves the app-server namespace and active version path', () => {
+    const result = adaptCodexEffectiveSkills([
+      skill(),
+      skill({
+        name: 'other:search',
+        path: '/home/.codex/plugins/cache/other/1.0.0/skills/search/SKILL.md'
+      })
+    ])
+    expect(result.map(({ name, skillFilePath }) => [name, skillFilePath])).toEqual([
+      ['plugin:search', '/home/.codex/plugins/cache/plugin/2.0.0/skills/search/SKILL.md'],
+      ['other:search', '/home/.codex/plugins/cache/other/1.0.0/skills/search/SKILL.md']
+    ])
+    expect(new Set(result.map((entry) => entry.id)).size).toBe(2)
+  })
+
+  it('keeps shared user and repo roots classified without scanning either root', () => {
+    const result = adaptCodexEffectiveSkills([
+      skill({ name: 'shared', path: '/home/.agents/skills/shared/SKILL.md' }),
+      skill({ name: 'repo', path: '/repo/.agents/skills/repo/SKILL.md', scope: 'repo' })
+    ])
+    expect(result.map(({ name, sourceKind }) => [name, sourceKind])).toEqual([
+      ['shared', 'home'],
+      ['repo', 'repo']
+    ])
+  })
+})

--- a/src/main/skills/codex-effective-skill-adapter.ts
+++ b/src/main/skills/codex-effective-skill-adapter.ts
@@ -1,0 +1,38 @@
+import { dirname } from 'node:path'
+import type { CodexEffectiveSkill, DiscoveredSkill, SkillSourceKind } from '../../shared/skills'
+import { stablePathId } from './skill-discovery-sources'
+
+function sourceKindForScope(scope: CodexEffectiveSkill['scope']): SkillSourceKind {
+  if (scope === 'repo') {
+    return 'repo'
+  }
+  if (scope === 'system' || scope === 'admin') {
+    return 'bundled'
+  }
+  return 'home'
+}
+
+export function adaptCodexEffectiveSkills(
+  skills: readonly CodexEffectiveSkill[]
+): DiscoveredSkill[] {
+  return skills
+    .filter((skill) => skill.enabled)
+    .map((skill) => {
+      const directoryPath = dirname(skill.path)
+      const sourceKind = sourceKindForScope(skill.scope)
+      return {
+        id: stablePathId(`${skill.name}\0${skill.path}`),
+        name: skill.name,
+        description: skill.description || null,
+        providers: ['codex'],
+        sourceKind,
+        sourceLabel: skill.scope === 'repo' ? 'Repo' : 'Codex',
+        rootPath: directoryPath,
+        directoryPath,
+        skillFilePath: skill.path,
+        installed: true,
+        fileCount: 1,
+        updatedAt: null
+      } satisfies DiscoveredSkill
+    })
+}

--- a/src/main/skills/codex-skill-inventory-service.test.ts
+++ b/src/main/skills/codex-skill-inventory-service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { spawn } from 'node:child_process'
 
 const { child, stdinWrite } = vi.hoisted(() => {
   function emitter() {
@@ -39,10 +40,11 @@ import { CodexSkillInventoryService } from './codex-skill-inventory-service'
 describe('CodexSkillInventoryService', () => {
   beforeEach(() => {
     stdinWrite.mockReset()
+    vi.mocked(spawn).mockClear()
   })
 
   it('uses skills/list for the requested cwd and forwards watcher invalidation', async () => {
-    const service = new CodexSkillInventoryService()
+    const service = new CodexSkillInventoryService('/profiles/active-codex-home')
     const changed = vi.fn()
     service.on('changed', changed)
     stdinWrite.mockImplementation((line: string) => {
@@ -89,6 +91,9 @@ describe('CodexSkillInventoryService', () => {
     await expect(service.list('/repo')).resolves.toEqual([
       expect.objectContaining({ name: 'plugin:active' })
     ])
+    expect(vi.mocked(spawn).mock.calls[0]?.[2]?.env).toMatchObject({
+      CODEX_HOME: '/profiles/active-codex-home'
+    })
     expect(
       stdinWrite.mock.calls
         .map(([line]) => JSON.parse(line as string))

--- a/src/main/skills/codex-skill-inventory-service.test.ts
+++ b/src/main/skills/codex-skill-inventory-service.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { child, stdinWrite } = vi.hoisted(() => {
+  function emitter() {
+    const listeners = new Map<string, ((...args: unknown[]) => void)[]>()
+    return {
+      on(event: string, listener: (...args: unknown[]) => void) {
+        listeners.set(event, [...(listeners.get(event) ?? []), listener])
+        return this
+      },
+      emit(event: string, ...args: unknown[]) {
+        for (const listener of listeners.get(event) ?? []) {
+          listener(...args)
+        }
+      }
+    }
+  }
+  const stdout = emitter()
+  const process = Object.assign(emitter(), {
+    stdout,
+    stderr: emitter(),
+    stdin: { write: vi.fn() },
+    kill: vi.fn()
+  })
+  return { child: process, stdinWrite: process.stdin.write }
+})
+
+vi.mock('node:child_process', () => ({ spawn: vi.fn(() => child) }))
+vi.mock('../codex-cli/command', () => ({ resolveCodexCommand: () => 'codex' }))
+vi.mock('../win32-utils', () => ({
+  getSpawnArgsForWindows: (command: string, args: string[]) => ({
+    spawnCmd: command,
+    spawnArgs: args
+  })
+}))
+
+import { CodexSkillInventoryService } from './codex-skill-inventory-service'
+
+describe('CodexSkillInventoryService', () => {
+  beforeEach(() => {
+    stdinWrite.mockReset()
+  })
+
+  it('uses skills/list for the requested cwd and forwards watcher invalidation', async () => {
+    const service = new CodexSkillInventoryService()
+    const changed = vi.fn()
+    service.on('changed', changed)
+    stdinWrite.mockImplementation((line: string) => {
+      const message = JSON.parse(line) as { id?: number; method: string }
+      if (message.method === 'initialize') {
+        queueMicrotask(() =>
+          child.stdout.emit(
+            'data',
+            Buffer.from(`${JSON.stringify({ id: message.id, result: {} })}\n`)
+          )
+        )
+      } else if (message.method === 'skills/list') {
+        queueMicrotask(() =>
+          child.stdout.emit(
+            'data',
+            Buffer.from(
+              `${JSON.stringify({
+                id: message.id,
+                result: {
+                  data: [
+                    {
+                      cwd: '/repo',
+                      errors: [],
+                      skills: [
+                        {
+                          name: 'plugin:active',
+                          description: 'Active',
+                          path: '/cache/plugin/2/skills/active/SKILL.md',
+                          scope: 'user',
+                          enabled: true
+                        }
+                      ]
+                    }
+                  ]
+                }
+              })}\n`
+            )
+          )
+        )
+      }
+      return true
+    })
+
+    await expect(service.list('/repo')).resolves.toEqual([
+      expect.objectContaining({ name: 'plugin:active' })
+    ])
+    expect(
+      stdinWrite.mock.calls
+        .map(([line]) => JSON.parse(line as string))
+        .find((message) => message.method === 'skills/list')
+    ).toMatchObject({ params: { cwds: ['/repo'], forceReload: false } })
+
+    child.stdout.emit('data', Buffer.from('{"method":"skills/changed","params":{}}\n'))
+    expect(changed).toHaveBeenCalledOnce()
+    service.dispose()
+  })
+})

--- a/src/main/skills/codex-skill-inventory-service.ts
+++ b/src/main/skills/codex-skill-inventory-service.ts
@@ -16,10 +16,14 @@ type SkillsListResponse = {
 
 export class CodexSkillInventoryService extends EventEmitter {
   private child: ChildProcessWithoutNullStreams | null = null
-  private buffer = ''
+  private buffers = new WeakMap<ChildProcessWithoutNullStreams, string>()
   private nextId = 0
   private initialized: Promise<void> | null = null
   private pending = new Map<number, PendingRequest>()
+
+  constructor(private readonly codexHome?: string) {
+    super()
+  }
 
   async list(cwd: string, forceReload = false): Promise<CodexEffectiveSkill[]> {
     await this.ensureInitialized()
@@ -53,12 +57,17 @@ export class CodexSkillInventoryService extends EventEmitter {
       const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(codexCommand, ['app-server'])
       const child = spawn(spawnCmd, spawnArgs, {
         stdio: ['pipe', 'pipe', 'pipe'],
-        windowsHide: true
+        windowsHide: true,
+        env: { ...process.env, ...(this.codexHome ? { CODEX_HOME: this.codexHome } : {}) }
       })
       this.child = child
-      child.stdout.on('data', (chunk: Buffer) => this.onData(chunk))
-      child.on('error', (error) => this.onExit(error))
-      child.on('close', () => this.onExit(new Error('Codex app-server exited.')))
+      this.buffers.set(child, '')
+      // Why: app-server can emit diagnostics for the lifetime of the session;
+      // leaving stderr unread can fill the pipe and deadlock skills/list.
+      child.stderr.resume()
+      child.stdout.on('data', (chunk: Buffer) => this.onData(child, chunk))
+      child.on('error', (error) => this.onExit(child, error))
+      child.on('close', () => this.onExit(child, new Error('Codex app-server exited.')))
       this.request('initialize', { clientInfo: { name: 'orca', version: '1.0.0' } })
         .then(() => {
           child.stdin.write(
@@ -66,7 +75,14 @@ export class CodexSkillInventoryService extends EventEmitter {
           )
           resolve()
         })
-        .catch(reject)
+        .catch((error) => {
+          if (this.child === child) {
+            this.child = null
+            this.initialized = null
+          }
+          child.kill()
+          reject(error)
+        })
     })
     return this.initialized
   }
@@ -87,12 +103,12 @@ export class CodexSkillInventoryService extends EventEmitter {
     })
   }
 
-  private onData(chunk: Buffer): void {
-    this.buffer += chunk.toString()
+  private onData(child: ChildProcessWithoutNullStreams, chunk: Buffer): void {
+    let buffer = (this.buffers.get(child) ?? '') + chunk.toString()
     let newlineIndex: number
-    while ((newlineIndex = this.buffer.indexOf('\n')) >= 0) {
-      const line = this.buffer.slice(0, newlineIndex).trim()
-      this.buffer = this.buffer.slice(newlineIndex + 1)
+    while ((newlineIndex = buffer.indexOf('\n')) >= 0) {
+      const line = buffer.slice(0, newlineIndex).trim()
+      buffer = buffer.slice(newlineIndex + 1)
       if (!line) {
         continue
       }
@@ -121,9 +137,13 @@ export class CodexSkillInventoryService extends EventEmitter {
         pending.resolve(message.result)
       }
     }
+    this.buffers.set(child, buffer)
   }
 
-  private onExit(error: Error): void {
+  private onExit(child: ChildProcessWithoutNullStreams, error: Error): void {
+    if (this.child !== child) {
+      return
+    }
     this.rejectPending(error)
     this.child = null
     this.initialized = null
@@ -138,4 +158,19 @@ export class CodexSkillInventoryService extends EventEmitter {
   }
 }
 
-export const codexSkillInventory = new CodexSkillInventoryService()
+export class CodexSkillInventoryRegistry extends EventEmitter {
+  private services = new Map<string, CodexSkillInventoryService>()
+
+  list(cwd: string, forceReload = false, codexHome?: string): Promise<CodexEffectiveSkill[]> {
+    const key = codexHome?.trim() || '<default>'
+    let service = this.services.get(key)
+    if (!service) {
+      service = new CodexSkillInventoryService(codexHome?.trim() || undefined)
+      service.on('changed', () => this.emit('changed'))
+      this.services.set(key, service)
+    }
+    return service.list(cwd, forceReload)
+  }
+}
+
+export const codexSkillInventory = new CodexSkillInventoryRegistry()

--- a/src/main/skills/codex-skill-inventory-service.ts
+++ b/src/main/skills/codex-skill-inventory-service.ts
@@ -1,0 +1,141 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+import { resolveCodexCommand } from '../codex-cli/command'
+import { getSpawnArgsForWindows } from '../win32-utils'
+import type { CodexEffectiveSkill } from '../../shared/skills'
+
+type RpcResponse = { id?: number; result?: unknown; error?: { message?: string }; method?: string }
+type PendingRequest = {
+  resolve: (value: unknown) => void
+  reject: (error: Error) => void
+  timeout: ReturnType<typeof setTimeout>
+}
+type SkillsListResponse = {
+  data?: { cwd?: string; skills?: CodexEffectiveSkill[]; errors?: { message: string }[] }[]
+}
+
+export class CodexSkillInventoryService extends EventEmitter {
+  private child: ChildProcessWithoutNullStreams | null = null
+  private buffer = ''
+  private nextId = 0
+  private initialized: Promise<void> | null = null
+  private pending = new Map<number, PendingRequest>()
+
+  async list(cwd: string, forceReload = false): Promise<CodexEffectiveSkill[]> {
+    await this.ensureInitialized()
+    const result = (await this.request('skills/list', {
+      cwds: [cwd],
+      forceReload
+    })) as SkillsListResponse
+    const entry = result.data?.find((candidate) => candidate.cwd === cwd) ?? result.data?.[0]
+    if (!entry) {
+      throw new Error(`Codex returned no skill inventory for ${cwd}.`)
+    }
+    if (entry.errors?.length) {
+      throw new Error(entry.errors.map((error) => error.message).join('; '))
+    }
+    return entry.skills ?? []
+  }
+
+  dispose(): void {
+    this.rejectPending(new Error('Codex skill inventory service stopped.'))
+    this.child?.kill()
+    this.child = null
+    this.initialized = null
+  }
+
+  private ensureInitialized(): Promise<void> {
+    if (this.initialized) {
+      return this.initialized
+    }
+    this.initialized = new Promise<void>((resolve, reject) => {
+      const codexCommand = resolveCodexCommand()
+      const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(codexCommand, ['app-server'])
+      const child = spawn(spawnCmd, spawnArgs, {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true
+      })
+      this.child = child
+      child.stdout.on('data', (chunk: Buffer) => this.onData(chunk))
+      child.on('error', (error) => this.onExit(error))
+      child.on('close', () => this.onExit(new Error('Codex app-server exited.')))
+      this.request('initialize', { clientInfo: { name: 'orca', version: '1.0.0' } })
+        .then(() => {
+          child.stdin.write(
+            `${JSON.stringify({ jsonrpc: '2.0', method: 'initialized', params: {} })}\n`
+          )
+          resolve()
+        })
+        .catch(reject)
+    })
+    return this.initialized
+  }
+
+  private request(method: string, params?: unknown): Promise<unknown> {
+    const child = this.child
+    if (!child) {
+      return Promise.reject(new Error('Codex app-server is not running.'))
+    }
+    const id = ++this.nextId
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error(`Codex app-server request timed out: ${method}.`))
+      }, 15_000)
+      this.pending.set(id, { resolve, reject, timeout })
+      child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`)
+    })
+  }
+
+  private onData(chunk: Buffer): void {
+    this.buffer += chunk.toString()
+    let newlineIndex: number
+    while ((newlineIndex = this.buffer.indexOf('\n')) >= 0) {
+      const line = this.buffer.slice(0, newlineIndex).trim()
+      this.buffer = this.buffer.slice(newlineIndex + 1)
+      if (!line) {
+        continue
+      }
+      let message: RpcResponse
+      try {
+        message = JSON.parse(line) as RpcResponse
+      } catch {
+        continue
+      }
+      if (message.method === 'skills/changed') {
+        this.emit('changed')
+        continue
+      }
+      if (message.id == null) {
+        continue
+      }
+      const pending = this.pending.get(message.id)
+      if (!pending) {
+        continue
+      }
+      this.pending.delete(message.id)
+      clearTimeout(pending.timeout)
+      if (message.error) {
+        pending.reject(new Error(message.error.message ?? 'Codex RPC failed.'))
+      } else {
+        pending.resolve(message.result)
+      }
+    }
+  }
+
+  private onExit(error: Error): void {
+    this.rejectPending(error)
+    this.child = null
+    this.initialized = null
+  }
+
+  private rejectPending(error: Error): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timeout)
+      pending.reject(error)
+    }
+    this.pending.clear()
+  }
+}
+
+export const codexSkillInventory = new CodexSkillInventoryService()

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2247,7 +2247,11 @@ export type PreloadApi = {
   }
   skills: {
     discover: (target?: SkillDiscoveryTarget) => Promise<SkillDiscoveryResult>
-    listCodex: (cwd: string, forceReload?: boolean) => Promise<DiscoveredSkill[]>
+    listCodex: (
+      cwd: string,
+      forceReload?: boolean,
+      codexHome?: string
+    ) => Promise<DiscoveredSkill[]>
     onCodexChanged: (listener: () => void) => () => void
   }
   pet: {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -320,7 +320,7 @@ import type {
 import type { ResolvedSourceControlAiGenerationParams } from '../shared/source-control-ai'
 import type { SourceControlAiSettings } from '../shared/source-control-ai-types'
 import type { ShellOpenLocalPathResult } from '../shared/shell-open-types'
-import type { SkillDiscoveryResult, SkillDiscoveryTarget } from '../shared/skills'
+import type { DiscoveredSkill, SkillDiscoveryResult, SkillDiscoveryTarget } from '../shared/skills'
 import type {
   CrashReportBreadcrumbData,
   CrashReportCopyDiagnosticsArgs,
@@ -2247,6 +2247,8 @@ export type PreloadApi = {
   }
   skills: {
     discover: (target?: SkillDiscoveryTarget) => Promise<SkillDiscoveryResult>
+    listCodex: (cwd: string, forceReload?: boolean) => Promise<DiscoveredSkill[]>
+    onCodexChanged: (listener: () => void) => () => void
   }
   pet: {
     import: () => Promise<CustomPet | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -71,7 +71,7 @@ import type {
 } from '../shared/terminal-custom-themes'
 import type { GitHistoryOptions, GitHistoryResult } from '../shared/git-history'
 import type { ShellOpenLocalPathResult } from '../shared/shell-open-types'
-import type { SkillDiscoveryResult, SkillDiscoveryTarget } from '../shared/skills'
+import type { DiscoveredSkill, SkillDiscoveryResult, SkillDiscoveryTarget } from '../shared/skills'
 import type {
   RuntimeBrowserDriverState,
   RuntimeMobileSessionTabMove,
@@ -2215,7 +2215,13 @@ const api = {
 
   skills: {
     discover: (target?: SkillDiscoveryTarget): Promise<SkillDiscoveryResult> =>
-      ipcRenderer.invoke('skills:discover', target)
+      ipcRenderer.invoke('skills:discover', target),
+    listCodex: (cwd: string, forceReload = false): Promise<DiscoveredSkill[]> =>
+      ipcRenderer.invoke('skills:list-codex', cwd, forceReload),
+    onCodexChanged: (listener: () => void): (() => void) => {
+      ipcRenderer.on('skills:codex-changed', listener)
+      return () => ipcRenderer.removeListener('skills:codex-changed', listener)
+    }
   },
 
   pet: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2216,8 +2216,8 @@ const api = {
   skills: {
     discover: (target?: SkillDiscoveryTarget): Promise<SkillDiscoveryResult> =>
       ipcRenderer.invoke('skills:discover', target),
-    listCodex: (cwd: string, forceReload = false): Promise<DiscoveredSkill[]> =>
-      ipcRenderer.invoke('skills:list-codex', cwd, forceReload),
+    listCodex: (cwd: string, forceReload = false, codexHome?: string): Promise<DiscoveredSkill[]> =>
+      ipcRenderer.invoke('skills:list-codex', cwd, forceReload, codexHome),
     onCodexChanged: (listener: () => void): (() => void) => {
       ipcRenderer.on('skills:codex-changed', listener)
       return () => ipcRenderer.removeListener('skills:codex-changed', listener)

--- a/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
@@ -89,6 +89,7 @@ describe('NativeChatComposer', () => {
     const onStop = vi.fn()
     render(
       <NativeChatComposer
+        paneKey="tab-1:leaf-1"
         terminalTabId="tab-1"
         targetPtyId="pty-1"
         agent="codex"
@@ -110,6 +111,7 @@ describe('NativeChatComposer', () => {
     const onOptimisticSend = vi.fn(() => 'pending-1')
     render(
       <NativeChatComposer
+        paneKey="tab-1:leaf-1"
         terminalTabId="tab-1"
         targetPtyId="pty-1"
         agent="codex"

--- a/src/renderer/src/components/native-chat/NativeChatComposer.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.tsx
@@ -54,12 +54,10 @@ import { useNativeChatSendLifecycle } from './use-native-chat-send-lifecycle'
 const ESC = '\x1b'
 
 export type NativeChatComposerProps = {
-  /** Tab hosting the agent; used to resolve the live ptyId + runtime settings. */
   terminalTabId: string
-  /** Specific split-pane PTY this chat view owns. */
   targetPtyId: string | null
   agent: AgentType
-  runtimeEnvironmentId?: string | null
+  paneKey: string
   /**
    * Mobile presence-lock seam (R8): when a mobile client holds the pty, desktop
    * sends must be guarded rather than silently dropped. U9 wires the real lock
@@ -67,7 +65,6 @@ export type NativeChatComposerProps = {
    * already renders the guarded/disabled affordance when it is `false`.
    */
   canSend?: boolean
-  /** True while the hosted TUI reports an in-flight turn; swaps Send to Stop. */
   isWorking?: boolean
   /** Interrupt the hosted agent, usually by sending ESC into the PTY. */
   onStop?: () => void
@@ -112,7 +109,7 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
       terminalTabId,
       targetPtyId,
       agent,
-      runtimeEnvironmentId = null,
+      paneKey,
       canSend = true,
       isWorking = false,
       onStop,
@@ -131,7 +128,7 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
     const [activeSuggestion, setActiveSuggestion] = useState(0)
     const [notice, setNotice] = useState<string | null>(null)
     const [dictationPressed, setDictationPressed] = useState(false)
-    const skills = useNativeChatSkills(agent, terminalTabId, runtimeEnvironmentId)
+    const skills = useNativeChatSkills(agent, terminalTabId, paneKey)
     const textareaRef = useRef<HTMLTextAreaElement>(null)
     const { cancelPendingSends, trackPendingSend } = useNativeChatSendLifecycle(
       terminalTabId,

--- a/src/renderer/src/components/native-chat/NativeChatComposer.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.tsx
@@ -59,6 +59,7 @@ export type NativeChatComposerProps = {
   /** Specific split-pane PTY this chat view owns. */
   targetPtyId: string | null
   agent: AgentType
+  runtimeEnvironmentId?: string | null
   /**
    * Mobile presence-lock seam (R8): when a mobile client holds the pty, desktop
    * sends must be guarded rather than silently dropped. U9 wires the real lock
@@ -111,6 +112,7 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
       terminalTabId,
       targetPtyId,
       agent,
+      runtimeEnvironmentId = null,
       canSend = true,
       isWorking = false,
       onStop,
@@ -129,7 +131,7 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
     const [activeSuggestion, setActiveSuggestion] = useState(0)
     const [notice, setNotice] = useState<string | null>(null)
     const [dictationPressed, setDictationPressed] = useState(false)
-    const skills = useNativeChatSkills(agent, terminalTabId)
+    const skills = useNativeChatSkills(agent, terminalTabId, runtimeEnvironmentId)
     const textareaRef = useRef<HTMLTextAreaElement>(null)
     const { cancelPendingSends, trackPendingSend } = useNativeChatSendLifecycle(
       terminalTabId,

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -146,8 +146,6 @@ function NativeChatResolvedView({
   onSwitchToTerminal?: () => void
   contextMenuActions?: Omit<NativeChatContextMenuActions, 'onPaste'>
 }): React.JSX.Element {
-  // Primitive owner selection (no useShallow): routes the pane's read/subscribe to
-  // the remote runtime host for a runtime-owned pane; null keeps the local path.
   const runtimeEnvironmentId = useAppStore((s) =>
     selectNativeChatRuntimeEnvironmentId(s, terminalTabId)
   )
@@ -161,16 +159,10 @@ function NativeChatResolvedView({
   const launchPrompt = useAppStore((s) => s.nativeChatLaunchPromptByTabId[terminalTabId] ?? null)
   const clearNativeChatLaunchPrompt = useAppStore((s) => s.clearNativeChatLaunchPrompt)
   const paneLaunchPrompt = launchPrompt?.agent === agent ? launchPrompt : null
-  // Live hook state for this pane, selected directly so the working indicator
-  // flips the instant the agent reports 'working' — even when switching to chat
-  // mid-turn before the transcript merge has caught up.
   const hookWorking = useAppStore((s) => s.agentStatusByPaneKey[paneKey]?.state === 'working')
-  // The agent's in-progress reply preview (hook), shown as a live streaming
-  // bubble while it works — before the completed turn flushes to the transcript.
   const hookPreview = useAppStore((s) => s.agentStatusByPaneKey[paneKey]?.lastAssistantMessage)
   const canSend = useNativeChatCanSend(targetPtyId)
-  // Reuse the verified composer send path for interactive cards and composer
-  // stop (Stop sends ESC, the agent-TUI interrupt key).
+  // Reuse the verified composer send path for interactive cards and stop.
   const interactiveSend = useNativeChatInteractiveSend(terminalTabId, targetPtyId, agent)
   const [workingInterrupted, setWorkingInterrupted] = useState(false)
   // True while a question card owns the input region, so the composer is hidden.
@@ -454,7 +446,7 @@ function NativeChatResolvedView({
           terminalTabId={terminalTabId}
           targetPtyId={targetPtyId}
           agent={agent}
-          runtimeEnvironmentId={runtimeEnvironmentId}
+          paneKey={paneKey}
           canSend={canSend}
           isWorking={isWorking}
           onStop={stopAgent}

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -454,6 +454,7 @@ function NativeChatResolvedView({
           terminalTabId={terminalTabId}
           targetPtyId={targetPtyId}
           agent={agent}
+          runtimeEnvironmentId={runtimeEnvironmentId}
           canSend={canSend}
           isWorking={isWorking}
           onStop={stopAgent}

--- a/src/renderer/src/components/native-chat/native-chat-skill-request.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-skill-request.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createNativeChatSkillRequest } from './native-chat-skill-request'
+import type { DiscoveredSkill } from '../../../../shared/skills'
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function skill(name: string): DiscoveredSkill {
+  return {
+    id: name,
+    name,
+    description: null,
+    providers: ['codex'],
+    sourceKind: 'home',
+    sourceLabel: 'Codex',
+    rootPath: '/skills',
+    directoryPath: `/skills/${name}`,
+    skillFilePath: `/skills/${name}/SKILL.md`,
+    installed: true,
+    fileCount: 1,
+    updatedAt: null
+  }
+}
+
+describe('createNativeChatSkillRequest', () => {
+  it('applies only the newest response when invalidation races an older list', async () => {
+    const first = deferred<DiscoveredSkill[]>()
+    const second = deferred<DiscoveredSkill[]>()
+    const apply = vi.fn()
+    const list = vi.fn().mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+    const request = createNativeChatSkillRequest({ cwd: '/repo', list, apply })
+    request.refresh()
+    request.refresh(true)
+    second.resolve([skill('installed')])
+    await second.promise
+    first.resolve([skill('stale')])
+    await first.promise
+    expect(list).toHaveBeenNthCalledWith(2, '/repo', true)
+    expect(apply).toHaveBeenCalledTimes(1)
+    expect(apply).toHaveBeenCalledWith([expect.objectContaining({ name: 'installed' })])
+  })
+
+  it('drops a response after cwd or agent teardown cancels the request', async () => {
+    const pending = deferred<DiscoveredSkill[]>()
+    const apply = vi.fn()
+    const request = createNativeChatSkillRequest({
+      cwd: '/old-cwd',
+      list: () => pending.promise,
+      apply
+    })
+    request.refresh()
+    request.cancel()
+    pending.resolve([skill('wrong-cwd')])
+    await pending.promise
+    expect(apply).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-skill-request.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-skill-request.test.ts
@@ -36,12 +36,13 @@ describe('createNativeChatSkillRequest', () => {
     const request = createNativeChatSkillRequest({ cwd: '/repo', list, apply })
     request.refresh()
     request.refresh(true)
+    expect(apply).toHaveBeenLastCalledWith([])
     second.resolve([skill('installed')])
     await second.promise
     first.resolve([skill('stale')])
     await first.promise
     expect(list).toHaveBeenNthCalledWith(2, '/repo', true)
-    expect(apply).toHaveBeenCalledTimes(1)
+    expect(apply).toHaveBeenCalledTimes(3)
     expect(apply).toHaveBeenCalledWith([expect.objectContaining({ name: 'installed' })])
   })
 
@@ -54,9 +55,10 @@ describe('createNativeChatSkillRequest', () => {
       apply
     })
     request.refresh()
+    expect(apply).toHaveBeenCalledWith([])
     request.cancel()
     pending.resolve([skill('wrong-cwd')])
     await pending.promise
-    expect(apply).not.toHaveBeenCalled()
+    expect(apply).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-skill-request.ts
+++ b/src/renderer/src/components/native-chat/native-chat-skill-request.ts
@@ -15,6 +15,9 @@ export function createNativeChatSkillRequest(args: {
   return {
     refresh(forceReload = false): void {
       const requestGeneration = ++generation
+      // Why: once the effective inventory is invalidated, keeping the previous
+      // list clickable would violate the callable-for-this-turn invariant.
+      args.apply([])
       void args
         .list(args.cwd, forceReload)
         .then((skills) => {

--- a/src/renderer/src/components/native-chat/native-chat-skill-request.ts
+++ b/src/renderer/src/components/native-chat/native-chat-skill-request.ts
@@ -1,0 +1,35 @@
+import type { DiscoveredSkill } from '../../../../shared/skills'
+
+export type NativeChatSkillRequest = {
+  refresh: (forceReload?: boolean) => void
+  cancel: () => void
+}
+
+export function createNativeChatSkillRequest(args: {
+  cwd: string
+  list: (cwd: string, forceReload: boolean) => Promise<DiscoveredSkill[]>
+  apply: (skills: DiscoveredSkill[]) => void
+}): NativeChatSkillRequest {
+  let generation = 0
+  let cancelled = false
+  return {
+    refresh(forceReload = false): void {
+      const requestGeneration = ++generation
+      void args
+        .list(args.cwd, forceReload)
+        .then((skills) => {
+          if (!cancelled && requestGeneration === generation) {
+            args.apply(skills)
+          }
+        })
+        .catch(() => {
+          if (!cancelled && requestGeneration === generation) {
+            args.apply([])
+          }
+        })
+    },
+    cancel(): void {
+      cancelled = true
+    }
+  }
+}

--- a/src/renderer/src/components/native-chat/use-native-chat-skills.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-skills.test.ts
@@ -1,63 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import type { DiscoveredSkill } from '../../../../shared/skills'
-import {
-  isNativeChatSkillForAgent,
-  resolveNativeChatSkillDiscoveryCwd
-} from './use-native-chat-skills'
-
-function skill(overrides: Partial<DiscoveredSkill>): DiscoveredSkill {
-  return {
-    id: overrides.name ?? 'skill',
-    name: 'agent-browser',
-    description: null,
-    providers: ['agent-skills'],
-    sourceKind: 'home',
-    sourceLabel: 'Agent skills home',
-    rootPath: '/Users/test/.agents/skills',
-    directoryPath: '/Users/test/.agents/skills/agent-browser',
-    skillFilePath: '/Users/test/.agents/skills/agent-browser/SKILL.md',
-    installed: true,
-    fileCount: 1,
-    updatedAt: null,
-    ...overrides
-  }
-}
-
-describe('isNativeChatSkillForAgent', () => {
-  it('shows Codex-native and generic agent skills for Codex chat', () => {
-    expect(isNativeChatSkillForAgent('codex', skill({ providers: ['codex'] }))).toBe(true)
-    expect(isNativeChatSkillForAgent('codex', skill({ providers: ['agent-skills'] }))).toBe(true)
-  })
-
-  it('keeps Claude skills out of the Codex skill picker', () => {
-    expect(isNativeChatSkillForAgent('codex', skill({ providers: ['claude'] }))).toBe(false)
-  })
-
-  it('does not enable skill autocomplete for other agents yet', () => {
-    expect(isNativeChatSkillForAgent('claude', skill({ providers: ['agent-skills'] }))).toBe(false)
-  })
-})
+import { resolveNativeChatSkillDiscoveryCwd } from './use-native-chat-skills'
 
 describe('resolveNativeChatSkillDiscoveryCwd', () => {
   it('returns the owning worktree path for a terminal tab', () => {
     expect(
       resolveNativeChatSkillDiscoveryCwd(
         {
-          tabsByWorktree: {
-            'repo-1::/repo/worktree': [
-              {
-                id: 'tab-1'
-              }
-            ]
-          },
-          worktreesByRepo: {
-            'repo-1': [
-              {
-                id: 'repo-1::/repo/worktree',
-                path: '/repo/worktree'
-              }
-            ]
-          }
+          tabsByWorktree: { worktree: [{ id: 'tab-1' }] },
+          worktreesByRepo: { repo: [{ id: 'worktree', path: '/repo/worktree' }] }
         },
         'tab-1'
       )

--- a/src/renderer/src/components/native-chat/use-native-chat-skills.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-skills.ts
@@ -5,6 +5,7 @@ import type { DiscoveredSkill } from '../../../../shared/skills'
 import { onInstalledAgentSkillsChanged } from '@/hooks/useInstalledAgentSkills'
 import { createNativeChatSkillRequest } from './native-chat-skill-request'
 import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
+import { selectNativeChatRuntimeEnvironmentId } from './native-chat-runtime-owner'
 
 type NativeChatSkillWorktreeState = {
   tabsByWorktree: Record<string, readonly { id: string }[]>
@@ -37,10 +38,16 @@ export function resolveNativeChatSkillDiscoveryCwd(
 export function useNativeChatSkills(
   agent: AgentType,
   terminalTabId: string,
-  runtimeEnvironmentId: string | null = null
+  paneKey: string
 ): DiscoveredSkill[] {
   const [skills, setSkills] = useState<DiscoveredSkill[]>([])
   const cwd = useAppStore((state) => resolveNativeChatSkillDiscoveryCwd(state, terminalTabId))
+  const runtimeEnvironmentId = useAppStore((state) =>
+    selectNativeChatRuntimeEnvironmentId(state, terminalTabId)
+  )
+  const codexHome = useAppStore(
+    (state) => state.agentLaunchConfigByPaneKey[paneKey]?.launchConfig.agentEnv.CODEX_HOME
+  )
 
   useEffect(() => {
     if (agent !== 'codex' || !cwd) {
@@ -54,25 +61,57 @@ export function useNativeChatSkills(
           ? callRuntimeRpc<DiscoveredSkill[]>(
               { kind: 'environment', environmentId: runtimeEnvironmentId },
               'skills.codexList',
-              { cwd: requestCwd, forceReload },
+              { cwd: requestCwd, forceReload, codexHome },
               { timeoutMs: 15_000 }
             )
-          : window.api.skills.listCodex(requestCwd, forceReload),
+          : window.api.skills.listCodex(requestCwd, forceReload, codexHome),
       apply: setSkills
     })
     request.refresh()
-    // Remote runtime inventory is queried on mount/lifecycle invalidation; local
-    // app-server watcher notifications additionally hot-reload immediately.
-    const unsubscribeCodex = runtimeEnvironmentId
-      ? () => {}
-      : window.api.skills.onCodexChanged(() => request.refresh())
+    let unsubscribeCodex = window.api.skills.onCodexChanged(() => request.refresh())
+    if (runtimeEnvironmentId) {
+      unsubscribeCodex()
+      let cancelled = false
+      let closeRemote = (): void => {}
+      void window.api.runtimeEnvironments
+        .subscribe(
+          {
+            selector: runtimeEnvironmentId,
+            method: 'skills.codexSubscribe',
+            params: {},
+            timeoutMs: 15_000
+          },
+          {
+            onResponse: (response) => {
+              if (
+                !cancelled &&
+                response.ok &&
+                (response.result as { type?: string })?.type === 'changed'
+              ) {
+                request.refresh()
+              }
+            }
+          }
+        )
+        .then((handle) => {
+          if (cancelled) {
+            handle.unsubscribe()
+          } else {
+            closeRemote = handle.unsubscribe
+          }
+        })
+      unsubscribeCodex = () => {
+        cancelled = true
+        closeRemote()
+      }
+    }
     const unsubscribeLifecycle = onInstalledAgentSkillsChanged(() => request.refresh(true))
     return () => {
       request.cancel()
       unsubscribeCodex()
       unsubscribeLifecycle()
     }
-  }, [agent, cwd, runtimeEnvironmentId])
+  }, [agent, codexHome, cwd, runtimeEnvironmentId])
 
   return skills
 }

--- a/src/renderer/src/components/native-chat/use-native-chat-skills.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-skills.ts
@@ -2,19 +2,13 @@ import { useEffect, useState } from 'react'
 import { useAppStore } from '../../store'
 import type { AgentType } from '../../../../shared/agent-status-types'
 import type { DiscoveredSkill } from '../../../../shared/skills'
+import { onInstalledAgentSkillsChanged } from '@/hooks/useInstalledAgentSkills'
+import { createNativeChatSkillRequest } from './native-chat-skill-request'
+import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
 
 type NativeChatSkillWorktreeState = {
   tabsByWorktree: Record<string, readonly { id: string }[]>
   worktreesByRepo: Record<string, readonly { id: string; path: string }[]>
-}
-
-export function isNativeChatSkillForAgent(agent: AgentType, skill: DiscoveredSkill): boolean {
-  if (agent !== 'codex') {
-    return false
-  }
-  // Why: Codex sessions can see both Codex-native skills and generic agent
-  // skills (for example ~/.agents/skills), so the picker should mirror that.
-  return skill.providers.includes('codex') || skill.providers.includes('agent-skills')
 }
 
 export function resolveNativeChatSkillDiscoveryCwd(
@@ -40,32 +34,45 @@ export function resolveNativeChatSkillDiscoveryCwd(
   return null
 }
 
-export function useNativeChatSkills(agent: AgentType, terminalTabId: string): DiscoveredSkill[] {
+export function useNativeChatSkills(
+  agent: AgentType,
+  terminalTabId: string,
+  runtimeEnvironmentId: string | null = null
+): DiscoveredSkill[] {
   const [skills, setSkills] = useState<DiscoveredSkill[]>([])
   const cwd = useAppStore((state) => resolveNativeChatSkillDiscoveryCwd(state, terminalTabId))
 
   useEffect(() => {
-    let cancelled = false
-    if (agent !== 'codex') {
+    if (agent !== 'codex' || !cwd) {
       setSkills([])
       return
     }
-    void window.api.skills
-      .discover(cwd ? { cwd } : undefined)
-      .then((result) => {
-        if (!cancelled) {
-          setSkills(result.skills.filter((skill) => isNativeChatSkillForAgent(agent, skill)))
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setSkills([])
-        }
-      })
+    const request = createNativeChatSkillRequest({
+      cwd,
+      list: (requestCwd, forceReload) =>
+        runtimeEnvironmentId
+          ? callRuntimeRpc<DiscoveredSkill[]>(
+              { kind: 'environment', environmentId: runtimeEnvironmentId },
+              'skills.codexList',
+              { cwd: requestCwd, forceReload },
+              { timeoutMs: 15_000 }
+            )
+          : window.api.skills.listCodex(requestCwd, forceReload),
+      apply: setSkills
+    })
+    request.refresh()
+    // Remote runtime inventory is queried on mount/lifecycle invalidation; local
+    // app-server watcher notifications additionally hot-reload immediately.
+    const unsubscribeCodex = runtimeEnvironmentId
+      ? () => {}
+      : window.api.skills.onCodexChanged(() => request.refresh())
+    const unsubscribeLifecycle = onInstalledAgentSkillsChanged(() => request.refresh(true))
     return () => {
-      cancelled = true
+      request.cancel()
+      unsubscribeCodex()
+      unsubscribeLifecycle()
     }
-  }, [agent, cwd])
+  }, [agent, cwd, runtimeEnvironmentId])
 
   return skills
 }

--- a/src/renderer/src/hooks/useInstalledAgentSkills.ts
+++ b/src/renderer/src/hooks/useInstalledAgentSkills.ts
@@ -83,6 +83,11 @@ export function notifyInstalledAgentSkillsChanged(): void {
   }
 }
 
+export function onInstalledAgentSkillsChanged(listener: () => void): () => void {
+  window.addEventListener(INSTALLED_AGENT_SKILLS_CHANGED_EVENT, listener)
+  return () => window.removeEventListener(INSTALLED_AGENT_SKILLS_CHANGED_EVENT, listener)
+}
+
 function normalizeSkillDiscoveryTarget(
   target: SkillDiscoveryTarget | undefined
 ): SkillDiscoveryTarget | undefined {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2658,8 +2658,12 @@ function createSkillsApi(): NonNullable<Partial<PreloadApi>['skills']> {
         sources: [],
         scannedAt: Date.now()
       })),
-    listCodex: (cwd, forceReload = false) =>
-      callRuntimeResult<DiscoveredSkill[]>('skills.codexList', { cwd, forceReload }, 15_000),
+    listCodex: (cwd, forceReload = false, codexHome) =>
+      callRuntimeResult<DiscoveredSkill[]>(
+        'skills.codexList',
+        { cwd, forceReload, codexHome },
+        15_000
+      ),
     onCodexChanged: () => () => {}
   }
 }

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -34,7 +34,7 @@ import type {
   WorkspaceSessionPatch,
   WorkspaceSessionState
 } from '../../../shared/types'
-import type { SkillDiscoveryResult } from '../../../shared/skills'
+import type { DiscoveredSkill, SkillDiscoveryResult } from '../../../shared/skills'
 import type { SshConnectionState, SshTarget } from '../../../shared/ssh-types'
 import {
   getDefaultOnboardingState,
@@ -2657,7 +2657,10 @@ function createSkillsApi(): NonNullable<Partial<PreloadApi>['skills']> {
         skills: [],
         sources: [],
         scannedAt: Date.now()
-      }))
+      })),
+    listCodex: (cwd, forceReload = false) =>
+      callRuntimeResult<DiscoveredSkill[]>('skills.codexList', { cwd, forceReload }, 15_000),
+    onCodexChanged: () => () => {}
   }
 }
 

--- a/src/shared/skills.ts
+++ b/src/shared/skills.ts
@@ -35,6 +35,14 @@ export type SkillDiscoveryResult = {
   scannedAt: number
 }
 
+export type CodexEffectiveSkill = {
+  name: string
+  description: string
+  path: string
+  scope: 'user' | 'repo' | 'system' | 'admin'
+  enabled: boolean
+}
+
 export type SkillDiscoveryTarget = {
   runtime?: 'host' | 'wsl'
   wslDistro?: string | null


### PR DESCRIPTION
## 변경 내용

- native-chat skill autocomplete의 Codex 소스를 filesystem discovery에서 app-server `skills/list(cwd, forceReload)` 결과로 교체했습니다.
- `skills/changed`와 설치 lifecycle 알림을 재조회로 연결하고, cwd/agent 전환 및 연속 invalidation의 stale response race를 차단했습니다.
- app-server가 반환한 namespace와 active path를 보존하면서 `enabled=false` 항목은 호출 가능 목록에서 제외합니다.
- paired runtime/web 경로에서도 해당 runtime의 Codex inventory를 조회하도록 RPC adapter를 추가했습니다.
- settings에서 사용하는 기존 Claude/standalone/shared/repo filesystem discovery는 변경하지 않았습니다.

## 원인

기존 native-chat hook은 `~/.codex/plugins/cache`를 포함한 filesystem scan 결과를 `installed=true`로 간주했습니다. 그 결과 disabled/uninstalled/stale/multiple-version cache와 catalog-only 항목까지 현재 Codex가 호출 가능한 skill처럼 노출됐습니다.

## 검증

- 실제 Codex 0.144.5 app-server `skills/list` 응답 schema 및 현재 cwd inventory 확인
- disabled/uninstalled cache 제외 및 effective entry만 변환
- namespace 중복 base name과 active-version path 보존
- shared user/repo scope 보존
- local 및 paired runtime의 same-session lifecycle/`skills/changed` hot reload
- pane launch `CODEX_HOME`별 inventory session 격리
- 연속 invalidation 및 cwd/agent teardown race
- `pnpm run lint`
- `pnpm run typecheck`
- 관련 테스트 15개 통과
- 전체 `pnpm test`: sandbox 밖 재실행에서 변경과 무관한 3건 실패 확인(2건은 상속된 중복 `GIT_CONFIG_*`, 1건은 shared-control cleanup timing); 변경 관련 테스트는 통과
