### PR TITLE
fix(i18n): translate untranslated Korean catalog strings

### DIFF
--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1425,7 +1425,7 @@
         "checkActionRequiredHint": "머지가 해제되려면 이 검사에 대해 GitHub에서 수동 작업(예: 워크플로우 실행 승인)이 필요합니다.",
         "dd5d9a4f17": "{{value0}}에 업데이트됨",
         "71a3c0f9d2": "워크스페이스 시작",
-        "filesUnavailable": "Couldn't load changed files.",
+        "filesUnavailable": "변경된 파일을 불러오지 못했습니다.",
         "filesRetry": "Retry"
       },
       "QuickOpen": {
@@ -2409,8 +2409,8 @@
             "error": "워크스페이스 정리 실패",
             "skippedAncestor": "중첩된 워크스페이스를 제거할 수 없어 건너뛰었습니다.",
             "timedOut": "{{value0}} 제거가 예상보다 오래 걸리고 있습니다. 백그라운드에서 계속 실행됩니다.",
-            "stillRemoving": "Still removing workspaces: {{value0}}",
-            "skippedPendingAncestor": "Skipped because a nested workspace has not finished removing."
+            "stillRemoving": "아직 워크스페이스를 제거하는 중입니다: {{value0}}",
+            "skippedPendingAncestor": "중첩된 워크스페이스의 제거가 끝나지 않아 건너뛰었습니다."
           },
           "candidateRow": {
             "gitLabel": "Git",
@@ -3262,8 +3262,8 @@
             "remaining": "{{value0}}% 남음"
           },
           "UsagePercentageDisplayChangeNotice": {
-            "title": "Usage now shows % used",
-            "body": "Prefer remaining? Change it in Settings.",
+            "title": "사용량이 이제 사용된 %로 표시됩니다",
+            "body": "남은 양 표시를 원하시나요? 설정에서 변경할 수 있습니다.",
             "dismiss": "Dismiss",
             "openSettings": "Open Settings",
             "gotIt": "Got it"
@@ -4770,7 +4770,7 @@
           "forgetBody": "이 작업 공간을 Orca에서만 제거합니다. 파일, Git 워크트리, {{host}}의 브랜치는 그대로 유지됩니다.",
           "title": "Delete “{{name}}”?",
           "disconnectedBody": "이 워크트리의 SSH 호스트가 연결되어 있지 않습니다. 재연결하여 원격에서도 삭제하거나 Orca에서만 제거하세요.",
-          "ghostBody": "{{host}} is no longer a saved SSH host, so this workspace is no longer connected to a live host. It can only be removed from Orca — files and branches on the remote are left untouched.",
+          "ghostBody": "{{host}}은(는) 더 이상 저장된 SSH 호스트가 아니므로 이 워크스페이스는 라이브 호스트에 연결되어 있지 않습니다. Orca에서 제거만 할 수 있으며, 원격의 파일과 브랜치는 그대로 유지됩니다.",
           "cancel": "취소",
           "forget": "Orca에서 제거",
           "reconnectAndDelete": "재연결 후 삭제"
@@ -5089,7 +5089,7 @@
           "windowSidebarSummary": "사이드바, 상태 표시줄 및 파일 탐색기",
           "statusBarCount": "{{value0}}개 표시기가 보입니다.",
           "gitIgnoredGlossary": ".gitignore와 일치하는 파일.",
-          "statusBarDescription": "Choose which indicators appear in the status bar.",
+          "statusBarDescription": "상태 표시줄에 표시할 항목을 선택합니다.",
           "showPinnedWorktreesInGroups": {
             "title": "고정된 워크트리를 원래 목록에도 표시",
             "description": "고정된 워크트리는 Pinned에 유지하면서 전체, 프로젝트, 상태 및 PR에도 표시합니다."
@@ -5485,8 +5485,8 @@
           "4aa4d9fb73": "가로 스크롤을 요구하는 대신 diff 편집기에서 긴 줄을 줄 바꿈합니다.",
           "bf16ef0af2": "사용 안 함",
           "3f6892f307": "사용",
-          "b82f86d7d2": "Rich Markdown Spellcheck",
-          "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown.",
+          "b82f86d7d2": "리치 Markdown 맞춤법 검사",
+          "5195f0b9ef": "리치 Markdown을 편집하는 동안 브라우저 맞춤법 밑줄과 제안을 표시합니다.",
           "7ddd66fede": "편집기 자동 줄 바꿈",
           "9b18de6eea": "가로 스크롤 대신 파일 편집기에서 긴 줄을 자동으로 줄 바꿈합니다."
         },
@@ -6464,7 +6464,7 @@
           "2309068a6f": "파괴적",
           "65358016ea": "버리기",
           "dev": "Dev Tools",
-          "devDescription": "Dev-only tools for exercising UI states.",
+          "devDescription": "UI 상태를 시험해 보기 위한 개발 전용 도구입니다.",
           "linearTitle": "Linear",
           "linearDescription": "Give agents the skill to read and update your linked Linear tickets."
         },
