### PR TITLE
fix(git): enable parallel worktree checkout

### DIFF
--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -1308,7 +1308,7 @@ branch refs/heads/main
     const calls = getGitCalls()
     expect(calls).toEqual(
       expect.arrayContaining([
-        'git worktree add --no-checkout --no-track -b feature/test /repo-feature',
+        'git -c checkout.workers=0 worktree add --no-checkout --no-track -b feature/test /repo-feature',
         'git config --get push.autoSetupRemote',
         'git config --local push.autoSetupRemote true',
         'git sparse-checkout init --cone',

--- a/src/main/git/worktree.test.ts
+++ b/src/main/git/worktree.test.ts
@@ -33,6 +33,8 @@ import {
   WORKTREE_ADD_TIMEOUT_MS
 } from './worktree'
 
+const PARALLEL_CHECKOUT_GIT_ARGS = ['-c', 'checkout.workers=0']
+
 beforeEach(() => {
   clearGitCapabilityStateForTests()
 })
@@ -685,6 +687,7 @@ describe('addWorktree', () => {
       [['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'], { cwd: '/repo' }],
       [
         [
+          ...PARALLEL_CHECKOUT_GIT_ARGS,
           'worktree',
           'add',
           '--no-track',
@@ -710,16 +713,16 @@ describe('addWorktree', () => {
     ])
   })
 
-  it('checks out a selected existing local branch without creating a new branch', async () => {
+  it('places parallel config before worktree add for a selected existing branch', async () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
 
-    await addWorktree('/repo', '/repo-feature', 'feature/test', 'feature/test', false, false, {
+    await addWorktree('/repo', '/repo feature', 'feature/test', 'feature/test', false, false, {
       checkoutExistingBranch: true
     })
 
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
       [
-        ['worktree', 'add', '/repo-feature', 'feature/test'],
+        [...PARALLEL_CHECKOUT_GIT_ARGS, 'worktree', 'add', '/repo feature', 'feature/test'],
         { cwd: '/repo', timeout: WORKTREE_ADD_TIMEOUT_MS }
       ]
     ])
@@ -736,7 +739,12 @@ describe('addWorktree', () => {
     })
 
     const worktreeAddCall = gitExecFileAsyncMock.mock.calls.find(
-      ([argv]) => Array.isArray(argv) && argv[0] === 'worktree' && argv[1] === 'add'
+      ([argv]) =>
+        Array.isArray(argv) &&
+        argv[0] === '-c' &&
+        argv[1] === 'checkout.workers=0' &&
+        argv[2] === 'worktree' &&
+        argv[3] === 'add'
     )
     expect(worktreeAddCall?.[1]).toMatchObject({ timeout: WORKTREE_ADD_TIMEOUT_MS })
     expect(WORKTREE_ADD_TIMEOUT_MS).toBeGreaterThan(0)
@@ -750,7 +758,15 @@ describe('addWorktree', () => {
 
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
       [
-        ['worktree', 'add', '--no-track', '-b', 'feature/no-base', '/repo-feature'],
+        [
+          ...PARALLEL_CHECKOUT_GIT_ARGS,
+          'worktree',
+          'add',
+          '--no-track',
+          '-b',
+          'feature/no-base',
+          '/repo-feature'
+        ],
         { cwd: '/repo', timeout: WORKTREE_ADD_TIMEOUT_MS }
       ],
       [['config', '--get', 'push.autoSetupRemote'], { cwd: '/repo-feature' }]
@@ -825,6 +841,7 @@ describe('addWorktree', () => {
       [['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'], { cwd: '/repo' }],
       [
         [
+          ...PARALLEL_CHECKOUT_GIT_ARGS,
           'worktree',
           'add',
           '--no-track',
@@ -863,6 +880,7 @@ describe('addWorktree', () => {
       [['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'], { cwd: '/repo' }],
       [
         [
+          ...PARALLEL_CHECKOUT_GIT_ARGS,
           'worktree',
           'add',
           '--no-track',
@@ -902,6 +920,7 @@ describe('addWorktree', () => {
       [['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'], { cwd: '/repo' }],
       [
         [
+          ...PARALLEL_CHECKOUT_GIT_ARGS,
           'worktree',
           'add',
           '--no-track',
@@ -942,6 +961,7 @@ describe('addWorktree', () => {
       [['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'], { cwd: '/repo' }],
       [
         [
+          ...PARALLEL_CHECKOUT_GIT_ARGS,
           'worktree',
           'add',
           '--no-track',
@@ -992,6 +1012,7 @@ describe('addWorktree', () => {
       [['reset', '--hard', 'remote-main'], { cwd: '/repo' }],
       [
         [
+          ...PARALLEL_CHECKOUT_GIT_ARGS,
           'worktree',
           'add',
           '--no-track',
@@ -1229,6 +1250,7 @@ describe('addWorktree', () => {
       'refs/remotes/origin/main^{commit}'
     ])
     expect(gitExecFileAsyncMock.mock.calls[7]?.[0]).toEqual([
+      ...PARALLEL_CHECKOUT_GIT_ARGS,
       'worktree',
       'add',
       '--no-track',
@@ -1278,6 +1300,7 @@ describe('addWorktree', () => {
       ],
       [
         [
+          ...PARALLEL_CHECKOUT_GIT_ARGS,
           'worktree',
           'add',
           '--no-track',
@@ -1350,6 +1373,7 @@ describe('addWorktree', () => {
       ],
       [
         [
+          ...PARALLEL_CHECKOUT_GIT_ARGS,
           'worktree',
           'add',
           '--no-track',
@@ -1435,6 +1459,7 @@ describe('addWorktree', () => {
       ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'],
       ['rev-list', '--left-right', '--count', 'refs/heads/main...refs/remotes/origin/main'],
       [
+        ...PARALLEL_CHECKOUT_GIT_ARGS,
         'worktree',
         'add',
         '--no-track',
@@ -1543,6 +1568,7 @@ describe('addWorktree', () => {
     ])
     expect(gitExecFileAsyncMock.mock.calls[1]).toEqual([
       [
+        ...PARALLEL_CHECKOUT_GIT_ARGS,
         'worktree',
         'add',
         '--no-track',
@@ -1569,6 +1595,7 @@ describe('addWorktree', () => {
       ['rev-parse', '--verify', '--quiet', 'refs/remotes/release/main^{commit}'],
       ['rev-parse', '--verify', '--quiet', 'refs/heads/release/main^{commit}'],
       [
+        ...PARALLEL_CHECKOUT_GIT_ARGS,
         'worktree',
         'add',
         '--no-track',
@@ -1610,6 +1637,7 @@ describe('addWorktree', () => {
       ['rev-parse', '--verify', '--quiet', 'refs/remotes/release/main^{commit}'],
       ['rev-parse', '--verify', '--quiet', 'refs/heads/release/main^{commit}'],
       [
+        ...PARALLEL_CHECKOUT_GIT_ARGS,
         'worktree',
         'add',
         '--no-track',
@@ -1660,6 +1688,52 @@ describe('addWorktree', () => {
       'reset',
       '--hard',
       'remote-upstream-main'
+    ])
+  })
+
+  it('uses parallel checkout for sparse worktrees without changing argument boundaries', async () => {
+    resolveRemoteBase()
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+    resolveCreationBaseConfigWrite()
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'true\n' }) // push.autoSetupRemote already set
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // sparse-checkout init
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // sparse-checkout set
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // checkout
+
+    await expect(
+      addSparseWorktree(
+        '/repo',
+        '/repo sparse feature',
+        'feature/sparse',
+        ['src folder', '--generated'],
+        'origin/main'
+      )
+    ).resolves.toEqual({})
+
+    expect(gitExecFileAsyncMock.mock.calls.map(([args]) => args)).toEqual([
+      ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'],
+      [
+        ...PARALLEL_CHECKOUT_GIT_ARGS,
+        'worktree',
+        'add',
+        '--no-checkout',
+        '--no-track',
+        '-b',
+        'feature/sparse',
+        '/repo sparse feature',
+        'refs/remotes/origin/main'
+      ],
+      [
+        'config',
+        '--local',
+        '--replace-all',
+        'branch.feature/sparse.base',
+        'refs/remotes/origin/main'
+      ],
+      ['config', '--get', 'push.autoSetupRemote'],
+      ['sparse-checkout', 'init', '--cone'],
+      ['sparse-checkout', 'set', '--', 'src folder', '--generated'],
+      [...PARALLEL_CHECKOUT_GIT_ARGS, 'checkout', 'feature/sparse']
     ])
   })
 

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -84,6 +84,10 @@ const SPARSE_CHECKOUT_DETECTION_CONCURRENCY = 8
 
 const PRUNABLE_EXISTENCE_PROBE_CONCURRENCY = 8
 
+// Why: Git 2.32+ can overlap checkout writes across CPU cores, while older
+// versions safely ignore the unknown config and keep their serial path.
+const PARALLEL_CHECKOUT_GIT_ARGS = ['-c', 'checkout.workers=0'] as const
+
 // Why: bound `git worktree add` so a OneDrive cloud-placeholder base path can't
 // stall its checkout writes for minutes (STA-1292) — a stuck create then fails
 // fast instead of spinning forever. Generous enough not to kill a legit large
@@ -976,7 +980,7 @@ async function performAddWorktree(
 ): Promise<AddWorktreeResult> {
   let localBaseRefRefresh: LocalBaseRefRefreshResult | undefined
   let localBaseRefUpdateSuggestion: LocalBaseRefUpdateSuggestion | undefined
-  const args = ['worktree', 'add']
+  const args = [...PARALLEL_CHECKOUT_GIT_ARGS, 'worktree', 'add']
   let effectiveBase: string | undefined
   if (noCheckout) {
     args.push('--no-checkout')
@@ -1126,7 +1130,10 @@ export async function addSparseWorktree(
       ['sparse-checkout', 'set', '--', ...directories],
       gitExecOptions(worktreePath, options)
     )
-    await gitExecFileAsync(['checkout', branch], gitExecOptions(worktreePath, options))
+    await gitExecFileAsync(
+      [...PARALLEL_CHECKOUT_GIT_ARGS, 'checkout', branch],
+      gitExecOptions(worktreePath, options)
+    )
     return addResult
   } catch (error) {
     const wrapped: SparseWorktreeCreateError =


### PR DESCRIPTION
## Summary

- opt local and WSL `git worktree add` into Git's parallel checkout workers
- apply the same checkout config to the materializing `git checkout` step for sparse worktrees
- preserve existing option ordering, branch/ref operands, paths with spaces, sparse `--` boundaries, and rollback behavior

Fixes #9139.

## ELI5

Creating a worktree writes thousands of files. Git can overlap those writes across CPU cores, which reduces time spent waiting on per-file filesystem and antivirus work. Orca now asks Git to use that built-in mode without changing what gets checked out.

## User Regression Tradeoffs

- Git 2.32+ can use parallel workers; older supported Git versions ignore the unknown config and keep their existing serial behavior.
- The speedup depends on storage, antivirus, repository size, and CPU count; checkout results and failure handling are unchanged.
- SSH relay worktree creation uses a separate command path and remains behaviorally unchanged and unoptimized in this focused local/WSL fix.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` - changed-file `oxlint`/`oxfmt` and max-lines checks pass; full lint reaches two pre-existing switch-exhaustiveness errors on `upstream/main` in `native-chat-session-option-labels.ts:47` and `skill-freshness-group.tsx:101`
- [x] `pnpm typecheck`
- [ ] `pnpm test` - full Windows suite completed with 133 unrelated existing failures in path/symlink, PTY, WSL, timing, and source-boundary suites; focused worktree coverage passes 101/101
- [x] `pnpm build`
- [x] Added regression coverage for ordinary/existing-branch creation, sparse materialization, global-option ordering, spaces, option-like sparse operands, and sparse rollback

Focused command:

```text
pnpm exec vitest run --config config/vitest.config.ts src/main/git/worktree.test.ts src/main/git/remove-worktree.test.ts
```

## AI Review Report

The change was independently reviewed after implementation and rebased onto the latest `upstream/main`.

- Correctness: `-c checkout.workers=0` stays before the Git subcommand; every existing branch/base/path operand and timeout is preserved. Sparse worktrees receive the config on both `worktree add --no-checkout` and the later checkout that actually materializes files.
- Cross-platform: the fixed Git config is platform-neutral and passed as argv, not through a shell. Native macOS/Linux/Windows and WSL use this path; no shortcuts, labels, path normalization, or Electron platform branches changed.
- SSH/remote/local: local and WSL behavior is optimized. The separate SSH relay path was inspected and intentionally left unchanged for this issue, so remote semantics do not regress.
- Agents and integrations: no agent, provider, terminal, integration, or git-host-specific behavior changed.
- Performance: worktree creation adds no probes or subprocesses; it only enables Git's built-in checkout worker pool. Gains are workload-dependent.
- UI quality: no UI or interaction code changed.

## Security Audit

No input execution, shell interpolation, authentication, secret, dependency, filesystem-permission, or IPC surface is introduced. The new arguments are fixed literals passed to the existing Git argv runner. User-controlled refs, paths, and sparse directories remain separate operands, including the existing `--` separator for sparse paths.

## Notes

- Branch is one commit on current `main`.
- X handle: not provided.