### PR TITLE
fix(grok): O(1) session path via encode_cwd_dirname parity

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "@electron-toolkit/utils": "^4.0.0",
     "@floating-ui/dom": "1.7.6",
     "@linear/sdk": "^82.1.0",
+    "@noble/hashes": "^1.8.0",
     "@parcel/watcher": "^2.5.6",
     "@xterm/addon-serialize": "0.15.0-beta.287",
     "@xterm/headless": "6.1.0-beta.287",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@linear/sdk':
         specifier: ^82.1.0
         version: 82.1.0(graphql@16.14.2)
+      '@noble/hashes':
+        specifier: ^1.8.0
+        version: 1.8.0
       '@parcel/watcher':
         specifier: ^2.5.6
         version: 2.5.6

--- a/src/shared/grok-cwd-dirname.test.ts
+++ b/src/shared/grok-cwd-dirname.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import {
+  encodeGrokCwdDirName,
+  encodeGrokUrlComponent,
+  GROK_ENCODED_CWD_DIR_MAX_BYTES,
+  grokCwdLeafName,
+  slugifyGrokCwdLeaf
+} from './grok-cwd-dirname'
+
+describe('grok-cwd-dirname (xai-org/grok-build encode_cwd_dirname parity)', () => {
+  it('URL-encodes short cwds like the urlencoding crate', () => {
+    expect(encodeGrokCwdDirName('/tmp/work')).toBe('%2Ftmp%2Fwork')
+    expect(encodeGrokUrlComponent('/a!b')).toBe('%2Fa%21b')
+    expect(encodeGrokUrlComponent('/a*b')).toBe('%2Fa%2Ab')
+    expect(encodeGrokUrlComponent("/a'b")).toBe('%2Fa%27b')
+    expect(encodeGrokUrlComponent('/a(b)')).toBe('%2Fa%28b%29')
+    // Unreserved `~` stays unescaped (matches Rust urlencoding).
+    expect(encodeGrokUrlComponent('com~apple')).toBe('com~apple')
+  })
+
+  it('slugifies leaves like Grok slugify', () => {
+    expect(slugifyGrokCwdLeaf('Hello World!', 40)).toBe('hello-world')
+    expect(slugifyGrokCwdLeaf('深层目录', 40)).toBe('')
+    expect(slugifyGrokCwdLeaf('a'.repeat(100), 10)).toBe('a'.repeat(10))
+    expect(grokCwdLeafName('/Users/dev/main-branch')).toBe('main-branch')
+    expect(grokCwdLeafName('C:\\Users\\dev\\my-app')).toBe('my-app')
+  })
+
+  it('uses slug-blake3 form when URL-encoded cwd exceeds 255 bytes', () => {
+    const longAb = `/${'a'.repeat(200)}/${'b'.repeat(200)}`
+    expect(Buffer.byteLength(encodeGrokUrlComponent(longAb), 'utf8')).toBeGreaterThan(
+      GROK_ENCODED_CWD_DIR_MAX_BYTES
+    )
+    // Golden from xai-org/grok-build algorithm (Rust blake3 + slugify).
+    expect(encodeGrokCwdDirName(longAb)).toBe(
+      `${'b'.repeat(40)}-e22e6487078c7674`
+    )
+  })
+
+  it('matches OSS golden vectors for long Unicode paths', () => {
+    const vectors: Array<{ cwd: string; encoded: string }> = [
+      {
+        cwd: '/Users/dev/Documents/開発プロジェクト/機能追加/テスト環境/ソースコード/main-branch',
+        encoded: 'main-branch-6aaeefdde2a621aa'
+      },
+      {
+        cwd: '/Users/user/Library/Mobile Documents/com~apple~CloudDocs/项目文件/深层嵌套目录/更深层次的/工作区域/project',
+        encoded: 'project-5a22eee5d15e14bd'
+      },
+      {
+        cwd: '/Users/user/Documents/工作文件夹/二零二六年项目/子目录一/子目录二/子目录三/源代码/code',
+        encoded: 'code-e5f13e136e4516ab'
+      },
+      {
+        cwd: '/Users/user/Library/CloudStorage/OneDrive-대한민국회사/프로젝트/개발환경/소스코드/백엔드/서비스/my-app',
+        encoded: 'my-app-00d240a68a30d482'
+      }
+    ]
+    for (const { cwd, encoded } of vectors) {
+      expect(Buffer.byteLength(encodeGrokUrlComponent(cwd), 'utf8')).toBeGreaterThan(
+        GROK_ENCODED_CWD_DIR_MAX_BYTES
+      )
+      expect(encodeGrokCwdDirName(cwd)).toBe(encoded)
+    }
+  })
+
+  it('returns null for empty cwd and rejects path-syntax components', () => {
+    expect(encodeGrokCwdDirName('')).toBeNull()
+    expect(encodeGrokCwdDirName('   ')).toBeNull()
+    expect(encodeGrokCwdDirName('.')).toBeNull()
+    expect(encodeGrokCwdDirName('..')).toBeNull()
+  })
+})

