### PR TITLE
feat(mobile): show all usage providers with visibility controls

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -187,6 +187,7 @@ export default function RootLayout() {
           <Stack.Screen name="native-chat-settings" options={{ headerShown: false }} />
           <Stack.Screen name="browser-settings" options={{ headerShown: false }} />
           <Stack.Screen name="voice-settings" options={{ headerShown: false }} />
+          <Stack.Screen name="account-usage-settings" options={{ headerShown: false }} />
           <Stack.Screen name="notifications" options={{ headerShown: false }} />
           <Stack.Screen name="troubleshoot" options={{ headerShown: false }} />
           <Stack.Screen name="connection-log" options={{ headerShown: false }} />

--- a/mobile/app/account-usage-settings.tsx
+++ b/mobile/app/account-usage-settings.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { View, Text, StyleSheet, Pressable, Switch, ScrollView } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { useRouter, useFocusEffect } from 'expo-router'
+import { useRouter } from 'expo-router'
 import { ChevronLeft } from 'lucide-react-native'
 import { colors, spacing, typography } from '../src/theme/mobile-theme'
 import {
@@ -9,46 +9,52 @@ import {
   DEFAULT_VISIBLE_USAGE_PROVIDERS,
   type UsageProviderKey
 } from '../src/components/AccountUsage'
-import { loadVisibleUsageProviders, saveVisibleUsageProviders } from '../src/storage/preferences'
+import {
+  loadVisibleUsageProvidersSettled,
+  setUsageProviderVisible
+} from '../src/storage/preferences'
 
 export default function AccountUsageSettingsScreen() {
   const router = useRouter()
   const insets = useSafeAreaInsets()
-  const [visible, setVisible] = useState<Set<UsageProviderKey>>(
-    () => new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
-  )
-  // Why: a fast toggle before the initial load resolves must win — otherwise
-  // the delayed read would clobber it with the stored value (mirrors the
-  // Settings → Terminal autocomplete toggle guard).
-  const userToggledRef = useRef(false)
+  // Why: null until the stored set loads. Switches stay disabled while null so a
+  // tap can't persist against the default base and silently drop a stored-only
+  // provider (e.g. an opted-in Grok); the load resolves within a frame or two.
+  const [visible, setVisible] = useState<Set<UsageProviderKey> | null>(null)
 
-  useFocusEffect(
-    useCallback(() => {
-      let active = true
-      void loadVisibleUsageProviders().then((set) => {
-        if (active && !userToggledRef.current) {
-          setVisible(set)
-        }
-      })
-      return () => {
-        active = false
+  // Why: this screen is the only writer of the visibility set, so load once on
+  // mount rather than on every focus — a focus-reload could resolve mid-toggle
+  // and overwrite the optimistic UI with a pre-write snapshot. The settled read
+  // also waits for any in-flight toggle so a quick leave/return shows the latest.
+  useEffect(() => {
+    let active = true
+    void loadVisibleUsageProvidersSettled().then((stored) => {
+      if (active) {
+        setVisible(stored)
       }
-    }, [])
-  )
+    })
+    return () => {
+      active = false
+    }
+  }, [])
 
   const toggle = useCallback((id: UsageProviderKey, value: boolean) => {
-    userToggledRef.current = true
+    // Optimistic UI; the storage-level toggle re-reads the latest stored set and
+    // changes only this provider, so it survives an unmount and never clobbers
+    // one the user didn't touch. Swallow a write failure so the UI stays put.
     setVisible((prev) => {
+      if (!prev) {
+        return prev
+      }
       const next = new Set(prev)
       if (value) {
         next.add(id)
       } else {
         next.delete(id)
       }
-      // Swallow a storage write failure so the UI stays on the user's choice.
-      void saveVisibleUsageProviders(next).catch(() => {})
       return next
     })
+    void setUsageProviderVisible(id, value).catch(() => {})
   }, [])
 
   return (
@@ -75,8 +81,13 @@ export default function AccountUsageSettingsScreen() {
               <View style={styles.row}>
                 <Text style={styles.rowLabel}>{descriptor.label}</Text>
                 <Switch
-                  value={visible.has(descriptor.id)}
+                  value={
+                    visible
+                      ? visible.has(descriptor.id)
+                      : DEFAULT_VISIBLE_USAGE_PROVIDERS.includes(descriptor.id)
+                  }
                   onValueChange={(v) => toggle(descriptor.id, v)}
+                  disabled={visible === null}
                   trackColor={{ false: colors.bgRaised, true: colors.textSecondary }}
                   thumbColor={colors.textPrimary}
                 />

--- a/mobile/app/account-usage-settings.tsx
+++ b/mobile/app/account-usage-settings.tsx
@@ -81,6 +81,7 @@ export default function AccountUsageSettingsScreen() {
               <View style={styles.row}>
                 <Text style={styles.rowLabel}>{descriptor.label}</Text>
                 <Switch
+                  accessibilityLabel={`Show ${descriptor.label} usage`}
                   value={
                     visible
                       ? visible.has(descriptor.id)

--- a/mobile/app/account-usage-settings.tsx
+++ b/mobile/app/account-usage-settings.tsx
@@ -1,0 +1,145 @@
+import { useCallback, useRef, useState } from 'react'
+import { View, Text, StyleSheet, Pressable, Switch, ScrollView } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useRouter, useFocusEffect } from 'expo-router'
+import { ChevronLeft } from 'lucide-react-native'
+import { colors, spacing, typography } from '../src/theme/mobile-theme'
+import {
+  USAGE_PROVIDERS,
+  DEFAULT_VISIBLE_USAGE_PROVIDERS,
+  type UsageProviderKey
+} from '../src/components/AccountUsage'
+import { loadVisibleUsageProviders, saveVisibleUsageProviders } from '../src/storage/preferences'
+
+export default function AccountUsageSettingsScreen() {
+  const router = useRouter()
+  const insets = useSafeAreaInsets()
+  const [visible, setVisible] = useState<Set<UsageProviderKey>>(
+    () => new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
+  )
+  // Why: a fast toggle before the initial load resolves must win — otherwise
+  // the delayed read would clobber it with the stored value (mirrors the
+  // Settings → Terminal autocomplete toggle guard).
+  const userToggledRef = useRef(false)
+
+  useFocusEffect(
+    useCallback(() => {
+      let active = true
+      void loadVisibleUsageProviders().then((set) => {
+        if (active && !userToggledRef.current) {
+          setVisible(set)
+        }
+      })
+      return () => {
+        active = false
+      }
+    }, [])
+  )
+
+  const toggle = useCallback((id: UsageProviderKey, value: boolean) => {
+    userToggledRef.current = true
+    setVisible((prev) => {
+      const next = new Set(prev)
+      if (value) {
+        next.add(id)
+      } else {
+        next.delete(id)
+      }
+      // Swallow a storage write failure so the UI stays on the user's choice.
+      void saveVisibleUsageProviders(next).catch(() => {})
+      return next
+    })
+  }, [])
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top + spacing.sm }]}>
+      <View style={styles.topRow}>
+        <Pressable style={styles.backButton} onPress={() => router.back()}>
+          <ChevronLeft size={22} color={colors.textSecondary} />
+        </Pressable>
+        <Text style={styles.heading}>Account usage</Text>
+      </View>
+
+      <ScrollView
+        contentContainerStyle={{ paddingBottom: insets.bottom + spacing.xl }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text style={styles.intro}>
+          Choose which providers appear in the Account usage cards and the per-host accounts screen.
+        </Text>
+
+        <View style={styles.section}>
+          {USAGE_PROVIDERS.map((descriptor, index) => (
+            <View key={descriptor.id}>
+              {index > 0 ? <View style={styles.separator} /> : null}
+              <View style={styles.row}>
+                <Text style={styles.rowLabel}>{descriptor.label}</Text>
+                <Switch
+                  value={visible.has(descriptor.id)}
+                  onValueChange={(v) => toggle(descriptor.id, v)}
+                  trackColor={{ false: colors.bgRaised, true: colors.textSecondary }}
+                  thumbColor={colors.textPrimary}
+                />
+              </View>
+            </View>
+          ))}
+        </View>
+      </ScrollView>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bgBase,
+    padding: spacing.lg
+  },
+  topRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing.lg
+  },
+  backButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: spacing.sm
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: colors.textPrimary
+  },
+  intro: {
+    fontSize: typography.metaSize,
+    color: colors.textMuted,
+    lineHeight: 18,
+    marginBottom: spacing.md
+  },
+  section: {
+    backgroundColor: colors.bgPanel,
+    borderRadius: 12,
+    overflow: 'hidden'
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.md + 2
+  },
+  rowLabel: {
+    flex: 1,
+    fontSize: typography.bodySize,
+    fontWeight: '500',
+    color: colors.textPrimary
+  },
+  separator: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: colors.borderSubtle,
+    marginLeft: spacing.md + 2
+  }
+})

