### PR TITLE
fix(relay): resolve non-interactive agent binaries via login-shell PATH fallback

### DIFF
--- a/src/relay/agent-exec-handler-posix-login-shell.test.ts
+++ b/src/relay/agent-exec-handler-posix-login-shell.test.ts
@@ -1,0 +1,163 @@
+import { exec, spawn } from 'node:child_process'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ChildProcess from 'node:child_process'
+import {
+  createFakeChild,
+  createHandlers,
+  requestContext,
+  withPlatform
+} from './agent-exec-handler-test-harness'
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof ChildProcess>()
+  return {
+    ...actual,
+    exec: vi.fn(),
+    spawn: vi.fn()
+  }
+})
+
+const spawnMock = vi.mocked(spawn)
+const execMock = vi.mocked(exec)
+
+describe('AgentExecHandler POSIX login-shell PATH fallback', () => {
+  beforeEach(() => {
+    spawnMock.mockReset()
+    execMock.mockReset()
+  })
+
+  it('retries a bare binary through the login shell after a direct ENOENT spawn failure', async () => {
+    await withPlatform('linux', async () => {
+      const directAttempt = createFakeChild()
+      const loginShellLookup = createFakeChild()
+      const resolvedRetry = createFakeChild()
+      spawnMock
+        .mockReturnValueOnce(directAttempt as never)
+        .mockReturnValueOnce(loginShellLookup as never)
+        .mockReturnValueOnce(resolvedRetry as never)
+      const handlers = createHandlers()
+
+      const pending = handlers.get('agent.execNonInteractive')!(
+        {
+          binary: 'opencode',
+          args: ['run'],
+          cwd: '/repo',
+          stdin: 'PROMPT',
+          timeoutMs: 5_000,
+          env: { SHELL: '/bin/zsh' }
+        },
+        requestContext()
+      )
+
+      directAttempt.emit(
+        'error',
+        Object.assign(new Error('spawn opencode ENOENT'), { code: 'ENOENT' })
+      )
+      // Why: the login-shell lookup resolves via a real Promise, so its .then()
+      // continuation (which spawns the retry) lands on a later microtask —
+      // wait for each spawn to actually happen before driving its fake child.
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2))
+      loginShellLookup.stdout.emit('data', Buffer.from('/home/user/.local/bin/opencode\n'))
+      loginShellLookup.emit('close', 0)
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(3))
+      resolvedRetry.stdout.emit('data', Buffer.from('hello'))
+      resolvedRetry.emit('close', 0)
+
+      await expect(pending).resolves.toEqual({
+        stdout: 'hello',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+        canceled: false
+      })
+
+      expect(spawnMock).toHaveBeenNthCalledWith(
+        2,
+        '/bin/zsh',
+        ['-lc', "command -v 'opencode'"],
+        expect.objectContaining({ stdio: ['ignore', 'pipe', 'ignore'] })
+      )
+      expect(spawnMock).toHaveBeenNthCalledWith(
+        3,
+        '/home/user/.local/bin/opencode',
+        ['run'],
+        expect.objectContaining({
+          cwd: '/repo',
+          stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true
+        })
+      )
+      expect(resolvedRetry.stdin.end).toHaveBeenCalledWith('PROMPT')
+    })
+  })
+
+  it('reports the original ENOENT error when the login shell cannot resolve the binary either', async () => {
+    await withPlatform('linux', async () => {
+      const directAttempt = createFakeChild()
+      const loginShellLookup = createFakeChild()
+      spawnMock
+        .mockReturnValueOnce(directAttempt as never)
+        .mockReturnValueOnce(loginShellLookup as never)
+      const handlers = createHandlers()
+
+      const pending = handlers.get('agent.execNonInteractive')!(
+        {
+          binary: 'opencode',
+          args: ['run'],
+          cwd: '/repo',
+          stdin: null,
+          timeoutMs: 5_000
+        },
+        requestContext()
+      )
+
+      directAttempt.emit(
+        'error',
+        Object.assign(new Error('spawn opencode ENOENT'), { code: 'ENOENT' })
+      )
+      loginShellLookup.emit('close', 1)
+
+      await expect(pending).resolves.toEqual({
+        stdout: '',
+        stderr: '',
+        exitCode: null,
+        timedOut: false,
+        spawnError: 'spawn opencode ENOENT'
+      })
+      expect(spawnMock).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('does not attempt the login-shell fallback for an absolute-path binary', async () => {
+    await withPlatform('linux', async () => {
+      const directAttempt = createFakeChild()
+      spawnMock.mockReturnValueOnce(directAttempt as never)
+      const handlers = createHandlers()
+
+      const pending = handlers.get('agent.execNonInteractive')!(
+        {
+          binary: '/opt/tools/opencode',
+          args: ['run'],
+          cwd: '/repo',
+          stdin: null,
+          timeoutMs: 5_000
+        },
+        requestContext()
+      )
+
+      directAttempt.emit(
+        'error',
+        Object.assign(new Error('spawn /opt/tools/opencode ENOENT'), { code: 'ENOENT' })
+      )
+
+      await expect(pending).resolves.toEqual({
+        stdout: '',
+        stderr: '',
+        exitCode: null,
+        timedOut: false,
+        spawnError: 'spawn /opt/tools/opencode ENOENT'
+      })
+      expect(spawnMock).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/relay/agent-exec-handler-posix-login-shell.test.ts
+++ b/src/relay/agent-exec-handler-posix-login-shell.test.ts
@@ -370,4 +370,88 @@ describe('AgentExecHandler POSIX login-shell PATH fallback', () => {
       expect(loginShellLookup.kill).toHaveBeenCalledWith('SIGKILL')
     })
   })
+
+  it('asks the login shell from the requested execution directory', async () => {
+    await withPlatform('linux', async () => {
+      const directAttempt = createFakeChild()
+      const loginShellLookup = createFakeChild()
+      const resolvedRetry = createFakeChild()
+      spawnMock
+        .mockReturnValueOnce(directAttempt as never)
+        .mockReturnValueOnce(loginShellLookup as never)
+        .mockReturnValueOnce(resolvedRetry as never)
+      const handlers = createHandlers()
+
+      const pending = handlers.get('agent.execNonInteractive')!(
+        {
+          binary: 'opencode',
+          args: [],
+          cwd: '/repo/packages/api',
+          stdin: null,
+          timeoutMs: 5_000
+        },
+        requestContext()
+      )
+
+      directAttempt.emit(
+        'error',
+        Object.assign(new Error('spawn opencode ENOENT'), { code: 'ENOENT' })
+      )
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2))
+      loginShellLookup.stdout.emit(
+        'data',
+        Buffer.from('/repo/packages/api/node_modules/.bin/opencode\n')
+      )
+      loginShellLookup.emit('close', 0)
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(3))
+      resolvedRetry.emit('close', 0)
+      await pending
+
+      // A login profile can answer per directory (direnv, .nvmrc), so the
+      // lookup has to run where the retry will.
+      const lookupOptions = spawnMock.mock.calls[1]?.[2] as { cwd?: string }
+      expect(lookupOptions.cwd).toBe('/repo/packages/api')
+    })
+  })
+
+  it('signals the whole lookup process group, not just the shell', async () => {
+    await withPlatform('linux', async () => {
+      const directAttempt = createFakeChild()
+      const loginShellLookup = createFakeChild()
+      spawnMock
+        .mockReturnValueOnce(directAttempt as never)
+        .mockReturnValueOnce(loginShellLookup as never)
+      const handlers = createHandlers()
+      const controller = new AbortController()
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as never)
+
+      try {
+        const pending = handlers.get('agent.execNonInteractive')!(
+          {
+            binary: 'opencode',
+            args: [],
+            cwd: '/repo',
+            stdin: null,
+            timeoutMs: 5_000
+          },
+          { ...requestContext(), signal: controller.signal }
+        )
+
+        directAttempt.emit(
+          'error',
+          Object.assign(new Error('spawn opencode ENOENT'), { code: 'ENOENT' })
+        )
+        await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2))
+        controller.abort()
+        await pending
+
+        // detached: true makes the shell a group leader; the negative pid is
+        // what reaches anything its profile backgrounded.
+        expect(spawnMock.mock.calls[1]?.[2]).toMatchObject({ detached: true })
+        expect(killSpy).toHaveBeenCalledWith(-loginShellLookup.pid, 'SIGKILL')
+      } finally {
+        killSpy.mockRestore()
+      }
+    })
+  })
 })

