### PR TITLE
fix(terminal): ignore navigation Escape for OMP and Pi

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -942,6 +942,137 @@ describe('AgentHookServer listener replay', () => {
     }
   })
 
+  it.each(['omp', 'pi'] as const)('rejects plain Escape inference for %s', (agentType) => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          payload: { state: 'working', prompt: 'long task', agentType }
+        },
+        'conn-1'
+      )
+      const baseline = server.getStatusSnapshot()[0]
+
+      vi.setSystemTime(1_500)
+      const applied = server.inferInterrupt({
+        paneKey: PANE,
+        baselineUpdatedAt: baseline.receivedAt,
+        baselineStateStartedAt: baseline.stateStartedAt,
+        baselinePrompt: 'long task',
+        baselineAgentType: agentType,
+        intent: 'plain-escape'
+      })
+
+      expect(applied).toBe(false)
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          state: 'working',
+          prompt: 'long task',
+          agentType
+        })
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it.each(['omp', 'pi'] as const)('still accepts Ctrl+C inference for %s', (agentType) => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          payload: { state: 'working', prompt: 'long task', agentType }
+        },
+        'conn-1'
+      )
+      const baseline = server.getStatusSnapshot()[0]
+
+      vi.setSystemTime(1_500)
+      const applied = server.inferInterrupt({
+        paneKey: PANE,
+        baselineUpdatedAt: baseline.receivedAt,
+        baselineStateStartedAt: baseline.stateStartedAt,
+        baselinePrompt: 'long task',
+        baselineAgentType: agentType,
+        intent: 'ctrl-c'
+      })
+
+      expect(applied).toBe(true)
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          state: 'done',
+          prompt: 'long task',
+          agentType,
+          interrupted: true
+        })
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it.each(['omp', 'pi'] as const)(
+    'ignored navigation Escape does not block %s agent_end',
+    (agentType) => {
+      vi.useFakeTimers()
+      vi.setSystemTime(1_000)
+      try {
+        const server = new AgentHookServer()
+        server.ingestRemote(
+          {
+            paneKey: PANE,
+            tabId: 'tab-1',
+            worktreeId: 'wt-1',
+            payload: { state: 'working', prompt: 'long task', agentType }
+          },
+          'conn-1'
+        )
+        const baseline = server.getStatusSnapshot()[0]
+
+        vi.setSystemTime(1_500)
+        const applied = server.inferInterrupt({
+          paneKey: PANE,
+          baselineUpdatedAt: baseline.receivedAt,
+          baselineStateStartedAt: baseline.stateStartedAt,
+          baselinePrompt: 'long task',
+          baselineAgentType: agentType,
+          intent: 'plain-escape'
+        })
+        expect(applied).toBe(false)
+
+        const event = normalizeHookPayload(
+          createHookListenerState(),
+          agentType,
+          buildBody({ hook_event_name: 'agent_end' }),
+          'production'
+        )
+        if (!event) {
+          throw new Error('normalizeHookPayload rejected a known-good agent_end fixture')
+        }
+        server.ingestRemote(event, 'conn-1')
+
+        expect(server.getStatusSnapshot()).toEqual([
+          expect.objectContaining({
+            state: 'done',
+            agentType
+          })
+        ])
+      } finally {
+        vi.useRealTimers()
+      }
+    }
+  )
+
   it('does not let late same-turn working hooks resurrect an inferred interrupt', () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -789,6 +789,10 @@ export class AgentHookServer {
     if (agentType === 'droid' && request.intent === 'ctrl-c') {
       return false
     }
+    // Why: OMP and Pi consume plain Escape for TUI navigation; their real stops still arrive through hooks.
+    if ((agentType === 'omp' || agentType === 'pi') && request.intent === 'plain-escape') {
+      return false
+    }
     // Why: these agents use the first Escape as a TUI cancel that can leave the turn running; only a double Escape infers an interrupt.
     if (
       (agentType === 'opencode' || agentType === 'copilot') &&

--- a/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
@@ -191,6 +191,25 @@ describe('agent interrupt inference', () => {
     entry = undefined
   })
 
+  it.each(['omp', 'pi'] as const)('does not infer plain Escape for %s', (agentType) => {
+    vi.useFakeTimers()
+    let entry: AgentStatusEntry | undefined = makeEntry({ agentType })
+    const inferInterrupt = vi.fn()
+    const tracker = createAgentInterruptInference({
+      paneKey: PANE_KEY,
+      getStatusEntry: () => entry,
+      inferInterrupt,
+      now: () => 1_100
+    })
+
+    tracker.observeInputIntent('plain-escape')
+    vi.advanceTimersByTime(500)
+
+    expect(inferInterrupt).not.toHaveBeenCalled()
+    tracker.dispose()
+    entry = undefined
+  })
+
   it.each(['opencode', 'copilot'] as const)(
     'infers immediately on double Escape for %s',
     (agentType) => {
@@ -317,6 +336,32 @@ describe('agent interrupt inference', () => {
       baselineStateStartedAt: 900,
       baselinePrompt: 'write tests',
       baselineAgentType: 'opencode',
+      intent: 'ctrl-c'
+    })
+    tracker.dispose()
+    entry = undefined
+  })
+
+  it.each(['omp', 'pi'] as const)('still infers Ctrl+C for %s', (agentType) => {
+    vi.useFakeTimers()
+    let entry: AgentStatusEntry | undefined = makeEntry({ agentType })
+    const inferInterrupt = vi.fn()
+    const tracker = createAgentInterruptInference({
+      paneKey: PANE_KEY,
+      getStatusEntry: () => entry,
+      inferInterrupt,
+      now: () => 1_100
+    })
+
+    tracker.observeInputIntent('ctrl-c')
+    vi.advanceTimersByTime(500)
+
+    expect(inferInterrupt).toHaveBeenCalledWith({
+      paneKey: PANE_KEY,
+      baselineUpdatedAt: 1_000,
+      baselineStateStartedAt: 900,
+      baselinePrompt: 'write tests',
+      baselineAgentType: agentType,
       intent: 'ctrl-c'
     })
     tracker.dispose()

--- a/src/renderer/src/components/terminal-pane/agent-interrupt-inference.ts
+++ b/src/renderer/src/components/terminal-pane/agent-interrupt-inference.ts
@@ -58,7 +58,10 @@ function shouldIgnoreInterruptIntent(
   agentType: AgentStatusEntry['agentType'],
   intent: AgentInterruptInputIntent
 ): boolean {
-  return agentType === 'droid' && intent === 'ctrl-c'
+  return (
+    (agentType === 'droid' && intent === 'ctrl-c') ||
+    ((agentType === 'omp' || agentType === 'pi') && intent === 'plain-escape')
+  )
 }
 
 function canInferInterrupt(entry: AgentStatusEntry, intent: AgentInterruptInputIntent): boolean {


### PR DESCRIPTION
## Summary

- Stop plain Escape used for OMP and Pi navigation from being inferred as a turn interruption.
- Keep terminal input, unread clearing, hook-driven completion, Ctrl+C handling, and other agents' interrupt policies unchanged.
- Recheck the exclusion in main so direct or stale-renderer inference requests cannot synthesize a false stopped result.

Closes #9208.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation run after the rebase onto current main:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts src/main/agent-hooks/server.test.ts` - passed, `303` tests passed
- `pnpm run typecheck:web` - passed
- `pnpm run typecheck:node` - passed
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/agent-interrupt-inference.ts src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts src/main/agent-hooks/server.ts src/main/agent-hooks/server.test.ts && pnpm exec oxfmt --check src/renderer/src/components/terminal-pane/agent-interrupt-inference.ts src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts src/main/agent-hooks/server.ts src/main/agent-hooks/server.test.ts` - passed

A server-level test also asserts that after an ignored plain-Escape inference for OMP and Pi, a subsequent `agent_end` hook still transitions the row to `done`, so hook-driven completion is verified end to end rather than only in isolation.

## AI Review Report

Reviewed against the touched renderer and main interrupt-inference paths. The diff is limited to a plain-Escape ignore guard for OMP and Pi plus regression coverage that proves those agents no longer infer interrupts from navigation Escape, while Ctrl+C for OMP and Pi, Droid's Ctrl+C exclusion, and OpenCode/Copilot double-Escape behavior remain intact. Cross-platform review stays clean on macOS, Linux, and Windows because the change only adjusts shared interrupt-intent policy, without changing shortcuts beyond the existing plain-Escape classification, labels, paths, shell behavior, or Electron-only code paths.

## Security Audit

Reviewed for bypass risk. Main keeps the authoritative plain-Escape exclusion, so a direct or stale renderer inference request still cannot synthesize a false stop for OMP or Pi. The change adds no command execution, path handling, credential flow, dependency, or new IPC/API surface.

## Notes

The guard is intentionally limited to plain Escape for OMP and Pi. It does not declare Escape globally non-interrupting and does not suppress genuine hook-reported completion.

## ELI5

Pressing Escape while navigating in OMP or Pi was treated as interrupting the agent turn. Plain Escape for those agents is ignored for interrupt inference so navigation keys do not fake a stop.

