### PR TITLE
fix(terminal): recover floating input after app refocus

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -823,6 +823,14 @@ describe('FloatingTerminalPanel close behavior', () => {
     mocks.setFloatingTerminalInputFocused.mockClear()
     mocks.focusTerminalTabSurface.mock.calls[0]?.[2].onImeRefocusSkipped()
     expect(mocks.setFloatingTerminalInputFocused).toHaveBeenCalledWith(false)
+
+    const newerFloatingInput = {
+      classList: { contains: (token: string) => token === 'xterm-helper-textarea' },
+      closest: vi.fn().mockReturnValue({})
+    }
+    Object.setPrototypeOf(newerFloatingInput, HTMLElement.prototype)
+    mocks.focusTerminalTabSurface.mock.calls[0]?.[2].onImeRefocusSkipped(newerFloatingInput)
+    expect(mocks.setFloatingTerminalInputFocused).toHaveBeenLastCalledWith(true)
   })
 
   it('preserves and reclaims terminal input ownership across window blur', async () => {

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -106,12 +106,14 @@ const mocks = vi.hoisted(() => ({
   getFloatingMarkdownDirectory: vi.fn(),
   getFloatingTerminalCwd: vi.fn(),
   getInstallStatus: vi.fn(),
+  isTerminalImeInputContextRefreshing: vi.fn(),
   isWebRuntimeSessionActive: vi.fn(),
   markFileDirty: vi.fn(),
   makePreviewFilePermanent: vi.fn(),
   openFile: vi.fn(),
   pickFloatingMarkdownDocument: vi.fn(),
   pinFile: vi.fn(),
+  setFloatingTerminalInputFocused: vi.fn(),
   setActiveTab: vi.fn(),
   setRenamingTabId: vi.fn(),
   setTabColor: vi.fn(),
@@ -183,6 +185,10 @@ vi.mock('@/components/terminal-pane/TerminalPane', () => ({
   default: function TerminalPane() {
     return null
   }
+}))
+
+vi.mock('@/components/terminal-pane/terminal-ime-input-context-refresh', () => ({
+  isTerminalImeInputContextRefreshing: mocks.isTerminalImeInputContextRefreshing
 }))
 
 vi.mock('@/components/browser-pane/BrowserPane', () => ({
@@ -744,6 +750,7 @@ describe('FloatingTerminalPanel close behavior', () => {
     mocks.getFloatingMarkdownDirectory.mockResolvedValue('/tmp/orca/floating-notes')
     mocks.getFloatingTerminalCwd.mockResolvedValue('/tmp/orca')
     mocks.getInstallStatus.mockResolvedValue({ state: 'installed', pathConfigured: true })
+    mocks.isTerminalImeInputContextRefreshing.mockReturnValue(false)
     mocks.isWebRuntimeSessionActive.mockReturnValue(false)
     mocks.pickFloatingMarkdownDocument.mockResolvedValue(null)
     const localStorage = {
@@ -762,7 +769,7 @@ describe('FloatingTerminalPanel close behavior', () => {
         },
         browser: { notifyActiveTabChanged: vi.fn() },
         cli: { getInstallStatus: mocks.getInstallStatus },
-        ui: { setFloatingTerminalInputFocused: vi.fn() }
+        ui: { setFloatingTerminalInputFocused: mocks.setFloatingTerminalInputFocused }
       },
       innerHeight: 800,
       innerWidth: 1200,
@@ -797,6 +804,102 @@ describe('FloatingTerminalPanel close behavior', () => {
     const element = await renderPanel(true)
 
     expect(getPanelClassName(element)).toContain('z-30')
+  })
+
+  it('refreshes terminal native input focus when the floating panel opens', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' })])
+
+    await renderPanel(true)
+    runEffects()
+
+    expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith(
+      'tab-1',
+      null,
+      expect.objectContaining({
+        onImeRefocusSkipped: expect.any(Function),
+        refreshImeContext: true
+      })
+    )
+    mocks.setFloatingTerminalInputFocused.mockClear()
+    mocks.focusTerminalTabSurface.mock.calls[0]?.[2].onImeRefocusSkipped()
+    expect(mocks.setFloatingTerminalInputFocused).toHaveBeenCalledWith(false)
+  })
+
+  it('preserves and reclaims terminal input ownership across window blur', async () => {
+    setFloatingTabs([makeTab({ id: 'tab-1' })])
+    const element = await renderPanel(true)
+    const panel = findByProp(element, 'data-floating-terminal-panel')
+    const panelElement = { contains: vi.fn().mockReturnValue(true), focus: vi.fn() }
+    const terminalInput = {
+      blur: vi.fn(),
+      classList: { contains: vi.fn((token: string) => token === 'xterm-helper-textarea') },
+      closest: vi.fn((selector: string) => {
+        if (selector === '[data-floating-terminal-panel]') {
+          return panelElement
+        }
+        return selector === '[data-leaf-id]'
+          ? {
+              getAttribute: (attribute: string) => (attribute === 'data-leaf-id' ? 'leaf-1' : null)
+            }
+          : null
+      }),
+      isConnected: true
+    }
+    Object.setPrototypeOf(panelElement, HTMLElement.prototype)
+    Object.setPrototypeOf(terminalInput, HTMLElement.prototype)
+    attachRef(panel.props.ref, panelElement)
+    mocks.isTerminalImeInputContextRefreshing.mockReturnValueOnce(true)
+    const onBlurCapture = panel.props.onBlurCapture as (event: unknown) => void
+    onBlurCapture({
+      relatedTarget: null,
+      target: terminalInput
+    })
+    expect(mocks.setFloatingTerminalInputFocused).not.toHaveBeenCalled()
+    const documentState = {
+      activeElement: terminalInput as unknown as HTMLElement | null,
+      addEventListener: vi.fn(),
+      body: {} as HTMLElement,
+      removeEventListener: vi.fn()
+    }
+    vi.stubGlobal('document', documentState)
+    runEffects()
+    const blurListener = vi
+      .mocked(window.addEventListener)
+      .mock.calls.findLast(([type]) => type === 'blur')?.[1] as (() => void) | undefined
+    const focusListener = vi
+      .mocked(window.addEventListener)
+      .mock.calls.find(([type]) => type === 'focus')?.[1] as (() => void) | undefined
+    if (!blurListener || !focusListener) {
+      throw new Error('floating terminal window focus listeners not registered')
+    }
+
+    blurListener()
+    expect(terminalInput.blur).not.toHaveBeenCalled()
+
+    focusListener()
+    expect(mocks.setFloatingTerminalInputFocused).toHaveBeenCalledWith(true)
+
+    documentState.activeElement = terminalInput as unknown as HTMLElement
+    blurListener()
+    documentState.activeElement = documentState.body
+    mocks.focusTerminalTabSurface.mockClear()
+    focusListener()
+    expect(mocks.focusTerminalTabSurface).not.toHaveBeenCalled()
+
+    documentState.activeElement = terminalInput as unknown as HTMLElement
+    blurListener()
+    terminalInput.isConnected = false
+    documentState.activeElement = documentState.body
+    focusListener()
+    expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith(
+      'tab-1',
+      'leaf-1',
+      expect.objectContaining({
+        onlyIfFocusUnclaimed: true,
+        onImeRefocusSkipped: expect.any(Function),
+        refreshImeContext: true
+      })
+    )
   })
 
   it('falls back to default bounds when persisted geometry is malformed', async () => {

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -584,7 +584,8 @@ export function FloatingTerminalPanel({
       return
     }
     focusTerminalTabSurface(activeTerminalId, null, {
-      onImeRefocusSkipped: () => setFloatingTerminalInputFocusedInMain(false),
+      onImeRefocusSkipped: (active) =>
+        setFloatingTerminalInputFocusedInMain(isFloatingWorkspaceTerminalInputTarget(active)),
       refreshImeContext: true
     })
   }, [activeTerminalId, open])
@@ -1367,7 +1368,8 @@ export function FloatingTerminalPanel({
         // tab/leaf recovery; the shared TerminalPane owner cannot reclaim it.
         focusTerminalTabSurface(activeTerminalId, reclaim.leafId, {
           onlyIfFocusUnclaimed: true,
-          onImeRefocusSkipped: () => setFloatingTerminalInputFocusedInMain(false),
+          onImeRefocusSkipped: (active) =>
+            setFloatingTerminalInputFocusedInMain(isFloatingWorkspaceTerminalInputTarget(active)),
           refreshImeContext: true
         })
       }

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -12,6 +12,7 @@ import { useContextualTour } from '@/components/contextual-tours/use-contextual-
 import TabBar from '@/components/tab-bar/TabBar'
 import { resolveGroupTabFromVisibleId } from '@/components/tab-group/tab-group-visible-id'
 import TerminalPane from '@/components/terminal-pane/TerminalPane'
+import { isTerminalImeInputContextRefreshing } from '@/components/terminal-pane/terminal-ime-input-context-refresh'
 import { Button } from '@/components/ui/button'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { useShortcutKeyDetails, type ShortcutKeyComboDetails } from '@/hooks/useShortcutLabel'
@@ -222,6 +223,10 @@ export function FloatingTerminalPanel({
   }
   const shortcutFocusFrameRef = useRef<number | null>(null)
   const shortcutFocusTimeoutRef = useRef<number | null>(null)
+  const reclaimTerminalInputOnWindowFocusRef = useRef<{
+    helper: HTMLElement
+    leafId: string | null
+  } | null>(null)
   const mountedRef = useMountedRef()
   const dragRef = useRef<{
     pointerId: number
@@ -578,7 +583,10 @@ export function FloatingTerminalPanel({
     if (!open || !activeTerminalId) {
       return
     }
-    focusTerminalTabSurface(activeTerminalId)
+    focusTerminalTabSurface(activeTerminalId, null, {
+      onImeRefocusSkipped: () => setFloatingTerminalInputFocusedInMain(false),
+      refreshImeContext: true
+    })
   }, [activeTerminalId, open])
 
   useEffect(() => {
@@ -1313,22 +1321,68 @@ export function FloatingTerminalPanel({
     const handleWindowBlur = (): void => {
       const panel = panelRef.current
       const active = document.activeElement
+      reclaimTerminalInputOnWindowFocusRef.current = null
       if (!panel || !(active instanceof HTMLElement) || !panel.contains(active)) {
         return
       }
       // Why: browser webviews focus out-of-process and do not emit renderer
       // pointerdown events, so release floating ownership on renderer blur too.
       setFloatingTerminalInputFocusedInMain(false)
+      if (isFloatingWorkspaceTerminalInputTarget(active)) {
+        // Why: the terminal focus lifecycle preserves this exact helper across
+        // app blur so macOS can rebuild its native input context on return.
+        reclaimTerminalInputOnWindowFocusRef.current = {
+          helper: active,
+          leafId: active.closest('[data-leaf-id]')?.getAttribute('data-leaf-id') ?? null
+        }
+        return
+      }
       active.blur()
+    }
+
+    const handleWindowFocus = (): void => {
+      const reclaim = reclaimTerminalInputOnWindowFocusRef.current
+      if (!reclaim) {
+        return
+      }
+      reclaimTerminalInputOnWindowFocusRef.current = null
+      const panel = panelRef.current
+      const active = document.activeElement
+      if (
+        panel &&
+        active instanceof HTMLElement &&
+        panel.contains(active) &&
+        isFloatingWorkspaceTerminalInputTarget(active)
+      ) {
+        setFloatingTerminalInputFocusedInMain(true)
+        return
+      }
+      if ((active === null || active === document.body) && activeTerminalId) {
+        if (reclaim.helper.isConnected && panel?.contains(reclaim.helper)) {
+          // Why: TerminalPane owns exact-helper reclaim and IME refresh. Avoid
+          // racing it with a second floating-layer blur/refocus cycle.
+          return
+        }
+        // Why: only a helper that genuinely remounted while backgrounded needs
+        // tab/leaf recovery; the shared TerminalPane owner cannot reclaim it.
+        focusTerminalTabSurface(activeTerminalId, reclaim.leafId, {
+          onlyIfFocusUnclaimed: true,
+          onImeRefocusSkipped: () => setFloatingTerminalInputFocusedInMain(false),
+          refreshImeContext: true
+        })
+      }
     }
 
     document.addEventListener('pointerdown', handleOutsidePointerDown, true)
     window.addEventListener('blur', handleWindowBlur)
+    window.addEventListener('focus', handleWindowFocus)
     return () => {
+      reclaimTerminalInputOnWindowFocusRef.current = null
       document.removeEventListener('pointerdown', handleOutsidePointerDown, true)
       window.removeEventListener('blur', handleWindowBlur)
+      window.removeEventListener('focus', handleWindowFocus)
     }
-  }, [open])
+  }, [activeTerminalId, open])
   const handleDragStart = (event: React.PointerEvent<HTMLDivElement>): void => {
     if (maximized) {
       return
@@ -1423,7 +1477,13 @@ export function FloatingTerminalPanel({
         commitUserBounds({ ...stagedBoundsRef.current, width: rect.width, height: rect.height })
       }}
       onFocusCapture={(event) => setFloatingTerminalInputFocused(event.target)}
-      onBlurCapture={(event) => setFloatingTerminalInputFocused(event.relatedTarget)}
+      onBlurCapture={(event) => {
+        // Why: keep terminal-first shortcut ownership latched during the
+        // synchronous macOS IME refresh blur; refocus or its skip callback settles it.
+        if (!isTerminalImeInputContextRefreshing(event.target)) {
+          setFloatingTerminalInputFocused(event.relatedTarget)
+        }
+      }}
       onKeyDownCapture={handleShortcutSurfaceKeyDown}
     >
       <div className="relative flex h-full w-full min-h-0 flex-col overflow-hidden rounded-lg border border-black/14 bg-card dark:border-white/14">

--- a/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.test.ts
+++ b/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.test.ts
@@ -154,12 +154,13 @@ describe('regular terminal focus ownership', () => {
     })
 
     expect(synced).toBe(true)
-    expect(syncFocused).toHaveBeenCalledWith(true)
+    expect(syncFocused).not.toHaveBeenCalled()
     // Why: reclaim is deferred so a newer focus owner during reactivation wins.
     expect(focus).not.toHaveBeenCalled()
     for (const run of scheduled) {
       run()
     }
+    expect(syncFocused).toHaveBeenCalledWith(true)
     expect(focus).toHaveBeenCalledOnce()
     expect(document.activeElement).toBe(helper)
   })
@@ -220,6 +221,7 @@ describe('regular terminal focus ownership', () => {
       syncFocused
     })
     document.body.focus()
+    syncFocused.mockClear()
     focus.mockClear()
     const scheduled: (() => void)[] = []
 
@@ -238,6 +240,7 @@ describe('regular terminal focus ownership', () => {
     }
 
     expect(focus).not.toHaveBeenCalled()
+    expect(syncFocused).toHaveBeenCalledWith(false)
     expect(document.activeElement).toBe(outside)
   })
 
@@ -355,6 +358,7 @@ describe('regular terminal focus ownership', () => {
       run()
     }
     expect(focus).not.toHaveBeenCalled()
+    expect(syncFocused).toHaveBeenLastCalledWith(false)
     expect(document.activeElement).toBe(outside)
   })
 

--- a/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.test.ts
+++ b/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.test.ts
@@ -204,6 +204,39 @@ describe('regular terminal focus ownership', () => {
     expect(document.activeElement).toBe(secondHelper)
   })
 
+  it('keeps ownership clear when the released helper cannot accept focus', () => {
+    const pane = appendPane()
+    const helper = appendHelper(pane)
+    const syncFocused = vi.fn()
+    helper.focus()
+
+    const releasedHelper = releaseTerminalFocusForWindowBlur({
+      container: pane,
+      activeElement: helper,
+      syncFocused
+    })
+    document.body.focus()
+    syncFocused.mockClear()
+    vi.spyOn(helper, 'focus').mockImplementation(() => undefined)
+    const scheduled: (() => void)[] = []
+
+    resyncTerminalFocusForWindowFocus({
+      container: pane,
+      activeElement: document.activeElement,
+      syncFocused,
+      releasedHelper,
+      isMac: false,
+      scheduleRefocus: (callback) => scheduled.push(callback)
+    })
+    for (const run of scheduled) {
+      run()
+    }
+
+    expect(document.activeElement).toBe(document.body)
+    expect(syncFocused).toHaveBeenCalledOnce()
+    expect(syncFocused).toHaveBeenCalledWith(false)
+  })
+
   it('does not yank focus back into the terminal if the user clicked elsewhere during reactivation', () => {
     // Why: the Linux reclaim path must honor the same "newer focus owner wins"
     // guard the macOS path uses, so a click into the sidebar/dialog isn't stolen.
@@ -242,6 +275,40 @@ describe('regular terminal focus ownership', () => {
     expect(focus).not.toHaveBeenCalled()
     expect(syncFocused).toHaveBeenCalledWith(false)
     expect(document.activeElement).toBe(outside)
+  })
+
+  it('does not clear ownership published by a newer terminal during deferred reclaim', () => {
+    const pane = appendPane()
+    const helper = appendHelper(pane)
+    const newerPane = appendPane()
+    const newerHelper = appendHelper(newerPane)
+    const syncFocused = vi.fn()
+    helper.focus()
+
+    const releasedHelper = releaseTerminalFocusForWindowBlur({
+      container: pane,
+      activeElement: helper,
+      syncFocused
+    })
+    document.body.focus()
+    syncFocused.mockClear()
+    const scheduled: (() => void)[] = []
+
+    resyncTerminalFocusForWindowFocus({
+      container: pane,
+      activeElement: document.activeElement,
+      syncFocused,
+      releasedHelper,
+      isMac: false,
+      scheduleRefocus: (callback) => scheduled.push(callback)
+    })
+    newerHelper.focus()
+    for (const run of scheduled) {
+      run()
+    }
+
+    expect(document.activeElement).toBe(newerHelper)
+    expect(syncFocused).not.toHaveBeenCalled()
   })
 
   it('does not reclaim a released helper that was detached from the DOM before refocus', () => {
@@ -360,6 +427,31 @@ describe('regular terminal focus ownership', () => {
     expect(focus).not.toHaveBeenCalled()
     expect(syncFocused).toHaveBeenLastCalledWith(false)
     expect(document.activeElement).toBe(outside)
+  })
+
+  it('does not clear ownership published by a newer terminal during IME refresh', () => {
+    const pane = appendPane()
+    const helper = appendHelper(pane)
+    const newerHelper = appendHelper(appendPane())
+    const syncFocused = vi.fn()
+    helper.focus()
+    const scheduled: (() => void)[] = []
+
+    resyncTerminalFocusForWindowFocus({
+      container: pane,
+      activeElement: document.activeElement,
+      syncFocused,
+      isMac: true,
+      scheduleRefocus: (callback) => scheduled.push(callback)
+    })
+    syncFocused.mockClear()
+    newerHelper.focus()
+    for (const run of scheduled) {
+      run()
+    }
+
+    expect(document.activeElement).toBe(newerHelper)
+    expect(syncFocused).not.toHaveBeenCalled()
   })
 
   it('skips the blur/refocus cycle on non-macOS platforms', () => {

--- a/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.ts
+++ b/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.ts
@@ -113,7 +113,7 @@ export function resyncTerminalFocusForWindowFocus(args: {
     const schedule = args.scheduleRefocus ?? scheduleNextFrame
     schedule(() => {
       if (!reclaimedHelper.isConnected) {
-        args.syncFocused(false)
+        syncFocusAfterFailedReclaim(reclaimedHelper.ownerDocument.activeElement, args.syncFocused)
         return
       }
       const active = reclaimedHelper.ownerDocument.activeElement
@@ -121,11 +121,15 @@ export function resyncTerminalFocusForWindowFocus(args: {
         active === reclaimedHelper ||
         isDocumentBodyOrNull(active, reclaimedHelper.ownerDocument)
       ) {
-        args.syncFocused(true)
         reclaimedHelper.focus()
+        if (reclaimedHelper.ownerDocument.activeElement === reclaimedHelper) {
+          args.syncFocused(true)
+        } else {
+          syncFocusAfterFailedReclaim(reclaimedHelper.ownerDocument.activeElement, args.syncFocused)
+        }
         return
       }
-      args.syncFocused(false)
+      syncFocusAfterFailedReclaim(active, args.syncFocused)
     })
     return true
   }
@@ -138,11 +142,22 @@ export function resyncTerminalFocusForWindowFocus(args: {
     isMac: args.isMac,
     // Why: if another control wins during the refresh frame, the terminal
     // mirror must follow that owner instead of remaining latched true.
-    onRefocusSkipped: () => args.syncFocused(false),
+    onRefocusSkipped: (active) => syncFocusAfterFailedReclaim(active, args.syncFocused),
     scheduleRefocus: args.scheduleRefocus
   })
 
   return true
+}
+
+function syncFocusAfterFailedReclaim(
+  activeElement: Element | null,
+  syncFocused: TerminalInputFocusSync
+): void {
+  // Why: a later xterm focusin already published terminal ownership; an older
+  // deferred reclaim must not overwrite that newer process-wide mirror.
+  if (!isXtermHelperTextarea(activeElement)) {
+    syncFocused(false)
+  }
 }
 
 function isNode(value: EventTarget | null): value is Node {

--- a/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.ts
+++ b/src/renderer/src/components/terminal-pane/regular-terminal-focus-ownership.ts
@@ -102,8 +102,6 @@ export function resyncTerminalFocusForWindowFocus(args: {
     }
   }
 
-  args.syncFocused(true)
-
   const reclaimedHelper = helper
 
   // Why: defer the reclaim refocus to the next frame and only take focus if
@@ -115,6 +113,7 @@ export function resyncTerminalFocusForWindowFocus(args: {
     const schedule = args.scheduleRefocus ?? scheduleNextFrame
     schedule(() => {
       if (!reclaimedHelper.isConnected) {
+        args.syncFocused(false)
         return
       }
       const active = reclaimedHelper.ownerDocument.activeElement
@@ -122,16 +121,24 @@ export function resyncTerminalFocusForWindowFocus(args: {
         active === reclaimedHelper ||
         isDocumentBodyOrNull(active, reclaimedHelper.ownerDocument)
       ) {
+        args.syncFocused(true)
         reclaimedHelper.focus()
+        return
       }
+      args.syncFocused(false)
     })
     return true
   }
+
+  args.syncFocused(true)
 
   // Why: macOS app reactivation leaves a stale NSTextInputContext on the
   // still-focused helper (electron#32307/#34952); non-mac returns false inside.
   refreshTerminalImeInputContext(reclaimedHelper, {
     isMac: args.isMac,
+    // Why: if another control wins during the refresh frame, the terminal
+    // mirror must follow that owner instead of remaining latched true.
+    onRefocusSkipped: () => args.syncFocused(false),
     scheduleRefocus: args.scheduleRefocus
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-ime-input-context-refresh.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-input-context-refresh.test.ts
@@ -98,7 +98,27 @@ describe('refreshTerminalImeInputContext', () => {
     for (const run of scheduled) {
       run()
     }
-    expect(onRefocusSkipped).toHaveBeenCalledOnce()
+    expect(onRefocusSkipped).toHaveBeenCalledWith(outside)
+  })
+
+  it('reports when a connected helper cannot accept the scheduled focus', () => {
+    const helper = appendHelper()
+    const onRefocusSkipped = vi.fn()
+    const scheduled: (() => void)[] = []
+    helper.focus()
+
+    refreshTerminalImeInputContext(helper, {
+      isMac: true,
+      onRefocusSkipped,
+      scheduleRefocus: (callback) => scheduled.push(callback)
+    })
+    vi.spyOn(helper, 'focus').mockImplementation(() => undefined)
+    for (const run of scheduled) {
+      run()
+    }
+
+    expect(document.activeElement).toBe(document.body)
+    expect(onRefocusSkipped).toHaveBeenCalledWith(document.body)
   })
 
   it('skips non-macOS platforms', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-ime-input-context-refresh.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-input-context-refresh.test.ts
@@ -1,6 +1,9 @@
 // @vitest-environment happy-dom
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { refreshTerminalImeInputContext } from './terminal-ime-input-context-refresh'
+import {
+  isTerminalImeInputContextRefreshing,
+  refreshTerminalImeInputContext
+} from './terminal-ime-input-context-refresh'
 
 describe('refreshTerminalImeInputContext', () => {
   beforeEach(() => {
@@ -38,6 +41,23 @@ describe('refreshTerminalImeInputContext', () => {
     expect(document.activeElement).toBe(helper)
   })
 
+  it('marks only the synchronous refresh blur so focus ownership can stay latched', () => {
+    const helper = appendHelper()
+    let refreshingDuringBlur = false
+    helper.addEventListener('blur', (event) => {
+      refreshingDuringBlur = isTerminalImeInputContextRefreshing(event.target)
+    })
+    helper.focus()
+
+    refreshTerminalImeInputContext(helper, {
+      isMac: true,
+      scheduleRefocus: vi.fn()
+    })
+
+    expect(refreshingDuringBlur).toBe(true)
+    expect(isTerminalImeInputContextRefreshing(helper)).toBe(false)
+  })
+
   it('does not steal focus if another element grabbed it before the refocus frame', () => {
     const helper = appendHelper()
     const outside = document.createElement('input')
@@ -58,6 +78,27 @@ describe('refreshTerminalImeInputContext', () => {
     }
     expect(focus).not.toHaveBeenCalled()
     expect(document.activeElement).toBe(outside)
+  })
+
+  it('reports when a newer focus owner wins the refocus guard', () => {
+    const helper = appendHelper()
+    const outside = document.createElement('input')
+    document.body.appendChild(outside)
+    const onRefocusSkipped = vi.fn()
+    const scheduled: (() => void)[] = []
+    helper.focus()
+
+    refreshTerminalImeInputContext(helper, {
+      isMac: true,
+      onRefocusSkipped,
+      scheduleRefocus: (callback) => scheduled.push(callback)
+    })
+
+    outside.focus()
+    for (const run of scheduled) {
+      run()
+    }
+    expect(onRefocusSkipped).toHaveBeenCalledOnce()
   })
 
   it('skips non-macOS platforms', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-ime-input-context-refresh.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-input-context-refresh.ts
@@ -3,8 +3,16 @@ export type TerminalImeInputContextRefocusScheduler = (callback: () => void) => 
 export type TerminalImeInputContextRefreshOptions = {
   /** Override the macOS check (tests). Defaults to the navigator user agent. */
   isMac?: boolean
+  /** Called when a newer focus owner prevents the scheduled refocus. */
+  onRefocusSkipped?: () => void
   /** Override the refocus scheduler (tests). Defaults to requestAnimationFrame. */
   scheduleRefocus?: TerminalImeInputContextRefocusScheduler
+}
+
+const refreshingHelpers = new WeakSet<HTMLElement>()
+
+export function isTerminalImeInputContextRefreshing(target: EventTarget | null): boolean {
+  return target instanceof HTMLElement && refreshingHelpers.has(target)
 }
 
 function isMacUserAgent(): boolean {
@@ -38,17 +46,25 @@ export function refreshTerminalImeInputContext(
   const ownerDocument = helper.ownerDocument
   // Why: Electron/Chromium can keep a stale NSTextInputContext on the xterm
   // helper after focus handoffs; blur/refocus rebuilds it so CJK IMEs work.
-  helper.blur()
+  refreshingHelpers.add(helper)
+  try {
+    helper.blur()
+  } finally {
+    refreshingHelpers.delete(helper)
+  }
 
   const schedule = options.scheduleRefocus ?? scheduleNextFrame
   schedule(() => {
     const active = ownerDocument.activeElement
     if (!helper.isConnected) {
+      options.onRefocusSkipped?.()
       return
     }
     if (active === helper || isDocumentBodyOrNull(active, ownerDocument)) {
       helper.focus()
+      return
     }
+    options.onRefocusSkipped?.()
   })
 
   return true

--- a/src/renderer/src/components/terminal-pane/terminal-ime-input-context-refresh.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-input-context-refresh.ts
@@ -3,8 +3,8 @@ export type TerminalImeInputContextRefocusScheduler = (callback: () => void) => 
 export type TerminalImeInputContextRefreshOptions = {
   /** Override the macOS check (tests). Defaults to the navigator user agent. */
   isMac?: boolean
-  /** Called when a newer focus owner prevents the scheduled refocus. */
-  onRefocusSkipped?: () => void
+  /** Called with the settled owner when the scheduled refocus does not land. */
+  onRefocusSkipped?: (activeElement: Element | null) => void
   /** Override the refocus scheduler (tests). Defaults to requestAnimationFrame. */
   scheduleRefocus?: TerminalImeInputContextRefocusScheduler
 }
@@ -55,16 +55,19 @@ export function refreshTerminalImeInputContext(
 
   const schedule = options.scheduleRefocus ?? scheduleNextFrame
   schedule(() => {
-    const active = ownerDocument.activeElement
     if (!helper.isConnected) {
-      options.onRefocusSkipped?.()
+      options.onRefocusSkipped?.(ownerDocument.activeElement)
       return
     }
+    const active = ownerDocument.activeElement
     if (active === helper || isDocumentBodyOrNull(active, ownerDocument)) {
       helper.focus()
+      if (ownerDocument.activeElement !== helper) {
+        options.onRefocusSkipped?.(ownerDocument.activeElement)
+      }
       return
     }
-    options.onRefocusSkipped?.()
+    options.onRefocusSkipped?.(active)
   })
 
   return true

--- a/src/renderer/src/lib/focus-terminal-tab-surface.test.ts
+++ b/src/renderer/src/lib/focus-terminal-tab-surface.test.ts
@@ -1,8 +1,17 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { focusTerminalTabSurface } from './focus-terminal-tab-surface'
 
+const mocks = vi.hoisted(() => ({
+  refreshTerminalImeInputContext: vi.fn()
+}))
+
+vi.mock('@/components/terminal-pane/terminal-ime-input-context-refresh', () => ({
+  refreshTerminalImeInputContext: mocks.refreshTerminalImeInputContext
+}))
+
 describe('focusTerminalTabSurface', () => {
   afterEach(() => {
+    mocks.refreshTerminalImeInputContext.mockClear()
     vi.unstubAllGlobals()
   })
 
@@ -26,6 +35,50 @@ describe('focusTerminalTabSurface', () => {
     focusTerminalTabSurface('tab-1')
 
     expect(textarea.focus).toHaveBeenCalled()
+  })
+
+  it('optionally refreshes the focused helper native input context', () => {
+    flushAnimationFrames()
+    const textarea = { focus: vi.fn() }
+    vi.stubGlobal('document', {
+      querySelector: vi.fn((selector: string) =>
+        selector === '[data-terminal-tab-id="tab-1"] .xterm-helper-textarea' ? textarea : null
+      )
+    })
+
+    focusTerminalTabSurface('tab-1', null, { refreshImeContext: true })
+
+    expect(textarea.focus).toHaveBeenCalledOnce()
+    expect(mocks.refreshTerminalImeInputContext).toHaveBeenCalledWith(textarea, {
+      onRefocusSkipped: undefined
+    })
+  })
+
+  it('does not steal focus from a newer owner during guarded remount recovery', () => {
+    const frames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      frames.push(callback)
+      return frames.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    const textarea = { focus: vi.fn() }
+    const body = {}
+    const outside = {}
+    const documentState = {
+      activeElement: body as unknown,
+      body,
+      querySelector: vi.fn((selector: string) =>
+        selector === '[data-terminal-tab-id="tab-1"] .xterm-helper-textarea' ? textarea : null
+      )
+    }
+    vi.stubGlobal('document', documentState)
+
+    focusTerminalTabSurface('tab-1', null, { onlyIfFocusUnclaimed: true })
+    frames.shift()?.(0)
+    documentState.activeElement = outside
+    frames.shift()?.(0)
+
+    expect(textarea.focus).not.toHaveBeenCalled()
   })
 
   it('does not steal focus while inline tab rename is open', () => {

--- a/src/renderer/src/lib/focus-terminal-tab-surface.ts
+++ b/src/renderer/src/lib/focus-terminal-tab-surface.ts
@@ -15,7 +15,7 @@ let pendingFocusFrameIds: number[] = []
 
 type FocusTerminalTabSurfaceOptions = {
   onlyIfFocusUnclaimed?: boolean
-  onImeRefocusSkipped?: () => void
+  onImeRefocusSkipped?: (activeElement: Element | null) => void
   refreshImeContext?: boolean
 }
 

--- a/src/renderer/src/lib/focus-terminal-tab-surface.ts
+++ b/src/renderer/src/lib/focus-terminal-tab-surface.ts
@@ -1,3 +1,5 @@
+import { refreshTerminalImeInputContext } from '@/components/terminal-pane/terminal-ime-input-context-refresh'
+
 /**
  * Move keyboard focus into the xterm instance for a freshly-mounted terminal
  * tab. Handles the two-step race where React must first mount the new
@@ -10,6 +12,29 @@ function cssAttributeString(value: string): string {
 }
 
 let pendingFocusFrameIds: number[] = []
+
+type FocusTerminalTabSurfaceOptions = {
+  onlyIfFocusUnclaimed?: boolean
+  onImeRefocusSkipped?: () => void
+  refreshImeContext?: boolean
+}
+
+function focusTerminalHelper(helper: HTMLElement, options: FocusTerminalTabSurfaceOptions): void {
+  if (options.onlyIfFocusUnclaimed) {
+    const active = document.activeElement
+    if (active !== helper && active !== null && active !== document.body) {
+      return
+    }
+  }
+  helper.focus()
+  if (options.refreshImeContext) {
+    // Why: a CSS-hidden, long-lived xterm can retain a stale macOS native text
+    // input context even after DOM focus returns; blur/refocus rebuilds it.
+    refreshTerminalImeInputContext(helper, {
+      onRefocusSkipped: options.onImeRefocusSkipped
+    })
+  }
+}
 
 function cancelPendingFocusFrames(): void {
   if (typeof cancelAnimationFrame === 'function') {
@@ -29,7 +54,11 @@ function canUseSinglePaneStaleLeafFallback(tabId: string, leafId: string): boole
   return expectedLeafIds?.length === 1 && !expectedLeafIds.includes(leafId)
 }
 
-export function focusTerminalTabSurface(tabId: string, leafId?: string | null): void {
+export function focusTerminalTabSurface(
+  tabId: string,
+  leafId?: string | null,
+  options: FocusTerminalTabSurfaceOptions = {}
+): void {
   cancelPendingFocusFrames()
   const firstFrameId = requestAnimationFrame(() => {
     pendingFocusFrameIds = pendingFocusFrameIds.filter((frameId) => frameId !== firstFrameId)
@@ -46,7 +75,7 @@ export function focusTerminalTabSurface(tabId: string, leafId?: string | null): 
         : `[data-terminal-tab-id="${escapedTabId}"] .xterm-helper-textarea`
       const scoped = document.querySelector(scopedSelector) as HTMLElement | null
       if (scoped) {
-        scoped.focus()
+        focusTerminalHelper(scoped, options)
         return
       }
       if (leafId) {
@@ -62,13 +91,17 @@ export function focusTerminalTabSurface(tabId: string, leafId?: string | null): 
         )
         if (tabScopedHelpers.length === 1) {
           const fallback = tabScopedHelpers.item(0) as HTMLElement | null
-          fallback?.focus()
+          if (fallback) {
+            focusTerminalHelper(fallback, options)
+          }
           return
         }
         return
       }
       const fallback = document.querySelector('.xterm-helper-textarea') as HTMLElement | null
-      fallback?.focus()
+      if (fallback) {
+        focusTerminalHelper(fallback, options)
+      }
     })
     pendingFocusFrameIds.push(secondFrameId)
   })


### PR DESCRIPTION
## Summary

Fix floating-workspace terminals that remain visible and connected after Orca is backgrounded but stop accepting keyboard input on return.

The floating panel now preserves xterm's helper across renderer blur, lets the shared `TerminalPane` lifecycle perform the established exact-helper/IME recovery, and only performs tab+leaf fallback when that helper genuinely remounted while backgrounded. Deferred recovery verifies that focus actually landed and cannot overwrite ownership already published by a newer xterm.

## Regression history

This area has accumulated several overlapping focus fixes:

- #2801 added a floating-panel blur handler to release stale floating shortcut ownership for browser webviews. It also explicitly blurred the active xterm helper.
- #6417 added macOS `NSTextInputContext` refresh after app/window switching.
- #6867 added exact-split reclaim, detached-helper safety, and the cross-platform "newer focus owner wins" guard.
- #7102 centralized the macOS IME refresh and latched terminal-first shortcut ownership through its synchronous blur/refocus handoff.

The later fixes live in `TerminalPane`; the floating panel retained its separate #2801 blur lifecycle. That meant it could erase the helper the shared lifecycle expected to reclaim. An initial floating-specific refresh also reproduced a swallowed first character because it raced `TerminalPane` with a second blur/refocus cycle.

This change makes `TerminalPane` the single owner for surviving-helper recovery. The floating layer still clears its process-wide shortcut mirror on blur (preserving #2801's browser-webview behavior), restores that mirror when the same xterm remains active, and uses guarded tab+leaf recovery only for a detached/remounted helper.

The shared recovery now settles its focus mirror only after deferred reclaim actually wins. A failed focus clears stale ownership, while a newer xterm owner remains authoritative instead of being overwritten by an older scheduled callback.

## Electron verification

Validated in an isolated dev instance for this worktree via CDP and a real macOS native app switch:

1. Focused the actual floating xterm and executed a baseline command.
2. Activated TextEdit, then reactivated this exact Electron process.
3. Waited for the established next-frame focus recovery.
4. Typed `echo ORCA_SINGLE_REFRESH_AFTER_REACTIVATE` without clicking the terminal again.
5. Observed the complete command and output, with the leading `e` intact and the xterm helper still active.

![orca-seacucumber-single-refresh.png](https://github.com/user-attachments/assets/356915e3-8101-4dc0-8564-bfa8655d1950)

The same validation caught and removed the duplicate floating/TerminalPane refresh before the final run.

## Reliability evidence

- **Invariant (`terminal-platform.live-pty-liveness` / terminal focus ownership):** after renderer-window reactivation, the exact previously focused floating xterm helper either regains keyboard focus and process-wide terminal shortcut ownership, or yields to a newer focus owner without stealing focus or publishing stale ownership.
- **Failure source:** the reported floating terminal stayed visible and PTY-connected after an app switch but stopped accepting input; the overlapping #2801, #6417, #6867, and #7102 lifecycles could also create duplicate refreshes or stale focus mirrors.
- **Oracle:** a real macOS TextEdit round trip accepted the complete first command without a click, while deterministic tests prove exact-split reclaim, detached/remounted fallback, focus-failure settlement, newer-control wins, and newer-xterm mirror preservation.
- **Gate:** primary mapping is experimental gate `terminal-platform.live-pty-liveness`; the macOS IME refresh is also supported by partial gate `terminal-input.ime-and-synthetic-forwarding`. Main still has no executable native app-reactivation command for the primary gate, so live cross-platform focus coverage remains an accepted gap.
- **Provider/platform coverage:** local macOS is covered by the native app-switch artifact and renderer tests. Linux/Windows non-mac behavior is covered deterministically but lacks a live native app-switch run. Daemon, SSH/remote, WSL, and mobile/relay transports are unaffected: the change is renderer-only and adds no PTY/provider operation; mobile/relay has no desktop window-focus lifecycle.
- **Performance budget:** each window-focus event adds only bounded active-element/containment checks. The tab/leaf DOM lookup runs only for an actual detached-helper recovery, and the macOS input-context refresh schedules one bounded next-frame callback. No polling, provider/session listing, PTY IPC, subprocess, store scan, recurring timer, or unbounded retained state was added. Count assertions prove a failed reclaim publishes one clearing update and a newer xterm causes zero stale clearing updates.
- **Diagnostics:** the exact-helper identity, active-element result, mirror callback counts, native input command/output, and screenshot are retained as test/manual artifacts. No high-frequency production logging was added to this focus path.
- **Residual gaps:** no automated real-OS app switch/IME oracle exists for Linux or Windows, and the experimental live-PTY gate on main has no command. Real OS IME language coverage remains owned by `terminal-input.ime-and-synthetic-forwarding`.

## Testing

- Four changed focus/IME/floating suites: 95 passed
- Registered IME gate plus adjacent floating/new-workspace/main-shortcut suites: 274 passed
- Adjacent terminal global-effects, lifecycle, and IPC suites: 123 passed
- Electron headless floating terminal shortcut journey: 1 passed
- `pnpm run typecheck:web`
- `pnpm exec oxlint` on all changed files
- `pnpm exec oxfmt --check` on all changed files
- `pnpm run check:max-lines-ratchet`
- `pnpm run check:reliability-gates`
- `git diff --check`

## Compatibility

- macOS-only native input-context refresh remains runtime-gated.
- Linux/Windows retain deferred, guarded exact-helper reclaim without a macOS blur/refocus cycle.
- No PTY transport, command construction, path handling, or IPC surface changed, so local, daemon, WSL, SSH, and remote-runtime terminals use the same renderer-only recovery.
