### PR TITLE
fix(main): cancel unread fetch response bodies so a peer socket close cannot crash the app

### DIFF
--- a/src/main/azure-devops/azure-devops-api-request.ts
+++ b/src/main/azure-devops/azure-devops-api-request.ts
@@ -1,5 +1,6 @@
 import { Buffer } from 'node:buffer'
 import type { AzureDevOpsRepoRef } from './repository-ref'
+import { cancelUnreadResponseBody } from '../lib/unread-response-body'
 
 const REQUEST_TIMEOUT_MS = 5000
 
@@ -84,6 +85,7 @@ export async function requestAzureDevOpsJsonAtBase<T>(
       signal: AbortSignal.timeout(options.timeoutMs ?? REQUEST_TIMEOUT_MS)
     })
     if (!response.ok) {
+      await cancelUnreadResponseBody(response)
       return null
     }
     return (await response.json()) as T

--- a/src/main/azure-devops/client.test.ts
+++ b/src/main/azure-devops/client.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cancelTrackingResponse } from '../lib/unread-response-body.test-fixtures'
 import {
   getAzureDevOpsAuthStatus,
   getAzureDevOpsPullRequestForBranch,
@@ -182,17 +183,11 @@ describe('Azure DevOps client', () => {
       stdout: 'https://dev.azure.com/acme/Project/_git/repo\n'
     })
     let cancelledBodies = 0
-    const fetchMock = vi.fn(async () => {
-      const body = new ReadableStream<Uint8Array>({
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode('<html>proxy error page</html>'))
-        },
-        cancel() {
-          cancelledBodies += 1
-        }
+    const fetchMock = vi.fn(async () =>
+      cancelTrackingResponse(502, () => {
+        cancelledBodies += 1
       })
-      return new Response(body, { status: 502 })
-    })
+    )
     globalThis.fetch = fetchMock as never
 
     await getAzureDevOpsPullRequestForBranch('/repo', 'refs/heads/feature/azure')

--- a/src/main/azure-devops/client.test.ts
+++ b/src/main/azure-devops/client.test.ts
@@ -176,4 +176,28 @@ describe('Azure DevOps client', () => {
       headSha: 'newsha'
     })
   })
+
+  it('cancels unread error-response bodies so bundled undici cannot crash on socket close', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: 'https://dev.azure.com/acme/Project/_git/repo\n'
+    })
+    let cancelledBodies = 0
+    const fetchMock = vi.fn(async () => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('<html>proxy error page</html>'))
+        },
+        cancel() {
+          cancelledBodies += 1
+        }
+      })
+      return new Response(body, { status: 502 })
+    })
+    globalThis.fetch = fetchMock as never
+
+    await getAzureDevOpsPullRequestForBranch('/repo', 'refs/heads/feature/azure')
+
+    expect(fetchMock).toHaveBeenCalled()
+    expect(cancelledBodies).toBe(fetchMock.mock.calls.length)
+  })
 })

--- a/src/main/bitbucket/client.test.ts
+++ b/src/main/bitbucket/client.test.ts
@@ -122,4 +122,25 @@ describe('Bitbucket client', () => {
       account: 'bitbucket-user'
     })
   })
+
+  it('cancels unread error-response bodies so bundled undici cannot crash on socket close', async () => {
+    let cancelledBodies = 0
+    const fetchMock = vi.fn(async () => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('<html>proxy error page</html>'))
+        },
+        cancel() {
+          cancelledBodies += 1
+        }
+      })
+      return new Response(body, { status: 502 })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await getBitbucketPullRequestForBranch('/repo', 'refs/heads/feature/bitbucket')
+
+    expect(fetchMock).toHaveBeenCalled()
+    expect(cancelledBodies).toBe(fetchMock.mock.calls.length)
+  })
 })

