### PR TITLE
fix(settings): stop shortcut filter rail overlapping the list below xl

### DIFF
--- a/src/renderer/src/components/settings/ShortcutsPane.tsx
+++ b/src/renderer/src/components/settings/ShortcutsPane.tsx
@@ -343,7 +343,10 @@ export function ShortcutsPane(): React.JSX.Element {
           </div>
         ) : null}
 
-        <div className="grid min-h-0 flex-1 gap-6 xl:grid-cols-[16rem_minmax(0,1fr)]">
+        {/* Below xl the rail stacks above the list in one column; pin the rail
+            row to its content (auto) and let the list row take the rest, so the
+            rail can't spill over the list the way two equal auto rows would. */}
+        <div className="grid min-h-0 flex-1 gap-6 max-xl:grid-rows-[auto_minmax(0,1fr)] xl:grid-cols-[16rem_minmax(0,1fr)]">
           <ShortcutFilterRail
             query={shortcutQuery}
             onQueryChange={setShortcutQuery}


### PR DESCRIPTION
## Problem

On the **Settings → Shortcuts** page, the **Status** filter rail (All / Modified / Unassigned / Conflicts) overlaps the shortcut list (group headers and command rows render on top of the filters). Reported from a Windows laptop — display scaling puts the CSS viewport just under the `xl` (1280px) breakpoint, which is what triggers it.

## Root cause

The rail + list are a two-column grid that only defines its columns at `xl`:

```
grid ... xl:grid-cols-[16rem_minmax(0,1fr)]
```

Below `xl` the grid collapses to a single column with only **implicit auto rows**. Inside the focused pane's fixed-height, `overflow-hidden` container, those two auto rows split the height into **two equal tracks** (measured: `grid-template-rows: 195px 195px`). The rail needs ~250px but its track is clamped to 195px, and because the rail is `overflow: visible`, its lower content (the *Conflicts* filter) **spills down into the list's track** → the overlap.

## Fix

One line — below `xl`, pin the rail row to its content height and give the list row the remainder, so nothing spills and the list keeps its own scroll:

```diff
-<div className="grid min-h-0 flex-1 gap-6 xl:grid-cols-[16rem_minmax(0,1fr)]">
+<div className="grid min-h-0 flex-1 gap-6 max-xl:grid-rows-[auto_minmax(0,1fr)] xl:grid-cols-[16rem_minmax(0,1fr)]">
```

`max-xl:` and `xl:` are mutually exclusive media queries, so `display` stays `grid` throughout and there's no precedence conflict. The `xl` two-column layout is unchanged.

## Before / After (viewport 1200px, below `xl`)

| Before (overlap) | After (fixed) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/stablyai/orca/nwparker/shortcut-display-bug-assets/before-1200-overlap.png) | ![after](https://raw.githubusercontent.com/stablyai/orca/nwparker/shortcut-display-bug-assets/after-1200-fixed.png) |

**`xl` (1600px) layout preserved — two columns, list scrolls independently:**

![xl](https://raw.githubusercontent.com/stablyai/orca/nwparker/shortcut-display-bug-assets/after-1600-xl.png)

## Testing

- Reproduced live in the Electron dev build at 1200px (below `xl`): rail overlapped the list; measured `grid-template-rows: 195px 195px`.
- After the fix at 1200px: `grid-template-rows: 225px auto-rest`, rail bottom (558px) sits above list top (582px), **0px overlap**.
- Verified `xl` (1600px) still renders the two-column layout (`grid-template-columns: 256px …`, rail left / list right).
- `oxlint` clean; existing shortcut unit tests pass (23/23).

_Note: the screenshots live on the `nwparker/shortcut-display-bug-assets` branch and can be deleted after merge._

Made with [Orca](https://github.com/stablyai/orca) 🐋
