### PR TITLE
fix(resource-manager): expose detached SSH terminal origins

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -8252,6 +8252,69 @@ describe('Store', () => {
     expect(session.terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual({})
   })
 
+  it('retires older SSH leases for the same terminal pane when a replacement attaches', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty-1',
+      worktreeId: 'wt1',
+      tabId: 'tab1',
+      leafId: TEST_LEAF_1,
+      state: 'attached'
+    })
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty-2',
+      worktreeId: 'wt1',
+      tabId: 'tab1',
+      leafId: TEST_LEAF_1,
+      state: 'attached'
+    })
+
+    const leases = store.getSshRemotePtyLeases('ssh-1')
+    expect(leases).toEqual([
+      expect.objectContaining({
+        ptyId: 'remote-pty-1',
+        state: 'expired'
+      }),
+      expect.objectContaining({
+        ptyId: 'remote-pty-2',
+        state: 'attached'
+      })
+    ])
+  })
+
+  it('keeps SSH leases for different leaves attached when another pane attaches', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty-1',
+      worktreeId: 'wt1',
+      tabId: 'tab1',
+      leafId: TEST_LEAF_1,
+      state: 'attached'
+    })
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty-2',
+      worktreeId: 'wt1',
+      tabId: 'tab1',
+      leafId: TEST_LEAF_2,
+      state: 'attached'
+    })
+
+    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([
+      expect.objectContaining({
+        ptyId: 'remote-pty-1',
+        state: 'attached'
+      }),
+      expect.objectContaining({
+        ptyId: 'remote-pty-2',
+        state: 'attached'
+      })
+    ])
+  })
+
   it('does not let an expired lease for another tab suppress a matching pty id', async () => {
     const store = await createStore()
     store.upsertSshRemotePtyLease({

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -6372,6 +6372,21 @@ export class Store {
       normalizedLease.ptyId
     )
     const now = Date.now()
+    if (normalizedLease.state === 'attached' && normalizedLease.tabId && normalizedLease.leafId) {
+      for (const entry of this.state.sshRemotePtyLeases) {
+        if (
+          entry.targetId === normalizedLease.targetId &&
+          entry.tabId === normalizedLease.tabId &&
+          entry.leafId === normalizedLease.leafId &&
+          entry.ptyId !== normalizedLease.ptyId &&
+          entry.state !== 'terminated' &&
+          entry.state !== 'expired'
+        ) {
+          entry.state = 'expired'
+          entry.updatedAt = now
+        }
+      }
+    }
     const existingIndex = this.state.sshRemotePtyLeases.findIndex(
       (entry) =>
         entry.targetId === normalizedLease.targetId && entry.ptyId === normalizedLease.ptyId

--- a/src/main/runtime/claude-agent-teams-service.test.ts
+++ b/src/main/runtime/claude-agent-teams-service.test.ts
@@ -57,6 +57,7 @@ function createServiceWithLeader(): {
       writable: true,
       lastOutputAt: null,
       preview: '',
+      presentation: 'visible' as const,
       paneRuntimeId: -1,
       ptyId: 'pty-1',
       rendererGraphEpoch: 1

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1773,7 +1773,9 @@ describe('OrcaRuntimeService', () => {
       branch: 'feature/foo',
       ptyId: 'pty-1',
       title: 'Claude',
-      preview: 'hello from terminal'
+      preview: 'hello from terminal',
+      presentation: 'visible',
+      presentationSource: 'renderer_graph'
     })
 
     const shown = await runtime.showTerminal(terminals.terminals[0].handle)
@@ -1975,7 +1977,10 @@ describe('OrcaRuntimeService', () => {
 
     const after = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`)
     expect(after.terminals).toHaveLength(1)
-    expect(after.terminals[0].ptyId).toBe('pty-agent')
+    expect(after.terminals[0]).toMatchObject({
+      ptyId: 'pty-agent',
+      presentation: 'visible'
+    })
   })
 
   it('invalidates a re-keyed leaf-unique handle so in-flight waiters fail fast', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -21223,7 +21223,9 @@ export class OrcaRuntimeService {
       connected: leaf.connected,
       writable: leaf.writable,
       lastOutputAt: leaf.lastOutputAt,
-      preview: leaf.preview
+      preview: leaf.preview,
+      presentation: 'visible',
+      presentationSource: 'renderer_graph'
     }
   }
 
@@ -22435,6 +22437,7 @@ export class OrcaRuntimeService {
     worktreesById: Map<string, ResolvedWorktree>
   ): RuntimeTerminalSummary {
     const worktree = worktreesById.get(pty.worktreeId)
+    const origin = this.findPersistedTerminalOriginForPty(pty.ptyId)
 
     return {
       handle: this.issuePtyHandle(pty),
@@ -22448,8 +22451,60 @@ export class OrcaRuntimeService {
       connected: pty.connected,
       writable: pty.connected,
       lastOutputAt: pty.lastOutputAt,
-      preview: pty.preview
+      preview: pty.preview,
+      presentation: 'orphaned',
+      presentationSource: 'pty_record',
+      orphanReason: 'live_pty_without_renderer_leaf',
+      originTabId: pty.tabId ?? origin?.tabId ?? null,
+      originLeafId: origin?.leafId ?? null,
+      originPaneKey: pty.paneKey ?? origin?.paneKey ?? null,
+      originConnectionId: pty.connectionId
     }
+  }
+
+  private findPersistedTerminalOriginForPty(ptyId: string): {
+    tabId: string
+    leafId: string | null
+    paneKey: string | null
+  } | null {
+    const session = this.store?.getWorkspaceSession?.()
+    if (!session) {
+      return null
+    }
+
+    const findLeafId = (tabId: string): string | null => {
+      const ptyIdsByLeafId = session.terminalLayoutsByTabId?.[tabId]?.ptyIdsByLeafId ?? {}
+      for (const [leafId, savedPtyId] of Object.entries(ptyIdsByLeafId)) {
+        if (savedPtyId === ptyId) {
+          return leafId
+        }
+      }
+      return null
+    }
+
+    for (const [tabId, savedPtyId] of Object.entries(session.remoteSessionIdsByTabId ?? {})) {
+      if (savedPtyId === ptyId) {
+        const leafId = findLeafId(tabId)
+        return {
+          tabId,
+          leafId,
+          paneKey: leafId ? makePaneKey(tabId, leafId) : null
+        }
+      }
+    }
+
+    for (const tabId of Object.keys(session.terminalLayoutsByTabId ?? {})) {
+      const leafId = findLeafId(tabId)
+      if (leafId) {
+        return {
+          tabId,
+          leafId,
+          paneKey: makePaneKey(tabId, leafId)
+        }
+      }
+    }
+
+    return null
   }
 
   private getLiveLeafForHandle(handle: string): {

--- a/src/main/runtime/orchestration/groups.test.ts
+++ b/src/main/runtime/orchestration/groups.test.ts
@@ -18,7 +18,8 @@ function makeSummary(
     connected: opts.connected ?? true,
     writable: opts.writable ?? true,
     lastOutputAt: opts.lastOutputAt ?? null,
-    preview: opts.preview ?? ''
+    preview: opts.preview ?? '',
+    presentation: opts.presentation ?? 'visible'
   }
 }
 

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -333,7 +333,8 @@ describe('orchestration RPC methods', () => {
         connected: opts.connected ?? true,
         writable: opts.writable ?? true,
         lastOutputAt: opts.lastOutputAt ?? null,
-        preview: opts.preview ?? ''
+        preview: opts.preview ?? '',
+        presentation: opts.presentation ?? 'visible'
       }
     }
 

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.rows.test.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.rows.test.tsx
@@ -49,6 +49,12 @@ function makeSession(overrides: Partial<UnifiedSessionRow>): UnifiedSessionRow {
     cpu: 1,
     memory: 100,
     hasLocalSamples: true,
+    connectionId: null,
+    hostLabel: null,
+    relayPtyId: null,
+    originLeafId: null,
+    originSource: null,
+    orphanReason: null,
     ...overrides
   }
 }
@@ -132,6 +138,33 @@ describe('resource manager row presentation', () => {
     )
 
     expect(container.querySelector('button[aria-label="Kill session orphan-a"]')).not.toBeNull()
+  })
+
+  it('shows detached session diagnostics', () => {
+    renderWorktreeRow(
+      makeWorktree({
+        sessions: [
+          makeSession({
+            sessionId: 'ssh:ssh-bumblebee@@pty-4',
+            bound: false,
+            tabId: null,
+            cpu: null,
+            memory: null,
+            connectionId: 'ssh-bumblebee',
+            hostLabel: 'Bumblebee',
+            relayPtyId: 'pty-4',
+            originLeafId: 'leaf-1',
+            originSource: 'layout-wake',
+            orphanReason: 'live PTY has a workspace but no renderer pane binding'
+          })
+        ]
+      })
+    )
+
+    expect(container.textContent).toContain('Detached')
+    expect(container.textContent).toContain('Bumblebee · pty-4')
+    expect(container.textContent).toContain('leaf leaf-1')
+    expect(container.textContent).toContain('live PTY has a workspace but no renderer pane binding')
   })
 
   it('shows browsers as read-only workspace resources', () => {

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.session-polling.test.ts
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.session-polling.test.ts
@@ -14,10 +14,20 @@ describe('ResourceUsageStatusSegment session polling', () => {
 
     const openEffectIndex = source.indexOf('if (!open)')
     const refreshIndex = source.indexOf('void refreshSessions()', openEffectIndex)
+    const runtimeRefreshIndex = source.indexOf('void refreshRuntimeTerminals()', openEffectIndex)
 
     // Why: pty.listSessions() is a global daemon inventory and can pause input
     // with large preserved-session sets. Keep it on explicit Resource Manager use.
     expect(openEffectIndex).toBeGreaterThanOrEqual(0)
     expect(refreshIndex).toBeGreaterThan(openEffectIndex)
+    expect(runtimeRefreshIndex).toBeGreaterThan(openEffectIndex)
+  })
+
+  it('attributes the complete local daemon session inventory', () => {
+    const source = readFileSync(SOURCE_PATH, 'utf8')
+
+    expect(source).toContain("{ kind: 'local' },\n        'terminal.list'")
+    expect(source).toContain('{ limit: Number.MAX_SAFE_INTEGER }')
+    expect(source).not.toContain('getActiveRuntimeTarget(settings)')
   })
 })

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -47,7 +47,8 @@ import type {
   Metric,
   UnifiedProjectGroup,
   UnifiedSessionRow,
-  UnifiedWorktreeRow
+  UnifiedWorktreeRow,
+  RuntimeTerminalAttribution
 } from './resource-usage-merge-types'
 import { WorkspaceSpaceCompactPanel } from './WorkspaceSpaceCompactPanel'
 import { STATUS_BAR_CONTEXT_MENU_EXEMPT_PROPS } from './status-bar-context-menu-policy'
@@ -79,6 +80,8 @@ import {
 } from './resource-session-bindings'
 import { createClosedResourceSessionCountSelector } from './resource-session-count-selector'
 import { translate } from '@/i18n/i18n'
+import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
+import type { RuntimeTerminalListResult } from '../../../../shared/runtime-types'
 
 const POLL_MS = 2_000
 const selectClosedResourceSessionCount = createClosedResourceSessionCountSelector()
@@ -120,6 +123,22 @@ function formatMetricCpu(value: Metric): string {
 
 function formatMetricMemory(value: Metric): string {
   return value === null ? '—' : formatMemory(value)
+}
+
+function formatSessionDiagnostics(session: UnifiedSessionRow): string | null {
+  const details: string[] = []
+  if (session.hostLabel) {
+    details.push(
+      session.relayPtyId ? `${session.hostLabel} · ${session.relayPtyId}` : session.hostLabel
+    )
+  }
+  if (session.originLeafId) {
+    details.push(`leaf ${session.originLeafId}`)
+  }
+  if (session.orphanReason) {
+    details.push(session.orphanReason)
+  }
+  return details.length > 0 ? details.join(' · ') : null
 }
 
 // ─── Sparkline ──────────────────────────────────────────────────────
@@ -406,8 +425,23 @@ export function SessionRow({
           session.bound ? 'bg-emerald-500' : 'bg-muted-foreground/40'
         )}
       />
-      <span className="text-[11px] text-muted-foreground truncate min-w-0 flex-1">
-        {session.label}
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-[11px] text-muted-foreground">
+          {session.label}
+          {!session.bound && (
+            <span className="ml-1 rounded bg-yellow-500/10 px-1 py-0.5 text-[9px] uppercase tracking-wide text-yellow-600 dark:text-yellow-400">
+              {translate(
+                'auto.components.status.bar.ResourceUsageStatusSegment.1a3f9d7c22',
+                'Detached'
+              )}
+            </span>
+          )}
+        </span>
+        {formatSessionDiagnostics(session) && (
+          <span className="block truncate font-mono text-[10px] text-muted-foreground/60">
+            {formatSessionDiagnostics(session)}
+          </span>
+        )}
       </span>
       <MetricPair cpu={session.cpu} memory={session.memory} size="small" />
       {/* Why: kill X lives inside the shared trailing gutter so CPU/Memory
@@ -758,6 +792,7 @@ export function ResourceUsageStatusSegment({
   const fetchSnapshot = useAppStore((s) => s.fetchMemorySnapshot)
   const workspaceSessionReady = useAppStore((s) => s.workspaceSessionReady)
   const closedSessionCount = useAppStore(selectClosedResourceSessionCount)
+  const sshTargetLabels = useAppStore((s) => s.sshTargetLabels)
   const setActiveView = useAppStore((s) => s.setActiveView)
   const openModal = useAppStore((s) => s.openModal)
   const openSpacePage = useAppStore((s) => s.openSpacePage)
@@ -773,6 +808,9 @@ export function ResourceUsageStatusSegment({
   const [collapsedWorktrees, setCollapsedWorktrees] = useState<Set<string>>(new Set())
   const [appCollapsed, setAppCollapsed] = useState(true)
   const [sessions, setSessions] = useState<DaemonSession[]>([])
+  const [runtimeTerminals, setRuntimeTerminals] = useState<RuntimeTerminalListResult['terminals']>(
+    []
+  )
   const [sessionsError, setSessionsError] = useState(false)
   const [killConfirm, setKillConfirm] = useState<UnifiedSessionRow | null>(null)
   const [killing, setKilling] = useState(false)
@@ -851,11 +889,35 @@ export function ResourceUsageStatusSegment({
     }
   }, [mountedRef])
 
+  const refreshRuntimeTerminals = useCallback(async () => {
+    try {
+      // Why: pty.listSessions inventories the local daemon even when the UI is
+      // focused on a remote runtime, so attribution must come from that owner.
+      const result = await callRuntimeRpc<RuntimeTerminalListResult>(
+        { kind: 'local' },
+        'terminal.list',
+        // Why: terminal.list defaults to 200 and has no pagination cursor; its
+        // complete local inventory is needed to match every daemon session.
+        { limit: Number.MAX_SAFE_INTEGER },
+        { timeoutMs: 10_000, suppressFeatureInteraction: true }
+      )
+      if (mountedRef.current) {
+        setRuntimeTerminals(result.terminals)
+      }
+    } catch (err) {
+      console.error('[resource-usage] terminal.list attribution failed', err)
+      if (mountedRef.current) {
+        setRuntimeTerminals([])
+      }
+    }
+  }, [mountedRef])
+
   const daemonActions = useDaemonActions({
     onRestartSettled: () => {
       setSessionsError(false)
       void fetchSnapshot()
       void refreshSessions()
+      void refreshRuntimeTerminals()
     },
     onKillAllSettled: () => {
       void refreshSessions()
@@ -892,6 +954,7 @@ export function ResourceUsageStatusSegment({
     }
     void fetchSnapshot()
     void refreshSessions()
+    void refreshRuntimeTerminals()
     // Why: only the memory snapshot keeps an interval while the popover is
     // open. Session inventory is explicit-on-open/action because it can be
     // expensive with many daemon-preserved terminals.
@@ -901,7 +964,7 @@ export function ResourceUsageStatusSegment({
     return () => {
       window.clearInterval(memTimer)
     }
-  }, [open, fetchSnapshot, refreshSessions])
+  }, [open, fetchSnapshot, refreshSessions, refreshRuntimeTerminals])
 
   const repoDisplayNameById = useMemo(() => {
     const map = new Map<string, string>()
@@ -926,6 +989,26 @@ export function ResourceUsageStatusSegment({
     }
     return map
   }, [repos])
+
+  const runtimeTerminalByPtyId = useMemo(() => {
+    const map = new Map<string, RuntimeTerminalAttribution>()
+    for (const terminal of runtimeTerminals) {
+      if (!terminal.ptyId) {
+        continue
+      }
+      map.set(terminal.ptyId, {
+        worktreeId: terminal.worktreeId,
+        worktreePath: terminal.worktreePath,
+        handle: terminal.handle,
+        title: terminal.title,
+        originTabId: terminal.originTabId ?? null,
+        originLeafId: terminal.originLeafId ?? null,
+        originConnectionId: terminal.originConnectionId ?? null,
+        orphanReason: terminal.orphanReason ?? null
+      })
+    }
+    return map
+  }, [runtimeTerminals])
 
   // Why: runtime-hosted repos never have local daemon samples or killable
   // local sessions; this map drives their per-row exclusion in the merge.
@@ -976,6 +1059,8 @@ export function ResourceUsageStatusSegment({
             repoDisplayNameById,
             repoConnectionIdById,
             repoRuntimeScopedById,
+            sshTargetLabelById: sshTargetLabels,
+            runtimeTerminalByPtyId,
             browserTabsByWorktree,
             worktreeById
           })
@@ -992,6 +1077,8 @@ export function ResourceUsageStatusSegment({
       repoDisplayNameById,
       repoConnectionIdById,
       repoRuntimeScopedById,
+      sshTargetLabels,
+      runtimeTerminalByPtyId,
       browserTabsByWorktree,
       worktreeById
     ]

--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
@@ -253,6 +253,56 @@ describe('mergeSnapshotAndSessions', () => {
     })
   })
 
+  it('uses runtime terminal attribution to keep detached SSH PTYs out of unattributed', () => {
+    const sessionId = 'ssh:ssh-bumblebee@@pty-4'
+    const worktreeId = 'teal-bumblebee::/Users/daveagent/workspaces/teal'
+    const ds: DaemonSession[] = [{ id: sessionId, cwd: '', title: 'shell' }]
+    const ctx = baseCtx({
+      repoDisplayNameById: new Map([['teal-bumblebee', 'Teal']]),
+      repoConnectionIdById: new Map([['teal-bumblebee', 'ssh-bumblebee']]),
+      runtimeTerminalByPtyId: new Map([
+        [
+          sessionId,
+          {
+            handle: 'term-bumblebee',
+            ptyId: sessionId,
+            worktreeId,
+            worktreePath: '/Users/daveagent/workspaces/teal',
+            title: 'Terminal 1',
+            originTabId: 'tab-bumblebee',
+            originLeafId: 'leaf-bumblebee',
+            originConnectionId: 'ssh-bumblebee',
+            orphanReason: 'live PTY has a workspace but no renderer pane binding'
+          }
+        ]
+      ])
+    })
+
+    const out = mergeSnapshotAndSessions(null, ds, ctx)
+
+    expect(out.find((repo) => repo.repoId === UNATTRIBUTED_REPO_ID)).toBeUndefined()
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({
+      repoId: 'teal-bumblebee',
+      repoName: 'Teal',
+      hasRemoteChildren: true
+    })
+    expect(out[0].worktrees[0]).toMatchObject({
+      worktreeId,
+      worktreeName: 'workspaces/teal',
+      isRemote: true
+    })
+    expect(out[0].worktrees[0].sessions[0]).toMatchObject({
+      sessionId,
+      label: 'Terminal 1',
+      connectionId: 'ssh-bumblebee',
+      relayPtyId: 'pty-4',
+      originLeafId: 'leaf-bumblebee',
+      originSource: 'layout-wake',
+      orphanReason: 'live PTY has a workspace but no renderer pane binding'
+    })
+  })
+
   it('repo aggregate sums only worktrees with numeric metrics; remote-by-connectionId flags chip', () => {
     // Why: a single repo can be both reflected as a snapshot worktree
     // (covered by the local collector) and a daemon-only session

--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.ts
@@ -17,13 +17,8 @@
  * See docs/resource-usage-merge-spec.md for the full design.
  */
 
-import type { MemorySnapshot, SessionMemory, WorktreeMemory } from '../../../../shared/types'
+import type { MemorySnapshot, WorktreeMemory } from '../../../../shared/types'
 import { parsePtySessionId } from '../../../../shared/pty-session-id-format'
-import { parsePaneKey as parseStablePaneKey } from '../../../../shared/stable-pane-id'
-import {
-  getRepoIdFromWorktreeId,
-  getWorktreePathBasenameFromId
-} from '../../../../shared/worktree-id'
 import type {
   DaemonSession,
   MergeContext,
@@ -32,98 +27,16 @@ import type {
   UnifiedWorktreeRow
 } from './resource-usage-merge-types'
 import { buildResourceSessionBindingIndex } from './resource-session-bindings'
-
-// ─── Helpers ────────────────────────────────────────────────────────
-
-function deriveRepoIdFromWorktreeId(worktreeId: string): string {
-  return getRepoIdFromWorktreeId(worktreeId)
-}
-
-function deriveWorktreeNameFromWorktreeId(worktreeId: string): string {
-  return getWorktreePathBasenameFromId(worktreeId) ?? worktreeId
-}
-
-function shortCwd(cwd: string): string {
-  if (!cwd) {
-    return ''
-  }
-  const sep = cwd.includes('\\') ? '\\' : '/'
-  const parts = cwd.split(/[\\/]+/).filter(Boolean)
-  return parts.length > 2 ? parts.slice(-2).join(sep) : cwd
-}
-
-function parsePaneKey(paneKey: string | null): { tabId: string; leafId: string } | null {
-  if (!paneKey) {
-    return null
-  }
-  const parsed = parseStablePaneKey(paneKey)
-  return parsed ? { tabId: parsed.tabId, leafId: parsed.leafId } : null
-}
-
-function resolveSnapshotSessionLabel(
-  session: SessionMemory,
-  worktreeId: string,
-  ctx: MergeContext
-): string {
-  const parsed = parsePaneKey(session.paneKey)
-  if (parsed) {
-    const tabs = ctx.tabsByWorktree[worktreeId] ?? []
-    const tabIndex = tabs.findIndex((t) => t.id === parsed.tabId)
-    const tab = tabIndex >= 0 ? tabs[tabIndex] : undefined
-    if (tab) {
-      const custom = tab.customTitle?.trim()
-      if (custom) {
-        return custom
-      }
-      return tab.defaultTitle?.trim() || tab.title?.trim() || `Terminal ${tabIndex + 1}`
-    }
-  }
-  if (session.pid > 0) {
-    return `pid ${session.pid}`
-  }
-  const fallback = session.sessionId?.slice(0, 8)
-  return fallback ? `session ${fallback}` : '(unknown session)'
-}
-
-function resolveDaemonSessionLabel(
-  session: DaemonSession,
-  resolvedWorktreeId: string | null,
-  tabId: string | null,
-  ctx: MergeContext
-): string {
-  if (tabId && resolvedWorktreeId) {
-    const tabs = ctx.tabsByWorktree[resolvedWorktreeId] ?? []
-    const tabIndex = tabs.findIndex((t) => t.id === tabId)
-    const tab = tabIndex >= 0 ? tabs[tabIndex] : undefined
-    if (tab) {
-      const custom = tab.customTitle?.trim()
-      if (custom) {
-        return custom
-      }
-      const runtimeMap = ctx.runtimePaneTitlesByTabId[tabId]
-      if (runtimeMap) {
-        const live = Object.values(runtimeMap).find((t) => t?.trim())
-        if (live) {
-          return live
-        }
-      }
-      const fallback = tab.defaultTitle?.trim() || tab.title?.trim()
-      if (fallback) {
-        return fallback
-      }
-    }
-  }
-  if (session.cwd) {
-    return shortCwd(session.cwd)
-  }
-  if (resolvedWorktreeId) {
-    return shortCwd(resolvedWorktreeId)
-  }
-  if (session.title) {
-    return session.title
-  }
-  return 'unknown'
-}
+import {
+  deriveRepoIdFromWorktreeId,
+  deriveWorktreeNameFromWorktreeId,
+  resolveDaemonSessionLabel,
+  resolveOrphanReason,
+  resolveRuntimeTerminalAttribution,
+  resolveSessionRoute,
+  resolveSnapshotSessionLabel,
+  shortCwd
+} from './resource-usage-merge-helpers'
 
 // ─── Public merge function ─────────────────────────────────────────
 
@@ -196,16 +109,28 @@ export function mergeSnapshotAndSessions(
       const sessions: UnifiedSessionRow[] = wt.sessions.map((s) => {
         seenSessionIds.add(s.sessionId)
         const tabId = index.ptyIdToTabId.get(s.sessionId) ?? null
+        const bound = ctx.workspaceSessionReady && boundPtyIds.has(s.sessionId)
+        const route = resolveSessionRoute(s.sessionId, ctx)
+        const origin = index.originByPtyId.get(s.sessionId)
         return {
           sessionId: s.sessionId,
           paneKey: s.paneKey,
           pid: s.pid,
           label: resolveSnapshotSessionLabel(s, wt.worktreeId, ctx),
-          bound: ctx.workspaceSessionReady && boundPtyIds.has(s.sessionId),
+          bound,
           tabId,
           cpu: s.cpu,
           memory: s.memory,
-          hasLocalSamples: true
+          hasLocalSamples: true,
+          ...route,
+          originLeafId: origin?.leafId ?? null,
+          originSource: origin?.source ?? null,
+          orphanReason: resolveOrphanReason({
+            bound,
+            tabId,
+            worktreeId: wt.worktreeId,
+            hasLocalSamples: true
+          })
         }
       })
       repo.worktrees.push({
@@ -231,9 +156,12 @@ export function mergeSnapshotAndSessions(
     }
     seenSessionIds.add(session.id)
 
+    const runtimeAttribution = resolveRuntimeTerminalAttribution(session.id, ctx)
+
     // 2a: tab-store walk — does this session belong to a tab in this renderer?
-    const tabId = index.ptyIdToTabId.get(session.id) ?? null
+    const tabId = index.ptyIdToTabId.get(session.id) ?? runtimeAttribution?.originTabId ?? null
     let worktreeId = tabId ? (index.tabIdToWorktreeId.get(tabId) ?? null) : null
+    worktreeId = worktreeId ?? runtimeAttribution?.worktreeId ?? null
 
     // 2b: @@-parse — recover worktreeId from the minted session id format.
     if (!worktreeId) {
@@ -251,7 +179,9 @@ export function mergeSnapshotAndSessions(
       : ctx.repoDisplayNameById.get(finalRepoId) || finalRepoId
     const finalWorktreeName = isUnattributed
       ? session.title || session.id.slice(0, 12)
-      : deriveWorktreeNameFromWorktreeId(finalWorktreeId)
+      : runtimeAttribution?.worktreePath
+        ? shortCwd(runtimeAttribution.worktreePath)
+        : deriveWorktreeNameFromWorktreeId(finalWorktreeId)
 
     // Why: the current daemon inputs are local/SSH only; this guard prevents a
     // future local daemon row accidentally exposing kill actions for runtime PTYs.
@@ -283,16 +213,27 @@ export function mergeSnapshotAndSessions(
       repo.worktrees.push(row)
     }
 
+    const bound = ctx.workspaceSessionReady && boundPtyIds.has(session.id)
+    const route = resolveSessionRoute(session.id, ctx)
+    const origin = index.originByPtyId.get(session.id)
     row.sessions.push({
       sessionId: session.id,
       paneKey: null,
       pid: 0,
-      label: resolveDaemonSessionLabel(session, worktreeId, tabId, ctx),
-      bound: ctx.workspaceSessionReady && boundPtyIds.has(session.id),
+      label:
+        runtimeAttribution?.title?.trim() ||
+        resolveDaemonSessionLabel(session, worktreeId, tabId, ctx),
+      bound,
       tabId,
       cpu: null,
       memory: null,
-      hasLocalSamples: false
+      hasLocalSamples: false,
+      ...route,
+      originLeafId: origin?.leafId ?? runtimeAttribution?.originLeafId ?? null,
+      originSource: origin?.source ?? (runtimeAttribution ? 'layout-wake' : null),
+      orphanReason:
+        runtimeAttribution?.orphanReason ??
+        resolveOrphanReason({ bound, tabId, worktreeId, hasLocalSamples: false })
     })
   }
 

--- a/src/renderer/src/components/status-bar/resource-session-bindings.test.ts
+++ b/src/renderer/src/components/status-bar/resource-session-bindings.test.ts
@@ -61,6 +61,21 @@ describe('resource session bindings', () => {
       'pty-live',
       'pty-restored'
     ])
+    expect(index.originByPtyId.get('pty-live')).toMatchObject({
+      tabId: 'tab-active',
+      source: 'live',
+      leafId: null
+    })
+    expect(index.originByPtyId.get('pty-restored')).toMatchObject({
+      tabId: 'tab-restored',
+      source: 'tab-wake',
+      leafId: null
+    })
+    expect(index.originByPtyId.get('pty-leaf-a')).toMatchObject({
+      tabId: 'tab-restored',
+      source: 'layout-wake',
+      leafId: 'leaf-1'
+    })
   })
 
   it('ignores stale layout-only PTYs after their tab is gone', () => {

--- a/src/renderer/src/components/status-bar/resource-session-bindings.ts
+++ b/src/renderer/src/components/status-bar/resource-session-bindings.ts
@@ -8,21 +8,39 @@ export type ResourceSessionBindingInputs = {
   workspaceSessionReady: boolean
 }
 
+export type ResourceSessionBindingOrigin = {
+  tabId: string
+  worktreeId: string | null
+  leafId: string | null
+  source: 'live' | 'tab-wake' | 'layout-wake'
+}
+
 export type ResourceSessionBindingIndex = {
   ptyIdToTabId: Map<string, string>
   tabIdToWorktreeId: Map<string, string>
   boundPtyIds: Set<string>
+  originByPtyId: Map<string, ResourceSessionBindingOrigin>
 }
 
 function addBinding(
   ptyIdToTabId: Map<string, string>,
+  originByPtyId: Map<string, ResourceSessionBindingOrigin>,
+  tabIdToWorktreeId: Map<string, string>,
   tabId: string,
-  ptyId: string | null | undefined
+  ptyId: string | null | undefined,
+  source: ResourceSessionBindingOrigin['source'],
+  leafId: string | null = null
 ): void {
   if (!ptyId || ptyIdToTabId.has(ptyId)) {
     return
   }
   ptyIdToTabId.set(ptyId, tabId)
+  originByPtyId.set(ptyId, {
+    tabId,
+    worktreeId: tabIdToWorktreeId.get(tabId) ?? null,
+    leafId,
+    source
+  })
 }
 
 export function buildResourceSessionBindingIndex(
@@ -30,6 +48,7 @@ export function buildResourceSessionBindingIndex(
 ): ResourceSessionBindingIndex {
   const ptyIdToTabId = new Map<string, string>()
   const tabIdToWorktreeId = new Map<string, string>()
+  const originByPtyId = new Map<string, ResourceSessionBindingOrigin>()
 
   for (const [worktreeId, tabs] of Object.entries(inputs.tabsByWorktree)) {
     for (const tab of tabs) {
@@ -39,7 +58,7 @@ export function buildResourceSessionBindingIndex(
 
   for (const [tabId, ptyIds] of Object.entries(inputs.ptyIdsByTabId)) {
     for (const ptyId of ptyIds) {
-      addBinding(ptyIdToTabId, tabId, ptyId)
+      addBinding(ptyIdToTabId, originByPtyId, tabIdToWorktreeId, tabId, ptyId, 'live')
     }
   }
 
@@ -48,7 +67,7 @@ export function buildResourceSessionBindingIndex(
   // wake hints. Resource Manager should not classify those as orphans.
   for (const tabs of Object.values(inputs.tabsByWorktree)) {
     for (const tab of tabs) {
-      addBinding(ptyIdToTabId, tab.id, tab.ptyId)
+      addBinding(ptyIdToTabId, originByPtyId, tabIdToWorktreeId, tab.id, tab.ptyId, 'tab-wake')
     }
   }
 
@@ -56,15 +75,24 @@ export function buildResourceSessionBindingIndex(
     if (!tabIdToWorktreeId.has(tabId)) {
       continue
     }
-    for (const ptyId of Object.values(layout.ptyIdsByLeafId ?? {})) {
-      addBinding(ptyIdToTabId, tabId, ptyId)
+    for (const [leafId, ptyId] of Object.entries(layout.ptyIdsByLeafId ?? {})) {
+      addBinding(
+        ptyIdToTabId,
+        originByPtyId,
+        tabIdToWorktreeId,
+        tabId,
+        ptyId,
+        'layout-wake',
+        leafId
+      )
     }
   }
 
   return {
     ptyIdToTabId,
     tabIdToWorktreeId,
-    boundPtyIds: inputs.workspaceSessionReady ? new Set(ptyIdToTabId.keys()) : new Set()
+    boundPtyIds: inputs.workspaceSessionReady ? new Set(ptyIdToTabId.keys()) : new Set(),
+    originByPtyId
   }
 }
 

--- a/src/renderer/src/components/status-bar/resource-usage-merge-helpers.ts
+++ b/src/renderer/src/components/status-bar/resource-usage-merge-helpers.ts
@@ -1,0 +1,144 @@
+import type { SessionMemory } from '../../../../shared/types'
+import { parseAppSshPtyId } from '../../../../shared/ssh-pty-id'
+import { parsePaneKey as parseStablePaneKey } from '../../../../shared/stable-pane-id'
+import {
+  getRepoIdFromWorktreeId,
+  getWorktreePathBasenameFromId
+} from '../../../../shared/worktree-id'
+import type { DaemonSession, MergeContext } from './resource-usage-merge-types'
+
+export function deriveRepoIdFromWorktreeId(worktreeId: string): string {
+  return getRepoIdFromWorktreeId(worktreeId)
+}
+
+export function deriveWorktreeNameFromWorktreeId(worktreeId: string): string {
+  return getWorktreePathBasenameFromId(worktreeId) ?? worktreeId
+}
+
+export function shortCwd(cwd: string): string {
+  if (!cwd) {
+    return ''
+  }
+  const sep = cwd.includes('\\') ? '\\' : '/'
+  const parts = cwd.split(/[\\/]+/).filter(Boolean)
+  return parts.length > 2 ? parts.slice(-2).join(sep) : cwd
+}
+
+function parsePaneKey(paneKey: string | null): { tabId: string; leafId: string } | null {
+  if (!paneKey) {
+    return null
+  }
+  const parsed = parseStablePaneKey(paneKey)
+  return parsed ? { tabId: parsed.tabId, leafId: parsed.leafId } : null
+}
+
+export function resolveSnapshotSessionLabel(
+  session: SessionMemory,
+  worktreeId: string,
+  ctx: MergeContext
+): string {
+  const parsed = parsePaneKey(session.paneKey)
+  if (parsed) {
+    const tabs = ctx.tabsByWorktree[worktreeId] ?? []
+    const tabIndex = tabs.findIndex((t) => t.id === parsed.tabId)
+    const tab = tabIndex >= 0 ? tabs[tabIndex] : undefined
+    if (tab) {
+      const custom = tab.customTitle?.trim()
+      if (custom) {
+        return custom
+      }
+      return tab.defaultTitle?.trim() || tab.title?.trim() || `Terminal ${tabIndex + 1}`
+    }
+  }
+  if (session.pid > 0) {
+    return `pid ${session.pid}`
+  }
+  const fallback = session.sessionId?.slice(0, 8)
+  return fallback ? `session ${fallback}` : '(unknown session)'
+}
+
+export function resolveSessionRoute(
+  sessionId: string,
+  ctx: MergeContext
+): {
+  connectionId: string | null
+  hostLabel: string | null
+  relayPtyId: string | null
+} {
+  const parsed = parseAppSshPtyId(sessionId)
+  if (!parsed) {
+    return { connectionId: null, hostLabel: null, relayPtyId: null }
+  }
+  return {
+    connectionId: parsed.connectionId,
+    hostLabel: ctx.sshTargetLabelById?.get(parsed.connectionId) ?? parsed.connectionId,
+    relayPtyId: parsed.relayPtyId
+  }
+}
+
+export function resolveRuntimeTerminalAttribution(
+  sessionId: string,
+  ctx: MergeContext
+): ReturnType<NonNullable<MergeContext['runtimeTerminalByPtyId']>['get']> | null {
+  return ctx.runtimeTerminalByPtyId?.get(sessionId) ?? null
+}
+
+export function resolveOrphanReason(args: {
+  bound: boolean
+  tabId: string | null
+  worktreeId: string | null
+  hasLocalSamples: boolean
+}): string | null {
+  if (args.bound) {
+    return null
+  }
+  if (args.tabId) {
+    return 'session is known to a tab but is not currently bound'
+  }
+  if (args.worktreeId) {
+    return 'live PTY has a workspace but no renderer pane binding'
+  }
+  return args.hasLocalSamples
+    ? 'local daemon session has no renderer pane binding'
+    : 'daemon session has no workspace or pane binding'
+}
+
+export function resolveDaemonSessionLabel(
+  session: DaemonSession,
+  resolvedWorktreeId: string | null,
+  tabId: string | null,
+  ctx: MergeContext
+): string {
+  if (tabId && resolvedWorktreeId) {
+    const tabs = ctx.tabsByWorktree[resolvedWorktreeId] ?? []
+    const tabIndex = tabs.findIndex((t) => t.id === tabId)
+    const tab = tabIndex >= 0 ? tabs[tabIndex] : undefined
+    if (tab) {
+      const custom = tab.customTitle?.trim()
+      if (custom) {
+        return custom
+      }
+      const runtimeMap = ctx.runtimePaneTitlesByTabId[tabId]
+      if (runtimeMap) {
+        const live = Object.values(runtimeMap).find((t) => t?.trim())
+        if (live) {
+          return live
+        }
+      }
+      const fallback = tab.defaultTitle?.trim() || tab.title?.trim()
+      if (fallback) {
+        return fallback
+      }
+    }
+  }
+  if (session.cwd) {
+    return shortCwd(session.cwd)
+  }
+  if (resolvedWorktreeId) {
+    return shortCwd(resolvedWorktreeId)
+  }
+  if (session.title) {
+    return session.title
+  }
+  return 'unknown'
+}

--- a/src/renderer/src/components/status-bar/resource-usage-merge-types.ts
+++ b/src/renderer/src/components/status-bar/resource-usage-merge-types.ts
@@ -14,6 +14,17 @@ export type DaemonSession = {
   title: string
 }
 
+export type RuntimeTerminalAttribution = {
+  worktreeId: string
+  worktreePath: string
+  handle: string
+  title: string | null
+  originTabId: string | null
+  originLeafId: string | null
+  originConnectionId: string | null
+  orphanReason: string | null
+}
+
 export type UnifiedSessionRow = {
   sessionId: string
   paneKey: string | null
@@ -24,6 +35,12 @@ export type UnifiedSessionRow = {
   cpu: Metric
   memory: Metric
   hasLocalSamples: boolean
+  connectionId: string | null
+  hostLabel: string | null
+  relayPtyId: string | null
+  originLeafId: string | null
+  originSource: 'live' | 'tab-wake' | 'layout-wake' | null
+  orphanReason: string | null
 }
 
 export type UnifiedWorktreeRow = {
@@ -68,6 +85,10 @@ export type MergeContext = {
   repoConnectionIdById: Map<string, string | null>
   /** Repo runtime-host scope by repo id (missing == keep row). */
   repoRuntimeScopedById: Map<string, boolean>
+  /** SSH target label by target id for detached terminal diagnostics. */
+  sshTargetLabelById?: Map<string, string>
+  /** Runtime terminal list attribution by daemon PTY id. */
+  runtimeTerminalByPtyId?: Map<string, RuntimeTerminalAttribution>
   /** Browser inventory is open-only; the Resource Manager never scans it in the background. */
   browserTabsByWorktree?: Record<string, BrowserWorkspace[]>
   /** Canonical worktrees keep browser-only workspace rows out of synthetic buckets. */

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2975,7 +2975,8 @@
             "b8f4a2c1d0e3": "{{value0}} orphans",
             "c7e3b1a0d9f2": "Kill {{value0}} orphan terminal",
             "d8f4c2b1e0a3": "Kill {{value0}} orphan terminals",
-            "e9a5d3c2b1f0": "Kill {{value0}}?"
+            "e9a5d3c2b1f0": "Kill {{value0}}?",
+            "1a3f9d7c22": "Detached"
           },
           "SshStatusSegment": {
             "3ad70e0365": "Manage Remote Hosts…",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2975,7 +2975,8 @@
             "b8f4a2c1d0e3": "{{value0}} huérfanos",
             "c7e3b1a0d9f2": "Terminar {{value0}} terminal huérfano",
             "d8f4c2b1e0a3": "Terminar {{value0}} terminales huérfanos",
-            "e9a5d3c2b1f0": "¿Terminar {{value0}}?"
+            "e9a5d3c2b1f0": "¿Terminar {{value0}}?",
+            "1a3f9d7c22": "Detached"
           },
           "SshStatusSegment": {
             "3ad70e0365": "Administrar hosts remotos…",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2975,7 +2975,8 @@
             "b8f4a2c1d0e3": "{{value0}} 件の孤立",
             "c7e3b1a0d9f2": "孤立した terminal {{value0}} 件を終了",
             "d8f4c2b1e0a3": "孤立した terminals {{value0}} 件を終了",
-            "e9a5d3c2b1f0": "{{value0}} を終了しますか？"
+            "e9a5d3c2b1f0": "{{value0}} を終了しますか？",
+            "1a3f9d7c22": "Detached"
           },
           "SshStatusSegment": {
             "3ad70e0365": "リモートホストを管理…",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2975,7 +2975,8 @@
             "b8f4a2c1d0e3": "고아 {{value0}}개",
             "c7e3b1a0d9f2": "고아 terminal {{value0}}개 종료",
             "d8f4c2b1e0a3": "고아 terminals {{value0}}개 종료",
-            "e9a5d3c2b1f0": "{{value0}}을(를) 종료할까요?"
+            "e9a5d3c2b1f0": "{{value0}}을(를) 종료할까요?",
+            "1a3f9d7c22": "Detached"
           },
           "SshStatusSegment": {
             "3ad70e0365": "원격 호스트 관리…",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2975,7 +2975,8 @@
             "b8f4a2c1d0e3": "{{value0}} 个孤立项",
             "c7e3b1a0d9f2": "终止 {{value0}} 个孤立终端",
             "d8f4c2b1e0a3": "终止 {{value0}} 个孤立终端",
-            "e9a5d3c2b1f0": "终止 {{value0}}？"
+            "e9a5d3c2b1f0": "终止 {{value0}}？",
+            "1a3f9d7c22": "Detached"
           },
           "SshStatusSegment": {
             "3ad70e0365": "管理远程主机",

--- a/src/renderer/src/store/slices/ssh.test.ts
+++ b/src/renderer/src/store/slices/ssh.test.ts
@@ -190,6 +190,98 @@ describe('createSshSlice', () => {
     expect(store.getState().sshConnectedGeneration).toBe(1)
   })
 
+  it('downgrades transient workspace sync disconnect errors when the SSH target is connected', () => {
+    const store = createTestStore()
+    store.setState({
+      sshConnectionStates: new Map([
+        ['ssh-1', { targetId: 'ssh-1', status: 'connected', error: null, reconnectAttempt: 0 }]
+      ])
+    })
+
+    store.getState().setRemoteWorkspaceSyncStatus('ssh-1', {
+      phase: 'error',
+      direction: 'pull',
+      message: 'Remote connection dropped. Click Reconnect on the SSH target before retrying.'
+    })
+
+    expect(store.getState().remoteWorkspaceSyncStatusByTargetId['ssh-1']).toMatchObject({
+      phase: 'offline',
+      direction: 'pull',
+      message: 'Remote connection dropped. Click Reconnect on the SSH target before retrying.'
+    })
+  })
+
+  it('keeps transient workspace sync disconnect errors destructive while the SSH target is disconnected', () => {
+    const store = createTestStore()
+    store.setState({
+      sshConnectionStates: new Map([
+        ['ssh-1', { targetId: 'ssh-1', status: 'disconnected', error: null, reconnectAttempt: 0 }]
+      ])
+    })
+
+    store.getState().setRemoteWorkspaceSyncStatus('ssh-1', {
+      phase: 'error',
+      direction: 'pull',
+      message: 'Remote connection dropped. Click Reconnect on the SSH target before retrying.'
+    })
+
+    expect(store.getState().remoteWorkspaceSyncStatusByTargetId['ssh-1']).toMatchObject({
+      phase: 'error',
+      direction: 'pull'
+    })
+  })
+
+  it('downgrades a stale transient sync error when the SSH target reconnects', () => {
+    const store = createTestStore()
+    store.setState({
+      sshConnectionStates: new Map([
+        ['ssh-1', { targetId: 'ssh-1', status: 'disconnected', error: null, reconnectAttempt: 0 }]
+      ]),
+      remoteWorkspaceSyncStatusByTargetId: {
+        'ssh-1': {
+          phase: 'error',
+          direction: 'pull',
+          message: 'Remote connection dropped. Click Reconnect on the SSH target before retrying.'
+        }
+      }
+    })
+
+    store.getState().setSshConnectionState('ssh-1', {
+      targetId: 'ssh-1',
+      status: 'connected',
+      error: null,
+      reconnectAttempt: 0
+    })
+
+    expect(store.getState().remoteWorkspaceSyncStatusByTargetId['ssh-1']).toMatchObject({
+      phase: 'offline',
+      direction: 'pull',
+      message: 'Remote connection dropped. Click Reconnect on the SSH target before retrying.'
+    })
+    expect(store.getState().sshConnectedGeneration).toBe(1)
+  })
+
+  it('keeps non-transient workspace sync errors destructive even when connected', () => {
+    const store = createTestStore()
+    store.setState({
+      sshConnectionStates: new Map([
+        ['ssh-1', { targetId: 'ssh-1', status: 'connected', error: null, reconnectAttempt: 0 }]
+      ])
+    })
+
+    store.getState().setRemoteWorkspaceSyncStatus('ssh-1', {
+      phase: 'error',
+      direction: 'pull',
+      message: 'Failed to apply remote workspace'
+    })
+
+    expect(store.getState().remoteWorkspaceSyncStatusByTargetId['ssh-1']).toMatchObject({
+      phase: 'error',
+      direction: 'pull',
+      message: 'Failed to apply remote workspace'
+    })
+  })
+
   it('does not publish state when cleanup finds no removed SSH target state', () => {
     const store = createTestStore()
     const previousState = store.getState()

--- a/src/renderer/src/store/slices/ssh.ts
+++ b/src/renderer/src/store/slices/ssh.ts
@@ -21,6 +21,29 @@ export type RemoteWorkspaceSyncStatus = {
   message?: string
 }
 
+function isTransientRemoteWorkspaceSyncError(status: RemoteWorkspaceSyncStatus): boolean {
+  return (
+    status.phase === 'error' &&
+    typeof status.message === 'string' &&
+    status.message.includes('Remote connection dropped')
+  )
+}
+
+function normalizeRemoteWorkspaceSyncStatus(
+  status: RemoteWorkspaceSyncStatus,
+  connectionState: SshConnectionState | undefined
+): RemoteWorkspaceSyncStatus {
+  if (!isTransientRemoteWorkspaceSyncError(status) || connectionState?.status !== 'connected') {
+    return status
+  }
+
+  return {
+    ...status,
+    phase: 'offline',
+    message: status.message || 'Remote workspace sync unavailable'
+  }
+}
+
 export type SshCredentialRequest = {
   requestId: string
   targetId: string
@@ -92,12 +115,25 @@ export const createSshSlice: StateCreator<AppState, [], [], SshSlice> = (set) =>
         return s
       }
       next.set(targetId, state)
+      const connectionBecameConnected =
+        previous?.status !== 'connected' && state.status === 'connected'
+      const existingSyncStatus = s.remoteWorkspaceSyncStatusByTargetId[targetId]
+      const normalizedSyncStatus = existingSyncStatus
+        ? normalizeRemoteWorkspaceSyncStatus(existingSyncStatus, state)
+        : null
+      const remoteWorkspaceSyncStatusByTargetId =
+        normalizedSyncStatus && normalizedSyncStatus !== existingSyncStatus
+          ? {
+              ...s.remoteWorkspaceSyncStatusByTargetId,
+              [targetId]: normalizedSyncStatus
+            }
+          : s.remoteWorkspaceSyncStatusByTargetId
       return {
         sshConnectionStates: next,
-        sshConnectedGeneration:
-          previous?.status !== 'connected' && state.status === 'connected'
-            ? s.sshConnectedGeneration + 1
-            : s.sshConnectedGeneration
+        remoteWorkspaceSyncStatusByTargetId,
+        sshConnectedGeneration: connectionBecameConnected
+          ? s.sshConnectedGeneration + 1
+          : s.sshConnectedGeneration
       }
     }),
 
@@ -131,12 +167,18 @@ export const createSshSlice: StateCreator<AppState, [], [], SshSlice> = (set) =>
       return { remoteWorkspaceHydratedTargetIds: next }
     }),
   setRemoteWorkspaceSyncStatus: (targetId, status) =>
-    set((s) => ({
-      remoteWorkspaceSyncStatusByTargetId: {
-        ...s.remoteWorkspaceSyncStatusByTargetId,
-        [targetId]: status
+    set((s) => {
+      const nextStatus = normalizeRemoteWorkspaceSyncStatus(
+        status,
+        s.sshConnectionStates.get(targetId)
+      )
+      return {
+        remoteWorkspaceSyncStatusByTargetId: {
+          ...s.remoteWorkspaceSyncStatusByTargetId,
+          [targetId]: nextStatus
+        }
       }
-    })),
+    }),
   enqueueSshCredentialRequest: (req) =>
     set((s) => ({ sshCredentialQueue: [...s.sshCredentialQueue, req] })),
   removeSshCredentialRequest: (requestId) =>

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -388,6 +388,13 @@ export type RuntimeTerminalSummary = {
   writable: boolean
   lastOutputAt: number | null
   preview: string
+  presentation: 'visible' | 'orphaned'
+  presentationSource?: 'renderer_graph' | 'pty_record'
+  orphanReason?: 'live_pty_without_renderer_leaf'
+  originTabId?: string | null
+  originLeafId?: string | null
+  originPaneKey?: string | null
+  originConnectionId?: string | null
 }
 
 export type RuntimeTerminalVisualTerminalNode = {


### PR DESCRIPTION
## Summary

Resource Manager now explains detached SSH terminals instead of burying them in `Unattributed`. SSH PTYs that survive reconnects or layout drift are matched back to runtime terminal metadata, shown with host/relay/origin details, and kept grouped under the workspace they came from.

The runtime now marks terminal summaries as visible or orphaned, with persisted origin hints when a live PTY no longer has a renderer pane. Resource Manager uses the local runtime that owns the daemon PTY inventory for attribution, requests the complete terminal list, and shows detached diagnostics without making remote-environment state responsible for local sessions.

Transient remote workspace sync errors are also softened once the SSH target is connected again, so recovered hosts do not keep stale destructive sync badges after relay reconnects.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar/ResourceUsageStatusSegment.rows.test.tsx src/renderer/src/components/status-bar/ResourceUsageStatusSegment.session-polling.test.ts src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts src/renderer/src/components/status-bar/resource-session-bindings.test.ts src/renderer/src/store/slices/ssh.test.ts`
- `pnpm run typecheck:web`
- `pnpm run typecheck:node`
- `pnpm run lint`
- `pnpm run build:desktop`

Notes: validation ran on Ultra Magnus with Node `v26.5.0`; the repo declares Node `24`. The build and checks passed, but this should get a Node 24 CI pass before merge.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5_Codex-000000)

## ELI5

Detached SSH terminals showed up as vague “Unattributed” in Resource Manager. They’re now matched back to their host and workspace so you can tell where they came from.