--- a/src/main/bitbucket/client.test.ts
+++ b/src/main/bitbucket/client.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { cancelTrackingResponse } from '../lib/unread-response-body.test-fixtures'
 
 const { gitExecFileAsyncMock } = vi.hoisted(() => ({
   gitExecFileAsyncMock: vi.fn()
@@ -125,17 +126,11 @@ describe('Bitbucket client', () => {
 
   it('cancels unread error-response bodies so bundled undici cannot crash on socket close', async () => {
     let cancelledBodies = 0
-    const fetchMock = vi.fn(async () => {
-      const body = new ReadableStream<Uint8Array>({
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode('<html>proxy error page</html>'))
-        },
-        cancel() {
-          cancelledBodies += 1
-        }
+    const fetchMock = vi.fn(async () =>
+      cancelTrackingResponse(502, () => {
+        cancelledBodies += 1
       })
-      return new Response(body, { status: 502 })
-    })
+    )
     vi.stubGlobal('fetch', fetchMock)
 
     await getBitbucketPullRequestForBranch('/repo', 'refs/heads/feature/bitbucket')

--- a/src/main/bitbucket/client.ts
+++ b/src/main/bitbucket/client.ts
@@ -12,6 +12,7 @@ import {
   getHostedReviewLocalGitOptions,
   type HostedReviewExecutionOptions
 } from '../source-control/hosted-review-git-options'
+import { cancelUnreadResponseBody } from '../lib/unread-response-body'
 
 const DEFAULT_API_BASE_URL = 'https://api.bitbucket.org/2.0'
 const REQUEST_TIMEOUT_MS = 5000
@@ -97,6 +98,7 @@ async function requestJson<T>(path: string, options: RequestOptions = {}): Promi
       signal: AbortSignal.timeout(options.timeoutMs ?? REQUEST_TIMEOUT_MS)
     })
     if (!response.ok) {
+      await cancelUnreadResponseBody(response)
       return null
     }
     return (await response.json()) as T

--- a/src/main/gitea/client.test.ts
+++ b/src/main/gitea/client.test.ts
@@ -301,4 +301,25 @@ describe('Gitea client', () => {
     })
     expect(String(fetchMock.mock.calls[0]?.[0])).toBe('https://git.example.com/api/v1/user')
   })
+
+  it('cancels unread error-response bodies so bundled undici cannot crash on socket close', async () => {
+    let cancelledBodies = 0
+    const fetchMock = vi.fn(async () => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('<html>proxy error page</html>'))
+        },
+        cancel() {
+          cancelledBodies += 1
+        }
+      })
+      return new Response(body, { status: 502 })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await getGiteaPullRequestForBranch('/repo', 'refs/heads/feature/gitea')
+
+    expect(fetchMock).toHaveBeenCalled()
+    expect(cancelledBodies).toBe(fetchMock.mock.calls.length)
+  })
 })

