### PR TITLE
fix(browser): connect Codex to active Orca browser

### DIFF
--- a/ORCA-IAB-BROWSER-CONNECTION.task-state.md
+++ b/ORCA-IAB-BROWSER-CONNECTION.task-state.md
@@ -1,0 +1,177 @@
+# Orca 브라우저 플러그인 직접 연결
+
+## Linear Source
+- 이슈: N/A
+- 링크: N/A
+- 상태: in-progress
+- 담당: Codex
+
+## Goal
+- 열린 Orca 브라우저 패널을 Browser 플러그인이 직접 발견하고 선택하도록 연결 정보를 전달합니다.
+
+## PRD / Problem
+- 패널은 화면에 있고 Orca 전용 제어도 되지만 Browser 플러그인 목록은 비어 있습니다. 규칙 우회가 아니라 세션 연결 정보를 실제 플러그인까지 전달해야 합니다.
+
+## Background
+- 현재 Orca 패널은 같은 작업공간의 활성 탭이며 URL과 화면 구조 조회가 성공합니다.
+- 같은 Codex 세션에서 Browser 플러그인 런타임을 초기화하면 브라우저 목록은 빈 배열이고 요청 메타데이터에는 브라우저 대상 정보가 없습니다.
+
+## Why It Matters / Why Now
+- 보이는 패널을 다시 열라고 안내하면 사용자가 현재 화면을 신뢰할 수 없습니다.
+- 규칙 우회는 다른 세션이나 새 세션에서 다시 깨질 수 있으므로 연결 계층을 지금 고쳐야 합니다.
+
+## Problem Definition
+- Orca 안에 활성 브라우저가 있어도 새 Codex 턴의 Browser 플러그인에서 `iab`가 발견되지 않습니다.
+
+## Solution Intent
+- 세션 생성·재개 시 현재 보이는 Orca 브라우저의 연결 정보가 플러그인 런타임에 전달되게 합니다.
+
+## Hypothesis
+- Codex 세션/도구 요청을 만드는 경계에서 활성 Orca 브라우저 정보를 누락해 Browser 플러그인이 백엔드를 만들지 못합니다.
+
+## Approach
+- 기존 세션의 변경이 섞인 checkout은 보존하고 독립 worktree에서 재현 테스트를 먼저 작성합니다.
+- Orca CLI 우회만 유지하는 방식과 Browser 플러그인 파일을 직접 수정하는 방식은 버립니다. 제품의 세션 연결 경계를 수정합니다.
+
+## Validation Plan / Implementation Plan
+- 연결 정보 생성 경로를 좁혀 실패 테스트를 작성합니다.
+- 최소 구현으로 테스트를 통과시킨 뒤 타입 검사와 관련 통합 테스트를 실행합니다.
+- 별도 dev Orca에서 브라우저 패널과 새 Codex 세션을 열어 Browser 플러그인이 `iab`를 직접 발견하고 화면을 읽는지 확인합니다.
+
+## Success Metrics / Failure Metrics / Completion Evidence
+- Success metrics: 새 세션에서 Browser 플러그인 목록에 `iab`가 한 개 나타나고 현재 보이는 패널을 선택합니다.
+- Failure metrics: 목록이 비어 있거나 숨겨진/다른 작업공간 탭을 선택하거나 Orca CLI 우회가 필요합니다.
+- Completion evidence: 실패→성공 테스트, 타입 검사, 관련 통합 테스트, 별도 dev 런타임의 직접 연결과 화면 읽기 결과입니다.
+
+## History
+- 07/17 패널 배치와 Orca 전용 제어는 확인했으나 Browser 플러그인의 직접 발견은 실패했습니다.
+
+## Current Status
+- 독립 worktree의 직접 연결 구현, 실제 dev 검증, 독립 리뷰와 코드 Done gate를 완료했습니다. 사용자의 "끝까지 진행" 요청에 따라 커밋·통합·실사용 앱 반영 및 최종 QA를 새 완료 범위로 진행합니다.
+
+## Context Lens
+- Required: yes
+- Primary lens: engineering
+- Secondary lens: product
+- Why this lens: 세션과 브라우저 연결 계약을 고치면서 사용자가 보는 현재 패널과 정확히 일치해야 합니다.
+- Source: 현재 Orca 탭 상태, Browser 플러그인 발견 결과, 새 worktree의 제품 코드와 테스트
+- Applied checks: 다른 세션 보존, 현재 표시 탭 일치, 새 세션 재현, SSH·Windows·Linux 호환, 우회 없는 직접 연결
+
+## Instruction Receipt
+- Read docs: `/Users/wjh/AGENTS.md`, worktree `AGENTS.md`, `ORCA-IAB-BROWSER-CONNECTION.task-state.md`, instruction manifest, Codex/session/communication rules, development/workflow/API/release/browser rules, Browser plugin·Orca CLI·TDD·deploy skills, Browser client의 발견·응답 메타데이터 코드
+- Selected bundle/lens: `base`, `code`, `api`, `browser`, `release`; engineering + product
+- Applied instructions: 독립 worktree, 테스트 선작성, 실제 dev 화면 검증, peer 검토, 다른 세션과 사용자 변경 보존, 현재 표시 패널만 직접 연결, deploy 절차의 빌드·테스트·실사용 검증 및 커밋·push 전 사용자 확인
+- Latest review applied: native socket별 CDP 소유권·재연결 cleanup, 지원 API 축소 광고, backend 시작 실패 격리, local/live/unique resolver와 reconnect 테스트를 완료 조건에 추가
+- N/A or deferred: 외부 서비스 변경은 요청 범위 밖입니다. 커밋·통합·기존 Orca 앱 반영은 07/18 사용자의 후속 요청으로 범위에 추가됐습니다.
+- Re-read trigger: 대상 경로가 세션 연결이 아닌 플러그인 패키지나 외부 Codex 호스트로 바뀌는 경우입니다.
+
+## Working Contract
+- In scope: Orca가 Codex Browser 플러그인에 현재 활성 브라우저 정보를 전달하는 코드와 관련 테스트, 커밋·안전한 통합·실사용 앱 반영·최종 QA
+- Out of scope: 다른 작업 세션 중단, 기존 dirty checkout의 관련 없는 수정, Safari/Chrome/Playwright 우회, 외부 서비스 변경
+- Done means: 별도 dev Orca와 반영된 실사용 Orca의 새 Codex 세션에서 Browser 플러그인이 현재 패널을 직접 발견하고 화면을 읽습니다.
+- How to verify: 실패 테스트, 관련 테스트·타입 검사, dev 런타임 새 세션의 `iab` 발견과 URL/가시 상태 확인
+- Main risks: 연결 정보 규약이 Orca 저장소 밖 Codex 호스트에만 있거나, dev 앱과 현재 플러그인 버전이 호환되지 않을 수 있습니다.
+
+## API 작업 체크리스트
+- 요청 원문: 완벽한 해결을 원한다.
+- 작업 분류: 로컬 세션 연결 계약 수정
+- 대상 API: Orca와 Codex 도구 요청 사이의 브라우저 연결 메타데이터
+- 대상 환경: local dev
+- method: 로컬 IPC/MCP 세션 초기화
+- payload: 현재 작업공간과 현재 표시 브라우저를 식별하는 최소 연결 정보
+- auth/account: 없음
+- 대상 객체: 별도 dev Orca의 새 Codex 세션과 브라우저 패널
+- 예상 화면 변화: 새 세션이 이미 열린 브라우저를 즉시 제어 가능
+- 영향 범위: Orca가 시작한 Codex 세션
+- rollback: 독립 worktree 변경을 폐기하고 현재 설치 앱을 유지
+- 검증 방법: 새 세션에서 Browser 플러그인 직접 발견과 화면 읽기
+- 실행 주체: Codex 가능
+
+## Design / Decisions
+- 연결 대상은 같은 작업공간의 현재 표시 브라우저 하나여야 합니다.
+- 연결 정보가 없을 때 다른 브라우저로 자동 전환하지 않습니다.
+- POSIX Browser client는 `/tmp/codex-browser-use` 디렉토리의 하위 소켓을 열거하므로 Orca 인스턴스별 소켓을 그 아래에 생성합니다.
+- 요청 `session_id`는 live local Codex pane의 provider session과 정확히 일치할 때만 worktree로 해석하며, 한 socket 연결에서 다른 session id로 변경할 수 없습니다.
+- Browser Use CDP는 Electron WebContents에 직접 명령만 던지지 않고 기존 `CdpWsProxy`의 target/session·navigation·screenshot 보정 경로를 전용 연결로 재사용합니다.
+- SSH 세션은 local pipe에 잘못 연결하지 않으며, 이번 macOS local 검증만으로 SSH·Windows 지원 완료를 주장하지 않습니다.
+
+## AI Operating Model
+- AI에게 맡길 일: 코드 경로 조사, 테스트·구현, dev 검증, 회귀 위험 점검
+- 사람이 직접 결정할 일: 운영 앱 설치·배포 여부
+- 검증/근거 산출물: 테스트 결과, dev 세션의 직접 연결 결과, 독립 리뷰
+- 품질 루프 강도와 확인 내용: 실패 비용이 높은 연결 수정으로 테스트·실행·peer 3단 확인
+
+## Operating Cadence
+- owner: Codex
+- due: 현재 세션
+- readout date: 07/17
+- kill criteria: 제품 저장소 밖의 비공개 Codex 호스트 변경 없이는 직접 연결을 구현할 수 없음이 증명되는 경우
+- review cadence: 원인 확정 후 1회, 구현 후 1회, 완료 전 1회
+
+## Implementation Log
+- 07/17 독립 worktree 생성 및 Browser 플러그인 빈 목록 재현
+- 07/17 Browser client가 `/tmp/codex-browser-use/<name>`을 열거하고 4-byte little-endian JSON-RPC frame으로 `getInfo`를 호출하는 계약 확인
+- 07/17 실패 테스트 선작성 후 native-pipe backend, session/worktree/tab mapping, connection session binding 구현
+- 07/17 AgentBrowserBridge가 worktree-scoped WebContents에 전용 `CdpWsProxy`를 만들도록 연결하고, CDP request/event/target attach 어댑터 구현
+- 07/17 독립 아키텍처 리뷰 수행: stale status, 다중 세션, 전체 protocol, CDP lifecycle, SSH 경계를 차단 이슈로 반영
+- 07/17 관련 단위 테스트 2개와 전체 TypeScript typecheck 통과
+- 07/17 설치 앱과 분리된 `IAB Direct Connection QA` dev Orca 기동
+- 07/18 Browser client의 IAB 필터가 요구하는 `codexAppBuildFlavor: "prod"` 계약을 확인하고 응답에 반영
+- 07/18 정리된 최종 dev 빌드에서 공식 Browser 런타임이 `iab` 선택 후 `https://example.com/`, `Example Domain`, 본문을 직접 읽음
+- 07/18 세션 전환 차단과 CDP 라우팅 회귀 테스트를 추가하고 당시 관련 테스트 5개, 전체 타입 검사, 변경 파일 lint 통과
+- 07/18 native 연결 소유권을 모든 target/CDP 호출에 적용하고 탭별 attach 직렬화, 이전 owner 거부, 동시 attach 테스트 추가
+- 07/18 렌더러 process swap 시 stale CDP 연결 종료·새 프록시 재생성·진행 중 명령 1회 재시도 경로 추가
+- 07/18 최상위 `Page.navigate`를 renderer 소유 탭 모델과 `<webview>.src` 갱신 경로에 연결
+- 07/18 최종 dev 빌드에서 같은 Browser/tab 객체의 `example.com` → `example.org` 이동과 URL·제목·본문 읽기 성공, 별도 새 Browser 연결에서도 같은 tabId와 동일 콘텐츠 재확인
+
+## Recent Changes
+- 규칙 우회가 아니라 Orca main process가 Browser 플러그인의 native-pipe backend가 되도록 제품 연결 계층을 추가했습니다.
+
+## Remaining Work
+- [x] 연결 정보 생성·전달 경로 확인
+- [x] 실패 테스트 작성 및 재현
+- [x] 최소 구현과 관련 테스트 통과
+- [x] 별도 dev Orca의 새 세션 직접 연결 검증
+- [x] 독립 리뷰와 Done gate
+- [x] 전체 desktop/native 빌드 통과
+- [ ] 변경 커밋과 원격 백업
+- [ ] 실사용 Orca 앱 반영과 최종 QA
+
+## Risks / Blockers
+- macOS local Codex 직접 연결과 process-swap 이동은 완료됐고 현재 blocker는 없습니다.
+- SSH 세션은 local pipe 대상에서 제외했습니다. Windows named pipe 경로는 구현했지만 이번 macOS 환경에서는 실행 검증하지 않았습니다.
+- 잘못되거나 분할된 JSON-RPC frame에 대한 추가 방어 테스트는 후속 hardening 후보이며 현재 macOS local 목표의 완료 차단 사항은 아닙니다.
+
+## Verification
+- 명령/방법: 관련 테스트, 타입 검사, 별도 dev 런타임의 Browser 플러그인 직접 연결
+- 결과: Browser 연결 테스트 15개와 기존 AgentBrowserBridge 회귀를 포함한 관련 테스트 99개, 전체 TypeScript typecheck, 변경 파일 oxlint, `git diff --check`, 전체 desktop/native 빌드 통과. 최종 dev 빌드에서 공식 Browser 런타임이 connection A/tabId 1의 `https://example.com/`을 읽고 같은 객체로 `https://example.org/` 이동 후 URL·제목·본문을 읽었으며, connection B에서도 tabId 1과 동일 화면 내용을 재확인했습니다.
+
+## Release / Handoff
+- 배포/반영 방식: 로컬 독립 worktree에서 검증 후 사용자 승인 범위에 맞춰 반영
+- 운영 전달사항: 현재 설치 앱과 다른 세션은 유지
+- 배포 없음이면 그 이유: 설치 앱 교체·커밋·병합은 이번 작업 계약 밖이며 별도 사용자 결정 사항
+
+## Final Outcome
+- 직접 발견, 렌더러 교체 중 이동, 새 연결 재접속까지 구현과 실제 dev 검증 완료. 독립 리뷰 결과 blocker 0개, major 0개로 Done gate 통과.
+
+## Independent Review
+- Contract met: yes
+- Out-of-scope preserved: yes
+- Verification evidence present: yes
+- Ready for next session: yes
+- Result: blocker 0개 / major 0개 / minor 2개. minor는 문서 최신화와 protocol negative coverage이며 현재 완료 범위를 막지 않음
+
+## Compact Preservation
+- Current work / 현재 작업: Orca Browser 플러그인 직접 연결·교차 출처 이동·재접속 구현, dev 검증, 독립 리뷰 완료
+- User request / 사용자 요청: 규칙 우회가 아닌 완벽한 해결
+- Decision rationale / 판단 이유: 패널은 정상이고 플러그인 요청에 브라우저 정보가 없습니다.
+- Decisions / 확정 판단: 독립 worktree, 테스트 우선, dev 새 세션 직접 검증
+- Rejected paths / 버린 대안: Orca CLI만으로 완료 처리, 기존 dirty checkout 수정, 다른 브라우저 전환
+- Evidence source paths / 근거 경로: 현재 작업 문서와 조사 후 확정할 코드·테스트
+- Verification / 검증: 공식 Browser 런타임 `iab` 발견, 같은 tab 객체의 `example.com` → `example.org` 이동과 새 connection 재접속 성공, 관련 테스트 99개·typecheck·lint·diff check 통과
+- Remaining risk / 남은 리스크: Windows와 SSH 원격 실행, protocol negative coverage는 이번 macOS local 완료 범위 밖
+- Resume next action / 재개 첫 행동: 필요 시 사용자 결정에 따라 커밋·병합·설치 앱 반영을 별도 작업으로 시작
+
+## Next Step
+- 다음 세션이 바로 실행할 첫 행동 1개: 사용자 요청이 있으면 커밋·병합·설치 앱 반영 범위를 확정
+- 이어 쓰면 안 되는 별도 작업: 기존 Shift+Enter 및 다른 Orca 기능 수정

