### PR TITLE
fix(relay): restore unstaged image previews in SSH diffs

### DIFF
--- a/src/relay/git-working-file-read.test.ts
+++ b/src/relay/git-working-file-read.test.ts
@@ -35,4 +35,31 @@ describe('readWorkingDiffFile', () => {
       isBinary: true
     })
   })
+
+  it('returns base64 content for previewable image working-tree files', async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), 'relay-working-file-'))
+    const filePath = path.join(tmpDir, 'image.png')
+    // Why: PNG signature + trailing null byte forces the binary-detection heuristic to trip.
+    const pngBuffer = Buffer.concat([
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      Buffer.from([0x00])
+    ])
+    await writeFile(filePath, pngBuffer)
+
+    await expect(readWorkingDiffFile(filePath)).resolves.toEqual({
+      content: pngBuffer.toString('base64'),
+      isBinary: true
+    })
+  })
+
+  it('returns empty content for non-previewable binary working-tree files', async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), 'relay-working-file-'))
+    const filePath = path.join(tmpDir, 'archive.bin')
+    await writeFile(filePath, Buffer.from([0x00, 0x01, 0x02, 0x00, 0x03]))
+
+    await expect(readWorkingDiffFile(filePath)).resolves.toEqual({
+      content: '',
+      isBinary: true
+    })
+  })
 })

--- a/src/relay/git-working-file-read.ts
+++ b/src/relay/git-working-file-read.ts
@@ -16,7 +16,7 @@ export async function readWorkingDiffFile(
       return { content: '', isBinary: true }
     }
     const buffer = await readFile(absPath)
-    return bufferToBlob(buffer)
+    return bufferToBlob(buffer, absPath)
   } catch {
     return { content: '', isBinary: false }
   }


### PR DESCRIPTION
## Summary

Over SSH/relay, unstaged image diffs showed an empty modified side even for previewable files like PNGs. Staged and HEAD reads already passed a path into `bufferToBlob`, so only the working-tree path was broken: without a path, extension-based MIME lookup always failed and every binary came back as empty content.

`readWorkingDiffFile` now passes the absolute path through, so previewable images return base64 content again while non-previewable binaries stay empty.

## Test plan

- [x] Unit: previewable PNG working-tree files return base64 + `isBinary: true`
- [x] Unit: non-previewable binaries still return empty content + `isBinary: true`
- [ ] Manual: open an unstaged image change over SSH/relay and confirm the modified side renders

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Grok](https://img.shields.io/badge/Grok_4.5-000000)