@@ -7764,8 +7764,8 @@
             "8e593f04fc": "고정된 탭을 닫기 전에 확인 대화상자를 표시합니다.",
             "defaultProjectRuntime": "기본 프로젝트 런타임",
             "defaultProjectRuntimeDescription": "로컬 Windows 프로젝트가 상속할 런타임을 선택합니다.",
-            "d2d2d929c0": "Rich Markdown Spellcheck",
-            "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown.",
+            "d2d2d929c0": "리치 Markdown 맞춤법 검사",
+            "4497e2e2bb": "리치 Markdown을 편집하는 동안 브라우저 맞춤법 밑줄과 제안을 표시합니다.",
             "e61157e926": "편집기 자동 줄 바꿈",
             "005be5c699": "가로 스크롤 대신 파일 편집기에서 긴 줄을 자동으로 줄 바꿈합니다."
           }
@@ -8208,7 +8208,7 @@
             "cfad7ce5f3": "ai",
             "a47f51127e": "소스 제어",
             "6cc5c65e64": "프로젝트별 Git 생성이 재정의됩니다.",
-            "eec3995dc6": "Git AI Author",
+            "eec3995dc6": "Git AI 작성자",
             "cc876ca5f2": "repos",
             "6469de5368": "프로젝트",
             "3067595d82": "삭제",
@@ -8540,7 +8540,7 @@
               "keyword_warp": "warp",
               "keyword_themes": "themes",
               "keyword_yaml": "yaml",
-              "keyword_legacy_title": "Import themes from Warp"
+              "keyword_legacy_title": "Warp에서 테마 가져오기"
             },
             "yaml_import": {
               "title": "YAML에서 가져오기",
@@ -8765,8 +8765,8 @@
                 "e1f5e6424c": "{{value0}}개 워크스페이스{{value1}} 연결됨",
                 "disconnect_all": "연결 해제",
                 "account_scope_prefix": "계정 범위",
-                "2d60ec7921": "Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token or username and password. Credentials are sent to the selected remote runtime and stored there with runtime-supported encryption.",
-                "977e360b71": "Connect a Jira Cloud site with an API token, or a self-hosted Jira with a personal access token or username and password. Credentials are stored locally and encrypted when local runtime storage supports it."
+                "2d60ec7921": "API 토큰으로 Jira Cloud 사이트를 연결하거나, 개인 액세스 토큰 또는 사용자 이름과 비밀번호로 자체 호스팅 Jira를 연결하세요. 자격 증명은 선택한 원격 런타임으로 전송되어 런타임이 지원하는 암호화로 저장됩니다.",
+                "977e360b71": "API 토큰으로 Jira Cloud 사이트를 연결하거나, 개인 액세스 토큰 또는 사용자 이름과 비밀번호로 자체 호스팅 Jira를 연결하세요. 자격 증명은 로컬에 저장되며 로컬 런타임 저장소가 지원하는 경우 암호화됩니다."
               }
             }
           }
