### PR TITLE
fix(keybindings): resolve Cmd+Shift+E collision on macOS (#8533)

### DIFF
--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -717,6 +717,41 @@ describe('keybindings', () => {
     ).toBe(true)
   })
 
+  // Why: #8533 — both previously defaulted to Mod+Shift+E on darwin; emulator won.
+  it('keeps explorer on Mod+Shift+E and gives the mobile emulator a non-colliding macOS default', () => {
+    expect(getEffectiveKeybindingsForAction('sidebar.explorer.toggle', 'darwin')).toEqual([
+      'Mod+Shift+E'
+    ])
+    expect(getEffectiveKeybindingsForAction('tab.newSimulator', 'darwin')).toEqual([
+      'Mod+Alt+Shift+E'
+    ])
+    expect(getEffectiveKeybindingsForAction('tab.newSimulator', 'linux')).toEqual([])
+    expect(getEffectiveKeybindingsForAction('tab.newSimulator', 'win32')).toEqual([])
+    expect(formatKeybindingList(['Mod+Alt+Shift+E'], 'darwin')).toBe('⌘⌥⇧E')
+
+    expect(
+      keybindingMatchesAction(
+        'sidebar.explorer.toggle',
+        { key: 'e', code: 'KeyE', meta: true, control: false, alt: false, shift: true },
+        'darwin'
+      )
+    ).toBe(true)
+    expect(
+      keybindingMatchesAction(
+        'tab.newSimulator',
+        { key: 'e', code: 'KeyE', meta: true, control: false, alt: false, shift: true },
+        'darwin'
+      )
+    ).toBe(false)
+    expect(
+      keybindingMatchesAction(
+        'tab.newSimulator',
+        { key: 'e', code: 'KeyE', meta: true, control: false, alt: true, shift: true },
+        'darwin'
+      )
+    ).toBe(true)
+  })
+
   it('defines an unassigned per-agent tab action for every TUI agent', () => {
     for (const agent of ALL_TUI_AGENTS) {
       const actionId = agentTabActionId(agent)

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -567,8 +567,10 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     group: 'Tabs',
     scope: 'tabs',
     searchKeywords: ['shortcut', 'tab', 'simulator', 'emulator', 'mobile', 'ios', 'new'],
+    // Why: keep explorer on Mod+Shift+E (VS Code muscle memory). Emulator is
+    // macOS-only and less common, so it yields to a free chord (#8533).
     defaultBindings: {
-      darwin: ['Mod+Shift+E'],
+      darwin: ['Mod+Alt+Shift+E'],
       linux: [],
       win32: []
     }


### PR DESCRIPTION
### Description

On macOS, `tab.newSimulator` and `sidebar.explorer.toggle` both defaulted to `Mod+Shift+E`. Runtime handlers for the mobile emulator consumed the chord first, so **Show Explorer** never fired despite Settings listing `Cmd+Shift+E` for it.

This change keeps Explorer on `Mod+Shift+E` (VS Code muscle memory) and moves the macOS-only mobile emulator default to `Mod+Alt+Shift+E`. Linux/Windows remain unbound for the emulator (unchanged).

Fixes #8533

### Evidence

**Bug proven (defaults in source before fix):**
| Action | darwin default |
|--------|----------------|
| `sidebar.explorer.toggle` | `Mod+Shift+E` |
| `tab.newSimulator` | `Mod+Shift+E` |

`findKeybindingConflicts()` only reports conflicts involving *customized* overrides, so this default-vs-default collision was silent.

**After fix:**
| Action | darwin default |
|--------|----------------|
| `sidebar.explorer.toggle` | `Mod+Shift+E` |
| `tab.newSimulator` | `Mod+Alt+Shift+E` |

**Verified:**
```bash
pnpm exec vitest run src/shared/keybindings.test.ts
# ✓ 61 tests passed
```

Regression test asserts Explorer still matches `Mod+Shift+E`, emulator does not, and emulator matches `Mod+Alt+Shift+E` only on darwin.

### ELI5

Two buttons were sharing the same keyboard shortcut on Mac, so only one of them worked. We left the common Explorer shortcut alone and gave the mobile emulator its own slightly different shortcut.

### User-regression-tradeoffs

- **Explorer (`Cmd+Shift+E`)**: no change — preferred VS Code-compatible binding kept.
- **Mobile emulator (macOS only)**: default moves from `Cmd+Shift+E` → `Cmd+Option+Shift+E`. Users who memorized the old emulator default need to relearn or rebind in Settings. Preferable to remapping Explorer because emulator is newer/less used and macOS-only.