### PR TITLE
fix(terminal): stabilize OMP agent status

### DIFF
--- a/src/shared/synthetic-agent-title.test.ts
+++ b/src/shared/synthetic-agent-title.test.ts
@@ -32,12 +32,20 @@ describe('synthetic agent titles', () => {
   it('provides Pi-compatible OMP titles for hook-driven status updates', () => {
     expect(getSyntheticAgentTerminalTitle('omp', 'done')).toBe('OMP ready')
     expect(getSyntheticAgentTerminalTitle('omp', 'waiting')).toBe('OMP - action required')
-    expect(shouldDriveSyntheticAgentTitleFromHook('omp', 'working')).toBe(true)
+    expect(shouldDriveSyntheticAgentTitleFromHook('omp', 'working')).toBe(false)
+    expect(shouldDriveSyntheticAgentTitleFromHook('omp', 'done')).toBe(true)
   })
 
   it('provides Pi titles for hook-driven status updates', () => {
     expect(getSyntheticAgentTerminalTitle('pi', 'done')).toBe('Pi ready')
     expect(getSyntheticAgentTerminalTitle('pi', 'waiting')).toBe('Pi - action required')
+    expect(shouldDriveSyntheticAgentTitleFromHook('pi', 'working')).toBe(true)
+  })
+
+  it('keeps OMP terminal-state synthesis while leaving Pi working-title synthesis enabled', () => {
+    expect(getSyntheticAgentTerminalTitle('omp', 'blocked')).toBe('OMP - action required')
+    expect(shouldDriveSyntheticAgentTitleFromHook('omp', 'blocked')).toBe(true)
+    expect(shouldDriveSyntheticAgentTitleFromHook('omp', 'working')).toBe(false)
     expect(shouldDriveSyntheticAgentTitleFromHook('pi', 'working')).toBe(true)
   })
 })

--- a/src/shared/synthetic-agent-title.ts
+++ b/src/shared/synthetic-agent-title.ts
@@ -40,7 +40,8 @@ export const SYNTHETIC_AGENT_TITLE_PROFILES: Record<string, SyntheticAgentTitleP
     workingLabel: 'OMP',
     permissionLabel: 'OMP - action required',
     idleLabel: 'OMP ready',
-    titleIdentityGroup: 'pi-compatible'
+    titleIdentityGroup: 'pi-compatible',
+    synthesizeWorkingTitle: false
   },
   droid: {
     workingLabel: 'Droid',


### PR DESCRIPTION
## Summary

- Keep OMP's native working title authoritative so hook-generated spinner frames no longer compete with OMP OSC titles.
- Preserve hook-derived OMP waiting and ready titles, plus the existing Pi, Codex, and OpenCode policies.

Refs #8986.

## Screenshots

Add a short after recording showing an OMP working turn with stable terminal-tab status.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation run in this session:

- `pnpm exec vitest run --config config/vitest.config.ts src/shared/synthetic-agent-title.test.ts` - passed
- `pnpm run typecheck:node && pnpm run typecheck:web` - passed
- `pnpm exec oxlint src/shared/synthetic-agent-title.ts src/shared/synthetic-agent-title.test.ts && pnpm exec oxfmt --check src/shared/synthetic-agent-title.ts src/shared/synthetic-agent-title.test.ts` - passed

## AI Review Report

Pending final diff review. Review must verify OMP working-hook suppression, preserved waiting and done titles, Pi working-title behavior, and no changes to sidebar retention or other agent integrations.

## Security Audit

Pending final diff review. The change adds no input handling, command execution, path handling, authentication, secret, dependency, or IPC surface.

## Notes

The ghost-row report is outside this PR. Its mechanism is not established by the supplied reproduction and overlaps open PRs #9008 and #9095.

## ELI5

OMP's working tab title fought with hook-generated spinner titles and flickered. OMP's own working title stays in charge while waiting/ready titles from hooks still apply.
