### PR TITLE
fix(serve): prefer explicit --port over stale WS fallback (#8535)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2119,7 +2119,15 @@ app.whenReady().then(async () => {
     enableWebSocket: true,
     ...(isE2E ? { wsPort: 0 } : {}),
     ...(devWsPort !== undefined ? { wsPort: devWsPort } : {}),
-    ...(serveOptions?.wsPort !== undefined ? { wsPort: serveOptions.wsPort } : {}),
+    ...(serveOptions?.wsPort !== undefined
+      ? {
+          wsPort: serveOptions.wsPort,
+          // Why: only an explicit `orca serve --port` pin prefers the requested
+          // port over a stale STA-1511 fallback (issue #8535). Default 6768 /
+          // dev 6769 keep fallback-first so mobile pairings stay stable.
+          preferPinnedWsPort: true
+        }
+      : {}),
     webClientRoot: getBundledWebClientRoot()
   })
   registerMobileHandlers(runtimeRpc, { getRelayStatus: () => desktopRelayStatus })

--- a/src/main/runtime/rpc/ws-transport.test.ts
+++ b/src/main/runtime/rpc/ws-transport.test.ts
@@ -472,6 +472,43 @@ describe('WebSocketTransport', () => {
       expect(transport.resolvedPort).toBe(fallbackPort)
     })
 
