### PR TITLE
feat(keybindings): swap tab-switch chords to the common convention for new users

### DIFF
--- a/src/main/browser/browser-guest-ui.ts
+++ b/src/main/browser/browser-guest-ui.ts
@@ -358,9 +358,9 @@ export function setupGuestShortcutForwarding(args: {
       return true
     }
 
-    // Why: Cmd/Ctrl+Alt+[ / ] cycles across every tab type. Handled before
-    // the generic modifier-chord gate below because that gate rejects Alt.
-    // Mirrors the Alt-exempt branch pattern used for worktreeHistoryNavigate.
+    // Why: match this action outside the main-process shortcut allowlist so
+    // both the fresh Shift binding and upgrading users' seeded Alt binding
+    // reach the renderer instead of the focused guest page.
     const switchAllTypesDirection = keybindingMatchesAction(
       'tab.nextAllTypes',
       input,

--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -2357,6 +2357,15 @@ describe('browserManager', () => {
       },
       {
         type: 'keyDown',
+        code: 'BracketRight',
+        key: ']',
+        meta: isDarwin,
+        control: !isDarwin,
+        alt: true,
+        shift: false
+      },
+      {
+        type: 'keyDown',
         code: 'PageDown',
         key: 'PageDown',
         meta: false,
@@ -2411,12 +2420,13 @@ describe('browserManager', () => {
     expect(rendererSendMock).toHaveBeenNthCalledWith(1, 'ui:newBrowserTab')
     expect(rendererSendMock).toHaveBeenNthCalledWith(2, 'ui:newTerminalTab')
     expect(rendererSendMock).toHaveBeenNthCalledWith(3, 'ui:closeActiveTab')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(4, 'ui:switchTab', 1)
-    expect(rendererSendMock).toHaveBeenNthCalledWith(5, 'ui:switchTerminalTab', 1)
-    expect(rendererSendMock).toHaveBeenNthCalledWith(6, 'ui:openQuickOpen')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(7, 'ui:focusBrowserAddressBar')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(8, 'ui:reloadBrowserPage')
-    expect(rendererSendMock).toHaveBeenNthCalledWith(9, 'ui:hardReloadBrowserPage')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(4, 'ui:switchTabAcrossAllTypes', 1)
+    expect(rendererSendMock).toHaveBeenNthCalledWith(5, 'ui:switchTab', 1)
+    expect(rendererSendMock).toHaveBeenNthCalledWith(6, 'ui:switchTerminalTab', 1)
+    expect(rendererSendMock).toHaveBeenNthCalledWith(7, 'ui:openQuickOpen')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(8, 'ui:focusBrowserAddressBar')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(9, 'ui:reloadBrowserPage')
+    expect(rendererSendMock).toHaveBeenNthCalledWith(10, 'ui:hardReloadBrowserPage')
   })
 
   it('uses customized keybindings when forwarding browser guest shortcuts', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1880,7 +1880,13 @@ app.whenReady().then(async () => {
   rateLimits.setNetworkProxySettingsResolver(() => store!.getSettings())
   keybindings = new KeybindingService({
     homePath: app.getPath('home'),
-    getLegacyOverrides: () => store!.getSettings().keybindings
+    getLegacyOverrides: () => store!.getSettings().keybindings,
+    legacyTabSwitchSeed: {
+      isPending: () => store!.getSettings().tabSwitchKeybindingSeed === 'pending',
+      markSeeded: () => {
+        store!.updateSettings({ tabSwitchKeybindingSeed: 'done' })
+      }
+    }
   })
   browserManager.setSettingsResolver(() => ({ keybindings: keybindings?.getOverrides() }))
   rateLimits.setInactiveClaudeAccountsResolver(() => {

--- a/src/main/keybindings/keybinding-file.test.ts
+++ b/src/main/keybindings/keybinding-file.test.ts
@@ -2,10 +2,12 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { LEGACY_TAB_SWITCH_BINDINGS } from '../../shared/keybindings'
 import {
   getUserKeybindingsPath,
   migrateLegacyKeybindings,
   readKeybindingFile,
+  seedLegacyTabSwitchBindings,
   writeKeybindingOverride
 } from './keybinding-file'
 
@@ -223,5 +225,51 @@ describe('keybinding-file', () => {
     expect(readKeybindingFile(filePath, 'linux').overrides).toEqual({
       'view.tasks': ['Ctrl+Alt+T']
     })
+  })
+
+  it('seeds the legacy tab-switch chords into the active platform section', () => {
+    const result = seedLegacyTabSwitchBindings(filePath, 'darwin', LEGACY_TAB_SWITCH_BINDINGS)
+
+    expect(result.seeded).toBe(true)
+    const snapshot = readKeybindingFile(filePath, 'darwin')
+    // Written to the platform section so Settings reset still works normally.
+    expect(snapshot.platformOverrides.darwin).toEqual({
+      'tab.nextSameType': ['Mod+Shift+BracketRight'],
+      'tab.previousSameType': ['Mod+Shift+BracketLeft'],
+      'tab.nextAllTypes': ['Mod+Alt+BracketRight'],
+      'tab.previousAllTypes': ['Mod+Alt+BracketLeft']
+    })
+    // Effective bindings reproduce the pre-swap behavior with no conflicts dropped.
+    expect(snapshot.overrides).toMatchObject({
+      'tab.nextSameType': ['Mod+Shift+BracketRight'],
+      'tab.nextAllTypes': ['Mod+Alt+BracketRight']
+    })
+    expect(snapshot.diagnostics).toEqual([])
+  })
+
+  it('skips the seed when the user has already customized any swapped action', () => {
+    writeKeybindingOverride(filePath, 'darwin', 'tab.nextSameType', ['Mod+Alt+K'])
+
+    const result = seedLegacyTabSwitchBindings(filePath, 'darwin', LEGACY_TAB_SWITCH_BINDINGS)
+
+    expect(result.seeded).toBe(false)
+    // The user's choice is untouched and the other actions stay on their defaults.
+    expect(readKeybindingFile(filePath, 'darwin').overrides).toEqual({
+      'tab.nextSameType': ['Mod+Alt+K']
+    })
+  })
+
+  it('leaves unrelated overrides intact and stays idempotent when seeding', () => {
+    writeKeybindingOverride(filePath, 'darwin', 'terminal.search', ['Mod+Shift+F'])
+
+    const first = seedLegacyTabSwitchBindings(filePath, 'darwin', LEGACY_TAB_SWITCH_BINDINGS)
+    const second = seedLegacyTabSwitchBindings(filePath, 'darwin', LEGACY_TAB_SWITCH_BINDINGS)
+
+    expect(first.seeded).toBe(true)
+    // A second pass is a no-op: the pins now read as existing customization.
+    expect(second.seeded).toBe(false)
+    const snapshot = readKeybindingFile(filePath, 'darwin')
+    expect(snapshot.overrides['terminal.search']).toEqual(['Mod+Shift+F'])
+    expect(snapshot.overrides['tab.nextAllTypes']).toEqual(['Mod+Alt+BracketRight'])
   })
 })

--- a/src/main/keybindings/keybinding-file.test.ts
+++ b/src/main/keybindings/keybinding-file.test.ts
@@ -247,15 +247,46 @@ describe('keybinding-file', () => {
     expect(snapshot.diagnostics).toEqual([])
   })
 
-  it('skips the seed when the user has already customized any swapped action', () => {
+  it('preserves a customized action while still pinning the un-customized ones', () => {
+    // A partially-customized existing user: they rebound one action. The other
+    // three must still land on their pre-swap defaults, not the new ones.
     writeKeybindingOverride(filePath, 'darwin', 'tab.nextSameType', ['Mod+Alt+K'])
 
     const result = seedLegacyTabSwitchBindings(filePath, 'darwin', LEGACY_TAB_SWITCH_BINDINGS)
 
-    expect(result.seeded).toBe(false)
-    // The user's choice is untouched and the other actions stay on their defaults.
+    expect(result.seeded).toBe(true)
     expect(readKeybindingFile(filePath, 'darwin').overrides).toEqual({
-      'tab.nextSameType': ['Mod+Alt+K']
+      'tab.nextSameType': ['Mod+Alt+K'],
+      'tab.previousSameType': ['Mod+Shift+BracketLeft'],
+      'tab.nextAllTypes': ['Mod+Alt+BracketRight'],
+      'tab.previousAllTypes': ['Mod+Alt+BracketLeft']
+    })
+  })
+
+  it('is a no-op once every swapped action already resolves on this platform', () => {
+    // Seeding writes the whole document at once, so it clears the per-write
+    // conflict guard that a naive one-action-at-a-time write would trip.
+    const first = seedLegacyTabSwitchBindings(filePath, 'darwin', LEGACY_TAB_SWITCH_BINDINGS)
+    expect(first.seeded).toBe(true)
+    expect(first.snapshot.diagnostics).toEqual([])
+
+    const second = seedLegacyTabSwitchBindings(filePath, 'darwin', LEGACY_TAB_SWITCH_BINDINGS)
+    expect(second.seeded).toBe(false)
+  })
+
+  it('does not let a foreign-platform override block the active-platform pin', () => {
+    // Only linux is customized; a darwin launch must still pin darwin so the
+    // active platform keeps the pre-swap behavior.
+    writeKeybindingOverride(filePath, 'linux', 'tab.nextAllTypes', ['Mod+Alt+K'])
+
+    const result = seedLegacyTabSwitchBindings(filePath, 'darwin', LEGACY_TAB_SWITCH_BINDINGS)
+
+    expect(result.seeded).toBe(true)
+    expect(readKeybindingFile(filePath, 'darwin').platformOverrides.darwin).toMatchObject({
+      'tab.nextAllTypes': ['Mod+Alt+BracketRight']
+    })
+    expect(readKeybindingFile(filePath, 'linux').platformOverrides.linux).toEqual({
+      'tab.nextAllTypes': ['Mod+Alt+K']
     })
   })
 

--- a/src/main/keybindings/keybinding-file.test.ts
+++ b/src/main/keybindings/keybinding-file.test.ts
@@ -303,4 +303,46 @@ describe('keybinding-file', () => {
     expect(snapshot.overrides['terminal.search']).toEqual(['Mod+Shift+F'])
     expect(snapshot.overrides['tab.nextAllTypes']).toEqual(['Mod+Alt+BracketRight'])
   })
+
+  it('migrates root-level legacy overrides without losing custom shortcuts', () => {
+    writeFileSync(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        'worktree.quickOpen': 'Mod+Shift+P',
+        'tab.nextSameType': 'Mod+K'
+      }),
+      'utf8'
+    )
+
+    seedLegacyTabSwitchBindings(filePath, 'darwin', LEGACY_TAB_SWITCH_BINDINGS)
+
+    const written = JSON.parse(readFileSync(filePath, 'utf8')) as {
+      keybindings: Record<string, unknown>
+      platforms: Record<string, Record<string, unknown>>
+      'worktree.quickOpen'?: unknown
+      'tab.nextSameType'?: unknown
+    }
+    expect(written['worktree.quickOpen']).toBeUndefined()
+    expect(written['tab.nextSameType']).toBeUndefined()
+    expect(written.keybindings).toMatchObject({
+      'worktree.quickOpen': ['Mod+Shift+P'],
+      'tab.nextSameType': ['Mod+K']
+    })
+    expect(readKeybindingFile(filePath, 'darwin').overrides).toMatchObject({
+      'worktree.quickOpen': ['Mod+Shift+P'],
+      'tab.nextSameType': ['Mod+K'],
+      'tab.nextAllTypes': ['Mod+Alt+BracketRight']
+    })
+  })
+
+  it('does not replace an unreadable keybindings file while seeding', () => {
+    const unreadableContents = '{{{not json'
+    writeFileSync(filePath, unreadableContents, 'utf8')
+
+    expect(() =>
+      seedLegacyTabSwitchBindings(filePath, 'darwin', LEGACY_TAB_SWITCH_BINDINGS)
+    ).toThrow()
+    expect(readFileSync(filePath, 'utf8')).toBe(unreadableContents)
+  })
 })

--- a/src/main/keybindings/keybinding-file.test.ts
+++ b/src/main/keybindings/keybinding-file.test.ts
@@ -263,6 +263,38 @@ describe('keybinding-file', () => {
     })
   })
 
+  it('preserves pre-swap customizations that conflict only with the new defaults', () => {
+    // This was valid before the swap: moving nextSameType to Mod+K freed its
+    // old Shift+] chord for previousSameType. The new registry temporarily
+    // assigns Shift+] to nextAllTypes, but the seed must not mistake the
+    // resulting conflict for an absent user override and replace it.
+    writeFileSync(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        platforms: {
+          darwin: {
+            'tab.nextSameType': ['Mod+K'],
+            'tab.previousSameType': ['Mod+Shift+BracketRight']
+          }
+        }
+      }),
+      'utf8'
+    )
+
+    seedLegacyTabSwitchBindings(filePath, 'darwin', LEGACY_TAB_SWITCH_BINDINGS)
+
+    expect(readKeybindingFile(filePath, 'darwin')).toMatchObject({
+      overrides: {
+        'tab.nextSameType': ['Mod+K'],
+        'tab.previousSameType': ['Mod+Shift+BracketRight'],
+        'tab.nextAllTypes': ['Mod+Alt+BracketRight'],
+        'tab.previousAllTypes': ['Mod+Alt+BracketLeft']
+      },
+      diagnostics: []
+    })
+  })
+
   it('is a no-op once every swapped action already resolves on this platform', () => {
     // Seeding writes the whole document at once, so it clears the per-write
     // conflict guard that a naive one-action-at-a-time write would trip.

--- a/src/main/keybindings/keybinding-file.ts
+++ b/src/main/keybindings/keybinding-file.ts
@@ -318,6 +318,67 @@ export function migrateLegacyKeybindings(
   writeJsonDocument(path, document)
 }
 
+/**
+ * Pin the pre-swap tab-switch chords for a pre-existing install so upgrading
+ * users keep the shortcuts they learned. Writes into the active-platform
+ * section (mirroring `writeKeybindingOverride`) so the seeded values stay
+ * resettable from Settings. No-op when the user has already customized any of
+ * the swapped actions — that is custom territory, and a half-swapped pin would
+ * be worse than leaving their choices alone.
+ */
+export function seedLegacyTabSwitchBindings(
+  path: string,
+  platform: NodeJS.Platform,
+  legacyBindings: Readonly<Partial<Record<KeybindingActionId, string[]>>>
+): { seeded: boolean; snapshot: KeybindingFileSnapshot } {
+  const keybindingPlatform = getKeybindingPlatform(platform)
+  const actionIds = Object.keys(legacyBindings) as KeybindingActionId[]
+  const current = readKeybindingFile(path, platform)
+  const alreadyCustomized = actionIds.some(
+    (actionId) =>
+      Object.prototype.hasOwnProperty.call(current.commonOverrides, actionId) ||
+      PLATFORM_KEYS.some((os) =>
+        Object.prototype.hasOwnProperty.call(current.platformOverrides[os] ?? {}, actionId)
+      )
+  )
+  if (alreadyCustomized) {
+    return { seeded: false, snapshot: current }
+  }
+
+  const readResult = readJsonDocument(path)
+  const document = isJsonObject(readResult.document)
+    ? { ...readResult.document }
+    : createEmptyDocument()
+  for (const rootKey of Object.keys(document)) {
+    if (isKeybindingActionId(rootKey)) {
+      delete document[rootKey]
+    }
+  }
+  const common = isJsonObject(document.keybindings) ? { ...document.keybindings } : {}
+  const platforms = isJsonObject(document.platforms) ? { ...document.platforms } : {}
+  const activePlatform = isJsonObject(platforms[keybindingPlatform])
+    ? { ...(platforms[keybindingPlatform] as JsonObject) }
+    : {}
+  for (const actionId of actionIds) {
+    const normalized = normalizeKeybindingArrayForAction(actionId, legacyBindings[actionId] ?? [])
+    if (Array.isArray(normalized)) {
+      activePlatform[actionId] = normalized
+    }
+  }
+
+  document.version = FILE_VERSION
+  document.keybindings = common
+  document.platforms = {
+    ...platforms,
+    darwin: isJsonObject(platforms.darwin) ? platforms.darwin : {},
+    linux: isJsonObject(platforms.linux) ? platforms.linux : {},
+    win32: isJsonObject(platforms.win32) ? platforms.win32 : {},
+    [keybindingPlatform]: activePlatform
+  }
+  writeJsonDocument(path, document)
+  return { seeded: true, snapshot: readKeybindingFile(path, platform) }
+}
+
 export function writeKeybindingOverride(
   path: string,
   platform: NodeJS.Platform,

--- a/src/main/keybindings/keybinding-file.ts
+++ b/src/main/keybindings/keybinding-file.ts
@@ -340,12 +340,14 @@ export function seedLegacyTabSwitchBindings(
   const keybindingPlatform = getKeybindingPlatform(platform)
   const actionIds = Object.keys(legacyBindings) as KeybindingActionId[]
   const current = readKeybindingFile(path, platform)
-  // `current.overrides` is the effective override map for this platform (common
-  // + this platform's section). Skip any action that already resolves to a
-  // user-set binding here; a foreign-platform-only override must not block the
-  // pin, or this platform would drift to the new default.
+  const activePlatformOverrides = current.platformOverrides[keybindingPlatform] ?? {}
+  // Why: the new defaults can temporarily make a valid pre-swap customization
+  // look conflicting and remove it from `current.overrides`. Inspect the parsed
+  // common + active-platform sections directly so the seed never replaces it.
   const toSeed = actionIds.filter(
-    (actionId) => !Object.prototype.hasOwnProperty.call(current.overrides, actionId)
+    (actionId) =>
+      !Object.prototype.hasOwnProperty.call(current.commonOverrides, actionId) &&
+      !Object.prototype.hasOwnProperty.call(activePlatformOverrides, actionId)
   )
   if (toSeed.length === 0) {
     return { seeded: false, snapshot: current }

--- a/src/main/keybindings/keybinding-file.ts
+++ b/src/main/keybindings/keybinding-file.ts
@@ -322,9 +322,15 @@ export function migrateLegacyKeybindings(
  * Pin the pre-swap tab-switch chords for a pre-existing install so upgrading
  * users keep the shortcuts they learned. Writes into the active-platform
  * section (mirroring `writeKeybindingOverride`) so the seeded values stay
- * resettable from Settings. No-op when the user has already customized any of
- * the swapped actions — that is custom territory, and a half-swapped pin would
- * be worse than leaving their choices alone.
+ * resettable from Settings.
+ *
+ * Pins per action, not all-or-nothing: an action is seeded only when this
+ * platform has no effective override for it yet. That way a user who rebound
+ * just one of the swapped actions keeps that choice AND keeps the pre-swap
+ * default on the other three — an existing user's behavior is never altered,
+ * whether they customized none, some, or all of them. Because every pin equals
+ * the action's old default, the seeded set reproduces exactly today's effective
+ * config and introduces no new conflicts.
  */
 export function seedLegacyTabSwitchBindings(
   path: string,
@@ -334,14 +340,14 @@ export function seedLegacyTabSwitchBindings(
   const keybindingPlatform = getKeybindingPlatform(platform)
   const actionIds = Object.keys(legacyBindings) as KeybindingActionId[]
   const current = readKeybindingFile(path, platform)
-  const alreadyCustomized = actionIds.some(
-    (actionId) =>
-      Object.prototype.hasOwnProperty.call(current.commonOverrides, actionId) ||
-      PLATFORM_KEYS.some((os) =>
-        Object.prototype.hasOwnProperty.call(current.platformOverrides[os] ?? {}, actionId)
-      )
+  // `current.overrides` is the effective override map for this platform (common
+  // + this platform's section). Skip any action that already resolves to a
+  // user-set binding here; a foreign-platform-only override must not block the
+  // pin, or this platform would drift to the new default.
+  const toSeed = actionIds.filter(
+    (actionId) => !Object.prototype.hasOwnProperty.call(current.overrides, actionId)
   )
-  if (alreadyCustomized) {
+  if (toSeed.length === 0) {
     return { seeded: false, snapshot: current }
   }
 
@@ -359,7 +365,7 @@ export function seedLegacyTabSwitchBindings(
   const activePlatform = isJsonObject(platforms[keybindingPlatform])
     ? { ...(platforms[keybindingPlatform] as JsonObject) }
     : {}
-  for (const actionId of actionIds) {
+  for (const actionId of toSeed) {
     const normalized = normalizeKeybindingArrayForAction(actionId, legacyBindings[actionId] ?? [])
     if (Array.isArray(normalized)) {
       activePlatform[actionId] = normalized

--- a/src/main/keybindings/keybinding-file.ts
+++ b/src/main/keybindings/keybinding-file.ts
@@ -352,15 +352,20 @@ export function seedLegacyTabSwitchBindings(
   }
 
   const readResult = readJsonDocument(path)
-  const document = isJsonObject(readResult.document)
-    ? { ...readResult.document }
-    : createEmptyDocument()
+  if (!readResult.document) {
+    // Why: migration must never replace a user-owned file that could not be
+    // parsed; leaving the cohort pending allows a safe retry after repair.
+    throw new Error(readResult.error ?? 'Could not read keybindings file.')
+  }
+  const document = { ...readResult.document }
+  const common = isJsonObject(document.keybindings)
+    ? { ...document.keybindings }
+    : { ...current.commonOverrides }
   for (const rootKey of Object.keys(document)) {
     if (isKeybindingActionId(rootKey)) {
       delete document[rootKey]
     }
   }
-  const common = isJsonObject(document.keybindings) ? { ...document.keybindings } : {}
   const platforms = isJsonObject(document.platforms) ? { ...document.platforms } : {}
   const activePlatform = isJsonObject(platforms[keybindingPlatform])
     ? { ...(platforms[keybindingPlatform] as JsonObject) }

--- a/src/main/keybindings/keybinding-service.test.ts
+++ b/src/main/keybindings/keybinding-service.test.ts
@@ -1,0 +1,227 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  getEffectiveKeybindingsForAction,
+  keybindingMatchesAction,
+  LEGACY_TAB_SWITCH_BINDINGS,
+  type KeybindingActionId,
+  type KeybindingInput
+} from '../../shared/keybindings'
+import { getUserKeybindingsPath, writeKeybindingOverride } from './keybinding-file'
+import { KeybindingService } from './keybinding-service'
+
+// End-to-end coverage of the tab-switch convention swap: constructs a real
+// KeybindingService (which runs the seed) and asserts the effective bindings AND
+// real keystroke matching for both cohorts. The load-bearing claim under test is
+// that a pre-existing install's behavior is byte-identical to what it was before
+// the swap, on every platform and every customization state.
+
+const PLATFORMS: NodeJS.Platform[] = ['darwin', 'linux', 'win32']
+const SWAPPED_ACTIONS = Object.keys(LEGACY_TAB_SWITCH_BINDINGS) as KeybindingActionId[]
+
+function makeCohort(pending: boolean): {
+  controller: { isPending: () => boolean; markSeeded: () => void }
+  seeded: () => boolean
+} {
+  let stillPending = pending
+  let didSeed = false
+  return {
+    controller: {
+      isPending: () => stillPending,
+      markSeeded: () => {
+        didSeed = true
+        stillPending = false
+      }
+    },
+    seeded: () => didSeed
+  }
+}
+
+// A physical bracket press. Mod is Cmd on macOS and Ctrl elsewhere; the matcher
+// resolves brackets by `code`, so this stays layout-independent.
+function bracketPress(opts: {
+  code: 'BracketLeft' | 'BracketRight'
+  alt: boolean
+  shift: boolean
+  platform: NodeJS.Platform
+}): KeybindingInput {
+  const isMac = opts.platform === 'darwin'
+  return {
+    code: opts.code,
+    key: opts.code === 'BracketRight' ? ']' : '[',
+    meta: isMac,
+    control: !isMac,
+    alt: opts.alt,
+    shift: opts.shift
+  }
+}
+
+describe('KeybindingService tab-switch cohort seeding', () => {
+  let home: string
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'orca-kb-service-'))
+  })
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  it.each(PLATFORMS)(
+    'fresh install (%s) adopts the swapped defaults and writes no file',
+    (platform) => {
+      const cohort = makeCohort(false)
+      const service = new KeybindingService({
+        homePath: home,
+        platform,
+        legacyTabSwitchSeed: cohort.controller
+      })
+
+      expect(cohort.seeded()).toBe(false)
+      // Nothing written: a fresh install rides on the registry defaults.
+      expect(existsSync(getUserKeybindingsPath(home))).toBe(false)
+
+      const overrides = service.getOverrides()
+      expect(getEffectiveKeybindingsForAction('tab.nextAllTypes', platform, overrides)).toEqual([
+        'Mod+Shift+BracketRight'
+      ])
+      expect(getEffectiveKeybindingsForAction('tab.nextSameType', platform, overrides)).toEqual([
+        'Mod+Alt+BracketRight'
+      ])
+
+      // Shift+bracket now drives the broad all-types cycle.
+      expect(
+        keybindingMatchesAction(
+          'tab.nextAllTypes',
+          bracketPress({ code: 'BracketRight', alt: false, shift: true, platform }),
+          platform,
+          overrides
+        )
+      ).toBe(true)
+      expect(
+        keybindingMatchesAction(
+          'tab.nextSameType',
+          bracketPress({ code: 'BracketRight', alt: false, shift: true, platform }),
+          platform,
+          overrides
+        )
+      ).toBe(false)
+    }
+  )
+
+  it.each(PLATFORMS)(
+    'existing install (%s) keeps the pre-swap chords exactly, on a clean profile',
+    (platform) => {
+      const cohort = makeCohort(true)
+      const service = new KeybindingService({
+        homePath: home,
+        platform,
+        legacyTabSwitchSeed: cohort.controller
+      })
+
+      expect(cohort.seeded()).toBe(true)
+      const overrides = service.getOverrides()
+
+      // Effective bindings for all four actions equal the pre-swap defaults.
+      for (const actionId of SWAPPED_ACTIONS) {
+        expect(getEffectiveKeybindingsForAction(actionId, platform, overrides)).toEqual(
+          LEGACY_TAB_SWITCH_BINDINGS[actionId]
+        )
+      }
+
+      // Behavior is unchanged: Mod+Shift+bracket still cycles same-type, and
+      // Mod+Alt+bracket still cycles all-types — the inverse of a fresh install.
+      const shiftRight = bracketPress({ code: 'BracketRight', alt: false, shift: true, platform })
+      expect(keybindingMatchesAction('tab.nextSameType', shiftRight, platform, overrides)).toBe(
+        true
+      )
+      expect(keybindingMatchesAction('tab.nextAllTypes', shiftRight, platform, overrides)).toBe(
+        false
+      )
+
+      const altLeft = bracketPress({ code: 'BracketLeft', alt: true, shift: false, platform })
+      expect(keybindingMatchesAction('tab.previousAllTypes', altLeft, platform, overrides)).toBe(
+        true
+      )
+      expect(keybindingMatchesAction('tab.previousSameType', altLeft, platform, overrides)).toBe(
+        false
+      )
+    }
+  )
+
+  it('existing install keeps a rebound action AND pins the pre-swap default on the rest', () => {
+    const platform: NodeJS.Platform = 'darwin'
+    // The user had rebound just one action before upgrading.
+    writeKeybindingOverride(getUserKeybindingsPath(home), platform, 'tab.nextSameType', ['Mod+K'])
+
+    const cohort = makeCohort(true)
+    const service = new KeybindingService({
+      homePath: home,
+      platform,
+      legacyTabSwitchSeed: cohort.controller
+    })
+    const overrides = service.getOverrides()
+
+    // Their custom binding is untouched...
+    expect(getEffectiveKeybindingsForAction('tab.nextSameType', platform, overrides)).toEqual([
+      'Mod+K'
+    ])
+    // ...and the other three still resolve to their pre-swap defaults, not the
+    // new ones — no silent behavior change for a partially-customized user.
+    expect(getEffectiveKeybindingsForAction('tab.previousSameType', platform, overrides)).toEqual([
+      'Mod+Shift+BracketLeft'
+    ])
+    expect(getEffectiveKeybindingsForAction('tab.nextAllTypes', platform, overrides)).toEqual([
+      'Mod+Alt+BracketRight'
+    ])
+    expect(getEffectiveKeybindingsForAction('tab.previousAllTypes', platform, overrides)).toEqual([
+      'Mod+Alt+BracketLeft'
+    ])
+  })
+
+  it('is idempotent: a second launch after the seed changes nothing', () => {
+    const platform: NodeJS.Platform = 'linux'
+    const cohort = makeCohort(true)
+    const first = new KeybindingService({
+      homePath: home,
+      platform,
+      legacyTabSwitchSeed: cohort.controller
+    })
+    const afterFirst = first.getOverrides()
+
+    // Same cohort controller: markSeeded flipped it to not-pending, mirroring the
+    // persisted flag flipping to 'done'.
+    const second = new KeybindingService({
+      homePath: home,
+      platform,
+      legacyTabSwitchSeed: cohort.controller
+    })
+    expect(second.getOverrides()).toEqual(afterFirst)
+    for (const actionId of SWAPPED_ACTIONS) {
+      expect(getEffectiveKeybindingsForAction(actionId, platform, second.getOverrides())).toEqual(
+        LEGACY_TAB_SWITCH_BINDINGS[actionId]
+      )
+    }
+  })
+
+  it('leaves the cohort pending when the seed write fails (retries next launch)', () => {
+    // homePath is a regular file, so creating `<home>/.orca/` throws. The service
+    // must swallow the error and NOT mark the one-shot done.
+    const fileHome = join(home, 'not-a-dir')
+    writeFileSync(fileHome, 'x', 'utf8')
+    const cohort = makeCohort(true)
+
+    expect(
+      () =>
+        new KeybindingService({
+          homePath: fileHome,
+          platform: 'darwin',
+          legacyTabSwitchSeed: cohort.controller
+        })
+    ).not.toThrow()
+    expect(cohort.seeded()).toBe(false)
+    expect(cohort.controller.isPending()).toBe(true)
+  })
+})

--- a/src/main/keybindings/keybinding-service.ts
+++ b/src/main/keybindings/keybinding-service.ts
@@ -1,13 +1,15 @@
-import type {
-  KeybindingActionId,
-  KeybindingFileSnapshot,
-  KeybindingOverrides
+import {
+  LEGACY_TAB_SWITCH_BINDINGS,
+  type KeybindingActionId,
+  type KeybindingFileSnapshot,
+  type KeybindingOverrides
 } from '../../shared/keybindings'
 import {
   ensureKeybindingFile,
   getUserKeybindingsPath,
   migrateLegacyKeybindings,
   readKeybindingFile,
+  seedLegacyTabSwitchBindings,
   writeKeybindingOverride
 } from './keybinding-file'
 
@@ -15,6 +17,13 @@ export type KeybindingServiceOptions = {
   homePath: string
   platform?: NodeJS.Platform
   getLegacyOverrides?: () => KeybindingOverrides | undefined
+  /** Cohort seed for the tab-switch convention swap. `isPending` is true only
+   *  for pre-existing installs on the first launch after the swap; `markSeeded`
+   *  freezes the one-shot so it never runs again. */
+  legacyTabSwitchSeed?: {
+    isPending: () => boolean
+    markSeeded: () => void
+  }
 }
 
 export class KeybindingService {
@@ -28,6 +37,17 @@ export class KeybindingService {
     // Why: older builds persisted custom shortcuts inside global settings.
     // Once a keybindings file exists, it is the sole source of truth.
     migrateLegacyKeybindings(this.configPath, this.platform, options.getLegacyOverrides?.())
+    // Why: pre-existing installs keep the old tab-switch chords. Only mark the
+    // one-shot done on success so a transient IO failure retries next launch
+    // instead of silently dropping the pin.
+    if (options.legacyTabSwitchSeed?.isPending()) {
+      try {
+        seedLegacyTabSwitchBindings(this.configPath, this.platform, LEGACY_TAB_SWITCH_BINDINGS)
+        options.legacyTabSwitchSeed.markSeeded()
+      } catch (error) {
+        console.error('Failed to seed legacy tab-switch keybindings:', error)
+      }
+    }
   }
 
   getPath(): string {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -9797,6 +9797,63 @@ describe('Store', () => {
   })
 })
 
+describe('Store.migrateTabSwitchKeybindings', () => {
+  // Freezes the install cohort for the tab-switch convention swap on first load.
+  // Keys on `fileExistedOnLoad` (not field presence) so the verdict is stable
+  // even after a fresh install writes its own data file on later launches.
+
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  it('marks a truly fresh install done so it adopts the new defaults', async () => {
+    const store = await createStore()
+    expect(store.getSettings().tabSwitchKeybindingSeed).toBe('done')
+  })
+
+  it('marks a pre-existing install pending so the legacy chords get seeded', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [makeRepo()],
+      worktreeMeta: {},
+      settings: { theme: 'dark' },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+    const store = await createStore()
+    expect(store.getSettings().tabSwitchKeybindingSeed).toBe('pending')
+    expect(store.getSettings().theme).toBe('dark')
+  })
+
+  it('treats a corrupt data file as a pre-existing install', async () => {
+    mkdirSync(testState.dir, { recursive: true })
+    writeFileSync(dataFile(), '{{{corrupt json', 'utf-8')
+    const store = await createStore()
+    expect(store.getSettings().tabSwitchKeybindingSeed).toBe('pending')
+  })
+
+  it('preserves an already-frozen cohort on subsequent launches', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: { tabSwitchKeybindingSeed: 'done' },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+    const store = await createStore()
+    // Existing file but cohort already resolved to 'done' — must not flip to
+    // 'pending' just because the data file happens to exist.
+    expect(store.getSettings().tabSwitchKeybindingSeed).toBe('done')
+  })
+})
+
 describe('Store.migrateWorktreeIdentity', () => {
   const OLD = 'repo1::/ws/cunner'
   const NEW = 'repo1::/ws/worktree-creation-spinner'

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -3544,7 +3544,10 @@ export class Store {
       this.loadNeedsSave = true
     }
 
-    const migrated = this.migrateTelemetry(result, fileExistedOnLoad)
+    const migrated = this.migrateTabSwitchKeybindings(
+      this.migrateTelemetry(result, fileExistedOnLoad),
+      fileExistedOnLoad
+    )
 
     // githubCache lives in a sidecar file now (see getGithubCacheFile). A
     // legacy in-file cache (pre-sidecar build, or a downgrade round-trip) is
@@ -3580,6 +3583,34 @@ export class Store {
   //     the banner resolves (the consent resolver returns `pending_banner`
   //     until then, so nothing transmits).
   //   - `installId` — anonymous UUID v4. Stable across launches; not surfaced in the UI.
+  // One-shot cohort freeze for the tab-switch keybinding convention swap. Runs
+  // on every `load()` but is a no-op once `tabSwitchKeybindingSeed` is set. The
+  // decision must be frozen on the first post-swap launch: `fileExistedOnLoad`
+  // only distinguishes existing vs fresh on that first run (a fresh install's
+  // data file exists on every subsequent launch), so persist the verdict now.
+  private migrateTabSwitchKeybindings(
+    state: PersistedState,
+    fileExistedOnLoad: boolean
+  ): PersistedState {
+    const existing = state.settings?.tabSwitchKeybindingSeed
+    if (existing === 'pending' || existing === 'done') {
+      return state
+    }
+    // Why: mark dirty so the frozen cohort survives the next restart even if no
+    // other setting changes this session; without this a fresh install could be
+    // re-read as "existing" once its data file lands on disk.
+    this.loadNeedsSave = true
+    return {
+      ...state,
+      settings: {
+        ...state.settings,
+        // Existing installs pin the old chords via a keybindings.json seed;
+        // fresh installs need nothing beyond the new registry defaults.
+        tabSwitchKeybindingSeed: fileExistedOnLoad ? 'pending' : 'done'
+      }
+    }
+  }
+
   private migrateTelemetry(state: PersistedState, fileExistedOnLoad: boolean): PersistedState {
     const existing = state.settings?.telemetry
     // Why: the one-shot is complete only when all three invariants hold.

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1950,10 +1950,9 @@ function Terminal(): React.JSX.Element | null {
         return
       }
 
-      // Cmd/Ctrl+Shift+] and Cmd/Ctrl+Shift+[ - switch tabs (scoped to the
-      // active tab type). Cmd/Ctrl+Alt+] and Cmd/Ctrl+Alt+[ cycles across
-      // every tab type as an escape hatch from the type-scoped default, and
-      // matches the platform tab-switch chord on macOS.
+      // Fresh installs use Cmd/Ctrl+Shift+[ / ] across all tab types and
+      // Cmd/Ctrl+Alt+[ / ] within the active type; upgrading users keep the
+      // inverse mapping, and both actions remain rebindable.
       // Why: use e.code instead of e.key because on macOS, Shift+[ reports '{'
       // as the key value (the shifted character), not '['. Option+[ also
       // composes to dead-key / punctuation on many layouts, so matching on

--- a/src/renderer/src/components/tab-bar/group-tab-order.ts
+++ b/src/renderer/src/components/tab-bar/group-tab-order.ts
@@ -18,8 +18,8 @@ export type ActiveTabNavOrderIds = {
 /**
  * Compute the visible tab-strip order for a single group.
  *
- * Why: keyboard navigation (Cmd/Ctrl+Shift+[ / ]) and the IPC switch-tab
- * shortcut must walk tabs in the same order the TabBar renders them. The
+ * Why: keyboard tab-cycle actions and the IPC switch-tab shortcut must walk
+ * tabs in the same order the TabBar renders them. The
  * TabBar derives its order from `group.tabOrder` (the canonical split-group
  * state, updated by drag/drop via `reorderUnifiedTabs`). Reading from the
  * legacy `tabBarOrderByWorktree` drifts out of sync because that store is

--- a/src/renderer/src/components/terminal/tab-type-cycle.ts
+++ b/src/renderer/src/components/terminal/tab-type-cycle.ts
@@ -44,8 +44,8 @@ type GetNextTabAcrossAllTypesParams = {
   direction: number
 }
 
-// Why: companion to getNextTabWithinActiveType for the Cmd/Ctrl+Alt+Shift+]/[
-// "cycle across every tab" chord. Keeps the same dual-id matching semantics
+// Why: companion to getNextTabWithinActiveType for the "cycle across every tab"
+// chord (Cmd/Ctrl+Shift+]/[ on fresh installs). Keeps the same dual-id matching semantics
 // (prefer the active group's unified tabId to disambiguate split layouts, fall
 // back to the backing entity id) so behavior matches what the TabBar renders.
 export function getNextTabAcrossAllTypes({

--- a/src/renderer/src/hooks/ipc-tab-switch.ts
+++ b/src/renderer/src/hooks/ipc-tab-switch.ts
@@ -18,9 +18,9 @@ type CycleContext = {
 }
 
 /**
- * Shared setup for the Cmd/Ctrl+Shift+[ / ] chords (both the type-scoped and
- * across-all-types variants). Returns null when there is no active worktree
- * or the visible nav has at most one tab (nothing to cycle).
+ * Shared setup for the type-scoped and across-all-types tab-cycle actions.
+ * Returns null when there is no active worktree or the visible nav has at most
+ * one tab (nothing to cycle).
  */
 function resolveCycleContext(): CycleContext | null {
   const store = useAppStore.getState()

--- a/src/renderer/src/hooks/ipc-tab-switch.ts
+++ b/src/renderer/src/hooks/ipc-tab-switch.ts
@@ -87,7 +87,9 @@ export function activateCyclableTab(store: AppStoreState, next: TypeCyclableTab)
 }
 
 /**
- * Handle Cmd/Ctrl+Shift+[ / ] direction switching within the active tab type.
+ * Handle direction switching within the active tab type (same-type cycle).
+ * The default chord is Cmd/Ctrl+Alt+[ / ] for fresh installs; pre-swap installs
+ * keep Cmd/Ctrl+Shift+[ / ] via the seed migration, and either is rebindable.
  * Extracted from useIpcEvents to keep file size under the max-lines lint threshold.
  * Returns true if a tab switch occurred, false otherwise.
  */
@@ -114,14 +116,13 @@ export function handleSwitchTab(direction: number): boolean {
 }
 
 /**
- * Handle Cmd/Ctrl+Alt+Shift+[ / ] cycling across every visible tab,
- * regardless of tab type.
+ * Handle cycling across every visible tab, regardless of tab type.
  *
- * Why: companion chord to the type-scoped Cmd/Ctrl+Shift+[ / ] that ships as
- * the default. The type-scoped chord is the VS Code-style per-pane cycle;
- * this one gives users an escape hatch back to the pre-scope "cycle through
- * everything" behavior without needing a settings toggle (see PR #1281
- * discussion). Returns true if a tab switch occurred, false otherwise.
+ * Why: companion chord to the type-scoped same-type cycle. Fresh installs bind
+ * this broad cycle to Cmd/Ctrl+Shift+[ / ] — the widespread "switch tab" chord —
+ * and the same-type cycle to Cmd/Ctrl+Alt+[ / ]; pre-swap installs keep the
+ * inverse via the seed migration (see PR #1281 for the original type-scope
+ * rationale). Returns true if a tab switch occurred, false otherwise.
  */
 export function handleSwitchTabAcrossAllTypes(direction: number): boolean {
   const ctx = resolveCycleContext()

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -12,6 +12,7 @@ import {
   isDigitIndexActionId,
   isDoubleTapBinding,
   keybindingFromInput,
+  LEGACY_TAB_SWITCH_BINDINGS,
   keybindingFromInputForAction,
   keybindingMatchesAction,
   keybindingMatchesInput,
@@ -441,6 +442,42 @@ describe('keybindings', () => {
         actionIds: ['workspace.rename', 'tab.rename']
       }
     ])
+  })
+
+  it('defaults tab-switch chords to the swapped convention for fresh installs', () => {
+    // New users get the widespread mapping: Shift+bracket cycles all tabs,
+    // Alt+bracket cycles within the active type.
+    expect(getEffectiveKeybindingsForAction('tab.nextAllTypes', 'darwin')).toEqual([
+      'Mod+Shift+BracketRight'
+    ])
+    expect(getEffectiveKeybindingsForAction('tab.previousAllTypes', 'darwin')).toEqual([
+      'Mod+Shift+BracketLeft'
+    ])
+    expect(getEffectiveKeybindingsForAction('tab.nextSameType', 'darwin')).toEqual([
+      'Mod+Alt+BracketRight'
+    ])
+    expect(getEffectiveKeybindingsForAction('tab.previousSameType', 'darwin')).toEqual([
+      'Mod+Alt+BracketLeft'
+    ])
+  })
+
+  it('pins the pre-swap chords via LEGACY_TAB_SWITCH_BINDINGS for upgrading installs', () => {
+    // These are what the seed migration writes so pre-existing users keep the
+    // shortcuts they learned; overriding an action with its legacy value must
+    // reproduce the old effective binding.
+    expect(LEGACY_TAB_SWITCH_BINDINGS).toEqual({
+      'tab.nextSameType': ['Mod+Shift+BracketRight'],
+      'tab.previousSameType': ['Mod+Shift+BracketLeft'],
+      'tab.nextAllTypes': ['Mod+Alt+BracketRight'],
+      'tab.previousAllTypes': ['Mod+Alt+BracketLeft']
+    })
+    for (const [actionId, bindings] of Object.entries(LEGACY_TAB_SWITCH_BINDINGS)) {
+      expect(
+        getEffectiveKeybindingsForAction(actionId as KeybindingActionId, 'darwin', {
+          [actionId]: bindings
+        })
+      ).toEqual(bindings)
+    }
   })
 
   it('defines browser history shortcuts for Logitech side-button remaps', () => {
@@ -1216,29 +1253,30 @@ describe('keybindings', () => {
     expect(keybindingMatchesAction('terminal.focusNextPane', jisLeftBracket, 'darwin')).toBe(false)
     expect(keybindingMatchesAction('terminal.focusNextPane', jisRightBracket, 'darwin')).toBe(true)
 
+    // Alt+bracket is the fresh-install same-type default after the convention swap.
     expect(
-      keybindingMatchesAction('tab.previousAllTypes', { ...jisLeftBracket, alt: true }, 'darwin')
+      keybindingMatchesAction('tab.previousSameType', { ...jisLeftBracket, alt: true }, 'darwin')
     ).toBe(true)
     expect(
-      keybindingMatchesAction('tab.nextAllTypes', { ...jisRightBracket, alt: true }, 'darwin')
+      keybindingMatchesAction('tab.nextSameType', { ...jisRightBracket, alt: true }, 'darwin')
     ).toBe(true)
     expect(
       keybindingMatchesAction(
-        'tab.previousAllTypes',
+        'tab.previousSameType',
         { ...jisLeftBracket, control: true, meta: false, alt: true },
         'linux'
       )
     ).toBe(true)
     expect(
       keybindingMatchesAction(
-        'tab.nextAllTypes',
+        'tab.nextSameType',
         { ...jisLeftBracket, control: true, meta: false, alt: true },
         'linux'
       )
     ).toBe(false)
     expect(
       keybindingMatchesAction(
-        'tab.nextAllTypes',
+        'tab.nextSameType',
         { ...jisRightBracket, control: true, meta: false, alt: true },
         'linux'
       )
@@ -1268,7 +1306,7 @@ describe('keybindings', () => {
 
     expect(
       keybindingMatchesAction(
-        'tab.previousAllTypes',
+        'tab.previousSameType',
         {
           key: '[',
           code: 'Digit8',
@@ -1282,7 +1320,7 @@ describe('keybindings', () => {
     ).toBe(false)
     expect(
       keybindingMatchesAction(
-        'tab.previousAllTypes',
+        'tab.previousSameType',
         {
           key: 'Dead',
           code: 'BracketLeft',
@@ -1385,7 +1423,9 @@ describe('keybindings', () => {
     expect(formatKeybindingList(['DoubleTap+Shift'], 'linux')).toBe('Shift Shift')
   })
 
-  it('matches macOS Option-composed bracket shortcuts for all-type tab switching', () => {
+  it('matches macOS Option-composed bracket shortcuts for same-type tab switching', () => {
+    // Cmd+Alt+bracket is the fresh-install same-type default after the swap, so
+    // Option-composed dead keys (\u2325[ -> "\u201c") must still resolve to that action.
     const macOptionLeftBracket = {
       key: '\u201c',
       code: 'BracketLeft',
@@ -1403,12 +1443,12 @@ describe('keybindings', () => {
       shift: false
     }
 
-    expect(keybindingMatchesAction('tab.previousAllTypes', macOptionLeftBracket, 'darwin')).toBe(
+    expect(keybindingMatchesAction('tab.previousSameType', macOptionLeftBracket, 'darwin')).toBe(
       true
     )
-    expect(keybindingMatchesAction('tab.nextAllTypes', macOptionLeftBracket, 'darwin')).toBe(false)
-    expect(keybindingMatchesAction('tab.nextAllTypes', macOptionRightBracket, 'darwin')).toBe(true)
-    expect(keybindingMatchesAction('tab.previousAllTypes', macOptionRightBracket, 'darwin')).toBe(
+    expect(keybindingMatchesAction('tab.nextSameType', macOptionLeftBracket, 'darwin')).toBe(false)
+    expect(keybindingMatchesAction('tab.nextSameType', macOptionRightBracket, 'darwin')).toBe(true)
+    expect(keybindingMatchesAction('tab.previousSameType', macOptionRightBracket, 'darwin')).toBe(
       false
     )
   })

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -643,7 +643,10 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     group: 'Tab Navigation',
     scope: 'tabs',
     searchKeywords: ['shortcut', 'tab', 'next', 'switch', 'cycle'],
-    defaultBindings: platformBindings(['Mod+Shift+BracketRight'])
+    // Why: Mod+Shift+Bracket is the widespread "switch tab" chord, so it now
+    // drives the broad all-types cycle for new users; same-type moves to
+    // Mod+Alt. Pre-release installs keep the old mapping via the seed migration.
+    defaultBindings: platformBindings(['Mod+Alt+BracketRight'])
   },
   {
     id: 'tab.previousSameType',
@@ -651,7 +654,7 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     group: 'Tab Navigation',
     scope: 'tabs',
     searchKeywords: ['shortcut', 'tab', 'previous', 'switch', 'cycle'],
-    defaultBindings: platformBindings(['Mod+Shift+BracketLeft'])
+    defaultBindings: platformBindings(['Mod+Alt+BracketLeft'])
   },
   {
     id: 'tab.nextAllTypes',
@@ -659,7 +662,7 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     group: 'Tab Navigation',
     scope: 'tabs',
     searchKeywords: ['shortcut', 'tab', 'next', 'switch', 'cycle', 'all', 'any'],
-    defaultBindings: platformBindings(['Mod+Alt+BracketRight'])
+    defaultBindings: platformBindings(['Mod+Shift+BracketRight'])
   },
   {
     id: 'tab.previousAllTypes',
@@ -667,7 +670,7 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     group: 'Tab Navigation',
     scope: 'tabs',
     searchKeywords: ['shortcut', 'tab', 'previous', 'switch', 'cycle', 'all', 'any'],
-    defaultBindings: platformBindings(['Mod+Alt+BracketLeft'])
+    defaultBindings: platformBindings(['Mod+Shift+BracketLeft'])
   },
   {
     id: 'tab.previousRecent',
@@ -1069,6 +1072,18 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
   },
   ...buildAgentTabKeybindingDefinitions()
 ]
+
+/**
+ * The tab-switch bindings as they shipped before the convention swap. A one-time
+ * migration pins these for pre-release installs so upgrading users keep the
+ * shortcuts they learned; fresh installs get the new registry defaults above.
+ */
+export const LEGACY_TAB_SWITCH_BINDINGS: Readonly<Partial<Record<KeybindingActionId, string[]>>> = {
+  'tab.nextSameType': ['Mod+Shift+BracketRight'],
+  'tab.previousSameType': ['Mod+Shift+BracketLeft'],
+  'tab.nextAllTypes': ['Mod+Alt+BracketRight'],
+  'tab.previousAllTypes': ['Mod+Alt+BracketLeft']
+}
 
 export function agentTabActionId(agent: TuiAgent): AgentTabActionId {
   return `tab.newAgent.${agent}`

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3042,6 +3042,12 @@ export type GlobalSettings = {
      *  false for fresh installs (no first-launch surface). */
     existedBeforeTelemetryRelease: boolean
   }
+  /** One-shot cohort marker for the tab-switch keybinding convention swap.
+   *  Absent before the migration runs. Set once on first boot after the swap:
+   *  `'pending'` for pre-existing installs (a seed then pins the old chords in
+   *  keybindings.json before flipping this to `'done'`), or `'done'` for fresh
+   *  installs, which adopt the new registry defaults with no seed. */
+  tabSwitchKeybindingSeed?: 'pending' | 'done'
   /** Local voice/dictation configuration (Phase 1 voice feature). Optional
    *  because profiles created before voice landed won't have the key;
    *  `getDefaultSettings()` hydrates `getDefaultVoiceSettings()` via the


### PR DESCRIPTION
## What & why

Orca's default tab-switch chords are inverted from the widespread desktop convention. Across common terminals and editors, **Cmd/Ctrl+Shift+[ / ]** is the broad "switch to the next/previous tab" chord, and the Alt-modified bracket is the narrower within-container move. Orca ships the opposite: Shift+bracket is the *same-type* cycle and Alt+bracket is the *all-types* cycle.

This aligns **new installs** with the convention while leaving **existing users exactly where they are**.

| Chord | Existing users (unchanged) | New users (this release onward) |
|---|---|---|
| `Mod+Shift+[ / ]` | same-type cycle | **all-types cycle** |
| `Mod+Alt+[ / ]` | all-types cycle | **same-type cycle** |

## How the cohort split works

The install cohort is frozen once on the first launch after this release, using the existing `fileExistedOnLoad` "has this user run Orca before?" signal — mirroring the telemetry cohort one-shot:

- **Fresh install** → `tabSwitchKeybindingSeed = 'done'`; adopts the new registry defaults, nothing written.
- **Pre-existing install** → `tabSwitchKeybindingSeed = 'pending'`; `KeybindingService` then pins the legacy chords into `~/.orca/keybindings.json` and flips the flag to `'done'`.

The seed is **strictly per-action**: it pins each swapped action to its pre-swap chord **only when this platform has no effective override for it yet**. So a user who rebound just one of the four keeps that binding *and* keeps the pre-swap default on the other three — an existing user's behavior is never altered, whether they customized none, some, or all of them. The skip check keys on the active platform's effective overrides, so a foreign-platform-only override can't leave the active platform on a new default. Writes go to the active-platform section so the pins stay resettable from Settings, and the one-shot only marks done on success (a transient IO error retries next launch).

Because every pin equals the action's old default, the seeded set reproduces exactly today's effective config and introduces no new conflicts. Action IDs keep their meaning, so every dispatch/matcher consumer (Terminal, floating terminal, browser guest) needs no change.

## Changes
- `src/shared/keybindings.ts` — swap the four `tab.*SameType` / `tab.*AllTypes` defaults; export `LEGACY_TAB_SWITCH_BINDINGS`
- `src/main/persistence.ts` + `src/shared/types.ts` — `migrateTabSwitchKeybindings` freezes the cohort flag
- `src/main/keybindings/keybinding-file.ts` — `seedLegacyTabSwitchBindings` writes the legacy pins (per-action, customization-aware)
- `src/main/keybindings/keybinding-service.ts` + `src/main/index.ts` — run the seed once for the pending cohort
- refreshed stale default-chord comments in `ipc-tab-switch.ts` / `tab-type-cycle.ts`

## Verification

Automated, at the real-function level (no mocked keybinding layer). **526 tests pass across the five affected suites**; node + CLI + web typecheck and changed-file oxlint clean.

**End-to-end cohort proof — `keybinding-service.test.ts`** constructs a real `KeybindingService` (which runs the seed against a temp home) and asserts both the effective bindings and **real keystroke matching** for both cohorts:
- *Existing install, clean profile, on darwin / linux / win32* — all four actions resolve to `LEGACY_TAB_SWITCH_BINDINGS` (the pre-swap defaults); a `Mod+Shift+]` press still matches `tab.nextSameType` and **not** `tab.nextAllTypes`, and `Mod+Alt+[` still matches `tab.previousAllTypes` — i.e. byte-identical to pre-swap.
- *Fresh install, on darwin / linux / win32* — no file written; `Mod+Shift+]` now matches `tab.nextAllTypes`, `Mod+Alt+]` matches `tab.nextSameType`.
- *Partially-customized existing user* — a rebound action is preserved and the other three still resolve to their pre-swap defaults (not the new ones).
- *Idempotency* — a second launch after the seed changes nothing.
- *Seed write fails* (home is an unwritable path) — the constructor swallows the error, leaves the cohort `pending`, and retries next launch.

**Cohort classification — `persistence.test.ts` (`Store.migrateTabSwitchKeybindings`):** fresh → `'done'`, pre-existing file → `'pending'`, corrupt data file → `'pending'` (treated as existing, matching the telemetry migration), already-frozen cohort preserved on later launches.

**Seed file mechanics — `keybinding-file.test.ts`:** writes to the active-platform section; preserves a customized action while pinning the rest; migrates root-level legacy overrides without data loss; refuses to replace an unreadable user file; a foreign-platform override does not block the active-platform pin; idempotent; no conflict diagnostics.

**Browser guest routing — `browser-manager.test.ts`:** verifies the new Shift chord reaches all-types cycling and the new Alt chord reaches same-type cycling while focus is inside a guest.

**Registry — `keybindings.test.ts`:** the swapped fresh-install defaults and the `LEGACY_TAB_SWITCH_BINDINGS` values; Alt-bracket matcher tests (JIS, dead-key, Option-composed) retargeted to `*SameType`, which now owns Cmd+Alt+bracket.

## Cross-platform / SSH
`Mod` resolves to Cmd on macOS and Ctrl on Linux/Windows; the seed writes to the active-platform section. Keybindings are per-home, so each machine (including SSH hosts) freezes its own cohort independently.

## Reviewer note
Existing users will see the four tab-switch shortcuts flagged as "modified" in Settings (they're now real overrides); resetting any one adopts that action's new default. This is the deliberate, precedent-matching tradeoff (same approach as the existing legacy-keybindings migration).

## Electron cohort validation

Validated PR head `e199c97e8` in real Electron launches attached through CDP, using isolated profile and keybinding-home paths. The attached app identity matched `salmon @ brennanb2025/tab-switch-keybinding-swap`.

- **Fresh install:** cohort persisted as `done`; no keybindings file or overrides were created; Settings visibly showed **Next tab (same type)** as `⌘⌥]` and **Next tab (all types)** as `⌘⇧]`, with `Modified 0` and no conflicts.
- **Pre-existing install:** relaunched the same isolated profile with the pre-release marker absent; startup wrote all four legacy pins and persisted the cohort as `done`. Settings visibly showed **Next tab (same type)** as `⌘⇧]` and **Next tab (all types)** as `⌘⌥]`, marked Modified with zero conflicts. The on-disk file contained the corresponding previous-direction pins as well.
- Both launches had zero renderer console errors and zero keybinding diagnostics.

Remaining gap: this quick Electron pass did not create heterogeneous tabs and observe selection after pressing the chord; real keystroke matching and browser-guest dispatch remain covered by the automated cohort and routing tests above.