### PR TITLE
fix(updater): humanize update-error card and hide raw error behind Show details

### DIFF
--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -1170,6 +1170,54 @@ describe('updater', () => {
     )
   })
 
+  it('surfaces an accepted retry before electron-updater emits download progress', async () => {
+    fetchNewerReleaseTagsMock.mockResolvedValue({ tags: ['v1.0.61'], state: 'ready' })
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => {
+        autoUpdaterMock.emit('update-available', { version: '1.0.61' })
+      })
+      return Promise.resolve(undefined)
+    })
+    autoUpdaterMock.downloadUpdate
+      .mockRejectedValueOnce(new Error('signature check blocked'))
+      .mockImplementationOnce(() => new Promise(() => {}))
+    const sendMock = vi.fn()
+    const mainWindow = { webContents: { send: sendMock } }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu, downloadUpdate } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    checkForUpdatesFromMenu()
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'available',
+        version: '1.0.61',
+        changelog: null
+      })
+    })
+
+    downloadUpdate()
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('updater:status', {
+        state: 'error',
+        message: 'signature check blocked'
+      })
+    })
+
+    sendMock.mockClear()
+    downloadUpdate()
+
+    expect(sendMock).toHaveBeenCalledWith('updater:status', {
+      state: 'downloading',
+      percent: 0,
+      version: '1.0.61'
+    })
+
+    downloadUpdate()
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledTimes(2)
+  })
+
   it('defers quitAndInstall through the shared main-process entrypoint', async () => {
     vi.useFakeTimers()
 

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -118,9 +118,8 @@ let _getPendingUpdateNudgeId: (() => string | null) | null = null
 let _getDismissedUpdateNudgeId: (() => string | null) | null = null
 let _setPendingUpdateNudgeId: ((id: string | null) => void) | null = null
 let _setDismissedUpdateNudgeId: ((id: string | null) => void) | null = null
-// Why: guards against duplicate download() calls when both the card and
-// Settings trigger a download before the first download-progress event
-// flips the status to 'downloading'.
+// Why: guards against duplicate download() calls while an accepted request
+// transitions the authoritative status to 'downloading'.
 let downloadInFlight = false
 /** Guards against the macOS `activate` handler re-opening the old version
  *  while Squirrel's ShipIt is replacing the .app bundle. */
@@ -1519,8 +1518,15 @@ export function downloadUpdate(): void {
   if (!canStart) {
     return
   }
+  const version = currentStatus.state === 'available' ? currentStatus.version : availableVersion
+  if (!version) {
+    return
+  }
   downloadInFlight = true
   beginMacUpdateDownload()
+  // Why: retries may spend seconds in setup before electron-updater emits
+  // progress; surface acceptance immediately so the action never looks inert.
+  sendStatus({ state: 'downloading', percent: 0, version })
   getAutoUpdater()
     .downloadUpdate()
     .catch((err) => {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -2,6 +2,7 @@
 import { app, BrowserWindow, powerMonitor } from 'electron'
 import { is } from '@electron-toolkit/utils'
 import type { UpdateCheckOptions, UpdateStatus } from '../shared/types'
+import { isWindowsSignatureCheckUnavailableFailure } from '../shared/updater-windows-signature-check'
 import { killAllPty } from './ipc/pty'
 import { withUpdaterSpan } from './observability/instrumentation'
 import { loadElectronAutoUpdater, type ElectronAutoUpdater } from './electron-updater-loader'
@@ -522,6 +523,14 @@ function sendErrorStatus(message: string, userInitiated?: boolean): void {
     currentStatus.userInitiated === userInitiated
   ) {
     return
+  }
+  // Why: counts AV/EDR-blocked Windows signature checks in the field so we can
+  // size the affected cohort before investing in bigger updater changes.
+  if (isWindowsSignatureCheckUnavailableFailure(message)) {
+    recordUpdaterLifecycle('windows_signature_check_blocked', undefined, {
+      level: 'warn',
+      message: 'Windows update signature check could not run'
+    })
   }
   sendStatus({ state: 'error', message, userInitiated })
 }

--- a/src/renderer/src/components/UpdateCard.error-card.test.tsx
+++ b/src/renderer/src/components/UpdateCard.error-card.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '../store'
+import { UpdateCard } from './UpdateCard'
+
+const openUrl = vi.fn()
+const download = vi.fn()
+
+function renderAfterAvailableStatus(): void {
+  useAppStore.setState({
+    updateStatus: {
+      state: 'available',
+      version: '1.4.200',
+      changelog: null
+    },
+    updateChangelog: null,
+    dismissedUpdateVersion: null,
+    updateCardCollapsed: false,
+    updateReassuranceSeen: true
+  })
+  render(<UpdateCard />)
+}
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState(), true)
+  openUrl.mockReset()
+  download.mockReset()
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: {
+      app: { relaunch: vi.fn() },
+      settings: { set: vi.fn().mockResolvedValue(undefined) },
+      shell: { openUrl },
+      ui: { set: vi.fn().mockResolvedValue(undefined) },
+      updater: {
+        check: vi.fn(),
+        dismissNudge: vi.fn(),
+        download,
+        quitAndInstall: vi.fn().mockResolvedValue(undefined)
+      }
+    }
+  })
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    })
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  useAppStore.setState(useAppStore.getInitialState(), true)
+})
+
+describe('UpdateCard Windows signature failures', () => {
+  it('does not offer the rejected version as a manual publisher-check bypass', () => {
+    const message =
+      'New version 1.4.200 is not signed by the application owner: publisherNames: Orca'
+    renderAfterAvailableStatus()
+
+    act(() => useAppStore.getState().setUpdateStatus({ state: 'error', message }))
+
+    expect(screen.getByText("Update Wasn't Installed")).toBeTruthy()
+    expect(screen.getByText(/Don't install this download/)).toBeTruthy()
+    expect(screen.queryByText(message)).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check official releases' }))
+    expect(openUrl).toHaveBeenCalledWith('https://github.com/stablyai/orca/releases')
+    expect(openUrl).not.toHaveBeenCalledWith(expect.stringContaining('/tag/'))
+  })
+
+  it('keeps the blocked-check error collapsed while preserving retry and details', () => {
+    const message =
+      'Command failed: powershell.exe Get-AuthenticodeSignature -LiteralPath update.exe'
+    renderAfterAvailableStatus()
+
+    act(() => useAppStore.getState().setUpdateStatus({ state: 'error', message }))
+
+    expect(screen.getByText('Update Verification Blocked')).toBeTruthy()
+    expect(screen.queryByText(message)).toBeNull()
+    expect(screen.queryByText(/Windows verifies the installer/)).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry Download' }))
+    expect(download).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show details' }))
+    expect(screen.getByText(message)).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Hide details' }).getAttribute('aria-expanded')).toBe(
+      'true'
+    )
+  })
+})

--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -7,7 +7,17 @@ import { useAppStore } from '../store'
 import { Card } from './ui/card'
 import { Button } from './ui/button'
 import { Progress } from './ui/progress'
-import { AlertCircle, Check, Loader2, Minus, Network, RotateCw, ShieldAlert, X } from 'lucide-react'
+import {
+  AlertCircle,
+  Check,
+  ChevronRight,
+  Loader2,
+  Minus,
+  Network,
+  RotateCw,
+  ShieldAlert,
+  X
+} from 'lucide-react'
 import type { ChangelogData } from '../../../shared/types'
 import {
   isWindowsSignatureCheckUnavailableFailure,
@@ -1011,14 +1021,33 @@ function ErrorCardContent({
         </div>
       ) : null}
 
-      {detail && showDetails ? (
-        <div className="rounded-md bg-muted/40 px-3 py-2">
-          <p className="mb-1 text-[11px] font-medium uppercase text-muted-foreground">
-            {translate('auto.components.UpdateCard.3553a8672f', 'Last error')}
-          </p>
-          <p className="scrollbar-sleek max-h-20 overflow-auto break-words font-mono text-xs leading-relaxed text-muted-foreground">
-            {detail}
-          </p>
+      {/* Why: a caret disclosure sits directly above the raw error it reveals,
+          so the card leads with the plain summary and expands the last-error
+          block in place — the action buttons stay pinned below it. */}
+      {detail ? (
+        <div className="flex flex-col gap-2">
+          <button
+            className="flex items-center gap-1 self-start text-xs text-muted-foreground hover:text-foreground"
+            onClick={() => setShowDetails((prev) => !prev)}
+            aria-expanded={showDetails}
+          >
+            <ChevronRight
+              className={`size-3.5 transition-transform ${showDetails ? 'rotate-90' : ''}`}
+            />
+            {showDetails
+              ? translate('auto.components.UpdateCard.5194358929', 'Hide details')
+              : translate('auto.components.UpdateCard.8bc9e17d8f', 'Show details')}
+          </button>
+          {showDetails ? (
+            <div className="rounded-md bg-muted/40 px-3 py-2">
+              <p className="mb-1 text-[11px] font-medium uppercase text-muted-foreground">
+                {translate('auto.components.UpdateCard.3553a8672f', 'Last error')}
+              </p>
+              <p className="scrollbar-sleek max-h-20 overflow-auto break-words font-mono text-xs leading-relaxed text-muted-foreground">
+                {detail}
+              </p>
+            </div>
+          ) : null}
         </div>
       ) : null}
 
@@ -1050,18 +1079,6 @@ function ErrorCardContent({
           {manualLabel ?? translate('auto.components.UpdateCard.47126bcf57', 'Download Manually')}
         </Button>
       </div>
-      {/* Why: the raw-error toggle sits on its own row so it never crowds the
-          two action buttons out of the narrow card. */}
-      {detail ? (
-        <button
-          className="-mt-1 self-start text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
-          onClick={() => setShowDetails((prev) => !prev)}
-        >
-          {showDetails
-            ? translate('auto.components.UpdateCard.5194358929', 'Hide details')
-            : translate('auto.components.UpdateCard.8bc9e17d8f', 'Show details')}
-        </button>
-      ) : null}
     </div>
   )
 }

--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -1039,7 +1039,7 @@ function ErrorCardContent({
             aria-controls={detailId}
           >
             <ChevronRight
-              className={`size-3.5 transition-transform ${showDetails ? 'rotate-90' : ''}`}
+              className={`size-3.5 transition-transform motion-reduce:transition-none ${showDetails ? 'rotate-90' : ''}`}
             />
             {showDetails
               ? translate('auto.components.UpdateCard.5194358929', 'Hide details')

--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -7,8 +7,12 @@ import { useAppStore } from '../store'
 import { Card } from './ui/card'
 import { Button } from './ui/button'
 import { Progress } from './ui/progress'
-import { AlertCircle, Check, Loader2, Minus, Network, RotateCw, X } from 'lucide-react'
+import { AlertCircle, Check, Loader2, Minus, Network, RotateCw, ShieldAlert, X } from 'lucide-react'
 import type { ChangelogData } from '../../../shared/types'
+import {
+  isWindowsSignatureCheckUnavailableFailure,
+  isWindowsSignatureMismatchFailure
+} from '../../../shared/updater-windows-signature-check'
 import { translate } from '@/i18n/i18n'
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -37,11 +41,16 @@ export function isHttp2ProtocolError(message: string): boolean {
 }
 
 type ErrorCardModel = {
-  variant?: 'default' | 'http1Compatibility'
+  variant?: 'default' | 'http1Compatibility' | 'security'
   title: string
   summary: string
-  message: string
+  /** Optional guidance box between the summary and the raw error output. */
+  explainer?: string
+  /** Raw error text, shown only when the user expands "Show details". */
+  detail?: string
   releaseUrl: string
+  /** Overrides the secondary button label (defaults to "Download Manually"). */
+  manualLabel?: string
   primaryAction?: {
     label: string
     pendingLabel?: string
@@ -337,7 +346,16 @@ export function UpdateCard() {
       })
   }
 
+  // Why: classify each failure so the card leads with one plain sentence and
+  // the right action, and keeps the raw error behind "Show details" instead of
+  // dumping a PowerShell/stack trace as the headline. Order matters: the
+  // security-stop (wrong publisher) must win over the AV/EDR "check couldn't
+  // run" case so a real integrity failure is never softened into "try again".
   const isHttp2UpdateError = status.state === 'error' && isHttp2ProtocolError(status.message)
+  const isSignatureMismatchError =
+    status.state === 'error' && isWindowsSignatureMismatchFailure(status.message)
+  const isSignatureCheckBlockedError =
+    status.state === 'error' && isWindowsSignatureCheckUnavailableFailure(status.message)
   const errorCard: ErrorCardModel | null =
     status.state === 'error'
       ? isHttp2UpdateError
@@ -345,7 +363,11 @@ export function UpdateCard() {
             variant: 'http1Compatibility',
             title: translate('auto.components.UpdateCard.1339b82cee', 'HTTP/2 Download Blocked'),
             summary: 'Orca can retry through HTTP/1.1 compatibility mode.',
-            message: compatibilitySetupError ?? status.message,
+            explainer: translate(
+              'auto.components.UpdateCard.90559b14e3',
+              'This turns on a process-wide Electron networking switch after restart. Use it for corporate VPNs or proxies that reject HTTP/2 update downloads.'
+            ),
+            detail: compatibilitySetupError ?? status.message,
             releaseUrl: releaseUrlForVersion(cachedVersion),
             primaryAction: {
               label: translate('auto.components.UpdateCard.933c6fdf5b', 'Enable & Restart'),
@@ -354,35 +376,69 @@ export function UpdateCard() {
               onClick: handleEnableHttp1Compatibility
             }
           }
-        : {
-            // Why: title is scoped to the operation that failed so check-time
-            // failures (commonly GitHub-side) don't read as a bug in Orca.
-            title: cachedVersion ? 'Update Error' : 'Update Check Failed',
-            summary: cachedVersion
-              ? 'Could not complete the update.'
-              : 'Could not check for updates.',
-            message: status.message,
-            releaseUrl: releaseUrlForVersion(cachedVersion),
-            // Why: check-time failures are often transient (offline, GitHub
-            // hiccup), so offer a Re-check next to "Download Manually" instead
-            // of forcing the user into the manual fallback.
-            primaryAction: cachedVersion
-              ? {
+        : isSignatureMismatchError
+          ? {
+              // Security stop: the installer is readable but signed by the wrong
+              // publisher. No retry — only a path to the verified download.
+              variant: 'security',
+              title: translate('auto.components.UpdateCard.5b309b19f3', "Update Wasn't Installed"),
+              summary: translate(
+                'auto.components.UpdateCard.092f09fc14',
+                "This download isn't signed by Orca, so we stopped it. Get the latest version from our official releases instead."
+              ),
+              detail: status.message,
+              releaseUrl: releaseUrlForVersion(cachedVersion),
+              manualLabel: translate(
+                'auto.components.UpdateCard.c9ff9b9ec2',
+                'Open official releases'
+              )
+            }
+          : isSignatureCheckBlockedError
+            ? {
+                title: translate(
+                  'auto.components.UpdateCard.e944c2de43',
+                  'Update Verification Blocked'
+                ),
+                summary: translate(
+                  'auto.components.UpdateCard.a05992a26b',
+                  "The signature check couldn't run — usually antivirus software blocking it. Retry, or download it manually; Windows verifies the installer when it runs."
+                ),
+                detail: status.message,
+                releaseUrl: releaseUrlForVersion(cachedVersion),
+                primaryAction: {
                   label: translate('auto.components.UpdateCard.48565a32bc', 'Retry Download'),
                   onClick: handleUpdate
                 }
-              : {
-                  label: translate('auto.components.UpdateCard.6b0085010d', 'Re-check'),
-                  onClick: () => {
-                    void window.api.updater.check({ includePrerelease: false })
-                  }
-                }
-          }
+              }
+            : {
+                // Why: title is scoped to the operation that failed so check-time
+                // failures (commonly GitHub-side) don't read as a bug in Orca.
+                title: cachedVersion ? 'Update Error' : 'Update Check Failed',
+                summary: cachedVersion
+                  ? 'Could not complete the update.'
+                  : 'Could not check for updates.',
+                detail: status.message,
+                releaseUrl: releaseUrlForVersion(cachedVersion),
+                // Why: check-time failures are often transient (offline, GitHub
+                // hiccup), so offer a Re-check next to "Download Manually" instead
+                // of forcing the user into the manual fallback.
+                primaryAction: cachedVersion
+                  ? {
+                      label: translate('auto.components.UpdateCard.48565a32bc', 'Retry Download'),
+                      onClick: handleUpdate
+                    }
+                  : {
+                      label: translate('auto.components.UpdateCard.6b0085010d', 'Re-check'),
+                      onClick: () => {
+                        void window.api.updater.check({ includePrerelease: false })
+                      }
+                    }
+              }
       : installError
         ? {
             title: translate('auto.components.UpdateCard.4cf109845a', 'Update Error'),
             summary: 'Could not restart to install the update.',
-            message: installError,
+            detail: installError,
             releaseUrl: releaseUrlForVersion(cachedVersion),
             primaryAction: {
               label: translate('auto.components.UpdateCard.2c2d3e03ca', 'Try Again'),
@@ -494,8 +550,10 @@ export function UpdateCard() {
         <ErrorCardContent
           title={errorCard.title}
           summary={errorCard.summary}
-          message={errorCard.message}
+          explainer={errorCard.explainer}
+          detail={errorCard.detail}
           releaseUrl={errorCard.releaseUrl}
+          manualLabel={errorCard.manualLabel}
           variant={errorCard.variant}
           primaryAction={errorCard.primaryAction}
           onClose={handleCollapseWithAnimation}
@@ -892,16 +950,20 @@ function ErrorCardContent({
   variant = 'default',
   title,
   summary,
-  message,
+  explainer,
+  detail,
   releaseUrl,
+  manualLabel,
   primaryAction,
   onClose
 }: {
-  variant?: 'default' | 'http1Compatibility'
+  variant?: 'default' | 'http1Compatibility' | 'security'
   title: string
   summary: string
-  message: string
+  explainer?: string
+  detail?: string
   releaseUrl: string
+  manualLabel?: string
   primaryAction?: {
     label: string
     pendingLabel?: string
@@ -910,12 +972,22 @@ function ErrorCardContent({
   }
   onClose: () => void
 }) {
+  // Why: the raw error is kept for support but starts collapsed so the card
+  // leads with the plain-language summary, not a PowerShell/stack dump.
+  const [showDetails, setShowDetails] = useState(false)
   const isCompatibility = variant === 'http1Compatibility'
-  const Icon = isCompatibility ? Network : AlertCircle
+  const isSecurity = variant === 'security'
+  const Icon = isCompatibility ? Network : isSecurity ? ShieldAlert : AlertCircle
   return (
     <div className="flex flex-col gap-3 p-4">
       <div className="flex items-start gap-3">
-        <div className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-md border border-border bg-muted/50 text-muted-foreground">
+        <div
+          className={`mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-md border bg-muted/50 ${
+            isSecurity
+              ? 'border-destructive/30 text-destructive'
+              : 'border-border text-muted-foreground'
+          }`}
+        >
           <Icon className="size-4" />
         </div>
         <div className="min-w-0 flex-1 space-y-1">
@@ -933,25 +1005,22 @@ function ErrorCardContent({
         </Button>
       </div>
 
-      {isCompatibility ? (
+      {explainer ? (
         <div className="rounded-md border border-border/70 bg-muted/30 px-3 py-2">
-          <p className="text-xs leading-relaxed text-muted-foreground">
-            {translate(
-              'auto.components.UpdateCard.90559b14e3',
-              'This turns on a process-wide Electron networking switch after restart. Use it for corporate VPNs or proxies that reject HTTP/2 update downloads.'
-            )}
-          </p>
+          <p className="text-xs leading-relaxed text-muted-foreground">{explainer}</p>
         </div>
       ) : null}
 
-      <div className="rounded-md bg-muted/40 px-3 py-2">
-        <p className="mb-1 text-[11px] font-medium uppercase text-muted-foreground">
-          {translate('auto.components.UpdateCard.3553a8672f', 'Last error')}
-        </p>
-        <p className="scrollbar-sleek max-h-20 overflow-auto break-words font-mono text-xs leading-relaxed text-muted-foreground">
-          {message}
-        </p>
-      </div>
+      {detail && showDetails ? (
+        <div className="rounded-md bg-muted/40 px-3 py-2">
+          <p className="mb-1 text-[11px] font-medium uppercase text-muted-foreground">
+            {translate('auto.components.UpdateCard.3553a8672f', 'Last error')}
+          </p>
+          <p className="scrollbar-sleek max-h-20 overflow-auto break-words font-mono text-xs leading-relaxed text-muted-foreground">
+            {detail}
+          </p>
+        </div>
+      ) : null}
 
       <div className="flex gap-2">
         {primaryAction && (
@@ -976,11 +1045,23 @@ function ErrorCardContent({
           variant="outline"
           size="sm"
           onClick={() => void window.api.shell.openUrl(releaseUrl)}
-          className={primaryAction ? 'flex-1' : 'w-full'}
+          className="flex-1"
         >
-          {translate('auto.components.UpdateCard.47126bcf57', 'Download Manually')}
+          {manualLabel ?? translate('auto.components.UpdateCard.47126bcf57', 'Download Manually')}
         </Button>
       </div>
+      {/* Why: the raw-error toggle sits on its own row so it never crowds the
+          two action buttons out of the narrow card. */}
+      {detail ? (
+        <button
+          className="-mt-1 self-start text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+          onClick={() => setShowDetails((prev) => !prev)}
+        >
+          {showDetails
+            ? translate('auto.components.UpdateCard.5194358929', 'Hide details')
+            : translate('auto.components.UpdateCard.8bc9e17d8f', 'Show details')}
+        </button>
+      ) : null}
     </div>
   )
 }

--- a/src/renderer/src/components/UpdateCard.tsx
+++ b/src/renderer/src/components/UpdateCard.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: the update card owns the full updater lifecycle in one
    renderer surface. Keeping the state machine and its presentation variants together avoids
    scattering tightly coupled update behavior across multiple files. */
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
 import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
 import { useAppStore } from '../store'
 import { Card } from './ui/card'
@@ -394,13 +394,15 @@ export function UpdateCard() {
               title: translate('auto.components.UpdateCard.5b309b19f3', "Update Wasn't Installed"),
               summary: translate(
                 'auto.components.UpdateCard.092f09fc14',
-                "This download isn't signed by Orca, so we stopped it. Get the latest version from our official releases instead."
+                "The installer's publisher doesn't match Orca, so we stopped the update. Don't install this download; check official releases for a corrected version."
               ),
               detail: status.message,
-              releaseUrl: releaseUrlForVersion(cachedVersion),
+              // Why: linking the rejected version directly would invite users
+              // to bypass the publisher check by running the same installer.
+              releaseUrl: releaseUrlForVersion(null),
               manualLabel: translate(
                 'auto.components.UpdateCard.c9ff9b9ec2',
-                'Open official releases'
+                'Check official releases'
               )
             }
           : isSignatureCheckBlockedError
@@ -411,7 +413,7 @@ export function UpdateCard() {
                 ),
                 summary: translate(
                   'auto.components.UpdateCard.a05992a26b',
-                  "The signature check couldn't run — usually antivirus software blocking it. Retry, or download it manually; Windows verifies the installer when it runs."
+                  "The signature check couldn't run — usually because antivirus software blocked it. Retry the download, or get the installer from our official releases."
                 ),
                 detail: status.message,
                 releaseUrl: releaseUrlForVersion(cachedVersion),
@@ -985,6 +987,7 @@ function ErrorCardContent({
   // Why: the raw error is kept for support but starts collapsed so the card
   // leads with the plain-language summary, not a PowerShell/stack dump.
   const [showDetails, setShowDetails] = useState(false)
+  const detailId = useId()
   const isCompatibility = variant === 'http1Compatibility'
   const isSecurity = variant === 'security'
   const Icon = isCompatibility ? Network : isSecurity ? ShieldAlert : AlertCircle
@@ -1026,10 +1029,14 @@ function ErrorCardContent({
           block in place — the action buttons stay pinned below it. */}
       {detail ? (
         <div className="flex flex-col gap-2">
-          <button
-            className="flex items-center gap-1 self-start text-xs text-muted-foreground hover:text-foreground"
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            className="-ml-2 self-start text-muted-foreground hover:text-foreground"
             onClick={() => setShowDetails((prev) => !prev)}
             aria-expanded={showDetails}
+            aria-controls={detailId}
           >
             <ChevronRight
               className={`size-3.5 transition-transform ${showDetails ? 'rotate-90' : ''}`}
@@ -1037,9 +1044,9 @@ function ErrorCardContent({
             {showDetails
               ? translate('auto.components.UpdateCard.5194358929', 'Hide details')
               : translate('auto.components.UpdateCard.8bc9e17d8f', 'Show details')}
-          </button>
+          </Button>
           {showDetails ? (
-            <div className="rounded-md bg-muted/40 px-3 py-2">
+            <div id={detailId} className="rounded-md bg-muted/40 px-3 py-2">
               <p className="mb-1 text-[11px] font-medium uppercase text-muted-foreground">
                 {translate('auto.components.UpdateCard.3553a8672f', 'Last error')}
               </p>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1815,7 +1815,14 @@
         "a726967bd3": "Dismiss",
         "d5253b54af": "error",
         "7ffc08506e": "check",
-        "522df222b9": "spinner"
+        "522df222b9": "spinner",
+        "e944c2de43": "Update Verification Blocked",
+        "5b309b19f3": "Update Wasn't Installed",
+        "092f09fc14": "This download isn't signed by Orca, so we stopped it. Get the latest version from our official releases instead.",
+        "c9ff9b9ec2": "Open official releases",
+        "a05992a26b": "The signature check couldn't run — usually antivirus software blocking it. Retry, or download it manually; Windows verifies the installer when it runs.",
+        "5194358929": "Hide details",
+        "8bc9e17d8f": "Show details"
       },
       "WorktreeJumpPalette": {
         "ac037cfac2": "Move",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1818,9 +1818,9 @@
         "522df222b9": "spinner",
         "e944c2de43": "Update Verification Blocked",
         "5b309b19f3": "Update Wasn't Installed",
-        "092f09fc14": "This download isn't signed by Orca, so we stopped it. Get the latest version from our official releases instead.",
-        "c9ff9b9ec2": "Open official releases",
-        "a05992a26b": "The signature check couldn't run — usually antivirus software blocking it. Retry, or download it manually; Windows verifies the installer when it runs.",
+        "092f09fc14": "The installer's publisher doesn't match Orca, so we stopped the update. Don't install this download; check official releases for a corrected version.",
+        "c9ff9b9ec2": "Check official releases",
+        "a05992a26b": "The signature check couldn't run — usually because antivirus software blocked it. Retry the download, or get the installer from our official releases.",
         "5194358929": "Hide details",
         "8bc9e17d8f": "Show details"
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1815,7 +1815,14 @@
         "a726967bd3": "Descartar",
         "d5253b54af": "error",
         "7ffc08506e": "check",
-        "522df222b9": "spinner"
+        "522df222b9": "spinner",
+        "e944c2de43": "Update Verification Blocked",
+        "5b309b19f3": "Update Wasn't Installed",
+        "092f09fc14": "This download isn't signed by Orca, so we stopped it. Get the latest version from our official releases instead.",
+        "c9ff9b9ec2": "Open official releases",
+        "a05992a26b": "The signature check couldn't run — usually antivirus software blocking it. Retry, or download it manually; Windows verifies the installer when it runs.",
+        "5194358929": "Hide details",
+        "8bc9e17d8f": "Show details"
       },
       "WorktreeJumpPalette": {
         "ac037cfac2": "Mover",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1818,9 +1818,9 @@
         "522df222b9": "spinner",
         "e944c2de43": "Update Verification Blocked",
         "5b309b19f3": "Update Wasn't Installed",
-        "092f09fc14": "This download isn't signed by Orca, so we stopped it. Get the latest version from our official releases instead.",
-        "c9ff9b9ec2": "Open official releases",
-        "a05992a26b": "The signature check couldn't run — usually antivirus software blocking it. Retry, or download it manually; Windows verifies the installer when it runs.",
+        "092f09fc14": "The installer's publisher doesn't match Orca, so we stopped the update. Don't install this download; check official releases for a corrected version.",
+        "c9ff9b9ec2": "Check official releases",
+        "a05992a26b": "The signature check couldn't run — usually because antivirus software blocked it. Retry the download, or get the installer from our official releases.",
         "5194358929": "Hide details",
         "8bc9e17d8f": "Show details"
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1818,9 +1818,9 @@
         "522df222b9": "スピナー",
         "e944c2de43": "Update Verification Blocked",
         "5b309b19f3": "Update Wasn't Installed",
-        "092f09fc14": "This download isn't signed by Orca, so we stopped it. Get the latest version from our official releases instead.",
-        "c9ff9b9ec2": "Open official releases",
-        "a05992a26b": "The signature check couldn't run — usually antivirus software blocking it. Retry, or download it manually; Windows verifies the installer when it runs.",
+        "092f09fc14": "The installer's publisher doesn't match Orca, so we stopped the update. Don't install this download; check official releases for a corrected version.",
+        "c9ff9b9ec2": "Check official releases",
+        "a05992a26b": "The signature check couldn't run — usually because antivirus software blocked it. Retry the download, or get the installer from our official releases.",
         "5194358929": "Hide details",
         "8bc9e17d8f": "Show details"
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1815,7 +1815,14 @@
         "a726967bd3": "閉じる",
         "d5253b54af": "エラー",
         "7ffc08506e": "チェック",
-        "522df222b9": "スピナー"
+        "522df222b9": "スピナー",
+        "e944c2de43": "Update Verification Blocked",
+        "5b309b19f3": "Update Wasn't Installed",
+        "092f09fc14": "This download isn't signed by Orca, so we stopped it. Get the latest version from our official releases instead.",
+        "c9ff9b9ec2": "Open official releases",
+        "a05992a26b": "The signature check couldn't run — usually antivirus software blocking it. Retry, or download it manually; Windows verifies the installer when it runs.",
+        "5194358929": "Hide details",
+        "8bc9e17d8f": "Show details"
       },
       "WorktreeJumpPalette": {
         "ac037cfac2": "移動",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1815,7 +1815,14 @@
         "a726967bd3": "닫기",
         "d5253b54af": "오류",
         "7ffc08506e": "확인",
-        "522df222b9": "스피너"
+        "522df222b9": "스피너",
+        "e944c2de43": "Update Verification Blocked",
+        "5b309b19f3": "Update Wasn't Installed",
+        "092f09fc14": "This download isn't signed by Orca, so we stopped it. Get the latest version from our official releases instead.",
+        "c9ff9b9ec2": "Open official releases",
+        "a05992a26b": "The signature check couldn't run — usually antivirus software blocking it. Retry, or download it manually; Windows verifies the installer when it runs.",
+        "5194358929": "Hide details",
+        "8bc9e17d8f": "Show details"
       },
       "WorktreeJumpPalette": {
         "ac037cfac2": "이동",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1818,9 +1818,9 @@
         "522df222b9": "스피너",
         "e944c2de43": "Update Verification Blocked",
         "5b309b19f3": "Update Wasn't Installed",
-        "092f09fc14": "This download isn't signed by Orca, so we stopped it. Get the latest version from our official releases instead.",
-        "c9ff9b9ec2": "Open official releases",
-        "a05992a26b": "The signature check couldn't run — usually antivirus software blocking it. Retry, or download it manually; Windows verifies the installer when it runs.",
+        "092f09fc14": "The installer's publisher doesn't match Orca, so we stopped the update. Don't install this download; check official releases for a corrected version.",
+        "c9ff9b9ec2": "Check official releases",
+        "a05992a26b": "The signature check couldn't run — usually because antivirus software blocked it. Retry the download, or get the installer from our official releases.",
         "5194358929": "Hide details",
         "8bc9e17d8f": "Show details"
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1818,9 +1818,9 @@
         "522df222b9": "旋转器",
         "e944c2de43": "Update Verification Blocked",
         "5b309b19f3": "Update Wasn't Installed",
-        "092f09fc14": "This download isn't signed by Orca, so we stopped it. Get the latest version from our official releases instead.",
-        "c9ff9b9ec2": "Open official releases",
-        "a05992a26b": "The signature check couldn't run — usually antivirus software blocking it. Retry, or download it manually; Windows verifies the installer when it runs.",
+        "092f09fc14": "The installer's publisher doesn't match Orca, so we stopped the update. Don't install this download; check official releases for a corrected version.",
+        "c9ff9b9ec2": "Check official releases",
+        "a05992a26b": "The signature check couldn't run — usually because antivirus software blocked it. Retry the download, or get the installer from our official releases.",
         "5194358929": "Hide details",
         "8bc9e17d8f": "Show details"
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1815,7 +1815,14 @@
         "a726967bd3": "关闭",
         "d5253b54af": "错误",
         "7ffc08506e": "查看",
-        "522df222b9": "旋转器"
+        "522df222b9": "旋转器",
+        "e944c2de43": "Update Verification Blocked",
+        "5b309b19f3": "Update Wasn't Installed",
+        "092f09fc14": "This download isn't signed by Orca, so we stopped it. Get the latest version from our official releases instead.",
+        "c9ff9b9ec2": "Open official releases",
+        "a05992a26b": "The signature check couldn't run — usually antivirus software blocking it. Retry, or download it manually; Windows verifies the installer when it runs.",
+        "5194358929": "Hide details",
+        "8bc9e17d8f": "Show details"
       },
       "WorktreeJumpPalette": {
         "ac037cfac2": "手机",

--- a/src/shared/updater-windows-signature-check.test.ts
+++ b/src/shared/updater-windows-signature-check.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isWindowsSignatureCheckUnavailableFailure,
+  isWindowsSignatureMismatchFailure
+} from './updater-windows-signature-check'
+
+describe('isWindowsSignatureCheckUnavailableFailure', () => {
+  it('matches the PowerShell command failure shape (timeout / non-zero exit)', () => {
+    expect(
+      isWindowsSignatureCheckUnavailableFailure(
+        'Command failed: set "PSModulePath=" & chcp 65001 >NUL & powershell.exe -NoProfile ' +
+          '-NonInteractive -InputFormat None -Command "Get-AuthenticodeSignature -LiteralPath ' +
+          "'C:\\Users\\u\\AppData\\Local\\orca-updater\\pending\\orca-windows-setup.exe' | " +
+          'ConvertTo-Json -Compress"'
+      )
+    ).toBe(true)
+  })
+
+  it('matches the stderr failure shape', () => {
+    expect(
+      isWindowsSignatureCheckUnavailableFailure(
+        'Cannot execute Get-AuthenticodeSignature, stderr: Access is denied. ' +
+          'Failing signature validation due to unknown stderr.'
+      )
+    ).toBe(true)
+  })
+
+  it('does not match a genuine signature mismatch', () => {
+    expect(
+      isWindowsSignatureCheckUnavailableFailure(
+        'New version 1.4.144 is not signed by the application owner: ' +
+          'publisherNames: SignPath Foundation, raw info: {"Status": 0}'
+      )
+    ).toBe(false)
+  })
+
+  it('does not match unrelated update errors', () => {
+    expect(isWindowsSignatureCheckUnavailableFailure('net::ERR_HTTP2_PROTOCOL_ERROR')).toBe(false)
+    expect(
+      isWindowsSignatureCheckUnavailableFailure('Cannot find channel "latest.yml" (404)')
+    ).toBe(false)
+  })
+})
+
+describe('isWindowsSignatureMismatchFailure', () => {
+  it('matches the wrong-publisher integrity failure', () => {
+    expect(
+      isWindowsSignatureMismatchFailure(
+        'New version 1.4.144 is not signed by the application owner: ' +
+          'publisherNames: SignPath Foundation, raw info: {"Status": 0}'
+      )
+    ).toBe(true)
+  })
+
+  it('is mutually exclusive with the check-unavailable classifier', () => {
+    const mismatch = 'New version 1.4.144 is not signed by the application owner: publisherNames: X'
+    expect(isWindowsSignatureMismatchFailure(mismatch)).toBe(true)
+    expect(isWindowsSignatureCheckUnavailableFailure(mismatch)).toBe(false)
+
+    const blocked = 'Command failed: … Get-AuthenticodeSignature -LiteralPath …'
+    expect(isWindowsSignatureCheckUnavailableFailure(blocked)).toBe(true)
+    expect(isWindowsSignatureMismatchFailure(blocked)).toBe(false)
+  })
+
+  it('does not match unrelated errors', () => {
+    expect(isWindowsSignatureMismatchFailure('net::ERR_HTTP2_PROTOCOL_ERROR')).toBe(false)
+  })
+})

--- a/src/shared/updater-windows-signature-check.ts
+++ b/src/shared/updater-windows-signature-check.ts
@@ -1,0 +1,23 @@
+// Why: electron-updater verifies Windows installers by spawning PowerShell's
+// Get-AuthenticodeSignature. Antivirus/EDR interception, its hardcoded 20s
+// timeout, or stalled revocation lookups kill that spawn, and the raw
+// child-process failure becomes the update error. Detect that shape so the UI
+// can explain it instead of dumping the command line. A true signature
+// mismatch ("not signed by the application owner") must NOT match — that is a
+// real integrity failure, not environment interference.
+export function isWindowsSignatureCheckUnavailableFailure(message: string): boolean {
+  const normalized = message.toLowerCase()
+  if (normalized.includes('not signed by the application owner')) {
+    return false
+  }
+  return normalized.includes('get-authenticodesignature')
+}
+
+// Why: electron-updater throws ERR_UPDATER_INVALID_SIGNATURE with this exact
+// phrase when the downloaded installer is validly readable but signed by the
+// wrong publisher — a genuine integrity failure, NOT environment interference.
+// This must drive a security-stop message (no silent "retry" framing) and stay
+// distinct from isWindowsSignatureCheckUnavailableFailure above.
+export function isWindowsSignatureMismatchFailure(message: string): boolean {
+  return message.toLowerCase().includes('not signed by the application owner')
+}


### PR DESCRIPTION
## What & why

Windows auto-update failures surfaced the **raw electron-updater error as the card headline** — most visibly the PowerShell `Command failed: … Get-AuthenticodeSignature …` dump that appears when antivirus/EDR blocks the post-download signature check. That reads like a crash, not an actionable state, and gives the user nothing to do.

This reshapes the error card to lead with **one plain-language sentence + the right action**, and keeps the raw error one click away behind a **Show details** caret. Mirrors how mature Electron updaters present failures (a friendly line, not a stack trace) while keeping the raw text reachable for support.

## What changed

- **New shared classifier** (`src/shared/updater-windows-signature-check.ts`): distinguishes an **AV/EDR-blocked signature check** (environment — safe to retry) from a **genuine wrong-publisher mismatch** (a security stop). The two are mutually exclusive, so a real integrity failure is never softened into "try again".
- **`UpdateCard.tsx`**: raw error moves behind a **Show details caret disclosure** that sits directly above the action buttons and expands the last-error block in place; adds a **security-stop variant** (wrong publisher → no retry, "Open official releases") and the **AV-blocked variant** ("Update Verification Blocked"). HTTP/2 and generic paths keep their existing actions with the same disclosure.
- **Main process** records a `windows_signature_check_blocked` lifecycle event so we can size the affected Windows cohort in the field.

## Validation

Tests (classifier + UpdateCard), `pnpm typecheck`, and full `pnpm lint` (incl. localization gates) all green. Each error scenario was driven in a **running Electron build** and screenshotted:

**Signature check blocked (AV/EDR) — the common Windows failure**
![signature check blocked](https://raw.githubusercontent.com/stablyai/orca/pr-assets/windows-update-error-ux/card-01-sigcheck.png?v=2)

**Show details expanded — caret reveals the raw error in place, buttons pinned below**
![show details expanded](https://raw.githubusercontent.com/stablyai/orca/pr-assets/windows-update-error-ux/card-02-showdetails.png?v=2)

**Wrong-publisher signature mismatch — security stop, no retry**
![security stop](https://raw.githubusercontent.com/stablyai/orca/pr-assets/windows-update-error-ux/card-03-security.png?v=2)

**Generic failure — one line + retry, raw error hidden**
![generic](https://raw.githubusercontent.com/stablyai/orca/pr-assets/windows-update-error-ux/card-04-generic.png?v=2)

**HTTP/2 blocked — existing compatibility action, unchanged**
![http2](https://raw.githubusercontent.com/stablyai/orca/pr-assets/windows-update-error-ux/card-05-http2.png?v=2)

## Scope / follow-ups

Deliberately scoped to the **renderer error-card UX**. Two ideas from the design exploration are left as separate follow-ups because they touch different subsystems:
- A "Finishing update…" state with a **Restart now** button for the install/restart-freeze case (needs main-process install-phase state + IPC; targets a different bug than this).
- The one-line "installs when you quit" **reassurance** on the ready-to-install card.
