### PR TITLE
fix(sidebar): preserve Project Group members under Hide sleeping

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -5711,9 +5711,10 @@ const WorktreeList = React.memo(function WorktreeList({
       groupBy,
       repos: visibleReposForRows,
       worktreesByRepo,
+      visibleWorktrees,
       filterRepoIds
     })
-  }, [filterRepoIds, groupBy, visibleReposForRows, worktreesByRepo])
+  }, [filterRepoIds, groupBy, visibleReposForRows, visibleWorktrees, worktreesByRepo])
   const allRepoIds = useMemo(() => repos.map((r) => r.id), [repos])
 
   // Why: buildRows only needs which creates exist and their repo. Subscribe on a

--- a/src/renderer/src/components/sidebar/empty-project-placeholder-repos.test.ts
+++ b/src/renderer/src/components/sidebar/empty-project-placeholder-repos.test.ts
@@ -38,6 +38,7 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
           groupBy: 'repo',
           repos: [repo],
           worktreesByRepo: { [repo.id]: [] },
+          visibleWorktrees: [],
           filterRepoIds: []
         })
       )
@@ -51,6 +52,7 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
           groupBy: 'repo',
           repos: [repo],
           worktreesByRepo: {},
+          visibleWorktrees: [],
           filterRepoIds: []
         })
       )
@@ -67,6 +69,7 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
           groupBy: 'repo',
           repos: [selectedRepo, hiddenRepo],
           worktreesByRepo: { [selectedRepo.id]: [], [hiddenRepo.id]: [] },
+          visibleWorktrees: [],
           filterRepoIds: [selectedRepo.id]
         })
       )
@@ -79,6 +82,7 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
         groupBy: 'none',
         repos: [repo],
         worktreesByRepo: { [repo.id]: [] },
+        visibleWorktrees: [],
         filterRepoIds: []
       }).size
     ).toBe(0)
@@ -90,6 +94,39 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
         groupBy: 'repo',
         repos: [repo],
         worktreesByRepo: { [repo.id]: [worktree] },
+        visibleWorktrees: [],
+        filterRepoIds: []
+      }).size
+    ).toBe(0)
+  })
+
+  it('keeps grouped repos visible when workspace filters hide all of their rows', () => {
+    const groupedRepo: Repo = { ...repo, projectGroupId: 'group-1' }
+    const groupedWorktree: Worktree = { ...worktree, repoId: groupedRepo.id }
+
+    expect(
+      Array.from(
+        getEmptyProjectPlaceholderRepoIds({
+          groupBy: 'repo',
+          repos: [groupedRepo],
+          worktreesByRepo: { [groupedRepo.id]: [groupedWorktree] },
+          visibleWorktrees: [],
+          filterRepoIds: []
+        })
+      )
+    ).toEqual([groupedRepo.id])
+  })
+
+  it('does not create a grouped repo placeholder when one of its workspaces is visible', () => {
+    const groupedRepo: Repo = { ...repo, projectGroupId: 'group-1' }
+    const groupedWorktree: Worktree = { ...worktree, repoId: groupedRepo.id }
+
+    expect(
+      getEmptyProjectPlaceholderRepoIds({
+        groupBy: 'repo',
+        repos: [groupedRepo],
+        worktreesByRepo: { [groupedRepo.id]: [groupedWorktree] },
+        visibleWorktrees: [groupedWorktree],
         filterRepoIds: []
       }).size
     ).toBe(0)

--- a/src/renderer/src/components/sidebar/empty-project-placeholder-repos.test.ts
+++ b/src/renderer/src/components/sidebar/empty-project-placeholder-repos.test.ts
@@ -131,4 +131,72 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
       }).size
     ).toBe(0)
   })
