### PR TITLE
fix(worktrees): run the macOS git-common narrow watch in the crash-isolated watcher child

### DIFF
--- a/src/main/ipc/worktree-git-common-watch.ts
+++ b/src/main/ipc/worktree-git-common-watch.ts
@@ -1,5 +1,6 @@
 import { stat } from 'node:fs/promises'
 import { join } from 'node:path'
+import { subscribeViaWatcherProcess } from './parcel-watcher-process'
 import type { WorktreeBaseWatchTarget } from './worktree-base-directory-event-filter'
 import type {
   WorktreeBasePollEvent,
@@ -13,13 +14,17 @@ import {
 // Watches a repo's `<common>/.git/worktrees` metadata plus the primary
 // checkout's shallow branch/index files — the only paths the git-common event
 // filter consumes.
-// macOS: a narrow native stream rooted at `worktrees/` — a tiny, rare-churn
-// tree — gives instant detection with zero idle cost and zero wide-scope
-// fseventsd delivery; the primary files are covered by a few stat calls per
-// tick (a native stream would have to span the whole common dir, objects
-// included). Other platforms: dir-listing poll (no fseventsd to protect, and
-// on Windows an open directory handle on `worktrees/` could interfere with
-// `git worktree prune` removing it).
+// macOS: a narrow native stream rooted at `worktrees/` gives instant
+// detection with zero wide-scope fseventsd delivery; the primary files are
+// covered by a few stat calls per tick (a native stream would have to span
+// the whole common dir, objects included). Other platforms: dir-listing poll
+// (no fseventsd to protect, and on Windows an open directory handle on
+// `worktrees/` could interfere with `git worktree prune` removing it).
+// The stream runs in the crash-isolated watcher child, never in-process:
+// linked-worktree HEAD/index churn plus root deletion on worktree removal
+// hits watcher.node's FSEvents teardown race (unsynchronized deletedRoot
+// self-stop vs unsubscribe), which corrupts the heap and fail-fasts the
+// hosting process (SIGTRAP in Watcher::isIgnored on the FSEvents thread).
 
 // Why: branch switches and commits made in the primary checkout rewrite these
 // top-level files (linked-worktree equivalents live under `worktrees/`).
@@ -172,26 +177,38 @@ async function startGitCommonNarrowWatch(
       armExistencePoll()
     }
     try {
-      const watcher = await import('@parcel/watcher')
-      const sub = await watcher.subscribe(worktreesDir, (error, events) => {
-        if (disposed) {
-          return
-        }
-        if (error) {
-          onEvents([{ type: 'update', path: worktreesDir }])
-          teardownAndRearm()
-          return
-        }
-        if (events.length > 0) {
-          const rootGone = events.some(
-            (event) => event.type === 'delete' && event.path === worktreesDir
-          )
-          onEvents(events.map((event) => ({ type: event.type, path: event.path })))
-          if (rootGone) {
+      const sub = await subscribeViaWatcherProcess(
+        worktreesDir,
+        (error, events) => {
+          if (disposed) {
+            return
+          }
+          if (error) {
+            onEvents([{ type: 'update', path: worktreesDir }])
             teardownAndRearm()
+            return
+          }
+          if (events.length > 0) {
+            const rootGone = events.some(
+              (event) => event.type === 'delete' && event.path === worktreesDir
+            )
+            onEvents(events.map((event) => ({ type: event.type, path: event.path })))
+            if (rootGone) {
+              teardownAndRearm()
+            }
+          }
+        },
+        {},
+        {
+          // A watcher-child restart re-establishes the stream with an event
+          // gap; surface a root update so the repo's worktree list refreshes.
+          onInterruption: () => {
+            if (!disposed) {
+              onEvents([{ type: 'update', path: worktreesDir }])
+            }
           }
         }
-      })
+      )
       if (disposed || errored) {
         void sub.unsubscribe().catch(() => {})
         return !errored


### PR DESCRIPTION
## Problem

Orca 1.4.143 crashes with EXC_BREAKPOINT (SIGTRAP) in the **Electron main process** on the FSEvents thread (`FSEventsBackend::start → FSEventsCallback → Watcher::isIgnored → brk 0`) under heavy worktree churn — e.g. many parallel builds in linked worktrees followed by bulk `git worktree remove`. Reproduced twice in ~30 minutes on macOS 26.5.2 (M4 Pro).

## Cause

The macOS git-common narrow watch (`src/main/ipc/worktree-git-common-watch.ts`) was the last production call site loading native `@parcel/watcher` directly in the Electron main process. Two assumptions broke:

- `.git/worktrees` is not the rare-churn tree the code assumed — every linked worktree's `HEAD`/`index`/lock files live under `<common>/.git/worktrees/<name>/`, so parallel agents generate constant events there.
- Bulk worktree removal deletes the watched root itself, hitting parcel-watcher 2.5.6's unsynchronized FSEvents teardown race ([`FSEventsBackend.cc`](https://github.com/parcel-bundler/watcher/blob/v2.5.6/src/macos/FSEventsBackend.cc): the root-deletion self-stop runs `stopStream()` + `watcher->state = nullptr` on the FSEvents thread without the backend mutex, racing `unsubscribe()` on the JS thread — a non-atomic `shared_ptr` read/write race and potential double `FSEventStreamRelease`).

The resulting heap corruption trips Electron's allocator (PartitionAlloc traps with `brk 0` — the "V8 internals" frames in the crash reports are nearest-symbol misattribution) and fail-fasts the whole app. 2.5.6 is the latest upstream release, so no fixed version exists to bump to; the race deserves a separate upstream report.

## Fix

Route the subscription through `subscribeViaWatcherProcess` like every other watcher, honoring the repo's own crash-isolation invariant (`parcel-watcher-process-entry.ts`, issue #7547). Root-deletion teardown-and-rearm semantics are unchanged — events (including the root `delete`) and watch errors reach the callback in the same shape. A new `onInterruption` hook surfaces a synthetic root update so the worktree list refreshes past the event gap after a watcher-child respawn. A native crash now costs a child restart instead of the app.

## Validation

- `pnpm typecheck:node`, oxlint, max-lines ratchet — clean.
- `worktree-base-directory-poller.test.ts` (includes the real-FSEvents macOS narrow-stream integration tests: add/update/remove, existence-poll arming, delete-and-recreate rearm) — 15/15 pass.
- `parcel-watcher-process`, `parcel-watcher-process-entry`, `filesystem-watcher` suites — 70/70 pass.
- Smoke-tested the built child entry (`out/main/parcel-watcher-process-entry.js`, real native `watcher.node`): subscribe to a `worktrees` dir → churn HEAD/index files → delete the watched root → unsubscribe, then 10 repeated cycles — host process unaffected throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)