### PR TITLE
fix(agents): recognize env-prefixed agent relaunches after runtime restart (#8808)

### DIFF
--- a/src/main/providers/agent-foreground-process.test.ts
+++ b/src/main/providers/agent-foreground-process.test.ts
@@ -109,6 +109,30 @@ describe('resolveAgentForegroundProcess', () => {
     await expect(resolveAgentForegroundProcess(100, 'node')).resolves.toBe('codex')
   })
 
+  it('recognizes env-prefixed agent relaunches after restart', async () => {
+    // Why: #8808 — after runtime restart, workers relaunch via `terminal send`
+    // with leading env assignments. The live ps command column can retain them.
+    mockPs(['101 100 S+   CLAUDE_CONFIG_DIR=~/.claude_sub claude --model sonnet'].join('\n'))
+
+    await expect(resolveAgentForegroundProcess(100, 'zsh')).resolves.toBe('claude')
+  })
+
+  it('recognizes multi-env-prefixed and path-qualified agent relaunches', async () => {
+    mockPs(
+      [
+        '101 100 S+   TERM=x CLAUDE_CONFIG_DIR=~/.claude_sub /usr/local/bin/claude --model sonnet'
+      ].join('\n')
+    )
+
+    await expect(resolveAgentForegroundProcess(100, 'bash')).resolves.toBe('claude')
+  })
+
+  it('does not treat env-prefixed non-agents as foreground agents', async () => {
+    mockPs(['101 100 S+   NODE_ENV=test npm test'].join('\n'))
+
+    await expect(resolveAgentForegroundProcess(100, 'zsh')).resolves.toBe('zsh')
+  })
+
   it('treats a fresh POSIX snapshot missing the PTY root as unavailable', async () => {
     mockPs('101 999 S+ node /Users/dev/.nvm/versions/node/bin/codex')
 

--- a/src/shared/agent-process-recognition.test.ts
+++ b/src/shared/agent-process-recognition.test.ts
@@ -198,6 +198,70 @@ describe('agent process recognition', () => {
     ).toEqual({ agent: 'gemini', processName: 'gemini' })
   })
 
+  it('recognizes agent CLIs prefixed with POSIX env-variable assignments', () => {
+    // Why: after runtime restart, workers relaunch with env prefixes typed into
+    // the surviving shell (`CLAUDE_CONFIG_DIR=… claude …`). Process listings can
+    // preserve those leading assignment words (#8808).
+    expect(
+      recognizeAgentProcessFromCommandLine('CLAUDE_CONFIG_DIR=~/.claude_sub claude --model sonnet')
+    ).toEqual({ agent: 'claude', processName: 'claude' })
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        'TERM=x CLAUDE_CONFIG_DIR=~/.claude_sub claude --model sonnet'
+      )
+    ).toEqual({ agent: 'claude', processName: 'claude' })
+    expect(
+      recognizeAgentProcessFromCommandLine('CLAUDE_CONFIG_DIR= FOO=a=b claude --resume ses_1')
+    ).toEqual({ agent: 'claude', processName: 'claude' })
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        String.raw`CLAUDE_CONFIG_DIR=C:\Users\dev\.claude_sub C:\Users\dev\AppData\Roaming\npm\claude.exe --model sonnet`
+      )
+    ).toEqual({ agent: 'claude', processName: 'claude' })
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        String.raw`CLAUDE_CONFIG_DIR=/home/dev/.claude_sub /home/dev/.local/bin/claude --model sonnet`
+      )
+    ).toEqual({ agent: 'claude', processName: 'claude' })
+    expect(recognizeAgentProcessFromCommandLine('PYTHONPATH=/opt/lib python3 -m aider')).toEqual({
+      agent: 'aider',
+      processName: 'aider'
+    })
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        'NODE_OPTIONS=--no-warnings node /Users/dev/.nvm/versions/node/bin/codex'
+      )
+    ).toEqual({ agent: 'codex', processName: 'codex' })
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        String.raw`TERM=xterm-256color node C:\Users\dev\AppData\Roaming\npm\gemini.cmd`
+      )
+    ).toEqual({ agent: 'gemini', processName: 'gemini' })
+    expect(
+      recognizeAgentProcessFromCommandLine('FACTORY_API_KEY=secret droid --model factory-1')
+    ).toEqual({ agent: 'droid', processName: 'droid' })
+    // Headless one-shots stay filtered even when env-prefixed.
+    expect(
+      recognizeAgentProcessFromCommandLine('CLAUDE_CONFIG_DIR=~/.claude_sub claude -p summarize')
+    ).toBeNull()
+    // Non-agents, assignment-only lines, and invalid assignment spellings.
+    expect(recognizeAgentProcessFromCommandLine('NODE_ENV=test npm test')).toBeNull()
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        "PROMPT='claude --model sonnet' printf '%s\\n' \"$PROMPT\""
+      )
+    ).toBeNull()
+    expect(recognizeAgentProcessFromCommandLine('BAD-NAME=value claude --model sonnet')).toBeNull()
+    expect(recognizeAgentProcessFromCommandLine('CLAUDE_CONFIG_DIR=~/.claude_sub')).toBeNull()
+    // Why: `env VAR=value cmd` is a different argv shape; do not treat `env` as
+    // an assignment word or invent agent identity from nested text.
+    expect(
+      recognizeAgentProcessFromCommandLine(
+        'env CLAUDE_CONFIG_DIR=~/.claude_sub claude --model sonnet'
+      )
+    ).toBeNull()
+  })
+
   it('recognizes only the agent subcommand of the generic Orca CLI', () => {
     expect(recognizeAgentProcessFromCommandLine('orca claude-teams')).toEqual({
       agent: 'claude-agent-teams',

--- a/src/shared/agent-process-recognition.ts
+++ b/src/shared/agent-process-recognition.ts
@@ -137,6 +137,12 @@ function tokenizeCommandLine(commandLine: string): string[] {
   return tokens
 }
 
+// Why: shells accept leading `KEY=value` words before the executable
+// (`CLAUDE_CONFIG_DIR=… claude …`). Process listings sometimes preserve that
+// full command string; without stripping, the first token is the assignment
+// and agent recognition fails after in-shell relaunches (#8808).
+const POSIX_ASSIGNMENT_WORD_RE = /^[A-Za-z_][A-Za-z0-9_]*=/
+
 function tokenLooksExecutable(token: string, index: number, firstNormalized: string): boolean {
   if (index === 0) {
     return true
@@ -288,11 +294,12 @@ export function recognizeAgentProcessFromCommandLine(
   // one-shot agent can't answer a prompt either.
   options?: { includeHeadlessOneShot?: boolean }
 ): RecognizedAgentProcess | null {
-  if (!commandLine) {
-    return null
-  }
   const keep = options?.includeHeadlessOneShot === true
-  const tokens = tokenizeCommandLine(commandLine)
+  const tokens = tokenizeCommandLine(commandLine ?? '')
+  // Drop contiguous leading POSIX assignment words so env-prefixed relaunches
+  // still resolve to the real executable head.
+  const firstExecutableIndex = tokens.findIndex((token) => !POSIX_ASSIGNMENT_WORD_RE.test(token))
+  tokens.splice(0, firstExecutableIndex < 0 ? tokens.length : firstExecutableIndex)
   const firstNormalized = normalizeProcessName(tokens[0])
   let direct = recognizeAgentProcess(tokens[0])
   // Why: the generic Orca CLI is not an agent; only this subcommand launches its TUI mode.


### PR DESCRIPTION
## Summary

After an Orca runtime restart, worker PTYs can survive as bare shells. Relaunching an agent inside that shell via `orca terminal send` with env prefixes such as `CLAUDE_CONFIG_DIR=… claude …` made `tui-idle` succeed, but `orchestration dispatch --inject` still failed with **no recognized agent detected**.

This strips contiguous leading POSIX `KEY=value` assignment words in the shared command-line recognizer so foreground-process detection resolves the real executable head again. Direct, interpreter-wrapped, headless-filtered, and negative paths stay unchanged.

**Credits:** builds on @rodboev's approach in #8942 (same core strip + provider path); this PR lands it with broader adversarial coverage and keeps the shared recognizer under the `max-lines` budget.

Closes #8808.

## Description

- Shared recognizer: after tokenization, drop leading tokens matching `^[A-Za-z_][A-Za-z0-9_]*=` before direct / interpreter / headless recognition.
- Invalid assignment spellings (`BAD-NAME=…`), assignment-only input, non-agents (`NODE_ENV=test npm test`), and prompt-text false identities remain unrecognized.
- Intentionally narrower than #7797 (no tmux / nested-shell topology fix). Does not treat the `env VAR=value cmd` argv shape as assignment words.

## Evidence

Focused validation:

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/shared/agent-process-recognition.test.ts \
  src/main/providers/agent-foreground-process.test.ts
# 2 files / 50 tests passed

pnpm exec oxlint src/shared/agent-process-recognition.ts \
  src/shared/agent-process-recognition.test.ts \
  src/main/providers/agent-foreground-process.test.ts
# clean

pnpm exec oxfmt --check src/shared/agent-process-recognition.ts \
  src/shared/agent-process-recognition.test.ts \
  src/main/providers/agent-foreground-process.test.ts
# clean

pnpm run typecheck:node
# clean
```

Regression cases added for:

- Reporter string: `CLAUDE_CONFIG_DIR=~/.claude_sub claude --model sonnet`
- Multi-env prefixes, empty/`=` values, path-qualified POSIX and Windows agent binaries
- Interpreter wrappers (`PYTHONPATH=… python3 -m aider`, `NODE_OPTIONS=… node …/codex`)
- Other agents (`droid`, `gemini`)
- Headless one-shot still filtered when env-prefixed
- Negatives: `npm test`, `PROMPT='claude…' printf…`, `BAD-NAME=…`, assignment-only, `env VAR=value claude`
- Provider path: env-prefixed `ps` rows resolve to `claude`; non-agents still fall back to shell

## ELI5

Orca looks at the terminal's live process command to decide if an agent is running. When people restart Claude with `SOME_SETTING=value claude`, that `SOME_SETTING=value` was treated as the program name, so Orca thought no agent was there. Now it skips those setting words and looks at the real program (`claude`).

## User-regression-tradeoffs

- **Benefit:** inject dispatch works again after runtime restart + in-shell env-prefixed relaunch (the reported workflow).
- **Risk:** over-stripping could theoretically mis-identify a command whose first tokens look like `KEY=value`. Mitigated by the POSIX identifier regex (rejects `BAD-NAME=…`) and negative tests for non-agents and assignment-only lines.
- **Out of scope:** nested shells / tmux (#7797), Windows `set VAR=… && cmd` / PowerShell `$env:` forms (native Windows process tables almost never put POSIX assignment words on the executable command line; Git Bash / SSH / POSIX listings are covered by the shared path).
- **No change** to titles, ready-prompt fallbacks, launch-metadata ownership for `terminal create --command`, or headless one-shot filtering policy.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` (oxlint on touched files)
- [x] `pnpm typecheck` (`typecheck:node`)
- [x] `pnpm test` (focused vitest files above — 50 passed)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Evaluated community PR #8942 (@rodboev): correct root cause and minimal shared-path fix. Took that approach and expanded adversarial tests.

Checked:

- **Cross-platform:** POSIX assignment strip is platform-agnostic string parsing used by macOS/Linux `ps` and by Windows providers when command lines are inspected. Added Windows path fixtures (`C:\…\claude.exe`, `gemini.cmd`) and multi-env cases. Native Windows `set` / `$env:` command shapes are documented as out of scope (different argv shape; not the #8808 repro).
- **False positives:** non-agent env-prefixed commands, assignment-only, invalid names, prompt embedding, headless `-p` remain null.
- **False negatives / gaps:** `env VAR=value claude` intentionally not rewritten (different argv head); full #7797 topology not claimed.
- **max-lines:** kept `agent-process-recognition.ts` at the 300 counted-line budget (no disable / no bump).
- **No** provider-local Windows/tmux/subprocess/I/O/IPC/UI changes beyond shared recognition + tests.

## Security Audit

- No new subprocesses, network I/O, IPC channels, auth, or secrets handling.
- Only changes executable-head selection on an already-trusted process-table / command-line string.
- Assignment-word matching is a bounded regex on tokenized argv; no shell evaluation of values.
- Negative cases covered for commands that merely mention agent names in env values or arguments.

## Notes

- Supersedes / takes over the fix direction of #8942 with credit to @rodboev.
- Related but separate: #7797 (agents started inside existing shells / tmux without env-prefix issues).
- Follow-up if needed: teach recognition about `env VAR=value cmd` and Windows shell env-set wrappers.