### PR TITLE
fix(terminal): avoid retained PowerShell for stock Codex on Windows

### DIFF
--- a/src/main/daemon/daemon-create-or-attach-protocol.ts
+++ b/src/main/daemon/daemon-create-or-attach-protocol.ts
@@ -1,0 +1,36 @@
+import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery'
+import type { TuiAgent } from '../../shared/types'
+
+export type CreateOrAttachRequest = {
+  id: string
+  type: 'createOrAttach'
+  payload: {
+    sessionId: string
+    cols: number
+    rows: number
+    cwd?: string
+    env?: Record<string, string>
+    envToDelete?: string[]
+    command?: string
+    startupCommandDelivery?: StartupCommandDelivery
+    launchAgent?: TuiAgent
+    windowsCodexShellHandoff?: boolean
+    /** Explicit Windows shell override selected by the user (e.g. 'wsl.exe').
+     *  The daemon forwards this to its subprocess spawner so each tab honors
+     *  the shell picked in the "+" menu or the persisted default-shell setting,
+     *  instead of defaulting to COMSPEC (which is always cmd.exe on Windows)
+     *  or the hard-coded powershell.exe fallback. */
+    shellOverride?: string
+    /** Preferred WSL distro for generic `wsl.exe` launches. */
+    terminalWindowsWslDistro?: string | null
+    /** Why: the UI keeps PowerShell as one shell family, but the runtime may
+     *  need to substitute pwsh.exe for powershell.exe when the user selected
+     *  PowerShell 7+. Forward the persisted implementation choice so the daemon
+     *  PTY path resolves the same effective executable as LocalPtyProvider. */
+    terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
+    shellReadySupported?: boolean
+    shellReadyTimeoutMs?: number
+    /** Recovered ANSI applied before the new subprocess can emit startup output. */
+    historySeed?: string
+  }
+}

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -95,6 +95,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
     cwd?: string
     env?: Record<string, string>
     command?: string
+    windowsCodexShellHandoff?: boolean
   } | null
   let subprocessDataOnSubscribe: string | undefined
 
