### PR TITLE
fix(pi): stop OMP tab icon flashing to Pi while working

### DIFF
--- a/src/renderer/src/lib/use-tab-agent-pi-identity.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-pi-identity.test.ts
@@ -132,6 +132,64 @@ describe('resolveTabAgentFromSignals — Pi/OMP identity', () => {
     expect(afterHookCleared).toBe('omp')
   })
 
+  it('does not flap between OMP and Pi as the foreground process oscillates', () => {
+    // The reported flicker: OMP wraps Pi (`shell → omp → pi`), so the foreground
+    // reader alternates between reporting `omp` and `pi` at command boundaries.
+    // The process signal outranks launchAgent, so without owner-normalization the
+    // OMP-owned tab's icon flips to Pi on every `pi` read. Both reads must land on
+    // the launched owner.
+    const readsPi = resolveTabAgentFromSignals({
+      hasObservedAgentSignal: true,
+      isRemote: false,
+      title: '⠋ OMP',
+      hookAgent: null,
+      processAgent: 'pi',
+      launchAgent: 'omp'
+    })
+    const readsOmp = resolveTabAgentFromSignals({
+      hasObservedAgentSignal: true,
+      isRemote: false,
+      title: '⠋ OMP',
+      hookAgent: null,
+      processAgent: 'omp',
+      launchAgent: 'omp'
+    })
+    expect(readsPi).toBe('omp')
+    expect(readsOmp).toBe('omp')
+  })
+
+  it('re-owns a Pi foreground read to a durable OMP identity when launchAgent is gone', () => {
+    // A mirrored/restored OMP pane keeps only its completed-hook identity; a `pi`
+    // foreground read (OMP's nested child) must not repaint it to Pi.
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: '⠋ OMP',
+        hookAgent: null,
+        focusedCompletedHookAgent: 'omp',
+        processAgent: 'pi',
+        launchAgent: undefined
+      })
+    ).toBe('omp')
+  })
+
+  it('still lets a genuine cross-group foreground process reclaim a reused OMP pane', () => {
+    // Scope guard: a different-group process (Codex is not Pi-compatible) is
+    // real-time proof the pane was reused, so it overrides the OMP launch owner
+    // instead of collapsing onto it.
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: 'zsh',
+        hookAgent: null,
+        processAgent: 'codex',
+        launchAgent: 'omp'
+      })
+    ).toBe('codex')
+  })
+
   it('keeps a launchAgent-less Pi pane on Pi and rejects a stale OMP session record', () => {
     // The fallback must not over-reach: a genuine Pi pane (recent Pi hook) stays
     // Pi even if a stale hibernated OMP record is present.

--- a/src/renderer/src/lib/use-tab-agent.ts
+++ b/src/renderer/src/lib/use-tab-agent.ts
@@ -168,7 +168,13 @@ export function resolveTabAgentFromSignals(args: {
     processShellForeground: args.processShellForeground
   })
   const activeLaunchAgent = launchedAgentExited ? null : launchAgent
-  const processAgent = args.processAgent ?? null
+  // Why: the foreground process, like the hook and title signals, must be
+  // re-owned within its title-identity group. OMP wraps Pi as `shell → omp → pi`,
+  // so the foreground reader oscillates between reporting `omp` and `pi` across
+  // command boundaries; taken raw it outranks launchAgent and flips an OMP-owned
+  // tab's icon between the two glyphs. Re-owning collapses the same-group read
+  // onto the durable owner while a genuine cross-group process still stands.
+  const processAgent = resolveSignalAgentForLaunchOwner(args.processAgent, owner)
   const sleepingSessionAgent = args.sleepingSessionAgent ?? null
   // Identity-first precedence. The live focused hook is ground truth while the
   // agent works; process identity covers agents with neither hook nor title; the
@@ -199,7 +205,8 @@ export function resolveTabAgentFromSignals(args: {
  * 2. Process identity — the recognized foreground process, read at OSC 133
  *    command boundaries (local panes only); covers agents that emit neither
  *    hooks nor titles, and its shell-foreground mark is title-independent exit
- *    evidence.
+ *    evidence. Re-owned within its title-identity group, so OMP's nested `pi`
+ *    child (the `shell → omp → pi` tree) cannot flip the icon back to Pi.
  * 3. Title — only as a reuse override (it names a DIFFERENT-group agent than the
  *    pane's known identity, proving reuse) or as a legacy standalone identity
  *    when the pane has no hook. Within the same title-identity group it carries


### PR DESCRIPTION
## Problem

While an **OMP** instance was doing work, its tab icon rapidly flickered between the OMP and Pi glyphs.

OMP runs as a `shell → omp → pi` process tree (it wraps Pi as its engine), and Orca recognizes both `omp` and `pi` as distinct agents. The foreground-process reader samples that tree at every OSC 133 command boundary and keeps alternating between reporting `omp` and `pi`.

In `resolveTabAgentFromSignals` (`use-tab-agent.ts` — the resolver that drives the tab-bar icon), every identity signal is "re-owned" onto the pane's durable owner within its title-identity group (pi and omp share the `pi-compatible` group), so a Pi-shaped signal on an OMP pane can't repaint it — **except the foreground-process signal, which was consumed raw**. Because the process signal ranks second in precedence (above `launchAgent`), each `pi` read repainted an OMP-owned tab's icon to the Pi glyph and the next read flipped it back.

The tab **title text** was never affected — its owner resolution already excludes the process signal — so this is icon-only.

## Fix

Re-own the process signal exactly the way the hook and title signals already are:

```ts
const processAgent = resolveSignalAgentForLaunchOwner(args.processAgent, owner)
```

A **same-group** read (pi↔omp) collapses onto the pane's owner, so an OMP pane stays OMP no matter which of its two child processes is foreground at that instant. A genuine **cross-group** process (e.g. Codex, which isn't Pi-compatible) still stands on its own and correctly reclaims a reused pane.

## Tests

Added regression coverage in `use-tab-agent-pi-identity.test.ts`:

- **Process oscillation** — `processAgent` alternating `pi`/`omp` with `launchAgent: 'omp'` now resolves to `omp` on both reads. This test fails on the un-fixed code (`expected 'pi' to be 'omp'`), reproducing the flash.
- **Mirrored/restored pane** — a `pi` foreground read on an OMP pane whose only identity is a completed OMP hook stays `omp`.
- **Cross-group scope guard** — a `codex` foreground process on an OMP-launched pane still resolves to `codex`, so the normalization can't over-reach.

All green: 68 `use-tab-agent` tests + 112 broader identity/title/sidebar/mirror tests; `typecheck:web` and lint clean.

## Known residual (out of scope)

A *fully hookless and launchless* OMP pane (no `launchAgent`, no live/completed hook, no hibernated session) still has a null owner, so nothing anchors the flip. Real launched or hooked OMP sessions always carry a non-null owner, so this only applies to a transient pre-hook window; documented inline rather than expanding scope here.