### PR TITLE
feat(sidebar): show active project git changes

### DIFF
--- a/src/renderer/src/components/sidebar/ActiveProjectGitChanges.test.tsx
+++ b/src/renderer/src/components/sidebar/ActiveProjectGitChanges.test.tsx
@@ -1,0 +1,54 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import type { GitStatusEntry } from '../../../../shared/types'
+import { countProjectGitChanges, ProjectGitChanges } from './ActiveProjectGitChanges'
+
+function gitEntry(status: GitStatusEntry['status'], path: string): GitStatusEntry {
+  return {
+    path,
+    status,
+    area: status === 'untracked' ? 'untracked' : 'unstaged'
+  }
+}
+
+describe('ActiveProjectGitChanges', () => {
+  it('groups Git statuses into modified, deleted, and added counts', () => {
+    expect(
+      countProjectGitChanges([
+        gitEntry('modified', 'modified.ts'),
+        gitEntry('renamed', 'renamed.ts'),
+        gitEntry('copied', 'copied.ts'),
+        gitEntry('deleted', 'deleted.ts'),
+        gitEntry('added', 'added.ts'),
+        gitEntry('untracked', 'untracked.ts')
+      ])
+    ).toEqual({ modified: 3, deleted: 1, added: 2 })
+  })
+
+  it('renders non-zero counts in modified, deleted, added order', () => {
+    const markup = renderToStaticMarkup(
+      <ProjectGitChanges
+        entries={[
+          gitEntry('added', 'added.ts'),
+          gitEntry('deleted', 'deleted.ts'),
+          gitEntry('modified', 'modified-a.ts'),
+          gitEntry('modified', 'modified-b.ts')
+        ]}
+      />
+    )
+
+    expect(markup).toMatch(/data-git-change-kind="modified"[^>]*>!2<\/span>/)
+    expect(markup).toMatch(/data-git-change-kind="deleted"[^>]*>!1<\/span>/)
+    expect(markup).toMatch(/data-git-change-kind="added"[^>]*>!1<\/span>/)
+    expect(markup).toContain('text-[var(--git-decoration-modified)]')
+    expect(markup).toContain('text-[var(--git-decoration-deleted)]')
+    expect(markup).toContain('text-[var(--git-decoration-added)]')
+    expect(markup.indexOf('modified')).toBeLessThan(markup.indexOf('deleted'))
+    expect(markup.indexOf('deleted')).toBeLessThan(markup.indexOf('added'))
+  })
+
+  it('renders nothing for a clean or not-yet-loaded worktree', () => {
+    expect(renderToStaticMarkup(<ProjectGitChanges entries={[]} />)).toBe('')
+    expect(renderToStaticMarkup(<ProjectGitChanges entries={undefined} />)).toBe('')
+  })
+})

