### PR TITLE
fix(runtime): fail orca file open for missing paths (#8844)

### DIFF
--- a/src/main/runtime/orca-runtime-files.test.ts
+++ b/src/main/runtime/orca-runtime-files.test.ts
@@ -252,6 +252,8 @@ describe('RuntimeFileCommands', () => {
   it('opens text files through the renderer host (inheriting active runtime env)', async () => {
     const openFile = vi.fn()
     const { commands } = createRuntimeFileCommands({ openFile })
+    resolveAuthorizedPathMock.mockResolvedValue('/repo/docs/readme.md')
+    statMock.mockResolvedValue({ isDirectory: () => false })
 
     const result = await commands.openMobileFile('id:wt-1', 'docs/readme.md')
 
@@ -272,6 +274,8 @@ describe('RuntimeFileCommands', () => {
   it('opens previewable images through the renderer host as an image tab', async () => {
     const openFile = vi.fn()
     const { commands } = createRuntimeFileCommands({ openFile })
+    resolveAuthorizedPathMock.mockResolvedValue('/repo/assets/logo.png')
+    statMock.mockResolvedValue({ isDirectory: () => false })
 
     const result = await commands.openMobileFile('id:wt-1', 'assets/logo.png')
 
@@ -296,12 +300,50 @@ describe('RuntimeFileCommands', () => {
     const result = await commands.openMobileFile('id:wt-1', 'dist/bundle.zip')
 
     expect(openFile).not.toHaveBeenCalled()
+    expect(statMock).not.toHaveBeenCalled()
     expect(result).toEqual({
       worktree: 'wt-1',
       relativePath: 'dist/bundle.zip',
       kind: 'binary',
       opened: false
     })
+  })
+
+  it('rejects missing local files without creating an editor tab', async () => {
+    const openFile = vi.fn()
+    const { commands } = createRuntimeFileCommands({ openFile })
+    resolveAuthorizedPathMock.mockResolvedValue('/repo/docs/missing.md')
+    statMock.mockRejectedValue(enoent())
+
+    await expect(commands.openMobileFile('id:wt-1', 'docs/missing.md')).rejects.toThrow(
+      "ENOENT: no such file or directory, open '/repo/docs/missing.md'"
+    )
+    expect(openFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects missing remote files without creating an editor tab', async () => {
+    const openFile = vi.fn()
+    const resolveRuntimeFileTarget = vi.fn(async () => ({
+      worktree: {
+        id: 'wt-1',
+        repoId: 'repo-1',
+        path: '/remote/repo'
+      },
+      connectionId: 'ssh-1'
+    }))
+    const { commands } = createRuntimeFileCommands({
+      openFile,
+      path: '/remote/repo',
+      resolveRuntimeFileTarget
+    })
+    vi.mocked(getSshFilesystemProvider).mockReturnValue({
+      stat: vi.fn().mockRejectedValue(new Error('ENOENT: no such file or directory'))
+    } as never)
+
+    await expect(commands.openMobileFile('id:wt-1', 'docs/missing.md')).rejects.toThrow(
+      "ENOENT: no such file or directory, open '/remote/repo/docs/missing.md'"
+    )
+    expect(openFile).not.toHaveBeenCalled()
   })
 
   it('does not follow symlinks when reading runtime-local file explorer dirs', async () => {

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -441,7 +441,7 @@ export class RuntimeFileCommands {
     worktreeSelector: string,
     relativePath: string
   ): Promise<RuntimeFileOpenResult> {
-    const { worktree } = await this.host.resolveRuntimeFileTarget(worktreeSelector)
+    const { worktree, connectionId } = await this.host.resolveRuntimeFileTarget(worktreeSelector)
     if (!isSafeMobileRelativePath(relativePath)) {
       throw new Error('invalid_relative_path')
     }
@@ -458,6 +458,9 @@ export class RuntimeFileCommands {
       return { worktree: worktree.id, relativePath, kind, opened: false }
     }
     const filePath = joinWorktreeRelativePath(worktree.path, relativePath)
+    // Why: CLI/agents treat opened:true as success. Stat first so missing paths
+    // fail the RPC instead of creating a ghost editor tab that only errors on read.
+    await this.assertMobileOpenTargetExists(filePath, connectionId)
     // Why: the service's internal runtimeId is not a registered runtime env selector
     // (those live in orca-environments.json). Passing it caused Unknown environment
     // errors on content load for CLI-initiated opens (via files.open from orca cli
@@ -466,6 +469,25 @@ export class RuntimeFileCommands {
     // allowing correct routing for local vs remote envs.
     this.host.openFile(worktree.id, filePath, relativePath, undefined)
     return { worktree: worktree.id, relativePath, kind, opened: true }
+  }
+
+  private async assertMobileOpenTargetExists(
+    filePath: string,
+    connectionId?: string
+  ): Promise<void> {
+    try {
+      await (connectionId
+        ? this.statRemoteTerminalPath(filePath, connectionId)
+        : stat(await resolveAuthorizedPath(filePath, this.host.requireStore())))
+    } catch (error) {
+      if (
+        isENOENT(error) ||
+        (connectionId && RuntimeFileCommands.isRemoteNotFoundErrorMessage(error))
+      ) {
+        throw new Error(`ENOENT: no such file or directory, open '${filePath}'`)
+      }
+      throw error
+    }
   }
 
   async openMobileDiff(


### PR DESCRIPTION
### Description

`orca file open <missing-path>` was reporting `ok: true` / `opened: true` and creating a ghost editor tab because `RuntimeFileCommands.openMobileFile` only classified by extension and never checked that the resolved path exists.

This change stats the resolved absolute path (local via authorized path + `stat`, SSH via remote filesystem provider) **before** calling the host `openFile` / returning success. Missing paths throw, so the RPC returns `ok: false` with a nonzero CLI exit and **no** tab is created. Existing files still open as before.

Fixes #8844.

### Evidence

- Unit tests in `src/main/runtime/orca-runtime-files.test.ts`:
  - existing local text/image open paths still call `openFile` and return `opened: true` (with successful stat mocks)
  - missing local path rejects with `ENOENT: no such file or directory, open '…'` and never calls `openFile`
  - missing remote (SSH) path rejects the same way and never calls `openFile`
  - non-previewable binaries still short-circuit with `opened: false` without statting
- `npx vitest run src/main/runtime/orca-runtime-files.test.ts` — 71 passed
- `npx vitest run src/main/runtime/rpc/methods/files.test.ts` — 40 passed
- Did **not** run live `orca file open` on missing paths (avoids ghost tabs in the user’s UI during development)

### ELI5

When you ask Orca to open a file that isn’t there, it used to smile and open an empty broken tab anyway. Now it checks “does this file actually exist?” first. If no, it says “nope” right away and doesn’t open a tab.

### User-regression-tradeoffs

Ideally zero: only changes false-success on missing paths to true-failure. Existing files keep the same success path. Binary “not openable on mobile” behavior is unchanged. `files.openDiff` is intentionally untouched (deleted/changed files can still be viewed as diffs).

## Screenshots

No visual change (CLI/RPC error path only).

## Testing

- [x] Added unit tests for missing local/remote open targets
- [x] `npx vitest run src/main/runtime/orca-runtime-files.test.ts`
- [x] `npx vitest run src/main/runtime/rpc/methods/files.test.ts`
- [ ] Full `pnpm lint` / `pnpm typecheck` / `pnpm test` / `pnpm build` not run in this focused fix (pre-commit oxlint + oxfmt passed on touched files)

## AI Review Report

Self-reviewed for:
- Cross-platform path joining via existing `joinWorktreeRelativePath`
- Local vs SSH existence checks reusing the same stat helpers as terminal path resolution
- Not creating tabs on failure (`openFile` only after successful existence assert)
- No hard-coded Meta/Ctrl shortcuts or platform-specific UI labels (N/A)

## Security Audit

- Existence check goes through `resolveAuthorizedPath` for local paths (same authorization boundary as other runtime file IO).
- Remote path uses the existing SSH filesystem provider bound to the worktree’s `connectionId`.
- No new command execution, secrets handling, or IPC surface; only an extra pre-open stat on an already-resolved worktree-relative path.

## Notes

- Error surfaces as `runtime_error` with message `ENOENT: no such file or directory, open '<abs-path>'` (matches existing plain-`Error` → `runtime_error` mapping; not added to the passthrough code allowlist).
- SSH use case covered via remote not-found message matching used elsewhere in this module.