### PR TITLE
feat(settings): add a project default directory for the folder pickers

### DIFF
--- a/src/main/ipc/repos-pick-default-path.test.ts
+++ b/src/main/ipc/repos-pick-default-path.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { resolvePickerDefaultPath } from './repos-pick-default-path'
+
+describe('resolvePickerDefaultPath', () => {
+  it('uses the explicit arg when provided', () => {
+    expect(resolvePickerDefaultPath('/arg/path', '/setting/path')).toBe('/arg/path')
+  })
+
+  it('falls back to the saved setting when no arg', () => {
+    expect(resolvePickerDefaultPath(undefined, '/setting/path')).toBe('/setting/path')
+  })
+
+  it('returns undefined when neither is set (preserves OS default)', () => {
+    expect(resolvePickerDefaultPath(undefined, undefined)).toBeUndefined()
+  })
+
+  it('treats an empty saved setting as unset', () => {
+    expect(resolvePickerDefaultPath(undefined, '')).toBeUndefined()
+  })
+})

--- a/src/main/ipc/repos-pick-default-path.test.ts
+++ b/src/main/ipc/repos-pick-default-path.test.ts
@@ -2,19 +2,19 @@ import { describe, expect, it } from 'vitest'
 import { resolvePickerDefaultPath } from './repos-pick-default-path'
 
 describe('resolvePickerDefaultPath', () => {
-  it('uses the explicit arg when provided', () => {
-    expect(resolvePickerDefaultPath('/arg/path', '/setting/path')).toBe('/arg/path')
+  it('returns the provided path', () => {
+    expect(resolvePickerDefaultPath('/projects')).toBe('/projects')
   })
 
-  it('falls back to the saved setting when no arg', () => {
-    expect(resolvePickerDefaultPath(undefined, '/setting/path')).toBe('/setting/path')
+  it('trims surrounding whitespace', () => {
+    expect(resolvePickerDefaultPath('  /projects  ')).toBe('/projects')
   })
 
-  it('returns undefined when neither is set (preserves OS default)', () => {
-    expect(resolvePickerDefaultPath(undefined, undefined)).toBeUndefined()
+  it('returns undefined when absent', () => {
+    expect(resolvePickerDefaultPath(undefined)).toBeUndefined()
   })
 
-  it('treats an empty saved setting as unset', () => {
-    expect(resolvePickerDefaultPath(undefined, '')).toBeUndefined()
+  it('treats whitespace as unset', () => {
+    expect(resolvePickerDefaultPath('  ')).toBeUndefined()
   })
 })

--- a/src/main/ipc/repos-pick-default-path.ts
+++ b/src/main/ipc/repos-pick-default-path.ts
@@ -1,10 +1,5 @@
-// Resolves the effective defaultPath for a project/repo folder picker.
-// Explicit arg wins over the saved global setting; an empty/absent value
-// yields undefined so the dialog keeps the OS last-used location.
-export function resolvePickerDefaultPath(
-  argPath: string | undefined,
-  settingPath: string | undefined
-): string | undefined {
-  const candidate = argPath?.trim() || settingPath?.trim()
-  return candidate ? candidate : undefined
+// Why: omitting defaultPath preserves the native dialog's last-used location
+// when a caller has no project-specific starting directory.
+export function resolvePickerDefaultPath(path: string | undefined): string | undefined {
+  return path?.trim() || undefined
 }

--- a/src/main/ipc/repos-pick-default-path.ts
+++ b/src/main/ipc/repos-pick-default-path.ts
@@ -1,0 +1,10 @@
+// Resolves the effective defaultPath for a project/repo folder picker.
+// Explicit arg wins over the saved global setting; an empty/absent value
+// yields undefined so the dialog keeps the OS last-used location.
+export function resolvePickerDefaultPath(
+  argPath: string | undefined,
+  settingPath: string | undefined
+): string | undefined {
+  const candidate = argPath?.trim() || settingPath?.trim()
+  return candidate ? candidate : undefined
+}

--- a/src/main/ipc/repos-picker.test.ts
+++ b/src/main/ipc/repos-picker.test.ts
@@ -56,6 +56,14 @@ describe('repos folder pickers', () => {
     getSettings: vi.fn().mockReturnValue({})
   }
 
+  const callPickFolder = (): Promise<string | null> => {
+    const handler = handlers.get('repos:pickFolder')
+    if (!handler) {
+      throw new Error('repos:pickFolder handler was never registered')
+    }
+    return handler(null, undefined) as Promise<string | null>
+  }
+
   const callPickFolders = (): Promise<string[]> => {
     const handler = handlers.get('repos:pickFolders')
     if (!handler) {
@@ -80,8 +88,22 @@ describe('repos folder pickers', () => {
     })
     removeHandlerMock.mockReset()
     showOpenDialogMock.mockReset()
+    mockStore.getSettings.mockReset().mockReturnValue({})
 
     registerRepoHandlers(mockWindow as never, mockStore as never)
+  })
+
+  it('applies the saved projectDefaultPath as the pickFolder dialog default', async () => {
+    const projectDefault = join(sep, 'some', 'dir')
+    mockStore.getSettings.mockReturnValue({ projectDefaultPath: projectDefault })
+    showOpenDialogMock.mockResolvedValue({ canceled: true, filePaths: [] })
+
+    await callPickFolder()
+
+    expect(showOpenDialogMock).toHaveBeenCalledWith(mockWindow, {
+      properties: ['openDirectory'],
+      defaultPath: projectDefault
+    })
   })
 
   it('registers the multi-folder picker with handler cleanup', () => {

--- a/src/main/ipc/repos-picker.test.ts
+++ b/src/main/ipc/repos-picker.test.ts
@@ -52,7 +52,8 @@ describe('repos folder pickers', () => {
     addRepo: vi.fn(),
     removeProject: vi.fn(),
     getRepo: vi.fn(),
-    updateRepo: vi.fn()
+    updateRepo: vi.fn(),
+    getSettings: vi.fn().mockReturnValue({})
   }
 
   const callPickFolders = (): Promise<string[]> => {

--- a/src/main/ipc/repos-picker.test.ts
+++ b/src/main/ipc/repos-picker.test.ts
@@ -52,16 +52,15 @@ describe('repos folder pickers', () => {
     addRepo: vi.fn(),
     removeProject: vi.fn(),
     getRepo: vi.fn(),
-    updateRepo: vi.fn(),
-    getSettings: vi.fn().mockReturnValue({})
+    updateRepo: vi.fn()
   }
 
-  const callPickFolder = (): Promise<string | null> => {
+  const callPickFolder = (args?: { defaultPath?: string }): Promise<string | null> => {
     const handler = handlers.get('repos:pickFolder')
     if (!handler) {
       throw new Error('repos:pickFolder handler was never registered')
     }
-    return handler(null, undefined) as Promise<string | null>
+    return handler(null, args) as Promise<string | null>
   }
 
   const callPickFolders = (): Promise<string[]> => {
@@ -88,17 +87,14 @@ describe('repos folder pickers', () => {
     })
     removeHandlerMock.mockReset()
     showOpenDialogMock.mockReset()
-    mockStore.getSettings.mockReset().mockReturnValue({})
-
     registerRepoHandlers(mockWindow as never, mockStore as never)
   })
 
-  it('applies the saved projectDefaultPath as the pickFolder dialog default', async () => {
+  it('applies the caller-provided pickFolder dialog default', async () => {
     const projectDefault = join(sep, 'some', 'dir')
-    mockStore.getSettings.mockReturnValue({ projectDefaultPath: projectDefault })
     showOpenDialogMock.mockResolvedValue({ canceled: true, filePaths: [] })
 
-    await callPickFolder()
+    await callPickFolder({ defaultPath: projectDefault })
 
     expect(showOpenDialogMock).toHaveBeenCalledWith(mockWindow, {
       properties: ['openDirectory'],

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -38,6 +38,7 @@ import {
 } from '../../shared/cross-platform-path'
 import { isTuiAgent } from '../../shared/tui-agent-config'
 import { invalidateAuthorizedRootsCache } from './filesystem-auth'
+import { resolvePickerDefaultPath } from './repos-pick-default-path'
 import type { ChildProcess } from 'node:child_process'
 import { access, mkdir, readdir, rm } from 'node:fs/promises'
 import { gitExecFileAsync, gitSpawn, nonInteractiveGitEnv } from '../git/runner'
@@ -2100,9 +2101,14 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
     notifySparsePresetsChanged(mainWindow, args.repoId)
   })
 
-  ipcMain.handle('repos:pickFolder', async () => {
+  ipcMain.handle('repos:pickFolder', async (_event, args?: { defaultPath?: string }) => {
+    const defaultPath = resolvePickerDefaultPath(
+      args?.defaultPath,
+      store.getSettings().projectDefaultPath
+    )
     const result = await dialog.showOpenDialog(mainWindow, {
-      properties: ['openDirectory']
+      properties: ['openDirectory'],
+      ...(defaultPath ? { defaultPath } : {})
     })
     if (result.canceled || result.filePaths.length === 0) {
       return null
@@ -2110,9 +2116,14 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
     return result.filePaths[0]
   })
 
-  ipcMain.handle('repos:pickFolders', async () => {
+  ipcMain.handle('repos:pickFolders', async (_event, args?: { defaultPath?: string }) => {
+    const defaultPath = resolvePickerDefaultPath(
+      args?.defaultPath,
+      store.getSettings().projectDefaultPath
+    )
     const result = await dialog.showOpenDialog(mainWindow, {
-      properties: ['openDirectory', 'multiSelections']
+      properties: ['openDirectory', 'multiSelections'],
+      ...(defaultPath ? { defaultPath } : {})
     })
     if (result.canceled || result.filePaths.length === 0) {
       return []
@@ -2121,10 +2132,15 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
   })
 
   // Why: generic folder picker, separate from pickFolder's add-project flow; a clone destination may not be a git repo yet.
-  ipcMain.handle('repos:pickDirectory', async () => {
+  ipcMain.handle('repos:pickDirectory', async (_event, args?: { defaultPath?: string }) => {
+    const defaultPath = resolvePickerDefaultPath(
+      args?.defaultPath,
+      store.getSettings().projectDefaultPath
+    )
     const result = await dialog.showOpenDialog(mainWindow, {
       // Why: macOS materializes typed partial paths with directory creation on; clone/create make the final path on submit.
-      properties: ['openDirectory']
+      properties: ['openDirectory'],
+      ...(defaultPath ? { defaultPath } : {})
     })
     if (result.canceled || result.filePaths.length === 0) {
       return null

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -2102,10 +2102,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
   })
 
   ipcMain.handle('repos:pickFolder', async (_event, args?: { defaultPath?: string }) => {
-    const defaultPath = resolvePickerDefaultPath(
-      args?.defaultPath,
-      store.getSettings().projectDefaultPath
-    )
+    const defaultPath = resolvePickerDefaultPath(args?.defaultPath)
     const result = await dialog.showOpenDialog(mainWindow, {
       properties: ['openDirectory'],
       ...(defaultPath ? { defaultPath } : {})
@@ -2117,10 +2114,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
   })
 
   ipcMain.handle('repos:pickFolders', async (_event, args?: { defaultPath?: string }) => {
-    const defaultPath = resolvePickerDefaultPath(
-      args?.defaultPath,
-      store.getSettings().projectDefaultPath
-    )
+    const defaultPath = resolvePickerDefaultPath(args?.defaultPath)
     const result = await dialog.showOpenDialog(mainWindow, {
       properties: ['openDirectory', 'multiSelections'],
       ...(defaultPath ? { defaultPath } : {})
@@ -2133,10 +2127,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
 
   // Why: generic folder picker, separate from pickFolder's add-project flow; a clone destination may not be a git repo yet.
   ipcMain.handle('repos:pickDirectory', async (_event, args?: { defaultPath?: string }) => {
-    const defaultPath = resolvePickerDefaultPath(
-      args?.defaultPath,
-      store.getSettings().projectDefaultPath
-    )
+    const defaultPath = resolvePickerDefaultPath(args?.defaultPath)
     const result = await dialog.showOpenDialog(mainWindow, {
       // Why: macOS materializes typed partial paths with directory creation on; clone/create make the final path on submit.
       properties: ['openDirectory'],

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1042,9 +1042,9 @@ export type PreloadApi = {
         externalWorktreeDiscoverySuppressedAt?: Repo['externalWorktreeDiscoverySuppressedAt'] | null
       }
     }) => Promise<Repo>
-    pickFolder: () => Promise<string | null>
-    pickFolders: () => Promise<string[]>
-    pickDirectory: () => Promise<string | null>
+    pickFolder: (args?: { defaultPath?: string }) => Promise<string | null>
+    pickFolders: (args?: { defaultPath?: string }) => Promise<string[]>
+    pickDirectory: (args?: { defaultPath?: string }) => Promise<string | null>
     clone: (args: { url: string; destination: string }) => Promise<Repo>
     cloneRemote: (args: { connectionId: string; url: string; destination: string }) => Promise<Repo>
     createRemote: (args: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -532,11 +532,12 @@ const api = {
 
     update: (args) => ipcRenderer.invoke('repos:update', args),
 
-    pickFolder: () => ipcRenderer.invoke('repos:pickFolder'),
+    pickFolder: (args?: { defaultPath?: string }) => ipcRenderer.invoke('repos:pickFolder', args),
 
-    pickFolders: () => ipcRenderer.invoke('repos:pickFolders'),
+    pickFolders: (args?: { defaultPath?: string }) => ipcRenderer.invoke('repos:pickFolders', args),
 
-    pickDirectory: () => ipcRenderer.invoke('repos:pickDirectory'),
+    pickDirectory: (args?: { defaultPath?: string }) =>
+      ipcRenderer.invoke('repos:pickDirectory', args),
 
     clone: (args) => ipcRenderer.invoke('repos:clone', args),
 

--- a/src/renderer/src/components/onboarding/use-onboarding-flow.ts
+++ b/src/renderer/src/components/onboarding/use-onboarding-flow.ts
@@ -764,7 +764,9 @@ export function useOnboardingFlow(
         return
       }
       track('onboarding_step4_path_clicked', { path: 'open_folder' })
-      const path = await window.api.repos.pickFolder()
+      const path = await window.api.repos.pickFolder({
+        defaultPath: settings?.projectDefaultPath
+      })
       if (!path) {
         track('onboarding_step4_path_failed', { path: 'open_folder', reason: 'cancelled' })
         return
@@ -831,7 +833,8 @@ export function useOnboardingFlow(
       scanNestedRepos,
       serverPath,
       showNestedRepoReview,
-      settings?.activeRuntimeEnvironmentId
+      settings?.activeRuntimeEnvironmentId,
+      settings?.projectDefaultPath
     ]
   )
 

--- a/src/renderer/src/components/settings/GeneralWorkspaceSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralWorkspaceSettingsSection.tsx
@@ -1,6 +1,7 @@
 import type React from 'react'
 import type { GlobalSettings } from '../../../../shared/types'
 import { OpenInMenuSetting } from './OpenInMenuSetting'
+import { ProjectDefaultPathSetting } from './ProjectDefaultPathSetting'
 import { SearchableSetting } from './SearchableSetting'
 import { SettingsSubsectionHeader, SettingsSwitchRow } from './SettingsFormControls'
 import { WorkspaceDirectorySetting } from './WorkspaceDirectorySetting'
@@ -29,6 +30,8 @@ export function GeneralWorkspaceSettingsSection({
       />
 
       <WorkspaceDirectorySetting settings={settings} updateSettings={updateSettings} />
+
+      <ProjectDefaultPathSetting settings={settings} updateSettings={updateSettings} />
 
       <SearchableSetting
         title={translate(

--- a/src/renderer/src/components/settings/ProjectDefaultPathSetting.test.tsx
+++ b/src/renderer/src/components/settings/ProjectDefaultPathSetting.test.tsx
@@ -2,7 +2,7 @@
 
 import '@testing-library/jest-dom/vitest'
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ProjectDefaultPathSetting } from './ProjectDefaultPathSetting'
 import type { GlobalSettings } from '../../../../shared/types'
@@ -48,7 +48,7 @@ describe('ProjectDefaultPathSetting', () => {
     expect(updateSettings).toHaveBeenCalledWith({ projectDefaultPath: '/Users/me/code' })
   })
 
-  it('clears the setting when Reset is pressed', () => {
+  it('resets without committing the edited draft during button focus', () => {
     const updateSettings = vi.fn()
     render(
       <ProjectDefaultPathSetting
@@ -56,12 +56,35 @@ describe('ProjectDefaultPathSetting', () => {
         updateSettings={updateSettings}
       />
     )
-    fireEvent.click(screen.getByRole('button', { name: /reset/i }))
+    const input = screen.getByRole('textbox')
+    const reset = screen.getByRole('button', { name: /reset/i })
+    fireEvent.change(input, { target: { value: '/Users/me/edited' } })
+    fireEvent.pointerDown(reset)
+    fireEvent.blur(input)
+    fireEvent.click(reset)
+    expect(updateSettings).toHaveBeenCalledOnce()
     expect(updateSettings).toHaveBeenCalledWith({ projectDefaultPath: '' })
   })
 
-  it('exposes an accessible name on the Browse button', () => {
-    render(<ProjectDefaultPathSetting settings={settingsWith('')} updateSettings={vi.fn()} />)
-    expect(screen.getByRole('button', { name: /browse/i })).toBeInTheDocument()
+  it('seeds Browse from the draft and commits the selected directory', async () => {
+    const updateSettings = vi.fn()
+    vi.mocked(window.api.repos.pickFolder).mockResolvedValue('/Users/me/selected')
+    render(
+      <ProjectDefaultPathSetting settings={settingsWith('')} updateSettings={updateSettings} />
+    )
+    const input = screen.getByRole('textbox')
+    const browse = screen.getByRole('button', { name: /browse/i })
+    fireEvent.change(input, { target: { value: '/Users/me/draft' } })
+    fireEvent.pointerDown(browse)
+    fireEvent.blur(input)
+    fireEvent.click(browse)
+
+    expect(window.api.repos.pickFolder).toHaveBeenCalledWith({
+      defaultPath: '/Users/me/draft'
+    })
+    await waitFor(() => {
+      expect(updateSettings).toHaveBeenCalledOnce()
+      expect(updateSettings).toHaveBeenCalledWith({ projectDefaultPath: '/Users/me/selected' })
+    })
   })
 })

--- a/src/renderer/src/components/settings/ProjectDefaultPathSetting.test.tsx
+++ b/src/renderer/src/components/settings/ProjectDefaultPathSetting.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ProjectDefaultPathSetting } from './ProjectDefaultPathSetting'
+import type { GlobalSettings } from '../../../../shared/types'
+
+// Only the fields the component reads matter; cast a minimal object.
+function settingsWith(projectDefaultPath?: string): GlobalSettings {
+  return { projectDefaultPath } as unknown as GlobalSettings
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('ProjectDefaultPathSetting', () => {
+  it('shows the saved path in the input', () => {
+    render(
+      <ProjectDefaultPathSetting
+        settings={settingsWith('/Users/me/dev')}
+        updateSettings={vi.fn()}
+      />
+    )
+    expect(screen.getByDisplayValue('/Users/me/dev')).toBeInTheDocument()
+  })
+
+  it('commits the typed path on blur', () => {
+    const updateSettings = vi.fn()
+    render(
+      <ProjectDefaultPathSetting settings={settingsWith('')} updateSettings={updateSettings} />
+    )
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: '/Users/me/code' } })
+    fireEvent.blur(input)
+    expect(updateSettings).toHaveBeenCalledWith({ projectDefaultPath: '/Users/me/code' })
+  })
+
+  it('clears the setting when Clear is pressed', () => {
+    const updateSettings = vi.fn()
+    render(
+      <ProjectDefaultPathSetting
+        settings={settingsWith('/Users/me/dev')}
+        updateSettings={updateSettings}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /clear/i }))
+    expect(updateSettings).toHaveBeenCalledWith({ projectDefaultPath: '' })
+  })
+})

--- a/src/renderer/src/components/settings/ProjectDefaultPathSetting.test.tsx
+++ b/src/renderer/src/components/settings/ProjectDefaultPathSetting.test.tsx
@@ -38,7 +38,7 @@ describe('ProjectDefaultPathSetting', () => {
     expect(updateSettings).toHaveBeenCalledWith({ projectDefaultPath: '/Users/me/code' })
   })
 
-  it('clears the setting when Clear is pressed', () => {
+  it('clears the setting when Reset is pressed', () => {
     const updateSettings = vi.fn()
     render(
       <ProjectDefaultPathSetting
@@ -46,7 +46,12 @@ describe('ProjectDefaultPathSetting', () => {
         updateSettings={updateSettings}
       />
     )
-    fireEvent.click(screen.getByRole('button', { name: /clear/i }))
+    fireEvent.click(screen.getByRole('button', { name: /reset/i }))
     expect(updateSettings).toHaveBeenCalledWith({ projectDefaultPath: '' })
+  })
+
+  it('exposes an accessible name on the Browse button', () => {
+    render(<ProjectDefaultPathSetting settings={settingsWith('')} updateSettings={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /browse/i })).toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/settings/ProjectDefaultPathSetting.test.tsx
+++ b/src/renderer/src/components/settings/ProjectDefaultPathSetting.test.tsx
@@ -3,7 +3,7 @@
 import '@testing-library/jest-dom/vitest'
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ProjectDefaultPathSetting } from './ProjectDefaultPathSetting'
 import type { GlobalSettings } from '../../../../shared/types'
 
@@ -12,8 +12,18 @@ function settingsWith(projectDefaultPath?: string): GlobalSettings {
   return { projectDefaultPath } as unknown as GlobalSettings
 }
 
+beforeEach(() => {
+  // The component reads window.api.platform.get() to pick a platform-aware
+  // placeholder; stub the minimal surface it touches.
+  ;(window as unknown as { api: unknown }).api = {
+    platform: { get: () => ({ platform: 'darwin', osRelease: '', displayServer: null }) },
+    repos: { pickFolder: vi.fn() }
+  }
+})
+
 afterEach(() => {
   cleanup()
+  vi.restoreAllMocks()
 })
 
 describe('ProjectDefaultPathSetting', () => {

--- a/src/renderer/src/components/settings/ProjectDefaultPathSetting.tsx
+++ b/src/renderer/src/components/settings/ProjectDefaultPathSetting.tsx
@@ -21,6 +21,7 @@ export function ProjectDefaultPathSetting({
   const value = settings.projectDefaultPath ?? ''
   const [draft, setDraft] = useState(value)
   const draftRef = useRef(value)
+  const skipNextBlurCommitRef = useRef(false)
 
   useEffect(() => {
     setDraft(value)
@@ -39,16 +40,25 @@ export function ProjectDefaultPathSetting({
     updateSettings({ projectDefaultPath: next })
   }
 
+  const handleBlur = (): void => {
+    if (skipNextBlurCommitRef.current) {
+      skipNextBlurCommitRef.current = false
+      return
+    }
+    commit(draftRef.current)
+  }
+
   const handleBrowse = async (): Promise<void> => {
-    // Why: seed the picker with the current draft so re-browsing starts near the
-    // in-progress edit. When the draft is empty, the main-process handler falls
-    // back to the saved projectDefaultPath setting on its own.
-    const picked = await window.api.repos.pickFolder(
-      draftRef.current ? { defaultPath: draftRef.current } : undefined
-    )
-    if (picked) {
-      setDraftValue(picked)
-      commit(picked)
+    try {
+      // Why: seed the picker from the in-progress edit instead of an older
+      // persisted value when the user browses before leaving the field.
+      const picked = await window.api.repos.pickFolder({ defaultPath: draftRef.current })
+      if (picked) {
+        setDraftValue(picked)
+        commit(picked)
+      }
+    } finally {
+      skipNextBlurCommitRef.current = false
     }
   }
 
@@ -56,10 +66,17 @@ export function ProjectDefaultPathSetting({
     'auto.components.settings.ProjectDefaultPathSetting.title',
     'Project default directory'
   )
+  // Why: native pickers browse the client filesystem; SSH/runtime project
+  // paths remain typed host paths and never inherit this local directory.
   const description = translate(
     'auto.components.settings.ProjectDefaultPathSetting.description',
-    'Where the folder pickers for adding or cloning a project open. Leave empty to use the last-used location.'
+    "Starting directory for local project folder pickers. Leave empty to use the system's last-used location."
   )
+  const browseLabel = translate(
+    'auto.components.settings.ProjectDefaultPathSetting.browse',
+    'Browse'
+  )
+  const resetLabel = translate('auto.components.settings.ProjectDefaultPathSetting.reset', 'Reset')
   // Why: show a path example that matches the user's OS so the placeholder reads
   // naturally on Windows as well as macOS/Linux.
   const placeholder =
@@ -79,39 +96,55 @@ export function ProjectDefaultPathSetting({
           value={draft}
           placeholder={placeholder}
           onChange={(e) => setDraftValue(e.target.value)}
-          onBlur={() => commit(draftRef.current)}
+          onBlur={handleBlur}
           onKeyDown={(e) => {
-            if (e.key === 'Enter' && !isImeCompositionKeyDown(e)) {
+            if (isImeCompositionKeyDown(e)) {
+              return
+            }
+            if (e.key === 'Enter') {
+              skipNextBlurCommitRef.current = true
               commit(draftRef.current)
+              e.currentTarget.blur()
+              return
+            }
+            if (e.key === 'Escape') {
+              skipNextBlurCommitRef.current = true
+              setDraftValue(value)
+              e.currentTarget.blur()
             }
           }}
+          className="flex-1 text-xs"
         />
         <Button
           type="button"
           variant="outline"
-          size="icon"
-          aria-label={translate(
-            'auto.components.settings.ProjectDefaultPathSetting.browse',
-            'Browse'
-          )}
+          size="sm"
+          onPointerDown={() => {
+            skipNextBlurCommitRef.current = true
+          }}
           onClick={() => void handleBrowse()}
+          className="shrink-0 gap-1.5"
         >
-          <FolderOpen className="size-4" />
+          <FolderOpen className="size-3.5" />
+          {browseLabel}
         </Button>
         <Button
           type="button"
-          variant="outline"
-          size="icon"
-          aria-label={translate(
-            'auto.components.settings.ProjectDefaultPathSetting.reset',
-            'Reset'
-          )}
+          variant="ghost"
+          size="sm"
+          disabled={!draft && !value}
+          onPointerDown={() => {
+            skipNextBlurCommitRef.current = true
+          }}
           onClick={() => {
             setDraftValue('')
             commit('')
+            skipNextBlurCommitRef.current = false
           }}
+          className="shrink-0 gap-1.5"
         >
-          <RotateCcw className="size-4" />
+          <RotateCcw className="size-3.5" />
+          {resetLabel}
         </Button>
       </div>
       <p className="text-xs text-muted-foreground">{description}</p>

--- a/src/renderer/src/components/settings/ProjectDefaultPathSetting.tsx
+++ b/src/renderer/src/components/settings/ProjectDefaultPathSetting.tsx
@@ -58,7 +58,7 @@ export function ProjectDefaultPathSetting({
   )
   const description = translate(
     'auto.components.settings.ProjectDefaultPathSetting.description',
-    'Where the add-project and clone folder pickers open. Leave empty to use the last-used location.'
+    'Where the folder pickers for adding or cloning a project open. Leave empty to use the last-used location.'
   )
 
   return (

--- a/src/renderer/src/components/settings/ProjectDefaultPathSetting.tsx
+++ b/src/renderer/src/components/settings/ProjectDefaultPathSetting.tsx
@@ -40,8 +40,9 @@ export function ProjectDefaultPathSetting({
   }
 
   const handleBrowse = async (): Promise<void> => {
-    // Why: pick with no defaultPath applied here — seeding this picker with the
-    // value being edited would be circular. Seed from the current value only.
+    // Why: seed the picker with the current draft so re-browsing starts near the
+    // in-progress edit. When the draft is empty, the main-process handler falls
+    // back to the saved projectDefaultPath setting on its own.
     const picked = await window.api.repos.pickFolder(
       draftRef.current ? { defaultPath: draftRef.current } : undefined
     )
@@ -51,24 +52,24 @@ export function ProjectDefaultPathSetting({
     }
   }
 
+  const title = translate(
+    'auto.components.settings.ProjectDefaultPathSetting.title',
+    'Project default directory'
+  )
+  const description = translate(
+    'auto.components.settings.ProjectDefaultPathSetting.description',
+    'Where the add-project and clone folder pickers open. Leave empty to use the last-used location.'
+  )
+
   return (
     <SearchableSetting
-      title={translate(
-        'auto.components.settings.ProjectDefaultPathSetting.title',
-        'Project default directory'
-      )}
-      description={translate(
-        'auto.components.settings.ProjectDefaultPathSetting.description',
-        'Where the add-project and clone folder pickers open. Leave empty to use the last-used location.'
-      )}
+      title={title}
+      description={description}
+      keywords={['project', 'default', 'directory', 'folder', 'path', 'clone', 'location']}
+      className="space-y-2"
     >
+      <Label htmlFor={inputId}>{title}</Label>
       <div className="flex items-center gap-2">
-        <Label htmlFor={inputId} className="sr-only">
-          {translate(
-            'auto.components.settings.ProjectDefaultPathSetting.title',
-            'Project default directory'
-          )}
-        </Label>
         <Input
           id={inputId}
           value={draft}
@@ -81,7 +82,16 @@ export function ProjectDefaultPathSetting({
             }
           }}
         />
-        <Button type="button" variant="outline" size="icon" onClick={() => void handleBrowse()}>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          aria-label={translate(
+            'auto.components.settings.GeneralWorkspaceSettingsSection.5567191a6e',
+            'Browse'
+          )}
+          onClick={() => void handleBrowse()}
+        >
           <FolderOpen className="size-4" />
         </Button>
         <Button
@@ -89,8 +99,8 @@ export function ProjectDefaultPathSetting({
           variant="outline"
           size="icon"
           aria-label={translate(
-            'auto.components.settings.ProjectDefaultPathSetting.clear',
-            'Clear'
+            'auto.components.settings.ProjectDefaultPathSetting.reset',
+            'Reset'
           )}
           onClick={() => {
             setDraftValue('')
@@ -100,6 +110,7 @@ export function ProjectDefaultPathSetting({
           <RotateCcw className="size-4" />
         </Button>
       </div>
+      <p className="text-xs text-muted-foreground">{description}</p>
     </SearchableSetting>
   )
 }

--- a/src/renderer/src/components/settings/ProjectDefaultPathSetting.tsx
+++ b/src/renderer/src/components/settings/ProjectDefaultPathSetting.tsx
@@ -60,6 +60,10 @@ export function ProjectDefaultPathSetting({
     'auto.components.settings.ProjectDefaultPathSetting.description',
     'Where the folder pickers for adding or cloning a project open. Leave empty to use the last-used location.'
   )
+  // Why: show a path example that matches the user's OS so the placeholder reads
+  // naturally on Windows as well as macOS/Linux.
+  const placeholder =
+    window.api.platform.get().platform === 'win32' ? 'C:\\Users\\you\\dev' : '/Users/you/dev'
 
   return (
     <SearchableSetting
@@ -73,7 +77,7 @@ export function ProjectDefaultPathSetting({
         <Input
           id={inputId}
           value={draft}
-          placeholder="/Users/you/dev"
+          placeholder={placeholder}
           onChange={(e) => setDraftValue(e.target.value)}
           onBlur={() => commit(draftRef.current)}
           onKeyDown={(e) => {
@@ -87,7 +91,7 @@ export function ProjectDefaultPathSetting({
           variant="outline"
           size="icon"
           aria-label={translate(
-            'auto.components.settings.GeneralWorkspaceSettingsSection.5567191a6e',
+            'auto.components.settings.ProjectDefaultPathSetting.browse',
             'Browse'
           )}
           onClick={() => void handleBrowse()}

--- a/src/renderer/src/components/settings/ProjectDefaultPathSetting.tsx
+++ b/src/renderer/src/components/settings/ProjectDefaultPathSetting.tsx
@@ -1,0 +1,105 @@
+import React, { useEffect, useId, useRef, useState } from 'react'
+import { FolderOpen, RotateCcw } from 'lucide-react'
+import type { GlobalSettings } from '../../../../shared/types'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { SearchableSetting } from './SearchableSetting'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
+import { translate } from '@/i18n/i18n'
+
+type ProjectDefaultPathSettingProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function ProjectDefaultPathSetting({
+  settings,
+  updateSettings
+}: ProjectDefaultPathSettingProps): React.JSX.Element {
+  const inputId = useId()
+  const value = settings.projectDefaultPath ?? ''
+  const [draft, setDraft] = useState(value)
+  const draftRef = useRef(value)
+
+  useEffect(() => {
+    setDraft(value)
+    draftRef.current = value
+  }, [value])
+
+  const setDraftValue = (next: string): void => {
+    draftRef.current = next
+    setDraft(next)
+  }
+
+  const commit = (next: string): void => {
+    if (next === value) {
+      return
+    }
+    updateSettings({ projectDefaultPath: next })
+  }
+
+  const handleBrowse = async (): Promise<void> => {
+    // Why: pick with no defaultPath applied here — seeding this picker with the
+    // value being edited would be circular. Seed from the current value only.
+    const picked = await window.api.repos.pickFolder(
+      draftRef.current ? { defaultPath: draftRef.current } : undefined
+    )
+    if (picked) {
+      setDraftValue(picked)
+      commit(picked)
+    }
+  }
+
+  return (
+    <SearchableSetting
+      title={translate(
+        'auto.components.settings.ProjectDefaultPathSetting.title',
+        'Project default directory'
+      )}
+      description={translate(
+        'auto.components.settings.ProjectDefaultPathSetting.description',
+        'Where the add-project and clone folder pickers open. Leave empty to use the last-used location.'
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <Label htmlFor={inputId} className="sr-only">
+          {translate(
+            'auto.components.settings.ProjectDefaultPathSetting.title',
+            'Project default directory'
+          )}
+        </Label>
+        <Input
+          id={inputId}
+          value={draft}
+          placeholder="/Users/you/dev"
+          onChange={(e) => setDraftValue(e.target.value)}
+          onBlur={() => commit(draftRef.current)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !isImeCompositionKeyDown(e)) {
+              commit(draftRef.current)
+            }
+          }}
+        />
+        <Button type="button" variant="outline" size="icon" onClick={() => void handleBrowse()}>
+          <FolderOpen className="size-4" />
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          aria-label={translate(
+            'auto.components.settings.ProjectDefaultPathSetting.clear',
+            'Clear'
+          )}
+          onClick={() => {
+            setDraftValue('')
+            commit('')
+          }}
+        >
+          <RotateCcw className="size-4" />
+        </Button>
+      </div>
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/sidebar/useAddRepoCloneFlow.test.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoCloneFlow.test.ts
@@ -9,7 +9,10 @@ const mocks = vi.hoisted(() => ({
   refValues: [] as unknown[],
   refIndex: 0,
   storeState: {
-    settings: { activeRuntimeEnvironmentId: null as string | null },
+    settings: {
+      activeRuntimeEnvironmentId: null as string | null,
+      projectDefaultPath: undefined as string | undefined
+    },
     repos: [] as Repo[],
     projects: [],
     projectHostSetups: []
@@ -100,6 +103,7 @@ describe('useAddRepoCloneFlow', () => {
     mocks.storeState.repos = []
     mocks.storeState.projects = []
     mocks.storeState.projectHostSetups = []
+    mocks.storeState.settings.projectDefaultPath = undefined
     vi.stubGlobal('window', {
       api: {
         repos: {
@@ -162,6 +166,25 @@ describe('useAddRepoCloneFlow', () => {
 
     expect(result.cloneDestination).toBe('')
     expect(mocks.stateSetters[1]).not.toHaveBeenCalledWith('/private/tmp/orca-setup-e2e.hOWO1f')
+  })
+
+  it('opens the local destination picker at the project default directory', async () => {
+    mocks.pickDirectory.mockResolvedValue('/projects')
+    mocks.storeState.settings.projectDefaultPath = '/Users/alice/projects'
+    const { useAddRepoCloneFlow } = await import('./useAddRepoCloneFlow')
+
+    const result = useAddRepoCloneFlow({
+      step: 'clone',
+      activeRuntimeEnvironmentId: null,
+      workspaceDir: '/local/workspace',
+      fetchWorktrees: mocks.fetchWorktrees,
+      onGitRepoReady: mocks.onGitRepoReady
+    })
+    await result.handlePickDestination()
+
+    expect(mocks.pickDirectory).toHaveBeenCalledWith({
+      defaultPath: '/Users/alice/projects'
+    })
   })
 
   it('strips Electron IPC wrappers from clone errors', async () => {

--- a/src/renderer/src/components/sidebar/useAddRepoCloneFlow.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoCloneFlow.ts
@@ -99,7 +99,9 @@ export function useAddRepoCloneFlow({
       return
     }
     const gen = cloneGenRef.current
-    const dir = await window.api.repos.pickDirectory()
+    const dir = await window.api.repos.pickDirectory({
+      defaultPath: useAppStore.getState().settings?.projectDefaultPath
+    })
     if (dir && gen === cloneGenRef.current) {
       setCloneDestination(dir)
       setCloneError(null)

--- a/src/renderer/src/components/sidebar/useAddRepoLocalFolderFlow.test.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoLocalFolderFlow.test.ts
@@ -2,6 +2,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as ReactModule from 'react'
 import type { NestedRepoScanResult, Repo } from '../../../../shared/types'
 
+const storeState = vi.hoisted(() => ({ settings: { projectDefaultPath: '/projects' } }))
+
+vi.mock('@/store', () => ({
+  useAppStore: { getState: () => storeState }
+}))
+
 vi.mock('react', async (importOriginal) => {
   const actual = await importOriginal<typeof ReactModule>()
   return {
@@ -104,7 +110,7 @@ describe('useAddRepoLocalFolderFlow', () => {
 
     await handleBrowse()
 
-    expect(pickFolders).toHaveBeenCalledTimes(1)
+    expect(pickFolders).toHaveBeenCalledWith({ defaultPath: '/projects' })
     expect(addRepoPath).toHaveBeenCalledTimes(2)
     expect(addRepoPath).toHaveBeenNthCalledWith(1, '/projects/alpha')
     expect(addRepoPath).toHaveBeenNthCalledWith(2, '/projects/beta')

--- a/src/renderer/src/components/sidebar/useAddRepoLocalFolderFlow.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoLocalFolderFlow.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { toast } from 'sonner'
+import { useAppStore } from '@/store'
 import { track } from '@/lib/telemetry'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
 import {
@@ -282,7 +283,9 @@ export function useAddRepoLocalFolderFlow({
     setIsAdding(true)
     setAddProjectBusyLabel('Choose a folder...')
     try {
-      const paths = await window.api.repos.pickFolders()
+      const paths = await window.api.repos.pickFolders({
+        defaultPath: useAppStore.getState().settings?.projectDefaultPath
+      })
       if (paths.length === 0 || gen !== localAddGenRef.current) {
         return
       }

--- a/src/renderer/src/components/sidebar/useCreateRepo.default-checkout.test.ts
+++ b/src/renderer/src/components/sidebar/useCreateRepo.default-checkout.test.ts
@@ -7,7 +7,10 @@ const mocks = vi.hoisted(() => ({
   stateSetters: [] as ReturnType<typeof vi.fn>[],
   stateIndex: 0,
   storeState: {
-    settings: { activeRuntimeEnvironmentId: null as string | null },
+    settings: {
+      activeRuntimeEnvironmentId: null as string | null,
+      projectDefaultPath: undefined as string | undefined
+    },
     repos: [] as Repo[],
     projects: [],
     projectHostSetups: [],
@@ -115,6 +118,7 @@ describe('useCreateRepo default-checkout handoff', () => {
     mocks.createRepo.mockReset()
     mocks.createRemoteRepo.mockReset()
     mocks.storeState.settings.activeRuntimeEnvironmentId = null
+    mocks.storeState.settings.projectDefaultPath = undefined
     vi.stubGlobal('window', {
       api: {
         repos: {
@@ -155,11 +159,15 @@ describe('useCreateRepo default-checkout handoff', () => {
   it('returns the selected parent directory after the local picker applies it', async () => {
     const pickedDir = '/Users/alice/custom-projects'
     vi.mocked(window.api.repos.pickDirectory).mockResolvedValue(pickedDir)
+    mocks.storeState.settings.projectDefaultPath = '/Users/alice/projects'
     const { useCreateRepo } = await import('./useCreateRepo')
 
     const result = useCreateRepo(mocks.fetchWorktrees, vi.fn(), mocks.onGitRepoReady)
     await expect(result.handlePickParent()).resolves.toBe(pickedDir)
 
+    expect(window.api.repos.pickDirectory).toHaveBeenCalledWith({
+      defaultPath: '/Users/alice/projects'
+    })
     expect(mocks.stateSetters[STATE_PARENT_PATH]).toHaveBeenCalledWith(pickedDir)
   })
 

--- a/src/renderer/src/components/sidebar/useCreateRepo.ts
+++ b/src/renderer/src/components/sidebar/useCreateRepo.ts
@@ -72,7 +72,9 @@ export function useCreateRepo(
       return null
     }
     const gen = createGenRef.current
-    const dir = await window.api.repos.pickDirectory()
+    const dir = await window.api.repos.pickDirectory({
+      defaultPath: useAppStore.getState().settings?.projectDefaultPath
+    })
     if (dir && gen === createGenRef.current && mountedRef.current) {
       setCreateParent(dir)
       setCreateError(null)

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9271,6 +9271,11 @@
         },
         "MobileRelayBetaNotice": {
           "notice": "Orca Relay is in beta."
+        },
+        "ProjectDefaultPathSetting": {
+          "title": "Project default directory",
+          "description": "Where the add-project and clone folder pickers open. Leave empty to use the last-used location.",
+          "clear": "Clear"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9275,7 +9275,7 @@
         "ProjectDefaultPathSetting": {
           "title": "Project default directory",
           "description": "Where the add-project and clone folder pickers open. Leave empty to use the last-used location.",
-          "clear": "Clear"
+          "reset": "Reset"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9275,7 +9275,8 @@
         "ProjectDefaultPathSetting": {
           "title": "Project default directory",
           "description": "Where the add-project and clone folder pickers open. Leave empty to use the last-used location.",
-          "reset": "Reset"
+          "reset": "Reset",
+          "browse": "Browse"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9274,7 +9274,7 @@
         },
         "ProjectDefaultPathSetting": {
           "title": "Project default directory",
-          "description": "Where the add-project and clone folder pickers open. Leave empty to use the last-used location.",
+          "description": "Starting directory for local project folder pickers. Leave empty to use the system's last-used location.",
           "reset": "Reset",
           "browse": "Browse"
         }

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9248,6 +9248,11 @@
         },
         "MobileRelayBetaNotice": {
           "notice": "Orca Relay is in beta."
+        },
+        "ProjectDefaultPathSetting": {
+          "title": "Project default directory",
+          "description": "Where the add-project and clone folder pickers open. Leave empty to use the last-used location.",
+          "clear": "Clear"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9251,7 +9251,7 @@
         },
         "ProjectDefaultPathSetting": {
           "title": "Project default directory",
-          "description": "Where the add-project and clone folder pickers open. Leave empty to use the last-used location.",
+          "description": "Starting directory for local project folder pickers. Leave empty to use the system's last-used location.",
           "reset": "Reset",
           "browse": "Browse"
         }

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9252,7 +9252,8 @@
         "ProjectDefaultPathSetting": {
           "title": "Project default directory",
           "description": "Where the add-project and clone folder pickers open. Leave empty to use the last-used location.",
-          "reset": "Reset"
+          "reset": "Reset",
+          "browse": "Browse"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9252,7 +9252,7 @@
         "ProjectDefaultPathSetting": {
           "title": "Project default directory",
           "description": "Where the add-project and clone folder pickers open. Leave empty to use the last-used location.",
-          "clear": "Clear"
+          "reset": "Reset"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9248,6 +9248,11 @@
         },
         "MobileRelayBetaNotice": {
           "notice": "Orca Relay is in beta."
+        },
+        "ProjectDefaultPathSetting": {
+          "title": "Project default directory",
+          "description": "Where the add-project and clone folder pickers open. Leave empty to use the last-used location.",
+          "clear": "Clear"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9251,7 +9251,7 @@
         },
         "ProjectDefaultPathSetting": {
           "title": "Project default directory",
-          "description": "Where the add-project and clone folder pickers open. Leave empty to use the last-used location.",
+          "description": "Starting directory for local project folder pickers. Leave empty to use the system's last-used location.",
           "reset": "Reset",
           "browse": "Browse"
         }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9252,7 +9252,8 @@
         "ProjectDefaultPathSetting": {
           "title": "Project default directory",
           "description": "Where the add-project and clone folder pickers open. Leave empty to use the last-used location.",
-          "reset": "Reset"
+          "reset": "Reset",
+          "browse": "Browse"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9252,7 +9252,7 @@
         "ProjectDefaultPathSetting": {
           "title": "Project default directory",
           "description": "Where the add-project and clone folder pickers open. Leave empty to use the last-used location.",
-          "clear": "Clear"
+          "reset": "Reset"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9248,6 +9248,11 @@
         },
         "MobileRelayBetaNotice": {
           "notice": "Orca Relay is in beta."
+        },
+        "ProjectDefaultPathSetting": {
+          "title": "Project default directory",
+          "description": "Where the add-project and clone folder pickers open. Leave empty to use the last-used location.",
+          "clear": "Clear"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9251,7 +9251,7 @@
         },
         "ProjectDefaultPathSetting": {
           "title": "Project default directory",
-          "description": "Where the add-project and clone folder pickers open. Leave empty to use the last-used location.",
+          "description": "Starting directory for local project folder pickers. Leave empty to use the system's last-used location.",
           "reset": "Reset",
           "browse": "Browse"
         }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9252,7 +9252,8 @@
         "ProjectDefaultPathSetting": {
           "title": "Project default directory",
           "description": "Where the add-project and clone folder pickers open. Leave empty to use the last-used location.",
-          "reset": "Reset"
+          "reset": "Reset",
+          "browse": "Browse"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9252,7 +9252,7 @@
         "ProjectDefaultPathSetting": {
           "title": "Project default directory",
           "description": "Where the add-project and clone folder pickers open. Leave empty to use the last-used location.",
-          "clear": "Clear"
+          "reset": "Reset"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9248,6 +9248,11 @@
         },
         "MobileRelayBetaNotice": {
           "notice": "Orca Relay is in beta."
+        },
+        "ProjectDefaultPathSetting": {
+          "title": "Project default directory",
+          "description": "Where the add-project and clone folder pickers open. Leave empty to use the last-used location.",
+          "clear": "Clear"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9251,7 +9251,7 @@
         },
         "ProjectDefaultPathSetting": {
           "title": "Project default directory",
-          "description": "Where the add-project and clone folder pickers open. Leave empty to use the last-used location.",
+          "description": "Starting directory for local project folder pickers. Leave empty to use the system's last-used location.",
           "reset": "Reset",
           "browse": "Browse"
         }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9252,7 +9252,8 @@
         "ProjectDefaultPathSetting": {
           "title": "Project default directory",
           "description": "Where the add-project and clone folder pickers open. Leave empty to use the last-used location.",
-          "reset": "Reset"
+          "reset": "Reset",
+          "browse": "Browse"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9252,7 +9252,7 @@
         "ProjectDefaultPathSetting": {
           "title": "Project default directory",
           "description": "Where the add-project and clone folder pickers open. Leave empty to use the last-used location.",
-          "clear": "Clear"
+          "reset": "Reset"
         }
       },
       "right": {

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -2666,7 +2666,9 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       )
       return null
     }
-    const path = await window.api.repos.pickFolder()
+    const path = await window.api.repos.pickFolder({
+      defaultPath: get().settings?.projectDefaultPath
+    })
     if (!path) {
       return null
     }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2568,6 +2568,9 @@ export type HostSettingOverrides = {
 
 export type GlobalSettings = {
   workspaceDir: string
+  /** Default directory the project/repo folder pickers open in (add project,
+   *  add multiple, clone destination). Unset = use the OS last-used location. */
+  projectDefaultPath?: string
   /** Per-host overrides keyed by ExecutionHostId. Effective value for a
    *  host-varying setting is `host override ?? client default`. */
   hostSettingOverrides?: Partial<Record<ExecutionHostId, HostSettingOverrides>>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2568,8 +2568,8 @@ export type HostSettingOverrides = {
 
 export type GlobalSettings = {
   workspaceDir: string
-  /** Default directory the project/repo folder pickers open in (add project,
-   *  add multiple, clone destination). Unset = use the OS last-used location. */
+  /** Starting directory for client-local project folder pickers.
+   *  Unset = use the native dialog's last-used location. */
   projectDefaultPath?: string
   /** Per-host overrides keyed by ExecutionHostId. Effective value for a
    *  host-varying setting is `host override ?? client default`. */


### PR DESCRIPTION
## Summary

Adds a global **Project default directory** setting so the add-project / add-multiple / clone-destination folder pickers open at a user-chosen location instead of the OS last-used folder.

Today the three `repos:*` directory pickers call `dialog.showOpenDialog` with no `defaultPath`, so macOS falls back to wherever you last browsed. If you keep your repos under a fixed root (e.g. `~/dev`), you have to navigate there manually every time. The workspace side already solves the analogous problem with `worktreeBasePath`; projects had no equivalent.

When the setting is empty, behavior is unchanged (the OS last-used location is preserved).

## What's included

- **`GlobalSettings.projectDefaultPath?: string`** — a new optional field (unset = today's behavior).
- **`src/main/ipc/repos.ts`** — the three pickers (`repos:pickFolder`, `repos:pickFolders`, `repos:pickDirectory`) resolve a `defaultPath` from an optional call arg or the saved setting (arg wins) via a small pure helper `resolvePickerDefaultPath`, and pass it only when one resolves (`...(defaultPath ? { defaultPath } : {})`).
- **Preload** — the three `repos` picker signatures accept an optional `{ defaultPath?: string }`, mirroring the existing `filesystem.pickDirectory` precedent. Existing arg-less callers are unaffected.
- **`ProjectDefaultPathSetting`** — a settings component modeled on `WorkspaceDirectorySetting` (single global value, no host-scope), rendered in the Workspace settings section: a path input (commits on blur/Enter), Browse, and Reset.
- **i18n** — new keys registered across en/ko/ja/es/zh via the catalog sync.

Scope is limited to the three project/repo pickers; other `openDirectory` pickers (shell/pet/warp-theme) are untouched.

## Screenshots

No visual recording attached. This is a settings row (labeled "Project default directory", modeled on the adjacent "Workspace Directory" row) plus picker plumbing. The logic is covered by unit tests; a manual in-app UI smoke has **not** been run in this branch (see Testing).

## Testing

- [x] `pnpm typecheck` — passes (node, cli, web).
- [ ] `pnpm lint` — my changed files are clean; the full run currently reports two **pre-existing** `switch-exhaustiveness` errors in files this PR does not touch (`native-chat-session-option-labels.ts`, `skill-freshness-group.tsx`), confirmed present on `main`.
- [x] `pnpm test` — 13 tests across the three affected suites pass (`repos-pick-default-path`, `repos-picker`, `ProjectDefaultPathSetting`). Full suite not run.
- [ ] `pnpm build` — not run.
- [x] Added tests: the pure `resolvePickerDefaultPath` (arg-wins / setting-fallback / both-absent / empty-string cases), a handler test asserting `showOpenDialog` receives `defaultPath` when the setting is present, and the component (shows saved path, commits on blur, Browse has an accessible name, Reset clears).

## AI Review Report

Built with an AI agent under a spec → plan → task-by-task workflow, each task gated by a spec-compliance and code-quality review, followed by a whole-branch review. What it checked and changed:

- **Backward compatibility** — verified across all three handlers that an unset/empty setting yields `undefined` and no `defaultPath` reaches the dialog, preserving today's behavior.
- **Cross-platform** — `defaultPath` is passed as a plain string with no path-separator assumptions; nothing platform-specific was added (relevant for Windows/Linux/SSH).
- **Scope** — confirmed only the three project/repo pickers changed; shell/pet/warp-theme pickers untouched. Note: `repos:pickFolder` is also used by the Workspace Directory Browse button and onboarding/add-repo flows, so those now seed from `projectDefaultPath` too — harmless (a reasonable starting location) and left intentional rather than adding a discriminator.
- **Findings fixed before this PR** — the settings row initially had no visible label (`SearchableSetting` renders only children); the Browse button lacked an `aria-label`; and the handler-with-setting path was untested. All three were addressed.

## Security Audit

Low surface. The feature reads one user-authored string from settings and passes it to Electron's `dialog.showOpenDialog` as the picker's starting directory. No command execution, no filesystem writes, no path-traversal exposure (it only affects where a native picker opens; the user still selects the final path). Non-existent paths fall back to the OS default, so no validation is added. No new dependencies, IPC exposure limited to the existing three picker channels gaining an optional arg.

## Notes

- Mirrors the established `worktreeBasePath` pattern (saved setting → Browse → used as a path), so no new concept is introduced.
- Happy to run a full build + manual UI smoke, split the commits differently, or narrow the shared-`pickFolder` seeding if you'd prefer the Workspace Directory picker excluded — just let me know.

## ELI5

You can now set a default folder where Orca opens when you pick a project location. That way, if all your repos live under something like ~/dev, the folder dialog starts there every time instead of wherever you last browsed.
