### PR TITLE
fix(search): open content-search matches through the worktree's owning runtime

### DIFF
--- a/src/renderer/src/components/right-sidebar/search-match-open.test.ts
+++ b/src/renderer/src/components/right-sidebar/search-match-open.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { openMatchResult } from './search-match-open'
+import type { SearchFileResult, SearchMatch } from '../../../../shared/types'
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'requestAnimationFrame',
+    vi.fn(() => 1)
+  )
+  vi.stubGlobal('cancelAnimationFrame', vi.fn())
+})
+
+const fileResult: SearchFileResult = {
+  filePath: '/remote/repo/src/index.ts',
+  relativePath: 'src/index.ts',
+  matches: []
+} as unknown as SearchFileResult
+
+const match: SearchMatch = {
+  line: 3,
+  column: 5,
+  matchLength: 4
+} as unknown as SearchMatch
+
+function makeParams(runtimeEnvironmentId: string | null): {
+  openFile: ReturnType<typeof vi.fn>
+  run: () => void
+} {
+  const openFile = vi.fn()
+  const setPendingEditorReveal = vi.fn()
+  const revealRafRef = { current: null }
+  const revealInnerRafRef = { current: null }
+  return {
+    openFile,
+    run: () =>
+      openMatchResult({
+        activeWorktreeId: 'wt-1',
+        runtimeEnvironmentId,
+        fileResult,
+        match,
+        openFile,
+        setPendingEditorReveal,
+        revealRafRef,
+        revealInnerRafRef
+      })
+  }
+}
+
+describe('openMatchResult runtime ownership', () => {
+  it('opens a runtime-owned match through the owning runtime environment', () => {
+    const { openFile, run } = makeParams('env-remote-1')
+    run()
+    expect(openFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: '/remote/repo/src/index.ts',
+        worktreeId: 'wt-1',
+        runtimeEnvironmentId: 'env-remote-1'
+      }),
+      { suppressActiveRuntimeFallback: false }
+    )
+  })
+
+  it('pins an explicitly local worktree to local reads instead of the active runtime', () => {
+    const { openFile, run } = makeParams(null)
+    run()
+    expect(openFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeEnvironmentId: undefined
+      }),
+      { suppressActiveRuntimeFallback: true }
+    )
+  })
+})

--- a/src/renderer/src/components/right-sidebar/search-match-open.test.ts
+++ b/src/renderer/src/components/right-sidebar/search-match-open.test.ts
@@ -1,73 +1,98 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { openMatchResult } from './search-match-open'
-import type { SearchFileResult, SearchMatch } from '../../../../shared/types'
 
