### PR TITLE
feat(status-bar): show local media playback

### DIFF
--- a/src/main/ipc/media-playback.test.ts
+++ b/src/main/ipc/media-playback.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handleMock, getMediaPlaybackStatusMock } = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  getMediaPlaybackStatusMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: handleMock }
+}))
+
+vi.mock('../media-playback/macos-media-playback-status', () => ({
+  getMediaPlaybackStatus: getMediaPlaybackStatusMock
+}))
+
+import { registerMediaPlaybackHandlers } from './media-playback'
+
+describe('registerMediaPlaybackHandlers', () => {
+  beforeEach(() => {
+    handleMock.mockReset()
+    getMediaPlaybackStatusMock.mockReset()
+  })
+
+  it('registers the read-only playback status bridge', async () => {
+    const status = {
+      player: 'spotify',
+      state: 'playing',
+      artist: 'AtHeart',
+      track: 'Say It'
+    }
+    getMediaPlaybackStatusMock.mockResolvedValue(status)
+
+    registerMediaPlaybackHandlers()
+
+    const registration = handleMock.mock.calls.find(
+      ([channel]) => channel === 'mediaPlayback:getStatus'
+    )
+    expect(registration).toBeTruthy()
+    await expect(registration![1]()).resolves.toBe(status)
+  })
+})

