### PR TITLE
fix(projects): treat symlinked directories as directories in Add Project browsers

### DIFF
--- a/src/main/ipc/ssh-browse.test.ts
+++ b/src/main/ipc/ssh-browse.test.ts
@@ -25,6 +25,12 @@ function createMockChannel(): EventEmitter & { stderr: EventEmitter } {
   })
 }
 
+// The POSIX listing appends `/` via `[ -d ]` (which follows symlinks) instead of
+// `ls -p` (which does not), so symlinked directories classify as directories.
+function posixBrowseCommand(cdTarget: string): string {
+  return `cd ${cdTarget} && pwd && entries=$(command ls -1A) && printf '%s\\n' "$entries" | while IFS= read -r f; do if [ -d "$f" ]; then printf '%s/\\n' "$f"; else printf '%s\\n' "$f"; fi; done`
+}
+
 // Recover the PowerShell script from a `powershell.exe ... -EncodedCommand <b64>`
 // command so tests can assert on the actual (UTF-16LE) payload sent to the host.
 function decodeEncodedCommand(command: string): string {
@@ -68,13 +74,41 @@ describe('registerSshBrowseHandler', () => {
         { name: 'README.md', isDirectory: false }
       ]
     })
-    expect(exec).toHaveBeenCalledWith('cd "$HOME" && pwd && command ls -1Ap')
+    expect(exec).toHaveBeenCalledWith(posixBrowseCommand('"$HOME"'))
     expect(channel.listenerCount('data')).toBe(0)
     expect(channel.listenerCount('exit')).toBe(0)
     expect(channel.listenerCount('close')).toBe(0)
     expect(channel.listenerCount('error')).toBe(0)
     expect(channel.stderr.listenerCount('data')).toBe(0)
     expect(channel.stderr.listenerCount('error')).toBe(0)
