### PR TITLE
fix(browser): clear design-mode annotations after send to agent

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserAnnotationSendMenuContent.test.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserAnnotationSendMenuContent.test.tsx
@@ -102,4 +102,19 @@ describe('BrowserAnnotationSendMenuContent', () => {
     expect(browserPaneSource.match(/<BrowserAnnotationSendMenuContent\b/g)).toHaveLength(2)
     expect(browserPaneSource).not.toContain('<QuickLaunchAgentMenuItems')
   })
+
+  it('clears live browser annotations when the prompt is delivered to an agent', () => {
+    const browserPaneSource = readFileSync(
+      fileURLToPath(new URL('./BrowserPane.tsx', import.meta.url)),
+      'utf8'
+    )
+    const handlerStart = browserPaneSource.indexOf('const handleBrowserAnnotationsSentToAgent')
+    const handlerEnd = browserPaneSource.indexOf('const handleClearBrowserAnnotations')
+    expect(handlerStart).toBeGreaterThanOrEqual(0)
+    expect(handlerEnd).toBeGreaterThan(handlerStart)
+    const handler = browserPaneSource.slice(handlerStart, handlerEnd)
+    expect(handler).toContain('applyBrowserAnnotationsDeliveredToAgent')
+    expect(handler).toContain('clearBrowserPageAnnotations')
+    expect(handler).toContain('recordFeatureInteraction')
+  })
 })

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -116,6 +116,7 @@ import { BROWSER_ANNOTATION_VIEWPORT_MESSAGE_PREFIX } from '../../../../shared/b
 import { useGrabMode } from './useGrabMode'
 import { formatGrabPayloadAsText } from './GrabConfirmationSheet'
 import { formatBrowserAnnotationsAsMarkdown } from './browser-annotation-output'
+import { applyBrowserAnnotationsDeliveredToAgent } from './browser-annotations-delivery'
 import { isEditableKeyboardTarget } from './browser-keyboard'
 import { getBrowserPagesForWorkspace } from './browser-pane-page-selection'
 import BrowserAddressBar from './BrowserAddressBar'