--- a/src/main/ipc/media-playback.ts
+++ b/src/main/ipc/media-playback.ts
@@ -1,0 +1,6 @@
+import { ipcMain } from 'electron'
+import { getMediaPlaybackStatus } from '../media-playback/macos-media-playback-status'
+
+export function registerMediaPlaybackHandlers(): void {
+  ipcMain.handle('mediaPlayback:getStatus', getMediaPlaybackStatus)
+}

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -24,6 +24,7 @@ const {
   registerTerminalRenderDesyncEvidenceHandlerMock,
   registerShellHandlersMock,
   registerPetHandlersMock,
+  registerMediaPlaybackHandlersMock,
   registerSessionHandlersMock,
   registerUIHandlersMock,
   setTrustedUIRendererWebContentsIdMock,
@@ -86,6 +87,7 @@ const {
   registerTerminalRenderDesyncEvidenceHandlerMock: vi.fn(),
   registerShellHandlersMock: vi.fn(),
   registerPetHandlersMock: vi.fn(),
+  registerMediaPlaybackHandlersMock: vi.fn(),
   registerSessionHandlersMock: vi.fn(),
   registerUIHandlersMock: vi.fn(),
   setTrustedUIRendererWebContentsIdMock: vi.fn(),
@@ -244,6 +246,10 @@ vi.mock('./pet', () => ({
   registerPetHandlers: registerPetHandlersMock
 }))
 
+vi.mock('./media-playback', () => ({
+  registerMediaPlaybackHandlers: registerMediaPlaybackHandlersMock
+}))
+
 vi.mock('./session', () => ({
   registerSessionHandlers: registerSessionHandlersMock
 }))
@@ -389,6 +395,7 @@ describe('registerCoreHandlers', () => {
     registerTerminalRenderDesyncEvidenceHandlerMock.mockReset()
     registerShellHandlersMock.mockReset()
     registerPetHandlersMock.mockReset()
+    registerMediaPlaybackHandlersMock.mockReset()
     registerSessionHandlersMock.mockReset()
     registerUIHandlersMock.mockReset()
     setTrustedUIRendererWebContentsIdMock.mockReset()
@@ -477,6 +484,7 @@ describe('registerCoreHandlers', () => {
       getPtyIdForPaneKey: expect.any(Function)
     })
     expect(registerPetHandlersMock).toHaveBeenCalled()
+    expect(registerMediaPlaybackHandlersMock).toHaveBeenCalled()
     expect(registerClaudeAccountHandlersMock).toHaveBeenCalledWith(claudeAccounts)
     expect(registerMiniMaxCredentialsHandlersMock).toHaveBeenCalledWith(rateLimits)
     expect(registerGrokAccountHandlersMock).toHaveBeenCalled()

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -46,6 +46,7 @@ import { registerTelemetryHandlers } from './telemetry'
 import { registerBrowserHandlers } from './browser'
 import { registerShellHandlers } from './shell'
 import { registerPetHandlers } from './pet'
+import { registerMediaPlaybackHandlers } from './media-playback'
 import { registerUIHandlers, setTrustedUIRendererWebContentsId } from './ui'
 import { registerEmulatorFrameStreamHandlers } from './emulator-frame-stream'
 import { registerEmulatorVideoStreamHandlers } from './emulator-video-stream'
@@ -172,6 +173,7 @@ export function registerCoreHandlers(
   registerBrowserHandlers()
   registerShellHandlers()
   registerPetHandlers()
+  registerMediaPlaybackHandlers()
   registerSessionHandlers(store)
   registerUIHandlers(store)
   registerEmulatorFrameStreamHandlers()

--- a/src/main/media-playback/macos-media-playback-status.test.ts
+++ b/src/main/media-playback/macos-media-playback-status.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { MediaPlaybackCommandRunner } from './macos-media-playback-status'
+import {
+  createMediaPlaybackStatusReader,
+  parseMediaPlaybackOutput,
+  selectMediaPlaybackStatus
+} from './macos-media-playback-status'
+
+describe('macOS media playback status', () => {
+  it('parses and normalizes AppleScript fields', () => {
+    expect(parseMediaPlaybackOutput('spotify', 'playing\u001f AtHeart \u001fSay\nIt\n')).toEqual({
+      player: 'spotify',
+      state: 'playing',
+      artist: 'AtHeart',
+      track: 'Say It'
+    })
+    expect(parseMediaPlaybackOutput('apple-music', '')).toBeNull()
+  })
+
+  it('matches tmux priority and retains the prior paused player', () => {
+    const spotify = {
+      player: 'spotify' as const,
+      state: 'paused' as const,
+      artist: 'Artist S',
+      track: 'Track S'
+    }
+    const appleMusic = {
+      player: 'apple-music' as const,
+      state: 'playing' as const,
+      artist: 'Artist A',
+      track: 'Track A'
+    }
+
+    expect(selectMediaPlaybackStatus([spotify, appleMusic], 'spotify')).toBe(appleMusic)
+    expect(
+      selectMediaPlaybackStatus([spotify, { ...appleMusic, state: 'paused' }], 'apple-music')
+    ).toMatchObject({ player: 'apple-music' })
+  })
+
+  it('queries both running players and caches the selected status for three seconds', async () => {
+    let currentTime = 1_000
+    const commandRunner = vi.fn(async (file: string, args: string[]) => {
+      if (file === '/usr/bin/pgrep') {
+        return { stdout: `${args.at(-1)}\n` }
+      }
+      const script = args.at(-1) ?? ''
+      return script.includes('com.spotify.client')
+        ? { stdout: 'paused\u001fSpotify Artist\u001fSpotify Track\n' }
+        : { stdout: 'playing\u001fMusic Artist\u001fMusic Track\n' }
+    }) as MediaPlaybackCommandRunner
+    const read = createMediaPlaybackStatusReader({
+      platform: 'darwin',
+      commandRunner,
+      now: () => currentTime
+    })
+
+    await expect(read()).resolves.toMatchObject({ player: 'apple-music', state: 'playing' })
+    await expect(read()).resolves.toMatchObject({ player: 'apple-music' })
+    expect(commandRunner).toHaveBeenCalledTimes(4)
+
+    currentTime += 3_000
+    await read()
+    expect(commandRunner).toHaveBeenCalledTimes(8)
+  })
+
+  it('does not probe local players outside macOS', async () => {
+    const commandRunner = vi.fn() as unknown as MediaPlaybackCommandRunner
+    const read = createMediaPlaybackStatusReader({ platform: 'linux', commandRunner })
+
+    await expect(read()).resolves.toBeNull()
+    expect(commandRunner).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/media-playback/macos-media-playback-status.ts
+++ b/src/main/media-playback/macos-media-playback-status.ts
@@ -1,0 +1,194 @@
+import { execFile } from 'node:child_process'
+import type {
+  MediaPlaybackPlayer,
+  MediaPlaybackState,
+  MediaPlaybackStatus
+} from '../../shared/media-playback-status'
+
+const CACHE_TTL_MS = 3_000
+const PROCESS_PROBE_TIMEOUT_MS = 1_000
+const APPLE_SCRIPT_TIMEOUT_MS = 2_000
+const FIELD_SEPARATOR = '\u001f'
+
+type CommandOptions = {
+  timeout: number
+  maxBuffer: number
+}
+
+export type MediaPlaybackCommandRunner = (
+  file: string,
+  args: string[],
+  options: CommandOptions
+) => Promise<{ stdout: string }>
+
+type PlayerDescriptor = {
+  player: MediaPlaybackPlayer
+  processName: string
+  appleScript: string
+}
+
+const PLAYERS: readonly PlayerDescriptor[] = [
+  {
+    player: 'spotify',
+    processName: 'Spotify',
+    appleScript: `tell application id "com.spotify.client"
+set playerState to player state as string
+set artistName to ""
+set trackName to ""
+try
+set artistName to artist of current track
+end try
+try
+set trackName to name of current track
+end try
+return playerState & (ASCII character 31) & artistName & (ASCII character 31) & trackName
+end tell`
+  },
+  {
+    player: 'apple-music',
+    processName: 'Music',
+    appleScript: `tell application id "com.apple.Music"
+set playerState to player state as string
+set artistName to ""
+set trackName to ""
+try
+set artistName to artist of current track
+end try
+try
+set trackName to name of current track
+end try
+return playerState & (ASCII character 31) & artistName & (ASCII character 31) & trackName
+end tell`
+  }
+]
+
+function runCommand(
+  file: string,
+  args: string[],
+  options: CommandOptions
+): Promise<{ stdout: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(file, args, { ...options, encoding: 'utf8' }, (error, stdout) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve({ stdout })
+    })
+  })
+}
+
+function normalizeText(value: string | undefined): string {
+  return (value ?? '').replace(/\s+/g, ' ').trim()
+}
+
+function normalizeState(value: string | undefined): MediaPlaybackState {
+  const state = normalizeText(value).toLowerCase()
+  if (state === 'playing' || state === 'paused') {
+    return state
+  }
+  return 'stopped'
+}
+
+export function parseMediaPlaybackOutput(
+  player: MediaPlaybackPlayer,
+  output: string
+): MediaPlaybackStatus | null {
+  const trimmed = output.trimEnd()
+  if (!trimmed) {
+    return null
+  }
+  const [state, artist, track] = trimmed.split(FIELD_SEPARATOR)
+  return {
+    player,
+    state: normalizeState(state),
+    artist: normalizeText(artist),
+    track: normalizeText(track)
+  }
+}
+
+async function queryPlayer(
+  descriptor: PlayerDescriptor,
+  commandRunner: MediaPlaybackCommandRunner
+): Promise<MediaPlaybackStatus | null> {
+  try {
+    // Why: addressing a missing or closed scriptable app can launch it or raise
+    // an Automation prompt, so only query players already running on this Mac.
+    await commandRunner('/usr/bin/pgrep', ['-x', descriptor.processName], {
+      timeout: PROCESS_PROBE_TIMEOUT_MS,
+      maxBuffer: 1_024
+    })
+    const { stdout } = await commandRunner('/usr/bin/osascript', ['-e', descriptor.appleScript], {
+      timeout: APPLE_SCRIPT_TIMEOUT_MS,
+      maxBuffer: 8_192
+    })
+    return parseMediaPlaybackOutput(descriptor.player, stdout)
+  } catch {
+    return null
+  }
+}
+
+export function selectMediaPlaybackStatus(
+  statuses: readonly (MediaPlaybackStatus | null)[],
+  previousPlayer: MediaPlaybackPlayer | null
+): MediaPlaybackStatus | null {
+  const available = statuses.filter((status): status is MediaPlaybackStatus => status !== null)
+  const spotify = available.find((status) => status.player === 'spotify') ?? null
+  const appleMusic = available.find((status) => status.player === 'apple-music') ?? null
+
+  if (spotify?.state === 'playing') {
+    return spotify
+  }
+  if (appleMusic?.state === 'playing') {
+    return appleMusic
+  }
+  return available.find((status) => status.player === previousPlayer) ?? spotify ?? appleMusic
+}
+
+type MediaPlaybackReaderOptions = {
+  platform?: NodeJS.Platform
+  commandRunner?: MediaPlaybackCommandRunner
+  now?: () => number
+}
+
+export function createMediaPlaybackStatusReader(
+  options: MediaPlaybackReaderOptions = {}
+): () => Promise<MediaPlaybackStatus | null> {
+  const platform = options.platform ?? process.platform
+  const commandRunner = options.commandRunner ?? runCommand
+  const now = options.now ?? Date.now
+  let previousPlayer: MediaPlaybackPlayer | null = null
+  let cached: { expiresAt: number; status: MediaPlaybackStatus | null } | null = null
+  let inFlight: Promise<MediaPlaybackStatus | null> | null = null
+
+  return async () => {
+    if (platform !== 'darwin') {
+      return null
+    }
+    if (cached && now() < cached.expiresAt) {
+      return cached.status
+    }
+    if (inFlight) {
+      return inFlight
+    }
+
+    inFlight = Promise.all(PLAYERS.map((player) => queryPlayer(player, commandRunner))).then(
+      (statuses) => {
+        const status = selectMediaPlaybackStatus(statuses, previousPlayer)
+        if (status) {
+          previousPlayer = status.player
+        }
+        cached = { expiresAt: now() + CACHE_TTL_MS, status }
+        return status
+      }
+    )
+
+    try {
+      return await inFlight
+    } finally {
+      inFlight = null
+    }
+  }
+}
+
+export const getMediaPlaybackStatus = createMediaPlaybackStatusReader()

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -51,7 +51,8 @@ const StatusBarItem = z.enum([
   'grok',
   'ssh',
   'resource-usage',
-  'ports'
+  'ports',
+  'media-playback'
 ])
 const WorkspaceStatusDefinition = z.object({
   id: z.string(),
@@ -217,6 +218,7 @@ export const UiUpdate = z
     _minimaxStatusBarDefaultAdded: z.boolean().optional(),
     _antigravityStatusBarDefaultAdded: z.boolean().optional(),
     _grokStatusBarDefaultAdded: z.boolean().optional(),
+    _mediaPlaybackStatusBarDefaultAdded: z.boolean().optional(),
     statusBarVisible: z.boolean().optional(),
     usagePercentageDisplay: z.enum(['used', 'remaining']).optional(),
     dismissedUpdateVersion: NullableString.optional(),

--- a/src/main/runtime/rpc/methods/client-ui.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui.test.ts
@@ -239,12 +239,21 @@ describe('client UI RPC methods', () => {
       ...getDefaultUIState(),
       worktreeCardProperties: ['status', 'branch', 'automation', 'inline-agents'],
       _worktreeCardModeDefaulted: true,
-      statusBarItems: ['codex', 'kimi', 'minimax', 'grok', 'antigravity', 'ports'],
+      statusBarItems: [
+        'codex',
+        'kimi',
+        'minimax',
+        'grok',
+        'antigravity',
+        'ports',
+        'media-playback'
+      ],
       _portsStatusBarDefaultAdded: true,
       _kimiStatusBarDefaultAdded: true,
       _minimaxStatusBarDefaultAdded: true,
       _grokStatusBarDefaultAdded: true,
       _antigravityStatusBarDefaultAdded: true,
+      _mediaPlaybackStatusBarDefaultAdded: true,
       taskResumeState: {
         githubMode: 'items',
         githubItemsQuery: 'is:open',
@@ -281,12 +290,21 @@ describe('client UI RPC methods', () => {
     const payload = {
       worktreeCardProperties: ['status', 'branch', 'automation', 'inline-agents'],
       _worktreeCardModeDefaulted: true,
-      statusBarItems: ['codex', 'kimi', 'minimax', 'grok', 'antigravity', 'ports'],
+      statusBarItems: [
+        'codex',
+        'kimi',
+        'minimax',
+        'grok',
+        'antigravity',
+        'ports',
+        'media-playback'
+      ],
       _portsStatusBarDefaultAdded: true,
       _kimiStatusBarDefaultAdded: true,
       _minimaxStatusBarDefaultAdded: true,
       _grokStatusBarDefaultAdded: true,
       _antigravityStatusBarDefaultAdded: true,
+      _mediaPlaybackStatusBarDefaultAdded: true,
       taskResumeState: {
         githubMode: 'items',
         githubItemsQuery: 'is:open',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -21,6 +21,7 @@ import type {
 } from '../shared/local-log-tail-types'
 import type { ReadClipboardTextOptions } from '../shared/clipboard-text'
 import type { AppIdentity } from '../shared/app-identity'
+import type { MediaPlaybackStatus } from '../shared/media-playback-status'
 import type {
   WriteTerminalRenderDesyncEvidenceArgs,
   WriteTerminalRenderDesyncEvidenceResult
@@ -1000,6 +1001,9 @@ export type PreloadApi = {
       osRelease: string
       displayServer: 'wayland' | 'x11' | null
     }
+  }
+  mediaPlayback: {
+    getStatus: () => Promise<MediaPlaybackStatus | null>
   }
   e2e: {
     getConfig: () => E2EConfig

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -6,6 +6,7 @@ import { electronAPI } from '@electron-toolkit/preload'
 import { preloadE2EConfig } from './e2e-config'
 import { glApi } from './gitlab'
 import type { AppIdentity } from '../shared/app-identity'
+import type { MediaPlaybackStatus } from '../shared/media-playback-status'
 import type { CliInstallStatus } from '../shared/cli-install-types'
 import type { AgentHookInstallStatus } from '../shared/agent-hook-types'
 import type { TerminalPaneSplitSource } from '../shared/feature-education-telemetry'
@@ -539,6 +540,11 @@ const api = {
       displayServer: getLinuxDisplayServer()
     })
   } satisfies PreloadApi['platform'],
+
+  mediaPlayback: {
+    getStatus: (): Promise<MediaPlaybackStatus | null> =>
+      ipcRenderer.invoke('mediaPlayback:getStatus')
+  } satisfies PreloadApi['mediaPlayback'],
 
   wsl: {
     isAvailable: (): Promise<boolean> => ipcRenderer.invoke('wsl:isAvailable'),

--- a/src/renderer/src/components/icons/SpotifyIcon.tsx
+++ b/src/renderer/src/components/icons/SpotifyIcon.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+// Why: Lucide has no Spotify glyph, so keep the Simple Icons v16 mark as a
+// local currentColor SVG instead of adding a second icon dependency.
+export function SpotifyIcon({ className }: { className?: string }): React.JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden
+      focusable="false"
+      className={className}
+      fill="currentColor"
+    >
+      <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
+    </svg>
+  )
+}

--- a/src/renderer/src/components/settings/appearance-status-bar-ports-media-toggle-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-ports-media-toggle-search.ts
@@ -1,0 +1,73 @@
+import type { StatusBarItem } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+type StatusBarToggleSearchEntry = {
+  id: StatusBarItem
+  title: string
+  description: string
+  keywords: string[]
+  toggleDescription: string
+}
+
+export function getPortsToggleEntry(): StatusBarToggleSearchEntry {
+  return {
+    id: 'ports',
+    title: translate('auto.components.settings.appearance.search.cf409b6c4d', 'Ports'),
+    description: translate(
+      'auto.components.settings.appearance.search.0ececfa190',
+      'Show live workspace ports in the status bar.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.896eb53fd4',
+        'status bar'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.006e67b279', 'ports'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.46d21eef62',
+        'localhost'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.43cfba3b95', 'server'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.dc02c8759d',
+        'workspace'
+      )
+    ],
+    toggleDescription: translate(
+      'settings.appearance.statusBar.portsToggleDescription',
+      'Show live workspace ports. Click it for workspace-scoped ports and external listeners.'
+    )
+  }
+}
+
+export function getMediaPlaybackToggleEntry(): StatusBarToggleSearchEntry {
+  return {
+    id: 'media-playback',
+    title: translate('settings.appearance.statusBar.mediaPlayback', 'Now Playing'),
+    description: translate(
+      'settings.appearance.statusBar.mediaPlaybackDescription',
+      'Show the current Apple Music or Spotify track in the status bar.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.896eb53fd4',
+        'status bar'
+      ),
+      ...translateSearchKeyword('settings.appearance.statusBar.mediaPlayback.music', 'music'),
+      ...translateSearchKeyword('settings.appearance.statusBar.mediaPlayback.spotify', 'spotify'),
+      ...translateSearchKeyword(
+        'settings.appearance.statusBar.mediaPlayback.appleMusic',
+        'apple music'
+      ),
+      ...translateSearchKeyword(
+        'settings.appearance.statusBar.mediaPlayback.nowPlaying',
+        'now playing'
+      )
+    ],
+    toggleDescription: translate(
+      'settings.appearance.statusBar.mediaPlaybackToggleDescription',
+      'Show the active local Apple Music or Spotify track on macOS.'
+    )
+  }
+}

--- a/src/renderer/src/components/settings/appearance-status-bar-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-search.ts
@@ -4,6 +4,10 @@ import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 import { getAntigravityStatusBarToggleSearchEntry } from './appearance-status-bar-antigravity-toggle-search'
 import { getGrokStatusBarToggleSearchEntry } from './appearance-status-bar-grok-toggle-search'
+import {
+  getMediaPlaybackToggleEntry,
+  getPortsToggleEntry
+} from './appearance-status-bar-ports-media-toggle-search'
 
 export const getStatusBarToggles = createLocalizedCatalog(
   (): readonly {
@@ -265,36 +269,7 @@ export const getStatusBarToggles = createLocalizedCatalog(
         'Show the Resource Manager. Click it for CPU, memory, sessions, daemon controls, and workspace disk scans.'
       )
     },
-    {
-      id: 'ports',
-      title: translate('auto.components.settings.appearance.search.cf409b6c4d', 'Ports'),
-      description: translate(
-        'auto.components.settings.appearance.search.0ececfa190',
-        'Show live workspace ports in the status bar.'
-      ),
-      keywords: [
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.896eb53fd4',
-          'status bar'
-        ),
-        ...translateSearchKeyword('auto.components.settings.appearance.search.006e67b279', 'ports'),
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.46d21eef62',
-          'localhost'
-        ),
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.43cfba3b95',
-          'server'
-        ),
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.dc02c8759d',
-          'workspace'
-        )
-      ],
-      toggleDescription: translate(
-        'settings.appearance.statusBar.portsToggleDescription',
-        'Show live workspace ports. Click it for workspace-scoped ports and external listeners.'
-      )
-    }
+    getPortsToggleEntry(),
+    getMediaPlaybackToggleEntry()
   ]
 )

--- a/src/renderer/src/components/status-bar/MediaPlaybackStatusSegment.test.tsx
+++ b/src/renderer/src/components/status-bar/MediaPlaybackStatusSegment.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MediaPlaybackStatusSegment } from './MediaPlaybackStatusSegment'
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => children,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => children,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <span>{children}</span>
+}))
+
+describe('MediaPlaybackStatusSegment', () => {
+  let container: HTMLDivElement
+  let root: Root
+  const getStatus = vi.fn()
+
+  beforeEach(() => {
+    getStatus.mockReset()
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { mediaPlayback: { getStatus } }
+    })
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('shows the player mark and emphasizes the track title before the artist', async () => {
+    getStatus.mockResolvedValue({
+      player: 'spotify',
+      state: 'paused',
+      artist: 'AtHeart',
+      track: 'Say It'
+    })
+
+    await act(async () => {
+      root.render(<MediaPlaybackStatusSegment compact={false} iconOnly={false} />)
+      await Promise.resolve()
+    })
+
+    const status = container.querySelector('[role="status"]')
+    const title = status?.querySelector('[data-media-track-title]')
+    const artist = status?.querySelector('[data-media-track-artist]')
+
+    expect(status?.querySelector('[data-media-player="spotify"] svg')).not.toBeNull()
+    expect(status?.textContent).toBe('Say It — AtHeart')
+    expect(status?.textContent).not.toContain('Spotify')
+    expect(title?.textContent).toBe('Say It')
+    expect(title?.className).toContain('font-semibold')
+    expect(title?.className).toContain('text-foreground')
+    expect(artist?.className).toContain('text-muted-foreground')
+    expect(status?.getAttribute('aria-label')).toBe('Spotify · Paused · AtHeart — Say It')
+  })
+
+  it('keeps the narrow status bar icon-only', async () => {
+    getStatus.mockResolvedValue({
+      player: 'apple-music',
+      state: 'playing',
+      artist: 'Artist',
+      track: 'Track'
+    })
+
+    await act(async () => {
+      root.render(<MediaPlaybackStatusSegment compact iconOnly />)
+      await Promise.resolve()
+    })
+
+    const status = container.querySelector('[role="status"]')
+    expect(status).not.toBeNull()
+    expect(status?.querySelector('[data-media-player="apple-music"] svg')).not.toBeNull()
+    expect(status?.textContent).toBe('')
+    expect(status?.getAttribute('aria-label')).toBe('Apple Music · Playing · Artist — Track')
+  })
+})

--- a/src/renderer/src/components/status-bar/MediaPlaybackStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/MediaPlaybackStatusSegment.tsx
@@ -1,0 +1,137 @@
+import { Apple, Pause, Play, Square } from 'lucide-react'
+import React, { useEffect, useState } from 'react'
+import type { MediaPlaybackStatus } from '../../../../shared/media-playback-status'
+import { SpotifyIcon } from '@/components/icons/SpotifyIcon'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { translate } from '@/i18n/i18n'
+
+const POLL_INTERVAL_MS = 3_000
+
+function playerLabel(status: MediaPlaybackStatus): string {
+  return status.player === 'spotify' ? 'Spotify' : 'Apple Music'
+}
+
+function stateLabel(status: MediaPlaybackStatus): string {
+  if (status.state === 'playing') {
+    return translate('statusBar.mediaPlayback.playing', 'Playing')
+  }
+  if (status.state === 'paused') {
+    return translate('statusBar.mediaPlayback.paused', 'Paused')
+  }
+  return translate('statusBar.mediaPlayback.stopped', 'Stopped')
+}
+
+function trackLabel(status: MediaPlaybackStatus): string {
+  if (status.artist && status.track) {
+    return `${status.artist} — ${status.track}`
+  }
+  return (
+    status.track || status.artist || translate('statusBar.mediaPlayback.noTrack', 'No track info')
+  )
+}
+
+function PlaybackIcon({ state }: Pick<MediaPlaybackStatus, 'state'>): React.JSX.Element {
+  if (state === 'playing') {
+    return <Play className="size-3 shrink-0" aria-hidden />
+  }
+  if (state === 'paused') {
+    return <Pause className="size-3 shrink-0" aria-hidden />
+  }
+  return <Square className="size-3 shrink-0" aria-hidden />
+}
+
+function PlayerIcon({ player }: Pick<MediaPlaybackStatus, 'player'>): React.JSX.Element {
+  return (
+    <span
+      data-media-player={player}
+      className="inline-flex shrink-0 items-center text-muted-foreground"
+      aria-hidden
+    >
+      {player === 'spotify' ? <SpotifyIcon className="size-3.5" /> : <Apple className="size-3.5" />}
+    </span>
+  )
+}
+
+export function MediaPlaybackStatusSegment({
+  compact,
+  iconOnly
+}: {
+  compact: boolean
+  iconOnly: boolean
+}): React.JSX.Element | null {
+  const [status, setStatus] = useState<MediaPlaybackStatus | null>(null)
+
+  useEffect(() => {
+    let disposed = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+
+    const refresh = async (): Promise<void> => {
+      try {
+        const nextStatus = await window.api.mediaPlayback.getStatus()
+        if (!disposed) {
+          setStatus(nextStatus)
+        }
+      } catch {
+        if (!disposed) {
+          setStatus(null)
+        }
+      } finally {
+        if (!disposed) {
+          timer = setTimeout(() => void refresh(), POLL_INTERVAL_MS)
+        }
+      }
+    }
+
+    void refresh()
+    return () => {
+      disposed = true
+      if (timer) {
+        clearTimeout(timer)
+      }
+    }
+  }, [])
+
+  if (!status) {
+    return null
+  }
+
+  const source = playerLabel(status)
+  const track = trackLabel(status)
+  const description = `${source} · ${stateLabel(status)} · ${track}`
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          role="status"
+          tabIndex={0}
+          aria-label={description}
+          className="inline-flex min-w-0 items-center gap-1.5 rounded px-1 py-0.5 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          <span className="inline-flex shrink-0 items-center gap-1 text-muted-foreground">
+            <PlayerIcon player={status.player} />
+            <PlaybackIcon state={status.state} />
+          </span>
+          {!iconOnly ? (
+            <span className={`${compact ? 'max-w-40' : 'max-w-72'} min-w-0 truncate text-xs`}>
+              <span data-media-track-title className="font-semibold text-foreground">
+                {status.track ||
+                  status.artist ||
+                  translate('statusBar.mediaPlayback.noTrack', 'No track info')}
+              </span>
+              {status.track && status.artist ? (
+                <span data-media-track-artist className="text-muted-foreground">
+                  {' — '}
+                  {status.artist}
+                </span>
+              ) : null}
+            </span>
+          ) : null}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={6}>
+        {description}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -11,7 +11,8 @@ import {
   Loader2,
   PanelsTopLeft,
   RefreshCw,
-  Server
+  Server,
+  Music2
 } from 'lucide-react'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { lazyWithRetry } from '@/lib/lazy-with-retry'
@@ -86,6 +87,9 @@ import {
   type UsagePercentageDisplay
 } from '../../../../shared/usage-percentage-display'
 import { formatUsagePercentageLabel } from './usage-percentage-label'
+import { MediaPlaybackStatusSegment } from './MediaPlaybackStatusSegment'
+import { isStatusBarItemSupportedOnPlatform } from './status-bar-platform-support'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 
 type StatusBarProps = {
   floatingTerminalOpen: boolean
@@ -2032,6 +2036,11 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   const showSsh = statusBarItems.includes('ssh')
   const showResourceUsage = statusBarItems.includes('resource-usage')
   const showPorts = statusBarItems.includes('ports')
+  const mediaPlaybackSupported = isStatusBarItemSupportedOnPlatform(
+    'media-playback',
+    getRendererAppPlatform()
+  )
+  const showMediaPlayback = mediaPlaybackSupported && statusBarItems.includes('media-playback')
   const showFloatingTerminalToggle =
     floatingTerminalEnabled && floatingTerminalTriggerLocation === 'status-bar'
   // Why: which usage-meter children actually render — excludes resource-usage
@@ -2212,6 +2221,9 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
         <UpdateStatusSegment compact={compact} iconOnly={iconOnly} />
         <React.Suspense fallback={null}>
           {petEnabled ? <PetStatusSegment /> : null}
+          {showMediaPlayback ? (
+            <MediaPlaybackStatusSegment compact={compact} iconOnly={iconOnly} />
+          ) : null}
           {showResourceUsage ? (
             <ResourceUsageStatusSegment compact={compact} iconOnly={iconOnly} />
           ) : null}
@@ -2389,6 +2401,15 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
             <Plug className="size-3.5" />
             {translate('auto.components.status.bar.StatusBar.9659e38343', 'Ports')}
           </DropdownMenuCheckboxItem>
+          {mediaPlaybackSupported ? (
+            <DropdownMenuCheckboxItem
+              checked={statusBarItems.includes('media-playback')}
+              onCheckedChange={() => toggleStatusBarItem('media-playback')}
+            >
+              <Music2 className="size-3.5" />
+              {translate('statusBar.mediaPlayback.nowPlaying', 'Now Playing')}
+            </DropdownMenuCheckboxItem>
+          ) : null}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/src/renderer/src/components/status-bar/status-bar-platform-support.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-platform-support.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { isStatusBarItemSupportedOnPlatform } from './status-bar-platform-support'
+
+describe('status bar platform support', () => {
+  it('limits local Apple Music and Spotify status to macOS', () => {
+    expect(isStatusBarItemSupportedOnPlatform('media-playback', 'darwin')).toBe(true)
+    expect(isStatusBarItemSupportedOnPlatform('media-playback', 'linux')).toBe(false)
+    expect(isStatusBarItemSupportedOnPlatform('media-playback', 'win32')).toBe(false)
+  })
+
+  it('keeps cross-platform status items available', () => {
+    expect(isStatusBarItemSupportedOnPlatform('ports', 'linux')).toBe(true)
+    expect(isStatusBarItemSupportedOnPlatform('resource-usage', 'win32')).toBe(true)
+  })
+})

--- a/src/renderer/src/components/status-bar/status-bar-platform-support.ts
+++ b/src/renderer/src/components/status-bar/status-bar-platform-support.ts
@@ -1,0 +1,8 @@
+import type { StatusBarItem } from '../../../../shared/types'
+
+export function isStatusBarItemSupportedOnPlatform(
+  id: StatusBarItem,
+  platform: NodeJS.Platform
+): boolean {
+  return id !== 'media-playback' || platform === 'darwin'
+}

--- a/src/renderer/src/components/status-bar/use-available-status-bar-toggles.ts
+++ b/src/renderer/src/components/status-bar/use-available-status-bar-toggles.ts
@@ -1,6 +1,8 @@
 import { useAppStore } from '../../store'
 import type { StatusBarItem } from '../../../../shared/types'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
+import { isStatusBarItemSupportedOnPlatform } from './status-bar-platform-support'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 
 /** Subscribes to detected-agent state and returns the toggles filtered to
  *  those whose underlying CLI is installed (or pre-detection). */
@@ -8,5 +10,10 @@ export function useAvailableStatusBarToggles<T extends { id: StatusBarItem }>(
   toggles: readonly T[]
 ): T[] {
   const detectedAgentIds = useAppStore((s) => s.detectedAgentIds)
-  return toggles.filter((t) => isStatusBarItemAvailable(t.id, detectedAgentIds))
+  const platform = getRendererAppPlatform()
+  return toggles.filter(
+    (toggle) =>
+      isStatusBarItemAvailable(toggle.id, detectedAgentIds) &&
+      isStatusBarItemSupportedOnPlatform(toggle.id, platform)
+  )
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -53,7 +53,10 @@
         "resourceUsageToggleDescription": "Show the Resource Manager. Click it for CPU, memory, sessions, daemon controls, and workspace disk scans.",
         "portsToggleDescription": "Show live workspace ports. Click it for workspace-scoped ports and external listeners.",
         "antigravityToggleDescription": "Show Antigravity subscription usage for the active workspace.",
-        "grokToggleDescription": "Show Grok subscription credit usage when signed in via Grok CLI."
+        "grokToggleDescription": "Show Grok subscription credit usage when signed in via Grok CLI.",
+        "mediaPlayback": "Now Playing",
+        "mediaPlaybackDescription": "Show the current Apple Music or Spotify track in the status bar.",
+        "mediaPlaybackToggleDescription": "Show the active local Apple Music or Spotify track on macOS."
       },
       "menuBarIcon": {
         "title": "Show Menu Bar Icon",
@@ -13383,6 +13386,15 @@
           "githubPullRequestNumber": "PR #{{value0}}"
         }
       }
+    }
+  },
+  "statusBar": {
+    "mediaPlayback": {
+      "playing": "Playing",
+      "paused": "Paused",
+      "stopped": "Stopped",
+      "noTrack": "No track info",
+      "nowPlaying": "Now Playing"
     }
   }
 }

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -30,7 +30,10 @@
         "resourceUsageToggleDescription": "Muestra el Administrador de recursos. Haz clic para ver CPU, memoria, sesiones, controles del servicio en segundo plano y análisis de disco de los espacios de trabajo.",
         "portsToggleDescription": "Muestra los puertos activos de los espacios de trabajo. Haz clic para ver los puertos de cada espacio de trabajo y los puertos externos.",
         "antigravityToggleDescription": "Muestra el uso de suscripción de Antigravity para el espacio de trabajo activo.",
