### PR TITLE
feat(terminal): add rich input composer (Warp-Like)

### DIFF
--- a/src/main/window/clipboard-image-data-url-ipc.test.ts
+++ b/src/main/window/clipboard-image-data-url-ipc.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { removeHandlerMock, handleMock, clipboardReadImageMock, nativeImageCreateFromBufferMock } =
+  vi.hoisted(() => ({
+    removeHandlerMock: vi.fn(),
+    handleMock: vi.fn(),
+    clipboardReadImageMock: vi.fn(),
+    nativeImageCreateFromBufferMock: vi.fn()
+  }))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/tmp')
+  },
+  clipboard: {
+    readText: vi.fn(),
+    readBuffer: vi.fn(),
+    writeText: vi.fn(),
+    readImage: clipboardReadImageMock,
+    writeImage: vi.fn(),
+    writeBuffer: vi.fn()
+  },
+  ipcMain: {
+    removeHandler: removeHandlerMock,
+    handle: handleMock
+  },
+  nativeImage: {
+    createFromBuffer: nativeImageCreateFromBufferMock
+  }
+}))
+
+vi.mock('./dashboard-popout-window', () => ({ isDashboardPopoutRenderer: () => false }))
+
+import { registerClipboardHandlers } from './clipboard-ipc-handlers'
+
+function getImageDataUrlHandler(): (...args: unknown[]) => unknown {
+  const call = (handleMock.mock.calls as [string, (...args: unknown[]) => unknown][]).find(
+    ([channel]) => channel === 'clipboard:readImageDataUrl'
+  )
+  if (!call) {
+    throw new Error('clipboard:readImageDataUrl was not registered')
+  }
+  return call[1]
+}
+
+function makeClipboardEvent(): { sender: Record<string, unknown> } {
+  return {
+    sender: {
+      id: 17,
+      getType: () => 'window',
+      getURL: () => 'file:///orca/index.html',
+      isDestroyed: () => false
+    }
+  }
+}
+
+describe('clipboard:readImageDataUrl', () => {
+  beforeEach(() => {
+    removeHandlerMock.mockReset()
+    handleMock.mockReset()
+    clipboardReadImageMock.mockReset()
+    nativeImageCreateFromBufferMock.mockReset()
+  })
+
+  it('returns a bounded PNG data URL for image attachment previews', () => {
+    const png = Buffer.from([0, 1, 2, 3])
+    clipboardReadImageMock.mockReturnValue({
+      getSize: () => ({ height: 1, width: 1 }),
+      isEmpty: () => false,
+      toPNG: () => png
+    })
+    registerClipboardHandlers({} as never)
+
+    expect(getImageDataUrlHandler()(makeClipboardEvent())).toBe(
+      `data:image/png;base64,${png.toString('base64')}`
+    )
+  })
+
+  it('bounds clipboard image previews before returning them to the renderer', () => {
+    const thumbnail = Buffer.from([4, 5, 6])
+    const resize = vi.fn(() => ({ toPNG: () => thumbnail }))
+    clipboardReadImageMock.mockReturnValue({
+      getSize: () => ({ height: 1000, width: 2000 }),
+      isEmpty: () => false,
+      resize,
+      toPNG: vi.fn()
+    })
+    registerClipboardHandlers({} as never)
+
+    expect(getImageDataUrlHandler()(makeClipboardEvent())).toBe(
+      `data:image/png;base64,${thumbnail.toString('base64')}`
+    )
+    expect(resize).toHaveBeenCalledWith({ height: 48, quality: 'good', width: 96 })
+  })
+})

--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -12,6 +12,7 @@ const {
   spawnMock,
   childStdinEndMock,
   resolveAuthorizedPathMock,
+  authorizeExternalPathMock,
   fsMkdirMock,
   fsReaddirMock,
   fsRmMock,
@@ -45,6 +46,7 @@ const {
     return child
   }),
   resolveAuthorizedPathMock: vi.fn(),
+  authorizeExternalPathMock: vi.fn(),
   fsMkdirMock: vi.fn(),
   fsReaddirMock: vi.fn(),
   fsRmMock: vi.fn(),
@@ -83,6 +85,7 @@ vi.mock('../ipc/filesystem-auth', () => ({
     'Access denied: path resolves outside allowed directories. If this blocks a legitimate workflow, please file a GitHub issue.',
   isENOENT: (error: unknown): boolean =>
     error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT',
+  authorizeExternalPath: authorizeExternalPathMock,
   resolveAuthorizedPath: resolveAuthorizedPathMock
 }))
 
