### PR TITLE
Reject adding the local Orca server as a remote environment

### DIFF
--- a/src/cli/runtime/environments.test.ts
+++ b/src/cli/runtime/environments.test.ts
@@ -1,7 +1,8 @@
-import { mkdtempSync, statSync } from 'node:fs'
+import { mkdtempSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { E2EE_KEYPAIR_FILENAME } from '../../shared/local-runtime-public-key'
 import { encodePairingOffer } from '../../shared/pairing'
 import {
   addEnvironmentFromPairingCode,
@@ -80,5 +81,24 @@ describe('CLI runtime environments', () => {
       'ws://127.0.0.1:1111'
     )
     expect(listEnvironments(userDataPath)[0]?.id).toBe(first.id)
+  })
+
+  it('rejects adding this host as a remote environment', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-env-store-'))
+    // Why: the CLI shares userData with the desktop app, so the running
+    // server's keypair identifies a pairing code that points back at it.
+    writeFileSync(
+      join(userDataPath, E2EE_KEYPAIR_FILENAME),
+      JSON.stringify({
+        v: 1,
+        publicKeyB64: Buffer.from(new Uint8Array(32).fill(1)).toString('base64'),
+        secretKeyB64: 'unused'
+      })
+    )
+
+    expect(() =>
+      addEnvironmentFromPairingCode(userDataPath, { name: 'itself', pairingCode: pairingCode() })
+    ).toThrow('This pairing code belongs to this Orca server.')
+    expect(listEnvironments(userDataPath)).toEqual([])
   })
 })