+    it('binds the preferred port first when preferPinnedPort is set and both are free', async () => {
+      // Why: issue #8535 — `orca serve --port <P>` clients dial the pin. A
+      // free but stale mobile-ws-fallback-port.json must not pre-empt it.
+      const preferredPort = await reserveFreePort()
+      const fallbackPort = await reserveFreePort()
+
+      const transport = new WebSocketTransport({
+        host: '127.0.0.1',
+        port: preferredPort,
+        fallbackPort,
+        preferPinnedPort: true
+      })
+      transports.push(transport)
+      await transport.start()
+      expect(transport.resolvedPort).toBe(preferredPort)
+    })
+
+    it('falls back when preferPinnedPort is set but the preferred port is taken', async () => {
+      // Why: explicit pins still degrade to the STA-1511 fallback on
+      // EADDRINUSE so previously-paired mobile devices remain reachable.
+      const preferredHolder = new WebSocketTransport({ host: '127.0.0.1', port: 0 })
+      transports.push(preferredHolder)
+      await preferredHolder.start()
+      const preferredPort = preferredHolder.resolvedPort
+      const fallbackPort = await reserveFreePort()
+
+      const transport = new WebSocketTransport({
+        host: '127.0.0.1',
+        port: preferredPort,
+        fallbackPort,
+        preferPinnedPort: true
+      })
+      transports.push(transport)
+      await transport.start()
+      expect(transport.resolvedPort).toBe(fallbackPort)
+    })
+
     it('binds the preferred port when the persisted fallback is taken', async () => {
       const fallbackHolder = new WebSocketTransport({ host: '127.0.0.1', port: 0 })
       transports.push(fallbackHolder)

--- a/src/main/runtime/rpc/ws-transport.ts
+++ b/src/main/runtime/rpc/ws-transport.ts
@@ -54,6 +54,11 @@ export type WebSocketTransportOptions = {
   // the (now free) preferred port instead would strand those pairings
   // (STA-1511). Callers pass the previously assigned fallback port here.
   fallbackPort?: number
+  // Why: `orca serve --port <P>` clients dial the pinned port. Prefer that port
+  // first (fallback second) so a stale mobile-ws-fallback-port.json cannot
+  // silently steal the pin (issue #8535). Default auto/desktop keeps
+  // fallback-first for STA-1511 pairing stability.
+  preferPinnedPort?: boolean
 }
 
 export class WebSocketTransport implements RpcTransport {
@@ -65,6 +70,7 @@ export class WebSocketTransport implements RpcTransport {
   private readonly preAuthTimeoutMs: number
   private readonly staticRoot: string | undefined
   private readonly fallbackPort: number | undefined
+  private readonly preferPinnedPort: boolean
   private httpServer: HttpsServer | HttpServer | null = null
   private wss: WebSocketServer | null = null
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null
@@ -89,7 +95,8 @@ export class WebSocketTransport implements RpcTransport {
     heartbeatIntervalMs,
     preAuthTimeoutMs,
     staticRoot,
-    fallbackPort
+    fallbackPort,
+    preferPinnedPort
   }: WebSocketTransportOptions) {
     this.host = host
     this.port = port
@@ -99,6 +106,7 @@ export class WebSocketTransport implements RpcTransport {
     this.preAuthTimeoutMs = preAuthTimeoutMs ?? PRE_AUTH_TIMEOUT_MS
     this.staticRoot = staticRoot
     this.fallbackPort = fallbackPort
+    this.preferPinnedPort = preferPinnedPort === true
   }
 
   onMessage(handler: WebSocketMessageHandler): void {
@@ -150,10 +158,12 @@ export class WebSocketTransport implements RpcTransport {
       return
     }
 
-    // Why: a persisted fallback port is bound FIRST — devices paired while it
-    // was active store ws://ip:<fallback> and would be permanently stranded if
-    // a later launch grabbed the (now free) preferred port instead (STA-1511).
-    // Without a persisted fallback the preferred port is tried first. On
+    // Why: default order binds a persisted fallback FIRST — devices paired
+    // while it was active store ws://ip:<fallback> and would be stranded if a
+    // later launch grabbed the (now free) preferred port instead (STA-1511).
+    // Explicit serve --port flips the order so the pinned port wins when free
+    // (issue #8535); fallback remains a secondary candidate for EADDRINUSE.
+    // Without a persisted fallback only the preferred port is tried. On
     // EADDRINUSE each candidate falls through to the next, ending at port 0
     // (OS-assigned) so mobile pairing still works when everything is taken.
     // The QR code reads resolvedPort after start, so it always advertises the
@@ -163,7 +173,11 @@ export class WebSocketTransport implements RpcTransport {
         ? this.fallbackPort
         : undefined
     const candidatePorts =
-      persistedFallbackPort !== undefined ? [persistedFallbackPort, this.port] : [this.port]
+      persistedFallbackPort === undefined
+        ? [this.port]
+        : this.preferPinnedPort
+          ? [this.port, persistedFallbackPort]
+          : [persistedFallbackPort, this.port]
     for (const port of candidatePorts) {
       try {
         await this.tryListen(port)

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -53,6 +53,10 @@ type OrcaRuntimeRpcServerOptions = {
   platform?: NodeJS.Platform
   enableWebSocket?: boolean
   wsPort?: number
+  // Why: true when the caller set an explicit port (e.g. `orca serve --port`).
+  // Distinguishes that pin from the DEFAULT_WS_PORT default so transport bind
+  // order can prefer the pin over a stale STA-1511 fallback (issue #8535).
+  preferPinnedWsPort?: boolean
   webClientRoot?: string
   // Why: test-only overrides for the two time-bound constants below.
   // Production callers must not pass these — defaults are set by the design
@@ -449,6 +453,7 @@ export class OrcaRuntimeRpcServer {
   private readonly platform: NodeJS.Platform
   private readonly enableWebSocket: boolean
   private readonly wsPort: number
+  private readonly preferPinnedWsPort: boolean
   private readonly webClientRoot: string | undefined
   private readonly authToken = randomBytes(24).toString('hex')
   private readonly keepaliveIntervalMs: number
@@ -481,6 +486,7 @@ export class OrcaRuntimeRpcServer {
     platform = process.platform,
     enableWebSocket = false,
     wsPort = DEFAULT_WS_PORT,
+    preferPinnedWsPort = false,
     webClientRoot,
     keepaliveIntervalMs = KEEPALIVE_INTERVAL_MS,
     longPollCap = LONG_POLL_CAP
@@ -492,6 +498,7 @@ export class OrcaRuntimeRpcServer {
     this.platform = platform
     this.enableWebSocket = enableWebSocket
     this.wsPort = wsPort
+    this.preferPinnedWsPort = preferPinnedWsPort
     this.webClientRoot = webClientRoot
     this.keepaliveIntervalMs = keepaliveIntervalMs
     this.longPollCap = longPollCap
@@ -862,10 +869,11 @@ export class OrcaRuntimeRpcServer {
           staticRoot: this.webClientRoot,
           // Why: keep the fallback port stable across restarts so paired
           // devices' stored endpoints stay valid (STA-1511) — the transport
-          // binds a persisted fallback before the preferred port. wsPort 0
-          // means the caller explicitly wants a random port (E2E) — don't
-          // pin it.
-          ...(this.wsPort !== 0 ? { fallbackPort: readWsFallbackPort(this.userDataPath) } : {})
+          // binds a persisted fallback before the preferred port unless the
+          // caller explicitly pinned a port (serve --port). wsPort 0 means
+          // the caller wants a random port (E2E) — don't pin it.
+          ...(this.wsPort !== 0 ? { fallbackPort: readWsFallbackPort(this.userDataPath) } : {}),
+          ...(this.preferPinnedWsPort ? { preferPinnedPort: true } : {})
         })
         const mobileSocketWiring = new MobileSocketWiring({
           deviceRegistry: this.deviceRegistry,


### PR DESCRIPTION
## Summary

Fixes #8535: when `orca serve --port <P>` is set explicitly, bind `<P>` before any port stored in `mobile-ws-fallback-port.json`. Default desktop / auto port paths keep STA-1511 fallback-first binding so existing mobile pairings stay stable.

## Description

`WebSocketTransport.start()` previously always tried `candidatePorts = [persistedFallbackPort, preferredPort]`. After a one-time `EADDRINUSE` on the preferred port, STA-1511 persistence wrote `mobile-ws-fallback-port.json`, and every later launch bound that stale free fallback **instead of** the CLI pin — stranding clients (and health checks) that dial `<P>`.

This change:

- Adds `preferPinnedPort` to `WebSocketTransport` (preferred first, fallback second when set).
- Plumbs `preferPinnedWsPort` from explicit serve CLI (`--serve-port` / `orca serve --port`) through `OrcaRuntimeRpcServer`.
- Leaves default 6768 / dev 6769 / GUI launches on fallback-first (STA-1511).
- Still falls through to the persisted fallback when the pin is busy, and still persists a new fallback when the resolved port diverges.

## Evidence

Focused vitest:

```text
pnpm exec vitest run src/main/runtime/rpc/ws-transport.test.ts src/main/runtime/rpc/ws-fallback-port-store.test.ts
✓ 27 passed (including new preferPinnedPort order tests)
```

New coverage:

- binds preferred first when `preferPinnedPort` is set and both ports free
- falls back when `preferPinnedPort` is set but preferred is taken
- existing STA-1511 “fallback even when preferred free” still asserts default order

## ELI5

If you say “always use door 6768”, Orca should open door 6768 when it’s free — not a sticky note from last time that said “use door 45175 instead”. Phone pairing that *didn’t* pin a door still trusts the sticky note first so old phones keep finding the house.

## User-regression-tradeoffs

| Path | Behavior after this PR |
| --- | --- |
| `orca serve --port <P>` | Pin first. Free pin always wins over stale fallback. If pin is busy, still try fallback then OS port. Clients dialing `<P>` get the pin when free. |
| Default desktop / no `--port` | Unchanged: fallback-first (STA-1511). Paired mobile devices that stored the fallback endpoint stay connected across restarts. |
| `pnpm dev` (6769) | Unchanged: still fallback-first. |

**Tradeoff (explicit pin only):** after a port conflict, mobile devices that only know the *old* fallback may need one re-pair / reconnect if serve later successfully binds the pin again (because we no longer prefer the fallback when free). That is intentional: an explicit pin means operators and health checks own that port. New pairing QR still advertises `resolvedPort`. Default auto path does **not** take this tradeoff.

## Screenshots

No visual change.

## Testing

- [x] Focused vitest: `ws-transport.test.ts`, `ws-fallback-port-store.test.ts` (27 passed)
- [ ] `pnpm lint` (pre-commit oxlint/oxfmt on touched files)
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added/updated high-quality tests that would catch regressions

## AI Review Report

Reviewed for:
- Bind-order regression on STA-1511 (default path still fallback-first).
- Explicit-port distinguishability from `DEFAULT_WS_PORT` (flag, not port equality).
- Error fall-through: preferred non-`EADDRINUSE` still fatal; fallback failures still degrade.
- Cross-platform: listen/`EADDRINUSE`/`EACCES` path is Node HTTP server (macOS/Linux/Windows); no keyboard shortcuts, path separators, or shell changes.

No residual flags after plumbing + tests.

## Security Audit

No new auth, secrets, IPC, or command execution. Only TCP bind candidate order changes when an operator explicitly requests a port. Fallback persistence and E2EE/device-token auth unchanged.

## Notes

- Flag is set only when `serveOptions.wsPort !== undefined` (CLI passed `--serve-port`), not for default 6768 or dev 6769.
- Workaround for unfixed builds remains: delete `mobile-ws-fallback-port.json`.