### PR TITLE
fix(onboarding): stop offering WSL as a Windows default shell

### DIFF
--- a/src/renderer/src/components/onboarding/WindowsTerminalStep.test.tsx
+++ b/src/renderer/src/components/onboarding/WindowsTerminalStep.test.tsx
@@ -1,8 +1,26 @@
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { WINDOWS_GIT_BASH_SHELL } from '../../../../shared/windows-terminal-shell'
 import type { GlobalSettings } from '../../../../shared/types'
+import type { WindowsTerminalCapabilities } from '@/lib/windows-terminal-capabilities'
 import { WindowsTerminalStep } from './WindowsTerminalStep'
+
+const mockCapabilities: WindowsTerminalCapabilities = {
+  wslAvailable: false,
+  wslDistros: [],
+  pwshAvailable: false,
+  gitBashAvailable: false,
+  hostPlatform: null,
+  isLoading: false
+}
+
+vi.mock('@/lib/windows-terminal-capabilities', () => ({
+  useWindowsTerminalCapabilities: (): WindowsTerminalCapabilities => mockCapabilities
+}))
+
+function setMockCapabilities(overrides: Partial<WindowsTerminalCapabilities>): void {
+  Object.assign(mockCapabilities, overrides)
+}
 
 function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings {
   return {
@@ -14,6 +32,31 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
 }
 
 describe('WindowsTerminalStep', () => {
+  beforeEach(() => {
+    setMockCapabilities({
+      wslAvailable: false,
+      wslDistros: [],
+      pwshAvailable: false,
+      gitBashAvailable: false,
+      hostPlatform: null,
+      isLoading: false
+    })
+  })
+
+  it('does not offer WSL as a fresh default-shell choice even when WSL is detected', () => {
+    // Why: #5519 moved WSL out of terminal shell selection into Project Runtime;
+    // onboarding must not persist terminalWindowsShell='wsl.exe' on fresh profiles,
+    // which Settings can no longer display back (issue #8537).
+    setMockCapabilities({ wslAvailable: true, wslDistros: ['Ubuntu'] })
+    const html = renderToStaticMarkup(
+      <WindowsTerminalStep settings={createSettings()} updateSettings={vi.fn()} />
+    )
+
+    expect(html).toContain('PowerShell')
+    expect(html).toContain('Command Prompt')
+    expect(html).not.toContain('WSL')
+  })
+
   it('renders default shell and right-click behavior choices', () => {
     const html = renderToStaticMarkup(
       <WindowsTerminalStep settings={createSettings()} updateSettings={vi.fn()} />

--- a/src/renderer/src/components/onboarding/WindowsTerminalStep.tsx
+++ b/src/renderer/src/components/onboarding/WindowsTerminalStep.tsx
@@ -62,7 +62,11 @@ export function WindowsTerminalStep({
       ? [selectedWslDistroName, ...capabilities.wslDistros]
       : capabilities.wslDistros
   const showGitBashOption = capabilities.gitBashAvailable || windowsShell === WINDOWS_GIT_BASH_SHELL
-  const showWslOption = capabilities.wslAvailable || windowsShell === 'wsl.exe'
+  // Why: #5519 moved WSL out of terminalWindowsShell into Project Runtime, but
+  // Settings can no longer display a persisted 'wsl.exe' host shell (it renders as
+  // PowerShell). So onboarding must not offer WSL as a fresh default-shell choice;
+  // it stays visible only to reflect a value a prior build already persisted (#8537).
+  const showWslOption = windowsShell === 'wsl.exe'
 
   const setSelectPortalHost = useCallback((node: HTMLDivElement | null) => {
     // Why: onboarding sits above body-level portals, so the distro menu must


### PR DESCRIPTION
## Summary

On Windows onboarding, WSL is no longer offered as a fresh default-shell choice, so new profiles never persist a `wsl.exe` value that Settings can't display or edit.

## ELI5

Setup used to let Windows users pick WSL as their terminal, but the Settings screen can no longer show that choice — so it looked like PowerShell while actually launching WSL. Now setup stops offering WSL to new users, keeping what you pick and what you see in sync.

## Root cause & fix

`WindowsTerminalStep` gated its WSL card on `capabilities.wslAvailable`, making onboarding the only path that persisted `terminalWindowsShell: "wsl.exe"` — a value the Settings control dropped when #5519 moved WSL to the Project Runtime model. The fix narrows the gate to `windowsShell === 'wsl.exe'`, so the option only appears to reflect a value a prior build already saved, never as a fresh choice. This keeps the stored setting, the Settings UI, and the shell used for new panes consistent, without stranding existing WSL users.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- Test file: `src/renderer/src/components/onboarding/WindowsTerminalStep.test.tsx` — 4 passed on branch.
- Reverting the fix to `origin/main` fails the guard test `does not offer WSL as a fresh default-shell choice even when WSL is detected` (`AssertionError: expected html not to contain 'WSL'`), proving the fix is load-bearing.
- Lint clean: `oxlint` on `WindowsTerminalStep.tsx` reported no findings.

```
STEP 2a (branch):  Test Files 1 passed (1), Tests 4 passed (4)
STEP 2b (fix reverted):  Tests 1 failed | 3 passed
  Failing: "does not offer WSL as a fresh default-shell choice even when WSL is detected"
  AssertionError: expected html not to contain 'WSL' (line 57)
```

## Trade-offs

None — pure fix.

## Regression risk

Zero-regression: the change only tightens one boolean gate in the onboarding WSL card. Users with a persisted `wsl.exe` value still see the option (verified by the still-passing sticky-WSL case), and all non-Windows / non-WSL paths are unaffected — proven by the 4-passing test suite and the targeted fail when the gate is reverted.

---

*Original fix by @xianjianlf2. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved.*