--- a/src/shared/grok-cwd-dirname.ts
+++ b/src/shared/grok-cwd-dirname.ts
@@ -1,0 +1,97 @@
+/**
+ * Grok session CWD directory encoding, aligned with xai-org/grok-build
+ * `xai_grok_config::paths::encode_cwd_dirname` (Apache-2.0 source).
+ *
+ * Short CWDs: URL-encode (urlencoding crate / unreserved set).
+ * Long CWDs (encoded > 255 bytes): `{slug40}-{blake3_hex16}` plus on-disk `.cwd`.
+ */
+import { blake3 } from '@noble/hashes/blake3'
+import { bytesToHex } from '@noble/hashes/utils'
+
+/** Filesystem max for a single directory name component (APFS/ext4/NTFS). */
+export const GROK_ENCODED_CWD_DIR_MAX_BYTES = 255
+
+const SLUG_MAX_CHARS = 40
+const BLAKE3_HEX_PREFIX_LEN = 16
+
+/**
+ * Percent-encode like Rust `urlencoding::encode`: UTF-8 bytes of every character
+ * outside the unreserved set (ALPHA / DIGIT / "-" / "." / "_" / "~").
+ * `encodeURIComponent` leaves `!'()*` unescaped; Grok's encoder does not.
+ */
+export function encodeGrokUrlComponent(value: string): string {
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`
+  )
+}
+
+/**
+ * URL-safe slug from a path leaf: lowercase, non-alnum → `-`, collapse dashes,
+ * trim, truncate to maxLen chars (matches Grok `slugify`).
+ */
+export function slugifyGrokCwdLeaf(input: string, maxLen: number = SLUG_MAX_CHARS): string {
+  let result = ''
+  let prevDash = false
+  for (const char of input.toLowerCase()) {
+    if (/[a-z0-9]/.test(char)) {
+      result += char
+      prevDash = false
+    } else if (!prevDash) {
+      result += '-'
+      prevDash = true
+    }
+  }
+  const trimmed = result.replace(/^-+|-+$/g, '')
+  return [...trimmed].slice(0, maxLen).join('')
+}
+
+// Why: split on both `/` and `\` deliberately (not host Path.file_name). Grok's
+// Rust Path is host-OS-specific; Orca resolves session paths for local and
+// remote/SSH guests, so treating either separator as a segment break keeps the
+// slug leaf correct. Blake3 still hashes the full raw cwd string either way.
+/** Last path segment using both `/` and `\` so Windows guest cwds match on any host. */
+export function grokCwdLeafName(cwd: string): string {
+  const withoutTrailing = cwd.replace(/[/\\]+$/u, '')
+  if (!withoutTrailing) {
+    return 'workspace'
+  }
+  const parts = withoutTrailing.split(/[/\\]/u)
+  const leaf = parts[parts.length - 1]
+  return leaf && leaf.length > 0 ? leaf : 'workspace'
+}
+
+/**
+ * Encode a CWD into Grok's sessions group directory name.
+ * Returns null only for empty/invalid inputs (never for "too long" — long paths
+ * use the slug+hash form).
+ */
+export function encodeGrokCwdDirName(cwd: string): string | null {
+  const trimmed = cwd.trim()
+  if (!trimmed) {
+    return null
+  }
+  let urlEncoded: string
+  try {
+    urlEncoded = encodeGrokUrlComponent(trimmed)
+  } catch {
+    return null
+  }
+  // Reject path-syntax components that would escape the sessions root.
+  if (
+    urlEncoded === '.' ||
+    urlEncoded === '..' ||
+    urlEncoded.includes('/') ||
+    urlEncoded.includes('\\')
+  ) {
+    return null
+  }
+  if (Buffer.byteLength(urlEncoded, 'utf8') <= GROK_ENCODED_CWD_DIR_MAX_BYTES) {
+    return urlEncoded
+  }
+  const hashHex = bytesToHex(blake3(new TextEncoder().encode(trimmed)))
+  const hash16 = hashHex.slice(0, BLAKE3_HEX_PREFIX_LEN)
+  const slug = slugifyGrokCwdLeaf(grokCwdLeafName(trimmed), SLUG_MAX_CHARS)
+  const safeSlug = slug.length > 0 ? slug : 'workspace'
+  return `${safeSlug}-${hash16}`
+}

--- a/src/shared/grok-session-paths.test.ts
+++ b/src/shared/grok-session-paths.test.ts
@@ -57,19 +57,20 @@ describe('grok-session-paths', () => {
     expect(resolveGrokHomeDir({}, '/home/ada')).toBe(join('/home/ada', '.grok'))
   })
 
-  it('refuses to invent encodeURIComponent names longer than 255 bytes', () => {
+  it('encodes long cwds with Grok slug+blake3 instead of inventing URL names', () => {
     const longCwd = `/${'a'.repeat(200)}/${'b'.repeat(200)}`
     expect(Buffer.byteLength(encodeURIComponent(longCwd), 'utf8')).toBeGreaterThan(
       GROK_ENCODED_CWD_DIR_MAX_BYTES
     )
-    expect(grokEncodedCwdDirName(longCwd)).toBeNull()
+    const encoded = grokEncodedCwdDirName(longCwd)
+    expect(encoded).toBe(`${'b'.repeat(40)}-e22e6487078c7674`)
     expect(
       buildGrokChatHistoryPathCandidates({
         sessionId: 'sess-1',
         cwd: longCwd,
         sessionsDir: '/tmp/sessions'
       })
-    ).toEqual([])
+    ).toEqual([join('/tmp/sessions', encoded!, 'sess-1', 'chat_history.jsonl')])
   })
 
   it('rejects unsafe session ids and path-special cwd components', async () => {
@@ -112,24 +113,24 @@ describe('grok-session-paths', () => {
     ).toBe(history)
   })
 
-  it('does not synchronously discover a long-cwd slug group', () => {
+  it('synchronously resolves a long-cwd slug group via encode_cwd_dirname', () => {
     const root = makeRoot()
     const sessionsDir = join(root, 'sessions')
     const sessionId = 'sess-long'
-    // Simulate Grok's slug+hash group directory (not encodeURIComponent of cwd).
-    const slugGroup = 'long-path-ab12cd34'
+    const longCwd = `/${'a'.repeat(200)}/${'b'.repeat(200)}`
+    const slugGroup = grokEncodedCwdDirName(longCwd)!
     const history = join(sessionsDir, slugGroup, sessionId, 'chat_history.jsonl')
     mkdirSync(dirname(history), { recursive: true })
-    writeFileSync(join(sessionsDir, slugGroup, '.cwd'), '/very/long/path\n')
+    writeFileSync(join(sessionsDir, slugGroup, '.cwd'), `${longCwd}\n`)
     writeFileSync(history, '{"type":"assistant","content":"hi"}\n')
 
     expect(
       resolveGrokChatHistoryPathSync({
         sessionId,
-        cwd: `/${'x'.repeat(300)}`,
+        cwd: longCwd,
         sessionsDir
       })
-    ).toBeNull()
+    ).toBe(history)
   })
 
   it('finds the documented group/session layout asynchronously', async () => {

--- a/src/shared/grok-session-paths.ts
+++ b/src/shared/grok-session-paths.ts
@@ -3,10 +3,20 @@ import { lstat, opendir } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import {
+  encodeGrokCwdDirName,
+  GROK_ENCODED_CWD_DIR_MAX_BYTES as GROK_CWD_DIR_MAX_BYTES
+} from './grok-cwd-dirname'
+import {
   GrokSessionPathLookupQueue,
   type GrokSessionPathScanner
 } from './grok-session-path-lookup-queue'
 
+export {
+  encodeGrokCwdDirName,
+  encodeGrokUrlComponent,
+  grokCwdLeafName,
+  slugifyGrokCwdLeaf
+} from './grok-cwd-dirname'
 export {
   GROK_SESSION_PATH_CACHE_MAX_ENTRIES,
   GROK_SESSION_SCAN_ACTIVE_ROOT_MAX,
@@ -16,8 +26,9 @@ export {
 
 export const GROK_CHAT_HISTORY_FILE = 'chat_history.jsonl'
 // Why: Grok URL-encodes the cwd for the sessions group directory. When that
-// encoded name exceeds 255 bytes it switches to a slug+hash layout.
-export const GROK_ENCODED_CWD_DIR_MAX_BYTES = 255
+// encoded name exceeds 255 bytes it switches to a slug+hash layout (OSS:
+// xai_grok_config::paths::encode_cwd_dirname).
+export const GROK_ENCODED_CWD_DIR_MAX_BYTES = GROK_CWD_DIR_MAX_BYTES
 export const GROK_SESSION_ID_MAX_LENGTH = 128
 // Why: session discovery runs in hook/main hot paths; one corrupt or enormous
 // sessions root must not cause unbounded candidate probes.
@@ -52,26 +63,16 @@ export function resolveGrokSessionsDir(
   return join(resolveGrokHomeDir(env, homeDir), 'sessions')
 }
 
-/** Return Grok's safe cwd-group component, or null for slug/invalid layouts. */
+/**
+ * Return Grok's sessions group dirname for a cwd.
+ * Short paths: URL-encoded form. Long paths: `{slug}-{blake3_hex16}`.
+ * Only empty/invalid inputs return null (length no longer forces null).
+ */
 export function grokEncodedCwdDirName(cwd: string): string | null {
-  const trimmed = cwd.trim()
-  if (!trimmed) {
-    return null
-  }
-  let encoded: string
-  try {
-    encoded = encodeURIComponent(trimmed)
-  } catch {
-    return null
-  }
-  // encodeURIComponent deliberately leaves dots untouched; reject path syntax.
-  if (encoded === '.' || encoded === '..' || encoded.includes('/') || encoded.includes('\\')) {
-    return null
-  }
-  return Buffer.byteLength(encoded, 'utf8') <= GROK_ENCODED_CWD_DIR_MAX_BYTES ? encoded : null
+  return encodeGrokCwdDirName(cwd)
 }
 
-/** Fast-path candidates when both session id and cwd are known. */
+/** Fast-path candidates when both session id and cwd are known (short + long). */
 export function buildGrokChatHistoryPathCandidates(args: {
   sessionId: string
   cwd?: string | null
@@ -85,7 +86,7 @@ export function buildGrokChatHistoryPathCandidates(args: {
   if (!cwd) {
     return []
   }
-  const encoded = grokEncodedCwdDirName(cwd)
+  const encoded = encodeGrokCwdDirName(cwd)
   if (!encoded) {
     return []
   }


### PR DESCRIPTION
## Summary

Grok chat-history lookup can miss the session file entirely for working directories containing `!`, `'`, `(`, `)` or `*`. `origin/main` builds the sessions group directory name with `encodeURIComponent` (`src/shared/grok-session-paths.ts:63`), which leaves those five characters unescaped. Grok Build's Rust `urlencoding::encode` percent-encodes every byte outside the unreserved set (ALPHA / DIGIT / `-` `.` `_` `~`), so the two disagree on the real on-disk name:

```
cwd    /Users/dev/repos/app (v2)
main   %2FUsers%2Fdev%2Frepos%2Fapp%20(v2)      <- looked up, never exists
grok   %2FUsers%2Fdev%2Frepos%2Fapp%20%28v2%29  <- the directory Grok wrote
```

The new `encodeGrokUrlComponent` closes that gap. The same module also ports Grok's long-path branch, which `main` declined to encode at all — it returned `null` once the encoded name exceeded 255 bytes and fell back to a bounded scan of up to `GROK_SESSION_GROUP_SCAN_MAX_ENTRIES` (2048) group dirs. Both branches now resolve in O(1) when `cwd` is known.

Aligned with open-source [`xai-org/grok-build`](https://github.com/xai-org/grok-build) `xai_grok_config::paths::encode_cwd_dirname`:

| CWD size | Group dirname |
|----------|----------------|
| URL-encoded ≤ 255 bytes | percent-encoded path (`urlencoding` unreserved set) |
| Longer | `{slug40}-{blake3_hex16}` (+ on-disk `.cwd` written by Grok) |

- New pure module: `src/shared/grok-cwd-dirname.ts`
- `buildGrokChatHistoryPathCandidates` / sync resolve use the full encoder (short **and** long)
- Bounded async scan remains the fallback when cwd is unknown

## Dependency note

`@noble/hashes` is pure JavaScript: no native addon, no `gypfile`, no install scripts. It therefore cannot affect the Ubuntu 20.04 / glibc 2.31 floor described in `docs/reference/linux-glibc-compatibility.md`, which constrains bundled `.node` binaries only. It has zero runtime dependencies — `pnpm-lock.yaml` records the snapshot as `'@noble/hashes@1.8.0': {}`. The library is independently audited (Cure53, 2022), with the caveat that upstream states plainly that `blake3` fell outside that audit's scope. `blake3` is used on exactly one branch: the `{slug40}-{blake3_hex16}` form for cwds whose URL-encoded name exceeds 255 bytes.

## Claude Opus review

Verdict: APPROVED (pre-push). The reviewer independently re-verified the golden blake3 vectors against the open-source algorithm.

Addressed before push:
- removed unused `isGrokSlugHashCwdDirName` (dead export)
- documented the deliberate `/` + `\` leaf split for SSH/guest path hosts

## Testing

- [x] `vitest` `grok-cwd-dirname` + `grok-session-paths` — 22 passed (includes open-source golden long-path vectors)
- [ ] full repository Vitest suite

## Notes

Contributor PR; enables native-chat, Stop enrichment, and AI Vault path hits for deep worktree paths without scanning.

## ELI5

Orca encoded the Grok chat-history directory name slightly differently from Grok itself, so some working directories were never found, and very long ones were not looked up at all. Orca now uses Grok's exact encoding, so the session file is located directly whenever the working directory is known.
