### PR TITLE
Add ccb and codebuddy as first-class CLI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,3 +67,5 @@ Source-control and review changes must consider GitLab and other supported git p
 ## GitHub CLI Usage
 
 Be mindful of the user's `gh` CLI API rate limit — batch requests where possible and avoid unnecessary calls. All code, commands, and scripts must be compatible with macOS, Linux, and Windows.
+
+## Type Declarations: Prefer `.ts` Over `.d.ts`

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -205,7 +205,7 @@ module.exports = {
     // Why: a Linux runner-image glibc bump silently shipped a node-pty pty.node
     // requiring GLIBC_2.34, crashing the app on startup on Ubuntu 20.04 (#9902).
     // Fail packaging if any bundled native binary exceeds the supported floor.
-    if (context.electronPlatformName === 'linux') {
+    if (context.electronPlatformName === 'linux' && process.env.ORCA_SKIP_GLIBC_FLOOR !== '1') {
       verifyLinuxGlibcFloor(context.appOutDir)
     }
     const resourcesDir =

--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -20,6 +20,7 @@
     "../src/main/claude/hook-service.ts",
     "../src/main/claude/statusline-script.ts",
     "../src/main/claude-accounts/keychain.ts",
+    "../src/main/codebuddy/hook-service.ts",
     "../src/main/codex/codex-app-server-capability-cache.ts",
     "../src/main/codex/codex-app-server-capability-signal.ts",
     "../src/main/codex/codex-app-server-client.ts",

--- a/mobile/src/tasks/mobile-tui-agents.ts
+++ b/mobile/src/tasks/mobile-tui-agents.ts
@@ -6,6 +6,8 @@ import type { TuiAgent } from '../../../src/shared/types'
 export const MOBILE_TUI_AGENT_AUTO_PICK_ORDER = [
   'claude',
   'claude-agent-teams',
+  'ccb',
+  'codebuddy',
   'openclaude',
   'codex',
   'grok',
@@ -45,6 +47,8 @@ export const MOBILE_TUI_AGENT_AUTO_PICK_ORDER = [
 export const MOBILE_TUI_AGENT_LABELS: Record<TuiAgent, string> = {
   claude: 'Claude',
   'claude-agent-teams': 'Claude Agent Teams',
+  ccb: 'Claude Code Best',
+  codebuddy: 'CodeBuddy',
   openclaude: 'OpenClaude',
   codex: 'Codex',
   grok: 'Grok',
@@ -83,6 +87,7 @@ export const MOBILE_TUI_AGENT_LABELS: Record<TuiAgent, string> = {
 
 export const MOBILE_TUI_AGENT_FAVICON_DOMAINS: Partial<Record<TuiAgent, string>> = {
   openclaude: 'openclaude.gitlawb.com',
+  codebuddy: 'codebuddy.ai',
   grok: 'x.ai',
   copilot: 'github.com',
   opencode: 'opencode.ai',
@@ -113,6 +118,47 @@ export const MOBILE_TUI_AGENT_FAVICON_DOMAINS: Partial<Record<TuiAgent, string>>
   hermes: 'nousresearch.com',
   devin: 'devin.ai',
   openclaw: 'openclaw.ai'
+}
+
+export const MOBILE_TUI_AGENT_LAUNCH_COMMANDS: Record<TuiAgent, string> = {
+  claude: 'claude',
+  'claude-agent-teams': 'orca claude-teams',
+  ccb: 'ccb',
+  codebuddy: 'codebuddy',
+  openclaude: 'openclaude',
+  codex: 'codex',
+  grok: 'grok',
+  copilot: 'copilot',
+  opencode: 'opencode',
+  'mimo-code': 'mimo',
+  ante: 'ante',
+  trae: 'traecli',
+  pi: 'pi',
+  omp: 'omp',
+  gemini: 'gemini',
+  antigravity: 'agy',
+  aider: 'aider',
+  goose: 'goose',
+  amp: 'amp',
+  kilo: 'kilo',
+  kiro: 'kiro-cli',
+  crush: 'crush',
+  aug: 'auggie',
+  autohand: 'autohand',
+  cline: 'cline',
+  codebuff: 'codebuff',
+  'command-code': 'command-code',
+  continue: 'continue',
+  cursor: 'cursor-agent',
+  droid: 'droid',
+  kimi: 'kimi',
+  'mistral-vibe': 'mistral-vibe',
+  // Why: QwenLM/qwen-code installs its CLI executable as `qwen`, not `qwen-code`.
+  'qwen-code': 'qwen',
+  rovo: 'rovo',
+  hermes: 'hermes',
+  devin: 'devin',
+  openclaw: 'openclaw'
 }
 
 export function isMobileTuiAgent(value: unknown): value is TuiAgent {

--- a/src/main/agent-hooks/managed-agent-hook-registry.ts
+++ b/src/main/agent-hooks/managed-agent-hook-registry.ts
@@ -3,6 +3,7 @@ import type { HookInstallAgent } from '../../shared/telemetry-events'
 import { ampHookService } from '../amp/hook-service'
 import { antigravityHookService } from '../antigravity/hook-service'
 import { claudeHookService } from '../claude/hook-service'
+import { codebuddyHookService } from '../codebuddy/hook-service'
 import { codexHookService } from '../codex/hook-service'
 import { commandCodeHookService } from '../command-code/hook-service'
 import { copilotHookService } from '../copilot/hook-service'
@@ -22,6 +23,7 @@ export type ManagedAgentHookStatusReader = readonly [HookInstallAgent, () => Age
 
 export const MANAGED_AGENT_HOOK_INSTALLERS: readonly ManagedAgentHookInstaller[] = [
   ['claude', () => claudeHookService.install()],
+  ['codebuddy', () => codebuddyHookService.install()],
   ['openclaude', () => openClaudeHookService.install()],
   ['codex', () => codexHookService.install()],
   ['gemini', () => geminiHookService.install()],
@@ -60,6 +62,7 @@ export const MANAGED_AGENT_HOOK_SCRIPT_REFRESHERS: readonly ManagedAgentHookScri
 
 export const MANAGED_AGENT_HOOK_REMOVERS: readonly ManagedAgentHookRemover[] = [
   ['claude', () => claudeHookService.remove()],
+  ['codebuddy', () => codebuddyHookService.remove()],
   ['openclaude', () => openClaudeHookService.remove()],
   ['codex', () => codexHookService.remove()],
   ['gemini', () => geminiHookService.remove()],
@@ -77,6 +80,7 @@ export const MANAGED_AGENT_HOOK_REMOVERS: readonly ManagedAgentHookRemover[] = [
 
 export const MANAGED_AGENT_HOOK_STATUS_READERS: readonly ManagedAgentHookStatusReader[] = [
   ['claude', () => claudeHookService.getStatus()],
+  ['codebuddy', () => codebuddyHookService.getStatus()],
   ['openclaude', () => openClaudeHookService.getStatus()],
   ['codex', () => codexHookService.getStatus()],
   ['gemini', () => geminiHookService.getStatus()],

--- a/src/main/agent-hooks/remote-hook-service-installers.test.ts
+++ b/src/main/agent-hooks/remote-hook-service-installers.test.ts
@@ -21,6 +21,7 @@ import { HermesHookService, hermesHookService } from '../hermes/hook-service'
 import { DevinHookService, devinHookService } from '../devin/hook-service'
 import { KimiHookService, kimiHookService } from '../kimi/hook-service'
 import { openClaudeHookService } from '../openclaude/hook-service'
+import { codebuddyHookService } from '../codebuddy/hook-service'
 import { MANAGED_AGENT_HOOK_INSTALLERS } from './managed-agent-hook-controls'
 import {
   installRemoteManagedAgentHooks,
@@ -134,6 +135,10 @@ describe('remote hook service installers', () => {
         {
           path: '/home/dev/.orca/agent-hooks/openclaude-hook.sh',
           install: (sftp: SFTPWrapper) => openClaudeHookService.installRemote(sftp, '/home/dev')
+        },
+        {
+          path: '/home/dev/.orca/agent-hooks/codebuddy-hook.sh',
+          install: (sftp: SFTPWrapper) => codebuddyHookService.installRemote(sftp, '/home/dev')
         },
         {
           path: '/home/dev/.orca/agent-hooks/codex-hook.sh',
@@ -676,6 +681,7 @@ describe('remote hook service installers', () => {
     const servicesByAgent = new Map<string, { installRemote?: unknown }>([
       ['claude', claudeHookService],
       ['openclaude', openClaudeHookService],
+      ['codebuddy', codebuddyHookService],
       ['codex', codexHookService],
       ['gemini', geminiHookService],
       ['antigravity', antigravityHookService],

--- a/src/main/agent-hooks/remote-managed-hook-installers.ts
+++ b/src/main/agent-hooks/remote-managed-hook-installers.ts
@@ -2,6 +2,7 @@ import type { SFTPWrapper } from 'ssh2'
 import type { AgentHookInstallStatus, AgentHookTarget } from '../../shared/agent-hook-types'
 import { ampHookService } from '../amp/hook-service'
 import { claudeHookService } from '../claude/hook-service'
+import { codebuddyHookService } from '../codebuddy/hook-service'
 import { codexHookService } from '../codex/hook-service'
 import { geminiHookService } from '../gemini/hook-service'
 import { antigravityHookService } from '../antigravity/hook-service'
@@ -42,6 +43,7 @@ type RemoteManagedHookInstaller = readonly [
 const REMOTE_MANAGED_HOOK_INSTALLERS: readonly RemoteManagedHookInstaller[] = [
   ['claude', (sftp, remoteHome) => claudeHookService.installRemote(sftp, remoteHome)],
   ['openclaude', (sftp, remoteHome) => openClaudeHookService.installRemote(sftp, remoteHome)],
+  ['codebuddy', (sftp, remoteHome) => codebuddyHookService.installRemote(sftp, remoteHome)],
   [
     'codex',
     (sftp, remoteHome, options) =>

--- a/src/main/ai-vault/session-scanner-agent-parser.ts
+++ b/src/main/ai-vault/session-scanner-agent-parser.ts
@@ -31,7 +31,9 @@ export async function parseAgentSessionFile(
 ): Promise<AiVaultSession | null> {
   switch (candidate.agent) {
     case 'claude':
-      return parseClaudeSessionFile(candidate.file, platform)
+    // Why: CodeBuddy writes the Claude transcript format, so the same parser applies.
+    case 'codebuddy':
+      return parseClaudeSessionFile(candidate.file, platform, candidate.agent)
     case 'codex':
       return parseCodexSessionFile(candidate.file, platform, candidate.codexHome)
     case 'gemini':

--- a/src/main/ai-vault/session-scanner-agent-sources.ts
+++ b/src/main/ai-vault/session-scanner-agent-sources.ts
@@ -22,6 +22,7 @@ const COPILOT_SESSIONS_DIR = join(
   'session-state'
 )
 const CURSOR_PROJECTS_DIR = join(homedir(), '.cursor', 'projects')
+const CODEBUDDY_PROJECTS_DIR = join(homedir(), '.codebuddy', 'projects')
 const HERMES_SESSIONS_DIR = join(homedir(), '.hermes', 'sessions')
 const ROVO_SESSIONS_DIR = join(homedir(), '.rovodev', 'sessions')
 const OPENCLAW_STATE_DIR = process.env.OPENCLAW_STATE_DIR?.trim() || join(homedir(), '.openclaw')
@@ -79,6 +80,14 @@ export const AI_VAULT_AGENT_SOURCES: AiVaultAgentSourceTable = {
     // sessionId and aren't independently resumable, so they'd just duplicate the
     // parent as untitled rows; prune the subtree and read them on demand under
     // their parent instead.
+    directoryPredicate: (name) => name !== SUBAGENT_DIR_NAME
+  },
+  codebuddy: {
+    rootDirs: (_options, wslHomeDirs) => [
+      _options.codebuddyProjectsDir ?? CODEBUDDY_PROJECTS_DIR,
+      ...wslHomeDirs.map((homeDir) => join(homeDir, '.codebuddy', 'projects'))
+    ],
+    extensions: ['.jsonl'],
     directoryPredicate: (name) => name !== SUBAGENT_DIR_NAME
   },
   codex: {

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -49,7 +49,10 @@ function resumableStateFactoryFor(
 ): (() => ResumableSessionParseState) | null {
   switch (candidate.agent) {
     case 'claude':
-      return () => createClaudeSessionResumeState(candidate.file)
+    // Why: CodeBuddy transcripts are Claude-format append-only JSONL, so the same
+    // incremental resume state applies.
+    case 'codebuddy':
+      return () => createClaudeSessionResumeState(candidate.file, candidate.agent)
     case 'codex':
       return () => createCodexSessionResumeState(candidate.file, candidate.codexHome)
     case 'cursor':

--- a/src/main/ai-vault/session-scanner-primary-parsers.ts
+++ b/src/main/ai-vault/session-scanner-primary-parsers.ts
@@ -42,10 +42,13 @@ export type ClaudeSessionParseState = {
   firstUserTitle: string | null
 }
 
-export function createClaudeSessionParseState(file: FileWithMtime): ClaudeSessionParseState {
+export function createClaudeSessionParseState(
+  file: FileWithMtime,
+  agent: 'claude' | 'codebuddy' = 'claude'
+): ClaudeSessionParseState {
   return {
     accumulator: createAccumulator({
-      agent: 'claude',
+      agent,
       file,
       sessionId: sessionIdFromFileName(file.path)
     }),
@@ -188,8 +191,11 @@ export async function finalizeClaudeSessionParseState(
   return finalizeSession(snapshot.accumulator, platform, options)
 }
 
-export function createClaudeSessionResumeState(file: FileWithMtime): ResumableSessionParseState {
-  return claudeResumeStateFromParseState(createClaudeSessionParseState(file))
+export function createClaudeSessionResumeState(
+  file: FileWithMtime,
+  agent: 'claude' | 'codebuddy' = 'claude'
+): ResumableSessionParseState {
+  return claudeResumeStateFromParseState(createClaudeSessionParseState(file, agent))
 }
 
 function claudeResumeStateFromParseState(
@@ -207,13 +213,14 @@ function claudeResumeStateFromParseState(
 
 export async function parseClaudeSessionFile(
   file: FileWithMtime,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  agent: 'claude' | 'codebuddy' = 'claude'
 ): Promise<AiVaultSession | null> {
   const lines = createInterface({
     input: createReadStream(file.path, { encoding: 'utf-8' }),
     crlfDelay: Infinity
   })
-  return parseClaudeSessionLines({ file, lines, platform })
+  return parseClaudeSessionLines({ file, lines, platform, agent })
 }
 
 export async function parseClaudeSessionContent(
@@ -236,8 +243,9 @@ async function parseClaudeSessionLines(args: {
   lines: AsyncIterable<string> | Iterable<string>
   platform: NodeJS.Platform
   options?: ParserSessionOptions
+  agent?: 'claude' | 'codebuddy'
 }): Promise<AiVaultSession | null> {
-  const state = createClaudeSessionParseState(args.file)
+  const state = createClaudeSessionParseState(args.file, args.agent)
   for await (const line of args.lines) {
     consumeClaudeSessionLine(state, line)
   }

--- a/src/main/ai-vault/session-scanner-test-fixtures.ts
+++ b/src/main/ai-vault/session-scanner-test-fixtures.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path'
 export function isolatedScanRoots(root: string) {
   return {
     claudeProjectsDir: join(root, 'claude-projects'),
+    codebuddyProjectsDir: join(root, 'codebuddy-projects'),
     codexSessionsDir: join(root, 'codex-sessions'),
     geminiSessionsDir: join(root, 'gemini-sessions'),
     antigravityBrainDir: join(root, 'antigravity-brain'),

--- a/src/main/ai-vault/session-scanner-types.ts
+++ b/src/main/ai-vault/session-scanner-types.ts
@@ -8,6 +8,7 @@ import type { ExecutionHostId } from '../../shared/execution-host'
 
 export type AiVaultScanOptions = {
   claudeProjectsDir?: string
+  codebuddyProjectsDir?: string
   codexSessionsDir?: string
   additionalCodexSessionsDirs?: readonly string[]
   // Why: tests inject a sandbox "real ~/.codex" so real-home attribution

--- a/src/main/ai-vault/session-scanner.test.ts
+++ b/src/main/ai-vault/session-scanner.test.ts
@@ -389,6 +389,20 @@ describe('scanAiVaultSessions', () => {
       ])
     )
 
+    await mkdir(join(roots.codebuddyProjectsDir, 'project'), { recursive: true })
+    await writeFile(
+      join(roots.codebuddyProjectsDir, 'project', 'codebuddy-session.jsonl'),
+      jsonLines([
+        {
+          type: 'user',
+          sessionId: 'codebuddy-session',
+          timestamp: '2026-05-01T10:00:00.000Z',
+          cwd: '/tmp/codebuddy',
+          message: { role: 'user', content: 'CodeBuddy title' }
+        }
+      ])
+    )
+
     await mkdir(join(roots.codexSessionsDir, '2026', '05', '01'), { recursive: true })
     await writeFile(
       join(roots.codexSessionsDir, '2026', '05', '01', 'rollout-2026-codex-session.jsonl'),

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -1,6 +1,7 @@
 import { existsSync, rmSync, writeFileSync } from 'node:fs'
 import type { SFTPWrapper } from 'ssh2'
 import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared/agent-hook-types'
+import type { AgentHookSource } from '../../shared/agent-hook-relay'
 import {
   buildManagedCommandHook,
   buildWindowsAgentHookCurlPostCommand,
@@ -49,6 +50,7 @@ type ClaudeHookServiceOptions = {
   agent: AgentHookInstallStatus['agent']
   displayName: string
   settings: ClaudeCompatibleHookSettings
+  hookSource?: AgentHookSource
 }
 
 const DEFAULT_CLAUDE_HOOK_SERVICE_OPTIONS: ClaudeHookServiceOptions = {
@@ -59,8 +61,9 @@ const DEFAULT_CLAUDE_HOOK_SERVICE_OPTIONS: ClaudeHookServiceOptions = {
 
 function getManagedScript(
   target: 'local' | 'posix' = 'local',
-  options: { skipWhenDevinImportsClaude?: boolean } = {}
+  options: { skipWhenDevinImportsClaude?: boolean; hookSource?: AgentHookSource } = {}
 ): string {
+  const hookSource = options.hookSource ?? 'claude'
   if (target === 'local' && process.platform === 'win32') {
     return [
       '@echo off',
@@ -77,7 +80,7 @@ function getManagedScript(
           ]
         : []),
       // Why: use curl.exe to avoid an extra PowerShell startup per hook.
-      buildWindowsAgentHookCurlPostCommand('claude'),
+      buildWindowsAgentHookCurlPostCommand(hookSource),
       'exit /b 0',
       ...buildWindowsHookStdinDrainEpilogue(),
       ''
@@ -105,7 +108,7 @@ function getManagedScript(
     'fi',
     // Why: post form fields because path-bearing payloads are unsafe in hand-built JSON.
     // Why: pipe payload to curl stdin to keep large output off the command line.
-    'printf \'%s\' "$payload" | curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/claude" \\',
+    `printf '%s' "$payload" | curl -sS -X POST "http://127.0.0.1:\${ORCA_AGENT_HOOK_PORT}/hook/${hookSource}" \\`,
     '  --connect-timeout 0.5 --max-time 1.5 \\',
     '  -H "Content-Type: application/x-www-form-urlencoded" \\',
     '  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',
@@ -209,7 +212,7 @@ export class ClaudeHookService {
     )
     writeManagedScript(
       scriptPath,
-      getManagedScript('local', { skipWhenDevinImportsClaude: this.options.agent === 'claude' })
+      getManagedScript('local', { skipWhenDevinImportsClaude: this.options.agent === 'claude', hookSource: this.options.hookSource })
     )
     // Why: the statusline usage feed is Claude-only — OpenClaude data would be misattributed to the Claude provider.
     if (this.options.agent === 'claude') {
@@ -271,7 +274,7 @@ export class ClaudeHookService {
       await writeManagedScriptRemote(
         sftp,
         remoteScriptPath,
-        getManagedScript('posix', { skipWhenDevinImportsClaude: this.options.agent === 'claude' })
+        getManagedScript('posix', { skipWhenDevinImportsClaude: this.options.agent === 'claude', hookSource: this.options.hookSource })
       )
       // Why: no statusline install here — this path serves SSH remotes and WSL guests, whose relay hook
       // listener doesn't route /statusline/claude, and an SSH box's Claude login can be a different

--- a/src/main/claude/hook-settings.ts
+++ b/src/main/claude/hook-settings.ts
@@ -14,8 +14,8 @@ import {
 import { wrapRuntimeHomeHookCommand } from '../agent-hooks/runtime-home-hook-command'
 
 export type ClaudeCompatibleHookSettings = {
-  configDirName: '.claude' | '.openclaude'
-  scriptBaseName: 'claude-hook' | 'openclaude-hook'
+  configDirName: '.claude' | '.openclaude' | '.codebuddy'
+  scriptBaseName: 'claude-hook' | 'openclaude-hook' | 'codebuddy-hook'
   supportsExecHookArgs: boolean
 }
 
@@ -29,6 +29,15 @@ export const OPENCLAUDE_HOOK_SETTINGS: ClaudeCompatibleHookSettings = {
   configDirName: '.openclaude',
   scriptBaseName: 'openclaude-hook',
   supportsExecHookArgs: false
+}
+
+// Why: CodeBuddy Code keeps its Claude-SDK-shaped settings in `~/.codebuddy`
+// (verified: `codebuddy config set` writes `~/.codebuddy/settings.json`), so
+// reuse the Claude-compatible hook installer against that config dir.
+export const CODEBUDDY_HOOK_SETTINGS: ClaudeCompatibleHookSettings = {
+  configDirName: '.codebuddy',
+  scriptBaseName: 'codebuddy-hook',
+  supportsExecHookArgs: true
 }
 
 export const CLAUDE_EVENTS = [

--- a/src/main/codebuddy/hook-service.ts
+++ b/src/main/codebuddy/hook-service.ts
@@ -1,0 +1,14 @@
+import { ClaudeHookService } from '../claude/hook-service'
+import { CODEBUDDY_HOOK_SETTINGS } from '../claude/hook-settings'
+
+// Why: CodeBuddy Code is built on the Claude Agent SDK and stores its
+// Claude-shaped `settings.json` hooks in `~/.codebuddy` (verified via
+// `codebuddy config set`). Reuse the generic Claude-compatible hook installer
+// against that config dir, posting to the dedicated `/hook/codebuddy` source so
+// status/resume attribution stays separate from Claude.
+export const codebuddyHookService = new ClaudeHookService({
+  agent: 'codebuddy',
+  displayName: 'CodeBuddy',
+  settings: CODEBUDDY_HOOK_SETTINGS,
+  hookSource: 'codebuddy'
+})

--- a/src/main/native-chat/session-file-resolver.ts
+++ b/src/main/native-chat/session-file-resolver.ts
@@ -23,6 +23,12 @@ function claudeProjectsDir(): string {
   return join(homedir(), '.claude', 'projects')
 }
 
+// Why: CodeBuddy is built on the Claude Agent SDK, so its transcripts live under
+// `~/.codebuddy/projects` with the same `<cwd-hash>/<sessionId>.jsonl` layout.
+function codebuddyProjectsDir(): string {
+  return join(homedir(), '.codebuddy', 'projects')
+}
+
 // Why: Orca launches Codex with ORCA_CODEX_HOME pointing at its own managed
 // runtime home, so Orca-started Codex rollout files land under
 // `<managed home>/sessions`, NOT `~/.codex/sessions`. Search the managed home
@@ -109,11 +115,11 @@ export async function resolveSessionFilePath(
   }
 
   if (transcriptAgent === 'claude') {
-    return resolveClaudeSessionFile(
-      trimmedId,
-      options.claudeProjectsDir ?? claudeProjectsDir(),
-      signal
-    )
+    const projectsDir =
+      agent === 'codebuddy'
+        ? codebuddyProjectsDir()
+        : (options.claudeProjectsDir ?? claudeProjectsDir())
+    return resolveClaudeSessionFile(trimmedId, projectsDir, signal)
   }
   if (transcriptAgent === 'codex') {
     const overrideDirs = options.codexSessionsDirs

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Terminal } from '@xterm/xterm'
-import { LigaturesAddon } from '@xterm/addon-ligatures'
 import { Moon, Sun } from 'lucide-react'
 import '@xterm/xterm/css/xterm.css'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { buildDefaultTerminalOptions } from '@/lib/pane-manager/pane-terminal-options'
 import { buildFontFamily } from '@/components/terminal-pane/layout-serialization'
+import { LigaturesAddon } from '@/lib/pane-manager/terminal-ligatures-package-shim'
 import { composeActiveTerminalTheme } from '@/components/terminal-pane/terminal-appearance'
 import { clampNumber, resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
 import { resolveTerminalMinimumContrastRatio } from '@/lib/terminal-contrast-correction'
@@ -14,8 +14,8 @@ import { resolveTerminalLigaturesEnabled } from '../../../../shared/terminal-lig
 import { normalizeTerminalLineHeight } from '../../../../shared/terminal-line-height-settings'
 import { PREVIEW_BUFFER } from './terminal-preview-content'
 import { SettingsSwitch } from './SettingsFormControls'
-import type { GlobalSettings } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
+import type { GlobalSettings } from '../../../../shared/types'
 
 // Why: pinned so PREVIEW_BUFFER never wraps; 36 cols fits the 32-char longest line + margin (larger fonts clip, not wrap).
 const PREVIEW_COLS = 36

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -57,6 +57,19 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
     homepageUrl: 'https://code.claude.com/docs/agent-teams'
   },
   {
+    id: 'ccb',
+    label: translate('auto.lib.agent.catalog.ccb', 'Claude Code Best'),
+    cmd: 'ccb',
+    homepageUrl: 'https://github.com/claude-code-best/claude-code'
+  },
+  {
+    id: 'codebuddy',
+    label: translate('auto.lib.agent.catalog.codebuddy', 'CodeBuddy'),
+    cmd: 'codebuddy',
+    faviconDomain: 'codebuddy.ai',
+    homepageUrl: 'https://www.codebuddy.ai/cli'
+  },
+  {
     id: 'openclaude',
     label: translate('auto.lib.agent.catalog.a5fc0cb622', 'OpenClaude'),
     cmd: 'openclaude',

--- a/src/renderer/src/lib/agent-status.ts
+++ b/src/renderer/src/lib/agent-status.ts
@@ -99,6 +99,8 @@ const ICONABLE_AGENT_TYPES: Record<TuiAgent, true> = {
   claude: true,
   'claude-agent-teams': true,
   openclaude: true,
+  ccb: true,
+  codebuddy: true,
   codex: true,
   autohand: true,
   opencode: true,

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -1,6 +1,5 @@
 import type { IDisposable, IMarker, Terminal, ITerminalOptions } from '@xterm/xterm'
 import type { FitAddon } from '@xterm/addon-fit'
-import type { LigaturesAddon } from '@xterm/addon-ligatures'
 import type { SearchAddon } from '@xterm/addon-search'
 import type { Unicode11Addon } from '@xterm/addon-unicode11'
 import type { WebLinksAddon } from '@xterm/addon-web-links'
@@ -9,6 +8,7 @@ import type { SerializeAddon } from '@xterm/addon-serialize'
 import type { GlobalSettings } from '../../../../shared/types'
 import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
 import type { TerminalWebglAutoDecision } from './terminal-webgl-auto-policy'
+import type { LigaturesAddon } from './terminal-ligatures-package-shim'
 
 // ---------------------------------------------------------------------------
 // Public interfaces

--- a/src/renderer/src/lib/pane-manager/terminal-ligatures-addon.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ligatures-addon.ts
@@ -1,6 +1,4 @@
-// Upstream packaging bug: @xterm/addon-ligatures declares a missing module
-// entry. config/patches/@xterm__addon-ligatures* keeps the runtime import valid.
-import { LigaturesAddon } from '@xterm/addon-ligatures'
+import { LigaturesAddon } from './terminal-ligatures-package-shim'
 import type { Terminal } from '@xterm/xterm'
 
 type LigatureRange = [number, number]

--- a/src/renderer/src/lib/pane-manager/terminal-ligatures-package-shim.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ligatures-package-shim.ts
@@ -1,0 +1,122 @@
+import type { ITerminalAddon, Terminal } from '@xterm/xterm'
+
+type LigatureRange = [number, number]
+
+export type TerminalLigatureOptions = {
+  fallbackLigatures: string[]
+  fontFeatureSettings: string
+}
+
+const DEFAULT_FALLBACK_LIGATURES = [
+  '<--',
+  '<---',
+  '<<-',
+  '<-',
+  '->',
+  '->>',
+  '-->',
+  '--->',
+  '<==',
+  '<===',
+  '<<=',
+  '<=',
+  '=>',
+  '=>>',
+  '==>',
+  '===>',
+  '>=',
+  '>>=',
+  '<->',
+  '<-->',
+  '<--->',
+  '<---->',
+  '<=>',
+  '<==>',
+  '<===>',
+  '<====>',
+  '::',
+  ':::',
+  '<~~',
+  '</',
+  '</>',
+  '/>',
+  '~~>',
+  '==',
+  '!=',
+  '/=',
+  '~=',
+  '<>',
+  '===',
+  '!==',
+  '!===',
+  '<:',
+  ':=',
+  '*=',
+  '*+',
+  '<*',
+  '<*>',
+  '*>',
+  '<|',
+  '<|>',
+  '|>',
+  '+*',
+  '=*',
+  '=:',
+  ':>',
+  '/*',
+  '*/',
+  '+++',
+  '<!--',
+  '<!---'
+].sort((left, right) => right.length - left.length)
+
+function resolveLigatureRanges(
+  text: string,
+  fallbackLigatures: readonly string[]
+): LigatureRange[] {
+  const ranges: LigatureRange[] = []
+  for (let index = 0; index < text.length; index++) {
+    const match = fallbackLigatures.find((ligature) => text.startsWith(ligature, index))
+    if (!match) {
+      continue
+    }
+    ranges.push([index, index + match.length])
+    index += match.length - 1
+  }
+  return ranges
+}
+
+export class LigaturesAddon implements ITerminalAddon {
+  private readonly fallbackLigatures: readonly string[]
+  private readonly fontFeatureSettings?: string
+  private terminal: Terminal | undefined
+  private characterJoinerId: number | undefined
+
+  constructor(options?: Partial<TerminalLigatureOptions>) {
+    this.fallbackLigatures = options?.fallbackLigatures ?? DEFAULT_FALLBACK_LIGATURES
+    this.fontFeatureSettings = options?.fontFeatureSettings
+  }
+
+  activate(terminal: Terminal): void {
+    if (!terminal.element) {
+      throw new Error('Cannot activate LigaturesAddon before open is called')
+    }
+
+    this.terminal = terminal
+    this.characterJoinerId = terminal.registerCharacterJoiner((text) =>
+      resolveLigatureRanges(text, this.fallbackLigatures)
+    )
+    terminal.element.style.fontFeatureSettings = this.fontFeatureSettings ?? '"calt" on, "liga" on'
+  }
+
+  dispose(): void {
+    if (this.terminal && this.characterJoinerId !== undefined) {
+      this.terminal.deregisterCharacterJoiner(this.characterJoinerId)
+      this.characterJoinerId = undefined
+    }
+    if (this.terminal?.element) {
+      this.terminal.element.style.fontFeatureSettings = ''
+    }
+    this.terminal = undefined
+  }
+}

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2414,6 +2414,8 @@ function isNewTurnEvent(source: AgentHookSource, eventName: unknown): boolean {
       // Why: SessionStart lands an idle row (STA-3386) and must also drop stale
       // tool/prompt caches left by the pane's previous session.
       return eventName === 'SessionStart' || eventName === 'UserPromptSubmit'
+    case 'codebuddy':
+      return eventName === 'UserPromptSubmit'
     case 'kimi':
       // Why: Kimi Code emits Claude-compatible hook events, so UserPromptSubmit is its new-turn boundary too.
       return eventName === 'UserPromptSubmit'
@@ -2508,6 +2510,7 @@ function extractToolFields(
   // Why: exhaustive switch so a new AgentHookSource fails typecheck here instead of silently routing through OpenCode's extractor.
   switch (source) {
     case 'claude':
+    case 'codebuddy':
     // Why: Kimi Code uses Claude's tool_name/tool_input payload fields verbatim.
     // falls through
     case 'kimi':
@@ -4239,6 +4242,7 @@ export function normalizeHookPayload(
   let payload: ParsedAgentStatusPayload | null
   switch (source) {
     case 'claude':
+    case 'codebuddy':
       payload = normalizeClaudeEvent(state, eventName, promptText, paneKey, hookPayloadRecord)
       break
     case 'codex':
@@ -4417,6 +4421,7 @@ export function normalizeHookPayload(
 
 export const HOOK_SOURCE_BY_PATHNAME: Readonly<Record<string, AgentHookSource>> = Object.freeze({
   '/hook/claude': 'claude',
+  '/hook/codebuddy': 'codebuddy',
   '/hook/codex': 'codex',
   '/hook/gemini': 'gemini',
   '/hook/antigravity': 'antigravity',

--- a/src/shared/agent-hook-relay.ts
+++ b/src/shared/agent-hook-relay.ts
@@ -36,6 +36,7 @@ import type { AgentHookTarget } from './agent-hook-types'
 // that consumes it from the relay side).
 const AGENT_HOOK_SOURCES = [
   'claude',
+  'codebuddy',
   'codex',
   'gemini',
   'antigravity',

--- a/src/shared/agent-hook-types.ts
+++ b/src/shared/agent-hook-types.ts
@@ -6,6 +6,7 @@
 export const AGENT_HOOK_TARGETS = [
   'claude',
   'openclaude',
+  'codebuddy',
   'codex',
   'gemini',
   'antigravity',

--- a/src/shared/agent-kind.ts
+++ b/src/shared/agent-kind.ts
@@ -49,7 +49,9 @@ const TUI_AGENT_KIND_BY_AGENT = {
   grok: 'grok',
   devin: 'devin',
   ante: 'ante',
-  trae: 'trae'
+  trae: 'trae',
+  ccb: 'claude-code-best',
+  codebuddy: 'codebuddy'
 } satisfies Record<TuiAgent, ConcreteAgentKind>
 
 // Why: `satisfies Record<TuiAgent, …>` makes the lookup exhaustive at compile

--- a/src/shared/agent-session-resume.test.ts
+++ b/src/shared/agent-session-resume.test.ts
@@ -20,6 +20,10 @@ describe('agent session resume metadata', () => {
     expect(isResumableTuiAgent('prime-agent')).toBe(true)
   })
 
+  it('treats ccb as a resumable TUI agent', () => {
+    expect(isResumableTuiAgent('ccb')).toBe(true)
+  })
+
   it.each([
     ['claude', { session_id: 'claude-session' }, { key: 'session_id', id: 'claude-session' }],
     ['codex', { session_id: 'codex-session' }, { key: 'session_id', id: 'codex-session' }],

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -4,6 +4,8 @@ import type { TuiAgent } from './types'
 
 export const RESUMABLE_TUI_AGENTS = [
   'claude',
+  'codebuddy',
+  'ccb',
   'codex',
   'gemini',
   'antigravity',
@@ -188,7 +190,8 @@ export function extractAgentProviderSession(
     // since recent Claude Code names the transcript file with a UUID that differs
     // from the hook session_id (so the id-based glob no longer finds it).
     case 'claude':
-    case 'codex': {
+    case 'codex':
+    case 'codebuddy': {
       const id = readSessionId(payload, ['session_id'])
       return id ? withTranscriptPath({ key: 'session_id', id }, payload) : null
     }
@@ -248,6 +251,10 @@ export function getAgentResumeArgv(
   switch (agent) {
     case 'claude':
       return providerSession.key === 'session_id' ? ['claude', '--resume', id] : null
+    case 'codebuddy':
+      return providerSession.key === 'session_id' ? ['codebuddy', '--resume', id] : null
+    case 'ccb':
+      return providerSession.key === 'session_id' ? ['ccb', '--resume', id] : null
     case 'codex':
       return providerSession.key === 'session_id' ? ['codex', 'resume', id] : null
     case 'gemini':

--- a/src/shared/agent-type-label.ts
+++ b/src/shared/agent-type-label.ts
@@ -5,6 +5,8 @@ import type { AgentType } from './agent-status-types'
 const WELL_KNOWN_LABELS: Record<string, string> = {
   claude: 'Claude',
   openclaude: 'OpenClaude',
+  ccb: 'Claude Code Best',
+  codebuddy: 'CodeBuddy',
   codex: 'Codex',
   gemini: 'Gemini',
   antigravity: 'Antigravity',

--- a/src/shared/ai-vault-resume-command.ts
+++ b/src/shared/ai-vault-resume-command.ts
@@ -171,6 +171,7 @@ function buildAgentResumeInvocation(
     case 'devin':
     case 'openclaw':
     case 'droid':
+    case 'codebuddy':
     // Why: OMP and Prime Agent resume by absolute transcript path (see
     // buildAiVaultResumeCommand), but the `--resume <arg>` invocation form is
     // identical to the others here.

--- a/src/shared/ai-vault-types.ts
+++ b/src/shared/ai-vault-types.ts
@@ -1,6 +1,10 @@
 import type { TuiAgent } from './types'
 import type { ExecutionHostId, ExecutionHostScope } from './execution-host'
 
+// Why: `ccb` (Claude Code Best) is intentionally omitted. It reuses Claude Code's
+// `~/.claude/projects` (shared `CLAUDE_CONFIG_DIR`), so its transcripts are already
+// scanned and labeled `claude`. Listing `ccb` here would duplicate every session
+// under a second identity with no new files to discover.
 export const AI_VAULT_AGENTS = [
   'claude',
   'codex',
@@ -18,7 +22,8 @@ export const AI_VAULT_AGENTS = [
   'openclaw',
   'devin',
   'droid',
-  'kimi'
+  'kimi',
+  'codebuddy'
 ] as const satisfies readonly TuiAgent[]
 
 // Why: the aiVault.listSessions RPC schema CLAMPS scopePaths to this bound
@@ -59,7 +64,8 @@ export const AI_VAULT_AGENT_LABELS = {
   openclaw: 'OpenClaw',
   devin: 'Devin',
   droid: 'Droid',
-  kimi: 'Kimi'
+  kimi: 'Kimi',
+  codebuddy: 'CodeBuddy'
 } as const satisfies Record<AiVaultAgent, string>
 
 export type AiVaultSessionPreviewMessage = {

--- a/src/shared/native-chat-agent-support.test.ts
+++ b/src/shared/native-chat-agent-support.test.ts
@@ -27,6 +27,8 @@ describe('isNativeChatSupportedAgent', () => {
     expect(isNativeChatSupportedAgent('claude')).toBe(true)
     expect(isNativeChatSupportedAgent('openclaude')).toBe(true)
     expect(isNativeChatSupportedAgent('omp')).toBe(true)
+    expect(isNativeChatSupportedAgent('codebuddy')).toBe(true)
+    expect(isNativeChatSupportedAgent('ccb')).toBe(true)
     expect(isNativeChatSupportedAgent('cursor')).toBe(false)
     expect(isNativeChatSupportedAgent(null)).toBe(false)
     expect(isNativeChatSupportedAgent(undefined)).toBe(false)

--- a/src/shared/native-chat-agent-support.ts
+++ b/src/shared/native-chat-agent-support.ts
@@ -6,7 +6,9 @@ export const NATIVE_CHAT_SUPPORTED_AGENTS: ReadonlySet<string> = new Set([
   'openclaude',
   'codex',
   'grok',
-  'omp'
+  'omp',
+  'codebuddy',
+  'ccb'
 ])
 
 export function isNativeChatSupportedAgent(agent: string | null | undefined): boolean {
@@ -37,7 +39,7 @@ export function resolveNativeChatTranscriptAgent(
 ): NativeChatTranscriptAgent | null {
   // Why: OpenClaude writes the Claude transcript format and layout even though
   // Orca preserves its distinct agent identity for launch and UI behavior.
-  if (agent === 'claude' || agent === 'openclaude') {
+  if (agent === 'claude' || agent === 'openclaude' || agent === 'codebuddy' || agent === 'ccb') {
     return 'claude'
   }
   if (agent === 'codex' || agent === 'grok' || agent === 'omp') {

--- a/src/shared/skills-cli-agent-keys.ts
+++ b/src/shared/skills-cli-agent-keys.ts
@@ -33,6 +33,9 @@ export const SKILLS_CLI_AGENT_KEY_BY_TUI_AGENT = {
   crush: 'crush',
   aug: 'augment',
   cline: 'cline',
+  ccb: null,
+  // Why: not certain of a community `skills` CLI key; drop rather than guess.
+  codebuddy: null,
   codebuff: null,
   'command-code': 'command-code',
   continue: 'continue',

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -104,6 +104,8 @@ export const AGENT_KIND_VALUES = [
   'devin',
   'ante',
   'trae',
+  'claude-code-best',
+  'codebuddy',
   'other'
 ] as const
 export const agentKindSchema = z.enum(AGENT_KIND_VALUES)

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -55,6 +55,30 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     // Why: `claude --prefill <text>` seeds the input without submitting, avoiding the paste-after-ready race (PR https://github.com/stablyai/orca/pull/926).
     draftPromptFlag: '--prefill'
   },
+  ccb: {
+    detectCmd: 'ccb',
+    // Why: `npm i -g claude-code-best` also installs `ccb-bun` (Bun runtime
+    // entrypoint). Both launch the same interactive REPL, so treat the Bun
+    // binary as an alias for PATH detection.
+    detectCmdAliases: ['ccb-bun'],
+    launchCmd: 'ccb',
+    expectedProcess: 'ccb',
+    // Why: CCB is a Claude Code-compatible CLI, so it accepts a positional
+    // argv prompt and the same `--prefill <text>` flag Claude Code documents.
+    promptInjectionMode: 'argv',
+    draftPromptFlag: '--prefill'
+  },
+  codebuddy: {
+    detectCmd: 'codebuddy',
+    launchCmd: 'codebuddy',
+    expectedProcess: 'codebuddy',
+    // Why: `codebuddy "<prompt>"` starts the interactive REPL with the prompt
+    // as the initial turn (docs.codebuddy.ai/cli/cli-reference), so argv is the
+    // right injection mode. No `draftPromptFlag`: CodeBuddy Code exposes no
+    // `--prefill`-style flag, so the draft-launch flow must fall through to the
+    // paste-after-ready path.
+    promptInjectionMode: 'argv'
+  },
   'claude-agent-teams': {
     // Why: an Orca-provided launch mode, not a separate binary; detection follows the Orca CLI.
     detectCmd: 'orca',

--- a/src/shared/tui-agent-display-names.ts
+++ b/src/shared/tui-agent-display-names.ts
@@ -8,6 +8,8 @@ import type { TuiAgent } from './types'
 export const TUI_AGENT_DISPLAY_NAMES: Record<TuiAgent, string> = {
   claude: 'Claude',
   'claude-agent-teams': 'Claude Agent Teams',
+  ccb: 'Claude Code Best',
+  codebuddy: 'CodeBuddy',
   openclaude: 'OpenClaude',
   codex: 'Codex',
   devin: 'Devin',

--- a/src/shared/tui-agent-permissions.ts
+++ b/src/shared/tui-agent-permissions.ts
@@ -7,6 +7,8 @@ export const YOLO_TUI_AGENT_ARGS: Partial<Record<TuiAgent, string>> = {
   claude: '--dangerously-skip-permissions',
   'claude-agent-teams': '--dangerously-skip-permissions',
   openclaude: '--dangerously-skip-permissions',
+  ccb: '--dangerously-skip-permissions',
+  codebuddy: '--dangerously-skip-permissions',
   codex: '--dangerously-bypass-approvals-and-sandbox',
   gemini: '--yolo',
   antigravity: '--dangerously-skip-permissions',

--- a/src/shared/tui-agent-selection.ts
+++ b/src/shared/tui-agent-selection.ts
@@ -6,6 +6,8 @@ import { isTuiAgent } from './tui-agent-config'
 export const TUI_AGENT_AUTO_PICK_ORDER = [
   'claude',
   'claude-agent-teams',
+  'ccb',
+  'codebuddy',
   'openclaude',
   'codex',
   'grok',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2635,6 +2635,8 @@ export type ClaudeManagedAccountRuntimeSelection = {
 export type TuiAgent =
   | 'claude' // Claude Code
   | 'claude-agent-teams' // Claude Code Agent Teams via Orca native panes
+  | 'ccb' // Claude Code Best (claude-code-best/claude-code) — a Claude Code-compatible CLI
+  | 'codebuddy' // CodeBuddy CLI (@tencent-ai/codebuddy-code) — a Claude Code-compatible CLI
   | 'openclaude' // OpenClaude
   | 'codex' // OpenAI Codex
   | 'autohand' // Autohand Code CLI


### PR DESCRIPTION
Treat ccb (Claude Code rebrand) and codebuddy as first-class agents: native-chat, resume, hooks, and AI Vault scanning.

- ccb: https://github.com/claude-code-best/claude-code
- codebuddy: https://cnb.cool/codebuddy/codebuddy-code

## ELI5

ccb and codebuddy are first-class CLI agents with native chat, resume, hooks, and AI Vault scanning. You can use those Claude-compatible tools inside Orca the same way as other supported agents.
