### PR TITLE
fix(win): stop shipping duplicate broken orca.cmd shim in app.asar

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -86,7 +86,13 @@ module.exports = {
     // Why: feature-wall media is copied via extraResources so runtime can read
     // it from process.resourcesPath; exclude the source copy from app.asar.
     '!resources/onboarding/feature-wall/**',
-    '!resources/skills/**'
+    '!resources/skills/**',
+    // Why: the Windows CLI shim ships via extraResources to resources/bin/orca.cmd
+    // (beside the native resources/bin/orca.exe). Packing the source tree into
+    // app.asar too lets asarUnpack:['resources/**'] extract a second copy at
+    // app.asar.unpacked/resources/win32/bin/orca.cmd with no adjacent orca.exe,
+    // which fails to launch the CLI (#7351).
+    '!resources/win32{,/**/*}'
   ],
   // Why: the CLI entry-point lives in out/cli/ but imports shared modules
   // from out/shared/ and local hook mutators from out/main/. These paths must be

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -77,6 +77,26 @@ describe('electron-builder config', () => {
     )
   })
 
+  // Why: the Windows CLI shim is delivered only via extraResources to
+  // resources/bin/orca.cmd (beside the native resources/bin/orca.exe). If the
+  // source tree is also packed into app.asar it gets extracted by
+  // asarUnpack:['resources/**'] to app.asar.unpacked/resources/win32/bin/orca.cmd,
+  // a duplicate with no adjacent orca.exe that fails to launch (#7351).
+  it('keeps the Windows CLI shim source tree out of app.asar', () => {
+    expect(electronBuilderConfig.files).toEqual(
+      expect.arrayContaining(['!resources/win32{,/**/*}'])
+    )
+    // Regression guard: the working shim must still ship via extraResources.
+    expect(electronBuilderConfig.win.extraResources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          from: 'resources/win32/bin/orca.cmd',
+          to: 'bin/orca.cmd'
+        })
+      ])
+    )
+  })
+
   // Why: on macOS 26 UNUserNotificationCenter aborts for executables launched
   // from Contents/Resources, so the helper must ship in Contents/MacOS (#7929).
   it('ships the mac notification-status helper in Contents/MacOS, not Resources', () => {


### PR DESCRIPTION
# fix(win): stop shipping duplicate broken orca.cmd shim in app.asar

## Summary
Fixes the Windows CLI launcher failing with *"Unable to locate the native Orca CLI launcher…"* because a duplicate, broken `orca.cmd` shim was bundled inside `app.asar` (#7351).

## ELI5
On Windows, Orca accidentally shipped two copies of its command-line helper — and the extra copy was placed where it couldn't find the program it needs to run, so it broke. This removes the bad copy and keeps the one that works.

## Root cause & fix
The Windows CLI shim ships correctly through `win.extraResources` to `resources/bin/orca.cmd`, right next to the native `resources/bin/orca.exe` it resolves against. But the source tree `resources/win32` was *also* packed into `app.asar`, and `asarUnpack: ['resources/**']` extracted a second copy to `app.asar.unpacked/resources/win32/bin/orca.cmd` with no adjacent `orca.exe`, so launching it failed. The fix adds `!resources/win32{,/**/*}` to `config.files`, excluding the source tree from `app.asar` while preserving the working `extraResources` delivery.

## Evidence
Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- Test: `keeps the Windows CLI shim source tree out of app.asar` in `config/scripts/electron-builder-config.test.mjs`.
- On branch (fix present): **22 passed (22)**.
- Fix reverted to `origin/main`, test kept: **1 failed | 21 passed** — the guard fails because `config.files` lacks `!resources/win32{,/**/*}`.

```
# On branch (fix present)
Test Files  1 passed (1)
Tests  22 passed (22)

# Fix reverted, test kept
Test Files  1 failed (1)
Tests  1 failed | 21 passed (22)
Failing: "keeps the Windows CLI shim source tree out of app.asar"
Assertion: expect(electronBuilderConfig.files).toEqual(
  expect.arrayContaining(['!resources/win32{,/**/*}']))
```

- Lint: `npx oxlint config/electron-builder.config.cjs` — clean, no findings.

## Trade-offs
None — pure fix.

## Regression risk
Zero-regression: the change only adds one exclusion glob to `config.files`, so the working `extraResources` copy at `resources/bin/orca.cmd` is untouched and all non-Windows paths are byte-identical. The proven regression test locks the exclusion in place.

_Credit to original author @xianjianlf2. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved._