@@ -8928,26 +8928,26 @@
           "e27c8d45bf": "환경 변수로 인해 진단이 비활성화되었습니다."
         },
         "ShortcutCommandBlock": {
-          "eb72c52c28": "Press a shortcut, or double-tap a modifier (e.g. {{value0}}). Esc cancels.",
+          "eb72c52c28": "단축키를 누르거나 수정자 키를 두 번 탭하세요(예: {{value0}}). Esc 키로 취소합니다.",
           "70b5d25583": "{{value0}} shortcut",
           "287e07ddde": "Modified",
           "3c83cd7d1c": "Disabled",
-          "07939d084e": "Reset {{value0}} to default",
-          "9b02917027": "Reset to default",
+          "07939d084e": "{{value0}}을(를) 기본값으로 재설정",
+          "9b02917027": "기본값으로 재설정",
           "a799f90f82": "Disable {{value0}}",
           "25e6e76618": "단축키 비활성화",
           "035a822ef0": "단축키 추가",
-          "a0e2ef0e61": "Add another shortcut for {{value0}}",
+          "a0e2ef0e61": "{{value0}}에 다른 단축키 추가",
           "245c83af24": "다른 단축키 추가",
           "482a60225d": "Enable {{value0}}",
           "6287677c37": "활성화",
-          "01481b964c": "Add shortcut for {{value0}}"
+          "01481b964c": "{{value0}}에 단축키 추가"
         },
         "ShortcutRecorderButton": {
-          "1a13bb054d": "Press shortcut keys for {{value0}}. Escape cancels.",
-          "3732775d74": "Add shortcut for {{value0}}",
-          "88764af2c1": "Change shortcut for {{value0}}",
-          "30feb099d6": "Change shortcut {{value0}} of {{value1}} for {{value2}}",
+          "1a13bb054d": "{{value0}}에 사용할 단축키를 누르세요. Escape 키로 취소합니다.",
+          "3732775d74": "{{value0}}에 단축키 추가",
+          "88764af2c1": "{{value0}}의 단축키 변경",
+          "30feb099d6": "{{value2}}의 단축키 {{value1}}개 중 {{value0}}번째 변경",
           "5d982a2a1f": "단축키 대기 중",
           "152e0bcd64": "단축키 추가",
           "5bd56445da": "단축키 변경",
@@ -8955,7 +8955,7 @@
         },
         "ShortcutRemoveButton": {
           "9e29aff18b": "{{value0}} 바로가기 {{value1}} 제거",
-          "2a9588b1c2": "Remove this binding"
+          "2a9588b1c2": "이 바인딩 제거"
         },
         "BrowserLocalhostWorktreeLabelsSetting": {
           "8ac8c3ad19": "로컬호스트 작업 트리 레이블",
@@ -8981,7 +8981,7 @@
           "b94ff260e6": "안드로이드 스튜디오 다운로드",
           "18925b082d": "SDK 폴더 찾기",
           "8c52684db8": "지우기",
-          "76eb88b88e": "iOS Simulator (Xcode)",
+          "76eb88b88e": "iOS 시뮬레이터(Xcode)",
           "c6f3ea4f12": "준비됨",
           "e4f14b50d7": "Xcode를 설치하고 iOS 시뮬레이터 런타임을 추가하세요.",
           "63fe73a1ea": "Android SDK 폴더를 업데이트할 수 없습니다."
@@ -8990,33 +8990,33 @@
           "advanced": "고급"
         },
         "DevToolsPane": {
-          "nativeActionLayoutCheck": "Native action layout check",
+          "nativeActionLayoutCheck": "네이티브 액션 레이아웃 확인",
           "secondary": "Secondary",
-          "secondaryActionClicked": "Secondary action clicked",
+          "secondaryActionClicked": "보조 액션 클릭됨",
           "primaryAction": "Primary action",
-          "primaryActionClicked": "Primary action clicked",
+          "primaryActionClicked": "기본 액션 클릭됨",
           "branchHasChanges": "branch has changes",
-          "viewChangesClicked": "View Changes clicked",
-          "forceDeleteClicked": "Force Delete clicked",
+          "viewChangesClicked": "변경 사항 보기 클릭됨",
+          "forceDeleteClicked": "강제 삭제 클릭됨",
           "devOnlyCallback": "Dev-only callback.",
           "infoToast": "Info toast",
           "infoToastDescription": "명시적 작업이 없는 긴 정보 메시지입니다.",
-          "localCanaryBehind": "Local canary is behind origin/canary",
+          "localCanaryBehind": "로컬 canary가 origin/canary보다 뒤처져 있습니다",
           "successToast": "Success toast",
           "successToastDescription": "짧은 확인 상태입니다.",
           "settingsSaved": "Settings saved",
           "shortSuccessCopy": "짧은 성공 메시지입니다.",
           "errorToast": "Error toast",
           "errorToastDescription": "복구 작업이 없는 긴 오류 메시지입니다.",
-          "failedToSyncWorkspaceMetadata": "Failed to sync workspace metadata",
-          "nativeActionToast": "Native action toast",
+          "failedToSyncWorkspaceMetadata": "워크스페이스 메타데이터 동기화에 실패했습니다",
+          "nativeActionToast": "네이티브 액션 토스트",
           "nativeActionToastDescription": "Sonner 작업 및 취소 슬롯을 사용합니다.",
-          "deleteFailureToast": "Delete failure toast",
+          "deleteFailureToast": "삭제 실패 토스트",
           "deleteFailureToastDescription": "보기 및 강제 삭제가 포함된 사용자 정의 바닥글입니다.",
-          "behindBaseRefToast": "Behind base ref toast",
+          "behindBaseRefToast": "기준 ref 뒤처짐 토스트",
           "behindBaseRefToastDescription": "인라인 설정 링크와 바닥글 작업이 있는 영구 프롬프트입니다.",
           "notificationPlayground": "Notification playground",
-          "notificationPlaygroundDescription": "Dev-only triggers for checking toast layout, recovery actions, and long-copy wrapping.",
+          "notificationPlaygroundDescription": "토스트 레이아웃, 복구 액션, 긴 텍스트 줄바꿈을 확인하기 위한 개발 전용 트리거입니다.",
           "devOnly": "Dev only",
           "orcaCloud": "Orca Cloud",
           "orcaCloudDescription": "1方클라우드 로그인의 개발자 전용 미리보기. 프로덕션에서는 숨겨집니다. 개발 환경에서는 ORCA_CLOUD_API_URL과 ORCA_CLOUD_CLIENT_ID가 설정되면 사이드바 계정 전환기에도 표시됩니다.",
@@ -9130,7 +9130,7 @@
           "b7e2d9f0a3": "터미널의 grok /usage 화면과 같은 주간 크레딧 비율입니다.",
           "c6d1a8f4e2": "{{when}}에 재설정",
           "e6dadc1e2b": "Monthly usage",
-          "75e396bf42": "Included monthly usage for Grok unified-billing accounts.",
+          "75e396bf42": "Grok 통합 결제 계정에 포함된 월간 사용량입니다.",
           "b36fa2c908": "Signed in. Orca reads the Grok CLI session stored on disk.",
           "f08c41de73": "Session expired — run grok on the computer running Orca and wait for it to start. If prompted, complete sign-in, then click Refresh usage. No chat message is needed."
         },
