### PR TITLE
fix(keybindings): resolve Mod+0 conflict for Focus worktree list (#8584)

### DIFF
--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -242,6 +242,43 @@ describe('keybindings', () => {
     })
   })
 
+  it('keeps zoom reset on Mod+0 and focuses worktree list on a distinct chord', () => {
+    // Why: both actions previously defaulted to Mod+0, so main-process zoom
+    // reset always won and Focus worktree list was unreachable (#8584).
+    for (const platform of ['darwin', 'linux', 'win32'] as const) {
+      expect(getEffectiveKeybindingsForAction('zoom.reset', platform)).toEqual(['Mod+0'])
+      expect(getEffectiveKeybindingsForAction('sidebar.focusWorktreeList', platform)).toEqual([
+        'Mod+Shift+0'
+      ])
+    }
+
+    const zoomResetInput = {
+      key: '0',
+      code: 'Digit0',
+      meta: true,
+      control: false,
+      alt: false,
+      shift: false
+    }
+    const focusListInput = { ...zoomResetInput, shift: true }
+
+    expect(keybindingMatchesAction('zoom.reset', zoomResetInput, 'darwin')).toBe(true)
+    expect(keybindingMatchesAction('sidebar.focusWorktreeList', zoomResetInput, 'darwin')).toBe(
+      false
+    )
+    expect(keybindingMatchesAction('sidebar.focusWorktreeList', focusListInput, 'darwin')).toBe(
+      true
+    )
+    expect(keybindingMatchesAction('zoom.reset', focusListInput, 'darwin')).toBe(false)
+
+    expect(
+      findKeybindingConflicts('darwin', { 'sidebar.focusWorktreeList': ['Mod+0'] })
+    ).toContainEqual({
+      binding: 'Mod+0',
+      actionIds: expect.arrayContaining(['zoom.reset', 'sidebar.focusWorktreeList'])
+    })
+  })
+
   it('reports quick-command menu conflicts with global shortcuts and digit ranges', () => {
     expect(
       findKeybindingConflicts('darwin', {

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -426,7 +426,9 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     group: 'Global',
     scope: 'global',
     searchKeywords: ['shortcut', 'sidebar', 'worktree', 'focus'],
-    defaultBindings: platformBindings(['Mod+0'])
+    // Why: keep zoom.reset on the browser-standard Mod+0; this chord was
+    // unreachable while it shared that default (#8584).
+    defaultBindings: platformBindings(['Mod+Shift+0'])
   },
   {
     id: 'floatingTerminal.toggle',


### PR DESCRIPTION
### Description

`zoom.reset` (“Reset Size”) and `sidebar.focusWorktreeList` (“Focus worktree list”) both shipped with default `Mod+0` on every platform. Main-process window shortcut handling resolves `zoom.reset` first, so Focus worktree list never received its advertised default.

This change:

- Keeps `zoom.reset` on browser-standard `Mod+0` (no zoom regression).
- Moves `sidebar.focusWorktreeList` default to free `Mod+Shift+0`.
- Adds registry/matcher regression coverage so the two actions stay distinct and Settings still flags a user remapping that reintroduces the collision.

Fixes #8584

### Evidence

```text
$ npx vitest run --config config/vitest.config.ts src/shared/keybindings.test.ts
 ✓ src/shared/keybindings.test.ts (61 tests) 14ms
 Test Files  1 passed (1)
      Tests  61 passed (61)
```

Defaults after fix:

- `zoom.reset` → `Mod+0` (darwin/linux/win32)
- `sidebar.focusWorktreeList` → `Mod+Shift+0` (darwin/linux/win32)

### ELI5

Two buttons claimed the same keyboard key (`Cmd/Ctrl+0`). Zoom always won, so “focus the worktree list” never worked. Zoom keeps the usual key; focusing the list now uses `Cmd/Ctrl+Shift+0`.

### User-regression-tradeoffs

Ideally zero for zoom users — `Mod+0` reset is unchanged.

Only users who expected Focus worktree list on `Mod+0` need the new default (`Mod+Shift+0`), or they can rebind it in Settings → Shortcuts. Anyone who already customized either shortcut is unaffected.