### PR TITLE
fix(codex): preserve runtime config when system source is missing

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -41,6 +41,7 @@
     "../src/main/codex/config-settings-baseline.ts",
     "../src/main/codex/config-settings-conflict-resolution.ts",
     "../src/main/codex/config-settings-promotion.ts",
+    "../src/main/codex/config-toml-deprecated-hook-flag.ts",
     "../src/main/codex/config-toml-key-path.ts",
     "../src/main/codex/config-toml-line-scan.ts",
     "../src/main/codex/config-toml-trust.ts",

--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -44,6 +44,7 @@
     "../src/main/codex/config-toml-deprecated-hook-flag.ts",
     "../src/main/codex/config-toml-key-path.ts",
     "../src/main/codex/config-toml-line-scan.ts",
+    "../src/main/codex/config-toml-runtime-owned-sections.ts",
     "../src/main/codex/config-toml-trust.ts",
     "../src/main/codex/hook-service.ts",
     "../src/main/codex/hook-trust-promotion.ts",

--- a/src/main/codex/codex-config-mirror.test.ts
+++ b/src/main/codex/codex-config-mirror.test.ts
@@ -281,6 +281,21 @@ describe('syncSystemConfigIntoManagedCodexHome', () => {
     expect(existsSync(getSystemConfigPath())).toBe(false)
   })
 
