### PR TITLE
fix(runtime): eliminate agent-send TOCTOU that rejects live agents during startup

### DIFF
--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -37,6 +37,7 @@ import {
   MOBILE_SNAPSHOT_BYTE_BUDGET,
   MOBILE_SUBSCRIBE_SCROLLBACK_ROWS
 } from '../../scrollback-limits'
+import { assertTerminalAgentSendable } from '../terminal-agent-send-guard'
 
 const REQUESTED_SNAPSHOT_BYTE_BUDGET = 2 * 1024 * 1024
 const TERMINAL_STREAM_CHUNK_BYTES = 48 * 1024
@@ -404,16 +405,6 @@ function getTerminalSendGuardRefusedReason(error: unknown): 'no-agent' | 'permis
 function isTerminalSendGuardNotWritable(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error)
   return message.includes('terminal_guard_not_writable')
-}
-
-function isTerminalAgentStatusNotWritable(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error)
-  return [
-    'terminal_not_writable',
-    'terminal_handle_stale',
-    'terminal_gone',
-    'terminal_exited'
-  ].some((code) => message.includes(code))
 }
 
 function assertTerminalSendExactPtyBinding(
@@ -1270,28 +1261,16 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
       const assertSendPreconditions =
         params.requireAgentStatus === 'sendable'
           ? async (ptyId?: string): Promise<void> => {
-              assertTerminalSendExactPtyBinding(runtime, params.terminal, ptyId)
-              if (ptyId && isTerminalInputLockedForClient(runtime, ptyId, params.client)) {
-                throw new Error('terminal_guard_not_writable')
-              }
-              let agentStatus
-              try {
-                agentStatus = await runtime.getTerminalAgentStatus(params.terminal)
-              } catch (error) {
-                if (isTerminalAgentStatusNotWritable(error)) {
-                  throw new Error('terminal_guard_not_writable')
+              await assertTerminalAgentSendable({
+                runtime,
+                handle: params.terminal,
+                assertWritable: () => {
+                  assertTerminalSendExactPtyBinding(runtime, params.terminal, ptyId)
+                  if (ptyId && isTerminalInputLockedForClient(runtime, ptyId, params.client)) {
+                    throw new Error('terminal_guard_not_writable')
+                  }
                 }
-                throw error
-              }
-              // Why: a send callback can race a pane reconnect; status evidence
-              // must never authorize the callback's replacement PTY.
-              assertTerminalSendExactPtyBinding(runtime, params.terminal, ptyId)
-              if (!agentStatus.isRunningAgent) {
-                throw new Error('terminal_guard_no_agent')
-              }
-              if (agentStatus.status === 'permission') {
-                throw new Error('terminal_guard_permission')
-              }
+              })
             }
           : undefined
       if (params.requireAgentStatus === 'sendable') {

--- a/src/main/runtime/rpc/terminal-agent-send-guard.test.ts
+++ b/src/main/runtime/rpc/terminal-agent-send-guard.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { OrcaRuntimeService } from '../orca-runtime'
+import type { RpcRequest } from './core'
+import { RpcDispatcher } from './dispatcher'
+import { TERMINAL_METHODS } from './methods/terminal'
+
+function stubRuntime(overrides: Partial<OrcaRuntimeService>): OrcaRuntimeService {
+  return {
+    getRuntimeId: () => 'test-runtime',
+    ...overrides
+  } as OrcaRuntimeService
+}
+
+function guardedSendRequest(): RpcRequest {
+  return {
+    id: 'req-1',
+    authToken: 'tok',
+    method: 'terminal.send',
+    params: {
+      terminal: 'terminal-1',
+      enter: true,
+      requireAgentStatus: 'sendable',
+      client: { id: 'desktop-1', type: 'desktop' }
+    }
+  }
+}
+
+describe('terminal agent send guard', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('rechecks a transient no-agent result before refusing a guarded send', async () => {
+    vi.useFakeTimers()
+    const getTerminalAgentStatus = vi
+      .fn()
+      .mockResolvedValueOnce({ handle: 'terminal-1', isRunningAgent: false, status: null })
+      .mockResolvedValue({ handle: 'terminal-1', isRunningAgent: true, status: 'working' })
+    const runtime = stubRuntime({
+      resolveLiveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+      getDriver: vi.fn().mockReturnValue({ kind: 'desktop' }),
+      getTerminalAgentStatus,
+      sendTerminal: vi.fn().mockResolvedValue({
+        handle: 'terminal-1',
+        accepted: true,
+        bytesWritten: 1
+      })
+    })
+    const responsePromise = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS }).dispatch(
+      guardedSendRequest()
+    )
+
+    await vi.advanceTimersByTimeAsync(150)
+
+    await expect(responsePromise).resolves.toMatchObject({
+      ok: true,
+      result: { send: { accepted: true, bytesWritten: 1 } }
+    })
+    expect(getTerminalAgentStatus).toHaveBeenCalledTimes(2)
+  })
+
+  it('rechecks a transient no-agent result immediately before the PTY write', async () => {
+    vi.useFakeTimers()
+    const getTerminalAgentStatus = vi
+      .fn()
+      .mockResolvedValueOnce({ handle: 'terminal-1', isRunningAgent: true, status: 'working' })
+      .mockResolvedValueOnce({ handle: 'terminal-1', isRunningAgent: false, status: null })
+      .mockResolvedValue({ handle: 'terminal-1', isRunningAgent: true, status: 'working' })
+    const write = vi.fn()
+    const runtime = stubRuntime({
+      resolveLiveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+      getDriver: vi.fn().mockReturnValue({ kind: 'desktop' }),
+      getTerminalAgentStatus,
+      sendTerminal: vi.fn().mockImplementation(async (_handle, _action, options) => {
+        await options.beforeWrite('pty-1')
+        write()
+        return { handle: 'terminal-1', accepted: true, bytesWritten: 1 }
+      })
+    })
+    const responsePromise = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS }).dispatch(
+      guardedSendRequest()
+    )
+
+    await vi.advanceTimersByTimeAsync(150)
+
+    await expect(responsePromise).resolves.toMatchObject({
+      ok: true,
+      result: { send: { accepted: true, bytesWritten: 1 } }
+    })
+    expect(getTerminalAgentStatus).toHaveBeenCalledTimes(3)
+    expect(write).toHaveBeenCalledOnce()
+  })
+
+  it('still refuses after the bounded recheck window without positive evidence', async () => {
+    vi.useFakeTimers()
+    const getTerminalAgentStatus = vi.fn().mockResolvedValue({
+      handle: 'terminal-1',
+      isRunningAgent: false,
+      status: null
+    })
+    const sendTerminal = vi.fn()
+    const runtime = stubRuntime({
+      resolveLiveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+      getDriver: vi.fn().mockReturnValue({ kind: 'desktop' }),
+      getTerminalAgentStatus,
+      sendTerminal
+    })
+    const responsePromise = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS }).dispatch(
+      guardedSendRequest()
+    )
+
+    await vi.advanceTimersByTimeAsync(1_050)
+
+    await expect(responsePromise).resolves.toMatchObject({
+      ok: true,
+      result: {
+        send: {
+          accepted: false,
+          bytesWritten: 0,
+          refusedReason: 'no-agent'
+        }
+      }
+    })
+    expect(getTerminalAgentStatus).toHaveBeenCalledTimes(8)
+    expect(sendTerminal).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/runtime/rpc/terminal-agent-send-guard.ts
+++ b/src/main/runtime/rpc/terminal-agent-send-guard.ts
@@ -1,0 +1,54 @@
+import type { OrcaRuntimeService } from '../orca-runtime'
+
+const AGENT_STATUS_RECHECK_INTERVAL_MS = 150
+const AGENT_STATUS_RECHECK_TIMEOUT_MS = 1_050
+
+type AssertTerminalAgentSendableOptions = {
+  runtime: OrcaRuntimeService
+  handle: string
+  assertWritable: () => void
+}
+
+export async function assertTerminalAgentSendable(
+  options: AssertTerminalAgentSendableOptions
+): Promise<void> {
+  const deadline = Date.now() + AGENT_STATUS_RECHECK_TIMEOUT_MS
+  while (true) {
+    options.assertWritable()
+    let agentStatus
+    try {
+      agentStatus = await options.runtime.getTerminalAgentStatus(options.handle)
+    } catch (error) {
+      if (isTerminalAgentStatusNotWritable(error)) {
+        throw new Error('terminal_guard_not_writable')
+      }
+      throw error
+    }
+    options.assertWritable()
+    if (agentStatus.isRunningAgent) {
+      if (agentStatus.status === 'permission') {
+        throw new Error('terminal_guard_permission')
+      }
+      return
+    }
+    const remainingMs = deadline - Date.now()
+    if (remainingMs <= 0) {
+      throw new Error('terminal_guard_no_agent')
+    }
+    // Why: title and foreground caches refresh asynchronously; require fresh
+    // positive evidence within a wall-clock bound so slow SSH reads cannot multiply it.
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.min(AGENT_STATUS_RECHECK_INTERVAL_MS, remainingMs))
+    )
+  }
+}
+
+function isTerminalAgentStatusNotWritable(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return [
+    'terminal_not_writable',
+    'terminal_handle_stale',
+    'terminal_gone',
+    'terminal_exited'
+  ].some((code) => message.includes(code))
+}

