### PR TITLE
fix(editor): preserve non-ASCII rich markdown saves

### DIFF
--- a/src/renderer/src/components/editor/rich-markdown-source-reconcile.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-source-reconcile.test.ts
@@ -48,6 +48,21 @@ describe('reconcileSerializedMarkdown', () => {
     expect(reconciled).not.toContain('- one')
   })
 
+  it('applies edits after non-ASCII text without dropping the save', () => {
+    const originalSource = '*   item\n\n터미널텔레그램통합실행마지막\n'
+    const baseCanonical = '- item\n\n터미널텔레그램통합실행마지막\n'
+    const edited = baseCanonical.replace('통합실행', '통합-실행')
+
+    const reconciled = reconcileSerializedMarkdown({
+      originalSource,
+      baseCanonical,
+      edited,
+      roundTrip: (markdown) => markdown.replace(/^\* +/, '- ')
+    })
+
+    expect(reconciled).toBe('*   item\n\n터미널텔레그램통합-실행마지막\n')
+  })
+
   it('preserves the trailing newline of the original source', () => {
     const originalSource = '# H\n\n_word_\n'
     const edited = fakeCanonicalize(originalSource).replace('# H', '# H!')

--- a/src/renderer/src/components/editor/rich-markdown-source-reconcile.ts
+++ b/src/renderer/src/components/editor/rich-markdown-source-reconcile.ts
@@ -3,7 +3,9 @@ import {
   cleanupEfficiency,
   cleanupSemantic,
   makeDiff,
-  makePatches
+  makePatches,
+  parsePatch,
+  stringifyPatches
 } from '@sanity/diff-match-patch'
 
 // Why: bound the safety re-parse cost — it builds a throwaway TipTap editor per
@@ -106,8 +108,13 @@ export function reconcileSerializedMarkdown({
     diffs = cleanupSemantic(diffs)
     diffs = cleanupEfficiency(diffs)
   }
-  const patches = makePatches(baseLf, diffs)
-  const [reconciledLf, results] = applyPatches(patches, originalSourceLf)
+  // `makePatches` stores start offsets as UCS-2, but `applyPatches` reads them
+  // as UTF-8 bytes. The wire format normalizes them; exceeding is allowed
+  // because the intentionally non-canonical target can shift a byte boundary.
+  const patches = parsePatch(stringifyPatches(makePatches(baseLf, diffs)))
+  const [reconciledLf, results] = applyPatches(patches, originalSourceLf, {
+    allowExceedingIndices: true
+  })
 
   // Branch 5: a hunk that failed to locate in the non-canonical source → the
   // fuzzy match is unreliable here, so fall back to canonical.


### PR DESCRIPTION
## Summary

- Fix rich Markdown saves for non-ASCII documents by normalizing `diff-match-patch` offsets through its public wire format before applying patches.
- Allow UTF-8 boundary overshoot when applying a patch to intentionally non-canonical source; the existing round-trip equivalence check still rejects a misplaced patch.
- Add a Korean regression case with shifted non-canonical Markdown bytes that failed with `Failed to determine byte offset` before this change.

Fixes #9158.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [x] `pnpm build`
- [x] Regression tests added/updated for changed behavior

Details:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/rich-markdown-source-reconcile.test.ts` — 27/27 passed.
- `pnpm typecheck` — passed on Node 24.11.1.
- `pnpm build` — passed, including desktop, web, relay, CLI, and macOS native builds.
- `pnpm lint` — changed files pass `oxlint`, `oxfmt --check`, and the pre-commit hooks. The full command reaches two unrelated existing `switch-exhaustiveness-check` errors in `native-chat-session-option-labels.ts` and `skill-freshness-group.tsx`; this branch does not modify either file.
- `pnpm test` — all 31,396 tests ran twice. The first run had one unrelated PTY timing failure; the second had one filesystem-watcher timing failure and a different PTY timing failure. Every failed test passed immediately when rerun alone. The changed reconciliation suite passed in both full runs.
- Manual Electron check on macOS: opened a real repo in Rich Editor, inserted `-` into `터미널텔레그램통합실행마지막`, saved, and verified the file contained `터미널텔레그램통합-실행마지막` while preserving the untouched non-canonical `*   item` bytes.

## AI Review Report

- Cross-platform: the change uses the dependency's platform-neutral parser/stringifier and existing apply option; no OS-specific APIs or path behavior changed. Logic is shared by macOS, Linux, and Windows renderers.
- Local/SSH/remote: reconciliation operates on strings after file loading and before the existing save request, so local, SSH, and remote-backed Markdown use the same fixed path. Manual validation covered local files; focused tests cover the provider-independent transform.
- Agents/integrations: no agent, provider, Git host, or external integration behavior changed.
- Performance: serialization/parsing is limited to generated patch hunks and remains behind the existing 50,000-code-unit reconciliation cap and bounded diff timeout.
- UI/accessibility: no UI, focus, keyboard, or accessibility behavior changed.
- Security: no new dependency, IPC surface, file access, or trust boundary. `parsePatch` consumes only a patch string generated in-process by `stringifyPatches`.
- Platform-specific validation: live app validation was performed on macOS with the repository-required Node 24. The reported Windows failure is in platform-independent JavaScript and is directly covered by the regression test.

## Security Audit

- No credentials, network requests, shell execution, or new user-controlled parser input introduced.
- Existing canonical round-trip validation remains the final guard against fuzzy patch misplacement or content corruption.

## Notes

- X: @Avichal2205
- No screenshot or recording is needed because rendered UI is unchanged; validation is behavioral and asserted on saved disk bytes.

## ELI5

Saving rich Markdown with Korean or other non-ASCII text could fail with a byte-offset error. Patch offsets are normalized for UTF-8 so those documents save correctly.
