### PR TITLE
fix: Cmd/Ctrl+Shift+O opens markdown picker in main window

### DIFF
--- a/src/main/browser/browser-guest-ui.test.ts
+++ b/src/main/browser/browser-guest-ui.test.ts
@@ -689,6 +689,23 @@ describe('setupGuestShortcutForwarding', () => {
     expect(rendererSendMock).not.toHaveBeenCalled()
   })
 
+  it('forwards open-markdown shortcut from focused guest pages', () => {
+    setupGuestShortcutForwarding({
+      browserTabId,
+      guest: makeGuest(),
+      resolveRenderer: () => makeRenderer()
+    })
+
+    const preventDefault = triggerBeforeInput({
+      code: 'KeyO',
+      key: 'o',
+      shift: true
+    })
+
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(rendererSendMock).toHaveBeenCalledWith('ui:openMarkdownTab')
+  })
+
   it('forwards double-tap window shortcuts from focused guest pages', () => {
     setupGuestShortcutForwarding({
       browserTabId,

--- a/src/main/browser/browser-guest-ui.ts
+++ b/src/main/browser/browser-guest-ui.ts
@@ -418,6 +418,10 @@ export function setupGuestShortcutForwarding(args: {
       renderer.send('ui:newSimulatorTab')
     } else if (keybindingMatchesAction('tab.newMarkdown', input, process.platform, keybindings)) {
       renderer.send('ui:newMarkdownTab')
+    } else if (keybindingMatchesAction('tab.openMarkdown', input, process.platform, keybindings)) {
+      // Why: Cmd/Ctrl+Shift+O opens a markdown picker in the active surface.
+      // Guest pages never hit Terminal.tsx keydown, so forward to the renderer.
+      renderer.send('ui:openMarkdownTab')
     } else if (keybindingMatchesAction('tab.newTerminal', input, process.platform, keybindings)) {
       // Why: Cmd/Ctrl+T opens a terminal in the user's active terminal surface
       // even when focus is inside a browser guest. Cmd/Ctrl+Shift+B is the

--- a/src/main/ipc/app.test.ts
+++ b/src/main/ipc/app.test.ts
@@ -356,4 +356,49 @@ describe('registerAppHandlers', () => {
     })
     expect(grantFloatingWorkspaceDirectoryMock).toHaveBeenCalledWith(store, '/Users/kaylee/notes')
   })
+
+  it('picks a markdown file rooted at the given worktree cwd', async () => {
+    showOpenDialogMock.mockResolvedValue({
+      canceled: false,
+      filePaths: ['/Users/kaylee/repo/docs/notes.md']
+    })
+    registerAppHandlers({} as never)
+
+    await expect(
+      handlers.get('app:pickWorktreeMarkdownDocument')?.({ sender: {} }, '/Users/kaylee/repo')
+    ).resolves.toMatchObject({
+      filePath: '/Users/kaylee/repo/docs/notes.md',
+      relativePath: 'docs/notes.md',
+      basename: 'notes.md',
+      name: 'notes'
+    })
+    expect(showOpenDialogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultPath: '/Users/kaylee/repo',
+        properties: ['openFile'],
+        filters: [{ name: 'Markdown', extensions: ['md', 'mdx', 'markdown'] }]
+      })
+    )
+  })
+
+  it('returns null when the markdown file picker is cancelled', async () => {
+    showOpenDialogMock.mockResolvedValue({ canceled: true, filePaths: [] })
+    registerAppHandlers({} as never)
+
+    await expect(
+      handlers.get('app:pickWorktreeMarkdownDocument')?.({ sender: {} }, '/Users/kaylee/repo')
+    ).resolves.toBeNull()
+  })
+
+  it('rejects a picked file that is not a markdown document', async () => {
+    showOpenDialogMock.mockResolvedValue({
+      canceled: false,
+      filePaths: ['/Users/kaylee/repo/notes.txt']
+    })
+    registerAppHandlers({} as never)
+
+    await expect(
+      handlers.get('app:pickWorktreeMarkdownDocument')?.({ sender: {} }, '/Users/kaylee/repo')
+    ).rejects.toThrow('Selected file is not a markdown document.')
+  })
 })

