### PR TITLE
Improve gh issue table

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -148,6 +148,21 @@ import { openLinearIssueWorkspaceOrStart } from '@/lib/linear-issue-workspace-op
 import { folderWorkspaceToWorktree } from '../../../shared/folder-workspace-worktree'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { useRepoAssigneesBySlug } from '@/hooks/useGitHubSlugMetadata'
+import { useTaskPageGitHubWorkItemMutation } from '@/hooks/useTaskPageGitHubWorkItemMutation'
+import {
+  materializeTaskPageItemList,
+  MAX_LAG_TRAILS,
+  overlayPendingOnTaskPagePages,
+  processTaskPageQuietRevalidateSettle,
+  reapplyPendingTaskPageGitHubMutationsToCache
+} from '@/components/task-page-github-work-item-mutations'
+import {
+  clearTaskPageGitHubConfirmedAuthority,
+  getOrCreateQuietRevalidateState,
+  setTaskPageGitHubMutationQueryKey,
+  taskPageGitHubItemKey
+} from '@/components/task-page-github-work-item-mutation-registry'
+import type { TaskPageGitHubMutationIntent } from '@/components/task-page-github-work-item-mutation-patches'
 import GitHubItemDialog, { type ItemDialogTab } from '@/components/GitHubItemDialog'
 import PullRequestPage from '@/components/PullRequestPage'
 import GitLabItemDialog from '@/components/GitLabItemDialog'
@@ -418,10 +433,13 @@ const GITHUB_TASK_GRID_CLASS =
   'min-w-[790px] grid-cols-[72px_minmax(320px,1fr)_84px_100px_92px_122px]'
 const GITHUB_PR_TASK_GRID_CLASS =
   'min-w-[1020px] grid-cols-[72px_minmax(360px,2fr)_132px_128px_132px_92px_158px]'
-const GITHUB_TASK_ROW_SURFACE_CLASS =
-  '[background:color-mix(in_srgb,var(--muted)_50%,var(--background))]'
-const GITHUB_TASK_ROW_HOVER_SURFACE_CLASS =
-  'group-hover/github-task-row:[background:color-mix(in_srgb,var(--muted)_70%,var(--background))]'
+// Why: sticky ID/Title cells need an opaque fill so scrolled content doesn't
+// bleed through. Match the table canvas (bg-background) and accent hover used
+// by the rest of the row — not the old muted wash that made the list look muddy.
+const GITHUB_TASK_ROW_SURFACE_CLASS = 'bg-background'
+const GITHUB_TASK_ROW_HOVER_SURFACE_CLASS = 'group-hover/github-task-row:bg-accent'
+const GITHUB_TASK_HEADER_SURFACE_CLASS =
+  '[background:color-mix(in_srgb,var(--muted)_25%,var(--background))]'
 
 function getGitHubWorkItemWorkspaceSeed(item: GitHubWorkItem): string {
   return getLinkedWorkItemWorkspaceName(item)?.seedName ?? getLinkedWorkItemSuggestedName(item)
@@ -540,14 +558,20 @@ function getTaskPageRepoCacheInput(repo: Repo): {
   }
 }
 
