### PR TITLE
feat(editor): add Nix syntax highlighting

### DIFF
--- a/src/renderer/src/lib/language-detect.test.ts
+++ b/src/renderer/src/lib/language-detect.test.ts
@@ -20,6 +20,11 @@ describe('detectLanguage', () => {
     expect(detectLanguage('packages/app.nimble')).toBe('nim')
   })
 
+  it('maps Nix files to the nix language id', () => {
+    expect(detectLanguage('flake.nix')).toBe('nix')
+    expect(detectLanguage('modules/service.nix')).toBe('nix')
+  })
+
   it('maps exact filenames from Windows paths', () => {
     expect(detectLanguage('C:\\Users\\alice\\repo\\Dockerfile')).toBe('dockerfile')
     expect(detectLanguage('C:\\Users\\alice\\repo\\CMakeLists.txt')).toBe('cmake')

--- a/src/renderer/src/lib/language-detect.ts
+++ b/src/renderer/src/lib/language-detect.ts
@@ -91,6 +91,7 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
   '.nim': 'nim',
   '.nims': 'nim',
   '.nimble': 'nim',
+  '.nix': 'nix',
   '.tf': 'hcl',
   '.hcl': 'hcl',
   '.prisma': 'graphql',

--- a/src/renderer/src/lib/monaco-languages/register-nix.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-nix.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  NIX_LANGUAGE_ID,
+  NIX_TEXTMATE_SCOPE,
+  createNixLanguageConfiguration,
+  loadNixTextMateGrammar,
+  registerNixLanguage
+} from './register-nix'
+
+function createMonacoMock() {
+  return {
+    languages: {
+      getLanguages: vi.fn(() => []),
+      register: vi.fn(),
+      setLanguageConfiguration: vi.fn(),
+      registerTokensProviderFactory: vi.fn(),
+      IndentAction: { None: 0, Indent: 1, IndentOutdent: 2, Outdent: 3 }
+    }
+  }
+}
+
+describe('registerNixLanguage', () => {
+  it('maps the Nix extension to the reusable TextMate-backed language registration', () => {
+    const monaco = createMonacoMock()
+
+    registerNixLanguage(monaco as never)
+
+    expect(monaco.languages.register).toHaveBeenCalledWith({
+      id: NIX_LANGUAGE_ID,
+      extensions: ['.nix'],
+      aliases: ['Nix', 'nix']
+    })
+    expect(monaco.languages.setLanguageConfiguration).toHaveBeenCalledWith(
+      NIX_LANGUAGE_ID,
+      createNixLanguageConfiguration(monaco as never)
+    )
+    expect(monaco.languages.registerTokensProviderFactory).toHaveBeenCalledWith(
+      NIX_LANGUAGE_ID,
+      expect.objectContaining({ create: expect.any(Function) })
+    )
+  })
+})
+
+describe('createNixLanguageConfiguration', () => {
+  it('keeps hyphenated Nix identifiers as single words', () => {
+    const configuration = createNixLanguageConfiguration(createMonacoMock() as never)
+
+    const words = 'pkgs.home-manager'.match(configuration.wordPattern as RegExp)
+
+    expect(words).toContain('home-manager')
+  })
+
+  it('indent-outdents between the Nix indented-string delimiters', () => {
+    const configuration = createNixLanguageConfiguration(createMonacoMock() as never)
+
+    const indentedStringRule = configuration.onEnterRules?.find(
+      (rule) => rule.beforeText.test("  script = ''") && rule.afterText?.test("'';")
+    )
+
+    expect(indentedStringRule?.action.indentAction).toBe(2)
+  })
+})
+
+describe('loadNixTextMateGrammar', () => {
+  it('loads the vendored Nix TextMate grammar for the Nix scope', async () => {
+    const grammar = await loadNixTextMateGrammar(NIX_TEXTMATE_SCOPE)
+
+    expect(grammar).toMatchObject({
+      name: 'Nix',
+      scopeName: NIX_TEXTMATE_SCOPE,
+      fileTypes: ['nix']
+    })
+  })
+
+  it('ignores unrelated TextMate scopes', async () => {
+    await expect(loadNixTextMateGrammar('source.python')).resolves.toBeNull()
+  })
+})

--- a/src/renderer/src/lib/monaco-languages/register-nix.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-nix.test.ts
@@ -59,6 +59,16 @@ describe('createNixLanguageConfiguration', () => {
 
     expect(indentedStringRule?.action.indentAction).toBe(2)
   })
+
+  it('indents after keywords but not after the plain identifier `and`', () => {
+    const configuration = createNixLanguageConfiguration(createMonacoMock() as never)
+
+    const matchesRule = (line: string) =>
+      configuration.onEnterRules?.some((rule) => !rule.afterText && rule.beforeText.test(line))
+
+    expect(matchesRule('  packages = with')).toBe(true)
+    expect(matchesRule('  value = and')).toBe(false)
+  })
 })
 
 describe('loadNixTextMateGrammar', () => {

--- a/src/renderer/src/lib/monaco-languages/register-nix.ts
+++ b/src/renderer/src/lib/monaco-languages/register-nix.ts
@@ -82,7 +82,9 @@ export function createNixLanguageConfiguration(
       },
       {
         // Why: `in` is intentionally absent — nixfmt does not indent after it.
-        beforeText: /^.*\b(?:let|with|if|then|else|rec|or|and|assert|inherit)\s*$/,
+        // `and` (present in the vscode-nix-ide source config) is excluded too:
+        // it is a plain identifier in Nix, not a keyword (conjunction is &&).
+        beforeText: /^.*\b(?:let|with|if|then|else|rec|or|assert|inherit)\s*$/,
         action: { indentAction: IndentAction.Indent }
       }
     ]

--- a/src/renderer/src/lib/monaco-languages/register-nix.ts
+++ b/src/renderer/src/lib/monaco-languages/register-nix.ts
@@ -1,0 +1,114 @@
+import type * as Monaco from 'monaco-editor'
+import type { IRawGrammar } from 'vscode-textmate'
+import { registerTextMateLanguage } from './textmate-language-registration'
+
+type MonacoModule = typeof Monaco
+
+export const NIX_LANGUAGE_ID = 'nix'
+export const NIX_TEXTMATE_SCOPE = 'source.nix'
+
+// Why: Nix identifiers and attribute names routinely contain hyphens and
+// slashes (home-manager, nixos/modules); Monaco's default word pattern splits
+// on '-', breaking double-click selection and word-based occurrence matching.
+// Pattern from nix-community/vscode-nix-ide language-configuration.json.
+const NIX_WORD_PATTERN =
+  /(-?\d*\.\d\w*)|((~|[^`~!@#%^&*()=+[{\]}\\|;:'",<>/?\s]+)\/[^`~!@#%^&*()=+[{\]}\\|;:'",<>?\s]+)|([^`~!@#%^&*()=+[{\]}\\|;:'",.<>/?\s]+)/g
+
+// Why: the configuration is a factory because onEnterRules needs the runtime
+// monaco.languages.IndentAction enum, which type-only imports cannot provide.
+export function createNixLanguageConfiguration(
+  monaco: MonacoModule
+): Monaco.languages.LanguageConfiguration {
+  const { IndentAction } = monaco.languages
+  return {
+    comments: {
+      lineComment: '#',
+      blockComment: ['/*', '*/']
+    },
+    brackets: [
+      ['{', '}'],
+      ['[', ']'],
+      ['(', ')']
+    ],
+    autoClosingPairs: [
+      { open: '{', close: '}' },
+      { open: '[', close: ']' },
+      { open: '(', close: ')' },
+      { open: '"', close: '"', notIn: ['string'] },
+      // Why: '' is Nix's indented-string delimiter, a distinct two-character
+      // quote pair — not two auto-closed single quotes.
+      { open: "''", close: "''", notIn: ['string', 'comment'] }
+    ],
+    surroundingPairs: [
+      { open: '{', close: '}' },
+      { open: '[', close: ']' },
+      { open: '(', close: ')' },
+      { open: '"', close: '"' },
+      { open: "''", close: "''" }
+    ],
+    wordPattern: NIX_WORD_PATTERN,
+    // Why: indentation rules from nix-community/vscode-nix-ide, so Enter
+    // between paired keywords (let/in, if/then, then/else) and inside ''
+    // indented strings indents like nixfmt expects.
+    onEnterRules: [
+      {
+        beforeText: /^.*\blet\s*$/,
+        afterText: /\s*in\b.*$/,
+        action: { indentAction: IndentAction.IndentOutdent }
+      },
+      {
+        beforeText: /^.*\bif\s*$/,
+        afterText: /\s*then\b.*$/,
+        action: { indentAction: IndentAction.IndentOutdent }
+      },
+      {
+        beforeText: /^.*\bthen\s*$/,
+        afterText: /\s*else\b.*$/,
+        action: { indentAction: IndentAction.IndentOutdent }
+      },
+      {
+        beforeText: /^.*''\s*$/,
+        afterText: /\s*''.*$/,
+        action: { indentAction: IndentAction.IndentOutdent }
+      },
+      {
+        beforeText: /^.*\/\*\*\s*$/,
+        afterText: /\s*\*\/.*$/,
+        action: { indentAction: IndentAction.IndentOutdent }
+      },
+      {
+        beforeText: /^.*(?:=|\/\*\*|'')\s*$/,
+        action: { indentAction: IndentAction.Indent }
+      },
+      {
+        // Why: `in` is intentionally absent — nixfmt does not indent after it.
+        beforeText: /^.*\b(?:let|with|if|then|else|rec|or|and|assert|inherit)\s*$/,
+        action: { indentAction: IndentAction.Indent }
+      }
+    ]
+  }
+}
+
+export async function loadNixTextMateGrammar(scopeName: string): Promise<IRawGrammar | null> {
+  if (scopeName !== NIX_TEXTMATE_SCOPE) {
+    return null
+  }
+
+  // Why: Nix highlighting uses the maintained VS Code TextMate grammar from
+  // nix-community/vscode-nix-ide (MIT; see textmate-grammars/nix-LICENSE.txt).
+  const grammarModule = await import('./textmate-grammars/nix.tmLanguage.json')
+  return grammarModule.default as unknown as IRawGrammar
+}
+
+export function registerNixLanguage(monaco: MonacoModule): void {
+  registerTextMateLanguage(monaco, {
+    language: {
+      id: NIX_LANGUAGE_ID,
+      extensions: ['.nix'],
+      aliases: ['Nix', 'nix']
+    },
+    configuration: createNixLanguageConfiguration(monaco),
+    scopeName: NIX_TEXTMATE_SCOPE,
+    loadGrammar: loadNixTextMateGrammar
+  })
+}

--- a/src/renderer/src/lib/monaco-languages/register-nix.ts
+++ b/src/renderer/src/lib/monaco-languages/register-nix.ts
@@ -14,8 +14,13 @@ export const NIX_TEXTMATE_SCOPE = 'source.nix'
 const NIX_WORD_PATTERN =
   /(-?\d*\.\d\w*)|((~|[^`~!@#%^&*()=+[{\]}\\|;:'",<>/?\s]+)\/[^`~!@#%^&*()=+[{\]}\\|;:'",<>?\s]+)|([^`~!@#%^&*()=+[{\]}\\|;:'",.<>/?\s]+)/g
 
-// Why: the configuration is a factory because onEnterRules needs the runtime
-// monaco.languages.IndentAction enum, which type-only imports cannot provide.
+/**
+ * Build the Monaco language configuration for Nix (comments, brackets,
+ * auto-closing pairs, word pattern, indentation rules).
+ *
+ * Why a factory: onEnterRules needs the runtime monaco.languages.IndentAction
+ * enum, which type-only imports cannot provide.
+ */
 export function createNixLanguageConfiguration(
   monaco: MonacoModule
 ): Monaco.languages.LanguageConfiguration {
@@ -91,6 +96,10 @@ export function createNixLanguageConfiguration(
   }
 }
 
+/**
+ * Lazily load the vendored Nix TextMate grammar for the `source.nix` scope;
+ * returns null for any other scope so the registry falls through.
+ */
 export async function loadNixTextMateGrammar(scopeName: string): Promise<IRawGrammar | null> {
   if (scopeName !== NIX_TEXTMATE_SCOPE) {
     return null
@@ -102,6 +111,10 @@ export async function loadNixTextMateGrammar(scopeName: string): Promise<IRawGra
   return grammarModule.default as unknown as IRawGrammar
 }
 
+/**
+ * Register the `nix` language with Monaco: `.nix` extension mapping, editor
+ * configuration, and the TextMate-backed tokenizer.
+ */
 export function registerNixLanguage(monaco: MonacoModule): void {
   registerTextMateLanguage(monaco, {
     language: {

--- a/src/renderer/src/lib/monaco-languages/textmate-grammars/nix-LICENSE.txt
+++ b/src/renderer/src/lib/monaco-languages/textmate-grammars/nix-LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 noor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/renderer/src/lib/monaco-languages/textmate-grammars/nix.tmLanguage.json
+++ b/src/renderer/src/lib/monaco-languages/textmate-grammars/nix.tmLanguage.json
@@ -1,0 +1,1188 @@
+{
+  "name": "Nix",
+  "scopeName": "source.nix",
+  "fileTypes": [
+    "nix"
+  ],
+  "uuid": "0514fd5f-acb6-436d-b42c-7643e6d36c8f",
+  "patterns": [
+    {
+      "include": "#expression"
+    }
+  ],
+  "repository": {
+    "expression": {
+      "patterns": [
+        {
+          "include": "#parens-and-cont"
+        },
+        {
+          "include": "#list-and-cont"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#interpolation"
+        },
+        {
+          "include": "#with-assert"
+        },
+        {
+          "include": "#function-for-sure"
+        },
+        {
+          "include": "#attrset-for-sure"
+        },
+        {
+          "include": "#attrset-or-function"
+        },
+        {
+          "include": "#let"
+        },
+        {
+          "include": "#if"
+        },
+        {
+          "include": "#operator-unary"
+        },
+        {
+          "include": "#operator-binary"
+        },
+        {
+          "include": "#constants"
+        },
+        {
+          "include": "#bad-reserved"
+        },
+        {
+          "include": "#parameter-name-and-cont"
+        },
+        {
+          "include": "#others"
+        }
+      ]
+    },
+    "expression-cont": {
+      "begin": "(?=.?)",
+      "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+      "patterns": [
+        {
+          "include": "#parens"
+        },
+        {
+          "include": "#list"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#interpolation"
+        },
+        {
+          "include": "#function-for-sure"
+        },
+        {
+          "include": "#attrset-for-sure"
+        },
+        {
+          "include": "#attrset-or-function"
+        },
+        {
+          "include": "#operator-binary"
+        },
+        {
+          "include": "#constants"
+        },
+        {
+          "include": "#bad-reserved"
+        },
+        {
+          "include": "#parameter-name"
+        },
+        {
+          "include": "#others"
+        }
+      ]
+    },
+    "parens": {
+      "begin": "\\(",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.expression.nix"
+        }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.expression.nix"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "parens-and-cont": {
+      "begin": "(?=\\()",
+      "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+      "patterns": [
+        {
+          "include": "#parens"
+        },
+        {
+          "include": "#expression-cont"
+        }
+      ]
+    },
+    "list": {
+      "begin": "\\[",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.list.nix"
+        }
+      },
+      "end": "\\]",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.list.nix"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "list-and-cont": {
+      "begin": "(?=\\[)",
+      "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+      "patterns": [
+        {
+          "include": "#list"
+        },
+        {
+          "include": "#expression-cont"
+        }
+      ]
+    },
+    "attrset-for-sure": {
+      "patterns": [
+        {
+          "begin": "(?=\\brec\\b)",
+          "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+          "patterns": [
+            {
+              "begin": "\\brec\\b",
+              "end": "(?=\\{)",
+              "beginCaptures": {
+                "0": {
+                  "name": "keyword.other.nix"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#others"
+                }
+              ]
+            },
+            {
+              "include": "#attrset-definition"
+            },
+            {
+              "include": "#others"
+            }
+          ]
+        },
+        {
+          "begin": "(?=\\{\\s*(\\}|[^,?]*(=|;)))",
+          "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+          "patterns": [
+            {
+              "include": "#attrset-definition"
+            },
+            {
+              "include": "#others"
+            }
+          ]
+        }
+      ]
+    },
+    "attrset-definition": {
+      "begin": "(?=\\{)",
+      "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+      "patterns": [
+        {
+          "begin": "(\\{)",
+          "end": "(\\})",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.attrset.nix"
+            }
+          },
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.attrset.nix"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#attrset-contents"
+            }
+          ]
+        },
+        {
+          "begin": "(?<=\\})",
+          "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+          "patterns": [
+            {
+              "include": "#expression-cont"
+            }
+          ]
+        }
+      ]
+    },
+    "attrset-definition-brace-opened": {
+      "patterns": [
+        {
+          "begin": "(?<=\\})",
+          "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+          "patterns": [
+            {
+              "include": "#expression-cont"
+            }
+          ]
+        },
+        {
+          "begin": "(?=.?)",
+          "end": "\\}",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.attrset.nix"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#attrset-contents"
+            }
+          ]
+        }
+      ]
+    },
+    "attrset-contents": {
+      "patterns": [
+        {
+          "include": "#attribute-inherit"
+        },
+        {
+          "include": "#bad-reserved"
+        },
+        {
+          "include": "#attribute-bind"
+        },
+        {
+          "include": "#others"
+        }
+      ]
+    },
+    "function-header-open-brace": {
+      "begin": "\\{",
+      "end": "(?=\\})",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.entity.function.2.nix"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#function-contents"
+        }
+      ]
+    },
+    "function-header-close-brace-no-arg": {
+      "begin": "\\}",
+      "end": "(?=\\:)",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.entity.function.nix"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#others"
+        }
+      ]
+    },
+    "function-header-terminal-arg": {
+      "begin": "(?=@)",
+      "end": "(?=\\:)",
+      "patterns": [
+        {
+          "begin": "\\@",
+          "end": "(?=\\:)",
+          "patterns": [
+            {
+              "begin": "(\\b[a-zA-Z\\_][a-zA-Z0-9\\_\\'\\-]*)",
+              "end": "(?=\\:)",
+              "name": "variable.parameter.function.3.nix"
+            },
+            {
+              "include": "#others"
+            }
+          ]
+        },
+        {
+          "include": "#others"
+        }
+      ]
+    },
+    "function-header-close-brace-with-arg": {
+      "begin": "\\}",
+      "end": "(?=\\:)",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.entity.function.nix"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#function-header-terminal-arg"
+        },
+        {
+          "include": "#others"
+        }
+      ]
+    },
+    "function-header-until-colon-no-arg": {
+      "begin": "(?=\\{)",
+      "end": "(?=\\:)",
+      "patterns": [
+        {
+          "include": "#function-header-open-brace"
+        },
+        {
+          "include": "#function-header-close-brace-no-arg"
+        }
+      ]
+    },
+    "function-header-until-colon-with-arg": {
+      "begin": "(?=\\{)",
+      "end": "(?=\\:)",
+      "patterns": [
+        {
+          "include": "#function-header-open-brace"
+        },
+        {
+          "include": "#function-header-close-brace-with-arg"
+        }
+      ]
+    },
+    "function-body-from-colon": {
+      "begin": "(\\:)",
+      "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.function.nix"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "function-definition": {
+      "begin": "(?=.?)",
+      "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+      "patterns": [
+        {
+          "include": "#function-body-from-colon"
+        },
+        {
+          "begin": "(?=.?)",
+          "end": "(?=\\:)",
+          "patterns": [
+            {
+              "begin": "(\\b[a-zA-Z\\_][a-zA-Z0-9\\_\\'\\-]*)",
+              "end": "(?=\\:)",
+              "beginCaptures": {
+                "0": {
+                  "name": "variable.parameter.function.4.nix"
+                }
+              },
+              "patterns": [
+                {
+                  "begin": "\\@",
+                  "end": "(?=\\:)",
+                  "patterns": [
+                    {
+                      "include": "#function-header-until-colon-no-arg"
+                    },
+                    {
+                      "include": "#others"
+                    }
+                  ]
+                },
+                {
+                  "include": "#others"
+                }
+              ]
+            },
+            {
+              "begin": "(?=\\{)",
+              "end": "(?=\\:)",
+              "patterns": [
+                {
+                  "include": "#function-header-until-colon-with-arg"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "include": "#others"
+        }
+      ]
+    },
+    "function-definition-brace-opened": {
+      "begin": "(?=.?)",
+      "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+      "patterns": [
+        {
+          "include": "#function-body-from-colon"
+        },
+        {
+          "begin": "(?=.?)",
+          "end": "(?=\\:)",
+          "patterns": [
+            {
+              "include": "#function-header-close-brace-with-arg"
+            },
+            {
+              "begin": "(?=.?)",
+              "end": "(?=\\})",
+              "patterns": [
+                {
+                  "include": "#function-contents"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "include": "#others"
+        }
+      ]
+    },
+    "function-for-sure": {
+      "patterns": [
+        {
+          "begin": "(?=(\\b[a-zA-Z\\_][a-zA-Z0-9\\_\\'\\-]*\\s*[:@]|\\{[^}\\\"']*\\}\\s*:|\\{[^#}\"'/=]*[,\\?]))",
+          "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+          "patterns": [
+            {
+              "include": "#function-definition"
+            }
+          ]
+        }
+      ]
+    },
+    "function-contents": {
+      "patterns": [
+        {
+          "include": "#bad-reserved"
+        },
+        {
+          "include": "#function-parameter"
+        },
+        {
+          "include": "#others"
+        }
+      ]
+    },
+    "attrset-or-function": {
+      "begin": "\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.attrset-or-function.nix"
+        }
+      },
+      "end": "(?=([\\])};]|\\b(else|then)\\b))",
+      "patterns": [
+        {
+          "begin": "(?=(\\s*\\}|\\\"|\\binherit\\b|\\$\\{|\\b[a-zA-Z\\_][a-zA-Z0-9\\_\\'\\-]*(\\s*\\.|\\s*=[^=])))",
+          "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+          "patterns": [
+            {
+              "include": "#attrset-definition-brace-opened"
+            }
+          ]
+        },
+        {
+          "begin": "(?=(\\.\\.\\.|\\b[a-zA-Z\\_][a-zA-Z0-9\\_\\'\\-]*\\s*[,?]))",
+          "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+          "patterns": [
+            {
+              "include": "#function-definition-brace-opened"
+            }
+          ]
+        },
+        {
+          "include": "#bad-reserved"
+        },
+        {
+          "begin": "\\b[a-zA-Z\\_][a-zA-Z0-9\\_\\'\\-]*",
+          "end": "(?=([\\])};]|\\b(else|then)\\b))",
+          "beginCaptures": {
+            "0": {
+              "name": "variable.parameter.function.maybe.nix"
+            }
+          },
+          "patterns": [
+            {
+              "begin": "(?=\\.)",
+              "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+              "patterns": [
+                {
+                  "include": "#attrset-definition-brace-opened"
+                }
+              ]
+            },
+            {
+              "begin": "\\s*(\\,)",
+              "beginCaptures": {
+                "1": {
+                  "name": "keyword.operator.nix"
+                }
+              },
+              "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+              "patterns": [
+                {
+                  "include": "#function-definition-brace-opened"
+                }
+              ]
+            },
+            {
+              "begin": "(?=\\=)",
+              "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+              "patterns": [
+                {
+                  "include": "#attribute-bind-from-equals"
+                },
+                {
+                  "include": "#attrset-definition-brace-opened"
+                }
+              ]
+            },
+            {
+              "begin": "(?=\\?)",
+              "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+              "patterns": [
+                {
+                  "include": "#function-parameter-default"
+                },
+                {
+                  "begin": "\\,",
+                  "beginCaptures": {
+                    "0": {
+                      "name": "keyword.operator.nix"
+                    }
+                  },
+                  "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+                  "patterns": [
+                    {
+                      "include": "#function-definition-brace-opened"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "include": "#others"
+            }
+          ]
+        },
+        {
+          "include": "#others"
+        }
+      ]
+    },
+    "with-assert": {
+      "begin": "(?<![\\w'-])(with|assert)(?![\\w'-])",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.other.nix"
+        }
+      },
+      "end": "\\;",
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "let": {
+      "begin": "(?=\\blet\\b)",
+      "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+      "patterns": [
+        {
+          "begin": "\\blet\\b",
+          "beginCaptures": {
+            "0": {
+              "name": "keyword.other.nix"
+            }
+          },
+          "end": "(?=([\\])};,]|\\b(in|else|then)\\b))",
+          "patterns": [
+            {
+              "begin": "(?=\\{)",
+              "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+              "patterns": [
+                {
+                  "begin": "\\{",
+                  "end": "\\}",
+                  "patterns": [
+                    {
+                      "include": "#attrset-contents"
+                    }
+                  ]
+                },
+                {
+                  "begin": "(^|(?<=\\}))",
+                  "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+                  "patterns": [
+                    {
+                      "include": "#expression-cont"
+                    }
+                  ]
+                },
+                {
+                  "include": "#others"
+                }
+              ]
+            },
+            {
+              "include": "#attrset-contents"
+            },
+            {
+              "include": "#others"
+            }
+          ]
+        },
+        {
+          "begin": "\\bin\\b",
+          "beginCaptures": {
+            "0": {
+              "name": "keyword.other.nix"
+            }
+          },
+          "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+          "patterns": [
+            {
+              "include": "#expression"
+            }
+          ]
+        }
+      ]
+    },
+    "if": {
+      "begin": "(?=\\bif\\b)",
+      "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+      "patterns": [
+        {
+          "begin": "\\bif\\b",
+          "end": "\\bth(?=en\\b)",
+          "beginCaptures": {
+            "0": {
+              "name": "keyword.other.nix"
+            }
+          },
+          "endCaptures": {
+            "0": {
+              "name": "keyword.other.nix"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#expression"
+            }
+          ]
+        },
+        {
+          "begin": "(?<=th)en\\b",
+          "end": "\\bel(?=se\\b)",
+          "beginCaptures": {
+            "0": {
+              "name": "keyword.other.nix"
+            }
+          },
+          "endCaptures": {
+            "0": {
+              "name": "keyword.other.nix"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#expression"
+            }
+          ]
+        },
+        {
+          "begin": "(?<=el)se\\b",
+          "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+          "endCaptures": {
+            "0": {
+              "name": "keyword.other.nix"
+            }
+          },
+          "beginCaptures": {
+            "0": {
+              "name": "keyword.other.nix"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#expression"
+            }
+          ]
+        }
+      ]
+    },
+    "function-body": {
+      "begin": "(@\\s*([a-zA-Z\\_][a-zA-Z0-9\\_\\'\\-]*)\\s*)?(\\:)",
+      "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "comment": {
+      "patterns": [
+        {
+          "name": "comment.block.nix",
+          "begin": "/\\*([^*]|\\*[^\\/])*",
+          "end": "\\*\\/"
+        },
+        {
+          "name": "comment.line.number-sign.nix",
+          "begin": "\\#",
+          "end": "$"
+        }
+      ]
+    },
+    "interpolation": {
+      "name": "meta.embedded",
+      "begin": "\\$\\{",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.section.embedded.begin.nix"
+        }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.embedded.end.nix"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "string-quoted": {
+      "name": "string.quoted.double.nix",
+      "begin": "\\\"",
+      "end": "\\\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.double.start.nix"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.double.end.nix"
+        }
+      },
+      "patterns": [
+        {
+          "match": "\\\\.",
+          "name": "constant.character.escape.nix"
+        },
+        {
+          "include": "#interpolation"
+        }
+      ]
+    },
+    "string": {
+      "patterns": [
+        {
+          "begin": "(?=\\'\\')",
+          "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+          "patterns": [
+            {
+              "name": "string.quoted.other.nix",
+              "begin": "\\'\\'",
+              "end": "\\'\\'(?!\\$|\\'|\\\\.)",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.definition.string.other.start.nix"
+                }
+              },
+              "endCaptures": {
+                "0": {
+                  "name": "punctuation.definition.string.other.end.nix"
+                }
+              },
+              "patterns": [
+                {
+                  "name": "constant.character.escape.nix",
+                  "match": "\\'\\'(\\$|\\'|\\\\.)"
+                },
+                {
+                  "include": "#interpolation"
+                }
+              ]
+            },
+            {
+              "include": "#expression-cont"
+            }
+          ]
+        },
+        {
+          "begin": "(?=\\\")",
+          "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+          "patterns": [
+            {
+              "include": "#string-quoted"
+            },
+            {
+              "include": "#expression-cont"
+            }
+          ]
+        },
+        {
+          "begin": "(~?[a-zA-Z0-9\\.\\_\\-\\+]*(\\/[a-zA-Z0-9\\.\\_\\-\\+]+)+)",
+          "beginCaptures": {
+            "0": {
+              "name": "string.unquoted.path.nix"
+            }
+          },
+          "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+          "patterns": [
+            {
+              "include": "#expression-cont"
+            }
+          ]
+        },
+        {
+          "begin": "(\\<[a-zA-Z0-9\\.\\_\\-\\+]+(\\/[a-zA-Z0-9\\.\\_\\-\\+]+)*\\>)",
+          "beginCaptures": {
+            "0": {
+              "name": "string.unquoted.spath.nix"
+            }
+          },
+          "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+          "patterns": [
+            {
+              "include": "#expression-cont"
+            }
+          ]
+        },
+        {
+          "begin": "([a-zA-Z][a-zA-Z0-9\\+\\-\\.]*\\:[a-zA-Z0-9\\%\\/\\?\\:\\@\\&\\=\\+\\$\\,\\-\\_\\.\\!\\~\\*\\']+)",
+          "beginCaptures": {
+            "0": {
+              "name": "string.unquoted.url.nix"
+            }
+          },
+          "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+          "patterns": [
+            {
+              "include": "#expression-cont"
+            }
+          ]
+        }
+      ]
+    },
+    "parameter-name": {
+      "match": "\\b[a-zA-Z\\_][a-zA-Z0-9\\_\\'\\-]*",
+      "captures": {
+        "0": {
+          "name": "variable.parameter.name.nix"
+        }
+      }
+    },
+    "parameter-name-and-cont": {
+      "begin": "\\b[a-zA-Z\\_][a-zA-Z0-9\\_\\'\\-]*",
+      "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+      "beginCaptures": {
+        "0": {
+          "name": "variable.parameter.name.nix"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expression-cont"
+        }
+      ]
+    },
+    "attribute-name-single": {
+      "match": "\\b[a-zA-Z\\_][a-zA-Z0-9\\_\\'\\-]*",
+      "name": "entity.other.attribute-name.single.nix"
+    },
+    "attribute-name": {
+      "patterns": [
+        {
+          "match": "\\b[a-zA-Z\\_][a-zA-Z0-9\\_\\'\\-]*",
+          "name": "entity.other.attribute-name.multipart.nix"
+        },
+        {
+          "match": "\\."
+        },
+        {
+          "include": "#string-quoted"
+        },
+        {
+          "include": "#interpolation"
+        }
+      ]
+    },
+    "function-parameter-default": {
+      "begin": "\\?",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.operator.nix"
+        }
+      },
+      "end": "(?=[,}])",
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "function-parameter": {
+      "patterns": [
+        {
+          "begin": "(\\.\\.\\.)",
+          "end": "(,|(?=\\}))",
+          "name": "keyword.operator.nix",
+          "patterns": [
+            {
+              "include": "#others"
+            }
+          ]
+        },
+        {
+          "begin": "\\b[a-zA-Z\\_][a-zA-Z0-9\\_\\'\\-]*",
+          "beginCaptures": {
+            "0": {
+              "name": "variable.parameter.function.1.nix"
+            }
+          },
+          "end": "(,|(?=\\}))",
+          "endCaptures": {
+            "0": {
+              "name": "keyword.operator.nix"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#whitespace"
+            },
+            {
+              "include": "#comment"
+            },
+            {
+              "include": "#function-parameter-default"
+            },
+            {
+              "include": "#expression"
+            }
+          ]
+        },
+        {
+          "include": "#others"
+        }
+      ]
+    },
+    "attribute-inherit": {
+      "begin": "\\binherit\\b",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.other.inherit.nix"
+        }
+      },
+      "end": "\\;",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.terminator.inherit.nix"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "\\(",
+          "end": "(?=\\;)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.section.function.arguments.nix"
+            }
+          },
+          "patterns": [
+            {
+              "begin": "\\)",
+              "end": "(?=\\;)",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.section.function.arguments.nix"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#bad-reserved"
+                },
+                {
+                  "include": "#attribute-name-single"
+                },
+                {
+                  "include": "#others"
+                }
+              ]
+            },
+            {
+              "include": "#expression"
+            }
+          ]
+        },
+        {
+          "begin": "(?=[a-zA-Z\\_])",
+          "end": "(?=\\;)",
+          "patterns": [
+            {
+              "include": "#bad-reserved"
+            },
+            {
+              "include": "#attribute-name-single"
+            },
+            {
+              "include": "#others"
+            }
+          ]
+        },
+        {
+          "include": "#others"
+        }
+      ]
+    },
+    "attribute-bind-from-equals": {
+      "begin": "\\=",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.operator.bind.nix"
+        }
+      },
+      "end": "\\;",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.terminator.bind.nix"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#expression"
+        }
+      ]
+    },
+    "attribute-bind": {
+      "patterns": [
+        {
+          "include": "#attribute-name"
+        },
+        {
+          "include": "#attribute-bind-from-equals"
+        }
+      ]
+    },
+    "operator-unary": {
+      "name": "keyword.operator.unary.nix",
+      "match": "(!|-)"
+    },
+    "operator-binary": {
+      "name": "keyword.operator.nix",
+      "match": "(\\bor\\b|\\.|\\|\\>|\\<\\||==|!=|!|\\<\\=|\\<|\\>\\=|\\>|&&|\\|\\||-\\>|//|\\?|\\+\\+|-|\\*|/(?=([^*]|$))|\\+)"
+    },
+    "constants": {
+      "patterns": [
+        {
+          "begin": "\\b(builtins|true|false|null)\\b",
+          "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+          "beginCaptures": {
+            "0": {
+              "name": "constant.language.nix"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#expression-cont"
+            }
+          ]
+        },
+        {
+          "beginCaptures": {
+            "0": {
+              "name": "support.function.nix"
+            }
+          },
+          "begin": "\\b(scopedImport|import|isNull|abort|throw|baseNameOf|dirOf|removeAttrs|map|toString|derivationStrict|derivation)\\b",
+          "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+          "patterns": [
+            {
+              "include": "#expression-cont"
+            }
+          ]
+        },
+        {
+          "beginCaptures": {
+            "0": {
+              "name": "constant.numeric.nix"
+            }
+          },
+          "begin": "\\b[0-9]+\\b",
+          "end": "(?=([\\])};,]|\\b(else|then)\\b))",
+          "patterns": [
+            {
+              "include": "#expression-cont"
+            }
+          ]
+        }
+      ]
+    },
+    "whitespace": {
+      "match": "\\s+"
+    },
+    "illegal": {
+      "match": ".",
+      "name": "invalid.illegal"
+    },
+    "others": {
+      "patterns": [
+        {
+          "include": "#whitespace"
+        },
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#illegal"
+        }
+      ]
+    },
+    "bad-reserved": {
+      "match": "(?<![\\w'-])(if|then|else|assert|with|let|in|rec|inherit)(?![\\w'-])",
+      "name": "invalid.illegal.reserved.nix"
+    }
+  }
+}

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -10,6 +10,7 @@ import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
 import { registerAstroLanguage } from './monaco-languages/register-astro'
 import { registerJsonlLanguage } from './monaco-languages/register-jsonl'
 import { registerNimLanguage } from './monaco-languages/register-nim'