-        "grokToggleDescription": "Muestra el uso de créditos de suscripción de Grok cuando has iniciado sesión con Grok CLI."
+        "grokToggleDescription": "Muestra el uso de créditos de suscripción de Grok cuando has iniciado sesión con Grok CLI.",
+        "mediaPlayback": "Reproduciendo ahora",
+        "mediaPlaybackDescription": "Muestra la pista actual de Apple Music o Spotify en la barra de estado.",
+        "mediaPlaybackToggleDescription": "Muestra la pista local activa de Apple Music o Spotify en macOS."
       },
       "menuBarIcon": {
         "title": "Mostrar icono en la barra de menús",
@@ -13383,6 +13386,15 @@
       "certificateChallengeChanged": "The certificate request changed. Retry the page and review the new warning.",
       "certificateChallengeUnavailable": "This certificate request is no longer available. Retry the page to request a new one.",
       "certificateProceedFailed": "Orca could not approve this certificate request. Retry the page and try again."
+    }
+  },
+  "statusBar": {
+    "mediaPlayback": {
+      "playing": "Reproduciendo",
+      "paused": "En pausa",
+      "stopped": "Detenido",
+      "noTrack": "Sin información de la pista",
+      "nowPlaying": "Reproduciendo ahora"
     }
   }
 }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -30,7 +30,10 @@
         "resourceUsageToggleDescription": "リソースマネージャーを表示します。これをクリックすると、CPU、メモリ、セッション、デーモン コントロール、およびワークスペース ディスク スキャンが行われます。",
         "portsToggleDescription": "ライブワークスペースポートを表示します。ワークスペーススコープのポートと外部リスナーの場合はこれをクリックします。",
         "antigravityToggleDescription": "アクティブなワークスペースの Antigravity サブスクリプション使用量を表示します。",
