### PR TITLE
fix(gitlab): render item descriptions and comments with document markdown variant

### DIFF
--- a/src/renderer/src/components/GitLabItemDialog.tsx
+++ b/src/renderer/src/components/GitLabItemDialog.tsx
@@ -217,7 +217,11 @@ function CommentCard({
           {comment.line ? `:${comment.line}` : ''}
         </div>
       ) : null}
-      <CommentMarkdown content={comment.body} />
+      <CommentMarkdown
+        content={comment.body}
+        variant="document"
+        className="min-w-0 max-w-full overflow-hidden break-words text-[13px] leading-relaxed [&_a]:break-all [&_code]:break-words [&_pre]:max-w-full"
+      />
     </div>
   )
 }
@@ -1387,7 +1391,11 @@ export default function GitLabItemDialog({
                           </Button>
                         </div>
                       ) : null}
-                      <CommentMarkdown content={details.body} />
+                      <CommentMarkdown
+                        content={details.body}
+                        variant="document"
+                        className="min-w-0 max-w-full overflow-hidden break-words text-[13px] leading-relaxed [&_a]:break-all [&_code]:break-words [&_pre]:max-w-full"
+                      />
                     </div>
                   ) : (
                     <div>

--- a/src/renderer/src/components/sidebar/CommentMarkdown.test.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.test.tsx
@@ -211,6 +211,24 @@ describe('CommentMarkdown', () => {
     expect(markup).not.toContain('mermaid-block')
   })
 
+  it('renders headings as block elements with hierarchy in the document variant', () => {
+    const markup = renderToStaticMarkup(
+      <CommentMarkdown variant="document" content={'## Problem to solve\n\nSome body text.'} />
+    )
+
+    expect(markup).toContain('<h2')
+    expect(markup).toContain('Problem to solve')
+  })
+
+  it('flattens headings to inline text in the compact variant', () => {
+    const markup = renderToStaticMarkup(
+      <CommentMarkdown content={'## Problem to solve\n\nSome body text.'} />
+    )
+
+    expect(markup).not.toContain('<h2')
+    expect(markup).toContain('Problem to solve')
+  })
+
   it('contains long PR body markdown inside its available width', () => {
     const markup = renderToStaticMarkup(
       <CommentMarkdown


### PR DESCRIPTION
## Summary

GitLab issue/MR descriptions and comments rendered as a single wall of text: Markdown headings (`## Problem to solve`, `## Proposed solution`, …) lost their size hierarchy and block spacing, so every section ran into the next paragraph.

This switches both surfaces to `variant="document"` with the same typography classes the GitHub item dialog already uses.

## Screenshots

Real Orca **GitLab item dialog** captures via Electron CDP (`agent-browser` / Playwright over `--remote-debugging-port`). Same live dialog surface this PR changes (`GitLabItemDialog` → `CommentMarkdown`).

Issues created on `gitlab.com/neil148/test` so each fixture exercises a different markdown shape.

### 1. GitLab default issue template

| Before (compact) | After (document) |
| --- | --- |
| ![before-template](https://github.com/user-attachments/assets/0b46c923-486b-4150-a90b-3c57259e53f0) | ![after-template](https://github.com/user-attachments/assets/2ca25660-269c-4068-829b-ebdb8ca5fd15) |

Headings like **Problem to solve** run into the following paragraph before; after they get real block hierarchy + spacing.

### 2. Heading hierarchy (h1–h4)

| Before (compact) | After (document) |
| --- | --- |
| ![before-headings](https://github.com/user-attachments/assets/121d6029-641a-4c1d-8ee3-a7394a4d2030) | ![after-headings](https://github.com/user-attachments/assets/7ca8dc12-22ed-4a5f-a5db-2a939bef4c41) |

### 3. Lists, tasks, and code

| Before (compact) | After (document) |
| --- | --- |
| ![before-lists](https://github.com/user-attachments/assets/402d6d93-90e0-462a-a01d-881fcd289ac7) | ![after-lists](https://github.com/user-attachments/assets/498429f8-bf07-43e6-a2a3-a79ca0e2d120) |

### 4. GFM table + blockquote

| Before (compact) | After (document) |
| --- | --- |
| ![before-table](https://github.com/user-attachments/assets/01437f1e-499c-4d96-b324-8c61832fac9f) | ![after-table](https://github.com/user-attachments/assets/d1dcdad2-4106-4dc2-9ebd-b12eae056634) |

### 5. Dense multi-section body

| Before (compact) | After (document) |
| --- | --- |
| ![before-dense](https://github.com/user-attachments/assets/c51d3e6d-2503-4c92-95e3-2d95e1eed84d) | ![after-dense](https://github.com/user-attachments/assets/fab65441-08ce-4650-91e7-17bbcdcbedc6) |

### Window context

| Before | After |
| --- | --- |
| ![before-window](https://github.com/user-attachments/assets/1c92b7e7-e802-44ba-b8c7-365fa76c0e01) | ![after-window](https://github.com/user-attachments/assets/2be53a2f-ed59-4b73-82d5-c735a81484b5) |

## Testing

- [x] `pnpm lint` — clean for the changed files
- [x] `pnpm typecheck`
- [x] `pnpm test` — `CommentMarkdown.test.tsx` passes (20 tests)
- [x] `pnpm build`
- [x] Added tests: two `CommentMarkdown` cases asserting the document variant renders headings as block `<h2>` while the compact variant does not — a direct regression guard for this bug.

## AI Review Report

> - **Correctness:** No issues. The change only swaps the `CommentMarkdown` variant and adds a className; the rendered content was already fetched and already passed through `CommentMarkdown`. The only removed behavior is the compact rendering of these two surfaces — which was the bug.
> - **Interaction with recent `main`:** Rebased onto current `main` (which now includes #9209, "make the review sidebar legible for structured bot markdown"). Confirmed no overlap: #9209 reworks the **compact** renderer + PR-review sidebar (`pr-comment-presentation.ts`) and adds `comment-md-h`/`role="heading"` semantics, but it does not touch the item dialogs and adds no global block-flow CSS — so the GitLab dialog's compact rendering is unchanged and this fix is still required. Both PRs' `CommentMarkdown` tests coexist.
> - **Cross-platform (macOS / Linux / Windows):** No platform-dependent code — no shortcuts, paths, shell, or Electron platform branches. Pure renderer markup + Tailwind; identical on all three, light/dark unaffected.
> - **SSH/remote/local:** No new data flow or timing; renders content the dialog already loads.
> - **Provider neutrality:** GitLab-specific and aligns GitLab with the existing GitHub sibling; no generic behavior changed.
> - **UI quality:** Matches the GitHub item dialog exactly (same variant + className), so the two dialogs read as one design.

## Security Audit

- **Input handling:** No new input. `comment.body` / `details.body` were already fetched from GitLab and already rendered through `CommentMarkdown` before this change.
- **Sanitization:** Both `compact` and `document` variants run the identical pipeline (`rehypeRaw` → `rehypeSanitize` with the shared schema). The `document` variant does **not** relax sanitization, so the XSS posture is unchanged.
- **Command execution / path handling / auth / secrets / IPC / dependencies:** None touched.
- **Follow-up:** none.

## Notes

No platform-specific behavior. Scope is a single topic (GitLab item dialog markdown rendering); no unrelated changes.

## ELI5

GitLab issue and MR descriptions rendered as one flat wall of text — headings lost size and spacing. They now use the same document markdown styling as GitHub items so sections are readable.