@@ -9139,8 +9139,8 @@
           "usagePercentageDisplayRemaining": "남음"
         },
         "TerminalInteractionSection": {
-          "567633ff50": "Right-click pastes the clipboard into the terminal. Control-click to open the context menu.",
-          "c64497148a": "Right-click pastes the clipboard. Control-click opens the context menu."
+          "567633ff50": "우클릭하면 클립보드 내용을 터미널에 붙여넣습니다. 컨텍스트 메뉴를 열려면 Control 클릭하세요.",
+          "c64497148a": "우클릭하면 클립보드를 붙여넣습니다. Control 클릭으로 컨텍스트 메뉴를 엽니다."
         },
         "MobileRelayStatusSection": {
           "registered": "Registered",
@@ -9148,13 +9148,13 @@
           "reconnecting": "Reconnecting",
           "offline": "Offline",
           "title": "Orca Relay",
-          "automatic": "Connect from anywhere when a phone is paired",
-          "signInPrompt": "Sign in on this desktop to connect from anywhere",
-          "directStillAvailable": "LAN and Tailscale connections remain available.",
-          "directNeedsNoAccount": "LAN and Tailscale pairing still work without an account.",
+          "automatic": "휴대폰이 페어링되면 어디서나 연결",
+          "signInPrompt": "어디서나 연결하려면 이 데스크톱에서 로그인하세요",
+          "directStillAvailable": "LAN 및 Tailscale 연결은 계속 사용할 수 있습니다.",
+          "directNeedsNoAccount": "LAN 및 Tailscale 페어링은 계정 없이도 계속 작동합니다.",
           "signIn": "Sign in",
           "unavailable": "Unavailable",
-          "standby": "Standby — no relay devices"
+          "standby": "대기 중 — 릴레이 기기 없음"
         },
         "MobilePairingConnectionOptions": {
           "ready": "준비됨",
@@ -9724,7 +9724,7 @@
             "b0da3a4d3e": "실행 레시피가 이미 저장되었습니다",
             "bff4795a6d": "저장된 레시피를 업데이트하려면 agent, 인수 또는 프롬프트 템플릿을 변경하세요.",
             "5c75b24735": "Orca가 시작하기 전에 agent가 받을 내용을 사용자 지정합니다.",
-            "repoAgentOverrideNote": "This repository overrides your global default ({{global}}) and currently runs {{effective}}. Save to this repository to change what runs here."
+            "repoAgentOverrideNote": "이 저장소는 전역 기본값({{global}})을 재정의하며 현재 {{effective}}을(를) 실행합니다. 이 저장소에서 실행할 항목을 바꾸려면 이 저장소에 저장하세요."
           },
           "SourceControlTextGenerationDialog": {
             "c5b7fa7cb6": "전역 기본값으로 저장",
@@ -9820,9 +9820,9 @@
                 "066fedd446": "실패한 작업",
                 "ae8a04ef17": "충돌 파일 세부정보를 사용할 수 없습니다.",
                 "73d0675356": "충돌 세부정보 새로고침 중…",
-                "f5bc5c4cf1": "The hosting provider reports conflicts, but local Git did not reproduce them. Refresh the review or push the branch to recalculate mergeability.",
-                "5bc9bda2af": "Run from this worktree",
-                "e87fb3d929": "Copy mergeability refresh commands",
+                "f5bc5c4cf1": "호스팅 제공자는 충돌을 보고했지만 로컬 Git에서는 재현되지 않았습니다. 리뷰를 새로 고치거나 브랜치를 푸시하여 병합 가능성을 다시 계산하세요.",
+                "5bc9bda2af": "이 워크트리에서 실행",
+                "e87fb3d929": "병합 가능성 새로 고침 명령 복사",
                 "1e53e45072": "복사됨",
                 "084c516efb": "Copy commands",
                 "5dc3af25c0": "댓글 선택",
@@ -9832,23 +9832,23 @@
                 "49ea0937e4": "댓글을 해결 목록에 추가",
                 "9fecebb29d": "추가",
                 "b8c4e2a1f7": "전체 로그 보기",
-                "f8a2c91d04": "Queue for agent",
+                "f8a2c91d04": "에이전트 대기열에 추가",
                 "b4e8a1c902": "Queued",
                 "7c1f0a2b11": "열기",
                 "e8b4c1a903": "Resolved · {{value0}}",
-                "c3a8e5d710": "Needs review · {{value0}}",
+                "c3a8e5d710": "리뷰 필요 · {{value0}}",
                 "a7f0c7e8d1": "Queue",
                 "8a621a2c4f": "그룹화",
                 "b13f85d75c": "타임라인",
-                "f5cf324efa": "Comment display options",
+                "f5cf324efa": "댓글 표시 옵션",
                 "5e6e5a13fa": "보기",
-                "actionRequiredHint": "This check needs a manual action on GitHub (for example, approving the workflow run) before merging is unblocked.",
+                "actionRequiredHint": "이 검사는 병합 차단이 해제되기 전에 GitHub에서 수동 작업(예: 워크플로 실행 승인)이 필요합니다.",
                 "b3195cba33": "작성자의 봇 지정 해제",
                 "f588b46a6c": "작성자를 봇으로 지정"
               },
               "empty": {
                 "state": {
-                  "3322603418": "Pull request status unavailable",
+                  "3322603418": "풀 리퀘스트 상태를 사용할 수 없음",
                   "5b0cfae9a5": "체크와 리뷰를 시작하려면 {{value0}}을(를) 만드세요.",
                   "13e1c7d5ed": "{{value0}}을(를) 찾을 수 없습니다.",
                   "d372072df1": "현재 속도 제한 예산으로 인해 GitHub 새로 고침이 일시 중지되었습니다.",
@@ -9864,7 +9864,7 @@
                   "41252bc53f": "게시되지 않은 브랜치",
                   "05e4aec17b": "{{value0}} 검사는 작업이 완료된 후에 사용할 수 있습니다.",
                   "d77c513c1e": "{{value0}} 진행 중",
-                  "b597440265": "Refresh GitHub status for this branch to load checks and review."
+                  "b597440265": "검사와 리뷰를 불러오려면 이 브랜치의 GitHub 상태를 새로 고치세요."
                 }
               }
             }