--- a/ORCA-IAB-BROWSER-CONNECTION.task-state.md
+++ b/ORCA-IAB-BROWSER-CONNECTION.task-state.md
@@ -127,6 +127,7 @@
 - 07/18 fragmented·coalesced·malformed·oversized frame, Windows named-pipe 경로, POSIX 소켓 디렉토리 소유권·권한·symlink·regular-file 방어 테스트 추가
 - 07/18 hardening 포함 전체 unpack 앱을 재빌드·심층 서명 검증하고 `/Applications/Orca.app`에 재설치
 - 07/18 재시작한 설치 앱에서 공식 Browser가 테스트 탭을 발견하고 동일 객체로 `example.com` → `example.org` 이동, 새 Browser 연결 재발견까지 통과. 테스트 탭만 정리하고 기존 사용자 탭 보존
+- 07/18 최종 실행 프로세스에서 macOS가 부착한 번들 루트 Finder 메타데이터를 제거하고, 앱 실행 상태의 strict 심층 서명과 새 runtime의 Browser 동일 탭 이동·재발견을 다시 통과
 - 07/18 원본 저장소 PR #9249 생성. GitHub 기준 mergeable이며 현재 자동 체크 통과
 
 ## Recent Changes
@@ -154,7 +155,7 @@
 
 ## Verification
 - 명령/방법: 관련 테스트, 타입 검사, 별도 dev 런타임의 Browser 플러그인 직접 연결
-- 결과: Browser 연결·protocol hardening과 기존 AgentBrowserBridge 회귀를 포함한 관련 테스트 107개, 전체 TypeScript typecheck, 변경 파일 oxlint, `git diff --check`, hardening 포함 전체 desktop/native unpack 빌드와 설치 전·후 strict 심층 서명 검증 통과. 교체·재시작한 실사용 Orca에서도 공식 Browser가 `example.com`을 직접 발견하고 같은 객체로 `example.org` 이동 후 URL·제목·본문을 읽었으며, 별도 새 Browser 연결에서 같은 탭을 재인식했습니다. 검증용 탭은 정리하고 기존 사용자 탭은 보존했습니다.
+- 결과: Browser 연결·protocol hardening과 기존 AgentBrowserBridge 회귀를 포함한 관련 테스트 107개, 전체 TypeScript typecheck, 변경 파일 oxlint, `git diff --check`, hardening 포함 전체 desktop/native unpack 빌드와 설치 전·실행 중 strict 심층 서명 검증 통과. 최종 실행 runtime의 실사용 Orca에서도 공식 Browser가 `example.com`을 직접 발견하고 같은 객체로 `example.org` 이동 후 URL·제목·본문을 읽었으며, 별도 새 Browser 연결에서 같은 탭을 재인식했습니다. 검증용 탭은 정리하고 기존 사용자 탭은 보존했습니다.
 
 ## Release / Handoff
 - 배포/반영 방식: 서명된 macOS unpack 앱을 `/Applications/Orca.app`에 반영하고 재시작

--- a/ORCA-IAB-BROWSER-CONNECTION.task-state.md
+++ b/ORCA-IAB-BROWSER-CONNECTION.task-state.md
@@ -3,7 +3,7 @@
 ## Linear Source
 - 이슈: N/A
 - 링크: N/A
-- 상태: in-progress
+- 상태: completed
 - 담당: Codex
 
 ## Goal
@@ -47,7 +47,7 @@
 - 07/17 패널 배치와 Orca 전용 제어는 확인했으나 Browser 플러그인의 직접 발견은 실패했습니다.
 
 ## Current Status
-- macOS 실사용 직접 연결은 완료했습니다. 사용자의 완전한 완수 요청에 따라 protocol negative coverage, Windows 경로, SSH 오연결 방지 검증과 원본 저장소 병합 요청을 추가 완료 범위로 진행합니다.
+- 구현·protocol hardening·서명 빌드·실사용 앱 재설치·공식 Browser 직접 QA·원본 저장소 PR 생성을 모두 완료했습니다. upstream 리뷰와 병합만 외부 결정으로 남아 있습니다.
 
 ## Context Lens
 - Required: yes
@@ -62,6 +62,7 @@
 - Selected bundle/lens: `base`, `code`, `api`, `browser`, `release`; engineering + product
 - Applied instructions: 독립 worktree, 테스트 선작성, 실제 dev 화면 검증, peer 검토, 다른 세션과 사용자 변경 보존, 현재 표시 패널만 직접 연결, deploy 절차의 빌드·테스트·실사용 검증 및 커밋·push 전 사용자 확인
 - Latest review applied: native socket별 CDP 소유권·재연결 cleanup, 지원 API 축소 광고, backend 시작 실패 격리, local/live/unique resolver와 reconnect 테스트를 완료 조건에 추가
+- Latest completion receipt: 동일 `base`·`code`·`api`·`browser`·`release` bundle과 engineering + product lens를 유지해 hardening 전체 빌드·서명·설치 앱 공식 Browser QA·원본 PR 상태 확인·복구본 보존 기준을 적용했습니다.
 - N/A or deferred: 외부 서비스 변경은 요청 범위 밖입니다. 커밋·통합·기존 Orca 앱 반영은 07/18 사용자의 후속 요청으로 범위에 추가됐습니다.
 - Re-read trigger: 대상 경로가 세션 연결이 아닌 플러그인 패키지나 외부 Codex 호스트로 바뀌는 경우입니다.
 
@@ -124,6 +125,9 @@
 - 07/18 최상위 `Page.navigate`를 renderer 소유 탭 모델과 `<webview>.src` 갱신 경로에 연결
 - 07/18 최종 dev 빌드에서 같은 Browser/tab 객체의 `example.com` → `example.org` 이동과 URL·제목·본문 읽기 성공, 별도 새 Browser 연결에서도 같은 tabId와 동일 콘텐츠 재확인
 - 07/18 fragmented·coalesced·malformed·oversized frame, Windows named-pipe 경로, POSIX 소켓 디렉토리 소유권·권한·symlink·regular-file 방어 테스트 추가
+- 07/18 hardening 포함 전체 unpack 앱을 재빌드·심층 서명 검증하고 `/Applications/Orca.app`에 재설치
+- 07/18 재시작한 설치 앱에서 공식 Browser가 테스트 탭을 발견하고 동일 객체로 `example.com` → `example.org` 이동, 새 Browser 연결 재발견까지 통과. 테스트 탭만 정리하고 기존 사용자 탭 보존
+- 07/18 원본 저장소 PR #9249 생성. GitHub 기준 mergeable이며 현재 자동 체크 통과
 
 ## Recent Changes
 - 규칙 우회가 아니라 Orca main process가 Browser 플러그인의 native-pipe backend가 되도록 제품 연결 계층을 추가했습니다.
@@ -140,25 +144,25 @@
 - [x] 실사용 Orca 앱 반영과 최종 QA
 - [x] protocol 분할·병합·초과 크기·malformed frame 방어 검증
 - [x] Windows named-pipe와 SSH 제외 경계 검증
-- [ ] 원본 저장소 병합 요청
+- [x] 원본 저장소 병합 요청
 
 ## Risks / Blockers
 - macOS local Codex 직접 연결과 process-swap 이동에는 코드 blocker가 없습니다.
 - SSH 세션은 local pipe 대상에서 제외했습니다. Windows named pipe 경로는 구현·단위 검증했습니다.
 - Windows named-pipe 문자열 계약과 SSH 세션 제외는 단위 테스트로 검증했습니다. 실제 Windows OS와 SSH 원격 GUI 실행은 해당 환경의 CI/실행 검증이 필요합니다.
-- 원본 `stablyai/orca`에는 두 개인 계정 모두 쓰기 권한이 없어, 사용자 승인에 따라 `jeonghoon0126/orca` 개인 fork에 백업했습니다.
+- 원본 `stablyai/orca` 직접 push 권한은 없지만, 사용자 승인 계정의 `jeonghoon0126/orca` fork에서 원본 PR #9249를 열었습니다. 코드 작업 blocker는 없으며 upstream 리뷰·병합은 저장소 관리자 결정입니다.
 
 ## Verification
 - 명령/방법: 관련 테스트, 타입 검사, 별도 dev 런타임의 Browser 플러그인 직접 연결
-- 결과: Browser 연결·protocol hardening과 기존 AgentBrowserBridge 회귀를 포함한 관련 테스트 107개, 전체 TypeScript typecheck, 변경 파일 oxlint, `git diff --check`, 전체 desktop/native 빌드와 서명 검증 통과. dev 앱뿐 아니라 교체·재시작한 실사용 Orca에서도 공식 Browser가 `example.com`을 직접 읽고 같은 객체로 `example.org` 이동 후 URL·제목·본문을 읽었으며, 새 Browser 연결에서 같은 탭을 재인식했습니다. 검증용 탭은 정리하고 기존 사용자 탭은 보존했습니다.
+- 결과: Browser 연결·protocol hardening과 기존 AgentBrowserBridge 회귀를 포함한 관련 테스트 107개, 전체 TypeScript typecheck, 변경 파일 oxlint, `git diff --check`, hardening 포함 전체 desktop/native unpack 빌드와 설치 전·후 strict 심층 서명 검증 통과. 교체·재시작한 실사용 Orca에서도 공식 Browser가 `example.com`을 직접 발견하고 같은 객체로 `example.org` 이동 후 URL·제목·본문을 읽었으며, 별도 새 Browser 연결에서 같은 탭을 재인식했습니다. 검증용 탭은 정리하고 기존 사용자 탭은 보존했습니다.
 
 ## Release / Handoff
 - 배포/반영 방식: 서명된 macOS unpack 앱을 `/Applications/Orca.app`에 반영하고 재시작
-- 운영 전달사항: 이전 앱은 `/Applications/Orca.app.pre-iab-backup`에 복구용으로 보존, 사용자 데이터와 기존 탭 유지
-- 원격 반영: `jeonghoon0126/orca` 개인 fork의 해결 브랜치
+- 운영 전달사항: 최초 앱은 `/Applications/Orca.app.pre-iab-backup`, hardening 직전 직접 연결 앱은 `/Applications/Orca.app.pre-hardening-backup`에 복구용으로 보존. 사용자 데이터와 기존 탭 유지
+- 원격 반영: `jeonghoon0126/orca` 개인 fork의 해결 브랜치 및 원본 저장소 PR https://github.com/stablyai/orca/pull/9249
 
 ## Final Outcome
-- Browser 패널 직접 발견과 protocol hardening을 코드·dev 앱·실사용 앱에서 해결했습니다. 설치 앱 최신 반영과 원본 저장소 병합 요청이 남았습니다.
+- Browser 패널 직접 발견과 protocol hardening을 코드·dev 앱·최신 실사용 앱에서 해결하고 원본 저장소 PR까지 열었습니다. 현재 요청 범위의 구현과 로컬 반영은 완료됐고, upstream 리뷰·병합만 외부 결정입니다.
 
 ## Independent Review
 - Contract met: yes
@@ -175,9 +179,9 @@
 - Rejected paths / 버린 대안: Orca CLI만으로 완료 처리, 기존 dirty checkout 수정, 다른 브라우저 전환
 - Evidence source paths / 근거 경로: 현재 작업 문서와 조사 후 확정할 코드·테스트
 - Verification / 검증: 공식 Browser 런타임 `iab` 발견, 같은 tab 객체의 `example.com` → `example.org` 이동과 새 connection 재접속 성공, 관련 테스트 107개·typecheck·lint·diff check 통과
-- Remaining risk / 남은 리스크: 실제 Windows OS와 SSH 원격 GUI 실행은 원본 저장소 CI/해당 환경 검증 대상
-- Resume next action / 재개 첫 행동: hardening 커밋·실사용 앱 재반영 후 원본 저장소 PR 생성
+- Remaining risk / 남은 리스크: 실제 Windows OS와 SSH 원격 GUI 실행은 원본 저장소 CI/해당 환경 검증 대상이며, macOS local 완료 주장과 분리합니다.
+- Resume next action / 재개 첫 행동: upstream PR #9249 리뷰 결과 확인
 
 ## Next Step
-- 다음 세션이 바로 실행할 첫 행동 1개: hardening 변경을 커밋하고 개인 fork에 push
+- 다음 세션이 바로 실행할 첫 행동 1개: upstream PR #9249의 리뷰·병합 상태 확인
 - 이어 쓰면 안 되는 별도 작업: 기존 Shift+Enter 및 다른 Orca 기능 수정

--- a/ORCA-IAB-BROWSER-CONNECTION.task-state.md
+++ b/ORCA-IAB-BROWSER-CONNECTION.task-state.md
@@ -3,7 +3,7 @@
 ## Linear Source
 - 이슈: N/A
 - 링크: N/A
-- 상태: completed
+- 상태: in-progress
 - 담당: Codex
 
 ## Goal
@@ -47,7 +47,7 @@
 - 07/17 패널 배치와 Orca 전용 제어는 확인했으나 Browser 플러그인의 직접 발견은 실패했습니다.
 
 ## Current Status
-- 직접 연결 구현, dev·실사용 앱 검증, 독립 리뷰, 전체 빌드, 커밋, 개인 fork 백업과 `/Applications/Orca.app` 반영을 완료했습니다. 재시작된 실사용 Orca에서 공식 Browser가 현재 폴더 브라우저를 직접 발견했고 동일 탭 이동과 새 연결 재인식을 확인했습니다.
+- macOS 실사용 직접 연결은 완료했습니다. 사용자의 완전한 완수 요청에 따라 protocol negative coverage, Windows 경로, SSH 오연결 방지 검증과 원본 저장소 병합 요청을 추가 완료 범위로 진행합니다.
 
 ## Context Lens
 - Required: yes
@@ -123,6 +123,7 @@
 - 07/18 렌더러 process swap 시 stale CDP 연결 종료·새 프록시 재생성·진행 중 명령 1회 재시도 경로 추가
 - 07/18 최상위 `Page.navigate`를 renderer 소유 탭 모델과 `<webview>.src` 갱신 경로에 연결
 - 07/18 최종 dev 빌드에서 같은 Browser/tab 객체의 `example.com` → `example.org` 이동과 URL·제목·본문 읽기 성공, 별도 새 Browser 연결에서도 같은 tabId와 동일 콘텐츠 재확인