+
+  it('still respects explicit project filters for sleep-filtered grouped members', () => {
+    const selected: Repo = { ...repo, id: 'repo-selected', projectGroupId: 'group-1' }
+    const filteredOut: Repo = { ...repo, id: 'repo-hidden', projectGroupId: 'group-1' }
+    const selectedWt: Worktree = { ...worktree, id: 'wt-selected', repoId: selected.id }
+    const hiddenWt: Worktree = { ...worktree, id: 'wt-hidden', repoId: filteredOut.id }
+
+    expect(
+      Array.from(
+        getEmptyProjectPlaceholderRepoIds({
+          groupBy: 'repo',
+          repos: [selected, filteredOut],
+          worktreesByRepo: {
+            [selected.id]: [selectedWt],
+            [filteredOut.id]: [hiddenWt]
+          },
+          // Why: simulate Hide sleeping removing every card while the project
+          // filter still intentionally excludes `filteredOut`.
+          visibleWorktrees: [],
+          filterRepoIds: [selected.id]
+        })
+      )
+    ).toEqual([selected.id])
+  })
+
+  it('placeholders only the fully-filtered members of a multi-project group', () => {
+    const sleeping: Repo = { ...repo, id: 'repo-sleeping', projectGroupId: 'group-1' }
+    const awake: Repo = { ...repo, id: 'repo-awake', projectGroupId: 'group-1' }
+    const sleepingWt: Worktree = { ...worktree, id: 'wt-sleeping', repoId: sleeping.id }
+    const awakeWt: Worktree = { ...worktree, id: 'wt-awake', repoId: awake.id }
+
+    expect(
+      Array.from(
+        getEmptyProjectPlaceholderRepoIds({
+          groupBy: 'repo',
+          repos: [sleeping, awake],
+          worktreesByRepo: {
+            [sleeping.id]: [sleepingWt],
+            [awake.id]: [awakeWt]
+          },
+          visibleWorktrees: [awakeWt],
+          filterRepoIds: []
+        })
+      )
+    ).toEqual([sleeping.id])
+  })
+
+  it('does not placeholder ungrouped neighbors of a filtered grouped member', () => {
+    const grouped: Repo = { ...repo, id: 'repo-grouped', projectGroupId: 'group-1' }
+    const ungrouped: Repo = { ...repo, id: 'repo-ungrouped' }
+    const groupedWt: Worktree = { ...worktree, id: 'wt-grouped', repoId: grouped.id }
+    const ungroupedWt: Worktree = { ...worktree, id: 'wt-ungrouped', repoId: ungrouped.id }
+
+    expect(
+      Array.from(
+        getEmptyProjectPlaceholderRepoIds({
+          groupBy: 'repo',
+          repos: [grouped, ungrouped],
+          worktreesByRepo: {
+            [grouped.id]: [groupedWt],
+            [ungrouped.id]: [ungroupedWt]
+          },
+          visibleWorktrees: [],
+          filterRepoIds: []
+        })
+      )
+    ).toEqual([grouped.id])
+  })
 })

