### PR TITLE
fix(terminal): stop leaking Orca's NODE_ENV into spawned shells

### DIFF
--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -181,6 +181,52 @@ describe('PtyHandler', () => {
     expect(handler.activePtyCount).toBe(1)
   })
 
+  it("does not forward Orca's own NODE_ENV into the spawned shell", async () => {
+    // Why: Orca's process carries NODE_ENV (`development` in dev/electron-dev
+    // builds). Forwarding it into integrated terminals breaks tools that key
+    // off NODE_ENV (e.g. `next build` / Vitest). It must be stripped from the
+    // inherited env; other inherited vars (PATH) must survive.
+    const original = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
+    try {
+      await dispatcher.callRequest('pty.spawn', { cols: 80, rows: 24 })
+
+      const spawnOptions = mockPtySpawn.mock.calls[0][2] as { env: Record<string, string> }
+      expect(spawnOptions.env).not.toHaveProperty('NODE_ENV')
+      expect(spawnOptions.env.PATH).toBe(process.env.PATH)
+    } finally {
+      if (original === undefined) {
+        delete process.env.NODE_ENV
+      } else {
+        process.env.NODE_ENV = original
+      }
+    }
+  })
+
+  it('lets a renderer-supplied NODE_ENV through (only the ambient Orca value is stripped)', async () => {
+    // Why: stripping targets the *inherited* process env, not an explicit
+    // caller request. A shell profile or startup plan that deliberately sets
+    // NODE_ENV must still win.
+    const original = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
+    try {
+      await dispatcher.callRequest('pty.spawn', {
+        cols: 80,
+        rows: 24,
+        env: { NODE_ENV: 'test' }
+      })
+
+      const spawnOptions = mockPtySpawn.mock.calls[0][2] as { env: Record<string, string> }
+      expect(spawnOptions.env.NODE_ENV).toBe('test')
+    } finally {
+      if (original === undefined) {
+        delete process.env.NODE_ENV
+      } else {
+        process.env.NODE_ENV = original
+      }
+    }
+  })
+
   it('atomically caps concurrent PTY spawn admission', async () => {
     const results = await Promise.allSettled(
       Array.from({ length: MAX_RELAY_PTY_SESSIONS + 1 }, () =>

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -376,9 +376,21 @@ export class PtyHandler {
     ctx: { id: string; paneKey?: string; shell: string; command?: string },
     envToDelete: readonly string[] = []
   ): Record<string, string> {
+    // Why: Orca's own process carries NODE_ENV (`development` in local dev /
+    // electron-dev builds). That's *Orca's* build mode, not the user's — and
+    // forwarding it into integrated terminals breaks any tool that keys off
+    // NODE_ENV. For example a Next.js app's `next build` expects to set
+    // `production` itself (a pre-set `development` yields a dev/prod React
+    // mismatch that crashes prerender), and Vitest only defaults NODE_ENV to
+    // `test` when it's unset (so a leaked `development` silently changes
+    // test-only branches). Strip it here so the login shell's profile or the
+    // invoked tool decides; anything the user genuinely wants can still be
+    // re-exported from their shell rc, rendererEnv, or an augmenter below.
+    const inheritedEnv: NodeJS.ProcessEnv = { ...process.env }
+    delete inheritedEnv.NODE_ENV
     const baseEnv = mergeGitConfigEnvProtocol(
       {
-        ...process.env,
+        ...inheritedEnv,
         TERM: 'xterm-256color',
         COLORTERM: 'truecolor',
         TERM_PROGRAM: 'Orca',


### PR DESCRIPTION
Closes #9057.

## Summary

Orca's relay built the environment for every integrated terminal by spreading the whole `process.env` (`src/relay/pty-handler.ts` → `buildSpawnEnv`). When Orca's own process carries `NODE_ENV` — as it does in local dev / `electron-dev` builds, where electron-vite sets `NODE_ENV=development` — that value was forwarded into every spawned shell, so every command in an Orca terminal saw `NODE_ENV=development`.

That's Orca's build mode, not the user's, and it silently breaks tools that key off `NODE_ENV`:

- **Next.js** — `next build` expects to set `production` itself; a pre-set `development` crashes static prerender with a dev/prod React mismatch (`Cannot read properties of null (reading 'useContext')`).
- **Vitest** — only defaults `NODE_ENV` to `test` when unset; a leaked `development` changes test-only branches (e.g. `next/image` host validation), so suites fail in an Orca terminal while passing on CI.

This strips `NODE_ENV` from the **inherited** environment before assembling the spawn env. A deliberately-set value still wins — from the login shell's profile, a renderer-supplied `env`, or an env augmenter — so only the ambient Orca build-mode value is dropped.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — ran `oxlint` on the changed files (clean); the pre-commit hook also ran `oxlint` + `oxfmt`. Did not run the full aggregate `lint` script locally.
- [x] `pnpm typecheck` — clean for the changed files. (Two unrelated pre-existing errors in this checkout — `Cannot find module 'typescript-api'` in two other test files — appear regardless of this change.)
- [x] `pnpm test` — `vitest run src/relay/pty-handler.test.ts` → **97 passed**, including 2 new cases. Did not run the full suite locally.
- [ ] `pnpm build` — not run locally (multi-platform desktop build); relying on CI.
- [x] Added high-quality tests that would catch a regression: one asserts the spawn env drops an ambient `NODE_ENV` while keeping other inherited vars (`PATH`); another asserts a renderer-supplied `NODE_ENV` still passes through.

## AI Review Report

Reviewed by the AI coding agent that wrote the change:

- **Cross-platform (macOS/Linux/Windows):** the change is in the relay's env assembly with no platform branches — it applies identically on all three. No shortcuts, labels, or path handling touched.
- **Local / remote / SSH:** `buildSpawnEnv` feeds both the local and SSH relay spawn paths, so the strip applies uniformly. Verified the renderer-supplied `env` is curated (specific vars, not a blanket `process.env` spread), so it won't silently re-introduce `NODE_ENV` — and if a startup plan sets it deliberately, it still wins.
- **Agents / integrations:** no agent- or provider-specific logic touched. Terminals previously saw `development`; they now see the shell/tool default, which is the correct baseline for CLI agents.
- **Performance:** negligible — one shallow object copy + a `delete`, on a path that already spread `process.env`. Not a hot path.
- **UI:** none.

## Security Audit

- No new input handling, command execution, path handling, auth, or IPC surface. The change **removes** an environment variable from what child processes inherit; it does not add or widen anything. No secrets involved (`NODE_ENV` is a build-mode flag). Net effect is slightly less ambient state leaking into spawned shells.

## Notes

Platform-agnostic; affects local and SSH relays equally. No follow-up required. Discovered while running project test/build commands inside an Orca terminal.

X: @debay