### PR TITLE
fix(remote): recover runtime streams after client wake

### DIFF
--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -1453,6 +1453,147 @@ describe('createRemoteRuntimePtyTransport', () => {
     await vi.waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(2))
   })
 
+  it('retries a transient wake failure without surfacing a PTY error', async () => {
+    let subscribeAttempt = 0
+    const transportCallbacks: NonNullable<typeof subscriptionCallbacks>[] = []
+    runtimeSubscribe.mockImplementation(
+      async (_args: unknown, callbacks: NonNullable<typeof subscriptionCallbacks>) => {
+        subscribeAttempt += 1
+        transportCallbacks.push(callbacks)
+        subscriptionCallbacks = callbacks
+        if (subscribeAttempt === 2) {
+          throw new Error('Could not connect to the remote Orca runtime.')
+        }
+        queueMicrotask(emitMultiplexReady)
+        return { unsubscribe: vi.fn(), sendBinary: subscriptionSendBinary }
+      }
+    )
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onError = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1'
+    })
+
+    await transport.connect({ url: '', callbacks: { onError } })
+    transportCallbacks[0].onError?.({
+      code: 'remote_runtime_unavailable',
+      message: 'Remote Orca runtime stopped responding; the stream connection was reset.'
+    })
+
+    await vi.waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(3))
+    expect(onError).not.toHaveBeenCalled()
+    transport.destroy?.()
+  })
+
+  it('retries a restored pane when the runtime is still unavailable', async () => {
+    let subscribeAttempt = 0
+    runtimeSubscribe.mockImplementation(
+      async (_args: unknown, callbacks: NonNullable<typeof subscriptionCallbacks>) => {
+        subscribeAttempt += 1
+        subscriptionCallbacks = callbacks
+        if (subscribeAttempt === 1) {
+          throw new Error('Could not connect to the remote Orca runtime.')
+        }
+        queueMicrotask(emitMultiplexReady)
+        return { unsubscribe: vi.fn(), sendBinary: subscriptionSendBinary }
+      }
+    )
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onError = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1'
+    })
+
+    transport.attach({
+      existingPtyId: 'remote:terminal-1',
+      callbacks: { onError }
+    })
+
+    await vi.waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(2))
+    expect(onError).not.toHaveBeenCalled()
+    transport.destroy?.()
+  })
+
+  it('does not let a stale reconnect rearm retries after reattach', async () => {
+    let rejectStaleReconnect = (_error: Error): void => {}
+    const transportCallbacks: NonNullable<typeof subscriptionCallbacks>[] = []
+    runtimeSubscribe.mockImplementation(
+      async (_args: unknown, callbacks: NonNullable<typeof subscriptionCallbacks>) => {
+        transportCallbacks.push(callbacks)
+        subscriptionCallbacks = callbacks
+        if (transportCallbacks.length === 2) {
+          return await new Promise((_, reject) => {
+            rejectStaleReconnect = reject
+          })
+        }
+        queueMicrotask(emitMultiplexReady)
+        return { unsubscribe: vi.fn(), sendBinary: subscriptionSendBinary }
+      }
+    )
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onError = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1'
+    })
+
+    await transport.connect({ url: '', callbacks: { onError } })
+    transportCallbacks[0].onClose?.()
+    await vi.waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(2))
+    transport.detach?.()
+    transport.attach({ existingPtyId: 'remote:terminal-1', callbacks: { onError } })
+    await vi.waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(3))
+
+    rejectStaleReconnect(new Error('Could not connect to the remote Orca runtime.'))
+    await new Promise((resolve) => setTimeout(resolve, 350))
+
+    expect(runtimeSubscribe).toHaveBeenCalledTimes(3)
+    expect(onError).not.toHaveBeenCalled()
+    transport.destroy?.()
+  })
+
+  it('does not let a stale same-handle attach rearm retries after reattach', async () => {
+    let rejectStaleAttach = (_error: Error): void => {}
+    runtimeSubscribe.mockImplementation(
+      async (_args: unknown, callbacks: NonNullable<typeof subscriptionCallbacks>) => {
+        subscriptionCallbacks = callbacks
+        if (runtimeSubscribe.mock.calls.length === 1) {
+          return await new Promise((_, reject) => {
+            rejectStaleAttach = reject
+          })
+        }
+        queueMicrotask(emitMultiplexReady)
+        return { unsubscribe: vi.fn(), sendBinary: subscriptionSendBinary }
+      }
+    )
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onError = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1'
+    })
+
+    transport.attach({ existingPtyId: 'remote:terminal-1', callbacks: { onError } })
+    await vi.waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(1))
+    transport.detach?.()
+    transport.attach({ existingPtyId: 'remote:terminal-1', callbacks: { onError } })
+    expect(runtimeSubscribe).toHaveBeenCalledTimes(1)
+
+    rejectStaleAttach(new Error('Could not connect to the remote Orca runtime.'))
+    await vi.waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(2))
+    await new Promise((resolve) => setTimeout(resolve, 350))
+
+    expect(runtimeSubscribe).toHaveBeenCalledTimes(2)
+    expect(onError).not.toHaveBeenCalled()
+    transport.destroy?.()
+  })
+
   it('releases pending claimed input when reconnect subscription fails', async () => {
     const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
     const onError = vi.fn()

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -1518,6 +1518,40 @@ describe('createRemoteRuntimePtyTransport', () => {
     transport.destroy?.()
   })
 
+  it('retries when recoverable transport error arrives before multiplex ready', async () => {
+    let subscribeAttempt = 0
+    runtimeSubscribe.mockImplementation(
+      async (_args: unknown, callbacks: NonNullable<typeof subscriptionCallbacks>) => {
+        subscribeAttempt += 1
+        subscriptionCallbacks = callbacks
+        if (subscribeAttempt === 1) {
+          queueMicrotask(() =>
+            callbacks.onError?.({
+              code: 'remote_runtime_unavailable',
+              message: 'Remote Orca runtime stopped responding; the stream connection was reset.'
+            })
+          )
+        } else {
+          queueMicrotask(emitMultiplexReady)
+        }
+        return { unsubscribe: vi.fn(), sendBinary: subscriptionSendBinary }
+      }
+    )
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onError = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1'
+    })
+
+    transport.attach({ existingPtyId: 'remote:terminal-1', callbacks: { onError } })
+
+    await vi.waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(2))
+    expect(onError).not.toHaveBeenCalled()
+    transport.destroy?.()
+  })
+
   it('does not let a stale reconnect rearm retries after reattach', async () => {
     let rejectStaleReconnect = (_error: Error): void => {}
     const transportCallbacks: NonNullable<typeof subscriptionCallbacks>[] = []

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -16,6 +16,7 @@ import { unwrapRuntimeRpcResult } from '../../runtime/runtime-rpc-client'
 import {
   getRemoteRuntimePtyEnvironmentId,
   getRemoteRuntimeTerminalHandle,
+  isRecoverableRuntimeTransportError,
   runtimeTerminalErrorMessage,
   toRemoteRuntimePtyId
 } from '../../runtime/runtime-terminal-stream'
@@ -41,6 +42,7 @@ const REMOTE_TERMINAL_INPUT_FLUSH_MS = 8
 const REMOTE_TERMINAL_VIEWPORT_FLUSH_MS = 33
 const HOST_SESSION_ATTACH_POLL_MS = 150
 const HOST_SESSION_ATTACH_TIMEOUT_MS = 15_000
+const REMOTE_TERMINAL_RESUBSCRIBE_DELAYS_MS = [250, 500, 1000, 2000, 4000, 8000, 15_000]
 
 function isRemoteTerminalGoneMessage(message: string): boolean {
   return (
@@ -91,6 +93,9 @@ export function createRemoteRuntimePtyTransport(
   let storedCallbacks: Parameters<PtyTransport['connect']>[0]['callbacks'] = {}
   let resubscribing = false
   let resubscribeRequested = false
+  let resubscribeRetryAttempt = 0
+  let resubscribeRetryTimer: ReturnType<typeof setTimeout> | null = null
+  let resubscribeCycle = 0
   let subscriptionGeneration = 0
   let pendingViewportClaim = false
   let pendingClaimInput = ''
@@ -404,6 +409,7 @@ export function createRemoteRuntimePtyTransport(
 
   function retireRemoteTerminalId(): void {
     connected = false
+    stopResubscribeRetries()
     clearPendingViewportClaim()
     const stalePtyId = remotePtyId
     handle = null
@@ -416,6 +422,11 @@ export function createRemoteRuntimePtyTransport(
 
   function handleRemoteTerminalError(error: unknown): void {
     const message = runtimeTerminalErrorMessage(error)
+    if (isRecoverableRuntimeTransportError(error)) {
+      // Why: the liveness path owns recovery; transient sleep/network gaps are
+      // not terminal failures and must not leave a red banner in the PTY.
+      return
+    }
     if (message === REMOTE_TERMINAL_SNAPSHOT_TOO_LARGE) {
       // Why: an oversized initial snapshot is skipped but live output keeps
       // flowing — informational, not fatal, so never surface a red xterm banner.
@@ -435,10 +446,16 @@ export function createRemoteRuntimePtyTransport(
   // handle (reconnect, epoch or PTY change). Re-derive it from the current
   // session snapshot instead of resubscribing the stale closure value, which
   // would mirror (and type into) whatever PTY now sits behind it (#7718).
-  async function resubscribeAfterTransportClose(previousHandle: string): Promise<void> {
+  async function resubscribeAfterTransportClose(
+    previousHandle: string,
+    cycle: number
+  ): Promise<void> {
+    if (cycle !== resubscribeCycle) {
+      return
+    }
     if (tabId && isWebTerminalSurfaceTabId(tabId)) {
       const nextHandle = await listHostSessionHandle(toHostSessionTabId(tabId))
-      if (destroyed || !connected || handle !== previousHandle) {
+      if (cycle !== resubscribeCycle || destroyed || !connected || handle !== previousHandle) {
         return
       }
       if (!nextHandle) {
@@ -453,7 +470,37 @@ export function createRemoteRuntimePtyTransport(
         onPtySpawn?.(remotePtyId)
       }
     }
+    if (cycle !== resubscribeCycle) {
+      return
+    }
     await subscribeToHandle()
+  }
+
+  function stopResubscribeRetries(): void {
+    resubscribeCycle += 1
+    if (resubscribeRetryTimer) {
+      clearTimeout(resubscribeRetryTimer)
+      resubscribeRetryTimer = null
+    }
+    resubscribeRetryAttempt = 0
+    resubscribeRequested = false
+    resubscribing = false
+  }
+
+  function scheduleResubscribeRetry(): void {
+    if (resubscribeRetryTimer || destroyed || !connected || !handle) {
+      return
+    }
+    const delay =
+      REMOTE_TERMINAL_RESUBSCRIBE_DELAYS_MS[
+        Math.min(resubscribeRetryAttempt, REMOTE_TERMINAL_RESUBSCRIBE_DELAYS_MS.length - 1)
+      ]
+    resubscribeRetryAttempt += 1
+    resubscribeRequested = false
+    resubscribeRetryTimer = setTimeout(() => {
+      resubscribeRetryTimer = null
+      scheduleResubscribeAfterTransportClose()
+    }, delay)
   }
 
   function scheduleResubscribeAfterTransportClose(): void {
@@ -464,18 +511,36 @@ export function createRemoteRuntimePtyTransport(
       resubscribeRequested = true
       return
     }
+    if (resubscribeRetryTimer) {
+      return
+    }
     resubscribing = true
+    const cycle = resubscribeCycle
     const resubscribeHandle = handle
-    void resubscribeAfterTransportClose(resubscribeHandle)
+    void resubscribeAfterTransportClose(resubscribeHandle, cycle)
+      .then(() => {
+        if (cycle === resubscribeCycle) {
+          resubscribeRetryAttempt = 0
+        }
+      })
       .catch((error) => {
-        if (!destroyed && connected && handle) {
+        if (cycle === resubscribeCycle && !destroyed && connected && handle) {
           clearPendingViewportClaim()
-          handleRemoteTerminalError(error)
+          if (isRecoverableRuntimeTransportError(error)) {
+            // Why: Tailscale/Wi-Fi can lag behind wake. Keep the pane alive and
+            // retry at a capped cadence until the runtime is reachable again.
+            scheduleResubscribeRetry()
+          } else {
+            handleRemoteTerminalError(error)
+          }
         }
       })
       .finally(() => {
+        if (cycle !== resubscribeCycle) {
+          return
+        }
         resubscribing = false
-        if (resubscribeRequested) {
+        if (resubscribeRequested && !resubscribeRetryTimer) {
           resubscribeRequested = false
           scheduleResubscribeAfterTransportClose()
         }
@@ -537,6 +602,7 @@ export function createRemoteRuntimePtyTransport(
           }
           outputProcessor.clearAccumulatedState()
           connected = false
+          stopResubscribeRetries()
           handle = null
           remotePtyId = null
           multiplexedStream = null
@@ -688,6 +754,8 @@ export function createRemoteRuntimePtyTransport(
     },
 
     attach(options) {
+      stopResubscribeRetries()
+      const attachCycle = resubscribeCycle
       storedCallbacks = options.callbacks
       currentRuntimeEnvironmentId =
         getRemoteRuntimePtyEnvironmentId(options.existingPtyId) ?? runtimeEnvironmentId
@@ -716,14 +784,21 @@ export function createRemoteRuntimePtyTransport(
       const targetHandle = handle
       const targetPtyId = remotePtyId
       void subscribeToHandle().catch((error) => {
-        if (!isCurrentRemoteTerminal(targetHandle, targetPtyId)) {
+        if (
+          attachCycle !== resubscribeCycle ||
+          !isCurrentRemoteTerminal(targetHandle, targetPtyId)
+        ) {
           return
         }
         if (handle === targetHandle && multiplexedStreamHandle !== targetHandle) {
           closeMultiplexedStream()
         }
         clearPendingViewportClaim()
-        handleRemoteTerminalError(error)
+        if (isRecoverableRuntimeTransportError(error)) {
+          scheduleResubscribeAfterTransportClose()
+        } else {
+          handleRemoteTerminalError(error)
+        }
       })
     },
 
@@ -732,6 +807,7 @@ export function createRemoteRuntimePtyTransport(
       inputBatcher.clear()
       viewportBatcher.flush()
       outputProcessor.clearAccumulatedState()
+      stopResubscribeRetries()
       if (!connected && !handle) {
         return
       }
@@ -752,6 +828,7 @@ export function createRemoteRuntimePtyTransport(
       inputBatcher.clear()
       viewportBatcher.flush()
       outputProcessor.clearAccumulatedState()
+      stopResubscribeRetries()
       connected = false
       clearPendingViewportClaim()
       closeMultiplexedStream()

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -783,9 +783,12 @@ export function createRemoteRuntimePtyTransport(
       }
       const targetHandle = handle
       const targetPtyId = remotePtyId
-      void subscribeToHandle().catch((error) => {
+      const attachSubscription = subscribeToHandle()
+      const attachSubscriptionGeneration = subscriptionGeneration
+      void attachSubscription.catch((error) => {
         if (
           attachCycle !== resubscribeCycle ||
+          attachSubscriptionGeneration !== subscriptionGeneration ||
           !isCurrentRemoteTerminal(targetHandle, targetPtyId)
         ) {
           return

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
@@ -340,7 +340,15 @@ class RemoteRuntimeTerminalMultiplexer {
           {
             onResponse: (response) => this.handleResponse(response),
             onBinary: (bytes) => this.handleBinary(bytes),
-            onError: (error) => this.failConnection(new Error(error.message)),
+            onError: (error) => {
+              if (error.code === 'remote_runtime_unavailable' || error.code === 'runtime_timeout') {
+                // Why: liveness/network failures are followed by a terminal close;
+                // drive recovery without painting a fatal PTY error first.
+                this.handleClose()
+                return
+              }
+              this.failConnection(new Error(error.message))
+            },
             onClose: () => this.handleClose('Remote Orca runtime closed the connection.')
           }
         )

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
@@ -344,7 +344,7 @@ class RemoteRuntimeTerminalMultiplexer {
               if (error.code === 'remote_runtime_unavailable' || error.code === 'runtime_timeout') {
                 // Why: liveness/network failures are followed by a terminal close;
                 // drive recovery without painting a fatal PTY error first.
-                this.handleClose()
+                this.handleClose(error.message)
                 return
               }
               this.failConnection(new Error(error.message))

--- a/src/renderer/src/runtime/runtime-terminal-stream.ts
+++ b/src/renderer/src/runtime/runtime-terminal-stream.ts
@@ -52,6 +52,28 @@ export function runtimeTerminalErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+export function isRecoverableRuntimeTransportError(error: unknown): boolean {
+  const code =
+    error instanceof RuntimeRpcCallError
+      ? error.code
+      : typeof error === 'object' && error !== null && 'code' in error
+        ? (error as { code?: unknown }).code
+        : null
+  if (code === 'remote_runtime_unavailable' || code === 'runtime_timeout') {
+    return true
+  }
+  const message = runtimeTerminalErrorMessage(error).toLowerCase()
+  return (
+    message.includes('remote orca runtime stopped responding') ||
+    message.includes('could not connect to the remote orca runtime') ||
+    message.includes('remote orca runtime closed the connection') ||
+    message.includes('timed out waiting for the remote orca runtime') ||
+    message.includes('remote orca runtime connection could not be restored') ||
+    message.includes('stream connection was reset') ||
+    message.includes('resetting the control connection')
+  )
+}
+
 export async function subscribeToRuntimeTerminalData(
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
   ptyId: string,

--- a/src/shared/remote-runtime-shared-control-connection.test.ts
+++ b/src/shared/remote-runtime-shared-control-connection.test.ts
@@ -191,7 +191,7 @@ describe('RemoteRuntimeSharedControlConnection', () => {
     connection.close()
   })
 
-  it('emits one final close when reconnect attempts are exhausted', async () => {
+  it('keeps passive subscriptions alive after reaching the capped reconnect delay', async () => {
     const server = await createServer()
     const connection = new RemoteRuntimeSharedControlConnection(server.pairing)
     const onClose = vi.fn()
@@ -215,11 +215,11 @@ describe('RemoteRuntimeSharedControlConnection', () => {
 
     unsafe.scheduleReconnect()
 
-    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onClose).not.toHaveBeenCalled()
     expect(connection.getDiagnostics()).toMatchObject({
-      state: 'closed',
-      reconnectAttempt: 7,
-      subscriptionCount: 0
+      state: 'reconnecting',
+      reconnectAttempt: 8,
+      subscriptionCount: 1
     })
 
     connection.close()

--- a/src/shared/remote-runtime-shared-control-connection.ts
+++ b/src/shared/remote-runtime-shared-control-connection.ts
@@ -10,7 +10,7 @@ import {
   isSharedControlReady,
   waitForSharedControlReadyWithTimeout
 } from './remote-runtime-shared-control-ready'
-import { scheduleSharedControlReconnectOrFinish } from './remote-runtime-shared-control-reconnect'
+import { scheduleSharedControlReconnectUntilClosed } from './remote-runtime-shared-control-reconnect'
 import { requestSharedControl } from './remote-runtime-shared-control-requests'
 import { SharedControlReadyStableResetTimer } from './remote-runtime-shared-control-stability'
 import * as sharedControlState from './remote-runtime-shared-control-state'
@@ -286,12 +286,11 @@ export class RemoteRuntimeSharedControlConnection {
   }
 
   private scheduleReconnect(): void {
-    const scheduled = scheduleSharedControlReconnectOrFinish({
+    const scheduled = scheduleSharedControlReconnectUntilClosed({
       current: this.reconnectTimer,
       intentionallyClosed: this.intentionallyClosed,
       reconnectAttempt: this.reconnectAttempt,
       delaysMs: [250, 500, 1000, 2000, 4000, 8000, 15_000],
-      subscriptions: this.subscriptions,
       open: () => {
         this.reconnectTimer = null
         this.open()

--- a/src/shared/remote-runtime-shared-control-reconnect.ts
+++ b/src/shared/remote-runtime-shared-control-reconnect.ts
@@ -1,26 +1,13 @@
-import { remoteRuntimeUnavailableError } from './remote-runtime-request-frames'
-import {
-  finishSharedControlSubscription,
-  scheduleSharedControlReconnect
-} from './remote-runtime-shared-control-state'
-import type { SharedControlLogicalSubscription } from './remote-runtime-shared-control-types'
+import { scheduleSharedControlReconnect } from './remote-runtime-shared-control-state'
 
-export function scheduleSharedControlReconnectOrFinish(args: {
+export function scheduleSharedControlReconnectUntilClosed(args: {
   current: ReturnType<typeof setTimeout> | null
   intentionallyClosed: boolean
   reconnectAttempt: number
   delaysMs: readonly number[]
-  subscriptions: Map<string, SharedControlLogicalSubscription<unknown>>
   open: () => void
 }): { timer: ReturnType<typeof setTimeout> | null; reconnectAttempt: number } {
-  if (args.reconnectAttempt >= args.delaysMs.length) {
-    const error = remoteRuntimeUnavailableError(
-      'Remote Orca runtime connection could not be restored.'
-    )
-    for (const subscription of Array.from(args.subscriptions.values())) {
-      finishSharedControlSubscription(args.subscriptions, subscription, true, error)
-    }
-    return { timer: null, reconnectAttempt: args.reconnectAttempt }
-  }
+  // Why: laptops can remain asleep or offline indefinitely. Passive subscriptions
+  // must survive that gap and retry at the capped delay until explicitly closed.
   return scheduleSharedControlReconnect(args)
 }


### PR DESCRIPTION
Fixes #9092

## Summary

- Keep shared-control subscriptions reconnecting indefinitely, with the existing delay capped at 15 seconds, instead of permanently closing them after seven attempts.
- Treat dedicated terminal stream availability failures as recoverable transport closes and retry resubscription while Tailscale or Wi-Fi restores the route.
- Suppress only known transient transport errors from the PTY error surface.
- Invalidate in-flight reconnect and attach work across detach, reattach, retire, disconnect, and destroy lifecycle changes.
- Cover wake failure, restored-pane retry, pre-ready transport failure, repeated replacement closes, and same-handle stale async races.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- 90 focused Vitest tests passed.
- Full Node, CLI, and web TypeScript checks passed on Node 24.
- Oxlint, type-aware switch lint, oxfmt, max-lines ratchet, reliability gates, and `git diff --check` passed for the changed surface.
- The full test suite reached 30,859 passing and 110 skipped tests; one unrelated environment-specific assertion failed in `src/relay/git-handler.test.ts` because this host Git returns `Stopping at filesystem boundary` where the test expects `not a git repository`.
- Full lint reaches an unrelated existing switch-exhaustiveness error in `src/renderer/src/components/skills/skill-freshness-group.tsx:101`.
- Build was not run.

## AI Review Report

The review focused on reconnect timer ownership, terminal lifecycle transitions, stale async completions, duplicate subscriptions, and explicit-close cancellation. It initially found stale retry races across detach/reattach and replacement stream closes; the implementation added cycle/generation guards and regression coverage. CodeRabbit then identified that a recoverable error arriving before multiplex readiness could be converted into a generic close and stop the initial attach retry. Commit `28ded1af4` preserves the transport error message, prevents the original attach rejection from scheduling a duplicate retry, and adds a regression test for that ordering.

The review explicitly checked macOS, Linux, and Windows compatibility, including shortcuts, labels, paths, shell behavior, and Electron-specific differences. This change is transport-level: it adds no shortcuts, labels, paths, shell commands, or platform-specific Electron behavior, and uses existing cross-platform timer and IPC abstractions. The SSH use case was included alongside native and Tailscale-backed remote runtimes.

## Security Audit

The change introduces no new user input, command execution, path handling, authentication, secrets, dependencies, or IPC surface. Review covered error-code/message classification, retry bounds, lifecycle cancellation, and whether transport errors or secrets could be newly exposed. Retry delay remains capped at 15 seconds, explicit close/terminal retirement cancels pending work, and no new logging or secret-bearing payloads were added. No security follow-up is currently needed.

## Notes

Recovery applies to native, SSH, and Tailscale-backed remote runtimes. Explicit close and terminal retirement still stop retries. The unchecked global lint and test boxes are documented above; their observed failures are outside this PR's changed surface.

## ELI5

After your laptop sleeps or Wi‑Fi drops, remote terminals and control streams could stop updating permanently. They now keep retrying reconnection so streams recover when the network comes back.
