### PR TITLE
fix(github): preserve custom GHES port in remote host identity

### DIFF
--- a/src/main/github/client-create-pr.test.ts
+++ b/src/main/github/client-create-pr.test.ts
@@ -156,7 +156,7 @@ describe('createGitHubPullRequest', () => {
     expect(args[args.indexOf('--repo') + 1]).toBe('github.acme-corp.com/team/orca')
   })
 
-  it('keeps a custom GHES port in the host-qualified --repo (P2)', async () => {
+  it('keeps a custom GHES port in the host-qualified --repo', async () => {
     getOwnerRepoMock.mockResolvedValueOnce(null)
     getEnterpriseGitHubRepoSlugMock.mockResolvedValueOnce({
       owner: 'team',

--- a/src/main/github/client-create-pr.test.ts
+++ b/src/main/github/client-create-pr.test.ts
@@ -156,6 +156,35 @@ describe('createGitHubPullRequest', () => {
     expect(args[args.indexOf('--repo') + 1]).toBe('github.acme-corp.com/team/orca')
   })
 
+  it('keeps a custom GHES port in the host-qualified --repo (P2)', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce(null)
+    getEnterpriseGitHubRepoSlugMock.mockResolvedValueOnce({
+      owner: 'team',
+      repo: 'orca',
+      host: 'ghe.acme.com:8443'
+    })
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: 'https://ghe.acme.com:8443/team/orca/pull/11\n'
+    })
+
+    await expect(
+      createGitHubPullRequest('/repo-root', {
+        provider: 'github',
+        base: 'main',
+        head: 'feature/create-pr',
+        title: 'GHES PR'
+      })
+    ).resolves.toEqual({
+      ok: true,
+      number: 11,
+      url: 'https://ghe.acme.com:8443/team/orca/pull/11'
+    })
+
+    const [args] = ghExecFileAsyncMock.mock.calls[0]
+    // Dropping :8443 would send gh to the wrong (or default-port) Enterprise host.
+    expect(args[args.indexOf('--repo') + 1]).toBe('ghe.acme.com:8443/team/orca')
+  })
+
   it('host-qualifies --repo for the GHES existing-PR fallback lookup (#8312)', async () => {
     getOwnerRepoMock.mockResolvedValue(null)
     getEnterpriseGitHubRepoSlugMock.mockResolvedValue({

--- a/src/main/github/github-enterprise-repository.test.ts
+++ b/src/main/github/github-enterprise-repository.test.ts
@@ -79,7 +79,7 @@ describe('getEnterpriseGitHubRepoSlug', () => {
     })
   })
 
-  it('preserves a custom GHES port when probing gh auth and in the slug (P2)', async () => {
+  it('preserves a custom GHES port when probing gh auth and in the slug', async () => {
     mockOriginRemote('https://ghe.acme.com:8443/team/orca.git')
     mockHostAuthenticated('ghe.acme.com:8443')
 

--- a/src/main/github/github-enterprise-repository.test.ts
+++ b/src/main/github/github-enterprise-repository.test.ts
@@ -79,6 +79,23 @@ describe('getEnterpriseGitHubRepoSlug', () => {
     })
   })
 
+  it('preserves a custom GHES port when probing gh auth and in the slug (P2)', async () => {
+    mockOriginRemote('https://ghe.acme.com:8443/team/orca.git')
+    mockHostAuthenticated('ghe.acme.com:8443')
+
+    await expect(getEnterpriseGitHubRepoSlug('/repo')).resolves.toEqual({
+      owner: 'team',
+      repo: 'orca',
+      host: 'ghe.acme.com:8443'
+    })
+    // The auth probe must target the port-qualified endpoint, not the bare host,
+    // so a login stored under ghe.acme.com:8443 is honored.
+    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
+      ['auth', 'status', '--hostname', 'ghe.acme.com:8443'],
+      { cwd: '/repo' }
+    )
+  })
+
   it('probes gh in the repository WSL runtime, not the host/default distro', async () => {
     mockOriginRemote('https://github.acme-corp.com/team/orca.git')
     mockHostAuthenticated()

--- a/src/main/github/github-remote-identity-parsing.test.ts
+++ b/src/main/github/github-remote-identity-parsing.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  parseGitHubOwnerRepo,
+  parseGitHubRemoteIdentity
+} from './github-remote-identity-parsing'
+
+describe('parseGitHubRemoteIdentity', () => {
+  it('parses a plain github.com https remote', () => {
+    expect(parseGitHubRemoteIdentity('https://github.com/team/orca.git')).toEqual({
+      host: 'github.com',
+      owner: 'team',
+      repo: 'orca'
+    })
+  })
+
+  it('parses an SCP-style github.com remote', () => {
+    expect(parseGitHubRemoteIdentity('git@github.com:team/orca.git')).toEqual({
+      host: 'github.com',
+      owner: 'team',
+      repo: 'orca'
+    })
+  })
+
+  it('preserves a custom port on a GHES https remote (P2)', () => {
+    // The port IS the Enterprise web/API endpoint, so gh must target
+    // ghe.acme.com:8443, not the portless hostname.
+    expect(parseGitHubRemoteIdentity('https://ghe.acme.com:8443/team/orca.git')).toEqual({
+      host: 'ghe.acme.com:8443',
+      owner: 'team',
+      repo: 'orca'
+    })
+  })
+
+  it('preserves a custom port on a GHES http remote', () => {
+    expect(parseGitHubRemoteIdentity('http://ghe.acme.com:8080/team/orca.git')).toEqual({
+      host: 'ghe.acme.com:8080',
+      owner: 'team',
+      repo: 'orca'
+    })
+  })
+
+  it('drops the default https port so github.com stays bare', () => {
+    // WHATWG URL omits default ports, so :443 never leaks into the host.
+    expect(parseGitHubRemoteIdentity('https://github.com:443/team/orca.git')?.host).toBe(
+      'github.com'
+    )
+  })
+
+  it('drops the default https port on a GHES host', () => {
+    expect(parseGitHubRemoteIdentity('https://ghe.acme.com:443/team/orca.git')?.host).toBe(
+      'ghe.acme.com'
+    )
+  })
+
+  it('normalizes ssh.github.com:443 (SSH-over-HTTPS) to github.com without a port', () => {
+    // :443 here is the ssh transport port, not an endpoint — it must not survive.
+    expect(parseGitHubRemoteIdentity('ssh://git@ssh.github.com:443/team/orca.git')).toEqual({
+      host: 'github.com',
+      owner: 'team',
+      repo: 'orca'
+    })
+  })
+
+  it('drops a custom ssh transport port on a GHES ssh remote', () => {
+    // ssh://…:2222 is a transport port; gh routes by hostname, so keep only the host.
+    expect(parseGitHubRemoteIdentity('ssh://git@ghe.acme.com:2222/team/orca.git')?.host).toBe(
+      'ghe.acme.com'
+    )
+  })
+
+  it('drops the transport port for git+ssh and git remotes', () => {
+    expect(parseGitHubRemoteIdentity('git+ssh://git@ghe.acme.com:2222/team/orca.git')?.host).toBe(
+      'ghe.acme.com'
+    )
+    expect(parseGitHubRemoteIdentity('git://ghe.acme.com:9418/team/orca.git')?.host).toBe(
+      'ghe.acme.com'
+    )
+  })
+
+  it('lowercases the host while keeping the port', () => {
+    expect(parseGitHubRemoteIdentity('https://GHE.Acme.COM:8443/team/orca.git')?.host).toBe(
+      'ghe.acme.com:8443'
+    )
+  })
+
+  it('returns null for an unparseable remote', () => {
+    expect(parseGitHubRemoteIdentity('not-a-remote')).toBeNull()
+  })
+})
+
+describe('parseGitHubOwnerRepo', () => {
+  it('returns owner/repo for github.com', () => {
+    expect(parseGitHubOwnerRepo('https://github.com/team/orca.git')).toEqual({
+      owner: 'team',
+      repo: 'orca'
+    })
+  })
+
+  it('returns null for a custom-port GHES remote (not github.com)', () => {
+    // GHES is handled by the enterprise resolver, not the github.com fast path,
+    // and the port must not make a github.com remote look like GHES either.
+    expect(parseGitHubOwnerRepo('https://ghe.acme.com:8443/team/orca.git')).toBeNull()
+  })
+
+  it('still recognizes github.com even with an explicit default port', () => {
+    expect(parseGitHubOwnerRepo('https://github.com:443/team/orca.git')).toEqual({
+      owner: 'team',
+      repo: 'orca'
+    })
+  })
+})

--- a/src/main/github/github-remote-identity-parsing.test.ts
+++ b/src/main/github/github-remote-identity-parsing.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import {
-  parseGitHubOwnerRepo,
-  parseGitHubRemoteIdentity
-} from './github-remote-identity-parsing'
+import { parseGitHubOwnerRepo, parseGitHubRemoteIdentity } from './github-remote-identity-parsing'
 
 describe('parseGitHubRemoteIdentity', () => {
   it('parses a plain github.com https remote', () => {
@@ -22,7 +19,7 @@ describe('parseGitHubRemoteIdentity', () => {
     })
   })
 
-  it('preserves a custom port on a GHES https remote (P2)', () => {
+  it('preserves a custom port on a GHES https remote', () => {
     // The port IS the Enterprise web/API endpoint, so gh must target
     // ghe.acme.com:8443, not the portless hostname.
     expect(parseGitHubRemoteIdentity('https://ghe.acme.com:8443/team/orca.git')).toEqual({

--- a/src/main/github/github-remote-identity-parsing.ts
+++ b/src/main/github/github-remote-identity-parsing.ts
@@ -8,6 +8,18 @@ function normalizeGitHubRemoteHost(host: string): string {
   return normalizedHost === 'ssh.github.com' ? 'github.com' : normalizedHost
 }
 
+// Why: for http(s) remotes the URL port is the GHES web/API endpoint (e.g. an
+// Enterprise server on :8443), which `gh --hostname` and host-qualified
+// `--repo host/owner/repo` must target, so it is kept via `url.host`. For
+// ssh/git remotes the port is a transport port (e.g. ssh.github.com:443) that
+// does not identify the host, so only the hostname is used — preserving
+// ssh.github.com normalization and SSH-over-HTTPS. Mirrors GitLab's project-ref
+// host resolution.
+function hostFromRemoteUrl(url: URL): string {
+  const protocol = url.protocol.toLowerCase()
+  return protocol === 'http:' || protocol === 'https:' ? url.host : url.hostname
+}
+
 function parseGitHubRemotePath(path: string): Pick<GitHubRemoteIdentity, 'owner' | 'repo'> | null {
   const parts = path.replace(/^\/+/, '').replace(/\/+$/, '').split('/')
   if (parts.length !== 2) {
@@ -34,7 +46,7 @@ export function parseGitHubRemoteIdentity(remoteUrl: string): GitHubRemoteIdenti
       return null
     }
     const path = parseGitHubRemotePath(url.pathname)
-    return path ? { host: normalizeGitHubRemoteHost(url.hostname), ...path } : null
+    return path ? { host: normalizeGitHubRemoteHost(hostFromRemoteUrl(url)), ...path } : null
   } catch {
     return null
   }

--- a/src/main/github/github-remote-identity-parsing.ts
+++ b/src/main/github/github-remote-identity-parsing.ts
@@ -8,13 +8,8 @@ function normalizeGitHubRemoteHost(host: string): string {
   return normalizedHost === 'ssh.github.com' ? 'github.com' : normalizedHost
 }
 
-// Why: for http(s) remotes the URL port is the GHES web/API endpoint (e.g. an
-// Enterprise server on :8443), which `gh --hostname` and host-qualified
-// `--repo host/owner/repo` must target, so it is kept via `url.host`. For
-// ssh/git remotes the port is a transport port (e.g. ssh.github.com:443) that
-// does not identify the host, so only the hostname is used — preserving
-// ssh.github.com normalization and SSH-over-HTTPS. Mirrors GitLab's project-ref
-// host resolution.
+// Why: HTTP ports identify the GHES web/API endpoint; SSH and git ports are
+// transport-only and must not leak into gh's host identity.
 function hostFromRemoteUrl(url: URL): string {
   const protocol = url.protocol.toLowerCase()
   return protocol === 'http:' || protocol === 'https:' ? url.host : url.hostname


### PR DESCRIPTION
## Summary

GitHub Enterprise Server remotes that use a custom HTTP(S) port (e.g. `https://ghe.acme.com:8443/team/orca.git`) were losing the port when Orca derived the host identity for `gh`. `URL.hostname` strips the port, so `gh auth status --hostname` and host-qualified `--repo` targeted the wrong (default-port) Enterprise endpoint.

This change uses `url.host` (hostname + non-default port) for HTTP(S) remotes — where the port **is** the GHES web/API endpoint — and keeps `url.hostname` for SSH/`git` remotes so transport-only ports (e.g. `ssh.github.com:443`, `ghe.acme.com:2222`) do not leak into the `gh` host identity. Mirrors GitLab's project-ref host resolution.

**User-visible impact:** Create PR / auth probes against GHES instances on a non-default port now hit the correct host (e.g. `ghe.acme.com:8443`) instead of failing or talking to the wrong endpoint.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [x] `pnpm test` (targeted: GitHub remote identity parsing, enterprise repo slug, create-PR host-qualified `--repo`)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed
  - New unit coverage for `parseGitHubRemoteIdentity` / `parseGitHubOwnerRepo` (custom ports, default ports, SSH transport ports)
  - Enterprise slug + create-PR tests assert port is preserved in `gh` `--hostname` / `--repo`

## AI Review Report

Reviewed the host-resolution change for:
- Correct protocol split (HTTP(S) keeps port; SSH/`git` drop transport ports)
- Default-port omission via WHATWG URL (`:443` / `:80` never leak)
- `ssh.github.com` → `github.com` normalization still works with SSH-over-HTTPS
- Downstream consumers (`getEnterpriseGitHubRepoSlug`, create-PR `--repo` qualification) receive the port-qualified host

Cross-platform: no UI shortcuts, path separators, or shell-specific behavior. Host parsing is pure string/`URL` logic shared across macOS, Linux, and Windows; `gh` args are host-qualified the same way on all platforms.

## Security Audit

- Remote URLs are still parsed via the existing `URL` path with a null return on failure; no new command construction beyond existing `gh` invocation patterns.
- Port is only retained when it is part of the HTTP(S) endpoint identity; SSH/git transport ports are intentionally excluded so they cannot be injected into `gh --hostname` / `--repo`.
- No secrets, auth tokens, or IPC surface changes. No dependency updates.

## Notes

- Affects only GitHub remote identity parsing used by Enterprise/`gh` flows. github.com and default-port hosts stay bare (no port suffix).
- Follow-up not required unless other call sites build host identity without going through `parseGitHubRemoteIdentity`.