### PR TITLE
fix(watcher): host macOS git-common narrow watch in the watcher child

### DIFF
--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -128,6 +128,17 @@ describe('worktree git-common narrow watch (darwin)', () => {
     await vi.waitFor(() => {
       expect(subscribeMock).toHaveBeenCalledTimes(2)
     })
+
+    const receivedAfterRearm = received.length
+    childSubscriptions[0].callback(new Error('late error from replaced watcher'), [])
+    childSubscriptions[0].callback(null, [
+      { type: 'create', path: join(worktreesDir, 'late-old-event') }
+    ])
+    childSubscriptions[0].hooks.onInterruption?.()
+
+    // A replaced watch cannot tear down its successor or report stale events.
+    expect(received).toHaveLength(receivedAfterRearm)
+    expect(childSubscriptions[1].unsubscribe).not.toHaveBeenCalled()
   })
 
   it('reports a structural change after a watcher-child interruption', async () => {

--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, mkdir, realpath, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { subscribeViaWatcherProcess } from './parcel-watcher-process'
+import type {
+  WatcherProcessCallback,
+  WatcherProcessHooks
+} from './parcel-watcher-process-subscription'
+import type { WorktreeBaseWatchTarget } from './worktree-base-directory-event-filter'
+import type { WorktreeBasePollEvent } from './worktree-base-directory-poller'
+import { startGitCommonWatch } from './worktree-git-common-watch'
+
+vi.mock('./parcel-watcher-process', () => ({
+  subscribeViaWatcherProcess: vi.fn()
+}))
+
+const POLL_MS = 25
+
+type ChildSubscription = {
+  dir: string
+  callback: WatcherProcessCallback
+  hooks: WatcherProcessHooks
+  unsubscribe: ReturnType<typeof vi.fn>
+}
+
+describe('worktree git-common narrow watch (darwin)', () => {
+  const cleanups: (() => Promise<void>)[] = []
+  const subscribeMock = vi.mocked(subscribeViaWatcherProcess)
+  let childSubscriptions: ChildSubscription[] = []
+
+  afterEach(async () => {
+    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+    childSubscriptions = []
+    subscribeMock.mockReset()
+  })
+
+  function installSubscribeMock(): void {
+    subscribeMock.mockImplementation(async (dir, callback, _opts, hooks = {}) => {
+      const unsubscribe = vi.fn(async () => {})
+      childSubscriptions.push({ dir, callback, hooks, unsubscribe })
+      return { unsubscribe }
+    })
+  }
+
+  async function makeCommonDir(withWorktrees: boolean): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'orca-git-common-watch-'))
+    cleanups.push(() => rm(root, { recursive: true, force: true }))
+    const commonDir = await realpath(root)
+    if (withWorktrees) {
+      await mkdir(join(commonDir, 'worktrees'))
+    }
+    return commonDir
+  }
+
+  function makeTarget(path: string): WorktreeBaseWatchTarget {
+    return {
+      key: `git-common:local:${path}`,
+      kind: 'git-common',
+      path,
+      repos: new Map([['repo-1', { repoId: 'repo-1', repoName: 'project', nestWorkspaces: false }]])
+    }
+  }
+
+  async function startWatch(commonDir: string, received: WorktreeBasePollEvent[][]): Promise<void> {
+    const watch = await startGitCommonWatch(
+      makeTarget(commonDir),
+      (events) => received.push(events),
+      POLL_MS,
+      'darwin'
+    )
+    cleanups.push(() => watch.unsubscribe())
+  }
+
+  it('hosts the narrow stream in the watcher child, not in-process', async () => {
+    installSubscribeMock()
+    const commonDir = await makeCommonDir(true)
+    const received: WorktreeBasePollEvent[][] = []
+    await startWatch(commonDir, received)
+
+    expect(subscribeMock).toHaveBeenCalledTimes(1)
+    const [dir, , opts] = subscribeMock.mock.calls[0]
+    expect(dir).toBe(join(commonDir, 'worktrees'))
+    expect(opts).toEqual({})
+
+    const entryPath = join(commonDir, 'worktrees', 'wt-a')
+    childSubscriptions[0].callback(null, [{ type: 'create', path: entryPath }])
+    expect(received.flat()).toContainEqual({ type: 'create', path: entryPath })
+  })
+
+  it('tears down and re-arms when the watched root is deleted', async () => {
+    installSubscribeMock()
+    const commonDir = await makeCommonDir(true)
+    const worktreesDir = join(commonDir, 'worktrees')
+    const received: WorktreeBasePollEvent[][] = []
+    await startWatch(commonDir, received)
+
+    await rm(worktreesDir, { recursive: true, force: true })
+    childSubscriptions[0].callback(null, [{ type: 'delete', path: worktreesDir }])
+    await vi.waitFor(() => {
+      expect(childSubscriptions[0].unsubscribe).toHaveBeenCalledTimes(1)
+    })
+    expect(received.flat()).toContainEqual({ type: 'delete', path: worktreesDir })
+
+    // The existence poll re-subscribes once a new first worktree recreates it.
+    await mkdir(worktreesDir)
+    await vi.waitFor(() => {
+      expect(subscribeMock).toHaveBeenCalledTimes(2)
+    })
+    expect(received.flat()).toContainEqual({ type: 'create', path: worktreesDir })
+  })
+
+  it('tears down and re-arms on watcher errors', async () => {
+    installSubscribeMock()
+    const commonDir = await makeCommonDir(true)
+    const worktreesDir = join(commonDir, 'worktrees')
+    const received: WorktreeBasePollEvent[][] = []
+    await startWatch(commonDir, received)
+
+    childSubscriptions[0].callback(new Error('watcher child reported failure'), [])
+    await vi.waitFor(() => {
+      expect(childSubscriptions[0].unsubscribe).toHaveBeenCalledTimes(1)
+    })
+    // The error is surfaced as a structural change so worktrees re-sync.
+    expect(received.flat()).toContainEqual({ type: 'update', path: worktreesDir })
+
+    // The dir still exists, so the existence poll re-subscribes.
+    await vi.waitFor(() => {
+      expect(subscribeMock).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('reports a structural change after a watcher-child interruption', async () => {
+    installSubscribeMock()
+    const commonDir = await makeCommonDir(true)
+    const worktreesDir = join(commonDir, 'worktrees')
+    const received: WorktreeBasePollEvent[][] = []
+    await startWatch(commonDir, received)
+
+    childSubscriptions[0].hooks.onInterruption?.()
+    expect(received.flat()).toContainEqual({ type: 'update', path: worktreesDir })
+    // The supervisor resubscribed the same record; no teardown should happen.
+    expect(childSubscriptions[0].unsubscribe).not.toHaveBeenCalled()
+  })
+
+  it('arms via existence polling when the worktrees dir appears later', async () => {
+    installSubscribeMock()
+    const commonDir = await makeCommonDir(false)
+    const received: WorktreeBasePollEvent[][] = []
+    await startWatch(commonDir, received)
+    expect(subscribeMock).not.toHaveBeenCalled()
+
+    await mkdir(join(commonDir, 'worktrees'))
+    await vi.waitFor(() => {
+      expect(subscribeMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('stops forwarding events and unsubscribes the child on dispose', async () => {
+    installSubscribeMock()
+    const commonDir = await makeCommonDir(true)
+    const received: WorktreeBasePollEvent[][] = []
+    const watch = await startGitCommonWatch(
+      makeTarget(commonDir),
+      (events) => received.push(events),
+      POLL_MS,
+      'darwin'
+    )
+    await watch.unsubscribe()
+    expect(childSubscriptions[0].unsubscribe).toHaveBeenCalledTimes(1)
+
+    received.length = 0
+    childSubscriptions[0].callback(null, [
+      { type: 'create', path: join(commonDir, 'worktrees', 'late') }
+    ])
+    expect(received).toHaveLength(0)
+  })
+})

--- a/src/main/ipc/worktree-git-common-watch.ts
+++ b/src/main/ipc/worktree-git-common-watch.ts
@@ -1,5 +1,6 @@
 import { stat } from 'node:fs/promises'
 import { join } from 'node:path'
+import { subscribeViaWatcherProcess } from './parcel-watcher-process'
 import type { WorktreeBaseWatchTarget } from './worktree-base-directory-event-filter'
 import type {
   WorktreeBasePollEvent,
@@ -20,6 +21,10 @@ import {
 // included). Other platforms: dir-listing poll (no fseventsd to protect, and
 // on Windows an open directory handle on `worktrees/` could interfere with
 // `git worktree prune` removing it).
+// The native stream is hosted in the crash-isolated watcher child, never the
+// Electron main process: watcher.node teardown races heap-corrupt the hosting
+// process when unsubscribe overlaps in-flight callbacks (issue #8732), and
+// root deletion via `git worktree prune` makes that overlap routine here.
 
 // Why: branch switches and commits made in the primary checkout rewrite these
 // top-level files (linked-worktree equivalents live under `worktrees/`).
@@ -172,26 +177,38 @@ async function startGitCommonNarrowWatch(
       armExistencePoll()
     }
     try {
-      const watcher = await import('@parcel/watcher')
-      const sub = await watcher.subscribe(worktreesDir, (error, events) => {
-        if (disposed) {
-          return
-        }
-        if (error) {
-          onEvents([{ type: 'update', path: worktreesDir }])
-          teardownAndRearm()
-          return
-        }
-        if (events.length > 0) {
-          const rootGone = events.some(
-            (event) => event.type === 'delete' && event.path === worktreesDir
-          )
-          onEvents(events.map((event) => ({ type: event.type, path: event.path })))
-          if (rootGone) {
+      const sub = await subscribeViaWatcherProcess(
+        worktreesDir,
+        (error, events) => {
+          if (disposed) {
+            return
+          }
+          if (error) {
+            onEvents([{ type: 'update', path: worktreesDir }])
             teardownAndRearm()
+            return
+          }
+          if (events.length > 0) {
+            const rootGone = events.some(
+              (event) => event.type === 'delete' && event.path === worktreesDir
+            )
+            onEvents(events.map((event) => ({ type: event.type, path: event.path })))
+            if (rootGone) {
+              teardownAndRearm()
+            }
+          }
+        },
+        {},
+        {
+          // Why: a watcher-child crash drops events during the automatic
+          // resubscribe gap; report a structural change so worktrees re-sync.
+          onInterruption: () => {
+            if (!disposed) {
+              onEvents([{ type: 'update', path: worktreesDir }])
+            }
           }
         }
-      })
+      )
       if (disposed || errored) {
         void sub.unsubscribe().catch(() => {})
         return !errored

--- a/src/main/ipc/worktree-git-common-watch.ts
+++ b/src/main/ipc/worktree-git-common-watch.ts
@@ -162,12 +162,14 @@ async function startGitCommonNarrowWatch(
       return false
     }
     let errored = false
+    let active = true
     // Why: parcel tears its native stream down when the watched root is
     // deleted (e.g. `git worktree prune` removing an empty worktrees dir) —
     // sometimes surfaced as an error, sometimes as a delete event for the
     // root. Either way: notify, drop the dead stream, and let the existence
     // poll re-arm when a future worktree add recreates the dir.
     const teardownAndRearm = (): void => {
+      active = false
       errored = true
       const current = subscription
       subscription = null
@@ -180,7 +182,7 @@ async function startGitCommonNarrowWatch(
       const sub = await subscribeViaWatcherProcess(
         worktreesDir,
         (error, events) => {
-          if (disposed) {
+          if (disposed || !active) {
             return
           }
           if (error) {
@@ -203,7 +205,7 @@ async function startGitCommonNarrowWatch(
           // Why: a watcher-child crash drops events during the automatic
           // resubscribe gap; report a structural change so worktrees re-sync.
           onInterruption: () => {
-            if (!disposed) {
+            if (!disposed && active) {
               onEvents([{ type: 'update', path: worktreesDir }])
             }
           }


### PR DESCRIPTION
Fixes #8732

## Root cause

The P0 macOS app crash in #8732 (`EXC_BREAKPOINT`/`brk 0` on the FSEvents thread, trapped while allocating inside `Watcher::isIgnored`) is heap corruption from data races inside `@parcel/watcher` 2.5.6's FSEvents backend. Verified with a ThreadSanitizer build of `watcher.node`, which flags the races within ~40 subscribe/write-burst/delete-root/unsubscribe iterations:

- `FSEventsBackend::unsubscribe` writes `watcher->state = nullptr` (`FSEventsBackend.cc:336`) with no synchronization against the FSEvents callback thread's `shared_ptr` copy of that same field (`cc:60`/`cc:64`) → control-block double-free → the next allocation on the FSEvents thread traps (the exact crashed frame).
- `startStream` starts delivering events (`cc:250`) before `state->tree` is assigned (`cc:262`).
- When the watched root is deleted, the callback thread itself calls `stopStream` (`cc:189-192`), racing a concurrent unsubscribe → double `FSEventStreamRelease`.

No fixed upstream release exists (2.5.6 is latest; this crash class is a long-standing open upstream issue).

Every other native watch already runs in the crash-isolated forked watcher child (#7547/#7757) precisely because of this failure class. The one exception was the darwin-only `.git/worktrees` narrow stream in `worktree-git-common-watch.ts`, which still called `watcher.subscribe()` in the Electron main process — and its own teardown flow (`teardownAndRearm` on `git worktree prune` deleting an empty `worktrees` dir, plus existence-poll re-subscribe) routinely exercises exactly the raciest paths. The crash report confirms the main process: thread 0 is `CrBrowserMain` and `watcher.node` is in the crashed process's binary images. With agents running, worktree add/prune churn made this a background-time app killer.

## Fix

Route the narrow stream through the existing `subscribeViaWatcherProcess` supervisor:

- Callback shape, root-deletion teardown/re-arm, and existence-poll semantics are unchanged.
- `onInterruption` (watcher-child crash → automatic resubscribe) now reports a structural change so the worktree list re-syncs across the event gap.
- Terminal child failures surface through the same error branch that already tears down and re-arms.
- Under Vitest the supervisor's in-process fallback keeps the existing darwin narrow-stream integration tests exercising real FSEvents.

A native watcher fault in this path is now a contained child crash with existing restart machinery (#8661) instead of main-process heap corruption.

## Verification

- New unit suite `worktree-git-common-watch.test.ts`: child routing, event forwarding, root-deletion teardown + existence-poll re-subscribe, error teardown/re-arm, interruption re-sync, dispose hygiene.
- Existing darwin narrow-stream integration tests (`worktree-base-directory-poller.test.ts`) pass through the new routing against real FSEvents; 24 watcher-adjacent test files (217 tests) pass; `typecheck:node` clean.
- Live A/B on macOS: production Orca main process has `watcher.node` mapped (`lsof`); a dev build with this fix has zero `watcher.node` in the main process while the forked watcher child hosts it.
- Live end-to-end: with a worktree created *outside* any watched workspace base dir (so only the `.git/worktrees` stream can see it), external `git worktree add`/`remove` produced `worktrees:changed` in the renderer in ~240–320 ms — far below the 2 s poll interval, proving detection came from the child-hosted native stream.