### PR TITLE
fix(terminal): commit the Hangul syllable before the Shift/Ctrl+Enter newline

### DIFF
--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -8,6 +8,7 @@ import type { PtyTransport } from './pty-transport'
 import { safeFind } from '../terminal-search-safe-find'
 import { resolveTerminalShortcutAction } from './terminal-shortcut-policy'
 import type { MacOptionAsAlt } from './terminal-shortcut-policy'
+import { sendTerminalInputAfterComposition } from './terminal-ime-deferred-newline'
 import {
   keybindingMatchesAction,
   type KeybindingOverrides,
@@ -399,24 +400,40 @@ export function useTerminalKeyboardShortcuts({
       }
 
       if (action.type === 'sendInput') {
+        // preventDefault here does not cancel a pending IME commit (the
+        // compositionend still fires and xterm forwards the glyph), so it is safe
+        // to consume the chord even mid-composition — it just stops a stray
+        // browser newline from also reaching the helper textarea.
         e.preventDefault()
         e.stopImmediatePropagation()
         const pane = manager.getActivePane() ?? manager.getPanes()[0]
         if (!pane) {
           return
         }
-        const sent = paneTransportsRef.current.get(pane.id)?.sendInput(action.data) === true
-        if (sent) {
-          recordTerminalUserInputForLeaf(tabId, pane.leafId)
-          if (action.data === '\x1b[13;2u') {
-            // Why: this direct shortcut write does not pass through PTY onData,
-            // so no-OSC shells need an explicit post-write confirmation ladder.
-            const binding = panePtyBindingsRef.current.get(pane.id) as
-              | (IDisposable & { requestDroidReconfirmation?: () => void })
-              | undefined
-            binding?.requestDroidReconfirmation?.()
+        const sendResolvedInput = (): void => {
+          const sent = paneTransportsRef.current.get(pane.id)?.sendInput(action.data) === true
+          if (sent) {
+            recordTerminalUserInputForLeaf(tabId, pane.leafId)
+            if (action.data === '\x1b[13;2u') {
+              // Why: this direct shortcut write does not pass through PTY onData,
+              // so no-OSC shells need an explicit post-write confirmation ladder.
+              const binding = panePtyBindingsRef.current.get(pane.id) as
+                | (IDisposable & { requestDroidReconfirmation?: () => void })
+                | undefined
+              binding?.requestDroidReconfirmation?.()
+            }
           }
         }
+        // Why: Shift+Enter / Ctrl+Enter pressed while an IME composition is open
+        // is the committing keystroke — sending the newline now races ahead of
+        // the pending commit and pushes the composed CJK glyph below it. Forward
+        // the newline once the composition ends so the glyph lands first (the
+        // committed char + newline, matching a non-composing Shift+Enter).
+        if (e.isComposing && e.key === 'Enter') {
+          sendTerminalInputAfterComposition(pane.terminal.element, sendResolvedInput)
+          return
+        }
+        sendResolvedInput()
         return
       }
 

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -434,10 +434,11 @@ export function useTerminalKeyboardShortcuts({
           deferredNewlineSender.defer(pane.id, pane.terminal.element, sendResolvedInput)
           return
         }
-        if (e.key === 'Enter' && deferredNewlineSender.isDeferredNewlinePending(pane.id)) {
+        if (e.key === 'Enter' && deferredNewlineSender.absorbRedispatchedEnter(pane.id)) {
           // Why: macOS Hangul re-dispatches the committing Enter keydown with
           // isComposing already false ~2ms after compositionend; it is the same
-          // physical keystroke as the deferred newline still in flight.
+          // physical keystroke as the deferred newline, and can land on either
+          // side of that send's macrotask.
           return
         }
         sendResolvedInput()

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -8,7 +8,7 @@ import type { PtyTransport } from './pty-transport'
 import { safeFind } from '../terminal-search-safe-find'
 import { resolveTerminalShortcutAction } from './terminal-shortcut-policy'
 import type { MacOptionAsAlt } from './terminal-shortcut-policy'
-import { sendTerminalInputAfterComposition } from './terminal-ime-deferred-newline'
+import { createTerminalImeDeferredNewlineSender } from './terminal-ime-deferred-newline'
 import {
   keybindingMatchesAction,
   type KeybindingOverrides,
@@ -261,6 +261,7 @@ export function useTerminalKeyboardShortcuts({
     // held. To distinguish left vs right Option, we record the Option key's
     // location from its own keydown event and clear it on keyup.
     let optionKeyLocation = 0
+    const deferredNewlineSender = createTerminalImeDeferredNewlineSender()
     const onModifierDown = (e: KeyboardEvent): void => {
       if (e.key === 'Alt') {
         optionKeyLocation = e.location
@@ -430,7 +431,13 @@ export function useTerminalKeyboardShortcuts({
         // the newline once the composition ends so the glyph lands first (the
         // committed char + newline, matching a non-composing Shift+Enter).
         if (e.isComposing && e.key === 'Enter') {
-          sendTerminalInputAfterComposition(pane.terminal.element, sendResolvedInput)
+          deferredNewlineSender.defer(pane.id, pane.terminal.element, sendResolvedInput)
+          return
+        }
+        if (e.key === 'Enter' && deferredNewlineSender.isDeferredNewlinePending(pane.id)) {
+          // Why: macOS Hangul re-dispatches the committing Enter keydown with
+          // isComposing already false ~2ms after compositionend; it is the same
+          // physical keystroke as the deferred newline still in flight.
           return
         }
         sendResolvedInput()

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
@@ -1,6 +1,9 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { sendTerminalInputAfterComposition } from './terminal-ime-deferred-newline'
+import {
+  createTerminalImeDeferredNewlineSender,
+  sendTerminalInputAfterComposition
+} from './terminal-ime-deferred-newline'
 
 describe('sendTerminalInputAfterComposition', () => {
   beforeEach(() => {
@@ -71,5 +74,82 @@ describe('sendTerminalInputAfterComposition', () => {
 
     vi.runAllTimers()
     expect(send).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('createTerminalImeDeferredNewlineSender', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('marks the pane pending until the deferred newline is sent', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+    const sender = createTerminalImeDeferredNewlineSender()
+
+    sender.defer(1, el, send)
+    // Why: this window is when macOS Hangul's re-dispatched committing Enter
+    // keydown (isComposing=false) arrives and must be identified as a duplicate.
+    expect(sender.isDeferredNewlinePending(1)).toBe(true)
+
+    el.dispatchEvent(new Event('compositionend'))
+    vi.runAllTimers()
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(sender.isDeferredNewlinePending(1)).toBe(false)
+  })
+
+  it('clears pending via the no-compositionend fallback too', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+    const sender = createTerminalImeDeferredNewlineSender()
+
+    sender.defer(1, el, send)
+    vi.runAllTimers()
+
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(sender.isDeferredNewlinePending(1)).toBe(false)
+  })
+
+  it('tracks panes independently', () => {
+    const el1 = document.createElement('div')
+    const el2 = document.createElement('div')
+    const sender = createTerminalImeDeferredNewlineSender()
+
+    sender.defer(1, el1, vi.fn())
+    expect(sender.isDeferredNewlinePending(1)).toBe(true)
+    expect(sender.isDeferredNewlinePending(2)).toBe(false)
+
+    sender.defer(2, el2, vi.fn())
+    el1.dispatchEvent(new Event('compositionend'))
+    vi.advanceTimersByTime(0)
+    expect(sender.isDeferredNewlinePending(1)).toBe(false)
+    expect(sender.isDeferredNewlinePending(2)).toBe(true)
+  })
+
+  it('settles fully when overlapping defers for the same pane both send', () => {
+    const el = document.createElement('div')
+    const sender = createTerminalImeDeferredNewlineSender()
+
+    sender.defer(1, el, vi.fn())
+    sender.defer(1, el, vi.fn())
+    el.dispatchEvent(new Event('compositionend'))
+    vi.runAllTimers()
+
+    expect(sender.isDeferredNewlinePending(1)).toBe(false)
+  })
+
+  it('still delivers without a terminal element and settles pending', () => {
+    const send = vi.fn()
+    const sender = createTerminalImeDeferredNewlineSender()
+
+    sender.defer(1, null, send)
+    expect(sender.isDeferredNewlinePending(1)).toBe(true)
+    vi.runAllTimers()
+
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(sender.isDeferredNewlinePending(1)).toBe(false)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { sendTerminalInputAfterComposition } from './terminal-ime-deferred-newline'
+
+describe('sendTerminalInputAfterComposition', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('sends the newline one macrotask after compositionend so the glyph flushes first', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+
+    sendTerminalInputAfterComposition(el, send)
+    expect(send).not.toHaveBeenCalled()
+
+    el.dispatchEvent(new Event('compositionend'))
+    // Deferred a macrotask so xterm's own post-compositionend flush runs first.
+    expect(send).not.toHaveBeenCalled()
+
+    vi.runAllTimers()
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to sending when no compositionend arrives', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+
+    sendTerminalInputAfterComposition(el, send)
+    vi.runAllTimers()
+
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends only once and drops the listener after firing', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+
+    sendTerminalInputAfterComposition(el, send)
+    el.dispatchEvent(new Event('compositionend'))
+    vi.runAllTimers()
+    expect(send).toHaveBeenCalledTimes(1)
+
+    // A later composition on the same terminal must not re-fire the stale newline.
+    el.dispatchEvent(new Event('compositionend'))
+    vi.runAllTimers()
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not double-send when compositionend arrives after the fallback fired', () => {
+    const el = document.createElement('div')
+    const send = vi.fn()
+
+    sendTerminalInputAfterComposition(el, send)
+    vi.runAllTimers()
+    expect(send).toHaveBeenCalledTimes(1)
+
+    el.dispatchEvent(new Event('compositionend'))
+    vi.runAllTimers()
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('still delivers the input on the next macrotask without a terminal element', () => {
+    const send = vi.fn()
+
+    sendTerminalInputAfterComposition(null, send)
+    expect(send).not.toHaveBeenCalled()
+
+    vi.runAllTimers()
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
@@ -79,20 +79,14 @@ describe('sendTerminalInputAfterComposition', () => {
 })
 
 describe('createTerminalImeDeferredNewlineSender', () => {
-  let clock = 0
-  const advanceClock = (ms: number): void => {
-    clock += ms
-  }
-
   beforeEach(() => {
     vi.useFakeTimers()
-    clock = 0
   })
   afterEach(() => {
     vi.useRealTimers()
   })
 
-  const createSender = () => createTerminalImeDeferredNewlineSender({ now: () => clock })
+  const createSender = () => createTerminalImeDeferredNewlineSender()
 
   it('absorbs the re-dispatch while the deferred send is still in flight, exactly once', () => {
     const el = document.createElement('div')
@@ -122,7 +116,7 @@ describe('createTerminalImeDeferredNewlineSender', () => {
     vi.runAllTimers()
     expect(send).toHaveBeenCalledTimes(1)
 
-    advanceClock(TERMINAL_IME_ENTER_REDISPATCH_ABSORB_WINDOW_MS)
+    vi.advanceTimersByTime(TERMINAL_IME_ENTER_REDISPATCH_ABSORB_WINDOW_MS)
     expect(sender.absorbRedispatchedEnter(1)).toBe(true)
     expect(sender.absorbRedispatchedEnter(1)).toBe(false)
   })
@@ -135,7 +129,7 @@ describe('createTerminalImeDeferredNewlineSender', () => {
     el.dispatchEvent(new Event('compositionend'))
     vi.runAllTimers()
 
-    advanceClock(TERMINAL_IME_ENTER_REDISPATCH_ABSORB_WINDOW_MS + 1)
+    vi.advanceTimersByTime(TERMINAL_IME_ENTER_REDISPATCH_ABSORB_WINDOW_MS + 1)
     expect(sender.absorbRedispatchedEnter(1)).toBe(false)
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.test.ts
@@ -2,7 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createTerminalImeDeferredNewlineSender,
-  sendTerminalInputAfterComposition
+  sendTerminalInputAfterComposition,
+  TERMINAL_IME_ENTER_REDISPATCH_ABSORB_WINDOW_MS
 } from './terminal-ime-deferred-newline'
 
 describe('sendTerminalInputAfterComposition', () => {
@@ -78,78 +79,107 @@ describe('sendTerminalInputAfterComposition', () => {
 })
 
 describe('createTerminalImeDeferredNewlineSender', () => {
+  let clock = 0
+  const advanceClock = (ms: number): void => {
+    clock += ms
+  }
+
   beforeEach(() => {
     vi.useFakeTimers()
+    clock = 0
   })
   afterEach(() => {
     vi.useRealTimers()
   })
 
-  it('marks the pane pending until the deferred newline is sent', () => {
+  const createSender = () => createTerminalImeDeferredNewlineSender({ now: () => clock })
+
+  it('absorbs the re-dispatch while the deferred send is still in flight, exactly once', () => {
     const el = document.createElement('div')
     const send = vi.fn()
-    const sender = createTerminalImeDeferredNewlineSender()
+    const sender = createSender()
 
     sender.defer(1, el, send)
-    // Why: this window is when macOS Hangul's re-dispatched committing Enter
-    // keydown (isComposing=false) arrives and must be identified as a duplicate.
-    expect(sender.isDeferredNewlinePending(1)).toBe(true)
+    expect(sender.absorbRedispatchedEnter(1)).toBe(true)
+    expect(sender.absorbRedispatchedEnter(1)).toBe(false)
 
     el.dispatchEvent(new Event('compositionend'))
     vi.runAllTimers()
     expect(send).toHaveBeenCalledTimes(1)
-    expect(sender.isDeferredNewlinePending(1)).toBe(false)
+    // The credit was consumed pre-send, so nothing lingers to eat a real Enter.
+    expect(sender.absorbRedispatchedEnter(1)).toBe(false)
   })
 
-  it('clears pending via the no-compositionend fallback too', () => {
+  it('absorbs the re-dispatch shortly after the deferred send fired', () => {
+    // Why: when the send's macrotask beats the re-dispatched keydown, the
+    // duplicate arrives a few ms after the newline went out.
     const el = document.createElement('div')
     const send = vi.fn()
-    const sender = createTerminalImeDeferredNewlineSender()
+    const sender = createSender()
 
     sender.defer(1, el, send)
+    el.dispatchEvent(new Event('compositionend'))
+    vi.runAllTimers()
+    expect(send).toHaveBeenCalledTimes(1)
+
+    advanceClock(TERMINAL_IME_ENTER_REDISPATCH_ABSORB_WINDOW_MS)
+    expect(sender.absorbRedispatchedEnter(1)).toBe(true)
+    expect(sender.absorbRedispatchedEnter(1)).toBe(false)
+  })
+
+  it('expires the post-send absorb window so a later real Enter is never eaten', () => {
+    const el = document.createElement('div')
+    const sender = createSender()
+
+    sender.defer(1, el, vi.fn())
+    el.dispatchEvent(new Event('compositionend'))
     vi.runAllTimers()
 
-    expect(send).toHaveBeenCalledTimes(1)
-    expect(sender.isDeferredNewlinePending(1)).toBe(false)
+    advanceClock(TERMINAL_IME_ENTER_REDISPATCH_ABSORB_WINDOW_MS + 1)
+    expect(sender.absorbRedispatchedEnter(1)).toBe(false)
   })
 
   it('tracks panes independently', () => {
-    const el1 = document.createElement('div')
-    const el2 = document.createElement('div')
-    const sender = createTerminalImeDeferredNewlineSender()
-
-    sender.defer(1, el1, vi.fn())
-    expect(sender.isDeferredNewlinePending(1)).toBe(true)
-    expect(sender.isDeferredNewlinePending(2)).toBe(false)
-
-    sender.defer(2, el2, vi.fn())
-    el1.dispatchEvent(new Event('compositionend'))
-    vi.advanceTimersByTime(0)
-    expect(sender.isDeferredNewlinePending(1)).toBe(false)
-    expect(sender.isDeferredNewlinePending(2)).toBe(true)
-  })
-
-  it('settles fully when overlapping defers for the same pane both send', () => {
     const el = document.createElement('div')
-    const sender = createTerminalImeDeferredNewlineSender()
+    const sender = createSender()
 
     sender.defer(1, el, vi.fn())
-    sender.defer(1, el, vi.fn())
-    el.dispatchEvent(new Event('compositionend'))
-    vi.runAllTimers()
-
-    expect(sender.isDeferredNewlinePending(1)).toBe(false)
+    expect(sender.absorbRedispatchedEnter(2)).toBe(false)
+    expect(sender.absorbRedispatchedEnter(1)).toBe(true)
   })
 
-  it('still delivers without a terminal element and settles pending', () => {
+  it('grants one credit per overlapping defer on the same pane', () => {
+    const el = document.createElement('div')
+    const sender = createSender()
+
+    sender.defer(1, el, vi.fn())
+    sender.defer(1, el, vi.fn())
+    expect(sender.absorbRedispatchedEnter(1)).toBe(true)
+    expect(sender.absorbRedispatchedEnter(1)).toBe(true)
+    expect(sender.absorbRedispatchedEnter(1)).toBe(false)
+  })
+
+  it('arms the absorb window on the fallback path too', () => {
+    const el = document.createElement('div')
     const send = vi.fn()
-    const sender = createTerminalImeDeferredNewlineSender()
+    const sender = createSender()
+
+    sender.defer(1, el, send)
+    vi.runAllTimers()
+    expect(send).toHaveBeenCalledTimes(1)
+
+    expect(sender.absorbRedispatchedEnter(1)).toBe(true)
+  })
+
+  it('still delivers without a terminal element and arms the absorb window', () => {
+    const send = vi.fn()
+    const sender = createSender()
 
     sender.defer(1, null, send)
-    expect(sender.isDeferredNewlinePending(1)).toBe(true)
     vi.runAllTimers()
 
     expect(send).toHaveBeenCalledTimes(1)
-    expect(sender.isDeferredNewlinePending(1)).toBe(false)
+    expect(sender.absorbRedispatchedEnter(1)).toBe(true)
+    expect(sender.absorbRedispatchedEnter(1)).toBe(false)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
@@ -53,3 +53,42 @@ export function sendTerminalInputAfterComposition(
   terminalElement.addEventListener('compositionend', onCompositionEnd)
   const fallbackTimer = window.setTimeout(finish, fallbackMs)
 }
+
+export type TerminalImeDeferredNewlineSender = {
+  /** Defers `send` until the pane's composition commits and tracks it as in
+   *  flight for that pane. */
+  defer: (paneId: number, terminalElement: HTMLElement | null | undefined, send: () => void) => void
+  /** True while a deferred newline for this pane has not been sent yet. An
+   *  Enter keydown arriving in this window is the IME's re-dispatch of the
+   *  same physical keystroke and must not send a second newline. */
+  isDeferredNewlinePending: (paneId: number) => boolean
+}
+
+/**
+ * Wraps sendTerminalInputAfterComposition with per-pane in-flight tracking.
+ *
+ * macOS Hangul delivers a committing Shift/Ctrl+Enter twice: first as an IME
+ * keydown (`keyCode 229, isComposing=true`), then — about 2 ms after
+ * compositionend — as a re-dispatched plain keydown (`keyCode 13,
+ * isComposing=false`). Deferring only the first press still lets the
+ * re-dispatch send its newline immediately, which both races ahead of xterm's
+ * pending glyph flush and doubles the newline once the deferred send fires.
+ */
+export function createTerminalImeDeferredNewlineSender(): TerminalImeDeferredNewlineSender {
+  const pendingSendsByPaneId = new Map<number, number>()
+  return {
+    defer: (paneId, terminalElement, send) => {
+      pendingSendsByPaneId.set(paneId, (pendingSendsByPaneId.get(paneId) ?? 0) + 1)
+      sendTerminalInputAfterComposition(terminalElement, () => {
+        const pending = (pendingSendsByPaneId.get(paneId) ?? 1) - 1
+        if (pending <= 0) {
+          pendingSendsByPaneId.delete(paneId)
+        } else {
+          pendingSendsByPaneId.set(paneId, pending)
+        }
+        send()
+      })
+    },
+    isDeferredNewlinePending: (paneId) => (pendingSendsByPaneId.get(paneId) ?? 0) > 0
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
@@ -90,10 +90,7 @@ type PaneDeferredNewlineState = {
  * re-dispatch send its newline immediately, which both races ahead of xterm's
  * pending glyph flush and doubles the newline once the deferred send fires.
  */
-export function createTerminalImeDeferredNewlineSender(options?: {
-  now?: () => number
-}): TerminalImeDeferredNewlineSender {
-  const now = options?.now ?? ((): number => Date.now())
+export function createTerminalImeDeferredNewlineSender(): TerminalImeDeferredNewlineSender {
   const statesByPaneId = new Map<number, PaneDeferredNewlineState>()
 
   const cleanUpIfSettled = (paneId: number, state: PaneDeferredNewlineState): void => {
@@ -116,7 +113,7 @@ export function createTerminalImeDeferredNewlineSender(options?: {
       sendTerminalInputAfterComposition(terminalElement, () => {
         state.inFlightSends -= 1
         if (state.inFlightSends <= 0 && state.absorbCredits > 0) {
-          state.absorbDeadline = now() + TERMINAL_IME_ENTER_REDISPATCH_ABSORB_WINDOW_MS
+          state.absorbDeadline = Date.now() + TERMINAL_IME_ENTER_REDISPATCH_ABSORB_WINDOW_MS
         }
         cleanUpIfSettled(paneId, state)
         send()
@@ -128,7 +125,7 @@ export function createTerminalImeDeferredNewlineSender(options?: {
         return false
       }
       if (state.inFlightSends <= 0) {
-        if (state.absorbDeadline === null || now() > state.absorbDeadline) {
+        if (state.absorbDeadline === null || Date.now() > state.absorbDeadline) {
           statesByPaneId.delete(paneId)
           return false
         }

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
@@ -1,0 +1,55 @@
+// Why: a newline chord (Shift+Enter / Ctrl+Enter) pressed while an IME
+// composition is still open must reach the PTY *after* the composed glyph
+// commits. The window-level terminal shortcut handler runs on the keydown, which
+// fires before compositionend, so sending the newline there races ahead of the
+// pending commit — the composed CJK character is then forwarded after the
+// newline and appears pushed down a line. Instead we wait for the composition to
+// commit and forward the newline once the glyph is on its way.
+
+// Why: compositionend fires within the same event-loop turn as the committing
+// key, so a real commit always resolves well under this bound. The fallback only
+// guards against an IME that never emits compositionend, so the newline is not
+// silently swallowed.
+export const TERMINAL_IME_DEFERRED_NEWLINE_FALLBACK_MS = 200
+
+/**
+ * Forwards a terminal byte sequence once, after the active IME composition ends.
+ *
+ * xterm flushes the committed glyph asynchronously (on the next `input` event or
+ * its own `setTimeout(0)` after `compositionend`), so a bubble-phase
+ * `compositionend` listener plus one more macrotask hop orders `send()` strictly
+ * after xterm's flush. With no terminal element (or no composition to wait on),
+ * `send()` runs on the next macrotask so callers get uniform async behavior.
+ */
+export function sendTerminalInputAfterComposition(
+  terminalElement: HTMLElement | null | undefined,
+  send: () => void,
+  options?: { fallbackMs?: number }
+): void {
+  if (!terminalElement) {
+    window.setTimeout(send, 0)
+    return
+  }
+
+  const fallbackMs = options?.fallbackMs ?? TERMINAL_IME_DEFERRED_NEWLINE_FALLBACK_MS
+  let done = false
+
+  const finish = (): void => {
+    if (done) {
+      return
+    }
+    done = true
+    terminalElement.removeEventListener('compositionend', onCompositionEnd)
+    window.clearTimeout(fallbackTimer)
+    // Defer one macrotask so xterm's own post-compositionend glyph flush runs
+    // before our newline reaches the PTY.
+    window.setTimeout(send, 0)
+  }
+
+  const onCompositionEnd = (): void => finish()
+
+  // Bubble phase (not capture) so this runs after xterm's textarea-level
+  // compositionend handler, keeping our deferred send ordered after its flush.
+  terminalElement.addEventListener('compositionend', onCompositionEnd)
+  const fallbackTimer = window.setTimeout(finish, fallbackMs)
+}

--- a/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-deferred-newline.ts
@@ -54,18 +54,34 @@ export function sendTerminalInputAfterComposition(
   const fallbackTimer = window.setTimeout(finish, fallbackMs)
 }
 
+// Why: when the deferred send's timer beats the re-dispatched keydown, the
+// re-dispatch arrives a few ms later at most (both are delayed together under
+// load). A real second press cannot complete a full press cycle this quickly
+// after a composing press, so the post-send window can stay this narrow.
+export const TERMINAL_IME_ENTER_REDISPATCH_ABSORB_WINDOW_MS = 50
+
 export type TerminalImeDeferredNewlineSender = {
-  /** Defers `send` until the pane's composition commits and tracks it as in
-   *  flight for that pane. */
+  /** Defers `send` until the pane's composition commits and arms one
+   *  re-dispatch absorb credit for that pane. */
   defer: (paneId: number, terminalElement: HTMLElement | null | undefined, send: () => void) => void
-  /** True while a deferred newline for this pane has not been sent yet. An
-   *  Enter keydown arriving in this window is the IME's re-dispatch of the
-   *  same physical keystroke and must not send a second newline. */
-  isDeferredNewlinePending: (paneId: number) => boolean
+  /** Returns true when a non-composing Enter on this pane is the IME's
+   *  re-dispatch of a deferred committing keystroke and must not send a second
+   *  newline. Consumes at most one credit per deferred press: either while the
+   *  deferred send is still in flight, or within a short window after it fired
+   *  (the re-dispatch can land on either side of the send's macrotask). */
+  absorbRedispatchedEnter: (paneId: number) => boolean
+}
+
+type PaneDeferredNewlineState = {
+  inFlightSends: number
+  absorbCredits: number
+  /** Set when the last in-flight send fires with credits left; unconsumed
+   *  credits expire at this timestamp so they can never eat a later real Enter. */
+  absorbDeadline: number | null
 }
 
 /**
- * Wraps sendTerminalInputAfterComposition with per-pane in-flight tracking.
+ * Wraps sendTerminalInputAfterComposition with per-pane re-dispatch tracking.
  *
  * macOS Hangul delivers a committing Shift/Ctrl+Enter twice: first as an IME
  * keydown (`keyCode 229, isComposing=true`), then — about 2 ms after
@@ -74,21 +90,52 @@ export type TerminalImeDeferredNewlineSender = {
  * re-dispatch send its newline immediately, which both races ahead of xterm's
  * pending glyph flush and doubles the newline once the deferred send fires.
  */
-export function createTerminalImeDeferredNewlineSender(): TerminalImeDeferredNewlineSender {
-  const pendingSendsByPaneId = new Map<number, number>()
+export function createTerminalImeDeferredNewlineSender(options?: {
+  now?: () => number
+}): TerminalImeDeferredNewlineSender {
+  const now = options?.now ?? ((): number => Date.now())
+  const statesByPaneId = new Map<number, PaneDeferredNewlineState>()
+
+  const cleanUpIfSettled = (paneId: number, state: PaneDeferredNewlineState): void => {
+    if (state.inFlightSends <= 0 && state.absorbCredits <= 0) {
+      statesByPaneId.delete(paneId)
+    }
+  }
+
   return {
     defer: (paneId, terminalElement, send) => {
-      pendingSendsByPaneId.set(paneId, (pendingSendsByPaneId.get(paneId) ?? 0) + 1)
+      const state = statesByPaneId.get(paneId) ?? {
+        inFlightSends: 0,
+        absorbCredits: 0,
+        absorbDeadline: null
+      }
+      state.inFlightSends += 1
+      state.absorbCredits += 1
+      state.absorbDeadline = null
+      statesByPaneId.set(paneId, state)
       sendTerminalInputAfterComposition(terminalElement, () => {
-        const pending = (pendingSendsByPaneId.get(paneId) ?? 1) - 1
-        if (pending <= 0) {
-          pendingSendsByPaneId.delete(paneId)
-        } else {
-          pendingSendsByPaneId.set(paneId, pending)
+        state.inFlightSends -= 1
+        if (state.inFlightSends <= 0 && state.absorbCredits > 0) {
+          state.absorbDeadline = now() + TERMINAL_IME_ENTER_REDISPATCH_ABSORB_WINDOW_MS
         }
+        cleanUpIfSettled(paneId, state)
         send()
       })
     },
-    isDeferredNewlinePending: (paneId) => (pendingSendsByPaneId.get(paneId) ?? 0) > 0
+    absorbRedispatchedEnter: (paneId) => {
+      const state = statesByPaneId.get(paneId)
+      if (!state || state.absorbCredits <= 0) {
+        return false
+      }
+      if (state.inFlightSends <= 0) {
+        if (state.absorbDeadline === null || now() > state.absorbDeadline) {
+          statesByPaneId.delete(paneId)
+          return false
+        }
+      }
+      state.absorbCredits -= 1
+      cleanUpIfSettled(paneId, state)
+      return true
+    }
   }
 }

--- a/tests/e2e/korean-ime-terminal-shift-enter-commit.spec.ts
+++ b/tests/e2e/korean-ime-terminal-shift-enter-commit.spec.ts
@@ -13,8 +13,8 @@ import {
   waitForTerminalOutput
 } from './helpers/terminal'
 
-// Repro for the Shift+Enter Hangul commit race: macOS delivers a committing
-// Shift+Enter TWICE — first as an IME keydown (keyCode 229, isComposing=true),
+// Repro for the Shift/Ctrl+Enter Hangul commit race: macOS delivers a
+// committing Enter chord TWICE — first as an IME keydown (keyCode 229, isComposing=true),
 // then ~2 ms after compositionend as a re-dispatched plain keydown
 // (keyCode 13, isComposing=false). The window-level shortcut handler must send
 // exactly one newline, and only after the committed syllable has flushed.
@@ -178,20 +178,20 @@ async function commitSyllableAndSpace(session: CDPSession, page: Page): Promise<
 }
 
 /**
- * The committing Shift+Enter as recorded from the real macOS 2-set Korean IME:
+ * The committing Enter chord as recorded from the real macOS 2-set Korean IME:
  * IME keydown (229) -> commit -> re-dispatched plain keydown (13) -> keyup,
  * delivered in one un-awaited burst. The real IME delivers all of this within
  * the same native key-processing turn, ahead of xterm's setTimeout(0) glyph
  * flush; awaiting each CDP round-trip would let the flush win and hide the
  * race.
  */
-async function dispatchCommittingShiftEnter(session: CDPSession): Promise<void> {
+async function dispatchCommittingEnterChord(session: CDPSession, modifiers: number): Promise<void> {
   await Promise.all([
     session.send('Input.dispatchKeyEvent', {
       type: 'rawKeyDown',
       key: 'Enter',
       code: 'Enter',
-      modifiers: 8,
+      modifiers,
       windowsVirtualKeyCode: 229,
       nativeVirtualKeyCode: 229,
       text: '',
@@ -202,7 +202,7 @@ async function dispatchCommittingShiftEnter(session: CDPSession): Promise<void> 
       type: 'rawKeyDown',
       key: 'Enter',
       code: 'Enter',
-      modifiers: 8,
+      modifiers,
       windowsVirtualKeyCode: 13,
       nativeVirtualKeyCode: 13,
       text: '',
@@ -212,66 +212,119 @@ async function dispatchCommittingShiftEnter(session: CDPSession): Promise<void> 
       type: 'keyUp',
       key: 'Enter',
       code: 'Enter',
-      modifiers: 8,
+      modifiers,
       windowsVirtualKeyCode: 13,
       nativeVirtualKeyCode: 13
     })
   ])
 }
 
-test.describe('Korean IME terminal Shift+Enter commit', () => {
-  test('sends exactly one newline, after the trailing syllable commits', async ({
-    orcaPage,
-    testRepoPath
-  }, testInfo) => {
-    await waitForSessionReady(orcaPage)
-    await waitForActiveWorktree(orcaPage)
-    await ensureTerminalVisible(orcaPage)
-    await waitForActiveTerminalManager(orcaPage, 30_000)
+async function readPromptLine(page: Page): Promise<string> {
+  const content = stripTerminalControls(await getTerminalContent(page, 20_000))
+  const promptIndex = content.lastIndexOf(PROMPT)
+  if (promptIndex < 0) {
+    return ''
+  }
+  return (content.slice(promptIndex + PROMPT.length).split(/\r?\n/)[0] ?? '').trimEnd()
+}
 
-    const ptyId = await waitForActivePanePtyId(orcaPage)
-    const runId = randomUUID()
-    const scriptPath = path.join(testRepoPath, `.orca-korean-shift-enter-harness-${runId}.cjs`)
-    const session = await orcaPage.context().newCDPSession(orcaPage)
+type CommittingEnterChordCase = {
+  name: string
+  slug: string
+  /** CDP modifier bitmask: 8 = Shift, 2 = Ctrl. */
+  modifiers: number
+  assertOutcome: (page: Page) => Promise<void>
+}
 
-    try {
-      writeFileSync(scriptPath, terminalImeHarnessScript(runId))
-      await sendToTerminal(orcaPage, ptyId, `node ${JSON.stringify(scriptPath)}\r`)
-      await waitForTerminalOutput(orcaPage, `IME_HARNESS_READY_${runId}`, 10_000, 20_000)
-      await focusActiveTerminalInput(orcaPage)
-
-      // 하 하 하 — first two syllables committed by Space, the last one left
-      // composing so Shift+Enter is the committing keystroke.
-      await composeHangulSyllable(session, orcaPage)
-      await commitSyllableAndSpace(session, orcaPage)
-      await composeHangulSyllable(session, orcaPage)
-      await commitSyllableAndSpace(session, orcaPage)
-      await composeHangulSyllable(session, orcaPage)
-      await dispatchCommittingShiftEnter(session)
-
-      // The harness treats the \x1b of the Shift+Enter chord (\x1b\r) as a
-      // literal char and \r as submit, so the ESC's position inside the
-      // submitted string marks exactly where the newline bytes landed.
+const COMMITTING_ENTER_CHORDS: CommittingEnterChordCase[] = [
+  {
+    name: 'Shift+Enter',
+    slug: 'shift-enter',
+    modifiers: 8,
+    assertOutcome: async (page) => {
+      // The harness records the chord's ESC (of ESC CR) as a literal char and
+      // CR submits, so the ESC's position inside the submitted string marks
+      // exactly where the newline bytes landed.
       await expect
-        .poll(async () => (await readSubmitted(orcaPage)).at(-1) ?? null, {
+        .poll(async () => (await readSubmitted(page)).at(-1) ?? null, {
           timeout: 10_000,
           message: 'submitted line must contain the full text with the trailing syllable inline'
         })
         .toBe('하 하 하\u001b')
-
-      // Exactly one newline: the re-dispatched keydown must not add a second
-      // submission on top of the deferred one.
-      await orcaPage.waitForTimeout(500)
+      // Exactly one submission: the re-dispatched keydown must not add a
+      // second newline on top of the deferred one.
+      await page.waitForTimeout(500)
       expect(
-        await readSubmitted(orcaPage),
+        await readSubmitted(page),
         'the committing Shift+Enter must produce exactly one newline'
       ).toEqual(['하 하 하\u001b'])
-      await attachEvidence(orcaPage, testInfo, 'korean-shift-enter-commit')
-    } finally {
-      await attachEvidence(orcaPage, testInfo, 'korean-shift-enter-final').catch(() => undefined)
-      await session.detach().catch(() => undefined)
-      await sendToTerminal(orcaPage, ptyId, '\x03').catch(() => undefined)
-      rmSync(scriptPath, { force: true })
     }
-  })
+  },
+  {
+    name: 'Ctrl+Enter',
+    slug: 'ctrl-enter',
+    modifiers: 2,
+    assertOutcome: async (page) => {
+      // The CSI-u chord (ESC [13;5u) carries no CR, so nothing submits; the
+      // harness echoes the model with ESC rendered as <ESC>. The sequence must
+      // appear exactly once, after the committed syllables.
+      await expect
+        .poll(() => readPromptLine(page), {
+          timeout: 10_000,
+          message: 'prompt must show the committed syllables followed by exactly one CSI-u chord'
+        })
+        .toBe('하 하 하<ESC>[13;5u')
+      await page.waitForTimeout(500)
+      expect(
+        await readPromptLine(page),
+        'the committing Ctrl+Enter must produce exactly one CSI-u chord'
+      ).toBe('하 하 하<ESC>[13;5u')
+      expect(await readSubmitted(page), 'CSI-u must not submit the line').toEqual([])
+    }
+  }
+]
+
+test.describe('Korean IME terminal committing Enter chords', () => {
+  for (const chord of COMMITTING_ENTER_CHORDS) {
+    test(`${chord.name} sends exactly one newline chord, after the trailing syllable commits`, async ({
+      orcaPage,
+      testRepoPath
+    }, testInfo) => {
+      await waitForSessionReady(orcaPage)
+      await waitForActiveWorktree(orcaPage)
+      await ensureTerminalVisible(orcaPage)
+      await waitForActiveTerminalManager(orcaPage, 30_000)
+
+      const ptyId = await waitForActivePanePtyId(orcaPage)
+      const runId = randomUUID()
+      const scriptPath = path.join(testRepoPath, `.orca-korean-ime-harness-${runId}.cjs`)
+      const session = await orcaPage.context().newCDPSession(orcaPage)
+
+      try {
+        writeFileSync(scriptPath, terminalImeHarnessScript(runId))
+        await sendToTerminal(orcaPage, ptyId, `node ${JSON.stringify(scriptPath)}\r`)
+        await waitForTerminalOutput(orcaPage, `IME_HARNESS_READY_${runId}`, 10_000, 20_000)
+        await focusActiveTerminalInput(orcaPage)
+
+        // 하 하 하 with the first two syllables committed by Space and the last
+        // one left composing, so the Enter chord is the committing keystroke.
+        await composeHangulSyllable(session, orcaPage)
+        await commitSyllableAndSpace(session, orcaPage)
+        await composeHangulSyllable(session, orcaPage)
+        await commitSyllableAndSpace(session, orcaPage)
+        await composeHangulSyllable(session, orcaPage)
+        await dispatchCommittingEnterChord(session, chord.modifiers)
+
+        await chord.assertOutcome(orcaPage)
+        await attachEvidence(orcaPage, testInfo, `korean-${chord.slug}-commit`)
+      } finally {
+        await attachEvidence(orcaPage, testInfo, `korean-${chord.slug}-final`).catch(
+          () => undefined
+        )
+        await session.detach().catch(() => undefined)
+        await sendToTerminal(orcaPage, ptyId, '\x03').catch(() => undefined)
+        rmSync(scriptPath, { force: true })
+      }
+    })
+  }
 })

--- a/tests/e2e/korean-ime-terminal-shift-enter-commit.spec.ts
+++ b/tests/e2e/korean-ime-terminal-shift-enter-commit.spec.ts
@@ -1,0 +1,277 @@
+import { randomUUID } from 'node:crypto'
+import { rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import type { CDPSession, Page, TestInfo } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  focusActiveTerminalInput,
+  getTerminalContent,
+  sendToTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager,
+  waitForTerminalOutput
+} from './helpers/terminal'
+
+// Repro for the Shift+Enter Hangul commit race: macOS delivers a committing
+// Shift+Enter TWICE — first as an IME keydown (keyCode 229, isComposing=true),
+// then ~2 ms after compositionend as a re-dispatched plain keydown
+// (keyCode 13, isComposing=false). The window-level shortcut handler must send
+// exactly one newline, and only after the committed syllable has flushed.
+// Deferring only the composing keydown is not enough: the re-dispatch would
+// still send its newline immediately (ahead of the glyph) and the deferred
+// send would then double it.
+
+const PROMPT = '› '
+
+function stripTerminalControls(value: string): string {
+  let output = ''
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index)
+    if (code === 0x1b) {
+      const next = value[index + 1]
+      if (next === ']') {
+        index += 2
+        while (index < value.length) {
+          const current = value.charCodeAt(index)
+          if (current === 0x07) {
+            break
+          }
+          if (current === 0x1b && value[index + 1] === '\\') {
+            index += 1
+            break
+          }
+          index += 1
+        }
+        continue
+      }
+      if (next === '[') {
+        index += 2
+        while (index < value.length && value.charCodeAt(index) < 0x40) {
+          index += 1
+        }
+        continue
+      }
+      continue
+    }
+    if ((code >= 0 && code <= 0x08) || (code >= 0x0b && code <= 0x1f) || code === 0x7f) {
+      continue
+    }
+    output += value[index]
+  }
+  return output
+}
+
+function terminalImeHarnessScript(runId: string): string {
+  return `
+const runId = ${JSON.stringify(runId)}
+let model = ''
+
+function handleData(data) {
+  for (const ch of data) {
+    if (ch === '\\u0003') {
+      process.exit(0)
+    }
+    if (ch === '\\r' || ch === '\\n') {
+      process.stdout.write('\\r\\x1b[2K[SUBMITTED_JSON_' + runId + ']' + JSON.stringify(model) + '\\n')
+      model = ''
+      continue
+    }
+    if (ch === '\\u007f' || ch === '\\b') {
+      model = Array.from(model).slice(0, -1).join('')
+      continue
+    }
+    model += ch
+  }
+  process.stdout.write('\\r\\x1b[2K${PROMPT}' + model.replace(/\\x1b/g, '<ESC>'))
+}
+
+if (process.stdin.isTTY) process.stdin.setRawMode(true)
+process.stdin.setEncoding('utf8')
+process.stdout.write('IME_HARNESS_READY_' + runId + '\\n')
+process.stdout.write('${PROMPT}')
+process.stdin.on('data', handleData)
+`
+}
+
+async function readSubmitted(page: Page): Promise<string[]> {
+  const content = stripTerminalControls(await getTerminalContent(page, 20_000))
+  const matches = [...content.matchAll(/\[SUBMITTED_JSON_[^\]]+\]("[\s\S]*?")/g)]
+  return matches
+    .map((match) => {
+      try {
+        return JSON.parse(match[1] ?? '""') as string
+      } catch {
+        return null
+      }
+    })
+    .filter((value): value is string => value !== null)
+}
+
+async function attachEvidence(page: Page, testInfo: TestInfo, name: string): Promise<void> {
+  const evidence = {
+    terminal: await getTerminalContent(page, 20_000),
+    submitted: await readSubmitted(page)
+  }
+  await testInfo.attach(`${name}.json`, {
+    body: `${JSON.stringify(evidence, null, 2)}\n`,
+    contentType: 'application/json'
+  })
+}
+
+async function dispatchHangulProcessKey(
+  session: CDPSession,
+  key: string,
+  code: string
+): Promise<void> {
+  // Why: macOS Hangul jamo keydowns arrive as IME Process keys (keyCode 229)
+  // with the jamo in `key`; the release carries the physical keyCode.
+  await session.send('Input.dispatchKeyEvent', {
+    type: 'rawKeyDown',
+    key,
+    code,
+    windowsVirtualKeyCode: 229,
+    nativeVirtualKeyCode: 229,
+    text: '',
+    unmodifiedText: ''
+  })
+  await session.send('Input.dispatchKeyEvent', {
+    type: 'keyUp',
+    key,
+    code,
+    windowsVirtualKeyCode: 229,
+    nativeVirtualKeyCode: 229,
+    text: '',
+    unmodifiedText: ''
+  })
+}
+
+async function composeHangulSyllable(session: CDPSession, page: Page): Promise<void> {
+  await dispatchHangulProcessKey(session, 'ㅎ', 'KeyG')
+  await session.send('Input.imeSetComposition', { text: 'ㅎ', selectionStart: 1, selectionEnd: 1 })
+  await page.waitForTimeout(60)
+  await dispatchHangulProcessKey(session, 'ㅏ', 'KeyK')
+  await session.send('Input.imeSetComposition', { text: '하', selectionStart: 1, selectionEnd: 1 })
+  await page.waitForTimeout(60)
+}
+
+async function commitSyllableAndSpace(session: CDPSession, page: Page): Promise<void> {
+  await session.send('Input.insertText', { text: '하' })
+  await page.waitForTimeout(60)
+  await session.send('Input.dispatchKeyEvent', {
+    type: 'keyDown',
+    key: ' ',
+    code: 'Space',
+    windowsVirtualKeyCode: 32,
+    nativeVirtualKeyCode: 32,
+    text: ' ',
+    unmodifiedText: ' '
+  })
+  await session.send('Input.dispatchKeyEvent', {
+    type: 'keyUp',
+    key: ' ',
+    code: 'Space',
+    windowsVirtualKeyCode: 32,
+    nativeVirtualKeyCode: 32
+  })
+  await page.waitForTimeout(60)
+}
+
+/**
+ * The committing Shift+Enter as recorded from the real macOS 2-set Korean IME:
+ * IME keydown (229) -> commit -> re-dispatched plain keydown (13) -> keyup,
+ * delivered in one un-awaited burst. The real IME delivers all of this within
+ * the same native key-processing turn, ahead of xterm's setTimeout(0) glyph
+ * flush; awaiting each CDP round-trip would let the flush win and hide the
+ * race.
+ */
+async function dispatchCommittingShiftEnter(session: CDPSession): Promise<void> {
+  await Promise.all([
+    session.send('Input.dispatchKeyEvent', {
+      type: 'rawKeyDown',
+      key: 'Enter',
+      code: 'Enter',
+      modifiers: 8,
+      windowsVirtualKeyCode: 229,
+      nativeVirtualKeyCode: 229,
+      text: '',
+      unmodifiedText: ''
+    }),
+    session.send('Input.insertText', { text: '하' }),
+    session.send('Input.dispatchKeyEvent', {
+      type: 'rawKeyDown',
+      key: 'Enter',
+      code: 'Enter',
+      modifiers: 8,
+      windowsVirtualKeyCode: 13,
+      nativeVirtualKeyCode: 13,
+      text: '',
+      unmodifiedText: ''
+    }),
+    session.send('Input.dispatchKeyEvent', {
+      type: 'keyUp',
+      key: 'Enter',
+      code: 'Enter',
+      modifiers: 8,
+      windowsVirtualKeyCode: 13,
+      nativeVirtualKeyCode: 13
+    })
+  ])
+}
+
+test.describe('Korean IME terminal Shift+Enter commit', () => {
+  test('sends exactly one newline, after the trailing syllable commits', async ({
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    const runId = randomUUID()
+    const scriptPath = path.join(testRepoPath, `.orca-korean-shift-enter-harness-${runId}.cjs`)
+    const session = await orcaPage.context().newCDPSession(orcaPage)
+
+    try {
+      writeFileSync(scriptPath, terminalImeHarnessScript(runId))
+      await sendToTerminal(orcaPage, ptyId, `node ${JSON.stringify(scriptPath)}\r`)
+      await waitForTerminalOutput(orcaPage, `IME_HARNESS_READY_${runId}`, 10_000, 20_000)
+      await focusActiveTerminalInput(orcaPage)
+
+      // 하 하 하 — first two syllables committed by Space, the last one left
+      // composing so Shift+Enter is the committing keystroke.
+      await composeHangulSyllable(session, orcaPage)
+      await commitSyllableAndSpace(session, orcaPage)
+      await composeHangulSyllable(session, orcaPage)
+      await commitSyllableAndSpace(session, orcaPage)
+      await composeHangulSyllable(session, orcaPage)
+      await dispatchCommittingShiftEnter(session)
+
+      // The harness treats the \x1b of the Shift+Enter chord (\x1b\r) as a
+      // literal char and \r as submit, so the ESC's position inside the
+      // submitted string marks exactly where the newline bytes landed.
+      await expect
+        .poll(async () => (await readSubmitted(orcaPage)).at(-1) ?? null, {
+          timeout: 10_000,
+          message: 'submitted line must contain the full text with the trailing syllable inline'
+        })
+        .toBe('하 하 하\u001b')
+
+      // Exactly one newline: the re-dispatched keydown must not add a second
+      // submission on top of the deferred one.
+      await orcaPage.waitForTimeout(500)
+      expect(
+        await readSubmitted(orcaPage),
+        'the committing Shift+Enter must produce exactly one newline'
+      ).toEqual(['하 하 하\u001b'])
+      await attachEvidence(orcaPage, testInfo, 'korean-shift-enter-commit')
+    } finally {
+      await attachEvidence(orcaPage, testInfo, 'korean-shift-enter-final').catch(() => undefined)
+      await session.detach().catch(() => undefined)
+      await sendToTerminal(orcaPage, ptyId, '\x03').catch(() => undefined)
+      rmSync(scriptPath, { force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #8038.

Shift/Ctrl+Enter during Hangul composition drops the trailing syllable below the newline, the exact symptom in #8038's screenshot. Includes #8578's commit unchanged (thanks @RickyPark) and adds the missing half.

**What #8578 misses**: macOS Hangul delivers a committing Enter **twice**. Real-keyboard trace (3/3 presses):

```
keydown #1  keyCode=229, isComposing=true   -> #8578 defers (correct)
compositionend                              -> syllable commits
keydown #2  keyCode=13,  isComposing=false  -> re-dispatch, passes the guard,
                                               sends newline ahead of the glyph flush;
                                               the deferred newline then doubles it
```

**Fix**: track deferred newlines per pane; an Enter `sendInput` arriving while one is still in flight is the same physical keystroke and is dropped. The window is a few ms (200 ms worst case), so real repeats and key-repeat are unaffected; IMEs that never re-dispatch see no behavior change.

Changes:

- `terminal-ime-deferred-newline.ts`: add `createTerminalImeDeferredNewlineSender()`, a per-pane in-flight counter around #8578's `sendTerminalInputAfterComposition`.
- `keyboard-handlers.ts`: defer through the sender; drop Enter `sendInput` while the pane's deferred newline is pending.
- `terminal-ime-deferred-newline.test.ts`: 5 unit tests for the sender lifecycle.
- `tests/e2e/korean-ime-terminal-shift-enter-commit.spec.ts`: new e2e regression spec.

## Screenshots


https://github.com/user-attachments/assets/77ac6669-b306-4c10-abe3-493944852415

Typing `하 하 하` with the last syllable still composing, then pressing Shift+Enter:

- **Left**: Orca v1.4.143 (latest release). The trailing syllable drops below the newline.
- **Right**: this PR's build. The syllable commits inline and exactly one newline follows.

No visual change otherwise; only PTY byte ordering changes.

**Test environment**

- macOS 26.5.1 (Darwin 25.5.0), Apple Silicon
- IME: 2-set Korean (macOS default)
- Electron 43

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (one pre-existing environmental failure, `local-pty-shell-ready.test.ts`, reproduces on pristine main on this machine)
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions: the e2e spec replays the recorded two-keydown shape against a PTY harness and asserts exactly one newline, delivered after the committed syllable. It **fails on #8578 alone** and passes with this fix. The burst is dispatched without per-command awaits; awaited round-trips let the glyph flush win the race and hide the bug. Also verified with a real 2-set Korean IME on the built app: `하 하 하` + Shift+Enter stays inline with one newline; plain Enter / Ctrl+Enter / Space+Enter flows verified in the same session.

## AI Review Report

Reviewed with an AI coding agent. Main risks checked: absorbing a genuine second Enter (impossible: the pending window is a few ms and key-repeat only fires outside composition); lost newline (one-shot guard + 200 ms fallback retained from #8578). The review explicitly checked cross-platform compatibility for macOS, Linux, and Windows: the dedupe requires an active IME composition to arm, byte encodings are untouched, and the Windows Shift+Enter encoding path is unaffected. SSH/remote/local: sends go through the same `PtyTransport` abstraction for all hosts; only timing changes, and the transport is re-read at send time as in #8578. Agents/integrations: KKP TUIs like Codex still receive their CSI-u encodings unchanged. Performance: one Map lookup per Enter keydown, nothing on other keys. No UI surface touched.

## Security Audit

No new IPC, command execution, path handling, auth, secrets, or dependency surface; the change only reorders and dedupes an already-authorized terminal input sequence relative to the IME composition commit. No follow-up needed.

## Notes

- The re-dispatch shape was observed and verified on macOS (Darwin 25.5.0, Apple Silicon, 2-set Korean, Electron 43). On platforms whose IMEs never re-dispatch, the dedupe never arms, so behavior is unchanged; CI exercises the unit and e2e suites cross-platform.
- Supersedes #8578 (its commit included unchanged); happy to fold into #8578 instead if @RickyPark prefers.
- On #8038: it is filed as plain Enter, but plain Enter does not reproduce on identical hardware; xterm already orders the re-dispatched plain-Enter shape correctly. The Shift+Enter gesture reproduces the issue's screenshot exactly (continuation line, no submission, cursor after the dropped syllable), so this PR fixes the reported behavior.

X handle: [@sanghunkan](https://x.com/sanghunkan)

## ELI5

Typing Korean Hangul and pressing Shift/Ctrl+Enter could drop the last syllable onto the wrong line. The terminal now finishes the syllable correctly before inserting the newline.
