### PR TITLE
[Draft] fix(daemon): refuse kill for recently-active sessions — local mitigation for #8459

### DIFF
--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -322,6 +322,91 @@ describe('DaemonServer', () => {
       expect(acknowledged).toBe(true)
     })
 
+    it('refuses to kill a recently active session unless the guard is disabled', async () => {
+      const originalWindowMs = process.env.ORCA_KILL_GUARD_WINDOW_MS
+      const log = { log: vi.fn(), close: vi.fn() }
+      try {
+        delete process.env.ORCA_KILL_GUARD_WINDOW_MS
+        let guardedSubprocess: ReturnType<typeof createMockSubprocess>
+        server = new DaemonServer({
+          socketPath,
+          tokenPath,
+          log,
+          spawnSubprocess: () => {
+            guardedSubprocess = createMockSubprocess()
+            return guardedSubprocess
+          }
+        })
+        const guardedDaemon = server as unknown as DaemonServerPrivate
+        await guardedDaemon.routeRequest('client-1', {
+          id: 'create-guarded',
+          type: 'createOrAttach',
+          payload: { sessionId: 'guarded-session', cols: 80, rows: 24 }
+        })
+        guardedSubprocess!._simulateData('recent output')
+
+        await guardedDaemon.routeRequest('client-1', {
+          id: 'kill-guarded',
+          type: 'kill',
+          payload: { sessionId: 'guarded-session', immediate: true }
+        })
+
+        expect(guardedSubprocess!.forceKill).not.toHaveBeenCalled()
+        await expect(
+          guardedDaemon.routeRequest('client-1', {
+            id: 'list-guarded',
+            type: 'listSessions'
+          })
+        ).resolves.toMatchObject({ sessions: [{ sessionId: 'guarded-session' }] })
+        expect(log.log).toHaveBeenCalledWith('kill-guard', { windowMs: 1_800_000 })
+        expect(log.log).toHaveBeenCalledWith(
+          'session-kill-refused',
+          expect.objectContaining({ sessionId: 'guarded-session', immediate: true })
+        )
+
+        await server.shutdown()
+        process.env.ORCA_KILL_GUARD_WINDOW_MS = '0'
+        let unguardedSubprocess: ReturnType<typeof createMockSubprocess>
+        server = new DaemonServer({
+          socketPath,
+          tokenPath,
+          log,
+          spawnSubprocess: () => {
+            unguardedSubprocess = createMockSubprocess()
+            return unguardedSubprocess
+          }
+        })
+        const unguardedDaemon = server as unknown as DaemonServerPrivate
+        await unguardedDaemon.routeRequest('client-1', {
+          id: 'create-unguarded',
+          type: 'createOrAttach',
+          payload: { sessionId: 'unguarded-session', cols: 80, rows: 24 }
+        })
+        unguardedSubprocess!._simulateData('recent output')
+
+        await unguardedDaemon.routeRequest('client-1', {
+          id: 'kill-unguarded',
+          type: 'kill',
+          payload: { sessionId: 'unguarded-session', immediate: true }
+        })
+
+        expect(unguardedSubprocess!.forceKill).toHaveBeenCalledTimes(1)
+        await expect(
+          unguardedDaemon.routeRequest('client-1', {
+            id: 'list-unguarded',
+            type: 'listSessions'
+          })
+        ).resolves.toEqual({ sessions: [] })
+        expect(log.log).toHaveBeenCalledWith('kill-guard', { windowMs: 0 })
+      } finally {
+        if (originalWindowMs === undefined) {
+          delete process.env.ORCA_KILL_GUARD_WINDOW_MS
+        } else {
+          process.env.ORCA_KILL_GUARD_WINDOW_MS = originalWindowMs
+        }
+      }
+    })
+
     it('handles getCwd', async () => {
       await startServer()
       const c = await connectClient()

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -47,6 +47,18 @@ export type DaemonServerOptions = {
   }) => SubprocessHandle
 }
 
