### PR TITLE
fix(mobile): harden WebSocket accept path against socket overload

### DIFF
--- a/src/main/runtime/rpc/ws-transport.test.ts
+++ b/src/main/runtime/rpc/ws-transport.test.ts
@@ -327,51 +327,22 @@ describe('WebSocketTransport', () => {
     liveClient.close()
   })
 
-  it('bounds TCP-level sockets so a leak cannot wedge the accept loop', async () => {
-    // Why: the :6768 accept-wedge — unbounded sockets exhausted the FD budget,
-    // accept() started failing with EMFILE, and new SYNs stalled in SYN_RCVD
-    // with zero ESTABLISHED and no self-heal. A TCP-level maxConnections makes
-    // Node accept-then-close past the cap so the listener never stops draining.
+  it('bounds raw TCP sockets above the WebSocket connection budget', async () => {
+    // Why: the WebSocket cap applies only after upgrade, so raw sockets need a
+    // finite independent bound without reducing the 128 legitimate WS slots.
     const { transport } = await createTransport()
     await transport.start()
 
     const httpServer = (transport as unknown as { httpServer: { maxConnections: number } })
       .httpServer
-    expect(httpServer.maxConnections).toBeGreaterThan(128)
-    expect(Number.isFinite(httpServer.maxConnections)).toBe(true)
-  })
-
-  it('keeps listening after an accept-level error and still accepts new clients', async () => {
-    // Why: an EMFILE/ENFILE from accept() surfaces as an 'error' on the http
-    // server, which `ws` forwards onto the WebSocketServer. Without a listener
-    // Node rethrows it as an uncaught exception that can silently kill the
-    // transport. The handler must swallow it and leave the listener able to
-    // accept the next connection.
-    const { transport } = await createTransport((msg, reply) => {
-      const request = JSON.parse(msg)
-      reply(JSON.stringify({ id: request.id, ok: true }))
-    })
-    await transport.start()
-
-    const httpServer = (
-      transport as unknown as { httpServer: { emit: (event: string, err: Error) => void } }
-    ).httpServer
-    // Why: emit on the http server (not wss) to exercise the real forwarding
-    // path — libuv raises accept errors on the underlying net server.
-    expect(() =>
-      httpServer.emit('error', Object.assign(new Error('accept EMFILE'), { code: 'EMFILE' }))
-    ).not.toThrow()
-
-    const ws = await connectWs(transport)
-    const response = await sendAndReceive(ws, JSON.stringify({ id: 'after-error', method: 'test' }))
-    expect(JSON.parse(response)).toMatchObject({ id: 'after-error', ok: true })
-    ws.close()
+    expect(httpServer.maxConnections).toBe(256)
   })
 
   it('force-terminates an over-capacity socket that ignores the close frame', async () => {
     // Why: a backgrounded/half-open phone may never ack the 1013 close, so a
-    // bare ws.close() would leave the socket in wss.clients at >cap forever and
-    // permanently reject everyone after it. rejectOverCapacity must hard-close.
+    // bare ws.close() retains its descriptor until the heartbeat. A reconnect
+    // flood can fill the TCP headroom during that window, so rejection must
+    // hard-close on a short fixed deadline.
     const { transport } = await createTransport()
     await transport.start()
 

--- a/src/main/runtime/rpc/ws-transport.test.ts
+++ b/src/main/runtime/rpc/ws-transport.test.ts
@@ -327,6 +327,75 @@ describe('WebSocketTransport', () => {
     liveClient.close()
   })
 
+  it('bounds TCP-level sockets so a leak cannot wedge the accept loop', async () => {
+    // Why: the :6768 accept-wedge — unbounded sockets exhausted the FD budget,
+    // accept() started failing with EMFILE, and new SYNs stalled in SYN_RCVD
+    // with zero ESTABLISHED and no self-heal. A TCP-level maxConnections makes
+    // Node accept-then-close past the cap so the listener never stops draining.
+    const { transport } = await createTransport()
+    await transport.start()
+
+    const httpServer = (transport as unknown as { httpServer: { maxConnections: number } })
+      .httpServer
+    expect(httpServer.maxConnections).toBeGreaterThan(128)
+    expect(Number.isFinite(httpServer.maxConnections)).toBe(true)
+  })
+
+  it('keeps listening after an accept-level error and still accepts new clients', async () => {
+    // Why: an EMFILE/ENFILE from accept() surfaces as an 'error' on the http
+    // server, which `ws` forwards onto the WebSocketServer. Without a listener
+    // Node rethrows it as an uncaught exception that can silently kill the
+    // transport. The handler must swallow it and leave the listener able to
+    // accept the next connection.
+    const { transport } = await createTransport((msg, reply) => {
+      const request = JSON.parse(msg)
+      reply(JSON.stringify({ id: request.id, ok: true }))
+    })
+    await transport.start()
+
+    const httpServer = (
+      transport as unknown as { httpServer: { emit: (event: string, err: Error) => void } }
+    ).httpServer
+    // Why: emit on the http server (not wss) to exercise the real forwarding
+    // path — libuv raises accept errors on the underlying net server.
+    expect(() =>
+      httpServer.emit('error', Object.assign(new Error('accept EMFILE'), { code: 'EMFILE' }))
+    ).not.toThrow()
+
+    const ws = await connectWs(transport)
+    const response = await sendAndReceive(ws, JSON.stringify({ id: 'after-error', method: 'test' }))
+    expect(JSON.parse(response)).toMatchObject({ id: 'after-error', ok: true })
+    ws.close()
+  })
+
+  it('force-terminates an over-capacity socket that ignores the close frame', async () => {
+    // Why: a backgrounded/half-open phone may never ack the 1013 close, so a
+    // bare ws.close() would leave the socket in wss.clients at >cap forever and
+    // permanently reject everyone after it. rejectOverCapacity must hard-close.
+    const { transport } = await createTransport()
+    await transport.start()
+
+    const ws = await connectWs(transport)
+    const wss = (transport as unknown as { wss: { clients: Set<WebSocket> } }).wss
+    const serverSocket = Array.from(wss.clients)[0]
+    expect(serverSocket).toBeDefined()
+    const terminateSpy = vi.spyOn(serverSocket!, 'terminate')
+
+    vi.useFakeTimers()
+    try {
+      ;(transport as unknown as { rejectOverCapacity(ws: WebSocket): void }).rejectOverCapacity(
+        serverSocket!
+      )
+      vi.advanceTimersByTime(1_000)
+    } finally {
+      vi.useRealTimers()
+    }
+
+    expect(terminateSpy).toHaveBeenCalled()
+    terminateSpy.mockRestore()
+    ws.close()
+  })
+
   it('is idempotent on double start', async () => {
     const { transport } = await createTransport()
 

--- a/src/main/runtime/rpc/ws-transport.ts
+++ b/src/main/runtime/rpc/ws-transport.ts
@@ -14,6 +14,15 @@ const MAX_WS_MESSAGE_BYTES = 1024 * 1024
 // streams (session tabs, terminals, file watches, browser streams). Keep the
 // cap high enough that leaked/stale streams do not starve short control RPCs.
 const MAX_WS_CONNECTIONS = 128
+// Why: hard bound on TCP-level sockets, set ABOVE the WS-upgrade cap so it only
+// bites under a genuine leak/abuse. When the http server is at this cap Node
+// accepts-then-immediately-closes each new socket, so the accept loop KEEPS
+// DRAINING — the listener can never stall with SYNs stuck in SYN_RCVD the way
+// an unbounded server does once leaked/half-open sockets exhaust the process
+// file-descriptor budget (EMFILE). The WS-upgrade cap alone runs only after a
+// socket is already accepted, so it cannot prevent that FD wedge. See the
+// :6768 accept-wedge post-mortem.
+const MAX_TCP_CONNECTIONS = MAX_WS_CONNECTIONS * 2
 const PRE_AUTH_TIMEOUT_MS = 10_000
 type WebSocketMessagePayload = string | Uint8Array<ArrayBufferLike>
 type WebSocketMessageHandler = {
@@ -224,14 +233,28 @@ export class WebSocketTransport implements RpcTransport {
       })
     })
 
+    // Why: bound TCP-level sockets so a leak/flood cannot exhaust the process
+    // FD budget and stall accept() with EMFILE (the :6768 accept-wedge: SYNs
+    // pile up in SYN_RCVD, zero ESTABLISHED, even localhost times out, no
+    // self-heal). At this cap Node accepts-then-closes new sockets, keeping the
+    // accept loop draining instead of silently wedging.
+    httpServer.maxConnections = MAX_TCP_CONNECTIONS
+
     const wss = new WebSocketServer({
       server: httpServer,
       maxPayload: MAX_WS_MESSAGE_BYTES
     })
 
+    // Why: an accept()-level failure (EMFILE/ENFILE) is emitted as 'error' on
+    // the http server, which `ws` forwards onto the WebSocketServer. With no
+    // listener Node rethrows it as an uncaught exception that can silently tear
+    // the transport down. Log and keep listening so the accept path is
+    // observable and recovers as descriptors free up.
+    wss.on('error', (error) => console.warn('[ws-transport] listener error on accept path:', error))
+
     wss.on('connection', (ws) => {
       if (wss.clients.size > MAX_WS_CONNECTIONS) {
-        ws.close(1013, 'Maximum connections reached')
+        this.rejectOverCapacity(ws)
         return
       }
       this.handleConnection(ws)
@@ -240,6 +263,22 @@ export class WebSocketTransport implements RpcTransport {
     this.httpServer = httpServer
     this.wss = wss
     this.startHeartbeat()
+  }
+
+  // Why: over the WS-upgrade cap, request a graceful 1013 close but force the
+  // socket down shortly after. A backgrounded/half-open phone may never ack the
+  // close frame, so a bare ws.close() would leave the socket in wss.clients (and
+  // holding a descriptor) at >cap forever, permanently rejecting every client
+  // after it. The 'error' listener keeps an ECONNRESET-while-closing from
+  // surfacing as an unhandled 'error' event (which would throw).
+  private rejectOverCapacity(ws: WebSocket): void {
+    ws.on('error', () => {})
+    ws.close(1013, 'Maximum connections reached')
+    // Why: give the 1013 close a brief window, then hard-terminate so the
+    // descriptor is freed even if the client never acks the close frame.
+    const terminateTimer = setTimeout(() => ws.terminate(), 1_000)
+    terminateTimer.unref?.()
+    ws.once('close', () => clearTimeout(terminateTimer))
   }
 
   // Why: ping every live socket on a fixed cadence and terminate any that
@@ -255,12 +294,14 @@ export class WebSocketTransport implements RpcTransport {
       if (!wss) {
         return
       }
+      let reaped = 0
       for (const ws of wss.clients) {
         if (!this.wsAlive.has(ws)) {
           // Why: terminate() (vs close()) skips the close handshake and
           // immediately fires the 'close' event, freeing the slot. close()
           // on an already-dead socket can hang for the OS-level TCP timeout.
           ws.terminate()
+          reaped++
           continue
         }
         this.wsAlive.delete(ws)
@@ -270,6 +311,12 @@ export class WebSocketTransport implements RpcTransport {
           // Why: ping() can throw on a socket that's mid-tear-down; the
           // close handler will run regardless, so swallow the throw.
         }
+      }
+      // Why: make the accept path observable. Steady reaping or a client count
+      // riding the cap are the early signs of the half-open-socket leak that
+      // used to wedge :6768 silently — surface them instead of failing dark.
+      if (reaped > 0 || wss.clients.size >= MAX_WS_CONNECTIONS) {
+        console.warn(`[ws-transport] heartbeat reaped ${reaped}; ${wss.clients.size} live sockets`)
       }
     }, this.heartbeatIntervalMs)
     if (typeof this.heartbeatTimer.unref === 'function') {

--- a/src/main/runtime/rpc/ws-transport.ts
+++ b/src/main/runtime/rpc/ws-transport.ts
@@ -14,14 +14,10 @@ const MAX_WS_MESSAGE_BYTES = 1024 * 1024
 // streams (session tabs, terminals, file watches, browser streams). Keep the
 // cap high enough that leaked/stale streams do not starve short control RPCs.
 const MAX_WS_CONNECTIONS = 128
-// Why: hard bound on TCP-level sockets, set ABOVE the WS-upgrade cap so it only
-// bites under a genuine leak/abuse. When the http server is at this cap Node
-// accepts-then-immediately-closes each new socket, so the accept loop KEEPS
-// DRAINING — the listener can never stall with SYNs stuck in SYN_RCVD the way
-// an unbounded server does once leaked/half-open sockets exhaust the process
-// file-descriptor budget (EMFILE). The WS-upgrade cap alone runs only after a
-// socket is already accepted, so it cannot prevent that FD wedge. See the
-// :6768 accept-wedge post-mortem.
+// Why: hard-bound this listener's descriptor use above the WS-upgrade cap.
+// Node accepts then drops sockets beyond maxConnections, so raw/pre-upgrade
+// clients cannot grow without bound while the existing WS budget remains
+// available to legitimate long-lived streams.
 const MAX_TCP_CONNECTIONS = MAX_WS_CONNECTIONS * 2
 const PRE_AUTH_TIMEOUT_MS = 10_000
 type WebSocketMessagePayload = string | Uint8Array<ArrayBufferLike>
@@ -233,24 +229,14 @@ export class WebSocketTransport implements RpcTransport {
       })
     })
 
-    // Why: bound TCP-level sockets so a leak/flood cannot exhaust the process
-    // FD budget and stall accept() with EMFILE (the :6768 accept-wedge: SYNs
-    // pile up in SYN_RCVD, zero ESTABLISHED, even localhost times out, no
-    // self-heal). At this cap Node accepts-then-closes new sockets, keeping the
-    // accept loop draining instead of silently wedging.
+    // Why: the WS cap applies only after upgrade. A separate TCP cap prevents
+    // raw and pre-upgrade sockets from consuming an unbounded descriptor budget.
     httpServer.maxConnections = MAX_TCP_CONNECTIONS
 
     const wss = new WebSocketServer({
       server: httpServer,
       maxPayload: MAX_WS_MESSAGE_BYTES
     })
-
-    // Why: an accept()-level failure (EMFILE/ENFILE) is emitted as 'error' on
-    // the http server, which `ws` forwards onto the WebSocketServer. With no
-    // listener Node rethrows it as an uncaught exception that can silently tear
-    // the transport down. Log and keep listening so the accept path is
-    // observable and recovers as descriptors free up.
-    wss.on('error', (error) => console.warn('[ws-transport] listener error on accept path:', error))
 
     wss.on('connection', (ws) => {
       if (wss.clients.size > MAX_WS_CONNECTIONS) {
@@ -267,10 +253,10 @@ export class WebSocketTransport implements RpcTransport {
 
   // Why: over the WS-upgrade cap, request a graceful 1013 close but force the
   // socket down shortly after. A backgrounded/half-open phone may never ack the
-  // close frame, so a bare ws.close() would leave the socket in wss.clients (and
-  // holding a descriptor) at >cap forever, permanently rejecting every client
-  // after it. The 'error' listener keeps an ECONNRESET-while-closing from
-  // surfacing as an unhandled 'error' event (which would throw).
+  // close frame, so a bare ws.close() can retain the descriptor until the next
+  // heartbeat. Under a reconnect flood, shortening that window bounds the
+  // number of rejected sockets that can accumulate behind the WS cap. The
+  // 'error' listener prevents a reset while closing from becoming unhandled.
   private rejectOverCapacity(ws: WebSocket): void {
     ws.on('error', () => {})
     ws.close(1013, 'Maximum connections reached')
@@ -312,11 +298,12 @@ export class WebSocketTransport implements RpcTransport {
           // close handler will run regardless, so swallow the throw.
         }
       }
-      // Why: make the accept path observable. Steady reaping or a client count
-      // riding the cap are the early signs of the half-open-socket leak that
-      // used to wedge :6768 silently — surface them instead of failing dark.
+      // Why: steady reaping or a client count riding the cap are early overload
+      // signals; surface them without logging on healthy heartbeat ticks.
       if (reaped > 0 || wss.clients.size >= MAX_WS_CONNECTIONS) {
-        console.warn(`[ws-transport] heartbeat reaped ${reaped}; ${wss.clients.size} live sockets`)
+        console.warn(
+          `[ws-transport] heartbeat reaped ${reaped}; ${wss.clients.size} tracked sockets`
+        )
       }
     }, this.heartbeatIntervalMs)
     if (typeof this.heartbeatTimer.unref === 'function') {


### PR DESCRIPTION
## Summary

The desktop mobile WebSocket listener could remain in `LISTEN` while new TCP handshakes stopped completing, disconnecting the persistent channel used for mobile RPC and notifications.

This change hardens the listener against connection accumulation:

- Caps all TCP sockets at 256, above the 128 upgraded-WebSocket budget, so raw and pre-upgrade clients cannot consume descriptors without bound.
- Gives upgraded sockets over the WebSocket cap a `1013` close, then force-terminates them after one second so reconnect floods cannot retain rejected sockets until the next 15-second heartbeat.
- Logs heartbeat reaping and capacity pressure without adding work to normal RPC message handling.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — changed files pass; the repository-wide command reaches two unrelated existing switch-exhaustiveness errors in `native-chat-session-option-labels.ts` and `skill-freshness-group.tsx`.
- [x] `pnpm typecheck`
- [ ] `pnpm test` — focused transport and full runtime RPC suites were run instead.
- [ ] `pnpm build` — not needed for this isolated main-process transport change.
- [x] Added or updated high-quality tests that would catch regressions.

Executed locally:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/ws-transport.test.ts` — 26/26 passed.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc` — 652/652 passed.
- `pnpm run typecheck` — passed across node, CLI, and web targets.
- Changed-file oxlint, diff check, and max-lines ratchet — passed.

## AI Review Report

Reviewed the connection lifecycle, raw TCP admission, WebSocket upgrade cap, pre-auth timeout, heartbeat, over-capacity rejection, shutdown, and timer/error cleanup paths. The review also checked message-path and heartbeat costs, reconnect-flood behavior, and the Node/`ws`/libuv behavior behind the proposed recovery claims.

The review found and removed an unsafe accept-error handler: on Windows, a real libuv accept failure can stop the listener, so swallowing the forwarded error would mask a fatal listener state without restarting it. The accompanying test only emitted a synthetic event and did not exercise a stopped acceptor. The remaining tests now assert the exact TCP budget and the one-second forced-termination deadline.

Cross-platform behavior was checked for macOS/Linux libuv descriptor-exhaustion handling and Windows AcceptEx failure semantics. This PR does not touch shortcuts, labels, paths, shell behavior, SSH routing, or Git behavior.

## Security Audit

The change reduces denial-of-service exposure by bounding unauthenticated raw/pre-upgrade connections. The existing 1 MiB WebSocket payload cap, ten-second pre-auth timeout, per-device authentication, and E2EE wiring are unchanged. No new input parsing, command execution, path handling, IPC surface, secrets, or dependencies are introduced.

## Notes

The production evidence conclusively showed a stalled accept path (`SYN_RCVD`, zero `ESTABLISHED`, including localhost), but did not capture the exact kernel/libuv trigger or prove `EMFILE`. This PR is a bounded-resource mitigation for the concrete connection-accumulation failure mode; it intentionally does not claim a generic listener restart or make all process-wide descriptor exhaustion impossible.

Client endpoint advancement, relay egress fallback, and richer active-path diagnostics remain separate follow-ups.
