### PR TITLE
fix(mobile): keep main-buffer TUI footer above the iOS keyboard

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -107,6 +107,7 @@ import type {
   TerminalWebViewHandle
 } from '../../../../src/terminal/terminal-webview-contract'
 import { isTerminalOscLinkRanges } from '../../../../src/terminal/terminal-osc-link-ranges'
+import { computeActiveTerminalKeyboardLift } from '../../../../src/terminal/terminal-keyboard-avoidance-lift'
 import { useTerminalViewportRefit } from '../../../../src/terminal/terminal-viewport-refit'
 import {
   getDefaultTerminalAccessoryBuiltInIds,
@@ -3590,6 +3591,7 @@ export default function SessionScreen() {
         if (
           current &&
           current.cursorY === metrics.cursorY &&
+          current.contentBottomRow === metrics.contentBottomRow &&
           current.rows === metrics.rows &&
           current.altScreen === metrics.altScreen
         ) {
@@ -4271,24 +4273,11 @@ export default function SessionScreen() {
         ? Math.max(0, keyboardHeight - insets.bottom)
         : keyboardHeight
       : 0
-  const activeTerminalKeyboardLift = (() => {
-    if (keyboardLift <= 0 || !activeHandle) {
-      return 0
-    }
-    const metrics = terminalKeyboardMetrics.get(activeHandle)
-    if (!metrics || metrics.rows <= 0 || terminalFrameHeightRef.current <= 0) {
-      return keyboardLift
-    }
-    if (metrics.altScreen) {
-      return keyboardLift
-    }
-    const rowHeight = terminalFrameHeightRef.current / metrics.rows
-    const cursorBottom = (metrics.cursorY + 1) * rowHeight
-    const dockTop = terminalFrameHeightRef.current - keyboardLift
-    const margin = rowHeight
-    // Why: only move the terminal when the cursor would sit under the raised input dock; short top output stays put.
-    return Math.min(keyboardLift, Math.max(0, cursorBottom + margin - dockTop))
-  })()
+  const activeTerminalKeyboardLift = computeActiveTerminalKeyboardLift({
+    keyboardLift,
+    metrics: activeHandle ? terminalKeyboardMetrics.get(activeHandle) : undefined,
+    terminalFrameHeight: terminalFrameHeightRef.current
+  })
   const toastAnimatedStyle = {
     opacity: toastOpacityRef.current,
     transform: [{ translateY: -keyboardLift }]

--- a/mobile/src/terminal/terminal-keyboard-avoidance-lift.test.ts
+++ b/mobile/src/terminal/terminal-keyboard-avoidance-lift.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
 import { computeActiveTerminalKeyboardLift } from './terminal-keyboard-avoidance-lift'
+import { parseTerminalKeyboardAvoidanceMetrics } from './terminal-webview-contract'
 import type { TerminalKeyboardAvoidanceMetrics } from './terminal-webview-contract'
 
-// rowHeight = 800 / 40 = 20px; dockTop = 800 - 300 = 500px
 const FRAME_HEIGHT = 800
 const ROWS = 40
 const KEYBOARD_LIFT = 300
@@ -62,19 +62,19 @@ describe('computeActiveTerminalKeyboardLift', () => {
     ).toBe(KEYBOARD_LIFT)
   })
 
-  it('anchors on the footer, not the caret, for a main-buffer full-screen TUI (Pi)', () => {
-    // Caret at row 30, footer/status chrome down to row 34.
-    const lift = computeActiveTerminalKeyboardLift({
+  it('clears a main-buffer footer while an old payload retains cursor-only behavior', () => {
+    const candidate = computeActiveTerminalKeyboardLift({
       keyboardLift: KEYBOARD_LIFT,
       metrics: metrics({ cursorY: 30, contentBottomRow: 34 }),
       terminalFrameHeight: FRAME_HEIGHT
     })
-    // anchorBottom = (34+1)*20 = 700; 700 + 20 - 500 = 220
-    expect(lift).toBe(220)
-    // Regression guard: cursor-only anchoring would under-lift and leave the
-    // footer under the keyboard.
-    const cursorOnly = (30 + 1) * 20 + 20 - 500
-    expect(lift).toBeGreaterThan(cursorOnly)
+    const oldPayload = parseTerminalKeyboardAvoidanceMetrics({ cursorY: 30, rows: ROWS })
+    const cursorOnly = computeActiveTerminalKeyboardLift({
+      keyboardLift: KEYBOARD_LIFT,
+      metrics: oldPayload,
+      terminalFrameHeight: FRAME_HEIGHT
+    })
+    expect({ candidate, cursorOnly }).toEqual({ candidate: 220, cursorOnly: 140 })
   })
 
   it('keeps short output near the top put (no lift)', () => {
@@ -88,13 +88,11 @@ describe('computeActiveTerminalKeyboardLift', () => {
   })
 
   it('matches cursor-clearing behavior for a scrolled shell (prompt at the bottom)', () => {
-    // Prompt/caret is the last content row.
     const lift = computeActiveTerminalKeyboardLift({
       keyboardLift: KEYBOARD_LIFT,
       metrics: metrics({ cursorY: 38, contentBottomRow: 38 }),
       terminalFrameHeight: FRAME_HEIGHT
     })
-    // anchorBottom = 39*20 = 780; 780 + 20 - 500 = 300, clamped to keyboardLift
     expect(lift).toBe(KEYBOARD_LIFT)
   })
 
@@ -105,5 +103,20 @@ describe('computeActiveTerminalKeyboardLift', () => {
       terminalFrameHeight: FRAME_HEIGHT
     })
     expect(lift).toBeLessThanOrEqual(KEYBOARD_LIFT)
+  })
+
+  it('uses the platform-adjusted lift proportionally on iOS and Android', () => {
+    const tuiMetrics = metrics({ cursorY: 30, contentBottomRow: 34 })
+    const android = computeActiveTerminalKeyboardLift({
+      keyboardLift: 300,
+      metrics: tuiMetrics,
+      terminalFrameHeight: FRAME_HEIGHT
+    })
+    const ios = computeActiveTerminalKeyboardLift({
+      keyboardLift: 266,
+      metrics: tuiMetrics,
+      terminalFrameHeight: FRAME_HEIGHT
+    })
+    expect({ android, ios }).toEqual({ android: 220, ios: 186 })
   })
 })

--- a/mobile/src/terminal/terminal-keyboard-avoidance-lift.test.ts
+++ b/mobile/src/terminal/terminal-keyboard-avoidance-lift.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeActiveTerminalKeyboardLift } from './terminal-keyboard-avoidance-lift'
+import type { TerminalKeyboardAvoidanceMetrics } from './terminal-webview-contract'
+
+// rowHeight = 800 / 40 = 20px; dockTop = 800 - 300 = 500px
+const FRAME_HEIGHT = 800
+const ROWS = 40
+const KEYBOARD_LIFT = 300
+
+function metrics(
+  overrides: Partial<TerminalKeyboardAvoidanceMetrics> = {}
+): TerminalKeyboardAvoidanceMetrics {
+  return { cursorY: 0, contentBottomRow: 0, rows: ROWS, altScreen: false, ...overrides }
+}
+
+describe('computeActiveTerminalKeyboardLift', () => {
+  it('returns 0 when the keyboard is closed', () => {
+    expect(
+      computeActiveTerminalKeyboardLift({
+        keyboardLift: 0,
+        metrics: metrics({ cursorY: 30, contentBottomRow: 34 }),
+        terminalFrameHeight: FRAME_HEIGHT
+      })
+    ).toBe(0)
+  })
+
+  it('falls back to the full lift when metrics are missing', () => {
+    expect(
+      computeActiveTerminalKeyboardLift({
+        keyboardLift: KEYBOARD_LIFT,
+        metrics: undefined,
+        terminalFrameHeight: FRAME_HEIGHT
+      })
+    ).toBe(KEYBOARD_LIFT)
+  })
+
+  it('falls back to the full lift when rows or frame height are unmeasured', () => {
+    expect(
+      computeActiveTerminalKeyboardLift({
+        keyboardLift: KEYBOARD_LIFT,
+        metrics: metrics({ rows: 0 }),
+        terminalFrameHeight: FRAME_HEIGHT
+      })
+    ).toBe(KEYBOARD_LIFT)
+    expect(
+      computeActiveTerminalKeyboardLift({
+        keyboardLift: KEYBOARD_LIFT,
+        metrics: metrics(),
+        terminalFrameHeight: 0
+      })
+    ).toBe(KEYBOARD_LIFT)
+  })
+
+  it('lifts fully for alt-screen TUIs', () => {
+    expect(
+      computeActiveTerminalKeyboardLift({
+        keyboardLift: KEYBOARD_LIFT,
+        metrics: metrics({ cursorY: 10, contentBottomRow: 10, altScreen: true }),
+        terminalFrameHeight: FRAME_HEIGHT
+      })
+    ).toBe(KEYBOARD_LIFT)
+  })
+
+  it('anchors on the footer, not the caret, for a main-buffer full-screen TUI (Pi)', () => {
+    // Caret at row 30, footer/status chrome down to row 34.
+    const lift = computeActiveTerminalKeyboardLift({
+      keyboardLift: KEYBOARD_LIFT,
+      metrics: metrics({ cursorY: 30, contentBottomRow: 34 }),
+      terminalFrameHeight: FRAME_HEIGHT
+    })
+    // anchorBottom = (34+1)*20 = 700; 700 + 20 - 500 = 220
+    expect(lift).toBe(220)
+    // Regression guard: cursor-only anchoring would under-lift and leave the
+    // footer under the keyboard.
+    const cursorOnly = (30 + 1) * 20 + 20 - 500
+    expect(lift).toBeGreaterThan(cursorOnly)
+  })
+
+  it('keeps short output near the top put (no lift)', () => {
+    expect(
+      computeActiveTerminalKeyboardLift({
+        keyboardLift: KEYBOARD_LIFT,
+        metrics: metrics({ cursorY: 2, contentBottomRow: 5 }),
+        terminalFrameHeight: FRAME_HEIGHT
+      })
+    ).toBe(0)
+  })
+
+  it('matches cursor-clearing behavior for a scrolled shell (prompt at the bottom)', () => {
+    // Prompt/caret is the last content row.
+    const lift = computeActiveTerminalKeyboardLift({
+      keyboardLift: KEYBOARD_LIFT,
+      metrics: metrics({ cursorY: 38, contentBottomRow: 38 }),
+      terminalFrameHeight: FRAME_HEIGHT
+    })
+    // anchorBottom = 39*20 = 780; 780 + 20 - 500 = 300, clamped to keyboardLift
+    expect(lift).toBe(KEYBOARD_LIFT)
+  })
+
+  it('never exceeds the keyboard lift', () => {
+    const lift = computeActiveTerminalKeyboardLift({
+      keyboardLift: KEYBOARD_LIFT,
+      metrics: metrics({ cursorY: 39, contentBottomRow: 39 }),
+      terminalFrameHeight: FRAME_HEIGHT
+    })
+    expect(lift).toBeLessThanOrEqual(KEYBOARD_LIFT)
+  })
+})

--- a/mobile/src/terminal/terminal-keyboard-avoidance-lift.ts
+++ b/mobile/src/terminal/terminal-keyboard-avoidance-lift.ts
@@ -1,25 +1,11 @@
 import type { TerminalKeyboardAvoidanceMetrics } from './terminal-webview-contract'
 
 type ActiveTerminalKeyboardLiftParams = {
-  // Screen-space keyboard lift (keyboard height minus the home-indicator inset
-  // on iOS); 0 when the keyboard is closed.
   keyboardLift: number
-  // Latest keyboard-avoidance metrics for the active terminal, or undefined
-  // when none have been reported yet.
   metrics: TerminalKeyboardAvoidanceMetrics | undefined
-  // Measured height of the terminal frame in px.
   terminalFrameHeight: number
 }
 
-// Why: when the keyboard opens we translate the terminal up instead of resizing
-// the PTY. How far to translate depends on what content must stay visible:
-//   - alt-screen TUIs (vim, etc.): the whole viewport is meaningful -> full lift.
-//   - main-buffer full-screen TUIs (e.g. the Pi agent): footer/status rows render
-//     BELOW the input caret, so anchoring on the cursor alone leaves them under
-//     the keyboard. Anchor on the bottom-most content row instead.
-//   - short shell output near the top: nothing at the bottom -> no lift.
-//   - scrolled shell with the prompt at the bottom: the prompt is the last
-//     content row, so this matches cursor-based behavior.
 export function computeActiveTerminalKeyboardLift(
   params: ActiveTerminalKeyboardLiftParams
 ): number {
@@ -34,8 +20,7 @@ export function computeActiveTerminalKeyboardLift(
     return keyboardLift
   }
   const rowHeight = terminalFrameHeight / metrics.rows
-  // Anchor on the lower of the caret and the last non-blank viewport row so
-  // below-caret chrome (Pi's footer/status) clears the raised input dock.
+  // Main-buffer TUI footer rows can sit below the caret.
   const anchorRow = Math.max(metrics.cursorY, metrics.contentBottomRow)
   const anchorBottom = (anchorRow + 1) * rowHeight
   const dockTop = terminalFrameHeight - keyboardLift

--- a/mobile/src/terminal/terminal-keyboard-avoidance-lift.ts
+++ b/mobile/src/terminal/terminal-keyboard-avoidance-lift.ts
@@ -1,0 +1,44 @@
+import type { TerminalKeyboardAvoidanceMetrics } from './terminal-webview-contract'
+
+type ActiveTerminalKeyboardLiftParams = {
+  // Screen-space keyboard lift (keyboard height minus the home-indicator inset
+  // on iOS); 0 when the keyboard is closed.
+  keyboardLift: number
+  // Latest keyboard-avoidance metrics for the active terminal, or undefined
+  // when none have been reported yet.
+  metrics: TerminalKeyboardAvoidanceMetrics | undefined
+  // Measured height of the terminal frame in px.
+  terminalFrameHeight: number
+}
+
+// Why: when the keyboard opens we translate the terminal up instead of resizing
+// the PTY. How far to translate depends on what content must stay visible:
+//   - alt-screen TUIs (vim, etc.): the whole viewport is meaningful -> full lift.
+//   - main-buffer full-screen TUIs (e.g. the Pi agent): footer/status rows render
+//     BELOW the input caret, so anchoring on the cursor alone leaves them under
+//     the keyboard. Anchor on the bottom-most content row instead.
+//   - short shell output near the top: nothing at the bottom -> no lift.
+//   - scrolled shell with the prompt at the bottom: the prompt is the last
+//     content row, so this matches cursor-based behavior.
+export function computeActiveTerminalKeyboardLift(
+  params: ActiveTerminalKeyboardLiftParams
+): number {
+  const { keyboardLift, metrics, terminalFrameHeight } = params
+  if (keyboardLift <= 0) {
+    return 0
+  }
+  if (!metrics || metrics.rows <= 0 || terminalFrameHeight <= 0) {
+    return keyboardLift
+  }
+  if (metrics.altScreen) {
+    return keyboardLift
+  }
+  const rowHeight = terminalFrameHeight / metrics.rows
+  // Anchor on the lower of the caret and the last non-blank viewport row so
+  // below-caret chrome (Pi's footer/status) clears the raised input dock.
+  const anchorRow = Math.max(metrics.cursorY, metrics.contentBottomRow)
+  const anchorBottom = (anchorRow + 1) * rowHeight
+  const dockTop = terminalFrameHeight - keyboardLift
+  const margin = rowHeight
+  return Math.min(keyboardLift, Math.max(0, anchorBottom + margin - dockTop))
+}

--- a/mobile/src/terminal/terminal-keyboard-avoidance-metrics-injected.ts
+++ b/mobile/src/terminal/terminal-keyboard-avoidance-metrics-injected.ts
@@ -1,6 +1,6 @@
 export const TERMINAL_KEYBOARD_AVOIDANCE_METRICS_JS = `
   function lineHasVisibleContent(line, cell) {
-    if (line.translateToString(true).length > 0) return true;
+    if (line.translateToString(true).trim().length > 0) return true;
     if (!cell || !line.getCell) return false;
     var limit = Math.min(term.cols || 0, line.length || 0);
     for (var x = 0; x < limit; x++) {

--- a/mobile/src/terminal/terminal-keyboard-avoidance-metrics-injected.ts
+++ b/mobile/src/terminal/terminal-keyboard-avoidance-metrics-injected.ts
@@ -1,0 +1,39 @@
+export const TERMINAL_KEYBOARD_AVOIDANCE_METRICS_JS = `
+  function lineHasVisibleContent(line, cell) {
+    if (line.translateToString(true).length > 0) return true;
+    if (!cell || !line.getCell) return false;
+    var limit = Math.min(term.cols || 0, line.length || 0);
+    for (var x = 0; x < limit; x++) {
+      var current = line.getCell(x, cell);
+      if (current && (!current.isBgDefault() || current.isInverse())) return true;
+    }
+    return false;
+  }
+
+  function computeContentBottomRow() {
+    if (!term || !term.buffer || !term.buffer.active) return 0;
+    var buffer = term.buffer.active;
+    var top = buffer.viewportY || 0;
+    var cell = buffer.getNullCell ? buffer.getNullCell() : null;
+    for (var y = (term.rows || 0) - 1; y >= 0; y--) {
+      try {
+        var line = buffer.getLine(top + y);
+        if (line && lineHasVisibleContent(line, cell)) return y;
+      } catch (e) {}
+    }
+    return 0;
+  }
+
+  function emitKeyboardAvoidanceMetrics() {
+    if (!term) return;
+    var alt = false;
+    try { alt = term.buffer && term.buffer.active && term.buffer.active.type === 'alternate'; } catch (e) {}
+    notify({
+      type: 'keyboard-avoidance-metrics',
+      cursorY: term.buffer && term.buffer.active ? term.buffer.active.cursorY : 0,
+      contentBottomRow: alt ? 0 : computeContentBottomRow(),
+      rows: term.rows || 0,
+      altScreen: alt
+    });
+  }
+`

--- a/mobile/src/terminal/terminal-keyboard-avoidance-metrics-injected.ts
+++ b/mobile/src/terminal/terminal-keyboard-avoidance-metrics-injected.ts
@@ -5,7 +5,11 @@ export const TERMINAL_KEYBOARD_AVOIDANCE_METRICS_JS = `
     var limit = Math.min(term.cols || 0, line.length || 0);
     for (var x = 0; x < limit; x++) {
       var current = line.getCell(x, cell);
-      if (current && (!current.isBgDefault() || current.isInverse())) return true;
+      if (!current) continue;
+      if (!current.isBgDefault() || current.isInverse()) return true;
+      if (typeof current.isUnderline === 'function' && current.isUnderline()) return true;
+      if (typeof current.isStrikethrough === 'function' && current.isStrikethrough()) return true;
+      if (typeof current.isOverline === 'function' && current.isOverline()) return true;
     }
     return false;
   }

--- a/mobile/src/terminal/terminal-keyboard-avoidance-webview.test.ts
+++ b/mobile/src/terminal/terminal-keyboard-avoidance-webview.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { Script } from 'node:vm'
+import { Terminal } from '@xterm/xterm'
 import { describe, expect, it, vi } from 'vitest'
 import { TERMINAL_KEYBOARD_AVOIDANCE_METRICS_JS } from './terminal-keyboard-avoidance-metrics-injected'
 
@@ -47,6 +48,21 @@ function runMetrics(lines: Array<ReturnType<typeof makeLine> | undefined>, altSc
   return notifications[0]
 }
 
+function runTerminalMetrics(term: Terminal) {
+  const notifications: Array<Record<string, unknown>> = []
+  new Script(
+    `${TERMINAL_KEYBOARD_AVOIDANCE_METRICS_JS}\nemitKeyboardAvoidanceMetrics();`
+  ).runInNewContext({
+    notify: (message: Record<string, unknown>) => notifications.push(message),
+    term
+  })
+  return notifications[0]
+}
+
+function write(term: Terminal, data: string): Promise<void> {
+  return new Promise((resolve) => term.write(data, resolve))
+}
+
 describe('terminal keyboard-avoidance WebView metrics', () => {
   it('finds text on wrapped rows using the visible viewport offset', () => {
     const lines = [makeLine('header'), makeLine(''), makeLine('wrapped footer')]
@@ -61,6 +77,25 @@ describe('terminal keyboard-avoidance WebView metrics', () => {
     expect(runMetrics([makeLine('header'), makeLine(''), makeLine('', [4])])).toMatchObject({
       contentBottomRow: 2
     })
+  })
+
+  it('ignores real xterm default spaces but keeps visible rows', async () => {
+    const cases = [
+      { data: '     ', expected: 0 },
+      { data: 'footer', expected: 7 },
+      { data: '\x1b[41m     \x1b[0m', expected: 7 },
+      { data: '\x1b[7m     \x1b[0m', expected: 7 }
+    ]
+
+    for (const { data, expected } of cases) {
+      const term = new Terminal({ cols: 10, rows: 8 })
+      try {
+        await write(term, `\x1b[8;1H${data}`)
+        expect(runTerminalMetrics(term)).toMatchObject({ contentBottomRow: expected })
+      } finally {
+        term.dispose()
+      }
+    }
   })
 
   it('stops at the first bottom-up match and skips scans on alternate screen', () => {

--- a/mobile/src/terminal/terminal-keyboard-avoidance-webview.test.ts
+++ b/mobile/src/terminal/terminal-keyboard-avoidance-webview.test.ts
@@ -3,6 +3,7 @@ import { Script } from 'node:vm'
 import { Terminal } from '@xterm/xterm'
 import { describe, expect, it, vi } from 'vitest'
 import { TERMINAL_KEYBOARD_AVOIDANCE_METRICS_JS } from './terminal-keyboard-avoidance-metrics-injected'
+import { parseTerminalKeyboardAvoidanceMetrics } from './terminal-webview-contract'
 
 const terminalHtmlSource = readFileSync(
   new URL('./terminal-webview-html.ts', import.meta.url),
@@ -14,6 +15,13 @@ const reflowSource = readFileSync(
 )
 
 type Cell = { isBgDefault: () => boolean; isInverse: () => number }
+type MetricsNotification = {
+  type: string
+  cursorY: number
+  contentBottomRow: number
+  rows: number
+  altScreen: boolean
+}
 
 function makeLine(text = '', styledColumns: number[] = []) {
   const styled = new Set(styledColumns)
@@ -28,8 +36,8 @@ function makeLine(text = '', styledColumns: number[] = []) {
   }
 }
 
-function runMetrics(lines: Array<ReturnType<typeof makeLine> | undefined>, altScreen = false) {
-  const notifications: Array<Record<string, unknown>> = []
+function runMetrics(lines: (ReturnType<typeof makeLine> | undefined)[], altScreen = false) {
+  const notifications: Record<string, unknown>[] = []
   const buffer = {
     cursorY: 2,
     viewportY: 3,
@@ -45,18 +53,18 @@ function runMetrics(lines: Array<ReturnType<typeof makeLine> | undefined>, altSc
   new Script(
     `${TERMINAL_KEYBOARD_AVOIDANCE_METRICS_JS}\nemitKeyboardAvoidanceMetrics();`
   ).runInNewContext(context)
-  return notifications[0]
+  return notifications[0] as MetricsNotification
 }
 
 function runTerminalMetrics(term: Terminal) {
-  const notifications: Array<Record<string, unknown>> = []
+  const notifications: Record<string, unknown>[] = []
   new Script(
     `${TERMINAL_KEYBOARD_AVOIDANCE_METRICS_JS}\nemitKeyboardAvoidanceMetrics();`
   ).runInNewContext({
     notify: (message: Record<string, unknown>) => notifications.push(message),
     term
   })
-  return notifications[0]
+  return notifications[0] as MetricsNotification
 }
 
 function write(term: Terminal, data: string): Promise<void> {
@@ -70,7 +78,7 @@ describe('terminal keyboard-avoidance WebView metrics', () => {
     expect(runMetrics(lines)).toMatchObject({ contentBottomRow: 2 })
   })
 
-  it('ignores blank rows but keeps background-only ANSI chrome visible', () => {
+  it('supports cells without decoration APIs and keeps background-only ANSI chrome visible', () => {
     expect(runMetrics([makeLine('header'), makeLine(''), makeLine('')])).toMatchObject({
       contentBottomRow: 0
     })
@@ -79,20 +87,91 @@ describe('terminal keyboard-avoidance WebView metrics', () => {
     })
   })
 
-  it('ignores real xterm default spaces but keeps visible rows', async () => {
+  it('classifies real xterm text and styled whitespace by rendered visibility', async () => {
     const cases = [
-      { data: '     ', expected: 0 },
-      { data: 'footer', expected: 7 },
-      { data: '\x1b[41m     \x1b[0m', expected: 7 },
-      { data: '\x1b[7m     \x1b[0m', expected: 7 }
+      { name: 'default spaces', data: '     ', expected: 0 },
+      { name: 'text', data: 'footer', expected: 7 },
+      { name: 'background', data: '\x1b[41m     \x1b[0m', expected: 7 },
+      { name: 'inverse', data: '\x1b[7m     \x1b[0m', expected: 7 },
+      { name: 'underline', data: '\x1b[4m     \x1b[0m', expected: 7 },
+      { name: 'strikethrough', data: '\x1b[9m     \x1b[0m', expected: 7 },
+      { name: 'overline', data: '\x1b[53m     \x1b[0m', expected: 7 },
+      // Hidden text still reserves TUI layout, so keyboard avoidance treats it as content.
+      { name: 'invisible text', data: '\x1b[8mfooter\x1b[0m', expected: 7 }
     ]
 
-    for (const { data, expected } of cases) {
+    for (const { name, data, expected } of cases) {
       const term = new Terminal({ cols: 10, rows: 8 })
       try {
         await write(term, `\x1b[8;1H${data}`)
-        expect(runTerminalMetrics(term)).toMatchObject({ contentBottomRow: expected })
+        expect(runTerminalMetrics(term), name).toMatchObject({ contentBottomRow: expected })
       } finally {
+        term.dispose()
+      }
+    }
+  })
+
+  it('tracks the real xterm viewport and alternate screen', async () => {
+    const term = new Terminal({ cols: 10, rows: 4, scrollback: 100 })
+    try {
+      await write(term, 'header\r\n\r\n\r\n\r\nfooter')
+      expect(runTerminalMetrics(term)).toMatchObject({ contentBottomRow: 3, altScreen: false })
+      term.scrollLines(-2)
+      expect(runTerminalMetrics(term)).toMatchObject({ contentBottomRow: 0, altScreen: false })
+      await write(term, '\x1b[?1049h\x1b[4m     \x1b[0m')
+      expect(runTerminalMetrics(term)).toMatchObject({ contentBottomRow: 0, altScreen: true })
+    } finally {
+      term.dispose()
+    }
+  })
+
+  it('follows real xterm resize and reset state', async () => {
+    const term = new Terminal({ cols: 10, rows: 8 })
+    try {
+      await write(term, '\x1b[8;1Hfooter')
+      expect(runTerminalMetrics(term)).toMatchObject({ contentBottomRow: 7 })
+      term.resize(10, 4)
+      expect(runTerminalMetrics(term)).toMatchObject({ contentBottomRow: 3 })
+      term.reset()
+      expect(runTerminalMetrics(term)).toMatchObject({ contentBottomRow: 0 })
+    } finally {
+      term.dispose()
+    }
+  })
+
+  it('keeps real xterm metrics compatible with old payloads', async () => {
+    const term = new Terminal({ cols: 10, rows: 8 })
+    try {
+      await write(term, '\x1b[8;1Hfooter\x1b[2;1H')
+      const { cursorY, rows, altScreen } = runTerminalMetrics(term)
+      expect(parseTerminalKeyboardAvoidanceMetrics({ cursorY, rows, altScreen })).toEqual({
+        cursorY: 1,
+        contentBottomRow: 1,
+        rows: 8,
+        altScreen: false
+      })
+    } finally {
+      term.dispose()
+    }
+  })
+
+  it('releases real xterm metric observers across terminal lifecycles', async () => {
+    for (let cycle = 0; cycle < 25; cycle += 1) {
+      const term = new Terminal({ cols: 10, rows: 4 })
+      let emissions = 0
+      const observer = term.onWriteParsed(() => {
+        runTerminalMetrics(term)
+        emissions += 1
+      })
+      try {
+        await write(term, `cycle ${cycle}`)
+        expect(emissions).toBeGreaterThan(0)
+        observer.dispose()
+        const disposedAt = emissions
+        await write(term, ' after dispose')
+        expect(emissions).toBe(disposedAt)
+      } finally {
+        observer.dispose()
         term.dispose()
       }
     }

--- a/mobile/src/terminal/terminal-keyboard-avoidance-webview.test.ts
+++ b/mobile/src/terminal/terminal-keyboard-avoidance-webview.test.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from 'node:fs'
+import { Script } from 'node:vm'
+import { describe, expect, it, vi } from 'vitest'
+import { TERMINAL_KEYBOARD_AVOIDANCE_METRICS_JS } from './terminal-keyboard-avoidance-metrics-injected'
+
+const terminalHtmlSource = readFileSync(
+  new URL('./terminal-webview-html.ts', import.meta.url),
+  'utf8'
+)
+const reflowSource = readFileSync(
+  new URL('./terminal-webview-reflow-injected.ts', import.meta.url),
+  'utf8'
+)
+
+type Cell = { isBgDefault: () => boolean; isInverse: () => number }
+
+function makeLine(text = '', styledColumns: number[] = []) {
+  const styled = new Set(styledColumns)
+  return {
+    isWrapped: false,
+    length: 10,
+    translateToString: vi.fn(() => text),
+    getCell: (column: number): Cell => ({
+      isBgDefault: () => !styled.has(column),
+      isInverse: () => 0
+    })
+  }
+}
+
+function runMetrics(lines: Array<ReturnType<typeof makeLine> | undefined>, altScreen = false) {
+  const notifications: Array<Record<string, unknown>> = []
+  const buffer = {
+    cursorY: 2,
+    viewportY: 3,
+    type: altScreen ? 'alternate' : 'normal',
+    getLine: (index: number) => lines[index - 3],
+    getNullCell: () => ({})
+  }
+  const context = {
+    notifications,
+    notify: (message: Record<string, unknown>) => notifications.push(message),
+    term: { buffer: { active: buffer }, cols: 10, rows: lines.length }
+  }
+  new Script(
+    `${TERMINAL_KEYBOARD_AVOIDANCE_METRICS_JS}\nemitKeyboardAvoidanceMetrics();`
+  ).runInNewContext(context)
+  return notifications[0]
+}
+
+describe('terminal keyboard-avoidance WebView metrics', () => {
+  it('finds text on wrapped rows using the visible viewport offset', () => {
+    const lines = [makeLine('header'), makeLine(''), makeLine('wrapped footer')]
+    lines[2]!.isWrapped = true
+    expect(runMetrics(lines)).toMatchObject({ contentBottomRow: 2 })
+  })
+
+  it('ignores blank rows but keeps background-only ANSI chrome visible', () => {
+    expect(runMetrics([makeLine('header'), makeLine(''), makeLine('')])).toMatchObject({
+      contentBottomRow: 0
+    })
+    expect(runMetrics([makeLine('header'), makeLine(''), makeLine('', [4])])).toMatchObject({
+      contentBottomRow: 2
+    })
+  })
+
+  it('stops at the first bottom-up match and skips scans on alternate screen', () => {
+    const footer = makeLine('footer')
+    const header = makeLine('header')
+    expect(runMetrics([header, makeLine(''), footer])).toMatchObject({ contentBottomRow: 2 })
+    expect(footer.translateToString).toHaveBeenCalledTimes(1)
+    expect(header.translateToString).not.toHaveBeenCalled()
+
+    footer.translateToString.mockImplementation(() => {
+      throw new Error('alternate screen must not scan')
+    })
+    expect(runMetrics([header, makeLine(''), footer], true)).toMatchObject({
+      altScreen: true,
+      contentBottomRow: 0
+    })
+  })
+
+  it('refreshes metrics after every buffer geometry reset', () => {
+    const resizeStart = terminalHtmlSource.indexOf('  function resize(cols, rows)')
+    const resizeEnd = terminalHtmlSource.indexOf('\n  // reflow()', resizeStart)
+    const clearStart = terminalHtmlSource.indexOf("} else if (msg.type === 'clear') {")
+    const clearEnd = terminalHtmlSource.indexOf("} else if (msg.type === 'measure')", clearStart)
+    const textScaleStart = terminalHtmlSource.indexOf('  function applyTextScale(scale)')
+    const textScaleEnd = terminalHtmlSource.indexOf('\n  var panX', textScaleStart)
+
+    for (const block of [
+      terminalHtmlSource.slice(resizeStart, resizeEnd),
+      terminalHtmlSource.slice(clearStart, clearEnd),
+      terminalHtmlSource.slice(textScaleStart, textScaleEnd),
+      reflowSource
+    ]) {
+      expect(block.indexOf('emitKeyboardAvoidanceMetrics()')).toBeGreaterThan(
+        block.includes('term.resize') ? block.indexOf('term.resize') : block.indexOf('term.reset')
+      )
+    }
+  })
+})

--- a/mobile/src/terminal/terminal-webview-contract.test.ts
+++ b/mobile/src/terminal/terminal-webview-contract.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseTerminalKeyboardAvoidanceMetrics } from './terminal-webview-contract'
+
+describe('parseTerminalKeyboardAvoidanceMetrics', () => {
+  it('coerces a full payload', () => {
+    expect(
+      parseTerminalKeyboardAvoidanceMetrics({
+        cursorY: 30,
+        contentBottomRow: 34,
+        rows: 40,
+        altScreen: true
+      })
+    ).toEqual({ cursorY: 30, contentBottomRow: 34, rows: 40, altScreen: true })
+  })
+
+  it('defaults contentBottomRow to cursorY when absent (older WebView bundles)', () => {
+    expect(parseTerminalKeyboardAvoidanceMetrics({ cursorY: 12, rows: 40 })).toEqual({
+      cursorY: 12,
+      contentBottomRow: 12,
+      rows: 40,
+      altScreen: false
+    })
+  })
+
+  it('defaults non-numeric fields to zero', () => {
+    expect(parseTerminalKeyboardAvoidanceMetrics({})).toEqual({
+      cursorY: 0,
+      contentBottomRow: 0,
+      rows: 0,
+      altScreen: false
+    })
+  })
+})

--- a/mobile/src/terminal/terminal-webview-contract.test.ts
+++ b/mobile/src/terminal/terminal-webview-contract.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { parseTerminalKeyboardAvoidanceMetrics } from './terminal-webview-contract'
 
 describe('parseTerminalKeyboardAvoidanceMetrics', () => {
-  it('coerces a full payload', () => {
+  it('parses a full payload', () => {
     expect(
       parseTerminalKeyboardAvoidanceMetrics({
         cursorY: 30,
@@ -30,5 +30,23 @@ describe('parseTerminalKeyboardAvoidanceMetrics', () => {
       rows: 0,
       altScreen: false
     })
+  })
+
+  it('bounds untrusted numeric fields to the reported viewport', () => {
+    expect(
+      parseTerminalKeyboardAvoidanceMetrics({
+        cursorY: Number.POSITIVE_INFINITY,
+        contentBottomRow: 99.8,
+        rows: 40.7,
+        altScreen: 'true'
+      })
+    ).toEqual({ cursorY: 0, contentBottomRow: 39, rows: 40, altScreen: false })
+    expect(
+      parseTerminalKeyboardAvoidanceMetrics({
+        cursorY: -4,
+        contentBottomRow: Number.NaN,
+        rows: -1
+      })
+    ).toEqual({ cursorY: 0, contentBottomRow: 0, rows: 0, altScreen: false })
   })
 })

--- a/mobile/src/terminal/terminal-webview-contract.ts
+++ b/mobile/src/terminal/terminal-webview-contract.ts
@@ -14,26 +14,32 @@ export type TerminalModes = {
 
 export type TerminalKeyboardAvoidanceMetrics = {
   cursorY: number
-  // Why: last non-blank viewport row (0-based). Full-screen TUIs in the main
-  // buffer (e.g. the Pi agent) render footer/status rows below the caret, so
-  // keyboard avoidance anchors on this, not just cursorY. See worktreeId.tsx.
+  // Main-buffer TUIs can render footer rows below the caret.
   contentBottomRow: number
   rows: number
   altScreen: boolean
 }
 
-// Why: coerce the raw WebView keyboard-avoidance payload into typed metrics.
-// contentBottomRow defaults to cursorY so older WebView bundles keep working.
 export function parseTerminalKeyboardAvoidanceMetrics(
   msg: Record<string, unknown>
 ): TerminalKeyboardAvoidanceMetrics {
-  const cursorY = typeof msg.cursorY === 'number' ? msg.cursorY : 0
+  const rows = toNonNegativeInteger(msg.rows)
+  const maxRow = Math.max(0, rows - 1)
+  const cursorY = Math.min(toNonNegativeInteger(msg.cursorY), maxRow)
+  const contentBottomRow =
+    msg.contentBottomRow === undefined
+      ? cursorY
+      : Math.min(toNonNegativeInteger(msg.contentBottomRow), maxRow)
   return {
     cursorY,
-    contentBottomRow: typeof msg.contentBottomRow === 'number' ? msg.contentBottomRow : cursorY,
-    rows: typeof msg.rows === 'number' ? msg.rows : 0,
-    altScreen: !!msg.altScreen
+    contentBottomRow,
+    rows,
+    altScreen: msg.altScreen === true
   }
+}
+
+function toNonNegativeInteger(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0
 }
 
 export type MobileTerminalTheme = RuntimeMobileTerminalTheme

--- a/mobile/src/terminal/terminal-webview-contract.ts
+++ b/mobile/src/terminal/terminal-webview-contract.ts
@@ -14,8 +14,26 @@ export type TerminalModes = {
 
 export type TerminalKeyboardAvoidanceMetrics = {
   cursorY: number
+  // Why: last non-blank viewport row (0-based). Full-screen TUIs in the main
+  // buffer (e.g. the Pi agent) render footer/status rows below the caret, so
+  // keyboard avoidance anchors on this, not just cursorY. See worktreeId.tsx.
+  contentBottomRow: number
   rows: number
   altScreen: boolean
+}
+
+// Why: coerce the raw WebView keyboard-avoidance payload into typed metrics.
+// contentBottomRow defaults to cursorY so older WebView bundles keep working.
+export function parseTerminalKeyboardAvoidanceMetrics(
+  msg: Record<string, unknown>
+): TerminalKeyboardAvoidanceMetrics {
+  const cursorY = typeof msg.cursorY === 'number' ? msg.cursorY : 0
+  return {
+    cursorY,
+    contentBottomRow: typeof msg.contentBottomRow === 'number' ? msg.contentBottomRow : cursorY,
+    rows: typeof msg.rows === 'number' ? msg.rows : 0,
+    altScreen: !!msg.altScreen
+  }
 }
 
 export type MobileTerminalTheme = RuntimeMobileTerminalTheme

--- a/mobile/src/terminal/terminal-webview-html.ts
+++ b/mobile/src/terminal/terminal-webview-html.ts
@@ -3,6 +3,7 @@ import type { RuntimeMobileTerminalTheme } from '../../../src/shared/runtime-typ
 import { colors } from '../theme/mobile-theme'
 import { TERMINAL_TEXT_SCALES } from '../storage/preferences'
 import { TERMINAL_PATH_TAP_JS } from './terminal-path-tap-injected'
+import { TERMINAL_KEYBOARD_AVOIDANCE_METRICS_JS } from './terminal-keyboard-avoidance-metrics-injected'
 import { XTERM_ENGINE_CSS, XTERM_ENGINE_JS } from './terminal-webview-engine.generated'
 import { TERMINAL_REFLOW_JS } from './terminal-webview-reflow-injected'
 import { TERMINAL_SURFACE_SWAP_JS } from './terminal-webview-surface-swap-injected'
@@ -287,6 +288,7 @@ window.onerror = function(msg) {
         if (cols < MIN_FIT_COLS) return;
         var rows = Math.max(8, Math.floor(window.innerHeight / cellH));
         term.resize(cols, rows);
+        emitKeyboardAvoidanceMetrics();
       }
       applyFitScale('text-scale');
     });
@@ -802,6 +804,7 @@ ${TERMINAL_WEBGL_RECOVERY_JS}
     if (!term) return;
     initRows = rows || initRows;
     term.resize(cols || term.cols, rows || term.rows);
+    emitKeyboardAvoidanceMetrics();
     applyFitScale('resize-msg');
     notify({ type: 'ready', cols: cols, rows: rows });
   }
@@ -958,6 +961,7 @@ ${TERMINAL_WEBGL_RECOVERY_JS}
       initialOscLinkEvictionReady = false;
       if (term) { term.clear(); term.reset(); }
       emitModesIfChanged();
+      emitKeyboardAvoidanceMetrics();
       resetEvictionCounter();
       if (selMode === 'select') {
         notify({ type: 'selection-evicted' });
@@ -1100,34 +1104,7 @@ ${TERMINAL_WEBGL_RECOVERY_JS}
     sgrMousePixelsMode: false
   };
 
-  // Why: main-buffer full-screen TUIs (e.g. the Pi agent) render footer/status
-  // rows below the caret, so anchor keyboard avoidance on the last non-blank
-  // viewport row (0..rows-1), not just cursorY. See terminal-keyboard-avoidance-lift.ts.
-  function computeContentBottomRow() {
-    if (!term || !term.buffer || !term.buffer.active) return 0;
-    var buffer = term.buffer.active;
-    var top = buffer.viewportY || 0;
-    for (var y = (term.rows || 0) - 1; y >= 0; y--) {
-      try {
-        var line = buffer.getLine(top + y);
-        if (line && line.translateToString(true).length > 0) return y;
-      } catch (e) {}
-    }
-    return 0;
-  }
-
-  function emitKeyboardAvoidanceMetrics() {
-    if (!term) return;
-    var alt = false;
-    try { alt = term.buffer && term.buffer.active && term.buffer.active.type === 'alternate'; } catch (e) {}
-    notify({
-      type: 'keyboard-avoidance-metrics',
-      cursorY: term.buffer && term.buffer.active ? term.buffer.active.cursorY : 0,
-      contentBottomRow: computeContentBottomRow(),
-      rows: term.rows || 0,
-      altScreen: alt
-    });
-  }
+  ${TERMINAL_KEYBOARD_AVOIDANCE_METRICS_JS}
 
   function attachTermObservers() {
     if (!term) return;

--- a/mobile/src/terminal/terminal-webview-html.ts
+++ b/mobile/src/terminal/terminal-webview-html.ts
@@ -1100,6 +1100,22 @@ ${TERMINAL_WEBGL_RECOVERY_JS}
     sgrMousePixelsMode: false
   };
 
+  // Why: main-buffer full-screen TUIs (e.g. the Pi agent) render footer/status
+  // rows below the caret, so anchor keyboard avoidance on the last non-blank
+  // viewport row (0..rows-1), not just cursorY. See terminal-keyboard-avoidance-lift.ts.
+  function computeContentBottomRow() {
+    if (!term || !term.buffer || !term.buffer.active) return 0;
+    var buffer = term.buffer.active;
+    var top = buffer.viewportY || 0;
+    for (var y = (term.rows || 0) - 1; y >= 0; y--) {
+      try {
+        var line = buffer.getLine(top + y);
+        if (line && line.translateToString(true).length > 0) return y;
+      } catch (e) {}
+    }
+    return 0;
+  }
+
   function emitKeyboardAvoidanceMetrics() {
     if (!term) return;
     var alt = false;
@@ -1107,6 +1123,7 @@ ${TERMINAL_WEBGL_RECOVERY_JS}
     notify({
       type: 'keyboard-avoidance-metrics',
       cursorY: term.buffer && term.buffer.active ? term.buffer.active.cursorY : 0,
+      contentBottomRow: computeContentBottomRow(),
       rows: term.rows || 0,
       altScreen: alt
     });

--- a/mobile/src/terminal/terminal-webview-notification-dispatch.test.ts
+++ b/mobile/src/terminal/terminal-webview-notification-dispatch.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { dispatchTerminalWebViewNotification } from './terminal-webview-notification-dispatch'
+
+describe('dispatchTerminalWebViewNotification', () => {
+  it('preserves bounded keyboard metrics through the dispatcher', () => {
+    const onKeyboardAvoidanceMetrics = vi.fn()
+    dispatchTerminalWebViewNotification(
+      {
+        type: 'keyboard-avoidance-metrics',
+        cursorY: 30,
+        contentBottomRow: 99,
+        rows: 40,
+        altScreen: true
+      },
+      { onKeyboardAvoidanceMetrics, reportEngineError: vi.fn() }
+    )
+    expect(onKeyboardAvoidanceMetrics).toHaveBeenCalledWith({
+      cursorY: 30,
+      contentBottomRow: 39,
+      rows: 40,
+      altScreen: true
+    })
+  })
+
+  it('keeps old WebView payloads cursor-compatible', () => {
+    const onKeyboardAvoidanceMetrics = vi.fn()
+    dispatchTerminalWebViewNotification(
+      { type: 'keyboard-avoidance-metrics', cursorY: 12, rows: 40 },
+      { onKeyboardAvoidanceMetrics, reportEngineError: vi.fn() }
+    )
+    expect(onKeyboardAvoidanceMetrics).toHaveBeenCalledWith({
+      cursorY: 12,
+      contentBottomRow: 12,
+      rows: 40,
+      altScreen: false
+    })
+  })
+})

--- a/mobile/src/terminal/terminal-webview-notification-dispatch.ts
+++ b/mobile/src/terminal/terminal-webview-notification-dispatch.ts
@@ -1,4 +1,7 @@
-import type { TerminalSelectionEvents } from './terminal-webview-contract'
+import {
+  parseTerminalKeyboardAvoidanceMetrics,
+  type TerminalSelectionEvents
+} from './terminal-webview-contract'
 
 export type TerminalWebViewNotificationHandlers = Omit<
   TerminalSelectionEvents,
@@ -63,13 +66,7 @@ export function dispatchTerminalWebViewNotification(
       handlers.onOpenUrl?.(url)
     }
   } else if (msg.type === 'keyboard-avoidance-metrics') {
-    const cursorY = typeof msg.cursorY === 'number' ? msg.cursorY : 0
-    const rows = typeof msg.rows === 'number' ? msg.rows : 0
-    handlers.onKeyboardAvoidanceMetrics?.({
-      cursorY,
-      rows,
-      altScreen: !!msg.altScreen
-    })
+    handlers.onKeyboardAvoidanceMetrics?.(parseTerminalKeyboardAvoidanceMetrics(msg))
   } else if (msg.type === 'haptic') {
     const kind = msg.kind
     if (kind === 'selection' || kind === 'success' || kind === 'error' || kind === 'edge-bump') {

--- a/mobile/src/terminal/terminal-webview-reflow-injected.ts
+++ b/mobile/src/terminal/terminal-webview-reflow-injected.ts
@@ -28,5 +28,6 @@ export const TERMINAL_REFLOW_JS = `
     }
     applyFitScale('reflow-msg');
     updateScrollIndicator(false);
+    emitKeyboardAvoidanceMetrics();
   }
 `


### PR DESCRIPTION
Fixes #8412

## Summary

On iOS, the mobile terminal's software keyboard could overlap the bottom of the Pi agent TUI — part of the TUI (its footer/status rows) stayed hidden under the keyboard (reported for the Pi ask-user extension in inline mode, #8412).

**Root cause:** the keyboard-avoidance lift (`activeTerminalKeyboardLift` in `mobile/app/h/[hostId]/session/[worktreeId].tsx`) anchored on the terminal **cursor row**. Pi's interactive TUI renders inline in the terminal's **main** screen buffer (only its external editor uses the alternate screen) and lays out `editorContainer → widgetContainerBelow → footer`, placing multi-row footer/status chrome **below** the input caret. Because the WebView reports `altScreen: false` for Pi, the `altScreen` full-lift branch was skipped and the cursor-based branch ran — it clears only one row below the caret, leaving Pi's footer/status under the raised input dock / keyboard.

**Fix:** anchor the lift on the **bottom-most non-blank viewport row**, not just the caret.

- `terminal-webview-html.ts`: `computeContentBottomRow()` finds the last non-blank viewport row; emit it as `contentBottomRow`.
- `terminal-webview-contract.ts`: add `contentBottomRow` to the metrics type + a `parseTerminalKeyboardAvoidanceMetrics` helper (defaults `contentBottomRow` to `cursorY` for older WebView bundles).
- `terminal-keyboard-avoidance-lift.ts` (new): pure, unit-tested lift function anchoring on `max(cursorY, contentBottomRow)`.
- Wired through `TerminalWebView.tsx` and `worktreeId.tsx`.

This generalizes the alt-screen case (content fills to the last row → full lift), keeps short output at the top put (no lift), and matches prior behavior for a scrolled shell prompt.

## Screenshots

No screenshots captured — the fix could not be validated on a physical iOS device in this environment. Expected behavior: with the software keyboard open over an inline Pi TUI, the footer/status rows now sit above the input dock instead of being hidden behind the keyboard. An on-device smoke test is recommended before merge.

## Testing

- [x] `pnpm lint` (oxlint, `mobile/` — exit 0)
- [x] `pnpm typecheck` (`tsc --noEmit`, `mobile/` — exit 0)
- [x] `pnpm test` (`vitest run`, `mobile/` — 286 files, 2047 passed / 2 skipped)
- [ ] `pnpm build` — not run; changes are React Native/TypeScript in `mobile/` only, no Electron build surface touched
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Added `terminal-keyboard-avoidance-lift.test.ts` (Pi-like footer-below-caret, alt-screen, short output, scrolled shell, clamp, closed keyboard) and `terminal-webview-contract.test.ts` (parser coercion + `contentBottomRow` fallback). `activeTerminalKeyboardLift` previously had no coverage. `oxfmt --check` is also clean, and the change respects the repo `max-lines` rule (no disables/bumps).

## AI Review Report

The change was produced through a root-cause debugging pass and self-reviewed line by line. Main risks checked:

- **Regression on non-Pi terminals:** the new anchor is `max(cursorY, contentBottomRow)`, so a scrolled shell (prompt at the bottom) computes the same lift as before, and short output near the top still yields zero lift. Covered by unit tests.
- **Alt-screen TUIs (vim, etc.):** still take the explicit full-lift branch; also naturally covered since content fills to the last row.
- **Backward compatibility:** older WebView bundles that don't emit `contentBottomRow` fall back to `cursorY` via `parseTerminalKeyboardAvoidanceMetrics`, so no behavior change until the new WebView JS ships.
- **Cross-platform:** this is mobile-app-only (React Native), so macOS/Linux/Windows Electron behavior is unaffected. Across mobile platforms, `keyboardLift` is already computed per-platform (iOS subtracts the home-indicator inset; Android uses the full IME height); the new content-bottom anchoring is platform-agnostic and improves both. No shortcuts, labels, or path handling touched.

Result of the review: extracted the lift into a pure, testable function and moved metrics parsing into a tested helper; kept the two oversized files under their `max-lines` limits without lint disables.

## Security Audit

- **Input handling:** `computeContentBottomRow()` reads xterm buffer lines inside the WebView and is fully guarded with try/catch; it emits only a bounded integer row index. `parseTerminalKeyboardAvoidanceMetrics` coerces untrusted WebView message fields with `typeof` checks and safe defaults — no unchecked values reach the lift math.
- **Command execution / paths / secrets / auth / IPC:** none touched. The WebView→RN message is a numeric metric only; no new IPC surface, no path or command handling, no secrets.
- **Follow-up:** none identified.

## Notes

- iOS/Android mobile terminal only; no desktop impact.
- On-device iOS verification is still pending — the fix is verified via lint/typecheck/unit tests and reasoned from the code + Pi's layout, but a physical-device smoke test before merge is advisable.

## ELI5

On iOS, the software keyboard covered the bottom of Pi's TUI footer because lift was based on the cursor row only. Keyboard avoidance uses the full main-buffer height so the TUI footer stays visible.
