### PR TITLE
fix(settings): keep Shortcuts rows visible on pane-title-only search

### DIFF
--- a/src/renderer/src/components/settings/ShortcutCommandBlock.tsx
+++ b/src/renderer/src/components/settings/ShortcutCommandBlock.tsx
@@ -106,6 +106,8 @@ export function ShortcutCommandBlock({
     />
   )
 
+  // Why: ShortcutsPane already filters rows against the global query;
+  // forceVisible skips the re-match here that would hide rows it kept.
   return (
     <SearchableSetting
       title={item.title}
@@ -115,6 +117,7 @@ export function ShortcutCommandBlock({
         { value0: groupTitle }
       )}
       keywords={[...item.searchKeywords]}
+      forceVisible
       className="group/shortcut flex max-w-none flex-col"
     >
       <div className="flex min-h-9 items-center gap-3 rounded-md px-2 py-1 transition-colors hover:bg-accent/40 focus-within:bg-accent/40">

--- a/src/renderer/src/components/settings/ShortcutFilterRail.test.ts
+++ b/src/renderer/src/components/settings/ShortcutFilterRail.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { KeybindingActionId } from '../../../../shared/keybindings'
 import {
   SHORTCUT_LOCAL_SEARCH_QUERY_MAX_BYTES,
+  buildShortcutGlobalSearchMatcher,
   isShortcutLocalSearchQueryTooLarge,
   matchesShortcutLocalSearch,
   normalizeShortcutLocalSearchQuery,
@@ -50,6 +51,40 @@ describe('ShortcutFilterRail search helpers', () => {
     expect(query.length).toBe(SHORTCUT_LOCAL_SEARCH_QUERY_MAX_BYTES)
     expect(isShortcutLocalSearchQueryTooLarge(query)).toBe(true)
     expect(normalizeShortcutLocalSearchQuery(query)).toBeNull()
+  })
+
+  it('narrows rows when the global settings query matches specific rows', () => {
+    const settingsRow = createShortcutRow()
+    const worktreeRow: ShortcutRowModel = {
+      ...createShortcutRow(),
+      item: {
+        ...createShortcutRow().item,
+        id: 'worktree.create' as KeybindingActionId,
+        title: 'Create worktree',
+        searchKeywords: ['worktree', 'create']
+      }
+    }
+
+    const matcher = buildShortcutGlobalSearchMatcher([settingsRow, worktreeRow], 'worktree')
+
+    expect(matcher(settingsRow)).toBe(false)
+    expect(matcher(worktreeRow)).toBe(true)
+  })
+
+  it('keeps every row visible on a pane-title-only global query', () => {
+    const rows = [createShortcutRow()]
+
+    // Mirrors sidebar search selecting the pane with a query that matches only
+    // pane-level metadata (e.g. a localized pane title) and no row metadata.
+    const matcher = buildShortcutGlobalSearchMatcher(rows, '단축키')
+
+    expect(matcher(rows[0])).toBe(true)
+  })
+
+  it('keeps every row visible when the global query is empty', () => {
+    const rows = [createShortcutRow()]
+
+    expect(buildShortcutGlobalSearchMatcher(rows, '')(rows[0])).toBe(true)
   })
 
   it('rejects oversized pasted shortcut searches before reading row metadata', () => {

--- a/src/renderer/src/components/settings/ShortcutFilterRail.tsx
+++ b/src/renderer/src/components/settings/ShortcutFilterRail.tsx
@@ -6,7 +6,7 @@ import { cn } from '../../lib/utils'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import type { ShortcutTerminalStatus } from './shortcut-terminal-status'
-import type { SettingsSearchEntry } from './settings-search'
+import { matchesSettingsSearch, type SettingsSearchEntry } from './settings-search'
 import { translate } from '@/i18n/i18n'
 
 export type ShortcutFilter = 'all' | 'modified' | 'unassigned' | 'conflicts'
@@ -58,6 +58,17 @@ export function getShortcutSearchEntry(row: ShortcutRowModel): SettingsSearchEnt
     ),
     keywords: [...row.item.searchKeywords]
   }
+}
+
+// Why: a sidebar query can select this pane by title alone while matching zero
+// rows; that would blank the list, so zero-row queries keep every row visible.
+export function buildShortcutGlobalSearchMatcher(
+  rows: readonly ShortcutRowModel[],
+  searchQuery: string
+): (row: ShortcutRowModel) => boolean {
+  const rowMatches = (row: ShortcutRowModel): boolean =>
+    matchesSettingsSearch(searchQuery, getShortcutSearchEntry(row))
+  return rows.some(rowMatches) ? rowMatches : () => true
 }
 
 export function matchesShortcutFilter(row: ShortcutRowModel, filter: ShortcutFilter): boolean {

--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -25,7 +25,7 @@ import {
   sameBindings
 } from './keybinding-override-edits'
 import {
-  getShortcutSearchEntry,
+  buildShortcutGlobalSearchMatcher,
   matchesShortcutFilter,
   matchesShortcutLocalSearch,
   normalizeShortcutLocalSearchQuery,
@@ -138,9 +138,10 @@ export function ShortcutsPane(): React.JSX.Element {
   )
   const shortcutSearchQuery = normalizeShortcutLocalSearchQuery(shortcutQuery)
   const shortcutRows = shortcutGroups.flatMap((group) => group.rows)
+  const matchesShortcutGlobalSearch = buildShortcutGlobalSearchMatcher(shortcutRows, searchQuery)
   const matchesShortcutSearch = (row: ShortcutRowsByGroup['rows'][number]): boolean =>
     shortcutSearchQuery !== null &&
-    matchesSettingsSearch(searchQuery, getShortcutSearchEntry(row)) &&
+    matchesShortcutGlobalSearch(row) &&
     matchesShortcutLocalSearch(row, shortcutSearchQuery, platform)
   const baseVisibleRows = shortcutRows.filter((row) => matchesShortcutSearch(row))
   const filterCounts: Record<ShortcutFilter, number> = {

--- a/tests/e2e/settings-search-shortcuts-pane.spec.ts
+++ b/tests/e2e/settings-search-shortcuts-pane.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+
+test.describe('Settings sidebar search on the Shortcuts pane', () => {
+  test('pane-title-only query keeps rows visible and local search usable', async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+
+    await orcaPage.evaluate(async () => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is not available')
+      }
+      // Why: the spec asserts on English strings; the host machine may run a
+      // non-English system locale, which 'system' would follow.
+      await store.getState().updateSettings({ uiLanguage: 'en' })
+      store.getState().openSettingsPage()
+    })
+
+    const searchInput = orcaPage.getByPlaceholder('Search settings')
+    await expect(searchInput).toBeVisible()
+    await searchInput.fill('shortcuts')
+
+    // The query matches the pane title, so the Shortcuts pane auto-activates.
+    await expect(orcaPage.getByRole('heading', { name: 'Shortcuts', exact: true })).toBeVisible()
+
+    // Regression: a pane-title-only query used to blank the whole list (0/112).
+    await expect(orcaPage.getByText('Go to File', { exact: true })).toBeVisible()
+    await expect(orcaPage.getByText('No shortcuts match those filters.')).not.toBeVisible()
+
+    // Regression: the pane's own search was dead while the global query was
+    // active, because it intersected with an already-empty base list.
+    const localSearch = orcaPage.getByPlaceholder('Search command or keys')
+    await localSearch.fill('go to')
+    await expect(orcaPage.getByText('Go to File', { exact: true })).toBeVisible()
+    await expect(orcaPage.getByText('Force Reload', { exact: true })).not.toBeVisible()
+
+    // A row-matching global query still narrows the list as before.
+    await localSearch.clear()
+    await searchInput.fill('worktree')
+    await expect(orcaPage.getByText('Create worktree', { exact: true })).toBeVisible()
+    await expect(orcaPage.getByText('Go to File', { exact: true })).not.toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #8577. Typing a sidebar query that matches only the Shortcuts pane title (e.g. `shortcuts`, or a localized title like `단축키`) auto-opens the pane with every row filtered out (`0/N`, local “Find shortcuts” dead) because the same `settingsSearchQuery` is ANDed against row metadata that does not include the pane title.

**Root cause:** sidebar ranking includes a pane-title entry via `getSettingsSectionSearchEntries`, but `ShortcutsPane` row filtering reuses that query against per-row entries only. `SearchableSetting` on each row re-applies the same query a second time.

**Fix** (from community PR #8579 by @m-a-king — taken over / rebased here with credit):

1. `buildShortcutGlobalSearchMatcher`: if the global query matches **no** shortcut row, treat it as pane-level-only and keep every row visible; row-matching queries still narrow.
2. `ShortcutCommandBlock` passes `forceVisible` so the wrapper cannot re-hide rows the pane already kept.
3. Unit + e2e coverage for pane-title-only, local search under a live sidebar query, and row-matching narrowing.

**Adversarial review (other panes):** Appearance already uses `forceVisiblePrimary` on section-title hits; Repository uses `forceFullPaneForRepoMatch`. Experimental and most form panes include pane-related keywords on entries. Shortcuts was uniquely broken because it dual-filters a large row list *and* ANDs a local search on the already-empty base set.

## Evidence

- Unit (`ShortcutFilterRail.test.ts`): matcher narrows on row-matching queries; keeps all rows on pane-title-only (incl. non-English) and empty query.
- Unit (`settings-search.test.ts`): existing ranking still prefers Shortcuts for `shortcuts`.
- E2E (`tests/e2e/settings-search-shortcuts-pane.spec.ts`): composed UI — only layer that catches the `SearchableSetting` double-filter (unit alone can pass while the app still blanks).

Verified locally:

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/components/settings/ShortcutFilterRail.test.ts \
  src/renderer/src/components/settings/settings-search.test.ts
# 17 passed
```

## ELI5

Settings search and the Shortcuts list were sharing one search box in a confusing way. If you typed the word “shortcuts” to open that page, the list thought you were looking for a command *named* “shortcuts,” found none, and showed a blank page — and the list’s own search couldn’t help because it was already empty. Now, if the sidebar search only matches the page name (not any command), we show the full list so you can use the local filter normally. If the sidebar search matches real commands (like “worktree”), the list still narrows.

## User-regression-tradeoffs

| Scenario | Before | After |
| --- | --- | --- |
| Sidebar `shortcuts` / localized pane title | Blank list 0/N; local search dead | Full list; local search works |
| Sidebar `worktree` (row match) | Narrowed list | Same — still narrows |
| Empty sidebar search | Full list | Same |
| Explicit sidebar click on Shortcuts | Cleared query, full list | Unchanged (still clears query) |

**Tradeoff kept deliberately:** a row-matching sidebar query still filters the Shortcuts list (consistent with other panes). Alternative would be “sidebar only selects the pane; only local search narrows rows” — not taken here.

**Credit:** Implementation and tests originate from #8579 by [@m-a-king](https://github.com/m-a-king). This PR rebases/takes over that fix so it can land cleanly.

---

X handle: n/a (internal take-over of community fix)