--- a/src/renderer/src/lib/active-agent-note-send.test.ts
+++ b/src/renderer/src/lib/active-agent-note-send.test.ts
@@ -993,8 +993,11 @@ describe('active agent note send', () => {
     )
   })
 
-  it('refuses explicit targets that are not recognized agents before writing', async () => {
-    testState.callRuntimeRpc.mockImplementation(async (_target, method) => {
+  it('lets guarded sends decide after transient no-agent snapshots for explicit targets', async () => {
+    const methods: string[] = []
+    let guardedSendAccepted = true
+    testState.callRuntimeRpc.mockImplementation(async (_target, method, params) => {
+      methods.push(method)
       if (method === 'terminal.list') {
         return {
           terminals: [
@@ -1005,7 +1008,7 @@ describe('active agent note send', () => {
               branch: 'main',
               tabId: 'tab-9',
               leafId: OTHER_LEAF_ID,
-              title: 'zsh',
+              title: 'Codex',
               connected: true,
               writable: true,
               lastOutputAt: 1,
@@ -1019,6 +1022,24 @@ describe('active agent note send', () => {
       if (method === 'terminal.agentStatus') {
         return { agentStatus: { handle: 'term-2', isRunningAgent: false, status: null } }
       }
+      if (method === 'terminal.send') {
+        expect(params).toMatchObject({
+          terminal: 'term-2',
+          requireAgentStatus: 'sendable'
+        })
+        return {
+          send: {
+            handle: 'term-2',
+            accepted: guardedSendAccepted,
+            bytesWritten: guardedSendAccepted
+              ? typeof params.text === 'string'
+                ? params.text.length
+                : 1
+              : 0,
+            ...(guardedSendAccepted ? {} : { refusedReason: 'no-agent' })
+          }
+        }
+      }
       throw new Error(`unexpected method ${method}`)
     })
 
@@ -1028,14 +1049,26 @@ describe('active agent note send', () => {
         prompt: 'notes',
         noteTarget: { tabId: 'tab-9', leafId: OTHER_LEAF_ID }
       })
-    ).resolves.toEqual({ status: 'no-agent' })
+    ).resolves.toEqual({ status: 'sent' })
 
-    expect(testState.callRuntimeRpc).not.toHaveBeenCalledWith(
-      expect.anything(),
+    expect(methods).toEqual([
+      'terminal.list',
+      'terminal.agentStatus',
       'terminal.send',
-      expect.anything(),
-      expect.anything()
-    )
+      'terminal.agentStatus',
+      'terminal.send'
+    ])
+
+    methods.length = 0
+    guardedSendAccepted = false
+    await expect(
+      sendNotesToActiveAgentSession({
+        worktreeId: 'wt-1',
+        prompt: 'notes',
+        noteTarget: { tabId: 'tab-9', leafId: OTHER_LEAF_ID }
+      })
+    ).resolves.toEqual({ status: 'no-agent' })
+    expect(methods).toEqual(['terminal.list', 'terminal.agentStatus', 'terminal.send'])
   })
 
   it('maps explicit target first-write refusal to not-writable', async () => {

--- a/src/renderer/src/lib/active-agent-note-send.ts
+++ b/src/renderer/src/lib/active-agent-note-send.ts
@@ -174,7 +174,12 @@ async function sendPromptWithGuardedPasteAndEnter(
   const initialAgentStatus = await getTerminalAgentSendReadiness(runtimeTarget, terminalHandle, {
     allowLegacyFallback: options.allowLegacyFallback
   })
-  if (initialAgentStatus.status !== 'sendable') {
+  // Why: the readiness probe and write guard can observe different transient
+  // title/process snapshots; the guard owns the bounded no-agent recheck.
+  if (
+    initialAgentStatus.status !== 'sendable' &&
+    !(initialAgentStatus.status === 'no-agent' && initialAgentStatus.supportsGuardedSend)
+  ) {
     return { status: initialAgentStatus.status }
   }
 
@@ -216,7 +221,10 @@ async function sendPromptWithGuardedPasteAndEnter(
     const submitAgentStatus = await getTerminalAgentSendReadiness(runtimeTarget, terminalHandle, {
       allowLegacyFallback: options.allowLegacyFallback
     })
-    if (submitAgentStatus.status !== 'sendable') {
+    if (
+      submitAgentStatus.status !== 'sendable' &&
+      !(submitAgentStatus.status === 'no-agent' && submitAgentStatus.supportsGuardedSend)
+    ) {
       return { status: 'partial-submit-failed' }
     }
   } catch (error) {


### PR DESCRIPTION
## Landing recommendation

**Recommended to land.** The change addresses the same startup-time false negative reported in #7935, keeps the existing fail-closed write protections, has a tightly bounded slow path, and passed both focused automation and real Electron validation. PR Checks are currently green.

## User problem and root cause

The user could select a live agent from **Send notes to an agent** and still get “not a recognized agent session” during agent startup; retrying shortly afterward worked. Instrumentation reproduced hundreds of transient `no-agent` observations during the first seconds of Claude startup.

This was a TOCTOU between independent status reads:

1. the renderer checked whether the terminal looked like an agent;
2. the runtime send guard checked again before writing;
3. those reads could see different foreground-process/title snapshots while the agent was starting or its title was temporarily neutral.

The runtime therefore rejected a live, selected agent even though the terminal identity and permissions were otherwise valid.

## Fix

- Move the transient `no-agent` handling into the runtime send guard, which owns the final write decision.
- Recheck **only** `no-agent` every 150 ms, with a 1,050 ms wall-clock bound (at most 8 probes), before refusing.
- Let a guarded runtime arbitrate a renderer preflight `no-agent` instead of treating that potentially stale snapshot as final.
- Keep legacy runtime behavior unchanged when guarded send capability is unavailable.

Commits:

- `462e04e0d` — runtime guarded-send retry
- `ae4d42b75` — renderer delegates the transient case to guarded send

## Safety / regression analysis

- No terminal input is written until the guard observes a sendable agent.
- Exact-PTY targeting, stale-handle rejection, lock/permission checks, and not-writable/unavailable failures remain fail-closed.
- Errors other than `no-agent` are not retried or softened.
- The logic is platform-neutral and uses the existing runtime RPC/status source, so native macOS/Linux/Windows, WSL, SSH, and relay targets retain the same authority and terminal identity checks.
- No Git/provider behavior or UI shortcut/path behavior changes.

## Performance

- Normal sendable-agent path: no retry delay and no new renderer polling/provider fan-out.
- Continuously negative path: bounded to 8 lightweight status probes over at most 1.05 seconds, only after an explicit send attempt reports `no-agent`.
- No background timer or persistent polling is introduced.

## Validation

Automated validation completed locally:

- 65/65 focused Vitest cases across runtime terminal send guard/send and renderer active-agent note send
- `pnpm typecheck`
- changed-file lint and format checks
- reliability gates and `git diff --check`
- Electron production build
- GitHub PR Checks: green

### Real Electron validation

Ran an isolated Electron instance from this branch with a separate user-data directory and an authenticated Claude Code terminal:

1. **Idle agent:** added a real line-level AI review note, selected the visible Idle Claude target, received the success toast, and Claude received the exact file/line/comment payload and replied `PR9166_NOTE_RECEIVED`.
2. **Working agent / mid-turn:** started a real `sleep 45` shell command, confirmed Orca showed Claude as Working, then sent another line-level review note to that Working target. Claude replied `PR9166_MIDTURN_RECEIVED` while explicitly reporting the original sleep was still running; the original command later completed and Claude returned `HOLD2_DONE`.
3. The sidebar transitioned Working → Done, the runtime continued to report a live agent, there were 0 Electron console errors, and the agent made no repository changes.

Successful guarded send from the branch diff:

![Electron success toast and active-agent state](https://github.com/user-attachments/assets/2f2adf47-abbd-417c-8ec2-4e32b3a1f385)

Idle and mid-turn delivery markers, including completion of the original command:

![Claude receives idle and mid-turn review notes](https://github.com/user-attachments/assets/17f8587e-c108-4062-83b7-86d8c092528b)

## Remaining risk

A naturally occurring neutral-title frame was not deterministically captured during the live Electron run. That exact timing window is covered by focused fake-timer tests for first-probe failure, eventual success, exhaustion, wall-clock bounding, and concurrent sends. Given the bounded scope and the successful idle + mid-turn end-to-end flows, remaining regression risk is low.

Fixes #7935