@@ -10004,7 +10004,7 @@
                   "226b85a3a7": "가져오기",
                   "323bb614aa": "Commit 및 동기화",
                   "2b8e6595fd": "Commit",
-                  "04d709801d": "Fetch from remote without merging"
+                  "04d709801d": "병합하지 않고 원격에서 가져오기(fetch)"
                 }
               },
               "primary": {
@@ -10029,8 +10029,8 @@
                   "2d8f185fbc": "부분적으로 준비된 파일을 commit 하기 전에 모든 변경 사항을 준비합니다.",
                   "a6457b46a7": "commit 하기 전에 충돌을 해결하세요.",
                   "484f45c439": "{{value0}} 진행 중…",
-                  "6f7a8b9c0d": "Remote operation in progress…",
-                  "7f8a9b0c1d": "Remote operation in progress — try again once it finishes",
+                  "6f7a8b9c0d": "원격 작업 진행 중…",
+                  "7f8a9b0c1d": "원격 작업 진행 중 — 완료된 후 다시 시도하세요",
                   "74fc171e99": "강제 푸시 진행 중…",
                   "16aee3a5c1": "Commit 진행 중…",
                   "e61b0d7a3c": "commits을 게시하기 전에 브랜치를 체크아웃하세요.",
@@ -10080,8 +10080,8 @@
             "8b8ee9d22f": "이 파일을 소유한 호스트를 확인할 수 없습니다. 워크스페이스 연결을 확인한 후 다시 시도하세요.",
             "af1270b90d": "{{count}}개 항목을 영구적으로 삭제하시겠습니까?",
             "dd029aa5cd": "원격 호스트의 선택한 항목과 디렉터리 내용을 영구적으로 삭제합니다. 이 작업은 되돌릴 수 없습니다.",
-            "77fdc36183": "Delete {{count}} items?",
-            "fca915a67a": "Remote items are permanently deleted and cannot be undone. Local items move to the {{value0}}."
+            "77fdc36183": "{{count}}개 항목을 삭제하시겠습니까?",
+            "fca915a67a": "원격 항목은 영구적으로 삭제되며 되돌릴 수 없습니다. 로컬 항목은 {{value0}}(으)로 이동합니다."
           },
           "useFileExplorerHandlers": {
             "32cd9fd991": "심볼릭 링크 대상을 열 수 없습니다"
@@ -10130,7 +10130,7 @@
             "sessionsShownCompact": "{{value0}} 표시됨",
             "originalPaneUnavailable": "원래 창은 더 이상 사용할 수 없습니다.",
             "worktreeUnavailable": "워크트리는 더 이상 사용할 수 없습니다.",
-            "openSupportedWorkspace": "Open a workspace before resuming a session.",
+            "openSupportedWorkspace": "세션을 재개하기 전에 워크스페이스를 여세요.",
             "localSessionSshWorkspaceUnsupported": "이 세션의 기록은 이 컴퓨터에 저장되어 있어 SSH 워크스페이스에서는 재개할 수 없습니다. 대신 로컬 워크스페이스를 여세요.",
             "sessionHostMismatchUnsupported": "이 세션은 다른 호스트에 속합니다. 재개하려면 같은 호스트의 워크스페이스를 여세요."
           },
