### PR TITLE
fix(grok): honor zero-usage weekly reset

### DIFF
--- a/src/main/rate-limits/grok-fetcher.test.ts
+++ b/src/main/rate-limits/grok-fetcher.test.ts
@@ -144,12 +144,17 @@ describe('fetchGrokRateLimits', () => {
     expect(result.monthly).toBeUndefined()
   })
 
-  it('maps monthly included usage for unified-billing accounts without a weekly period', async () => {
+  it('maps monthly included usage when a unified-billing response has an ambiguous weekly period', async () => {
     authState.file = freshAuthJson()
     netFetchMock
       .mockResolvedValueOnce(
         jsonResponse({
           config: {
+            currentPeriod: {
+              type: 'USAGE_PERIOD_TYPE_WEEKLY',
+              start: '2026-07-10T19:38:56.948570+00:00',
+              end: '2026-07-17T19:38:56.948570+00:00'
+            },
             isUnifiedBillingUser: true,
             subscriptionTier: 'SuperGrok'
           }
@@ -182,6 +187,7 @@ describe('fetchGrokRateLimits', () => {
         headers: expect.objectContaining({ Authorization: 'Bearer access-token' })
       })
     )
+    expect(netFetchMock).toHaveBeenCalledTimes(2)
   })
 
   // Why: 'unavailable' would make applyStalePolicy discard the last good

--- a/src/main/rate-limits/grok-fetcher.test.ts
+++ b/src/main/rate-limits/grok-fetcher.test.ts
@@ -100,6 +100,31 @@ describe('fetchGrokRateLimits', () => {
     )
   })
 
+  it('maps an omitted protobuf percentage as zero for a weekly credits period', async () => {
+    authState.file = freshAuthJson()
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        config: {
+          currentPeriod: {
+            type: 'USAGE_PERIOD_TYPE_WEEKLY',
+            start: '2026-07-17T19:38:56.948570+00:00',
+            end: '2026-07-24T19:38:56.948570+00:00'
+          },
+          billingPeriodStart: '2026-07-17T19:38:56.948570+00:00',
+          billingPeriodEnd: '2026-07-24T19:38:56.948570+00:00',
+          isUnifiedBillingUser: true
+        }
+      })
+    )
+
+    const result = await fetchGrokRateLimits()
+    expect(result.status).toBe('ok')
+    expect(result.weekly?.usedPercent).toBe(0)
+    expect(result.weekly?.resetsAt).toBe(Date.parse('2026-07-24T19:38:56.948570+00:00'))
+    expect(result.monthly).toBeUndefined()
+    expect(netFetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('returns unavailable when not signed in even if a token-less auth file exists', async () => {
     authState.file = JSON.stringify({})
     const result = await fetchGrokRateLimits()
@@ -119,17 +144,12 @@ describe('fetchGrokRateLimits', () => {
     expect(result.monthly).toBeUndefined()
   })
 
-  it('maps monthly included usage for unified-billing accounts without weekly credits', async () => {
+  it('maps monthly included usage for unified-billing accounts without a weekly period', async () => {
     authState.file = freshAuthJson()
     netFetchMock
       .mockResolvedValueOnce(
         jsonResponse({
           config: {
-            currentPeriod: {
-              type: 'USAGE_PERIOD_TYPE_WEEKLY',
-              start: '2026-07-10T19:38:56.948570+00:00',
-              end: '2026-07-17T19:38:56.948570+00:00'
-            },
             isUnifiedBillingUser: true,
             subscriptionTier: 'SuperGrok'
           }

--- a/src/main/rate-limits/grok-fetcher.ts
+++ b/src/main/rate-limits/grok-fetcher.ts
@@ -16,8 +16,8 @@ const GROK_CLI_PROXY_BASE =
   process.env.GROK_CLI_CHAT_PROXY_BASE_URL?.trim().replace(/\/$/, '') ||
   'https://cli-chat-proxy.grok.com/v1'
 const BILLING_CREDITS_URL = `${GROK_CLI_PROXY_BASE}/billing?format=credits`
-// Why: unified-billing accounts have no weekly credits; their included monthly
-// budget is only present in the default (format-less) billing view.
+// Why: some unified-billing accounts expose only a monthly included budget,
+// which is present in the default (format-less) billing view.
 const BILLING_DEFAULT_URL = `${GROK_CLI_PROXY_BASE}/billing`
 const API_TIMEOUT_MS = 10_000
 const WEEKLY_WINDOW_MINUTES = 10_080
@@ -81,12 +81,28 @@ function parseResetDescription(isoString: string | undefined): string | null {
     : date.toLocaleDateString(undefined, { weekday: 'short', hour: 'numeric', minute: '2-digit' })
 }
 
+function timestampsMatch(left: string | undefined, right: string | undefined): boolean {
+  const leftTimestamp = left ? Date.parse(left) : Number.NaN
+  const rightTimestamp = right ? Date.parse(right) : Number.NaN
+  return Number.isFinite(leftTimestamp) && leftTimestamp === rightTimestamp
+}
+
+function hasConfirmedWeeklyPeriod(config: GrokBillingConfig): boolean {
+  const period = config.currentPeriod
+  // Why: monthly unified-billing responses can also carry a weekly currentPeriod;
+  // matching billing bounds identify Grok's omitted protobuf zero unambiguously.
+  return (
+    period?.type === 'USAGE_PERIOD_TYPE_WEEKLY' &&
+    timestampsMatch(period.start, config.billingPeriodStart) &&
+    timestampsMatch(period.end, config.billingPeriodEnd)
+  )
+}
+
 function mapWeeklyCredits(config: GrokBillingConfig): RateLimitWindow | null {
-  // Why: Grok's protobuf JSON omits zero-valued percentages; a declared weekly
-  // period without this field is 0% usage, not an absent weekly allowance.
   const usedPercent =
-    config.creditUsagePercent ??
-    (config.currentPeriod?.type === 'USAGE_PERIOD_TYPE_WEEKLY' ? 0 : null)
+    config.creditUsagePercent === undefined && hasConfirmedWeeklyPeriod(config)
+      ? 0
+      : config.creditUsagePercent
   if (typeof usedPercent !== 'number' || !Number.isFinite(usedPercent)) {
     return null
   }
@@ -261,9 +277,8 @@ export async function fetchGrokRateLimits(
     if (weekly) {
       return billingUsageResult({ weekly }, config, session)
     }
-    // Why: unified-billing accounts report a monthly included-usage budget
-    // instead of weekly credits; the credits view omits creditUsagePercent
-    // for them, so read the default billing view before giving up.
+    // Why: some unified-billing accounts expose only a monthly included budget;
+    // their credits view omits creditUsagePercent, so read the default view.
     const fallback = await fetchMonthlyUsageFallback(session, options.signal)
     if (fallback.kind === 'result') {
       return fallback.result

--- a/src/main/rate-limits/grok-fetcher.ts
+++ b/src/main/rate-limits/grok-fetcher.ts
@@ -82,7 +82,11 @@ function parseResetDescription(isoString: string | undefined): string | null {
 }
 
 function mapWeeklyCredits(config: GrokBillingConfig): RateLimitWindow | null {
-  const usedPercent = config.creditUsagePercent
+  // Why: Grok's protobuf JSON omits zero-valued percentages; a declared weekly
+  // period without this field is 0% usage, not an absent weekly allowance.
+  const usedPercent =
+    config.creditUsagePercent ??
+    (config.currentPeriod?.type === 'USAGE_PERIOD_TYPE_WEEKLY' ? 0 : null)
   if (typeof usedPercent !== 'number' || !Number.isFinite(usedPercent)) {
     return null
   }


### PR DESCRIPTION
## Summary

- Treat an omitted Grok `creditUsagePercent` as protobuf zero only when the declared weekly period is corroborated by matching billing-period bounds.
- Keep that confirmed weekly period and reset authoritative instead of falling back to the unrelated monthly billing boundary.
- Preserve monthly included-usage fallback for unified-billing responses that carry an ambiguous weekly-looking `currentPeriod` without matching billing bounds.
- Add regression coverage for both live response shapes and their network-request counts.

Fixes #9214

## Testing

- `pnpm vitest run src/main/rate-limits src/main/ipc/rate-limits.test.ts src/shared/rate-limit-types.test.ts` (315 tests)
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar/tooltip.test.ts` (41 tests)
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/settings/GrokAccountsSection.test.tsx src/renderer/src/components/status-bar/provider-segment-monthly-window.test.tsx` (5 tests)
- `pnpm run typecheck:node`
- Focused Oxlint, type-aware lint, and formatting checks
- Max-lines ratchet and reliability gates
- Electron dev validation against the real Grok account response: the visible menu showed **Weekly**, **0% used**, and **Resets in 6d 23h**, matching the July 24 weekly reset in backing state.

## Performance

- Confirmed zero-usage weekly responses make exactly one billing request.
- Ambiguous unified-billing responses make exactly two requests so monthly quota remains correct; tests assert both request budgets.

## Electron validation

![Orca dev instance showing Grok weekly usage and the corrected reset countdown](https://github.com/user-attachments/assets/a8c441ab-f420-4602-83dc-d6bbdd3248ea)
