### PR TITLE
feat(source-control): add copy relative path

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -7974,6 +7974,7 @@ const UncommittedEntryRow = React.memo(function UncommittedEntryRow({
     <SourceControlEntryContextMenu
       currentWorktreeId={currentWorktreeId}
       absolutePath={joinPath(worktreePath, entry.path)}
+      relativePath={entry.path}
       connectionId={connectionId}
       onView={() => onOpen(entry)}
       onRevealInExplorer={onRevealInExplorer}
@@ -8229,6 +8230,7 @@ function BranchEntryRow({
     <SourceControlEntryContextMenu
       currentWorktreeId={currentWorktreeId}
       absolutePath={joinPath(worktreePath, entry.path)}
+      relativePath={entry.path}
       connectionId={connectionId}
       onView={() => onOpen()}
       onRevealInExplorer={onRevealInExplorer}

--- a/src/renderer/src/components/right-sidebar/source-control-entry-context-menu.test.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control-entry-context-menu.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SourceControlEntryContextMenu } from './source-control-entry-context-menu'
+
+type ItemProps = { onSelect?: () => void; children?: React.ReactNode }
+
+const items = vi.hoisted(() => ({ list: [] as ItemProps[] }))
+
+vi.mock('@/components/ui/context-menu', async () => {
+  const React_ = await import('react')
+  const passthrough = ({ children }: { children?: React.ReactNode }) =>
+    React_.createElement(React_.Fragment, null, children)
+
+  return {
+    ContextMenu: passthrough,
+    ContextMenuContent: passthrough,
+    ContextMenuItem: (props: ItemProps) => {
+      items.list.push(props)
+      return React_.createElement(React_.Fragment, null, props.children)
+    },
+    ContextMenuSeparator: () => null,
+    ContextMenuSub: passthrough,
+    ContextMenuSubContent: passthrough,
+    ContextMenuSubTrigger: passthrough,
+    ContextMenuTrigger: passthrough
+  }
+})
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: { settings: { openInApplications: never[] } }) => unknown) =>
+    selector({ settings: { openInApplications: [] } })
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+vi.mock('@/lib/local-file-manager-label', () => ({
+  getLocalFileManagerLabel: () => 'Finder'
+}))
+
+vi.mock('@/lib/open-in-app-catalog', () => ({
+  OpenInApplicationIcon: () => null
+}))
+
+vi.mock('@/components/sidebar/WorktreeOpenInMenu', () => ({
+  getWorktreeOpenInEntries: () => [],
+  openOpenInAppsSettings: vi.fn(),
+  openWorktreePath: vi.fn()
+}))
+
+function childrenText(children: React.ReactNode): string {
+  return React.Children.toArray(children)
+    .filter((child): child is string => typeof child === 'string')
+    .join('')
+}
+
+describe('SourceControlEntryContextMenu', () => {
+  const writeClipboardText = vi.fn()
+
+  beforeEach(() => {
+    items.list = []
+    writeClipboardText.mockReset()
+    vi.stubGlobal('window', {
+      api: { ui: { writeClipboardText } }
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('copies the supplied relative path', () => {
+    renderToStaticMarkup(
+      <SourceControlEntryContextMenu
+        currentWorktreeId="worktree-1"
+        absolutePath="/repo/src/example.ts"
+        relativePath="src/example.ts"
+        onRevealInExplorer={vi.fn()}
+      >
+        <div />
+      </SourceControlEntryContextMenu>
+    )
+
+    const copyRelativePathItem = items.list.find(
+      (item) => childrenText(item.children) === 'Copy Relative Path'
+    )
+
+    expect(copyRelativePathItem).toBeDefined()
+    copyRelativePathItem?.onSelect?.()
+    expect(writeClipboardText).toHaveBeenCalledWith('src/example.ts')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control-entry-context-menu.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control-entry-context-menu.tsx
@@ -23,6 +23,7 @@ import {
 type SourceControlEntryContextMenuProps = {
   currentWorktreeId: string
   absolutePath?: string
+  relativePath?: string
   connectionId?: string | null
   onView?: () => void
   onRevealInExplorer: (worktreeId: string, absolutePath: string) => void
@@ -33,6 +34,7 @@ type SourceControlEntryContextMenuProps = {
 export function SourceControlEntryContextMenu({
   currentWorktreeId,
   absolutePath,
+  relativePath,
   connectionId,
   onView,
   onRevealInExplorer,
@@ -52,6 +54,13 @@ export function SourceControlEntryContextMenu({
     }
     void window.api.ui.writeClipboardText(absolutePath)
   }, [absolutePath])
+
+  const handleCopyRelativePath = useCallback(() => {
+    if (!relativePath) {
+      return
+    }
+    void window.api.ui.writeClipboardText(relativePath)
+  }, [relativePath])
 
   const handleRevealInOrcaExplorer = useCallback(() => {
     if (!absolutePath) {
@@ -90,6 +99,13 @@ export function SourceControlEntryContextMenu({
         <ContextMenuItem onSelect={handleCopyPath} disabled={!absolutePath}>
           <Copy className="size-3.5" />
           {translate('auto.components.right.sidebar.FileExplorerRow.b5d436aa30', 'Copy Path')}
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={handleCopyRelativePath} disabled={!relativePath}>
+          <Copy className="size-3.5" />
+          {translate(
+            'auto.components.right.sidebar.FileExplorerRow.66a29dde82',
+            'Copy Relative Path'
+          )}
         </ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuSub>


### PR DESCRIPTION
## Summary

Adds “Copy Relative Path” to the Source Control file context menu, directly below the existing “Copy Path” command.

The command copies the path of the row whose context menu was opened, relative to the worktree root. It intentionally preserves the existing single-row behavior of “Copy Path” and does not change multi-selection behavior.

Closes https://github.com/stablyai/orca/issues/9017

## Screenshots

<img width="345" height="453" alt="SCR-20260716-qrxm" src="https://github.com/user-attachments/assets/e94bf3a2-c33e-448e-a27a-54bd5b89dc51" />

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

The full test suite completed with 29,963 passing tests, 42 skipped tests, and two failures unrelated to this change:

- The orchestration keepalive timing test failed during the full run but passed when rerun in isolation.
- The zsh path-lookup test consistently resolves the Homebrew `mise` executable instead of the current `mise`-managed Node executable in this local environment.

The focused Source Control context-menu regression test passes.

## AI Review Report

The AI coding agent reviewed the implementation and regression test for:

- Consistency with the existing “Copy Path” behavior
- Correct placement and labeling of the new context-menu command
- Correct wiring for both uncommitted-change and branch-comparison rows
- Accidental changes to Source Control multi-selection behavior
- Reuse of existing context-menu primitives, icons, translations, and clipboard IPC
- SSH and cross-platform path behavior

The review confirmed that the command copies the existing Git-relative `entry.path` without local filesystem conversion. This keeps the behavior consistent across macOS, Linux, Windows, WSL, and SSH environments.

A standalone React Doctor scan reported existing diagnostics in the large `SourceControl.tsx` component. None related to this change; the repository’s changed-file React Doctor gate passed. No implementation changes were required as a result.

The review explicitly checked cross-platform compatibility. This PR does not add or change keyboard shortcuts, shortcut labels, shell commands, filesystem operations, or Electron platform-specific behavior. It only passes an existing Git-relative path string to the existing clipboard API.

## Security Audit

The AI coding agent reviewed the change for input handling, command execution, path handling, authentication, secrets, dependencies, and IPC risks.

- The relative path originates from existing Git status data.
- The value is copied to the clipboard only after an explicit user action.
- The path is not executed, resolved, parsed, or passed to a shell.
- No filesystem access, authentication, secrets, or permissions are involved.
- No dependencies were added or changed.
- No new IPC surface was introduced; the implementation reuses the existing `window.api.ui.writeClipboardText` API already used by “Copy Path.”

No security follow-up is needed.

## Notes

- The command intentionally copies only the row whose context menu was opened, matching the existing “Copy Path” behavior.
- Multi-selection behavior is unchanged.
- Relative paths come directly from Git status data, so the feature does not depend on local path separators and works for remote SSH worktrees.
- No shortcuts, shell behavior, or Electron platform-specific behavior were changed.