### PR TITLE
fix(agent-detection): do not cache empty agent detection results

### DIFF
--- a/src/renderer/src/hooks/useDetectedAgents.ts
+++ b/src/renderer/src/hooks/useDetectedAgents.ts
@@ -125,6 +125,14 @@ export function useDetectedAgents(
       }
     } else {
       if (detectedIds === null) {
+        retriedEmptyTargetRef.current = null
+        void ensureLocal()
+      } else if (detectedIds.length === 0 && retriedEmptyTargetRef.current !== 'local') {
+        // Why: initial detection may return empty when shell PATH hydration
+        // hasn't completed yet (slow login shell, corporate env setup).
+        // Retry once so a subsequent probe picks up agents that are actually
+        // on PATH. See stablyai/orca#9011.
+        retriedEmptyTargetRef.current = 'local'
         void ensureLocal()
       }
     }

--- a/src/renderer/src/store/slices/detected-agents.ts
+++ b/src/renderer/src/store/slices/detected-agents.ts
@@ -95,7 +95,15 @@ export const createDetectedAgentsSlice: StateCreator<AppState, [], [], DetectedA
         const typed = ids as TuiAgent[]
         if (requestGeneration === localDetectionGeneration) {
           set({ detectedAgentIds: typed, isDetectingAgents: false })
-          detectedContextKey = contextKey
+          if (typed.length > 0) {
+            detectedContextKey = contextKey
+          } else {
+            // Why: initial detection may return empty when shell PATH hydration
+            // hasn't completed yet (slow login shell, corporate env setup).
+            // Don't cache empty results so subsequent callers re-probe once
+            // the shell is warmed up. See stablyai/orca#9011.
+            detectPromise = null
+          }
         }
         return typed
       })
@@ -140,8 +148,13 @@ export const createDetectedAgentsSlice: StateCreator<AppState, [], [], DetectedA
           })
           // Why: once refresh has run, treat its result as the current detection
           // snapshot so `ensureDetectedAgents` short-circuits.
-          detectedContextKey = contextKey
-          detectPromise = { key: contextKey, promise: Promise.resolve(typed) }
+          // Only cache non-empty results — an empty list may indicate that shell
+          // PATH hydration produced a minimal PATH. The next `ensureDetectedAgents`
+          // call should re-probe. See stablyai/orca#9011.
+          if (typed.length > 0) {
+            detectedContextKey = contextKey
+            detectPromise = { key: contextKey, promise: Promise.resolve(typed) }
+          }
         }
         return typed
       })


### PR DESCRIPTION
## Summary

When Orca starts, the "+" new tab menu shows "No agents detected" instead of listing available agents (Claude, etc.). Only after opening Settings → Getting Started → "Choose your default agent" step (which calls `refreshDetectedAgents()`) do agents appear.

The root cause is that `ensureDetectedAgents()` caches its result — including empty `[]` — via `detectPromise` and `detectedContextKey`. An empty array `[]` is truthy in JavaScript, so subsequent calls short-circuit at the guard:

```ts
if (existing \&\& detectedContextKey === contextKey) {
  return Promise.resolve(existing) // returns [] forever
}
```

`refreshDetectedAgents()` (called by the Setup Guide step) always re-probes shell PATH with `hydrateShellPath({ force: true })`, which finds agents the initial detection missed — but the `detectPromise` cache was already poisoned with empty results.

Additionally, the `useDetectedAgents` hook only triggers re-detection when `detectedIds === null` (initial state). After receiving `[]`, it never re-triggers.

**Changes:**

1. **`detected-agents.ts` — `ensureDetectedAgents`**: When the IPC returns `[]`, don't set `detectedContextKey` and clear `detectPromise` so the next caller re-probes instead of returning cached empty results.

2. **`detected-agents.ts` — `refreshDetectedAgents`**: Don't update `detectPromise` cache when the result is empty, preventing a later `ensureDetectedAgents` call from returning a stale empty result.

3. **`useDetectedAgents.ts`**: Add a one-shot empty-result retry for local detection (matching the existing SSH/runtime empty-retry pattern). When `detectedIds` is `[]` and hasn't been retried yet, trigger a fresh `ensureDetectedAgents()` probe.

## Screenshots

No visual change.

## Testing

- [x] `pnpm typecheck` ✅
- [x] `pnpm test` — existing detected-agents tests: 15/15 passed ✅
- [x] `pnpm test` — QuickLaunchButton tests: 5/5 passed ✅

## AI Review Report

Code review checked for:
- **Correctness**: empty `[]` is no longer cached as a final detection result; retry-once pattern prevents infinite loops
- **Cross-platform**: changes are in renderer-only code (TypeScript). No platform-dependent paths, shortcuts, or shell behavior introduced
- **Caching**: `detectPromise` is only set/updated when result is non-empty; `detectedContextKey` guarded similarly
- **Side effects**: no new IPC calls or state outside the existing detection flow

## Security Audit

- No new IPC channels, command execution, or file path handling
- Changes are limited to in-memory caching behavior in the renderer store slice and hook
- No user input, secrets, or auth tokens affected

## Notes

- Fixes #9011
- The SSH/runtime detection already had an empty-result retry pattern (`retriedEmptyTargetRef`) — the local detection now follows the same pattern
- In the worst case (user truly has no agents installed), detection runs at most twice per session per mount surface

## ELI5

At startup the “+” menu sometimes said “No agents detected” even when Claude and others were installed. Empty detection results are no longer cached forever, so agents show up without a Settings refresh dance.