-// Why: sticky header bg must be opaque or scrolled rows bleed through; the ::before gap-cover keeps horizontally-scrolled columns off the px-3 padding strip.
+// Why: the sticky header's bg must be opaque (GITHUB_TASK_HEADER_SURFACE_CLASS)
+// or vertically-scrolled rows bleed through it. These left-sticky cells
+// additionally need a ::before gap-cover so horizontally-scrolled header
+// columns don't show through the row's px-3 padding strip.
 const GITHUB_TASK_STICKY_ID_HEADER_CLASS = cn(
-  'sticky left-3 z-30 before:absolute before:-left-3 before:top-0 before:bottom-0 before:w-3 before:bg-inherit',
-  GITHUB_TASK_ROW_SURFACE_CLASS
+  // Why: stretch to full row height so sticky fill covers the header band;
+  // flex centers the label without using grid items-center (which would shrink
+  // sticky cells and let scrolled content bleed at the edges).
+  'sticky left-3 z-30 flex items-center before:absolute before:-left-3 before:top-0 before:bottom-0 before:w-3 before:bg-inherit',
+  GITHUB_TASK_HEADER_SURFACE_CLASS
 )
 const GITHUB_TASK_STICKY_TITLE_HEADER_CLASS = cn(
-  'sticky left-[92px] z-30 border-r border-border/50 before:absolute before:-left-2 before:top-0 before:bottom-0 before:w-2 before:bg-inherit',
-  GITHUB_TASK_ROW_SURFACE_CLASS
+  'sticky left-[92px] z-30 flex items-center border-r border-border/40 before:absolute before:-left-2 before:top-0 before:bottom-0 before:w-2 before:bg-inherit',
+  GITHUB_TASK_HEADER_SURFACE_CLASS
 )
 const GITHUB_TASK_STICKY_ID_CELL_CLASS = cn(
   'sticky left-3 z-20 flex items-center before:absolute before:-left-3 before:top-0 before:bottom-0 before:w-3 before:bg-inherit',
@@ -555,7 +579,7 @@ const GITHUB_TASK_STICKY_ID_CELL_CLASS = cn(
   GITHUB_TASK_ROW_HOVER_SURFACE_CLASS
 )
 const GITHUB_TASK_STICKY_TITLE_CELL_CLASS = cn(
-  'sticky left-[92px] z-20 min-w-0 border-r border-border/50 pr-2 before:absolute before:-left-2 before:top-0 before:bottom-0 before:w-2 before:bg-inherit',
+  'sticky left-[92px] z-20 flex min-w-0 flex-col justify-center border-r border-border/40 pr-2 before:absolute before:-left-2 before:top-0 before:bottom-0 before:w-2 before:bg-inherit',
   GITHUB_TASK_ROW_SURFACE_CLASS,
   GITHUB_TASK_ROW_HOVER_SURFACE_CLASS
 )
@@ -1074,16 +1098,28 @@ function buildJiraCreateCustomFields(
   return Object.keys(customFields).length > 0 ? customFields : undefined
 }
 
+type TaskPageGitHubWorkItemMutationRunner = {
+  run: (input: {
+    item: GitHubWorkItem
+    intent: TaskPageGitHubMutationIntent
+    sourceContext?: TaskSourceContext | null
+    mutate: () => Promise<{ ok?: boolean; error?: string | { message?: string } } | void>
+    successToast?: string
+    errorToast: string
+  }) => Promise<'confirmed' | 'rolled_back' | 'stale'>
+}
+
 function GHStatusCell({
   item,
   repo,
-  sourceContext
+  sourceContext,
+  workItemMutation
 }: {
   item: GitHubWorkItem
   repo: Repo | null
   sourceContext?: TaskSourceContext | null
+  workItemMutation: TaskPageGitHubWorkItemMutationRunner
 }): React.JSX.Element {
-  const patchWorkItem = useAppStore((s) => s.patchWorkItem)
   const [statusStateDraft, setStatusStateDraft] = useState(() =>
     createTaskPageGitHubStatusStateDraft(item)
   )
@@ -1125,7 +1161,6 @@ function GHStatusCell({
         : repoOwnerSettings,
     [repoOwnerSettings, sourceContext]
   )
-  const reqRef = useRef(0)
   const parsedIssueLink = useMemo(() => parseGitHubIssueOrPRLink(item.url), [item.url])
   const filteredDuplicateCandidates = useMemo(
     () =>
@@ -1173,110 +1208,77 @@ function GHStatusCell({
       if (!repo && !parsedOwnerRepo) {
         return
       }
-      reqRef.current += 1
-      const reqId = reqRef.current
       const updates: GitHubIssueUpdate =
         newState === 'closed' && closeAction
           ? buildTaskPageGitHubCloseUpdate(closeAction)
           : { state: newState }
       updateLocalState(newState)
-      patchWorkItem(item.id, { state: newState }, item.repoId, { sourceContext })
-      const target = getActiveRuntimeTarget(sourceSettings)
-      // Why: issue rows can be sourced by owner/repo URL, not local repo context; slug-aware writes preserve close reasons and duplicates.
-      const updatePromise = parsedOwnerRepo
-        ? target.kind === 'environment'
-          ? callRuntimeRpc<{ ok?: boolean; error?: { message?: string } | string }>(
-              target,
-              'github.project.updateIssueBySlug',
-              {
-                owner: parsedOwnerRepo.owner,
-                repo: parsedOwnerRepo.repo,
-                host: githubProjectHost(parsedOwnerRepo.host),
-                number: item.number,
-                updates
-              },
-              { timeoutMs: 30_000 }
-            )
-          : window.api.gh.updateIssueBySlug({
-              owner: parsedOwnerRepo.owner,
-              repo: parsedOwnerRepo.repo,
-              host: githubProjectHost(parsedOwnerRepo.host),
-              number: item.number,
-              updates
-            })
-        : (() => {
-            if (!repo) {
-              throw new Error('No GitHub repository context available for this issue.')
-            }
-            const runtimeRepoId =
-              sourceContext?.provider === 'github' ? (sourceContext.repoId ?? repo.id) : repo.id
+      // Why: coordinator owns durable patch + soft-hide + quiet revalidate; keep
+      // the status draft so one-frame flash is still covered until proven safe.
+      void workItemMutation.run({
+        item,
+        intent: { type: 'setState', state: newState, closeAction },
+        sourceContext,
+        errorToast: translate('auto.components.TaskPage.1c893195ac', 'Failed to update state'),
+        mutate: async () => {
+          const target = getActiveRuntimeTarget(sourceSettings)
+          // Why: issue rows can be sourced by owner/repo URL instead of the local
+          // repo context; slug-aware writes preserve close reasons and duplicates.
+          if (parsedOwnerRepo) {
             return target.kind === 'environment'
-              ? callRuntimeRpc<{ ok?: boolean; error?: string }>(
+              ? callRuntimeRpc<{ ok?: boolean; error?: { message?: string } | string }>(
                   target,
-                  'github.updateIssue',
-                  { repo: runtimeRepoId, number: item.number, updates },
+                  'github.project.updateIssueBySlug',
+                  {
+                    owner: parsedOwnerRepo.owner,
+                    repo: parsedOwnerRepo.repo,
+                    host: githubProjectHost(parsedOwnerRepo.host),
+                    number: item.number,
+                    updates
+                  },
                   { timeoutMs: 30_000 }
                 )
-              : window.api.gh.updateIssue({
-                  repoPath: repo.path,
-                  repoId: repo.id,
-                  sourceContext,
+              : window.api.gh.updateIssueBySlug({
+                  owner: parsedOwnerRepo.owner,
+                  repo: parsedOwnerRepo.repo,
+                  host: githubProjectHost(parsedOwnerRepo.host),
                   number: item.number,
                   updates
                 })
-          })()
-      updatePromise
-        .then((result) => {
-          if (reqId !== reqRef.current) {
-            return
           }
-          const typed = result as { ok?: boolean; error?: string | { message?: string } }
-          if (typed && typed.ok === false) {
-            updateLocalState(newState === 'closed' ? 'open' : 'closed')
-            patchWorkItem(
-              item.id,
-              { state: newState === 'closed' ? 'open' : 'closed' },
-              item.repoId,
-              { sourceContext }
-            )
-            toast.error(
-              typeof typed.error === 'string'
-                ? typed.error
-                : (typed.error?.message ??
-                    translate('auto.components.TaskPage.1c893195ac', 'Failed to update state'))
-            )
-            return
+          if (!repo) {
+            throw new Error('No GitHub repository context available for this issue.')
           }
-          if (repo) {
-            useAppStore.getState().evictGitHubRepoCaches(repo.id, repo.path)
-          }
-          useAppStore.getState().recordFeatureInteraction('github-tasks')
-        })
-        .catch(() => {
-          if (reqId !== reqRef.current) {
-            return
-          }
-          updateLocalState(newState === 'closed' ? 'open' : 'closed')
-          patchWorkItem(
-            item.id,
-            { state: newState === 'closed' ? 'open' : 'closed' },
-            item.repoId,
-            {
-              sourceContext
-            }
-          )
-          toast.error(translate('auto.components.TaskPage.1c893195ac', 'Failed to update state'))
-        })
+          const runtimeRepoId =
+            sourceContext?.provider === 'github' ? (sourceContext.repoId ?? repo.id) : repo.id
+          return target.kind === 'environment'
+            ? callRuntimeRpc<{ ok?: boolean; error?: string }>(
+                target,
+                'github.updateIssue',
+                { repo: runtimeRepoId, number: item.number, updates },
+                { timeoutMs: 30_000 }
+              )
+            : window.api.gh.updateIssue({
+                repoPath: repo.path,
+                repoId: repo.id,
+                sourceContext,
+                number: item.number,
+                updates
+              })
+        }
+      })
+      // Why: draft realigns from item.state via resolveTaskPageGitHubStatusStateDraft
+      // when patchWorkItem (begin/rollback) updates the cache-backed row.
     },
     [
       item,
       localState,
       parsedIssueLink,
-      patchWorkItem,
       repo,
       sourceContext,
       sourceSettings,
-      updateLocalState
+      updateLocalState,
+      workItemMutation
     ]
   )
 
@@ -1770,13 +1772,14 @@ function GitHubIssueAssigneeSelector({
 function GHAssigneesCell({
   item,
   repo,
-  sourceContext
+  sourceContext,
+  workItemMutation
 }: {
   item: GitHubWorkItem
   repo: Repo | null
   sourceContext?: TaskSourceContext | null
+  workItemMutation: TaskPageGitHubWorkItemMutationRunner
 }): React.JSX.Element {
-  const patchWorkItem = useAppStore((s) => s.patchWorkItem)
   const repoOwnerSettings = useAppStore(
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, repo?.id ?? null))
   )
@@ -1814,91 +1817,85 @@ function GHAssigneesCell({
 
   const toggleAssignee = useCallback(
     async (user: GitHubAssignableUser): Promise<void> => {
-      if (item.type !== 'issue' || pendingLogin) {
+      if (item.type !== 'issue') {
         return
       }
       const userLoginKey = user.login.toLowerCase()
       const isOn = assignees.some((a) => a.login.toLowerCase() === userLoginKey)
-      const previousAssignees = assignees
-      const nextAssignees = isOn
-        ? assignees.filter((a) => a.login.toLowerCase() !== userLoginKey)
-        : [...assignees, user]
       setPendingLogin(user.login)
-      patchWorkItem(item.id, { assignees: nextAssignees }, item.repoId, { sourceContext })
-
       try {
-        const updates = isOn ? { removeAssignees: [user.login] } : { addAssignees: [user.login] }
-        const target = getActiveRuntimeTarget(sourceSettings)
-        if (owner && repoName) {
-          const args = {
-            owner,
-            repo: repoName,
-            host: githubProjectHost(parsed?.slug.host),
-            number: item.number,
-            updates
+        await workItemMutation.run({
+          item,
+          intent: { type: 'toggleAssignee', user },
+          sourceContext,
+          errorToast: translate(
+            'auto.components.TaskPage.ca63694b4c',
+            'Failed to update assignees.'
+          ),
+          mutate: async () => {
+            const updates = isOn
+              ? { removeAssignees: [user.login] }
+              : { addAssignees: [user.login] }
+            const target = getActiveRuntimeTarget(sourceSettings)
+            if (owner && repoName) {
+              const args = {
+                owner,
+                repo: repoName,
+                host: githubProjectHost(parsed?.slug.host),
+                number: item.number,
+                updates
+              }
+              const res =
+                target.kind === 'environment'
+                  ? await callRuntimeRpc<
+                      Awaited<ReturnType<typeof window.api.gh.updateIssueBySlug>>
+                    >(target, 'github.project.updateIssueBySlug', args, { timeoutMs: 30_000 })
+                  : await window.api.gh.updateIssueBySlug(args)
+              if (!res.ok) {
+                throw new Error(res.error.message)
+              }
+              return res
+            }
+            if (repo) {
+              const runtimeRepoId =
+                sourceContext?.provider === 'github' ? (sourceContext.repoId ?? repo.id) : repo.id
+              const res =
+                target.kind === 'environment'
+                  ? await callRuntimeRpc<{ ok?: boolean; error?: string }>(
+                      target,
+                      'github.updateIssue',
+                      { repo: runtimeRepoId, number: item.number, updates },
+                      { timeoutMs: 30_000 }
+                    )
+                  : await window.api.gh.updateIssue({
+                      repoPath: repo.path,
+                      repoId: repo.id,
+                      sourceContext,
+                      number: item.number,
+                      updates
+                    })
+              if (res && res.ok === false) {
+                throw new Error(res.error)
+              }
+              return res
+            }
+            throw new Error('No GitHub repository context available for this issue.')
           }
-          const res =
-            target.kind === 'environment'
-              ? await callRuntimeRpc<Awaited<ReturnType<typeof window.api.gh.updateIssueBySlug>>>(
-                  target,
-                  'github.project.updateIssueBySlug',
-                  args,
-                  { timeoutMs: 30_000 }
-                )
-              : await window.api.gh.updateIssueBySlug(args)
-          if (!res.ok) {
-            throw new Error(res.error.message)
-          }
-        } else if (repo) {
-          const runtimeRepoId =
-            sourceContext?.provider === 'github' ? (sourceContext.repoId ?? repo.id) : repo.id
-          const res =
-            target.kind === 'environment'
-              ? await callRuntimeRpc<{ ok?: boolean; error?: string }>(
-                  target,
-                  'github.updateIssue',
-                  { repo: runtimeRepoId, number: item.number, updates },
-                  { timeoutMs: 30_000 }
-                )
-              : await window.api.gh.updateIssue({
-                  repoPath: repo.path,
-                  repoId: repo.id,
-                  sourceContext,
-                  number: item.number,
-                  updates
-                })
-          if (res && res.ok === false) {
-            throw new Error(res.error)
-          }
-        } else {
-          throw new Error('No GitHub repository context available for this issue.')
-        }
-        useAppStore.getState().recordFeatureInteraction('github-tasks')
-      } catch (err) {
-        patchWorkItem(item.id, { assignees: previousAssignees }, item.repoId, { sourceContext })
-        toast.error(
-          err instanceof Error
-            ? err.message
-            : translate('auto.components.TaskPage.ca63694b4c', 'Failed to update assignees.')
-        )
+        })
       } finally {
         setPendingLogin(null)
       }
     },
     [
       assignees,
-      item.id,
-      item.number,
-      item.repoId,
-      item.type,
+      item,
       owner,
-      patchWorkItem,
       parsed?.slug.host,
-      pendingLogin,
       repo,
       repoName,
       sourceContext,
-      sourceSettings
+      sourceSettings,
+      workItemMutation
     ]
   )
 
@@ -2082,11 +2079,13 @@ function buildRequestedReviewUsers(
 function PRReviewCell({
   item,
   repo,
-  sourceContext
+  sourceContext,
+  workItemMutation
 }: {
   item: GitHubWorkItem
   repo: Repo | null
   sourceContext?: TaskSourceContext | null
+  workItemMutation: TaskPageGitHubWorkItemMutationRunner
 }): React.JSX.Element {
   const [open, setOpen] = useState(false)
   const [reviewerInput, setReviewerInput] = useState('')
@@ -2100,7 +2099,6 @@ function PRReviewCell({
     repoId: item.repoId,
     reviewRequests: item.reviewRequests
   }))
-  const patchWorkItem = useAppStore((s) => s.patchWorkItem)
   const [activeReviewerCursor, setActiveReviewerCursor] = useState({ resetKey: '', index: 0 })
   const [submitting, setSubmitting] = useState(false)
   const repoOwnerSettings = useAppStore(
@@ -2302,50 +2300,53 @@ function PRReviewCell({
       )
       return
     }
+    // Why: pre-network optimistic update via coordinator; local display follows
+    // item.reviewRequests once patchWorkItem + reconcile land.
+    const optimistic = buildRequestedReviewUsers(logins, reviewerCandidates, localReviewRequests)
+    setLocalReviewRequests(optimistic)
     setSubmitting(true)
     try {
-      const target = getActiveRuntimeTarget(sourceSettings)
-      const runtimeRepoId =
-        sourceContext?.provider === 'github' ? (sourceContext.repoId ?? repo.id) : repo.id
-      const result =
-        target.kind === 'environment'
-          ? await callRuntimeRpc<{ ok: boolean; error?: string }>(
-              target,
-              'github.requestPRReviewers',
-              {
-                repo: runtimeRepoId,
+      const outcome = await workItemMutation.run({
+        item,
+        intent: {
+          type: 'addReviewers',
+          logins,
+          candidates: reviewerCandidates
+        },
+        sourceContext,
+        successToast: translate('auto.components.TaskPage.8f06dbb9e5', 'Reviewer requested'),
+        errorToast: translate('auto.components.TaskPage.dc67f69962', 'Failed to request reviewer'),
+        mutate: async () => {
+          const target = getActiveRuntimeTarget(sourceSettings)
+          const runtimeRepoId =
+            sourceContext?.provider === 'github' ? (sourceContext.repoId ?? repo.id) : repo.id
+          return target.kind === 'environment'
+            ? callRuntimeRpc<{ ok: boolean; error?: string }>(
+                target,
+                'github.requestPRReviewers',
+                {
+                  repo: runtimeRepoId,
+                  prNumber: item.number,
+                  reviewers: logins,
+                  prRepo: reviewRepo
+                },
+                { timeoutMs: 30_000 }
+              )
+            : window.api.gh.requestPRReviewers({
+                repoPath: repo.path,
+                repoId: repo.id,
+                sourceContext,
                 prNumber: item.number,
                 reviewers: logins,
                 prRepo: reviewRepo
-              },
-              { timeoutMs: 30_000 }
-            )
-          : await window.api.gh.requestPRReviewers({
-              repoPath: repo.path,
-              repoId: repo.id,
-              sourceContext,
-              prNumber: item.number,
-              reviewers: logins,
-              prRepo: reviewRepo
-            })
-      if (result.ok) {
-        toast.success(translate('auto.components.TaskPage.8f06dbb9e5', 'Reviewer requested'))
-        const nextReviewRequests = buildRequestedReviewUsers(
-          logins,
-          reviewerCandidates,
-          localReviewRequests
-        )
-        setLocalReviewRequests(nextReviewRequests)
-        patchWorkItem(item.id, { reviewRequests: nextReviewRequests }, item.repoId, {
-          sourceContext
-        })
+              })
+        }
+      })
+      // Why: only clear the typed reviewer on success — a failed request rolls
+      // back, so keep the user's input instead of forcing a retype.
+      if (outcome === 'confirmed') {
         setReviewerInput('')
-        useAppStore.getState().recordFeatureInteraction('github-tasks')
-      } else {
-        toast.error(result.error)
       }
-    } catch {
-      toast.error(translate('auto.components.TaskPage.dc67f69962', 'Failed to request reviewer'))
     } finally {
       setSubmitting(false)
     }
@@ -2362,52 +2363,50 @@ function PRReviewCell({
     if (logins.length === 0) {
       return
     }
+    const removed = new Set(logins.map((login) => login.toLowerCase()))
+    setLocalReviewRequests((current) =>
+      current.filter((reviewer) => !removed.has(reviewer.login.toLowerCase()))
+    )
     setSubmitting(true)
     try {
-      const target = getActiveRuntimeTarget(sourceSettings)
-      const runtimeRepoId =
-        sourceContext?.provider === 'github' ? (sourceContext.repoId ?? repo.id) : repo.id
-      const result =
-        target.kind === 'environment'
-          ? await callRuntimeRpc<{ ok: boolean; error?: string }>(
-              target,
-              'github.removePRReviewers',
-              {
-                repo: runtimeRepoId,
+      const outcome = await workItemMutation.run({
+        item,
+        intent: { type: 'removeReviewers', logins },
+        sourceContext,
+        successToast:
+          logins.length === 1
+            ? translate('auto.components.TaskPage.f9191d1714', 'Reviewer removed')
+            : translate('auto.components.TaskPage.837bb901ec', 'Reviewers removed'),
+        errorToast: translate('auto.components.TaskPage.ed1daeb49a', 'Failed to remove reviewer'),
+        mutate: async () => {
+          const target = getActiveRuntimeTarget(sourceSettings)
+          const runtimeRepoId =
+            sourceContext?.provider === 'github' ? (sourceContext.repoId ?? repo.id) : repo.id
+          return target.kind === 'environment'
+            ? callRuntimeRpc<{ ok: boolean; error?: string }>(
+                target,
+                'github.removePRReviewers',
+                {
+                  repo: runtimeRepoId,
+                  prNumber: item.number,
+                  reviewers: logins,
+                  prRepo: reviewRepo
+                },
+                { timeoutMs: 30_000 }
+              )
+            : window.api.gh.removePRReviewers({
+                repoPath: repo.path,
+                repoId: repo.id,
+                sourceContext,
                 prNumber: item.number,
                 reviewers: logins,
                 prRepo: reviewRepo
-              },
-              { timeoutMs: 30_000 }
-            )
-          : await window.api.gh.removePRReviewers({
-              repoPath: repo.path,
-              repoId: repo.id,
-              sourceContext,
-              prNumber: item.number,
-              reviewers: logins,
-              prRepo: reviewRepo
-            })
-      if (result.ok) {
-        toast.success(
-          logins.length === 1
-            ? translate('auto.components.TaskPage.f9191d1714', 'Reviewer removed')
-            : translate('auto.components.TaskPage.837bb901ec', 'Reviewers removed')
-        )
-        const removed = new Set(logins.map((login) => login.toLowerCase()))
-        const nextReviewRequests = localReviewRequests.filter(
-          (reviewer) => !removed.has(reviewer.login.toLowerCase())
-        )
-        setLocalReviewRequests(nextReviewRequests)
-        patchWorkItem(item.id, { reviewRequests: nextReviewRequests }, item.repoId, {
-          sourceContext
-        })
+              })
+        }
+      })
+      if (outcome === 'confirmed') {
         setReviewerInput('')
-      } else {
-        toast.error(result.error)
       }
-    } catch {
-      toast.error(translate('auto.components.TaskPage.ed1daeb49a', 'Failed to remove reviewer'))
     } finally {
       setSubmitting(false)
     }
@@ -2724,12 +2723,12 @@ function PRMergeCell({
   item,
   repo,
   sourceContext,
-  onRefresh
+  workItemMutation
 }: {
   item: GitHubWorkItem
   repo: Repo | null
   sourceContext?: TaskSourceContext | null
-  onRefresh: () => void
+  workItemMutation: TaskPageGitHubWorkItemMutationRunner
 }): React.JSX.Element {
   const [merging, setMerging] = useState(false)
   const confirm = useConfirmationDialog()
@@ -2779,39 +2778,41 @@ function PRMergeCell({
     }
     setMerging(true)
     try {
-      const target = getActiveRuntimeTarget(sourceSettings)
-      const runtimeRepoId =
-        sourceContext?.provider === 'github' ? (sourceContext.repoId ?? repo.id) : repo.id
-      const result =
-        target.kind === 'environment'
-          ? await callRuntimeRpc<{ ok: boolean; error?: string }>(
-              target,
-              'github.mergePR',
-              {
-                repo: runtimeRepoId,
+      await workItemMutation.run({
+        item,
+        intent: { type: 'merge' },
+        sourceContext,
+        successToast: translate('auto.components.TaskPage.a161925adc', 'Pull request merged'),
+        errorToast: translate(
+          'auto.components.TaskPage.88f478cdef',
+          'Failed to merge pull request'
+        ),
+        mutate: async () => {
+          const target = getActiveRuntimeTarget(sourceSettings)
+          const runtimeRepoId =
+            sourceContext?.provider === 'github' ? (sourceContext.repoId ?? repo.id) : repo.id
+          return target.kind === 'environment'
+            ? callRuntimeRpc<{ ok: boolean; error?: string }>(
+                target,
+                'github.mergePR',
+                {
+                  repo: runtimeRepoId,
+                  prNumber: item.number,
+                  method,
+                  prRepo
+                },
+                { timeoutMs: 30_000 }
+              )
+            : window.api.gh.mergePR({
+                repoPath: repo.path,
+                repoId: repo.id,
+                sourceContext,
                 prNumber: item.number,
                 method,
                 prRepo
-              },
-              { timeoutMs: 30_000 }
-            )
-          : await window.api.gh.mergePR({
-              repoPath: repo.path,
-              repoId: repo.id,
-              sourceContext,
-              prNumber: item.number,
-              method,
-              prRepo
-            })
-      if (result.ok) {
-        useAppStore.getState().recordFeatureInteraction('github-tasks')
-        toast.success(translate('auto.components.TaskPage.a161925adc', 'Pull request merged'))
-        onRefresh()
-      } else {
-        toast.error(result.error)
-      }
-    } catch {
-      toast.error(translate('auto.components.TaskPage.88f478cdef', 'Failed to merge pull request'))
+              })
+        }
+      })
     } finally {
       setMerging(false)
     }
@@ -2824,49 +2825,44 @@ function PRMergeCell({
     const enabled = mergePresentation.autoMergeAction.kind === 'enable'
     setMerging(true)
     try {
-      const target = getActiveRuntimeTarget(sourceSettings)
-      const runtimeRepoId =
-        sourceContext?.provider === 'github' ? (sourceContext.repoId ?? repo.id) : repo.id
-      const result =
-        target.kind === 'environment'
-          ? await callRuntimeRpc<{ ok: boolean; error?: string }>(
-              target,
-              'github.setPRAutoMerge',
-              {
-                repo: runtimeRepoId,
+      await workItemMutation.run({
+        item,
+        intent: { type: 'setAutoMerge', enabled },
+        sourceContext,
+        successToast: enabled
+          ? translate('auto.components.TaskPage.fed317634c', 'Auto-merge enabled')
+          : translate('auto.components.TaskPage.a5bf86defe', 'Auto-merge disabled'),
+        errorToast: enabled
+          ? translate('auto.components.TaskPage.a3318684bc', 'Failed to enable auto-merge')
+          : translate('auto.components.TaskPage.1a9ea003dc', 'Failed to disable auto-merge'),
+        mutate: async () => {
+          const target = getActiveRuntimeTarget(sourceSettings)
+          const runtimeRepoId =
+            sourceContext?.provider === 'github' ? (sourceContext.repoId ?? repo.id) : repo.id
+          return target.kind === 'environment'
+            ? callRuntimeRpc<{ ok: boolean; error?: string }>(
+                target,
+                'github.setPRAutoMerge',
+                {
+                  repo: runtimeRepoId,
+                  prNumber: item.number,
+                  enabled,
+                  method: enabled ? mergeMethods.defaultMethod : undefined,
+                  prRepo
+                },
+                { timeoutMs: 30_000 }
+              )
+            : window.api.gh.setPRAutoMerge({
+                repoPath: repo.path,
+                repoId: repo.id,
+                sourceContext,
                 prNumber: item.number,
                 enabled,
                 method: enabled ? mergeMethods.defaultMethod : undefined,
                 prRepo
-              },
-              { timeoutMs: 30_000 }
-            )
-          : await window.api.gh.setPRAutoMerge({
-              repoPath: repo.path,
-              repoId: repo.id,
-              sourceContext,
-              prNumber: item.number,
-              enabled,
-              method: enabled ? mergeMethods.defaultMethod : undefined,
-              prRepo
-            })
-      if (result.ok) {
-        useAppStore.getState().recordFeatureInteraction('github-tasks')
-        toast.success(
-          enabled
-            ? translate('auto.components.TaskPage.fed317634c', 'Auto-merge enabled')
-            : translate('auto.components.TaskPage.a5bf86defe', 'Auto-merge disabled')
-        )
-        onRefresh()
-      } else {
-        toast.error(result.error)
-      }
-    } catch {
-      toast.error(
-        enabled
-          ? translate('auto.components.TaskPage.a3318684bc', 'Failed to enable auto-merge')
-          : translate('auto.components.TaskPage.1a9ea003dc', 'Failed to disable auto-merge')
-      )
+              })
+        }
+      })
     } finally {
       setMerging(false)
     }
@@ -3786,7 +3782,13 @@ export default function TaskPage(): React.JSX.Element {
   // Why: when every refresh fails (GitHub outage/network/rate limit), attribute it to GitHub instead of showing an empty or stale list as current.
   const [githubUnavailable, setGithubUnavailable] = useState(false)
   const [taskRefreshNonce, setTaskRefreshNonce] = useState(0)
-  // Why: lets the fetch effect tell a user refresh-click nonce bump (force=true) from a re-run for another reason (e.g. repo change with nonce > 0).
+  // Why: quiet success revalidate must never share taskRefreshNonce / tasksFiltering
+  // (K23) — membership exits and merge success refresh without filter skeletons.
+  const [quietRefreshNonce, setQuietRefreshNonce] = useState(0)
+  const [githubViewerLogin, setGitHubViewerLogin] = useState<string | null>(null)
+  // Why: the fetch effect uses this to detect when a nonce bump is from the
+  // user clicking the refresh button (force=true) vs. re-running for any
+  // other reason — e.g. a repo change while the nonce happens to be > 0.
   const lastFetchedNonceRef = useRef(-1)
   // Why: invalidation-nonce analog of lastFetchedNonceRef; a preference flip must force past fetch-dedupe or the fan-out collapses onto a stale in-flight request from the pre-flip source.
   const lastFetchedInvalidationNonceRef = useRef(0)
@@ -4036,9 +4038,14 @@ export default function TaskPage(): React.JSX.Element {
     if (taskSource !== 'github' || githubMode !== 'items') {
       return
     }
-    // Why: inline/dialog edits patch workItemsCache; the paged table renders from a local snapshot, so copy patched rows across.
+    // Why: inline/dialog edits patch `workItemsCache`; the paged table renders
+    // from a local snapshot so it needs the patched row objects copied across.
+    // Hard guarantee (K4): always overlay pending after reconcile so list
+    // fetch clobbers never paint unprotected coordinator fields.
     setPages((current) =>
-      reconcileTaskPagePagesWithWorkItemsCache(current, selectedWorkItemsCacheEntries)
+      reconcileTaskPagePagesWithWorkItemsCache(current, selectedWorkItemsCacheEntries).map((page) =>
+        page ? (overlayPendingOnTaskPagePages([page])[0] ?? []) : null
+      )
     )
   }, [githubMode, selectedWorkItemsCacheEntries, taskSource])
 
@@ -5842,6 +5849,56 @@ export default function TaskPage(): React.JSX.Element {
 
   const activeGithubTaskKind = getGitHubTaskKind(activeTaskPreset, appliedTaskSearch)
   const appliedTaskQuery = useMemo(() => parseTaskQuery(appliedTaskSearch), [appliedTaskSearch])
+
+  // Why: multi-repo queryKey omits a singular sourceScope (scopes include repoId).
+  const githubWorkItemMutationQueryKey = useMemo(() => {
+    const hostOrSetupIds = [
+      ...new Set(
+        selectedRepos.map((repo) => {
+          const ctx = getTaskPageRepoSourceContext(repo, 'github')
+          return ctx?.projectHostSetupId || ctx?.hostId || 'local'
+        })
+      )
+    ].sort()
+    const repoIds = selectedRepos.map((repo) => repo.id).sort()
+    return `${githubMode}::${hostOrSetupIds.join(',')}::${repoIds.join(',')}::${appliedTaskSearch}`
+  }, [appliedTaskSearch, githubMode, selectedRepos])
+
+  useEffect(() => {
+    setTaskPageGitHubMutationQueryKey(githubWorkItemMutationQueryKey)
+  }, [githubWorkItemMutationQueryKey])
+
+  useEffect(() => {
+    let cancelled = false
+    void window.api.gh
+      .viewer()
+      .then((viewer) => {
+        if (!cancelled) {
+          setGitHubViewerLogin(viewer?.login ?? null)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setGitHubViewerLogin(null)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const scheduleQuietRevalidate = useCallback(() => {
+    setQuietRefreshNonce((current) => current + 1)
+  }, [])
+
+  const githubWorkItemMutation = useTaskPageGitHubWorkItemMutation({
+    appliedTaskSearch,
+    queryKey: githubWorkItemMutationQueryKey,
+    query: appliedTaskQuery,
+    viewerLogin: githubViewerLogin,
+    scheduleQuietRevalidate
+  })
+
   const selectedGitHubRepoExternalLink = useMemo(() => {
     if (selectedRepos.length !== 1) {
       return null
@@ -6135,9 +6192,25 @@ export default function TaskPage(): React.JSX.Element {
 
   const currentPageItems = useMemo(() => pages[currentPage] ?? [], [pages, currentPage])
 
-  const filteredWorkItems = useMemo(
+  const typeFilteredCurrentPageItems = useMemo(
     () => applyTypeFilter(currentPageItems),
     [applyTypeFilter, currentPageItems]
+  )
+  // Why: soft-hide keeps membership-exit rows in pages for rollback/cursors but
+  // removes them from the visible table (sticky ∪ pending membership).
+  const filteredWorkItems = useMemo(
+    () =>
+      typeFilteredCurrentPageItems.filter(
+        (workItem) =>
+          !githubWorkItemMutation.softHiddenItemKeys.has(
+            taskPageGitHubItemKey(workItem.repoId, workItem.id)
+          )
+      ),
+    [githubWorkItemMutation.softHiddenItemKeys, typeFilteredCurrentPageItems]
+  )
+  const softHiddenVisibleCount = useMemo(
+    () => typeFilteredCurrentPageItems.length - filteredWorkItems.length,
+    [filteredWorkItems.length, typeFilteredCurrentPageItems.length]
   )
   const showGitHubTaskSkeletons = tasksFiltering || (tasksLoading && filteredWorkItems.length === 0)
   const loadedGitHubAuthorLogins = useMemo(() => {
@@ -6325,7 +6398,7 @@ export default function TaskPage(): React.JSX.Element {
           while (next.length <= target) {
             next.push(null)
           }
-          next[target] = items
+          next[target] = overlayPendingOnTaskPagePages([items])[0] ?? []
           return next
         })
         setCurrentPage(target)
@@ -6419,10 +6492,17 @@ export default function TaskPage(): React.JSX.Element {
         preMerged.push(...cached)
       }
     }
-    // Why: always replace — an empty preMerged clears the previous query's rows instead of leaving them under the spinner.
-    const page0 =
+    // Why: always replace so an empty cache clears the previous query's rows.
+    const page0Raw =
       preMerged.length > 0 ? sortWorkItemsByNumber(preMerged).slice(0, githubPageSize) : []
-    setPages([page0])
+    // Why: pre-paint must still overlay in-flight mutations (K4/K18).
+    setPages((previous) => [
+      materializeTaskPageItemList({
+        networkItems: page0Raw,
+        previousItems: previous.flatMap((page) => page ?? []),
+        queryKey: githubWorkItemMutationQueryKey
+      })
+    ])
     setCurrentPage(0)
     setCountedTotalPages(null)
     countedTotalPagesRef.current = null
@@ -6478,15 +6558,40 @@ export default function TaskPage(): React.JSX.Element {
         if (cancelled) {
           return
         }
+        // Why: user hard refresh (force) is design tier-3 — drop confirmed
+        // authority so search can adopt for non-pending families. Pending ops
+        // still overlay. Quiet path must NOT clear authority.
+        if (forcedFetch) {
+          clearTaskPageGitHubConfirmedAuthority()
+        }
+        // Why: best-effort cache re-apply after wholesale list replace (K4).
+        const sourceContextByRepoId = new Map(
+          repoArgs.map((r) => [r.repoId, r.sourceContext] as const)
+        )
+        reapplyPendingTaskPageGitHubMutationsToCache({
+          items,
+          patchWorkItem: useAppStore.getState().patchWorkItem,
+          sourceContextByRepoId
+        })
         if (shouldProbeOnLanding) {
-          const replaceFirstPage = shouldReplaceTaskPageItemsAfterRefresh(page0, items)
-          const resetPagination = shouldResetTaskPagePaginationAfterLandingRefresh(page0, items)
-          setPages((current) => reconcileTaskPagePagesAfterLandingRefresh(current, items))
+          const replaceFirstPage = shouldReplaceTaskPageItemsAfterRefresh(page0Raw, items)
+          const resetPagination = shouldResetTaskPagePaginationAfterLandingRefresh(page0Raw, items)
+          setPages((current) =>
+            reconcileTaskPagePagesAfterLandingRefresh(current, items).map((page) =>
+              page ? (overlayPendingOnTaskPagePages([page])[0] ?? []) : null
+            )
+          )
           if (replaceFirstPage || resetPagination) {
             setCurrentPage(0)
           }
         } else {
-          setPages([items])
+          setPages((previous) => [
+            materializeTaskPageItemList({
+              networkItems: items,
+              previousItems: previous.flatMap((page) => page ?? []),
+              queryKey: githubWorkItemMutationQueryKey
+            })
+          ])
           setCurrentPage(0)
         }
         setFailedCount(failed)
@@ -6555,8 +6660,104 @@ export default function TaskPage(): React.JSX.Element {
     taskSource,
     githubMode,
     workItemsInvalidationNonce,
-    taskResumeApplied
+    taskResumeApplied,
+    githubWorkItemMutationQueryKey
   ])
+
+  // Why: dedicated quiet revalidate path (K23) — never tasksFiltering / skeleton,
+  // never blanks pages, never bumps taskRefreshNonce. Single-flight with backoff
+  // trailing; never clear confirmed authority (K21).
+  useEffect(() => {
+    if (quietRefreshNonce === 0) {
+      return
+    }
+    if (taskSource !== 'github' || githubMode !== 'items' || selectedRepos.length === 0) {
+      return
+    }
+    const quietState = getOrCreateQuietRevalidateState(githubWorkItemMutationQueryKey)
+    // Why: coalesce concurrent quiet requests so lag cannot stack force fetches.
+    if (quietState.inFlight) {
+      quietState.trailingQueued = true
+      return
+    }
+    quietState.inFlight = true
+    quietState.trailingQueued = false
+    quietState.fetchStartedAtGeneration = quietState.dirtyGeneration
+    let cancelled = false
+    const q = stripRepoQualifiers(appliedTaskSearch.trim())
+    const repoArgs = selectedRepos.map((r) => ({
+      repoId: r.id,
+      path: r.path,
+      executionHostId: r.executionHostId,
+      sourceContext: getTaskPageRepoSourceContext(r, 'github')
+    }))
+    const sourceContextByRepoId = new Map(repoArgs.map((r) => [r.repoId, r.sourceContext] as const))
+    const lagBackoffMs = [500, 1000, 2000, 4000, 8000] as const
+    void fetchWorkItemsAcrossRepos(repoArgs, PER_REPO_FETCH_LIMIT, CROSS_REPO_DISPLAY_LIMIT, q, {
+      force: true,
+      noCache: true
+    })
+      .then(async ({ items }) => {
+        if (cancelled) {
+          return
+        }
+        reapplyPendingTaskPageGitHubMutationsToCache({
+          items,
+          patchWorkItem: useAppStore.getState().patchWorkItem,
+          sourceContextByRepoId
+        })
+        const settle = await processTaskPageQuietRevalidateSettle({
+          queryKey: githubWorkItemMutationQueryKey,
+          networkItems: items,
+          patchWorkItem: useAppStore.getState().patchWorkItem,
+          sourceContextByRepoId,
+          // Why: TaskPage owns trailing via quietRefreshNonce + backoff below.
+          scheduleTrailing: false
+        })
+        setPages((previous) => [
+          materializeTaskPageItemList({
+            networkItems: items,
+            previousItems: previous.flatMap((page) => page ?? []),
+            queryKey: githubWorkItemMutationQueryKey
+          })
+        ])
+        const lagValues = [...quietState.lagSkipAttempts.values()]
+        const attempts = lagValues.length === 0 ? 0 : Math.max(...lagValues)
+        const wallExceeded =
+          quietState.lastConfirmAt > 0 && Date.now() - quietState.lastConfirmAt > 90_000
+        // Why: a new mutation confirmed while this fetch was in flight (queued) is
+        // fresh work and must always revalidate — only lag *retries* (needTrailing)
+        // are bounded by attempts/wall so a stuck server can't spin forever.
+        const hasQueuedWork = quietState.trailingQueued
+        quietState.trailingQueued = false
+        const lagTrail = settle.needTrailing && attempts < MAX_LAG_TRAILS && !wallExceeded
+        if ((hasQueuedWork || lagTrail) && !cancelled) {
+          const delay = hasQueuedWork
+            ? 0
+            : (lagBackoffMs[Math.min(attempts, lagBackoffMs.length - 1)] ?? 500)
+          window.setTimeout(() => {
+            if (!cancelled) {
+              setQuietRefreshNonce((current) => current + 1)
+            }
+          }, delay)
+        }
+      })
+      .catch((err) => {
+        // Quiet revalidate soft-fails; keep optimistic/sticky state.
+        console.error('Quiet GitHub work-item revalidate failed:', err)
+      })
+      .finally(() => {
+        quietState.inFlight = false
+        if (quietState.trailingQueued && !cancelled) {
+          quietState.trailingQueued = false
+          setQuietRefreshNonce((current) => current + 1)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [quietRefreshNonce])
 
   const applyPRFilterChange = useCallback(
     (change: PRFilterChange): void => {
@@ -8444,10 +8645,10 @@ export default function TaskPage(): React.JSX.Element {
                                 handleSelectGithubTaskKind(mode.id)
                               }}
                               className={cn(
-                                'rounded-md border px-2 py-1 text-xs transition',
+                                'rounded-md border px-2.5 py-1 text-xs font-medium transition',
                                 active
-                                  ? 'border-border/50 bg-foreground/90 text-background'
-                                  : 'border-border/50 bg-transparent text-foreground hover:bg-muted/50'
+                                  ? 'border-border/50 bg-foreground/90 text-background shadow-xs'
+                                  : 'border-border/60 bg-muted/50 text-foreground shadow-xs hover:bg-muted/70'
                               )}
                             >
                               {mode.label}
@@ -8537,11 +8738,13 @@ export default function TaskPage(): React.JSX.Element {
                 ) : null}
 
                 {taskSource === 'github' && githubMode === 'items' ? (
+                  // Why: top of the joined GitHub list card — pairs with the
+                  // table shell below (rounded-t-none border-t-0) as one surface.
                   <div
-                    className="min-w-0 rounded-md rounded-b-none border border-border/50 bg-muted/50 px-3 pt-2 pb-0 shadow-sm"
+                    className="flex min-w-0 flex-col gap-2.5 rounded-md rounded-b-none border border-border/50 bg-muted/35 px-3 py-2.5"
                     data-contextual-tour-target="tasks-search-presets"
                   >
-                    <div className="mb-2 flex flex-wrap gap-2">
+                    <div className="flex flex-wrap gap-1.5">
                       {getGitHubTaskKindPresets(activeGithubTaskKind).map((option) => {
                         const active = activeTaskPreset === option.id
                         return (
@@ -8564,10 +8767,10 @@ export default function TaskPage(): React.JSX.Element {
                               handleSetDefaultTaskPreset(option.id)
                             }}
                             className={cn(
-                              'rounded-md border px-2 py-1 text-xs transition',
+                              'rounded-md border px-2.5 py-1 text-xs font-medium transition',
                               active
-                                ? 'border-border/50 bg-foreground/90 text-background backdrop-blur-md'
-                                : 'border-border/50 bg-transparent text-foreground hover:bg-muted/50'
+                                ? 'border-border/50 bg-foreground/90 text-background shadow-xs'
+                                : 'border-border/60 bg-background text-foreground shadow-xs hover:bg-muted/60'
                             )}
                           >
                             {option.label}
@@ -8603,7 +8806,7 @@ export default function TaskPage(): React.JSX.Element {
                                   'Search GitHub issues...'
                                 )
                           }
-                          className="h-8 rounded-md border-border/50 bg-background pl-8 pr-8 text-xs"
+                          className="h-8 rounded-md border-border/60 bg-background pl-8 pr-8 text-xs text-foreground shadow-xs"
                         />
                         {taskSearchInput || appliedTaskSearch ? (
                           <button
@@ -8646,7 +8849,7 @@ export default function TaskPage(): React.JSX.Element {
                                 'auto.components.TaskPage.d3d0998b7d',
                                 'New GitHub issue'
                               )}
-                              className="size-8 border-border/50 bg-transparent hover:bg-muted/50 backdrop-blur-md supports-[backdrop-filter]:bg-transparent"
+                              className="size-8 border-border/60 bg-background text-foreground shadow-xs hover:bg-muted/60"
                             >
                               <Plus className="size-4" />
                             </Button>
@@ -8674,7 +8877,7 @@ export default function TaskPage(): React.JSX.Element {
                                       'Refresh GitHub work'
                                     )
                               }
-                              className="size-8 cursor-pointer border-border/50 bg-transparent hover:bg-muted/50 backdrop-blur-md disabled:pointer-events-auto disabled:cursor-wait supports-[backdrop-filter]:bg-transparent"
+                              className="size-8 cursor-pointer border-border/60 bg-background text-foreground shadow-xs hover:bg-muted/60 disabled:pointer-events-auto disabled:cursor-wait"
                             >
                               {githubTasksBusy ? (
                                 <LoaderCircle className="size-4 animate-spin" />
@@ -8707,7 +8910,7 @@ export default function TaskPage(): React.JSX.Element {
                         return null
                       }
                       return (
-                        <div className="mt-2 flex flex-wrap items-center gap-2">
+                        <div className="flex flex-wrap items-center gap-2">
                           {rows.map((s) => {
                             const repo = selectedRepos.find((r) => r.id === s.repoId)
                             const showRepoBadgeLabel = selectedRepos.length > 1 && repo
@@ -9375,7 +9578,9 @@ export default function TaskPage(): React.JSX.Element {
               <ProjectViewWrapper selectedRepoIds={repoSelection} />
             </div>
           ) : taskSource === 'github' ? (
-            <div className="flex min-h-0 min-w-0 max-h-full flex-col overflow-hidden rounded-md rounded-t-none border border-t-0 border-border/50 bg-muted/50 shadow-sm">
+            // Why: bottom of the joined GitHub list card — flush under the filter
+            // chrome (no gap, no top border/radius) so toolbar + table read as one.
+            <div className="flex min-h-0 min-w-0 max-h-full flex-col overflow-hidden rounded-md rounded-t-none border border-t-0 border-border/50 bg-background shadow-sm">
               <div
                 className="min-h-0 flex-initial overflow-auto scrollbar-sleek scrollbar-sleek-lg"
                 style={{ scrollbarGutter: 'stable' }}
@@ -9383,8 +9588,8 @@ export default function TaskPage(): React.JSX.Element {
                 <div
                   // Why: z-40 must beat the rows' sticky left cells (z-20); this stacking context's z sets the whole header's level.
                   className={cn(
-                    'sticky top-0 z-40 grid gap-2 border-b border-border/50 px-3 py-2 text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground',
-                    GITHUB_TASK_ROW_SURFACE_CLASS,
+                    'sticky top-0 z-40 grid h-8 gap-3 border-b border-border/50 px-3 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground [&>span]:flex [&>span]:items-center',
+                    GITHUB_TASK_HEADER_SURFACE_CLASS,
                     githubTaskGridClass
                   )}
                 >
@@ -9518,16 +9723,22 @@ export default function TaskPage(): React.JSX.Element {
                 ))}
 
                 {showGitHubTaskSkeletons ? (
-                  // Why: fill a typical viewport with shimmer rows so the table doesn't jump in height when results land.
-                  <div className="divide-y divide-border/50">
+                  // Why: render enough shimmer rows to fill a typical viewport
+                  // so the table doesn't visibly grow when results land. A
+                  // 3-row stub jumps to ~30 real rows; matching the steady-
+                  // state height keeps layout stable across the load.
+                  <div className="divide-y divide-border/40">
                     {Array.from({ length: 12 }).map((_, i) => (
-                      <div key={i} className={cn('grid gap-2 px-3 py-2', githubTaskGridClass)}>
+                      <div
+                        key={i}
+                        className={cn('grid min-h-12 gap-3 px-3 py-2.5', githubTaskGridClass)}
+                      >
                         <div className={GITHUB_TASK_STICKY_ID_CELL_CLASS}>
-                          <div className="h-7 w-16 animate-pulse rounded-lg bg-muted/70" />
+                          <div className="h-6 w-16 animate-pulse rounded-md bg-muted/70" />
                         </div>
                         <div className={GITHUB_TASK_STICKY_TITLE_CELL_CLASS}>
-                          <div className="h-4 w-3/5 animate-pulse rounded bg-muted/70" />
-                          <div className="mt-2 h-3 w-2/5 animate-pulse rounded bg-muted/60" />
+                          <div className="h-3.5 w-3/5 animate-pulse rounded bg-muted/70" />
+                          <div className="mt-1.5 h-3 w-2/5 animate-pulse rounded bg-muted/60" />
                         </div>
                         {!showPRManagementColumns ? (
                           <div className="flex items-center">
@@ -9555,16 +9766,26 @@ export default function TaskPage(): React.JSX.Element {
                           <div className="h-3 w-20 animate-pulse rounded bg-muted/60" />
                         </div>
                         <div className="flex items-center justify-start lg:justify-end">
-                          <div className="h-7 w-16 animate-pulse rounded-xl bg-muted/70" />
+                          <div className="h-7 w-16 animate-pulse rounded-md bg-muted/70" />
                         </div>
                       </div>
                     ))}
                   </div>
                 ) : null}
 
-                {/* Why: hide the empty state while any error banner shows, so "No matching work" doesn't contradict "Couldn't load issues". */}
+                {/* Why: suppress the generic empty state when any error banner is
+                    visible (IPC reject via tasksError, cross-repo partial failure
+                    via failedCount, or per-repo issue-side error). Showing
+                    "No matching GitHub work" next to "Couldn't load issues from X/Y"
+                    is contradictory and misleads the user into thinking they
+                    typed the wrong query. */}
+                {/* Why: soft-hidden membership exits must not look like an empty
+                    query when pager/count still implies items remain — but on a
+                    single page (totalPages <= 1) there's nothing else to show, so
+                    surface the empty state instead of a blank panel. */}
                 {!showGitHubTaskSkeletons &&
                 filteredWorkItems.length === 0 &&
+                (softHiddenVisibleCount === 0 || totalPages <= 1) &&
                 !tasksError &&
                 !githubUnavailable &&
                 failedCount === 0 &&
@@ -9580,7 +9801,7 @@ export default function TaskPage(): React.JSX.Element {
                   </div>
                 ) : null}
 
-                <div className="divide-y divide-border/50">
+                <div className="divide-y divide-border/40">
                   {!showGitHubTaskSkeletons &&
                     filteredWorkItems.map((item) => {
                       const itemRepo = repoMap.get(item.repoId) ?? null
@@ -9595,7 +9816,7 @@ export default function TaskPage(): React.JSX.Element {
                         : null
                       const githubTaskIdPill = (
                         <span
-                          className="inline-flex items-center gap-1 rounded-md border border-border/50 bg-muted/40 px-1.5 py-0.5 text-muted-foreground"
+                          className="inline-flex items-center gap-1 rounded-md border border-border/40 bg-muted/30 px-1.5 py-0.5 text-muted-foreground"
                           aria-label={`${item.type === 'pr' ? (isTaskPageGitHubDraftPR(item) ? 'Draft pull request' : 'Pull request') : 'Issue'} #${item.number}`}
                         >
                           {item.type === 'pr' ? (
@@ -9631,8 +9852,10 @@ export default function TaskPage(): React.JSX.Element {
                             }
                           }}
                           className={cn(
-                            // Why: hover uses the same opaque muted-70% mix as the sticky ID/Title cells so the left columns match the rest of the row.
-                            'group/github-task-row grid cursor-pointer gap-2 px-3 py-2 text-left transition-colors hover:[background:color-mix(in_srgb,var(--muted)_70%,var(--background))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+                            // Why: hover uses bg-accent on both the row and sticky
+                            // ID/Title cells so left columns match the rest of the row.
+                            // Grid stretch (default) keeps sticky fills full-height.
+                            'group/github-task-row grid min-h-12 cursor-pointer gap-3 px-3 py-2.5 text-left transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
                             githubTaskGridClass
                           )}
                         >
@@ -9651,7 +9874,7 @@ export default function TaskPage(): React.JSX.Element {
 
                           <div className={GITHUB_TASK_STICKY_TITLE_CELL_CLASS}>
                             <div className="flex min-w-0 items-center gap-2">
-                              <h3 className="truncate text-sm font-semibold text-foreground">
+                              <h3 className="truncate text-[13px] font-medium text-foreground">
                                 {item.title}
                               </h3>
                               {item.type === 'pr' &&
@@ -9672,7 +9895,7 @@ export default function TaskPage(): React.JSX.Element {
                                 />
                               ) : null}
                             </div>
-                            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                            <div className="mt-0.5 flex flex-wrap items-center gap-x-2.5 gap-y-0.5 text-[12px] text-muted-foreground">
                               <span>
                                 {item.author ??
                                   translate(
@@ -9706,7 +9929,7 @@ export default function TaskPage(): React.JSX.Element {
                               {item.labels.slice(0, 3).map((label) => (
                                 <span
                                   key={label}
-                                  className="rounded-full border border-border/50 bg-background/80 px-1.5 py-0 text-[10px] text-muted-foreground"
+                                  className="rounded-full border border-border/40 bg-muted/30 px-1.5 py-0 text-[10px] text-muted-foreground"
                                 >
                                   {label}
                                 </span>
@@ -9720,6 +9943,7 @@ export default function TaskPage(): React.JSX.Element {
                                 item={item}
                                 repo={itemRepo ?? null}
                                 sourceContext={getTaskPageRepoSourceContext(itemRepo, 'github')}
+                                workItemMutation={githubWorkItemMutation}
                               />
                             </div>
                           ) : null}
@@ -9731,6 +9955,7 @@ export default function TaskPage(): React.JSX.Element {
                                   item={item}
                                   repo={itemRepo ?? null}
                                   sourceContext={getTaskPageRepoSourceContext(itemRepo, 'github')}
+                                  workItemMutation={githubWorkItemMutation}
                                 />
                               </div>
 
@@ -9747,7 +9972,7 @@ export default function TaskPage(): React.JSX.Element {
                                   item={item}
                                   repo={itemRepo ?? null}
                                   sourceContext={getTaskPageRepoSourceContext(itemRepo, 'github')}
-                                  onRefresh={() => setTaskRefreshNonce((current) => current + 1)}
+                                  workItemMutation={githubWorkItemMutation}
                                 />
                               </div>
                             </>
@@ -9757,6 +9982,7 @@ export default function TaskPage(): React.JSX.Element {
                                 item={item}
                                 repo={itemRepo ?? null}
                                 sourceContext={getTaskPageRepoSourceContext(itemRepo, 'github')}
+                                workItemMutation={githubWorkItemMutation}
                               />
                             </div>
                           )}
@@ -9928,9 +10154,13 @@ export default function TaskPage(): React.JSX.Element {
                 </div>
               </div>
 
-              {/* Why: pagination sits outside the scroll container so it stays pinned at the panel bottom instead of scrolling away. */}
-              {filteredWorkItems.length > 0 && !showGitHubTaskSkeletons && totalPages > 1 ? (
-                <div className="flex-none border-t border-border/50 bg-muted/50">
+              {/* Why: pagination sits outside the scroll container so it
+                  remains pinned at the bottom of the panel rather than
+                  hiding below the last row inside the scrolling region. */}
+              {(filteredWorkItems.length > 0 || softHiddenVisibleCount > 0) &&
+              !showGitHubTaskSkeletons &&
+              totalPages > 1 ? (
+                <div className="flex-none border-t border-border/50 bg-background">
                   <PaginationBar
                     currentPage={currentPage}
                     totalPages={totalPages}

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -149,7 +149,10 @@ import { folderWorkspaceToWorktree } from '../../../shared/folder-workspace-work
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { useRepoAssigneesBySlug } from '@/hooks/useGitHubSlugMetadata'
 import { useTaskPageGitHubWorkItemMutation } from '@/hooks/useTaskPageGitHubWorkItemMutation'
+import { useMountedRef } from '@/hooks/useMountedRef'
 import {
+  LAG_BACKOFF_MS,
+  LAG_WALL_BUDGET_MS,
   materializeTaskPageItemList,
   MAX_LAG_TRAILS,
   overlayPendingOnTaskPagePages,
@@ -6664,6 +6667,11 @@ export default function TaskPage(): React.JSX.Element {
     githubWorkItemMutationQueryKey
   ])
 
+  // Why: track true unmount only. The quiet-revalidate coalescing keys off the
+  // shared quietState (inFlight/trailingQueued), so a nonce-triggered re-render
+  // must NOT cancel the in-flight run's trailing bookkeeping.
+  const quietRevalidateMountedRef = useMountedRef()
+
   // Why: dedicated quiet revalidate path (K23) — never tasksFiltering / skeleton,
   // never blanks pages, never bumps taskRefreshNonce. Single-flight with backoff
   // trailing; never clear confirmed authority (K21).
@@ -6683,7 +6691,6 @@ export default function TaskPage(): React.JSX.Element {
     quietState.inFlight = true
     quietState.trailingQueued = false
     quietState.fetchStartedAtGeneration = quietState.dirtyGeneration
-    let cancelled = false
     const q = stripRepoQualifiers(appliedTaskSearch.trim())
     const repoArgs = selectedRepos.map((r) => ({
       repoId: r.id,
@@ -6692,13 +6699,14 @@ export default function TaskPage(): React.JSX.Element {
       sourceContext: getTaskPageRepoSourceContext(r, 'github')
     }))
     const sourceContextByRepoId = new Map(repoArgs.map((r) => [r.repoId, r.sourceContext] as const))
-    const lagBackoffMs = [500, 1000, 2000, 4000, 8000] as const
     void fetchWorkItemsAcrossRepos(repoArgs, PER_REPO_FETCH_LIMIT, CROSS_REPO_DISPLAY_LIMIT, q, {
       force: true,
       noCache: true
     })
       .then(async ({ items }) => {
-        if (cancelled) {
+        // Why: skip renderer state writes after unmount, but still let .finally
+        // settle the shared quietState so a queued trailing is never stranded.
+        if (!quietRevalidateMountedRef.current) {
           return
         }
         reapplyPendingTaskPageGitHubMutationsToCache({
@@ -6724,19 +6732,19 @@ export default function TaskPage(): React.JSX.Element {
         const lagValues = [...quietState.lagSkipAttempts.values()]
         const attempts = lagValues.length === 0 ? 0 : Math.max(...lagValues)
         const wallExceeded =
-          quietState.lastConfirmAt > 0 && Date.now() - quietState.lastConfirmAt > 90_000
+          quietState.lastConfirmAt > 0 && Date.now() - quietState.lastConfirmAt > LAG_WALL_BUDGET_MS
         // Why: a new mutation confirmed while this fetch was in flight (queued) is
         // fresh work and must always revalidate — only lag *retries* (needTrailing)
         // are bounded by attempts/wall so a stuck server can't spin forever.
         const hasQueuedWork = quietState.trailingQueued
         quietState.trailingQueued = false
         const lagTrail = settle.needTrailing && attempts < MAX_LAG_TRAILS && !wallExceeded
-        if ((hasQueuedWork || lagTrail) && !cancelled) {
+        if ((hasQueuedWork || lagTrail) && quietRevalidateMountedRef.current) {
           const delay = hasQueuedWork
             ? 0
-            : (lagBackoffMs[Math.min(attempts, lagBackoffMs.length - 1)] ?? 500)
+            : (LAG_BACKOFF_MS[Math.min(attempts, LAG_BACKOFF_MS.length - 1)] ?? 500)
           window.setTimeout(() => {
-            if (!cancelled) {
+            if (quietRevalidateMountedRef.current) {
               setQuietRefreshNonce((current) => current + 1)
             }
           }, delay)
@@ -6748,14 +6756,14 @@ export default function TaskPage(): React.JSX.Element {
       })
       .finally(() => {
         quietState.inFlight = false
-        if (quietState.trailingQueued && !cancelled) {
+        // Why: drain a trailing queued from the shared quietState — not the old
+        // per-render cancelled flag, which stranded the retry when a new nonce
+        // arrived mid-flight. Gate the renderer bump on mount only.
+        if (quietState.trailingQueued && quietRevalidateMountedRef.current) {
           quietState.trailingQueued = false
           setQuietRefreshNonce((current) => current + 1)
         }
       })
-    return () => {
-      cancelled = true
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [quietRefreshNonce])
 

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Why: repo selector, task-source controls, and task list stay co-located so their wiring reads in one place. */
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useShallow } from 'zustand/react/shallow'
 import {
@@ -151,21 +151,36 @@ import { useRepoAssigneesBySlug } from '@/hooks/useGitHubSlugMetadata'
 import { useTaskPageGitHubWorkItemMutation } from '@/hooks/useTaskPageGitHubWorkItemMutation'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import {
+  advanceTaskPageQuietRevalidateScope,
+  clearTaskPageGitHubAuthorityAbsentFromLoadedItems,
+  clearTaskPageGitHubAuthorityThroughGeneration,
+  getTaskPageQuietRevalidateBackoffAttempt,
+  getTaskPageGitHubRevalidatableAuthorityItemKeys,
+  isTaskPageQuietRevalidateRunCurrent,
+  isTaskPageQuietRevalidateScopeCurrent,
   LAG_BACKOFF_MS,
   LAG_WALL_BUDGET_MS,
   materializeTaskPageItemList,
   MAX_LAG_TRAILS,
   overlayPendingOnTaskPagePages,
+  patchTaskPageGitHubWorkItemPages,
   processTaskPageQuietRevalidateSettle,
-  reapplyPendingTaskPageGitHubMutationsToCache
+  reapplyPendingTaskPageGitHubMutationsToCache,
+  reconcileTaskPagePagesAfterQuietRefresh,
+  rebuildSoftHiddenKeysFromPendingAndSticky
 } from '@/components/task-page-github-work-item-mutations'
 import {
-  clearTaskPageGitHubConfirmedAuthority,
   getOrCreateQuietRevalidateState,
+  getTaskPageGitHubConfirmedAuthorityItemKeys,
   setTaskPageGitHubMutationQueryKey,
   taskPageGitHubItemKey
 } from '@/components/task-page-github-work-item-mutation-registry'
+import {
+  beginTaskPageQuietRevalidateRun,
+  finishTaskPageQuietRevalidateRun
+} from '@/components/task-page-github-work-item-quiet-state'
 import type { TaskPageGitHubMutationIntent } from '@/components/task-page-github-work-item-mutation-patches'
+import type { TaskPageGitHubPatchWorkItem } from '@/components/task-page-github-work-item-mutation-types'
 import GitHubItemDialog, { type ItemDialogTab } from '@/components/GitHubItemDialog'
 import PullRequestPage from '@/components/PullRequestPage'
 import GitLabItemDialog from '@/components/GitLabItemDialog'
@@ -436,10 +451,8 @@ const GITHUB_TASK_GRID_CLASS =
   'min-w-[790px] grid-cols-[72px_minmax(320px,1fr)_84px_100px_92px_122px]'
 const GITHUB_PR_TASK_GRID_CLASS =
   'min-w-[1020px] grid-cols-[72px_minmax(360px,2fr)_132px_128px_132px_92px_158px]'
-// Why: sticky ID/Title cells need an opaque fill so scrolled content doesn't
-// bleed through. Match the table canvas (bg-background) and accent hover used
-// by the rest of the row — not the old muted wash that made the list look muddy.
-const GITHUB_TASK_ROW_SURFACE_CLASS = 'bg-background'
+// Why: sticky cells need the row's opaque, animated surface to prevent bleed and hover flashes.
+const GITHUB_TASK_ROW_SURFACE_CLASS = 'bg-background transition-colors'
 const GITHUB_TASK_ROW_HOVER_SURFACE_CLASS = 'group-hover/github-task-row:bg-accent'
 const GITHUB_TASK_HEADER_SURFACE_CLASS =
   '[background:color-mix(in_srgb,var(--muted)_25%,var(--background))]'
@@ -561,14 +574,9 @@ function getTaskPageRepoCacheInput(repo: Repo): {
   }
 }
 
-// Why: the sticky header's bg must be opaque (GITHUB_TASK_HEADER_SURFACE_CLASS)
-// or vertically-scrolled rows bleed through it. These left-sticky cells
-// additionally need a ::before gap-cover so horizontally-scrolled header
-// columns don't show through the row's px-3 padding strip.
+// Why: opaque sticky headers and a padding-gap cover prevent vertical and horizontal bleed.
 const GITHUB_TASK_STICKY_ID_HEADER_CLASS = cn(
-  // Why: stretch to full row height so sticky fill covers the header band;
-  // flex centers the label without using grid items-center (which would shrink
-  // sticky cells and let scrolled content bleed at the edges).
+  // Why: full-height flex keeps the sticky fill from shrinking around its label.
   'sticky left-3 z-30 flex items-center before:absolute before:-left-3 before:top-0 before:bottom-0 before:w-3 before:bg-inherit',
   GITHUB_TASK_HEADER_SURFACE_CLASS
 )
@@ -1110,6 +1118,11 @@ type TaskPageGitHubWorkItemMutationRunner = {
     successToast?: string
     errorToast: string
   }) => Promise<'confirmed' | 'rolled_back' | 'stale'>
+  isIntentPending: (input: {
+    item: GitHubWorkItem
+    intent: TaskPageGitHubMutationIntent
+    sourceContext?: TaskSourceContext | null
+  }) => boolean
 }
 
 function GHStatusCell({
@@ -1127,6 +1140,7 @@ function GHStatusCell({
     createTaskPageGitHubStatusStateDraft(item)
   )
   const [open, setOpen] = useState(false)
+  const [statusUpdating, setStatusUpdating] = useState(false)
   const [duplicatePickerOpen, setDuplicatePickerOpen] = useState(false)
   const [duplicateSearch, setDuplicateSearch] = useState('')
   const [duplicateError, setDuplicateError] = useState<string | null>(null)
@@ -1193,6 +1207,11 @@ function GHStatusCell({
     setStatusStateDraft(resolvedStatusStateDraft)
   }
   const localState = resolvedStatusStateDraft.localState
+  const stateMutationPending = workItemMutation.isIntentPending({
+    item,
+    intent: { type: 'setState', state: localState === 'open' ? 'closed' : 'open' },
+    sourceContext
+  })
   const updateLocalState = useCallback(
     (nextState: GitHubWorkItem['state']) => {
       setStatusStateDraft((current) =>
@@ -1203,8 +1222,13 @@ function GHStatusCell({
   )
 
   const handleStateChange = useCallback(
-    (newState: 'open' | 'closed', closeAction?: TaskPageGitHubCloseAction) => {
-      if (newState === localState || item.type !== 'issue') {
+    async (newState: 'open' | 'closed', closeAction?: TaskPageGitHubCloseAction) => {
+      if (
+        statusUpdating ||
+        stateMutationPending ||
+        newState === localState ||
+        item.type !== 'issue'
+      ) {
         return
       }
       const parsedOwnerRepo = parsedIssueLink?.slug
@@ -1218,58 +1242,63 @@ function GHStatusCell({
       updateLocalState(newState)
       // Why: coordinator owns durable patch + soft-hide + quiet revalidate; keep
       // the status draft so one-frame flash is still covered until proven safe.
-      void workItemMutation.run({
-        item,
-        intent: { type: 'setState', state: newState, closeAction },
-        sourceContext,
-        errorToast: translate('auto.components.TaskPage.1c893195ac', 'Failed to update state'),
-        mutate: async () => {
-          const target = getActiveRuntimeTarget(sourceSettings)
-          // Why: issue rows can be sourced by owner/repo URL instead of the local
-          // repo context; slug-aware writes preserve close reasons and duplicates.
-          if (parsedOwnerRepo) {
-            return target.kind === 'environment'
-              ? callRuntimeRpc<{ ok?: boolean; error?: { message?: string } | string }>(
-                  target,
-                  'github.project.updateIssueBySlug',
-                  {
+      setStatusUpdating(true)
+      try {
+        await workItemMutation.run({
+          item,
+          intent: { type: 'setState', state: newState, closeAction },
+          sourceContext,
+          errorToast: translate('auto.components.TaskPage.1c893195ac', 'Failed to update state'),
+          mutate: async () => {
+            const target = getActiveRuntimeTarget(sourceSettings)
+            // Why: issue rows can be sourced by owner/repo URL instead of the local
+            // repo context; slug-aware writes preserve close reasons and duplicates.
+            if (parsedOwnerRepo) {
+              return target.kind === 'environment'
+                ? callRuntimeRpc<{ ok?: boolean; error?: { message?: string } | string }>(
+                    target,
+                    'github.project.updateIssueBySlug',
+                    {
+                      owner: parsedOwnerRepo.owner,
+                      repo: parsedOwnerRepo.repo,
+                      host: githubProjectHost(parsedOwnerRepo.host),
+                      number: item.number,
+                      updates
+                    },
+                    { timeoutMs: 30_000 }
+                  )
+                : window.api.gh.updateIssueBySlug({
                     owner: parsedOwnerRepo.owner,
                     repo: parsedOwnerRepo.repo,
                     host: githubProjectHost(parsedOwnerRepo.host),
                     number: item.number,
                     updates
-                  },
+                  })
+            }
+            if (!repo) {
+              throw new Error('No GitHub repository context available for this issue.')
+            }
+            const runtimeRepoId =
+              sourceContext?.provider === 'github' ? (sourceContext.repoId ?? repo.id) : repo.id
+            return target.kind === 'environment'
+              ? callRuntimeRpc<{ ok?: boolean; error?: string }>(
+                  target,
+                  'github.updateIssue',
+                  { repo: runtimeRepoId, number: item.number, updates },
                   { timeoutMs: 30_000 }
                 )
-              : window.api.gh.updateIssueBySlug({
-                  owner: parsedOwnerRepo.owner,
-                  repo: parsedOwnerRepo.repo,
-                  host: githubProjectHost(parsedOwnerRepo.host),
+              : window.api.gh.updateIssue({
+                  repoPath: repo.path,
+                  repoId: repo.id,
+                  sourceContext,
                   number: item.number,
                   updates
                 })
           }
-          if (!repo) {
-            throw new Error('No GitHub repository context available for this issue.')
-          }
-          const runtimeRepoId =
-            sourceContext?.provider === 'github' ? (sourceContext.repoId ?? repo.id) : repo.id
-          return target.kind === 'environment'
-            ? callRuntimeRpc<{ ok?: boolean; error?: string }>(
-                target,
-                'github.updateIssue',
-                { repo: runtimeRepoId, number: item.number, updates },
-                { timeoutMs: 30_000 }
-              )
-            : window.api.gh.updateIssue({
-                repoPath: repo.path,
-                repoId: repo.id,
-                sourceContext,
-                number: item.number,
-                updates
-              })
-        }
-      })
+        })
+      } finally {
+        setStatusUpdating(false)
+      }
       // Why: draft realigns from item.state via resolveTaskPageGitHubStatusStateDraft
       // when patchWorkItem (begin/rollback) updates the cache-backed row.
     },
@@ -1280,6 +1309,8 @@ function GHStatusCell({
       repo,
       sourceContext,
       sourceSettings,
+      stateMutationPending,
+      statusUpdating,
       updateLocalState,
       workItemMutation
     ]
@@ -1330,6 +1361,7 @@ function GHStatusCell({
       <PopoverTrigger asChild>
         <button
           type="button"
+          disabled={statusUpdating || stateMutationPending}
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
           className={cn(
@@ -1825,6 +1857,15 @@ function GHAssigneesCell({
       }
       const userLoginKey = user.login.toLowerCase()
       const isOn = assignees.some((a) => a.login.toLowerCase() === userLoginKey)
+      if (
+        workItemMutation.isIntentPending({
+          item,
+          intent: { type: 'toggleAssignee', user },
+          sourceContext
+        })
+      ) {
+        return
+      }
       setPendingLogin(user.login)
       try {
         await workItemMutation.run({
@@ -2306,16 +2347,20 @@ function PRReviewCell({
     // Why: pre-network optimistic update via coordinator; local display follows
     // item.reviewRequests once patchWorkItem + reconcile land.
     const optimistic = buildRequestedReviewUsers(logins, reviewerCandidates, localReviewRequests)
+    const intent = {
+      type: 'addReviewers' as const,
+      logins,
+      candidates: reviewerCandidates
+    }
+    if (workItemMutation.isIntentPending({ item, intent, sourceContext })) {
+      return
+    }
     setLocalReviewRequests(optimistic)
     setSubmitting(true)
     try {
       const outcome = await workItemMutation.run({
         item,
-        intent: {
-          type: 'addReviewers',
-          logins,
-          candidates: reviewerCandidates
-        },
+        intent,
         sourceContext,
         successToast: translate('auto.components.TaskPage.8f06dbb9e5', 'Reviewer requested'),
         errorToast: translate('auto.components.TaskPage.dc67f69962', 'Failed to request reviewer'),
@@ -2366,6 +2411,10 @@ function PRReviewCell({
     if (logins.length === 0) {
       return
     }
+    const intent = { type: 'removeReviewers' as const, logins }
+    if (workItemMutation.isIntentPending({ item, intent, sourceContext })) {
+      return
+    }
     const removed = new Set(logins.map((login) => login.toLowerCase()))
     setLocalReviewRequests((current) =>
       current.filter((reviewer) => !removed.has(reviewer.login.toLowerCase()))
@@ -2374,7 +2423,7 @@ function PRReviewCell({
     try {
       const outcome = await workItemMutation.run({
         item,
-        intent: { type: 'removeReviewers', logins },
+        intent,
         sourceContext,
         successToast:
           logins.length === 1
@@ -2416,6 +2465,14 @@ function PRReviewCell({
   }
 
   const requestReviewer = async (reviewer: GitHubAssignableUser): Promise<void> => {
+    const intent: TaskPageGitHubMutationIntent = selectedReviewerLogins.has(
+      reviewer.login.toLowerCase()
+    )
+      ? { type: 'removeReviewers', logins: [reviewer.login] }
+      : { type: 'addReviewers', logins: [reviewer.login], candidates: reviewerCandidates }
+    if (workItemMutation.isIntentPending({ item, intent, sourceContext })) {
+      return
+    }
     // Close the popover immediately for responsiveness; the GitHub request/remove runs in the background and toasts on completion.
     setOpen(false)
     setReviewerInput('')
@@ -2758,7 +2815,23 @@ function PRMergeCell({
   const mergePresentation = presentGitHubPRMergeState(item)
   const mergeMethods = resolveGitHubPRMergeMethods(item.mergeMethodSettings)
   const prRepo = resolveTaskPullRequestRepo(item)
-  const mergeDisabled = !repo || merging || !mergePresentation.directMergeAvailable
+  const mergeMutationPending = workItemMutation.isIntentPending({
+    item,
+    intent: { type: 'merge' },
+    sourceContext
+  })
+  const autoMergeMutationPending = mergePresentation.autoMergeAction
+    ? workItemMutation.isIntentPending({
+        item,
+        intent: {
+          type: 'setAutoMerge',
+          enabled: mergePresentation.autoMergeAction.kind === 'enable'
+        },
+        sourceContext
+      })
+    : false
+  const mergeDisabled =
+    !repo || merging || mergeMutationPending || !mergePresentation.directMergeAvailable
 
   const handleMerge = async (method: GitHubPRMergeMethod): Promise<void> => {
     if (!repo || mergeDisabled) {
@@ -2822,7 +2895,7 @@ function PRMergeCell({
   }
 
   const handleAutoMerge = async (): Promise<void> => {
-    if (!repo || !mergePresentation.autoMergeAction) {
+    if (!repo || autoMergeMutationPending || !mergePresentation.autoMergeAction) {
       return
     }
     const enabled = mergePresentation.autoMergeAction.kind === 'enable'
@@ -2900,7 +2973,10 @@ function PRMergeCell({
       </Tooltip>
       <DropdownMenuContent align="start" onClick={(event) => event.stopPropagation()}>
         {mergePresentation.autoMergeAction && (
-          <DropdownMenuItem disabled={!repo || merging} onSelect={() => void handleAutoMerge()}>
+          <DropdownMenuItem
+            disabled={!repo || merging || autoMergeMutationPending}
+            onSelect={() => void handleAutoMerge()}
+          >
             <GitMerge className="size-4" />
             {mergePresentation.autoMergeAction.label}
           </DropdownMenuItem>
@@ -3828,6 +3904,10 @@ export default function TaskPage(): React.JSX.Element {
     return [page0]
   })
   const [currentPage, setCurrentPage] = useState(0)
+  const pagesRef = useRef(pages)
+  const currentPageRef = useRef(currentPage)
+  pagesRef.current = pages
+  currentPageRef.current = currentPage
   const [paginationLoading, setPaginationLoading] = useState(false)
   const [loadingTargetPage, setLoadingTargetPage] = useState<number | null>(null)
   const [countedTotalPages, setCountedTotalPages] = useState<number | null>(null)
@@ -3838,6 +3918,7 @@ export default function TaskPage(): React.JSX.Element {
   // Why: synchronous mirror of countedTotalPages — the empty-page branch needs
   // the committed value, not a click-time closure, and refs update immediately.
   const countedTotalPagesRef = useRef<number | null>(null)
+  const hardRefreshEpochRef = useRef(0)
   const fetchWorkItemsNextPage = useAppStore((s) => s.fetchWorkItemsNextPage)
   const countWorkItemsAcrossRepos = useAppStore((s) => s.countWorkItemsAcrossRepos)
 
@@ -3993,26 +4074,7 @@ export default function TaskPage(): React.JSX.Element {
       shouldPatch?: (item: GitHubWorkItem) => boolean
     ): void => {
       setPages((current) => {
-        let changed = false
-        const nextPages = current.map((page) => {
-          if (!page) {
-            return page
-          }
-          let pageChanged = false
-          const nextPage = page.map((item) => {
-            if (item.id !== itemKey.id || item.repoId !== itemKey.repoId) {
-              return item
-            }
-            if (shouldPatch && !shouldPatch(item)) {
-              return item
-            }
-            pageChanged = true
-            changed = true
-            return { ...item, ...patch }
-          })
-          return pageChanged ? nextPage : page
-        })
-        return changed ? nextPages : current
+        return patchTaskPageGitHubWorkItemPages(current, itemKey, patch, shouldPatch)
       })
     },
     []
@@ -5867,7 +5929,7 @@ export default function TaskPage(): React.JSX.Element {
     return `${githubMode}::${hostOrSetupIds.join(',')}::${repoIds.join(',')}::${appliedTaskSearch}`
   }, [appliedTaskSearch, githubMode, selectedRepos])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setTaskPageGitHubMutationQueryKey(githubWorkItemMutationQueryKey)
   }, [githubWorkItemMutationQueryKey])
 
@@ -5894,13 +5956,59 @@ export default function TaskPage(): React.JSX.Element {
     setQuietRefreshNonce((current) => current + 1)
   }, [])
 
+  const patchCoordinatedGitHubWorkItem = useCallback(
+    (...args: Parameters<TaskPageGitHubPatchWorkItem>): void => {
+      const [id, patch, repoId, options] = args
+      useAppStore.getState().patchWorkItem(id, patch, repoId, options)
+      if (repoId) {
+        patchTaskPageWorkItemRows({ id, repoId }, patch)
+      }
+    },
+    [patchTaskPageWorkItemRows]
+  )
+
   const githubWorkItemMutation = useTaskPageGitHubWorkItemMutation({
-    appliedTaskSearch,
     queryKey: githubWorkItemMutationQueryKey,
     query: appliedTaskQuery,
     viewerLogin: githubViewerLogin,
-    scheduleQuietRevalidate
+    patchWorkItem: patchCoordinatedGitHubWorkItem
   })
+
+  useLayoutEffect(() => {
+    rebuildSoftHiddenKeysFromPendingAndSticky({
+      query: appliedTaskQuery,
+      queryKey: githubWorkItemMutationQueryKey,
+      viewerLogin: githubViewerLogin,
+      items: pages.flatMap((page) => page ?? [])
+    })
+  }, [appliedTaskQuery, githubViewerLogin, githubWorkItemMutationQueryKey, pages])
+
+  const observedQuietScopeRef = useRef({ queryKey: '', dirtyGeneration: -1 })
+  useEffect(() => {
+    if (taskSource !== 'github' || githubMode !== 'items') {
+      observedQuietScopeRef.current = { queryKey: '', dirtyGeneration: -1 }
+      return
+    }
+    const quietState = getOrCreateQuietRevalidateState(githubWorkItemMutationQueryKey)
+    const enteringScope = observedQuietScopeRef.current.queryKey !== githubWorkItemMutationQueryKey
+    const dirtyAdvanced = quietState.dirtyGeneration > observedQuietScopeRef.current.dirtyGeneration
+    observedQuietScopeRef.current = {
+      queryKey: githubWorkItemMutationQueryKey,
+      dirtyGeneration: quietState.dirtyGeneration
+    }
+    if (
+      getTaskPageGitHubConfirmedAuthorityItemKeys().size > 0 &&
+      (enteringScope || dirtyAdvanced)
+    ) {
+      scheduleQuietRevalidate()
+    }
+  }, [
+    githubMode,
+    githubWorkItemMutation.softHiddenItemKeys,
+    githubWorkItemMutationQueryKey,
+    scheduleQuietRevalidate,
+    taskSource
+  ])
 
   const selectedGitHubRepoExternalLink = useMemo(() => {
     if (selectedRepos.length !== 1) {
@@ -6396,14 +6504,14 @@ export default function TaskPage(): React.JSX.Element {
           }
           return
         }
-        setPages((previous) => {
-          const next = [...previous]
-          while (next.length <= target) {
-            next.push(null)
-          }
-          next[target] = overlayPendingOnTaskPagePages([items])[0] ?? []
-          return next
-        })
+        const nextPages = [...pagesRef.current]
+        while (nextPages.length <= target) {
+          nextPages.push(null)
+        }
+        nextPages[target] = overlayPendingOnTaskPagePages([items])[0] ?? []
+        pagesRef.current = nextPages
+        currentPageRef.current = target
+        setPages(nextPages)
         setCurrentPage(target)
       } catch (err) {
         console.error('Failed to load next page:', err)
@@ -6506,6 +6614,7 @@ export default function TaskPage(): React.JSX.Element {
         queryKey: githubWorkItemMutationQueryKey
       })
     ])
+    currentPageRef.current = 0
     setCurrentPage(0)
     setCountedTotalPages(null)
     countedTotalPagesRef.current = null
@@ -6523,6 +6632,12 @@ export default function TaskPage(): React.JSX.Element {
       workItemsInvalidationNonce !== lastFetchedInvalidationNonceRef.current
     lastFetchedInvalidationNonceRef.current = workItemsInvalidationNonce
     const forcedFetch = (forceRefresh && taskRefreshNonce > 0) || preferenceInvalidated
+    if (forcedFetch) {
+      hardRefreshEpochRef.current += 1
+    }
+    const forcedFetchAuthorityGeneration = forcedFetch
+      ? getOrCreateQuietRevalidateState(githubWorkItemMutationQueryKey).dirtyGeneration
+      : null
     const repoArgs = selectedRepos.map((r) => ({
       repoId: r.id,
       path: r.path,
@@ -6544,65 +6659,86 @@ export default function TaskPage(): React.JSX.Element {
     // Why: snapshot retrying keys at dispatch so an earlier settling effect doesn't wipe a newer retry's pending source.
     const dispatchedRetrySourceKeys = retryingSourceKeys
     void fetchWorkItemsAcrossRepos(repoArgs, githubPerRepoPageLimit, githubPageSize, q, {
-      ...deriveTaskPageGitHubWorkItemsFetchOptions(forcedFetch, shouldProbeOnLanding)
+      ...deriveTaskPageGitHubWorkItemsFetchOptions(forcedFetch, shouldProbeOnLanding),
+      ...(forcedFetch ? { requireComplete: true } : {})
     })
-      .then(({ items, failedCount: failed, githubUnavailable: unavailable }) => {
-        // Why: clear only the dispatch-time snapshot keys so an overlapping retry's newer source isn't wiped.
-        setRetryingSourceKeys((prev) => {
-          if (dispatchedRetrySourceKeys.size === 0) {
-            return prev
-          }
-          const next = new Set(prev)
-          for (const key of dispatchedRetrySourceKeys) {
-            next.delete(key)
-          }
-          return next
-        })
-        if (cancelled) {
-          return
-        }
-        // Why: user hard refresh (force) is design tier-3 — drop confirmed
-        // authority so search can adopt for non-pending families. Pending ops
-        // still overlay. Quiet path must NOT clear authority.
-        if (forcedFetch) {
-          clearTaskPageGitHubConfirmedAuthority()
-        }
-        // Why: best-effort cache re-apply after wholesale list replace (K4).
-        const sourceContextByRepoId = new Map(
-          repoArgs.map((r) => [r.repoId, r.sourceContext] as const)
-        )
-        reapplyPendingTaskPageGitHubMutationsToCache({
+      .then(
+        ({
           items,
-          patchWorkItem: useAppStore.getState().patchWorkItem,
-          sourceContextByRepoId
-        })
-        if (shouldProbeOnLanding) {
-          const replaceFirstPage = shouldReplaceTaskPageItemsAfterRefresh(page0Raw, items)
-          const resetPagination = shouldResetTaskPagePaginationAfterLandingRefresh(page0Raw, items)
-          setPages((current) =>
-            reconcileTaskPagePagesAfterLandingRefresh(current, items).map((page) =>
-              page ? (overlayPendingOnTaskPagePages([page])[0] ?? []) : null
+          failedCount: failed,
+          githubUnavailable: unavailable,
+          requestFailureCount = 0
+        }) => {
+          // Why: clear only the dispatch-time snapshot keys so an overlapping retry's newer source isn't wiped.
+          setRetryingSourceKeys((prev) => {
+            if (dispatchedRetrySourceKeys.size === 0) {
+              return prev
+            }
+            const next = new Set(prev)
+            for (const key of dispatchedRetrySourceKeys) {
+              next.delete(key)
+            }
+            return next
+          })
+          if (cancelled) {
+            return
+          }
+          // Why: user hard refresh (force) is design tier-3 — drop confirmed
+          // authority so search can adopt for non-pending families. Pending ops
+          // still overlay. Quiet path must NOT clear authority.
+          if (
+            forcedFetchAuthorityGeneration !== null &&
+            failed === 0 &&
+            requestFailureCount === 0 &&
+            !unavailable
+          ) {
+            clearTaskPageGitHubAuthorityThroughGeneration(
+              githubWorkItemMutationQueryKey,
+              forcedFetchAuthorityGeneration
             )
+          }
+          // Why: best-effort cache re-apply after wholesale list replace (K4).
+          const sourceContextByRepoId = new Map(
+            repoArgs.map((r) => [r.repoId, r.sourceContext] as const)
           )
-          if (replaceFirstPage || resetPagination) {
+          reapplyPendingTaskPageGitHubMutationsToCache({
+            items,
+            patchWorkItem: useAppStore.getState().patchWorkItem,
+            sourceContextByRepoId
+          })
+          if (shouldProbeOnLanding) {
+            const replaceFirstPage = shouldReplaceTaskPageItemsAfterRefresh(page0Raw, items)
+            const resetPagination = shouldResetTaskPagePaginationAfterLandingRefresh(
+              page0Raw,
+              items
+            )
+            setPages((current) =>
+              reconcileTaskPagePagesAfterLandingRefresh(current, items).map((page) =>
+                page ? (overlayPendingOnTaskPagePages([page])[0] ?? []) : null
+              )
+            )
+            if (replaceFirstPage || resetPagination) {
+              currentPageRef.current = 0
+              setCurrentPage(0)
+            }
+          } else {
+            setPages((previous) => [
+              materializeTaskPageItemList({
+                networkItems: items,
+                previousItems: previous.flatMap((page) => page ?? []),
+                queryKey: githubWorkItemMutationQueryKey
+              })
+            ])
+            currentPageRef.current = 0
             setCurrentPage(0)
           }
-        } else {
-          setPages((previous) => [
-            materializeTaskPageItemList({
-              networkItems: items,
-              previousItems: previous.flatMap((page) => page ?? []),
-              queryKey: githubWorkItemMutationQueryKey
-            })
-          ])
-          setCurrentPage(0)
+          setFailedCount(failed)
+          setGithubUnavailable(unavailable)
+          setTasksLoading(false)
+          setTasksRefreshing(false)
+          setTasksFiltering(false)
         }
-        setFailedCount(failed)
-        setGithubUnavailable(unavailable)
-        setTasksLoading(false)
-        setTasksRefreshing(false)
-        setTasksFiltering(false)
-      })
+      )
       .catch((err) => {
         // Why: fetchWorkItemsAcrossRepos swallows per-repo failures, so a reject here is IPC/programmer error — surface it.
         // Why: clear only the dispatch-time snapshot keys so an overlapping retry's newer source isn't wiped.
@@ -6671,6 +6807,15 @@ export default function TaskPage(): React.JSX.Element {
   // shared quietState (inFlight/trailingQueued), so a nonce-triggered re-render
   // must NOT cancel the in-flight run's trailing bookkeeping.
   const quietRevalidateMountedRef = useMountedRef()
+  const quietRevalidateOwnerRef = useRef<object>({})
+  const quietRevalidateScopeRef = useRef({
+    queryKey: githubWorkItemMutationQueryKey,
+    generation: 0
+  })
+  quietRevalidateScopeRef.current = advanceTaskPageQuietRevalidateScope(
+    quietRevalidateScopeRef.current,
+    githubWorkItemMutationQueryKey
+  )
 
   // Why: dedicated quiet revalidate path (K23) — never tasksFiltering / skeleton,
   // never blanks pages, never bumps taskRefreshNonce. Single-flight with backoff
@@ -6683,15 +6828,53 @@ export default function TaskPage(): React.JSX.Element {
       return
     }
     const quietState = getOrCreateQuietRevalidateState(githubWorkItemMutationQueryKey)
-    // Why: coalesce concurrent quiet requests so lag cannot stack force fetches.
-    if (quietState.inFlight) {
-      quietState.trailingQueued = true
+    const loadedItemKeys = new Set(
+      pagesRef.current.flatMap((page) =>
+        (page ?? []).map((item) => taskPageGitHubItemKey(item.repoId, item.id))
+      )
+    )
+    clearTaskPageGitHubAuthorityAbsentFromLoadedItems(loadedItemKeys)
+    if (getTaskPageGitHubConfirmedAuthorityItemKeys().size === 0) {
       return
     }
-    quietState.inFlight = true
-    quietState.trailingQueued = false
+    const quietRunGeneration = beginTaskPageQuietRevalidateRun(
+      quietState,
+      quietRevalidateOwnerRef.current
+    )
+    if (quietRunGeneration === null) {
+      return
+    }
     quietState.fetchStartedAtGeneration = quietState.dirtyGeneration
+    const scopeGeneration = quietRevalidateScopeRef.current.generation
+    const hardRefreshEpoch = hardRefreshEpochRef.current
+    const isCurrentQueryScope = (): boolean =>
+      isTaskPageQuietRevalidateScopeCurrent(
+        quietRevalidateScopeRef.current,
+        githubWorkItemMutationQueryKey,
+        scopeGeneration
+      )
+    const isCurrentScope = (): boolean =>
+      isTaskPageQuietRevalidateRunCurrent(
+        quietRevalidateScopeRef.current,
+        githubWorkItemMutationQueryKey,
+        scopeGeneration,
+        hardRefreshEpoch,
+        hardRefreshEpochRef.current
+      )
     const q = stripRepoQualifiers(appliedTaskSearch.trim())
+    const authorityItemKeys = getTaskPageGitHubRevalidatableAuthorityItemKeys(
+      githubWorkItemMutationQueryKey
+    )
+    const authorityPage = pages.findIndex((page) =>
+      page?.some((item) => authorityItemKeys.has(taskPageGitHubItemKey(item.repoId, item.id)))
+    )
+    const quietPage = authorityPage >= 0 ? authorityPage : currentPage
+    const visiblePage = currentPage > quietPage ? currentPage : undefined
+    const pageItemKeys = (page: number): Set<string> =>
+      new Set((pages[page] ?? []).map((item) => taskPageGitHubItemKey(item.repoId, item.id)))
+    const authorityPageItemKeys = pageItemKeys(quietPage)
+    const visiblePageItemKeys = visiblePage === undefined ? undefined : pageItemKeys(visiblePage)
+    const revalidatedItemKeys = new Set([...authorityPageItemKeys, ...(visiblePageItemKeys ?? [])])
     const repoArgs = selectedRepos.map((r) => ({
       repoId: r.id,
       path: r.path,
@@ -6699,44 +6882,148 @@ export default function TaskPage(): React.JSX.Element {
       sourceContext: getTaskPageRepoSourceContext(r, 'github')
     }))
     const sourceContextByRepoId = new Map(repoArgs.map((r) => [r.repoId, r.sourceContext] as const))
-    void fetchWorkItemsAcrossRepos(repoArgs, PER_REPO_FETCH_LIMIT, CROSS_REPO_DISPLAY_LIMIT, q, {
-      force: true,
-      noCache: true
-    })
-      .then(async ({ items }) => {
+    const fetchQuietPage = (page: number): Promise<GitHubWorkItem[]> =>
+      page === 0
+        ? fetchWorkItemsAcrossRepos(repoArgs, githubPerRepoPageLimit, githubPageSize, q, {
+            force: true,
+            noCache: true,
+            requireComplete: true,
+            allowStaleFallback: false
+          }).then((result) => {
+            if (result.failedCount > 0 || result.githubUnavailable) {
+              throw new Error('GitHub quiet revalidate did not receive a fresh complete result.')
+            }
+            return result.items
+          })
+        : fetchWorkItemsNextPage(
+            repoArgs,
+            githubPerRepoPageLimit,
+            githubPageSize,
+            q,
+            taskPageToGitHubApiPage(page),
+            { noCache: true, requireComplete: true }
+          ).then((result) => {
+            if (result.failedCount > 0 || result.errorTypes.length > 0) {
+              throw new Error('GitHub quiet revalidate did not receive a complete page result.')
+            }
+            return result.items
+          })
+    const quietFetch = Promise.all([
+      fetchQuietPage(quietPage),
+      ...(visiblePage === undefined ? [] : [fetchQuietPage(visiblePage)])
+    ]).then(([authorityItems, visibleItems]) => ({ authorityItems, visibleItems }))
+    let networkRetryDelay: number | null = null
+    void quietFetch
+      .then(async ({ authorityItems, visibleItems }) => {
         // Why: skip renderer state writes after unmount, but still let .finally
         // settle the shared quietState so a queued trailing is never stranded.
-        if (!quietRevalidateMountedRef.current) {
+        if (!quietRevalidateMountedRef.current || !isCurrentScope()) {
           return
         }
+        let fetchedVisiblePage = visiblePage
+        let fetchedVisibleItems = visibleItems
+        let fetchedVisiblePageItemKeys = visiblePageItemKeys
+        const latestVisiblePage =
+          currentPageRef.current > quietPage ? currentPageRef.current : undefined
+        if (latestVisiblePage !== undefined && latestVisiblePage !== fetchedVisiblePage) {
+          fetchedVisiblePage = latestVisiblePage
+          const latestVisiblePageItemKeys = new Set(
+            (pagesRef.current[latestVisiblePage] ?? []).map((item) =>
+              taskPageGitHubItemKey(item.repoId, item.id)
+            )
+          )
+          fetchedVisiblePageItemKeys = latestVisiblePageItemKeys
+          fetchedVisibleItems = await fetchQuietPage(latestVisiblePage)
+          for (const itemKey of latestVisiblePageItemKeys) {
+            revalidatedItemKeys.add(itemKey)
+          }
+          if (!quietRevalidateMountedRef.current || !isCurrentScope()) {
+            return
+          }
+        }
+        const liveVisiblePage =
+          currentPageRef.current > quietPage ? currentPageRef.current : undefined
+        const liveVisibleItems =
+          liveVisiblePage === undefined
+            ? undefined
+            : liveVisiblePage === fetchedVisiblePage
+              ? fetchedVisibleItems
+              : (pagesRef.current[liveVisiblePage] ?? [])
+        const liveVisiblePageItemKeys =
+          liveVisiblePage === undefined
+            ? undefined
+            : new Set(
+                (pagesRef.current[liveVisiblePage] ?? []).map((item) =>
+                  taskPageGitHubItemKey(item.repoId, item.id)
+                )
+              )
+        quietState.networkFailureAttempts = 0
+        const revalidatedItems = [
+          ...authorityItems,
+          ...(visibleItems ?? []),
+          ...(fetchedVisiblePage === visiblePage ? [] : (fetchedVisibleItems ?? []))
+        ]
         reapplyPendingTaskPageGitHubMutationsToCache({
-          items,
+          items: revalidatedItems,
           patchWorkItem: useAppStore.getState().patchWorkItem,
           sourceContextByRepoId
         })
-        const settle = await processTaskPageQuietRevalidateSettle({
+        const settle = processTaskPageQuietRevalidateSettle({
           queryKey: githubWorkItemMutationQueryKey,
-          networkItems: items,
+          networkItems: revalidatedItems,
           patchWorkItem: useAppStore.getState().patchWorkItem,
           sourceContextByRepoId,
-          // Why: TaskPage owns trailing via quietRefreshNonce + backoff below.
-          scheduleTrailing: false
+          revalidatedItemKeys
         })
-        setPages((previous) => [
-          materializeTaskPageItemList({
-            networkItems: items,
-            previousItems: previous.flatMap((page) => page ?? []),
-            queryKey: githubWorkItemMutationQueryKey
-          })
-        ])
-        const lagValues = [...quietState.lagSkipAttempts.values()]
-        const attempts = lagValues.length === 0 ? 0 : Math.max(...lagValues)
+        const networkItemKeys = new Set(
+          authorityItems.map((item) => taskPageGitHubItemKey(item.repoId, item.id))
+        )
+        const visibleNetworkItemKeys = new Set(
+          (liveVisibleItems ?? []).map((item) => taskPageGitHubItemKey(item.repoId, item.id))
+        )
+        const fetchedVisibleNetworkItemKeys = new Set(
+          (fetchedVisibleItems ?? []).map((item) => taskPageGitHubItemKey(item.repoId, item.id))
+        )
+        const membershipChanged =
+          networkItemKeys.size !== authorityPageItemKeys.size ||
+          [...networkItemKeys].some((key) => !authorityPageItemKeys.has(key)) ||
+          (fetchedVisiblePageItemKeys !== undefined &&
+            (fetchedVisibleNetworkItemKeys.size !== fetchedVisiblePageItemKeys.size ||
+              [...fetchedVisibleNetworkItemKeys].some(
+                (key) => !fetchedVisiblePageItemKeys.has(key)
+              ))) ||
+          (liveVisiblePageItemKeys !== undefined &&
+            (visibleNetworkItemKeys.size !== liveVisiblePageItemKeys.size ||
+              [...visibleNetworkItemKeys].some((key) => !liveVisiblePageItemKeys.has(key))))
+        const reconciledPages = reconcileTaskPagePagesAfterQuietRefresh({
+          pages: pagesRef.current,
+          queryKey: githubWorkItemMutationQueryKey,
+          authorityPage: quietPage,
+          authorityItems,
+          membershipChanged,
+          ...(liveVisiblePage === undefined || liveVisibleItems === undefined
+            ? {}
+            : { visiblePage: liveVisiblePage, visibleItems: liveVisibleItems })
+        })
+        pagesRef.current = reconciledPages
+        setPages(reconciledPages)
+        const attempts = getTaskPageQuietRevalidateBackoffAttempt(
+          quietState.lagSkipAttempts.values()
+        )
         const wallExceeded =
           quietState.lastConfirmAt > 0 && Date.now() - quietState.lastConfirmAt > LAG_WALL_BUDGET_MS
         // Why: a new mutation confirmed while this fetch was in flight (queued) is
         // fresh work and must always revalidate — only lag *retries* (needTrailing)
         // are bounded by attempts/wall so a stuck server can't spin forever.
-        const hasQueuedWork = quietState.trailingQueued
+        const hasQueuedWork =
+          quietState.trailingQueued ||
+          [...getTaskPageGitHubRevalidatableAuthorityItemKeys(githubWorkItemMutationQueryKey)].some(
+            (itemKey) =>
+              !revalidatedItemKeys.has(itemKey) &&
+              pages.some((page) =>
+                page?.some((item) => taskPageGitHubItemKey(item.repoId, item.id) === itemKey)
+              )
+          )
         quietState.trailingQueued = false
         const lagTrail = settle.needTrailing && attempts < MAX_LAG_TRAILS && !wallExceeded
         if ((hasQueuedWork || lagTrail) && quietRevalidateMountedRef.current) {
@@ -6744,7 +7031,7 @@ export default function TaskPage(): React.JSX.Element {
             ? 0
             : (LAG_BACKOFF_MS[Math.min(attempts, LAG_BACKOFF_MS.length - 1)] ?? 500)
           window.setTimeout(() => {
-            if (quietRevalidateMountedRef.current) {
+            if (quietRevalidateMountedRef.current && isCurrentScope()) {
               setQuietRefreshNonce((current) => current + 1)
             }
           }, delay)
@@ -6753,15 +7040,44 @@ export default function TaskPage(): React.JSX.Element {
       .catch((err) => {
         // Quiet revalidate soft-fails; keep optimistic/sticky state.
         console.error('Quiet GitHub work-item revalidate failed:', err)
+        if (quietRevalidateMountedRef.current && isCurrentScope()) {
+          quietState.networkFailureAttempts += 1
+          if (quietState.networkFailureAttempts <= 2) {
+            networkRetryDelay =
+              LAG_BACKOFF_MS[quietState.networkFailureAttempts - 1] ?? LAG_BACKOFF_MS[0]
+          }
+        }
       })
       .finally(() => {
-        quietState.inFlight = false
+        if (
+          !finishTaskPageQuietRevalidateRun(
+            quietState,
+            quietRevalidateOwnerRef.current,
+            quietRunGeneration
+          )
+        ) {
+          return
+        }
         // Why: drain a trailing queued from the shared quietState — not the old
         // per-render cancelled flag, which stranded the retry when a new nonce
         // arrived mid-flight. Gate the renderer bump on mount only.
-        if (quietState.trailingQueued && quietRevalidateMountedRef.current) {
+        if (
+          quietState.trailingQueued &&
+          quietRevalidateMountedRef.current &&
+          isCurrentQueryScope()
+        ) {
           quietState.trailingQueued = false
           setQuietRefreshNonce((current) => current + 1)
+        } else if (
+          networkRetryDelay !== null &&
+          quietRevalidateMountedRef.current &&
+          isCurrentScope()
+        ) {
+          window.setTimeout(() => {
+            if (quietRevalidateMountedRef.current && isCurrentScope()) {
+              setQuietRefreshNonce((current) => current + 1)
+            }
+          }, networkRetryDelay)
         }
       })
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -9596,7 +9912,7 @@ export default function TaskPage(): React.JSX.Element {
                 <div
                   // Why: z-40 must beat the rows' sticky left cells (z-20); this stacking context's z sets the whole header's level.
                   className={cn(
-                    'sticky top-0 z-40 grid h-8 gap-3 border-b border-border/50 px-3 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground [&>span]:flex [&>span]:items-center',
+                    'sticky top-0 z-40 grid h-8 gap-3 border-b border-border/50 px-3 text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground [&>span]:flex [&>span]:items-center',
                     GITHUB_TASK_HEADER_SURFACE_CLASS,
                     githubTaskGridClass
                   )}
@@ -9824,7 +10140,9 @@ export default function TaskPage(): React.JSX.Element {
                         : null
                       const githubTaskIdPill = (
                         <span
-                          className="inline-flex items-center gap-1 rounded-md border border-border/40 bg-muted/30 px-1.5 py-0.5 text-muted-foreground"
+                          // Why: no fill — a muted wash on the pill stacks on the
+                          // row's hover:bg-accent and reads as a second hover tint.
+                          className="inline-flex items-center gap-1 rounded-md border border-border/40 px-1.5 py-0.5 text-muted-foreground"
                           aria-label={`${item.type === 'pr' ? (isTaskPageGitHubDraftPR(item) ? 'Draft pull request' : 'Pull request') : 'Issue'} #${item.number}`}
                         >
                           {item.type === 'pr' ? (
@@ -9860,8 +10178,9 @@ export default function TaskPage(): React.JSX.Element {
                             }
                           }}
                           className={cn(
-                            // Why: hover uses bg-accent on both the row and sticky
-                            // ID/Title cells so left columns match the rest of the row.
+                            // Why: sticky ID/Title paint the same bg-background /
+                            // hover:bg-accent pair (with transition-colors) so the
+                            // left columns don't flash a separate hover wash.
                             // Grid stretch (default) keeps sticky fills full-height.
                             'group/github-task-row grid min-h-12 cursor-pointer gap-3 px-3 py-2.5 text-left transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
                             githubTaskGridClass
@@ -10175,6 +10494,7 @@ export default function TaskPage(): React.JSX.Element {
                     loadingTarget={loadingTargetPage}
                     onPageChange={(page) => {
                       if (pages[page] !== null && pages[page] !== undefined) {
+                        currentPageRef.current = page
                         setCurrentPage(page)
                       } else {
                         void handleLoadNextPage(page)

--- a/src/renderer/src/components/feature-interaction-writer-boundaries.test.ts
+++ b/src/renderer/src/components/feature-interaction-writer-boundaries.test.ts
@@ -53,20 +53,20 @@ describe('feature interaction writer boundaries', () => {
   it('records GitHub provider-depth for inline item mutation success paths', () => {
     const source = componentSource('TaskPage.tsx')
     const githubWriter = "recordFeatureInteraction('github-tasks')"
-    const mutationSections = [
-      sourceBetween(source, 'function GHAssigneesCell', 'const triggerContent ='),
-      sourceBetween(source, 'function PRReviewCell', 'const requestReviewer ='),
-      sourceBetween(source, 'function PRMergeCell', 'const handleAutoMerge'),
+    // Why: table cells route success telemetry through the optimistic mutation
+    // hook so provider-depth recording stays on one confirm path.
+    const hookSource = readFileSync(
+      join(COMPONENT_ROOT, '../hooks/useTaskPageGitHubWorkItemMutation.ts'),
+      'utf8'
+    )
+    expect(hookSource).toContain(githubWriter)
+    expect(
       sourceBetween(
         source,
         'const handleOpenOrUseGitHubWorkItem',
         'const openComposerForGitLabItem'
       )
-    ]
-
-    for (const section of mutationSections) {
-      expect(section).toContain(githubWriter)
-    }
+    ).toContain(githubWriter)
   })
 
   it('threads GitHub task source context through inline task mutations', () => {

--- a/src/renderer/src/components/feature-interaction-writer-boundaries.test.ts
+++ b/src/renderer/src/components/feature-interaction-writer-boundaries.test.ts
@@ -59,7 +59,9 @@ describe('feature interaction writer boundaries', () => {
       join(COMPONENT_ROOT, '../hooks/useTaskPageGitHubWorkItemMutation.ts'),
       'utf8'
     )
-    expect(hookSource).toContain(githubWriter)
+    expect(
+      sourceBetween(hookSource, "if (confirmed === 'confirmed')", 'return confirmed')
+    ).toContain(githubWriter)
     expect(
       sourceBetween(
         source,

--- a/src/renderer/src/components/github/PRFilterDropdowns.tsx
+++ b/src/renderer/src/components/github/PRFilterDropdowns.tsx
@@ -177,8 +177,9 @@ export default function PRFilterDropdowns({
             variant="outline"
             size="sm"
             className={cn(
-              'h-7 gap-1.5 rounded-md border-border/50 px-2 text-xs font-normal',
-              'bg-transparent hover:bg-muted/50',
+              // Why: solid fill + full foreground text so the control stays
+              // readable on both page canvas and the muted toolbar band.
+              'h-8 gap-1.5 rounded-md border-border/60 bg-background px-2.5 text-xs font-medium text-foreground shadow-xs hover:bg-muted/60',
               activeCount > 0 && 'border-border'
             )}
           >

--- a/src/renderer/src/components/task-page-github-work-item-authority-refresh.ts
+++ b/src/renderer/src/components/task-page-github-work-item-authority-refresh.ts
@@ -1,0 +1,115 @@
+import { taskPageGitHubFamilyDirtyKey } from './task-page-github-work-item-mutation-keys'
+import {
+  clearConfirmedAuthorityForItem,
+  deleteConfirmedListSnapshot,
+  deleteLastConfirmedClientValue,
+  deleteStickyHideEntry,
+  getConfirmedListSnapshot,
+  getLastConfirmedClientValue,
+  getStickyHideEntry,
+  getTaskPageGitHubConfirmedAuthorityItemKeys,
+  hasPendingTaskPageGitHubOpsForItem,
+  listPendingTaskPageGitHubOpsForItem,
+  notifyTaskPageGitHubMutationRegistry,
+  resolveItemSourceScope,
+  updateSoftHiddenItemKey
+} from './task-page-github-work-item-mutation-registry'
+import { getQuietRevalidateState } from './task-page-github-work-item-quiet-state'
+import { MAX_LAG_TRAILS } from './task-page-github-work-item-quiet-adopt'
+
+const AUTHORITY_FAMILIES = ['state', 'autoMerge', 'assignees', 'reviewRequests'] as const
+
+export function clearTaskPageGitHubAuthorityAbsentFromLoadedItems(
+  loadedItemKeys: ReadonlySet<string>
+): void {
+  let changed = false
+  for (const itemKey of getTaskPageGitHubConfirmedAuthorityItemKeys()) {
+    if (loadedItemKeys.has(itemKey)) {
+      continue
+    }
+    const separator = itemKey.indexOf('\0')
+    const repoId = itemKey.slice(0, separator)
+    const itemId = itemKey.slice(separator + 1)
+    if (hasPendingTaskPageGitHubOpsForItem(repoId, itemId)) {
+      continue
+    }
+    clearConfirmedAuthorityForItem(repoId, itemId)
+    deleteStickyHideEntry(itemKey)
+    updateSoftHiddenItemKey(itemKey, false)
+    changed = true
+  }
+  if (changed) {
+    notifyTaskPageGitHubMutationRegistry()
+  }
+}
+
+export function getTaskPageGitHubRevalidatableAuthorityItemKeys(
+  queryKey: string
+): ReadonlySet<string> {
+  const keys = new Set<string>()
+  const quiet = getQuietRevalidateState(queryKey)
+  for (const itemKey of getTaskPageGitHubConfirmedAuthorityItemKeys()) {
+    const separator = itemKey.indexOf('\0')
+    if (separator < 0) {
+      continue
+    }
+    const repoId = itemKey.slice(0, separator)
+    const itemId = itemKey.slice(separator + 1)
+    const sourceScope = resolveItemSourceScope(repoId, itemId)
+    const activeFamilies = AUTHORITY_FAMILIES.filter((family) =>
+      family === 'assignees' || family === 'reviewRequests'
+        ? getConfirmedListSnapshot(sourceScope, repoId, itemId, family) !== undefined
+        : getLastConfirmedClientValue(sourceScope, repoId, itemId, family) !== undefined
+    )
+    if (
+      activeFamilies.some(
+        (family) =>
+          (quiet?.lagSkipAttempts.get(taskPageGitHubFamilyDirtyKey(itemKey, family)) ?? 0) <
+          MAX_LAG_TRAILS
+      )
+    ) {
+      keys.add(itemKey)
+    }
+  }
+  return keys
+}
+
+export function clearTaskPageGitHubAuthorityThroughGeneration(
+  queryKey: string,
+  generation: number
+): void {
+  const quiet = getQuietRevalidateState(queryKey)
+  for (const itemKey of getTaskPageGitHubConfirmedAuthorityItemKeys()) {
+    const separator = itemKey.indexOf('\0')
+    const repoId = itemKey.slice(0, separator)
+    const itemId = itemKey.slice(separator + 1)
+    const sourceScope = resolveItemSourceScope(repoId, itemId)
+    for (const family of AUTHORITY_FAMILIES) {
+      const dirtyAt = quiet?.familyDirtyAt.get(taskPageGitHubFamilyDirtyKey(itemKey, family)) ?? 0
+      if (dirtyAt > generation) {
+        continue
+      }
+      if (family === 'assignees' || family === 'reviewRequests') {
+        deleteConfirmedListSnapshot(sourceScope, repoId, itemId, family)
+      } else {
+        deleteLastConfirmedClientValue(sourceScope, repoId, itemId, family)
+      }
+    }
+    const hasMembershipAuthority =
+      getLastConfirmedClientValue(sourceScope, repoId, itemId, 'state') !== undefined ||
+      getConfirmedListSnapshot(sourceScope, repoId, itemId, 'assignees') !== undefined ||
+      getConfirmedListSnapshot(sourceScope, repoId, itemId, 'reviewRequests') !== undefined
+    const hasPendingMembership = listPendingTaskPageGitHubOpsForItem(repoId, itemId).some(
+      (op) => op.listOp !== undefined || op.key.opKey === 'state' || op.key.opKey === 'merge'
+    )
+    if (!hasMembershipAuthority && !hasPendingMembership) {
+      if (getStickyHideEntry(itemKey)?.queryKey === queryKey) {
+        deleteStickyHideEntry(itemKey)
+      }
+      if (!hasPendingTaskPageGitHubOpsForItem(repoId, itemId)) {
+        updateSoftHiddenItemKey(itemKey, false)
+      }
+    }
+  }
+  notifyTaskPageGitHubMutationRegistry()
+}

--- a/src/renderer/src/components/task-page-github-work-item-filter-membership.test.ts
+++ b/src/renderer/src/components/task-page-github-work-item-filter-membership.test.ts
@@ -108,6 +108,26 @@ describe('shouldSoftHideTaskPageGitHubWorkItem', () => {
     ).toBe(true)
   })
 
+  it('hides non-draft items under is:draft', () => {
+    const query = baseQuery({ scope: 'pr', state: 'open', draft: true })
+    expect(
+      shouldSoftHideTaskPageGitHubWorkItem({
+        item: { state: 'open', assignees: [], reviewRequests: [] },
+        query,
+        viewerLogin: 'me',
+        skipMeQualifiers: false
+      })
+    ).toBe(true)
+    expect(
+      shouldSoftHideTaskPageGitHubWorkItem({
+        item: { state: 'draft', assignees: [], reviewRequests: [] },
+        query,
+        viewerLogin: 'me',
+        skipMeQualifiers: false
+      })
+    ).toBe(false)
+  })
+
   it('hides when review-requested @me is missing', () => {
     expect(
       shouldSoftHideTaskPageGitHubWorkItem({

--- a/src/renderer/src/components/task-page-github-work-item-filter-membership.test.ts
+++ b/src/renderer/src/components/task-page-github-work-item-filter-membership.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest'
+import type { ParsedTaskQuery } from '../../../shared/task-query'
+import {
+  recomputeTaskPageGitHubItemSoftHide,
+  shouldSoftHideTaskPageGitHubWorkItem
+} from './task-page-github-work-item-filter-membership'
+
+const baseQuery = (overrides: Partial<ParsedTaskQuery> = {}): ParsedTaskQuery => ({
+  scope: 'all',
+  state: null,
+  draft: false,
+  assignee: null,
+  author: null,
+  reviewRequested: null,
+  reviewedBy: null,
+  labels: [],
+  freeText: '',
+  ...overrides
+})
+
+describe('shouldSoftHideTaskPageGitHubWorkItem', () => {
+  it('hides closed or merged under is:open', () => {
+    expect(
+      shouldSoftHideTaskPageGitHubWorkItem({
+        item: { state: 'closed', assignees: [], reviewRequests: [] },
+        query: baseQuery({ state: 'open' }),
+        viewerLogin: 'me',
+        skipMeQualifiers: false
+      })
+    ).toBe(true)
+    expect(
+      shouldSoftHideTaskPageGitHubWorkItem({
+        item: { state: 'merged', assignees: [], reviewRequests: [] },
+        query: baseQuery({ state: 'open' }),
+        viewerLogin: 'me',
+        skipMeQualifiers: false
+      })
+    ).toBe(true)
+  })
+
+  it('does not state-soft-hide when state is null', () => {
+    expect(
+      shouldSoftHideTaskPageGitHubWorkItem({
+        item: { state: 'closed', assignees: [], reviewRequests: [] },
+        query: baseQuery({ state: null }),
+        viewerLogin: 'me',
+        skipMeQualifiers: false
+      })
+    ).toBe(false)
+  })
+
+  it('AND: hides on close or unassign under is:open assignee:@me', () => {
+    const query = baseQuery({ state: 'open', assignee: '@me' })
+    expect(
+      shouldSoftHideTaskPageGitHubWorkItem({
+        item: {
+          state: 'closed',
+          assignees: [{ login: 'me', name: null, avatarUrl: '' }],
+          reviewRequests: []
+        },
+        query,
+        viewerLogin: 'me',
+        skipMeQualifiers: false
+      })
+    ).toBe(true)
+    expect(
+      shouldSoftHideTaskPageGitHubWorkItem({
+        item: { state: 'open', assignees: [], reviewRequests: [] },
+        query,
+        viewerLogin: 'me',
+        skipMeQualifiers: false
+      })
+    ).toBe(true)
+  })
+
+  it('skips @me when skipMeQualifiers or viewerLogin null', () => {
+    const query = baseQuery({ assignee: '@me' })
+    expect(
+      shouldSoftHideTaskPageGitHubWorkItem({
+        item: { state: 'open', assignees: [], reviewRequests: [] },
+        query,
+        viewerLogin: null,
+        skipMeQualifiers: false
+      })
+    ).toBe(false)
+    expect(
+      shouldSoftHideTaskPageGitHubWorkItem({
+        item: { state: 'open', assignees: [], reviewRequests: [] },
+        query,
+        viewerLogin: 'me',
+        skipMeQualifiers: true
+      })
+    ).toBe(false)
+  })
+
+  it('hides when concrete assignee login missing', () => {
+    expect(
+      shouldSoftHideTaskPageGitHubWorkItem({
+        item: {
+          state: 'open',
+          assignees: [{ login: 'bob', name: null, avatarUrl: '' }],
+          reviewRequests: []
+        },
+        query: baseQuery({ assignee: 'alice' }),
+        viewerLogin: 'me',
+        skipMeQualifiers: false
+      })
+    ).toBe(true)
+  })
+
+  it('hides when review-requested @me is missing', () => {
+    expect(
+      shouldSoftHideTaskPageGitHubWorkItem({
+        item: { state: 'open', assignees: [], reviewRequests: [] },
+        query: baseQuery({ reviewRequested: '@me' }),
+        viewerLogin: 'me',
+        skipMeQualifiers: false
+      })
+    ).toBe(true)
+  })
+})
+
+describe('recomputeTaskPageGitHubItemSoftHide', () => {
+  it('includes sticky hide for matching queryKey', () => {
+    const itemKey = 'repo\0item'
+    const result = recomputeTaskPageGitHubItemSoftHide({
+      item: {
+        state: 'open',
+        assignees: [{ login: 'me', name: null, avatarUrl: '' }],
+        reviewRequests: []
+      },
+      query: baseQuery({ state: 'open' }),
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      queryKey: 'q1',
+      sticky: new Map([
+        [
+          itemKey,
+          { itemKey, sourceScope: null, queryKey: 'q1', reason: 'filter_membership' as const }
+        ]
+      ]),
+      itemKey
+    })
+    expect(result.hide).toBe(true)
+    expect(result.sticky).toBe(true)
+  })
+})

--- a/src/renderer/src/components/task-page-github-work-item-filter-membership.ts
+++ b/src/renderer/src/components/task-page-github-work-item-filter-membership.ts
@@ -46,6 +46,12 @@ export function shouldSoftHideTaskPageGitHubWorkItem(args: {
   }
   // state === null | 'all' → no state-based soft-hide
 
+  // Why: is:draft forces state to 'open', so a draft that turns non-draft still
+  // passes the state check; the draft qualifier soft-hides it explicitly.
+  if (query.draft && item.state !== 'draft') {
+    return true
+  }
+
   // Assignee membership
   if (query.assignee) {
     const assignee = query.assignee.trim()

--- a/src/renderer/src/components/task-page-github-work-item-filter-membership.ts
+++ b/src/renderer/src/components/task-page-github-work-item-filter-membership.ts
@@ -1,0 +1,100 @@
+import type { ParsedTaskQuery } from '../../../shared/task-query'
+import type { GitHubAssignableUser, GitHubWorkItem } from '../../../shared/types'
+import type { StickyHideEntry } from './task-page-github-work-item-mutation-registry'
+
+function includesLogin(users: readonly GitHubAssignableUser[] | undefined, login: string): boolean {
+  const target = login.toLowerCase()
+  return (users ?? []).some((user) => user.login.toLowerCase() === target)
+}
+
+function resolveMeLogin(viewerLogin: string | null): string | null {
+  const trimmed = viewerLogin?.trim()
+  return trimmed ? trimmed.toLowerCase() : null
+}
+
+/**
+ * Whether a registry-merged work item should be soft-hidden for the active query.
+ * Evaluate every applicable membership signal; hide if any fails (AND of constraints).
+ */
+export function shouldSoftHideTaskPageGitHubWorkItem(args: {
+  item: Pick<GitHubWorkItem, 'state' | 'assignees' | 'reviewRequests'>
+  query: ParsedTaskQuery
+  viewerLogin: string | null
+  /**
+   * Per-item: true when this item’s sourceContext resolves to environment/SSH.
+   * Never a page-level flag (multi-repo can mix local + remote).
+   */
+  skipMeQualifiers: boolean
+}): boolean {
+  const { item, query, skipMeQualifiers } = args
+  const viewer = resolveMeLogin(args.viewerLogin)
+
+  // State membership
+  if (query.state === 'open') {
+    if (item.state === 'closed' || item.state === 'merged') {
+      return true
+    }
+  } else if (query.state === 'closed') {
+    // Why: closed-only lists treat merged as out-of-membership for soft-hide.
+    if (item.state === 'open' || item.state === 'merged' || item.state === 'draft') {
+      return true
+    }
+  } else if (query.state === 'merged') {
+    if (item.state !== 'merged') {
+      return true
+    }
+  }
+  // state === null | 'all' → no state-based soft-hide
+
+  // Assignee membership
+  if (query.assignee) {
+    const assignee = query.assignee.trim()
+    if (assignee.toLowerCase() === '@me') {
+      if (!skipMeQualifiers && viewer && !includesLogin(item.assignees, viewer)) {
+        return true
+      }
+    } else if (!includesLogin(item.assignees, assignee.replace(/^@/, ''))) {
+      return true
+    }
+  }
+
+  // Review-requested membership
+  if (query.reviewRequested) {
+    const requested = query.reviewRequested.trim()
+    if (requested.toLowerCase() === '@me') {
+      if (!skipMeQualifiers && viewer && !includesLogin(item.reviewRequests, viewer)) {
+        return true
+      }
+    } else if (!includesLogin(item.reviewRequests, requested.replace(/^@/, ''))) {
+      return true
+    }
+  }
+
+  // author @me / labels / free text: do not soft-hide from those alone
+  return false
+}
+
+export function recomputeTaskPageGitHubItemSoftHide(args: {
+  item: Pick<GitHubWorkItem, 'state' | 'assignees' | 'reviewRequests'>
+  query: ParsedTaskQuery
+  viewerLogin: string | null
+  skipMeQualifiers: boolean
+  queryKey: string
+  sticky: ReadonlyMap<string, StickyHideEntry>
+  itemKey: string
+}): { hide: boolean; sticky: boolean } {
+  const membershipHide = shouldSoftHideTaskPageGitHubWorkItem({
+    item: args.item,
+    query: args.query,
+    viewerLogin: args.viewerLogin,
+    skipMeQualifiers: args.skipMeQualifiers
+  })
+  const stickyEntry = args.sticky.get(args.itemKey)
+  const stickyActive = Boolean(stickyEntry && stickyEntry.queryKey === args.queryKey)
+  // Why: sticky keeps successful membership exits hidden after pending clears;
+  // pending membership hide still applies before confirm.
+  return {
+    hide: membershipHide || stickyActive,
+    sticky: stickyActive
+  }
+}

--- a/src/renderer/src/components/task-page-github-work-item-mutation-composition.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutation-composition.ts
@@ -1,0 +1,227 @@
+import type { ParsedTaskQuery } from '../../../shared/task-query'
+import type { GitHubAssignableUser, GitHubWorkItem } from '../../../shared/types'
+import {
+  recomputeTaskPageGitHubItemSoftHide,
+  shouldSoftHideTaskPageGitHubWorkItem
+} from './task-page-github-work-item-filter-membership'
+import { applyTaskPageGitHubListOps } from './task-page-github-work-item-mutation-patches'
+import {
+  deleteStickyHideEntry,
+  getAllStickyHideEntries,
+  getConfirmedListSnapshot,
+  getLastConfirmedClientValue,
+  listPendingTaskPageGitHubOpsForItem,
+  resolveItemSourceScope,
+  setSoftHiddenItemKeys,
+  setStickyHideEntry,
+  taskPageGitHubItemKey,
+  updateSoftHiddenItemKey,
+  type PendingListOp,
+  type PendingOp,
+  type TaskPageGitHubListFamily
+} from './task-page-github-work-item-mutation-registry'
+
+export function freezeTaskPageGitHubUsers(
+  users: readonly GitHubAssignableUser[]
+): GitHubAssignableUser[] {
+  return users.map((user) => ({
+    login: user.login,
+    name: user.name,
+    avatarUrl: user.avatarUrl
+  }))
+}
+
+export function pendingListOpsForFamily(
+  ops: readonly PendingOp[],
+  family: TaskPageGitHubListFamily
+): PendingListOp[] {
+  // Why: same login may appear in multiple pending ops after rapid toggles;
+  // keep only the latest op per login so composition matches last intent.
+  return [...ops]
+    .filter((pending) => pending.listOp?.family === family)
+    .sort((a, b) => a.startedAt - b.startedAt)
+    .reduce<PendingListOp[]>((acc, pending) => {
+      if (!pending.listOp) {
+        return acc
+      }
+      if (pending.listOp.logins.length > 1) {
+        acc.push(pending.listOp)
+        return acc
+      }
+      const login = pending.listOp.logins[0]
+      const lastIndex = acc.findIndex((op) => op.logins.length === 1 && op.logins[0] === login)
+      if (lastIndex >= 0) {
+        acc[lastIndex] = pending.listOp
+      } else {
+        acc.push(pending.listOp)
+      }
+      return acc
+    }, [])
+}
+
+export function stripFamilyPendingFromList(
+  item: GitHubWorkItem,
+  family: TaskPageGitHubListFamily,
+  ops: readonly PendingOp[]
+): GitHubAssignableUser[] {
+  const current = freezeTaskPageGitHubUsers(
+    family === 'assignees' ? (item.assignees ?? []) : (item.reviewRequests ?? [])
+  )
+  let list = current
+  const familyOps = pendingListOpsForFamily(ops, family)
+  // Why: strip by reversing adds/removes so lazy snapshot ignores in-flight intent.
+  for (let i = familyOps.length - 1; i >= 0; i--) {
+    const op = familyOps[i]
+    for (let j = 0; j < op.logins.length; j++) {
+      const login = op.logins[j]
+      if (op.kind === 'add') {
+        list = list.filter((user) => user.login.toLowerCase() !== login)
+      } else if (!list.some((user) => user.login.toLowerCase() === login)) {
+        const restored = op.users?.[j] ?? { login, name: null, avatarUrl: '' }
+        list.push(restored)
+      }
+    }
+  }
+  return list
+}
+
+export function getRegistryMergedTaskPageGitHubWorkItem(
+  item: GitHubWorkItem,
+  sourceScope: string | null
+): GitHubWorkItem {
+  const ops = listPendingTaskPageGitHubOpsForItem(item.repoId, item.id, sourceScope)
+  let merged: GitHubWorkItem = { ...item }
+
+  // Why: after confirm, pending is cleared but search may still lag — hold the
+  // last confirmed whole-field values until a matching adopt or newer pending.
+  const lastState = getLastConfirmedClientValue(sourceScope, item.repoId, item.id, 'state')
+  if (typeof lastState === 'string') {
+    merged = { ...merged, state: lastState as GitHubWorkItem['state'] }
+  }
+  const lastAutoMerge = getLastConfirmedClientValue(sourceScope, item.repoId, item.id, 'autoMerge')
+  if (typeof lastAutoMerge === 'boolean') {
+    merged = { ...merged, autoMergeEnabled: lastAutoMerge }
+  }
+
+  const wholeByOpKey = new Map<string, PendingOp>()
+  for (const op of ops) {
+    if (op.listOp) {
+      continue
+    }
+    wholeByOpKey.set(op.key.opKey, op)
+  }
+  for (const op of wholeByOpKey.values()) {
+    merged = { ...merged, ...op.next }
+  }
+
+  for (const family of ['assignees', 'reviewRequests'] as const) {
+    let snapshot = getConfirmedListSnapshot(sourceScope, item.repoId, item.id, family)
+    if (!snapshot) {
+      snapshot = stripFamilyPendingFromList(item, family, ops)
+    }
+    const composed = applyTaskPageGitHubListOps(snapshot, pendingListOpsForFamily(ops, family))
+    merged =
+      family === 'assignees'
+        ? { ...merged, assignees: composed }
+        : { ...merged, reviewRequests: composed }
+  }
+
+  return merged
+}
+
+export function recomputeSoftHideForItem(args: {
+  item: GitHubWorkItem
+  sourceScope: string | null
+  query: ParsedTaskQuery
+  queryKey: string
+  viewerLogin: string | null
+  skipMeQualifiers: boolean
+  /** When true (confirm/rollback), set or clear sticky per K22. */
+  updateSticky: boolean
+}): boolean {
+  const merged = getRegistryMergedTaskPageGitHubWorkItem(args.item, args.sourceScope)
+  const itemKey = taskPageGitHubItemKey(args.item.repoId, args.item.id)
+  const membershipHide = shouldSoftHideTaskPageGitHubWorkItem({
+    item: merged,
+    query: args.query,
+    viewerLogin: args.viewerLogin,
+    skipMeQualifiers: args.skipMeQualifiers
+  })
+
+  if (args.updateSticky) {
+    if (membershipHide) {
+      setStickyHideEntry({
+        itemKey,
+        sourceScope: args.sourceScope,
+        queryKey: args.queryKey,
+        reason: 'filter_membership'
+      })
+    } else {
+      deleteStickyHideEntry(itemKey)
+    }
+  }
+
+  const result = recomputeTaskPageGitHubItemSoftHide({
+    item: merged,
+    query: args.query,
+    viewerLogin: args.viewerLogin,
+    skipMeQualifiers: args.skipMeQualifiers,
+    queryKey: args.queryKey,
+    sticky: getAllStickyHideEntries(),
+    itemKey
+  })
+  updateSoftHiddenItemKey(itemKey, result.hide)
+  return result.hide
+}
+
+export function rebuildSoftHiddenKeysFromPendingAndSticky(args: {
+  query: ParsedTaskQuery
+  queryKey: string
+  viewerLogin: string | null
+  items: readonly GitHubWorkItem[]
+  skipMeByItemKey?: ReadonlyMap<string, boolean>
+}): void {
+  const next = new Set<string>()
+  for (const [itemKey, entry] of getAllStickyHideEntries()) {
+    if (entry.queryKey === args.queryKey) {
+      next.add(itemKey)
+    }
+  }
+  for (const item of args.items) {
+    const ops = listPendingTaskPageGitHubOpsForItem(item.repoId, item.id)
+    const itemKey = taskPageGitHubItemKey(item.repoId, item.id)
+    if (ops.length === 0 && !next.has(itemKey)) {
+      continue
+    }
+    const sourceScope = ops[0]?.key.sourceScope ?? resolveItemSourceScope(item.repoId, item.id)
+    const skipMe = args.skipMeByItemKey?.get(itemKey) ?? ops[0]?.skipMeQualifiers ?? false
+    const merged = getRegistryMergedTaskPageGitHubWorkItem(item, sourceScope)
+    if (
+      shouldSoftHideTaskPageGitHubWorkItem({
+        item: merged,
+        query: args.query,
+        viewerLogin: args.viewerLogin,
+        skipMeQualifiers: skipMe
+      })
+    ) {
+      next.add(itemKey)
+    }
+  }
+  setSoftHiddenItemKeys(next)
+}
+
+export function familiesFromPendingOp(op: PendingOp): string[] {
+  if (op.listOp) {
+    return [op.listOp.family]
+  }
+  if (op.key.opKey === 'merge') {
+    return ['state', 'merge', 'autoMerge']
+  }
+  if (op.key.opKey === 'autoMerge') {
+    return ['autoMerge']
+  }
+  if (op.key.opKey === 'state') {
+    return ['state']
+  }
+  return [op.key.opKey]
+}

--- a/src/renderer/src/components/task-page-github-work-item-mutation-composition.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutation-composition.ts
@@ -10,8 +10,11 @@ import {
   getAllStickyHideEntries,
   getConfirmedListSnapshot,
   getLastConfirmedClientValue,
+  getTaskPageGitHubSoftHiddenItemKeys,
+  hasConfirmedAuthorityForItem,
   listPendingTaskPageGitHubOpsForItem,
   resolveItemSourceScope,
+  notifyTaskPageGitHubMutationRegistry,
   setSoftHiddenItemKeys,
   setStickyHideEntry,
   taskPageGitHubItemKey,
@@ -115,11 +118,15 @@ export function getRegistryMergedTaskPageGitHubWorkItem(
   }
 
   for (const family of ['assignees', 'reviewRequests'] as const) {
+    const familyOps = pendingListOpsForFamily(ops, family)
     let snapshot = getConfirmedListSnapshot(sourceScope, item.repoId, item.id, family)
+    if (!snapshot && familyOps.length === 0) {
+      continue
+    }
     if (!snapshot) {
       snapshot = stripFamilyPendingFromList(item, family, ops)
     }
-    const composed = applyTaskPageGitHubListOps(snapshot, pendingListOpsForFamily(ops, family))
+    const composed = applyTaskPageGitHubListOps(snapshot, familyOps)
     merged =
       family === 'assignees'
         ? { ...merged, assignees: composed }
@@ -190,7 +197,11 @@ export function rebuildSoftHiddenKeysFromPendingAndSticky(args: {
   for (const item of args.items) {
     const ops = listPendingTaskPageGitHubOpsForItem(item.repoId, item.id)
     const itemKey = taskPageGitHubItemKey(item.repoId, item.id)
-    if (ops.length === 0 && !next.has(itemKey)) {
+    if (
+      ops.length === 0 &&
+      !next.has(itemKey) &&
+      !hasConfirmedAuthorityForItem(item.repoId, item.id)
+    ) {
       continue
     }
     const sourceScope = ops[0]?.key.sourceScope ?? resolveItemSourceScope(item.repoId, item.id)
@@ -207,7 +218,12 @@ export function rebuildSoftHiddenKeysFromPendingAndSticky(args: {
       next.add(itemKey)
     }
   }
+  const current = getTaskPageGitHubSoftHiddenItemKeys()
+  if (next.size === current.size && [...next].every((itemKey) => current.has(itemKey))) {
+    return
+  }
   setSoftHiddenItemKeys(next)
+  notifyTaskPageGitHubMutationRegistry()
 }
 
 export function familiesFromPendingOp(op: PendingOp): string[] {

--- a/src/renderer/src/components/task-page-github-work-item-mutation-keys.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutation-keys.ts
@@ -1,0 +1,40 @@
+import type {
+  TaskPageGitHubListFamily,
+  TaskPageGitHubMutationKey
+} from './task-page-github-work-item-mutation-registry'
+
+export function taskPageGitHubItemKey(repoId: string, itemId: string): string {
+  return `${repoId}\0${itemId}`
+}
+export function serializeTaskPageGitHubMutationKey(key: TaskPageGitHubMutationKey): string {
+  return `${key.sourceScope ?? ''}\0${key.repoId}\0${key.itemId}\0${key.opKey}`
+}
+export function taskPageGitHubSnapshotKey(
+  sourceScope: string | null,
+  repoId: string,
+  itemId: string,
+  family: TaskPageGitHubListFamily
+): string {
+  return `${sourceScope ?? ''}\0${repoId}\0${itemId}\0${family}`
+}
+export function taskPageGitHubLastConfirmedKey(
+  sourceScope: string | null,
+  repoId: string,
+  itemId: string,
+  family: string
+): string {
+  return `${sourceScope ?? ''}\0${repoId}\0${itemId}\0${family}`
+}
+export function taskPageGitHubFamilyDirtyKey(itemKey: string, family: string): string {
+  return `${itemKey}\0${family}`
+}
+export function taskPageGitHubListOpKey(
+  family: TaskPageGitHubListFamily,
+  logins: readonly string[]
+): string {
+  const normalized = logins.map((login) => login.toLowerCase()).sort()
+  if (normalized.length === 1) {
+    return `${family}:${normalized[0]}`
+  }
+  return `${family}:batch:${normalized.join(',')}`
+}

--- a/src/renderer/src/components/task-page-github-work-item-mutation-keys.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutation-keys.ts
@@ -1,7 +1,7 @@
 import type {
   TaskPageGitHubListFamily,
   TaskPageGitHubMutationKey
-} from './task-page-github-work-item-mutation-registry'
+} from './task-page-github-work-item-registry-types'
 
 export function taskPageGitHubItemKey(repoId: string, itemId: string): string {
   return `${repoId}\0${itemId}`

--- a/src/renderer/src/components/task-page-github-work-item-mutation-lifecycle.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutation-lifecycle.ts
@@ -1,0 +1,203 @@
+import type { ParsedTaskQuery } from '../../../shared/task-query'
+import type { GitHubWorkItem } from '../../../shared/types'
+import type { TaskSourceContext } from '../../../shared/task-source-context'
+import { applyTaskPageGitHubListOps } from './task-page-github-work-item-mutation-patches'
+import {
+  familiesFromPendingOp,
+  freezeTaskPageGitHubUsers,
+  getRegistryMergedTaskPageGitHubWorkItem,
+  recomputeSoftHideForItem
+} from './task-page-github-work-item-mutation-composition'
+import {
+  deletePendingTaskPageGitHubOp,
+  getConfirmedListSnapshot,
+  getPendingTaskPageGitHubOp,
+  listPendingTaskPageGitHubOpsForItem,
+  notifyTaskPageGitHubMutationRegistry,
+  setConfirmedListSnapshot,
+  setLastConfirmedClientValue,
+  getOrCreateQuietRevalidateState,
+  taskPageGitHubFamilyDirtyKey,
+  taskPageGitHubItemKey,
+  type TaskPageGitHubMutationKey
+} from './task-page-github-work-item-mutation-registry'
+import type { TaskPageGitHubPatchWorkItem } from './task-page-github-work-item-mutation-types'
+function applyServerEntityIfPresent(
+  key: TaskPageGitHubMutationKey,
+  opts: {
+    serverEntity?: Partial<GitHubWorkItem>
+    patchWorkItem?: TaskPageGitHubPatchWorkItem
+    sourceContext?: TaskSourceContext | null
+  }
+): void {
+  if (!opts.serverEntity || !opts.patchWorkItem) {
+    return
+  }
+  const entityPatch: Partial<GitHubWorkItem> = {}
+  if (opts.serverEntity.state !== undefined) {
+    entityPatch.state = opts.serverEntity.state
+    setLastConfirmedClientValue(
+      key.sourceScope,
+      key.repoId,
+      key.itemId,
+      'state',
+      opts.serverEntity.state
+    )
+  }
+  if (opts.serverEntity.autoMergeEnabled !== undefined) {
+    entityPatch.autoMergeEnabled = opts.serverEntity.autoMergeEnabled
+    setLastConfirmedClientValue(
+      key.sourceScope,
+      key.repoId,
+      key.itemId,
+      'autoMerge',
+      opts.serverEntity.autoMergeEnabled
+    )
+  }
+  if (opts.serverEntity.assignees) {
+    const users = freezeTaskPageGitHubUsers(opts.serverEntity.assignees)
+    setConfirmedListSnapshot(key.sourceScope, key.repoId, key.itemId, 'assignees', users)
+    entityPatch.assignees = users
+  }
+  if (opts.serverEntity.reviewRequests) {
+    const users = freezeTaskPageGitHubUsers(opts.serverEntity.reviewRequests)
+    setConfirmedListSnapshot(key.sourceScope, key.repoId, key.itemId, 'reviewRequests', users)
+    entityPatch.reviewRequests = users
+  }
+  if (Object.keys(entityPatch).length > 0) {
+    opts.patchWorkItem(key.itemId, entityPatch, key.repoId, {
+      sourceContext: opts.sourceContext
+    })
+  }
+}
+export function confirmTaskPageGitHubWorkItemMutation(
+  key: TaskPageGitHubMutationKey,
+  generation: number,
+  opts: {
+    query: ParsedTaskQuery
+    queryKey: string
+    viewerLogin: string | null
+    item: GitHubWorkItem
+    serverEntity?: Partial<GitHubWorkItem>
+    patchWorkItem?: TaskPageGitHubPatchWorkItem
+    sourceContext?: TaskSourceContext | null
+    scheduleQuiet?: boolean
+  }
+): 'confirmed' | 'stale' {
+  const pending = getPendingTaskPageGitHubOp(key)
+  if (!pending || pending.generation !== generation) {
+    return 'stale'
+  }
+  // K20: capture before delete.
+  const { skipMeQualifiers, listOp, next } = pending
+  if (listOp) {
+    const snapshot =
+      getConfirmedListSnapshot(key.sourceScope, key.repoId, key.itemId, listOp.family) ??
+      freezeTaskPageGitHubUsers(
+        listOp.family === 'assignees'
+          ? (opts.item.assignees ?? [])
+          : (opts.item.reviewRequests ?? [])
+      )
+    // K10: apply confirmed op into snapshot immediately. List authority lives in
+    // confirmedSnapshots; lastConfirmedClientValue is scalar-only (state/autoMerge).
+    const applied = applyTaskPageGitHubListOps(snapshot, [listOp])
+    setConfirmedListSnapshot(key.sourceScope, key.repoId, key.itemId, listOp.family, applied)
+  } else {
+    if (next.state !== undefined) {
+      setLastConfirmedClientValue(key.sourceScope, key.repoId, key.itemId, 'state', next.state)
+    }
+    if (next.autoMergeEnabled !== undefined) {
+      setLastConfirmedClientValue(
+        key.sourceScope,
+        key.repoId,
+        key.itemId,
+        'autoMerge',
+        next.autoMergeEnabled
+      )
+    }
+  }
+  deletePendingTaskPageGitHubOp(key)
+  applyServerEntityIfPresent(key, opts)
+  const remaining = listPendingTaskPageGitHubOpsForItem(key.repoId, key.itemId, key.sourceScope)
+  const merged = getRegistryMergedTaskPageGitHubWorkItem(opts.item, key.sourceScope)
+  if (opts.patchWorkItem && remaining.some((op) => op.listOp)) {
+    opts.patchWorkItem(
+      key.itemId,
+      { assignees: merged.assignees, reviewRequests: merged.reviewRequests },
+      key.repoId,
+      { sourceContext: opts.sourceContext }
+    )
+  }
+  recomputeSoftHideForItem({
+    item: { ...opts.item, ...merged },
+    sourceScope: key.sourceScope,
+    query: opts.query,
+    queryKey: opts.queryKey,
+    viewerLogin: opts.viewerLogin,
+    skipMeQualifiers,
+    updateSticky: true
+  })
+  const itemKey = taskPageGitHubItemKey(key.repoId, key.itemId)
+  const quiet = getOrCreateQuietRevalidateState(opts.queryKey)
+  quiet.dirtyGeneration += 1
+  quiet.lastConfirmAt = Date.now()
+  for (const family of familiesFromPendingOp(pending)) {
+    quiet.familyDirtyAt.set(taskPageGitHubFamilyDirtyKey(itemKey, family), quiet.dirtyGeneration)
+  }
+  notifyTaskPageGitHubMutationRegistry()
+  return 'confirmed'
+}
+export function rollbackTaskPageGitHubWorkItemMutation(args: {
+  key: TaskPageGitHubMutationKey
+  generation: number
+  patchWorkItem: TaskPageGitHubPatchWorkItem
+  sourceContext?: TaskSourceContext | null
+  query: ParsedTaskQuery
+  queryKey: string
+  viewerLogin: string | null
+  item: GitHubWorkItem
+}): 'rolled_back' | 'stale' {
+  const pending = getPendingTaskPageGitHubOp(args.key)
+  if (!pending || pending.generation !== args.generation) {
+    return 'stale'
+  }
+  const { skipMeQualifiers, listOp } = pending
+  deletePendingTaskPageGitHubOp(args.key)
+  const merged = getRegistryMergedTaskPageGitHubWorkItem(args.item, args.key.sourceScope)
+  if (listOp) {
+    args.patchWorkItem(
+      args.key.itemId,
+      listOp.family === 'assignees'
+        ? { assignees: merged.assignees }
+        : { reviewRequests: merged.reviewRequests },
+      args.key.repoId,
+      { sourceContext: args.sourceContext }
+    )
+  } else {
+    const recomposed = getRegistryMergedTaskPageGitHubWorkItem(
+      { ...args.item, ...pending.previous },
+      args.key.sourceScope
+    )
+    args.patchWorkItem(
+      args.key.itemId,
+      {
+        state: recomposed.state,
+        autoMergeEnabled: recomposed.autoMergeEnabled
+      },
+      args.key.repoId,
+      { sourceContext: args.sourceContext }
+    )
+  }
+  const after = getRegistryMergedTaskPageGitHubWorkItem(args.item, args.key.sourceScope)
+  recomputeSoftHideForItem({
+    item: { ...args.item, ...after },
+    sourceScope: args.key.sourceScope,
+    query: args.query,
+    queryKey: args.queryKey,
+    viewerLogin: args.viewerLogin,
+    skipMeQualifiers,
+    updateSticky: true
+  })
+  notifyTaskPageGitHubMutationRegistry()
+  return 'rolled_back'
+}

--- a/src/renderer/src/components/task-page-github-work-item-mutation-lifecycle.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutation-lifecycle.ts
@@ -12,12 +12,13 @@ import {
   deletePendingTaskPageGitHubOp,
   getConfirmedListSnapshot,
   getPendingTaskPageGitHubOp,
+  getTaskPageGitHubMutationQueryKey,
   listPendingTaskPageGitHubOpsForItem,
   notifyTaskPageGitHubMutationRegistry,
   setConfirmedListSnapshot,
   setLastConfirmedClientValue,
-  getOrCreateQuietRevalidateState,
-  taskPageGitHubFamilyDirtyKey,
+  markTaskPageGitHubFamiliesDirty,
+  isTaskPageGitHubMutationQueryKeyCurrent,
   taskPageGitHubItemKey,
   type TaskPageGitHubMutationKey
 } from './task-page-github-work-item-mutation-registry'
@@ -128,22 +129,23 @@ export function confirmTaskPageGitHubWorkItemMutation(
       { sourceContext: opts.sourceContext }
     )
   }
-  recomputeSoftHideForItem({
-    item: { ...opts.item, ...merged },
-    sourceScope: key.sourceScope,
-    query: opts.query,
-    queryKey: opts.queryKey,
-    viewerLogin: opts.viewerLogin,
-    skipMeQualifiers,
-    updateSticky: true
-  })
-  const itemKey = taskPageGitHubItemKey(key.repoId, key.itemId)
-  const quiet = getOrCreateQuietRevalidateState(opts.queryKey)
-  quiet.dirtyGeneration += 1
-  quiet.lastConfirmAt = Date.now()
-  for (const family of familiesFromPendingOp(pending)) {
-    quiet.familyDirtyAt.set(taskPageGitHubFamilyDirtyKey(itemKey, family), quiet.dirtyGeneration)
+  if (isTaskPageGitHubMutationQueryKeyCurrent(opts.queryKey)) {
+    recomputeSoftHideForItem({
+      item: { ...opts.item, ...merged },
+      sourceScope: key.sourceScope,
+      query: opts.query,
+      queryKey: opts.queryKey,
+      viewerLogin: opts.viewerLogin,
+      skipMeQualifiers,
+      updateSticky: true
+    })
   }
+  const itemKey = taskPageGitHubItemKey(key.repoId, key.itemId)
+  markTaskPageGitHubFamiliesDirty(
+    getTaskPageGitHubMutationQueryKey() ?? opts.queryKey,
+    itemKey,
+    familiesFromPendingOp(pending)
+  )
   notifyTaskPageGitHubMutationRegistry()
   return 'confirmed'
 }
@@ -189,15 +191,17 @@ export function rollbackTaskPageGitHubWorkItemMutation(args: {
     )
   }
   const after = getRegistryMergedTaskPageGitHubWorkItem(args.item, args.key.sourceScope)
-  recomputeSoftHideForItem({
-    item: { ...args.item, ...after },
-    sourceScope: args.key.sourceScope,
-    query: args.query,
-    queryKey: args.queryKey,
-    viewerLogin: args.viewerLogin,
-    skipMeQualifiers,
-    updateSticky: true
-  })
+  if (isTaskPageGitHubMutationQueryKeyCurrent(args.queryKey)) {
+    recomputeSoftHideForItem({
+      item: { ...args.item, ...after },
+      sourceScope: args.key.sourceScope,
+      query: args.query,
+      queryKey: args.queryKey,
+      viewerLogin: args.viewerLogin,
+      skipMeQualifiers,
+      updateSticky: true
+    })
+  }
   notifyTaskPageGitHubMutationRegistry()
   return 'rolled_back'
 }

--- a/src/renderer/src/components/task-page-github-work-item-mutation-pages.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutation-pages.ts
@@ -2,6 +2,7 @@ import type { GitHubWorkItem } from '../../../shared/types'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
 import { getRegistryMergedTaskPageGitHubWorkItem } from './task-page-github-work-item-mutation-composition'
 import {
+  getStickyHideEntry,
   hasConfirmedAuthorityForItem,
   hasPendingTaskPageGitHubOpsForItem,
   resolveItemSourceScope,
@@ -53,7 +54,6 @@ export function materializeTaskPageItemList(args: {
   previousItems: readonly GitHubWorkItem[]
   queryKey: string
 }): GitHubWorkItem[] {
-  void args.queryKey
   const overlaid = applyPendingTaskPageGitHubMutationsToItems(args.networkItems)
   const byKey = new Map(overlaid.map((item) => [taskPageGitHubItemKey(item.repoId, item.id), item]))
   for (const item of args.previousItems) {
@@ -62,11 +62,14 @@ export function materializeTaskPageItemList(args: {
       continue
     }
     // Why: retain in-flight pending rows for rollback visibility; also retain
-    // confirmed-authority rows still soft-hidden while search lag omits them.
-    if (
-      !hasPendingTaskPageGitHubOpsForItem(item.repoId, item.id) &&
-      !hasConfirmedAuthorityForItem(item.repoId, item.id)
-    ) {
+    // confirmed rows soft-hidden by a sticky hide scoped to THIS query while
+    // search lag omits them. Requiring the query-scoped sticky avoids retaining
+    // non-membership confirms (e.g. auto-merge) as stale ghosts across refetch.
+    const hasPending = hasPendingTaskPageGitHubOpsForItem(item.repoId, item.id)
+    const sticky = getStickyHideEntry(k)
+    const hasConfirmedStickyHide =
+      hasConfirmedAuthorityForItem(item.repoId, item.id) && sticky?.queryKey === args.queryKey
+    if (!hasPending && !hasConfirmedStickyHide) {
       continue
     }
     const scope = resolveItemSourceScope(item.repoId, item.id)

--- a/src/renderer/src/components/task-page-github-work-item-mutation-pages.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutation-pages.ts
@@ -1,0 +1,85 @@
+import type { GitHubWorkItem } from '../../../shared/types'
+import type { TaskSourceContext } from '../../../shared/task-source-context'
+import { getRegistryMergedTaskPageGitHubWorkItem } from './task-page-github-work-item-mutation-composition'
+import {
+  hasConfirmedAuthorityForItem,
+  hasPendingTaskPageGitHubOpsForItem,
+  resolveItemSourceScope,
+  taskPageGitHubItemKey
+} from './task-page-github-work-item-mutation-registry'
+import type { TaskPageGitHubPatchWorkItem } from './task-page-github-work-item-mutation-types'
+
+/** Match each item to pending/confirmed authority by repoId + itemId + remembered sourceScope. */
+export function applyPendingTaskPageGitHubMutationsToItems(
+  items: readonly GitHubWorkItem[]
+): GitHubWorkItem[] {
+  return items.map((item) => {
+    const sourceScope = resolveItemSourceScope(item.repoId, item.id)
+    return getRegistryMergedTaskPageGitHubWorkItem(item, sourceScope)
+  })
+}
+
+export function reapplyPendingTaskPageGitHubMutationsToCache(args: {
+  items: readonly GitHubWorkItem[]
+  patchWorkItem: TaskPageGitHubPatchWorkItem
+  sourceContextByRepoId?: ReadonlyMap<string, TaskSourceContext | null | undefined>
+}): void {
+  for (const item of args.items) {
+    const sourceScope = resolveItemSourceScope(item.repoId, item.id)
+    const hasAuthority =
+      hasPendingTaskPageGitHubOpsForItem(item.repoId, item.id) ||
+      hasConfirmedAuthorityForItem(item.repoId, item.id)
+    if (!hasAuthority) {
+      continue
+    }
+    const merged = getRegistryMergedTaskPageGitHubWorkItem(item, sourceScope)
+    args.patchWorkItem(
+      item.id,
+      {
+        state: merged.state,
+        assignees: merged.assignees,
+        reviewRequests: merged.reviewRequests,
+        autoMergeEnabled: merged.autoMergeEnabled
+      },
+      item.repoId,
+      { sourceContext: args.sourceContextByRepoId?.get(item.repoId) }
+    )
+  }
+}
+
+/** Full-replace flat list: overlay + retain pending/confirmed-omitted rows (K18). */
+export function materializeTaskPageItemList(args: {
+  networkItems: readonly GitHubWorkItem[]
+  previousItems: readonly GitHubWorkItem[]
+  queryKey: string
+}): GitHubWorkItem[] {
+  void args.queryKey
+  const overlaid = applyPendingTaskPageGitHubMutationsToItems(args.networkItems)
+  const byKey = new Map(overlaid.map((item) => [taskPageGitHubItemKey(item.repoId, item.id), item]))
+  for (const item of args.previousItems) {
+    const k = taskPageGitHubItemKey(item.repoId, item.id)
+    if (byKey.has(k)) {
+      continue
+    }
+    // Why: retain in-flight pending rows for rollback visibility; also retain
+    // confirmed-authority rows still soft-hidden while search lag omits them.
+    if (
+      !hasPendingTaskPageGitHubOpsForItem(item.repoId, item.id) &&
+      !hasConfirmedAuthorityForItem(item.repoId, item.id)
+    ) {
+      continue
+    }
+    const scope = resolveItemSourceScope(item.repoId, item.id)
+    byKey.set(k, getRegistryMergedTaskPageGitHubWorkItem(item, scope))
+  }
+  return [...byKey.values()].sort(
+    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+  )
+}
+
+/** In-place overlay per page; preserves multi-page structure; no retain. */
+export function overlayPendingOnTaskPagePages(
+  pages: readonly GitHubWorkItem[][]
+): GitHubWorkItem[][] {
+  return pages.map((page) => applyPendingTaskPageGitHubMutationsToItems(page))
+}

--- a/src/renderer/src/components/task-page-github-work-item-mutation-pages.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutation-pages.ts
@@ -10,6 +10,35 @@ import {
 } from './task-page-github-work-item-mutation-registry'
 import type { TaskPageGitHubPatchWorkItem } from './task-page-github-work-item-mutation-types'
 
+export function patchTaskPageGitHubWorkItemPages(
+  pages: readonly (GitHubWorkItem[] | null)[],
+  itemKey: { id: string; repoId: string },
+  patch: Partial<GitHubWorkItem>,
+  shouldPatch?: (item: GitHubWorkItem) => boolean
+): (GitHubWorkItem[] | null)[] {
+  let changed = false
+  const nextPages = pages.map((page) => {
+    if (!page) {
+      return null
+    }
+    let pageChanged = false
+    const nextPage = page.map((item) => {
+      if (
+        item.id !== itemKey.id ||
+        item.repoId !== itemKey.repoId ||
+        (shouldPatch && !shouldPatch(item))
+      ) {
+        return item
+      }
+      changed = true
+      pageChanged = true
+      return { ...item, ...patch }
+    })
+    return pageChanged ? nextPage : page
+  })
+  return changed ? nextPages : (pages as (GitHubWorkItem[] | null)[])
+}
+
 /** Match each item to pending/confirmed authority by repoId + itemId + remembered sourceScope. */
 export function applyPendingTaskPageGitHubMutationsToItems(
   items: readonly GitHubWorkItem[]
@@ -78,6 +107,43 @@ export function materializeTaskPageItemList(args: {
   return [...byKey.values()].sort(
     (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
   )
+}
+
+export function reconcileTaskPagePagesAfterQuietRefresh(args: {
+  pages: readonly (GitHubWorkItem[] | null)[]
+  queryKey: string
+  authorityPage: number
+  authorityItems: readonly GitHubWorkItem[]
+  membershipChanged: boolean
+  visiblePage?: number
+  visibleItems?: readonly GitHubWorkItem[]
+}): (GitHubWorkItem[] | null)[] {
+  const next = [...args.pages]
+  const lastPage = args.visiblePage ?? args.authorityPage
+  while (next.length <= lastPage) {
+    next.push(null)
+  }
+  next[args.authorityPage] = materializeTaskPageItemList({
+    networkItems: args.authorityItems,
+    previousItems: args.pages[args.authorityPage] ?? [],
+    queryKey: args.queryKey
+  })
+  if (args.visiblePage !== undefined && args.visibleItems !== undefined) {
+    if (args.membershipChanged) {
+      for (let page = args.authorityPage + 1; page < args.visiblePage; page++) {
+        next[page] = null
+      }
+    }
+    next[args.visiblePage] = materializeTaskPageItemList({
+      networkItems: args.visibleItems,
+      previousItems: args.pages[args.visiblePage] ?? [],
+      queryKey: args.queryKey
+    })
+  }
+  if (args.membershipChanged) {
+    next.length = lastPage + 1
+  }
+  return next
 }
 
 /** In-place overlay per page; preserves multi-page structure; no retain. */

--- a/src/renderer/src/components/task-page-github-work-item-mutation-patches.test.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutation-patches.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import type { GitHubWorkItem } from '../../../shared/types'
+import {
+  applyTaskPageGitHubListOps,
+  buildTaskPageGitHubWorkItemMutationPatch,
+  loginSetOfUsers,
+  loginSetsEqual
+} from './task-page-github-work-item-mutation-patches'
+
+function baseItem(overrides: Partial<GitHubWorkItem> = {}): GitHubWorkItem {
+  return {
+    id: 'issue:1',
+    type: 'issue',
+    number: 1,
+    title: 't',
+    state: 'open',
+    url: 'https://github.com/o/r/issues/1',
+    labels: [],
+    updatedAt: '2026-01-01T00:00:00Z',
+    author: 'alice',
+    repoId: 'repo-1',
+    assignees: [],
+    reviewRequests: [],
+    ...overrides
+  }
+}
+
+describe('applyTaskPageGitHubListOps', () => {
+  it('adds and removes logins', () => {
+    const snapshot = [{ login: 'alice', name: null, avatarUrl: '' }]
+    const afterAdd = applyTaskPageGitHubListOps(snapshot, [
+      {
+        family: 'assignees',
+        kind: 'add',
+        logins: ['bob'],
+        users: [{ login: 'bob', name: 'Bob', avatarUrl: 'x' }]
+      }
+    ])
+    expect(afterAdd.map((u) => u.login)).toEqual(['alice', 'bob'])
+    const afterRemove = applyTaskPageGitHubListOps(afterAdd, [
+      { family: 'assignees', kind: 'remove', logins: ['alice'] }
+    ])
+    expect(afterRemove.map((u) => u.login)).toEqual(['bob'])
+  })
+
+  it('does not mutate input snapshot arrays', () => {
+    const snapshot = [{ login: 'alice', name: null, avatarUrl: '' }]
+    const frozen = [...snapshot]
+    applyTaskPageGitHubListOps(snapshot, [{ family: 'assignees', kind: 'add', logins: ['bob'] }])
+    expect(snapshot).toEqual(frozen)
+  })
+})
+
+describe('buildTaskPageGitHubWorkItemMutationPatch', () => {
+  it('builds merge patch with state merged and autoMerge cleared', () => {
+    const item = baseItem({
+      type: 'pr',
+      state: 'open',
+      autoMergeEnabled: true
+    })
+    const patch = buildTaskPageGitHubWorkItemMutationPatch(item, { type: 'merge' })
+    expect(patch.kind).toBe('whole')
+    if (patch.kind !== 'whole') {
+      return
+    }
+    expect(patch.next).toEqual({ state: 'merged', autoMergeEnabled: false })
+    expect(patch.previous).toEqual({ state: 'open', autoMergeEnabled: true })
+  })
+
+  it('builds autoMerge patch', () => {
+    const patch = buildTaskPageGitHubWorkItemMutationPatch(baseItem({ type: 'pr' }), {
+      type: 'setAutoMerge',
+      enabled: true
+    })
+    expect(patch.next).toEqual({ autoMergeEnabled: true })
+  })
+
+  it('builds per-login assignee toggle', () => {
+    const patch = buildTaskPageGitHubWorkItemMutationPatch(baseItem(), {
+      type: 'toggleAssignee',
+      user: { login: 'Alice', name: 'A', avatarUrl: '' }
+    })
+    expect(patch.kind).toBe('list')
+    if (patch.kind !== 'list') {
+      return
+    }
+    expect(patch.opKey).toBe('assignees:alice')
+    expect(patch.listOp.kind).toBe('add')
+    expect(patch.next.assignees?.map((u) => u.login.toLowerCase())).toEqual(['alice'])
+  })
+
+  it('builds multi-login reviewer batch opKey', () => {
+    const patch = buildTaskPageGitHubWorkItemMutationPatch(baseItem({ type: 'pr' }), {
+      type: 'addReviewers',
+      logins: ['bob', 'carol'],
+      candidates: [
+        { login: 'bob', name: null, avatarUrl: '' },
+        { login: 'carol', name: null, avatarUrl: '' }
+      ]
+    })
+    expect(patch.kind).toBe('list')
+    if (patch.kind !== 'list') {
+      return
+    }
+    expect(patch.opKey).toBe('reviewRequests:batch:bob,carol')
+    expect(patch.listOp.logins).toEqual(['bob', 'carol'])
+  })
+})
+
+describe('loginSetsEqual', () => {
+  it('compares case-insensitive login sets', () => {
+    expect(
+      loginSetsEqual(
+        loginSetOfUsers([{ login: 'Alice', name: null, avatarUrl: '' }]),
+        loginSetOfUsers([{ login: 'alice', name: null, avatarUrl: '' }])
+      )
+    ).toBe(true)
+  })
+})

--- a/src/renderer/src/components/task-page-github-work-item-mutation-patches.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutation-patches.ts
@@ -1,0 +1,230 @@
+import type { GitHubAssignableUser, GitHubWorkItem } from '../../../shared/types'
+import type { TaskPageGitHubCloseAction } from './task-page-github-status-actions'
+import {
+  taskPageGitHubListOpKey,
+  type PendingListOp,
+  type TaskPageGitHubListFamily
+} from './task-page-github-work-item-mutation-registry'
+
+export type TaskPageGitHubMutationIntent =
+  | { type: 'setState'; state: 'open' | 'closed'; closeAction?: TaskPageGitHubCloseAction }
+  | { type: 'toggleAssignee'; user: GitHubAssignableUser }
+  | { type: 'addReviewers'; logins: string[]; candidates: GitHubAssignableUser[] }
+  | { type: 'removeReviewers'; logins: string[] }
+  | { type: 'merge' }
+  | { type: 'setAutoMerge'; enabled: boolean }
+
+export type TaskPageGitHubWholeFieldPatch = {
+  kind: 'whole'
+  opKey: string
+  previous: Partial<GitHubWorkItem>
+  next: Partial<GitHubWorkItem>
+  /** Families touched for quiet dirty-bit / lastConfirmed. */
+  families: string[]
+}
+
+export type TaskPageGitHubListFieldPatch = {
+  kind: 'list'
+  opKey: string
+  family: TaskPageGitHubListFamily
+  listOp: PendingListOp
+  previous: Partial<GitHubWorkItem>
+  next: Partial<GitHubWorkItem>
+  families: string[]
+}
+
+export type TaskPageGitHubBuiltPatch = TaskPageGitHubWholeFieldPatch | TaskPageGitHubListFieldPatch
+
+function freezeUsers(users: readonly GitHubAssignableUser[]): GitHubAssignableUser[] {
+  return users.map((user) => ({
+    login: user.login,
+    name: user.name,
+    avatarUrl: user.avatarUrl
+  }))
+}
+
+function normalizeLogin(login: string): string {
+  return login.trim().replace(/^@/, '').toLowerCase()
+}
+
+/**
+ * Apply pending list ops onto a confirmed snapshot.
+ * Same login keeps only the latest op (callers should pre-collapse if needed).
+ */
+export function applyTaskPageGitHubListOps(
+  snapshot: readonly GitHubAssignableUser[],
+  ops: readonly PendingListOp[]
+): GitHubAssignableUser[] {
+  let list = freezeUsers(snapshot)
+  for (const op of ops) {
+    for (let i = 0; i < op.logins.length; i++) {
+      const login = op.logins[i]
+      if (op.kind === 'add') {
+        if (!list.some((user) => user.login.toLowerCase() === login)) {
+          const candidate = op.users?.[i]
+          list.push(
+            candidate
+              ? { login: candidate.login, name: candidate.name, avatarUrl: candidate.avatarUrl }
+              : { login, name: null, avatarUrl: '' }
+          )
+        }
+      } else {
+        list = list.filter((user) => user.login.toLowerCase() !== login)
+      }
+    }
+  }
+  return list
+}
+
+export function loginSetOfUsers(users: readonly GitHubAssignableUser[] | undefined): Set<string> {
+  const set = new Set<string>()
+  for (const user of users ?? []) {
+    if (user.login) {
+      set.add(user.login.toLowerCase())
+    }
+  }
+  return set
+}
+
+export function loginSetsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  if (a.size !== b.size) {
+    return false
+  }
+  for (const login of a) {
+    if (!b.has(login)) {
+      return false
+    }
+  }
+  return true
+}
+
+function findUser(
+  candidates: readonly GitHubAssignableUser[],
+  loginLower: string
+): GitHubAssignableUser | undefined {
+  return candidates.find((user) => user.login.toLowerCase() === loginLower)
+}
+
+/**
+ * Pure intent → frozen previous/next patches against a registry-merged base item.
+ */
+export function buildTaskPageGitHubWorkItemMutationPatch(
+  baseItem: GitHubWorkItem,
+  intent: TaskPageGitHubMutationIntent
+): TaskPageGitHubBuiltPatch {
+  switch (intent.type) {
+    case 'setState': {
+      return {
+        kind: 'whole',
+        opKey: 'state',
+        previous: { state: baseItem.state },
+        next: { state: intent.state },
+        families: ['state']
+      }
+    }
+    case 'merge': {
+      return {
+        kind: 'whole',
+        opKey: 'merge',
+        previous: {
+          state: baseItem.state,
+          autoMergeEnabled: baseItem.autoMergeEnabled
+        },
+        next: {
+          state: 'merged',
+          autoMergeEnabled: false
+        },
+        families: ['state', 'merge', 'autoMerge']
+      }
+    }
+    case 'setAutoMerge': {
+      return {
+        kind: 'whole',
+        opKey: 'autoMerge',
+        previous: { autoMergeEnabled: baseItem.autoMergeEnabled },
+        next: { autoMergeEnabled: intent.enabled },
+        families: ['autoMerge']
+      }
+    }
+    case 'toggleAssignee': {
+      const login = normalizeLogin(intent.user.login)
+      const current = freezeUsers(baseItem.assignees ?? [])
+      const isOn = current.some((user) => user.login.toLowerCase() === login)
+      const listOp: PendingListOp = isOn
+        ? { family: 'assignees', kind: 'remove', logins: [login] }
+        : {
+            family: 'assignees',
+            kind: 'add',
+            logins: [login],
+            users: [
+              {
+                login: intent.user.login,
+                name: intent.user.name,
+                avatarUrl: intent.user.avatarUrl
+              }
+            ]
+          }
+      const nextAssignees = applyTaskPageGitHubListOps(current, [listOp])
+      return {
+        kind: 'list',
+        opKey: taskPageGitHubListOpKey('assignees', [login]),
+        family: 'assignees',
+        listOp,
+        previous: { assignees: current },
+        next: { assignees: nextAssignees },
+        families: ['assignees']
+      }
+    }
+    case 'addReviewers': {
+      const logins = intent.logins.map(normalizeLogin).filter(Boolean)
+      const unique = [...new Set(logins)]
+      const users = unique.map((login) => {
+        const fromCandidates = findUser(intent.candidates, login)
+        const fromCurrent = findUser(baseItem.reviewRequests ?? [], login)
+        return (
+          fromCandidates ??
+          fromCurrent ?? {
+            login,
+            name: null,
+            avatarUrl: ''
+          }
+        )
+      })
+      const listOp: PendingListOp = {
+        family: 'reviewRequests',
+        kind: 'add',
+        logins: unique,
+        users: freezeUsers(users)
+      }
+      const current = freezeUsers(baseItem.reviewRequests ?? [])
+      return {
+        kind: 'list',
+        opKey: taskPageGitHubListOpKey('reviewRequests', unique),
+        family: 'reviewRequests',
+        listOp,
+        previous: { reviewRequests: current },
+        next: { reviewRequests: applyTaskPageGitHubListOps(current, [listOp]) },
+        families: ['reviewRequests']
+      }
+    }
+    case 'removeReviewers': {
+      const logins = intent.logins.map(normalizeLogin).filter(Boolean)
+      const unique = [...new Set(logins)]
+      const listOp: PendingListOp = {
+        family: 'reviewRequests',
+        kind: 'remove',
+        logins: unique
+      }
+      const current = freezeUsers(baseItem.reviewRequests ?? [])
+      return {
+        kind: 'list',
+        opKey: taskPageGitHubListOpKey('reviewRequests', unique),
+        family: 'reviewRequests',
+        listOp,
+        previous: { reviewRequests: current },
+        next: { reviewRequests: applyTaskPageGitHubListOps(current, [listOp]) },
+        families: ['reviewRequests']
+      }
+    }
+  }
+}

--- a/src/renderer/src/components/task-page-github-work-item-mutation-registry.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutation-registry.ts
@@ -1,0 +1,333 @@
+import type { GitHubAssignableUser, GitHubWorkItem } from '../../../shared/types'
+/** Whole-field replace keys (single RPC / single superseding generation). */
+export type TaskPageGitHubWholeField = 'state' | 'merge' | 'autoMerge'
+/**
+ * Op-keyed list families: each independent login RPC gets its own generation.
+ * Serialized as `assignees:${loginLower}` / `reviewRequests:${loginLower}`.
+ */
+export type TaskPageGitHubListFamily = 'assignees' | 'reviewRequests'
+export type TaskPageGitHubMutationKey = {
+  sourceScope: string | null
+  repoId: string
+  itemId: string
+  /** e.g. 'state' | 'merge' | 'autoMerge' | 'assignees:alice' | 'reviewRequests:bob' */
+  opKey: string
+}
+export type PendingListOp = {
+  family: TaskPageGitHubListFamily
+  kind: 'add' | 'remove'
+  /** Length 1 for per-login; N for atomic multi-login batch. */
+  logins: string[]
+  users?: GitHubAssignableUser[]
+}
+export type PendingOp = {
+  generation: number
+  key: TaskPageGitHubMutationKey
+  previous: Partial<GitHubWorkItem>
+  next: Partial<GitHubWorkItem>
+  listOp?: PendingListOp
+  /** Frozen at begin for soft-hide recompute on confirm/rollback (K20). */
+  skipMeQualifiers: boolean
+  startedAt: number
+}
+export type StickyHideEntry = {
+  itemKey: string
+  sourceScope: string | null
+  queryKey: string
+  reason: 'filter_membership'
+}
+export type QuietRevalidateState = {
+  inFlight: boolean
+  /** Set when a quiet run is requested while another is in flight. */
+  trailingQueued: boolean
+  dirtyGeneration: number
+  fetchStartedAtGeneration: number
+  familyDirtyAt: Map<string, number>
+  lagSkipAttempts: Map<string, number>
+  lastConfirmAt: number
+}
+import {
+  serializeTaskPageGitHubMutationKey,
+  taskPageGitHubItemKey,
+  taskPageGitHubLastConfirmedKey,
+  taskPageGitHubSnapshotKey
+} from './task-page-github-work-item-mutation-keys'
+export {
+  serializeTaskPageGitHubMutationKey,
+  taskPageGitHubFamilyDirtyKey,
+  taskPageGitHubItemKey,
+  taskPageGitHubLastConfirmedKey,
+  taskPageGitHubListOpKey,
+  taskPageGitHubSnapshotKey
+} from './task-page-github-work-item-mutation-keys'
+type Listener = () => void
+const listeners = new Set<Listener>()
+const pendingByKey = new Map<string, PendingOp>()
+const generations = new Map<string, number>()
+const confirmedSnapshots = new Map<string, GitHubAssignableUser[]>()
+const lastConfirmedClientValues = new Map<string, unknown>()
+/**
+ * Why: after confirm, pending ops are gone but lastConfirmed/snapshots stay keyed
+ * by sourceScope. Overlay must still resolve the same scope or authority is lost.
+ */
+const itemSourceScopeByItemKey = new Map<string, string | null>()
+const stickyHideByItemKey = new Map<string, StickyHideEntry>()
+const softHiddenItemKeys = new Set<string>()
+const quietByQueryKey = new Map<string, QuietRevalidateState>()
+let mutationQueryKey: string | null = null
+export function subscribeTaskPageGitHubMutationRegistry(listener: Listener): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+export function notifyTaskPageGitHubMutationRegistry(): void {
+  for (const listener of listeners) {
+    listener()
+  }
+}
+export function getTaskPageGitHubSoftHiddenItemKeys(): ReadonlySet<string> {
+  return softHiddenItemKeys
+}
+/**
+ * Drop confirmed-client authority (not in-flight pending). Used when the user
+ * hard-refreshes so search can adopt for non-pending families (design tier 3).
+ */
+export function clearTaskPageGitHubConfirmedAuthority(): void {
+  confirmedSnapshots.clear()
+  lastConfirmedClientValues.clear()
+  itemSourceScopeByItemKey.clear()
+}
+
+/**
+ * Sticky hides + confirmed authority are query-scoped. Changing query/repo set
+ * clears them so a new filter does not inherit membership exits / lastConfirmed
+ * from a previous search.
+ */
+export function setTaskPageGitHubMutationQueryKey(queryKey: string): void {
+  if (mutationQueryKey === queryKey) {
+    return
+  }
+  mutationQueryKey = queryKey
+  stickyHideByItemKey.clear()
+  softHiddenItemKeys.clear()
+  // Why: lastConfirmed is for lag hold within one query; a new search should
+  // not permanently override rows with the previous filter's mutations.
+  clearTaskPageGitHubConfirmedAuthority()
+  // Why: bound growth — quiet lag/dirty state and generation counters accumulate
+  // per queryKey/opKey over a session. A new query starts fresh, so drop the old
+  // quiet states and any generation counters with no in-flight pending op (keys
+  // with a live op must keep their counter so staleness detection stays valid).
+  quietByQueryKey.clear()
+  for (const serialized of generations.keys()) {
+    if (!pendingByKey.has(serialized)) {
+      generations.delete(serialized)
+    }
+  }
+  notifyTaskPageGitHubMutationRegistry()
+}
+export function getPendingTaskPageGitHubOp(key: TaskPageGitHubMutationKey): PendingOp | undefined {
+  return pendingByKey.get(serializeTaskPageGitHubMutationKey(key))
+}
+export function nextTaskPageGitHubMutationGeneration(key: TaskPageGitHubMutationKey): number {
+  const serialized = serializeTaskPageGitHubMutationKey(key)
+  const next = (generations.get(serialized) ?? 0) + 1
+  generations.set(serialized, next)
+  return next
+}
+export function setPendingTaskPageGitHubOp(op: PendingOp): void {
+  const serialized = serializeTaskPageGitHubMutationKey(op.key)
+  // Why: whole-field supersede abandons older pending without rollback; list
+  // ops share the same map entry only when opKey matches (per-login / batch).
+  pendingByKey.set(serialized, op)
+  rememberItemSourceScope(op.key.repoId, op.key.itemId, op.key.sourceScope)
+}
+
+export function rememberItemSourceScope(
+  repoId: string,
+  itemId: string,
+  sourceScope: string | null
+): void {
+  itemSourceScopeByItemKey.set(taskPageGitHubItemKey(repoId, itemId), sourceScope)
+}
+
+/**
+ * Resolve the sourceScope used for lastConfirmed/snapshot lookups for an item.
+ * Prefer live pending, then the remembered scope from the last begin/confirm.
+ */
+export function resolveItemSourceScope(repoId: string, itemId: string): string | null {
+  const fromPending = getSourceScopeFromPendingOps(repoId, itemId)
+  if (fromPending !== undefined) {
+    return fromPending
+  }
+  const remembered = itemSourceScopeByItemKey.get(taskPageGitHubItemKey(repoId, itemId))
+  return remembered !== undefined ? remembered : null
+}
+
+export function hasConfirmedAuthorityForItem(repoId: string, itemId: string): boolean {
+  const sourceScope = resolveItemSourceScope(repoId, itemId)
+  return (
+    getConfirmedListSnapshot(sourceScope, repoId, itemId, 'assignees') !== undefined ||
+    getConfirmedListSnapshot(sourceScope, repoId, itemId, 'reviewRequests') !== undefined ||
+    getLastConfirmedClientValue(sourceScope, repoId, itemId, 'state') !== undefined ||
+    getLastConfirmedClientValue(sourceScope, repoId, itemId, 'autoMerge') !== undefined
+  )
+}
+export function deletePendingTaskPageGitHubOp(
+  key: TaskPageGitHubMutationKey
+): PendingOp | undefined {
+  const serialized = serializeTaskPageGitHubMutationKey(key)
+  const existing = pendingByKey.get(serialized)
+  if (existing) {
+    pendingByKey.delete(serialized)
+  }
+  return existing
+}
+export function listPendingTaskPageGitHubOpsForItem(
+  repoId: string,
+  itemId: string,
+  sourceScope?: string | null
+): PendingOp[] {
+  const ops: PendingOp[] = []
+  for (const op of pendingByKey.values()) {
+    if (op.key.repoId !== repoId || op.key.itemId !== itemId) {
+      continue
+    }
+    if (sourceScope !== undefined && op.key.sourceScope !== sourceScope) {
+      continue
+    }
+    ops.push(op)
+  }
+  return ops.sort((a, b) => a.startedAt - b.startedAt)
+}
+export function hasPendingTaskPageGitHubOpsForItem(repoId: string, itemId: string): boolean {
+  for (const op of pendingByKey.values()) {
+    if (op.key.repoId === repoId && op.key.itemId === itemId) {
+      return true
+    }
+  }
+  return false
+}
+export function getSourceScopeFromPendingOps(
+  repoId: string,
+  itemId: string
+): string | null | undefined {
+  for (const op of pendingByKey.values()) {
+    if (op.key.repoId === repoId && op.key.itemId === itemId) {
+      return op.key.sourceScope
+    }
+  }
+  return undefined
+}
+export function getConfirmedListSnapshot(
+  sourceScope: string | null,
+  repoId: string,
+  itemId: string,
+  family: TaskPageGitHubListFamily
+): GitHubAssignableUser[] | undefined {
+  return confirmedSnapshots.get(taskPageGitHubSnapshotKey(sourceScope, repoId, itemId, family))
+}
+export function setConfirmedListSnapshot(
+  sourceScope: string | null,
+  repoId: string,
+  itemId: string,
+  family: TaskPageGitHubListFamily,
+  users: readonly GitHubAssignableUser[]
+): void {
+  rememberItemSourceScope(repoId, itemId, sourceScope)
+  confirmedSnapshots.set(taskPageGitHubSnapshotKey(sourceScope, repoId, itemId, family), [...users])
+}
+export function getLastConfirmedClientValue(
+  sourceScope: string | null,
+  repoId: string,
+  itemId: string,
+  family: string
+): unknown {
+  return lastConfirmedClientValues.get(
+    taskPageGitHubLastConfirmedKey(sourceScope, repoId, itemId, family)
+  )
+}
+export function setLastConfirmedClientValue(
+  sourceScope: string | null,
+  repoId: string,
+  itemId: string,
+  family: string,
+  value: unknown
+): void {
+  rememberItemSourceScope(repoId, itemId, sourceScope)
+  lastConfirmedClientValues.set(
+    taskPageGitHubLastConfirmedKey(sourceScope, repoId, itemId, family),
+    value
+  )
+}
+export function getStickyHideEntry(itemKey: string): StickyHideEntry | undefined {
+  return stickyHideByItemKey.get(itemKey)
+}
+export function setStickyHideEntry(entry: StickyHideEntry): void {
+  stickyHideByItemKey.set(entry.itemKey, entry)
+}
+export function deleteStickyHideEntry(itemKey: string): void {
+  stickyHideByItemKey.delete(itemKey)
+}
+export function clearAllStickyHideEntries(): void {
+  stickyHideByItemKey.clear()
+}
+export function getAllStickyHideEntries(): ReadonlyMap<string, StickyHideEntry> {
+  return stickyHideByItemKey
+}
+export function setSoftHiddenItemKeys(keys: Iterable<string>): void {
+  softHiddenItemKeys.clear()
+  for (const key of keys) {
+    softHiddenItemKeys.add(key)
+  }
+}
+export function updateSoftHiddenItemKey(itemKey: string, hide: boolean): void {
+  if (hide) {
+    softHiddenItemKeys.add(itemKey)
+  } else {
+    softHiddenItemKeys.delete(itemKey)
+  }
+}
+export function getOrCreateQuietRevalidateState(queryKey: string): QuietRevalidateState {
+  let state = quietByQueryKey.get(queryKey)
+  if (!state) {
+    state = {
+      inFlight: false,
+      trailingQueued: false,
+      dirtyGeneration: 0,
+      fetchStartedAtGeneration: 0,
+      familyDirtyAt: new Map(),
+      lagSkipAttempts: new Map(),
+      lastConfirmAt: 0
+    }
+    quietByQueryKey.set(queryKey, state)
+  }
+  return state
+}
+export function gcStickyHidesAbsentFromPages(
+  pageItemKeys: ReadonlySet<string>,
+  queryKey: string
+): void {
+  for (const [itemKey, entry] of stickyHideByItemKey) {
+    if (entry.queryKey !== queryKey) {
+      continue
+    }
+    if (!pageItemKeys.has(itemKey)) {
+      stickyHideByItemKey.delete(itemKey)
+      softHiddenItemKeys.delete(itemKey)
+    }
+  }
+}
+/** Test-only: wipe module state between unit cases. */
+export function resetTaskPageGitHubMutationRegistryForTests(): void {
+  pendingByKey.clear()
+  generations.clear()
+  confirmedSnapshots.clear()
+  lastConfirmedClientValues.clear()
+  itemSourceScopeByItemKey.clear()
+  stickyHideByItemKey.clear()
+  softHiddenItemKeys.clear()
+  quietByQueryKey.clear()
+  mutationQueryKey = null
+  listeners.clear()
+}

--- a/src/renderer/src/components/task-page-github-work-item-mutation-registry.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutation-registry.ts
@@ -1,57 +1,29 @@
-import type { GitHubAssignableUser, GitHubWorkItem } from '../../../shared/types'
-/** Whole-field replace keys (single RPC / single superseding generation). */
-export type TaskPageGitHubWholeField = 'state' | 'merge' | 'autoMerge'
-/**
- * Op-keyed list families: each independent login RPC gets its own generation.
- * Serialized as `assignees:${loginLower}` / `reviewRequests:${loginLower}`.
- */
-export type TaskPageGitHubListFamily = 'assignees' | 'reviewRequests'
-export type TaskPageGitHubMutationKey = {
-  sourceScope: string | null
-  repoId: string
-  itemId: string
-  /** e.g. 'state' | 'merge' | 'autoMerge' | 'assignees:alice' | 'reviewRequests:bob' */
-  opKey: string
-}
-export type PendingListOp = {
-  family: TaskPageGitHubListFamily
-  kind: 'add' | 'remove'
-  /** Length 1 for per-login; N for atomic multi-login batch. */
-  logins: string[]
-  users?: GitHubAssignableUser[]
-}
-export type PendingOp = {
-  generation: number
-  key: TaskPageGitHubMutationKey
-  previous: Partial<GitHubWorkItem>
-  next: Partial<GitHubWorkItem>
-  listOp?: PendingListOp
-  /** Frozen at begin for soft-hide recompute on confirm/rollback (K20). */
-  skipMeQualifiers: boolean
-  startedAt: number
-}
-export type StickyHideEntry = {
-  itemKey: string
-  sourceScope: string | null
-  queryKey: string
-  reason: 'filter_membership'
-}
-export type QuietRevalidateState = {
-  inFlight: boolean
-  /** Set when a quiet run is requested while another is in flight. */
-  trailingQueued: boolean
-  dirtyGeneration: number
-  fetchStartedAtGeneration: number
-  familyDirtyAt: Map<string, number>
-  lagSkipAttempts: Map<string, number>
-  lastConfirmAt: number
-}
+import type { GitHubAssignableUser } from '../../../shared/types'
+import type {
+  PendingOp,
+  StickyHideEntry,
+  TaskPageGitHubListFamily,
+  TaskPageGitHubMutationKey
+} from './task-page-github-work-item-registry-types'
+export type {
+  PendingListOp,
+  PendingOp,
+  StickyHideEntry,
+  TaskPageGitHubListFamily,
+  TaskPageGitHubMutationKey
+} from './task-page-github-work-item-registry-types'
 import {
   serializeTaskPageGitHubMutationKey,
   taskPageGitHubItemKey,
   taskPageGitHubLastConfirmedKey,
   taskPageGitHubSnapshotKey
 } from './task-page-github-work-item-mutation-keys'
+import { clearTaskPageGitHubQuietStates } from './task-page-github-work-item-quiet-state'
+export {
+  getOrCreateQuietRevalidateState,
+  markTaskPageGitHubFamiliesDirty,
+  type QuietRevalidateState
+} from './task-page-github-work-item-quiet-state'
 export {
   serializeTaskPageGitHubMutationKey,
   taskPageGitHubFamilyDirtyKey,
@@ -73,7 +45,6 @@ const lastConfirmedClientValues = new Map<string, unknown>()
 const itemSourceScopeByItemKey = new Map<string, string | null>()
 const stickyHideByItemKey = new Map<string, StickyHideEntry>()
 const softHiddenItemKeys = new Set<string>()
-const quietByQueryKey = new Map<string, QuietRevalidateState>()
 let mutationQueryKey: string | null = null
 export function subscribeTaskPageGitHubMutationRegistry(listener: Listener): () => void {
   listeners.add(listener)
@@ -89,6 +60,19 @@ export function notifyTaskPageGitHubMutationRegistry(): void {
 export function getTaskPageGitHubSoftHiddenItemKeys(): ReadonlySet<string> {
   return softHiddenItemKeys
 }
+export function getTaskPageGitHubConfirmedAuthorityItemKeys(): ReadonlySet<string> {
+  const keys = new Set<string>()
+  for (const itemKey of itemSourceScopeByItemKey.keys()) {
+    const separator = itemKey.indexOf('\0')
+    if (
+      separator >= 0 &&
+      hasConfirmedAuthorityForItem(itemKey.slice(0, separator), itemKey.slice(separator + 1))
+    ) {
+      keys.add(itemKey)
+    }
+  }
+  return keys
+}
 /**
  * Drop confirmed-client authority (not in-flight pending). Used when the user
  * hard-refreshes so search can adopt for non-pending families (design tier 3).
@@ -98,7 +82,6 @@ export function clearTaskPageGitHubConfirmedAuthority(): void {
   lastConfirmedClientValues.clear()
   itemSourceScopeByItemKey.clear()
 }
-
 /**
  * Sticky hides + confirmed authority are query-scoped. Changing query/repo set
  * clears them so a new filter does not inherit membership exits / lastConfirmed
@@ -118,13 +101,19 @@ export function setTaskPageGitHubMutationQueryKey(queryKey: string): void {
   // per queryKey/opKey over a session. A new query starts fresh, so drop the old
   // quiet states and any generation counters with no in-flight pending op (keys
   // with a live op must keep their counter so staleness detection stays valid).
-  quietByQueryKey.clear()
+  clearTaskPageGitHubQuietStates()
   for (const serialized of generations.keys()) {
     if (!pendingByKey.has(serialized)) {
       generations.delete(serialized)
     }
   }
   notifyTaskPageGitHubMutationRegistry()
+}
+export function isTaskPageGitHubMutationQueryKeyCurrent(queryKey: string): boolean {
+  return mutationQueryKey === queryKey
+}
+export function getTaskPageGitHubMutationQueryKey(): string | null {
+  return mutationQueryKey
 }
 export function getPendingTaskPageGitHubOp(key: TaskPageGitHubMutationKey): PendingOp | undefined {
   return pendingByKey.get(serializeTaskPageGitHubMutationKey(key))
@@ -237,6 +226,14 @@ export function setConfirmedListSnapshot(
   rememberItemSourceScope(repoId, itemId, sourceScope)
   confirmedSnapshots.set(taskPageGitHubSnapshotKey(sourceScope, repoId, itemId, family), [...users])
 }
+export function deleteConfirmedListSnapshot(
+  sourceScope: string | null,
+  repoId: string,
+  itemId: string,
+  family: TaskPageGitHubListFamily
+): void {
+  confirmedSnapshots.delete(taskPageGitHubSnapshotKey(sourceScope, repoId, itemId, family))
+}
 export function getLastConfirmedClientValue(
   sourceScope: string | null,
   repoId: string,
@@ -260,6 +257,23 @@ export function setLastConfirmedClientValue(
     value
   )
 }
+export function deleteLastConfirmedClientValue(
+  sourceScope: string | null,
+  repoId: string,
+  itemId: string,
+  family: string
+): void {
+  lastConfirmedClientValues.delete(
+    taskPageGitHubLastConfirmedKey(sourceScope, repoId, itemId, family)
+  )
+}
+export function clearConfirmedAuthorityForItem(repoId: string, itemId: string): void {
+  const sourceScope = resolveItemSourceScope(repoId, itemId)
+  deleteConfirmedListSnapshot(sourceScope, repoId, itemId, 'assignees')
+  deleteConfirmedListSnapshot(sourceScope, repoId, itemId, 'reviewRequests')
+  deleteLastConfirmedClientValue(sourceScope, repoId, itemId, 'state')
+  deleteLastConfirmedClientValue(sourceScope, repoId, itemId, 'autoMerge')
+}
 export function getStickyHideEntry(itemKey: string): StickyHideEntry | undefined {
   return stickyHideByItemKey.get(itemKey)
 }
@@ -268,9 +282,6 @@ export function setStickyHideEntry(entry: StickyHideEntry): void {
 }
 export function deleteStickyHideEntry(itemKey: string): void {
   stickyHideByItemKey.delete(itemKey)
-}
-export function clearAllStickyHideEntries(): void {
-  stickyHideByItemKey.clear()
 }
 export function getAllStickyHideEntries(): ReadonlyMap<string, StickyHideEntry> {
   return stickyHideByItemKey
@@ -287,22 +298,6 @@ export function updateSoftHiddenItemKey(itemKey: string, hide: boolean): void {
   } else {
     softHiddenItemKeys.delete(itemKey)
   }
-}
-export function getOrCreateQuietRevalidateState(queryKey: string): QuietRevalidateState {
-  let state = quietByQueryKey.get(queryKey)
-  if (!state) {
-    state = {
-      inFlight: false,
-      trailingQueued: false,
-      dirtyGeneration: 0,
-      fetchStartedAtGeneration: 0,
-      familyDirtyAt: new Map(),
-      lagSkipAttempts: new Map(),
-      lastConfirmAt: 0
-    }
-    quietByQueryKey.set(queryKey, state)
-  }
-  return state
 }
 export function gcStickyHidesAbsentFromPages(
   pageItemKeys: ReadonlySet<string>,
@@ -327,7 +322,7 @@ export function resetTaskPageGitHubMutationRegistryForTests(): void {
   itemSourceScopeByItemKey.clear()
   stickyHideByItemKey.clear()
   softHiddenItemKeys.clear()
-  quietByQueryKey.clear()
+  clearTaskPageGitHubQuietStates()
   mutationQueryKey = null
   listeners.clear()
 }

--- a/src/renderer/src/components/task-page-github-work-item-mutation-regressions.test.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutation-regressions.test.ts
@@ -1,0 +1,373 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { ParsedTaskQuery } from '../../../shared/task-query'
+import type { GitHubWorkItem } from '../../../shared/types'
+import {
+  adoptQuietSearchFieldsForItem,
+  advanceTaskPageQuietRevalidateScope,
+  applyPendingTaskPageGitHubMutationsToItems,
+  beginTaskPageGitHubWorkItemMutation,
+  canStartTaskPageGitHubWorkItemMutation,
+  clearTaskPageGitHubAuthorityAbsentFromLoadedItems,
+  clearTaskPageGitHubAuthorityThroughGeneration,
+  confirmTaskPageGitHubWorkItemMutation,
+  getTaskPageQuietRevalidateBackoffAttempt,
+  getTaskPageGitHubRevalidatableAuthorityItemKeys,
+  isTaskPageQuietRevalidateRunCurrent,
+  isTaskPageQuietRevalidateScopeCurrent,
+  MAX_LAG_TRAILS,
+  patchTaskPageGitHubWorkItemPages,
+  reconcileTaskPagePagesAfterQuietRefresh,
+  rebuildSoftHiddenFromItemsForTests
+} from './task-page-github-work-item-mutations'
+import {
+  getLastConfirmedClientValue,
+  getOrCreateQuietRevalidateState,
+  getTaskPageGitHubSoftHiddenItemKeys,
+  resetTaskPageGitHubMutationRegistryForTests,
+  setTaskPageGitHubMutationQueryKey,
+  subscribeTaskPageGitHubMutationRegistry,
+  taskPageGitHubFamilyDirtyKey,
+  taskPageGitHubItemKey
+} from './task-page-github-work-item-mutation-registry'
+import {
+  beginTaskPageQuietRevalidateRun,
+  finishTaskPageQuietRevalidateRun
+} from './task-page-github-work-item-quiet-state'
+
+function query(): ParsedTaskQuery {
+  return {
+    scope: 'all',
+    state: 'open',
+    draft: false,
+    assignee: null,
+    author: null,
+    reviewRequested: null,
+    reviewedBy: null,
+    labels: [],
+    freeText: ''
+  }
+}
+
+function item(overrides: Partial<GitHubWorkItem> = {}): GitHubWorkItem {
+  return {
+    id: 'issue:1',
+    type: 'issue',
+    number: 1,
+    title: 't',
+    state: 'open',
+    url: 'https://github.com/o/r/issues/1',
+    labels: [],
+    updatedAt: '2026-01-01T00:00:00Z',
+    author: 'author',
+    repoId: 'repo-1',
+    ...overrides
+  }
+}
+
+afterEach(() => resetTaskPageGitHubMutationRegistryForTests())
+
+describe('TaskPage GitHub mutation regressions', () => {
+  it('invalidates quiet responses after a query changes away and back', () => {
+    const initial = { queryKey: 'q1', generation: 0 }
+    const returned = advanceTaskPageQuietRevalidateScope(
+      advanceTaskPageQuietRevalidateScope(initial, 'q2'),
+      'q1'
+    )
+    expect(isTaskPageQuietRevalidateScopeCurrent(returned, 'q1', initial.generation)).toBe(false)
+    expect(isTaskPageQuietRevalidateScopeCurrent(returned, 'q1', returned.generation)).toBe(true)
+  })
+
+  it('invalidates an older quiet response after a hard refresh dispatches', () => {
+    expect(
+      isTaskPageQuietRevalidateRunCurrent({ queryKey: 'q', generation: 0 }, 'q', 0, 0, 1)
+    ).toBe(false)
+  })
+
+  it('lets a remounted TaskPage take over an orphaned quiet run', () => {
+    const quiet = getOrCreateQuietRevalidateState('q')
+    const oldOwner = {}
+    const newOwner = {}
+    const oldRun = beginTaskPageQuietRevalidateRun(quiet, oldOwner)
+    const newRun = beginTaskPageQuietRevalidateRun(quiet, newOwner)
+    if (oldRun === null || newRun === null) {
+      throw new Error('Expected both quiet owners to start a run.')
+    }
+    expect(finishTaskPageQuietRevalidateRun(quiet, oldOwner, oldRun)).toBe(false)
+    expect(quiet.inFlight).toBe(true)
+    expect(finishTaskPageQuietRevalidateRun(quiet, newOwner, newRun)).toBe(true)
+    expect(quiet.inFlight).toBe(false)
+  })
+
+  it('does not let an exhausted lag key block a newer item retry', () => {
+    expect(getTaskPageQuietRevalidateBackoffAttempt([MAX_LAG_TRAILS, 1])).toBe(1)
+  })
+
+  it('resets exhausted family lag when a new confirmation arrives', () => {
+    const base = item()
+    const confirmState = (state: 'open' | 'closed'): void => {
+      const began = beginTaskPageGitHubWorkItemMutation({
+        item: base,
+        intent: { type: 'setState', state },
+        query: query(),
+        queryKey: 'q',
+        viewerLogin: 'me',
+        patchWorkItem: () => {}
+      })
+      confirmTaskPageGitHubWorkItemMutation(began.key, began.generation, {
+        query: query(),
+        queryKey: 'q',
+        viewerLogin: 'me',
+        item: base
+      })
+    }
+    confirmState('closed')
+    const familyKey = taskPageGitHubFamilyDirtyKey(
+      taskPageGitHubItemKey(base.repoId, base.id),
+      'state'
+    )
+    getOrCreateQuietRevalidateState('q').lagSkipAttempts.set(familyKey, MAX_LAG_TRAILS)
+    expect(getTaskPageGitHubRevalidatableAuthorityItemKeys('q')).not.toContain(
+      taskPageGitHubItemKey(base.repoId, base.id)
+    )
+    confirmState('open')
+    expect(getTaskPageGitHubRevalidatableAuthorityItemKeys('q')).toContain(
+      taskPageGitHubItemKey(base.repoId, base.id)
+    )
+  })
+
+  it('blocks a second same-key write while the first is unresolved', () => {
+    const base = item()
+    const input = { item: base, intent: { type: 'setState', state: 'closed' } as const }
+    expect(canStartTaskPageGitHubWorkItemMutation(input)).toBe(true)
+    beginTaskPageGitHubWorkItemMutation({
+      ...input,
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      patchWorkItem: () => {}
+    })
+    expect(canStartTaskPageGitHubWorkItemMutation(input)).toBe(false)
+  })
+
+  it('blocks overlapping list and whole-field writes while allowing disjoint list writes', () => {
+    const base = item({ reviewRequests: [] })
+    beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: {
+        type: 'addReviewers',
+        logins: ['alice', 'bob'],
+        candidates: []
+      },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      patchWorkItem: () => {}
+    })
+    expect(
+      canStartTaskPageGitHubWorkItemMutation({
+        item: base,
+        intent: { type: 'removeReviewers', logins: ['alice'] }
+      })
+    ).toBe(false)
+    expect(
+      canStartTaskPageGitHubWorkItemMutation({
+        item: base,
+        intent: { type: 'removeReviewers', logins: ['carol'] }
+      })
+    ).toBe(true)
+
+    const autoMerge = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: { type: 'setAutoMerge', enabled: true },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      patchWorkItem: () => {}
+    })
+    expect(autoMerge.opKey).toBe('autoMerge')
+    expect(canStartTaskPageGitHubWorkItemMutation({ item: base, intent: { type: 'merge' } })).toBe(
+      false
+    )
+  })
+
+  it('does not notify subscribers when a soft-hide rebuild is unchanged', () => {
+    const base = item()
+    beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: { type: 'setState', state: 'closed' },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      patchWorkItem: () => {}
+    })
+    let notifications = 0
+    const unsubscribe = subscribeTaskPageGitHubMutationRegistry(() => {
+      notifications += 1
+    })
+    rebuildSoftHiddenFromItemsForTests({
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      items: [base]
+    })
+    unsubscribe()
+    expect(notifications).toBe(0)
+  })
+
+  it('preserves the visible page when an earlier authority page changes membership', () => {
+    const pages = [[item({ id: 'issue:1' })], [item({ id: 'issue:2' })], [item({ id: 'issue:3' })]]
+    const next = reconcileTaskPagePagesAfterQuietRefresh({
+      pages,
+      queryKey: 'q',
+      authorityPage: 0,
+      authorityItems: [],
+      membershipChanged: true,
+      visiblePage: 2,
+      visibleItems: [item({ id: 'issue:4' })]
+    })
+    expect(next).toHaveLength(3)
+    expect(next[1]).toBeNull()
+    expect(next[2]?.[0].id).toBe('issue:4')
+  })
+
+  it('does not apply an old query soft-hide after mutation completion', () => {
+    const patchWorkItem = (): void => {}
+    const base = item({ state: 'open' })
+    const began = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: { type: 'setState', state: 'closed' },
+      query: query(),
+      queryKey: 'open-query',
+      viewerLogin: 'me',
+      patchWorkItem
+    })
+    setTaskPageGitHubMutationQueryKey('current-open-query')
+    confirmTaskPageGitHubWorkItemMutation(began.key, began.generation, {
+      query: query(),
+      queryKey: 'open-query',
+      viewerLogin: 'me',
+      item: base,
+      patchWorkItem
+    })
+    expect(getTaskPageGitHubSoftHiddenItemKeys()).not.toContain(
+      taskPageGitHubItemKey(base.repoId, base.id)
+    )
+    expect(getOrCreateQuietRevalidateState('current-open-query').dirtyGeneration).toBe(1)
+    rebuildSoftHiddenFromItemsForTests({
+      query: query(),
+      queryKey: 'current-open-query',
+      viewerLogin: 'me',
+      items: [base]
+    })
+    expect(getTaskPageGitHubSoftHiddenItemKeys()).toContain(
+      taskPageGitHubItemKey(base.repoId, base.id)
+    )
+  })
+
+  it('hard refresh clears only authority that predates its request', () => {
+    const patchWorkItem = (): void => {}
+    const base = item({ state: 'open', autoMergeEnabled: false })
+    const stateMutation = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: { type: 'setState', state: 'closed' },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      patchWorkItem
+    })
+    confirmTaskPageGitHubWorkItemMutation(stateMutation.key, stateMutation.generation, {
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: base,
+      patchWorkItem
+    })
+    const fetchGeneration = getOrCreateQuietRevalidateState('q').dirtyGeneration
+    const autoMergeMutation = beginTaskPageGitHubWorkItemMutation({
+      item: { ...base, state: 'closed' },
+      intent: { type: 'setAutoMerge', enabled: true },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      patchWorkItem
+    })
+    confirmTaskPageGitHubWorkItemMutation(autoMergeMutation.key, autoMergeMutation.generation, {
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: { ...base, state: 'closed' },
+      patchWorkItem
+    })
+
+    clearTaskPageGitHubAuthorityThroughGeneration('q', fetchGeneration)
+
+    expect(getLastConfirmedClientValue(null, base.repoId, base.id, 'state')).toBeUndefined()
+    expect(getLastConfirmedClientValue(null, base.repoId, base.id, 'autoMerge')).toBe(true)
+    expect(getTaskPageGitHubSoftHiddenItemKeys()).not.toContain(
+      taskPageGitHubItemKey(base.repoId, base.id)
+    )
+  })
+
+  it('releases confirmed authority for rows no longer present on loaded pages', () => {
+    const base = item({ autoMergeEnabled: false })
+    const began = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: { type: 'setAutoMerge', enabled: true },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      patchWorkItem: () => {}
+    })
+    confirmTaskPageGitHubWorkItemMutation(began.key, began.generation, {
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: base
+    })
+    clearTaskPageGitHubAuthorityAbsentFromLoadedItems(new Set())
+    expect(getTaskPageGitHubRevalidatableAuthorityItemKeys('q')).not.toContain(
+      taskPageGitHubItemKey(base.repoId, base.id)
+    )
+  })
+
+  it('preserves unavailable list metadata on untouched rows', () => {
+    const [overlaid] = applyPendingTaskPageGitHubMutationsToItems([
+      item({ assignees: undefined, reviewRequests: undefined })
+    ])
+    expect(overlaid.assignees).toBeUndefined()
+    expect(overlaid.reviewRequests).toBeUndefined()
+  })
+
+  it('patches a later provider page without rebuilding untouched pages', () => {
+    const firstPage = [item({ id: 'issue:1' })]
+    const pages = patchTaskPageGitHubWorkItemPages(
+      [firstPage, [item({ id: 'issue:2' })]],
+      { id: 'issue:2', repoId: 'repo-1' },
+      { state: 'closed' }
+    )
+    expect(pages[0]).toBe(firstPage)
+    expect(pages[1]?.[0].state).toBe('closed')
+  })
+
+  it('does not claim authority over untouched search fields', () => {
+    const patches: Partial<GitHubWorkItem>[] = []
+    const patchWorkItem = (_id: string, patch: Partial<GitHubWorkItem>): void => {
+      patches.push(patch)
+    }
+    const open = item({ state: 'open', assignees: undefined, reviewRequests: undefined })
+    const closed = item({ state: 'closed', assignees: undefined, reviewRequests: undefined })
+    for (const serverItem of [open, closed]) {
+      adoptQuietSearchFieldsForItem({
+        item: serverItem,
+        serverItem,
+        sourceScope: null,
+        queryKey: 'q',
+        fetchStartedAtGeneration: 0,
+        patchWorkItem
+      })
+    }
+    expect(getLastConfirmedClientValue(null, open.repoId, open.id, 'state')).toBeUndefined()
+    expect(patches.findLast((patch) => patch.state !== undefined)?.state).toBe('closed')
+    expect(patches.at(-1)?.assignees).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/task-page-github-work-item-mutation-types.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutation-types.ts
@@ -1,0 +1,31 @@
+import type { ParsedTaskQuery } from '../../../shared/task-query'
+import type { GitHubWorkItem } from '../../../shared/types'
+import type { TaskSourceContext } from '../../../shared/task-source-context'
+import type { TaskPageGitHubMutationIntent } from './task-page-github-work-item-mutation-patches'
+import type { TaskPageGitHubMutationKey } from './task-page-github-work-item-mutation-registry'
+
+export type TaskPageGitHubPatchWorkItem = (
+  itemId: string,
+  patch: Partial<GitHubWorkItem>,
+  repoId?: string,
+  options?: { sourceContext?: TaskSourceContext | null }
+) => void
+
+export type BeginTaskPageGitHubWorkItemMutationArgs = {
+  item: GitHubWorkItem
+  intent: TaskPageGitHubMutationIntent
+  sourceContext?: TaskSourceContext | null
+  query: ParsedTaskQuery
+  queryKey: string
+  viewerLogin: string | null
+  /** Derived inside begin from item sourceContext if omitted. */
+  skipMeQualifiers?: boolean
+  patchWorkItem: TaskPageGitHubPatchWorkItem
+}
+
+export type BeginTaskPageGitHubWorkItemMutationResult = {
+  generation: number
+  opKey: string
+  itemKey: string
+  key: TaskPageGitHubMutationKey
+}

--- a/src/renderer/src/components/task-page-github-work-item-mutation-types.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutation-types.ts
@@ -27,5 +27,6 @@ export type BeginTaskPageGitHubWorkItemMutationResult = {
   generation: number
   opKey: string
   itemKey: string
+  families: string[]
   key: TaskPageGitHubMutationKey
 }

--- a/src/renderer/src/components/task-page-github-work-item-mutations.test.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutations.test.ts
@@ -1,0 +1,833 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ParsedTaskQuery } from '../../../shared/task-query'
+import type { GitHubWorkItem } from '../../../shared/types'
+import {
+  adoptQuietSearchFieldsForItem,
+  applyPendingTaskPageGitHubMutationsToItems,
+  beginTaskPageGitHubWorkItemMutation,
+  confirmTaskPageGitHubWorkItemMutation,
+  getRegistryMergedTaskPageGitHubWorkItem,
+  materializeTaskPageItemList,
+  overlayPendingOnTaskPagePages,
+  rollbackTaskPageGitHubWorkItemMutation,
+  settleQuietSearchRevalidate,
+  reapplyPendingTaskPageGitHubMutationsToCache,
+  clearTaskPageGitHubConfirmedAuthority
+} from './task-page-github-work-item-mutations'
+import {
+  getConfirmedListSnapshot,
+  getLastConfirmedClientValue,
+  getOrCreateQuietRevalidateState,
+  getTaskPageGitHubSoftHiddenItemKeys,
+  resetTaskPageGitHubMutationRegistryForTests,
+  taskPageGitHubItemKey
+} from './task-page-github-work-item-mutation-registry'
+import { getTaskPageGitHubStickyHideForTests } from './task-page-github-work-item-mutations'
+
+function query(overrides: Partial<ParsedTaskQuery> = {}): ParsedTaskQuery {
+  return {
+    scope: 'all',
+    state: 'open',
+    draft: false,
+    assignee: null,
+    author: null,
+    reviewRequested: null,
+    reviewedBy: null,
+    labels: [],
+    freeText: '',
+    ...overrides
+  }
+}
+
+function item(overrides: Partial<GitHubWorkItem> = {}): GitHubWorkItem {
+  return {
+    id: 'issue:1',
+    type: 'issue',
+    number: 1,
+    title: 't',
+    state: 'open',
+    url: 'https://github.com/o/r/issues/1',
+    labels: [],
+    updatedAt: '2026-01-01T00:00:00Z',
+    author: 'author',
+    repoId: 'repo-1',
+    assignees: [],
+    reviewRequests: [],
+    ...overrides
+  }
+}
+
+function createPatchRecorder() {
+  const patches: { id: string; patch: Partial<GitHubWorkItem>; repoId?: string }[] = []
+  const patchWorkItem = (id: string, patch: Partial<GitHubWorkItem>, repoId?: string): void => {
+    patches.push({ id, patch, repoId })
+  }
+  return { patches, patchWorkItem }
+}
+
+beforeEach(() => {
+  resetTaskPageGitHubMutationRegistryForTests()
+})
+
+afterEach(() => {
+  resetTaskPageGitHubMutationRegistryForTests()
+})
+
+describe('TaskPage GitHub work item mutations', () => {
+  it('alice confirm while bob pending → composed [alice, bob]', () => {
+    const { patchWorkItem } = createPatchRecorder()
+    const base = item()
+    const alice = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: {
+        type: 'toggleAssignee',
+        user: { login: 'alice', name: null, avatarUrl: '' }
+      },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    const bob = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: {
+        type: 'toggleAssignee',
+        user: { login: 'bob', name: null, avatarUrl: '' }
+      },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+
+    confirmTaskPageGitHubWorkItemMutation(alice.key, alice.generation, {
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: base,
+      patchWorkItem,
+      scheduleQuiet: false
+    })
+
+    const merged = getRegistryMergedTaskPageGitHubWorkItem(base, null)
+    expect(merged.assignees?.map((u) => u.login.toLowerCase()).sort()).toEqual(['alice', 'bob'])
+    expect(
+      getConfirmedListSnapshot(null, 'repo-1', 'issue:1', 'assignees')?.map((u) =>
+        u.login.toLowerCase()
+      )
+    ).toEqual(['alice'])
+
+    // bob still pending
+    void bob
+  })
+
+  it('multi-login batch confirm applies all logins; rollback of batch removes all', () => {
+    const { patchWorkItem } = createPatchRecorder()
+    const base = item({ type: 'pr', id: 'pr:1' })
+    const began = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: {
+        type: 'addReviewers',
+        logins: ['bob', 'carol'],
+        candidates: [
+          { login: 'bob', name: null, avatarUrl: '' },
+          { login: 'carol', name: null, avatarUrl: '' }
+        ]
+      },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    expect(
+      getRegistryMergedTaskPageGitHubWorkItem(base, null).reviewRequests?.map((u) =>
+        u.login.toLowerCase()
+      )
+    ).toEqual(['bob', 'carol'])
+
+    confirmTaskPageGitHubWorkItemMutation(began.key, began.generation, {
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: base,
+      patchWorkItem,
+      scheduleQuiet: false
+    })
+    expect(
+      getConfirmedListSnapshot(null, 'repo-1', 'pr:1', 'reviewRequests')?.map((u) =>
+        u.login.toLowerCase()
+      )
+    ).toEqual(['bob', 'carol'])
+
+    // Separate batch rollback path
+    resetTaskPageGitHubMutationRegistryForTests()
+    const began2 = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: {
+        type: 'addReviewers',
+        logins: ['bob', 'carol'],
+        candidates: [
+          { login: 'bob', name: null, avatarUrl: '' },
+          { login: 'carol', name: null, avatarUrl: '' }
+        ]
+      },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    rollbackTaskPageGitHubWorkItemMutation({
+      key: began2.key,
+      generation: began2.generation,
+      patchWorkItem,
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: base
+    })
+    expect(
+      getRegistryMergedTaskPageGitHubWorkItem(base, null).reviewRequests?.map((u) => u.login) ?? []
+    ).toEqual([])
+  })
+
+  it('adopt matching server list updates confirmedSnapshot; next begin keeps carol', () => {
+    const { patchWorkItem } = createPatchRecorder()
+    // Seed confirmed snapshot [alice, carol] via sequential confirms.
+    const empty = item({ assignees: [] })
+    const addAlice = beginTaskPageGitHubWorkItemMutation({
+      item: empty,
+      intent: {
+        type: 'toggleAssignee',
+        user: { login: 'alice', name: null, avatarUrl: '' }
+      },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    confirmTaskPageGitHubWorkItemMutation(addAlice.key, addAlice.generation, {
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: empty,
+      patchWorkItem,
+      scheduleQuiet: false
+    })
+    const withAlice = item({
+      assignees: [{ login: 'alice', name: null, avatarUrl: '' }]
+    })
+    const addCarol = beginTaskPageGitHubWorkItemMutation({
+      item: withAlice,
+      intent: {
+        type: 'toggleAssignee',
+        user: { login: 'carol', name: null, avatarUrl: '' }
+      },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    confirmTaskPageGitHubWorkItemMutation(addCarol.key, addCarol.generation, {
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: withAlice,
+      patchWorkItem,
+      scheduleQuiet: false
+    })
+
+    // Matching S=R search adopt freezes richer server list into snapshot (K21).
+    const server = item({
+      assignees: [
+        { login: 'alice', name: 'Alice', avatarUrl: 'a2' },
+        { login: 'carol', name: 'Carol', avatarUrl: 'c2' }
+      ]
+    })
+    const quiet = getOrCreateQuietRevalidateState('q')
+    quiet.fetchStartedAtGeneration = quiet.dirtyGeneration
+    adoptQuietSearchFieldsForItem({
+      item: server,
+      serverItem: server,
+      sourceScope: null,
+      queryKey: 'q',
+      fetchStartedAtGeneration: quiet.fetchStartedAtGeneration,
+      patchWorkItem
+    })
+
+    const snap = getConfirmedListSnapshot(null, 'repo-1', 'issue:1', 'assignees')
+    expect(snap?.map((u) => u.login.toLowerCase()).sort()).toEqual(['alice', 'carol'])
+    expect(snap?.find((u) => u.login.toLowerCase() === 'carol')?.avatarUrl).toBe('c2')
+
+    beginTaskPageGitHubWorkItemMutation({
+      item: server,
+      intent: {
+        type: 'toggleAssignee',
+        user: { login: 'bob', name: null, avatarUrl: '' }
+      },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    const merged = getRegistryMergedTaskPageGitHubWorkItem(server, null)
+    expect(merged.assignees?.map((u) => u.login.toLowerCase()).sort()).toEqual([
+      'alice',
+      'bob',
+      'carol'
+    ])
+  })
+
+  it('K21: thin search after confirmed add does not force-accept', () => {
+    const { patchWorkItem } = createPatchRecorder()
+    const base = item({
+      assignees: [{ login: 'alice', name: null, avatarUrl: '' }]
+    })
+    // confirm alice already in snapshot path via begin+confirm bob on top of alice snapshot
+    const addBob = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: {
+        type: 'toggleAssignee',
+        user: { login: 'bob', name: null, avatarUrl: '' }
+      },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    confirmTaskPageGitHubWorkItemMutation(addBob.key, addBob.generation, {
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: base,
+      patchWorkItem,
+      scheduleQuiet: false
+    })
+
+    const quiet = getOrCreateQuietRevalidateState('q')
+    quiet.fetchStartedAtGeneration = quiet.dirtyGeneration
+    const thin = item({
+      assignees: [{ login: 'alice', name: null, avatarUrl: '' }]
+    })
+    const result = adoptQuietSearchFieldsForItem({
+      item: thin,
+      serverItem: thin,
+      sourceScope: null,
+      queryKey: 'q',
+      fetchStartedAtGeneration: quiet.fetchStartedAtGeneration,
+      patchWorkItem
+    })
+    expect(result.needTrailing).toBe(true)
+    expect(
+      getConfirmedListSnapshot(null, 'repo-1', 'issue:1', 'assignees')?.map((u) =>
+        u.login.toLowerCase()
+      )
+    ).toEqual(['alice', 'bob'])
+  })
+
+  it('K21: fat search after confirmed remove does not force-accept', () => {
+    const { patchWorkItem } = createPatchRecorder()
+    const base = item({
+      assignees: [
+        { login: 'alice', name: null, avatarUrl: '' },
+        { login: 'bob', name: null, avatarUrl: '' }
+      ]
+    })
+    const removeBob = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: {
+        type: 'toggleAssignee',
+        user: { login: 'bob', name: null, avatarUrl: '' }
+      },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    confirmTaskPageGitHubWorkItemMutation(removeBob.key, removeBob.generation, {
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: base,
+      patchWorkItem,
+      scheduleQuiet: false
+    })
+    expect(
+      getConfirmedListSnapshot(null, 'repo-1', 'issue:1', 'assignees')?.map((u) =>
+        u.login.toLowerCase()
+      )
+    ).toEqual(['alice'])
+
+    const quiet = getOrCreateQuietRevalidateState('q')
+    quiet.fetchStartedAtGeneration = quiet.dirtyGeneration
+    const fat = item({
+      assignees: [
+        { login: 'alice', name: null, avatarUrl: '' },
+        { login: 'bob', name: null, avatarUrl: '' }
+      ]
+    })
+    adoptQuietSearchFieldsForItem({
+      item: fat,
+      serverItem: fat,
+      sourceScope: null,
+      queryKey: 'q',
+      fetchStartedAtGeneration: quiet.fetchStartedAtGeneration,
+      patchWorkItem
+    })
+    expect(
+      getConfirmedListSnapshot(null, 'repo-1', 'issue:1', 'assignees')?.map((u) =>
+        u.login.toLowerCase()
+      )
+    ).toEqual(['alice'])
+  })
+
+  it('K21: lagging open after close confirm keeps closed + sticky', () => {
+    const { patchWorkItem } = createPatchRecorder()
+    const base = item({ state: 'open' })
+    const began = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: { type: 'setState', state: 'closed' },
+      query: query({ state: 'open' }),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    confirmTaskPageGitHubWorkItemMutation(began.key, began.generation, {
+      query: query({ state: 'open' }),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: base,
+      patchWorkItem,
+      scheduleQuiet: false
+    })
+    expect(getLastConfirmedClientValue(null, 'repo-1', 'issue:1', 'state')).toBe('closed')
+    const itemKey = taskPageGitHubItemKey('repo-1', 'issue:1')
+    expect(getTaskPageGitHubStickyHideForTests(itemKey)).toBeTruthy()
+    expect(getTaskPageGitHubSoftHiddenItemKeys().has(itemKey)).toBe(true)
+
+    const quiet = getOrCreateQuietRevalidateState('q')
+    quiet.fetchStartedAtGeneration = quiet.dirtyGeneration
+    // Simulate budget exceeded — still no force-accept
+    quiet.lastConfirmAt = Date.now() - 200_000
+    for (let i = 0; i < 6; i++) {
+      adoptQuietSearchFieldsForItem({
+        item: item({ state: 'open' }),
+        serverItem: item({ state: 'open' }),
+        sourceScope: null,
+        queryKey: 'q',
+        fetchStartedAtGeneration: quiet.fetchStartedAtGeneration,
+        patchWorkItem
+      })
+    }
+    expect(getLastConfirmedClientValue(null, 'repo-1', 'issue:1', 'state')).toBe('closed')
+    expect(getTaskPageGitHubStickyHideForTests(itemKey)).toBeTruthy()
+  })
+
+  it('K22: confirm close then open under Open clears sticky', () => {
+    const { patchWorkItem } = createPatchRecorder()
+    const base = item({ state: 'open' })
+    const close = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: { type: 'setState', state: 'closed' },
+      query: query({ state: 'open' }),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    confirmTaskPageGitHubWorkItemMutation(close.key, close.generation, {
+      query: query({ state: 'open' }),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: base,
+      patchWorkItem,
+      scheduleQuiet: false
+    })
+    const itemKey = taskPageGitHubItemKey('repo-1', 'issue:1')
+    expect(getTaskPageGitHubStickyHideForTests(itemKey)).toBeTruthy()
+
+    const reopen = beginTaskPageGitHubWorkItemMutation({
+      item: { ...base, state: 'closed' },
+      intent: { type: 'setState', state: 'open' },
+      query: query({ state: 'open' }),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    confirmTaskPageGitHubWorkItemMutation(reopen.key, reopen.generation, {
+      query: query({ state: 'open' }),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: { ...base, state: 'closed' },
+      patchWorkItem,
+      scheduleQuiet: false
+    })
+    expect(getTaskPageGitHubStickyHideForTests(itemKey)).toBeUndefined()
+    expect(getTaskPageGitHubSoftHiddenItemKeys().has(itemKey)).toBe(false)
+  })
+
+  it('whole-field supersede: stale rollback/confirm no-ops', () => {
+    const { patchWorkItem } = createPatchRecorder()
+    const base = item()
+    const first = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: { type: 'setState', state: 'closed' },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    const second = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: { type: 'setState', state: 'open' },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    expect(
+      confirmTaskPageGitHubWorkItemMutation(first.key, first.generation, {
+        query: query(),
+        queryKey: 'q',
+        viewerLogin: 'me',
+        item: base,
+        scheduleQuiet: false
+      })
+    ).toBe('stale')
+    expect(
+      rollbackTaskPageGitHubWorkItemMutation({
+        key: first.key,
+        generation: first.generation,
+        patchWorkItem,
+        query: query(),
+        queryKey: 'q',
+        viewerLogin: 'me',
+        item: base
+      })
+    ).toBe('stale')
+    expect(
+      confirmTaskPageGitHubWorkItemMutation(second.key, second.generation, {
+        query: query(),
+        queryKey: 'q',
+        viewerLogin: 'me',
+        item: base,
+        scheduleQuiet: false
+      })
+    ).toBe('confirmed')
+  })
+
+  it('per-login assignee: A fail after B begin leaves B only', () => {
+    const { patchWorkItem } = createPatchRecorder()
+    const base = item()
+    const a = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: {
+        type: 'toggleAssignee',
+        user: { login: 'alice', name: null, avatarUrl: '' }
+      },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: {
+        type: 'toggleAssignee',
+        user: { login: 'bob', name: null, avatarUrl: '' }
+      },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    rollbackTaskPageGitHubWorkItemMutation({
+      key: a.key,
+      generation: a.generation,
+      patchWorkItem,
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: base
+    })
+    const merged = getRegistryMergedTaskPageGitHubWorkItem(base, null)
+    expect(merged.assignees?.map((u) => u.login.toLowerCase())).toEqual(['bob'])
+  })
+
+  it('materialize retains pending-omitted row; overlay preserves multi-page', () => {
+    const { patchWorkItem } = createPatchRecorder()
+    const base = item({ state: 'open' })
+    beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: { type: 'setState', state: 'closed' },
+      query: query({ state: 'open' }),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    const list = materializeTaskPageItemList({
+      networkItems: [],
+      previousItems: [base],
+      queryKey: 'q'
+    })
+    expect(list).toHaveLength(1)
+    expect(list[0].state).toBe('closed')
+
+    const pages = overlayPendingOnTaskPagePages([
+      [item({ id: 'issue:1', state: 'open' })],
+      [item({ id: 'issue:2', repoId: 'repo-1', state: 'open' })]
+    ])
+    expect(pages).toHaveLength(2)
+    expect(pages[0][0].state).toBe('closed')
+    expect(pages[1]).toHaveLength(1)
+  })
+
+  it('multi-repo: pending on repo A and B both survive applyPending', () => {
+    const { patchWorkItem } = createPatchRecorder()
+    const a = item({ id: 'issue:1', repoId: 'repo-a', state: 'open' })
+    const b = item({ id: 'issue:1', repoId: 'repo-b', state: 'open' })
+    beginTaskPageGitHubWorkItemMutation({
+      item: a,
+      intent: { type: 'setState', state: 'closed' },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    beginTaskPageGitHubWorkItemMutation({
+      item: b,
+      intent: { type: 'setState', state: 'closed' },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    const applied = applyPendingTaskPageGitHubMutationsToItems([
+      { ...a, state: 'open' },
+      { ...b, state: 'open' }
+    ])
+    expect(applied.map((i) => i.state)).toEqual(['closed', 'closed'])
+    expect(applied.map((i) => i.repoId)).toEqual(['repo-a', 'repo-b'])
+  })
+
+  it('dirty-bit: confirm during quiet R1 does not adopt thinner list', () => {
+    const { patchWorkItem } = createPatchRecorder()
+    const base = item({
+      assignees: [{ login: 'alice', name: null, avatarUrl: '' }]
+    })
+    const bob = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: {
+        type: 'toggleAssignee',
+        user: { login: 'bob', name: null, avatarUrl: '' }
+      },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    confirmTaskPageGitHubWorkItemMutation(bob.key, bob.generation, {
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: base,
+      patchWorkItem,
+      scheduleQuiet: false
+    })
+    // Quiet R1 started at generation before carol confirm
+    const quiet = getOrCreateQuietRevalidateState('q')
+    const g0 = quiet.dirtyGeneration
+    quiet.fetchStartedAtGeneration = g0
+
+    const carol = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: {
+        type: 'toggleAssignee',
+        user: { login: 'carol', name: null, avatarUrl: '' }
+      },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    confirmTaskPageGitHubWorkItemMutation(carol.key, carol.generation, {
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: base,
+      patchWorkItem,
+      scheduleQuiet: false
+    })
+    expect(quiet.dirtyGeneration).toBeGreaterThan(g0)
+
+    const thin = item({
+      assignees: [{ login: 'alice', name: null, avatarUrl: '' }]
+    })
+    const settle = settleQuietSearchRevalidate({
+      queryKey: 'q',
+      networkItems: [thin],
+      fetchStartedAtGeneration: g0,
+      patchWorkItem
+    })
+    expect(settle.needTrailing).toBe(true)
+    // Snapshot should still reflect confirmed bob (carol may be pending-cleared with snapshot)
+    const snap = getConfirmedListSnapshot(null, 'repo-1', 'issue:1', 'assignees')
+    expect(snap?.map((u) => u.login.toLowerCase()).sort()).toEqual(['alice', 'bob', 'carol'])
+  })
+
+  it('stale confirm does not clobber lastConfirmed', () => {
+    vi.useFakeTimers()
+    const { patchWorkItem } = createPatchRecorder()
+    const base = item()
+    const first = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: { type: 'setState', state: 'closed' },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    const second = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: { type: 'setState', state: 'open' },
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    confirmTaskPageGitHubWorkItemMutation(second.key, second.generation, {
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: base,
+      scheduleQuiet: false
+    })
+    confirmTaskPageGitHubWorkItemMutation(first.key, first.generation, {
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: base,
+      scheduleQuiet: false
+    })
+    expect(getLastConfirmedClientValue(null, 'repo-1', 'issue:1', 'state')).toBe('open')
+    vi.useRealTimers()
+  })
+})
+
+describe('post-confirm authority with non-null sourceScope', () => {
+  const sourceContext = {
+    kind: 'task-source' as const,
+    provider: 'github' as const,
+    hostId: 'local' as const,
+    projectId: 'proj',
+    projectHostSetupId: 'setup',
+    repoId: 'repo-1'
+  }
+
+  it('holds closed after confirm when overlay sees open network item', () => {
+    const { patchWorkItem } = createPatchRecorder()
+    const base = item({ state: 'open' })
+    const began = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: { type: 'setState', state: 'closed' },
+      sourceContext,
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    expect(began.key.sourceScope).not.toBeNull()
+    confirmTaskPageGitHubWorkItemMutation(began.key, began.generation, {
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: { ...base, state: 'closed' },
+      patchWorkItem,
+      sourceContext
+    })
+    const overlaid = applyPendingTaskPageGitHubMutationsToItems([item({ state: 'open' })])
+    expect(overlaid[0].state).toBe('closed')
+  })
+
+  it('reapply after confirm holds closed when network returns open', () => {
+    const store = new Map<string, GitHubWorkItem>()
+    const base = item({ state: 'open' })
+    store.set(base.id, base)
+    const patchWorkItem = (id: string, patch: Partial<GitHubWorkItem>): void => {
+      const current = store.get(id) ?? base
+      store.set(id, { ...current, ...patch })
+    }
+    const began = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: { type: 'setState', state: 'closed' },
+      sourceContext,
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    confirmTaskPageGitHubWorkItemMutation(began.key, began.generation, {
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: { ...base, state: 'closed' },
+      patchWorkItem,
+      sourceContext
+    })
+    store.set(base.id, item({ state: 'open' }))
+    reapplyPendingTaskPageGitHubMutationsToCache({
+      items: [item({ state: 'open' })],
+      patchWorkItem
+    })
+    expect(store.get(base.id)?.state).toBe('closed')
+  })
+
+  it('user-style clearConfirmedAuthority allows network open after hard refresh', () => {
+    const { patchWorkItem } = createPatchRecorder()
+    const base = item({ state: 'open' })
+    const began = beginTaskPageGitHubWorkItemMutation({
+      item: base,
+      intent: { type: 'setState', state: 'closed' },
+      sourceContext,
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      skipMeQualifiers: false,
+      patchWorkItem
+    })
+    confirmTaskPageGitHubWorkItemMutation(began.key, began.generation, {
+      query: query(),
+      queryKey: 'q',
+      viewerLogin: 'me',
+      item: { ...base, state: 'closed' },
+      patchWorkItem,
+      sourceContext
+    })
+    clearTaskPageGitHubConfirmedAuthority()
+    const overlaid = applyPendingTaskPageGitHubMutationsToItems([item({ state: 'open' })])
+    expect(overlaid[0].state).toBe('open')
+  })
+})

--- a/src/renderer/src/components/task-page-github-work-item-mutations.test.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutations.test.ts
@@ -12,7 +12,8 @@ import {
   rollbackTaskPageGitHubWorkItemMutation,
   settleQuietSearchRevalidate,
   reapplyPendingTaskPageGitHubMutationsToCache,
-  clearTaskPageGitHubConfirmedAuthority
+  clearTaskPageGitHubConfirmedAuthority,
+  getTaskPageGitHubStickyHideForTests
 } from './task-page-github-work-item-mutations'
 import {
   getConfirmedListSnapshot,
@@ -22,7 +23,6 @@ import {
   resetTaskPageGitHubMutationRegistryForTests,
   taskPageGitHubItemKey
 } from './task-page-github-work-item-mutation-registry'
-import { getTaskPageGitHubStickyHideForTests } from './task-page-github-work-item-mutations'
 
 function query(overrides: Partial<ParsedTaskQuery> = {}): ParsedTaskQuery {
   return {
@@ -194,8 +194,8 @@ describe('TaskPage GitHub work item mutations', () => {
     ).toEqual([])
   })
 
-  it('adopt matching server list updates confirmedSnapshot; next begin keeps carol', () => {
-    const { patchWorkItem } = createPatchRecorder()
+  it('matching server list releases authority; next begin keeps server metadata', () => {
+    const { patches, patchWorkItem } = createPatchRecorder()
     // Seed confirmed snapshot [alice, carol] via sequential confirms.
     const empty = item({ assignees: [] })
     const addAlice = beginTaskPageGitHubWorkItemMutation({
@@ -242,7 +242,6 @@ describe('TaskPage GitHub work item mutations', () => {
       scheduleQuiet: false
     })
 
-    // Matching S=R search adopt freezes richer server list into snapshot (K21).
     const server = item({
       assignees: [
         { login: 'alice', name: 'Alice', avatarUrl: 'a2' },
@@ -261,8 +260,12 @@ describe('TaskPage GitHub work item mutations', () => {
     })
 
     const snap = getConfirmedListSnapshot(null, 'repo-1', 'issue:1', 'assignees')
-    expect(snap?.map((u) => u.login.toLowerCase()).sort()).toEqual(['alice', 'carol'])
-    expect(snap?.find((u) => u.login.toLowerCase() === 'carol')?.avatarUrl).toBe('c2')
+    expect(snap).toBeUndefined()
+    expect(
+      patches
+        .findLast((entry) => entry.patch.assignees !== undefined)
+        ?.patch.assignees?.find((u) => u.login === 'carol')?.avatarUrl
+    ).toBe('c2')
 
     beginTaskPageGitHubWorkItemMutation({
       item: server,

--- a/src/renderer/src/components/task-page-github-work-item-mutations.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutations.ts
@@ -1,0 +1,164 @@
+import type { GitHubWorkItem } from '../../../shared/types'
+import {
+  getTaskSourceCacheScope,
+  type TaskSourceContext
+} from '../../../shared/task-source-context'
+import { buildTaskPageGitHubWorkItemMutationPatch } from './task-page-github-work-item-mutation-patches'
+import {
+  getRegistryMergedTaskPageGitHubWorkItem,
+  recomputeSoftHideForItem,
+  rebuildSoftHiddenKeysFromPendingAndSticky,
+  stripFamilyPendingFromList
+} from './task-page-github-work-item-mutation-composition'
+import {
+  getConfirmedListSnapshot,
+  getPendingTaskPageGitHubOp,
+  getStickyHideEntry,
+  listPendingTaskPageGitHubOpsForItem,
+  nextTaskPageGitHubMutationGeneration,
+  notifyTaskPageGitHubMutationRegistry,
+  setConfirmedListSnapshot,
+  setPendingTaskPageGitHubOp,
+  setTaskPageGitHubMutationQueryKey,
+  taskPageGitHubItemKey,
+  type PendingOp,
+  type TaskPageGitHubMutationKey
+} from './task-page-github-work-item-mutation-registry'
+import type {
+  BeginTaskPageGitHubWorkItemMutationArgs,
+  BeginTaskPageGitHubWorkItemMutationResult
+} from './task-page-github-work-item-mutation-types'
+import type { ParsedTaskQuery } from '../../../shared/task-query'
+
+export type {
+  BeginTaskPageGitHubWorkItemMutationArgs,
+  BeginTaskPageGitHubWorkItemMutationResult,
+  TaskPageGitHubPatchWorkItem
+} from './task-page-github-work-item-mutation-types'
+
+export {
+  applyPendingTaskPageGitHubMutationsToItems,
+  materializeTaskPageItemList,
+  overlayPendingOnTaskPagePages,
+  reapplyPendingTaskPageGitHubMutationsToCache
+} from './task-page-github-work-item-mutation-pages'
+
+export {
+  adoptQuietSearchFieldsForItem,
+  processTaskPageQuietRevalidateSettle,
+  scheduleTaskPageQuietRevalidate,
+  setTaskPageQuietRevalidateRunner,
+  settleQuietSearchRevalidate,
+  MAX_LAG_TRAILS
+} from './task-page-github-work-item-quiet-revalidate'
+
+export {
+  clearTaskPageGitHubConfirmedAuthority,
+  resolveItemSourceScope
+} from './task-page-github-work-item-mutation-registry'
+
+export {
+  confirmTaskPageGitHubWorkItemMutation,
+  rollbackTaskPageGitHubWorkItemMutation
+} from './task-page-github-work-item-mutation-lifecycle'
+
+export { getRegistryMergedTaskPageGitHubWorkItem } from './task-page-github-work-item-mutation-composition'
+
+export { setTaskPageGitHubMutationQueryKey, taskPageGitHubItemKey }
+
+function resolveSourceScope(sourceContext?: TaskSourceContext | null): string | null {
+  if (sourceContext?.provider === 'github') {
+    return getTaskSourceCacheScope(sourceContext)
+  }
+  return null
+}
+
+export function beginTaskPageGitHubWorkItemMutation(
+  args: BeginTaskPageGitHubWorkItemMutationArgs
+): BeginTaskPageGitHubWorkItemMutationResult {
+  setTaskPageGitHubMutationQueryKey(args.queryKey)
+  const sourceScope = resolveSourceScope(args.sourceContext)
+  const skipMeQualifiers = args.skipMeQualifiers ?? false
+  const base = getRegistryMergedTaskPageGitHubWorkItem(args.item, sourceScope)
+  const built = buildTaskPageGitHubWorkItemMutationPatch(base, args.intent)
+
+  const key: TaskPageGitHubMutationKey = {
+    sourceScope,
+    repoId: args.item.repoId,
+    itemId: args.item.id,
+    opKey: built.opKey
+  }
+  const generation = nextTaskPageGitHubMutationGeneration(key)
+
+  if (built.kind === 'list') {
+    const existing = getConfirmedListSnapshot(
+      sourceScope,
+      args.item.repoId,
+      args.item.id,
+      built.family
+    )
+    if (!existing) {
+      const ops = listPendingTaskPageGitHubOpsForItem(args.item.repoId, args.item.id, sourceScope)
+      const snapshot = stripFamilyPendingFromList(args.item, built.family, ops)
+      setConfirmedListSnapshot(sourceScope, args.item.repoId, args.item.id, built.family, snapshot)
+    }
+  }
+
+  const op: PendingOp = {
+    generation,
+    key,
+    previous: built.previous,
+    next: built.next,
+    listOp: built.kind === 'list' ? built.listOp : undefined,
+    skipMeQualifiers,
+    startedAt: Date.now()
+  }
+  setPendingTaskPageGitHubOp(op)
+
+  const merged = getRegistryMergedTaskPageGitHubWorkItem(args.item, sourceScope)
+  const composedFields: Partial<GitHubWorkItem> =
+    built.kind === 'list'
+      ? built.family === 'assignees'
+        ? { assignees: merged.assignees }
+        : { reviewRequests: merged.reviewRequests }
+      : built.next
+
+  args.patchWorkItem(args.item.id, composedFields, args.item.repoId, {
+    sourceContext: args.sourceContext
+  })
+
+  recomputeSoftHideForItem({
+    item: { ...args.item, ...merged },
+    sourceScope,
+    query: args.query,
+    queryKey: args.queryKey,
+    viewerLogin: args.viewerLogin,
+    skipMeQualifiers,
+    updateSticky: false
+  })
+  notifyTaskPageGitHubMutationRegistry()
+
+  return {
+    generation,
+    opKey: built.opKey,
+    itemKey: taskPageGitHubItemKey(args.item.repoId, args.item.id),
+    key
+  }
+}
+
+export function isTaskPageGitHubMutationPendingKey(key: TaskPageGitHubMutationKey): boolean {
+  return getPendingTaskPageGitHubOp(key) !== undefined
+}
+
+export function getTaskPageGitHubStickyHideForTests(itemKey: string) {
+  return getStickyHideEntry(itemKey)
+}
+
+export function rebuildSoftHiddenFromItemsForTests(args: {
+  query: ParsedTaskQuery
+  queryKey: string
+  viewerLogin: string | null
+  items: readonly GitHubWorkItem[]
+}): void {
+  rebuildSoftHiddenKeysFromPendingAndSticky(args)
+}

--- a/src/renderer/src/components/task-page-github-work-item-mutations.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutations.ts
@@ -49,6 +49,8 @@ export {
   scheduleTaskPageQuietRevalidate,
   setTaskPageQuietRevalidateRunner,
   settleQuietSearchRevalidate,
+  LAG_BACKOFF_MS,
+  LAG_WALL_BUDGET_MS,
   MAX_LAG_TRAILS
 } from './task-page-github-work-item-quiet-revalidate'
 

--- a/src/renderer/src/components/task-page-github-work-item-mutations.ts
+++ b/src/renderer/src/components/task-page-github-work-item-mutations.ts
@@ -3,8 +3,12 @@ import {
   getTaskSourceCacheScope,
   type TaskSourceContext
 } from '../../../shared/task-source-context'
-import { buildTaskPageGitHubWorkItemMutationPatch } from './task-page-github-work-item-mutation-patches'
 import {
+  buildTaskPageGitHubWorkItemMutationPatch,
+  type TaskPageGitHubMutationIntent
+} from './task-page-github-work-item-mutation-patches'
+import {
+  familiesFromPendingOp,
   getRegistryMergedTaskPageGitHubWorkItem,
   recomputeSoftHideForItem,
   rebuildSoftHiddenKeysFromPendingAndSticky,
@@ -40,19 +44,31 @@ export {
   applyPendingTaskPageGitHubMutationsToItems,
   materializeTaskPageItemList,
   overlayPendingOnTaskPagePages,
-  reapplyPendingTaskPageGitHubMutationsToCache
+  patchTaskPageGitHubWorkItemPages,
+  reapplyPendingTaskPageGitHubMutationsToCache,
+  reconcileTaskPagePagesAfterQuietRefresh
 } from './task-page-github-work-item-mutation-pages'
 
 export {
   adoptQuietSearchFieldsForItem,
+  advanceTaskPageQuietRevalidateScope,
+  getTaskPageQuietRevalidateBackoffAttempt,
+  isTaskPageQuietRevalidateRunCurrent,
+  isTaskPageQuietRevalidateScopeCurrent,
   processTaskPageQuietRevalidateSettle,
-  scheduleTaskPageQuietRevalidate,
-  setTaskPageQuietRevalidateRunner,
   settleQuietSearchRevalidate,
   LAG_BACKOFF_MS,
   LAG_WALL_BUDGET_MS,
   MAX_LAG_TRAILS
 } from './task-page-github-work-item-quiet-revalidate'
+
+export type { TaskPageQuietRevalidateScope } from './task-page-github-work-item-quiet-revalidate'
+
+export {
+  clearTaskPageGitHubAuthorityAbsentFromLoadedItems,
+  clearTaskPageGitHubAuthorityThroughGeneration,
+  getTaskPageGitHubRevalidatableAuthorityItemKeys
+} from './task-page-github-work-item-authority-refresh'
 
 export {
   clearTaskPageGitHubConfirmedAuthority,
@@ -65,6 +81,7 @@ export {
 } from './task-page-github-work-item-mutation-lifecycle'
 
 export { getRegistryMergedTaskPageGitHubWorkItem } from './task-page-github-work-item-mutation-composition'
+export { rebuildSoftHiddenKeysFromPendingAndSticky } from './task-page-github-work-item-mutation-composition'
 
 export { setTaskPageGitHubMutationQueryKey, taskPageGitHubItemKey }
 
@@ -75,16 +92,56 @@ function resolveSourceScope(sourceContext?: TaskSourceContext | null): string | 
   return null
 }
 
+function resolveTaskPageGitHubMutation(args: {
+  item: GitHubWorkItem
+  intent: TaskPageGitHubMutationIntent
+  sourceContext?: TaskSourceContext | null
+}) {
+  const sourceScope = resolveSourceScope(args.sourceContext)
+  const base = getRegistryMergedTaskPageGitHubWorkItem(args.item, sourceScope)
+  return {
+    sourceScope,
+    built: buildTaskPageGitHubWorkItemMutationPatch(base, args.intent)
+  }
+}
+
+export function canStartTaskPageGitHubWorkItemMutation(args: {
+  item: GitHubWorkItem
+  intent: TaskPageGitHubMutationIntent
+  sourceContext?: TaskSourceContext | null
+}): boolean {
+  const { sourceScope, built } = resolveTaskPageGitHubMutation(args)
+  const key = {
+    sourceScope,
+    repoId: args.item.repoId,
+    itemId: args.item.id,
+    opKey: built.opKey
+  }
+  if (isTaskPageGitHubMutationPendingKey(key)) {
+    return false
+  }
+  const pending = listPendingTaskPageGitHubOpsForItem(args.item.repoId, args.item.id, sourceScope)
+  if (built.kind === 'list') {
+    const affectedLogins = new Set(built.listOp.logins)
+    return !pending.some(
+      (op) =>
+        op.listOp?.family === built.family &&
+        op.listOp.logins.some((login) => affectedLogins.has(login))
+    )
+  }
+  return !pending.some(
+    (op) =>
+      !op.listOp && familiesFromPendingOp(op).some((family) => built.families.includes(family))
+  )
+}
+
 export function beginTaskPageGitHubWorkItemMutation(
   args: BeginTaskPageGitHubWorkItemMutationArgs
 ): BeginTaskPageGitHubWorkItemMutationResult {
   setTaskPageGitHubMutationQueryKey(args.queryKey)
-  const sourceScope = resolveSourceScope(args.sourceContext)
+  const { sourceScope, built } = resolveTaskPageGitHubMutation(args)
   const skipMeQualifiers = args.skipMeQualifiers ?? false
-  const base = getRegistryMergedTaskPageGitHubWorkItem(args.item, sourceScope)
-  const built = buildTaskPageGitHubWorkItemMutationPatch(base, args.intent)
-
-  const key: TaskPageGitHubMutationKey = {
+  const key = {
     sourceScope,
     repoId: args.item.repoId,
     itemId: args.item.id,
@@ -144,6 +201,7 @@ export function beginTaskPageGitHubWorkItemMutation(
     generation,
     opKey: built.opKey,
     itemKey: taskPageGitHubItemKey(args.item.repoId, args.item.id),
+    families: built.families,
     key
   }
 }

--- a/src/renderer/src/components/task-page-github-work-item-quiet-adopt.ts
+++ b/src/renderer/src/components/task-page-github-work-item-quiet-adopt.ts
@@ -1,0 +1,188 @@
+import type { GitHubWorkItem } from '../../../shared/types'
+import type { TaskSourceContext } from '../../../shared/task-source-context'
+import { loginSetOfUsers, loginSetsEqual } from './task-page-github-work-item-mutation-patches'
+import {
+  familiesFromPendingOp,
+  freezeTaskPageGitHubUsers
+} from './task-page-github-work-item-mutation-composition'
+import {
+  getConfirmedListSnapshot,
+  getLastConfirmedClientValue,
+  getOrCreateQuietRevalidateState,
+  listPendingTaskPageGitHubOpsForItem,
+  setConfirmedListSnapshot,
+  setLastConfirmedClientValue,
+  taskPageGitHubFamilyDirtyKey,
+  taskPageGitHubItemKey
+} from './task-page-github-work-item-mutation-registry'
+import type { TaskPageGitHubPatchWorkItem } from './task-page-github-work-item-mutation-types'
+
+export const MAX_LAG_TRAILS = 5
+export const LAG_WALL_BUDGET_MS = 90_000
+export const LAG_BACKOFF_MS = [500, 1000, 2000, 4000, 8000] as const
+
+function hasPendingForFamily(
+  sourceScope: string | null,
+  repoId: string,
+  itemId: string,
+  family: string
+): boolean {
+  for (const op of listPendingTaskPageGitHubOpsForItem(repoId, itemId, sourceScope)) {
+    if (op.listOp?.family === family) {
+      return true
+    }
+    if (!op.listOp && familiesFromPendingOp(op).includes(family)) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Non-regressive field-wise adopt from search (K21). Never force-accept.
+ */
+export function adoptQuietSearchFieldsForItem(args: {
+  item: GitHubWorkItem
+  serverItem: GitHubWorkItem
+  sourceScope: string | null
+  queryKey: string
+  fetchStartedAtGeneration: number
+  patchWorkItem: TaskPageGitHubPatchWorkItem
+  sourceContext?: TaskSourceContext | null
+}): { needTrailing: boolean } {
+  const state = getOrCreateQuietRevalidateState(args.queryKey)
+  const itemKey = taskPageGitHubItemKey(args.item.repoId, args.item.id)
+  let needTrailing = false
+  const G0 = args.fetchStartedAtGeneration
+  const tryFamily = (
+    family: string,
+    adopt: () => void,
+    matches: () => boolean,
+    hasClientAuthority: () => boolean
+  ): void => {
+    if (hasPendingForFamily(args.sourceScope, args.item.repoId, args.item.id, family)) {
+      return
+    }
+    const dirtyAt = state.familyDirtyAt.get(taskPageGitHubFamilyDirtyKey(itemKey, family)) ?? 0
+    if (dirtyAt > G0) {
+      needTrailing = true
+      return
+    }
+    if (hasClientAuthority() && !matches()) {
+      const lagKey = taskPageGitHubFamilyDirtyKey(itemKey, family)
+      const attempts = (state.lagSkipAttempts.get(lagKey) ?? 0) + 1
+      state.lagSkipAttempts.set(lagKey, attempts)
+      const wallExceeded = Date.now() - state.lastConfirmAt > LAG_WALL_BUDGET_MS
+      if (attempts < MAX_LAG_TRAILS && !wallExceeded) {
+        needTrailing = true
+      }
+      // K21: never force-accept lagging search.
+      return
+    }
+    if (!hasClientAuthority() || matches()) {
+      adopt()
+      state.lagSkipAttempts.delete(taskPageGitHubFamilyDirtyKey(itemKey, family))
+    }
+  }
+  tryFamily(
+    'state',
+    () => {
+      args.patchWorkItem(args.item.id, { state: args.serverItem.state }, args.item.repoId, {
+        sourceContext: args.sourceContext
+      })
+      setLastConfirmedClientValue(
+        args.sourceScope,
+        args.item.repoId,
+        args.item.id,
+        'state',
+        args.serverItem.state
+      )
+    },
+    () => {
+      const last = getLastConfirmedClientValue(
+        args.sourceScope,
+        args.item.repoId,
+        args.item.id,
+        'state'
+      )
+      return last === undefined || args.serverItem.state === last
+    },
+    () =>
+      getLastConfirmedClientValue(args.sourceScope, args.item.repoId, args.item.id, 'state') !==
+      undefined
+  )
+  tryFamily(
+    'autoMerge',
+    () => {
+      args.patchWorkItem(
+        args.item.id,
+        { autoMergeEnabled: args.serverItem.autoMergeEnabled },
+        args.item.repoId,
+        { sourceContext: args.sourceContext }
+      )
+      setLastConfirmedClientValue(
+        args.sourceScope,
+        args.item.repoId,
+        args.item.id,
+        'autoMerge',
+        args.serverItem.autoMergeEnabled
+      )
+    },
+    () => {
+      const last = getLastConfirmedClientValue(
+        args.sourceScope,
+        args.item.repoId,
+        args.item.id,
+        'autoMerge'
+      )
+      return last === undefined || args.serverItem.autoMergeEnabled === last
+    },
+    () =>
+      getLastConfirmedClientValue(args.sourceScope, args.item.repoId, args.item.id, 'autoMerge') !==
+      undefined
+  )
+  for (const family of ['assignees', 'reviewRequests'] as const) {
+    tryFamily(
+      family,
+      () => {
+        const serverList =
+          family === 'assignees'
+            ? freezeTaskPageGitHubUsers(args.serverItem.assignees ?? [])
+            : freezeTaskPageGitHubUsers(args.serverItem.reviewRequests ?? [])
+        // Why: list authority lives in confirmedSnapshots; lastConfirmedClientValue
+        // is scalar-only (state/autoMerge), so no list write here.
+        setConfirmedListSnapshot(
+          args.sourceScope,
+          args.item.repoId,
+          args.item.id,
+          family,
+          serverList
+        )
+        args.patchWorkItem(
+          args.item.id,
+          family === 'assignees' ? { assignees: serverList } : { reviewRequests: serverList },
+          args.item.repoId,
+          { sourceContext: args.sourceContext }
+        )
+      },
+      () => {
+        const snapshot = getConfirmedListSnapshot(
+          args.sourceScope,
+          args.item.repoId,
+          args.item.id,
+          family
+        )
+        if (!snapshot) {
+          return true
+        }
+        const serverList =
+          family === 'assignees' ? args.serverItem.assignees : args.serverItem.reviewRequests
+        return loginSetsEqual(loginSetOfUsers(snapshot), loginSetOfUsers(serverList))
+      },
+      () =>
+        getConfirmedListSnapshot(args.sourceScope, args.item.repoId, args.item.id, family) !==
+        undefined
+    )
+  }
+  return { needTrailing }
+}

--- a/src/renderer/src/components/task-page-github-work-item-quiet-adopt.ts
+++ b/src/renderer/src/components/task-page-github-work-item-quiet-adopt.ts
@@ -10,8 +10,8 @@ import {
   getLastConfirmedClientValue,
   getOrCreateQuietRevalidateState,
   listPendingTaskPageGitHubOpsForItem,
-  setConfirmedListSnapshot,
-  setLastConfirmedClientValue,
+  deleteConfirmedListSnapshot,
+  deleteLastConfirmedClientValue,
   taskPageGitHubFamilyDirtyKey,
   taskPageGitHubItemKey
 } from './task-page-github-work-item-mutation-registry'
@@ -58,7 +58,8 @@ export function adoptQuietSearchFieldsForItem(args: {
     family: string,
     adopt: () => void,
     matches: () => boolean,
-    hasClientAuthority: () => boolean
+    hasClientAuthority: () => boolean,
+    releaseClientAuthority: () => void
   ): void => {
     if (hasPendingForFamily(args.sourceScope, args.item.repoId, args.item.id, family)) {
       return
@@ -68,7 +69,8 @@ export function adoptQuietSearchFieldsForItem(args: {
       needTrailing = true
       return
     }
-    if (hasClientAuthority() && !matches()) {
+    const hasAuthority = hasClientAuthority()
+    if (hasAuthority && !matches()) {
       const lagKey = taskPageGitHubFamilyDirtyKey(itemKey, family)
       const attempts = (state.lagSkipAttempts.get(lagKey) ?? 0) + 1
       state.lagSkipAttempts.set(lagKey, attempts)
@@ -79,10 +81,11 @@ export function adoptQuietSearchFieldsForItem(args: {
       // K21: never force-accept lagging search.
       return
     }
-    if (!hasClientAuthority() || matches()) {
-      adopt()
-      state.lagSkipAttempts.delete(taskPageGitHubFamilyDirtyKey(itemKey, family))
+    adopt()
+    if (hasAuthority) {
+      releaseClientAuthority()
     }
+    state.lagSkipAttempts.delete(taskPageGitHubFamilyDirtyKey(itemKey, family))
   }
   tryFamily(
     'state',
@@ -90,13 +93,6 @@ export function adoptQuietSearchFieldsForItem(args: {
       args.patchWorkItem(args.item.id, { state: args.serverItem.state }, args.item.repoId, {
         sourceContext: args.sourceContext
       })
-      setLastConfirmedClientValue(
-        args.sourceScope,
-        args.item.repoId,
-        args.item.id,
-        'state',
-        args.serverItem.state
-      )
     },
     () => {
       const last = getLastConfirmedClientValue(
@@ -109,7 +105,8 @@ export function adoptQuietSearchFieldsForItem(args: {
     },
     () =>
       getLastConfirmedClientValue(args.sourceScope, args.item.repoId, args.item.id, 'state') !==
-      undefined
+      undefined,
+    () => deleteLastConfirmedClientValue(args.sourceScope, args.item.repoId, args.item.id, 'state')
   )
   tryFamily(
     'autoMerge',
@@ -119,13 +116,6 @@ export function adoptQuietSearchFieldsForItem(args: {
         { autoMergeEnabled: args.serverItem.autoMergeEnabled },
         args.item.repoId,
         { sourceContext: args.sourceContext }
-      )
-      setLastConfirmedClientValue(
-        args.sourceScope,
-        args.item.repoId,
-        args.item.id,
-        'autoMerge',
-        args.serverItem.autoMergeEnabled
       )
     },
     () => {
@@ -139,25 +129,20 @@ export function adoptQuietSearchFieldsForItem(args: {
     },
     () =>
       getLastConfirmedClientValue(args.sourceScope, args.item.repoId, args.item.id, 'autoMerge') !==
-      undefined
+      undefined,
+    () =>
+      deleteLastConfirmedClientValue(args.sourceScope, args.item.repoId, args.item.id, 'autoMerge')
   )
   for (const family of ['assignees', 'reviewRequests'] as const) {
+    const serverListValue =
+      family === 'assignees' ? args.serverItem.assignees : args.serverItem.reviewRequests
+    if (serverListValue === undefined) {
+      continue
+    }
     tryFamily(
       family,
       () => {
-        const serverList =
-          family === 'assignees'
-            ? freezeTaskPageGitHubUsers(args.serverItem.assignees ?? [])
-            : freezeTaskPageGitHubUsers(args.serverItem.reviewRequests ?? [])
-        // Why: list authority lives in confirmedSnapshots; lastConfirmedClientValue
-        // is scalar-only (state/autoMerge), so no list write here.
-        setConfirmedListSnapshot(
-          args.sourceScope,
-          args.item.repoId,
-          args.item.id,
-          family,
-          serverList
-        )
+        const serverList = freezeTaskPageGitHubUsers(serverListValue)
         args.patchWorkItem(
           args.item.id,
           family === 'assignees' ? { assignees: serverList } : { reviewRequests: serverList },
@@ -175,13 +160,12 @@ export function adoptQuietSearchFieldsForItem(args: {
         if (!snapshot) {
           return true
         }
-        const serverList =
-          family === 'assignees' ? args.serverItem.assignees : args.serverItem.reviewRequests
-        return loginSetsEqual(loginSetOfUsers(snapshot), loginSetOfUsers(serverList))
+        return loginSetsEqual(loginSetOfUsers(snapshot), loginSetOfUsers(serverListValue))
       },
       () =>
         getConfirmedListSnapshot(args.sourceScope, args.item.repoId, args.item.id, family) !==
-        undefined
+        undefined,
+      () => deleteConfirmedListSnapshot(args.sourceScope, args.item.repoId, args.item.id, family)
     )
   }
   return { needTrailing }

--- a/src/renderer/src/components/task-page-github-work-item-quiet-revalidate.ts
+++ b/src/renderer/src/components/task-page-github-work-item-quiet-revalidate.ts
@@ -18,7 +18,7 @@ import {
 } from './task-page-github-work-item-mutation-registry'
 import type { TaskPageGitHubPatchWorkItem } from './task-page-github-work-item-mutation-types'
 
-export { adoptQuietSearchFieldsForItem, MAX_LAG_TRAILS }
+export { adoptQuietSearchFieldsForItem, LAG_BACKOFF_MS, LAG_WALL_BUDGET_MS, MAX_LAG_TRAILS }
 
 type QuietRunner = (queryKey: string) => Promise<readonly GitHubWorkItem[]>
 let quietRunner: QuietRunner | null = null
@@ -117,8 +117,12 @@ export async function scheduleTaskPageQuietRevalidate(queryKey: string): Promise
   }
   const after = getOrCreateQuietRevalidateState(queryKey)
   if (after.dirtyGeneration > runGeneration) {
+    // Why: mirror processTaskPageQuietRevalidateSettle — index the backoff by the
+    // worst lag attempt (Math.max), not the count of lagging keys, so several
+    // items each lagging once cannot jump the delay tier.
     const lagValues = [...after.lagSkipAttempts.values()]
-    const delay = LAG_BACKOFF_MS[Math.min(lagValues.length, LAG_BACKOFF_MS.length - 1)] ?? 500
+    const attempts = lagValues.length === 0 ? 0 : Math.max(...lagValues)
+    const delay = LAG_BACKOFF_MS[Math.min(attempts, LAG_BACKOFF_MS.length - 1)] ?? 500
     await new Promise((resolve) => setTimeout(resolve, delay))
     await scheduleTaskPageQuietRevalidate(queryKey)
   }

--- a/src/renderer/src/components/task-page-github-work-item-quiet-revalidate.ts
+++ b/src/renderer/src/components/task-page-github-work-item-quiet-revalidate.ts
@@ -1,0 +1,155 @@
+import type { GitHubWorkItem } from '../../../shared/types'
+import type { TaskSourceContext } from '../../../shared/task-source-context'
+import {
+  adoptQuietSearchFieldsForItem,
+  LAG_BACKOFF_MS,
+  LAG_WALL_BUDGET_MS,
+  MAX_LAG_TRAILS
+} from './task-page-github-work-item-quiet-adopt'
+import {
+  gcStickyHidesAbsentFromPages,
+  getAllStickyHideEntries,
+  getOrCreateQuietRevalidateState,
+  hasConfirmedAuthorityForItem,
+  hasPendingTaskPageGitHubOpsForItem,
+  notifyTaskPageGitHubMutationRegistry,
+  resolveItemSourceScope,
+  taskPageGitHubItemKey
+} from './task-page-github-work-item-mutation-registry'
+import type { TaskPageGitHubPatchWorkItem } from './task-page-github-work-item-mutation-types'
+
+export { adoptQuietSearchFieldsForItem, MAX_LAG_TRAILS }
+
+type QuietRunner = (queryKey: string) => Promise<readonly GitHubWorkItem[]>
+let quietRunner: QuietRunner | null = null
+export function setTaskPageQuietRevalidateRunner(runner: QuietRunner | null): void {
+  quietRunner = runner
+}
+export function settleQuietSearchRevalidate(args: {
+  queryKey: string
+  networkItems: readonly GitHubWorkItem[]
+  fetchStartedAtGeneration: number
+  patchWorkItem: TaskPageGitHubPatchWorkItem
+  resolveSourceScope?: (item: GitHubWorkItem) => string | null
+  sourceContextByRepoId?: ReadonlyMap<string, TaskSourceContext | null | undefined>
+}): { needTrailing: boolean } {
+  let needTrailing = false
+  for (const serverItem of args.networkItems) {
+    const sourceScope =
+      args.resolveSourceScope?.(serverItem) ??
+      resolveItemSourceScope(serverItem.repoId, serverItem.id)
+    const result = adoptQuietSearchFieldsForItem({
+      item: serverItem,
+      serverItem,
+      sourceScope,
+      queryKey: args.queryKey,
+      fetchStartedAtGeneration: args.fetchStartedAtGeneration,
+      patchWorkItem: args.patchWorkItem,
+      sourceContext: args.sourceContextByRepoId?.get(serverItem.repoId)
+    })
+    if (result.needTrailing) {
+      needTrailing = true
+    }
+  }
+  // Why: do not GC sticky solely because search omitted a row under lag — that
+  // would unhide a successful close under Open. Keep sticky for omitted rows
+  // that still have pending or confirmed authority.
+  const pageKeys = new Set(
+    args.networkItems.map((item) => taskPageGitHubItemKey(item.repoId, item.id))
+  )
+  const safeGcKeys = new Set(pageKeys)
+  for (const [itemKey] of getAllStickyHideEntries()) {
+    if (pageKeys.has(itemKey)) {
+      continue
+    }
+    const sep = itemKey.indexOf('\0')
+    if (sep < 0) {
+      continue
+    }
+    const repoId = itemKey.slice(0, sep)
+    const itemId = itemKey.slice(sep + 1)
+    if (
+      hasPendingTaskPageGitHubOpsForItem(repoId, itemId) ||
+      hasConfirmedAuthorityForItem(repoId, itemId)
+    ) {
+      safeGcKeys.add(itemKey)
+    }
+  }
+  gcStickyHidesAbsentFromPages(safeGcKeys, args.queryKey)
+  const quiet = getOrCreateQuietRevalidateState(args.queryKey)
+  // Why: lag counters are aggregated with Math.max across the query, so an orphan
+  // stuck at MAX (item lagged then left the result set) would disable lag-retry
+  // for every row. Drop counters for items fully gone (no page/pending/authority).
+  for (const lagKey of quiet.lagSkipAttempts.keys()) {
+    const itemKey = lagKey.slice(0, lagKey.lastIndexOf('\0'))
+    if (safeGcKeys.has(itemKey)) {
+      continue
+    }
+    const sep = itemKey.indexOf('\0')
+    if (sep < 0) {
+      continue
+    }
+    if (
+      !hasPendingTaskPageGitHubOpsForItem(itemKey.slice(0, sep), itemKey.slice(sep + 1)) &&
+      !hasConfirmedAuthorityForItem(itemKey.slice(0, sep), itemKey.slice(sep + 1))
+    ) {
+      quiet.lagSkipAttempts.delete(lagKey)
+    }
+  }
+  if (quiet.dirtyGeneration > args.fetchStartedAtGeneration) {
+    needTrailing = true
+  }
+  notifyTaskPageGitHubMutationRegistry()
+  return { needTrailing }
+}
+export async function scheduleTaskPageQuietRevalidate(queryKey: string): Promise<void> {
+  const state = getOrCreateQuietRevalidateState(queryKey)
+  if (state.inFlight || !quietRunner) {
+    return
+  }
+  state.inFlight = true
+  const runGeneration = state.dirtyGeneration
+  state.fetchStartedAtGeneration = runGeneration
+  try {
+    await quietRunner(queryKey)
+  } finally {
+    state.inFlight = false
+  }
+  const after = getOrCreateQuietRevalidateState(queryKey)
+  if (after.dirtyGeneration > runGeneration) {
+    const lagValues = [...after.lagSkipAttempts.values()]
+    const delay = LAG_BACKOFF_MS[Math.min(lagValues.length, LAG_BACKOFF_MS.length - 1)] ?? 500
+    await new Promise((resolve) => setTimeout(resolve, delay))
+    await scheduleTaskPageQuietRevalidate(queryKey)
+  }
+}
+export async function processTaskPageQuietRevalidateSettle(args: {
+  queryKey: string
+  networkItems: readonly GitHubWorkItem[]
+  patchWorkItem: TaskPageGitHubPatchWorkItem
+  resolveSourceScope?: (item: GitHubWorkItem) => string | null
+  sourceContextByRepoId?: ReadonlyMap<string, TaskSourceContext | null | undefined>
+  scheduleTrailing?: boolean
+}): Promise<{ needTrailing: boolean }> {
+  const state = getOrCreateQuietRevalidateState(args.queryKey)
+  const G0 = state.fetchStartedAtGeneration
+  const result = settleQuietSearchRevalidate({
+    queryKey: args.queryKey,
+    networkItems: args.networkItems,
+    fetchStartedAtGeneration: G0,
+    patchWorkItem: args.patchWorkItem,
+    resolveSourceScope: args.resolveSourceScope,
+    sourceContextByRepoId: args.sourceContextByRepoId
+  })
+  if (result.needTrailing && args.scheduleTrailing !== false) {
+    const lagValues = [...state.lagSkipAttempts.values()]
+    const attempts = lagValues.length === 0 ? 0 : Math.max(...lagValues)
+    const wallExceeded = Date.now() - state.lastConfirmAt > LAG_WALL_BUDGET_MS
+    if (attempts < MAX_LAG_TRAILS && !wallExceeded) {
+      const delay = LAG_BACKOFF_MS[Math.min(attempts, LAG_BACKOFF_MS.length - 1)] ?? 500
+      await new Promise((resolve) => setTimeout(resolve, delay))
+      await scheduleTaskPageQuietRevalidate(args.queryKey)
+    }
+  }
+  return result
+}

--- a/src/renderer/src/components/task-page-github-work-item-quiet-revalidate.ts
+++ b/src/renderer/src/components/task-page-github-work-item-quiet-revalidate.ts
@@ -7,6 +7,7 @@ import {
   MAX_LAG_TRAILS
 } from './task-page-github-work-item-quiet-adopt'
 import {
+  clearConfirmedAuthorityForItem,
   gcStickyHidesAbsentFromPages,
   getAllStickyHideEntries,
   getOrCreateQuietRevalidateState,
@@ -20,11 +21,41 @@ import type { TaskPageGitHubPatchWorkItem } from './task-page-github-work-item-m
 
 export { adoptQuietSearchFieldsForItem, LAG_BACKOFF_MS, LAG_WALL_BUDGET_MS, MAX_LAG_TRAILS }
 
-type QuietRunner = (queryKey: string) => Promise<readonly GitHubWorkItem[]>
-let quietRunner: QuietRunner | null = null
-export function setTaskPageQuietRevalidateRunner(runner: QuietRunner | null): void {
-  quietRunner = runner
+export type TaskPageQuietRevalidateScope = { queryKey: string; generation: number }
+
+export function advanceTaskPageQuietRevalidateScope(
+  scope: TaskPageQuietRevalidateScope,
+  queryKey: string
+): TaskPageQuietRevalidateScope {
+  return scope.queryKey === queryKey ? scope : { queryKey, generation: scope.generation + 1 }
 }
+
+export function isTaskPageQuietRevalidateScopeCurrent(
+  scope: TaskPageQuietRevalidateScope,
+  queryKey: string,
+  generation: number
+): boolean {
+  return scope.queryKey === queryKey && scope.generation === generation
+}
+
+export function isTaskPageQuietRevalidateRunCurrent(
+  scope: TaskPageQuietRevalidateScope,
+  queryKey: string,
+  generation: number,
+  capturedRefreshEpoch: number,
+  currentRefreshEpoch: number
+): boolean {
+  return (
+    isTaskPageQuietRevalidateScopeCurrent(scope, queryKey, generation) &&
+    capturedRefreshEpoch === currentRefreshEpoch
+  )
+}
+
+export function getTaskPageQuietRevalidateBackoffAttempt(attempts: Iterable<number>): number {
+  const eligible = [...attempts].filter((attempt) => attempt < MAX_LAG_TRAILS)
+  return eligible.length === 0 ? 0 : Math.max(...eligible)
+}
+
 export function settleQuietSearchRevalidate(args: {
   queryKey: string
   networkItems: readonly GitHubWorkItem[]
@@ -32,6 +63,7 @@ export function settleQuietSearchRevalidate(args: {
   patchWorkItem: TaskPageGitHubPatchWorkItem
   resolveSourceScope?: (item: GitHubWorkItem) => string | null
   sourceContextByRepoId?: ReadonlyMap<string, TaskSourceContext | null | undefined>
+  revalidatedItemKeys?: ReadonlySet<string>
 }): { needTrailing: boolean } {
   let needTrailing = false
   for (const serverItem of args.networkItems) {
@@ -57,6 +89,22 @@ export function settleQuietSearchRevalidate(args: {
   const pageKeys = new Set(
     args.networkItems.map((item) => taskPageGitHubItemKey(item.repoId, item.id))
   )
+  for (const [itemKey, entry] of getAllStickyHideEntries()) {
+    if (
+      entry.queryKey !== args.queryKey ||
+      pageKeys.has(itemKey) ||
+      !args.revalidatedItemKeys?.has(itemKey)
+    ) {
+      continue
+    }
+    const separator = itemKey.indexOf('\0')
+    if (
+      separator >= 0 &&
+      !hasPendingTaskPageGitHubOpsForItem(itemKey.slice(0, separator), itemKey.slice(separator + 1))
+    ) {
+      clearConfirmedAuthorityForItem(itemKey.slice(0, separator), itemKey.slice(separator + 1))
+    }
+  }
   const safeGcKeys = new Set(pageKeys)
   for (const [itemKey] of getAllStickyHideEntries()) {
     if (pageKeys.has(itemKey)) {
@@ -102,58 +150,22 @@ export function settleQuietSearchRevalidate(args: {
   notifyTaskPageGitHubMutationRegistry()
   return { needTrailing }
 }
-export async function scheduleTaskPageQuietRevalidate(queryKey: string): Promise<void> {
-  const state = getOrCreateQuietRevalidateState(queryKey)
-  if (state.inFlight || !quietRunner) {
-    return
-  }
-  state.inFlight = true
-  const runGeneration = state.dirtyGeneration
-  state.fetchStartedAtGeneration = runGeneration
-  try {
-    await quietRunner(queryKey)
-  } finally {
-    state.inFlight = false
-  }
-  const after = getOrCreateQuietRevalidateState(queryKey)
-  if (after.dirtyGeneration > runGeneration) {
-    // Why: mirror processTaskPageQuietRevalidateSettle — index the backoff by the
-    // worst lag attempt (Math.max), not the count of lagging keys, so several
-    // items each lagging once cannot jump the delay tier.
-    const lagValues = [...after.lagSkipAttempts.values()]
-    const attempts = lagValues.length === 0 ? 0 : Math.max(...lagValues)
-    const delay = LAG_BACKOFF_MS[Math.min(attempts, LAG_BACKOFF_MS.length - 1)] ?? 500
-    await new Promise((resolve) => setTimeout(resolve, delay))
-    await scheduleTaskPageQuietRevalidate(queryKey)
-  }
-}
-export async function processTaskPageQuietRevalidateSettle(args: {
+export function processTaskPageQuietRevalidateSettle(args: {
   queryKey: string
   networkItems: readonly GitHubWorkItem[]
   patchWorkItem: TaskPageGitHubPatchWorkItem
   resolveSourceScope?: (item: GitHubWorkItem) => string | null
   sourceContextByRepoId?: ReadonlyMap<string, TaskSourceContext | null | undefined>
-  scheduleTrailing?: boolean
-}): Promise<{ needTrailing: boolean }> {
+  revalidatedItemKeys?: ReadonlySet<string>
+}): { needTrailing: boolean } {
   const state = getOrCreateQuietRevalidateState(args.queryKey)
-  const G0 = state.fetchStartedAtGeneration
-  const result = settleQuietSearchRevalidate({
+  return settleQuietSearchRevalidate({
     queryKey: args.queryKey,
     networkItems: args.networkItems,
-    fetchStartedAtGeneration: G0,
+    fetchStartedAtGeneration: state.fetchStartedAtGeneration,
     patchWorkItem: args.patchWorkItem,
     resolveSourceScope: args.resolveSourceScope,
-    sourceContextByRepoId: args.sourceContextByRepoId
+    sourceContextByRepoId: args.sourceContextByRepoId,
+    revalidatedItemKeys: args.revalidatedItemKeys
   })
-  if (result.needTrailing && args.scheduleTrailing !== false) {
-    const lagValues = [...state.lagSkipAttempts.values()]
-    const attempts = lagValues.length === 0 ? 0 : Math.max(...lagValues)
-    const wallExceeded = Date.now() - state.lastConfirmAt > LAG_WALL_BUDGET_MS
-    if (attempts < MAX_LAG_TRAILS && !wallExceeded) {
-      const delay = LAG_BACKOFF_MS[Math.min(attempts, LAG_BACKOFF_MS.length - 1)] ?? 500
-      await new Promise((resolve) => setTimeout(resolve, delay))
-      await scheduleTaskPageQuietRevalidate(args.queryKey)
-    }
-  }
-  return result
 }

--- a/src/renderer/src/components/task-page-github-work-item-quiet-state.ts
+++ b/src/renderer/src/components/task-page-github-work-item-quiet-state.ts
@@ -1,0 +1,88 @@
+import { taskPageGitHubFamilyDirtyKey } from './task-page-github-work-item-mutation-keys'
+
+export type QuietRevalidateState = {
+  inFlight: boolean
+  trailingQueued: boolean
+  dirtyGeneration: number
+  fetchStartedAtGeneration: number
+  familyDirtyAt: Map<string, number>
+  lagSkipAttempts: Map<string, number>
+  networkFailureAttempts: number
+  lastConfirmAt: number
+  runGeneration: number
+  runOwner: object | null
+}
+
+const quietByQueryKey = new Map<string, QuietRevalidateState>()
+
+export function getOrCreateQuietRevalidateState(queryKey: string): QuietRevalidateState {
+  let state = quietByQueryKey.get(queryKey)
+  if (!state) {
+    state = {
+      inFlight: false,
+      trailingQueued: false,
+      dirtyGeneration: 0,
+      fetchStartedAtGeneration: 0,
+      familyDirtyAt: new Map(),
+      lagSkipAttempts: new Map(),
+      networkFailureAttempts: 0,
+      lastConfirmAt: 0,
+      runGeneration: 0,
+      runOwner: null
+    }
+    quietByQueryKey.set(queryKey, state)
+  }
+  return state
+}
+
+export function beginTaskPageQuietRevalidateRun(
+  state: QuietRevalidateState,
+  owner: object
+): number | null {
+  if (state.inFlight && state.runOwner === owner) {
+    state.trailingQueued = true
+    return null
+  }
+  state.inFlight = true
+  state.trailingQueued = false
+  state.runGeneration += 1
+  state.runOwner = owner
+  return state.runGeneration
+}
+
+export function finishTaskPageQuietRevalidateRun(
+  state: QuietRevalidateState,
+  owner: object,
+  generation: number
+): boolean {
+  if (state.runOwner !== owner || state.runGeneration !== generation) {
+    return false
+  }
+  state.inFlight = false
+  state.runOwner = null
+  return true
+}
+
+export function getQuietRevalidateState(queryKey: string): QuietRevalidateState | undefined {
+  return quietByQueryKey.get(queryKey)
+}
+
+export function markTaskPageGitHubFamiliesDirty(
+  queryKey: string,
+  itemKey: string,
+  families: readonly string[]
+): void {
+  const quiet = getOrCreateQuietRevalidateState(queryKey)
+  quiet.dirtyGeneration += 1
+  quiet.lastConfirmAt = Date.now()
+  quiet.networkFailureAttempts = 0
+  for (const family of families) {
+    const familyKey = taskPageGitHubFamilyDirtyKey(itemKey, family)
+    quiet.familyDirtyAt.set(familyKey, quiet.dirtyGeneration)
+    quiet.lagSkipAttempts.delete(familyKey)
+  }
+}
+
+export function clearTaskPageGitHubQuietStates(): void {
+  quietByQueryKey.clear()
+}

--- a/src/renderer/src/components/task-page-github-work-item-registry-types.ts
+++ b/src/renderer/src/components/task-page-github-work-item-registry-types.ts
@@ -1,0 +1,30 @@
+import type { GitHubAssignableUser, GitHubWorkItem } from '../../../shared/types'
+
+export type TaskPageGitHubListFamily = 'assignees' | 'reviewRequests'
+export type TaskPageGitHubMutationKey = {
+  sourceScope: string | null
+  repoId: string
+  itemId: string
+  opKey: string
+}
+export type PendingListOp = {
+  family: TaskPageGitHubListFamily
+  kind: 'add' | 'remove'
+  logins: string[]
+  users?: GitHubAssignableUser[]
+}
+export type PendingOp = {
+  generation: number
+  key: TaskPageGitHubMutationKey
+  previous: Partial<GitHubWorkItem>
+  next: Partial<GitHubWorkItem>
+  listOp?: PendingListOp
+  skipMeQualifiers: boolean
+  startedAt: number
+}
+export type StickyHideEntry = {
+  itemKey: string
+  sourceScope: string | null
+  queryKey: string
+  reason: 'filter_membership'
+}

--- a/src/renderer/src/hooks/use-task-page-github-work-item-mutation-host.test.ts
+++ b/src/renderer/src/hooks/use-task-page-github-work-item-mutation-host.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import type { TaskSourceContext } from '../../../shared/task-source-context'
+import { shouldSkipLocalViewerQualifiers } from './useTaskPageGitHubWorkItemMutation'
+
+function sourceContext(hostId: TaskSourceContext['hostId']): TaskSourceContext {
+  return {
+    kind: 'task-source',
+    provider: 'github',
+    projectId: 'project-1',
+    hostId
+  }
+}
+
+describe('TaskPage GitHub work-item mutation host handling', () => {
+  it('uses the local viewer only for local task sources', () => {
+    expect(shouldSkipLocalViewerQualifiers(sourceContext('local'))).toBe(false)
+    expect(shouldSkipLocalViewerQualifiers(sourceContext('ssh:builder'))).toBe(true)
+    expect(shouldSkipLocalViewerQualifiers(sourceContext('runtime:environment-1'))).toBe(true)
+  })
+
+  it('does not reuse the github.com viewer for a local enterprise host', () => {
+    expect(
+      shouldSkipLocalViewerQualifiers({
+        ...sourceContext('local'),
+        providerIdentity: {
+          provider: 'github',
+          owner: 'acme',
+          repo: 'project',
+          host: 'github.acme.test'
+        }
+      })
+    ).toBe(true)
+  })
+})

--- a/src/renderer/src/hooks/useTaskPageGitHubWorkItemMutation.ts
+++ b/src/renderer/src/hooks/useTaskPageGitHubWorkItemMutation.ts
@@ -1,0 +1,174 @@
+import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import type { ParsedTaskQuery } from '../../../shared/task-query'
+import type { GitHubWorkItem } from '../../../shared/types'
+import {
+  getTaskSourceRuntimeSettings,
+  type TaskSourceContext
+} from '../../../shared/task-source-context'
+import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import { useAppStore } from '@/store'
+import {
+  beginTaskPageGitHubWorkItemMutation,
+  confirmTaskPageGitHubWorkItemMutation,
+  isTaskPageGitHubMutationPendingKey,
+  rollbackTaskPageGitHubWorkItemMutation
+} from '@/components/task-page-github-work-item-mutations'
+import type { TaskPageGitHubMutationIntent } from '@/components/task-page-github-work-item-mutation-patches'
+import {
+  getTaskPageGitHubSoftHiddenItemKeys,
+  subscribeTaskPageGitHubMutationRegistry,
+  setTaskPageGitHubMutationQueryKey,
+  type TaskPageGitHubMutationKey
+} from '@/components/task-page-github-work-item-mutation-registry'
+import { useMountedRef } from './useMountedRef'
+
+export type UseTaskPageGitHubWorkItemMutationArgs = {
+  appliedTaskSearch: string
+  queryKey: string
+  query: ParsedTaskQuery
+  /** Local gh viewer login only; may be null. */
+  viewerLogin: string | null
+  /**
+   * Bumps quietRefreshNonce (or equivalent) only — must not set tasksFiltering /
+   * must not use taskRefreshNonce (K23). When provided, also registers with
+   * the mutations quiet scheduler via scheduleTaskPageQuietRevalidate.
+   */
+  scheduleQuietRevalidate: () => void
+}
+
+function deriveSkipMeQualifiers(sourceContext?: TaskSourceContext | null): boolean {
+  if (!sourceContext) {
+    return false
+  }
+  const settings = getTaskSourceRuntimeSettings(sourceContext)
+  const target = getActiveRuntimeTarget(settings)
+  // Why: local gh viewer must not evaluate @me soft-hide for SSH/environment rows.
+  return target.kind === 'environment'
+}
+
+export function useTaskPageGitHubWorkItemMutation(args: UseTaskPageGitHubWorkItemMutationArgs): {
+  run: (input: {
+    item: GitHubWorkItem
+    intent: TaskPageGitHubMutationIntent
+    sourceContext?: TaskSourceContext | null
+    mutate: () => Promise<{ ok?: boolean; error?: string | { message?: string } } | void>
+    successToast?: string
+    errorToast: string
+    serverEntityFromResult?: (result: unknown) => Partial<GitHubWorkItem> | undefined
+  }) => Promise<'confirmed' | 'rolled_back' | 'stale'>
+  isPending: (key: TaskPageGitHubMutationKey) => boolean
+  softHiddenItemKeys: ReadonlySet<string>
+} {
+  const patchWorkItem = useAppStore((s) => s.patchWorkItem)
+  const mountedRef = useMountedRef()
+  const [softHiddenItemKeys, setSoftHiddenItemKeys] = useState<ReadonlySet<string>>(
+    () => new Set(getTaskPageGitHubSoftHiddenItemKeys())
+  )
+
+  useEffect(() => {
+    setTaskPageGitHubMutationQueryKey(args.queryKey)
+  }, [args.queryKey])
+
+  useEffect(() => {
+    setSoftHiddenItemKeys(new Set(getTaskPageGitHubSoftHiddenItemKeys()))
+    return subscribeTaskPageGitHubMutationRegistry(() => {
+      setSoftHiddenItemKeys(new Set(getTaskPageGitHubSoftHiddenItemKeys()))
+    })
+  }, [])
+
+  const isPending = useCallback((key: TaskPageGitHubMutationKey) => {
+    return isTaskPageGitHubMutationPendingKey(key)
+  }, [])
+
+  const { query, queryKey, viewerLogin, scheduleQuietRevalidate } = args
+
+  const run = useCallback(
+    async (input: {
+      item: GitHubWorkItem
+      intent: TaskPageGitHubMutationIntent
+      sourceContext?: TaskSourceContext | null
+      mutate: () => Promise<{ ok?: boolean; error?: string | { message?: string } } | void>
+      successToast?: string
+      errorToast: string
+      serverEntityFromResult?: (result: unknown) => Partial<GitHubWorkItem> | undefined
+    }): Promise<'confirmed' | 'rolled_back' | 'stale'> => {
+      const skipMeQualifiers = deriveSkipMeQualifiers(input.sourceContext)
+      const began = beginTaskPageGitHubWorkItemMutation({
+        item: input.item,
+        intent: input.intent,
+        sourceContext: input.sourceContext,
+        query,
+        queryKey,
+        viewerLogin,
+        skipMeQualifiers,
+        patchWorkItem
+      })
+
+      try {
+        const result = await input.mutate()
+        const typed = result as { ok?: boolean; error?: string | { message?: string } } | void
+        if (typed && typeof typed === 'object' && typed.ok === false) {
+          const rolled = rollbackTaskPageGitHubWorkItemMutation({
+            key: began.key,
+            generation: began.generation,
+            patchWorkItem,
+            sourceContext: input.sourceContext,
+            query,
+            queryKey,
+            viewerLogin,
+            item: input.item
+          })
+          if (rolled === 'rolled_back' && mountedRef.current) {
+            const message =
+              typeof typed.error === 'string'
+                ? typed.error
+                : (typed.error?.message ?? input.errorToast)
+            toast.error(message)
+          }
+          return rolled
+        }
+
+        const serverEntity = input.serverEntityFromResult?.(result)
+        const confirmed = confirmTaskPageGitHubWorkItemMutation(began.key, began.generation, {
+          query,
+          queryKey,
+          viewerLogin,
+          item: input.item,
+          serverEntity,
+          patchWorkItem,
+          sourceContext: input.sourceContext,
+          // Quiet revalidate: mark dirty; TaskPage runner is registered separately.
+          scheduleQuiet: false
+        })
+        if (confirmed === 'confirmed') {
+          // Why: TaskPage owns the quiet fetch (K23); confirm already marked dirty.
+          scheduleQuietRevalidate()
+          if (input.successToast && mountedRef.current) {
+            toast.success(input.successToast)
+          }
+          useAppStore.getState().recordFeatureInteraction('github-tasks')
+        }
+        return confirmed
+      } catch (err) {
+        const rolled = rollbackTaskPageGitHubWorkItemMutation({
+          key: began.key,
+          generation: began.generation,
+          patchWorkItem,
+          sourceContext: input.sourceContext,
+          query,
+          queryKey,
+          viewerLogin,
+          item: input.item
+        })
+        if (rolled === 'rolled_back' && mountedRef.current) {
+          toast.error(err instanceof Error ? err.message : input.errorToast)
+        }
+        return rolled
+      }
+    },
+    [query, queryKey, viewerLogin, scheduleQuietRevalidate, mountedRef, patchWorkItem]
+  )
+
+  return { run, isPending, softHiddenItemKeys }
+}

--- a/src/renderer/src/hooks/useTaskPageGitHubWorkItemMutation.ts
+++ b/src/renderer/src/hooks/useTaskPageGitHubWorkItemMutation.ts
@@ -1,50 +1,47 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
+import { parseExecutionHostId } from '../../../shared/execution-host'
 import type { ParsedTaskQuery } from '../../../shared/task-query'
 import type { GitHubWorkItem } from '../../../shared/types'
-import {
-  getTaskSourceRuntimeSettings,
-  type TaskSourceContext
-} from '../../../shared/task-source-context'
-import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import type { TaskSourceContext } from '../../../shared/task-source-context'
 import { useAppStore } from '@/store'
 import {
   beginTaskPageGitHubWorkItemMutation,
+  canStartTaskPageGitHubWorkItemMutation,
   confirmTaskPageGitHubWorkItemMutation,
-  isTaskPageGitHubMutationPendingKey,
   rollbackTaskPageGitHubWorkItemMutation
 } from '@/components/task-page-github-work-item-mutations'
 import type { TaskPageGitHubMutationIntent } from '@/components/task-page-github-work-item-mutation-patches'
+import type { TaskPageGitHubPatchWorkItem } from '@/components/task-page-github-work-item-mutation-types'
 import {
   getTaskPageGitHubSoftHiddenItemKeys,
   subscribeTaskPageGitHubMutationRegistry,
-  setTaskPageGitHubMutationQueryKey,
-  type TaskPageGitHubMutationKey
+  setTaskPageGitHubMutationQueryKey
 } from '@/components/task-page-github-work-item-mutation-registry'
 import { useMountedRef } from './useMountedRef'
 
 export type UseTaskPageGitHubWorkItemMutationArgs = {
-  appliedTaskSearch: string
   queryKey: string
   query: ParsedTaskQuery
   /** Local gh viewer login only; may be null. */
   viewerLogin: string | null
-  /**
-   * Bumps quietRefreshNonce (or equivalent) only — must not set tasksFiltering /
-   * must not use taskRefreshNonce (K23). When provided, also registers with
-   * the mutations quiet scheduler via scheduleTaskPageQuietRevalidate.
-   */
-  scheduleQuietRevalidate: () => void
+  patchWorkItem: TaskPageGitHubPatchWorkItem
 }
 
-function deriveSkipMeQualifiers(sourceContext?: TaskSourceContext | null): boolean {
+export function shouldSkipLocalViewerQualifiers(sourceContext?: TaskSourceContext | null): boolean {
   if (!sourceContext) {
     return false
   }
-  const settings = getTaskSourceRuntimeSettings(sourceContext)
-  const target = getActiveRuntimeTarget(settings)
   // Why: local gh viewer must not evaluate @me soft-hide for SSH/environment rows.
-  return target.kind === 'environment'
+  const hostKind = parseExecutionHostId(sourceContext.hostId)?.kind
+  if (hostKind === 'ssh' || hostKind === 'runtime') {
+    return true
+  }
+  const providerHost =
+    sourceContext.providerIdentity?.provider === 'github'
+      ? sourceContext.providerIdentity.host?.toLowerCase()
+      : undefined
+  return Boolean(providerHost && providerHost !== 'github.com')
 }
 
 export function useTaskPageGitHubWorkItemMutation(args: UseTaskPageGitHubWorkItemMutationArgs): {
@@ -57,11 +54,25 @@ export function useTaskPageGitHubWorkItemMutation(args: UseTaskPageGitHubWorkIte
     errorToast: string
     serverEntityFromResult?: (result: unknown) => Partial<GitHubWorkItem> | undefined
   }) => Promise<'confirmed' | 'rolled_back' | 'stale'>
-  isPending: (key: TaskPageGitHubMutationKey) => boolean
+  isIntentPending: (input: {
+    item: GitHubWorkItem
+    intent: TaskPageGitHubMutationIntent
+    sourceContext?: TaskSourceContext | null
+  }) => boolean
   softHiddenItemKeys: ReadonlySet<string>
 } {
-  const patchWorkItem = useAppStore((s) => s.patchWorkItem)
+  const patchWorkItem = args.patchWorkItem
   const mountedRef = useMountedRef()
+  const activeQueryRef = useRef({
+    query: args.query,
+    queryKey: args.queryKey,
+    viewerLogin: args.viewerLogin
+  })
+  activeQueryRef.current = {
+    query: args.query,
+    queryKey: args.queryKey,
+    viewerLogin: args.viewerLogin
+  }
   const [softHiddenItemKeys, setSoftHiddenItemKeys] = useState<ReadonlySet<string>>(
     () => new Set(getTaskPageGitHubSoftHiddenItemKeys())
   )
@@ -77,11 +88,16 @@ export function useTaskPageGitHubWorkItemMutation(args: UseTaskPageGitHubWorkIte
     })
   }, [])
 
-  const isPending = useCallback((key: TaskPageGitHubMutationKey) => {
-    return isTaskPageGitHubMutationPendingKey(key)
-  }, [])
+  const isIntentPending = useCallback(
+    (input: {
+      item: GitHubWorkItem
+      intent: TaskPageGitHubMutationIntent
+      sourceContext?: TaskSourceContext | null
+    }) => !canStartTaskPageGitHubWorkItemMutation(input),
+    []
+  )
 
-  const { query, queryKey, viewerLogin, scheduleQuietRevalidate } = args
+  const { query, queryKey, viewerLogin } = args
 
   const run = useCallback(
     async (input: {
@@ -93,7 +109,10 @@ export function useTaskPageGitHubWorkItemMutation(args: UseTaskPageGitHubWorkIte
       errorToast: string
       serverEntityFromResult?: (result: unknown) => Partial<GitHubWorkItem> | undefined
     }): Promise<'confirmed' | 'rolled_back' | 'stale'> => {
-      const skipMeQualifiers = deriveSkipMeQualifiers(input.sourceContext)
+      if (!canStartTaskPageGitHubWorkItemMutation(input)) {
+        return 'stale'
+      }
+      const skipMeQualifiers = shouldSkipLocalViewerQualifiers(input.sourceContext)
       const began = beginTaskPageGitHubWorkItemMutation({
         item: input.item,
         intent: input.intent,
@@ -107,6 +126,7 @@ export function useTaskPageGitHubWorkItemMutation(args: UseTaskPageGitHubWorkIte
 
       try {
         const result = await input.mutate()
+        const activeQuery = activeQueryRef.current
         const typed = result as { ok?: boolean; error?: string | { message?: string } } | void
         if (typed && typeof typed === 'object' && typed.ok === false) {
           const rolled = rollbackTaskPageGitHubWorkItemMutation({
@@ -114,9 +134,9 @@ export function useTaskPageGitHubWorkItemMutation(args: UseTaskPageGitHubWorkIte
             generation: began.generation,
             patchWorkItem,
             sourceContext: input.sourceContext,
-            query,
-            queryKey,
-            viewerLogin,
+            query: activeQuery.query,
+            queryKey: activeQuery.queryKey,
+            viewerLogin: activeQuery.viewerLogin,
             item: input.item
           })
           if (rolled === 'rolled_back' && mountedRef.current) {
@@ -131,9 +151,9 @@ export function useTaskPageGitHubWorkItemMutation(args: UseTaskPageGitHubWorkIte
 
         const serverEntity = input.serverEntityFromResult?.(result)
         const confirmed = confirmTaskPageGitHubWorkItemMutation(began.key, began.generation, {
-          query,
-          queryKey,
-          viewerLogin,
+          query: activeQuery.query,
+          queryKey: activeQuery.queryKey,
+          viewerLogin: activeQuery.viewerLogin,
           item: input.item,
           serverEntity,
           patchWorkItem,
@@ -142,8 +162,6 @@ export function useTaskPageGitHubWorkItemMutation(args: UseTaskPageGitHubWorkIte
           scheduleQuiet: false
         })
         if (confirmed === 'confirmed') {
-          // Why: TaskPage owns the quiet fetch (K23); confirm already marked dirty.
-          scheduleQuietRevalidate()
           if (input.successToast && mountedRef.current) {
             toast.success(input.successToast)
           }
@@ -151,14 +169,15 @@ export function useTaskPageGitHubWorkItemMutation(args: UseTaskPageGitHubWorkIte
         }
         return confirmed
       } catch (err) {
+        const activeQuery = activeQueryRef.current
         const rolled = rollbackTaskPageGitHubWorkItemMutation({
           key: began.key,
           generation: began.generation,
           patchWorkItem,
           sourceContext: input.sourceContext,
-          query,
-          queryKey,
-          viewerLogin,
+          query: activeQuery.query,
+          queryKey: activeQuery.queryKey,
+          viewerLogin: activeQuery.viewerLogin,
           item: input.item
         })
         if (rolled === 'rolled_back' && mountedRef.current) {
@@ -167,8 +186,8 @@ export function useTaskPageGitHubWorkItemMutation(args: UseTaskPageGitHubWorkIte
         return rolled
       }
     },
-    [query, queryKey, viewerLogin, scheduleQuietRevalidate, mountedRef, patchWorkItem]
+    [query, queryKey, viewerLogin, mountedRef, patchWorkItem]
   )
 
-  return { run, isPending, softHiddenItemKeys }
+  return { run, isIntentPending, softHiddenItemKeys }
 }

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -5655,6 +5655,26 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
     })
   })
 
+  it('rejects provider-side partial results when completeness is required', async () => {
+    const store = createTestStore()
+    mockApi.gh.listWorkItems.mockResolvedValueOnce({
+      items: [],
+      sources: {
+        issues: { owner: 'up', repo: 'r' },
+        prs: { owner: 'fork', repo: 'r' },
+        originCandidate: { owner: 'fork', repo: 'r' },
+        upstreamCandidate: { owner: 'up', repo: 'r' }
+      },
+      errors: { issues: { type: 'permission_denied', message: 'no access' } }
+    })
+
+    await expect(
+      store
+        .getState()
+        .fetchWorkItems('repo-id', '/repo', 24, '', { force: true, requireComplete: true })
+    ).rejects.toThrow('partial result')
+  })
+
   it('force-retry invalidates a still-failing in-flight request instead of deduping onto it', async () => {
     // Why: parent design doc §2 acceptance criterion 4 — the [Retry] button
     // must re-invoke the fetch with force=true and clear the banner on
@@ -6454,6 +6474,7 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
         }
       })
       .mockRejectedValueOnce(new Error('HTTP 503: Service Unavailable'))
+      .mockRejectedValueOnce(new Error('HTTP 503: Service Unavailable'))
 
     try {
       const repos = [{ repoId: 'github-repo', path: '/server/github-repo' }]
@@ -6466,7 +6487,16 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
       expect(result.items).toEqual([{ ...item, repoId: 'github-repo' }])
       expect(result.failedCount).toBe(0)
       expect(result.githubUnavailable).toBe(true)
-      expect(mockApi.gh.listWorkItems).toHaveBeenCalledTimes(2)
+      expect(result.requestFailureCount).toBe(1)
+
+      const completeOnly = await store.getState().fetchWorkItemsAcrossRepos(repos, 24, 100, '', {
+        force: true,
+        requireComplete: true,
+        allowStaleFallback: false
+      })
+      expect(completeOnly.items).toEqual([])
+      expect(completeOnly.failedCount).toBe(1)
+      expect(mockApi.gh.listWorkItems).toHaveBeenCalledTimes(3)
     } finally {
       consoleWarn.mockRestore()
     }
@@ -6604,6 +6634,73 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
     }
   })
 
+  it('reports skipped SSH repos when a complete first page is required', async () => {
+    const store = createTestStore()
+    mockApi.gh.listWorkItems.mockRejectedValueOnce(
+      new Error(GITHUB_WORK_ITEMS_SSH_REMOTE_REQUIRED_MESSAGE)
+    )
+
+    const result = await store
+      .getState()
+      .fetchWorkItemsAcrossRepos([{ repoId: 'ssh-repo', path: '/server/ssh-repo' }], 24, 100, '', {
+        requireComplete: true
+      })
+
+    expect(result.failedCount).toBe(1)
+    expect(result.requestFailureCount).toBe(1)
+  })
+
+  it('reports skipped SSH repos when a complete later page is required', async () => {
+    const store = createTestStore()
+    mockApi.gh.listWorkItems.mockRejectedValueOnce(
+      new Error(GITHUB_WORK_ITEMS_SSH_REMOTE_REQUIRED_MESSAGE)
+    )
+
+    const result = await store
+      .getState()
+      .fetchWorkItemsNextPage([{ repoId: 'ssh-repo', path: '/server/ssh-repo' }], 24, 100, '', 1, {
+        requireComplete: true
+      })
+
+    expect(result.failedCount).toBe(1)
+  })
+
+  it('rejects provider-side partial data from a complete later-page result', async () => {
+    const store = createTestStore()
+    mockApi.gh.listWorkItems.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'issue:1',
+          type: 'issue',
+          number: 1,
+          title: 'Partial',
+          state: 'open',
+          url: 'https://github.com/o/r/issues/1',
+          labels: [],
+          updatedAt: '2026-05-22T00:00:00Z',
+          author: 'author'
+        }
+      ],
+      sources: {
+        issues: { owner: 'o', repo: 'r' },
+        prs: { owner: 'o', repo: 'r' },
+        originCandidate: { owner: 'o', repo: 'r' },
+        upstreamCandidate: null
+      },
+      errors: { issues: { type: 'permission_denied', message: 'no access' } }
+    })
+
+    const result = await store
+      .getState()
+      .fetchWorkItemsNextPage([{ repoId: 'repo-1', path: '/repo' }], 24, 100, '', 2, {
+        requireComplete: true
+      })
+
+    expect(result.items).toEqual([])
+    expect(result.failedCount).toBe(1)
+    expect(result.errorTypes).toEqual(['permission_denied'])
+  })
+
   it('routes work-item next-page fetches through the active runtime environment', async () => {
     const item = {
       type: 'pr',
@@ -6639,7 +6736,8 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
         24,
         100,
         'is:open',
-        1
+        1,
+        { noCache: true }
       )
 
     expect(mockApi.gh.listWorkItems).not.toHaveBeenCalled()
@@ -6650,7 +6748,8 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
         repo: 'runtime-repo-id',
         limit: 24,
         query: 'is:open',
-        page: 1
+        page: 1,
+        noCache: true
       },
       timeoutMs: 30_000
     })

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -621,6 +621,8 @@ export type CacheEntry<T> = {
 type FetchOptions = {
   force?: boolean
   noCache?: boolean
+  requireComplete?: boolean
+  allowStaleFallback?: boolean
   sourceContext?: TaskSourceContext | null
 }
 
@@ -681,6 +683,7 @@ type InflightWorkItems = {
   promise: Promise<GitHubWorkItem[]>
   force: boolean
   noCache: boolean
+  requireComplete: boolean
 }
 const inflightWorkItemsRequests = new Map<string, InflightWorkItems>()
 const prRequestGenerations = new Map<string, number>()
@@ -1958,7 +1961,12 @@ export type GitHubSlice = {
     displayLimit: number,
     query: string,
     options?: FetchOptions
-  ) => Promise<{ items: GitHubWorkItem[]; failedCount: number; githubUnavailable: boolean }>
+  ) => Promise<{
+    items: GitHubWorkItem[]
+    failedCount: number
+    githubUnavailable: boolean
+    requestFailureCount?: number
+  }>
   /** Fetch one numbered provider page. Pagination pages remain renderer-local. */
   fetchWorkItemsNextPage: (
     repos: {
@@ -1970,7 +1978,8 @@ export type GitHubSlice = {
     perRepoLimit: number,
     displayLimit: number,
     query: string,
-    page: number
+    page: number,
+    options?: Pick<FetchOptions, 'noCache' | 'requireComplete'>
   ) => Promise<{
     items: GitHubWorkItem[]
     failedCount: number
@@ -2651,7 +2660,11 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     const existing = inflightWorkItemsRequests.get(inflightKey)
     if (existing) {
       // Why: a forcing/noCache caller must not dedupe to a weaker in-flight fetch (noCache is stricter — it must bypass gh api's cache too).
-      if ((options?.force && !existing.force) || (options?.noCache && !existing.noCache)) {
+      if (
+        (options?.force && !existing.force) ||
+        (options?.noCache && !existing.noCache) ||
+        (options?.requireComplete && !existing.requireComplete)
+      ) {
         await existing.promise.catch(() => {})
       } else {
         return existing.promise
@@ -2668,6 +2681,9 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
         })
         // Why: stamp repoId at the fetch boundary so downstream consumers can rely on it — main doesn't know Orca's Repo.id.
         const items: GitHubWorkItem[] = envelope.items.map((item) => ({ ...item, repoId }))
+        if (options?.requireComplete && (envelope.errors?.issues || envelope.errors?.prs)) {
+          throw new Error('GitHub work-item fetch returned a partial result.')
+        }
         // Why: only surface issues-side errors here; PR-side failures predate the issue-source split (#1076) and are out of scope for this banner (design doc §2).
         const issuesError = envelope.errors?.issues
         // Why: errors.issues without sources.issues has no slug for the banner, so it's dropped from the cache; log it so this rare case is visible in devtools.
@@ -2720,7 +2736,8 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
     inflightWorkItemsRequests.set(inflightKey, {
       promise: request,
       force: Boolean(options?.force),
-      noCache: Boolean(options?.noCache)
+      noCache: Boolean(options?.noCache),
+      requireComplete: Boolean(options?.requireComplete)
     })
     return request
   },
@@ -2745,6 +2762,10 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
           // Why: fall back to any cache entry (stale or not) before declaring this repo failed; only count as failed when it has nothing to contribute.
           // Why: use perRepoLimit (not displayLimit) so the cache key matches what fetchWorkItems wrote.
           if (isGitHubWorkItemsSshRemoteRequiredError(err)) {
+            if (options?.requireComplete) {
+              requestFailureCount += 1
+              failedCount += 1
+            }
             skippedSourceCount += 1
             return [] as GitHubWorkItem[]
           }
@@ -2762,7 +2783,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
                 )
               : getWorkItemsCacheKeyForOwner(get(), r.repoId, perRepoLimit, query, r.path)
           const cached = get().workItemsCache[key]?.data
-          if (cached) {
+          if (cached && options?.allowStaleFallback !== false) {
             console.warn(`[workItems] ${r.repoId} failed, serving cached:`, err)
             return cached
           }
@@ -2778,10 +2799,15 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       requestFailureCount > 0 &&
       requestFailureCount === repos.length - skippedSourceCount &&
       unavailableFailureCount === requestFailureCount
-    return { items: merged, failedCount, githubUnavailable }
+    return {
+      items: merged,
+      failedCount,
+      githubUnavailable,
+      ...(requestFailureCount > 0 ? { requestFailureCount } : {})
+    }
   },
 
-  fetchWorkItemsNextPage: async (repos, perRepoLimit, displayLimit, query, page) => {
+  fetchWorkItemsNextPage: async (repos, perRepoLimit, displayLimit, query, page, options) => {
     if (isGitHubWorkItemsQueryTooLarge(query)) {
       return { items: [], failedCount: 0, errorTypes: [] }
     }
@@ -2808,7 +2834,8 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
           const envelope = await listGitHubWorkItemsForRepo(requestContext, {
             limit: perRepoLimit,
             query: query || undefined,
-            page
+            page,
+            ...(options?.noCache ? { noCache: true } : {})
           })
           // Why: page-N failures aren't in the per-repo banner (keyed on the initial fetch); log them so pagination failures are observable instead of silently truncating (richer surface deferred, design doc §6).
           if (envelope.errors?.issues) {
@@ -2836,9 +2863,16 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
               envelope.errors.prs
             )
           }
+          if (options?.requireComplete && (envelope.errors?.issues || envelope.errors?.prs)) {
+            failedCount += 1
+            return [] as GitHubWorkItem[]
+          }
           return envelope.items.map((item): GitHubWorkItem => ({ ...item, repoId: r.repoId }))
         } catch (err) {
           if (isGitHubWorkItemsSshRemoteRequiredError(err)) {
+            if (options?.requireComplete) {
+              failedCount += 1
+            }
             return [] as GitHubWorkItem[]
           }
           console.warn(`[workItems] next page ${r.repoId} failed:`, err)


### PR DESCRIPTION
## Summary

Centralizes GitHub issue/PR row mutations on the Task page behind a shared optimistic coordinator, and hardens quiet revalidation so status/assignee/reviewer/merge/auto-merge actions stay consistent with active filters without blanking the table.

- Extract PR/issue status, assignee, reviewer, and merge/auto-merge mutations out of TaskPage cell components into a registry-backed begin/confirm/rollback pipeline (`task-page-github-work-item-mutation-*`).
- Quiet revalidation (no filter skeleton / page blanking) plus soft-hide so rows that leave the active filter (e.g. closing under `is:open`, undrafting under `is:draft`) stay hidden without a jarring reflow.
- Scoped sticky-hide and cancellation fixes so non-membership confirms and nonce-triggered re-renders do not leave stale rows or stranded backoff bookkeeping.
- Restyle the GitHub task table: opaque sticky ID/Title cells, distinct header fill, accent hover, tighter row/toolbar chrome.

## Screenshots

- Visual change: table chrome / sticky ID+Title cells / hover accents on the GitHub issues+PRs table.
- Screenshots not attached in this update; UI-only polish is secondary to the mutation coordinator.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test` (targeted unit tests for mutation/filter/quiet-revalidate modules)
- [ ] `pnpm build`
- [x] Added/updated high-quality unit tests: filter membership, mutation patches, mutation lifecycle, quiet revalidation regressions, host hook guard, github slice authority refresh

## AI Review Report

- Risk focus: optimistic update/rollback consistency, sticky filter membership across query keys, quiet revalidate cancellation/backoff, draft soft-hide, cross-platform UI (table only — no shortcuts/path/shell changes).
- Cross-platform: no platform-specific keyboard shortcuts, path handling, shell behavior, or Electron native APIs touched; changes are renderer React + Zustand cache coordination only (macOS/Linux/Windows-neutral).

## Security Audit

- No new IPC, command execution, secrets, or auth surface.
- Mutations still go through existing GitHub API helpers; optimistic patches are local cache only.
- Quiet revalidation uses existing search/fetch paths with no-cache adopt rules and confirmed-authority guards to avoid clobbering user-confirmed fields with stale server data.

## Notes

- Rebased onto latest `main` (was ~1.3k commits behind).
- Includes follow-up commit for scoped quiet revalidation beyond the original 3-commit PR tip.