### PR TITLE
fix(sidebar): dismiss stale agent rows after SSH relay restart (#9030)

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
@@ -50,15 +50,18 @@ function mockAgent({
 let mockAgents: DashboardAgentRowData[] = []
 let mockAgentActivityDisplayMode: 'compact' | 'full' | undefined
 let mockTabsByWorktree: Record<string, { id: string }[]> = {}
-// Why: the activation guard keeps a worktree-attributed row alive only while it
-// is runtime-backed (orchestration context or a terminal handle) — the same
-// hydration signal applyAgentStatus uses for snapshot replay. The mock store
-// entry therefore carries those fields so each test can model either a
-// hydrating orchestration worker or a stale non-runtime-backed row faithfully.
+// Why: the activation guard keeps a worktree-attributed row alive only while
+// the runtime CURRENTLY lists the pane as an orchestration allocation — the
+// live runtimeAgentOrchestrationByPaneKey mirror, not the entry's retained
+// terminalHandle/orchestration strings (those survive an SSH relay restart and
+// would make the row silently unclickable again). The mock store carries both
+// the entry shape and the live mirror so each test can model a hydrating
+// orchestration worker or a stale relay-restart remnant faithfully.
 let mockAgentStatusByPaneKey: Record<
   string,
   { worktreeId?: string; orchestration?: unknown; terminalHandle?: string }
 > = {}
+let mockRuntimeAgentOrchestrationByPaneKey: Record<string, unknown> = {}
 let mockActiveTabId: string | null = null
 let mockActiveTabType: string = 'editor'
 const mockSetActiveTab = vi.fn((tabId: string) => {
@@ -82,6 +85,7 @@ function buildMockStoreState(): Record<string, unknown> {
     acknowledgeAgents: vi.fn(),
     agentSendPopoverTargetMode: null,
     agentStatusByPaneKey: mockAgentStatusByPaneKey,
+    runtimeAgentOrchestrationByPaneKey: mockRuntimeAgentOrchestrationByPaneKey,
     agentStatusEpoch: 0,
     activeTabId: mockActiveTabId,
     activeTabType: mockActiveTabType,
@@ -163,6 +167,7 @@ describe('WorktreeCardAgents activation', () => {
     mockAgentActivityDisplayMode = undefined
     mockTabsByWorktree = {}
     mockAgentStatusByPaneKey = {}
+    mockRuntimeAgentOrchestrationByPaneKey = {}
     mockActiveTabId = null
     mockActiveTabType = 'editor'
     capturedRowActivations = []
@@ -255,12 +260,15 @@ describe('WorktreeCardAgents activation', () => {
         worktreeId: 'wt-1'
       })
     ]
-    // Why: a hydrating orchestration worker is runtime-backed (it carries an
-    // orchestration dispatch context), which is the signal that distinguishes
-    // legitimate mid-spawn hydration from a stale relay-restart remnant.
+    // Why: a hydrating orchestration worker is one the runtime currently lists
+    // as an orchestration allocation (the live runtimeAgentOrchestrationByPaneKey
+    // mirror). That current-allocation signal — not the entry's retained
+    // strings — is what distinguishes legitimate mid-spawn hydration from a
+    // stale relay-restart remnant.
     mockAgentStatusByPaneKey = {
       [paneKey]: { worktreeId: 'wt-1', orchestration: { taskId: 't-1' } }
     }
+    mockRuntimeAgentOrchestrationByPaneKey = { [paneKey]: { taskId: 't-1' } }
     const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
 
     renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
@@ -289,6 +297,7 @@ describe('WorktreeCardAgents activation', () => {
     mockAgentStatusByPaneKey = {
       [paneKey]: { worktreeId: 'wt-1', orchestration: { taskId: 't-1' } }
     }
+    mockRuntimeAgentOrchestrationByPaneKey = { [paneKey]: { taskId: 't-1' } }
     // Why: activation may create/select a different terminal before the
     // automation worker hydrates; the row must only pane-focus its exact tab.
     activationMocks.activateAndRevealWorktree.mockImplementation(() => {
@@ -385,13 +394,20 @@ describe('WorktreeCardAgents activation', () => {
     expect(staleAgentRowMocks.dismissStaleAgentRowByKey).toHaveBeenCalledWith(paneKey)
   })
 
-  it('dismisses a stale relay-restart row whose worktree still matches but has no runtime backing', async () => {
+  it('dismisses a stale SSH relay-restart remnant that still carries a retained terminalHandle', async () => {
     // Regression for issue #9030: after an SSH relay daemon restarts the agent's
     // terminal tab is gone for good, but the renderer-memory status entry still
-    // carries a matching worktreeId and counts as fresh for 30 minutes. The row
-    // must not stay silently unclickable forever. Because the entry lacks runtime
-    // backing (it is a plain terminal agent, not a hydrating orchestration
-    // worker), the click dismisses it with truthful feedback instead of no-op'ing.
+    // carries a matching worktreeId AND a retained terminalHandle (main stamps a
+    // handle for SSH panes via registerPty, and setAgentStatus retains it), so it
+    // counts as fresh for 30 minutes. The row must not stay silently unclickable.
+    // Because the runtime no longer lists the pane as an orchestration allocation
+    // (runtimeAgentOrchestrationByPaneKey is empty — a plain terminal agent is
+    // never in that map, and the live mirror is rebuilt from main's current
+    // state), the click dismisses the row with truthful feedback instead of
+    // trusting the retained terminalHandle string.
+    //
+    // This fails on a1351d33e, whose guard gated on hasRuntimeBackedAttribution
+    // (the retained terminalHandle) and so still kept the row as a silent no-op.
     mockAgentActivityDisplayMode = 'full'
     const tabId = 'relay-restart-tab'
     const paneKey = makePaneKey(tabId, LEAF_A)
@@ -404,10 +420,13 @@ describe('WorktreeCardAgents activation', () => {
         worktreeId: 'wt-1'
       })
     ]
-    // Why: worktreeId matches wt-1 (so the old guard kept it), but there is no
-    // orchestration context and no terminal handle — the row is not a runtime
-    // allocation whose tab is still hydrating.
-    mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-1' } }
+    // Why: realistic SSH remnant shape — worktreeId matches wt-1 AND the entry
+    // retains the non-empty terminalHandle main stamped before the relay died.
+    // runtimeAgentOrchestrationByPaneKey stays empty (default), modelling that
+    // the runtime no longer tracks this pane as a live orchestration allocation.
+    mockAgentStatusByPaneKey = {
+      [paneKey]: { worktreeId: 'wt-1', terminalHandle: 'ssh-term-handle-1' }
+    }
     const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
 
     renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
@@ -50,7 +50,15 @@ function mockAgent({
 let mockAgents: DashboardAgentRowData[] = []
 let mockAgentActivityDisplayMode: 'compact' | 'full' | undefined
 let mockTabsByWorktree: Record<string, { id: string }[]> = {}
-let mockAgentStatusByPaneKey: Record<string, { worktreeId?: string }> = {}
+// Why: the activation guard keeps a worktree-attributed row alive only while it
+// is runtime-backed (orchestration context or a terminal handle) — the same
+// hydration signal applyAgentStatus uses for snapshot replay. The mock store
+// entry therefore carries those fields so each test can model either a
+// hydrating orchestration worker or a stale non-runtime-backed row faithfully.
+let mockAgentStatusByPaneKey: Record<
+  string,
+  { worktreeId?: string; orchestration?: unknown; terminalHandle?: string }
+> = {}
 let mockActiveTabId: string | null = null
 let mockActiveTabType: string = 'editor'
 const mockSetActiveTab = vi.fn((tabId: string) => {
@@ -247,7 +255,12 @@ describe('WorktreeCardAgents activation', () => {
         worktreeId: 'wt-1'
       })
     ]
-    mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-1' } }
+    // Why: a hydrating orchestration worker is runtime-backed (it carries an
+    // orchestration dispatch context), which is the signal that distinguishes
+    // legitimate mid-spawn hydration from a stale relay-restart remnant.
+    mockAgentStatusByPaneKey = {
+      [paneKey]: { worktreeId: 'wt-1', orchestration: { taskId: 't-1' } }
+    }
     const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
 
     renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
@@ -273,7 +286,9 @@ describe('WorktreeCardAgents activation', () => {
         worktreeId: 'wt-1'
       })
     ]
-    mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-1' } }
+    mockAgentStatusByPaneKey = {
+      [paneKey]: { worktreeId: 'wt-1', orchestration: { taskId: 't-1' } }
+    }
     // Why: activation may create/select a different terminal before the
     // automation worker hydrates; the row must only pane-focus its exact tab.
     activationMocks.activateAndRevealWorktree.mockImplementation(() => {
@@ -359,6 +374,40 @@ describe('WorktreeCardAgents activation', () => {
       })
     ]
     mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-2' } }
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+    expect(capturedRowActivations).toHaveLength(1)
+    capturedRowActivations[0].onActivate(tabId, paneKey)
+
+    expect(activationMocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
+    expect(activationMocks.activateTabAndFocusPane).not.toHaveBeenCalled()
+    expect(staleAgentRowMocks.dismissStaleAgentRowByKey).toHaveBeenCalledWith(paneKey)
+  })
+
+  it('dismisses a stale relay-restart row whose worktree still matches but has no runtime backing', async () => {
+    // Regression for issue #9030: after an SSH relay daemon restarts the agent's
+    // terminal tab is gone for good, but the renderer-memory status entry still
+    // carries a matching worktreeId and counts as fresh for 30 minutes. The row
+    // must not stay silently unclickable forever. Because the entry lacks runtime
+    // backing (it is a plain terminal agent, not a hydrating orchestration
+    // worker), the click dismisses it with truthful feedback instead of no-op'ing.
+    mockAgentActivityDisplayMode = 'full'
+    const tabId = 'relay-restart-tab'
+    const paneKey = makePaneKey(tabId, LEAF_A)
+    mockAgents = [
+      mockAgent({
+        paneKey,
+        tabId,
+        agentType: 'codex',
+        prompt: 'Worker on a relay that restarted',
+        worktreeId: 'wt-1'
+      })
+    ]
+    // Why: worktreeId matches wt-1 (so the old guard kept it), but there is no
+    // orchestration context and no terminal handle — the row is not a runtime
+    // allocation whose tab is still hydrating.
+    mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-1' } }
     const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
 
     renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -14,7 +14,6 @@ import { useWorktreeAgentRows } from './useWorktreeAgentRows'
 import { cn } from '@/lib/utils'
 import type { DashboardAgentRow as DashboardAgentRowData } from '@/components/dashboard/useDashboardData'
 import { parsePaneKey } from '../../../../shared/stable-pane-id'
-import { hasRuntimeBackedAttribution } from '../../../../shared/agent-status-types'
 import { dismissStaleAgentRowByKey } from '../terminal-pane/stale-agent-row'
 import { useFocusedAgentPaneKey } from './focused-agent-row-highlight'
 import {
@@ -207,22 +206,29 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
           scrollToBottomIfOutputSinceLastView: true
         })
       } else {
-        const liveEntry = useAppStore.getState().agentStatusByPaneKey[paneKey]
-        if (liveEntry?.worktreeId === worktreeId && hasRuntimeBackedAttribution(liveEntry)) {
-          // Why: orchestration workers report worktree-attributed status before
-          // the renderer has a terminal tab for them. Runtime backing (an
-          // orchestration context or a runtime terminal handle) is the same
-          // hydration signal applyAgentStatus uses for snapshot replay, so keep
-          // the visible live row while its tab hydrates instead of dismissing it.
+        const store = useAppStore.getState()
+        const liveEntry = store.agentStatusByPaneKey[paneKey]
+        if (
+          liveEntry?.worktreeId === worktreeId &&
+          store.runtimeAgentOrchestrationByPaneKey[paneKey] !== undefined
+        ) {
+          // Why: an orchestration worker can report worktree-attributed status
+          // before the renderer has a terminal tab for it (the legitimate
+          // mid-spawn hydration case). Keep the row only while the runtime
+          // CURRENTLY lists this pane as an orchestration allocation — the live
+          // runtimeAgentOrchestrationByPaneKey mirror synced from main, not the
+          // entry's retained terminalHandle/orchestration strings, which survive
+          // an SSH relay daemon restart and would leave the row silently
+          // unclickable again (issue #9030).
           return
         }
-        // Why: a worktree-attributed row with no runtime backing and no
-        // resolvable tab is a stale remnant — most often a plain terminal agent
-        // whose SSH relay daemon restarted so its tab is gone for good. The
-        // session is dead on the host, but the renderer-memory row lingered up
-        // to the 30-min freshness window and a click must not silently no-op
-        // forever (issue #9030). Dismiss with truthful feedback, mirroring the
-        // snapshot-replay drop that clears these rows after a window reload.
+        // Why: a worktree-attributed row with no resolvable tab and no current
+        // runtime orchestration allocation is a stale remnant — most often a
+        // terminal agent whose SSH relay daemon restarted so its tab is gone for
+        // good. The host session is dead but the renderer-memory row lingered up
+        // to the 30-min freshness window; a click must not silently no-op
+        // forever. Dismiss with truthful feedback so the row reconciles instead
+        // of waiting for the freshness window to expire.
         dismissStaleAgentRowByKey(paneKey)
       }
     },

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -14,6 +14,7 @@ import { useWorktreeAgentRows } from './useWorktreeAgentRows'
 import { cn } from '@/lib/utils'
 import type { DashboardAgentRow as DashboardAgentRowData } from '@/components/dashboard/useDashboardData'
 import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import { hasRuntimeBackedAttribution } from '../../../../shared/agent-status-types'
 import { dismissStaleAgentRowByKey } from '../terminal-pane/stale-agent-row'
 import { useFocusedAgentPaneKey } from './focused-agent-row-highlight'
 import {
@@ -207,12 +208,21 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
         })
       } else {
         const liveEntry = useAppStore.getState().agentStatusByPaneKey[paneKey]
-        if (liveEntry?.worktreeId === worktreeId) {
-          // Why: orchestration worker status can be worktree-attributed before
-          // the renderer knows its tab. Keep the visible live row instead of
-          // dismissing it as stale just because it cannot be focused yet.
+        if (liveEntry?.worktreeId === worktreeId && hasRuntimeBackedAttribution(liveEntry)) {
+          // Why: orchestration workers report worktree-attributed status before
+          // the renderer has a terminal tab for them. Runtime backing (an
+          // orchestration context or a runtime terminal handle) is the same
+          // hydration signal applyAgentStatus uses for snapshot replay, so keep
+          // the visible live row while its tab hydrates instead of dismissing it.
           return
         }
+        // Why: a worktree-attributed row with no runtime backing and no
+        // resolvable tab is a stale remnant — most often a plain terminal agent
+        // whose SSH relay daemon restarted so its tab is gone for good. The
+        // session is dead on the host, but the renderer-memory row lingered up
+        // to the 30-min freshness window and a click must not silently no-op
+        // forever (issue #9030). Dismiss with truthful feedback, mirroring the
+        // snapshot-replay drop that clears these rows after a window reload.
         dismissStaleAgentRowByKey(paneKey)
       }
     },

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -56,6 +56,7 @@ import {
   rememberPrelaunchedSimulatorSession
 } from '@/lib/simulator-launch-coordination'
 import {
+  hasRuntimeBackedAttribution,
   normalizeAgentStatusPayload,
   type AgentStatusIpcPayload,
   type ParsedAgentStatusPayload
@@ -3086,7 +3087,7 @@ export function useIpcEvents(): void {
         repoConnectionResolved,
         owningWorktreeId
       } = resolvePaneKey(store, paneKey)
-      if (!exists && data.worktreeId && hasRuntimeBackedWorktreeAttribution(data)) {
+      if (!exists && data.worktreeId && hasRuntimeBackedAttribution(data)) {
         // Why: orchestration worker hooks can carry main-side worktree
         // attribution before this renderer has a terminal tab for the pane.
         // Require runtime identity too; durable snapshots with only worktreeId
@@ -3492,13 +3493,6 @@ export function useIpcEvents(): void {
       resetAgentHookCompletionNotificationCoordinators()
     }
   }, [])
-}
-
-function hasRuntimeBackedWorktreeAttribution(data: AgentStatusIpcPayload): boolean {
-  return (
-    (typeof data.terminalHandle === 'string' && data.terminalHandle.length > 0) ||
-    data.orchestration !== undefined
-  )
 }
 
 function tryMakePaneKey(tabId: string, leafId: string): string | null {

--- a/src/shared/agent-status-types.test.ts
+++ b/src/shared/agent-status-types.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, it, expect, vi } from 'vitest'
 import {
   agentSubagentsEqual,
+  hasRuntimeBackedAttribution,
   parseAgentStatusPayload,
   normalizeAgentStatusPayload,
   AGENT_STATUS_MAX_FIELD_LENGTH,
@@ -530,5 +531,36 @@ describe('agentSubagentsEqual', () => {
     expect(agentSubagentsEqual([snapshot], undefined)).toBe(false)
     expect(agentSubagentsEqual(undefined, [snapshot])).toBe(false)
     expect(agentSubagentsEqual([snapshot], [snapshot, { ...snapshot, id: 'b' }])).toBe(false)
+  })
+})
+
+describe('hasRuntimeBackedAttribution', () => {
+  it('is false for a plain worktree-attributed entry with no runtime reference', () => {
+    // Why: this is the stale relay-restart remnant shape — a worktreeId alone
+    // does not prove a live runtime allocation, so the row is not hydrating.
+    expect(hasRuntimeBackedAttribution({})).toBe(false)
+    expect(hasRuntimeBackedAttribution({ terminalHandle: undefined })).toBe(false)
+    expect(hasRuntimeBackedAttribution({ orchestration: undefined })).toBe(false)
+  })
+
+  it('is false for an empty terminal handle', () => {
+    expect(hasRuntimeBackedAttribution({ terminalHandle: '' })).toBe(false)
+  })
+
+  it('is true when an orchestration dispatch context is present', () => {
+    expect(hasRuntimeBackedAttribution({ orchestration: { taskId: 't-1' } as never })).toBe(true)
+  })
+
+  it('is true when a non-empty runtime terminal handle is present', () => {
+    expect(hasRuntimeBackedAttribution({ terminalHandle: 'term-1' })).toBe(true)
+  })
+
+  it('treats orchestration as backing even alongside an empty terminal handle', () => {
+    expect(
+      hasRuntimeBackedAttribution({
+        terminalHandle: '',
+        orchestration: { taskId: 't-2' } as never
+      })
+    ).toBe(true)
   })
 })

--- a/src/shared/agent-status-types.test.ts
+++ b/src/shared/agent-status-types.test.ts
@@ -535,9 +535,10 @@ describe('agentSubagentsEqual', () => {
 })
 
 describe('hasRuntimeBackedAttribution', () => {
-  it('is false for a plain worktree-attributed entry with no runtime reference', () => {
-    // Why: this is the stale relay-restart remnant shape — a worktreeId alone
-    // does not prove a live runtime allocation, so the row is not hydrating.
+  it('is false for an IPC payload with no runtime reference on its face', () => {
+    // Why: this predicate only inspects fields present on a just-received IPC
+    // payload — it is not a liveness test for a stored entry, so a bare
+    // worktreeId does not count as runtime backing on the fresh-IPC path.
     expect(hasRuntimeBackedAttribution({})).toBe(false)
     expect(hasRuntimeBackedAttribution({ terminalHandle: undefined })).toBe(false)
     expect(hasRuntimeBackedAttribution({ orchestration: undefined })).toBe(false)

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -263,19 +263,18 @@ export function isFreshNonDoneAgentStatus(
   return Boolean(entry && entry.state !== 'done' && now - entry.updatedAt <= staleAfterMs)
 }
 
-/** Whether an agent-status entry carries a runtime reference — an orchestration
- *  dispatch context or a runtime terminal handle — proving it is backed by a
- *  live runtime allocation rather than only a durable worktree attribution.
+/** Whether an agent-status IPC payload carries a runtime reference — an
+ *  orchestration dispatch context or a runtime terminal handle — at the moment
+ *  main enriched it for IPC fanout.
  *
- *  Why: orchestration workers can report worktree-attributed status before the
- *  renderer has a terminal tab for them (the legitimate mid-spawn hydration
- *  case). Such runtime-backed rows are kept visible while their tab hydrates;
- *  rows that merely carry a worktreeId with no runtime backing and no
- *  resolvable tab are stale remnants (e.g. an agent whose SSH relay daemon
- *  restarted) and must not linger as silently unclickable. This is the single
- *  discriminator used by both the snapshot-replay hydration path in
- *  useIpcEvents and the sidebar activation guard in WorktreeCardAgents, so they
- *  cannot drift apart on what counts as "still hydrating". */
+ *  Why: applyAgentStatus uses this on the fresh-IPC path to accept a
+ *  worktree-attributed status whose tab is not yet present in the renderer
+ *  (orchestration workers can arrive worktree-attributed before their terminal
+ *  tab hydrates). It reads fields on a just-received IPC payload, which reflect
+ *  main's current enrichment. It is NOT a liveness test for an already-stored
+ *  entry: a renderer-side entry retains its terminalHandle/orchestration strings
+ *  across an SSH relay daemon restart, so the sidebar activation guard uses the
+ *  live runtimeAgentOrchestrationByPaneKey mirror instead of this predicate. */
 export function hasRuntimeBackedAttribution(
   entry: Pick<AgentStatusEntry, 'terminalHandle' | 'orchestration'>
 ): boolean {

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -263,6 +263,28 @@ export function isFreshNonDoneAgentStatus(
   return Boolean(entry && entry.state !== 'done' && now - entry.updatedAt <= staleAfterMs)
 }
 
+/** Whether an agent-status entry carries a runtime reference — an orchestration
+ *  dispatch context or a runtime terminal handle — proving it is backed by a
+ *  live runtime allocation rather than only a durable worktree attribution.
+ *
+ *  Why: orchestration workers can report worktree-attributed status before the
+ *  renderer has a terminal tab for them (the legitimate mid-spawn hydration
+ *  case). Such runtime-backed rows are kept visible while their tab hydrates;
+ *  rows that merely carry a worktreeId with no runtime backing and no
+ *  resolvable tab are stale remnants (e.g. an agent whose SSH relay daemon
+ *  restarted) and must not linger as silently unclickable. This is the single
+ *  discriminator used by both the snapshot-replay hydration path in
+ *  useIpcEvents and the sidebar activation guard in WorktreeCardAgents, so they
+ *  cannot drift apart on what counts as "still hydrating". */
+export function hasRuntimeBackedAttribution(
+  entry: Pick<AgentStatusEntry, 'terminalHandle' | 'orchestration'>
+): boolean {
+  return (
+    (typeof entry.terminalHandle === 'string' && entry.terminalHandle.length > 0) ||
+    entry.orchestration !== undefined
+  )
+}
+
 // Why: typed as ReadonlySet<string> so .has() accepts any string without
 // requiring `state as AgentStatusState` at the check site. The narrowing
 // cast stays on the return line, where it's actually proven safe.


### PR DESCRIPTION
Fixes #9030

## Summary

After an SSH relay daemon restarts (crash or manual kill), agent rows for that project stay visible in the sidebar but clicking them does nothing — no tab opens, no toast, no console error — until the 30-minute status freshness window expires. The rows are stale renderer-memory entries whose terminal tabs are gone for good, but the activation guard silently returned without activating or dismissing them.

This PR makes clicking a stale row give **truthful, actionable feedback** (dismiss + toast) instead of a silent no-op, while preserving the legitimate mid-spawn hydration case for orchestration workers (whose worktree-attributed status can arrive before their terminal tab).

### Root cause
The `WorktreeCardAgents` activation guard kept any worktree-attributed row alive when its tab was missing. That is correct for an orchestration worker mid-spawn, but it also trapped stale rows after a relay restart: `agentStatusByPaneKey` is cleared on tab close / worktree sleep-remove but never on relay/daemon teardown, and a real SSH terminal agent's stored entry retains its `terminalHandle` (main stamps one via `registerPty` + the `ptysById` fallback, and `setAgentStatus` retains it across the restart). So gating on the stored entry's strings keeps the stale SSH remnant too.

### Fix (live runtime signal, not retained strings)
The guard now keeps a worktree-attributed row alive **only while the runtime currently lists the pane as an orchestration allocation** — via the live `runtimeAgentOrchestrationByPaneKey` mirror synced from main's runtime (`buildAgentOrchestrationByPaneKey` → `syncWindowGraph` → renderer store). That mirror is rebuilt from main's current state, so:
- A plain terminal agent is **never** in it (no orchestration dispatch) → a stale row whose tab is gone is dismissed with a toast.
- A currently-running orchestration worker **is** in it → the hydrating row is kept.
- A dead allocation drops out on the next graph sync.

Retained `terminalHandle`/`orchestration` strings on a stored entry are no longer treated as liveness. The fresh-IPC hydration path in `useIpcEvents` still uses `hasRuntimeBackedAttribution` on the just-received payload (a current signal, not retained); the helper was extracted to `src/shared/agent-status-types.ts` and its doc comment scoped accordingly.

## Screenshots

No visual change. Clicking a stale row now dismisses it with the existing transient toast "Agent's pane is no longer available." instead of no-op'ing silently.

## Testing

Rebased onto current `upstream/main` (`1c54171c5`); head is now `127a6e4c3` (was `01e6a6b03`). The rebase was conflict-free (0 behind / 2 ahead); the only upstream commit touching a PR file is `6e91ca6c0` (`useIpcEvents.ts` local-HTTPS handler, a different region from this PR's `hasRuntimeBackedAttribution` extraction).

- [x] `pnpm lint` (changed-file `oxlint`: 0 warnings, 0 errors; `oxfmt` clean)
- [x] `pnpm typecheck` (node, tc.cli, tc.web — all clean; re-verified on the rebased tree)
- [x] `pnpm test` — focused: activation + predicate + `useIpcEvents` = **135 pass** (re-verified on the rebased tree); broader sidebar + agent-status slices = **1,542 pass** on the equivalent pre-rebase logic; no-mistakes pipeline `test` stage 0 findings
- [x] `pnpm build` — full `verify` CI `Build unpacked app` + `Smoke packaged CLI` green on the rebased tree (head `127a6e4c3`)
- [x] Full CI green on the exact rebased head via the fork PR: `verify` (lint/typecheck/test/build/smoke, 15m), golden e2e (linux + mac), native-smoke (ubuntu + windows), roundtrip (all platform × copy/symlink combos), wayland terminal input. (`track-community-pr` is a fork-only check that fails on the fork because the `BUFO_BOT` app secret is absent there; it does not exist on `stablyai/orca`, where the secret is configured.)
- [x] Added/updated high-quality tests:
  - New regression `dismisses a stale SSH relay-restart remnant that still carries a retained terminalHandle` — models the realistic stale shape (retained `terminalHandle`, empty runtime mirror), **fails on the prior `a1351d33e` guard and passes now**.
  - The two hydration-keep tests now set the live `runtimeAgentOrchestrationByPaneKey` mirror and still assert a currently-runtime-backed orchestration worker row is kept.
  - Added a focused `hasRuntimeBackedAttribution` unit test for the fresh-IPC predicate contract.

## AI Review Report

This change went through multiple independent automated reviews: two written reviews on prior heads (`a1351d33e` and `3d20c69c0`) plus a no-mistakes pipeline review. The first review correctly found that gating on the stored entry's retained `terminalHandle` was ineffective for real SSH remnants (the entry retains it across a restart); the remediation re-gated on the live `runtimeAgentOrchestrationByPaneKey` mirror, which the second review verified end-to-end and approved.

The no-mistakes pipeline revalidated the pre-rebase logic at `01e6a6b03` with **0 findings** across review/test/document/lint (review ran 2 rounds). After the rebase onto `upstream/main`, full CI was re-run and is green on the rebased head `127a6e4c3`. The pipeline review additionally surfaced and resolved a **web/remote nuance** (no code change): `runtimeAgentOrchestrationByPaneKey` is always `{}` on web because web's `syncWindowGraph` returns `RuntimeStatus` without that field — but the keep-branch is unreachable on web, since `buildMirroredAgentStatusPatch` derives each row's paneKey from the same `terminalSurfaceTabs` source that produces the terminal tabs, so a row cannot exist without its tab there. The finding is vacuously correct on web and the fix works on its real desktop/SSH target.

Risks checked:
- **Cross-platform (macOS/Linux/Windows):** the change is platform-agnostic renderer data-flow logic; no keyboard shortcuts, paths, shell, or Electron platform behavior touched.
- **Local / SSH / paired-remote:** `buildAgentOrchestrationByPaneKey` iterates both graph leaves and `ptysById` (the latter covers SSH panes via `registerPty`); dispatch resolution is host-agnostic. Behavior is identical for local / WSL / SSH / paired remote. The guard additionally requires `liveEntry?.worktreeId === worktreeId`, so a foreign paneKey cannot keep a row in another worktree's card.
- **Performance:** one cheap map lookup added on user click only; no hot-path impact. The fresh-IPC predicate is unchanged behavior.
- **Accessibility:** a previously silent no-op now yields a truthful transient toast — strictly better feedback.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependencies, or IPC surfaces. The fix reuses the existing `dismissStaleAgentRowByKey` path (`dropAgentStatus` + the existing `agentStatus:drop` IPC mirror). The `runtimeAgentOrchestrationByPaneKey` mirror is read-only here. No follow-up security work identified.

## Notes

- **Evidence limitations:** validation was performed on Linux. The regression is a grounded unit reproduction of the renderer state machine using the realistic stale-entry shape (retained `terminalHandle` + empty live mirror) traced through main's enrichment/retention paths. **No live macOS/SSH relay restart reproduction was performed or claimed.** Maintainers may want to confirm end-to-end (start an SSH agent, `pkill -f relay.js`, reconnect, click the row) before merge.
- **Scope:** intentionally limited to the #9030 click-surface lifecycle fix. Rows reconcile on click (truthful feedback) rather than auto-clearing on reconnect; this does not touch #8986 sticky-delete suppression, status-badge work, retry policy, or remote activation authority.
- **Residual timing note:** the runtime mirror is renderer-pull-based (updated on `syncWindowGraph`, coalesced on a frame). Worst case for an orchestration worker is a transient false-dismiss with a truthful toast that self-corrects when the worker's tab hydrates and its next status hook re-renders the row — strictly better than the prior silent no-op, and self-correcting (no data loss, no stuck state).
- X handle: @ericjung