-        "grokToggleDescription": "Grok CLI でサインインしている場合に Grok サブスクリプションのクレジット使用量を表示します。"
+        "grokToggleDescription": "Grok CLI でサインインしている場合に Grok サブスクリプションのクレジット使用量を表示します。",
+        "mediaPlayback": "再生中",
+        "mediaPlaybackDescription": "現在のApple MusicまたはSpotifyの曲をステータスバーに表示します。",
+        "mediaPlaybackToggleDescription": "macOSで再生中のローカルApple MusicまたはSpotifyの曲を表示します。"
       },
       "menuBarIcon": {
         "title": "メニューバーアイコンを表示",
@@ -13383,6 +13386,15 @@
       "certificateChallengeChanged": "The certificate request changed. Retry the page and review the new warning.",
       "certificateChallengeUnavailable": "This certificate request is no longer available. Retry the page to request a new one.",
       "certificateProceedFailed": "Orca could not approve this certificate request. Retry the page and try again."
+    }
+  },
+  "statusBar": {
+    "mediaPlayback": {
+      "playing": "再生中",
+      "paused": "一時停止",
+      "stopped": "停止",
+      "noTrack": "曲情報なし",
+      "nowPlaying": "再生中"
     }
   }
 }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -30,7 +30,10 @@
         "resourceUsageToggleDescription": "리소스 관리자를 표시합니다. 클릭하면 CPU, 메모리, 세션, 데몬 제어, 워크스페이스 디스크 스캔을 볼 수 있습니다.",
         "portsToggleDescription": "라이브 워크스페이스 포트를 표시합니다. 워크스페이스 범위 포트 및 외부 수신기를 보려면 클릭하세요.",
         "antigravityToggleDescription": "활성 워크스페이스에 대한 Antigravity 구독 사용량을 표시합니다.",
