### PR TITLE
fix(agent-resume): skip sleeping-session resume for runtime-owned worktrees

### DIFF
--- a/src/renderer/src/lib/repro-8878-remote-resume-no-runtime-gate.test.ts
+++ b/src/renderer/src/lib/repro-8878-remote-resume-no-runtime-gate.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Issue #8878 — Remote client resumes live host agent sessions, spawning
+ * duplicate TUIs on the same provider session.
+ *
+ * Regression guard (was a failing-first repro on the handoff branch):
+ * `resumeSleepingAgentSessionsForWorktree` must short-circuit when the
+ * worktree is runtime-owned — same host-authority predicate as plain
+ * terminal auto-create (`isWebRuntimeSessionActive` +
+ * `getRuntimeEnvironmentIdForWorktree`). Behavioral matrix lives in
+ * `resume-sleeping-agent-session-runtime-owner.test.ts`.
+ *
+ * Re-run:
+ *   pnpm exec vitest run --config config/vitest.config.ts \
+ *     src/renderer/src/lib/repro-8878-remote-resume-no-runtime-gate.test.ts
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const resumeSource = readFileSync(join(__dirname, 'resume-sleeping-agent-session.ts'), 'utf8')
+const activationSource = readFileSync(join(__dirname, 'worktree-activation.ts'), 'utf8')
+const terminalSource = readFileSync(join(__dirname, '../components/Terminal.tsx'), 'utf8')
+
+describe('#8878 remote client resume runtime-ownership gate', () => {
+  it('resumeSleepingAgentSessionsForWorktree gates on isWebRuntimeSessionActive', () => {
+    expect(resumeSource).toMatch(
+      /export function resumeSleepingAgentSessionsForWorktree\s*\(\s*worktreeId:\s*string/
+    )
+    // Fix: choke-point gate shared by activation, startup, and background wake.
+    expect(resumeSource).toMatch(/isWebRuntimeSessionActive/)
+    expect(resumeSource).toMatch(/getRuntimeEnvironmentIdForWorktree/)
+    expect(resumeSource).toMatch(
+      /isWebRuntimeSessionActive\(\s*getRuntimeEnvironmentIdForWorktree\(\s*state,\s*worktreeId\s*\)\s*\)/
+    )
+  })
+
+  it('worktree activation still invokes resume (gate lives inside the choke point)', () => {
+    expect(activationSource).toMatch(/resumeSleepingAgentSessionsForWorktree\(workspaceKey\)/)
+    expect(activationSource).toMatch(/resumeSleepingAgentSessionsForWorktree\(worktreeId\)/)
+    // Auto-create for runtime-owned worktrees remains gated nearby.
+    expect(activationSource).toMatch(
+      /isWebRuntimeSessionActive\(getRuntimeEnvironmentIdForWorktree/
+    )
+  })
+
+  it('Terminal auto-create and startup resume stay consistent via the choke point', () => {
+    expect(terminalSource).toMatch(
+      /isWebRuntimeSessionActive\(getActiveWorktreeRuntimeEnvironmentId\(activeWorktreeId\)\)/
+    )
+    expect(terminalSource).toMatch(/resumeSleepingAgentSessionsForWorktree\(activeWorktreeId\)/)
+  })
+})

--- a/src/renderer/src/lib/resume-sleeping-agent-session-runtime-owner.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-runtime-owner.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import {
+  LOCAL_EXECUTION_HOST_ID,
+  toRuntimeExecutionHostId,
+  toSshExecutionHostId
+} from '../../../shared/execution-host'
+import { useAppStore } from '@/store'
+import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
+
+const initialAppStoreState = useAppStore.getState()
+// A runtime env focused globally that is NOT any worktree's explicit owner, so a
+// gate can only fire from a worktree's own runtime ownership, never global focus.
+const GLOBAL_FOCUSED_ENV = 'env-global'
+
+afterEach(() => {
+  useAppStore.setState(initialAppStoreState, true)
+})
+
+function makeLiveRecord(worktreeId: string, tabId: string): SleepingAgentSessionRecord {
+  return {
+    paneKey: `${tabId}:leaf-1`,
+    tabId,
+    worktreeId,
+    agent: 'claude',
+    providerSession: { key: 'session_id', id: `sess-${worktreeId}` },
+    prompt: 'finish the task',
+    state: 'working',
+    origin: 'live',
+    capturedAt: 1,
+    updatedAt: 1
+  }
+}
+
+function makeTerminalTab(id: string, worktreeId: string): Record<string, unknown> {
+  return {
+    id,
+    ptyId: null,
+    worktreeId,
+    title: 'shell',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+type WorktreeOwner =
+  | { via: 'worktreeHost'; hostId: string }
+  | { via: 'repoHost'; executionHostId: string }
+
+function worktreeRow(id: string, repoId: string, owner: WorktreeOwner): Record<string, unknown> {
+  return {
+    id,
+    repoId,
+    // path feeds the WSL/remote launch checks during resume; the gate itself
+    // only reads hostId. A defined path keeps createTab from dereferencing undefined.
+    path: `/repo/${id}`,
+    ...(owner.via === 'worktreeHost' ? { hostId: owner.hostId } : {})
+  }
+}
+
+// Installs the target worktree (with its explicit owner) alongside a runtime-owned
+// sibling, both carrying a live record, while a different runtime env is globally
+// focused. Exercises the explicit per-worktree/per-repo owner branch of
+// getRuntimeEnvironmentIdForWorktree, not just the global fallback.
+function installState(targetOwner: WorktreeOwner): {
+  targetRecord: SleepingAgentSessionRecord
+  siblingRecord: SleepingAgentSessionRecord
+} {
+  const targetRecord = makeLiveRecord('wt-target', 'tab-target')
+  const siblingRecord = makeLiveRecord('wt-sibling', 'tab-sibling')
+  const repos =
+    targetOwner.via === 'repoHost'
+      ? [{ id: 'repo-target', executionHostId: targetOwner.executionHostId }]
+      : []
+  useAppStore.setState({
+    settings: { ...initialAppStoreState.settings, activeRuntimeEnvironmentId: GLOBAL_FOCUSED_ENV },
+    repos,
+    worktreesByRepo: {
+      'repo-target': [worktreeRow('wt-target', 'repo-target', targetOwner)],
+      'repo-sibling': [
+        worktreeRow('wt-sibling', 'repo-sibling', {
+          via: 'worktreeHost',
+          hostId: toRuntimeExecutionHostId('env-sibling')
+        })
+      ]
+    },
+    tabsByWorktree: {
+      'wt-target': [makeTerminalTab('tab-target', 'wt-target')],
+      'wt-sibling': [makeTerminalTab('tab-sibling', 'wt-sibling')]
+    },
+    sleepingAgentSessionsByPaneKey: {
+      [targetRecord.paneKey]: targetRecord,
+      [siblingRecord.paneKey]: siblingRecord
+    }
+  } as never)
+  return { targetRecord, siblingRecord }
+}
+
+const cases: { name: string; owner: WorktreeOwner; expectedLaunched: number }[] = [
+  {
+    name: 'explicit runtime-owned worktree host is gated',
+    owner: { via: 'worktreeHost', hostId: toRuntimeExecutionHostId('env-1') },
+    expectedLaunched: 0
+  },
+  {
+    name: 'explicit runtime-owned repo host is gated',
+    owner: { via: 'repoHost', executionHostId: toRuntimeExecutionHostId('env-2') },
+    expectedLaunched: 0
+  },
+  {
+    name: 'explicit local worktree host still resumes',
+    owner: { via: 'worktreeHost', hostId: LOCAL_EXECUTION_HOST_ID },
+    expectedLaunched: 1
+  },
+  {
+    name: 'explicit ssh worktree host still resumes',
+    owner: { via: 'worktreeHost', hostId: toSshExecutionHostId('my-server') },
+    expectedLaunched: 1
+  },
+  {
+    name: 'explicit local repo host (forced WSL) still resumes',
+    owner: { via: 'repoHost', executionHostId: LOCAL_EXECUTION_HOST_ID },
+    expectedLaunched: 1
+  }
+]
+
+describe('resumeSleepingAgentSessionsForWorktree runtime-owner gate', () => {
+  it.each(cases)(
+    '$name while a different runtime env is globally focused',
+    ({ owner, expectedLaunched }) => {
+      const { targetRecord, siblingRecord } = installState(owner)
+
+      const launched = resumeSleepingAgentSessionsForWorktree('wt-target')
+
+      const state = useAppStore.getState()
+      expect(launched).toBe(expectedLaunched)
+      if (expectedLaunched === 0) {
+        expect(state.tabsByWorktree['wt-target']).toHaveLength(1)
+        expect(state.pendingStartupByTabId).toEqual({})
+        expect(state.sleepingAgentSessionsByPaneKey[targetRecord.paneKey]).toBe(targetRecord)
+      } else {
+        const resumedTab = state.tabsByWorktree['wt-target']?.find((tab) => tab.id !== 'tab-target')
+        expect(resumedTab?.launchAgent).toBe('claude')
+        expect(state.sleepingAgentSessionsByPaneKey[targetRecord.paneKey]).toBeUndefined()
+      }
+      // The runtime-owned sibling is never touched: the gate keys off the requested
+      // worktree's own ownership, not whichever runtime is globally focused.
+      expect(state.tabsByWorktree['wt-sibling']).toHaveLength(1)
+      expect(state.sleepingAgentSessionsByPaneKey[siblingRecord.paneKey]).toBe(siblingRecord)
+    }
+  )
+
+  it('gates only the runtime-owned worktree when a local sibling shares the store', () => {
+    const { targetRecord: localRecord, siblingRecord: runtimeRecord } = installState({
+      via: 'worktreeHost',
+      hostId: LOCAL_EXECUTION_HOST_ID
+    })
+
+    const runtimeLaunched = resumeSleepingAgentSessionsForWorktree('wt-sibling')
+    const localLaunched = resumeSleepingAgentSessionsForWorktree('wt-target')
+
+    const state = useAppStore.getState()
+    expect(runtimeLaunched).toBe(0)
+    expect(localLaunched).toBe(1)
+    expect(state.sleepingAgentSessionsByPaneKey[runtimeRecord.paneKey]).toBe(runtimeRecord)
+    expect(state.tabsByWorktree['wt-sibling']).toHaveLength(1)
+    expect(state.sleepingAgentSessionsByPaneKey[localRecord.paneKey]).toBeUndefined()
+    const resumedLocalTab = state.tabsByWorktree['wt-target']?.find((tab) => tab.id !== 'tab-target')
+    expect(resumedLocalTab?.launchAgent).toBe('claude')
+  })
+})

--- a/src/renderer/src/lib/resume-sleeping-agent-session-runtime-owner.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-runtime-owner.test.ts
@@ -5,6 +5,7 @@ import {
   toRuntimeExecutionHostId,
   toSshExecutionHostId
 } from '../../../shared/execution-host'
+import { folderWorkspaceKey } from '../../../shared/workspace-scope'
 import { useAppStore } from '@/store'
 import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
 
@@ -167,7 +168,9 @@ describe('resumeSleepingAgentSessionsForWorktree runtime-owner gate', () => {
     expect(state.sleepingAgentSessionsByPaneKey[runtimeRecord.paneKey]).toBe(runtimeRecord)
     expect(state.tabsByWorktree['wt-sibling']).toHaveLength(1)
     expect(state.sleepingAgentSessionsByPaneKey[localRecord.paneKey]).toBeUndefined()
-    const resumedLocalTab = state.tabsByWorktree['wt-target']?.find((tab) => tab.id !== 'tab-target')
+    const resumedLocalTab = state.tabsByWorktree['wt-target']?.find(
+      (tab) => tab.id !== 'tab-target'
+    )
     expect(resumedLocalTab?.launchAgent).toBe('claude')
   })
 
@@ -205,5 +208,78 @@ describe('resumeSleepingAgentSessionsForWorktree runtime-owner gate', () => {
     expect(
       useAppStore.getState().sleepingAgentSessionsByPaneKey[targetRecord.paneKey]
     ).toBeUndefined()
+  })
+
+  it('gates folder workspaces owned by a runtime project group (activation path)', () => {
+    // Why: folder activation also calls resumeSleepingAgentSessionsForWorktree
+    // with a folder:* workspace key; that path must share the same gate.
+    const workspaceKey = folderWorkspaceKey('folder-1')
+    const record = makeLiveRecord(workspaceKey, 'tab-folder')
+    useAppStore.setState({
+      settings: {
+        ...initialAppStoreState.settings,
+        activeRuntimeEnvironmentId: GLOBAL_FOCUSED_ENV
+      },
+      folderWorkspaces: [{ id: 'folder-1', projectGroupId: 'group-1', connectionId: null }],
+      projectGroups: [
+        {
+          id: 'group-1',
+          connectionId: null,
+          executionHostId: toRuntimeExecutionHostId('env-folder')
+        }
+      ],
+      tabsByWorktree: {
+        [workspaceKey]: [makeTerminalTab('tab-folder', workspaceKey)]
+      },
+      sleepingAgentSessionsByPaneKey: {
+        [record.paneKey]: record
+      }
+    } as never)
+
+    expect(resumeSleepingAgentSessionsForWorktree(workspaceKey)).toBe(0)
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
+    expect(useAppStore.getState().tabsByWorktree[workspaceKey]).toHaveLength(1)
+  })
+
+  it('gates unmarked worktrees via the active runtime fallback (paired remote client)', () => {
+    // Why: remote clients often leave worktree.hostId unset and rely on the
+    // focused runtime env; that global fallback must also skip client resume.
+    const record = makeLiveRecord('wt-unmarked', 'tab-unmarked')
+    useAppStore.setState({
+      settings: {
+        ...initialAppStoreState.settings,
+        activeRuntimeEnvironmentId: 'env-paired'
+      },
+      repos: [{ id: 'repo-unmarked', executionHostId: null, connectionId: null }],
+      worktreesByRepo: {
+        'repo-unmarked': [{ id: 'wt-unmarked', repoId: 'repo-unmarked', path: '/repo/unmarked' }]
+      },
+      tabsByWorktree: {
+        'wt-unmarked': [makeTerminalTab('tab-unmarked', 'wt-unmarked')]
+      },
+      sleepingAgentSessionsByPaneKey: {
+        [record.paneKey]: record
+      }
+    } as never)
+
+    expect(resumeSleepingAgentSessionsForWorktree('wt-unmarked')).toBe(0)
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
+  })
+
+  it('stays gated across re-entrant activation/startup resume races', () => {
+    // Why: worktree activation and Terminal startup hydration can both call
+    // resume for the same runtime-owned worktree before the mirror arrives.
+    const { targetRecord } = installState({
+      via: 'worktreeHost',
+      hostId: toRuntimeExecutionHostId('env-1')
+    })
+
+    expect(resumeSleepingAgentSessionsForWorktree('wt-target')).toBe(0)
+    expect(resumeSleepingAgentSessionsForWorktree('wt-target')).toBe(0)
+
+    const state = useAppStore.getState()
+    expect(state.tabsByWorktree['wt-target']).toHaveLength(1)
+    expect(state.pendingStartupByTabId).toEqual({})
+    expect(state.sleepingAgentSessionsByPaneKey[targetRecord.paneKey]).toBe(targetRecord)
   })
 })

--- a/src/renderer/src/lib/resume-sleeping-agent-session-runtime-owner.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-runtime-owner.test.ts
@@ -170,4 +170,40 @@ describe('resumeSleepingAgentSessionsForWorktree runtime-owner gate', () => {
     const resumedLocalTab = state.tabsByWorktree['wt-target']?.find((tab) => tab.id !== 'tab-target')
     expect(resumedLocalTab?.launchAgent).toBe('claude')
   })
+
+  it('leaves the sleeping record present and unmodified when the gate skips resume', () => {
+    const { targetRecord } = installState({
+      via: 'worktreeHost',
+      hostId: toRuntimeExecutionHostId('env-1')
+    })
+    const recordSnapshot = JSON.parse(JSON.stringify(targetRecord))
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-target')
+
+    const gatedState = useAppStore.getState()
+    expect(launched).toBe(0)
+    const preserved = gatedState.sleepingAgentSessionsByPaneKey[targetRecord.paneKey]
+    // The gate is non-destructive: it must not consume or mutate the record, only
+    // decline to launch. Retirement policy is the deferred follow-up (#8878).
+    expect(preserved).toBe(targetRecord)
+    expect(preserved).toEqual(recordSnapshot)
+
+    // The preserved record stays resumable once the worktree is no longer
+    // runtime-owned (ownership legitimately moving back to this client).
+    useAppStore.setState({
+      worktreesByRepo: {
+        ...gatedState.worktreesByRepo,
+        'repo-target': [
+          worktreeRow('wt-target', 'repo-target', {
+            via: 'worktreeHost',
+            hostId: LOCAL_EXECUTION_HOST_ID
+          })
+        ]
+      }
+    } as never)
+    expect(resumeSleepingAgentSessionsForWorktree('wt-target')).toBe(1)
+    expect(
+      useAppStore.getState().sleepingAgentSessionsByPaneKey[targetRecord.paneKey]
+    ).toBeUndefined()
+  })
 })