+const DEFAULT_KILL_GUARD_WINDOW_MS = 1_800_000
+
+function resolveKillGuardWindowMs(value: string | undefined): number {
+  if (value === undefined || value.trim() === '') {
+    return DEFAULT_KILL_GUARD_WINDOW_MS
+  }
+  const windowMs = Number(value)
+  return Number.isFinite(windowMs) && windowMs >= 0
+    ? Math.floor(windowMs)
+    : DEFAULT_KILL_GUARD_WINDOW_MS
+}
+
 type ConnectedClient = {
   clientId: string
   controlSocket: Socket
@@ -96,6 +108,8 @@ export class DaemonServer {
   })
   private streamClientIdBySessionId = new Map<string, string>()
   private lastInputAtBySessionId = new Map<string, number>()
+  private lastOutputAtBySessionId = new Map<string, number>()
+  private killGuardWindowMs: number
   private stopStreamBacklogProbe: () => void = () => {}
 
   // Why: main-process PTY IPC has the same recent-input bypass, but daemon
@@ -120,6 +134,8 @@ export class DaemonServer {
       backgroundedSessionIdSuffixes: this.transientFactRelay.backgroundedSessionIdSuffixes()
     }))
     this.log = opts.log ?? createNoopDaemonFileLog()
+    this.killGuardWindowMs = resolveKillGuardWindowMs(process.env.ORCA_KILL_GUARD_WINDOW_MS)
+    this.log.log('kill-guard', { windowMs: this.killGuardWindowMs })
   }
 
   async start(): Promise<void> {
@@ -365,6 +381,7 @@ export class DaemonServer {
             onData: (data) => {
               // Scan BEFORE enqueue: the batcher may keep-tail drop this
               // chunk, but its facts must be captured regardless.
+              this.lastOutputAtBySessionId.set(p.sessionId, performance.now())
               this.transientFactRelay.onSessionData(p.sessionId, data)
               const lastInputAt = this.lastInputAtBySessionId.get(p.sessionId)
               const isInteractiveOutput =
@@ -394,6 +411,7 @@ export class DaemonServer {
               this.transientFactRelay.onSessionExit(p.sessionId)
               this.streamClientIdBySessionId.delete(p.sessionId)
               this.lastInputAtBySessionId.delete(p.sessionId)
+              this.lastOutputAtBySessionId.delete(p.sessionId)
             }
           }
         })