-        "grokToggleDescription": "Grok CLI로 로그인한 경우 Grok 구독 크레딧 사용량을 표시합니다."
+        "grokToggleDescription": "Grok CLI로 로그인한 경우 Grok 구독 크레딧 사용량을 표시합니다.",
+        "mediaPlayback": "현재 재생 중",
+        "mediaPlaybackDescription": "현재 Apple Music 또는 Spotify 곡을 상태바에 표시합니다.",
+        "mediaPlaybackToggleDescription": "macOS에서 재생 중인 로컬 Apple Music 또는 Spotify 곡을 표시합니다."
       },
       "menuBarIcon": {
         "title": "메뉴 바 아이콘 표시",
@@ -13383,6 +13386,15 @@
       "certificateChallengeChanged": "The certificate request changed. Retry the page and review the new warning.",
       "certificateChallengeUnavailable": "This certificate request is no longer available. Retry the page to request a new one.",
       "certificateProceedFailed": "Orca could not approve this certificate request. Retry the page and try again."
+    }
+  },
+  "statusBar": {
+    "mediaPlayback": {
+      "playing": "재생 중",
+      "paused": "일시 정지",
+      "stopped": "정지",
+      "noTrack": "곡 정보 없음",
+      "nowPlaying": "현재 재생 중"
     }
   }
 }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -30,7 +30,10 @@
         "resourceUsageToggleDescription": "显示资源管理器。点击可查看 CPU、内存、会话、守护进程控制和工作区磁盘扫描。",
         "portsToggleDescription": "显示实时工作区端口。单击可查看工作区范围的端口和外部监听器。",
         "antigravityToggleDescription": "显示当前工作区的 Antigravity 订阅使用量。",
