### PR TITLE
fix(terminal): preserve Codex Shift+Enter routing

### DIFF
--- a/ORCA-SHIFT-ENTER-REGRESSION.task-state.md
+++ b/ORCA-SHIFT-ENTER-REGRESSION.task-state.md
@@ -104,4 +104,11 @@
 
 ## Risks
 
-- 실제 OS 키 주입은 Accessibility 제한으로 자동화하지 못했다. 제품 E2E와 패키지 확인으로 보완했으며, 원격 반영 상태는 push 뒤 다시 확인한다.
+- 실제 OS 키 주입은 Accessibility 제한으로 자동화하지 못했다. 제품 E2E와 패키지 확인으로 보완했다.
+- 두 로컬 GitHub 계정 모두 공식 저장소에는 read 권한만 있어 main 반영은 maintainer merge가 필요하다. 개인 fork에 커밋을 push하고 공식 저장소 PR #9273을 생성해 소스 유실 가능성을 제거했다.
+
+## Release / Handoff
+
+- 로컬 배포: 서명된 Orca 1.4.144-rc.4 수정본을 설치하고 재시작했으며 기존 PTY 9/9가 유지됐다.
+- 원격 배포: `beige-ian/orca`의 `fix/codex-shift-enter-durable` 브랜치에 push했고, `stablyai/orca` main 대상 PR #9273이 열려 있다.
+- 현재 PR은 merge 가능한 상태이며 GitHub 검사가 실행 중이다. 공식 main 병합은 저장소 write 권한이 있는 maintainer가 수행한다.

--- a/ORCA-SHIFT-ENTER-REGRESSION.task-state.md
+++ b/ORCA-SHIFT-ENTER-REGRESSION.task-state.md
@@ -111,4 +111,5 @@
 
 - 로컬 배포: 서명된 Orca 1.4.144-rc.4 수정본을 설치하고 재시작했으며 기존 PTY 9/9가 유지됐다.
 - 원격 배포: `beige-ian/orca`의 `fix/codex-shift-enter-durable` 브랜치에 push했고, `stablyai/orca` main 대상 PR #9273이 열려 있다.
-- 현재 PR은 merge 가능한 상태이며 GitHub 검사가 실행 중이다. 공식 main 병합은 저장소 write 권한이 있는 maintainer가 수행한다.
+- 현재 PR은 merge 가능한 상태이며 별도 GitHub 검사는 보고되지 않았다. 공식 main 병합은 저장소 write 권한이 있는 maintainer가 수행한다.
+- 07/18 사용자가 공식 반영을 승인했다. 자동 squash merge를 시도했으나 현재 계정의 upstream 권한이 read-only라 GitHub가 거절했고, PR에 전체 검증 결과와 maintainer merge 요청을 남겼다.

