### PR TITLE
test(e2e): harden terminal restart regressions on Windows

### DIFF
--- a/.github/workflows/windows-terminal-restart-e2e.yml
+++ b/.github/workflows/windows-terminal-restart-e2e.yml
@@ -84,8 +84,10 @@ jobs:
           SKIP_BUILD: '1'
           ORCA_E2E_FORWARD_APP_LOGS: '1'
           ORCA_REQUIRE_WINDOWS_TERMINAL_RESTART_E2E: '1'
+        # Why: pnpm forwards a literal `--` to Playwright, which makes the
+        # grep and worker flags positional filters instead of CLI options.
         run: >-
-          pnpm run test:e2e --
+          pnpm run test:e2e
           tests/e2e/restart-restore-terminal-input.spec.ts
           tests/e2e/terminal-restart-persistence.spec.ts
           --grep "clean restart with a live daemon session|cold-restored pane accepts typing|daemon snapshot relaunch preserves"

--- a/.github/workflows/windows-terminal-restart-e2e.yml
+++ b/.github/workflows/windows-terminal-restart-e2e.yml
@@ -1,0 +1,101 @@
+name: Windows terminal restart E2E
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - '.github/workflows/windows-terminal-restart-e2e.yml'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'electron.vite.config.ts'
+      - 'config/patches/**'
+      - 'config/scripts/ensure-native-runtime.mjs'
+      - 'config/scripts/rebuild-native-deps.mjs'
+      - 'tests/playwright.config.ts'
+      - 'tests/e2e/global-setup.ts'
+      - 'tests/e2e/global-teardown.ts'
+      - 'tests/e2e/helpers/**'
+      - 'tests/e2e/restart-restore-terminal-input.spec.ts'
+      - 'tests/e2e/restored-terminal-input-readiness.unit.test.ts'
+      - 'tests/e2e/terminal-probe-input-sequence.ts'
+      - 'tests/e2e/terminal-probe-input-sequence.unit.test.ts'
+      - 'tests/e2e/terminal-restart-persistence.spec.ts'
+      - 'src/main/daemon/**'
+      - 'src/main/ipc/pty*.ts'
+      - 'src/main/providers/**'
+      - 'src/main/pty/**'
+      - 'src/preload/**'
+      - 'src/renderer/src/components/terminal-pane/**'
+      - 'src/renderer/src/lib/pane-manager/**'
+      - 'src/shared/pty-session-id-format.ts'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Ref to check out
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-terminal-restart-e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows-terminal-restart:
+    name: Windows terminal restart regressions
+    runs-on: windows-2022
+    timeout-minutes: 30
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
+
+      # Why: pnpm must exist before setup-node resolves its dependency cache.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Electron app for Windows E2E
+        run: pnpm exec electron-vite build --mode e2e
+
+      - name: Run Windows terminal restart regressions
+        env:
+          SKIP_BUILD: '1'
+          ORCA_E2E_FORWARD_APP_LOGS: '1'
+          ORCA_REQUIRE_WINDOWS_TERMINAL_RESTART_E2E: '1'
+        run: >-
+          pnpm run test:e2e --
+          tests/e2e/restart-restore-terminal-input.spec.ts
+          tests/e2e/terminal-restart-persistence.spec.ts
+          --grep "clean restart with a live daemon session|cold-restored pane accepts typing|daemon snapshot relaunch preserves"
+          --workers=1
+
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-terminal-restart-playwright-traces
+          path: test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/tests/e2e/helpers/restored-terminal-input-readiness.ts
+++ b/tests/e2e/helpers/restored-terminal-input-readiness.ts
@@ -1,0 +1,80 @@
+import { randomUUID } from 'node:crypto'
+import type { Page } from '@stablyai/playwright-test'
+import { buildFreshShellProbeInputSequence } from '../terminal-probe-input-sequence'
+
+type ReadinessAttempt = {
+  marker: string
+  paneInstanceId: string
+}
+
+export async function waitForRestoredTerminalInputReady(
+  page: Page,
+  expectedPtyId: string,
+  timeoutMs = 15_000
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  // Why: ConPTY echo can lag behind the poll interval, so retain every marker
+  // sent to the current concrete pane instead of chasing only the newest one.
+  let pendingAttempts: readonly ReadinessAttempt[] = []
+
+  while (Date.now() < deadline) {
+    const marker = `ORCA_RESTORED_INPUT_READY_${randomUUID().replaceAll('-', '')}`
+    const [input] = buildFreshShellProbeInputSequence(`echo ${marker}\r`)
+    if (!input) {
+      return false
+    }
+    try {
+      const result = await page.evaluate(
+        ({ expectedPtyId, input, pendingAttempts }) => {
+          for (const manager of window.__paneManagers?.values() ?? []) {
+            const pane = manager.getActivePane?.() ?? manager.getPanes?.()[0]
+            if (pane?.container?.dataset?.ptyId !== expectedPtyId) {
+              continue
+            }
+            const container = pane.container as HTMLElement & {
+              __orcaE2eTerminalInputReadinessInstanceId?: string
+            }
+            container.__orcaE2eTerminalInputReadinessInstanceId ??= crypto.randomUUID()
+            const paneInstanceId = container.__orcaE2eTerminalInputReadinessInstanceId
+            const output = pane.serializeAddon?.serialize?.() ?? ''
+            if (
+              pendingAttempts.some(
+                (attempt) =>
+                  attempt.paneInstanceId === paneInstanceId && output.includes(attempt.marker)
+              )
+            ) {
+              return { ready: true, paneInstanceId }
+            }
+            // Why: one input() payload is either wholly replay-suppressed or
+            // wholly forwarded, unlike character-by-character keyboard typing.
+            pane.terminal.input(input, true)
+            return { ready: false, paneInstanceId }
+          }
+          return null
+        },
+        { expectedPtyId, input, pendingAttempts }
+      )
+      if (result?.ready) {
+        return true
+      }
+      pendingAttempts = result
+        ? [
+            ...pendingAttempts.filter(
+              (attempt) => attempt.paneInstanceId === result.paneInstanceId
+            ),
+            { marker, paneInstanceId: result.paneInstanceId }
+          ]
+        : []
+    } catch {
+      // Relaunch can replace the document between polls; the next attempt
+      // resolves the current pane and binding instead of retaining stale state.
+      pendingAttempts = []
+    }
+
+    const remainingMs = deadline - Date.now()
+    if (remainingMs > 0) {
+      await page.waitForTimeout(Math.min(100, remainingMs))
+    }
+  }
+  return false
+}