-        "grokToggleDescription": "通过 Grok CLI 登录后显示 Grok 订阅额度使用量。"
+        "grokToggleDescription": "通过 Grok CLI 登录后显示 Grok 订阅额度使用量。",
+        "mediaPlayback": "正在播放",
+        "mediaPlaybackDescription": "在状态栏中显示当前的 Apple Music 或 Spotify 曲目。",
+        "mediaPlaybackToggleDescription": "在 macOS 上显示当前播放的本地 Apple Music 或 Spotify 曲目。"
       },
       "menuBarIcon": {
         "title": "显示菜单栏图标",
@@ -13383,6 +13386,15 @@
       "certificateChallengeChanged": "The certificate request changed. Retry the page and review the new warning.",
       "certificateChallengeUnavailable": "This certificate request is no longer available. Retry the page to request a new one.",
       "certificateProceedFailed": "Orca could not approve this certificate request. Retry the page and try again."
+    }
+  },
+  "statusBar": {
+    "mediaPlayback": {
+      "playing": "正在播放",
+      "paused": "已暂停",
+      "stopped": "已停止",
+      "noTrack": "无曲目信息",
+      "nowPlaying": "正在播放"
     }
   }
 }

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -1362,7 +1362,8 @@ describe('createUISlice hydratePersistedUI', () => {
       'kimi',
       'minimax',
       'antigravity',
-      'grok'
+      'grok',
+      'media-playback'
     ])
     expect(setUI).toHaveBeenCalledWith({
       statusBarItems: [
@@ -1372,13 +1373,15 @@ describe('createUISlice hydratePersistedUI', () => {
         'kimi',
         'minimax',
         'antigravity',
-        'grok'
+        'grok',
+        'media-playback'
       ],
       _portsStatusBarDefaultAdded: true,
       _kimiStatusBarDefaultAdded: true,
       _minimaxStatusBarDefaultAdded: true,
       _antigravityStatusBarDefaultAdded: true,
-      _grokStatusBarDefaultAdded: true
+      _grokStatusBarDefaultAdded: true,
+      _mediaPlaybackStatusBarDefaultAdded: true
     })
   })
 