--- a/ORCA-SHIFT-ENTER-REGRESSION.task-state.md
+++ b/ORCA-SHIFT-ENTER-REGRESSION.task-state.md
@@ -1,0 +1,107 @@
+# Codex Shift+Enter 줄바꿈 재발 수정
+
+## 현재 판단
+
+- As-is: 수정 전 설치본은 Codex pane에서도 Kitty/host 기본 Shift+Enter 바이트를 보내 줄바꿈이 다시 실패했다.
+- To-be: Codex로 확인된 pane은 LF를 보내고, 종료 뒤 shell 및 다음 Codex 실행 세대에서는 각각 안전하게 차단·복구한다.
+- 07/18 설치된 Orca 1.4.144-rc.4에는 이전 Codex 전용 Shift+Enter 수정이 포함되지 않았다.
+- 현재 설치본은 Codex pane에서 Shift+Enter를 LF로 보내는 수정본으로 교체됐다.
+- 이전 수정은 별도 dirty worktree에만 남아 있었고 최신 모바일 연결 빌드에 합쳐지지 않았다.
+
+## 작업 계약
+
+- 최신 1.4.144 모바일 연결 변경을 보존한 채 Codex로 확인된 pane에서만 Shift+Enter를 Ctrl+J 줄바꿈 바이트로 보낸다.
+- 일반 shell, 다른 agent, Windows 전용 Droid 처리, Kitty keyboard 동작은 기존 의미를 보존한다.
+- 실패 테스트를 먼저 확인하고 최소 구현, 관련 단위·통합 테스트, 타입 검사를 실행한다.
+- 앱 종료·교체·재시작과 원격 반영은 사용자 명시 승인 뒤 수행한다. 사용자는 설치본 검증 뒤 커밋·배포까지 완료하도록 승인했다.
+
+## Context Lens
+
+- Required: yes
+- Primary lens: engineering
+- Secondary lens: product
+- Why this lens: terminal 입력·세션 복구의 기술 정확성과 사용자가 실제로 보는 줄바꿈 행동을 함께 검증해야 한다.
+- Source: 사용자 재현, 설치본과 최신 소스 비교, terminal lifecycle 회귀 테스트, 실제 재시작 세션 목록.
+- Applied checks: Codex pane 범위, 일반 shell·다른 agent 비회귀, 로컬·SSH·WSL 종료와 재실행, 동일 PTY 복구, 실제 UI 키 입력.
+
+## 완료 기준
+
+- Codex pane의 Shift+Enter가 host OS와 Kitty 상태에 관계없이 LF를 보내는 테스트가 통과한다.
+- stale local agent identity는 일반 shell 입력을 바꾸지 않고, 로컬 확인이 어려운 SSH·WSL만 pane identity fallback을 사용한다.
+- 관련 회귀 테스트와 타입 검사가 통과한다.
+- 사용자 승인 뒤 앱을 교체·재시작하고 기존 세션의 동일 PTY 복구를 확인한다.
+
+## 지침 적용 확인
+
+- 읽은 기준: 전역·저장소 `AGENTS.md`, instruction manifest, `CODEX.md`, `MEMORY.md`, Codex 최신 세션·archive, session·development·API·사람 문장·터미널 출력·Markdown 기준, 기존 Shift+Enter 작업 기록. API 기준이 요구한 `CLAUDE.md`는 현재 경로에 존재하지 않았다.
+- 선택 bundle/lens: `code`, engineering, cross-platform terminal input correctness.
+- 적용 skill: `tdd-workflow`, `orca-cli`, `computer-use`, `deploy`.
+- 적용 기준: 최신 모바일 연결 작업 보존, 테스트 우선, Codex pane 범위 제한, 앱 재시작 보호, 독립 검토.
+- 해당 없음: 외부 API, 운영 데이터, 외부 발송, 브라우저 원문 조회.
+- 배포 범위가 추가된 뒤 release 기준과 프로젝트별 배포 절차를 다시 확인했다.
+
+## API 작업 체크리스트
+
+- 요청 원문: 설치·재시작 뒤 세션을 이어가고 Shift+Enter 재발을 막는다.
+- 작업 분류: local read-only 조회와 실제 키 입력 검증.
+- 대상 API: 실행 중인 Orca의 localhost DevTools endpoint.
+- 환경: local.
+- method: GET 조회 후 로컬 DevTools WebSocket 키 이벤트 전달.
+- payload: 선택된 Orca renderer에 Shift+Enter 키 이벤트 1회.
+- auth/account: localhost의 현재 사용자 세션, 별도 계정·토큰 없음.
+- 대상 객체: 현재 Orca renderer와 검증용 terminal pane.
+- 예상 화면 변화: 검증 pane의 입력창에 줄바꿈 1회 추가.
+- 영향 범위: 로컬 Orca UI 한 pane, 외부 전송 없음.
+- rollback: 검증용 입력을 지우거나 검증 pane을 닫는다.
+- 검증 방법: PTY 입력 바이트 또는 composer의 줄 수를 전후 비교한다.
+- 실행 주체: Codex 가능.
+
+## 검증 기록
+
+- 설치본 대조: 1.4.144-rc.4 renderer의 Shift+Enter 분기는 Codex 판별 없이 CSI-u 또는 Esc+Enter만 선택한다.
+- 소스 대조: 기존 dirty 작업공간의 구현을 `origin/main` 기준 독립 브랜치로 분리해 커밋했다.
+- RED: Codex LF 라우팅, 종료 뒤 stale identity 차단, 포커스·idle 중 trust 유지, 원격 launch-only 종료와 재실행 generation 테스트가 구현 전 각각 실패함을 확인했다.
+- GREEN: 관련 단위·통합 7개 파일 541개 테스트, 타입 검사, 포맷 검사, diff 검사가 통과했다.
+- Electron: terminal shortcuts 시나리오 7개 통과, Windows 전용 2개는 macOS에서 예정대로 skip됐다.
+- 독립 검토: local stale identity, 포커스 재확인, 원격 fallback, launch-only 종료, 재실행 generation, production store 동일성 문제를 순차 보완한 뒤 최종 승인됐다.
+- 설치 후보: Orca 1.4.144-rc.4 arm64 앱 생성, deep codesign 검증 통과, 패키지 renderer에서 Codex `ctrl-j`와 generation tombstone 분기를 확인했다.
+- 사용자 승인 뒤 앱을 교체·재시작했고, runtime은 새 ID로 ready 상태가 됐다.
+- 작업 중 생긴 mobile transport 변경은 별도 동시 작업으로 판단해 수정하거나 되돌리지 않았다.
+- 재시작 승인 직전 runtime은 ready였고, 9개 terminal 모두 connected·writable 상태였다. 동일 PTY identity와 개수를 재시작 후 복구 기준으로 사용한다.
+- 재시작 뒤에도 기존 PTY 9/9가 보존됐고, terminal 9개 모두 connected·writable이었다. 새 PTY 대체나 누락은 0개였다.
+- 설치된 앱의 version은 1.4.144-rc.4이며 Finder metadata를 정리한 뒤 deep codesign 검증을 통과했다. 이전 앱은 명시적 backup 경로에 복구 가능하게 보존했다.
+- 실제 UI 키 입력 자동화는 macOS Accessibility가 새 helper에 허용되지 않아 실행하지 못했다. 임시 검증 tab은 닫았고 기존 9개 세션에는 입력하지 않았다. 제품 Electron shortcut E2E의 Codex LF 검증은 7 passed/2 platform-skip 상태다.
+- Shift+Enter 수정만 `origin/main` 기준 독립 브랜치로 분리해 커밋했으며, 동시 작업 중인 mobile transport 변경은 포함하지 않았다.
+- 깨끗한 독립 브랜치에서 타입 검사, 관련 7개 파일 541개 테스트, desktop production build가 다시 통과했다. 기존 CSS·chunk 경고와 선택적 CLI symlink 권한 안내 외 빌드 실패는 없었다.
+
+## Goal
+
+- Codex pane에서 Shift+Enter 줄바꿈을 복구하고, 설치 교체와 이후 소스 반영에서도 같은 문제가 재발하지 않게 한다.
+
+## In Scope
+
+- Codex 전용 LF 라우팅, agent identity lifecycle, 로컬·SSH·WSL 회귀 테스트, 앱 설치, 독립 커밋과 원격 반영이다.
+
+## Out of Scope
+
+- 동시 작업 중인 mobile transport 변경, 일반 shell·다른 agent의 키 동작 변경, Accessibility 권한 변경이다.
+
+## Instruction Receipt
+
+- Read docs: 전역·저장소 `AGENTS.md`, instruction manifest, `CODEX.md`, session·development·release·workflow·operating-change·product·Markdown·사람 문장 기준을 읽었다.
+- Selected bundle/lens: `code`, `release`, `markdown_docs`, `operating`, `po_context`; engineering과 product lens를 선택했다.
+- Applied instructions: 사용자 세션 보존, 테스트 우선, 독립 브랜치 분리, 테스트·빌드 통과 뒤 commit·push, main 직접 push 금지와 PR 경유 절차를 적용했다.
+- N/A or deferred: 고객 운영 데이터·백오피스·외부 발송은 해당 없고, 실제 OS 키 주입은 Accessibility 제한으로 자동화하지 못해 제품 E2E로 보완했다.
+- Re-read trigger: 배포 대상이나 release 방식이 바뀌면 저장소 release 기준과 `deploy` 절차를 다시 읽는다.
+
+## Done Means
+
+- 설치본에서 기존 9개 PTY가 유지되고, Codex Shift+Enter 회귀 테스트와 production build가 통과하며, 수정 커밋이 원격 공식 반영 경로에 존재한다.
+
+## Verification Plan
+
+- 타입 검사, 관련 541개 테스트, Electron shortcut E2E, desktop production build, 설치본 codesign·패키지 분기, 재시작 전후 PTY identity를 확인한다.
+
+## Risks
+
+- 실제 OS 키 주입은 Accessibility 제한으로 자동화하지 못했다. 제품 E2E와 패키지 확인으로 보완했으며, 원격 반영 상태는 push 뒤 다시 확인한다.

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -31,8 +31,14 @@ import { useAppStore } from '@/store'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 import { isLocalWindowsConptyPaneForCtrlArrow } from './terminal-ctrl-arrow-conpty'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
-import { resolveWindowsShiftEnterEncodingForPane } from './terminal-windows-shift-enter'
-import { resolveTerminalInputHostPlatform } from './terminal-input-host-platform'
+import {
+  resolveAgentShiftEnterEncodingForPane,
+  resolveWindowsShiftEnterEncodingForPane
+} from './terminal-windows-shift-enter'
+import {
+  resolveTerminalInputHostPlatform,
+  terminalInputLacksLocalForegroundConfirmation
+} from './terminal-input-host-platform'
 import {
   markTerminalFollowOutput,
   markTerminalPinnedViewport,
@@ -50,7 +56,8 @@ export function resolveTerminalKeyboardShortcutAction(
   isKittyKeyboardActivePane: Parameters<typeof resolveTerminalShortcutAction>[7],
   layoutBaseCharacterForCode: Parameters<typeof resolveTerminalShortcutAction>[8],
   getWindowsShiftEnterEncoding: Parameters<typeof resolveTerminalShortcutAction>[9],
-  isWindowsTerminalHost: NonNullable<Parameters<typeof resolveTerminalShortcutAction>[10]>
+  isWindowsTerminalHost: NonNullable<Parameters<typeof resolveTerminalShortcutAction>[10]>,
+  getAgentShiftEnterEncoding: Parameters<typeof resolveTerminalShortcutAction>[11] = undefined
 ): ReturnType<typeof resolveTerminalShortcutAction> {
   // Why: keep the host callback required at the production boundary so a
   // caller cannot silently fall back to client-OS byte routing.
@@ -65,7 +72,8 @@ export function resolveTerminalKeyboardShortcutAction(
     isKittyKeyboardActivePane,
     layoutBaseCharacterForCode,
     getWindowsShiftEnterEncoding,
-    isWindowsTerminalHost
+    isWindowsTerminalHost,
+    getAgentShiftEnterEncoding
   )
 }
 
@@ -286,6 +294,26 @@ export function useTerminalKeyboardShortcuts({
       return resolveWindowsShiftEnterEncodingForPane(state, paneKey)
     }
 
+    const getActivePaneAgentShiftEnterEncoding = () => {
+      const manager = managerRef.current
+      const activePane = manager?.getActivePane() ?? manager?.getPanes()[0]
+      if (!activePane) {
+        return null
+      }
+      const state = useAppStore.getState()
+      const transport = paneTransportsRef.current.get(activePane.id) ?? null
+      return resolveAgentShiftEnterEncodingForPane(
+        state,
+        makePaneKey(tabId, activePane.leafId),
+        terminalInputLacksLocalForegroundConfirmation({
+          clientPlatform: shortcutPlatform,
+          state,
+          worktreeId,
+          transport
+        })
+      )
+    }
+
     // Why: host metadata is live and can hydrate after the terminal mounts;
     // resolve it only when Shift+Enter needs to choose a byte protocol.
     const isActivePaneWindowsTerminalHost = (): boolean => {
@@ -397,7 +425,8 @@ export function useTerminalKeyboardShortcuts({
         isKittyKeyboardActivePane,
         getLayoutBaseCharacterForCode,
         getActivePaneWindowsShiftEnterEncoding,
-        isActivePaneWindowsTerminalHost
+        isActivePaneWindowsTerminalHost,
+        getActivePaneAgentShiftEnterEncoding
       )
       if (!action) {
         return
@@ -421,13 +450,13 @@ export function useTerminalKeyboardShortcuts({
         const sent = paneTransportsRef.current.get(pane.id)?.sendInput(action.data) === true
         if (sent) {
           recordTerminalUserInputForLeaf(tabId, pane.leafId)
-          if (action.data === '\x1b[13;2u') {
+          if (action.data === '\x1b[13;2u' || action.data === '\x0a') {
             // Why: this direct shortcut write does not pass through PTY onData,
             // so no-OSC shells need an explicit post-write confirmation ladder.
             const binding = panePtyBindingsRef.current.get(pane.id) as
-              | (IDisposable & { requestDroidReconfirmation?: () => void })
+              | (IDisposable & { requestAgentShiftEnterReconfirmation?: () => void })
               | undefined
-            binding?.requestDroidReconfirmation?.()
+            binding?.requestAgentShiftEnterReconfirmation?.()
           }
         }
         return
@@ -666,6 +695,7 @@ export function useTerminalKeyboardShortcuts({
     keyboardScopeRef,
     managerRef,
     paneTransportsRef,
+    panePtyBindingsRef,
     paneCwdRef,
     fallbackCwd,
     expandedPaneIdRef,

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -14,7 +14,10 @@ import {
 import { buildFreshShellViewportBlankingSequence } from './terminal-restored-viewport'
 import { DEFAULT_DA1_RESPONSE } from './terminal-capability-replies'
 import { TERMINAL_PASTE_DIRECT_MAX_BYTES } from './terminal-paste-coordinator'
-import { resolveWindowsShiftEnterEncodingForPane } from './terminal-windows-shift-enter'
+import {
+  resolveAgentShiftEnterEncodingForPane,
+  resolveWindowsShiftEnterEncodingForPane
+} from './terminal-windows-shift-enter'
 import type * as UseNotificationDispatchModule from './use-notification-dispatch'
 import { getEagerPtyBufferHandle } from './pty-dispatcher'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
@@ -187,7 +190,7 @@ type StoreState = {
   suppressedPtyExitIds: Record<string, true>
   agentLaunchConfigByPaneKey: Record<
     string,
-    { launchConfig: unknown; identity?: { agentType?: string } }
+    { launchConfig: unknown; registeredAt?: number; identity?: { agentType?: string } }
   >
   getAgentLaunchConfigForStatusEntry: ReturnType<typeof vi.fn>
   getAgentLaunchConfigForStatusMetadata: ReturnType<typeof vi.fn>
@@ -5260,6 +5263,8 @@ describe('connectPanePty', () => {
 
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
       agent: 'droid',
+      routingTrusted: false,
+      blockedLaunchRegisteredAt: null,
       shellForeground: false
     })
     expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('alt-enter')
@@ -5271,6 +5276,139 @@ describe('connectPanePty', () => {
       shellForeground: true
     })
     expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('alt-enter')
+  })
+
+  it('revokes trusted Codex after accepted no-OSC exit input until shell confirmation', async () => {
+    vi.useFakeTimers()
+    const { connectPanePty } = await import('./pty-connection')
+    vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('zsh')
+    const pane = createPane(1)
+    const ptyId = 'pty-codex-exit-no-osc'
+    const tabId = 'tab-codex-exit-no-osc'
+    const paneKey = makePaneKey(tabId, LEAF_1)
+    transportFactoryQueue.push(createMockTransport(ptyId))
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps({ tabId }) as never)
+    await vi.advanceTimersByTimeAsync(20)
+    await flushAsyncTicks()
+    mockStoreState.paneForegroundAgentByPaneKey[paneKey] = {
+      agent: 'codex',
+      routingTrusted: true,
+      shellForeground: false
+    }
+
+    sendTerminalInputThroughPane(pane, '\x04')
+    await flushAsyncTicks()
+
+    expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      agent: 'codex',
+      routingTrusted: false,
+      blockedLaunchRegisteredAt: null,
+      shellForeground: false
+    })
+
+    await vi.advanceTimersByTimeAsync(350 + 1200 + 6000)
+
+    expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      agent: null,
+      shellForeground: true
+    })
+  })
+
+  it('blocks remote Codex fallback immediately after no-OSC exit input', async () => {
+    vi.useFakeTimers()
+    const { connectPanePty } = await import('./pty-connection')
+    const pane = createPane(1)
+    const ptyId = 'ssh:conn@@pty-codex-exit-no-osc'
+    const tabId = 'tab-remote-codex-exit-no-osc'
+    const paneKey = makePaneKey(tabId, LEAF_1)
+    transportFactoryQueue.push(createMockTransport(ptyId))
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps({ tabId }) as never)
+    await vi.advanceTimersByTimeAsync(20)
+    await flushAsyncTicks()
+    mockStoreState.agentLaunchConfigByPaneKey[paneKey] = {
+      launchConfig: { agentCommand: 'codex', agentArgs: '', agentEnv: {} },
+      registeredAt: 10,
+      identity: { agentType: 'codex' }
+    }
+    const resolveRemoteEncoding = () =>
+      resolveAgentShiftEnterEncodingForPane(
+        {
+          paneForegroundAgentByPaneKey: mockStoreState.paneForegroundAgentByPaneKey,
+          agentLaunchConfigByPaneKey: {
+            [paneKey]: { identity: { agentType: 'codex' }, registeredAt: 10 }
+          }
+        },
+        paneKey,
+        true
+      )
+    expect(resolveRemoteEncoding()).toBe('ctrl-j')
+
+    sendTerminalInputThroughPane(pane, '\x04')
+    await flushAsyncTicks()
+
+    expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      agent: 'codex',
+      routingTrusted: false,
+      blockedLaunchRegisteredAt: 10,
+      shellForeground: false
+    })
+    expect(resolveRemoteEncoding()).toBeNull()
+
+    mockStoreState.agentLaunchConfigByPaneKey[paneKey] = {
+      launchConfig: { agentCommand: 'codex', agentArgs: '', agentEnv: {} },
+      registeredAt: 11,
+      identity: { agentType: 'codex' }
+    }
+    expect(
+      resolveAgentShiftEnterEncodingForPane(
+        {
+          paneForegroundAgentByPaneKey: mockStoreState.paneForegroundAgentByPaneKey,
+          agentLaunchConfigByPaneKey: {
+            [paneKey]: { identity: { agentType: 'codex' }, registeredAt: 11 }
+          }
+        },
+        paneKey,
+        true
+      )
+    ).toBe('ctrl-j')
+  })
+
+  it('keeps remote Codex fallback through ordinary submit input', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const pane = createPane(1)
+    const ptyId = 'ssh:conn@@pty-codex-submit'
+    const tabId = 'tab-remote-codex-submit'
+    const paneKey = makePaneKey(tabId, LEAF_1)
+    transportFactoryQueue.push(createMockTransport(ptyId))
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps({ tabId }) as never)
+    await flushAsyncTicks()
+    mockStoreState.agentLaunchConfigByPaneKey[paneKey] = {
+      launchConfig: { agentCommand: 'codex', agentArgs: '', agentEnv: {} },
+      identity: { agentType: 'codex' }
+    }
+    mockStoreState.paneForegroundAgentByPaneKey[paneKey] = {
+      agent: 'codex',
+      shellForeground: false
+    }
+
+    sendTerminalInputThroughPane(pane, '\r')
+    await flushAsyncTicks()
+
+    expect(
+      resolveAgentShiftEnterEncodingForPane(
+        {
+          paneForegroundAgentByPaneKey: mockStoreState.paneForegroundAgentByPaneKey,
+          agentLaunchConfigByPaneKey: {
+            [paneKey]: { identity: { agentType: 'codex' } }
+          }
+        },
+        paneKey,
+        true
+      )
+    ).toBe('ctrl-j')
   })
 
   it('never promotes typed Droid text when foreground enrichment is unavailable', async () => {
@@ -18612,7 +18750,7 @@ describe('connectPanePty', () => {
       binding: {
         noteVisibilityResume: () => void
         sampleForegroundAgentOnFocus: () => void
-        requestDroidReconfirmation: () => void
+        requestAgentShiftEnterReconfirmation: () => void
       }
       deps: ReturnType<typeof createDeps>
       transport: MockTransport
@@ -18649,7 +18787,7 @@ describe('connectPanePty', () => {
       ) as unknown as {
         noteVisibilityResume: () => void
         sampleForegroundAgentOnFocus: () => void
-        requestDroidReconfirmation: () => void
+        requestAgentShiftEnterReconfirmation: () => void
       }
       await vi.advanceTimersByTimeAsync(20)
       await flushAsyncTicks(20)
@@ -18766,7 +18904,7 @@ describe('connectPanePty', () => {
       }
     })
 
-    it('keeps trusted Droid routing through a rapid Shift+Enter burst', async () => {
+    it('keeps trusted Droid routing while Shift+Enter confirmation runs', async () => {
       vi.useFakeTimers()
       const ptyId = 'pty-droid-shift-enter-burst'
       const tabId = `tab-${ptyId}`
@@ -18785,9 +18923,9 @@ describe('connectPanePty', () => {
       }
       vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('droid')
 
-      binding.requestDroidReconfirmation()
+      binding.requestAgentShiftEnterReconfirmation()
       await vi.advanceTimersByTimeAsync(200)
-      binding.requestDroidReconfirmation()
+      binding.requestAgentShiftEnterReconfirmation()
       await vi.advanceTimersByTimeAsync(349)
 
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
@@ -18799,6 +18937,7 @@ describe('connectPanePty', () => {
       await vi.advanceTimersByTimeAsync(1)
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
         agent: 'droid',
+        routingTrusted: true,
         shellForeground: false
       })
 
@@ -18811,11 +18950,50 @@ describe('connectPanePty', () => {
         shellForeground: false
       })
 
-      binding.requestDroidReconfirmation()
+      binding.requestAgentShiftEnterReconfirmation()
       await vi.advanceTimersByTimeAsync(700)
       await flushAsyncTicks()
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
         agent: 'droid',
+        routingTrusted: true,
+        shellForeground: false
+      })
+    })
+
+    it('keeps trusted Codex routing immediately after focus and Shift+Enter idle sampling', async () => {
+      vi.useFakeTimers()
+      const ptyId = 'pty-codex-trust-through-benign-samples'
+      const tabId = `tab-${ptyId}`
+      const { binding, cacheKey } = await connectRestoredPaneForForegroundSampling({
+        ptyId,
+        tabId
+      })
+      mockStoreState.paneForegroundAgentByPaneKey[cacheKey] = {
+        agent: 'codex',
+        routingTrusted: true,
+        shellForeground: false
+      }
+      vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('codex')
+
+      binding.sampleForegroundAgentOnFocus()
+      expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        agent: 'codex',
+        routingTrusted: true,
+        shellForeground: false
+      })
+
+      binding.requestAgentShiftEnterReconfirmation()
+      await vi.advanceTimersByTimeAsync(350)
+      expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        agent: 'codex',
+        routingTrusted: true,
+        shellForeground: false
+      })
+
+      await vi.advanceTimersByTimeAsync(350 + 1200 + 6000)
+      await flushAsyncTicks()
+      expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        agent: 'codex',
         routingTrusted: true,
         shellForeground: false
       })

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -634,7 +634,7 @@ type PanePtyBinding = IDisposable & {
    *  agent pane has no OSC boundary left to correct it. */
   sampleForegroundAgentOnFocus: () => void
   /** Reconfirm after direct shortcut input, which bypasses PTY onData. */
-  requestDroidReconfirmation: () => void
+  requestAgentShiftEnterReconfirmation: () => void
   reconcileIfSessionDead: (liveSessionIds: Set<string>, snapshotRequestedAt?: number) => void
   reconcileIfSessionMissing: (hasPty: HasPty, livenessRequestedAt?: number) => void
   /** True when the hidden-delivery gate structurally manages the pane's
@@ -1251,7 +1251,7 @@ export function connectPanePty(
   let commandInferredPaneAgentGeneration = 0
   let shellCommandInferenceSuspendedUntilCommandEnd = false
   let startAcceptedInferredCommand = (_agent: TuiAgent): void => {}
-  let requestKnownDroidReconfirmation = (): void => {}
+  let revokeKnownShiftEnterAgentRouting = (_blockUntrackableFallback?: boolean): void => {}
   const resetPendingShellCommandLine = (): void => {
     pendingShellCommandLine = ''
     pendingShellCommandCursor = 0
@@ -1500,8 +1500,8 @@ export function connectPanePty(
       data.includes('\x04')
     ) {
       // Why: shells without OSC 133 give no command/exit boundary. An accepted
-      // submit or interrupt revokes only stale Droid routing and confirms once.
-      requestKnownDroidReconfirmation()
+      // submit or interrupt revokes stale Shift+Enter routing and confirms once.
+      revokeKnownShiftEnterAgentRouting(data.includes('\x04'))
     }
     if (commandInferredPaneAgent) {
       return
@@ -2045,7 +2045,7 @@ export function connectPanePty(
     if (
       !deps.isVisibleRef.current ||
       visibleForegroundSamplePending ||
-      visibleForegroundSampleSettled
+      (!forceRoutingConfirmation && visibleForegroundSampleSettled)
     ) {
       return
     }
@@ -2053,7 +2053,7 @@ export function connectPanePty(
     const foreground = state.paneForegroundAgentByPaneKey[cacheKey]
     // Why: a daemon reattach may restore display identity without current
     // routing authority. Only fresh evidence can suppress its confirmation.
-    if (foreground?.agent && foreground.routingTrusted === true) {
+    if (!forceRoutingConfirmation && foreground?.agent && foreground.routingTrusted === true) {
       return
     }
     if (!forceRoutingConfirmation && paneHasLiveHookAgentIcon(state)) {
@@ -2069,22 +2069,48 @@ export function connectPanePty(
     // identity from local process state, with remote/SSH excluded by the tracker.
     visibleForegroundSamplePending = paneForegroundAgentTracker.onVisiblePtyBound(expectsAgent)
   }
+  const refreshTrustedVisiblePaneForegroundAgent = (): void => {
+    const foreground = useAppStore.getState().paneForegroundAgentByPaneKey[cacheKey]
+    // Why: benign focus/visibility/Shift+Enter events may refresh an already
+    // trusted agent, but must not resurrect sampling after a settled shell.
+    sampleVisiblePaneForegroundAgent(
+      foreground?.agent !== null && foreground?.routingTrusted === true
+    )
+  }
   startAcceptedInferredCommand = (agent) => {
     paneForegroundAgentTracker.onCommandStarted(agent)
   }
-  requestKnownDroidReconfirmation = () => {
+  revokeKnownShiftEnterAgentRouting = (blockUntrackableFallback = false) => {
     const foreground = useAppStore.getState().paneForegroundAgentByPaneKey[cacheKey]
     // Why: daemon reattach/launch metadata is display-only until a live
     // provider read confirms it. Submit/interrupt/title-exit evidence must
     // revoke that launch-only hint too, otherwise Shift+Enter can route bytes
     // to a Droid that already exited before confirmation ever ran.
-    if (foreground?.agent !== 'droid') {
+    const ptyId = transport.getPtyId()
+    const lacksForegroundTracking = Boolean(ptyId && !isForegroundTrackingAllowed(ptyId))
+    const launchOnlyAgent =
+      blockUntrackableFallback && lacksForegroundTracking ? resolveExpectedLaunchTuiAgent() : null
+    const agent = foreground?.agent ?? launchOnlyAgent
+    if (
+      !agent ||
+      (!TUI_AGENT_CONFIG[agent].shiftEnterEncoding &&
+        !TUI_AGENT_CONFIG[agent].windowsShiftEnterEncoding)
+    ) {
+      return
+    }
+    if (lacksForegroundTracking && !blockUntrackableFallback) {
+      // Why: Enter, pasted LF, and Ctrl+C are normal in-agent input. A remote
+      // pane cannot asynchronously restore trust, so only hard exit evidence
+      // (Ctrl+D or an agent-exited signal) may block its launch fallback.
       return
     }
     // Why: cmd.exe and Git Bash have no OSC command boundaries. Keep the icon
     // as a hint, but revoke bytes until one current provider confirmation lands.
     useAppStore.getState().setPaneForegroundAgent(cacheKey, {
-      agent: 'droid',
+      agent,
+      routingTrusted: false,
+      blockedLaunchRegisteredAt:
+        useAppStore.getState().agentLaunchConfigByPaneKey[cacheKey]?.registeredAt ?? null,
       shellForeground: false
     })
     visibleForegroundSamplePending = false
@@ -3085,7 +3111,7 @@ export function connectPanePty(
   const onAgentExited = (): void => {
     clearSuppressedTitleSideEffects()
     clearCommandInferredPaneAgent()
-    requestKnownDroidReconfirmation()
+    revokeKnownShiftEnterAgentRouting(true)
     // Why: when the terminal title reverts to a plain shell (e.g., "bash", "zsh"),
     // the agent has exited. Clear any running cache timer so the sidebar doesn't
     // show a stale countdown for a tab that no longer has an active Claude session.
@@ -8165,8 +8191,9 @@ export function connectPanePty(
     noteVisibilityResume() {
       ptySizeReassertion.request({ fit: false })
       consumeHibernatedAgentWake()
-      requestKnownDroidReconfirmation()
-      sampleVisiblePaneForegroundAgent()
+      // Why: focus/visibility is not exit evidence. Preserve trusted routing
+      // while the provider refresh runs so Shift+Enter remains usable.
+      refreshTrustedVisiblePaneForegroundAgent()
     },
     // Why: mobile wake reaches this pane while it stays hidden on the desktop, so
     // it must consume only the armed hibernation wake — no size/foreground reads.
@@ -8210,10 +8237,11 @@ export function connectPanePty(
       return null
     },
     sampleForegroundAgentOnFocus() {
-      requestKnownDroidReconfirmation()
-      sampleVisiblePaneForegroundAgent()
+      // Why: focusing a live agent pane must not open a transient fallback
+      // window before the asynchronous foreground refresh completes.
+      refreshTrustedVisiblePaneForegroundAgent()
     },
-    requestDroidReconfirmation() {
+    requestAgentShiftEnterReconfirmation() {
       if (shiftEnterReconfirmTimer !== null) {
         clearTimeout(shiftEnterReconfirmTimer)
       }
@@ -8221,8 +8249,9 @@ export function connectPanePty(
       // confirm only after the Shift+Enter burst goes idle.
       shiftEnterReconfirmTimer = setTimeout(() => {
         shiftEnterReconfirmTimer = null
-        requestKnownDroidReconfirmation()
-        sampleVisiblePaneForegroundAgent()
+        // Why: Shift+Enter is normal in-agent input, not evidence that the
+        // agent exited. Refresh without revoking the last trusted identity.
+        refreshTrustedVisiblePaneForegroundAgent()
       }, SHIFT_ENTER_RECONFIRM_IDLE_MS)
     },
     reconcileIfSessionDead,

--- a/src/renderer/src/components/terminal-pane/terminal-input-host-platform.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-input-host-platform.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import type { AppState } from '@/store/types'
-import { resolveTerminalInputHostPlatform } from './terminal-input-host-platform'
+import {
+  resolveTerminalInputHostPlatform,
+  terminalInputLacksLocalForegroundConfirmation
+} from './terminal-input-host-platform'
 
 function state(overrides: Partial<AppState> = {}): AppState {
   return {
@@ -243,5 +246,52 @@ describe('resolveTerminalInputHostPlatform', () => {
         transport: null
       })
     ).toBe('darwin')
+  })
+})
+
+describe('terminalInputLacksLocalForegroundConfirmation', () => {
+  it('distinguishes SSH, remote runtime, and WSL panes from a local PTY', () => {
+    const base = {
+      clientPlatform: 'darwin' as const,
+      state: state(),
+      worktreeId: 'repo::/repo'
+    }
+
+    expect(
+      terminalInputLacksLocalForegroundConfirmation({
+        ...base,
+        transport: { getConnectionId: () => 'ssh-1' }
+      })
+    ).toBe(true)
+    expect(
+      terminalInputLacksLocalForegroundConfirmation({
+        ...base,
+        transport: {
+          getConnectionId: () => null,
+          getPtyId: () => 'remote:runtime-1@@pty-1'
+        }
+      })
+    ).toBe(true)
+    expect(
+      terminalInputLacksLocalForegroundConfirmation({
+        ...base,
+        clientPlatform: 'win32',
+        transport: {
+          getConnectionId: () => null,
+          getPtyId: () => 'local-pty-1',
+          getLocalSessionMetadata: () => ({ shellOverride: 'wsl.exe -d Ubuntu' })
+        }
+      })
+    ).toBe(true)
+    expect(
+      terminalInputLacksLocalForegroundConfirmation({
+        ...base,
+        transport: {
+          getConnectionId: () => null,
+          getPtyId: () => 'local-pty-1',
+          getLocalSessionMetadata: () => ({ cwd: '/repo' })
+        }
+      })
+    ).toBe(false)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-input-host-platform.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-input-host-platform.ts
@@ -19,7 +19,7 @@ type TerminalInputHostPlatformState = Pick<
   | 'restoredRuntimeHostIdByWorkspaceSessionKey'
 >
 
-export function resolveTerminalInputHostPlatform(args: {
+type TerminalInputHostPlatformArgs = {
   clientPlatform: NodeJS.Platform
   state: TerminalInputHostPlatformState
   worktreeId: string
@@ -29,7 +29,43 @@ export function resolveTerminalInputHostPlatform(args: {
           Pick<PtyTransport, 'getPtyId' | 'getRuntimeEnvironmentId' | 'getLocalSessionMetadata'>
         >)
     | null
-}): NodeJS.Platform {
+}
+
+export function terminalInputLacksLocalForegroundConfirmation(
+  args: TerminalInputHostPlatformArgs
+): boolean {
+  const ptyId = args.transport?.getPtyId?.() ?? null
+  const runtimeEnvironmentId =
+    args.transport?.getRuntimeEnvironmentId?.() ??
+    (ptyId ? getRemoteRuntimePtyEnvironmentId(ptyId) : null)
+  if (runtimeEnvironmentId) {
+    return true
+  }
+
+  const localSessionMetadata = args.transport?.getLocalSessionMetadata?.()
+  if (ptyId !== null && localSessionMetadata != null) {
+    return (
+      isWslUncPath(localSessionMetadata.cwd ?? '') ||
+      isWslShellOverride(localSessionMetadata.shellOverride)
+    )
+  }
+
+  const transportConnectionId = args.transport?.getConnectionId?.()
+  const connectionId =
+    transportConnectionId === undefined
+      ? getConnectionIdFromState(args.state, args.worktreeId)
+      : transportConnectionId
+  if (connectionId) {
+    return true
+  }
+
+  const host = parseExecutionHostId(getExecutionHostIdForWorktree(args.state, args.worktreeId))
+  return host?.kind === 'ssh' || host?.kind === 'runtime'
+}
+
+export function resolveTerminalInputHostPlatform(
+  args: TerminalInputHostPlatformArgs
+): NodeJS.Platform {
   const transportConnectionId = args.transport?.getConnectionId?.()
   const connectionId =
     transportConnectionId === undefined

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy-codex-shift-enter.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy-codex-shift-enter.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveTerminalShortcutAction,
+  type TerminalShortcutEvent
+} from './terminal-shortcut-policy'
+
+const shiftEnterEvent: TerminalShortcutEvent = {
+  key: 'Enter',
+  code: 'Enter',
+  metaKey: false,
+  ctrlKey: false,
+  altKey: false,
+  shiftKey: true,
+  repeat: false
+}
+
+describe('Codex Shift+Enter shortcut policy', () => {
+  it('uses Ctrl+J for a trusted Codex pane even while Kitty keyboard is active', () => {
+    expect(
+      resolveTerminalShortcutAction(
+        shiftEnterEvent,
+        true,
+        'false',
+        0,
+        false,
+        undefined,
+        undefined,
+        () => true,
+        undefined,
+        undefined,
+        undefined,
+        () => 'ctrl-j'
+      )
+    ).toEqual({ type: 'sendInput', data: '\x0a' })
+  })
+
+  it('keeps Codex Ctrl+J ahead of client OS, host OS, and Kitty protocol choices', () => {
+    for (const [isMac, isWindows, kittyActive, windowsHost] of [
+      [true, false, false, false],
+      [false, true, false, true],
+      [false, false, true, true]
+    ] as const) {
+      expect(
+        resolveTerminalShortcutAction(
+          shiftEnterEvent,
+          isMac,
+          'false',
+          0,
+          isWindows,
+          undefined,
+          undefined,
+          () => kittyActive,
+          undefined,
+          () => 'csi-u',
+          () => windowsHost,
+          () => 'ctrl-j'
+        )
+      ).toEqual({ type: 'sendInput', data: '\x0a' })
+    }
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -1,5 +1,8 @@
 import { keybindingMatchesAction, type KeybindingOverrides } from '../../../../shared/keybindings'
-import type { WindowsShiftEnterEncoding } from './terminal-windows-shift-enter'
+import type {
+  AgentShiftEnterEncoding,
+  WindowsShiftEnterEncoding
+} from './terminal-windows-shift-enter'
 
 export type TerminalShortcutEvent = {
   key: string
@@ -94,7 +97,8 @@ export function resolveTerminalShortcutAction(
   getWindowsShiftEnterEncoding?: () => WindowsShiftEnterEncoding,
   // Why: keybindings follow the client OS, but terminal byte protocols follow
   // the PTY host. They differ for macOS clients attached to Windows runtimes.
-  isWindowsTerminalHost: () => boolean = () => isWindows
+  isWindowsTerminalHost: () => boolean = () => isWindows,
+  getAgentShiftEnterEncoding?: () => AgentShiftEnterEncoding | null
 ): TerminalShortcutAction | null {
   const platform: NodeJS.Platform = isMac ? 'darwin' : isWindows ? 'win32' : 'linux'
 
@@ -161,6 +165,9 @@ export function resolveTerminalShortcutAction(
     event.shiftKey &&
     event.key === 'Enter'
   ) {
+    if (getAgentShiftEnterEncoding?.() === 'ctrl-j') {
+      return { type: 'sendInput', data: '\x0a' }
+    }
     // Why: negotiated KKP is authoritative on every host; trusted pane
     // evidence additionally preserves Droid's Windows encoding without KKP.
     const windowsHost = isWindowsTerminalHost()

--- a/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts
@@ -1,8 +1,129 @@
 import { describe, expect, it } from 'vitest'
 import {
+  resolveAgentShiftEnterEncoding,
+  resolveAgentShiftEnterEncodingForPane,
   resolveWindowsShiftEnterEncoding,
   resolveWindowsShiftEnterEncodingForPane
 } from './terminal-windows-shift-enter'
+
+describe('resolveAgentShiftEnterEncoding', () => {
+  it('routes trusted Codex panes through Ctrl+J', () => {
+    expect(
+      resolveAgentShiftEnterEncoding({
+        foreground: { agent: 'codex', routingTrusted: true, shellForeground: false }
+      })
+    ).toBe('ctrl-j')
+  })
+
+  it('does not apply stale Codex routing to shells or newer null evidence', () => {
+    expect(
+      resolveAgentShiftEnterEncoding({
+        foreground: { agent: null, routingTrusted: true, shellForeground: true },
+        launchAgentType: 'codex'
+      })
+    ).toBeNull()
+  })
+
+  it('keeps Orca-known Codex routing available when remote process confirmation is unavailable', () => {
+    expect(
+      resolveAgentShiftEnterEncoding({
+        launchAgentType: 'codex',
+        allowUntrustedCodexFallback: true
+      })
+    ).toBe('ctrl-j')
+    expect(
+      resolveAgentShiftEnterEncoding({
+        foreground: { agent: 'codex', shellForeground: false },
+        launchAgentType: 'codex',
+        allowUntrustedCodexFallback: true
+      })
+    ).toBe('ctrl-j')
+    expect(
+      resolveAgentShiftEnterEncoding({
+        foreground: { agent: 'codex', shellForeground: false },
+        allowUntrustedCodexFallback: true
+      })
+    ).toBeNull()
+  })
+
+  it('keeps display-only Codex identity from routing bytes on local panes', () => {
+    expect(resolveAgentShiftEnterEncoding({ launchAgentType: 'codex' })).toBeNull()
+    expect(
+      resolveAgentShiftEnterEncoding({
+        foreground: { agent: 'codex', shellForeground: false },
+        launchAgentType: 'codex'
+      })
+    ).toBeNull()
+  })
+
+  it('does not reuse stale Codex launch identity after newer foreground evidence', () => {
+    expect(
+      resolveAgentShiftEnterEncoding({
+        foreground: { agent: null, shellForeground: false },
+        launchAgentType: 'codex'
+      })
+    ).toBeNull()
+    expect(
+      resolveAgentShiftEnterEncoding({
+        foreground: { agent: 'antigravity', shellForeground: false },
+        launchAgentType: 'codex'
+      })
+    ).toBeNull()
+  })
+
+  it('keeps routing scoped to the active leaf', () => {
+    const state = {
+      paneForegroundAgentByPaneKey: {
+        'tab:codex': { agent: 'codex' as const, routingTrusted: true, shellForeground: false }
+      },
+      agentLaunchConfigByPaneKey: {}
+    }
+
+    expect(resolveAgentShiftEnterEncodingForPane(state, 'tab:codex')).toBe('ctrl-j')
+    expect(resolveAgentShiftEnterEncodingForPane(state, 'tab:sibling')).toBeNull()
+  })
+
+  it('retires remote Codex fallback when pane launch ownership is cleared', () => {
+    const state = {
+      paneForegroundAgentByPaneKey: {
+        'tab:codex': { agent: 'codex' as const, shellForeground: false }
+      },
+      agentLaunchConfigByPaneKey: {
+        'tab:codex': { identity: { agentType: 'codex' as const } }
+      } as Record<string, { identity: { agentType: 'codex' } } | undefined>
+    }
+
+    expect(resolveAgentShiftEnterEncodingForPane(state, 'tab:codex', true)).toBe('ctrl-j')
+    delete state.agentLaunchConfigByPaneKey['tab:codex']
+    expect(resolveAgentShiftEnterEncodingForPane(state, 'tab:codex', true)).toBeNull()
+  })
+
+  it('blocks remote Codex fallback after explicit exit-risk evidence', () => {
+    expect(
+      resolveAgentShiftEnterEncoding({
+        foreground: { agent: 'codex', routingTrusted: false, shellForeground: false },
+        launchAgentType: 'codex',
+        allowUntrustedCodexFallback: true
+      })
+    ).toBeNull()
+  })
+
+  it('restores remote Codex fallback for a newer launch generation', () => {
+    expect(
+      resolveAgentShiftEnterEncoding({
+        foreground: {
+          agent: 'codex',
+          routingTrusted: false,
+          blockedLaunchRegisteredAt: 10,
+          shellForeground: false
+        },
+        launchAgentType: 'codex',
+        launchRegisteredAt: 11,
+        allowUntrustedCodexFallback: true
+      })
+    ).toBe('ctrl-j')
+  })
+})
 
 describe('resolveWindowsShiftEnterEncoding', () => {
   it('uses CSI-u only for trusted Droid process evidence', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.ts
@@ -3,15 +3,70 @@ import { TUI_AGENT_CONFIG } from '../../../../shared/tui-agent-config'
 import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 
 export type WindowsShiftEnterEncoding = 'alt-enter' | 'csi-u'
+export type AgentShiftEnterEncoding = 'ctrl-j'
 
 type WindowsShiftEnterAgentSignals = {
   foreground?: PaneForegroundAgentEntry
   launchAgentType?: AgentType
+  launchRegisteredAt?: number
+  allowUntrustedCodexFallback?: boolean
 }
 
 type WindowsShiftEnterPaneState = {
   paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry | undefined>
-  agentLaunchConfigByPaneKey: Record<string, { identity: { agentType?: AgentType } } | undefined>
+  agentLaunchConfigByPaneKey: Record<
+    string,
+    { identity: { agentType?: AgentType }; registeredAt?: number } | undefined
+  >
+}
+
+export function resolveAgentShiftEnterEncoding(
+  signals: WindowsShiftEnterAgentSignals
+): AgentShiftEnterEncoding | null {
+  if (signals.foreground?.shellForeground) {
+    return null
+  }
+  // Why: remote panes cannot prove the next foreground process locally. An
+  // explicit false records newer exit-risk input and must block launch fallback.
+  if (
+    signals.foreground?.routingTrusted === false &&
+    (signals.foreground.blockedLaunchRegisteredAt ?? null) === (signals.launchRegisteredAt ?? null)
+  ) {
+    return null
+  }
+  const agent =
+    signals.foreground?.agent ??
+    (signals.foreground === undefined &&
+    signals.allowUntrustedCodexFallback === true &&
+    signals.launchAgentType === 'codex'
+      ? 'codex'
+      : null)
+  // Why: remote, SSH, and WSL panes cannot provide local process confirmation.
+  // A newer null or other foreground entry still blocks stale launch identity.
+  if (
+    agent === 'codex' &&
+    (signals.foreground?.routingTrusted === true ||
+      (signals.allowUntrustedCodexFallback === true && signals.launchAgentType === 'codex'))
+  ) {
+    return TUI_AGENT_CONFIG.codex.shiftEnterEncoding ?? null
+  }
+  if (signals.foreground?.routingTrusted !== true) {
+    return null
+  }
+  return agent ? (TUI_AGENT_CONFIG[agent].shiftEnterEncoding ?? null) : null
+}
+
+export function resolveAgentShiftEnterEncodingForPane(
+  state: WindowsShiftEnterPaneState,
+  paneKey: string,
+  allowUntrustedCodexFallback = false
+): AgentShiftEnterEncoding | null {
+  return resolveAgentShiftEnterEncoding({
+    foreground: state.paneForegroundAgentByPaneKey[paneKey],
+    launchAgentType: state.agentLaunchConfigByPaneKey[paneKey]?.identity.agentType,
+    launchRegisteredAt: state.agentLaunchConfigByPaneKey[paneKey]?.registeredAt,
+    allowUntrustedCodexFallback
+  })
 }
 
 /** Resolve without key-path PTY I/O; current process/shell evidence overrides

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -1300,12 +1300,15 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
     registerAgentLaunchConfig: (paneKey, launchConfig, metadata) => {
       set((s) => {
         const copiedLaunchConfig = copyLaunchConfig(launchConfig)
+        const existingRegistryEntry = s.agentLaunchConfigByPaneKey[paneKey]
         const nextRegistryEntry: AgentLaunchConfigRegistryEntry = {
           launchConfig: copiedLaunchConfig,
-          registeredAt: Date.now(),
+          registeredAt: Math.max(
+            Date.now(),
+            (existingRegistryEntry?.registeredAt ?? Number.NEGATIVE_INFINITY) + 1
+          ),
           identity: normalizeLaunchConfigRegistrationMetadata(paneKey, metadata)
         }
-        const existingRegistryEntry = s.agentLaunchConfigByPaneKey[paneKey]
         const registryChanged = !launchConfigRegistryEntriesEqual(
           existingRegistryEntry,
           nextRegistryEntry

--- a/src/renderer/src/store/slices/pane-foreground-agent.test.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createTestStore } from './store-test-helpers'
 import type { TerminalTab } from '../../../../shared/types'
+import { resolveAgentShiftEnterEncodingForPane } from '../../components/terminal-pane/terminal-windows-shift-enter'
 
 function terminalTab(id: string, worktreeId: string): TerminalTab {
   return {
@@ -30,6 +31,48 @@ describe('pane foreground agent slice', () => {
 
     store.getState().clearPaneForegroundAgent('tab-1:leaf-1')
     expect(store.getState().paneForegroundAgentByPaneKey).toEqual({})
+  })
+
+  it('updates a remote exit tombstone for each new launch generation', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    const paneKey = 'tab-1:leaf-1'
+    const launchConfig = { agentArgs: '', agentEnv: {} }
+
+    vi.setSystemTime(10)
+    store.getState().registerAgentLaunchConfig(paneKey, launchConfig, {
+      agentType: 'codex',
+      launchToken: 'launch-10'
+    })
+    const generation10 = store.getState().agentLaunchConfigByPaneKey[paneKey]!.registeredAt
+    store.getState().setPaneForegroundAgent(paneKey, {
+      agent: 'codex',
+      routingTrusted: false,
+      blockedLaunchRegisteredAt: generation10,
+      shellForeground: false
+    })
+    expect(resolveAgentShiftEnterEncodingForPane(store.getState(), paneKey, true)).toBeNull()
+
+    vi.setSystemTime(10)
+    store.getState().registerAgentLaunchConfig(paneKey, launchConfig, {
+      agentType: 'codex',
+      launchToken: 'launch-11'
+    })
+    const generation11 = store.getState().agentLaunchConfigByPaneKey[paneKey]!.registeredAt
+    expect(generation11).toBeGreaterThan(generation10)
+    expect(resolveAgentShiftEnterEncodingForPane(store.getState(), paneKey, true)).toBe('ctrl-j')
+
+    store.getState().setPaneForegroundAgent(paneKey, {
+      agent: 'codex',
+      routingTrusted: false,
+      blockedLaunchRegisteredAt: generation11,
+      shellForeground: false
+    })
+    expect(store.getState().paneForegroundAgentByPaneKey[paneKey]?.blockedLaunchRegisteredAt).toBe(
+      generation11
+    )
+    expect(resolveAgentShiftEnterEncodingForPane(store.getState(), paneKey, true)).toBeNull()
+    vi.useRealTimers()
   })
 
   it('sweeps only the closed tab prefix, not sibling tabs or prefix-share ids', () => {

--- a/src/renderer/src/store/slices/pane-foreground-agent.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.ts
@@ -7,6 +7,9 @@ export type PaneForegroundAgentEntry = {
   agent: TuiAgent | null
   /** True only when fresh provider evidence is safe for input-byte routing. */
   routingTrusted?: boolean
+  /** Launch generation blocked by exit-risk evidence on a pane whose remote
+   * foreground process cannot be inspected. A newer launch may route again. */
+  blockedLaunchRegisteredAt?: number | null
   /** True once the foreground is proven back at the shell (OSC 133;D) —
    *  process-grade launched-agent exit evidence, independent of titles. */
   shellForeground: boolean
@@ -41,6 +44,7 @@ export const createPaneForegroundAgentSlice: StateCreator<
         current &&
         current.agent === entry.agent &&
         current.routingTrusted === entry.routingTrusted &&
+        current.blockedLaunchRegisteredAt === entry.blockedLaunchRegisteredAt &&
         current.shellForeground === entry.shellForeground
       ) {
         return s

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -67,6 +67,9 @@ export type TuiAgentConfig = {
   /** Windows Shift+Enter override. Omitted agents keep the legacy Esc+CR path
    * because the renderer cannot infer every local or remote TUI's decoder. */
   windowsShiftEnterEncoding?: 'csi-u'
+  /** Agent-specific Shift+Enter fallback when the TUI's negotiated keyboard
+   * protocol does not match the multiline bytes it accepts. */
+  shiftEnterEncoding?: 'ctrl-j'
 }
 
 export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
@@ -113,7 +116,10 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     expectedProcess: 'codex',
     promptInjectionMode: 'argv',
     preflightTrust: 'codex',
-    draftPasteReadySignal: 'codex-composer-prompt'
+    draftPasteReadySignal: 'codex-composer-prompt',
+    // Why: current Codex accepts Ctrl+J for a composer newline but ignores the
+    // CSI-u Shift+Enter sequence it negotiates through some terminal hosts.
+    shiftEnterEncoding: 'ctrl-j'
   },
   autohand: {
     detectCmd: 'autohand',

--- a/tests/e2e/terminal-shortcuts.spec.ts
+++ b/tests/e2e/terminal-shortcuts.spec.ts
@@ -37,7 +37,7 @@ import {
 
 async function setActivePaneForegroundAgent(
   page: Page,
-  agent: 'droid' | 'antigravity' | null
+  agent: 'codex' | 'droid' | 'antigravity' | null
 ): Promise<string> {
   return page.evaluate((agent) => {
     const state = window.__store?.getState()
@@ -57,9 +57,8 @@ async function setActivePaneForegroundAgent(
     state.setPaneForegroundAgent(paneKey, {
       agent,
       shellForeground: false,
-      // The shortcut only emits CSI-u for a process identity confirmed to
-      // belong to this PTY; keep the fixture aligned with that trust gate.
-      routingTrusted: agent === 'droid'
+      // Keep the fixture aligned with the shortcut's trusted-process gate.
+      routingTrusted: agent === 'droid' || agent === 'codex'
     })
     return paneKey
   }, agent)
@@ -484,6 +483,9 @@ test.describe('Terminal Shortcuts', () => {
     await execInTerminal(orcaPage, ptyId, "printf '\\033[>1u'")
     await expect.poll(() => getKittyKeyboardFlags(orcaPage)).toBe(1)
     await pressAndExpectWrite(orcaPage, electronApp, 'Shift+Enter', '\x1b[13;2u')
+    await setActivePaneForegroundAgent(orcaPage, 'codex')
+    await pressAndExpectWrite(orcaPage, electronApp, 'Shift+Enter', '\x0a')
+    await setActivePaneForegroundAgent(orcaPage, null)
 
     // Clear the shell's unconsumed CSI-u line before resetting flags in a settled
     // command; otherwise its line editor can swallow the reset bytes.


### PR DESCRIPTION
## Summary
- route Shift+Enter to LF only for confirmed Codex terminal panes
- clear stale local agent identity while preserving safe SSH/WSL fallback behavior
- add lifecycle and cross-platform regression coverage

## Verification
- 541 terminal and agent lifecycle tests passed
- full typecheck passed
- desktop production build passed
- packaged macOS app was signed, installed, and preserved all 9 existing PTY sessions across restart

## ELI5

Shift+Enter in Codex was not always inserting a newline the way Codex expects. Routing is limited to confirmed Codex panes and stale local agent identity is cleared so the key works across platforms.
