### PR TITLE
test(pty-connection): drain async confirm reads between tests to fix flaky CI

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -906,7 +906,16 @@ describe('connectPanePty', () => {
     globalThis.cancelAnimationFrame = vi.fn()
   })
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Why: pane foreground-agent trackers run async foreground-confirm reads
+    // (`confirmForegroundProcess`) whose continuations settle on the microtask
+    // queue, not on fake timers. A test that ends with one still in flight
+    // leaks it into the NEXT test, where it resolves against that test's fresh
+    // store mock and calls e.g. clearAgentLaunchConfig with THIS test's pane
+    // key — a flaky cross-test call-count failure (seen in CI). Drain pending
+    // microtasks while this test still owns the store mock, before fake timers
+    // are torn down, so each test absorbs its own async fallout.
+    await flushAsyncTicks()
     vi.useRealTimers()
     if (originalRequestAnimationFrame) {
       globalThis.requestAnimationFrame = originalRequestAnimationFrame


### PR DESCRIPTION
## Problem

The `verify` job intermittently fails in CI on the `connectPanePty` suite
(`src/renderer/src/components/terminal-pane/pty-connection.test.ts`) with a
`clearAgentLaunchConfig` call-count assertion, e.g.:

```
AssertionError: expected "vi.fn()" to be called once with arguments: [ Array(1) ]
Number of calls: 5
  2nd call: [ "tab-1:22222222-2222-4222-8222-222222222222" ]   // a DIFFERENT test's pane key
  5th call: [ "tab-1:22222222-2222-4222-8222-222222222222" ]
```

(This is what failed the `verify` check on #9254.)

## Root cause

Cross-test async leakage. Pane foreground-agent trackers
(`createPaneForegroundAgentTracker`) kick off `confirmForegroundProcess` reads
whose continuations settle on the **microtask queue**, not on fake timers. A
test that ends with one still in flight leaks it into the *next* test, where it
resolves against that test's freshly-reset store mock and calls
`clearAgentLaunchConfig` with the **prior** test's pane key. Because the store
mock's `getState()` always returns the current test's `mockStoreState`, the
stale continuation pollutes whichever test happens to be running when it
settles — hence the foreign `2222…` (LEAF_2) keys in a test that only uses
`1111…` (LEAF_1).

## Fix

Drain pending microtasks in `afterEach` (via the existing `flushAsyncTicks`
helper) **before** tearing down fake timers, while the test still owns its
store mock. Each test then absorbs its own async fallout instead of leaking it
forward. Behavior-only test-harness change; no product code touched.

## Validation

- Full file stays green: **446/446**, repeatedly (incl. under `--max-old-space-size=700` GC pressure).
- No regression; the change only adds a microtask drain to teardown.

### Honest caveat on reproducibility

This is a **CI-timing flake**: I could not reproduce it locally in isolation —
ordered runs pass repeatedly, and the delicate inter-test microtask timing that
triggers it only shows up under the full-suite CI environment. The fix targets
the one mechanism that can produce the exact error signature (a leaked async
continuation calling a store mutator with another test's pane key) and removes
the timing dependence. Nearly all reads in the affected path run under fake
timers, so a real-timer variant of the same leak is not the vector here.

Separately, I noticed running this file with `--sequence.shuffle` OOMs (runaway
allocation) — a **distinct, pre-existing** issue unrelated to the ordered CI
failure and out of scope for this PR; noting it for follow-up.