+- 07/18 fragmented·coalesced·malformed·oversized frame, Windows named-pipe 경로, POSIX 소켓 디렉토리 소유권·권한·symlink·regular-file 방어 테스트 추가
 
 ## Recent Changes
 - 규칙 우회가 아니라 Orca main process가 Browser 플러그인의 native-pipe backend가 되도록 제품 연결 계층을 추가했습니다.
@@ -137,16 +138,19 @@
 - [x] 변경 로컬 커밋
 - [x] 개인 fork 원격 백업
 - [x] 실사용 Orca 앱 반영과 최종 QA
+- [x] protocol 분할·병합·초과 크기·malformed frame 방어 검증
+- [x] Windows named-pipe와 SSH 제외 경계 검증
+- [ ] 원본 저장소 병합 요청
 
 ## Risks / Blockers
 - macOS local Codex 직접 연결과 process-swap 이동에는 코드 blocker가 없습니다.
-- SSH 세션은 local pipe 대상에서 제외했습니다. Windows named pipe 경로는 구현했지만 이번 macOS 환경에서는 실행 검증하지 않았습니다.
-- 잘못되거나 분할된 JSON-RPC frame에 대한 추가 방어 테스트는 후속 hardening 후보이며 현재 macOS local 목표의 완료 차단 사항은 아닙니다.
+- SSH 세션은 local pipe 대상에서 제외했습니다. Windows named pipe 경로는 구현·단위 검증했습니다.
+- Windows named-pipe 문자열 계약과 SSH 세션 제외는 단위 테스트로 검증했습니다. 실제 Windows OS와 SSH 원격 GUI 실행은 해당 환경의 CI/실행 검증이 필요합니다.
 - 원본 `stablyai/orca`에는 두 개인 계정 모두 쓰기 권한이 없어, 사용자 승인에 따라 `jeonghoon0126/orca` 개인 fork에 백업했습니다.
 
 ## Verification
 - 명령/방법: 관련 테스트, 타입 검사, 별도 dev 런타임의 Browser 플러그인 직접 연결
-- 결과: Browser 연결 테스트 15개와 기존 AgentBrowserBridge 회귀를 포함한 관련 테스트 99개, 전체 TypeScript typecheck, 변경 파일 oxlint, `git diff --check`, 전체 desktop/native 빌드와 서명 검증 통과. dev 앱뿐 아니라 교체·재시작한 실사용 Orca에서도 공식 Browser가 `example.com`을 직접 읽고 같은 객체로 `example.org` 이동 후 URL·제목·본문을 읽었으며, 새 Browser 연결에서 같은 탭을 재인식했습니다. 검증용 탭은 정리하고 기존 사용자 탭은 보존했습니다.
+- 결과: Browser 연결·protocol hardening과 기존 AgentBrowserBridge 회귀를 포함한 관련 테스트 107개, 전체 TypeScript typecheck, 변경 파일 oxlint, `git diff --check`, 전체 desktop/native 빌드와 서명 검증 통과. dev 앱뿐 아니라 교체·재시작한 실사용 Orca에서도 공식 Browser가 `example.com`을 직접 읽고 같은 객체로 `example.org` 이동 후 URL·제목·본문을 읽었으며, 새 Browser 연결에서 같은 탭을 재인식했습니다. 검증용 탭은 정리하고 기존 사용자 탭은 보존했습니다.
 
 ## Release / Handoff
 - 배포/반영 방식: 서명된 macOS unpack 앱을 `/Applications/Orca.app`에 반영하고 재시작
@@ -154,14 +158,14 @@
 - 원격 반영: `jeonghoon0126/orca` 개인 fork의 해결 브랜치
 
 ## Final Outcome
-- Browser 패널 직접 발견 문제를 코드·dev 앱·실사용 앱에서 해결했습니다. 설치 앱 교체 후 동일 탭 이동과 새 연결 재인식까지 통과했으며 blocker는 없습니다.
+- Browser 패널 직접 발견과 protocol hardening을 코드·dev 앱·실사용 앱에서 해결했습니다. 설치 앱 최신 반영과 원본 저장소 병합 요청이 남았습니다.
 
 ## Independent Review
 - Contract met: yes
 - Out-of-scope preserved: yes
 - Verification evidence present: yes
 - Ready for next session: yes
-- Result: blocker 0개 / major 0개 / minor 2개. minor는 문서 최신화와 protocol negative coverage이며 현재 완료 범위를 막지 않음
+- Result: 기존 리뷰 blocker 0개 / major 0개. 당시 minor였던 문서 최신화와 protocol negative coverage도 반영 완료
 
 ## Compact Preservation
 - Current work / 현재 작업: Orca Browser 플러그인 직접 연결·교차 출처 이동·재접속 구현, dev·실사용 검증, 앱 반영 완료
@@ -170,10 +174,10 @@
 - Decisions / 확정 판단: 독립 worktree, 테스트 우선, dev 새 세션 직접 검증
 - Rejected paths / 버린 대안: Orca CLI만으로 완료 처리, 기존 dirty checkout 수정, 다른 브라우저 전환
 - Evidence source paths / 근거 경로: 현재 작업 문서와 조사 후 확정할 코드·테스트
-- Verification / 검증: 공식 Browser 런타임 `iab` 발견, 같은 tab 객체의 `example.com` → `example.org` 이동과 새 connection 재접속 성공, 관련 테스트 99개·typecheck·lint·diff check 통과
-- Remaining risk / 남은 리스크: Windows와 SSH 원격 실행, protocol negative coverage는 이번 macOS local 완료 범위 밖
-- Resume next action / 재개 첫 행동: 없음. 후속 hardening이 필요하면 별도 작업으로 시작
+- Verification / 검증: 공식 Browser 런타임 `iab` 발견, 같은 tab 객체의 `example.com` → `example.org` 이동과 새 connection 재접속 성공, 관련 테스트 107개·typecheck·lint·diff check 통과
+- Remaining risk / 남은 리스크: 실제 Windows OS와 SSH 원격 GUI 실행은 원본 저장소 CI/해당 환경 검증 대상
+- Resume next action / 재개 첫 행동: hardening 커밋·실사용 앱 재반영 후 원본 저장소 PR 생성
 
 ## Next Step
-- 다음 세션이 바로 실행할 첫 행동 1개: 없음 — 현재 완료 상태 유지
+- 다음 세션이 바로 실행할 첫 행동 1개: hardening 변경을 커밋하고 개인 fork에 push
 - 이어 쓰면 안 되는 별도 작업: 기존 Shift+Enter 및 다른 Orca 기능 수정

--- a/ORCA-IAB-BROWSER-CONNECTION.task-state.md
+++ b/ORCA-IAB-BROWSER-CONNECTION.task-state.md
@@ -3,7 +3,7 @@
 ## Linear Source
 - 이슈: N/A
 - 링크: N/A
-- 상태: in-progress
+- 상태: completed
 - 담당: Codex
 
 ## Goal
@@ -47,7 +47,7 @@
 - 07/17 패널 배치와 Orca 전용 제어는 확인했으나 Browser 플러그인의 직접 발견은 실패했습니다.
 
 ## Current Status
-- 직접 연결 구현, 실제 dev 검증, 독립 리뷰, 전체 빌드와 로컬 커밋을 완료했습니다. 원격 저장소가 현재 GitHub 계정의 쓰기와 SSH 인증을 모두 거부해 deploy 절차가 중단됐으며, 실사용 앱 교체는 시작하지 않았습니다.
+- 직접 연결 구현, dev·실사용 앱 검증, 독립 리뷰, 전체 빌드, 커밋, 개인 fork 백업과 `/Applications/Orca.app` 반영을 완료했습니다. 재시작된 실사용 Orca에서 공식 Browser가 현재 폴더 브라우저를 직접 발견했고 동일 탭 이동과 새 연결 재인식을 확인했습니다.
 
 ## Context Lens
 - Required: yes
@@ -135,26 +135,26 @@
 - [x] 독립 리뷰와 Done gate
 - [x] 전체 desktop/native 빌드 통과
 - [x] 변경 로컬 커밋
-- [ ] 원격 백업 — GitHub 쓰기 권한 필요
-- [ ] 실사용 Orca 앱 반영과 최종 QA
+- [x] 개인 fork 원격 백업
+- [x] 실사용 Orca 앱 반영과 최종 QA
 
 ## Risks / Blockers
 - macOS local Codex 직접 연결과 process-swap 이동에는 코드 blocker가 없습니다.
 - SSH 세션은 local pipe 대상에서 제외했습니다. Windows named pipe 경로는 구현했지만 이번 macOS 환경에서는 실행 검증하지 않았습니다.
 - 잘못되거나 분할된 JSON-RPC frame에 대한 추가 방어 테스트는 후속 hardening 후보이며 현재 macOS local 목표의 완료 차단 사항은 아닙니다.
-- 배포 blocker: HTTPS push는 현재 계정의 저장소 쓰기 권한 부족으로 403, SSH push는 등록된 public key가 없어 거부됐습니다.
+- 원본 `stablyai/orca`에는 두 개인 계정 모두 쓰기 권한이 없어, 사용자 승인에 따라 `jeonghoon0126/orca` 개인 fork에 백업했습니다.
 
 ## Verification
 - 명령/방법: 관련 테스트, 타입 검사, 별도 dev 런타임의 Browser 플러그인 직접 연결
-- 결과: Browser 연결 테스트 15개와 기존 AgentBrowserBridge 회귀를 포함한 관련 테스트 99개, 전체 TypeScript typecheck, 변경 파일 oxlint, `git diff --check`, 전체 desktop/native 빌드 통과. 최종 dev 빌드에서 공식 Browser 런타임이 connection A/tabId 1의 `https://example.com/`을 읽고 같은 객체로 `https://example.org/` 이동 후 URL·제목·본문을 읽었으며, connection B에서도 tabId 1과 동일 화면 내용을 재확인했습니다.
+- 결과: Browser 연결 테스트 15개와 기존 AgentBrowserBridge 회귀를 포함한 관련 테스트 99개, 전체 TypeScript typecheck, 변경 파일 oxlint, `git diff --check`, 전체 desktop/native 빌드와 서명 검증 통과. dev 앱뿐 아니라 교체·재시작한 실사용 Orca에서도 공식 Browser가 `example.com`을 직접 읽고 같은 객체로 `example.org` 이동 후 URL·제목·본문을 읽었으며, 새 Browser 연결에서 같은 탭을 재인식했습니다. 검증용 탭은 정리하고 기존 사용자 탭은 보존했습니다.
 
 ## Release / Handoff
-- 배포/반영 방식: 로컬 독립 worktree에서 검증 후 사용자 승인 범위에 맞춰 반영
-- 운영 전달사항: 현재 설치 앱과 다른 세션은 유지
-- 배포 없음이면 그 이유: 설치 앱 교체·커밋·병합은 이번 작업 계약 밖이며 별도 사용자 결정 사항
+- 배포/반영 방식: 서명된 macOS unpack 앱을 `/Applications/Orca.app`에 반영하고 재시작
+- 운영 전달사항: 이전 앱은 `/Applications/Orca.app.pre-iab-backup`에 복구용으로 보존, 사용자 데이터와 기존 탭 유지
+- 원격 반영: `jeonghoon0126/orca` 개인 fork의 해결 브랜치
 
 ## Final Outcome
-- 코드 Done gate와 로컬 커밋은 완료했습니다. 원격 백업 권한이 없어 배포 파이프라인과 실사용 앱 교체는 대기 중입니다.
+- Browser 패널 직접 발견 문제를 코드·dev 앱·실사용 앱에서 해결했습니다. 설치 앱 교체 후 동일 탭 이동과 새 연결 재인식까지 통과했으며 blocker는 없습니다.
 
 ## Independent Review
 - Contract met: yes
@@ -164,7 +164,7 @@
 - Result: blocker 0개 / major 0개 / minor 2개. minor는 문서 최신화와 protocol negative coverage이며 현재 완료 범위를 막지 않음
 
 ## Compact Preservation
-- Current work / 현재 작업: Orca Browser 플러그인 직접 연결·교차 출처 이동·재접속 구현, dev 검증, 독립 리뷰 완료
+- Current work / 현재 작업: Orca Browser 플러그인 직접 연결·교차 출처 이동·재접속 구현, dev·실사용 검증, 앱 반영 완료
 - User request / 사용자 요청: 규칙 우회가 아닌 완벽한 해결
 - Decision rationale / 판단 이유: 패널은 정상이고 플러그인 요청에 브라우저 정보가 없습니다.
 - Decisions / 확정 판단: 독립 worktree, 테스트 우선, dev 새 세션 직접 검증
@@ -172,8 +172,8 @@
 - Evidence source paths / 근거 경로: 현재 작업 문서와 조사 후 확정할 코드·테스트
 - Verification / 검증: 공식 Browser 런타임 `iab` 발견, 같은 tab 객체의 `example.com` → `example.org` 이동과 새 connection 재접속 성공, 관련 테스트 99개·typecheck·lint·diff check 통과
 - Remaining risk / 남은 리스크: Windows와 SSH 원격 실행, protocol negative coverage는 이번 macOS local 완료 범위 밖
-- Resume next action / 재개 첫 행동: stablyai/orca 쓰기 권한이 있는 GitHub 인증을 활성화한 뒤 push부터 재개
+- Resume next action / 재개 첫 행동: 없음. 후속 hardening이 필요하면 별도 작업으로 시작
 
 ## Next Step
-- 다음 세션이 바로 실행할 첫 행동 1개: 권한 있는 GitHub 인증으로 해결 브랜치를 push
+- 다음 세션이 바로 실행할 첫 행동 1개: 없음 — 현재 완료 상태 유지
 - 이어 쓰면 안 되는 별도 작업: 기존 Shift+Enter 및 다른 Orca 기능 수정

--- a/ORCA-IAB-BROWSER-CONNECTION.task-state.md
+++ b/ORCA-IAB-BROWSER-CONNECTION.task-state.md
@@ -47,7 +47,7 @@
 - 07/17 패널 배치와 Orca 전용 제어는 확인했으나 Browser 플러그인의 직접 발견은 실패했습니다.
 
 ## Current Status
-- 독립 worktree의 직접 연결 구현, 실제 dev 검증, 독립 리뷰와 코드 Done gate를 완료했습니다. 사용자의 "끝까지 진행" 요청에 따라 커밋·통합·실사용 앱 반영 및 최종 QA를 새 완료 범위로 진행합니다.
+- 직접 연결 구현, 실제 dev 검증, 독립 리뷰, 전체 빌드와 로컬 커밋을 완료했습니다. 원격 저장소가 현재 GitHub 계정의 쓰기와 SSH 인증을 모두 거부해 deploy 절차가 중단됐으며, 실사용 앱 교체는 시작하지 않았습니다.
 
 ## Context Lens
 - Required: yes
@@ -134,13 +134,15 @@
 - [x] 별도 dev Orca의 새 세션 직접 연결 검증
 - [x] 독립 리뷰와 Done gate
 - [x] 전체 desktop/native 빌드 통과
-- [ ] 변경 커밋과 원격 백업
+- [x] 변경 로컬 커밋
+- [ ] 원격 백업 — GitHub 쓰기 권한 필요
 - [ ] 실사용 Orca 앱 반영과 최종 QA
 
 ## Risks / Blockers
