### PR TITLE
fix(terminal): replay cold restores at recovered grid

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -1296,6 +1296,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(result.coldRestore).toBeDefined()
       expect(result.coldRestore!.scrollback).toContain('Server running')
       expect(result.coldRestore!.cwd).toBe('/projects/myapp')
+      expect(result.coldRestore).toMatchObject({ cols: 120, rows: 40 })
       expect(lastSpawnOpts).toMatchObject({
         sessionId,
         cwd: '/projects/myapp',

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -36,6 +36,8 @@ import type { TerminalOscLinkRange } from '../../shared/terminal-osc-link-ranges
 type ColdRestorePayload = {
   scrollback: string
   cwd: string
+  cols: number
+  rows: number
   oscLinks?: TerminalOscLinkRange[]
 }
 
@@ -595,7 +597,13 @@ export class DaemonPtyAdapter implements IPtyProvider {
     if (!scrollback) {
       return null
     }
-    return { scrollback, cwd: restoreInfo.cwd, oscLinks: restoreInfo.oscLinks }
+    return {
+      scrollback,
+      cwd: restoreInfo.cwd,
+      cols: restoreInfo.cols,
+      rows: restoreInfo.rows,
+      oscLinks: restoreInfo.oscLinks
+    }
   }
 
   async sendSignal(id: string, signal: string): Promise<void> {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -10765,15 +10765,24 @@ describe('registerPtyHandlers', () => {
     )
   })
 
-  it('seeds headless terminal state with cold-restore cwd metadata', async () => {
+  it('seeds cold restore at recovered dimensions with a legacy dimensionless fallback', async () => {
     const oscLinks = [{ row: 0, startCol: 0, endCol: 8, uri: 'https://example.com/restored' }]
     const coldRestore = {
       scrollback: 'restored history\r\n',
       cwd: '/projects/restored',
+      cols: 132,
+      rows: 43,
       oscLinks
     }
+    const spawn = vi
+      .fn()
+      .mockResolvedValueOnce({ id: 'pty-cold-restore', coldRestore })
+      .mockResolvedValueOnce({
+        id: 'pty-legacy-cold-restore',
+        coldRestore: { scrollback: 'legacy history\r\n', cwd: '/projects/legacy' }
+      })
     setLocalPtyProvider({
-      spawn: vi.fn(async () => ({ id: 'pty-cold-restore', coldRestore })),
+      spawn,
       write: vi.fn(),
       resize: vi.fn(),
       kill: vi.fn(),
@@ -10798,11 +10807,22 @@ describe('registerPtyHandlers', () => {
 
     await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
 
-    expect(runtime.seedHeadlessTerminal).toHaveBeenCalledWith(
+    expect(runtime.seedHeadlessTerminal).toHaveBeenNthCalledWith(
+      1,
       'pty-cold-restore',
       'restored history\r\n',
-      undefined,
+      { cols: 132, rows: 43 },
       { cwd: '/projects/restored', oscLinks, preferProviderIfExisting: true }
+    )
+
+    await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
+
+    expect(runtime.seedHeadlessTerminal).toHaveBeenNthCalledWith(
+      2,
+      'pty-legacy-cold-restore',
+      'legacy history\r\n',
+      undefined,
+      { cwd: '/projects/legacy', oscLinks: undefined, preferProviderIfExisting: true }
     )
   })
 

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -4374,7 +4374,7 @@ export function registerPtyHandlers(
         // its hydration path will seed the emulator from xterm's live buffer,
         // which is richer than the daemon snapshot.
         if (runtime && !rendererPreSignaled && !rendererAlreadyRegistered) {
-          const seedSize =
+          const snapshotSeedSize =
             typeof result.snapshotCols === 'number' && typeof result.snapshotRows === 'number'
               ? { cols: result.snapshotCols, rows: result.snapshotRows }
               : undefined
@@ -4386,7 +4386,7 @@ export function registerPtyHandlers(
             runtime.seedHeadlessTerminal(
               result.id,
               result.snapshot,
-              seedSize,
+              snapshotSeedSize,
               typeof result.snapshotKittyKeyboardFlags === 'number'
                 ? { kittyKeyboardFlags: result.snapshotKittyKeyboardFlags }
                 : {}
@@ -4396,11 +4396,21 @@ export function registerPtyHandlers(
             typeof result.coldRestore.scrollback === 'string' &&
             result.coldRestore.scrollback.length > 0
           ) {
-            runtime.seedHeadlessTerminal(result.id, result.coldRestore.scrollback, seedSize, {
-              cwd: result.coldRestore.cwd,
-              oscLinks: result.coldRestore.oscLinks,
-              preferProviderIfExisting: true
-            })
+            const coldRestoreSeedSize =
+              typeof result.coldRestore.cols === 'number' &&
+              typeof result.coldRestore.rows === 'number'
+                ? { cols: result.coldRestore.cols, rows: result.coldRestore.rows }
+                : undefined
+            runtime.seedHeadlessTerminal(
+              result.id,
+              result.coldRestore.scrollback,
+              coldRestoreSeedSize,
+              {
+                cwd: result.coldRestore.cwd,
+                oscLinks: result.coldRestore.oscLinks,
+                preferProviderIfExisting: true
+              }
+            )
           }
         }
         if (

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -147,6 +147,9 @@ export type PtySpawnResult = {
   coldRestore?: {
     scrollback: string
     cwd: string
+    /** Optional for compatibility with restore payloads from older app code. */
+    cols?: number
+    rows?: number
     oscLinks?: TerminalOscLinkRange[]
   }
 }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1333,7 +1333,7 @@ export type PreloadApi = {
       isAlternateScreen?: boolean
       replay?: string
       sessionExpired?: boolean
-      coldRestore?: { scrollback: string; cwd: string }
+      coldRestore?: { scrollback: string; cwd: string; cols?: number; rows?: number }
       startupCwdFallback?: { kind: 'worktree'; cwd: string }
     }>
     write: (id: string, data: string) => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -874,7 +874,7 @@ const api = {
       isAlternateScreen?: boolean
       replay?: string
       sessionExpired?: boolean
-      coldRestore?: { scrollback: string; cwd: string }
+      coldRestore?: { scrollback: string; cwd: string; cols?: number; rows?: number }
       startupCwdFallback?: { kind: 'worktree'; cwd: string }
     }> => ipcRenderer.invoke('pty:spawn', opts),
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -7160,15 +7160,30 @@ describe('connectPanePty', () => {
     expect(rendered.visibleLines).toEqual(['PS >', '', '', ''])
   })
 
-  it('cold-restores scrollback then blanks the viewport without erasing scrollback', async () => {
+  it('cold-restores at the recovered grid and clears only the dirty viewport before blanking', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('fresh-pty')
     const written: string[] = []
+    const operations: (
+      | { kind: 'write'; data: string }
+      | { kind: 'resize'; cols: number; rows: number }
+    )[] = []
+    const destinationCols = 10
+    const destinationRows = 5
+    const recoveredCols = 20
+    const recoveredRows = 3
+    const coldScrollback = '\x1b[1;1HCOLD\x1b[1;15HEND\r\nCOLD_SOURCE_ROW_02'
+    const viewportClear = '\x1b[2J\x1b[H'
     transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
       if (sessionId) {
         return {
           id: 'fresh-pty',
-          coldRestore: { scrollback: 'cold TUI row one\r\ncold TUI row two', cwd: '/tmp/wt-1' }
+          coldRestore: {
+            scrollback: coldScrollback,
+            cwd: '/tmp/wt-1',
+            cols: recoveredCols,
+            rows: recoveredRows
+          }
         }
       }
       return 'fresh-pty'
@@ -7182,13 +7197,34 @@ describe('connectPanePty', () => {
     } as StoreState
 
     const pane = createPane(1)
-    pane.terminal.rows = 4
-    pane.terminal.cols = 20
+    pane.terminal.rows = destinationRows
+    pane.terminal.cols = destinationCols
+    let sawViewportClear = false
+    const preResizeBarrier = { release: null as (() => void) | null }
     pane.terminal.write = vi.fn((data: string, callback?: () => void) => {
       written.push(data)
+      operations.push({ kind: 'write', data })
+      if (data === viewportClear) {
+        sawViewportClear = true
+      } else if (sawViewportClear && data === '' && preResizeBarrier.release === null) {
+        preResizeBarrier.release = callback ?? (() => {})
+        return
+      }
       callback?.()
     })
+    pane.terminal.resize = vi.fn((cols: number, rows: number) => {
+      operations.push({ kind: 'resize', cols, rows })
+      pane.terminal.cols = cols
+      pane.terminal.rows = rows
+    })
     const manager = createManager(1)
+    pane.fitAddon.proposeDimensions = vi.fn(() => ({
+      cols: destinationCols,
+      rows: destinationRows
+    }))
+    pane.fitAddon.fit = vi.fn(() => {
+      pane.terminal.resize(destinationCols, destinationRows)
+    })
     const deps = createDeps({
       restoredLeafId: LEAF_1,
       restoredPtyIdByLeafId: { [LEAF_1]: 'lost-pty' }
@@ -7196,24 +7232,110 @@ describe('connectPanePty', () => {
 
     connectPanePty(pane as never, manager as never, deps as never)
     await flushAsyncTicks(20)
+    expect(preResizeBarrier.release).not.toBeNull()
+    expect(pane.terminal.resize).not.toHaveBeenCalledWith(recoveredCols, recoveredRows)
+    expect(written).not.toContain(coldScrollback)
 
-    const blankViewport = buildFreshShellViewportBlankingSequence(4)
+    preResizeBarrier.release?.()
+    await flushAsyncTicks(20)
+
+    const blankViewport = buildFreshShellViewportBlankingSequence(destinationRows)
+    expect(pane.terminal.resize).toHaveBeenCalledWith(recoveredCols, recoveredRows)
+    expect(transport.resize).not.toHaveBeenCalledWith(recoveredCols, recoveredRows)
+    expect(transport.resize).toHaveBeenLastCalledWith(destinationCols, destinationRows)
+    expect(written).toContain(viewportClear)
     expect(written).not.toContain('\x1b[2J\x1b[3J\x1b[H')
     expect(written).toEqual(
-      expect.arrayContaining([
-        'cold TUI row one\r\ncold TUI row two',
-        POST_REPLAY_MODE_RESET,
-        blankViewport
-      ])
+      expect.arrayContaining([coldScrollback, POST_REPLAY_MODE_RESET, blankViewport])
     )
-    expect(written.indexOf('cold TUI row one\r\ncold TUI row two')).toBeLessThan(
-      written.indexOf(blankViewport)
+    expect(written.indexOf(viewportClear)).toBeLessThan(written.indexOf(coldScrollback))
+    expect(written.indexOf(coldScrollback)).toBeLessThan(written.indexOf(blankViewport))
+    const viewportClearOperation = operations.findIndex(
+      (operation) => operation.kind === 'write' && operation.data === viewportClear
     )
+    const recoveredResizeOperation = operations.findIndex(
+      (operation) =>
+        operation.kind === 'resize' &&
+        operation.cols === recoveredCols &&
+        operation.rows === recoveredRows
+    )
+    expect(viewportClearOperation).toBeLessThan(recoveredResizeOperation)
 
-    const rendered = await renderHeadlessTerminalState([...written, 'PS >'], 20, 4)
-    expect(rendered.baseY).toBeGreaterThan(0)
-    expect(rendered.allLines.some((line) => line.includes('cold TUI row'))).toBe(true)
-    expect(rendered.visibleLines).toEqual(['PS >', '', '', ''])
+    // Model the real operation order. The previous behavior appended the
+    // recovered 20-column snapshot to a dirty 10-column xterm, leaving stale
+    // cells and wrapping each authoritative row at the wrong grid.
+    const rendered = new Terminal({
+      cols: destinationCols,
+      rows: destinationRows,
+      allowProposedApi: true
+    })
+    try {
+      await writeHeadlessTerminal(
+        rendered,
+        'KEEP_1\r\nKEEP_2\r\nOLD_ROW_1\r\nOLD_ROW_2\r\nOLD_ROW_3\r\nOLD_ROW_4\r\nOLD_ROW_5'
+      )
+      let replayedAtRecoveredGrid = false
+      let sourceGridLines: string[] = []
+      for (const operation of operations) {
+        if (operation.kind === 'resize') {
+          if (
+            replayedAtRecoveredGrid &&
+            operation.cols === destinationCols &&
+            operation.rows === destinationRows &&
+            sourceGridLines.length === 0
+          ) {
+            sourceGridLines = Array.from(
+              { length: rendered.buffer.active.length },
+              (_, lineIndex) =>
+                rendered.buffer.active.getLine(lineIndex)?.translateToString(true) ?? ''
+            )
+          }
+          rendered.resize(operation.cols, operation.rows)
+          if (operation.cols === recoveredCols && operation.rows === recoveredRows) {
+            replayedAtRecoveredGrid = true
+          }
+        } else {
+          await writeHeadlessTerminal(rendered, operation.data)
+        }
+      }
+      if (sourceGridLines.length === 0) {
+        sourceGridLines = Array.from(
+          { length: rendered.buffer.active.length },
+          (_, lineIndex) => rendered.buffer.active.getLine(lineIndex)?.translateToString(true) ?? ''
+        )
+      }
+      expect(sourceGridLines).toContain('COLD          END')
+      if (rendered.cols !== destinationCols || rendered.rows !== destinationRows) {
+        rendered.resize(destinationCols, destinationRows)
+      }
+      await writeHeadlessTerminal(rendered, 'PS >')
+      const buffer = rendered.buffer.active
+      const lines = Array.from({ length: buffer.length }, (_, lineIndex) =>
+        buffer.getLine(lineIndex)?.translateToString(true)
+      )
+      const logicalLines: string[] = []
+      for (let lineIndex = 0; lineIndex < buffer.length; lineIndex += 1) {
+        const line = buffer.getLine(lineIndex)
+        const text = line?.translateToString(true) ?? ''
+        if (line?.isWrapped && logicalLines.length > 0) {
+          logicalLines[logicalLines.length - 1] += text
+        } else {
+          logicalLines.push(text)
+        }
+      }
+      const visibleLines = Array.from({ length: rendered.rows }, (_, row) =>
+        buffer.getLine(buffer.viewportY + row)?.translateToString(true)
+      )
+      expect(buffer.baseY).toBeGreaterThan(0)
+      expect(lines.some((line) => line?.includes('OLD_ROW_'))).toBe(false)
+      expect(lines.some((line) => line?.includes('KEEP_1'))).toBe(true)
+      expect(lines.some((line) => line?.includes('KEEP_2'))).toBe(true)
+      expect(logicalLines.some((line) => /COLD\s+END/.test(line))).toBe(true)
+      expect(logicalLines.some((line) => line.includes('COLD_SOURCE_ROW_02'))).toBe(true)
+      expect(visibleLines).toEqual(['PS >', '', '', '', ''])
+    } finally {
+      rendered.dispose()
+    }
   })
 
   it('resumes the provider agent session when daemon reattach cold-restores a fresh shell', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1019,7 +1019,7 @@ export function connectPanePty(
   // foreground frame opened, so a split end marker that lands after the redraw
   // window still drains on the fast path instead of the 1s coalesce fallback.
   let synchronizedForegroundFrameInteractive = false
-  let suppressSnapshotReplayPtyResize = false
+  let suppressStructuralReplayPtyResize = false
   // Why: hidden-delivery gate sync is wired up alongside the deferred PTY
   // output plumbing inside the connect frame; lifecycle hooks (visibility
   // flips, exit, dispose) run before/after it exists, so start with no-ops.
@@ -3677,7 +3677,7 @@ export function connectPanePty(
   pane.container.addEventListener(PANE_PTY_RESIZE_HOLD_FLUSH_EVENT, onHeldPtyResizeFlush)
 
   const onResizeDisposable = pane.terminal.onResize(({ cols, rows }) => {
-    if (suppressSnapshotReplayPtyResize || suppressViewportClaimTerminalResize) {
+    if (suppressStructuralReplayPtyResize || suppressViewportClaimTerminalResize) {
       return
     }
     forwardPtyResize(cols, rows)
@@ -4906,8 +4906,8 @@ export function connectPanePty(
       return deps.restoredViewportBlankingPanesRef?.current.delete(pane.id) ?? false
     }
 
-    const writeFreshShellViewportBlanking = (): void => {
-      writeReplayData(buildFreshShellViewportBlankingSequence(pane.terminal.rows))
+    const writeFreshShellViewportBlanking = (rows = pane.terminal.rows): void => {
+      writeReplayData(buildFreshShellViewportBlankingSequence(rows))
     }
 
     const prepareFreshShellViewportForSpawn = (options: FreshSpawnOptions): void => {
@@ -6500,11 +6500,11 @@ export function connectPanePty(
             ) {
               // Why: xterm parses writes later. Keep snapshot dimensions until
               // the FIFO sentinel completes so serialized wraps stay exact.
-              suppressSnapshotReplayPtyResize = true
+              suppressStructuralReplayPtyResize = true
               try {
                 pane.terminal.resize(snapshot.cols, snapshot.rows)
               } finally {
-                suppressSnapshotReplayPtyResize = false
+                suppressStructuralReplayPtyResize = false
               }
             }
             if (!snapshot.alternateScreen) {
@@ -7286,11 +7286,11 @@ export function connectPanePty(
             hasSnapshotDimensions &&
             (pane.terminal.cols !== snapshotCols || pane.terminal.rows !== snapshotRows)
           ) {
-            suppressSnapshotReplayPtyResize = true
+            suppressStructuralReplayPtyResize = true
             try {
               pane.terminal.resize(snapshotCols, snapshotRows)
             } finally {
-              suppressSnapshotReplayPtyResize = false
+              suppressStructuralReplayPtyResize = false
             }
           }
           writeReplayData('\x1b[2J\x1b[3J\x1b[H')
@@ -7337,6 +7337,48 @@ export function connectPanePty(
             }
           }
         } else if (connectResult?.coldRestore) {
+          let destinationRows = pane.terminal.rows
+          try {
+            const proposedDestination = pane.fitAddon.proposeDimensions()
+            if (
+              proposedDestination &&
+              Number.isFinite(proposedDestination.rows) &&
+              proposedDestination.rows > 0
+            ) {
+              destinationRows = Math.max(destinationRows, proposedDestination.rows)
+            }
+          } catch {
+            // The current xterm grid remains a safe lower bound for blanking.
+          }
+          // Why: shrinking first would promote clipped stale viewport rows into
+          // scrollback, beyond the reach of a later viewport-only clear.
+          writeReplayData('\x1b[2J\x1b[H')
+          await waitForTerminalReplayWritesParsed(pane.terminal)
+          if (!isCurrentReattachPayload()) {
+            return
+          }
+          const coldRestoreCols = connectResult.coldRestore.cols
+          const coldRestoreRows = connectResult.coldRestore.rows
+          const hasColdRestoreDimensions =
+            typeof coldRestoreCols === 'number' &&
+            typeof coldRestoreRows === 'number' &&
+            Number.isFinite(coldRestoreCols) &&
+            Number.isFinite(coldRestoreRows) &&
+            coldRestoreCols > 0 &&
+            coldRestoreRows > 0
+          if (
+            hasColdRestoreDimensions &&
+            (pane.terminal.cols !== coldRestoreCols || pane.terminal.rows !== coldRestoreRows)
+          ) {
+            // Why: recovered ANSI cursor positions belong to the checkpoint's
+            // grid. Keep this layout-only resize from reaching the fresh PTY.
+            suppressStructuralReplayPtyResize = true
+            try {
+              pane.terminal.resize(coldRestoreCols, coldRestoreRows)
+            } finally {
+              suppressStructuralReplayPtyResize = false
+            }
+          }
           // replayIntoTerminal: the recorded scrollback is raw PTY output that
           // may contain query sequences the previous agent CLI emitted;
           // writing them through xterm.write would trigger auto-replies that
@@ -7359,7 +7401,9 @@ export function connectPanePty(
           // flags it pushed died with it — the fresh shell starts at zero.
           kittyKeyboardModes.reset()
           consumeRestoredViewportBlankingMarker()
-          writeFreshShellViewportBlanking()
+          // Why: a taller destination fit must not pull recovered rows back
+          // into the fresh shell's viewport after source-grid replay.
+          writeFreshShellViewportBlanking(Math.max(destinationRows, pane.terminal.rows))
           if (!isRemoteRuntimePtyId(ptyId)) {
             window.api.pty.ackColdRestore(ptyId)
           }

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -49,7 +49,7 @@ export type PtyConnectResult = {
   snapshotRows?: number
   isAlternateScreen?: boolean
   sessionExpired?: boolean
-  coldRestore?: { scrollback: string; cwd: string }
+  coldRestore?: { scrollback: string; cwd: string; cols?: number; rows?: number }
   replay?: string
   startupCwdFallback?: { kind: 'worktree'; cwd: string }
   /** Trailing partial escape the daemon emulator held mid-parse; the reattach


### PR DESCRIPTION
## Summary

- Preserve disk cold-restore `cols`/`rows` across the daemon provider, IPC/preload, renderer, and main headless terminal.
- Replay cold ANSI at its recovered grid without forwarding that temporary resize to the fresh PTY.
- Clear stale viewport cells at the destination grid (`CSI 2J` + home), await parsing before any recovered-grid shrink can promote clipped rows into scrollback, continue to forbid `CSI 3J`, blank enough source/immediate-destination rows, then use the existing structural replay barrier and authoritative fit.
- Keep older dimensionless cold-restore payloads compatible.

This is a cold-restore parity follow-up found while investigating #8751. Runtime evidence indicates the screenshot's immediate warm-reattach race is separately addressed by #8674; this PR does not claim that the cold path alone produced the screenshot or replace #8674.

## Screenshots

No visual design change. The failure screenshot and investigation are in #8751.

## Testing

- [ ] `pnpm lint` — full repository lint not run; touched `oxlint` and `oxfmt --check` passed
- [x] `pnpm typecheck`
- [ ] `pnpm test` — full repository suite not run; affected 5-file matrix passed with 904 tests / 15 skipped
- [ ] `pnpm build` — full production/native build not run; the Electron E2E bundle built successfully
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Commands run:

- `pnpm test -- src/main/daemon/daemon-pty-adapter.test.ts src/main/ipc/pty.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/lib/pane-manager/terminal-structural-replay-coordinator.test.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts`
- `pnpm typecheck`
- `pnpm exec electron-vite build --mode e2e`
- touched-file `pnpm exec oxfmt --check ...`
- touched-file `pnpm exec oxlint ...`
- `pnpm run check:max-lines-ratchet`
- `git diff --check`

The initial regression was red in three focused assertions: missing adapter dimensions, `undefined` runtime seed dimensions, and no renderer resize to the recovered grid. A strengthened dirty-grid regression then caught a blocker in the first implementation: shrinking from a dirty 10x5 destination to the recovered 20x3 grid before clearing promoted clipped stale rows into scrollback, beyond a later viewport-only clear. Its clear-before-resize ordering assertion failed before the correction and passes after the clear parse barrier. The final five-file matrix passed.

### Same-PC Windows Electron verification

The exact PR-head app bundle (`877a3c28c04b54037f983c8b25029b7fd95e2cbe`) was exercised with disposable user data on the affected Windows PC:

- clean close/relaunch retained the same daemon PID/session and the restored pane accepted keyboard-path and direct PTY input;
- daemon-snapshot replay restored the cursor to a shell prompt rather than an older output row;
- killing the disposable daemon between launches forced disk cold restore, created the replacement PTY, and left the completed restore interactive in isolated repeats.

On the final amended bundle, both warm checks passed and all 3 repeated cold runs that reached the input assertion passed. One serial run began the delayed keyboard probe during the intentional replay guard: PowerShell received only the suffix `RED_OK`, while direct PTY input already worked before `pty:listSessions`. Independent trace and code reviews classified this as an E2E replay-readiness race, not a persistent transport or ownership failure. Two further repetitions ended earlier during app setup when navigation destroyed the Playwright execution context; neither reached the cold-input assertion.

The committed E2E drivers assume POSIX `Ctrl+U`/`export PS1`, and the cold case is normally skipped on Windows, so only the temporary test driver was adapted; the built application stayed at the exact PR head and all driver edits were restored afterward. The packaged installer/update harness was not run because it correctly refuses while an unrelated Orca app process is active.

## AI Review Report

Parallel investigation covered the issue/release history, local Windows runtime chronology, restore-path code tracing, test-first implementation, and independent adversarial diff, external-state, and Windows-runtime reviews.

Main risks checked:

- A recovered-height shrink can promote dirty destination rows into scrollback; the patch clears and awaits xterm parsing before that structural resize, and the regression preserves pre-existing scrollback sentinels.
- A full clear would regress #7310 by erasing restored scrollback; the patch uses viewport-only `CSI 2J` and tests that `CSI 3J` is absent.
- The incident's immediate warm-return mechanism belongs to unreleased #8674; PR and issue wording were narrowed to the independently proven cold-restore gap.
- Cold dimensions remain optional at public boundaries so older payloads retain their current fallback.
- Synthetic source-grid resizes are suppressed from PTY forwarding; only the post-replay destination fit reaches the PTY.
- The main headless emulator uses cold dimensions rather than accidentally borrowing warm snapshot fields.
- The headless oracle starts from adversarial dirty state and proves stale-content absence, recovered cursor spacing, scrollback retention, reflow, and a clean final viewport.
- Existing delayed-parse tests cover the shared replay barrier, fit/SIGWINCH gating, and live-byte ordering used by snapshot, replay, and cold restore.

Cross-platform review explicitly covered macOS, Linux, Windows/ConPTY, SSH relay, and remote-runtime behavior. No shortcut, label, path, shell-command, Git-provider, or local-only assumption was added. SSH relay restore remains on its existing replay branch; optional cold metadata is transport-neutral.

## Security Audit

No dependency, command execution, filesystem path, auth, secret, network, or new IPC-channel surface was added. The existing internal cold-restore result gains two numeric metadata fields sourced from recovered terminal history. Renderer use requires finite positive dimensions before resizing; legacy/missing values fall back safely. Replay remains under the existing query-response guard so recorded terminal queries cannot write replies into the fresh shell.

## Notes

- #8674 (`69c14fadce`) merged after v1.4.143 and is absent from that release. Newly published [v1.4.144-rc.0](https://github.com/stablyai/orca/releases/tag/v1.4.144-rc.0) contains #8674, but not this cold-restore follow-up.
- Completed Windows Electron warm restoration and all 3 cold repeats that reached input passed on the exact PR head; one serial keyboard probe raced replay readiness rather than finding a persistent freeze. v1.4.144-rc.0 can now verify the warm fix, while a future packaged build containing this PR is still required for combined warm/cold release verification before #8751 is closed.
- GitHub's ordinary PR, Wayland GPU, and computer-use workflows currently await maintainer approval for this fork PR; only `track-community-pr` has run and passed so far.
- Detailed investigation comment: https://github.com/stablyai/orca/issues/8751#issuecomment-4994737327
- Companion Windows restart-regression PR: #9064. It hardens the PowerShell/replay-readiness drivers and adds the non-skippable Windows gate. The PRs are independently mergeable, but #9043 and #9064 should land together; merge #9064 first, then synchronize or mark #9043 ready so the new workflow runs.
