### PR TITLE
fix(preflight): detect Grok installed in ~/.grok/bin

### DIFF
--- a/src/main/startup/configure-process.test.ts
+++ b/src/main/startup/configure-process.test.ts
@@ -56,7 +56,7 @@ describe('patchPackagedProcessPath', () => {
     }
   })
 
-  it('prepends agent-CLI install dirs (~/.opencode/bin, ~/.vite-plus/bin) for packaged darwin runs', async () => {
+  it('prepends agent-CLI install dirs (~/.opencode/bin, ~/.vite-plus/bin, ~/.grok/bin) for packaged darwin runs', async () => {
     const { app } = await import('electron')
     const { patchPackagedProcessPath } = await import('./configure-process')
 
@@ -68,12 +68,13 @@ describe('patchPackagedProcessPath', () => {
     patchPackagedProcessPath()
 
     const segments = (process.env.PATH ?? '').split(':')
-    // Why: issue #829 — ~/.opencode/bin and ~/.vite-plus/bin are the documented
-    // fallback install locations for the opencode and Pi CLI install scripts.
-    // Without them on PATH, GUI-launched Orca reports both as "Not installed"
+    // Why: issue #829 — ~/.opencode/bin, ~/.vite-plus/bin, and ~/.grok/bin are
+    // documented fallback install locations for those agent CLI install scripts.
+    // Without them on PATH, GUI-launched Orca reports them as "Not installed"
     // even when `which` resolves them in the user's shell.
     expect(segments).toContain(join('/Users/tester', '.opencode/bin'))
     expect(segments).toContain(join('/Users/tester', '.vite-plus/bin'))
+    expect(segments).toContain(join('/Users/tester', '.grok/bin'))
     expect(segments).toContain(join('/Users/tester', 'bin'))
   })
 

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -144,12 +144,14 @@ export function patchPackagedProcessPath(): void {
         join(home, '.nix-profile/bin'),
         // Why: several agent CLIs ship install scripts that drop binaries into
         // tool-specific ~/.<name>/bin directories (opencode's documented fallback,
-        // Pi's vite-plus installer). GUI-launched Electron inherits a minimal PATH
-        // without shell rc files, so these stay invisible to `which` probes — and
-        // the Agents settings page reports them as "Not installed" even when the
-        // user can run them from Terminal. See stablyai/orca#829.
+        // Pi's vite-plus installer, Grok's ~/.grok/bin). GUI-launched Electron
+        // inherits a minimal PATH without shell rc files, so these stay invisible
+        // to `which` probes — and the Agents settings page reports them as "Not
+        // installed" even when the user can run them from Terminal. See
+        // stablyai/orca#829.
         join(home, '.opencode/bin'),
-        join(home, '.vite-plus/bin')
+        join(home, '.vite-plus/bin'),
+        join(home, '.grok/bin')
       )
     }
   }


### PR DESCRIPTION
## Summary

- Include `~/.grok/bin` in the packaged macOS process PATH alongside the existing agent-specific fallback install directories.
- Allow GUI-launched Orca to detect a Grok CLI installation that works in the user's shell but is absent from the minimal Electron launch environment.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Updated targeted regression coverage: 1 test file / 23 tests passed, including the packaged macOS PATH assertion.

## AI Review Report

Targeted review checked that the fallback is limited to packaged macOS startup, uses the existing home-directory lookup and `path.join`, and does not change Linux/Windows launch behavior. `git diff --check` and TypeScript type checking passed. Cross-platform/SSH review confirmed there are no hard-coded separators, shortcuts, labels, or remote-host command changes.

## Security Audit

The change adds a fixed user-local binary directory to the same existing PATH fallback list; it adds no shell interpolation, command execution, auth, secrets, dependency, or writable path. The path is derived from Electron's home directory and joined with Node path utilities.

## Notes

- Full repository lint/test/build were not run; the targeted suite and full typecheck passed.

## ELI5

Grok installed under ~/.grok/bin was invisible to GUI-launched Orca on macOS because that path was not on Electron's PATH. The preflight PATH now includes that folder so Grok is detected.