--- a/src/main/ipc/runtime-environments-pairing.test.ts
+++ b/src/main/ipc/runtime-environments-pairing.test.ts
@@ -1,7 +1,8 @@
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { E2EE_KEYPAIR_FILENAME } from '../../shared/local-runtime-public-key'
 import {
   ELECTRON_REMOTE_RUNTIME_CLIENT_CAPABILITIES,
   MIN_COMPATIBLE_RUNTIME_SERVER_VERSION
@@ -398,6 +399,30 @@ describe('registerRuntimeEnvironmentHandlers', () => {
     )
     expect(activeRuntimeEnvironmentId).toBe(added.environment.id)
     expect(store.updateSettings).not.toHaveBeenCalled()
+  })
+
+  it('rejects adding the local Orca server as a remote environment', () => {
+    // Why: the store reads this host's server identity from userData, so the
+    // handler rejects a self-referential code without extra IPC plumbing.
+    writeFileSync(
+      join(userDataPath, E2EE_KEYPAIR_FILENAME),
+      JSON.stringify({
+        v: 1,
+        publicKeyB64: Buffer.from(new Uint8Array(32).fill(1)).toString('base64'),
+        secretKeyB64: 'unused'
+      })
+    )
+    registerRuntimeEnvironmentHandlers(store as never)
+
+    const add = handler<
+      { name: string; pairingCode: string },
+      { environment: { id: string; name: string } }
+    >('runtimeEnvironments:addFromPairingCode')
+
+    expect(() => add(null, { name: 'this server', pairingCode: pairingCode() })).toThrow(
+      'This pairing code belongs to this Orca server.'
+    )
+    expect(environmentStore.listEnvironments(userDataPath)).toEqual([])
   })
 
   it('disconnects a saved runtime without removing it', async () => {

--- a/src/main/runtime/mobile-pairing-files.ts
+++ b/src/main/runtime/mobile-pairing-files.ts
@@ -1,5 +1,7 @@
+import { E2EE_KEYPAIR_FILENAME } from '../../shared/local-runtime-public-key'
+
 export const DEVICE_REGISTRY_FILENAME = 'orca-devices.json'
-export const E2EE_KEYPAIR_FILENAME = 'orca-e2ee-keypair.json'
+export { E2EE_KEYPAIR_FILENAME }
 
 // Migrate these together so device tokens and E2EE material never split across dirs.
 export const MOBILE_PAIRING_USERDATA_FILES = [

--- a/src/shared/local-runtime-public-key.test.ts
+++ b/src/shared/local-runtime-public-key.test.ts
@@ -1,8 +1,12 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { E2EE_KEYPAIR_FILENAME, readLocalRuntimePublicKeyB64 } from './local-runtime-public-key'
+import {
+  E2EE_KEYPAIR_FILENAME,
+  MAX_KEYPAIR_FILE_BYTES,
+  readLocalRuntimePublicKeyB64
+} from './local-runtime-public-key'
 
 describe('readLocalRuntimePublicKeyB64', () => {
   const tempDirs: string[] = []
@@ -44,6 +48,19 @@ describe('readLocalRuntimePublicKeyB64', () => {
     const userDataPath = makeUserDataPath()
 
     expect(readLocalRuntimePublicKeyB64(userDataPath)).toBeNull()
+    expect(readLocalRuntimePublicKeyB64(userDataPath)).toBeNull()
+    expect(existsSync(join(userDataPath, E2EE_KEYPAIR_FILENAME))).toBe(false)
+  })
+
+  it('returns null for an oversized sparse keypair without reading it wholesale', () => {
+    const userDataPath = makeUserDataPath()
+    const path = join(userDataPath, E2EE_KEYPAIR_FILENAME)
+    writeFileSync(
+      path,
+      JSON.stringify({ v: 1, publicKeyB64: 'public-key', secretKeyB64: 'secret-key' })
+    )
+    truncateSync(path, MAX_KEYPAIR_FILE_BYTES + 1)
+
     expect(readLocalRuntimePublicKeyB64(userDataPath)).toBeNull()
   })
 })

--- a/src/shared/local-runtime-public-key.test.ts
+++ b/src/shared/local-runtime-public-key.test.ts
@@ -1,0 +1,49 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { E2EE_KEYPAIR_FILENAME, readLocalRuntimePublicKeyB64 } from './local-runtime-public-key'
+
+describe('readLocalRuntimePublicKeyB64', () => {
+  const tempDirs: string[] = []
+
+  function makeUserDataPath(): string {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-local-key-'))
+    tempDirs.push(userDataPath)
+    return userDataPath
+  }
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('reads the public key written by the runtime server', () => {
+    const userDataPath = makeUserDataPath()
+    writeFileSync(
+      join(userDataPath, E2EE_KEYPAIR_FILENAME),
+      JSON.stringify({ v: 1, publicKeyB64: 'public-key', secretKeyB64: 'secret-key' })
+    )
+
+    expect(readLocalRuntimePublicKeyB64(userDataPath)).toBe('public-key')
+  })
+
+  it('returns null when no keypair has been generated yet', () => {
+    expect(readLocalRuntimePublicKeyB64(makeUserDataPath())).toBeNull()
+  })
+
+  it('returns null for a malformed keypair file instead of throwing', () => {
+    const userDataPath = makeUserDataPath()
+    writeFileSync(join(userDataPath, E2EE_KEYPAIR_FILENAME), 'not json')
+
+    expect(readLocalRuntimePublicKeyB64(userDataPath)).toBeNull()
+  })
+
+  it('never creates the keypair file', () => {
+    const userDataPath = makeUserDataPath()
+
+    expect(readLocalRuntimePublicKeyB64(userDataPath)).toBeNull()
+    expect(readLocalRuntimePublicKeyB64(userDataPath)).toBeNull()
+  })
+})

--- a/src/shared/local-runtime-public-key.ts
+++ b/src/shared/local-runtime-public-key.ts
@@ -2,12 +2,13 @@
 // Orca server. Reading it from disk lets non-Electron entry points (the CLI)
 // recognize a pairing offer that points back at this same server, without
 // importing main-process modules.
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { join } from 'node:path'
+import { readNodeFileSyncWithinLimit } from './node-bounded-file-reader'
 
 export const E2EE_KEYPAIR_FILENAME = 'orca-e2ee-keypair.json'
 
-const MAX_KEYPAIR_FILE_BYTES = 8 * 1024
+export const MAX_KEYPAIR_FILE_BYTES = 8 * 1024
 
 /**
  * Reads this host's runtime E2EE public key from `userDataPath`, or null when
@@ -20,16 +21,14 @@ export function readLocalRuntimePublicKeyB64(userDataPath: string): string | nul
     return null
   }
   try {
-    const raw = readFileSync(filePath, 'utf8')
-    if (raw.length > MAX_KEYPAIR_FILE_BYTES) {
-      return null
-    }
+    // Why: bound the read itself so a huge/corrupt keypair cannot exhaust memory during pairing.
+    const raw = readNodeFileSyncWithinLimit(filePath, MAX_KEYPAIR_FILE_BYTES).buffer.toString('utf8')
     const parsed: unknown = JSON.parse(raw)
     const publicKeyB64 = (parsed as { publicKeyB64?: unknown } | null)?.publicKeyB64
     return typeof publicKeyB64 === 'string' && publicKeyB64.length > 0 ? publicKeyB64 : null
   } catch {
-    // Malformed keypair file: fall back to allowing the pair rather than
-    // blocking every add.
+    // Malformed or oversized keypair file: fall back to allowing the pair rather
+    // than blocking every add.
     return null
   }
 }

--- a/src/shared/local-runtime-public-key.ts
+++ b/src/shared/local-runtime-public-key.ts
@@ -1,0 +1,35 @@
+// Why: the runtime RPC server's E2EE public key is the stable identity of an
+// Orca server. Reading it from disk lets non-Electron entry points (the CLI)
+// recognize a pairing offer that points back at this same server, without
+// importing main-process modules.
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+export const E2EE_KEYPAIR_FILENAME = 'orca-e2ee-keypair.json'
+
+const MAX_KEYPAIR_FILE_BYTES = 8 * 1024
+
+/**
+ * Reads this host's runtime E2EE public key from `userDataPath`, or null when
+ * no server has generated one yet. Never creates the keypair: callers only
+ * compare identities, and generating one here would race the RPC server.
+ */
+export function readLocalRuntimePublicKeyB64(userDataPath: string): string | null {
+  const filePath = join(userDataPath, E2EE_KEYPAIR_FILENAME)
+  if (!existsSync(filePath)) {
+    return null
+  }
+  try {
+    const raw = readFileSync(filePath, 'utf8')
+    if (raw.length > MAX_KEYPAIR_FILE_BYTES) {
+      return null
+    }
+    const parsed: unknown = JSON.parse(raw)
+    const publicKeyB64 = (parsed as { publicKeyB64?: unknown } | null)?.publicKeyB64
+    return typeof publicKeyB64 === 'string' && publicKeyB64.length > 0 ? publicKeyB64 : null
+  } catch {
+    // Malformed keypair file: fall back to allowing the pair rather than
+    // blocking every add.
+    return null
+  }
+}

--- a/src/shared/local-runtime-public-key.ts
+++ b/src/shared/local-runtime-public-key.ts
@@ -21,8 +21,11 @@ export function readLocalRuntimePublicKeyB64(userDataPath: string): string | nul
     return null
   }
   try {
-    // Why: bound the read itself so a huge/corrupt keypair cannot exhaust memory during pairing.
-    const raw = readNodeFileSyncWithinLimit(filePath, MAX_KEYPAIR_FILE_BYTES).buffer.toString('utf8')
+    // Why: bound the read itself so a huge/corrupt keypair cannot exhaust memory
+    // during pairing.
+    const raw = readNodeFileSyncWithinLimit(filePath, MAX_KEYPAIR_FILE_BYTES).buffer.toString(
+      'utf8'
+    )
     const parsed: unknown = JSON.parse(raw)
     const publicKeyB64 = (parsed as { publicKeyB64?: unknown } | null)?.publicKeyB64
     return typeof publicKeyB64 === 'string' && publicKeyB64.length > 0 ? publicKeyB64 : null

--- a/src/shared/runtime-environment-store.test.ts
+++ b/src/shared/runtime-environment-store.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { E2EE_KEYPAIR_FILENAME } from './local-runtime-public-key'
 import { encodePairingOffer } from './pairing'
 import {
   RuntimeEnvironmentStoreError,
@@ -12,6 +13,13 @@ import {
   markEnvironmentUsed,
   updateEnvironmentFromPairingCode
 } from './runtime-environment-store'
+
+function writeStoredE2EEPublicKey(userDataPath: string, publicKey: Buffer): void {
+  writeFileSync(
+    join(userDataPath, E2EE_KEYPAIR_FILENAME),
+    JSON.stringify({ v: 1, publicKeyB64: publicKey.toString('base64'), secretKeyB64: 'unused' })
+  )
+}
 
 function pairingCode(endpoint = 'ws://127.0.0.1:6768', pairedDeviceId?: string): string {
   return encodePairingOffer({
@@ -86,6 +94,89 @@ describe('runtime environment store', () => {
       backwardClock.pairingRevision,
       laterClock.pairingRevision
     ]).toEqual([101, 102, 200])
+  })
+
+  it('rejects pairing the local Orca server to itself before saving it', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-env-store-'))
+    tempDirs.push(userDataPath)
+    writeStoredE2EEPublicKey(userDataPath, Buffer.from(new Uint8Array(32).fill(1)))
+
+    expect(() =>
+      addEnvironmentFromPairingCode(userDataPath, {
+        name: 'this server',
+        pairingCode: pairingCode('ws://192.0.2.10:6768')
+      })
+    ).toThrow('This pairing code belongs to this Orca server.')
+    expect(listEnvironments(userDataPath)).toEqual([])
+  })
+
+  it('allows the same endpoint when it identifies a different Orca server', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-env-store-'))
+    tempDirs.push(userDataPath)
+    writeStoredE2EEPublicKey(userDataPath, Buffer.from(new Uint8Array(32).fill(2)))
+
+    const environment = addEnvironmentFromPairingCode(userDataPath, {
+      name: 'other server',
+      pairingCode: pairingCode()
+    })
+
+    expect(listEnvironments(userDataPath)).toEqual([environment])
+  })
+
+  it('rejects self-pairing for callers that do not pass the local key, using the stored keypair', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-env-store-'))
+    tempDirs.push(userDataPath)
+    writeStoredE2EEPublicKey(userDataPath, Buffer.from(new Uint8Array(32).fill(1)))
+
+    // The CLI and ephemeral-VM wiring call without localRuntimePublicKeyB64.
+    expect(() =>
+      addEnvironmentFromPairingCode(userDataPath, {
+        name: 'this server',
+        pairingCode: pairingCode()
+      })
+    ).toThrow('This pairing code belongs to this Orca server.')
+    expect(listEnvironments(userDataPath)).toEqual([])
+  })
+
+  it('allows a remote server reached over an SSH local port-forward at 127.0.0.1', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-env-store-'))
+    tempDirs.push(userDataPath)
+    // Why: a forwarded remote server shares this host's loopback address but
+    // never its keypair, so identity-based detection must let it through.
+    writeStoredE2EEPublicKey(userDataPath, Buffer.from(new Uint8Array(32).fill(9)))
+
+    const environment = addEnvironmentFromPairingCode(userDataPath, {
+      name: 'forwarded server',
+      pairingCode: pairingCode('ws://127.0.0.1:6768')
+    })
+
+    expect(listEnvironments(userDataPath)).toEqual([environment])
+  })
+
+  it('keeps listing an already-saved self-referential environment', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-env-store-'))
+    tempDirs.push(userDataPath)
+    // Saved before this check existed; rejecting it at read time would break
+    // startup and hide the entry the user needs in order to remove it.
+    const environment = addEnvironmentFromPairingCode(userDataPath, {
+      name: 'itself',
+      pairingCode: pairingCode()
+    })
+    writeStoredE2EEPublicKey(userDataPath, Buffer.from(new Uint8Array(32).fill(1)))
+
+    expect(listEnvironments(userDataPath)).toEqual([environment])
+  })
+
+  it('still saves environments when no local keypair exists yet', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-env-store-'))
+    tempDirs.push(userDataPath)
+
+    const environment = addEnvironmentFromPairingCode(userDataPath, {
+      name: 'workstation',
+      pairingCode: pairingCode()
+    })
+
+    expect(listEnvironments(userDataPath)).toEqual([environment])
   })
 
   it('keeps SSH-tunnel metadata only while the pairing endpoint is loopback', () => {

--- a/src/shared/runtime-environment-store.ts
+++ b/src/shared/runtime-environment-store.ts
@@ -3,6 +3,8 @@ import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { JsonStringifyByteLimitError } from './node-bounded-json-stringify'
 import { readNodeFileSyncWithinLimit } from './node-bounded-file-reader'
+import { publicKeyFromBase64, publicKeyToBase64 } from './e2ee-crypto'
+import { readLocalRuntimePublicKeyB64 } from './local-runtime-public-key'
 import { parsePairingCode, type PairingOffer } from './pairing'
 import { classifyRemotePairingHostname } from './remote-pairing-address'
 import { writeSecureJsonFileWithinLimit } from './bounded-secure-json-file'
@@ -40,6 +42,12 @@ export function listEnvironments(userDataPath: string): KnownRuntimeEnvironment[
   return readEnvironmentStore(userDataPath).environments
 }
 
+/**
+ * Parses a pairing code and persists the offered server as a known remote
+ * environment. Throws when the code is invalid, the name is taken, or the offer
+ * identifies this server itself — matched on the E2EE public key rather than the
+ * endpoint, so an SSH-forwarded remote server still pairs from 127.0.0.1.
+ */
 export function addEnvironmentFromPairingCode(
   userDataPath: string,
   args: {
@@ -55,6 +63,19 @@ export function addEnvironmentFromPairingCode(
     throw new RuntimeEnvironmentStoreError(
       'invalid_argument',
       'Invalid pairing code. Expected an orca://pair?... URL or bare pairing payload.'
+    )
+  }
+  // Why: reading this host's server identity here covers every entry point —
+  // desktop IPC, the CLI, and ephemeral-VM wiring — instead of one call site.
+  const localRuntimePublicKeyB64 = readLocalRuntimePublicKeyB64(userDataPath)
+  if (
+    localRuntimePublicKeyB64 &&
+    pairingPublicKeysMatch(offer.publicKeyB64, localRuntimePublicKeyB64)
+  ) {
+    // Why: connecting the local runtime back to itself creates recursive host state.
+    throw new RuntimeEnvironmentStoreError(
+      'invalid_argument',
+      'This pairing code belongs to this Orca server. Add a different remote server.'
     )
   }
   const store = readEnvironmentStore(userDataPath)
@@ -84,6 +105,21 @@ export function addEnvironmentFromPairingCode(
   }
   writeEnvironmentStore(userDataPath, next)
   return environment
+}
+
+/**
+ * Compares two base64 pairing public keys after decode/re-encode
+ * normalization, so padding or whitespace differences cannot defeat the
+ * self-pairing check. Malformed keys never match.
+ */
+function pairingPublicKeysMatch(left: string, right: string): boolean {
+  try {
+    return (
+      publicKeyToBase64(publicKeyFromBase64(left)) === publicKeyToBase64(publicKeyFromBase64(right))
+    )
+  } catch {
+    return false
+  }
 }
 
 export function removeEnvironment(userDataPath: string, selector: string): KnownRuntimeEnvironment {


### PR DESCRIPTION
## Summary

Adding a remote Orca server from a pairing code no longer lets you add **this** machine's own Orca server as if it were remote, which produced a runtime environment that recursively pointed back at itself.

Detection is **identity-based**: the pairing offer carries the server's E2EE public key, and the environment store compares it against this host's own key (`orca-e2ee-keypair.json` in userData). It deliberately does **not** look at the host/port, because the address tells you nothing reliable here in either direction.

The check lives in `addEnvironmentFromPairingCode` in `src/shared/runtime-environment-store.ts`, which is the single choke point every entry point goes through — desktop IPC, `orca environment add`, and the ephemeral-VM wiring.

## ELI5

Orca can connect to other computers running Orca. There was nothing stopping you from accidentally telling it "connect to this remote computer" and handing it your *own* computer's address — so it tried to connect to itself, which never works properly.

Now it notices. Every Orca server has a unique cryptographic fingerprint, and the invite code contains it. If the fingerprint in the code is your own, Orca says so instead of saving a broken entry. Crucially, it checks the *fingerprint*, not the address — so connecting to a genuinely different machine still works even when that machine happens to be reachable at an address that looks local.

## Proof of fix

Three tests fail on `origin/main` and pass with this branch. Sources reverted to `origin/main` with the new tests kept:

```
$ git checkout origin/main -- src/shared/runtime-environment-store.ts
$ npx vitest run --config config/vitest.config.ts \
    src/shared/runtime-environment-store.test.ts src/cli/runtime/environments.test.ts

 ❯ src/cli/runtime/environments.test.ts (4 tests | 1 failed) 15ms
     × rejects adding this host as a remote environment 5ms
 ❯ src/shared/runtime-environment-store.test.ts (11 tests | 2 failed) 44ms
     × rejects pairing the local Orca server to itself before saving it 6ms
     × rejects self-pairing for callers that do not pass the local key, using the stored keypair 2ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  ... > rejects pairing the local Orca server to itself before saving it
 FAIL  ... > rejects self-pairing for callers that do not pass the local key, using the stored keypair
 FAIL  ... > rejects adding this host as a remote environment
AssertionError: expected [Function] to throw an error

 Test Files  2 failed (2)
      Tests  3 failed | 12 passed (15)
```

With the fix applied:

```
$ npx vitest run --config config/vitest.config.ts \
    src/shared/runtime-environment-store.test.ts src/shared/local-runtime-public-key.test.ts \
    src/main/ipc/runtime-environments.test.ts src/main/ipc/register-core-handlers.test.ts \
    src/cli/runtime/environments.test.ts

 Test Files  5 passed (5)
      Tests  59 passed (59)
```

### Defect found and fixed during review

The original patch threaded the local key from `src/main/index.ts` → `register-core-handlers.ts` → the `runtimeEnvironments:addFromPairingCode` IPC handler. That covers the desktop dialog **only**. `orca environment add --name x --pairing-code <own code>` bypassed the check entirely, as did the ephemeral-VM path — both call the same store function directly without going through IPC. Verified against the original patch:

```
$ npx vitest run --config config/vitest.config.ts src/cli/runtime/cli-bypass.test.ts
 ✓ CLI environment add can save the local server as a remote env
 Test Files  1 passed (1)
```

Moving the lookup into the store closed all three paths at once and let the IPC/lifecycle plumbing be dropped, so `src/main/index.ts` and `src/main/ipc/runtime-environments.ts` are now byte-identical to `main`. That also resolved an `oxlint max-lines` error the added plumbing introduced in `runtime-environments.ts` (306 > 300) — resolved by removing code, not by adding a disable.

## Proof of no regressions

```
$ npx vitest run --config config/vitest.config.ts src/shared/
 Test Files  341 passed | 2 skipped (343)
      Tests  3078 passed | 6 skipped (3084)

$ npx vitest run --config config/vitest.config.ts src/main/ipc/
 Test Files  146 passed (146)
      Tests  2265 passed | 9 skipped (2274)

$ npx vitest run --config config/vitest.config.ts src/cli/ src/shared/pairing.test.ts \
    src/shared/runtime-environments.test.ts src/main/runtime/e2ee-keypair.test.ts
 Test Files  41 passed (41)
      Tests  539 passed (539)

$ npx tsc --noEmit -p config/tsconfig.node.json     # exit 0
$ npx oxlint <changed files>                        # no findings
$ npx oxfmt --check <changed files>                 # All matched files use the correct format
$ node config/scripts/verify-localization-catalog.mjs
Verified 10358 localization key references against en.json.
Verified locale parity for es.json / ja.json / ko.json / zh.json (11174 keys each).
```

Two user-visible behavior changes, both intended:

- Adding a pairing code whose E2EE public key matches this host's now fails with `This pairing code belongs to this Orca server. Add a different remote server.` This previously succeeded and produced a self-referential environment.
- The same rejection now also applies to `orca environment add` and the ephemeral-VM add path, which the original patch left unguarded.

Nothing else changes. Specifically:

- **Existing saved environments are never re-validated.** The check is in the *add* path only; `listEnvironments`, `resolveEnvironment`, and startup are untouched, so a user who already has a self-referential entry saved still sees it listed and can remove it normally. Covered by `keeps listing an already-saved self-referential environment`.
- **No new user-facing string needs localization.** This message is a `RuntimeEnvironmentStoreError` surfaced through the existing add-server error path, matching the untranslated store errors already there (`Invalid pairing code…`, `Unknown environment: …`). `audit-localization-coverage.mjs --check` reports the same 6 pre-existing findings with and without this change (all `Ghostty` keywords in files this PR does not touch).
- **Fail-open on missing/corrupt key.** `readLocalRuntimePublicKeyB64` returns `null` when the keypair file is absent, oversized, or malformed, so pairing keeps working rather than being blocked wholesale. It never *creates* the keypair — generating one here would race the RPC server.

## Compatibility

- **Platforms:** macOS / Linux / Windows. Pure Node `fs` + `Buffer`/base64; the path is built with `path.join`, and the filename constant is now shared with `mobile-pairing-files.ts` so the CLI and the RPC server cannot drift. No shortcuts, labels, shell invocations, or Electron platform branches touched. Test suites run on macOS here; the store suite pins `process.platform = 'linux'` as it already did.
- **SSH / remote:** This is the case that drove the identity-based design. A genuinely remote Orca reached over an SSH local port-forward appears at `127.0.0.1:PORT`; an address/loopback check would wrongly block it. Because detection compares E2EE public keys, the forwarded server pairs normally — locked in by `allows a remote server reached over an SSH local port-forward at 127.0.0.1`. The mirrored case (a container or VM reaching the host's Orca over a LAN IP) is likewise unaffected. `src/renderer/src/web/web-preload-api.ts` is untouched: a browser client is by definition not the server it pairs with.
- **Performance:** No hot-path change. The one added read is a single `existsSync` + `readFileSync` of a <1 KB file, and it happens only when a user adds a server — not per list render, per status poll, or per runtime round-trip. `listEnvironments` is unchanged, so no network round-trip or extra I/O was added to any render path.

## Screenshots

No visual change. The only new user-visible surface is the error toast text, delivered through the existing add-server error path in `AddRemoteHostDialog.tsx` / `RuntimeEnvironmentsPane.tsx`.

## Testing

- [x] `pnpm lint` — `oxlint` and `oxfmt --check` clean on every changed file.
- [x] `pnpm typecheck` — `npx tsc --noEmit -p config/tsconfig.node.json`, exit 0.
- [x] `pnpm test` — targeted, not the full suite: `src/shared/` (3078 passed), `src/main/ipc/` (2265 passed), `src/cli/` + pairing/e2ee suites (539 passed).
- [ ] `pnpm build` — not run; no build-config or packaging changes.
- [x] Added or updated high-quality tests that would catch regressions — see below.

Tests added: store-level self-pairing rejection via the stored keypair; the CLI entry point (the bypass the original patch missed); the SSH port-forward acceptance case; same-endpoint/different-key acceptance; already-saved self-referential environments still listing; no-keypair-yet still saving; and unit coverage for `readLocalRuntimePublicKeyB64` (valid, missing, malformed, never-creates).

## AI Review Report

Reviewed as a hostile reviewer, with cross-platform compatibility for macOS, Linux, and Windows explicitly checked (paths, shortcuts, labels, shell behavior, Electron platform differences) — no platform-dependent behavior is introduced.

- **Coverage of the invariant (defect found).** The original wiring guarded one of three call sites. Confirmed by executing the bypass, then fixed by relocating the check to the shared store. This was the substantive finding.
- **Too-broad rejection (the dangerous direction).** Explicitly checked that the SSH local-port-forward workflow and the container→host LAN-IP workflow still pair. Both do, because nothing compares addresses. A regression test pins the port-forward case.
- **Migration / boot ordering.** `src/main/index.ts` is no longer in the diff at all, so there is no new startup dependency and no boot-order risk. Pre-existing self-referential entries are not re-validated and degrade gracefully.
- **Key comparison correctness.** Both keys are normalized through `publicKeyFromBase64` → `publicKeyToBase64`, so base64 padding differences cannot defeat or falsely trigger the check; `publicKeyFromBase64` enforces 32 bytes and malformed keys are treated as non-matching.
- **Ordering.** Rejection happens before `readEnvironmentStore` and before any write, so no partial record is persisted.
- **Lint rules.** The `max-lines` error introduced by the original plumbing was resolved by deleting the plumbing. No `max-lines` disable was added anywhere.

## Security Audit

- **Input handling:** The pairing code is parsed by the existing `parsePairingCode`; only its `publicKeyB64` is consumed. `pairingPublicKeysMatch` wraps decoding in try/catch, so malformed input degrades to "no match" rather than an unhandled exception. `readLocalRuntimePublicKeyB64` bounds the file read at 8 KB before parsing and validates the field is a non-empty string.
- **IPC:** No new channels, and the handler signature is now *simpler* than before — `registerRuntimeEnvironmentHandlers(store)` is unchanged from `main`. No renderer-controlled data reaches the comparison besides the pairing code itself; the local key comes from disk in the main process, so the renderer cannot spoof or suppress the check.
- **Secrets:** Only the *public* key is read; `secretKeyB64` is never touched, logged, or persisted by this change. Comparison is not constant-time, which is fine — both inputs are public keys and the result is not secret.
- **Path handling:** `path.join` on the caller-supplied userData path; no user-controlled path segments. The filename constant is shared to prevent divergence.
- **Command execution / dependencies:** None touched. No follow-up needed.

## Notes

- This guards the *add* path. `updateEnvironmentFromPairingCode` (used only by ephemeral-VM resume, which re-pairs an existing entry to a newly booted VM) is not guarded; a self-referential key cannot be introduced there without the entry having been added first, which is now blocked. Worth revisiting if that function ever becomes reachable from user input.
- If the local runtime server has never started, no keypair file exists and the check is inert by design — there is no local server to pair back to in that state.
- The branch was rebased onto current `main` (it was ~1400 commits behind, and `runtime-environment-store.ts` had since gained bounded file reads and `pairingRevision`); those changes are preserved intact.

Original patch by @s546126.