--- a/src/renderer/src/components/sidebar/ActiveProjectGitChanges.tsx
+++ b/src/renderer/src/components/sidebar/ActiveProjectGitChanges.tsx
@@ -1,0 +1,86 @@
+import React, { useMemo } from 'react'
+import { useAppStore } from '@/store'
+import type { GitStatusEntry } from '../../../../shared/types'
+
+export type ProjectGitChangeCounts = {
+  modified: number
+  deleted: number
+  added: number
+}
+
+const CHANGE_PRESENTATION = [
+  {
+    key: 'modified',
+    className: 'text-[var(--git-decoration-modified)]'
+  },
+  {
+    key: 'deleted',
+    className: 'text-[var(--git-decoration-deleted)]'
+  },
+  {
+    key: 'added',
+    className: 'text-[var(--git-decoration-added)]'
+  }
+] as const
+
+export function countProjectGitChanges(entries: readonly GitStatusEntry[]): ProjectGitChangeCounts {
+  const counts: ProjectGitChangeCounts = { modified: 0, deleted: 0, added: 0 }
+
+  for (const entry of entries) {
+    if (entry.status === 'deleted') {
+      counts.deleted += 1
+    } else if (entry.status === 'added' || entry.status === 'untracked') {
+      counts.added += 1
+    } else {
+      // Why: the compact project summary has three requested buckets; renamed
+      // and copied files remain edited content rather than disappearing.
+      counts.modified += 1
+    }
+  }
+
+  return counts
+}
+
+export function ProjectGitChanges({
+  entries
+}: {
+  entries: readonly GitStatusEntry[] | undefined
+}): React.JSX.Element | null {
+  const counts = useMemo(() => countProjectGitChanges(entries ?? []), [entries])
+
+  if (counts.modified === 0 && counts.deleted === 0 && counts.added === 0) {
+    return null
+  }
+
+  return (
+    <span
+      data-active-project-git-changes=""
+      className="inline-flex shrink-0 items-center gap-1 font-mono text-[10px] font-semibold leading-none"
+    >
+      {CHANGE_PRESENTATION.map(({ key, className }) =>
+        counts[key] > 0 ? (
+          <span
+            key={key}
+            data-git-change-kind={key}
+            className={className}
+            aria-label={`${key} ${counts[key]}`}
+          >
+            !{counts[key]}
+          </span>
+        ) : null
+      )}
+    </span>
+  )
+}
+
+export function ActiveProjectGitChanges({
+  worktreeId
+}: {
+  worktreeId: string | null
+}): React.JSX.Element | null {
+  const entries = useAppStore((state) =>
+    worktreeId ? state.gitStatusByWorktree[worktreeId] : undefined
+  )
+
+  return <ProjectGitChanges entries={entries} />
+}

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -274,6 +274,7 @@ import { useHostHeaderDrag } from './host-header-drag'
 import { buildSidebarHostOptions } from './sidebar-host-options'
 import { HostSectionHeaderMenu } from './HostSectionHeaderMenu'
 import { ProjectHeaderActions } from './ProjectHeaderActions'
+import { ActiveProjectGitChanges } from './ActiveProjectGitChanges'
 import { translate } from '@/i18n/i18n'
 import { folderWorkspaceKey, getActiveSidebarWorkspaceId } from '../../../../shared/workspace-scope'
 import { getHostDisplayLabelOverrides } from '../../../../shared/host-setting-overrides'
@@ -4162,6 +4163,12 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
               const isRepoHeader = groupBy === 'repo' && row.repo !== undefined
               const isProjectGroupHeader = groupBy === 'repo' && row.projectGroup !== undefined
               const projectIdForHeader = isRepoHeader ? row.repo!.id : undefined
+              const activeProjectWorktreeId =
+                projectIdForHeader &&
+                activeWorktreeId &&
+                worktreeMap.get(activeWorktreeId)?.repoId === projectIdForHeader
+                  ? activeWorktreeId
+                  : null
               const projectGroupIdForHeader =
                 isProjectGroupHeader && !row.repo && typeof row.projectGroup?.id === 'string'
                   ? row.projectGroup.id
@@ -4399,6 +4406,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                         <div className="min-w-0 truncate text-[13px] font-semibold leading-none">
                           {row.label}
                         </div>
+                        <ActiveProjectGitChanges worktreeId={activeProjectWorktreeId} />
                         <RepoForkIndicator upstream={row.repo?.upstream} />
                         <FolderPathStatusIndicator status={projectGroupPathStatus} />
                       </div>


### PR DESCRIPTION
## Summary

- Show compact modified, deleted, and added counts next to the currently active project's header.
- Reuse the active worktree's existing Git status store and render nothing while the status is unavailable or clean.
- Group renamed/copied files with modified content and untracked files with additions so every status remains visible in the three-bucket summary.

## Screenshots

- Not attached yet. This draft adds compact colored counts to the active project header.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added targeted regression coverage: 1 test file / 3 tests passed for grouping, display order/colors, and clean/unloaded worktrees.

## AI Review Report

Targeted review checked status bucketing, active-project scoping, clean/loading behavior, accessible labels, and reuse of the existing Git decoration color tokens. `git diff --check` and TypeScript type checking passed. Cross-platform/SSH review found no new path, shortcut, shell, Electron main-process, or provider-specific behavior; the component only consumes existing host-scoped Git status state.

## Security Audit

This change adds no command execution, IPC, authentication, dependency, secret handling, or filesystem access. Git status entries are read from the existing application store, counted, and rendered through React.

## Notes

- Full repository lint/test/build were not run; the targeted suite and full typecheck passed.

## ELI5

The active project's sidebar header can show compact counts of modified, deleted, and added files. Numbers come from the worktree's existing git status and hide when everything is clean.