+  })
+
+  it('classifies remote symlinked directories as directories', async () => {
+    const channel = createMockChannel()
+    const exec = vi.fn().mockResolvedValue(channel)
+    const getConnectionManager = () => ({
+      getConnection: () => ({ exec })
+    })
+    registerSshBrowseHandler(getConnectionManager as never)
+
+    const resultPromise = handler(null, { targetId: 'ssh-1', dirPath: '/srv' })
+    await Promise.resolve()
+    // `[ -d ]` follows symlinks, so the remote loop emits `linked-dir/` even
+    // though it is a symlink; `ls -p` alone would have printed it bare.
+    channel.emit('data', Buffer.from('/srv\nlinked-dir/\nreal-dir/\nbroken-link\nlinked-file\n'))
+    channel.emit('exit', 0)
+    channel.emit('close')
+
+    await expect(resultPromise).resolves.toEqual({
+      resolvedPath: '/srv',
+      entries: [
+        { name: 'linked-dir', isDirectory: true },
+        { name: 'real-dir', isDirectory: true },
+        { name: 'broken-link', isDirectory: false },
+        { name: 'linked-file', isDirectory: false }
+      ]
+    })
+    expect(exec).toHaveBeenCalledWith(posixBrowseCommand("'/srv'"))
   })
 
   it('escapes remote browse paths before invoking command ls', async () => {
@@ -95,7 +129,7 @@ describe('registerSshBrowseHandler', () => {
       resolvedPath: "/tmp/it's here",
       entries: []
     })
-    expect(exec).toHaveBeenCalledWith("cd '/tmp/it'\\''s here' && pwd && command ls -1Ap")
+    expect(exec).toHaveBeenCalledWith(posixBrowseCommand("'/tmp/it'\\''s here'"))
   })
 
   it('falls back to PowerShell when a Windows SSH shell rejects POSIX exec', async () => {
@@ -134,7 +168,7 @@ describe('registerSshBrowseHandler', () => {
       ]
     })
     expect(exec).toHaveBeenCalledTimes(2)
-    expect(exec).toHaveBeenNthCalledWith(1, "cd 'C:/Users/alice' && pwd && command ls -1Ap")
+    expect(exec).toHaveBeenNthCalledWith(1, posixBrowseCommand("'C:/Users/alice'"))
     expect(exec.mock.calls[1]?.[0]).toMatch(/^powershell\.exe /)
     expect(exec.mock.calls[1]?.[1]).toEqual({ wrapCommand: false })
 

--- a/src/main/ipc/ssh-browse.ts
+++ b/src/main/ipc/ssh-browse.ts
@@ -95,12 +95,18 @@ function browseWithPosixShell(
 ): Promise<{ entries: RemoteDirEntry[]; resolvedPath: string }> {
   // Why: using one line per entry preserves filenames containing spaces.
   // `command ls` bypasses user aliases/functions like `ls='eza ...'`.
-  // The -1 flag outputs one entry per line. The -p flag appends / to directories.
   // We resolve ~ and get the absolute path via `cd <path> && pwd`.
-  // `cd` and `ls` are chained with `&&` so a failing `ls` (e.g. permission
-  // denied after a readable `cd ... && pwd`) propagates as a non-zero exit
-  // code rather than being indistinguishable from an empty directory.
-  return runBrowseCommand(conn, `cd ${shellEscape(dirPath)} && pwd && command ls -1Ap`)
+  // The trailing `/` dir marker comes from `[ -d ]`, which follows symlinks,
+  // instead of `ls -p`, which does not — otherwise a symlinked directory is
+  // listed as a file and can't be descended into from Add Remote Project.
+  // Capturing `ls` output into a variable keeps a failing `ls` (e.g.
+  // permission denied after a readable `cd ... && pwd`) propagating through
+  // the `&&` chain as a non-zero exit code rather than being masked by the
+  // while-loop pipeline and misread as an empty directory.
+  return runBrowseCommand(
+    conn,
+    `cd ${shellEscape(dirPath)} && pwd && entries=$(command ls -1A) && printf '%s\\n' "$entries" | while IFS= read -r f; do if [ -d "$f" ]; then printf '%s/\\n' "$f"; else printf '%s\\n' "$f"; fi; done`
+  )
 }
 
 function browseWithWindowsPowerShell(

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -6,7 +6,7 @@ import { EventEmitter } from 'node:events'
 import { randomUUID } from 'node:crypto'
 import { execFileSync } from 'node:child_process'
 import { mkdirSync } from 'node:fs'
-import { lstat, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { lstat, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { homedir, tmpdir } from 'node:os'
 import { join, win32 } from 'node:path'
 import { ipcMain } from 'electron'
@@ -5863,6 +5863,34 @@ describe('OrcaRuntimeService', () => {
         { name: 'alpha', isDirectory: true, isSymlink: false },
         { name: 'zeta', isDirectory: true, isSymlink: false },
         { name: 'readme.md', isDirectory: false, isSymlink: false }
+      ])
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('classifies symlinked directories as directories when browsing server dirs', async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), 'orca-runtime-browse-symlink-'))
+    try {
+      await mkdir(join(tempRoot, 'real-dir'))
+      await writeFile(join(tempRoot, 'real-file.txt'), 'contents\n')
+      await symlink(
+        join(tempRoot, 'real-dir'),
+        join(tempRoot, 'linked-dir'),
+        process.platform === 'win32' ? 'junction' : 'dir'
+      )
+      await symlink(join(tempRoot, 'real-file.txt'), join(tempRoot, 'linked-file'))
+      await symlink(join(tempRoot, 'missing-target'), join(tempRoot, 'broken-link'))
+      const runtime = new OrcaRuntimeService(store)
+
+      const result = await runtime.browseServerDir(tempRoot)
+
+      expect(result.entries).toEqual([
+        { name: 'linked-dir', isDirectory: true, isSymlink: true },
+        { name: 'real-dir', isDirectory: true, isSymlink: false },
+        { name: 'broken-link', isDirectory: false, isSymlink: true },
+        { name: 'linked-file', isDirectory: false, isSymlink: true },
+        { name: 'real-file.txt', isDirectory: false, isSymlink: false }
       ])
     } finally {
       await rm(tempRoot, { recursive: true, force: true })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1902,6 +1902,25 @@ async function pathExists(pathValue: string): Promise<boolean> {
   }
 }
 
+async function isServerBrowseEntryDirectory(
+  dirPath: string,
+  entry: { name: string; isDirectory(): boolean; isSymbolicLink(): boolean }
+): Promise<boolean> {
+  if (entry.isDirectory()) {
+    return true
+  }
+  if (!entry.isSymbolicLink()) {
+    return false
+  }
+  try {
+    // Why: the Add Project browser must let users descend into symlinked
+    // directories, so classify links by their target type like relay fs.readDir.
+    return (await stat(join(dirPath, entry.name))).isDirectory()
+  } catch {
+    return false
+  }
+}
+
 function resolveServerBrowsePath(pathValue: string): string {
   const trimmed = pathValue.trim() || '~'
   if (trimmed.includes('\0')) {
@@ -12337,13 +12356,15 @@ export class OrcaRuntimeService {
       throw new Error(`${dirPath} is not a directory`)
     }
     const entries = await readdir(dirPath, { withFileTypes: true })
-    const mapped = entries
-      .filter((entry) => entry.name !== '.' && entry.name !== '..')
-      .map((entry) => ({
-        name: entry.name,
-        isDirectory: entry.isDirectory(),
-        isSymlink: entry.isSymbolicLink()
-      }))
+    const mapped = await Promise.all(
+      entries
+        .filter((entry) => entry.name !== '.' && entry.name !== '..')
+        .map(async (entry) => ({
+          name: entry.name,
+          isDirectory: await isServerBrowseEntryDirectory(dirPath, entry),
+          isSymlink: entry.isSymbolicLink()
+        }))
+    )
     mapped.sort((a, b) => {
       if (a.isDirectory !== b.isDirectory) {
         return a.isDirectory ? -1 : 1


### PR DESCRIPTION
## Summary

Fixes #8983.

In the Add Project / Add Remote Project folder browsers, a symbolic link pointing to a directory was listed as a file — no folder icon, not navigable — so any project living behind a symlinked path could not be reached or selected.

Two classification sites had the same bug:

- **`browseServerDir`** (`src/main/runtime/orca-runtime.ts`) used `Dirent.isDirectory()`, which does not follow symlinks. Symlink entries are now classified by their target type via `stat`, mirroring the existing (and test-locked) behavior of the relay `fs.readDir` handler in `src/relay/fs-handler.ts`.
- **`ssh:browseDir` POSIX branch** (`src/main/ipc/ssh-browse.ts`) derived the directory marker from `ls -p`, which does not dereference links. The listing now appends the `/` marker via `[ -d ]` (which follows symlinks) in a plain POSIX `sh` loop. The `ls` output is captured into a variable first so a failing `ls` (e.g. permission denied) still propagates through the `&&` chain as a non-zero exit code instead of being masked by the while-loop pipeline — preserving the existing error semantics.

Deliberately unchanged: the local file-explorer `fs:readDir` and runtime file listing intentionally treat symlinks as file-like to avoid macOS TCC prompts (documented and test-locked); the Windows remote fallback already classifies symlinked directories correctly via `PSIsContainer`.

## Screenshots

Remote filesystem browser (Add Remote Project) on a real Linux SSH host, running this branch. `linked-dir` is a symlink to `real-dir`; it now renders as a navigable directory, sorts with directories, and can be descended into and selected as a project (breadcrumb reached `/tmp/orca-symlink-verify/linked-dir`):

<img src="https://raw.githubusercontent.com/choihjin/orca/pr-assets-symlink-browser/pr-symlink-browser.png" width="560" alt="Remote file browser showing a symlinked directory classified as a folder" />

Before this change the same entry rendered with a file icon and could not be entered.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New regression tests (both watched failing before the fix):

- `orca-runtime.test.ts`: `browseServerDir` over a real temp directory containing a symlinked directory, a symlinked file, and a broken symlink — asserts symlink-to-dir classifies as a directory, symlink-to-file and broken links stay file-like, and sort order holds. Uses `junction` on Windows, matching the existing relay symlink test.
- `ssh-browse.test.ts`: locks the new POSIX listing command and asserts symlinked-directory entries parse as directories; existing command-string assertions updated via a shared helper.

Manual verification: drove the built dev app end-to-end against a real Linux SSH host — browsed into the symlinked directory and confirmed it is selectable as a project. The new shell snippet was additionally exercised directly in `sh` against fixtures with spaces in names, an empty directory, a broken symlink, and a permission-denied directory (still exits non-zero).

## AI Review Report

Review by Claude (Fable 5), which also authored the change. Checks performed:

- **Cross-platform (macOS/Linux/Windows):** the `browseServerDir` change is pure `node:fs` and platform-neutral; Node reports Windows junctions as symlinks, and the new test uses `junction` on win32. The SSH change touches only the POSIX branch; the Windows PowerShell fallback (`PSIsContainer`, already symlink-correct) is untouched. No shortcuts, labels, or path-separator handling involved.
- **SSH/remote/local:** the remote listing keeps a single exec round-trip (no per-entry SSH calls) and preserves exit-code error semantics for permission-denied/unreadable directories (verified in a real shell). Verified live over SSH against a Linux host. The relay/daemon `fs.readDir` path already handled symlinks and is unchanged.
- **Shell portability:** the new snippet uses only POSIX `sh` constructs (`command ls -1A`, `[ -d ]`, `printf`, `while IFS= read -r`) — no bashisms, no `find -maxdepth`, no `pipefail` — so dash/busybox login shells are fine. Filenames with spaces are preserved; filenames containing newlines remain a pre-existing limitation of the line-based protocol, unchanged by this PR.
- **Performance:** extra `stat` calls are issued only for symlink entries and run concurrently; non-symlink entries take the previous fast path. Remote listing adds one subshell and a builtin test per entry inside the existing single exec.
- **Behavioral risk:** broken symlinks classify as files (matching relay behavior); the browse target itself was already `stat`-validated, so selecting a symlinked folder keeps working as before.

## Security Audit

- The remote command keeps the existing `shellEscape` for the only user-controlled input (the directory path); the added shell text is a static string with no interpolation, and `"$f"` values come from `ls` output inside the already-escaped target directory — no new injection surface.
- No new IPC endpoints, no auth/secrets/dependency changes. Local symlink following is confined to classifying entries of a directory the user explicitly browsed; the relay ACL model is untouched (the raw-exec browse path exists precisely because browsing happens before workspace roots are registered, unchanged).

## Notes

- POSIX remote hosts get the fix via the new listing command; Windows remote hosts were already correct.
- The local file explorer's intentional "symlinks are file-like" TCC-avoidance behavior is out of scope and unchanged.

## ELI5

Symlinked folders in Add Project looked like plain files and couldn’t be opened. They’re treated as real directories now so you can navigate into them and pick projects.
