### PR TITLE
fix: enumerate IPv6 addresses for mobile pairing on IPv6-only hosts (#9130)

### DIFF
--- a/src/main/ipc/mobile.test.ts
+++ b/src/main/ipc/mobile.test.ts
@@ -59,6 +59,41 @@ describe('registerMobileHandlers', () => {
     })
   })
 
+  it('includes IPv6 addresses (ranked after IPv4) and excludes link-local IPv6', () => {
+    networkInterfacesMock.mockReturnValue({
+      en0: [
+        { family: 'IPv4', internal: false, address: '192.168.1.24' },
+        { family: 'IPv6', internal: false, address: 'fe80::1' },
+        { family: 'IPv6', internal: false, address: '2605:340:cd51:2a01:0:2b13:f279:c096' }
+      ],
+      lo0: [{ family: 'IPv6', internal: true, address: '::1' }]
+    })
+
+    registerMobileHandlers({} as never)
+
+    expect(handlers.get('mobile:listNetworkInterfaces')?.()).toEqual({
+      interfaces: [
+        { name: 'en0', address: '192.168.1.24' },
+        { name: 'en0', address: '2605:340:cd51:2a01:0:2b13:f279:c096' }
+      ]
+    })
+  })
+
+  it('returns an IPv6 interface on an IPv6-only host (regression: was empty, breaking mobile pairing)', () => {
+    networkInterfacesMock.mockReturnValue({
+      eth0: [
+        { family: 'IPv6', internal: false, address: '2605:340:cd51:2a01:0:2b13:f279:c096' },
+        { family: 'IPv6', internal: false, address: 'fe80::42:acff:fe11:2' }
+      ]
+    })
+
+    registerMobileHandlers({} as never)
+
+    expect(handlers.get('mobile:listNetworkInterfaces')?.()).toEqual({
+      interfaces: [{ name: 'eth0', address: '2605:340:cd51:2a01:0:2b13:f279:c096' }]
+    })
+  })
+
   it('generates mobile pairing urls with the tailnet address by default', async () => {
     networkInterfacesMock.mockReturnValue({
       en0: [{ family: 'IPv4', internal: false, address: '192.168.1.24' }],

--- a/src/main/ipc/mobile.ts
+++ b/src/main/ipc/mobile.ts
@@ -19,10 +19,19 @@ export type NetworkInterface = {
   address: string
 }
 
+// Why: link-local IPv6 addresses (fe80::/10) require a scope/zone id to be
+// connectable and never work as a QR-advertised pairing host, so they are
+// excluded from the pickable list.
+function isUsableIPv6Address(address: string): boolean {
+  return !/^fe80:/i.test(address)
+}
+
 // Why: the WebSocket transport advertises 0.0.0.0 as its endpoint, which isn't
-// connectable from a mobile device. We enumerate all non-internal IPv4
-// addresses so the user can choose which one to advertise in the QR code
-// (e.g. LAN vs Tailscale).
+// connectable from a mobile device. We enumerate all non-internal IPv4 and
+// (non-link-local) IPv6 addresses so the user can choose which one to advertise
+// in the QR code (e.g. LAN vs Tailscale). IPv6 must be included so pairing works
+// on IPv6-only hosts (e.g. a headless `orca serve` reachable only over IPv6),
+// where an IPv4-only scan returns nothing and the UI reports "no interfaces".
 function getNetworkInterfaces(): NetworkInterface[] {
   const result: NetworkInterface[] = []
   const interfaces = networkInterfaces()
@@ -31,14 +40,26 @@ function getNetworkInterfaces(): NetworkInterface[] {
       continue
     }
     for (const addr of addrs) {
-      if (addr.family === 'IPv4' && !addr.internal) {
+      if (addr.internal) {
+        continue
+      }
+      if (addr.family === 'IPv4') {
+        result.push({ name, address: addr.address })
+      } else if (addr.family === 'IPv6' && isUsableIPv6Address(addr.address)) {
         result.push({ name, address: addr.address })
       }
     }
   }
-  return result.sort(
-    (a, b) => Number(isTailnetIPv4Address(b.address)) - Number(isTailnetIPv4Address(a.address))
-  )
+  // Why: prefer tailnet IPv4 first (most portable across networks), then other
+  // IPv4, then IPv6 as a fallback for IPv6-only environments.
+  return result.sort((a, b) => rankAddress(a.address) - rankAddress(b.address))
+}
+
+function rankAddress(address: string): number {
+  if (isTailnetIPv4Address(address)) {
+    return 0
+  }
+  return address.includes(':') ? 2 : 1
 }
 
 function getDefaultPairingAddress(): string | null {

--- a/src/main/ipc/mobile.ts
+++ b/src/main/ipc/mobile.ts
@@ -21,9 +21,10 @@ export type NetworkInterface = {
 
 // Why: link-local IPv6 addresses (fe80::/10) require a scope/zone id to be
 // connectable and never work as a QR-advertised pairing host, so they are
-// excluded from the pickable list.
+// excluded from the pickable list. The regex covers the full /10 range
+// (fe80: through febf:), not just the fe80: prefix the OS usually assigns.
 function isUsableIPv6Address(address: string): boolean {
-  return !/^fe80:/i.test(address)
+  return !/^fe[89ab][0-9a-f]:/i.test(address)
 }
 
 // Why: the WebSocket transport advertises 0.0.0.0 as its endpoint, which isn't


### PR DESCRIPTION
## Summary

Fixes mobile pairing being impossible on IPv6-only hosts, where Settings → Mobile showed no selectable network interface and reported the transport as unavailable.

## ELI5

If your computer could only be reached over the newer IPv6 kind of address, the app couldn't find any way to connect your phone. Now it looks for IPv6 addresses too, so pairing works.

## Root cause & fix

`getNetworkInterfaces()` in `src/main/ipc/mobile.ts` only enumerated non-internal IPv4 addresses. On IPv6-only hosts (e.g. a headless `orca serve` reachable only over IPv6) the scan returned an empty list, making `getDefaultPairingAddress()` null so QR generation reported the transport as not running. The fix includes non-internal IPv6 addresses — excluding link-local `fe80::/10` (which need a zone id and can't be advertised in a QR) via `isUsableIPv6Address()` — and preserves preference order in `rankAddress()`: tailnet IPv4 (0) < other IPv4 (1) < IPv6 (2).

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- Suite `src/main/ipc/mobile.test.ts` (via `npx vitest run --config config/vitest.config.ts`): all 14 tests pass on branch.
- Reverting only the fix (`git checkout origin/main -- src/main/ipc/mobile.ts`) while keeping the tests fails 2 of 14, proving the tests capture the bug:

```
On branch:        Test Files 1 passed (1); Tests 14 passed (14)
Fix reverted:     Test Files 1 failed (1); Tests 2 failed | 12 passed (14)
  ✗ returns an IPv6 interface on an IPv6-only host
      expected interfaces:[{eth0, 2605:...}] but got interfaces:[]
  ✗ includes IPv6 addresses (ranked after IPv4) and excludes link-local IPv6
```

- Lint clean: `npx oxlint src/main/ipc/mobile.ts` reports no diagnostics.

## Trade-offs

None — pure fix.

## Regression risk

Zero-regression: IPv6 is only added as the lowest-priority fallback, so default pairing behavior on IPv4/tailnet hosts is unchanged. The link-local exclusion regex correctly covers `fe80:`–`febf:`, and all 12 pre-existing IPv4/tailnet tests still pass.

_Credit to @PannenetsF for the original fix. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved._
