### PR TITLE
fix(runtime): keep remote activation publish-only

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -17075,6 +17075,74 @@ describe('OrcaRuntimeService', () => {
     ])
   })
 
+  it('keeps runtime-client tab activation publish-only unless host follow is explicit', async () => {
+    const focusTerminal = vi.fn()
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setNotifier({
+      worktreesChanged: vi.fn(),
+      reposChanged: vi.fn(),
+      activateWorktree: vi.fn(),
+      createTerminal: vi.fn(),
+      revealTerminalSession: vi.fn(),
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal,
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    })
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [],
+      leaves: [],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'epoch-1',
+          snapshotVersion: 1,
+          activeGroupId: 'group-1',
+          activeTabId: 'tab-1::pane:2',
+          activeTabType: 'terminal',
+          tabGroups: [{ id: 'group-1', activeTabId: 'tab-1', tabOrder: ['tab-1'] }],
+          tabs: [
+            {
+              type: 'terminal',
+              id: 'tab-1::pane:1',
+              parentTabId: 'tab-1',
+              leafId: 'pane:1',
+              ptyId: 'pty-pane-1',
+              title: 'left',
+              isActive: false
+            },
+            {
+              type: 'terminal',
+              id: 'tab-1::pane:2',
+              parentTabId: 'tab-1',
+              leafId: 'pane:2',
+              ptyId: 'pty-pane-2',
+              title: 'right',
+              isActive: true
+            }
+          ]
+        }
+      ]
+    })
+    runtime.registerPty('pty-pane-1', TEST_WORKTREE_ID)
+    runtime.registerPty('pty-pane-2', TEST_WORKTREE_ID)
+
+    await runtime.activateMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'tab-1::pane:1', undefined, {
+      clientKind: 'runtime'
+    })
+    expect(focusTerminal).not.toHaveBeenCalled()
+
+    await runtime.activateMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'tab-1', 'pane:2', {
+      clientKind: 'runtime',
+      followHost: true
+    })
+    expect(focusTerminal).toHaveBeenCalledWith('tab-1', TEST_WORKTREE_ID, 'pane:2')
+  })
+
   it('clears unread metadata on mobile worktree activation without focusing desktop clients', async () => {
     const metaById: Record<string, WorktreeMeta> = {
       [TEST_WORKTREE_ID]: makeWorktreeMeta({ isUnread: true })
@@ -17115,6 +17183,44 @@ describe('OrcaRuntimeService', () => {
     expect(metaById[TEST_WORKTREE_ID]?.isUnread).toBe(false)
     expect(worktreesChanged).toHaveBeenCalledWith(TEST_REPO_ID)
     expect(activateWorktree).not.toHaveBeenCalled()
+  })
+
+  it('keeps runtime-client worktree activation publish-only unless host follow is explicit', async () => {
+    const activateWorktree = vi.fn()
+    const runtime = new OrcaRuntimeService(store as never)
+    runtime.setNotifier({
+      worktreesChanged: vi.fn(),
+      reposChanged: vi.fn(),
+      activateWorktree,
+      createTerminal: vi.fn(),
+      revealTerminalSession: vi.fn(),
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    })
+    runtime.attachWindow(TEST_WINDOW_ID)
+    runtime.markGraphReady(TEST_WINDOW_ID)
+
+    await runtime.activateManagedWorktree(`id:${TEST_WORKTREE_ID}`, {
+      clientKind: 'runtime'
+    })
+    expect(activateWorktree).not.toHaveBeenCalled()
+
+    await runtime.activateManagedWorktree(`id:${TEST_WORKTREE_ID}`, {
+      clientKind: 'runtime',
+      followHost: true
+    })
+    expect(activateWorktree).toHaveBeenCalledWith(
+      TEST_REPO_ID,
+      TEST_WORKTREE_ID,
+      undefined,
+      undefined,
+      undefined
+    )
   })
 
   it('wakes slept agents on the host renderer when a phone activates a worktree', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4377,8 +4377,14 @@ export class OrcaRuntimeService {
     worktreeSelector: string,
     tabId: string,
     leafId?: string,
-    opts: { notifyClients?: boolean } = {}
+    opts: {
+      notifyClients?: boolean
+      clientKind?: 'mobile' | 'runtime'
+      followHost?: boolean
+    } = {}
   ): Promise<RuntimeMobileSessionTabsResult> {
+    const notifyHost =
+      opts.notifyClients !== false && (opts.clientKind !== 'runtime' || opts.followHost === true)
     const explicitWorktreeId = this.getValidatedExplicitWorktreeIdSelector(worktreeSelector)
     const worktreeId =
       explicitWorktreeId ?? (await this.resolveWorktreeSelector(worktreeSelector)).id
@@ -4416,7 +4422,7 @@ export class OrcaRuntimeService {
       const shouldMaterializePendingTerminal =
         publicTab?.type === 'terminal' &&
         publicTab.status !== 'ready' &&
-        (opts.notifyClients === false ||
+        (!notifyHost ||
           !this.notifier?.focusTerminal ||
           this.shouldMaterializeHeadlessMobileSessionTab(snapshot!, tab))
       if (shouldMaterializePendingTerminal) {
@@ -4478,7 +4484,7 @@ export class OrcaRuntimeService {
                 candidate.isActive
             )
       const targetTab = activeSibling ?? tab
-      if (opts.notifyClients === false) {
+      if (!notifyHost) {
         this.activateMobileSessionTabForRemoteClient(worktreeId, snapshot!, targetTab)
         return this.getMobileSessionTabsForWorktree(worktreeId)
       }
@@ -4493,7 +4499,7 @@ export class OrcaRuntimeService {
       }
       this.notifier?.focusTerminal(targetTab.parentTabId, worktreeId, targetTab.leafId)
     } else if (tab.type === 'browser') {
-      if (opts.notifyClients === false) {
+      if (!notifyHost) {
         this.activateMobileSessionTabForRemoteClient(worktreeId, snapshot!, tab)
         return this.getMobileSessionTabsForWorktree(worktreeId)
       }
@@ -4501,7 +4507,7 @@ export class OrcaRuntimeService {
       // session tab keeps desktop tab order/group state authoritative.
       this.notifier?.focusEditorTab?.(tab.id, worktreeId)
     } else {
-      if (opts.notifyClients === false) {
+      if (!notifyHost) {
         this.activateMobileSessionTabForRemoteClient(worktreeId, snapshot!, tab)
         return this.getMobileSessionTabsForWorktree(worktreeId)
       }
@@ -14698,7 +14704,11 @@ export class OrcaRuntimeService {
 
   async activateManagedWorktree(
     worktreeSelector: string,
-    opts: { notifyClients?: boolean; clientKind?: 'mobile' | 'runtime' } = {}
+    opts: {
+      notifyClients?: boolean
+      clientKind?: 'mobile' | 'runtime'
+      followHost?: boolean
+    } = {}
   ): Promise<{
     repoId: string
     worktreeId: string
@@ -14715,7 +14725,10 @@ export class OrcaRuntimeService {
       throw new Error('repo_not_found')
     }
 
-    if (opts.notifyClients === false && this.store?.getWorktreeMeta(worktree.id)?.isUnread) {
+    const notifyHost =
+      opts.notifyClients !== false && (opts.clientKind !== 'runtime' || opts.followHost === true)
+
+    if (!notifyHost && this.store?.getWorktreeMeta(worktree.id)?.isUnread) {
       // Why: mobile/web session activation intentionally bypasses renderer
       // selection, so the runtime must acknowledge the unread state itself.
       this.store.setWorktreeMeta(worktree.id, { isUnread: false })
@@ -14724,7 +14737,7 @@ export class OrcaRuntimeService {
 
     let sleepingAgentWake: 'requested' | 'unsupported-headless' | 'not-applicable' =
       'not-applicable'
-    if (opts.notifyClients !== false) {
+    if (notifyHost) {
       // Why: inactive worktree terminal panes are renderer-owned and may not have
       // live PTYs until the desktop activates the worktree and mounts them.
       this.notifyActivateWorktree(repo.id, worktree.id)

--- a/src/main/runtime/rpc/methods/session-tabs-schemas.ts
+++ b/src/main/runtime/rpc/methods/session-tabs-schemas.ts
@@ -21,7 +21,8 @@ export const ActivateTab = WorktreeTabSelector.extend({
     .transform((v) => (typeof v === 'string' ? v : ''))
     .pipe(z.string().min(1, 'Missing tab id')),
   leafId: z.string().max(128).optional(),
-  notifyClients: OptionalBoolean
+  notifyClients: OptionalBoolean,
+  followHost: OptionalBoolean
 })
 
 export type TerminalPaneLayoutNodeInput =

--- a/src/main/runtime/rpc/methods/session-tabs.test.ts
+++ b/src/main/runtime/rpc/methods/session-tabs.test.ts
@@ -35,8 +35,48 @@ describe('session tab RPC methods', () => {
 
     expect(response.ok).toBe(true)
     expect(runtime.activateMobileSessionTab).toHaveBeenCalledWith('id:wt-1', 'tab-1', 'leaf-1', {
-      notifyClients: false
+      notifyClients: false,
+      clientKind: undefined,
+      followHost: false
     })
+  })
+
+  it('keeps runtime-client tab activation publish-only unless followHost is explicit', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      activateMobileSessionTab: vi.fn().mockResolvedValue({ tabs: [] })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: SESSION_TAB_METHODS })
+
+    await dispatcher.dispatchStreaming(
+      makeRequest('session.tabs.activate', { worktree: 'id:wt-1', tabId: 'tab-1' }),
+      vi.fn(),
+      { clientKind: 'runtime' }
+    )
+    await dispatcher.dispatchStreaming(
+      makeRequest('session.tabs.activate', {
+        worktree: 'id:wt-1',
+        tabId: 'tab-1',
+        followHost: true
+      }),
+      vi.fn(),
+      { clientKind: 'runtime' }
+    )
+
+    expect(runtime.activateMobileSessionTab).toHaveBeenNthCalledWith(
+      1,
+      'id:wt-1',
+      'tab-1',
+      undefined,
+      { notifyClients: false, clientKind: 'runtime', followHost: false }
+    )
+    expect(runtime.activateMobileSessionTab).toHaveBeenNthCalledWith(
+      2,
+      'id:wt-1',
+      'tab-1',
+      undefined,
+      { notifyClients: true, clientKind: 'runtime', followHost: true }
+    )
   })
 
   it('dispatches tab moves through the runtime', async () => {

--- a/src/main/runtime/rpc/methods/session-tabs.ts
+++ b/src/main/runtime/rpc/methods/session-tabs.ts
@@ -27,10 +27,14 @@ export const SESSION_TAB_METHODS: RpcAnyMethod[] = [
   defineMethod({
     name: 'session.tabs.activate',
     params: ActivateTab,
-    handler: async (params, { runtime }) =>
-      runtime.activateMobileSessionTab(params.worktree, params.tabId, params.leafId, {
-        notifyClients: params.notifyClients !== false
+    handler: async (params, { runtime, clientKind }) => {
+      const followHost = params.followHost === true
+      return runtime.activateMobileSessionTab(params.worktree, params.tabId, params.leafId, {
+        notifyClients: params.notifyClients !== false && (clientKind !== 'runtime' || followHost),
+        clientKind,
+        followHost
       })
+    }
   }),
   defineMethod({
     name: 'session.tabs.close',

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -56,7 +56,8 @@ export const WorktreeSelector = z.object({
 })
 
 export const WorktreeActivate = WorktreeSelector.extend({
-  notifyClients: OptionalBoolean
+  notifyClients: OptionalBoolean,
+  followHost: OptionalBoolean
 })
 
 export const WorktreeCreate = z

--- a/src/main/runtime/rpc/methods/worktree.test.ts
+++ b/src/main/runtime/rpc/methods/worktree.test.ts
@@ -39,7 +39,8 @@ describe('worktree RPC methods', () => {
     expect(response).toMatchObject({ ok: true })
     expect(runtime.activateManagedWorktree).toHaveBeenCalledWith('id:wt-1', {
       notifyClients: false,
-      clientKind: undefined
+      clientKind: undefined,
+      followHost: false
     })
   })
 
@@ -63,7 +64,41 @@ describe('worktree RPC methods', () => {
 
     expect(runtime.activateManagedWorktree).toHaveBeenCalledWith('id:wt-1', {
       notifyClients: false,
-      clientKind: 'mobile'
+      clientKind: 'mobile',
+      followHost: false
+    })
+  })
+
+  it('keeps runtime-client activation publish-only unless followHost is explicit', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      activateManagedWorktree: vi
+        .fn()
+        .mockResolvedValue({ repoId: 'repo-1', worktreeId: 'wt-1', activated: true })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
+    const replies: string[] = []
+
+    await dispatcher.dispatchStreaming(
+      makeRequest('worktree.activate', { worktree: 'id:wt-1' }),
+      (response) => replies.push(response),
+      { clientKind: 'runtime' }
+    )
+    await dispatcher.dispatchStreaming(
+      makeRequest('worktree.activate', { worktree: 'id:wt-1', followHost: true }),
+      (response) => replies.push(response),
+      { clientKind: 'runtime' }
+    )
+
+    expect(runtime.activateManagedWorktree).toHaveBeenNthCalledWith(1, 'id:wt-1', {
+      notifyClients: false,
+      clientKind: 'runtime',
+      followHost: false
+    })
+    expect(runtime.activateManagedWorktree).toHaveBeenNthCalledWith(2, 'id:wt-1', {
+      notifyClients: true,
+      clientKind: 'runtime',
+      followHost: true
     })
   })
 

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -59,13 +59,18 @@ export const WORKTREE_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'worktree.activate',
     params: WorktreeActivate,
-    handler: async (params, { runtime, clientKind }) =>
-      // Why: clientKind ('mobile'|'runtime') scopes the host-renderer slept-agent
-      // wake to phones so web/desktop activation behavior is unchanged.
-      runtime.activateManagedWorktree(params.worktree, {
-        notifyClients: params.notifyClients !== false,
-        clientKind
+    handler: async (params, { runtime, clientKind }) => {
+      // Why: clientKind scopes both phone-only sleeping-agent wakes and whether
+      // a paired desktop may turn publication into host-window navigation.
+      const followHost = params.followHost === true
+      return runtime.activateManagedWorktree(params.worktree, {
+        // Why: paired desktops publish selection by default. Host navigation
+        // requires an affirmative followHost bit, not a legacy true default.
+        notifyClients: params.notifyClients !== false && (clientKind !== 'runtime' || followHost),
+        clientKind,
+        followHost
       })
+    }
   }),
   defineMethod({
     name: 'worktree.create',

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -907,7 +907,13 @@ describe('createRemoteRuntimePtyTransport', () => {
     expect(runtimeCall).toHaveBeenCalledWith(
       expect.objectContaining({
         method: 'session.tabs.activate',
-        params: { worktree: 'id:wt-1', tabId: 'host-tab-1', leafId: 'leaf-1' }
+        params: {
+          worktree: 'id:wt-1',
+          tabId: 'host-tab-1',
+          leafId: 'leaf-1',
+          notifyClients: false,
+          followHost: false
+        }
       })
     )
     expect(runtimeCall).not.toHaveBeenCalledWith(
@@ -1009,7 +1015,13 @@ describe('createRemoteRuntimePtyTransport', () => {
     expect(runtimeCall).toHaveBeenCalledWith(
       expect.objectContaining({
         method: 'session.tabs.activate',
-        params: { worktree: 'id:wt-1', tabId: 'host-tab-1', leafId: 'leaf-2' }
+        params: {
+          worktree: 'id:wt-1',
+          tabId: 'host-tab-1',
+          leafId: 'leaf-2',
+          notifyClients: false,
+          followHost: false
+        }
       })
     )
     expect(runtimeCall).not.toHaveBeenCalledWith(

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -167,7 +167,9 @@ export function createRemoteRuntimePtyTransport(
     const activated = await callRuntime<RuntimeMobileSessionTabsResult>('session.tabs.activate', {
       worktree,
       tabId: hostTabId,
-      ...(leafId ? { leafId } : {})
+      ...(leafId ? { leafId } : {}),
+      notifyClients: false,
+      followHost: false
     })
     const immediate = findReadyHostSessionHandle(activated, hostTabId)
     if (immediate) {

--- a/src/renderer/src/lib/worktree-activation-created-agent.test.ts
+++ b/src/renderer/src/lib/worktree-activation-created-agent.test.ts
@@ -364,7 +364,7 @@ describe('activateAndRevealWorktree created agent reopen', () => {
     expect(callRuntimeEnvironment).toHaveBeenCalledWith({
       selector: 'web-runtime-1',
       method: 'worktree.activate',
-      params: { worktree: `id:${worktree.id}`, notifyClients: false },
+      params: { worktree: `id:${worktree.id}`, notifyClients: false, followHost: false },
       timeoutMs: 15_000
     })
   })

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -333,8 +333,7 @@ export function activateAndRevealWorktree(
     // desktop navigation command.
     void activateWebRuntimeSessionWorktree({
       worktreeId,
-      environmentId: ownerRuntimeEnvironmentId,
-      notifyDesktop: (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ !== true
+      environmentId: ownerRuntimeEnvironmentId
     })
   }
 

--- a/src/renderer/src/runtime/web-runtime-session.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session.test.ts
@@ -98,7 +98,7 @@ describe('activateWebRuntimeSessionWorktree', () => {
     await expect(
       activateWebRuntimeSessionWorktree({
         worktreeId: WORKTREE_ID,
-        notifyDesktop: false
+        followHost: false
       })
     ).resolves.toBe(true)
 
@@ -107,7 +107,8 @@ describe('activateWebRuntimeSessionWorktree', () => {
       method: 'worktree.activate',
       params: {
         worktree: `id:${WORKTREE_ID}`,
-        notifyClients: false
+        notifyClients: false,
+        followHost: false
       },
       timeoutMs: 15_000
     })
@@ -851,7 +852,9 @@ describe('web runtime session tab actions', () => {
       method: 'session.tabs.activate',
       params: {
         worktree: `id:${WORKTREE_ID}`,
-        tabId: 'host-browser-unified'
+        tabId: 'host-browser-unified',
+        notifyClients: false,
+        followHost: false
       },
       timeoutMs: 15_000
     })

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -288,7 +288,7 @@ async function refreshWebRuntimeSessionTabsSnapshot(
 export async function activateWebRuntimeSessionWorktree(args: {
   worktreeId: string
   environmentId?: string | null
-  notifyDesktop?: boolean
+  followHost?: boolean
 }): Promise<boolean> {
   const environmentId =
     args.environmentId?.trim() ??
@@ -304,7 +304,8 @@ export async function activateWebRuntimeSessionWorktree(args: {
       method: 'worktree.activate',
       params: {
         worktree: toRuntimeWorktreeSelector(args.worktreeId),
-        notifyClients: args.notifyDesktop !== false
+        notifyClients: args.followHost === true,
+        followHost: args.followHost === true
       },
       timeoutMs: 15_000
     })
@@ -323,6 +324,7 @@ export async function activateWebRuntimeSessionTab(args: {
   worktreeId: string
   tabId: string
   environmentId?: string | null
+  followHost?: boolean
 }): Promise<boolean> {
   return callWebRuntimeSessionTabMethod('session.tabs.activate', args)
 }
@@ -442,6 +444,7 @@ async function callWebRuntimeSessionTabMethod(
     worktreeId: string
     tabId: string
     environmentId?: string | null
+    followHost?: boolean
   }
 ): Promise<boolean> {
   const environmentId =
@@ -482,7 +485,13 @@ async function callWebRuntimeSessionTabMethod(
       method,
       params: {
         worktree: toRuntimeWorktreeSelector(args.worktreeId),
-        tabId: hostTabId
+        tabId: hostTabId,
+        ...(method === 'session.tabs.activate'
+          ? {
+              notifyClients: args.followHost === true,
+              followHost: args.followHost === true
+            }
+          : {})
       },
       timeoutMs: 15_000
     })


### PR DESCRIPTION
## Summary

- make paired runtime-client worktree and session-tab activation publish selection state without navigating or focusing the host renderer by default
- require an explicit `followHost: true` opt-in before a runtime client can drive host-window activation
- send both `notifyClients: false` and `followHost: false` from remote-session clients, so the safe default also works against older hosts that do not know `followHost`
- preserve existing mobile and in-process activation behavior

Related to #8871. This is the activation/focus companion to #8872 and #8888.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused verification:

- `pnpm exec vitest run --config config/vitest.config.ts` across 13 affected runtime/RPC/renderer test files: 889 tests passed
- `git diff --name-only -z origin/main | xargs -0 pnpm exec oxlint`
- `pnpm run check:max-lines-ratchet`
- `git diff --check`

## AI Review Report

The review traced worktree and tab activation from the renderer client, through RPC parsing and client-kind context, into the runtime notifier boundary. It checked both halves of mixed-version compatibility: a new client stays publish-only against an older host via `notifyClients: false`, while a new host defaults older runtime clients to publish-only unless they explicitly send `followHost: true`.

The main risk was accidentally changing phone activation or local/in-process navigation. The implementation therefore gates only `clientKind === 'runtime'`; focused tests verify runtime defaults and explicit opt-in, while the existing mobile activation suite remains green. The review also checked macOS, Linux, Windows, and SSH impact. This change introduces no platform-specific shortcuts, labels, paths, shell behavior, or Electron platform branches.

## Security Audit

The new field is schema-validated as a boolean and reaches only the existing host focus/navigation notifier boundary. It does not add command execution, file/path handling, credentials, secrets, dependencies, destructive terminal actions, or a new IPC transport. The default for paired runtime clients is deny-by-default host navigation; explicit `followHost: true` restores the existing navigation capability for trusted callers that intentionally request it.

## Notes

- This PR is intentionally limited to activation/focus authority. Destructive close intent and host-side destructive-action policy are handled separately in #8872 and #8888.
- No UI currently opts into `followHost`; the field is an explicit RPC capability for future intentional host-follow flows.
