### PR TITLE
ci(release): regenerate skill manifest on version bump

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -472,13 +472,8 @@ jobs:
           # message and tag name explicitly (avoids npm's `v1.2.3` prefix
           # assumptions and any lifecycle scripts that would run on bump).
           npm version "$VERSION" --no-git-tag-version --allow-same-version
-          # Why: regenerate the bundled skill manifest so its appVersion tracks the
-          # just-bumped package.json. Otherwise the committed manifest keeps the
-          # prior version and verify:skill-bundle-manifest (run in `pnpm lint` and
-          # the PR `verify` job) goes red on every branch after the cut — which is
-          # how v1.4.144-rc.1/rc.2/rc.3 all shipped an rc.1 manifest. The generator
-          # is dependency-free (node builtins + git) so it needs no pnpm install,
-          # and the fetch-depth:0 checkout above gives it the full tag history.
+          # Why: package version is embedded in generated skill provenance; full tag
+          # history preserves released snapshots while the current version is updated.
           node config/scripts/generate-skill-bundle-manifest.mjs --write
           git add package.json resources/skills
           commit_message="release: v$VERSION"

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -472,7 +472,15 @@ jobs:
           # message and tag name explicitly (avoids npm's `v1.2.3` prefix
           # assumptions and any lifecycle scripts that would run on bump).
           npm version "$VERSION" --no-git-tag-version --allow-same-version
-          git add package.json
+          # Why: regenerate the bundled skill manifest so its appVersion tracks the
+          # just-bumped package.json. Otherwise the committed manifest keeps the
+          # prior version and verify:skill-bundle-manifest (run in `pnpm lint` and
+          # the PR `verify` job) goes red on every branch after the cut — which is
+          # how v1.4.144-rc.1/rc.2/rc.3 all shipped an rc.1 manifest. The generator
+          # is dependency-free (node builtins + git) so it needs no pnpm install,
+          # and the fetch-depth:0 checkout above gives it the full tag history.
+          node config/scripts/generate-skill-bundle-manifest.mjs --write
+          git add package.json resources/skills
           commit_message="release: v$VERSION"
           if [[ "$EVENT_NAME" == "schedule" ]]; then
             commit_message="$commit_message [rc-slot:$SLOT]"

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -374,7 +374,7 @@ describe('Electron runtime package contract', () => {
     expect(afterInstallScript).not.toContain('chmod 0755 "$sandbox"')
   })
 
-  it('lets release-cut tag a version that is already present on main', () => {
+  it('keeps release-cut version commits self-healing and taggable on retries', () => {
     const releaseWorkflow = readFileSync(
       join(projectDir, '.github/workflows/release-cut.yml'),
       'utf8'
@@ -384,6 +384,16 @@ describe('Electron runtime package contract', () => {
       (step) => step.name === 'Bump package.json and tag'
     )
 
+    const bumpIndex = bumpStep.run.indexOf(
+      'npm version "$VERSION" --no-git-tag-version --allow-same-version'
+    )
+    const generateIndex = bumpStep.run.indexOf(
+      'node config/scripts/generate-skill-bundle-manifest.mjs --write'
+    )
+    const stageIndex = bumpStep.run.indexOf('git add package.json resources/skills')
+    expect(bumpIndex).toBeGreaterThanOrEqual(0)
+    expect(generateIndex).toBeGreaterThan(bumpIndex)
+    expect(stageIndex).toBeGreaterThan(generateIndex)
     expect(bumpStep.run).toContain('git diff --cached --quiet')
     expect(bumpStep.run).toContain('git commit --allow-empty -m "$commit_message"')
   })

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -380,6 +380,7 @@ describe('Electron runtime package contract', () => {
       'utf8'
     )
     const parsedWorkflow = parse(releaseWorkflow)
+    const checkoutStep = parsedWorkflow.jobs.cut.steps.find((step) => step.name === 'Checkout ref')
     const bumpStep = parsedWorkflow.jobs.cut.steps.find(
       (step) => step.name === 'Bump package.json and tag'
     )
@@ -391,6 +392,7 @@ describe('Electron runtime package contract', () => {
       'node config/scripts/generate-skill-bundle-manifest.mjs --write'
     )
     const stageIndex = bumpStep.run.indexOf('git add package.json resources/skills')
+    expect(checkoutStep.with['fetch-depth']).toBe(0)
     expect(bumpIndex).toBeGreaterThanOrEqual(0)
     expect(generateIndex).toBeGreaterThan(bumpIndex)
     expect(stageIndex).toBeGreaterThan(generateIndex)


### PR DESCRIPTION
## What

Makes the release-cut workflow regenerate the bundled skill manifest whenever it bumps the version, so `resources/skills/current-manifest.json` can never again drift behind `package.json`.

## Why

The **"Bump package.json and tag"** step in `release-cut.yml` runs `npm version …` but only staged `package.json`. It never regenerated the skill manifest, whose `appVersion` is derived from `package.json`. So every cut left the committed manifest pointing at the *previous* release.

This shipped in **v1.4.144-rc.1, rc.2, and rc.3** — all three carried an `appVersion: 1.4.144-rc.1` manifest against an ever-newer `package.json`. Because `verify:skill-bundle-manifest` runs inside `pnpm run lint` **and** as the `.github/workflows/pr.yml` `verify` job, the stale manifest turns that check **red on every branch** after a cut until someone regenerates by hand (which is what #9082 did as a one-off for rc.2).

Runtime impact was nil — `appVersion` is a provenance label, not used for freshness classification — but the CI breakage is real and recurring.

## Fix

Regenerate the manifest right after `npm version` and stage `resources/skills` into the release commit:

```yaml
npm version "$VERSION" --no-git-tag-version --allow-same-version
node config/scripts/generate-skill-bundle-manifest.mjs --write
git add package.json resources/skills
```

- The generator is **dependency-free** (only `node:` builtins + `git`), so it runs in the cut job without a `pnpm install` (the job never installs deps).
- The step's `fetch-depth: 0` checkout gives the generator the full tag history it reads for the release mapping (also fixes the shallow-checkout `assertReleasedHistoryPreserved` failure noted during the audit).
- The existing `git diff --cached --quiet` / empty-commit branch still works: on a normal cut both `package.json` and the manifest change; on a re-cut of the same version it self-heals a stale manifest into the commit.

## Verification

Simulated the cut sequence in a worktree at current `main`:

| Step | `verify:skill-bundle-manifest` |
|---|---|
| baseline (`main`, post-#9082) | exit 0 |
| after `npm version 1.4.144-rc.99` (bump, no regen) | **exit 1** — reproduces the shipped bug |
| after `node config/scripts/generate-skill-bundle-manifest.mjs --write` (new step) | manifest `appVersion → 1.4.144-rc.99`, exit 0 |

Workflow YAML parses cleanly. No product code changed.

Found during the v1.4.144 RC release audit — this is the root-cause fix behind the stale-manifest P1 (the per-tag symptom was patched by #9082).