--- a/src/renderer/src/components/sidebar/empty-project-placeholder-repos.ts
+++ b/src/renderer/src/components/sidebar/empty-project-placeholder-repos.ts
@@ -5,6 +5,7 @@ export function getEmptyProjectPlaceholderRepoIds(args: {
   groupBy: WorktreeGroupBy
   repos: readonly Repo[]
   worktreesByRepo: Readonly<Record<string, readonly Worktree[] | undefined>>
+  visibleWorktrees: readonly Worktree[]
   filterRepoIds: readonly string[]
 }): Set<string> {
   if (args.groupBy !== 'repo') {
@@ -12,12 +13,17 @@ export function getEmptyProjectPlaceholderRepoIds(args: {
   }
 
   const filterSet = args.filterRepoIds.length > 0 ? new Set(args.filterRepoIds) : null
+  const visibleRepoIds = new Set(args.visibleWorktrees.map((worktree) => worktree.repoId))
   const placeholderRepoIds = new Set<string>()
   for (const repo of args.repos) {
     if (filterSet && !filterSet.has(repo.id)) {
       continue
     }
-    if ((args.worktreesByRepo[repo.id]?.length ?? 0) === 0) {
+    const hasNoWorktrees = (args.worktreesByRepo[repo.id]?.length ?? 0) === 0
+    // Why: workspace filters hide cards, but must not rewrite the visible
+    // membership of a persisted Project Group. #8865
+    const isFilteredProjectGroupMember = repo.projectGroupId != null && !visibleRepoIds.has(repo.id)
+    if (hasNoWorktrees || isFilteredProjectGroupMember) {
       placeholderRepoIds.add(repo.id)
     }
   }

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -1933,6 +1933,73 @@ describe('project groups', () => {
     expect(rows[0]).toMatchObject({ label: 'Platform' })
   })
 
+  it('keeps sleep-filtered Project Group members as empty project headers', () => {
+    // Why: #8865 — Hide sleeping removes workspace cards; membership placeholders
+    // must still project the grouped project header so the group count stays honest.
+    const group: ProjectGroup = {
+      id: 'group-1',
+      name: 'Platform',
+      parentPath: '/platform',
+      parentGroupId: null,
+      createdFrom: 'folder-scan',
+      tabOrder: 0,
+      isCollapsed: false,
+      color: null,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const sleepingRepo: Repo = {
+      ...repo,
+      id: 'repo-sleeping',
+      displayName: 'sleeping-project',
+      projectGroupId: group.id
+    }
+    const awakeRepo: Repo = {
+      ...repo,
+      id: 'repo-awake',
+      displayName: 'awake-project',
+      projectGroupId: group.id
+    }
+    const awakeWorktree: Worktree = {
+      ...worktree,
+      id: 'wt-awake',
+      repoId: awakeRepo.id,
+      path: '/tmp/awake'
+    }
+
+    const rows = buildRows(
+      'repo',
+      [awakeWorktree],
+      new Map([
+        [sleepingRepo.id, sleepingRepo],
+        [awakeRepo.id, awakeRepo]
+      ]),
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      {},
+      new Map([[awakeWorktree.id, awakeWorktree]]),
+      false,
+      undefined,
+      [group],
+      new Set([sleepingRepo.id])
+    )
+
+    expect(rows[0]).toMatchObject({
+      type: 'header',
+      key: 'project-group:group-1',
+      count: 2
+    })
+    // Why: empty/placeholder projects sort after projects with visible activity.
+    expect(rows.filter((row) => row.type === 'header').map((row) => row.key)).toEqual([
+      'project-group:group-1',
+      `repo:${awakeRepo.id}`,
+      `repo:${sleepingRepo.id}`
+    ])
+  })
+
   it('renders ungrouped repos as top-level repo rows when Project Groups exist', () => {
     const group: ProjectGroup = {
       id: 'group-1',


### PR DESCRIPTION
## Summary

**Hide sleeping** (and other workspace-level filters) was erasing Project Group membership: if every workspace under a grouped project was filtered out, the project header vanished and the group count dropped — even though `repo.list` / profile membership were still complete.

This keeps every persisted Project Group member visible as a project header when workspace filters hide all of its cards. Ungrouped projects still hide under the existing sleep-filter behavior. Explicit project filters and host scope continue to apply.

Fixes #8865.

Credit: core fix by @bbingz in #8866 (cherry-picked and rebased onto current `main`, with additional adversarial regression coverage).

## Description

| Layer | Before | After |
|-------|--------|-------|
| `computeVisibleWorktreeIds` | Hides sleeping cards (correct) | Unchanged |
| `getEmptyProjectPlaceholderRepoIds` | Placeholder only if store has **zero** worktrees | Also placeholder when `projectGroupId != null` and no **visible** worktrees |
| `buildRows` Project Group membership | Only repos with visible cards (or true-empty placeholders) | Filtered grouped members kept via placeholders |

## Screenshots

No visual styling change. Behavior-only: which project headers remain in the sidebar row model under workspace filters.

## Evidence

**Root cause** (from repro kit + code):

- Row building consumes post-filter `visibleWorktrees`.
- Placeholder selection consulted only raw `worktreesByRepo` emptiness.
- A grouped project with store worktrees that are all sleep-filtered got neither a card nor a placeholder → dropped from the group.

**Red/green:**

- Prior behavior codified by `does not treat non-empty repos as empty when workspace filters hide their rows` for **ungrouped** repos (still true).
- New case `keeps grouped repos visible when workspace filters hide all of their rows` fails without the fix (`expected [] to deeply equal ['repo-1']`) and passes with it.

**Automated:**

```text
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/components/sidebar/empty-project-placeholder-repos.test.ts \
  src/renderer/src/components/sidebar/worktree-list-groups.test.ts \
  src/renderer/src/components/sidebar/visible-worktrees.test.ts
# 3 files, 138 tests passed
```

## ELI5

A Project Group is a sticky folder of projects. **Hide sleeping** should tuck away quiet workspace *cards*, not rip projects out of the folder. We now leave an empty project header in the group when all of that project's workspaces are hidden.

## User-regression-tradeoffs

| Behavior | Tradeoff |
|----------|----------|
| Grouped project with only sleeping workspaces | **Now stays** as an empty header under its group (intended fix). |
| Ungrouped project with only sleeping workspaces | **Still disappears** from the flat project list (unchanged; Hide sleeping still cleans noise). |
| Explicit project/repo filter excluding a member | Still excluded (filter wins over group preservation). |
| Host scope | Still enforced via `visibleReposForRows` before placeholders. |
| Sleeping workspaces themselves | Still hidden; we do not wake them or change activity classification. |

## Testing

- [x] `pnpm lint` — pre-commit lint-staged (oxlint + oxfmt) on changed files
- [ ] `pnpm typecheck` — not run full matrix; change is local TypeScript shape only (`visibleWorktrees` arg)
- [x] Focused tests: 138/138 sidebar tests listed above
- [ ] `pnpm test` — full suite not run
- [ ] `pnpm build` — not run; no packaging/deps changes
- [x] Added or updated high-quality tests that would catch regressions

## AI Review Report

Evaluated community PR #8866 and took it over after adversarial review.

- **Root cause:** confirmed mismatch between post-filter row building and raw-store placeholder selection.
- **Scope gate:** `repo.projectGroupId != null` keeps ungrouped Hide-sleeping behavior intact.
- **Memo deps:** `visibleWorktrees` added to selector + `useMemo` deps so activity/filter changes recompute headers.
- **Adversarial cases added:**
  - Explicit `filterRepoIds` still wins for sleep-filtered grouped members.
  - Multi-member group: only fully filtered members get placeholders.
  - Ungrouped neighbors of a filtered grouped member do not get placeholders.
  - `buildRows` integration: group count stays 2 with one awake + one sleep-filtered placeholder member; placeholder sorts after active projects.
- **Cross-platform / SSH:** pure renderer projection over existing `Repo`/`Worktree` metadata. No shortcuts, paths, shell, Git, Electron platform branches, or host-specific IPC. Local / WSL / SSH / paired-runtime share the same path (matches the original paired-Mac repro).
- **Related non-duplicates:** #4692, #7196, #7353, #7511.

No production-logic changes needed beyond #8866's approach.

## Security Audit

No new security surface. Set-membership over already-loaded in-memory `Repo`/`Worktree` objects only. No external input parsing, command execution, filesystem paths, network/IPC, auth, secrets, dependencies, or persistence writes.

## Notes

- Supersedes community #8866 after rebase onto current `main` + extra tests; please close #8866 in favor of this PR.
- Does not change workspace activity classification or wake sleeping sessions.