### PR TITLE
fix(remote): isolate shared control request timeouts

### DIFF
--- a/src/shared/remote-runtime-shared-control-connection.test.ts
+++ b/src/shared/remote-runtime-shared-control-connection.test.ts
@@ -454,32 +454,37 @@ describe('RemoteRuntimeSharedControlConnection', () => {
     connection.close()
   })
 
-  it('tears down the socket when a request times out and reconnects active subscriptions', async () => {
-    const server = await createServer({ silentMethods: ['worktree.hang'] })
-    const connection = new RemoteRuntimeSharedControlConnection(server.pairing)
-    const onResponse = vi.fn()
-    const onClose = vi.fn()
-
-    await connection.subscribe('runtime.clientEvents.subscribe', null, 1000, {
-      onResponse,
-      onError: vi.fn(),
-      onClose
+  it('keeps unrelated pending requests alive when one request times out', async () => {
+    const server = await createServer({
+      silentMethods: ['worktree.hang'],
+      delayedMethods: ['worktree.ps']
     })
-    await vi.waitFor(() => expect(onResponse).toHaveBeenCalled())
+    const connection = new RemoteRuntimeSharedControlConnection(server.pairing)
 
-    // Why: mirrors RemoteRuntimeRequestConnection — a request the server never
-    // answered marks the socket as suspect and must not leave it 'ready'.
-    await expect(connection.request('worktree.hang', undefined, 50)).rejects.toThrow('Timed out')
-
-    await vi.waitFor(() => expect(server.connectionCount()).toBe(2), { timeout: 5000 })
-    await vi.waitFor(
-      () =>
-        expect(
-          server.requests.filter((request) => request.method === 'runtime.clientEvents.subscribe')
-        ).toHaveLength(2),
-      { timeout: 5000 }
+    const timedOut = connection.request('worktree.hang', undefined, 250)
+    void timedOut.catch(() => undefined)
+    await vi.waitFor(() =>
+      expect(server.requests.map(({ method }) => method)).toContain('worktree.hang')
     )
-    expect(onClose).not.toHaveBeenCalled()
+    const survivor = connection.request('worktree.ps', undefined, 1000).then(
+      (response) => ({ ok: true as const, response }),
+      (error: unknown) => ({ ok: false as const, error })
+    )
+    await vi.waitFor(() =>
+      expect(server.requests.map(({ method }) => method)).toContain('worktree.ps')
+    )
+
+    await expect(timedOut).rejects.toThrow('Timed out')
+    // Why: a single slow method is not evidence that a shared socket is dead;
+    // liveness monitoring owns connection-wide failure detection.
+    expect(connection.getDiagnostics()).toMatchObject({ state: 'ready', pendingRequestCount: 1 })
+
+    server.flushDelayedResponses()
+    await expect(survivor).resolves.toMatchObject({
+      ok: true,
+      response: { ok: true, result: { method: 'worktree.ps' } }
+    })
+    expect(server.connectionCount()).toBe(1)
 
     connection.close()
   })
@@ -515,6 +520,7 @@ async function createServer(
     // Why: half-open simulation — the socket stays open but never answers
     // protocol pings, like a wedged tunnel that swallows frames silently.
     disableAutoPong?: boolean
+    delayedMethods?: string[]
     silentMethods?: string[]
   } = {}
 ): Promise<TestServer> {
@@ -613,6 +619,7 @@ function handleRequest(
     sendUnknownResponseBeforeResponse?: boolean
     closeAfterStreamingResponse?: () => boolean
     closeBeforeResponse?: boolean
+    delayedMethods?: string[]
     silentMethods?: string[]
   },
   delayedResponses: (() => void)[]
@@ -662,6 +669,10 @@ function handleRequest(
     sendEncrypted(ws, sharedKey, { _keepalive: true })
   }
   if (options.delaySubscriptionReady && streaming) {
+    delayedResponses.push(sendResponse)
+    return
+  }
+  if (options.delayedMethods?.includes(request.method)) {
     delayedResponses.push(sendResponse)
     return
   }

--- a/src/shared/remote-runtime-shared-control-connection.ts
+++ b/src/shared/remote-runtime-shared-control-connection.ts
@@ -74,10 +74,7 @@ export class RemoteRuntimeSharedControlConnection {
       timeoutMs,
       ensureReady: () => this.ensureReadyWithTimeout(timeoutMs),
       send: (requestId, requestMethod, requestParams) =>
-        this.sendRequest(requestId, requestMethod, requestParams),
-      // Why: a timed-out request marks the socket as suspect (#7718) — tear
-      // it down so reconnect+replay runs instead of keeping a zombie socket.
-      onTimeout: (error) => this.handleSocketClosed(error)
+        this.sendRequest(requestId, requestMethod, requestParams)
     })
   }
 

--- a/src/shared/remote-runtime-shared-control-keepalive-refresh.test.ts
+++ b/src/shared/remote-runtime-shared-control-keepalive-refresh.test.ts
@@ -22,10 +22,8 @@ describe('shared control keepalive timeout refresh semantics', () => {
   function startRequest(options: { refreshTimeoutOnKeepalive?: boolean } = {}): {
     pendingRequests: Map<string, SharedControlPendingRequest<unknown>>
     promise: Promise<unknown>
-    onTimeout: ReturnType<typeof vi.fn>
   } {
     const pendingRequests = new Map<string, SharedControlPendingRequest<unknown>>()
-    const onTimeout = vi.fn()
     const promise = requestSharedControl({
       pendingRequests,
       method: 'git.status',
@@ -35,16 +33,15 @@ describe('shared control keepalive timeout refresh semantics', () => {
       // server never answers, modelling a genuinely stuck server-side call.
       ensureReady: () => Promise.resolve(),
       send: () => undefined,
-      onTimeout,
       refreshTimeoutOnKeepalive: options.refreshTimeoutOnKeepalive
     })
     // Swallow the eventual rejection so unhandled-rejection noise doesn't leak.
     promise.catch(() => undefined)
-    return { pendingRequests, promise, onTimeout }
+    return { pendingRequests, promise }
   }
 
   it('times out a stuck short RPC even while keepalive frames keep arriving', async () => {
-    const { pendingRequests, promise, onTimeout } = startRequest()
+    const { pendingRequests, promise } = startRequest()
 
     // Periodic keepalives arrive faster than the 1000ms deadline — as they
     // would while a long-poll subscription streams over the same socket.
@@ -55,13 +52,11 @@ describe('shared control keepalive timeout refresh semantics', () => {
     await vi.advanceTimersByTimeAsync(1)
 
     await expect(promise).rejects.toThrow()
-    // The stuck-request path tears the connection down so reconnect+replay runs.
-    expect(onTimeout).toHaveBeenCalledTimes(1)
     expect(pendingRequests.size).toBe(0)
   })
 
   it('keeps refreshing a long-poll request that opted into keepalive refresh', async () => {
-    const { pendingRequests, promise, onTimeout } = startRequest({
+    const { pendingRequests, promise } = startRequest({
       refreshTimeoutOnKeepalive: true
     })
 
@@ -72,7 +67,6 @@ describe('shared control keepalive timeout refresh semantics', () => {
       refreshSharedControlPendingRequestTimeouts(pendingRequests)
     }
 
-    expect(onTimeout).not.toHaveBeenCalled()
     expect(pendingRequests.size).toBe(1)
 
     // It still resolves normally once the server finally answers.
@@ -87,12 +81,11 @@ describe('shared control keepalive timeout refresh semantics', () => {
   })
 
   it('fires the deadline for a short RPC when no keepalives arrive', async () => {
-    const { pendingRequests, promise, onTimeout } = startRequest()
+    const { pendingRequests, promise } = startRequest()
 
     await vi.advanceTimersByTimeAsync(1001)
 
     await expect(promise).rejects.toThrow()
-    expect(onTimeout).toHaveBeenCalledTimes(1)
     expect(pendingRequests.size).toBe(0)
   })
 })

--- a/src/shared/remote-runtime-shared-control-requests.ts
+++ b/src/shared/remote-runtime-shared-control-requests.ts
@@ -1,9 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import type { RemoteRuntimeClientError } from './remote-runtime-client-error'
-import {
-  remoteRuntimeTimeoutError,
-  remoteRuntimeUnavailableError
-} from './remote-runtime-request-frames'
+import { remoteRuntimeTimeoutError } from './remote-runtime-request-frames'
 import type { RuntimeRpcResponse } from './runtime-rpc-envelope'
 import { toRemoteRuntimeClientError } from './remote-runtime-shared-control-protocol'
 import { rejectSharedControlPendingRequest } from './remote-runtime-shared-control-state'
@@ -16,7 +12,6 @@ export function requestSharedControl<TResult>(args: {
   timeoutMs: number
   ensureReady: () => Promise<void>
   send: (requestId: string, method: string, params: unknown) => void
-  onTimeout?: (error: RemoteRuntimeClientError) => void
   // Why: default off — ordinary short RPCs keep an absolute deadline. Only
   // long-polls routed through this path opt in so keepalives extend them.
   refreshTimeoutOnKeepalive?: boolean
@@ -29,16 +24,9 @@ export function requestSharedControl<TResult>(args: {
         return
       }
       args.pendingRequests.delete(requestId)
+      // Why: one stalled method does not prove the shared socket is dead;
+      // socket liveness owns connection-wide teardown so other RPCs survive.
       pending.reject(remoteRuntimeTimeoutError())
-      // Why: a request the server never answered means the socket is suspect
-      // (half-open tunnels swallow frames silently); mirror
-      // RemoteRuntimeRequestConnection and hand the connection a teardown
-      // error so reconnect+replay runs instead of keeping a zombie socket.
-      args.onTimeout?.(
-        remoteRuntimeUnavailableError(
-          'Remote Orca runtime did not answer in time; resetting the control connection.'
-        )
-      )
     }, args.timeoutMs)
     args.pendingRequests.set(requestId, {
       method: args.method,


### PR DESCRIPTION
## Summary

ELI5: one slow remote operation currently pulls the plug on the shared control socket, so unrelated operations fail with it. This change lets only the slow operation time out and leaves socket-wide failure detection to the existing ping/pong liveness monitor.

The RPC timers were already independent. The cascade came from the first expired timer calling the connection's close path, which rejected every other pending RPC on that socket. This removes that timeout-to-socket-teardown callback. Real WebSocket close/error events and the existing liveness timeout still close the transport, reject pending work, reconnect, and replay subscriptions.

Fixes #8541.

## Reproduction

Historical release pair, using the real encrypted paired runtime transport:

- Client: Orca v1.4.137 arm64 macOS zip, SHA-256 `fabecfd28bc7f661d5b836da7bc4c70f6fab0ea51a8958455db6fddb052ab2ce`
- Server: Orca v1.4.137 arm64 Linux AppImage in Ubuntu 24.04 Docker, SHA-256 `e08b52b98c4274aedc5c57b7bcbdf4ab916bc4aa356e606f6ab514aef096b306`
- Topology: 13 remote worktrees, 26 tabs, 26 live remote PTYs, four active subscriptions
- Trigger: detach the live server container from its Docker network, issue five real runtime RPCs, then reattach it

| Sample | Measured outage | Five RPC durations | Completion span | Timeout/reset split |
| --- | ---: | ---: | ---: | ---: |
| 1 | 17.443 s | 15.008 s | 0.3 ms | 1 timeout / 4 collateral resets |
| 2 | 16.875 s | 14.267–14.268 s | 0.1 ms | 0 timeouts / 5 collateral resets |
| 3 | 17.015 s | 10.057 s | 0.2 ms | 0 timeouts / 5 collateral resets |

Trace/log attribution points to `requestSharedControl`'s timer: it rejects its own request, then invokes `onTimeout`; `handleSocketClosed` closes the shared socket and `closeSharedControlSocket` rejects all remaining pending methods. The report's proposed “shared timeout clock” is therefore not the mechanism—the shared teardown side effect is.

## Fix evidence

The deterministic regression starts a silent `worktree.hang` request, then a younger delayed `worktree.ps` request on the same real test WebSocket. Before this change, the older timeout closes the socket and rejects the younger request. With this change, the older request times out, diagnostics remain `ready` with one pending request, and the younger response resolves on the original socket (`connectionCount() === 1`).

I also reran the current development client against the unchanged v1.4.137 Linux AppImage server over Orca's real encrypted paired WebSocket. One older RPC started at T+0, five younger RPCs at T+8 seconds, and a network reattach was initiated at approximately T+14 seconds.

| Sample | Older RPC | Five younger RPCs | Docker reattach completed | Recovered | Stable canaries |
| --- | ---: | ---: | ---: | ---: | --- |
| 1 | timeout at 15.013 s | physical socket close at 7.897–7.899 s | T+17.379 s | T+21.872 s | 30 s, ready / 0 pending / 1 subscription |
| 2 | timeout at 15.416 s | own deadlines at 15.361–15.368 s | T+32.791 s | T+35.725 s | 30 s, ready / 0 pending / 1 subscription |
| 3 | timeout at 15.129 s | own deadlines at 15.235–15.237 s | T+37.142 s | T+43.171 s | 30 s, ready / 0 pending / 1 subscription |

Samples 2–3 demonstrate that the younger RPCs survived the older timeout and reached their own deadlines instead of being rejected about eight seconds early. Sample 1 exercised the separate, expected physical-close path, which still rejects pending work. All samples recovered, retained the subscription, and finished with reconnect attempt zero.

Docker reattachment itself completed after the older deadline in all three samples, so this evidence does not claim the network was restored before the first timeout. The deterministic regression is the direct proof for the healthy-socket survivor case; the paired run verifies the policy through the production encrypted transport without mocked RPC.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — full lint intentionally not run; targeted `oxlint` passed for all four changed files
- [ ] `pnpm typecheck` — full three-target check intentionally not run; `pnpm run typecheck:node` passed
- [ ] `pnpm test` — full suite intentionally not run; the four shared-control test files passed serially, 33/33 tests
- [ ] `pnpm build` — `pnpm run build:electron-vite` passed during paired-client preparation
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional checks: targeted `oxfmt --check`, `git diff --check`, three historical-release reproduction samples, and three post-fix real-pair samples with a 30-second stable recovery window each.

## AI Review Report

Manually reviewed the full diff and the prior reconnect history because an internal review skill was unavailable and this investigation was constrained to one agent. The review checked:

- whether the old behavior was protecting #7718 half-open tunnels;
- whether physical close/error and 25-second inactivity paths still reject pending work and reconnect/replay subscriptions;
- independent short-RPC deadlines and opt-in long-poll keepalive refresh;
- cleanup of the timed-out request from the pending map;
- macOS, Linux, Windows, SSH, and Electron implications.

The key finding was that the dedicated client liveness monitor was added after the original reconnect failure and now owns half-open detection. This diff changes no shortcuts, labels, paths, shell behavior, UI, or platform-specific code.

## Security Audit

No new input, command execution, path, auth, secret, dependency, or IPC surface is introduced. Pairing, E2EE framing, device-token authentication, and RPC envelope validation are unchanged. The only policy change is which existing failure path owns shared-socket teardown. Ignored local evidence contains pairing/auth material and was not committed or uploaded.

## Notes

Tradeoff: a truly half-open socket may now wait for the existing liveness policy (25 seconds without inbound activity, checked on the 10-second ping cadence) instead of being reset by the first 15-second RPC deadline. That is intentional: one slow server method is not proof that a multiplexed transport is dead. Actual socket closure remains immediate.

Confidence is high: the failing mechanism is deterministic, the regression fails under the previous timeout policy and passes with this change, the existing half-open reconnect/replay test remains green, and the behavior was verified over a real cross-version paired transport.

Made with [Orca](https://github.com/stablyai/orca) 🐋