--- a/src/main/gitea/client.test.ts
+++ b/src/main/gitea/client.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { cancelTrackingResponse } from '../lib/unread-response-body.test-fixtures'
 
 const { gitExecFileAsyncMock } = vi.hoisted(() => ({
   gitExecFileAsyncMock: vi.fn()
@@ -304,17 +305,11 @@ describe('Gitea client', () => {
 
   it('cancels unread error-response bodies so bundled undici cannot crash on socket close', async () => {
     let cancelledBodies = 0
-    const fetchMock = vi.fn(async () => {
-      const body = new ReadableStream<Uint8Array>({
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode('<html>proxy error page</html>'))
-        },
-        cancel() {
-          cancelledBodies += 1
-        }
+    const fetchMock = vi.fn(async () =>
+      cancelTrackingResponse(502, () => {
+        cancelledBodies += 1
       })
-      return new Response(body, { status: 502 })
-    })
+    )
     vi.stubGlobal('fetch', fetchMock)
 
     await getGiteaPullRequestForBranch('/repo', 'refs/heads/feature/gitea')

--- a/src/main/gitea/client.ts
+++ b/src/main/gitea/client.ts
@@ -11,6 +11,7 @@ import {
   getHostedReviewLocalGitOptions,
   type HostedReviewExecutionOptions
 } from '../source-control/hosted-review-git-options'
+import { cancelUnreadResponseBody } from '../lib/unread-response-body'
 
 const REQUEST_TIMEOUT_MS = 5000
 // Why: self-hosted Forgejo can take ~5s to serve one /pulls page (it loads
@@ -89,6 +90,7 @@ async function requestJsonAtBase<T>(
       signal: AbortSignal.timeout(options.timeoutMs ?? REQUEST_TIMEOUT_MS)
     })
     if (!response.ok) {
+      await cancelUnreadResponseBody(response)
       return null
     }
     return (await response.json()) as T

--- a/src/main/global-fetch-call-site-audit.test.ts
+++ b/src/main/global-fetch-call-site-audit.test.ts
@@ -1,0 +1,71 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// Bare global fetch (unlike Electron's net.fetch) goes through Node's bundled
+// undici, which crashes the whole main process when an unread response body
+// pauses the HTTP/1 parser and the peer closes the socket (nodejs/undici#5360,
+// orca#8695). Every file below has been audited: real call sites consume or
+// cancel the body on all paths (see lib/unread-response-body.ts).
+const AUDITED_BARE_FETCH_FILES = new Set([
+  // HTTP call sites — body consumed or cancelled on every path, including !ok
+  'azure-devops/azure-devops-api-request.ts',
+  'bitbucket/client.ts',
+  'gitea/client.ts',
+  'orca-profiles/profile-cloud-client.ts',
+  'orca-profiles/profile-cloud-org-members-client.ts',
+  'rate-limits/codex-fetcher.ts',
+  'source-control/hosted-review-api-request.ts',
+  'speech/openai-transcription-client.ts',
+  // fetch appears only inside injected-page script source strings, not as a
+  // main-process call
+  'amp/hook-service.ts',
+  'opencode/hook-service.ts',
+  'pi/agent-status-extension-source.ts',
+  // local callback named `fetch` (git fetch), not HTTP
+  'ipc/worktree-remote.ts'
+])
+
+const BARE_FETCH_PATTERN = /(^|[^.\w])fetch\(/
+
+function bareFetchFiles(root: string): string[] {
+  const hits = new Set<string>()
+  for (const entry of readdirSync(root, { recursive: true, withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.ts')) {
+      continue
+    }
+    if (entry.name.endsWith('.test.ts') || entry.name.endsWith('.d.ts')) {
+      continue
+    }
+    const filePath = join(entry.parentPath, entry.name)
+    for (const line of readFileSync(filePath, 'utf8').split('\n')) {
+      const trimmed = line.trimStart()
+      if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) {
+        continue
+      }
+      if (BARE_FETCH_PATTERN.test(line)) {
+        hits.add(relative(root, filePath).split(sep).join('/'))
+        break
+      }
+    }
+  }
+  return [...hits].sort()
+}
+
+describe('main-process bare global fetch audit', () => {
+  it('keeps every bare fetch( call site in the audited allowlist', () => {
+    const found = bareFetchFiles(__dirname)
+    const unaudited = found.filter((file) => !AUDITED_BARE_FETCH_FILES.has(file))
+    expect(
+      unaudited,
+      'New bare global fetch( call sites in the main process must either use ' +
+        'Electron net.fetch or guarantee the response body is consumed/cancelled ' +
+        'on ALL paths (cancelUnreadResponseBody in lib/unread-response-body.ts), ' +
+        'then be added to AUDITED_BARE_FETCH_FILES. Unread bodies can crash the ' +
+        'whole main process (orca#8695).'
+    ).toEqual([])
+
+    const stale = [...AUDITED_BARE_FETCH_FILES].filter((file) => !found.includes(file)).sort()
+    expect(stale, 'Remove allowlist entries whose bare fetch( call sites are gone.').toEqual([])
+  })
+})

--- a/src/main/global-fetch-call-site-audit.test.ts
+++ b/src/main/global-fetch-call-site-audit.test.ts
@@ -2,70 +2,96 @@ import { readdirSync, readFileSync } from 'node:fs'
 import { join, relative, sep } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-// Bare global fetch (unlike Electron's net.fetch) goes through Node's bundled
-// undici, which crashes the whole main process when an unread response body
-// pauses the HTTP/1 parser and the peer closes the socket (nodejs/undici#5360,
-// orca#8695). Every file below has been audited: real call sites consume or
-// cancel the body on all paths (see lib/unread-response-body.ts).
-const AUDITED_BARE_FETCH_FILES = new Set([
+// Global fetch (bare or via globalThis/global — unlike Electron's net.fetch)
+// goes through Node's bundled undici, which can crash the whole process when
+// an unread response body pauses the HTTP/1 parser and the peer closes the
+// socket (nodejs/undici#5360, orca#8695). This applies to every Node process
+// we ship: Electron main, the CLI, and the SSH relay.
+//
+// Each entry below maps an audited file to its expected number of matching
+// lines. Real call sites must consume or cancel the body on every path,
+// including !response.ok (see main/lib/unread-response-body.ts). A count
+// change means a call site was added, removed, or moved: re-audit the file
+// and update the count.
+const AUDITED_GLOBAL_FETCH_LINES = new Map<string, number>([
   // HTTP call sites — body consumed or cancelled on every path, including !ok
-  'azure-devops/azure-devops-api-request.ts',
-  'bitbucket/client.ts',
-  'gitea/client.ts',
-  'orca-profiles/profile-cloud-client.ts',
-  'orca-profiles/profile-cloud-org-members-client.ts',
-  'rate-limits/codex-fetcher.ts',
-  'source-control/hosted-review-api-request.ts',
-  'speech/openai-transcription-client.ts',
+  ['main/azure-devops/azure-devops-api-request.ts', 1],
+  ['main/bitbucket/client.ts', 1],
+  ['main/gitea/client.ts', 1],
+  ['main/orca-profiles/profile-cloud-client.ts', 1],
+  ['main/orca-profiles/profile-cloud-org-members-client.ts', 1],
+  ['main/rate-limits/codex-fetcher.ts', 3],
+  ['main/runtime/relay/relay-http-client.ts', 2],
+  ['main/source-control/hosted-review-api-request.ts', 1],
+  ['main/speech/openai-transcription-client.ts', 1],
   // fetch appears only inside injected-page script source strings, not as a
-  // main-process call
-  'amp/hook-service.ts',
-  'opencode/hook-service.ts',
-  'pi/agent-status-extension-source.ts',
-  // local callback named `fetch` (git fetch), not HTTP
-  'ipc/worktree-remote.ts'
+  // call this process makes
+  ['main/amp/hook-service.ts', 1],
+  ['main/opencode/hook-service.ts', 1],
+  ['main/pi/agent-status-extension-source.ts', 1],
+  // local identifiers named `fetch` (git fetch), not HTTP
+  ['main/ipc/worktree-remote.ts', 2],
+  ['relay/git-handler.ts', 1],
+  // fetch mentioned only in a comment
+  ['main/ipc/feedback.ts', 1]
 ])
 
-const BARE_FETCH_PATTERN = /(^|[^.\w])fetch\(/
+// A line is a hit when it calls bare `fetch(` or touches `globalThis.fetch` /
+// `global.fetch` in any way (call, alias, fallback like `input.fetch ??
+// globalThis.fetch`). `typeof globalThis.fetch` type annotations are exempt.
+const GLOBAL_FETCH_LINE = /(^|[^.\w])fetch\(|(?<!typeof )\bglobal(This)?\.fetch\b/
 
-function bareFetchFiles(root: string): string[] {
-  const hits = new Set<string>()
-  for (const entry of readdirSync(root, { recursive: true, withFileTypes: true })) {
-    if (!entry.isFile() || !entry.name.endsWith('.ts')) {
-      continue
-    }
-    if (entry.name.endsWith('.test.ts') || entry.name.endsWith('.d.ts')) {
-      continue
-    }
-    const filePath = join(entry.parentPath, entry.name)
-    for (const line of readFileSync(filePath, 'utf8').split('\n')) {
-      const trimmed = line.trimStart()
-      if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) {
+const SCANNED_ROOTS = ['main', 'cli', 'relay']
+
+function globalFetchLineCounts(srcRoot: string): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const root of SCANNED_ROOTS) {
+    for (const entry of readdirSync(join(srcRoot, root), {
+      recursive: true,
+      withFileTypes: true
+    })) {
+      if (!entry.isFile() || !entry.name.endsWith('.ts')) {
         continue
       }
-      if (BARE_FETCH_PATTERN.test(line)) {
-        hits.add(relative(root, filePath).split(sep).join('/'))
-        break
+      if (
+        entry.name.endsWith('.test.ts') ||
+        entry.name.endsWith('.test-fixtures.ts') ||
+        entry.name.endsWith('.d.ts')
+      ) {
+        continue
+      }
+      const filePath = join(entry.parentPath, entry.name)
+      const content = readFileSync(filePath, 'utf8')
+      if (!GLOBAL_FETCH_LINE.test(content)) {
+        continue
+      }
+      const hits = content.split('\n').filter((line) => GLOBAL_FETCH_LINE.test(line)).length
+      if (hits > 0) {
+        counts.set(relative(srcRoot, filePath).split(sep).join('/'), hits)
       }
     }
   }
-  return [...hits].sort()
+  return counts
 }
 
-describe('main-process bare global fetch audit', () => {
-  it('keeps every bare fetch( call site in the audited allowlist', () => {
-    const found = bareFetchFiles(__dirname)
-    const unaudited = found.filter((file) => !AUDITED_BARE_FETCH_FILES.has(file))
+describe('global fetch call-site audit (main, cli, relay)', () => {
+  it('keeps every global-fetch line audited with its expected count', () => {
+    const found = globalFetchLineCounts(join(__dirname, '..'))
+
+    const drifted = [...found]
+      .filter(([file, count]) => AUDITED_GLOBAL_FETCH_LINES.get(file) !== count)
+      .map(([file, count]) => `${file}: found ${count} line(s)`)
+      .sort()
     expect(
-      unaudited,
-      'New bare global fetch( call sites in the main process must either use ' +
-        'Electron net.fetch or guarantee the response body is consumed/cancelled ' +
-        'on ALL paths (cancelUnreadResponseBody in lib/unread-response-body.ts), ' +
-        'then be added to AUDITED_BARE_FETCH_FILES. Unread bodies can crash the ' +
-        'whole main process (orca#8695).'
+      drifted,
+      'Global fetch (bare, globalThis.fetch, or global.fetch) uses undici, ' +
+        'where an unread response body can crash the whole process (orca#8695). ' +
+        'New or moved call sites must either use Electron net.fetch or consume/' +
+        'cancel the response body on ALL paths (cancelUnreadResponseBody in ' +
+        'main/lib/unread-response-body.ts), then update AUDITED_GLOBAL_FETCH_LINES.'
     ).toEqual([])
 
-    const stale = [...AUDITED_BARE_FETCH_FILES].filter((file) => !found.includes(file)).sort()
-    expect(stale, 'Remove allowlist entries whose bare fetch( call sites are gone.').toEqual([])
+    const stale = [...AUDITED_GLOBAL_FETCH_LINES.keys()].filter((file) => !found.has(file)).sort()
+    expect(stale, 'Remove audited entries whose global-fetch lines are gone.').toEqual([])
   })
 })

--- a/src/main/lib/unread-response-body.test-fixtures.ts
+++ b/src/main/lib/unread-response-body.test-fixtures.ts
@@ -1,0 +1,13 @@
+/** Response whose body reports cancellation, for asserting that error paths
+ *  cancel unread bodies (see unread-response-body.ts). */
+export function cancelTrackingResponse(status: number, onCancel: () => void): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode('<html>unread error body</html>'))
+    },
+    cancel() {
+      onCancel()
+    }
+  })
+  return new Response(body, { status })
+}

--- a/src/main/lib/unread-response-body.test.ts
+++ b/src/main/lib/unread-response-body.test.ts
@@ -1,27 +1,16 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { cancelUnreadResponseBody } from './unread-response-body'
-
-function responseWithCancelTracking(status = 500): {
-  response: Response
-  cancelled: () => boolean
-} {
-  let cancelled = false
-  const body = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode('unread error body'))
-    },
-    cancel() {
-      cancelled = true
-    }
-  })
-  return { response: new Response(body, { status }), cancelled: () => cancelled }
-}
+import { cancelTrackingResponse } from './unread-response-body.test-fixtures'
 
 describe('cancelUnreadResponseBody', () => {
   it('cancels an unread body stream', async () => {
-    const { response, cancelled } = responseWithCancelTracking()
-    await cancelUnreadResponseBody(response)
-    expect(cancelled()).toBe(true)
+    let cancelled = false
+    await cancelUnreadResponseBody(
+      cancelTrackingResponse(500, () => {
+        cancelled = true
+      })
+    )
+    expect(cancelled).toBe(true)
   })
 
   it('no-ops on a body-less response', async () => {
@@ -31,18 +20,8 @@ describe('cancelUnreadResponseBody', () => {
   })
 
   it('swallows cancellation failures on a locked stream', async () => {
-    const { response } = responseWithCancelTracking()
+    const response = cancelTrackingResponse(500, () => {})
     response.body?.getReader()
     await expect(cancelUnreadResponseBody(response)).resolves.toBeUndefined()
-  })
-
-  it('swallows a rejecting cancel', async () => {
-    const response = {
-      body: { cancel: vi.fn().mockRejectedValue(new Error('already destroyed')) }
-    } as unknown as Response
-    await expect(cancelUnreadResponseBody(response)).resolves.toBeUndefined()
-    expect(
-      (response.body as unknown as { cancel: ReturnType<typeof vi.fn> }).cancel
-    ).toHaveBeenCalled()
   })
 })

--- a/src/main/lib/unread-response-body.test.ts
+++ b/src/main/lib/unread-response-body.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+import { cancelUnreadResponseBody } from './unread-response-body'
+
+function responseWithCancelTracking(status = 500): {
+  response: Response
+  cancelled: () => boolean
+} {
+  let cancelled = false
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode('unread error body'))
+    },
+    cancel() {
+      cancelled = true
+    }
+  })
+  return { response: new Response(body, { status }), cancelled: () => cancelled }
+}
+
+describe('cancelUnreadResponseBody', () => {
+  it('cancels an unread body stream', async () => {
+    const { response, cancelled } = responseWithCancelTracking()
+    await cancelUnreadResponseBody(response)
+    expect(cancelled()).toBe(true)
+  })
+
+  it('no-ops on a body-less response', async () => {
+    await expect(
+      cancelUnreadResponseBody(new Response(null, { status: 500 }))
+    ).resolves.toBeUndefined()
+  })
+
+  it('swallows cancellation failures on a locked stream', async () => {
+    const { response } = responseWithCancelTracking()
+    response.body?.getReader()
+    await expect(cancelUnreadResponseBody(response)).resolves.toBeUndefined()
+  })
+
+  it('swallows a rejecting cancel', async () => {
+    const response = {
+      body: { cancel: vi.fn().mockRejectedValue(new Error('already destroyed')) }
+    } as unknown as Response
+    await expect(cancelUnreadResponseBody(response)).resolves.toBeUndefined()
+    expect(
+      (response.body as unknown as { cancel: ReturnType<typeof vi.fn> }).cancel
+    ).toHaveBeenCalled()
+  })
+})

--- a/src/main/lib/unread-response-body.ts
+++ b/src/main/lib/unread-response-body.ts
@@ -1,0 +1,17 @@
+/**
+ * Cancel a fetch Response body that no code path will read.
+ *
+ * Why: Node's bundled undici (used by global fetch, unlike Electron's
+ * net.fetch) crashes the whole process with an uncatchable AssertionError
+ * when a response body large enough to pause the HTTP/1 parser is left
+ * unread and the peer closes the socket (nodejs/undici#5360, orca#8695).
+ * Every main-process global-fetch call site must consume or cancel the
+ * body on all paths, including !response.ok early returns.
+ */
+export async function cancelUnreadResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel()
+  } catch {
+    // Cancelling an already-errored, locked, or closed stream is harmless.
+  }
+}

--- a/src/main/lib/unread-response-body.ts
+++ b/src/main/lib/unread-response-body.ts
@@ -1,12 +1,7 @@
 /**
- * Cancel a fetch Response body that no code path will read.
- *
- * Why: Node's bundled undici (used by global fetch, unlike Electron's
- * net.fetch) crashes the whole process with an uncatchable AssertionError
- * when a response body large enough to pause the HTTP/1 parser is left
- * unread and the peer closes the socket (nodejs/undici#5360, orca#8695).
- * Every main-process global-fetch call site must consume or cancel the
- * body on all paths, including !response.ok early returns.
+ * Cancel a fetch Response body that no code path will read. Why: leaving it
+ * unread can crash the whole process from inside Node's bundled undici
+ * (nodejs/undici#5360, orca#8695); see global-fetch-call-site-audit.test.ts.
  */
 export async function cancelUnreadResponseBody(response: Response): Promise<void> {
   try {

--- a/src/main/orca-profiles/profile-cloud-client.test.ts
+++ b/src/main/orca-profiles/profile-cloud-client.test.ts
@@ -248,4 +248,20 @@ describe('Orca cloud client', () => {
       }
     })
   })
+
+  it('cancels the unread error-response body so bundled undici cannot crash on socket close', async () => {
+    let cancelledBodies = 0
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('<html>gateway error page</html>'))
+      },
+      cancel() {
+        cancelledBodies += 1
+      }
+    })
+    fetchMock.mockResolvedValue(new Response(body, { status: 502 }))
+
+    await expect(refreshOrcaCloudCapabilities(config, session)).rejects.toThrow()
+    expect(cancelledBodies).toBe(1)
+  })
 })

