### PR TITLE
Preserve native OpenCode session titles

### DIFF
--- a/src/renderer/src/lib/agent-status-terminal-title.test.ts
+++ b/src/renderer/src/lib/agent-status-terminal-title.test.ts
@@ -58,4 +58,25 @@ describe('resolveAgentStatusTerminalTitle', () => {
       resolveAgentStatusTerminalTitle({ agentType: 'devin', state: 'waiting' }, '\u280b Devin')
     ).toBe('Devin - action required')
   })
+
+  it('preserves native OpenCode titles through hook status transitions', () => {
+    expect(
+      resolveAgentStatusTerminalTitle(
+        { agentType: 'opencode', state: 'done' },
+        'OC | Native Stable Session'
+      )
+    ).toBe('OC | Native Stable Session')
+    expect(
+      resolveAgentStatusTerminalTitle(
+        { agentType: 'opencode', state: 'waiting' },
+        'OC | Native Stable Session'
+      )
+    ).toBe('OC | Native Stable Session')
+  })
+
+  it('does not invent an OpenCode title when no native title exists', () => {
+    expect(
+      resolveAgentStatusTerminalTitle({ agentType: 'opencode', state: 'done' }, undefined)
+    ).toBeUndefined()
+  })
 })

--- a/src/shared/opencode-terminal-title.test.ts
+++ b/src/shared/opencode-terminal-title.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { isMeaningfulOpenCodeTerminalTitle } from './opencode-terminal-title'
+
+describe('OpenCode terminal titles', () => {
+  it('recognizes native session titles', () => {
+    expect(isMeaningfulOpenCodeTerminalTitle('OC | Native Stable Session')).toBe(true)
+    expect(isMeaningfulOpenCodeTerminalTitle('  OC|Session  ')).toBe(true)
+  })
+
+  it('rejects generic or incomplete OpenCode titles', () => {
+    expect(isMeaningfulOpenCodeTerminalTitle('OpenCode')).toBe(false)
+    expect(isMeaningfulOpenCodeTerminalTitle('OpenCode ready')).toBe(false)
+    expect(isMeaningfulOpenCodeTerminalTitle('OC |')).toBe(false)
+    expect(isMeaningfulOpenCodeTerminalTitle(undefined)).toBe(false)
+  })
+})

--- a/src/shared/opencode-terminal-title.ts
+++ b/src/shared/opencode-terminal-title.ts
@@ -1,0 +1,4 @@
+export function isMeaningfulOpenCodeTerminalTitle(title: string | null | undefined): boolean {
+  // Why: bare OpenCode labels are status/identity; `OC | …` carries native session identity.
+  return /^OC\s*\|\s*\S/u.test(title?.trim() ?? '')
+}

--- a/src/shared/synthetic-agent-title.test.ts
+++ b/src/shared/synthetic-agent-title.test.ts
@@ -15,6 +15,14 @@ describe('synthetic agent titles', () => {
     expect(shouldDriveSyntheticAgentTitleFromHook('codex', 'done')).toBe(true)
   })
 
