### PR TITLE
fix(tasks): scope issue list to the resolved repo instead of a global GitHub search

### DIFF
--- a/src/main/github/client-issue-source.test.ts
+++ b/src/main/github/client-issue-source.test.ts
@@ -206,6 +206,43 @@ describe('GitHub issue source split', () => {
     expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(2, prListArgs('fork/orca'), {})
   })
 
+  it('does not run a repo-less issue search when the issue source is unresolved (recent)', async () => {
+    // #9202: gh api search/issues ignores cwd, so a repo-less issue query returns
+    // issues from all of GitHub. When the issue source can't be resolved (e.g. the
+    // default remote is not named origin), the issue side must stay empty instead
+    // of leaking foreign issues stamped with this project.
+    resolveIssueSourceMock.mockResolvedValueOnce({ source: null, fellBack: false })
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'fork', repo: 'orca' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' })
+
+    const result = await listWorkItems('/repo-root', 10)
+
+    // Only the PR list runs; the issue side never spawns a search/issues call.
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    const ranIssueSearch = ghExecFileAsyncMock.mock.calls.some((call) =>
+      (call[0] as string[]).some((arg) => arg.startsWith('search/issues?'))
+    )
+    expect(ranIssueSearch).toBe(false)
+    expect(result.items).toEqual([])
+    expect(result.sources.issues).toBeNull()
+  })
+
+  it('does not run a repo-less issue search when the issue source is unresolved (queried)', async () => {
+    // #9202: same guard for the explicit-query path.
+    resolveIssueSourceMock.mockResolvedValueOnce({ source: null, fellBack: false })
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'fork', repo: 'orca' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' })
+
+    const result = await listWorkItems('/repo-root', 10, 'is:open')
+
+    const ranIssueSearch = ghExecFileAsyncMock.mock.calls.some((call) =>
+      (call[0] as string[]).some((arg) => arg.startsWith('search/issues?'))
+    )
+    expect(ranIssueSearch).toBe(false)
+    expect(result.items).toEqual([])
+    expect(result.sources.issues).toBeNull()
+  })
+
   it('uses upstream for issue-only queries and origin for PR-only queries', async () => {
     getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'fork', repo: 'orca' })

