### PR TITLE
fix(github): load PR diffs for Enterprise remotes

### DIFF
--- a/src/main/github/work-item-details-file-viewed.test.ts
+++ b/src/main/github/work-item-details-file-viewed.test.ts
@@ -8,6 +8,7 @@ const {
   ghExecFileAsyncMock,
   getOwnerRepoMock,
   getIssueOwnerRepoMock,
+  getEnterpriseGitHubRepoSlugMock,
   getWorkItemMock,
   getPRChecksMock,
   getPRCommentsMock,
@@ -19,6 +20,7 @@ const {
   ghExecFileAsyncMock: vi.fn(),
   getOwnerRepoMock: vi.fn(),
   getIssueOwnerRepoMock: vi.fn(),
+  getEnterpriseGitHubRepoSlugMock: vi.fn(),
   getWorkItemMock: vi.fn(),
   getPRChecksMock: vi.fn(),
   getPRCommentsMock: vi.fn(),
@@ -47,6 +49,10 @@ vi.mock('./client', () => ({
   getPRComments: getPRCommentsMock
 }))
 
+vi.mock('./github-enterprise-repository', () => ({
+  getEnterpriseGitHubRepoSlug: getEnterpriseGitHubRepoSlugMock
+}))
+
 vi.mock('./rate-limit', () => ({
   rateLimitGuard: rateLimitGuardMock,
   noteRateLimitSpend: noteRateLimitSpendMock
@@ -59,6 +65,8 @@ describe('getWorkItemDetails PR file viewed state', () => {
     ghExecFileAsyncMock.mockReset()
     getOwnerRepoMock.mockReset()
     getIssueOwnerRepoMock.mockReset()
+    getEnterpriseGitHubRepoSlugMock.mockReset()
+    getEnterpriseGitHubRepoSlugMock.mockResolvedValue(null)
     getWorkItemMock.mockReset()
     getPRChecksMock.mockReset()
     getPRCommentsMock.mockReset()

--- a/src/main/github/work-item-details-ghe-host.test.ts
+++ b/src/main/github/work-item-details-ghe-host.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Issue #8935 — GitHub Enterprise PR work item diffs must target the Enterprise host.
+ *
+ * Root cause chain (pre-fix):
+ * 1. parseGitHubOwnerRepo only accepts github.com → null for GHE remotes
+ * 2. getPRFiles / getPRFileContents used getOwnerRepo only → null / empty
+ * 3. gh api never passed --hostname → wrong host even with a forced slug
+ *
+ * Related prior art: https://github.com/stablyai/orca/pull/8932 (@wonjerry)
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type RateLimitGuardResult =
+  | { blocked: false }
+  | { blocked: true; remaining: number; limit: number; resetAt: number }
+
+const {
+  ghExecFileAsyncMock,
+  getOwnerRepoMock,
+  getIssueOwnerRepoMock,
+  getEnterpriseGitHubRepoSlugMock,
+  getWorkItemMock,
+  getPRChecksMock,
+  getPRCommentsMock,
+  rateLimitGuardMock,
+  noteRateLimitSpendMock,
+  acquireMock,
+  releaseMock
+} = vi.hoisted(() => ({
+  ghExecFileAsyncMock: vi.fn(),
+  getOwnerRepoMock: vi.fn(),
+  getIssueOwnerRepoMock: vi.fn(),
+  getEnterpriseGitHubRepoSlugMock: vi.fn(),
+  getWorkItemMock: vi.fn(),
+  getPRChecksMock: vi.fn(),
+  getPRCommentsMock: vi.fn(),
+  rateLimitGuardMock: vi.fn<() => RateLimitGuardResult>(() => ({ blocked: false })),
+  noteRateLimitSpendMock: vi.fn(),
+  acquireMock: vi.fn(),
+  releaseMock: vi.fn()
+}))
+
+vi.mock('./gh-utils', () => ({
+  ghExecFileAsync: ghExecFileAsyncMock,
+  getOwnerRepo: getOwnerRepoMock,
+  getIssueOwnerRepo: getIssueOwnerRepoMock,
+  ghRepoExecOptions: vi.fn((context) =>
+    context.connectionId
+      ? {}
+      : { cwd: context.repoPath, ...(context.wslDistro ? { wslDistro: context.wslDistro } : {}) }
+  ),
+  githubRepoContext: vi.fn((repoPath, connectionId, localGitOptions) => ({
+    repoPath,
+    connectionId: connectionId ?? null,
+    ...localGitOptions
+  })),
+  acquire: acquireMock,
+  release: releaseMock
+}))
+
+vi.mock('./client', () => ({
+  getWorkItem: getWorkItemMock,
+  getPRChecks: getPRChecksMock,
+  getPRComments: getPRCommentsMock
+}))
+
+vi.mock('./github-enterprise-repository', () => ({
+  getEnterpriseGitHubRepoSlug: getEnterpriseGitHubRepoSlugMock
+}))
+
+vi.mock('./rate-limit', () => ({
+  rateLimitGuard: rateLimitGuardMock,
+  noteRateLimitSpend: noteRateLimitSpendMock
+}))
+
+import { getPRFileContents, getWorkItemDetails } from './work-item-details'
+import { parseGitHubOwnerRepo, parseGitHubRemoteIdentity } from './github-remote-identity-parsing'
+
+describe('issue #8935 GHE PR diff host routing', () => {
+  beforeEach(() => {
+    ghExecFileAsyncMock.mockReset()
+    getOwnerRepoMock.mockReset()
+    getIssueOwnerRepoMock.mockReset()
+    getEnterpriseGitHubRepoSlugMock.mockReset()
+    getEnterpriseGitHubRepoSlugMock.mockResolvedValue(null)
+    getWorkItemMock.mockReset()
+    getPRChecksMock.mockReset()
+    getPRCommentsMock.mockReset()
+    rateLimitGuardMock.mockReset()
+    rateLimitGuardMock.mockReturnValue({ blocked: false })
+    noteRateLimitSpendMock.mockReset()
+    acquireMock.mockReset()
+    releaseMock.mockReset()
+    acquireMock.mockResolvedValue(undefined)
+  })
+
+  it('parseGitHubOwnerRepo returns null for Enterprise remotes (github.com only)', () => {
+    expect(parseGitHubOwnerRepo('https://github.acme-corp.com/team/orca.git')).toBeNull()
+    expect(parseGitHubOwnerRepo('git@github.acme-corp.com:team/orca.git')).toBeNull()
+    expect(parseGitHubOwnerRepo('https://ghe.acme.internal/acme/widgets.git')).toBeNull()
+
+    // Identity parser still sees host+owner+repo — data is available via enterprise slug
+    expect(parseGitHubRemoteIdentity('https://github.acme-corp.com/team/orca.git')).toEqual({
+      host: 'github.acme-corp.com',
+      owner: 'team',
+      repo: 'orca'
+    })
+  })
+
+  it('loads PR files and contents via enterprise host when getOwnerRepo is null', async () => {
+    getWorkItemMock.mockResolvedValueOnce({
+      id: 'pr:7',
+      type: 'pr',
+      number: 7,
+      title: 'Enterprise PR',
+      state: 'open',
+      url: 'https://github.acme-corp.com/team/orca/pull/7',
+      labels: [],
+      updatedAt: '2026-07-16T00:00:00Z',
+      author: 'pr-author'
+    })
+    getOwnerRepoMock.mockResolvedValue(null)
+    getEnterpriseGitHubRepoSlugMock.mockResolvedValue({
+      owner: 'team',
+      repo: 'orca',
+      host: 'github.acme-corp.com'
+    })
+    getPRCommentsMock.mockResolvedValue([])
+    getPRChecksMock.mockResolvedValue([])
+    ghExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      const endpoint = args.find((arg) => arg.startsWith('repos/')) ?? ''
+      if (endpoint === 'repos/team/orca/pulls/7') {
+        return {
+          stdout: JSON.stringify({
+            body: 'Enterprise PR body',
+            head: { sha: 'head-sha' },
+            base: { sha: 'base-sha' }
+          })
+        }
+      }
+      if (endpoint === 'repos/team/orca/pulls/7/files?per_page=100') {
+        return {
+          stdout: JSON.stringify([
+            {
+              filename: 'src/main.ts',
+              status: 'modified',
+              additions: 1,
+              deletions: 0,
+              changes: 1,
+              patch: '@@ -1 +1 @@'
+            }
+          ])
+        }
+      }
+      if (endpoint.includes('contents/src/main.ts?ref=base-sha')) {
+        return { stdout: 'old' }
+      }
+      if (endpoint.includes('contents/src/main.ts?ref=head-sha')) {
+        return { stdout: 'new' }
+      }
+      return { stdout: JSON.stringify({ data: {} }) }
+    })
+
+    const details = await getWorkItemDetails('/repo-root', 7, 'pr')
+    expect(details?.filesUnavailable).toBe(false)
+    expect(details?.files?.map((f) => f.path)).toEqual(['src/main.ts'])
+
+    const contents = await getPRFileContents({
+      repoPath: '/repo-root',
+      prNumber: 7,
+      path: 'src/main.ts',
+      status: 'modified',
+      headSha: 'head-sha',
+      baseSha: 'base-sha'
+    })
+    expect(contents).toMatchObject({ original: 'old', modified: 'new' })
+
+    const apiCalls = ghExecFileAsyncMock.mock.calls
+      .map(([args]) => args as string[])
+      .filter((args) => args[0] === 'api')
+    expect(apiCalls.length).toBeGreaterThan(0)
+    expect(apiCalls.every((args) => args.includes('--hostname'))).toBe(true)
+    expect(
+      apiCalls.every((args) => args[args.indexOf('--hostname') + 1] === 'github.acme-corp.com')
+    ).toBe(true)
+  })
+
+  it('returns empty PR file contents when owner/repo cannot be resolved on any host', async () => {
+    getOwnerRepoMock.mockResolvedValue(null)
+    getEnterpriseGitHubRepoSlugMock.mockResolvedValue(null)
+
+    const contents = await getPRFileContents({
+      repoPath: '/repo-root',
+      prNumber: 7,
+      path: 'src/main.ts',
+      status: 'modified',
+      headSha: 'head-sha',
+      baseSha: 'base-sha'
+    })
+
+    expect(contents).toEqual({
+      original: '',
+      modified: '',
+      originalIsBinary: false,
+      modifiedIsBinary: false
+    })
+    expect(ghExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('encodes # and ? in content paths while preserving directory separators', async () => {
+    getOwnerRepoMock.mockResolvedValue(null)
+    getEnterpriseGitHubRepoSlugMock.mockResolvedValue({
+      owner: 'team',
+      repo: 'orca',
+      host: 'ghe.example.com'
+    })
+    ghExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      const endpoint = args.find((arg) => arg.startsWith('repos/')) ?? ''
+      if (endpoint === 'repos/team/orca/contents/dir/a%23b%3Fc.ts?ref=base-sha') {
+        return { stdout: 'base' }
+      }
+      if (endpoint === 'repos/team/orca/contents/dir/a%23b%3Fc.ts?ref=head-sha') {
+        return { stdout: 'head' }
+      }
+      throw new Error(`unexpected gh call: ${args.join(' ')}`)
+    })
+
+    const contents = await getPRFileContents({
+      repoPath: '/repo-root',
+      prNumber: 7,
+      path: 'dir/a#b?c.ts',
+      status: 'modified',
+      headSha: 'head-sha',
+      baseSha: 'base-sha'
+    })
+
+    expect(contents).toMatchObject({ original: 'base', modified: 'head' })
+  })
+})

--- a/src/main/github/work-item-details.test.ts
+++ b/src/main/github/work-item-details.test.ts
@@ -8,6 +8,7 @@ const {
   ghExecFileAsyncMock,
   getOwnerRepoMock,
   getIssueOwnerRepoMock,
+  getEnterpriseGitHubRepoSlugMock,
   getWorkItemMock,
   getPRChecksMock,
   getPRCommentsMock,
@@ -21,6 +22,7 @@ const {
   ghExecFileAsyncMock: vi.fn(),
   getOwnerRepoMock: vi.fn(),
   getIssueOwnerRepoMock: vi.fn(),
+  getEnterpriseGitHubRepoSlugMock: vi.fn(),
   getWorkItemMock: vi.fn(),
   getPRChecksMock: vi.fn(),
   getPRCommentsMock: vi.fn(),
@@ -56,18 +58,24 @@ vi.mock('./client', () => ({
   getPRComments: getPRCommentsMock
 }))
 
+vi.mock('./github-enterprise-repository', () => ({
+  getEnterpriseGitHubRepoSlug: getEnterpriseGitHubRepoSlugMock
+}))
+
 vi.mock('./rate-limit', () => ({
   rateLimitGuard: rateLimitGuardMock,
   noteRateLimitSpend: noteRateLimitSpendMock
 }))
 
-import { getWorkItemDetails } from './work-item-details'
+import { getPRFileContents, getWorkItemDetails } from './work-item-details'
 
 describe('getWorkItemDetails', () => {
   beforeEach(() => {
     ghExecFileAsyncMock.mockReset()
     getOwnerRepoMock.mockReset()
     getIssueOwnerRepoMock.mockReset()
+    getEnterpriseGitHubRepoSlugMock.mockReset()
+    getEnterpriseGitHubRepoSlugMock.mockResolvedValue(null)
     getWorkItemMock.mockReset()
     getPRChecksMock.mockReset()
     getPRCommentsMock.mockReset()
@@ -497,6 +505,220 @@ describe('getWorkItemDetails', () => {
     expect(ghExecFileAsyncMock.mock.calls.every((call) => call[1]?.wslDistro === 'Ubuntu')).toBe(
       true
     )
+  })
+
+  // Why: #8935 — GHES remotes resolve via getEnterpriseGitHubRepoSlug and must
+  // pin every gh api call with --hostname so diffs do not hit github.com.
+  it('uses the GitHub Enterprise host for PR files in work item details', async () => {
+    getWorkItemMock.mockResolvedValueOnce({
+      id: 'pr:7',
+      type: 'pr',
+      number: 7,
+      title: 'Enterprise PR files',
+      state: 'open',
+      url: 'https://github.acme-corp.com/team/orca/pull/7',
+      labels: [],
+      updatedAt: '2026-07-16T00:00:00Z',
+      author: 'pr-author'
+    })
+    getOwnerRepoMock.mockResolvedValue(null)
+    getEnterpriseGitHubRepoSlugMock.mockResolvedValue({
+      owner: 'team',
+      repo: 'orca',
+      host: 'github.acme-corp.com'
+    })
+    getPRCommentsMock.mockResolvedValue([])
+    getPRChecksMock.mockResolvedValue([])
+    ghExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      const endpoint = args.find((arg) => arg.startsWith('repos/')) ?? ''
+      if (endpoint === 'repos/team/orca/pulls/7') {
+        return {
+          stdout: JSON.stringify({
+            body: 'Enterprise PR body',
+            head: { sha: 'head-sha' },
+            base: { sha: 'base-sha' }
+          })
+        }
+      }
+      if (endpoint === 'repos/team/orca/pulls/7/files?per_page=100') {
+        return {
+          stdout: JSON.stringify([
+            {
+              filename: 'src/enterprise.ts',
+              status: 'modified',
+              additions: 2,
+              deletions: 1,
+              changes: 3,
+              patch: '@@ -1 +1 @@'
+            }
+          ])
+        }
+      }
+      const query = args.find((arg) => arg.startsWith('query=')) ?? ''
+      if (query.includes('viewerViewedState')) {
+        return {
+          stdout: JSON.stringify({
+            data: {
+              repository: {
+                pullRequest: {
+                  id: 'PR_enterprise',
+                  files: {
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                    nodes: [{ path: 'src/enterprise.ts', viewerViewedState: 'VIEWED' }]
+                  }
+                }
+              }
+            }
+          })
+        }
+      }
+      if (query.includes('participants(first: 100)')) {
+        return {
+          stdout: JSON.stringify({
+            data: { repository: { pullRequest: { participants: { nodes: [] } } } }
+          })
+        }
+      }
+      throw new Error(`unexpected gh call: ${args.join(' ')}`)
+    })
+
+    const details = await getWorkItemDetails('/repo-root', 7, 'pr')
+
+    expect(details?.body).toBe('Enterprise PR body')
+    expect(details?.headSha).toBe('head-sha')
+    expect(details?.baseSha).toBe('base-sha')
+    expect(details?.filesUnavailable).toBe(false)
+    expect(details?.files).toEqual([
+      {
+        path: 'src/enterprise.ts',
+        oldPath: undefined,
+        status: 'modified',
+        additions: 2,
+        deletions: 1,
+        isBinary: false,
+        reviewCommentLineNumbers: [],
+        viewerViewedState: 'VIEWED'
+      }
+    ])
+    const apiCalls = ghExecFileAsyncMock.mock.calls
+      .map(([args]) => args as string[])
+      .filter((args) => args[0] === 'api')
+    expect(apiCalls.length).toBeGreaterThan(0)
+    expect(apiCalls.every((args) => args.includes('--hostname'))).toBe(true)
+    expect(
+      apiCalls.every((args) => args[args.indexOf('--hostname') + 1] === 'github.acme-corp.com')
+    ).toBe(true)
+  })
+
+  it('uses the GitHub Enterprise host when fetching PR file contents with special path chars', async () => {
+    getOwnerRepoMock.mockResolvedValue(null)
+    getEnterpriseGitHubRepoSlugMock.mockResolvedValue({
+      owner: 'team',
+      repo: 'orca',
+      host: 'github.acme-corp.com'
+    })
+    ghExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      const endpoint = args.find((arg) => arg.startsWith('repos/')) ?? ''
+      if (endpoint === 'repos/team/orca/contents/src/path%23with%3Fchars.ts?ref=base-sha') {
+        return { stdout: 'base content' }
+      }
+      if (endpoint === 'repos/team/orca/contents/src/path%23with%3Fchars.ts?ref=head-sha') {
+        return { stdout: 'head content' }
+      }
+      throw new Error(`unexpected gh call: ${args.join(' ')}`)
+    })
+
+    const contents = await getPRFileContents({
+      repoPath: '/repo-root',
+      prNumber: 7,
+      path: 'src/path#with?chars.ts',
+      status: 'modified',
+      headSha: 'head-sha',
+      baseSha: 'base-sha'
+    })
+
+    expect(contents).toMatchObject({
+      original: 'base content',
+      modified: 'head content',
+      originalIsBinary: false,
+      modifiedIsBinary: false
+    })
+    const apiCalls = ghExecFileAsyncMock.mock.calls.map(([args]) => args as string[])
+    expect(apiCalls).toHaveLength(2)
+    expect(apiCalls.every((args) => args.includes('--hostname'))).toBe(true)
+    expect(
+      apiCalls.every((args) => args[args.indexOf('--hostname') + 1] === 'github.acme-corp.com')
+    ).toBe(true)
+  })
+
+  // Why: github.com remotes must keep the pre-fix argv shape — no --hostname —
+  // so process-level GH_HOST overrides still only apply where gh already did.
+  it('does not pin --hostname for github.com PR detail API calls', async () => {
+    getWorkItemMock.mockResolvedValueOnce({
+      id: 'pr:9',
+      type: 'pr',
+      number: 9,
+      title: 'Dotcom PR',
+      state: 'open',
+      url: 'https://github.com/acme/widgets/pull/9',
+      labels: [],
+      updatedAt: '2026-07-16T00:00:00Z',
+      author: 'pr-author'
+    })
+    getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+    getPRCommentsMock.mockResolvedValue([])
+    getPRChecksMock.mockResolvedValue([])
+    ghExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      const endpoint = args.find((arg) => arg.startsWith('repos/')) ?? ''
+      if (endpoint === 'repos/acme/widgets/pulls/9') {
+        return {
+          stdout: JSON.stringify({
+            body: 'dotcom body',
+            head: { sha: 'head-sha' },
+            base: { sha: 'base-sha' }
+          })
+        }
+      }
+      if (endpoint === 'repos/acme/widgets/pulls/9/files?per_page=100') {
+        return { stdout: '[]' }
+      }
+      return { stdout: JSON.stringify({ data: {} }) }
+    })
+
+    const details = await getWorkItemDetails('/repo-root', 9, 'pr')
+
+    expect(details?.filesUnavailable).toBe(false)
+    expect(getEnterpriseGitHubRepoSlugMock).not.toHaveBeenCalled()
+    const apiCalls = ghExecFileAsyncMock.mock.calls
+      .map(([args]) => args as string[])
+      .filter((args) => args[0] === 'api')
+    expect(apiCalls.every((args) => !args.includes('--hostname'))).toBe(true)
+  })
+
+  it('keeps filesUnavailable when neither github.com nor Enterprise owner/repo resolve', async () => {
+    getWorkItemMock.mockResolvedValueOnce({
+      id: 'pr:11',
+      type: 'pr',
+      number: 11,
+      title: 'Unresolved remote PR',
+      state: 'open',
+      url: 'https://example.invalid/team/repo/pull/11',
+      labels: [],
+      updatedAt: '2026-07-16T00:00:00Z',
+      author: 'pr-author'
+    })
+    getOwnerRepoMock.mockResolvedValue(null)
+    getEnterpriseGitHubRepoSlugMock.mockResolvedValue(null)
+    getPRCommentsMock.mockResolvedValue([])
+    getPRChecksMock.mockResolvedValue([])
+    ghExecFileAsyncMock.mockResolvedValue({
+      stdout: JSON.stringify({ body: 'meta only', headRefOid: 'h', baseRefOid: 'b' })
+    })
+
+    const details = await getWorkItemDetails('/repo-root', 11, 'pr')
+
+    expect(details?.filesUnavailable).toBe(true)
+    expect(details?.files).toBeUndefined()
   })
 
   // Why: a rate-limited/auth-failed file fetch must not render as an empty PR;

--- a/src/main/github/work-item-details.ts
+++ b/src/main/github/work-item-details.ts
@@ -24,6 +24,7 @@ import {
   type LocalGitExecOptions
 } from './gh-utils'
 import { getWorkItem, getPRChecks, getPRComments } from './client'
+import { getEnterpriseGitHubRepoSlug } from './github-enterprise-repository'
 import { noteRateLimitSpend, rateLimitGuard } from './rate-limit'
 import { getPRReviewCommentLineNumbersFromPatch } from './pr-review-comment-lines'
 import { isMaxBufferOverflowError } from '../git/max-buffer-overflow'
@@ -43,6 +44,50 @@ const GITHUB_RAW_CONTENT_MAX_BUFFER_BYTES = 8 * 1024 * 1024
 
 function localGitOptionArgs(options: LocalGitExecOptions = {}): [] | [LocalGitExecOptions] {
   return Object.keys(options).length > 0 ? [options] : []
+}
+
+function hostedReviewLocalGitOptions(options: LocalGitExecOptions = {}): {
+  localGitExecOptions?: LocalGitExecOptions
+} {
+  return Object.keys(options).length > 0 ? { localGitExecOptions: options } : {}
+}
+
+// Why: getOwnerRepo is github.com-only; GHES remotes need the enterprise slug
+// (owner/repo + host) so PR file/diff API calls can target the right server.
+async function getOriginApiOwnerRepo(
+  repoPath: string,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): Promise<GitHubOwnerRepoSlug | null> {
+  const ownerRepo = await getOwnerRepo(
+    repoPath,
+    connectionId,
+    ...localGitOptionArgs(localGitOptions)
+  )
+  return (
+    ownerRepo ??
+    (await getEnterpriseGitHubRepoSlug(
+      repoPath,
+      connectionId,
+      hostedReviewLocalGitOptions(localGitOptions)
+    ))
+  )
+}
+
+function ghApiHostArgs(ownerRepo: GitHubOwnerRepoSlug): string[] {
+  // Why: without --hostname, gh defaults to github.com even when the repo
+  // lives on Enterprise — the #8935 empty-diff failure mode.
+  const host = ownerRepo.host?.trim()
+  if (!host || host.toLowerCase() === 'github.com') {
+    return []
+  }
+  return ['--hostname', host]
+}
+
+// Why: encodeURI leaves #/? unescaped, which breaks GitHub contents URLs;
+// encode each path segment so special filenames still resolve.
+function encodeGitHubContentPath(path: string): string {
+  return path.split('/').map(encodeURIComponent).join('/')
 }
 
 const PR_FILE_VIEWED_STATES_QUERY = `query($owner: String!, $repo: String!, $number: Int!, $after: String) {
@@ -132,7 +177,7 @@ type GraphQLIssueDetailsResponse = {
   errors?: { message?: string }[]
 }
 
-type GitHubOwnerRepoSlug = { owner: string; repo: string }
+type GitHubOwnerRepoSlug = { owner: string; repo: string; host?: string }
 
 type RestTimelineUser = {
   login?: string | null
@@ -488,15 +533,17 @@ async function getPRHeadBaseSha(
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<{ headSha: string; baseSha: string } | null> {
   const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId, localGitOptions))
-  const ownerRepo = await getOwnerRepo(
-    repoPath,
-    connectionId,
-    ...localGitOptionArgs(localGitOptions)
-  )
+  const ownerRepo = await getOriginApiOwnerRepo(repoPath, connectionId, localGitOptions)
   try {
     if (ownerRepo) {
       const { stdout } = await ghExecFileAsync(
-        ['api', '--cache', '60s', `repos/${ownerRepo.owner}/${ownerRepo.repo}/pulls/${prNumber}`],
+        [
+          'api',
+          ...ghApiHostArgs(ownerRepo),
+          '--cache',
+          '60s',
+          `repos/${ownerRepo.owner}/${ownerRepo.repo}/pulls/${prNumber}`
+        ],
         ghOptions
       )
       const data = JSON.parse(stdout) as {
@@ -535,11 +582,7 @@ async function getPRFiles(
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<GitHubPRFile[] | null> {
   const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId, localGitOptions))
-  const ownerRepo = await getOwnerRepo(
-    repoPath,
-    connectionId,
-    ...localGitOptionArgs(localGitOptions)
-  )
+  const ownerRepo = await getOriginApiOwnerRepo(repoPath, connectionId, localGitOptions)
   if (!ownerRepo) {
     return null
   }
@@ -547,6 +590,7 @@ async function getPRFiles(
     const { stdout } = await ghExecFileAsync(
       [
         'api',
+        ...ghApiHostArgs(ownerRepo),
         '--cache',
         '60s',
         `repos/${ownerRepo.owner}/${ownerRepo.repo}/pulls/${prNumber}/files?per_page=100`
@@ -580,11 +624,7 @@ async function getPRFileViewedStates(
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<PRFileViewedStatesResult | null> {
   const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId, localGitOptions))
-  const ownerRepo = await getOwnerRepo(
-    repoPath,
-    connectionId,
-    ...localGitOptionArgs(localGitOptions)
-  )
+  const ownerRepo = await getOriginApiOwnerRepo(repoPath, connectionId, localGitOptions)
   if (!ownerRepo) {
     return null
   }
@@ -599,6 +639,7 @@ async function getPRFileViewedStates(
     for (let fetched = 0; fetched < MAX_PR_FILES; fetched += 100) {
       const args = [
         'api',
+        ...ghApiHostArgs(ownerRepo),
         'graphql',
         '-f',
         `query=${PR_FILE_VIEWED_STATES_QUERY}`,
@@ -773,15 +814,17 @@ async function getPRBody(
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<string> {
   const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId, localGitOptions))
-  const ownerRepo = await getOwnerRepo(
-    repoPath,
-    connectionId,
-    ...localGitOptionArgs(localGitOptions)
-  )
+  const ownerRepo = await getOriginApiOwnerRepo(repoPath, connectionId, localGitOptions)
   try {
     if (ownerRepo) {
       const { stdout } = await ghExecFileAsync(
-        ['api', '--cache', '60s', `repos/${ownerRepo.owner}/${ownerRepo.repo}/pulls/${prNumber}`],
+        [
+          'api',
+          ...ghApiHostArgs(ownerRepo),
+          '--cache',
+          '60s',
+          `repos/${ownerRepo.owner}/${ownerRepo.repo}/pulls/${prNumber}`
+        ],
         ghOptions
       )
       const data = JSON.parse(stdout) as { body?: string | null }
@@ -806,11 +849,11 @@ async function getWorkItemParticipants(
 ): Promise<GitHubAssignableUser[]> {
   // Why: issues in a fork live on the upstream remote, so participants must be
   // resolved via getIssueOwnerRepo to stay consistent with getIssueBodyAndComments.
-  // PRs remain tied to origin via getOwnerRepo.
+  // PRs remain tied to origin via getOriginApiOwnerRepo (github.com + GHES).
   const ownerRepo =
     item.type === 'issue'
       ? await getIssueOwnerRepo(repoPath, connectionId, ...localGitOptionArgs(localGitOptions))
-      : await getOwnerRepo(repoPath, connectionId, ...localGitOptionArgs(localGitOptions))
+      : await getOriginApiOwnerRepo(repoPath, connectionId, localGitOptions)
   if (!ownerRepo) {
     return []
   }
@@ -822,6 +865,7 @@ async function getWorkItemParticipants(
     const { stdout } = await ghExecFileAsync(
       [
         'api',
+        ...ghApiHostArgs(ownerRepo),
         'graphql',
         '-f',
         `query=${WORK_ITEM_PARTICIPANTS_QUERY}`,
@@ -879,6 +923,9 @@ async function getGitHubUsersByLogin(
   if (rateLimitGuard('graphql').blocked) {
     return []
   }
+  // Why: mention-author hydration must hit the same host as the work item so
+  // GHES users are not looked up against github.com.
+  const ownerRepo = await getOriginApiOwnerRepo(repoPath, connectionId, localGitOptions)
   const fields = uniqueLogins
     .map(
       (login, index) =>
@@ -888,7 +935,13 @@ async function getGitHubUsersByLogin(
   try {
     noteRateLimitSpend('graphql')
     const { stdout } = await ghExecFileAsync(
-      ['api', 'graphql', '-f', `query=query { ${fields} }`],
+      [
+        'api',
+        ...(ownerRepo ? ghApiHostArgs(ownerRepo) : []),
+        'graphql',
+        '-f',
+        `query=query { ${fields} }`
+      ],
       ghRepoExecOptions(githubRepoContext(repoPath, connectionId, localGitOptions))
     )
     const data = JSON.parse(stdout) as {
@@ -1090,8 +1143,7 @@ async function fetchContentAtRef(args: {
   repoPath: string
   connectionId?: string | null
   localGitOptions?: LocalGitExecOptions
-  owner: string
-  repo: string
+  ownerRepo: GitHubOwnerRepoSlug
   path: string
   ref: string
 }): Promise<{ content: string; isBinary: boolean; tooLarge?: boolean }> {
@@ -1099,11 +1151,12 @@ async function fetchContentAtRef(args: {
     const { stdout } = await ghExecFileAsync(
       [
         'api',
+        ...ghApiHostArgs(args.ownerRepo),
         '--cache',
         '300s',
         '-H',
         'Accept: application/vnd.github.raw',
-        `repos/${args.owner}/${args.repo}/contents/${encodeURI(args.path)}?ref=${encodeURIComponent(args.ref)}`
+        `repos/${args.ownerRepo.owner}/${args.ownerRepo.repo}/contents/${encodeGitHubContentPath(args.path)}?ref=${encodeURIComponent(args.ref)}`
       ],
       {
         ...ghRepoExecOptions(
@@ -1139,10 +1192,10 @@ export async function getPRFileContents(args: {
   headSha: string
   baseSha: string
 }): Promise<GitHubPRFileContents> {
-  const ownerRepo = await getOwnerRepo(
+  const ownerRepo = await getOriginApiOwnerRepo(
     args.repoPath,
     args.connectionId,
-    ...localGitOptionArgs(args.localGitOptions)
+    args.localGitOptions
   )
   if (!ownerRepo) {
     return {
@@ -1169,8 +1222,7 @@ export async function getPRFileContents(args: {
             repoPath: args.repoPath,
             connectionId: args.connectionId,
             localGitOptions: args.localGitOptions,
-            owner: ownerRepo.owner,
-            repo: ownerRepo.repo,
+            ownerRepo,
             path: originalPath,
             ref: originalRef
           })
@@ -1183,8 +1235,7 @@ export async function getPRFileContents(args: {
             repoPath: args.repoPath,
             connectionId: args.connectionId,
             localGitOptions: args.localGitOptions,
-            owner: ownerRepo.owner,
-            repo: ownerRepo.repo,
+            ownerRepo,
             path: args.path,
             ref: args.headSha
           })


### PR DESCRIPTION
## Summary

Fixes #8935.

GitHub Enterprise Server PR work items open with metadata, but the file diff/content view stays empty because work-item detail calls only resolve `github.com` owner/repo and never pass `gh --hostname <enterprise-host>`.

This routes PR detail GitHub CLI calls through `getEnterpriseGitHubRepoSlug` when the standard GitHub.com owner/repo lookup is unavailable, pins `--hostname` on Enterprise API calls, and encodes PR file-content paths by segment so filenames containing characters like `#` or `?` do not break the GitHub contents API URL.

**Credits:** Focused approach and initial fix from [@wonjerry](https://github.com/wonjerry) in #8932. That PR also evolved into a large host-aware rewrite (thanks [@AmethystLiang](https://github.com/AmethystLiang)); this lands the #8935-scoped fix on current `main` so Enterprise diffs work without waiting on the broader stack.

## Description

- Add `getOriginApiOwnerRepo`: try `getOwnerRepo`, fall back to `getEnterpriseGitHubRepoSlug`
- Add `ghApiHostArgs` so non-`github.com` hosts get `['--hostname', host]`
- Thread host-aware owner/repo through PR body, SHA, files, viewed-state, participants, mention hydration, and file contents
- Encode contents API paths with per-segment `encodeURIComponent`

## Evidence

- Repro kit: `docs/bug-reproductions/8935.md` on `nwparker/bug-repro-handoffs` (root cause: `parseGitHubOwnerRepo` is github.com-only → `getPRFiles`/`getPRFileContents` return null/empty)
- Regression suite: `src/main/github/work-item-details-ghe-host.test.ts`
- Adversarial coverage in `work-item-details.test.ts`:
  - GHES PR files load with `--hostname`
  - Special path chars (`#`, `?`) segment-encoded
  - github.com path never pins `--hostname` and skips enterprise slug probe
  - Unresolved remote still sets `filesUnavailable`

## ELI5

Orca was asking github.com for your company’s private GitHub Enterprise PR files. It now asks the right Enterprise server, so the diff shows up.

## User-regression-tradeoffs

- **github.com users:** unchanged — still use `getOwnerRepo` only; no `--hostname` on API args
- **GHES users with `gh` logged in to that host:** PR diffs/files load correctly
- **GHES users without host auth / non-GitHub forges:** still `filesUnavailable` (safe no-steal of other forges; same as enterprise slug contract elsewhere)
- **Issue-only GHES work items:** not fully host-wired here (follow-up); this PR targets the reported PR diff path
- Tradeoff vs #8932’s broad rewrite: smaller blast radius and lands the user-visible bug now; broader host/rate-limit plumbing can continue separately

## Screenshots

No visual change. Behavior: GHES PR work item Files tab loads diffs instead of empty/unavailable.

## Testing

- [x] `pnpm lint` (oxlint on touched files via pre-commit + targeted oxlint)
- [x] `pnpm typecheck` — `pnpm run typecheck:node` passed
- [ ] `pnpm test` (full suite not run; targeted suites passed)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Targeted verification:

```bash
pnpm exec oxlint src/main/github/work-item-details.ts \
  src/main/github/work-item-details.test.ts \
  src/main/github/work-item-details-file-viewed.test.ts \
  src/main/github/work-item-details-ghe-host.test.ts

pnpm exec vitest run --config config/vitest.config.ts \
  src/main/github/work-item-details.test.ts \
  src/main/github/work-item-details-file-viewed.test.ts \
  src/main/github/work-item-details-ghe-host.test.ts

pnpm run typecheck:node
```

Result: 18 tests passed across the three files; oxlint clean; node typecheck clean.

## AI Review Report

Adversarial self-review focused on:

- GHES vs github.com routing (null owner/repo, enterprise slug fallback, no hostname on dotcom)
- Command construction (`gh api` argv arrays with `--hostname`, no shell interpolation)
- Path encoding (`#`/`?` and multi-segment paths)
- Failure modes when neither slug resolves (`filesUnavailable` / empty contents)
- Cross-platform: argv arrays only; no shell-specific behavior; no shortcut/label/UI changes; WSL/localGitOptions still forwarded through existing helpers

Compared with #8932: preferred the focused work-item-details fix for #8935 over the multi-thousand-line host rewrite still in flux on that PR.

## Security Audit

- Enterprise host comes from existing remote URL + `gh auth status` authentication probe (`getEnterpriseGitHubRepoSlug`); unauthenticated custom hosts do not claim the GitHub provider
- Host is passed as a single `gh` argv value (`--hostname <host>`), not interpolated into a shell string
- PR file paths are segment-encoded before placement in the GitHub contents API path
- No new secrets, tokens, filesystem writes, IPC surfaces, or permission flows

## Notes

- Supersedes the #8935-specific portion of #8932 with a minimal main-based patch; credit to @wonjerry (and @AmethystLiang for broader GHES follow-ups on that branch)
- Issue timeline / issue-only Enterprise work items may still need separate host threading
- SSH/WSL/local git options continue through `localGitOptions` / `githubRepoContext` as before