--- a/src/main/orca-profiles/profile-cloud-client.test.ts
+++ b/src/main/orca-profiles/profile-cloud-client.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { cancelTrackingResponse } from '../lib/unread-response-body.test-fixtures'
 import type { OrcaCloudAuthConfig } from './profile-cloud-auth-config'
 import type { OrcaCloudSession } from './profile-cloud-session-store'
 import {
@@ -251,15 +252,11 @@ describe('Orca cloud client', () => {
 
   it('cancels the unread error-response body so bundled undici cannot crash on socket close', async () => {
     let cancelledBodies = 0
-    const body = new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(new TextEncoder().encode('<html>gateway error page</html>'))
-      },
-      cancel() {
+    fetchMock.mockResolvedValue(
+      cancelTrackingResponse(502, () => {
         cancelledBodies += 1
-      }
-    })
-    fetchMock.mockResolvedValue(new Response(body, { status: 502 }))
+      })
+    )
 
     await expect(refreshOrcaCloudCapabilities(config, session)).rejects.toThrow()
     expect(cancelledBodies).toBe(1)

--- a/src/main/orca-profiles/profile-cloud-client.ts
+++ b/src/main/orca-profiles/profile-cloud-client.ts
@@ -6,6 +6,7 @@ import type {
 import type { OrcaCloudAuthConfig } from './profile-cloud-auth-config'
 import type { OrcaCloudSession } from './profile-cloud-session-store'
 import type { OrcaCloudSessionExchangeResponse } from './profile-cloud-session-exchange'
+import { cancelUnreadResponseBody } from '../lib/unread-response-body'
 
 type ExchangeCodeArgs = {
   code: string
@@ -173,6 +174,7 @@ async function postJson<T>(url: string, body: unknown, accessToken?: string): Pr
     signal: AbortSignal.timeout(CLOUD_REQUEST_TIMEOUT_MS)
   })
   if (!response.ok) {
+    await cancelUnreadResponseBody(response)
     throw new OrcaCloudRequestError(response.status)
   }
   return (await response.json()) as T

--- a/src/main/rate-limits/codex-fetcher-backend.test.ts
+++ b/src/main/rate-limits/codex-fetcher-backend.test.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path'
+import { cancelTrackingResponse } from '../lib/unread-response-body.test-fixtures'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { childSpawnMock, readFileMock, ptySpawnMock } = vi.hoisted(() => ({
@@ -201,15 +202,11 @@ describe('Codex backend rate-limit requests', () => {
       })
     )
     let cancelledBodies = 0
-    const body = new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(new TextEncoder().encode('<html>rate-limited error page</html>'))
-      },
-      cancel() {
+    vi.mocked(fetch).mockResolvedValue(
+      cancelTrackingResponse(429, () => {
         cancelledBodies += 1
-      }
-    })
-    vi.mocked(fetch).mockResolvedValue(new Response(body, { status: 429 }))
+      })
+    )
 
     await expect(
       consumeCodexRateLimitResetCredit({

--- a/src/main/rate-limits/codex-fetcher-backend.test.ts
+++ b/src/main/rate-limits/codex-fetcher-backend.test.ts
@@ -193,4 +193,30 @@ describe('Codex backend rate-limit requests', () => {
       })
     )
   })
+
+  it('cancels the unread error-response body so bundled undici cannot crash on socket close', async () => {
+    readFileMock.mockResolvedValue(
+      JSON.stringify({
+        tokens: { access_token: 'access-token', account_id: 'account-id' }
+      })
+    )
+    let cancelledBodies = 0
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('<html>rate-limited error page</html>'))
+      },
+      cancel() {
+        cancelledBodies += 1
+      }
+    })
+    vi.mocked(fetch).mockResolvedValue(new Response(body, { status: 429 }))
+
+    await expect(
+      consumeCodexRateLimitResetCredit({
+        codexHomePath: '/managed/codex-home',
+        idempotencyKey: 'redeem-429'
+      })
+    ).rejects.toThrow('Codex reset failed: HTTP 429')
+    expect(cancelledBodies).toBe(1)
+  })
 })

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -9,6 +9,7 @@ import type {
 import { spawn } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
+import { cancelUnreadResponseBody } from '../lib/unread-response-body'
 import { join } from 'node:path'
 import { probeCodexAuthPresence } from './codex-auth-presence'
 import { resolveCodexCommand } from '../codex-cli/command'
@@ -381,6 +382,7 @@ async function fetchBackendRateLimitResetCredits(
     signal
   })
   if (!response.ok) {
+    await cancelUnreadResponseBody(response)
     return null
   }
   const payload = (await response.json()) as BackendRateLimitResetCreditsResponse
