### PR TITLE
feat(new-workspace): always offer "Add a new project" in Create worktree picker

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -836,6 +836,7 @@ export default function NewWorkspaceComposerCard({
             value={selectedProjectId}
             onValueChange={onProjectChange}
             onValueSelected={focusNameInput}
+            onAddProject={handleAddRepo}
             placeholder={
               projectPlaceholder ??
               translate('auto.components.NewWorkspaceComposerCard.dccd26d4e4', 'Choose project')

--- a/src/renderer/src/components/new-workspace/ProjectCombobox.test.tsx
+++ b/src/renderer/src/components/new-workspace/ProjectCombobox.test.tsx
@@ -139,6 +139,40 @@ describe('ProjectCombobox', () => {
     expect(onValueChange).toHaveBeenCalledWith('project-group:folder-group')
   })
 
+  it('always offers an "Add a new project" action, including when the list is empty', () => {
+    const onAddProject = vi.fn()
+
+    act(() => {
+      root.render(
+        <ProjectCombobox
+          options={[]}
+          value={null}
+          onValueChange={vi.fn()}
+          onAddProject={onAddProject}
+        />
+      )
+    })
+
+    const addButton = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.textContent?.includes('Add a new project')
+    )
+    expect(addButton).toBeTruthy()
+
+    act(() => {
+      addButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(onAddProject).toHaveBeenCalledTimes(1)
+  })
+
+  it('omits the "Add a new project" action when no handler is provided', () => {
+    act(() => {
+      root.render(<ProjectCombobox options={projects} value={null} onValueChange={vi.fn()} />)
+    })
+
+    expect(container.textContent).not.toContain('Add a new project')
+  })
+
   it('renders directory details for duplicate project names', () => {
     const duplicateProjects: NewWorkspaceProjectOption[] = [
       {

--- a/src/renderer/src/components/new-workspace/ProjectCombobox.tsx
+++ b/src/renderer/src/components/new-workspace/ProjectCombobox.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import { Check, ChevronsUpDown, FolderOpen } from 'lucide-react'
+import { Check, ChevronsUpDown, FolderOpen, FolderPlus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   Command,
@@ -22,6 +22,7 @@ type ProjectComboboxProps = {
   value: string | null
   onValueChange: (projectId: string) => void
   onValueSelected?: (projectId: string) => void
+  onAddProject?: () => void
   placeholder?: string
   triggerClassName?: string
   invalid?: boolean
@@ -33,6 +34,7 @@ export default function ProjectCombobox({
   value,
   onValueChange,
   onValueSelected,
+  onAddProject,
   placeholder = 'Choose project',
   triggerClassName,
   invalid = false,
@@ -99,6 +101,12 @@ export default function ProjectCombobox({
     },
     [onValueChange, onValueSelected]
   )
+
+  const handleAddProject = useCallback((): void => {
+    setOpen(false)
+    setQuery('')
+    onAddProject?.()
+  }, [onAddProject])
 
   const handleTriggerKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLButtonElement>): void => {
@@ -219,6 +227,29 @@ export default function ProjectCombobox({
               </CommandItem>
             ))}
           </CommandList>
+          {onAddProject ? (
+            // Why: pinned below the scrollable list so "Add a new project" stays
+            // reachable in every state, including when the list is empty and
+            // CommandEmpty shows "No projects match your search."
+            <div className="border-t border-border">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={handleAddProject}
+                onMouseDown={(event) => event.preventDefault()}
+                onMouseEnter={() => setCommandValue('')}
+                className="h-8 w-full justify-start rounded-none px-3 text-xs font-normal"
+              >
+                <FolderPlus className="size-3.5 text-muted-foreground" />
+                <span>
+                  {translate(
+                    'auto.components.new.workspace.ProjectCombobox.addProject',
+                    'Add a new project'
+                  )}
+                </span>
+              </Button>
+            </div>
+          ) : null}
         </Command>
       </PopoverContent>
     </Popover>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10682,7 +10682,8 @@
           },
           "ProjectCombobox": {
             "search": "Search projects...",
-            "empty": "No projects match your search."
+            "empty": "No projects match your search.",
+            "addProject": "Add a new project"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -10659,7 +10659,8 @@
           },
           "ProjectCombobox": {
             "search": "Buscar proyectos...",
-            "empty": "Ningún proyecto coincide con tu búsqueda."
+            "empty": "Ningún proyecto coincide con tu búsqueda.",
+            "addProject": "Add a new project"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -10659,7 +10659,8 @@
           },
           "ProjectCombobox": {
             "search": "Search projects...",
-            "empty": "No projects match your search."
+            "empty": "No projects match your search.",
+            "addProject": "Add a new project"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10659,7 +10659,8 @@
           },
           "ProjectCombobox": {
             "search": "프로젝트 검색...",
-            "empty": "검색과 일치하는 프로젝트가 없습니다."
+            "empty": "검색과 일치하는 프로젝트가 없습니다.",
+            "addProject": "Add a new project"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -10659,7 +10659,8 @@
           },
           "ProjectCombobox": {
             "search": "搜索项目...",
-            "empty": "没有匹配搜索的项目。"
+            "empty": "没有匹配搜索的项目。",
+            "addProject": "Add a new project"
           }
         }
       },


### PR DESCRIPTION
## Summary

The **Create worktree** dialog's project picker now always shows an **"Add a new project"** action pinned at the bottom of the dropdown — in every state, including when the search yields **"No projects match your search."**

Previously the only in-dialog affordance for adding a project was the small icon button next to the *Project* label. If you opened the picker, searched, and found nothing, there was no obvious way to add the project you were looking for without backing out. Now the action is always one click away, right where you're already looking.

## What changed

- `ProjectCombobox` gains an optional `onAddProject` callback. When provided, it renders a pinned footer (`FolderPlus` + "Add a new project") **below** the scrollable `CommandList`, so it stays visible regardless of the list/empty state.
- `NewWorkspaceComposerCard` wires `onAddProject={handleAddRepo}`, so the footer opens the **same** add-project flow (`openModal('add-repo')`) used by the label-row icon and the sidebar.
- Footer styling and placement mirror the existing `AutomationProjectCombobox` footer, and it uses the shared `FolderPlus` icon used everywhere else for "add project".
- New `auto.components.new.workspace.ProjectCombobox.addProject` catalog key ("Add a new project"), synced across all locales.

The footer is a sibling **after** `CommandList`, not a `CommandItem` — so `CommandEmpty`'s "No projects match your search." still shows when the filter is empty, with the action pinned beneath it (exactly as requested).

## Screenshots

### Dark

**Dropdown open — "Add a new project" pinned below the project list**
![Dropdown open](https://raw.githubusercontent.com/nwparker/orca/pr/create-worktree-add-project-screenshots/screenshots/02-dropdown-open.png)

**"No projects match your search." — the action still shows**
![No match with footer](https://raw.githubusercontent.com/nwparker/orca/pr/create-worktree-add-project-screenshots/screenshots/03-no-match-with-footer.png)

**Filtered results — footer stays pinned**
![Partial match](https://raw.githubusercontent.com/nwparker/orca/pr/create-worktree-add-project-screenshots/screenshots/04-partial-match.png)

**Clicking it opens the shared add-project flow (`add-repo`)**
![Add a project opened](https://raw.githubusercontent.com/nwparker/orca/pr/create-worktree-add-project-screenshots/screenshots/05-add-repo-opened.png)

**Dialog on open**
![Dialog open](https://raw.githubusercontent.com/nwparker/orca/pr/create-worktree-add-project-screenshots/screenshots/01-dialog-open.png)

### Light

**Dropdown open**
![Light dropdown](https://raw.githubusercontent.com/nwparker/orca/pr/create-worktree-add-project-screenshots/screenshots/06-light-dropdown.png)

**"No projects match your search." — the action still shows**
![Light no match](https://raw.githubusercontent.com/nwparker/orca/pr/create-worktree-add-project-screenshots/screenshots/07-light-no-match.png)

## Testing

- `ProjectCombobox.test.tsx`: added coverage that the action shows (and fires `onAddProject`) even with an empty option list, and is omitted when no handler is passed. **6/6 pass.**
- `NewWorkspaceComposerCard.test.tsx`: **12/12 pass.**
- `pnpm typecheck:web`, `oxlint`, `oxfmt`, and `verify:localization-catalog` all clean.
- Verified end-to-end in the running Electron app (screenshots above are from the dev build): populated list, empty-search state, filtered state, and the click-through to the add-project dialog.

Made with [Orca](https://github.com/stablyai/orca) 🐋
