### PR TITLE
fix(status-bar): sync Codex rate-limit chip with remaining reset time (#8378)

### DIFF
--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -57,7 +57,7 @@ import {
 } from './tooltip'
 import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
 import { AgentIcon } from '@/lib/agent-catalog'
-import { formatWindowLabel } from '@/lib/window-label-formatter'
+import { formatRateLimitWindowChipLabel } from '@/lib/window-label-formatter'
 import { markLiveCodexSessionsForRestart } from '@/lib/codex-session-restart'
 import { UpdateStatusSegment } from './UpdateStatusSegment'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
@@ -1191,7 +1191,7 @@ export function ProviderSegment({
         {visibleBuckets.length === 0 && p.session && (
           <WindowLabel
             w={p.session}
-            label={formatWindowLabel(p.session.windowMinutes)}
+            label={formatRateLimitWindowChipLabel(p.session)}
             display={display}
           />
         )}
@@ -1205,14 +1205,14 @@ export function ProviderSegment({
       ? {
           key: 'session',
           window: p.session,
-          label: formatWindowLabel(p.session.windowMinutes)
+          label: formatRateLimitWindowChipLabel(p.session)
         }
       : null,
     p.weekly
       ? {
           key: 'weekly',
           window: p.weekly,
-          label: formatWindowLabel(p.weekly.windowMinutes)
+          label: formatRateLimitWindowChipLabel(p.weekly)
         }
       : null,
     p.fableWeekly
@@ -1229,7 +1229,7 @@ export function ProviderSegment({
       ? {
           key: 'monthly',
           window: p.monthly,
-          label: formatWindowLabel(p.monthly.windowMinutes)
+          label: formatRateLimitWindowChipLabel(p.monthly)
         }
       : null
   ].filter((w): w is { key: string; window: RateLimitWindow; label: string } => w !== null)

--- a/src/renderer/src/components/status-bar/provider-segment-monthly-window.test.tsx
+++ b/src/renderer/src/components/status-bar/provider-segment-monthly-window.test.tsx
@@ -22,8 +22,12 @@ vi.mock('../../store', () => ({
     selector({ usagePercentageDisplay: 'used' })
 }))
 
-function windowOf(usedPercent: number, windowMinutes: number): RateLimitWindow {
-  return { usedPercent, windowMinutes, resetsAt: null, resetDescription: null }
+function windowOf(
+  usedPercent: number,
+  windowMinutes: number,
+  resetsAt: number | null = null
+): RateLimitWindow {
+  return { usedPercent, windowMinutes, resetsAt, resetDescription: null }
 }
 
 // Grok unified-billing accounts surface a monthly window and nothing else.
@@ -82,5 +86,35 @@ describe('ProviderSegment monthly window', () => {
     expect(markup).toContain('10% used 5h')
     expect(markup).toContain('20% used wk')
     expect(markup).not.toContain('30d')
+  })
+
+  // Why: #8378 — status-bar chip showed fixed window size ("5h") while the
+  // usage popup showed remaining time for the same resetsAt.
+  it('shows remaining session time on the chip when resetsAt is known (repro-8378)', async () => {
+    const { ProviderSegment } = await import('./StatusBar')
+    const now = 1_700_000_000_000
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(now)
+    const remainingMs = 2 * 60 * 60_000 + 33 * 60_000
+
+    try {
+      const limits: ProviderRateLimits = {
+        provider: 'codex',
+        session: windowOf(42, 300, now + remainingMs),
+        weekly: windowOf(10, 10080, now + 6 * 24 * 60 * 60_000),
+        updatedAt: now,
+        error: null,
+        status: 'ok'
+      }
+      const markup = renderToStaticMarkup(
+        <ProviderSegment p={limits} compact={false} display="used" />
+      )
+
+      expect(markup).toContain('42% used 2h 33m')
+      expect(markup).not.toContain('5h')
+      expect(markup).toContain('10% used 6d')
+      expect(markup).not.toContain('wk')
+    } finally {
+      dateNow.mockRestore()
+    }
   })
 })

--- a/src/renderer/src/lib/window-label-formatter.test.ts
+++ b/src/renderer/src/lib/window-label-formatter.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { formatWindowLabel } from './window-label-formatter'
+import { formatResetCountdown, formatResetDuration } from '../../../shared/rate-limit-reset-format'
+import { formatRateLimitWindowChipLabel, formatWindowLabel } from './window-label-formatter'
+
+const MIN = 60_000
+const HOUR = 60 * MIN
 
 describe('formatWindowLabel', () => {
   it('returns "5h" for 300 minutes', () => {
@@ -53,5 +57,32 @@ describe('formatWindowLabel', () => {
     // render the raw minute count rather than guess at a half-bucket label.
     expect(formatWindowLabel(75)).toBe('75m')
     expect(formatWindowLabel(150)).toBe('150m')
+  })
+})
+
+describe('formatRateLimitWindowChipLabel', () => {
+  // Why: repro for #8378 — Codex session chip said "5h" while the popup said
+  // "Resets in 2h 33m" for the same resetsAt. Both surfaces must share the
+  // remaining-time duration when a reset timestamp is available.
+  it('shows remaining time when resetsAt is known (repro-8378)', () => {
+    const now = 1_700_000_000_000
+    const remainingMs = 2 * HOUR + 33 * MIN
+    const window = { windowMinutes: 300, resetsAt: now + remainingMs }
+
+    expect(formatRateLimitWindowChipLabel(window, now)).toBe('2h 33m')
+    expect(formatRateLimitWindowChipLabel(window, now)).toBe(formatResetDuration(remainingMs))
+    expect(formatResetCountdown(remainingMs)).toBe('Resets in 2h 33m')
+  })
+
+  it('falls back to fixed window size when resetsAt is null', () => {
+    expect(formatRateLimitWindowChipLabel({ windowMinutes: 300, resetsAt: null })).toBe('5h')
+    expect(formatRateLimitWindowChipLabel({ windowMinutes: 10080, resetsAt: null })).toBe('wk')
+  })
+
+  it('reports "now" when the reset timestamp has already passed', () => {
+    const now = 1_700_000_000_000
+    expect(formatRateLimitWindowChipLabel({ windowMinutes: 300, resetsAt: now - MIN }, now)).toBe(
+      'now'
+    )
   })
 })

--- a/src/renderer/src/lib/window-label-formatter.ts
+++ b/src/renderer/src/lib/window-label-formatter.ts
@@ -1,3 +1,5 @@
+import { formatResetDuration } from '../../../shared/rate-limit-reset-format'
+
 /**
  * Returns a short human-readable label for a usage window duration.
  *
@@ -27,4 +29,23 @@ export function formatWindowLabel(windowMinutes: number): string {
     return `${windowMinutes / 60}h`
   }
   return `${windowMinutes}m`
+}
+
+/**
+ * Status-bar chip label for a rate-limit window.
+ *
+ * Why: the popup already shows remaining time via formatResetCountdown
+ * ("Resets in 2h 33m"). The chip used fixed windowMinutes labels ("5h"),
+ * so the same Codex session looked out of sync (#8378). Prefer remaining
+ * duration when resetsAt is known; fall back to the fixed window size only
+ * when no reset timestamp is available.
+ */
+export function formatRateLimitWindowChipLabel(
+  window: { windowMinutes: number; resetsAt: number | null },
+  now: number = Date.now()
+): string {
+  if (window.resetsAt != null) {
+    return formatResetDuration(window.resetsAt - now)
+  }
+  return formatWindowLabel(window.windowMinutes)
 }


### PR DESCRIPTION
## Summary

Status-bar rate-limit chips now show **remaining time until reset** when `resetsAt` is known (e.g. `2h 33m`), matching the usage popup countdown. Fixed window labels (`5h`, `wk`) remain only as a fallback when no reset timestamp is available.

Fixes #8378

### Description

Codex (and other providers) exposed a mismatch between:
- **Usage popup**: `formatResetCountdown` → “Resets in 2h 33m”
- **Status-bar chip**: `formatWindowLabel(windowMinutes)` → “5h” (full window size)

Both surfaces now share remaining-time semantics via `formatResetDuration` when `resetsAt` is present. Chip copy stays compact (`2h 33m`); the popup still prefixes with “Resets in …”.

### Evidence

- Repro unit test: chip with `windowMinutes: 300` and `resetsAt = now + 2h33m` renders `42% used 2h 33m`, not `5h`.
- Formatter unit test pins chip duration = `formatResetDuration` and popup = `Resets in 2h 33m` for the same delta.
- Fallback preserved: `resetsAt: null` still yields `5h` / `wk` / `30d`.

```
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/lib/window-label-formatter.test.ts \
  src/renderer/src/components/status-bar/provider-segment-monthly-window.test.tsx \
  src/shared/rate-limit-reset-format.test.ts \
  src/renderer/src/components/status-bar/tooltip.test.ts
# Test Files  4 passed (4)
# Tests  61 passed (61)
```

### ELI5

The little number in the bottom bar said “this window is 5 hours long,” while the popup said “you have 2 hours 33 minutes left.” They now both talk about **time left**.

### User-regression-tradeoffs

Ideally **zero**: users already expected remaining time (popup was correct; chip was wrong).  
Possible mild surprise only if someone relied on the chip as a static window-size badge (`5h`/`wk`); that fallback still appears when the API omits `resetsAt`. Chip labels can be slightly longer (`2h 33m` vs `5h`).

## Screenshots

No new UI chrome — text change on existing status-bar usage chips (remaining duration instead of fixed window size when reset time is known).

## Testing

- [x] Added/updated unit tests (formatter + ProviderSegment repro-8378)
- [x] `vitest` for rate-limit label / status-bar segment / tooltip suites
- [ ] `pnpm lint` (not run full suite)
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (full suite)
- [ ] `pnpm build`

## AI Review Report

Checked that:
- Chip and popup share `formatResetDuration` / `formatResetCountdown` from the same remaining-ms input.
- Fallback path for missing `resetsAt` still uses fixed window labels.
- Fable continues to use the product name label (not a time label).
- Pure formatting only — no platform-specific shortcuts, paths, shell, or Electron APIs. Safe on macOS/Linux/Windows.

## Security Audit

Display-only change: formats existing numeric timestamps for UI. No new IPC, auth, secrets, command execution, or path handling.

## Notes

Countdown updates on re-render (same as the popup), not a live 1s ticker. Session/weekly/monthly chips all prefer remaining time when `resetsAt` is set.