@@ -448,6 +450,7 @@ export async function consumeCodexRateLimitResetCredit(options: {
     }
   )
   if (!response.ok) {
+    await cancelUnreadResponseBody(response)
     throw new Error(`Codex reset failed: HTTP ${response.status}`)
   }
   const payload = (await response.json()) as BackendConsumeRateLimitResetCreditResponse
@@ -531,6 +534,7 @@ async function fetchViaBackend(
     signal
   })
   if (!response.ok) {
+    await cancelUnreadResponseBody(response)
     return null
   }
   const payload = (await response.json()) as BackendUsageResponse

--- a/src/main/runtime/relay/relay-http-client.test.ts
+++ b/src/main/runtime/relay/relay-http-client.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import nacl from 'tweetnacl'
+import { cancelTrackingResponse } from '../../lib/unread-response-body.test-fixtures'
 import { exchangeRelayAuthorization, requestRelayAssignment } from './relay-http-client'
 
 describe('relay HTTP client', () => {
@@ -71,5 +72,36 @@ describe('relay HTTP client', () => {
         fetch
       })
     ).rejects.toThrow('relay_assignment_failed_502')
+  })
+
+  it('cancels unread error-response bodies so bundled undici cannot crash on socket close', async () => {
+    const keypair = nacl.box.keyPair()
+    let cancelledBodies = 0
+    const fetch = vi.fn<typeof globalThis.fetch>(async () =>
+      cancelTrackingResponse(503, () => {
+        cancelledBodies += 1
+      })
+    )
+
+    await expect(
+      exchangeRelayAuthorization({
+        endpoint: 'https://auth.example/v1/desktop/auth/relay-token',
+        accessToken: 'ordinary-access-token',
+        keypair: {
+          ...keypair,
+          publicKeyB64: Buffer.from(keypair.publicKey).toString('base64')
+        },
+        fetch
+      })
+    ).rejects.toThrow()
+    await expect(
+      requestRelayAssignment({
+        directorUrl: 'https://relay.example',
+        relayToken: 'scoped-token',
+        relayHostId: 'AbCdEf0123_-xyZ9',
+        fetch
+      })
+    ).rejects.toThrow()
+    expect(cancelledBodies).toBe(2)
   })
 })