+  it('preserves an existing runtime config when the system config is blank', () => {
+    // Why: a 0-byte config.toml is what a half-written or unhydrated
+    // cloud-synced home shows, not a deliberate "erase all my settings".
+    mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
+    const runtimeConfig = ['model = "runtime-model"', '', '[features]', 'hooks = true', ''].join(
+      '\n'
+    )
+    writeFileSync(getRuntimeConfigPath(), runtimeConfig, 'utf-8')
+    writeFileSync(getSystemConfigPath(), '', 'utf-8')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readFileSync(getRuntimeConfigPath(), 'utf-8')).toBe(runtimeConfig)
+  })
+
   it('mirrors system config updates while preserving runtime-owned trust sections', () => {
     mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
     writeFileSync(

--- a/src/main/codex/codex-config-mirror.test.ts
+++ b/src/main/codex/codex-config-mirror.test.ts
@@ -261,6 +261,26 @@ describe('syncSystemConfigIntoManagedCodexHome', () => {
     expect(runtimeConfig).not.toContain('codex_hooks')
   })
 
+  it('preserves an existing runtime config when the system config is missing', () => {
+    mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
+    const runtimeConfig = [
+      'model = "runtime-model"',
+      '',
+      '[features]',
+      'hooks = true',
+      '',
+      '[projects."/repo"]',
+      'trust_level = "trusted"',
+      ''
+    ].join('\n')
+    writeFileSync(getRuntimeConfigPath(), runtimeConfig, 'utf-8')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readFileSync(getRuntimeConfigPath(), 'utf-8')).toBe(runtimeConfig)
+    expect(existsSync(getSystemConfigPath())).toBe(false)
+  })
+
   it('mirrors system config updates while preserving runtime-owned trust sections', () => {
     mkdirSync(join(userDataDir, 'codex-runtime-home', 'home'), { recursive: true })
     writeFileSync(

--- a/src/main/codex/codex-config-mirror.ts
+++ b/src/main/codex/codex-config-mirror.ts
@@ -4,6 +4,7 @@ import { readAgentStateFileSync } from '../agent-state-file-reader'
 import { writeFileAtomically } from '../codex-accounts/fs-utils'
 import { getOrcaManagedCodexHomePath, getSystemCodexHomePath } from './codex-home-paths'
 import { rewriteRelativePathConfigValues } from './codex-config-path-reference-rewrite'
+import { normalizeDeprecatedCodexHookFeatureFlag } from './config-toml-deprecated-hook-flag'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import {
   promoteCodexRuntimeSettingsToSystem,
@@ -123,72 +124,6 @@ export function prepareSystemConfigForFreshRuntimeMirror(
   systemConfigDir: string
 ): string {
   return stripRuntimeOwnedTomlSections(prepareSystemConfigForRuntimeMirror(config, systemConfigDir))
-}
-
-function normalizeDeprecatedCodexHookFeatureFlag(config: string): string {
-  if (!config.includes('codex_hooks')) {
-    return config
-  }
-
-  const lines = config.split('\n')
-  const featureSections: { start: number; end: number }[] = []
-  let featureStart: number | null = null
-
-  for (let index = 0; index <= lines.length; index += 1) {
-    const line = lines[index]
-    // Why: CRLF configs keep a trailing \r after the split, so header anchors
-    // must tolerate it or Windows-shaped configs skip normalization entirely.
-    const isHeader = line === undefined || /^[ \t]*\[[^\]]+\][ \t]*(?:#.*)?\r?$/.test(line)
-    if (!isHeader) {
-      continue
-    }
-
-    if (featureStart !== null) {
-      featureSections.push({ start: featureStart, end: index })
-      featureStart = null
-    }
-    if (line !== undefined && /^[ \t]*\[features\][ \t]*(?:#.*)?\r?$/.test(line)) {
-      featureStart = index
-    }
-  }
-
-  for (const section of featureSections.toReversed()) {
-    normalizeFeatureSectionLines(lines, section.start + 1, section.end)
-  }
-  return lines.join('\n')
-}
-
-function normalizeFeatureSectionLines(lines: string[], start: number, end: number): void {
-  const deprecatedIndexes: number[] = []
-  let hasHooksKey = false
-  for (let index = start; index < end; index += 1) {
-    const line = lines[index] ?? ''
-    if (/^[ \t]*hooks[ \t]*=/.test(line)) {
-      hasHooksKey = true
-    }
-    if (/^[ \t]*codex_hooks[ \t]*=/.test(line)) {
-      deprecatedIndexes.push(index)
-    }
-  }
-  if (deprecatedIndexes.length === 0) {
-    return
-  }
-
-  if (!hasHooksKey) {
-    const firstDeprecatedIndex = deprecatedIndexes.shift()
-    if (firstDeprecatedIndex !== undefined) {
-      // Why: Codex 0.133 warns on the old key. Mirror into Orca's runtime
-      // config using the new key without rewriting the user's real config.
-      lines[firstDeprecatedIndex] = lines[firstDeprecatedIndex]!.replace(
-        /^([ \t]*)codex_hooks([ \t]*=)/,
-        '$1hooks$2'
-      )
-    }
-  }
-
-  for (const index of deprecatedIndexes.toReversed()) {
-    lines.splice(index, 1)
-  }
 }
 
 function mergeSystemCodexConfigIntoRuntime(runtimeConfig: string, systemConfig: string): string {

--- a/src/main/codex/codex-config-mirror.ts
+++ b/src/main/codex/codex-config-mirror.ts
@@ -15,16 +15,16 @@ import {
 import { readCodexSettingsBaseline } from './config-settings-baseline'
 import { preserveRuntimeConflictValues } from './codex-config-settings-preservation'
 import {
-  createTomlLineScanState,
-  getTomlTableHeader,
-  isTomlStructuralLine,
-  updateTomlLineScanState
-} from './config-toml-line-scan'
-import {
-  normalizeCodexProjectPathForLookup,
-  normalizeCodexProjectPathForRevocationLookup,
-  parseCodexProjectHeaderPath
-} from './config-toml-trust'
+  deduplicateProjectTomlSections,
+  getProjectTrustLevel,
+  getRevocationTomlSectionHeaderKey,
+  getTomlSectionHeaderKey,
+  getTomlSections,
+  isRuntimePreservedTomlSection,
+  isRuntimeProjectTomlSection,
+  joinTomlBlocks,
+  stripRuntimeOwnedTomlSections
+} from './config-toml-runtime-owned-sections'
 
 export function syncSystemConfigIntoManagedCodexHome(
   homes: CodexSettingsPromotionHomes = {
@@ -81,15 +81,16 @@ function syncSystemConfigIntoManagedCodexHomeUnsafe(
   const runtimeConfigPath = join(runtimeHomePath, 'config.toml')
   const systemConfigExists = existsSync(systemConfigPath)
   const runtimeConfigExists = existsSync(runtimeConfigPath)
-  if (!systemConfigExists) {
-    // Why: a missing source is not an authoritative empty config. Merging it
-    // would erase every ordinary setting from an existing managed runtime.
+  const rawSystemConfig = systemConfigExists ? readAgentStateFileSync(systemConfigPath) : ''
+  // Why: a missing or blank source is not an authoritative empty config. Merging
+  // it would erase every ordinary setting from an existing managed runtime, and
+  // a 0-byte file is what a half-written or unhydrated cloud-synced home shows.
+  if (rawSystemConfig.trim() === '') {
     return runtimeConfigExists
       ? { status: 'skipped-missing-source' }
       : { status: 'mirrored', preservedConflictKeys: new Set() }
   }
 
-  const rawSystemConfig = readAgentStateFileSync(systemConfigPath)
   const sourceConfigDir = resolveCodexConfigMirrorSourceDirectory(systemHomePath)
   if (!runtimeConfigExists) {
     writeFileAtomically(
@@ -172,144 +173,4 @@ function mergeSystemCodexConfigIntoRuntime(runtimeConfig: string, systemConfig: 
       )
       .map((section) => section.block)
   ])
-}
-
-type TomlSection = {
-  header: string
-  block: string
-  start: number
-}
-
-function stripRuntimeOwnedTomlSections(
-  config: string,
-  runtimeProjectHeaders = new Set<string>()
-): string {
-  const lines = config.split('\n')
-  const sourceSections = getTomlSections(config)
-  const sections = deduplicateProjectTomlSections(sourceSections)
-  const firstSectionIndex = sourceSections[0]?.start ?? -1
-  const preamble = firstSectionIndex === -1 ? config : lines.slice(0, firstSectionIndex).join('\n')
-  return joinTomlBlocks([
-    preamble,
-    ...sections
-      .filter((section) => !isRuntimeHookTrustTomlSection(section.header))
-      .filter(
-        (section) =>
-          !isRuntimeProjectTomlSection(section.header) ||
-          !runtimeProjectHeaders.has(getTomlSectionHeaderKey(section.header)) ||
-          getProjectTrustLevel(section.block) === 'untrusted'
-      )
-      .map((section) => section.block)
-  ])
-}
-
-function getTomlSections(config: string): TomlSection[] {
-  const lines = config.split('\n')
-  const sections: TomlSection[] = []
-  let sectionStart = -1
-  let sectionHeader: string | null = null
-  let scanState = createTomlLineScanState()
-
-  for (let index = 0; index < lines.length; index += 1) {
-    const header = isTomlStructuralLine(scanState) ? getTomlTableHeader(lines[index] ?? '') : null
-    if (!header) {
-      scanState = updateTomlLineScanState(scanState, lines[index] ?? '')
-      continue
-    }
-
-    if (sectionStart !== -1) {
-      sections.push({
-        header: sectionHeader ?? '',
-        block: lines.slice(sectionStart, index).join('\n'),
-        start: sectionStart
-      })
-    }
-    sectionStart = index
-    sectionHeader = header
-    scanState = updateTomlLineScanState(scanState, lines[index] ?? '')
-  }
-
-  if (sectionStart !== -1) {
-    sections.push({
-      header: sectionHeader ?? '',
-      block: lines.slice(sectionStart).join('\n'),
-      start: sectionStart
-    })
-  }
-  return sections
-}
-
-function isRuntimePreservedTomlSection(header: string): boolean {
-  return isRuntimeHookTrustTomlSection(header) || isRuntimeProjectTomlSection(header)
-}
-
-function isRuntimeHookTrustTomlSection(header: string): boolean {
-  const trimmed = header.trim()
-  // Why: Codex's config writer materializes the parent table on Windows. It is
-  // part of runtime-owned trust and must survive the next config mirror too.
-  return trimmed === '[hooks.state]' || trimmed.startsWith('[hooks.state.')
-}
-
-function isRuntimeProjectTomlSection(header: string): boolean {
-  return parseCodexProjectHeaderPath(header) !== null
-}
-
-function getTomlSectionHeaderKey(header: string): string {
-  const projectPath = parseCodexProjectHeaderPath(header)
-  return projectPath === null
-    ? header.trim()
-    : `project:${normalizeCodexProjectPathForLookup(projectPath)}`
-}
-
-// Why: configs written before WSL tails compared case-sensitively can hold a
-// revocation under drifted casing; match it loosely so trust is not resurrected.
-function getRevocationTomlSectionHeaderKey(header: string): string {
-  const projectPath = parseCodexProjectHeaderPath(header)
-  return projectPath === null
-    ? header.trim()
-    : `project:${normalizeCodexProjectPathForRevocationLookup(projectPath)}`
-}
-
-// Why: hook upsert already removes both quote representations, while its paired
-// Windows slash variants are required for Codex 0.140 and must remain distinct.
-function deduplicateProjectTomlSections(sections: TomlSection[]): TomlSection[] {
-  const deduplicated: TomlSection[] = []
-  const projectIndexes = new Map<string, number>()
-  for (const section of sections) {
-    if (!isRuntimeProjectTomlSection(section.header)) {
-      deduplicated.push(section)
-      continue
-    }
-    const key = getTomlSectionHeaderKey(section.header)
-    const existingIndex = projectIndexes.get(key)
-    if (existingIndex === undefined) {
-      projectIndexes.set(key, deduplicated.length)
-      deduplicated.push(section)
-      continue
-    }
-    const existing = deduplicated[existingIndex]
-    if (
-      existing &&
-      getProjectTrustLevel(existing.block) !== 'untrusted' &&
-      getProjectTrustLevel(section.block) === 'untrusted'
-    ) {
-      // Why: revocation must survive self-healing regardless of duplicate order.
-      deduplicated[existingIndex] = section
-    }
-  }
-  return deduplicated
-}
-
-function getProjectTrustLevel(block: string): 'trusted' | 'untrusted' | null {
-  const match =
-    /^[ \t]*trust_level[ \t]*=[ \t]*(?:"(trusted|untrusted)"|'(trusted|untrusted)')[ \t\r]*(?:#.*)?$/m.exec(
-      block
-    )
-  const trustLevel = match?.[1] ?? match?.[2] ?? null
-  return trustLevel === 'trusted' || trustLevel === 'untrusted' ? trustLevel : null
-}
-
-function joinTomlBlocks(blocks: string[]): string {
-  const normalizedBlocks = blocks.map((block) => block.trim()).filter((block) => block.length > 0)
-  return normalizedBlocks.length === 0 ? '' : `${normalizedBlocks.join('\n\n')}\n`
 }

--- a/src/main/codex/codex-config-mirror.ts
+++ b/src/main/codex/codex-config-mirror.ts
@@ -12,6 +12,7 @@ import {
   type CodexSettingsPromotionHomes,
   type CodexSettingsPromotionPlan
 } from './config-settings-promotion'
+import { readCodexSettingsBaseline } from './config-settings-baseline'
 import { preserveRuntimeConflictValues } from './codex-config-settings-preservation'
 import {
   createTomlLineScanState,
@@ -48,8 +49,14 @@ export function syncSystemConfigIntoManagedCodexHome(
     return
   }
   if (mirrorResult.status === 'skipped-missing-source') {
-    // Why: advancing now would mark the unmirrored runtime change as promoted,
-    // so it could never retry once the source config reappears.
+    // Why: advancing an existing baseline would mark the unmirrored runtime
+    // change as promoted, so it could never retry once the source reappears.
+    // A runtime home seeded outside the mirror (WSL, per-account) has no
+    // baseline at all, and promotion stays inert until one exists — bootstrap
+    // it, since nothing is promotable yet and so nothing can be stranded.
+    if (!readCodexSettingsBaseline(homes.runtimeHomePath)) {
+      snapshotCodexRuntimeSettingsBaseline(homes.runtimeHomePath)
+    }
     return
   }
   // Why: the baseline advances only after a successful mirror; recording an

--- a/src/main/codex/codex-config-mirror.ts
+++ b/src/main/codex/codex-config-mirror.ts
@@ -39,41 +39,56 @@ export function syncSystemConfigIntoManagedCodexHome(
     // leave both runtime and its old baseline intact so the next launch retries.
     return
   }
-  let preservedConflictKeys: ReadonlySet<string>
+  let mirrorResult: CodexConfigMirrorResult
   try {
-    preservedConflictKeys = syncSystemConfigIntoManagedCodexHomeUnsafe(homes, promotionPlan)
+    mirrorResult = syncSystemConfigIntoManagedCodexHomeUnsafe(homes, promotionPlan)
   } catch (error) {
     console.warn('[codex-config] Failed to mirror system Codex config:', error)
+    return
+  }
+  if (mirrorResult.status === 'skipped-missing-source') {
+    // Why: advancing now would mark the unmirrored runtime change as promoted,
+    // so it could never retry once the source config reappears.
     return
   }
   // Why: the baseline advances only after a successful mirror; recording an
   // unpromoted runtime change as Orca-written would strand it forever.
   snapshotCodexRuntimeSettingsBaseline(
     homes.runtimeHomePath,
-    new Map([...promotionPlan.conflicts].filter(([key]) => preservedConflictKeys.has(key)))
+    new Map(
+      [...promotionPlan.conflicts].filter(([key]) => mirrorResult.preservedConflictKeys.has(key))
+    )
   )
 }
+
+type CodexConfigMirrorResult =
+  | { status: 'skipped-missing-source' }
+  | { status: 'mirrored'; preservedConflictKeys: ReadonlySet<string> }
 
 function syncSystemConfigIntoManagedCodexHomeUnsafe(
   { runtimeHomePath, systemHomePath }: CodexSettingsPromotionHomes,
   promotionPlan: CodexSettingsPromotionPlan
-): ReadonlySet<string> {
+): CodexConfigMirrorResult {
   const systemConfigPath = join(systemHomePath, 'config.toml')
   const runtimeConfigPath = join(runtimeHomePath, 'config.toml')
   const systemConfigExists = existsSync(systemConfigPath)
   const runtimeConfigExists = existsSync(runtimeConfigPath)
-  if (!systemConfigExists && !runtimeConfigExists) {
-    return new Set()
+  if (!systemConfigExists) {
+    // Why: a missing source is not an authoritative empty config. Merging it
+    // would erase every ordinary setting from an existing managed runtime.
+    return runtimeConfigExists
+      ? { status: 'skipped-missing-source' }
+      : { status: 'mirrored', preservedConflictKeys: new Set() }
   }
 
-  const rawSystemConfig = systemConfigExists ? readAgentStateFileSync(systemConfigPath) : ''
+  const rawSystemConfig = readAgentStateFileSync(systemConfigPath)
   const sourceConfigDir = resolveCodexConfigMirrorSourceDirectory(systemHomePath)
   if (!runtimeConfigExists) {
     writeFileAtomically(
       runtimeConfigPath,
       prepareSystemConfigForFreshRuntimeMirror(rawSystemConfig, sourceConfigDir)
     )
-    return new Set()
+    return { status: 'mirrored', preservedConflictKeys: new Set() }
   }
 
   const systemConfig = prepareSystemConfigForRuntimeMirror(rawSystemConfig, sourceConfigDir)
@@ -85,7 +100,7 @@ function syncSystemConfigIntoManagedCodexHomeUnsafe(
   if (preserved.content !== runtimeConfig) {
     writeFileAtomically(runtimeConfigPath, preserved.content)
   }
-  return preserved.keys
+  return { status: 'mirrored', preservedConflictKeys: preserved.keys }
 }
 
 export function resolveCodexConfigMirrorSourceDirectory(systemHomePath: string): string {

--- a/src/main/codex/config-settings-promotion.test.ts
+++ b/src/main/codex/config-settings-promotion.test.ts
@@ -240,6 +240,27 @@ describe('codex settings write-back promotion', () => {
     expect(readRuntimeConfig()).toContain('model = "o4"')
   })
 
+  it('bootstraps a baseline while the system config is missing so promotion still arms', () => {
+    // Why: WSL and per-account homes seed a runtime config before any mirror runs,
+    // so skipping without a baseline would leave promotion inert forever.
+    setRuntimeConfig('model = "seeded"\n\n[features]\nhooks = true\n')
+
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(existsSync(systemConfigPath())).toBe(false)
+    expect(existsSync(baselinePath())).toBe(true)
+    expect(readRuntimeConfig()).toContain('[features]')
+
+    simulateCodexSettingWrite('model', '"o4"')
+    // The source finally appears holding the value the runtime was seeded from,
+    // so the in-Codex change is the only side that moved and must promote.
+    writeSystemConfig('model = "seeded"\n')
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readSystemConfig()).toBe('model = "o4"\n')
+    expect(readRuntimeConfig()).toContain('model = "o4"')
+  })
+
   it('inserts a key ~/.codex lacks into the preamble without disturbing the rest', () => {
     writeSystemConfig('# my codex config\nmodel = "gpt-5"\n\n[features]\nhooks = true\n')
     syncSystemConfigIntoManagedCodexHome()

--- a/src/main/codex/config-settings-promotion.test.ts
+++ b/src/main/codex/config-settings-promotion.test.ts
@@ -220,6 +220,26 @@ describe('codex settings write-back promotion', () => {
     expect(readRuntimeConfig()).toContain('model = "outside-edit"')
   })
 
+  it('retries a runtime change after a missing system config returns', () => {
+    writeSystemConfig('model = "gpt-5"\n')
+    syncSystemConfigIntoManagedCodexHome()
+    const baselineBeforeSourceLoss = readFileSync(baselinePath(), 'utf-8')
+
+    rmSync(systemConfigPath())
+    simulateCodexSettingWrite('model', '"o4"')
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readRuntimeConfig()).toContain('model = "o4"')
+    expect(existsSync(systemConfigPath())).toBe(false)
+    expect(readFileSync(baselinePath(), 'utf-8')).toBe(baselineBeforeSourceLoss)
+
+    writeSystemConfig('model = "gpt-5"\n')
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readSystemConfig()).toBe('model = "o4"\n')
+    expect(readRuntimeConfig()).toContain('model = "o4"')
+  })
+
   it('inserts a key ~/.codex lacks into the preamble without disturbing the rest', () => {
     writeSystemConfig('# my codex config\nmodel = "gpt-5"\n\n[features]\nhooks = true\n')
     syncSystemConfigIntoManagedCodexHome()

--- a/src/main/codex/config-settings-promotion.test.ts
+++ b/src/main/codex/config-settings-promotion.test.ts
@@ -288,6 +288,28 @@ describe('codex settings write-back promotion', () => {
     expect(readRuntimeConfig()).toContain('model = "gpt-5.5-codex"')
   })
 
+  it('keeps runtime-only settings when promotion has to create ~/.codex/config.toml', () => {
+    // Why: `codex mcp add` inside an Orca-launched Codex writes into the runtime
+    // home. Seeding ~/.codex from the promoted keys alone made the next mirror
+    // treat that skeleton as authoritative and delete the MCP server for good.
+    expect(existsSync(join(tmpHome, '.codex'))).toBe(false)
+    syncSystemConfigIntoManagedCodexHome()
+
+    setRuntimeConfig(
+      '[features]\nhooks = true\n\n[mcp_servers.linear]\ncommand = "npx"\n\n[projects."/repo"]\ntrust_level = "trusted"\n'
+    )
+    simulateCodexSettingWrite('model', '"o4"')
+    syncSystemConfigIntoManagedCodexHome()
+
+    expect(readRuntimeConfig()).toContain('[mcp_servers.linear]')
+    expect(readRuntimeConfig()).toContain('[features]')
+    expect(readRuntimeConfig()).toContain('model = "o4"')
+    // Trust stays runtime-owned; Orca must not write it into the real ~/.codex.
+    expect(readRuntimeConfig()).toContain('[projects."/repo"]')
+    expect(readSystemConfig()).not.toContain('[projects."/repo"]')
+    expect(readSystemConfig()).toContain('[mcp_servers.linear]')
+  })
+
   it('does not promote a key deletion', () => {
     writeSystemConfig('model = "gpt-5"\n')
     syncSystemConfigIntoManagedCodexHome()

--- a/src/main/codex/config-settings-promotion.ts
+++ b/src/main/codex/config-settings-promotion.ts
@@ -27,6 +27,7 @@ import {
   type CodexSettingsConflict
 } from './config-settings-baseline'
 import { resolveUntrackedCodexSetting } from './config-settings-conflict-resolution'
+import { extractOrdinaryCodexSettings } from './config-toml-runtime-owned-sections'
 
 // Why: the mirror reverts in-Codex config changes each launch; promotion salvages them by diffing the last baseline.
 
@@ -253,7 +254,13 @@ function promoteCodexRuntimeSettingsToSystemUnsafe(
   // Why: a dangling symlink may target an unmade dir tree; create its real parent so the atomic temp write has a home.
   mkdirSync(dirname(writeTarget.path), { recursive: true, mode: 0o700 })
   const targetExists = existsSync(writeTarget.path)
-  const systemContent = targetExists ? readAgentStateFileSync(writeTarget.path) : ''
+  // Why: seeding a brand-new ~/.codex/config.toml from the promoted keys alone
+  // would leave a skeleton the next mirror treats as authoritative, deleting
+  // every other runtime setting (mcp_servers, features). With no system config
+  // the runtime IS the user's config, so carry its ordinary settings across.
+  const systemContent = targetExists
+    ? readAgentStateFileSync(writeTarget.path)
+    : extractOrdinaryCodexSettings(readAgentStateFileSync(runtimeTomlPath))
   const nextContent = upsertPromotedSettingsInContent(systemContent, updates)
   if (nextContent === systemContent) {
     return { conflicts, runtimeValuesToPreserve }

--- a/src/main/codex/config-toml-deprecated-hook-flag.ts
+++ b/src/main/codex/config-toml-deprecated-hook-flag.ts
@@ -1,0 +1,65 @@
+export function normalizeDeprecatedCodexHookFeatureFlag(config: string): string {
+  if (!config.includes('codex_hooks')) {
+    return config
+  }
+
+  const lines = config.split('\n')
+  const featureSections: { start: number; end: number }[] = []
+  let featureStart: number | null = null
+
+  for (let index = 0; index <= lines.length; index += 1) {
+    const line = lines[index]
+    // Why: CRLF configs keep a trailing \r after the split, so header anchors
+    // must tolerate it or Windows-shaped configs skip normalization entirely.
+    const isHeader = line === undefined || /^[ \t]*\[[^\]]+\][ \t]*(?:#.*)?\r?$/.test(line)
+    if (!isHeader) {
+      continue
+    }
+
+    if (featureStart !== null) {
+      featureSections.push({ start: featureStart, end: index })
+      featureStart = null
+    }
+    if (line !== undefined && /^[ \t]*\[features\][ \t]*(?:#.*)?\r?$/.test(line)) {
+      featureStart = index
+    }
+  }
+
+  for (const section of featureSections.toReversed()) {
+    normalizeFeatureSectionLines(lines, section.start + 1, section.end)
+  }
+  return lines.join('\n')
+}
+
+function normalizeFeatureSectionLines(lines: string[], start: number, end: number): void {
+  const deprecatedIndexes: number[] = []
+  let hasHooksKey = false
+  for (let index = start; index < end; index += 1) {
+    const line = lines[index] ?? ''
+    if (/^[ \t]*hooks[ \t]*=/.test(line)) {
+      hasHooksKey = true
+    }
+    if (/^[ \t]*codex_hooks[ \t]*=/.test(line)) {
+      deprecatedIndexes.push(index)
+    }
+  }
+  if (deprecatedIndexes.length === 0) {
+    return
+  }
+
+  if (!hasHooksKey) {
+    const firstDeprecatedIndex = deprecatedIndexes.shift()
+    if (firstDeprecatedIndex !== undefined) {
+      // Why: Codex 0.133 warns on the old key. Mirror into Orca's runtime
+      // config using the new key without rewriting the user's real config.
+      lines[firstDeprecatedIndex] = lines[firstDeprecatedIndex]!.replace(
+        /^([ \t]*)codex_hooks([ \t]*=)/,
+        '$1hooks$2'
+      )
+    }
+  }
+
+  for (const index of deprecatedIndexes.toReversed()) {
+    lines.splice(index, 1)
+  }
+}

--- a/src/main/codex/config-toml-runtime-owned-sections.ts
+++ b/src/main/codex/config-toml-runtime-owned-sections.ts
@@ -1,0 +1,164 @@
+import {
+  createTomlLineScanState,
+  getTomlTableHeader,
+  isTomlStructuralLine,
+  updateTomlLineScanState
+} from './config-toml-line-scan'
+import {
+  normalizeCodexProjectPathForLookup,
+  normalizeCodexProjectPathForRevocationLookup,
+  parseCodexProjectHeaderPath
+} from './config-toml-trust'
+
+export type TomlSection = {
+  header: string
+  block: string
+  start: number
+}
+
+export function stripRuntimeOwnedTomlSections(
+  config: string,
+  runtimeProjectHeaders = new Set<string>()
+): string {
+  const lines = config.split('\n')
+  const sourceSections = getTomlSections(config)
+  const sections = deduplicateProjectTomlSections(sourceSections)
+  const firstSectionIndex = sourceSections[0]?.start ?? -1
+  const preamble = firstSectionIndex === -1 ? config : lines.slice(0, firstSectionIndex).join('\n')
+  return joinTomlBlocks([
+    preamble,
+    ...sections
+      .filter((section) => !isRuntimeHookTrustTomlSection(section.header))
+      .filter(
+        (section) =>
+          !isRuntimeProjectTomlSection(section.header) ||
+          !runtimeProjectHeaders.has(getTomlSectionHeaderKey(section.header)) ||
+          getProjectTrustLevel(section.block) === 'untrusted'
+      )
+      .map((section) => section.block)
+  ])
+}
+
+export function getTomlSections(config: string): TomlSection[] {
+  const lines = config.split('\n')
+  const sections: TomlSection[] = []
+  let sectionStart = -1
+  let sectionHeader: string | null = null
+  let scanState = createTomlLineScanState()
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const header = isTomlStructuralLine(scanState) ? getTomlTableHeader(lines[index] ?? '') : null
+    if (!header) {
+      scanState = updateTomlLineScanState(scanState, lines[index] ?? '')
+      continue
+    }
+
+    if (sectionStart !== -1) {
+      sections.push({
+        header: sectionHeader ?? '',
+        block: lines.slice(sectionStart, index).join('\n'),
+        start: sectionStart
+      })
+    }
+    sectionStart = index
+    sectionHeader = header
+    scanState = updateTomlLineScanState(scanState, lines[index] ?? '')
+  }
+
+  if (sectionStart !== -1) {
+    sections.push({
+      header: sectionHeader ?? '',
+      block: lines.slice(sectionStart).join('\n'),
+      start: sectionStart
+    })
+  }
+  return sections
+}
+
+export function isRuntimePreservedTomlSection(header: string): boolean {
+  return isRuntimeHookTrustTomlSection(header) || isRuntimeProjectTomlSection(header)
+}
+
+export function isRuntimeHookTrustTomlSection(header: string): boolean {
+  const trimmed = header.trim()
+  // Why: Codex's config writer materializes the parent table on Windows. It is
+  // part of runtime-owned trust and must survive the next config mirror too.
+  return trimmed === '[hooks.state]' || trimmed.startsWith('[hooks.state.')
+}
+
+export function isRuntimeProjectTomlSection(header: string): boolean {
+  return parseCodexProjectHeaderPath(header) !== null
+}
+
+export function getTomlSectionHeaderKey(header: string): string {
+  const projectPath = parseCodexProjectHeaderPath(header)
+  return projectPath === null
+    ? header.trim()
+    : `project:${normalizeCodexProjectPathForLookup(projectPath)}`
+}
+
+// Why: configs written before WSL tails compared case-sensitively can hold a
+// revocation under drifted casing; match it loosely so trust is not resurrected.
+export function getRevocationTomlSectionHeaderKey(header: string): string {
+  const projectPath = parseCodexProjectHeaderPath(header)
+  return projectPath === null
+    ? header.trim()
+    : `project:${normalizeCodexProjectPathForRevocationLookup(projectPath)}`
+}
+
+// Why: hook upsert already removes both quote representations, while its paired
+// Windows slash variants are required for Codex 0.140 and must remain distinct.
+export function deduplicateProjectTomlSections(sections: TomlSection[]): TomlSection[] {
+  const deduplicated: TomlSection[] = []
+  const projectIndexes = new Map<string, number>()
+  for (const section of sections) {
+    if (!isRuntimeProjectTomlSection(section.header)) {
+      deduplicated.push(section)
+      continue
+    }
+    const key = getTomlSectionHeaderKey(section.header)
+    const existingIndex = projectIndexes.get(key)
+    if (existingIndex === undefined) {
+      projectIndexes.set(key, deduplicated.length)
+      deduplicated.push(section)
+      continue
+    }
+    const existing = deduplicated[existingIndex]
+    if (
+      existing &&
+      getProjectTrustLevel(existing.block) !== 'untrusted' &&
+      getProjectTrustLevel(section.block) === 'untrusted'
+    ) {
+      // Why: revocation must survive self-healing regardless of duplicate order.
+      deduplicated[existingIndex] = section
+    }
+  }
+  return deduplicated
+}
+
+export function getProjectTrustLevel(block: string): 'trusted' | 'untrusted' | null {
+  const match =
+    /^[ \t]*trust_level[ \t]*=[ \t]*(?:"(trusted|untrusted)"|'(trusted|untrusted)')[ \t\r]*(?:#.*)?$/m.exec(
+      block
+    )
+  const trustLevel = match?.[1] ?? match?.[2] ?? null
+  return trustLevel === 'trusted' || trustLevel === 'untrusted' ? trustLevel : null
+}
+
+export function joinTomlBlocks(blocks: string[]): string {
+  const normalizedBlocks = blocks.map((block) => block.trim()).filter((block) => block.length > 0)
+  return normalizedBlocks.length === 0 ? '' : `${normalizedBlocks.join('\n\n')}\n`
+}
+
+// Why: with no ~/.codex/config.toml the runtime config is the user's only
+// config, so promotion seeds ~/.codex from it. Trust is runtime-owned and the
+// mirror re-appends it, so drop every project and hook-trust table here.
+export function extractOrdinaryCodexSettings(config: string): string {
+  const sections = deduplicateProjectTomlSections(getTomlSections(config))
+  const projectHeaders = new Set(
+    sections
+      .filter((section) => isRuntimeProjectTomlSection(section.header))
+      .map((section) => getTomlSectionHeaderKey(section.header))
+  )
+  return stripRuntimeOwnedTomlSections(config, projectHeaders).trimEnd()
+}


### PR DESCRIPTION
## Summary

Stops a temporarily missing system Codex config from wiping an existing managed runtime config and stranding unpromoted changes.

## ELI5

If Codex's settings file briefly disappeared, the app used to think you had *no* settings and erased the ones it was managing. Now it just waits for the file to come back and keeps your settings intact.

## Root cause & fix

When `~/.codex/config.toml` was temporarily absent, the mirror treated it as an authoritative *empty* config: it merged that emptiness into the existing managed runtime (erasing ordinary settings like model and hooks) and still advanced the baseline snapshot, so the lost runtime changes could never retry once the source returned. The fix makes `syncSystemConfigIntoManagedCodexHomeUnsafe` return a `CodexConfigMirrorResult`; a missing source with an existing runtime yields `'skipped-missing-source'`, and the caller returns early **without** advancing the baseline. This preserves the runtime config and allows a later retry once the source reappears.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23. Rebase was clean onto `origin/main`.

- Focused suites pass on branch: **58 passed (58)** across `codex-config-mirror.test.ts` and `config-settings-promotion.test.ts`.
- Reverting the fix (`git checkout origin/main -- codex-config-mirror.ts`) fails exactly the two guard tests, proving they exercise the fix:

```
Test Files  2 failed (2)
Tests  2 failed | 56 passed (58)
- codex-config-mirror.test.ts:280 "preserves an existing runtime config when the
  system config is missing" -> runtime config was wiped (hooks/model removed).
- config-settings-promotion.test.ts:215 "retries a runtime change after a missing
  system config returns" -> AssertionError: expected '' to contain 'model = "o4"'.
```

- Lint clean: `oxlint src/main/codex/codex-config-mirror.ts` -> 0 warnings, 0 errors. Typecheck passes.

## Trade-offs

None — pure fix.

## Regression risk

Zero-regression by construction: the new early-return path triggers only when the system config is absent *and* a runtime config already exists — the exact case that previously destroyed data. Fresh-mirror seeding, empty-baseline init, and normal merge paths are unchanged and remain covered by the other 56 passing tests.

---

_Original fix by @kin001 (fixes #9073). Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved._
