### PR TITLE
fix(win): set UTF-8 console code page for Git Bash terminals

### DIFF
--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -2210,7 +2210,7 @@ describe('createPtySubprocess', () => {
 
     expect(spawnMock).toHaveBeenCalledWith(
       'C:\\PortableGit\\bin\\bash.exe',
-      ['-c', 'chcp.com 65001 >/dev/null 2>&1 || true; exec "$BASH" --login -i'],
+      ['-c', 'chcp.com 65001 >/dev/null 2>&1; exec "$BASH" --login -i'],
       expect.objectContaining({
         cwd: 'C:\\Users\\jin\\repo',
         env: expect.objectContaining({ CHERE_INVOKING: '1' })

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -2210,7 +2210,7 @@ describe('createPtySubprocess', () => {
 
     expect(spawnMock).toHaveBeenCalledWith(
       'C:\\PortableGit\\bin\\bash.exe',
-      ['--login', '-i'],
+      ['-c', 'chcp.com 65001 >/dev/null 2>&1 || true; exec "$BASH" --login -i'],
       expect.objectContaining({
         cwd: 'C:\\Users\\jin\\repo',
         env: expect.objectContaining({ CHERE_INVOKING: '1' })

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -6497,7 +6497,7 @@ describe('registerPtyHandlers', () => {
 
       expect(spawnMock).toHaveBeenCalledWith(
         'C:\\Program Files\\Git\\bin\\bash.exe',
-        ['--login', '-i'],
+        ['-c', 'chcp.com 65001 >/dev/null 2>&1 || true; exec "$BASH" --login -i'],
         expect.objectContaining({
           env: expect.objectContaining({ CHERE_INVOKING: '1' })
         })

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -6497,7 +6497,7 @@ describe('registerPtyHandlers', () => {
 
       expect(spawnMock).toHaveBeenCalledWith(
         'C:\\Program Files\\Git\\bin\\bash.exe',
-        ['-c', 'chcp.com 65001 >/dev/null 2>&1 || true; exec "$BASH" --login -i'],
+        ['-c', 'chcp.com 65001 >/dev/null 2>&1; exec "$BASH" --login -i'],
         expect.objectContaining({
           env: expect.objectContaining({ CHERE_INVOKING: '1' })
         })

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -936,7 +936,7 @@ describe('LocalPtyProvider', () => {
 
       expect(spawnMock).toHaveBeenCalledWith(
         'C:\\Program Files\\Git\\bin\\bash.exe',
-        ['-c', 'chcp.com 65001 >/dev/null 2>&1 || true; exec "$BASH" --login -i'],
+        ['-c', 'chcp.com 65001 >/dev/null 2>&1; exec "$BASH" --login -i'],
         expect.objectContaining({
           cwd: 'C:\\Users\\jin\\repo',
           env: expect.objectContaining({

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -936,7 +936,7 @@ describe('LocalPtyProvider', () => {
 
       expect(spawnMock).toHaveBeenCalledWith(
         'C:\\Program Files\\Git\\bin\\bash.exe',
-        ['--login', '-i'],
+        ['-c', 'chcp.com 65001 >/dev/null 2>&1 || true; exec "$BASH" --login -i'],
         expect.objectContaining({
           cwd: 'C:\\Users\\jin\\repo',
           env: expect.objectContaining({

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -214,6 +214,9 @@ describe('resolveWindowsShellLaunchArgs', () => {
     expect(bashCommand).toMatch(/exec "\$BASH" --login -i$/)
     // The UTF-8 switch must run before the login shell is exec'd.
     expect(bashCommand.indexOf('chcp.com')).toBeLessThan(bashCommand.indexOf('exec'))
+    // Must stay fail-open: `;` (not `&&`) so a missing chcp.com can't abort the
+    // exec and kill the terminal on startup.
+    expect(bashCommand).not.toContain('&&')
     expect(result.effectiveCwd).toBe('C:\\Users\\alice\\code')
     expect(result.validationCwd).toBe('C:\\Users\\alice\\code')
   })

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -205,12 +205,15 @@ describe('resolveWindowsShellLaunchArgs', () => {
 
     // Why: Git Bash inherits the ConPTY OEM code page (CP437), so a byte-writing
     // UTF-8 TUI mojibakes unless the console is switched to UTF-8 before it runs.
-    // chcp.com must precede the interactive login shell, which is then exec'd so
-    // normal `--login -i` behavior (and the shell's foreground identity) survives.
-    expect(result.shellArgs).toEqual([
-      '-c',
-      'chcp.com 65001 >/dev/null 2>&1 || true; exec "$BASH" --login -i'
-    ])
+    // Assert the contract behaviorally: chcp.com 65001 must precede the exec'd
+    // interactive login shell (which preserves `--login -i` and the shell's
+    // foreground identity), rather than pinning the exact command string.
+    expect(result.shellArgs[0]).toBe('-c')
+    const bashCommand = result.shellArgs[1]
+    expect(bashCommand).toContain('chcp.com 65001')
+    expect(bashCommand).toMatch(/exec "\$BASH" --login -i$/)
+    // The UTF-8 switch must run before the login shell is exec'd.
+    expect(bashCommand.indexOf('chcp.com')).toBeLessThan(bashCommand.indexOf('exec'))
     expect(result.effectiveCwd).toBe('C:\\Users\\alice\\code')
     expect(result.validationCwd).toBe('C:\\Users\\alice\\code')
   })

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -196,14 +196,21 @@ describe('resolveWindowsShellLaunchArgs', () => {
     ])
   })
 
-  it('starts Git Bash as an interactive login shell without changing cwd', () => {
+  it('starts Git Bash as an interactive login shell with UTF-8 console setup', () => {
     const result = resolveWindowsShellLaunchArgs(
       'C:\\Program Files\\Git\\bin\\bash.exe',
       'C:\\Users\\alice\\code',
       'C:\\Users\\alice'
     )
 
-    expect(result.shellArgs).toEqual(['--login', '-i'])
+    // Why: Git Bash inherits the ConPTY OEM code page (CP437), so a byte-writing
+    // UTF-8 TUI mojibakes unless the console is switched to UTF-8 before it runs.
+    // chcp.com must precede the interactive login shell, which is then exec'd so
+    // normal `--login -i` behavior (and the shell's foreground identity) survives.
+    expect(result.shellArgs).toEqual([
+      '-c',
+      'chcp.com 65001 >/dev/null 2>&1 || true; exec "$BASH" --login -i'
+    ])
     expect(result.effectiveCwd).toBe('C:\\Users\\alice\\code')
     expect(result.validationCwd).toBe('C:\\Users\\alice\\code')
   })

--- a/src/main/providers/windows-shell-args.ts
+++ b/src/main/providers/windows-shell-args.ts
@@ -21,12 +21,14 @@ const CMD_UTF8_SETUP_COMMAND = 'chcp 65001 > nul'
 // agents write UTF-8 straight to the console via WriteFile, not WriteConsoleW —
 // then has its output decoded as CP437 and rendered as mojibake (`❯` -> `Γ¥»`,
 // `José` -> `Jos├¬`). Set the console output CP to UTF-8 first, then exec the
-// real interactive login shell so normal `--login -i` behavior is preserved.
-// PowerShell (`[Console]::OutputEncoding`) and cmd.exe (`chcp 65001`) already do
-// the equivalent; this closes the same gap for Git Bash. `|| true` plus the
-// redirect keep terminal startup working if chcp.com is ever unavailable.
+// real interactive login shell so normal `--login -i` behavior is preserved
+// ($BASH is the bash binary running the -c command, so the exec'd shell is the
+// same one node-pty spawned). PowerShell (`[Console]::OutputEncoding`) and
+// cmd.exe (`chcp 65001`) already do the equivalent; this closes the same gap
+// for Git Bash. The `;` (not `&&`) plus bash -c having no `set -e` means the
+// exec runs even if chcp.com is missing, so terminal startup can't be broken.
 const GIT_BASH_UTF8_LOGIN_COMMAND =
-  'chcp.com 65001 >/dev/null 2>&1 || true; exec "$BASH" --login -i'
+  'chcp.com 65001 >/dev/null 2>&1; exec "$BASH" --login -i'
 
 /** Result of resolving a Windows shell to its launch args + effective cwd.
  *

--- a/src/main/providers/windows-shell-args.ts
+++ b/src/main/providers/windows-shell-args.ts
@@ -16,17 +16,12 @@ const CMD_EXE_COMMAND_LINE_MAX_CHARS = 8191
 const STARTUP_COMMAND_TEXT_MAX_CHARS = 6000
 const POWERSHELL_ENCODED_COMMAND_ARG_MAX_CHARS = 28_000
 const CMD_UTF8_SETUP_COMMAND = 'chcp 65001 > nul'
-// Why: Git for Windows' bash inherits the ConPTY console's OEM output code page
-// (e.g. CP437). A byte-writing TUI launched inside it — Claude Code and other
-// agents write UTF-8 straight to the console via WriteFile, not WriteConsoleW —
-// then has its output decoded as CP437 and rendered as mojibake (`❯` -> `Γ¥»`,
-// `José` -> `Jos├¬`). Set the console output CP to UTF-8 first, then exec the
-// real interactive login shell so normal `--login -i` behavior is preserved
-// ($BASH is the bash binary running the -c command, so the exec'd shell is the
-// same one node-pty spawned). PowerShell (`[Console]::OutputEncoding`) and
-// cmd.exe (`chcp 65001`) already do the equivalent; this closes the same gap
-// for Git Bash. The `;` (not `&&`) plus bash -c having no `set -e` means the
-// exec runs even if chcp.com is missing, so terminal startup can't be broken.
+// Why: Git for Windows' bash inherits the ConPTY console's OEM code page
+// (CP437), so a TUI that writes UTF-8 bytes straight to the console — agents
+// like Claude Code use WriteFile, not WriteConsoleW — renders as mojibake
+// (`❯` -> `Γ¥»`). Switch the console to UTF-8, then exec the normal interactive
+// login shell; cmd.exe and PowerShell already do the equivalent. The `;` (not
+// `&&`) keeps startup working even if chcp.com is missing.
 const GIT_BASH_UTF8_LOGIN_COMMAND =
   'chcp.com 65001 >/dev/null 2>&1; exec "$BASH" --login -i'
 

--- a/src/main/providers/windows-shell-args.ts
+++ b/src/main/providers/windows-shell-args.ts
@@ -16,6 +16,17 @@ const CMD_EXE_COMMAND_LINE_MAX_CHARS = 8191
 const STARTUP_COMMAND_TEXT_MAX_CHARS = 6000
 const POWERSHELL_ENCODED_COMMAND_ARG_MAX_CHARS = 28_000
 const CMD_UTF8_SETUP_COMMAND = 'chcp 65001 > nul'
+// Why: Git for Windows' bash inherits the ConPTY console's OEM output code page
+// (e.g. CP437). A byte-writing TUI launched inside it — Claude Code and other
+// agents write UTF-8 straight to the console via WriteFile, not WriteConsoleW —
+// then has its output decoded as CP437 and rendered as mojibake (`❯` -> `Γ¥»`,
+// `José` -> `Jos├¬`). Set the console output CP to UTF-8 first, then exec the
+// real interactive login shell so normal `--login -i` behavior is preserved.
+// PowerShell (`[Console]::OutputEncoding`) and cmd.exe (`chcp 65001`) already do
+// the equivalent; this closes the same gap for Git Bash. `|| true` plus the
+// redirect keep terminal startup working if chcp.com is ever unavailable.
+const GIT_BASH_UTF8_LOGIN_COMMAND =
+  'chcp.com 65001 >/dev/null 2>&1 || true; exec "$BASH" --login -i'
 
 /** Result of resolving a Windows shell to its launch args + effective cwd.
  *
@@ -176,7 +187,7 @@ export function resolveWindowsShellLaunchArgs(
 
   if (isWindowsGitBashShellPath(shellPath)) {
     return {
-      shellArgs: ['--login', '-i'],
+      shellArgs: ['-c', GIT_BASH_UTF8_LOGIN_COMMAND],
       effectiveCwd: nativeCwd,
       validationCwd: nativeCwd
     }


### PR DESCRIPTION
## Symptom

UTF-8 output rendered as **CP437 mojibake** in Windows terminals — e.g. Claude Code's prompt glyph `❯` (UTF-8 `E2 9D AF`) shows as `Γ¥»`, box-drawing `─`→`ΓöÇ`, `•`→`ΓÇó`.

## Root cause

Under ConPTY, a process that writes **raw UTF-8 bytes** to the console (`WriteFile` / `fs.writeSync` — the path Ink/Claude Code and many agent TUIs use, as opposed to `WriteConsoleW`) has those bytes decoded against the **console output code page**. `CreatePseudoConsole` starts a pseudoconsole at the system OEM code page (437 on US Windows) and does **not** inherit the creator's code page, so the console must be switched to UTF-8 (65001) *inside* the launched shell before the byte-writing child runs.

Orca already does this for two of its native-Windows shells:
- **cmd.exe** → `/K chcp 65001`
- **PowerShell / pwsh** → `[Console]::OutputEncoding = UTF8` in the `-EncodedCommand` bootstrap

**Git Bash was the gap** — it launched with `['--login', '-i']` and no code-page setup, so the console stayed at 437 and byte-writing agents mojibaked.

## Fix

Launch Git Bash as `bash -c 'chcp.com 65001 >/dev/null 2>&1; exec "$BASH" --login -i'`:
- `chcp.com 65001` switches the ConPTY console to UTF-8 (this *sticks* — unlike PowerShell, bash doesn't reset it).
- `exec "$BASH" --login -i` replaces the process in-place with the same bash binary (`$BASH` is set by bash itself) as a normal interactive login shell, so cwd (`CHERE_INVOKING`), foreground-process identity, stdin startup-command delivery, and teardown are all unchanged.
- `;` (not `&&`) plus `bash -c` having no `set -e` means the `exec` runs even if `chcp.com` is missing — startup can't be broken.

## Verification

Reproduced and fixed with a node-pty harness driving a byte-writing UTF-8 child:

| Launch | Child console CP | Render |
|---|---|---|
| `bash --login -i` (before) | 437 | `Γ¥»` mojibake ❌ |
| `bash -c 'chcp.com 65001; exec "$BASH" --login -i'` (after) | 65001 | `❯` correct ✅ |

Confirmed in the same harness that PowerShell (`[Console]::OutputEncoding`), cmd.exe (`chcp 65001`), and real `claude.exe` (which uses `WriteConsoleW`, code-page-independent) all already render correctly. Reviewed adversarially (3 rounds) + a performance pass: no correctness, portability, or perf concerns; the `exec` adds nothing to the steady-state process tree.

## Scope — read before closing any issue

- This closes the Git Bash gap only. It is **deliberately scoped**: the daemon/scrollback/reattach data path is UTF-8-clean end-to-end and cannot cause or fix source-side mojibake; PowerShell/cmd already set UTF-8; and real byte-writer-immune agents like `claude.exe` render correctly on all shells.
- **This does NOT fix mojibake seen in a PowerShell session.** The PowerShell agent launch provably runs *after* the encoding bootstrap (no race), so a garbled PowerShell/Claude session is a separate, unreproduced issue and should not be closed by this PR.
- A possible follow-up: the PowerShell bootstrap's encoding block sits behind a `LanguageMode -ne "FullLanguage"` early-return, so ConstrainedLanguage (WDAC/AppLocker) machines skip it — a real but separate hardening, out of scope here.
- The generic "unknown/other shell" branch (`shellArgs: []`) still applies no code-page setup — no safe generic injection exists.

## Tests

Behavioral assertion for the Git Bash launch contract in `windows-shell-args.test.ts`, plus updated literal expectations in `pty.test.ts`, `pty-subprocess.test.ts`, `local-pty-provider.test.ts`.