--- a/src/main/github/client-work-items.test.ts
+++ b/src/main/github/client-work-items.test.ts
@@ -114,12 +114,14 @@ describe('listWorkItems', () => {
     )
 
     await expect(listWorkItems('/no-remote-repo', 36)).rejects.toThrow('no git remotes found')
-    // The first refresh pays the two cwd-fallback spawns (issue + pr list).
-    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    // The first refresh pays a single cwd-fallback spawn (pr list). The issue
+    // side no longer spawns a repo-less search/issues, which gh api runs against
+    // all of GitHub because it ignores cwd (#9202).
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
 
     await expect(listWorkItems('/no-remote-repo', 36)).rejects.toThrow('no git remotes found')
     // The second refresh is served from the negative cache — zero new spawns.
-    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
   })
 
   it('runs both issue and PR GitHub searches for a mixed query and merges the results by recency', async () => {

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -1164,11 +1164,12 @@ async function listRecentWorkItems(
     // PR half — the UI renders partial results plus a banner for the failing
     // side, matching the parent design doc's partial-failure rule (§2).
     const [issuesSettled, prsSettled] = await Promise.allSettled([
+      // Why: gh api search/issues ignores cwd/--repo, so a repo-less issue query
+      // silently searches all of GitHub. Only run it with a resolved owner/repo;
+      // otherwise scope issues to empty rather than leaking foreign issues (#9202).
       issueOwnerRepo
         ? ghExecFileAsync(issueRequest.args, ghOptions)
-        : requiresExplicitRepo
-          ? Promise.resolve({ stdout: '[]' })
-          : ghCwdResolvedExec(repoContext, issueRequest.args, ghOptions),
+        : Promise.resolve({ stdout: '[]' }),
       prOwnerRepo
         ? ghExecFileAsync(prRequest.args, ghOptions)
         : requiresExplicitRepo
@@ -1225,17 +1226,14 @@ async function listRecentWorkItems(
     }
   }
 
-  // Why: the fallback path (non-GitHub remote — neither issueOwnerRepo nor
-  // prOwnerRepo resolved) intentionally stays on Promise.all rather than the
-  // Promise.allSettled + per-side classification used above. There are no
-  // `sources` to surface on this branch and nothing for the partial-failure
-  // banner to render, so a single-side failure here means the whole call is
-  // effectively unusable for the feature — reject-all matches reality. If
-  // non-GitHub remotes ever grow source metadata, revisit this symmetry.
-  const [issuesResult, prsResult] = await Promise.all([
-    ghCwdResolvedExec(repoContext, issueRequest.args, ghOptions),
-    ghCwdResolvedExec(repoContext, prRequest.args, ghOptions)
-  ])
+  // Why: the fallback path (neither issueOwnerRepo nor prOwnerRepo resolved)
+  // has no `sources` to surface and nothing for the partial-failure banner to
+  // render, so a PR-side failure means the whole call is effectively unusable
+  // for the feature — letting it reject matches reality. The issue side stays
+  // empty because gh api search/issues ignores cwd, so a repo-less query would
+  // silently search all of GitHub rather than this repo (#9202).
+  const issuesResult = { stdout: '[]' }
+  const prsResult = await ghCwdResolvedExec(repoContext, prRequest.args, ghOptions)
 
   const issues = (JSON.parse(issuesResult.stdout) as Record<string, unknown>[])
     .filter((item) => !('pull_request' in item))
@@ -1281,7 +1279,10 @@ async function listQueriedWorkItems(
     if (!issueScope) {
       return { items: [] }
     }
-    if (requiresExplicitRepo && !issueOwnerRepo) {
+    // Why: gh api search/issues ignores cwd/--repo, so without a resolved
+    // owner/repo the query silently searches all of GitHub. Return empty rather
+    // than leaking foreign issues (#9202). PRs below can still resolve via cwd.
+    if (!issueOwnerRepo) {
       return { items: [] }
     }
     const request = buildWorkItemListRequest({
@@ -1292,9 +1293,7 @@ async function listQueriedWorkItems(
       page: page ?? 1
     })
     try {
-      const { stdout } = issueOwnerRepo
-        ? await ghExecFileAsync(request.args, ghOptions)
-        : await ghCwdResolvedExec(repoContext, request.args, ghOptions)
+      const { stdout } = await ghExecFileAsync(request.args, ghOptions)
       const items = (JSON.parse(stdout) as Record<string, unknown>[])
         .filter((item) => !('pull_request' in item))
         .map(mapIssueWorkItem)


### PR DESCRIPTION
## Summary

The Tasks issue list could show issues from unrelated repositories. `gh api search/issues` **ignores `cwd` and `--repo`** — scoping only comes from a `repo:owner/name` qualifier inside the query string. So whenever the owner/repo could not be resolved, Orca fell back to running the issue query anyway via `ghCwdResolvedExec`, and that silently became a search across all of GitHub.

The fix makes the unresolved case return an empty issue list instead of an unscoped search. Pull requests are unaffected — `gh pr list` genuinely does honour `cwd`, so the PR half still resolves that way.

Closes #9202

## ELI5

Orca asks GitHub "show me the issues for this project". The command it used only limits results to your project if you explicitly name the project in the question — just running it from the project folder isn't enough, which is easy to assume and wrong. When Orca couldn't work out the project name it asked anyway, and GitHub answered with issues from *all of GitHub*, which then appeared in your list as if they were yours.

Now, if Orca can't work out which project you mean, it shows nothing for issues rather than showing strangers' issues.

## Proof of fix

This branch is 557 commits behind `main`, and `client.ts` on `main` imports a module that doesn't exist at this branch's base — so reverting the file against `origin/main` produces a module-resolution error, not a meaningful test result. The proof therefore uses the branch's own merge base (`ef03a50b1d`), which is the correct comparison.

**With `client.ts` restored from the merge base — 3 failures:**

```
$ git checkout $(git merge-base HEAD origin/main) -- src/main/github/client.ts
$ npx vitest run --config config/vitest.config.ts \
    src/main/github/client-issue-source.test.ts src/main/github/client-work-items.test.ts

 × stops re-spawning gh for a repo whose cwd resolution already failed with no remotes
 × does not run a repo-less issue search when the issue source is unresolved (recent)
 × does not run a repo-less issue search when the issue source is unresolved (queried)

      Tests  3 failed | 44 passed (47)
```

**With this PR:**

```
$ git checkout HEAD -- src/main/github/client.ts
$ npx vitest run --config config/vitest.config.ts src/main/github/

 Test Files  26 passed (26)
      Tests  382 passed (382)
```

Both entry points are covered — `listRecentWorkItems` (the "recent" case) and `listQueriedWorkItems` (the "queried" case). Fixing only one would leave the leak reachable through the other.

## Proof of no regressions

```
$ npx vitest run --config config/vitest.config.ts src/main/github/
 Test Files  26 passed (26)
      Tests  382 passed (382)

$ npx oxlint src/main/github/client.ts \
             src/main/github/client-issue-source.test.ts \
             src/main/github/client-work-items.test.ts
(no findings)
```

`npx tsc --noEmit -p config/tsconfig.node.json` reports 8 errors, **all pre-existing and unrelated to this PR** — they are in `src/main/ipc/worktree-common-git-directory.ts` and `src/main/skills/skill-installation-topology.ts`, neither of which this diff touches. They are an artifact of the branch being 557 commits behind; a rebase clears them.

**PRs are not returned as issues.** The `.filter((item) => !('pull_request' in item))` guard is retained on the parsed issue payload — worth stating explicitly, because GitHub models PRs as issues and an endpoint change here would otherwise start surfacing PRs in the issue list.

User-visible behavior that changes:

- When the owner/repo cannot be resolved, the issue list is now **empty** instead of populated with issues from unrelated repositories. That is the fix.
- Anyone who was relying on that unscoped search as a de-facto "all my GitHub issues" view loses it. That was never intentional behavior, and #9202 reports it as a bug.
- The PR half is unchanged in every case, including the non-GitHub-remote fallback path.

## Compatibility

- **Platforms:** macOS / Linux / Windows. No paths, shell quoting, key modifiers, or Electron APIs are touched — the change is control flow around which `gh` invocation runs.
- **SSH / remote:** N/A for transport, but relevant for resolution: on hosts where the remote can't be resolved to an `owner/repo`, the issue list is now deliberately empty rather than globally scoped. That is the intended safe degradation — the previous behavior wasn't "more results", it was wrong results.
- **Provider compatibility:** this file is the GitHub client specifically; GitLab, Gitea, and Bitbucket paths are untouched. Per `AGENTS.md` I checked that nothing GitHub-only leaked into shared naming or shared code.
- **Performance:** Strictly fewer `gh` invocations. The unresolved case now short-circuits to `{ stdout: '[]' }` instead of spawning a subprocess, and one test explicitly pins that Orca "stops re-spawning gh for a repo whose cwd resolution already failed". This reduces pressure on the `gh` API rate limit, which `AGENTS.md` calls out.

## Screenshots

No visual change to any component — the same list renders, with correctly scoped contents. The behavior is asserted in `client-issue-source.test.ts` and `client-work-items.test.ts` rather than captured as an image, since a screenshot of a correctly-scoped list is indistinguishable from an incorrectly-scoped one without knowing the underlying repo. I did not capture before/after images; noting that plainly rather than implying a check I didn't run.

## Testing

- [ ] `pnpm lint` — not run in full. Ran `npx oxlint` on all three changed files: no findings.
- [ ] `pnpm typecheck` — run, but **does not pass cleanly**: 8 pre-existing errors in files this PR does not touch (see Proof of no regressions). Not ticking a box I can't honestly claim.
- [ ] `pnpm test` — not run in full (30+ min). Ran the whole touched module: `src/main/github/` → 26 files, 382 tests passed.
- [ ] `pnpm build` — not run.
- [x] Added or updated high-quality tests that would catch regressions — three tests covering both entry points and the no-re-spawn behavior, all failing at the merge base.

## AI Review Report

Reviewed with Claude Code (Opus 5). Risks checked:

- **PRs leaking into the issue list.** GitHub's REST API models pull requests as issues, so any change to issue fetching risks surfacing PRs. Verified the `!('pull_request' in item)` filter is retained on the parsed payload.
- **Silent fallback re-introducing the bug.** The dangerous shape here is "couldn't resolve the repo, so run the query anyway" — which is exactly the original defect. Confirmed both `listRecentWorkItems` and `listQueriedWorkItems` now return empty rather than falling through to an unscoped `ghCwdResolvedExec`. Fixing one and not the other would have left the leak reachable.
- **Query-parameter preservation:** the change is control flow only — it does not rebuild the request, so `state`, sort, pagination, and `per_page` carry through `buildWorkItemListRequest` untouched.
- **Rate limits (`AGENTS.md`):** verified the change strictly reduces `gh` spawns rather than adding an N+1 pattern; a dedicated test pins that a failed cwd resolution does not re-spawn.
- **Partial-failure semantics:** the `Promise.allSettled` + per-side classification on the primary path is preserved, and the comment explaining why the fallback path deliberately differs was updated to match the new behavior rather than left stale.
- **Cross-platform (macOS / Linux / Windows):** no platform-dependent code, shell behavior, paths, or shortcut handling in this diff.

## Security Audit

- **Input handling:** no new parsing. The change removes a code path rather than adding one.
- **Command execution:** `gh` argument construction is unchanged; the diff only decides *whether* to invoke it. No user input reaches a shell.
- **Auth / secrets:** none touched. Worth noting the direction is a privacy improvement — the old behavior queried GitHub-wide and rendered issues from repositories the user hadn't asked about, which is exactly the leak #9202 reports.
- **Path handling:** none.
- **Dependencies:** none added or changed.
- **IPC:** untouched.

## Notes

- **Needs a rebase before merge.** The branch is 557 commits behind `main`, and `client.ts` has since gained an import (`./pr-refresh-error-classification`) that doesn't exist at this base. The logic change is small and should rebase cleanly, but it hasn't been validated against current `main` — only against its own merge base.
- The root cause is worth remembering beyond this PR: `gh api search/issues` ignores `cwd` and `--repo`, so scoping must be inside the query string. Any future code reaching for that endpoint needs the same care.

Original patch by @kaynansc.