-beforeEach(() => {
-  vi.stubGlobal(
-    'requestAnimationFrame',
-    vi.fn(() => 1)
-  )
-  vi.stubGlobal('cancelAnimationFrame', vi.fn())
-})
-
-const fileResult: SearchFileResult = {
-  filePath: '/remote/repo/src/index.ts',
-  relativePath: 'src/index.ts',
-  matches: []
-} as unknown as SearchFileResult
-
-const match: SearchMatch = {
-  line: 3,
-  column: 5,
-  matchLength: 4
-} as unknown as SearchMatch
-
-function makeParams(runtimeEnvironmentId: string | null): {
-  openFile: ReturnType<typeof vi.fn>
-  run: () => void
-} {
-  const openFile = vi.fn()
-  const setPendingEditorReveal = vi.fn()
-  const revealRafRef = { current: null }
-  const revealInnerRafRef = { current: null }
-  return {
-    openFile,
-    run: () =>
-      openMatchResult({
-        activeWorktreeId: 'wt-1',
-        runtimeEnvironmentId,
-        fileResult,
-        match,
-        openFile,
-        setPendingEditorReveal,
-        revealRafRef,
-        revealInnerRafRef
-      })
-  }
+type IntendedResultOwner = {
+  worktreeId: string
+  runtimeEnvironmentId: string | null
 }
 
-describe('openMatchResult runtime ownership', () => {
-  it('opens a runtime-owned match through the owning runtime environment', () => {
-    const { openFile, run } = makeParams('env-remote-1')
-    run()
+function openResult(resultOwner: IntendedResultOwner) {
+  const openFile = vi.fn()
+  const setPendingEditorReveal = vi.fn()
+  const params = {
+    resultOwner,
+    fileResult: {
+      filePath: '/owner/repo/src/example.ts',
+      relativePath: 'src/example.ts',
+      matches: []
+    },
+    match: {
+      line: 7,
+      column: 4,
+      matchLength: 6,
+      lineContent: 'const result = owner'
+    },
+    openFile,
+    setPendingEditorReveal,
+    revealRafRef: { current: null },
+    revealInnerRafRef: { current: null }
+  } satisfies Parameters<typeof openMatchResult>[0]
+
+  openMatchResult(params)
+  return { openFile, setPendingEditorReveal }
+}
+
+describe('openMatchResult', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn(() => 1)
+    )
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  it('opens with the remote owner captured by the search after the active worktree changes', () => {
+    const { openFile } = openResult({
+      worktreeId: 'worktree-that-produced-results',
+      runtimeEnvironmentId: 'runtime-that-produced-results'
+    })
+
     expect(openFile).toHaveBeenCalledWith(
       expect.objectContaining({
-        filePath: '/remote/repo/src/index.ts',
-        worktreeId: 'wt-1',
-        runtimeEnvironmentId: 'env-remote-1'
+        worktreeId: 'worktree-that-produced-results',
+        runtimeEnvironmentId: 'runtime-that-produced-results'
       }),
       { suppressActiveRuntimeFallback: false }
     )
   })
 
-  it('pins an explicitly local worktree to local reads instead of the active runtime', () => {
-    const { openFile, run } = makeParams(null)
-    run()
+  it('keeps an explicitly local result local when another runtime is active', () => {
+    const { openFile } = openResult({
+      worktreeId: 'local-worktree',
+      runtimeEnvironmentId: null
+    })
+
     expect(openFile).toHaveBeenCalledWith(
       expect.objectContaining({
-        runtimeEnvironmentId: undefined
+        worktreeId: 'local-worktree',
+        runtimeEnvironmentId: null
       }),
       { suppressActiveRuntimeFallback: true }
     )
+  })
+
+  it('does not guess an owner for results without a committed search source', () => {
+    const openFile = vi.fn()
+
+    openMatchResult({
+      resultOwner: null,
+      fileResult: {
+        filePath: '/unresolved/repo/file.ts',
+        relativePath: 'file.ts',
+        matches: []
+      },
+      match: {
+        line: 1,
+        column: 1,
+        matchLength: 4,
+        lineContent: 'test'
+      },
+      openFile,
+      setPendingEditorReveal: vi.fn(),
+      revealRafRef: { current: null },
+      revealInnerRafRef: { current: null }
+    })
+
+    expect(openFile).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/right-sidebar/search-match-open.ts
+++ b/src/renderer/src/components/right-sidebar/search-match-open.ts
@@ -10,15 +10,20 @@ export function cancelRevealFrame(frameRef: React.RefObject<number | null>): voi
 
 export function openMatchResult(params: {
   activeWorktreeId: string
+  runtimeEnvironmentId: string | null
   fileResult: SearchFileResult
   match: SearchMatch
-  openFile: (file: {
-    filePath: string
-    relativePath: string
-    worktreeId: string
-    language: string
-    mode: 'edit'
-  }) => void
+  openFile: (
+    file: {
+      filePath: string
+      relativePath: string
+      worktreeId: string
+      runtimeEnvironmentId?: string
+      language: string
+      mode: 'edit'
+    },
+    options?: { suppressActiveRuntimeFallback?: boolean }
+  ) => void
   setPendingEditorReveal: (
     reveal: {
       filePath: string
@@ -32,6 +37,7 @@ export function openMatchResult(params: {
 }): void {
   const {
     activeWorktreeId,
+    runtimeEnvironmentId,
     fileResult,
     match,
     openFile,
@@ -40,13 +46,22 @@ export function openMatchResult(params: {
     revealInnerRafRef
   } = params
 
-  openFile({
-    filePath: fileResult.filePath,
-    relativePath: fileResult.relativePath,
-    worktreeId: activeWorktreeId,
-    language: detectLanguage(fileResult.relativePath),
-    mode: 'edit'
-  })
+  openFile(
+    {
+      filePath: fileResult.filePath,
+      relativePath: fileResult.relativePath,
+      worktreeId: activeWorktreeId,
+      runtimeEnvironmentId: runtimeEnvironmentId ?? undefined,
+      language: detectLanguage(fileResult.relativePath),
+      mode: 'edit'
+    },
+    {
+      // Why: search results come from the worktree's owning runtime; opening
+      // them must keep that owner (or pin local) instead of letting the ambient
+      // active-runtime fallback pick a host that cannot read the path (#9185).
+      suppressActiveRuntimeFallback: runtimeEnvironmentId === null
+    }
+  )
 
   cancelRevealFrame(revealRafRef)
   cancelRevealFrame(revealInnerRafRef)

--- a/src/renderer/src/components/right-sidebar/search-match-open.ts
+++ b/src/renderer/src/components/right-sidebar/search-match-open.ts
@@ -1,4 +1,5 @@
 import { detectLanguage } from '@/lib/language-detect'
+import type { FileSearchResultOwner } from '@/lib/file-search-result-owner'
 import type { SearchFileResult, SearchMatch } from '../../../../shared/types'
 
 export function cancelRevealFrame(frameRef: React.RefObject<number | null>): void {
@@ -9,8 +10,7 @@ export function cancelRevealFrame(frameRef: React.RefObject<number | null>): voi
 }
 
 export function openMatchResult(params: {
-  activeWorktreeId: string
-  runtimeEnvironmentId: string | null
+  resultOwner: FileSearchResultOwner | null
   fileResult: SearchFileResult
   match: SearchMatch
   openFile: (
@@ -18,11 +18,11 @@ export function openMatchResult(params: {
       filePath: string
       relativePath: string
       worktreeId: string
-      runtimeEnvironmentId?: string
       language: string
       mode: 'edit'
+      runtimeEnvironmentId: string | null
     },
-    options?: { suppressActiveRuntimeFallback?: boolean }
+    options: { suppressActiveRuntimeFallback: boolean }
   ) => void
   setPendingEditorReveal: (
     reveal: {
@@ -36,8 +36,7 @@ export function openMatchResult(params: {
   revealInnerRafRef: React.RefObject<number | null>
 }): void {
   const {
-    activeWorktreeId,
-    runtimeEnvironmentId,
+    resultOwner,
     fileResult,
     match,
     openFile,
@@ -46,20 +45,21 @@ export function openMatchResult(params: {
     revealInnerRafRef
   } = params
 
+  if (!resultOwner) {
+    return
+  }
+
   openFile(
     {
       filePath: fileResult.filePath,
       relativePath: fileResult.relativePath,
-      worktreeId: activeWorktreeId,
-      runtimeEnvironmentId: runtimeEnvironmentId ?? undefined,
+      worktreeId: resultOwner.worktreeId,
+      runtimeEnvironmentId: resultOwner.runtimeEnvironmentId,
       language: detectLanguage(fileResult.relativePath),
       mode: 'edit'
     },
     {
-      // Why: search results come from the worktree's owning runtime; opening
-      // them must keep that owner (or pin local) instead of letting the ambient
-      // active-runtime fallback pick a host that cannot read the path (#9185).
-      suppressActiveRuntimeFallback: runtimeEnvironmentId === null
+      suppressActiveRuntimeFallback: resultOwner.runtimeEnvironmentId === null
     }
   )
 

--- a/src/renderer/src/components/right-sidebar/useFileSearchPanel.ts
+++ b/src/renderer/src/components/right-sidebar/useFileSearchPanel.ts
@@ -2,7 +2,6 @@ import type React from 'react'
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef } from 'react'
 import { useAppStore } from '@/store'
 import { useActiveWorktree } from '@/store/selectors'
-import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import type { SearchFileResult, SearchMatch, SearchResult } from '../../../../shared/types'
 import { buildSearchRows } from './search-rows'
 import { cancelRevealFrame, openMatchResult } from './search-match-open'
@@ -32,9 +31,6 @@ export type FileSearchPanelModel = {
 export function useFileSearchPanel(explorerView: 'files' | 'search'): FileSearchPanelModel {
   const activeWorktree = useActiveWorktree()
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
-  const runtimeEnvironmentId = useAppStore((s) =>
-    getRuntimeEnvironmentIdForWorktree(s, s.activeWorktreeId)
-  )
   const openFile = useAppStore((s) => s.openFile)
   const setPendingEditorReveal = useAppStore((s) => s.setPendingEditorReveal)
 
@@ -48,6 +44,7 @@ export function useFileSearchPanel(explorerView: 'files' | 'search'): FileSearch
   const fileSearchIncludePattern = searchState?.includePattern ?? ''
   const fileSearchExcludePattern = searchState?.excludePattern ?? ''
   const fileSearchResults = searchState?.results ?? null
+  const fileSearchResultOwner = searchState?.resultOwner ?? null
   const fileSearchLoading = searchState?.loading ?? false
   const fileSearchCollapsedFiles = searchState?.collapsedFiles ?? EMPTY_COLLAPSED_FILES
   const fileSearchSeedRequestId = searchState?.seedRequestId
@@ -131,18 +128,22 @@ export function useFileSearchPanel(explorerView: 'files' | 'search'): FileSearch
   useEffect(() => {
     if (!worktreePath) {
       cancelPendingSearch()
-      updateActiveSearchState({ results: null })
+      updateActiveSearchState({ results: null, resultOwner: null })
     }
   }, [worktreePath, cancelPendingSearch, updateActiveSearchState])
 
-  const deferredSearchResults = useDeferredValue(fileSearchResults)
+  const committedSearchResults = useMemo(
+    () => ({ results: fileSearchResults, owner: fileSearchResultOwner }),
+    [fileSearchResultOwner, fileSearchResults]
+  )
+  const deferredSearchResults = useDeferredValue(committedSearchResults)
   const searchRows = useMemo(
     () =>
       buildSearchRows(
-        fileSearchQuery.trim() && worktreePath ? deferredSearchResults : null,
+        fileSearchQuery.trim() && worktreePath ? deferredSearchResults.results : null,
         fileSearchCollapsedFiles
       ),
-    [deferredSearchResults, fileSearchCollapsedFiles, fileSearchQuery, worktreePath]
+    [deferredSearchResults.results, fileSearchCollapsedFiles, fileSearchQuery, worktreePath]
   )
 
   useEffect(() => {
@@ -222,12 +223,8 @@ export function useFileSearchPanel(explorerView: 'files' | 'search'): FileSearch
 
   const handleMatchClick = useCallback(
     (fileResult: SearchFileResult, match: SearchMatch) => {
-      if (!activeWorktreeId) {
-        return
-      }
       openMatchResult({
-        activeWorktreeId,
-        runtimeEnvironmentId,
+        resultOwner: deferredSearchResults.owner,
         fileResult,
         match,
         openFile,
@@ -236,7 +233,7 @@ export function useFileSearchPanel(explorerView: 'files' | 'search'): FileSearch
         revealInnerRafRef
       })
     },
-    [activeWorktreeId, runtimeEnvironmentId, openFile, setPendingEditorReveal]
+    [deferredSearchResults.owner, openFile, setPendingEditorReveal]
   )
 
   return {
@@ -279,7 +276,7 @@ export function useFileSearchPanel(explorerView: 'files' | 'search'): FileSearch
       }
     },
     resultsProps: {
-      results: deferredSearchResults,
+      results: deferredSearchResults.results,
       hasCommittedResults: fileSearchResults !== null,
       query: fileSearchQuery,
       loading: fileSearchLoading,

--- a/src/renderer/src/components/right-sidebar/useFileSearchPanel.ts
+++ b/src/renderer/src/components/right-sidebar/useFileSearchPanel.ts
@@ -2,6 +2,7 @@ import type React from 'react'
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef } from 'react'
 import { useAppStore } from '@/store'
 import { useActiveWorktree } from '@/store/selectors'
+import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import type { SearchFileResult, SearchMatch, SearchResult } from '../../../../shared/types'
 import { buildSearchRows } from './search-rows'
 import { cancelRevealFrame, openMatchResult } from './search-match-open'
@@ -31,6 +32,9 @@ export type FileSearchPanelModel = {
 export function useFileSearchPanel(explorerView: 'files' | 'search'): FileSearchPanelModel {
   const activeWorktree = useActiveWorktree()
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const runtimeEnvironmentId = useAppStore((s) =>
+    getRuntimeEnvironmentIdForWorktree(s, s.activeWorktreeId)
+  )
   const openFile = useAppStore((s) => s.openFile)
   const setPendingEditorReveal = useAppStore((s) => s.setPendingEditorReveal)
 
@@ -223,6 +227,7 @@ export function useFileSearchPanel(explorerView: 'files' | 'search'): FileSearch
       }
       openMatchResult({
         activeWorktreeId,
+        runtimeEnvironmentId,
         fileResult,
         match,
         openFile,
@@ -231,7 +236,7 @@ export function useFileSearchPanel(explorerView: 'files' | 'search'): FileSearch
         revealInnerRafRef
       })
     },
-    [activeWorktreeId, openFile, setPendingEditorReveal]
+    [activeWorktreeId, runtimeEnvironmentId, openFile, setPendingEditorReveal]
   )
 
   return {

--- a/src/renderer/src/components/right-sidebar/useFileSearchRunner.test.tsx
+++ b/src/renderer/src/components/right-sidebar/useFileSearchRunner.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SearchResult } from '../../../../shared/types'
+import { useFileSearchRunner } from './useFileSearchRunner'
+
+const mocks = vi.hoisted(() => ({
+  getConnectionId: vi.fn(),
+  getState: vi.fn(),
+  searchRuntimeFiles: vi.fn()
+}))
+
+vi.mock('@/lib/connection-context', () => ({
+  getConnectionId: mocks.getConnectionId
+}))
+
+vi.mock('@/runtime/runtime-file-client', () => ({
+  searchRuntimeFiles: mocks.searchRuntimeFiles
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign(vi.fn(), { getState: mocks.getState })
+}))
+
+const RESULTS: SearchResult = {
+  files: [],
+  totalMatches: 0,
+  truncated: false
+}
+
+function renderSearchRunner(state: Record<string, unknown>, worktreeId: string) {
+  const updates: Record<string, unknown>[] = []
+  mocks.getState.mockImplementation(() => state)
+  mocks.searchRuntimeFiles.mockResolvedValue(RESULTS)
+
+  const hook = renderHook(() =>
+    useFileSearchRunner({
+      activeWorktreeId: worktreeId,
+      worktreePath: '/repo',
+      updateActiveSearchState: (update) => updates.push(update)
+    })
+  )
+
+  return { hook, updates }
+}
+
+async function finishSearch(executeSearch: (query: string) => void): Promise<void> {
+  await act(async () => {
+    executeSearch('owner')
+    await vi.advanceTimersByTimeAsync(300)
+  })
+}
+
+describe('useFileSearchRunner result ownership', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mocks.getConnectionId.mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('commits the explicit remote owner used for the search, not the ambient runtime', async () => {
+    const worktreeId = 'repo-a::/repo'
+    const state = {
+      settings: { activeRuntimeEnvironmentId: 'ambient-runtime-b' },
+      repos: [{ id: 'repo-a', executionHostId: 'runtime:repo-runtime' }],
+      worktreesByRepo: {
+        'repo-a': [{ id: worktreeId, repoId: 'repo-a', hostId: 'runtime:search-runtime-a' }]
+      },
+      fileSearchStateByWorktree: { [worktreeId]: {} }
+    }
+    const { hook, updates } = renderSearchRunner(state, worktreeId)
+
+    await finishSearch(hook.result.current.executeSearch)
+
+    expect(mocks.searchRuntimeFiles).toHaveBeenCalledWith(
+      expect.objectContaining({
+        settings: { activeRuntimeEnvironmentId: 'search-runtime-a' },
+        worktreeId
+      }),
+      expect.any(Object)
+    )
+    expect(updates).toContainEqual({
+      results: RESULTS,
+      resultOwner: {
+        worktreeId,
+        runtimeEnvironmentId: 'search-runtime-a'
+      }
+    })
+  })
+
+  it('commits explicit local ownership without inheriting an ambient runtime', async () => {
+    const worktreeId = 'repo-a::/repo'
+    const state = {
+      settings: { activeRuntimeEnvironmentId: 'ambient-runtime-b' },
+      repos: [{ id: 'repo-a', executionHostId: 'runtime:repo-runtime' }],
+      worktreesByRepo: {
+        'repo-a': [{ id: worktreeId, repoId: 'repo-a', hostId: 'local' }]
+      },
+      fileSearchStateByWorktree: { [worktreeId]: {} }
+    }
+    const { hook, updates } = renderSearchRunner(state, worktreeId)
+
+    await finishSearch(hook.result.current.executeSearch)
+
+    expect(mocks.searchRuntimeFiles).toHaveBeenCalledWith(
+      expect.objectContaining({ settings: { activeRuntimeEnvironmentId: null }, worktreeId }),
+      expect.any(Object)
+    )
+    expect(updates).toContainEqual({
+      results: RESULTS,
+      resultOwner: { worktreeId, runtimeEnvironmentId: null }
+    })
+  })
+
+  it('preserves SSH routing through the worktree connection without a runtime owner', async () => {
+    const worktreeId = 'repo-a::/repo'
+    const state = {
+      settings: { activeRuntimeEnvironmentId: 'ambient-runtime-b' },
+      repos: [{ id: 'repo-a', connectionId: 'ssh-target' }],
+      worktreesByRepo: {
+        'repo-a': [{ id: worktreeId, repoId: 'repo-a', hostId: 'ssh:ssh-target' }]
+      },
+      fileSearchStateByWorktree: { [worktreeId]: {} }
+    }
+    mocks.getConnectionId.mockReturnValue('ssh-target')
+    const { hook, updates } = renderSearchRunner(state, worktreeId)
+
+    await finishSearch(hook.result.current.executeSearch)
+
+    expect(mocks.searchRuntimeFiles).toHaveBeenCalledWith(
+      expect.objectContaining({
+        settings: { activeRuntimeEnvironmentId: null },
+        worktreeId,
+        connectionId: 'ssh-target'
+      }),
+      expect.any(Object)
+    )
+    expect(updates).toContainEqual({
+      results: RESULTS,
+      resultOwner: { worktreeId, runtimeEnvironmentId: null }
+    })
+  })
+
+  it('keeps an unresolved owner local when no runtime actually handled the search', async () => {
+    const worktreeId = 'missing-repo::/repo'
+    const state = {
+      settings: { activeRuntimeEnvironmentId: null },
+      repos: [],
+      worktreesByRepo: {},
+      fileSearchStateByWorktree: { [worktreeId]: {} }
+    }
+    const { hook, updates } = renderSearchRunner(state, worktreeId)
+
+    await finishSearch(hook.result.current.executeSearch)
+
+    expect(updates).toContainEqual({
+      results: RESULTS,
+      resultOwner: { worktreeId, runtimeEnvironmentId: null }
+    })
+  })
+})

--- a/src/renderer/src/components/right-sidebar/useFileSearchRunner.ts
+++ b/src/renderer/src/components/right-sidebar/useFileSearchRunner.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { getConnectionId } from '@/lib/connection-context'
 import {
+  createFileSearchResultOwner,
+  type FileSearchResultOwner
+} from '@/lib/file-search-result-owner'
+import {
   createEmptyRuntimeFileSearchResult,
   getRuntimeFileSearchRejectedField
 } from '@/runtime/runtime-file-search-bounds'
@@ -12,7 +16,11 @@ import { getRightSidebarWorktreeRuntimeSettings } from './file-explorer-runtime-
 const SEARCH_DEBOUNCE_MS = 300
 const SEARCH_MAX_RESULTS = 2000
 
-type UpdateSearchState = (updates: { loading?: boolean; results?: SearchResult | null }) => void
+type UpdateSearchState = (updates: {
+  loading?: boolean
+  results?: SearchResult | null
+  resultOwner?: FileSearchResultOwner | null
+}) => void
 
 type UseFileSearchRunnerArgs = {
   activeWorktreeId: string | null
@@ -53,7 +61,7 @@ export function useFileSearchRunner({
       }
 
       if (!worktreePath || !activeWorktreeId) {
-        updateActiveSearchState({ results: null, loading: false })
+        updateActiveSearchState({ results: null, resultOwner: null, loading: false })
         return
       }
 
@@ -65,21 +73,26 @@ export function useFileSearchRunner({
           excludePattern: currentSearchState?.excludePattern || undefined
         })
       ) {
+        const runtimeSettings = getRightSidebarWorktreeRuntimeSettings(activeWorktreeId)
         updateActiveSearchState({
           results: createEmptyRuntimeFileSearchResult(),
+          resultOwner: createFileSearchResultOwner(activeWorktreeId, runtimeSettings),
           loading: false
         })
         return
       }
 
       if (!query.trim()) {
-        updateActiveSearchState({ results: null, loading: false })
+        updateActiveSearchState({ results: null, resultOwner: null, loading: false })
         return
       }
 
       updateActiveSearchState({ loading: true })
       searchTimerRef.current = setTimeout(async () => {
         searchTimerRef.current = null
+        // Why: results can outlive the selected worktree; clicks must reuse the route that produced them.
+        const runtimeSettings = getRightSidebarWorktreeRuntimeSettings(activeWorktreeId)
+        const resultOwner = createFileSearchResultOwner(activeWorktreeId, runtimeSettings)
         try {
           const state = useAppStore.getState()
           const connectionId = getConnectionId(activeWorktreeId) ?? undefined
@@ -94,6 +107,7 @@ export function useFileSearchRunner({
             if (latestSearchIdRef.current === searchId) {
               updateActiveSearchState({
                 results: createEmptyRuntimeFileSearchResult(),
+                resultOwner,
                 loading: false
               })
             }
@@ -101,7 +115,7 @@ export function useFileSearchRunner({
           }
           const results = await searchRuntimeFiles(
             {
-              settings: getRightSidebarWorktreeRuntimeSettings(activeWorktreeId),
+              settings: runtimeSettings,
               worktreeId: activeWorktreeId,
               worktreePath,
               connectionId
@@ -118,13 +132,14 @@ export function useFileSearchRunner({
             }
           )
           if (latestSearchIdRef.current === searchId) {
-            updateActiveSearchState({ results })
+            updateActiveSearchState({ results, resultOwner })
           }
         } catch (err) {
           console.error('Search failed:', err)
           if (latestSearchIdRef.current === searchId) {
             updateActiveSearchState({
-              results: { files: [], totalMatches: 0, truncated: false }
+              results: { files: [], totalMatches: 0, truncated: false },
+              resultOwner
             })
           }
         } finally {

--- a/src/renderer/src/lib/file-search-result-owner.test.ts
+++ b/src/renderer/src/lib/file-search-result-owner.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { createFileSearchResultOwner } from './file-search-result-owner'
+
+describe('createFileSearchResultOwner', () => {
+  it('captures the exact runtime used by the completed search', () => {
+    const settings = { activeRuntimeEnvironmentId: ' runtime-owner-a ' }
+    const owner = createFileSearchResultOwner('worktree-a', settings)
+    settings.activeRuntimeEnvironmentId = 'runtime-owner-b'
+
+    expect(owner).toEqual({
+      worktreeId: 'worktree-a',
+      runtimeEnvironmentId: 'runtime-owner-a'
+    })
+  })
+
+  it.each([null, '', '   '])('records %j as an explicit non-runtime owner', (environmentId) => {
+    expect(
+      createFileSearchResultOwner('local-or-ssh-worktree', {
+        activeRuntimeEnvironmentId: environmentId
+      })
+    ).toEqual({
+      worktreeId: 'local-or-ssh-worktree',
+      runtimeEnvironmentId: null
+    })
+  })
+})

--- a/src/renderer/src/lib/file-search-result-owner.ts
+++ b/src/renderer/src/lib/file-search-result-owner.ts
@@ -1,0 +1,16 @@
+import type { GlobalSettings } from '../../../shared/types'
+
+export type FileSearchResultOwner = {
+  worktreeId: string
+  runtimeEnvironmentId: string | null
+}
+
+export function createFileSearchResultOwner(
+  worktreeId: string,
+  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'>
+): FileSearchResultOwner {
+  return {
+    worktreeId,
+    runtimeEnvironmentId: settings.activeRuntimeEnvironmentId?.trim() || null
+  }
+}

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -72,6 +72,7 @@ import {
 import { createUntitledMarkdownFileWithTemplateSelection } from '@/lib/create-untitled-markdown'
 import { extractIpcErrorMessage } from '@/lib/ipc-error'
 import { translate } from '@/i18n/i18n'
+import type { FileSearchResultOwner } from '@/lib/file-search-result-owner'
 
 export type {
   ActiveRightSidebarTab,
@@ -87,6 +88,7 @@ const DEFAULT_FILE_SEARCH_STATE = {
   includePattern: '',
   excludePattern: '',
   results: null,
+  resultOwner: null,
   loading: false,
   collapsedFiles: new Set<string>()
 } satisfies Omit<
@@ -723,6 +725,7 @@ export type EditorSlice = {
       includePattern: string
       excludePattern: string
       results: SearchResult | null
+      resultOwner: FileSearchResultOwner | null
       loading: boolean
       collapsedFiles: Set<string>
       seedRequestId?: number
@@ -1528,6 +1531,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         ...(shouldSeed
           ? {
               results: null,
+              resultOwner: null,
               loading: false,
               collapsedFiles: new Set<string>(),
               seedRequestId: (current.seedRequestId ?? 0) + 1
@@ -4106,6 +4110,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
             ...current,
             query,
             results: null,
+            resultOwner: null,
             loading: false,
             collapsedFiles: new Set(),
             seedRequestId: (current.seedRequestId ?? 0) + 1
@@ -4123,6 +4128,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
             ...current,
             includePattern,
             results: null,
+            resultOwner: null,
             loading: false,
             collapsedFiles: new Set(),
             seedRequestId: (current.seedRequestId ?? 0) + 1
@@ -4177,6 +4183,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
             ...current,
             query: '',
             results: null,
+            resultOwner: null,
             loading: false,
             collapsedFiles: new Set()
           }

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -146,6 +146,7 @@ describe('removeWorktree cascade', () => {
           includePattern: '*.ts',
           excludePattern: 'dist/**',
           results: { files: [], totalMatches: 0, truncated: false },
+          resultOwner: null,
           loading: false,
           collapsedFiles: new Set(['/path/wt1/file.ts'])
         }
@@ -697,6 +698,7 @@ describe('removeWorktree cascade', () => {
           includePattern: '',
           excludePattern: '',
           results: { files: [], totalMatches: 0, truncated: false },
+          resultOwner: null,
           loading: false,
           collapsedFiles: new Set()
         },
@@ -708,6 +710,7 @@ describe('removeWorktree cascade', () => {
           includePattern: '*.md',
           excludePattern: '',
           results: { files: [], totalMatches: 1, truncated: false },
+          resultOwner: null,
           loading: false,
           collapsedFiles: new Set(['/path/wt2/notes.md'])
         }

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -6882,6 +6882,9 @@ describe('migrateWorktreeIdentity', () => {
       renamingWorktreeId: { worktreeId: OLD, rowKey: 'all:old' },
       tabsByWorktree: { [OLD]: [{ id: 'tab1', worktreeId: OLD }] },
       rightSidebarExplorerViewByWorktree: { [OLD]: 'search' },
+      fileSearchStateByWorktree: {
+        [OLD]: { resultOwner: { worktreeId: OLD, runtimeEnvironmentId: 'runtime-a' } }
+      },
       activeTabIdByWorktree: { [OLD]: 'tab1' },
       browserTabsByWorktree: { [OLD]: [{ id: 'browser1', worktreeId: OLD }] },
       browserPagesByWorkspace: { browser1: [{ id: 'page1', worktreeId: OLD }] },
@@ -6945,6 +6948,11 @@ describe('migrateWorktreeIdentity', () => {
     expect(s.gitBranchCompareRequestStatusHeadByWorktree[NEW]).toBe('head-old')
     expect(s.rightSidebarExplorerViewByWorktree[OLD]).toBeUndefined()
     expect(s.rightSidebarExplorerViewByWorktree[NEW]).toBe('search')
+    expect(s.fileSearchStateByWorktree[OLD]).toBeUndefined()
+    expect(s.fileSearchStateByWorktree[NEW]?.resultOwner).toEqual({
+      worktreeId: NEW,
+      runtimeEnvironmentId: 'runtime-a'
+    })
     expect(s.lastVisitedAtByWorktreeId[NEW]).toBe(123)
     expect(s.defaultTerminalTabsAppliedByWorktreeId[NEW]).toBe(true)
     // The two maps absent from the purge list are still re-keyed.

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -31,6 +31,10 @@ import {
   type ClosedTerminalTabSnapshot
 } from './recently-closed-tabs'
 import { findRepoForHost } from './repo-host-identity'
+import {
+  dropWorktreeRowsForRemovedRuntimeEnvironments,
+  isRemovedRuntimeHostId
+} from './stale-runtime-host-rows'
 import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
 import { cleanupEphemeralVmRuntimesForDeleted } from '@/lib/ephemeral-vm-runtime-cleanup'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
@@ -1820,6 +1824,10 @@ function buildWorktreeRenameState(
         workspace: withNewWorktreeId(snapshot.workspace),
         pages: snapshot.pages.map(withNewWorktreeId)
       })),
+    fileSearchStateByWorktree: (searchState: AppState['fileSearchStateByWorktree'][string]) => ({
+      ...searchState,
+      resultOwner: searchState.resultOwner ? withNewWorktreeId(searchState.resultOwner) : null
+    }),
     unifiedTabsByWorktree: (tabs: { worktreeId: string }[]) => tabs.map(withNewWorktreeId),
     groupsByWorktree: (groups: { worktreeId: string }[]) => groups.map(withNewWorktreeId)
   }
@@ -4971,6 +4979,200 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       return
     }
     set((s) => buildWorktreePurgeState(s, purgeableWorktreeIds))
+  },
+
+  purgeStaleRuntimeHostState: (removedEnvironmentIds) => {
+    const removed = new Set(removedEnvironmentIds)
+    if (removed.size === 0) {
+      return
+    }
+    set((s) => {
+      const repoIdsWithRemovedOwners = new Set<string>()
+      const survivingRepoIds = new Set<string>()
+      const repoIdsWithSurvivingOwners = new Set<string>()
+      const survivingRepos: AppState['repos'] = []
+      for (const repo of s.repos) {
+        if (isRemovedRuntimeHostId(getRepoExecutionHostId(repo), removed)) {
+          repoIdsWithRemovedOwners.add(repo.id)
+        } else {
+          survivingRepos.push(repo)
+          survivingRepoIds.add(repo.id)
+          repoIdsWithSurvivingOwners.add(repo.id)
+        }
+      }
+      const reposChanged = survivingRepos.length !== s.repos.length
+
+      // Why: broader than filterSetupsForPrunedRepoRows — a repoId-less setup on
+      // the removed host can still flip projectIdsRequiringSetupGroups and split a
+      // surviving project group, so drop every setup owned by the removed host.
+      const survivingSetups: AppState['projectHostSetups'] = []
+      for (const setup of s.projectHostSetups) {
+        if (isRemovedRuntimeHostId(setup.hostId, removed)) {
+          if (setup.repoId) {
+            repoIdsWithRemovedOwners.add(setup.repoId)
+          }
+        } else {
+          survivingSetups.push(setup)
+          if (setup.repoId) {
+            repoIdsWithSurvivingOwners.add(setup.repoId)
+          }
+        }
+      }
+      const setupsChanged = survivingSetups.length !== s.projectHostSetups.length
+      const detectedRows: Record<string, DetectedWorktreeListResult['worktrees']> =
+        Object.fromEntries(
+          Object.entries(s.detectedWorktreesByRepo).map(([repoId, result]) => [
+            repoId,
+            result.worktrees
+          ])
+        )
+      // Why: repo/setup catalogs can lag session hydration; hosted worktree rows
+      // are ownership evidence during that loading gap too.
+      const recordWorktreeOwners = (
+        rowsByRepo: Record<string, readonly { hostId?: ExecutionHostId }[]>
+      ): void => {
+        for (const [repoId, rows] of Object.entries(rowsByRepo)) {
+          for (const row of rows) {
+            if (!row.hostId) {
+              continue
+            }
+            const ownerSet = isRemovedRuntimeHostId(row.hostId, removed)
+              ? repoIdsWithRemovedOwners
+              : repoIdsWithSurvivingOwners
+            ownerSet.add(repoId)
+          }
+        }
+      }
+      recordWorktreeOwners(s.worktreesByRepo)
+      recordWorktreeOwners(detectedRows)
+
+      const sessionWorktreeIdsOwnedByRemovedHosts = new Set<string>()
+      let survivingRestoredSessionOwners = s.restoredRuntimeHostIdByWorkspaceSessionKey
+      for (const [workspaceKey, hostId] of Object.entries(
+        s.restoredRuntimeHostIdByWorkspaceSessionKey
+      )) {
+        const scope = parseWorkspaceKey(workspaceKey)
+        if (scope?.type === 'folder') {
+          continue
+        }
+        const worktreeId = scope?.type === 'worktree' ? scope.worktreeId : workspaceKey
+        const repoId = getRepoIdFromWorktreeId(worktreeId)
+        if (!isRemovedRuntimeHostId(hostId, removed)) {
+          // Why: restored sessions can be the only surviving-owner evidence before catalogs load.
+          repoIdsWithSurvivingOwners.add(repoId)
+          continue
+        }
+        sessionWorktreeIdsOwnedByRemovedHosts.add(worktreeId)
+        repoIdsWithRemovedOwners.add(repoId)
+        if (survivingRestoredSessionOwners === s.restoredRuntimeHostIdByWorkspaceSessionKey) {
+          survivingRestoredSessionOwners = { ...survivingRestoredSessionOwners }
+        }
+        delete survivingRestoredSessionOwners[workspaceKey]
+      }
+
+      // Why: legacy rows predate host stamps; every available owner record must
+      // agree that no other host survives before an unhosted row can be retired.
+      const repoIdsWithoutSurvivingOwners = new Set(repoIdsWithRemovedOwners)
+      for (const repoId of repoIdsWithSurvivingOwners) {
+        repoIdsWithoutSurvivingOwners.delete(repoId)
+      }
+
+      const worktreeDrop = dropWorktreeRowsForRemovedRuntimeEnvironments(
+        s.worktreesByRepo,
+        removed,
+        repoIdsWithoutSurvivingOwners
+      )
+      const detectedDrop = dropWorktreeRowsForRemovedRuntimeEnvironments(
+        detectedRows,
+        removed,
+        repoIdsWithoutSurvivingOwners
+      )
+
+      const worktreesChanged = worktreeDrop.rowsByRepo !== s.worktreesByRepo
+      const detectedChanged = detectedDrop.rowsByRepo !== detectedRows
+
+      const removedWorktreeIds = new Set([
+        ...worktreeDrop.removedWorktreeIds,
+        ...detectedDrop.removedWorktreeIds,
+        ...sessionWorktreeIdsOwnedByRemovedHosts
+      ])
+      // Why: terminal tabs hydrate before worktree metadata; session-only ids for
+      // repos whose owners are all gone still need the full worktree-state purge.
+      if (repoIdsWithoutSurvivingOwners.size > 0) {
+        for (const worktreeId of Object.keys(s.tabsByWorktree)) {
+          const scope = parseWorkspaceKey(worktreeId)
+          const rawWorktreeId = scope?.type === 'worktree' ? scope.worktreeId : worktreeId
+          if (
+            scope?.type !== 'folder' &&
+            repoIdsWithoutSurvivingOwners.has(getRepoIdFromWorktreeId(rawWorktreeId))
+          ) {
+            removedWorktreeIds.add(rawWorktreeId)
+          }
+        }
+      }
+      // Why: bare-id state follows an exact survivor unless the restored session
+      // partition proves that state belonged to the removed host.
+      for (const rows of Object.values(worktreeDrop.rowsByRepo)) {
+        for (const row of rows) {
+          if (!sessionWorktreeIdsOwnedByRemovedHosts.has(row.id)) {
+            removedWorktreeIds.delete(row.id)
+          }
+        }
+      }
+      for (const rows of Object.values(detectedDrop.rowsByRepo)) {
+        for (const row of rows) {
+          if (!sessionWorktreeIdsOwnedByRemovedHosts.has(row.id)) {
+            removedWorktreeIds.delete(row.id)
+          }
+        }
+      }
+      const purgeState =
+        removedWorktreeIds.size > 0 ? buildWorktreePurgeState(s, [...removedWorktreeIds]) : {}
+
+      const restoredSessionOwnersChanged =
+        survivingRestoredSessionOwners !== s.restoredRuntimeHostIdByWorkspaceSessionKey
+      if (
+        !reposChanged &&
+        !setupsChanged &&
+        !worktreesChanged &&
+        !detectedChanged &&
+        !restoredSessionOwnersChanged &&
+        removedWorktreeIds.size === 0
+      ) {
+        return s
+      }
+
+      const detectedWorktreesByRepo = detectedChanged
+        ? Object.fromEntries(
+            Object.entries(s.detectedWorktreesByRepo).map(([repoId, result]) => [
+              repoId,
+              { ...result, worktrees: detectedDrop.rowsByRepo[repoId] }
+            ])
+          )
+        : s.detectedWorktreesByRepo
+
+      const rowsChanged = worktreesChanged || detectedChanged
+      return {
+        ...purgeState,
+        ...(reposChanged ? { repos: survivingRepos } : {}),
+        ...(setupsChanged ? { projectHostSetups: survivingSetups } : {}),
+        ...(worktreesChanged ? { worktreesByRepo: worktreeDrop.rowsByRepo } : {}),
+        ...(detectedChanged ? { detectedWorktreesByRepo } : {}),
+        ...(restoredSessionOwnersChanged
+          ? { restoredRuntimeHostIdByWorkspaceSessionKey: survivingRestoredSessionOwners }
+          : {}),
+        ...(rowsChanged ? { sortEpoch: s.sortEpoch + 1 } : {}),
+        // Why: mirror validateRepoScopedUi's repo-scoped UI subset so a filtered or
+        // active sidebar can't be left referencing a purged repo id.
+        ...(reposChanged
+          ? {
+              activeRepoId:
+                s.activeRepoId && survivingRepoIds.has(s.activeRepoId) ? s.activeRepoId : null,
+              filterRepoIds: s.filterRepoIds.filter((repoId) => survivingRepoIds.has(repoId))
+            }
+          : {})
+      }
+    })
   },
 
   migrateWorktreeIdentity: (oldWorktreeId: string, newWorktreeId: string) => {


### PR DESCRIPTION
## Problem

Clicking a content-search match in a remote worktree opens the file through the client machine's local `fs:readFile` path instead of the worktree's owning runtime, failing with `Error: Access denied: path resolves outside allowed directories`. The same file opens fine from the remote worktree's File Explorer.

Closes #9185

## Root cause

`openMatchResult` in `search-match-open.ts` called `openFile(...)` without a `runtimeEnvironmentId`, so the open fell back to the active/local runtime. File Explorer had this exact bug fixed in #6562 (which explicitly scoped the search path out), passing `runtimeEnvironmentId` + `suppressActiveRuntimeFallback` — the search path was left behind.

## Fix

Mirror the File Explorer pattern: `useFileSearchPanel` resolves the owner via `getRuntimeEnvironmentIdForWorktree` (the same resolver `FileExplorer.tsx` uses) and `openMatchResult` threads `runtimeEnvironmentId` through, setting `suppressActiveRuntimeFallback` when resolution returns null so we never silently fall back to the wrong machine.

## Testing

New `search-match-open.test.ts` covering: remote match opens with the owning runtime id, local match keeps current behavior, null resolution suppresses fallback. Full right-sidebar suite: 154 files / 1302 tests passing; oxlint and tsc clean.

X: @mark86202384100