-- macOS local Codex 직접 연결과 process-swap 이동은 완료됐고 현재 blocker는 없습니다.
+- macOS local Codex 직접 연결과 process-swap 이동에는 코드 blocker가 없습니다.
 - SSH 세션은 local pipe 대상에서 제외했습니다. Windows named pipe 경로는 구현했지만 이번 macOS 환경에서는 실행 검증하지 않았습니다.
 - 잘못되거나 분할된 JSON-RPC frame에 대한 추가 방어 테스트는 후속 hardening 후보이며 현재 macOS local 목표의 완료 차단 사항은 아닙니다.
+- 배포 blocker: HTTPS push는 현재 계정의 저장소 쓰기 권한 부족으로 403, SSH push는 등록된 public key가 없어 거부됐습니다.
 
 ## Verification
 - 명령/방법: 관련 테스트, 타입 검사, 별도 dev 런타임의 Browser 플러그인 직접 연결
@@ -152,7 +154,7 @@
 - 배포 없음이면 그 이유: 설치 앱 교체·커밋·병합은 이번 작업 계약 밖이며 별도 사용자 결정 사항
 
 ## Final Outcome
-- 직접 발견, 렌더러 교체 중 이동, 새 연결 재접속까지 구현과 실제 dev 검증 완료. 독립 리뷰 결과 blocker 0개, major 0개로 Done gate 통과.
+- 코드 Done gate와 로컬 커밋은 완료했습니다. 원격 백업 권한이 없어 배포 파이프라인과 실사용 앱 교체는 대기 중입니다.
 
 ## Independent Review
 - Contract met: yes
@@ -170,8 +172,8 @@
 - Evidence source paths / 근거 경로: 현재 작업 문서와 조사 후 확정할 코드·테스트
 - Verification / 검증: 공식 Browser 런타임 `iab` 발견, 같은 tab 객체의 `example.com` → `example.org` 이동과 새 connection 재접속 성공, 관련 테스트 99개·typecheck·lint·diff check 통과
 - Remaining risk / 남은 리스크: Windows와 SSH 원격 실행, protocol negative coverage는 이번 macOS local 완료 범위 밖
-- Resume next action / 재개 첫 행동: 필요 시 사용자 결정에 따라 커밋·병합·설치 앱 반영을 별도 작업으로 시작
+- Resume next action / 재개 첫 행동: stablyai/orca 쓰기 권한이 있는 GitHub 인증을 활성화한 뒤 push부터 재개
 
 ## Next Step
-- 다음 세션이 바로 실행할 첫 행동 1개: 사용자 요청이 있으면 커밋·병합·설치 앱 반영 범위를 확정
+- 다음 세션이 바로 실행할 첫 행동 1개: 권한 있는 GitHub 인증으로 해결 브랜치를 push
 - 이어 쓰면 안 되는 별도 작업: 기존 Shift+Enter 및 다른 Orca 기능 수정

--- a/src/main/browser/agent-browser-bridge.test.ts
+++ b/src/main/browser/agent-browser-bridge.test.ts
@@ -84,6 +84,7 @@ function mockBrowserManager(
     unregisterGuest: vi.fn(),
     ensureWebviewVisible: vi.fn(async () => () => {}),
     acquireAutomationVisibility: vi.fn(async () => () => {}),
+    requestBrowserTabNavigation: vi.fn(() => true),
     ...overrides
   } as unknown as BrowserManager
 }
@@ -306,6 +307,20 @@ describe('AgentBrowserBridge', () => {
     const args = execFileMock.mock.calls[0][1] as string[]
     expect(args).toContain('--session')
     expect(args[args.indexOf('--session') + 1]).toBe('orca-tab-tab-1')
+  })
+
+  it('routes Browser Use navigation through the renderer-owned tab model', async () => {
+    const requestNavigation = vi.fn(() => true)
+    const tabs = new Map([['tab-1', 100]])
+    const worktrees = new Map([['tab-1', 'worktree-1']])
+    const scopedBridge = new AgentBrowserBridge(
+      mockBrowserManager(tabs, worktrees, { requestBrowserTabNavigation: requestNavigation })
+    )
+
+    await expect(
+      scopedBridge.navigateCodexBrowserUseTab('worktree-1', 'tab-1', 'https://example.org/')
+    ).resolves.toEqual({ frameId: 'orca-proxy-target' })
+    expect(requestNavigation).toHaveBeenCalledWith('tab-1', 'https://example.org/')
   })
 
   // ── --cdp first-use only ──

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -536,6 +536,7 @@ export class AgentBrowserBridge {
   // finishes can let the old teardown close the new daemon session.
   private readonly pendingSessionDestruction = new Map<string, Promise<void>>()
   private readonly cancelledProcesses = new WeakSet<ChildProcess>()
+  private readonly codexBrowserUseProcessSwapListeners = new Set<(browserPageId: string) => void>()
 
   constructor(
     private readonly browserManager: BrowserManager,
@@ -595,6 +596,40 @@ export class AgentBrowserBridge {
     }
   }
 
+  createCodexBrowserUseCdpProxy(worktreeId: string, browserPageId: string): CdpWsProxy {
+    const target = this.resolveCommandTarget(worktreeId, browserPageId, true)
+    const webContents = this.getWebContents(target.webContentsId)
+    if (!webContents) {
+      throw new BrowserError(
+        'browser_tab_not_found',
+        `Browser page ${browserPageId} is no longer available`
+      )
+    }
+    // Why: Browser Use needs the same Electron-specific CDP fixes as agent-browser,
+    // while a dedicated proxy keeps concurrent Codex sessions from replacing clients.
+    return new CdpWsProxy(webContents)
+  }
+
+  async navigateCodexBrowserUseTab(
+    worktreeId: string,
+    browserPageId: string,
+    url: string
+  ): Promise<{ frameId: string }> {
+    this.resolveCommandTarget(worktreeId, browserPageId, true)
+    if (!this.browserManager.requestBrowserTabNavigation(browserPageId, url)) {
+      throw new BrowserError(
+        'browser_tab_not_found',
+        `Browser page ${browserPageId} is no longer available`
+      )
+    }
+    return { frameId: 'orca-proxy-target' }
+  }
+
+  onCodexBrowserUseProcessSwap(listener: (browserPageId: string) => void): () => void {
+    this.codexBrowserUseProcessSwapListeners.add(listener)
+    return () => this.codexBrowserUseProcessSwapListeners.delete(listener)
+  }
+
   onTabChanged(webContentsId: number, worktreeId?: string): void {
     this.activeWebContentsId = webContentsId
     if (worktreeId) {
@@ -637,6 +672,9 @@ export class AgentBrowserBridge {
     // Why: Electron process swaps give same browserPageId but new webContentsId.
     // Old proxy's webContents is destroyed, so destroy session and let next command recreate.
     const sessionName = `orca-tab-${browserPageId}`
+    for (const listener of this.codexBrowserUseProcessSwapListeners) {
+      listener(browserPageId)
+    }
     const session = this.sessions.get(sessionName)
     const oldWebContentsId = previousWebContentsId ?? session?.webContentsId
     const owningWorktreeId = this.browserManager.getWorktreeIdForTab(browserPageId)

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -398,6 +398,23 @@ export class BrowserManager {
     return renderer
   }
 
+  requestBrowserTabNavigation(browserTabId: string, rawUrl: string): boolean {
+    const renderer = this.resolveRendererForBrowserTab(browserTabId)
+    const url = normalizeBrowserNavigationUrl(rawUrl)
+    if (!renderer || !url) {
+      return false
+    }
+    // Why: the renderer owns the browser-page model and is the only layer that can
+    // update both the persisted URL and the mounted <webview>.src without creating
+    // a second tab or leaving the address bar stale.
+    renderer.send('browser:navigation-update', {
+      browserPageId: browserTabId,
+      url,
+      title: url
+    })
+    return true
+  }
+
   // Why: screenshot sessions target guest page ids, but Orca's visible browser
   // chrome is keyed by workspace ids. If we activate the page id directly, the
   // webview stays hidden under the terminal pane and Page.captureScreenshot

--- a/src/main/browser/browser-use-cdp-connection.ts
+++ b/src/main/browser/browser-use-cdp-connection.ts
@@ -1,0 +1,177 @@
+import { WebSocket } from 'ws'
+import type { CdpWsProxy } from './cdp-ws-proxy'
+import type { CodexBrowserUseCdpTarget, RpcNotificationEmitter } from './codex-browser-use-protocol'
+
+type PendingCdpRequest = {
+  resolve: (value: unknown) => void
+  reject: (error: Error) => void
+}
+
+export type BrowserUseConnection = {
+  execute: (
+    target: CodexBrowserUseCdpTarget,
+    method: string,
+    params: Record<string, unknown>
+  ) => Promise<unknown>
+  attachTarget: (targetId: string) => Promise<void>
+  detachTarget: (targetId: string) => Promise<void>
+  close: () => Promise<void>
+}
+
+export type BrowserUseConnectionFactory = (
+  proxy: CdpWsProxy,
+  tabId: number,
+  emit: RpcNotificationEmitter,
+  onClose: () => void
+) => Promise<BrowserUseConnection>
+
+export class BrowserUseCdpConnection implements BrowserUseConnection {
+  private readonly pending = new Map<number, PendingCdpRequest>()
+  private readonly debuggerSessionIdByTargetId = new Map<string, string>()
+  private nextId = 1
+  private closeNotified = false
+
+  private constructor(
+    private readonly proxy: CdpWsProxy,
+    private readonly socket: WebSocket,
+    private readonly tabId: number,
+    private readonly emit: RpcNotificationEmitter,
+    private readonly onClose: () => void
+  ) {
+    socket.on('message', (data) => this.onMessage(data.toString()))
+    socket.once('close', () => {
+      this.rejectPending(new Error('Browser CDP connection closed'))
+      this.notifyClose()
+    })
+    socket.once('error', (error) => this.rejectPending(error))
+  }
+
+  static async create(
+    proxy: CdpWsProxy,
+    tabId: number,
+    emit: RpcNotificationEmitter,
+    onClose: () => void
+  ): Promise<BrowserUseCdpConnection> {
+    const endpoint = await proxy.start()
+    const socket = new WebSocket(endpoint)
+    try {
+      await new Promise<void>((resolve, reject) => {
+        socket.once('open', resolve)
+        socket.once('error', reject)
+      })
+      return new BrowserUseCdpConnection(proxy, socket, tabId, emit, onClose)
+    } catch (error) {
+      socket.close()
+      await proxy.stop()
+      throw error
+    }
+  }
+
+  async execute(
+    target: CodexBrowserUseCdpTarget,
+    method: string,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const sessionId = target.targetId
+      ? this.debuggerSessionIdByTargetId.get(target.targetId)
+      : target.sessionId
+    return await this.request(method, params, sessionId)
+  }
+
+  async attachTarget(targetId: string): Promise<void> {
+    const result = (await this.request('Target.attachToTarget', {
+      targetId,
+      flatten: true
+    })) as { sessionId?: unknown }
+    if (typeof result?.sessionId !== 'string') {
+      throw new Error(`Browser target ${targetId} did not return a debugger session`)
+    }
+    this.debuggerSessionIdByTargetId.set(targetId, result.sessionId)
+  }
+
+  async detachTarget(targetId: string): Promise<void> {
+    const sessionId = this.debuggerSessionIdByTargetId.get(targetId)
+    if (!sessionId) {
+      return
+    }
+    this.debuggerSessionIdByTargetId.delete(targetId)
+    await this.request('Target.detachFromTarget', { sessionId })
+  }
+
+  async close(): Promise<void> {
+    this.socket.close()
+    this.rejectPending(new Error('Browser CDP connection closed'))
+    this.notifyClose()
+    await this.proxy.stop()
+  }
+
+  private request(
+    method: string,
+    params: Record<string, unknown>,
+    sessionId?: string
+  ): Promise<unknown> {
+    if (this.socket.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error('Browser CDP connection is not open'))
+    }
+    const id = this.nextId++
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject })
+      this.socket.send(JSON.stringify({ id, method, params, ...(sessionId ? { sessionId } : {}) }))
+    })
+  }
+
+  private onMessage(raw: string): void {
+    let message: {
+      id?: number
+      result?: unknown
+      error?: { message?: string }
+      method?: string
+      params?: unknown
+      sessionId?: string
+    }
+    try {
+      message = JSON.parse(raw) as typeof message
+    } catch {
+      return
+    }
+    if (typeof message.id === 'number') {
+      const pending = this.pending.get(message.id)
+      if (!pending) {
+        return
+      }
+      this.pending.delete(message.id)
+      if (message.error) {
+        pending.reject(new Error(message.error.message ?? 'CDP request failed'))
+      } else {
+        pending.resolve(message.result)
+      }
+      return
+    }
+    if (!message.method) {
+      return
+    }
+    const targetId = message.sessionId
+      ? [...this.debuggerSessionIdByTargetId].find(([, id]) => id === message.sessionId)?.[0]
+      : undefined
+    this.emit('onCDPEvent', {
+      source: { tabId: this.tabId, ...(targetId ? { targetId } : {}) },
+      method: message.method,
+      params: message.params
+    })
+  }
+
+  private rejectPending(error: Error): void {
+    for (const request of this.pending.values()) {
+      request.reject(error)
+    }
+    this.pending.clear()
+  }
+
+  private notifyClose(): void {
+    if (this.closeNotified) {
+      return
+    }
+    this.closeNotified = true
+    this.onClose()
+  }
+}

