### PR TITLE
fix(workspace): remove 4px gap above workspace tab bar

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -714,8 +714,7 @@
 /* Why: workspace view still needs a full titlebar-height strip above the
    sidebar so the native macOS traffic lights and sidebar chrome sit in the
    same vertical band they use in settings/landing. The center and right
-   workspace columns are offset separately to align with this 36px baseline
-   (4px drag strip + 32px tab row). */
+   workspace columns use the same 36px tab-row baseline. */
 .titlebar-left {
   height: 36px;
   min-height: 36px;

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -238,7 +238,7 @@ export default function TabGroupPanel({
           this, the empty space after tabs in the center column is dead — the
           user can only drag from the tiny left-sidebar header strip. */}
       <div
-        className="h-[32px] shrink-0 border-b border-border bg-card"
+        className="h-[36px] shrink-0 border-b border-border bg-card"
         data-tab-group-strip-id={groupId}
         data-terminal-focus-release-surface="true"
         data-worktree-id={worktreeId}

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
@@ -78,10 +78,9 @@ describe('TabGroupSplitLayout', () => {
   }
 
   function getSplitNodeElement(element: ReturnType<typeof TabGroupSplitLayout>) {
-    const layoutWrapperChildren = React.Children.toArray(
+    const splitBody = React.Children.only(
       asElement(getLayoutWrapper(element)).props.children as React.ReactNode
     )
-    const splitBody = layoutWrapperChildren[1]
     const splitNodeElement = React.Children.only(
       asElement(splitBody).props.children as React.ReactNode
     )
@@ -142,6 +141,21 @@ describe('TabGroupSplitLayout', () => {
     })
 
     expect(asElement(getLayoutWrapper(element)).props.ref).toBe(setDragRootNodeMock)
+  })
+
+  it('renders the pane body flush to the top without a spacer', () => {
+    const element = TabGroupSplitLayout({
+      layout: { type: 'leaf', groupId: 'group-1' },
+      worktreeId: 'wt-1',
+      focusedGroupId: 'group-1',
+      isWorktreeActive: true
+    })
+
+    const layoutWrapper = asElement(getLayoutWrapper(element))
+    const children = React.Children.toArray(layoutWrapper.props.children as React.ReactNode)
+
+    expect(children).toHaveLength(1)
+    expect(asElement(children[0]).props.className).toContain('flex-1')
   })
 
   it('only reserves top-right header space for the floating explorer toggle', () => {

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -265,27 +265,15 @@ export default function TabGroupSplitLayout({
         // so disabling it is the simplest fix.
         autoScroll={false}
       >
-        {/* Why: the 10px drag strip sits ABOVE the split layout — lifted out of
-          each pane — so vertical split resize handles don't extend into the
-          window-drag region at the top. Only the split layout's own panes
-          own the resize handles, while this strip keeps the whole top of the
-          center column draggable regardless of how the splits are arranged.
-          Why 4px specifically: pairs with the 32px tab row below so the
-          total top-band is 36px, matching the sibling `titlebar-left` above
-          the sidebar. Keep this small — it's just enough drag surface above
-          the tabs without opening a visible gap between the window top and
-          the tab chrome. Without this, the tab row's bottom border falls short
-          of the sidebar header's and the seam between columns reads as off.
-          Why `border-l` on the wrapper: paint the single full-height divider
+        {/* Why: `border-l` on the wrapper paints the single full-height divider
           between the left sidebar and the terminal area, regardless of split
           state. The leftmost pane suppresses its own `border-l` via
           `touchesLeftEdge`, so the seam is always exactly 1px — previously
-          both painted and stacked into a 2px bar below the drag strip. */}
+          both painted and stacked into a 2px bar below the tab row. */}
         <div
           ref={dragSplit.setDragRootNode}
           className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden border-l border-border"
         >
-          <div className="h-[4px] shrink-0 bg-card" data-terminal-focus-release-surface="true" />
           <div className="flex flex-1 min-w-0 min-h-0 overflow-hidden">
             <SplitNode
               node={layout}

--- a/src/renderer/src/components/tab-group/tab-drop-zone.test.ts
+++ b/src/renderer/src/components/tab-group/tab-drop-zone.test.ts
@@ -1,5 +1,27 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { resolvePaneColumnEdgeZone, TAB_GROUP_TAB_STRIP_HEIGHT_PX } from './tab-drop-zone'
+
+describe('tab strip drop boundary', () => {
+  // Why: the constant is the *only* link between the rendered tab row and pane
+  // split hit-testing — every other test references it symbolically, so a
+  // desync between the two leaves drops resolving against a stale offset.
+  it('matches the tab row height rendered by TabGroupPanel', () => {
+    const panelSource = readFileSync(join(__dirname, 'TabGroupPanel.tsx'), 'utf8')
+
+    expect(panelSource).toContain(`h-[${TAB_GROUP_TAB_STRIP_HEIGHT_PX}px] shrink-0 border-b`)
+  })
+
+  // Why: the tab row alone now spans the full top band that `titlebar-left`
+  // sets beside it. A spacer creeping back above the panes would reopen the gap.
+  it('spans the full titlebar-left band so panes stay flush to the top', () => {
+    const mainCss = readFileSync(join(__dirname, '../../assets/main.css'), 'utf8')
+    const titlebarLeftHeight = /\.titlebar-left\s*{[^}]*height:\s*(\d+)px/s.exec(mainCss)?.[1]
+
+    expect(titlebarLeftHeight).toBe(String(TAB_GROUP_TAB_STRIP_HEIGHT_PX))
+  })
+})
 
 describe('resolvePaneColumnEdgeZone', () => {
   const panelRect = { left: 0, top: 0, width: 300, height: 200 }

--- a/src/renderer/src/components/tab-group/tab-drop-zone.ts
+++ b/src/renderer/src/components/tab-group/tab-drop-zone.ts
@@ -1,7 +1,7 @@
 import type { TabDropZone } from './useTabDragSplit'
 
-/** Matches TabGroupPanel tab row height (`h-[32px]`). */
-export const TAB_GROUP_TAB_STRIP_HEIGHT_PX = 32
+/** Matches TabGroupPanel tab row height (`h-[36px]`). */
+export const TAB_GROUP_TAB_STRIP_HEIGHT_PX = 36
 
 type PaneRect = { left: number; top: number; width: number; height: number }
 


### PR DESCRIPTION
## Summary

The center workspace column stacked a 4px drag strip above a 32px tab row to reach the 36px sidebar title-bar baseline, leaving a visible gap between the window top and the tabs.

The fix removes the separate spacer and expands the tab row to 36px directly. The tab-row bottom stays aligned with the sidebar title bar while tabs now reach the top edge.

Affects macOS, Linux, and Windows — the drag strip and tab row are rendered from shared components with no platform-specific code.

### Files changed
- `src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx` — removed the 4px drag strip
- `src/renderer/src/components/tab-group/TabGroupPanel.tsx` — tab row 32px → 36px
- `src/renderer/src/components/tab-group/tab-drop-zone.ts` — drag hit-test constant 32 → 36
- `src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts` — guards panes rendering flush to the top
- `src/renderer/src/components/tab-group/tab-drop-zone.test.ts` — pins the constant to the rendered height (added during maintainer review)
- `src/renderer/src/assets/main.css` — comment only, no token or value changed

## ELI5

The row of tabs at the top of your workspace used to sit 4 pixels too low, so there was a thin empty stripe between the top of the window and the tabs. We deleted that stripe and made the tab row itself 4 pixels taller, so the tabs now reach the top and still line up perfectly with the sidebar next to them. We also added a safety check so nobody can accidentally knock the tabs and the drag-and-drop targets out of alignment again.

## Proof of fix

The tab row's height is not just cosmetic — `TAB_GROUP_TAB_STRIP_HEIGHT_PX` is the boundary that pane-split hit-testing uses to decide whether a dragged tab lands in the tab strip (reorder) or the pane body (open a split), via `panelRect.top + TAB_GROUP_TAB_STRIP_HEIGHT_PX`.

**1. The layout fix — `TabGroupSplitLayout.test.ts` fails on `main`:**

```
$ git checkout origin/main -- src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
$ npx vitest run --config config/vitest.config.ts .../TabGroupSplitLayout.test.ts

 FAIL  TabGroupSplitLayout > records pane resizing at the start of the gesture
 Error: React.Children.only expected to receive a single React element child.
 ❯ getSplitNodeElement TabGroupSplitLayout.test.ts:81:38

 Test Files  1 failed (1)
      Tests  5 failed | 1 passed (6)
```

**2. The gap itself — new boundary test fails on pristine `main`:**

```
$ git checkout origin/main -- .../TabGroupPanel.tsx .../tab-drop-zone.ts
$ npx vitest run --config config/vitest.config.ts .../tab-drop-zone.test.ts

 × spans the full titlebar-left band so panes stay flush to the top
 AssertionError: expected '36' to be '32' // Object.is equality

      Tests  1 failed | 5 passed (6)
```

On `main` the constant and the CSS class agree (both 32), so the first assertion passes — but the 32px row does not span the 36px `.titlebar-left` band beside it. That 4px shortfall **is** the reported gap, now pinned as a deterministic assertion.

**3. Both pass with the fix:**

```
$ npx vitest run --config config/vitest.config.ts src/renderer/src/components/tab-group/
 Test Files  11 passed (11)
      Tests  73 passed (73)
```

### Defect found and fixed during review

The drop-zone constant was updated correctly, but **nothing tied it to the rendered height**. Every existing test referenced `TAB_GROUP_TAB_STRIP_HEIGHT_PX` symbolically, so it validated against itself. Reverting the constant to `32` while leaving the row at `h-[36px]` — a desync that would make every tab drag in the top 4px of a pane body resolve as a tab-strip hover instead of a split target — still passed the entire suite:

```
$ sed -i 's/TAB_GROUP_TAB_STRIP_HEIGHT_PX = 36/... = 32/' tab-drop-zone.ts
$ npx vitest run --config config/vitest.config.ts src/renderer/src/components/tab-group/
 Test Files  11 passed (11)
      Tests  71 passed (71)     # <-- desync completely undetected
```

`tab-drop-zone.test.ts` now asserts the constant against the literal `h-[36px]` class in `TabGroupPanel.tsx` and against the `.titlebar-left` height in `main.css`, following the repo's existing `readFileSync` source-boundary test pattern. Both new assertions fail under the desync shown above.

## Proof of no regressions

```
$ npx vitest run --config config/vitest.config.ts src/renderer/src/components/tab-group/
 Test Files  11 passed (11)
      Tests  73 passed (73)

$ npx vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/
 Test Files  171 passed (171)
      Tests  2192 passed (2192)

$ npx tsc --noEmit -p config/tsconfig.tc.web.json
 (exit 0, no output)

$ npx oxlint <5 changed files>
 (clean)

$ node config/scripts/check-styled-scrollbars.mjs
 (clean)
```

`terminal-pane` is included because `terminal-pane-tab-detach.ts` resolves drops through the `[data-tab-group-strip-id]` element whose height this PR changes.

User-visible behavior that changes, beyond closing the gap:

- **The tab row is 4px taller (32px → 36px)** and the pane body starts 4px lower. Total top-band height is unchanged at 36px, so nothing below shifts.
- **The window-drag region is preserved.** The removed strip carried `data-terminal-focus-release-surface="true"` (which maps to `-webkit-app-region: drag` in `main.css`); the tab row it was merged into carries the same attribute, so drag-to-move and the terminal focus-release behavior are retained across the full 36px band.
- **Split resize handles still cannot reach the top band.** The removed strip's comment claimed it kept resize handles out of the drag region, but handles are rendered by `SplitNode` *inside* the pane body, below the tab row — never in the top band. The strip was not load-bearing for this.

No other behavior changes. `main.css` is a comment-only edit — no token, color, or size value was modified, so no other consumer of the stylesheet is affected.

## Compatibility

- **Platforms:** macOS / Linux / Windows — all four source files contain zero platform checks (`win32`, `darwin`, `metaKey`); the strip and tab row render identically from shared components, so one fix covers all three. The new test uses `join(__dirname, ...)` rather than hardcoded separators, so it passes on Windows. The `.titlebar-left` 36px baseline it asserts against is platform-independent. Verified on macOS via the test suite and typecheck; Linux/Windows verified by static reasoning over the absence of platform branches (not executed on those OSes).
- **SSH / remote:** N/A — pure renderer layout and pointer geometry, no main-process, filesystem, or transport code. Behaves identically for local, SSH, and folder workspaces.
- **Performance:** No hot-path change. One DOM node fewer per workspace column; the drop-zone change is a single constant in an existing arithmetic comparison, with no added allocation or work per drag event. The two new assertions read source files at test time only.

## Screenshots

No screenshot captured — this was verified through deterministic assertions rather than a rendered image, and I did not run the app to capture one. The 4px change is pinned by the `tab-drop-zone.test.ts` boundary test above, which fails on `main` and passes here.

## Testing

- [x] `npx oxlint <changed files>` (full `pnpm lint` not run)
- [x] `npx tsc --noEmit -p config/tsconfig.tc.web.json` (renderer typecheck, exit 0)
- [x] Targeted tests: `tab-group` (73 passed) + `terminal-pane` (2192 passed). Full `pnpm test` not run.
- [ ] `pnpm build` — not run
- [x] Added or updated high-quality tests that would catch regressions

`pnpm lint`, `pnpm test`, and `pnpm build` were not run in full; the targeted equivalents covering every changed file are reported above with real output. No pre-existing failures were observed in the suites that were run.

## AI Review Report

Reviewed adversarially for correctness, regressions, cross-platform behavior, and style.

- **Checked and cleared:** `main.css` is the canonical token source, so the diff was audited for shared-token edits — it is comment-only, no value changed, so no app-wide spacing impact. Every consumer of `TAB_GROUP_TAB_STRIP_HEIGHT_PX` was enumerated (`tab-group-panel-split-target.ts` at two call sites, plus three test files); all treat it as panel-relative (`panelRect.top + …`), so 32 → 36 is required for the hit-test to track the taller row. Verified the removed strip's window-drag role is preserved by the merged tab row, and that split resize handles never occupied the top band.
- **Checked and cleared:** the removed 4px was not load-bearing for a focus ring or drop shadow. The focused-pane cue is a *bottom* border (`border-b-accent`); the only `ring-2` in the panel is on a 28px button that gains clearance in a 36px row.
- **Flagged and fixed:** the drop-zone constant had no test coupling it to the rendered height — a silent desync passed all 71 tests. Added a source-boundary test; suite is now 73.
- **Cross-platform:** explicitly confirmed. No `win32`/`darwin` branches, no `metaKey` usage, no shortcut labels, and no path handling in the changed renderer files. The one new path operation uses `join(__dirname, ...)`. Electron-specific surface reviewed: `-webkit-app-region: drag` inheritance via `data-terminal-focus-release-surface`, and the `no-drag` spacer for the floating collapsed-sidebar header, which is unchanged and still punches its hole in the now-36px row.

## Security Audit

No security-relevant surface. The diff is renderer-side layout: two Tailwind height classes, one numeric UI constant, a removed `<div>`, a CSS comment, and tests. No input handling, command execution, path traversal, auth, secrets, IPC, or dependency changes. The added test reads two first-party repo files at test time with a constant path and does not execute their contents. No follow-up needed.

## Notes

- The 36px top band is now asserted in two places (`.titlebar-left` in `main.css` and the tab row class), so a future titlebar-height change will fail `tab-drop-zone.test.ts` with a clear message rather than silently reopening the gap or desyncing drop targets. This is intentional coupling — the two heights must move together.
- The e2e spec `tests/e2e/tab-sidebar-closed-overlap.spec.ts` measures the floating titlebar against tabs using live geometry (`getBoundingClientRect`) with no hardcoded 32/36 values, so it needs no update. It was not executed here (requires an Electron run).
- Residual risk is limited to visual polish at the 4px scale on non-macOS chrome, which I did not render.

Original patch by @iamshakibali.