+  it('does not synthesize OpenCode titles over native session titles', () => {
+    expect(getSyntheticAgentTerminalTitle('opencode', 'done')).toBeNull()
+    expect(getSyntheticAgentTerminalTitle('opencode', 'waiting')).toBeNull()
+    expect(shouldDriveSyntheticAgentTitleFromHook('opencode', 'working')).toBe(false)
+    expect(shouldDriveSyntheticAgentTitleFromHook('opencode', 'done')).toBe(false)
+    expect(shouldDriveSyntheticAgentTitleFromHook('opencode', 'waiting')).toBe(false)
+  })
+
   it('provides Devin titles for hook-driven status updates', () => {
     expect(getSyntheticAgentTerminalTitle('devin', 'done')).toBe('Devin ready')
     expect(getSyntheticAgentTerminalTitle('devin', 'waiting')).toBe('Devin - action required')

--- a/src/shared/synthetic-agent-title.ts
+++ b/src/shared/synthetic-agent-title.ts
@@ -5,6 +5,7 @@ export type SyntheticAgentTitleProfile = {
   permissionLabel: string
   idleLabel: string
   titleIdentityGroup?: string
+  synthesizeTerminalTitle?: boolean
   synthesizeWorkingTitle?: boolean
 }
 
@@ -25,7 +26,9 @@ export const SYNTHETIC_AGENT_TITLE_PROFILES: Record<string, SyntheticAgentTitleP
   opencode: {
     workingLabel: 'OpenCode',
     permissionLabel: 'OpenCode - action required',
-    idleLabel: 'OpenCode ready'
+    idleLabel: 'OpenCode ready',
+    // Why: OpenCode owns semantic OSC session titles; hook status must not replace them.
+    synthesizeTerminalTitle: false
   },
   pi: {
     workingLabel: 'Pi',
@@ -70,7 +73,7 @@ export function getSyntheticAgentTerminalTitle(
   state: AgentStatusState
 ): string | null {
   const profile = getSyntheticAgentTitleProfile(agentType)
-  if (!profile || state === 'working') {
+  if (!profile || profile.synthesizeTerminalTitle === false || state === 'working') {
     return null
   }
   return state === 'blocked' || state === 'waiting' ? profile.permissionLabel : profile.idleLabel
@@ -81,7 +84,7 @@ export function shouldDriveSyntheticAgentTitleFromHook(
   state: AgentStatusState
 ): boolean {
   const profile = getSyntheticAgentTitleProfile(agentType)
-  if (!profile) {
+  if (!profile || profile.synthesizeTerminalTitle === false) {
     return false
   }
   return state !== 'working' || profile.synthesizeWorkingTitle !== false

--- a/src/shared/tab-title-resolution.test.ts
+++ b/src/shared/tab-title-resolution.test.ts
@@ -26,6 +26,28 @@ describe('tab title resolution', () => {
     ).toBe('Payments')
   })
 
+  it('uses meaningful native OpenCode session titles before generated titles', () => {
+    expect(
+      resolveTerminalTabTitle(
+        {
+          customTitle: null,
+          generatedTitle: 'Refactor auth',
+          title: 'OC | Native Stable Session'
+        },
+        true
+      )
+    ).toBe('OC | Native Stable Session')
+  })
+
+  it('keeps generated titles ahead of generic OpenCode titles', () => {
+    expect(
+      resolveTerminalTabTitle(
+        { customTitle: null, generatedTitle: 'Refactor auth', title: 'OpenCode' },
+        true
+      )
+    ).toBe('Refactor auth')
+  })
+
   it('places quick command labels between manual and generated titles', () => {
     expect(
       resolveTerminalTabTitle(
@@ -68,6 +90,44 @@ describe('tab title resolution', () => {
           quickCommandLabel: 'Run build',
           generatedLabel: 'Fix flaky tests',
           label: 'Codex working'
+        },
+        true
+      )
+    ).toBe('Run build')
+  })
+
+  it('uses meaningful native OpenCode labels before generated unified labels', () => {
+    expect(
+      resolveUnifiedTabLabel(
+        {
+          customLabel: null,
+          generatedLabel: 'Fix flaky tests',
+          label: 'OC | Native Stable Session'
+        },
+        true
+      )
+    ).toBe('OC | Native Stable Session')
+  })
+
+  it('keeps manual and quick command labels ahead of native OpenCode labels', () => {
+    expect(
+      resolveUnifiedTabLabel(
+        {
+          customLabel: 'Manual label',
+          quickCommandLabel: 'Run build',
+          generatedLabel: 'Fix flaky tests',
+          label: 'OC | Native Stable Session'
+        },
+        true
+      )
+    ).toBe('Manual label')
+    expect(
+      resolveUnifiedTabLabel(
+        {
+          customLabel: null,
+          quickCommandLabel: 'Run build',
+          generatedLabel: 'Fix flaky tests',
+          label: 'OC | Native Stable Session'
         },
         true
       )

--- a/src/shared/tab-title-resolution.ts
+++ b/src/shared/tab-title-resolution.ts
@@ -1,15 +1,18 @@
 import type { Tab, TerminalTab } from './types'
+import { isMeaningfulOpenCodeTerminalTitle } from './opencode-terminal-title'
 
 export function resolveTerminalTabTitle(
   tab: Pick<TerminalTab, 'customTitle' | 'quickCommandLabel' | 'generatedTitle' | 'title'>,
   generatedTitlesEnabled: boolean,
   fallback = ''
 ): string {
+  const liveTitle = tab.title?.trim() ?? ''
   return (
     tab.customTitle?.trim() ||
     tab.quickCommandLabel?.trim() ||
+    (isMeaningfulOpenCodeTerminalTitle(liveTitle) ? liveTitle : '') ||
     (generatedTitlesEnabled ? tab.generatedTitle?.trim() : '') ||
-    tab.title?.trim() ||
+    liveTitle ||
     fallback
   )
 }
@@ -19,11 +22,13 @@ export function resolveUnifiedTabLabel(
   generatedTitlesEnabled: boolean,
   fallback = ''
 ): string {
+  const liveLabel = tab?.label?.trim() ?? ''
   return (
     tab?.customLabel?.trim() ||
     tab?.quickCommandLabel?.trim() ||
+    (isMeaningfulOpenCodeTerminalTitle(liveLabel) ? liveLabel : '') ||
     (generatedTitlesEnabled ? tab?.generatedLabel?.trim() : '') ||
-    tab?.label?.trim() ||
+    liveLabel ||
     fallback
   )
 }


### PR DESCRIPTION
## Summary

- stop OpenCode hook status updates from injecting synthetic OSC titles such as `OpenCode ready`
- prefer meaningful native OpenCode session titles (`OC | …`) over Orca generated fallback titles
- keep manual labels and quick-command labels at the top of the existing precedence, while bare `OpenCode` remains a generic fallback

## ELI5

OpenCode already knows the name of its conversation. Orca was replacing that name with status text or a prompt-derived fallback after messages. This change lets OpenCode keep its real session name when it has one, and otherwise keeps a stable generic/generated label instead of retitling the tab on each status transition.

## Root cause and reproduction

Faithful OpenCode 1.17.15 sessions showed two independent title writers:

1. Orca resolved generated prompt/task titles before the live terminal OSC title, so an `OC | …` session title could not become visible.
2. OpenCode hook events injected synthetic OSC frames into the same title tracker as native terminal titles, replacing the native title with working and done labels.

With hook title synthesis disabled as a control, native titles survived first, later, long, and restored prompts. The exact report of a new prompt title on every turn did not reproduce; generated prompt titles are first-write stable, but the synthetic status title still changed every turn.

## Expected precedence

`manual > quick command > meaningful native OpenCode title > generated fallback > generic live title > default`

Other agents retain their current title behavior.

## Validation

- disposable Electron dev profile with OpenCode 1.17.15: first prompt and long later prompt both kept the stable `OpenCode` tab label through working and done transitions when no native session title was emitted
- 918 focused title, status, generated-title, and runtime tests pass
- full TypeScript typecheck passes
- targeted lint passes for every changed file
- full lint passed before rebasing; current `main` has an unrelated existing switch-exhaustiveness failure in `src/renderer/src/components/skills/skill-freshness-group.tsx`

## Risk

Low and OpenCode-specific. Hook status continues to drive activity state, notifications, sorting, unread state, and agent rows; only hook-driven terminal retitling is disabled for OpenCode. The native-title classifier is intentionally narrow so generic `OpenCode` titles do not suppress useful generated fallbacks.