--- a/mobile/app/account-usage-settings.tsx
+++ b/mobile/app/account-usage-settings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { View, Text, StyleSheet, Pressable, Switch, ScrollView } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
@@ -21,12 +21,14 @@ export default function AccountUsageSettingsScreen() {
   // tap can't persist against the default base and silently drop a stored-only
   // provider (e.g. an opted-in Grok); the load resolves within a frame or two.
   const [visible, setVisible] = useState<Set<UsageProviderKey> | null>(null)
+  const mounted = useRef(false)
 
   // Why: this screen is the only writer of the visibility set, so load once on
   // mount rather than on every focus — a focus-reload could resolve mid-toggle
   // and overwrite the optimistic UI with a pre-write snapshot. The settled read
   // also waits for any in-flight toggle so a quick leave/return shows the latest.
   useEffect(() => {
+    mounted.current = true
     let active = true
     void loadVisibleUsageProvidersSettled().then((stored) => {
       if (active) {
@@ -35,13 +37,13 @@ export default function AccountUsageSettingsScreen() {
     })
     return () => {
       active = false
+      mounted.current = false
     }
   }, [])
 
   const toggle = useCallback((id: UsageProviderKey, value: boolean) => {
-    // Optimistic UI; the storage-level toggle re-reads the latest stored set and
-    // changes only this provider, so it survives an unmount and never clobbers
-    // one the user didn't touch. Swallow a write failure so the UI stays put.
+    // Why: keep taps responsive, then reconcile after a failed write so the
+    // switches never claim a provider choice that storage did not persist.
     setVisible((prev) => {
       if (!prev) {
         return prev
@@ -54,13 +56,23 @@ export default function AccountUsageSettingsScreen() {
       }
       return next
     })
-    void setUsageProviderVisible(id, value).catch(() => {})
+    void setUsageProviderVisible(id, value).catch(async () => {
+      const stored = await loadVisibleUsageProvidersSettled()
+      if (mounted.current) {
+        setVisible(stored)
+      }
+    })
   }, [])
 
   return (
     <View style={[styles.container, { paddingTop: insets.top + spacing.sm }]}>
       <View style={styles.topRow}>
-        <Pressable style={styles.backButton} onPress={() => router.back()}>
+        <Pressable
+          style={styles.backButton}
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+        >
           <ChevronLeft size={22} color={colors.textSecondary} />
         </Pressable>
         <Text style={styles.heading}>Account usage</Text>

--- a/mobile/app/h/[hostId]/accounts.tsx
+++ b/mobile/app/h/[hostId]/accounts.tsx
@@ -17,15 +17,13 @@ import { colors, spacing } from '../../../src/theme/mobile-theme'
 import { styles } from './accounts-screen-styles'
 import { useNow } from '../../../src/hooks/use-now'
 import { ClaudeIcon, OpenAIIcon } from '../../../src/components/AgentIcons'
-import { loadVisibleUsageProviders } from '../../../src/storage/preferences'
+import { useVisibleUsageProviders } from '../../../src/components/use-visible-usage-providers'
 import {
   type AccountsSnapshot,
   type ProviderKey,
   decodeAccountsSnapshot,
-  type UsageProviderKey,
   type UsageProviderDescriptor,
   USAGE_PROVIDERS,
-  DEFAULT_VISIBLE_USAGE_PROVIDERS,
   getActiveProviderRateLimits,
   getInactiveProviderUsage,
   getProviderUsageWindows,
@@ -56,26 +54,7 @@ export default function AccountsScreen() {
   const [refreshing, setRefreshing] = useState(false)
   const [busyAccountId, setBusyAccountId] = useState<string | null>(null)
   const [clockEnabled, setClockEnabled] = useState(false)
-  const [visibleProviders, setVisibleProviders] = useState<Set<UsageProviderKey>>(
-    () => new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
-  )
-
-  // Why: reload on focus so a change made in Settings → Account usage is
-  // reflected when the user navigates back — the screen stays mounted and
-  // updates in place (mirrors how the terminal picks up Settings → Terminal).
-  useFocusEffect(
-    useCallback(() => {
-      let active = true
-      void loadVisibleUsageProviders().then((set) => {
-        if (active) {
-          setVisibleProviders(set)
-        }
-      })
-      return () => {
-        active = false
-      }
-    }, [])
-  )
+  const visibleProviders = useVisibleUsageProviders()
 
   const acceptSnapshot = useCallback((nextSnapshot: AccountsSnapshot) => {
     setSnapshot(nextSnapshot)

--- a/mobile/app/h/[hostId]/accounts.tsx
+++ b/mobile/app/h/[hostId]/accounts.tsx
@@ -353,7 +353,7 @@ export default function AccountsScreen() {
     )
   }
 
-  // Why: display-only providers (Gemini/OpenCode Go/Kimi/MiniMax/Grok) have no
+  // Why: display-only providers (Gemini/Antigravity/OpenCode Go/Kimi/MiniMax/Grok) have no
   // Orca-managed accounts and no interactive switching, so the section is a
   // non-pressable card that just surfaces the system-default target's usage.
   // Rendered windows come from getProviderUsageWindows so Gemini buckets and

--- a/mobile/app/h/[hostId]/accounts.tsx
+++ b/mobile/app/h/[hostId]/accounts.tsx
@@ -10,23 +10,30 @@ import {
 } from 'react-native'
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router'
-import { ChevronLeft, Check, RefreshCw, User } from 'lucide-react-native'
+import { ChevronLeft, Check, RefreshCw, User, Gauge } from 'lucide-react-native'
 import { loadHosts } from '../../../src/transport/host-store'
 import { useHostClient } from '../../../src/transport/client-context'
 import { colors, spacing } from '../../../src/theme/mobile-theme'
 import { styles } from './accounts-screen-styles'
 import { useNow } from '../../../src/hooks/use-now'
 import { ClaudeIcon, OpenAIIcon } from '../../../src/components/AgentIcons'
+import { loadVisibleUsageProviders } from '../../../src/storage/preferences'
 import {
   type AccountsSnapshot,
   type ProviderKey,
   decodeAccountsSnapshot,
+  type UsageProviderKey,
+  type UsageProviderDescriptor,
+  USAGE_PROVIDERS,
+  DEFAULT_VISIBLE_USAGE_PROVIDERS,
   getActiveProviderRateLimits,
   getInactiveProviderUsage,
+  getProviderUsageWindows,
   getUsageBarState,
   getWindowResetLabel,
   hasActiveProviderUsage,
-  UsageBar
+  UsageBar,
+  UsageWindowBars
 } from '../../../src/components/AccountUsage'
 import {
   getActiveCodexAccountIdForRateLimitTarget,
@@ -48,6 +55,26 @@ export default function AccountsScreen() {
   const [refreshing, setRefreshing] = useState(false)
   const [busyAccountId, setBusyAccountId] = useState<string | null>(null)
   const [clockEnabled, setClockEnabled] = useState(false)
+  const [visibleProviders, setVisibleProviders] = useState<Set<UsageProviderKey>>(
+    () => new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
+  )
+
+  // Why: reload on focus so a change made in Settings → Account usage is
+  // reflected when the user navigates back — the screen stays mounted and
+  // updates in place (mirrors how the terminal picks up Settings → Terminal).
+  useFocusEffect(
+    useCallback(() => {
+      let active = true
+      void loadVisibleUsageProviders().then((set) => {
+        if (active) {
+          setVisibleProviders(set)
+        }
+      })
+      return () => {
+        active = false
+      }
+    }, [])
+  )
 
   const acceptSnapshot = useCallback((nextSnapshot: AccountsSnapshot) => {
     setSnapshot(nextSnapshot)
@@ -205,7 +232,7 @@ export default function AccountsScreen() {
     const resetCredit = provider === 'codex' ? getCodexResetCreditSummary(activeUsage, now) : null
     const Icon = provider === 'claude' ? ClaudeIcon : OpenAIIcon
     return (
-      <View style={styles.section}>
+      <View style={styles.section} key={provider}>
         <View style={styles.sectionHeader}>
           <Icon size={14} />
           <Text style={styles.sectionHeading}>{title}</Text>
@@ -326,6 +353,49 @@ export default function AccountsScreen() {
     )
   }
 
+  // Why: display-only providers (Gemini/OpenCode Go/Kimi/MiniMax/Grok) have no
+  // Orca-managed accounts and no interactive switching, so the section is a
+  // non-pressable card that just surfaces the system-default target's usage.
+  // Rendered windows come from getProviderUsageWindows so Gemini buckets and
+  // OpenCode Go monthly show instead of two hardcoded 5h/7d bars.
+  const renderDisplayProviderSection = (descriptor: UsageProviderDescriptor) => {
+    if (!snapshot) {
+      return null
+    }
+    const usage = getActiveProviderRateLimits(snapshot, descriptor.id)
+    // Why: show a configured provider that is still loading or transiently
+    // failing (spinner / error copy below); only hide a genuinely
+    // unconfigured provider (no data and not fetching/error).
+    const renderable =
+      hasActiveProviderUsage(usage) || usage?.status === 'fetching' || usage?.status === 'error'
+    if (!renderable) {
+      return null
+    }
+    const windows = getProviderUsageWindows(usage)
+    const fetching = usage?.status === 'fetching'
+    return (
+      <View style={styles.section} key={descriptor.id}>
+        <View style={styles.sectionHeader}>
+          <Gauge size={14} color={colors.textMuted} />
+          <Text style={styles.sectionHeading}>{descriptor.label}</Text>
+        </View>
+        <View style={styles.card}>
+          <View style={styles.row}>
+            <View style={styles.rowMain}>
+              <Text style={styles.rowTitle}>System default</Text>
+              <UsageWindowBars windows={windows} fetching={fetching} />
+              {usage?.error ? (
+                <Text style={styles.errorText} numberOfLines={1}>
+                  {usage.error}
+                </Text>
+              ) : null}
+            </View>
+          </View>
+        </View>
+      </View>
+    )
+  }
+
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <View style={styles.topRow}>
@@ -379,8 +449,11 @@ export default function AccountsScreen() {
           </View>
         ) : (
           <>
-            {renderProviderSection('claude', 'Claude')}
-            {renderProviderSection('codex', 'Codex')}
+            {USAGE_PROVIDERS.filter((p) => visibleProviders.has(p.id)).map((p) =>
+              p.id === 'claude' || p.id === 'codex'
+                ? renderProviderSection(p.id, p.label)
+                : renderDisplayProviderSection(p)
+            )}
             <View style={styles.footerHint}>
               <User size={14} color={colors.textMuted} />
               <Text style={styles.footerHintText}>

--- a/mobile/app/h/[hostId]/accounts.tsx
+++ b/mobile/app/h/[hostId]/accounts.tsx
@@ -32,6 +32,7 @@ import {
   getUsageBarState,
   getWindowResetLabel,
   hasActiveProviderUsage,
+  hasRenderableUsage,
   UsageBar,
   UsageWindowBars
 } from '../../../src/components/AccountUsage'
@@ -366,9 +367,7 @@ export default function AccountsScreen() {
     // Why: show a configured provider that is still loading or transiently
     // failing (spinner / error copy below); only hide a genuinely
     // unconfigured provider (no data and not fetching/error).
-    const renderable =
-      hasActiveProviderUsage(usage) || usage?.status === 'fetching' || usage?.status === 'error'
-    if (!renderable) {
+    if (!hasRenderableUsage(snapshot, descriptor.id)) {
       return null
     }
     const windows = getProviderUsageWindows(usage)
@@ -383,7 +382,7 @@ export default function AccountsScreen() {
           <View style={styles.row}>
             <View style={styles.rowMain}>
               <Text style={styles.rowTitle}>System default</Text>
-              <UsageWindowBars windows={windows} fetching={fetching} />
+              <UsageWindowBars windows={windows} fetching={fetching} now={now} />
               {usage?.error ? (
                 <Text style={styles.errorText} numberOfLines={1}>
                   {usage.error}

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -13,17 +13,16 @@ import {
   Edit3,
   ListTodo
 } from 'lucide-react-native'
-import { ClaudeIcon, OpenAIIcon } from '../src/components/AgentIcons'
 import {
   type AccountsSnapshot,
-  type ProviderKey,
   decodeAccountsSnapshot,
-  getActiveProviderRateLimits,
-  getUsageBarState,
-  hasActiveProviderUsage,
-  hasRenderableUsage,
-  UsageBar
+  type UsageProviderKey,
+  USAGE_PROVIDERS,
+  DEFAULT_VISIBLE_USAGE_PROVIDERS,
+  hasRenderableUsage
 } from '../src/components/AccountUsage'
+import { HomeAccountUsageCard } from '../src/components/HomeAccountUsageCard'
+import { loadVisibleUsageProviders } from '../src/storage/preferences'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { loadHosts } from '../src/transport/host-store'
 import { removeHostAndCloseClient } from '../src/transport/host-removal-lifecycle'
@@ -305,6 +304,9 @@ export default function HomeScreen() {
   const [stats, setStats] = useState<StatsSummary | null>(null)
   const [worktreeInfo, setWorktreeInfo] = useState<Record<string, HostWorktreeInfo>>({})
   const [accountsByHost, setAccountsByHost] = useState<Record<string, AccountsSnapshot>>({})
+  const [visibleUsageProviders, setVisibleUsageProviders] = useState<Set<UsageProviderKey>>(
+    () => new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
+  )
   const [taskProvidersByHost, setTaskProvidersByHost] = useState<Record<string, TaskProvider[]>>({})
   const [lastVisited, setLastVisited] = useState<{ hostId: string; worktreeId: string } | null>(
     null
@@ -393,6 +395,11 @@ export default function HomeScreen() {
         }
         if (onboardingSteps.length > 0) {
           router.replace(mobileOnboardingDestination(onboardingSteps))
+        }
+      })
+      void loadVisibleUsageProviders().then((set) => {
+        if (!stale) {
+          setVisibleUsageProviders(set)
         }
       })
       void AsyncStorage.getItem('orca:last-visited-worktree').then((raw) => {
@@ -589,13 +596,20 @@ export default function HomeScreen() {
       if (!snap) {
         continue
       }
-      // Why: also show hosts whose only usage is the system-default login, else those users see no usage section.
-      if (hasRenderableUsage(snap, 'claude') || hasRenderableUsage(snap, 'codex')) {
+      // Why: also show hosts whose only usage is the system-default login
+      // (no Orca-managed accounts but live rate-limit data for the active
+      // target), otherwise system-default users see no usage section at all.
+      // Gated by the per-device visibility filter so hidden providers don't
+      // keep the section alive.
+      const anyVisible = USAGE_PROVIDERS.some(
+        (p) => visibleUsageProviders.has(p.id) && hasRenderableUsage(snap, p.id)
+      )
+      if (anyVisible) {
         items.push({ host, snapshot: snap })
       }
     }
     return items
-  }, [sortedHosts, hostStates, accountsByHost])
+  }, [sortedHosts, hostStates, accountsByHost, visibleUsageProviders])
 
   const primaryConnectedHost = useMemo(
     () => sortedHosts.find((host) => hostStates[host.id] === 'connected') ?? null,
@@ -891,75 +905,16 @@ export default function HomeScreen() {
                   <Text style={[styles.sectionHeading, { marginTop: spacing.xl }]}>
                     Account usage
                   </Text>
-                  {accountsHosts.map(({ host, snapshot }) => {
-                    const claudeActiveId = snapshot.claude.activeAccountId
-                    const claudeActive =
-                      snapshot.claude.accounts.find((a) => a.id === claudeActiveId) ?? null
-                    const codexActiveId = snapshot.codex.activeAccountId
-                    const codexActive =
-                      snapshot.codex.accounts.find((a) => a.id === codexActiveId) ?? null
-                    const showHostName = accountsHosts.length > 1
-                    return (
-                      <Pressable
-                        key={host.id}
-                        style={({ pressed }) => [
-                          styles.accountsCard,
-                          pressed && styles.hostCardPressed
-                        ]}
-                        onPress={() => router.push(`/h/${host.id}/accounts`)}
-                      >
-                        {showHostName ? (
-                          <Text style={styles.accountsHostLabel} numberOfLines={1}>
-                            {host.name}
-                          </Text>
-                        ) : null}
-                        {(['claude', 'codex'] as ProviderKey[]).map((provider) => {
-                          const active = provider === 'claude' ? claudeActive : codexActive
-                          const accounts =
-                            provider === 'claude'
-                              ? snapshot.claude.accounts
-                              : snapshot.codex.accounts
-                          const limits = getActiveProviderRateLimits(snapshot, provider)
-                          // Why: with no managed accounts, still render the row when the active target has live usage data.
-                          if (accounts.length === 0 && !hasActiveProviderUsage(limits)) {
-                            return null
-                          }
-                          const sessionBar = getUsageBarState(limits, 'session')
-                          const weeklyBar = getUsageBarState(limits, 'weekly')
-                          return (
-                            <View key={provider} style={styles.accountsRow}>
-                              <View style={styles.accountsIcon}>
-                                {provider === 'claude' ? (
-                                  <ClaudeIcon size={18} />
-                                ) : (
-                                  <OpenAIIcon size={18} color={colors.textPrimary} />
-                                )}
-                              </View>
-                              <View style={styles.accountsInfo}>
-                                <Text style={styles.accountsEmail} numberOfLines={1}>
-                                  {active?.email ?? 'System default'}
-                                </Text>
-                                <View style={styles.accountsBars}>
-                                  <UsageBar
-                                    label="5h"
-                                    usedPercent={sessionBar.usedPercent}
-                                    unavailable={sessionBar.unavailable}
-                                    loading={sessionBar.loading}
-                                  />
-                                  <UsageBar
-                                    label="7d"
-                                    usedPercent={weeklyBar.usedPercent}
-                                    unavailable={weeklyBar.unavailable}
-                                    loading={weeklyBar.loading}
-                                  />
-                                </View>
-                              </View>
-                            </View>
-                          )
-                        })}
-                      </Pressable>
-                    )
-                  })}
+                  {accountsHosts.map(({ host, snapshot }) => (
+                    <HomeAccountUsageCard
+                      key={host.id}
+                      snapshot={snapshot}
+                      visibleProviders={visibleUsageProviders}
+                      showHostName={accountsHosts.length > 1}
+                      hostName={host.name}
+                      onPress={() => router.push(`/h/${host.id}/accounts`)}
+                    />
+                  ))}
                 </>
               ) : null}
             </View>
@@ -1272,52 +1227,6 @@ const styles = StyleSheet.create({
   },
 
   /* ─── Account usage ─── */
-  accountsCard: {
-    backgroundColor: colors.bgPanel,
-    borderWidth: 1,
-    borderColor: colors.borderSubtle,
-    borderRadius: radii.card,
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.sm + 2,
-    gap: spacing.sm,
-    marginBottom: spacing.sm
-  },
-  accountsHostLabel: {
-    fontSize: 11,
-    color: colors.textMuted,
-    fontWeight: '500',
-    textTransform: 'uppercase',
-    letterSpacing: 0.4
-  },
-  accountsRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.sm + 2
-  },
-  accountsIcon: {
-    width: 32,
-    height: 32,
-    borderRadius: 9,
-    backgroundColor: colors.bgRaised,
-    alignItems: 'center',
-    justifyContent: 'center'
-  },
-  accountsInfo: {
-    flex: 1,
-    minWidth: 0,
-    gap: 2
-  },
-  accountsEmail: {
-    fontSize: 13,
-    fontWeight: '600',
-    color: colors.textPrimary
-  },
-  accountsBars: {
-    flexDirection: 'row',
-    gap: spacing.md,
-    marginTop: 4
-  },
-
   /* ─── Quick actions ─── */
   quickActions: {
     flexDirection: 'row',

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -55,6 +55,7 @@ import {
   type TaskProvider
 } from '../src/tasks/mobile-task-providers'
 import { useResponsiveLayout } from '../src/layout/responsive-layout'
+import { useNow } from '../src/hooks/use-now'
 
 function endpointLabel(endpoint: string): string {
   try {
@@ -303,6 +304,7 @@ export default function HomeScreen() {
   const [worktreeInfo, setWorktreeInfo] = useState<Record<string, HostWorktreeInfo>>({})
   const [accountsByHost, setAccountsByHost] = useState<Record<string, AccountsSnapshot>>({})
   const visibleUsageProviders = useVisibleUsageProviders()
+  const now = useNow(60_000)
   const [taskProvidersByHost, setTaskProvidersByHost] = useState<Record<string, TaskProvider[]>>({})
   const [lastVisited, setLastVisited] = useState<{ hostId: string; worktreeId: string } | null>(
     null
@@ -903,6 +905,7 @@ export default function HomeScreen() {
                       visibleProviders={visibleUsageProviders}
                       showHostName={accountsHosts.length > 1}
                       hostName={host.name}
+                      now={now}
                       onPress={() => router.push(`/h/${host.id}/accounts`)}
                     />
                   ))}

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -16,13 +16,11 @@ import {
 import {
   type AccountsSnapshot,
   decodeAccountsSnapshot,
-  type UsageProviderKey,
   USAGE_PROVIDERS,
-  DEFAULT_VISIBLE_USAGE_PROVIDERS,
   hasRenderableUsage
 } from '../src/components/AccountUsage'
 import { HomeAccountUsageCard } from '../src/components/HomeAccountUsageCard'
-import { loadVisibleUsageProviders } from '../src/storage/preferences'
+import { useVisibleUsageProviders } from '../src/components/use-visible-usage-providers'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { loadHosts } from '../src/transport/host-store'
 import { removeHostAndCloseClient } from '../src/transport/host-removal-lifecycle'
@@ -304,9 +302,7 @@ export default function HomeScreen() {
   const [stats, setStats] = useState<StatsSummary | null>(null)
   const [worktreeInfo, setWorktreeInfo] = useState<Record<string, HostWorktreeInfo>>({})
   const [accountsByHost, setAccountsByHost] = useState<Record<string, AccountsSnapshot>>({})
-  const [visibleUsageProviders, setVisibleUsageProviders] = useState<Set<UsageProviderKey>>(
-    () => new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
-  )
+  const visibleUsageProviders = useVisibleUsageProviders()
   const [taskProvidersByHost, setTaskProvidersByHost] = useState<Record<string, TaskProvider[]>>({})
   const [lastVisited, setLastVisited] = useState<{ hostId: string; worktreeId: string } | null>(
     null
@@ -395,11 +391,6 @@ export default function HomeScreen() {
         }
         if (onboardingSteps.length > 0) {
           router.replace(mobileOnboardingDestination(onboardingSteps))
-        }
-      })
-      void loadVisibleUsageProviders().then((set) => {
-        if (!stale) {
-          setVisibleUsageProviders(set)
         }
       })
       void AsyncStorage.getItem('orca:last-visited-worktree').then((raw) => {

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -22,7 +22,8 @@ import {
   Globe,
   MessageSquare,
   Terminal as TerminalIcon,
-  KeyRound
+  KeyRound,
+  Gauge
 } from 'lucide-react-native'
 import { colors, radii, spacing, typography } from '../src/theme/mobile-theme'
 import {
@@ -139,6 +140,15 @@ export default function SettingsScreen() {
           >
             <Mic size={16} color={colors.textSecondary} />
             <Text style={styles.rowLabel}>Voice</Text>
+            <ChevronRight size={16} color={colors.textMuted} />
+          </Pressable>
+          <View style={styles.separator} />
+          <Pressable
+            style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+            onPress={() => router.push('/account-usage-settings')}
+          >
+            <Gauge size={16} color={colors.textSecondary} />
+            <Text style={styles.rowLabel}>Account usage</Text>
             <ChevronRight size={16} color={colors.textMuted} />
           </Pressable>
           <View style={styles.separator} />

--- a/mobile/src/account-usage-settings-route.test.ts
+++ b/mobile/src/account-usage-settings-route.test.ts
@@ -1,0 +1,111 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import AccountUsageSettingsScreen from '../app/account-usage-settings'
+
+const dependencies = vi.hoisted(() => ({
+  back: vi.fn(),
+  loadVisibleUsageProvidersSettled: vi.fn(),
+  setUsageProviderVisible: vi.fn()
+}))
+
+vi.mock('react-native', () => ({
+  Pressable: 'Pressable',
+  ScrollView: 'ScrollView',
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  Switch: 'Switch',
+  Text: 'Text',
+  View: 'View'
+}))
+
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ bottom: 0, left: 0, right: 0, top: 0 })
+}))
+
+vi.mock('expo-router', () => ({
+  useRouter: () => ({ back: dependencies.back })
+}))
+
+vi.mock('lucide-react-native', () => ({
+  ChevronLeft: 'ChevronLeft'
+}))
+
+vi.mock('./storage/preferences', () => ({
+  loadVisibleUsageProvidersSettled: dependencies.loadVisibleUsageProvidersSettled,
+  setUsageProviderVisible: dependencies.setUsageProviderVisible
+}))
+
+async function renderRoute(): Promise<ReactTestRenderer> {
+  let renderer: ReactTestRenderer | null = null
+  await act(async () => {
+    renderer = create(createElement(AccountUsageSettingsScreen))
+    await Promise.resolve()
+  })
+  if (!renderer) {
+    throw new Error('Account usage settings route did not render')
+  }
+  return renderer
+}
+
+describe('account usage settings route', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    dependencies.loadVisibleUsageProvidersSettled
+      .mockReset()
+      .mockResolvedValue(new Set(['claude', 'codex']))
+    dependencies.setUsageProviderVisible.mockReset().mockResolvedValue(new Set(['claude', 'codex']))
+    const originalConsoleError = console.error
+    vi.spyOn(console, 'error').mockImplementation((...args) => {
+      if (typeof args[0] === 'string' && args[0].includes('react-test-renderer is deprecated')) {
+        return
+      }
+      originalConsoleError(...args)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('exposes all eight provider switches with stable accessible names', async () => {
+    const renderer = await renderRoute()
+    const back = renderer.root.findAllByType('Pressable')[0]
+    const switches = renderer.root.findAllByType('Switch')
+
+    expect(back?.props).toMatchObject({ accessibilityLabel: 'Back', accessibilityRole: 'button' })
+    expect(switches.map((item) => item.props.accessibilityLabel)).toEqual([
+      'Show Claude usage',
+      'Show Codex usage',
+      'Show Gemini usage',
+      'Show Antigravity usage',
+      'Show OpenCode Go usage',
+      'Show Kimi usage',
+      'Show MiniMax usage',
+      'Show Grok usage'
+    ])
+
+    act(() => renderer.unmount())
+  })
+
+  it('rolls an optimistic toggle back when persistence fails', async () => {
+    dependencies.setUsageProviderVisible.mockRejectedValueOnce(new Error('storage unavailable'))
+    const renderer = await renderRoute()
+    const antigravity = () =>
+      renderer.root
+        .findAllByType('Switch')
+        .find((item) => item.props.accessibilityLabel === 'Show Antigravity usage')
+
+    expect(antigravity()?.props.value).toBe(false)
+    await act(async () => {
+      antigravity()?.props.onValueChange(true)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(dependencies.setUsageProviderVisible).toHaveBeenCalledWith('antigravity', true)
+    expect(dependencies.loadVisibleUsageProvidersSettled).toHaveBeenCalledTimes(2)
+    expect(antigravity()?.props.value).toBe(false)
+
+    act(() => renderer.unmount())
+  })
+})

--- a/mobile/src/accounts-route-display-provider.test.ts
+++ b/mobile/src/accounts-route-display-provider.test.ts
@@ -13,6 +13,7 @@ const dependencies = vi.hoisted(() => ({
 vi.mock('react-native', () => ({
   ActivityIndicator: 'ActivityIndicator',
   Alert: { alert: vi.fn() },
+  AppState: { currentState: 'active', addEventListener: () => ({ remove: () => {} }) },
   Pressable: 'Pressable',
   RefreshControl: 'RefreshControl',
   ScrollView: 'ScrollView',
@@ -26,10 +27,18 @@ vi.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ bottom: 0, left: 0, right: 0, top: 0 })
 }))
 
-vi.mock('expo-router', () => ({
-  useLocalSearchParams: () => ({ hostId: 'host-1' }),
-  useRouter: () => ({ back: vi.fn() })
-}))
+vi.mock('expo-router', async () => {
+  const React = await import('react')
+  return {
+    useFocusEffect(effect: () => void | (() => void)): void {
+      React.useEffect(effect, [effect])
+    },
+    useLocalSearchParams: () => ({ hostId: 'host-1' }),
+    useRouter: () => ({ back: vi.fn() })
+  }
+})
+
+vi.mock('expo-crypto', () => ({ randomUUID: vi.fn() }))
 
 vi.mock('lucide-react-native', () => ({
   Check: 'Check',
@@ -40,12 +49,17 @@ vi.mock('lucide-react-native', () => ({
 }))
 
 vi.mock('./transport/host-store', () => ({ loadHosts: dependencies.loadHosts }))
-vi.mock('./transport/client-context', () => ({
-  useHostClient: () => ({
-    client: { sendRequest: vi.fn(), subscribe: dependencies.subscribe },
-    state: 'connected'
-  })
-}))
+vi.mock('./transport/client-context', () => {
+  const client = {
+    sendRequest: vi
+      .fn()
+      .mockResolvedValue({ id: 'status', ok: true, result: { capabilities: [] } }),
+    subscribe: dependencies.subscribe
+  }
+  return {
+    useHostClient: () => ({ client, state: 'connected' })
+  }
+})
 vi.mock('./components/use-visible-usage-providers', () => ({
   useVisibleUsageProviders: () => new Set(['antigravity'])
 }))

--- a/mobile/src/accounts-route-display-provider.test.ts
+++ b/mobile/src/accounts-route-display-provider.test.ts
@@ -1,0 +1,148 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import AccountsScreen from '../app/h/[hostId]/accounts'
+import type { AccountsSnapshot, ProviderRateLimits } from './components/account-usage-state'
+
+const dependencies = vi.hoisted(() => ({
+  loadHosts: vi.fn(),
+  snapshot: null as AccountsSnapshot | null,
+  subscribe: vi.fn()
+}))
+
+vi.mock('react-native', () => ({
+  ActivityIndicator: 'ActivityIndicator',
+  Alert: { alert: vi.fn() },
+  Pressable: 'Pressable',
+  RefreshControl: 'RefreshControl',
+  ScrollView: 'ScrollView',
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  Text: 'Text',
+  View: 'View'
+}))
+
+vi.mock('react-native-safe-area-context', () => ({
+  SafeAreaView: 'SafeAreaView',
+  useSafeAreaInsets: () => ({ bottom: 0, left: 0, right: 0, top: 0 })
+}))
+
+vi.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ hostId: 'host-1' }),
+  useRouter: () => ({ back: vi.fn() })
+}))
+
+vi.mock('lucide-react-native', () => ({
+  Check: 'Check',
+  ChevronLeft: 'ChevronLeft',
+  Gauge: 'Gauge',
+  RefreshCw: 'RefreshCw',
+  User: 'User'
+}))
+
+vi.mock('./transport/host-store', () => ({ loadHosts: dependencies.loadHosts }))
+vi.mock('./transport/client-context', () => ({
+  useHostClient: () => ({
+    client: { sendRequest: vi.fn(), subscribe: dependencies.subscribe },
+    state: 'connected'
+  })
+}))
+vi.mock('./components/use-visible-usage-providers', () => ({
+  useVisibleUsageProviders: () => new Set(['antigravity'])
+}))
+vi.mock('./components/AgentIcons', () => ({
+  ClaudeIcon: 'ClaudeIcon',
+  OpenAIIcon: 'OpenAIIcon'
+}))
+
+function limits(): ProviderRateLimits {
+  return {
+    provider: 'antigravity',
+    session: {
+      usedPercent: 25,
+      windowMinutes: 300,
+      resetsAt: Date.now() + 60 * 60_000,
+      resetDescription: null
+    },
+    weekly: null,
+    updatedAt: 1,
+    error: null,
+    status: 'ok'
+  }
+}
+
+function snapshot(antigravity: ProviderRateLimits | null): AccountsSnapshot {
+  return {
+    claude: { accounts: [], activeAccountId: null },
+    codex: { accounts: [], activeAccountId: null },
+    rateLimits: {
+      claude: null,
+      codex: null,
+      antigravity,
+      inactiveClaudeAccounts: [],
+      inactiveCodexAccounts: []
+    }
+  }
+}
+
+async function renderRoute(): Promise<ReactTestRenderer> {
+  let renderer: ReactTestRenderer | null = null
+  await act(async () => {
+    renderer = create(createElement(AccountsScreen))
+    await Promise.resolve()
+  })
+  if (!renderer) {
+    throw new Error('Accounts route did not render')
+  }
+  return renderer
+}
+
+function textValues(renderer: ReactTestRenderer): string[] {
+  return renderer.root
+    .findAllByType('Text')
+    .map((node) => node.props.children)
+    .filter((value): value is string => typeof value === 'string')
+}
+
+describe('accounts route display-only providers', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    dependencies.loadHosts.mockReset().mockResolvedValue([{ id: 'host-1', name: 'Desk' }])
+    dependencies.subscribe.mockReset().mockImplementation((_method, _params, emit) => {
+      emit({ type: 'ready', snapshot: dependencies.snapshot })
+      return vi.fn()
+    })
+    const originalConsoleError = console.error
+    vi.spyOn(console, 'error').mockImplementation((...args) => {
+      if (typeof args[0] === 'string' && args[0].includes('react-test-renderer is deprecated')) {
+        return
+      }
+      originalConsoleError(...args)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders a visible display-only provider with its dynamic window and reset', async () => {
+    dependencies.snapshot = snapshot(limits())
+    const renderer = await renderRoute()
+    const texts = textValues(renderer)
+
+    expect(texts).toContain('Antigravity')
+    expect(texts).toContain('System default')
+    expect(texts).toContain('25%')
+    expect(texts.some((text) => text.startsWith('Resets in'))).toBe(true)
+
+    act(() => renderer.unmount())
+  })
+
+  it('hides a visible display-only provider when the host has no data for it', async () => {
+    dependencies.snapshot = snapshot(null)
+    const renderer = await renderRoute()
+
+    expect(textValues(renderer)).not.toContain('Antigravity')
+
+    act(() => renderer.unmount())
+  })
+})

--- a/mobile/src/components/AccountUsage.tsx
+++ b/mobile/src/components/AccountUsage.tsx
@@ -51,8 +51,12 @@ export function UsageBar({
   labelWidth?: number
   resetText?: string | null
 }) {
-  // Why: round then clamp so bar width, color, and label share one value (desktop parity).
-  const used = usedPercent == null ? null : Math.max(0, Math.min(100, Math.round(usedPercent)))
+  // Round+clamp so width/color/label share one value (desktop parity); a
+  // non-finite value counts as no data so the bar never renders `width: "NaN%"`.
+  const used =
+    usedPercent == null || !Number.isFinite(usedPercent)
+      ? null
+      : Math.max(0, Math.min(100, Math.round(usedPercent)))
   // Why: same consumption bands as desktop barColor (green <60, amber <80, red ≥80).
   const barColor =
     used == null

--- a/mobile/src/components/AccountUsage.tsx
+++ b/mobile/src/components/AccountUsage.tsx
@@ -132,7 +132,7 @@ export function UsageWindowBars({
           <UsageBar
             label={w.label}
             usedPercent={w.usedPercent}
-            unavailable={false}
+            unavailable={!Number.isFinite(w.usedPercent)}
             labelWidth={labelWidth}
             resetText={now == null ? null : getUsageWindowResetLabel(w, now)}
           />

--- a/mobile/src/components/AccountUsage.tsx
+++ b/mobile/src/components/AccountUsage.tsx
@@ -1,6 +1,6 @@
 import { View, Text, StyleSheet, ActivityIndicator } from 'react-native'
 import { colors, spacing, typography } from '../theme/mobile-theme'
-import type { UsageWindowRow } from './account-usage-state'
+import { getUsageWindowResetLabel, type UsageWindowRow } from './account-usage-state'
 
 // Pure types and selectors live in account-usage-state.ts (no RN imports) so
 // they are unit-testable; re-exported here so existing import sites are stable.
@@ -27,6 +27,7 @@ export {
   getActiveProviderRateLimits,
   getInactiveProviderUsage,
   getProviderUsageWindows,
+  getUsageWindowResetLabel,
   getUsageBarState,
   getWindowResetLabel,
   hasActiveProviderUsage,
@@ -111,10 +112,12 @@ export function UsageBar({
 // provider is mid-fetch with nothing yet.
 export function UsageWindowBars({
   windows,
-  fetching
+  fetching,
+  now
 }: {
   windows: UsageWindowRow[]
   fetching?: boolean
+  now?: number
 }) {
   if (windows.length === 0) {
     return <UsageBar label="—" usedPercent={null} unavailable={!fetching} loading={fetching} />
@@ -131,6 +134,7 @@ export function UsageWindowBars({
             usedPercent={w.usedPercent}
             unavailable={false}
             labelWidth={labelWidth}
+            resetText={now == null ? null : getUsageWindowResetLabel(w, now)}
           />
         </View>
       ))}

--- a/mobile/src/components/AccountUsage.tsx
+++ b/mobile/src/components/AccountUsage.tsx
@@ -1,5 +1,6 @@
 import { View, Text, StyleSheet, ActivityIndicator } from 'react-native'
 import { colors, spacing, typography } from '../theme/mobile-theme'
+import type { UsageWindowRow } from './account-usage-state'
 
 // Pure types and selectors live in account-usage-state.ts (no RN imports) so
 // they are unit-testable; re-exported here so existing import sites are stable.
@@ -11,12 +12,21 @@ export type {
   CodexAccountSummary,
   AccountsSnapshot,
   ProviderKey,
+  ManagedAccountProviderKey,
+  UsageProviderKey,
+  UsageProviderDescriptor,
+  UsageWindowRow,
   UsageBarState
 } from './account-usage-state'
 export {
   decodeAccountsSnapshot,
+  USAGE_PROVIDERS,
+  USAGE_PROVIDER_IDS,
+  DEFAULT_VISIBLE_USAGE_PROVIDERS,
+  getUsageProviderDescriptor,
   getActiveProviderRateLimits,
   getInactiveProviderUsage,
+  getProviderUsageWindows,
   getUsageBarState,
   getWindowResetLabel,
   hasActiveProviderUsage,
@@ -31,12 +41,14 @@ export function UsageBar({
   usedPercent,
   unavailable,
   loading,
+  labelWidth,
   resetText
 }: {
   label: string
   usedPercent: number | null
   unavailable: boolean
   loading?: boolean
+  labelWidth?: number
   resetText?: string | null
 }) {
   // Why: round then clamp so bar width, color, and label share one value (desktop parity).
@@ -53,7 +65,12 @@ export function UsageBar({
   return (
     <View style={styles.usageBarColumn}>
       <View style={styles.usageBar}>
-        <Text style={styles.usageLabel}>{label}</Text>
+        <Text
+          style={[styles.usageLabel, labelWidth != null ? { width: labelWidth } : null]}
+          numberOfLines={1}
+        >
+          {label}
+        </Text>
         <View style={styles.usageTrack}>
           <View
             style={[
@@ -84,7 +101,44 @@ export function UsageBar({
   )
 }
 
+// Why: display-only providers can report a variable set of windows (Gemini
+// named buckets, OpenCode Go monthly, others session/weekly). Render one bar
+// per window stacked full-width, or a single loading/unavailable bar when a
+// provider is mid-fetch with nothing yet.
+export function UsageWindowBars({
+  windows,
+  fetching
+}: {
+  windows: UsageWindowRow[]
+  fetching?: boolean
+}) {
+  if (windows.length === 0) {
+    return <UsageBar label="—" usedPercent={null} unavailable={!fetching} loading={fetching} />
+  }
+  // Widen the label column for named buckets (e.g. "3.1 Flash Lite") so they
+  // don't wrap in the 22px slot sized for "5h"/"7d".
+  const labelWidth = windows.some((w) => w.label.length > 4) ? 76 : undefined
+  return (
+    <>
+      {windows.map((w) => (
+        <View style={styles.windowRow} key={w.key}>
+          <UsageBar
+            label={w.label}
+            usedPercent={w.usedPercent}
+            unavailable={false}
+            labelWidth={labelWidth}
+          />
+        </View>
+      ))}
+    </>
+  )
+}
+
 const styles = StyleSheet.create({
+  windowRow: {
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
   usageBarColumn: {
     flex: 1,
     gap: 2

--- a/mobile/src/components/HomeAccountUsageCard.tsx
+++ b/mobile/src/components/HomeAccountUsageCard.tsx
@@ -54,10 +54,15 @@ export function HomeAccountUsageCard({
             : descriptor.id === 'codex'
               ? snapshot.codex.accounts
               : []
-        // Hide a provider with neither a managed account nor live usage; a
-        // managed provider still shows a "System default" row when the active
-        // target has data.
-        if (managedAccounts.length === 0 && !hasActiveProviderUsage(limits)) {
+        // Hide a provider with no managed account and no usage — but keep a
+        // display-only one visible while fetching/error, matching the accounts screen.
+        const displayOnlyPending =
+          !descriptor.managed && (limits?.status === 'fetching' || limits?.status === 'error')
+        if (
+          managedAccounts.length === 0 &&
+          !hasActiveProviderUsage(limits) &&
+          !displayOnlyPending
+        ) {
           return null
         }
         const active =

--- a/mobile/src/components/HomeAccountUsageCard.tsx
+++ b/mobile/src/components/HomeAccountUsageCard.tsx
@@ -1,0 +1,168 @@
+import { View, Text, Pressable, StyleSheet } from 'react-native'
+import { Gauge } from 'lucide-react-native'
+import { colors, spacing, radii } from '../theme/mobile-theme'
+import { ClaudeIcon, OpenAIIcon } from './AgentIcons'
+import {
+  type AccountsSnapshot,
+  type UsageProviderKey,
+  USAGE_PROVIDERS,
+  getActiveProviderRateLimits,
+  getProviderUsageWindows,
+  getUsageBarState,
+  hasActiveProviderUsage,
+  UsageBar,
+  UsageWindowBars
+} from './AccountUsage'
+
+// Why: one host's Account-usage card on the home screen. Extracted from
+// app/index.tsx to keep that screen under the max-lines ratchet and to house
+// the multi-provider rendering (managed Claude/Codex switch summary + the
+// display-only providers gated by the per-device visibility filter).
+export function HomeAccountUsageCard({
+  snapshot,
+  visibleProviders,
+  showHostName,
+  hostName,
+  onPress
+}: {
+  snapshot: AccountsSnapshot
+  visibleProviders: Set<UsageProviderKey>
+  showHostName: boolean
+  hostName: string
+  onPress: () => void
+}) {
+  const claudeActiveId = snapshot.claude.activeAccountId
+  const claudeActive = snapshot.claude.accounts.find((a) => a.id === claudeActiveId) ?? null
+  const codexActiveId = snapshot.codex.activeAccountId
+  const codexActive = snapshot.codex.accounts.find((a) => a.id === codexActiveId) ?? null
+
+  return (
+    <Pressable
+      style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
+      onPress={onPress}
+    >
+      {showHostName ? (
+        <Text style={styles.hostLabel} numberOfLines={1}>
+          {hostName}
+        </Text>
+      ) : null}
+      {USAGE_PROVIDERS.filter((p) => visibleProviders.has(p.id)).map((descriptor) => {
+        const limits = getActiveProviderRateLimits(snapshot, descriptor.id)
+        const managedAccounts =
+          descriptor.id === 'claude'
+            ? snapshot.claude.accounts
+            : descriptor.id === 'codex'
+              ? snapshot.codex.accounts
+              : []
+        // Hide a provider with neither a managed account nor live usage; a
+        // managed provider still shows a "System default" row when the active
+        // target has data.
+        if (managedAccounts.length === 0 && !hasActiveProviderUsage(limits)) {
+          return null
+        }
+        const active =
+          descriptor.id === 'claude' ? claudeActive : descriptor.id === 'codex' ? codexActive : null
+        const sessionBar = getUsageBarState(limits, 'session')
+        const weeklyBar = getUsageBarState(limits, 'weekly')
+        return (
+          <View key={descriptor.id} style={styles.row}>
+            <View style={styles.icon}>
+              {descriptor.id === 'claude' ? (
+                <ClaudeIcon size={18} />
+              ) : descriptor.id === 'codex' ? (
+                <OpenAIIcon size={18} color={colors.textPrimary} />
+              ) : (
+                <Gauge size={18} color={colors.textSecondary} />
+              )}
+            </View>
+            <View style={styles.info}>
+              <Text style={styles.email} numberOfLines={1}>
+                {descriptor.managed ? (active?.email ?? 'System default') : descriptor.label}
+              </Text>
+              {descriptor.managed ? (
+                <View style={styles.bars}>
+                  <UsageBar
+                    label="5h"
+                    usedPercent={sessionBar.usedPercent}
+                    unavailable={sessionBar.unavailable}
+                    loading={sessionBar.loading}
+                  />
+                  <UsageBar
+                    label="7d"
+                    usedPercent={weeklyBar.usedPercent}
+                    unavailable={weeklyBar.unavailable}
+                    loading={weeklyBar.loading}
+                  />
+                </View>
+              ) : (
+                <View style={styles.windows}>
+                  <UsageWindowBars
+                    windows={getProviderUsageWindows(limits)}
+                    fetching={limits?.status === 'fetching'}
+                  />
+                </View>
+              )}
+            </View>
+          </View>
+        )
+      })}
+    </Pressable>
+  )
+}
+
+// Mirrors the styles this card used when it lived inline in app/index.tsx, so
+// the visual result is unchanged by the extraction.
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: colors.bgPanel,
+    borderWidth: 1,
+    borderColor: colors.borderSubtle,
+    borderRadius: radii.card,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm + 2,
+    gap: spacing.sm,
+    marginBottom: spacing.sm
+  },
+  cardPressed: {
+    backgroundColor: colors.bgRaised
+  },
+  hostLabel: {
+    fontSize: 11,
+    color: colors.textMuted,
+    fontWeight: '500',
+    textTransform: 'uppercase',
+    letterSpacing: 0.4
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm + 2
+  },
+  icon: {
+    width: 32,
+    height: 32,
+    borderRadius: 9,
+    backgroundColor: colors.bgRaised,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  info: {
+    flex: 1,
+    minWidth: 0,
+    gap: 2
+  },
+  email: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.textPrimary
+  },
+  bars: {
+    flexDirection: 'row',
+    gap: spacing.md,
+    marginTop: 4
+  },
+  windows: {
+    marginTop: 4,
+    gap: 4
+  }
+})

--- a/mobile/src/components/HomeAccountUsageCard.tsx
+++ b/mobile/src/components/HomeAccountUsageCard.tsx
@@ -9,7 +9,7 @@ import {
   getActiveProviderRateLimits,
   getProviderUsageWindows,
   getUsageBarState,
-  hasActiveProviderUsage,
+  hasRenderableUsage,
   UsageBar,
   UsageWindowBars
 } from './AccountUsage'
@@ -48,21 +48,7 @@ export function HomeAccountUsageCard({
       ) : null}
       {USAGE_PROVIDERS.filter((p) => visibleProviders.has(p.id)).map((descriptor) => {
         const limits = getActiveProviderRateLimits(snapshot, descriptor.id)
-        const managedAccounts =
-          descriptor.id === 'claude'
-            ? snapshot.claude.accounts
-            : descriptor.id === 'codex'
-              ? snapshot.codex.accounts
-              : []
-        // Hide a provider with no managed account and no usage — but keep a
-        // display-only one visible while fetching/error, matching the accounts screen.
-        const displayOnlyPending =
-          !descriptor.managed && (limits?.status === 'fetching' || limits?.status === 'error')
-        if (
-          managedAccounts.length === 0 &&
-          !hasActiveProviderUsage(limits) &&
-          !displayOnlyPending
-        ) {
+        if (!hasRenderableUsage(snapshot, descriptor.id)) {
           return null
         }
         const active =

--- a/mobile/src/components/HomeAccountUsageCard.tsx
+++ b/mobile/src/components/HomeAccountUsageCard.tsx
@@ -23,12 +23,14 @@ export function HomeAccountUsageCard({
   visibleProviders,
   showHostName,
   hostName,
+  now,
   onPress
 }: {
   snapshot: AccountsSnapshot
   visibleProviders: Set<UsageProviderKey>
   showHostName: boolean
   hostName: string
+  now: number
   onPress: () => void
 }) {
   const claudeActiveId = snapshot.claude.activeAccountId
@@ -90,6 +92,7 @@ export function HomeAccountUsageCard({
                   <UsageWindowBars
                     windows={getProviderUsageWindows(limits)}
                     fetching={limits?.status === 'fetching'}
+                    now={now}
                   />
                 </View>
               )}

--- a/mobile/src/components/account-usage-state.test.ts
+++ b/mobile/src/components/account-usage-state.test.ts
@@ -4,6 +4,7 @@ import {
   getActiveProviderRateLimits,
   getInactiveProviderUsage,
   getProviderUsageWindows,
+  getUsageWindowResetLabel,
   getUsageBarState,
   getWindowResetLabel,
   hasActiveProviderUsage,
@@ -65,8 +66,8 @@ function makeSnapshot(
   }
 }
 
-function window(usedPercent: number, windowMinutes = 300) {
-  return { usedPercent, windowMinutes, resetsAt: null, resetDescription: null }
+function window(usedPercent: number, windowMinutes = 300, resetsAt: number | null = null) {
+  return { usedPercent, windowMinutes, resetsAt, resetDescription: null }
 }
 
 describe('hasActiveProviderUsage', () => {
@@ -286,8 +287,8 @@ describe('getProviderUsageWindows', () => {
       ]
     })
     expect(getProviderUsageWindows(gemini)).toEqual([
-      { key: 'bucket:0:Pro', label: 'Pro', usedPercent: 20 },
-      { key: 'bucket:1:Flash', label: 'Flash', usedPercent: 5 }
+      { key: 'bucket:0:Pro', label: 'Pro', usedPercent: 20, resetsAt: null },
+      { key: 'bucket:1:Flash', label: 'Flash', usedPercent: 5, resetsAt: null }
     ])
   })
 
@@ -305,8 +306,8 @@ describe('getProviderUsageWindows', () => {
       ]
     })
     expect(getProviderUsageWindows(gemini)).toEqual([
-      { key: 'bucket:0:Pro', label: 'Pro', usedPercent: 20 },
-      { key: 'bucket:1:Flash', label: 'Flash', usedPercent: 5 }
+      { key: 'bucket:0:Pro', label: 'Pro', usedPercent: 20, resetsAt: null },
+      { key: 'bucket:1:Flash', label: 'Flash', usedPercent: 5, resetsAt: null }
     ])
   })
 
@@ -317,16 +318,28 @@ describe('getProviderUsageWindows', () => {
       monthly: window(42, 43200)
     })
     expect(getProviderUsageWindows(openCode)).toEqual([
-      { key: 'monthly', label: '30d', usedPercent: 42 }
+      { key: 'monthly', label: '30d', usedPercent: 42, resetsAt: null }
     ])
   })
 
-  it('returns session and weekly rows for the classic two-window shape', () => {
-    const claude = makeLimits({ status: 'ok', session: window(10), weekly: window(60, 10080) })
+  it('returns reset timestamps with classic session and weekly rows', () => {
+    const claude = makeLimits({
+      status: 'ok',
+      session: window(10, 300, 1_000),
+      weekly: window(60, 10080, 2_000)
+    })
     expect(getProviderUsageWindows(claude)).toEqual([
-      { key: 'session', label: '5h', usedPercent: 10 },
-      { key: 'weekly', label: '7d', usedPercent: 60 }
+      { key: 'session', label: '5h', usedPercent: 10, resetsAt: 1_000 },
+      { key: 'weekly', label: '7d', usedPercent: 60, resetsAt: 2_000 }
     ])
+  })
+
+  it('formats a dynamic window reset with the desktop countdown copy', () => {
+    const [row] = getProviderUsageWindows(
+      makeLimits({ status: 'ok', monthly: window(42, 43200, 3_600_000) })
+    )
+
+    expect(getUsageWindowResetLabel(row!, 0)).toBe('Resets in 1h')
   })
 })
 
@@ -340,6 +353,18 @@ describe('hasRenderableUsage for display-only providers', () => {
 
   it('is false for a display-only provider with no data (no managed-account fallback)', () => {
     expect(hasRenderableUsage(makeSnapshot(), 'grok')).toBe(false)
+  })
+
+  it('keeps display-only fetching and error states reachable on the home screen', () => {
+    const fetching = makeSnapshot({
+      grokLimits: makeLimits({ provider: 'grok', status: 'fetching' })
+    })
+    const error = makeSnapshot({
+      grokLimits: makeLimits({ provider: 'grok', status: 'error', error: 'temporary failure' })
+    })
+
+    expect(hasRenderableUsage(fetching, 'grok')).toBe(true)
+    expect(hasRenderableUsage(error, 'grok')).toBe(true)
   })
 })
 

--- a/mobile/src/components/account-usage-state.test.ts
+++ b/mobile/src/components/account-usage-state.test.ts
@@ -32,6 +32,7 @@ function makeSnapshot(
     claudeLimits?: ProviderRateLimits | null
     codexLimits?: ProviderRateLimits | null
     geminiLimits?: ProviderRateLimits | null
+    antigravityLimits?: ProviderRateLimits | null
     grokLimits?: ProviderRateLimits | null
     claudeAccounts?: AccountsSnapshot['claude']['accounts']
     codexAccounts?: AccountsSnapshot['codex']['accounts']
@@ -56,6 +57,7 @@ function makeSnapshot(
       claudeTarget: { runtime: 'host', wslDistro: null },
       codexTarget: { runtime: 'host', wslDistro: null },
       gemini: overrides.geminiLimits ?? null,
+      antigravity: overrides.antigravityLimits ?? null,
       grok: overrides.grokLimits ?? null,
       inactiveClaudeAccounts: overrides.inactiveClaudeAccounts ?? [],
       inactiveCodexAccounts: overrides.inactiveCodexAccounts ?? []
@@ -238,6 +240,17 @@ describe('getActiveProviderRateLimits', () => {
     expect(getActiveProviderRateLimits(snapshot, 'opencode-go')).toBe(openCode)
   })
 
+  it('reads Antigravity from its dedicated snapshot field', () => {
+    const antigravity = makeLimits({
+      provider: 'antigravity',
+      status: 'ok',
+      session: window(27)
+    })
+    expect(
+      getActiveProviderRateLimits(makeSnapshot({ antigravityLimits: antigravity }), 'antigravity')
+    ).toBe(antigravity)
+  })
+
   // Old home-snapshot-cache v1 entries predate these fields; a missing field
   // must normalize to null instead of undefined so cold-start hydration can't
   // throw when a selector dereferences it.
@@ -253,6 +266,7 @@ describe('getActiveProviderRateLimits', () => {
       }
     } as AccountsSnapshot
     expect(getActiveProviderRateLimits(legacy, 'gemini')).toBeNull()
+    expect(getActiveProviderRateLimits(legacy, 'antigravity')).toBeNull()
     expect(getActiveProviderRateLimits(legacy, 'minimax')).toBeNull()
   })
 })
@@ -330,11 +344,12 @@ describe('hasRenderableUsage for display-only providers', () => {
 })
 
 describe('USAGE_PROVIDER_IDS', () => {
-  it('covers all seven providers the desktop tracks', () => {
+  it('covers all eight providers in desktop status-bar order', () => {
     expect(USAGE_PROVIDER_IDS).toEqual([
       'claude',
       'codex',
       'gemini',
+      'antigravity',
       'opencode-go',
       'kimi',
       'minimax',

--- a/mobile/src/components/account-usage-state.test.ts
+++ b/mobile/src/components/account-usage-state.test.ts
@@ -311,6 +311,23 @@ describe('getProviderUsageWindows', () => {
     ])
   })
 
+  it('keeps independent weekly and monthly windows alongside named buckets', () => {
+    const bucketed = makeLimits({
+      provider: 'gemini',
+      status: 'ok',
+      session: window(20),
+      weekly: window(35, 10080),
+      monthly: window(45, 43200),
+      buckets: [{ name: 'Pro', ...window(20) }]
+    })
+
+    expect(getProviderUsageWindows(bucketed)).toEqual([
+      { key: 'bucket:0:Pro', label: 'Pro', usedPercent: 20, resetsAt: null },
+      { key: 'weekly', label: '7d', usedPercent: 35, resetsAt: null },
+      { key: 'monthly', label: '30d', usedPercent: 45, resetsAt: null }
+    ])
+  })
+
   it('includes OpenCode Go monthly window', () => {
     const openCode = makeLimits({
       provider: 'opencode-go',

--- a/mobile/src/components/account-usage-state.test.ts
+++ b/mobile/src/components/account-usage-state.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  getActiveProviderRateLimits,
   getInactiveProviderUsage,
+  getProviderUsageWindows,
   getUsageBarState,
   getWindowResetLabel,
   hasActiveProviderUsage,
   hasRenderableUsage,
+  USAGE_PROVIDER_IDS,
   type AccountsSnapshot,
   type InactiveAccountUsage,
   type ProviderRateLimits
@@ -28,6 +31,8 @@ function makeSnapshot(
   overrides: {
     claudeLimits?: ProviderRateLimits | null
     codexLimits?: ProviderRateLimits | null
+    geminiLimits?: ProviderRateLimits | null
+    grokLimits?: ProviderRateLimits | null
     claudeAccounts?: AccountsSnapshot['claude']['accounts']
     codexAccounts?: AccountsSnapshot['codex']['accounts']
     inactiveClaudeAccounts?: InactiveAccountUsage[]
@@ -50,10 +55,16 @@ function makeSnapshot(
       codex: overrides.codexLimits ?? null,
       claudeTarget: { runtime: 'host', wslDistro: null },
       codexTarget: { runtime: 'host', wslDistro: null },
+      gemini: overrides.geminiLimits ?? null,
+      grok: overrides.grokLimits ?? null,
       inactiveClaudeAccounts: overrides.inactiveClaudeAccounts ?? [],
       inactiveCodexAccounts: overrides.inactiveCodexAccounts ?? []
     }
   }
+}
+
+function window(usedPercent: number, windowMinutes = 300) {
+  return { usedPercent, windowMinutes, resetsAt: null, resetDescription: null }
 }
 
 describe('hasActiveProviderUsage', () => {
@@ -207,5 +218,127 @@ describe('getUsageBarState', () => {
       unavailable: false,
       loading: true
     })
+  })
+})
+
+describe('getActiveProviderRateLimits', () => {
+  it('reads a display-only provider (grok) via its descriptor field', () => {
+    const grok = makeLimits({ provider: 'grok', status: 'ok', session: window(15) })
+    expect(getActiveProviderRateLimits(makeSnapshot({ grokLimits: grok }), 'grok')).toBe(grok)
+  })
+
+  it('maps opencode-go wire id to the opencodeGo snapshot field', () => {
+    const snapshot = makeSnapshot()
+    const openCode = makeLimits({
+      provider: 'opencode-go',
+      status: 'ok',
+      monthly: window(30, 43200)
+    })
+    ;(snapshot.rateLimits as { opencodeGo?: ProviderRateLimits }).opencodeGo = openCode
+    expect(getActiveProviderRateLimits(snapshot, 'opencode-go')).toBe(openCode)
+  })
+
+  // Old home-snapshot-cache v1 entries predate these fields; a missing field
+  // must normalize to null instead of undefined so cold-start hydration can't
+  // throw when a selector dereferences it.
+  it('returns null for a provider field absent from an old cached snapshot', () => {
+    const legacy = {
+      claude: { accounts: [], activeAccountId: null },
+      codex: { accounts: [], activeAccountId: null },
+      rateLimits: {
+        claude: null,
+        codex: null,
+        inactiveClaudeAccounts: [],
+        inactiveCodexAccounts: []
+      }
+    } as AccountsSnapshot
+    expect(getActiveProviderRateLimits(legacy, 'gemini')).toBeNull()
+    expect(getActiveProviderRateLimits(legacy, 'minimax')).toBeNull()
+  })
+})
+
+describe('getProviderUsageWindows', () => {
+  it('returns no rows for missing limits', () => {
+    expect(getProviderUsageWindows(null)).toEqual([])
+  })
+
+  it('expands Gemini named buckets with index-stable keys', () => {
+    const gemini = makeLimits({
+      provider: 'gemini',
+      status: 'ok',
+      buckets: [
+        { name: 'Pro', ...window(20) },
+        { name: 'Flash', ...window(5) }
+      ]
+    })
+    expect(getProviderUsageWindows(gemini)).toEqual([
+      { key: 'bucket:0:Pro', label: 'Pro', usedPercent: 20 },
+      { key: 'bucket:1:Flash', label: 'Flash', usedPercent: 5 }
+    ])
+  })
+
+  // The host sets session = deriveSessionSummary(buckets) (the most-constrained
+  // bucket), so buckets are authoritative and the synthesized session row must
+  // not double-show it.
+  it('omits the derived session row when Gemini reports buckets', () => {
+    const gemini = makeLimits({
+      provider: 'gemini',
+      status: 'ok',
+      session: window(20), // mirrors the worst bucket
+      buckets: [
+        { name: 'Pro', ...window(20) },
+        { name: 'Flash', ...window(5) }
+      ]
+    })
+    expect(getProviderUsageWindows(gemini)).toEqual([
+      { key: 'bucket:0:Pro', label: 'Pro', usedPercent: 20 },
+      { key: 'bucket:1:Flash', label: 'Flash', usedPercent: 5 }
+    ])
+  })
+
+  it('includes OpenCode Go monthly window', () => {
+    const openCode = makeLimits({
+      provider: 'opencode-go',
+      status: 'ok',
+      monthly: window(42, 43200)
+    })
+    expect(getProviderUsageWindows(openCode)).toEqual([
+      { key: 'monthly', label: '30d', usedPercent: 42 }
+    ])
+  })
+
+  it('returns session and weekly rows for the classic two-window shape', () => {
+    const claude = makeLimits({ status: 'ok', session: window(10), weekly: window(60, 10080) })
+    expect(getProviderUsageWindows(claude)).toEqual([
+      { key: 'session', label: '5h', usedPercent: 10 },
+      { key: 'weekly', label: '7d', usedPercent: 60 }
+    ])
+  })
+})
+
+describe('hasRenderableUsage for display-only providers', () => {
+  it('is true for grok when the system-default target has active usage', () => {
+    const snapshot = makeSnapshot({
+      grokLimits: makeLimits({ provider: 'grok', status: 'ok', weekly: window(33, 10080) })
+    })
+    expect(hasRenderableUsage(snapshot, 'grok')).toBe(true)
+  })
+
+  it('is false for a display-only provider with no data (no managed-account fallback)', () => {
+    expect(hasRenderableUsage(makeSnapshot(), 'grok')).toBe(false)
+  })
+})
+
+describe('USAGE_PROVIDER_IDS', () => {
+  it('covers all seven providers the desktop tracks', () => {
+    expect(USAGE_PROVIDER_IDS).toEqual([
+      'claude',
+      'codex',
+      'gemini',
+      'opencode-go',
+      'kimi',
+      'minimax',
+      'grok'
+    ])
   })
 })

--- a/mobile/src/components/account-usage-state.ts
+++ b/mobile/src/components/account-usage-state.ts
@@ -34,6 +34,7 @@ export type ManagedAccountProviderKey = 'claude' | 'codex'
 export type UsageProviderKey =
   | ManagedAccountProviderKey
   | 'gemini'
+  | 'antigravity'
   | 'opencode-go'
   | 'kimi'
   | 'minimax'
@@ -49,6 +50,7 @@ type ProviderSnapshotField =
   | 'claude'
   | 'codex'
   | 'gemini'
+  | 'antigravity'
   | 'opencodeGo'
   | 'kimi'
   | 'minimax'
@@ -68,6 +70,7 @@ export const USAGE_PROVIDERS: readonly UsageProviderDescriptor[] = [
   { id: 'claude', label: 'Claude', snapshotField: 'claude', managed: true },
   { id: 'codex', label: 'Codex', snapshotField: 'codex', managed: true },
   { id: 'gemini', label: 'Gemini', snapshotField: 'gemini', managed: false },
+  { id: 'antigravity', label: 'Antigravity', snapshotField: 'antigravity', managed: false },
   { id: 'opencode-go', label: 'OpenCode Go', snapshotField: 'opencodeGo', managed: false },
   { id: 'kimi', label: 'Kimi', snapshotField: 'kimi', managed: false },
   { id: 'minimax', label: 'MiniMax', snapshotField: 'minimax', managed: false },

--- a/mobile/src/components/account-usage-state.ts
+++ b/mobile/src/components/account-usage-state.ts
@@ -161,6 +161,7 @@ export type UsageWindowRow = {
   key: string
   label: string
   usedPercent: number
+  resetsAt: number | null
 }
 
 // Why: providers do not share one fixed pair of windows. Gemini reports named
@@ -181,20 +182,40 @@ export function getProviderUsageWindows(limits: ProviderRateLimits | null): Usag
     return buckets.map((bucket, index) => ({
       key: `bucket:${index}:${bucket.name}`,
       label: bucket.name,
-      usedPercent: bucket.usedPercent
+      usedPercent: bucket.usedPercent,
+      resetsAt: bucket.resetsAt
     }))
   }
   const rows: UsageWindowRow[] = []
   if (limits.session) {
-    rows.push({ key: 'session', label: '5h', usedPercent: limits.session.usedPercent })
+    rows.push({
+      key: 'session',
+      label: '5h',
+      usedPercent: limits.session.usedPercent,
+      resetsAt: limits.session.resetsAt
+    })
   }
   if (limits.weekly) {
-    rows.push({ key: 'weekly', label: '7d', usedPercent: limits.weekly.usedPercent })
+    rows.push({
+      key: 'weekly',
+      label: '7d',
+      usedPercent: limits.weekly.usedPercent,
+      resetsAt: limits.weekly.resetsAt
+    })
   }
   if (limits.monthly) {
-    rows.push({ key: 'monthly', label: '30d', usedPercent: limits.monthly.usedPercent })
+    rows.push({
+      key: 'monthly',
+      label: '30d',
+      usedPercent: limits.monthly.usedPercent,
+      resetsAt: limits.monthly.resetsAt
+    })
   }
   return rows
+}
+
+export function getUsageWindowResetLabel(window: UsageWindowRow, now: number): string | null {
+  return window.resetsAt == null ? null : formatResetCountdown(window.resetsAt - now)
 }
 
 /**
@@ -232,5 +253,9 @@ export function hasRenderableUsage(
       return true
     }
   }
-  return hasActiveProviderUsage(getActiveProviderRateLimits(snapshot, provider))
+  const limits = getActiveProviderRateLimits(snapshot, provider)
+  if (!descriptor?.managed && (limits?.status === 'fetching' || limits?.status === 'error')) {
+    return true
+  }
+  return hasActiveProviderUsage(limits)
 }

--- a/mobile/src/components/account-usage-state.ts
+++ b/mobile/src/components/account-usage-state.ts
@@ -174,20 +174,19 @@ export function getProviderUsageWindows(limits: ProviderRateLimits | null): Usag
     return []
   }
   const buckets = limits.buckets ?? []
-  // Why: when named buckets exist they are authoritative. Gemini's `session`
-  // is derived from the most-constrained bucket (host deriveSessionSummary), so
-  // emitting both would show that worst bucket twice under a false "5h" label.
-  // Key includes the index so two buckets with the same name stay distinct.
-  if (buckets.length > 0) {
-    return buckets.map((bucket, index) => ({
-      key: `bucket:${index}:${bucket.name}`,
-      label: bucket.name,
-      usedPercent: bucket.usedPercent,
-      resetsAt: bucket.resetsAt
-    }))
-  }
   const rows: UsageWindowRow[] = []
-  if (limits.session) {
+  // Why: named buckets replace only the synthesized session summary; independent
+  // weekly/monthly windows still belong beside them, matching desktop behavior.
+  if (buckets.length > 0) {
+    rows.push(
+      ...buckets.map((bucket, index) => ({
+        key: `bucket:${index}:${bucket.name}`,
+        label: bucket.name,
+        usedPercent: bucket.usedPercent,
+        resetsAt: bucket.resetsAt
+      }))
+    )
+  } else if (limits.session) {
     rows.push({
       key: 'session',
       label: '5h',

--- a/mobile/src/components/account-usage-state.ts
+++ b/mobile/src/components/account-usage-state.ts
@@ -26,7 +26,66 @@ export {
   type RateLimitWindow
 } from './accounts-snapshot'
 
-export type ProviderKey = 'claude' | 'codex'
+// Why: only Claude and Codex have Orca-managed accounts and interactive
+// switching (add/re-auth stays desktop-only). Everything else is display-only
+// usage, so account-switching selectors accept only this narrow type — a
+// display-only provider can never route to accounts.selectClaude/selectCodex.
+export type ManagedAccountProviderKey = 'claude' | 'codex'
+export type UsageProviderKey =
+  | ManagedAccountProviderKey
+  | 'gemini'
+  | 'opencode-go'
+  | 'kimi'
+  | 'minimax'
+  | 'grok'
+
+// Kept as an alias so existing switching call sites stay constrained to the
+// two managed providers.
+export type ProviderKey = ManagedAccountProviderKey
+
+// The snapshot rateLimits field a provider's usage lives under. Distinct from
+// the wire id: OpenCode Go's id is 'opencode-go' but its field is 'opencodeGo'.
+type ProviderSnapshotField =
+  | 'claude'
+  | 'codex'
+  | 'gemini'
+  | 'opencodeGo'
+  | 'kimi'
+  | 'minimax'
+  | 'grok'
+
+export type UsageProviderDescriptor = {
+  id: UsageProviderKey
+  label: string
+  snapshotField: ProviderSnapshotField
+  managed: boolean
+}
+
+// Single source that maps the stable preference/wire id to its snapshot field,
+// label, and whether it supports account switching. Drives iteration order,
+// visibility toggles, and field lookup.
+export const USAGE_PROVIDERS: readonly UsageProviderDescriptor[] = [
+  { id: 'claude', label: 'Claude', snapshotField: 'claude', managed: true },
+  { id: 'codex', label: 'Codex', snapshotField: 'codex', managed: true },
+  { id: 'gemini', label: 'Gemini', snapshotField: 'gemini', managed: false },
+  { id: 'opencode-go', label: 'OpenCode Go', snapshotField: 'opencodeGo', managed: false },
+  { id: 'kimi', label: 'Kimi', snapshotField: 'kimi', managed: false },
+  { id: 'minimax', label: 'MiniMax', snapshotField: 'minimax', managed: false },
+  { id: 'grok', label: 'Grok', snapshotField: 'grok', managed: false }
+]
+
+export const USAGE_PROVIDER_IDS: readonly UsageProviderKey[] = USAGE_PROVIDERS.map((p) => p.id)
+
+// Providers shown by default when the user has never opened the filter — the
+// two primary agents, matching the phone's historical behavior and the rule
+// that the phone must not surface every provider at once.
+export const DEFAULT_VISIBLE_USAGE_PROVIDERS: readonly UsageProviderKey[] = ['claude', 'codex']
+
+export function getUsageProviderDescriptor(
+  provider: UsageProviderKey
+): UsageProviderDescriptor | null {
+  return USAGE_PROVIDERS.find((p) => p.id === provider) ?? null
+}
 
 export type UsageBarState = {
   usedPercent: number | null
@@ -36,14 +95,19 @@ export type UsageBarState = {
 
 export function getActiveProviderRateLimits(
   snapshot: AccountsSnapshot,
-  provider: ProviderKey
+  provider: UsageProviderKey
 ): ProviderRateLimits | null {
-  return provider === 'claude' ? snapshot.rateLimits.claude : snapshot.rateLimits.codex
+  const field = getUsageProviderDescriptor(provider)?.snapshotField
+  if (!field) {
+    return null
+  }
+  // `?? null` normalizes a field missing from an old cached snapshot.
+  return snapshot.rateLimits[field] ?? null
 }
 
 export function getInactiveProviderUsage(
   snapshot: AccountsSnapshot,
-  provider: ProviderKey,
+  provider: ManagedAccountProviderKey,
   accountId: string
 ): InactiveAccountUsage | null {
   const list =
@@ -90,6 +154,46 @@ export function getUsageBarState(
   }
 }
 
+export type UsageWindowRow = {
+  key: string
+  label: string
+  usedPercent: number
+}
+
+// Why: providers do not share one fixed pair of windows. Gemini reports named
+// per-model buckets, OpenCode Go reports a monthly window, others report
+// session (5h) / weekly (7d). Return the labelled rows a provider actually has
+// so display-only sections render each provider's real usage instead of two
+// hardcoded 5h/7d bars that would show dashes for buckets/monthly.
+export function getProviderUsageWindows(limits: ProviderRateLimits | null): UsageWindowRow[] {
+  if (!limits) {
+    return []
+  }
+  const buckets = limits.buckets ?? []
+  // Why: when named buckets exist they are authoritative. Gemini's `session`
+  // is derived from the most-constrained bucket (host deriveSessionSummary), so
+  // emitting both would show that worst bucket twice under a false "5h" label.
+  // Key includes the index so two buckets with the same name stay distinct.
+  if (buckets.length > 0) {
+    return buckets.map((bucket, index) => ({
+      key: `bucket:${index}:${bucket.name}`,
+      label: bucket.name,
+      usedPercent: bucket.usedPercent
+    }))
+  }
+  const rows: UsageWindowRow[] = []
+  if (limits.session) {
+    rows.push({ key: 'session', label: '5h', usedPercent: limits.session.usedPercent })
+  }
+  if (limits.weekly) {
+    rows.push({ key: 'weekly', label: '7d', usedPercent: limits.weekly.usedPercent })
+  }
+  if (limits.monthly) {
+    rows.push({ key: 'monthly', label: '30d', usedPercent: limits.monthly.usedPercent })
+  }
+  return rows
+}
+
 /**
  * Reset countdown for one window, e.g. "Resets in 3h 54m" / "Resets now",
  * or null when the window has no reset timestamp (so the UI degrades to
@@ -114,10 +218,16 @@ export function getWindowResetLabel(
 // Why: the usage UI must render for the system-default login, not only for
 // Orca-managed accounts. Show a provider when it has at least one managed
 // account OR active rate-limit data for the system-default target.
-export function hasRenderableUsage(snapshot: AccountsSnapshot, provider: ProviderKey): boolean {
-  const accounts = provider === 'claude' ? snapshot.claude.accounts : snapshot.codex.accounts
-  if (accounts.length > 0) {
-    return true
+export function hasRenderableUsage(
+  snapshot: AccountsSnapshot,
+  provider: UsageProviderKey
+): boolean {
+  const descriptor = getUsageProviderDescriptor(provider)
+  if (descriptor?.managed) {
+    const accounts = provider === 'claude' ? snapshot.claude.accounts : snapshot.codex.accounts
+    if (accounts.length > 0) {
+      return true
+    }
   }
   return hasActiveProviderUsage(getActiveProviderRateLimits(snapshot, provider))
 }

--- a/mobile/src/components/accounts-snapshot.test.ts
+++ b/mobile/src/components/accounts-snapshot.test.ts
@@ -103,6 +103,22 @@ describe('decodeAccountsSnapshot', () => {
     expect(snapshot.rateLimits.codexTarget).toEqual({ runtime: 'host', wslDistro: null })
   })
 
+  it('validates display-only provider identities', () => {
+    const snapshot = makeSnapshot()
+    setPath(snapshot, ['rateLimits', 'gemini'], {
+      provider: 'gemini',
+      session: null,
+      weekly: null,
+      updatedAt: 100,
+      error: null,
+      status: 'ok'
+    })
+    expect(decodeAccountsSnapshot(snapshot).rateLimits.gemini?.provider).toBe('gemini')
+
+    setPath(snapshot, ['rateLimits', 'gemini', 'provider'], 'codex')
+    expect(() => decodeAccountsSnapshot(snapshot)).toThrow('Invalid accounts snapshot from host')
+  })
+
   it.each([
     ['account arrays', ['codex', 'accounts'], {}],
     ['active account IDs', ['codex', 'activeAccountId'], 42],

--- a/mobile/src/components/accounts-snapshot.ts
+++ b/mobile/src/components/accounts-snapshot.ts
@@ -103,6 +103,19 @@ const HostRateLimitRuntimeTarget = {
   wslDistro: null
 }
 
+const DisplayOnlyProviderRateLimitsSchema = ProviderRateLimitsSchema.nullable().optional()
+
+const RateLimitProviderFields = [
+  ['claude', 'claude'],
+  ['codex', 'codex'],
+  ['gemini', 'gemini'],
+  ['opencodeGo', 'opencode-go'],
+  ['kimi', 'kimi'],
+  ['minimax', 'minimax'],
+  ['grok', 'grok'],
+  ['antigravity', 'antigravity']
+] as const
+
 const ClaudeAccountSummarySchema = z
   .object({
     id: AccountIdSchema,
@@ -174,6 +187,12 @@ export const AccountsSnapshotSchema = z
       .object({
         claude: ProviderRateLimitsSchema.nullable(),
         codex: ProviderRateLimitsSchema.nullable(),
+        gemini: DisplayOnlyProviderRateLimitsSchema,
+        opencodeGo: DisplayOnlyProviderRateLimitsSchema,
+        kimi: DisplayOnlyProviderRateLimitsSchema,
+        minimax: DisplayOnlyProviderRateLimitsSchema,
+        grok: DisplayOnlyProviderRateLimitsSchema,
+        antigravity: DisplayOnlyProviderRateLimitsSchema,
         // Why: protocol-compatible hosts from before runtime targeting omit
         // these fields; their account selection semantics were host-only.
         claudeTarget: RateLimitRuntimeTargetSchema.default(HostRateLimitRuntimeTarget),
@@ -185,19 +204,15 @@ export const AccountsSnapshotSchema = z
   })
   .passthrough()
   .superRefine((snapshot, context) => {
-    if (snapshot.rateLimits.claude && snapshot.rateLimits.claude.provider !== 'claude') {
-      context.addIssue({
-        code: 'custom',
-        message: 'Claude limits use the wrong provider identity',
-        path: ['rateLimits', 'claude', 'provider']
-      })
-    }
-    if (snapshot.rateLimits.codex && snapshot.rateLimits.codex.provider !== 'codex') {
-      context.addIssue({
-        code: 'custom',
-        message: 'Codex limits use the wrong provider identity',
-        path: ['rateLimits', 'codex', 'provider']
-      })
+    for (const [field, provider] of RateLimitProviderFields) {
+      const limits = snapshot.rateLimits[field]
+      if (limits && limits.provider !== provider) {
+        context.addIssue({
+          code: 'custom',
+          message: `${provider} limits use the wrong provider identity`,
+          path: ['rateLimits', field, 'provider']
+        })
+      }
     }
     for (const [index, entry] of snapshot.rateLimits.inactiveClaudeAccounts.entries()) {
       if (entry.rateLimits && entry.rateLimits.provider !== 'claude') {

--- a/mobile/src/components/home-account-usage-card.test.ts
+++ b/mobile/src/components/home-account-usage-card.test.ts
@@ -1,0 +1,89 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { HomeAccountUsageCard } from './HomeAccountUsageCard'
+import type { AccountsSnapshot, ProviderRateLimits } from './account-usage-state'
+
+vi.mock('react-native', () => ({
+  ActivityIndicator: 'ActivityIndicator',
+  Pressable: 'Pressable',
+  StyleSheet: { create: (styles: unknown) => styles },
+  Text: 'Text',
+  View: 'View'
+}))
+
+vi.mock('lucide-react-native', () => ({ Gauge: 'Gauge' }))
+vi.mock('./AgentIcons', () => ({ ClaudeIcon: 'ClaudeIcon', OpenAIIcon: 'OpenAIIcon' }))
+
+function limits(provider: ProviderRateLimits['provider']): ProviderRateLimits {
+  return {
+    provider,
+    session: { usedPercent: 25, windowMinutes: 300, resetsAt: null, resetDescription: null },
+    weekly: null,
+    updatedAt: 1,
+    error: null,
+    status: 'ok'
+  }
+}
+
+function snapshot(): AccountsSnapshot {
+  return {
+    claude: {
+      accounts: [{ id: 'claude-1', email: 'claude@example.com' }],
+      activeAccountId: 'claude-1'
+    },
+    codex: { accounts: [], activeAccountId: null },
+    rateLimits: {
+      claude: limits('claude'),
+      codex: null,
+      antigravity: limits('antigravity'),
+      inactiveClaudeAccounts: [],
+      inactiveCodexAccounts: []
+    }
+  }
+}
+
+function textValues(renderer: ReactTestRenderer): string[] {
+  return renderer.root
+    .findAllByType('Text')
+    .map((node) => node.props.children)
+    .filter((value): value is string => typeof value === 'string')
+}
+
+describe('HomeAccountUsageCard visibility', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    const originalConsoleError = console.error
+    vi.spyOn(console, 'error').mockImplementation((...args) => {
+      if (typeof args[0] === 'string' && args[0].includes('react-test-renderer is deprecated')) {
+        return
+      }
+      originalConsoleError(...args)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders only providers selected by the persisted visibility set', () => {
+    let renderer: ReactTestRenderer | null = null
+    act(() => {
+      renderer = create(
+        createElement(HomeAccountUsageCard, {
+          snapshot: snapshot(),
+          visibleProviders: new Set(['antigravity']),
+          showHostName: false,
+          hostName: 'Desk',
+          onPress: vi.fn()
+        })
+      )
+    })
+
+    const texts = textValues(renderer!)
+    expect(texts).toContain('Antigravity')
+    expect(texts).not.toContain('claude@example.com')
+
+    act(() => renderer?.unmount())
+  })
+})

--- a/mobile/src/components/home-account-usage-card.test.ts
+++ b/mobile/src/components/home-account-usage-card.test.ts
@@ -18,7 +18,12 @@ vi.mock('./AgentIcons', () => ({ ClaudeIcon: 'ClaudeIcon', OpenAIIcon: 'OpenAIIc
 function limits(provider: ProviderRateLimits['provider']): ProviderRateLimits {
   return {
     provider,
-    session: { usedPercent: 25, windowMinutes: 300, resetsAt: null, resetDescription: null },
+    session: {
+      usedPercent: 25,
+      windowMinutes: 300,
+      resetsAt: 3_600_000,
+      resetDescription: null
+    },
     weekly: null,
     updatedAt: 1,
     error: null,
@@ -75,6 +80,7 @@ describe('HomeAccountUsageCard visibility', () => {
           visibleProviders: new Set(['antigravity']),
           showHostName: false,
           hostName: 'Desk',
+          now: 0,
           onPress: vi.fn()
         })
       )
@@ -83,6 +89,26 @@ describe('HomeAccountUsageCard visibility', () => {
     const texts = textValues(renderer!)
     expect(texts).toContain('Antigravity')
     expect(texts).not.toContain('claude@example.com')
+
+    act(() => renderer?.unmount())
+  })
+
+  it('renders display-only provider reset countdowns using the current timestamp', () => {
+    let renderer: ReactTestRenderer | null = null
+    act(() => {
+      renderer = create(
+        createElement(HomeAccountUsageCard, {
+          snapshot: snapshot(),
+          visibleProviders: new Set(['antigravity']),
+          showHostName: false,
+          hostName: 'Desk',
+          now: 0,
+          onPress: vi.fn()
+        })
+      )
+    })
+
+    expect(textValues(renderer!)).toContain('Resets in 1h')
 
     act(() => renderer?.unmount())
   })

--- a/mobile/src/components/use-visible-usage-providers.test.ts
+++ b/mobile/src/components/use-visible-usage-providers.test.ts
@@ -1,0 +1,81 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useVisibleUsageProviders } from './use-visible-usage-providers'
+
+type FocusCallback = () => void | (() => void)
+
+const dependencies = vi.hoisted(() => ({
+  focusCallback: null as FocusCallback | null,
+  loadVisibleUsageProviders: vi.fn()
+}))
+
+vi.mock('expo-router', () => ({
+  useFocusEffect: (callback: FocusCallback) => {
+    dependencies.focusCallback = callback
+  }
+}))
+
+vi.mock('../storage/preferences', () => ({
+  loadVisibleUsageProviders: dependencies.loadVisibleUsageProviders
+}))
+
+function Probe({ onValue }: { onValue: (value: string[]) => void }) {
+  onValue([...useVisibleUsageProviders()])
+  return null
+}
+
+describe('useVisibleUsageProviders', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    dependencies.focusCallback = null
+    dependencies.loadVisibleUsageProviders.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('starts with Claude and Codex, then reloads the stored set on focus', async () => {
+    dependencies.loadVisibleUsageProviders.mockResolvedValue(new Set(['antigravity', 'grok']))
+    const values: string[][] = []
+    let renderer: ReactTestRenderer | null = null
+
+    act(() => {
+      renderer = create(createElement(Probe, { onValue: (value) => values.push(value) }))
+    })
+    expect(values.at(-1)).toEqual(['claude', 'codex'])
+
+    let cleanup: void | (() => void)
+    await act(async () => {
+      cleanup = dependencies.focusCallback?.()
+      await Promise.resolve()
+    })
+    expect(values.at(-1)).toEqual(['antigravity', 'grok'])
+
+    cleanup?.()
+    act(() => renderer?.unmount())
+  })
+
+  it('ignores a storage read that resolves after the screen loses focus', async () => {
+    let resolveLoad: ((value: Set<string>) => void) | null = null
+    dependencies.loadVisibleUsageProviders.mockImplementation(
+      () => new Promise((resolve) => (resolveLoad = resolve))
+    )
+    const values: string[][] = []
+    let renderer: ReactTestRenderer | null = null
+
+    act(() => {
+      renderer = create(createElement(Probe, { onValue: (value) => values.push(value) }))
+    })
+    const cleanup = dependencies.focusCallback?.()
+    cleanup?.()
+    await act(async () => {
+      resolveLoad?.(new Set(['grok']))
+      await Promise.resolve()
+    })
+
+    expect(values.at(-1)).toEqual(['claude', 'codex'])
+    act(() => renderer?.unmount())
+  })
+})

--- a/mobile/src/components/use-visible-usage-providers.test.ts
+++ b/mobile/src/components/use-visible-usage-providers.test.ts
@@ -7,7 +7,7 @@ type FocusCallback = () => void | (() => void)
 
 const dependencies = vi.hoisted(() => ({
   focusCallback: null as FocusCallback | null,
-  loadVisibleUsageProviders: vi.fn()
+  loadVisibleUsageProvidersSettled: vi.fn()
 }))
 
 vi.mock('expo-router', () => ({
@@ -17,7 +17,7 @@ vi.mock('expo-router', () => ({
 }))
 
 vi.mock('../storage/preferences', () => ({
-  loadVisibleUsageProviders: dependencies.loadVisibleUsageProviders
+  loadVisibleUsageProvidersSettled: dependencies.loadVisibleUsageProvidersSettled
 }))
 
 function Probe({ onValue }: { onValue: (value: string[]) => void }) {
@@ -29,7 +29,14 @@ describe('useVisibleUsageProviders', () => {
   beforeEach(() => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
     dependencies.focusCallback = null
-    dependencies.loadVisibleUsageProviders.mockReset()
+    dependencies.loadVisibleUsageProvidersSettled.mockReset()
+    const originalConsoleError = console.error
+    vi.spyOn(console, 'error').mockImplementation((...args) => {
+      if (typeof args[0] === 'string' && args[0].includes('react-test-renderer is deprecated')) {
+        return
+      }
+      originalConsoleError(...args)
+    })
   })
 
   afterEach(() => {
@@ -37,7 +44,9 @@ describe('useVisibleUsageProviders', () => {
   })
 
   it('starts with Claude and Codex, then reloads the stored set on focus', async () => {
-    dependencies.loadVisibleUsageProviders.mockResolvedValue(new Set(['antigravity', 'grok']))
+    dependencies.loadVisibleUsageProvidersSettled.mockResolvedValue(
+      new Set(['antigravity', 'grok'])
+    )
     const values: string[][] = []
     let renderer: ReactTestRenderer | null = null
 
@@ -59,7 +68,7 @@ describe('useVisibleUsageProviders', () => {
 
   it('ignores a storage read that resolves after the screen loses focus', async () => {
     let resolveLoad: ((value: Set<string>) => void) | null = null
-    dependencies.loadVisibleUsageProviders.mockImplementation(
+    dependencies.loadVisibleUsageProvidersSettled.mockImplementation(
       () => new Promise((resolve) => (resolveLoad = resolve))
     )
     const values: string[][] = []

--- a/mobile/src/components/use-visible-usage-providers.ts
+++ b/mobile/src/components/use-visible-usage-providers.ts
@@ -1,0 +1,28 @@
+import { useCallback, useState } from 'react'
+import { useFocusEffect } from 'expo-router'
+import { loadVisibleUsageProviders } from '../storage/preferences'
+import { DEFAULT_VISIBLE_USAGE_PROVIDERS, type UsageProviderKey } from './account-usage-state'
+
+export function useVisibleUsageProviders(): Set<UsageProviderKey> {
+  const [visible, setVisible] = useState<Set<UsageProviderKey>>(
+    () => new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
+  )
+
+  // Why: settings routes are pushed over existing screens, so visibility must
+  // reload on focus rather than only when a home/accounts screen first mounts.
+  useFocusEffect(
+    useCallback(() => {
+      let active = true
+      void loadVisibleUsageProviders().then((stored) => {
+        if (active) {
+          setVisible(stored)
+        }
+      })
+      return () => {
+        active = false
+      }
+    }, [])
+  )
+
+  return visible
+}

--- a/mobile/src/components/use-visible-usage-providers.ts
+++ b/mobile/src/components/use-visible-usage-providers.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react'
 import { useFocusEffect } from 'expo-router'
-import { loadVisibleUsageProviders } from '../storage/preferences'
+import { loadVisibleUsageProvidersSettled } from '../storage/preferences'
 import { DEFAULT_VISIBLE_USAGE_PROVIDERS, type UsageProviderKey } from './account-usage-state'
 
 export function useVisibleUsageProviders(): Set<UsageProviderKey> {
@@ -13,7 +13,7 @@ export function useVisibleUsageProviders(): Set<UsageProviderKey> {
   useFocusEffect(
     useCallback(() => {
       let active = true
-      void loadVisibleUsageProviders().then((stored) => {
+      void loadVisibleUsageProvidersSettled().then((stored) => {
         if (active) {
           setVisible(stored)
         }

--- a/mobile/src/storage/preferences.test.ts
+++ b/mobile/src/storage/preferences.test.ts
@@ -15,6 +15,7 @@ import {
   loadTerminalLinkOpenMode,
   readPushNotificationsPreference,
   loadVisibleUsageProviders,
+  loadVisibleUsageProvidersSettled,
 
   readDisabledTerminalLiveInputHandlesPreference,
   saveDisabledTerminalLiveInputHandles,
@@ -22,7 +23,8 @@ import {
   savePushNotificationsEnabled,
   saveTerminalAutocompleteEnabled,
   saveTerminalLinkOpenMode,
-  saveVisibleUsageProviders
+  saveVisibleUsageProviders,
+  setUsageProviderVisible
 } from './preferences'
 import {
   loadDefaultSessionView,
@@ -540,5 +542,86 @@ describe('visible usage providers preference', () => {
     vi.mocked(AsyncStorage.getItem).mockRejectedValue(new Error('storage unavailable'))
 
     await expect(loadVisibleUsageProviders()).resolves.toEqual(new Set(['claude', 'codex']))
+  })
+})
+
+describe('setUsageProviderVisible (serialized read-modify-write)', () => {
+  // Back the mock with an in-memory value so a toggle's read sees the prior
+  // write — the whole point of the serialized read-modify-write.
+  let store: string | null
+  beforeEach(() => {
+    store = null
+    vi.mocked(AsyncStorage.getItem)
+      .mockReset()
+      .mockImplementation(async () => store)
+    vi.mocked(AsyncStorage.setItem)
+      .mockReset()
+      .mockImplementation(async (_key, value) => {
+        store = value as string
+      })
+  })
+
+  // The bug: a toggle that persisted the whole set against a stale base dropped
+  // a provider it never touched. Re-reading the latest set keeps it.
+  it('adds a provider without dropping a stored-only one (the Grok race)', async () => {
+    store = JSON.stringify(['claude', 'codex', 'grok'])
+
+    const result = await setUsageProviderVisible('gemini', true)
+
+    expect(result).toEqual(new Set(['claude', 'codex', 'gemini', 'grok']))
+    await expect(loadVisibleUsageProviders()).resolves.toEqual(
+      new Set(['claude', 'codex', 'gemini', 'grok'])
+    )
+  })
+
+  it('removes only the toggled provider', async () => {
+    store = JSON.stringify(['claude', 'codex', 'grok'])
+
+    await setUsageProviderVisible('grok', false)
+
+    await expect(loadVisibleUsageProviders()).resolves.toEqual(new Set(['claude', 'codex']))
+  })
+
+  it('serializes concurrent toggles so neither is lost', async () => {
+    store = JSON.stringify(['claude', 'codex'])
+
+    await Promise.all([
+      setUsageProviderVisible('grok', true),
+      setUsageProviderVisible('gemini', true)
+    ])
+
+    await expect(loadVisibleUsageProviders()).resolves.toEqual(
+      new Set(['claude', 'codex', 'gemini', 'grok'])
+    )
+  })
+
+  it('aborts the write (keeps the stored set) when the read fails', async () => {
+    store = JSON.stringify(['claude', 'codex', 'grok'])
+    vi.mocked(AsyncStorage.getItem).mockRejectedValueOnce(new Error('read blip'))
+
+    await expect(setUsageProviderVisible('gemini', true)).rejects.toThrow()
+    // The stored set is untouched — a transient read failure must not persist
+    // the default and drop Grok.
+    await expect(loadVisibleUsageProviders()).resolves.toEqual(new Set(['claude', 'codex', 'grok']))
+  })
+
+  it('self-heals malformed stored JSON by re-basing on the default', async () => {
+    store = 'not json{'
+
+    await setUsageProviderVisible('grok', true)
+
+    // Malformed content is corrupt, not an I/O failure: re-base on the default
+    // and rewrite so the toggle repairs the stored value instead of rejecting.
+    await expect(loadVisibleUsageProviders()).resolves.toEqual(new Set(['claude', 'codex', 'grok']))
+  })
+
+  it('loadVisibleUsageProvidersSettled waits for an in-flight toggle', async () => {
+    store = JSON.stringify(['claude', 'codex'])
+
+    const pending = setUsageProviderVisible('grok', true)
+    const settled = await loadVisibleUsageProvidersSettled()
+    await pending
+
+    expect(settled).toEqual(new Set(['claude', 'codex', 'grok']))
   })
 })

--- a/mobile/src/storage/preferences.test.ts
+++ b/mobile/src/storage/preferences.test.ts
@@ -14,12 +14,15 @@ import {
   loadTerminalAutocompleteEnabled,
   loadTerminalLinkOpenMode,
   readPushNotificationsPreference,
+  loadVisibleUsageProviders,
+
   readDisabledTerminalLiveInputHandlesPreference,
   saveDisabledTerminalLiveInputHandles,
   saveHostSidebarWidth,
   savePushNotificationsEnabled,
   saveTerminalAutocompleteEnabled,
-  saveTerminalLinkOpenMode
+  saveTerminalLinkOpenMode,
+  saveVisibleUsageProviders
 } from './preferences'
 import {
   loadDefaultSessionView,
@@ -487,5 +490,55 @@ describe('terminal link open mode preference', () => {
     await saveTerminalLinkOpenMode('phone-browser')
 
     expect(AsyncStorage.setItem).toHaveBeenCalledWith('orca:terminalLinkOpenMode', 'phone-browser')
+  })
+})
+
+describe('visible usage providers preference', () => {
+  beforeEach(() => {
+    vi.mocked(AsyncStorage.getItem).mockReset()
+    vi.mocked(AsyncStorage.setItem).mockReset()
+  })
+
+  it('defaults to Claude + Codex when never set', async () => {
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue(null)
+
+    await expect(loadVisibleUsageProviders()).resolves.toEqual(new Set(['claude', 'codex']))
+    expect(AsyncStorage.getItem).toHaveBeenCalledWith('orca:visibleUsageProviders')
+  })
+
+  it('round-trips a saved set in canonical order', async () => {
+    await saveVisibleUsageProviders(new Set(['grok', 'claude', 'gemini']))
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'orca:visibleUsageProviders',
+      JSON.stringify(['claude', 'gemini', 'grok'])
+    )
+  })
+
+  it('drops unknown or stale ids on load', async () => {
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue(
+      JSON.stringify(['claude', 'opencodeGo', 'bogus', 'grok'])
+    )
+
+    // 'opencodeGo' (field name, not the wire id) and 'bogus' are dropped.
+    await expect(loadVisibleUsageProviders()).resolves.toEqual(new Set(['claude', 'grok']))
+  })
+
+  it('preserves an explicit empty set as "show none"', async () => {
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue(JSON.stringify([]))
+
+    await expect(loadVisibleUsageProviders()).resolves.toEqual(new Set())
+  })
+
+  it('falls back to the default set for non-array corrupted JSON', async () => {
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue(JSON.stringify({}))
+
+    await expect(loadVisibleUsageProviders()).resolves.toEqual(new Set(['claude', 'codex']))
+  })
+
+  it('falls back to the default set when storage cannot be read', async () => {
+    vi.mocked(AsyncStorage.getItem).mockRejectedValue(new Error('storage unavailable'))
+
+    await expect(loadVisibleUsageProviders()).resolves.toEqual(new Set(['claude', 'codex']))
   })
 })

--- a/mobile/src/storage/preferences.test.ts
+++ b/mobile/src/storage/preferences.test.ts
@@ -509,11 +509,11 @@ describe('visible usage providers preference', () => {
   })
 
   it('round-trips a saved set in canonical order', async () => {
-    await saveVisibleUsageProviders(new Set(['grok', 'claude', 'gemini']))
+    await saveVisibleUsageProviders(new Set(['grok', 'antigravity', 'claude', 'gemini']))
 
     expect(AsyncStorage.setItem).toHaveBeenCalledWith(
       'orca:visibleUsageProviders',
-      JSON.stringify(['claude', 'gemini', 'grok'])
+      JSON.stringify(['claude', 'gemini', 'antigravity', 'grok'])
     )
   })
 

--- a/mobile/src/storage/preferences.test.ts
+++ b/mobile/src/storage/preferences.test.ts
@@ -624,4 +624,23 @@ describe('setUsageProviderVisible (serialized read-modify-write)', () => {
 
     expect(settled).toEqual(new Set(['claude', 'codex', 'grok']))
   })
+
+  it('waits again when a toggle is queued while the settled read is in progress', async () => {
+    store = JSON.stringify(['claude', 'codex'])
+    const staleRead = deferred<string | null>()
+    let readCount = 0
+    vi.mocked(AsyncStorage.getItem).mockImplementation(async () => {
+      readCount += 1
+      return readCount === 1 ? staleRead.promise : store
+    })
+
+    const settled = loadVisibleUsageProvidersSettled()
+    await vi.waitFor(() => expect(AsyncStorage.getItem).toHaveBeenCalledTimes(1))
+
+    const pending = setUsageProviderVisible('grok', true)
+    staleRead.resolve(JSON.stringify(['claude', 'codex']))
+
+    await pending
+    await expect(settled).resolves.toEqual(new Set(['claude', 'codex', 'grok']))
+  })
 })

--- a/mobile/src/storage/preferences.ts
+++ b/mobile/src/storage/preferences.ts
@@ -246,19 +246,34 @@ function knownVisibleUsageProviders(ids: string[]): UsageProviderKey[] {
   return USAGE_PROVIDER_IDS.filter((id) => ids.includes(id))
 }
 
+// Distinguishes an I/O read failure from corrupt content. Only the I/O failure
+// propagates: a write must abort on it (it can't know the real stored set), but
+// corrupt content — missing, malformed JSON, or a non-array — normalizes to the
+// default so a toggle can self-heal it. loadVisibleUsageProviders maps the I/O
+// failure to the default for display; a write re-bases on the default and
+// rewrites, which repairs the stored value.
+async function readVisibleUsageProviders(): Promise<Set<UsageProviderKey>> {
+  const raw = await AsyncStorage.getItem(VISIBLE_USAGE_PROVIDERS_KEY)
+  if (raw === null) {
+    return new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
+  }
+  // Only a real array carries the "explicit empty set = show none" semantics;
+  // corrupted non-array JSON (e.g. `{}`) falls back to the default instead.
+  if (!Array.isArray(parsed)) {
+    return new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
+  }
+  return new Set(knownVisibleUsageProviders(stringArray(parsed)))
+}
+
 export async function loadVisibleUsageProviders(): Promise<Set<UsageProviderKey>> {
   try {
-    const raw = await AsyncStorage.getItem(VISIBLE_USAGE_PROVIDERS_KEY)
-    if (raw === null) {
-      return new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
-    }
-    const parsed: unknown = JSON.parse(raw)
-    // Only a real array carries the "explicit empty set = show none" semantics;
-    // corrupted non-array JSON (e.g. `{}`) falls back to the default instead.
-    if (!Array.isArray(parsed)) {
-      return new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
-    }
-    return new Set(knownVisibleUsageProviders(stringArray(parsed)))
+    return await readVisibleUsageProviders()
   } catch {
     return new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
   }
@@ -270,4 +285,38 @@ export async function saveVisibleUsageProviders(ids: ReadonlySet<UsageProviderKe
     VISIBLE_USAGE_PROVIDERS_KEY,
     JSON.stringify(USAGE_PROVIDER_IDS.filter((id) => ids.has(id)))
   )
+}
+
+// Serialize toggles so two fast switches can't lose each other through a
+// read-modify-write race on the same key: each toggle re-reads the latest
+// stored set and changes only its own provider, so it never clobbers a
+// provider it didn't touch. ponytail: a module-level chain is enough for the
+// single settings screen; revisit if more writers appear.
+let visibleUsageWrite: Promise<Set<UsageProviderKey>> = Promise.resolve(new Set())
+
+export function setUsageProviderVisible(
+  id: UsageProviderKey,
+  value: boolean
+): Promise<Set<UsageProviderKey>> {
+  visibleUsageWrite = visibleUsageWrite
+    .catch(() => undefined)
+    .then(async () => {
+      // Strict read: if the read fails, abort the write rather than clobber the
+      // stored set with the default (which would drop stored-only providers).
+      const next = await readVisibleUsageProviders()
+      if (value) {
+        next.add(id)
+      } else {
+        next.delete(id)
+      }
+      await saveVisibleUsageProviders(next)
+      return next
+    })
+  return visibleUsageWrite
+}
+
+// Read after any in-flight toggle settles, so a screen that re-mounts right
+// after a toggle sees the just-written value instead of a pre-write snapshot.
+export function loadVisibleUsageProvidersSettled(): Promise<Set<UsageProviderKey>> {
+  return visibleUsageWrite.catch(() => undefined).then(() => loadVisibleUsageProviders())
 }

--- a/mobile/src/storage/preferences.ts
+++ b/mobile/src/storage/preferences.ts
@@ -312,8 +312,15 @@ export function setUsageProviderVisible(
   return visibleUsageWrite
 }
 
-// Read after any in-flight toggle settles, so a screen that re-mounts right
-// after a toggle sees the just-written value instead of a pre-write snapshot.
-export function loadVisibleUsageProvidersSettled(): Promise<Set<UsageProviderKey>> {
-  return visibleUsageWrite.catch(() => undefined).then(() => loadVisibleUsageProviders())
+// Why: retry if a toggle is appended while the stored read is in flight, so
+// rollback/focus reloads cannot overwrite newer optimistic state.
+export async function loadVisibleUsageProvidersSettled(): Promise<Set<UsageProviderKey>> {
+  while (true) {
+    const pending = visibleUsageWrite
+    await pending.catch(() => undefined)
+    const stored = await loadVisibleUsageProviders()
+    if (pending === visibleUsageWrite) {
+      return stored
+    }
+  }
 }

--- a/mobile/src/storage/preferences.ts
+++ b/mobile/src/storage/preferences.ts
@@ -287,11 +287,8 @@ export async function saveVisibleUsageProviders(ids: ReadonlySet<UsageProviderKe
   )
 }
 
-// Serialize toggles so two fast switches can't lose each other through a
-// read-modify-write race on the same key: each toggle re-reads the latest
-// stored set and changes only its own provider, so it never clobbers a
-// provider it didn't touch. ponytail: a module-level chain is enough for the
-// single settings screen; revisit if more writers appear.
+// Why: serialize the settings screen's read-modify-write toggles so rapid
+// changes cannot overwrite a provider that another toggle just persisted.
 let visibleUsageWrite: Promise<Set<UsageProviderKey>> = Promise.resolve(new Set())
 
 export function setUsageProviderVisible(

--- a/mobile/src/storage/preferences.ts
+++ b/mobile/src/storage/preferences.ts
@@ -1,4 +1,9 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
+import {
+  DEFAULT_VISIBLE_USAGE_PROVIDERS,
+  USAGE_PROVIDER_IDS,
+  type UsageProviderKey
+} from '../components/account-usage-state'
 
 const PINS_PREFIX = 'orca:pins:'
 const NOTIF_KEY = 'orca:pushNotificationsEnabled'
@@ -230,4 +235,39 @@ export async function loadPinnedIds(hostId: string): Promise<Set<string>> {
 
 export async function savePinnedIds(hostId: string, ids: Set<string>): Promise<void> {
   await AsyncStorage.setItem(PINS_PREFIX + hostId, JSON.stringify([...ids]))
+}
+
+const VISIBLE_USAGE_PROVIDERS_KEY = 'orca:visibleUsageProviders'
+
+// Why: intersect stored ids with the known descriptor ids so a removed,
+// misspelled, or future id can't linger in the set or silently re-enable a
+// provider after an id is reused. An explicit empty set is a valid "show none".
+function knownVisibleUsageProviders(ids: string[]): UsageProviderKey[] {
+  return USAGE_PROVIDER_IDS.filter((id) => ids.includes(id))
+}
+
+export async function loadVisibleUsageProviders(): Promise<Set<UsageProviderKey>> {
+  try {
+    const raw = await AsyncStorage.getItem(VISIBLE_USAGE_PROVIDERS_KEY)
+    if (raw === null) {
+      return new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
+    }
+    const parsed: unknown = JSON.parse(raw)
+    // Only a real array carries the "explicit empty set = show none" semantics;
+    // corrupted non-array JSON (e.g. `{}`) falls back to the default instead.
+    if (!Array.isArray(parsed)) {
+      return new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
+    }
+    return new Set(knownVisibleUsageProviders(stringArray(parsed)))
+  } catch {
+    return new Set(DEFAULT_VISIBLE_USAGE_PROVIDERS)
+  }
+}
+
+export async function saveVisibleUsageProviders(ids: ReadonlySet<UsageProviderKey>): Promise<void> {
+  // Persist in canonical descriptor order so the stored value is stable.
+  await AsyncStorage.setItem(
+    VISIBLE_USAGE_PROVIDERS_KEY,
+    JSON.stringify(USAGE_PROVIDER_IDS.filter((id) => ids.has(id)))
+  )
 }


### PR DESCRIPTION
## Summary

Continues and supersedes #8571 by @audichuang.

- Preserves the original author's three commits and authorship, then resolves the current `main` conflicts on top.
- Gives mobile the same eight usage providers exposed by desktop: Claude, Codex, Gemini, Antigravity, OpenCode Go, Kimi, MiniMax, and Grok.
- Adds Settings → Account usage switches. Claude and Codex remain enabled by default; the persisted selection controls both Home and each host's Accounts screen.
- Keeps Claude/Codex account switching unchanged. The other six providers are display-only and render their actual named buckets or session/weekly/monthly windows, including reset countdowns on the detailed Accounts screen.
- Handles legacy cached snapshots, rapid/concurrent preference writes, failed writes, focus reloads, loading/error/stale data, and non-finite percentages safely.

## Screenshots

Mobile viewport (390 × 844), showing the default Claude + Codex selection and all eight provider controls:

![Mobile Account usage settings showing all eight providers](https://raw.githubusercontent.com/bbingz/orca/0aee211170b50d08be5c29052d84c6f6cff5b1c2/mobile-provider-usage-settings.png)

## Testing

- [x] `corepack pnpm@10.24.0 --dir mobile lint`
- [x] `corepack pnpm@10.24.0 --dir mobile typecheck`
- [x] `corepack pnpm@10.24.0 --dir mobile test` — 290 files passed; 2080 tests passed, 2 skipped
- [x] `CI=true corepack pnpm@10.24.0 --dir mobile exec expo export --platform web`
- [x] Added regression coverage for all provider mappings, Antigravity/legacy snapshots, dynamic windows and reset labels, Home/Accounts visibility, focus/write races, settings accessibility, persistence failures, and display-only Accounts rendering
- [x] Playwright mobile-web smoke at 390 × 844: all eight switches exposed with stable accessible names; Antigravity persisted across reload; no feature console errors
- [ ] Root `pnpm build` — not run; this is mobile-only, and the mobile production export above is the relevant build gate
- [ ] Native iOS/Android visual smoke — no installed simulator/emulator was available on this host

## AI Review Report

Claude Opus (`claude-opus-4-8`) reviewed the full `origin/main..HEAD` diff after the latest `main` merge and returned **Ready to merge: Yes** with no Critical or Important findings.

Earlier review rounds caught or prompted verification of focus-refresh coverage, dynamic bucket + weekly/monthly coexistence, the preference write/return race, Accounts display-only render coverage, and non-finite usage handling. Those items were fixed or adjudicated against source and covered by tests before the final approval.

Cross-platform review found no new shortcut, label, filesystem-path, shell, or Electron platform behavior. The UI uses React Native primitives and existing theme tokens. Remote/SSH hosts use the existing host-scoped `accounts.list` / `accounts.subscribe` RPC; current `main` was verified to send the full eight-provider `RateLimitState`.

## Security Audit

- No dependencies, command execution, shell input, path handling, auth flows, IPC methods, or secret storage were added.
- Preference input is restricted to the canonical provider allowlist; unknown/stale IDs are discarded.
- Existing account-selection RPC remains statically limited to Claude and Codex; display-only providers cannot route to account switching.
- Usage snapshots contain the same account/rate-limit metadata already exposed by the existing Accounts RPC. No tokens or credentials are added to the payload.

## Notes

- Original #8571 commits retained unchanged:
  - `0745110e09` by @audichuang
  - `03924e168e` by @audichuang
  - `263c4c2301` by @audichuang
- This PR intentionally references rather than closes #8571 so maintainers can choose how to retire the stale draft.

## ELI5

Mobile can show the same set of usage providers as desktop, with settings toggles for which ones appear. You control visibility on Home and each host's Accounts screen.