--- a/src/renderer/src/lib/resume-sleeping-agent-session.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.ts
@@ -1,4 +1,6 @@
 import { useAppStore } from '@/store'
+import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { isWebRuntimeSessionActive } from '@/runtime/web-runtime-session'
 import type {
   AgentProviderSessionMetadata,
   SleepingAgentSessionRecord
@@ -145,6 +147,11 @@ export function resumeSleepingAgentSessionsForWorktree(
   options?: ResumeSleepingAgentSessionsOptions
 ): number {
   const state = useAppStore.getState()
+  // Why: runtime-owned worktrees are host-authoritative for agent wake; a paired
+  // client resuming here would double-launch a still-live host session (#8878).
+  if (isWebRuntimeSessionActive(getRuntimeEnvironmentIdForWorktree(state, worktreeId))) {
+    return 0
+  }
   const worktreeRecords = Object.values(state.sleepingAgentSessionsByPaneKey)
     .filter((record) => record.worktreeId === worktreeId)
     .sort((a, b) => a.capturedAt - b.capturedAt || a.updatedAt - b.updatedAt)


### PR DESCRIPTION
## Description

Fixes #8878. A paired remote client (web client or a second Orca desktop) could launch `codex resume <id>` / `claude --resume` for agent sessions that are **still alive and daemon-backed on the host**, spawning a second TUI on the same provider session. The client-side resume pass runs before the async session-tabs mirror arrives, and every guard reads client-local state, so a live host session is invisible to it.

`resumeSleepingAgentSessionsForWorktree` now short-circuits when the target worktree is runtime-owned (host-authoritative) — the same host-authority predicate the plain-terminal auto-create gate already uses in `Terminal.tsx` (`isWebRuntimeSessionActive(getRuntimeEnvironmentIdForWorktree(...))`), applied at the single choke point that covers activation, startup hydration, and background wake. The host renderer keeps wake authority (its worktrees are not runtime-owned there); local, SSH, and WSL worktrees are unaffected.

**Credit:** Core fix and original runtime-owner matrix by @bbingz in #8887 (cherry-picked and rebased onto current `main`). This PR takes over that approach with adversarial coverage (folder workspaces, active-runtime global fallback, re-entrant activation/startup races) and the handoff-branch repro flipped into a positive regression guard.

**Evaluated and not used:** #9074 (`@brennanb2025`) — unrelated AskUserQuestion amber-status linger work; no overlap with the resume ownership gate.

Deliberate follow-ups tracked in #8878 (out of scope here): host-side provider-session dedup in `terminal.create`, and retiring resume records on tab close. Interaction with #8871: mirror-echo kills currently convert live sessions into pending duplicate resumes — this PR stops the duplicate-resume half on clients.

## Evidence

- **Root cause:** resume runs client-side with no runtime-ownership gate; guards only consult client-local `tabsByWorktree` / claim maps; host tabs arrive async via session-tabs mirror.
- **Fix site:** `src/renderer/src/lib/resume-sleeping-agent-session.ts` — early return when `isWebRuntimeSessionActive(getRuntimeEnvironmentIdForWorktree(...))`.
- **Automated:**
  ```bash
  pnpm exec vitest run --config config/vitest.config.ts \
    src/renderer/src/lib/resume-sleeping-agent-session-runtime-owner.test.ts \
    src/renderer/src/lib/repro-8878-remote-resume-no-runtime-gate.test.ts \
    src/renderer/src/lib/resume-sleeping-agent-session.test.ts \
    src/renderer/src/lib/resume-sleeping-agent-session-replay.test.ts \
    src/renderer/src/lib/resume-sleeping-agent-session-suppress-navigation.test.ts \
    src/renderer/src/lib/wake-sleeping-agents-in-background.test.ts \
    src/renderer/src/lib/worktree-activation
  ```
  → **16 files / 110 tests green** (65 resume + 45 activation).
- **Failing-first:** without the gate, runtime-owned matrix cases fail with `expected 1 to be +0` (client resumes a live host session); with the gate, all pass.
- **Adversarial matrix:**
  - explicit `runtime:*` worktree / repo host → skip
  - explicit `local` / `ssh:*` / WSL-local → still resume
  - runtime sibling isolation under different global focus
  - non-destructive record preservation + re-resume after ownership moves local
  - `folder:*` workspace keys via runtime project group
  - unmarked worktrees via active-runtime global fallback (paired client)
  - re-entrant activation + Terminal startup double-call stays 0

## ELI5

When you open a worktree from another computer that's connected to your main Orca machine, that remote computer used to try to "wake up" agent sessions it thought were asleep. But those sessions were still running fine on the main machine — so you got two chat windows fighting over the same agent. Now the remote computer knows "this worktree belongs to the host machine" and leaves wake-up to the host, same rule we already use for not auto-creating extra empty terminals.

## User-regression-tradeoffs

| Change | Who feels it | Tradeoff |
|--------|--------------|----------|
| Skip client-side sleeping-session resume for runtime-owned worktrees | Paired web / second-desktop clients | Clients no longer auto-resume host sessions they only mirrored; host remains the sole wake authority. Correct — clients never had enough state to decide safely. |
| Local / SSH / WSL resume | Unchanged | Explicit non-runtime owners still resume. |
| Sleeping records left on disk when gated | Clients with stale `origin:live/quit` records for host sessions | Records are preserved (non-destructive) so a later ownership move back to this client can still resume. Retirement-on-close is a separate follow-up. |
| No host-side `terminal.create` provider-session dedup | Defense-in-depth still missing if some other path spawns a resume | Intentional scope cut; tracked in #8878. This gate covers all four production call sites of the resume choke point. |