### PR TITLE
fix(grok): Windows hook GROK_HOME safety + pure pending discovery

### DIFF
--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -555,12 +555,16 @@ describe('wrapWindowsCmdHookCommand', () => {
 })
 
 describe('wrapWindowsGitBashHookCommand', () => {
-  it('guards the forward-slash fast path and drains when missing', () => {
+  it('returns a bare forward-slash path for a bash-safe managed script', () => {
+    // Why: Claude Git Bash can run the bare .cmd; Grok compat-loads the same
+    // settings.json command and must CreateProcess a single spawnable token —
+    // not a bash `if [ -f … ]` compound (exit 1 under cmd / direct spawn).
     expect(
       wrapWindowsGitBashHookCommand('C:\\Users\\alice\\.orca\\agent-hooks\\claude-hook.cmd')
-    ).toBe(
-      `if [ -f 'C:/Users/alice/.orca/agent-hooks/claude-hook.cmd' ]; then 'C:/Users/alice/.orca/agent-hooks/claude-hook.cmd'; else ${POSIX_HOOK_STDIN_DRAIN_COMMAND}; fi`
-    )
+    ).toBe('C:/Users/alice/.orca/agent-hooks/claude-hook.cmd')
+    expect(
+      wrapWindowsGitBashHookCommand('C:\\Users\\alice\\.orca\\agent-hooks\\claude-hook.cmd')
+    ).not.toMatch(/^if\b/)
   })
 
   it('falls back to the encoded launcher when bash would split the path', () => {

--- a/src/main/agent-hooks/installer-utils.ts
+++ b/src/main/agent-hooks/installer-utils.ts
@@ -155,10 +155,15 @@ export const WINDOWS_GIT_BASH_SAFE_PATH = /^[A-Za-z0-9_.:/~-]+$/
 
 export function wrapWindowsGitBashHookCommand(scriptPath: string): string {
   const bashPath = scriptPath.replaceAll('\\', '/')
-  // Why: Claude's Git Bash runner can execute a forward-slash .cmd directly; unsafe paths stay encoded.
-  return WINDOWS_GIT_BASH_SAFE_PATH.test(bashPath)
-    ? `if [ -f ${quotePosixShellString(bashPath)} ]; then ${quotePosixShellString(bashPath)}; else ${POSIX_HOOK_STDIN_DRAIN_COMMAND}; fi`
-    : wrapWindowsHookCommand(scriptPath)
+  // Why: Claude's Git Bash runner can execute a forward-slash .cmd directly.
+  // The safe-path fast path must remain a single spawnable token (bare path),
+  // not a bash `if [ -f … ]` compound: Grok (and any CreateProcess-style runner)
+  // loads ~/.claude/settings.json hooks via [compat.claude] and launches the
+  // command without Git Bash, so a bash guard fails every hook with exit 1
+  // ("-f was unexpected"). Same trade-off as wrapWindowsCmdHookCommand / #8737:
+  // missing-script stdin drain lives on the encoded-PowerShell fallback used for
+  // spaced/metacharacter paths.
+  return WINDOWS_GIT_BASH_SAFE_PATH.test(bashPath) ? bashPath : wrapWindowsHookCommand(scriptPath)
 }
 
 export function buildWindowsAgentHookPostCommand(source: AgentHookSource): string {

--- a/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
+++ b/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
@@ -28,25 +28,6 @@ afterEach(() => {
   rmSync(isolatedUserDataDir, { recursive: true, force: true })
 })
 
-function findGitBash(): string {
-  if (process.env.KIMI_SHELL_PATH) {
-    return process.env.KIMI_SHELL_PATH
-  }
-  const candidates = [
-    process.env.ProgramFiles && join(process.env.ProgramFiles, 'Git', 'bin', 'bash.exe'),
-    process.env['ProgramFiles(x86)'] &&
-      join(process.env['ProgramFiles(x86)'], 'Git', 'bin', 'bash.exe'),
-    process.env.LOCALAPPDATA && join(process.env.LOCALAPPDATA, 'Programs', 'Git', 'bin', 'bash.exe')
-  ]
-  const bash = candidates.find((candidate): candidate is string =>
-    Boolean(candidate && existsSync(candidate))
-  )
-  if (!bash) {
-    throw new Error('Git Bash is required for the Windows Kimi hook lifecycle test')
-  }
-  return bash
-}
-
 const { homedirMock } = vi.hoisted(() => ({
   homedirMock: vi.fn<() => string>()
 }))
@@ -201,9 +182,13 @@ function hookEnvironment(extraEnv: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   }
 }
 
-/** Prefer a real Git Bash on Windows; Store `bash.exe` stubs often exit 127. */
-function resolveWindowsTestBash(): string {
-  if (process.env.KIMI_SHELL_PATH) {
+/**
+ * Prefer a real Git Bash on Windows; Store `bash.exe` stubs often exit 127.
+ * Returns null when no on-disk executable is found so callers can skip instead
+ * of spawning a PATH lookup that may not exist (or is a broken stub).
+ */
+function resolveWindowsTestBash(): string | null {
+  if (process.env.KIMI_SHELL_PATH && existsSync(process.env.KIMI_SHELL_PATH)) {
     return process.env.KIMI_SHELL_PATH
   }
   const candidates = [
@@ -226,7 +211,7 @@ function resolveWindowsTestBash(): string {
       return candidate
     }
   }
-  return 'bash.exe'
+  return null
 }
 
 // Why: the Git Bash safe-path tests only exercise the bare `.cmd` fast path when
@@ -356,7 +341,6 @@ describe('Windows managed hook stdin structure', () => {
       const home = mkdtempSync(join(tmpdir(), 'orca-hook-stdin-windows-live-'))
       homedirMock.mockReturnValue(home)
       try {
-        const gitBash = findGitBash()
         for (const entry of LOCAL_INSTALLERS) {
           expect(entry.install().state, `${entry.agent} install status`).toBe('installed')
         }
@@ -369,24 +353,32 @@ describe('Windows managed hook stdin structure', () => {
             (name.endsWith('-hook.cmd') && !name.startsWith('antigravity-'))
         )
         expect(mainScripts).toHaveLength(12)
+        const gitBash = resolveWindowsTestBash()
         for (const fileName of mainScripts) {
           const scriptPath = join(hooksDir, fileName)
+          if (fileName.endsWith('.sh')) {
+            if (!gitBash) {
+              // No verified Git Bash on this host — skip .sh live spawn rather
+              // than shell out to a missing/stub `bash.exe` PATH lookup.
+              continue
+            }
+            const result = await runHookProcess(gitBash, [scriptPath], hookEnvironment())
+            expect(result.exitCode, `${fileName} exit code`).toBe(0)
+            expect(result.stdinErrors, `${fileName} stdin errors`).toHaveLength(0)
+            continue
+          }
           const executable = fileName.endsWith('.cmd')
             ? 'cmd.exe'
-            : fileName.endsWith('.ps1')
-              ? join(
-                  process.env.SystemRoot ?? 'C:\\Windows',
-                  'System32',
-                  'WindowsPowerShell',
-                  'v1.0',
-                  'powershell.exe'
-                )
-              : gitBash
+            : join(
+                process.env.SystemRoot ?? 'C:\\Windows',
+                'System32',
+                'WindowsPowerShell',
+                'v1.0',
+                'powershell.exe'
+              )
           const args = fileName.endsWith('.cmd')
             ? ['/d', '/c', scriptPath]
-            : fileName.endsWith('.ps1')
-              ? ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', scriptPath]
-              : [scriptPath]
+            : ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', scriptPath]
           const result = await runHookProcess(executable, args, hookEnvironment())
           expect(result.exitCode, `${fileName} exit code`).toBe(0)
           expect(result.stdinErrors, `${fileName} stdin errors`).toHaveLength(0)
@@ -454,11 +446,12 @@ describe('Windows managed hook stdin structure', () => {
           /powershell\.exe/i
         )
         expect(command).toBe(claudeScript.replaceAll('\\', '/'))
-        const result = await runHookProcess(
-          resolveWindowsTestBash(),
-          ['-c', command],
-          hookEnvironment()
-        )
+        const gitBash = resolveWindowsTestBash()
+        if (!gitBash) {
+          ctx.skip()
+          return
+        }
+        const result = await runHookProcess(gitBash, ['-c', command], hookEnvironment())
         expect(result.exitCode, 'claude git bash bare .cmd exit code').toBe(0)
         expect(result.stdinErrors, 'claude git bash bare .cmd stdin errors').toHaveLength(0)
       } finally {

--- a/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
+++ b/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
@@ -78,6 +78,7 @@ import { GrokHookService } from '../grok/hook-service'
 import { KimiHookService } from '../kimi/hook-service'
 import { openClaudeHookService } from '../openclaude/hook-service'
 import {
+  WINDOWS_GIT_BASH_SAFE_PATH,
   wrapPosixHookCommand,
   wrapWindowsGitBashHookCommand,
   wrapWindowsHookCommand
@@ -198,6 +199,56 @@ function hookEnvironment(extraEnv: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
     ORCA_AGENT_HOOK_ENDPOINT: '',
     ...extraEnv
   }
+}
+
+/** Prefer a real Git Bash on Windows; Store `bash.exe` stubs often exit 127. */
+function resolveWindowsTestBash(): string {
+  if (process.env.KIMI_SHELL_PATH) {
+    return process.env.KIMI_SHELL_PATH
+  }
+  const candidates = [
+    join(process.env.ProgramFiles ?? 'C:\\Program Files', 'Git', 'bin', 'bash.exe'),
+    join(process.env['ProgramFiles(x86)'] ?? 'C:\\Program Files (x86)', 'Git', 'bin', 'bash.exe'),
+    // Why: derive Git Bash from a Git dir on PATH instead of hardcoding an
+    // install location, so a non-default Git resolves on any Windows dev/CI box.
+    // Cover both the `Git\bin` and `Git\cmd` PATH layouts (bash lives under bin).
+    ...(process.env.PATH ?? '')
+      .split(';')
+      .filter((dir) => /\bgit\b/i.test(dir))
+      .flatMap((dir) => [
+        join(dir, 'bash.exe'),
+        join(dir, '..', 'bin', 'bash.exe'),
+        join(dir, '..', 'usr', 'bin', 'bash.exe')
+      ])
+  ]
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate
+    }
+  }
+  return 'bash.exe'
+}
+
+// Why: the Git Bash safe-path tests only exercise the bare `.cmd` fast path when
+// the fixture home is bash-safe (WINDOWS_GIT_BASH_SAFE_PATH). tmpdir() alone can
+// carry spaces/metacharacters (spaced usernames, redirected TEMP), which would
+// silently route to the PowerShell fallback and make those tests vacuously pass.
+// Try each writable root until mkdtemp yields a bash-safe path; '' means no safe
+// root exists here, so the caller skips instead of asserting nothing.
+function mkdtempBashSafe(prefix: string): string {
+  for (const root of [tmpdir(), process.cwd()]) {
+    let dir: string
+    try {
+      dir = mkdtempSync(join(root, prefix))
+    } catch {
+      continue
+    }
+    if (WINDOWS_GIT_BASH_SAFE_PATH.test(dir.replaceAll('\\', '/'))) {
+      return dir
+    }
+    rmSync(dir, { recursive: true, force: true })
+  }
+  return ''
 }
 
 function runPosixHook(command: string, extraEnv: NodeJS.ProcessEnv = {}): Promise<HookRun> {
@@ -341,31 +392,124 @@ describe('Windows managed hook stdin structure', () => {
           expect(result.stdinErrors, `${fileName} stdin errors`).toHaveLength(0)
         }
 
-        const missingScript = 'C:\\missing\\orca-hook.cmd'
-        // Why: the cmd fast path is intentionally a bare, directly-spawnable .cmd
-        // path (Codex/Antigravity/Devin launch it as argv[0], not via cmd.exe), so
-        // it cannot own stdin for a missing script — a cmd-builtin drain would make
-        // argv[0] unspawnable and fail every hook (#8430 regression). Only launchers
-        // that already require a real interpreter (encoded PowerShell, Git Bash)
-        // drain a missing script; the bare path's missing-script behavior is a
-        // normal launch failure, covered in installer-utils.test.ts.
+        // Why: cmd + Claude Git Bash *safe-path* fast paths are bare, directly
+        // spawnable `.cmd` paths (argv[0] / Grok CreateProcess / Claude Git Bash).
+        // A shell-builtin `if` drain is unspawnable or non-portable (#8430 / Grok
+        // compat loading Claude settings), so missing-script drain lives only on
+        // launchers that already require a real interpreter (encoded PowerShell).
+        // Use a spaced path so wrapWindowsGitBashHookCommand takes that fallback.
+        const missingUnsafeScript = 'C:\\missing path\\orca-hook.cmd'
         const launcherCases = [
           {
             name: 'encoded PowerShell',
             executable: 'cmd.exe',
-            args: ['/d', '/c', wrapWindowsHookCommand(missingScript)]
+            args: ['/d', '/c', wrapWindowsHookCommand(missingUnsafeScript)]
           },
           {
-            name: 'Git Bash fast path',
-            executable: gitBash,
-            args: ['-lc', wrapWindowsGitBashHookCommand(missingScript)]
+            name: 'Git Bash unsafe-path encoded fallback',
+            executable: 'cmd.exe',
+            args: ['/d', '/c', wrapWindowsGitBashHookCommand(missingUnsafeScript)]
           }
         ]
         for (const launcher of launcherCases) {
+          expect(launcher.args[2], `${launcher.name} uses encoded launcher`).toMatch(
+            /powershell\.exe/i
+          )
           const result = await runHookProcess(launcher.executable, launcher.args, hookEnvironment())
           expect(result.exitCode, `${launcher.name} exit code`).toBe(0)
           expect(result.stdinErrors, `${launcher.name} stdin errors`).toHaveLength(0)
         }
+      } finally {
+        homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
+        rmSync(home, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it.skipIf(process.platform !== 'win32')(
+    'runs the Claude Git Bash safe-path launcher (bare .cmd) under a real Git Bash',
+    async (ctx) => {
+      // Why: the Claude/OpenClaude launcher is now a bare forward-slash `.cmd`
+      // so Grok's CreateProcess can spawn it. Grok's native spawn can't be
+      // reproduced from Node (spawn rejects `.cmd` without a shell), but the
+      // primary consumer — Claude's Git Bash runner — must exec the bare `.cmd`
+      // and own stdin. Prove that end to end so a regression in bash `.cmd`
+      // execution can't hide behind the string-shape unit test.
+      const home = mkdtempBashSafe('orca-hook-stdin-gitbash-')
+      if (!home) {
+        // No bash-safe temp root on this host; skip loudly rather than let the
+        // bare `.cmd` assertions never run and pass vacuously (unsafe paths are
+        // already covered by the encoded-fallback matrix above).
+        ctx.skip()
+        return
+      }
+      homedirMock.mockReturnValue(home)
+      try {
+        expect(new ClaudeHookService().install().state).toBe('installed')
+        const claudeScript = join(home, '.orca', 'agent-hooks', 'claude-hook.cmd')
+        const command = wrapWindowsGitBashHookCommand(claudeScript)
+        // home is guaranteed bash-safe, so the launcher MUST be the bare
+        // forward-slash `.cmd` fast path, never the PowerShell fallback.
+        expect(command, 'safe path must take the bare .cmd fast path').not.toMatch(
+          /powershell\.exe/i
+        )
+        expect(command).toBe(claudeScript.replaceAll('\\', '/'))
+        const result = await runHookProcess(
+          resolveWindowsTestBash(),
+          ['-c', command],
+          hookEnvironment()
+        )
+        expect(result.exitCode, 'claude git bash bare .cmd exit code').toBe(0)
+        expect(result.stdinErrors, 'claude git bash bare .cmd stdin errors').toHaveLength(0)
+      } finally {
+        homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
+        rmSync(home, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it.skipIf(process.platform !== 'win32')(
+    'runs the safe-path launcher under a cmd shell and rejects the old bash compound (Grok compat)',
+    async (ctx) => {
+      // Why: Grok's [compat.claude] loads the same settings.json command and
+      // runs it through its Windows shell (cmd/PowerShell), not Git Bash. The
+      // bare forward-slash `.cmd` must run there and own stdin; the pre-fix
+      // `if [ -f … ]` compound fails with "-f was unexpected" under cmd. Lock
+      // both so a revert to the compound form can't slip back.
+      // NB: never model this as spawn(bareCmd, {shell:false}) — Node rejects a
+      // bare `.cmd` with EINVAL, a false negative unrelated to Grok's runtime.
+      const home = mkdtempBashSafe('orca-hook-stdin-grokcompat-')
+      if (!home) {
+        // No bash-safe temp root on this host; skip loudly rather than let the
+        // bare `.cmd` assertions never run and pass vacuously.
+        ctx.skip()
+        return
+      }
+      homedirMock.mockReturnValue(home)
+      try {
+        expect(new ClaudeHookService().install().state).toBe('installed')
+        const claudeScript = join(home, '.orca', 'agent-hooks', 'claude-hook.cmd')
+        const command = wrapWindowsGitBashHookCommand(claudeScript)
+        // home is guaranteed bash-safe, so the launcher MUST be the bare
+        // forward-slash `.cmd` fast path, never the PowerShell fallback.
+        expect(command, 'safe path must take the bare .cmd fast path').not.toMatch(
+          /powershell\.exe/i
+        )
+        const forwardSlash = claudeScript.replaceAll('\\', '/')
+        expect(command).toBe(forwardSlash)
+
+        const fixed = await runHookProcess('cmd.exe', ['/d', '/c', command], hookEnvironment())
+        expect(fixed.exitCode, 'bare .cmd under cmd shell exit code').toBe(0)
+        expect(fixed.stdinErrors, 'bare .cmd under cmd shell stdin errors').toHaveLength(0)
+
+        const quoted = `'${forwardSlash}'`
+        const oldCompound = `if [ -f ${quoted} ]; then ${quoted}; else cat >/dev/null 2>&1 || :; fi`
+        const regressed = await runHookProcess(
+          'cmd.exe',
+          ['/d', '/c', oldCompound],
+          hookEnvironment()
+        )
+        expect(regressed.exitCode, 'old bash compound must fail under a cmd spawn').not.toBe(0)
       } finally {
         homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
         rmSync(home, { recursive: true, force: true })

--- a/src/main/agent-hooks/server-grok-discovery.test.ts
+++ b/src/main/agent-hooks/server-grok-discovery.test.ts
@@ -3,12 +3,17 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import * as agentHookListener from '../../shared/agent-hook-listener'
+import {
+  clearGrokSessionPathLookupCacheForTests,
+  setGrokSessionPathScannerForTests
+} from '../../shared/grok-session-paths'
 import { makePaneKey } from '../../shared/stable-pane-id'
 import { AgentHookServer } from './server'
 
 const PANE_KEY = makePaneKey('tab-1', '11111111-1111-4111-8111-111111111111')
 
 afterEach(() => {
+  clearGrokSessionPathLookupCacheForTests()
   vi.restoreAllMocks()
   vi.unstubAllEnvs()
 })
@@ -38,6 +43,35 @@ async function postGrokHook(
 }
 
 describe('AgentHookServer Grok discovery retries', () => {
+  it('runs slug-group discovery once while bounded content retries continue', async () => {
+    let scanCount = 0
+    setGrokSessionPathScannerForTests(async () => {
+      scanCount += 1
+      return null
+    })
+    const server = new AgentHookServer()
+    const root = mkdtempSync(join(tmpdir(), 'orca-grok-discovery-count-'))
+    vi.stubEnv('HOME', root)
+    vi.stubEnv('USERPROFILE', root)
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const endpoint = { port: env.ORCA_AGENT_HOOK_PORT, token: env.ORCA_AGENT_HOOK_TOKEN }
+
+      await postGrokHook(endpoint, {
+        hookEventName: 'Stop',
+        sessionId: '019e37f4-5135-7b63-a4ab-6d13aa6bf534',
+        cwd: join(root, 'workspace')
+      })
+      await new Promise((resolve) => setTimeout(resolve, 400))
+
+      expect(scanCount).toBe(1)
+    } finally {
+      server.stop()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('waits for delayed discovery beyond the transcript retry window', async () => {
     let releaseDiscovery!: () => void
     const discovery = new Promise<void>((resolve) => {

--- a/src/main/grok/grok-hook-script.ts
+++ b/src/main/grok/grok-hook-script.ts
@@ -1,0 +1,81 @@
+import { buildWindowsAgentHookPostCommand } from '../agent-hooks/installer-utils'
+import {
+  buildPosixHookPayloadCapture,
+  buildWindowsHookEnvironmentGuardLines,
+  buildWindowsHookStdinDrainEpilogue
+} from '../agent-hooks/hook-stdin-contract'
+
+// Envelope bound shared with the hook listener's grokHome validation; a home
+// longer than this is dropped rather than forwarded.
+export const GROK_HOME_ENVELOPE_MAX_LENGTH = 4096
+
+const WINDOWS_HOOK_PAYLOAD_FORM_LINE = '  --data-urlencode "payload@-" >nul 2>nul'
+
+const WINDOWS_GROK_HOOK_POST_COMMAND = buildWindowsAgentHookPostCommand('grok').replace(
+  WINDOWS_HOOK_PAYLOAD_FORM_LINE,
+  `  --data-urlencode "grokHome=%ORCA_GROK_HOME%" ^\r\n${WINDOWS_HOOK_PAYLOAD_FORM_LINE}`
+)
+
+export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
+  if (target === 'local' && process.platform === 'win32') {
+    // Why: cmd.exe expands %VAR% before evaluating `if` chains, so
+    // `if defined X if "%X:~-1%"=="\"` still parse-errors when X is empty.
+    // Goto keeps the trailing-backslash check on a line that is only reached
+    // when a non-empty ORCA_GROK_HOME exists (Grok defaults to unset
+    // GROK_HOME / ~/.grok; Orca panes always set PORT/TOKEN/PANE so we do
+    // not early-exit via the stdin drain).
+    const grokHomeReadyLabel = 'orca_grok_home_ready'
+    return [
+      '@echo off',
+      'setlocal',
+      'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
+      ...buildWindowsHookEnvironmentGuardLines(),
+      'set "ORCA_GROK_HOME="',
+      `if not defined GROK_HOME goto :${grokHomeReadyLabel}`,
+      'set "ORCA_GROK_HOME=%GROK_HOME%"',
+      `if not "%GROK_HOME:~${GROK_HOME_ENVELOPE_MAX_LENGTH},1%"=="" set "ORCA_GROK_HOME="`,
+      `if not defined ORCA_GROK_HOME goto :${grokHomeReadyLabel}`,
+      // Why: a trailing backslash escapes curl's closing argv quote on Windows,
+      // merging the payload option into grokHome and dropping the hook body.
+      'if "%ORCA_GROK_HOME:~-1%"=="\\" set "ORCA_GROK_HOME=%ORCA_GROK_HOME%."',
+      `:${grokHomeReadyLabel}`,
+      WINDOWS_GROK_HOOK_POST_COMMAND,
+      'exit /b 0',
+      ...buildWindowsHookStdinDrainEpilogue(),
+      ''
+    ].join('\r\n')
+  }
+
+  return [
+    '#!/bin/sh',
+    ...buildPosixHookPayloadCapture(),
+    'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',
+    '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
+    'fi',
+    'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
+    '  exit 0',
+    'fi',
+    'grok_home=',
+    `if [ -n "\${GROK_HOME:-}" ] && [ "\${#GROK_HOME}" -le ${GROK_HOME_ENVELOPE_MAX_LENGTH} ]; then`,
+    '  grok_home=$GROK_HOME',
+    'fi',
+    // Timeout caps best-effort hook posts if the local listener stalls.
+    // Why: pipe payload to curl's stdin (`payload@-`) instead of an inline
+    // `payload=$VALUE` arg, so tens-of-KB tool output stays off the curl
+    // command line (EDR command-line false positives). Wire body is identical.
+    'printf \'%s\' "$payload" | curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/grok" \\',
+    '  --connect-timeout 0.5 --max-time 1.5 \\',
+    '  -H "Content-Type: application/x-www-form-urlencoded" \\',
+    '  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',
+    '  --data-urlencode "paneKey=${ORCA_PANE_KEY}" \\',
+    '  --data-urlencode "tabId=${ORCA_TAB_ID}" \\',
+    '  --data-urlencode "launchToken=${ORCA_AGENT_LAUNCH_TOKEN}" \\',
+    '  --data-urlencode "worktreeId=${ORCA_WORKTREE_ID}" \\',
+    '  --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
+    '  --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
+    '  --data-urlencode "grokHome=${grok_home}" \\',
+    '  --data-urlencode "payload@-" >/dev/null 2>&1 || true',
+    'exit 0',
+    ''
+  ].join('\n')
+}

--- a/src/main/grok/grok-hook-script.ts
+++ b/src/main/grok/grok-hook-script.ts
@@ -32,8 +32,12 @@ export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
       ...buildWindowsHookEnvironmentGuardLines(),
       'set "ORCA_GROK_HOME="',
       `if not defined GROK_HOME goto :${grokHomeReadyLabel}`,
+      // Why: length-check BEFORE `set "ORCA_GROK_HOME=%GROK_HOME%"`. cmd expands
+      // %GROK_HOME% on the set line; a home longer than the envelope (or near
+      // cmd's ~8191 char limit) must not be copied at all — drop by skipping
+      // the assignment rather than assign-then-clear.
+      `if not "%GROK_HOME:~${GROK_HOME_ENVELOPE_MAX_LENGTH},1%"=="" goto :${grokHomeReadyLabel}`,
       'set "ORCA_GROK_HOME=%GROK_HOME%"',
-      `if not "%GROK_HOME:~${GROK_HOME_ENVELOPE_MAX_LENGTH},1%"=="" set "ORCA_GROK_HOME="`,
       `if not defined ORCA_GROK_HOME goto :${grokHomeReadyLabel}`,
       // Why: a trailing backslash escapes curl's closing argv quote on Windows,
       // merging the payload option into grokHome and dropping the hook body.

--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -106,8 +106,13 @@ describe('GrokHookService', () => {
       // cmd expands %VAR% before `if` chains, so only a goto-skip is safe.
       expect(script).toContain('set "ORCA_GROK_HOME="')
       expect(script).toContain('if not defined GROK_HOME goto :orca_grok_home_ready')
-      expect(script).toContain('set "ORCA_GROK_HOME=%GROK_HOME%"')
-      expect(script).toContain('%GROK_HOME:~4096,1%')
+      // Why: length guard must precede the %GROK_HOME% copy so oversized values
+      // never expand on the set line (cmd ~8191 limit / envelope drop).
+      const lengthGuardIdx = script.indexOf('if not "%GROK_HOME:~4096,1%"=="" goto :orca_grok_home_ready')
+      const setCopyIdx = script.indexOf('set "ORCA_GROK_HOME=%GROK_HOME%"')
+      expect(lengthGuardIdx).toBeGreaterThan(-1)
+      expect(setCopyIdx).toBeGreaterThan(-1)
+      expect(lengthGuardIdx).toBeLessThan(setCopyIdx)
       expect(script).toContain('if not defined ORCA_GROK_HOME goto :orca_grok_home_ready')
       expect(script).toContain(
         'if "%ORCA_GROK_HOME:~-1%"=="\\" set "ORCA_GROK_HOME=%ORCA_GROK_HOME%."'
@@ -240,6 +245,61 @@ describe('GrokHookService', () => {
         ORCA_AGENT_HOOK_VERSION: '1'
       }
       delete env.GROK_HOME
+
+      const result = await new Promise<{ exitCode: number | null; stderr: string }>(
+        (resolve, reject) => {
+          const child = spawn('cmd.exe', ['/d', '/c', scriptPath], {
+            env,
+            stdio: ['pipe', 'ignore', 'pipe']
+          })
+          let stderr = ''
+          const timeout = setTimeout(() => {
+            child.kill('SIGKILL')
+            reject(new Error('grok-hook.cmd timed out'))
+          }, 10_000)
+          child.stderr.on('data', (chunk: Buffer) => {
+            stderr += chunk.toString('utf8')
+          })
+          child.on('error', (error) => {
+            clearTimeout(timeout)
+            reject(error)
+          })
+          child.on('close', (exitCode) => {
+            clearTimeout(timeout)
+            resolve({ exitCode, stderr })
+          })
+          child.stdin.end('{"hookEventName":"pre_tool_use","sessionId":"test"}')
+        }
+      )
+
+      expect(result.exitCode, `stderr=${result.stderr}`).toBe(0)
+      expect(result.stderr).not.toMatch(/syntax of the command is incorrect/i)
+    }
+  )
+
+  it.skipIf(process.platform !== 'win32')(
+    'exits 0 with Orca env set and GROK_HOME longer than the envelope (drop before set)',
+    async () => {
+      expect(new GrokHookService().install().state).toBe('installed')
+      const scriptPath = join(homeDir, '.orca', 'agent-hooks', GROK_SCRIPT_FILE_NAME)
+      // Why: over envelope max but under cmd's ~8191 limit so inheritance works;
+      // the length guard must skip the set copy without parse/expand failure.
+      const grokHome = `C:\\${'x'.repeat(4200)}`
+
+      const env: NodeJS.ProcessEnv = {
+        ...Object.fromEntries(
+          Object.entries(process.env).filter(([key]) => !key.startsWith('ORCA_'))
+        ),
+        GROK_HOME: grokHome,
+        ORCA_AGENT_HOOK_PORT: '1',
+        ORCA_AGENT_HOOK_TOKEN: 'test-token',
+        ORCA_PANE_KEY: 'test-pane',
+        ORCA_TAB_ID: 'test-tab',
+        ORCA_AGENT_LAUNCH_TOKEN: 'test-launch',
+        ORCA_WORKTREE_ID: 'test-worktree',
+        ORCA_AGENT_HOOK_ENV: 'test',
+        ORCA_AGENT_HOOK_VERSION: '1'
+      }
 
       const result = await new Promise<{ exitCode: number | null; stderr: string }>(
         (resolve, reject) => {

--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { spawn } from 'node:child_process'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -24,15 +25,27 @@ const WINDOWS_POWERSHELL_LAUNCHER =
 
 describe('GrokHookService', () => {
   let homeDir: string
+  let previousGrokHome: string | undefined
 
   beforeEach(() => {
     homeDir = mkdtempSync(join(tmpdir(), 'orca-grok-home-'))
     homedirMock.mockReturnValue(homeDir)
+    // Why: neutralize an ambient GROK_HOME so install() resolves under the
+    // mocked home instead of writing orca-status.json into the developer's real
+    // Grok home (which afterEach never cleans up). Tests that exercise a set
+    // GROK_HOME opt back in explicitly.
+    previousGrokHome = process.env.GROK_HOME
+    delete process.env.GROK_HOME
   })
 
   afterEach(() => {
     vi.clearAllMocks()
     rmSync(homeDir, { recursive: true, force: true })
+    if (previousGrokHome === undefined) {
+      delete process.env.GROK_HOME
+    } else {
+      process.env.GROK_HOME = previousGrokHome
+    }
   })
 
   it('installs a dedicated global Grok hook config and managed script', () => {
@@ -89,11 +102,17 @@ describe('GrokHookService', () => {
     expect(script).toContain('/hook/grok')
     if (process.platform === 'win32') {
       expect(script).toContain('%SystemRoot%\\System32\\curl.exe')
+      // Why: empty GROK_HOME must not reach the trailing-backslash check.
+      // cmd expands %VAR% before `if` chains, so only a goto-skip is safe.
+      expect(script).toContain('set "ORCA_GROK_HOME="')
+      expect(script).toContain('if not defined GROK_HOME goto :orca_grok_home_ready')
       expect(script).toContain('set "ORCA_GROK_HOME=%GROK_HOME%"')
       expect(script).toContain('%GROK_HOME:~4096,1%')
+      expect(script).toContain('if not defined ORCA_GROK_HOME goto :orca_grok_home_ready')
       expect(script).toContain(
         'if "%ORCA_GROK_HOME:~-1%"=="\\" set "ORCA_GROK_HOME=%ORCA_GROK_HOME%."'
       )
+      expect(script).toContain(':orca_grok_home_ready')
       expect(script).toContain('--data-urlencode "grokHome=%ORCA_GROK_HOME%"')
     } else {
       // Why: payload is piped to curl via stdin (`payload@-`) so it never lands
@@ -192,4 +211,117 @@ describe('GrokHookService', () => {
       )
     ).toBe(true)
   })
+
+  // Why: Orca panes inject ORCA_AGENT_HOOK_* so the script reaches the
+  // GROK_HOME block instead of the stdin-drain early exit. Grok itself
+  // almost never sets GROK_HOME (defaults to ~/.grok). The old script ran
+  // `if "%ORCA_GROK_HOME:~-1%"=="\"` on an empty variable and failed every
+  // hook with "The syntax of the command is incorrect."
+  it.skipIf(process.platform !== 'win32')(
+    'exits 0 with Orca env set and GROK_HOME unset (empty-home cmd parse)',
+    async () => {
+      expect(new GrokHookService().install().state).toBe('installed')
+      const scriptPath = join(homeDir, '.orca', 'agent-hooks', GROK_SCRIPT_FILE_NAME)
+
+      const env: NodeJS.ProcessEnv = {
+        ...Object.fromEntries(
+          Object.entries(process.env).filter(
+            ([key]) => !key.startsWith('ORCA_') && key !== 'GROK_HOME'
+          )
+        ),
+        // Why: non-routable port — curl fails closed; the script still exits 0.
+        ORCA_AGENT_HOOK_PORT: '1',
+        ORCA_AGENT_HOOK_TOKEN: 'test-token',
+        ORCA_PANE_KEY: 'test-pane',
+        ORCA_TAB_ID: 'test-tab',
+        ORCA_AGENT_LAUNCH_TOKEN: 'test-launch',
+        ORCA_WORKTREE_ID: 'test-worktree',
+        ORCA_AGENT_HOOK_ENV: 'test',
+        ORCA_AGENT_HOOK_VERSION: '1'
+      }
+      delete env.GROK_HOME
+
+      const result = await new Promise<{ exitCode: number | null; stderr: string }>(
+        (resolve, reject) => {
+          const child = spawn('cmd.exe', ['/d', '/c', scriptPath], {
+            env,
+            stdio: ['pipe', 'ignore', 'pipe']
+          })
+          let stderr = ''
+          const timeout = setTimeout(() => {
+            child.kill('SIGKILL')
+            reject(new Error('grok-hook.cmd timed out'))
+          }, 10_000)
+          child.stderr.on('data', (chunk: Buffer) => {
+            stderr += chunk.toString('utf8')
+          })
+          child.on('error', (error) => {
+            clearTimeout(timeout)
+            reject(error)
+          })
+          child.on('close', (exitCode) => {
+            clearTimeout(timeout)
+            resolve({ exitCode, stderr })
+          })
+          child.stdin.end('{"hookEventName":"pre_tool_use","sessionId":"test"}')
+        }
+      )
+
+      expect(result.exitCode, `stderr=${result.stderr}`).toBe(0)
+      expect(result.stderr).not.toMatch(/syntax of the command is incorrect/i)
+    }
+  )
+
+  it.skipIf(process.platform !== 'win32')(
+    'exits 0 with Orca env set and GROK_HOME trailing backslash',
+    async () => {
+      expect(new GrokHookService().install().state).toBe('installed')
+      const scriptPath = join(homeDir, '.orca', 'agent-hooks', GROK_SCRIPT_FILE_NAME)
+      const grokHome = `${join(homeDir, 'custom-grok')}\\`
+
+      const env: NodeJS.ProcessEnv = {
+        ...Object.fromEntries(
+          Object.entries(process.env).filter(([key]) => !key.startsWith('ORCA_'))
+        ),
+        GROK_HOME: grokHome,
+        ORCA_AGENT_HOOK_PORT: '1',
+        ORCA_AGENT_HOOK_TOKEN: 'test-token',
+        ORCA_PANE_KEY: 'test-pane',
+        ORCA_TAB_ID: 'test-tab',
+        ORCA_AGENT_LAUNCH_TOKEN: 'test-launch',
+        ORCA_WORKTREE_ID: 'test-worktree',
+        ORCA_AGENT_HOOK_ENV: 'test',
+        ORCA_AGENT_HOOK_VERSION: '1'
+      }
+
+      const result = await new Promise<{ exitCode: number | null; stderr: string }>(
+        (resolve, reject) => {
+          const child = spawn('cmd.exe', ['/d', '/c', scriptPath], {
+            env,
+            stdio: ['pipe', 'ignore', 'pipe']
+          })
+          let stderr = ''
+          const timeout = setTimeout(() => {
+            child.kill('SIGKILL')
+            reject(new Error('grok-hook.cmd timed out'))
+          }, 10_000)
+          child.stderr.on('data', (chunk: Buffer) => {
+            stderr += chunk.toString('utf8')
+          })
+          child.on('error', (error) => {
+            clearTimeout(timeout)
+            reject(error)
+          })
+          child.on('close', (exitCode) => {
+            clearTimeout(timeout)
+            resolve({ exitCode, stderr })
+          })
+          child.stdin.end('{"hookEventName":"pre_tool_use","sessionId":"test"}')
+        }
+      )
+
+      expect(result.exitCode, `stderr=${result.stderr}`).toBe(0)
+      expect(result.stderr).not.toMatch(/syntax of the command is incorrect/i)
+    }
+  )
 })

--- a/src/main/grok/hook-service.ts
+++ b/src/main/grok/hook-service.ts
@@ -5,7 +5,6 @@ import { resolveGrokHomeDir } from '../../shared/grok-session-paths'
 import {
   buildManagedCommandHook,
   createManagedCommandMatcher,
-  buildWindowsAgentHookPostCommand,
   getSharedManagedScriptPath,
   readHooksJson,
   removeManagedCommands,
@@ -20,19 +19,13 @@ import {
   writeHooksJsonRemote,
   writeManagedScriptRemote
 } from '../agent-hooks/installer-utils-remote'
-import {
-  buildPosixHookPayloadCapture,
-  buildWindowsHookEnvironmentGuardLines,
-  buildWindowsHookStdinDrainEpilogue
-} from '../agent-hooks/hook-stdin-contract'
+import { GROK_HOME_ENVELOPE_MAX_LENGTH, getManagedScript } from './grok-hook-script'
 
 // Why: Grok's tool-event matcher is a real regex (see Grok hooks docs). Bare
 // `*` is not a valid "match all" pattern and can fail to load/match, so tool
 // lifecycle hooks never fire. `.*` matches every tool name (same as Command
 // Code's managed hooks).
 const GROK_TOOL_EVENT_MATCHER = '.*'
-const GROK_HOME_ENVELOPE_MAX_LENGTH = 4096
-const WINDOWS_HOOK_PAYLOAD_FORM_LINE = '  --data-urlencode "payload@-" >nul 2>nul'
 
 const GROK_EVENTS = [
   { eventName: 'SessionStart', definition: { hooks: [{ type: 'command', command: '' }] } },
@@ -95,11 +88,6 @@ function hasControlCharacter(value: string): boolean {
   })
 }
 
-const WINDOWS_GROK_HOOK_POST_COMMAND = buildWindowsAgentHookPostCommand('grok').replace(
-  WINDOWS_HOOK_PAYLOAD_FORM_LINE,
-  `  --data-urlencode "grokHome=%ORCA_GROK_HOME%" ^\r\n${WINDOWS_HOOK_PAYLOAD_FORM_LINE}`
-)
-
 function getManagedScriptFileName(): string {
   return process.platform === 'win32' ? 'grok-hook.cmd' : 'grok-hook.sh'
 }
@@ -112,59 +100,6 @@ function getManagedCommand(scriptPath: string): string {
   return process.platform === 'win32'
     ? wrapWindowsHookCommand(scriptPath)
     : wrapPosixHookCommand(scriptPath)
-}
-
-function getManagedScript(target: 'local' | 'posix' = 'local'): string {
-  if (target === 'local' && process.platform === 'win32') {
-    return [
-      '@echo off',
-      'setlocal',
-      'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
-      ...buildWindowsHookEnvironmentGuardLines(),
-      'set "ORCA_GROK_HOME=%GROK_HOME%"',
-      `if not "%GROK_HOME:~${GROK_HOME_ENVELOPE_MAX_LENGTH},1%"=="" set "ORCA_GROK_HOME="`,
-      // Why: a trailing backslash escapes curl's closing argv quote on Windows,
-      // merging the payload option into grokHome and dropping the hook body.
-      'if "%ORCA_GROK_HOME:~-1%"=="\\" set "ORCA_GROK_HOME=%ORCA_GROK_HOME%."',
-      WINDOWS_GROK_HOOK_POST_COMMAND,
-      'exit /b 0',
-      ...buildWindowsHookStdinDrainEpilogue(),
-      ''
-    ].join('\r\n')
-  }
-
-  return [
-    '#!/bin/sh',
-    ...buildPosixHookPayloadCapture(),
-    'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',
-    '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
-    'fi',
-    'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
-    '  exit 0',
-    'fi',
-    'grok_home=',
-    `if [ -n "\${GROK_HOME:-}" ] && [ "\${#GROK_HOME}" -le ${GROK_HOME_ENVELOPE_MAX_LENGTH} ]; then`,
-    '  grok_home=$GROK_HOME',
-    'fi',
-    // Timeout caps best-effort hook posts if the local listener stalls.
-    // Why: pipe payload to curl's stdin (`payload@-`) instead of an inline
-    // `payload=$VALUE` arg, so tens-of-KB tool output stays off the curl
-    // command line (EDR command-line false positives). Wire body is identical.
-    'printf \'%s\' "$payload" | curl -sS -X POST "http://127.0.0.1:${ORCA_AGENT_HOOK_PORT}/hook/grok" \\',
-    '  --connect-timeout 0.5 --max-time 1.5 \\',
-    '  -H "Content-Type: application/x-www-form-urlencoded" \\',
-    '  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',
-    '  --data-urlencode "paneKey=${ORCA_PANE_KEY}" \\',
-    '  --data-urlencode "tabId=${ORCA_TAB_ID}" \\',
-    '  --data-urlencode "launchToken=${ORCA_AGENT_LAUNCH_TOKEN}" \\',
-    '  --data-urlencode "worktreeId=${ORCA_WORKTREE_ID}" \\',
-    '  --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
-    '  --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
-    '  --data-urlencode "grokHome=${grok_home}" \\',
-    '  --data-urlencode "payload@-" >/dev/null 2>&1 || true',
-    'exit 0',
-    ''
-  ].join('\n')
 }
 
 function buildInstalledConfig(

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -1267,12 +1267,9 @@ export function hasPendingAgentResultText(source: AgentHookSource, body: unknown
     const transcriptPath = record.transcriptPath ?? record.transcript_path
     return typeof transcriptPath === 'string' && transcriptPath.trim().length > 0
   }
-  const pendingGrokDiscovery = preparePendingGrokResultDiscovery(source, body)
-  if (pendingGrokDiscovery) {
-    void pendingGrokDiscovery
-    return true
-  }
-  return false
+  // Why: this predicate runs before every bounded content retry. Starting path
+  // discovery here repeated a full Grok sessions-root scan on every retry.
+  return readPendingGrokResultMetadata(source, body) !== undefined
 }
 
 function hasNonEmptyString(value: unknown): boolean {
@@ -1286,19 +1283,18 @@ function hasExplicitLastAssistantResult(record: Record<string, unknown>): boolea
   )
 }
 
-/** Start bounded discovery only for a Grok completion that still needs result text. */
-export function preparePendingGrokResultDiscovery(
+function readPendingGrokResultMetadata(
   source: AgentHookSource,
   body: unknown
-): Promise<void> | null {
+): GrokSessionMetadata | undefined {
   if (source !== 'grok') {
-    return null
+    return undefined
   }
   const envelope =
     typeof body === 'object' && body !== null ? (body as Record<string, unknown>) : null
   const record = parseHookBodyPayloadRecord(body)
   if (!record || hasExplicitLastAssistantResult(record)) {
-    return null
+    return undefined
   }
   const eventName =
     envelope?.hook_event_name ??
@@ -1306,12 +1302,17 @@ export function preparePendingGrokResultDiscovery(
     record.hook_event_name ??
     record.hookEventName
   if (!isGrokEvent(eventName, 'stop', 'session_end')) {
-    return null
+    return undefined
   }
-  const metadata = readGrokSessionMetadata(
-    record,
-    envelope ? readGrokHomeEnvelope(envelope) : undefined
-  )
+  return readGrokSessionMetadata(record, envelope ? readGrokHomeEnvelope(envelope) : undefined)
+}
+
+/** Start bounded discovery only for a Grok completion that still needs result text. */
+export function preparePendingGrokResultDiscovery(
+  source: AgentHookSource,
+  body: unknown
+): Promise<void> | null {
+  const metadata = readPendingGrokResultMetadata(source, body)
   if (!metadata) {
     return null
   }

--- a/src/shared/grok-session-path-discovery-cost.bench.test.ts
+++ b/src/shared/grok-session-path-discovery-cost.bench.test.ts
@@ -1,0 +1,53 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+  clearGrokSessionPathLookupCacheForTests,
+  findGrokChatHistoryBySessionId,
+  GROK_SESSION_GROUP_SCAN_MAX_ENTRIES
+} from './grok-session-paths'
+
+const describePerf = process.env.ORCA_GROK_PATH_PERF_BENCH === '1' ? describe : describe.skip
+const ROUNDS = 5
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  return sorted[Math.floor(sorted.length / 2)]
+}
+
+describePerf('Grok session path discovery cost', () => {
+  let root = ''
+  let sessionsDir = ''
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), 'orca-grok-path-cost-'))
+    sessionsDir = join(root, 'sessions')
+    await mkdir(sessionsDir)
+    await Promise.all(
+      Array.from({ length: GROK_SESSION_GROUP_SCAN_MAX_ENTRIES }, (_unused, index) =>
+        mkdir(join(sessionsDir, `group-${index}`))
+      )
+    )
+  })
+
+  afterAll(async () => {
+    clearGrokSessionPathLookupCacheForTests()
+    await rm(root, { recursive: true, force: true })
+  })
+
+  it('measures one bounded missing-session scan through real filesystem IO', async () => {
+    const durations: number[] = []
+    for (let round = 0; round < ROUNDS; round++) {
+      clearGrokSessionPathLookupCacheForTests()
+      const startedAt = performance.now()
+      const result = await findGrokChatHistoryBySessionId(sessionsDir, `missing-session-${round}`)
+      durations.push(performance.now() - startedAt)
+      expect(result).toBeNull()
+    }
+    console.log(
+      `bounded Grok discovery median: ${median(durations).toFixed(2)} ms ` +
+        `(${GROK_SESSION_GROUP_SCAN_MAX_ENTRIES} groups)`
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Rebases and combines the still-unique Grok-compat fixes from #8856 and #8159 onto current `main`:

1. **Windows Grok hook launcher (`#8856`)**
   - Empty/unset/`>4096` `GROK_HOME` no longer runs `%ORCA_GROK_HOME:~-1%` (cmd.exe parse error on every hook).
   - Uses `goto` so trailing-backslash strip only runs when a non-empty home is present.
   - Extracts Windows/POSIX script templates to `grok-hook-script.ts` (max-lines, no disable).
   - Claude Windows safe-path launcher is a bare forward-slash `.cmd` so Grok `[compat.claude]` CreateProcess can spawn it (bash `if [ -f … ]` compound fails with `-f was unexpected`).

2. **Pure pending discovery (`#8159`)**
   - `hasPendingAgentResultText` is side-effect-free (metadata only).
   - Path discovery starts once via `preparePendingGrokResultDiscovery` from the hook server/relay.
   - Regression: real Grok `Stop` posts now run the sessions-root scanner once (was 7).

### Relation to existing PRs

- Supersedes unique remaining value of **#8856** and **#8159** (authors: @Cainiaooo, @nwparker — credit retained; this is a rebased contributor re-submission).
- Does **not** re-touch zero-percent usage (#9219 already merged).

## Claude Opus review

**Verdict: APPROVED** (local staged review before push).

Only nit (non-blocking): `GROK_HOME_ENVELOPE_MAX_LENGTH = 4096` is duplicated with `agent-hook-listener.ts` — pre-existing, optional follow-up to share the constant.

## Testing

- [x] Focused Vitest: `hook-service`, `installer-utils`, `server-grok-discovery` (incl. scanCount===1), `managed-hook-stdin-lifecycle` — 53 passed / 8 skipped (Windows-gated on macOS)
- [ ] `pnpm lint` / full suite — deferred to CI
- [x] Claude Opus review: APPROVED

## Notes

Contributor re-submission for maintainer merge; no merge rights on the upstream PRs.

## ELI5

Broken Windows Grok hook scripts crashed when GROK_HOME was empty or huge, and pending session discovery had unsafe edge cases. Hook launchers and discovery are hardened so hooks run safely on Windows.
