### PR TITLE
fix(terminal): confirm the agent from ConPTY console presence to avoid false exits

### DIFF
--- a/src/main/daemon/pty-subprocess-foreground-degraded-scan.test.ts
+++ b/src/main/daemon/pty-subprocess-foreground-degraded-scan.test.ts
@@ -1,0 +1,152 @@
+// Guards the daemon foreground identity against Windows scan degradation: a
+// timed-out CIM scan (available:false) or an incomplete snapshot (available:true
+// with the agent row missing) must not retire a still-working agent and make
+// the coordinator read the shell as a false "agent done". Console presence is
+// the arbiter of a real exit.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const { spawnMock, isPwshAvailableMock, resolveAgentForegroundProcessMock, readConptyMock } =
+  vi.hoisted(() => ({
+    spawnMock: vi.fn(),
+    isPwshAvailableMock: vi.fn(),
+    resolveAgentForegroundProcessMock: vi.fn(),
+    readConptyMock: vi.fn()
+  }))
+
+vi.mock('node-pty', () => ({ spawn: spawnMock }))
+vi.mock('../pwsh', () => ({ isPwshAvailable: isPwshAvailableMock }))
+
+const PWSH7_ABS = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe'
+const WINDOWS_POWERSHELL_ABS = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+const CMD_ABS = 'C:\\Windows\\System32\\cmd.exe'
+vi.mock('../providers/windows-powershell-executable', () => ({
+  resolveWindowsPowerShellExecutablePath: (family: 'pwsh.exe' | 'powershell.exe') =>
+    family === 'pwsh.exe' ? PWSH7_ABS : WINDOWS_POWERSHELL_ABS,
+  resolveWindowsPowerShellSpawnChain: (family: 'pwsh.exe' | 'powershell.exe') =>
+    family === 'pwsh.exe'
+      ? [PWSH7_ABS, WINDOWS_POWERSHELL_ABS, CMD_ABS]
+      : [WINDOWS_POWERSHELL_ABS, CMD_ABS],
+  getWindowsCmdPath: () => CMD_ABS
+}))
+
+vi.mock('../providers/agent-foreground-process', () => ({
+  resolveAgentForegroundProcessWithAvailability: (...args: unknown[]) =>
+    resolveAgentForegroundProcessMock(...args)
+}))
+
+vi.mock('../providers/windows-conpty-process-membership', () => ({
+  readWindowsConptyProcessIds: (...args: unknown[]) => readConptyMock(...args)
+}))
+
+import { createPtySubprocess } from './pty-subprocess'
+
+const BASE_TIME_MS = 1_000_000
+
+function mockPtyProcess(processName: string, pid = 12345) {
+  return {
+    pid,
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    process: processName,
+    onData: vi.fn(() => ({ dispose: vi.fn() })),
+    onExit: vi.fn(() => ({ dispose: vi.fn() }))
+  }
+}
+
+async function flushAsyncTicks(count = 12): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    await Promise.resolve()
+  }
+}
+
+async function readForegroundAt(
+  handle: { getForegroundProcess: () => string | null },
+  atMs: number
+): Promise<string | null> {
+  vi.setSystemTime(BASE_TIME_MS + atMs)
+  const foreground = handle.getForegroundProcess()
+  await flushAsyncTicks()
+  return foreground
+}
+
+describe('daemon pty foreground degraded-scan handling', () => {
+  let platform: PropertyDescriptor | undefined
+  let previousUserDataPath: string | undefined
+  let userDataPath: string
+
+  beforeEach(() => {
+    spawnMock.mockReset()
+    isPwshAvailableMock.mockReset()
+    isPwshAvailableMock.mockReturnValue(false)
+    resolveAgentForegroundProcessMock.mockReset()
+    readConptyMock.mockReset()
+    readConptyMock.mockResolvedValue(null)
+    previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+    userDataPath = mkdtempSync(join(tmpdir(), 'daemon-pty-degraded-scan-test-'))
+    process.env.ORCA_USER_DATA_PATH = userDataPath
+    platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(BASE_TIME_MS)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    if (platform) {
+      Object.defineProperty(process, 'platform', platform)
+    }
+    if (previousUserDataPath === undefined) {
+      delete process.env.ORCA_USER_DATA_PATH
+    } else {
+      process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+    }
+    rmSync(userDataPath, { recursive: true, force: true })
+  })
+
+  function spawnWindowsShell() {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const proc = mockPtyProcess('powershell.exe')
+    spawnMock.mockReturnValue(proc)
+    const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    return { proc, handle }
+  }
+
+  it('keeps a cached agent across a degraded (timed-out) scan', async () => {
+    resolveAgentForegroundProcessMock
+      .mockResolvedValueOnce({ available: true, processName: 'claude' })
+      .mockResolvedValue({ available: false, processName: null })
+    const { handle } = spawnWindowsShell()
+
+    await readForegroundAt(handle, 0) // establishes 'claude'
+    expect(await readForegroundAt(handle, 1_000)).toBe('claude') // refresh returns degraded → keep
+    // Past the 1s TTL with a shell fallback: pre-fix this returned the shell.
+    expect(await readForegroundAt(handle, 2_500)).toBe('claude')
+  })
+
+  it('keeps a cached agent when a scan finds no agent but the console still has a child', async () => {
+    resolveAgentForegroundProcessMock
+      .mockResolvedValueOnce({ available: true, processName: 'claude' })
+      .mockResolvedValue({ available: true, processName: null })
+    readConptyMock.mockResolvedValue(new Set([12345, 999])) // child still attached
+    const { handle } = spawnWindowsShell()
+
+    await readForegroundAt(handle, 0)
+    expect(await readForegroundAt(handle, 1_000)).toBe('claude')
+    expect(await readForegroundAt(handle, 2_500)).toBe('claude')
+  })
+
+  it('retires a cached agent when a scan finds no agent and the console is shell-only', async () => {
+    resolveAgentForegroundProcessMock
+      .mockResolvedValueOnce({ available: true, processName: 'claude' })
+      .mockResolvedValue({ available: true, processName: null })
+    readConptyMock.mockResolvedValue(null) // console shows only the shell → agent gone
+    const { handle } = spawnWindowsShell()
+
+    await readForegroundAt(handle, 0)
+    await readForegroundAt(handle, 1_000) // refresh clears the cache
+    expect(await readForegroundAt(handle, 1_100)).toBe('powershell.exe')
+  })
+})