@@ -1394,7 +1397,8 @@ describe('createUISlice hydratePersistedUI', () => {
         _kimiStatusBarDefaultAdded: true,
         _minimaxStatusBarDefaultAdded: true,
         _antigravityStatusBarDefaultAdded: true,
-        _grokStatusBarDefaultAdded: true
+        _grokStatusBarDefaultAdded: true,
+        _mediaPlaybackStatusBarDefaultAdded: true
       })
     )
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -278,6 +278,7 @@ const DEFAULT_ON_KIMI_STATUS_BAR_ITEM: StatusBarItem = 'kimi'
 const DEFAULT_ON_MINIMAX_STATUS_BAR_ITEM: StatusBarItem = 'minimax'
 const DEFAULT_ON_ANTIGRAVITY_STATUS_BAR_ITEM: StatusBarItem = 'antigravity'
 const DEFAULT_ON_GROK_STATUS_BAR_ITEM: StatusBarItem = 'grok'
+const DEFAULT_ON_MEDIA_PLAYBACK_STATUS_BAR_ITEM: StatusBarItem = 'media-playback'
 
 function normalizeHydratedVisibleWorkspaceHostIds(ui: PersistedUIState): VisibleWorkspaceHostIds {
   const visibleHostIds = normalizeVisibleExecutionHostIds(ui.visibleWorkspaceHostIds)
@@ -2423,22 +2424,28 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         ui._grokStatusBarDefaultAdded || statusBarItemsWithAntigravity.includes('grok')
           ? statusBarItemsWithAntigravity
           : [...statusBarItemsWithAntigravity, DEFAULT_ON_GROK_STATUS_BAR_ITEM]
+      const statusBarItemsWithMediaPlayback =
+        ui._mediaPlaybackStatusBarDefaultAdded || statusBarItemsWithGrok.includes('media-playback')
+          ? statusBarItemsWithGrok
+          : [...statusBarItemsWithGrok, DEFAULT_ON_MEDIA_PLAYBACK_STATUS_BAR_ITEM]
       if (
         (!ui._portsStatusBarDefaultAdded ||
           !ui._kimiStatusBarDefaultAdded ||
           !ui._minimaxStatusBarDefaultAdded ||
           !ui._antigravityStatusBarDefaultAdded ||
-          !ui._grokStatusBarDefaultAdded) &&
+          !ui._grokStatusBarDefaultAdded ||
+          !ui._mediaPlaybackStatusBarDefaultAdded) &&
         typeof window !== 'undefined'
       ) {
         window.api.ui
           .set({
-            statusBarItems: statusBarItemsWithGrok,
+            statusBarItems: statusBarItemsWithMediaPlayback,
             _portsStatusBarDefaultAdded: true,
             _kimiStatusBarDefaultAdded: true,
             _minimaxStatusBarDefaultAdded: true,
             _antigravityStatusBarDefaultAdded: true,
-            _grokStatusBarDefaultAdded: true
+            _grokStatusBarDefaultAdded: true,
+            _mediaPlaybackStatusBarDefaultAdded: true
           })
           .catch(console.error)
       }
