### PR TITLE
fix(daemon): rebuild WSL OSC-7 cwd as a distro UNC path on wake

### DIFF
--- a/src/main/daemon/headless-emulator.test.ts
+++ b/src/main/daemon/headless-emulator.test.ts
@@ -239,6 +239,25 @@ describe('HeadlessEmulator', () => {
       expect(emulator.getSnapshot().cwd).toBe('\\\\server\\share\\project')
     })
 
+    it('rebuilds a WSL shell OSC-7 cwd as a distro UNC path (#8470)', async () => {
+      // Why: a WSL-backed pane reports its Linux hostname as the OSC-7
+      // authority; without distro context it became an invalid \\<hostname>\...
+      // UNC that failed sleep/wake cwd validation.
+      emulator = new HeadlessEmulator({
+        cols: 80,
+        rows: 24,
+        pathFlavor: 'win32',
+        wslDistro: 'Ubuntu'
+      })
+      await emulator.write(
+        '\x1b]7;file://remoteseaview/home/yuming/project_ongoing/orca_remote\x07'
+      )
+
+      expect(emulator.getSnapshot().cwd).toBe(
+        '\\\\wsl.localhost\\Ubuntu\\home\\yuming\\project_ongoing\\orca_remote'
+      )
+    })
+
     it('handles OSC-7 with ST terminator', async () => {
       emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
       await emulator.write('\x1b]7;file:///path/here\x1b\\')

--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -35,6 +35,7 @@ export type HeadlessEmulatorOptions = {
   onQueryReply?: (reply: string) => void
   pathFlavor?: 'posix' | 'win32'
   remotePosixFileUriAuthority?: boolean
+  wslDistro?: string
 }
 
 export type HeadlessEmulatorWriteOptions = {
@@ -72,6 +73,7 @@ export class HeadlessEmulator {
   private mouseModes = new TerminalMouseModeMirror()
   private readonly pathFlavor?: 'posix' | 'win32'
   private readonly remotePosixFileUriAuthority: boolean
+  private readonly wslDistro?: string
   private restoredOscLinks: TerminalOscLinkRange[] = []
   private disposed = false
   private onQueryReply: ((reply: string) => void) | null
@@ -91,9 +93,11 @@ export class HeadlessEmulator {
   constructor(opts: HeadlessEmulatorOptions) {
     this.pathFlavor = opts.pathFlavor
     this.remotePosixFileUriAuthority = opts.remotePosixFileUriAuthority === true
+    this.wslDistro = opts.wslDistro
     this.oscText = new TerminalOscCwdTitleScanner({
       pathFlavor: this.pathFlavor,
-      remotePosixAuthority: this.remotePosixFileUriAuthority
+      remotePosixAuthority: this.remotePosixFileUriAuthority,
+      wslDistro: this.wslDistro
     })
     this.terminal = new Terminal({
       cols: opts.cols,

--- a/src/main/daemon/osc7-file-uri.test.ts
+++ b/src/main/daemon/osc7-file-uri.test.ts
@@ -31,6 +31,21 @@ describe('parseFileUriPath', () => {
     }
   })
 
+  it('rewrites a WSL PTY OSC7 authority to a distro UNC path instead of a bogus share', () => {
+    // Why: on a Windows host a WSL-backed shell reports its Linux hostname as
+    // the OSC7 authority. Without distro context it becomes an invalid
+    // \\<hostname>\... UNC that fails sleep/wake cwd validation (#8470).
+    expect(
+      parseFileUriPathParts('file://remoteseaview/home/yuming/project_ongoing/orca_remote', {
+        pathFlavor: 'win32',
+        wslDistro: 'Ubuntu'
+      })
+    ).toEqual({
+      path: '\\\\wsl.localhost\\Ubuntu\\home\\yuming\\project_ongoing\\orca_remote',
+      hostname: 'remoteseaview'
+    })
+  })
+
   it('parses Windows SSH OSC7 drive paths independent of the desktop platform', () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })

--- a/src/main/daemon/osc7-file-uri.ts
+++ b/src/main/daemon/osc7-file-uri.ts
@@ -6,6 +6,7 @@ export type ParsedFileUriPath = {
 export type ParseFileUriPathOptions = {
   pathFlavor?: 'posix' | 'win32'
   remotePosixAuthority?: boolean
+  wslDistro?: string
 }
 
 export function parseFileUriPath(
@@ -34,6 +35,16 @@ export function parseFileUriPathParts(
 
     if (/^\/[A-Za-z]:/.test(decodedPath)) {
       return { path: decodedPath.slice(1), hostname }
+    }
+    // Why: a WSL-backed local PTY reports its Linux shell hostname as the OSC-7
+    // authority, which is never a Windows UNC server. Rebuild the POSIX path as
+    // the session distro's \\wsl.localhost UNC so sleep/wake cwd validation
+    // resolves it instead of a bogus \\<hostname>\... share (#8470).
+    if (options.wslDistro) {
+      return {
+        path: `\\\\wsl.localhost\\${options.wslDistro}${decodedPath.replace(/\//g, '\\')}`,
+        hostname
+      }
     }
     // Why: localhost/empty-host OSC-7 URIs are POSIX paths even when parsed by
     // a Windows app; only non-local hosts describe Windows UNC shares.

--- a/src/main/daemon/terminal-osc-cwd-title-scanner.ts
+++ b/src/main/daemon/terminal-osc-cwd-title-scanner.ts
@@ -11,6 +11,7 @@ const OSC_SCAN_TAIL_LIMIT = 4096
 export type TerminalOscCwdTitleScannerOptions = {
   pathFlavor?: 'posix' | 'win32'
   remotePosixAuthority?: boolean
+  wslDistro?: string
 }
 
 export class TerminalOscCwdTitleScanner {
@@ -39,7 +40,8 @@ export class TerminalOscCwdTitleScanner {
     scanOsc7Uris(input, (uri) => {
       const parsed = parseFileUriPath(uri, {
         pathFlavor: this.parseOptions.pathFlavor,
-        remotePosixAuthority: this.parseOptions.remotePosixAuthority
+        remotePosixAuthority: this.parseOptions.remotePosixAuthority,
+        wslDistro: this.parseOptions.wslDistro
       })
       if (parsed) {
         this.cwd = parsed

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -245,7 +245,7 @@ import {
   normalizeRuntimePathForComparison
 } from '../../shared/cross-platform-path'
 import { resolveTerminalStartupCwd } from '../../shared/terminal-startup-cwd'
-import { isWslUncPath } from '../../shared/wsl-paths'
+import { isWslUncPath, parseWslUncPath } from '../../shared/wsl-paths'
 import {
   folderWorkspaceKey,
   isWorkspaceKey,
@@ -6750,7 +6750,8 @@ export class OrcaRuntimeService {
     return uri
       ? parseFileUriPathParts(uri, {
           pathFlavor,
-          remotePosixAuthority: !!pty?.connectionId && pathFlavor !== 'win32'
+          remotePosixAuthority: !!pty?.connectionId && pathFlavor !== 'win32',
+          wslDistro: this.wslDistroForPty(pty, pathFlavor)
         })
       : null
   }
@@ -6782,6 +6783,20 @@ export class OrcaRuntimeService {
     }
     const worktreePath = splitWorktreeIdForFilesystem(pty.worktreeId)?.worktreePath
     return worktreePath && isWindowsAbsolutePathLike(worktreePath) ? 'win32' : 'posix'
+  }
+
+  /** WSL distro backing a local (non-SSH) win32 PTY, derived from its
+   *  \\wsl.localhost worktree path. Lets OSC-7 rebuild the Linux shell's cwd as
+   *  a distro UNC path instead of a bogus \\<shell-hostname>\... share (#8470). */
+  private wslDistroForPty(
+    pty: RuntimePtyWorktreeRecord | null | undefined,
+    pathFlavor: 'posix' | 'win32'
+  ): string | undefined {
+    if (!pty || pty.connectionId || pathFlavor !== 'win32') {
+      return undefined
+    }
+    const worktreePath = splitWorktreeIdForFilesystem(pty.worktreeId)?.worktreePath
+    return worktreePath ? (parseWslUncPath(worktreePath)?.distro ?? undefined) : undefined
   }
 
   /** Returns true when any retained agent-row snapshot changed in a
@@ -7416,13 +7431,14 @@ export class OrcaRuntimeService {
     dims: { cols: number; rows: number }
   ): RuntimeHeadlessTerminal {
     let state: RuntimeHeadlessTerminal | null = null
-    const pathFlavor = this.pathFlavorForPty(this.ptysById.get(ptyId))
+    const pty = this.ptysById.get(ptyId)
+    const pathFlavor = this.pathFlavorForPty(pty)
     const emulator = new HeadlessEmulator({
       cols: dims.cols,
       rows: dims.rows,
       pathFlavor,
-      remotePosixFileUriAuthority:
-        !!this.ptysById.get(ptyId)?.connectionId && pathFlavor !== 'win32',
+      remotePosixFileUriAuthority: !!pty?.connectionId && pathFlavor !== 'win32',
+      wslDistro: this.wslDistroForPty(pty, pathFlavor),
       // Why: replies take the provider input path (same entry as pty:write —
       // daemon shell-ready gating and the SSH relay write apply unchanged),
       // NOT writePtyInput, so renderer interactive-output metering never


### PR DESCRIPTION
## Problem
Sleeping then waking a WSL-backed workspace on Windows fails to restore the terminal:

> DaemonProtocolError: Working directory "\\remoteseaview\home\yuming\project_ongoing\orca_remote" does not exist. It may have been deleted or is on an unmounted volume.

The directory exists inside WSL under the valid path `\\wsl.localhost\Ubuntu\home\yuming\project_ongoing\orca_remote`.

## Root cause
A WSL-backed local PTY reports its Linux shell hostname as the OSC-7 file URI authority (`file://remoteseaview/home/yuming/...`). The win32 branch of `parseFileUriPathParts` treats any non-`localhost` authority as a Windows UNC server, so the cwd is persisted as `\\remoteseaview\home\yuming\...`. On sleep/wake the daemon revalidates that cwd; it never resolves, and restoration fails. A WSL shell hostname is never a UNC server.

## Fix
Derive the session's WSL distro from the PTY's `\\wsl.localhost\<distro>\...` worktree path and rebuild the OSC-7 POSIX pathname as that distro's `\\wsl.localhost` UNC — a path Windows can stat, so wake restoration validates. The distro is threaded to both OSC-7 cwd consumers (the headless emulator snapshot and the runtime fallback map). Non-WSL and SSH PTYs derive no distro and are unaffected.

## Tests
- `osc7-file-uri.test.ts`: WSL authority now maps to `\\wsl.localhost\Ubuntu\...` (fails before the fix, producing the bogus `\\remoteseaview\...` share).
- `headless-emulator.test.ts`: end-to-end OSC-7 sequence through the emulator yields the distro UNC cwd.

Closes #8470

X: @mark86202384100