--- a/src/main/daemon/pty-subprocess-foreground-degraded-scan.test.ts
+++ b/src/main/daemon/pty-subprocess-foreground-degraded-scan.test.ts
@@ -124,6 +124,7 @@ describe('daemon pty foreground degraded-scan handling', () => {
     expect(await readForegroundAt(handle, 1_000)).toBe('claude') // refresh returns degraded → keep
     // Past the 1s TTL with a shell fallback: pre-fix this returned the shell.
     expect(await readForegroundAt(handle, 2_500)).toBe('claude')
+    expect(readConptyMock).not.toHaveBeenCalled()
   })
 
   it('keeps a cached agent when a scan finds no agent but the console still has a child', async () => {
@@ -142,11 +143,25 @@ describe('daemon pty foreground degraded-scan handling', () => {
     resolveAgentForegroundProcessMock
       .mockResolvedValueOnce({ available: true, processName: 'claude' })
       .mockResolvedValue({ available: true, processName: null })
-    readConptyMock.mockResolvedValue(null) // console shows only the shell → agent gone
+    readConptyMock.mockResolvedValue(new Set([12345]))
     const { handle } = spawnWindowsShell()
 
     await readForegroundAt(handle, 0)
     await readForegroundAt(handle, 1_000) // refresh clears the cache
     expect(await readForegroundAt(handle, 1_100)).toBe('powershell.exe')
+    expect(readConptyMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps a cached agent when the console-membership probe is unavailable', async () => {
+    resolveAgentForegroundProcessMock
+      .mockResolvedValueOnce({ available: true, processName: 'claude' })
+      .mockResolvedValue({ available: true, processName: null })
+    readConptyMock.mockResolvedValue(null)
+    const { handle } = spawnWindowsShell()
+
+    await readForegroundAt(handle, 0)
+    expect(await readForegroundAt(handle, 1_000)).toBe('claude')
+    expect(await readForegroundAt(handle, 2_500)).toBe('claude')
+    expect(readConptyMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -72,7 +72,7 @@ vi.mock('../providers/agent-foreground-process', () => ({
 // to its existing retirement logic (the degraded-scan behavior itself is
 // covered in pty-subprocess-foreground-degraded-scan.test.ts).
 vi.mock('../providers/windows-conpty-process-membership', () => ({
-  readWindowsConptyProcessIds: () => Promise.resolve(null)
+  readWindowsConptyProcessIds: () => Promise.resolve(new Set([12345]))
 }))
 
 import { createPtySubprocess, checkPtySpawnHealth } from './pty-subprocess'

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -67,6 +67,14 @@ vi.mock('../providers/agent-foreground-process', () => ({
   }
 }))
 
+// Console-membership reads run a real node-pty fork that never settles under
+// fake timers; default to "shell-only" so the degraded-scan guard falls through
+// to its existing retirement logic (the degraded-scan behavior itself is
+// covered in pty-subprocess-foreground-degraded-scan.test.ts).
+vi.mock('../providers/windows-conpty-process-membership', () => ({
+  readWindowsConptyProcessIds: () => Promise.resolve(null)
+}))
+
 import { createPtySubprocess, checkPtySpawnHealth } from './pty-subprocess'
 import { PREVIOUS_DAEMON_PROTOCOL_VERSIONS, PROTOCOL_VERSION } from './types'
 import { TERMINAL_GIT_CREDENTIAL_GUARD_POLICY_ENV } from '../../shared/terminal-git-credential-guard'

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -983,10 +983,8 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     // Why: daemon foreground reads are sync and run on the IPC hot path.
     // Refresh derived identities (shell/wrapper/helper -> codex/claude/etc.)
     // in the background and serve them from a short cache on later reads.
-    // Why: retire the resolved identity only on authoritative "no agent"
-    // evidence. Kept as a helper so the Windows console-presence guard can run it
-    // after its async membership read without duplicating the shell/wrapper rules
-    // or moving that read onto the sync foreground path.
+    // Why: Windows may need an async membership check before this shared
+    // shell/wrapper retirement policy is safe to apply.
     const retireStaleForegroundIdentity = (): void => {
       const currentFallbackProcess = getFallbackForegroundProcess()
       if (
@@ -1012,29 +1010,21 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     void resolveAgentForegroundProcessWithAvailability(proc.pid, fallbackProcess, {
       contextPaths: agentForegroundContextPaths
     })
-      .then(({ processName, available }) => {
+      .then<string | void>(({ processName, available }) => {
         if (dead) {
           return
         }
-        // Why: a degraded/timed-out scan (Windows CIM timeout under load) is not
-        // authoritative evidence of an exit — leave the recognized agent in place
-        // rather than retiring it, which would make foreground reads fall back to
-        // the shell and fire a false "agent done" while the agent is still working.
-        // Only an authoritative scan may retire the identity.
+        // Why: a degraded scan is not exit evidence; retiring here fires false
+        // completion while an agent is still working under CIM load.
         if (!available) {
           return
         }
         if (!processName || !recognizeAgentProcess(processName)) {
-          // Why: an authoritative scan that resolves no agent can still be an
-          // incomplete Windows snapshot (the agent's row missing under load). A
-          // child still attached to this console proves the agent is working —
-          // keep it; only retire when the console is shell-only. Scoped to a shell
-          // fallback so the deliberate wrapper retirement is not held open by an
-          // unrelated wrapper's own console presence. The membership read stays
-          // off the sync foreground path.
+          // Why: a Windows snapshot can omit a live agent; only verified
+          // shell-only membership may retire its cached identity.
           if (process.platform === 'win32' && fallbackIsShell && cachedAgentForeground !== null) {
             return readWindowsConptyProcessIds(proc.pid).then((consoleProcessIds) => {
-              if (dead || consoleProcessIds !== null) {
+              if (dead || consoleProcessIds === null || consoleProcessIds.size > 1) {
                 return
               }
               retireStaleForegroundIdentity()
@@ -1045,6 +1035,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
         }
         cachedAgentForeground = { processName, refreshedAt: Date.now() }
         startupAgentForeground = null
+        return processName
       })
       .catch(() => {
         // Best-effort only: foreground enrichment must never affect PTY health.

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -983,34 +983,64 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     // Why: daemon foreground reads are sync and run on the IPC hot path.
     // Refresh derived identities (shell/wrapper/helper -> codex/claude/etc.)
     // in the background and serve them from a short cache on later reads.
+    // Why: retire the resolved identity only on authoritative "no agent"
+    // evidence. Kept as a helper so the Windows console-presence guard can run it
+    // after its async membership read without duplicating the shell/wrapper rules
+    // or moving that read onto the sync foreground path.
+    const retireStaleForegroundIdentity = (): void => {
+      const currentFallbackProcess = getFallbackForegroundProcess()
+      if (
+        fallbackIsShell &&
+        !getActiveStartupAgentForeground() &&
+        currentFallbackProcess !== null &&
+        isShellProcess(currentFallbackProcess)
+      ) {
+        cachedAgentForeground = null
+        startupAgentForeground = null
+      } else if (
+        cachedAgentForeground !== null &&
+        Date.now() - cachedAgentForeground.refreshedAt > FOREGROUND_AGENT_CACHE_TTL_MS &&
+        currentFallbackProcess !== null &&
+        isAgentForegroundWrapperProcess(currentFallbackProcess)
+      ) {
+        // Why: the wrapper's tree no longer resolves to an agent — an expired
+        // identity must not transfer to an unrelated wrapper (e.g. npm right
+        // after an agent exit). Fresh identities survive one-off scan hiccups.
+        cachedAgentForeground = null
+      }
+    }
     void resolveAgentForegroundProcessWithAvailability(proc.pid, fallbackProcess, {
       contextPaths: agentForegroundContextPaths
     })
-      .then(({ processName }) => {
+      .then(({ processName, available }) => {
         if (dead) {
           return
         }
+        // Why: a degraded/timed-out scan (Windows CIM timeout under load) is not
+        // authoritative evidence of an exit — leave the recognized agent in place
+        // rather than retiring it, which would make foreground reads fall back to
+        // the shell and fire a false "agent done" while the agent is still working.
+        // Only an authoritative scan may retire the identity.
+        if (!available) {
+          return
+        }
         if (!processName || !recognizeAgentProcess(processName)) {
-          const currentFallbackProcess = getFallbackForegroundProcess()
-          if (
-            fallbackIsShell &&
-            !getActiveStartupAgentForeground() &&
-            currentFallbackProcess !== null &&
-            isShellProcess(currentFallbackProcess)
-          ) {
-            cachedAgentForeground = null
-            startupAgentForeground = null
-          } else if (
-            cachedAgentForeground !== null &&
-            Date.now() - cachedAgentForeground.refreshedAt > FOREGROUND_AGENT_CACHE_TTL_MS &&
-            currentFallbackProcess !== null &&
-            isAgentForegroundWrapperProcess(currentFallbackProcess)
-          ) {
-            // Why: the wrapper's tree no longer resolves to an agent — an expired
-            // identity must not transfer to an unrelated wrapper (e.g. npm right
-            // after an agent exit). Fresh identities survive one-off scan hiccups.
-            cachedAgentForeground = null
+          // Why: an authoritative scan that resolves no agent can still be an
+          // incomplete Windows snapshot (the agent's row missing under load). A
+          // child still attached to this console proves the agent is working —
+          // keep it; only retire when the console is shell-only. Scoped to a shell
+          // fallback so the deliberate wrapper retirement is not held open by an
+          // unrelated wrapper's own console presence. The membership read stays
+          // off the sync foreground path.
+          if (process.platform === 'win32' && fallbackIsShell && cachedAgentForeground !== null) {
+            return readWindowsConptyProcessIds(proc.pid).then((consoleProcessIds) => {
+              if (dead || consoleProcessIds !== null) {
+                return
+              }
+              retireStaleForegroundIdentity()
+            })
           }
+          retireStaleForegroundIdentity()
           return
         }
         cachedAgentForeground = { processName, refreshedAt: Date.now() }
@@ -1069,14 +1099,18 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
           return cachedAgentForeground.processName
         }
         // Why: a wrapper foreground (node/python) can never identify itself, and
-        // readers poll slower than the cache TTL — returning the raw wrapper here
+        // readers poll slower than the cache TTL — returning the raw fallback here
         // would hide the resolved identity forever. Serve the last resolved agent
-        // while the scheduled refresh revalidates; exit truth is safe because an
-        // exited agent's foreground falls back to the shell, not a wrapper.
+        // while the scheduled refresh revalidates. On Windows a shell fallback is
+        // also an unreliable exit signal (ConPTY lag under load surfaces the shell
+        // while the agent is alive), so trust the cache there too; the background
+        // refresh retires the identity only after a console-presence read confirms
+        // the agent left the console.
         if (
           cachedAgentForeground &&
           fallbackProcess !== null &&
-          isAgentForegroundWrapperProcess(fallbackProcess)
+          (isAgentForegroundWrapperProcess(fallbackProcess) ||
+            (process.platform === 'win32' && isShellProcess(fallbackProcess)))
         ) {
           return cachedAgentForeground.processName
         }

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -1462,11 +1462,39 @@ describe('LocalPtyProvider', () => {
         available: true,
         processName: 'claude'
       })
+      readWindowsConptyProcessIdsMock.mockResolvedValue(new Set([12345]))
+      const { id } = await provider.spawn({ cols: 80, rows: 24 })
+
+      await expect(provider.getForegroundProcess(id)).resolves.toBe('claude')
+      await expect(provider.getForegroundProcess(id)).resolves.toBe('claude')
+      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('keeps the cached agent when both the console probe and process snapshot are inconclusive', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      mockProc.process = 'powershell.exe'
+      resolveAgentForegroundProcessMock
+        .mockResolvedValueOnce({ available: true, processName: 'claude' })
+        .mockResolvedValue({ available: true, processName: null })
       readWindowsConptyProcessIdsMock.mockResolvedValue(null)
       const { id } = await provider.spawn({ cols: 80, rows: 24 })
 
       await expect(provider.getForegroundProcess(id)).resolves.toBe('claude')
       await expect(provider.getForegroundProcess(id)).resolves.toBe('claude')
+      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('retires the cached agent after verified shell-only membership and a no-agent scan', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      mockProc.process = 'powershell.exe'
+      resolveAgentForegroundProcessMock
+        .mockResolvedValueOnce({ available: true, processName: 'claude' })
+        .mockResolvedValue({ available: true, processName: null })
+      readWindowsConptyProcessIdsMock.mockResolvedValue(new Set([12345]))
+      const { id } = await provider.spawn({ cols: 80, rows: 24 })
+
+      await expect(provider.getForegroundProcess(id)).resolves.toBe('claude')
+      await expect(provider.getForegroundProcess(id)).resolves.toBeNull()
       expect(resolveAgentForegroundProcessMock).toHaveBeenCalledTimes(2)
     })
   })

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -12,6 +12,7 @@ const {
   spawnMock,
   prepareMacosTccLoginShellMock,
   resolveAgentForegroundProcessMock,
+  readWindowsConptyProcessIdsMock,
   captureDescendantSnapshotMock,
   terminateDescendantSnapshotMock
 } = vi.hoisted(() => ({
@@ -23,6 +24,7 @@ const {
   spawnMock: vi.fn(),
   prepareMacosTccLoginShellMock: vi.fn(),
   resolveAgentForegroundProcessMock: vi.fn(),
+  readWindowsConptyProcessIdsMock: vi.fn(),
   captureDescendantSnapshotMock: vi.fn(),
   terminateDescendantSnapshotMock: vi.fn()
 }))
@@ -77,6 +79,10 @@ vi.mock('./windows-powershell-executable', () => ({
 vi.mock('./agent-foreground-process', () => ({
   resolveAgentForegroundProcessWithAvailability: (...args: unknown[]) =>
     resolveAgentForegroundProcessMock(...args)
+}))
+
+vi.mock('./windows-conpty-process-membership', () => ({
+  readWindowsConptyProcessIds: (...args: unknown[]) => readWindowsConptyProcessIdsMock(...args)
 }))
 
 vi.mock('../wsl', () => ({
@@ -156,6 +162,8 @@ describe('LocalPtyProvider', () => {
         processName: fallbackProcess
       })
     )
+    readWindowsConptyProcessIdsMock.mockReset()
+    readWindowsConptyProcessIdsMock.mockResolvedValue(null)
 
     exitCb = undefined
     mockProc = {
@@ -1426,6 +1434,40 @@ describe('LocalPtyProvider', () => {
       resolveScan({ available: true, processName: 'droid' })
 
       await expect(foreground).resolves.toBeNull()
+    })
+
+    it('confirms a still-active agent from ConPTY console presence without a whole-table scan', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      mockProc.process = 'powershell.exe'
+      resolveAgentForegroundProcessMock.mockResolvedValue({
+        available: true,
+        processName: 'claude'
+      })
+      // A child beyond the shell is still attached to this console.
+      readWindowsConptyProcessIdsMock.mockResolvedValue(new Set([12345, 999]))
+      const { id } = await provider.spawn({ cols: 80, rows: 24 })
+
+      // First call establishes the agent identity via the scan.
+      await expect(provider.getForegroundProcess(id)).resolves.toBe('claude')
+      // node-pty still only names the shell, but console presence confirms the
+      // agent — no second whole-table scan.
+      await expect(provider.getForegroundProcess(id)).resolves.toBe('claude')
+      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('falls through to the scan when the ConPTY console shows only the shell', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      mockProc.process = 'powershell.exe'
+      resolveAgentForegroundProcessMock.mockResolvedValue({
+        available: true,
+        processName: 'claude'
+      })
+      readWindowsConptyProcessIdsMock.mockResolvedValue(null)
+      const { id } = await provider.spawn({ cols: 80, rows: 24 })
+
+      await expect(provider.getForegroundProcess(id)).resolves.toBe('claude')
+      await expect(provider.getForegroundProcess(id)).resolves.toBe('claude')
+      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledTimes(2)
     })
   })
 

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -61,6 +61,7 @@ import {
   terminateDescendantSnapshot
 } from '../pty-descendant-termination'
 import { readWindowsConptyProcessIds } from './windows-conpty-process-membership'
+import { canConfirmAgentFromConsolePresence } from './windows-console-foreground'
 import { forceKillPosixPtyProcessGroups } from '../pty/posix-pty-process-groups'
 import { shouldUseShellReadyStartupDelivery } from '../../shared/codex-startup-delivery'
 import { assertSafeAgentStartupCwd, resolveSafePtyDefaultCwd } from './pty-default-cwd'
@@ -1234,10 +1235,37 @@ export class LocalPtyProvider implements IPtyProvider {
       ptyLastRecognizedForeground.delete(id)
       return null
     }
+    const fallbackProcess = resolveForegroundFallbackProcess(
+      proc.process || null,
+      ptyShellName.get(id)
+    )
+    const cachedAgent = ptyLastRecognizedForeground.get(id) ?? null
+    // Why: while a recognized agent is still active in this ConPTY, a cheap
+    // console-membership read confirms it without the whole-table scan that,
+    // under load, times out or returns an incomplete snapshot and makes the
+    // completion coordinator fire a false "agent done". A child still attached
+    // to this console means the agent is working; fall through to the
+    // authoritative scan only when the console is shell-only (agent likely gone).
+    if (
+      process.platform === 'win32' &&
+      canConfirmAgentFromConsolePresence(cachedAgent, fallbackProcess)
+    ) {
+      try {
+        const consoleProcessIds = await readWindowsConptyProcessIds(proc.pid)
+        if (ptyProcesses.get(id) !== proc) {
+          return null
+        }
+        if (consoleProcessIds !== null && cachedAgent !== null) {
+          return cachedAgent
+        }
+      } catch {
+        // Fall through to the authoritative scan on any console-read failure.
+      }
+    }
     try {
       const resolution = await resolveAgentForegroundProcessWithAvailability(
         proc.pid,
-        resolveForegroundFallbackProcess(proc.process || null, ptyShellName.get(id)),
+        fallbackProcess,
         {
           contextPaths: ptyAgentForegroundContextPaths.get(id)
         }

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -1240,12 +1240,9 @@ export class LocalPtyProvider implements IPtyProvider {
       ptyShellName.get(id)
     )
     const cachedAgent = ptyLastRecognizedForeground.get(id) ?? null
-    // Why: while a recognized agent is still active in this ConPTY, a cheap
-    // console-membership read confirms it without the whole-table scan that,
-    // under load, times out or returns an incomplete snapshot and makes the
-    // completion coordinator fire a false "agent done". A child still attached
-    // to this console means the agent is working; fall through to the
-    // authoritative scan only when the console is shell-only (agent likely gone).
+    let consoleMembershipUnavailable = false
+    // Why: exact console membership can preserve a live cached agent without
+    // trusting the whole-table scan that becomes incomplete under Windows load.
     if (
       process.platform === 'win32' &&
       canConfirmAgentFromConsolePresence(cachedAgent, fallbackProcess)
@@ -1255,11 +1252,12 @@ export class LocalPtyProvider implements IPtyProvider {
         if (ptyProcesses.get(id) !== proc) {
           return null
         }
-        if (consoleProcessIds !== null && cachedAgent !== null) {
+        if (consoleProcessIds !== null && consoleProcessIds.size > 1 && cachedAgent !== null) {
           return cachedAgent
         }
+        consoleMembershipUnavailable = consoleProcessIds === null
       } catch {
-        // Fall through to the authoritative scan on any console-read failure.
+        consoleMembershipUnavailable = true
       }
     }
     try {
@@ -1279,9 +1277,17 @@ export class LocalPtyProvider implements IPtyProvider {
       // foreground — the completion coordinator reads that as an exit and fires
       // a false "agent done" while the agent is still working. Prefer the last
       // recognized agent across a transient failure (e.g. a Windows CIM timeout).
+      const lastRecognizedAgent = ptyLastRecognizedForeground.get(id) ?? null
+      const resolvedAgent = resolution.processName
+        ? recognizeAgentProcessFromCommandLine(resolution.processName)
+        : null
+      // Why: an incomplete global snapshot plus an unavailable console probe is
+      // not exit proof; only verified shell-only membership may clear the cache.
       const stable = resolveStableForegroundProcess(
-        resolution,
-        ptyLastRecognizedForeground.get(id) ?? null
+        consoleMembershipUnavailable && resolvedAgent === null
+          ? { ...resolution, available: false }
+          : resolution,
+        lastRecognizedAgent
       )
       if (stable.lastRecognizedAgent) {
         ptyLastRecognizedForeground.set(id, stable.lastRecognizedAgent)

--- a/src/main/providers/windows-conpty-process-membership.test.ts
+++ b/src/main/providers/windows-conpty-process-membership.test.ts
@@ -26,7 +26,7 @@ function forkWith(event: 'message' | 'error' | 'none', value?: unknown, pid?: nu
 
 describe('readWindowsConptyProcessIds', () => {
   it('returns exact console membership from the fixed node-pty helper', async () => {
-    const { forkProcess } = forkWith('message', [101, 202, 303])
+    const { forkProcess } = forkWith('message', [999, 101, 202, 303], 999)
 
     await expect(
       readWindowsConptyProcessIds(101, {
@@ -42,19 +42,19 @@ describe('readWindowsConptyProcessIds', () => {
   })
 
   it.each([
-    ['root-only failure fallback', [101]],
-    ['malformed response', [101, '202']],
-    ['missing PTY root', [202, 303]]
-  ])('fails closed for %s', async (_label, processIds) => {
-    const { forkProcess } = forkWith('message', processIds)
+    ['root-only failure fallback', [101], 999],
+    ['malformed response', [999, 101, '202'], 999],
+    ['missing PTY root', [999, 202, 303], 999],
+    ['missing helper pid', [101, 202], 999],
+    ['unavailable helper pid', [101, 202], undefined]
+  ])('fails closed for %s', async (_label, processIds, helperPid) => {
+    const { forkProcess } = forkWith('message', processIds, helperPid)
     await expect(readWindowsConptyProcessIds(101, { forkProcess })).resolves.toBeNull()
   })
 
-  it('treats a console of only the helper and the shell as shell-only (no child)', async () => {
-    // The helper (pid 999) attaches itself, so a bare shell reads as [999, 101].
-    // Without excluding the helper this looks like a child is still running.
+  it('returns root-only membership when only the helper and shell are attached', async () => {
     const { forkProcess } = forkWith('message', [999, 101], 999)
-    await expect(readWindowsConptyProcessIds(101, { forkProcess })).resolves.toBeNull()
+    await expect(readWindowsConptyProcessIds(101, { forkProcess })).resolves.toEqual(new Set([101]))
   })
 
   it('reports membership excluding the helper when a real child is attached', async () => {

--- a/src/main/providers/windows-conpty-process-membership.test.ts
+++ b/src/main/providers/windows-conpty-process-membership.test.ts
@@ -2,9 +2,15 @@ import { EventEmitter } from 'node:events'
 import { describe, expect, it, vi } from 'vitest'
 import { readWindowsConptyProcessIds } from './windows-conpty-process-membership'
 
-function forkWith(event: 'message' | 'error' | 'none', value?: unknown) {
-  const child = new EventEmitter() as EventEmitter & { kill: ReturnType<typeof vi.fn> }
+function forkWith(event: 'message' | 'error' | 'none', value?: unknown, pid?: number) {
+  const child = new EventEmitter() as EventEmitter & {
+    kill: ReturnType<typeof vi.fn>
+    pid?: number
+  }
   child.kill = vi.fn()
+  if (pid !== undefined) {
+    child.pid = pid
+  }
   const forkProcess = vi.fn(() => {
     queueMicrotask(() => {
       if (event === 'message') {
@@ -42,6 +48,20 @@ describe('readWindowsConptyProcessIds', () => {
   ])('fails closed for %s', async (_label, processIds) => {
     const { forkProcess } = forkWith('message', processIds)
     await expect(readWindowsConptyProcessIds(101, { forkProcess })).resolves.toBeNull()
+  })
+
+  it('treats a console of only the helper and the shell as shell-only (no child)', async () => {
+    // The helper (pid 999) attaches itself, so a bare shell reads as [999, 101].
+    // Without excluding the helper this looks like a child is still running.
+    const { forkProcess } = forkWith('message', [999, 101], 999)
+    await expect(readWindowsConptyProcessIds(101, { forkProcess })).resolves.toBeNull()
+  })
+
+  it('reports membership excluding the helper when a real child is attached', async () => {
+    const { forkProcess } = forkWith('message', [999, 101, 202], 999)
+    await expect(readWindowsConptyProcessIds(101, { forkProcess })).resolves.toEqual(
+      new Set([101, 202])
+    )
   })
 
   it('handles helper spawn errors without an unhandled child error', async () => {

--- a/src/main/providers/windows-conpty-process-membership.test.ts
+++ b/src/main/providers/windows-conpty-process-membership.test.ts
@@ -81,4 +81,20 @@ describe('readWindowsConptyProcessIds', () => {
       vi.useRealTimers()
     }
   })
+
+  it('absorbs an asynchronous kill error after timeout settlement', async () => {
+    vi.useFakeTimers()
+    try {
+      const { child, forkProcess } = forkWith('none')
+      child.kill.mockImplementation(() => {
+        queueMicrotask(() => child.emit('error', new Error('kill failed')))
+      })
+      const result = readWindowsConptyProcessIds(101, { forkProcess, timeoutMs: 10 })
+      await vi.advanceTimersByTimeAsync(10)
+      await expect(result).resolves.toBeNull()
+      expect(child.listenerCount('error')).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/src/main/providers/windows-conpty-process-membership.ts
+++ b/src/main/providers/windows-conpty-process-membership.ts
@@ -45,11 +45,15 @@ export function readWindowsConptyProcessIds(
       settled = true
       clearTimeout(timeout)
       child.removeListener('message', onMessage)
-      child.removeListener('error', onFailure)
-      child.removeListener('exit', onFailure)
+      // Why: kill failures can emit asynchronously after timeout settlement;
+      // teardown listeners stay until exit so they cannot crash the daemon.
       resolve(value)
     }
     const onFailure = (): void => finish(null)
+    const onExit = (): void => {
+      child.removeListener('error', onFailure)
+      finish(null)
+    }
     const onMessage = (message: ProcessListMessage): void => {
       const value = message?.consoleProcessList
       const helperPid = child.pid
@@ -75,6 +79,6 @@ export function readWindowsConptyProcessIds(
     }, deps.timeoutMs ?? CONPTY_PROCESS_LIST_TIMEOUT_MS)
     child.once('message', onMessage)
     child.once('error', onFailure)
-    child.once('exit', onFailure)
+    child.once('exit', onExit)
   })
 }

--- a/src/main/providers/windows-conpty-process-membership.ts
+++ b/src/main/providers/windows-conpty-process-membership.ts
@@ -54,14 +54,27 @@ export function readWindowsConptyProcessIds(
       const value = message?.consoleProcessList
       if (
         !Array.isArray(value) ||
-        value.length <= 1 ||
         !value.includes(rootPid) ||
         value.some((pid) => !Number.isSafeInteger(pid) || pid <= 0)
       ) {
         finish(null)
         return
       }
-      finish(new Set(value))
+      // Why: the helper attaches to the console to read it, so GetConsoleProcessList
+      // counts the helper's own forked process. Drop it before judging membership,
+      // or a bare shell (helper + shell) looks like it still has a child and a
+      // genuine shell-only console (an exited agent) is never detected. A remaining
+      // set of only the shell — or the helper's AttachConsole-failure fallback — is
+      // not child proof.
+      const consoleProcessIds = new Set(value)
+      if (child.pid !== undefined) {
+        consoleProcessIds.delete(child.pid)
+      }
+      if (consoleProcessIds.size <= 1) {
+        finish(null)
+        return
+      }
+      finish(consoleProcessIds)
     }
     const timeout = setTimeout(() => {
       child.kill()

--- a/src/main/providers/windows-conpty-process-membership.ts
+++ b/src/main/providers/windows-conpty-process-membership.ts
@@ -15,8 +15,8 @@ function resolveNodePtyConsoleListAgent(): string {
 }
 
 /**
- * Runs node-pty's fixed native console-list helper with bounded error/exit
- * handling. A root-only result is its failure fallback, not shell proof.
+ * Returns normalized console membership, or null when the probe is unavailable.
+ * A root-only set proves the shell is alone because successful raw results include the helper.
  */
 export function readWindowsConptyProcessIds(
   rootPid: number,
@@ -52,28 +52,21 @@ export function readWindowsConptyProcessIds(
     const onFailure = (): void => finish(null)
     const onMessage = (message: ProcessListMessage): void => {
       const value = message?.consoleProcessList
+      const helperPid = child.pid
       if (
         !Array.isArray(value) ||
+        helperPid === undefined ||
         !value.includes(rootPid) ||
+        !value.includes(helperPid) ||
         value.some((pid) => !Number.isSafeInteger(pid) || pid <= 0)
       ) {
         finish(null)
         return
       }
-      // Why: the helper attaches to the console to read it, so GetConsoleProcessList
-      // counts the helper's own forked process. Drop it before judging membership,
-      // or a bare shell (helper + shell) looks like it still has a child and a
-      // genuine shell-only console (an exited agent) is never detected. A remaining
-      // set of only the shell — or the helper's AttachConsole-failure fallback — is
-      // not child proof.
+      // Why: GetConsoleProcessList includes this helper; removing it makes a
+      // root-only set authoritative shell-only evidence instead of a false child.
       const consoleProcessIds = new Set(value)
-      if (child.pid !== undefined) {
-        consoleProcessIds.delete(child.pid)
-      }
-      if (consoleProcessIds.size <= 1) {
-        finish(null)
-        return
-      }
+      consoleProcessIds.delete(helperPid)
       finish(consoleProcessIds)
     }
     const timeout = setTimeout(() => {

--- a/src/main/providers/windows-console-foreground.test.ts
+++ b/src/main/providers/windows-console-foreground.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { canConfirmAgentFromConsolePresence } from './windows-console-foreground'
+
+describe('canConfirmAgentFromConsolePresence', () => {
+  it('is true for a cached agent when node-pty only names the shell (a scan would run)', () => {
+    expect(canConfirmAgentFromConsolePresence('claude', 'powershell.exe')).toBe(true)
+    expect(canConfirmAgentFromConsolePresence('codex', 'cmd.exe')).toBe(true)
+  })
+
+  it('is false when node-pty already names a recognized agent (no scan needed)', () => {
+    // Nothing to save here — the fast no-scan path already returns the agent.
+    expect(canConfirmAgentFromConsolePresence('claude', 'claude')).toBe(false)
+  })
+
+  it('is false when no agent has been recognized yet (identity must be established first)', () => {
+    expect(canConfirmAgentFromConsolePresence(null, 'powershell.exe')).toBe(false)
+  })
+
+  it('is false when there is no fallback process name', () => {
+    expect(canConfirmAgentFromConsolePresence('claude', null)).toBe(false)
+  })
+})

--- a/src/main/providers/windows-console-foreground.test.ts
+++ b/src/main/providers/windows-console-foreground.test.ts
@@ -12,6 +12,10 @@ describe('canConfirmAgentFromConsolePresence', () => {
     expect(canConfirmAgentFromConsolePresence('claude', 'claude')).toBe(false)
   })
 
+  it('is false for a generic wrapper that may outlive the cached agent', () => {
+    expect(canConfirmAgentFromConsolePresence('claude', 'node.exe')).toBe(false)
+  })
+
   it('is false when no agent has been recognized yet (identity must be established first)', () => {
     expect(canConfirmAgentFromConsolePresence(null, 'powershell.exe')).toBe(false)
   })

--- a/src/main/providers/windows-console-foreground.ts
+++ b/src/main/providers/windows-console-foreground.ts
@@ -1,0 +1,27 @@
+import { shouldInspectWindowsAgentForeground } from './windows-agent-foreground-process'
+
+/**
+ * Whether a cheap ConPTY console-membership read can confirm the foreground
+ * agent, letting us skip the whole-table process scan.
+ *
+ * Why: on Windows the foreground scan is a whole-process-table PowerShell fork
+ * that, under load, exceeds its timeout or returns an incomplete snapshot — the
+ * completion coordinator then reads the shell as the foreground and fires a
+ * false "agent done" while the agent is still working. When node-pty only names
+ * the shell (so a scan would otherwise run) and we already recognized an agent
+ * here, a child process still attached to this console means that agent is still
+ * active, so we can keep it without the scan. If node-pty already names a
+ * recognized agent, the fast path already returns it and no scan runs; if no
+ * agent has been recognized yet, identity must be established by a real scan
+ * first.
+ */
+export function canConfirmAgentFromConsolePresence(
+  cachedAgentName: string | null,
+  fallbackProcess: string | null
+): boolean {
+  return (
+    cachedAgentName !== null &&
+    fallbackProcess !== null &&
+    shouldInspectWindowsAgentForeground(fallbackProcess)
+  )
+}

--- a/src/main/providers/windows-console-foreground.ts
+++ b/src/main/providers/windows-console-foreground.ts
@@ -1,20 +1,6 @@
-import { shouldInspectWindowsAgentForeground } from './windows-agent-foreground-process'
+import { isShellProcess } from '../../shared/shell-process-detection'
 
-/**
- * Whether a cheap ConPTY console-membership read can confirm the foreground
- * agent, letting us skip the whole-table process scan.
- *
- * Why: on Windows the foreground scan is a whole-process-table PowerShell fork
- * that, under load, exceeds its timeout or returns an incomplete snapshot — the
- * completion coordinator then reads the shell as the foreground and fires a
- * false "agent done" while the agent is still working. When node-pty only names
- * the shell (so a scan would otherwise run) and we already recognized an agent
- * here, a child process still attached to this console means that agent is still
- * active, so we can keep it without the scan. If node-pty already names a
- * recognized agent, the fast path already returns it and no scan runs; if no
- * agent has been recognized yet, identity must be established by a real scan
- * first.
- */
+/** Whether ConPTY membership can revalidate a cached agent without a process scan. */
 export function canConfirmAgentFromConsolePresence(
   cachedAgentName: string | null,
   fallbackProcess: string | null
@@ -22,6 +8,8 @@ export function canConfirmAgentFromConsolePresence(
   return (
     cachedAgentName !== null &&
     fallbackProcess !== null &&
-    shouldInspectWindowsAgentForeground(fallbackProcess)
+    // Why: a generic wrapper may outlive the agent; only the shell fallback is
+    // the known unreliable Windows exit signal this cache is allowed to bridge.
+    isShellProcess(fallbackProcess)
   )
 }


### PR DESCRIPTION
Follow-up to #9244. Fixes false "agent done" notifications on Windows by removing the whole-process-table scan from the hot path of foreground detection — including the **daemon** path, which is what actually runs on Windows.

## Problem

Deciding an agent finished depends partly on "is the agent still the terminal's foreground process?" On Windows that answer comes from a whole-process-table `Get-CimInstance Win32_Process` PowerShell scan with a 3s timeout. Under load (many agents doing heavy work) the scan **times out** or returns an **incomplete snapshot**, so the completion coordinator reads the shell as the foreground, concludes the agent exited, and fires a false completion while it's still working — multiplied across panes into the notification flood.

#9244 addressed the timeout case in the local PTY provider, but Windows PTYs are hosted by the terminal daemon, so that change is inert on the default path. This PR fixes the primary (daemon) path.

## Fix

Confirm the agent with a cheap, terminal-scoped **ConPTY console-membership read** (`readWindowsConptyProcessIds`, already vendored) instead of the whole-table scan:

- **Local + daemon foreground reads:** while a recognized agent is active and node-pty only names the shell, a child still attached to the console means the agent is working → keep the agent and skip the whole-table scan; only a shell-only console falls through to the authoritative scan.
- **Daemon refresh:** a degraded scan (`available: false`) no longer retires the identity; an authoritative no-agent scan is confirmed against the console read before retiring (an incomplete snapshot with a child still attached keeps the agent). Scoped to a shell fallback so the deliberate wrapper (`npm`-after-exit) retirement is unaffected; the membership read stays off the sync foreground read.
- **Console-membership off-by-one:** the console-list helper attaches to the console to read it, so `GetConsoleProcessList` counts the helper's own forked process — a bare shell read as `[helper, shell]` and never looked shell-only, holding an exited agent's identity forever. The helper's own pid is now dropped before judging membership, so a real exit is surfaced promptly. This fixes both the daemon and local paths.

No-op off Windows; never worse than the pre-existing degraded-scan fallback.

## Testing

- Pure gate helper + real-function membership tests (helper-pid exclusion: `[helper, shell] → {shell}`, `[helper, shell, agent] → {shell, agent}`).
- Daemon degraded-scan tests: keep-on-degraded, keep-on-incomplete-snapshot-with-console-child, retire-on-shell-only.
- Local provider tests: console presence skips the scan; shell-only falls through.
- Full `src/main/daemon` + `src/main/providers` suites (1319 tests) green; `typecheck:node`, oxlint, oxfmt clean.

## Windows validation (real hardware, under CIM-timeout load)

- **False "agent done" under load: fixed** — foreground stays on the agent (40/40) while it works; no false completion.
- **Real-exit detection: works** — after a real exit the console reads shell-only, the identity is retired, and foreground returns the shell within ~2s.
- Console-membership probe flipped as expected (bare shell → shell-only; shell + child → child present).

Supersedes the Windows behavior of #9244 (which remains a correct, no-regression improvement to the daemon-unavailable fallback path).


## Reliability and performance contract

- **Invariant (`agent-session.foreground-liveness`):** A recognized Windows agent remains foreground while evidence is degraded or inconclusive, and retires only after a no-agent scan plus verified shell-only ConPTY membership. Generic wrappers keep their existing retirement behavior.
- **Failure source:** Windows CIM timeouts and incomplete whole-process snapshots under multi-agent load caused the completion coordinator to observe the shell and emit false completion.
- **Oracle:** Deterministic daemon and local-provider tests prove keep-on-degraded, keep-on-incomplete-with-child, keep-on-membership-unavailable, retire-on-verified-shell-only, helper PID exclusion, wrapper isolation, and exact helper/scan counts. Physical Windows 11 validation proves live-agent retention and real-exit retirement.
- **Gate:** The shared foreground/membership contract is exercised by `terminal-input.windows-modified-enter-routing`; a dedicated completion-notification gate is an accepted manifest gap for this PR.
- **Provider/platform coverage:** Windows local and daemon paths are covered. macOS/Linux are runtime no-ops. SSH, WSL, remote-runtime, and mobile/relay do not execute this local ConPTY branch and are unaffected.
- **Performance budget:** Whole-process scans retain the shared 500 ms snapshot dedupe and existing foreground cadence. Degraded scans add zero per-PTY membership forks; the exact ConPTY helper runs only after an authoritative no-agent Windows snapshot needs PTY-scoped confirmation. Every helper remains bounded by the existing 3 s timeout and kill cleanup.
- **Diagnostics:** The evidence contract now distinguishes unavailable membership (`null`), verified shell-only membership (`{shell}`), and attached-child membership (`{shell, child...}`), so future failures can be classified without treating probe failure as exit proof.
- **Residual gap:** Live validation covers Windows 11 hardware, while CI provides simulated Windows provider contracts rather than a real ConPTY membership artifact.

Additional review verification: the 22-file reliability gate passed with 1,443 tests; full node/CLI/web typecheck, oxlint, reliability-manifest validation, and max-lines ratchet passed.