@@ -432,6 +450,7 @@ export class DaemonServer {
           this.host.write(request.payload.sessionId, request.payload.data)
         } catch (err) {
           this.lastInputAtBySessionId.delete(request.payload.sessionId)
+          this.lastOutputAtBySessionId.delete(request.payload.sessionId)
           if (err instanceof SessionNotFoundError) {
             this.sendExitEvent(client, request.payload.sessionId, -1)
           }
@@ -500,14 +519,36 @@ export class DaemonServer {
         return {}
       }
 
-      case 'kill':
-        this.lastInputAtBySessionId.delete(request.payload.sessionId)
+      case 'kill': {
+        const sessionId = request.payload.sessionId
+        const immediate = request.payload.immediate === true
+        const lastInputAt = this.lastInputAtBySessionId.get(sessionId)
+        const lastOutputAt = this.lastOutputAtBySessionId.get(sessionId)
+        const lastActivityAt = Math.max(lastInputAt ?? -Infinity, lastOutputAt ?? -Infinity)
+        const lastActivityAgoMs = performance.now() - lastActivityAt
+        if (
+          this.killGuardWindowMs > 0 &&
+          Number.isFinite(lastActivityAgoMs) &&
+          lastActivityAgoMs <= this.killGuardWindowMs
+        ) {
+          // Why: renderer-initiated tab cleanup is indistinguishable from a
+          // user close, so active sessions must remain available for reattach.
+          this.log.log('session-kill-refused', {
+            sessionId,
+            immediate,
+            lastActivityAgoMs: Math.max(0, Math.round(lastActivityAgoMs))
+          })
+          return {}
+        }
+        this.lastInputAtBySessionId.delete(sessionId)
+        this.lastOutputAtBySessionId.delete(sessionId)
         this.log.log('session-killed', {
-          sessionId: request.payload.sessionId,
-          immediate: request.payload.immediate === true
+          sessionId,
+          immediate
         })
-        await this.host.kill(request.payload.sessionId, { immediate: request.payload.immediate })
+        await this.host.kill(sessionId, { immediate: request.payload.immediate })
         return {}
+      }
 
       case 'signal':
         this.host.signal(request.payload.sessionId, request.payload.signal)


### PR DESCRIPTION
## Summary

The daemon refuses `kill` requests — including `immediate: true` — for sessions that had PTY
input or output within a configurable window (default 30 min via `ORCA_KILL_GUARD_WINDOW_MS`;
`0` disables), logging `session-kill-refused` instead. Sessions with no recorded activity fall
through to the normal kill path, so idle-shell cleanup keeps working. Startup logs
`kill-guard { windowMs }` for observability.

## Code patch at the daemon:

Renderer-side callers cannot distinguish an explicit user close from programmatic tab cleanup:
`closeTab` defaults its close reason to `'user'` and no production call site passes an explicit
reason (the only explicit values are `'cleanup'` and `'pty-exit'`). When the renderer binding
index is stale — e.g. right after an update relaunch — reconciliation issues destructive bulk
kills for live sessions (the `immediate:true` bursts in #8459). The daemon is the last place
that reliably knows a session is live, so this guard sits there as a stopgap.

## Field results

- Before: 36 bulk-kill events in <8 h across two machines on v1.4.141/142, repeatedly destroying
  live agent sessions (one was killed mid-write, 11 ms after its last output).
- After: 12 refusals in the first hours — including a 4-workspace burst identical to the original
  incident — with **zero live-session losses**. Refusal timings (`lastActivityAgoMs`): 11 ms,
  27 ms, 59 ms, 0.6 s, 2.5 s, 4.2 s ×2, 4.6 s, 21 s ×2, 7 min, 417 s.

## Regarding #8467

#8467 routes the Resource Manager cleanup through a new verified channel
(`pty:killInactiveSessions`, with per-session `killed / protected / gone / failed` outcomes) —
that covers the manual "Kill orphan terminals" variant originally reported in #8459, and its
response shape is exactly what limitation 1 below asks for. However, the bursts we observe occur
**without any Resource Manager interaction**: renderer tab-retirement still issues plain,
unverified `pty:kill` (its `closeTab` reason defaults to `'user'` with no production caller
passing an explicit reason), so #8467 alone does not stop them. This daemon-side guard is the
stopgap for that remaining path; the proper fix would extend #8467-style verification (or an
explicit-intent flag) to the generic `pty:kill` route as well.

## Limitations (adversarial review & design requirements for the proper fix)

1. **Currently, refusal is reported as success.** The kill response stays `{}`, so the adapter/main clear
   ownership, write tombstones, and emit a synthetic exit while the session lives on — it
   resurfaces as an unbound session. A proper fix needs a `killed | refused` result in the
   response and caller-side handling.
2. **Worktree destructive removal loses its physical-stop guarantee.** Teardown treats the
   resolved kill as proof processes stopped and proceeds to delete the directory. The guard
   should be bypassed (or `listSessions` re-verified) on that path.
3. **Sleep flow**: the UI sleeps but the PTY keeps running, so resources are not released.
4. **Activity is not ownership.** A session idle longer than the window is still killable by the
   same false-positive path; conversely a user's explicit close of an active session is refused.
   The real fix per #8459 is re-verifying ownership before destructive cleanup (as #8467 does for
   the Resource Manager path) plus an explicit-intent flag on the kill RPC.
5. **Semantic protocol change without a version bump.** Old app ↔ new daemon (and vice versa,
   since daemons outlive app updates) disagree about kill semantics.
6. **Refused sessions are never retried**, so repeated close/spawn cycles accumulate daemon
   sessions with no product-level cap.

## Testing

- `pnpm typecheck` — clean
- `pnpm vitest run src/main/daemon` — 51 files passed / 2 skipped; **837 tests passed / 5 skipped**
- 2 new tests: refusal keeps the session listed and logs the refusal; `ORCA_KILL_GUARD_WINDOW_MS=0`
  restores prior behavior

## ELI5

The daemon could kill a terminal session that was still actively used, which is bad for long jobs. It now refuses kill for sessions with recent input/output for a short window, unless they’re truly idle.