@@ -543,6 +546,7 @@ describe('registerClipboardHandlers', () => {
 
     expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:readText')
     expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:readSelectionText')
+    expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:readImageDataUrl')
     expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:writeText')
     expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:writeSelectionText')
     expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:writeImage')
@@ -571,6 +575,7 @@ describe('registerClipboardHandlers', () => {
     expect(fsWriteFileMock).toHaveBeenCalledWith(expectedPath, png)
     expect(clipboardReadBufferMock).not.toHaveBeenCalled()
     expect(fsOpenMock).not.toHaveBeenCalled()
+    expect(authorizeExternalPathMock).toHaveBeenCalledWith(expectedPath)
     expect(getSshFilesystemProviderMock).not.toHaveBeenCalled()
   })
 

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -9,7 +9,12 @@ import {
 import { spawn } from 'node:child_process'
 import { open, stat } from 'node:fs/promises'
 import type { Store } from '../persistence'
-import { isENOENT, PATH_ACCESS_DENIED_MESSAGE, resolveAuthorizedPath } from '../ipc/filesystem-auth'
+import {
+  authorizeExternalPath,
+  isENOENT,
+  PATH_ACCESS_DENIED_MESSAGE,
+  resolveAuthorizedPath
+} from '../ipc/filesystem-auth'
 import {
   assertClipboardTextWriteWithinLimitWithYield,
   assertClipboardTextWithinLimitWithYield,
@@ -38,6 +43,8 @@ import { readWindowsClipboardImageFileAsPng } from './clipboard-windows-image-fi
 import { writeClipboardTextAndVerify } from './clipboard-text-write-verify'
 import { isDashboardPopoutRenderer } from './dashboard-popout-window'
 
+const CLIPBOARD_IMAGE_PREVIEW_MAX_DIMENSION = 96
+
 let trustedClipboardRendererWebContentsId: number | null = null
 
 type ClipboardWriteFileRequest = {
@@ -54,7 +61,13 @@ async function saveClipboardImageBufferForTarget(
   if (runtimeEnvironmentId && !args?.connectionId) {
     return saveClipboardImageBufferInRuntime(app.getPath('userData'), runtimeEnvironmentId, buffer)
   }
-  return saveClipboardImageBufferAsTempFile(buffer, args)
+  const tempPath = await saveClipboardImageBufferAsTempFile(buffer, args)
+  if (!args?.connectionId) {
+    // Why: Orca-created clipboard files are safe preview sources even though
+    // the OS temp directory sits outside normal workspace authorization.
+    authorizeExternalPath(tempPath)
+  }
+  return tempPath
 }
 
 export function setTrustedClipboardRendererWebContentsId(webContentsId: number | null): void {
@@ -77,6 +90,7 @@ function runCommand(command: string, args: string[], stdin?: string): Promise<vo
 export function registerClipboardHandlers(store: Store): void {
   ipcMain.removeHandler('clipboard:readText')
   ipcMain.removeHandler('clipboard:readSelectionText')
+  ipcMain.removeHandler('clipboard:readImageDataUrl')
   ipcMain.removeHandler('clipboard:writeText')
   ipcMain.removeHandler('clipboard:writeTerminalText')
   ipcMain.removeHandler('clipboard:writeSelectionText')
@@ -97,6 +111,34 @@ export function registerClipboardHandlers(store: Store): void {
       return assertClipboardTextWithinLimitWithYield(clipboard.readText('selection'), options)
     }
   )
+  ipcMain.handle('clipboard:readImageDataUrl', (event) => {
+    assertTrustedClipboardSender(event)
+    const image = clipboard.readImage()
+    if (image.isEmpty()) {
+      return null
+    }
+    const size = image.getSize()
+    assertClipboardImageDimensionsWithinLimit(size)
+    const scale = Math.min(
+      1,
+      CLIPBOARD_IMAGE_PREVIEW_MAX_DIMENSION / Math.max(size.width, size.height)
+    )
+    // Keep cached composer previews bounded; the full-resolution PNG is saved
+    // separately and remains the path submitted to the agent.
+    const preview =
+      scale < 1
+        ? image.resize({
+            width: Math.max(1, Math.round(size.width * scale)),
+            height: Math.max(1, Math.round(size.height * scale)),
+            quality: 'good'
+          })
+        : image
+    const png = preview.toPNG()
+    assertClipboardImageByteLengthWithinLimit(png.byteLength)
+    const contentBase64 = png.toString('base64')
+    assertClipboardImageBase64LengthWithinLimit(contentBase64.length)
+    return `data:image/png;base64,${contentBase64}`
+  })
   // Why: terminals need to detect clipboard images to support tools like Claude
   // Code that accept image input via paste. Writes the clipboard image to a
   // temp file and returns the path, or null if the clipboard has no image.

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -3218,6 +3218,7 @@ export type PreloadApi = {
     onSystemResumed: (callback: () => void) => () => void
     readClipboardText: (options?: ReadClipboardTextOptions) => Promise<string>
     readSelectionClipboardText: (options?: ReadClipboardTextOptions) => Promise<string>
+    readClipboardImageDataUrl: () => Promise<string | null>
     saveClipboardImageAsTempFile: (args?: {
       connectionId?: string | null
       runtimeEnvironmentId?: string | null

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3941,6 +3941,8 @@ const api = {
       ipcRenderer.invoke('clipboard:readText', options),
     readSelectionClipboardText: (options?: ReadClipboardTextOptions): Promise<string> =>
       ipcRenderer.invoke('clipboard:readSelectionText', options),
+    readClipboardImageDataUrl: (): Promise<string | null> =>
+      ipcRenderer.invoke('clipboard:readImageDataUrl'),
     saveClipboardImageAsTempFile: (args?: {
       connectionId?: string | null
       runtimeEnvironmentId?: string | null

--- a/src/renderer/src/assets/terminal.css
+++ b/src/renderer/src/assets/terminal.css
@@ -536,3 +536,79 @@
   color: #a1a1aa;
   background: rgba(24, 24, 27, 0.85);
 }
+
+/* Rich input is a real dock row rather than an overlay: xterm's observed
+   container shrinks, so its existing ResizeObserver refits instead of hiding
+   the last terminal lines behind the composer. */
+.pane[data-terminal-rich-input-mounted] {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+}
+
+.pane[data-terminal-rich-input-mounted] .xterm-container {
+  grid-row: 1;
+  min-height: 0;
+}
+
+.terminal-rich-input-dock {
+  position: relative;
+  z-index: 30;
+  display: grid;
+  grid-row: 2;
+  grid-template-rows: 0fr;
+}
+
+.terminal-rich-input-dock[data-layout-open] {
+  grid-template-rows: 1fr;
+}
+
+.terminal-rich-input-dock[data-layout-open] .terminal-rich-input-dock-content {
+  overflow: visible;
+}
+
+.terminal-rich-input-dock-content {
+  opacity: 0;
+  transform: translateY(4px);
+  transition:
+    opacity 140ms ease-out,
+    transform 140ms ease-out;
+}
+
+.terminal-rich-input-dock[data-visible] .terminal-rich-input-dock-content {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .terminal-rich-input-dock-content {
+    transition: none;
+  }
+}
+
+.pane-manager-root [data-terminal-rich-input-dock] {
+  border-color: var(--border);
+}
+
+.pane-manager-root [data-terminal-rich-input-card] {
+  border-color: var(--input);
+}
+
+.pane-manager-root [data-terminal-rich-input-card]:focus-within {
+  border-color: var(--ring);
+}
+
+.pane-manager-root [data-terminal-rich-input-menu],
+.pane-manager-root [data-terminal-rich-input-mention],
+.pane-manager-root [data-terminal-rich-input-attachment],
+.pane-manager-root [data-terminal-rich-input-send] {
+  border-color: var(--border);
+}
+
+.terminal-rich-input-editor {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.terminal-rich-input-editor .ProseMirror-selectednode [data-terminal-rich-input-mention] {
+  box-shadow: 0 0 0 1px var(--ring);
+}

--- a/src/renderer/src/components/native-chat/native-chat-image-paste.ts
+++ b/src/renderer/src/components/native-chat/native-chat-image-paste.ts
@@ -5,30 +5,10 @@
 // message instead of silently injecting a path that the model reads as text.
 
 import type { AgentType } from '../../../../shared/agent-status-types'
+import { getAgentImageHandling } from '../../../../shared/agent-image-handling'
 import { isImageDropPath } from '../terminal-pane/terminal-drop-image-path'
 
-/** How a given agent consumes a pasted image. `attachment` = bracket-paste the
- *  image path into the hosted TUI so it becomes an image chip; `unsupported` =
- *  no confirmed mechanism. */
-export type AgentImageHandling = 'attachment' | 'unsupported'
-
-const IMAGE_ATTACHMENT_AGENTS: ReadonlySet<AgentType> = new Set<AgentType>([
-  'claude',
-  'openclaude',
-  'codex',
-  'gemini',
-  'cursor',
-  'copilot',
-  'droid',
-  // Why: Grok CLI pastes images via bracketed path / image chips (see xAI
-  // terminal docs + pager paste.rs). Keep it on the same attachment path as
-  // Claude/Codex rather than treating path paste as unsupported text.
-  'grok'
-])
-
-export function getAgentImageHandling(agent: AgentType): AgentImageHandling {
-  return IMAGE_ATTACHMENT_AGENTS.has(agent) ? 'attachment' : 'unsupported'
-}
+export { getAgentImageHandling } from '../../../../shared/agent-image-handling'
 
 export type ImagePasteResult =
   | { kind: 'attach'; path: string }

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -73,6 +73,11 @@ import {
   arePaneTitleOverlayRectsEqual,
   clearPaneTitleOverlayRects
 } from './pane-title-overlay-rects'
+import { TerminalRichInput } from './TerminalRichInput'
+import {
+  submitTerminalRichInput,
+  type TerminalRichInputSubmitResult
+} from './terminal-rich-input-submit'
 import NativeChatView from '../native-chat/NativeChatView'
 import { splitTerminalPaneWithInheritedCwd } from './terminal-pane-split-with-inherited-cwd'
 import { TerminalAgentSessionForkDialog } from './TerminalAgentSessionForkDialog'
@@ -181,6 +186,7 @@ import {
   assertClipboardTextWithinLimitWithYield,
   type ReadClipboardTextOptions
 } from '../../../../shared/clipboard-text'
+import { terminalPasteIsOwnedByOverlay } from './terminal-paste-overlay-target'
 import { scheduleImagePasteWebglAtlasRecovery } from './terminal-webgl-atlas-recovery'
 import { restoreTerminalFitToDesktop, restoreTerminalFitsToDesktop } from './terminal-fit-restore'
 import { useVisibleTerminalTabClaim } from './use-visible-terminal-tab-claim'
@@ -192,12 +198,6 @@ import {
   updateTerminalRemoteRuntimeRecoveryUiState,
   type VisiblePtyRecoveryState
 } from './terminal-remote-runtime-recovery-ui-state'
-
-const NATIVE_CHAT_ROOT_SELECTOR = '[data-native-chat-root="true"]'
-
-function isInsideNativeChatRoot(target: EventTarget | null): boolean {
-  return target instanceof Element && target.closest(NATIVE_CHAT_ROOT_SELECTOR) !== null
-}
 
 // Why: registry lives in a leaf module to break the slice → TerminalPane → store → slice import cycle that leaves createTerminalSlice undefined at init.
 import { shutdownBufferCaptures } from './shutdown-buffer-captures'
@@ -388,6 +388,7 @@ function TerminalPane(
   const [tabWideAgentHintLeafId, setTabWideAgentHintLeafId] = useState<string | null | undefined>(
     undefined
   )
+  const [richInputLeafId, setRichInputLeafId] = useState<string | null>(null)
   // Why: each Add action starts with a fresh draft so the terminal menu doesn't reuse cancelled quick-command text.
   const [quickCommandDraft, setQuickCommandDraft] = useState(createTerminalQuickCommandDraft)
   const [agentSessionFork, setAgentSessionFork] = useState<PreparedAgentSessionFork | null>(null)
@@ -607,6 +608,52 @@ function TerminalPane(
   )
   const nativeChatEnabled = useAppStore((store) => store.settings?.experimentalNativeChat === true)
   const effectiveChatViewMode = nativeChatEnabled && isChatViewMode
+  const closeRichInput = useCallback(() => {
+    setRichInputLeafId(null)
+    requestAnimationFrame(() => {
+      const manager = managerRef.current
+      const pane = manager?.getActivePane() ?? manager?.getPanes()[0]
+      pane?.terminal.focus()
+    })
+  }, [])
+  const toggleRichInput = useCallback(() => {
+    if (effectiveChatViewMode) {
+      return
+    }
+    const activeLeafId = managerRef.current?.getActivePane()?.leafId ?? null
+    if (!activeLeafId) {
+      return
+    }
+    if (richInputLeafId === activeLeafId) {
+      closeRichInput()
+      return
+    }
+    setRichInputLeafId(activeLeafId)
+  }, [closeRichInput, effectiveChatViewMode, richInputLeafId])
+  const submitRichInputForPane = useCallback(
+    async (
+      pane: ManagedPane,
+      text: string,
+      imagePaths: string[]
+    ): Promise<TerminalRichInputSubmitResult> => {
+      const transport = paneTransportsRef.current.get(pane.id)
+      const ptyId = transport?.getPtyId() ?? null
+      if (ptyId && isPtyLocked(ptyId)) {
+        return { status: 'not-started' }
+      }
+      return await submitTerminalRichInput({
+        text,
+        imagePaths,
+        tabId,
+        worktreeId,
+        pane,
+        transport,
+        getManager: () => managerRef.current,
+        getPaneTransports: () => paneTransportsRef.current
+      })
+    },
+    [tabId, worktreeId]
+  )
   const unifiedTabLabel = useAppStore(
     (store) =>
       getCachedUnifiedTerminalTabForWorktree(store.unifiedTabsByWorktree, worktreeId, tabId)?.label
@@ -760,6 +807,7 @@ function TerminalPane(
       }
       setChatLeafId(leafId)
       if (!effectiveChatViewMode) {
+        setRichInputLeafId(null)
         toggleTabViewMode(unifiedTabId)
       }
     },
@@ -1757,6 +1805,7 @@ function TerminalPane(
     onClearPaneScrollback: clearPaneScrollback,
     onSetTitle: handleStartRename,
     onClearPaneTitle: handleClearPaneTitleShortcut,
+    onToggleRichInput: toggleRichInput,
     searchOpenRef,
     searchStateRef,
     macOptionAsAltRef,
@@ -2077,10 +2126,7 @@ function TerminalPane(
     }
     const onKeyPaste = (e: KeyboardEvent): void => {
       const target = e.target
-      if (
-        (target instanceof Element && target.closest('[data-terminal-search-root]')) ||
-        isInsideNativeChatRoot(target)
-      ) {
+      if (terminalPasteIsOwnedByOverlay(target)) {
         return
       }
       const matchesPaste = keybindingMatchesAction(
@@ -2135,10 +2181,7 @@ function TerminalPane(
     // Fallback: paste events from non-keyboard sources (Edit > Paste menu, programmatic paste, etc.).
     const onPaste = (e: ClipboardEvent): void => {
       const target = e.target
-      if (
-        (target instanceof Element && target.closest('[data-terminal-search-root]')) ||
-        isInsideNativeChatRoot(target)
-      ) {
+      if (terminalPasteIsOwnedByOverlay(target)) {
         return
       }
       if (suppressNextNativePaste) {
@@ -2176,8 +2219,7 @@ function TerminalPane(
       if (
         !(activeElementAtDispatch instanceof Element) ||
         !container.contains(activeElementAtDispatch) ||
-        activeElementAtDispatch.closest('[data-terminal-search-root]') ||
-        isInsideNativeChatRoot(activeElementAtDispatch)
+        terminalPasteIsOwnedByOverlay(activeElementAtDispatch)
       ) {
         return
       }
@@ -2834,6 +2876,7 @@ function TerminalPane(
 
   const activePane = managerRef.current?.getActivePane()
   const managedPanes = managerRef.current?.getPanes() ?? []
+  const activePaneTransport = activePane ? paneTransportsRef.current.get(activePane.id) : undefined
   const showSshReconnectOverlay = Boolean(
     isActive &&
     isVisible &&
@@ -3011,6 +3054,25 @@ function TerminalPane(
         panes={managerRef.current?.getPanes() ?? []}
         paneIds={sessionRestoredBannerPaneIds}
       />
+      {isActive && !effectiveChatViewMode && activePane?.container
+        ? createPortal(
+            <TerminalRichInput
+              open={richInputLeafId === activePane.leafId}
+              pane={activePane}
+              scopeKey={`${tabId}:${activePane.leafId}`}
+              worktreeId={worktreeId}
+              agent={
+                tabAgentTypeByLeaf[activePane.leafId] ?? resolveTitleAgentForLeaf(activePane.leafId)
+              }
+              connectionId={activePaneTransport?.getConnectionId?.() ?? null}
+              runtimeEnvironmentId={activePaneTransport?.getRuntimeEnvironmentId?.() ?? null}
+              onClose={closeRichInput}
+              onSubmit={(text, imagePaths) => submitRichInputForPane(activePane, text, imagePaths)}
+            />,
+            activePane.container,
+            `terminal-rich-input-${tabId}-${activePane.leafId}`
+          )
+        : null}
       {effectiveChatViewMode && chatPane?.container
         ? createPortal(
             <div className="absolute inset-0 z-10 flex min-h-0 min-w-0 bg-background">
@@ -3146,6 +3208,9 @@ function TerminalPane(
         hiddenStartupStyle={hiddenStartupStyle}
         managerRef={managerRef}
         paneTransportsRef={paneTransportsRef}
+        canToggleRichInput={isActive && !effectiveChatViewMode}
+        isRichInputOpen={richInputLeafId === activePane?.leafId}
+        onToggleRichInput={toggleRichInput}
         canToggleNativeChat={activePaneCanToggleChat}
         isChatViewMode={activePaneIsChatLeaf}
         onToggleNativeChat={handleToggleNativeChat}

--- a/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneHeaderOverlay.tsx
@@ -14,6 +14,7 @@ import { WORKSPACE_FILE_PATH_MIME, WORKSPACE_FILE_PATHS_MIME } from '@/lib/works
 import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import type { PtyTransport } from './pty-transport'
 import { handleInternalTerminalFileDrop } from './terminal-drop-handler'
+import { TerminalPaneRichInputToggle } from './TerminalPaneRichInputToggle'
 
 export type PaneTitleOverlayRect = {
   left: number
@@ -42,6 +43,9 @@ type TerminalPaneHeaderOverlayProps = {
   hiddenStartupStyle: CSSProperties
   managerRef: RefObject<PaneManager | null>
   paneTransportsRef: RefObject<Map<number, PtyTransport>>
+  canToggleRichInput?: boolean
+  isRichInputOpen?: boolean
+  onToggleRichInput?: () => void
   /** When true, this pane can toggle the native chat view; renders a chat/terminal
    *  toggle as the first button in the pane header actions row (beside split/close).
    *  The caller gates it to the active pane to avoid duplicating it across splits. */
@@ -85,6 +89,9 @@ export default function TerminalPaneHeaderOverlay({
   hiddenStartupStyle,
   managerRef,
   paneTransportsRef,
+  canToggleRichInput,
+  isRichInputOpen,
+  onToggleRichInput,
   canToggleNativeChat,
   isChatViewMode,
   onToggleNativeChat,
@@ -244,6 +251,12 @@ export default function TerminalPaneHeaderOverlay({
                   </button>
                 ) : null}
                 <div className="pane-title-actions ml-auto flex shrink-0 items-center gap-0">
+                  {canToggleRichInput && isActivePane ? (
+                    <TerminalPaneRichInputToggle
+                      isOpen={isRichInputOpen}
+                      onToggle={onToggleRichInput}
+                    />
+                  ) : null}
                   {canContinueAgentSessionInNewSession && isActivePane ? (
                     <Tooltip>
                       <TooltipTrigger asChild>

--- a/src/renderer/src/components/terminal-pane/TerminalPaneRichInputToggle.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneRichInputToggle.tsx
@@ -1,0 +1,40 @@
+import { TextCursorInput } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { translate } from '@/i18n/i18n'
+
+type TerminalPaneRichInputToggleProps = {
+  isOpen: boolean | undefined
+  onToggle: (() => void) | undefined
+}
+
+/** Header affordance that opens/closes the pane's rich input dock. */
+export function TerminalPaneRichInputToggle({
+  isOpen,
+  onToggle
+}: TerminalPaneRichInputToggleProps): React.JSX.Element {
+  const label = translate('components.terminal.richInput.toggle', 'Toggle rich terminal input')
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="pane-title-split-trigger"
+          aria-label={label}
+          aria-pressed={isOpen}
+          onClick={(event) => {
+            event.stopPropagation()
+            onToggle?.()
+          }}
+        >
+          <TextCursorInput className="size-3" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={4}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/components/terminal-pane/TerminalRichInput.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalRichInput.tsx
@@ -1,9 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ArrowUp, Loader2 } from 'lucide-react'
 import { EditorContent, useEditor, type Editor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import { Button } from '@/components/ui/button'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
 import { useRuntimeFileListForWorktree } from '@/components/quick-open-file-list'
@@ -29,6 +26,7 @@ import { TerminalRichInputFileMention } from './TerminalRichInputFileMention'
 import { TerminalRichInputFileMenu } from './TerminalRichInputFileMenu'
 import { TerminalRichInputAttachments } from './TerminalRichInputAttachments'
 import { TerminalRichInputSlashMenu } from './TerminalRichInputSlashMenu'
+import { TerminalRichInputSendButton } from './TerminalRichInputSendButton'
 import { TerminalRichInputStatus, type TerminalRichInputSendError } from './TerminalRichInputStatus'
 import {
   findTerminalRichInputMentionQuery,
@@ -36,6 +34,7 @@ import {
   type TerminalRichInputQuery
 } from './terminal-rich-input-autocomplete'
 import { useTerminalRichInputAnimation } from './use-terminal-rich-input-animation'
+import { useTerminalRichInputAutocompleteAria } from './use-terminal-rich-input-autocomplete-aria'
 import { useTerminalRichInputAttachments } from './use-terminal-rich-input-attachments'
 import { useTerminalRichInputDrop } from './use-terminal-rich-input-drop'
 import { handleTerminalRichInputKeyDown } from './terminal-rich-input-keydown'
@@ -54,7 +53,8 @@ export function TerminalRichInput({
   onSubmit
 }: TerminalRichInputProps): React.JSX.Element {
   const initialDraft = useMemo(() => readTerminalRichInputDraft(scopeKey), [scopeKey])
-  const [draft, setDraftState] = useState(initialDraft)
+  const [draftState, setDraftState] = useState(() => ({ scopeKey, value: initialDraft }))
+  const draft = draftState.scopeKey === scopeKey ? draftState.value : initialDraft
   const [mention, setMention] = useState<TerminalRichInputQuery | null>(null)
   const [slash, setSlash] = useState<TerminalRichInputQuery | null>(null)
   const [activeSuggestion, setActiveSuggestion] = useState(0)
@@ -78,7 +78,7 @@ export function TerminalRichInput({
 
   const setDraft = useCallback(
     (next: string) => {
-      setDraftState(next)
+      setDraftState({ scopeKey, value: next })
       writeTerminalRichInputDraft(scopeKey, next)
     },
     [scopeKey]
@@ -107,10 +107,10 @@ export function TerminalRichInput({
     attachmentPending,
     notice: attachmentNotice,
     appendImagePaths,
-    clearAttachments,
     handlePaste,
     pasteImageFromClipboard,
-    removeAttachment
+    removeAttachment,
+    removeAttachments
   } = useTerminalRichInputAttachments({
     scopeKey,
     connectionId,
@@ -130,6 +130,9 @@ export function TerminalRichInput({
       editorProps: {
         attributes: {
           'aria-label': translate('components.terminal.richInput.label', 'Rich terminal input'),
+          'aria-autocomplete': 'list',
+          'aria-expanded': 'false',
+          role: 'combobox',
           class:
             'terminal-rich-input-editor scrollbar-sleek min-h-12 max-h-40 overflow-y-auto px-2 py-1 text-sm outline-none'
         },
@@ -181,6 +184,18 @@ export function TerminalRichInput({
     [agent, slash?.query]
   )
   slashSuggestionsRef.current = slashSuggestions
+  const {
+    fileMenuId,
+    slashMenuId,
+    activeIndex: activeAutocompleteIndex
+  } = useTerminalRichInputAutocompleteAria({
+    editor,
+    fileMenuOpen: mention !== null,
+    fileSuggestionCount: suggestionPaths.length,
+    slashMenuOpen: slash !== null && slashSuggestions.length > 0,
+    slashSuggestionCount: slashSuggestions.length,
+    activeSuggestion
+  })
 
   const chooseFile = useCallback(
     (filePath: string) => {
@@ -257,6 +272,7 @@ export function TerminalRichInput({
     if (submissionBlocked || !hasSubmissionContent || !editor) {
       return
     }
+    const submittedAttachments = attachments
     setSending(true)
     setSendError(null)
     editor.setEditable(false)
@@ -264,7 +280,7 @@ export function TerminalRichInput({
     try {
       result = await onSubmit(
         draft,
-        attachments.map((attachment) => attachment.path)
+        submittedAttachments.map((attachment) => attachment.path)
       )
     } catch {
       result = { status: 'not-started' }
@@ -273,23 +289,28 @@ export function TerminalRichInput({
     editor.setEditable(true)
     if (result.status !== 'submitted') {
       if (result.status === 'partially-written') {
-        removeWrittenTerminalRichInputContent(result, attachments, editor, removeAttachment)
+        removeWrittenTerminalRichInputContent(
+          result,
+          submittedAttachments,
+          editor,
+          removeAttachment
+        )
       }
       setSendError(result.status)
       editor.commands.focus('end')
       return
     }
     editor.commands.clearContent()
-    clearAttachments()
+    removeAttachments(submittedAttachments.map((attachment) => attachment.id))
     editor.commands.focus('start')
   }, [
     attachments,
-    clearAttachments,
     draft,
     editor,
     hasSubmissionContent,
     onSubmit,
     removeAttachment,
+    removeAttachments,
     submissionBlocked
   ])
   submitRef.current = () => void submit()
@@ -322,17 +343,19 @@ export function TerminalRichInput({
           <div className="relative w-full">
             {mention ? (
               <TerminalRichInputFileMenu
+                id={fileMenuId}
                 loading={fileList.loading}
                 error={fileList.loadError}
                 paths={suggestionPaths}
-                activeIndex={activeSuggestion}
+                activeIndex={activeAutocompleteIndex}
                 onChoose={chooseFile}
               />
             ) : null}
             {slash ? (
               <TerminalRichInputSlashMenu
+                id={slashMenuId}
                 suggestions={slashSuggestions}
-                activeIndex={activeSuggestion}
+                activeIndex={activeAutocompleteIndex}
                 onChoose={(command) => chooseSlash(command, false)}
               />
             ) : null}
@@ -372,32 +395,11 @@ export function TerminalRichInput({
               </div>
               <div className="flex items-center gap-2 px-1 pt-0.5">
                 <TerminalRichInputStatus error={sendError} />
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-sm"
-                      className="ml-auto size-8 rounded-md border border-border text-muted-foreground shadow-none hover:bg-accent hover:text-accent-foreground"
-                      data-terminal-rich-input-send=""
-                      disabled={submissionBlocked || !hasSubmissionContent}
-                      onClick={() => void submit()}
-                      aria-label={translate(
-                        'components.terminal.richInput.send',
-                        'Send to terminal'
-                      )}
-                    >
-                      {sending ? (
-                        <Loader2 className="size-3.5 animate-spin" />
-                      ) : (
-                        <ArrowUp className="size-3.5" />
-                      )}
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="top" sideOffset={4}>
-                    {translate('components.terminal.richInput.send', 'Send to terminal')}
-                  </TooltipContent>
-                </Tooltip>
+                <TerminalRichInputSendButton
+                  sending={sending}
+                  disabled={submissionBlocked || !hasSubmissionContent}
+                  onSend={() => void submit()}
+                />
               </div>
             </div>
           </div>

--- a/src/renderer/src/components/terminal-pane/TerminalRichInput.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalRichInput.tsx
@@ -1,0 +1,408 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ArrowUp, Loader2 } from 'lucide-react'
+import { EditorContent, useEditor, type Editor } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+import { useRuntimeFileListForWorktree } from '@/components/quick-open-file-list'
+import { prepareQuickOpenFiles, rankQuickOpenFiles } from '@/components/quick-open-search'
+import { getAgentImageHandling } from '../../../../shared/agent-image-handling'
+import {
+  filterSlashCommands,
+  getAgentSlashCommands,
+  type SlashCommandSuggestion
+} from '../../../../shared/native-chat-slash-commands'
+import { isImageDropPath } from './terminal-drop-image-path'
+import {
+  readTerminalRichInputDraft,
+  writeTerminalRichInputDraft
+} from './terminal-rich-input-draft'
+import {
+  TERMINAL_RICH_INPUT_FILE_MENTION_NODE,
+  terminalRichInputContentToText,
+  terminalRichInputPathsToContent,
+  terminalRichInputTextToContent
+} from './terminal-rich-input-model'
+import { TerminalRichInputFileMention } from './TerminalRichInputFileMention'
+import { TerminalRichInputFileMenu } from './TerminalRichInputFileMenu'
+import { TerminalRichInputAttachments } from './TerminalRichInputAttachments'
+import { TerminalRichInputSlashMenu } from './TerminalRichInputSlashMenu'
+import { TerminalRichInputStatus, type TerminalRichInputSendError } from './TerminalRichInputStatus'
+import {
+  findTerminalRichInputMentionQuery,
+  findTerminalRichInputSlashQuery,
+  type TerminalRichInputQuery
+} from './terminal-rich-input-autocomplete'
+import { useTerminalRichInputAnimation } from './use-terminal-rich-input-animation'
+import { useTerminalRichInputAttachments } from './use-terminal-rich-input-attachments'
+import { useTerminalRichInputDrop } from './use-terminal-rich-input-drop'
+import { handleTerminalRichInputKeyDown } from './terminal-rich-input-keydown'
+import { removeWrittenTerminalRichInputContent } from './terminal-rich-input-submit-reconcile'
+import type { TerminalRichInputProps } from './terminal-rich-input-types'
+
+export function TerminalRichInput({
+  open,
+  pane,
+  scopeKey,
+  worktreeId,
+  agent,
+  connectionId,
+  runtimeEnvironmentId,
+  onClose,
+  onSubmit
+}: TerminalRichInputProps): React.JSX.Element {
+  const initialDraft = useMemo(() => readTerminalRichInputDraft(scopeKey), [scopeKey])
+  const [draft, setDraftState] = useState(initialDraft)
+  const [mention, setMention] = useState<TerminalRichInputQuery | null>(null)
+  const [slash, setSlash] = useState<TerminalRichInputQuery | null>(null)
+  const [activeSuggestion, setActiveSuggestion] = useState(0)
+  const [sending, setSending] = useState(false)
+  const [sendError, setSendError] = useState<TerminalRichInputSendError>(null)
+  const mentionRef = useRef(mention)
+  const slashRef = useRef(slash)
+  const suggestionsRef = useRef<string[]>([])
+  const slashSuggestionsRef = useRef<SlashCommandSuggestion[]>([])
+  const activeSuggestionRef = useRef(activeSuggestion)
+  const chooseFileRef = useRef<(path: string) => void>(() => {})
+  const chooseSlashRef = useRef<(command: SlashCommandSuggestion, submit: boolean) => void>(
+    () => {}
+  )
+  const submitRef = useRef<() => void>(() => {})
+  const closeRef = useRef(onClose)
+  mentionRef.current = mention
+  slashRef.current = slash
+  activeSuggestionRef.current = activeSuggestion
+  closeRef.current = onClose
+
+  const setDraft = useCallback(
+    (next: string) => {
+      setDraftState(next)
+      writeTerminalRichInputDraft(scopeKey, next)
+    },
+    [scopeKey]
+  )
+
+  const editorRef = useRef<Editor | null>(null)
+  const syncAutocomplete = useCallback(
+    (editor: Editor) => {
+      const nextMention = agent ? findTerminalRichInputMentionQuery(editor) : null
+      const nextSlash = agent ? findTerminalRichInputSlashQuery(editor) : null
+      setMention(nextMention)
+      setSlash(nextMention ? null : nextSlash)
+      if (
+        nextMention?.query !== mentionRef.current?.query ||
+        nextSlash?.query !== slashRef.current?.query
+      ) {
+        setActiveSuggestion(0)
+      }
+    },
+    [agent]
+  )
+  const canAttachImages = agent ? getAgentImageHandling(agent) === 'attachment' : false
+  const {
+    attachments,
+    attachmentBusy,
+    attachmentPending,
+    notice: attachmentNotice,
+    appendImagePaths,
+    clearAttachments,
+    handlePaste,
+    pasteImageFromClipboard,
+    removeAttachment
+  } = useTerminalRichInputAttachments({
+    scopeKey,
+    connectionId,
+    runtimeEnvironmentId,
+    focusEditor: () => editorRef.current?.commands.focus('end'),
+    enabled: canAttachImages
+  })
+
+  const editor = useEditor(
+    {
+      immediatelyRender: false,
+      extensions: [
+        StarterKit.configure({ heading: false, blockquote: false, codeBlock: false }),
+        TerminalRichInputFileMention
+      ],
+      content: terminalRichInputTextToContent(initialDraft, Boolean(agent)),
+      editorProps: {
+        attributes: {
+          'aria-label': translate('components.terminal.richInput.label', 'Rich terminal input'),
+          class:
+            'terminal-rich-input-editor scrollbar-sleek min-h-12 max-h-40 overflow-y-auto px-2 py-1 text-sm outline-none'
+        },
+        handlePaste: (_view, event) => handlePaste(event),
+        handleKeyDown: (_view, event) =>
+          handleTerminalRichInputKeyDown(event, {
+            mentionRef,
+            slashRef,
+            fileSuggestionsRef: suggestionsRef,
+            slashSuggestionsRef,
+            activeSuggestionRef,
+            setActiveSuggestion,
+            pasteImageFromClipboard,
+            chooseFile: (path) => chooseFileRef.current(path),
+            chooseSlash: (command, submit) => chooseSlashRef.current(command, submit),
+            closeAutocomplete: () => {
+              setMention(null)
+              setSlash(null)
+            },
+            closeComposer: () => closeRef.current(),
+            submit: () => submitRef.current()
+          })
+      },
+      onUpdate: ({ editor: updatedEditor }) => {
+        const next = terminalRichInputContentToText(updatedEditor.getJSON())
+        setDraft(next)
+        setSendError(null)
+        syncAutocomplete(updatedEditor)
+      },
+      onSelectionUpdate: ({ editor: updatedEditor }) => syncAutocomplete(updatedEditor)
+    },
+    [scopeKey, agent]
+  )
+  editorRef.current = editor
+
+  const fileList = useRuntimeFileListForWorktree({ enabled: mention !== null, worktreeId })
+  const indexedFiles = useMemo(() => prepareQuickOpenFiles(fileList.files), [fileList.files])
+  const suggestions = useMemo(
+    () => rankQuickOpenFiles(mention?.query ?? '', indexedFiles, 8),
+    [indexedFiles, mention?.query]
+  )
+  const suggestionPaths = useMemo(
+    () => suggestions.map((suggestion) => suggestion.path),
+    [suggestions]
+  )
+  suggestionsRef.current = suggestionPaths
+  const slashSuggestions = useMemo(
+    () => (agent ? filterSlashCommands(getAgentSlashCommands(agent), slash?.query ?? '') : []),
+    [agent, slash?.query]
+  )
+  slashSuggestionsRef.current = slashSuggestions
+
+  const chooseFile = useCallback(
+    (filePath: string) => {
+      const currentMention = mentionRef.current
+      if (!editor || !currentMention) {
+        return
+      }
+      editor
+        .chain()
+        .focus()
+        .deleteRange({ from: currentMention.from, to: currentMention.to })
+        .insertContent([
+          { type: TERMINAL_RICH_INPUT_FILE_MENTION_NODE, attrs: { path: filePath } },
+          { type: 'text', text: ' ' }
+        ])
+        .run()
+      setMention(null)
+      setActiveSuggestion(0)
+    },
+    [editor]
+  )
+  chooseFileRef.current = chooseFile
+
+  const chooseSlash = useCallback(
+    (command: SlashCommandSuggestion, submitAfterInsert: boolean) => {
+      const currentSlash = slashRef.current
+      if (!editor || !currentSlash) {
+        return
+      }
+      editor
+        .chain()
+        .focus()
+        .deleteRange({ from: currentSlash.from, to: currentSlash.to })
+        .insertContent(`/${command.name}${submitAfterInsert ? '' : ' '}`)
+        .run()
+      setSlash(null)
+      setActiveSuggestion(0)
+      if (submitAfterInsert) {
+        requestAnimationFrame(() => submitRef.current())
+      }
+    },
+    [editor]
+  )
+  chooseSlashRef.current = chooseSlash
+
+  const insertFilePaths = useCallback(
+    (paths: string[]) => {
+      const files = paths.filter((path) => !isImageDropPath(path))
+      if (!editor || files.length === 0) {
+        return
+      }
+      editor
+        .chain()
+        .focus()
+        .insertContent(terminalRichInputPathsToContent(files, Boolean(agent)))
+        .run()
+    },
+    [agent, editor]
+  )
+
+  const insertDroppedPaths = useCallback(
+    (paths: string[]) => {
+      const images = canAttachImages ? paths.filter(isImageDropPath) : []
+      appendImagePaths(images)
+      insertFilePaths(paths.filter((path) => !images.includes(path)))
+    },
+    [appendImagePaths, canAttachImages, insertFilePaths]
+  )
+  const dropHandlers = useTerminalRichInputDrop({ open, pane, insertPaths: insertDroppedPaths })
+  const hasSubmissionContent = Boolean(draft.trim() || attachments.length > 0)
+  const submissionBlocked = sending || attachmentBusy || dropHandlers.busy
+
+  const submit = useCallback(async () => {
+    if (submissionBlocked || !hasSubmissionContent || !editor) {
+      return
+    }
+    setSending(true)
+    setSendError(null)
+    editor.setEditable(false)
+    let result: Awaited<ReturnType<typeof onSubmit>> = { status: 'not-started' }
+    try {
+      result = await onSubmit(
+        draft,
+        attachments.map((attachment) => attachment.path)
+      )
+    } catch {
+      result = { status: 'not-started' }
+    }
+    setSending(false)
+    editor.setEditable(true)
+    if (result.status !== 'submitted') {
+      if (result.status === 'partially-written') {
+        removeWrittenTerminalRichInputContent(result, attachments, editor, removeAttachment)
+      }
+      setSendError(result.status)
+      editor.commands.focus('end')
+      return
+    }
+    editor.commands.clearContent()
+    clearAttachments()
+    editor.commands.focus('start')
+  }, [
+    attachments,
+    clearAttachments,
+    draft,
+    editor,
+    hasSubmissionContent,
+    onSubmit,
+    removeAttachment,
+    submissionBlocked
+  ])
+  submitRef.current = () => void submit()
+
+  const { layoutOpen } = useTerminalRichInputAnimation({ open, pane })
+
+  useEffect(() => {
+    if (open) {
+      editor?.commands.focus('end')
+    }
+  }, [editor, open])
+
+  return (
+    <div
+      className={cn('terminal-rich-input-dock min-w-0', !open && 'pointer-events-none')}
+      data-layout-open={layoutOpen ? '' : undefined}
+      data-visible={open ? '' : undefined}
+      data-pane-prevent-terminal-focus=""
+      aria-hidden={!open}
+      inert={open ? undefined : true}
+      onPasteCapture={(event) => handlePaste(event.nativeEvent)}
+      onDragOver={dropHandlers.onDragOver}
+      onDrop={dropHandlers.onDrop}
+    >
+      <div className="terminal-rich-input-dock-content min-h-0 overflow-hidden">
+        <div
+          className="border-t border-border bg-transparent px-2 pb-2 pt-1.5"
+          data-terminal-rich-input-dock=""
+        >
+          <div className="relative w-full">
+            {mention ? (
+              <TerminalRichInputFileMenu
+                loading={fileList.loading}
+                error={fileList.loadError}
+                paths={suggestionPaths}
+                activeIndex={activeSuggestion}
+                onChoose={chooseFile}
+              />
+            ) : null}
+            {slash ? (
+              <TerminalRichInputSlashMenu
+                suggestions={slashSuggestions}
+                activeIndex={activeSuggestion}
+                onChoose={(command) => chooseSlash(command, false)}
+              />
+            ) : null}
+            {attachmentNotice ? (
+              <div className="mb-1.5 px-1 text-xs text-destructive">{attachmentNotice}</div>
+            ) : null}
+            <div
+              data-terminal-rich-input-card=""
+              className={cn(
+                'rounded-lg border border-input bg-transparent p-1.5 shadow-xs transition-colors',
+                'focus-within:border-ring focus-within:ring-1 focus-within:ring-ring/50'
+              )}
+              onMouseDown={(event) => {
+                if (event.target === event.currentTarget) {
+                  editor?.commands.focus('end')
+                }
+              }}
+            >
+              <TerminalRichInputAttachments
+                attachments={attachments}
+                pending={attachmentPending || dropHandlers.imagePending}
+                connectionId={connectionId}
+                runtimeEnvironmentId={runtimeEnvironmentId}
+                worktreeId={worktreeId}
+                onRemove={removeAttachment}
+              />
+              <div className="relative">
+                {!draft ? (
+                  <span className="pointer-events-none absolute left-2 top-1 text-sm text-muted-foreground/60">
+                    {translate(
+                      'components.terminal.richInput.placeholder',
+                      'Write a terminal prompt…'
+                    )}
+                  </span>
+                ) : null}
+                <EditorContent editor={editor} />
+              </div>
+              <div className="flex items-center gap-2 px-1 pt-0.5">
+                <TerminalRichInputStatus error={sendError} />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      className="ml-auto size-8 rounded-md border border-border text-muted-foreground shadow-none hover:bg-accent hover:text-accent-foreground"
+                      data-terminal-rich-input-send=""
+                      disabled={submissionBlocked || !hasSubmissionContent}
+                      onClick={() => void submit()}
+                      aria-label={translate(
+                        'components.terminal.richInput.send',
+                        'Send to terminal'
+                      )}
+                    >
+                      {sending ? (
+                        <Loader2 className="size-3.5 animate-spin" />
+                      ) : (
+                        <ArrowUp className="size-3.5" />
+                      )}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" sideOffset={4}>
+                    {translate('components.terminal.richInput.send', 'Send to terminal')}
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/terminal-pane/TerminalRichInputAttachments.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalRichInputAttachments.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { TerminalRichInputAttachments } from './TerminalRichInputAttachments'
+
+vi.mock('@/components/editor/useLocalImageSrc', () => ({
+  useLocalImageSrc: () => 'blob:terminal-rich-input-image'
+}))
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+describe('TerminalRichInputAttachments', () => {
+  it('renders a full-opacity removable thumbnail with a concise image filename', () => {
+    const html = renderToStaticMarkup(
+      <TerminalRichInputAttachments
+        attachments={[{ id: 'image-1', path: '/tmp/orca-paste-123.png' }]}
+        pending={false}
+        connectionId={null}
+        runtimeEnvironmentId={null}
+        worktreeId="worktree-1"
+        onRemove={() => {}}
+      />
+    )
+
+    expect(html).toContain('blob:terminal-rich-input-image')
+    expect(html).toContain('image.png')
+    expect(html).toContain('opacity-100')
+    expect(html).toContain('Remove attachment')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/TerminalRichInputAttachments.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalRichInputAttachments.tsx
@@ -4,6 +4,7 @@ import { translate } from '@/i18n/i18n'
 import { basename } from '@/lib/path'
 import { useLocalImageSrc } from '@/components/editor/useLocalImageSrc'
 import { isNativeChatPastedImagePath } from '@/components/native-chat/native-chat-image-paste'
+import { Button } from '@/components/ui/button'
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
 import { IMAGE_FILE_MIME_TYPES } from '../../../../shared/image-file-extensions'
 import type { TerminalRichInputImageAttachment } from './terminal-rich-input-attachment-cache'
@@ -112,17 +113,19 @@ function TerminalRichInputAttachment({
             )}
           </div>
           <span className="max-w-56 truncate font-medium">{label}</span>
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="icon-xs"
             onClick={() => onRemove(attachment.id)}
             aria-label={translate(
               'components.terminal.richInput.removeAttachment',
               'Remove attachment'
             )}
-            className="flex size-6 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="shrink-0 rounded-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground"
           >
             <X className="size-3.5" />
-          </button>
+          </Button>
         </div>
       </HoverCardTrigger>
       {previewOpen ? (

--- a/src/renderer/src/components/terminal-pane/TerminalRichInputAttachments.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalRichInputAttachments.tsx
@@ -1,0 +1,173 @@
+import { useMemo, useState } from 'react'
+import { Image as ImageIcon, Loader2, X } from 'lucide-react'
+import { translate } from '@/i18n/i18n'
+import { basename } from '@/lib/path'
+import { useLocalImageSrc } from '@/components/editor/useLocalImageSrc'
+import { isNativeChatPastedImagePath } from '@/components/native-chat/native-chat-image-paste'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
+import { IMAGE_FILE_MIME_TYPES } from '../../../../shared/image-file-extensions'
+import type { TerminalRichInputImageAttachment } from './terminal-rich-input-attachment-cache'
+
+export function TerminalRichInputAttachments({
+  attachments,
+  pending,
+  connectionId,
+  runtimeEnvironmentId,
+  worktreeId,
+  onRemove
+}: {
+  attachments: readonly TerminalRichInputImageAttachment[]
+  pending: boolean
+  connectionId: string | null
+  runtimeEnvironmentId: string | null
+  worktreeId: string
+  onRemove: (id: string) => void
+}): React.JSX.Element | null {
+  if (attachments.length === 0 && !pending) {
+    return null
+  }
+  return (
+    <div className="mb-1.5 flex flex-wrap gap-1.5 px-1">
+      {pending ? (
+        <div className="flex items-center gap-2 rounded-md border border-border bg-background px-2 py-1.5 text-xs text-muted-foreground">
+          <Loader2 className="size-3.5 animate-spin" />
+          {translate('components.terminal.richInput.addingImage', 'Adding image…')}
+        </div>
+      ) : null}
+      {attachments.map((attachment) => (
+        <TerminalRichInputAttachment
+          key={attachment.id}
+          attachment={attachment}
+          connectionId={connectionId}
+          runtimeEnvironmentId={runtimeEnvironmentId}
+          worktreeId={worktreeId}
+          onRemove={onRemove}
+        />
+      ))}
+    </div>
+  )
+}
+
+type AttachmentImageProps = {
+  attachment: TerminalRichInputImageAttachment
+  connectionId: string | null
+  runtimeEnvironmentId: string | null
+  worktreeId: string
+}
+
+function useAttachmentImageSrc(
+  { attachment, connectionId, runtimeEnvironmentId, worktreeId }: AttachmentImageProps,
+  load = true
+): string | undefined {
+  const runtimeContext = useMemo(
+    () =>
+      runtimeEnvironmentId
+        ? {
+            settings: { activeRuntimeEnvironmentId: runtimeEnvironmentId },
+            worktreeId,
+            worktreePath: undefined,
+            connectionId: connectionId ?? undefined
+          }
+        : undefined,
+    [connectionId, runtimeEnvironmentId, worktreeId]
+  )
+  return useLocalImageSrc(
+    load ? attachment.path : undefined,
+    attachment.path,
+    connectionId,
+    runtimeContext
+  )
+}
+
+function TerminalRichInputAttachment({
+  attachment,
+  connectionId,
+  runtimeEnvironmentId,
+  worktreeId,
+  onRemove
+}: AttachmentImageProps & { onRemove: (id: string) => void }): React.JSX.Element {
+  const [previewOpen, setPreviewOpen] = useState(false)
+  const loadedImageSrc = useAttachmentImageSrc(
+    { attachment, connectionId, runtimeEnvironmentId, worktreeId },
+    !attachment.previewSrc
+  )
+  const imageSrc = attachment.previewSrc ?? loadedImageSrc
+  const label = isNativeChatPastedImagePath(attachment.path)
+    ? 'image.png'
+    : basename(attachment.path)
+  const mediaType = getImageMediaType(attachment.path)
+  return (
+    <HoverCard open={previewOpen} onOpenChange={setPreviewOpen} openDelay={250} closeDelay={120}>
+      <HoverCardTrigger asChild>
+        <div
+          className="flex max-w-full cursor-default items-center gap-2 rounded-md border border-input bg-background p-1 pr-1.5 text-sm text-foreground"
+          title={attachment.path}
+          data-terminal-rich-input-attachment=""
+        >
+          <div className="flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-sm border border-border bg-muted">
+            {imageSrc ? (
+              <img src={imageSrc} alt={label} className="size-full object-cover opacity-100" />
+            ) : (
+              <ImageIcon className="size-4 text-muted-foreground" />
+            )}
+          </div>
+          <span className="max-w-56 truncate font-medium">{label}</span>
+          <button
+            type="button"
+            onClick={() => onRemove(attachment.id)}
+            aria-label={translate(
+              'components.terminal.richInput.removeAttachment',
+              'Remove attachment'
+            )}
+            className="flex size-6 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <X className="size-3.5" />
+          </button>
+        </div>
+      </HoverCardTrigger>
+      {previewOpen ? (
+        <HoverCardContent side="top" align="start" sideOffset={8} className="w-auto p-2">
+          <TerminalRichInputAttachmentPreview
+            attachment={attachment}
+            connectionId={connectionId}
+            runtimeEnvironmentId={runtimeEnvironmentId}
+            worktreeId={worktreeId}
+            label={label}
+            mediaType={mediaType}
+          />
+        </HoverCardContent>
+      ) : null}
+    </HoverCard>
+  )
+}
+
+function getImageMediaType(path: string): string {
+  const extension = path.slice(path.lastIndexOf('.')).toLowerCase()
+  return IMAGE_FILE_MIME_TYPES[extension] ?? 'image'
+}
+
+function TerminalRichInputAttachmentPreview({
+  label,
+  mediaType,
+  ...imageProps
+}: AttachmentImageProps & { label: string; mediaType: string }): React.JSX.Element {
+  const fullImageSrc = useAttachmentImageSrc(imageProps)
+  const imageSrc = fullImageSrc ?? imageProps.attachment.previewSrc
+  return (
+    <div className="w-80 space-y-2">
+      <div className="flex max-h-80 min-h-32 w-full items-center justify-center overflow-hidden rounded-md border border-border bg-background">
+        {imageSrc ? (
+          <img src={imageSrc} alt={label} className="max-h-80 max-w-full object-contain" />
+        ) : (
+          <Loader2 className="size-5 animate-spin text-muted-foreground" />
+        )}
+      </div>
+      <div className="min-w-0 space-y-1 px-0.5">
+        <div className="truncate text-sm font-medium text-foreground" title={label}>
+          {label}
+        </div>
+        <div className="truncate font-mono text-xs text-muted-foreground">{mediaType}</div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/terminal-pane/TerminalRichInputFileMention.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalRichInputFileMention.tsx
@@ -1,0 +1,59 @@
+import { mergeAttributes, Node } from '@tiptap/core'
+import { NodeViewWrapper, type NodeViewProps } from '@tiptap/react'
+import { getFileTypeIcon } from '@/lib/file-type-icons'
+import { basename } from '@/lib/path'
+import { safeReactNodeViewRenderer } from '@/components/editor/safe-react-node-view-renderer'
+import { formatNativeChatFileReference } from '../native-chat/native-chat-composer-target'
+import { TERMINAL_RICH_INPUT_FILE_MENTION_NODE } from './terminal-rich-input-model'
+
+export const TerminalRichInputFileMention = Node.create({
+  name: TERMINAL_RICH_INPUT_FILE_MENTION_NODE,
+  group: 'inline',
+  inline: true,
+  atom: true,
+  selectable: true,
+
+  addAttributes() {
+    return { path: { default: '' } }
+  },
+
+  parseHTML() {
+    return [{ tag: 'span[data-terminal-file-mention]' }]
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    return [
+      'span',
+      mergeAttributes(HTMLAttributes, {
+        'data-terminal-file-mention': '',
+        'data-path': node.attrs.path
+      }),
+      formatNativeChatFileReference(String(node.attrs.path ?? ''))
+    ]
+  },
+
+  renderText({ node }) {
+    return formatNativeChatFileReference(String(node.attrs.path ?? ''))
+  },
+
+  addNodeView() {
+    return safeReactNodeViewRenderer(TerminalRichInputFileMentionView, { as: 'span' })
+  }
+})
+
+function TerminalRichInputFileMentionView({ node }: NodeViewProps): React.JSX.Element {
+  const path = String(node.attrs.path ?? '')
+  const FileIcon = getFileTypeIcon(path)
+  return (
+    <NodeViewWrapper
+      as="span"
+      data-terminal-rich-input-mention=""
+      title={path}
+      contentEditable={false}
+      className="mx-0.5 inline-flex h-6 max-w-64 select-none items-center gap-1 rounded-md border border-border bg-muted px-1.5 align-middle text-xs text-foreground"
+    >
+      <FileIcon className="size-3.5 shrink-0 text-muted-foreground" />
+      <span className="truncate">{basename(path) || path}</span>
+    </NodeViewWrapper>
+  )
+}

--- a/src/renderer/src/components/terminal-pane/TerminalRichInputFileMenu.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalRichInputFileMenu.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { TerminalRichInputFileMenu } from './TerminalRichInputFileMenu'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+vi.mock('@/lib/file-type-icons', () => ({
+  getFileTypeIcon: () => () => null
+}))
+
+describe('TerminalRichInputFileMenu', () => {
+  it('connects the listbox and active shadcn option with stable IDs', () => {
+    const html = renderToStaticMarkup(
+      <TerminalRichInputFileMenu
+        id="file-menu"
+        loading={false}
+        error={null}
+        paths={['src/index.ts', 'README.md']}
+        activeIndex={1}
+        onChoose={() => {}}
+      />
+    )
+
+    expect(html).toContain('id="file-menu"')
+    expect(html).toContain('role="listbox"')
+    expect(html).toContain('id="file-menu-option-1"')
+    expect(html).toContain('aria-selected="true"')
+    expect(html).toContain('data-slot="button"')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/TerminalRichInputFileMenu.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalRichInputFileMenu.tsx
@@ -1,0 +1,57 @@
+import { Loader2 } from 'lucide-react'
+import { getFileTypeIcon } from '@/lib/file-type-icons'
+import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+
+export function TerminalRichInputFileMenu({
+  loading,
+  error,
+  paths,
+  activeIndex,
+  onChoose
+}: {
+  loading: boolean
+  error: string | null
+  paths: string[]
+  activeIndex: number
+  onChoose: (path: string) => void
+}): React.JSX.Element {
+  return (
+    <div
+      data-terminal-rich-input-menu=""
+      className="scrollbar-sleek absolute bottom-full left-0 right-0 z-20 mb-1 max-h-64 overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"
+    >
+      {loading ? (
+        <div className="flex items-center gap-2 px-2 py-1.5 text-xs text-muted-foreground">
+          <Loader2 className="size-3.5 animate-spin" />
+          {translate('components.terminal.richInput.loadingFiles', 'Loading files…')}
+        </div>
+      ) : error ? (
+        <div className="px-2 py-1.5 text-xs text-muted-foreground">{error}</div>
+      ) : paths.length === 0 ? (
+        <div className="px-2 py-1.5 text-xs text-muted-foreground">
+          {translate('components.terminal.richInput.noFiles', 'No matching files')}
+        </div>
+      ) : (
+        paths.map((path, index) => {
+          const FileIcon = getFileTypeIcon(path)
+          return (
+            <button
+              key={path}
+              type="button"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => onChoose(path)}
+              className={cn(
+                'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm',
+                index === activeIndex ? 'bg-accent text-accent-foreground' : 'text-foreground'
+              )}
+            >
+              <FileIcon className="size-3.5 shrink-0 text-muted-foreground" />
+              <span className="truncate font-mono text-xs">{path}</span>
+            </button>
+          )
+        })
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/terminal-pane/TerminalRichInputFileMenu.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalRichInputFileMenu.tsx
@@ -1,15 +1,18 @@
 import { Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import { getFileTypeIcon } from '@/lib/file-type-icons'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
 
 export function TerminalRichInputFileMenu({
+  id,
   loading,
   error,
   paths,
   activeIndex,
   onChoose
 }: {
+  id: string
   loading: boolean
   error: string | null
   paths: string[]
@@ -18,8 +21,11 @@ export function TerminalRichInputFileMenu({
 }): React.JSX.Element {
   return (
     <div
+      id={id}
       data-terminal-rich-input-menu=""
       className="scrollbar-sleek absolute bottom-full left-0 right-0 z-20 mb-1 max-h-64 overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"
+      role="listbox"
+      aria-label={translate('components.terminal.richInput.files', 'Files')}
     >
       {loading ? (
         <div className="flex items-center gap-2 px-2 py-1.5 text-xs text-muted-foreground">
@@ -36,19 +42,24 @@ export function TerminalRichInputFileMenu({
         paths.map((path, index) => {
           const FileIcon = getFileTypeIcon(path)
           return (
-            <button
+            <Button
+              id={`${id}-option-${index}`}
               key={path}
               type="button"
+              variant="ghost"
+              size="sm"
+              role="option"
+              aria-selected={index === activeIndex}
               onMouseDown={(event) => event.preventDefault()}
               onClick={() => onChoose(path)}
               className={cn(
-                'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm',
+                'h-auto min-w-0 w-full justify-start rounded-sm px-2 py-1.5 text-left text-sm',
                 index === activeIndex ? 'bg-accent text-accent-foreground' : 'text-foreground'
               )}
             >
               <FileIcon className="size-3.5 shrink-0 text-muted-foreground" />
               <span className="truncate font-mono text-xs">{path}</span>
-            </button>
+            </Button>
           )
         })
       )}

--- a/src/renderer/src/components/terminal-pane/TerminalRichInputSendButton.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalRichInputSendButton.tsx
@@ -1,0 +1,41 @@
+import { ArrowUp, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { translate } from '@/i18n/i18n'
+
+export function TerminalRichInputSendButton({
+  sending,
+  disabled,
+  onSend
+}: {
+  sending: boolean
+  disabled: boolean
+  onSend: () => void
+}): React.JSX.Element {
+  const label = translate('components.terminal.richInput.send', 'Send to terminal')
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="ml-auto size-8 rounded-md border border-border text-muted-foreground shadow-none hover:bg-accent hover:text-accent-foreground"
+          data-terminal-rich-input-send=""
+          disabled={disabled}
+          onClick={onSend}
+          aria-label={label}
+        >
+          {sending ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <ArrowUp className="size-3.5" />
+          )}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={4}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/components/terminal-pane/TerminalRichInputSlashMenu.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalRichInputSlashMenu.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { describe, expect, it, vi } from 'vitest'
+import { TerminalRichInputSlashMenu } from './TerminalRichInputSlashMenu'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+describe('TerminalRichInputSlashMenu', () => {
+  it('never returns scrollIntoView as a React effect cleanup', async () => {
+    const scrollIntoView = vi.fn(() => false)
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView
+    })
+    const container = document.createElement('div')
+    const root = createRoot(container)
+
+    await act(async () => {
+      root.render(
+        <TerminalRichInputSlashMenu
+          suggestions={[{ name: 'clear', description: 'Clear conversation' }]}
+          activeIndex={0}
+          onChoose={() => {}}
+        />
+      )
+    })
+    expect(scrollIntoView).toHaveBeenCalledOnce()
+
+    expect(() => {
+      act(() => root.unmount())
+    }).not.toThrow()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/TerminalRichInputSlashMenu.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalRichInputSlashMenu.test.tsx
@@ -21,6 +21,7 @@ describe('TerminalRichInputSlashMenu', () => {
     await act(async () => {
       root.render(
         <TerminalRichInputSlashMenu
+          id="slash-menu"
           suggestions={[{ name: 'clear', description: 'Clear conversation' }]}
           activeIndex={0}
           onChoose={() => {}}
@@ -28,6 +29,9 @@ describe('TerminalRichInputSlashMenu', () => {
       )
     })
     expect(scrollIntoView).toHaveBeenCalledOnce()
+    expect(container.querySelector('[role="listbox"]')?.id).toBe('slash-menu')
+    expect(container.querySelector('[role="option"]')?.id).toBe('slash-menu-option-0')
+    expect(container.querySelector('[role="option"]')?.getAttribute('aria-selected')).toBe('true')
 
     expect(() => {
       act(() => root.unmount())

--- a/src/renderer/src/components/terminal-pane/TerminalRichInputSlashMenu.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalRichInputSlashMenu.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import type { SlashCommandSuggestion } from '../../../../shared/native-chat-slash-commands'
+
+export function TerminalRichInputSlashMenu({
+  suggestions,
+  activeIndex,
+  onChoose
+}: {
+  suggestions: readonly SlashCommandSuggestion[]
+  activeIndex: number
+  onChoose: (command: SlashCommandSuggestion) => void
+}): React.JSX.Element | null {
+  const activeRef = useRef<HTMLButtonElement | null>(null)
+  useEffect(() => {
+    activeRef.current?.scrollIntoView({ block: 'nearest' })
+  }, [activeIndex])
+  if (suggestions.length === 0) {
+    return null
+  }
+  return (
+    <div
+      className="scrollbar-sleek absolute bottom-full left-0 right-0 z-20 mb-1 max-h-64 overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"
+      data-terminal-rich-input-menu=""
+      role="listbox"
+      aria-label={translate('components.terminal.richInput.slashCommands', 'Slash commands')}
+    >
+      {suggestions.map((command, index) => (
+        <button
+          key={command.name}
+          ref={index === activeIndex ? activeRef : undefined}
+          type="button"
+          role="option"
+          aria-selected={index === activeIndex}
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => onChoose(command)}
+          className={cn(
+            'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm',
+            index === activeIndex ? 'bg-accent text-accent-foreground' : 'text-foreground'
+          )}
+        >
+          <span className="shrink-0 font-medium">/{command.name}</span>
+          {command.description ? (
+            <span className="truncate text-xs text-muted-foreground">{command.description}</span>
+          ) : null}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/terminal-pane/TerminalRichInputSlashMenu.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalRichInputSlashMenu.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useRef } from 'react'
+import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
 import type { SlashCommandSuggestion } from '../../../../shared/native-chat-slash-commands'
 
 export function TerminalRichInputSlashMenu({
+  id,
   suggestions,
   activeIndex,
   onChoose
 }: {
+  id: string
   suggestions: readonly SlashCommandSuggestion[]
   activeIndex: number
   onChoose: (command: SlashCommandSuggestion) => void
@@ -21,22 +24,26 @@ export function TerminalRichInputSlashMenu({
   }
   return (
     <div
+      id={id}
       className="scrollbar-sleek absolute bottom-full left-0 right-0 z-20 mb-1 max-h-64 overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"
       data-terminal-rich-input-menu=""
       role="listbox"
       aria-label={translate('components.terminal.richInput.slashCommands', 'Slash commands')}
     >
       {suggestions.map((command, index) => (
-        <button
+        <Button
+          id={`${id}-option-${index}`}
           key={command.name}
           ref={index === activeIndex ? activeRef : undefined}
           type="button"
+          variant="ghost"
+          size="sm"
           role="option"
           aria-selected={index === activeIndex}
           onMouseDown={(event) => event.preventDefault()}
           onClick={() => onChoose(command)}
           className={cn(
-            'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm',
+            'h-auto min-w-0 w-full justify-start rounded-sm px-2 py-1.5 text-left text-sm',
             index === activeIndex ? 'bg-accent text-accent-foreground' : 'text-foreground'
           )}
         >
@@ -44,7 +51,7 @@ export function TerminalRichInputSlashMenu({
           {command.description ? (
             <span className="truncate text-xs text-muted-foreground">{command.description}</span>
           ) : null}
-        </button>
+        </Button>
       ))}
     </div>
   )

--- a/src/renderer/src/components/terminal-pane/TerminalRichInputStatus.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalRichInputStatus.tsx
@@ -1,0 +1,25 @@
+import { SquareTerminal } from 'lucide-react'
+import { translate } from '@/i18n/i18n'
+
+export type TerminalRichInputSendError = 'not-started' | 'partially-written' | null
+
+export function TerminalRichInputStatus({
+  error
+}: {
+  error: TerminalRichInputSendError
+}): React.JSX.Element {
+  const text = error
+    ? error === 'partially-written'
+      ? translate(
+          'components.terminal.richInput.sendPartial',
+          'Part of the input was pasted. Check the terminal before retrying.'
+        )
+      : translate('components.terminal.richInput.sendFailed', 'Terminal input was not sent.')
+    : translate('components.terminal.richInput.hint', 'Enter to send · Shift+Enter for newline')
+  return (
+    <>
+      <SquareTerminal className="size-3.5 text-muted-foreground" />
+      <span className="text-xs text-muted-foreground">{text}</span>
+    </>
+  )
+}

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -202,6 +202,7 @@ type KeyboardHandlersDeps = {
   onClearPaneScrollback: (pane: ManagedPane) => void
   onSetTitle: (paneId: number) => void
   onClearPaneTitle: (paneId: number) => void
+  onToggleRichInput: () => void
   searchOpenRef: React.RefObject<boolean>
   searchStateRef: React.RefObject<SearchState>
   macOptionAsAltRef: React.RefObject<MacOptionAsAlt>
@@ -237,6 +238,7 @@ export function useTerminalKeyboardShortcuts({
   onClearPaneScrollback,
   onSetTitle,
   onClearPaneTitle,
+  onToggleRichInput,
   searchOpenRef,
   searchStateRef,
   macOptionAsAltRef,
@@ -345,6 +347,21 @@ export function useTerminalKeyboardShortcuts({
         }
         runTerminalSearchNavigation(pane, direction, searchStateRef.current)
         pane.terminal.focus()
+        return
+      }
+
+      // The same binding closes the composer while its textarea is focused, so
+      // this check must run before editable targets return to native text input.
+      if (
+        !e.repeat &&
+        keybindingMatchesAction('terminal.richInput.toggle', e, shortcutPlatform, keybindings, {
+          context: 'terminal',
+          terminalShortcutPolicy
+        })
+      ) {
+        e.preventDefault()
+        e.stopImmediatePropagation()
+        onToggleRichInput()
         return
       }
 
@@ -687,6 +704,7 @@ export function useTerminalKeyboardShortcuts({
     onClearPaneScrollback,
     onSetTitle,
     onClearPaneTitle,
+    onToggleRichInput,
     searchOpenRef,
     searchStateRef,
     macOptionAsAltRef,

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -28,6 +28,7 @@ import {
   resetAgentStartupDelayedDeliveryForTests
 } from '@/lib/agent-startup-delayed-delivery'
 import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
+import { requestPaneTuiRepaint } from '@/lib/pane-manager/pane-tui-repaint-request'
 
 // Repro command:
 //   pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "OpenTUI-style small ANSI redraw"
@@ -15281,6 +15282,36 @@ describe('connectPanePty', () => {
     expect(transport.resize).toHaveBeenCalledWith(132, 40)
     expect(transport.resize).toHaveBeenCalledWith(133, 40)
     expect(signalPty).not.toHaveBeenCalledWith('pty-id', 'SIGWINCH')
+    disposable.dispose()
+  })
+
+  it('reasserts only the settled alternate-screen size through normal resize routing', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    transportFactoryQueue.push(transport)
+    const pane = createPane(1)
+    pane.terminal.cols = 133
+    pane.terminal.rows = 47
+    ;(pane.terminal.buffer.active as { type: 'normal' | 'alternate' }).type = 'alternate'
+    const manager = createManager(1)
+    const disposable = connectPanePty(
+      pane as never,
+      manager as never,
+      createDeps({ isVisibleRef: { current: true } }) as never
+    )
+    await flushAsyncTicks(6)
+    transport.resize.mockClear()
+
+    requestPaneTuiRepaint(pane.container, { cols: 133, rows: 47 })
+
+    expect(transport.resize).toHaveBeenCalledOnce()
+    expect(transport.resize).toHaveBeenCalledWith(133, 47, { claim: true })
+
+    requestPaneTuiRepaint(pane.container, { cols: 132, rows: 47 })
+    expect(transport.resize).toHaveBeenCalledOnce()
+    ;(pane.terminal.buffer.active as { type: 'normal' | 'alternate' }).type = 'normal'
+    requestPaneTuiRepaint(pane.container, { cols: 133, rows: 47 })
+    expect(transport.resize).toHaveBeenCalledOnce()
     disposable.dispose()
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -109,6 +109,10 @@ import {
   type PanePtyResizeHoldFlushDetail
 } from '@/lib/pane-manager/pane-pty-resize-hold'
 import {
+  PANE_TUI_REPAINT_REQUEST_EVENT,
+  type PaneTuiRepaintRequestDetail
+} from '@/lib/pane-manager/pane-tui-repaint-request'
+import {
   buildPostReplayLiveAgentReattachReset,
   POST_REPLAY_LIVE_AGENT_SNAPSHOT_RESET,
   POST_REPLAY_LIVE_SNAPSHOT_RESET,
@@ -4065,6 +4069,20 @@ export function connectPanePty(
     forwardPtyResize(detail.cols, detail.rows)
   }
   pane.container.addEventListener(PANE_PTY_RESIZE_HOLD_FLUSH_EVENT, onHeldPtyResizeFlush)
+  const onTuiRepaintRequest = (event: Event): void => {
+    const detail = (event as CustomEvent<PaneTuiRepaintRequestDetail>).detail
+    if (
+      detail &&
+      detail.cols === pane.terminal.cols &&
+      detail.rows === pane.terminal.rows &&
+      pane.terminal.buffer.active.type === 'alternate'
+    ) {
+      // Reassert only the settled size through the normal authority/hold path;
+      // transient dimensions can strand delayed SSH or runtime resize relays.
+      forwardPtyResize(detail.cols, detail.rows)
+    }
+  }
+  pane.container.addEventListener(PANE_TUI_REPAINT_REQUEST_EVENT, onTuiRepaintRequest)
 
   const onResizeDisposable = pane.terminal.onResize(({ cols, rows }) => {
     if (suppressStructuralReplayPtyResize || suppressViewportClaimTerminalResize) {
@@ -8787,6 +8805,7 @@ export function connectPanePty(
       onResizeDisposable.dispose()
       onBufferChangeDisposable?.dispose()
       pane.container.removeEventListener(PANE_PTY_RESIZE_HOLD_FLUSH_EVENT, onHeldPtyResizeFlush)
+      pane.container.removeEventListener(PANE_TUI_REPAINT_REQUEST_EVENT, onTuiRepaintRequest)
       geometryReportObserver?.disconnect()
       if (pendingGeometryReportRaf !== null) {
         cancelAnimationFrame(pendingGeometryReportRaf)

--- a/src/renderer/src/components/terminal-pane/terminal-drop-handler.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-handler.test.ts
@@ -164,6 +164,38 @@ describe('handleTerminalFileDrop', () => {
     expect(mocks.toastDismiss).toHaveBeenCalledWith('toast-1')
   })
 
+  it('routes resolved runtime paths to an open rich-input composer without PTY writes', async () => {
+    mocks.importExternalPathsToRuntime.mockResolvedValue({
+      results: [
+        {
+          sourcePath: '/Users/me/logo.png',
+          status: 'imported',
+          destPath: '/remote/repo/.orca/drops/logo.png',
+          kind: 'file',
+          renamed: false
+        }
+      ]
+    })
+    const sendInput = vi.fn(() => true)
+    const onResolvedPaths = vi.fn()
+    const pane = { id: 1, leafId: 'leaf-1', terminal: { focus: vi.fn() } }
+    const manager = { getActivePane: () => pane, getPanes: () => [pane] }
+
+    await handleTerminalFileDrop({
+      manager: manager as never,
+      paneTransports: new Map([[1, createTerminalTransport(sendInput)]]) as never,
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      cwd: undefined,
+      data: { paths: ['/Users/me/logo.png'], target: 'terminal' },
+      onResolvedPaths
+    })
+
+    expect(onResolvedPaths).toHaveBeenCalledWith(['/remote/repo/.orca/drops/logo.png'])
+    expect(sendInput).not.toHaveBeenCalled()
+    expect(mocks.recordTerminalUserInputForLeaf).not.toHaveBeenCalled()
+  })
+
   it('does not paste runtime-uploaded paths when the target PTY changed', async () => {
     let ptyId = 'pty-1'
     mocks.importExternalPathsToRuntime.mockImplementation(async () => {

--- a/src/renderer/src/components/terminal-pane/terminal-drop-handler.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-handler.test.ts
@@ -177,7 +177,7 @@ describe('handleTerminalFileDrop', () => {
       ]
     })
     const sendInput = vi.fn(() => true)
-    const onResolvedPaths = vi.fn()
+    const onResolvedPaths = vi.fn(() => true)
     const pane = { id: 1, leafId: 'leaf-1', terminal: { focus: vi.fn() } }
     const manager = { getActivePane: () => pane, getPanes: () => [pane] }
 
@@ -194,6 +194,39 @@ describe('handleTerminalFileDrop', () => {
     expect(onResolvedPaths).toHaveBeenCalledWith(['/remote/repo/.orca/drops/logo.png'])
     expect(sendInput).not.toHaveBeenCalled()
     expect(mocks.recordTerminalUserInputForLeaf).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the captured PTY when rich input closes during path resolution', async () => {
+    mocks.importExternalPathsToRuntime.mockResolvedValue({
+      results: [
+        {
+          sourcePath: '/Users/me/logo.png',
+          status: 'imported',
+          destPath: '/remote/repo/.orca/drops/logo.png',
+          kind: 'file',
+          renamed: false
+        }
+      ]
+    })
+    const sendInput = vi.fn(() => true)
+    const onResolvedPaths = vi.fn(() => false)
+    const pane = { id: 1, leafId: 'leaf-1', terminal: { focus: vi.fn() } }
+    const manager = { getActivePane: () => pane, getPanes: () => [pane] }
+
+    await handleTerminalFileDrop({
+      manager: manager as never,
+      paneTransports: new Map([[1, createTerminalTransport(sendInput)]]) as never,
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      cwd: undefined,
+      data: { paths: ['/Users/me/logo.png'], target: 'terminal' },
+      onResolvedPaths
+    })
+
+    expect(sendInput).toHaveBeenCalledWith(
+      wrapTerminalBracketedPasteText('/remote/repo/.orca/drops/logo.png')
+    )
+    expect(mocks.recordTerminalUserInputForLeaf).toHaveBeenCalledWith('tab-1', 'leaf-1')
   })
 
   it('does not paste runtime-uploaded paths when the target PTY changed', async () => {

--- a/src/renderer/src/components/terminal-pane/terminal-native-file-drop.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-native-file-drop.ts
@@ -36,6 +36,7 @@ export type NativeTerminalFileDropArgs = {
   tabId: string
   cwd: string | undefined
   data: { paths: string[]; target: string; tabId?: string; paneLeafId?: string }
+  onResolvedPaths?: (paths: string[]) => void | Promise<void>
 }
 
 /**
@@ -60,7 +61,7 @@ export async function handleNativeTerminalFileDrop(
 async function handleNativeTerminalFileDropWithCapturedOwner(
   args: NativeTerminalFileDropArgs
 ): Promise<void> {
-  const { manager, paneTransports, worktreeId, tabId, cwd, data } = args
+  const { manager, paneTransports, worktreeId, tabId, cwd, data, onResolvedPaths } = args
   if (data.paths.length === 0) {
     return
   }
@@ -92,6 +93,7 @@ async function handleNativeTerminalFileDropWithCapturedOwner(
       dataPaths: data.paths,
       dropTarget,
       manager,
+      onResolvedPaths,
       paneTransports,
       pane,
       settings,
@@ -132,6 +134,7 @@ async function handleNativeTerminalFileDropWithCapturedOwner(
       dropTarget,
       localWslDrop,
       manager,
+      onResolvedPaths,
       paneTransports,
       pane,
       tabId,
@@ -147,6 +150,7 @@ async function handleNativeTerminalFileDropWithCapturedOwner(
     dataPaths: data.paths,
     dropTarget,
     manager,
+    onResolvedPaths,
     paneTransports,
     pane,
     tabId,
@@ -159,6 +163,7 @@ type NativeDropFlowArgs = {
   dataPaths: string[]
   dropTarget: ReturnType<typeof captureTerminalDropTarget>
   manager: PaneManager
+  onResolvedPaths?: (paths: string[]) => void | Promise<void>
   paneTransports: Map<number, PtyTransport>
   pane: ReturnType<typeof resolveNativeTerminalDropPane> & {}
   tabId: string
@@ -287,6 +292,10 @@ async function pasteResolvedDropPaths(
     args.dropTarget
   )
   if (!liveTransport) {
+    return
+  }
+  if (args.onResolvedPaths) {
+    await args.onResolvedPaths(args.paths)
     return
   }
   const writeResult = await writeTerminalDropPathsToCapturedTarget({

--- a/src/renderer/src/components/terminal-pane/terminal-native-file-drop.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-native-file-drop.ts
@@ -36,7 +36,7 @@ export type NativeTerminalFileDropArgs = {
   tabId: string
   cwd: string | undefined
   data: { paths: string[]; target: string; tabId?: string; paneLeafId?: string }
-  onResolvedPaths?: (paths: string[]) => void | Promise<void>
+  onResolvedPaths?: (paths: string[]) => boolean | Promise<boolean>
 }
 
 /**
@@ -163,7 +163,7 @@ type NativeDropFlowArgs = {
   dataPaths: string[]
   dropTarget: ReturnType<typeof captureTerminalDropTarget>
   manager: PaneManager
-  onResolvedPaths?: (paths: string[]) => void | Promise<void>
+  onResolvedPaths?: (paths: string[]) => boolean | Promise<boolean>
   paneTransports: Map<number, PtyTransport>
   pane: ReturnType<typeof resolveNativeTerminalDropPane> & {}
   tabId: string
@@ -294,8 +294,7 @@ async function pasteResolvedDropPaths(
   if (!liveTransport) {
     return
   }
-  if (args.onResolvedPaths) {
-    await args.onResolvedPaths(args.paths)
+  if (args.onResolvedPaths && (await args.onResolvedPaths(args.paths))) {
     return
   }
   const writeResult = await writeTerminalDropPathsToCapturedTarget({

--- a/src/renderer/src/components/terminal-pane/terminal-paste-overlay-target.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-overlay-target.test.ts
@@ -1,0 +1,21 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { terminalPasteIsOwnedByOverlay } from './terminal-paste-overlay-target'
+
+describe('terminalPasteIsOwnedByOverlay', () => {
+  it.each([
+    '<div class="terminal-rich-input-dock"><div class="editor"></div></div>',
+    '<div data-native-chat-root="true"><textarea></textarea></div>',
+    '<div data-terminal-search-root><input></div>'
+  ])('keeps paste inside higher-level terminal editors', (markup) => {
+    const root = document.createElement('div')
+    root.innerHTML = markup
+    expect(terminalPasteIsOwnedByOverlay(root.querySelector('div, textarea, input'))).toBe(true)
+  })
+
+  it('leaves raw xterm paste routing enabled', () => {
+    const textarea = document.createElement('textarea')
+    textarea.className = 'xterm-helper-textarea'
+    expect(terminalPasteIsOwnedByOverlay(textarea)).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-paste-overlay-target.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-overlay-target.ts
@@ -1,0 +1,10 @@
+const TERMINAL_PASTE_OVERLAY_SELECTOR = [
+  '[data-terminal-search-root]',
+  '[data-native-chat-root="true"]',
+  '.terminal-rich-input-dock'
+].join(',')
+
+/** Whether a higher-level terminal editor owns paste instead of the raw PTY. */
+export function terminalPasteIsOwnedByOverlay(target: EventTarget | null): boolean {
+  return target instanceof Element && target.closest(TERMINAL_PASTE_OVERLAY_SELECTOR) !== null
+}

--- a/src/renderer/src/components/terminal-pane/terminal-programmatic-text-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-programmatic-text-paste.ts
@@ -1,5 +1,5 @@
 import type { PasteTerminalTextDetail } from '@/constants/terminal'
-import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { PtyTransport } from './pty-transport'
 import { getConnectionId } from '@/lib/connection-context'
 import { pasteTerminalText } from './terminal-bracketed-paste'
@@ -16,6 +16,77 @@ type HandleTerminalProgrammaticTextPasteArgs = {
   worktreeId: string
   getManager: () => PaneManager | null
   getPaneTransports: () => Map<number, PtyTransport>
+}
+
+export type PasteTextIntoTerminalPaneArgs = {
+  text: string
+  tabId: string
+  worktreeId: string
+  pane: ManagedPane
+  transport: PtyTransport | undefined
+  getManager: () => PaneManager | null
+  getPaneTransports: () => Map<number, PtyTransport>
+  focusAfterPaste?: boolean
+  forceBracketedPaste?: boolean
+}
+
+/** Runs programmatic composer/file pastes through the same bounded local/remote path. */
+export async function pasteTextIntoTerminalPane({
+  text,
+  tabId,
+  worktreeId,
+  pane,
+  transport,
+  getManager,
+  getPaneTransports,
+  focusAfterPaste = false,
+  forceBracketedPaste = false
+}: PasteTextIntoTerminalPaneArgs): Promise<boolean> {
+  const ptyId = transport?.getPtyId() ?? null
+  const platform = getShortcutPlatform()
+  const connectionId = getConnectionId(worktreeId) ?? null
+  const plan = await planTerminalPasteWithYield({
+    text,
+    source: 'programmatic',
+    target: {
+      kind: 'terminal',
+      paneId: pane.id,
+      leafId: pane.leafId,
+      ptyId,
+      runtime: resolveTerminalPasteRuntime({
+        platform,
+        ptyId,
+        connectionId,
+        remotePlatform: getTerminalPasteSshRemotePlatform(connectionId),
+        transport
+      })
+    },
+    terminalBracketedPasteMode: pane.terminal.modes?.bracketedPasteMode === true,
+    forceBracketedPaste
+  })
+  const targetIsCurrent = (): boolean =>
+    isTerminalPanePasteTargetCurrent({
+      manager: getManager(),
+      paneTransports: getPaneTransports(),
+      paneId: pane.id,
+      leafId: pane.leafId,
+      transport,
+      ptyId
+    })
+  const result = await executeTerminalPastePlan(plan, {
+    pasteText: (nextText, options) => pasteTerminalText(pane.terminal, nextText, options),
+    writePty: (data) => writeTerminalPastePtyInput(transport, data),
+    isTargetCurrent: targetIsCurrent,
+    canContinue: targetIsCurrent
+  })
+  if (result.status !== 'pasted') {
+    return false
+  }
+  recordTerminalUserInputForLeaf(tabId, pane.leafId)
+  if (focusAfterPaste) {
+    pane.terminal.focus()
+  }
+  return true
 }
 
 export function handleTerminalProgrammaticTextPaste({
@@ -40,60 +111,16 @@ export function handleTerminalProgrammaticTextPaste({
   if (!pane) {
     return
   }
-  const paneTransports = getPaneTransports()
-  const transport = paneTransports.get(pane.id)
-  const ptyId = transport?.getPtyId() ?? null
-  const platform = getShortcutPlatform()
-  const connectionId = getConnectionId(worktreeId) ?? null
-  void planTerminalPasteWithYield({
+  void pasteTextIntoTerminalPane({
     text: detail.text,
-    source: 'programmatic',
-    target: {
-      kind: 'terminal',
-      paneId: pane.id,
-      leafId: pane.leafId,
-      ptyId,
-      runtime: resolveTerminalPasteRuntime({
-        platform,
-        ptyId,
-        connectionId,
-        remotePlatform: getTerminalPasteSshRemotePlatform(connectionId),
-        transport
-      })
-    },
-    terminalBracketedPasteMode: pane.terminal.modes?.bracketedPasteMode === true
+    tabId,
+    worktreeId,
+    pane,
+    transport: getPaneTransports().get(pane.id),
+    getManager,
+    getPaneTransports,
+    focusAfterPaste: true
   })
-    .then((plan) =>
-      executeTerminalPastePlan(plan, {
-        pasteText: (text, options) => pasteTerminalText(pane.terminal, text, options),
-        writePty: (data) => writeTerminalPastePtyInput(transport, data),
-        isTargetCurrent: () =>
-          isTerminalPanePasteTargetCurrent({
-            manager: getManager(),
-            paneTransports: getPaneTransports(),
-            paneId: pane.id,
-            leafId: pane.leafId,
-            transport,
-            ptyId
-          }),
-        canContinue: () =>
-          isTerminalPanePasteTargetCurrent({
-            manager: getManager(),
-            paneTransports: getPaneTransports(),
-            paneId: pane.id,
-            leafId: pane.leafId,
-            transport,
-            ptyId
-          })
-      })
-    )
-    .then((result) => {
-      if (result.status !== 'pasted') {
-        return
-      }
-      recordTerminalUserInputForLeaf(tabId, pane.leafId)
-      pane.terminal.focus()
-    })
 }
 
 function getShortcutPlatform(userAgent = globalThis.navigator?.userAgent ?? ''): NodeJS.Platform {

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-attachment-cache.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-attachment-cache.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  clearTerminalRichInputAttachmentCacheForTests,
+  readTerminalRichInputAttachments,
+  writeTerminalRichInputAttachments
+} from './terminal-rich-input-attachment-cache'
+
+describe('terminal rich input attachment cache', () => {
+  beforeEach(clearTerminalRichInputAttachmentCacheForTests)
+
+  it('keeps pending images scoped to one terminal leaf', () => {
+    writeTerminalRichInputAttachments('tab:leaf-a', [{ id: '1', path: '/tmp/image.png' }])
+
+    expect(readTerminalRichInputAttachments('tab:leaf-a')).toEqual([
+      { id: '1', path: '/tmp/image.png' }
+    ])
+    expect(readTerminalRichInputAttachments('tab:leaf-b')).toEqual([])
+  })
+
+  it('returns defensive copies and deletes empty entries', () => {
+    writeTerminalRichInputAttachments('scope', [{ id: '1', path: '/tmp/image.png' }])
+    const first = readTerminalRichInputAttachments('scope')
+    first.length = 0
+    expect(readTerminalRichInputAttachments('scope')).toHaveLength(1)
+
+    writeTerminalRichInputAttachments('scope', [])
+    expect(readTerminalRichInputAttachments('scope')).toEqual([])
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-attachment-cache.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-attachment-cache.ts
@@ -1,0 +1,42 @@
+export type TerminalRichInputImageAttachment = {
+  id: string
+  path: string
+  previewSrc?: string
+}
+
+const MAX_TERMINAL_RICH_INPUT_ATTACHMENT_SCOPES = 128
+const attachmentCache = new Map<string, TerminalRichInputImageAttachment[]>()
+
+export function readTerminalRichInputAttachments(
+  scopeKey: string
+): TerminalRichInputImageAttachment[] {
+  const attachments = attachmentCache.get(scopeKey) ?? []
+  if (attachments.length > 0) {
+    attachmentCache.delete(scopeKey)
+    attachmentCache.set(scopeKey, attachments)
+  }
+  return [...attachments]
+}
+
+export function writeTerminalRichInputAttachments(
+  scopeKey: string,
+  attachments: readonly TerminalRichInputImageAttachment[]
+): void {
+  if (attachments.length === 0) {
+    attachmentCache.delete(scopeKey)
+    return
+  }
+  attachmentCache.delete(scopeKey)
+  attachmentCache.set(scopeKey, [...attachments])
+  while (attachmentCache.size > MAX_TERMINAL_RICH_INPUT_ATTACHMENT_SCOPES) {
+    const oldest = attachmentCache.keys().next().value
+    if (typeof oldest !== 'string') {
+      break
+    }
+    attachmentCache.delete(oldest)
+  }
+}
+
+export function clearTerminalRichInputAttachmentCacheForTests(): void {
+  attachmentCache.clear()
+}

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-autocomplete.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-autocomplete.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import {
+  findTerminalRichInputMentionQuery,
+  findTerminalRichInputSlashQuery
+} from './terminal-rich-input-autocomplete'
+
+function editorWithText(text: string): Editor {
+  const editor = new Editor({
+    extensions: [StarterKit],
+    content: {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text }] }]
+    }
+  })
+  editor.commands.setTextSelection(text.length + 1)
+  return editor
+}
+
+describe('terminal rich input autocomplete queries', () => {
+  it('finds file mentions and slash commands at the caret', () => {
+    const mentionEditor = editorWithText('review @src')
+    const slashEditor = editorWithText('/comp')
+
+    expect(findTerminalRichInputMentionQuery(mentionEditor as never)?.query).toBe('src')
+    expect(findTerminalRichInputSlashQuery(slashEditor as never)?.query).toBe('comp')
+  })
+
+  it('only triggers slash commands in the absolute first token', () => {
+    for (const text of ['https://example.com', 'please /comp', ' /comp']) {
+      const editor = editorWithText(text)
+      expect(findTerminalRichInputSlashQuery(editor as never)).toBeNull()
+    }
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-autocomplete.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-autocomplete.ts
@@ -1,0 +1,40 @@
+import type { Editor } from '@tiptap/react'
+
+export type TerminalRichInputQuery = {
+  from: number
+  to: number
+  query: string
+}
+
+export function findTerminalRichInputMentionQuery(editor: Editor): TerminalRichInputQuery | null {
+  return findTerminalRichInputQuery(editor, '@')
+}
+
+export function findTerminalRichInputSlashQuery(editor: Editor): TerminalRichInputQuery | null {
+  const { from } = editor.state.selection
+  const before = editor.state.doc.textBetween(0, from, '\n', '\ufffc')
+  const match = before.match(/^\/(\S*)$/)
+  if (!match) {
+    return null
+  }
+  const query = match[1]
+  return { from: from - query.length - 1, to: from, query }
+}
+
+function findTerminalRichInputQuery(editor: Editor, trigger: '@'): TerminalRichInputQuery | null {
+  const { $from } = editor.state.selection
+  if (!$from.parent.isTextblock) {
+    return null
+  }
+  const before = $from.parent.textBetween(0, $from.parentOffset, undefined, '\ufffc')
+  const match = before.match(new RegExp(`(^|\\s)${trigger}(\\S*)$`))
+  if (!match) {
+    return null
+  }
+  const query = match[2]
+  return {
+    from: editor.state.selection.from - query.length - 1,
+    to: editor.state.selection.from,
+    query
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-draft.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-draft.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  clearTerminalRichInputDraftsForTests,
+  readTerminalRichInputDraft,
+  writeTerminalRichInputDraft
+} from './terminal-rich-input-draft'
+
+describe('terminal rich input drafts', () => {
+  beforeEach(() => clearTerminalRichInputDraftsForTests())
+
+  it('keeps independent drafts for stable terminal leaves', () => {
+    writeTerminalRichInputDraft('tab-1:leaf-a', 'first')
+    writeTerminalRichInputDraft('tab-1:leaf-b', 'second')
+
+    expect(readTerminalRichInputDraft('tab-1:leaf-a')).toBe('first')
+    expect(readTerminalRichInputDraft('tab-1:leaf-b')).toBe('second')
+  })
+
+  it('drops an empty draft', () => {
+    writeTerminalRichInputDraft('tab-1:leaf-a', 'first')
+    writeTerminalRichInputDraft('tab-1:leaf-a', '')
+
+    expect(readTerminalRichInputDraft('tab-1:leaf-a')).toBe('')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-draft.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-draft.ts
@@ -1,0 +1,31 @@
+const MAX_TERMINAL_RICH_INPUT_DRAFTS = 128
+const drafts = new Map<string, string>()
+
+export function readTerminalRichInputDraft(scopeKey: string): string {
+  const draft = drafts.get(scopeKey) ?? ''
+  if (draft) {
+    // Refresh insertion order so active panes survive bounded eviction.
+    drafts.delete(scopeKey)
+    drafts.set(scopeKey, draft)
+  }
+  return draft
+}
+
+export function writeTerminalRichInputDraft(scopeKey: string, draft: string): void {
+  drafts.delete(scopeKey)
+  if (!draft) {
+    return
+  }
+  drafts.set(scopeKey, draft)
+  while (drafts.size > MAX_TERMINAL_RICH_INPUT_DRAFTS) {
+    const oldest = drafts.keys().next().value
+    if (typeof oldest !== 'string') {
+      break
+    }
+    drafts.delete(oldest)
+  }
+}
+
+export function clearTerminalRichInputDraftsForTests(): void {
+  drafts.clear()
+}

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-keydown.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-keydown.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest'
+import { handleTerminalRichInputKeyDown } from './terminal-rich-input-keydown'
+
+function context() {
+  return {
+    mentionRef: { current: null },
+    slashRef: { current: { from: 1, to: 4, query: 'cl' } },
+    fileSuggestionsRef: { current: [] as string[] },
+    slashSuggestionsRef: {
+      current: [{ name: 'clear', description: 'Clear conversation' }]
+    },
+    activeSuggestionRef: { current: 0 },
+    setActiveSuggestion: vi.fn(),
+    pasteImageFromClipboard: vi.fn(),
+    chooseFile: vi.fn(),
+    chooseSlash: vi.fn(),
+    closeAutocomplete: vi.fn(),
+    closeComposer: vi.fn(),
+    submit: vi.fn()
+  }
+}
+
+describe('terminal rich input keydown', () => {
+  it('probes for native clipboard images without consuming Cmd/Ctrl+V', () => {
+    const ctx = context()
+    const event = new KeyboardEvent('keydown', { key: 'v', metaKey: true })
+
+    expect(handleTerminalRichInputKeyDown(event, ctx)).toBe(false)
+    expect(ctx.pasteImageFromClipboard).toHaveBeenCalledOnce()
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('dispatches the selected slash command on Enter', () => {
+    const ctx = context()
+    const event = new KeyboardEvent('keydown', { key: 'Enter', cancelable: true })
+
+    expect(handleTerminalRichInputKeyDown(event, ctx)).toBe(true)
+    expect(ctx.chooseSlash).toHaveBeenCalledWith(ctx.slashSuggestionsRef.current[0], true)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-keydown.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-keydown.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { handleTerminalRichInputKeyDown } from './terminal-rich-input-keydown'
 
 function context() {
@@ -22,13 +22,27 @@ function context() {
 }
 
 describe('terminal rich input keydown', () => {
-  it('probes for native clipboard images without consuming Cmd/Ctrl+V', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('probes for native clipboard images without consuming Cmd+V on macOS', () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('Macintosh')
     const ctx = context()
     const event = new KeyboardEvent('keydown', { key: 'v', metaKey: true })
 
     expect(handleTerminalRichInputKeyDown(event, ctx)).toBe(false)
     expect(ctx.pasteImageFromClipboard).toHaveBeenCalledOnce()
     expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('uses Ctrl+V and ignores Windows+V on non-Mac platforms', () => {
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue('Windows')
+    const ctx = context()
+
+    handleTerminalRichInputKeyDown(new KeyboardEvent('keydown', { key: 'v', metaKey: true }), ctx)
+    expect(ctx.pasteImageFromClipboard).not.toHaveBeenCalled()
+
+    handleTerminalRichInputKeyDown(new KeyboardEvent('keydown', { key: 'v', ctrlKey: true }), ctx)
+    expect(ctx.pasteImageFromClipboard).toHaveBeenCalledOnce()
   })
 
   it('dispatches the selected slash command on Enter', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-keydown.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-keydown.ts
@@ -1,0 +1,80 @@
+import type { RefObject } from 'react'
+import type { SlashCommandSuggestion } from '../../../../shared/native-chat-slash-commands'
+import type { TerminalRichInputQuery } from './terminal-rich-input-autocomplete'
+
+type TerminalRichInputKeydownContext = {
+  mentionRef: RefObject<TerminalRichInputQuery | null>
+  slashRef: RefObject<TerminalRichInputQuery | null>
+  fileSuggestionsRef: RefObject<string[]>
+  slashSuggestionsRef: RefObject<SlashCommandSuggestion[]>
+  activeSuggestionRef: RefObject<number>
+  setActiveSuggestion: (update: (index: number) => number) => void
+  pasteImageFromClipboard: () => void
+  chooseFile: (path: string) => void
+  chooseSlash: (command: SlashCommandSuggestion, submit: boolean) => void
+  closeAutocomplete: () => void
+  closeComposer: () => void
+  submit: () => void
+}
+
+export function handleTerminalRichInputKeyDown(
+  event: KeyboardEvent,
+  context: TerminalRichInputKeydownContext
+): boolean {
+  if (event.isComposing) {
+    return false
+  }
+  if (event.key.toLowerCase() === 'v' && (event.metaKey || event.ctrlKey)) {
+    // Native Electron image clipboards can omit the DOM paste payload. Probe
+    // first, but the attachment hook does not block text paste unless an image exists.
+    context.pasteImageFromClipboard()
+  }
+  const currentMention = context.mentionRef.current
+  const fileSuggestions = context.fileSuggestionsRef.current
+  const currentSlash = context.slashRef.current
+  const slashSuggestions = context.slashSuggestionsRef.current
+  const suggestionCount = currentMention
+    ? fileSuggestions.length
+    : currentSlash
+      ? slashSuggestions.length
+      : 0
+  if (suggestionCount > 0 && (event.key === 'ArrowDown' || event.key === 'ArrowUp')) {
+    event.preventDefault()
+    const direction = event.key === 'ArrowDown' ? 1 : -1
+    context.setActiveSuggestion((index) => (index + direction + suggestionCount) % suggestionCount)
+    return true
+  }
+  if (currentMention && fileSuggestions.length > 0) {
+    if (event.key === 'Tab' || (event.key === 'Enter' && !event.shiftKey)) {
+      event.preventDefault()
+      context.chooseFile(fileSuggestions[context.activeSuggestionRef.current] ?? fileSuggestions[0])
+      return true
+    }
+  }
+  if (currentSlash && slashSuggestions.length > 0) {
+    if (event.key === 'Tab' || (event.key === 'Enter' && !event.shiftKey)) {
+      event.preventDefault()
+      context.chooseSlash(
+        slashSuggestions[context.activeSuggestionRef.current] ?? slashSuggestions[0],
+        event.key === 'Enter'
+      )
+      return true
+    }
+  }
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    event.stopPropagation()
+    if (currentMention || currentSlash) {
+      context.closeAutocomplete()
+    } else {
+      context.closeComposer()
+    }
+    return true
+  }
+  if (event.key === 'Enter' && !event.shiftKey) {
+    event.preventDefault()
+    context.submit()
+    return true
+  }
+  return false
+}

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-keydown.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-keydown.ts
@@ -24,7 +24,8 @@ export function handleTerminalRichInputKeyDown(
   if (event.isComposing) {
     return false
   }
-  if (event.key.toLowerCase() === 'v' && (event.metaKey || event.ctrlKey)) {
+  const pasteModifier = navigator.userAgent.includes('Mac') ? event.metaKey : event.ctrlKey
+  if (event.key.toLowerCase() === 'v' && pasteModifier) {
     // Native Electron image clipboards can omit the DOM paste payload. Probe
     // first, but the attachment hook does not block text paste unless an image exists.
     context.pasteImageFromClipboard()

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-model.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-model.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import {
+  terminalRichInputContentToText,
+  terminalRichInputPathsToContent,
+  terminalRichInputTextToContent
+} from './terminal-rich-input-model'
+
+describe('terminal rich input model', () => {
+  it('parses file references into atomic editor nodes', () => {
+    expect(terminalRichInputTextToContent('Review @src/app.ts and @"design notes.md"')).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Review ' },
+            { type: 'terminalFileMention', attrs: { path: 'src/app.ts' } },
+            { type: 'text', text: ' and ' },
+            { type: 'terminalFileMention', attrs: { path: 'design notes.md' } }
+          ]
+        }
+      ]
+    })
+  })
+
+  it('round trips multiline text and quoted file references', () => {
+    const text = 'Review @src/app.ts\nThen open @"design notes.md"'
+    expect(terminalRichInputContentToText(terminalRichInputTextToContent(text))).toBe(text)
+  })
+
+  it('leaves email addresses as ordinary text', () => {
+    const content = terminalRichInputTextToContent('Ask dev@example.com about @src/app.ts')
+    expect(content.content?.[0].content?.[0]).toEqual({
+      type: 'text',
+      text: 'Ask dev@example.com about '
+    })
+    expect(terminalRichInputContentToText(content)).toBe('Ask dev@example.com about @src/app.ts')
+  })
+
+  it('keeps typed at-sign tokens as plain shell text when references are disabled', () => {
+    expect(terminalRichInputTextToContent('echo @release', false)).toEqual({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'echo @release' }] }]
+    })
+  })
+
+  it('inserts plain quoted paths instead of agent mentions for ordinary shells', () => {
+    expect(
+      terminalRichInputPathsToContent(['/repo/file.ts', '/repo/design notes.md'], false)
+    ).toEqual([
+      { type: 'text', text: '/repo/file.ts ' },
+      { type: 'text', text: '"/repo/design notes.md" ' }
+    ])
+  })
+
+  it('serializes multiple editor paragraphs as terminal prompt lines', () => {
+    expect(
+      terminalRichInputContentToText({
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [{ type: 'text', text: 'first' }] },
+          { type: 'paragraph', content: [{ type: 'text', text: 'second' }] }
+        ]
+      })
+    ).toBe('first\nsecond')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-model.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-model.ts
@@ -1,0 +1,78 @@
+import type { JSONContent } from '@tiptap/core'
+import { formatNativeChatFileReference } from '../native-chat/native-chat-composer-target'
+
+export const TERMINAL_RICH_INPUT_FILE_MENTION_NODE = 'terminalFileMention'
+
+export function terminalRichInputPathsToContent(
+  paths: string[],
+  useMentions: boolean
+): JSONContent[] {
+  if (useMentions) {
+    return paths.flatMap((path) => [
+      { type: TERMINAL_RICH_INPUT_FILE_MENTION_NODE, attrs: { path } },
+      { type: 'text', text: ' ' }
+    ])
+  }
+  return paths.map((path) => ({
+    type: 'text',
+    text: `${/\s/.test(path) ? `"${path.replaceAll('"', '\\"')}"` : path} `
+  }))
+}
+
+const FILE_REFERENCE_PATTERN = /(?<!\S)(?:@"((?:\\.|[^"])*)"|@(\S+))/g
+
+export function terminalRichInputTextToContent(
+  text: string,
+  parseFileReferences = true
+): JSONContent {
+  const content: JSONContent[] = []
+  if (!parseFileReferences) {
+    appendTextWithHardBreaks(content, text)
+    return { type: 'doc', content: [{ type: 'paragraph', content }] }
+  }
+  let textStart = 0
+  let match = FILE_REFERENCE_PATTERN.exec(text)
+  while (match) {
+    appendTextWithHardBreaks(content, text.slice(textStart, match.index))
+    content.push({
+      type: TERMINAL_RICH_INPUT_FILE_MENTION_NODE,
+      attrs: { path: match[1] ? match[1].replace(/\\"/g, '"') : match[2] }
+    })
+    textStart = match.index + match[0].length
+    match = FILE_REFERENCE_PATTERN.exec(text)
+  }
+  appendTextWithHardBreaks(content, text.slice(textStart))
+  return { type: 'doc', content: [{ type: 'paragraph', content }] }
+}
+
+export function terminalRichInputContentToText(doc: JSONContent): string {
+  if (doc.type === 'doc') {
+    return (doc.content ?? []).map(serializeBlock).join('\n')
+  }
+  return serializeBlock(doc)
+}
+
+function serializeBlock(node: JSONContent): string {
+  if (node.type === 'text') {
+    return node.text ?? ''
+  }
+  if (node.type === 'hardBreak') {
+    return '\n'
+  }
+  if (node.type === TERMINAL_RICH_INPUT_FILE_MENTION_NODE) {
+    return formatNativeChatFileReference(String(node.attrs?.path ?? ''))
+  }
+  return (node.content ?? []).map(serializeBlock).join('')
+}
+
+function appendTextWithHardBreaks(content: JSONContent[], text: string): void {
+  const lines = text.split('\n')
+  lines.forEach((line, index) => {
+    if (line) {
+      content.push({ type: 'text', text: line })
+    }
+    if (index < lines.length - 1) {
+      content.push({ type: 'hardBreak' })
+    }
+  })
+}

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-native-drop.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-native-drop.ts
@@ -1,0 +1,47 @@
+import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import { resolveNativeTerminalDropPane } from './terminal-drop-pane-resolution'
+import { isImageDropPath } from './terminal-drop-image-path'
+
+export const TERMINAL_RICH_INPUT_NATIVE_DROP_EVENT = 'terminal-rich-input-native-drop'
+
+export type TerminalRichInputNativeDropDetail =
+  | { phase: 'start'; imagePending: boolean }
+  | { phase: 'resolved'; paths: string[] }
+  | { phase: 'end' }
+
+export type TerminalRichInputDropPathReceiver = {
+  begin: (sourcePaths: string[]) => void
+  receive: (paths: string[]) => void
+  end: () => void
+}
+
+function dispatchTerminalRichInputNativeDrop(
+  container: HTMLElement,
+  detail: TerminalRichInputNativeDropDetail
+): void {
+  container.dispatchEvent(
+    new CustomEvent<TerminalRichInputNativeDropDetail>(TERMINAL_RICH_INPUT_NATIVE_DROP_EVENT, {
+      detail
+    })
+  )
+}
+
+export function getTerminalRichInputDropPathReceiver(
+  manager: PaneManager,
+  paneLeafId: string | undefined
+): TerminalRichInputDropPathReceiver | undefined {
+  const pane = resolveNativeTerminalDropPane(manager, paneLeafId)
+  if (!pane || pane.container.dataset.terminalRichInputOpen === undefined) {
+    return undefined
+  }
+  return {
+    begin: (sourcePaths) =>
+      dispatchTerminalRichInputNativeDrop(pane.container, {
+        phase: 'start',
+        imagePending: sourcePaths.some(isImageDropPath)
+      }),
+    receive: (paths) =>
+      dispatchTerminalRichInputNativeDrop(pane.container, { phase: 'resolved', paths }),
+    end: () => dispatchTerminalRichInputNativeDrop(pane.container, { phase: 'end' })
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-native-drop.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-native-drop.ts
@@ -11,7 +11,7 @@ export type TerminalRichInputNativeDropDetail =
 
 export type TerminalRichInputDropPathReceiver = {
   begin: (sourcePaths: string[]) => void
-  receive: (paths: string[]) => void
+  receive: (paths: string[]) => boolean
   end: () => void
 }
 
@@ -40,8 +40,13 @@ export function getTerminalRichInputDropPathReceiver(
         phase: 'start',
         imagePending: sourcePaths.some(isImageDropPath)
       }),
-    receive: (paths) =>
-      dispatchTerminalRichInputNativeDrop(pane.container, { phase: 'resolved', paths }),
+    receive: (paths) => {
+      if (pane.container.dataset.terminalRichInputOpen === undefined) {
+        return false
+      }
+      dispatchTerminalRichInputNativeDrop(pane.container, { phase: 'resolved', paths })
+      return true
+    },
     end: () => dispatchTerminalRichInputNativeDrop(pane.container, { phase: 'end' })
   }
 }

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-submit-reconcile.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-submit-reconcile.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest'
+import { removeWrittenTerminalRichInputContent } from './terminal-rich-input-submit-reconcile'
+
+describe('removeWrittenTerminalRichInputContent', () => {
+  it('removes only attachment and text stages that already reached the PTY', () => {
+    const removeAttachment = vi.fn()
+    const clearContent = vi.fn()
+
+    removeWrittenTerminalRichInputContent(
+      { status: 'partially-written', imagePathsWritten: 1, textWritten: true },
+      [
+        { id: 'first', path: '/tmp/first.png' },
+        { id: 'second', path: '/tmp/second.png' }
+      ],
+      { commands: { clearContent } } as never,
+      removeAttachment
+    )
+
+    expect(removeAttachment).toHaveBeenCalledOnce()
+    expect(removeAttachment).toHaveBeenCalledWith('first')
+    expect(clearContent).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-submit-reconcile.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-submit-reconcile.ts
@@ -1,0 +1,18 @@
+import type { Editor } from '@tiptap/react'
+import type { TerminalRichInputImageAttachment } from './terminal-rich-input-attachment-cache'
+import type { TerminalRichInputSubmitResult } from './terminal-rich-input-submit'
+
+export function removeWrittenTerminalRichInputContent(
+  result: Extract<TerminalRichInputSubmitResult, { status: 'partially-written' }>,
+  attachments: readonly TerminalRichInputImageAttachment[],
+  editor: Editor,
+  removeAttachment: (id: string) => void
+): void {
+  // A retry must contain only stages that never reached the PTY.
+  for (const attachment of attachments.slice(0, result.imagePathsWritten)) {
+    removeAttachment(attachment.id)
+  }
+  if (result.textWritten) {
+    editor.commands.clearContent()
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-submit.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-submit.test.ts
@@ -29,7 +29,10 @@ function makePane() {
 }
 
 function makeTransport(ptyId = 'pty-1') {
-  return { getPtyId: vi.fn(() => ptyId) } as unknown as PtyTransport
+  return {
+    getPtyId: vi.fn(() => ptyId),
+    isConnected: vi.fn(() => true)
+  } as unknown as PtyTransport
 }
 
 describe('terminal rich input submit', () => {
@@ -120,6 +123,34 @@ describe('terminal rich input submit', () => {
       imagePathsWritten: 1,
       textWritten: false
     })
+    expect(pane.terminal.input).not.toHaveBeenCalled()
+  })
+
+  it('does not report submission when the transport disconnects during the final delay', async () => {
+    const pane = makePane()
+    const transport = makeTransport()
+    const panes = new Map([[pane.id, transport]])
+    const delay = async () => {
+      vi.mocked(transport.isConnected).mockReturnValue(false)
+    }
+
+    await expect(
+      submitTerminalRichInput({
+        text: 'hello',
+        tabId: 'tab-1',
+        worktreeId: 'worktree-1',
+        pane,
+        transport,
+        getManager: () => ({ getPanes: () => [pane] }) as unknown as PaneManager,
+        getPaneTransports: () => panes,
+        delay
+      })
+    ).resolves.toEqual({
+      status: 'partially-written',
+      imagePathsWritten: 0,
+      textWritten: true
+    })
+
     expect(pane.terminal.input).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-submit.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-submit.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
+import type { PtyTransport } from './pty-transport'
+
+const mocks = vi.hoisted(() => ({
+  pasteTextIntoTerminalPane: vi.fn(),
+  recordTerminalUserInputForLeaf: vi.fn()
+}))
+
+vi.mock('./terminal-programmatic-text-paste', () => ({
+  pasteTextIntoTerminalPane: mocks.pasteTextIntoTerminalPane
+}))
+vi.mock('./terminal-input-activity', () => ({
+  recordTerminalUserInputForLeaf: mocks.recordTerminalUserInputForLeaf
+}))
+
+import {
+  TERMINAL_RICH_INPUT_IMAGE_SETTLE_MS,
+  TERMINAL_RICH_INPUT_SUBMIT_DELAY_MS,
+  submitTerminalRichInput
+} from './terminal-rich-input-submit'
+
+function makePane() {
+  return {
+    id: 1,
+    leafId: 'leaf-1',
+    terminal: { input: vi.fn(), scrollToBottom: vi.fn() }
+  } as unknown as ManagedPane
+}
+
+function makeTransport(ptyId = 'pty-1') {
+  return { getPtyId: vi.fn(() => ptyId) } as unknown as PtyTransport
+}
+
+describe('terminal rich input submit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.pasteTextIntoTerminalPane.mockResolvedValue(true)
+  })
+
+  it('pastes, waits, and submits to the same live leaf', async () => {
+    const pane = makePane()
+    const transport = makeTransport()
+    const panes = new Map([[pane.id, transport]])
+    const delay = vi.fn(async () => {})
+
+    await expect(
+      submitTerminalRichInput({
+        text: 'first\nsecond',
+        tabId: 'tab-1',
+        worktreeId: 'worktree-1',
+        pane,
+        transport,
+        getManager: () => ({ getPanes: () => [pane] }) as unknown as PaneManager,
+        getPaneTransports: () => panes,
+        delay
+      })
+    ).resolves.toEqual({ status: 'submitted' })
+
+    expect(delay).toHaveBeenCalledWith(TERMINAL_RICH_INPUT_SUBMIT_DELAY_MS)
+    expect(pane.terminal.input).toHaveBeenCalledWith('\r')
+    expect(pane.terminal.scrollToBottom).toHaveBeenCalled()
+    expect(mocks.recordTerminalUserInputForLeaf).toHaveBeenCalledWith('tab-1', 'leaf-1')
+  })
+
+  it('pastes image attachments before the prompt and waits for each stage', async () => {
+    const pane = makePane()
+    const transport = makeTransport()
+    const panes = new Map([[pane.id, transport]])
+    const delay = vi.fn(async () => {})
+
+    await expect(
+      submitTerminalRichInput({
+        text: 'review this image',
+        imagePaths: ['/tmp/orca-paste-image.png'],
+        tabId: 'tab-1',
+        worktreeId: 'worktree-1',
+        pane,
+        transport,
+        getManager: () => ({ getPanes: () => [pane] }) as unknown as PaneManager,
+        getPaneTransports: () => panes,
+        delay
+      })
+    ).resolves.toEqual({ status: 'submitted' })
+
+    expect(mocks.pasteTextIntoTerminalPane).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        text: '/tmp/orca-paste-image.png',
+        forceBracketedPaste: true
+      })
+    )
+    expect(mocks.pasteTextIntoTerminalPane).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: 'review this image' })
+    )
+    expect(delay).toHaveBeenNthCalledWith(1, TERMINAL_RICH_INPUT_IMAGE_SETTLE_MS)
+    expect(delay).toHaveBeenNthCalledWith(2, TERMINAL_RICH_INPUT_SUBMIT_DELAY_MS)
+  })
+
+  it('reports exactly which stages were written before a later paste failed', async () => {
+    mocks.pasteTextIntoTerminalPane.mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+    const pane = makePane()
+    const transport = makeTransport()
+
+    await expect(
+      submitTerminalRichInput({
+        text: 'review both',
+        imagePaths: ['/tmp/first.png'],
+        tabId: 'tab-1',
+        worktreeId: 'worktree-1',
+        pane,
+        transport,
+        getManager: () => ({ getPanes: () => [pane] }) as unknown as PaneManager,
+        getPaneTransports: () => new Map([[pane.id, transport]]),
+        delay: vi.fn(async () => {})
+      })
+    ).resolves.toEqual({
+      status: 'partially-written',
+      imagePathsWritten: 1,
+      textWritten: false
+    })
+    expect(pane.terminal.input).not.toHaveBeenCalled()
+  })
+
+  it('does not send Enter after the leaf changes PTY ownership', async () => {
+    const pane = makePane()
+    const originalTransport = makeTransport('pty-1')
+    const replacementTransport = makeTransport('pty-2')
+    const panes = new Map([[pane.id, originalTransport]])
+    const delay = async () => {
+      panes.set(pane.id, replacementTransport)
+    }
+
+    await expect(
+      submitTerminalRichInput({
+        text: 'hello',
+        tabId: 'tab-1',
+        worktreeId: 'worktree-1',
+        pane,
+        transport: originalTransport,
+        getManager: () => ({ getPanes: () => [pane] }) as unknown as PaneManager,
+        getPaneTransports: () => panes,
+        delay
+      })
+    ).resolves.toEqual({
+      status: 'partially-written',
+      imagePathsWritten: 0,
+      textWritten: true
+    })
+
+    expect(pane.terminal.input).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-submit.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-submit.ts
@@ -87,7 +87,12 @@ export async function submitTerminalRichInput({
     ?.getPanes()
     .find((candidate) => candidate.leafId === pane.leafId)
   const currentTransport = currentPane ? getPaneTransports().get(currentPane.id) : undefined
-  if (!currentPane || currentTransport !== transport || currentTransport.getPtyId() !== ptyId) {
+  if (
+    !currentPane ||
+    currentTransport !== transport ||
+    !currentTransport.isConnected() ||
+    currentTransport.getPtyId() !== ptyId
+  ) {
     return interruptedResult()
   }
   currentPane.terminal.input('\r')

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-submit.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-submit.ts
@@ -1,0 +1,101 @@
+import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
+import type { PtyTransport } from './pty-transport'
+import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
+import { pasteTextIntoTerminalPane } from './terminal-programmatic-text-paste'
+
+export const TERMINAL_RICH_INPUT_SUBMIT_DELAY_MS = 500
+export const TERMINAL_RICH_INPUT_IMAGE_SETTLE_MS = 300
+
+export type TerminalRichInputSubmitResult =
+  | { status: 'not-started' }
+  | { status: 'partially-written'; imagePathsWritten: number; textWritten: boolean }
+  | { status: 'submitted' }
+
+type SubmitTerminalRichInputArgs = {
+  text: string
+  imagePaths?: readonly string[]
+  tabId: string
+  worktreeId: string
+  pane: ManagedPane
+  transport: PtyTransport | undefined
+  getManager: () => PaneManager | null
+  getPaneTransports: () => Map<number, PtyTransport>
+  delay?: (milliseconds: number) => Promise<void>
+}
+
+/** Pastes the composed block first, then submits only if the same PTY still owns the leaf. */
+export async function submitTerminalRichInput({
+  text,
+  imagePaths = [],
+  tabId,
+  worktreeId,
+  pane,
+  transport,
+  getManager,
+  getPaneTransports,
+  delay = wait
+}: SubmitTerminalRichInputArgs): Promise<TerminalRichInputSubmitResult> {
+  const ptyId = transport?.getPtyId() ?? null
+  if ((!text.trim() && imagePaths.length === 0) || !transport || !ptyId) {
+    return { status: 'not-started' }
+  }
+  let imagePathsWritten = 0
+  let textWritten = false
+  const interruptedResult = (): TerminalRichInputSubmitResult =>
+    imagePathsWritten > 0 || textWritten
+      ? { status: 'partially-written', imagePathsWritten, textWritten }
+      : { status: 'not-started' }
+  for (const imagePath of imagePaths) {
+    const pastedImage = await pasteTextIntoTerminalPane({
+      text: imagePath,
+      tabId,
+      worktreeId,
+      pane,
+      transport,
+      getManager,
+      getPaneTransports,
+      forceBracketedPaste: true
+    })
+    if (!pastedImage) {
+      return interruptedResult()
+    }
+    imagePathsWritten += 1
+  }
+  if (imagePaths.length > 0) {
+    await delay(TERMINAL_RICH_INPUT_IMAGE_SETTLE_MS)
+  }
+  if (text.trim()) {
+    const pastedText = await pasteTextIntoTerminalPane({
+      text,
+      tabId,
+      worktreeId,
+      pane,
+      transport,
+      getManager,
+      getPaneTransports
+    })
+    if (!pastedText) {
+      return interruptedResult()
+    }
+    textWritten = true
+  }
+
+  // Why: busy agent TUIs can process Enter before a freshly pasted prompt has
+  // reached their editor, leaving the prompt queued but unsent.
+  await delay(TERMINAL_RICH_INPUT_SUBMIT_DELAY_MS)
+  const currentPane = getManager()
+    ?.getPanes()
+    .find((candidate) => candidate.leafId === pane.leafId)
+  const currentTransport = currentPane ? getPaneTransports().get(currentPane.id) : undefined
+  if (!currentPane || currentTransport !== transport || currentTransport.getPtyId() !== ptyId) {
+    return interruptedResult()
+  }
+  currentPane.terminal.input('\r')
+  currentPane.terminal.scrollToBottom()
+  recordTerminalUserInputForLeaf(tabId, currentPane.leafId)
+  return { status: 'submitted' }
+}
+
+function wait(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds))
+}

--- a/src/renderer/src/components/terminal-pane/terminal-rich-input-types.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-rich-input-types.ts
@@ -1,0 +1,15 @@
+import type { AgentType } from '../../../../shared/agent-status-types'
+import type { ManagedPane } from '@/lib/pane-manager/pane-manager'
+import type { TerminalRichInputSubmitResult } from './terminal-rich-input-submit'
+
+export type TerminalRichInputProps = {
+  open: boolean
+  pane: ManagedPane
+  scopeKey: string
+  worktreeId: string
+  agent: AgentType | null
+  connectionId: string | null
+  runtimeEnvironmentId: string | null
+  onClose: () => void
+  onSubmit: (text: string, imagePaths: string[]) => Promise<TerminalRichInputSubmitResult>
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -1252,11 +1252,36 @@ describe('useTerminalPaneGlobalEffects', () => {
 
     onFileDrop(data)
     const args = mocks.handleTerminalFileDrop.mock.calls[0][0]
-    args.onResolvedPaths(['/remote/.orca/drops/image.png'])
+    expect(args.onResolvedPaths(['/remote/.orca/drops/image.png'])).toBe(true)
 
-    expect(dispatchEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'terminal-rich-input-native-drop' })
+    expect(dispatchEvent).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        type: 'terminal-rich-input-native-drop',
+        detail: {
+          phase: 'resolved',
+          paths: ['/remote/.orca/drops/image.png']
+        }
+      })
     )
+  })
+
+  it('declines resolved paths after rich input closes so the drop can fall back to the PTY', () => {
+    const { onFileDrop, manager } = useMountForFileDrop()
+    const dispatchEvent = vi.fn()
+    const dataset: Record<string, string> = { terminalRichInputOpen: '' }
+    manager.getPanes.mockReturnValue([{ leafId: 'leaf-1', container: { dataset, dispatchEvent } }])
+
+    onFileDrop({
+      paths: ['/tmp/image.png'],
+      target: 'terminal',
+      tabId: 'tab-1',
+      paneLeafId: 'leaf-1'
+    })
+    delete dataset.terminalRichInputOpen
+    const args = mocks.handleTerminalFileDrop.mock.calls[0][0]
+
+    expect(args.onResolvedPaths(['/remote/.orca/drops/image.png'])).toBe(false)
+    expect(dispatchEvent).toHaveBeenCalledTimes(1)
   })
 
   it('keeps handling legacy terminal file drops without a terminal tab id', () => {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -1234,6 +1234,31 @@ describe('useTerminalPaneGlobalEffects', () => {
     })
   })
 
+  it('routes native drop paths through the resolver when rich input is open', () => {
+    const { onFileDrop, manager } = useMountForFileDrop()
+    const dispatchEvent = vi.fn()
+    manager.getPanes.mockReturnValue([
+      {
+        leafId: 'leaf-1',
+        container: { dataset: { terminalRichInputOpen: '' }, dispatchEvent }
+      }
+    ])
+    const data = {
+      paths: ['/tmp/image.png'],
+      target: 'terminal',
+      tabId: 'tab-1',
+      paneLeafId: 'leaf-1'
+    }
+
+    onFileDrop(data)
+    const args = mocks.handleTerminalFileDrop.mock.calls[0][0]
+    args.onResolvedPaths(['/remote/.orca/drops/image.png'])
+
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'terminal-rich-input-native-drop' })
+    )
+  })
+
   it('keeps handling legacy terminal file drops without a terminal tab id', () => {
     const { onFileDrop, manager, paneTransports } = useMountForFileDrop()
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -10,6 +10,7 @@ import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { PtyTransport } from './pty-transport'
 import type { IDisposable } from '@xterm/xterm'
 import { handleTerminalFileDrop } from './terminal-drop-handler'
+import { getTerminalRichInputDropPathReceiver } from './terminal-rich-input-native-drop'
 import { handleFocusTerminalPaneDetail } from './focus-terminal-pane-event'
 import { surfaceStaleAgentRow } from './stale-agent-row'
 import { useAppStore } from '@/store'
@@ -315,14 +316,20 @@ export function useTerminalPaneGlobalEffects({
       if (!wtId) {
         return
       }
-      void handleTerminalFileDrop({
+      const richInputPathReceiver = getTerminalRichInputDropPathReceiver(manager, data.paneLeafId)
+      richInputPathReceiver?.begin(data.paths)
+      const dropResult = handleTerminalFileDrop({
         manager,
         paneTransports: paneTransportsRef.current,
         worktreeId: wtId,
         tabId,
         cwd: cwdRef.current,
-        data
+        data,
+        // Why: native drops still need the terminal's WSL/SSH/runtime resolver,
+        // but an open composer must receive the resolved paths instead of PTY input.
+        ...(richInputPathReceiver ? { onResolvedPaths: richInputPathReceiver.receive } : {})
       })
+      void Promise.resolve(dropResult).finally(() => richInputPathReceiver?.end())
     })
   }, [isActive, isVisible, managerRef, paneTransportsRef, tabId])
 }

--- a/src/renderer/src/components/terminal-pane/use-terminal-rich-input-animation.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-rich-input-animation.ts
@@ -1,0 +1,61 @@
+import { useLayoutEffect, useState } from 'react'
+import type { ManagedPane } from '@/lib/pane-manager/pane-manager'
+import { requestPaneTuiRepaint } from '@/lib/pane-manager/pane-tui-repaint-request'
+import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
+import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
+
+const CONTENT_TRANSITION_MS = 140
+
+export function useTerminalRichInputAnimation({
+  open,
+  pane
+}: {
+  open: boolean
+  pane: ManagedPane
+}): { layoutOpen: boolean } {
+  const [layoutOpen, setLayoutOpen] = useState(open)
+  const prefersReducedMotion = usePrefersReducedMotion()
+
+  useLayoutEffect(() => {
+    pane.container.dataset.terminalRichInputMounted = ''
+    return () => {
+      delete pane.container.dataset.terminalRichInputMounted
+    }
+  }, [pane])
+
+  useLayoutEffect(() => {
+    if (open || prefersReducedMotion) {
+      setLayoutOpen(open)
+      return
+    }
+    const timer = window.setTimeout(() => setLayoutOpen(false), CONTENT_TRANSITION_MS)
+    return () => window.clearTimeout(timer)
+  }, [open, prefersReducedMotion])
+
+  useLayoutEffect(() => {
+    if (layoutOpen !== open) {
+      return
+    }
+    // safeFit owns the pre-fit scroll snapshot; a second restoration pipeline
+    // can rewind user scrolling performed while the dock is transitioning.
+    safeFit(pane)
+    const repaintTimer =
+      !layoutOpen && pane.terminal.buffer.active.type === 'alternate'
+        ? window.setTimeout(
+            () =>
+              requestPaneTuiRepaint(pane.container, {
+                cols: pane.terminal.cols,
+                rows: pane.terminal.rows
+              }),
+            180
+          )
+        : null
+    return () => {
+      if (repaintTimer !== null) {
+        window.clearTimeout(repaintTimer)
+      }
+    }
+  }, [layoutOpen, open, pane])
+
+  return { layoutOpen }
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-rich-input-attachments.test.tsx
+++ b/src/renderer/src/components/terminal-pane/use-terminal-rich-input-attachments.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { act, createElement } from 'react'
+import { act, createElement, useEffect } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { clearTerminalRichInputAttachmentCacheForTests } from './terminal-rich-input-attachment-cache'
@@ -19,7 +19,9 @@ function Probe({ onReady }: { onReady: (api: ProbeApi) => void }): React.JSX.Ele
     focusEditor: () => {},
     enabled: true
   })
-  onReady(api)
+  useEffect(() => {
+    onReady(api)
+  }, [api, onReady])
   return createElement('div')
 }
 
@@ -133,6 +135,20 @@ describe('useTerminalRichInputAttachments', () => {
 
     await act(async () => probe.latest().removeAttachment(probe.latest().attachments[0].id))
     expect(probe.latest().attachments).toEqual([])
+    probe.root.unmount()
+  })
+
+  it('removes only attachments included in a completed submission', async () => {
+    const probe = await renderProbe()
+    await act(async () => probe.latest().appendImagePaths(['/tmp/first.png', '/tmp/second.png']))
+    const submittedIds = probe.latest().attachments.map((attachment) => attachment.id)
+
+    await act(async () => probe.latest().appendImagePaths(['/tmp/added-while-sending.png']))
+    await act(async () => probe.latest().removeAttachments(submittedIds))
+
+    expect(probe.latest().attachments.map((attachment) => attachment.path)).toEqual([
+      '/tmp/added-while-sending.png'
+    ])
     probe.root.unmount()
   })
 })

--- a/src/renderer/src/components/terminal-pane/use-terminal-rich-input-attachments.test.tsx
+++ b/src/renderer/src/components/terminal-pane/use-terminal-rich-input-attachments.test.tsx
@@ -2,6 +2,7 @@
 import { act, createElement, useEffect } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { joinPath } from '@/lib/path'
 import { clearTerminalRichInputAttachmentCacheForTests } from './terminal-rich-input-attachment-cache'
 import { useTerminalRichInputAttachments } from './use-terminal-rich-input-attachments'
 
@@ -140,14 +141,17 @@ describe('useTerminalRichInputAttachments', () => {
 
   it('removes only attachments included in a completed submission', async () => {
     const probe = await renderProbe()
-    await act(async () => probe.latest().appendImagePaths(['/tmp/first.png', '/tmp/second.png']))
+    const firstPath = joinPath('tmp', 'first.png')
+    const secondPath = joinPath('tmp', 'second.png')
+    const addedWhileSendingPath = joinPath('tmp', 'added-while-sending.png')
+    await act(async () => probe.latest().appendImagePaths([firstPath, secondPath]))
     const submittedIds = probe.latest().attachments.map((attachment) => attachment.id)
 
-    await act(async () => probe.latest().appendImagePaths(['/tmp/added-while-sending.png']))
+    await act(async () => probe.latest().appendImagePaths([addedWhileSendingPath]))
     await act(async () => probe.latest().removeAttachments(submittedIds))
 
     expect(probe.latest().attachments.map((attachment) => attachment.path)).toEqual([
-      '/tmp/added-while-sending.png'
+      addedWhileSendingPath
     ])
     probe.root.unmount()
   })

--- a/src/renderer/src/components/terminal-pane/use-terminal-rich-input-attachments.test.tsx
+++ b/src/renderer/src/components/terminal-pane/use-terminal-rich-input-attachments.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment happy-dom
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { clearTerminalRichInputAttachmentCacheForTests } from './terminal-rich-input-attachment-cache'
+import { useTerminalRichInputAttachments } from './use-terminal-rich-input-attachments'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+type ProbeApi = ReturnType<typeof useTerminalRichInputAttachments>
+
+function Probe({ onReady }: { onReady: (api: ProbeApi) => void }): React.JSX.Element {
+  const api = useTerminalRichInputAttachments({
+    scopeKey: 'tab:leaf',
+    connectionId: null,
+    runtimeEnvironmentId: null,
+    focusEditor: () => {},
+    enabled: true
+  })
+  onReady(api)
+  return createElement('div')
+}
+
+async function renderProbe(): Promise<{ root: Root; latest: () => ProbeApi }> {
+  const root = createRoot(document.createElement('div'))
+  let api: ProbeApi | null = null
+  await act(async () => {
+    root.render(createElement(Probe, { onReady: (next: ProbeApi) => (api = next) }))
+  })
+  return {
+    root,
+    latest: () => {
+      if (!api) {
+        throw new Error('Probe did not render')
+      }
+      return api
+    }
+  }
+}
+
+describe('useTerminalRichInputAttachments', () => {
+  afterEach(() => {
+    clearTerminalRichInputAttachmentCacheForTests()
+    vi.restoreAllMocks()
+  })
+
+  it('does not block or persist anything for a speculative text-clipboard probe', async () => {
+    const saveClipboardImageAsTempFile = vi.fn()
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        ui: {
+          readClipboardImageDataUrl: vi.fn().mockResolvedValue(null),
+          saveClipboardImageAsTempFile
+        }
+      }
+    })
+    const probe = await renderProbe()
+
+    await act(async () => {
+      probe.latest().pasteImageFromClipboard()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(saveClipboardImageAsTempFile).not.toHaveBeenCalled()
+    expect(probe.latest().attachmentBusy).toBe(false)
+    expect(probe.latest().attachments).toEqual([])
+    probe.root.unmount()
+  })
+
+  it('upgrades an in-flight keydown probe when the image paste event confirms it', async () => {
+    let resolvePreview: (value: string | null) => void = () => {}
+    const readClipboardImageDataUrl = vi.fn(
+      () => new Promise<string | null>((resolve) => (resolvePreview = resolve))
+    )
+    const saveClipboardImageAsTempFile = vi.fn().mockResolvedValue('/tmp/confirmed.png')
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { ui: { readClipboardImageDataUrl, saveClipboardImageAsTempFile } }
+    })
+    const probe = await renderProbe()
+    const preventDefault = vi.fn()
+
+    await act(async () => {
+      probe.latest().pasteImageFromClipboard()
+      expect(
+        probe.latest().handlePaste({
+          clipboardData: { items: [], getData: () => '' } as unknown as DataTransfer,
+          defaultPrevented: false,
+          preventDefault
+        })
+      ).toBe(true)
+      resolvePreview(null)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(saveClipboardImageAsTempFile).toHaveBeenCalledOnce()
+    expect(probe.latest().attachments[0]?.path).toBe('/tmp/confirmed.png')
+    probe.root.unmount()
+  })
+
+  it('turns a clipboard image temp file into a removable pending attachment', async () => {
+    const saveClipboardImageAsTempFile = vi.fn().mockResolvedValue('/tmp/orca-paste-1.png')
+    const readClipboardImageDataUrl = vi.fn().mockResolvedValue('data:image/png;base64,AAAA')
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { ui: { readClipboardImageDataUrl, saveClipboardImageAsTempFile } }
+    })
+    const probe = await renderProbe()
+
+    await act(async () => {
+      probe.latest().pasteImageFromClipboard()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(saveClipboardImageAsTempFile).toHaveBeenCalledWith({
+      connectionId: undefined,
+      runtimeEnvironmentId: undefined
+    })
+    expect(probe.latest().attachments).toEqual([
+      {
+        id: expect.any(String),
+        path: '/tmp/orca-paste-1.png',
+        previewSrc: 'data:image/png;base64,AAAA'
+      }
+    ])
+
+    await act(async () => probe.latest().removeAttachment(probe.latest().attachments[0].id))
+    expect(probe.latest().attachments).toEqual([])
+    probe.root.unmount()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/use-terminal-rich-input-attachments.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-rich-input-attachments.ts
@@ -1,0 +1,171 @@
+import { useCallback, useRef, useState } from 'react'
+import { translate } from '@/i18n/i18n'
+import { extractIpcErrorMessage } from '@/lib/ipc-error'
+import {
+  readTerminalRichInputAttachments,
+  writeTerminalRichInputAttachments,
+  type TerminalRichInputImageAttachment
+} from './terminal-rich-input-attachment-cache'
+import { isImageDropPath } from './terminal-drop-image-path'
+
+type ClipboardEventLike = {
+  clipboardData: DataTransfer | null
+  preventDefault: () => void
+  defaultPrevented: boolean
+}
+
+export function useTerminalRichInputAttachments({
+  scopeKey,
+  connectionId,
+  runtimeEnvironmentId,
+  focusEditor,
+  enabled
+}: {
+  scopeKey: string
+  connectionId: string | null
+  runtimeEnvironmentId: string | null
+  focusEditor: () => void
+  enabled: boolean
+}): {
+  attachments: TerminalRichInputImageAttachment[]
+  attachmentBusy: boolean
+  attachmentPending: boolean
+  notice: string | null
+  appendImagePaths: (paths: string[], previewSrc?: string) => void
+  clearAttachments: () => void
+  handlePaste: (event: ClipboardEventLike) => boolean
+  pasteImageFromClipboard: (confirmedImage?: boolean) => void
+  removeAttachment: (id: string) => void
+} {
+  const [attachments, setAttachments] = useState<TerminalRichInputImageAttachment[]>(() =>
+    readTerminalRichInputAttachments(scopeKey)
+  )
+  const [notice, setNotice] = useState<string | null>(null)
+  const [attachmentBusy, setAttachmentBusy] = useState(false)
+  const [attachmentPending, setAttachmentPending] = useState(false)
+  const attachmentCounter = useRef(0)
+  const clipboardPasteInFlight = useRef(false)
+  const clipboardPasteConfirmed = useRef(false)
+
+  const updateAttachments = useCallback(
+    (
+      update: (previous: TerminalRichInputImageAttachment[]) => TerminalRichInputImageAttachment[]
+    ) => {
+      setAttachments((previous) => {
+        const next = update(previous)
+        writeTerminalRichInputAttachments(scopeKey, next)
+        return next
+      })
+    },
+    [scopeKey]
+  )
+
+  const appendImagePaths = useCallback(
+    (paths: string[], previewSrc?: string) => {
+      const images = paths.filter(isImageDropPath)
+      if (images.length === 0) {
+        return
+      }
+      updateAttachments((previous) => [
+        ...previous,
+        ...images.map((path, index) => {
+          attachmentCounter.current += 1
+          return {
+            id: `${Date.now()}-${attachmentCounter.current}`,
+            path,
+            previewSrc: index === 0 ? previewSrc : undefined
+          }
+        })
+      ])
+      setNotice(null)
+      requestAnimationFrame(focusEditor)
+    },
+    [focusEditor, updateAttachments]
+  )
+
+  const pasteImageFromClipboard = useCallback(
+    (confirmedImage = false) => {
+      if (!enabled) {
+        return
+      }
+      if (clipboardPasteInFlight.current) {
+        clipboardPasteConfirmed.current ||= confirmedImage
+        return
+      }
+      clipboardPasteInFlight.current = true
+      clipboardPasteConfirmed.current = confirmedImage
+      let pendingTimer: number | null = null
+      const previewPromise = window.api.ui.readClipboardImageDataUrl
+        ? window.api.ui.readClipboardImageDataUrl().catch(() => null)
+        : Promise.resolve(null)
+      void previewPromise
+        .then(async (previewSrc) => {
+          if (!previewSrc && !clipboardPasteConfirmed.current) {
+            return
+          }
+          setAttachmentBusy(true)
+          pendingTimer = window.setTimeout(() => setAttachmentPending(true), 120)
+          const path = await window.api.ui.saveClipboardImageAsTempFile({
+            connectionId: connectionId ?? undefined,
+            runtimeEnvironmentId: runtimeEnvironmentId ?? undefined
+          })
+          if (path) {
+            appendImagePaths([path], previewSrc ?? undefined)
+          }
+        })
+        .catch((error) => {
+          setNotice(
+            extractIpcErrorMessage(
+              error,
+              translate('components.terminal.richInput.imagePasteFailed', 'Image paste failed.')
+            )
+          )
+        })
+        .finally(() => {
+          if (pendingTimer !== null) {
+            window.clearTimeout(pendingTimer)
+          }
+          clipboardPasteInFlight.current = false
+          clipboardPasteConfirmed.current = false
+          setAttachmentBusy(false)
+          setAttachmentPending(false)
+        })
+    },
+    [appendImagePaths, connectionId, enabled, runtimeEnvironmentId]
+  )
+
+  const handlePaste = useCallback(
+    (event: ClipboardEventLike): boolean => {
+      if (!enabled || event.defaultPrevented) {
+        return false
+      }
+      const data = event.clipboardData
+      // Electron can expose image-only native clipboards with an empty items
+      // list, so text presence is the reliable fallthrough signal.
+      if (!clipboardHasImage(data) && data?.getData('text/plain')) {
+        return false
+      }
+      event.preventDefault()
+      pasteImageFromClipboard(true)
+      return true
+    },
+    [enabled, pasteImageFromClipboard]
+  )
+
+  return {
+    attachments,
+    attachmentBusy,
+    attachmentPending,
+    notice,
+    appendImagePaths,
+    clearAttachments: () => updateAttachments(() => []),
+    handlePaste,
+    pasteImageFromClipboard,
+    removeAttachment: (id) =>
+      updateAttachments((previous) => previous.filter((attachment) => attachment.id !== id))
+  }
+}
+
+function clipboardHasImage(data: DataTransfer | null): boolean {
+  return Boolean(data && Array.from(data.items).some((item) => item.type.startsWith('image/')))
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-rich-input-attachments.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-rich-input-attachments.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { translate } from '@/i18n/i18n'
 import { extractIpcErrorMessage } from '@/lib/ipc-error'
 import {
@@ -32,15 +32,24 @@ export function useTerminalRichInputAttachments({
   attachmentPending: boolean
   notice: string | null
   appendImagePaths: (paths: string[], previewSrc?: string) => void
-  clearAttachments: () => void
   handlePaste: (event: ClipboardEventLike) => boolean
+  removeAttachments: (ids: readonly string[]) => void
   pasteImageFromClipboard: (confirmedImage?: boolean) => void
   removeAttachment: (id: string) => void
 } {
-  const [attachments, setAttachments] = useState<TerminalRichInputImageAttachment[]>(() =>
-    readTerminalRichInputAttachments(scopeKey)
+  const initialAttachments = useMemo(() => readTerminalRichInputAttachments(scopeKey), [scopeKey])
+  const [attachmentState, setAttachmentState] = useState(() => ({
+    scopeKey,
+    attachments: initialAttachments
+  }))
+  const attachments =
+    attachmentState.scopeKey === scopeKey ? attachmentState.attachments : initialAttachments
+  const [noticeState, setNoticeState] = useState({ scopeKey, notice: null as string | null })
+  const notice = noticeState.scopeKey === scopeKey ? noticeState.notice : null
+  const setNotice = useCallback(
+    (next: string | null) => setNoticeState({ scopeKey, notice: next }),
+    [scopeKey]
   )
-  const [notice, setNotice] = useState<string | null>(null)
   const [attachmentBusy, setAttachmentBusy] = useState(false)
   const [attachmentPending, setAttachmentPending] = useState(false)
   const attachmentCounter = useRef(0)
@@ -51,10 +60,14 @@ export function useTerminalRichInputAttachments({
     (
       update: (previous: TerminalRichInputImageAttachment[]) => TerminalRichInputImageAttachment[]
     ) => {
-      setAttachments((previous) => {
-        const next = update(previous)
-        writeTerminalRichInputAttachments(scopeKey, next)
-        return next
+      setAttachmentState((previous) => {
+        const previousAttachments =
+          previous.scopeKey === scopeKey
+            ? previous.attachments
+            : readTerminalRichInputAttachments(scopeKey)
+        const attachments = update(previousAttachments)
+        writeTerminalRichInputAttachments(scopeKey, attachments)
+        return { scopeKey, attachments }
       })
     },
     [scopeKey]
@@ -80,7 +93,7 @@ export function useTerminalRichInputAttachments({
       setNotice(null)
       requestAnimationFrame(focusEditor)
     },
-    [focusEditor, updateAttachments]
+    [focusEditor, setNotice, updateAttachments]
   )
 
   const pasteImageFromClipboard = useCallback(
@@ -131,7 +144,7 @@ export function useTerminalRichInputAttachments({
           setAttachmentPending(false)
         })
     },
-    [appendImagePaths, connectionId, enabled, runtimeEnvironmentId]
+    [appendImagePaths, connectionId, enabled, runtimeEnvironmentId, setNotice]
   )
 
   const handlePaste = useCallback(
@@ -158,9 +171,14 @@ export function useTerminalRichInputAttachments({
     attachmentPending,
     notice,
     appendImagePaths,
-    clearAttachments: () => updateAttachments(() => []),
     handlePaste,
     pasteImageFromClipboard,
+    removeAttachments: (ids) => {
+      const removedIds = new Set(ids)
+      updateAttachments((previous) =>
+        previous.filter((attachment) => !removedIds.has(attachment.id))
+      )
+    },
     removeAttachment: (id) =>
       updateAttachments((previous) => previous.filter((attachment) => attachment.id !== id))
   }

--- a/src/renderer/src/components/terminal-pane/use-terminal-rich-input-autocomplete-aria.test.tsx
+++ b/src/renderer/src/components/terminal-pane/use-terminal-rich-input-autocomplete-aria.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import type { Editor } from '@tiptap/react'
+import { describe, expect, it } from 'vitest'
+import { useTerminalRichInputAutocompleteAria } from './use-terminal-rich-input-autocomplete-aria'
+
+function Probe({ editor, open }: { editor: Editor; open: boolean }): null {
+  useTerminalRichInputAutocompleteAria({
+    editor,
+    fileMenuOpen: open,
+    fileSuggestionCount: 2,
+    slashMenuOpen: false,
+    slashSuggestionCount: 0,
+    activeSuggestion: 1
+  })
+  return null
+}
+
+describe('useTerminalRichInputAutocompleteAria', () => {
+  it('connects and clears the editor autocomplete relationship', async () => {
+    const editorElement = document.createElement('div')
+    const editor = { isDestroyed: false, view: { dom: editorElement } } as unknown as Editor
+    const root = createRoot(document.createElement('div'))
+
+    await act(async () => root.render(<Probe editor={editor} open />))
+    const menuId = editorElement.getAttribute('aria-controls')
+    expect(editorElement.getAttribute('aria-expanded')).toBe('true')
+    expect(menuId).toContain('-files')
+    expect(editorElement.getAttribute('aria-activedescendant')).toBe(`${menuId}-option-1`)
+
+    await act(async () => root.render(<Probe editor={editor} open={false} />))
+    expect(editorElement.getAttribute('aria-expanded')).toBe('false')
+    expect(editorElement.hasAttribute('aria-controls')).toBe(false)
+    expect(editorElement.hasAttribute('aria-activedescendant')).toBe(false)
+    root.unmount()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/use-terminal-rich-input-autocomplete-aria.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-rich-input-autocomplete-aria.ts
@@ -1,0 +1,51 @@
+import { useEffect, useId } from 'react'
+import type { Editor } from '@tiptap/react'
+
+export function useTerminalRichInputAutocompleteAria({
+  editor,
+  fileMenuOpen,
+  fileSuggestionCount,
+  slashMenuOpen,
+  slashSuggestionCount,
+  activeSuggestion
+}: {
+  editor: Editor | null
+  fileMenuOpen: boolean
+  fileSuggestionCount: number
+  slashMenuOpen: boolean
+  slashSuggestionCount: number
+  activeSuggestion: number
+}): { fileMenuId: string; slashMenuId: string; activeIndex: number } {
+  const autocompleteId = useId()
+  const fileMenuId = `${autocompleteId}-files`
+  const slashMenuId = `${autocompleteId}-slashes`
+  const activeMenuId = fileMenuOpen ? fileMenuId : slashMenuOpen ? slashMenuId : null
+  const suggestionCount = fileMenuOpen
+    ? fileSuggestionCount
+    : slashMenuOpen
+      ? slashSuggestionCount
+      : 0
+  const activeIndex = suggestionCount > 0 ? Math.min(activeSuggestion, suggestionCount - 1) : 0
+  const activeOptionId =
+    activeMenuId && suggestionCount > 0 ? `${activeMenuId}-option-${activeIndex}` : null
+
+  useEffect(() => {
+    if (!editor || editor.isDestroyed) {
+      return
+    }
+    const editorElement = editor.view.dom
+    editorElement.setAttribute('aria-expanded', activeMenuId ? 'true' : 'false')
+    if (activeMenuId) {
+      editorElement.setAttribute('aria-controls', activeMenuId)
+    } else {
+      editorElement.removeAttribute('aria-controls')
+    }
+    if (activeOptionId) {
+      editorElement.setAttribute('aria-activedescendant', activeOptionId)
+    } else {
+      editorElement.removeAttribute('aria-activedescendant')
+    }
+  }, [activeMenuId, activeOptionId, editor])
+
+  return { fileMenuId, slashMenuId, activeIndex }
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-rich-input-drop.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-rich-input-drop.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useState } from 'react'
+import { getWorkspaceFileDragPaths } from '@/lib/workspace-file-drag'
+import type { ManagedPane } from '@/lib/pane-manager/pane-manager'
+import {
+  TERMINAL_RICH_INPUT_NATIVE_DROP_EVENT,
+  type TerminalRichInputNativeDropDetail
+} from './terminal-rich-input-native-drop'
+
+export function useTerminalRichInputDrop({
+  open,
+  pane,
+  insertPaths
+}: {
+  open: boolean
+  pane: ManagedPane
+  insertPaths: (paths: string[]) => void
+}): {
+  busy: boolean
+  imagePending: boolean
+  onDragOver: (event: React.DragEvent) => void
+  onDrop: (event: React.DragEvent) => void
+} {
+  const [nativeDrop, setNativeDrop] = useState({ count: 0, imagePending: false })
+  useEffect(() => {
+    if (open) {
+      pane.container.dataset.terminalRichInputOpen = ''
+    } else {
+      delete pane.container.dataset.terminalRichInputOpen
+    }
+    return () => {
+      delete pane.container.dataset.terminalRichInputOpen
+    }
+  }, [open, pane])
+
+  useEffect(() => {
+    const onNativeDrop = (event: Event): void => {
+      const detail = (event as CustomEvent<TerminalRichInputNativeDropDetail>).detail
+      if (detail?.phase === 'start') {
+        setNativeDrop((current) => ({
+          count: current.count + 1,
+          imagePending: current.imagePending || detail.imagePending
+        }))
+      } else if (detail?.phase === 'resolved' && detail.paths.length > 0) {
+        insertPaths(detail.paths)
+      } else if (detail?.phase === 'end') {
+        setNativeDrop((current) => {
+          const count = Math.max(0, current.count - 1)
+          return { count, imagePending: count > 0 && current.imagePending }
+        })
+      }
+    }
+    pane.container.addEventListener(TERMINAL_RICH_INPUT_NATIVE_DROP_EVENT, onNativeDrop)
+    return () =>
+      pane.container.removeEventListener(TERMINAL_RICH_INPUT_NATIVE_DROP_EVENT, onNativeDrop)
+  }, [insertPaths, pane])
+
+  const onDragOver = useCallback((event: React.DragEvent) => {
+    if (getWorkspaceFileDragPaths(event.dataTransfer).length > 0) {
+      event.preventDefault()
+      event.dataTransfer.dropEffect = 'copy'
+    }
+  }, [])
+
+  const onDrop = useCallback(
+    (event: React.DragEvent) => {
+      const paths = getWorkspaceFileDragPaths(event.dataTransfer)
+      if (paths.length === 0) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      insertPaths(paths)
+    },
+    [insertPaths]
+  )
+
+  return {
+    busy: nativeDrop.count > 0,
+    imagePending: nativeDrop.imagePending,
+    onDragOver,
+    onDrop
+  }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14207,6 +14207,24 @@
       },
       "launchPromptNotDelivered": "Not delivered — check the terminal"
     },
+    "terminal": {
+      "richInput": {
+        "label": "Rich terminal input",
+        "placeholder": "Write a terminal prompt…",
+        "sendFailed": "Terminal input was not sent.",
+        "sendPartial": "Part of the input was pasted. Check the terminal before retrying.",
+        "hint": "Enter to send · Shift+Enter for newline",
+        "send": "Send to terminal",
+        "loadingFiles": "Loading files…",
+        "files": "Files",
+        "noFiles": "No matching files",
+        "toggle": "Toggle rich terminal input",
+        "imagePasteFailed": "Image paste failed.",
+        "addingImage": "Adding image…",
+        "slashCommands": "Slash commands",
+        "removeAttachment": "Remove attachment"
+      }
+    },
     "tab": {
       "bar": {
         "SortableTabContextMenu": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -14184,6 +14184,24 @@
       },
       "launchPromptNotDelivered": "No entregado — revisa la terminal"
     },
+    "terminal": {
+      "richInput": {
+        "label": "Entrada enriquecida del terminal",
+        "placeholder": "Escribe una instrucción para el terminal…",
+        "sendFailed": "No se envió la entrada al terminal.",
+        "sendPartial": "Se pegó parte de la entrada. Revisa el terminal antes de volver a intentarlo.",
+        "hint": "Intro para enviar · Mayús+Intro para una nueva línea",
+        "send": "Enviar al terminal",
+        "loadingFiles": "Cargando archivos…",
+        "files": "Archivos",
+        "noFiles": "No hay archivos coincidentes",
+        "toggle": "Alternar entrada enriquecida del terminal",
+        "imagePasteFailed": "No se pudo pegar la imagen.",
+        "addingImage": "Añadiendo imagen…",
+        "slashCommands": "Comandos con barra",
+        "removeAttachment": "Eliminar archivo adjunto"
+      }
+    },
     "tab": {
       "bar": {
         "SortableTabContextMenu": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -14184,6 +14184,24 @@
       },
       "launchPromptNotDelivered": "配信されませんでした — ターミナルを確認してください"
     },
+    "terminal": {
+      "richInput": {
+        "label": "リッチターミナル入力",
+        "placeholder": "ターミナルへのプロンプトを入力…",
+        "sendFailed": "ターミナル入力を送信できませんでした。",
+        "sendPartial": "入力の一部が貼り付けられました。再試行する前にターミナルを確認してください。",
+        "hint": "Enterで送信 · Shift+Enterで改行",
+        "send": "ターミナルに送信",
+        "loadingFiles": "ファイルを読み込み中…",
+        "files": "ファイル",
+        "noFiles": "一致するファイルはありません",
+        "toggle": "リッチターミナル入力を切り替え",
+        "imagePasteFailed": "画像の貼り付けに失敗しました。",
+        "addingImage": "画像を追加中…",
+        "slashCommands": "スラッシュコマンド",
+        "removeAttachment": "添付ファイルを削除"
+      }
+    },
     "tab": {
       "bar": {
         "SortableTabContextMenu": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14184,6 +14184,24 @@
       },
       "launchPromptNotDelivered": "전달되지 않음 — 터미널을 확인하세요"
     },
+    "terminal": {
+      "richInput": {
+        "label": "리치 터미널 입력",
+        "placeholder": "터미널 프롬프트를 입력하세요…",
+        "sendFailed": "터미널 입력을 보내지 못했습니다.",
+        "sendPartial": "입력 일부가 붙여넣어졌습니다. 다시 시도하기 전에 터미널을 확인하세요.",
+        "hint": "Enter로 보내기 · Shift+Enter로 줄 바꿈",
+        "send": "터미널로 보내기",
+        "loadingFiles": "파일 불러오는 중…",
+        "files": "파일",
+        "noFiles": "일치하는 파일 없음",
+        "toggle": "리치 터미널 입력 전환",
+        "imagePasteFailed": "이미지 붙여넣기에 실패했습니다.",
+        "addingImage": "이미지 추가 중…",
+        "slashCommands": "슬래시 명령",
+        "removeAttachment": "첨부 파일 제거"
+      }
+    },
     "tab": {
       "bar": {
         "SortableTabContextMenu": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -14184,6 +14184,24 @@
       },
       "launchPromptNotDelivered": "未送达 — 请检查终端"
     },
+    "terminal": {
+      "richInput": {
+        "label": "增强型终端输入",
+        "placeholder": "输入终端提示…",
+        "sendFailed": "终端输入未发送。",
+        "sendPartial": "部分输入已粘贴。重试前请检查终端。",
+        "hint": "Enter 发送 · Shift+Enter 换行",
+        "send": "发送到终端",
+        "loadingFiles": "正在加载文件…",
+        "files": "文件",
+        "noFiles": "没有匹配的文件",
+        "toggle": "切换增强型终端输入",
+        "imagePasteFailed": "图片粘贴失败。",
+        "addingImage": "正在添加图片…",
+        "slashCommands": "斜杠命令",
+        "removeAttachment": "移除附件"
+      }
+    },
     "tab": {
       "bar": {
         "SortableTabContextMenu": {

--- a/src/renderer/src/lib/pane-manager/pane-tui-repaint-request.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tui-repaint-request.ts
@@ -1,0 +1,15 @@
+export const PANE_TUI_REPAINT_REQUEST_EVENT = 'orca-pane-tui-repaint-request'
+
+export type PaneTuiRepaintRequestDetail = {
+  cols: number
+  rows: number
+}
+
+export function requestPaneTuiRepaint(
+  container: HTMLElement,
+  detail: PaneTuiRepaintRequestDetail
+): void {
+  container.dispatchEvent(
+    new CustomEvent<PaneTuiRepaintRequestDetail>(PANE_TUI_REPAINT_REQUEST_EVENT, { detail })
+  )
+}

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2497,6 +2497,9 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
       ),
     readSelectionClipboardText: () =>
       Promise.reject(new Error('Selection clipboard is unavailable in the web client')),
+    // Runtime previews load from the saved target path; avoid retaining the
+    // full clipboard PNG as a second renderer-side copy in the web client.
+    readClipboardImageDataUrl: () => Promise.resolve(null),
     saveClipboardImageAsTempFile: async (args?: {
       connectionId?: string | null
       runtimeEnvironmentId?: string | null

--- a/src/shared/agent-image-handling.ts
+++ b/src/shared/agent-image-handling.ts
@@ -1,0 +1,19 @@
+import type { AgentType } from './agent-status-types'
+
+export type AgentImageHandling = 'attachment' | 'unsupported'
+
+const IMAGE_ATTACHMENT_AGENTS: ReadonlySet<AgentType> = new Set<AgentType>([
+  'claude',
+  'openclaude',
+  'codex',
+  'gemini',
+  'cursor',
+  'copilot',
+  'droid',
+  // Why: Grok CLI turns bracket-pasted image paths into image chips.
+  'grok'
+])
+
+export function getAgentImageHandling(agent: AgentType): AgentImageHandling {
+  return IMAGE_ATTACHMENT_AGENTS.has(agent) ? 'attachment' : 'unsupported'
+}

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -102,6 +102,7 @@ export type KeybindingActionId =
   | 'settings.search'
   | 'terminal.copySelection'
   | 'terminal.paste'
+  | 'terminal.richInput.toggle'
   | 'terminal.search'
   | 'terminal.clear'
   | 'terminal.focusNextPane'
@@ -951,6 +952,19 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
       darwin: ['Mod+V'],
       linux: ['Ctrl+V', 'Ctrl+Shift+V', 'Shift+Insert'],
       win32: ['Ctrl+V', 'Ctrl+Shift+V', 'Shift+Insert']
+    }
+  },
+  {
+    id: 'terminal.richInput.toggle',
+    title: 'Toggle rich terminal input',
+    group: 'Terminal Panes',
+    scope: 'terminal',
+    searchKeywords: ['shortcut', 'terminal', 'prompt', 'composer', 'rich input', 'multiline'],
+    defaultBindings: {
+      darwin: ['Mod+I'],
+      // Why: keep Ctrl+I available to terminal applications on non-Mac hosts.
+      linux: ['Ctrl+Shift+M'],
+      win32: ['Ctrl+Shift+M']
     }
   },
   {


### PR DESCRIPTION
## Summary

Adds a Warp-inspired rich input dock to terminal panes so longer prompts can be composed without fighting raw terminal/TUI input constraints.

- Toggle the dock from the pane header or with `⌘I` on macOS / `Ctrl+Shift+M` on Windows and Linux.
- Compose multiline prompts with Enter to send, Shift+Enter for a newline, and Escape to close.
- Insert searchable `@file` mentions with Orca's existing file icons.
- Discover harness-specific slash commands at the first token.
- Paste or drop images as removable, filename-first attachments with lazy hover previews.
- Keep drafts and attachments scoped to each split-pane leaf.
- Submit through the owning PTY with staged-write recovery, stale-target checks, and runtime-aware local, WSL, SSH, and managed-runtime paths.

The composer is cross-harness rather than tied to one coding agent: multiline composition works across terminal sessions, while mentions, slash commands, and image handling are capability-gated for the active harness. The visual direction takes inspiration from Warp's easier composition model while staying within Orca's quieter, full-width terminal utility styling.

Closes #6034. Advances the broader input and context goals in #7084. Related to the terminal/TUI experience discussed in #7425; this PR does not attempt to implement that issue's separate smooth-scrolling scope.

## Screenshots

https://github.com/user-attachments/assets/a83f9df1-535f-47bd-8332-aafa1ac063d4

## Testing

- [ ] `pnpm lint` — the main lint pass and all remaining gates pass, but the full command currently stops on pre-existing switch-exhaustiveness errors in `native-chat-session-option-labels.ts` and `skill-freshness-group.tsx`, neither changed by this PR
- [x] `pnpm typecheck`
- [x] `pnpm test` — 31,383 passed, 52 skipped (run with inherited harness `GIT_CONFIG_*` variables unset so relay environment assertions use their expected baseline)
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, including composer serialization, autocomplete and keyboard behavior, paste ownership, image persistence and caching, native drops, staged PTY submission/reconciliation, split-pane lifecycle behavior, and settled TUI repaint handling

Additional checks passed: localization catalog/parity/coverage, reliability gates, max-lines ratchet, styled-scrollbar check, bundled-skill checks, and React Doctor lint. The feature was also exercised manually in a Claude alternate-screen session for open/close repaint behavior, text paste, file mentions, slash commands, image attachments, and hover previews.

## AI Review Report

A read-only UX/rendering review and a senior architecture review focused on PTY safety, split-pane ownership, full-screen TUI repaint behavior, scroll preservation, runtime path handling, resource bounds, accessibility, and regression coverage.

The review flagged speculative clipboard probes, raw-terminal paste leakage, duplicate retries after partial PTY writes, unrestricted preview caching, native-drop routing gaps, and a competing resize/scroll-restoration path. In response, this PR:

- isolates overlay-owned paste events and keeps ordinary text paste non-blocking;
- tracks image/text/Enter submission stages and retains only unsent content after failures;
- validates PTY ownership immediately before submission;
- bounds clipboard image bytes, dimensions, base64 payloads, thumbnails, and per-leaf caches;
- routes native and internal drops through runtime-aware upload/path resolution;
- uses one settled, dimension-checked resize through Orca's normal authority/hold path;
- adds reduced-motion behavior, menu accessibility semantics, and targeted regression tests.

A follow-up CodeRabbit review identified races around composer closure, transport disconnects, scope changes, and attachments added during submission, plus incomplete autocomplete ARIA relationships. Those paths now recheck their live owner/transport, preserve only newly added attachments, restore scope-keyed state, use platform-specific paste modifiers, expose complete listbox/active-option relationships, and have focused regression coverage. The new controls also consistently use Orca's shadcn `Button` primitive.

The review explicitly checked macOS, Linux, and Windows behavior: platform-aware shortcuts and labels, `CmdOrCtrl` conventions, path construction/quoting, shell-safe serialization, Electron IPC/preload boundaries, and local/WSL/SSH/runtime execution. No hardcoded macOS-only input behavior or path separators were introduced.

## Security Audit

Reviewed untrusted clipboard/drop data, filesystem authorization, IPC sender validation, command/PTY submission, path quoting, remote uploads, cache growth, and accidental secret/dependency exposure.

- Clipboard image IPC accepts trusted renderer senders only and enforces MIME, byte, dimension, and base64 limits before persistence/preview.
- Orca-created clipboard temp files receive narrow preview authorization; workspace filesystem access was not broadened.
- Dropped paths use existing native-file-drop and runtime upload resolution for local, WSL, SSH, and managed targets.
- File mentions serialize to quoted paths in ordinary shells and harness syntax only where supported.
- Enter is sent only after staged content succeeds and the same leaf still owns the PTY, reducing stale-target and duplicate-command risk.
- Attachment previews and caches are bounded and revoked/cleared with leaf lifecycle.
- No secrets or new dependencies were added.

No follow-up security issue is currently known.

## Notes

This is an initial cross-harness input surface. If it is well received, the interaction details and capability coverage can be refined further. Feedback is always welcome.

The dock intentionally avoids continuously animated terminal row resizing: it reserves real pane height, preserves user scroll intent through the existing fit path, and performs a settled alternate-screen repaint check to avoid clipped or stale TUI rows.

## ELI5

Terminal panes get an optional Warp-like rich input dock for longer prompts. Toggle it from the header or a shortcut, use multiline edit, @file mentions, slash commands, and send without fighting the raw TUI.