@@ -10162,7 +10162,7 @@
             "projectScope": "프로젝트",
             "currentProjectLower": "현재 프로젝트",
             "project": "프로젝트",
-            "hostScopeAriaLabel": "Session History host: {{value0}}",
+            "hostScopeAriaLabel": "세션 기록 호스트: {{value0}}",
             "host": "호스트"
           },
           "AiVaultSessionDetails": {
@@ -10312,9 +10312,9 @@
             "viewLog": "로그 보기"
           },
           "aiVaultSessionLogOpen": {
-            "workspaceGone": "Couldn't open log — workspace is no longer available.",
-            "notAuthorized": "Couldn't open log — path not authorized.",
-            "alreadyEditable": "Log is already open for editing."
+            "workspaceGone": "로그를 열 수 없습니다 — 워크스페이스를 더 이상 사용할 수 없습니다.",
+            "notAuthorized": "로그를 열 수 없습니다 — 경로가 승인되지 않았습니다.",
+            "alreadyEditable": "로그가 이미 편집용으로 열려 있습니다."
           },
           "github": {
             "refresh": {
@@ -10729,7 +10729,7 @@
           "9883b58693": "Orca 모바일 닫기",
           "fb5f28330e": "사이드바에 표시",
           "c669abcf8f": "사이드바에서 숨기기",
-          "e1c7b4a92d": "Configure in Settings > Mobile.",
+          "e1c7b4a92d": "설정 > 모바일에서 구성하세요.",
           "a4f8c2d91e": "왼쪽 사이드바에서 Orca Mobile 제거",
           "b7e3d1c84a": "왼쪽 사이드바에 Orca Mobile 표시",
           "f3d8e5b71a": "단축키를 왼쪽 사이드바에 다시 추가합니다."
@@ -10839,19 +10839,19 @@
           "add-custom": "사용자 지정 주소 추가…"
         },
         "WindowsFirewallNotice": {
-          "repair-success": "Windows Firewall now allows Orca Mobile on private networks",
-          "repair-failed": "Could not update the Windows Firewall rules",
-          "public-title": "Windows marks this network as public",
-          "missing-title": "Allow phone connections through Windows Firewall",
-          "public-description": "Change this trusted Wi-Fi network to Private before allowing Orca Mobile connections.",
-          "missing-description": "Windows may block the pairing server. Add a rule for this Orca app and TCP port {{port}} on Private networks.",
-          "open-settings": "Open network settings",
-          "waiting": "Waiting for Windows…",
-          "allow": "Allow phone connections",
-          "repair-unverified": "Windows Firewall access could not be verified",
-          "blocked-title": "Windows may be blocking Orca Mobile",
-          "blocked-description": "An existing inbound Block rule can override the pairing exception. Repair removes conflicting TCP rules for this Orca app, then allows port {{port}} on Private networks.",
-          "repair": "Repair firewall access"
+          "repair-success": "이제 Windows 방화벽이 개인 네트워크에서 Orca Mobile을 허용합니다",
+          "repair-failed": "Windows 방화벽 규칙을 업데이트할 수 없습니다",
+          "public-title": "Windows가 이 네트워크를 공용으로 표시합니다",
+          "missing-title": "Windows 방화벽에서 휴대폰 연결 허용",
+          "public-description": "Orca Mobile 연결을 허용하기 전에 이 신뢰할 수 있는 Wi-Fi 네트워크를 개인으로 변경하세요.",
+          "missing-description": "Windows가 페어링 서버를 차단할 수 있습니다. 개인 네트워크에서 이 Orca 앱과 TCP 포트 {{port}}에 대한 규칙을 추가하세요.",
+          "open-settings": "네트워크 설정 열기",
+          "waiting": "Windows 대기 중…",
+          "allow": "휴대폰 연결 허용",
+          "repair-unverified": "Windows 방화벽 액세스를 확인할 수 없습니다",
+          "blocked-title": "Windows가 Orca Mobile을 차단하고 있을 수 있습니다",
+          "blocked-description": "기존 인바운드 차단 규칙이 페어링 예외보다 우선할 수 있습니다. 복구를 실행하면 이 Orca 앱의 충돌하는 TCP 규칙을 제거한 다음 개인 네트워크에서 포트 {{port}}을(를) 허용합니다.",
+          "repair": "방화벽 액세스 복구"
         }
       },
       "gitlab": {
@@ -11506,9 +11506,9 @@
             }
           },
           "useEmulatorScreenKeyboard": {
-            "pasteTooLarge": "Paste is too large for emulator keyboard input.",
-            "unsupportedPasteText": "Emulator keyboard paste supports US keyboard text only.",
-            "pasteTargetUnavailable": "Emulator keyboard paste failed because the device is not ready."
+            "pasteTooLarge": "붙여넣을 내용이 에뮬레이터 키보드 입력에 비해 너무 큽니다.",
+            "unsupportedPasteText": "에뮬레이터 키보드 붙여넣기는 US 키보드 텍스트만 지원합니다.",
+            "pasteTargetUnavailable": "기기가 준비되지 않아 에뮬레이터 키보드 붙여넣기에 실패했습니다."
           }
         }
       },