+import { registerNixLanguage } from './monaco-languages/register-nix'
 import { registerSvelteLanguage } from './monaco-languages/register-svelte'
 import { registerVueLanguage } from './monaco-languages/register-vue'
 import { installMonacoDelayerCancellationGuard } from './monaco-delayer-cancellation-guard'
@@ -78,6 +79,7 @@ registerVueLanguage(monaco)
 registerSvelteLanguage(monaco)
 registerAstroLanguage(monaco)
 registerNimLanguage(monaco)
+registerNixLanguage(monaco)
 registerJsonlLanguage(monaco)
 installMonacoDelayerCancellationGuard()
 installMonacoDiffEditorDisposalGuard(monaco)


### PR DESCRIPTION
## Summary

Add syntax highlighting for Nix (`.nix`) files, which previously rendered as plain text. Nix is the configuration language of the Nix package manager and NixOS; repositories in this ecosystem (flakes, NixOS/home-manager configurations, nixpkgs contributions) are almost entirely `.nix` files, so agents and humans reviewing diffs in Orca currently get no highlighting at all.

The implementation follows the existing TextMate-backed registration pattern introduced for Nim (#5434):

- `register-nix.ts` — Monaco registration for the `nix` language id with `source.nix` scope.
- Vendored grammar from [nix-community/vscode-nix-ide](https://github.com/nix-community/vscode-nix-ide) (`dist/nix.tmLanguage.json`), the canonical, maintained VS Code Nix grammar. MIT; license vendored alongside as `nix-LICENSE.txt`, mirroring the `nim-LICENSE.txt` convention.
- Language configuration ports the essentials of upstream's `language-configuration.json`: comments (`#`, `/* */`), bracket pairs, auto-closing pairs including Nix's `''` indented-string delimiter, a `wordPattern` that keeps hyphenated identifiers (`home-manager`) selectable as one word, and `onEnterRules` so Enter indents correctly between `let`/`in`, `if`/`then`, `then`/`else` and inside `''` strings.
- The configuration is a factory (`createNixLanguageConfiguration(monaco)`) because `onEnterRules` needs the runtime `monaco.languages.IndentAction` enum, which a type-only import cannot provide.
- `.nix` → `nix` mapping in `language-detect.ts`; registration call in `monaco-setup.ts`.

No new dependencies; the grammar loads through the existing `vscode-textmate`/`vscode-oniguruma` infrastructure.

Related: #8093 (user-provided TextMate grammars) is the general mechanism; this PR adds Nix as a built-in in the meantime, like Nim.

## Screenshots

<img width="1114" height="1793" alt="highlight-demo" src="https://github.com/user-attachments/assets/331543de-955f-40ca-975a-8e1ce65acfc7" />

## Testing

- [x] `pnpm lint` — the touched files are clean; the two `switch-exhaustiveness-check` errors reported are pre-existing on `main` in files this PR does not touch (`native-chat-session-option-labels.ts`, `skill-freshness-group.tsx`)
- [x] `pnpm typecheck`
- [x] `pnpm test` — all monaco-languages and language-detect suites pass (9 files / 40 tests); the handful of failing suites on my machine are environment-sensitive PTY/SSH/WSL main-process tests unrelated to this change (NixOS sandbox), and they fail identically without this PR
- [x] `pnpm build:web` — built and manually verified (see below); desktop/native packaging left to CI
- [x] Added tests: registration wiring, grammar loading (name/scope/fileTypes), hyphenated-identifier word pattern, `''` indent-outdent onEnterRule, `.nix` language detection

Manual verification: built the web client with this change and paired it against a live `orca serve` runtime; opened `.nix` files (NixOS flake + module files) in the editor — highlighting, bracket matching, `''` auto-close, and double-click selection of hyphenated attribute names all behave as expected.

## AI Review Report

Reviewed with Claude Code. Checks performed:

- **Pattern fidelity**: the registration mirrors `register-nim.ts` structurally (ids, scope constant, grammar loader guard, test shape); the only deliberate deviation (config factory) is commented with the reason.
- **Grammar correctness**: a dedicated review pass diffed the vendored grammar against upstream `dist/nix.tmLanguage.json` (byte-identical, JSON-normalized) and spot-checked coverage of Nix constructs — line/block comments, `"…"` strings with `${}` interpolation, `''` indented strings with their `''$`/`'''`/`''\` escapes, paths/`<nixpkgs>` spaths/URIs, `let`/`in`/`with`/`assert`/`inherit`/`rec`, lambda parameter patterns, builtins. Scope names are conventional (`comment.*`, `string.*`, `keyword.*`, …), so the existing editor themes color them with no theme changes.
- **Cross-platform (macOS / Linux / Windows)**: renderer-only TypeScript + a static JSON asset; no keyboard shortcuts, no file-system paths, no shell or Electron main-process involvement, no platform conditionals needed. Applies identically in the desktop app and the web client (verified in the web client on Linux).
- **SSH/remote/local**: highlighting is purely client-side rendering of buffer content; no assumptions about where the file lives.
- **Performance**: the grammar (~28 kB) is loaded lazily via dynamic import only when a Nix file is first opened, matching the Nim approach; no impact on startup or other languages.

Flagged and fixed during review: two unnecessary regex escapes (oxlint `no-useless-escape`), and two editing-experience gaps in the initial version (missing `wordPattern` and `onEnterRules`) — both now included with regression tests.

## Security Audit

- The only new asset is a static TextMate grammar JSON vendored from the canonical MIT-licensed repository (`nix-community/vscode-nix-ide`), fetched from its `main` branch and verified identical to upstream. It contains only declarative regex patterns consumed by the existing `vscode-textmate` engine — no executable code, no network access, no new dependencies, no IPC surface.
- Regexes in the language configuration (`wordPattern`, `onEnterRules`) are copied from the same upstream configuration that ships in the VS Code extension; they are anchored, non-nested patterns evaluated per line by Monaco, with no user-controlled amplification beyond what every existing language configuration already allows.
- No input handling, command execution, path handling, auth, or secrets are touched.

## Notes

- First registration to use `onEnterRules`, hence the config-factory shape noted in Summary; siblings (`register-nim.ts` etc.) are unaffected.
- No visual change for any language other than Nix.

## ELI5

Nix files (.nix) get syntax highlighting instead of plain text. Flakes and NixOS configs are readable in the editor and diffs with proper coloring.