@@ -2507,7 +2514,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         workspaceBoardOpacity: clampWorkspaceBoardOpacity(ui.workspaceBoardOpacity),
         workspaceBoardColumnWidth: clampWorkspaceBoardColumnWidth(ui.workspaceBoardColumnWidth),
         syncTaskStatusFromWorkspaceBoard: ui.syncTaskStatusFromWorkspaceBoard === true,
-        statusBarItems: statusBarItemsWithGrok,
+        statusBarItems: statusBarItemsWithMediaPlayback,
         statusBarVisible: ui.statusBarVisible ?? true,
         usagePercentageDisplay: normalizeUsagePercentageDisplay(ui.usagePercentageDisplay),
         // Why: absent → true so existing users see the pet the first time

--- a/src/shared/media-playback-status.ts
+++ b/src/shared/media-playback-status.ts
@@ -1,0 +1,10 @@
+export type MediaPlaybackPlayer = 'spotify' | 'apple-music'
+
+export type MediaPlaybackState = 'playing' | 'paused' | 'stopped'
+
+export type MediaPlaybackStatus = {
+  player: MediaPlaybackPlayer
+  state: MediaPlaybackState
+  artist: string
+  track: string
+}

--- a/src/shared/status-bar-defaults.ts
+++ b/src/shared/status-bar-defaults.ts
@@ -11,5 +11,6 @@ export const DEFAULT_STATUS_BAR_ITEMS: StatusBarItem[] = [
   'grok',
   'ssh',
   'resource-usage',
-  'ports'
+  'ports',
+  'media-playback'
 ]

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3269,6 +3269,7 @@ export type StatusBarItem =
   | 'ssh'
   | 'resource-usage'
   | 'ports'
+  | 'media-playback'
 export type FloatingTerminalTriggerLocation = 'floating-button' | 'status-bar'
 
 export type TaskResumeState = {
@@ -3408,6 +3409,8 @@ export type PersistedUIState = {
   _antigravityStatusBarDefaultAdded?: boolean
   /** One-shot migration flag for adding the default-on Grok status item. */
   _grokStatusBarDefaultAdded?: boolean
+  /** One-shot migration flag for adding the default-on media playback status item. */
+  _mediaPlaybackStatusBarDefaultAdded?: boolean
   statusBarItems: StatusBarItem[]
   statusBarVisible: boolean
   /** Why: this is client-side presentation, not a provider/account or execution-host setting. */


### PR DESCRIPTION
## Summary

- Add an optional macOS status-bar item for the current Spotify or Apple Music track.
- Poll only already-running players, cache results for three seconds, and avoid launching apps or prompting for Automation when they are closed.
- Keep the item unavailable on non-macOS platforms and expose compact/icon-only status-bar presentations with localized accessible labels.

## Screenshots

- Not attached yet. This draft adds a new status-bar segment showing the player, playback state, track, and artist.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added targeted regression coverage: 8 test files / 180 tests passed, including IPC registration, macOS command parsing and selection, runtime schema, status-bar rendering/platform support, settings search, and UI-store migration.
- [x] Localization catalog verification passed for all five locales (10,846 keys each).

## AI Review Report

Targeted review checked the macOS platform gate, fixed command paths, process and AppleScript timeouts, cache/in-flight behavior, IPC/preload typing, status-bar accessibility, settings migration, and localization. `git diff --check` and TypeScript type checking passed. Cross-platform review confirmed the item is hidden outside macOS and no platform-specific shortcuts or path separators were added.

## Security Audit

The implementation invokes only fixed `/usr/bin/pgrep` and `/usr/bin/osascript` executables with constant player descriptors; no user-controlled command or AppleScript text is interpolated. Both probes have timeouts and bounded output buffers, failures return no status, and the IPC result is limited to normalized playback metadata. No auth, secrets, dependencies, or writable paths were added.

## Notes

- The feature is intentionally macOS-only because it uses AppleScript support from Spotify and Apple Music.
- Full repository lint/test/build were not run; the targeted suite, localization verification, and full typecheck passed.

## ELI5

On macOS, an optional status-bar item can show what Spotify or Apple Music is playing. It only polls apps that are already running and never launches them or prompts for Automation when they are closed.
