### PR TITLE
fix(android): enable split-screen/multi-window for Samsung devices

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -80,6 +80,7 @@
     "plugins": [
       "expo-router",
       "./plugins/android-respect-rotation-lock.js",
+      "./plugins/android-split-screen-fix.js",
       [
         "expo-splash-screen",
         {

--- a/mobile/plugins/android-split-screen-fix.js
+++ b/mobile/plugins/android-split-screen-fix.js
@@ -1,0 +1,40 @@
+const { withAndroidManifest, AndroidConfig } = require('expo/config-plugins')
+
+// Why: Samsung OneUI and other Android skins require explicit multi-window
+// support declarations. Without android:resizeableActivity="true", split-screen
+// and freeform windowing either refuse to launch or render the activity in
+// an incorrectly sized container (letterboxing instead of filling the split).
+// Additionally, screenSize and smallestScreenSize must be present in
+// android:configChanges so the app does not restart on every split resize.
+module.exports = function withAndroidSplitScreenFix(config) {
+  return withAndroidManifest(config, (cfg) => {
+    const activity = AndroidConfig.Manifest.getMainActivityOrThrow(cfg.modResults)
+
+    // 1. Explicitly declare the activity supports multi-window / split-screen.
+    activity.$['android:resizeableActivity'] = 'true'
+
+    // 2. Ensure configChanges include size-related keys. This prevents the
+    //    activity from being destroyed and recreated when the user drags the
+    //    split divider, which is the main cause of the "not filling" visual bug.
+    const existingConfigChanges = activity.$['android:configChanges'] || ''
+    const changesSet = new Set(
+      existingConfigChanges
+        .split('|')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    )
+    const requiredChanges = [
+      'screenSize',
+      'smallestScreenSize',
+      'density',
+      'orientation',
+      'screenLayout'
+    ]
+    for (const change of requiredChanges) {
+      changesSet.add(change)
+    }
+    activity.$['android:configChanges'] = Array.from(changesSet).join('|')
+
+    return cfg
+  })
+}


### PR DESCRIPTION
## Summary

Adds an Expo config plugin that patches the Android `MainActivity` manifest entry for multi-window support: it sets `android:resizeableActivity="true"` and adds `smallestScreenSize` + `density` to `android:configChanges`.

**Be aware of what actually does the work here.** `resizeableActivity` is largely a no-op on the SDK this app targets — it defaults to `true` for `targetSdk >= 24` and is *ignored entirely* on API 31+, and this app is on Expo 55 / RN 0.83. The real fix is the `configChanges` half: Expo's template omits `smallestScreenSize` and `density`, so **dragging the split-screen divider destroys and recreates the activity**, remounting the React tree and losing UI state. Adding those two keys is what makes split-screen usable rather than merely permitted.

I'd suggest the title undersells it — this is closer to "stop the activity restarting on split-screen resize" than "enable split-screen".

## ELI5

On Android you can run two apps side by side and drag the divider to resize them. Orca was being torn down and rebuilt from scratch every time you dragged that divider, so whatever you were looking at got reset. This tells Android "I can handle being resized myself, don't restart me," so dragging the divider just resizes the app smoothly.

The other half of the change — the part the title is about — turns out to have no effect on modern Android, and I've said so rather than claiming credit for it.

## Proof of fix

The mobile Vitest suite **cannot run in this environment** — `mobile/tsconfig.json` extends `expo/tsconfig.base.json`, which fails to resolve here (`TSConfckParseError`). I confirmed this is pre-existing and unrelated to this PR by reproducing it on unmodified `main` with an existing test (`src/host-route-action-state.test.ts` → same error, `Tests no tests`). So I proved the plugin by driving it directly with a stubbed `expo/config-plugins`, feeding it Expo SDK 55's real template value for `MainActivity`:

```
BEFORE configChanges = keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode
AFTER  configChanges = keyboard|keyboardHidden|orientation|screenSize|screenLayout|uiMode|smallestScreenSize|density
resizeableActivity   = true
NEWLY ADDED          = smallestScreenSize,density
REMOVED              = (none)
```

Edge cases, same harness:

```
idempotent      = true          # a second prebuild produces an identical string
no dup keys     = true
bare activity   = screenSize|smallestScreenSize|density|orientation|screenLayout
no empty token  = true          # empty existing configChanges does not yield a leading '|'
preserves expo  = true          # every key Expo already declared survives
```

Idempotency matters because `expo prebuild` runs repeatedly; a naive string concat would accumulate duplicates. The plugin uses a `Set`, so it doesn't.

**Registration verified** — a config plugin that isn't listed in `app.json`'s `plugins` array is dead code. The diff adds `"./plugins/android-split-screen-fix.js"` to that array, alongside the existing `android-respect-rotation-lock.js`.

I did **not** run `expo prebuild` and diff the generated `AndroidManifest.xml`. That would be stronger, but it needs the Android SDK and network access that aren't available here. Stating that plainly rather than implying a verification I didn't perform.

## Proof of no regressions

- **Additive only.** The plugin unions into `configChanges`; the probe confirms `REMOVED = (none)` and that all six Expo defaults survive.
- **iOS untouched.** `withAndroidManifest` is Android-only; no iOS code path or config is modified.
- **No app code changed.** The diff is two files: a new plugin and one line in `app.json`. No TypeScript, no runtime behavior outside the manifest.
- **Mobile test suite:** could not be executed (pre-existing `expo/tsconfig.base.json` resolution failure, reproduced on clean `main`). No test was modified or removed.

Behavior that changes for users: on Android, dragging the split-screen divider no longer recreates the activity, so in-progress UI state survives a resize. Nothing else.

## Compatibility

- **Platforms:** Android only. `resizeableActivity` has no effect on API 31+ (this app's target), so on current devices the observable change is entirely from `smallestScreenSize`/`density`. On older devices (API 24–30) the explicit `resizeableActivity="true"` is a harmless restatement of the default. iOS, macOS, Linux, and Windows are untouched.
- **SSH / remote:** N/A — build-time Android manifest generation, no runtime, network, or host interaction.
- **Performance:** No runtime cost. This changes a manifest attribute consumed at install time. If anything it *reduces* work, since the activity is no longer destroyed and the React tree remounted on every split-divider drag.

## Screenshots

No screenshot. Split-screen behavior can only be demonstrated on a physical Samsung/Android device or emulator, which isn't available in this environment, and a mocked-up image would not evidence anything. The manifest transformation — which is the entire change — is shown as literal before/after output under **Proof of fix**.

## Testing

- [ ] `pnpm lint` — not run; this PR touches only `mobile/`, and the root lint suite does not cover it.
- [ ] `pnpm typecheck` — not applicable; the plugin is plain CommonJS JavaScript with no TypeScript surface, and `app.json` is data.
- [ ] `pnpm test` — **cannot run.** The `mobile/` Vitest suite fails to start in this environment on `expo/tsconfig.base.json` resolution; verified pre-existing on clean `main`, not caused by this PR.
- [ ] `pnpm build` — not run (requires the Android SDK).
- [x] Added or updated high-quality tests, **or explained why not** — I wrote a five-case Vitest spec for the plugin (default-template, preservation, `resizeableActivity`, idempotency, bare-activity) but **did not include it**, because the suite it would live in cannot execute here and I won't add a test I can't demonstrate passing. The same five cases are proven above via the standalone harness. A maintainer who can run `mobile` tests should land that spec; I'm happy to attach it.

## AI Review Report

Reviewed with Claude Code (Opus 5). Cross-platform review confirmed: this is an Android-only, build-time manifest change with no shortcut, label, path, shell, or Electron surface, and no iOS effect. Findings:

- **Is this a no-op?** Checked first, because it very nearly is. `resizeableActivity` defaults to `true` at `targetSdk >= 24` and is ignored on API 31+; on Expo 55 / RN 0.83 that means the headline attribute changes nothing on any device users are likely running. Reported honestly in `## Summary` rather than shipping a placebo. The `configChanges` half is real and is why the PR is worth landing.
- **Activity recreation** — the risk I most wanted to check, and it's the one the plugin actually fixes. Making an activity resizable without covering size keys in `configChanges` causes destroy/recreate on every resize; the plugin adds exactly `smallestScreenSize` and `density`, the two Expo omits.
- **Plugin registration** — verified present in `app.json`'s `plugins` array. An unregistered plugin is silent dead code.
- **Idempotency and merge safety** — `Set`-based union, verified to preserve all existing keys, produce no duplicates across repeated application, and handle an activity with no `configChanges` without emitting an empty token.
- **Attribute placement** — `resizeableActivity` is set on `<activity>` via `getMainActivityOrThrow`, which is correct; it is valid on both `<activity>` and `<application>`, and the activity-level placement is the narrower, intended one.
- **No Samsung-specific cargo cult** — the plugin does not add speculative vendor metadata (e.g. `com.samsung.android.multidisplay.keep_process_alive`), which I'd have flagged as unjustified.

## Security Audit

- **Input handling:** none. The plugin reads and writes a manifest object during prebuild.
- **Command execution:** none.
- **Path handling:** none — no filesystem paths are constructed or joined.
- **Auth / secrets:** none touched.
- **Dependencies:** none added. `expo/config-plugins` is already a transitive dependency used by the existing `android-respect-rotation-lock.js` plugin.
- **IPC:** untouched.
- **Permissions/exposure:** the change does not add an Android permission, exported component, or intent filter. `resizeableActivity` and `configChanges` do not widen the app's attack surface.

## Notes

- **Recommend retitling** to reflect what actually changes — e.g. *"fix(android): stop the activity restarting when the split-screen divider is dragged"*. The current title credits the attribute that has no effect on the target SDK.
- The Vitest spec described under Testing is ready to land once the `mobile` suite can run; it's a straight port of the harness cases shown above.
- Untested on real Samsung One UI hardware. The manifest transformation is proven; the resulting device behavior is inferred from documented Android semantics, and a maintainer with a device should sanity-check the divider-drag case before release.

Original patch by @techinpark.
