### PR TITLE
fix(agent-status): follow daemon-hosted Claude sessions to their true pane (spawn pin + fork lineage + prompt-time rebind)

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -7434,3 +7434,117 @@ describe('AgentHookServer provider-session pane attribution', () => {
     expect(internals.providerSessionPanes.has(`session-${total - 1}`)).toBe(true)
   })
 })
+
+describe('AgentHookServer fork lineage and input rebind', () => {
+  const postClaude = (
+    server: AgentHookServer,
+    payload: Record<string, unknown>
+  ): Promise<Response> => {
+    const env = server.buildPtyEnv()
+    return fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/claude`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+      },
+      body: JSON.stringify(buildBody(payload))
+    })
+  }
+
+  it('inherits the parent binding for a resume-forked session via the daemon roster', async () => {
+    const configDir = mkdtempSync(join(tmpdir(), 'orca-claude-config-'))
+    const parentId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+    const forkId = 'bbbbbbbb-cccc-4ddd-8eee-ffffffffffff'
+    const projectDir = join(configDir, 'projects', '-tmp-proj')
+    mkdirSync(projectDir, { recursive: true })
+    mkdirSync(join(configDir, 'daemon'), { recursive: true })
+    writeFileSync(
+      join(configDir, 'daemon', 'roster.json'),
+      JSON.stringify({
+        workers: {
+          [forkId.slice(0, 8)]: {
+            sessionId: forkId,
+            dispatch: { launch: { mode: 'resume', sessionId: `/x/${parentId}.jsonl` } }
+          }
+        }
+      })
+    )
+
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      server.registerProviderSessionPane(parentId, GOOD_PANE, 'pty-parent')
+      await expect(
+        postClaude(server, {
+          hook_event_name: 'UserPromptSubmit',
+          prompt: 'forked turn',
+          session_id: forkId,
+          transcript_path: join(projectDir, `${forkId}.jsonl`)
+        })
+      ).resolves.toMatchObject({ status: 204 })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ paneKey: GOOD_PANE, prompt: 'forked turn' })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('binds an unknown session at prompt time to the pane with fresh input', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      server.setClaudePaneInputProbe(() => ({ paneKey: GOOD_PANE, ptyId: 'pty-live' }))
+      await expect(
+        postClaude(server, {
+          hook_event_name: 'UserPromptSubmit',
+          prompt: 'attached turn',
+          session_id: 'cccccccc-dddd-4eee-8fff-000000000000'
+        })
+      ).resolves.toMatchObject({ status: 204 })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ paneKey: GOOD_PANE, prompt: 'attached turn' })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('does not steal a pane for mid-turn events or when the probe is empty', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      // Probe returns null (no recent input) — prompt stays on the posted pane.
+      server.setClaudePaneInputProbe(() => null)
+      await expect(
+        postClaude(server, {
+          hook_event_name: 'UserPromptSubmit',
+          prompt: 'no signal',
+          session_id: 'dddddddd-eeee-4fff-8000-111111111111'
+        })
+      ).resolves.toMatchObject({ status: 204 })
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ paneKey: PANE, prompt: 'no signal' })
+      ])
+
+      // Mid-turn tool event never consults the probe even when it has signal.
+      let probed = 0
+      server.setClaudePaneInputProbe(() => {
+        probed += 1
+        return { paneKey: GOOD_PANE, ptyId: 'pty-live' }
+      })
+      await expect(
+        postClaude(server, {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Bash',
+          session_id: 'dddddddd-eeee-4fff-8000-111111111111'
+        })
+      ).resolves.toMatchObject({ status: 204 })
+      expect(probed).toBe(0)
+    } finally {
+      server.stop()
+    }
+  })
+})

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -7334,3 +7334,103 @@ describe('AgentHookServer closed-tab suppression bound', () => {
     expect(internals.closedAgentStatusTabIds.has(`closed-tab-${total - 1}`)).toBe(true)
   })
 })
+
+describe('AgentHookServer provider-session pane attribution', () => {
+  it('re-attributes a daemon-hosted claude hook post to the spawn-pinned pane', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const sessionId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+      server.registerProviderSessionPane(sessionId, GOOD_PANE, 'pty-1')
+
+      // Daemon workers inherit the daemon's stale pane key (PANE here), but
+      // the payload's session_id names the pinned session.
+      const response = await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/claude`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+        },
+        body: JSON.stringify(
+          buildBody({
+            hook_event_name: 'UserPromptSubmit',
+            prompt: 'daemon-hosted turn',
+            session_id: sessionId
+          })
+        )
+      })
+
+      expect(response.status).toBe(204)
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: GOOD_PANE,
+          state: 'working',
+          prompt: 'daemon-hosted turn'
+        })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('leaves posts with unknown session ids on their posted pane', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      server.registerProviderSessionPane(
+        'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+        GOOD_PANE,
+        'pty-1'
+      )
+
+      const response = await fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/claude`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+        },
+        body: JSON.stringify(
+          buildBody({
+            hook_event_name: 'UserPromptSubmit',
+            prompt: 'unpinned session',
+            session_id: 'ffffffff-0000-4000-8000-000000000000'
+          })
+        )
+      })
+
+      expect(response.status).toBe(204)
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({ paneKey: PANE, prompt: 'unpinned session' })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('drops a session binding when its spawning PTY exits', () => {
+    const server = new AgentHookServer()
+    const sessionId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+    server.registerProviderSessionPane(sessionId, GOOD_PANE, 'pty-1')
+    server.clearProviderSessionPanesForPty('pty-1')
+    const internals = server as unknown as {
+      providerSessionPanes: Map<string, { paneKey: string; ptyId: string }>
+    }
+    expect(internals.providerSessionPanes.size).toBe(0)
+  })
+
+  it('bounds the provider-session pane registry with FIFO eviction', () => {
+    const server = new AgentHookServer()
+    const internals = server as unknown as {
+      providerSessionPanes: Map<string, { paneKey: string; ptyId: string }>
+    }
+    const total = 512 + 100
+    for (let i = 0; i < total; i += 1) {
+      server.registerProviderSessionPane(`session-${i}`, GOOD_PANE, `pty-${i}`)
+    }
+    expect(internals.providerSessionPanes.size).toBe(512)
+    expect(internals.providerSessionPanes.has('session-0')).toBe(false)
+    expect(internals.providerSessionPanes.has(`session-${total - 1}`)).toBe(true)
+  })
+})

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -13,7 +13,7 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
 import { createHash, randomBytes, randomUUID } from 'node:crypto'
 import { chmodSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
 
 import { track } from '../telemetry/client'
 import { getCohortAtEmit } from '../telemetry/cohort-classifier'
@@ -330,24 +330,97 @@ function equivalentParsedAgentStatusPayload(
 // any realistic live-session count while bounding a leaky caller.
 const MAX_PROVIDER_SESSION_PANES = 512
 
+// Why: a UserPromptSubmit hook fires within moments of the user pressing
+// Enter, so keyboard input older than this cannot belong to that submit.
+// Bounds the rebind signal so headless/automated prompts do not steal a pane
+// the user merely touched earlier.
+const CLAUDE_PANE_INPUT_REBIND_WINDOW_MS = 5_000
+
+type HookBodyClaudeMeta = {
+  sessionId: string | null
+  eventName: string | null
+  transcriptPath: string | null
+}
+
 // Why: hook bodies carry the provider payload as a JSON string (or object on
 // some relays); session_id inside it is the only daemon-proof identity a
 // Claude hook event carries. Parse defensively — attribution must fail open.
-function readHookBodyPayloadSessionId(record: Record<string, unknown>): string | null {
+function readHookBodyClaudeMeta(record: Record<string, unknown>): HookBodyClaudeMeta {
+  const empty: HookBodyClaudeMeta = { sessionId: null, eventName: null, transcriptPath: null }
   const rawPayload = record.payload
   let payload: unknown = rawPayload
   if (typeof rawPayload === 'string') {
     try {
       payload = JSON.parse(rawPayload)
     } catch {
-      return null
+      return empty
     }
   }
   if (typeof payload !== 'object' || payload === null) {
+    return empty
+  }
+  const p = payload as Record<string, unknown>
+  const readString = (value: unknown): string | null =>
+    typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+  return {
+    sessionId: readString(p.session_id),
+    eventName:
+      readString(p.hook_event_name) ??
+      readString(p.hookEventName) ??
+      readString(record.hook_event_name) ??
+      readString(record.hookEventName),
+    transcriptPath: readString(p.transcript_path) ?? readString(p.transcriptPath)
+  }
+}
+
+// Why: `--resume`/`--continue` FORK the session id, so the forked id has no
+// spawn-time binding. Claude's daemon records each fork's parent in
+// <configDir>/daemon/roster.json (dispatch.launch.sessionId names the parent
+// transcript), and the hook payload's transcript_path locates configDir —
+// so lineage resolves without knowing the user's CLAUDE_CONFIG_DIR.
+function resolveClaudeForkParentSessionId(
+  sessionId: string,
+  transcriptPath: string | null
+): string | null {
+  if (!transcriptPath) {
     return null
   }
-  const sessionId = (payload as Record<string, unknown>).session_id
-  return typeof sessionId === 'string' && sessionId.trim().length > 0 ? sessionId.trim() : null
+  const projectsDir = dirname(dirname(transcriptPath))
+  if (basename(projectsDir) !== 'projects') {
+    return null
+  }
+  const rosterPath = join(dirname(projectsDir), 'daemon', 'roster.json')
+  let workers: Record<string, unknown>
+  try {
+    const parsed = JSON.parse(readFileSync(rosterPath, 'utf8')) as Record<string, unknown>
+    if (typeof parsed.workers !== 'object' || parsed.workers === null) {
+      return null
+    }
+    workers = parsed.workers as Record<string, unknown>
+  } catch {
+    return null
+  }
+  for (const worker of Object.values(workers)) {
+    if (typeof worker !== 'object' || worker === null) {
+      continue
+    }
+    const w = worker as Record<string, unknown>
+    if (w.sessionId !== sessionId) {
+      continue
+    }
+    const launch = ((w.dispatch as Record<string, unknown> | undefined)?.launch ?? {}) as Record<
+      string,
+      unknown
+    >
+    const ref = launch.sessionId ?? launch.transcriptPath
+    const base = typeof ref === 'string' ? basename(ref) : ''
+    if (base.endsWith('.jsonl')) {
+      const parent = base.slice(0, -'.jsonl'.length)
+      return parent !== sessionId ? parent : null
+    }
+    return null
+  }
+  return null
 }
 
 function trackEmptyPaneKeyHook(body: unknown): void {
@@ -544,6 +617,12 @@ export class AgentHookServer {
   // id here; incoming hook posts matching a pinned session are re-attributed
   // to the recorded pane regardless of the env-derived key they carry.
   private providerSessionPanes = new Map<string, { paneKey: string; ptyId: string }>()
+  // Why: injected by the PTY layer (which owns keyboard-input timing and the
+  // live-Claude-PTY set) so an unbound session's first prompt can bind to the
+  // pane the user just typed in. Kept as a probe to avoid a module cycle.
+  private claudePaneInputProbe:
+    | ((windowMs: number) => { paneKey: string; ptyId: string } | null)
+    | null = null
   private paneKeyAliasPersistenceListener: PaneKeyAliasPersistenceListener | null = null
   // Why: full path to the on-disk last-status cache. Set in start() from
   // userDataPath. Null when the server runs without a userDataPath (e.g.
@@ -1368,16 +1447,53 @@ export class AgentHookServer {
     }
   }
 
+  setClaudePaneInputProbe(
+    probe: ((windowMs: number) => { paneKey: string; ptyId: string } | null) | null
+  ): void {
+    this.claudePaneInputProbe = probe
+  }
+
   private normalizeHookBodyProviderSessionPane(body: unknown): unknown {
-    if (this.providerSessionPanes.size === 0 || typeof body !== 'object' || body === null) {
+    if (typeof body !== 'object' || body === null) {
       return body
     }
     const record = body as Record<string, unknown>
-    const sessionId = readHookBodyPayloadSessionId(record)
-    if (!sessionId) {
+    const meta = readHookBodyClaudeMeta(record)
+    if (!meta.sessionId) {
       return body
     }
-    const pinned = this.providerSessionPanes.get(sessionId)
+    // Why: resume/continue fork the session id, so the fork arrives unbound.
+    // The daemon roster names the fork's parent — inherit the parent's pane.
+    // Deterministic, so it runs before the input heuristic below.
+    if (!this.providerSessionPanes.has(meta.sessionId)) {
+      const parent = resolveClaudeForkParentSessionId(meta.sessionId, meta.transcriptPath)
+      const parentBinding = parent ? this.providerSessionPanes.get(parent) : undefined
+      if (parentBinding) {
+        this.registerProviderSessionPane(
+          meta.sessionId,
+          parentBinding.paneKey,
+          parentBinding.ptyId
+        )
+      }
+    }
+    // Why: fleet-view/`/resume` attach swaps the session inside an existing
+    // client — no spawn, no fork, no binding. The submit follows the user's
+    // Enter by moments, so the Claude pane with the freshest keyboard input
+    // names the owning pane. Only unbound sessions may claim it (bindings
+    // clear on PTY exit, so stale ones do not block), and only at turn start.
+    // Known ceiling: a headless prompt to an unbound session that lands
+    // within the input window of unrelated typing can misbind until the next
+    // interactive turn corrects it.
+    if (
+      meta.eventName === 'UserPromptSubmit' &&
+      !this.providerSessionPanes.has(meta.sessionId)
+    ) {
+      const pane = this.claudePaneInputProbe?.(CLAUDE_PANE_INPUT_REBIND_WINDOW_MS) ?? null
+      if (pane) {
+        this.registerProviderSessionPane(meta.sessionId, pane.paneKey, pane.ptyId)
+      }
+    }
+    const pinned = this.providerSessionPanes.get(meta.sessionId)
     if (!pinned || record.paneKey === pinned.paneKey) {
       return body
     }

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -326,6 +326,30 @@ function equivalentParsedAgentStatusPayload(
   )
 }
 
+// Why: one binding per spawn-pinned Claude session; generous headroom over
+// any realistic live-session count while bounding a leaky caller.
+const MAX_PROVIDER_SESSION_PANES = 512
+
+// Why: hook bodies carry the provider payload as a JSON string (or object on
+// some relays); session_id inside it is the only daemon-proof identity a
+// Claude hook event carries. Parse defensively — attribution must fail open.
+function readHookBodyPayloadSessionId(record: Record<string, unknown>): string | null {
+  const rawPayload = record.payload
+  let payload: unknown = rawPayload
+  if (typeof rawPayload === 'string') {
+    try {
+      payload = JSON.parse(rawPayload)
+    } catch {
+      return null
+    }
+  }
+  if (typeof payload !== 'object' || payload === null) {
+    return null
+  }
+  const sessionId = (payload as Record<string, unknown>).session_id
+  return typeof sessionId === 'string' && sessionId.trim().length > 0 ? sessionId.trim() : null
+}
+
 function trackEmptyPaneKeyHook(body: unknown): void {
   if (typeof body !== 'object' || body === null) {
     return
@@ -514,6 +538,12 @@ export class AgentHookServer {
   // evidence of live agent work in this main-process runtime.
   private runtimeObservedStatusPaneKeys = new Set<string>()
   private legacyPaneKeyAliases = new Map<string, PaneKeyAliasEntry>()
+  // Why: Claude Code >=2.1.206 runs sessions in a shared daemon whose hook
+  // commands inherit the daemon's stale ORCA_PANE_KEY. Spawn-time pinning
+  // (pinClaudeSessionIdForPaneAttribution) records the true pane per session
+  // id here; incoming hook posts matching a pinned session are re-attributed
+  // to the recorded pane regardless of the env-derived key they carry.
+  private providerSessionPanes = new Map<string, { paneKey: string; ptyId: string }>()
   private paneKeyAliasPersistenceListener: PaneKeyAliasPersistenceListener | null = null
   // Why: full path to the on-disk last-status cache. Set in start() from
   // userDataPath. Null when the server runs without a userDataPath (e.g.
@@ -1314,6 +1344,49 @@ export class AgentHookServer {
     return this.legacyPaneKeyAliases.get(paneKey)?.stablePaneKey ?? paneKey
   }
 
+  registerProviderSessionPane(sessionId: string, paneKey: string, ptyId: string): void {
+    if (!sessionId || !isValidPaneKey(paneKey)) {
+      return
+    }
+    // Why: bounded — one entry per spawn-pinned session; re-registration on
+    // re-attach moves the session to its current pane.
+    this.providerSessionPanes.set(sessionId, { paneKey, ptyId })
+    while (this.providerSessionPanes.size > MAX_PROVIDER_SESSION_PANES) {
+      const oldest = this.providerSessionPanes.keys().next().value
+      if (oldest === undefined) {
+        break
+      }
+      this.providerSessionPanes.delete(oldest)
+    }
+  }
+
+  clearProviderSessionPanesForPty(ptyId: string): void {
+    for (const [sessionId, entry] of this.providerSessionPanes) {
+      if (entry.ptyId === ptyId) {
+        this.providerSessionPanes.delete(sessionId)
+      }
+    }
+  }
+
+  private normalizeHookBodyProviderSessionPane(body: unknown): unknown {
+    if (this.providerSessionPanes.size === 0 || typeof body !== 'object' || body === null) {
+      return body
+    }
+    const record = body as Record<string, unknown>
+    const sessionId = readHookBodyPayloadSessionId(record)
+    if (!sessionId) {
+      return body
+    }
+    const pinned = this.providerSessionPanes.get(sessionId)
+    if (!pinned || record.paneKey === pinned.paneKey) {
+      return body
+    }
+    // Why: daemon-hosted Claude workers post the daemon's env-derived pane
+    // key; the spawn-time session binding names the pane that actually owns
+    // this session, so trust it over the posted key.
+    return { ...record, paneKey: pinned.paneKey, tabId: parsePaneKey(pinned.paneKey)?.tabId }
+  }
+
   private normalizeHookBodyPaneKeyAlias(body: unknown): unknown {
     if (typeof body !== 'object' || body === null) {
       return body
@@ -1605,7 +1678,8 @@ export class AgentHookServer {
         }
 
         trackEmptyPaneKeyHook(body)
-        const aliasedBody = this.normalizeHookBodyPaneKeyAlias(body)
+        const sessionAttributedBody = this.normalizeHookBodyProviderSessionPane(body)
+        const aliasedBody = this.normalizeHookBodyPaneKeyAlias(sessionAttributedBody)
         const normalized = normalizeHookPayload(this.state, source, aliasedBody, this.env)
         if (normalized && !this.shouldSuppressClosedTabStatus(normalized.paneKey)) {
           const enriched = this.applyNormalizedStatus(normalized)

--- a/src/main/claude-accounts/live-pty-gate.ts
+++ b/src/main/claude-accounts/live-pty-gate.ts
@@ -61,6 +61,10 @@ export function hasLiveClaudePtys(): boolean {
   return liveClaudePtyIds.size > 0
 }
 
+export function isLiveClaudePty(ptyId: string): boolean {
+  return liveClaudePtyIds.has(ptyId)
+}
+
 export function beginClaudeAuthSwitch(): void {
   if (switchInProgress) {
     throw new Error('A Claude account switch is already in progress.')

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -73,6 +73,7 @@ import type { ClaudeAccountSelectionTarget } from '../claude-accounts/runtime-se
 import { CLAUDE_AUTH_ENV_VARS, hasClaudeAuthEnvConflict } from '../claude-accounts/environment'
 import {
   isClaudeAuthSwitchInProgress,
+  isLiveClaudePty,
   markClaudePtyExited,
   markClaudePtySpawned
 } from '../claude-accounts/live-pty-gate'
@@ -207,6 +208,30 @@ const ptyPaneKey = new Map<string, string>()
 // back into the pane's data stream) need to find the ptyId for that paneKey.
 // Kept in lock-step with ptyPaneKey via the same spawn and teardown sites.
 const paneKeyPtyId = new Map<string, string>()
+
+// Why: fleet-view/`/resume` attach swaps a Claude session inside an existing
+// client with no spawn, so the hook server sees an unbound session id at the
+// next UserPromptSubmit. The Claude pane the user typed in most recently
+// (within windowMs) names the owner. Ambiguity (no candidate) returns null —
+// attribution then falls back to the posted key. lastInputAtByPty uses
+// performance.now(), so the window compares against the same clock.
+agentHookServer.setClaudePaneInputProbe((windowMs) => {
+  const now = performance.now()
+  let best: { paneKey: string; ptyId: string; at: number } | null = null
+  for (const [ptyId, at] of lastInputAtByPty) {
+    if (now - at > windowMs || !isLiveClaudePty(ptyId)) {
+      continue
+    }
+    const paneKey = ptyPaneKey.get(ptyId)
+    if (!paneKey) {
+      continue
+    }
+    if (!best || at > best.at) {
+      best = { paneKey, ptyId, at }
+    }
+  }
+  return best ? { paneKey: best.paneKey, ptyId: best.ptyId } : null
+})
 
 const AGENT_HOOK_RUNTIME_ENV_KEYS = [
   'ORCA_AGENT_HOOK_PORT',

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -1072,6 +1072,37 @@ function isClaudeLaunchCommand(command: string | undefined): boolean {
   )
 }
 
+// Why: Claude Code >=2.1.206 hosts new TUI sessions in a shared background
+// daemon whose workers inherit the DAEMON's env, so hook posts carry a stale
+// ORCA_PANE_KEY. Pinning --session-id at spawn gives the hook listener a
+// spawn-time sessionId→paneKey binding to attribute against instead.
+const CLAUDE_SESSION_LIFECYCLE_FLAG_RE =
+  /(^|\s)(--session-id|--resume|--continue|--fork-session|-r|-c)(\s|=|$)/
+// Why: only a lone claude invocation whose first argument is a flag or a
+// quoted prompt can safely take an appended flag — compound commands would
+// hand it to the wrong word, and bare-word subcommands (`claude daemon
+// status`, `claude mcp list`) reject unknown flags.
+const APPENDABLE_CLAUDE_COMMAND_RE =
+  /^(?:[A-Za-z_][A-Za-z0-9_]*=(?:'[^']*'|"[^"]*"|[^\s'"`;&|<>()]*)\s+)*(?:[^\s;&|('"`]*[\\/])?claude(?:\.cmd|\.exe)?(?:\s+['"-][^;&|<>`()]*)?$/i
+
+function pinClaudeSessionIdForPaneAttribution(command: string | undefined): {
+  command: string | undefined
+  pinnedSessionId: string | null
+} {
+  if (!command || !isClaudeLaunchCommand(command)) {
+    return { command, pinnedSessionId: null }
+  }
+  const trimmed = command.trim()
+  if (
+    CLAUDE_SESSION_LIFECYCLE_FLAG_RE.test(trimmed) ||
+    !APPENDABLE_CLAUDE_COMMAND_RE.test(trimmed)
+  ) {
+    return { command, pinnedSessionId: null }
+  }
+  const pinnedSessionId = randomUUID()
+  return { command: `${trimmed} --session-id ${pinnedSessionId}`, pinnedSessionId }
+}
+
 function routesFreshSpawnsToLocalProvider(
   provider: IPtyProvider
 ): provider is FreshLocalFallbackProvider {
@@ -1180,6 +1211,9 @@ export function clearProviderPtyState(id: string): void {
   // Why: SSH exit and connection-teardown paths bypass pty.ts's local onExit
   // callback but still need to release Claude account-switch guards.
   markClaudePtyExited(id)
+  // Why: a dead PTY's pinned session binding must not re-route a future
+  // session that happens to reuse the id space.
+  agentHookServer.clearProviderSessionPanesForPty(id)
   ptySizes.delete(id)
   lastInputAtByPty.delete(id)
   interactiveOutputCharsByPty.delete(id)
@@ -2991,6 +3025,9 @@ export function registerPtyHandlers(
       const cwd = resolvePtySpawnStartupCwd(args.worktreeId, args.cwd)
       const provider = getProvider(args.connectionId)
       const isClaudeLaunch = !args.connectionId && isClaudeLaunchCommand(args.command)
+      const claudePin = isClaudeLaunch
+        ? pinClaudeSessionIdForPaneAttribution(args.command)
+        : { command: args.command, pinnedSessionId: null }
       if (isClaudeLaunch && isClaudeAuthSwitchInProgress()) {
         throw new Error('A Claude account switch is in progress. Try again after it finishes.')
       }
@@ -3123,8 +3160,8 @@ export function registerPtyHandlers(
       }
       deleteRequestedEnvKeys(env, spawnOptions.envToDelete)
       promoteAgentTeamsShimPath(env, requestedAgentTeamsPath)
-      if (args.command !== undefined) {
-        spawnOptions.command = args.command
+      if (claudePin.command !== undefined) {
+        spawnOptions.command = claudePin.command
       }
       if (args.commandDelivery !== undefined) {
         spawnOptions.commandDelivery = args.commandDelivery
@@ -3350,6 +3387,13 @@ export function registerPtyHandlers(
         // so record their spawn-time paneKey here too. Synthetic hook titles and
         // paneKey-scoped cache cleanup both depend on this reverse lookup.
         const paneKey = rememberPaneKeyForPty(result.id, env?.ORCA_PANE_KEY)
+        if (claudePin.pinnedSessionId && paneKey) {
+          agentHookServer.registerProviderSessionPane(
+            claudePin.pinnedSessionId,
+            paneKey,
+            result.id
+          )
+        }
         const pendingSerializer = paneKey ? pendingByPaneKey.get(paneKey) : undefined
         const inheritRendererReadiness =
           result.isReattach === true &&
@@ -3769,6 +3813,9 @@ export function registerPtyHandlers(
       spawnTiming.mark('preflight')
       const provider = getProvider(args.connectionId)
       const isClaudeLaunch = !args.connectionId && isClaudeLaunchCommand(args.command)
+      const claudePin = isClaudeLaunch
+        ? pinClaudeSessionIdForPaneAttribution(args.command)
+        : { command: args.command, pinnedSessionId: null }
       if (isClaudeLaunch && isClaudeAuthSwitchInProgress()) {
         throw new Error('A Claude account switch is in progress. Try again after it finishes.')
       }
@@ -4049,8 +4096,8 @@ export function registerPtyHandlers(
       if (combinedEnvToDelete) {
         spawnOptions.envToDelete = combinedEnvToDelete
       }
-      if (args.command !== undefined) {
-        spawnOptions.command = args.command
+      if (claudePin.command !== undefined) {
+        spawnOptions.command = claudePin.command
       }
       if (args.commandDelivery !== undefined) {
         spawnOptions.commandDelivery = args.commandDelivery
@@ -4448,6 +4495,13 @@ export function registerPtyHandlers(
         const rememberedPaneKey = validatedPaneKey
           ? rememberPaneKeyForPty(result.id, validatedPaneKey)
           : null
+        if (claudePin.pinnedSessionId && rememberedPaneKey) {
+          agentHookServer.registerProviderSessionPane(
+            claudePin.pinnedSessionId,
+            rememberedPaneKey,
+            result.id
+          )
+        }
         if (legacySpawnPaneKey && migrationUnsupportedPaneKey) {
           agentHookServer.registerPaneKeyAlias(
             legacySpawnPaneKey.paneKey,


### PR DESCRIPTION
## Summary

Fixes #9236.

Claude Code ≥ 2.1.206 transparently hosts new TUI sessions as workers under one shared background daemon. Hook commands now execute inside those workers, which inherit the **daemon's** environment — so every `/hook/claude` post carries the `ORCA_PANE_KEY` of whichever pane first spawned the daemon. New Claude sessions never register on their own pane (no working/waiting/done in the sidebar) and continuously clobber one stale pane's status entry, across worktrees.

Pane identity has to be established where Orca still knows the pane, then followed as the session moves. Continued live testing against CC 2.1.210–2.1.212 showed one binding moment isn't enough — sessions fork ids on resume and hop panes via the agents view — so this PR binds at three points, mirroring the existing `legacyPaneKeyAliases` pattern:

1. **Spawn-time pinning** (`src/main/ipc/pty.ts`): when a local Claude launch has a validated pane identity and no session lifecycle flags (`--session-id` / `--resume` / `--continue` / `--fork-session` / `-r` / `-c`), append a minted `--session-id <uuid>` and register the `sessionId → paneKey` binding with the hook server. Only lone `claude` invocations whose first argument is a flag or quoted prompt are pinned; compound commands (`claude && …`) and bare-word subcommands (`claude daemon status`, `claude mcp list`) pass through untouched.
2. **Fork lineage** (`src/main/agent-hooks/server.ts`): `--resume`/`--continue` FORK the session id, so the forked id arrives with no binding. Claude's daemon records each fork's parent in `<configDir>/daemon/roster.json` (`dispatch.launch.sessionId` names the parent transcript), and the payload's `transcript_path` locates the config dir — so an unknown session id deterministically inherits its parent's pane, with no knowledge of the user's `CLAUDE_CONFIG_DIR` needed.
3. **Prompt-time rebind** (`server.ts` + a probe injected from `pty.ts`): the agents/fleet view and `/resume` picker swap the session inside an existing client — no spawn, no fork, no binding. On `UserPromptSubmit` only, an unbound session binds to the live Claude pane with the freshest keyboard input (5s window; `lastInputAtByPty` and the live-Claude-PTY set both live in the PTY layer, hence the injected probe — avoids a module cycle). Mid-turn events never consult the probe; an empty probe keeps the posted key.

At ingest, if a post's payload `session_id` resolves to a binding and the posted (env-derived) pane key differs, `paneKey`/`tabId` are rewritten to the bound pane — before `legacyPaneKeyAliases` normalization, so migrated-pane aliasing still applies on top. Session ids that resolve nowhere pass through unchanged, so user-typed `claude` in a plain shell keeps today's behavior. Bindings are FIFO-bounded (512), dropped when their spawning PTY exits, and re-registered on reattach.

## Screenshots

No visual change (attribution fix — the sidebar simply shows status on the correct pane again for CC ≥ 2.1.206, and keeps following the session through resume forks and fleet-view attaches).

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Seven vitest cases in `src/main/agent-hooks/server.test.ts` (existing HTTP-driven harness): daemon-stale-key re-attribution to the pinned pane, unknown-session passthrough, binding cleanup on PTY exit, FIFO bound on the registry, roster-based fork lineage (temp config dir + real roster.json fixture), prompt-time rebind via the probe, and the no-steal guarantees (mid-turn events never probe; empty probe keeps the posted key). The spawn-side command classifier was validated standalone against 25 command shapes (pin vs. passthrough for flags/quoted prompts/env-prefixes vs. resume flows/compounds/subcommands/redirects/pipelines). I was unable to run the full pnpm suite in my sandboxed environment — CI should exercise the checklist above; happy to iterate on any failures.

Root cause and both follow-on gaps were verified against live Claude Code 2.1.210–2.1.212 daemons on macOS: the pane's TUI process carries the correct `ORCA_PANE_KEY` but is a thin client; the session worker (child of `claude daemon run`) carries the daemon's stale pane key, and hooks fire in the worker. The daemon's dispatch env forwards only an allowlist (`ANTHROPIC_*`, `AWS_*`, `CLAUDE_CONFIG_DIR`, …), so no per-pane env can survive into workers. Resume forks and fleet-view attaches were both reproduced live and both mechanisms validated in a local shim before porting here.

## AI Review Report

Developed and reviewed with Claude Code. Main risks checked: (1) session pinning must never break non-TUI invocations — guarded by a conservative appendability classifier (flag/quoted-prompt first-arg only) tested against 25 command shapes; (2) hook-ingest overrides must fail open — unknown/malformed `session_id`, unreadable/malformed roster.json, and transcript paths that don't sit under a `projects/` dir all pass the body through unchanged; (3) pane stealing — the input-rebind probe is consulted only for `UserPromptSubmit` on sessions with no live binding, only within a 5s input window, and only over panes in the live-Claude-PTY set, so background/headless sessions and mid-turn events cannot displace a user's pane (the residual case — a headless prompt landing inside the typing window of an unrelated unbound session — self-corrects at that session's next interactive turn); (4) unbounded memory — registry FIFO-bounded at 512 and cleaned on PTY exit; roster reads are per-miss, not cached. Cross-platform: path handling uses `node:path` (`dirname`/`basename`/`join`), no separators assumed; changes are local-spawn-only (`!args.connectionId`), so SSH flows are untouched.

## Security Audit

Reviewed with Claude Code. Untrusted inputs from the local hook HTTP endpoint: `session_id` (Map key for exact lookup only), `transcript_path` (used to *derive* a roster path via `dirname`×2 + a literal `daemon/roster.json` join, gated on the parent dir being named `projects`; the file is JSON-parsed read-only, never written or executed — a hostile poster can at most point the parse at a file the same user could already read, and a non-roster JSON yields no binding). No path contents are echoed back. The minted spawn UUID comes from `randomUUID()` (no user input interpolated into the command string). The PTY-layer probe exposes only `{paneKey, ptyId}` for panes Orca already tracks. Registry writes bounded (FIFO 512 + PTY-exit cleanup). Existing token auth (`x-orca-agent-hook-token`) on the hook endpoint is unchanged and still gates all posts.

## Notes

- The stale `ORCA_AGENT_HOOK_PORT` in daemon workers is survivable today because the generated hook script re-sources `ORCA_AGENT_HOOK_ENDPOINT`; pane identity had no such refresh path — this PR adds one.
- Two smaller adjacent gaps noted in #9236 (`claudeLivePtySessionIds` not tracking `agentCmdOverrides` wrappers whose binary isn't literally `claude`; daemon-hosted sessions outliving their thin-client PTY) remain out of scope here.
- Workaround for affected users until this lands: `CLAUDE_CODE_DISABLE_AGENT_VIEW=1 claude`.

## ELI5

Newer Claude Code runs sessions under a shared daemon, so status hooks all reported the wrong pane and clobbered one card. Orca rebinds status to the true pane using spawn pins, fork lineage, and prompt-time fixes.