--- a/src/relay/agent-exec-handler-posix-login-shell.test.ts
+++ b/src/relay/agent-exec-handler-posix-login-shell.test.ts
@@ -160,4 +160,214 @@ describe('AgentExecHandler POSIX login-shell PATH fallback', () => {
       expect(spawnMock).toHaveBeenCalledTimes(1)
     })
   })
+
+  it('runs the login-shell lookup with the execution environment, not the relay PATH', async () => {
+    await withPlatform('linux', async () => {
+      const directAttempt = createFakeChild()
+      const loginShellLookup = createFakeChild()
+      const resolvedRetry = createFakeChild()
+      spawnMock
+        .mockReturnValueOnce(directAttempt as never)
+        .mockReturnValueOnce(loginShellLookup as never)
+        .mockReturnValueOnce(resolvedRetry as never)
+      const handlers = createHandlers()
+
+      const pending = handlers.get('agent.execNonInteractive')!(
+        {
+          binary: 'opencode',
+          args: [],
+          cwd: '/repo',
+          stdin: null,
+          timeoutMs: 5_000,
+          env: { SHELL: '/bin/zsh', PATH: '/opt/agents/bin' }
+        },
+        requestContext()
+      )
+
+      directAttempt.emit(
+        'error',
+        Object.assign(new Error('spawn opencode ENOENT'), { code: 'ENOENT' })
+      )
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2))
+      loginShellLookup.stdout.emit('data', Buffer.from('/opt/agents/bin/opencode\n'))
+      loginShellLookup.emit('close', 0)
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(3))
+      resolvedRetry.emit('close', 0)
+      await pending
+
+      // The lookup answers for whichever PATH it runs under, so it has to run
+      // under the same env as the retry exec.
+      const lookupOptions = spawnMock.mock.calls[1]?.[2] as { env?: NodeJS.ProcessEnv }
+      const retryOptions = spawnMock.mock.calls[2]?.[2] as { env?: NodeJS.ProcessEnv }
+      expect(lookupOptions.env).toBeDefined()
+      expect(lookupOptions.env?.PATH).toBe('/opt/agents/bin')
+      expect(lookupOptions.env).toEqual(retryOptions.env)
+    })
+  })
+
+  it('takes the resolved path from the last line when a login profile prints first', async () => {
+    await withPlatform('linux', async () => {
+      const directAttempt = createFakeChild()
+      const loginShellLookup = createFakeChild()
+      const resolvedRetry = createFakeChild()
+      spawnMock
+        .mockReturnValueOnce(directAttempt as never)
+        .mockReturnValueOnce(loginShellLookup as never)
+        .mockReturnValueOnce(resolvedRetry as never)
+      const handlers = createHandlers()
+
+      const pending = handlers.get('agent.execNonInteractive')!(
+        {
+          binary: 'opencode',
+          args: [],
+          cwd: '/repo',
+          stdin: null,
+          timeoutMs: 5_000
+        },
+        requestContext()
+      )
+
+      directAttempt.emit(
+        'error',
+        Object.assign(new Error('spawn opencode ENOENT'), { code: 'ENOENT' })
+      )
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2))
+      // A profile that greets on login lands ahead of `command -v`'s answer.
+      loginShellLookup.stdout.emit(
+        'data',
+        Buffer.from('Welcome to build-box 3\nnvm: using v22.23.2\n/home/user/.local/bin/opencode\n')
+      )
+      loginShellLookup.emit('close', 0)
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(3))
+      resolvedRetry.emit('close', 0)
+      await pending
+
+      expect(spawnMock).toHaveBeenNthCalledWith(
+        3,
+        '/home/user/.local/bin/opencode',
+        [],
+        expect.anything()
+      )
+    })
+  })
+
+  it('refuses a lookup result that is not an absolute path', async () => {
+    await withPlatform('linux', async () => {
+      const directAttempt = createFakeChild()
+      const loginShellLookup = createFakeChild()
+      spawnMock
+        .mockReturnValueOnce(directAttempt as never)
+        .mockReturnValueOnce(loginShellLookup as never)
+      const handlers = createHandlers()
+
+      const pending = handlers.get('agent.execNonInteractive')!(
+        {
+          binary: 'opencode',
+          args: [],
+          cwd: '/repo',
+          stdin: null,
+          timeoutMs: 5_000
+        },
+        requestContext()
+      )
+
+      directAttempt.emit(
+        'error',
+        Object.assign(new Error('spawn opencode ENOENT'), { code: 'ENOENT' })
+      )
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2))
+      // What `command -v` prints for an alias — spawning this would run the
+      // literal text as a binary name.
+      loginShellLookup.stdout.emit('data', Buffer.from("alias opencode='opencode --oneshot'\n"))
+      loginShellLookup.emit('close', 0)
+
+      await expect(pending).resolves.toEqual({
+        stdout: '',
+        stderr: '',
+        exitCode: null,
+        timedOut: false,
+        spawnError: 'spawn opencode ENOENT'
+      })
+      expect(spawnMock).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('kills the lookup and gives up once it has printed more than it should', async () => {
+    await withPlatform('linux', async () => {
+      const directAttempt = createFakeChild()
+      const loginShellLookup = createFakeChild()
+      spawnMock
+        .mockReturnValueOnce(directAttempt as never)
+        .mockReturnValueOnce(loginShellLookup as never)
+      const handlers = createHandlers()
+
+      const pending = handlers.get('agent.execNonInteractive')!(
+        {
+          binary: 'opencode',
+          args: [],
+          cwd: '/repo',
+          stdin: null,
+          timeoutMs: 5_000
+        },
+        requestContext()
+      )
+
+      directAttempt.emit(
+        'error',
+        Object.assign(new Error('spawn opencode ENOENT'), { code: 'ENOENT' })
+      )
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2))
+      loginShellLookup.stdout.emit('data', Buffer.from('x'.repeat(64 * 1024 + 1)))
+
+      await expect(pending).resolves.toEqual({
+        stdout: '',
+        stderr: '',
+        exitCode: null,
+        timedOut: false,
+        spawnError: 'spawn opencode ENOENT'
+      })
+      expect(loginShellLookup.kill).toHaveBeenCalledWith('SIGKILL')
+    })
+  })
+
+  it('cancels the lookup instead of waiting for it when the request aborts', async () => {
+    await withPlatform('linux', async () => {
+      const directAttempt = createFakeChild()
+      const loginShellLookup = createFakeChild()
+      spawnMock
+        .mockReturnValueOnce(directAttempt as never)
+        .mockReturnValueOnce(loginShellLookup as never)
+      const handlers = createHandlers()
+      const controller = new AbortController()
+
+      const pending = handlers.get('agent.execNonInteractive')!(
+        {
+          binary: 'opencode',
+          args: [],
+          cwd: '/repo',
+          stdin: null,
+          timeoutMs: 5_000
+        },
+        { ...requestContext(), signal: controller.signal }
+      )
+
+      directAttempt.emit(
+        'error',
+        Object.assign(new Error('spawn opencode ENOENT'), { code: 'ENOENT' })
+      )
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2))
+      // The lookup never answers. Without cancellation reaching it, this exec
+      // sits here until the resolver's own five-second timer fires.
+      controller.abort()
+
+      await expect(pending).resolves.toEqual({
+        stdout: '',
+        stderr: '',
+        exitCode: null,
+        timedOut: false,
+        canceled: true
+      })
+      expect(loginShellLookup.kill).toHaveBeenCalledWith('SIGKILL')
+    })
+  })
 })