--- a/src/main/browser/codex-browser-use-backend.test.ts
+++ b/src/main/browser/codex-browser-use-backend.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { connect, type Socket } from 'node:net'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { chmod, lstat, mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { CodexBrowserUseBackend } from './codex-browser-use-backend'
@@ -9,7 +9,51 @@ import {
   type CodexBrowserUseAdapter
 } from './codex-browser-use-protocol'
 
-type RpcResponse = { id: number; result?: unknown; error?: { message: string } }
+type RpcResponse = { id: number | null; result?: unknown; error?: { message: string } }
+
+function encodeFrame(message: unknown): Buffer {
+  const body = Buffer.from(typeof message === 'string' ? message : JSON.stringify(message))
+  const frame = Buffer.allocUnsafe(body.length + 4)
+  frame.writeUInt32LE(body.length, 0)
+  body.copy(frame, 4)
+  return frame
+}
+
+async function connectedSocket(socketPath: string): Promise<Socket> {
+  const socket = connect(socketPath)
+  await new Promise<void>((resolve, reject) => {
+    socket.once('connect', resolve)
+    socket.once('error', reject)
+  })
+  return socket
+}
+
+async function readResponses(socket: Socket, count: number): Promise<RpcResponse[]> {
+  return await new Promise<RpcResponse[]>((resolve, reject) => {
+    let pending = Buffer.alloc(0)
+    const responses: RpcResponse[] = []
+    const onData = (chunk: Buffer) => {
+      pending = Buffer.concat([pending, Buffer.from(chunk)])
+      while (pending.length >= 4) {
+        const length = pending.readUInt32LE(0)
+        if (pending.length < length + 4) {
+          return
+        }
+        responses.push(JSON.parse(pending.subarray(4, length + 4).toString('utf8')) as RpcResponse)
+        pending = pending.subarray(length + 4)
+        if (responses.length === count) {
+          socket.off('data', onData)
+          socket.off('error', onError)
+          resolve(responses)
+          return
+        }
+      }
+    }
+    const onError = (error: Error) => reject(error)
+    socket.on('data', onData)
+    socket.once('error', onError)
+  })
+}
 
 async function rpc(socketPath: string, method: string, params: object): Promise<RpcResponse> {
   const socket = connect(socketPath)
@@ -86,6 +130,135 @@ describe('CodexBrowserUseBackend', () => {
     expect(defaultCodexBrowserUseSocketPath('linux', 42)).toBe(
       '/tmp/codex-browser-use/orca-42.sock'
     )
+  })
+
+  it('uses a process-scoped Windows named pipe without a POSIX path', () => {
+    expect(defaultCodexBrowserUseSocketPath('win32', 42)).toBe(
+      '\\\\.\\pipe\\codex-browser-use-orca-42'
+    )
+  })
+
+  it('locks an existing POSIX socket directory and the created socket to the current user', async () => {
+    tempDirectory = await mkdtemp(join(tmpdir(), 'orca-iab-test-'))
+    await chmod(tempDirectory, 0o755)
+    const socketPath = join(tempDirectory, 'backend.sock')
+    service = new CodexBrowserUseBackend(testAdapter(), { socketPath })
+
+    await service.start()
+
+    expect((await lstat(tempDirectory)).mode & 0o777).toBe(0o700)
+    expect((await lstat(socketPath)).mode & 0o777).toBe(0o600)
+  })
+
+  it('rejects a symbolic-link socket directory', async () => {
+    tempDirectory = await mkdtemp(join(tmpdir(), 'orca-iab-test-'))
+    const targetDirectory = join(tempDirectory, 'target')
+    const linkedDirectory = join(tempDirectory, 'linked')
+    await mkdir(targetDirectory)
+    await symlink(targetDirectory, linkedDirectory)
+    service = new CodexBrowserUseBackend(testAdapter(), {
+      socketPath: join(linkedDirectory, 'backend.sock')
+    })
+
+    await expect(service.start()).rejects.toThrow('not owned by the current user')
+  })
+
+  it('does not replace a regular file at the socket path', async () => {
+    tempDirectory = await mkdtemp(join(tmpdir(), 'orca-iab-test-'))
+    const socketPath = join(tempDirectory, 'backend.sock')
+    await writeFile(socketPath, 'keep-me')
+    service = new CodexBrowserUseBackend(testAdapter(), { socketPath })
+
+    await expect(service.start()).rejects.toThrow('not a user-owned socket')
+    expect((await lstat(socketPath)).isFile()).toBe(true)
+  })
+
+  it('accepts a request split across multiple socket chunks', async () => {
+    tempDirectory = await mkdtemp(join(tmpdir(), 'orca-iab-test-'))
+    const socketPath = join(tempDirectory, 'backend.sock')
+    service = new CodexBrowserUseBackend(testAdapter(), { socketPath })
+    await service.start()
+    const socket = await connectedSocket(socketPath)
+    const frame = encodeFrame({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'getInfo',
+      params: { session_id: 'codex-session' }
+    })
+    const response = readResponses(socket, 1)
+
+    socket.write(frame.subarray(0, 2))
+    socket.write(frame.subarray(2, 7))
+    socket.write(frame.subarray(7))
+
+    await expect(response).resolves.toMatchObject([{ id: 1, result: { type: 'iab' } }])
+    socket.end()
+  })
+
+  it('accepts multiple request frames coalesced into one socket chunk', async () => {
+    tempDirectory = await mkdtemp(join(tmpdir(), 'orca-iab-test-'))
+    const socketPath = join(tempDirectory, 'backend.sock')
+    service = new CodexBrowserUseBackend(testAdapter(), { socketPath })
+    await service.start()
+    const socket = await connectedSocket(socketPath)
+    const responses = readResponses(socket, 2)
+
+    socket.write(
+      Buffer.concat([
+        encodeFrame({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'getInfo',
+          params: { session_id: 'codex-session' }
+        }),
+        encodeFrame({
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'getTabs',
+          params: { session_id: 'codex-session' }
+        })
+      ])
+    )
+
+    await expect(responses).resolves.toEqual([
+      expect.objectContaining({ id: 1, result: expect.objectContaining({ type: 'iab' }) }),
+      expect.objectContaining({ id: 2, result: expect.any(Array) })
+    ])
+    socket.end()
+  })
+
+  it('returns a parse error for malformed JSON and keeps the connection usable', async () => {
+    tempDirectory = await mkdtemp(join(tmpdir(), 'orca-iab-test-'))
+    const socketPath = join(tempDirectory, 'backend.sock')
+    service = new CodexBrowserUseBackend(testAdapter(), { socketPath })
+    await service.start()
+    const socket = await connectedSocket(socketPath)
+    const malformedResponse = readResponses(socket, 1)
+
+    socket.write(encodeFrame('{'))
+
+    await expect(malformedResponse).resolves.toMatchObject([
+      { id: null, error: { message: expect.stringContaining('JSON') } }
+    ])
+    await expect(
+      rpcOnSocket(socket, 2, 'getInfo', { session_id: 'codex-session' })
+    ).resolves.toMatchObject({ id: 2, result: { type: 'iab' } })
+    socket.end()
+  })
+
+  it('closes a connection that advertises an oversized frame', async () => {
+    tempDirectory = await mkdtemp(join(tmpdir(), 'orca-iab-test-'))
+    const socketPath = join(tempDirectory, 'backend.sock')
+    service = new CodexBrowserUseBackend(testAdapter(), { socketPath })
+    await service.start()
+    const socket = await connectedSocket(socketPath)
+    const closed = new Promise<void>((resolve) => socket.once('close', () => resolve()))
+    const header = Buffer.alloc(4)
+    header.writeUInt32LE(16 * 1024 * 1024 + 1, 0)
+
+    socket.write(header)
+
+    await expect(closed).resolves.toBeUndefined()
   })
 
   it('advertises only the worktree owned by the requesting Codex session', async () => {

--- a/src/main/browser/codex-browser-use-backend.test.ts
+++ b/src/main/browser/codex-browser-use-backend.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { connect, type Socket } from 'node:net'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { CodexBrowserUseBackend } from './codex-browser-use-backend'
+import {
+  defaultCodexBrowserUseSocketPath,
+  type CodexBrowserUseAdapter
+} from './codex-browser-use-protocol'
+
+type RpcResponse = { id: number; result?: unknown; error?: { message: string } }
+
+async function rpc(socketPath: string, method: string, params: object): Promise<RpcResponse> {
+  const socket = connect(socketPath)
+  await new Promise<void>((resolve, reject) => {
+    socket.once('connect', resolve)
+    socket.once('error', reject)
+  })
+  const response = await rpcOnSocket(socket, 1, method, params)
+  socket.end()
+  return response
+}
+
+async function rpcOnSocket(
+  socket: Socket,
+  id: number,
+  method: string,
+  params: object
+): Promise<RpcResponse> {
+  const body = Buffer.from(JSON.stringify({ jsonrpc: '2.0', id, method, params }))
+  const frame = Buffer.allocUnsafe(body.length + 4)
+  frame.writeUInt32LE(body.length, 0)
+  body.copy(frame, 4)
+  socket.write(frame)
+
+  const response = await new Promise<RpcResponse>((resolve, reject) => {
+    let pending = Buffer.alloc(0)
+    socket.on('data', (chunk) => {
+      pending = Buffer.concat([pending, Buffer.from(chunk)])
+      if (pending.length < 4) {
+        return
+      }
+      const length = pending.readUInt32LE(0)
+      if (pending.length < length + 4) {
+        return
+      }
+      const parsed = JSON.parse(pending.subarray(4, length + 4).toString('utf8')) as RpcResponse
+      if (parsed.id === id) {
+        resolve(parsed)
+      }
+    })
+    socket.once('error', reject)
+  })
+  return response
+}
+
+function testAdapter(overrides: Partial<CodexBrowserUseAdapter> = {}): CodexBrowserUseAdapter {
+  return {
+    resolveWorktreeId: vi.fn((sessionId) => (sessionId === 'codex-session' ? 'worktree-1' : null)),
+    listTabs: vi.fn(() => [
+      { browserPageId: 'page-a', url: 'https://example.com', title: 'Example', active: true }
+    ]),
+    attach: vi.fn(),
+    detach: vi.fn(),
+    executeCdp: vi.fn(),
+    ...overrides
+  }
+}
+
+describe('CodexBrowserUseBackend', () => {
+  let service: CodexBrowserUseBackend | undefined
+  let tempDirectory: string | undefined
+
+  afterEach(async () => {
+    await service?.stop()
+    if (tempDirectory) {
+      await rm(tempDirectory, { recursive: true, force: true })
+    }
+  })
+
+  it('uses the fixed POSIX directory scanned by the Browser plugin', () => {
+    expect(defaultCodexBrowserUseSocketPath('darwin', 42)).toBe(
+      '/tmp/codex-browser-use/orca-42.sock'
+    )
+    expect(defaultCodexBrowserUseSocketPath('linux', 42)).toBe(
+      '/tmp/codex-browser-use/orca-42.sock'
+    )
+  })
+
+  it('advertises only the worktree owned by the requesting Codex session', async () => {
+    tempDirectory = await mkdtemp(join(tmpdir(), 'orca-iab-test-'))
+    const socketPath = join(tempDirectory, 'backend.sock')
+    const adapter = testAdapter()
+    service = new CodexBrowserUseBackend(adapter, { socketPath })
+    await service.start()
+
+    const info = await rpc(socketPath, 'getInfo', {
+      session_id: 'codex-session',
+      turn_id: 'turn-1',
+      session_context: 'live'
+    })
+    expect(info.result).toMatchObject({
+      type: 'iab',
+      metadata: {
+        codexSessionId: 'codex-session',
+        codexAppBuildFlavor: 'prod'
+      },
+      apiSupportOverrides: {
+        'Browser.nameSession': false,
+        'ContentAPI.export': false,
+        'Tabs.new': false
+      }
+    })
+
+    const tabs = await rpc(socketPath, 'getTabs', {
+      session_id: 'codex-session',
+      turn_id: 'turn-1',
+      session_context: 'live'
+    })
+    expect(tabs.result).toEqual([
+      { id: 1, url: 'https://example.com', title: 'Example', active: true }
+    ])
+    expect(adapter.listTabs).toHaveBeenCalledWith('worktree-1')
+  })
+
+  it('rejects a session that is not owned by an Orca pane', async () => {
+    tempDirectory = await mkdtemp(join(tmpdir(), 'orca-iab-test-'))
+    const socketPath = join(tempDirectory, 'backend.sock')
+    const adapter: CodexBrowserUseAdapter = {
+      resolveWorktreeId: () => null,
+      listTabs: vi.fn(),
+      attach: vi.fn(),
+      detach: vi.fn(),
+      executeCdp: vi.fn()
+    }
+    service = new CodexBrowserUseBackend(adapter, { socketPath })
+    await service.start()
+
+    const response = await rpc(socketPath, 'getInfo', {
+      session_id: 'unknown-session',
+      turn_id: 'turn-1',
+      session_context: 'live'
+    })
+    expect(response.error?.message).toContain('not associated with an Orca workspace')
+  })
+
+  it('does not allow one socket connection to switch Codex sessions', async () => {
+    tempDirectory = await mkdtemp(join(tmpdir(), 'orca-iab-test-'))
+    const socketPath = join(tempDirectory, 'backend.sock')
+    const adapter = testAdapter({ resolveWorktreeId: vi.fn(() => 'worktree-1') })
+    service = new CodexBrowserUseBackend(adapter, { socketPath })
+    await service.start()
+    const socket = connect(socketPath)
+    await new Promise<void>((resolve, reject) => {
+      socket.once('connect', resolve)
+      socket.once('error', reject)
+    })
+
+    expect(
+      (
+        await rpcOnSocket(socket, 1, 'getInfo', {
+          session_id: 'codex-session',
+          turn_id: 'turn-1'
+        })
+      ).error
+    ).toBeUndefined()
+    const switched = await rpcOnSocket(socket, 2, 'getInfo', {
+      session_id: 'other-session',
+      turn_id: 'turn-2'
+    })
+    expect(switched.error?.message).toContain('cannot change Codex sessions')
+    socket.end()
+  })
+
+  it('routes CDP execution to the tab owned by the requesting session', async () => {
+    tempDirectory = await mkdtemp(join(tmpdir(), 'orca-iab-test-'))
+    const socketPath = join(tempDirectory, 'backend.sock')
+    const executeCdp = vi.fn(() => ({ result: { value: 'Example Domain' } }))
+    const adapter = testAdapter({ executeCdp })
+    service = new CodexBrowserUseBackend(adapter, { socketPath })
+    await service.start()
+
+    const response = await rpc(socketPath, 'executeCdp', {
+      session_id: 'codex-session',
+      turn_id: 'turn-1',
+      target: { tabId: 1, sessionId: 'cdp-session' },
+      method: 'Runtime.evaluate',
+      commandParams: { expression: 'document.title' }
+    })
+    expect(response.result).toEqual({ result: { value: 'Example Domain' } })
+    expect(executeCdp).toHaveBeenCalledWith(
+      expect.any(String),
+      'codex-session',
+      'worktree-1',
+      'page-a',
+      { tabId: 1, sessionId: 'cdp-session' },
+      'Runtime.evaluate',
+      { expression: 'document.title' }
+    )
+  })
+
+  it('releases an attached CDP connection and assigns a fresh owner after reconnect', async () => {
+    tempDirectory = await mkdtemp(join(tmpdir(), 'orca-iab-test-'))
+    const socketPath = join(tempDirectory, 'backend.sock')
+    const attach = vi.fn()
+    const detach = vi.fn()
+    const adapter = testAdapter({ attach, detach })
+    service = new CodexBrowserUseBackend(adapter, { socketPath })
+    await service.start()
+
+    const connectAndAttach = async (requestId: number): Promise<Socket> => {
+      const socket = connect(socketPath)
+      await new Promise<void>((resolve, reject) => {
+        socket.once('connect', resolve)
+        socket.once('error', reject)
+      })
+      await rpcOnSocket(socket, requestId, 'getTabs', {
+        session_id: 'codex-session',
+        turn_id: `turn-${requestId}`
+      })
+      await rpcOnSocket(socket, requestId + 1, 'attach', {
+        session_id: 'codex-session',
+        turn_id: `turn-${requestId}`,
+        tabId: 1
+      })
+      return socket
+    }
+
+    const firstSocket = await connectAndAttach(10)
+    const firstOwner = attach.mock.calls[0]?.[0]
+    firstSocket.end()
+    await vi.waitFor(() =>
+      expect(detach).toHaveBeenCalledWith(firstOwner, 'codex-session', 'worktree-1', 'page-a')
+    )
+
+    const secondSocket = await connectAndAttach(20)
+    const secondOwner = attach.mock.calls[1]?.[0]
+    expect(secondOwner).not.toBe(firstOwner)
+    secondSocket.end()
+  })
+
+  it('retires a closed tab id and assigns a new id after tab replacement', async () => {
+    tempDirectory = await mkdtemp(join(tmpdir(), 'orca-iab-test-'))
+    const socketPath = join(tempDirectory, 'backend.sock')
+    const listTabs = vi
+      .fn()
+      .mockReturnValueOnce([
+        { browserPageId: 'page-a', url: 'https://old.example', title: 'Old', active: true }
+      ])
+      .mockReturnValue([
+        { browserPageId: 'page-b', url: 'https://new.example', title: 'New', active: true }
+      ])
+    const adapter = testAdapter({ listTabs })
+    service = new CodexBrowserUseBackend(adapter, { socketPath })
+    await service.start()
+
+    const first = await rpc(socketPath, 'getTabs', {
+      session_id: 'codex-session',
+      turn_id: 'turn-1'
+    })
+    const second = await rpc(socketPath, 'getTabs', {
+      session_id: 'codex-session',
+      turn_id: 'turn-2'
+    })
+    expect(first.result).toEqual([
+      { id: 1, url: 'https://old.example', title: 'Old', active: true }
+    ])
+    expect(second.result).toEqual([
+      { id: 2, url: 'https://new.example', title: 'New', active: true }
+    ])
+  })
+})

--- a/src/main/browser/codex-browser-use-backend.ts
+++ b/src/main/browser/codex-browser-use-backend.ts
@@ -1,6 +1,6 @@
 import { createServer, type Server, type Socket } from 'node:net'
 import { randomUUID } from 'node:crypto'
-import { chmod, mkdir, rm } from 'node:fs/promises'
+import { chmod, lstat, mkdir, rm } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import {
   defaultCodexBrowserUseSocketPath,
@@ -12,6 +12,36 @@ import {
 import { CodexBrowserUseRpcRouter } from './codex-browser-use-rpc-router'
 
 const MAX_FRAME_BYTES = 16 * 1024 * 1024
+
+async function preparePosixSocketPath(socketPath: string): Promise<void> {
+  const directory = dirname(socketPath)
+  await mkdir(directory, { recursive: true, mode: 0o700 })
+  const directoryStat = await lstat(directory)
+  const currentUserId = process.getuid?.()
+  if (
+    !directoryStat.isDirectory() ||
+    directoryStat.isSymbolicLink() ||
+    (currentUserId !== undefined && directoryStat.uid !== currentUserId)
+  ) {
+    throw new Error('Browser backend socket directory is not owned by the current user')
+  }
+  await chmod(directory, 0o700)
+
+  try {
+    const socketStat = await lstat(socketPath)
+    if (
+      !socketStat.isSocket() ||
+      (currentUserId !== undefined && socketStat.uid !== currentUserId)
+    ) {
+      throw new Error('Browser backend socket path is not a user-owned socket')
+    }
+    await rm(socketPath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error
+    }
+  }
+}
 
 export type CodexBrowserUseConnectionAttachment = {
   sessionId: string
@@ -32,6 +62,7 @@ export class CodexBrowserUseBackend {
   private server: Server | null = null
   private readonly router: CodexBrowserUseRpcRouter
   private readonly sockets = new Set<Socket>()
+  private ownsSocketPath = false
 
   constructor(
     private readonly adapter: CodexBrowserUseAdapter,
@@ -48,8 +79,7 @@ export class CodexBrowserUseBackend {
       return
     }
     if (process.platform !== 'win32') {
-      await mkdir(dirname(this.socketPath), { recursive: true, mode: 0o700 })
-      await rm(this.socketPath, { force: true })
+      await preparePosixSocketPath(this.socketPath)
     }
 
     const server = createServer((socket) => this.accept(socket))
@@ -63,11 +93,16 @@ export class CodexBrowserUseBackend {
         })
       })
       if (process.platform !== 'win32') {
+        this.ownsSocketPath = true
         await chmod(this.socketPath, 0o600)
       }
     } catch (error) {
       this.server = null
       server.close()
+      if (process.platform !== 'win32' && this.ownsSocketPath) {
+        this.ownsSocketPath = false
+        await rm(this.socketPath, { force: true })
+      }
       throw error
     }
   }
@@ -82,7 +117,8 @@ export class CodexBrowserUseBackend {
     if (server) {
       await new Promise<void>((resolve) => server.close(() => resolve()))
     }
-    if (process.platform !== 'win32') {
+    if (process.platform !== 'win32' && this.ownsSocketPath) {
+      this.ownsSocketPath = false
       await rm(this.socketPath, { force: true })
     }
     this.router.clear()
@@ -106,7 +142,8 @@ export class CodexBrowserUseBackend {
       while (pending.length >= 4) {
         const length = pending.readUInt32LE(0)
         if (length > MAX_FRAME_BYTES) {
-          socket.destroy(new Error('Browser backend frame exceeds the size limit'))
+          // An oversized prefix is untrusted and has no safe request id to answer.
+          socket.destroy()
           return
         }
         if (pending.length < length + 4) {

--- a/src/main/browser/codex-browser-use-backend.ts
+++ b/src/main/browser/codex-browser-use-backend.ts
@@ -1,0 +1,185 @@
+import { createServer, type Server, type Socket } from 'node:net'
+import { randomUUID } from 'node:crypto'
+import { chmod, mkdir, rm } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import {
+  defaultCodexBrowserUseSocketPath,
+  sendBrowserUseMessage,
+  type CodexBrowserUseAdapter,
+  type CodexBrowserUseBackendOptions,
+  type CodexBrowserUseRpcRequest
+} from './codex-browser-use-protocol'
+import { CodexBrowserUseRpcRouter } from './codex-browser-use-rpc-router'
+
+const MAX_FRAME_BYTES = 16 * 1024 * 1024
+
+export type CodexBrowserUseConnectionAttachment = {
+  sessionId: string
+  worktreeId: string
+  browserPageId: string
+}
+
+export type CodexBrowserUseConnectionContext = {
+  id: string
+  closed: boolean
+  attachments: Map<string, CodexBrowserUseConnectionAttachment>
+  getSessionId: () => string | null
+  bindSessionId: (sessionId: string) => void
+}
+
+export class CodexBrowserUseBackend {
+  private readonly socketPath: string
+  private server: Server | null = null
+  private readonly router: CodexBrowserUseRpcRouter
+  private readonly sockets = new Set<Socket>()
+
+  constructor(
+    private readonly adapter: CodexBrowserUseAdapter,
+    options: CodexBrowserUseBackendOptions = {}
+  ) {
+    this.router = new CodexBrowserUseRpcRouter(adapter)
+    this.socketPath =
+      options.socketPath ??
+      defaultCodexBrowserUseSocketPath(options.platform ?? process.platform, options.processId)
+  }
+
+  async start(): Promise<void> {
+    if (this.server) {
+      return
+    }
+    if (process.platform !== 'win32') {
+      await mkdir(dirname(this.socketPath), { recursive: true, mode: 0o700 })
+      await rm(this.socketPath, { force: true })
+    }
+
+    const server = createServer((socket) => this.accept(socket))
+    this.server = server
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(this.socketPath, () => {
+          server.removeListener('error', reject)
+          resolve()
+        })
+      })
+      if (process.platform !== 'win32') {
+        await chmod(this.socketPath, 0o600)
+      }
+    } catch (error) {
+      this.server = null
+      server.close()
+      throw error
+    }
+  }
+
+  async stop(): Promise<void> {
+    const server = this.server
+    this.server = null
+    for (const socket of this.sockets) {
+      socket.destroy()
+    }
+    this.sockets.clear()
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+    if (process.platform !== 'win32') {
+      await rm(this.socketPath, { force: true })
+    }
+    this.router.clear()
+  }
+
+  private accept(socket: Socket): void {
+    this.sockets.add(socket)
+    let pending = Buffer.alloc(0)
+    let boundSessionId: string | null = null
+    const context: CodexBrowserUseConnectionContext = {
+      id: randomUUID(),
+      closed: false,
+      attachments: new Map(),
+      getSessionId: () => boundSessionId,
+      bindSessionId: (sessionId) => {
+        boundSessionId ??= sessionId
+      }
+    }
+    socket.on('data', (chunk) => {
+      pending = Buffer.concat([pending, Buffer.from(chunk)])
+      while (pending.length >= 4) {
+        const length = pending.readUInt32LE(0)
+        if (length > MAX_FRAME_BYTES) {
+          socket.destroy(new Error('Browser backend frame exceeds the size limit'))
+          return
+        }
+        if (pending.length < length + 4) {
+          return
+        }
+        const payload = pending.subarray(4, length + 4).toString('utf8')
+        pending = pending.subarray(length + 4)
+        void this.handlePayload(socket, payload, context)
+      }
+    })
+    socket.once('close', () => {
+      this.sockets.delete(socket)
+      context.closed = true
+      const attachments = [...context.attachments.values()]
+      context.attachments.clear()
+      void Promise.allSettled(
+        attachments.map((attachment) =>
+          this.adapter.detach(
+            context.id,
+            attachment.sessionId,
+            attachment.worktreeId,
+            attachment.browserPageId
+          )
+        )
+      )
+    })
+  }
+
+  private async handlePayload(
+    socket: Socket,
+    payload: string,
+    context: CodexBrowserUseConnectionContext
+  ): Promise<void> {
+    let request: CodexBrowserUseRpcRequest
+    try {
+      request = JSON.parse(payload) as CodexBrowserUseRpcRequest
+      if (request.jsonrpc !== '2.0' || typeof request.method !== 'string') {
+        throw new Error('Invalid JSON-RPC request')
+      }
+    } catch (error) {
+      sendBrowserUseMessage(socket, {
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32700, message: error instanceof Error ? error.message : String(error) }
+      })
+      return
+    }
+
+    if (request.id == null) {
+      return
+    }
+    try {
+      const requestSessionId = request.params?.session_id
+      if (typeof requestSessionId === 'string') {
+        const boundSessionId = context.getSessionId()
+        if (boundSessionId && boundSessionId !== requestSessionId) {
+          throw new Error('Browser backend connection cannot change Codex sessions')
+        }
+        context.bindSessionId(requestSessionId)
+      }
+      const result = await this.router.dispatch(request, context, (method, params) => {
+        sendBrowserUseMessage(socket, { jsonrpc: '2.0', method, params })
+      })
+      sendBrowserUseMessage(socket, { jsonrpc: '2.0', id: request.id, result })
+    } catch (error) {
+      console.warn(
+        `[codex-browser-use] failed ${request.method}: ${error instanceof Error ? error.message : String(error)}`
+      )
+      sendBrowserUseMessage(socket, {
+        jsonrpc: '2.0',
+        id: request.id,
+        error: { code: 1, message: error instanceof Error ? error.message : String(error) }
+      })
+    }
+  }
+}

--- a/src/main/browser/codex-browser-use-protocol.ts
+++ b/src/main/browser/codex-browser-use-protocol.ts
@@ -1,0 +1,127 @@
+import { join } from 'node:path'
+import type { Socket } from 'node:net'
+
+export type CodexBrowserUseTab = {
+  browserPageId: string
+  url: string
+  title: string
+  active: boolean
+}
+
+export type CodexBrowserUseCdpTarget = {
+  tabId: number
+  sessionId?: string
+  targetId?: string
+}
+
+export type RpcNotificationEmitter = (method: string, params: unknown) => void
+
+export type CodexBrowserUseRpcRequest = {
+  jsonrpc: '2.0'
+  id?: number | string
+  method: string
+  params?: Record<string, unknown>
+}
+
+export type CodexBrowserUseSession = {
+  sessionId: string
+  worktreeId: string
+  pageIdByTabId: Map<number, string>
+  tabIdByPageId: Map<string, number>
+  nextTabId: number
+}
+
+export type CodexBrowserUseBackendOptions = {
+  socketPath?: string
+  platform?: NodeJS.Platform
+  processId?: number
+}
+
+export type CodexBrowserUseAdapter = {
+  resolveWorktreeId: (sessionId: string) => string | null
+  listTabs: (worktreeId: string) => CodexBrowserUseTab[]
+  attach: (
+    connectionId: string,
+    sessionId: string,
+    worktreeId: string,
+    browserPageId: string,
+    tabId: number,
+    emit: RpcNotificationEmitter
+  ) => void | Promise<void>
+  attachTarget?: (
+    connectionId: string,
+    sessionId: string,
+    worktreeId: string,
+    browserPageId: string,
+    tabId: number,
+    targetId: string
+  ) => void | Promise<void>
+  detach: (
+    connectionId: string,
+    sessionId: string,
+    worktreeId: string,
+    browserPageId: string
+  ) => void | Promise<void>
+  detachTarget?: (
+    connectionId: string,
+    sessionId: string,
+    worktreeId: string,
+    browserPageId: string,
+    targetId: string
+  ) => void | Promise<void>
+  executeCdp: (
+    connectionId: string,
+    sessionId: string,
+    worktreeId: string,
+    browserPageId: string,
+    target: CodexBrowserUseCdpTarget,
+    method: string,
+    params: Record<string, unknown>
+  ) => unknown | Promise<unknown>
+}
+
+export function requireBrowserUseString(value: unknown, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${name} is required`)
+  }
+  return value
+}
+
+export function asBrowserUseRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
+export function asBrowserUseCdpTarget(value: unknown): CodexBrowserUseCdpTarget {
+  const record = asBrowserUseRecord(value)
+  const tabId = Number(record.tabId)
+  if (!Number.isSafeInteger(tabId) || tabId < 1) {
+    throw new Error('target.tabId is required')
+  }
+  return {
+    tabId,
+    ...(typeof record.sessionId === 'string' ? { sessionId: record.sessionId } : {}),
+    ...(typeof record.targetId === 'string' ? { targetId: record.targetId } : {})
+  }
+}
+
+export function defaultCodexBrowserUseSocketPath(
+  platform: NodeJS.Platform,
+  processId = process.pid
+): string {
+  return platform === 'win32'
+    ? `\\\\.\\pipe\\codex-browser-use-orca-${processId}`
+    : join('/tmp', 'codex-browser-use', `orca-${processId}.sock`)
+}
+
+export function sendBrowserUseMessage(socket: Socket, message: unknown): void {
+  if (socket.destroyed) {
+    return
+  }
+  const body = Buffer.from(JSON.stringify(message), 'utf8')
+  const frame = Buffer.allocUnsafe(body.length + 4)
+  frame.writeUInt32LE(body.length, 0)
+  body.copy(frame, 4)
+  socket.write(frame)
+}

--- a/src/main/browser/codex-browser-use-rpc-router.ts
+++ b/src/main/browser/codex-browser-use-rpc-router.ts
@@ -1,0 +1,214 @@
+import {
+  asBrowserUseCdpTarget,
+  asBrowserUseRecord,
+  requireBrowserUseString,
+  type CodexBrowserUseAdapter,
+  type CodexBrowserUseRpcRequest,
+  type CodexBrowserUseSession,
+  type RpcNotificationEmitter
+} from './codex-browser-use-protocol'
+import type { CodexBrowserUseConnectionContext } from './codex-browser-use-backend'
+
+export class CodexBrowserUseRpcRouter {
+  private readonly browserSessions = new Map<string, CodexBrowserUseSession>()
+
+  constructor(private readonly adapter: CodexBrowserUseAdapter) {}
+
+  clear(): void {
+    this.browserSessions.clear()
+  }
+
+  async dispatch(
+    request: CodexBrowserUseRpcRequest,
+    context: CodexBrowserUseConnectionContext,
+    emit: RpcNotificationEmitter
+  ): Promise<unknown> {
+    if (request.method === 'ping') {
+      return 'pong'
+    }
+    const session = this.requireSession(request.params)
+    switch (request.method) {
+      case 'getInfo':
+        return {
+          type: 'iab',
+          name: 'Orca',
+          metadata: {
+            codexSessionId: session.sessionId,
+            codexAppBuildFlavor: 'prod'
+          },
+          capabilities: { browser: [], tab: [] },
+          apiSupportOverrides: {
+            'Browser.nameSession': false,
+            'BrowserUser.claimTab': false,
+            'ContentAPI.export': false,
+            'ContentAPI.exportGsuite': false,
+            'Tabs.new': false
+          }
+        }
+      case 'getTabs':
+        return this.listTabs(session)
+      case 'getUserTabs':
+      case 'getUserHistory':
+        return []
+      case 'attach':
+        return await this.attach(request, context, session, emit)
+      case 'attachTarget': {
+        const tab = this.requireTab(session, request.params?.tabId)
+        const targetId = requireBrowserUseString(request.params?.targetId, 'targetId')
+        if (!this.adapter.attachTarget) {
+          throw new Error('Target attachment is unavailable')
+        }
+        await this.adapter.attachTarget(
+          context.id,
+          session.sessionId,
+          session.worktreeId,
+          tab.browserPageId,
+          tab.tabId,
+          targetId
+        )
+        return {}
+      }
+      case 'detach': {
+        const tab = this.requireTab(session, request.params?.tabId)
+        context.attachments.delete(tab.browserPageId)
+        await this.adapter.detach(
+          context.id,
+          session.sessionId,
+          session.worktreeId,
+          tab.browserPageId
+        )
+        return {}
+      }
+      case 'detachTarget': {
+        const tab = this.requireTab(session, request.params?.tabId)
+        const targetId = requireBrowserUseString(request.params?.targetId, 'targetId')
+        if (!this.adapter.detachTarget) {
+          throw new Error('Target detachment is unavailable')
+        }
+        await this.adapter.detachTarget(
+          context.id,
+          session.sessionId,
+          session.worktreeId,
+          tab.browserPageId,
+          targetId
+        )
+        return {}
+      }
+      case 'executeCdp': {
+        const target = asBrowserUseCdpTarget(request.params?.target)
+        const tab = this.requireTab(session, target.tabId)
+        const method = requireBrowserUseString(request.params?.method, 'method')
+        const commandParams = asBrowserUseRecord(request.params?.commandParams)
+        return await this.adapter.executeCdp(
+          context.id,
+          session.sessionId,
+          session.worktreeId,
+          tab.browserPageId,
+          target,
+          method,
+          commandParams
+        )
+      }
+      case 'nameSession':
+      case 'markTab':
+      case 'finalizeTabs':
+      case 'moveMouse':
+      case 'turnEnded':
+        return {}
+      default:
+        throw new Error(`No handler registered for method: ${request.method}`)
+    }
+  }
+
+  private async attach(
+    request: CodexBrowserUseRpcRequest,
+    context: CodexBrowserUseConnectionContext,
+    session: CodexBrowserUseSession,
+    emit: RpcNotificationEmitter
+  ): Promise<Record<string, never>> {
+    const tab = this.requireTab(session, request.params?.tabId)
+    await this.adapter.attach(
+      context.id,
+      session.sessionId,
+      session.worktreeId,
+      tab.browserPageId,
+      tab.tabId,
+      emit
+    )
+    const attachment = {
+      sessionId: session.sessionId,
+      worktreeId: session.worktreeId,
+      browserPageId: tab.browserPageId
+    }
+    if (context.closed) {
+      await this.adapter.detach(
+        context.id,
+        attachment.sessionId,
+        attachment.worktreeId,
+        attachment.browserPageId
+      )
+    } else {
+      context.attachments.set(tab.browserPageId, attachment)
+    }
+    return {}
+  }
+
+  private requireSession(params: Record<string, unknown> | undefined): CodexBrowserUseSession {
+    const sessionId = requireBrowserUseString(params?.session_id, 'session_id')
+    const worktreeId = this.adapter.resolveWorktreeId(sessionId)
+    if (!worktreeId) {
+      throw new Error(`Codex session ${sessionId} is not associated with an Orca workspace`)
+    }
+    const existing = this.browserSessions.get(sessionId)
+    if (existing?.worktreeId === worktreeId) {
+      return existing
+    }
+    const session: CodexBrowserUseSession = {
+      sessionId,
+      worktreeId,
+      pageIdByTabId: new Map(),
+      tabIdByPageId: new Map(),
+      nextTabId: 1
+    }
+    this.browserSessions.set(sessionId, session)
+    return session
+  }
+
+  private listTabs(session: CodexBrowserUseSession): Record<string, unknown>[] {
+    const tabs = this.adapter.listTabs(session.worktreeId)
+    const livePageIds = new Set(tabs.map((tab) => tab.browserPageId))
+    for (const [pageId, tabId] of session.tabIdByPageId) {
+      if (!livePageIds.has(pageId)) {
+        session.tabIdByPageId.delete(pageId)
+        session.pageIdByTabId.delete(tabId)
+      }
+    }
+    return tabs.map((tab) => {
+      let id = session.tabIdByPageId.get(tab.browserPageId)
+      if (id == null) {
+        id = session.nextTabId++
+        session.tabIdByPageId.set(tab.browserPageId, id)
+        session.pageIdByTabId.set(id, tab.browserPageId)
+      }
+      return { id, url: tab.url, title: tab.title, active: tab.active }
+    })
+  }
+
+  private requireTab(
+    session: CodexBrowserUseSession,
+    rawTabId: unknown
+  ): { tabId: number; browserPageId: string } {
+    const tabId = Number(rawTabId)
+    if (!Number.isSafeInteger(tabId) || tabId < 1) {
+      throw new Error('tabId must be a positive integer')
+    }
+    if (!session.pageIdByTabId.has(tabId)) {
+      this.listTabs(session)
+    }
+    const browserPageId = session.pageIdByTabId.get(tabId)
+    if (!browserPageId) {
+      throw new Error(`Browser tab ${tabId} is not available`)
+    }
+    return { tabId, browserPageId }
+  }
+}

--- a/src/main/browser/orca-codex-browser-use-adapter.test.ts
+++ b/src/main/browser/orca-codex-browser-use-adapter.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AgentStatusIpcPayload } from '../../shared/agent-status-types'
+import type { AgentBrowserBridge } from './agent-browser-bridge'
+import type { BrowserUseConnection } from './browser-use-cdp-connection'
+import type { CdpWsProxy } from './cdp-ws-proxy'
+import type { CodexBrowserUseCdpTarget, RpcNotificationEmitter } from './codex-browser-use-protocol'
+import { OrcaCodexBrowserUseAdapter } from './orca-codex-browser-use-adapter'
+
+function status(overrides: Partial<AgentStatusIpcPayload> = {}): AgentStatusIpcPayload {
+  return {
+    agentType: 'codex',
+    connectionId: null,
+    paneKey: 'tab:pane',
+    prompt: '',
+    providerSession: { key: 'session_id', id: 'codex-session' },
+    receivedAt: 1,
+    state: 'working',
+    stateStartedAt: 1,
+    worktreeId: 'worktree-1',
+    ...overrides
+  } as AgentStatusIpcPayload
+}
+
+function adapter(
+  statuses: AgentStatusIpcPayload[],
+  livePaneKeys = new Set(statuses.map(({ paneKey }) => paneKey))
+): OrcaCodexBrowserUseAdapter {
+  return new OrcaCodexBrowserUseAdapter(
+    { onCodexBrowserUseProcessSwap: () => () => undefined } as unknown as AgentBrowserBridge,
+    () => statuses,
+    (paneKey) => livePaneKeys.has(paneKey)
+  )
+}
+
+describe('OrcaCodexBrowserUseAdapter session resolution', () => {
+  it('resolves an exact live local Codex session to one worktree', () => {
+    expect(adapter([status()]).resolveWorktreeId('codex-session')).toBe('worktree-1')
+  })
+
+  it('rejects remote, stale, non-Codex, and mismatched provider sessions', () => {
+    const statuses = [
+      status({ connectionId: 'ssh-1', paneKey: 'remote' }),
+      status({ paneKey: 'stale' }),
+      status({ agentType: 'claude', paneKey: 'claude' }),
+      status({ paneKey: 'other', providerSession: { key: 'session_id', id: 'other-session' } })
+    ]
+    expect(
+      adapter(statuses, new Set(['remote', 'claude', 'other'])).resolveWorktreeId('codex-session')
+    ).toBeNull()
+  })
+
+  it('rejects an ambiguous session mapped to more than one live worktree', () => {
+    const statuses = [status(), status({ paneKey: 'tab:other', worktreeId: 'worktree-2' })]
+    expect(adapter(statuses).resolveWorktreeId('codex-session')).toBeNull()
+  })
+})
+
+type FakeConnection = {
+  execute: BrowserUseConnection['execute']
+  attachTarget: BrowserUseConnection['attachTarget']
+  detachTarget: BrowserUseConnection['detachTarget']
+  close: BrowserUseConnection['close']
+  triggerClose: () => void
+}
+
+function connectionAdapter(
+  options: { waitForFirstConnection?: Promise<void>; holdFirstExecute?: boolean } = {}
+) {
+  const proxies: CdpWsProxy[] = []
+  const connections: FakeConnection[] = []
+  let rejectFirstExecute: ((error: Error) => void) | null = null
+  let processSwapListener: ((browserPageId: string) => void) | null = null
+  const bridge = {
+    onCodexBrowserUseProcessSwap: vi.fn((listener: (browserPageId: string) => void) => {
+      processSwapListener = listener
+      return () => {
+        processSwapListener = null
+      }
+    }),
+    createCodexBrowserUseCdpProxy: vi.fn(() => {
+      const proxy = { sequence: proxies.length + 1 } as unknown as CdpWsProxy
+      proxies.push(proxy)
+      return proxy
+    }),
+    navigateCodexBrowserUseTab: vi.fn(async () => ({ frameId: 'orca-proxy-target' }))
+  } as unknown as AgentBrowserBridge
+  const createConnection = vi.fn(
+    async (
+      _proxy: CdpWsProxy,
+      _tabId: number,
+      _emit: RpcNotificationEmitter,
+      onClose: () => void
+    ) => {
+      if (connections.length === 0) {
+        await options.waitForFirstConnection
+      }
+      const sequence = connections.length + 1
+      const connection: FakeConnection = {
+        execute: vi.fn(async (_target: CodexBrowserUseCdpTarget, method: string) => {
+          if (sequence === 1 && options.holdFirstExecute) {
+            return await new Promise<never>((_resolve, reject) => {
+              rejectFirstExecute = reject
+            })
+          }
+          return `connection-${sequence}:${method}`
+        }),
+        attachTarget: vi.fn(async () => undefined),
+        detachTarget: vi.fn(async () => undefined),
+        close: vi.fn(async () => {
+          rejectFirstExecute?.(new Error('Browser CDP connection closed'))
+          rejectFirstExecute = null
+        }),
+        triggerClose: onClose
+      }
+      connections.push(connection)
+      return connection
+    }
+  )
+  return {
+    adapter: new OrcaCodexBrowserUseAdapter(
+      bridge,
+      () => [],
+      () => false,
+      createConnection
+    ),
+    bridge,
+    connections,
+    createConnection,
+    emitProcessSwap: (browserPageId: string) => processSwapListener?.(browserPageId)
+  }
+}
+
+const noNotification: RpcNotificationEmitter = () => undefined
+const cdpTarget: CodexBrowserUseCdpTarget = { tabId: 1 }
+
+describe('OrcaCodexBrowserUseAdapter connection lifecycle', () => {
+  it('recreates the CDP proxy lazily after the current renderer connection closes', async () => {
+    const harness = connectionAdapter()
+    await harness.adapter.attach('owner-1', 'session-1', 'worktree-1', 'page-1', 1, noNotification)
+
+    harness.emitProcessSwap('page-1')
+    await expect(
+      harness.adapter.executeCdp(
+        'owner-1',
+        'session-1',
+        'worktree-1',
+        'page-1',
+        cdpTarget,
+        'Runtime.evaluate',
+        {}
+      )
+    ).resolves.toBe('connection-2:Runtime.evaluate')
+
+    expect(harness.bridge.createCodexBrowserUseCdpProxy).toHaveBeenCalledTimes(2)
+    expect(harness.bridge.createCodexBrowserUseCdpProxy).toHaveBeenNthCalledWith(
+      2,
+      'worktree-1',
+      'page-1'
+    )
+  })
+
+  it('retries an in-flight CDP command on the replacement renderer connection', async () => {
+    const harness = connectionAdapter({ holdFirstExecute: true })
+    await harness.adapter.attach('owner-1', 'session-1', 'worktree-1', 'page-1', 1, noNotification)
+    const command = harness.adapter.executeCdp(
+      'owner-1',
+      'session-1',
+      'worktree-1',
+      'page-1',
+      cdpTarget,
+      'Runtime.evaluate',
+      { expression: 'location.href' }
+    )
+    await vi.waitFor(() => expect(harness.connections[0].execute).toHaveBeenCalledOnce())
+
+    harness.emitProcessSwap('page-1')
+
+    await expect(command).resolves.toBe('connection-2:Runtime.evaluate')
+    expect(harness.connections[0].close).toHaveBeenCalledOnce()
+    expect(harness.bridge.createCodexBrowserUseCdpProxy).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses the current Electron tab for top-level navigation', async () => {
+    const harness = connectionAdapter()
+    await harness.adapter.attach('owner-1', 'session-1', 'worktree-1', 'page-1', 1, noNotification)
+
+    await expect(
+      harness.adapter.executeCdp(
+        'owner-1',
+        'session-1',
+        'worktree-1',
+        'page-1',
+        cdpTarget,
+        'Page.navigate',
+        { url: 'https://example.org/', frameId: 'playwright-main-frame' }
+      )
+    ).resolves.toEqual({ frameId: 'orca-proxy-target' })
+
+    expect(harness.bridge.navigateCodexBrowserUseTab).toHaveBeenCalledWith(
+      'worktree-1',
+      'page-1',
+      'https://example.org/'
+    )
+    expect(harness.connections[0].execute).not.toHaveBeenCalled()
+  })
+
+  it('rejects CDP commands from a native connection that no longer owns the tab', async () => {
+    const harness = connectionAdapter()
+    await harness.adapter.attach('owner-1', 'session-1', 'worktree-1', 'page-1', 1, noNotification)
+    await harness.adapter.attach('owner-2', 'session-1', 'worktree-1', 'page-1', 1, noNotification)
+
+    await expect(
+      harness.adapter.executeCdp(
+        'owner-1',
+        'session-1',
+        'worktree-1',
+        'page-1',
+        cdpTarget,
+        'Runtime.evaluate',
+        {}
+      )
+    ).rejects.toThrow('not owned')
+    await expect(
+      harness.adapter.executeCdp(
+        'owner-2',
+        'session-1',
+        'worktree-1',
+        'page-1',
+        cdpTarget,
+        'Runtime.evaluate',
+        {}
+      )
+    ).resolves.toBe('connection-2:Runtime.evaluate')
+    expect(harness.connections[0].close).toHaveBeenCalledOnce()
+  })
+
+  it('serializes overlapping owners so only the last attachment remains active', async () => {
+    let releaseFirst!: () => void
+    const firstConnectionGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const harness = connectionAdapter({ waitForFirstConnection: firstConnectionGate })
+    const first = harness.adapter.attach(
+      'owner-1',
+      'session-1',
+      'worktree-1',
+      'page-1',
+      1,
+      noNotification
+    )
+    await vi.waitFor(() => expect(harness.createConnection).toHaveBeenCalledTimes(1))
+    const second = harness.adapter.attach(
+      'owner-2',
+      'session-1',
+      'worktree-1',
+      'page-1',
+      1,
+      noNotification
+    )
+
+    releaseFirst()
+    await Promise.all([first, second])
+
+    expect(harness.createConnection).toHaveBeenCalledTimes(2)
+    expect(harness.connections[0].close).toHaveBeenCalledOnce()
+    await expect(
+      harness.adapter.executeCdp(
+        'owner-1',
+        'session-1',
+        'worktree-1',
+        'page-1',
+        cdpTarget,
+        'Runtime.evaluate',
+        {}
+      )
+    ).rejects.toThrow('not owned')
+    await expect(
+      harness.adapter.executeCdp(
+        'owner-2',
+        'session-1',
+        'worktree-1',
+        'page-1',
+        cdpTarget,
+        'Runtime.evaluate',
+        {}
+      )
+    ).resolves.toBe('connection-2:Runtime.evaluate')
+  })
+})

--- a/src/main/browser/orca-codex-browser-use-adapter.ts
+++ b/src/main/browser/orca-codex-browser-use-adapter.ts
@@ -1,0 +1,251 @@
+import type { AgentStatusIpcPayload } from '../../shared/agent-status-types'
+import type { AgentBrowserBridge } from './agent-browser-bridge'
+import {
+  BrowserUseCdpConnection,
+  type BrowserUseConnection,
+  type BrowserUseConnectionFactory
+} from './browser-use-cdp-connection'
+import type {
+  CodexBrowserUseAdapter,
+  CodexBrowserUseCdpTarget,
+  RpcNotificationEmitter
+} from './codex-browser-use-protocol'
+
+type OwnedConnection = {
+  ownerId: string
+  browserPageId: string
+  worktreeId: string
+  tabId: number
+  emit: RpcNotificationEmitter
+  connection: BrowserUseConnection | null
+}
+
+export class OrcaCodexBrowserUseAdapter implements CodexBrowserUseAdapter {
+  private readonly connections = new Map<string, OwnedConnection>()
+  private readonly connectionTails = new Map<string, Promise<void>>()
+  private readonly unsubscribeProcessSwap: () => void
+
+  constructor(
+    private readonly bridge: AgentBrowserBridge,
+    private readonly getAgentStatuses: () => AgentStatusIpcPayload[],
+    private readonly isPaneLive: (paneKey: string) => boolean,
+    private readonly createConnection: BrowserUseConnectionFactory = (
+      proxy,
+      tabId,
+      emit,
+      onClose
+    ) => BrowserUseCdpConnection.create(proxy, tabId, emit, onClose)
+  ) {
+    this.unsubscribeProcessSwap = this.bridge.onCodexBrowserUseProcessSwap((browserPageId) =>
+      this.invalidateBrowserPage(browserPageId)
+    )
+  }
+
+  resolveWorktreeId(sessionId: string): string | null {
+    const matches = this.getAgentStatuses().filter(
+      (status) =>
+        status.connectionId === null &&
+        status.agentType === 'codex' &&
+        status.providerSession?.key === 'session_id' &&
+        status.providerSession.id === sessionId &&
+        typeof status.worktreeId === 'string' &&
+        this.isPaneLive(status.paneKey)
+    )
+    const worktreeIds = new Set(matches.map((status) => status.worktreeId!))
+    return worktreeIds.size === 1 ? [...worktreeIds][0] : null
+  }
+
+  listTabs(worktreeId: string) {
+    return this.bridge.tabList(worktreeId).tabs
+  }
+
+  async attach(
+    connectionId: string,
+    sessionId: string,
+    worktreeId: string,
+    browserPageId: string,
+    tabId: number,
+    emit: RpcNotificationEmitter
+  ): Promise<void> {
+    const key = this.connectionKey(sessionId, browserPageId)
+    await this.withConnectionLock(key, async () => {
+      const existing = this.connections.get(key)
+      if (existing?.ownerId === connectionId && existing.connection) {
+        return
+      }
+      if (existing) {
+        this.connections.delete(key)
+        await existing.connection?.close()
+      }
+      const owned: OwnedConnection = {
+        ownerId: connectionId,
+        browserPageId,
+        worktreeId,
+        tabId,
+        emit,
+        connection: null
+      }
+      this.connections.set(key, owned)
+      try {
+        await this.createOwnedConnection(key, browserPageId, owned)
+      } catch (error) {
+        if (this.connections.get(key) === owned) {
+          this.connections.delete(key)
+        }
+        throw error
+      }
+    })
+  }
+
+  async detach(
+    connectionId: string,
+    sessionId: string,
+    _worktreeId: string,
+    browserPageId: string
+  ): Promise<void> {
+    const key = this.connectionKey(sessionId, browserPageId)
+    await this.withConnectionLock(key, async () => {
+      const owned = this.connections.get(key)
+      if (owned?.ownerId !== connectionId) {
+        return
+      }
+      this.connections.delete(key)
+      await owned.connection?.close()
+    })
+  }
+
+  async attachTarget(
+    connectionId: string,
+    sessionId: string,
+    _worktreeId: string,
+    browserPageId: string,
+    _tabId: number,
+    targetId: string
+  ): Promise<void> {
+    await this.withOwnedConnection(connectionId, sessionId, browserPageId, (connection) =>
+      connection.attachTarget(targetId)
+    )
+  }
+
+  async detachTarget(
+    connectionId: string,
+    sessionId: string,
+    _worktreeId: string,
+    browserPageId: string,
+    targetId: string
+  ): Promise<void> {
+    await this.withOwnedConnection(connectionId, sessionId, browserPageId, (connection) =>
+      connection.detachTarget(targetId)
+    )
+  }
+
+  async executeCdp(
+    connectionId: string,
+    sessionId: string,
+    worktreeId: string,
+    browserPageId: string,
+    target: CodexBrowserUseCdpTarget,
+    method: string,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    return await this.withOwnedConnection(connectionId, sessionId, browserPageId, (connection) => {
+      if (method === 'Page.navigate' && typeof params.url === 'string') {
+        return this.bridge.navigateCodexBrowserUseTab(worktreeId, browserPageId, params.url)
+      }
+      return connection.execute(target, method, params)
+    })
+  }
+
+  async close(): Promise<void> {
+    this.unsubscribeProcessSwap()
+    const connections = [...this.connections.values()].flatMap(({ connection }) =>
+      connection ? [connection] : []
+    )
+    this.connections.clear()
+    this.connectionTails.clear()
+    await Promise.allSettled(connections.map((connection) => connection.close()))
+  }
+
+  private async withOwnedConnection<T>(
+    connectionId: string,
+    sessionId: string,
+    browserPageId: string,
+    action: (connection: BrowserUseConnection) => Promise<T>
+  ): Promise<T> {
+    const key = this.connectionKey(sessionId, browserPageId)
+    return await this.withConnectionLock(key, async () => {
+      const owned = this.connections.get(key)
+      if (!owned) {
+        throw new Error('Browser tab is not attached')
+      }
+      if (owned.ownerId !== connectionId) {
+        throw new Error('Browser connection is not owned by this native session')
+      }
+      const connection =
+        owned.connection ?? (await this.createOwnedConnection(key, browserPageId, owned))
+      try {
+        return await action(connection)
+      } catch (error) {
+        const current = this.connections.get(key)
+        if (current !== owned || current.ownerId !== connectionId || current.connection !== null) {
+          throw error
+        }
+        const replacement = await this.createOwnedConnection(key, browserPageId, owned)
+        return await action(replacement)
+      }
+    })
+  }
+
+  private invalidateBrowserPage(browserPageId: string): void {
+    for (const owned of this.connections.values()) {
+      if (owned.browserPageId !== browserPageId || !owned.connection) {
+        continue
+      }
+      const stale = owned.connection
+      owned.connection = null
+      void stale.close().catch(() => undefined)
+    }
+  }
+
+  private async createOwnedConnection(
+    key: string,
+    browserPageId: string,
+    owned: OwnedConnection
+  ): Promise<BrowserUseConnection> {
+    const proxy = this.bridge.createCodexBrowserUseCdpProxy(owned.worktreeId, browserPageId)
+    let created: BrowserUseConnection | null = null
+    created = await this.createConnection(proxy, owned.tabId, owned.emit, () => {
+      const current = this.connections.get(key)
+      if (created && current === owned && current.connection === created) {
+        current.connection = null
+      }
+    })
+    if (this.connections.get(key) !== owned) {
+      await created.close()
+      throw new Error('Browser connection owner changed while attaching')
+    }
+    owned.connection = created
+    return created
+  }
+
+  private async withConnectionLock<T>(key: string, action: () => Promise<T>): Promise<T> {
+    const previous = this.connectionTails.get(key) ?? Promise.resolve()
+    const result = previous.catch(() => undefined).then(action)
+    const tail = result.then(
+      () => undefined,
+      () => undefined
+    )
+    this.connectionTails.set(key, tail)
+    try {
+      return await result
+    } finally {
+      if (this.connectionTails.get(key) === tail) {
+        this.connectionTails.delete(key)
+      }
+    }
+  }
+
+  private connectionKey(sessionId: string, browserPageId: string): string {
+    return `${sessionId}:${browserPageId}`
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -162,6 +162,8 @@ import {
   registerHeadlessPtyRuntime
 } from './ipc/pty'
 import { AgentBrowserBridge } from './browser/agent-browser-bridge'
+import { CodexBrowserUseBackend } from './browser/codex-browser-use-backend'
+import { OrcaCodexBrowserUseAdapter } from './browser/orca-codex-browser-use-adapter'
 import { EmulatorBridge } from './emulator/emulator-bridge'
 import { browserCertificateTrustController, browserManager } from './browser/browser-manager'
 import { OffscreenBrowserBackend } from './browser/offscreen-browser-backend'
@@ -228,6 +230,8 @@ let rateLimits: RateLimitService | null = null
 let runtimeRpc: OrcaRuntimeRpcServer | null = null
 let desktopRelayService: DesktopRelayService | null = null
 let desktopRelayStatus: RelayBrokerStatus = 'offline'
+let codexBrowserUseBackend: CodexBrowserUseBackend | null = null
+let codexBrowserUseAdapter: OrcaCodexBrowserUseAdapter | null = null
 // Why: set during early startup; gates whether headless serve installs the
 // offscreen browser backend (and thus advertises browser pane support).
 let headlessBrowserDisplayAvailable = false
@@ -2043,11 +2047,26 @@ app.whenReady().then(async () => {
   starNag = new StarNagService(store, stats)
   starNag.start()
   starNag.registerIpcHandlers()
-  runtimeService.setAgentBrowserBridge(
-    new AgentBrowserBridge(browserManager, {
-      onTabsChanged: (worktreeId) => runtimeService.notifyMobileSessionTabsChanged(worktreeId)
-    })
+  const agentBrowserBridge = new AgentBrowserBridge(browserManager, {
+    onTabsChanged: (worktreeId) => runtimeService.notifyMobileSessionTabsChanged(worktreeId)
+  })
+  runtimeService.setAgentBrowserBridge(agentBrowserBridge)
+  codexBrowserUseAdapter = new OrcaCodexBrowserUseAdapter(
+    agentBrowserBridge,
+    () => agentHookServer.getStatusSnapshot(),
+    (paneKey) => getPtyIdForPaneKey(paneKey) != null
   )
+  codexBrowserUseBackend = new CodexBrowserUseBackend(codexBrowserUseAdapter)
+  try {
+    await codexBrowserUseBackend.start()
+  } catch (error) {
+    console.warn(
+      `[codex-browser-use] backend unavailable; continuing without Browser plugin discovery: ${error instanceof Error ? error.message : String(error)}`
+    )
+    await codexBrowserUseAdapter.close()
+    codexBrowserUseBackend = null
+    codexBrowserUseAdapter = null
+  }
 
   // Emulator bridge (serve-sim). macOS-only feature (gated in CLI/runtime); always ship like agent-browser.
   // Why: only Orca-managed or explicitly attached helpers belong to a workspace;
@@ -2410,6 +2429,10 @@ app.on('will-quit', (e) => {
   automations?.stop()
   setUnreadDockBadgeCount(0)
   agentHookServer.stop()
+  const codexBrowserUseShutdown = (async () => {
+    await codexBrowserUseBackend?.stop()
+    await codexBrowserUseAdapter?.close()
+  })()
   // Why: cancels relay restart/reinstall timers and kills wsl.exe children
   // deterministically instead of relying on stdio-pipe teardown.
   wslHookRelayManager.disposeAll()
@@ -2472,7 +2495,13 @@ app.on('will-quit', (e) => {
     // Why: normal quits preserve the detached daemon for warm reattach, but a
     // dev parent dying means the temp/dev profile has no owner left to reattach.
     const daemonTeardown = isDevParentShutdownRequested() ? shutdownDaemon() : disconnectDaemon()
-    Promise.allSettled([daemonTeardown, rpcStopAndClear, watcherShutdown, emulatorShutdown])
+    Promise.allSettled([
+      daemonTeardown,
+      rpcStopAndClear,
+      watcherShutdown,
+      emulatorShutdown,
+      codexBrowserUseShutdown
+    ])
       .then(() => shutdownTelemetry())
       .then(() => shutdownObservability())
       .catch(() => {


### PR DESCRIPTION
## Summary
- expose the active Orca browser to the official Codex Browser runtime over the native-pipe protocol
- bind each connection to one live local Codex session and preserve ownership across CDP attach, navigation, renderer swaps, and reconnects
- harden framing, POSIX socket ownership/permissions, Windows named-pipe addressing, and SSH exclusion

## Verification
- 107 focused Browser/bridge tests pass
- full TypeScript typecheck passes
- desktop/native build and signed macOS package pass
- installed Orca discovers the visible browser, navigates the same tab across origins, and rediscovers it from a fresh Browser connection

## Scope
- local Orca sessions only; SSH sessions are intentionally excluded from the local pipe
- no fallback to Chrome, Safari, Playwright, or CLI browser control

## ELI5

Codex's official browser runtime could not attach to Orca's active browser. Orca exposes the live browser over the native-pipe protocol with ownership across reconnects so Codex drives the same browser you see.
