### PR TITLE
fix(terminal): tear down runtime-owned headless PTYs on whole-tab close

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -19722,11 +19722,9 @@ describe('OrcaRuntimeService', () => {
     expect(getSession().terminalLayoutsByTabId['host-tab']).toBeUndefined()
   })
 
-  it('tears down a runtime-owned SSH headless tab authoritatively even when the renderer relay is wired', async () => {
-    // #8958 regression: with a window attached, both closeTerminal and
-    // closeTerminalTab are wired. A headless SSH tab is absent from the window
-    // graph, so the closeTerminalTab relay would resolve nothing and ack success
-    // while the PTY kept running. The authoritative teardown must win.
+  it('durably tears down a runtime-owned SSH headless tab when renderer cleanup fails', async () => {
+    // #8958 regression: the acknowledged renderer relay cannot see headless tabs;
+    // its advisory fallback must not prevent authoritative teardown or flushing.
     const persistedPtyId = 'ssh:ssh-1@@relay-pty'
     const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(
       makeWorkspaceSessionWithHeadlessTerminal({
@@ -19750,9 +19748,14 @@ describe('OrcaRuntimeService', () => {
       })
     )
     const kill = vi.fn(() => true)
-    const closeTerminal = vi.fn()
+    const flushOrThrow = vi.fn()
+    const rendererError = new Error('renderer unavailable')
+    const closeTerminal = vi.fn(() => {
+      throw rendererError
+    })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const closeTerminalTab = vi.fn(async () => {})
-    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    const runtime = new OrcaRuntimeService({ ...runtimeStore, flushOrThrow } as never)
     runtime.setPtyController({
       write: () => true,
       kill,
@@ -19767,6 +19770,11 @@ describe('OrcaRuntimeService', () => {
     expect(closeTerminalTab).not.toHaveBeenCalled()
     expect(kill).toHaveBeenCalledWith(persistedPtyId)
     expect(closeTerminal).toHaveBeenCalledWith('host-tab')
+    expect(flushOrThrow).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalledWith(
+      '[runtime] failed to notify renderer after headless terminal close',
+      { parentTabId: 'host-tab', error: rendererError }
+    )
     expect(getSession().tabsByWorktree[TEST_WORKTREE_ID]).toEqual([])
     expect(getSession().terminalLayoutsByTabId['host-tab']).toBeUndefined()
   })

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -19722,6 +19722,55 @@ describe('OrcaRuntimeService', () => {
     expect(getSession().terminalLayoutsByTabId['host-tab']).toBeUndefined()
   })
 
+  it('tears down a runtime-owned SSH headless tab authoritatively even when the renderer relay is wired', async () => {
+    // #8958 regression: with a window attached, both closeTerminal and
+    // closeTerminalTab are wired. A headless SSH tab is absent from the window
+    // graph, so the closeTerminalTab relay would resolve nothing and ack success
+    // while the PTY kept running. The authoritative teardown must win.
+    const persistedPtyId = 'ssh:ssh-1@@relay-pty'
+    const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: 'host-tab',
+              ptyId: persistedPtyId,
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'Remote Terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          'host-tab': makeHeadlessTerminalLayout({ [HEADLESS_LEAF_ID]: persistedPtyId })
+        }
+      })
+    )
+    const kill = vi.fn(() => true)
+    const closeTerminal = vi.fn()
+    const closeTerminalTab = vi.fn(async () => {})
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.setPtyController({
+      write: () => true,
+      kill,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => [{ id: persistedPtyId, cwd: TEST_WORKTREE_PATH, title: 'Remote' }]
+    })
+    runtime.setNotifier({ closeTerminal, closeTerminalTab } as never)
+    runtime.syncWindowGraph(0, { tabs: [], leaves: [] })
+
+    await runtime.closeMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'host-tab')
+
+    expect(closeTerminalTab).not.toHaveBeenCalled()
+    expect(kill).toHaveBeenCalledWith(persistedPtyId)
+    expect(closeTerminal).toHaveBeenCalledWith('host-tab')
+    expect(getSession().tabsByWorktree[TEST_WORKTREE_ID]).toEqual([])
+    expect(getSession().terminalLayoutsByTabId['host-tab']).toBeUndefined()
+  })
+
   it('materializes hydrated pending headless terminals with the persisted session identity', async () => {
     const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
       makeWorkspaceSessionWithHeadlessTerminal()

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -19771,6 +19771,77 @@ describe('OrcaRuntimeService', () => {
     expect(getSession().terminalLayoutsByTabId['host-tab']).toBeUndefined()
   })
 
+  it('keeps the renderer close transaction for an adopted runtime-owned tab', async () => {
+    // The renderer pin state can be newer than the debounced workspace session.
+    // Once adopted, its live close guard must win over stale persisted metadata.
+    const servePtyId = 'serve-adopted-1'
+    const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: 'host-tab',
+              ptyId: servePtyId,
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'Adopted Terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1,
+              isPinned: false
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          'host-tab': makeHeadlessTerminalLayout({ [HEADLESS_LEAF_ID]: servePtyId })
+        }
+      })
+    )
+    const kill = vi.fn(() => true)
+    const closeTerminal = vi.fn()
+    const closeTerminalTab = vi.fn(async () => {
+      throw new Error('terminal_tab_pinned')
+    })
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.setPtyController({
+      write: () => true,
+      kill,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => [{ id: servePtyId, cwd: TEST_WORKTREE_PATH, title: 'Adopted' }]
+    })
+    runtime.setNotifier({ closeTerminal, closeTerminalTab } as never)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'host-tab',
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'Adopted Terminal',
+          activeLeafId: HEADLESS_LEAF_ID,
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'host-tab',
+          worktreeId: TEST_WORKTREE_ID,
+          leafId: HEADLESS_LEAF_ID,
+          paneRuntimeId: 1,
+          ptyId: servePtyId
+        }
+      ]
+    })
+
+    await expect(
+      runtime.closeMobileSessionTab(`id:${TEST_WORKTREE_ID}`, 'host-tab')
+    ).rejects.toThrow('terminal_tab_pinned')
+
+    expect(closeTerminalTab).toHaveBeenCalledWith('host-tab')
+    expect(closeTerminal).not.toHaveBeenCalled()
+    expect(kill).not.toHaveBeenCalled()
+    expect(getSession().tabsByWorktree[TEST_WORKTREE_ID]).toHaveLength(1)
+    expect(getSession().terminalLayoutsByTabId['host-tab']).toBeDefined()
+  })
+
   it('materializes hydrated pending headless terminals with the persisted session identity', async () => {
     const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
       makeWorkspaceSessionWithHeadlessTerminal()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4692,7 +4692,7 @@ export class OrcaRuntimeService {
       // renderer's live pin guard and durable close transaction.
       if (closingWholeParent && !this.tabs.has(tab.parentTabId)) {
         this.closeHeadlessMobileTerminalTab(worktreeId, snapshot!, tab)
-        this.notifier?.closeTerminal(tab.parentTabId)
+        this.notifyRendererOfHeadlessTerminalClose(tab.parentTabId)
         this.store?.flushOrThrow?.()
         return { closed: true }
       }
@@ -4706,7 +4706,7 @@ export class OrcaRuntimeService {
       // only raw pane close. Runtime-owned parents still need de-persist + kill.
       if (closingWholeParent && this.isRuntimeOwnedHeadlessMobileTab(worktreeId, tab)) {
         this.closeHeadlessMobileTerminalTab(worktreeId, snapshot!, tab)
-        this.notifier?.closeTerminal(tab.parentTabId)
+        this.notifyRendererOfHeadlessTerminalClose(tab.parentTabId)
         this.store?.flushOrThrow?.()
         return { closed: true }
       }
@@ -4737,6 +4737,19 @@ export class OrcaRuntimeService {
       this.notifier?.closeSessionTab?.(tab.id, worktreeId)
     }
     return { closed: true }
+  }
+
+  private notifyRendererOfHeadlessTerminalClose(parentTabId: string): void {
+    // Why: this relay is advisory after main owns teardown; renderer failure must
+    // not prevent the authoritative session flush or turn the close into failure.
+    try {
+      this.notifier?.closeTerminal(parentTabId)
+    } catch (error) {
+      console.warn('[runtime] failed to notify renderer after headless terminal close', {
+        parentTabId,
+        error
+      })
+    }
   }
 
   private async closeHeadlessMobileBrowserTab(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4685,6 +4685,18 @@ export class OrcaRuntimeService {
         (candidate) => candidate.type === 'terminal' && candidate.parentTabId === tab.parentTabId
       ).length
       const closingWholeParent = tab.id !== tabId || parentLeafCount <= 1
+      // Why: a runtime-owned headless tab is absent from renderer state, so the
+      // closeTerminalTab relay below would ack success without killing its PTY,
+      // and syncMobileSessionTabs would republish the "closed" tab. Tear it down
+      // authoritatively here — ahead of the relay, even with a renderer attached —
+      // and best-effort notify the renderer to close any adopted pane. A single
+      // split leaf (exact id, multi-leaf parent) stays on the per-leaf path below.
+      if (closingWholeParent && this.isRuntimeOwnedHeadlessMobileTab(worktreeId, tab)) {
+        this.closeHeadlessMobileTerminalTab(worktreeId, snapshot!, tab)
+        this.notifier?.closeTerminal(tab.parentTabId)
+        this.store?.flushOrThrow?.()
+        return { closed: true }
+      }
       if (closingWholeParent && this.notifier?.closeTerminalTab) {
         // Why: whole-tab close is a lifecycle transaction. The renderer reply
         // arrives only after canonical retirement and a forced session flush.
@@ -4693,18 +4705,6 @@ export class OrcaRuntimeService {
       }
       if (!this.notifier?.closeTerminal) {
         this.closeHeadlessMobileTerminalTab(worktreeId, snapshot!, tab)
-        this.store?.flushOrThrow?.()
-        return { closed: true }
-      }
-      // Why: a runtime-owned headless tab whose whole parent is being closed must
-      // be torn down authoritatively even with a renderer attached — kill the
-      // PTY, drop the persisted binding, and prune+emit — or syncMobileSessionTabs
-      // keeps republishing the "closed" tab with a live PTY. Best-effort notify the
-      // renderer too so any adopted pane closes (no dead pane). A single split leaf
-      // (exact id, multi-leaf parent) keeps the per-leaf path so siblings survive.
-      if (closingWholeParent && this.isRuntimeOwnedHeadlessMobileTab(worktreeId, tab)) {
-        this.closeHeadlessMobileTerminalTab(worktreeId, snapshot!, tab)
-        this.notifier?.closeTerminal(tab.parentTabId)
         this.store?.flushOrThrow?.()
         return { closed: true }
       }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4687,11 +4687,10 @@ export class OrcaRuntimeService {
       const closingWholeParent = tab.id !== tabId || parentLeafCount <= 1
       // Why: a runtime-owned headless tab is absent from renderer state, so the
       // closeTerminalTab relay below would ack success without killing its PTY,
-      // and syncMobileSessionTabs would republish the "closed" tab. Tear it down
-      // authoritatively here — ahead of the relay, even with a renderer attached —
-      // and best-effort notify the renderer to close any adopted pane. A single
-      // split leaf (exact id, multi-leaf parent) stays on the per-leaf path below.
-      if (closingWholeParent && this.isRuntimeOwnedHeadlessMobileTab(worktreeId, tab)) {
+      // and syncMobileSessionTabs would republish the "closed" tab. Only bypass
+      // the relay when no renderer owns the parent: an adopted tab needs the
+      // renderer's live pin guard and durable close transaction.
+      if (closingWholeParent && !this.tabs.has(tab.parentTabId)) {
         this.closeHeadlessMobileTerminalTab(worktreeId, snapshot!, tab)
         this.notifier?.closeTerminal(tab.parentTabId)
         this.store?.flushOrThrow?.()
@@ -4701,6 +4700,14 @@ export class OrcaRuntimeService {
         // Why: whole-tab close is a lifecycle transaction. The renderer reply
         // arrives only after canonical retirement and a forced session flush.
         await this.notifier.closeTerminalTab(tab.parentTabId)
+        return { closed: true }
+      }
+      // Why: notifier implementations without the acknowledged relay may expose
+      // only raw pane close. Runtime-owned parents still need de-persist + kill.
+      if (closingWholeParent && this.isRuntimeOwnedHeadlessMobileTab(worktreeId, tab)) {
+        this.closeHeadlessMobileTerminalTab(worktreeId, snapshot!, tab)
+        this.notifier?.closeTerminal(tab.parentTabId)
+        this.store?.flushOrThrow?.()
         return { closed: true }
       }
       if (!this.notifier?.closeTerminal) {


### PR DESCRIPTION
## What

Fixes a durability regression introduced by #8958 ("make whole-tab close durable"): closing the whole parent of a **runtime-owned headless terminal tab** can leak its PTY and let the "closed" tab reappear when a renderer notifier is attached.

The final routing also preserves the renderer transaction for an adopted serve/SSH tab. That matters because live renderer pin state can be newer than the deliberately debounced workspace-session copy; bypassing the renderer for every runtime-owned PTY could kill a newly pinned terminal from stale persisted metadata.

## Root cause

`closeMobileSessionTab` delegated every whole-parent close to `closeTerminalTab` before the pre-existing authoritative headless teardown. Production wires that relay whenever a window exists.

The relay resolves targets only from renderer state. A runtime-owned headless tab is absent there, so the renderer acknowledged a no-op as success. The runtime left the SSH/serve PTY and persisted binding alive, and `syncMobileSessionTabs` published the tab again.

Simply moving the full runtime-owned classifier ahead of the relay creates a second bug for **adopted** tabs: it skips the renderer's live pin guard and acknowledged persistence transaction. Renderer graph publication is coalesced at 16 ms and workspace-session persistence is debounced at 150 ms, so that stale-pin window is deterministic.

## Fix

- For a whole parent absent from the runtime's renderer graph, perform authoritative runtime teardown before the relay: prune persistence, kill the exact owned PTY(s), publish the pruned snapshot, flush, and best-effort close any racing adopted pane.
- For an adopted parent, retain #8958's renderer request/reply transaction so live pin state can reject close and success still means the renderer state was durably flushed.
- Keep the authoritative fallback for notifier implementations that expose only raw pane close.
- Contain advisory renderer-notification failures so they cannot skip the authoritative session flush or turn an already-committed close into a failed receipt; emit a targeted warning for diagnostics.
- Preserve the existing split-leaf path, so closing one leaf never retires its siblings.

## Reliability contract

- **Invariant (`terminal-session.explicit-close-retirement`):** a whole-parent close of an unadopted runtime-owned terminal removes its exact PTY and durable resume authority; an adopted tab is closed only through the renderer's live guard and durable transaction.
- **Failure source:** #8958 placed a renderer-only resolver ahead of runtime headless teardown; review then found stale persisted pin state could make an unconditional reorder kill an adopted pinned tab.
- **Oracle:** with both production notifiers wired, an absent SSH parent never calls the renderer relay, kills its exact relay PTY, and removes its tab/layout persistence. An adopted serve parent whose renderer rejects `terminal_tab_pinned` calls the relay, propagates the rejection, kills nothing, and preserves persistence.
- **Gates:** `runtime.headless-desktop-promotion-continuity` and `terminal-session.explicit-close-retirement` from `config/reliability-gates.jsonc`.
- **Diagnostics:** close failures continue to surface through the existing RPC error boundary (`terminal_tab_pinned`, renderer timeout/unavailable, persistence errors); a targeted warning records advisory renderer cleanup failures, and deterministic tests record exact relay, PTY-kill, flush, and persisted-layout counts.

## Provider / platform coverage

- **Local + daemon:** adopted renderer ownership remains on the existing durable close path; provider/retirement and parked-close gates pass.
- **SSH/remote:** deterministic coverage uses an exact `ssh:<connection>@@<relay>` identity and proves kill + de-persist. Live remote-host process absence remains uncollected.
- **Serve/headless:** deterministic absent/adopted routing passes; the macOS headless-serve promotion journey preserves the original daemon PTY.
- **Mobile/relay:** `closeMobileSessionTab` is the exercised entry point; no desktop-only filesystem or process assumption was added.
- **macOS/Linux/Windows/WSL:** the routing change is platform-independent TypeScript with no path, shell, signal, or Git behavior. macOS has live Electron evidence; Linux, Windows, and WSL live close evidence remain gaps.

## Performance budget

- **User-visible symptom/resource:** a close appeared successful while an SSH/serve PTY, process, and durable binding remained allocated.
- **Measurement:** deterministic exact kill/persistence/relay counts, the full runtime suite, registered teardown fanout gates, and two live Electron lifecycle journeys.
- **Cost after fix:** an ordinary adopted whole-tab close adds one constant-time `Map.has` ownership check before the existing transaction. It does not run the broader headless classifier, add polling, call `listSessions`, add provider/subprocess fanout, or add background work. Authoritative pruning remains user-triggered and uses the existing bounded snapshot teardown.

## Verification

- Fail-first review test: prior PR head resolved `{ closed: true }` and killed the adopted tab instead of propagating `terminal_tab_pinned`; green after routing refinement.
- Original leak test was confirmed red before the headless routing fix (renderer relay called; PTY not killed) and green after.
- Advisory renderer failure test was confirmed red before containment (exception escaped and flush was skipped) and green after; it asserts exact kill, persistence pruning, one flush, and the diagnostic warning.
- `src/main/runtime/orca-runtime.test.ts`: **717 passed**.
- Headless promotion/runtime gate: **7 files, 754 tests passed**.
- Retirement/authority gate under Node 24: **10 files, 446 tests passed**.
- Provider/descendant/worktree teardown gate: **5 files, 218 tests passed**.
- Fresh Electron: `headless-serve-desktop-activation.spec.ts` passed.
- Fresh Electron: `terminal-parked-close-retirement.spec.ts` passed.
- `pnpm run tc` passed.
- Touched-file `oxlint` and `oxfmt --check` passed; reliability manifest and max-lines ratchet passed.
- Repository-wide `pnpm run lint` currently stops on two unrelated pre-existing switch-exhaustiveness errors in `native-chat-session-option-labels.ts` and `skill-freshness-group.tsx`; this PR does not touch them.

## Residual gaps / risk

- Live Linux, Windows/ConPTY, WSL, and SSH-host process-absence evidence was not collected.
- Advisory renderer cleanup failure now has a targeted warning; broader live Linux, Windows, WSL, and SSH-host teardown diagnostics remain uncollected.
- Cross-platform behavior is unchanged beyond ownership routing (no OS-specific code). SSH/remote is the primary affected surface.
