### PR TITLE
fix(editor): use Monaco's registered proto language id for .proto files

### DIFF
--- a/src/renderer/src/lib/language-detect.test.ts
+++ b/src/renderer/src/lib/language-detect.test.ts
@@ -38,6 +38,10 @@ describe('detectLanguage', () => {
     expect(detectLanguage('C:\\rtl\\TOP.SV')).toBe('systemverilog')
   })
 
+  it('maps .proto files to the Monaco built-in proto language id, not the alias', () => {
+    expect(detectLanguage('api/v1/service.proto')).toBe('proto')
+  })
+
   it('maps .jsonl files to the dedicated jsonl language id (case-insensitive)', () => {
     expect(detectLanguage('/home/user/.claude/sessions/transcript.jsonl')).toBe('jsonl')
     expect(detectLanguage('C:\\Users\\alice\\.codex\\LOG.JSONL')).toBe('jsonl')

--- a/src/renderer/src/lib/language-detect.ts
+++ b/src/renderer/src/lib/language-detect.ts
@@ -69,7 +69,7 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
   '.graphql': 'graphql',
   '.gql': 'graphql',
   '.dockerfile': 'dockerfile',
-  '.proto': 'protobuf',
+  '.proto': 'proto',
   '.lua': 'lua',
   '.r': 'r',
   '.R': 'r',


### PR DESCRIPTION
Fixes #9280

## Summary

`.proto` (Protocol Buffers) files rendered as flat, uncolored text. Monaco ships a Protocol Buffers grammar, so this was a wiring bug, not a missing language.

`detectLanguage()` returned the language id `'protobuf'`. Monaco registers Protocol Buffers under the id `'proto'` — `'protobuf'` is only an *alias*:

```js
// monaco-editor/esm/vs/basic-languages/protobuf/protobuf.contribution.js
registerLanguage({
  id: "proto",
  extensions: [".proto"],
  aliases: ["protobuf", "Protocol Buffers"],
  loader: () => import('./protobuf.js')
});
```

Monaco matches ids and never resolves aliases, and degrades silently instead of erroring, so both surfaces that pass the id explicitly lost highlighting:

- **File editor and diff viewer.** `@monaco-editor/react` calls `monaco.editor.createModel(value, language, uri)`. With an explicit language Monaco uses `createById()`, which falls back to plaintext for an unregistered id. It only guesses from the file path when *no* language is passed, and Orca always passes one.
- **PR/issue review comment code excerpts.** `MonacoCodeExcerpt` calls `monaco.editor.colorize(code, language)`, which fails `isRegisteredLanguageId` and returns uncolored output.

The fix is one line in the extension map: `'.proto': 'proto'`. Monaco lazy-loads the tokenizer on first use, so no bundling or worker change is needed.

## Screenshots

| Before | After |
| :--: | :--: |
| <img height="520" alt="service.proto rendered as uncolored plain text" src="https://github.com/user-attachments/assets/5cdb7e12-c249-40ac-b5be-4b97b3e70ae4" /> | <img height="520" alt="service.proto with proto syntax highlighting" src="https://github.com/user-attachments/assets/c0f4ee18-5fce-4123-b821-555870291ed1" /> |
| Every token falls into a single uncolored class. | Keywords, types, strings, and comments are tokenized. |

## Testing

- [x] `pnpm lint` — pre-existing failure on `skill-freshness-group.tsx:101`, reproduced identically on a clean `origin/main`; untouched by this branch
- [x] `pnpm typecheck`
- [x] `pnpm test` — 38 failures, all pre-existing: `origin/main` fails the same 7 files / 38 tests, and this branch differs only by the +1 test added here
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

## AI Review Report

Reviewed with Claude Code.

- **Cross-platform (macOS / Linux / Windows).** No platform-specific behavior. One entry in a static extension→id map in renderer code — no platform branches, shortcuts, accelerator labels, or path construction. Lookup already lowercases via `extname(filename).toLowerCase()`, so `.PROTO` resolves identically on case-insensitive filesystems.
- **SSH / remote / local.** `detectLanguage()` takes a path string and touches no filesystem, process, or network; behavior is identical for local worktrees, SSH worktrees, and remote runtimes.
- **Agent / integration / git provider.** Nothing provider-specific. `MonacoCodeExcerpt` is shared by `PullRequestPage` and `GitHubItemDialog`, so the fix benefits GitLab and other providers on the same components.
- **Performance.** No hot-path impact. Monaco lazy-loads the `proto` tokenizer on first use, so the old value was not saving work — it was silently rendering plaintext.
- **UI quality.** Verified in a real build. Coloring comes from the active Monaco theme, so light and dark both follow existing theme tokens; no new colors introduced.
- **Blast radius.** `detectLanguage` has many call sites, but only the `.proto` entry changed, so no other language moves.

Verified against Monaco's own APIs rather than by inspection alone: `createModel(sample, 'protobuf', Uri.file('x.proto')).getLanguageId()` returns `plaintext`, `'proto'` returns `proto`, and `colorize()` with the alias yields a single uncolored token class versus five with the registered id.

## Security Audit

Low risk; no security-relevant surface is touched.

- **Input handling.** No new parsing. The changed value is a compile-time constant, not derived from user input.
- **Path handling.** Unchanged — the existing `extname`/separator logic was not modified.
- **Command execution, auth, secrets, IPC, dependencies.** None involved. No new dependency, IPC channel, or privilege change.
- **Downstream sinks.** The value flows only into Monaco language-registry lookups (`createById`, `isRegisteredLanguageId`), which treat it as an opaque key. Supplying a *registered* id strictly narrows behavior versus the unregistered string it replaces.

No follow-up needed.

## Notes

- No platform-specific, SSH-specific, agent-specific, or provider-specific behavior in this change.
- Unrelated observation while testing a build with the fix reverted: the editor stuck on the `Loading editor...` Suspense fallback and Monaco never mounted for a 3 KB `.proto` file, with no JS error surfaced. Not addressed here; happy to file separately if others can reproduce.
- X (Twitter) handle: <!-- TODO: add your handle -->
