### PR TITLE
fix(terminal): filter focus reports after Codex history resume

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -17820,6 +17820,61 @@ describe('connectPanePty', () => {
     }
   })
 
+  it.each([
+    {
+      name: 'Claude history resume',
+      launchAgent: 'claude',
+      agentKind: 'claude',
+      requestKind: 'resume'
+    },
+    {
+      name: 'fresh Codex launch',
+      launchAgent: 'codex',
+      agentKind: 'codex',
+      requestKind: 'new'
+    }
+  ])(
+    'keeps focus reports enabled for a native Windows $name',
+    async ({ launchAgent, agentKind, requestKind }) => {
+      const restoreUserAgent = temporarilySetNavigatorUserAgent(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+      )
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      transportFactoryQueue.push(transport)
+
+      try {
+        const pane = createPane(1)
+        pane.terminal.modes.sendFocusMode = true
+
+        connectPanePty(
+          pane as never,
+          createManager(1) as never,
+          createDeps({
+            startup: {
+              command: `${launchAgent} session-command`,
+              launchAgent,
+              telemetry: {
+                agent_kind: agentKind,
+                launch_source: 'sidebar',
+                request_kind: requestKind
+              }
+            }
+          }) as never
+        )
+
+        transport.sendInput.mockClear()
+        sendTerminalInputThroughPane(pane, '\x1b[O')
+        sendTerminalInputThroughPane(pane, '\x1b[I')
+
+        expect(transport.sendInput).toHaveBeenNthCalledWith(1, '\x1b[O')
+        expect(transport.sendInput).toHaveBeenNthCalledWith(2, '\x1b[I')
+      } finally {
+        restoreUserAgent()
+      }
+    }
+  )
+
   it('drops only focus reports while native Windows Codex is done and resumes them when working', async () => {
     const restoreUserAgent = temporarilySetNavigatorUserAgent(
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -17766,6 +17766,60 @@ describe('connectPanePty', () => {
     }
   })
 
+  it('drops native Windows Codex focus reports while a history resume is idle', async () => {
+    const restoreUserAgent = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+
+    try {
+      const paneKey = makePaneKey('tab-1', LEAF_1)
+      const pane = createPane(1)
+      pane.terminal.modes.sendFocusMode = true
+
+      connectPanePty(
+        pane as never,
+        createManager(1) as never,
+        createDeps({
+          startup: {
+            command: "codex 'resume' 'codex-session-1'",
+            launchAgent: 'codex',
+            telemetry: {
+              agent_kind: 'codex',
+              launch_source: 'sidebar',
+              request_kind: 'resume'
+            }
+          }
+        }) as never
+      )
+
+      expect(mockStoreState.agentStatusByPaneKey[paneKey]).toBeUndefined()
+      transport.sendInput.mockClear()
+
+      sendTerminalInputThroughPane(pane, '\x1b[O')
+      sendTerminalInputThroughPane(pane, '\x1b[I')
+      expect(transport.sendInput).not.toHaveBeenCalled()
+
+      mockStoreState.agentStatusByPaneKey[paneKey] = {
+        state: 'working',
+        prompt: 'continue the resumed session',
+        updatedAt: Date.now(),
+        stateStartedAt: Date.now(),
+        agentType: 'codex',
+        paneKey,
+        stateHistory: []
+      }
+      notifyStoreSubscribers()
+
+      sendTerminalInputThroughPane(pane, '\x1b[I')
+      expect(transport.sendInput).toHaveBeenCalledWith('\x1b[I')
+    } finally {
+      restoreUserAgent()
+    }
+  })
+
   it('drops only focus reports while native Windows Codex is done and resumes them when working', async () => {
     const restoreUserAgent = temporarilySetNavigatorUserAgent(
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -3157,6 +3157,16 @@ export function connectPanePty(
   let unsubscribeWindowsDoneTerminalModeReset: (() => void) | null = null
   if (isNativeWindowsConpty) {
     const initialAgentStatus = state.agentStatusByPaneKey[cacheKey]
+    if (
+      !initialAgentStatus &&
+      paneStartup?.telemetry?.launch_source === 'sidebar' &&
+      paneStartup.telemetry.request_kind === 'resume' &&
+      (paneStartup.launchAgent === 'codex' || paneStartup.telemetry.agent_kind === 'codex')
+    ) {
+      // Why: history resumes open on a completed Codex composer without a done
+      // row, so arm the same Windows stale-focus guard until work starts again.
+      suppressNativeWindowsIdleCodexFocusReports = true
+    }
     if (initialAgentStatus?.state === 'done') {
       setFocusReportSuppressionForAgentCompletion(undefined, initialAgentStatus.agentType)
     }


### PR DESCRIPTION
## Summary

Prevents native Windows Codex history resumes from leaving literal `[I`, `[[I`, or `[O` focus-report fragments in the idle composer.

The existing Windows guard was armed by an agent `done` status. A session resumed from Agent Session History can open directly on a completed Codex composer with focus reporting enabled but no pane status row, so `ESC[O` / `ESC[I` could still reach ConPTY. This change recognizes the explicit Codex sidebar-resume startup metadata and arms the same guard until the resumed session starts working again.

## Screenshots

No visual change.

Electron validation exercised the visible Agent Session History resume flow and a real focus handoff between the history search and resumed terminal. The completed Codex composer remained clean with focus reporting enabled and no agent-status row.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional focused validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts` — 449 passed
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- Electron CDP validation on native Windows ConPTY

## AI Review Report

Reviewed the existing startup input ordering fix and the native Windows post-turn focus-report suppression path. The main risk was over-broadly suppressing legitimate focus events for normal shells, Cursor, WSL, SSH, or runtime-hosted terminals. The implementation is restricted to native Windows ConPTY, explicit sidebar resume requests, and Codex startup metadata with no authoritative initial status. Existing working-state transitions restore focus reports.

Cross-platform compatibility was explicitly checked. The change does not alter shortcuts, labels, paths, Git commands, shell selection, macOS/Linux behavior, SSH, WSL, or remote-runtime transport behavior. The full PTY connection test file includes the neighboring remote-safety and non-Codex focus-report coverage.

## Security Audit

No new command execution, path handling, authentication, dependency, or IPC surface was introduced. The filter accepts only xterm's exact focus-in and focus-out control sequences and uses existing trusted startup telemetry. Ordinary keyboard input and terminal query replies remain unchanged.

## Notes

The behavioral change is intentionally Windows ConPTY-specific. The pre-fix failure was reproduced deterministically at the PTY transport boundary; the visible corruption itself is timing-sensitive.

## Reliability Evidence

- **Invariant (`terminal-input.focus-report-ownership`):** an idle native-Windows Codex history resume must not forward exact xterm focus-in/out reports as composer input; non-Codex resumes and fresh Codex launches must continue receiving them.
- **Failure source:** the reported Agent Session History resume path can open a completed Codex composer with `?1004h` active and no pane status row, allowing literal `[I` / `[O` fragments through ConPTY.
- **Oracle:** the PTY transport tests assert exact filtered and forwarded byte sequences, preserve ordinary input, and prove suppression clears when Codex starts working. The focused file passes 449 tests.
- **Gate:** accepted gap — there is no dedicated `config/reliability-gates.jsonc` entry for this narrow focus-report invariant. The manifest validator passes, and the deterministic renderer-unit oracle is recorded here until a stable native-Windows Electron gate is added.
- **Provider/platform coverage:** local Windows ConPTY is covered. WSL, SSH, remote-runtime, mobile/relay, macOS, and Linux are unaffected by the existing native-ConPTY predicate and neighboring remote-safety tests.
- **Performance budget:** no polling, timers, subprocesses, IPC, provider calls, broad scans, or new subscriptions were added. Classification is constant work once at pane connection; the existing input path retains two exact-string comparisons.
- **Diagnostics:** a regression is visible as the exact focus bytes observed by the mock transport together with the pane startup metadata and agent-status transition.
- **Residual gap:** the real Windows focus handoff was validated manually and is covered by the PR's Windows terminal CI, but no dedicated automated Electron focus-report gate exists yet.