### PR TITLE
fix(codex): clarify account-switch restart card actions

### DIFF
--- a/src/renderer/src/components/CodexRestartChip.tsx
+++ b/src/renderer/src/components/CodexRestartChip.tsx
@@ -209,17 +209,17 @@ function LoudRestartOverlay({
         </div>
         <div id={bodyId} className="text-sm leading-relaxed text-muted-foreground">
           {translate(
-            'auto.components.CodexRestartChip.e9b2c7d1a5',
-            'Restart this session to use {{value0}}. Collapse to keep working with the current account.',
+            'auto.components.CodexRestartChip.9375620cc3',
+            'Restart this session to use {{value0}}. It stays on the previous account until you do.',
             { value0: restartNotice.nextAccountLabel }
           )}
         </div>
         <div className="mt-1 flex flex-wrap justify-end gap-2">
           <Button type="button" variant="outline" size="sm" onClick={onDismiss}>
-            {translate('auto.components.CodexRestartChip.9132779820', 'Dismiss')}
+            {translate('auto.components.CodexRestartChip.6133594b12', 'Keep old account')}
           </Button>
           <Button type="button" variant="outline" size="sm" onClick={onCollapse}>
-            {translate('auto.components.CodexRestartChip.f1a6c8e3b4', 'Collapse')}
+            {translate('auto.components.CodexRestartChip.b9000fe511', 'Not now')}
           </Button>
           <Button ref={restartRef} type="button" variant="default" size="sm" onClick={onRestart}>
             <RefreshCw />

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -762,13 +762,13 @@
     },
     "components": {
       "CodexRestartChip": {
-        "9132779820": "Dismiss",
         "a4c8e1b2f7": "Codex is still signed in as {{value0}}",
         "c72a5fb234": "Restart",
         "9263e75f49": "Codex is using the previous account",
         "d3e8a1f4b2": "Account switched",
-        "e9b2c7d1a5": "Restart this session to use {{value0}}. Collapse to keep working with the current account.",
-        "f1a6c8e3b4": "Collapse"
+        "9375620cc3": "Restart this session to use {{value0}}. It stays on the previous account until you do.",
+        "6133594b12": "Keep old account",
+        "b9000fe511": "Not now"
       },
       "FirstLaunchBanner": {
         "b9e1b966c7": "Dismiss notice",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -739,13 +739,13 @@
     },
     "components": {
       "CodexRestartChip": {
-        "9132779820": "Descartar",
         "c72a5fb234": "Reiniciar",
         "9263e75f49": "Codex está usando la cuenta anterior.",
         "a4c8e1b2f7": "Codex sigue conectado como {{value0}}",
         "d3e8a1f4b2": "Cuenta cambiada",
-        "e9b2c7d1a5": "Reinicia esta sesión para usar {{value0}}. Contrae para seguir trabajando con la cuenta actual.",
-        "f1a6c8e3b4": "Contraer"
+        "9375620cc3": "Restart this session to use {{value0}}. It stays on the previous account until you do.",
+        "6133594b12": "Keep old account",
+        "b9000fe511": "Not now"
       },
       "FirstLaunchBanner": {
         "b9e1b966c7": "Descartar aviso",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -739,13 +739,13 @@
     },
     "components": {
       "CodexRestartChip": {
-        "9132779820": "閉じる",
         "c72a5fb234": "再起動",
         "9263e75f49": "Codex は前のアカウントを使用しています",
         "a4c8e1b2f7": "Codex はまだ {{value0}} としてサインインしています",
         "d3e8a1f4b2": "アカウントを切り替えました",
-        "e9b2c7d1a5": "{{value0}} を使用するにはこのセッションを再起動してください。現在のアカウントで作業を続けるには折りたたんでください。",
-        "f1a6c8e3b4": "折りたたむ"
+        "9375620cc3": "Restart this session to use {{value0}}. It stays on the previous account until you do.",
+        "6133594b12": "Keep old account",
+        "b9000fe511": "Not now"
       },
       "FirstLaunchBanner": {
         "b9e1b966c7": "通知を閉じる",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -739,13 +739,13 @@
     },
     "components": {
       "CodexRestartChip": {
-        "9132779820": "닫기",
         "c72a5fb234": "다시 시작",
         "9263e75f49": "Codex는 이전 계정을 사용하고 있습니다",
         "a4c8e1b2f7": "Codex가 아직 {{value0}} 계정으로 로그인되어 있습니다",
         "d3e8a1f4b2": "계정 전환됨",
-        "e9b2c7d1a5": "{{value0}}을(를) 사용하려면 이 세션을 다시 시작하세요. 현재 계정으로 계속 작업하려면 접으세요.",
-        "f1a6c8e3b4": "접기"
+        "9375620cc3": "Restart this session to use {{value0}}. It stays on the previous account until you do.",
+        "6133594b12": "Keep old account",
+        "b9000fe511": "Not now"
       },
       "FirstLaunchBanner": {
         "b9e1b966c7": "알림 닫기",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -739,13 +739,13 @@
     },
     "components": {
       "CodexRestartChip": {
-        "9132779820": "关闭",
         "c72a5fb234": "重新启动",
         "9263e75f49": "Codex 正在使用之前的账户",
         "a4c8e1b2f7": "Codex 仍以 {{value0}} 身份登录",
         "d3e8a1f4b2": "账户已切换",
-        "e9b2c7d1a5": "重启此会话以使用 {{value0}}。折叠以继续使用当前账户。",
-        "f1a6c8e3b4": "折叠"
+        "9375620cc3": "Restart this session to use {{value0}}. It stays on the previous account until you do.",
+        "6133594b12": "Keep old account",
+        "b9000fe511": "Not now"
       },
       "FirstLaunchBanner": {
         "b9e1b966c7": "关闭通知",


### PR DESCRIPTION
## What

The Codex **"Account switched"** restart card had two dismissive buttons whose
distinct behaviors weren't legible, plus body copy that misdescribed one of them:

| Before | Problem |
|---|---|
| **Dismiss** | Permanently clears the notice — pane keeps the old account. Reads as generic "go away." |
| **Collapse** | Only minimizes the card to a pill; decision deferred. "Collapse" is a layout verb, not a decision. |
| Body: *"…Collapse to keep working with the current account."* | Attributes "keep the current account" to **Collapse**, but that's actually what **Dismiss** does. Collapse commits to nothing. |

## Change

Intent-named actions so each button says what it does:

| Button | Old label | New label | Behavior (unchanged) |
|---|---|---|---|
| `onDismiss` | Dismiss | **Keep old account** | Clears the notice; pane stays on the old account |
| `onCollapse` | Collapse | **Not now** | Minimizes to the pill; decision deferred |
| `onRestart` | Restart | Restart | Restarts the pane under the new account |

Body copy rewritten so it no longer claims the minimize action commits you to an
account: *"Restart this session to use {account}. It stays on the previous account until you do."*

Title (**Account switched**) and heading (**Codex is still signed in as …**) are unchanged.

## i18n

New English strings get **fresh auto keys** (`localize-renderer-strings` hashing scheme) so the
old es/ja/ko/zh translations don't silently persist under a reused key. Ran
`sync:localization-catalog` to add the new keys, prune the three obsolete ones, and seed the
other locales with the English fallback (translators fill them in later —
better than showing a stale/wrong translation). `verify:localization-catalog` and
`verify:localization-coverage` pass.

## Testing

- `vitest` `codex-restart-chip.test.ts` — 5/5 pass
- `typecheck:web`, `oxlint`, `verify:localization-catalog`, `verify:localization-coverage` — clean
- **Live in the running Electron app** (dev build, real store action `markCodexRestartNotices` on a live terminal PTY):

**Loud card**

![loud card](https://raw.githubusercontent.com/stablyai/orca/00892e7f325cf1255e4abc28a4e11a2d91455136/qa/codex-restart-card-loud.png)

**"Not now" → collapsed pill**

![collapsed pill](https://raw.githubusercontent.com/stablyai/orca/00892e7f325cf1255e4abc28a4e11a2d91455136/qa/codex-restart-card-collapsed.png)

<sub>Screenshots hosted on a throwaway `codex-restart-copy-qa` branch to keep this diff image-free; delete after review.</sub>