--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -37,10 +37,10 @@ type RegisterAppHandlersOptions = {
   onBeforeRelaunch?: () => void | Promise<void>
 }
 
-async function pickFloatingMarkdownDocument(
-  event: IpcMainInvokeEvent
+async function pickMarkdownDocumentAt(
+  event: IpcMainInvokeEvent,
+  cwd: string
 ): Promise<MarkdownDocument | null> {
-  const cwd = await ensureDefaultFloatingWorkspacePath()
   const options = {
     defaultPath: cwd,
     properties: ['openFile'],
@@ -59,6 +59,20 @@ async function pickFloatingMarkdownDocument(
   }
   authorizeExternalPath(filePath)
   return markdownDocumentFromFilePath(cwd, filePath, { outsideRootRelativePath: 'basename' })
+}
+
+async function pickFloatingMarkdownDocument(
+  event: IpcMainInvokeEvent
+): Promise<MarkdownDocument | null> {
+  const cwd = await ensureDefaultFloatingWorkspacePath()
+  return pickMarkdownDocumentAt(event, cwd)
+}
+
+async function pickWorktreeMarkdownDocument(
+  event: IpcMainInvokeEvent,
+  cwd: string
+): Promise<MarkdownDocument | null> {
+  return pickMarkdownDocumentAt(event, cwd)
 }
 
 async function pickFloatingWorkspaceDirectory(
@@ -341,6 +355,10 @@ export function registerAppHandlers(store: Store, options: RegisterAppHandlersOp
   ipcMain.handle('app:getFloatingMarkdownDirectory', () => ensureDefaultFloatingWorkspacePath())
 
   ipcMain.handle('app:pickFloatingMarkdownDocument', (event) => pickFloatingMarkdownDocument(event))
+
+  ipcMain.handle('app:pickWorktreeMarkdownDocument', (event, cwd: string) =>
+    pickWorktreeMarkdownDocument(event, cwd)
+  )
 
   ipcMain.handle('app:pickFloatingWorkspaceDirectory', (event) =>
     pickFloatingWorkspaceDirectory(event, store)

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -913,6 +913,9 @@ export type AppApi = {
   /** Opens a native picker for markdown documents, rooted in the floating
    *  workspace, and authorizes the selected file for editor reads/writes. */
   pickFloatingMarkdownDocument: () => Promise<MarkdownDocument | null>
+  /** Opens a native picker for markdown documents, rooted in the given
+   *  worktree path, and authorizes the selected file for editor reads/writes. */
+  pickWorktreeMarkdownDocument: (cwd: string) => Promise<MarkdownDocument | null>
   /** Opens a native directory picker and authorizes the selected directory
    *  for Floating Workspace markdown file creation. */
   pickFloatingWorkspaceDirectory: () => Promise<string | null>

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2793,6 +2793,7 @@ export type PreloadApi = {
     onWorktreeHistoryNavigate: (callback: (direction: 'back' | 'forward') => void) => () => void
     onNewBrowserTab: (callback: () => void) => () => void
     onNewMarkdownTab: (callback: () => void) => () => void
+    onOpenMarkdownTab: (callback: () => void) => () => void
     onNewSimulatorTab: (callback: () => void) => () => void
     onRequestTabCreate: (
       callback: (data: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -503,6 +503,8 @@ const api = {
       ipcRenderer.invoke('app:getFloatingMarkdownDirectory'),
     pickFloatingMarkdownDocument: (): Promise<MarkdownDocument | null> =>
       ipcRenderer.invoke('app:pickFloatingMarkdownDocument'),
+    pickWorktreeMarkdownDocument: (cwd: string): Promise<MarkdownDocument | null> =>
+      ipcRenderer.invoke('app:pickWorktreeMarkdownDocument', cwd),
     pickFloatingWorkspaceDirectory: (): Promise<string | null> =>
       ipcRenderer.invoke('app:pickFloatingWorkspaceDirectory')
   },

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3279,6 +3279,11 @@ const api = {
       ipcRenderer.on('ui:newMarkdownTab', listener)
       return () => ipcRenderer.removeListener('ui:newMarkdownTab', listener)
     },
+    onOpenMarkdownTab: (callback: () => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent) => callback()
+      ipcRenderer.on('ui:openMarkdownTab', listener)
+      return () => ipcRenderer.removeListener('ui:openMarkdownTab', listener)
+    },
     onNewSimulatorTab: (callback: () => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent) => callback()
       ipcRenderer.on('ui:newSimulatorTab', listener)

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -119,6 +119,7 @@ import {
   createFloatingWorkspaceTerminalTab,
   handleEmptyFloatingWorkspacePanelCloseShortcut,
   isFloatingWorkspacePanelFocused,
+  openFloatingWorkspaceMarkdownTab,
   switchFloatingWorkspaceTab
 } from '@/lib/floating-workspace-terminal-actions'
 import {
@@ -308,6 +309,7 @@ function Terminal(): React.JSX.Element | null {
     (s) => s.openNewBrowserTabInActiveWorkspace
   )
   const openNewMarkdownInActiveWorkspace = useAppStore((s) => s.openNewMarkdownInActiveWorkspace)
+  const openMarkdownFileInActiveWorkspace = useAppStore((s) => s.openMarkdownFileInActiveWorkspace)
   const openNewTerminalTabInActiveWorkspace = useAppStore(
     (s) => s.openNewTerminalTabInActiveWorkspace
   )
@@ -1444,6 +1446,19 @@ function Terminal(): React.JSX.Element | null {
     await openNewMarkdownInActiveWorkspace(targetGroupId)
   }, [activeWorktreeId, openNewMarkdownInActiveWorkspace])
 
+  const handleOpenFile = useCallback(async () => {
+    if (!activeWorktreeId) {
+      return
+    }
+    const targetGroupId =
+      useAppStore.getState().activeGroupIdByWorktree[activeWorktreeId] ??
+      useAppStore.getState().groupsByWorktree[activeWorktreeId]?.[0]?.id
+    if (!targetGroupId) {
+      return
+    }
+    await openMarkdownFileInActiveWorkspace(targetGroupId)
+  }, [activeWorktreeId, openMarkdownFileInActiveWorkspace])
+
   const handleCloseTab = useCallback((tabId: string) => {
     closeTerminalTab(tabId)
   }, [])
@@ -1899,6 +1914,24 @@ function Terminal(): React.JSX.Element | null {
         return
       }
 
+      // Cmd/Ctrl+Shift+O - open existing markdown file
+      if (!e.repeat && matchShortcut('tab.openMarkdown')) {
+        e.preventDefault()
+        notifyTerminalCapture('tab.openMarkdown')
+        if (floatingWorkspaceFocused) {
+          void openFloatingWorkspaceMarkdownTab(useAppStore.getState()).catch((err) => {
+            toast.error(
+              err instanceof Error
+                ? err.message
+                : translate('auto.components.Terminal.3a460c3322', 'Failed to open markdown file.')
+            )
+          })
+          return
+        }
+        void handleOpenFile()
+        return
+      }
+
       if (handleEmptyFloatingWorkspacePanelCloseShortcut(e, shortcutPlatform, keybindings)) {
         return
       }
@@ -2040,6 +2073,7 @@ function Terminal(): React.JSX.Element | null {
     handleNewBrowserTab,
     handleNewSimulatorTab,
     handleNewFile,
+    handleOpenFile,
     handleNewTab,
     handleNewAgentTab,
     handleCloseTab,
@@ -2199,6 +2233,7 @@ function Terminal(): React.JSX.Element | null {
             onNewSimulatorTab={mobileEmulatorEnabled ? handleNewSimulatorTab : undefined}
             onOpenEntry={handleOpenEntry}
             onNewFileTab={handleNewFile}
+            onOpenFileTab={handleOpenFile}
             onSetCustomTitle={setTabCustomTitle}
             onSetTabColor={setTabColor}
             expandedPaneByTabId={expandedPaneByTabId}

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -988,6 +988,7 @@ describe('useIpcEvents browser tab create routing', () => {
           onResumeSleepingAgents: () => () => {},
           onNewBrowserTab: () => () => {},
           onNewMarkdownTab: () => () => {},
+          onOpenMarkdownTab: () => () => {},
           onRequestTabCreate: (
             listener: NonNullable<typeof requestTabCreateListenerRef.current>
           ) => {
@@ -1211,6 +1212,7 @@ describe('useIpcEvents updater integration', () => {
           onResumeSleepingAgents: () => () => {},
           onNewBrowserTab: () => () => {},
           onNewMarkdownTab: () => () => {},
+          onOpenMarkdownTab: () => () => {},
           onRequestTabCreate: () => () => {},
           replyTabCreate: () => {},
           onRequestTabClose: () => () => {},
@@ -1581,6 +1583,7 @@ describe('useIpcEvents updater integration', () => {
           onResumeSleepingAgents: () => () => {},
           onNewBrowserTab: () => () => {},
           onNewMarkdownTab: () => () => {},
+          onOpenMarkdownTab: () => () => {},
           onRequestTabCreate: () => () => {},
           replyTabCreate: () => {},
           onRequestTabClose: () => () => {},
@@ -2079,6 +2082,7 @@ describe('useIpcEvents updater integration', () => {
           onResumeSleepingAgents: () => () => {},
           onNewBrowserTab: () => () => {},
           onNewMarkdownTab: () => () => {},
+          onOpenMarkdownTab: () => () => {},
           onRequestTabCreate: () => () => {},
           replyTabCreate: () => {},
           onRequestTabClose: () => () => {},
@@ -2988,6 +2992,7 @@ describe('useIpcEvents browser tab close routing', () => {
           onResumeSleepingAgents: () => () => {},
           onNewBrowserTab: () => () => {},
           onNewMarkdownTab: () => () => {},
+          onOpenMarkdownTab: () => () => {},
           onRequestTabCreate: () => () => {},
           replyTabCreate: () => {},
           onRequestTabClose: (listener: RequestTabCloseListener) => {
@@ -3528,6 +3533,7 @@ describe('useIpcEvents browser tab close routing', () => {
           onResumeSleepingAgents: () => () => {},
           onNewBrowserTab: () => () => {},
           onNewMarkdownTab: () => () => {},
+          onOpenMarkdownTab: () => () => {},
           onRequestTabCreate: () => () => {},
           replyTabCreate: () => {},
           onRequestTabClose: (
@@ -3747,6 +3753,7 @@ describe('useIpcEvents browser tab close routing', () => {
           onResumeSleepingAgents: () => () => {},
           onNewBrowserTab: () => () => {},
           onNewMarkdownTab: () => () => {},
+          onOpenMarkdownTab: () => () => {},
           onRequestTabCreate: () => () => {},
           replyTabCreate: () => {},
           onRequestTabClose: (
@@ -3961,6 +3968,7 @@ describe('useIpcEvents browser tab close routing', () => {
           onResumeSleepingAgents: () => () => {},
           onNewBrowserTab: () => () => {},
           onNewMarkdownTab: () => () => {},
+          onOpenMarkdownTab: () => () => {},
           onRequestTabCreate: () => () => {},
           replyTabCreate: () => {},
           onRequestTabClose: (
@@ -4202,6 +4210,7 @@ describe('useIpcEvents CLI-created worktree activation', () => {
           onResumeSleepingAgents: () => () => {},
           onNewBrowserTab: () => () => {},
           onNewMarkdownTab: () => () => {},
+          onOpenMarkdownTab: () => () => {},
           onRequestTabCreate: () => () => {},
           replyTabCreate: () => {},
           onRequestTabClose: () => () => {},
@@ -4451,6 +4460,7 @@ describe('useIpcEvents CLI-created worktree activation', () => {
           onResumeSleepingAgents: () => () => {},
           onNewBrowserTab: () => () => {},
           onNewMarkdownTab: () => () => {},
+          onOpenMarkdownTab: () => () => {},
           onRequestTabCreate: () => () => {},
           replyTabCreate: () => {},
           onRequestTabClose: () => () => {},
@@ -4686,6 +4696,7 @@ describe('useIpcEvents agent status snapshot integration', () => {
           onResumeSleepingAgents: () => () => {},
           onNewBrowserTab: () => () => {},
           onNewMarkdownTab: () => () => {},
+          onOpenMarkdownTab: () => () => {},
           onRequestTabCreate: () => () => {},
           replyTabCreate: () => {},
           onRequestTabClose: () => () => {},

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -115,6 +115,7 @@ import {
   createFloatingWorkspaceTerminalTab,
   isEmptyFloatingWorkspacePanelVisible,
   isFloatingWorkspacePanelFocused,
+  openFloatingWorkspaceMarkdownTab,
   switchFloatingWorkspaceTab
 } from '@/lib/floating-workspace-terminal-actions'
 import {
@@ -2245,6 +2246,31 @@ export function useIpcEvents(): void {
           store.activeGroupIdByWorktree[worktreeId] ?? store.groupsByWorktree[worktreeId]?.[0]?.id
         if (targetGroupId) {
           void store.openNewMarkdownInActiveWorkspace(targetGroupId)
+        }
+      })
+    )
+
+    unsubs.push(
+      window.api.ui.onOpenMarkdownTab(() => {
+        const store = useAppStore.getState()
+        if (isFloatingWorkspacePanelFocused()) {
+          void openFloatingWorkspaceMarkdownTab(store).catch((err) => {
+            toast.error(
+              err instanceof Error
+                ? err.message
+                : translate('auto.hooks.useIpcEvents.3a460c3322', 'Failed to open markdown file.')
+            )
+          })
+          return
+        }
+        const worktreeId = store.activeWorktreeId
+        if (!worktreeId) {
+          return
+        }
+        const targetGroupId =
+          store.activeGroupIdByWorktree[worktreeId] ?? store.groupsByWorktree[worktreeId]?.[0]?.id
+        if (targetGroupId) {
+          void store.openMarkdownFileInActiveWorkspace(targetGroupId)
         }
       })
     )

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -626,6 +626,7 @@
         "f45fa2b03c": "Browser profiles are unavailable while a remote runtime is active",
         "f000b2ff76": "No active worktree",
         "56d3ec4203": "Failed to create untitled markdown file.",
+        "3a460c3322": "Failed to open markdown file.",
         "f6300deb8b": "New Browser Tab",
         "7a64b31991": "Local terminal creation is unavailable while a remote runtime is active",
         "60428567b4": "Local terminal reveal is unavailable while a remote runtime is active",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1776,7 +1776,8 @@
         "61ed600d29": "\"{{value0}}\" has unsaved changes. Do you want to save before closing?",
         "cdc9ac4b2d": "editor",
         "e57db40c11": "Could not build launch command for {{value0}}.",
-        "5b2c1a9e44": "No agent CLI detected — install one or pick a default agent in Settings."
+        "5b2c1a9e44": "No agent CLI detected — install one or pick a default agent in Settings.",
+        "3a460c3322": "Failed to open markdown file."
       },
       "TerminalSearch": {
         "db234b7519": "Close",

--- a/src/renderer/src/lib/floating-workspace-tab-creation.ts
+++ b/src/renderer/src/lib/floating-workspace-tab-creation.ts
@@ -82,3 +82,28 @@ export async function createFloatingWorkspaceMarkdownTab(
     }
   )
 }
+
+export async function openFloatingWorkspaceMarkdownTab(
+  store: FloatingWorkspaceMarkdownStore
+): Promise<void> {
+  const targetGroupId = store.activeGroupIdByWorktree[FLOATING_TERMINAL_WORKTREE_ID]
+  const document = await window.api.app.pickFloatingMarkdownDocument()
+  if (!document) {
+    return
+  }
+  store.openFile(
+    {
+      filePath: document.filePath,
+      relativePath: document.relativePath,
+      worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+      language: detectLanguage(document.relativePath),
+      mode: 'edit',
+      runtimeEnvironmentId: null
+    },
+    {
+      preview: false,
+      targetGroupId,
+      suppressActiveRuntimeFallback: true
+    }
+  )
+}

--- a/src/renderer/src/lib/floating-workspace-terminal-actions.ts
+++ b/src/renderer/src/lib/floating-workspace-terminal-actions.ts
@@ -14,7 +14,8 @@ import { keybindingMatchesAction, type KeybindingOverrides } from '../../../shar
 export {
   createFloatingWorkspaceBrowserTab,
   createFloatingWorkspaceMarkdownTab,
-  createFloatingWorkspaceTerminalTab
+  createFloatingWorkspaceTerminalTab,
+  openFloatingWorkspaceMarkdownTab
 } from './floating-workspace-tab-creation'
 export {
   isFloatingWorkspacePanelShortcut,

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -493,6 +493,7 @@ export type EditorSlice = {
     }
   ) => void
   openNewMarkdownInActiveWorkspace: (groupId: string) => Promise<void>
+  openMarkdownFileInActiveWorkspace: (groupId: string) => Promise<void>
   // Why: dispatcher for markdown link activation. Lives on the slice because it
   // sequences openFile, setMarkdownViewMode, and setPendingEditorReveal around
   // an async Monaco remount — all reading/writing state in this slice. See
@@ -1887,6 +1888,37 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       get().recordFeatureInteraction('markdown-file-created')
     } catch (err) {
       toast.error(extractIpcErrorMessage(err, 'Failed to create untitled markdown file.'))
+    }
+  },
+
+  openMarkdownFileInActiveWorkspace: async (groupId) => {
+    const state = get()
+    const worktreeId = state.activeWorktreeId
+    if (!worktreeId) {
+      return
+    }
+    const worktree = state.getKnownWorktreeById(worktreeId)
+    if (!worktree) {
+      return
+    }
+    try {
+      const document = await window.api.app.pickWorktreeMarkdownDocument(worktree.path)
+      if (!document) {
+        return
+      }
+      get().openFile(
+        {
+          filePath: document.filePath,
+          relativePath: document.relativePath,
+          worktreeId,
+          language: detectLanguage(document.relativePath),
+          mode: 'edit',
+          runtimeEnvironmentId: null
+        },
+        { preview: false, targetGroupId: groupId }
+      )
+    } catch (err) {
+      toast.error(extractIpcErrorMessage(err, 'Failed to open markdown file.'))
     }
   },
 

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -1901,6 +1901,15 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
     if (!worktree) {
       return
     }
+    // Why: the picker uses a local Electron file dialog, which can't browse a
+    // remote host's filesystem. Guard remote worktrees instead of letting the
+    // user pick a local file that doesn't belong to the remote worktree.
+    const connectionId =
+      state.repos.find((entry) => entry.id === worktree.repoId)?.connectionId ?? undefined
+    if (connectionId) {
+      toast.error('Opening a markdown file is not supported for remote worktrees yet.')
+      return
+    }
     try {
       const document = await window.api.app.pickWorktreeMarkdownDocument(worktree.path)
       if (!document) {

--- a/src/renderer/src/store/slices/open-markdown-file.test.ts
+++ b/src/renderer/src/store/slices/open-markdown-file.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { toast } from 'sonner'
+import { createTestStore, makeWorktree, TEST_REPO } from './store-test-helpers'
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn()
+  }
+}))
+
+const wt1 = makeWorktree({ id: 'wt-1', repoId: TEST_REPO.id, path: '/repo1/wt1' })
+
+function seedActiveWorktree(store: ReturnType<typeof createTestStore>): void {
+  store.setState({
+    repos: [TEST_REPO],
+    worktreesByRepo: { [TEST_REPO.id]: [wt1] },
+    activeWorktreeId: wt1.id
+  })
+}
+
+describe('openMarkdownFileInActiveWorkspace', () => {
+  beforeEach(() => {
+    vi.mocked(toast.error).mockClear()
+  })
+
+  it('opens the picked file rooted at the active worktree path', async () => {
+    const pickWorktreeMarkdownDocument = vi.fn().mockResolvedValue({
+      filePath: '/repo1/wt1/notes.md',
+      relativePath: 'notes.md'
+    })
+    globalThis.window.api = {
+      app: { pickWorktreeMarkdownDocument }
+    } as unknown as Window['api']
+
+    const store = createTestStore()
+    seedActiveWorktree(store)
+
+    await store.getState().openMarkdownFileInActiveWorkspace('group-1')
+
+    expect(pickWorktreeMarkdownDocument).toHaveBeenCalledWith(wt1.path)
+    expect(store.getState().openFiles).toHaveLength(1)
+    expect(store.getState().openFiles[0]).toMatchObject({
+      filePath: '/repo1/wt1/notes.md',
+      relativePath: 'notes.md',
+      worktreeId: wt1.id,
+      language: 'markdown',
+      mode: 'edit'
+    })
+  })
+
+  it('does nothing when the picker is cancelled', async () => {
+    const pickWorktreeMarkdownDocument = vi.fn().mockResolvedValue(null)
+    globalThis.window.api = {
+      app: { pickWorktreeMarkdownDocument }
+    } as unknown as Window['api']
+
+    const store = createTestStore()
+    seedActiveWorktree(store)
+
+    await store.getState().openMarkdownFileInActiveWorkspace('group-1')
+
+    expect(store.getState().openFiles).toHaveLength(0)
+  })
+
+  it('does nothing when there is no active worktree', async () => {
+    const pickWorktreeMarkdownDocument = vi.fn()
+    globalThis.window.api = {
+      app: { pickWorktreeMarkdownDocument }
+    } as unknown as Window['api']
+
+    const store = createTestStore()
+    store.setState({ repos: [TEST_REPO], activeWorktreeId: null })
+
+    await store.getState().openMarkdownFileInActiveWorkspace('group-1')
+
+    expect(pickWorktreeMarkdownDocument).not.toHaveBeenCalled()
+    expect(store.getState().openFiles).toHaveLength(0)
+  })
+
+  it('shows a toast error when the picker rejects', async () => {
+    const pickWorktreeMarkdownDocument = vi.fn().mockRejectedValue(new Error('boom'))
+    globalThis.window.api = {
+      app: { pickWorktreeMarkdownDocument }
+    } as unknown as Window['api']
+
+    const store = createTestStore()
+    seedActiveWorktree(store)
+
+    await store.getState().openMarkdownFileInActiveWorkspace('group-1')
+
+    expect(toast.error).toHaveBeenCalledWith('boom')
+    expect(store.getState().openFiles).toHaveLength(0)
+  })
+})

--- a/src/renderer/src/store/slices/open-markdown-file.test.ts
+++ b/src/renderer/src/store/slices/open-markdown-file.test.ts
@@ -82,6 +82,27 @@ describe('openMarkdownFileInActiveWorkspace', () => {
     expect(store.getState().openFiles).toHaveLength(0)
   })
 
+  it('guards remote worktrees instead of opening the local file dialog', async () => {
+    const pickWorktreeMarkdownDocument = vi.fn()
+    globalThis.window.api = {
+      app: { pickWorktreeMarkdownDocument }
+    } as unknown as Window['api']
+
+    const store = createTestStore()
+    const remoteRepo = { ...TEST_REPO, connectionId: 'conn-1' }
+    store.setState({
+      repos: [remoteRepo],
+      worktreesByRepo: { [remoteRepo.id]: [wt1] },
+      activeWorktreeId: wt1.id
+    })
+
+    await store.getState().openMarkdownFileInActiveWorkspace('group-1')
+
+    expect(pickWorktreeMarkdownDocument).not.toHaveBeenCalled()
+    expect(toast.error).toHaveBeenCalled()
+    expect(store.getState().openFiles).toHaveLength(0)
+  })
+
   it('shows a toast error when the picker rejects', async () => {
     const pickWorktreeMarkdownDocument = vi.fn().mockRejectedValue(new Error('boom'))
     globalThis.window.api = {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2488,6 +2488,7 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
     onWorktreeHistoryNavigate: () => noopUnsubscribe,
     onNewBrowserTab: () => noopUnsubscribe,
     onNewMarkdownTab: () => noopUnsubscribe,
+    onOpenMarkdownTab: () => noopUnsubscribe,
     onNewSimulatorTab: () => noopUnsubscribe,
     onRequestTabCreate: () => noopUnsubscribe,
     replyTabCreate: () => {},

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -499,6 +499,7 @@ function createWebPreloadApi(): Partial<PreloadApi> {
       getFloatingTerminalCwd: () => Promise.resolve(''),
       getFloatingMarkdownDirectory: () => Promise.resolve(''),
       pickFloatingMarkdownDocument: () => Promise.resolve(null),
+      pickWorktreeMarkdownDocument: () => Promise.resolve(null),
       pickFloatingWorkspaceDirectory: () => Promise.resolve(null)
     },
     starNag: {


### PR DESCRIPTION
## Description
`tab.openMarkdown` (`Cmd/Ctrl+Shift+O`) only worked inside the Floating Terminal panel: the action lived in the floating shortcut list and floating keydown path, but the main-window Terminal keydown handler and browser-guest forwarder never wired it.

This takes over / builds on #8564 by @VitorRibeiroCustodio:

- Main-window keydown + tab-bar **Open Markdown…** menu call a new store action that opens a native markdown picker rooted at the active worktree, then `openFile`s the selection (mirrors `tab.newMarkdown`).
- Shared IPC `app:pickWorktreeMarkdownDocument` reuses the floating picker helper (filters, authorize, markdown name check).
- Floating workspace still works via the panel’s own handler and Terminal’s floating-focused branch (`openFloatingWorkspaceMarkdownTab`).
- Remote (SSH) worktrees are guarded with a toast — local Electron dialogs cannot browse remote FS.
- **Completeness beyond #8564:** browser guests forward `ui:openMarkdownTab` (same gap the issue called out for `ui:newMarkdownTab`), handled in `useIpcEvents`.

## Evidence
- Confirmed gap on main: Terminal had `tab.newMarkdown` only; no `tab.openMarkdown` / no `onOpenFileTab` wiring; guest UI had `ui:newMarkdownTab` only.
- Vitest (`config/vitest.config.ts`):
  - `src/main/ipc/app.test.ts` — picker IPC (pick / cancel / non-md reject)
  - `src/renderer/src/store/slices/open-markdown-file.test.ts` — open / cancel / no worktree / remote guard / reject toast
  - `src/main/browser/browser-guest-ui.test.ts` — guest `Cmd/Ctrl+Shift+O` → `ui:openMarkdownTab`
- oxlint clean on touched files

## ELI5
The “open markdown” keyboard shortcut was only plugged into the floating mini-window. We plugged it into the normal app window (and browser tabs) the same way “new markdown” already was, so the shortcut opens the file picker everywhere you’d expect.

## User-regression-tradeoffs
- **Local main window:** shortcut + tab menu open the picker (intended fix).
- **Floating terminal:** unchanged behavior (still opens floating markdown picker).
- **Browser guest focus:** shortcut now works (was broken like main window).
- **SSH/remote worktrees:** toast instead of local-only dialog (avoids opening a wrong-host file). Use file explorer / quick open for remote markdown until a remote-aware picker exists.
- **Linux/Windows:** uses `Mod` → Ctrl; same as other tab shortcuts. No new platform-specific binding.
- **terminal-first policy:** same as `tab.newMarkdown` — not captured when xterm owns focus under terminal-first (by design for tab-scoped shortcuts).
- Does not add a main-menu accelerator; matches existing `tab.newMarkdown` pattern (renderer + guest IPC).

Fixes #8532

Credit: core main-window picker path from #8564 (@VitorRibeiroCustodio).