### PR TITLE
fix(codex): strip Orca-owned hook trust before mirroring config into managed homes (PR-A)

### DIFF
--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -394,6 +394,43 @@ describe('CodexAccountService config sync', () => {
     expectSanitizedManagedConfig()
   })
 
+  it('keeps flag-off config mirroring byte-identical', async () => {
+    const fixture = await createCanonicalHookTrustFixture()
+    const canonicalConfigPath = join(testState.fakeHomeDir, '.codex', 'config.toml')
+    writeFileSync(canonicalConfigPath, fixture.config, 'utf-8')
+    const managedHomePath = createManagedHome(
+      testState.userDataDir,
+      'account-1',
+      'approval_policy = "on-request"\n'
+    )
+    const settings = createSettings({
+      codexSystemDefaultRealHomeEnabled: false,
+      codexManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'user@example.com',
+          managedHomePath,
+          providerAccountId: null,
+          workspaceLabel: null,
+          workspaceAccountId: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ]
+    })
+
+    const { CodexAccountService } = await import('./service')
+    new CodexAccountService(
+      createStore(settings) as never,
+      createRateLimits() as never,
+      createRuntimeHome() as never
+    )
+
+    expect(readFileSync(join(managedHomePath, 'config.toml'), 'utf-8')).toBe(fixture.config)
+    expect(readFileSync(canonicalConfigPath, 'utf-8')).toBe(fixture.config)
+  })
+
   it('rewrites relative path config values when syncing into managed homes', async () => {
     const canonicalConfigPath = join(testState.fakeHomeDir, '.codex', 'config.toml')
     writeFileSync(

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -16,6 +16,7 @@ import { join } from 'node:path'
 import { PassThrough } from 'node:stream'
 import type { GlobalSettings } from '../../shared/types'
 import { buildWslCodexAvailabilityArgs, buildWslCodexLoginArgs } from './wsl-codex-command'
+import type { readHookTrustEntries as ReadHookTrustEntries } from '../codex/config-toml-trust'
 
 const testState = {
   userDataDir: '',
@@ -220,6 +221,65 @@ function createCodexAuthJson(email: string, accountId: string, refreshToken: str
   )}\n`
 }
 
+async function createCanonicalHookTrustFixture(): Promise<{
+  config: string
+  orcaKeys: string[]
+  userKey: string
+}> {
+  const { MANAGED_HOOK_TIMEOUT_SECONDS } = await import('../agent-hooks/installer-utils')
+  const { getCodexManagedHookInstallMaterial } = await import('../codex/hook-service')
+  const { computeTrustKey, computeTrustedHash, escapeTomlString, normalizeHookTrustKeyForLookup } =
+    await import('../codex/config-toml-trust')
+  const { getCodexHookTrustSignature } = await import('../codex/codex-hook-identity')
+  const { writeCodexTrustGrantLedgerHome } = await import('../codex/codex-trust-grant-ledger')
+  const sourceHomePath = join(testState.fakeHomeDir, '.codex')
+  const sourcePath = join(sourceHomePath, 'hooks.json')
+  const material = getCodexManagedHookInstallMaterial()
+  const expectedHashEntry = {
+    sourcePath,
+    eventLabel: 'stop' as const,
+    groupIndex: 0,
+    handlerIndex: 0,
+    command: material.command,
+    timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
+  }
+  const ledgerHashEntry = {
+    ...expectedHashEntry,
+    eventLabel: 'session_start' as const,
+    groupIndex: 1
+  }
+  const userEntry = {
+    ...expectedHashEntry,
+    groupIndex: 2,
+    command: 'user-authored-hook'
+  }
+  const expectedHashKey = computeTrustKey(expectedHashEntry)
+  const ledgerHashKey = computeTrustKey(ledgerHashEntry)
+  const userKey = computeTrustKey(userEntry)
+  const ledgerTrustedHash = 'sha256:codex-granted-orca-hook'
+  writeCodexTrustGrantLedgerHome(sourceHomePath, {
+    binary: null,
+    entries: {
+      [normalizeHookTrustKeyForLookup(ledgerHashKey)]: {
+        signature: getCodexHookTrustSignature(ledgerHashEntry),
+        trustedHash: ledgerTrustedHash
+      }
+    }
+  })
+  const block = (key: string, trustedHash: string): string =>
+    `[hooks.state."${escapeTomlString(key)}"]\ntrusted_hash = "${trustedHash}"\nenabled = true`
+  return {
+    config: [
+      'approval_policy = "never"',
+      block(expectedHashKey, computeTrustedHash(expectedHashEntry)),
+      block(ledgerHashKey, ledgerTrustedHash),
+      block(userKey, computeTrustedHash(userEntry))
+    ].join('\n\n'),
+    orcaKeys: [expectedHashKey, ledgerHashKey],
+    userKey
+  }
+}
+
 describe('CodexAccountService config sync', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -280,6 +340,60 @@ describe('CodexAccountService config sync', () => {
     )
   })
 
+  it('strips only Orca-owned source-home hook trust on startup and account selection', async () => {
+    const fixture = await createCanonicalHookTrustFixture()
+    const canonicalConfigPath = join(testState.fakeHomeDir, '.codex', 'config.toml')
+    writeFileSync(canonicalConfigPath, fixture.config, 'utf-8')
+    const managedHomePath = createManagedHome(
+      testState.userDataDir,
+      'account-1',
+      'approval_policy = "on-request"\n'
+    )
+    const settings = createSettings({
+      codexManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'user@example.com',
+          managedHomePath,
+          providerAccountId: null,
+          workspaceLabel: null,
+          workspaceAccountId: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ]
+    })
+    const store = createStore(settings)
+    const rateLimits = createRateLimits()
+    const runtimeHome = createRuntimeHome()
+    const { readHookTrustEntries } = await import('../codex/config-toml-trust')
+    const { readCodexTrustGrantLedgerHome } = await import('../codex/codex-trust-grant-ledger')
+
+    const { CodexAccountService } = await import('./service')
+    const service = new CodexAccountService(
+      store as never,
+      rateLimits as never,
+      runtimeHome as never
+    )
+    const expectSanitizedManagedConfig = (): void => {
+      const entries = readHookTrustEntries(join(managedHomePath, 'config.toml'))
+      for (const key of fixture.orcaKeys) {
+        expect(entries.has(key)).toBe(false)
+      }
+      expect(entries.has(fixture.userKey)).toBe(true)
+    }
+
+    expectSanitizedManagedConfig()
+    expect(readFileSync(canonicalConfigPath, 'utf-8')).toBe(fixture.config)
+    expect(readCodexTrustGrantLedgerHome(join(testState.fakeHomeDir, '.codex'))).not.toBeNull()
+
+    writeFileSync(join(managedHomePath, 'config.toml'), 'approval_policy = "untrusted"\n', 'utf-8')
+    await service.selectAccount('account-1')
+
+    expectSanitizedManagedConfig()
+  })
+
   it('rewrites relative path config values when syncing into managed homes', async () => {
     const canonicalConfigPath = join(testState.fakeHomeDir, '.codex', 'config.toml')
     writeFileSync(
@@ -325,7 +439,15 @@ describe('CodexAccountService config sync', () => {
 
   it('does not rewrite managed configs that already match canonical config', async () => {
     const canonicalConfigPath = join(testState.fakeHomeDir, '.codex', 'config.toml')
-    const canonicalConfig = 'approval_policy = "never"\nsandbox_mode = "danger-full-access"\n'
+    const { escapeTomlString } = await import('../codex/config-toml-trust')
+    const userHookKey = `${join(testState.fakeHomeDir, '.codex', 'user-hooks.json')}:stop:0:0`
+    const canonicalConfig = [
+      'approval_policy = "never"',
+      'sandbox_mode = "danger-full-access"',
+      `[hooks.state."${escapeTomlString(userHookKey)}"]`,
+      'trusted_hash = "sha256:user-owned"',
+      ''
+    ].join('\n')
     writeFileSync(canonicalConfigPath, canonicalConfig, 'utf-8')
     const managedHomePath = createManagedHome(
       testState.userDataDir,
@@ -562,6 +684,65 @@ describe('CodexAccountService config sync', () => {
 
     expect(spawnMock).toHaveBeenCalledTimes(1)
     expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not seed Orca-owned source-home trust when adding an account', async () => {
+    vi.resetModules()
+    let fixture: Awaited<ReturnType<typeof createCanonicalHookTrustFixture>>
+    let readHookTrustEntries: typeof ReadHookTrustEntries
+    const spawnMock = vi.fn(
+      (_command: string, _args: string[], options: { env: NodeJS.ProcessEnv }) => {
+        const child = new EventEmitter() as EventEmitter & {
+          stdout: PassThrough
+          stderr: PassThrough
+          kill: () => void
+        }
+        child.stdout = new PassThrough()
+        child.stderr = new PassThrough()
+        child.kill = vi.fn()
+
+        const loginHome = options.env.CODEX_HOME
+        expect(loginHome).toBeTruthy()
+        const entries = readHookTrustEntries(join(loginHome!, 'config.toml'))
+        for (const key of fixture.orcaKeys) {
+          expect(entries.has(key)).toBe(false)
+        }
+        expect(entries.has(fixture.userKey)).toBe(true)
+        writeFileSync(
+          join(loginHome!, 'auth.json'),
+          createCodexAuthJson('user@example.com', 'provider-account-1', 'refresh-token'),
+          'utf-8'
+        )
+
+        queueMicrotask(() => child.emit('close', 0))
+        return child
+      }
+    )
+
+    vi.doMock('node:child_process', () => ({
+      execFileSync: vi.fn(),
+      spawn: spawnMock
+    }))
+    vi.doMock('../codex-cli/command', () => ({
+      resolveCodexCommand: () => 'codex'
+    }))
+    fixture = await createCanonicalHookTrustFixture()
+    readHookTrustEntries = (await import('../codex/config-toml-trust')).readHookTrustEntries
+    writeFileSync(join(testState.fakeHomeDir, '.codex', 'config.toml'), fixture.config, 'utf-8')
+
+    const store = createStore(createSettings())
+    const rateLimits = createRateLimits()
+    const runtimeHome = createRuntimeHome()
+    const { CodexAccountService } = await import('./service')
+    const service = new CodexAccountService(
+      store as never,
+      rateLimits as never,
+      runtimeHome as never
+    )
+
+    await service.addAccount()
+
+    expect(spawnMock).toHaveBeenCalledTimes(1)
   })
 
   it('recreates the expected missing managed home before reauthenticating', async () => {

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -17,6 +17,7 @@ import type { CodexRuntimeHomeService } from './runtime-home-service'
 import { writeFileAtomically } from './fs-utils'
 import { rewriteRelativePathConfigValues } from '../codex/codex-config-path-reference-rewrite'
 import { stripCodexManagedHookTrustEntriesFromConfig } from '../codex/codex-managed-trust-reconciliation'
+import { isCodexSystemDefaultRealHomeEnabled } from '../codex/codex-real-home-flag'
 import { getCodexManagedHookInstallMaterial } from '../codex/hook-service'
 import { MANAGED_HOOK_TIMEOUT_SECONDS } from '../agent-hooks/installer-utils'
 import { resolveCodexCommand } from '../codex-cli/command'
@@ -472,15 +473,18 @@ export class CodexAccountService {
     // account while preserving consistent Codex behavior. Managed homes are
     // real CODEX_HOMEs for `codex login`, so relative path-valued settings
     // must keep resolving against the home the config was read from.
-    const material = getCodexManagedHookInstallMaterial()
-    // Why: source-home Orca trust is foreign to each managed home's hooks.json.
-    const sanitizedConfig = stripCodexManagedHookTrustEntriesFromConfig(canonicalConfig.contents, {
-      runtimeHomePath: canonicalConfig.sourceHomePath,
-      sourcePath: canonicalConfig.sourceHooksPath,
-      command: material.command,
-      managedEventLabels: new Set(Object.values(material.eventLabel)),
-      timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
-    })
+    let sanitizedConfig = canonicalConfig.contents
+    if (isCodexSystemDefaultRealHomeEnabled(this.store.getSettings())) {
+      const material = getCodexManagedHookInstallMaterial()
+      // Why: source-home Orca trust is foreign to each managed home's hooks.json.
+      sanitizedConfig = stripCodexManagedHookTrustEntriesFromConfig(canonicalConfig.contents, {
+        runtimeHomePath: canonicalConfig.sourceHomePath,
+        sourcePath: canonicalConfig.sourceHooksPath,
+        command: material.command,
+        managedEventLabels: new Set(Object.values(material.eventLabel)),
+        timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
+      })
+    }
     this.writeManagedConfig(
       trustedManagedHomePath,
       rewriteRelativePathConfigValues(sanitizedConfig, canonicalConfig.sourceHomePath)

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -16,6 +16,9 @@ import type {
 import type { CodexRuntimeHomeService } from './runtime-home-service'
 import { writeFileAtomically } from './fs-utils'
 import { rewriteRelativePathConfigValues } from '../codex/codex-config-path-reference-rewrite'
+import { stripCodexManagedHookTrustEntriesFromConfig } from '../codex/codex-managed-trust-reconciliation'
+import { getCodexManagedHookInstallMaterial } from '../codex/hook-service'
+import { MANAGED_HOOK_TIMEOUT_SECONDS } from '../agent-hooks/installer-utils'
 import { resolveCodexCommand } from '../codex-cli/command'
 import type { Store } from '../persistence'
 import type { RateLimitService } from '../rate-limits/service'
@@ -58,6 +61,7 @@ type CanonicalCodexConfig = {
   /** Home the config was read from, in the path style Codex sees at runtime
    *  (Linux-side for WSL); relative path-valued settings resolve against it. */
   sourceHomePath: string
+  sourceHooksPath: string
 }
 
 export type CodexAccountAddTarget = {
@@ -468,9 +472,18 @@ export class CodexAccountService {
     // account while preserving consistent Codex behavior. Managed homes are
     // real CODEX_HOMEs for `codex login`, so relative path-valued settings
     // must keep resolving against the home the config was read from.
+    const material = getCodexManagedHookInstallMaterial()
+    // Why: source-home Orca trust is foreign to each managed home's hooks.json.
+    const sanitizedConfig = stripCodexManagedHookTrustEntriesFromConfig(canonicalConfig.contents, {
+      runtimeHomePath: canonicalConfig.sourceHomePath,
+      sourcePath: canonicalConfig.sourceHooksPath,
+      command: material.command,
+      managedEventLabels: new Set(Object.values(material.eventLabel)),
+      timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
+    })
     this.writeManagedConfig(
       trustedManagedHomePath,
-      rewriteRelativePathConfigValues(canonicalConfig.contents, canonicalConfig.sourceHomePath)
+      rewriteRelativePathConfigValues(sanitizedConfig, canonicalConfig.sourceHomePath)
     )
   }
 
@@ -482,7 +495,11 @@ export class CodexAccountService {
     }
 
     try {
-      return { contents: readFileSync(primaryConfigPath, 'utf-8'), sourceHomePath }
+      return {
+        contents: readFileSync(primaryConfigPath, 'utf-8'),
+        sourceHomePath,
+        sourceHooksPath: join(sourceHomePath, 'hooks.json')
+      }
     } catch (error) {
       console.warn('[codex-accounts] Failed to read canonical config:', error)
       return null
@@ -509,7 +526,11 @@ export class CodexAccountService {
     try {
       // Why: the config is read over UNC but consumed by Codex inside WSL, so
       // path rewrites must anchor to the Linux-side ~/.codex, not the UNC path.
-      return { contents: readFileSync(configPath, 'utf-8'), sourceHomePath: `${wslHome}/.codex` }
+      return {
+        contents: readFileSync(configPath, 'utf-8'),
+        sourceHomePath: `${wslHome}/.codex`,
+        sourceHooksPath: `${wslHome}/.codex/hooks.json`
+      }
     } catch (error) {
       console.warn('[codex-accounts] Failed to read WSL canonical config:', error)
       return null

--- a/src/main/codex/codex-managed-trust-reconciliation.ts
+++ b/src/main/codex/codex-managed-trust-reconciliation.ts
@@ -6,8 +6,11 @@ import {
   normalizeCodexHookSourcePath,
   parseTrustKey,
   readHookTrustEntries,
+  readHookTrustEntriesFromContent,
   removeHookTrustEntries,
+  removeHookTrustEntriesFromContent,
   type CodexEventLabel,
+  type CodexHookTrustState,
   type CodexTrustEntry
 } from './config-toml-trust'
 import { getCodexHookTrustSignature } from './codex-hook-identity'
@@ -52,8 +55,7 @@ function addLedgerRecognizedHashes(
   }
 }
 
-export function removeCodexManagedHookTrustEntries(options: {
-  tomlPath: string
+type CodexManagedHookTrustOwnershipOptions = {
   runtimeHomePath: string
   sourcePath: string
   command: string
@@ -61,8 +63,12 @@ export function removeCodexManagedHookTrustEntries(options: {
   timeoutSec: number
   /** Explicit native homes resolve their parent before hook discovery. */
   sourceUsesExplicitCodexHome?: boolean
-}): void {
-  const existingEntries = readHookTrustEntries(options.tomlPath)
+}
+
+function getCodexManagedHookTrustEntryKeys(
+  existingEntries: ReadonlyMap<string, CodexHookTrustState>,
+  options: CodexManagedHookTrustOwnershipOptions
+): string[] {
   const ledgerHome = readCodexTrustGrantLedgerHomeForReconciliation(options.runtimeHomePath)
   const expectedSourcePath = options.sourceUsesExplicitCodexHome
     ? getCodexExplicitHomeHookSourcePath(options.sourcePath)
@@ -94,6 +100,27 @@ export function removeCodexManagedHookTrustEntries(options: {
       ownedKeys.push(key)
     }
   }
+  return ownedKeys
+}
+
+export function stripCodexManagedHookTrustEntriesFromConfig(
+  contents: string,
+  options: CodexManagedHookTrustOwnershipOptions
+): string {
+  const ownedKeys = getCodexManagedHookTrustEntryKeys(
+    readHookTrustEntriesFromContent(contents),
+    options
+  )
+  return removeHookTrustEntriesFromContent(contents, ownedKeys)
+}
+
+export function removeCodexManagedHookTrustEntries(
+  options: CodexManagedHookTrustOwnershipOptions & { tomlPath: string }
+): void {
+  const ownedKeys = getCodexManagedHookTrustEntryKeys(
+    readHookTrustEntries(options.tomlPath),
+    options
+  )
   if (ownedKeys.length > 0) {
     removeHookTrustEntries(options.tomlPath, ownedKeys)
   }

--- a/src/main/codex/config-toml-trust.test.ts
+++ b/src/main/codex/config-toml-trust.test.ts
@@ -26,7 +26,9 @@ import {
   normalizeCodexProjectPathForRevocationLookup,
   parseTrustKey,
   readHookTrustEntries,
+  readHookTrustEntriesFromContent,
   removeHookTrustEntries,
+  removeHookTrustEntriesFromContent,
   upsertHookTrustEntries,
   upsertProjectTrustLevel,
   upsertProjectTrustLevelInContent,
@@ -1662,6 +1664,70 @@ describe('readHookTrustEntries', () => {
     expect(result.get(keyA)?.enabled).toBe(true)
     expect(result.get(keyB)?.trustedHash).toBe('sha256:BBB')
     expect(result.get(keyB)?.enabled).toBe(true)
+  })
+
+  it('fails closed when normalized duplicate blocks have conflicting hashes', () => {
+    const key = '/x/hooks.json:stop:0:0'
+    writeFileSync(
+      configPath,
+      [
+        `[hooks.state."${key}"]`,
+        'trusted_hash = "sha256:USER"',
+        '',
+        `[hooks.state.'${key}']`,
+        'trusted_hash = "sha256:ORCA"',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+
+    expect(readHookTrustEntries(configPath).get(key)?.trustedHash).toBeUndefined()
+  })
+
+  it('ignores trust-looking fields inside multiline strings', () => {
+    const key = '/x/hooks.json:stop:0:0'
+    writeFileSync(
+      configPath,
+      [
+        `[hooks.state."${key}"]`,
+        'note = """',
+        'trusted_hash = "sha256:NOT-A-FIELD"',
+        'enabled = false',
+        '"""',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+
+    expect(readHookTrustEntries(configPath).get(key)).toEqual({
+      trustedHash: undefined,
+      enabled: undefined
+    })
+  })
+
+  it('does not accept an unterminated trusted_hash string', () => {
+    const key = '/x/hooks.json:stop:0:0'
+    writeFileSync(
+      configPath,
+      `[hooks.state."${key}"]\ntrusted_hash = "sha256:UNTERMINATED\n`,
+      'utf-8'
+    )
+
+    expect(readHookTrustEntries(configPath).get(key)?.trustedHash).toBeUndefined()
+  })
+
+  it('recognizes and removes a first trust block after a leading BOM', () => {
+    const key = '/x/hooks.json:stop:0:0'
+    const content = [
+      `\uFEFF[hooks.state."${key}"]`,
+      'trusted_hash = "sha256:ORCA"',
+      '[other]',
+      'value = true',
+      ''
+    ].join('\n')
+
+    expect(readHookTrustEntriesFromContent(content).get(key)?.trustedHash).toBe('sha256:ORCA')
+    expect(removeHookTrustEntriesFromContent(content, [key])).toBe('[other]\nvalue = true\n')
   })
 
   it('does not let triple quotes in comments hide later trust entries', () => {

--- a/src/main/codex/config-toml-trust.ts
+++ b/src/main/codex/config-toml-trust.ts
@@ -876,14 +876,18 @@ export function removeHookTrustEntries(configPath: string, keys: readonly string
     return
   }
   const existing = readTomlFile(configPath)
-  let updated = existing
-  for (const key of keys) {
-    updated = removeTrustBlock(updated, key)
-  }
+  const updated = removeHookTrustEntriesFromContent(existing, keys)
   if (updated === existing) {
     return
   }
   writeConfigAtomically(configPath, updated)
+}
+
+export function removeHookTrustEntriesFromContent(
+  content: string,
+  keys: readonly string[]
+): string {
+  return keys.reduce((updated, key) => removeTrustBlock(updated, key), content)
 }
 
 function removeTrustBlock(content: string, key: string): string {
@@ -902,11 +906,14 @@ function removeTrustBlock(content: string, key: string): string {
 }
 
 export function readHookTrustEntries(configPath: string): Map<string, CodexHookTrustState> {
-  const result = new HookTrustEntryMap()
   if (!existsSync(configPath)) {
-    return result
+    return new HookTrustEntryMap()
   }
-  const content = readTomlFile(configPath)
+  return readHookTrustEntriesFromContent(readTomlFile(configPath))
+}
+
+export function readHookTrustEntriesFromContent(content: string): Map<string, CodexHookTrustState> {
+  const result = new HookTrustEntryMap()
   // Why: walk line-by-line so `[hooks.state."..."]` inside a `"""..."""` or
   // `'''...'''` multi-line string isn't mistaken for a real header.
   let cursor = 0

--- a/src/main/codex/config-toml-trust.ts
+++ b/src/main/codex/config-toml-trust.ts
@@ -599,18 +599,34 @@ export function normalizeHookTrustKeyForLookup(key: string): string {
 }
 
 function findTrustBlockRanges(content: string, key: string): TrustBlockRange[] {
+  return findTrustBlockRangesForNormalizedKeys(
+    content,
+    new Set([normalizeHookTrustKeyForLookup(key)])
+  )
+}
+
+function findTrustBlockRangesForNormalizedKeys(
+  content: string,
+  normalizedKeys: ReadonlySet<string>
+): TrustBlockRange[] {
   const ranges: TrustBlockRange[] = []
-  const normalizedKey = normalizeHookTrustKeyForLookup(key)
+  if (normalizedKeys.size === 0) {
+    return ranges
+  }
   let cursor = 0
   let scanState = createTomlLineScanState()
   while (cursor < content.length) {
     const newlineIdx = content.indexOf('\n', cursor)
     const lineEnd = newlineIdx === -1 ? content.length : newlineIdx
     const rawLine = content.slice(cursor, lineEnd)
-    const line = rawLine.replace(/\r$/, '')
+    const lineWithoutCr = rawLine.replace(/\r$/, '')
+    const line =
+      cursor === 0 && lineWithoutCr.charCodeAt(0) === 0xfeff
+        ? lineWithoutCr.slice(1)
+        : lineWithoutCr
     const nextCursor = newlineIdx === -1 ? content.length : newlineIdx + 1
     const headerKey = isTomlStructuralLine(scanState) ? parseHookStateHeaderKey(line) : null
-    if (headerKey !== null && normalizeHookTrustKeyForLookup(headerKey) === normalizedKey) {
+    if (headerKey !== null && normalizedKeys.has(normalizeHookTrustKeyForLookup(headerKey))) {
       const headerLineEnd = rawLine.endsWith('\r') ? lineEnd - 1 : lineEnd
       const after = content.slice(headerLineEnd)
       const nextHeaderRel = findNextTableHeader(after)
@@ -887,11 +903,8 @@ export function removeHookTrustEntriesFromContent(
   content: string,
   keys: readonly string[]
 ): string {
-  return keys.reduce((updated, key) => removeTrustBlock(updated, key), content)
-}
-
-function removeTrustBlock(content: string, key: string): string {
-  const ranges = findTrustBlockRanges(content, key)
+  const normalizedKeys = new Set(keys.map(normalizeHookTrustKeyForLookup))
+  const ranges = findTrustBlockRangesForNormalizedKeys(content, normalizedKeys)
   if (ranges.length === 0) {
     return content
   }
@@ -912,8 +925,39 @@ export function readHookTrustEntries(configPath: string): Map<string, CodexHookT
   return readHookTrustEntriesFromContent(readTomlFile(configPath))
 }
 
+function readHookTrustBlockState(block: string): {
+  trustedHashes: Set<string>
+  enabled?: boolean
+} {
+  const trustedHashes = new Set<string>()
+  let enabled: boolean | undefined
+  let cursor = 0
+  let scanState = createTomlLineScanState()
+  while (cursor < block.length) {
+    const newlineIdx = block.indexOf('\n', cursor)
+    const lineEnd = newlineIdx === -1 ? block.length : newlineIdx
+    const line = block.slice(cursor, lineEnd).replace(/\r$/, '')
+    if (isTomlStructuralLine(scanState)) {
+      const hashMatch = /^[ \t]*trusted_hash[ \t]*=[ \t]*"((?:[^"\\]|\\.)*)"[ \t]*(?:#.*)?$/.exec(
+        line
+      )
+      if (hashMatch) {
+        trustedHashes.add(unescapeTomlString(hashMatch[1]))
+      }
+      const enabledMatch = /^[ \t]*enabled[ \t]*=[ \t]*(true|false)[ \t]*(?:#.*)?$/.exec(line)
+      if (enabledMatch) {
+        enabled = enabled !== false && enabledMatch[1] === 'true'
+      }
+    }
+    scanState = updateTomlLineScanState(scanState, line)
+    cursor = newlineIdx === -1 ? block.length : newlineIdx + 1
+  }
+  return { trustedHashes, enabled }
+}
+
 export function readHookTrustEntriesFromContent(content: string): Map<string, CodexHookTrustState> {
   const result = new HookTrustEntryMap()
+  const conflictingTrustedHashKeys = new Set<string>()
   // Why: walk line-by-line so `[hooks.state."..."]` inside a `"""..."""` or
   // `'''...'''` multi-line string isn't mistaken for a real header.
   let cursor = 0
@@ -922,7 +966,11 @@ export function readHookTrustEntriesFromContent(content: string): Map<string, Co
     const newlineIdx = content.indexOf('\n', cursor)
     const lineEnd = newlineIdx === -1 ? content.length : newlineIdx
     const rawLine = content.slice(cursor, lineEnd)
-    const line = rawLine.replace(/\r$/, '')
+    const lineWithoutCr = rawLine.replace(/\r$/, '')
+    const line =
+      cursor === 0 && lineWithoutCr.charCodeAt(0) === 0xfeff
+        ? lineWithoutCr.slice(1)
+        : lineWithoutCr
     const nextCursor = newlineIdx === -1 ? content.length : newlineIdx + 1
     const key = isTomlStructuralLine(scanState) ? parseHookStateHeaderKey(line) : null
     if (key !== null) {
@@ -931,21 +979,33 @@ export function readHookTrustEntriesFromContent(content: string): Map<string, Co
       const nextHeaderRel = findNextTableHeader(after)
       const blockEnd = nextHeaderRel === -1 ? content.length : nextCursor + nextHeaderRel
       const block = content.slice(nextCursor, blockEnd)
-      // Why: we own this block's shape (only `enabled` + `trusted_hash`), so
-      // a line scan beats pulling in a full TOML value parser.
-      const hashMatch = /^[ \t]*trusted_hash[ \t]*=[ \t]*"((?:[^"\\]|\\.)*)"/m.exec(block)
-      const enabledMatch = /^[ \t]*enabled[ \t]*=[ \t]*(true|false)[ \t\r]*(?:#.*)?$/m.exec(block)
+      const blockState = readHookTrustBlockState(block)
       const normalizedKey = normalizeHookTrustKeyForLookup(key)
       const existingState = result.get(normalizedKey)
-      const enabled = enabledMatch ? enabledMatch[1] === 'true' : undefined
+      const trustedHash =
+        blockState.trustedHashes.size === 1
+          ? blockState.trustedHashes.values().next().value
+          : undefined
+      if (
+        blockState.trustedHashes.size > 1 ||
+        (trustedHash !== undefined &&
+          existingState?.trustedHash !== undefined &&
+          existingState.trustedHash !== trustedHash)
+      ) {
+        // Why: conflicting normalized duplicates are malformed and cannot prove
+        // which block is owned, so trust cleanup must preserve them all.
+        conflictingTrustedHashKeys.add(normalizedKey)
+      }
       result.set(normalizedKey, {
-        trustedHash: hashMatch ? unescapeTomlString(hashMatch[1]) : existingState?.trustedHash,
+        trustedHash: conflictingTrustedHashKeys.has(normalizedKey)
+          ? undefined
+          : (trustedHash ?? existingState?.trustedHash),
         // Why: Windows writes both slash variants for one hook; a disabled copy
         // must remain authoritative regardless of which variant appears last.
         enabled:
-          existingState?.enabled === false || enabled === false
+          existingState?.enabled === false || blockState.enabled === false
             ? false
-            : (enabled ?? existingState?.enabled)
+            : (blockState.enabled ?? existingState?.enabled)
       })
       cursor = nextCursor
       continue


### PR DESCRIPTION
## What and why

Sanitize canonical Codex config before mirroring it into managed account homes. Orca-owned hook trust is identified with the existing expected-hash and grant-ledger ownership rules and removed from the mirrored bytes, while genuine user-authored hook trust is preserved.

This prevents real-home hook trust from referencing the wrong hooks.json path/hash in every managed account home and addresses user-case matrix rows 3 and 5.

## Verification

- `npx vitest run --config config/vitest.config.ts src/main/codex-accounts/service.test.ts` — 25 passed
- trust/reconciliation regression suites — 156 passed across config-toml-trust, real-home install, trust grant, and WSL runtime tests
- `pnpm run typecheck:node` — passed
- targeted oxlint — passed
- `pnpm run check:max-lines-ratchet` — passed

## Guardrails

- Tests use sandboxed temporary home and user-data directories only; the real `~/.codex` is never read or mutated.
- Canonical config and its grant ledger remain unchanged; sanitization is content-only before the ownership-marked managed-home atomic write.
- Flag-OFF behavior is unchanged.
- No merge or approval actions are included.