### PR TITLE
feat(tray): mark dev-instance tray icons with a DEV indicator

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -851,6 +851,8 @@ function getSystemTrayOptions(): SystemTrayOptions | null {
   }
   return {
     appIcon: store.getSettings().appIcon,
+    isDevInstance: devInstanceIdentity.isDev,
+    devInstanceLabel: devInstanceIdentity.devLabel,
     onOpen: showMainWindowFromTray,
     onOpenSettings: openSettingsFromSystemMenu,
     onCheckForUpdates: () => {

--- a/src/main/tray/system-tray.test.ts
+++ b/src/main/tray/system-tray.test.ts
@@ -7,10 +7,13 @@ const {
   composeAttentionMock,
   createAppIconImageMock,
   createFromPathMock,
+  devBadgeImage,
+  devBadgeRetinaImage,
   menuFromTemplateMock,
   nativeThemeMock,
   resizedImage,
   retinaMacImage,
+  stampDevBadgeMock,
   themeState,
   tintedMacImage,
   tintTemplateMock,
@@ -30,6 +33,8 @@ const {
   const retinaMacImage = makeImage('mac-retina')
   const tintedMacImage = makeImage('mac-tinted')
   const attentionImage = makeImage('attention')
+  const devBadgeImage = makeImage('dev-badge')
+  const devBadgeRetinaImage = makeImage('dev-badge-retina')
   const themeState = { updatedListener: null as (() => void) | null }
   const nativeThemeMock = {
     shouldUseDarkColors: false,
@@ -48,10 +53,15 @@ const {
     composeAttentionMock: vi.fn(() => attentionImage),
     createAppIconImageMock: vi.fn(),
     createFromPathMock: vi.fn(),
+    devBadgeImage,
+    devBadgeRetinaImage,
     menuFromTemplateMock: vi.fn((template: unknown) => ({ template })),
     nativeThemeMock,
     resizedImage,
     retinaMacImage,
+    stampDevBadgeMock: vi.fn((_base: unknown, scaleFactor?: number) =>
+      scaleFactor === 2 ? devBadgeRetinaImage : devBadgeImage
+    ),
     themeState,
     tintedMacImage,
     tintTemplateMock: vi.fn(() => tintedMacImage),
@@ -94,6 +104,10 @@ vi.mock('../app-icon', () => ({
 vi.mock('./tray-attention-icon', () => ({
   composeTrayAttentionIcon: composeAttentionMock,
   tintTrayTemplateForAttention: tintTemplateMock
+}))
+
+vi.mock('./tray-dev-badge', () => ({
+  stampTrayDevBadge: stampDevBadgeMock
 }))
 
 type TrayModule = typeof SystemTrayModule
@@ -139,7 +153,18 @@ beforeEach(() => {
   createFromPathMock.mockImplementation((path: string) =>
     path.includes('@2x') ? retinaMacImage : baseMacImage
   )
-  for (const image of [baseMacImage, retinaMacImage, tintedMacImage, attentionImage]) {
+  stampDevBadgeMock.mockClear()
+  stampDevBadgeMock.mockImplementation((_base: unknown, scaleFactor?: number) =>
+    scaleFactor === 2 ? devBadgeRetinaImage : devBadgeImage
+  )
+  for (const image of [
+    baseMacImage,
+    retinaMacImage,
+    tintedMacImage,
+    attentionImage,
+    devBadgeImage,
+    devBadgeRetinaImage
+  ]) {
     image.addRepresentation.mockClear()
     image.getScaleFactors.mockReset().mockReturnValue([1, 2])
     image.getSize.mockReset().mockReturnValue({ width: 16, height: 16 })
@@ -243,18 +268,52 @@ describe('createSystemTray', () => {
 })
 
 describe('dev instance indicator', () => {
-  it('shows a DEV title, labeled tooltip, and menu header on macOS', async () => {
+  it('stamps the DEV badge into the macOS template with a rebuilt Retina rep', async () => {
     setPlatform('darwin')
     const { createSystemTray } = await loadModule()
 
     createSystemTray(createOptions({ isDevInstance: true, devInstanceLabel: 'my-branch' }))
 
-    expect(trayInstances[0].setTitle).toHaveBeenCalledWith('DEV')
+    expect(stampDevBadgeMock).toHaveBeenCalledWith(baseMacImage)
+    expect(stampDevBadgeMock).toHaveBeenCalledWith(baseMacImage, 2)
+    expect(devBadgeImage.addRepresentation).toHaveBeenCalledWith({
+      scaleFactor: 2,
+      dataURL: 'data:image/png;base64,dev-badge-retina'
+    })
+    expect(devBadgeImage.setTemplateImage).toHaveBeenCalledWith(true)
+    expect(trayInstances[0].image).toBe(devBadgeImage)
+    expect(trayInstances[0].setTitle).not.toHaveBeenCalled()
     expect(trayInstances[0].setToolTip).toHaveBeenCalledWith('Orca DEV (my-branch)')
     expect(builtMenuItems()[0]).toMatchObject({
       label: 'Orca DEV (my-branch)',
       enabled: false
     })
+  })
+
+  it('tints the badged image (not the plain one) for macOS attention', async () => {
+    setPlatform('darwin')
+    const { createSystemTray, setTrayAttention } = await loadModule()
+    createSystemTray(createOptions({ isDevInstance: true, devInstanceLabel: 'my-branch' }))
+
+    setTrayAttention(true)
+
+    expect(tintTemplateMock).toHaveBeenCalledWith(devBadgeImage, false)
+  })
+
+  it('falls back to the plain icon when badge stamping fails', async () => {
+    setPlatform('darwin')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    stampDevBadgeMock.mockImplementation(() => {
+      throw new Error('bitmap failure')
+    })
+    const { createSystemTray } = await loadModule()
+
+    expect(createSystemTray(createOptions({ isDevInstance: true }))).not.toBeNull()
+    expect(trayInstances[0].image).toBe(baseMacImage)
+    expect(warn).toHaveBeenCalledWith(
+      '[system-tray] dev badge could not be stamped; showing plain icon',
+      expect.any(Error)
+    )
   })
 
   it('omits the label suffix when the dev instance has none', async () => {
@@ -280,14 +339,14 @@ describe('dev instance indicator', () => {
     expect(created.setToolTip).toHaveBeenLastCalledWith('Orca DEV (my-branch)')
   })
 
-  it('marks the Windows tooltip without touching the macOS-only title', async () => {
+  it('marks the Windows tooltip without badging the icon', async () => {
     setPlatform('win32')
     const { createSystemTray } = await loadModule()
 
     createSystemTray(createOptions({ isDevInstance: true, devInstanceLabel: 'my-branch' }))
 
     expect(trayInstances[0].setToolTip).toHaveBeenCalledWith('Orca DEV (my-branch)')
-    expect(trayInstances[0].setTitle).not.toHaveBeenCalled()
+    expect(stampDevBadgeMock).not.toHaveBeenCalled()
     expect(builtMenuItems()[0]).toMatchObject({ label: 'Orca DEV (my-branch)', enabled: false })
   })
 
@@ -297,7 +356,8 @@ describe('dev instance indicator', () => {
 
     createSystemTray(createOptions())
 
-    expect(trayInstances[0].setTitle).not.toHaveBeenCalled()
+    expect(stampDevBadgeMock).not.toHaveBeenCalled()
+    expect(trayInstances[0].image).toBe(baseMacImage)
     expect(builtMenuItems()[0].label).toBe('Open Orca')
   })
 })

--- a/src/main/tray/system-tray.test.ts
+++ b/src/main/tray/system-tray.test.ts
@@ -61,6 +61,7 @@ const {
 
 class FakeTray {
   setToolTip = vi.fn()
+  setTitle = vi.fn()
   setContextMenu = vi.fn()
   setImage = vi.fn()
   on = vi.fn()
@@ -109,9 +110,13 @@ async function loadModule(): Promise<TrayModule> {
   return import('./system-tray')
 }
 
-function createOptions() {
+function createOptions(
+  overrides: { isDevInstance?: boolean; devInstanceLabel?: string | null } = {}
+) {
   return {
     appIcon: 'classic',
+    isDevInstance: overrides.isDevInstance ?? false,
+    devInstanceLabel: overrides.devInstanceLabel ?? null,
     onOpen: vi.fn(),
     onOpenSettings: vi.fn(),
     onCheckForUpdates: vi.fn(),
@@ -234,6 +239,66 @@ describe('createSystemTray', () => {
     setPlatform('linux')
     const linuxModule = await loadModule()
     expect(linuxModule.createSystemTray(options)).toBeNull()
+  })
+})
+
+describe('dev instance indicator', () => {
+  it('shows a DEV title, labeled tooltip, and menu header on macOS', async () => {
+    setPlatform('darwin')
+    const { createSystemTray } = await loadModule()
+
+    createSystemTray(createOptions({ isDevInstance: true, devInstanceLabel: 'my-branch' }))
+
+    expect(trayInstances[0].setTitle).toHaveBeenCalledWith('DEV')
+    expect(trayInstances[0].setToolTip).toHaveBeenCalledWith('Orca DEV (my-branch)')
+    expect(builtMenuItems()[0]).toMatchObject({
+      label: 'Orca DEV (my-branch)',
+      enabled: false
+    })
+  })
+
+  it('omits the label suffix when the dev instance has none', async () => {
+    setPlatform('darwin')
+    const { createSystemTray } = await loadModule()
+
+    createSystemTray(createOptions({ isDevInstance: true }))
+
+    expect(trayInstances[0].setToolTip).toHaveBeenCalledWith('Orca DEV')
+    expect(builtMenuItems()[0]).toMatchObject({ label: 'Orca DEV', enabled: false })
+  })
+
+  it('keeps the DEV marker in the tooltip across the attention toggle', async () => {
+    setPlatform('darwin')
+    const { createSystemTray, setTrayAttention } = await loadModule()
+    createSystemTray(createOptions({ isDevInstance: true, devInstanceLabel: 'my-branch' }))
+    const created = trayInstances[0]
+    created.setToolTip.mockClear()
+
+    setTrayAttention(true)
+    expect(created.setToolTip).toHaveBeenCalledWith('Orca DEV (my-branch) - activity waiting')
+    setTrayAttention(false)
+    expect(created.setToolTip).toHaveBeenLastCalledWith('Orca DEV (my-branch)')
+  })
+
+  it('marks the Windows tooltip without touching the macOS-only title', async () => {
+    setPlatform('win32')
+    const { createSystemTray } = await loadModule()
+
+    createSystemTray(createOptions({ isDevInstance: true, devInstanceLabel: 'my-branch' }))
+
+    expect(trayInstances[0].setToolTip).toHaveBeenCalledWith('Orca DEV (my-branch)')
+    expect(trayInstances[0].setTitle).not.toHaveBeenCalled()
+    expect(builtMenuItems()[0]).toMatchObject({ label: 'Orca DEV (my-branch)', enabled: false })
+  })
+
+  it('adds no DEV marker for production instances', async () => {
+    setPlatform('darwin')
+    const { createSystemTray } = await loadModule()
+
+    createSystemTray(createOptions())
+
+    expect(trayInstances[0].setTitle).not.toHaveBeenCalled()
+    expect(builtMenuItems()[0].label).toBe('Open Orca')
   })
 })
 

--- a/src/main/tray/system-tray.ts
+++ b/src/main/tray/system-tray.ts
@@ -8,6 +8,10 @@ import { composeTrayAttentionIcon, tintTrayTemplateForAttention } from './tray-a
 export type SystemTrayOptions = {
   /** App icon id from settings; the tray reuses the app icon image. */
   appIcon: unknown
+  /** True for dev/unpackaged instances; shows a DEV marker on the tray. */
+  isDevInstance: boolean
+  /** Worktree/branch label identifying the dev instance, when known. */
+  devInstanceLabel: string | null
   /** Restore + show + focus the main window (recreating it if needed). */
   onOpen: () => void
   /** Restore the main window and open its Settings surface. */
@@ -31,7 +35,20 @@ let baseTrayImage: NativeImage | null = null
 // freshly created tray reflects it immediately.
 let attentionActive = false
 
+// Why: dev instances share the production template glyph, so remember dev-ness
+// at module scope; tooltip rebuilds (attention on/off) must keep the marker.
+let devIndicator: { label: string | null } | null = null
+
 let nativeThemeUpdatedListener: (() => void) | null = null
+
+// Why: multiple dev instances can run side by side (one per worktree); the
+// tooltip carries the worktree/branch label so hovering tells them apart.
+function baseTooltip(): string {
+  if (!devIndicator) {
+    return 'Orca'
+  }
+  return devIndicator.label ? `Orca DEV (${devIndicator.label})` : 'Orca DEV'
+}
 
 // Why: on Windows the notification area expects a 16px icon; the app icon PNG
 // is larger, so downscale to avoid a cropped/blurry tray glyph.
@@ -66,7 +83,11 @@ function applyTrayImage(): void {
         }
         attentionImage.setTemplateImage(false)
         tray.setImage(attentionImage)
-        tray.setToolTip(translateMain('tray.activityWaiting', 'Orca - activity waiting'))
+        tray.setToolTip(
+          devIndicator
+            ? `${baseTooltip()} - ${translateMain('tray.activityWaitingSuffix', 'activity waiting')}`
+            : translateMain('tray.activityWaiting', 'Orca - activity waiting')
+        )
         return
       } catch (error) {
         // Why: this path runs inside unguarded callbacks (nativeTheme 'updated',
@@ -78,7 +99,7 @@ function applyTrayImage(): void {
 
     baseTrayImage.setTemplateImage(true)
     tray.setImage(baseTrayImage)
-    tray.setToolTip('Orca')
+    tray.setToolTip(baseTooltip())
     return
   }
 
@@ -162,6 +183,8 @@ export function createSystemTray(opts: SystemTrayOptions): Tray | null {
     return tray
   }
 
+  devIndicator = opts.isDevInstance ? { label: opts.devInstanceLabel } : null
+
   if (process.platform === 'darwin') {
     baseTrayImage = createMacMenuBarImage()
     if (!baseTrayImage) {
@@ -175,10 +198,23 @@ export function createSystemTray(opts: SystemTrayOptions): Tray | null {
   }
 
   tray = new Tray(baseTrayImage)
+  if (process.platform === 'darwin' && devIndicator) {
+    // Why: dev builds reuse the production template glyph, so without a marker
+    // a dev status item is indistinguishable from the installed app's.
+    tray.setTitle('DEV')
+  }
   // Why: reflect any attention event that fired before the tray existed.
   applyTrayImage()
 
   const menu = Menu.buildFromTemplate([
+    ...(devIndicator
+      ? ([
+          // Why: several dev instances (one per worktree) can show trays at
+          // once; the disabled header ties this one to its worktree/branch.
+          { label: baseTooltip(), enabled: false },
+          { type: 'separator' }
+        ] as Electron.MenuItemConstructorOptions[])
+      : []),
     {
       label: translateMain('tray.openOrca', 'Open Orca'),
       click: safeMenuAction(() => opts.onOpen())
@@ -202,7 +238,7 @@ export function createSystemTray(opts: SystemTrayOptions): Tray | null {
   ])
   tray.setContextMenu(menu)
   if (process.platform === 'win32') {
-    tray.setToolTip('Orca')
+    tray.setToolTip(baseTooltip())
     // Why: a left-click on the tray icon is the conventional Windows gesture to
     // restore a minimized-to-tray app; macOS opens the attached menu instead.
     tray.on(

--- a/src/main/tray/system-tray.ts
+++ b/src/main/tray/system-tray.ts
@@ -4,6 +4,7 @@ import menuBarIconRetinaPath from '../../../resources/tray/orca-menu-barTemplate
 import { createAppIconImage } from '../app-icon'
 import { translateMain } from '../i18n/main-i18n'
 import { composeTrayAttentionIcon, tintTrayTemplateForAttention } from './tray-attention-icon'
+import { stampTrayDevBadge } from './tray-dev-badge'
 
 export type SystemTrayOptions = {
   /** App icon id from settings; the tray reuses the app icon image. */
@@ -138,6 +139,33 @@ function createMacMenuBarImage(): NativeImage | null {
   return image
 }
 
+// Why: dev builds reuse the production template glyph, so without a marker a
+// dev status item is indistinguishable from the installed app's. Stamping the
+// badge into the template (instead of tray.setTitle) keeps the status item at
+// the exact production width, and the attention tint path inherits it since it
+// reads these same pixels.
+function stampMacDevBadge(base: NativeImage): NativeImage {
+  try {
+    const stamped = stampTrayDevBadge(base)
+    if (base.getScaleFactors().includes(2)) {
+      // Why: createFromBitmap starts from 1x pixels only, so the @2x
+      // representation must be rebuilt or the badge blurs on Retina.
+      const retinaStamped = stampTrayDevBadge(base, 2)
+      stamped.addRepresentation({
+        scaleFactor: 2,
+        dataURL: retinaStamped.toDataURL()
+      })
+    }
+    stamped.setTemplateImage(true)
+    return stamped
+  } catch (error) {
+    // Why: the badge is diagnostics-only chrome; a NativeImage failure must
+    // degrade to the plain icon, not abort tray creation.
+    console.warn('[system-tray] dev badge could not be stamped; showing plain icon', error)
+    return base
+  }
+}
+
 function watchMacAppearance(): void {
   if (nativeThemeUpdatedListener) {
     return
@@ -190,6 +218,9 @@ export function createSystemTray(opts: SystemTrayOptions): Tray | null {
     if (!baseTrayImage) {
       return null
     }
+    if (devIndicator) {
+      baseTrayImage = stampMacDevBadge(baseTrayImage)
+    }
   } else {
     baseTrayImage = createAppIconImage(opts.appIcon).resize({
       width: TRAY_ICON_SIZE,
@@ -198,11 +229,6 @@ export function createSystemTray(opts: SystemTrayOptions): Tray | null {
   }
 
   tray = new Tray(baseTrayImage)
-  if (process.platform === 'darwin' && devIndicator) {
-    // Why: dev builds reuse the production template glyph, so without a marker
-    // a dev status item is indistinguishable from the installed app's.
-    tray.setTitle('DEV')
-  }
   // Why: reflect any attention event that fired before the tray existed.
   applyTrayImage()
 

--- a/src/main/tray/tray-dev-badge.test.ts
+++ b/src/main/tray/tray-dev-badge.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const createFromBitmapMock = vi.hoisted(() =>
+  vi.fn((buffer: Buffer, options: { width: number; height: number }) => ({
+    __image: true,
+    buffer,
+    ...options
+  }))
+)
+
+vi.mock('electron', () => ({
+  nativeImage: { createFromBitmap: createFromBitmapMock }
+}))
+
+import { stampTrayDevBadge } from './tray-dev-badge'
+
+function fakeTemplate(width: number, height: number) {
+  // All-transparent base so any opaque pixel in the result is the badge.
+  return {
+    getSize: () => ({ width, height }),
+    toBitmap: vi.fn((options?: { scaleFactor?: number }) => {
+      const scale = options?.scaleFactor ?? 1
+      return Buffer.alloc(width * scale * height * scale * 4, 0)
+    })
+  }
+}
+
+describe('stampTrayDevBadge', () => {
+  it('returns the base unchanged when it has no pixels', () => {
+    createFromBitmapMock.mockClear()
+    const base = { getSize: () => ({ width: 0, height: 0 }), toBitmap: () => Buffer.alloc(0) }
+
+    expect(stampTrayDevBadge(base as never)).toBe(base)
+    expect(createFromBitmapMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps the template canvas size and stamps opaque template-black pixels', () => {
+    createFromBitmapMock.mockClear()
+    const width = 22
+    const height = 14
+    stampTrayDevBadge(fakeTemplate(width, height) as never)
+
+    const [bitmap, options] = createFromBitmapMock.mock.calls[0]
+    expect(options).toEqual({ width, height })
+
+    let stamped = 0
+    let maxX = 0
+    let maxY = 0
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const o = (y * width + x) * 4
+        if (bitmap[o + 3] === 0xff) {
+          expect([bitmap[o], bitmap[o + 1], bitmap[o + 2]]).toEqual([0x00, 0x00, 0x00])
+          stamped++
+          maxX = Math.max(maxX, x)
+          maxY = Math.max(maxY, y)
+        }
+      }
+    }
+    expect(stamped).toBeGreaterThan(0)
+    // The badge occupies the lower-left area and never spills off canvas.
+    expect(maxX).toBeLessThan(width)
+    expect(maxY).toBeLessThan(height)
+  })
+
+  it('reads and scales the requested Retina representation', () => {
+    const opaque = (buffer: Buffer): number => {
+      let count = 0
+      for (let o = 3; o < buffer.length; o += 4) {
+        if (buffer[o] === 0xff) {
+          count++
+        }
+      }
+      return count
+    }
+
+    createFromBitmapMock.mockClear()
+    const base = fakeTemplate(22, 14)
+    stampTrayDevBadge(base as never, 2)
+    expect(base.toBitmap).toHaveBeenCalledWith({ scaleFactor: 2 })
+    const [bitmap2x, options2x] = createFromBitmapMock.mock.calls[0]
+    expect(options2x).toEqual({ width: 44, height: 28 })
+
+    createFromBitmapMock.mockClear()
+    stampTrayDevBadge(fakeTemplate(22, 14) as never, 1)
+    const [bitmap1x] = createFromBitmapMock.mock.calls[0]
+
+    // Each 1x badge pixel becomes a 2x2 block, so the @2x stamp has 4x the area.
+    expect(opaque(bitmap2x)).toBe(opaque(bitmap1x) * 4)
+  })
+})

--- a/src/main/tray/tray-dev-badge.ts
+++ b/src/main/tray/tray-dev-badge.ts
@@ -1,0 +1,66 @@
+import { nativeImage, type NativeImage } from 'electron'
+
+// Why: a 5px-tall pixel-caps "DEV" is the smallest text that stays legible in
+// the 14pt menu-bar template; it fills the empty area left of the orca glyph
+// so the status item keeps the exact production footprint.
+const DEV_BADGE_ROWS = ['##..###.#.#', '#.#.#...#.#', '#.#.##..#.#', '#.#.#...#.#', '##..###..#.']
+const BADGE_OFFSET_X = 0
+const BADGE_OFFSET_Y = 3
+// Why: the orca tail's antialiased pixels touch the V's right stroke and make
+// "DEV" read as "DEU"; clearing a margin around the badge keeps it legible.
+const BADGE_CLEAR_MARGIN = 1
+
+/**
+ * Returns a copy of the menu-bar template with a "DEV" pixel-text badge
+ * stamped left of the glyph. Badge pixels are template black (#000 + alpha),
+ * so macOS tints them with the glyph in both menu-bar themes and the attention
+ * tint path inherits the badge unchanged. Returns `base` untouched when the
+ * image has no pixels.
+ */
+export function stampTrayDevBadge(base: NativeImage, scaleFactor = 1): NativeImage {
+  const { width, height } = base.getSize()
+  if (width <= 0 || height <= 0) {
+    return base
+  }
+
+  const bitmap = Buffer.from(base.toBitmap({ scaleFactor }))
+  const pixelWidth = width * scaleFactor
+  const pixelHeight = height * scaleFactor
+
+  const clearLeft = (BADGE_OFFSET_X - BADGE_CLEAR_MARGIN) * scaleFactor
+  const clearTop = (BADGE_OFFSET_Y - BADGE_CLEAR_MARGIN) * scaleFactor
+  const clearRight = (BADGE_OFFSET_X + DEV_BADGE_ROWS[0].length + BADGE_CLEAR_MARGIN) * scaleFactor
+  const clearBottom = (BADGE_OFFSET_Y + DEV_BADGE_ROWS.length + BADGE_CLEAR_MARGIN) * scaleFactor
+  for (let y = Math.max(0, clearTop); y < Math.min(pixelHeight, clearBottom); y++) {
+    for (let x = Math.max(0, clearLeft); x < Math.min(pixelWidth, clearRight); x++) {
+      bitmap.fill(0x00, (y * pixelWidth + x) * 4, (y * pixelWidth + x) * 4 + 4)
+    }
+  }
+
+  for (let row = 0; row < DEV_BADGE_ROWS.length; row++) {
+    const pattern = DEV_BADGE_ROWS[row]
+    for (let col = 0; col < pattern.length; col++) {
+      if (pattern[col] !== '#') {
+        continue
+      }
+      // Why: replicate each badge pixel scaleFactor times so the Retina
+      // representation shows the same physical badge as the 1x one.
+      for (let dy = 0; dy < scaleFactor; dy++) {
+        for (let dx = 0; dx < scaleFactor; dx++) {
+          const x = (BADGE_OFFSET_X + col) * scaleFactor + dx
+          const y = (BADGE_OFFSET_Y + row) * scaleFactor + dy
+          if (x >= pixelWidth || y >= pixelHeight) {
+            continue
+          }
+          const offset = (y * pixelWidth + x) * 4
+          bitmap[offset] = 0x00
+          bitmap[offset + 1] = 0x00
+          bitmap[offset + 2] = 0x00
+          bitmap[offset + 3] = 0xff
+        }
+      }
+    }
+  }
+
+  return nativeImage.createFromBitmap(bitmap, { width: pixelWidth, height: pixelHeight })
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -95,7 +95,8 @@
     "minimizeNotice": {
       "body": "Orca is still running in the system tray"
     },
-    "activityWaiting": "Orca - activity waiting"
+    "activityWaiting": "Orca - activity waiting",
+    "activityWaitingSuffix": "activity waiting"
   },
   "worktreeJumpPalette": {
     "matchLabel": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -72,7 +72,8 @@
     "minimizeNotice": {
       "body": "Orca sigue ejecutándose en la bandeja del sistema"
     },
-    "activityWaiting": "Orca: actividad en espera"
+    "activityWaiting": "Orca: actividad en espera",
+    "activityWaitingSuffix": "activity waiting"
   },
   "worktreeJumpPalette": {
     "matchLabel": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -72,7 +72,8 @@
     "minimizeNotice": {
       "body": "Orcaはシステムトレイで実行中です"
     },
-    "activityWaiting": "Orca - アクティビティ待機中"
+    "activityWaiting": "Orca - アクティビティ待機中",
+    "activityWaitingSuffix": "activity waiting"
   },
   "worktreeJumpPalette": {
     "matchLabel": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -72,7 +72,8 @@
     "minimizeNotice": {
       "body": "Orca가 시스템 트레이에서 계속 실행 중입니다"
     },
-    "activityWaiting": "Orca - 활동 대기 중"
+    "activityWaiting": "Orca - 활동 대기 중",
+    "activityWaitingSuffix": "activity waiting"
   },
   "worktreeJumpPalette": {
     "matchLabel": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -72,7 +72,8 @@
     "minimizeNotice": {
       "body": "Orca 仍在系统托盘中运行"
     },
-    "activityWaiting": "Orca - 活动等待中"
+    "activityWaiting": "Orca - 活动等待中",
+    "activityWaitingSuffix": "activity waiting"
   },
   "worktreeJumpPalette": {
     "matchLabel": {


### PR DESCRIPTION
## Summary

Dev builds reuse the production template glyph in the macOS menu bar, so a dev instance's status item was indistinguishable from the installed app's. This adds a **DEV** indicator to the system tray without changing the status item's size:

- **macOS**: a 5px pixel-caps `DEV` badge is stamped directly into the menu-bar template bitmap (`tray-dev-badge.ts`), in the empty area left of the orca glyph — the status item keeps the exact production footprint. Badge pixels are template black, so macOS tints them correctly in both light and dark menu bars, and the attention (amber dot) tint path inherits the badge for free since it reads the same pixels. A one-pixel cleared margin keeps the orca tail's antialiased pixels from bleeding into the `V`. The @2x Retina representation is rebuilt with the badge so it stays sharp.
- **macOS + Windows**: the tooltip becomes `Orca DEV (<worktree/branch label>)`, using the same `getDevInstanceIdentity` label that already feeds the window title and Dock, so multiple side-by-side dev instances (one per worktree) can be told apart by hover.
- **Both**: the tray context menu gains a disabled header row with the same label, tying the menu to its instance.
- Production instances are entirely unaffected (`isDev: false` short-circuits to the previous image and strings), and a badge-stamping failure degrades to the plain icon instead of aborting tray creation.

New `tray.activityWaitingSuffix` key synced across all locale catalogs via `pnpm run sync:localization-catalog`.

## Screenshots

Menu bar — dev instance (left, with DEV badge) next to the production Orca icon (right), same footprint:

![menu bar with DEV-badged icon](https://github.com/stablyai/orca/blob/6da8b692728f0240ef63bba90aa9a9dded0a61fa/dev-tray-menubar-v2.png?raw=true)

Pixel zoom (nearest-neighbor 8x) of the badged icon vs the production icon:

![badge pixel zoom](https://github.com/stablyai/orca/blob/0dcc5bd71c84760eb3cc897466dc24bb82a4e32c/badge-zoom-v4-nn.png?raw=true)

Tray menu with the instance-identifying header:

![tray menu with Orca DEV header](https://github.com/stablyai/orca/blob/2a13a78b682e6cbd84bd77896baceaae58cb198f/dev-tray-menu-v2.png?raw=true)

## Testing

- `tray-dev-badge.test.ts`: badge keeps the template canvas size, stamps only opaque template-black pixels, empty-image no-op, and the @2x stamp covers exactly 4x the 1x area.
- `system-tray.test.ts`: dev badge stamped with rebuilt Retina rep + `setTemplateImage(true)`, attention tints the badged image, stamping failure falls back to the plain icon, tooltip/menu header with and without label, attention-toggle tooltip persistence, Windows tooltip, production no-op. 32/32 tray tests pass.
- `pnpm run typecheck` clean.
- Verified live across three iterations: launched the dev build via `run-electron-vite-dev.mjs`, screenshotted the real menu bar, and pixel-zoomed the result. First attempt used `tray.setTitle('DEV')` (rejected: widens the item); the first in-icon placement collided with the orca tail's antialiasing and read "DEU" — fixed by shifting the badge up one row and clearing a margin. Final screenshots above show the corrected badge at production width.