### PR TITLE
fix(ssh): clear stale agent rows after connection loss

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -1407,7 +1407,7 @@ describe('AgentHookServer listener replay', () => {
     expect(listener).toHaveBeenNthCalledWith(4, [])
   })
 
-  it('notifies pane-status-clear listener when pane teardown evicts a cached status', () => {
+  it('notifies pane-status-clear listener once for terminal and transient cleanup', () => {
     const server = new AgentHookServer()
     const listener = vi.fn()
     server.setPaneStatusClearListener(listener)
@@ -1424,8 +1424,21 @@ describe('AgentHookServer listener replay', () => {
     server.clearPaneState(PANE)
     server.clearPaneState(PANE)
 
-    expect(listener).toHaveBeenCalledTimes(1)
-    expect(listener).toHaveBeenCalledWith(PANE)
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        payload: { state: 'working', agentType: 'claude' }
+      },
+      'conn-1'
+    )
+    server.clearTransientStatusEntry(PANE)
+    server.clearTransientStatusEntry(PANE)
+
+    expect(listener).toHaveBeenCalledTimes(2)
+    expect(listener).toHaveBeenNthCalledWith(1, PANE)
+    expect(listener).toHaveBeenNthCalledWith(2, PANE, { transient: true })
   })
 
   it('drops cached statuses and pane-scoped listener caches under one tab prefix', () => {

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -93,7 +93,7 @@ export type AgentHookStatusChangeEntry = {
 }
 
 type StatusChangeListener = (statuses: AgentHookStatusChangeEntry[]) => void
-type PaneStatusClearListener = (paneKey: string) => void
+type PaneStatusClearListener = (paneKey: string, options?: { transient?: boolean }) => void
 type PaneKeyAliasPersistenceListener = (entries: LegacyPaneKeyAliasEntry[]) => void
 type PaneKeyAliasEntry = {
   stablePaneKey: string
@@ -1703,6 +1703,22 @@ export class AgentHookServer {
     }
     this.scheduleStatusPersist()
     this.notifyStatusChangeListeners()
+  }
+
+  /**
+   * Clears one visible status after transport loss without retiring pane caches.
+   *
+   * @param paneKey Stable pane identity whose transient status should be removed.
+   */
+  clearTransientStatusEntry(paneKey: string): void {
+    const resolvedPaneKey = this.resolvePaneKeyAlias(paneKey)
+    if (!this.state.lastStatusByPaneKey.has(resolvedPaneKey)) {
+      return
+    }
+    // Why: the remote PTY may reattach and emit a partial replay event, so
+    // preserve prompt/tool context while still driving the renderer clear IPC.
+    this.dropStatusEntry(resolvedPaneKey)
+    this.onPaneStatusCleared?.(resolvedPaneKey, { transient: true })
   }
 
   dropStatusEntriesByTabPrefix(tabId: string): void {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -871,6 +871,11 @@ function syncMacMenuBarIcon(showMenuBarIcon: boolean): Tray | null {
   return options ? setMacMenuBarIconVisible(showMenuBarIcon, options) : null
 }
 
+/**
+ * Creates the primary application window and wires its main-process event bridges.
+ *
+ * @returns The created or restored main window.
+ */
 function openMainWindow(): BrowserWindow {
   logStartupMilestone('open-main-window-start')
   if (!store) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1197,11 +1197,14 @@ function openMainWindow(): BrowserWindow {
       }
     }
   )
-  agentHookServer.setPaneStatusClearListener((paneKey) => {
+  agentHookServer.setPaneStatusClearListener((paneKey, options) => {
     if (mainWindow?.isDestroyed()) {
       return
     }
-    mainWindow?.webContents.send('agentStatus:clear', { paneKey })
+    mainWindow?.webContents.send('agentStatus:clear', {
+      paneKey,
+      ...(options?.transient ? { transient: true } : {})
+    })
   })
   setMigrationUnsupportedPtyListener((event) => {
     if (mainWindow?.isDestroyed()) {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -46,6 +46,8 @@ const {
   openCodeClearPtyMock,
   mimoCodeBuildPtyEnvMock,
   buildAgentHookEnvMock,
+  getAgentHookStatusSnapshotMock,
+  clearTransientAgentHookPaneStatusMock,
   clearAgentHookPaneStateMock,
   registerPaneKeyAliasMock,
   piBuildPtyEnvMock,
@@ -78,6 +80,8 @@ const {
   isPwshAvailableMock: vi.fn(),
   openCodeClearPtyMock: vi.fn(),
   buildAgentHookEnvMock: vi.fn(),
+  getAgentHookStatusSnapshotMock: vi.fn(),
+  clearTransientAgentHookPaneStatusMock: vi.fn(),
   clearAgentHookPaneStateMock: vi.fn(),
   registerPaneKeyAliasMock: vi.fn(),
   piBuildPtyEnvMock: vi.fn(),
@@ -145,6 +149,8 @@ vi.mock('../mimo/hook-service', () => ({
 vi.mock('../agent-hooks/server', () => ({
   agentHookServer: {
     buildPtyEnv: buildAgentHookEnvMock,
+    getStatusSnapshot: getAgentHookStatusSnapshotMock,
+    clearTransientStatusEntry: clearTransientAgentHookPaneStatusMock,
     clearPaneState: clearAgentHookPaneStateMock,
     registerPaneKeyAlias: registerPaneKeyAliasMock,
     clearPaneKeyAliasesForPty: clearPaneKeyAliasesForPtyMock
@@ -193,11 +199,13 @@ import { SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV } from '../../shared/setup-age
 import {
   registerPtyHandlers,
   registerSshPtyProvider,
+  clearAgentHookStatusesForConnection,
   clearProviderPtyState,
   deletePtyOwnership,
   getPtyRendererDeliveryDebugSnapshot,
   resetPtyRendererDeliveryDebug,
   getPtyIdForPaneKey,
+  getPtyIdsForConnection,
   hasPendingRendererSerializerForPaneKey,
   setPtyOwnership,
   setLocalPtyProvider,
@@ -331,6 +339,9 @@ describe('registerPtyHandlers', () => {
     mimoCodeBuildPtyEnvMock.mockReset()
     openCodeClearPtyMock.mockReset()
     buildAgentHookEnvMock.mockReset()
+    getAgentHookStatusSnapshotMock.mockReset()
+    getAgentHookStatusSnapshotMock.mockReturnValue([])
+    clearTransientAgentHookPaneStatusMock.mockReset()
     clearAgentHookPaneStateMock.mockReset()
     registerPaneKeyAliasMock.mockReset()
     piBuildPtyEnvMock.mockReset()
@@ -10918,6 +10929,64 @@ describe('registerPtyHandlers', () => {
     clearProviderPtyState(second.id)
     expect(getPtyIdForPaneKey(stablePaneKey)).toBeUndefined()
     expect(clearAgentHookPaneStateMock).toHaveBeenCalledWith(stablePaneKey)
+  })
+
+  it('clears SSH agent statuses by host while preserving reattach identity', async () => {
+    registerPtyHandlers(mainWindow as never)
+    const firstLeafId = '11111111-1111-4111-8111-111111111111'
+    const secondLeafId = '22222222-2222-4222-8222-222222222222'
+    const firstPaneKey = makePaneKey('tab-1', firstLeafId)
+    const secondPaneKey = makePaneKey('tab-2', secondLeafId)
+    const first = (await handlers.get('pty:spawn')!(null, {
+      cols: 80,
+      rows: 24,
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: firstLeafId,
+      sessionId: 'ssh-test-pty-1',
+      env: { ORCA_PANE_KEY: firstPaneKey }
+    })) as { id: string }
+    const second = (await handlers.get('pty:spawn')!(null, {
+      cols: 80,
+      rows: 24,
+      worktreeId: 'wt-2',
+      tabId: 'tab-2',
+      leafId: secondLeafId,
+      sessionId: 'ssh-test-pty-2',
+      env: { ORCA_PANE_KEY: secondPaneKey }
+    })) as { id: string }
+    expect(first.id).not.toBe(second.id)
+    setPtyOwnership(first.id, 'ssh-1')
+    setPtyOwnership(second.id, 'ssh-2')
+    const firstHostPtyIds = getPtyIdsForConnection('ssh-1')
+    const secondHostPtyIds = getPtyIdsForConnection('ssh-2')
+    const restartEraPaneKey = makePaneKey('tab-restart', '33333333-3333-4333-8333-333333333333')
+    getAgentHookStatusSnapshotMock.mockReturnValue([
+      { paneKey: restartEraPaneKey, connectionId: 'ssh-1' },
+      { paneKey: secondPaneKey, connectionId: 'ssh-2' }
+    ])
+    clearTransientAgentHookPaneStatusMock.mockClear()
+
+    try {
+      clearAgentHookStatusesForConnection('ssh-1')
+      clearAgentHookStatusesForConnection('ssh-1')
+
+      expect(clearTransientAgentHookPaneStatusMock).toHaveBeenCalledTimes(4)
+      expect(clearTransientAgentHookPaneStatusMock).toHaveBeenCalledWith(firstPaneKey)
+      expect(clearTransientAgentHookPaneStatusMock).toHaveBeenCalledWith(restartEraPaneKey)
+      expect(clearTransientAgentHookPaneStatusMock).not.toHaveBeenCalledWith(secondPaneKey)
+      expect(getPtyIdsForConnection('ssh-1')).toEqual(firstHostPtyIds)
+      expect(getPtyIdsForConnection('ssh-2')).toEqual(secondHostPtyIds)
+      expect(firstHostPtyIds).toContain(first.id)
+      expect(secondHostPtyIds).toContain(second.id)
+      expect(getPtyIdForPaneKey(firstPaneKey)).toBe(first.id)
+      expect(getPtyIdForPaneKey(secondPaneKey)).toBe(second.id)
+    } finally {
+      clearProviderPtyState(first.id)
+      clearProviderPtyState(second.id)
+      deletePtyOwnership(first.id)
+      deletePtyOwnership(second.id)
+    }
   })
 
   it('does not let restart-era alias cleanup clear a newer pane-key owner', async () => {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -1169,6 +1169,38 @@ export function clearPtyOwnershipForConnection(connectionId: string): void {
   }
 }
 
+/**
+ * Clears transient agent statuses for one remote connection while retaining
+ * PTY ownership and pane mappings for a later reattach.
+ *
+ * @param connectionId SSH target identity whose visible statuses should be cleared.
+ */
+export function clearAgentHookStatusesForConnection(connectionId: string): void {
+  const paneKeys = new Set<string>()
+  for (const [ptyId, connId] of ptyOwnership) {
+    if (connId !== connectionId) {
+      continue
+    }
+    const paneKey = ptyPaneKey.get(ptyId)
+    if (paneKey && paneKeyPtyId.get(paneKey) === ptyId) {
+      paneKeys.add(paneKey)
+    }
+  }
+  // Why: restart-era reattach can rebuild PTY ownership before the in-memory
+  // pane map. Main stamps remote statuses with the target id, so include those
+  // entries without borrowing identity from another SSH host.
+  for (const entry of agentHookServer.getStatusSnapshot()) {
+    if (entry.connectionId === connectionId) {
+      paneKeys.add(entry.paneKey)
+    }
+  }
+  for (const paneKey of paneKeys) {
+    // Why: a relay disconnect does not kill the remote PTY. Drop only its
+    // live status so ownership, pane identity, and hook aliases can reattach.
+    agentHookServer.clearTransientStatusEntry(paneKey)
+  }
+}
+
 // ─── Provider-scoped PTY state cleanup ──────────────────────────────
 
 export function clearProviderPtyState(id: string): void {

--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -157,6 +157,7 @@ vi.mock('../providers/ssh-filesystem-provider', () => ({
 vi.mock('./pty', () => ({
   registerSshPtyProvider: vi.fn(),
   unregisterSshPtyProvider: vi.fn(),
+  clearAgentHookStatusesForConnection: vi.fn(),
   clearPtyOwnershipForConnection: vi.fn(),
   clearProviderPtyState: vi.fn(),
   deletePtyOwnership: vi.fn(),

--- a/src/main/ssh/ssh-relay-session-terminal-error.test.ts
+++ b/src/main/ssh/ssh-relay-session-terminal-error.test.ts
@@ -55,6 +55,7 @@ vi.mock('../ipc/pty', () => ({
     attach: vi.fn().mockResolvedValue(undefined)
   }),
   getPtyIdsForConnection: vi.fn().mockReturnValue([]),
+  clearAgentHookStatusesForConnection: vi.fn(),
   clearPtyOwnershipForConnection: vi.fn(),
   clearProviderPtyState: vi.fn(),
   deletePtyOwnership: vi.fn(),

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -70,6 +70,7 @@ vi.mock('../ipc/pty', () => ({
     attachForReconnect: vi.fn().mockResolvedValue({})
   }),
   getPtyIdsForConnection: vi.fn().mockReturnValue([]),
+  clearAgentHookStatusesForConnection: vi.fn(),
   clearPtyOwnershipForConnection: vi.fn(),
   clearProviderPtyState: vi.fn(),
   deletePtyOwnership: vi.fn(),
@@ -475,18 +476,18 @@ describe('SshRelaySession', () => {
     vi.clearAllMocks()
     mockDeploySuccess()
 
-    const { getSshPtyProvider } = await import('../ipc/pty')
+    const ptyIpc = await import('../ipc/pty')
     const mockAttach = vi.fn().mockResolvedValue(undefined)
-    vi.mocked(getSshPtyProvider).mockReturnValue({
+    vi.mocked(ptyIpc.getSshPtyProvider).mockReturnValue({
       attachForReconnect: mockAttach,
       dispose: vi.fn()
-    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    } as unknown as ReturnType<typeof ptyIpc.getSshPtyProvider>)
     vi.mocked(getPtyIdsForConnection).mockReturnValue(['pty-1', 'pty-2'])
 
     await session.reconnect(mockConn)
 
-    expect(mockAttach).toHaveBeenCalledWith('pty-1')
-    expect(mockAttach).toHaveBeenCalledWith('pty-2')
+    expect(ptyIpc.clearAgentHookStatusesForConnection).toHaveBeenCalledWith('target-1')
+    expect(mockAttach.mock.calls).toEqual([['pty-1'], ['pty-2']])
   })
 
   it('forwards reconnect replay after the attach attempt is still current', async () => {

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -39,6 +39,7 @@ import {
   getSshPtyProvider,
   getPtyIdsForConnection,
   clearPtyOwnershipForConnection,
+  clearAgentHookStatusesForConnection,
   clearProviderPtyState,
   deletePtyOwnership,
   setPtyOwnership,
@@ -1011,6 +1012,10 @@ export class SshRelaySession {
 
     if (reason === 'shutdown') {
       clearPtyOwnershipForConnection(this.targetId)
+    } else {
+      // Why: detach hook notifications before clearing status so an in-flight
+      // relay event cannot recreate a ghost row during connection teardown.
+      clearAgentHookStatusesForConnection(this.targetId)
     }
 
     const ptyProvider = getSshPtyProvider(this.targetId)

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -1000,6 +1000,11 @@ export class SshRelaySession {
     })
   }
 
+  /**
+   * Disposes relay-backed providers using lifecycle-specific identity cleanup.
+   *
+   * @param reason Whether the remote identity is retiring or may reconnect.
+   */
   private teardownProviders(reason: 'shutdown' | 'connection_lost'): void {
     this.muxDisposeCleanup?.()
     this.muxDisposeCleanup = null

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -3207,8 +3207,8 @@ export type PreloadApi = {
   agentStatus: {
     /** Listen for agent status updates forwarded from native hook receivers. */
     onSet: (callback: (data: AgentStatusIpcPayload) => void) => () => void
-    /** Listen for main-process pane teardown that evicted a cached hook status. */
-    onClear: (callback: (data: { paneKey: string }) => void) => () => void
+    /** Listen for main-process cleanup that evicted a cached hook status. */
+    onClear: (callback: (data: { paneKey: string; transient?: boolean }) => void) => () => void
     /** Return the current main-process hook cache after renderer hydration. */
     getSnapshot: () => Promise<AgentStatusIpcPayload[]>
     inferInterrupt: (request: AgentInterruptInferenceRequest) => Promise<boolean>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4395,9 +4395,17 @@ const api = {
       ipcRenderer.on('agentStatus:set', listener)
       return () => ipcRenderer.removeListener('agentStatus:set', listener)
     },
-    onClear: (callback: (data: { paneKey: string }) => void): (() => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, data: { paneKey: string }) =>
-        callback(data)
+    /**
+     * Subscribes to main-process status removal events.
+     *
+     * @param callback Receives the pane identity and whether cleanup preserves reattach state.
+     * @returns A function that removes the IPC listener.
+     */
+    onClear: (callback: (data: { paneKey: string; transient?: boolean }) => void): (() => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        data: { paneKey: string; transient?: boolean }
+      ) => callback(data)
       ipcRenderer.on('agentStatus:clear', listener)
       return () => ipcRenderer.removeListener('agentStatus:clear', listener)
     },

--- a/src/renderer/src/hooks/ssh-disconnect-worktree-selection.test.ts
+++ b/src/renderer/src/hooks/ssh-disconnect-worktree-selection.test.ts
@@ -9,7 +9,7 @@ describe('getSshDisconnectWorktreeIds', () => {
           repos: [
             { id: 'same-repo', connectionId: 'ssh-a', executionHostId: 'ssh:ssh-a' },
             { id: 'same-repo', connectionId: 'ssh-b', executionHostId: 'ssh:ssh-b' },
-            { id: 'same-repo', connectionId: null, executionHostId: 'local' }
+            { id: 'same-repo', connectionId: 'ssh-a', executionHostId: 'local' }
           ],
           worktreesByRepo: {
             'same-repo': [
@@ -25,6 +25,20 @@ describe('getSshDisconnectWorktreeIds', () => {
     ).toEqual(new Set(['ssh-a-worktree']))
   })
 
+  it('matches an SSH execution host even when connectionId is absent', () => {
+    expect(
+      getSshDisconnectWorktreeIds(
+        {
+          repos: [{ id: 'remote-repo', connectionId: null, executionHostId: 'ssh:ssh-a' }],
+          worktreesByRepo: {
+            'remote-repo': [{ id: 'remote-worktree', hostId: 'ssh:ssh-a' }]
+          }
+        },
+        'ssh-a'
+      )
+    ).toEqual(new Set(['remote-worktree']))
+  })
+
   it('attributes a legacy unhosted worktree to an unambiguous SSH repo owner', () => {
     expect(
       getSshDisconnectWorktreeIds(
@@ -37,5 +51,25 @@ describe('getSshDisconnectWorktreeIds', () => {
         'ssh-a'
       )
     ).toEqual(new Set(['legacy-worktree']))
+  })
+
+  it('uses the canonical encoded execution host id for matching', () => {
+    expect(
+      getSshDisconnectWorktreeIds(
+        {
+          repos: [
+            {
+              id: 'encoded-repo',
+              connectionId: null,
+              executionHostId: 'ssh:target%20one%2Fprimary'
+            }
+          ],
+          worktreesByRepo: {
+            'encoded-repo': [{ id: 'encoded-worktree', hostId: 'ssh:target%20one%2Fprimary' }]
+          }
+        },
+        'target one/primary'
+      )
+    ).toEqual(new Set(['encoded-worktree']))
   })
 })

--- a/src/renderer/src/hooks/ssh-disconnect-worktree-selection.test.ts
+++ b/src/renderer/src/hooks/ssh-disconnect-worktree-selection.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { getSshDisconnectWorktreeIds } from './ssh-disconnect-worktree-selection'
+
+describe('getSshDisconnectWorktreeIds', () => {
+  it('keeps same-repository worktrees owned by local and sibling SSH hosts', () => {
+    expect(
+      getSshDisconnectWorktreeIds(
+        {
+          repos: [
+            { id: 'same-repo', connectionId: 'ssh-a', executionHostId: 'ssh:ssh-a' },
+            { id: 'same-repo', connectionId: 'ssh-b', executionHostId: 'ssh:ssh-b' },
+            { id: 'same-repo', connectionId: null, executionHostId: 'local' }
+          ],
+          worktreesByRepo: {
+            'same-repo': [
+              { id: 'ssh-a-worktree', hostId: 'ssh:ssh-a' },
+              { id: 'ssh-b-worktree', hostId: 'ssh:ssh-b' },
+              { id: 'local-worktree', hostId: 'local' },
+              { id: 'ambiguous-legacy-worktree' }
+            ]
+          }
+        },
+        'ssh-a'
+      )
+    ).toEqual(new Set(['ssh-a-worktree']))
+  })
+
+  it('attributes a legacy unhosted worktree to an unambiguous SSH repo owner', () => {
+    expect(
+      getSshDisconnectWorktreeIds(
+        {
+          repos: [{ id: 'remote-repo', connectionId: 'ssh-a' }],
+          worktreesByRepo: {
+            'remote-repo': [{ id: 'legacy-worktree' }]
+          }
+        },
+        'ssh-a'
+      )
+    ).toEqual(new Set(['legacy-worktree']))
+  })
+})

--- a/src/renderer/src/hooks/ssh-disconnect-worktree-selection.ts
+++ b/src/renderer/src/hooks/ssh-disconnect-worktree-selection.ts
@@ -1,4 +1,4 @@
-import { getRepoExecutionHostId } from '../../../shared/execution-host'
+import { getRepoExecutionHostId, toSshExecutionHostId } from '../../../shared/execution-host'
 import type { Repo, Worktree } from '../../../shared/types'
 
 type SshDisconnectWorktreeState = {
@@ -17,6 +17,7 @@ export function getSshDisconnectWorktreeIds(
   state: SshDisconnectWorktreeState,
   targetId: string
 ): Set<string> {
+  const targetHostId = toSshExecutionHostId(targetId)
   const allHostIdsByRepo = new Map<string, Set<string>>()
   const targetHostIdsByRepo = new Map<string, Set<string>>()
   for (const repo of state.repos) {
@@ -24,7 +25,7 @@ export function getSshDisconnectWorktreeIds(
     const allHostIds = allHostIdsByRepo.get(repo.id) ?? new Set<string>()
     allHostIds.add(hostId)
     allHostIdsByRepo.set(repo.id, allHostIds)
-    if (repo.connectionId === targetId) {
+    if (hostId === targetHostId) {
       const targetHostIds = targetHostIdsByRepo.get(repo.id) ?? new Set<string>()
       targetHostIds.add(hostId)
       targetHostIdsByRepo.set(repo.id, targetHostIds)

--- a/src/renderer/src/hooks/ssh-disconnect-worktree-selection.ts
+++ b/src/renderer/src/hooks/ssh-disconnect-worktree-selection.ts
@@ -1,0 +1,55 @@
+import { getRepoExecutionHostId } from '../../../shared/execution-host'
+import type { Repo, Worktree } from '../../../shared/types'
+
+type SshDisconnectWorktreeState = {
+  repos: readonly Pick<Repo, 'id' | 'connectionId' | 'executionHostId'>[]
+  worktreesByRepo: Record<string, readonly Pick<Worktree, 'id' | 'hostId'>[]>
+}
+
+/**
+ * Collects worktrees owned by one disconnected SSH target without crossing host boundaries.
+ *
+ * @param state Repository and worktree ownership currently known by the renderer.
+ * @param targetId SSH target whose live workspace state should be cleared.
+ * @returns Worktree IDs attributable to the disconnected target.
+ */
+export function getSshDisconnectWorktreeIds(
+  state: SshDisconnectWorktreeState,
+  targetId: string
+): Set<string> {
+  const allHostIdsByRepo = new Map<string, Set<string>>()
+  const targetHostIdsByRepo = new Map<string, Set<string>>()
+  for (const repo of state.repos) {
+    const hostId = getRepoExecutionHostId(repo)
+    const allHostIds = allHostIdsByRepo.get(repo.id) ?? new Set<string>()
+    allHostIds.add(hostId)
+    allHostIdsByRepo.set(repo.id, allHostIds)
+    if (repo.connectionId === targetId) {
+      const targetHostIds = targetHostIdsByRepo.get(repo.id) ?? new Set<string>()
+      targetHostIds.add(hostId)
+      targetHostIdsByRepo.set(repo.id, targetHostIds)
+    }
+  }
+
+  const worktreeIds = new Set<string>()
+  for (const [repoId, worktrees] of Object.entries(state.worktreesByRepo)) {
+    const targetHostIds = targetHostIdsByRepo.get(repoId)
+    if (!targetHostIds) {
+      continue
+    }
+    const allHostIds = allHostIdsByRepo.get(repoId)
+    const soleHostId = allHostIds?.size === 1 ? allHostIds.values().next().value : undefined
+    const legacyRowsBelongToTarget = soleHostId ? targetHostIds.has(soleHostId) : false
+    for (const worktree of worktrees) {
+      // Why: old persisted worktrees may not have hostId. Attribute those only
+      // when the repo has one owner; duplicate repo ids must never be guessed.
+      if (
+        (worktree.hostId && targetHostIds.has(worktree.hostId)) ||
+        (!worktree.hostId && legacyRowsBelongToTarget)
+      ) {
+        worktreeIds.add(worktree.id)
+      }
+    }
+  }
+  return worktreeIds
+}

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -1426,6 +1426,7 @@ describe('useIpcEvents updater integration', () => {
 
   it('clears stale remote PTYs when an SSH connection fully disconnects', async () => {
     const clearTabPtyId = vi.fn()
+    const removeAgentStatusByWorktree = vi.fn()
     const setSshConnectionState = vi.fn()
     const setSshTargetsMetadata = vi.fn()
     const clearRemovedSshTargetState = vi.fn()
@@ -1478,6 +1479,7 @@ describe('useIpcEvents updater integration', () => {
       clearRemoteDetectedAgents: vi.fn(),
       clearRemovedSshTargetState,
       clearTabPtyId,
+      removeAgentStatusByWorktree,
       repos: [{ id: 'repo-1', connectionId: 'conn-1' }],
       worktreesByRepo: {
         'repo-1': [{ id: 'wt-1', repoId: 'repo-1' }]
@@ -1664,6 +1666,8 @@ describe('useIpcEvents updater integration', () => {
     )
     expect(clearTabPtyId).toHaveBeenCalledWith('tab-1')
     expect(clearTabPtyId).not.toHaveBeenCalledWith('tab-2')
+    expect(removeAgentStatusByWorktree).toHaveBeenCalledOnce()
+    expect(removeAgentStatusByWorktree).toHaveBeenCalledWith('wt-1')
     expect(storeState.clearRemoteDetectedAgents).toHaveBeenCalledWith('conn-1')
 
     setSshConnectionState.mockClear()
@@ -4638,7 +4642,7 @@ describe('useIpcEvents agent status snapshot integration', () => {
 
   function buildWindowApi(args: {
     onSet: (cb: (data: AgentStatusSetData) => void) => () => void
-    onClear?: (cb: (data: { paneKey: string }) => void) => () => void
+    onClear?: (cb: (data: { paneKey: string; transient?: boolean }) => void) => () => void
     getSnapshot?: () => Promise<AgentStatusSetData[]>
     drop?: (paneKey: string) => void
     remoteWorkspace?: Record<string, unknown>
@@ -5803,6 +5807,90 @@ describe('useIpcEvents agent status snapshot integration', () => {
 
     expect(removeAgentStatus).toHaveBeenCalledTimes(1)
     expect(removeAgentStatus).toHaveBeenCalledWith(FUTURE_PANE_KEY)
+  })
+
+  it('transient clear preserves pane identity and drops a pending status', async () => {
+    const setAgentStatus = vi.fn()
+    const removeAgentStatus = vi.fn()
+    const removeTransientAgentStatus = vi.fn()
+    const subscribeListenerRef: { current: StoreSubscribeListener | null } = { current: null }
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
+      current: null
+    }
+    const onClearListenerRef: {
+      current: ((data: { paneKey: string; transient?: boolean }) => void) | null
+    } = { current: null }
+    const storeState: StoreLike = buildStoreState({
+      setAgentStatus,
+      removeAgentStatus,
+      removeTransientAgentStatus,
+      workspaceSessionReady: true,
+      settings: { terminalFontSize: 13, notifications: { enabled: false } },
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {}
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn((listener: StoreSubscribeListener) => {
+          subscribeListenerRef.current = listener
+          return () => {
+            subscribeListenerRef.current = null
+          }
+        }),
+        getState: () => storeState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: (cb) => {
+          onSetListenerRef.current = cb
+          return () => {}
+        },
+        onClear: (cb) => {
+          onClearListenerRef.current = cb
+          return () => {}
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    await Promise.resolve()
+
+    if (
+      typeof onSetListenerRef.current !== 'function' ||
+      typeof onClearListenerRef.current !== 'function' ||
+      typeof subscribeListenerRef.current !== 'function'
+    ) {
+      throw new Error('Expected agent status listeners to be registered')
+    }
+
+    onSetListenerRef.current({
+      paneKey: FUTURE_PANE_KEY,
+      state: 'working',
+      prompt: 'status before tab hydration',
+      agentType: 'codex',
+      receivedAt: 1_700_000_000_200,
+      stateStartedAt: 1_700_000_000_000
+    })
+    expect(setAgentStatus).not.toHaveBeenCalled()
+
+    onClearListenerRef.current({ paneKey: FUTURE_PANE_KEY, transient: true })
+    storeState.tabsByWorktree = {
+      'wt-1': [{ id: 'tab-future', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Future Tab' }]
+    }
+    storeState.terminalLayoutsByTabId = {
+      'tab-future': { root: { type: 'leaf', leafId: FUTURE_LEAF_ID } }
+    }
+    subscribeListenerRef.current(storeState, storeState)
+
+    expect(removeTransientAgentStatus).toHaveBeenCalledWith(FUTURE_PANE_KEY)
+    expect(removeAgentStatus).not.toHaveBeenCalled()
+    expect(setAgentStatus).not.toHaveBeenCalled()
   })
 
   it('keeps a completed worktree-attributed row when main reports pane teardown', async () => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2,6 +2,7 @@
 import { useEffect } from 'react'
 import { toast } from 'sonner'
 import { useAppStore } from '../store'
+import { getSshDisconnectWorktreeIds } from './ssh-disconnect-worktree-selection'
 import { shouldRetryPaneSpawnOnSshReconnect } from './ssh-reconnect-pane-retry'
 import { applyWorktreeHeadIdentities } from './worktree-head-identity-apply'
 import { getWorktreeMapFromState, getRepoMapFromState } from '@/store/selectors'
@@ -2798,12 +2799,7 @@ export function useIpcEvents(): void {
         // PTY provider without emitting per-PTY exit events. Clear the stale
         // PTY ids in renderer state so a later reconnect remounts TerminalPane
         // instead of keeping a dead remote PTY attached to the tab.
-        const remoteWorktreeIds = new Set(
-          Object.values(store.worktreesByRepo)
-            .flat()
-            .filter((w) => remoteRepos.some((r) => r.id === w.repoId))
-            .map((w) => w.id)
-        )
+        const remoteWorktreeIds = getSshDisconnectWorktreeIds(store, targetId)
         for (const worktreeId of remoteWorktreeIds) {
           // Why: connection loss is reversible, so purge only live status;
           // replay on reconnect can repopulate the same pane identities.

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2804,6 +2804,9 @@ export function useIpcEvents(): void {
             .map((w) => w.id)
         )
         for (const worktreeId of remoteWorktreeIds) {
+          // Why: connection loss is reversible, so purge only live status;
+          // replay on reconnect can repopulate the same pane identities.
+          useAppStore.getState().removeAgentStatusByWorktree(worktreeId)
           const tabs = useAppStore.getState().tabsByWorktree[worktreeId] ?? []
           for (const tab of tabs) {
             if (tab.ptyId) {
@@ -3336,11 +3339,30 @@ export function useIpcEvents(): void {
       if (typeof data?.paneKey !== 'string') {
         return
       }
+      const clearedPaneKey = resolveAgentPaneAuthorityKey(data.paneKey)
+      // Why: a clear can arrive before tab hydration. Evict the queued push too,
+      // or the next store update can resurrect status that main already dropped.
+      for (let index = pendingAgentStatusEvents.length - 1; index >= 0; index -= 1) {
+        const pendingPaneKey = resolveAgentPaneAuthorityKey(
+          pendingAgentStatusEvents[index].data.paneKey
+        )
+        if (pendingPaneKey === clearedPaneKey) {
+          pendingAgentStatusEvents.splice(index, 1)
+        }
+      }
+      if (pendingAgentStatusEvents.length === 0 && pendingAgentStatusRetryTimer !== null) {
+        globalThis.clearTimeout(pendingAgentStatusRetryTimer)
+        pendingAgentStatusRetryTimer = null
+      }
       const store = useAppStore.getState()
-      if (store.agentStatusByPaneKey[data.paneKey]?.state === 'done') {
+      if (data.transient === true) {
+        store.removeTransientAgentStatus(clearedPaneKey)
         return
       }
-      store.removeAgentStatus(data.paneKey)
+      if (store.agentStatusByPaneKey[clearedPaneKey]?.state === 'done') {
+        return
+      }
+      store.removeAgentStatus(clearedPaneKey)
     })
     if (unsubscribeAgentStatusClear) {
       unsubs.push(unsubscribeAgentStatusClear)

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -838,6 +838,7 @@ function getWorktreeRuntimeEnvironmentId(worktreeId: string | null | undefined):
   return getRuntimeEnvironmentIdForWorktree(useAppStore.getState(), worktreeId)
 }
 
+/** Registers renderer subscriptions for main-process lifecycle and state events. */
 export function useIpcEvents(): void {
   useEffect(() => {
     const unsubs: (() => void)[] = []

--- a/src/renderer/src/store/slices/agent-status-ssh-disconnect.test.ts
+++ b/src/renderer/src/store/slices/agent-status-ssh-disconnect.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { AppState } from '../types'
+import { createTestStore, makeTab } from './store-test-helpers'
+
+describe('agent status cleanup on SSH disconnect', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('removes only live entries for the affected worktree and is idempotent', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const targetPane = 'tab-remote:11111111-1111-4111-8111-111111111111'
+    const attributedPane = 'tab-worker:22222222-2222-4222-8222-222222222222'
+    const otherPane = 'tab-other:33333333-3333-4333-8333-333333333333'
+    store.setState({
+      tabsByWorktree: {
+        'wt-remote': [makeTab({ id: 'tab-remote', worktreeId: 'wt-remote' })],
+        'wt-other': [makeTab({ id: 'tab-other', worktreeId: 'wt-other' })]
+      },
+      acknowledgedAgentsByPaneKey: { [targetPane]: 123 },
+      retentionSuppressedPaneKeys: { [targetPane]: true }
+    } as Partial<AppState>)
+    store
+      .getState()
+      .setAgentStatus(targetPane, { state: 'working', prompt: 'remote', agentType: 'codex' })
+    store
+      .getState()
+      .setAgentStatus(
+        attributedPane,
+        { state: 'waiting', prompt: 'worker', agentType: 'claude' },
+        undefined,
+        undefined,
+        { worktreeId: 'wt-remote', tabId: 'tab-worker' }
+      )
+    store
+      .getState()
+      .setAgentStatus(otherPane, { state: 'working', prompt: 'other', agentType: 'codex' })
+    store.setState({
+      agentLaunchConfigByPaneKey: {
+        [targetPane]: {
+          launchConfig: { agentCommand: 'codex', agentArgs: '', agentEnv: {} },
+          registeredAt: 123,
+          identity: {}
+        }
+      },
+      acknowledgedAgentsByPaneKey: { [targetPane]: 123 },
+      retentionSuppressedPaneKeys: { [targetPane]: true }
+    } as Partial<AppState>)
+
+    store.getState().removeAgentStatusByWorktree('wt-remote')
+    const epochAfterFirstRemoval = store.getState().agentStatusEpoch
+
+    expect(store.getState().agentStatusByPaneKey[targetPane]).toBeUndefined()
+    expect(store.getState().agentStatusByPaneKey[attributedPane]).toBeUndefined()
+    expect(store.getState().agentStatusByPaneKey[otherPane]).toBeDefined()
+    expect(store.getState().agentLaunchConfigByPaneKey[targetPane]).toMatchObject({
+      launchConfig: { agentCommand: 'codex' },
+      registeredAt: 123
+    })
+    expect(store.getState().acknowledgedAgentsByPaneKey[targetPane]).toBe(123)
+    expect(store.getState().retentionSuppressedPaneKeys).toEqual({ [targetPane]: true })
+
+    store.getState().removeAgentStatusByWorktree('wt-remote')
+    expect(store.getState().agentStatusEpoch).toBe(epochAfterFirstRemoval)
+    expect(store.getState().agentStatusByPaneKey[otherPane]).toBeDefined()
+  })
+
+  it('removes one transient status without retiring its pane metadata', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const paneKey = 'tab-remote:11111111-1111-4111-8111-111111111111'
+    store
+      .getState()
+      .setAgentStatus(paneKey, { state: 'working', prompt: 'remote', agentType: 'codex' })
+    store.setState({
+      agentLaunchConfigByPaneKey: {
+        [paneKey]: {
+          launchConfig: { agentCommand: 'codex', agentArgs: '--full-auto', agentEnv: {} },
+          registeredAt: 123,
+          identity: {}
+        }
+      },
+      acknowledgedAgentsByPaneKey: { [paneKey]: 456 },
+      retentionSuppressedPaneKeys: { [paneKey]: true }
+    } as Partial<AppState>)
+
+    store.getState().removeTransientAgentStatus(paneKey)
+    const epochAfterRemoval = store.getState().agentStatusEpoch
+
+    expect(store.getState().agentStatusByPaneKey[paneKey]).toBeUndefined()
+    expect(store.getState().agentLaunchConfigByPaneKey[paneKey]).toMatchObject({
+      launchConfig: { agentCommand: 'codex', agentArgs: '--full-auto' },
+      registeredAt: 123
+    })
+    expect(store.getState().acknowledgedAgentsByPaneKey[paneKey]).toBe(456)
+    expect(store.getState().retentionSuppressedPaneKeys[paneKey]).toBe(true)
+
+    store.getState().removeTransientAgentStatus(paneKey)
+    expect(store.getState().agentStatusEpoch).toBe(epochAfterRemoval)
+  })
+})

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -207,6 +207,13 @@ export type AgentStatusSlice = {
    *  Used when a tab is closed — same prefix-sweep as cacheTimerByKey cleanup. */
   removeAgentStatusByTabPrefix: (tabIdPrefix: string) => void
 
+  /** Remove live entries for a worktree without treating it as user teardown.
+   *  Used for transient connection loss so replay can restore the same panes. */
+  removeAgentStatusByWorktree: (worktreeId: string) => void
+
+  /** Remove one live entry without retiring its launch or resume identity. */
+  removeTransientAgentStatus: (paneKey: string) => void
+
   /** Remove a single entry AND suppress re-retention on its next disappearance.
    *  Used for USER-INITIATED teardown — the dashboard/hover X button, and
    *  pane close — where the user is telling us "I'm done with this row". */
@@ -2178,6 +2185,75 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         }
       })
       queueMicrotask(() => freshness.schedule())
+    },
+
+    /**
+     * Removes live status for one worktree while preserving reconnect metadata.
+     *
+     * @param worktreeId Worktree whose transient live rows should be removed.
+     */
+    removeAgentStatusByWorktree: (worktreeId) => {
+      let hadLive = false
+      set((s) => {
+        const tabPrefixes = (s.tabsByWorktree[worktreeId] ?? []).map((tab) => `${tab.id}:`)
+        const liveKeys = Object.entries(s.agentStatusByPaneKey)
+          .filter(
+            ([paneKey, entry]) =>
+              entry.worktreeId === worktreeId || paneKeyMatchesAnyTabPrefix(paneKey, tabPrefixes)
+          )
+          .map(([paneKey]) => paneKey)
+        const migrationUnsupported = pruneMigrationUnsupportedEntries(
+          s.migrationUnsupportedByPtyId,
+          (entry) =>
+            entry.worktreeId === worktreeId ||
+            (entry.paneKey ? paneKeyMatchesAnyTabPrefix(entry.paneKey, tabPrefixes) : false)
+        )
+        if (liveKeys.length === 0 && !migrationUnsupported.changed) {
+          return s
+        }
+        hadLive = liveKeys.length > 0
+        const nextLive = { ...s.agentStatusByPaneKey }
+        for (const paneKey of liveKeys) {
+          delete nextLive[paneKey]
+        }
+        return {
+          agentStatusByPaneKey: nextLive,
+          migrationUnsupportedByPtyId: migrationUnsupported.next,
+          agentStatusEpoch:
+            hadLive || migrationUnsupported.changed ? s.agentStatusEpoch + 1 : s.agentStatusEpoch,
+          sortEpoch: hadLive || migrationUnsupported.changed ? s.sortEpoch + 1 : s.sortEpoch
+        }
+      })
+      if (hadLive) {
+        queueMicrotask(() => freshness.schedule())
+      }
+    },
+
+    /**
+     * Removes one live status without applying user-initiated teardown semantics.
+     *
+     * @param paneKey Stable pane identity whose transient row should be removed.
+     */
+    removeTransientAgentStatus: (paneKey) => {
+      let hadLive = false
+      set((s) => {
+        if (!(paneKey in s.agentStatusByPaneKey)) {
+          return s
+        }
+        hadLive = true
+        const nextLive = { ...s.agentStatusByPaneKey }
+        delete nextLive[paneKey]
+        // Why: transport loss does not retire the remote pane. Preserve launch,
+        // resume, acknowledgement, and retention identity for relay replay.
+        return {
+          agentStatusByPaneKey: nextLive,
+          agentStatusEpoch: s.agentStatusEpoch + 1,
+          sortEpoch: s.sortEpoch + 1
+        }
+      })
+      if (hadLive) {
+        queueMicrotask(() => freshness.schedule())
+      }
     },
 
     dropAgentStatus: (paneKey) => {


### PR DESCRIPTION
## Summary

Fixes #9217.

SSH relay connection loss can leave remote agent rows pinned in the sidebar after the underlying session is gone. This change clears those transient rows at both lifecycle boundaries while preserving the identity needed to reattach surviving remote PTYs:

- Main clears hook status only for pane keys owned by the disconnected SSH target, after relay notifications are detached. PTY ownership, pane aliases, prompt/tool context, and remote leases remain intact.
- The clear IPC is marked transient so the renderer removes only live status instead of applying user-teardown semantics that would erase launch or resume metadata.
- The renderer independently sweeps live status for worktrees on the disconnected target and removes any queued pre-hydration event that could otherwise resurrect a cleared row.
- Relay replay remains authoritative after reconnect and can repopulate the same pane identities.

Host matching uses both current PTY ownership and the status entry's stamped connection ID, covering restart-era reattach where ownership may exist before the in-memory pane map is rebuilt.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — all changed files and every downstream lint gate pass; the repository-wide command stops at the existing switch-exhaustiveness error in `src/renderer/src/components/skills/skill-freshness-group.tsx`.
- [x] `pnpm typecheck`
- [ ] `pnpm test` — after refreshing the rebased dependency patches, the full suite ran with 31,611 passing and 52 skipped. One unrelated system-SSH integration test timed out under full parallel load; its file passed 3/3 in isolation in 7.9 seconds.
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions.

Executed locally:

- Focused agent-hook, PTY, SSH relay, IPC, renderer hydration, and store suites: 714/714 passed.
- Changed-file Oxlint, React Doctor, and Oxfmt checks passed.
- Max-lines ratchet, reliability gates, scrollbar checks, feature-asset budget, macOS entitlements, skill manifests, and localization checks passed.
- Mobile TypeScript, lint, formatting, and tests passed: 2,046 tests passed and two skipped.
- Android Expo prebuild passed. The Gradle release build could not start because this machine has no Java runtime or Android SDK configured.
- Production desktop, relay, CLI, web, and macOS native build passed.

## AI Review Report

The review traced every `connection_lost` teardown site, the relay notification-disposal order, PTY ownership and pane-key maps, restart-era reattach, main-to-renderer clear IPC, pre-hydration event queuing, retained-agent behavior, and reconnect replay.

It flagged and corrected three lifecycle risks:

1. Status cleanup originally ran through a helper that removed main state without driving the established renderer clear IPC. A dedicated transient clear now emits that notification while retaining prompt/tool caches.
2. Treating the notification as ordinary pane teardown would delete launch and acknowledgement metadata. The IPC now carries an explicit transient marker and uses a non-destructive renderer removal path.
3. A status queued before workspace hydration could survive the clear and later recreate the ghost row. Clear handling now evicts matching queued events, including pane-authority aliases.

The final review also checked idempotency, concurrent/repeated teardown, cross-host isolation, and late relay events. Cleanup runs after notification handlers and the multiplexer are detached, so an in-flight event cannot recreate status during teardown.

Cross-platform compatibility was reviewed for macOS, Linux, Windows, WSL, and SSH execution. The change adds no shortcuts, labels, path construction, shell commands, Git behavior, or platform-specific branches. Remote state is scoped by SSH target ID and the relay build still succeeds for Linux, macOS, Windows, and WSL targets.

## Security Audit

No new external input parser, command execution, file/path handling, authentication, secret storage, dependency, or network surface is introduced. The only IPC shape change is an optional main-to-renderer `transient` boolean on the existing agent-status clear event. The renderer continues to validate that the pane key is a string, resolves it through the existing pane-authority mapping, and limits the effect to in-memory status cleanup.

Connection and worktree filtering prevents one SSH target's disconnect from clearing another target's rows. No follow-up security work is required.

## Notes

- No documentation change is required; this restores existing disconnect behavior and adds no user-facing setting or workflow.
- No manual disconnect/reconnect run against a physical SSH host was available locally. Coverage uses the real lifecycle/store logic with mocked relay and PTY boundaries.
- Cleanup is bounded to disconnect handling and does not add polling or work to the status-event hot path.
- CodeRabbit still displays a non-blocking 0% docstring aggregate, but its current-head analysis confirmed that all eight changed production callables have attached JSDoc and that no further code remediation exists.


