### PR TITLE
fix(agents): preserve OpenCode identity for bare status titles

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -178,6 +178,49 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(rows).toHaveLength(0)
   })
 
+  it('keeps a single-pane OpenCode launch stable across native, synthetic, bare, and idle titles', () => {
+    const frames = [
+      ['OC | ⠋ implementing the feature', 'working'],
+      ['⠋ OpenCode', 'working'],
+      ['⠋ implementing the feature', 'working'],
+      ['OpenCode ready', 'idle']
+    ] as const
+
+    for (const [title, state] of frames) {
+      const rows = buildWorktreeAgentRows({
+        tabs: [makeTab('tab-1', { launchAgent: 'opencode' })],
+        entries: [],
+        retained: [],
+        runtimePaneTitlesByTabId: { 'tab-1': { 1: title } },
+        ptyIdsByTabId: { 'tab-1': ['pty-opencode'] },
+        terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+        now: 2000
+      })
+
+      expect(rows.map((row) => [row.agentType, row.state])).toEqual([['opencode', state]])
+    }
+  })
+
+  it('stops applying launch ownership after it is cleared, without weakening Claude inference', () => {
+    const rowsFor = (title: string, launchAgent?: TuiAgent) =>
+      buildWorktreeAgentRows({
+        tabs: [makeTab('tab-1', launchAgent ? { launchAgent } : {})],
+        entries: [],
+        retained: [],
+        runtimePaneTitlesByTabId: { 'tab-1': { 1: title } },
+        ptyIdsByTabId: { 'tab-1': ['pty-agent'] },
+        terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+        now: 2000
+      })
+
+    expect(rowsFor('⠋ implementing the feature', 'opencode').map((row) => row.agentType)).toEqual([
+      'opencode'
+    ])
+    expect(rowsFor('⠋ implementing the feature')).toHaveLength(0)
+    expect(rowsFor('⠋ Claude Code').map((row) => row.agentType)).toEqual(['claude'])
+    expect(rowsFor('zsh')).toHaveLength(0)
+  })
+
   it('adds an idle Claude row for the Claude agents surface', () => {
     for (const title of [
       'claude agents',

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -3,6 +3,7 @@ import { applyAgentRowLineage } from '@/components/dashboard/agent-row-lineage'
 import type { TerminalLayoutSnapshot, TerminalTab, TuiAgent } from '../../../../shared/types'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { buildWorktreeAgentRows } from './worktree-agent-rows'
+import { resolveAgentTypeFromTerminalTitle } from './worktree-title-derived-agent-rows'
 
 const LEAF_ID_1 = '77777777-7777-4777-8777-777777777777'
 const LEAF_ID_2 = '88888888-8888-4888-8888-888888888888'
@@ -219,6 +220,14 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(rowsFor('⠋ implementing the feature')).toHaveLength(0)
     expect(rowsFor('⠋ Claude Code').map((row) => row.agentType)).toEqual(['claude'])
     expect(rowsFor('zsh')).toHaveLength(0)
+  })
+
+  it('uses explicit owner evidence when resolving provider-neutral activity titles', () => {
+    expect(resolveAgentTypeFromTerminalTitle('⠋ implementing the feature', 'opencode')).toBe(
+      'opencode'
+    )
+    expect(resolveAgentTypeFromTerminalTitle('⠋ implementing the feature')).toBeNull()
+    expect(resolveAgentTypeFromTerminalTitle('⠋ Claude Code', 'opencode')).toBe('claude')
   })
 
   it('adds an idle Claude row for the Claude agents surface', () => {

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -18,6 +18,7 @@ import {
   normalizeCompatibleAgentTitleForOwner,
   resolveCompatibleAgentTypeForOwner
 } from '../../../../shared/agent-title-owner'
+import { resolvePaneAgentOwner } from '../../../../shared/pane-agent-owner'
 
 const EMPTY_RUNTIME_TITLES: Record<string, Record<number, string>> = {}
 const EMPTY_LIVE_PTY_IDS: Record<string, string[]> = {}
@@ -83,6 +84,7 @@ export function buildTitleDerivedAgentRows(args: {
           tab,
           leafId,
           title,
+          ownerAgentType: resolveTitleDerivedPaneOwner(tab, layout, leafId),
           now: args.now,
           runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
         })
@@ -103,6 +105,7 @@ export function buildTitleDerivedAgentRows(args: {
       tab,
       leafId,
       title: tab.title,
+      ownerAgentType: resolveTitleDerivedPaneOwner(tab, layout, leafId),
       now: args.now,
       runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
     })
@@ -124,10 +127,11 @@ function buildTitleDerivedAgentRow(args: {
   tab: TerminalTab
   leafId: string
   title: string
+  ownerAgentType: AgentType | null
   now: number
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
 }): DashboardAgentRow | null {
-  const title = normalizeCompatibleAgentTitleForOwner(args.title, args.tab.launchAgent)
+  const title = normalizeCompatibleAgentTitleForOwner(args.title, args.ownerAgentType)
   const isClaudeAgentsTitle = isClaudeManagementTitle(title)
   // Why: `claude agents` is a live Claude Code Agent Teams surface, but the
   // shared detector keeps it neutral so runtime liveness probes do not treat
@@ -142,7 +146,9 @@ function buildTitleDerivedAgentRow(args: {
   }
   const paneKey = makePaneKey(args.tab.id, args.leafId)
   const orchestration = args.runtimeAgentOrchestrationByPaneKey?.[paneKey]
-  const agentType = isClaudeAgentsTitle ? 'claude' : resolveTitleDerivedAgentType(title, label)
+  const agentType = isClaudeAgentsTitle
+    ? 'claude'
+    : resolveTitleDerivedAgentType(title, label, args.ownerAgentType)
   if (!agentType) {
     return null
   }
@@ -173,7 +179,11 @@ function buildTitleDerivedAgentRow(args: {
   }
 }
 
-export function resolveTitleDerivedAgentType(title: string, label: string): AgentType | null {
+export function resolveTitleDerivedAgentType(
+  title: string,
+  label: string,
+  ownerAgentType?: AgentType | null
+): AgentType | null {
   const agentType = TITLE_AGENT_LABEL_TO_TYPE[label] ?? 'unknown'
   if (agentType !== 'claude') {
     return agentType
@@ -181,7 +191,26 @@ export function resolveTitleDerivedAgentType(title: string, label: string): Agen
   // Why: Claude's task-title spinner heuristic has no provider identity. In
   // split panes it can match arbitrary terminal spinners, so sidebar rows only
   // accept Claude when the title itself names Claude.
-  return CLAUDE_AGENT_TOKEN_RE.test(title) ? agentType : null
+  if (CLAUDE_AGENT_TOKEN_RE.test(title)) {
+    return agentType
+  }
+  // Why: bare Claude-shaped status frames carry activity but not identity. A
+  // single-pane launch owner is pane-safe authority for the row; without one,
+  // retain the existing refusal to mint a Claude identity from the frame alone.
+  return ownerAgentType && ownerAgentType !== 'unknown' ? ownerAgentType : null
+}
+
+function resolveTitleDerivedPaneOwner(
+  tab: TerminalTab,
+  layout: TerminalLayoutSnapshot | undefined,
+  leafId: string
+): AgentType | null {
+  // Why: launchAgent is tab-scoped. It is pane ownership only while the tab has
+  // one known leaf; applying it to splits would let one pane brand its sibling.
+  if (layout?.root?.type !== 'leaf' || layout.root.leafId !== leafId) {
+    return null
+  }
+  return resolvePaneAgentOwner({ launchAgent: tab.launchAgent })
 }
 
 /**

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -228,7 +228,7 @@ export function resolveAgentTypeFromTerminalTitle(
   const label = resolveTitleActivityLabel(normalizedTitle)
   return label
     ? (resolveCompatibleAgentTypeForOwner(
-        resolveTitleDerivedAgentType(normalizedTitle, label),
+        resolveTitleDerivedAgentType(normalizedTitle, label, ownerAgentType),
         ownerAgentType
       ) ?? null)
     : null

--- a/src/renderer/src/lib/use-tab-agent.test.ts
+++ b/src/renderer/src/lib/use-tab-agent.test.ts
@@ -272,6 +272,54 @@ describe('resolveTabAgentFromSignals', () => {
     ).toBe('opencode')
   })
 
+  it('keeps a known OpenCode pane stable across native, synthetic, bare, and idle titles', () => {
+    const titles = [
+      'OC | ⠋ implementing the feature',
+      '⠋ OpenCode',
+      '⠋ implementing the feature',
+      'OpenCode ready'
+    ]
+
+    for (const title of titles) {
+      expect(
+        resolveTabAgentFromSignals({
+          hasObservedAgentSignal: true,
+          isRemote: false,
+          title,
+          hookAgent: null,
+          launchAgent: 'opencode'
+        })
+      ).toBe('opencode')
+      expect(
+        resolveTabAgentFromSignals({
+          hasObservedAgentSignal: true,
+          isRemote: true,
+          title,
+          hookAgent: 'opencode'
+        })
+      ).toBe('opencode')
+      expect(
+        resolveTabAgentFromSignals({
+          hasObservedAgentSignal: true,
+          isRemote: false,
+          title,
+          hookAgent: null,
+          processAgent: 'opencode'
+        })
+      ).toBe('opencode')
+    }
+
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: 'zsh',
+        hookAgent: null,
+        launchAgent: 'opencode'
+      })
+    ).toBeNull()
+  })
+
   it('does not let an explicit title override launch identity before any activity is observed', () => {
     expect(
       resolveTabAgentFromSignals({


### PR DESCRIPTION
## Summary

- Preserve a proven single-pane agent owner when the sidebar receives a provider-neutral braille/task title.
- Keep OpenCode rows stable across native `OC | ...`, synthetic, bare task, and idle title frames.
- Keep explicit Claude detection, unknown-shell behavior, and split-pane isolation unchanged.

Fixes #8940.

### ELI5

OpenCode can publish a spinner title that says what it is doing without saying "OpenCode." The sidebar used to treat that title shape as Claude activity and forget the pane's known owner. It now keeps the known single-pane owner while still using the title for working/idle state.

### User Regression Tradeoffs

- Bare spinner titles still do not create an agent identity when Orca has no owner evidence.
- Explicitly named Claude titles still resolve as Claude.
- Tab-scoped launch identity is not applied to split panes, so one pane cannot label a sibling.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` - full lint reaches two pre-existing switch-exhaustiveness errors on `upstream/main` in `native-chat-session-option-labels.ts:47` and `skill-freshness-group.tsx:101`; changed-file `oxlint` and `oxfmt` pass.
- [x] `pnpm typecheck`
- [ ] `pnpm test` - the full Windows run completed with 2,879 files / 30,670 tests passing, then reported 44 files / 135 tests failing in unrelated Windows/POSIX path, symlink, shell, WSL, PTY, and source-newline suites. Focused identity coverage passes: 7 files / 113 tests.
- [x] `pnpm build`
- [x] Added regression coverage for the real title sequence, launch/hook/process owners, reset behavior, explicit Claude identity, unknown shells, and split-pane isolation.

Focused command:

    pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts src/renderer/src/lib/use-tab-agent.test.ts src/renderer/src/lib/use-tab-agent-pi-identity.test.ts src/shared/terminal-title-agent-type.test.ts src/shared/opencode-terminal-title.test.ts src/shared/repro-8478-opencode-native-title-icon.test.ts

## AI Review Report

The change was independently reviewed after implementation for identity precedence, stale-owner clearing, split-pane leakage, cross-platform behavior, remote behavior, and regressions across supported agents.

- Correctness: explicit hook/status rows remain authoritative. The title-derived fallback uses launch ownership only for a layout proven to contain one leaf, and only generic Claude-shaped activity claims are re-owned.
- Cross-platform: no shortcuts, labels, paths, shell commands, native APIs, or Electron platform branches changed. The pure title/layout logic is identical on macOS, Linux, and Windows.
- SSH/remote/local: no PTY transport or host assumptions changed. Remote hook/process tab identity is pinned by the same resolver tests; sidebar launch ownership remains scoped to a proven single pane.
- Agents and integrations: global Claude spinner inference remains intact. Explicit Claude, OpenCode native titles, Pi/OMP compatibility, Codex launch identity, unknown terminals, and split siblings were checked.
- Performance: one constant-time owner resolution is added per title-derived single pane; no new subscriptions, probes, filesystem access, or network calls are introduced.
- UI quality: no layout or styling changed; only the existing agent icon/row identity becomes stable.

CodeRabbit found one owner-aware fallback call site that had not received the new owner argument. Commit `67c4f0714` corrected it and added direct regression coverage for owner-present, owner-absent, and explicit-Claude cases.

## Security Audit

No input execution, command construction, filesystem path handling, IPC, authentication, secret, dependency, or network surface is introduced. Terminal titles remain untrusted display/status input and are only mapped to an existing enum; the change does not execute or persist title content beyond the existing row model.

## Notes

- This builds on #9102, which recognizes explicit native `OC | ...` titles; this PR covers later provider-neutral frames without weakening global Claude heuristics.
- Residual limitation: a manually typed, hookless OpenCode session with no launch/process identity remains neutral rather than being guessed from a bare spinner.
- X handle: not provided.