--- a/tests/e2e/helpers/terminal-input-probes.ts
+++ b/tests/e2e/helpers/terminal-input-probes.ts
@@ -11,7 +11,7 @@
  *
  * Direct `window.api.pty.write` bypasses the renderer transport, so:
  *   direct dead                 → MAIN-side drop (ownership/provider routing)
- *   direct alive, transport dead → RENDERER transport unbound
+ *   direct alive, renderer dead → RENDERER input path (replay, focus, binding)
  * The ownership-rebuild probe invokes pty:listSessions, which repopulates
  * `ptyOwnership` as a side effect — input reviving after it is a smoking gun
  * for the missing-ownership drop path.
@@ -25,6 +25,7 @@
 
 import { expect, type ElectronApplication, type Page } from '@stablyai/playwright-test'
 import { sendToTerminal, waitForTerminalOutput } from './terminal'
+import { buildSettledShellProbeInputSequence } from '../terminal-probe-input-sequence'
 
 // ─── Page-based probes (healthy CDP session) ────────────────────────
 
@@ -34,9 +35,9 @@ export async function probeDirectWrite(
   marker: string,
   timeoutMs = 10_000
 ): Promise<boolean> {
-  // \x03\x15 = ETX+NAK (interrupt + kill-line) so a TUI or half-typed line on
-  // the shell doesn't swallow the probe — same trick discoverActivePtyId uses.
-  await sendToTerminal(page, ptyId, `\x03\x15echo ${marker}\r`)
+  for (const input of buildSettledShellProbeInputSequence(`echo ${marker}\r`)) {
+    await sendToTerminal(page, ptyId, input)
+  }
   try {
     await waitForTerminalOutput(page, marker, timeoutMs)
     return true
@@ -209,6 +210,7 @@ export async function mainProbeTransportPaste(
   timeoutMs = 10_000
 ): Promise<boolean> {
   try {
+    const inputs = buildSettledShellProbeInputSequence(`echo ${marker}\r`)
     const fed = await mainRendererEval<boolean>(
       electronApp,
       `(() => {
@@ -217,7 +219,9 @@ export async function mainProbeTransportPaste(
         for (const manager of managers.values()) {
           const pane = manager.getActivePane?.() ?? (manager.getPanes?.() ?? [])[0]
           if (pane?.terminal?.input) {
-            pane.terminal.input('\\x03\\x15echo ${marker}\\r', true)
+            for (const input of ${JSON.stringify(inputs)}) {
+              pane.terminal.input(input, true)
+            }
             return true
           }
         }
@@ -240,9 +244,10 @@ export async function mainProbeDirectWrite(
   timeoutMs = 10_000
 ): Promise<boolean> {
   try {
+    const inputs = buildSettledShellProbeInputSequence(`echo ${marker}\r`)
     await mainRendererEval<void>(
       electronApp,
-      `window.api.pty.write(${JSON.stringify(ptyId)}, ${JSON.stringify(`\x03\x15echo ${marker}\r`)})`
+      `for (const input of ${JSON.stringify(inputs)}) { window.api.pty.write(${JSON.stringify(ptyId)}, input) }`
     )
   } catch {
     return false
@@ -275,14 +280,20 @@ export function buildFrozenPaneReport(
     directAlive: boolean
     transportAlive: boolean
     revivedByOwnershipRebuild: boolean
+    ownershipRebuildAttempted?: boolean
+    readinessAlive?: boolean
     ptyIds: string[]
     terminalTail: string
   }
 ): string {
   return [
     `REPRODUCED frozen terminal (${context}):`,
+    ...(probes.readinessAlive === undefined
+      ? []
+      : [`  replay + transport readiness probe alive: ${probes.readinessAlive}`]),
     `  direct pty:write probe alive: ${probes.directAlive} (false ⇒ MAIN-side drop: ptyOwnership/provider)`,
-    `  transport (onData→sendInput) probe alive: ${probes.transportAlive} (false with direct alive ⇒ RENDERER transport unbound)`,
+    `  renderer input-path probe alive: ${probes.transportAlive} (false with direct alive ⇒ replay, focus, or renderer binding failure)`,
+    `  ownership rebuild attempted: ${probes.ownershipRebuildAttempted ?? true}`,
     `  revived by pty:listSessions ownership rebuild: ${probes.revivedByOwnershipRebuild}`,
     `  pane ptyIds: ${JSON.stringify(probes.ptyIds)}`,
     `  terminal tail:\n${probes.terminalTail.slice(-600)}`

--- a/tests/e2e/helpers/terminal.ts
+++ b/tests/e2e/helpers/terminal.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines -- Terminal E2E helpers share one PaneManager-backed path for PTY IO, split actions, and stable pane identity snapshots. */
 import type { Page } from '@stablyai/playwright-test'
 import { expect } from '@stablyai/playwright-test'
+import { buildFreshShellProbeInputSequence } from '../terminal-probe-input-sequence'
 
 export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
 
@@ -264,15 +265,21 @@ export async function discoverActivePtyId(page: Page): Promise<string> {
     throw new Error('discoverActivePtyId: active tab has no PTY candidates in store')
   }
 
+  const candidateInputs = candidateIds.map((_id, index) =>
+    buildFreshShellProbeInputSequence(`echo ${marker}_${index}\r`)
+  )
+
   await page.evaluate(
-    ({ marker, candidateIds }) => {
+    ({ candidateIds, candidateInputs }) => {
       // Why: daemon PTY IDs can contain path separators and shell metacharacters.
       // Echo a numeric probe index, then map it back to the opaque ID in Node.
       for (const [index, id] of candidateIds.entries()) {
-        window.api.pty.write(String(id), `\x03\x15echo ${marker}_${index}\r`)
+        for (const input of candidateInputs[index] ?? []) {
+          window.api.pty.write(String(id), input)
+        }
       }
     },
-    { marker, candidateIds }
+    { candidateIds, candidateInputs }
   )
 
   let foundPtyId: string | null = null

--- a/tests/e2e/restart-restore-terminal-input.spec.ts
+++ b/tests/e2e/restart-restore-terminal-input.spec.ts
@@ -90,7 +90,15 @@ async function terminateDaemonForColdRestart(pid: number): Promise<void> {
       }
     }
   } else {
-    process.kill(pid, 'SIGKILL')
+    try {
+      process.kill(pid, 'SIGKILL')
+    } catch (error) {
+      // Why: the daemon can self-exit between the liveness guard and this
+      // signal; tolerate ESRCH like the Windows branch re-checks liveness.
+      if ((error as NodeJS.ErrnoException).code !== 'ESRCH') {
+        throw error
+      }
+    }
   }
   await expect
     .poll(() => isProcessAlive(pid), {

--- a/tests/e2e/restart-restore-terminal-input.spec.ts
+++ b/tests/e2e/restart-restore-terminal-input.spec.ts
@@ -20,6 +20,7 @@
  *      a typeable pane
  */
 
+import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import type { ElectronApplication, Page } from '@stablyai/playwright-test'
@@ -42,8 +43,12 @@ import {
   probeKeyboardType,
   probeOwnershipRebuildRevival
 } from './helpers/terminal-input-probes'
+import { waitForRestoredTerminalInputReady } from './helpers/restored-terminal-input-readiness'
 import { PROTOCOL_VERSION } from '../../src/main/daemon/types'
 import { PTY_SESSION_ID_SEPARATOR } from '../../src/shared/pty-session-id-format'
+
+const REQUIRE_WINDOWS_TERMINAL_RESTART_E2E =
+  process.env.ORCA_REQUIRE_WINDOWS_TERMINAL_RESTART_E2E === '1'
 
 function readDaemonPid(userDataDir: string): number {
   const raw = readFileSync(
@@ -57,11 +62,53 @@ function readDaemonPid(userDataDir: string): number {
   return parsed.pid
 }
 
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ESRCH') {
+      return false
+    }
+    throw error
+  }
+}
+
+async function terminateDaemonForColdRestart(pid: number): Promise<void> {
+  if (!isProcessAlive(pid)) {
+    return
+  }
+  if (process.platform === 'win32') {
+    try {
+      execFileSync('taskkill.exe', ['/PID', String(pid), '/T', '/F'], {
+        stdio: 'pipe',
+        timeout: 10_000
+      })
+    } catch (error) {
+      if (isProcessAlive(pid)) {
+        throw error
+      }
+    }
+  } else {
+    process.kill(pid, 'SIGKILL')
+  }
+  await expect
+    .poll(() => isProcessAlive(pid), {
+      timeout: 10_000,
+      message: `daemon ${pid} remained alive after forced termination`
+    })
+    .toBe(false)
+}
+
 function seededRepoPathOrSkip(): string {
   const repoPath = existsSync(TEST_REPO_PATH_FILE)
     ? readFileSync(TEST_REPO_PATH_FILE, 'utf-8').trim()
     : ''
-  test.skip(!repoPath || !existsSync(repoPath), 'Global setup did not produce a seeded test repo')
+  const unavailable = !repoPath || !existsSync(repoPath)
+  if (unavailable && REQUIRE_WINDOWS_TERMINAL_RESTART_E2E) {
+    throw new Error('Required Windows restart E2E seeded repo is unavailable')
+  }
+  test.skip(unavailable, 'Global setup did not produce a seeded test repo')
   return repoPath
 }
 
@@ -99,18 +146,23 @@ async function settleRestoredLaunch(page: Page): Promise<void> {
  */
 async function expectRestoredPaneAcceptsInput(page: Page, context: string): Promise<void> {
   const ptyIds = await getStorePtyIds(page)
-  const kbAlive = await probeKeyboardType(page, 'KB_RESTORED_OK', 15_000)
+  const readinessAlive =
+    ptyIds.length > 0 && (await waitForRestoredTerminalInputReady(page, ptyIds[0], 15_000))
+  const kbAlive = readinessAlive && (await probeKeyboardType(page, 'KB_RESTORED_OK', 15_000))
   const directAlive =
     ptyIds.length > 0 && (await probeDirectWrite(page, ptyIds[0], 'DIRECT_RESTORED_OK', 15_000))
-  if (!kbAlive || !directAlive) {
+  if (!readinessAlive || !kbAlive || !directAlive) {
+    const ownershipRebuildAttempted = !directAlive && ptyIds.length > 0
     const revived =
-      ptyIds.length > 0 &&
+      ownershipRebuildAttempted &&
       (await probeOwnershipRebuildRevival(page, ptyIds[0], 'REVIVED_RESTORED_OK'))
     throw new Error(
       buildFrozenPaneReport(context, {
         directAlive,
         transportAlive: kbAlive,
         revivedByOwnershipRebuild: revived,
+        ownershipRebuildAttempted,
+        readinessAlive,
         ptyIds,
         terminalTail: await getTerminalContent(page)
       })
@@ -223,7 +275,6 @@ test('restored pane recovers input after the daemon un-wedges', async (// oxlint
 
 test('cold-restored pane accepts typing after the daemon died between launches', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
 {}, testInfo) => {
-  test.skip(process.platform === 'win32', 'POSIX signal semantics keep this deterministic')
   test.setTimeout(300_000)
   const repoPath = seededRepoPathOrSkip()
   const session = createRestartSession(testInfo)
@@ -240,7 +291,7 @@ test('cold-restored pane accepts typing after the daemon died between launches',
 
     // The daemon dies uncleanly between runs (crash, reboot, force-kill). The
     // persisted session now references sessions no living daemon holds.
-    process.kill(daemonPid, 'SIGKILL')
+    await terminateDaemonForColdRestart(daemonPid)
 
     const second = await session.launch()
     secondApp = second.app

--- a/tests/e2e/restored-terminal-input-readiness.unit.test.ts
+++ b/tests/e2e/restored-terminal-input-readiness.unit.test.ts
@@ -142,4 +142,69 @@ describe('restored terminal input readiness', () => {
     expect(firstInput).toHaveBeenCalledTimes(1)
     expect(replacementInput).toHaveBeenCalledTimes(1)
   })
+
+  it('discards stale attempts when document replacement rejects evaluation', async () => {
+    let activePane: TestPane
+    let replacementContent = ''
+    const replacementInput = vi.fn((data: string) => {
+      replacementContent = data
+    })
+    const replacementPane: TestPane = {
+      container: { dataset: { ptyId: 'pty-1' } },
+      serializeAddon: { serialize: () => replacementContent },
+      terminal: { input: replacementInput }
+    }
+    let originalInputCalls = 0
+    const firstInput = vi.fn((data: string) => {
+      originalInputCalls += 1
+      if (originalInputCalls === 2) {
+        replacementContent = data
+        activePane = replacementPane
+      }
+    })
+    activePane = {
+      container: { dataset: { ptyId: 'pty-1' } },
+      serializeAddon: { serialize: () => '' },
+      terminal: { input: firstInput }
+    }
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        __paneManagers: new Map([
+          [
+            'tab-1',
+            {
+              getActivePane: () => activePane,
+              getPanes: () => [activePane]
+            }
+          ]
+        ])
+      }
+    })
+
+    const pendingAttemptCounts: number[] = []
+    let evaluateCalls = 0
+    const page = {
+      evaluate: async (callback: (arg: unknown) => unknown, arg: unknown) => {
+        evaluateCalls += 1
+        pendingAttemptCounts.push(
+          (arg as { pendingAttempts: readonly unknown[] }).pendingAttempts.length
+        )
+        const result = callback(arg)
+        if (evaluateCalls === 2) {
+          throw new Error('Execution context was destroyed')
+        }
+        return result
+      },
+      waitForTimeout: async (timeoutMs: number) => {
+        await vi.advanceTimersByTimeAsync(timeoutMs)
+      }
+    } as unknown as Page
+
+    await expect(waitForRestoredTerminalInputReady(page, 'pty-1', 500)).resolves.toBe(true)
+    expect(pendingAttemptCounts).toEqual([0, 1, 0, 1])
+    expect(firstInput).toHaveBeenCalledTimes(2)
+    expect(replacementInput).toHaveBeenCalledTimes(1)
+    expect(replacementInput.mock.calls[0]?.[0]).not.toBe(firstInput.mock.calls[1]?.[0])
+  })
 })

--- a/tests/e2e/restored-terminal-input-readiness.unit.test.ts
+++ b/tests/e2e/restored-terminal-input-readiness.unit.test.ts
@@ -1,0 +1,145 @@
+import type { Page } from '@stablyai/playwright-test'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { waitForRestoredTerminalInputReady } from './helpers/restored-terminal-input-readiness'
+
+type TestPane = {
+  container: {
+    dataset: { ptyId: string }
+    __orcaE2eTerminalInputReadinessInstanceId?: string
+  }
+  serializeAddon: { serialize: () => string }
+  terminal: { input: (data: string, wasUserInput: boolean) => void }
+}
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window')
+
+function installPaneWindow(pane: TestPane): void {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      __paneManagers: new Map([
+        [
+          'tab-1',
+          {
+            getActivePane: () => pane,
+            getPanes: () => [pane]
+          }
+        ]
+      ])
+    }
+  })
+}
+
+function createPage(): Page {
+  return {
+    evaluate: async (callback: (arg: unknown) => unknown, arg: unknown) => callback(arg),
+    waitForTimeout: async (timeoutMs: number) => {
+      await vi.advanceTimersByTimeAsync(timeoutMs)
+    }
+  } as unknown as Page
+}
+
+describe('restored terminal input readiness', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    if (originalWindowDescriptor) {
+      Object.defineProperty(globalThis, 'window', originalWindowDescriptor)
+    } else {
+      Reflect.deleteProperty(globalThis, 'window')
+    }
+  })
+
+  it('retries after replay drops the first full input payload', async () => {
+    let content = ''
+    let attempts = 0
+    const input = vi.fn((data: string) => {
+      attempts += 1
+      if (attempts >= 2) {
+        content = data
+      }
+    })
+    installPaneWindow({
+      container: { dataset: { ptyId: 'pty-1' } },
+      serializeAddon: { serialize: () => content },
+      terminal: { input }
+    })
+
+    await expect(waitForRestoredTerminalInputReady(createPage(), 'pty-1', 500)).resolves.toBe(true)
+    expect(input).toHaveBeenCalledTimes(2)
+    expect(input.mock.calls.every(([, wasUserInput]) => wasUserInput === true)).toBe(true)
+  })
+
+  it('accepts a healthy PTY echo that arrives after multiple poll intervals', async () => {
+    let content = ''
+    const input = vi.fn((data: string) => {
+      setTimeout(() => {
+        content = data
+      }, 250)
+    })
+    installPaneWindow({
+      container: { dataset: { ptyId: 'pty-1' } },
+      serializeAddon: { serialize: () => content },
+      terminal: { input }
+    })
+
+    await expect(waitForRestoredTerminalInputReady(createPage(), 'pty-1', 800)).resolves.toBe(true)
+    expect(input.mock.calls.length).toBeGreaterThan(1)
+  })
+
+  it('never treats a different pane PTY as ready', async () => {
+    const input = vi.fn()
+    installPaneWindow({
+      container: { dataset: { ptyId: 'pty-other' } },
+      serializeAddon: { serialize: () => 'unrelated terminal output' },
+      terminal: { input }
+    })
+
+    await expect(waitForRestoredTerminalInputReady(createPage(), 'pty-1', 250)).resolves.toBe(false)
+    expect(input).not.toHaveBeenCalled()
+  })
+
+  it('does not accept a marker replayed into a replacement pane', async () => {
+    let activePane: TestPane
+    let replacementContent = ''
+    const replacementInput = vi.fn((data: string) => {
+      replacementContent = data
+    })
+    const replacementPane: TestPane = {
+      container: { dataset: { ptyId: 'pty-1' } },
+      serializeAddon: { serialize: () => replacementContent },
+      terminal: { input: replacementInput }
+    }
+    const firstInput = vi.fn((data: string) => {
+      replacementContent = data
+      activePane = replacementPane
+    })
+    activePane = {
+      container: { dataset: { ptyId: 'pty-1' } },
+      serializeAddon: { serialize: () => '' },
+      terminal: { input: firstInput }
+    }
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        __paneManagers: new Map([
+          [
+            'tab-1',
+            {
+              getActivePane: () => activePane,
+              getPanes: () => [activePane]
+            }
+          ]
+        ])
+      }
+    })
+
+    await expect(waitForRestoredTerminalInputReady(createPage(), 'pty-1', 500)).resolves.toBe(true)
+    expect(firstInput).toHaveBeenCalledTimes(1)
+    expect(replacementInput).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/e2e/terminal-probe-input-sequence.ts
+++ b/tests/e2e/terminal-probe-input-sequence.ts
@@ -3,3 +3,12 @@ export function buildFreshShellProbeInputSequence(command: string): readonly str
   // corrupts the following PowerShell command before the shell is ready.
   return [command]
 }
+
+export function buildSettledShellProbeInputSequence(
+  command: string,
+  platform: NodeJS.Platform = process.platform
+): readonly string[] {
+  // Why: Ctrl+U is a POSIX line-editor binding. A settled native Windows shell
+  // needs a separate Ctrl+C so ConPTY cannot join it to the command as input.
+  return platform === 'win32' ? ['\x03', command] : ['\x03\x15', command]
+}

--- a/tests/e2e/terminal-probe-input-sequence.unit.test.ts
+++ b/tests/e2e/terminal-probe-input-sequence.unit.test.ts
@@ -1,12 +1,26 @@
 import { describe, expect, it } from 'vitest'
-import { buildFreshShellProbeInputSequence } from './terminal-probe-input-sequence'
+import {
+  buildFreshShellProbeInputSequence,
+  buildSettledShellProbeInputSequence
+} from './terminal-probe-input-sequence'
+
+const command = "& 'C:\\node\\node.exe' '-e' 'console.log(1)'\r"
 
 describe('buildFreshShellProbeInputSequence', () => {
   it('does not prefix fresh shell probes with interrupt or line-kill bytes', () => {
-    const command = "& 'C:\\node\\node.exe' '-e' 'console.log(1)'\r"
-
     expect(buildFreshShellProbeInputSequence(command)).toEqual([command])
     expect(buildFreshShellProbeInputSequence(command).join('')).not.toContain('\x03')
     expect(buildFreshShellProbeInputSequence(command).join('')).not.toContain('\x15')
+  })
+})
+
+describe('buildSettledShellProbeInputSequence', () => {
+  it('resets PowerShell without sending the POSIX Ctrl+U binding', () => {
+    expect(buildSettledShellProbeInputSequence(command, 'win32')).toEqual(['\x03', command])
+    expect(buildSettledShellProbeInputSequence(command, 'win32').join('')).not.toContain('\x15')
+  })
+
+  it.each(['linux', 'darwin'] as const)('preserves the POSIX reset on %s', (platform) => {
+    expect(buildSettledShellProbeInputSequence(command, platform)).toEqual(['\x03\x15', command])
   })
 })

--- a/tests/e2e/terminal-restart-persistence.spec.ts
+++ b/tests/e2e/terminal-restart-persistence.spec.ts
@@ -48,11 +48,27 @@ import {
 import { attachRepoAndOpenTerminal, createRestartSession } from './helpers/orca-restart'
 import { PTY_SESSION_ID_SEPARATOR } from '../../src/shared/pty-session-id-format'
 
+const REQUIRE_WINDOWS_TERMINAL_RESTART_E2E =
+  process.env.ORCA_REQUIRE_WINDOWS_TERMINAL_RESTART_E2E === '1'
+const MISSING_SEEDED_REPO_MESSAGE = 'Global setup did not produce a seeded test repo'
+
 // Why: each test in this file does a full quit→relaunch cycle, which spawns
 // two Electron instances back-to-back. Running in serial keeps the isolated
 // userDataDirs from competing for the same Electron cache lock on cold start
 // and keeps the failure mode interpretable when something goes wrong.
 test.describe.configure({ mode: 'serial' })
+
+function seededRepoPathOrSkip(): string {
+  const repoPath = existsSync(TEST_REPO_PATH_FILE)
+    ? readFileSync(TEST_REPO_PATH_FILE, 'utf-8').trim()
+    : ''
+  const unavailable = !repoPath || !existsSync(repoPath)
+  if (unavailable && REQUIRE_WINDOWS_TERMINAL_RESTART_E2E) {
+    throw new Error('Required Windows restart E2E seeded repo is unavailable')
+  }
+  test.skip(unavailable, MISSING_SEEDED_REPO_MESSAGE)
+  return repoPath
+}
 
 /**
  * Shared bootstrap for a *first* launch: attach the seeded test repo,
@@ -75,6 +91,9 @@ async function bootstrapFirstLaunch(
   const hasPaneManager = await waitForActiveTerminalManager(page, 30_000)
     .then(() => true)
     .catch(() => false)
+  if (!hasPaneManager && REQUIRE_WINDOWS_TERMINAL_RESTART_E2E) {
+    throw new Error('Required Windows restart E2E TerminalPane manager did not mount')
+  }
   test.skip(
     !hasPaneManager,
     'Electron automation in this environment never mounts the TerminalPane manager, so restart-persistence assertions would only fail on harness setup.'
@@ -189,11 +208,7 @@ async function expectSavedLayoutToContainTitle(
 test.describe('Terminal restart persistence', () => {
   test('scrollback survives clean quit and relaunch', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
   {}, testInfo) => {
-    const repoPath = readFileSync(TEST_REPO_PATH_FILE, 'utf-8').trim()
-    if (!repoPath || !existsSync(repoPath)) {
-      test.skip(true, 'Global setup did not produce a seeded test repo')
-      return
-    }
+    const repoPath = seededRepoPathOrSkip()
 
     const session = createRestartSession(testInfo)
     let firstApp: ElectronApplication | null = null
@@ -249,11 +264,7 @@ test.describe('Terminal restart persistence', () => {
 
   test('daemon snapshot relaunch preserves the cursor on the shell prompt', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
   {}, testInfo) => {
-    const repoPath = readFileSync(TEST_REPO_PATH_FILE, 'utf-8').trim()
-    if (!repoPath || !existsSync(repoPath)) {
-      test.skip(true, 'Global setup did not produce a seeded test repo')
-      return
-    }
+    const repoPath = seededRepoPathOrSkip()
 
     const session = createRestartSession(testInfo)
     let firstApp: ElectronApplication | null = null
@@ -267,7 +278,13 @@ test.describe('Terminal restart persistence', () => {
 
       const prompt = `ORCA_RESTART_PROMPT_${Date.now()}_GT `
       const marker = `ORCA_CURSOR_RESTART_${Date.now()}`
-      await execInTerminal(firstLaunch.page, ptyId, `export PS1='${prompt}'; PROMPT='${prompt}'`)
+      const promptCommand =
+        process.platform === 'win32'
+          ? `function global:prompt { '${prompt}' }`
+          : `export PS1='${prompt}'; PROMPT='${prompt}'`
+      // Why: the Windows default shell is PowerShell, whose prompt is a
+      // function; PS1/PROMPT assignments remain the Bash/Zsh path.
+      await execInTerminal(firstLaunch.page, ptyId, promptCommand)
       await waitForTerminalActiveLine(firstLaunch.page, prompt.trim())
       await execInTerminal(firstLaunch.page, ptyId, `echo ${marker}`)
       await waitForTerminalOutput(firstLaunch.page, marker)
@@ -313,11 +330,7 @@ test.describe('Terminal restart persistence', () => {
 
   test('active worktree and terminal tab count survive restart', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
   {}, testInfo) => {
-    const repoPath = readFileSync(TEST_REPO_PATH_FILE, 'utf-8').trim()
-    if (!repoPath || !existsSync(repoPath)) {
-      test.skip(true, 'Global setup did not produce a seeded test repo')
-      return
-    }
+    const repoPath = seededRepoPathOrSkip()
 
     const session = createRestartSession(testInfo)
     let firstApp: ElectronApplication | null = null
@@ -378,11 +391,7 @@ test.describe('Terminal restart persistence', () => {
 
   test('restored Set Title pane label survives agent title churn', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
   {}, testInfo) => {
-    const repoPath = readFileSync(TEST_REPO_PATH_FILE, 'utf-8').trim()
-    if (!repoPath || !existsSync(repoPath)) {
-      test.skip(true, 'Global setup did not produce a seeded test repo')
-      return
-    }
+    const repoPath = seededRepoPathOrSkip()
 
     const session = createRestartSession(testInfo)
     let firstApp: ElectronApplication | null = null
@@ -451,11 +460,7 @@ test.describe('Terminal restart persistence', () => {
 
   test('idle session does not spam session.set writes', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
   {}, testInfo) => {
-    const repoPath = readFileSync(TEST_REPO_PATH_FILE, 'utf-8').trim()
-    if (!repoPath || !existsSync(repoPath)) {
-      test.skip(true, 'Global setup did not produce a seeded test repo')
-      return
-    }
+    const repoPath = seededRepoPathOrSkip()
 
     const session = createRestartSession(testInfo)
     let app: ElectronApplication | null = null


### PR DESCRIPTION
## Summary

- Make terminal restart probes native-PowerShell safe: fresh-shell discovery sends no startup control bytes, settled Windows probes separate Ctrl+C from the command, PowerShell installs a prompt function, and cold daemon loss uses bounded `taskkill.exe` termination.
- Gate keyboard assertions on a full renderer-input round trip that survives replay suppression, delayed ConPTY echo, and pane replacement without accepting replayed markers from a stale pane.
- Enable the cold daemon-loss restart regression on Windows and add a focused Windows 2022 workflow whose three selected cases cannot silently skip required setup.
- Keep this test-only companion independently mergeable from #9043 while recommending that both PRs land together as regression coverage for #8751.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the full Windows suite was attempted: 30,274 passed, 342 skipped, and 100 failed with 2 suite errors. The failures are existing broad Windows incompatibilities such as `/bin/sh ENOENT`, POSIX paths/signals, and line-ending assumptions; none touch this patch.
- [ ] `pnpm build` — the full production/native build was not run; `pnpm exec electron-vite build --mode e2e` passed on the rebased commit.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation on commit `2ef995ea34a0af8682f9315533d21a87e85f1325`:

- `pnpm exec vitest run tests/e2e/restored-terminal-input-readiness.unit.test.ts tests/e2e/terminal-probe-input-sequence.unit.test.ts` — 2 files / 9 tests passed.
- Required Windows workflow command — 3/3 passed in 2.0 minutes with normal cleanup:
  - clean restart with the live daemon session restored;
  - cold restore after the daemon was force-killed between launches;
  - daemon snapshot relaunch preserving the cursor on the PowerShell prompt.
- The cold daemon-loss assertion also passed 5/5 in an earlier isolated repetition.
- Workflow YAML parsing and `git diff --check` passed.

The original driver was red on Windows because a fresh PowerShell probe was prefixed with POSIX Ctrl+U/startup control bytes. During adversarial review, a real clean-restart run exposed a second red case: readiness kept only the latest 100 ms marker while valid ConPTY echoes arrived later. The terminal tail contained the markers, but the helper never observed the immediately previous one. The final helper retains all outstanding markers for the same concrete pane instance and has dedicated delayed-echo and pane-replacement regressions.

## AI Review Report

Three parallel audits checked Windows runtime behavior, replay/readiness semantics, CI non-skippability and security, cross-platform compatibility, and code minimality.

Findings corrected during review:

- Bound readiness evidence to the concrete mounted pane so replaying an old marker into a replacement pane cannot false-pass.
- Retained delayed same-pane markers instead of chasing only the newest marker every 100 ms.
- Changed stale diagnostics from “renderer transport unbound” to the accurate renderer-input-path possibilities: replay, focus, or binding.
- Made missing seeded repo state and missing PaneManager hard failures under the dedicated workflow flag.
- Removed renderer-crash coverage from this workflow and reverted its spec diff to keep the companion focused.
- Extracted restored-input readiness into a concrete module rather than adding a forbidden max-lines waiver.

Cross-platform review covered macOS, Linux, Windows/ConPTY, WSL, and SSH. POSIX shells retain Ctrl+C + Ctrl+U behavior; Windows receives Ctrl+C as a separate payload and never receives Ctrl+U. No shortcut, provider, path-separator, or local-only product behavior changed.

Final verdict from all three audits: ship, with no blockers.

## Security Audit

This PR changes tests and CI only; it adds no product dependency, auth, secret, network, filesystem API, or IPC surface. Windows termination targets only the daemon PID parsed from the test's isolated user-data directory, passes arguments through `execFileSync` without a shell, is bounded by a 10-second timeout, and verifies the PID is gone.

The workflow uses `pull_request` rather than `pull_request_target`, grants read-only contents permission, does not persist checkout credentials, runs serially with a 30-minute job timeout, and uploads only failure traces.

## Notes

- Paired with #9043; regression coverage for #8751. This PR intentionally uses `Refs #8751` semantics and does not claim to close the production issue.
- Recommended order: merge this companion first so the Windows workflow exists on `main`, then synchronize or mark #9043 ready for review. Every product file in #9043 matches this workflow's trigger paths.
- The PRs are independently mergeable, but they should go hand in hand: #9043 supplies the cold-restore correction, while this PR makes the Windows restart harness deterministic and enforces the regression gate.
- Packaged warm/cold verification remains the closing gate for #8751.