@@ -138,6 +139,46 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
     it('uses worktreeId as session prefix when provided', async () => {
       const result = await adapter.spawn({ cols: 80, rows: 24, worktreeId: 'wt-1' })
       expect(result.id).toContain('wt-1')
+    })
+
+    it('forwards Windows Codex handoff provenance only when it is true', async () => {
+      await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'codex-handoff-true',
+        windowsCodexShellHandoff: true
+      })
+      expect(lastSpawnOpts).toMatchObject({ windowsCodexShellHandoff: true })
+
+      await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'codex-handoff-false',
+        windowsCodexShellHandoff: false
+      })
+      expect(lastSpawnOpts).not.toHaveProperty('windowsCodexShellHandoff')
+    })
+
+    it('does not arm the shell-ready barrier for a Windows Codex handoff', async () => {
+      const client = (
+        adapter as unknown as {
+          client: { request: (type: string, payload?: unknown) => Promise<unknown> }
+        }
+      ).client
+      const requestSpy = vi.spyOn(client, 'request')
+
+      await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'codex-handoff-no-shell-ready',
+        command: 'codex',
+        env: { SHELL: '/bin/zsh' },
+        windowsCodexShellHandoff: true
+      })
+
+      const payload = requestSpy.mock.calls.find((call) => call[0] === 'createOrAttach')?.[1]
+      expect(payload).toMatchObject({ shellReadySupported: false })
+      expect(payload).not.toHaveProperty('shellReadyTimeoutMs')
     })
 
     itOnPosix('keeps plain Codex startup on the short daemon shell-ready timeout', async () => {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -233,7 +233,12 @@ export class DaemonPtyAdapter implements IPtyProvider {
     let effectiveCols = restoreInfo?.cols ?? opts.cols
     let effectiveRows = restoreInfo?.rows ?? opts.rows
 
-    const shellReadySupported = opts.command ? supportsPtyStartupBarrier(opts.env ?? {}) : false
+    // Why: this handoff delivers Codex in shell argv, so there is no interactive
+    // shell that can emit the daemon's readiness marker.
+    const shellReadySupported =
+      opts.windowsCodexShellHandoff !== true && opts.command
+        ? supportsPtyStartupBarrier(opts.env ?? {})
+        : false
     const isCodexStartupCommand =
       recognizeAgentProcessFromCommandLine(opts.command)?.agent === 'codex'
     const shouldWaitForShellReady =
@@ -258,6 +263,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
         command: opts.command,
         startupCommandDelivery: opts.startupCommandDelivery,
         launchAgent: opts.launchAgent,
+        ...(opts.windowsCodexShellHandoff === true ? { windowsCodexShellHandoff: true } : {}),
         // Why: without this, the daemon always spawns cmd.exe (COMSPEC) or
         // PowerShell as a fallback — regardless of which shell the renderer
         // asked for in the "+" menu or persisted as the default. Forwarding

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -209,6 +209,40 @@ describe('DaemonServer', () => {
       expect(unknown).not.toHaveProperty('launchAgent')
     })
 
+    it('forwards only literal true Windows Codex handoff provenance', async () => {
+      const spawnSubprocess = vi.fn((_opts: { windowsCodexShellHandoff?: boolean }) =>
+        createMockSubprocess()
+      )
+      server = new DaemonServer({ socketPath, tokenPath, spawnSubprocess })
+      await server.start()
+      const c = await connectClient()
+
+      await c.request('createOrAttach', {
+        sessionId: 'handoff-true',
+        cols: 80,
+        rows: 24,
+        windowsCodexShellHandoff: true
+      })
+      await c.request('createOrAttach', {
+        sessionId: 'handoff-false',
+        cols: 80,
+        rows: 24,
+        windowsCodexShellHandoff: false
+      })
+      await c.request('createOrAttach', {
+        sessionId: 'handoff-string',
+        cols: 80,
+        rows: 24,
+        windowsCodexShellHandoff: 'true'
+      } as never)
+
+      expect(spawnSubprocess.mock.calls[0]?.[0]).toMatchObject({
+        windowsCodexShellHandoff: true
+      })
+      expect(spawnSubprocess.mock.calls[1]?.[0]).not.toHaveProperty('windowsCodexShellHandoff')
+      expect(spawnSubprocess.mock.calls[2]?.[0]).not.toHaveProperty('windowsCodexShellHandoff')
+    })
+
     it('handles listSessions', async () => {
       await startServer()
       const c = await connectClient()

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -43,6 +43,7 @@ export type DaemonServerOptions = {
     cwd?: string
     env?: Record<string, string>
     command?: string
+    windowsCodexShellHandoff?: boolean
     shellOverride?: string
   }) => SubprocessHandle
 }
@@ -353,6 +354,7 @@ export class DaemonServer {
           // Why: daemon RPC payloads are untrusted JSON. Persist only the
           // allowlisted enum used for byte routing, never arbitrary identity.
           ...(isTuiAgent(p.launchAgent) ? { launchAgent: p.launchAgent } : {}),
+          ...(p.windowsCodexShellHandoff === true ? { windowsCodexShellHandoff: true } : {}),
           shellOverride: p.shellOverride,
           terminalWindowsWslDistro: p.terminalWindowsWslDistro,
           terminalWindowsPowerShellImplementation: p.terminalWindowsPowerShellImplementation,

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -20,6 +20,7 @@ import {
 } from './daemon-stream-backlog-probe'
 import { readCurrentProcessMacSystemResolverHealth } from '../network/macos-system-resolver-health'
 import type { SubprocessHandle } from './session'
+import type { TerminalHostSubprocessOptions } from './terminal-host-create-contract'
 import { checkPtySpawnHealth } from './pty-subprocess'
 import { createNoopDaemonFileLog, type DaemonFileLog } from './daemon-file-log'
 import { isTuiAgent } from '../../shared/tui-agent-config'
@@ -36,16 +37,7 @@ export type DaemonServerOptions = {
   tokenPath: string
   ptySpawnHealthCheck?: () => Promise<void>
   log?: DaemonFileLog
-  spawnSubprocess: (opts: {
-    sessionId: string
-    cols: number
-    rows: number
-    cwd?: string
-    env?: Record<string, string>
-    command?: string
-    windowsCodexShellHandoff?: boolean
-    shellOverride?: string
-  }) => SubprocessHandle
+  spawnSubprocess: (opts: TerminalHostSubprocessOptions) => SubprocessHandle
 }
 
 type ConnectedClient = {

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -7,12 +7,14 @@ import type * as LocalPtyUtils from '../providers/local-pty-utils'
 
 const {
   spawnMock,
+  buildWindowsCodexShellHandoffAttemptMock,
   isPwshAvailableMock,
   validateWorkingDirectoryMock,
   resolveUnixShellPathMock,
   resolveAgentForegroundProcessMock
 } = vi.hoisted(() => ({
   spawnMock: vi.fn(),
+  buildWindowsCodexShellHandoffAttemptMock: vi.fn(),
   isPwshAvailableMock: vi.fn(),
   resolveUnixShellPathMock: vi.fn((shellPath: string) => shellPath),
   resolveAgentForegroundProcessMock: vi.fn(),
@@ -31,6 +33,10 @@ vi.mock('node-pty', () => ({
 
 vi.mock('../pwsh', () => ({
   isPwshAvailable: isPwshAvailableMock
+}))
+
+vi.mock('../providers/windows-codex-shell-handoff', () => ({
+  buildWindowsCodexShellHandoffAttempt: buildWindowsCodexShellHandoffAttemptMock
 }))
 
 // Resolve PowerShell family names to deterministic absolute paths so these
@@ -115,6 +121,8 @@ describe('createPtySubprocess', () => {
 
   beforeEach(() => {
     spawnMock.mockReset()
+    buildWindowsCodexShellHandoffAttemptMock.mockReset()
+    buildWindowsCodexShellHandoffAttemptMock.mockReturnValue(null)
     isPwshAvailableMock.mockReset()
     resolveAgentForegroundProcessMock.mockReset()
     resolveAgentForegroundProcessMock.mockImplementation(
@@ -327,6 +335,11 @@ describe('createPtySubprocess', () => {
   it('uses a new daemon protocol for post-merge Git guard behavior', () => {
     expect(PROTOCOL_VERSION).toBeGreaterThan(21)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(21)
+  })
+
+  it('uses daemon protocol v23 for Windows Codex shell handoff behavior', () => {
+    expect(PROTOCOL_VERSION).toBe(23)
+    expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS.at(-1)).toBe(22)
   })
 
   it('resolves a missing Unix default before spawning node-pty', () => {
@@ -1069,6 +1082,69 @@ describe('createPtySubprocess', () => {
 
       await vi.waitFor(() => expect(handle.getForegroundProcess()).toBe('codex'))
     } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+  })
+
+  it('spawns the same Windows Codex handoff host and exposes its logical PowerShell', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-16T12:00:00.000Z'))
+    const proc = mockPtyProcess()
+    proc.process = 'xterm-256color'
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const nodeHost = 'C:\\Program Files\\nodejs\\node.exe'
+    buildWindowsCodexShellHandoffAttemptMock.mockReturnValue({
+      shellPath: nodeHost,
+      shellArgs: ['-e', 'handoff-script', 'encoded-config'],
+      logicalShellPath: PWSH7_ABS,
+      effectiveCwd: 'C:\\repo',
+      validationCwd: 'C:\\repo',
+      startupCommandDeliveredInShellArgs: true
+    })
+    resolveAgentForegroundProcessMock.mockResolvedValue('pwsh.exe')
+
+    try {
+      const handle = createPtySubprocess({
+        sessionId: 'repo::C:\\repo@@codex-handoff',
+        cols: 80,
+        rows: 24,
+        cwd: 'C:\\repo',
+        env: { COMSPEC: WINDOWS_POWERSHELL_ABS },
+        terminalWindowsPowerShellImplementation: 'pwsh.exe',
+        command: "codex '--version'",
+        launchAgent: 'codex',
+        windowsCodexShellHandoff: true
+      })
+
+      expect(buildWindowsCodexShellHandoffAttemptMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          launchAgent: 'codex',
+          startupCommand: "codex '--version'",
+          windowsCodexShellHandoff: true
+        })
+      )
+      expect(spawnMock).toHaveBeenCalledWith(
+        nodeHost,
+        ['-e', 'handoff-script', 'encoded-config'],
+        expect.objectContaining({ cwd: 'C:\\repo' })
+      )
+      expect(handle.shellPath).toBe(PWSH7_ABS)
+      expect(handle.startupCommandDeliveredInShellArgs).toBe(true)
+      expect(handle.getForegroundProcess()).toBe('codex')
+
+      vi.advanceTimersByTime(5_001)
+      expect(handle.getForegroundProcess()).toBe('pwsh.exe')
+      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledWith(
+        proc.pid,
+        'pwsh.exe',
+        expect.any(Object)
+      )
+    } finally {
+      vi.useRealTimers()
       if (platform) {
         Object.defineProperty(process, 'platform', platform)
       }

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -26,6 +26,7 @@ import {
 } from '../providers/windows-powershell'
 import {
   buildWindowsPowerShellSpawnAttempts,
+  prependWindowsCodexShellHandoffAttempt,
   type WindowsShellSpawnAttempt
 } from '../providers/windows-shell-fallback-chain'
 import { isPwshAvailable } from '../pwsh'
@@ -115,6 +116,7 @@ export type PtySubprocessOptions = {
   command?: string
   startupCommandDelivery?: StartupCommandDelivery
   launchAgent?: TuiAgent
+  windowsCodexShellHandoff?: boolean
   /** Explicit shell executable path/basename the renderer asked for.
    *  Overrides env.COMSPEC / env.SHELL resolution inside the daemon so a user
    *  who picks "New WSL terminal" from the "+" menu actually gets WSL. */
@@ -509,6 +511,7 @@ function spawnDaemonPtyWithWindowsFallback(args: {
 }): {
   process: pty.IPty
   shellPath: string
+  logicalShellPath?: string
   spawnCwd: string
   startupCommandDeliveredInShellArgs?: boolean
 } {
@@ -530,6 +533,9 @@ function spawnDaemonPtyWithWindowsFallback(args: {
     return {
       process: spawnAt(args.shellPath, args.shellArgs, args.spawnCwd),
       shellPath: args.shellPath,
+      ...(args.windowsFallbackAttempts[0]?.logicalShellPath
+        ? { logicalShellPath: args.windowsFallbackAttempts[0].logicalShellPath }
+        : {}),
       spawnCwd: args.spawnCwd
     }
   } catch (primaryErr) {
@@ -547,6 +553,7 @@ function spawnDaemonPtyWithWindowsFallback(args: {
         return {
           process,
           shellPath: attempt.shellPath,
+          ...(attempt.logicalShellPath ? { logicalShellPath: attempt.logicalShellPath } : {}),
           spawnCwd: attempt.effectiveCwd,
           startupCommandDeliveredInShellArgs: attempt.startupCommandDeliveredInShellArgs
         }
@@ -819,6 +826,27 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   }
   promoteAgentTeamsShimPath(env, opts.env?.PATH)
 
+  if (process.platform === 'win32' && windowsFallbackAttempts.length > 0) {
+    windowsFallbackAttempts = prependWindowsCodexShellHandoffAttempt({
+      attempts: windowsFallbackAttempts,
+      cwd: requestedCwd,
+      defaultCwd: getDefaultCwd(),
+      wslContext: sessionWslContext ?? preferredWslContext,
+      startupCommand: opts.command,
+      launchAgent: opts.launchAgent,
+      windowsCodexShellHandoff: opts.windowsCodexShellHandoff,
+      env
+    })
+    const primaryAttempt = windowsFallbackAttempts[0]
+    if (primaryAttempt) {
+      shellPath = primaryAttempt.shellPath
+      shellArgs = primaryAttempt.shellArgs
+      spawnCwd = primaryAttempt.effectiveCwd
+      validationCwd = primaryAttempt.validationCwd
+      startupCommandDeliveredInShellArgs = primaryAttempt.startupCommandDeliveredInShellArgs
+    }
+  }
+
   // Why: asar packaging can strip the +x bit from node-pty's spawn-helper
   // binary. The main process fixes this via LocalPtyProvider, but the daemon
   // runs in a separate forked process with its own code path.
@@ -844,7 +872,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     proc = spawned.process
     // Why: a Windows fallback (e.g. cmd.exe) carries its own argv-embedded
     // startup command, so adopt the winning shell's identity + delivery flag.
-    shellPath = spawned.shellPath
+    shellPath = spawned.logicalShellPath ?? spawned.shellPath
     spawnCwd = spawned.spawnCwd
     if (spawned.startupCommandDeliveredInShellArgs !== undefined) {
       startupCommandDeliveredInShellArgs = spawned.startupCommandDeliveredInShellArgs

--- a/src/main/daemon/terminal-host-create-contract.ts
+++ b/src/main/daemon/terminal-host-create-contract.ts
@@ -2,7 +2,7 @@ import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery
 import type { TuiAgent } from '../../shared/types'
 import type { ShellReadyState, TerminalSnapshot } from './types'
 
-export type CreateOrAttachOptions = {
+export type TerminalHostSubprocessOptions = {
   sessionId: string
   cols: number
   rows: number
@@ -12,10 +12,14 @@ export type CreateOrAttachOptions = {
   command?: string
   startupCommandDelivery?: StartupCommandDelivery
   launchAgent?: TuiAgent
+  windowsCodexShellHandoff?: boolean
   /** Explicit shell the renderer asked for, forwarded to the subprocess. */
   shellOverride?: string
   terminalWindowsWslDistro?: string | null
   terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
+}
+
+export type CreateOrAttachOptions = TerminalHostSubprocessOptions & {
   shellReadySupported?: boolean
   shellReadyTimeoutMs?: number
   historySeed?: string

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -2,7 +2,6 @@ import { Session, type SubprocessHandle } from './session'
 import { normalizePtySize } from './daemon-pty-size'
 import { shellPathSupportsPtyStartupBarrier } from './shell-ready'
 import { resolveProcessCwd } from '../providers/process-cwd'
-import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery'
 import { buildStartupCommandSubmission } from '../../shared/startup-command-submission'
 import {
   SessionNotFoundError,
@@ -10,7 +9,11 @@ import {
   type TakePendingOutputResult,
   type TerminalSnapshot
 } from './types'
-import type { CreateOrAttachOptions, CreateOrAttachResult } from './terminal-host-create-contract'
+import type {
+  CreateOrAttachOptions,
+  CreateOrAttachResult,
+  TerminalHostSubprocessOptions
+} from './terminal-host-create-contract'
 import { shutdownTerminalHostSessions } from './terminal-host-session-shutdown'
 import { TerminalSessionTeardown } from './terminal-session-teardown'
 
@@ -19,19 +22,7 @@ export type { CreateOrAttachOptions, CreateOrAttachResult } from './terminal-hos
 const DEFAULT_MAX_TOMBSTONES = 1000
 
 export type TerminalHostOptions = {
-  spawnSubprocess: (opts: {
-    sessionId: string
-    cols: number
-    rows: number
-    cwd?: string
-    env?: Record<string, string>
-    envToDelete?: string[]
-    command?: string
-    startupCommandDelivery?: StartupCommandDelivery
-    shellOverride?: string
-    terminalWindowsWslDistro?: string | null
-    terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
-  }) => SubprocessHandle
+  spawnSubprocess: (opts: TerminalHostSubprocessOptions) => SubprocessHandle
   // Why: on graceful shutdown, the host writes final checkpoints for all live
   // sessions before killing them. This bypasses the RPC round-trip — the daemon
   // writes checkpoints in-process, guaranteeing completion before teardown.
@@ -121,6 +112,7 @@ export class TerminalHost {
       command: opts.command,
       startupCommandDelivery: opts.startupCommandDelivery,
       ...(opts.launchAgent ? { launchAgent: opts.launchAgent } : {}),
+      ...(opts.windowsCodexShellHandoff === true ? { windowsCodexShellHandoff: true } : {}),
       shellOverride: opts.shellOverride,
       terminalWindowsWslDistro: opts.terminalWindowsWslDistro,
       terminalWindowsPowerShellImplementation: opts.terminalWindowsPowerShellImplementation

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -10,16 +10,17 @@ export type {
 } from './daemon-foreground-process-protocol'
 
 // ─── Protocol Version ────────────────────────────────────────────────
-import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery'
 import type { TuiAgent } from '../../shared/types'
+import type { CreateOrAttachRequest } from './daemon-create-or-attach-protocol'
+export type { CreateOrAttachRequest } from './daemon-create-or-attach-protocol'
 // Why: daemons can survive app updates. Bump for IPC wire-shape changes, or
 // when daemon-baked behavior cannot be delivered by on-disk wrapper refresh.
 // Why: bump when adding daemon wire behavior so same-version old daemons do
 // not silently accept the handshake and then reject new RPCs.
-export const PROTOCOL_VERSION = 22
+export const PROTOCOL_VERSION = 23
 export const GIT_CREDENTIAL_GUARD_HOST_PROTOCOL_VERSION = 22
 export const PREVIOUS_DAEMON_PROTOCOL_VERSIONS = [
-  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21
+  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22
 ] as const
 
 // ─── Session State Machine ──────────────────────────────────────────
@@ -95,39 +96,6 @@ export type HelloResponse = {
 }
 
 // ─── RPC Requests (Client → Daemon, on control socket) ─────────────
-
-export type CreateOrAttachRequest = {
-  id: string
-  type: 'createOrAttach'
-  payload: {
-    sessionId: string
-    cols: number
-    rows: number
-    cwd?: string
-    env?: Record<string, string>
-    envToDelete?: string[]
-    command?: string
-    startupCommandDelivery?: StartupCommandDelivery
-    launchAgent?: TuiAgent
-    /** Explicit Windows shell override selected by the user (e.g. 'wsl.exe').
-     *  The daemon forwards this to its subprocess spawner so each tab honors
-     *  the shell picked in the "+" menu or the persisted default-shell setting,
-     *  instead of defaulting to COMSPEC (which is always cmd.exe on Windows)
-     *  or the hard-coded powershell.exe fallback. */
-    shellOverride?: string
-    /** Preferred WSL distro for generic `wsl.exe` launches. */
-    terminalWindowsWslDistro?: string | null
-    /** Why: the UI keeps PowerShell as one shell family, but the runtime may
-     *  need to substitute pwsh.exe for powershell.exe when the user selected
-     *  PowerShell 7+. Forward the persisted implementation choice so the daemon
-     *  PTY path resolves the same effective executable as LocalPtyProvider. */
-    terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
-    shellReadySupported?: boolean
-    shellReadyTimeoutMs?: number
-    /** Recovered ANSI applied before the new subprocess can emit startup output. */
-    historySeed?: string
-  }
-}
 
 export type CancelCreateOrAttachRequest = {
   id: string

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -1407,6 +1407,7 @@ describe('registerPtyHandlers', () => {
             env: Record<string, string>
             sessionId?: string
             isNewSession?: boolean
+            windowsCodexShellHandoff?: boolean
           }) => ({
             id: options.sessionId ?? 'daemon-pty'
           })
@@ -1433,6 +1434,7 @@ describe('registerPtyHandlers', () => {
         shellOverride?: string
         terminalWindowsWslDistro?: string | null
         terminalWindowsPowerShellImplementation?: string
+        windowsCodexShellHandoff?: boolean
       }
 
       async function withWin32Platform<T>(fn: () => Promise<T>): Promise<T> {
@@ -1490,6 +1492,12 @@ describe('registerPtyHandlers', () => {
           shellOverride?: string
           command?: string
           envToDelete?: string[]
+          launchConfig?: {
+            agentCommand?: string
+            agentArgs: string
+            agentEnv: Record<string, string>
+            windowsCodexShellHandoff?: true
+          }
         },
         supportsGitCredentialGuardHost = true
       ): Promise<DaemonSpawnCall> {
@@ -1813,6 +1821,52 @@ describe('registerPtyHandlers', () => {
         )
         expect(spawnOptions.env.ORCA_AGENT_HOOK_PORT).toBe('5678')
         expect(spawnOptions.env.ORCA_AGENT_HOOK_TOKEN).toBe('agent-token')
+      })
+
+      it('forwards the explicit Windows Codex shell handoff marker from runtime-created PTYs', async () => {
+        type RuntimeSpawnController = {
+          spawn(args: {
+            cols: number
+            rows: number
+            worktreeId?: string
+            command?: string
+            windowsCodexShellHandoff?: boolean
+          }): Promise<{ id: string }>
+        }
+        const daemonSpawn = setupDaemonAdapter()
+        const runtime = {
+          setPtyController: vi.fn(),
+          registerPty: vi.fn(),
+          noteTerminalSpawnCommand: vi.fn(),
+          onPtySpawned: vi.fn(),
+          onPtyExit: vi.fn(),
+          onPtyData: vi.fn()
+        }
+        handlers.clear()
+        registerPtyHandlers(mainWindow as never, runtime as never)
+        const controller = runtime.setPtyController.mock.calls[0]?.[0] as RuntimeSpawnController
+
+        await controller.spawn({
+          cols: 80,
+          rows: 24,
+          worktreeId: 'wt-runtime',
+          command: "codex 'fix it'",
+          windowsCodexShellHandoff: true
+        })
+        const markedSpawnOptions = daemonSpawn.mock.calls.at(-1)?.[0] as DaemonSpawnCall | undefined
+        expect(markedSpawnOptions?.windowsCodexShellHandoff).toBe(true)
+
+        await controller.spawn({
+          cols: 80,
+          rows: 24,
+          worktreeId: 'wt-runtime',
+          command: "codex 'fix it'",
+          windowsCodexShellHandoff: false
+        })
+        const unmarkedSpawnOptions = daemonSpawn.mock.calls.at(-1)?.[0] as
+          | DaemonSpawnCall
+          | undefined
+        expect(unmarkedSpawnOptions?.windowsCodexShellHandoff).toBeUndefined()
       })
 
       it('threads the validated pane identity into registerPty for a runtime-created daemon PTY (#7587)', async () => {
@@ -2165,6 +2219,31 @@ describe('registerPtyHandlers', () => {
         expect((sessionId ?? '').length).toBeGreaterThan(0)
         expect(spawnOpts.isNewSession).toBe(true)
         expect(piBuildPtyEnvMock).toHaveBeenCalledWith(sessionId, undefined, 'pi')
+      })
+
+      it('derives Windows Codex handoff provenance from the renderer launch config', async () => {
+        const marked = await daemonSpawnAndGetOptions(undefined, undefined, undefined, undefined, {
+          command: "codex 'fix it'",
+          launchConfig: {
+            agentCommand: 'codex',
+            agentArgs: '',
+            agentEnv: {},
+            windowsCodexShellHandoff: true
+          }
+        })
+        const unmarked = await daemonSpawnAndGetOptions(
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          {
+            command: "codex 'fix it'",
+            launchConfig: { agentCommand: 'codex', agentArgs: '', agentEnv: {} }
+          }
+        )
+
+        expect(marked.windowsCodexShellHandoff).toBe(true)
+        expect(unmarked.windowsCodexShellHandoff).toBeUndefined()
       })
 
       it('respects a caller-provided sessionId instead of minting a new one', async () => {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -3135,6 +3135,9 @@ export function registerPtyHandlers(
       if (isTuiAgent(args.launchAgent)) {
         spawnOptions.launchAgent = args.launchAgent
       }
+      if (args.windowsCodexShellHandoff === true) {
+        spawnOptions.windowsCodexShellHandoff = true
+      }
       if (args.worktreeId !== undefined) {
         spawnOptions.worktreeId = args.worktreeId
       }
@@ -4060,6 +4063,9 @@ export function registerPtyHandlers(
       }
       if (isTuiAgent(args.launchAgent)) {
         spawnOptions.launchAgent = args.launchAgent
+      }
+      if (args.launchConfig?.windowsCodexShellHandoff === true) {
+        spawnOptions.windowsCodexShellHandoff = true
       }
       if (args.worktreeId !== undefined) {
         spawnOptions.worktreeId = args.worktreeId

--- a/src/main/providers/__fixtures__/codex-cli-entrypoint-0.144.5.txt
+++ b/src/main/providers/__fixtures__/codex-cli-entrypoint-0.144.5.txt
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+// Unified entry point for the Codex CLI.
+
+import { spawn } from "node:child_process";
+import { existsSync, realpathSync } from "fs";
+import { createRequire } from "node:module";
+import path from "path";
+import { fileURLToPath } from "url";
+
+// __dirname equivalent in ESM
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const require = createRequire(import.meta.url);
+const codexPackageRoot = realpathSync(path.join(__dirname, ".."));
+
+const PLATFORM_PACKAGE_BY_TARGET = {
+  "x86_64-unknown-linux-musl": "@openai/codex-linux-x64",
+  "aarch64-unknown-linux-musl": "@openai/codex-linux-arm64",
+  "x86_64-apple-darwin": "@openai/codex-darwin-x64",
+  "aarch64-apple-darwin": "@openai/codex-darwin-arm64",
+  "x86_64-pc-windows-msvc": "@openai/codex-win32-x64",
+  "aarch64-pc-windows-msvc": "@openai/codex-win32-arm64",
+};
+
+const { platform, arch } = process;
+
+let targetTriple = null;
+switch (platform) {
+  case "linux":
+  case "android":
+    switch (arch) {
+      case "x64":
+        targetTriple = "x86_64-unknown-linux-musl";
+        break;
+      case "arm64":
+        targetTriple = "aarch64-unknown-linux-musl";
+        break;
+      default:
+        break;
+    }
+    break;
+  case "darwin":
+    switch (arch) {
+      case "x64":
+        targetTriple = "x86_64-apple-darwin";
+        break;
+      case "arm64":
+        targetTriple = "aarch64-apple-darwin";
+        break;
+      default:
+        break;
+    }
+    break;
+  case "win32":
+    switch (arch) {
+      case "x64":
+        targetTriple = "x86_64-pc-windows-msvc";
+        break;
+      case "arm64":
+        targetTriple = "aarch64-pc-windows-msvc";
+        break;
+      default:
+        break;
+    }
+    break;
+  default:
+    break;
+}
+
+if (!targetTriple) {
+  throw new Error(`Unsupported platform: ${platform} (${arch})`);
+}
+
+const platformPackage = PLATFORM_PACKAGE_BY_TARGET[targetTriple];
+if (!platformPackage) {
+  throw new Error(`Unsupported target triple: ${targetTriple}`);
+}
+
+function findCodexExecutable() {
+  let vendorRoot;
+  try {
+    const packageJsonPath = require.resolve(`${platformPackage}/package.json`);
+    vendorRoot = path.join(path.dirname(packageJsonPath), "vendor");
+  } catch {
+    vendorRoot = path.join(__dirname, "..", "vendor");
+  }
+
+  const codexExecutable = path.join(
+    vendorRoot,
+    targetTriple,
+    "bin",
+    process.platform === "win32" ? "codex.exe" : "codex",
+  );
+  if (existsSync(codexExecutable)) {
+    return codexExecutable;
+  }
+
+  const packageManager = detectPackageManager();
+  const updateCommand =
+    packageManager === "bun"
+      ? "bun install -g @openai/codex@latest"
+      : packageManager === "pnpm"
+        ? "pnpm add -g @openai/codex@latest"
+        : "npm install -g @openai/codex@latest";
+  throw new Error(
+    `Missing optional dependency ${platformPackage}. Reinstall Codex: ${updateCommand}`,
+  );
+}
+
+const binaryPath = findCodexExecutable();
+
+// Use an asynchronous spawn instead of spawnSync so that Node is able to
+// respond to signals (e.g. Ctrl-C / SIGINT) while the native binary is
+// executing. This allows us to forward those signals to the child process
+// and guarantees that when either the child terminates or the parent
+// receives a fatal signal, both processes exit in a predictable manner.
+
+function isPnpmOwnedCodexInstall(nodeModulesDir) {
+  if (!existsSync(path.join(nodeModulesDir, ".modules.yaml"))) {
+    return false;
+  }
+
+  try {
+    return (
+      realpathSync(path.join(nodeModulesDir, "@openai", "codex")) ===
+      codexPackageRoot
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Use heuristics to detect the package manager that was used to install Codex
+ * in order to give the user a hint about how to update it.
+ */
+function detectPackageManager() {
+  // pnpm's owning node_modules directory can be several parents above the
+  // package in isolated global layouts. Search ancestors of both the canonical
+  // package root and lexical entrypoint because pnpm may link either path.
+  const entrypointDir = path.dirname(path.resolve(process.argv[1]));
+  for (const startDir of new Set([codexPackageRoot, entrypointDir])) {
+    const filesystemRoot = path.parse(startDir).root;
+    for (
+      let currentDir = startDir;
+      currentDir !== filesystemRoot;
+      currentDir = path.dirname(currentDir)
+    ) {
+      if (isPnpmOwnedCodexInstall(path.join(currentDir, "node_modules"))) {
+        return "pnpm";
+      }
+    }
+
+    if (isPnpmOwnedCodexInstall(path.join(filesystemRoot, "node_modules"))) {
+      return "pnpm";
+    }
+  }
+
+  const userAgent = process.env.npm_config_user_agent || "";
+  if (/\bbun\//.test(userAgent)) {
+    return "bun";
+  }
+
+  const execPath = process.env.npm_execpath || "";
+  if (execPath.includes("bun")) {
+    return "bun";
+  }
+
+  if (
+    __dirname.includes(".bun/install/global") ||
+    __dirname.includes(".bun\\install\\global")
+  ) {
+    return "bun";
+  }
+
+  return userAgent ? "npm" : null;
+}
+
+const packageManager = detectPackageManager();
+const packageManagerEnvVar =
+  packageManager === "bun"
+    ? "CODEX_MANAGED_BY_BUN"
+    : packageManager === "pnpm"
+      ? "CODEX_MANAGED_BY_PNPM"
+      : "CODEX_MANAGED_BY_NPM";
+const env = {
+  ...process.env,
+  CODEX_MANAGED_PACKAGE_ROOT: codexPackageRoot,
+};
+delete env.CODEX_MANAGED_BY_NPM;
+delete env.CODEX_MANAGED_BY_BUN;
+delete env.CODEX_MANAGED_BY_PNPM;
+env[packageManagerEnvVar] = "1";
+
+const child = spawn(binaryPath, process.argv.slice(2), {
+  stdio: "inherit",
+  env,
+});
+
+child.on("error", (err) => {
+  // Typically triggered when the binary is missing or not executable.
+  // Re-throwing here will terminate the parent with a non-zero exit code
+  // while still printing a helpful stack trace.
+  // eslint-disable-next-line no-console
+  console.error(err);
+  process.exit(1);
+});
+
+// Forward common termination signals to the child so that it shuts down
+// gracefully. In the handler we temporarily disable the default behavior of
+// exiting immediately; once the child has been signaled we simply wait for
+// its exit event which will in turn terminate the parent (see below).
+const forwardSignal = (signal) => {
+  if (child.killed) {
+    return;
+  }
+  try {
+    child.kill(signal);
+  } catch {
+    /* ignore */
+  }
+};
+
+["SIGINT", "SIGTERM", "SIGHUP"].forEach((sig) => {
+  process.on(sig, () => forwardSignal(sig));
+});
+
+// When the child exits, mirror its termination reason in the parent so that
+// shell scripts and other tooling observe the correct exit status.
+// Wrap the lifetime of the child process in a Promise so that we can await
+// its termination in a structured way. The Promise resolves with an object
+// describing how the child exited: either via exit code or due to a signal.
+const childResult = await new Promise((resolve) => {
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      resolve({ type: "signal", signal });
+    } else {
+      resolve({ type: "code", exitCode: code ?? 1 });
+    }
+  });
+});
+
+if (childResult.type === "signal") {
+  // Re-emit the same signal so that the parent terminates with the expected
+  // semantics (this also sets the correct exit code of 128 + n).
+  process.kill(process.pid, childResult.signal);
+} else {
+  process.exit(childResult.exitCode);
+}

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -9,6 +9,7 @@ const {
   mkdirSyncMock,
   writeFileSyncMock,
   spawnMock,
+  buildWindowsCodexShellHandoffAttemptMock,
   resolveAgentForegroundProcessMock,
   captureDescendantSnapshotMock,
   terminateDescendantSnapshotMock
@@ -19,6 +20,7 @@ const {
   mkdirSyncMock: vi.fn(),
   writeFileSyncMock: vi.fn(),
   spawnMock: vi.fn(),
+  buildWindowsCodexShellHandoffAttemptMock: vi.fn(),
   resolveAgentForegroundProcessMock: vi.fn(),
   captureDescendantSnapshotMock: vi.fn(),
   terminateDescendantSnapshotMock: vi.fn()
@@ -42,6 +44,10 @@ vi.mock('electron', () => ({
 
 vi.mock('node-pty', () => ({
   spawn: spawnMock
+}))
+
+vi.mock('./windows-codex-shell-handoff', () => ({
+  buildWindowsCodexShellHandoffAttempt: buildWindowsCodexShellHandoffAttemptMock
 }))
 
 vi.mock('../pty-descendant-termination', () => ({
@@ -170,6 +176,8 @@ describe('LocalPtyProvider', () => {
       pid: 12345
     }
     spawnMock.mockReturnValue(mockProc)
+    buildWindowsCodexShellHandoffAttemptMock.mockReset()
+    buildWindowsCodexShellHandoffAttemptMock.mockReturnValue(null)
 
     provider = new LocalPtyProvider()
   })
@@ -714,6 +722,52 @@ describe('LocalPtyProvider', () => {
       expect(spawnCall[0]).toBe(PWSH7_ABS)
       expect(spawnCall[1]).toContain('-EncodedCommand')
       expect(pwshAvailable).not.toHaveBeenCalled()
+    })
+
+    it('spawns the Windows Codex handoff host while preserving the selected shell identity', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      mockProc.process = 'xterm-256color'
+      const nodeHost = 'C:\\Program Files\\nodejs\\node.exe'
+      buildWindowsCodexShellHandoffAttemptMock.mockReturnValue({
+        shellPath: nodeHost,
+        shellArgs: ['-e', 'handoff-script', 'encoded-config'],
+        logicalShellPath: PWSH7_ABS,
+        effectiveCwd: 'C:\\repo',
+        validationCwd: 'C:\\repo',
+        startupCommandDeliveredInShellArgs: true
+      })
+
+      provider.configure({
+        getWindowsShell: () => 'powershell.exe',
+        getWindowsPowerShellImplementation: () => 'pwsh.exe'
+      })
+      const result = await provider.spawn({
+        cols: 80,
+        rows: 24,
+        cwd: 'C:\\repo',
+        command: "codex '--version'",
+        launchAgent: 'codex',
+        windowsCodexShellHandoff: true
+      })
+
+      expect(buildWindowsCodexShellHandoffAttemptMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          launchAgent: 'codex',
+          startupCommand: "codex '--version'",
+          windowsCodexShellHandoff: true
+        })
+      )
+      expect(spawnMock).toHaveBeenCalledWith(
+        nodeHost,
+        ['-e', 'handoff-script', 'encoded-config'],
+        expect.objectContaining({ cwd: 'C:\\repo' })
+      )
+      expect(await provider.getForegroundProcess(result.id)).toBe('pwsh.exe')
+      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledWith(
+        mockProc.pid,
+        'pwsh.exe',
+        expect.any(Object)
+      )
     })
 
     it('marks Orca terminal handle for WSL import when buildSpawnEnv opts in', async () => {

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -10,7 +10,10 @@ import {
   shouldProbeWindowsPowerShellAvailability,
   type WindowsPowerShellShellFamily
 } from './windows-powershell'
-import { buildWindowsPowerShellSpawnAttempts } from './windows-shell-fallback-chain'
+import {
+  buildWindowsPowerShellSpawnAttempts,
+  prependWindowsCodexShellHandoffAttempt
+} from './windows-shell-fallback-chain'
 import { resolveProcessCwd } from './process-cwd'
 import { existsSync } from 'node:fs'
 import * as pty from 'node-pty'
@@ -790,6 +793,27 @@ export class LocalPtyProvider implements IPtyProvider {
       logHistoryInjection(worktreeId, historyResult)
     }
 
+    if (process.platform === 'win32' && windowsFallbackAttempts.length > 0) {
+      windowsFallbackAttempts = prependWindowsCodexShellHandoffAttempt({
+        attempts: windowsFallbackAttempts,
+        cwd,
+        defaultCwd,
+        wslContext: worktreeWslContext ?? preferredWslContext,
+        startupCommand: args.command,
+        launchAgent: args.launchAgent,
+        windowsCodexShellHandoff: args.windowsCodexShellHandoff,
+        env: finalEnv
+      })
+      const primaryAttempt = windowsFallbackAttempts[0]
+      if (primaryAttempt) {
+        shellPath = primaryAttempt.shellPath
+        shellArgs = primaryAttempt.shellArgs
+        effectiveCwd = primaryAttempt.effectiveCwd
+        validationCwd = primaryAttempt.validationCwd
+        startupCommandDeliveredInShellArgs = primaryAttempt.startupCommandDeliveredInShellArgs
+      }
+    }
+
     const spawnResult = spawnShellWithFallback({
       shellPath,
       shellArgs,
@@ -808,7 +832,7 @@ export class LocalPtyProvider implements IPtyProvider {
         : undefined,
       windowsFallbackAttempts
     })
-    shellPath = spawnResult.shellPath
+    shellPath = spawnResult.logicalShellPath ?? spawnResult.shellPath
     // Why: a Windows fallback (e.g. cmd.exe) embeds its own startup command in
     // argv, so honor the winning shell's delivery flag to avoid a double write.
     if (spawnResult.startupCommandDeliveredInShellArgs !== undefined) {

--- a/src/main/providers/local-pty-utils.ts
+++ b/src/main/providers/local-pty-utils.ts
@@ -138,6 +138,7 @@ export function validateWorkingDirectory(cwd: string): void {
 export type WindowsShellSpawnAttempt = {
   shellPath: string
   shellArgs: string[]
+  logicalShellPath?: string
   effectiveCwd: string
   validationCwd: string
   startupCommandDeliveredInShellArgs: boolean
@@ -168,6 +169,7 @@ export type ShellSpawnParams = {
 export type ShellSpawnResult = {
   process: pty.IPty
   shellPath: string
+  logicalShellPath?: string
   /** True when the winning shell's startup command was already embedded in its
    *  argv, so callers must not re-deliver it through stdin. Only set when a
    *  Windows fallback attempt other than the primary was used. */
@@ -213,6 +215,7 @@ function spawnWindowsFallbackChain(
       return {
         process: proc,
         shellPath: attempt.shellPath,
+        ...(attempt.logicalShellPath ? { logicalShellPath: attempt.logicalShellPath } : {}),
         startupCommandDeliveredInShellArgs: attempt.startupCommandDeliveredInShellArgs
       }
     } catch {
@@ -257,7 +260,10 @@ export function spawnShellWithFallback(params: ShellSpawnParams): ShellSpawnResu
           env,
           ...windowsConptyDllOptions()
         }),
-        shellPath
+        shellPath,
+        ...(params.windowsFallbackAttempts?.[0]?.logicalShellPath
+          ? { logicalShellPath: params.windowsFallbackAttempts[0].logicalShellPath }
+          : {})
       }
     } catch (err) {
       primaryError = err instanceof Error ? err.message : String(err)

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -66,6 +66,8 @@ export type PtySpawnOptions = {
   startupCommandDelivery?: StartupCommandDelivery
   /** Minimal allowlisted launch ownership preserved by daemon reattach. */
   launchAgent?: TuiAgent
+  /** Trusted startup-plan provenance for the native Windows Codex handoff. */
+  windowsCodexShellHandoff?: boolean
   /** Orca worktree identity. When present, the local provider scopes shell
    *  history to this worktree so ArrowUp only surfaces local commands. */
   worktreeId?: string

--- a/src/main/providers/windows-codex-generated-command.ts
+++ b/src/main/providers/windows-codex-generated-command.ts
@@ -1,0 +1,54 @@
+function quoteGeneratedPowerShellArg(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`
+}
+
+/** Parse only the byte-for-byte command shape emitted by Orca's PowerShell planner. */
+export function parseGeneratedPowerShellCodexCommand(command: string): string[] | null {
+  if (command === 'codex') {
+    return []
+  }
+  if (!command.startsWith('codex ')) {
+    return null
+  }
+
+  let index = 'codex '.length
+  const args: string[] = []
+  while (index < command.length) {
+    if (command[index] !== "'") {
+      return null
+    }
+    index += 1
+    let value = ''
+    let closed = false
+    while (index < command.length) {
+      const char = command[index]
+      if (char !== "'") {
+        value += char
+        index += 1
+        continue
+      }
+      if (command[index + 1] === "'") {
+        value += "'"
+        index += 2
+        continue
+      }
+      index += 1
+      closed = true
+      break
+    }
+    if (!closed || value.includes('\0')) {
+      return null
+    }
+    args.push(value)
+    if (index === command.length) {
+      break
+    }
+    if (command[index] !== ' ') {
+      return null
+    }
+    index += 1
+  }
+
+  const canonical = ['codex', ...args.map(quoteGeneratedPowerShellArg)].join(' ')
+  return command === canonical ? args : null
+}

--- a/src/main/providers/windows-codex-package-resolution.ts
+++ b/src/main/providers/windows-codex-package-resolution.ts
@@ -1,0 +1,235 @@
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, extname, isAbsolute, join, parse, relative, sep } from 'node:path'
+import {
+  isCanonicalCodexPackageShim,
+  resolvePowerShellExternalCommand
+} from './windows-powershell-command-resolution'
+
+export type ResolvedWindowsCodexTarget = {
+  file: string
+  envToDelete: string[]
+  env: Record<string, string>
+}
+
+type PackageManifest = {
+  name?: unknown
+  bin?: unknown
+  version?: unknown
+  optionalDependencies?: unknown
+}
+
+type ResolvedCodexPackage = {
+  root: string
+  manifest: PackageManifest
+}
+
+const TRUSTED_CODEX_ENTRYPOINT_SHA256 = new Set([
+  '134063e133f0b4244fa3b251acf973d4fe4b4aeeacbdc135211bf480f59f1477'
+])
+
+function readPackageManifest(path: string): PackageManifest | null {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as PackageManifest
+  } catch {
+    return null
+  }
+}
+
+function isFile(path: string): boolean {
+  try {
+    return statSync(path).isFile()
+  } catch {
+    return false
+  }
+}
+
+function isTrustedCodexJavaScript(path: string): boolean {
+  try {
+    const hash = createHash('sha256').update(readFileSync(path)).digest('hex')
+    return TRUSTED_CODEX_ENTRYPOINT_SHA256.has(hash)
+  } catch {
+    return false
+  }
+}
+
+function isExpectedRelativePath(root: string, candidate: string, expected: string): boolean {
+  const candidateRelativePath = relative(root, candidate)
+  return (
+    !isAbsolute(candidateRelativePath) &&
+    candidateRelativePath !== '..' &&
+    !candidateRelativePath.startsWith(`..${sep}`) &&
+    candidateRelativePath.toLowerCase() === expected.toLowerCase()
+  )
+}
+
+function resolveCodexPackage(commandPath: string): ResolvedCodexPackage | null {
+  try {
+    const packageRoot = realpathSync(join(dirname(commandPath), 'node_modules', '@openai', 'codex'))
+    const manifest = readPackageManifest(join(packageRoot, 'package.json'))
+    const bin = manifest?.bin
+    if (
+      manifest?.name !== '@openai/codex' ||
+      !bin ||
+      typeof bin !== 'object' ||
+      Array.isArray(bin) ||
+      (bin as Record<string, unknown>).codex !== 'bin/codex.js'
+    ) {
+      return null
+    }
+    const codexJavaScript = realpathSync(join(packageRoot, 'bin', 'codex.js'))
+    // Why: direct native launch may bypass only an official entrypoint whose
+    // package-manager/env behavior the handoff host deliberately reproduces.
+    return isFile(codexJavaScript) &&
+      isTrustedCodexJavaScript(codexJavaScript) &&
+      isExpectedRelativePath(packageRoot, codexJavaScript, join('bin', 'codex.js'))
+      ? { root: packageRoot, manifest }
+      : null
+  } catch {
+    return null
+  }
+}
+
+function isPnpmOwnedCodexInstall(nodeModulesDir: string, canonicalPackageRoot: string): boolean {
+  if (!existsSync(join(nodeModulesDir, '.modules.yaml'))) {
+    return false
+  }
+  try {
+    return realpathSync(join(nodeModulesDir, '@openai', 'codex')) === canonicalPackageRoot
+  } catch {
+    return false
+  }
+}
+
+function hasPnpmOwnedCodexInstall(packageRoot: string, commandPath: string): boolean {
+  for (const start of new Set([packageRoot, dirname(commandPath)])) {
+    const filesystemRoot = parse(start).root
+    for (let current = start; ; current = dirname(current)) {
+      if (isPnpmOwnedCodexInstall(join(current, 'node_modules'), packageRoot)) {
+        return true
+      }
+      if (current === filesystemRoot) {
+        break
+      }
+    }
+  }
+  return false
+}
+
+function getManagedPackageEnv(
+  packageRoot: string,
+  commandPath: string,
+  env: Record<string, string>
+): Pick<ResolvedWindowsCodexTarget, 'env' | 'envToDelete'> {
+  const managedKeys = ['CODEX_MANAGED_BY_NPM', 'CODEX_MANAGED_BY_PNPM', 'CODEX_MANAGED_BY_BUN']
+  const userAgent = env.npm_config_user_agent ?? ''
+  const npmExecPath = env.npm_execpath ?? ''
+  const isBunInstall =
+    /\.bun[\\/]install[\\/]global/i.test(packageRoot) ||
+    /\.bun[\\/]install[\\/]global/i.test(commandPath)
+  const managedKey =
+    /\bbun\//.test(userAgent) || npmExecPath.toLowerCase().includes('bun') || isBunInstall
+      ? 'CODEX_MANAGED_BY_BUN'
+      : hasPnpmOwnedCodexInstall(packageRoot, commandPath)
+        ? 'CODEX_MANAGED_BY_PNPM'
+        : 'CODEX_MANAGED_BY_NPM'
+  return {
+    envToDelete: managedKeys,
+    env: {
+      CODEX_MANAGED_PACKAGE_ROOT: packageRoot,
+      [managedKey]: '1'
+    }
+  }
+}
+
+function resolveCodexVendorRoot(
+  codexPackage: ResolvedCodexPackage,
+  packageName: string
+): string | null {
+  let packageJsonPath: string
+  try {
+    packageJsonPath = createRequire(join(codexPackage.root, 'package.json')).resolve(
+      `${packageName}/package.json`
+    )
+  } catch {
+    return join(codexPackage.root, 'vendor')
+  }
+  const platformPackageRoot = realpathSync(dirname(packageJsonPath))
+  const manifest = readPackageManifest(join(platformPackageRoot, 'package.json'))
+  const optionalDependencies = codexPackage.manifest.optionalDependencies
+  const aliasedDependency =
+    optionalDependencies &&
+    typeof optionalDependencies === 'object' &&
+    !Array.isArray(optionalDependencies)
+      ? (optionalDependencies as Record<string, unknown>)[packageName]
+      : undefined
+  const isDirectPackage = manifest?.name === packageName
+  const isNpmAlias =
+    manifest?.name === '@openai/codex' &&
+    typeof manifest.version === 'string' &&
+    aliasedDependency === `npm:@openai/codex@${manifest.version}`
+  return isDirectPackage || isNpmAlias ? join(platformPackageRoot, 'vendor') : null
+}
+
+function resolvePackagedCodexExecutable(
+  commandPath: string,
+  arch: string,
+  env: Record<string, string>
+): ResolvedWindowsCodexTarget | null {
+  if (!isCanonicalCodexPackageShim(commandPath)) {
+    return null
+  }
+  const codexPackage = resolveCodexPackage(commandPath)
+  const target =
+    arch === 'x64'
+      ? { packageName: '@openai/codex-win32-x64', triple: 'x86_64-pc-windows-msvc' }
+      : arch === 'arm64'
+        ? { packageName: '@openai/codex-win32-arm64', triple: 'aarch64-pc-windows-msvc' }
+        : null
+  if (!codexPackage || !target) {
+    return null
+  }
+  try {
+    const vendorRoot = resolveCodexVendorRoot(codexPackage, target.packageName)
+    if (!vendorRoot) {
+      return null
+    }
+    const executable = realpathSync(join(vendorRoot, target.triple, 'bin', 'codex.exe'))
+    if (
+      !isFile(executable) ||
+      !isExpectedRelativePath(vendorRoot, executable, join(target.triple, 'bin', 'codex.exe'))
+    ) {
+      return null
+    }
+    return {
+      file: executable,
+      ...getManagedPackageEnv(codexPackage.root, commandPath, env)
+    }
+  } catch {
+    return null
+  }
+}
+
+export function resolveWindowsCodexTarget(args: {
+  env: Record<string, string>
+  arch: string
+  pathEnv: string | null | undefined
+  pathExt: string | null | undefined
+}): ResolvedWindowsCodexTarget | null {
+  const commandPath = resolvePowerShellExternalCommand({
+    command: 'codex',
+    pathEnv: args.pathEnv,
+    pathExt: args.pathExt
+  })
+  if (!commandPath || !isAbsolute(commandPath) || !existsSync(commandPath)) {
+    return null
+  }
+  const extension = extname(commandPath).toLowerCase()
+  if (extension === '.exe') {
+    return { file: commandPath, envToDelete: [], env: {} }
+  }
+  return extension === '.cmd' || extension === '.ps1'
+    ? resolvePackagedCodexExecutable(commandPath, args.arch, args.env)
+    : null
+}

--- a/src/main/providers/windows-codex-shell-handoff-host.ts
+++ b/src/main/providers/windows-codex-shell-handoff-host.ts
@@ -18,22 +18,24 @@ export type WindowsCodexShellHandoffConfig = {
 // Why: this process owns the ConPTY while Codex runs, then starts the selected
 // PowerShell only after Codex exits so the pane still returns to its normal shell.
 export const WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT = String.raw`
-const { spawn } = require('node:child_process')
-const { inflateRawSync } = require('node:zlib')
-const config = JSON.parse(inflateRawSync(Buffer.from(process.argv[1], 'base64url')).toString('utf8'))
+const { spawn } = require('child_process')
+const { inflateRawSync } = require('zlib')
+const config = JSON.parse(inflateRawSync(Buffer.from(process.argv[1], 'base64')).toString('utf8'))
 let activeChild = null
 let phase = 'agent'
 let shuttingDown = false
 
 const run = (attempt, env) => new Promise((resolve) => {
   let settled = false
-  let spawned = false
   const child = spawn(attempt.file, attempt.args, {
     cwd: attempt.cwd,
     env,
     stdio: 'inherit',
     windowsHide: true
   })
+  // Why: child.pid is set synchronously after a successful native spawn, and
+  // unlike the spawn event it is available on the older PATH Node hosts we support.
+  const spawned = typeof child.pid === 'number'
   activeChild = child
   const finish = (code) => {
     if (settled) return
@@ -41,7 +43,6 @@ const run = (attempt, env) => new Promise((resolve) => {
     if (activeChild === child) activeChild = null
     resolve({ spawned, code: typeof code === 'number' ? code : 1 })
   }
-  child.once('spawn', () => { spawned = true })
   child.once('error', (error) => {
     process.stderr.write('[orca] Failed to launch ' + attempt.file + ': ' + error.message + '\n')
     finish(1)
@@ -97,7 +98,7 @@ process.on('SIGHUP', () => forwardSignal('SIGHUP', true))
 export function encodeWindowsCodexShellHandoffConfig(
   config: WindowsCodexShellHandoffConfig
 ): string {
-  return deflateRawSync(Buffer.from(JSON.stringify(config), 'utf8')).toString('base64url')
+  return deflateRawSync(Buffer.from(JSON.stringify(config), 'utf8')).toString('base64')
 }
 
 export function decodeWindowsCodexShellHandoffConfig(attempt: {
@@ -108,6 +109,6 @@ export function decodeWindowsCodexShellHandoffConfig(attempt: {
     throw new Error('Windows Codex shell handoff is missing its encoded configuration.')
   }
   return JSON.parse(
-    inflateRawSync(Buffer.from(encoded, 'base64url')).toString('utf8')
+    inflateRawSync(Buffer.from(encoded, 'base64')).toString('utf8')
   ) as WindowsCodexShellHandoffConfig
 }

--- a/src/main/providers/windows-codex-shell-handoff-host.ts
+++ b/src/main/providers/windows-codex-shell-handoff-host.ts
@@ -1,0 +1,110 @@
+import { deflateRawSync, inflateRawSync } from 'node:zlib'
+
+export type WindowsCodexShellChildAttempt = {
+  file: string
+  args: string[]
+  cwd: string
+}
+
+export type WindowsCodexShellHandoffConfig = {
+  agentFile: string
+  agentArgs: string[]
+  agentEnvToDelete: string[]
+  agentEnv: Record<string, string>
+  shellAttempts: WindowsCodexShellChildAttempt[]
+  agentFallbackAttempts: WindowsCodexShellChildAttempt[]
+}
+
+// Why: this process owns the ConPTY while Codex runs, then starts the selected
+// PowerShell only after Codex exits so the pane still returns to its normal shell.
+export const WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT = String.raw`
+const { spawn } = require('node:child_process')
+const { inflateRawSync } = require('node:zlib')
+const config = JSON.parse(inflateRawSync(Buffer.from(process.argv[1], 'base64url')).toString('utf8'))
+let activeChild = null
+let phase = 'agent'
+let shuttingDown = false
+
+const run = (attempt, env) => new Promise((resolve) => {
+  let settled = false
+  let spawned = false
+  const child = spawn(attempt.file, attempt.args, {
+    cwd: attempt.cwd,
+    env,
+    stdio: 'inherit',
+    windowsHide: true
+  })
+  activeChild = child
+  const finish = (code) => {
+    if (settled) return
+    settled = true
+    if (activeChild === child) activeChild = null
+    resolve({ spawned, code: typeof code === 'number' ? code : 1 })
+  }
+  child.once('spawn', () => { spawned = true })
+  child.once('error', (error) => {
+    process.stderr.write('[orca] Failed to launch ' + attempt.file + ': ' + error.message + '\n')
+    finish(1)
+  })
+  child.once('exit', (code) => finish(code))
+})
+
+const runFirstAvailable = async (attempts, env) => {
+  for (const attempt of attempts) {
+    const result = await run(attempt, env)
+    if (result.spawned) return result.code
+  }
+  return 1
+}
+
+const forwardSignal = (signal, terminateHost) => {
+  if (terminateHost) shuttingDown = true
+  if (!activeChild || activeChild.killed) return
+  try { activeChild.kill(signal) } catch {}
+}
+
+// Normal Ctrl+C is PTY input delivered by ConPTY. Only forward an explicit
+// process-level SIGINT while Codex owns the pane; killing the later shell would
+// close a terminal whose agent already exited.
+process.on('SIGINT', () => {
+  if (phase === 'agent') forwardSignal('SIGINT', false)
+})
+process.on('SIGTERM', () => forwardSignal('SIGTERM', true))
+process.on('SIGHUP', () => forwardSignal('SIGHUP', true))
+
+;(async () => {
+  const agentEnv = { ...process.env }
+  for (const key of config.agentEnvToDelete) delete agentEnv[key]
+  Object.assign(agentEnv, config.agentEnv)
+  const agentResult = await run(
+    { file: config.agentFile, args: config.agentArgs, cwd: process.cwd() },
+    agentEnv
+  )
+  if (shuttingDown) return
+  phase = 'shell'
+  process.exitCode = agentResult.spawned
+    ? await runFirstAvailable(config.shellAttempts, process.env)
+    : await runFirstAvailable(config.agentFallbackAttempts, process.env)
+})().catch((error) => {
+  process.stderr.write('[orca] Windows Codex handoff failed: ' + error.message + '\n')
+  process.exitCode = 1
+})
+`
+
+export function encodeWindowsCodexShellHandoffConfig(
+  config: WindowsCodexShellHandoffConfig
+): string {
+  return deflateRawSync(Buffer.from(JSON.stringify(config), 'utf8')).toString('base64url')
+}
+
+export function decodeWindowsCodexShellHandoffConfig(attempt: {
+  shellArgs: string[]
+}): WindowsCodexShellHandoffConfig {
+  const encoded = attempt.shellArgs[2]
+  if (!encoded) {
+    throw new Error('Windows Codex shell handoff is missing its encoded configuration.')
+  }
+  return JSON.parse(
+    inflateRawSync(Buffer.from(encoded, 'base64url')).toString('utf8')
+  ) as WindowsCodexShellHandoffConfig
+}

--- a/src/main/providers/windows-codex-shell-handoff-host.ts
+++ b/src/main/providers/windows-codex-shell-handoff-host.ts
@@ -51,8 +51,11 @@ const run = (attempt, env) => new Promise((resolve) => {
 
 const runFirstAvailable = async (attempts, env) => {
   for (const attempt of attempts) {
+    // Why: teardown must never create a replacement child after the active
+    // attempt exits or fails in response to SIGTERM/SIGHUP.
+    if (shuttingDown) return 1
     const result = await run(attempt, env)
-    if (result.spawned) return result.code
+    if (result.spawned || shuttingDown) return result.code
   }
   return 1
 }

--- a/src/main/providers/windows-codex-shell-handoff.conpty.test.ts
+++ b/src/main/providers/windows-codex-shell-handoff.conpty.test.ts
@@ -296,6 +296,16 @@ describeWindows('Windows Codex shell handoff ConPTY integration', () => {
             'Failed to tear down handoff ConPTY'
           ).catch(() => undefined)
         }
+        for (const pid of [...trackedPids].toReversed()) {
+          if (!isPidAlive(pid)) {
+            continue
+          }
+          try {
+            process.kill(pid)
+          } catch {
+            // Best-effort cleanup after a failed assertion or teardown.
+          }
+        }
       }
     }
   )
@@ -405,13 +415,14 @@ describeWindows('Windows Codex shell handoff ConPTY integration', () => {
           'Failed to tear down active-agent handoff ConPTY'
         ).catch(() => undefined)
       }
-      if (!exited) {
-        for (const pid of [...trackedPids].toReversed()) {
-          try {
-            process.kill(pid)
-          } catch {
-            // Best-effort cleanup only after the ConPTY close path failed.
-          }
+      for (const pid of [...trackedPids].toReversed()) {
+        if (!isPidAlive(pid)) {
+          continue
+        }
+        try {
+          process.kill(pid)
+        } catch {
+          // Best-effort cleanup after a failed assertion or teardown.
         }
       }
     }

--- a/src/main/providers/windows-codex-shell-handoff.conpty.test.ts
+++ b/src/main/providers/windows-codex-shell-handoff.conpty.test.ts
@@ -1,0 +1,419 @@
+import { basename } from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
+import * as pty from 'node-pty'
+import { describe, expect, it } from 'vitest'
+import {
+  queryWindowsProcessDescendants,
+  type WindowsProcessCandidate
+} from './windows-foreground-process-rows'
+import {
+  encodeWindowsCodexShellHandoffConfig,
+  WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT,
+  type WindowsCodexShellHandoffConfig
+} from './windows-codex-shell-handoff'
+import { resolveWindowsPowerShellSpawnChain } from './windows-powershell-executable'
+import { resolveWindowsShellLaunchArgs } from './windows-shell-args'
+
+const describeWindows = process.platform === 'win32' ? describe : describe.skip
+const PHASE_TIMEOUT_MS = 12_000
+const EXIT_TIMEOUT_MS = 8_000
+
+const SURROGATE_AGENT_SCRIPT = String.raw`
+process.stdin.setEncoding('utf8')
+if (process.stdin.isTTY && typeof process.stdin.setRawMode === 'function') {
+  process.stdin.setRawMode(true)
+}
+process.stdin.resume()
+
+let pending = ''
+let reportedCtrlC = false
+const reportCtrlC = () => {
+  if (reportedCtrlC) return
+  reportedCtrlC = true
+  process.stdout.write('AGENT_CTRL_C\r\n')
+}
+
+process.on('SIGINT', reportCtrlC)
+
+const handleLine = (line) => {
+  if (line === 'size') {
+    process.stdout.write('AGENT_SIZE:' + process.stdout.columns + 'x' + process.stdout.rows + '\r\n')
+    return
+  }
+  if (line === 'agent-exit') {
+    process.stdout.write('\x1b[?1049lAGENT_EXITING\r\n', () => process.exit(0))
+    return
+  }
+  process.stdout.write('AGENT_ECHO:' + line + '\r\n')
+}
+
+process.stdin.on('data', (chunk) => {
+  for (const char of chunk) {
+    if (char === '\x03') {
+      reportCtrlC()
+    } else if (char === '\r' || char === '\n') {
+      if (pending) {
+        const line = pending
+        pending = ''
+        handleLine(line)
+      }
+    } else {
+      pending += char
+    }
+  }
+})
+
+process.stdout.write('\x1b[?1049hAGENT_READY\r\n')
+`
+
+const TEARDOWN_SURROGATE_AGENT_SCRIPT = String.raw`
+const { spawn } = require('node:child_process')
+const token = process.argv[1]
+const grandchild = spawn(
+  process.execPath,
+  ['-e', "process.stdout.write('GRANDCHILD_READY\\r\\n'); setInterval(() => {}, 1000)", token],
+  { stdio: 'inherit', windowsHide: true }
+)
+
+grandchild.once('spawn', () => {
+  process.stdout.write('TEARDOWN_AGENT_READY:' + process.pid + ':' + grandchild.pid + '\r\n')
+})
+grandchild.once('error', (error) => {
+  process.stderr.write('GRANDCHILD_ERROR:' + error.message + '\r\n')
+  process.exit(2)
+})
+setInterval(() => {}, 1000)
+`
+
+function stringEnv(): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(process.env).filter((entry): entry is [string, string] => Boolean(entry[1]))
+  )
+}
+
+function outputTail(output: string): string {
+  return output.slice(-4_000)
+}
+
+async function waitForOutput(readOutput: () => string, marker: string): Promise<void> {
+  const deadline = Date.now() + PHASE_TIMEOUT_MS
+  while (!readOutput().includes(marker)) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for ${marker}. PTY output:\n${outputTail(readOutput())}`)
+    }
+    await delay(25)
+  }
+}
+
+async function waitForProcessTree(
+  rootPid: number,
+  description: string,
+  predicate: (rows: WindowsProcessCandidate[]) => boolean
+): Promise<WindowsProcessCandidate[]> {
+  const deadline = Date.now() + PHASE_TIMEOUT_MS
+  let lastRows: WindowsProcessCandidate[] | null = null
+  while (Date.now() < deadline) {
+    lastRows = await queryWindowsProcessDescendants(rootPid, { fresh: true })
+    if (lastRows && predicate(lastRows)) {
+      return lastRows
+    }
+    await delay(50)
+  }
+  throw new Error(`Timed out waiting for ${description}: ${JSON.stringify(lastRows)}`)
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH'
+  }
+}
+
+async function waitForPidsToExit(pids: ReadonlySet<number>): Promise<void> {
+  const deadline = Date.now() + EXIT_TIMEOUT_MS
+  let alive = [...pids].filter(isPidAlive)
+  while (alive.length > 0 && Date.now() < deadline) {
+    await delay(25)
+    alive = [...pids].filter(isPidAlive)
+  }
+  expect(alive, `Handoff process tree left live PIDs: ${alive.join(', ')}`).toEqual([])
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(() => reject(new Error(message)), timeoutMs)
+  })
+  return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timeout))
+}
+
+describeWindows('Windows Codex shell handoff ConPTY integration', () => {
+  it(
+    'owns one real ConPTY across the native-agent and restored-PowerShell phases',
+    { timeout: 45_000 },
+    async () => {
+      const cwd = process.cwd()
+      const shellPath = resolveWindowsPowerShellSpawnChain('pwsh.exe').find((candidate) =>
+        ['pwsh.exe', 'powershell.exe'].includes(basename(candidate).toLowerCase())
+      )
+      expect(shellPath, 'Windows must provide a real PowerShell executable').toBeTruthy()
+      if (!shellPath) {
+        return
+      }
+
+      const shellLaunch = resolveWindowsShellLaunchArgs(shellPath, cwd, cwd)
+      const token = `ORCA_HANDOFF_CONPTY_${process.pid}_${Date.now()}`
+      const config: WindowsCodexShellHandoffConfig = {
+        agentFile: process.execPath,
+        agentArgs: ['-e', SURROGATE_AGENT_SCRIPT, token],
+        agentEnvToDelete: [],
+        agentEnv: { ORCA_HANDOFF_CONPTY_TEST: token },
+        shellAttempts: [
+          { file: shellPath, args: shellLaunch.shellArgs, cwd: shellLaunch.effectiveCwd }
+        ],
+        agentFallbackAttempts: [
+          { file: shellPath, args: shellLaunch.shellArgs, cwd: shellLaunch.effectiveCwd }
+        ]
+      }
+      const proc = pty.spawn(
+        process.execPath,
+        [
+          '-e',
+          WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT,
+          encodeWindowsCodexShellHandoffConfig(config)
+        ],
+        {
+          name: 'xterm-256color',
+          cols: 80,
+          rows: 24,
+          cwd,
+          env: { ...stringEnv(), TERM: 'xterm-256color' }
+        }
+      )
+
+      let output = ''
+      let exited = false
+      proc.onData((data) => {
+        output += data
+      })
+      const exitPromise = new Promise<{ exitCode: number; signal?: number }>((resolve) => {
+        proc.onExit((event) => {
+          exited = true
+          resolve(event)
+        })
+      })
+      const trackedPids = new Set<number>([proc.pid])
+
+      try {
+        await waitForOutput(() => output, 'AGENT_READY')
+        const agentTree = await waitForProcessTree(proc.pid, 'surrogate agent process', (rows) =>
+          rows.some((row) => row.command.includes(token))
+        )
+        for (const row of agentTree) {
+          trackedPids.add(row.pid)
+        }
+        expect(
+          agentTree.some((row) => ['pwsh.exe', 'powershell.exe'].includes(row.name.toLowerCase()))
+        ).toBe(false)
+        const agentProcess = agentTree.find((row) => row.command.includes(token))
+        expect(agentProcess).toBeTruthy()
+
+        proc.resize(111, 37)
+        await delay(100)
+        proc.write('size\r')
+        await waitForOutput(() => output, 'AGENT_SIZE:111x37')
+        proc.write('unicode-\u03a9\u96ea\r')
+        await waitForOutput(() => output, 'AGENT_ECHO:unicode-\u03a9\u96ea')
+        proc.write('\x03')
+        await waitForOutput(() => output, 'AGENT_CTRL_C')
+
+        proc.write('agent-exit\r')
+        await waitForOutput(() => output, 'AGENT_EXITING')
+        const shellName = basename(shellPath).toLowerCase()
+        const shellTree = await waitForProcessTree(
+          proc.pid,
+          'restored PowerShell process',
+          (rows) => rows.some((row) => row.name.toLowerCase() === shellName)
+        )
+        for (const row of shellTree) {
+          trackedPids.add(row.pid)
+        }
+        expect(shellTree.some((row) => row.pid === agentProcess?.pid)).toBe(false)
+        expect(shellTree.some((row) => row.name.toLowerCase() === shellName)).toBe(true)
+
+        proc.write("Write-Output ('SHELL_' + 'READY')\r")
+        await waitForOutput(() => output, 'SHELL_READY')
+        proc.write("Write-Output ('SHELL_UNICODE:' + [char]0x03A9 + [char]0x96EA)\r")
+        await waitForOutput(() => output, 'SHELL_UNICODE:\u03a9\u96ea')
+        proc.write(
+          "$size = $Host.UI.RawUI.WindowSize; Write-Output (('SHELL_' + 'SIZE:') + $size.Width + 'x' + $size.Height)\r"
+        )
+        await waitForOutput(() => output, 'SHELL_SIZE:111x37')
+
+        proc.write(
+          "Write-Output ('SHELL_SLEEP_' + 'START'); Start-Sleep -Seconds 60; Write-Output ('SHELL_SLEEP_' + 'END')\r"
+        )
+        await waitForOutput(() => output, 'SHELL_SLEEP_START')
+        proc.write('\x03')
+        await delay(200)
+        proc.write("Write-Output ('SHELL_CTRL_C_' + 'RECOVERED')\r")
+        await waitForOutput(() => output, 'SHELL_CTRL_C_RECOVERED')
+        expect(output).not.toContain('SHELL_SLEEP_END')
+
+        // Why: ConPTY may inject cursor-visibility frames while applying a
+        // screen-buffer switch, so assert semantic ordering rather than byte adjacency.
+        const altEnter = output.indexOf('\x1b[?1049h')
+        const agentReady = output.indexOf('AGENT_READY')
+        const altLeave = output.indexOf('\x1b[?1049l')
+        const agentExiting = output.indexOf('AGENT_EXITING')
+        const shellReady = output.indexOf('SHELL_READY')
+        expect(altEnter, outputTail(output)).toBeGreaterThanOrEqual(0)
+        expect(agentReady, outputTail(output)).toBeGreaterThan(altEnter)
+        expect(altLeave, outputTail(output)).toBeGreaterThan(agentReady)
+        expect(agentExiting, outputTail(output)).toBeGreaterThan(altLeave)
+        expect(shellReady, outputTail(output)).toBeGreaterThan(agentExiting)
+
+        proc.write('exit\r')
+        const exit = await withTimeout(
+          exitPromise,
+          EXIT_TIMEOUT_MS,
+          `Handoff PTY did not exit. Output:\n${outputTail(output)}`
+        )
+        expect(exit.exitCode).toBe(0)
+        await waitForPidsToExit(trackedPids)
+      } finally {
+        if (!exited) {
+          try {
+            proc.kill()
+          } catch {
+            // The PTY may have exited between the state check and cleanup.
+          }
+          await withTimeout(
+            exitPromise,
+            EXIT_TIMEOUT_MS,
+            'Failed to tear down handoff ConPTY'
+          ).catch(() => undefined)
+        }
+      }
+    }
+  )
+
+  it('reaps the active agent process tree when the pane closes', { timeout: 30_000 }, async () => {
+    const cwd = process.cwd()
+    const shellPath = resolveWindowsPowerShellSpawnChain('pwsh.exe').find((candidate) =>
+      ['pwsh.exe', 'powershell.exe'].includes(basename(candidate).toLowerCase())
+    )
+    expect(shellPath, 'Windows must provide a real PowerShell executable').toBeTruthy()
+    if (!shellPath) {
+      return
+    }
+
+    const shellLaunch = resolveWindowsShellLaunchArgs(shellPath, cwd, cwd)
+    const token = `ORCA_HANDOFF_TEARDOWN_${process.pid}_${Date.now()}`
+    const config: WindowsCodexShellHandoffConfig = {
+      agentFile: process.execPath,
+      agentArgs: ['-e', TEARDOWN_SURROGATE_AGENT_SCRIPT, token],
+      agentEnvToDelete: [],
+      agentEnv: { ORCA_HANDOFF_CONPTY_TEST: token },
+      shellAttempts: [
+        { file: shellPath, args: shellLaunch.shellArgs, cwd: shellLaunch.effectiveCwd }
+      ],
+      agentFallbackAttempts: [
+        { file: shellPath, args: shellLaunch.shellArgs, cwd: shellLaunch.effectiveCwd }
+      ]
+    }
+    const proc = pty.spawn(
+      process.execPath,
+      ['-e', WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT, encodeWindowsCodexShellHandoffConfig(config)],
+      {
+        name: 'xterm-256color',
+        cols: 80,
+        rows: 24,
+        cwd,
+        env: { ...stringEnv(), TERM: 'xterm-256color' }
+      }
+    )
+
+    let output = ''
+    let exited = false
+    let killIssued = false
+    proc.onData((data) => {
+      output += data
+    })
+    const exitPromise = new Promise<{ exitCode: number; signal?: number }>((resolve) => {
+      proc.onExit((event) => {
+        exited = true
+        resolve(event)
+      })
+    })
+    const trackedPids = new Set<number>([proc.pid])
+
+    try {
+      await waitForOutput(() => output, 'TEARDOWN_AGENT_READY:')
+      await waitForOutput(() => output, 'GRANDCHILD_READY')
+      const marker = /TEARDOWN_AGENT_READY:(\d+):(\d+)/.exec(output)
+      expect(marker, outputTail(output)).toBeTruthy()
+      const agentPid = Number(marker?.[1])
+      const grandchildPid = Number(marker?.[2])
+      expect(Number.isSafeInteger(agentPid)).toBe(true)
+      expect(Number.isSafeInteger(grandchildPid)).toBe(true)
+
+      const agentTree = await waitForProcessTree(
+        proc.pid,
+        'active agent and grandchild',
+        (rows) =>
+          rows.some((row) => row.pid === agentPid) && rows.some((row) => row.pid === grandchildPid)
+      )
+      for (const row of agentTree) {
+        trackedPids.add(row.pid)
+      }
+      expect(agentTree.some((row) => row.pid === agentPid && row.command.includes(token))).toBe(
+        true
+      )
+      expect(
+        agentTree.some((row) => row.pid === grandchildPid && row.command.includes(token))
+      ).toBe(true)
+      expect(
+        agentTree.some((row) => ['pwsh.exe', 'powershell.exe'].includes(row.name.toLowerCase()))
+      ).toBe(false)
+
+      // Why: pane close uses node-pty's ConPTY kill, which must reap the
+      // handoff host and every process sharing the active agent's console.
+      proc.kill()
+      killIssued = true
+      await withTimeout(
+        exitPromise,
+        EXIT_TIMEOUT_MS,
+        `Active-agent handoff PTY did not exit. Output:\n${outputTail(output)}`
+      )
+      await waitForPidsToExit(trackedPids)
+    } finally {
+      if (!exited && !killIssued) {
+        try {
+          proc.kill()
+          killIssued = true
+        } catch {
+          // The PTY may have exited between the state check and cleanup.
+        }
+      }
+      if (!exited) {
+        await withTimeout(
+          exitPromise,
+          EXIT_TIMEOUT_MS,
+          'Failed to tear down active-agent handoff ConPTY'
+        ).catch(() => undefined)
+      }
+      if (!exited) {
+        for (const pid of [...trackedPids].toReversed()) {
+          try {
+            process.kill(pid)
+          } catch {
+            // Best-effort cleanup only after the ConPTY close path failed.
+          }
+        }
+      }
+    }
+  })
+})

--- a/src/main/providers/windows-codex-shell-handoff.test.ts
+++ b/src/main/providers/windows-codex-shell-handoff.test.ts
@@ -489,6 +489,68 @@ describe('buildWindowsCodexShellHandoffAttempt', () => {
 })
 
 describe('WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT', () => {
+  it('keeps the inline host compatible with legacy PATH Node runtimes', () => {
+    expect(WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT).not.toContain("require('node:")
+    expect(WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT).not.toContain("'base64url'")
+    expect(WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT).not.toContain(".once('spawn'")
+  })
+
+  it('recognizes a successful child from its pid without a spawn event', () => {
+    const config: WindowsCodexShellHandoffConfig = {
+      agentFile: 'virtual-codex.exe',
+      agentArgs: [],
+      agentEnvToDelete: [],
+      agentEnv: {},
+      shellAttempts: [
+        {
+          file: process.execPath,
+          args: ['-e', "process.stdout.write('shell\\n')"],
+          cwd: process.cwd()
+        }
+      ],
+      agentFallbackAttempts: [
+        {
+          file: process.execPath,
+          args: ['-e', "process.stdout.write('wrong-fallback\\n')"],
+          cwd: process.cwd()
+        }
+      ]
+    }
+    const encoded = encodeWindowsCodexShellHandoffConfig(config)
+    const wrapper = `
+const { EventEmitter } = require('events')
+const childProcess = require('child_process')
+const actualSpawn = childProcess.spawn
+let spawnCount = 0
+
+childProcess.spawn = (...args) => {
+  spawnCount += 1
+  if (spawnCount > 1) return actualSpawn(...args)
+  const child = new EventEmitter()
+  child.pid = 1234
+  child.killed = false
+  child.kill = () => {
+    child.killed = true
+    return true
+  }
+  process.nextTick(() => child.emit('exit', 0))
+  return child
+}
+
+eval(${JSON.stringify(WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT)})
+`
+
+    const result = spawnSync(process.execPath, ['-e', wrapper, encoded], {
+      encoding: 'utf8',
+      timeout: 5_000
+    })
+
+    expect(result.error).toBeUndefined()
+    expect(result.status).toBe(0)
+    expect(result.stderr).toBe('')
+    expect(result.stdout).toBe('shell\n')
+  })
+
   it('runs the agent before the shell without leaking agent-only env', () => {
     const config: WindowsCodexShellHandoffConfig = {
       agentFile: process.execPath,

--- a/src/main/providers/windows-codex-shell-handoff.test.ts
+++ b/src/main/providers/windows-codex-shell-handoff.test.ts
@@ -1,0 +1,659 @@
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { delimiter, dirname, join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  buildWindowsCodexShellHandoffAttempt,
+  decodeWindowsCodexShellHandoffConfig,
+  encodeWindowsCodexShellHandoffConfig,
+  WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT,
+  type WindowsCodexShellHandoffConfig
+} from './windows-codex-shell-handoff'
+import { isCanonicalCodexPackageShim } from './windows-powershell-command-resolution'
+import { resolveWindowsShellLaunchArgs } from './windows-shell-args'
+
+const POWER_SHELL = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe'
+const CWD = 'C:\\repo'
+const DEFAULT_CWD = 'C:\\Users\\dev'
+const DEFAULT_PATH_EXT = '.COM;.EXE;.BAT;.CMD'
+const TRUSTED_CODEX_ENTRYPOINT = readFileSync(
+  new URL('./__fixtures__/codex-cli-entrypoint-0.144.5.txt', import.meta.url),
+  'utf8'
+).replace(/\r\n?/g, '\n')
+
+const CANONICAL_NPM_CMD_SHIM = String.raw`@ECHO off
+GOTO start
+:find_dp0
+SET dp0=%~dp0
+EXIT /b
+:start
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\node_modules\@openai\codex\bin\codex.js" %*
+`
+
+const CANONICAL_NPM_POWERSHELL_SHIM = String.raw`#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  # Support pipeline input
+  if ($MyInvocation.ExpectingInput) {
+    $input | & "$basedir/node$exe"  "$basedir/node_modules/@openai/codex/bin/codex.js" $args
+  } else {
+    & "$basedir/node$exe"  "$basedir/node_modules/@openai/codex/bin/codex.js" $args
+  }
+  $ret=$LASTEXITCODE
+} else {
+  # Support pipeline input
+  if ($MyInvocation.ExpectingInput) {
+    $input | & "node$exe"  "$basedir/node_modules/@openai/codex/bin/codex.js" $args
+  } else {
+    & "node$exe"  "$basedir/node_modules/@openai/codex/bin/codex.js" $args
+  }
+  $ret=$LASTEXITCODE
+}
+exit $ret
+`
+
+const tempRoots: string[] = []
+
+function makeTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca-windows-codex-handoff-'))
+  tempRoots.push(root)
+  return root
+}
+
+function makeFile(path: string, contents = ''): string {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, contents)
+  return path
+}
+
+function makeBasePaths(root: string): {
+  nodePath: string
+  npmBin: string
+  pathEnv: string
+} {
+  const nodePath = makeFile(join(root, 'node-bin', 'node.exe'))
+  const npmBin = join(root, 'npm-bin')
+  mkdirSync(npmBin, { recursive: true })
+  return { nodePath, npmBin, pathEnv: [npmBin, dirname(nodePath)].join(delimiter) }
+}
+
+function makePackagedCodex(
+  npmBin: string,
+  shim: 'cmd' | 'ps1' = 'cmd'
+): {
+  nativeCodex: string
+  packageRoot: string
+} {
+  makeFile(
+    join(npmBin, `codex.${shim}`),
+    shim === 'cmd' ? CANONICAL_NPM_CMD_SHIM : CANONICAL_NPM_POWERSHELL_SHIM
+  )
+  const packageRoot = join(npmBin, 'node_modules', '@openai', 'codex')
+  makeFile(
+    join(packageRoot, 'package.json'),
+    JSON.stringify({
+      name: '@openai/codex',
+      version: '0.0.0-test',
+      bin: { codex: 'bin/codex.js' },
+      optionalDependencies: {
+        '@openai/codex-win32-x64': 'npm:@openai/codex@0.0.0-test-win32-x64'
+      }
+    })
+  )
+  makeFile(join(packageRoot, 'bin', 'codex.js'), TRUSTED_CODEX_ENTRYPOINT)
+  const platformPackageRoot = join(packageRoot, 'node_modules', '@openai', 'codex-win32-x64')
+  makeFile(
+    join(platformPackageRoot, 'package.json'),
+    JSON.stringify({ name: '@openai/codex', version: '0.0.0-test-win32-x64' })
+  )
+  return {
+    packageRoot,
+    nativeCodex: makeFile(
+      join(platformPackageRoot, 'vendor', 'x86_64-pc-windows-msvc', 'bin', 'codex.exe')
+    )
+  }
+}
+
+function buildAttempt(args: {
+  root: string
+  command: string
+  launchAgent?: string
+  pathEnv: string
+  arch?: string
+  eligible?: boolean
+  env?: Record<string, string>
+}) {
+  const powerShellLaunch = resolveWindowsShellLaunchArgs(
+    POWER_SHELL,
+    CWD,
+    DEFAULT_CWD,
+    undefined,
+    args.command
+  )
+  return buildWindowsCodexShellHandoffAttempt({
+    fallbackAttempts: [
+      {
+        shellPath: POWER_SHELL,
+        shellArgs: powerShellLaunch.shellArgs,
+        effectiveCwd: powerShellLaunch.effectiveCwd,
+        validationCwd: powerShellLaunch.validationCwd,
+        startupCommandDeliveredInShellArgs:
+          powerShellLaunch.startupCommandDeliveredInShellArgs === true
+      }
+    ],
+    cwd: CWD,
+    defaultCwd: DEFAULT_CWD,
+    startupCommand: args.command,
+    launchAgent: args.launchAgent ?? 'codex',
+    windowsCodexShellHandoff: args.eligible ?? true,
+    env: { PATH: args.pathEnv, PATHEXT: DEFAULT_PATH_EXT, ...args.env },
+    resolveOptions: {
+      platform: 'win32',
+      arch: args.arch ?? 'x64',
+      pathEnv: args.pathEnv
+    }
+  })
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('isCanonicalCodexPackageShim', () => {
+  it('accepts only newline-normalized copies of the known npm templates', () => {
+    const root = makeTempRoot()
+    const cmdPath = makeFile(
+      join(root, 'codex.cmd'),
+      `\uFEFF${CANONICAL_NPM_CMD_SHIM.replace(/\n/g, '\r\n')}`
+    )
+    const powerShellPath = makeFile(join(root, 'codex.ps1'), CANONICAL_NPM_POWERSHELL_SHIM)
+
+    expect(isCanonicalCodexPackageShim(cmdPath)).toBe(true)
+    expect(isCanonicalCodexPackageShim(powerShellPath)).toBe(true)
+  })
+
+  it.each([
+    ['cmd comment', 'codex.cmd', `REM company policy\n${CANONICAL_NPM_CMD_SHIM}`],
+    ['cmd executable hash line', 'codex.cmd', `${CANONICAL_NPM_CMD_SHIM}# & wrapper.exe\n`],
+    ['cmd alternate target', 'codex.cmd', CANONICAL_NPM_CMD_SHIM.replace('codex.js', 'wrapper.js')],
+    ['PowerShell comment', 'codex.ps1', `${CANONICAL_NPM_POWERSHELL_SHIM}# company policy\n`],
+    [
+      'PowerShell dead code',
+      'codex.ps1',
+      `${CANONICAL_NPM_POWERSHELL_SHIM}if ($false) { & 'wrapper.exe' }\n`
+    ]
+  ])('rejects a canonical-looking shim with $name', (_name, fileName, contents) => {
+    const commandPath = makeFile(join(makeTempRoot(), fileName), contents)
+
+    expect(isCanonicalCodexPackageShim(commandPath)).toBe(false)
+  })
+})
+
+describe('buildWindowsCodexShellHandoffAttempt', () => {
+  it('carries generated Codex argv losslessly and defers the selected PowerShell', () => {
+    const root = makeTempRoot()
+    const { nodePath, npmBin, pathEnv } = makeBasePaths(root)
+    const codexPath = makeFile(join(npmBin, 'codex.exe'))
+    const command =
+      "codex '--flag' 'line one\nline two with %PATH%, !, `code`, Ω, and it''s quoted'"
+
+    const attempt = buildAttempt({ root, command, pathEnv })
+
+    expect(attempt).not.toBeNull()
+    expect(attempt?.shellPath).toBe(nodePath)
+    expect(attempt?.logicalShellPath).toBe(POWER_SHELL)
+    expect(attempt?.startupCommandDeliveredInShellArgs).toBe(true)
+    const config = decodeWindowsCodexShellHandoffConfig(attempt!)
+    expect(config.agentFile.toLowerCase()).toBe(codexPath.toLowerCase())
+    expect(config.agentArgs).toEqual([
+      '--flag',
+      "line one\nline two with %PATH%, !, `code`, Ω, and it's quoted"
+    ])
+    expect(config.shellAttempts).toHaveLength(1)
+    expect(config.shellAttempts[0]).toMatchObject({ file: POWER_SHELL, cwd: CWD })
+    expect(config.shellAttempts[0].args).toContain('-NoExit')
+    expect(config.shellAttempts[0].args).toContain('-EncodedCommand')
+    expect(config.agentFallbackAttempts[0]).toMatchObject({ file: POWER_SHELL, cwd: CWD })
+    expect(config.agentFallbackAttempts[0].args).toContain('-EncodedCommand')
+  })
+
+  it('resolves an npm shim to its matching packaged native binary and managed env', () => {
+    const root = makeTempRoot()
+    const { npmBin, pathEnv } = makeBasePaths(root)
+    const { nativeCodex, packageRoot } = makePackagedCodex(npmBin)
+
+    const attempt = buildAttempt({ root, command: "codex '--version'", pathEnv })
+
+    expect(attempt).not.toBeNull()
+    const config = decodeWindowsCodexShellHandoffConfig(attempt!)
+    expect(config.agentFile).toBe(nativeCodex)
+    expect(config.agentEnv).toMatchObject({
+      CODEX_MANAGED_PACKAGE_ROOT: realpathSync(packageRoot),
+      CODEX_MANAGED_BY_NPM: '1'
+    })
+    expect(config.agentEnvToDelete).toEqual([
+      'CODEX_MANAGED_BY_NPM',
+      'CODEX_MANAGED_BY_PNPM',
+      'CODEX_MANAGED_BY_BUN'
+    ])
+  })
+
+  it('only marks pnpm when the discovered node_modules owns this Codex package', () => {
+    const root = makeTempRoot()
+    const { npmBin, pathEnv } = makeBasePaths(root)
+    makePackagedCodex(npmBin)
+    makeFile(join(npmBin, 'node_modules', '.modules.yaml'))
+
+    const attempt = buildAttempt({ root, command: "codex '--version'", pathEnv })
+
+    expect(decodeWindowsCodexShellHandoffConfig(attempt!).agentEnv).toMatchObject({
+      CODEX_MANAGED_BY_PNPM: '1'
+    })
+  })
+
+  it('marks Bun global installs without relying on transient npm environment variables', () => {
+    const root = makeTempRoot()
+    const bunBin = join(root, '.bun', 'install', 'global', 'bin')
+    const nodePath = makeFile(join(root, 'node-bin', 'node.exe'))
+    makePackagedCodex(bunBin)
+    const pathEnv = [bunBin, dirname(nodePath)].join(delimiter)
+
+    const attempt = buildAttempt({ root, command: "codex '--version'", pathEnv })
+
+    expect(decodeWindowsCodexShellHandoffConfig(attempt!).agentEnv).toMatchObject({
+      CODEX_MANAGED_BY_BUN: '1'
+    })
+  })
+
+  it.each([
+    { name: 'custom compound command', command: "codex --profile work 'fix it'", agent: 'codex' },
+    { name: 'PowerShell call operator', command: "& 'codex' 'fix it'", agent: 'codex' },
+    { name: 'different launch owner', command: "codex 'fix it'", agent: 'claude' },
+    { name: 'unclosed generated quote', command: "codex 'fix it", agent: 'codex' },
+    { name: 'leading whitespace', command: " codex 'fix it'", agent: 'codex' },
+    { name: 'trailing whitespace', command: "codex 'fix it' ", agent: 'codex' },
+    { name: 'repeated whitespace', command: "codex  'fix it'", agent: 'codex' },
+    { name: 'tab separator', command: "codex\t'fix it'", agent: 'codex' }
+  ])('keeps the existing PowerShell path for $name', ({ command, agent }) => {
+    const root = makeTempRoot()
+    const { npmBin, pathEnv } = makeBasePaths(root)
+    makeFile(join(npmBin, 'codex.exe'))
+
+    expect(buildAttempt({ root, command, launchAgent: agent, pathEnv })).toBeNull()
+  })
+
+  it('keeps a canonical-looking custom command on the existing PowerShell path', () => {
+    const root = makeTempRoot()
+    const { npmBin, pathEnv } = makeBasePaths(root)
+    makeFile(join(npmBin, 'codex.exe'))
+
+    expect(buildAttempt({ root, command: "codex 'fix it'", pathEnv, eligible: false })).toBeNull()
+  })
+
+  it('rejects a package shim shadowed by a noncanonical PowerShell shim', () => {
+    const root = makeTempRoot()
+    const { npmBin, pathEnv } = makeBasePaths(root)
+    makePackagedCodex(npmBin)
+    makeFile(join(npmBin, 'codex.ps1'), "Write-Output 'enterprise wrapper'")
+
+    expect(buildAttempt({ root, command: "codex 'fix it'", pathEnv })).toBeNull()
+  })
+
+  it('resolves the canonical npm PowerShell shim selected ahead of its cmd pair', () => {
+    const root = makeTempRoot()
+    const { npmBin, pathEnv } = makeBasePaths(root)
+    makeFile(join(npmBin, 'codex.cmd'), CANONICAL_NPM_CMD_SHIM)
+    const { nativeCodex } = makePackagedCodex(npmBin, 'ps1')
+
+    const attempt = buildAttempt({ root, command: "codex '--version'", pathEnv })
+
+    expect(attempt).not.toBeNull()
+    expect(decodeWindowsCodexShellHandoffConfig(attempt!).agentFile).toBe(nativeCodex)
+  })
+
+  it('uses the same-directory executable PowerShell selects before a cmd shim', () => {
+    const root = makeTempRoot()
+    const { npmBin, pathEnv } = makeBasePaths(root)
+    makeFile(join(npmBin, 'codex.cmd'), CANONICAL_NPM_CMD_SHIM)
+    const codexExe = makeFile(join(npmBin, 'codex.exe'))
+
+    const attempt = buildAttempt({ root, command: "codex '--version'", pathEnv })
+
+    expect(attempt).not.toBeNull()
+    expect(decodeWindowsCodexShellHandoffConfig(attempt!).agentFile.toLowerCase()).toBe(
+      codexExe.toLowerCase()
+    )
+  })
+
+  it('keeps PowerShell when an earlier PATH directory contains a custom shim', () => {
+    const root = makeTempRoot()
+    const { npmBin, pathEnv } = makeBasePaths(root)
+    makePackagedCodex(npmBin)
+    const enterpriseBin = join(root, 'enterprise-bin')
+    makeFile(join(enterpriseBin, 'codex.ps1'), "& 'company-wrapper.exe' @args")
+
+    expect(
+      buildAttempt({
+        root,
+        command: "codex 'fix it'",
+        pathEnv: [enterpriseBin, pathEnv].join(delimiter)
+      })
+    ).toBeNull()
+  })
+
+  it('keeps PowerShell when custom PATHEXT selects a batch wrapper first', () => {
+    const root = makeTempRoot()
+    const { npmBin, pathEnv } = makeBasePaths(root)
+    makePackagedCodex(npmBin)
+    makeFile(join(npmBin, 'codex.bat'), '@echo off\r\ncompany-wrapper.exe %*\r\n')
+
+    expect(
+      buildAttempt({
+        root,
+        command: "codex 'fix it'",
+        pathEnv,
+        env: { PATHEXT: '.BAT;.CMD;.EXE' }
+      })
+    ).toBeNull()
+  })
+
+  it('rejects executable text added to an otherwise canonical cmd shim', () => {
+    const root = makeTempRoot()
+    const { npmBin, pathEnv } = makeBasePaths(root)
+    makePackagedCodex(npmBin)
+    makeFile(join(npmBin, 'codex.cmd'), `${CANONICAL_NPM_CMD_SHIM}# & company-wrapper.exe\n`)
+
+    expect(buildAttempt({ root, command: "codex 'fix it'", pathEnv })).toBeNull()
+  })
+
+  it('rejects package metadata that redirects the Codex bin entry', () => {
+    const root = makeTempRoot()
+    const { npmBin, pathEnv } = makeBasePaths(root)
+    const { packageRoot } = makePackagedCodex(npmBin)
+    makeFile(
+      join(packageRoot, 'package.json'),
+      JSON.stringify({ name: '@openai/codex', bin: { codex: 'bin/company-wrapper.js' } })
+    )
+
+    expect(buildAttempt({ root, command: "codex 'fix it'", pathEnv })).toBeNull()
+  })
+
+  it('rejects a modified Codex JavaScript entrypoint before bypassing it', () => {
+    const root = makeTempRoot()
+    const { npmBin, pathEnv } = makeBasePaths(root)
+    const { packageRoot } = makePackagedCodex(npmBin)
+    makeFile(
+      join(packageRoot, 'bin', 'codex.js'),
+      `${TRUSTED_CODEX_ENTRYPOINT}\nconsole.log('company wrapper')\n`
+    )
+
+    expect(buildAttempt({ root, command: "codex 'fix it'", pathEnv })).toBeNull()
+  })
+
+  it('does not infer default executable extensions when PATHEXT is absent', () => {
+    const root = makeTempRoot()
+    const { npmBin, pathEnv } = makeBasePaths(root)
+    makeFile(join(npmBin, 'codex.exe'))
+
+    expect(
+      buildWindowsCodexShellHandoffAttempt({
+        fallbackAttempts: [
+          {
+            shellPath: POWER_SHELL,
+            shellArgs: [],
+            effectiveCwd: CWD,
+            validationCwd: CWD,
+            startupCommandDeliveredInShellArgs: false
+          }
+        ],
+        cwd: CWD,
+        defaultCwd: DEFAULT_CWD,
+        startupCommand: "codex 'fix it'",
+        launchAgent: 'codex',
+        windowsCodexShellHandoff: true,
+        env: { PATH: pathEnv },
+        resolveOptions: { platform: 'win32', arch: 'x64', pathEnv }
+      })
+    ).toBeNull()
+  })
+
+  it('keeps the existing PowerShell path when the exact Codex target is unresolved', () => {
+    const root = makeTempRoot()
+    const { pathEnv } = makeBasePaths(root)
+
+    expect(buildAttempt({ root, command: "codex 'fix it'", pathEnv })).toBeNull()
+  })
+
+  it('keeps oversized launch payloads below the Windows CreateProcess limit', () => {
+    const root = makeTempRoot()
+    const { npmBin, pathEnv } = makeBasePaths(root)
+    makeFile(join(npmBin, 'codex.exe'))
+
+    expect(buildAttempt({ root, command: `codex '${'x'.repeat(30_000)}'`, pathEnv })).toBeNull()
+  })
+
+  it('keeps a 6,001-character command in every async PowerShell fallback', () => {
+    const root = makeTempRoot()
+    const { npmBin, pathEnv } = makeBasePaths(root)
+    makeFile(join(npmBin, 'codex.exe'))
+    const command = `codex '${'x'.repeat(6_001)}'`
+
+    const attempt = buildAttempt({ root, command, pathEnv })
+
+    expect(attempt).not.toBeNull()
+    const config = decodeWindowsCodexShellHandoffConfig(attempt!)
+    expect(config.agentFallbackAttempts).toHaveLength(1)
+    const fallbackCommand = Buffer.from(
+      config.agentFallbackAttempts[0].args[3] ?? '',
+      'base64'
+    ).toString('utf16le')
+    expect(fallbackCommand.trimEnd().endsWith(command)).toBe(true)
+  })
+
+  it('rejects handoff commands that no shell fallback can embed safely', () => {
+    const root = makeTempRoot()
+    const { npmBin, pathEnv } = makeBasePaths(root)
+    makeFile(join(npmBin, 'codex.exe'))
+
+    expect(buildAttempt({ root, command: `codex '${'x'.repeat(12_000)}'`, pathEnv })).toBeNull()
+  })
+
+  it('accounts for Windows quote escaping at the native child boundary', () => {
+    const root = makeTempRoot()
+    const { npmBin, pathEnv } = makeBasePaths(root)
+    makeFile(join(npmBin, 'codex.exe'))
+
+    expect(buildAttempt({ root, command: `codex '${'"'.repeat(16_000)}'`, pathEnv })).toBeNull()
+  })
+})
+
+describe('WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT', () => {
+  it('runs the agent before the shell without leaking agent-only env', () => {
+    const config: WindowsCodexShellHandoffConfig = {
+      agentFile: process.execPath,
+      agentArgs: [
+        '-e',
+        "process.stdout.write('agent:' + process.env.ORCA_HANDOFF_AGENT_ONLY + '\\n')"
+      ],
+      agentEnvToDelete: [],
+      agentEnv: { ORCA_HANDOFF_AGENT_ONLY: 'yes' },
+      shellAttempts: [
+        {
+          file: process.execPath,
+          args: [
+            '-e',
+            "process.stdout.write('shell:' + String(process.env.ORCA_HANDOFF_AGENT_ONLY) + '\\n')"
+          ],
+          cwd: process.cwd()
+        }
+      ],
+      agentFallbackAttempts: [
+        {
+          file: process.execPath,
+          args: ['-e', "process.stdout.write('agent-fallback\\n')"],
+          cwd: process.cwd()
+        }
+      ]
+    }
+    const encoded = encodeWindowsCodexShellHandoffConfig(config)
+
+    const result = spawnSync(
+      process.execPath,
+      ['-e', WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT, encoded],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, ORCA_HANDOFF_AGENT_ONLY: undefined },
+        timeout: 5_000
+      }
+    )
+
+    expect(result.status).toBe(0)
+    expect(result.stderr).toBe('')
+    expect(result.stdout).toBe('agent:yes\nshell:undefined\n')
+  })
+
+  it('uses the original shell command when the native agent fails to spawn', () => {
+    const config: WindowsCodexShellHandoffConfig = {
+      agentFile: join(makeTempRoot(), 'missing-codex.exe'),
+      agentArgs: [],
+      agentEnvToDelete: [],
+      agentEnv: {},
+      shellAttempts: [],
+      agentFallbackAttempts: [
+        {
+          file: process.execPath,
+          args: ['-e', "process.stdout.write('fallback\\n')"],
+          cwd: process.cwd()
+        }
+      ]
+    }
+    const encoded = encodeWindowsCodexShellHandoffConfig(config)
+
+    const result = spawnSync(
+      process.execPath,
+      ['-e', WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT, encoded],
+      { encoding: 'utf8', timeout: 5_000 }
+    )
+
+    expect(result.status).toBe(0)
+    expect(result.stderr).toContain('Failed to launch')
+    expect(result.stdout).toBe('fallback\n')
+  })
+
+  it('tries only the supplied PowerShell-family command fallbacks after an async spawn error', () => {
+    const prompt = 'fix spaced & piped | redirected < input > output 100%'
+    const config: WindowsCodexShellHandoffConfig = {
+      agentFile: join(makeTempRoot(), 'missing-codex.exe'),
+      agentArgs: [prompt],
+      agentEnvToDelete: [],
+      agentEnv: {},
+      shellAttempts: [],
+      agentFallbackAttempts: [
+        {
+          file: join(makeTempRoot(), 'missing-pwsh.exe'),
+          args: [],
+          cwd: process.cwd()
+        },
+        {
+          file: process.execPath,
+          args: ['-e', 'process.stdout.write(process.argv[1])', prompt],
+          cwd: process.cwd()
+        }
+      ]
+    }
+    const encoded = encodeWindowsCodexShellHandoffConfig(config)
+
+    const result = spawnSync(
+      process.execPath,
+      ['-e', WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT, encoded],
+      { encoding: 'utf8', timeout: 5_000 }
+    )
+
+    expect(result.status).toBe(0)
+    expect(result.stderr).toContain('Failed to launch')
+    expect(result.stdout).toBe(prompt)
+  })
+
+  it('opens the normal shell after a nonzero agent exit without relaunching the agent', () => {
+    const config: WindowsCodexShellHandoffConfig = {
+      agentFile: process.execPath,
+      agentArgs: ['-e', 'process.exitCode = 7'],
+      agentEnvToDelete: [],
+      agentEnv: {},
+      shellAttempts: [
+        {
+          file: process.execPath,
+          args: ['-e', "process.stdout.write('shell\\n')"],
+          cwd: process.cwd()
+        }
+      ],
+      agentFallbackAttempts: [
+        {
+          file: process.execPath,
+          args: ['-e', "process.stdout.write('wrong\\n')"],
+          cwd: process.cwd()
+        }
+      ]
+    }
+    const encoded = encodeWindowsCodexShellHandoffConfig(config)
+
+    const result = spawnSync(
+      process.execPath,
+      ['-e', WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT, encoded],
+      { encoding: 'utf8', timeout: 5_000 }
+    )
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toBe('shell\n')
+  })
+
+  it('tries the remaining shell-only fallback after a shell spawn error', () => {
+    const config: WindowsCodexShellHandoffConfig = {
+      agentFile: process.execPath,
+      agentArgs: ['-e', ''],
+      agentEnvToDelete: [],
+      agentEnv: {},
+      shellAttempts: [
+        { file: join(makeTempRoot(), 'missing-pwsh.exe'), args: [], cwd: process.cwd() },
+        {
+          file: process.execPath,
+          args: ['-e', "process.stdout.write('second-shell\\n')"],
+          cwd: process.cwd()
+        }
+      ],
+      agentFallbackAttempts: []
+    }
+    const encoded = encodeWindowsCodexShellHandoffConfig(config)
+
+    const result = spawnSync(
+      process.execPath,
+      ['-e', WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT, encoded],
+      { encoding: 'utf8', timeout: 5_000 }
+    )
+
+    expect(result.status).toBe(0)
+    expect(result.stderr).toContain('Failed to launch')
+    expect(result.stdout).toBe('second-shell\n')
+  })
+})

--- a/src/main/providers/windows-codex-shell-handoff.test.ts
+++ b/src/main/providers/windows-codex-shell-handoff.test.ts
@@ -595,6 +595,64 @@ describe('WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT', () => {
     expect(result.stdout).toBe(prompt)
   })
 
+  it('does not start another fallback after termination begins during a failed attempt', () => {
+    const config: WindowsCodexShellHandoffConfig = {
+      agentFile: 'missing-agent.exe',
+      agentArgs: [],
+      agentEnvToDelete: [],
+      agentEnv: {},
+      shellAttempts: [],
+      agentFallbackAttempts: [
+        { file: 'missing-first-fallback.exe', args: [], cwd: process.cwd() },
+        { file: 'sentinel-second-fallback.exe', args: [], cwd: process.cwd() }
+      ]
+    }
+    const encoded = encodeWindowsCodexShellHandoffConfig(config)
+    const wrapper = `
+const { EventEmitter } = require('node:events')
+const childProcess = require('node:child_process')
+let spawnCount = 0
+
+childProcess.spawn = () => {
+  const attemptNumber = ++spawnCount
+  const child = new EventEmitter()
+  child.killed = false
+  child.kill = () => {
+    child.killed = true
+    return true
+  }
+  queueMicrotask(() => {
+    if (attemptNumber === 1) {
+      child.emit('error', new Error('native launch failed'))
+      return
+    }
+    if (attemptNumber === 2) {
+      process.emit('SIGTERM')
+      child.emit('error', new Error('first fallback failed during shutdown'))
+      return
+    }
+    process.stdout.write('SECOND_FALLBACK_STARTED')
+    child.emit('spawn')
+    child.emit('exit', 0)
+  })
+  return child
+}
+
+eval(${JSON.stringify(WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT)})
+`
+
+    const result = spawnSync(process.execPath, ['-e', wrapper, encoded], {
+      encoding: 'utf8',
+      timeout: 5_000
+    })
+
+    expect(result.error).toBeUndefined()
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('native launch failed')
+    expect(result.stderr).toContain('first fallback failed during shutdown')
+    expect(result.stdout).not.toContain('SECOND_FALLBACK_STARTED')
+  })
+
   it('opens the normal shell after a nonzero agent exit without relaunching the agent', () => {
     const config: WindowsCodexShellHandoffConfig = {
       agentFile: process.execPath,

--- a/src/main/providers/windows-codex-shell-handoff.ts
+++ b/src/main/providers/windows-codex-shell-handoff.ts
@@ -1,0 +1,201 @@
+import { existsSync } from 'node:fs'
+import { delimiter, isAbsolute, join, win32 as pathWin32 } from 'node:path'
+import { resolveWindowsCodexTarget } from './windows-codex-package-resolution'
+import { parseGeneratedPowerShellCodexCommand } from './windows-codex-generated-command'
+import { resolveWindowsShellLaunchArgs, type WindowsShellWslContext } from './windows-shell-args'
+import {
+  encodeWindowsCodexShellHandoffConfig,
+  WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT,
+  type WindowsCodexShellChildAttempt,
+  type WindowsCodexShellHandoffConfig
+} from './windows-codex-shell-handoff-host'
+
+export {
+  decodeWindowsCodexShellHandoffConfig,
+  encodeWindowsCodexShellHandoffConfig,
+  WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT,
+  type WindowsCodexShellHandoffConfig
+} from './windows-codex-shell-handoff-host'
+
+const WINDOWS_CREATE_PROCESS_COMMAND_LINE_MAX_CHARS = 32_767
+const WINDOWS_CODEX_HANDOFF_COMMAND_LINE_MARGIN_CHARS = 4_000
+
+function getWindowsCommandLineChars(file: string, args: string[]): number {
+  return [file, ...args].reduce((total, arg, index) => {
+    const hasLopsidedEnclosingQuote = (arg[0] !== '"') !== (arg.at(-1) !== '"')
+    const hasNoEnclosingQuotes = arg[0] !== '"' && arg.at(-1) !== '"'
+    const quote =
+      arg === '' ||
+      ((arg.includes(' ') || arg.includes('\t')) &&
+        arg.length > 1 &&
+        (hasLopsidedEnclosingQuote || hasNoEnclosingQuotes))
+    let escapedChars = 0
+    let backslashes = 0
+    for (const char of arg) {
+      if (char === '\\') {
+        backslashes += 1
+      } else if (char === '"') {
+        escapedChars += backslashes * 2 + 2
+        backslashes = 0
+      } else {
+        escapedChars += backslashes + 1
+        backslashes = 0
+      }
+    }
+    escapedChars += quote ? backslashes * 2 + 2 : backslashes
+    return total + (index === 0 ? 0 : 1) + escapedChars
+  }, 0)
+}
+
+export type WindowsCodexShellHandoffAttempt = {
+  shellPath: string
+  shellArgs: string[]
+  logicalShellPath: string
+  effectiveCwd: string
+  validationCwd: string
+  startupCommandDeliveredInShellArgs: true
+}
+
+type WindowsCodexShellSourceAttempt = {
+  shellPath: string
+  shellArgs: string[]
+  effectiveCwd: string
+  validationCwd: string
+  startupCommandDeliveredInShellArgs: boolean
+}
+
+type WindowsCodexShellHandoffResolveOptions = {
+  platform?: NodeJS.Platform
+  arch?: string
+  pathEnv?: string | null
+}
+
+function resolveNodeHost(args: { pathEnv: string | null | undefined }): string | null {
+  for (const rawDirectory of args.pathEnv?.split(delimiter) ?? []) {
+    const directory = rawDirectory.trim().replace(/^"|"$/g, '')
+    if (!directory) {
+      continue
+    }
+    const commandPath = join(directory, 'node.exe')
+    if (isAbsolute(commandPath) && existsSync(commandPath)) {
+      return commandPath
+    }
+  }
+  return null
+}
+
+function toChildAttempt(attempt: WindowsCodexShellSourceAttempt): WindowsCodexShellChildAttempt {
+  return { file: attempt.shellPath, args: attempt.shellArgs, cwd: attempt.effectiveCwd }
+}
+
+function isPowerShellFamily(shellPath: string): boolean {
+  const basename = pathWin32.basename(shellPath).toLowerCase()
+  return basename === 'pwsh.exe' || basename === 'powershell.exe'
+}
+
+export function buildWindowsCodexShellHandoffAttempt(args: {
+  fallbackAttempts: WindowsCodexShellSourceAttempt[]
+  cwd: string
+  defaultCwd: string
+  wslContext?: WindowsShellWslContext
+  startupCommand?: string
+  launchAgent?: string
+  windowsCodexShellHandoff?: boolean
+  env: Record<string, string>
+  resolveOptions?: WindowsCodexShellHandoffResolveOptions
+}): WindowsCodexShellHandoffAttempt | null {
+  try {
+    const platform = args.resolveOptions?.platform ?? process.platform
+    const primaryAttempt = args.fallbackAttempts[0]
+    if (
+      platform !== 'win32' ||
+      args.launchAgent !== 'codex' ||
+      args.windowsCodexShellHandoff !== true ||
+      !args.startupCommand ||
+      !primaryAttempt
+    ) {
+      return null
+    }
+    const agentArgs = parseGeneratedPowerShellCodexCommand(args.startupCommand)
+    if (!agentArgs) {
+      return null
+    }
+    const pathEnv =
+      args.resolveOptions?.pathEnv ?? args.env.PATH ?? args.env.Path ?? args.env.path ?? null
+    const arch = args.resolveOptions?.arch ?? process.arch
+    const agent = resolveWindowsCodexTarget({
+      env: args.env,
+      arch,
+      pathEnv,
+      pathExt: args.env.PATHEXT ?? args.env.PathExt
+    })
+    const nodeHost = resolveNodeHost({ pathEnv })
+    if (!agent || !nodeHost || !existsSync(nodeHost)) {
+      return null
+    }
+    const agentCommandLineChars = getWindowsCommandLineChars(agent.file, agentArgs)
+    if (
+      agentCommandLineChars >
+      WINDOWS_CREATE_PROCESS_COMMAND_LINE_MAX_CHARS -
+        WINDOWS_CODEX_HANDOFF_COMMAND_LINE_MARGIN_CHARS
+    ) {
+      return null
+    }
+
+    const shellAttempts = args.fallbackAttempts.map((attempt) => {
+      const launch = resolveWindowsShellLaunchArgs(
+        attempt.shellPath,
+        args.cwd,
+        args.defaultCwd,
+        args.wslContext
+      )
+      return { file: attempt.shellPath, args: launch.shellArgs, cwd: launch.effectiveCwd }
+    })
+    const agentFallbackAttempts = args.fallbackAttempts
+      // Why: the generated launch text is PowerShell syntax. Passing it to cmd
+      // can reinterpret quoting and prompt metacharacters after a native spawn race.
+      .filter(
+        (attempt) =>
+          attempt.startupCommandDeliveredInShellArgs && isPowerShellFamily(attempt.shellPath)
+      )
+      .map(toChildAttempt)
+    if (agentFallbackAttempts.length === 0) {
+      return null
+    }
+    const config: WindowsCodexShellHandoffConfig = {
+      agentFile: agent.file,
+      agentArgs,
+      agentEnvToDelete: agent.envToDelete,
+      agentEnv: agent.env,
+      shellAttempts,
+      // Why: a native spawn race may fall back only to shells that already
+      // carry the agent command; a plain shell would silently lose the launch.
+      agentFallbackAttempts
+    }
+    const encodedConfig = encodeWindowsCodexShellHandoffConfig(config)
+    const estimatedCommandLineChars = getWindowsCommandLineChars(nodeHost, [
+      '-e',
+      WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT,
+      encodedConfig
+    ])
+    if (
+      estimatedCommandLineChars >
+      WINDOWS_CREATE_PROCESS_COMMAND_LINE_MAX_CHARS -
+        WINDOWS_CODEX_HANDOFF_COMMAND_LINE_MARGIN_CHARS
+    ) {
+      return null
+    }
+
+    return {
+      shellPath: nodeHost,
+      shellArgs: ['-e', WINDOWS_CODEX_SHELL_HANDOFF_HOST_SCRIPT, encodedConfig],
+      logicalShellPath: primaryAttempt.shellPath,
+      effectiveCwd: primaryAttempt.effectiveCwd,
+      validationCwd: primaryAttempt.validationCwd,
+      startupCommandDeliveredInShellArgs: true
+    }
+  } catch {
+    // Resolver/filesystem races must preserve the established PowerShell launch path.
+    return null
+  }
+}

--- a/src/main/providers/windows-powershell-command-resolution.ts
+++ b/src/main/providers/windows-powershell-command-resolution.ts
@@ -1,0 +1,121 @@
+import { readFileSync, statSync } from 'node:fs'
+import { delimiter, extname, join } from 'node:path'
+
+function isFile(path: string): boolean {
+  try {
+    return statSync(path).isFile()
+  } catch {
+    return false
+  }
+}
+
+function getPowerShellCommandNames(command: string, pathExt: string | null | undefined): string[] {
+  const executableExtensions = (pathExt ?? '')
+    .split(';')
+    .map((extension) => extension.trim())
+    .filter(Boolean)
+    .map((extension) => (extension.startsWith('.') ? extension : `.${extension}`))
+  return [
+    `${command}.ps1`,
+    ...executableExtensions.map((extension) => `${command}${extension}`),
+    command
+  ].filter(
+    (name, index, names) =>
+      names.findIndex((entry) => entry.toLowerCase() === name.toLowerCase()) === index
+  )
+}
+
+/** Resolve the external command a fresh PowerShell would select from PATH. */
+export function resolvePowerShellExternalCommand(args: {
+  command: string
+  pathEnv: string | null | undefined
+  pathExt?: string | null
+}): string | null {
+  const names = getPowerShellCommandNames(args.command, args.pathExt)
+  for (const rawDirectory of args.pathEnv?.split(delimiter) ?? []) {
+    const directory = rawDirectory.trim().replace(/^"|"$/g, '')
+    if (!directory) {
+      continue
+    }
+    for (const name of names) {
+      const candidate = join(directory, name)
+      if (isFile(candidate)) {
+        return candidate
+      }
+    }
+  }
+  return null
+}
+
+function normalizeShimNewlines(contents: string): string {
+  return contents.replace(/^\uFEFF/, '').replace(/\r\n?/g, '\n')
+}
+
+// Why: bypassing PowerShell is safe only when the selected shim has no behavior
+// beyond forwarding argv to the official Codex JavaScript entry point.
+const NPM_CMD_SHIM_TEMPLATES = [
+  String.raw`@ECHO off
+GOTO start
+:find_dp0
+SET dp0=%~dp0
+EXIT /b
+:start
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\node_modules\@openai\codex\bin\codex.js" %*
+`
+]
+
+const NPM_POWERSHELL_SHIM_TEMPLATES = [
+  String.raw`#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  # Support pipeline input
+  if ($MyInvocation.ExpectingInput) {
+    $input | & "$basedir/node$exe"  "$basedir/node_modules/@openai/codex/bin/codex.js" $args
+  } else {
+    & "$basedir/node$exe"  "$basedir/node_modules/@openai/codex/bin/codex.js" $args
+  }
+  $ret=$LASTEXITCODE
+} else {
+  # Support pipeline input
+  if ($MyInvocation.ExpectingInput) {
+    $input | & "node$exe"  "$basedir/node_modules/@openai/codex/bin/codex.js" $args
+  } else {
+    & "node$exe"  "$basedir/node_modules/@openai/codex/bin/codex.js" $args
+  }
+  $ret=$LASTEXITCODE
+}
+exit $ret
+`
+]
+
+/** Accept only known package-manager shims with no additional executable statements. */
+export function isCanonicalCodexPackageShim(commandPath: string): boolean {
+  try {
+    const contents = normalizeShimNewlines(readFileSync(commandPath, 'utf8'))
+    const extension = extname(commandPath).toLowerCase()
+    if (extension === '.cmd') {
+      return NPM_CMD_SHIM_TEMPLATES.includes(contents)
+    }
+    return extension === '.ps1' && NPM_POWERSHELL_SHIM_TEMPLATES.includes(contents)
+  } catch {
+    return false
+  }
+}

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -168,13 +168,27 @@ describe('resolveWindowsShellLaunchArgs', () => {
     expect(command.trimEnd().endsWith(startupCommand)).toBe(true)
   })
 
-  it('keeps large PowerShell startup commands on stdin delivery', () => {
+  it('embeds PowerShell startup commands above the conservative cmd.exe limit', () => {
     const result = resolveWindowsShellLaunchArgs(
       'powershell.exe',
       'C:\\Users\\alice',
       'C:\\Users\\alice',
       undefined,
-      `orca ${'x'.repeat(7000)}`
+      `orca ${'x'.repeat(6_001)}`
+    )
+
+    expect(result.startupCommandDeliveredInShellArgs).toBe(true)
+    const command = Buffer.from(result.shellArgs[3] ?? '', 'base64').toString('utf16le')
+    expect(command.trimEnd().endsWith(`orca ${'x'.repeat(6_001)}`)).toBe(true)
+  })
+
+  it('keeps PowerShell startup commands beyond its encoded argv limit on stdin delivery', () => {
+    const result = resolveWindowsShellLaunchArgs(
+      'powershell.exe',
+      'C:\\Users\\alice',
+      'C:\\Users\\alice',
+      undefined,
+      `orca ${'x'.repeat(12_000)}`
     )
 
     expect(result.startupCommandDeliveredInShellArgs).toBeUndefined()

--- a/src/main/providers/windows-shell-args.ts
+++ b/src/main/providers/windows-shell-args.ts
@@ -13,7 +13,7 @@ import {
 } from '../powershell-osc133-bootstrap'
 
 const CMD_EXE_COMMAND_LINE_MAX_CHARS = 8191
-const STARTUP_COMMAND_TEXT_MAX_CHARS = 6000
+const CMD_STARTUP_COMMAND_TEXT_MAX_CHARS = 6000
 const POWERSHELL_ENCODED_COMMAND_ARG_MAX_CHARS = 28_000
 const CMD_UTF8_SETUP_COMMAND = 'chcp 65001 > nul'
 
@@ -52,7 +52,7 @@ export type WindowsShellWslContext = {
  * keep the older stdin delivery path.
  */
 function getCmdShellArgStartupCommand(command?: string): string | null {
-  if (!command || command.length > STARTUP_COMMAND_TEXT_MAX_CHARS) {
+  if (!command || command.length > CMD_STARTUP_COMMAND_TEXT_MAX_CHARS) {
     return null
   }
   // Why: node-pty's C-runtime argv escaping changes normal cmd quotes in `/K`
@@ -70,15 +70,15 @@ function getCmdShellArgStartupCommand(command?: string): string | null {
 /**
  * Builds the PowerShell -EncodedCommand payload for startup bootstrap.
  *
- * Short startup commands are appended to the bootstrap and marked as delivered;
- * large payloads return the bootstrap alone so stdin delivery remains available.
+ * Startup commands that fit the encoded argv limit are appended to the bootstrap;
+ * larger payloads return the bootstrap alone so stdin delivery remains available.
  */
 function getPowerShellEncodedCommand(startupCommand?: string): {
   encodedCommand: string
   startupCommandDeliveredInShellArgs?: boolean
 } {
   const bootstrap = getPowerShellOsc133Bootstrap()
-  if (!startupCommand || startupCommand.length > STARTUP_COMMAND_TEXT_MAX_CHARS) {
+  if (!startupCommand) {
     return { encodedCommand: encodePowerShellCommand(bootstrap) }
   }
 

--- a/src/main/providers/windows-shell-fallback-chain.test.ts
+++ b/src/main/providers/windows-shell-fallback-chain.test.ts
@@ -1,6 +1,12 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { delimiter, dirname, join, win32 as pathWin32 } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { win32 as pathWin32 } from 'node:path'
-import { buildWindowsPowerShellSpawnAttempts } from './windows-shell-fallback-chain'
+import {
+  buildWindowsPowerShellSpawnAttempts,
+  prependWindowsCodexShellHandoffAttempt
+} from './windows-shell-fallback-chain'
+import { decodeWindowsCodexShellHandoffConfig } from './windows-codex-shell-handoff'
 
 const WIN_ENV: NodeJS.ProcessEnv = {
   ProgramW6432: 'C:\\Program Files',
@@ -19,10 +25,20 @@ function setPlatform(platform: NodeJS.Platform): () => void {
 }
 
 let restorePlatform: (() => void) | null = null
+const tempRoots: string[] = []
 afterEach(() => {
   restorePlatform?.()
   restorePlatform = null
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
 })
+
+function makeFile(path: string): string {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, '')
+  return path
+}
 
 describe('buildWindowsPowerShellSpawnAttempts', () => {
   it('returns no attempts for non-PowerShell shells (cmd.exe keeps single-shell behavior)', () => {
@@ -76,5 +92,184 @@ describe('buildWindowsPowerShellSpawnAttempts', () => {
     for (const attempt of attempts) {
       expect(pathWin32.isAbsolute(attempt.shellPath)).toBe(true)
     }
+  })
+
+  it('prepends the Codex handoff while preserving the established shell fallbacks', () => {
+    restorePlatform = setPlatform('win32')
+    const root = mkdtempSync(join(tmpdir(), 'orca-windows-shell-fallback-'))
+    tempRoots.push(root)
+    const npmBin = join(root, 'npm-bin')
+    const nodeBin = join(root, 'node-bin')
+    const codexPath = makeFile(join(npmBin, 'codex.exe'))
+    const nodePath = makeFile(join(nodeBin, 'node.exe'))
+    const pathEnv = [npmBin, nodeBin].join(delimiter)
+    const attempts = buildWindowsPowerShellSpawnAttempts({
+      shellPath: 'pwsh.exe',
+      cwd: 'C:\\repo',
+      defaultCwd: 'C:\\Users\\dev',
+      startupCommand: "codex 'fix it'",
+      resolveOptions: {
+        platform: 'win32',
+        env: WIN_ENV,
+        isRealExecutable: (path) => path === PWSH7 || path === WINDOWS_POWERSHELL
+      }
+    })
+
+    const optimized = prependWindowsCodexShellHandoffAttempt({
+      attempts,
+      cwd: 'C:\\repo',
+      defaultCwd: 'C:\\Users\\dev',
+      startupCommand: "codex 'fix it'",
+      launchAgent: 'codex',
+      windowsCodexShellHandoff: true,
+      env: { PATH: pathEnv, PATHEXT: '.COM;.EXE;.BAT;.CMD' }
+    })
+
+    expect(optimized).toHaveLength(attempts.length + 1)
+    expect(optimized.slice(1)).toEqual(attempts)
+    expect(optimized[0]).toMatchObject({
+      shellPath: nodePath,
+      logicalShellPath: PWSH7,
+      startupCommandDeliveredInShellArgs: true
+    })
+    const config = decodeWindowsCodexShellHandoffConfig(optimized[0])
+    expect(config.agentFile.toLowerCase()).toBe(codexPath.toLowerCase())
+    expect(config.agentArgs).toEqual(['fix it'])
+    expect(config.shellAttempts.map((attempt) => attempt.file)).toEqual([
+      PWSH7,
+      WINDOWS_POWERSHELL,
+      CMD
+    ])
+    expect(config.agentFallbackAttempts.map((attempt) => attempt.file)).toEqual([
+      PWSH7,
+      WINDOWS_POWERSHELL
+    ])
+  })
+
+  it('keeps metacharacters inside PowerShell-only async agent fallbacks', () => {
+    restorePlatform = setPlatform('win32')
+    const root = mkdtempSync(join(tmpdir(), 'orca-windows-shell-fallback-'))
+    tempRoots.push(root)
+    const npmBin = join(root, 'npm-bin')
+    const nodeBin = join(root, 'node-bin')
+    makeFile(join(npmBin, 'codex.exe'))
+    makeFile(join(nodeBin, 'node.exe'))
+    const command = "codex 'fix spaced & piped | redirected < input > output 100%'"
+    const attempts = buildWindowsPowerShellSpawnAttempts({
+      shellPath: 'pwsh.exe',
+      cwd: 'C:\\repo',
+      defaultCwd: 'C:\\Users\\dev',
+      startupCommand: command,
+      resolveOptions: {
+        platform: 'win32',
+        env: WIN_ENV,
+        isRealExecutable: (path) => path === PWSH7 || path === WINDOWS_POWERSHELL
+      }
+    })
+
+    const optimized = prependWindowsCodexShellHandoffAttempt({
+      attempts,
+      cwd: 'C:\\repo',
+      defaultCwd: 'C:\\Users\\dev',
+      startupCommand: command,
+      launchAgent: 'codex',
+      windowsCodexShellHandoff: true,
+      env: {
+        PATH: [npmBin, nodeBin].join(delimiter),
+        PATHEXT: '.COM;.EXE;.BAT;.CMD'
+      }
+    })
+
+    const config = decodeWindowsCodexShellHandoffConfig(optimized[0])
+    expect(config.agentArgs).toEqual(['fix spaced & piped | redirected < input > output 100%'])
+    expect(config.agentFallbackAttempts.map((attempt) => attempt.file)).toEqual([
+      PWSH7,
+      WINDOWS_POWERSHELL
+    ])
+    expect(config.agentFallbackAttempts.some((attempt) => attempt.file === CMD)).toBe(false)
+    for (const fallback of config.agentFallbackAttempts) {
+      const encodedCommand = fallback.args[fallback.args.indexOf('-EncodedCommand') + 1]
+      expect(Buffer.from(encodedCommand ?? '', 'base64').toString('utf16le')).toContain(command)
+    }
+  })
+
+  it('does not prepend the handoff without explicit default-command provenance', () => {
+    restorePlatform = setPlatform('win32')
+    const root = mkdtempSync(join(tmpdir(), 'orca-windows-shell-fallback-'))
+    tempRoots.push(root)
+    const npmBin = join(root, 'npm-bin')
+    const nodeBin = join(root, 'node-bin')
+    makeFile(join(npmBin, 'codex.exe'))
+    makeFile(join(nodeBin, 'node.exe'))
+    const attempts = buildWindowsPowerShellSpawnAttempts({
+      shellPath: 'pwsh.exe',
+      cwd: 'C:\\repo',
+      defaultCwd: 'C:\\Users\\dev',
+      startupCommand: "codex 'fix it'",
+      resolveOptions: {
+        platform: 'win32',
+        env: WIN_ENV,
+        isRealExecutable: (path) => path === PWSH7 || path === WINDOWS_POWERSHELL
+      }
+    })
+
+    expect(
+      prependWindowsCodexShellHandoffAttempt({
+        attempts,
+        cwd: 'C:\\repo',
+        defaultCwd: 'C:\\Users\\dev',
+        startupCommand: "codex 'fix it'",
+        launchAgent: 'codex',
+        env: {
+          PATH: [npmBin, nodeBin].join(delimiter),
+          PATHEXT: '.COM;.EXE;.BAT;.CMD'
+        }
+      })
+    ).toEqual(attempts)
+  })
+
+  it('omits an unsafe cmd fallback for a 6,001-character native-spawn race', () => {
+    restorePlatform = setPlatform('win32')
+    const root = mkdtempSync(join(tmpdir(), 'orca-windows-shell-fallback-'))
+    tempRoots.push(root)
+    const npmBin = join(root, 'npm-bin')
+    const nodeBin = join(root, 'node-bin')
+    makeFile(join(npmBin, 'codex.exe'))
+    makeFile(join(nodeBin, 'node.exe'))
+    const pathEnv = [npmBin, nodeBin].join(delimiter)
+    const command = `codex '${'x'.repeat(6_001)}'`
+    const attempts = buildWindowsPowerShellSpawnAttempts({
+      shellPath: 'pwsh.exe',
+      cwd: 'C:\\repo',
+      defaultCwd: 'C:\\Users\\dev',
+      startupCommand: command,
+      resolveOptions: {
+        platform: 'win32',
+        env: WIN_ENV,
+        isRealExecutable: (path) => path === PWSH7 || path === WINDOWS_POWERSHELL
+      }
+    })
+
+    const optimized = prependWindowsCodexShellHandoffAttempt({
+      attempts,
+      cwd: 'C:\\repo',
+      defaultCwd: 'C:\\Users\\dev',
+      startupCommand: command,
+      launchAgent: 'codex',
+      windowsCodexShellHandoff: true,
+      env: { PATH: pathEnv, PATHEXT: '.COM;.EXE;.BAT;.CMD' }
+    })
+
+    expect(optimized).toHaveLength(attempts.length + 1)
+    const config = decodeWindowsCodexShellHandoffConfig(optimized[0])
+    expect(config.agentFallbackAttempts.map((attempt) => attempt.file)).toEqual([
+      PWSH7,
+      WINDOWS_POWERSHELL
+    ])
+    expect(config.shellAttempts.map((attempt) => attempt.file)).toEqual([
+      PWSH7,
+      WINDOWS_POWERSHELL,
+      CMD
+    ])
   })
 })

--- a/src/main/providers/windows-shell-fallback-chain.ts
+++ b/src/main/providers/windows-shell-fallback-chain.ts
@@ -5,12 +5,15 @@ import {
   resolveWindowsPowerShellSpawnChain,
   type WindowsPowerShellResolveOptions
 } from './windows-powershell-executable'
+import { buildWindowsCodexShellHandoffAttempt } from './windows-codex-shell-handoff'
 
 /** A single attempt in the Windows shell-spawn fallback chain: the absolute
  *  executable plus the launch args + cwd computed for it. */
 export type WindowsShellSpawnAttempt = {
   shellPath: string
   shellArgs: string[]
+  /** User-selected shell represented by a lightweight launch host. */
+  logicalShellPath?: string
   effectiveCwd: string
   validationCwd: string
   startupCommandDeliveredInShellArgs: boolean
@@ -68,4 +71,37 @@ export function buildWindowsPowerShellSpawnAttempts(args: {
   return chain.map((candidate) =>
     toAttempt(candidate, args.cwd, args.defaultCwd, args.wslContext, args.startupCommand)
   )
+}
+
+export function prependWindowsCodexShellHandoffAttempt(args: {
+  attempts: WindowsShellSpawnAttempt[]
+  cwd: string
+  defaultCwd: string
+  wslContext?: WindowsShellWslContext
+  startupCommand?: string
+  launchAgent?: string
+  windowsCodexShellHandoff?: boolean
+  env: Record<string, string>
+}): WindowsShellSpawnAttempt[] {
+  const powerShellAttempt = args.attempts[0]
+  if (!powerShellAttempt) {
+    return args.attempts
+  }
+  const powerShellBasename = pathWin32.basename(powerShellAttempt.shellPath).toLowerCase()
+  if (powerShellBasename !== 'pwsh.exe' && powerShellBasename !== 'powershell.exe') {
+    return args.attempts
+  }
+  const handoff = buildWindowsCodexShellHandoffAttempt({
+    fallbackAttempts: args.attempts,
+    cwd: args.cwd,
+    defaultCwd: args.defaultCwd,
+    wslContext: args.wslContext,
+    startupCommand: args.startupCommand,
+    launchAgent: args.launchAgent,
+    windowsCodexShellHandoff: args.windowsCodexShellHandoff,
+    env: args.env
+  })
+  // Why: keep the established PowerShell -> cmd chain behind the optimized
+  // host so an unavailable Node/native Codex target still fails open safely.
+  return handoff ? [handoff, ...args.attempts] : args.attempts
 }

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -10045,7 +10045,8 @@ describe('OrcaRuntimeService', () => {
         launchConfig: {
           agentCommand: "codex '--dangerously-bypass-approvals-and-sandbox'",
           agentArgs: '--dangerously-bypass-approvals-and-sandbox',
-          agentEnv: { CODEX_PROFILE: 'captured' }
+          agentEnv: { CODEX_PROFILE: 'captured' },
+          windowsCodexShellHandoff: true
         }
       })
     )

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1077,7 +1077,8 @@ function copySleepingAgentLaunchConfig(
   return {
     ...(config.agentCommand ? { agentCommand: config.agentCommand } : {}),
     agentArgs: config.agentArgs,
-    agentEnv: { ...config.agentEnv }
+    agentEnv: { ...config.agentEnv },
+    ...(config.windowsCodexShellHandoff === true ? { windowsCodexShellHandoff: true } : {})
   }
 }
 
@@ -1212,6 +1213,7 @@ type RuntimePtyController = {
     cwd?: string
     command?: string
     launchAgent?: TuiAgent
+    windowsCodexShellHandoff?: boolean
     commandDelivery?: 'renderer' | 'provider'
     startupCommandDelivery?: WorktreeStartupLaunch['startupCommandDelivery']
     env?: Record<string, string>
@@ -18344,6 +18346,9 @@ export class OrcaRuntimeService {
           ? launchOpts.command
           : (agentTeamsPlan?.command ?? launchOpts.command),
         launchAgent: launchOpts.launchAgent,
+        ...(effectiveLaunchConfig?.windowsCodexShellHandoff === true
+          ? { windowsCodexShellHandoff: true }
+          : {}),
         commandDelivery: 'provider',
         startupCommandDelivery: launchOpts.startupCommandDelivery,
         env,

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -26,6 +26,7 @@ import {
 } from '../../../../shared/terminal-input'
 import { measureClipboardTextByteLength } from '../../../../shared/clipboard-text'
 import { isTuiAgent } from '../../../../shared/tui-agent-config'
+import { sleepingAgentLaunchConfigSchema } from '../../../../shared/workspace-session-sleeping-agents'
 import { isTerminalQueryReply } from '../../../../shared/terminal-query-reply'
 import {
   EMPTY_TERMINAL_REPLY_QUERY_SCAN_STATE,
@@ -868,13 +869,9 @@ const TerminalCreateParams = z.object({
   command: OptionalString,
   startupCommandDelivery: z.enum(['fast', 'shell-ready']).optional(),
   env: z.record(z.string(), z.string()).optional(),
-  launchConfig: z
-    .object({
-      agentCommand: z.string().optional(),
-      agentArgs: z.string(),
-      agentEnv: z.record(z.string(), z.string())
-    })
-    .optional(),
+  // Why: launch config is untrusted RPC data; the shared schema fail-closes malformed
+  // fields and permits only literal true to opt into the Windows Codex handoff.
+  launchConfig: sleepingAgentLaunchConfigSchema,
   launchToken: OptionalString,
   launchAgent: z.string().refine(isTuiAgent).optional(),
   title: OptionalString,

--- a/src/main/runtime/rpc/terminal-create.test.ts
+++ b/src/main/runtime/rpc/terminal-create.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { OrcaRuntimeService } from '../orca-runtime'
+import type { RpcRequest } from './core'
+import { RpcDispatcher } from './dispatcher'
+import { TERMINAL_METHODS } from './methods/terminal'
+
+function makeRequest(params: unknown): RpcRequest {
+  return {
+    id: 'req-1',
+    authToken: 'tok',
+    method: 'terminal.create',
+    params
+  }
+}
+
+function createDispatcher(): {
+  dispatcher: RpcDispatcher
+  createTerminal: ReturnType<typeof vi.fn>
+} {
+  const createTerminal = vi.fn().mockResolvedValue('terminal-1')
+  const runtime = {
+    getRuntimeId: () => 'test-runtime',
+    createTerminal
+  } as unknown as OrcaRuntimeService
+
+  return {
+    dispatcher: new RpcDispatcher({ runtime, methods: TERMINAL_METHODS }),
+    createTerminal
+  }
+}
+
+describe('terminal.create RPC', () => {
+  it('forwards a literal-true Windows Codex shell handoff marker', async () => {
+    const { dispatcher, createTerminal } = createDispatcher()
+    const launchConfig = {
+      agentCommand: 'codex',
+      agentArgs: '--model gpt-5',
+      agentEnv: { CODEX_PROFILE: 'captured' },
+      windowsCodexShellHandoff: true
+    }
+
+    const response = await dispatcher.dispatch(
+      makeRequest({
+        worktree: 'id:wt-1',
+        launchConfig
+      })
+    )
+
+    expect(response.ok).toBe(true)
+    expect(createTerminal).toHaveBeenCalledWith(
+      'id:wt-1',
+      expect.objectContaining({ launchConfig })
+    )
+  })
+
+  it.each([false, 'true', 1])(
+    'fails closed for a malformed Windows Codex shell handoff marker (%j)',
+    async (windowsCodexShellHandoff) => {
+      const { dispatcher, createTerminal } = createDispatcher()
+
+      const response = await dispatcher.dispatch(
+        makeRequest({
+          worktree: 'id:wt-1',
+          launchConfig: {
+            agentCommand: 'codex',
+            agentArgs: '--model gpt-5',
+            agentEnv: { CODEX_PROFILE: 'captured' },
+            windowsCodexShellHandoff
+          }
+        })
+      )
+
+      expect(response.ok).toBe(true)
+      expect(createTerminal).toHaveBeenCalledTimes(1)
+      expect(createTerminal.mock.calls[0]?.[1]).not.toHaveProperty('launchConfig')
+    }
+  )
+})

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4398,6 +4398,9 @@ export function connectPanePty(
             ? launchConfig.agentEnv
             : resolveTuiAgentLaunchEnv(agent, state.settings?.agentDefaultEnv),
         ...(launchConfig?.agentCommand ? { agentCommand: launchConfig.agentCommand } : {}),
+        ...(launchConfig?.windowsCodexShellHandoff === true
+          ? { windowsCodexShellHandoff: true }
+          : {}),
         platform: resumePlatform
       })
       if (!startupPlan) {

--- a/src/renderer/src/lib/ai-vault-session-drag.test.ts
+++ b/src/renderer/src/lib/ai-vault-session-drag.test.ts
@@ -131,6 +131,50 @@ describe('Session History session drag data', () => {
     expect(readAiVaultSessionDragData(transfer)).toBeNull()
   })
 
+  it('preserves a literal-true Windows Codex shell handoff marker', () => {
+    const transfer = createTransfer()
+    const payload: AiVaultSessionDragPayload = {
+      agent: 'codex',
+      sessionId: 'session-codex-handoff',
+      title: 'Resume Codex shell handoff',
+      command: 'codex resume session-codex-handoff',
+      launchConfig: {
+        agentArgs: '',
+        agentEnv: {},
+        windowsCodexShellHandoff: true
+      }
+    }
+
+    writeAiVaultSessionDragData(transfer, payload)
+
+    expect(readAiVaultSessionDragData(transfer)).toEqual(payload)
+  })
+
+  it.each([false, 'true', 1])(
+    'rejects a malformed Windows Codex shell handoff marker (%j)',
+    (windowsCodexShellHandoff) => {
+      const transfer = createTransfer()
+      transfer.setData(
+        AI_VAULT_SESSION_DRAG_TYPE,
+        JSON.stringify({
+          kind: 'ai-vault-session',
+          version: 1,
+          agent: 'codex',
+          sessionId: 'session-codex-handoff',
+          title: 'Malformed Codex shell handoff',
+          command: 'codex resume session-codex-handoff',
+          launchConfig: {
+            agentArgs: '',
+            agentEnv: {},
+            windowsCodexShellHandoff
+          }
+        })
+      )
+
+      expect(readAiVaultSessionDragData(transfer)).toBeNull()
+    }
+  )
+
   it('rejects oversized serialized payloads before parsing', () => {
     const transfer = createTransfer()
     const secret = 'ai-vault-drag-secret'

--- a/src/renderer/src/lib/ai-vault-session-drag.ts
+++ b/src/renderer/src/lib/ai-vault-session-drag.ts
@@ -49,10 +49,12 @@ function isLaunchConfig(value: unknown): value is SleepingAgentLaunchConfig {
     return false
   }
   const config = value as Partial<SleepingAgentLaunchConfig>
+  // Why: serialized drag data is untrusted; only literal true may enable the shell handoff.
   return (
     (config.agentCommand === undefined || typeof config.agentCommand === 'string') &&
     typeof config.agentArgs === 'string' &&
-    isStringRecord(config.agentEnv)
+    isStringRecord(config.agentEnv) &&
+    (config.windowsCodexShellHandoff === undefined || config.windowsCodexShellHandoff === true)
   )
 }
 

--- a/src/renderer/src/lib/sleeping-agent-session-launch.ts
+++ b/src/renderer/src/lib/sleeping-agent-session-launch.ts
@@ -81,6 +81,7 @@ export function launchSleepingAgentSession(
         ? launchConfig.agentEnv
         : resolveTuiAgentLaunchEnv(record.agent, state.settings?.agentDefaultEnv),
     ...(launchConfig?.agentCommand ? { agentCommand: launchConfig.agentCommand } : {}),
+    ...(launchConfig?.windowsCodexShellHandoff === true ? { windowsCodexShellHandoff: true } : {}),
     platform: getResumeLaunchPlatform(record.worktreeId)
   })
   if (!startupPlan) {

--- a/src/renderer/src/store/slices/agent-status-quit-capture.test.ts
+++ b/src/renderer/src/store/slices/agent-status-quit-capture.test.ts
@@ -123,7 +123,8 @@ describe('captureAllSleepingAgentSessions', () => {
     const launchConfig = {
       agentCommand: "codex '--model' 'gpt-5'",
       agentArgs: '--model gpt-5',
-      agentEnv: { CODEX_PROFILE: 'captured' }
+      agentEnv: { CODEX_PROFILE: 'captured' },
+      windowsCodexShellHandoff: true as const
     }
     const providerSession = { key: 'session_id' as const, id: 'codex-session-1' }
 

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -706,7 +706,8 @@ function copyLaunchConfig(config: SleepingAgentLaunchConfig): SleepingAgentLaunc
   return {
     ...(config.agentCommand ? { agentCommand: config.agentCommand } : {}),
     agentArgs: config.agentArgs,
-    agentEnv: { ...config.agentEnv }
+    agentEnv: { ...config.agentEnv },
+    ...(config.windowsCodexShellHandoff === true ? { windowsCodexShellHandoff: true } : {})
   }
 }
 
@@ -717,7 +718,11 @@ function launchConfigsEqual(
   if (a === undefined || b === undefined) {
     return a === b
   }
-  if (a.agentCommand !== b.agentCommand || a.agentArgs !== b.agentArgs) {
+  if (
+    a.agentCommand !== b.agentCommand ||
+    a.agentArgs !== b.agentArgs ||
+    a.windowsCodexShellHandoff !== b.windowsCodexShellHandoff
+  ) {
     return false
   }
   const aKeys = Object.keys(a.agentEnv)

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -33,6 +33,7 @@ export type SleepingAgentLaunchConfig = {
   agentCommand?: string
   agentArgs: string
   agentEnv: Record<string, string>
+  windowsCodexShellHandoff?: true
 }
 
 export type SleepingAgentSessionRecord = {

--- a/src/shared/sleeping-agent-launch-config.ts
+++ b/src/shared/sleeping-agent-launch-config.ts
@@ -4,12 +4,14 @@ export function buildSleepingAgentLaunchConfig(args: {
   agentCommand?: string | null
   agentArgs?: string | null
   agentEnv?: Record<string, string> | null
+  windowsCodexShellHandoff?: true
 }): SleepingAgentLaunchConfig {
   return {
     ...(args.agentCommand?.trim() ? { agentCommand: args.agentCommand } : {}),
     agentArgs: args.agentArgs ?? '',
     // Why: startup env may include prompt transport or pane identity values;
     // durable resume state is limited to Orca-managed agent inputs.
-    agentEnv: args.agentEnv ? { ...args.agentEnv } : {}
+    agentEnv: args.agentEnv ? { ...args.agentEnv } : {},
+    ...(args.windowsCodexShellHandoff === true ? { windowsCodexShellHandoff: true } : {})
   }
 }

--- a/src/shared/tui-agent-base-command.ts
+++ b/src/shared/tui-agent-base-command.ts
@@ -1,0 +1,30 @@
+import { planAgentCliArgsSuffix, type AgentStartupShell } from './tui-agent-startup-shell'
+import { getTuiAgentLaunchCommand, TUI_AGENT_CONFIG } from './tui-agent-config'
+import type { TuiAgent } from './types'
+
+export function resolveTuiAgentBaseCommand(args: {
+  agent: TuiAgent
+  cmdOverrides: Partial<Record<TuiAgent, string>>
+  platform: NodeJS.Platform
+  shell: AgentStartupShell
+  agentArgs?: string | null
+  isRemote?: boolean
+}): { ok: true; command: string; usesDefaultCommand: boolean } | { ok: false; error: string } {
+  const override = args.cmdOverrides[args.agent]
+  const command =
+    override ||
+    getTuiAgentLaunchCommand(TUI_AGENT_CONFIG[args.agent], args.platform, {
+      isRemote: args.isRemote
+    })
+  const suffix = planAgentCliArgsSuffix(args.agentArgs, args.shell)
+  if (!suffix.ok) {
+    return suffix
+  }
+  // Why: Codex status hooks live in Orca's runtime CODEX_HOME; adding
+  // --profile-v2 makes Codex load a second hook representation and warn.
+  return {
+    ok: true,
+    command: suffix.suffix ? `${command} ${suffix.suffix}` : command,
+    usesDefaultCommand: !override
+  }
+}

--- a/src/shared/tui-agent-launch-provenance.ts
+++ b/src/shared/tui-agent-launch-provenance.ts
@@ -1,0 +1,30 @@
+import type { SleepingAgentLaunchConfig } from './agent-session-resume'
+import { buildSleepingAgentLaunchConfig } from './sleeping-agent-launch-config'
+import type { AgentStartupShell } from './tui-agent-startup-shell'
+import type { TuiAgent } from './types'
+
+export function buildTuiAgentLaunchConfig(args: {
+  agent: TuiAgent
+  platform: NodeJS.Platform
+  shell: AgentStartupShell
+  isRemote?: boolean
+  usesDefaultCommand: boolean
+  agentCommand?: string | null
+  agentArgs?: string | null
+  agentEnv?: Record<string, string> | null
+}): SleepingAgentLaunchConfig {
+  // Why: argv handoff may reinterpret only Orca's stock local Codex launch;
+  // custom commands and remote shells must retain their existing semantics.
+  const useWindowsCodexShellHandoff =
+    args.agent === 'codex' &&
+    args.platform === 'win32' &&
+    args.shell === 'powershell' &&
+    args.isRemote !== true &&
+    args.usesDefaultCommand
+  return buildSleepingAgentLaunchConfig({
+    agentCommand: args.agentCommand,
+    agentArgs: args.agentArgs,
+    agentEnv: args.agentEnv,
+    ...(useWindowsCodexShellHandoff ? { windowsCodexShellHandoff: true } : {})
+  })
+}

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -438,7 +438,8 @@ describe('tui agent startup plans', () => {
       platform: 'win32'
     })
 
-    expect(plan?.launchConfig.windowsCodexShellHandoff).toBeUndefined()
+    expect(plan).not.toBeNull()
+    expect(plan!.launchConfig.windowsCodexShellHandoff).toBeUndefined()
   })
 
   it.each([
@@ -460,7 +461,8 @@ describe('tui agent startup plans', () => {
       isRemote
     })
 
-    expect(plan?.launchConfig.windowsCodexShellHandoff).toBeUndefined()
+    expect(plan).not.toBeNull()
+    expect(plan!.launchConfig.windowsCodexShellHandoff).toBeUndefined()
   })
 
   it('keeps plain empty Codex startup on the fast delivery path', () => {

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -419,6 +419,50 @@ describe('tui agent startup plans', () => {
     expect(plan?.startupCommandDelivery).toBe('shell-ready')
   })
 
+  it('marks stock local Windows PowerShell Codex launches for the native handoff', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'codex',
+      prompt: 'fix it',
+      cmdOverrides: {},
+      platform: 'win32'
+    })
+
+    expect(plan?.launchConfig.windowsCodexShellHandoff).toBe(true)
+  })
+
+  it('does not mark an exact-looking custom Codex command override', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'codex',
+      prompt: 'fix it',
+      cmdOverrides: { codex: 'codex' },
+      platform: 'win32'
+    })
+
+    expect(plan?.launchConfig.windowsCodexShellHandoff).toBeUndefined()
+  })
+
+  it.each([
+    { name: 'cmd', platform: 'win32' as const, shell: 'cmd' as const, isRemote: false },
+    {
+      name: 'remote PowerShell',
+      platform: 'win32' as const,
+      shell: 'powershell' as const,
+      isRemote: true
+    },
+    { name: 'non-Windows', platform: 'linux' as const, shell: 'posix' as const, isRemote: false }
+  ])('does not mark stock Codex on $name', ({ platform, shell, isRemote }) => {
+    const plan = buildAgentStartupPlan({
+      agent: 'codex',
+      prompt: 'fix it',
+      cmdOverrides: {},
+      platform,
+      shell,
+      isRemote
+    })
+
+    expect(plan?.launchConfig.windowsCodexShellHandoff).toBeUndefined()
+  })
+
   it('keeps plain empty Codex startup on the fast delivery path', () => {
     const plan = buildAgentStartupPlan({
       agent: 'codex',
@@ -618,6 +662,24 @@ describe('tui agent startup plans', () => {
       agentCommand: 'codex --profile captured',
       agentArgs: '',
       agentEnv: {}
+    })
+  })
+
+  it('preserves a captured Windows Codex handoff marker when resuming', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'codex',
+      providerSession: { key: 'session_id', id: 's1' },
+      cmdOverrides: { codex: 'codex --profile changed' },
+      agentCommand: 'codex',
+      windowsCodexShellHandoff: true,
+      platform: 'win32'
+    })
+
+    expect(plan?.launchConfig).toEqual({
+      agentCommand: 'codex',
+      agentArgs: '',
+      agentEnv: {},
+      windowsCodexShellHandoff: true
     })
   })
 

--- a/src/shared/tui-agent-startup.ts
+++ b/src/shared/tui-agent-startup.ts
@@ -8,17 +8,17 @@ import {
 import {
   clearEnvCommand,
   commandSeparator,
-  planAgentCliArgsSuffix,
   quoteStartupArg,
   resolveStartupShell,
   type AgentStartupShell
 } from './tui-agent-startup-shell'
-import { getTuiAgentLaunchCommand, TUI_AGENT_CONFIG } from './tui-agent-config'
+import { TUI_AGENT_CONFIG } from './tui-agent-config'
 import type { StartupCommandDelivery } from './codex-startup-delivery'
-import { buildSleepingAgentLaunchConfig } from './sleeping-agent-launch-config'
+import { buildTuiAgentLaunchConfig } from './tui-agent-launch-provenance'
 import { planHermesStartupQuery } from './hermes-startup-query'
 import { inlineAgentDraftFitsPlatform } from './agent-draft-platform-limit'
 import type { TuiAgent } from './types'
+import { resolveTuiAgentBaseCommand } from './tui-agent-base-command'
 
 export type AgentStartupPlan = {
   agent: TuiAgent
@@ -30,29 +30,6 @@ export type AgentStartupPlan = {
   draftPrompt?: string | null
   env?: Record<string, string>
   startupCommandDelivery?: StartupCommandDelivery
-}
-
-function resolveBaseCommand(args: {
-  agent: TuiAgent
-  cmdOverrides: Partial<Record<TuiAgent, string>>
-  platform: NodeJS.Platform
-  shell: AgentStartupShell
-  agentArgs?: string | null
-  isRemote?: boolean
-}): { ok: true; command: string } | { ok: false; error: string } {
-  const override = args.cmdOverrides[args.agent]
-  const command =
-    override ||
-    getTuiAgentLaunchCommand(TUI_AGENT_CONFIG[args.agent], args.platform, {
-      isRemote: args.isRemote
-    })
-  const suffix = planAgentCliArgsSuffix(args.agentArgs, args.shell)
-  if (!suffix.ok) {
-    return suffix
-  }
-  // Why: Codex status hooks live in Orca's runtime CODEX_HOME; adding
-  // --profile-v2 makes Codex load a second hook representation and warn.
-  return { ok: true, command: suffix.suffix ? `${command} ${suffix.suffix}` : command }
 }
 
 export function buildAgentStartupPlan(args: {
@@ -73,7 +50,7 @@ export function buildAgentStartupPlan(args: {
   const trimmedPrompt = prompt.trim()
   const config = TUI_AGENT_CONFIG[agent]
   const usesQuery = config.promptInjectionMode === 'hermes-query' && Boolean(trimmedPrompt)
-  const baseCommand = resolveBaseCommand({
+  const baseCommand = resolveTuiAgentBaseCommand({
     agent,
     cmdOverrides,
     platform,
@@ -84,9 +61,11 @@ export function buildAgentStartupPlan(args: {
   if (!baseCommand.ok) {
     return null
   }
-  const launchConfig = buildSleepingAgentLaunchConfig({
+  const launchConfig = buildTuiAgentLaunchConfig({
     ...args,
-    agentCommand: baseCommand.command
+    shell,
+    agentCommand: baseCommand.command,
+    usesDefaultCommand: baseCommand.usesDefaultCommand
   })
 
   if (!trimmedPrompt) {
@@ -195,6 +174,7 @@ export function buildAgentResumeStartupPlan(args: {
   agentArgs?: string | null
   agentEnv?: Record<string, string> | null
   agentCommand?: string | null
+  windowsCodexShellHandoff?: true
   /** Why: see buildAgentStartupPlan — remote launches use the plain `orca` shim. */
   isRemote?: boolean
 }): AgentStartupPlan | null {
@@ -206,8 +186,12 @@ export function buildAgentResumeStartupPlan(args: {
   const config = TUI_AGENT_CONFIG[args.agent]
   const resolvedAgentCommand = args.agentCommand?.trim()
   const baseCommand = resolvedAgentCommand
-    ? ({ ok: true, command: resolvedAgentCommand } as const)
-    : resolveBaseCommand({
+    ? ({
+        ok: true,
+        command: resolvedAgentCommand,
+        usesDefaultCommand: args.windowsCodexShellHandoff === true
+      } as const)
+    : resolveTuiAgentBaseCommand({
         agent: args.agent,
         cmdOverrides: args.cmdOverrides,
         platform: args.platform,
@@ -218,9 +202,11 @@ export function buildAgentResumeStartupPlan(args: {
   if (!baseCommand.ok) {
     return null
   }
-  const launchConfig = buildSleepingAgentLaunchConfig({
+  const launchConfig = buildTuiAgentLaunchConfig({
     ...args,
-    agentCommand: baseCommand.command
+    shell,
+    agentCommand: baseCommand.command,
+    usesDefaultCommand: baseCommand.usesDefaultCommand
   })
   const resumeArgs = argv
     .slice(1)
@@ -264,7 +250,7 @@ export function buildAgentDraftLaunchPlan(args: {
   if (!trimmed) {
     return null
   }
-  const baseCommand = resolveBaseCommand({
+  const baseCommand = resolveTuiAgentBaseCommand({
     agent,
     cmdOverrides,
     platform,
@@ -275,9 +261,11 @@ export function buildAgentDraftLaunchPlan(args: {
   if (!baseCommand.ok) {
     return null
   }
-  const launchConfig = buildSleepingAgentLaunchConfig({
+  const launchConfig = buildTuiAgentLaunchConfig({
     ...args,
-    agentCommand: baseCommand.command
+    shell,
+    agentCommand: baseCommand.command,
+    usesDefaultCommand: baseCommand.usesDefaultCommand
   })
   let plan: AgentDraftLaunchPlan | null = null
   if (config.draftPromptFlag) {

--- a/src/shared/workspace-session-schema.sleeping-agent.test.ts
+++ b/src/shared/workspace-session-schema.sleeping-agent.test.ts
@@ -161,6 +161,43 @@ describe('parseWorkspaceSession sleeping agents', () => {
     }
   })
 
+  it('preserves the literal Windows Codex handoff provenance marker', () => {
+    const result = parseWorkspaceSession({
+      activeRepoId: null,
+      activeWorktreeId: null,
+      activeTabId: null,
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {},
+      sleepingAgentSessionsByPaneKey: {
+        'tab1:pane-1': {
+          paneKey: 'tab1:pane-1',
+          tabId: 'tab1',
+          worktreeId: 'wt',
+          agent: 'codex',
+          providerSession: { key: 'session_id', id: 'codex-session' },
+          prompt: 'continue',
+          state: 'working',
+          capturedAt: 10,
+          updatedAt: 9,
+          launchConfig: {
+            agentCommand: 'codex',
+            agentArgs: '',
+            agentEnv: {},
+            windowsCodexShellHandoff: true
+          }
+        }
+      }
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(
+        result.value.sleepingAgentSessionsByPaneKey?.['tab1:pane-1']?.launchConfig
+          ?.windowsCodexShellHandoff
+      ).toBe(true)
+    }
+  })
+
   it('drops sleeping agent launch config with NUL env values without dropping the record', () => {
     const result = parseWorkspaceSession({
       activeRepoId: null,

--- a/src/shared/workspace-session-sleeping-agents.ts
+++ b/src/shared/workspace-session-sleeping-agents.ts
@@ -57,7 +57,8 @@ const sleepingAgentLaunchEnvSchema = z.preprocess(
 const sleepingAgentLaunchConfigBaseSchema = z.object({
   agentCommand: z.string().optional(),
   agentArgs: z.string(),
-  agentEnv: sleepingAgentLaunchEnvSchema
+  agentEnv: sleepingAgentLaunchEnvSchema,
+  windowsCodexShellHandoff: z.literal(true).optional()
 })
 
 export const sleepingAgentLaunchConfigSchema = z.preprocess((raw) => {


### PR DESCRIPTION
## Summary

On stock local Windows PowerShell Codex launches, start the exact trusted native Codex binary under a lightweight ConPTY handoff host instead of retaining PowerShell plus the npm Node wrapper for the lifetime of every pane. When Codex exits, the host starts the selected PowerShell so the terminal remains usable.

The fast path is deliberately narrow and fail-closed: custom commands, remote/SSH/WSL launches, non-PowerShell shells, modified or unknown package shims/entrypoints, unresolvable native packages, malformed IPC provenance, and oversized command lines retain the established shell launch path.

Observed Windows evidence:

- Three live Orca Codex panes retained 269.1 MiB of PowerShell RSS (88.8-91.0 MiB each), in addition to their Node/Codex processes.
- A controlled five-pane surrogate benchmark reduced retained root-process RSS from 390.6-391.4 MiB to 282.6-282.7 MiB (about 108 MiB), and reduced all-ready startup from 279-500 ms to 95-98 ms (about 3-5x).

Fixes #8814

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the full Windows run was attempted but has 101 existing platform-sensitive failures outside this diff; changed-surface and lifecycle coverage below is green
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Validation on final reviewed commit `363d0a76c`:

- 14 changed test files: 782 passed, 19 platform skips
- Latest-main terminal pane-fit regression: 9 passed
- Targeted renderer-backed runtime propagation: 1 passed, 714 unrelated tests skipped
- Exact inline handoff host under real Node 14.17.6: passed through agent and restored-shell phases
- Focused daemon subprocess-contract suite: 27 passed
- Real Windows ConPTY coverage: Unicode, resize, alternate-screen ordering, Ctrl+C in both phases, shell restoration, and process-tree cleanup
- Changed-file formatting and `git diff --check`: passed
- Full build: TypeScript, relay, CLI, Electron main/preload/renderer, web verification, and native build passed

## AI Review Report

Separate adversarial reviews audited launch provenance, package/shim resolution, local/daemon parity, ConPTY lifecycle, signal handling, fallback ordering, command-length boundaries, cleanup, PATH runtime compatibility, SSH/WSL exclusions, and every changed file. Their findings were fixed and regression-tested; both implementation audits approved `d4d30acbc` with no remaining blocker. A separate exact-head audit then approved the final type-contract refactor in `363d0a76c` with no findings.

CodeRabbit first found a shutdown fallback retry race and incomplete failed-test descendant cleanup; both were fixed and their threads resolved. Its later review found reliance on Node features newer than some PATH runtimes plus two optional-chain assertions that could false-pass. The host was made backward-compatible instead of adding a context-sensitive version probe, exercised end-to-end under Node 14.17.6, and the assertions now prove the startup plan is non-null before checking provenance. These fixes are included in `d4d30acbc`. Its collapsed shared subprocess-contract nitpick was then applied and independently approved in `363d0a76c`.

Cross-platform compatibility was checked explicitly. The optimization requires Windows + local + PowerShell + stock Codex provenance. macOS, Linux, WSL, SSH, Git Bash, cmd, custom commands, keyboard behavior, labels, and unrelated Electron paths remain on their existing behavior. Shell paths use Node path utilities and daemon/local transports carry the same literal opt-in marker.

## Security Audit

- Parses only Orca's exact generated PowerShell Codex grammar before converting it to argv.
- Resolves the command with PowerShell-compatible PATH/PATHEXT precedence and recognizes only full canonical npm shims.
- Validates package names, bin metadata, realpath containment, platform package layout, and a reviewed official Codex JavaScript entrypoint hash before bypassing the npm launcher.
- Accepts only literal `true` provenance at persistence, renderer drag, RPC, IPC, and daemon boundaries.
- Keeps command-bearing asynchronous fallback PowerShell-only so `cmd.exe` cannot reinterpret prompt metacharacters; `cmd.exe` remains available only as a post-agent interactive shell fallback.
- Enforces Windows command-line size margins and falls back to existing behavior on resolution/filesystem races.
- No auth, secret, or dependency changes.

## Notes

During the native Codex phase, application-owned stock launches intentionally do not load a PowerShell profile or apply PowerShell execution-policy semantics. The selected PowerShell starts normally after Codex exits, and every custom/unverified launch keeps the previous PowerShell path.

The trusted Codex JavaScript entrypoint allowlist currently covers the reviewed `@openai/codex` 0.144.5 launcher. A changed upstream launcher safely falls back to PowerShell until its behavior is reviewed and recognized.

## ELI5

On Windows, starting Codex kept a heavy PowerShell-plus-Node wrapper running for every pane. Orca now starts the real Codex binary more directly when safe, and only falls back to PowerShell after Codex exits.