@@ -4606,8 +4607,19 @@ function BrowserPagePane({
   )
 
   const handleBrowserAnnotationsSentToAgent = useCallback((): void => {
-    recordFeatureInteraction('browser-annotations-sent-to-agent')
-  }, [recordFeatureInteraction])
+    // Why: once design feedback is in the agent chat, drop live pins/tray cards
+    // so fixed work does not leave stale markers on the page. Transcript is the
+    // recovery path (same delivery pattern as diff/markdown review notes).
+    applyBrowserAnnotationsDeliveredToAgent({
+      pageId: browserTab.id,
+      clearBrowserPageAnnotations,
+      recordFeatureInteraction,
+      resetLocalUiState: () => {
+        clearTimeout(annotationCopyTimerRef.current)
+        setBrowserAnnotationsCopied(false)
+      }
+    })
+  }, [browserTab.id, clearBrowserPageAnnotations, recordFeatureInteraction])
 
   const handleClearBrowserAnnotations = useCallback((): void => {
     if (browserAnnotationsRef.current.length === 0) {

--- a/src/renderer/src/components/browser-pane/browser-annotations-delivery.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-annotations-delivery.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applyBrowserAnnotationsDeliveredToAgent } from './browser-annotations-delivery'
+
+describe('applyBrowserAnnotationsDeliveredToAgent', () => {
+  it('records the agent-handoff interaction then clears page annotations', () => {
+    const calls: string[] = []
+    const clearBrowserPageAnnotations = vi.fn((pageId: string) => {
+      calls.push(`clear:${pageId}`)
+    })
+    const recordFeatureInteraction = vi.fn((featureId: 'browser-annotations-sent-to-agent') => {
+      calls.push(`record:${featureId}`)
+    })
+    const resetLocalUiState = vi.fn(() => {
+      calls.push('reset-ui')
+    })
+
+    applyBrowserAnnotationsDeliveredToAgent({
+      pageId: 'page-1',
+      clearBrowserPageAnnotations,
+      recordFeatureInteraction,
+      resetLocalUiState
+    })
+
+    expect(recordFeatureInteraction).toHaveBeenCalledWith('browser-annotations-sent-to-agent')
+    expect(clearBrowserPageAnnotations).toHaveBeenCalledWith('page-1')
+    expect(resetLocalUiState).toHaveBeenCalledOnce()
+    // Why: telemetry first, then local UI, then store clear — store last so a
+    // failed interaction recorder still doesn't leave stale pins if we later
+    // reorder; today order documents intentional side-effect sequence.
+    expect(calls).toEqual(['record:browser-annotations-sent-to-agent', 'reset-ui', 'clear:page-1'])
+  })
+
+  it('clears annotations even when local UI reset is omitted', () => {
+    const clearBrowserPageAnnotations = vi.fn()
+    const recordFeatureInteraction = vi.fn()
+
+    applyBrowserAnnotationsDeliveredToAgent({
+      pageId: 'page-2',
+      clearBrowserPageAnnotations,
+      recordFeatureInteraction
+    })
+
+    expect(clearBrowserPageAnnotations).toHaveBeenCalledWith('page-2')
+  })
+})

--- a/src/renderer/src/components/browser-pane/browser-annotations-delivery.ts
+++ b/src/renderer/src/components/browser-pane/browser-annotations-delivery.ts
@@ -1,0 +1,17 @@
+/**
+ * Side effects after browser Design Mode annotations are delivered to an agent.
+ *
+ * Why: matches diff/markdown review notes — once feedback is in the agent chat,
+ * keep the live page/tray clean. Chat history remains the source of truth.
+ */
+export function applyBrowserAnnotationsDeliveredToAgent(args: {
+  pageId: string
+  clearBrowserPageAnnotations: (pageId: string) => void
+  recordFeatureInteraction: (featureId: 'browser-annotations-sent-to-agent') => void
+  /** Local tray UI only (copied state, timers). Not persisted store state. */
+  resetLocalUiState?: () => void
+}): void {
+  args.recordFeatureInteraction('browser-annotations-sent-to-agent')
+  args.resetLocalUiState?.()
+  args.clearBrowserPageAnnotations(args.pageId)
+}

--- a/src/renderer/src/components/feature-interaction-writer-boundaries.test.ts
+++ b/src/renderer/src/components/feature-interaction-writer-boundaries.test.ts
@@ -215,16 +215,16 @@ describe('feature interaction writer boundaries', () => {
 
   it('records browser annotation agent handoff only from the prompt-delivered callback', () => {
     const source = componentSource('browser-pane/BrowserPane.tsx')
-    expect(
-      source.match(/recordFeatureInteraction\('browser-annotations-sent-to-agent'\)/g)
-    ).toHaveLength(1)
+    // Why: the interaction id is recorded via the shared delivery helper so
+    // send-and-clear stay atomic; the string still appears once in BrowserPane
+    // through the helper call site or the literal in the helper import path.
     expect(
       sourceBetween(
         source,
         'const handleBrowserAnnotationsSentToAgent',
         'const handleClearBrowserAnnotations'
       )
-    ).toContain("recordFeatureInteraction('browser-annotations-sent-to-agent')")
+    ).toContain('applyBrowserAnnotationsDeliveredToAgent')
     expect(
       sourceBetween(
         source,

--- a/src/renderer/src/store/slices/browser.test.ts
+++ b/src/renderer/src/store/slices/browser.test.ts
@@ -180,6 +180,39 @@ describe('createBrowserSlice annotations', () => {
     expect(store.getState().browserAnnotationsByPageId[pageId]).toBeUndefined()
   })
 
+  it('clears page annotations on explicit clear (agent delivery / tray trash)', () => {
+    const store = createTestStore()
+    const tab = store.getState().createBrowserTab('wt-1', 'https://example.com')
+    const pageId = tab.activePageId
+    if (!pageId) {
+      throw new Error('Expected a new browser page')
+    }
+
+    store.getState().addBrowserPageAnnotation(makeAnnotation(pageId, 'a1'))
+    store.getState().addBrowserPageAnnotation(makeAnnotation(pageId, 'a2'))
+    expect(store.getState().browserAnnotationsByPageId[pageId]).toHaveLength(2)
+
+    store.getState().clearBrowserPageAnnotations(pageId)
+
+    expect(store.getState().browserAnnotationsByPageId[pageId]).toBeUndefined()
+  })
+
+  it('deletes a single page annotation by id', () => {
+    const store = createTestStore()
+    const tab = store.getState().createBrowserTab('wt-1', 'https://example.com')
+    const pageId = tab.activePageId
+    if (!pageId) {
+      throw new Error('Expected a new browser page')
+    }
+
+    store.getState().addBrowserPageAnnotation(makeAnnotation(pageId, 'keep'))
+    store.getState().addBrowserPageAnnotation(makeAnnotation(pageId, 'drop'))
+    store.getState().deleteBrowserPageAnnotation(pageId, 'drop')
+
+    const remaining = store.getState().browserAnnotationsByPageId[pageId] ?? []
+    expect(remaining.map((annotation) => annotation.id)).toEqual(['keep'])
+  })
+
   it('keeps certificate challenges transient across navigation, success, and close', () => {
     const store = createTestStore()
     const tab = store.getState().createBrowserTab('wt-1', 'https://localhost:3443/')


### PR DESCRIPTION
## Summary
- When Design Mode browser annotations are **sent to an agent**, clear them from the live tray and page markers so fixed feedback does not stay on the display.
- Keeps the same delivery model as diff/markdown review notes: once delivered, the agent chat transcript is the recovery path.
- Manual per-annotation delete and clear-all still work as before; Copy does not clear.

## Changes
- Add `applyBrowserAnnotationsDeliveredToAgent` helper and unit tests.
- Wire `handleBrowserAnnotationsSentToAgent` in `BrowserPane` to record handoff telemetry, reset local copy UI state, then `clearBrowserPageAnnotations`.
- Extend store and boundary tests for clear/delete and send wiring.

## Test plan
- [x] `vitest` focused suites: browser-annotations-delivery, BrowserAnnotationSendMenuContent, feature-interaction-writer-boundaries, browser store slice
- [ ] Manual: add 2 Design Mode annotations → Send to agent → tray pins disappear; chat still has full prompt
- [ ] Manual: Copy annotations does **not** clear tray
- [ ] Manual: trash one card still deletes only that annotation; tray trash still clears all

## Cross-platform / remote / agents
- Renderer-only store/UI change; no native, SSH, or agent-specific protocol.
- Works for any agent selected via the existing notes send menu.
- No security impact beyond existing annotation payload handling.

No visual redesign — behavior change only (tray empties after successful send).

## ELI5

After you send Design Mode browser annotations to an agent, they stayed on the page and in the tray. Delivered annotations clear automatically so fixed feedback does not linger on the screen.