--- a/src/relay/agent-exec-handler.test.ts
+++ b/src/relay/agent-exec-handler.test.ts
@@ -332,7 +332,9 @@ describe('AgentExecHandler', () => {
     })
     expect(child.stdout.listenerCount('data')).toBe(0)
     expect(child.stderr.listenerCount('data')).toBe(0)
-    expect(child.listenerCount('error')).toBe(0)
+    // Why 1, not 0: a no-op replaces the real error listener so a late 'error'
+    // on this now-irrelevant child can't crash the relay as an uncaught exception.
+    expect(child.listenerCount('error')).toBe(1)
     expect(child.listenerCount('close')).toBe(0)
   })
 
@@ -449,7 +451,9 @@ describe('AgentExecHandler', () => {
       }
       expect(child.stdout.listenerCount('data')).toBe(0)
       expect(child.stderr.listenerCount('data')).toBe(0)
-      expect(child.listenerCount('error')).toBe(0)
+      // Why 1, not 0: a no-op replaces the real error listener so a late 'error'
+      // on this now-irrelevant child can't crash the relay as an uncaught exception.
+      expect(child.listenerCount('error')).toBe(1)
       expect(child.listenerCount('close')).toBe(0)
     } finally {
       vi.useRealTimers()

--- a/src/relay/agent-exec-handler.ts
+++ b/src/relay/agent-exec-handler.ts
@@ -209,6 +209,9 @@ export class AgentExecHandler {
           child.stdout?.off('data', onStdoutData)
           child.stderr?.off('data', onStderrData)
           child.off('error', onError)
+          // Why: a late 'error' after we've stopped caring (timeout/cancel/retry)
+          // would otherwise have zero listeners and crash the relay process.
+          child.on('error', () => {})
           child.off('close', onClose)
         }
         if (entry) {

--- a/src/relay/agent-exec-handler.ts
+++ b/src/relay/agent-exec-handler.ts
@@ -1,71 +1,18 @@
 import { spawn, type ChildProcess } from 'node:child_process'
-import { existsSync } from 'node:fs'
-import { delimiter, join } from 'node:path'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
 import { applyTerminalGitCredentialPromptGuard } from '../shared/terminal-git-credential-guard'
 import { mergeGitConfigEnvProtocol } from '../shared/git-credential-prompt-env'
 import { terminateRelaySubprocessTree } from './subprocess-tree-termination'
+import {
+  isBareBinaryName,
+  isEnoentSpawnError,
+  resolvePosixBinaryViaLoginShell
+} from './agent-exec-posix-login-shell-resolve'
+import { getWindowsSafeSpawn } from './agent-exec-windows-safe-spawn'
 
 const DEFAULT_TIMEOUT_MS = 60_000
 const MAX_TIMEOUT_MS = 5 * 60 * 1000
 const MAX_OUTPUT_BYTES = 4 * 1024 * 1024
-const WINDOWS_BATCH_UNSAFE_ARGUMENTS_ERROR = 'UNSAFE_WINDOWS_BATCH_ARGUMENTS'
-
-function getCmdExePath(): string {
-  return process.env.ComSpec || `${process.env.SystemRoot ?? 'C:\\Windows'}\\System32\\cmd.exe`
-}
-
-function isWindowsBatchScript(commandPath: string): boolean {
-  return process.platform === 'win32' && /\.(cmd|bat)$/i.test(commandPath)
-}
-
-function hasUnsafeWindowsBatchSyntax(value: string): boolean {
-  return /[&|<>^"%!\r\n]/.test(value)
-}
-
-function quoteWindowsBatchToken(value: string): string {
-  if (hasUnsafeWindowsBatchSyntax(value)) {
-    throw new Error(WINDOWS_BATCH_UNSAFE_ARGUMENTS_ERROR)
-  }
-  return `"${value}"`
-}
-
-function resolveWindowsCommand(binary: string, env: NodeJS.ProcessEnv): string {
-  if (process.platform !== 'win32') {
-    return binary
-  }
-  if (/[\\/]/.test(binary) || /\.[a-z0-9]+$/i.test(binary)) {
-    return binary
-  }
-
-  const pathEnv = env.PATH ?? env.Path
-  if (!pathEnv) {
-    return binary
-  }
-  const names = [`${binary}.cmd`, `${binary}.exe`, `${binary}.bat`, binary]
-  for (const directory of pathEnv.split(delimiter).filter(Boolean)) {
-    for (const name of names) {
-      const candidate = join(directory, name)
-      if (existsSync(candidate)) {
-        return candidate
-      }
-    }
-  }
-  return binary
-}
-
-function getWindowsSafeSpawn(
-  binary: string,
-  args: string[],
-  env: NodeJS.ProcessEnv
-): { spawnCmd: string; spawnArgs: string[] } {
-  const resolvedBinary = resolveWindowsCommand(binary, env)
-  if (!isWindowsBatchScript(resolvedBinary)) {
-    return { spawnCmd: resolvedBinary, spawnArgs: args }
-  }
-  const commandLine = [resolvedBinary, ...args].map(quoteWindowsBatchToken).join(' ')
-  return { spawnCmd: getCmdExePath(), spawnArgs: ['/d', '/s', '/c', commandLine] }
-}
 
 type ExecParams = {
   binary: unknown
@@ -160,15 +107,17 @@ export class AgentExecHandler {
     })
 
     return new Promise<ExecResult>((resolve) => {
-      let child
-      try {
-        const { spawnCmd, spawnArgs } = getWindowsSafeSpawn(binary, args, spawnEnv)
-        child = spawn(spawnCmd, spawnArgs, {
+      let child: ChildProcess
+      const spawnChild = (spawnCmd: string, spawnArgs: string[]): ChildProcess =>
+        spawn(spawnCmd, spawnArgs, {
           cwd,
           env: spawnEnv,
           stdio: ['pipe', 'pipe', 'pipe'],
           windowsHide: true
         })
+      try {
+        const { spawnCmd, spawnArgs } = getWindowsSafeSpawn(binary, args, spawnEnv)
+        child = spawnChild(spawnCmd, spawnArgs)
       } catch (error) {
         resolve({
           stdout: '',
@@ -187,6 +136,7 @@ export class AgentExecHandler {
       let timedOut = false
       let canceled = false
       let settled = false
+      let attemptedLoginShellFallback = false
       const laneKey = typeof cwd === 'string' ? this.laneKey(cwd, params.operation) : ''
       let entry: InFlightExec | null = null
       let timer: ReturnType<typeof setTimeout> | null = null
@@ -250,28 +200,69 @@ export class AgentExecHandler {
         }
         stderr += chunk.toString('utf-8')
       }
+      const wireChild = (): void => {
+        child.stdout?.on('data', onStdoutData)
+        child.stderr?.on('data', onStderrData)
+        child.on('error', onError)
+        child.on('close', onClose)
+        detachChildListeners = () => {
+          child.stdout?.off('data', onStdoutData)
+          child.stderr?.off('data', onStderrData)
+          child.off('error', onError)
+          child.off('close', onClose)
+        }
+        if (entry) {
+          entry.child = child
+        }
+        if (stdinPayload !== null) {
+          child.stdin?.end(stdinPayload)
+        } else {
+          child.stdin?.end()
+        }
+      }
       const onError = (error: Error): void => {
-        finish({
-          stdout,
-          stderr,
-          exitCode: null,
-          timedOut,
-          spawnError: error.message
+        const canRetryViaLoginShell =
+          !attemptedLoginShellFallback &&
+          process.platform !== 'win32' &&
+          isBareBinaryName(binary) &&
+          isEnoentSpawnError(error)
+        if (!canRetryViaLoginShell) {
+          finish({ stdout, stderr, exitCode: null, timedOut, spawnError: error.message })
+          return
+        }
+        attemptedLoginShellFallback = true
+        detachChildListeners()
+        void resolvePosixBinaryViaLoginShell(binary, spawnEnv).then((resolvedPath) => {
+          if (settled) {
+            return
+          }
+          if (canceled) {
+            finish({ stdout, stderr, exitCode: null, timedOut, canceled })
+            return
+          }
+          if (!resolvedPath) {
+            finish({ stdout, stderr, exitCode: null, timedOut, spawnError: error.message })
+            return
+          }
+          try {
+            child = spawnChild(resolvedPath, args)
+          } catch (retryError) {
+            finish({
+              stdout,
+              stderr,
+              exitCode: null,
+              timedOut,
+              spawnError: retryError instanceof Error ? retryError.message : String(retryError)
+            })
+            return
+          }
+          wireChild()
         })
       }
       const onClose = (code: number | null): void => {
         finish({ stdout, stderr, exitCode: code, timedOut, canceled })
       }
-      child.stdout?.on('data', onStdoutData)
-      child.stderr?.on('data', onStderrData)
-      child.on('error', onError)
-      child.on('close', onClose)
-      detachChildListeners = () => {
-        child.stdout?.off('data', onStdoutData)
-        child.stderr?.off('data', onStderrData)
-        child.off('error', onError)
-        child.off('close', onClose)
-      }
+      wireChild()
 
       if (context?.signal) {
         if (context.signal.aborted) {
@@ -282,12 +273,6 @@ export class AgentExecHandler {
             context.signal?.removeEventListener('abort', cancelCurrent)
           }
         }
-      }
-
-      if (stdinPayload !== null) {
-        child.stdin?.end(stdinPayload)
-      } else {
-        child.stdin?.end()
       }
     })
   }

--- a/src/relay/agent-exec-handler.ts
+++ b/src/relay/agent-exec-handler.ts
@@ -241,34 +241,35 @@ export class AgentExecHandler {
         }
         attemptedLoginShellFallback = true
         detachChildListeners()
-        void resolvePosixBinaryViaLoginShell(binary, spawnEnv, lookupAbort.signal).then(
-          (resolvedPath) => {
-            if (settled) {
-              return
-            }
-            if (canceled) {
-              finish({ stdout, stderr, exitCode: null, timedOut, canceled })
-              return
-            }
-            if (!resolvedPath) {
-              finish({ stdout, stderr, exitCode: null, timedOut, spawnError: error.message })
-              return
-            }
-            try {
-              child = spawnChild(resolvedPath, args)
-            } catch (retryError) {
-              finish({
-                stdout,
-                stderr,
-                exitCode: null,
-                timedOut,
-                spawnError: retryError instanceof Error ? retryError.message : String(retryError)
-              })
-              return
-            }
-            wireChild()
+        void resolvePosixBinaryViaLoginShell(binary, spawnEnv, {
+          cwd,
+          signal: lookupAbort.signal
+        }).then((resolvedPath) => {
+          if (settled) {
+            return
           }
-        )
+          if (canceled) {
+            finish({ stdout, stderr, exitCode: null, timedOut, canceled })
+            return
+          }
+          if (!resolvedPath) {
+            finish({ stdout, stderr, exitCode: null, timedOut, spawnError: error.message })
+            return
+          }
+          try {
+            child = spawnChild(resolvedPath, args)
+          } catch (retryError) {
+            finish({
+              stdout,
+              stderr,
+              exitCode: null,
+              timedOut,
+              spawnError: retryError instanceof Error ? retryError.message : String(retryError)
+            })
+            return
+          }
+          wireChild()
+        })
       }
       const onClose = (code: number | null): void => {
         finish({ stdout, stderr, exitCode: code, timedOut, canceled })

--- a/src/relay/agent-exec-handler.ts
+++ b/src/relay/agent-exec-handler.ts
@@ -158,8 +158,13 @@ export class AgentExecHandler {
         }
         resolve(result)
       }
+      // Why: the login-shell lookup runs a shell of its own, outside the child
+      // tree terminated here. Cancel and timeout have to reach it too, or a
+      // canceled exec waits on it and a timed-out one leaves it running.
+      const lookupAbort = new AbortController()
       const cancelCurrent = (): void => {
         canceled = true
+        lookupAbort.abort()
         terminateRelaySubprocessTree(child)
       }
       if (laneKey) {
@@ -180,6 +185,7 @@ export class AgentExecHandler {
         // Why: tree-kill because some CLIs trap SIGTERM and continue streaming;
         // also Windows wraps `.cmd` shims in cmd.exe, so the immediate child
         // is not the real node.exe process.
+        lookupAbort.abort()
         terminateRelaySubprocessTree(child)
         finish({ stdout, stderr, exitCode: null, timedOut, canceled })
       }, timeoutMs)
@@ -235,32 +241,34 @@ export class AgentExecHandler {
         }
         attemptedLoginShellFallback = true
         detachChildListeners()
-        void resolvePosixBinaryViaLoginShell(binary, spawnEnv).then((resolvedPath) => {
-          if (settled) {
-            return
+        void resolvePosixBinaryViaLoginShell(binary, spawnEnv, lookupAbort.signal).then(
+          (resolvedPath) => {
+            if (settled) {
+              return
+            }
+            if (canceled) {
+              finish({ stdout, stderr, exitCode: null, timedOut, canceled })
+              return
+            }
+            if (!resolvedPath) {
+              finish({ stdout, stderr, exitCode: null, timedOut, spawnError: error.message })
+              return
+            }
+            try {
+              child = spawnChild(resolvedPath, args)
+            } catch (retryError) {
+              finish({
+                stdout,
+                stderr,
+                exitCode: null,
+                timedOut,
+                spawnError: retryError instanceof Error ? retryError.message : String(retryError)
+              })
+              return
+            }
+            wireChild()
           }
-          if (canceled) {
-            finish({ stdout, stderr, exitCode: null, timedOut, canceled })
-            return
-          }
-          if (!resolvedPath) {
-            finish({ stdout, stderr, exitCode: null, timedOut, spawnError: error.message })
-            return
-          }
-          try {
-            child = spawnChild(resolvedPath, args)
-          } catch (retryError) {
-            finish({
-              stdout,
-              stderr,
-              exitCode: null,
-              timedOut,
-              spawnError: retryError instanceof Error ? retryError.message : String(retryError)
-            })
-            return
-          }
-          wireChild()
-        })
+        )
       }
       const onClose = (code: number | null): void => {
         finish({ stdout, stderr, exitCode: code, timedOut, canceled })

--- a/src/relay/agent-exec-posix-login-shell-resolve.ts
+++ b/src/relay/agent-exec-posix-login-shell-resolve.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from 'node:child_process'
+import { basename } from 'node:path'
 
 const LOGIN_SHELL_RESOLVE_TIMEOUT_MS = 5_000
 // Why: csh/tcsh reject combined -lc; sh/dash don't need login mode. Mirrors
@@ -11,7 +12,7 @@ function shellQuote(value: string): string {
 }
 
 export function isBareBinaryName(binary: string): boolean {
-  return !binary.includes('/')
+  return basename(binary) === binary
 }
 
 export function isEnoentSpawnError(error: Error): boolean {
@@ -32,7 +33,7 @@ export function resolvePosixBinaryViaLoginShell(
 ): Promise<string | null> {
   return new Promise((resolve) => {
     const shell = env.SHELL || '/bin/sh'
-    const shellName = shell.split('/').at(-1)
+    const shellName = basename(shell)
     const mode = shellName && COMMAND_ONLY_LOGIN_SHELLS.has(shellName) ? '-c' : '-lc'
 
     let child: ChildProcess

--- a/src/relay/agent-exec-posix-login-shell-resolve.ts
+++ b/src/relay/agent-exec-posix-login-shell-resolve.ts
@@ -1,0 +1,81 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+
+const LOGIN_SHELL_RESOLVE_TIMEOUT_MS = 5_000
+// Why: csh/tcsh reject combined -lc; sh/dash don't need login mode. Mirrors
+// src/main/ssh/ssh-login-shell-command.ts, duplicated because the relay ships
+// to remote hosts and can't import from src/main.
+const COMMAND_ONLY_LOGIN_SHELLS = new Set(['sh', 'dash', 'csh', 'tcsh'])
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`
+}
+
+export function isBareBinaryName(binary: string): boolean {
+  return !binary.includes('/')
+}
+
+export function isEnoentSpawnError(error: Error): boolean {
+  return (error as NodeJS.ErrnoException).code === 'ENOENT' || /ENOENT/.test(error.message)
+}
+
+// Why: a plain `spawn(binary, ...)` only sees the relay process's own PATH, so
+// a binary installed only via the remote user's shell rc/profile files (the
+// common case for version-managed or manually-PATH'd CLIs like `opencode`)
+// spawns ENOENT even though an interactive login resolves it fine. Resolve
+// through a bounded, non-interactive `command -v` lookup — not by running the
+// actual command inside a shell — so stdout stays clean and a hanging rc file
+// can't wedge the real exec. Mirrors the Node-resolution fallback in
+// src/main/ssh/ssh-remote-node-resolution.ts.
+export function resolvePosixBinaryViaLoginShell(
+  binary: string,
+  env: NodeJS.ProcessEnv
+): Promise<string | null> {
+  return new Promise((resolve) => {
+    const shell = env.SHELL || '/bin/sh'
+    const shellName = shell.split('/').at(-1)
+    const mode = shellName && COMMAND_ONLY_LOGIN_SHELLS.has(shellName) ? '-c' : '-lc'
+
+    let child: ChildProcess
+    try {
+      child = spawn(shell, [mode, `command -v ${shellQuote(binary)}`], {
+        stdio: ['ignore', 'pipe', 'ignore']
+      })
+    } catch {
+      resolve(null)
+      return
+    }
+
+    let stdout = ''
+    let settled = false
+    const finish = (result: string | null): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      resolve(result)
+    }
+    const timer = setTimeout(() => {
+      try {
+        child.kill('SIGKILL')
+      } catch {
+        /* already exited */
+      }
+      finish(null)
+    }, LOGIN_SHELL_RESOLVE_TIMEOUT_MS)
+    timer.unref?.()
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf-8')
+    })
+    child.on('error', () => finish(null))
+    child.on('close', (code) => {
+      if (code !== 0) {
+        finish(null)
+        return
+      }
+      const resolved = stdout.split('\n')[0]?.trim()
+      finish(resolved ? resolved : null)
+    })
+  })
+}

--- a/src/relay/agent-exec-posix-login-shell-resolve.ts
+++ b/src/relay/agent-exec-posix-login-shell-resolve.ts
@@ -47,8 +47,9 @@ function lookupResultPath(stdout: string): string | null {
 export function resolvePosixBinaryViaLoginShell(
   binary: string,
   env: NodeJS.ProcessEnv,
-  signal?: AbortSignal
+  options: { cwd?: string; signal?: AbortSignal } = {}
 ): Promise<string | null> {
+  const { cwd, signal } = options
   return new Promise((resolve) => {
     if (signal?.aborted) {
       resolve(null)
@@ -62,6 +63,14 @@ export function resolvePosixBinaryViaLoginShell(
     try {
       child = spawn(shell, [mode, `command -v ${shellQuote(binary)}`], {
         stdio: ['ignore', 'pipe', 'ignore'],
+        // Why: the retry exec runs in the caller's cwd, and a login profile can
+        // answer differently per directory (direnv, nvm's .nvmrc, asdf), quite
+        // apart from relative PATH entries. The lookup has to ask from there.
+        cwd,
+        // Why: the profile can background work of its own. Killing the shell
+        // PID alone leaves those children behind, so the lookup leads its own
+        // process group and the whole group is signalled below.
+        detached: true,
         // Why: without this the lookup runs against the relay's own PATH while
         // the retry exec runs against spawnEnv, so `command -v` can answer for
         // a different environment than the one that will run the binary.
@@ -77,9 +86,20 @@ export function resolvePosixBinaryViaLoginShell(
     let settled = false
     const kill = (): void => {
       try {
-        child.kill('SIGKILL')
+        // Negative pid signals the whole group, which detached: true made this
+        // child the leader of. Falls back to the single child if the group is
+        // already gone.
+        if (child.pid) {
+          process.kill(-child.pid, 'SIGKILL')
+        } else {
+          child.kill('SIGKILL')
+        }
       } catch {
-        /* already exited */
+        try {
+          child.kill('SIGKILL')
+        } catch {
+          /* already exited */
+        }
       }
     }
     const finish = (result: string | null): void => {

--- a/src/relay/agent-exec-posix-login-shell-resolve.ts
+++ b/src/relay/agent-exec-posix-login-shell-resolve.ts
@@ -1,7 +1,11 @@
 import { spawn, type ChildProcess } from 'node:child_process'
-import { basename } from 'node:path'
+import { basename, posix } from 'node:path'
 
 const LOGIN_SHELL_RESOLVE_TIMEOUT_MS = 5_000
+// Why: rc/profile files can print without bound (motd, version-manager
+// chatter). The lookup only ever needs one path, so cap what we buffer and
+// fail closed past it rather than letting the relay grow for five seconds.
+const LOGIN_SHELL_RESOLVE_MAX_STDOUT_BYTES = 64 * 1024
 // Why: csh/tcsh reject combined -lc; sh/dash don't need login mode. Mirrors
 // src/main/ssh/ssh-login-shell-command.ts, duplicated because the relay ships
 // to remote hosts and can't import from src/main.
@@ -27,11 +31,29 @@ export function isEnoentSpawnError(error: Error): boolean {
 // actual command inside a shell — so stdout stays clean and a hanging rc file
 // can't wedge the real exec. Mirrors the Node-resolution fallback in
 // src/main/ssh/ssh-remote-node-resolution.ts.
+// Why: `command -v` prints the resolved path last, after anything a login
+// profile echoed on the way in, so the first line is not reliably the answer.
+// Aliases and shell builtins print non-path text ("alias foo='...'", "foo"),
+// which must never reach spawn() as a binary.
+function lookupResultPath(stdout: string): string | null {
+  const lines = stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+  const last = lines.at(-1)
+  return last && posix.isAbsolute(last) ? last : null
+}
+
 export function resolvePosixBinaryViaLoginShell(
   binary: string,
-  env: NodeJS.ProcessEnv
+  env: NodeJS.ProcessEnv,
+  signal?: AbortSignal
 ): Promise<string | null> {
   return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve(null)
+      return
+    }
     const shell = env.SHELL || '/bin/sh'
     const shellName = basename(shell)
     const mode = shellName && COMMAND_ONLY_LOGIN_SHELLS.has(shellName) ? '-c' : '-lc'
@@ -39,7 +61,11 @@ export function resolvePosixBinaryViaLoginShell(
     let child: ChildProcess
     try {
       child = spawn(shell, [mode, `command -v ${shellQuote(binary)}`], {
-        stdio: ['ignore', 'pipe', 'ignore']
+        stdio: ['ignore', 'pipe', 'ignore'],
+        // Why: without this the lookup runs against the relay's own PATH while
+        // the retry exec runs against spawnEnv, so `command -v` can answer for
+        // a different environment than the one that will run the binary.
+        env
       })
     } catch {
       resolve(null)
@@ -47,26 +73,48 @@ export function resolvePosixBinaryViaLoginShell(
     }
 
     let stdout = ''
+    let stdoutBytes = 0
     let settled = false
+    const kill = (): void => {
+      try {
+        child.kill('SIGKILL')
+      } catch {
+        /* already exited */
+      }
+    }
     const finish = (result: string | null): void => {
       if (settled) {
         return
       }
       settled = true
       clearTimeout(timer)
+      signal?.removeEventListener('abort', onAbort)
       resolve(result)
     }
+    // Why: the caller's cancel and timeout paths abandon the exec, but this
+    // lookup owns a login shell of its own — without this it keeps running for
+    // up to the full timeout after the caller has already settled.
+    const onAbort = (): void => {
+      kill()
+      finish(null)
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
     const timer = setTimeout(() => {
-      try {
-        child.kill('SIGKILL')
-      } catch {
-        /* already exited */
-      }
+      kill()
       finish(null)
     }, LOGIN_SHELL_RESOLVE_TIMEOUT_MS)
     timer.unref?.()
 
     child.stdout?.on('data', (chunk: Buffer) => {
+      if (settled) {
+        return
+      }
+      stdoutBytes += chunk.byteLength
+      if (stdoutBytes > LOGIN_SHELL_RESOLVE_MAX_STDOUT_BYTES) {
+        kill()
+        finish(null)
+        return
+      }
       stdout += chunk.toString('utf-8')
     })
     child.on('error', () => finish(null))
@@ -75,8 +123,7 @@ export function resolvePosixBinaryViaLoginShell(
         finish(null)
         return
       }
-      const resolved = stdout.split('\n')[0]?.trim()
-      finish(resolved ? resolved : null)
+      finish(lookupResultPath(stdout))
     })
   })
 }

--- a/src/relay/agent-exec-windows-safe-spawn.ts
+++ b/src/relay/agent-exec-windows-safe-spawn.ts
@@ -1,0 +1,63 @@
+import { existsSync } from 'node:fs'
+import { delimiter, join } from 'node:path'
+
+export const WINDOWS_BATCH_UNSAFE_ARGUMENTS_ERROR = 'UNSAFE_WINDOWS_BATCH_ARGUMENTS'
+
+function getCmdExePath(): string {
+  return process.env.ComSpec || `${process.env.SystemRoot ?? 'C:\\Windows'}\\System32\\cmd.exe`
+}
+
+function isWindowsBatchScript(commandPath: string): boolean {
+  return process.platform === 'win32' && /\.(cmd|bat)$/i.test(commandPath)
+}
+
+function hasUnsafeWindowsBatchSyntax(value: string): boolean {
+  return /[&|<>^"%!\r\n]/.test(value)
+}
+
+function quoteWindowsBatchToken(value: string): string {
+  if (hasUnsafeWindowsBatchSyntax(value)) {
+    throw new Error(WINDOWS_BATCH_UNSAFE_ARGUMENTS_ERROR)
+  }
+  return `"${value}"`
+}
+
+function resolveWindowsCommand(binary: string, env: NodeJS.ProcessEnv): string {
+  if (process.platform !== 'win32') {
+    return binary
+  }
+  if (/[\\/]/.test(binary) || /\.[a-z0-9]+$/i.test(binary)) {
+    return binary
+  }
+
+  const pathEnv = env.PATH ?? env.Path
+  if (!pathEnv) {
+    return binary
+  }
+  const names = [`${binary}.cmd`, `${binary}.exe`, `${binary}.bat`, binary]
+  for (const directory of pathEnv.split(delimiter).filter(Boolean)) {
+    for (const name of names) {
+      const candidate = join(directory, name)
+      if (existsSync(candidate)) {
+        return candidate
+      }
+    }
+  }
+  return binary
+}
+
+// Why: mirrors src/main/text-generation/commit-message-text-generation.ts. On
+// Windows, npm-installed CLIs like `claude`/`codex` are usually `.cmd` shims.
+// We route those through cmd.exe so Node can launch them.
+export function getWindowsSafeSpawn(
+  binary: string,
+  args: string[],
+  env: NodeJS.ProcessEnv
+): { spawnCmd: string; spawnArgs: string[] } {
+  const resolvedBinary = resolveWindowsCommand(binary, env)
+  if (!isWindowsBatchScript(resolvedBinary)) {
+    return { spawnCmd: resolvedBinary, spawnArgs: args }
+  }
+  const commandLine = [resolvedBinary, ...args].map(quoteWindowsBatchToken).join(' ')
+  return { spawnCmd: getCmdExePath(), spawnArgs: ['/d', '/s', '/c', commandLine] }
+}


### PR DESCRIPTION
## Summary

When the relay spawns an agent CLI (opencode, claude, codex, ...) non-interactively for commit-message / PR-field / branch-name generation over SSH, it only sees its own process PATH (`spawn(binary, args, ...)`, no shell). A binary installed only via the remote user's shell rc/profile files (a common setup for `opencode` and version-managed CLIs) fails with ENOENT even though an interactive login on that same host resolves it fine.

On a bare (non-path) binary name, POSIX host, ENOENT spawn failure, the relay now resolves the binary via a bounded, non-interactive `$SHELL -lc "command -v <binary>"` lookup and retries with the resolved absolute path — mirroring the existing Node-resolution fallback in `src/main/ssh/ssh-remote-node-resolution.ts` (deliberately *not* wrapping the whole command in an interactive/login shell, to avoid banner/prompt pollution of the captured stdout or a hanging rc file wedging the exec). If the lookup also fails, the original ENOENT error and message are preserved unchanged. Windows spawning is completely untouched (separate code path).

No visual change — this is a backend relay fix with no UI surface.

Fixes #4720

## What does NOT change

- Windows spawn/batch-shim resolution (`agent-exec-windows-safe-spawn.ts`) — moved into its own file, logic untouched.
- Any exec call where the binary already resolves directly (the common case) — the fallback only engages after an actual ENOENT.
- Existing cancellation, timeout, and abort-signal semantics — the retry reuses the same lane/timer and is itself gated on `canceled`/`settled` so a cancel or timeout during the lookup can't leak a stray retry process.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — all `src/relay/agent-exec-handler*` suites pass (15/15). Full-repo `pnpm test` has pre-existing failures on this Windows dev sandbox (PTY exit timing, missing `/bin/sh`, path-separator assertions) unrelated to this change — confirmed identical failure set on unmodified `main`.
- [x] `pnpm build`
- [x] Added a regression test suite (`agent-exec-handler-posix-login-shell.test.ts`) that fails before this change (verified red) and passes after: (1) resolves via login shell and retries successfully, (2) falls back to the original ENOENT error when the login shell also can't resolve it, (3) does not attempt the fallback for an absolute-path binary.

## AI Review Report

Reviewed the diff for: correctness of the retry wiring (child/listener reassignment on retry, stdin re-delivery, byte-count counters not double-reset), race safety (a cancel or the outer timeout firing during the async login-shell lookup is checked via `settled`/`canceled` before spawning the retry), and that the Windows code path is untouched (gated on `process.platform !== 'win32'` and a bare-binary-name check). No new IPC channels, no new dependencies, no credential handling changes.

## Security Audit

The fallback only runs a fixed, deterministic `command -v <binary>` lookup (no shell interpolation of untrusted input — `binary` here is Orca's own agent-spec-selected command name, e.g. `opencode`/`claude`/`codex`, not free-form user text) and never executes the actual agent command through a shell — only the resolution step touches a shell, and only to look up a path, with a 5s bounded timeout and no interactive/login side effects beyond that. The retried spawn uses the same `spawnEnv`/`cwd`/`stdio` as before, just a different resolved binary path.

## Platform / environment notes

- POSIX-only change (macOS/Linux SSH targets). Windows relay hosts are unaffected.
- Applies to the SSH/remote exec path only (`src/relay/agent-exec-handler.ts`, which runs on the remote host); local (non-SSH) generation already uses a different, unaffected code path.
- No effect on interactive terminal sessions — this is the non-interactive commit-message/PR-field/branch-name generation exec only.

Made with [Claude Code](https://claude.com/claude-code)

## ELI5

Over SSH, agents for commit messages or PR fields failed if the CLI only lived on the user’s shell PATH. The relay now falls back to a login-shell PATH lookup so tools like opencode still resolve.
