### PR TITLE
Fix GitHub CLI proxy auth preflight

### DIFF
--- a/src/main/git/runner-wsl-gh-fallback.test.ts
+++ b/src/main/git/runner-wsl-gh-fallback.test.ts
@@ -1,11 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as WslModule from '../wsl'
 
-const { execFileMock, execFileSyncMock, spawnMock, getDefaultWslDistroMock } = vi.hoisted(() => ({
+const {
+  execFileMock,
+  execFileSyncMock,
+  spawnMock,
+  getDefaultWslDistroMock,
+  buildLocalCliEnvironmentMock
+} = vi.hoisted(() => ({
   execFileMock: vi.fn(),
   execFileSyncMock: vi.fn(),
   spawnMock: vi.fn(),
-  getDefaultWslDistroMock: vi.fn()
+  getDefaultWslDistroMock: vi.fn(),
+  buildLocalCliEnvironmentMock: vi.fn()
 }))
 
 vi.mock('child_process', () => ({
@@ -19,6 +26,10 @@ vi.mock('../wsl', async (importOriginal) => ({
   getDefaultWslDistro: getDefaultWslDistroMock
 }))
 
+vi.mock('../network/local-cli-environment', () => ({
+  buildLocalCliEnvironment: buildLocalCliEnvironmentMock
+}))
+
 import { ghExecFileAsync, glabExecFileAsync } from './runner'
 
 describe('ghExecFileAsync WSL fallback', () => {
@@ -28,6 +39,11 @@ describe('ghExecFileAsync WSL fallback', () => {
     execFileMock.mockReset()
     getDefaultWslDistroMock.mockReset()
     getDefaultWslDistroMock.mockReturnValue(null)
+    buildLocalCliEnvironmentMock.mockReset()
+    buildLocalCliEnvironmentMock.mockImplementation(async (env: NodeJS.ProcessEnv | undefined) => ({
+      ...env,
+      HTTPS_PROXY: 'http://host-proxy.example:8080'
+    }))
     Object.defineProperty(process, 'platform', {
       configurable: true,
       value: 'win32'
@@ -39,6 +55,72 @@ describe('ghExecFileAsync WSL fallback', () => {
       configurable: true,
       value: originalPlatform
     })
+  })
+
+  it('injects the local CLI proxy environment into host gh and glab calls', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'darwin'
+    })
+    execFileMock.mockImplementation((_binary, _args, _options, callback) => {
+      callback(null, { stdout: '[]', stderr: '' })
+    })
+
+    await ghExecFileAsync(['api', 'rate_limit'], { env: { GH_HOST: 'github.example' } })
+    await glabExecFileAsync(['api', 'projects'], { env: { GITLAB_HOST: 'gitlab.example' } })
+
+    expect(buildLocalCliEnvironmentMock).toHaveBeenNthCalledWith(1, {
+      GH_HOST: 'github.example'
+    })
+    expect(buildLocalCliEnvironmentMock).toHaveBeenNthCalledWith(2, {
+      GITLAB_HOST: 'gitlab.example'
+    })
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      1,
+      'gh',
+      ['api', 'rate_limit'],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          GH_HOST: 'github.example',
+          HTTPS_PROXY: 'http://host-proxy.example:8080'
+        })
+      }),
+      expect.any(Function)
+    )
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      2,
+      'glab',
+      ['api', 'projects'],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          GITLAB_HOST: 'gitlab.example',
+          HTTPS_PROXY: 'http://host-proxy.example:8080'
+        })
+      }),
+      expect.any(Function)
+    )
+  })
+
+  it('does not inject host proxy variables into commands executed inside WSL', async () => {
+    execFileMock.mockImplementation((_binary, _args, _options, callback) => {
+      callback(null, { stdout: '[]', stderr: '' })
+    })
+
+    await ghExecFileAsync(['issue', 'list'], {
+      cwd: String.raw`\\wsl.localhost\Ubuntu\home\jinwoo\stably\noqa`
+    })
+
+    expect(buildLocalCliEnvironmentMock).not.toHaveBeenCalled()
+    expect(execFileMock).toHaveBeenCalledWith(
+      'wsl.exe',
+      expect.any(Array),
+      expect.not.objectContaining({
+        env: expect.objectContaining({
+          HTTPS_PROXY: 'http://host-proxy.example:8080'
+        })
+      }),
+      expect.any(Function)
+    )
   })
 
   it('falls back to host gh for explicit-repo WSL calls when gh is missing in the distro', async () => {

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -37,6 +37,7 @@ import {
 } from '../../shared/wsl-login-shell-command'
 import { UNTRANSLATED_GIT_OUTPUT_ENV } from '../../shared/git-output-locale'
 import { endSubprocessStdin } from '../../shared/subprocess-stdin-write'
+import { buildLocalCliEnvironment } from '../network/local-cli-environment'
 
 // ─── Core resolution ────────────────────────────────────────────────
 
@@ -1422,6 +1423,10 @@ export async function ghExecFileAsync(
   let attemptedDefaultWslFallback = false
   for (let attempt = 0; attempt <= GH_RETRY_DELAYS_MS.length; attempt++) {
     try {
+      const commandEnv =
+        resolved.wsl === null
+          ? nonInteractiveGhEnv(await buildLocalCliEnvironment(options.env))
+          : nonInteractiveGhEnv(options.env)
       const { stdout, stderr } = await execFileCapture(resolved.binary, resolved.args, {
         cwd: resolved.cwd,
         encoding: (options.encoding ?? 'utf-8') as BufferEncoding,
@@ -1429,7 +1434,7 @@ export async function ghExecFileAsync(
         // Why: GitHub detail IPC powers PR cards, Tasks, and URL worktree
         // creation; one stuck gh child must fail visibly, not wedge every lane.
         timeout: options.timeout ?? defaultGhExecTimeoutMs(options.env),
-        env: nonInteractiveGhEnv(options.env)
+        env: commandEnv
       })
       return { stdout: stdout as string, stderr: stderr as string }
     } catch (err) {
@@ -1555,12 +1560,14 @@ export async function glabExecFileAsync(
   let attemptedDefaultWslFallback = false
   for (let attempt = 0; attempt <= GH_RETRY_DELAYS_MS.length; attempt++) {
     try {
+      const commandEnv =
+        resolved.wsl === null ? await buildLocalCliEnvironment(options.env) : options.env
       const { stdout, stderr } = await execFileCapture(resolved.binary, resolved.args, {
         cwd: resolved.cwd,
         encoding: (options.encoding ?? 'utf-8') as BufferEncoding,
         maxBuffer: options.maxBuffer,
         timeout: options.timeout,
-        env: options.env
+        env: commandEnv
       })
       return { stdout: stdout as string, stderr: stderr as string }
     } catch (err) {

--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -128,38 +128,43 @@ import { resetMergedPRCommitMembershipCacheForTest } from './merged-pr-commit-me
 
 describe('checkOrcaStarred', () => {
   beforeEach(() => {
-    execFileAsyncMock.mockReset()
+    ghExecFileAsyncMock.mockReset()
     acquireMock.mockReset()
     releaseMock.mockReset()
     acquireMock.mockResolvedValue(undefined)
   })
 
   it('returns true only for an included successful GitHub response', async () => {
-    execFileAsyncMock.mockResolvedValueOnce({ stdout: 'HTTP/2.0 204 No Content\r\n', stderr: '' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: 'HTTP/2.0 204 No Content\r\n',
+      stderr: ''
+    })
 
     await expect(checkOrcaStarred()).resolves.toBe(true)
 
-    expect(execFileAsyncMock).toHaveBeenCalledWith(
-      'gh',
+    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
       ['api', '--include', 'user/starred/stablyai/orca'],
       { encoding: 'utf-8' }
     )
   })
 
   it('returns true for an HTTP 200 starred response', async () => {
-    execFileAsyncMock.mockResolvedValueOnce({ stdout: 'HTTP/2.0 200 OK\r\n', stderr: '' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: 'HTTP/2.0 200 OK\r\n',
+      stderr: ''
+    })
 
     await expect(checkOrcaStarred()).resolves.toBe(true)
   })
 
   it('returns false for GitHub 404 not starred responses', async () => {
-    execFileAsyncMock.mockRejectedValueOnce(new Error('HTTP 404: Not Found'))
+    ghExecFileAsyncMock.mockRejectedValueOnce(new Error('HTTP 404: Not Found'))
 
     await expect(checkOrcaStarred()).resolves.toBe(false)
   })
 
   it('returns null when gh exits successfully without response headers', async () => {
-    execFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
 
     await expect(checkOrcaStarred()).resolves.toBe(null)
   })

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -43,7 +43,6 @@ import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import { joinWorktreeRelativePath } from '../runtime/runtime-relative-paths'
 import { splitRemoteBranchName } from '../../shared/git-effective-upstream'
 import {
-  execFileAsync,
   ghExecFileAsync,
   gitExecFileAsync,
   extractExecError,
@@ -249,8 +248,7 @@ function isNoPullRequestError(err: unknown): boolean {
 export async function checkOrcaStarred(): Promise<boolean | null> {
   await acquire()
   try {
-    const { stdout, stderr } = await execFileAsync(
-      'gh',
+    const { stdout, stderr } = await ghExecFileAsync(
       ['api', '--include', `user/starred/${ORCA_REPO}`],
       { encoding: 'utf-8' }
     )
@@ -409,7 +407,7 @@ export async function getPullRequestPushTarget(
 export async function starOrca(): Promise<boolean> {
   await acquire()
   try {
-    await execFileAsync('gh', ['api', '-X', 'PUT', `user/starred/${ORCA_REPO}`], {
+    await ghExecFileAsync(['api', '-X', 'PUT', `user/starred/${ORCA_REPO}`], {
       encoding: 'utf-8'
     })
     return true
@@ -427,8 +425,7 @@ export async function starOrca(): Promise<boolean> {
 export async function getAuthenticatedViewer(): Promise<GitHubViewer | null> {
   await acquire()
   try {
-    const { stdout } = await execFileAsync(
-      'gh',
+    const { stdout } = await ghExecFileAsync(
       ['api', 'user', '--jq', '{login: .login, email: .email}'],
       { encoding: 'utf-8' }
     )

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -185,6 +185,7 @@ import { resolveTuiAgentPermissionMode } from '../shared/tui-agent-permissions'
 import type { TerminalSideEffectBatch } from '../shared/terminal-side-effect-facts'
 import { KeybindingService } from './keybindings/keybinding-service'
 import { applyElectronProxySettings } from './network/proxy-settings'
+import { setLocalCliProxySettings } from './network/local-cli-environment'
 import { preserveAgentAuthBeforeRestart } from './agent-auth-restart-preservation'
 import { CliInstaller } from './cli/cli-installer'
 import { installLinuxBareOrcaDispatcher } from './cli/linux-bare-orca-dispatcher'
@@ -1663,6 +1664,7 @@ app.whenReady().then(async () => {
   }
   selfHealRuntimeEnvironmentFocus({ store, userDataPath: app.getPath('userData') })
   applyAppIcon(store.getSettings().appIcon)
+  setLocalCliProxySettings(store.getSettings())
   if (shouldSuppressDevEducation({ isDev: is.dev })) {
     suppressDevEducationForStore(store)
   }

--- a/src/main/ipc/preflight-cli-auth.test.ts
+++ b/src/main/ipc/preflight-cli-auth.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from 'vitest'
+import { probeGhAuthentication, probeGlabAuthentication } from './preflight-cli-auth'
+
+describe('preflight CLI authentication', () => {
+  it('reads the active GitHub account from structured status output', async () => {
+    const run = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({
+        hosts: {
+          'github.com': [
+            {
+              active: true,
+              state: 'success'
+            }
+          ]
+        }
+      }),
+      stderr: ''
+    })
+
+    await expect(probeGhAuthentication(run)).resolves.toEqual({
+      authenticated: true,
+      authState: 'authenticated'
+    })
+    expect(run).toHaveBeenCalledWith(['auth', 'status', '--active', '--json', 'hosts'])
+  })
+
+  it('treats structured GitHub status without a valid active account as unauthenticated', async () => {
+    const run = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({
+        hosts: {
+          'github.com': [
+            {
+              active: true,
+              state: 'error',
+              error: 'HTTP 401: Bad credentials'
+            }
+          ]
+        }
+      }),
+      stderr: ''
+    })
+
+    await expect(probeGhAuthentication(run)).resolves.toEqual({
+      authenticated: false,
+      authState: 'unauthenticated'
+    })
+  })
+
+  it('preserves timeout and network failures reported inside structured GitHub output', async () => {
+    const timedOutRun = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({
+        hosts: {
+          'github.com': [{ active: true, state: 'timeout', error: 'request timed out' }]
+        }
+      }),
+      stderr: ''
+    })
+    const unreachableRun = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({
+        hosts: {
+          'github.com': [
+            {
+              active: true,
+              state: 'error',
+              error: 'dial tcp: lookup github.com: no such host'
+            }
+          ]
+        }
+      }),
+      stderr: ''
+    })
+
+    await expect(probeGhAuthentication(timedOutRun)).resolves.toEqual({
+      authenticated: false,
+      authState: 'timeout'
+    })
+    await expect(probeGhAuthentication(unreachableRun)).resolves.toEqual({
+      authenticated: false,
+      authState: 'unreachable'
+    })
+  })
+
+  it('preserves GitHub timeout and reachability failures instead of reporting logout', async () => {
+    const timedOutRun = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error('Timed out running gh'), { code: 'ETIMEDOUT' }))
+    const unreachableRun = vi.fn().mockRejectedValue(
+      Object.assign(new Error('connect ECONNREFUSED github.com:443'), {
+        code: 'ECONNREFUSED'
+      })
+    )
+
+    await expect(probeGhAuthentication(timedOutRun)).resolves.toEqual({
+      authenticated: false,
+      authState: 'timeout'
+    })
+    await expect(probeGhAuthentication(unreachableRun)).resolves.toEqual({
+      authenticated: false,
+      authState: 'unreachable'
+    })
+  })
+
+  it.each(['unknown flag: --active', 'unknown flag: --json'])(
+    'falls back to plain GitHub auth status when the structured probe fails with "%s"',
+    async (unsupportedFlagError) => {
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce({ stderr: unsupportedFlagError })
+        .mockResolvedValueOnce({
+          stdout: 'github.com\n  - Logged in to github.com\n',
+          stderr: ''
+        })
+
+      await expect(probeGhAuthentication(run)).resolves.toEqual({
+        authenticated: true,
+        authState: 'authenticated'
+      })
+      expect(run).toHaveBeenNthCalledWith(2, ['auth', 'status'])
+    }
+  )
+
+  it('does not retry plain auth status after an unrelated structured probe failure', async () => {
+    const run = vi.fn().mockRejectedValueOnce({ stderr: 'failed to read GitHub CLI configuration' })
+
+    await expect(probeGhAuthentication(run)).resolves.toEqual({
+      authenticated: false,
+      authState: 'error'
+    })
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps legacy GitHub success markers emitted with a nonzero exit code', async () => {
+    const run = vi.fn().mockRejectedValue({ stderr: 'Logged in to github.com account octocat\n' })
+
+    await expect(probeGhAuthentication(run)).resolves.toEqual({
+      authenticated: true,
+      authState: 'authenticated'
+    })
+  })
+
+  it('classifies explicit GitHub logout separately from unknown execution failures', async () => {
+    const loggedOutRun = vi
+      .fn()
+      .mockRejectedValue({ stderr: 'You are not logged into any GitHub hosts.\n' })
+    const failedRun = vi.fn().mockRejectedValue(new Error('unexpected gh failure'))
+
+    await expect(probeGhAuthentication(loggedOutRun)).resolves.toEqual({
+      authenticated: false,
+      authState: 'unauthenticated'
+    })
+    await expect(probeGhAuthentication(failedRun)).resolves.toEqual({
+      authenticated: false,
+      authState: 'error'
+    })
+  })
+
+  it('does not treat ambiguous legacy invalid-token output as confirmed logout', async () => {
+    const run = vi.fn().mockRejectedValue({
+      stderr: 'authentication failed: the token in hosts.yml is invalid'
+    })
+
+    await expect(probeGhAuthentication(run)).resolves.toEqual({
+      authenticated: false,
+      authState: 'error'
+    })
+  })
+
+  it('keeps conservative legacy classification after falling back from unsupported flags', async () => {
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce({ stderr: 'unknown flag: --active' })
+      .mockRejectedValueOnce({
+        stderr: 'authentication failed: token is no longer valid'
+      })
+
+    await expect(probeGhAuthentication(run)).resolves.toEqual({
+      authenticated: false,
+      authState: 'error'
+    })
+  })
+
+  it('applies the same authentication failure classes to GitLab CLI', async () => {
+    const authenticatedRun = vi.fn().mockResolvedValue({ stdout: '', stderr: '' })
+    const loggedOutRun = vi
+      .fn()
+      .mockRejectedValue({ stderr: 'You are not logged into any GitLab hosts.\n' })
+    const unreachableRun = vi
+      .fn()
+      .mockRejectedValue(
+        Object.assign(new Error('network is unreachable'), { code: 'ENETUNREACH' })
+      )
+
+    await expect(probeGlabAuthentication(authenticatedRun)).resolves.toEqual({
+      authenticated: true,
+      authState: 'authenticated'
+    })
+    await expect(probeGlabAuthentication(loggedOutRun)).resolves.toEqual({
+      authenticated: false,
+      authState: 'unauthenticated'
+    })
+    await expect(probeGlabAuthentication(unreachableRun)).resolves.toEqual({
+      authenticated: false,
+      authState: 'unreachable'
+    })
+  })
+})

--- a/src/main/ipc/preflight-cli-auth.test.ts
+++ b/src/main/ipc/preflight-cli-auth.test.ts
@@ -80,6 +80,35 @@ describe('preflight CLI authentication', () => {
     })
   })
 
+  it.each([
+    'Get "https://api.github.com/": Proxy Authentication Required',
+    'HTTP 407: Proxy Authentication Required'
+  ])(
+    'treats a structured GitHub proxy-authentication failure as unreachable: %s',
+    async (error) => {
+      const run = vi.fn().mockRejectedValue({
+        stdout: JSON.stringify({
+          hosts: {
+            'github.com': [
+              {
+                active: true,
+                state: 'error',
+                error
+              }
+            ]
+          }
+        }),
+        stderr: ''
+      })
+
+      await expect(probeGhAuthentication(run)).resolves.toEqual({
+        authenticated: false,
+        authState: 'unreachable'
+      })
+      expect(run).toHaveBeenCalledTimes(1)
+    }
+  )
+
   it('preserves GitHub timeout and reachability failures instead of reporting logout', async () => {
     const timedOutRun = vi
       .fn()

--- a/src/main/ipc/preflight-cli-auth.ts
+++ b/src/main/ipc/preflight-cli-auth.ts
@@ -1,0 +1,243 @@
+import type { CliAuthState } from '../../shared/cli-auth-status'
+import type { PreflightCommandResult } from './preflight-command-exec'
+
+export type CliAuthProbeResult = {
+  authenticated: boolean
+  authState: CliAuthState
+}
+
+export type CliAuthCommandRunner = (args: string[]) => Promise<PreflightCommandResult>
+
+const NETWORK_ERROR_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ENOTFOUND',
+  'EAI_AGAIN'
+])
+
+/**
+ * Build a consistent authentication probe result.
+ *
+ * @param authState Classified CLI authentication outcome.
+ * @returns Boolean compatibility field plus the richer state.
+ */
+function authProbeResult(authState: CliAuthState): CliAuthProbeResult {
+  return {
+    authenticated: authState === 'authenticated',
+    authState
+  }
+}
+
+/**
+ * Collect stdout, stderr, and message text from an exec rejection.
+ *
+ * @param error Rejected child-process error.
+ * @returns Combined diagnostic text without logging credentials.
+ */
+function authErrorOutput(error: unknown): string {
+  const record = error && typeof error === 'object' ? (error as Record<string, unknown>) : {}
+  const stdout = typeof record.stdout === 'string' ? record.stdout : ''
+  const stderr = typeof record.stderr === 'string' ? record.stderr : ''
+  const message = error instanceof Error ? error.message : String(error ?? '')
+  return `${stdout}\n${stderr}\n${message}`
+}
+
+/**
+ * Read a child-process error code when one is present.
+ *
+ * @param error Rejected child-process error.
+ * @returns Normalized code or an empty string.
+ */
+function authErrorCode(error: unknown): string {
+  if (!error || typeof error !== 'object' || !('code' in error)) {
+    return ''
+  }
+  return String((error as { code?: unknown }).code ?? '').toUpperCase()
+}
+
+/**
+ * Classify a failed CLI authentication command without treating every failure as logout.
+ *
+ * @param error Rejected child-process error.
+ * @returns Timeout, reachability, authentication, or execution-error state.
+ */
+function classifyAuthFailure(error: unknown): CliAuthProbeResult {
+  const code = authErrorCode(error)
+  const output = authErrorOutput(error)
+  if (code === 'ETIMEDOUT' || /\b(?:timed out|timeout)\b/i.test(output)) {
+    return authProbeResult('timeout')
+  }
+  if (
+    NETWORK_ERROR_CODES.has(code) ||
+    /network is unreachable|no such host|could not resolve|temporary failure in name resolution|connection (?:refused|reset)|failed to connect|error connecting|proxyconnect tcp|tls handshake/i.test(
+      output
+    )
+  ) {
+    return authProbeResult('unreachable')
+  }
+  if (
+    /not logged (?:in|into)|not authenticated|authentication failed|authentication required|bad credentials|http 401|no token|invalid token|token (?:is )?(?:invalid|expired)|run (?:gh|glab) auth login/i.test(
+      output
+    )
+  ) {
+    return authProbeResult('unauthenticated')
+  }
+  return authProbeResult('error')
+}
+
+/**
+ * Conservatively classify plain-text gh failures from versions without JSON status.
+ *
+ * @param error Rejected legacy gh status command.
+ * @returns Definite logout/reachability state, or a generic execution error.
+ */
+function classifyUnstructuredGhAuthFailure(error: unknown): CliAuthProbeResult {
+  const classified = classifyAuthFailure(error)
+  if (classified.authState === 'timeout' || classified.authState === 'unreachable') {
+    return classified
+  }
+  // Why: older gh versions collapse invalid credentials and several network
+  // failures into the same "invalid token"/"authentication failed" text.
+  // Only the no-host/no-token cases prove that login is actually required.
+  return /not logged into any github hosts|no (?:authentication )?token found/i.test(
+    authErrorOutput(error)
+  )
+    ? authProbeResult('unauthenticated')
+    : authProbeResult('error')
+}
+
+/**
+ * Parse `gh auth status --json hosts` without requesting or exposing tokens.
+ *
+ * @param stdout Structured gh output.
+ * @returns Classified result, or null when output is not valid status JSON.
+ */
+function parseGhAuthStatusJson(stdout: string): CliAuthProbeResult | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(stdout)
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed !== 'object' || !('hosts' in parsed)) {
+    return null
+  }
+  const hosts = (parsed as { hosts?: unknown }).hosts
+  if (!hosts || typeof hosts !== 'object') {
+    return authProbeResult('unauthenticated')
+  }
+  const accounts = Object.values(hosts)
+    .flatMap((value) => (Array.isArray(value) ? value : []))
+    .filter(
+      (account): account is Record<string, unknown> =>
+        account !== null &&
+        typeof account === 'object' &&
+        (account as { active?: unknown }).active === true
+    )
+  if (accounts.length === 0) {
+    return authProbeResult('unauthenticated')
+  }
+  if (accounts.every((account) => account.state === 'success')) {
+    return authProbeResult('authenticated')
+  }
+  if (accounts.some((account) => account.state === 'timeout')) {
+    return authProbeResult('timeout')
+  }
+  const errorOutput = accounts
+    .map((account) => (typeof account.error === 'string' ? account.error : ''))
+    .filter(Boolean)
+    .join('\n')
+  const classifiedError = classifyAuthFailure(
+    new Error(errorOutput || 'GitHub CLI returned an unknown authentication state')
+  )
+  return classifiedError
+}
+
+/**
+ * Detect success markers emitted by older plain-text gh versions.
+ *
+ * @param output Combined CLI output.
+ * @returns True when output identifies an active logged-in account.
+ */
+function hasLegacyGhSuccessMarker(output: string): boolean {
+  return output.includes('Logged in') || output.includes('Active account: true')
+}
+
+/**
+ * Detect a gh version that does not support the structured active-account probe.
+ *
+ * @param error Rejected structured-status command.
+ * @returns True only when an active/JSON probe argument is unsupported.
+ */
+function isGhStructuredStatusUnsupported(error: unknown): boolean {
+  const output = authErrorOutput(error)
+  return /unknown (?:flag|option).*(?:--active|--json)|unknown json field|invalid value.*hosts/i.test(
+    output
+  )
+}
+
+/**
+ * Probe GitHub CLI authentication with structured output and a legacy fallback.
+ *
+ * @param run Command runner scoped to the selected local or WSL runtime.
+ * @returns Classified GitHub CLI authentication state.
+ */
+export async function probeGhAuthentication(
+  run: CliAuthCommandRunner
+): Promise<CliAuthProbeResult> {
+  try {
+    const result = await run(['auth', 'status', '--active', '--json', 'hosts'])
+    const parsed = parseGhAuthStatusJson(result.stdout)
+    if (parsed) {
+      return parsed
+    }
+    return hasLegacyGhSuccessMarker(`${result.stdout}\n${result.stderr}`)
+      ? authProbeResult('authenticated')
+      : authProbeResult('error')
+  } catch (error) {
+    const parsed = parseGhAuthStatusJson(
+      error && typeof error === 'object' && 'stdout' in error
+        ? String((error as { stdout?: unknown }).stdout ?? '')
+        : ''
+    )
+    if (parsed) {
+      return parsed
+    }
+    if (hasLegacyGhSuccessMarker(authErrorOutput(error))) {
+      return authProbeResult('authenticated')
+    }
+    if (!isGhStructuredStatusUnsupported(error)) {
+      return classifyUnstructuredGhAuthFailure(error)
+    }
+  }
+
+  try {
+    await run(['auth', 'status'])
+    return authProbeResult('authenticated')
+  } catch (error) {
+    return hasLegacyGhSuccessMarker(authErrorOutput(error))
+      ? authProbeResult('authenticated')
+      : classifyUnstructuredGhAuthFailure(error)
+  }
+}
+
+/**
+ * Probe GitLab CLI authentication while preserving network and execution failures.
+ *
+ * @param run Command runner scoped to the selected local or WSL runtime.
+ * @returns Classified GitLab CLI authentication state.
+ */
+export async function probeGlabAuthentication(
+  run: CliAuthCommandRunner
+): Promise<CliAuthProbeResult> {
+  try {
+    await run(['auth', 'status'])
+    return authProbeResult('authenticated')
+  } catch (error) {
+    return authErrorOutput(error).includes('Logged in')
+      ? authProbeResult('authenticated')
+      : classifyAuthFailure(error)
+  }
+}

--- a/src/main/ipc/preflight-cli-auth.ts
+++ b/src/main/ipc/preflight-cli-auth.ts
@@ -71,7 +71,7 @@ function classifyAuthFailure(error: unknown): CliAuthProbeResult {
   }
   if (
     NETWORK_ERROR_CODES.has(code) ||
-    /network is unreachable|no such host|could not resolve|temporary failure in name resolution|connection (?:refused|reset)|failed to connect|error connecting|proxyconnect tcp|tls handshake/i.test(
+    /network is unreachable|no such host|could not resolve|temporary failure in name resolution|connection (?:refused|reset)|failed to connect|error connecting|proxyconnect tcp|proxy authentication required|http 407|tls handshake/i.test(
       output
     )
   ) {

--- a/src/main/ipc/preflight-command-exec.ts
+++ b/src/main/ipc/preflight-command-exec.ts
@@ -12,10 +12,23 @@ const WSL_COMMAND_PATH_SENTINEL = '__ORCA_PREFLIGHT_COMMAND_PATH__'
 
 export type PreflightCommandResult = { stdout: string; stderr: string }
 
+/**
+ * Quote one literal argument for a POSIX shell command.
+ *
+ * @param value Argument value to protect from shell expansion.
+ * @returns Single-quoted shell token with embedded quotes escaped.
+ */
 export function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`
 }
 
+/**
+ * Bound a preflight subprocess promise even when its runtime timeout does not fire.
+ *
+ * @param command Command label included in timeout errors.
+ * @param commandPromise Subprocess result to race against the preflight timeout.
+ * @returns The subprocess result when it settles within the timeout.
+ */
 async function withPreflightTimeout<T>(command: string, commandPromise: Promise<T>): Promise<T> {
   let timeout: ReturnType<typeof setTimeout> | null = null
   try {
@@ -40,6 +53,13 @@ async function withPreflightTimeout<T>(command: string, commandPromise: Promise<
   }
 }
 
+/**
+ * Execute a local-host command with Orca's hydrated CLI environment.
+ *
+ * @param command Executable name or path.
+ * @param args Literal argv entries passed without a shell.
+ * @returns Captured stdout and stderr.
+ */
 export async function execLocalPreflightCommand(
   command: string,
   args: string[]
@@ -54,6 +74,13 @@ export async function execLocalPreflightCommand(
   return withPreflightTimeout(command, commandPromise)
 }
 
+/**
+ * Execute a preflight command inside the selected WSL distribution.
+ *
+ * @param target WSL distribution and user context.
+ * @param command POSIX command string to run in WSL.
+ * @returns Captured stdout and stderr.
+ */
 export async function execCommandInWsl(
   target: WslPreflightTarget,
   command: string
@@ -62,6 +89,13 @@ export async function execCommandInWsl(
   return withPreflightTimeout('wsl.exe', commandPromise)
 }
 
+/**
+ * Check whether a CLI can execute its version command in the selected runtime.
+ *
+ * @param command Executable name.
+ * @param wslTarget Optional WSL runtime; omitted for the local host.
+ * @returns True when the version command succeeds.
+ */
 export async function isCommandAvailable(
   command: string,
   wslTarget?: WslPreflightTarget
@@ -76,6 +110,13 @@ export async function isCommandAvailable(
   }
 }
 
+/**
+ * Check whether a CLI resolves to an absolute executable path.
+ *
+ * @param command Executable name.
+ * @param wslTarget Optional WSL runtime; omitted for the local host.
+ * @returns True when the runtime path lookup returns an absolute path.
+ */
 export async function isCommandOnPath(
   command: string,
   wslTarget?: WslPreflightTarget

--- a/src/main/ipc/preflight-command-exec.ts
+++ b/src/main/ipc/preflight-command-exec.ts
@@ -44,11 +44,11 @@ export async function execLocalPreflightCommand(
   command: string,
   args: string[]
 ): Promise<PreflightCommandResult> {
-  const env = buildLocalPreflightEnv()
+  const env = await buildLocalPreflightEnv()
   const commandPromise = execFileAsync(command, args, {
     encoding: 'utf-8',
     timeout: PREFLIGHT_COMMAND_TIMEOUT_MS,
-    ...(env ? { env } : {})
+    env
   }) as Promise<PreflightCommandResult>
 
   return withPreflightTimeout(command, commandPromise)

--- a/src/main/ipc/preflight-local-env.ts
+++ b/src/main/ipc/preflight-local-env.ts
@@ -1,22 +1,10 @@
-import { mergePersistedWindowsPath } from '../pty/windows-environment-path'
+import { buildLocalCliEnvironment } from '../network/local-cli-environment'
 
-function stringOnlyProcessEnv(env: NodeJS.ProcessEnv): Record<string, string> {
-  const result: Record<string, string> = {}
-  for (const [key, value] of Object.entries(env)) {
-    if (value !== undefined) {
-      result[key] = value
-    }
-  }
-  return result
-}
-
-export function buildLocalPreflightEnv(): Record<string, string> | undefined {
-  if (process.platform !== 'win32') {
-    return undefined
-  }
-  const env = stringOnlyProcessEnv(process.env)
-  // Why: newly installed CLIs update persisted Windows Path, but the running
-  // Electron process keeps its old environment until we merge it explicitly.
-  mergePersistedWindowsPath(env)
-  return env
+/**
+ * Build the environment shared by local preflight CLI probes.
+ *
+ * @returns A local-host CLI environment with current PATH and proxy settings.
+ */
+export function buildLocalPreflightEnv(): Promise<Record<string, string>> {
+  return buildLocalCliEnvironment()
 }

--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -356,7 +356,7 @@ describe('preflight', () => {
       throw new Error(`unexpected command ${String(command)}`)
     })
 
-    const status = await runPreflightCheck(false, { wslDistro: 'Ubuntu' })
+    const status = await runPreflightCheck(true, { wslDistro: 'Ubuntu' })
 
     expect(status.gh).toEqual({
       installed: true,
@@ -373,6 +373,7 @@ describe('preflight', () => {
       ['-d', 'Ubuntu', '--', 'sh', '-c', expect.stringMatching(/gh[\s\S]*auth[\s\S]*status/)],
       { encoding: 'utf-8', timeout: 5000 }
     )
+    expect(hydrateShellPathMock).not.toHaveBeenCalled()
   })
 
   it('uses the persisted Windows Path when probing host CLIs', async () => {
@@ -390,13 +391,14 @@ describe('preflight', () => {
       .mockResolvedValueOnce({ stdout: authenticatedGhStatusJson })
       .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
 
-    const status = await runPreflightCheck()
+    const status = await runPreflightCheck(true)
 
     expect(status.gh).toEqual({
       installed: true,
       authenticated: true,
       authState: 'authenticated'
     })
+    expect(hydrateShellPathMock).not.toHaveBeenCalled()
     expect(mergePersistedWindowsPathMock).toHaveBeenCalled()
     expect(execFileAsyncMock).toHaveBeenNthCalledWith(2, 'gh', ['--version'], {
       encoding: 'utf-8',
@@ -484,6 +486,51 @@ describe('preflight', () => {
       authState: 'authenticated'
     })
     expect(execFileAsyncMock).toHaveBeenCalledTimes(10)
+    expect(hydrateShellPathMock).toHaveBeenCalledWith({ force: true })
+  })
+
+  it('does not let an older in-flight probe overwrite a forced refresh', async () => {
+    let resolveStaleGhAuth: ((result: { stdout: string; stderr?: string }) => void) | undefined
+    let ghAuthProbeCount = 0
+    execFileAsyncMock.mockImplementation(async (command, args) => {
+      if (Array.isArray(args) && args[0] === '--version') {
+        return { stdout: `${String(command)} version 2.0.0\n` }
+      }
+      if (command === 'glab') {
+        return { stdout: 'Logged in to gitlab.com\n' }
+      }
+      if (command === 'gh') {
+        ghAuthProbeCount += 1
+        if (ghAuthProbeCount === 1) {
+          return new Promise((resolve) => {
+            resolveStaleGhAuth = resolve
+          })
+        }
+        return { stdout: authenticatedGhStatusJson }
+      }
+      throw new Error(`unexpected command ${String(command)}`)
+    })
+
+    const staleRequest = runPreflightCheck()
+    await vi.waitFor(() => {
+      expect(resolveStaleGhAuth).toBeDefined()
+    })
+    const freshStatus = await runPreflightCheck(true)
+
+    resolveStaleGhAuth?.({
+      stdout: JSON.stringify({
+        hosts: {
+          'github.com': [{ active: true, state: 'error', error: 'HTTP 401: Bad credentials' }]
+        }
+      })
+    })
+    const staleStatus = await staleRequest
+    const cachedStatus = await runPreflightCheck()
+
+    expect(freshStatus.gh.authState).toBe('authenticated')
+    expect(staleStatus.gh.authState).toBe('unauthenticated')
+    expect(cachedStatus.gh.authState).toBe('authenticated')
+    expect(ghAuthProbeCount).toBe(2)
   })
 
   it('registers the preflight handler', async () => {

--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -101,12 +101,22 @@ describe('preflight', () => {
     baseUrl: null,
     tokenConfigured: false
   }
+  const authenticatedGhStatusJson = JSON.stringify({
+    hosts: {
+      'github.com': [{ active: true, state: 'success' }]
+    }
+  })
 
   beforeEach(() => {
     handleMock.mockReset()
     execFileAsyncMock.mockReset()
     hydrateShellPathMock.mockReset()
-    hydrateShellPathMock.mockResolvedValue({ segments: [], ok: false, failureReason: 'no_shell' })
+    hydrateShellPathMock.mockResolvedValue({
+      segments: [],
+      proxyEnv: {},
+      ok: false,
+      failureReason: 'no_shell'
+    })
     mergePathSegmentsMock.mockReset()
     getActiveMultiplexerMock.mockReset()
     getBitbucketAuthStatusMock.mockReset()
@@ -152,26 +162,33 @@ describe('preflight', () => {
       .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
-      .mockResolvedValueOnce({ stdout: 'github.com\n  - Active account: true\n' })
+      .mockResolvedValueOnce({ stdout: authenticatedGhStatusJson })
       .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
 
     const status = await runPreflightCheck()
 
     expect(status).toEqual({
       git: { installed: true },
-      gh: { installed: true, authenticated: true },
-      glab: { installed: true, authenticated: true },
+      gh: { installed: true, authenticated: true, authState: 'authenticated' },
+      glab: { installed: true, authenticated: true, authState: 'authenticated' },
       bitbucket: defaultBitbucketStatus,
       azureDevOps: defaultAzureDevOpsStatus,
       gitea: defaultGiteaStatus
     })
-    expect(execFileAsyncMock).toHaveBeenNthCalledWith(4, 'gh', ['auth', 'status'], {
-      encoding: 'utf-8',
-      timeout: 5000
-    })
+    expect(execFileAsyncMock).toHaveBeenNthCalledWith(
+      4,
+      'gh',
+      ['auth', 'status', '--active', '--json', 'hosts'],
+      {
+        encoding: 'utf-8',
+        timeout: 5000,
+        env: expect.any(Object)
+      }
+    )
     expect(execFileAsyncMock).toHaveBeenNthCalledWith(5, 'glab', ['auth', 'status'], {
       encoding: 'utf-8',
-      timeout: 5000
+      timeout: 5000,
+      env: expect.any(Object)
     })
   })
 
@@ -185,7 +202,40 @@ describe('preflight', () => {
 
     const status = await runPreflightCheck()
 
-    expect(status.gh).toEqual({ installed: true, authenticated: false })
+    expect(status.gh).toEqual({
+      installed: true,
+      authenticated: false,
+      authState: 'unauthenticated'
+    })
+  })
+
+  it('preserves a structured gh timeout instead of returning an unauthenticated state', async () => {
+    execFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
+      .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
+      .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          hosts: {
+            'github.com': [
+              {
+                active: true,
+                state: 'timeout',
+                error: 'request timed out'
+              }
+            ]
+          }
+        })
+      })
+      .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
+
+    const status = await runPreflightCheck()
+
+    expect(status.gh).toEqual({
+      installed: true,
+      authenticated: false,
+      authState: 'timeout'
+    })
   })
 
   it('keeps older gh stderr success output from showing a false auth warning', async () => {
@@ -198,7 +248,11 @@ describe('preflight', () => {
 
     const status = await runPreflightCheck()
 
-    expect(status.gh).toEqual({ installed: true, authenticated: true })
+    expect(status.gh).toEqual({
+      installed: true,
+      authenticated: true,
+      authState: 'authenticated'
+    })
   })
 
   it('marks glab as not installed when `glab --version` fails', async () => {
@@ -221,12 +275,16 @@ describe('preflight', () => {
       .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
-      .mockResolvedValueOnce({ stdout: 'github.com\n  - Active account: true\n' })
+      .mockResolvedValueOnce({ stdout: authenticatedGhStatusJson })
       .mockRejectedValueOnce({ stderr: 'You are not logged into any GitLab hosts.\n' })
 
     const status = await runPreflightCheck()
 
-    expect(status.glab).toEqual({ installed: true, authenticated: false })
+    expect(status.glab).toEqual({
+      installed: true,
+      authenticated: false,
+      authState: 'unauthenticated'
+    })
   })
 
   it('times out hung local preflight probes', async () => {
@@ -290,8 +348,8 @@ describe('preflight', () => {
         if (script.includes('gh') && script.includes('--version')) {
           return { stdout: 'gh version 2.0.0\n' }
         }
-        if (script.includes('gh') && script.includes('auth status')) {
-          return { stdout: 'github.com\n  - Active account: true\n' }
+        if (script.includes('gh') && script.includes('auth') && script.includes('status')) {
+          return { stdout: authenticatedGhStatusJson }
         }
         throw new Error(`unexpected WSL script ${script}`)
       }
@@ -300,7 +358,11 @@ describe('preflight', () => {
 
     const status = await runPreflightCheck(false, { wslDistro: 'Ubuntu' })
 
-    expect(status.gh).toEqual({ installed: true, authenticated: true })
+    expect(status.gh).toEqual({
+      installed: true,
+      authenticated: true,
+      authState: 'authenticated'
+    })
     expect(execFileAsyncMock).toHaveBeenCalledWith(
       'wsl.exe',
       ['-d', 'Ubuntu', '--', 'sh', '-c', expect.stringMatching(/gh[\s\S]*--version/)],
@@ -308,7 +370,7 @@ describe('preflight', () => {
     )
     expect(execFileAsyncMock).toHaveBeenCalledWith(
       'wsl.exe',
-      ['-d', 'Ubuntu', '--', 'sh', '-c', expect.stringMatching(/gh[\s\S]*auth status/)],
+      ['-d', 'Ubuntu', '--', 'sh', '-c', expect.stringMatching(/gh[\s\S]*auth[\s\S]*status/)],
       { encoding: 'utf-8', timeout: 5000 }
     )
   })
@@ -325,12 +387,16 @@ describe('preflight', () => {
       .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
-      .mockResolvedValueOnce({ stdout: 'github.com\n  - Active account: true\n' })
+      .mockResolvedValueOnce({ stdout: authenticatedGhStatusJson })
       .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
 
     const status = await runPreflightCheck()
 
-    expect(status.gh).toEqual({ installed: true, authenticated: true })
+    expect(status.gh).toEqual({
+      installed: true,
+      authenticated: true,
+      authState: 'authenticated'
+    })
     expect(mergePersistedWindowsPathMock).toHaveBeenCalled()
     expect(execFileAsyncMock).toHaveBeenNthCalledWith(2, 'gh', ['--version'], {
       encoding: 'utf-8',
@@ -401,14 +467,22 @@ describe('preflight', () => {
       .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
-      .mockResolvedValueOnce({ stdout: 'github.com\n  - Active account: true\n' })
+      .mockResolvedValueOnce({ stdout: authenticatedGhStatusJson })
       .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
 
     const firstStatus = await runPreflightCheck()
     const refreshedStatus = await runPreflightCheck(true)
 
-    expect(firstStatus.gh).toEqual({ installed: true, authenticated: false })
-    expect(refreshedStatus.gh).toEqual({ installed: true, authenticated: true })
+    expect(firstStatus.gh).toEqual({
+      installed: true,
+      authenticated: false,
+      authState: 'unauthenticated'
+    })
+    expect(refreshedStatus.gh).toEqual({
+      installed: true,
+      authenticated: true,
+      authState: 'authenticated'
+    })
     expect(execFileAsyncMock).toHaveBeenCalledTimes(10)
   })
 
@@ -417,7 +491,7 @@ describe('preflight', () => {
       .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
-      .mockResolvedValueOnce({ stdout: 'github.com\n' })
+      .mockResolvedValueOnce({ stdout: authenticatedGhStatusJson })
       .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
 
     registerPreflightHandlers()
@@ -426,8 +500,8 @@ describe('preflight', () => {
 
     expect(status).toEqual({
       git: { installed: true },
-      gh: { installed: true, authenticated: true },
-      glab: { installed: true, authenticated: true },
+      gh: { installed: true, authenticated: true, authState: 'authenticated' },
+      glab: { installed: true, authenticated: true, authState: 'authenticated' },
       bitbucket: defaultBitbucketStatus,
       azureDevOps: defaultAzureDevOpsStatus,
       gitea: defaultGiteaStatus
@@ -444,7 +518,7 @@ describe('preflight', () => {
       .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
-      .mockResolvedValueOnce({ stdout: 'github.com\n  - Active account: true\n' })
+      .mockResolvedValueOnce({ stdout: authenticatedGhStatusJson })
       .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
 
     registerPreflightHandlers()
@@ -454,16 +528,16 @@ describe('preflight', () => {
 
     expect(firstStatus).toEqual({
       git: { installed: true },
-      gh: { installed: true, authenticated: false },
-      glab: { installed: true, authenticated: true },
+      gh: { installed: true, authenticated: false, authState: 'unauthenticated' },
+      glab: { installed: true, authenticated: true, authState: 'authenticated' },
       bitbucket: defaultBitbucketStatus,
       azureDevOps: defaultAzureDevOpsStatus,
       gitea: defaultGiteaStatus
     })
     expect(refreshedStatus).toEqual({
       git: { installed: true },
-      gh: { installed: true, authenticated: true },
-      glab: { installed: true, authenticated: true },
+      gh: { installed: true, authenticated: true, authState: 'authenticated' },
+      glab: { installed: true, authenticated: true, authState: 'authenticated' },
       bitbucket: defaultBitbucketStatus,
       azureDevOps: defaultAzureDevOpsStatus,
       gitea: defaultGiteaStatus
@@ -634,6 +708,7 @@ describe('preflight', () => {
     process.env.PATH = '/usr/bin'
     hydrateShellPathMock.mockResolvedValueOnce({
       segments: ['/home/test/.local/bin'],
+      proxyEnv: {},
       ok: true,
       failureReason: 'none'
     })
@@ -958,6 +1033,7 @@ describe('preflight', () => {
     // (3) re-run `which` so newly-installed CLIs appear without a restart.
     hydrateShellPathMock.mockResolvedValueOnce({
       segments: ['/Users/test/.opencode/bin'],
+      proxyEnv: {},
       ok: true,
       failureReason: 'none'
     })
@@ -995,6 +1071,7 @@ describe('preflight', () => {
   it('still re-detects when the shell spawn fails — relies on the existing PATH', async () => {
     hydrateShellPathMock.mockResolvedValueOnce({
       segments: [],
+      proxyEnv: {},
       ok: false,
       failureReason: 'timeout'
     })
@@ -1034,7 +1111,12 @@ describe('preflight', () => {
   it.each(['no_shell', 'spawn_error', 'empty_path'] as const)(
     'classifies pathFailureReason=%s when hydration reports it',
     async (failureReason) => {
-      hydrateShellPathMock.mockResolvedValueOnce({ segments: [], ok: false, failureReason })
+      hydrateShellPathMock.mockResolvedValueOnce({
+        segments: [],
+        proxyEnv: {},
+        ok: false,
+        failureReason
+      })
       execFileAsyncMock.mockRejectedValue(new Error('not found'))
 
       registerPreflightHandlers()

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -26,15 +26,22 @@ import {
   KNOWN_TUI_AGENT_DETECTION_COMMANDS,
   resolveDetectedTuiAgentIds
 } from './tui-agent-detection-commands'
+import type { CliAuthStatus } from '../../shared/cli-auth-status'
+import {
+  probeGhAuthentication,
+  probeGlabAuthentication,
+  type CliAuthCommandRunner,
+  type CliAuthProbeResult
+} from './preflight-cli-auth'
 
 export type PreflightStatus = {
   git: { installed: boolean }
-  gh: { installed: boolean; authenticated: boolean }
+  gh: CliAuthStatus
   // Why: optional so existing renderer call sites that only render git/gh
   // status keep typechecking. Consumers that surface GitLab-specific
   // affordances (the GitLab tab in the source picker, MR list, etc.)
   // gate on `glab?.authenticated`.
-  glab?: { installed: boolean; authenticated: boolean }
+  glab?: CliAuthStatus
   bitbucket?: { configured: boolean; authenticated: boolean; account: string | null }
   azureDevOps?: {
     configured: boolean
@@ -189,39 +196,25 @@ export async function detectRemoteAgents(args: { connectionId: string }): Promis
   return uniqueAgentIds(result.agents)
 }
 
-async function isGhAuthenticated(wslTarget?: WslPreflightTarget): Promise<boolean> {
-  try {
-    await (wslTarget
-      ? execCommandInWsl(wslTarget, `${shellQuote('gh')} auth status`)
-      : execLocalPreflightCommand('gh', ['auth', 'status']))
-    // Why: for plain-text `gh auth status`, exit 0 means gh did not detect any
-    // authentication issues for the checked hosts/accounts.
-    return true
-  } catch (error) {
-    // Why: some environments may surface partial command output on the thrown
-    // error object. Keep a compatibility fallback so we avoid a false auth
-    // warning if success markers are present despite a non-zero result.
-    const stdout = (error as { stdout?: string }).stdout ?? ''
-    const stderr = (error as { stderr?: string }).stderr ?? ''
-    const output = `${stdout}\n${stderr}`
-    return output.includes('Logged in') || output.includes('Active account: true')
+/**
+ * Build an auth command runner for either the local host or selected WSL distro.
+ *
+ * @param command CLI executable name.
+ * @param wslTarget Optional WSL runtime selected by preflight context.
+ * @returns Runner that preserves the CLI argument boundary on both runtimes.
+ */
+function createAuthCommandRunner(
+  command: 'gh' | 'glab',
+  wslTarget?: WslPreflightTarget
+): CliAuthCommandRunner {
+  if (!wslTarget) {
+    return (args) => execLocalPreflightCommand(command, args)
   }
-}
-
-// Why: parallel to isGhAuthenticated for the glab CLI. glab writes auth
-// status to stderr in some versions and stdout in others; check both.
-async function isGlabAuthenticated(wslTarget?: WslPreflightTarget): Promise<boolean> {
-  try {
-    await (wslTarget
-      ? execCommandInWsl(wslTarget, `${shellQuote('glab')} auth status`)
-      : execLocalPreflightCommand('glab', ['auth', 'status']))
-    return true
-  } catch (error) {
-    const stdout = (error as { stdout?: string }).stdout ?? ''
-    const stderr = (error as { stderr?: string }).stderr ?? ''
-    const output = `${stdout}\n${stderr}`
-    return output.includes('Logged in')
-  }
+  return (args) =>
+    execCommandInWsl(
+      wslTarget,
+      [shellQuote(command), ...args.map((argument) => shellQuote(argument))].join(' ')
+    )
 }
 
 export async function runPreflightCheck(
@@ -249,9 +242,13 @@ export async function runPreflightCheck(
     detectCommandRuntime('glab', context)
   ])
 
-  const [ghAuthenticated, glabAuthenticated, bitbucket, azureDevOps, gitea] = await Promise.all([
-    ghProbe.installed ? isGhAuthenticated(ghProbe.wslTarget) : Promise.resolve(false),
-    glabProbe.installed ? isGlabAuthenticated(glabProbe.wslTarget) : Promise.resolve(false),
+  const [ghAuth, glabAuth, bitbucket, azureDevOps, gitea] = await Promise.all([
+    ghProbe.installed
+      ? probeGhAuthentication(createAuthCommandRunner('gh', ghProbe.wslTarget))
+      : Promise.resolve<CliAuthProbeResult | null>(null),
+    glabProbe.installed
+      ? probeGlabAuthentication(createAuthCommandRunner('glab', glabProbe.wslTarget))
+      : Promise.resolve<CliAuthProbeResult | null>(null),
     getBitbucketAuthStatus(),
     getAzureDevOpsAuthStatus(),
     getGiteaAuthStatus()
@@ -259,8 +256,16 @@ export async function runPreflightCheck(
 
   const result = {
     git: { installed: gitProbe.installed },
-    gh: { installed: ghProbe.installed, authenticated: ghAuthenticated },
-    glab: { installed: glabProbe.installed, authenticated: glabAuthenticated },
+    gh: {
+      installed: ghProbe.installed,
+      authenticated: ghAuth?.authenticated ?? false,
+      ...(ghAuth ? { authState: ghAuth.authState } : {})
+    },
+    glab: {
+      installed: glabProbe.installed,
+      authenticated: glabAuth?.authenticated ?? false,
+      ...(glabAuth ? { authState: glabAuth.authState } : {})
+    },
     bitbucket,
     azureDevOps,
     gitea

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -65,10 +65,12 @@ export type { RemoteWindowsTerminalCapabilities }
 // Why: cache the result so repeated Landing mounts don't re-spawn processes.
 // The check only runs once per app session — relaunch to re-check.
 let cached: PreflightStatus | null = null
+let cacheGeneration = 0
 
 /** @internal - tests need a clean preflight cache between cases. */
 export function _resetPreflightCache(): void {
   cached = null
+  cacheGeneration += 1
 }
 
 function uniqueAgentIds(ids: Iterable<string>): string[] {
@@ -221,10 +223,12 @@ export async function runPreflightCheck(
   force = false,
   context?: PreflightRuntimeContext
 ): Promise<PreflightStatus> {
-  const cacheable = !getPreflightWslTarget(context)
+  const wslTarget = getPreflightWslTarget(context)
+  const cacheable = !wslTarget
   if (cacheable && cached && !force) {
     return cached
   }
+  const requestGeneration = cacheable ? ++cacheGeneration : 0
 
   if (force) {
     // Why: the GitLab known-hosts cache (gl-utils) is populated lazily on the
@@ -234,6 +238,15 @@ export async function runPreflightCheck(
     // path in IntegrationsPane forces preflight, so piggyback on that signal
     // to refresh the host list too.
     _resetKnownHostsCache()
+  }
+
+  if (force && !wslTarget && process.platform !== 'win32') {
+    // Why: a manual re-check must observe proxy and PATH edits made in shell rc
+    // files since startup. Refresh once here so parallel CLI probes share it.
+    const shellHydration = await hydrateShellPath({ force: true })
+    if (shellHydration.segments.length > 0) {
+      mergePathSegments(shellHydration.segments)
+    }
   }
 
   const [gitProbe, ghProbe, glabProbe] = await Promise.all([
@@ -271,7 +284,7 @@ export async function runPreflightCheck(
     gitea
   }
 
-  if (cacheable) {
+  if (cacheable && requestGeneration === cacheGeneration) {
     cached = result
   }
 

--- a/src/main/ipc/settings.test.ts
+++ b/src/main/ipc/settings.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 const {
   applyAppIconMock,
   applyElectronProxySettingsMock,
+  setLocalCliProxySettingsMock,
   browserWindowGetAllWindowsMock,
   handleMock,
   onMock,
@@ -13,6 +14,7 @@ const {
 } = vi.hoisted(() => ({
   applyAppIconMock: vi.fn(),
   applyElectronProxySettingsMock: vi.fn(),
+  setLocalCliProxySettingsMock: vi.fn(),
   browserWindowGetAllWindowsMock: vi.fn(),
   handleMock: vi.fn(),
   onMock: vi.fn(),
@@ -38,6 +40,10 @@ vi.mock('../warp-themes', () => ({
 
 vi.mock('../network/proxy-settings', () => ({
   applyElectronProxySettings: applyElectronProxySettingsMock
+}))
+
+vi.mock('../network/local-cli-environment', () => ({
+  setLocalCliProxySettings: setLocalCliProxySettingsMock
 }))
 
 vi.mock('../app-icon', () => ({
@@ -76,6 +82,7 @@ describe('registerSettingsHandlers', () => {
     applyAppIconMock.mockClear()
     applyElectronProxySettingsMock.mockClear()
     applyElectronProxySettingsMock.mockResolvedValue({ source: 'settings' })
+    setLocalCliProxySettingsMock.mockClear()
     previewGhosttyImportMock.mockClear()
     previewWarpThemeImportMock.mockClear()
     prepareLocalWorktreeRootsForReposMock.mockReset().mockResolvedValue(undefined)
@@ -438,6 +445,10 @@ describe('registerSettingsHandlers', () => {
       httpProxyUrl: 'http://proxy.example:8080',
       httpProxyBypassRules: 'localhost;*.internal'
     })
+    expect(setLocalCliProxySettingsMock).toHaveBeenCalledWith({
+      httpProxyUrl: 'http://proxy.example:8080',
+      httpProxyBypassRules: 'localhost;*.internal'
+    })
   })
 
   it('drops invalid proxy URLs at the settings boundary', async () => {
@@ -457,6 +468,7 @@ describe('registerSettingsHandlers', () => {
       { notifyListeners: true, originWebContentsId: 1 }
     )
     expect(applyElectronProxySettingsMock).toHaveBeenCalledWith({ httpProxyUrl: '' })
+    expect(setLocalCliProxySettingsMock).toHaveBeenCalledWith({ httpProxyUrl: '' })
   })
 
   it('normalizes and applies app icon changes from renderer settings IPC', async () => {

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -22,6 +22,7 @@ import { normalizeTerminalLineHeight } from '../../shared/terminal-line-height-s
 import { prepareLocalWorktreeRootsForRepos } from '../worktree-root-preparation'
 import { scheduleCurrentWorktreeBaseDirectoryWatcherSync } from './worktree-base-directory-watcher'
 import { applyPRBotAuthorOverride } from '../../shared/pr-bot-author-overrides'
+import { setLocalCliProxySettings } from '../network/local-cli-environment'
 
 // Why: the whitelist is the source-of-truth for which keys we emit on. Casting
 // to a Set once at module load lets the IPC handler's per-key membership
@@ -165,6 +166,7 @@ export function registerSettingsHandlers(
       rebuildAppMenu()
     }
     if ('httpProxyUrl' in sanitizedArgs || 'httpProxyBypassRules' in sanitizedArgs) {
+      setLocalCliProxySettings(result)
       try {
         await applyElectronProxySettings(result)
       } catch {

--- a/src/main/network/local-cli-environment.test.ts
+++ b/src/main/network/local-cli-environment.test.ts
@@ -1,12 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { hydrateShellPathMock, mergePersistedWindowsPathMock } = vi.hoisted(() => ({
-  hydrateShellPathMock: vi.fn(),
-  mergePersistedWindowsPathMock: vi.fn()
-}))
+const { hydrateShellPathMock, mergePathSegmentsMock, mergePersistedWindowsPathMock } = vi.hoisted(
+  () => ({
+    hydrateShellPathMock: vi.fn(),
+    mergePathSegmentsMock: vi.fn(),
+    mergePersistedWindowsPathMock: vi.fn()
+  })
+)
 
 vi.mock('../startup/hydrate-shell-path', () => ({
-  hydrateShellPath: hydrateShellPathMock
+  hydrateShellPath: hydrateShellPathMock,
+  mergePathSegments: mergePathSegmentsMock
 }))
 
 vi.mock('../pty/windows-environment-path', () => ({
@@ -18,13 +22,16 @@ import {
   buildLocalCliEnvironment,
   setLocalCliProxySettings
 } from './local-cli-environment'
+import type { HydrationResult } from '../startup/hydrate-shell-path'
 
 describe('local CLI environment', () => {
   const originalPlatform = process.platform
+  const originalPath = process.env.PATH
 
   beforeEach(() => {
     _resetLocalCliProxySettings()
     hydrateShellPathMock.mockReset()
+    mergePathSegmentsMock.mockReset()
     mergePersistedWindowsPathMock.mockReset()
     hydrateShellPathMock.mockResolvedValue({
       segments: ['/usr/local/bin'],
@@ -47,6 +54,11 @@ describe('local CLI environment', () => {
       configurable: true,
       value: originalPlatform
     })
+    if (originalPath === undefined) {
+      delete process.env.PATH
+    } else {
+      process.env.PATH = originalPath
+    }
   })
 
   it('fills missing proxy variables from the login shell without importing unrelated values', async () => {
@@ -73,6 +85,43 @@ describe('local CLI environment', () => {
 
     expect(env.HTTPS_PROXY).toBe('http://launch-proxy.example:8080')
     expect(env.NO_PROXY).toBe('launch.internal')
+  })
+
+  it('copies the process PATH only after an in-flight shell hydration has merged it', async () => {
+    process.env.PATH = '/usr/bin'
+    let resolveHydration: ((result: HydrationResult) => void) | undefined
+    hydrateShellPathMock.mockReturnValueOnce(
+      new Promise<HydrationResult>((resolve) => {
+        resolveHydration = resolve
+      })
+    )
+    mergePathSegmentsMock.mockImplementationOnce((segments: string[]) => {
+      process.env.PATH = [...segments, '/usr/bin'].join(':')
+      return segments
+    })
+
+    const environmentPromise = buildLocalCliEnvironment()
+    expect(mergePathSegmentsMock).not.toHaveBeenCalled()
+
+    resolveHydration?.({
+      segments: ['/Users/test/.local/bin'],
+      proxyEnv: {},
+      ok: true,
+      failureReason: 'none'
+    })
+
+    await expect(environmentPromise).resolves.toMatchObject({
+      PATH: '/Users/test/.local/bin:/usr/bin'
+    })
+    expect(mergePathSegmentsMock).toHaveBeenCalledWith(['/Users/test/.local/bin'])
+  })
+
+  it('preserves an explicitly supplied PATH while still importing shell proxy values', async () => {
+    const env = await buildLocalCliEnvironment({ PATH: '/custom/bin' })
+
+    expect(env.PATH).toBe('/custom/bin')
+    expect(env.HTTPS_PROXY).toBe('http://shell-proxy.example:8080')
+    expect(mergePathSegmentsMock).not.toHaveBeenCalled()
   })
 
   it('lets manual Orca proxy settings override inherited proxy and bypass values', async () => {

--- a/src/main/network/local-cli-environment.test.ts
+++ b/src/main/network/local-cli-environment.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { hydrateShellPathMock, mergePersistedWindowsPathMock } = vi.hoisted(() => ({
+  hydrateShellPathMock: vi.fn(),
+  mergePersistedWindowsPathMock: vi.fn()
+}))
+
+vi.mock('../startup/hydrate-shell-path', () => ({
+  hydrateShellPath: hydrateShellPathMock
+}))
+
+vi.mock('../pty/windows-environment-path', () => ({
+  mergePersistedWindowsPath: mergePersistedWindowsPathMock
+}))
+
+import {
+  _resetLocalCliProxySettings,
+  buildLocalCliEnvironment,
+  setLocalCliProxySettings
+} from './local-cli-environment'
+
+describe('local CLI environment', () => {
+  const originalPlatform = process.platform
+
+  beforeEach(() => {
+    _resetLocalCliProxySettings()
+    hydrateShellPathMock.mockReset()
+    mergePersistedWindowsPathMock.mockReset()
+    hydrateShellPathMock.mockResolvedValue({
+      segments: ['/usr/local/bin'],
+      proxyEnv: {
+        HTTPS_PROXY: 'http://shell-proxy.example:8080',
+        https_proxy: 'http://shell-lower.example:8080',
+        NO_PROXY: 'localhost'
+      },
+      ok: true,
+      failureReason: 'none'
+    })
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'darwin'
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: originalPlatform
+    })
+  })
+
+  it('fills missing proxy variables from the login shell without importing unrelated values', async () => {
+    const env = await buildLocalCliEnvironment({
+      PATH: '/usr/bin',
+      GH_TOKEN: 'token-from-launch'
+    })
+
+    expect(env).toMatchObject({
+      PATH: '/usr/bin',
+      GH_TOKEN: 'token-from-launch',
+      HTTPS_PROXY: 'http://shell-proxy.example:8080',
+      https_proxy: 'http://shell-lower.example:8080',
+      NO_PROXY: 'localhost'
+    })
+    expect(env.GITHUB_TOKEN).toBeUndefined()
+  })
+
+  it('preserves launch-time proxy variables when Orca has no manual proxy', async () => {
+    const env = await buildLocalCliEnvironment({
+      HTTPS_PROXY: 'http://launch-proxy.example:8080',
+      NO_PROXY: 'launch.internal'
+    })
+
+    expect(env.HTTPS_PROXY).toBe('http://launch-proxy.example:8080')
+    expect(env.NO_PROXY).toBe('launch.internal')
+  })
+
+  it('lets manual Orca proxy settings override inherited proxy and bypass values', async () => {
+    setLocalCliProxySettings({
+      httpProxyUrl: 'http://orca-proxy.example:9000',
+      httpProxyBypassRules: 'localhost;*.internal'
+    })
+
+    const env = await buildLocalCliEnvironment({
+      HTTPS_PROXY: 'http://launch-proxy.example:8080',
+      NO_PROXY: 'launch.internal'
+    })
+
+    expect(env).toMatchObject({
+      HTTP_PROXY: 'http://orca-proxy.example:9000',
+      HTTPS_PROXY: 'http://orca-proxy.example:9000',
+      ALL_PROXY: 'http://orca-proxy.example:9000',
+      http_proxy: 'http://orca-proxy.example:9000',
+      https_proxy: 'http://orca-proxy.example:9000',
+      all_proxy: 'http://orca-proxy.example:9000',
+      NO_PROXY: 'localhost,*.internal',
+      no_proxy: 'localhost,*.internal'
+    })
+  })
+
+  it('uses persisted Windows Path without importing the host shell proxy snapshot', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+    mergePersistedWindowsPathMock.mockImplementation((env: Record<string, string>) => {
+      env.Path = 'C:\\Windows\\System32;C:\\Program Files\\GitHub CLI'
+    })
+
+    const env = await buildLocalCliEnvironment({ Path: 'C:\\Windows\\System32' })
+
+    expect(env.Path).toContain('GitHub CLI')
+    expect(env.HTTPS_PROXY).toBeUndefined()
+    expect(hydrateShellPathMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/network/local-cli-environment.ts
+++ b/src/main/network/local-cli-environment.ts
@@ -4,7 +4,11 @@ import {
   type NetworkProxySettings
 } from '../../shared/network-proxy'
 import { mergePersistedWindowsPath } from '../pty/windows-environment-path'
-import { hydrateShellPath, type HydrationResult } from '../startup/hydrate-shell-path'
+import {
+  hydrateShellPath,
+  mergePathSegments,
+  type HydrationResult
+} from '../startup/hydrate-shell-path'
 
 let configuredProxySettings: NetworkProxySettings | null = null
 
@@ -74,13 +78,22 @@ function fillShellProxyEnvironment(
 export async function buildLocalCliEnvironment(
   baseEnv: NodeJS.ProcessEnv = process.env
 ): Promise<Record<string, string>> {
-  const env = stringOnlyEnvironment(baseEnv)
   if (process.platform === 'win32') {
+    const env = stringOnlyEnvironment(baseEnv)
     mergePersistedWindowsPath(env)
-  } else {
-    const shellHydration = await hydrateShellPath()
-    fillShellProxyEnvironment(env, shellHydration)
+    Object.assign(env, buildConfiguredProxyEnv(configuredProxySettings))
+    return env
   }
+
+  const shellHydration = await hydrateShellPath()
+  // Why: the startup hydration callback can finish while this function awaits
+  // the same promise. Merge before copying so GUI-launched probes do not retain
+  // the sparse PATH snapshot from before shell startup completed.
+  if (baseEnv === process.env && shellHydration.segments.length > 0) {
+    mergePathSegments(shellHydration.segments)
+  }
+  const env = stringOnlyEnvironment(baseEnv)
+  fillShellProxyEnvironment(env, shellHydration)
 
   // Why: a manual Orca proxy is the child-process source of truth. Applying it
   // last also clears inherited NO_PROXY through buildConfiguredProxyEnv.

--- a/src/main/network/local-cli-environment.ts
+++ b/src/main/network/local-cli-environment.ts
@@ -1,0 +1,89 @@
+import {
+  buildConfiguredProxyEnv,
+  NETWORK_PROXY_ENV_KEYS,
+  type NetworkProxySettings
+} from '../../shared/network-proxy'
+import { mergePersistedWindowsPath } from '../pty/windows-environment-path'
+import { hydrateShellPath, type HydrationResult } from '../startup/hydrate-shell-path'
+
+let configuredProxySettings: NetworkProxySettings | null = null
+
+/**
+ * Replace the proxy settings used by app-owned local CLI subprocesses.
+ *
+ * @param settings Current persisted Orca proxy settings.
+ */
+export function setLocalCliProxySettings(settings: NetworkProxySettings | null | undefined): void {
+  configuredProxySettings = settings
+    ? {
+        httpProxyUrl: settings.httpProxyUrl,
+        httpProxyBypassRules: settings.httpProxyBypassRules
+      }
+    : null
+}
+
+/**
+ * Reset process-wide proxy settings retained by this module.
+ *
+ * @internal Tests use this to keep module state isolated.
+ */
+export function _resetLocalCliProxySettings(): void {
+  configuredProxySettings = null
+}
+
+/**
+ * Copy only string-valued process environment entries.
+ *
+ * @param env Environment to sanitize for child_process.
+ * @returns A mutable environment record without undefined values.
+ */
+function stringOnlyEnvironment(env: NodeJS.ProcessEnv): Record<string, string> {
+  const result: Record<string, string> = {}
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined) {
+      result[key] = value
+    }
+  }
+  return result
+}
+
+/**
+ * Fill missing proxy variables from the user's login shell snapshot.
+ *
+ * @param env Mutable child-process environment.
+ * @param shellHydration Cached shell hydration result.
+ */
+function fillShellProxyEnvironment(
+  env: Record<string, string>,
+  shellHydration: HydrationResult
+): void {
+  for (const key of NETWORK_PROXY_ENV_KEYS) {
+    const value = shellHydration.proxyEnv[key]
+    if (env[key] === undefined && value !== undefined) {
+      env[key] = value
+    }
+  }
+}
+
+/**
+ * Build the environment for a CLI that executes on the local host.
+ *
+ * @param baseEnv Caller-specific environment, defaulting to the Orca process.
+ * @returns Environment with shell proxy fallback and authoritative Orca proxy settings.
+ */
+export async function buildLocalCliEnvironment(
+  baseEnv: NodeJS.ProcessEnv = process.env
+): Promise<Record<string, string>> {
+  const env = stringOnlyEnvironment(baseEnv)
+  if (process.platform === 'win32') {
+    mergePersistedWindowsPath(env)
+  } else {
+    const shellHydration = await hydrateShellPath()
+    fillShellProxyEnvironment(env, shellHydration)
+  }
+
+  // Why: a manual Orca proxy is the child-process source of truth. Applying it
+  // last also clears inherited NO_PROXY through buildConfiguredProxyEnv.
+  Object.assign(env, buildConfiguredProxyEnv(configuredProxySettings))
+  return env
+}

--- a/src/main/startup/hydrate-shell-path.test.ts
+++ b/src/main/startup/hydrate-shell-path.test.ts
@@ -54,6 +54,7 @@ describe('hydrateShellPath', () => {
         capturedShell = shell
         return {
           segments: ['/Users/tester/.opencode/bin', '/Users/tester/.cargo/bin'],
+          proxyEnv: { HTTPS_PROXY: 'http://proxy.example:8080' },
           ok: true,
           failureReason: 'none'
         }
@@ -63,6 +64,7 @@ describe('hydrateShellPath', () => {
     expect(capturedShell).toBe('/bin/zsh')
     expect(result.ok).toBe(true)
     expect(result.segments).toEqual(['/Users/tester/.opencode/bin', '/Users/tester/.cargo/bin'])
+    expect(result.proxyEnv).toEqual({ HTTPS_PROXY: 'http://proxy.example:8080' })
     expect(result.failureReason).toBe('none')
   })
 
@@ -70,7 +72,7 @@ describe('hydrateShellPath', () => {
     let spawnCount = 0
     const spawner: HydrationSpawner = async () => {
       spawnCount += 1
-      return { segments: ['/a'], ok: true, failureReason: 'none' }
+      return { segments: ['/a'], proxyEnv: {}, ok: true, failureReason: 'none' }
     }
 
     await hydrateShellPath({ shellOverride: '/bin/zsh', spawner })
@@ -84,7 +86,7 @@ describe('hydrateShellPath', () => {
     let spawnCount = 0
     const spawner: HydrationSpawner = async () => {
       spawnCount += 1
-      return { segments: ['/a'], ok: true, failureReason: 'none' }
+      return { segments: ['/a'], proxyEnv: {}, ok: true, failureReason: 'none' }
     }
 
     await hydrateShellPath({ shellOverride: '/bin/zsh', spawner })
@@ -101,7 +103,7 @@ describe('hydrateShellPath', () => {
       }
     })
 
-    expect(result).toEqual({ segments: [], ok: false, failureReason: 'no_shell' })
+    expect(result).toEqual({ segments: [], proxyEnv: {}, ok: false, failureReason: 'no_shell' })
   })
 
   // Why: each failure mode tagged independently so dashboards can pick the
@@ -112,25 +114,30 @@ describe('hydrateShellPath', () => {
   it('propagates failureReason:timeout from the spawner', async () => {
     const result = await hydrateShellPath({
       shellOverride: '/bin/zsh',
-      spawner: async () => ({ segments: [], ok: false, failureReason: 'timeout' })
+      spawner: async () => ({ segments: [], proxyEnv: {}, ok: false, failureReason: 'timeout' })
     })
-    expect(result).toEqual({ segments: [], ok: false, failureReason: 'timeout' })
+    expect(result).toEqual({ segments: [], proxyEnv: {}, ok: false, failureReason: 'timeout' })
   })
 
   it('propagates failureReason:spawn_error from the spawner', async () => {
     const result = await hydrateShellPath({
       shellOverride: '/bin/zsh',
-      spawner: async () => ({ segments: [], ok: false, failureReason: 'spawn_error' })
+      spawner: async () => ({
+        segments: [],
+        proxyEnv: {},
+        ok: false,
+        failureReason: 'spawn_error'
+      })
     })
-    expect(result).toEqual({ segments: [], ok: false, failureReason: 'spawn_error' })
+    expect(result).toEqual({ segments: [], proxyEnv: {}, ok: false, failureReason: 'spawn_error' })
   })
 
   it('propagates failureReason:empty_path from the spawner', async () => {
     const result = await hydrateShellPath({
       shellOverride: '/bin/zsh',
-      spawner: async () => ({ segments: [], ok: false, failureReason: 'empty_path' })
+      spawner: async () => ({ segments: [], proxyEnv: {}, ok: false, failureReason: 'empty_path' })
     })
-    expect(result).toEqual({ segments: [], ok: false, failureReason: 'empty_path' })
+    expect(result).toEqual({ segments: [], proxyEnv: {}, ok: false, failureReason: 'empty_path' })
   })
 
   it('cleans up shell listeners when hydration times out', async () => {
@@ -142,6 +149,7 @@ describe('hydrateShellPath', () => {
       const resultPromise = hydrateShellPath({ shellOverride: '/bin/zsh', force: true })
       const assertion = expect(resultPromise).resolves.toEqual({
         segments: [],
+        proxyEnv: {},
         ok: false,
         failureReason: 'timeout'
       })
@@ -156,6 +164,44 @@ describe('hydrateShellPath', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('captures only allowlisted proxy variables from the login shell', async () => {
+    const proc = createMockShellProcess()
+    spawnMock.mockReturnValue(proc)
+
+    const resultPromise = hydrateShellPath({ shellOverride: '/bin/zsh', force: true })
+    const shellArgs = spawnMock.mock.calls[0][1] as string[]
+    expect(shellArgs[1]).toContain("printenv 'HTTPS_PROXY'")
+    expect(shellArgs[1]).not.toContain('GITHUB_TOKEN')
+
+    proc.stdout.emit(
+      'data',
+      Buffer.from(
+        [
+          '__ORCA_SHELL_PATH__',
+          ['/usr/local/bin', '/usr/bin'].join(delimiter),
+          '__ORCA_SHELL_PATH__',
+          '__ORCA_SHELL_PROXY_HTTPS_PROXY__',
+          'http://proxy.example:8080\n',
+          '__ORCA_SHELL_PROXY_HTTPS_PROXY__',
+          '__ORCA_SHELL_PROXY_NO_PROXY__',
+          'localhost,*.internal\n',
+          '__ORCA_SHELL_PROXY_NO_PROXY__'
+        ].join('')
+      )
+    )
+    proc.emit('close')
+
+    await expect(resultPromise).resolves.toEqual({
+      segments: ['/usr/local/bin', '/usr/bin'],
+      proxyEnv: {
+        HTTPS_PROXY: 'http://proxy.example:8080',
+        NO_PROXY: 'localhost,*.internal'
+      },
+      ok: true,
+      failureReason: 'none'
+    })
   })
 })
 

--- a/src/main/startup/hydrate-shell-path.test.ts
+++ b/src/main/startup/hydrate-shell-path.test.ts
@@ -82,7 +82,7 @@ describe('hydrateShellPath', () => {
     expect(spawnCount).toBe(1)
   })
 
-  it('re-spawns when force:true is passed — matches the Refresh button contract', async () => {
+  it('re-spawns once and coalesces concurrent force callers after the cache settles', async () => {
     let spawnCount = 0
     const spawner: HydrationSpawner = async () => {
       spawnCount += 1
@@ -90,9 +90,54 @@ describe('hydrateShellPath', () => {
     }
 
     await hydrateShellPath({ shellOverride: '/bin/zsh', spawner })
-    await hydrateShellPath({ shellOverride: '/bin/zsh', spawner, force: true })
+    const firstRefresh = hydrateShellPath({ shellOverride: '/bin/zsh', spawner, force: true })
+    const secondRefresh = hydrateShellPath({ shellOverride: '/bin/zsh', spawner, force: true })
 
+    expect(firstRefresh).toBe(secondRefresh)
+    await Promise.all([firstRefresh, secondRefresh])
     expect(spawnCount).toBe(2)
+  })
+
+  it('serializes and coalesces forced refreshes behind an in-flight hydration', async () => {
+    let resolveInitial: ((result: HydrationResult) => void) | undefined
+    let resolveRefresh: ((result: HydrationResult) => void) | undefined
+    const initialSpawner = vi.fn(
+      () =>
+        new Promise<HydrationResult>((resolve) => {
+          resolveInitial = resolve
+        })
+    )
+    const refreshSpawner = vi.fn(
+      () =>
+        new Promise<HydrationResult>((resolve) => {
+          resolveRefresh = resolve
+        })
+    )
+
+    const initial = hydrateShellPath({ shellOverride: '/bin/zsh', spawner: initialSpawner })
+    const firstRefresh = hydrateShellPath({
+      shellOverride: '/bin/zsh',
+      spawner: refreshSpawner,
+      force: true
+    })
+    const secondRefresh = hydrateShellPath({
+      shellOverride: '/bin/zsh',
+      spawner: refreshSpawner,
+      force: true
+    })
+
+    expect(firstRefresh).toBe(secondRefresh)
+    expect(refreshSpawner).not.toHaveBeenCalled()
+
+    resolveInitial?.({ segments: ['/old'], proxyEnv: {}, ok: true, failureReason: 'none' })
+    await initial
+    await vi.waitFor(() => {
+      expect(refreshSpawner).toHaveBeenCalledTimes(1)
+    })
+
+    resolveRefresh?.({ segments: ['/fresh'], proxyEnv: {}, ok: true, failureReason: 'none' })
+    await expect(firstRefresh).resolves.toMatchObject({ segments: ['/fresh'] })
+    expect(refreshSpawner).toHaveBeenCalledTimes(1)
   })
 
   it('returns failureReason:no_shell when no shell is available (Windows path)', async () => {

--- a/src/main/startup/hydrate-shell-path.ts
+++ b/src/main/startup/hydrate-shell-path.ts
@@ -42,10 +42,16 @@ export type HydrationResult =
     }
 
 let cached: Promise<HydrationResult> | null = null
+let inFlight: Promise<HydrationResult> | null = null
+let inFlightForced = false
+let queuedForced: Promise<HydrationResult> | null = null
 
 /** @internal - tests need a clean hydration cache between cases. */
 export function _resetHydrateShellPathCache(): void {
   cached = null
+  inFlight = null
+  inFlightForced = false
+  queuedForced = null
 }
 
 function pickShell(): string | null {
@@ -219,15 +225,12 @@ type HydrateOptions = {
 }
 
 /**
- * Spawn the user's login shell once and return the PATH it would export.
- * Caches the promise for the lifetime of the process — call
- * `_resetHydrateShellPathCache()` in tests or `hydrateShellPath({ force: true })`
- * when the user asks to re-probe (e.g. after installing a new CLI).
+ * Start one shell hydration and expose it as the shared in-flight result.
+ *
+ * @param options Shell selection and test overrides for this hydration.
+ * @returns The newly started hydration promise.
  */
-export function hydrateShellPath(options: HydrateOptions = {}): Promise<HydrationResult> {
-  if (cached && !options.force) {
-    return cached
-  }
+function startShellHydration(options: HydrateOptions): Promise<HydrationResult> {
   const shell = options.shellOverride !== undefined ? options.shellOverride : pickShell()
   if (!shell) {
     // Windows uses cmd/PowerShell rather than a POSIX login shell — the
@@ -235,8 +238,55 @@ export function hydrateShellPath(options: HydrateOptions = {}): Promise<Hydratio
     cached = Promise.resolve({ segments: [], proxyEnv: {}, ok: false, failureReason: 'no_shell' })
     return cached
   }
-  cached = (options.spawner ?? spawnShellAndReadPath)(shell)
-  return cached
+
+  const started = (options.spawner ?? spawnShellAndReadPath)(shell)
+  inFlight = started
+  inFlightForced = options.force === true
+  cached = started
+  const clearInFlight = (): void => {
+    if (inFlight === started) {
+      inFlight = null
+      inFlightForced = false
+    }
+  }
+  void started.then(clearInFlight, clearInFlight)
+  return started
+}
+
+/**
+ * Spawn the user's login shell once and return the PATH it would export.
+ * Caches the promise for the lifetime of the process — call
+ * `_resetHydrateShellPathCache()` in tests or `hydrateShellPath({ force: true })`
+ * when the user asks to re-probe (e.g. after installing a new CLI).
+ */
+export function hydrateShellPath(options: HydrateOptions = {}): Promise<HydrationResult> {
+  if (!options.force) {
+    return cached ?? startShellHydration(options)
+  }
+
+  if (!inFlight) {
+    return startShellHydration(options)
+  }
+  if (queuedForced) {
+    return queuedForced
+  }
+  if (inFlightForced) {
+    return inFlight
+  }
+
+  // Why: startup and user-triggered refreshes can overlap. Queue one fresh
+  // capture behind the active shell and coalesce later force callers onto it.
+  const startForcedHydration = (): Promise<HydrationResult> => startShellHydration(options)
+  const queued = inFlight.then(startForcedHydration, startForcedHydration)
+  queuedForced = queued
+  cached = queued
+  const clearQueuedForced = (): void => {
+    if (queuedForced === queued) {
+      queuedForced = null
+    }
+  }
+  void queued.then(clearQueuedForced, clearQueuedForced)
+  return queued
 }
 
 /**

--- a/src/main/startup/hydrate-shell-path.ts
+++ b/src/main/startup/hydrate-shell-path.ts
@@ -54,6 +54,11 @@ export function _resetHydrateShellPathCache(): void {
   queuedForced = null
 }
 
+/**
+ * Select the user's login shell used for environment hydration.
+ *
+ * @returns Configured shell, a platform default, or null on Windows.
+ */
 function pickShell(): string | null {
   if (process.platform === 'win32') {
     return null
@@ -65,6 +70,12 @@ function pickShell(): string | null {
   return process.platform === 'darwin' ? '/bin/zsh' : '/bin/bash'
 }
 
+/**
+ * Parse the delimited PATH value emitted by the login shell.
+ *
+ * @param stdout Captured shell output, including possible startup banners.
+ * @returns De-duplicated PATH segments in shell resolution order.
+ */
 function parseCapturedPath(stdout: string): string[] {
   const cleaned = stdout.replace(ANSI_RE, '')
   const first = cleaned.indexOf(DELIMITER)
@@ -141,6 +152,12 @@ function buildShellCaptureCommand(): string {
   return `${pathCapture}; ${proxyCapture}`
 }
 
+/**
+ * Spawn one login shell and capture its PATH and proxy environment.
+ *
+ * @param shell Login shell executable selected for hydration.
+ * @returns Hydration result classified by success or failure reason.
+ */
 function spawnShellAndReadPath(shell: string): Promise<HydrationResult> {
   return new Promise((resolve) => {
     // Why: printing $PATH between delimiters is resilient to rc-file banners,

--- a/src/main/startup/hydrate-shell-path.ts
+++ b/src/main/startup/hydrate-shell-path.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 import { delimiter } from 'node:path'
 import type { ShellHydrationFailureReason } from '../../shared/types'
+import { NETWORK_PROXY_ENV_KEYS } from '../../shared/network-proxy'
 
 // Why: GUI-launched Electron on macOS/Linux inherits a minimal PATH from launchd
 // that does not include dirs appended by the user's shell rc files (~/.zshrc,
@@ -15,6 +16,7 @@ import type { ShellHydrationFailureReason } from '../../shared/types'
 // we implement it inline to avoid adding a dependency.
 
 const DELIMITER = '__ORCA_SHELL_PATH__'
+const PROXY_DELIMITER_PREFIX = '__ORCA_SHELL_PROXY_'
 const SPAWN_TIMEOUT_MS = 5000
 
 // ANSI escape sequences can leak into the captured output when the user's rc
@@ -26,10 +28,16 @@ const ANSI_RE = /\x1b\[[0-9;?]*[A-Za-z]/g // eslint-disable-line no-control-rege
 // with the right reason. The shared alias keeps the enum in lockstep with the
 // telemetry schema (compile-time guard in telemetry-events.ts).
 export type HydrationResult =
-  | { ok: true; segments: string[]; failureReason: 'none' }
+  | {
+      ok: true
+      segments: string[]
+      proxyEnv: Record<string, string>
+      failureReason: 'none'
+    }
   | {
       ok: false
       segments: []
+      proxyEnv: Record<string, string>
       failureReason: Exclude<ShellHydrationFailureReason, 'none'>
     }
 
@@ -77,13 +85,63 @@ function parseCapturedPath(stdout: string): string[] {
   ]
 }
 
+/**
+ * Return the marker that brackets one captured shell proxy variable.
+ *
+ * @param key Standard proxy environment variable name.
+ * @returns A delimiter unique to that variable.
+ */
+function proxyDelimiter(key: string): string {
+  return `${PROXY_DELIMITER_PREFIX}${key}__`
+}
+
+/**
+ * Parse only the allowlisted proxy variables from shell output.
+ *
+ * @param stdout Captured login-shell output, including possible startup banners.
+ * @returns Proxy environment values discovered in the shell.
+ */
+function parseCapturedProxyEnvironment(stdout: string): Record<string, string> {
+  const cleaned = stdout.replace(ANSI_RE, '')
+  const result: Record<string, string> = {}
+  for (const key of NETWORK_PROXY_ENV_KEYS) {
+    const marker = proxyDelimiter(key)
+    const first = cleaned.indexOf(marker)
+    const second = first < 0 ? -1 : cleaned.indexOf(marker, first + marker.length)
+    if (first < 0 || second < 0) {
+      continue
+    }
+    const value = cleaned.slice(first + marker.length, second).trim()
+    if (value) {
+      result[key] = value
+    }
+  }
+  return result
+}
+
+/**
+ * Build a cross-shell command that captures PATH and proxy allowlist values.
+ *
+ * @returns Shell command suitable for a login/interactive shell.
+ */
+function buildShellCaptureCommand(): string {
+  const pathCapture = `printf '%s' '${DELIMITER}'; printf '%s' "$PATH"; printf '%s' '${DELIMITER}'`
+  const proxyCapture = NETWORK_PROXY_ENV_KEYS.map((key) => {
+    const marker = proxyDelimiter(key)
+    // Why: printenv avoids shell-specific indirect expansion; missing variables
+    // simply contribute an empty delimited value in zsh, bash, and fish.
+    return `printf '%s' '${marker}'; printenv '${key}'; printf '%s' '${marker}'`
+  }).join('; ')
+  return `${pathCapture}; ${proxyCapture}`
+}
+
 function spawnShellAndReadPath(shell: string): Promise<HydrationResult> {
   return new Promise((resolve) => {
     // Why: printing $PATH between delimiters is resilient to rc-file banners,
     // MOTDs, and `echo` invocations that shells like fish print unprompted.
     // `-ilc` runs the shell as a login+interactive so both .profile/.zprofile
     // and .bashrc/.zshrc are sourced — matches what `which` in Terminal sees.
-    const command = `printf '%s' '${DELIMITER}'; printf '%s' "$PATH"; printf '%s' '${DELIMITER}'`
+    const command = buildShellCaptureCommand()
     let finished = false
     let stdout = ''
     let timer: ReturnType<typeof setTimeout> | null = null
@@ -125,7 +183,7 @@ function spawnShellAndReadPath(shell: string): Promise<HydrationResult> {
       } catch {
         // ignore
       }
-      finish({ segments: [], ok: false, failureReason: 'timeout' })
+      finish({ segments: [], proxyEnv: {}, ok: false, failureReason: 'timeout' })
     }, SPAWN_TIMEOUT_MS)
 
     const onStdoutData = (chunk: Buffer): void => {
@@ -133,16 +191,17 @@ function spawnShellAndReadPath(shell: string): Promise<HydrationResult> {
     }
 
     const onError = (): void => {
-      finish({ segments: [], ok: false, failureReason: 'spawn_error' })
+      finish({ segments: [], proxyEnv: {}, ok: false, failureReason: 'spawn_error' })
     }
 
     const onClose = (): void => {
       const segments = parseCapturedPath(stdout)
+      const proxyEnv = parseCapturedProxyEnvironment(stdout)
       if (segments.length === 0) {
-        finish({ segments: [], ok: false, failureReason: 'empty_path' })
+        finish({ segments: [], proxyEnv, ok: false, failureReason: 'empty_path' })
         return
       }
-      finish({ segments, ok: true, failureReason: 'none' })
+      finish({ segments, proxyEnv, ok: true, failureReason: 'none' })
     }
 
     child.stdout.on('data', onStdoutData)
@@ -173,7 +232,7 @@ export function hydrateShellPath(options: HydrateOptions = {}): Promise<Hydratio
   if (!shell) {
     // Windows uses cmd/PowerShell rather than a POSIX login shell — the
     // `patchPackagedProcessPath` static list is sufficient there.
-    cached = Promise.resolve({ segments: [], ok: false, failureReason: 'no_shell' })
+    cached = Promise.resolve({ segments: [], proxyEnv: {}, ok: false, failureReason: 'no_shell' })
     return cached
   }
   cached = (options.spawner ?? spawnShellAndReadPath)(shell)

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -57,6 +57,7 @@ import type {
   FolderWorkspacePathStatus,
   FolderWorkspacePathStatusRequest
 } from '../shared/folder-workspace-path-status'
+import type { CliAuthStatus } from '../shared/cli-auth-status'
 import type {
   BaseRefDefaultResult,
   BaseRefSearchResult,
@@ -588,10 +589,10 @@ export type DetectedBrowserInfo = {
 
 export type PreflightStatus = {
   git: { installed: boolean }
-  gh: { installed: boolean; authenticated: boolean }
+  gh: CliAuthStatus
   /** Optional — older preload payloads predating GitLab support don't
    *  include it. Consumers gate on `glab?.installed` / `authenticated`. */
-  glab?: { installed: boolean; authenticated: boolean }
+  glab?: CliAuthStatus
   bitbucket?: { configured: boolean; authenticated: boolean; account: string | null }
   azureDevOps?: {
     configured: boolean

--- a/src/renderer/src/components/feature-wall/use-integration-connection-status.test.ts
+++ b/src/renderer/src/components/feature-wall/use-integration-connection-status.test.ts
@@ -395,6 +395,23 @@ describe('deriveCliProviderCardState', () => {
       })
     ).toBe('unavailable')
   })
+
+  it('does not turn a failed auth probe into login instructions', () => {
+    expect(
+      deriveCliProviderCardState({
+        cliStatus: {
+          installed: true,
+          authenticated: false,
+          authState: 'unreachable'
+        },
+        preflightStatusAvailable: true,
+        preflightStatusChecked: true,
+        preflightStatusCurrent: true,
+        preflightStatusError: null,
+        preflightStatusLoading: false
+      })
+    ).toBe('connection-error')
+  })
 })
 
 describe('deriveIntegrationFlowState', () => {

--- a/src/renderer/src/components/feature-wall/use-integration-connection-status.test.ts
+++ b/src/renderer/src/components/feature-wall/use-integration-connection-status.test.ts
@@ -412,6 +412,23 @@ describe('deriveCliProviderCardState', () => {
       })
     ).toBe('connection-error')
   })
+
+  it('keeps an unexpected CLI error separate from a connection failure', () => {
+    expect(
+      deriveCliProviderCardState({
+        cliStatus: {
+          installed: true,
+          authenticated: false,
+          authState: 'error'
+        },
+        preflightStatusAvailable: true,
+        preflightStatusChecked: true,
+        preflightStatusCurrent: true,
+        preflightStatusError: null,
+        preflightStatusLoading: false
+      })
+    ).toBe('check-error')
+  })
 })
 
 describe('deriveIntegrationFlowState', () => {

--- a/src/renderer/src/components/landing-preflight-issues.test.ts
+++ b/src/renderer/src/components/landing-preflight-issues.test.ts
@@ -75,6 +75,21 @@ describe('landing preflight issues', () => {
     expect(issues[0]?.description).toContain('network or proxy')
   })
 
+  it('reports an unexpected CLI error separately from connectivity and login issues', () => {
+    const issues = getLandingPreflightIssues(
+      {
+        git: { installed: true },
+        gh: { installed: true, authenticated: false, authState: 'error' }
+      },
+      { hasGitHubBackedProject: true }
+    )
+
+    expect(issues.map((issue) => issue.id)).toEqual(['gh-check-error'])
+    expect(issues[0]?.description).toContain('gh auth status')
+    expect(issues[0]?.description).not.toContain('network or proxy')
+    expect(issues[0]?.description).not.toContain('gh auth login')
+  })
+
   it('treats GitLab-only registered projects as not GitHub-backed', () => {
     expect(
       hasGitHubBackedProject([

--- a/src/renderer/src/components/landing-preflight-issues.test.ts
+++ b/src/renderer/src/components/landing-preflight-issues.test.ts
@@ -61,6 +61,20 @@ describe('landing preflight issues', () => {
     expect(issues.map((issue) => issue.id)).toContain('gh-auth')
   })
 
+  it('reports a connectivity issue instead of login instructions when auth cannot be verified', () => {
+    const issues = getLandingPreflightIssues(
+      {
+        git: { installed: true },
+        gh: { installed: true, authenticated: false, authState: 'timeout' }
+      },
+      { hasGitHubBackedProject: true }
+    )
+
+    expect(issues.map((issue) => issue.id)).toContain('gh-connectivity')
+    expect(issues.map((issue) => issue.id)).not.toContain('gh-auth')
+    expect(issues[0]?.description).toContain('network or proxy')
+  })
+
   it('treats GitLab-only registered projects as not GitHub-backed', () => {
     expect(
       hasGitHubBackedProject([

--- a/src/renderer/src/components/landing-preflight-issues.ts
+++ b/src/renderer/src/components/landing-preflight-issues.ts
@@ -1,6 +1,6 @@
 import { translate } from '@/i18n/i18n'
 import { projectHostSetupProjectionFromRepos } from '../../../shared/project-host-setup-projection'
-import type { CliAuthState } from '../../../shared/cli-auth-status'
+import type { CliAuthStatus } from '../../../shared/cli-auth-status'
 import type { Repo } from '../../../shared/types'
 
 export type PreflightIssue = {
@@ -16,18 +16,31 @@ export type PreflightIssue = {
 
 export type LandingPreflightStatus = {
   git: { installed: boolean }
-  gh: { installed: boolean; authenticated: boolean; authState?: CliAuthState }
+  gh: CliAuthStatus
 }
 
 export type LandingPreflightIssueOptions = {
   hasGitHubBackedProject: boolean
 }
 
+/**
+ * Determine whether the landing page represents at least one GitHub-backed project.
+ *
+ * @param repos Repositories visible to the landing page.
+ * @returns True when any projected project uses GitHub.
+ */
 export function hasGitHubBackedProject(repos: readonly Repo[]): boolean {
   const projection = projectHostSetupProjectionFromRepos(repos)
   return projection.projects.some((project) => project.providerIdentity?.provider === 'github')
 }
 
+/**
+ * Build actionable landing-page issues for Git and GitHub CLI readiness.
+ *
+ * @param status Current local preflight result.
+ * @param options Provider context used to suppress irrelevant GitHub guidance.
+ * @returns Ordered setup and connectivity issues for display.
+ */
 export function getLandingPreflightIssues(
   status: LandingPreflightStatus,
   options: LandingPreflightIssueOptions

--- a/src/renderer/src/components/landing-preflight-issues.ts
+++ b/src/renderer/src/components/landing-preflight-issues.ts
@@ -1,5 +1,6 @@
 import { translate } from '@/i18n/i18n'
 import { projectHostSetupProjectionFromRepos } from '../../../shared/project-host-setup-projection'
+import type { CliAuthState } from '../../../shared/cli-auth-status'
 import type { Repo } from '../../../shared/types'
 
 export type PreflightIssue = {
@@ -15,7 +16,7 @@ export type PreflightIssue = {
 
 export type LandingPreflightStatus = {
   git: { installed: boolean }
-  gh: { installed: boolean; authenticated: boolean }
+  gh: { installed: boolean; authenticated: boolean; authState?: CliAuthState }
 }
 
 export type LandingPreflightIssueOptions = {
@@ -62,6 +63,26 @@ export function getLandingPreflightIssues(
       ),
       fixLabel: 'Install GitHub CLI',
       fixUrl: 'https://cli.github.com',
+      dismissible: true
+    })
+  } else if (
+    !status.gh.authenticated &&
+    status.gh.authState !== undefined &&
+    status.gh.authState !== 'unauthenticated'
+  ) {
+    issues.push({
+      id: 'gh-connectivity',
+      title: translate(
+        'auto.components.Landing.github_cli_auth_check_failed',
+        'GitHub CLI authentication could not be verified'
+      ),
+      description: translate(
+        'auto.components.Landing.github_cli_auth_check_failed_description',
+        'Check your network or proxy settings, then re-check the GitHub CLI connection.'
+      ),
+      fixLabel: 'Troubleshoot',
+      fixUrl:
+        'https://docs.github.com/en/get-started/using-github/troubleshooting-connectivity-problems',
       dismissible: true
     })
   } else if (!status.gh.authenticated) {

--- a/src/renderer/src/components/landing-preflight-issues.ts
+++ b/src/renderer/src/components/landing-preflight-issues.ts
@@ -65,10 +65,27 @@ export function getLandingPreflightIssues(
       fixUrl: 'https://cli.github.com',
       dismissible: true
     })
+  } else if (!status.gh.authenticated && status.gh.authState === 'error') {
+    issues.push({
+      id: 'gh-check-error',
+      title: translate(
+        'auto.components.Landing.github_cli_auth_check_error',
+        'GitHub CLI returned an unexpected error'
+      ),
+      description: translate(
+        'auto.components.Landing.github_cli_auth_check_error_description',
+        'Run "gh auth status" in a terminal, resolve the reported CLI error, then re-check.'
+      ),
+      fixLabel: translate(
+        'auto.components.Landing.github_cli_auth_check_error_fix_label',
+        'Review status'
+      ),
+      fixUrl: 'https://cli.github.com/manual/gh_auth_status',
+      dismissible: true
+    })
   } else if (
     !status.gh.authenticated &&
-    status.gh.authState !== undefined &&
-    status.gh.authState !== 'unauthenticated'
+    (status.gh.authState === 'timeout' || status.gh.authState === 'unreachable')
   ) {
     issues.push({
       id: 'gh-connectivity',

--- a/src/renderer/src/components/settings/cli-source-control-integration-cards.test.tsx
+++ b/src/renderer/src/components/settings/cli-source-control-integration-cards.test.tsx
@@ -141,4 +141,20 @@ describe('CLI source-control integration card account scope', () => {
     expect(rendered.textContent).toContain('network or proxy settings')
     expect(rendered.textContent).not.toContain('gh auth login')
   })
+
+  it('shows CLI error guidance without proxy or login instructions', async () => {
+    mocks.store.current = {
+      settings: { activeRuntimeEnvironmentId: null },
+      openSettingsPage: vi.fn(),
+      openSettingsTarget: vi.fn()
+    }
+    mocks.preflight.statuses.ghStatus = 'check-error'
+
+    const rendered = await renderCard(<GitHubIntegrationCard />)
+
+    expect(rendered.textContent).toContain('CLI error')
+    expect(rendered.textContent).toContain('gh auth status')
+    expect(rendered.textContent).not.toContain('network or proxy')
+    expect(rendered.textContent).not.toContain('gh auth login')
+  })
 })

--- a/src/renderer/src/components/settings/cli-source-control-integration-cards.test.tsx
+++ b/src/renderer/src/components/settings/cli-source-control-integration-cards.test.tsx
@@ -126,4 +126,19 @@ describe('CLI source-control integration card account scope', () => {
     )
     expect(rendered.textContent).toContain('glab auth login')
   })
+
+  it('shows connection guidance without login commands when GitHub auth cannot be verified', async () => {
+    mocks.store.current = {
+      settings: { activeRuntimeEnvironmentId: null },
+      openSettingsPage: vi.fn(),
+      openSettingsTarget: vi.fn()
+    }
+    mocks.preflight.statuses.ghStatus = 'connection-error'
+
+    const rendered = await renderCard(<GitHubIntegrationCard />)
+
+    expect(rendered.textContent).toContain('Connection error')
+    expect(rendered.textContent).toContain('network or proxy settings')
+    expect(rendered.textContent).not.toContain('gh auth login')
+  })
 })

--- a/src/renderer/src/components/settings/cli-source-control-integration-cards.tsx
+++ b/src/renderer/src/components/settings/cli-source-control-integration-cards.tsx
@@ -77,7 +77,12 @@ export function GitHubIntegrationCard(): React.JSX.Element {
                     'auto.components.settings.cli.source.control.integration.cards.connection_error',
                     'Connection error'
                   )
-                : 'Not authenticated'
+                : status === 'check-error'
+                  ? translate(
+                      'auto.components.settings.cli.source.control.integration.cards.cli_error',
+                      'CLI error'
+                    )
+                  : 'Not authenticated'
       }
     >
       <ProviderAccountScopeDetails>
@@ -124,6 +129,21 @@ export function GitHubIntegrationCard(): React.JSX.Element {
                   )}
                 </Button>
               </div>
+            </>
+          ) : status === 'check-error' ? (
+            <>
+              <p className="text-xs text-muted-foreground">
+                {translate(
+                  'auto.components.settings.cli.source.control.integration.cards.github_auth_check_error',
+                  'GitHub CLI returned an unexpected error. Run "gh auth status" in a terminal, then re-check.'
+                )}
+              </p>
+              <Button variant="ghost" size="sm" onClick={refresh}>
+                {translate(
+                  'auto.components.settings.cli.source.control.integration.cards.d5b3be8ecd',
+                  'Re-check'
+                )}
+              </Button>
             </>
           ) : status === 'connection-error' ? (
             <>
@@ -226,7 +246,12 @@ export function GitLabIntegrationCard(): React.JSX.Element {
                     'auto.components.settings.cli.source.control.integration.cards.connection_error',
                     'Connection error'
                   )
-                : 'Not authenticated'
+                : status === 'check-error'
+                  ? translate(
+                      'auto.components.settings.cli.source.control.integration.cards.cli_error',
+                      'CLI error'
+                    )
+                  : 'Not authenticated'
       }
     >
       <ProviderAccountScopeDetails>
@@ -275,6 +300,21 @@ export function GitLabIntegrationCard(): React.JSX.Element {
                   )}
                 </Button>
               </div>
+            </>
+          ) : status === 'check-error' ? (
+            <>
+              <p className="text-xs text-muted-foreground">
+                {translate(
+                  'auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_error',
+                  'GitLab CLI returned an unexpected error. Run "glab auth status" in a terminal, then re-check.'
+                )}
+              </p>
+              <Button variant="ghost" size="sm" onClick={refresh}>
+                {translate(
+                  'auto.components.settings.cli.source.control.integration.cards.d5b3be8ecd',
+                  'Re-check'
+                )}
+              </Button>
             </>
           ) : status === 'connection-error' ? (
             <>

--- a/src/renderer/src/components/settings/cli-source-control-integration-cards.tsx
+++ b/src/renderer/src/components/settings/cli-source-control-integration-cards.tsx
@@ -72,7 +72,12 @@ export function GitHubIntegrationCard(): React.JSX.Element {
             ? 'Unavailable'
             : status === 'not-installed'
               ? 'Not installed'
-              : 'Not authenticated'
+              : status === 'connection-error'
+                ? translate(
+                    'auto.components.settings.cli.source.control.integration.cards.connection_error',
+                    'Connection error'
+                  )
+                : 'Not authenticated'
       }
     >
       <ProviderAccountScopeDetails>
@@ -119,6 +124,21 @@ export function GitHubIntegrationCard(): React.JSX.Element {
                   )}
                 </Button>
               </div>
+            </>
+          ) : status === 'connection-error' ? (
+            <>
+              <p className="text-xs text-muted-foreground">
+                {translate(
+                  'auto.components.settings.cli.source.control.integration.cards.github_auth_check_failed',
+                  'Orca could not verify GitHub CLI authentication. Check your network or proxy settings, then re-check.'
+                )}
+              </p>
+              <Button variant="ghost" size="sm" onClick={refresh}>
+                {translate(
+                  'auto.components.settings.cli.source.control.integration.cards.d5b3be8ecd',
+                  'Re-check'
+                )}
+              </Button>
             </>
           ) : (
             <>
@@ -201,7 +221,12 @@ export function GitLabIntegrationCard(): React.JSX.Element {
             ? 'Unavailable'
             : status === 'not-installed'
               ? 'Not installed'
-              : 'Not authenticated'
+              : status === 'connection-error'
+                ? translate(
+                    'auto.components.settings.cli.source.control.integration.cards.connection_error',
+                    'Connection error'
+                  )
+                : 'Not authenticated'
       }
     >
       <ProviderAccountScopeDetails>
@@ -250,6 +275,21 @@ export function GitLabIntegrationCard(): React.JSX.Element {
                   )}
                 </Button>
               </div>
+            </>
+          ) : status === 'connection-error' ? (
+            <>
+              <p className="text-xs text-muted-foreground">
+                {translate(
+                  'auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_failed',
+                  'Orca could not verify GitLab CLI authentication. Check your network or proxy settings, then re-check.'
+                )}
+              </p>
+              <Button variant="ghost" size="sm" onClick={refresh}>
+                {translate(
+                  'auto.components.settings.cli.source.control.integration.cards.d5b3be8ecd',
+                  'Re-check'
+                )}
+              </Button>
             </>
           ) : (
             <>

--- a/src/renderer/src/components/settings/integrations-pane-status.test.ts
+++ b/src/renderer/src/components/settings/integrations-pane-status.test.ts
@@ -96,4 +96,20 @@ describe('getPreflightIntegrationStatuses', () => {
       giteaStatus: 'checking'
     })
   })
+
+  it('distinguishes failed CLI auth probes from confirmed logout', () => {
+    expect(
+      getPreflightIntegrationStatuses(
+        {
+          ...connectedPreflight,
+          gh: { installed: true, authenticated: false, authState: 'timeout' },
+          glab: { installed: true, authenticated: false, authState: 'unreachable' }
+        },
+        new Set()
+      )
+    ).toMatchObject({
+      ghStatus: 'connection-error',
+      glabStatus: 'connection-error'
+    })
+  })
 })

--- a/src/renderer/src/components/settings/integrations-pane-status.test.ts
+++ b/src/renderer/src/components/settings/integrations-pane-status.test.ts
@@ -112,4 +112,20 @@ describe('getPreflightIntegrationStatuses', () => {
       glabStatus: 'connection-error'
     })
   })
+
+  it('keeps unexpected CLI errors separate from network failures', () => {
+    expect(
+      getPreflightIntegrationStatuses(
+        {
+          ...connectedPreflight,
+          gh: { installed: true, authenticated: false, authState: 'error' },
+          glab: { installed: true, authenticated: false, authState: 'error' }
+        },
+        new Set()
+      )
+    ).toMatchObject({
+      ghStatus: 'check-error',
+      glabStatus: 'check-error'
+    })
+  })
 })

--- a/src/renderer/src/components/settings/integrations-pane-status.ts
+++ b/src/renderer/src/components/settings/integrations-pane-status.ts
@@ -6,6 +6,7 @@ export type GhStatus =
   | 'not-installed'
   | 'not-authenticated'
   | 'connection-error'
+  | 'check-error'
 // Why: parallel to GhStatus — GitLab uses glab and the same three failure
 // modes plus a distinct failed-auth-probe state.
 export type GlabStatus = GhStatus
@@ -75,9 +76,10 @@ function ghStatusFromPreflight(status: PreflightStatus['gh']): GhStatus {
   if (status.authenticated) {
     return 'connected'
   }
-  return status.authState === undefined || status.authState === 'unauthenticated'
-    ? 'not-authenticated'
-    : 'connection-error'
+  if (status.authState === undefined || status.authState === 'unauthenticated') {
+    return 'not-authenticated'
+  }
+  return status.authState === 'error' ? 'check-error' : 'connection-error'
 }
 
 function glabStatusFromPreflight(status: PreflightStatus['glab']): GlabStatus {
@@ -87,9 +89,10 @@ function glabStatusFromPreflight(status: PreflightStatus['glab']): GlabStatus {
   if (status.authenticated) {
     return 'connected'
   }
-  return status.authState === undefined || status.authState === 'unauthenticated'
-    ? 'not-authenticated'
-    : 'connection-error'
+  if (status.authState === undefined || status.authState === 'unauthenticated') {
+    return 'not-authenticated'
+  }
+  return status.authState === 'error' ? 'check-error' : 'connection-error'
 }
 
 function bitbucketStatusFromPreflight(status: PreflightStatus['bitbucket']): BitbucketStatus {

--- a/src/renderer/src/components/settings/integrations-pane-status.ts
+++ b/src/renderer/src/components/settings/integrations-pane-status.ts
@@ -1,8 +1,13 @@
 import type { PreflightStatus } from '../../../../preload/api-types'
 
-export type GhStatus = 'checking' | 'connected' | 'not-installed' | 'not-authenticated'
+export type GhStatus =
+  | 'checking'
+  | 'connected'
+  | 'not-installed'
+  | 'not-authenticated'
+  | 'connection-error'
 // Why: parallel to GhStatus — GitLab uses glab and the same three failure
-// modes (probe in-flight / installed-but-unauth / missing entirely).
+// modes plus a distinct failed-auth-probe state.
 export type GlabStatus = GhStatus
 export type BitbucketStatus = 'checking' | 'connected' | 'not-configured' | 'not-authenticated'
 export type AzureDevOpsStatus = 'checking' | 'configured' | 'not-configured' | 'not-authenticated'
@@ -67,14 +72,24 @@ function ghStatusFromPreflight(status: PreflightStatus['gh']): GhStatus {
   if (!status.installed) {
     return 'not-installed'
   }
-  return status.authenticated ? 'connected' : 'not-authenticated'
+  if (status.authenticated) {
+    return 'connected'
+  }
+  return status.authState === undefined || status.authState === 'unauthenticated'
+    ? 'not-authenticated'
+    : 'connection-error'
 }
 
 function glabStatusFromPreflight(status: PreflightStatus['glab']): GlabStatus {
   if (!status?.installed) {
     return 'not-installed'
   }
-  return status.authenticated ? 'connected' : 'not-authenticated'
+  if (status.authenticated) {
+    return 'connected'
+  }
+  return status.authState === undefined || status.authState === 'unauthenticated'
+    ? 'not-authenticated'
+    : 'connection-error'
 }
 
 function bitbucketStatusFromPreflight(status: PreflightStatus['bitbucket']): BitbucketStatus {

--- a/src/renderer/src/components/settings/source-control-preflight-card-status.ts
+++ b/src/renderer/src/components/settings/source-control-preflight-card-status.ts
@@ -21,6 +21,7 @@ export type CliProviderCardState =
   | 'not-installed'
   | 'not-authenticated'
   | 'connection-error'
+  | 'check-error'
   | 'unavailable'
 
 export function deriveCliProviderCardState(input: {
@@ -47,9 +48,10 @@ export function deriveCliProviderCardState(input: {
   if (input.cliStatus.authenticated) {
     return 'connected'
   }
-  return input.cliStatus.authState === undefined || input.cliStatus.authState === 'unauthenticated'
-    ? 'not-authenticated'
-    : 'connection-error'
+  if (input.cliStatus.authState === undefined || input.cliStatus.authState === 'unauthenticated') {
+    return 'not-authenticated'
+  }
+  return input.cliStatus.authState === 'error' ? 'check-error' : 'connection-error'
 }
 
 export type PreflightCardStatuses = {

--- a/src/renderer/src/components/settings/source-control-preflight-card-status.ts
+++ b/src/renderer/src/components/settings/source-control-preflight-card-status.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import type { CliAuthState } from '../../../../shared/cli-auth-status'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { getLocalPreflightContext, localPreflightContextKey } from '@/lib/local-preflight-context'
 import { useAppStore } from '@/store'
@@ -11,6 +12,7 @@ import {
 type CliStatus = {
   installed?: boolean
   authenticated?: boolean
+  authState?: CliAuthState
 }
 
 export type CliProviderCardState =
@@ -18,6 +20,7 @@ export type CliProviderCardState =
   | 'connected'
   | 'not-installed'
   | 'not-authenticated'
+  | 'connection-error'
   | 'unavailable'
 
 export function deriveCliProviderCardState(input: {
@@ -41,7 +44,12 @@ export function deriveCliProviderCardState(input: {
   if (!input.cliStatus.installed) {
     return 'not-installed'
   }
-  return input.cliStatus.authenticated ? 'connected' : 'not-authenticated'
+  if (input.cliStatus.authenticated) {
+    return 'connected'
+  }
+  return input.cliStatus.authState === undefined || input.cliStatus.authState === 'unauthenticated'
+    ? 'not-authenticated'
+    : 'connection-error'
 }
 
 export type PreflightCardStatuses = {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1047,7 +1047,10 @@
         "157bb5ecbb": "Open GitHub",
         "preflightDismiss": "Dismiss",
         "github_cli_auth_check_failed": "GitHub CLI authentication could not be verified",
-        "github_cli_auth_check_failed_description": "Check your network or proxy settings, then re-check the GitHub CLI connection."
+        "github_cli_auth_check_failed_description": "Check your network or proxy settings, then re-check the GitHub CLI connection.",
+        "github_cli_auth_check_error": "GitHub CLI returned an unexpected error",
+        "github_cli_auth_check_error_description": "Run \"gh auth status\" in a terminal, resolve the reported CLI error, then re-check.",
+        "github_cli_auth_check_error_fix_label": "Review status"
       },
       "LinearIssueMarkdownDescriptionEditor": {
         "d9c47069ef": "Markdown",
@@ -8648,8 +8651,11 @@
                   "b4d900e7f1": "Pull requests, issues, and checks via the",
                   "account_scope_prefix": "Account scope",
                   "connection_error": "Connection error",
+                  "cli_error": "CLI error",
                   "github_auth_check_failed": "Orca could not verify GitHub CLI authentication. Check your network or proxy settings, then re-check.",
-                  "gitlab_auth_check_failed": "Orca could not verify GitLab CLI authentication. Check your network or proxy settings, then re-check."
+                  "gitlab_auth_check_failed": "Orca could not verify GitLab CLI authentication. Check your network or proxy settings, then re-check.",
+                  "github_auth_check_error": "GitHub CLI returned an unexpected error. Run \"gh auth status\" in a terminal, then re-check.",
+                  "gitlab_auth_check_error": "GitLab CLI returned an unexpected error. Run \"glab auth status\" in a terminal, then re-check."
                 }
               }
             }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1045,7 +1045,9 @@
         "0d0ace8861": "Star on GitHub",
         "ec43b38ba7": "Starred on GitHub",
         "157bb5ecbb": "Open GitHub",
-        "preflightDismiss": "Dismiss"
+        "preflightDismiss": "Dismiss",
+        "github_cli_auth_check_failed": "GitHub CLI authentication could not be verified",
+        "github_cli_auth_check_failed_description": "Check your network or proxy settings, then re-check the GitHub CLI connection."
       },
       "LinearIssueMarkdownDescriptionEditor": {
         "d9c47069ef": "Markdown",
@@ -8644,7 +8646,10 @@
                   "6f30fc4216": "GitHub CLI status is not available in this runtime yet.",
                   "6b2cfb52b4": "gh",
                   "b4d900e7f1": "Pull requests, issues, and checks via the",
-                  "account_scope_prefix": "Account scope"
+                  "account_scope_prefix": "Account scope",
+                  "connection_error": "Connection error",
+                  "github_auth_check_failed": "Orca could not verify GitHub CLI authentication. Check your network or proxy settings, then re-check.",
+                  "gitlab_auth_check_failed": "Orca could not verify GitLab CLI authentication. Check your network or proxy settings, then re-check."
                 }
               }
             }

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1045,7 +1045,9 @@
         "0d0ace8861": "Dar estrella en GitHub",
         "ec43b38ba7": "Con estrella en GitHub",
         "157bb5ecbb": "Abrir GitHub",
-        "preflightDismiss": "Descartar"
+        "preflightDismiss": "Descartar",
+        "github_cli_auth_check_failed": "GitHub CLI authentication could not be verified",
+        "github_cli_auth_check_failed_description": "Check your network or proxy settings, then re-check the GitHub CLI connection."
       },
       "LinearIssueMarkdownDescriptionEditor": {
         "d9c47069ef": "Markdown",
@@ -8636,7 +8638,10 @@
                   "6f30fc4216": "El estado de la CLI de GitHub aún no está disponible en este runtime.",
                   "6b2cfb52b4": "gh",
                   "b4d900e7f1": "Pull requests, issues y checks mediante la",
-                  "account_scope_prefix": "Alcance de la cuenta"
+                  "account_scope_prefix": "Alcance de la cuenta",
+                  "connection_error": "Connection error",
+                  "github_auth_check_failed": "Orca could not verify GitHub CLI authentication. Check your network or proxy settings, then re-check.",
+                  "gitlab_auth_check_failed": "Orca could not verify GitLab CLI authentication. Check your network or proxy settings, then re-check."
                 }
               }
             }

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1046,8 +1046,11 @@
         "ec43b38ba7": "Con estrella en GitHub",
         "157bb5ecbb": "Abrir GitHub",
         "preflightDismiss": "Descartar",
-        "github_cli_auth_check_failed": "GitHub CLI authentication could not be verified",
-        "github_cli_auth_check_failed_description": "Check your network or proxy settings, then re-check the GitHub CLI connection."
+        "github_cli_auth_check_failed": "No se pudo verificar la autenticación de GitHub CLI",
+        "github_cli_auth_check_failed_description": "Comprueba la configuración de red o proxy y vuelve a verificar la conexión de GitHub CLI.",
+        "github_cli_auth_check_error": "GitHub CLI devolvió un error inesperado",
+        "github_cli_auth_check_error_description": "Ejecuta \"gh auth status\" en una terminal, corrige el error de CLI indicado y vuelve a comprobarlo.",
+        "github_cli_auth_check_error_fix_label": "Revisar estado"
       },
       "LinearIssueMarkdownDescriptionEditor": {
         "d9c47069ef": "Markdown",
@@ -8639,9 +8642,12 @@
                   "6b2cfb52b4": "gh",
                   "b4d900e7f1": "Pull requests, issues y checks mediante la",
                   "account_scope_prefix": "Alcance de la cuenta",
-                  "connection_error": "Connection error",
-                  "github_auth_check_failed": "Orca could not verify GitHub CLI authentication. Check your network or proxy settings, then re-check.",
-                  "gitlab_auth_check_failed": "Orca could not verify GitLab CLI authentication. Check your network or proxy settings, then re-check."
+                  "connection_error": "Error de conexión",
+                  "cli_error": "Error de CLI",
+                  "github_auth_check_failed": "Orca no pudo verificar la autenticación de GitHub CLI. Comprueba la configuración de red o proxy y vuelve a intentarlo.",
+                  "gitlab_auth_check_failed": "Orca no pudo verificar la autenticación de GitLab CLI. Comprueba la configuración de red o proxy y vuelve a intentarlo.",
+                  "github_auth_check_error": "GitHub CLI devolvió un error inesperado. Ejecuta \"gh auth status\" en una terminal y vuelve a comprobarlo.",
+                  "gitlab_auth_check_error": "GitLab CLI devolvió un error inesperado. Ejecuta \"glab auth status\" en una terminal y vuelve a comprobarlo."
                 }
               }
             }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1045,7 +1045,9 @@
         "0d0ace8861": "GitHub でスターを付ける",
         "ec43b38ba7": "GitHub でスター済み",
         "157bb5ecbb": "GitHub を開く",
-        "preflightDismiss": "閉じる"
+        "preflightDismiss": "閉じる",
+        "github_cli_auth_check_failed": "GitHub CLI authentication could not be verified",
+        "github_cli_auth_check_failed_description": "Check your network or proxy settings, then re-check the GitHub CLI connection."
       },
       "LinearIssueMarkdownDescriptionEditor": {
         "d9c47069ef": "Markdown",
@@ -8636,7 +8638,10 @@
                   "6f30fc4216": "GitHub CLI status is not available in this runtime yet.",
                   "6b2cfb52b4": "gh",
                   "b4d900e7f1": "PR、Issue、チェックは",
-                  "account_scope_prefix": "Account scope"
+                  "account_scope_prefix": "Account scope",
+                  "connection_error": "Connection error",
+                  "github_auth_check_failed": "Orca could not verify GitHub CLI authentication. Check your network or proxy settings, then re-check.",
+                  "gitlab_auth_check_failed": "Orca could not verify GitLab CLI authentication. Check your network or proxy settings, then re-check."
                 }
               }
             }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1046,8 +1046,11 @@
         "ec43b38ba7": "GitHub でスター済み",
         "157bb5ecbb": "GitHub を開く",
         "preflightDismiss": "閉じる",
-        "github_cli_auth_check_failed": "GitHub CLI authentication could not be verified",
-        "github_cli_auth_check_failed_description": "Check your network or proxy settings, then re-check the GitHub CLI connection."
+        "github_cli_auth_check_failed": "GitHub CLI の認証を確認できませんでした",
+        "github_cli_auth_check_failed_description": "ネットワークまたはプロキシ設定を確認してから、GitHub CLI の接続を再確認してください。",
+        "github_cli_auth_check_error": "GitHub CLI が予期しないエラーを返しました",
+        "github_cli_auth_check_error_description": "ターミナルで「gh auth status」を実行し、報告された CLI エラーを解決してから再確認してください。",
+        "github_cli_auth_check_error_fix_label": "状態を確認"
       },
       "LinearIssueMarkdownDescriptionEditor": {
         "d9c47069ef": "Markdown",
@@ -8639,9 +8642,12 @@
                   "6b2cfb52b4": "gh",
                   "b4d900e7f1": "PR、Issue、チェックは",
                   "account_scope_prefix": "Account scope",
-                  "connection_error": "Connection error",
-                  "github_auth_check_failed": "Orca could not verify GitHub CLI authentication. Check your network or proxy settings, then re-check.",
-                  "gitlab_auth_check_failed": "Orca could not verify GitLab CLI authentication. Check your network or proxy settings, then re-check."
+                  "connection_error": "接続エラー",
+                  "cli_error": "CLI エラー",
+                  "github_auth_check_failed": "Orca は GitHub CLI の認証を確認できませんでした。ネットワークまたはプロキシ設定を確認してから、再確認してください。",
+                  "gitlab_auth_check_failed": "Orca は GitLab CLI の認証を確認できませんでした。ネットワークまたはプロキシ設定を確認してから、再確認してください。",
+                  "github_auth_check_error": "GitHub CLI が予期しないエラーを返しました。ターミナルで「gh auth status」を実行してから再確認してください。",
+                  "gitlab_auth_check_error": "GitLab CLI が予期しないエラーを返しました。ターミナルで「glab auth status」を実行してから再確認してください。"
                 }
               }
             }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1045,7 +1045,9 @@
         "0d0ace8861": "GitHub에서 별표 주기",
         "ec43b38ba7": "GitHub에 별표 표시됨",
         "157bb5ecbb": "GitHub 열기",
-        "preflightDismiss": "닫기"
+        "preflightDismiss": "닫기",
+        "github_cli_auth_check_failed": "GitHub CLI authentication could not be verified",
+        "github_cli_auth_check_failed_description": "Check your network or proxy settings, then re-check the GitHub CLI connection."
       },
       "LinearIssueMarkdownDescriptionEditor": {
         "d9c47069ef": "Markdown",
@@ -8636,7 +8638,10 @@
                   "6f30fc4216": "이 런타임에서는 아직 GitHub CLI 상태를 사용할 수 없습니다.",
                   "6b2cfb52b4": "gh",
                   "b4d900e7f1": "PR, 이슈 및 검사는 다음을 통해 이루어집니다.",
-                  "account_scope_prefix": "계정 범위"
+                  "account_scope_prefix": "계정 범위",
+                  "connection_error": "Connection error",
+                  "github_auth_check_failed": "Orca could not verify GitHub CLI authentication. Check your network or proxy settings, then re-check.",
+                  "gitlab_auth_check_failed": "Orca could not verify GitLab CLI authentication. Check your network or proxy settings, then re-check."
                 }
               }
             }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1046,8 +1046,11 @@
         "ec43b38ba7": "GitHub에 별표 표시됨",
         "157bb5ecbb": "GitHub 열기",
         "preflightDismiss": "닫기",
-        "github_cli_auth_check_failed": "GitHub CLI authentication could not be verified",
-        "github_cli_auth_check_failed_description": "Check your network or proxy settings, then re-check the GitHub CLI connection."
+        "github_cli_auth_check_failed": "GitHub CLI 인증을 확인할 수 없습니다",
+        "github_cli_auth_check_failed_description": "네트워크 또는 프록시 설정을 확인한 후 GitHub CLI 연결을 다시 확인하세요.",
+        "github_cli_auth_check_error": "GitHub CLI에서 예기치 않은 오류가 발생했습니다",
+        "github_cli_auth_check_error_description": "터미널에서 \"gh auth status\"를 실행하고 보고된 CLI 오류를 해결한 후 다시 확인하세요.",
+        "github_cli_auth_check_error_fix_label": "상태 확인"
       },
       "LinearIssueMarkdownDescriptionEditor": {
         "d9c47069ef": "Markdown",
@@ -8639,9 +8642,12 @@
                   "6b2cfb52b4": "gh",
                   "b4d900e7f1": "PR, 이슈 및 검사는 다음을 통해 이루어집니다.",
                   "account_scope_prefix": "계정 범위",
-                  "connection_error": "Connection error",
-                  "github_auth_check_failed": "Orca could not verify GitHub CLI authentication. Check your network or proxy settings, then re-check.",
-                  "gitlab_auth_check_failed": "Orca could not verify GitLab CLI authentication. Check your network or proxy settings, then re-check."
+                  "connection_error": "연결 오류",
+                  "cli_error": "CLI 오류",
+                  "github_auth_check_failed": "Orca에서 GitHub CLI 인증을 확인할 수 없습니다. 네트워크 또는 프록시 설정을 확인한 후 다시 확인하세요.",
+                  "gitlab_auth_check_failed": "Orca에서 GitLab CLI 인증을 확인할 수 없습니다. 네트워크 또는 프록시 설정을 확인한 후 다시 확인하세요.",
+                  "github_auth_check_error": "GitHub CLI에서 예기치 않은 오류가 발생했습니다. 터미널에서 \"gh auth status\"를 실행한 후 다시 확인하세요.",
+                  "gitlab_auth_check_error": "GitLab CLI에서 예기치 않은 오류가 발생했습니다. 터미널에서 \"glab auth status\"를 실행한 후 다시 확인하세요."
                 }
               }
             }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1045,7 +1045,9 @@
         "0d0ace8861": "在 GitHub 上加星标",
         "ec43b38ba7": "已在 GitHub 上加星标",
         "157bb5ecbb": "打开 GitHub",
-        "preflightDismiss": "关闭"
+        "preflightDismiss": "关闭",
+        "github_cli_auth_check_failed": "GitHub CLI authentication could not be verified",
+        "github_cli_auth_check_failed_description": "Check your network or proxy settings, then re-check the GitHub CLI connection."
       },
       "LinearIssueMarkdownDescriptionEditor": {
         "d9c47069ef": "Markdown",
@@ -8636,7 +8638,10 @@
                   "6f30fc4216": "此运行时暂不支持 GitHub CLI 状态。",
                   "6b2cfb52b4": "gh",
                   "b4d900e7f1": "通过",
-                  "account_scope_prefix": "账户范围"
+                  "account_scope_prefix": "账户范围",
+                  "connection_error": "Connection error",
+                  "github_auth_check_failed": "Orca could not verify GitHub CLI authentication. Check your network or proxy settings, then re-check.",
+                  "gitlab_auth_check_failed": "Orca could not verify GitLab CLI authentication. Check your network or proxy settings, then re-check."
                 }
               }
             }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1046,8 +1046,11 @@
         "ec43b38ba7": "已在 GitHub 上加星标",
         "157bb5ecbb": "打开 GitHub",
         "preflightDismiss": "关闭",
-        "github_cli_auth_check_failed": "GitHub CLI authentication could not be verified",
-        "github_cli_auth_check_failed_description": "Check your network or proxy settings, then re-check the GitHub CLI connection."
+        "github_cli_auth_check_failed": "无法验证 GitHub CLI 身份",
+        "github_cli_auth_check_failed_description": "请检查网络或代理设置，然后重新检查 GitHub CLI 连接。",
+        "github_cli_auth_check_error": "GitHub CLI 返回了意外错误",
+        "github_cli_auth_check_error_description": "请在终端中运行“gh auth status”，解决报告的 CLI 错误后重新检查。",
+        "github_cli_auth_check_error_fix_label": "查看状态"
       },
       "LinearIssueMarkdownDescriptionEditor": {
         "d9c47069ef": "Markdown",
@@ -8639,9 +8642,12 @@
                   "6b2cfb52b4": "gh",
                   "b4d900e7f1": "通过",
                   "account_scope_prefix": "账户范围",
-                  "connection_error": "Connection error",
-                  "github_auth_check_failed": "Orca could not verify GitHub CLI authentication. Check your network or proxy settings, then re-check.",
-                  "gitlab_auth_check_failed": "Orca could not verify GitLab CLI authentication. Check your network or proxy settings, then re-check."
+                  "connection_error": "连接错误",
+                  "cli_error": "CLI 错误",
+                  "github_auth_check_failed": "Orca 无法验证 GitHub CLI 身份。请检查网络或代理设置，然后重新检查。",
+                  "gitlab_auth_check_failed": "Orca 无法验证 GitLab CLI 身份。请检查网络或代理设置，然后重新检查。",
+                  "github_auth_check_error": "GitHub CLI 返回了意外错误。请在终端中运行“gh auth status”，然后重新检查。",
+                  "gitlab_auth_check_error": "GitLab CLI 返回了意外错误。请在终端中运行“glab auth status”，然后重新检查。"
                 }
               }
             }

--- a/src/renderer/src/i18n/preflight-cli-auth-locales.test.ts
+++ b/src/renderer/src/i18n/preflight-cli-auth-locales.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import en from './locales/en.json'
+import es from './locales/es.json'
+import ja from './locales/ja.json'
+import ko from './locales/ko.json'
+import zh from './locales/zh.json'
+
+const englishPreflightAuthCopy = [
+  en.auto.components.Landing.github_cli_auth_check_failed,
+  en.auto.components.Landing.github_cli_auth_check_failed_description,
+  en.auto.components.Landing.github_cli_auth_check_error,
+  en.auto.components.Landing.github_cli_auth_check_error_description,
+  en.auto.components.Landing.github_cli_auth_check_error_fix_label,
+  en.auto.components.settings.cli.source.control.integration.cards.connection_error,
+  en.auto.components.settings.cli.source.control.integration.cards.cli_error,
+  en.auto.components.settings.cli.source.control.integration.cards.github_auth_check_failed,
+  en.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_failed,
+  en.auto.components.settings.cli.source.control.integration.cards.github_auth_check_error,
+  en.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_error
+]
+
+const localizedPreflightAuthCopy = [
+  [
+    es.auto.components.Landing.github_cli_auth_check_failed,
+    es.auto.components.Landing.github_cli_auth_check_failed_description,
+    es.auto.components.Landing.github_cli_auth_check_error,
+    es.auto.components.Landing.github_cli_auth_check_error_description,
+    es.auto.components.Landing.github_cli_auth_check_error_fix_label,
+    es.auto.components.settings.cli.source.control.integration.cards.connection_error,
+    es.auto.components.settings.cli.source.control.integration.cards.cli_error,
+    es.auto.components.settings.cli.source.control.integration.cards.github_auth_check_failed,
+    es.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_failed,
+    es.auto.components.settings.cli.source.control.integration.cards.github_auth_check_error,
+    es.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_error
+  ],
+  [
+    ja.auto.components.Landing.github_cli_auth_check_failed,
+    ja.auto.components.Landing.github_cli_auth_check_failed_description,
+    ja.auto.components.Landing.github_cli_auth_check_error,
+    ja.auto.components.Landing.github_cli_auth_check_error_description,
+    ja.auto.components.Landing.github_cli_auth_check_error_fix_label,
+    ja.auto.components.settings.cli.source.control.integration.cards.connection_error,
+    ja.auto.components.settings.cli.source.control.integration.cards.cli_error,
+    ja.auto.components.settings.cli.source.control.integration.cards.github_auth_check_failed,
+    ja.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_failed,
+    ja.auto.components.settings.cli.source.control.integration.cards.github_auth_check_error,
+    ja.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_error
+  ],
+  [
+    ko.auto.components.Landing.github_cli_auth_check_failed,
+    ko.auto.components.Landing.github_cli_auth_check_failed_description,
+    ko.auto.components.Landing.github_cli_auth_check_error,
+    ko.auto.components.Landing.github_cli_auth_check_error_description,
+    ko.auto.components.Landing.github_cli_auth_check_error_fix_label,
+    ko.auto.components.settings.cli.source.control.integration.cards.connection_error,
+    ko.auto.components.settings.cli.source.control.integration.cards.cli_error,
+    ko.auto.components.settings.cli.source.control.integration.cards.github_auth_check_failed,
+    ko.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_failed,
+    ko.auto.components.settings.cli.source.control.integration.cards.github_auth_check_error,
+    ko.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_error
+  ],
+  [
+    zh.auto.components.Landing.github_cli_auth_check_failed,
+    zh.auto.components.Landing.github_cli_auth_check_failed_description,
+    zh.auto.components.Landing.github_cli_auth_check_error,
+    zh.auto.components.Landing.github_cli_auth_check_error_description,
+    zh.auto.components.Landing.github_cli_auth_check_error_fix_label,
+    zh.auto.components.settings.cli.source.control.integration.cards.connection_error,
+    zh.auto.components.settings.cli.source.control.integration.cards.cli_error,
+    zh.auto.components.settings.cli.source.control.integration.cards.github_auth_check_failed,
+    zh.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_failed,
+    zh.auto.components.settings.cli.source.control.integration.cards.github_auth_check_error,
+    zh.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_error
+  ]
+]
+
+describe('preflight CLI authentication translations', () => {
+  it('does not ship English fallback copy in non-English locales', () => {
+    for (const localizedCopy of localizedPreflightAuthCopy) {
+      localizedCopy.forEach((value, index) => {
+        expect(value).not.toBe(englishPreflightAuthCopy[index])
+      })
+    }
+  })
+})

--- a/src/renderer/src/i18n/preflight-cli-auth-locales.test.ts
+++ b/src/renderer/src/i18n/preflight-cli-auth-locales.test.ts
@@ -5,74 +5,30 @@ import ja from './locales/ja.json'
 import ko from './locales/ko.json'
 import zh from './locales/zh.json'
 
-const englishPreflightAuthCopy = [
-  en.auto.components.Landing.github_cli_auth_check_failed,
-  en.auto.components.Landing.github_cli_auth_check_failed_description,
-  en.auto.components.Landing.github_cli_auth_check_error,
-  en.auto.components.Landing.github_cli_auth_check_error_description,
-  en.auto.components.Landing.github_cli_auth_check_error_fix_label,
-  en.auto.components.settings.cli.source.control.integration.cards.connection_error,
-  en.auto.components.settings.cli.source.control.integration.cards.cli_error,
-  en.auto.components.settings.cli.source.control.integration.cards.github_auth_check_failed,
-  en.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_failed,
-  en.auto.components.settings.cli.source.control.integration.cards.github_auth_check_error,
-  en.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_error
-]
-
-const localizedPreflightAuthCopy = [
-  [
-    es.auto.components.Landing.github_cli_auth_check_failed,
-    es.auto.components.Landing.github_cli_auth_check_failed_description,
-    es.auto.components.Landing.github_cli_auth_check_error,
-    es.auto.components.Landing.github_cli_auth_check_error_description,
-    es.auto.components.Landing.github_cli_auth_check_error_fix_label,
-    es.auto.components.settings.cli.source.control.integration.cards.connection_error,
-    es.auto.components.settings.cli.source.control.integration.cards.cli_error,
-    es.auto.components.settings.cli.source.control.integration.cards.github_auth_check_failed,
-    es.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_failed,
-    es.auto.components.settings.cli.source.control.integration.cards.github_auth_check_error,
-    es.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_error
-  ],
-  [
-    ja.auto.components.Landing.github_cli_auth_check_failed,
-    ja.auto.components.Landing.github_cli_auth_check_failed_description,
-    ja.auto.components.Landing.github_cli_auth_check_error,
-    ja.auto.components.Landing.github_cli_auth_check_error_description,
-    ja.auto.components.Landing.github_cli_auth_check_error_fix_label,
-    ja.auto.components.settings.cli.source.control.integration.cards.connection_error,
-    ja.auto.components.settings.cli.source.control.integration.cards.cli_error,
-    ja.auto.components.settings.cli.source.control.integration.cards.github_auth_check_failed,
-    ja.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_failed,
-    ja.auto.components.settings.cli.source.control.integration.cards.github_auth_check_error,
-    ja.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_error
-  ],
-  [
-    ko.auto.components.Landing.github_cli_auth_check_failed,
-    ko.auto.components.Landing.github_cli_auth_check_failed_description,
-    ko.auto.components.Landing.github_cli_auth_check_error,
-    ko.auto.components.Landing.github_cli_auth_check_error_description,
-    ko.auto.components.Landing.github_cli_auth_check_error_fix_label,
-    ko.auto.components.settings.cli.source.control.integration.cards.connection_error,
-    ko.auto.components.settings.cli.source.control.integration.cards.cli_error,
-    ko.auto.components.settings.cli.source.control.integration.cards.github_auth_check_failed,
-    ko.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_failed,
-    ko.auto.components.settings.cli.source.control.integration.cards.github_auth_check_error,
-    ko.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_error
-  ],
-  [
-    zh.auto.components.Landing.github_cli_auth_check_failed,
-    zh.auto.components.Landing.github_cli_auth_check_failed_description,
-    zh.auto.components.Landing.github_cli_auth_check_error,
-    zh.auto.components.Landing.github_cli_auth_check_error_description,
-    zh.auto.components.Landing.github_cli_auth_check_error_fix_label,
-    zh.auto.components.settings.cli.source.control.integration.cards.connection_error,
-    zh.auto.components.settings.cli.source.control.integration.cards.cli_error,
-    zh.auto.components.settings.cli.source.control.integration.cards.github_auth_check_failed,
-    zh.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_failed,
-    zh.auto.components.settings.cli.source.control.integration.cards.github_auth_check_error,
-    zh.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_error
+/**
+ * Select the authentication copy that every locale must translate independently.
+ *
+ * @param locale Locale catalog with the English catalog shape.
+ * @returns Authentication-related landing and integration-card messages.
+ */
+function getPreflightAuthCopy(locale: typeof en): string[] {
+  return [
+    locale.auto.components.Landing.github_cli_auth_check_failed,
+    locale.auto.components.Landing.github_cli_auth_check_failed_description,
+    locale.auto.components.Landing.github_cli_auth_check_error,
+    locale.auto.components.Landing.github_cli_auth_check_error_description,
+    locale.auto.components.Landing.github_cli_auth_check_error_fix_label,
+    locale.auto.components.settings.cli.source.control.integration.cards.connection_error,
+    locale.auto.components.settings.cli.source.control.integration.cards.cli_error,
+    locale.auto.components.settings.cli.source.control.integration.cards.github_auth_check_failed,
+    locale.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_failed,
+    locale.auto.components.settings.cli.source.control.integration.cards.github_auth_check_error,
+    locale.auto.components.settings.cli.source.control.integration.cards.gitlab_auth_check_error
   ]
-]
+}
+
+const englishPreflightAuthCopy = getPreflightAuthCopy(en)
+const localizedPreflightAuthCopy = [es, ja, ko, zh].map(getPreflightAuthCopy)
 
 describe('preflight CLI authentication translations', () => {
   it('does not ship English fallback copy in non-English locales', () => {

--- a/src/shared/cli-auth-status.ts
+++ b/src/shared/cli-auth-status.ts
@@ -1,0 +1,8 @@
+export type CliAuthState = 'authenticated' | 'unauthenticated' | 'timeout' | 'unreachable' | 'error'
+
+export type CliAuthStatus = {
+  installed: boolean
+  authenticated: boolean
+  /** Optional so renderer/preload compatibility survives mixed app/runtime versions. */
+  authState?: CliAuthState
+}

--- a/src/shared/network-proxy.ts
+++ b/src/shared/network-proxy.ts
@@ -10,7 +10,7 @@ export type ProxyUrlValidationResult =
 const PROXY_URL_MAX_LENGTH = 2048
 const PROXY_BYPASS_RULES_MAX_LENGTH = 4096
 const PROXY_PROTOCOLS = new Set(['http:', 'https:', 'socks:', 'socks4:', 'socks5:'])
-const PROXY_ENV_KEYS = [
+export const NETWORK_PROXY_URL_ENV_KEYS = [
   'HTTPS_PROXY',
   'https_proxy',
   'ALL_PROXY',
@@ -18,7 +18,11 @@ const PROXY_ENV_KEYS = [
   'HTTP_PROXY',
   'http_proxy'
 ] as const
-const NO_PROXY_ENV_KEYS = ['NO_PROXY', 'no_proxy'] as const
+export const NETWORK_PROXY_BYPASS_ENV_KEYS = ['NO_PROXY', 'no_proxy'] as const
+export const NETWORK_PROXY_ENV_KEYS = [
+  ...NETWORK_PROXY_URL_ENV_KEYS,
+  ...NETWORK_PROXY_BYPASS_ENV_KEYS
+] as const
 
 function formatProxyUrl(url: URL): string {
   const auth =
@@ -72,7 +76,7 @@ export function normalizeProxyBypassRules(value: unknown): string {
 export function getProxyUrlFromEnvironment(
   env: Record<string, string | undefined>
 ): ProxyUrlValidationResult {
-  for (const key of PROXY_ENV_KEYS) {
+  for (const key of NETWORK_PROXY_URL_ENV_KEYS) {
     if (env[key]) {
       return normalizeProxyUrl(env[key])
     }
@@ -83,7 +87,7 @@ export function getProxyUrlFromEnvironment(
 export function getProxyBypassRulesFromEnvironment(
   env: Record<string, string | undefined>
 ): string {
-  for (const key of NO_PROXY_ENV_KEYS) {
+  for (const key of NETWORK_PROXY_BYPASS_ENV_KEYS) {
     if (env[key]) {
       return normalizeProxyBypassRules(env[key])
     }


### PR DESCRIPTION
## Summary

- pass Orca's persisted and login-shell proxy environment to local `gh` / `glab` preflight and runner calls
- distinguish confirmed logout from timeout, unreachable, and unknown authentication checks
- show connection/proxy guidance instead of `gh auth login` for non-authentication failures
- refresh login-shell PATH/proxy state on an explicit re-check without allowing stale concurrent probes to overwrite the result

## Screenshots

No visual layout change. The affected UI only changes status labels and guidance copy; renderer unit tests cover the distinct unauthenticated, connection-error, and CLI-error states.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the native-runtime precheck cannot load the patched `node-pty` dependency in this fresh worktree; affected non-native suites were run directly with the repository Vitest config under Node 24
- [ ] `pnpm build` — not run; no packaging or build-pipeline code changed
- [x] Added or updated high-quality regression tests

Validation evidence:

- 12 affected Vitest files: 273 tests passed
- post-review focused run: 5 files, 69 tests passed
- full typecheck passed for node, CLI, and renderer configs
- full lint, switch exhaustiveness, reliability, max-lines, and localization gates passed
- `oxfmt --check` and `git diff --check` passed

## AI Review Report

The AI review challenged the failure classification, shell hydration ordering, force-refresh concurrency, renderer state mapping, locale parity, and the CodeRabbit follow-up comments.

- macOS/Linux: verified GUI-launched local probes wait for login-shell PATH/proxy hydration; explicit refresh performs one fresh hydration.
- Windows: verified native Windows skips POSIX shell hydration and preserves persisted Windows PATH behavior.
- WSL/SSH/local: verified host proxy hydration is not injected into WSL or SSH execution; WSL probes remain scoped to the selected distro, while local `gh`/`glab` share the local CLI environment.
- Integrations: verified both GitHub and GitLab distinguish unauthenticated, timeout/unreachable, and generic CLI errors; token-based providers are unchanged.
- Performance: force refresh uses single-flight hydration and cache generations so concurrent requests neither spawn redundant shells nor let stale results overwrite fresh results.
- UI/localization: verified landing and integration cards show provider-appropriate guidance and all five locale catalogs remain structurally aligned without English fallback copy in non-English locales.
- Review findings addressed: reused the shared `CliAuthStatus` contract, de-duplicated locale key selection, and documented the shell/command boundary functions. The reported duplicate `resolveStaleGhAuth` declaration was checked in both local and remote source and is not present.

## Security Audit

- Proxy input remains limited to the existing allowlisted HTTP(S)/SOCKS settings and standard proxy environment keys.
- Persisted Orca proxy settings are applied last and therefore remain authoritative; proxy URLs are normalized and redacted before diagnostic use.
- Authentication probes do not request or log tokens. Structured `gh auth status` reads host/account state only.
- Local subprocesses use `execFile` with literal argv boundaries; WSL command arguments are explicitly shell-quoted.
- Host proxy values are not forwarded into WSL or SSH runtimes, avoiding host/remote trust-boundary leakage.
- No new dependencies, filesystem writes, IPC mutation surface, or secret persistence were introduced.

## Notes

- The standard `pnpm test` wrapper remains blocked in this worktree by the unavailable patched `node-pty` build; direct Vitest evidence does not cover native PTY or Electron E2E behavior.
- GitHub and GitLab are the only provider integrations changed.
- X handle: N/A.

Fixes #9241

## ELI5

GitHub CLI preflight ignored Orca's proxy settings and treated timeouts like not logged in. Proxy env is passed through, and failures show connection guidance instead of always saying run gh auth login.