--- a/src/main/runtime/relay/relay-http-client.ts
+++ b/src/main/runtime/relay/relay-http-client.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto'
 import { z } from 'zod'
 import type { E2EEKeypair } from '../e2ee-keypair'
+import { cancelUnreadResponseBody } from '../../lib/unread-response-body'
 
 const RelayTokenResponseSchema = z
   .object({
@@ -69,6 +70,7 @@ export async function exchangeRelayAuthorization(input: {
     body: JSON.stringify({ relayHostId, hostPublicKeyB64: input.keypair.publicKeyB64 })
   })
   if (!response.ok) {
+    await cancelUnreadResponseBody(response)
     throw new RelayHttpError('token-exchange', response.status)
   }
   const parsed = RelayTokenResponseSchema.safeParse(await response.json())
@@ -96,6 +98,7 @@ export async function requestRelayAssignment(input: {
     body: JSON.stringify({ v: 1, relayHostId: input.relayHostId })
   })
   if (!response.ok) {
+    await cancelUnreadResponseBody(response)
     throw new RelayHttpError('assignment', response.status)
   }
   const parsed = AssignmentResponseSchema.safeParse(await response.json())


### PR DESCRIPTION
## Summary

Part of #8695. Orca's bundled runtime (Electron 43.1.0 / Node 24.18.0 / undici 7.28.0) crashes the **entire main process** with an uncatchable `AssertionError: assert(!this.paused)` when a `fetch` response body big enough to pause undici's HTTP/1 parser (≥64 KiB) is left unread and the peer closes the socket (upstream nodejs/undici#5360). Application-level error handling cannot catch it; the user sees the "A JavaScript error occurred in the main process" dialog and the app closes.

No Electron release on any channel contains the upstream fix yet (undici's fix PR nodejs/undici#5474 shipped in undici 8.6.0; the 7.x backport nodejs/undici#5553 is still open, so no Node 24.x — and therefore no Electron — has it). This PR removes every trigger in our own code instead of waiting:

- **New `src/main/lib/unread-response-body.ts`** — `cancelUnreadResponseBody(response)` cancels a body no code path will read.
- **Applied at all 9 undici-exposed call sites** that dropped bodies on `!response.ok`: Gitea/Bitbucket/Azure DevOps clients, Orca cloud profile client, Codex backend rate-limit fetcher (3 sites), and the relay HTTP client (2 sites — token exchange and assignment, which reach the cloud director via `globalThis.fetch`).
- **New audit test `src/main/global-fetch-call-site-audit.test.ts`** — scans `src/main`, `src/cli`, and `src/relay` (all Node processes we ship) for bare `fetch(` / `globalThis.fetch` / `global.fetch` lines and pins each audited file to its expected count, so a new or moved call site fails CI until it is audited. `net.fetch` call sites (Chromium network stack) are unaffected and exempt.

Deterministic repro + verification against the exact shipped runtime (details below): the unfixed pattern crashes 100% of runs on both the repo's Electron 43.1.0 and the installed Orca.app binary; the fixed pattern survives 14/14 runs across immediate- and delayed-FIN timings.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 12 locally failing files are pre-existing: the same files fail identically on a clean `origin/main` worktree (6 stable + parallel-run flake; verified by isolated re-runs on both trees). All 60 test files in the touched directories pass.
- [x] `pnpm build`
- [x] Added regression tests: per-client tests assert the `!ok` path cancels the body (shared `unread-response-body.test-fixtures.ts`); helper unit tests; the call-site audit test failed on a real unguarded site (relay client) before the fix and passes after.

**Runtime verification on the vulnerable runtime** (Electron 43.1.0, `ELECTRON_RUN_AS_NODE`, localhost TCP server sending a 64 KiB body + FIN):
- Unfixed pattern (body dropped on `!ok`): crashes with the exact stack from #8695, 100% reproducible, also on the installed Orca.app binary.
- This PR's pattern (compiled `cancelUnreadResponseBody` from this branch): survives every run, immediate and delayed FIN.
- Version bisect on the same Electron binary: userland undici 7.28.0/8.3.0 crash; 8.6.0/8.7.0 (contain the upstream fix) survive — confirming the fix boundary and that bundled 7.28.0 is unfixed.

## AI Review Report

Ran an 8-angle review (line-by-line, removed-behavior, cross-file tracer, reuse, simplification, efficiency, altitude, conventions) with adversarial verification. Key outcomes:

- **Caught and fixed a missed call site**: `relay-http-client.ts` reaches the cloud director via `globalThis.fetch` and dropped error bodies unread — invisible to the initial bare-`fetch(` sweep. Both sites now cancel, with a regression test.
- **Hardened the audit test from review findings**: matches `globalThis.fetch`/`global.fetch` spellings (`typeof` annotations exempt), scans `src/cli` and `src/relay` too, uses per-file line counts so an allowlisted file cannot silently gain a new call site, and dropped a comment-skip heuristic that was wrong in both directions.
- **Cross-platform**: no shortcuts, shell, or UI touched. The audit test normalizes paths with `node:path` `sep` for Windows and uses `readdirSync(recursive)`; behavior is identical on macOS/Linux/Windows. The crash and fix were verified on macOS; the defect is in cross-platform bundled undici, not platform code.
- Deferred (follow-up, not this PR): consolidating the three near-identical provider `requestJson` helpers onto the shared hosted-review JSON request seam so the guard is structural rather than per-site.

## Security Audit

- The change only cancels response body streams on error paths; no request construction, auth header, redirect policy, or origin validation changed (relay client's `isAllowedRelayOrigin` and profile-cloud `redirect: 'error'` untouched).
- Removes a remote-crash vector: any reachable HTTP endpoint (or intermediary proxy) could previously kill the main process — and the SSH relay process — with a large error page plus connection close.
- `cancelUnreadResponseBody` swallows only cancellation errors on an already-dead stream; request errors still propagate as before.
- No new dependencies, no IPC changes. The audit test reads repo source files at test time only.

## Notes

- **This does not close #8695**: third-party code in the main process could still trigger the undici assertion. The complete fix requires an Electron release whose Node bundles undici ≥8.6.0 semantics (7.x backport nodejs/undici#5553 → next Node 24.x → Electron). Worth adopting the moment it exists.
- The relay finding means this crash class also affected SSH relay reliability (a dying relay presents as the SSH connection dropping), not just the desktop app.
- Follow-up candidate: route these JSON clients through one shared request helper (see review report) and/or migrate them to `net.fetch` for proxy consistency — both are behavior changes kept out of this crash fix.

Made with [Orca](https://github.com/stablyai/orca) 🐋
