### PR TITLE
fix(relay): make mobile recovery self-healing

### DIFF
--- a/mobile/src/transport/host-store.test.ts
+++ b/mobile/src/transport/host-store.test.ts
@@ -39,6 +39,7 @@ import {
   removeHost,
   resolvePairingHostIdentity,
   resetHostStoreForTests,
+  runHostCredentialWriteForExistingHost,
   saveHost,
   saveExistingHostRelayUpgrade,
   updateHostNameAndEndpoint,
@@ -231,6 +232,86 @@ describe('host-store list mutations', () => {
 
     expect(JSON.parse(storedHostsRaw)).toEqual([HOST_TWO])
     expect(secureStoreMock.setItemAsync).not.toHaveBeenCalled()
+  })
+
+  it('serializes guarded relay secret writes ahead of host removal', async () => {
+    let releaseWrite!: () => void
+    let markWriteStarted!: () => void
+    const writeStarted = new Promise<void>((resolve) => {
+      markWriteStarted = resolve
+    })
+    const guardedWrite = runHostCredentialWriteForExistingHost(HOST_ONE.id, async () => {
+      markWriteStarted()
+      await new Promise<void>((resolve) => (releaseWrite = resolve))
+    })
+    await writeStarted
+
+    const removal = removeHost(HOST_ONE.id)
+    await Promise.resolve()
+    expect(JSON.parse(storedHostsRaw)).toContainEqual(HOST_ONE)
+
+    releaseWrite()
+    await Promise.all([guardedWrite, removal])
+
+    expect(JSON.parse(storedHostsRaw)).toEqual([HOST_TWO])
+    expect(scheduleCleanupMock).toHaveBeenCalledWith(HOST_ONE.id, expect.any(Function))
+  })
+
+  it('blocks guarded relay secret writes after host removal', async () => {
+    await removeHost(HOST_ONE.id)
+
+    const writeCredential = vi.fn(async () => {})
+    await expect(
+      runHostCredentialWriteForExistingHost(HOST_ONE.id, writeCredential)
+    ).rejects.toBeInstanceOf(MobileRelayUpgradeHostRemovedError)
+    expect(writeCredential).not.toHaveBeenCalled()
+  })
+
+  it('keeps relay host persistence ordered ahead of concurrent removal', async () => {
+    let releaseTokenWrite!: () => void
+    let markTokenWriteStarted!: () => void
+    const tokenWriteStarted = new Promise<void>((resolve) => {
+      markTokenWriteStarted = resolve
+    })
+    secureStoreMock.setItemAsync.mockImplementationOnce(async () => {
+      markTokenWriteStarted()
+      await new Promise<void>((resolve) => (releaseTokenWrite = resolve))
+    })
+    const relay = {
+      v: 1 as const,
+      directorUrl: 'https://relay.onorca.dev',
+      cellUrl: 'https://relay-c1.onorca.dev',
+      assignmentEpoch: 7,
+      relayHostId: 'AbCdEf0123_-xyZ9',
+      e2eeFraming: 2 as const
+    }
+    const saving = saveExistingHostRelayUpgrade({
+      ...HOST_ONE,
+      deviceToken: 'replacement-token',
+      endpoints: [
+        { id: 'direct-primary', kind: 'lan', url: HOST_ONE.endpoint },
+        {
+          id: 'relay-primary',
+          kind: 'relay',
+          url: `wss://relay-c1.onorca.dev/v1/connect/${relay.relayHostId}`
+        }
+      ],
+      relayHostId: relay.relayHostId,
+      relay
+    })
+    await tokenWriteStarted
+
+    const removal = removeHost(HOST_ONE.id)
+    const removedBeforeRelease = await Promise.race([
+      removal.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 10))
+    ])
+    releaseTokenWrite()
+    await Promise.all([saving, removal])
+
+    expect(removedBeforeRelease).toBe(false)
+    expect(JSON.parse(storedHostsRaw)).toEqual([HOST_TWO])
+    expect(JSON.parse(storedOverlayRaw!)).toEqual([])
   })
 
   it('awaits cleanup scheduling after metadata commit', async () => {

--- a/mobile/src/transport/host-store.ts
+++ b/mobile/src/transport/host-store.ts
@@ -21,6 +21,14 @@ import {
 import { deleteMobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
 import { deleteMobileRelayDirectUpgradeJournal } from './mobile-relay-direct-upgrade-journal'
 import { scheduleOrphanedMobileRelayCleanup } from './mobile-relay-orphan-cleanup'
+import { SerializedOperationQueue } from './serialized-operation-queue'
+import {
+  MobileRelayUpgradeHostRemovedError,
+  prepareStoredHostPersistence,
+  toStoredHostProfile
+} from './stored-host-profile'
+
+export { MobileRelayUpgradeHostRemovedError } from './stored-host-profile'
 
 const STORAGE_KEY = 'orca:hosts'
 // Why: SecureStore keys must match [A-Za-z0-9._-]; colons are rejected.
@@ -88,7 +96,7 @@ let inflightLoad: Promise<HostProfile[]> | null = null
 // Why: rename / lastConnected / remove / save all RMW the same hosts JSON.
 // Without a queue, concurrent writers re-read a stale snapshot and the last
 // setItem wins — resurrecting a removed host or dropping a rename.
-let hostListMutation: Promise<void> = Promise.resolve()
+const hostListMutation = new SerializedOperationQueue()
 
 function parseStoredHosts(raw: string | null): StoredHostProfile[] | null {
   if (!raw) {
@@ -117,7 +125,7 @@ function parseStoredHosts(raw: string | null): StoredHostProfile[] | null {
 export async function loadHosts(): Promise<HostProfile[]> {
   // Why: writers hold the mutation chain across their full RMW; wait so a
   // load right after rename/remove does not race a half-written list.
-  await hostListMutation
+  await hostListMutation.wait()
   // Why: deduplicate concurrent loadHosts() calls so multiple screens
   // mounting simultaneously share one Keychain read pass.
   if (inflightLoad) {
@@ -189,7 +197,7 @@ export async function resolvePairingHostIdentity(
 ): Promise<{ id: string; name: string }> {
   // Why: one durable read both preserves an existing identity and names a new host,
   // avoiding duplicate cards and a second serial storage read before connecting.
-  await hostListMutation
+  await hostListMutation.wait()
   const hosts = await readStoredHostsForMutation()
   const match = hosts.find((host) => host.publicKeyB64 === publicKeyB64)
   return match
@@ -217,26 +225,27 @@ async function readStoredHostsForMutation(): Promise<StoredHostProfile[]> {
 async function mutateStoredHosts(
   update: (hosts: StoredHostProfile[]) => StoredHostProfile[]
 ): Promise<void> {
-  const mutation = hostListMutation.then(async () => {
+  return hostListMutation.run(async () => {
     const current = await readStoredHostsForMutation()
     const next = update(current)
     await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next))
   })
-  hostListMutation = mutation.catch(() => {})
-  return mutation
 }
 
-function toStored(host: HostProfile): StoredHostProfile {
-  return {
-    id: host.id,
-    name: host.name,
-    endpoint: host.endpoint,
-    publicKeyB64: host.publicKeyB64,
-    lastConnected: host.lastConnected
-  }
+export function runHostCredentialWriteForExistingHost(
+  hostId: string,
+  writeCredential: () => Promise<void>
+): Promise<void> {
+  // Why: serialize secret writes with host removal. Either the write commits
+  // first and removal cleans it, or removal commits first and blocks the write.
+  return hostListMutation.run(async () => {
+    const hosts = await readStoredHostsForMutation()
+    if (!hosts.some(({ id }) => id === hostId)) {
+      throw new MobileRelayUpgradeHostRemovedError('mobile relay host was removed')
+    }
+    await writeCredential()
+  })
 }
-
-export class MobileRelayUpgradeHostRemovedError extends Error {}
 
 export async function saveHost(host: HostProfile): Promise<void> {
   await persistHost(host, false)
@@ -248,63 +257,43 @@ export async function saveExistingHostRelayUpgrade(host: HostProfile): Promise<v
 
 async function persistHost(host: HostProfile, requireExisting: boolean): Promise<void> {
   const validated = HostProfileSchema.parse(host)
-  const stored = toStored(validated)
-  const duplicateHostIds = new Set<string>()
-  let updatedExistingHost = false
-  await mutateStoredHosts((hosts) => {
-    const index = hosts.findIndex((h) => h.id === stored.id)
-    for (const candidate of hosts) {
-      if (candidate.id !== stored.id && candidate.publicKeyB64 === stored.publicKeyB64) {
-        duplicateHostIds.add(candidate.id)
+  const stored = toStoredHostProfile(validated)
+  await hostListMutation.run(async () => {
+    const prepared = prepareStoredHostPersistence(
+      await readStoredHostsForMutation(),
+      stored,
+      requireExisting
+    )
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(prepared.hosts))
+    // Why: hold the removal queue through token and overlay publication so a
+    // later removal always cleans every secret written by this save.
+    await writeDeviceToken(stored.id, validated.deviceToken)
+    tokenCache.set(stored.id, validated.deviceToken)
+    if (validated.endpoints) {
+      await saveMobileRelayHostOverlay({
+        v: 2,
+        hostId: stored.id,
+        endpoints: validated.endpoints,
+        relayHostId: validated.relayHostId,
+        relay: validated.relay
+      })
+    }
+    const overlayRemovalIds = [...prepared.duplicateHostIds]
+    if (!validated.endpoints && prepared.updatedExistingHost) {
+      overlayRemovalIds.push(stored.id)
+    }
+    if (overlayRemovalIds.length > 0) {
+      await removeMobileRelayHostOverlays(overlayRemovalIds)
+    }
+    for (const duplicateHostId of prepared.duplicateHostIds) {
+      tokenCache.delete(duplicateHostId)
+      try {
+        await scheduleHostCredentialCleanup(duplicateHostId, deleteHostCredentials)
+      } catch {
+        // Metadata is deduplicated; orphan-token recovery is best-effort.
       }
     }
-    if (index >= 0) {
-      updatedExistingHost = true
-      // Why: affected installs may already contain duplicate rows; an authoritative
-      // save is the safe point to collapse them to the preserved host id.
-      return hosts
-        .filter(({ id }) => !duplicateHostIds.has(id))
-        .map((candidate) => (candidate.id === stored.id ? stored : candidate))
-    }
-    if (requireExisting) {
-      // Why: an in-flight relay upgrade must not resurrect a host the user removed.
-      throw new MobileRelayUpgradeHostRemovedError('mobile relay upgrade host was removed')
-    }
-    return [...hosts.filter(({ id }) => !duplicateHostIds.has(id)), stored]
   })
-  // Why: write metadata BEFORE the keychain token so a crash between the two
-  // leaves orphaned metadata (which loadHosts skips and removeHost can clean
-  // up) rather than an orphaned keychain token with no metadata pointer —
-  // the latter would persist forever since removeHost only deletes by hostId
-  // from current metadata.
-  await writeDeviceToken(stored.id, validated.deviceToken)
-  tokenCache.set(stored.id, validated.deviceToken)
-  if (validated.endpoints) {
-    await saveMobileRelayHostOverlay({
-      v: 2,
-      hostId: stored.id,
-      endpoints: validated.endpoints,
-      relayHostId: validated.relayHostId,
-      relay: validated.relay
-    })
-  }
-  const overlayRemovalIds = [...duplicateHostIds]
-  if (!validated.endpoints && updatedExistingHost) {
-    overlayRemovalIds.push(stored.id)
-  }
-  if (overlayRemovalIds.length > 0) {
-    // Why: reusing an id for direct-only re-pairing must not retain routing
-    // metadata from the host's previous transport state.
-    await removeMobileRelayHostOverlays(overlayRemovalIds)
-  }
-  for (const duplicateHostId of duplicateHostIds) {
-    tokenCache.delete(duplicateHostId)
-    try {
-      await scheduleHostCredentialCleanup(duplicateHostId, deleteHostCredentials)
-    } catch {
-      // Metadata is already deduplicated; orphan-token recovery is best-effort.
-    }
-  }
 }
 
 export async function removeHost(hostId: string): Promise<void> {
@@ -376,7 +365,7 @@ export async function updateLastConnected(hostId: string): Promise<void> {
 
 /** Test-only: drain module mutation chain between cases. */
 export function resetHostStoreForTests(): void {
-  hostListMutation = Promise.resolve()
+  hostListMutation.reset()
   tokenCache.clear()
   inflightLoad = null
 }

--- a/mobile/src/transport/mobile-direct-probe-operation.ts
+++ b/mobile/src/transport/mobile-direct-probe-operation.ts
@@ -1,0 +1,57 @@
+import { openAuthenticatedDirectEndpoint } from './mobile-direct-endpoint-probe'
+import type { MobileEndpointHysteresis } from './mobile-endpoint-hysteresis'
+import type { MobileRelayCredentialRecovery } from './mobile-relay-credential-recovery'
+import type { MobileRelayRecoveryTimer } from './mobile-relay-recovery-timer'
+import type { RpcClient } from './rpc-client'
+import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
+import type { HostProfile } from './types'
+
+export async function runMobileDirectProbe(args: {
+  logical: StableLogicalRpcClient
+  host: HostProfile
+  openDirect: (endpoint: string) => RpcClient
+  hysteresis: MobileEndpointHysteresis
+  recovery: MobileRelayCredentialRecovery
+  recoveryTimer: MobileRelayRecoveryTimer
+  leaseTimer: MobileRelayRecoveryTimer
+  now: () => number
+  isStopped: () => boolean
+  isForeground: () => boolean
+  clearRelayRotation: () => void
+  retryCredentialRepair: () => void
+}): Promise<void> {
+  let successful: Awaited<ReturnType<typeof openAuthenticatedDirectEndpoint>> = null
+  try {
+    successful = await openAuthenticatedDirectEndpoint(args.host, args.openDirect, 12_000)
+    if (!successful || args.isStopped() || !args.isForeground()) {
+      if (!successful) {
+        args.hysteresis.recordDirectFailure(args.now())
+      }
+      return
+    }
+    if (!args.hysteresis.recordDirectSuccess(args.now())) {
+      successful.client.close()
+      return
+    }
+    await args.logical.migrateTo(successful.client, successful.path)
+    successful = null
+    if (!args.isForeground()) {
+      args.logical.suspendActiveSession()
+      return
+    }
+    args.hysteresis.recordMigration(args.now())
+    args.recoveryTimer.clear()
+    args.leaseTimer.clear()
+    args.clearRelayRotation()
+    if (args.recovery.needsRepair) {
+      const outcome = await args.recovery.reprovision(args.logical)
+      if (outcome === 'deferred') {
+        args.recoveryTimer.scheduleIfIdle(5000, args.retryCredentialRepair)
+      }
+    } else {
+      await args.recovery.rotateIfNeeded(args.logical)
+    }
+  } finally {
+    successful?.client.close()
+  }
+}

--- a/mobile/src/transport/mobile-endpoint-hysteresis.ts
+++ b/mobile/src/transport/mobile-endpoint-hysteresis.ts
@@ -5,6 +5,15 @@ export type EndpointHysteresisOptions = {
   minimumDwellMs: number
 }
 
+export function createMobileEndpointHysteresis(startedAt: number): MobileEndpointHysteresis {
+  return new MobileEndpointHysteresis(startedAt, {
+    directSuccessesRequired: 3,
+    directObservationMs: 30_000,
+    failureCooldownMs: 60_000,
+    minimumDwellMs: 60_000
+  })
+}
+
 export class MobileEndpointHysteresis {
   private consecutiveDirectSuccesses = 0
   private directObservationStartedAt: number | null = null

--- a/mobile/src/transport/mobile-endpoint-lifecycle.ts
+++ b/mobile/src/transport/mobile-endpoint-lifecycle.ts
@@ -5,11 +5,13 @@ import { MobileEndpointSupervisor } from './mobile-endpoint-supervisor'
 import { connectMobileRelayRpcSession } from './mobile-relay-rpc-session'
 import { resolveMobileRelayEndpoint } from './mobile-relay-resume-director'
 import {
-  readMobileRelayCredentialBundle,
-  writeMobileRelayCredentialBundle
+  deleteMobileRelayCredentialBundle,
+  readMobileRelayCredentialBundle
 } from './mobile-relay-credential-bundle'
-import { saveHost } from './host-store'
+import { saveExistingHostRelayUpgrade } from './host-store'
+import { writeMobileRelayCredentialBundleForExistingHost } from './mobile-relay-existing-host-credential-writer'
 import { upgradeDirectMobileRelay } from './mobile-relay-direct-upgrade'
+import { reprovisionExistingMobileRelayCredential } from './mobile-relay-direct-upgrade'
 import { MobileRelayDirectUpgradeController } from './mobile-relay-direct-upgrade-controller'
 import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
 
@@ -88,8 +90,12 @@ function createSupervisor(
       }),
     resolveRelay: resolveMobileRelayEndpoint,
     readBundle: readMobileRelayCredentialBundle,
-    writeBundle: writeMobileRelayCredentialBundle,
-    saveHost,
+    writeBundle: writeMobileRelayCredentialBundleForExistingHost,
+    deleteBundle: deleteMobileRelayCredentialBundle,
+    reprovisionRelay: (client, currentHost) =>
+      reprovisionExistingMobileRelayCredential({ client, host: currentHost }),
+    saveHost: saveExistingHostRelayUpgrade,
+    onLog,
     now: Date.now,
     randomBytes: ExpoCrypto.getRandomBytes,
     setTimer: setTimeout,

--- a/mobile/src/transport/mobile-endpoint-supervisor-dependencies.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor-dependencies.ts
@@ -1,0 +1,17 @@
+import type { MobileRelayEndpoint } from '../../../src/shared/mobile-relay-credential-contract'
+import type { MobileRelayCredentialRecoveryDependencies } from './mobile-relay-credential-recovery'
+import type { MobileRelayRpcSession } from './mobile-relay-rpc-session'
+import { resolveMobileRelayEndpoint } from './mobile-relay-resume-director'
+import type { RpcClient } from './rpc-client'
+
+export type MobileEndpointSupervisorDependencies = MobileRelayCredentialRecoveryDependencies & {
+  openDirect: (endpoint: string) => RpcClient
+  openRelay: (
+    relay: MobileRelayEndpoint,
+    credential: { token: string; version: number },
+    confirmReqId: string
+  ) => MobileRelayRpcSession
+  resolveRelay: typeof resolveMobileRelayEndpoint
+  setTimer: typeof setTimeout
+  clearTimer: typeof clearTimeout
+}

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -191,6 +191,26 @@ describe('mobile endpoint supervisor', () => {
     supervisor.stop()
   })
 
+  it('retries relay recovery while the foreground direct client remains reconnecting', async () => {
+    const logical = new FakeLogicalClient('reconnecting', 'lan')
+    const openRelay = vi
+      .fn()
+      .mockReturnValueOnce(new FakeRelaySession('disconnected', new Error('relay unavailable')))
+      .mockReturnValueOnce(new FakeRelaySession('disconnected', new Error('relay unavailable')))
+      .mockReturnValueOnce(new FakeRelaySession('connected'))
+    const deps = dependencies({ openRelay })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    expect(logical.getActivePath()).toBe('lan')
+
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    expect(openRelay).toHaveBeenCalledTimes(3)
+    expect(logical.getActivePath()).toBe('relay')
+    supervisor.stop()
+  })
+
   it('uses POST resolve for wrong-cell recovery and persists the authoritative target', async () => {
     const logical = new FakeLogicalClient('disconnected', 'lan')
     const openRelay = vi

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
+import { hashMobileRelayCredential } from './mobile-relay-credential-hash'
 import { RelayOuterError } from './mobile-relay-e2ee-link'
 import type { MobileRelayRpcSession } from './mobile-relay-rpc-session'
 import {
@@ -83,6 +84,7 @@ class FakeLogicalClient extends FakeSession implements StableLogicalRpcClient {
     }
     this.path = path
     this.generation += 1
+    this.publishState('connected')
   })
   suspendActiveSession = vi.fn(() => this.publishState('disconnected'))
   getActivePath = () => this.path
@@ -132,7 +134,10 @@ function dependencies(
     resolveRelay: vi.fn(async ({ relay }) => relay),
     readBundle: vi.fn(async () => bundle),
     writeBundle: vi.fn(async () => {}),
+    deleteBundle: vi.fn(async () => {}),
+    reprovisionRelay: vi.fn(async () => ({ host, bundle })),
     saveHost: vi.fn(async () => {}),
+    onLog: vi.fn(),
     now: Date.now,
     randomBytes: (length) => new Uint8Array(length).fill(1),
     setTimer: setTimeout,
@@ -163,6 +168,321 @@ describe('mobile endpoint supervisor', () => {
     expect(deps.writeBundle).toHaveBeenCalledWith(
       expect.objectContaining({ current: expect.objectContaining({ version: 2 }) })
     )
+    supervisor.stop()
+  })
+
+  it('waits for stored credentials before reacting to an early foreground signal', async () => {
+    const logical = new FakeLogicalClient('connected', 'lan')
+    let finishRead!: (value: MobileRelayCredentialBundle) => void
+    const readBundle = vi.fn(
+      () =>
+        new Promise<MobileRelayCredentialBundle>((resolve) => {
+          finishRead = resolve
+        })
+    )
+    const deps = dependencies({ readBundle })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    const starting = supervisor.start()
+    supervisor.setForeground(true)
+    await Promise.resolve()
+
+    expect(deps.reprovisionRelay).not.toHaveBeenCalled()
+    expect(deps.openRelay).not.toHaveBeenCalled()
+    finishRead(bundle)
+    await starting
+
+    expect(deps.reprovisionRelay).not.toHaveBeenCalled()
+    expect(deps.onLog).not.toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Relay credential unavailable' })
+    )
+    supervisor.stop()
+  })
+
+  it('reprovisions a missing relay credential after authenticated direct startup', async () => {
+    const logical = new FakeLogicalClient('connected', 'lan')
+    const reprovisionRelay = vi.fn(async () => ({ host, bundle }))
+    const deps = dependencies({
+      readBundle: vi.fn(async () => null),
+      reprovisionRelay
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+
+    expect(reprovisionRelay).toHaveBeenCalledWith(logical, host)
+    logical.publishState('reconnecting')
+    await vi.waitFor(() => expect(logical.getActivePath()).toBe('relay'))
+    expect(deps.onLog).toHaveBeenCalledWith(
+      expect.objectContaining({ level: 'success', message: 'Relay credential restored' })
+    )
+    supervisor.stop()
+  })
+
+  it('reprovisions when every stored relay credential is expired', async () => {
+    const logical = new FakeLogicalClient('connected', 'lan')
+    const expired = {
+      ...bundle,
+      current: { ...bundle.current, expiresAt: Date.now() - 1 }
+    }
+    const reprovisionRelay = vi.fn(async () => ({ host, bundle }))
+    const deps = dependencies({
+      readBundle: vi.fn(async () => expired),
+      reprovisionRelay
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+
+    expect(reprovisionRelay).toHaveBeenCalledOnce()
+    expect(deps.onLog).toHaveBeenCalledWith(
+      expect.objectContaining({ level: 'warn', message: 'Relay credential unavailable' })
+    )
+    supervisor.stop()
+  })
+
+  it('disables a rejected relay credential and restores it on the next direct connection', async () => {
+    const logical = new FakeLogicalClient('reconnecting', 'lan')
+    const openRelay = vi.fn(() => new FakeRelaySession('disconnected', new RelayOuterError(4401)))
+    const reprovisionRelay = vi.fn(async () => ({ host, bundle }))
+    const deps = dependencies({ openRelay, reprovisionRelay })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    logical.publishState('connected')
+    await vi.waitFor(() => expect(reprovisionRelay).toHaveBeenCalledOnce())
+    await vi.advanceTimersByTimeAsync(15_000)
+
+    expect(openRelay).toHaveBeenCalledOnce()
+    expect(deps.onLog).toHaveBeenCalledWith(
+      expect.objectContaining({ level: 'error', message: 'Relay credential rejected' })
+    )
+    const renderedLogs = JSON.stringify((deps.onLog as ReturnType<typeof vi.fn>).mock.calls)
+    expect(renderedLogs).not.toContain(bundle.current.token)
+    expect(renderedLogs).not.toContain(bundle.current.hash)
+    expect(renderedLogs).not.toContain(bundle.deviceToken)
+    supervisor.stop()
+  })
+
+  it('retries a usable grace credential after current is rejected and grace briefly fails', async () => {
+    const logical = new FakeLogicalClient('reconnecting', 'lan')
+    const bundleWithGrace: MobileRelayCredentialBundle = {
+      ...bundle,
+      grace: {
+        token: 'C'.repeat(43),
+        hash: 'D'.repeat(43),
+        version: 1,
+        expiresAt: Number.MAX_SAFE_INTEGER
+      }
+    }
+    let graceAttempts = 0
+    const openRelay = vi.fn((_relay, credential: { token: string; version: number }) => {
+      if (credential.version === bundle.current.version) {
+        return new FakeRelaySession('disconnected', new RelayOuterError(4401))
+      }
+      graceAttempts += 1
+      return graceAttempts === 1
+        ? new FakeRelaySession('disconnected', new RelayOuterError(4408))
+        : new FakeRelaySession('connected')
+    })
+    const deps = dependencies({
+      readBundle: vi.fn(async () => bundleWithGrace),
+      openRelay
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    expect(openRelay).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(4_999)
+    expect(openRelay).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(1)
+
+    expect(openRelay).toHaveBeenCalledTimes(3)
+    expect(openRelay.mock.calls.map((call) => call[1].version)).toEqual([2, 1, 1])
+    expect(logical.getActivePath()).toBe('relay')
+    supervisor.stop()
+  })
+
+  it('recovers relay when direct disconnects while credential reprovision is in flight', async () => {
+    const logical = new FakeLogicalClient('connected', 'lan')
+    let finishReprovision!: (result: {
+      host: HostProfile
+      bundle: MobileRelayCredentialBundle
+    }) => void
+    const reprovisionRelay = vi.fn(
+      () =>
+        new Promise<{ host: HostProfile; bundle: MobileRelayCredentialBundle }>((resolve) => {
+          finishReprovision = resolve
+        })
+    )
+    const deps = dependencies({
+      readBundle: vi.fn(async () => null),
+      reprovisionRelay
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    const starting = supervisor.start()
+    await vi.waitFor(() => expect(reprovisionRelay).toHaveBeenCalledOnce())
+    logical.publishState('reconnecting')
+    finishReprovision({ host, bundle })
+    await starting
+    await vi.waitFor(() => expect(logical.getActivePath()).toBe('relay'))
+
+    expect(deps.openRelay).toHaveBeenCalledOnce()
+    supervisor.stop()
+  })
+
+  it('retries transient credential reprovision failure while direct stays authenticated', async () => {
+    const logical = new FakeLogicalClient('connected', 'lan')
+    const reprovisionRelay = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('temporary direct RPC failure'))
+      .mockResolvedValueOnce({ host, bundle })
+    const deps = dependencies({
+      readBundle: vi.fn(async () => null),
+      reprovisionRelay
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    expect(reprovisionRelay).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(4_999)
+    expect(reprovisionRelay).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(1)
+
+    expect(reprovisionRelay).toHaveBeenCalledTimes(2)
+    expect(deps.openRelay).not.toHaveBeenCalled()
+    expect(deps.onLog).toHaveBeenCalledWith(
+      expect.objectContaining({ level: 'success', message: 'Relay credential restored' })
+    )
+    logical.publishState('reconnecting')
+    await vi.waitFor(() => expect(logical.getActivePath()).toBe('relay'))
+    supervisor.stop()
+  })
+
+  it('retries transient credential reprovision failure after relay migrates to direct', async () => {
+    const logical = new FakeLogicalClient('reconnecting', 'lan')
+    const bundleWithGrace: MobileRelayCredentialBundle = {
+      ...bundle,
+      grace: {
+        token: 'C'.repeat(43),
+        hash: 'D'.repeat(43),
+        version: 1,
+        expiresAt: Number.MAX_SAFE_INTEGER
+      }
+    }
+    const openRelay = vi.fn((_relay, credential: { token: string; version: number }) =>
+      credential.version === bundle.current.version
+        ? new FakeRelaySession('disconnected', new RelayOuterError(4401))
+        : new FakeRelaySession('connected')
+    )
+    const reprovisionRelay = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('temporary direct RPC failure'))
+      .mockResolvedValueOnce({ host, bundle })
+    const deps = dependencies({
+      readBundle: vi.fn(async () => bundleWithGrace),
+      openRelay,
+      reprovisionRelay
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(logical.getActivePath()).toBe('lan')
+    expect(reprovisionRelay).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(4_999)
+    expect(reprovisionRelay).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(1)
+
+    expect(reprovisionRelay).toHaveBeenCalledTimes(2)
+    supervisor.stop()
+  })
+
+  it('recovers relay when direct drops before a deferred credential retry', async () => {
+    const logical = new FakeLogicalClient('reconnecting', 'lan')
+    const bundleWithGrace: MobileRelayCredentialBundle = {
+      ...bundle,
+      grace: {
+        token: 'C'.repeat(43),
+        hash: 'D'.repeat(43),
+        version: 1,
+        expiresAt: Number.MAX_SAFE_INTEGER
+      }
+    }
+    let graceAttempts = 0
+    const openRelay = vi.fn((_relay, credential: { token: string; version: number }) => {
+      if (credential.version === bundle.current.version) {
+        return new FakeRelaySession('disconnected', new RelayOuterError(4401))
+      }
+      graceAttempts += 1
+      return graceAttempts === 2
+        ? new FakeRelaySession('disconnected', new RelayOuterError(4408))
+        : new FakeRelaySession('connected')
+    })
+    const deps = dependencies({
+      readBundle: vi.fn(async () => bundleWithGrace),
+      openRelay,
+      reprovisionRelay: vi.fn(async () => {
+        throw new Error('temporary direct RPC failure')
+      })
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(logical.getActivePath()).toBe('lan')
+
+    logical.publishState('disconnected')
+    await vi.waitFor(() => expect(openRelay).toHaveBeenCalledTimes(3))
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    expect(openRelay).toHaveBeenCalledTimes(4)
+    expect(logical.getActivePath()).toBe('relay')
+    supervisor.stop()
+  })
+
+  it('reprovisions when direct wins while an in-flight relay attempt is rejected', async () => {
+    const logical = new FakeLogicalClient('reconnecting', 'lan')
+    let rejectMigration!: () => void
+    logical.migrateTo = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectMigration = () => reject(new Error('replacement rejected'))
+        })
+    )
+    const token = 'E'.repeat(43)
+    const validBundle: MobileRelayCredentialBundle = {
+      ...bundle,
+      current: {
+        ...bundle.current,
+        token,
+        hash: hashMobileRelayCredential(token)
+      }
+    }
+    const openRelay = vi.fn(() => new FakeRelaySession('disconnected', new RelayOuterError(4401)))
+    const reprovisionRelay = vi.fn(async () => ({ host, bundle: validBundle }))
+    const deps = dependencies({
+      readBundle: vi.fn(async () => validBundle),
+      openRelay,
+      reprovisionRelay
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    const starting = supervisor.start()
+    await vi.waitFor(() => expect(openRelay).toHaveBeenCalledOnce())
+    logical.publishState('connected')
+    expect(reprovisionRelay).not.toHaveBeenCalled()
+    rejectMigration()
+    await starting
+    await vi.waitFor(() => expect(reprovisionRelay).toHaveBeenCalledOnce())
+
     supervisor.stop()
   })
 
@@ -208,6 +528,82 @@ describe('mobile endpoint supervisor', () => {
 
     expect(openRelay).toHaveBeenCalledTimes(3)
     expect(logical.getActivePath()).toBe('relay')
+    supervisor.stop()
+  })
+
+  it('retries a dropped relay before the previous lease rotation deadline', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const openRelay = vi
+      .fn()
+      .mockReturnValueOnce(new FakeRelaySession('connected'))
+      .mockReturnValueOnce(new FakeRelaySession('disconnected', new RelayOuterError(4408)))
+      .mockReturnValueOnce(new FakeRelaySession('connected'))
+    const deps = dependencies({ openRelay })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    expect(openRelay).toHaveBeenCalledOnce()
+
+    logical.publishState('reconnecting')
+    await vi.waitFor(() => expect(openRelay).toHaveBeenCalledTimes(2))
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    expect(openRelay).toHaveBeenCalledTimes(3)
+    supervisor.stop()
+  })
+
+  it('cancels an older forced retry after a newer relay recovery succeeds', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const openRelay = vi
+      .fn()
+      .mockReturnValueOnce(new FakeRelaySession('connected', null, Date.now() + 31_000))
+      .mockReturnValueOnce(new FakeRelaySession('disconnected', new RelayOuterError(4408)))
+      .mockReturnValueOnce(new FakeRelaySession('connected'))
+      .mockReturnValueOnce(new FakeRelaySession('connected'))
+    const deps = dependencies({ openRelay })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(openRelay).toHaveBeenCalledTimes(2)
+
+    supervisor.setForeground(true)
+    await vi.waitFor(() => expect(openRelay).toHaveBeenCalledTimes(3))
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    expect(openRelay).toHaveBeenCalledTimes(3)
+    supervisor.stop()
+  })
+
+  it('recovers a relay disconnect that occurs while confirmation persistence is pending', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const migrate = logical.migrateTo
+    logical.migrateTo = vi.fn(async (session, path) => {
+      await migrate(session, path)
+      logical.publishState('connected')
+    })
+    let finishFirstWrite!: () => void
+    const writeBundle = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishFirstWrite = resolve
+          })
+      )
+      .mockResolvedValue(undefined)
+    const openRelay = vi.fn(() => new FakeRelaySession('connected'))
+    const deps = dependencies({ openRelay, writeBundle })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    const starting = supervisor.start()
+    await vi.waitFor(() => expect(writeBundle).toHaveBeenCalledOnce())
+    logical.publishState('disconnected')
+    finishFirstWrite()
+    await starting
+    await vi.waitFor(() => expect(openRelay).toHaveBeenCalledTimes(2))
+
+    expect(logical.getState()).toBe('connected')
     supervisor.stop()
   })
 
@@ -261,6 +657,85 @@ describe('mobile endpoint supervisor', () => {
     supervisor.setForeground(true)
     await vi.waitFor(() => expect(logical.migrateTo).toHaveBeenCalled())
     expect(logical.getActivePath()).toBe('relay')
+    supervisor.stop()
+  })
+
+  it('does not promote a direct probe that authenticates after the app backgrounds', async () => {
+    const logical = new FakeLogicalClient('connected', 'relay')
+    const pendingDirect = new FakeSession('connecting')
+    const openDirect = vi
+      .fn()
+      .mockReturnValueOnce(new FakeSession('connected'))
+      .mockReturnValueOnce(new FakeSession('connected'))
+      .mockReturnValueOnce(new FakeSession('connected'))
+      .mockReturnValueOnce(pendingDirect)
+    const deps = dependencies({ openDirect })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+    await supervisor.start()
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(openDirect).toHaveBeenCalledTimes(4)
+    expect(logical.migrateTo).not.toHaveBeenCalled()
+
+    supervisor.setForeground(false)
+    pendingDirect.publishState('connected')
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(logical.migrateTo).not.toHaveBeenCalled()
+    expect(pendingDirect.close).toHaveBeenCalledOnce()
+    supervisor.stop()
+  })
+
+  it('recovers a relay disconnect that occurs while a direct probe is pending', async () => {
+    const logical = new FakeLogicalClient('connected', 'relay')
+    const migrate = logical.migrateTo
+    logical.migrateTo = vi.fn(async (session, path) => {
+      await migrate(session, path)
+      logical.publishState('connected')
+    })
+    const pendingDirect = new FakeSession('connecting')
+    const openRelay = vi.fn(() => new FakeRelaySession('connected'))
+    const deps = dependencies({
+      openDirect: vi.fn(() => pendingDirect),
+      openRelay
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+    await supervisor.start()
+
+    await vi.advanceTimersByTimeAsync(15_000)
+    logical.publishState('disconnected')
+    pendingDirect.publishState('disconnected')
+    await vi.waitFor(() => expect(openRelay).toHaveBeenCalledOnce())
+
+    expect(logical.getState()).toBe('connected')
+    supervisor.stop()
+  })
+
+  it('resuspends a direct migration that finishes after the app backgrounds', async () => {
+    const logical = new FakeLogicalClient('connected', 'relay')
+    const migrate = logical.migrateTo
+    let releaseMigration!: () => void
+    logical.migrateTo = vi.fn(async (session, path) => {
+      await new Promise<void>((resolve) => {
+        releaseMigration = resolve
+      })
+      await migrate(session, path)
+    })
+    const deps = dependencies()
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+    await supervisor.start()
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    await vi.waitFor(() => expect(logical.migrateTo).toHaveBeenCalledOnce())
+
+    supervisor.setForeground(false)
+    expect(logical.suspendActiveSession).toHaveBeenCalledOnce()
+    releaseMigration()
+    await vi.waitFor(() => expect(logical.getActivePath()).toBe('lan'))
+
+    expect(logical.suspendActiveSession).toHaveBeenCalledTimes(2)
+    expect(logical.getState()).toBe('disconnected')
     supervisor.stop()
   })
 })

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -1,83 +1,68 @@
-import type { MobileRelayEndpoint } from '../../../src/shared/mobile-relay-credential-contract'
-import { openAuthenticatedDirectEndpoint } from './mobile-direct-endpoint-probe'
-import { MobileEndpointHysteresis } from './mobile-endpoint-hysteresis'
+import { runMobileDirectProbe } from './mobile-direct-probe-operation'
 import {
-  encodeBase64Url,
-  isDirectorResolutionFailure,
-  persistRelayHost,
-  toError
-} from './mobile-endpoint-supervisor-support'
+  createMobileEndpointHysteresis,
+  type MobileEndpointHysteresis
+} from './mobile-endpoint-hysteresis'
+import { MobileRelayCredentialRecovery } from './mobile-relay-credential-recovery'
+import type { MobileEndpointSupervisorDependencies } from './mobile-endpoint-supervisor-dependencies'
+import { MobileRelayRecoveryTimer } from './mobile-relay-recovery-timer'
+import { migrateMobileRelaySession } from './mobile-relay-session-migration'
 import {
-  applyResumeConfirmation,
-  mobileRelayCredentialNeedsRotation,
-  rotateMobileRelayCredential
-} from './mobile-relay-credential-rotation'
-import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
-import type { MobileRelayRpcSession } from './mobile-relay-rpc-session'
-import { resolveMobileRelayEndpoint } from './mobile-relay-resume-director'
-import type { RpcClient } from './rpc-client'
+  retryMobileRelayWithEndpointRefresh,
+  type MobileRelayAttemptResult
+} from './mobile-relay-endpoint-retry'
 import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
 import type { HostProfile } from './types'
 
-const DIRECT_PROBE_INTERVAL_MS = 15_000
-const DIRECT_OBSERVATION_MS = 30_000
-const MINIMUM_DWELL_MS = 60_000
-const FAILURE_COOLDOWN_MS = 60_000
-const LEASE_ROTATION_MARGIN_MS = 30_000
+export type { MobileEndpointSupervisorDependencies } from './mobile-endpoint-supervisor-dependencies'
 
-export type MobileEndpointSupervisorDependencies = {
-  openDirect: (endpoint: string) => RpcClient
-  openRelay: (
-    relay: MobileRelayEndpoint,
-    credential: { token: string; version: number },
-    confirmReqId: string
-  ) => MobileRelayRpcSession
-  resolveRelay: typeof resolveMobileRelayEndpoint
-  readBundle: (hostId: string) => Promise<MobileRelayCredentialBundle | null>
-  writeBundle: (bundle: MobileRelayCredentialBundle) => Promise<void>
-  saveHost: (host: HostProfile) => Promise<void>
-  now: () => number
-  randomBytes: (length: number) => Uint8Array
-  setTimer: typeof setTimeout
-  clearTimer: typeof clearTimeout
-}
+const DIRECT_PROBE_INTERVAL_MS = 15_000
+type RelayCredential = { token: string; version: number }
 
 export class MobileEndpointSupervisor {
-  private host: HostProfile
-  private bundle: MobileRelayCredentialBundle | null = null
   private stopped = false
+  private ready = false
   private foreground = true
   private operationInFlight = false
-  private credentialRotationInFlight = false
   private relayRotationPending = false
   private probeTimer: ReturnType<typeof setTimeout> | null = null
-  private leaseTimer: ReturnType<typeof setTimeout> | null = null
   private unsubscribeState: (() => void) | null = null
   private readonly hysteresis: MobileEndpointHysteresis
+  private readonly credentialRecovery: MobileRelayCredentialRecovery
+  private readonly recoveryTimer: MobileRelayRecoveryTimer
+  private readonly leaseTimer: MobileRelayRecoveryTimer
 
   constructor(
     private readonly logical: StableLogicalRpcClient,
     host: HostProfile,
     private readonly dependencies: MobileEndpointSupervisorDependencies
   ) {
-    this.host = host
-    this.hysteresis = new MobileEndpointHysteresis(dependencies.now(), {
-      directSuccessesRequired: 3,
-      directObservationMs: DIRECT_OBSERVATION_MS,
-      failureCooldownMs: FAILURE_COOLDOWN_MS,
-      minimumDwellMs: MINIMUM_DWELL_MS
-    })
+    this.credentialRecovery = new MobileRelayCredentialRecovery(host, dependencies)
+    this.recoveryTimer = new MobileRelayRecoveryTimer(
+      dependencies.setTimer,
+      dependencies.clearTimer
+    )
+    this.leaseTimer = new MobileRelayRecoveryTimer(dependencies.setTimer, dependencies.clearTimer)
+    this.hysteresis = createMobileEndpointHysteresis(dependencies.now())
   }
 
   async start(): Promise<void> {
-    this.bundle = await this.dependencies.readBundle(this.host.id).catch(() => null)
-    if (this.stopped || !this.bundle || !this.host.relay) {
+    await this.credentialRecovery.load()
+    if (this.stopped || !this.credentialRecovery.host.relay) {
       return
     }
+    this.ready = true
     this.unsubscribeState = this.logical.onStateChange((state) => {
+      if (!this.foreground) {
+        return
+      }
       if (state === 'connected') {
         if (this.logical.getActivePath() !== 'relay') {
-          void this.rotateCredentialIfNeeded()
+          if (this.credentialRecovery.needsAuthenticatedRepair) {
+            void this.reprovisionRelayCredentialIfPossible()
+          } else {
+            void this.credentialRecovery.rotateIfNeeded(this.logical)
+          }
         }
         this.scheduleDirectProbe()
       } else if (state === 'reconnecting' || state === 'disconnected' || state === 'auth-failed') {
@@ -85,6 +70,11 @@ export class MobileEndpointSupervisor {
         void this.recoverRelay()
       }
     })
+    if (!this.credentialRecovery.hasUsableCredential()) {
+      this.credentialRecovery.markUnavailable()
+      await this.reprovisionRelayCredentialIfPossible()
+      return
+    }
     const initialState = this.logical.getState()
     if (
       initialState === 'reconnecting' ||
@@ -93,6 +83,12 @@ export class MobileEndpointSupervisor {
     ) {
       // Why: the first direct dial may fail before encrypted relay credentials finish loading.
       await this.recoverRelay()
+    } else if (
+      this.foreground &&
+      initialState === 'connected' &&
+      this.logical.getActivePath() !== 'relay'
+    ) {
+      await this.credentialRecovery.rotateIfNeeded(this.logical)
     } else {
       this.scheduleDirectProbe()
     }
@@ -100,8 +96,19 @@ export class MobileEndpointSupervisor {
 
   setForeground(foreground: boolean): void {
     this.foreground = foreground
+    if (!this.ready) {
+      return
+    }
     if (foreground) {
-      void this.recoverRelay(this.relayRotationPending)
+      if (
+        this.logical.getState() === 'connected' &&
+        this.logical.getActivePath() !== 'relay' &&
+        this.credentialRecovery.needsAuthenticatedRepair
+      ) {
+        void this.reprovisionRelayCredentialIfPossible()
+      } else {
+        void this.recoverRelay(this.relayRotationPending)
+      }
       this.scheduleDirectProbe(0)
     } else {
       if (this.logical.getActivePath() === 'relay') {
@@ -124,7 +131,8 @@ export class MobileEndpointSupervisor {
       this.dependencies.clearTimer(this.probeTimer)
       this.probeTimer = null
     }
-    this.clearLeaseTimer()
+    this.recoveryTimer.clear()
+    this.leaseTimer.clear()
   }
 
   private async recoverRelay(forceReplacement = false): Promise<void> {
@@ -132,88 +140,86 @@ export class MobileEndpointSupervisor {
       this.stopped ||
       !this.foreground ||
       this.operationInFlight ||
-      !this.bundle ||
-      !this.host.relay ||
+      !this.credentialRecovery.host.relay ||
       (!forceReplacement && this.logical.getState() === 'connected')
     ) {
       return
     }
     this.operationInFlight = true
+    let recovered = false
     try {
-      const credentials = [this.bundle.current, this.bundle.grace].filter(
-        (credential): credential is NonNullable<typeof credential> =>
-          Boolean(credential && credential.expiresAt > this.dependencies.now())
-      )
+      const credentials = this.credentialRecovery.usableCredentials()
+      if (credentials.length === 0) {
+        this.credentialRecovery.markUnavailable()
+        return
+      }
       for (const credential of credentials) {
-        if (await this.tryRelayCredential(credential)) {
+        const result = await this.tryRelayCredential(credential)
+        if (result.ok) {
+          recovered = true
           return
         }
+        this.credentialRecovery.recordFailure(credential.version, result.error)
       }
     } finally {
       this.operationInFlight = false
-      const retry = !forceReplacement || this.relayRotationPending
-      if (retry && this.foreground && !this.stopped && !this.leaseTimer) {
-        this.leaseTimer = this.dependencies.setTimer(() => {
-          this.leaseTimer = null
-          void this.recoverRelay(forceReplacement)
-        }, 5000)
+      if (
+        recovered &&
+        !this.stopped &&
+        this.foreground &&
+        this.logical.getState() !== 'connected'
+      ) {
+        void this.recoverRelay(this.relayRotationPending)
+      } else if (!recovered && !this.stopped && this.foreground) {
+        const directNeedsRepair =
+          this.logical.getState() === 'connected' &&
+          this.logical.getActivePath() !== 'relay' &&
+          this.credentialRecovery.needsAuthenticatedRepair
+        if (directNeedsRepair) {
+          void this.reprovisionRelayCredentialIfPossible()
+        } else if (
+          this.credentialRecovery.hasUsableCredential() &&
+          (!forceReplacement || this.relayRotationPending)
+        ) {
+          this.recoveryTimer.scheduleIfIdle(5000, () => {
+            void this.recoverRelay(forceReplacement)
+          })
+        }
       }
     }
   }
 
-  private async tryRelayCredential(credential: {
-    token: string
-    version: number
-  }): Promise<boolean> {
-    const first = await this.openAndMigrateRelay(credential)
-    if (first.ok) {
-      return true
-    }
-    if (!isDirectorResolutionFailure(first.error) || !this.host.relay) {
-      return false
-    }
-    try {
-      const resolved = await this.dependencies.resolveRelay({
-        relay: this.host.relay,
-        resumeToken: credential.token
-      })
-      this.host = await persistRelayHost(this.host, resolved, this.dependencies.saveHost)
-      return (await this.openAndMigrateRelay(credential)).ok
-    } catch {
-      return false
-    }
-  }
-
-  private async openAndMigrateRelay(credential: {
-    token: string
-    version: number
-  }): Promise<{ ok: true } | { ok: false; error: Error }> {
-    if (!this.host.relay || !this.bundle) {
-      return { ok: false, error: new Error('relay state missing') }
-    }
-    const session = this.dependencies.openRelay(
-      this.host.relay,
-      credential,
-      `confirm-${encodeBase64Url(this.dependencies.randomBytes(16))}`
-    )
-    try {
-      await this.logical.migrateTo(session, 'relay')
-      if (!this.foreground) {
-        this.logical.suspendActiveSession()
-      }
-      this.relayRotationPending = false
-      this.hysteresis.recordMigration(this.dependencies.now())
-      const confirmation = session.getResumeConfirmation()
-      if (confirmation) {
-        this.bundle = applyResumeConfirmation(this.bundle, credential.version, confirmation)
-        await this.dependencies.writeBundle(this.bundle)
-      }
-      this.scheduleLeaseRotation(session)
-      this.scheduleDirectProbe()
-      return { ok: true }
-    } catch (error) {
-      return { ok: false, error: session.getFailure() ?? toError(error) }
-    }
+  private async tryRelayCredential(credential: RelayCredential): Promise<MobileRelayAttemptResult> {
+    const retried = await retryMobileRelayWithEndpointRefresh({
+      host: this.credentialRecovery.host,
+      resumeToken: credential.token,
+      resolveRelay: this.dependencies.resolveRelay,
+      saveHost: this.dependencies.saveHost,
+      tryRelay: (host) =>
+        migrateMobileRelaySession({
+          logical: this.logical,
+          relay: host.relay,
+          credential,
+          recovery: this.credentialRecovery,
+          hysteresis: this.hysteresis,
+          leaseTimer: this.leaseTimer,
+          openRelay: this.dependencies.openRelay,
+          randomBytes: this.dependencies.randomBytes,
+          now: this.dependencies.now,
+          isForeground: () => this.foreground,
+          clearRelayRotation: () => {
+            this.recoveryTimer.clear()
+            this.relayRotationPending = false
+          },
+          requestRelayRotation: () => {
+            this.relayRotationPending = true
+            void this.recoverRelay(true)
+          },
+          scheduleDirectProbe: () => this.scheduleDirectProbe()
+        })
+    })
+    this.credentialRecovery.host = retried.host
+    return retried.result
   }
 
   private scheduleDirectProbe(delayMs = DIRECT_PROBE_INTERVAL_MS): void {
@@ -242,80 +248,65 @@ export class MobileEndpointSupervisor {
       return
     }
     this.operationInFlight = true
-    let successful: Awaited<ReturnType<typeof openAuthenticatedDirectEndpoint>> = null
     try {
-      const openDirect = this.dependencies.openDirect
-      successful = await openAuthenticatedDirectEndpoint(this.host, openDirect, 12_000)
-      if (!successful) {
-        this.hysteresis.recordDirectFailure(this.dependencies.now())
-        return
-      }
-      if (!this.hysteresis.recordDirectSuccess(this.dependencies.now())) {
-        successful.client.close()
-        return
-      }
-      await this.logical.migrateTo(successful.client, successful.path)
-      successful = null
-      this.hysteresis.recordMigration(this.dependencies.now())
-      this.clearLeaseTimer()
-      this.relayRotationPending = false
-      await this.rotateCredentialIfNeeded()
+      await runMobileDirectProbe({
+        logical: this.logical,
+        host: this.credentialRecovery.host,
+        openDirect: this.dependencies.openDirect,
+        hysteresis: this.hysteresis,
+        recovery: this.credentialRecovery,
+        recoveryTimer: this.recoveryTimer,
+        leaseTimer: this.leaseTimer,
+        now: this.dependencies.now,
+        isStopped: () => this.stopped,
+        isForeground: () => this.foreground,
+        clearRelayRotation: () => {
+          this.relayRotationPending = false
+        },
+        retryCredentialRepair: () => void this.reprovisionRelayCredentialIfPossible()
+      })
     } finally {
-      successful?.client.close()
       this.operationInFlight = false
-      if (this.relayRotationPending) {
+      if (!this.stopped && this.foreground && this.logical.getState() !== 'connected') {
+        void this.recoverRelay(this.relayRotationPending)
+      } else if (this.relayRotationPending) {
         void this.recoverRelay(true)
       }
       this.scheduleDirectProbe()
     }
   }
 
-  private async rotateCredentialIfNeeded(): Promise<void> {
-    if (
-      this.stopped ||
-      this.credentialRotationInFlight ||
-      !this.bundle ||
-      this.logical.getActivePath() === 'relay' ||
-      !mobileRelayCredentialNeedsRotation(this.bundle, this.dependencies.now())
-    ) {
+  private async reprovisionRelayCredentialIfPossible(): Promise<void> {
+    if (this.stopped || !this.foreground || this.operationInFlight) {
       return
     }
-    this.credentialRotationInFlight = true
+    if (this.logical.getState() !== 'connected' || this.logical.getActivePath() === 'relay') {
+      if (this.logical.getState() !== 'connected') {
+        void this.recoverRelay(this.relayRotationPending)
+      }
+      return
+    }
+    this.recoveryTimer.clear()
+    this.leaseTimer.clear()
+    this.operationInFlight = true
+    let outcome: Awaited<ReturnType<MobileRelayCredentialRecovery['reprovision']>> = 'unsupported'
     try {
-      const result = await rotateMobileRelayCredential({
-        client: this.logical,
-        bundle: this.bundle,
-        writeBundle: this.dependencies.writeBundle,
-        randomBytes: this.dependencies.randomBytes
-      })
-      this.bundle = result.bundle
-      this.host = await persistRelayHost(this.host, result.relay, this.dependencies.saveHost)
-    } catch {
-      // Why: pending material remains durable; the next authenticated direct
-      // opportunity must reconcile it before creating another install key.
+      outcome = await this.credentialRecovery.reprovision(this.logical)
     } finally {
-      this.credentialRotationInFlight = false
-    }
-  }
-
-  private scheduleLeaseRotation(session: MobileRelayRpcSession): void {
-    this.clearLeaseTimer()
-    const deadline = session.getLeaseExpiresAt()
-    if (!deadline) {
-      return
-    }
-    const delay = Math.max(1000, deadline - this.dependencies.now() - LEASE_ROTATION_MARGIN_MS)
-    this.leaseTimer = this.dependencies.setTimer(() => {
-      this.leaseTimer = null
-      this.relayRotationPending = true
-      void this.recoverRelay(true)
-    }, delay)
-  }
-
-  private clearLeaseTimer(): void {
-    if (this.leaseTimer) {
-      this.dependencies.clearTimer(this.leaseTimer)
-      this.leaseTimer = null
+      this.operationInFlight = false
+      if (!this.stopped && this.foreground) {
+        if (this.logical.getState() !== 'connected') {
+          void this.recoverRelay(this.relayRotationPending)
+        } else if (
+          this.logical.getActivePath() !== 'relay' &&
+          outcome === 'deferred' &&
+          this.credentialRecovery.needsAuthenticatedRepair
+        ) {
+          this.recoveryTimer.scheduleIfIdle(5000, () => {
+            void this.reprovisionRelayCredentialIfPossible()
+          })
+        }
+      }
     }
   }
 }

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -81,8 +81,7 @@ export class MobileEndpointSupervisor {
         }
         this.scheduleDirectProbe()
       } else if (state === 'reconnecting' || state === 'disconnected' || state === 'auth-failed') {
-        // Why: the direct client enters reconnecting after its first failed
-        // dial and may never publish disconnected while its retry loop lives.
+        // Why: the direct client may stay reconnecting without another state change after its first failed dial.
         void this.recoverRelay()
       }
     })
@@ -92,8 +91,7 @@ export class MobileEndpointSupervisor {
       initialState === 'disconnected' ||
       initialState === 'auth-failed'
     ) {
-      // Why: the first direct dial can fail while encrypted relay credentials
-      // are still loading, before the supervisor subscribes to state changes.
+      // Why: the first direct dial may fail before encrypted relay credentials finish loading.
       await this.recoverRelay()
     } else {
       this.scheduleDirectProbe()
@@ -153,10 +151,11 @@ export class MobileEndpointSupervisor {
       }
     } finally {
       this.operationInFlight = false
-      if (forceReplacement && this.relayRotationPending && !this.stopped && !this.leaseTimer) {
+      const retry = !forceReplacement || this.relayRotationPending
+      if (retry && this.foreground && !this.stopped && !this.leaseTimer) {
         this.leaseTimer = this.dependencies.setTimer(() => {
           this.leaseTimer = null
-          void this.recoverRelay(true)
+          void this.recoverRelay(forceReplacement)
         }, 5000)
       }
     }

--- a/mobile/src/transport/mobile-relay-credential-recovery.test.ts
+++ b/mobile/src/transport/mobile-relay-credential-recovery.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MobileRelayUpgradeHostRemovedError } from './host-store'
+import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
+import { MobileRelayCredentialRecovery } from './mobile-relay-credential-recovery'
+import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
+import type { HostProfile } from './types'
+
+const { rotateCredential } = vi.hoisted(() => ({ rotateCredential: vi.fn() }))
+
+vi.mock('./mobile-relay-credential-rotation', async (importOriginal) => {
+  const original = await importOriginal<typeof import('./mobile-relay-credential-rotation')>()
+  return { ...original, rotateMobileRelayCredential: rotateCredential }
+})
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
+vi.mock('expo-secure-store', () => ({ WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'when-unlocked' }))
+vi.mock('expo-crypto', () => ({ getRandomBytes: (length: number) => new Uint8Array(length) }))
+
+const relay = {
+  v: 1 as const,
+  directorUrl: 'https://relay.onorca.dev',
+  cellUrl: 'https://relay-c1.onorca.dev',
+  assignmentEpoch: 7,
+  relayHostId: 'AbCdEf0123_-xyZ9',
+  e2eeFraming: 2 as const
+}
+const host: HostProfile = {
+  id: 'host-1',
+  name: 'Blue Whale',
+  endpoint: 'ws://192.168.1.10:6768',
+  deviceToken: 'device-token',
+  publicKeyB64: 'A'.repeat(44),
+  lastConnected: 1,
+  relayHostId: relay.relayHostId,
+  relay
+}
+const bundle: MobileRelayCredentialBundle = {
+  v: 1,
+  hostId: host.id,
+  deviceToken: host.deviceToken,
+  current: {
+    token: 'A'.repeat(43),
+    hash: 'B'.repeat(43),
+    version: 2,
+    expiresAt: Date.now() + 1_000
+  }
+}
+
+describe('mobile relay credential recovery', () => {
+  beforeEach(() => {
+    rotateCredential.mockReset()
+  })
+
+  it('serializes rotation and reprovision so the repaired bundle wins', async () => {
+    let finishRotation!: (value: {
+      bundle: MobileRelayCredentialBundle
+      relay: typeof relay
+    }) => void
+    rotateCredential.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishRotation = resolve
+        })
+    )
+    const rotatedBundle = {
+      ...bundle,
+      current: { ...bundle.current, version: 3, expiresAt: Number.MAX_SAFE_INTEGER }
+    }
+    const repairedBundle = {
+      ...bundle,
+      current: { ...bundle.current, version: 4, expiresAt: Number.MAX_SAFE_INTEGER }
+    }
+    const reprovisionRelay = vi.fn(async () => ({ host, bundle: repairedBundle }))
+    const recovery = new MobileRelayCredentialRecovery(host, {
+      readBundle: vi.fn(async () => bundle),
+      writeBundle: vi.fn(async () => {}),
+      deleteBundle: vi.fn(async () => {}),
+      reprovisionRelay,
+      saveHost: vi.fn(async () => {}),
+      onLog: vi.fn(),
+      now: Date.now,
+      randomBytes: (length) => new Uint8Array(length)
+    })
+    const client = { getActivePath: () => 'lan' } as StableLogicalRpcClient
+    await recovery.load()
+
+    const rotating = recovery.rotateIfNeeded(client)
+    await vi.waitFor(() => expect(rotateCredential).toHaveBeenCalledOnce())
+    const reprovisioning = recovery.reprovision(client)
+    await Promise.resolve()
+
+    expect(reprovisionRelay).not.toHaveBeenCalled()
+    finishRotation({ bundle: rotatedBundle, relay })
+    await rotating
+    await reprovisioning
+
+    expect(reprovisionRelay).toHaveBeenCalledOnce()
+    expect(recovery.bundle).toEqual(repairedBundle)
+  })
+
+  it('keeps durable pending rotation material while serializing resume confirmation', async () => {
+    let failRotation!: () => void
+    const pendingBundle: MobileRelayCredentialBundle = {
+      ...bundle,
+      pending: { token: 'C'.repeat(43), hash: 'D'.repeat(43), reqId: 'rotate-pending' }
+    }
+    rotateCredential.mockImplementationOnce(
+      async (args: {
+        writeBundle: (value: MobileRelayCredentialBundle) => Promise<void>
+        onBundlePersisted?: (value: MobileRelayCredentialBundle) => void
+      }) => {
+        await args.writeBundle(pendingBundle)
+        args.onBundlePersisted?.(pendingBundle)
+        await new Promise<never>((_resolve, reject) => {
+          failRotation = () => reject(new Error('lost rotation response'))
+        })
+      }
+    )
+    const writes: MobileRelayCredentialBundle[] = []
+    const recovery = new MobileRelayCredentialRecovery(host, {
+      readBundle: vi.fn(async () => bundle),
+      writeBundle: vi.fn(async (value) => {
+        writes.push(value)
+      }),
+      deleteBundle: vi.fn(async () => {}),
+      reprovisionRelay: vi.fn(async () => null),
+      saveHost: vi.fn(async () => {}),
+      onLog: vi.fn(),
+      now: Date.now,
+      randomBytes: (length) => new Uint8Array(length)
+    })
+    const client = { getActivePath: () => 'lan' } as StableLogicalRpcClient
+    await recovery.load()
+
+    const rotating = recovery.rotateIfNeeded(client)
+    await vi.waitFor(() => expect(writes).toHaveLength(1))
+    const confirming = recovery.recordRelayConnected(2, {
+      v: 1,
+      reqId: 'confirm-current',
+      currentVersion: 2,
+      acceptedAs: 'current',
+      renewed: true,
+      resumeExpiresAt: Number.MAX_SAFE_INTEGER
+    })
+    await Promise.resolve()
+
+    expect(writes).toHaveLength(1)
+    failRotation()
+    await rotating
+    await confirming
+
+    expect(recovery.bundle?.pending).toEqual(pendingBundle.pending)
+    expect(writes.at(-1)?.pending).toEqual(pendingBundle.pending)
+  })
+
+  it('deletes a late rotated bundle when the host was removed before persistence', async () => {
+    const rotatedBundle: MobileRelayCredentialBundle = {
+      ...bundle,
+      current: { ...bundle.current, version: 3, expiresAt: Number.MAX_SAFE_INTEGER }
+    }
+    rotateCredential.mockImplementationOnce(async () => ({ bundle: rotatedBundle, relay }))
+    const deleteBundle = vi.fn(async () => {})
+    const saveHost = vi.fn(async () => {
+      throw new MobileRelayUpgradeHostRemovedError('host removed')
+    })
+    const dependencies = {
+      readBundle: vi.fn(async () => bundle),
+      writeBundle: vi.fn(async () => {}),
+      deleteBundle,
+      reprovisionRelay: vi.fn(async () => null),
+      saveHost,
+      onLog: vi.fn(),
+      now: Date.now,
+      randomBytes: (length: number) => new Uint8Array(length)
+    }
+    const recovery = new MobileRelayCredentialRecovery(host, dependencies)
+    await recovery.load()
+
+    await recovery.rotateIfNeeded({ getActivePath: () => 'lan' } as StableLogicalRpcClient)
+
+    expect(saveHost).toHaveBeenCalledOnce()
+    expect(deleteBundle).toHaveBeenCalledWith(host.id)
+  })
+})

--- a/mobile/src/transport/mobile-relay-credential-recovery.ts
+++ b/mobile/src/transport/mobile-relay-credential-recovery.ts
@@ -1,0 +1,224 @@
+import { MOBILE_RELAY_CLOSE_CODE } from '../../../src/shared/mobile-relay-close-codes'
+import type { DeviceResumeConfirmed } from '../../../src/shared/mobile-relay-credential-contract'
+import { MobileRelayUpgradeHostRemovedError } from './host-store'
+import { persistRelayHost } from './mobile-endpoint-supervisor-support'
+import {
+  applyResumeConfirmation,
+  mobileRelayCredentialNeedsRotation,
+  rotateMobileRelayCredential
+} from './mobile-relay-credential-rotation'
+import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
+import type { MobileRelayDirectUpgradeResult } from './mobile-relay-direct-upgrade'
+import { RelayOuterError } from './mobile-relay-e2ee-link'
+import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
+import type { ConnectionLogLevel, ConnectionLogSink, HostProfile } from './types'
+
+export type MobileRelayCredentialRecoveryDependencies = {
+  readBundle: (hostId: string) => Promise<MobileRelayCredentialBundle | null>
+  writeBundle: (bundle: MobileRelayCredentialBundle) => Promise<void>
+  deleteBundle: (hostId: string) => Promise<void>
+  reprovisionRelay: (
+    client: StableLogicalRpcClient,
+    host: HostProfile
+  ) => Promise<MobileRelayDirectUpgradeResult | null>
+  saveHost: (host: HostProfile) => Promise<void>
+  onLog: ConnectionLogSink
+  now: () => number
+  randomBytes: (length: number) => Uint8Array
+}
+
+export type MobileRelayReprovisionOutcome = 'restored' | 'unsupported' | 'deferred'
+
+export class MobileRelayCredentialRecovery {
+  host: HostProfile
+  bundle: MobileRelayCredentialBundle | null = null
+  private repairNeeded = false
+  private unavailableLogged = false
+  private rotationInFlight = false
+  private mutationTail: Promise<void> = Promise.resolve()
+  private readonly disabledVersions = new Set<number>()
+  private logSequence = 0
+
+  constructor(
+    host: HostProfile,
+    private readonly dependencies: MobileRelayCredentialRecoveryDependencies
+  ) {
+    this.host = host
+  }
+
+  get needsRepair(): boolean {
+    return this.repairNeeded
+  }
+
+  get needsAuthenticatedRepair(): boolean {
+    return this.repairNeeded || !this.hasUsableCredential()
+  }
+
+  async load(): Promise<void> {
+    this.bundle = await this.dependencies.readBundle(this.host.id).catch(() => null)
+  }
+
+  hasUsableCredential(): boolean {
+    return this.usableCredentials().length > 0
+  }
+
+  usableCredentials(): Array<{ token: string; version: number }> {
+    return [this.bundle?.current, this.bundle?.grace].filter(
+      (credential): credential is NonNullable<typeof credential> =>
+        Boolean(
+          credential &&
+          credential.expiresAt > this.dependencies.now() &&
+          !this.disabledVersions.has(credential.version)
+        )
+    )
+  }
+
+  markUnavailable(): void {
+    this.repairNeeded = true
+    if (this.unavailableLogged) {
+      return
+    }
+    this.unavailableLogged = true
+    this.emit('warn', 'Relay credential unavailable', 'Will restore on authenticated LAN')
+  }
+
+  recordFailure(version: number, error: Error): void {
+    if (
+      error instanceof RelayOuterError &&
+      error.code === MOBILE_RELAY_CLOSE_CODE.BAD_OUTER_CREDENTIAL
+    ) {
+      this.disabledVersions.add(version)
+      this.repairNeeded = true
+      this.emit('error', 'Relay credential rejected', 'Will restore on authenticated LAN')
+      return
+    }
+    this.emit('warn', 'Relay connection failed', relayFailureDetail(error))
+  }
+
+  async recordRelayConnected(
+    usedCredentialVersion: number,
+    confirmation: DeviceResumeConfirmed | null
+  ): Promise<void> {
+    await this.runCredentialMutation(async () => {
+      this.unavailableLogged = false
+      if (confirmation && this.bundle) {
+        const next = applyResumeConfirmation(this.bundle, usedCredentialVersion, confirmation)
+        await this.writeBundle(next)
+        this.bundle = next
+      }
+      this.emit('success', 'Relay connected')
+    })
+  }
+
+  async rotateIfNeeded(client: StableLogicalRpcClient): Promise<void> {
+    if (this.rotationInFlight) {
+      return
+    }
+    this.rotationInFlight = true
+    try {
+      await this.runCredentialMutation(async () => {
+        if (
+          !this.bundle ||
+          client.getActivePath() === 'relay' ||
+          !mobileRelayCredentialNeedsRotation(this.bundle, this.dependencies.now())
+        ) {
+          return
+        }
+        try {
+          const result = await rotateMobileRelayCredential({
+            client,
+            bundle: this.bundle,
+            writeBundle: (value) => this.writeBundle(value),
+            onBundlePersisted: (value) => {
+              this.bundle = value
+            },
+            randomBytes: this.dependencies.randomBytes
+          })
+          this.bundle = result.bundle
+          this.host = await persistRelayHost(this.host, result.relay, this.dependencies.saveHost)
+        } catch (error) {
+          if (error instanceof MobileRelayUpgradeHostRemovedError) {
+            await this.removeDeletedHostBundle()
+          }
+          // Why: pending material remains durable; the next authenticated direct
+          // opportunity must reconcile it before creating another install key.
+        }
+      })
+    } finally {
+      this.rotationInFlight = false
+    }
+  }
+
+  async reprovision(client: StableLogicalRpcClient): Promise<MobileRelayReprovisionOutcome> {
+    return this.runCredentialMutation(async () => {
+      try {
+        const result = await this.dependencies.reprovisionRelay(client, this.host)
+        if (!result) {
+          return 'unsupported'
+        }
+        this.host = result.host
+        this.bundle = result.bundle
+        this.disabledVersions.clear()
+        this.repairNeeded = false
+        this.unavailableLogged = false
+        this.emit('success', 'Relay credential restored')
+        return 'restored'
+      } catch (error) {
+        if (error instanceof MobileRelayUpgradeHostRemovedError) {
+          await this.removeDeletedHostBundle()
+          return 'unsupported'
+        }
+        this.emit('warn', 'Relay credential restore deferred', 'Will retry on authenticated LAN')
+        return 'deferred'
+      }
+    })
+  }
+
+  private emit(level: ConnectionLogLevel, message: string, detail?: string): void {
+    const ts = this.dependencies.now()
+    this.dependencies.onLog({
+      id: `relay-${ts}-${++this.logSequence}`,
+      ts,
+      level,
+      message,
+      ...(detail ? { detail } : {})
+    })
+  }
+
+  private async writeBundle(bundle: MobileRelayCredentialBundle): Promise<void> {
+    try {
+      await this.dependencies.writeBundle(bundle)
+    } catch (error) {
+      if (error instanceof MobileRelayUpgradeHostRemovedError) {
+        await this.removeDeletedHostBundle()
+      }
+      throw error
+    }
+  }
+
+  private async removeDeletedHostBundle(): Promise<void> {
+    this.bundle = null
+    await this.dependencies.deleteBundle(this.host.id).catch(() => {})
+  }
+
+  private async runCredentialMutation<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.mutationTail
+    let release!: () => void
+    this.mutationTail = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    await previous
+    try {
+      return await operation()
+    } finally {
+      release()
+    }
+  }
+}
+
+function relayFailureDetail(error: Error): string {
+  if (error instanceof RelayOuterError) {
+    return `Relay closed (${error.code})`
+  }
+  return 'Secure Relay handshake did not complete'
+}

--- a/mobile/src/transport/mobile-relay-credential-rotation.test.ts
+++ b/mobile/src/transport/mobile-relay-credential-rotation.test.ts
@@ -76,17 +76,21 @@ describe('mobile relay credential rotation', () => {
       })
     ])
     const writes: MobileRelayCredentialBundle[] = []
+    const onBundlePersisted = vi.fn()
 
-    const result = await rotateMobileRelayCredential({
+    const rotation = {
       client,
       bundle,
       writeBundle: async (value) => {
         writes.push(value)
       },
-      randomBytes: (length) => new Uint8Array(length).fill(length === 32 ? 7 : 8)
-    })
+      randomBytes: (length: number) => new Uint8Array(length).fill(length === 32 ? 7 : 8),
+      onBundlePersisted
+    }
+    const result = await rotateMobileRelayCredential(rotation)
 
     expect(writes).toHaveLength(2)
+    expect(onBundlePersisted.mock.calls.map(([value]) => value)).toEqual(writes)
     expect(writes[0]!.pending).toMatchObject({ reqId: installed.reqId })
     expect(writes[0]!.pending!.hash).toBe('3Ev4DHdHPRMPoN6GukAY_pi7IUAF5qWJHRK6kURvnoE')
     expect(client.sendRequest).toHaveBeenNthCalledWith(2, 'pairing.provisionRelay', {

--- a/mobile/src/transport/mobile-relay-credential-rotation.ts
+++ b/mobile/src/transport/mobile-relay-credential-rotation.ts
@@ -23,6 +23,7 @@ export async function rotateMobileRelayCredential(args: {
   client: RpcClient
   bundle: MobileRelayCredentialBundle
   writeBundle: (bundle: MobileRelayCredentialBundle) => Promise<void>
+  onBundlePersisted?: (bundle: MobileRelayCredentialBundle) => void
   randomBytes?: (length: number) => Uint8Array
 }): Promise<RotationResult> {
   let bundle = args.bundle
@@ -40,6 +41,7 @@ export async function rotateMobileRelayCredential(args: {
     // Why: a crash or lost response must leave enough material to query the
     // one global install key before any second authorization attempt.
     await args.writeBundle(bundle)
+    args.onBundlePersisted?.(bundle)
   }
 
   const pending = bundle.pending
@@ -83,6 +85,7 @@ export async function rotateMobileRelayCredential(args: {
     pending: undefined
   })
   await args.writeBundle(next)
+  args.onBundlePersisted?.(next)
   return { bundle: next, relay: endpoints.relay }
 }
 

--- a/mobile/src/transport/mobile-relay-direct-upgrade.test.ts
+++ b/mobile/src/transport/mobile-relay-direct-upgrade.test.ts
@@ -5,7 +5,10 @@ import {
   createMobileRelayDirectUpgradeJournal,
   type MobileRelayDirectUpgradeJournal
 } from './mobile-relay-direct-upgrade-journal'
-import { upgradeDirectMobileRelay } from './mobile-relay-direct-upgrade'
+import {
+  reprovisionExistingMobileRelayCredential,
+  upgradeDirectMobileRelay
+} from './mobile-relay-direct-upgrade'
 import type { RpcClient } from './rpc-client'
 import type { HostProfile, RpcResponse } from './types'
 
@@ -70,6 +73,52 @@ function dependencies(journal: MobileRelayDirectUpgradeJournal | null = null) {
 }
 
 describe('existing direct pairing relay upgrade', () => {
+  it('reprovisions a lost relay credential for an existing relay host', async () => {
+    const relayHost: HostProfile = {
+      ...host,
+      endpoints: [
+        { id: 'direct-primary', kind: 'lan', url: host.endpoint },
+        {
+          id: 'relay-primary',
+          kind: 'relay',
+          url: `wss://relay-staging.onorca.dev/v1/connect/${relay.relayHostId}`
+        }
+      ],
+      relayHostId: relay.relayHostId,
+      relay
+    }
+    const deps = dependencies()
+    const committed = {
+      v: 1 as const,
+      reqId: 'upgrade-BwcHBwcHBwcHBwcHBwcHBw',
+      authorizationMode: 'authenticated-direct' as const,
+      currentVersion: 4,
+      resumeExpiresAt: 9_999_999
+    }
+    const client = clientWith([
+      success({ v: 1, relay }),
+      success(committed),
+      success({
+        v: 1,
+        relay,
+        installStatus: { v: 1, reqId: committed.reqId, state: 'committed', result: committed }
+      })
+    ])
+
+    const result = await reprovisionExistingMobileRelayCredential({
+      client,
+      host: relayHost,
+      dependencies: deps
+    })
+
+    expect(client.sendRequest).toHaveBeenNthCalledWith(2, 'pairing.provisionRelay', {
+      reqId: committed.reqId,
+      newResumeTokenHash: expect.any(String)
+    })
+    expect(result?.bundle.current.version).toBe(4)
+    expect(result?.host.relay).toEqual(relay)
+  })
+
   it('persists pending material before install and publishes only after committed status', async () => {
     const deps = dependencies()
     let journal: MobileRelayDirectUpgradeJournal | null = null
@@ -187,6 +236,32 @@ describe('existing direct pairing relay upgrade', () => {
     await expect(
       upgradeDirectMobileRelay({ client, host, dependencies: deps })
     ).rejects.toBeInstanceOf(MobileRelayUpgradeHostRemovedError)
+    expect(deps.deleteBundle).toHaveBeenCalledWith(host.id)
+    expect(deps.clearJournal).toHaveBeenCalledWith(host.id)
+  })
+
+  it('cleans the journal when removal wins before credential publication', async () => {
+    const journal = createMobileRelayDirectUpgradeJournal(host.id, (length) =>
+      new Uint8Array(length).fill(6)
+    )
+    const committed = installed(journal)
+    const deps = dependencies(journal)
+    deps.writeBundle.mockRejectedValue(
+      new MobileRelayUpgradeHostRemovedError('mobile relay host was removed')
+    )
+    const client = clientWith([
+      success({
+        v: 1,
+        relay,
+        installStatus: { v: 1, reqId: journal.reqId, state: 'committed', result: committed }
+      })
+    ])
+
+    await expect(
+      upgradeDirectMobileRelay({ client, host, dependencies: deps })
+    ).rejects.toBeInstanceOf(MobileRelayUpgradeHostRemovedError)
+
+    expect(deps.saveHost).not.toHaveBeenCalled()
     expect(deps.deleteBundle).toHaveBeenCalledWith(host.id)
     expect(deps.clearJournal).toHaveBeenCalledWith(host.id)
   })

--- a/mobile/src/transport/mobile-relay-direct-upgrade.ts
+++ b/mobile/src/transport/mobile-relay-direct-upgrade.ts
@@ -10,16 +10,18 @@ import { persistRelayHost } from './mobile-endpoint-supervisor-support'
 import {
   MobileRelayCredentialBundleSchema,
   deleteMobileRelayCredentialBundle,
-  writeMobileRelayCredentialBundle,
   type MobileRelayCredentialBundle
 } from './mobile-relay-credential-bundle'
 import {
   createMobileRelayDirectUpgradeJournal,
   deleteMobileRelayDirectUpgradeJournal,
   readMobileRelayDirectUpgradeJournal,
-  writeMobileRelayDirectUpgradeJournal,
   type MobileRelayDirectUpgradeJournal
 } from './mobile-relay-direct-upgrade-journal'
+import {
+  writeMobileRelayCredentialBundleForExistingHost,
+  writeMobileRelayDirectUpgradeJournalForExistingHost
+} from './mobile-relay-existing-host-credential-writer'
 import type { RpcClient } from './rpc-client'
 import type { HostProfile, RpcResponse } from './types'
 
@@ -30,27 +32,46 @@ export type MobileRelayDirectUpgradeResult = {
 
 type Dependencies = {
   readJournal: typeof readMobileRelayDirectUpgradeJournal
-  writeJournal: typeof writeMobileRelayDirectUpgradeJournal
+  writeJournal: typeof writeMobileRelayDirectUpgradeJournalForExistingHost
   clearJournal: typeof deleteMobileRelayDirectUpgradeJournal
-  writeBundle: typeof writeMobileRelayCredentialBundle
+  writeBundle: typeof writeMobileRelayCredentialBundleForExistingHost
   saveHost: typeof saveExistingHostRelayUpgrade
   deleteBundle: typeof deleteMobileRelayCredentialBundle
   randomBytes: (length: number) => Uint8Array
 }
 
-export async function upgradeDirectMobileRelay(args: {
+type DirectProvisionArgs = {
   client: RpcClient
   host: HostProfile
   dependencies?: Partial<Dependencies>
-}): Promise<MobileRelayDirectUpgradeResult | null> {
+}
+
+export async function upgradeDirectMobileRelay(
+  args: DirectProvisionArgs
+): Promise<MobileRelayDirectUpgradeResult | null> {
   if (args.host.relay) {
     return null
   }
+  return provisionMobileRelayCredentialFromDirect(args)
+}
+
+export async function reprovisionExistingMobileRelayCredential(
+  args: DirectProvisionArgs
+): Promise<MobileRelayDirectUpgradeResult | null> {
+  if (!args.host.relay) {
+    return null
+  }
+  return provisionMobileRelayCredentialFromDirect(args)
+}
+
+async function provisionMobileRelayCredentialFromDirect(
+  args: DirectProvisionArgs
+): Promise<MobileRelayDirectUpgradeResult | null> {
   const dependencies: Dependencies = {
     readJournal: readMobileRelayDirectUpgradeJournal,
-    writeJournal: writeMobileRelayDirectUpgradeJournal,
+    writeJournal: writeMobileRelayDirectUpgradeJournalForExistingHost,
     clearJournal: deleteMobileRelayDirectUpgradeJournal,
-    writeBundle: writeMobileRelayCredentialBundle,
+    writeBundle: writeMobileRelayCredentialBundleForExistingHost,
     saveHost: saveExistingHostRelayUpgrade,
     deleteBundle: deleteMobileRelayCredentialBundle,
     randomBytes: ExpoCrypto.getRandomBytes,
@@ -115,10 +136,10 @@ async function publishCommitted(
       expiresAt: installed.resumeExpiresAt
     }
   })
-  // Why: the overlay must never advertise relay without its matching credential.
-  await dependencies.writeBundle(bundle)
   let updatedHost: HostProfile
   try {
+    // Why: the overlay must never advertise relay without its matching credential.
+    await dependencies.writeBundle(bundle)
     updatedHost = await persistRelayHost(host, endpoints.relay, dependencies.saveHost)
   } catch (error) {
     if (error instanceof MobileRelayUpgradeHostRemovedError) {

--- a/mobile/src/transport/mobile-relay-endpoint-retry.ts
+++ b/mobile/src/transport/mobile-relay-endpoint-retry.ts
@@ -1,0 +1,35 @@
+import type { MobileRelayEndpoint } from '../../../src/shared/mobile-relay-credential-contract'
+import {
+  isDirectorResolutionFailure,
+  persistRelayHost,
+  toError
+} from './mobile-endpoint-supervisor-support'
+import type { HostProfile } from './types'
+
+export type MobileRelayAttemptResult = { ok: true } | { ok: false; error: Error }
+
+export async function retryMobileRelayWithEndpointRefresh(args: {
+  host: HostProfile
+  resumeToken: string
+  resolveRelay: (input: {
+    relay: MobileRelayEndpoint
+    resumeToken: string
+  }) => Promise<MobileRelayEndpoint>
+  saveHost: (host: HostProfile) => Promise<void>
+  tryRelay: (host: HostProfile) => Promise<MobileRelayAttemptResult>
+}): Promise<{ host: HostProfile; result: MobileRelayAttemptResult }> {
+  const first = await args.tryRelay(args.host)
+  if (first.ok || !isDirectorResolutionFailure(first.error) || !args.host.relay) {
+    return { host: args.host, result: first }
+  }
+  try {
+    const resolved = await args.resolveRelay({
+      relay: args.host.relay,
+      resumeToken: args.resumeToken
+    })
+    const host = await persistRelayHost(args.host, resolved, args.saveHost)
+    return { host, result: await args.tryRelay(host) }
+  } catch (error) {
+    return { host: args.host, result: { ok: false, error: toError(error) } }
+  }
+}

--- a/mobile/src/transport/mobile-relay-existing-host-credential-writer.ts
+++ b/mobile/src/transport/mobile-relay-existing-host-credential-writer.ts
@@ -1,0 +1,25 @@
+import { runHostCredentialWriteForExistingHost } from './host-store'
+import {
+  writeMobileRelayCredentialBundle,
+  type MobileRelayCredentialBundle
+} from './mobile-relay-credential-bundle'
+import {
+  writeMobileRelayDirectUpgradeJournal,
+  type MobileRelayDirectUpgradeJournal
+} from './mobile-relay-direct-upgrade-journal'
+
+export function writeMobileRelayCredentialBundleForExistingHost(
+  bundle: MobileRelayCredentialBundle
+): Promise<void> {
+  return runHostCredentialWriteForExistingHost(bundle.hostId, () =>
+    writeMobileRelayCredentialBundle(bundle)
+  )
+}
+
+export function writeMobileRelayDirectUpgradeJournalForExistingHost(
+  journal: MobileRelayDirectUpgradeJournal
+): Promise<void> {
+  return runHostCredentialWriteForExistingHost(journal.hostId, () =>
+    writeMobileRelayDirectUpgradeJournal(journal)
+  )
+}

--- a/mobile/src/transport/mobile-relay-recovery-timer.ts
+++ b/mobile/src/transport/mobile-relay-recovery-timer.ts
@@ -1,0 +1,38 @@
+export class MobileRelayRecoveryTimer {
+  private timer: ReturnType<typeof setTimeout> | null = null
+
+  constructor(
+    private readonly setTimer: typeof setTimeout,
+    private readonly clearTimer: typeof clearTimeout
+  ) {}
+
+  get scheduled(): boolean {
+    return this.timer !== null
+  }
+
+  scheduleIfIdle(delayMs: number, callback: () => void): void {
+    if (this.timer) {
+      return
+    }
+    this.schedule(delayMs, callback)
+  }
+
+  scheduleBefore(deadline: number, marginMs: number, now: number, callback: () => void): void {
+    this.clear()
+    this.schedule(Math.max(1000, deadline - now - marginMs), callback)
+  }
+
+  clear(): void {
+    if (this.timer) {
+      this.clearTimer(this.timer)
+      this.timer = null
+    }
+  }
+
+  private schedule(delayMs: number, callback: () => void): void {
+    this.timer = this.setTimer(() => {
+      this.timer = null
+      callback()
+    }, delayMs)
+  }
+}

--- a/mobile/src/transport/mobile-relay-session-migration.ts
+++ b/mobile/src/transport/mobile-relay-session-migration.ts
@@ -1,0 +1,64 @@
+import type { MobileRelayEndpoint } from '../../../src/shared/mobile-relay-credential-contract'
+import type { MobileEndpointHysteresis } from './mobile-endpoint-hysteresis'
+import { encodeBase64Url, toError } from './mobile-endpoint-supervisor-support'
+import type { MobileRelayCredentialRecovery } from './mobile-relay-credential-recovery'
+import type { MobileRelayAttemptResult } from './mobile-relay-endpoint-retry'
+import type { MobileRelayRpcSession } from './mobile-relay-rpc-session'
+import type { MobileRelayRecoveryTimer } from './mobile-relay-recovery-timer'
+import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
+
+const LEASE_ROTATION_MARGIN_MS = 30_000
+
+export async function migrateMobileRelaySession(args: {
+  logical: StableLogicalRpcClient
+  relay: MobileRelayEndpoint | undefined
+  credential: { token: string; version: number }
+  recovery: MobileRelayCredentialRecovery
+  hysteresis: MobileEndpointHysteresis
+  leaseTimer: MobileRelayRecoveryTimer
+  openRelay: (
+    relay: MobileRelayEndpoint,
+    credential: { token: string; version: number },
+    confirmReqId: string
+  ) => MobileRelayRpcSession
+  randomBytes: (length: number) => Uint8Array
+  now: () => number
+  isForeground: () => boolean
+  clearRelayRotation: () => void
+  requestRelayRotation: () => void
+  scheduleDirectProbe: () => void
+}): Promise<MobileRelayAttemptResult> {
+  if (!args.relay || !args.recovery.bundle) {
+    return { ok: false, error: new Error('relay state missing') }
+  }
+  const session = args.openRelay(
+    args.relay,
+    args.credential,
+    `confirm-${encodeBase64Url(args.randomBytes(16))}`
+  )
+  try {
+    await args.logical.migrateTo(session, 'relay')
+    if (!args.isForeground()) {
+      args.logical.suspendActiveSession()
+    }
+    args.clearRelayRotation()
+    args.hysteresis.recordMigration(args.now())
+    await args.recovery.recordRelayConnected(
+      args.credential.version,
+      session.getResumeConfirmation()
+    )
+    const leaseDeadline = session.getLeaseExpiresAt()
+    if (leaseDeadline) {
+      args.leaseTimer.scheduleBefore(
+        leaseDeadline,
+        LEASE_ROTATION_MARGIN_MS,
+        args.now(),
+        args.requestRelayRotation
+      )
+    }
+    args.scheduleDirectProbe()
+    return { ok: true }
+  } catch (error) {
+    return { ok: false, error: session.getFailure() ?? toError(error) }
+  }
+}

--- a/mobile/src/transport/rpc-client.test.ts
+++ b/mobile/src/transport/rpc-client.test.ts
@@ -687,6 +687,44 @@ describe('mobile rpc-client connection timeout', () => {
       client.close()
     })
 
+    it('restarts a socket stuck connecting when the app returns to foreground', () => {
+      const client = connect('ws://desktop.invalid', 'token', 'server-key')
+      const stuckSocket = mockSockets[0]!
+
+      expect(client.getState()).toBe('connecting')
+      client.notifyForeground()
+
+      expect(stuckSocket.close).toHaveBeenCalledTimes(1)
+      expect(mockSockets).toHaveLength(2)
+      expect(client.getState()).toBe('connecting')
+
+      const replacementSocket = mockSockets[1]!
+      replacementSocket.open()
+      replacementSocket.receive(JSON.stringify({ type: 'e2ee_ready' }))
+      expect(replacementSocket.sent).toContain(
+        'encrypted:{"type":"e2ee_auth","deviceToken":"token"}'
+      )
+      replacementSocket.receive('encrypted:{"type":"e2ee_authenticated"}')
+      expect(client.getState()).toBe('connected')
+
+      client.close()
+    })
+
+    it('restarts a socket stuck handshaking when the app returns to foreground', () => {
+      const client = connect('ws://desktop.invalid', 'token', 'server-key')
+      const stuckSocket = mockSockets[0]!
+      stuckSocket.open()
+
+      expect(client.getState()).toBe('handshaking')
+      client.notifyForeground()
+
+      expect(stuckSocket.close).toHaveBeenCalledTimes(1)
+      expect(mockSockets).toHaveLength(2)
+      expect(client.getState()).toBe('connecting')
+
+      client.close()
+    })
+
     it('reaps a half-open socket within 8s of foreground', async () => {
       const client = connect('ws://desktop.invalid', 'token', 'server-key')
       const socket = mockSockets[0]!

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -1220,6 +1220,27 @@ export function connect(
         runActivityProbe()
         return
       }
+      if (state === 'connecting' || state === 'handshaking') {
+        // Why: iOS can suspend the socket and its timeout while backgrounded,
+        // so waiting for the old attempt can leave the UI stuck indefinitely.
+        console.log('[net] foreground — replacing stalled connection', { state })
+        clearConnectTimer()
+        if (handshakeTimer) {
+          clearTimeout(handshakeTimer)
+          handshakeTimer = null
+        }
+        const stalledWs = ws
+        ws = null
+        sharedKey = null
+        currentWsOpenedAt = null
+        if (stalledWs) {
+          stalledWs.onclose = null
+          stalledWs.close()
+        }
+        reconnectAttempt = 0
+        openConnection()
+        return
+      }
       if (state === 'reconnecting') {
         // Why: while backgrounded the retry loop may be sitting on a 60s
         // backoff or 90s trickle timer. Returning to the foreground is a

--- a/mobile/src/transport/serialized-operation-queue.ts
+++ b/mobile/src/transport/serialized-operation-queue.ts
@@ -1,0 +1,20 @@
+export class SerializedOperationQueue {
+  private tail: Promise<void> = Promise.resolve()
+
+  wait(): Promise<void> {
+    return this.tail
+  }
+
+  run<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.tail.then(operation)
+    this.tail = result.then(
+      () => undefined,
+      () => undefined
+    )
+    return result
+  }
+
+  reset(): void {
+    this.tail = Promise.resolve()
+  }
+}

--- a/mobile/src/transport/stored-host-profile.ts
+++ b/mobile/src/transport/stored-host-profile.ts
@@ -1,0 +1,43 @@
+import type { HostProfile, StoredHostProfile } from './types'
+
+export class MobileRelayUpgradeHostRemovedError extends Error {}
+
+export function toStoredHostProfile(host: HostProfile): StoredHostProfile {
+  return {
+    id: host.id,
+    name: host.name,
+    endpoint: host.endpoint,
+    publicKeyB64: host.publicKeyB64,
+    lastConnected: host.lastConnected
+  }
+}
+
+export function prepareStoredHostPersistence(
+  hosts: StoredHostProfile[],
+  stored: StoredHostProfile,
+  requireExisting: boolean
+): {
+  hosts: StoredHostProfile[]
+  duplicateHostIds: Set<string>
+  updatedExistingHost: boolean
+} {
+  const duplicateHostIds = new Set(
+    hosts
+      .filter(
+        (candidate) => candidate.id !== stored.id && candidate.publicKeyB64 === stored.publicKeyB64
+      )
+      .map(({ id }) => id)
+  )
+  const updatedExistingHost = hosts.some(({ id }) => id === stored.id)
+  if (!updatedExistingHost && requireExisting) {
+    throw new MobileRelayUpgradeHostRemovedError('mobile relay upgrade host was removed')
+  }
+  const retained = hosts.filter(({ id }) => !duplicateHostIds.has(id))
+  return {
+    hosts: updatedExistingHost
+      ? retained.map((candidate) => (candidate.id === stored.id ? stored : candidate))
+      : [...retained, stored],
+    duplicateHostIds,
+    updatedExistingHost
+  }
+}

--- a/src/main/runtime/relay/relay-control-client-liveness.test.ts
+++ b/src/main/runtime/relay/relay-control-client-liveness.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import nacl from 'tweetnacl'
 import type WebSocket from 'ws'
 import { RelayControlClient } from './relay-control-client'
@@ -54,6 +54,10 @@ async function activate(client: RelayControlClient, socket: SilentControlSocket)
 }
 
 describe('RelayControlClient liveness', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('terminates an active control socket that receives no relay traffic', async () => {
     vi.useFakeTimers()
     const socket = new SilentControlSocket()
@@ -65,7 +69,6 @@ describe('RelayControlClient liveness', () => {
 
     expect(socket.terminate).toHaveBeenCalledOnce()
     expect(onClose).toHaveBeenCalledWith(1006)
-    vi.useRealTimers()
   })
 
   it('extends the deadline whenever relay traffic arrives', async () => {
@@ -81,6 +84,5 @@ describe('RelayControlClient liveness', () => {
 
     await vi.advanceTimersByTimeAsync(81)
     expect(socket.terminate).toHaveBeenCalledOnce()
-    vi.useRealTimers()
   })
 })

--- a/src/main/runtime/relay/relay-control-client-liveness.test.ts
+++ b/src/main/runtime/relay/relay-control-client-liveness.test.ts
@@ -1,0 +1,86 @@
+import { EventEmitter } from 'node:events'
+import { describe, expect, it, vi } from 'vitest'
+import nacl from 'tweetnacl'
+import type WebSocket from 'ws'
+import { RelayControlClient } from './relay-control-client'
+
+class SilentControlSocket extends EventEmitter {
+  readonly send = vi.fn()
+  readonly close = vi.fn()
+  readonly terminate = vi.fn(() => this.emit('close', 1006))
+}
+
+function createClient(socket: SilentControlSocket, onClose = vi.fn()): RelayControlClient {
+  const keys = nacl.box.keyPair()
+  return new RelayControlClient({
+    cellUrl: 'https://relay.example.test',
+    relayJwt: 'relay-jwt',
+    relayHostId: 'relay-host-1',
+    assignmentEpoch: 1,
+    identity: { userId: 'user-1', profileId: 'profile-1', organizationId: 'org-1' },
+    keypair: {
+      publicKey: keys.publicKey,
+      secretKey: keys.secretKey,
+      publicKeyB64: Buffer.from(keys.publicKey).toString('base64')
+    },
+    appVersion: '1.0.0',
+    onConnectionOpen: vi.fn(),
+    onDrain: vi.fn(),
+    onClose,
+    createSocket: () => socket as unknown as WebSocket,
+    livenessTimeoutMs: 100
+  })
+}
+
+async function activate(client: RelayControlClient, socket: SilentControlSocket): Promise<void> {
+  const connecting = client.connect()
+  socket.emit('open')
+  socket.emit(
+    'message',
+    Buffer.from(
+      JSON.stringify({
+        type: 'host-hello-ack',
+        v: 1,
+        generation: 1,
+        controlResumeSecret: 'R'.repeat(43),
+        leaseExpiresAt: Date.now() + 60_000,
+        activeConnIds: [],
+        pendingConns: []
+      })
+    ),
+    false
+  )
+  await connecting
+}
+
+describe('RelayControlClient liveness', () => {
+  it('terminates an active control socket that receives no relay traffic', async () => {
+    vi.useFakeTimers()
+    const socket = new SilentControlSocket()
+    const onClose = vi.fn()
+    const client = createClient(socket, onClose)
+
+    await activate(client, socket)
+    await vi.advanceTimersByTimeAsync(101)
+
+    expect(socket.terminate).toHaveBeenCalledOnce()
+    expect(onClose).toHaveBeenCalledWith(1006)
+    vi.useRealTimers()
+  })
+
+  it('extends the deadline whenever relay traffic arrives', async () => {
+    vi.useFakeTimers()
+    const socket = new SilentControlSocket()
+    const client = createClient(socket)
+
+    await activate(client, socket)
+    await vi.advanceTimersByTimeAsync(90)
+    socket.emit('message', Buffer.from(JSON.stringify({ type: 'ping', t: Date.now() })), false)
+    await vi.advanceTimersByTimeAsync(20)
+    expect(socket.terminate).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(81)
+    expect(socket.terminate).toHaveBeenCalledOnce()
+    vi.useRealTimers()
+  })
+})

--- a/src/main/runtime/relay/relay-control-client.ts
+++ b/src/main/runtime/relay/relay-control-client.ts
@@ -34,7 +34,10 @@ type RelayControlClientOptions = {
   onDrain: (message: RelayDrainMessage) => void
   onClose: (code: number) => void
   createSocket?: (url: string, relayJwt: string) => WebSocket
+  livenessTimeoutMs?: number
 }
+
+const RELAY_CONTROL_LIVENESS_TIMEOUT_MS = 45_000
 
 function controlWebSocketUrl(cellUrl: string): { origin: string; url: string } {
   const parsed = new URL(cellUrl)
@@ -62,6 +65,7 @@ export class RelayControlClient {
   private state: RelayControlState = 'idle'
   private connectResolve: ((ack: RelayHostHelloAckMessage) => void) | null = null
   private connectReject: ((error: Error) => void) | null = null
+  private livenessTimer: ReturnType<typeof setTimeout> | null = null
 
   constructor(options: RelayControlClientOptions) {
     this.options = options
@@ -154,6 +158,7 @@ export class RelayControlClient {
 
   closeNow(): void {
     this.state = 'closed'
+    this.clearLivenessTimer()
     this.requests.rejectAll(new Error('relay_control_closed'))
     this.socket?.terminate()
     this.socket = null
@@ -183,6 +188,9 @@ export class RelayControlClient {
   }
 
   private handleMessage(raw: RawData): void {
+    if (this.state === 'active' || this.state === 'draining') {
+      this.armLivenessTimer()
+    }
     const message = parseRelayControlMessage(raw)
     if (!message) {
       this.failProtocol('invalid control JSON')
@@ -249,6 +257,7 @@ export class RelayControlClient {
       return
     }
     this.state = 'active'
+    this.armLivenessTimer()
     this.connectResolve?.(ack.data)
     this.clearConnectPromise()
   }
@@ -269,6 +278,7 @@ export class RelayControlClient {
   private handleClose(code: number): void {
     const wasConnecting = this.state === 'opening' || this.state === 'proving'
     this.state = 'closed'
+    this.clearLivenessTimer()
     if (wasConnecting) {
       this.connectReject?.(new Error(`relay_control_closed_${code}`))
       this.clearConnectPromise()
@@ -280,5 +290,26 @@ export class RelayControlClient {
   private clearConnectPromise(): void {
     this.connectResolve = null
     this.connectReject = null
+  }
+
+  private armLivenessTimer(): void {
+    this.clearLivenessTimer()
+    const timeoutMs = this.options.livenessTimeoutMs ?? RELAY_CONTROL_LIVENESS_TIMEOUT_MS
+    this.livenessTimer = setTimeout(() => {
+      this.livenessTimer = null
+      if (this.state === 'active' || this.state === 'draining') {
+        // Why: a half-open TCP path may never emit close; terminating it lets the
+        // origin pool re-resolve the relay instead of staying falsely registered.
+        this.socket?.terminate()
+      }
+    }, timeoutMs)
+    this.livenessTimer.unref?.()
+  }
+
+  private clearLivenessTimer(): void {
+    if (this.livenessTimer) {
+      clearTimeout(this.livenessTimer)
+      this.livenessTimer = null
+    }
   }
 }

--- a/src/main/runtime/relay/relay-origin-pool.ts
+++ b/src/main/runtime/relay/relay-origin-pool.ts
@@ -113,6 +113,13 @@ export class RelayOriginPool {
           this.basisOrigins.delete(connectionId)
         }
         this.maybeCloseDrainedOrigin(origin)
+        if (![...this.basisOrigins.values()].includes(origin)) {
+          this.handleDrain(
+            origin,
+            { type: 'drain', graceMs: 0, recovery: 'resolve-director' },
+            true
+          )
+        }
       },
       onDrain: (origin, message) => this.handleDrain(origin, message),
       onClose: (origin) => {
@@ -128,7 +135,11 @@ export class RelayOriginPool {
     })
   }
 
-  private handleDrain(origin: RelayControlOrigin, message: RelayDrainMessage): void {
+  private handleDrain(
+    origin: RelayControlOrigin,
+    message: RelayDrainMessage,
+    forceFreshGeneration = false
+  ): void {
     if (!this.isCurrent() || origin !== this.activeOrigin) {
       return
     }
@@ -136,15 +147,18 @@ export class RelayOriginPool {
     this.drainingOrigins.add(origin)
     this.options.onStatus('draining')
     if (!this.rotationPromise) {
-      this.rotationPromise = this.resolveDrainTarget(origin, message).finally(() => {
-        this.rotationPromise = null
-      })
+      this.rotationPromise = this.resolveDrainTarget(origin, message, forceFreshGeneration).finally(
+        () => {
+          this.rotationPromise = null
+        }
+      )
     }
   }
 
   private async resolveDrainTarget(
     origin: RelayControlOrigin,
-    message: RelayDrainMessage
+    message: RelayDrainMessage,
+    forceFreshGeneration: boolean
   ): Promise<void> {
     try {
       if (!this.relayJwt) {
@@ -158,7 +172,7 @@ export class RelayOriginPool {
         fetch: this.options.fetch
       })
       this.assertCurrent()
-      if (assignment.cellUrl === origin.cellUrl) {
+      if (assignment.cellUrl === origin.cellUrl && !forceFreshGeneration) {
         let rebound = false
         try {
           await origin.rebind(this.relayJwt, assignment)
@@ -182,7 +196,10 @@ export class RelayOriginPool {
     } catch {
       if (this.isCurrent()) {
         const random = this.options.random ?? Math.random
-        setTimeout(() => this.handleDrain(origin, message), 250 + Math.floor(random() * 751))
+        setTimeout(
+          () => this.handleDrain(origin, message, forceFreshGeneration),
+          250 + Math.floor(random() * 751)
+        )
       }
     }
   }

--- a/src/main/runtime/relay/relay-session-broker.test.ts
+++ b/src/main/runtime/relay/relay-session-broker.test.ts
@@ -26,6 +26,9 @@ const fakes = vi.hoisted(() => ({
     pendingRequestCount: number
   }[],
   transports: [] as {
+    options: {
+      onConnectionClosed?: (connectionId: string) => void
+    }
     start: ReturnType<typeof vi.fn>
     stop: ReturnType<typeof vi.fn>
     setGeneration: ReturnType<typeof vi.fn>
@@ -80,7 +83,7 @@ vi.mock('../rpc/relay-transport', () => ({
     metadataFor = vi.fn()
     openConnection = vi.fn().mockResolvedValue(undefined)
 
-    constructor() {
+    constructor(readonly options: (typeof fakes.transports)[number]['options']) {
       fakes.transports.push(this)
     }
   }
@@ -291,6 +294,52 @@ describe('RelaySessionBroker lifecycle ownership', () => {
     expect(fakes.controls[2]!.options.controlResumeSecret).toBeUndefined()
     expect(fakes.transports).toHaveLength(2)
     await vi.waitFor(() => expect(onStatus).toHaveBeenLastCalledWith('registered'))
+    expect(broker.endpoint?.cellUrl).toBe('https://relay.example.test')
+  })
+
+  it('opens a fresh generation after the last relay data connection closes', async () => {
+    const ack: RelayHostHelloAckMessage = {
+      type: 'host-hello-ack',
+      v: 1,
+      generation: 7,
+      controlResumeSecret: 'R'.repeat(43),
+      leaseExpiresAt: 1_000_000,
+      activeConnIds: [],
+      pendingConns: []
+    }
+    fakes.controlConnect.mockResolvedValueOnce(ack).mockResolvedValueOnce({
+      ...ack,
+      generation: 8,
+      controlResumeSecret: 'N'.repeat(43)
+    })
+    const broker = await RelaySessionBroker.connect(brokerOptions())
+    fakes.controls[0]!.options.onConnectionOpen({
+      connId: 'closed-basis',
+      connTicket: 'T'.repeat(43),
+      kind: 'resume',
+      relayDeviceId: 'device-1',
+      attachDeadlineMs: 1_000
+    })
+    fakes.controls[0]!.options.onConnectionOpen({
+      connId: 'remaining-basis',
+      connTicket: 'U'.repeat(43),
+      kind: 'resume',
+      relayDeviceId: 'device-2',
+      attachDeadlineMs: 1_000
+    })
+    expect(brokerBasisIds(broker)).toEqual(['closed-basis', 'remaining-basis'])
+
+    fakes.transports[0]!.options.onConnectionClosed?.('closed-basis')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(fakes.controls).toHaveLength(1)
+
+    fakes.transports[0]!.options.onConnectionClosed?.('remaining-basis')
+    await vi.waitFor(() => expect(fakes.controls).toHaveLength(2))
+
+    expect(fakes.controls[1]!.options.previousGeneration).toBeUndefined()
+    expect(fakes.controls[1]!.options.controlResumeSecret).toBeUndefined()
+    expect(fakes.transports).toHaveLength(2)
+    expect(fakes.controls[0]!.closeNow).toHaveBeenCalledOnce()
     expect(broker.endpoint?.cellUrl).toBe('https://relay.example.test')
   })
 })


### PR DESCRIPTION
## Summary

- Recover mobile connections that stall across iOS foreground and Wi-Fi/cellular transitions.
- Retry Relay recovery after transient endpoint or credential failures instead of remaining on `Connecting...` indefinitely.
- Reprovision missing, expired, or rejected Relay credentials over an authenticated Direct connection, while preserving usable grace credentials.
- Refresh a stale desktop Relay control/data generation after the last mobile data path closes.
- Serialize Host metadata and Relay credential writes with Host removal so late async work cannot recreate deleted Hosts or leave orphaned secrets.
- Supersedes #9245 with a Relay-only branch rebased onto the latest `main`; the unrelated Shift+Enter commit and files are excluded.

## User-visible behavior

No visual redesign. A paired iPhone now moves from `Connected · Direct · LAN` to `Connected · Relay` when Wi-Fi is disabled, remains connected on 5G, and reconnects without re-pairing after the mobile or desktop app restarts.

## Testing

- [x] Mobile full suite: 287 files passed, 2,073 tests passed, 2 conditionally skipped.
- [x] Mobile lint, typecheck, formatting, and `git diff --check` passed.
- [x] Desktop Relay targeted suite: 9 files and 35 tests passed, with Node typecheck and static checks.
- [x] Added failure-first regression coverage for foreground socket replacement, Relay retry exhaustion, stale generation recovery, rejected/grace credential handling, transient reprovision retry, background races, and Host removal/write races.
- [x] Signed standalone iOS Release build completed; embedded JavaScript bundle, bundle identity, freshness, and code signature were verified.
- [x] An expanded desktop suite run passed 31,639 tests and found 5 failures in one pre-existing terminal IME test file outside this PR's Relay-only diff.

## Real-device verification

- [x] Existing Host and committed Relay binding survived an in-place app update.
- [x] Wi-Fi ON connected through Direct/LAN.
- [x] Wi-Fi OFF removed all LAN connections and produced a new 5G Relay connection.
- [x] The 5G Relay connection remained stable for 90 seconds.
- [x] Terminating and relaunching the iPhone app on 5G reconnected automatically without user repair or re-pairing.
- [x] Restarting the desktop Orca UI preserved the current conversation and terminal count, while the 5G Relay connection remained available.

## Security audit

- Relay tokens, hashes, device tokens, signing identifiers, and provisioning identifiers are never emitted in connection diagnostics.
- Credential bundle, journal, endpoint, token, and overlay persistence is guarded against Host deletion races.
- The change reuses the existing authenticated Direct provisioning and encrypted Relay handshake paths; it adds no new public endpoint or credential surface.

## Review status

- Two independent code reviews found no remaining merge blocker after the Direct/Relay retry timer race and Host deletion persistence race were fixed.
- The replacement branch contains 26 mobile/Relay files and excludes all 15 unrelated Shift+Enter files from #9245.
- This fork PR requires a maintainer with write access to review and merge.
