### PR TITLE
fix(web): route headless serve local worktrees through active runtime for web clients

### DIFF
--- a/src/renderer/src/components/right-sidebar/file-explorer-operation-owner.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-operation-owner.ts
@@ -14,6 +14,7 @@ import {
   getSettingsForWorktreeRuntimeOwner
 } from '@/lib/worktree-runtime-owner'
 import type { FileExplorerOperationOwner } from './file-explorer-types'
+import { isWebClientLocation } from '@/lib/web-client-location'
 
 export type FileExplorerOperationRoute = {
   settings: { activeRuntimeEnvironmentId: string | null }
@@ -43,6 +44,18 @@ export function getFileExplorerOperationOwnerFromState(
     }
     const exactHostId = exactHostIds.values().next().value
     if (exactHostId) {
+      // Why: worktrees on a headless serve report hostId "local", but a web
+      // client has no browser-local host — route through the active runtime.
+      if (
+        exactHostId === 'local' &&
+        isWebClientLocation() &&
+        state.settings?.activeRuntimeEnvironmentId?.trim()
+      ) {
+        return {
+          kind: 'runtime',
+          environmentId: state.settings.activeRuntimeEnvironmentId.trim()
+        }
+      }
       return operationOwnerFromHostId(exactHostId)
     }
 

--- a/src/renderer/src/lib/web-client-location.ts
+++ b/src/renderer/src/lib/web-client-location.ts
@@ -2,8 +2,12 @@ export function isWebClientLocation(): boolean {
   if (typeof window === 'undefined') {
     return false
   }
-  return (
-    Boolean((window as unknown as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__) ||
-    window.location.pathname.endsWith('/web-index.html')
-  )
+  if ((window as unknown as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__) {
+    return true
+  }
+  try {
+    return window.location.pathname.endsWith('/web-index.html')
+  } catch {
+    return false
+  }
 }

--- a/src/renderer/src/lib/worktree-runtime-owner.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.ts
@@ -20,6 +20,7 @@ import {
   findIndexedRepoOwner as findRepoRecord,
   findIndexedWorktreeOwner as findWorktreeRecord
 } from './worktree-runtime-owner-index'
+import { isWebClientLocation } from '@/lib/web-client-location'
 
 type RuntimeExecutionHost = Extract<ParsedExecutionHost, { kind: 'runtime' }>
 
@@ -167,7 +168,14 @@ export function getRuntimeEnvironmentIdForWorktree(
   if (worktreeRuntimeEnvironmentId !== undefined) {
     // Why: the same repo can exist on local and remote hosts; a concrete
     // worktree host must override the repo-level default owner.
-    return worktreeRuntimeEnvironmentId
+    if (worktreeRuntimeEnvironmentId !== null) {
+      return worktreeRuntimeEnvironmentId
+    }
+    // Why: worktrees on a headless serve report hostId "local", but a web
+    // client has no browser-local host — fall through to the runtime fallback.
+    if (!isWebClientLocation() || !state.settings?.activeRuntimeEnvironmentId?.trim()) {
+      return null
+    }
   }
   const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
   const repo = findRepoRecord(state.repos, repoId)


### PR DESCRIPTION
## Description

When a browser web client connects to a headless `orca serve` instance, workspaces owned by the server's `local` host cannot be operated: launching agents/terminals fails with "Local PTYs unavailable" and the file explorer shows "Couldn't determine which host owns this workspace."

**Root cause:** Worktrees on the serve machine report `hostId: "local"`, which causes both `getRuntimeEnvironmentIdForWorktree` and `getFileExplorerOperationOwnerFromState` to resolve the owner as local — routing operations to the browser's local host (which has no PTY or filesystem) instead of the remote runtime environment.

**Fix:** When running in a web client with an active runtime environment, treat `hostId: "local"` worktrees as belonging to the runtime rather than the browser-local host. Changes span three files:

1. `worktree-runtime-owner.ts` (`getRuntimeEnvironmentIdForWorktree`): Skip the early null return for explicit-local worktrees and fall through to the `activeRuntimeEnvironmentId` fallback when the client is a web browser.
2. `file-explorer-operation-owner.ts` (`getFileExplorerOperationOwnerFromState`): When the exact worktree hostId is "local" and the web client has an active runtime environment, return `{kind:'runtime', environmentId}` instead of `{kind:'local'}`.
3. `web-client-location.ts` (`isWebClientLocation`): Made defensive against test environments where `window.location` may be undefined.

## No visual change

This is an architectural fix for operation routing — no UI changes.

## Code review summary

- **Cross-platform compatibility:** Changes only apply in web client context; Electron desktop behavior is unchanged. The `isWebClientLocation()` guard ensures desktop apps continue routing local worktrees to the local host.
- **SSH/remote/local compatibility:** Local worktrees on a desktop app (no runtime) remain local. SSH worktrees (hostId starts with `ssh:`) are unaffected. Only the web-client + active-runtime combination triggers the new path.
- **Agent/integration compatibility:** All agent and terminal operations benefit from the fix since they all flow through `getRuntimeEnvironmentIdForWorktree`.
- **Performance risk:** One extra `isWebClientLocation()` call and optional chaining in the worktree owner resolution hot path. Negligible overhead.
- **Security risk:** No new IPC or RPC surface; only changes how existing host routing decisions are made.
- **Testing:** All 751 existing tests pass across 93 test files. Changes are guarded by `isWebClientLocation()` which uses `__ORCA_WEB_CLIENT__` flag and `window.location` checks.

## Testing notes

- Tested via existing unit tests (751 pass). Manual testing on a headless `orca serve` instance with a web browser client would confirm end-to-end.
- Platform-independent: the web client detection works identically across OS platforms.
- Git provider independent: no git provider code was touched.

Fixes #9047
