### PR TITLE
fix(pty): terminate Windows ConPTY descendants during teardown

### DIFF
--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -1398,7 +1398,7 @@ describe('createPtySubprocess', () => {
     expect(proc.kill).toHaveBeenCalledTimes(2)
   })
 
-  it('propagates rejected force kills so the owner can retry', () => {
+  itOnPosixHost('propagates rejected force kills so the owner can retry', () => {
     const proc = mockPtyProcess(77)
     proc.kill.mockImplementation(() => {
       throw new Error('native fallback rejected')
@@ -1422,7 +1422,7 @@ describe('createPtySubprocess', () => {
     }
   })
 
-  it('forceKill sends SIGKILL to the child pid', () => {
+  itOnPosixHost('forceKill sends SIGKILL to the child pid', () => {
     const proc = mockPtyProcess(77)
     spawnMock.mockReturnValue(proc)
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
@@ -1432,6 +1432,53 @@ describe('createPtySubprocess', () => {
 
     expect(killSpy).toHaveBeenCalledWith(77, 'SIGKILL')
     killSpy.mockRestore()
+  })
+
+  it('forceKill on Windows uses node-pty kill instead of raw process.kill', () => {
+    const proc = mockPtyProcess(77)
+    spawnMock.mockReturnValue(proc)
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    try {
+      const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+      handle.forceKill()
+
+      expect(proc.kill).toHaveBeenCalledOnce()
+      expect(killSpy).not.toHaveBeenCalled()
+    } finally {
+      killSpy.mockRestore()
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+  })
+
+  it('propagates rejected Windows node-pty force kills so the owner can retry', () => {
+    const proc = mockPtyProcess(77)
+    proc.kill
+      .mockImplementationOnce(() => {
+        throw new Error('native Windows kill rejected')
+      })
+      .mockImplementationOnce(() => undefined)
+    spawnMock.mockReturnValue(proc)
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    try {
+      const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+      expect(() => handle.forceKill()).toThrow('native Windows kill rejected')
+      expect(() => handle.forceKill()).not.toThrow()
+      expect(proc.kill).toHaveBeenCalledTimes(2)
+      expect(killSpy).not.toHaveBeenCalled()
+    } finally {
+      killSpy.mockRestore()
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
   })
 
   it('routes onData events', () => {
@@ -2819,17 +2866,15 @@ describe('createPtySubprocess', () => {
       }
       proc.destroy = vi.fn(() => proc.kill())
       spawnMock.mockReturnValue(proc)
-      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
-        throw new Error('already gone')
-      })
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
       const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
       Object.defineProperty(process, 'platform', { value: 'win32' })
       try {
         const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
         handle.forceKill()
         handle.dispose()
-        expect(killSpy).toHaveBeenCalledWith(123456, 'SIGKILL')
         expect(proc.kill).toHaveBeenCalledOnce()
+        expect(killSpy).not.toHaveBeenCalled()
         expect(proc.destroy).not.toHaveBeenCalled()
       } finally {
         killSpy.mockRestore()
@@ -2878,14 +2923,23 @@ describe('createPtySubprocess', () => {
       killSpy.mockRestore()
     })
 
-    it('forceKill before exit still fires SIGKILL (live child)', () => {
+    it('forceKill before exit uses node-pty kill on Windows', () => {
       const proc = mockPtyProcess(77)
       spawnMock.mockReturnValue(proc)
       const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
-      const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
-      handle.forceKill()
-      expect(killSpy).toHaveBeenCalledWith(77, 'SIGKILL')
-      killSpy.mockRestore()
+      const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+      Object.defineProperty(process, 'platform', { value: 'win32' })
+      try {
+        const handle = createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+        handle.forceKill()
+        expect(proc.kill).toHaveBeenCalledOnce()
+        expect(killSpy).not.toHaveBeenCalled()
+      } finally {
+        killSpy.mockRestore()
+        if (origPlatform) {
+          Object.defineProperty(process, 'platform', origPlatform)
+        }
+      }
     })
   })
 })

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -1215,9 +1215,21 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       // has run, proc.pid refers to a recycled pid. Sending SIGKILL would
       // terminate an unrelated process. The fd release is handled by
       // dispose()/destroy(); forceKill is strictly for signalling a live child.
-      // Why: Windows node-pty kill already closes ConPTY; retrying it through
-      // forceKill can double-close the native handle during workspace teardown.
+      // Why: Windows node-pty kill already closes ConPTY and tears down the
+      // owning shell. Match the local provider path here; raw process.kill()
+      // can leave the PTY owner alive long enough for worktree teardown to
+      // time out even after descendant cleanup succeeds.
       if (dead || (process.platform === 'win32' && nodePtyKillIssued)) {
+        return
+      }
+      if (process.platform === 'win32') {
+        try {
+          proc.kill()
+          nodePtyKillIssued = true
+        } catch (error) {
+          nodePtyKillIssued = false
+          throw error
+        }
         return
       }
       try {

--- a/src/main/daemon/terminal-host-agent-inference.test.ts
+++ b/src/main/daemon/terminal-host-agent-inference.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TerminalHost } from './terminal-host'
+import type { SubprocessHandle } from './session'
+
+const killWithDescendantSweepMock = vi.hoisted(() => vi.fn())
+vi.mock('../pty-descendant-termination', () => ({
+  killWithDescendantSweep: killWithDescendantSweepMock
+}))
+
+function createMockSubprocess(): SubprocessHandle & {
+  _onExitCb: ((code: number) => void) | null
+} {
+  let onExitCb: ((code: number) => void) | null = null
+  return {
+    pid: 99999,
+    getForegroundProcess: vi.fn(() => null),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(() => {
+      setTimeout(() => onExitCb?.(0), 5)
+    }),
+    forceKill: vi.fn(() => onExitCb?.(137)),
+    signal: vi.fn(),
+    onData: vi.fn(),
+    onExit(cb) {
+      onExitCb = cb
+    },
+    dispose: vi.fn(),
+    get _onExitCb() {
+      return onExitCb
+    }
+  }
+}
+
+describe('TerminalHost agent inference', () => {
+  let host: TerminalHost
+  let spawnFn: ReturnType<typeof vi.fn>
+  let lastSubprocess: ReturnType<typeof createMockSubprocess>
+
+  beforeEach(() => {
+    killWithDescendantSweepMock.mockReset()
+    spawnFn = vi.fn(() => {
+      lastSubprocess = createMockSubprocess()
+      return lastSubprocess
+    })
+    host = new TerminalHost({ spawnSubprocess: spawnFn })
+  })
+
+  afterEach(async () => {
+    await host.dispose()
+  })
+
+  it('infers agent identity from the startup command and forwards it to spawn', async () => {
+    const result = await host.createOrAttach({
+      sessionId: 'session-1',
+      cols: 80,
+      rows: 24,
+      command: 'powershell -File C:\\tools\\claude.ps1',
+      streamClient: { onData: vi.fn(), onExit: vi.fn() }
+    })
+
+    expect(spawnFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-1',
+        command: 'powershell -File C:\\tools\\claude.ps1',
+        launchAgent: 'claude'
+      })
+    )
+    expect(result.launchAgent).toBe('claude')
+  })
+
+  it('routes command-inferred immediate agent kill through the descendant sweep', async () => {
+    await host.createOrAttach({
+      sessionId: 'agent-inferred',
+      cols: 80,
+      rows: 24,
+      command: 'powershell -File C:\\tools\\claude.ps1',
+      streamClient: { onData: vi.fn(), onExit: vi.fn() }
+    })
+    lastSubprocess.forceKill = vi.fn()
+
+    const killing = host.kill('agent-inferred', { immediate: true })
+
+    expect(killWithDescendantSweepMock).toHaveBeenCalledWith(
+      99999,
+      expect.any(Function),
+      expect.objectContaining({ ownsRoot: expect.any(Function) })
+    )
+    expect(lastSubprocess.forceKill).not.toHaveBeenCalled()
+
+    const finish = killWithDescendantSweepMock.mock.calls[0][1] as () => void
+    finish()
+    expect(lastSubprocess.forceKill).toHaveBeenCalledOnce()
+
+    lastSubprocess._onExitCb?.(137)
+    await killing
+    expect(lastSubprocess.dispose).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -3,6 +3,7 @@ import { normalizePtySize } from './daemon-pty-size'
 import { shellPathSupportsPtyStartupBarrier } from './shell-ready'
 import { resolveProcessCwd } from '../providers/process-cwd'
 import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery'
+import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process-recognition'
 import { buildStartupCommandSubmission } from '../../shared/startup-command-submission'
 import {
   SessionNotFoundError,
@@ -110,6 +111,8 @@ export class TerminalHost {
     // Clear tombstone if re-creating a killed session
     this.killedTombstones.delete(opts.sessionId)
     const size = normalizePtySize(opts.cols, opts.rows)
+    const launchAgent =
+      opts.launchAgent ?? recognizeAgentProcessFromCommandLine(opts.command)?.agent
 
     const subprocess = this.spawnSubprocess({
       sessionId: opts.sessionId,
@@ -120,7 +123,7 @@ export class TerminalHost {
       envToDelete: opts.envToDelete,
       command: opts.command,
       startupCommandDelivery: opts.startupCommandDelivery,
-      ...(opts.launchAgent ? { launchAgent: opts.launchAgent } : {}),
+      ...(launchAgent ? { launchAgent } : {}),
       shellOverride: opts.shellOverride,
       terminalWindowsWslDistro: opts.terminalWindowsWslDistro,
       terminalWindowsPowerShellImplementation: opts.terminalWindowsPowerShellImplementation
@@ -141,7 +144,7 @@ export class TerminalHost {
       cols: size.cols,
       rows: size.rows,
       terminalHandle: opts.env?.ORCA_TERMINAL_HANDLE,
-      launchAgent: opts.launchAgent,
+      launchAgent,
       subprocess,
       shellReadySupported,
       historySeed: opts.historySeed,

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -10,8 +10,7 @@ const {
   writeFileSyncMock,
   spawnMock,
   resolveAgentForegroundProcessMock,
-  captureDescendantSnapshotMock,
-  terminateDescendantSnapshotMock
+  killWithDescendantSweepMock
 } = vi.hoisted(() => ({
   existsSyncMock: vi.fn(),
   statSyncMock: vi.fn(),
@@ -20,8 +19,7 @@ const {
   writeFileSyncMock: vi.fn(),
   spawnMock: vi.fn(),
   resolveAgentForegroundProcessMock: vi.fn(),
-  captureDescendantSnapshotMock: vi.fn(),
-  terminateDescendantSnapshotMock: vi.fn()
+  killWithDescendantSweepMock: vi.fn()
 }))
 
 vi.mock('fs', () => ({
@@ -45,8 +43,7 @@ vi.mock('node-pty', () => ({
 }))
 
 vi.mock('../pty-descendant-termination', () => ({
-  captureDescendantSnapshot: captureDescendantSnapshotMock,
-  terminateDescendantSnapshot: terminateDescendantSnapshotMock
+  killWithDescendantSweep: killWithDescendantSweepMock
 }))
 
 // Resolve PowerShell family names to deterministic absolute paths (the fs mock
@@ -136,9 +133,10 @@ describe('LocalPtyProvider', () => {
     accessSyncMock.mockReturnValue(undefined)
     mkdirSyncMock.mockReset()
     writeFileSyncMock.mockReset()
-    captureDescendantSnapshotMock.mockReset()
-    captureDescendantSnapshotMock.mockResolvedValue(null)
-    terminateDescendantSnapshotMock.mockReset()
+    killWithDescendantSweepMock.mockReset()
+    killWithDescendantSweepMock.mockImplementation(async (_pid: number, killRoot: () => void) =>
+      killRoot()
+    )
     resolveAgentForegroundProcessMock.mockReset()
     resolveAgentForegroundProcessMock.mockImplementation(
       async (_pid: number, fallbackProcess: string | null) => ({
@@ -1242,12 +1240,13 @@ describe('LocalPtyProvider', () => {
     })
 
     it('waits for an in-flight agent shutdown before reusing the same session id', async () => {
-      let resolveSnapshot!: (value: null) => void
-      captureDescendantSnapshotMock.mockReturnValue(
-        new Promise<null>((resolve) => {
-          resolveSnapshot = resolve
+      let resolveSweep!: () => void
+      killWithDescendantSweepMock.mockImplementation(async (_pid: number, killRoot: () => void) => {
+        await new Promise<void>((resolve) => {
+          resolveSweep = resolve
         })
-      )
+        killRoot()
+      })
       const spawnArgs = {
         cols: 80,
         rows: 24,
@@ -1262,19 +1261,20 @@ describe('LocalPtyProvider', () => {
       await Promise.resolve()
       expect(spawnMock).toHaveBeenCalledTimes(spawnCallsBefore + 1)
 
-      resolveSnapshot(null)
+      resolveSweep()
       await shutdown
       await respawn
       expect(spawnMock).toHaveBeenCalledTimes(spawnCallsBefore + 2)
     })
 
     it('coalesces duplicate shutdown while descendant capture is pending', async () => {
-      let resolveSnapshot!: (value: null) => void
-      captureDescendantSnapshotMock.mockReturnValue(
-        new Promise<null>((resolve) => {
-          resolveSnapshot = resolve
+      let resolveSweep!: () => void
+      killWithDescendantSweepMock.mockImplementation(async (_pid: number, killRoot: () => void) => {
+        await new Promise<void>((resolve) => {
+          resolveSweep = resolve
         })
-      )
+        killRoot()
+      })
       const { id } = await provider.spawn({
         cols: 80,
         rows: 24,
@@ -1283,22 +1283,23 @@ describe('LocalPtyProvider', () => {
 
       const first = provider.shutdown(id, { immediate: true })
       const second = provider.shutdown(id, { immediate: true })
-      expect(captureDescendantSnapshotMock).toHaveBeenCalledOnce()
-      resolveSnapshot(null)
+      expect(killWithDescendantSweepMock).toHaveBeenCalledOnce()
+      resolveSweep()
       await Promise.all([first, second])
-      expect(captureDescendantSnapshotMock).toHaveBeenCalledOnce()
+      expect(killWithDescendantSweepMock).toHaveBeenCalledOnce()
     })
 
     it('does not signal a captured tree after the tracked root exits naturally', async () => {
-      let resolveSnapshot!: (value: {
-        rootPgid: number
-        descendants: []
-        capturedAtMs: number
-      }) => void
-      captureDescendantSnapshotMock.mockReturnValue(
-        new Promise((resolve) => {
-          resolveSnapshot = resolve
-        })
+      let resolveSweep!: () => void
+      killWithDescendantSweepMock.mockImplementation(
+        async (_pid: number, killRoot: () => void, deps: { ownsRoot?: () => boolean }) => {
+          await new Promise<void>((resolve) => {
+            resolveSweep = resolve
+          })
+          if (deps.ownsRoot?.()) {
+            killRoot()
+          }
+        }
       )
       const { id } = await provider.spawn({
         cols: 80,
@@ -1308,10 +1309,10 @@ describe('LocalPtyProvider', () => {
 
       const shutdown = provider.shutdown(id, { immediate: true })
       exitCb?.({ exitCode: 0 })
-      resolveSnapshot({ rootPgid: mockProc.pid, descendants: [], capturedAtMs: Date.now() })
+      resolveSweep()
       await shutdown
 
-      expect(terminateDescendantSnapshotMock).not.toHaveBeenCalled()
+      expect(killWithDescendantSweepMock).toHaveBeenCalledOnce()
     })
   })
 

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -55,10 +55,7 @@ import { resolveAgentForegroundProcessWithAvailability } from './agent-foregroun
 import { resolveStableForegroundProcess } from './stable-foreground-process'
 import { getAgentForegroundContextPaths } from './agent-foreground-context-paths'
 import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process-recognition'
-import {
-  captureDescendantSnapshot,
-  terminateDescendantSnapshot
-} from '../pty-descendant-termination'
+import { killWithDescendantSweep } from '../pty-descendant-termination'
 import { readWindowsConptyProcessIds } from './windows-conpty-process-membership'
 import { forceKillPosixPtyProcessGroups } from '../pty/posix-pty-process-groups'
 import { shouldUseShellReadyStartupDelivery } from '../../shared/codex-startup-delivery'
@@ -1075,19 +1072,25 @@ export class LocalPtyProvider implements IPtyProvider {
     operation: PtyShutdownOperation
   ): Promise<void> {
     const physicalExit = ptyPhysicalExits.get(id)
-    // Why: the snapshot must precede any signal — once the shell dies,
-    // surviving descendants reparent to pid 1 and a ppid walk can't find them.
-    const descendants = ptyAgentSessionIds.has(id)
-      ? await captureDescendantSnapshot(proc.pid)
-      : null
-    // Why: a natural exit can race the snapshot. Never signal descendants or
-    // a root PID after this exact PTY has lost ownership.
-    if (ptyProcesses.get(id) === proc) {
-      if (descendants) {
-        terminateDescendantSnapshot(descendants)
-      }
-      // Cancel startup delivery now, but preserve the exit listener and all
-      // ownership maps until node-pty reports the physical process exit.
+    if (ptyAgentSessionIds.has(id)) {
+      await killWithDescendantSweep(
+        proc.pid,
+        () => {
+          if (ptyProcesses.get(id) !== proc) {
+            return
+          }
+          // Cancel startup delivery now, but preserve the exit listener and all
+          // ownership maps until node-pty reports the physical process exit.
+          runPtyCleanup(id)
+          operation.rootSignalled = true
+          this.requestTrackedPtyShutdown(id, proc, operation.immediate)
+        },
+        {
+          ownsRoot: () => ptyProcesses.get(id) === proc,
+          readWindowsProcessIds: () => readWindowsConptyProcessIds(proc.pid)
+        }
+      )
+    } else if (ptyProcesses.get(id) === proc) {
       runPtyCleanup(id)
       operation.rootSignalled = true
       this.requestTrackedPtyShutdown(id, proc, operation.immediate)

--- a/src/main/providers/windows-foreground-process-rows.test.ts
+++ b/src/main/providers/windows-foreground-process-rows.test.ts
@@ -96,4 +96,35 @@ describe('windows foreground process rows spawn options', () => {
     expect(candidates?.[0]?.pid).toBe(200)
     expect(optionsForCommand('wmic')).toMatchObject({ windowsHide: true })
   })
+
+  it('keeps descendants when the root pid has already exited but child rows still point to it', async () => {
+    execFileMock.mockImplementation((_cmd: string, _args, _opts, cb: ExecFileCallback) => {
+      cb(null, {
+        stdout: JSON.stringify([
+          {
+            ProcessId: 200,
+            ParentProcessId: 100,
+            Name: 'powershell.exe',
+            CommandLine: 'powershell.exe -File C:/tools/claude.ps1',
+            ExecutablePath: 'C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe'
+          },
+          {
+            ProcessId: 300,
+            ParentProcessId: 200,
+            Name: 'node.exe',
+            CommandLine: 'node claude-child.js',
+            ExecutablePath: 'C:/Program Files/nodejs/node.exe'
+          }
+        ]),
+        stderr: ''
+      })
+    })
+
+    const candidates = await queryWindowsProcessDescendants(100, { fresh: true })
+
+    expect(candidates).toEqual([
+      expect.objectContaining({ pid: 300, ppid: 200, depth: 2 }),
+      expect.objectContaining({ pid: 200, ppid: 100, depth: 1 })
+    ])
+  })
 })

--- a/src/main/providers/windows-foreground-process-rows.ts
+++ b/src/main/providers/windows-foreground-process-rows.ts
@@ -60,9 +60,11 @@ export async function queryWindowsProcessDescendants(
   } catch {
     return null
   }
-  // Why: a snapshot that omitted the PTY root may be stale or permission-
-  // filtered; only an observed root can authoritatively have no descendants.
-  if (!rows.some((row) => row.pid === rootPid)) {
+  // Why: a startup shell on Windows can spawn the long-lived agent shell and
+  // then exit before teardown runs. Keep that child chain when the snapshot
+  // still shows rows parented to the original pid; otherwise a missing root
+  // would mask live descendants and leave worktree cleanup hanging.
+  if (!rows.some((row) => row.pid === rootPid) && !rows.some((row) => row.ppid === rootPid)) {
     return null
   }
   return collectDescendants(rows, rootPid).sort((a, b) => b.depth - a.depth)

--- a/src/main/pty-descendant-termination.test.ts
+++ b/src/main/pty-descendant-termination.test.ts
@@ -52,7 +52,11 @@ function snapshot(
   rootPgid: number | null = 10,
   capturedAtMs = CAPTURED_AT_MS
 ) {
-  return { rootPgid, descendants, capturedAtMs }
+  return { platform: 'posix' as const, rootPgid, descendants, capturedAtMs }
+}
+
+function windowsDescendants(...pids: number[]) {
+  return new Set(pids)
 }
 
 describe('parseProcessTable', () => {
@@ -115,10 +119,56 @@ describe('captureDescendantSnapshot', () => {
     expect(vi.getTimerCount()).toBe(0)
   })
 
-  it('is a null no-op on Windows', async () => {
-    const readTable = vi.fn()
-    expect(await captureDescendantSnapshot(10, { readTable, platform: 'win32' })).toBeNull()
-    expect(readTable).not.toHaveBeenCalled()
+  it('captures Windows ConPTY members without the root', async () => {
+    const readWindowsProcessIds = vi.fn().mockResolvedValue(new Set([10, 20, 30]))
+    await expect(
+      captureDescendantSnapshot(10, {
+        platform: 'win32',
+        readWindowsDescendantPids: vi.fn().mockResolvedValue(null),
+        readWindowsProcessIds
+      })
+    ).resolves.toMatchObject({ platform: 'win32', rootPid: 10, descendants: [20, 30] })
+    expect(readWindowsProcessIds).toHaveBeenCalledWith(10)
+  })
+
+  it('captures Windows detached descendants from the live parent chain', async () => {
+    await expect(
+      captureDescendantSnapshot(10, {
+        platform: 'win32',
+        readWindowsDescendantPids: vi.fn().mockResolvedValue(windowsDescendants(20, 30)),
+        readWindowsProcessIds: vi.fn().mockResolvedValue(null)
+      })
+    ).resolves.toMatchObject({ platform: 'win32', rootPid: 10, descendants: [20, 30] })
+  })
+
+  it('unions Windows detached descendants with ConPTY members', async () => {
+    await expect(
+      captureDescendantSnapshot(10, {
+        platform: 'win32',
+        readWindowsDescendantPids: vi.fn().mockResolvedValue(windowsDescendants(20, 30)),
+        readWindowsProcessIds: vi.fn().mockResolvedValue(new Set([10, 30, 40]))
+      })
+    ).resolves.toMatchObject({ platform: 'win32', rootPid: 10, descendants: [20, 30, 40] })
+  })
+
+  it('degrades to null when both Windows snapshot sources are unavailable', async () => {
+    await expect(
+      captureDescendantSnapshot(10, {
+        platform: 'win32',
+        readWindowsDescendantPids: vi.fn().mockResolvedValue(null),
+        readWindowsProcessIds: vi.fn().mockResolvedValue(null)
+      })
+    ).resolves.toBeNull()
+  })
+
+  it('degrades to the parent-chain snapshot when Windows membership contains only the root', async () => {
+    await expect(
+      captureDescendantSnapshot(10, {
+        platform: 'win32',
+        readWindowsDescendantPids: vi.fn().mockResolvedValue(windowsDescendants(20)),
+        readWindowsProcessIds: vi.fn().mockResolvedValue(new Set([10]))
+      })
+    ).resolves.toMatchObject({ platform: 'win32', rootPid: 10, descendants: [20] })
   })
 
   it('degrades to null when ps fails', async () => {
@@ -198,6 +248,15 @@ describe('terminateDescendantSnapshot', () => {
       [20, 'SIGTERM'],
       [30, 'SIGTERM']
     ])
+  })
+
+  it('kills Windows descendants immediately and leaves the root to the caller', () => {
+    const killWindowsProcess = vi.fn()
+    terminateDescendantSnapshot(
+      { platform: 'win32', rootPid: 10, descendants: [20, 30], capturedAtMs: CAPTURED_AT_MS },
+      { killWindowsProcess }
+    )
+    expect(killWindowsProcess.mock.calls).toEqual([[20], [30]])
   })
 
   it('SIGKILLs only identity-matched survivors after the grace window', async () => {
@@ -379,5 +438,23 @@ describe('killWithDescendantSweep', () => {
     expect(ownsRoot).toHaveBeenCalledOnce()
     expect(sendSignal).not.toHaveBeenCalled()
     expect(killRoot).toHaveBeenCalledOnce()
+  })
+
+  it('kills Windows descendants before closing the root', async () => {
+    const events: string[] = []
+    const readWindowsDescendantPids = vi.fn().mockResolvedValue(windowsDescendants(20))
+    const readWindowsProcessIds = vi.fn().mockResolvedValue(new Set([10, 30]))
+    const killWindowsProcess = vi.fn(() => events.push('descendant-kill'))
+    const killRoot = vi.fn(() => events.push('root-kill'))
+
+    await killWithDescendantSweep(10, killRoot, {
+      platform: 'win32',
+      readWindowsDescendantPids,
+      readWindowsProcessIds,
+      killWindowsProcess
+    })
+
+    expect(killWindowsProcess.mock.calls).toEqual([[20], [30]])
+    expect(events).toEqual(['descendant-kill', 'descendant-kill', 'root-kill'])
   })
 })

--- a/src/main/pty-descendant-termination.ts
+++ b/src/main/pty-descendant-termination.ts
@@ -1,4 +1,6 @@
 import { execFile } from 'node:child_process'
+import { readWindowsConptyProcessIds } from './providers/windows-conpty-process-membership'
+import { queryWindowsProcessDescendants } from './providers/windows-foreground-process-rows'
 
 export const DESCENDANT_KILL_GRACE_MS = 2_000
 export const DESCENDANT_SNAPSHOT_TIMEOUT_MS = 1_000
@@ -15,13 +17,23 @@ export type ProcessTableRow = {
   startedAt: string
 }
 
-export type DescendantSnapshot = {
+export type PosixDescendantSnapshot = {
+  platform: 'posix'
   rootPgid: number | null
   descendants: ProcessTableRow[]
   /** Wall-clock boundary for deciding whether ps's second-resolution lstart
    *  can safely distinguish this process from a later PID reuse. */
   capturedAtMs: number
 }
+
+export type WindowsDescendantSnapshot = {
+  platform: 'win32'
+  rootPid: number
+  descendants: number[]
+  capturedAtMs: number
+}
+
+export type DescendantSnapshot = PosixDescendantSnapshot | WindowsDescendantSnapshot
 
 export type ProcessTableCapture = {
   rows: ProcessTableRow[]
@@ -147,7 +159,7 @@ export function collectDescendantRows(
   rootPid: number,
   table: ProcessTableRow[],
   capturedAtMs = Date.now()
-): DescendantSnapshot {
+): PosixDescendantSnapshot {
   const childrenByPpid = new Map<number, ProcessTableRow[]>()
   let rootRow: ProcessTableRow | null = null
   for (const row of table) {
@@ -178,20 +190,29 @@ export function collectDescendantRows(
       queue.push(child.pid)
     }
   }
-  return { rootPgid: rootRow?.pgid ?? null, descendants, capturedAtMs }
+  return { platform: 'posix', rootPgid: rootRow?.pgid ?? null, descendants, capturedAtMs }
 }
 
 type SnapshotDeps = {
   readTable?: ProcessTableReader
+  readWindowsProcessIds?: (rootPid: number) => Promise<ReadonlySet<number> | null>
+  readWindowsDescendantPids?: (rootPid: number) => Promise<ReadonlySet<number> | null>
   platform?: NodeJS.Platform
   timeoutMs?: number
+}
+
+async function readWindowsDetachedDescendantPids(
+  rootPid: number
+): Promise<ReadonlySet<number> | null> {
+  const descendants = await queryWindowsProcessDescendants(rootPid, { fresh: true })
+  return descendants ? new Set(descendants.map((candidate) => candidate.pid)) : null
 }
 
 /**
  * Snapshots a PTY root's live descendant tree. Must run BEFORE the root is
  * signalled: once the root dies, surviving descendants reparent to pid 1 and
  * can no longer be found by a ppid walk. Resolves null (never rejects) on
- * Windows, ps failure, or timeout — callers then degrade to today's
+ * ps failure, or timeout; callers then degrade to today's
  * shell-only kill.
  */
 export async function captureDescendantSnapshot(
@@ -199,8 +220,35 @@ export async function captureDescendantSnapshot(
   deps: SnapshotDeps = {}
 ): Promise<DescendantSnapshot | null> {
   const platform = deps.platform ?? process.platform
-  if (platform === 'win32' || !Number.isInteger(rootPid) || rootPid <= 0) {
+  if (!Number.isInteger(rootPid) || rootPid <= 0) {
     return null
+  }
+  if (platform === 'win32') {
+    const descendantPids = new Set<number>()
+    try {
+      for (const pid of (await (
+        deps.readWindowsDescendantPids ?? readWindowsDetachedDescendantPids
+      )(rootPid)) ?? []) {
+        descendantPids.add(pid)
+      }
+    } catch {
+      /* degrade to the console-membership snapshot */
+    }
+    try {
+      const members = await (deps.readWindowsProcessIds ?? readWindowsConptyProcessIds)(rootPid)
+      if (members?.has(rootPid)) {
+        for (const pid of members) {
+          if (pid !== rootPid) {
+            descendantPids.add(pid)
+          }
+        }
+      }
+    } catch {
+      /* degrade to the parent-chain snapshot */
+    }
+    return descendantPids.size > 0
+      ? { platform: 'win32', rootPid, descendants: [...descendantPids], capturedAtMs: Date.now() }
+      : null
   }
   const readTable = deps.readTable ?? readProcessTable
   const timeoutMs = deps.timeoutMs ?? DESCENDANT_SNAPSHOT_TIMEOUT_MS
@@ -247,6 +295,7 @@ function defaultSendSignal(pid: number, signal: NodeJS.Signals): void {
 type TerminateDeps = {
   readTable?: ProcessTableReader
   sendSignal?: SignalSender
+  killWindowsProcess?: (pid: number) => void
   graceMs?: number
   timeoutMs?: number
 }
@@ -271,6 +320,18 @@ export function terminateDescendantSnapshot(
   snapshot: DescendantSnapshot,
   deps: TerminateDeps = {}
 ): void {
+  if (snapshot.platform === 'win32') {
+    const killWindowsProcess =
+      deps.killWindowsProcess ?? ((pid: number) => process.kill(pid, 'SIGKILL'))
+    for (const pid of snapshot.descendants) {
+      try {
+        killWindowsProcess(pid)
+      } catch {
+        /* already gone */
+      }
+    }
+    return
+  }
   const sendSignal = deps.sendSignal ?? defaultSendSignal
   const readTable = deps.readTable ?? readProcessTable
   for (const row of snapshot.descendants) {

--- a/tests/e2e/agent-descendant-process-kill.spec.ts
+++ b/tests/e2e/agent-descendant-process-kill.spec.ts
@@ -19,10 +19,14 @@ function isProcessAlive(pid: number): boolean {
 // token is literally `claude` so PTY spawn recognition marks the session as an
 // agent; tab close → pty.kill routing is already covered by
 // terminal-parked-close-retirement.spec.ts, so this spec drives pty.kill.
-test('killing an agent PTY terminates its detached-pgid descendants', async ({ orcaPage }) => {
-  test.skip(process.platform === 'win32', 'descendant tree-kill is POSIX-only for now')
-
+test('killing an agent PTY terminates its detached-pgid descendants', async ({
+  orcaPage,
+  registerPostElectronShutdownCleanup
+}) => {
   const stage = mkdtempSync(join(tmpdir(), 'orca-agent-descendant-'))
+  registerPostElectronShutdownCleanup(async () => {
+    rmSync(stage, { recursive: true, force: true })
+  })
   const markerPath = join(stage, 'detached-child.pid')
   const spawnerPath = join(stage, 'spawn-detached.cjs')
   writeFileSync(
@@ -31,7 +35,7 @@ test('killing an agent PTY terminates its detached-pgid descendants', async ({ o
       "const { spawn } = require('node:child_process')",
       // detached:true → setsid → own pgid/session, exactly the topology of an
       // agent CLI's tool subprocess that a dying shell's SIGHUP cannot reach.
-      "const child = spawn('sleep', ['31337'], { detached: true, stdio: 'ignore' })",
+      "const child = process.platform === 'win32' ? spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { detached: true, stdio: 'ignore' }) : spawn('sleep', ['31337'], { detached: true, stdio: 'ignore' })",
       'child.unref()',
       "require('node:fs').writeFileSync(process.argv[2], String(child.pid))",
       // Stay alive like a real agent at its prompt: the detached child's ppid
@@ -41,9 +45,13 @@ test('killing an agent PTY terminates its detached-pgid descendants', async ({ o
       ''
     ].join('\n')
   )
-  const fakeAgentPath = join(stage, 'claude')
-  writeFileSync(fakeAgentPath, `#!/bin/sh\nexec "${process.execPath}" "${spawnerPath}" "$1"\n`)
-  chmodSync(fakeAgentPath, 0o755)
+  const fakeAgentPath = join(stage, process.platform === 'win32' ? 'claude.cmd' : 'claude')
+  if (process.platform === 'win32') {
+    writeFileSync(fakeAgentPath, `@echo off\r\n"${process.execPath}" "${spawnerPath}" "%~1"\r\n`)
+  } else {
+    writeFileSync(fakeAgentPath, `#!/bin/sh\nexec "${process.execPath}" "${spawnerPath}" "$1"\n`)
+    chmodSync(fakeAgentPath, 0o755)
+  }
 
   let detachedChildPid = 0
   try {
@@ -51,18 +59,27 @@ test('killing an agent PTY terminates its detached-pgid descendants', async ({ o
     const worktreeId = await waitForActiveWorktree(orcaPage)
 
     const ptyId = await orcaPage.evaluate(
-      async ({ command, cwd, worktreeId: wt }) => {
+      async ({ command, cwd, shellOverride, worktreeId: wt }) => {
         const result = await window.api.pty.spawn({
           cols: 120,
           rows: 40,
           cwd,
           command,
           launchAgent: 'claude',
+          ...(shellOverride ? { shellOverride } : {}),
           worktreeId: wt
         })
         return result.id
       },
-      { command: `'${fakeAgentPath}' '${markerPath}'`, cwd: stage, worktreeId }
+      {
+        ...(process.platform === 'win32' ? { shellOverride: 'cmd.exe' } : {}),
+        command:
+          process.platform === 'win32'
+            ? `"${fakeAgentPath}" "${markerPath}"`
+            : `'${fakeAgentPath}' '${markerPath}'`,
+        cwd: stage,
+        worktreeId
+      }
     )
     expect(ptyId).toBeTruthy()
 
@@ -92,6 +109,5 @@ test('killing an agent PTY terminates its detached-pgid descendants', async ({ o
         /* already gone */
       }
     }
-    rmSync(stage, { recursive: true, force: true })
   }
 })


### PR DESCRIPTION
## Summary

- Terminate Windows agent descendants before PTY teardown closes the root shell, including detached children that fall outside the ConPTY membership list.
- Reuse the shared descendant-sweep owner in `LocalPtyProvider`, keep root-kill ownership with the caller, and preserve macOS/Linux teardown behavior.
- Keep daemon-backed worktree teardown on the same agent-owned path by inferring `launchAgent` from startup commands such as `powershell -File ...\\claude.ps1`.
- Preserve Windows descendant capture even after a startup shell exits, as long as `Win32_Process` still shows the live child chain under that root PID.
- Use node-pty's native Windows kill path for daemon immediate teardown so ConPTY ownership closes the same way in headless worktree removal as it does in the local provider.
- Stabilize the Windows descendant E2E by pinning the fixture shell to `cmd.exe` and deferring temp-dir cleanup until after Electron shutdown.

Closes #9045.

## Screenshots

No visual change

## Testing

- [x] `pnpm exec vitest run src/main/pty-descendant-termination.test.ts src/main/providers/local-pty-provider.test.ts`
- [x] `pnpm exec vitest run src/main/daemon/terminal-host.test.ts src/main/daemon/pty-subprocess.test.ts src/main/providers/windows-foreground-process-rows.test.ts src/main/daemon/daemon-server.test.ts`
- [x] `pnpm run typecheck:node`
- [x] `pnpm exec oxlint src/main/pty-descendant-termination.ts src/main/pty-descendant-termination.test.ts src/main/providers/local-pty-provider.ts src/main/providers/local-pty-provider.test.ts tests/e2e/agent-descendant-process-kill.spec.ts`
- [x] `pnpm exec oxfmt src/main/pty-descendant-termination.ts src/main/pty-descendant-termination.test.ts tests/e2e/agent-descendant-process-kill.spec.ts`
- [x] `pnpm run test:e2e -- tests/e2e/agent-descendant-process-kill.spec.ts`
- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Manual Windows worktree-delete pass with orphan-process check

## AI Review Report

- Windows teardown no longer depends on ConPTY membership alone; it snapshots the live `Win32_Process` parent chain before root kill, then unions those PIDs with attached console members.
- Local provider ownership stayed fail-closed. Descendants are only signaled while the tracked PTY still owns the root, and physical-exit waiting remains in the provider.
- Daemon-backed teardown now shares the same ownership model: agent identity is inferred from startup commands, Windows immediate kill closes ConPTY through node-pty, and startup-shell PID loss no longer blinds the descendant snapshot.
- The change stays inside existing main-process teardown code. Renderer, IPC, and non-Windows signal contracts are unchanged by the follow-up fix.

## Security Audit

- Windows descendant PIDs come from bounded host-owned sources already used by Orca, not from renderer input or shell text.
- The root PID is still excluded from descendant kills inside the shared helper.
- The new parent-chain snapshot is read-only process metadata. It does not add filesystem, network, or IPC authority.

## Notes

No visual change. The focused Windows runtime repro passed on Saturday, July 18, 2026. The headless manual worktree-delete proof also passed on Saturday, July 18, 2026 after rebuilding the `out/` bundle that `orca-dev serve` actually launches.

## ELI5

On Windows, closing a PTY could leave agent child processes running after the shell exited. Descendants are terminated during teardown so ConPTY cleanups do not orphan agent processes.