@@ -11533,7 +11533,7 @@
           "21783df79f": "파일 트리 축소",
           "481e63ca52": "파일",
           "d5ac717d65": "commit 안 됨",
-          "39b6b9e4e4": "Committed on Branch"
+          "39b6b9e4e4": "브랜치에 커밋됨"
         },
         "CombinedDiffViewer": {
           "35cc27aeb2": "소스 제어에서",
@@ -12193,14 +12193,14 @@
           },
           "submit": {
             "notice": {
-              "unknownError": "The crash report request failed before it returned a reason.",
-              "ticketUploaded": "Diagnostic ticket {{value0}} was uploaded but not linked.",
-              "uncheckDiagnostics": "Uncheck \"Attach recent diagnostic logs\" and try again, or copy the details.",
-              "checkConnection": "Check your connection and try again, or copy the details.",
-              "notSent": "Crash report wasn't sent",
+              "unknownError": "크래시 보고서 요청이 이유를 반환하기 전에 실패했습니다.",
+              "ticketUploaded": "진단 티켓 {{value0}}이(가) 업로드되었지만 연결되지 않았습니다.",
+              "uncheckDiagnostics": "\"최근 진단 로그 첨부\"를 해제하고 다시 시도하거나, 세부 정보를 복사하세요.",
+              "checkConnection": "연결을 확인하고 다시 시도하거나, 세부 정보를 복사하세요.",
+              "notSent": "크래시 보고서가 전송되지 않았습니다",
               "copyDetails": "Copy Details",
-              "sentWithoutDiagnostics": "Crash report sent without diagnostic logs",
-              "diagnosticsReason": "Diagnostic logs were not attached: {{value0}}"
+              "sentWithoutDiagnostics": "진단 로그 없이 크래시 보고서를 전송했습니다",
+              "diagnosticsReason": "진단 로그가 첨부되지 않았습니다: {{value0}}"
             }
           },
           "copy": {
@@ -12391,9 +12391,9 @@
             "c13693fe27": "{{value0}}개 주석",
             "074f0ed10b": "{{value0}}개 주석이 준비되었습니다. 다른 요소를 선택하거나 모든 피드백을 복사하세요.",
             "a2164a6e5a": "{{value0}}개 주석이 준비되었습니다. 다른 요소를 선택하거나 모든 피드백을 복사하세요.",
-            "9f6f2e8c19": "The downloaded file path is unavailable.",
-            "0c79b7634d": "Could not open the downloaded file. It may have been moved or deleted.",
-            "397d9dc923": "Could not show the downloaded file. It may have been moved or deleted.",
+            "9f6f2e8c19": "다운로드한 파일 경로를 사용할 수 없습니다.",
+            "0c79b7634d": "다운로드한 파일을 열 수 없습니다. 파일이 이동되었거나 삭제되었을 수 있습니다.",
+            "397d9dc923": "다운로드한 파일을 표시할 수 없습니다. 파일이 이동되었거나 삭제되었을 수 있습니다.",
             "39c04fed61": "Downloading paused",
             "5c3d530a68": "Downloaded",
             "4bb7424d6b": "Canceled",
@@ -12757,7 +12757,7 @@
         "AutomationSetupDecisionField": {
           "5a7863909c": "새 워크스페이스마다 설정 실행",
           "18f000ad4e": "고급",
-          "874b72195b": "When this automation creates a workspace, prepare it the same way creating a worktree by hand does — run the project's setup and open its terminal tabs."
+          "874b72195b": "이 자동화가 워크스페이스를 만들 때, 워크트리를 직접 만들 때와 같은 방식으로 준비합니다 — 프로젝트 설정을 실행하고 터미널 탭을 엽니다."
         }
       },
       "agent": {
@@ -12830,23 +12830,23 @@
             "e176f9d0c5": "Jira Cloud 사이트 URL",
             "d785c42b8b": "Jira Cloud 사이트 URL, Atlassian 이메일, API 토큰을 사용해 이슈를 탐색합니다.",
             "8388bdea2b": "Jira 사이트 연결",
-            "2e2b69e48e": "Use a self-hosted Jira base URL and a personal access token to browse issues.",
-            "b67e919bd5": "Jira instance type",
+            "2e2b69e48e": "자체 호스팅 Jira 기본 URL과 개인 액세스 토큰으로 이슈를 탐색하세요.",
+            "b67e919bd5": "Jira 인스턴스 유형",
             "17787d6e4b": "Atlassian Cloud",
             "bc7a831773": "Self-hosted",
-            "3489e186d6": "Jira site URL",
+            "3489e186d6": "Jira 사이트 URL",
             "cbc27fa599": "https://jira.example.com",
-            "730d973bae": "Personal access token",
-            "8b9c7b9e7b": "Jira personal access token",
-            "ccfb086d3e": "Create a personal access token in your Jira profile under Personal Access Tokens.",
-            "1d947a07ab": "Use a self-hosted Jira base URL, username, and password to browse issues.",
-            "f49708c369": "Jira authentication method",
+            "730d973bae": "개인 액세스 토큰",
+            "8b9c7b9e7b": "Jira 개인 액세스 토큰",
+            "ccfb086d3e": "Jira 프로필의 개인 액세스 토큰 메뉴에서 개인 액세스 토큰을 생성하세요.",
+            "1d947a07ab": "자체 호스팅 Jira 기본 URL, 사용자 이름, 비밀번호로 이슈를 탐색하세요.",
+            "f49708c369": "Jira 인증 방법",
             "84a810dd0e": "Username & password",
             "8d1223fa5c": "Username",
             "be9eba0a1b": "username",
             "70035652d7": "Password",
-            "c50abbf340": "Jira account password",
-            "d8737db691": "Use your Jira Server or Data Center account username and password."
+            "c50abbf340": "Jira 계정 비밀번호",
+            "d8737db691": "Jira Server 또는 Data Center 계정의 사용자 이름과 비밀번호를 사용하세요."
           }
         }
       },


