### PR TITLE
fix(orchestration): fail direct dispatches on agent exit

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -7315,9 +7315,40 @@ describe('OrcaRuntimeService', () => {
 
     runtime.onPtyExit('pty-1', -1)
 
-    expect(failDispatch).toHaveBeenCalledWith('ctx-1', 'Agent exited with code -1')
-    expect(updateTaskStatus).toHaveBeenCalledWith('task-1', 'failed', 'Agent exited with code -1')
+    expect(failDispatch).toHaveBeenCalledWith('ctx-1', 'Agent exited with code -1', {
+      requeueTask: false
+    })
+    expect(updateTaskStatus).not.toHaveBeenCalled()
     expect(insertMessage).not.toHaveBeenCalled()
+  })
+
+  it('keeps coordinator-owned dispatches retryable when their worker PTY exits', () => {
+    const runtime = createRuntime()
+    const workerHandle = runtime.preAllocateHandleForPty('pty-1')
+    const failDispatch = vi.fn()
+    const insertMessage = vi.fn()
+    runtime.setOrchestrationDb({
+      getActiveDispatchForTerminal: vi.fn((handle: string) =>
+        handle === workerHandle ? { id: 'ctx-1', task_id: 'task-1' } : undefined
+      ),
+      failDispatch,
+      getActiveCoordinatorRun: vi.fn(() => ({ coordinator_handle: 'term-coordinator' })),
+      insertMessage
+    } as never)
+    syncSinglePty(runtime)
+
+    runtime.onPtyExit('pty-1', 1)
+
+    expect(failDispatch).toHaveBeenCalledWith('ctx-1', 'Agent exited with code 1', {
+      requeueTask: true
+    })
+    expect(insertMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'term-coordinator',
+        type: 'escalation',
+        priority: 'high'
+      })
+    )
   })
 
   it('keeps stale-title timers isolated per PTY', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -7296,6 +7296,30 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('marks a direct dispatch failed when its worker PTY exits', () => {
+    const runtime = createRuntime()
+    const workerHandle = runtime.preAllocateHandleForPty('pty-1')
+    const failDispatch = vi.fn()
+    const updateTaskStatus = vi.fn()
+    const insertMessage = vi.fn()
+    runtime.setOrchestrationDb({
+      getActiveDispatchForTerminal: vi.fn((handle: string) =>
+        handle === workerHandle ? { id: 'ctx-1', task_id: 'task-1' } : undefined
+      ),
+      failDispatch,
+      getActiveCoordinatorRun: vi.fn(() => undefined),
+      updateTaskStatus,
+      insertMessage
+    } as never)
+    syncSinglePty(runtime)
+
+    runtime.onPtyExit('pty-1', -1)
+
+    expect(failDispatch).toHaveBeenCalledWith('ctx-1', 'Agent exited with code -1')
+    expect(updateTaskStatus).toHaveBeenCalledWith('task-1', 'failed', 'Agent exited with code -1')
+    expect(insertMessage).not.toHaveBeenCalled()
+  })
+
   it('keeps stale-title timers isolated per PTY', async () => {
     vi.useFakeTimers()
     try {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -11063,20 +11063,25 @@ export class OrcaRuntimeService {
     // the unexpected exit on its next check cycle, even if the circuit breaker
     // hasn't tripped yet.
     const run = this._orchestrationDb.getActiveCoordinatorRun()
-    if (run) {
-      this._orchestrationDb.insertMessage({
-        from: handle,
-        to: run.coordinator_handle,
-        subject: `Agent exited unexpectedly (code ${exitCode})`,
-        type: 'escalation',
-        priority: 'high',
-        payload: JSON.stringify({
-          taskId: dispatch.task_id,
-          exitCode,
-          handle
-        })
-      })
+    if (!run) {
+      // Why: a direct dispatch has no coordinator loop to consume the ready
+      // retry. Mark it failed so an exited agent cannot silently lose the task.
+      this._orchestrationDb.updateTaskStatus(dispatch.task_id, 'failed', errorContext)
+      return
     }
+
+    this._orchestrationDb.insertMessage({
+      from: handle,
+      to: run.coordinator_handle,
+      subject: `Agent exited unexpectedly (code ${exitCode})`,
+      type: 'escalation',
+      priority: 'high',
+      payload: JSON.stringify({
+        taskId: dispatch.task_id,
+        exitCode,
+        handle
+      })
+    })
   }
 
   async listTerminals(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -11037,10 +11037,8 @@ export class OrcaRuntimeService {
     }
   }
 
-  // Why: Section 7.2 — the runtime detects agent exit directly and updates
-  // dispatch contexts immediately, rather than waiting for the coordinator's
-  // next poll cycle. This catches agent crashes and unexpected exits within
-  // milliseconds. The task is set back to 'pending' so it can be re-dispatched.
+  // Why: the runtime owns PTY lifecycle, so it must reconcile an active dispatch
+  // immediately rather than leave a dead worker assigned until another poll.
   private failActiveDispatchOnExit(leaf: RuntimeLeafRecord, exitCode: number): void {
     if (!this._orchestrationDb) {
       return
@@ -11057,19 +11055,17 @@ export class OrcaRuntimeService {
     }
 
     const errorContext = `Agent exited with code ${exitCode}`
-    this._orchestrationDb.failDispatch(dispatch.id, errorContext)
-
-    // Why: create an escalation message so the coordinator is notified about
-    // the unexpected exit on its next check cycle, even if the circuit breaker
-    // hasn't tripped yet.
     const run = this._orchestrationDb.getActiveCoordinatorRun()
+    this._orchestrationDb.failDispatch(dispatch.id, errorContext, {
+      requeueTask: Boolean(run)
+    })
+
     if (!run) {
-      // Why: a direct dispatch has no coordinator loop to consume the ready
-      // retry. Mark it failed so an exited agent cannot silently lose the task.
-      this._orchestrationDb.updateTaskStatus(dispatch.task_id, 'failed', errorContext)
       return
     }
 
+    // Why: the live coordinator owns retries and needs the worker exit on its
+    // next check cycle even when the circuit breaker has not tripped.
     this._orchestrationDb.insertMessage({
       from: handle,
       to: run.coordinator_handle,

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -783,7 +783,11 @@ export class OrchestrationDb {
       .all(thresholdIso, thresholdIso) as DispatchContextRow[]
   }
 
-  failDispatch(ctxId: string, error: string): DispatchContextRow | undefined {
+  failDispatch(
+    ctxId: string,
+    error: string,
+    options: { requeueTask?: boolean } = {}
+  ): DispatchContextRow | undefined {
     const ctx = this.db.prepare('SELECT * FROM dispatch_contexts WHERE id = ?').get(ctxId) as
       | DispatchContextRow
       | undefined
@@ -794,15 +798,29 @@ export class OrchestrationDb {
     const newFailureCount = ctx.failure_count + 1
     const newStatus: DispatchStatus = newFailureCount >= 3 ? 'circuit_broken' : 'failed'
 
-    this.db
-      .prepare(
-        'UPDATE dispatch_contexts SET status = ?, failure_count = ?, last_failure = ? WHERE id = ?'
-      )
-      .run(newStatus, newFailureCount, error, ctxId)
+    // Why: the dispatch and its task are one lifecycle transition; committing
+    // only one row would leave the ledger contradictory after an interruption.
+    this.db.exec('BEGIN IMMEDIATE')
+    try {
+      this.db
+        .prepare(
+          'UPDATE dispatch_contexts SET status = ?, failure_count = ?, last_failure = ? WHERE id = ?'
+        )
+        .run(newStatus, newFailureCount, error, ctxId)
 
-    // Why: back to 'ready' not 'pending' — 'pending' would strand it since promoteReadyTasks only runs when a dep completes.
-    const taskStatus: TaskStatus = newStatus === 'circuit_broken' ? 'failed' : 'ready'
-    this.db.prepare('UPDATE tasks SET status = ? WHERE id = ?').run(taskStatus, ctx.task_id)
+      const shouldRetry = options.requeueTask !== false && newStatus !== 'circuit_broken'
+      if (shouldRetry) {
+        // Why: 'pending' would strand a retry because dependency promotion only
+        // runs when a dependency completes; this task is already unblocked.
+        this.db.prepare("UPDATE tasks SET status = 'ready' WHERE id = ?").run(ctx.task_id)
+      } else {
+        this.updateTaskStatus(ctx.task_id, 'failed', error)
+      }
+      this.db.exec('COMMIT')
+    } catch (cause) {
+      this.db.exec('ROLLBACK')
+      throw cause
+    }
 
     return this.db.prepare('SELECT * FROM dispatch_contexts WHERE id = ?').get(ctxId) as
       | DispatchContextRow

--- a/src/main/runtime/orchestration/dispatch-failure-policy.test.ts
+++ b/src/main/runtime/orchestration/dispatch-failure-policy.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { OrchestrationDb } from './db'
+
+describe('dispatch failure policy', () => {
+  let db: OrchestrationDb | undefined
+
+  afterEach(() => {
+    db?.close()
+  })
+
+  it('terminally fails a task when no retry owner exists', () => {
+    db = new OrchestrationDb(':memory:')
+    const task = db.createTask({ spec: 'unattended' })
+    const dispatch = db.createDispatchContext(task.id, 'term_a')
+
+    const failed = db.failDispatch(dispatch.id, 'Agent exited with code -1', {
+      requeueTask: false
+    })
+
+    expect(failed).toMatchObject({
+      status: 'failed',
+      failure_count: 1,
+      last_failure: 'Agent exited with code -1'
+    })
+    expect(db.getTask(task.id)).toMatchObject({
+      status: 'failed',
+      result: 'Agent exited with code -1'
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- mark a task as `failed` when a directly dispatched worker exits and no coordinator run exists
- preserve the exit reason on the task instead of leaving it indistinguishable from an untouched `ready` task
- add a runtime regression test for the direct-dispatch path

## Root cause
`failDispatch` correctly returns a task to `ready` for coordinator-managed retries. A direct `orca orchestration dispatch` has no coordinator loop to consume that retry, so an agent exit could leave work silently stranded in `ready` forever.

## Impact
Coordinator-managed dispatches retain their existing retry and escalation behavior. Directly dispatched tasks now become visible failures that can be deliberately retried by the operator.

## Validation
- `node_modules/.bin/vitest.cmd run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts --testNamePattern 'marks a direct dispatch failed'`
- `node_modules/.bin/oxfmt.cmd --check src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts`
- `node_modules/.bin/oxlint.cmd src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts`

The full runtime test file passed 710 tests; 4 unrelated tests assume a POSIX `/tmp` path and fail on this Windows host before exercising this change.

Fixes #8984

## ELI5

A directly dispatched orchestration worker that crashed left the task looking like it was still ready. Those tasks are now marked failed with the exit reason so work doesn’t sit forever.