### PR DESCRIPTION
## Summary

Translate 105 `ko.json` entries that were still identical to their English source after the machine bootstrap. Affected areas: dialog bodies, settings descriptions, shortcut recorder labels, Windows firewall notices, Jira connection copy, crash-report notices, emulator/browser pane errors, and source-control checks-panel text.

Intentionally left in English:

- brand/product names (e.g. "Claude Agent Teams")
- command and config examples (e.g. `orca serve --pairing-address <host>`)
- CSS/selector strings used by animated feature-wall visuals
- lowercase concatenation fragments (e.g. `"from Orca. Its files stay on {{value0}} …"`) whose word order cannot be reordered safely into Korean without touching the composing code

Translations follow the catalog's existing polite register (descriptions in -합니다, imperatives in -하세요) and preserve all `{{placeholder}}` tokens, adding Korean particle alternations (`을(를)`, `이(가)`, `(으)로`) where the placeholder value is variable. Translated by a native Korean speaker.

## Screenshots

Text-only catalog change; no visual/layout change beyond the strings themselves rendering in Korean instead of English when the UI language is set to 한국어.

## Testing

- [x] `pnpm run verify:localization-catalog` — key parity verified for all 5 locales (10,683 keys each)
- [x] `npx vitest run --config config/vitest.config.ts src/renderer/src/i18n` — 5 files, 17 tests passed
- [x] `oxfmt` clean; diff is exactly one line per translated key (no reformatting noise)

## Code Review Summary

- Cross-platform: string-only change; no code paths touched. Windows-specific strings (firewall notices) reviewed for accuracy against the English source.
- Local/remote/SSH: no behavior change; SSH-related strings (ForgetSshWorkspaceDialog, remote runtime Jira credential copy) translated faithfully including the remote-vs-local credential storage distinction.
- Agents/integrations/providers: provider names kept in English; provider-neutral wording preserved (e.g. "hosting provider" → "호스팅 제공자").
- Performance: none — data-only change to an existing catalog file.
- UI quality: longer Korean strings checked to be comparable in length to English; no truncation risk beyond what other locales already exercise.
- Security: no code, no credentials, no dependency changes.

## Notes

- No platform-, agent-, or git-provider-specific behavior changes.
