### PR TITLE
perf(persistence): compact JSON for durable-state save payload (drop pretty-print)

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -5573,6 +5573,22 @@ describe('Store', () => {
     }
   })
 
+  it('writes compact JSON (no pretty-print indentation) that round-trips via JSON.parse', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo({ id: 'compact-repo', path: '/compact/repo' }))
+    store.updateUI({ sidebarWidth: 321 })
+    store.flush()
+
+    const raw = readFileSync(dataFile(), 'utf-8')
+    // Compact payload: no newline-plus-indentation from JSON.stringify(_, null, 2).
+    expect(raw).not.toMatch(/\n\s+"/)
+    const parsed = JSON.parse(raw) as PersistedState
+    expect(parsed.repos).toContainEqual(
+      expect.objectContaining({ id: 'compact-repo', path: '/compact/repo' })
+    )
+    expect(parsed.ui.sidebarWidth).toBe(321)
+  })
+
   it('migrates missing rightSidebarOpen from the legacy default setting', async () => {
     writeDataFile({
       schemaVersion: 1,

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -2637,7 +2637,7 @@ export class Store {
   private writesFrozen = false
   // Why: hash of the plaintext state as of the last successful write. Saves
   // triggered by mutations that net out to identical state skip the full
-  // 1.6MB pretty-print + tmp write + rename. Hashing plaintext (not the
+  // multi-MB serialize + tmp write + rename. Hashing plaintext (not the
   // written payload) because encrypt() uses a random IV per call, so the
   // on-disk bytes differ even for identical state.
   private lastWrittenStateHash: string | null = null
@@ -3733,7 +3733,10 @@ export class Store {
         browserKagiSessionLink: encryptOptionalSecret(this.state.ui.browserKagiSessionLink)
       }
     }
-    return JSON.stringify(stateToSave, null, 2)
+    // Why compact: ~20-30% fewer bytes (state-shape dependent; measured 21% on
+    // real state) and less serialize time on the sync-flush path; all readers
+    // JSON.parse, so on-disk formatting is irrelevant.
+    return JSON.stringify(stateToSave)
   }
 
   // Why: async writes avoid blocking the main Electron thread on every


### PR DESCRIPTION
## Description

Orca serialized its durable state with `JSON.stringify(stateToSave, null, 2)` before every write — the 2-space pretty-print inflates a multi-MB file with indentation no reader needs, since every consumer loads it back via `JSON.parse`. `buildStateToSave()` now emits compact JSON (`JSON.stringify(stateToSave)`, `src/main/persistence.ts:3738`), trimming both the bytes written and the serialize time on the synchronous flush path (pty:spawn, tab-close, shutdown) as well as the async debounced write. A stale comment referencing the old pretty-print was updated (`src/main/persistence.ts:2640`).

This is the **safe downscope**. The fuller "single stringify" win was abandoned on purpose: it required memoizing `encrypt()` to make the payload deterministic, which adversarial review showed risks **credential data-loss** (stale ciphertext written after a keyring rotation / safeStorage outage → unrecoverable on restart). So the double-stringify stays — the no-op dedupe hash still runs over the **plaintext** durable state (`computeStateHash`, unchanged), and `encrypt()`, write-generation re-checks, force-on-in-flight, atomic tmp+rename, backup rotation, and the synchronous shutdown flush are all untouched. Only the payload formatting becomes compact.

## Evidence

Measured on the real Store serializer (median stringify over warmed iters, Node v24):

| Workload | Bytes written | Payload stringify (median) |
| --- | --- | --- |
| **Live production `orca-data.json`** (1,544,310 B) — pretty → compact | 1,544,310 → **1,214,766 B (−21.3%)** | 1.810 → **1.444 ms (−0.366 ms, ~20%)** |
| Metadata-heavy realistic state — pretty → compact | 2,606.9 → **1,772.3 KB (−32.0%)** | 3.86 → **2.77 ms (~28%)** |
| 4× scale — pretty → compact | 10,437.6 → **7,108.4 KB (−31.9%)** | 16.16 → **11.36 ms (~30%)** |

**Applies to:** every non-no-op save — most importantly the synchronous main-thread flush at pty:spawn / tab-close / shutdown, where this shaves ~0.4 ms (1.5 MB state) up to ~4.8 ms (7 MB state) of block per flush, plus the smaller tmp-write + rename + backup-rotation I/O.

**Does NOT change:** no-op deduped saves (still short-circuit on the plaintext hash *before* serializing), the double-stringify itself (the hash guard still stringifies plaintext separately — that's the safe part we kept), or amortized background CPU (debounce is bounded to 1 s trailing / 5 s max-wait, so worst-case ~1 ms/s — negligible). Honest caveat: the byte ratio is state-shape dependent and shrinks when large opaque scrollback blobs are stored inline (pretty-print adds no whitespace inside opaque strings); the code comment says "~20-30% (measured 21% on real state)".

## Proof of no regressions

- **Typecheck:** `tsc --noEmit -p config/tsconfig.node.json --composite false` → exit 0 (verified independently).
- **Targeted tests:** `vitest run src/main/persistence.test.ts` → **382 passed (382)** (verified independently), including a new test asserting the on-disk bytes contain no pretty-print indentation (`/\n\s+"/`) and that `JSON.parse` round-trips. The existing no-op dedupe test passes unchanged (the hash is over plaintext).
- **Lint / format:** `oxlint` on both files → 0 warnings / 0 errors; `oxfmt` no changes; `check:max-lines-ratchet` OK (no new bypass).
- **Behavior equivalence:** (1) `deepStrictEqual(JSON.parse(compact), JSON.parse(pretty))` across all measured states — identical (differ only in insignificant whitespace). (2) Every data-file reader consumes via `JSON.parse` (`load()@2879`, profile state file, startup config, github-cache) — no line-based/streaming parse exists, so on-disk formatting is irrelevant. (3) The no-op-save skip hashes plaintext (unchanged), so write-skip logic is unaffected.
- **Adversarial review:** GPT-5.6-Sol xHIGH converged to **two consecutive clean rounds, zero blocking findings**. The review also *drove the downscope* — rejecting the full single-stringify because the required `encrypt()` memo risks persisting stale ciphertext. Zero regressions is the bar and is met.

## ELI5

Orca saves your workspace to a file over and over, and it used to add lots of extra spacing to make that file pretty for humans — but nothing ever reads it by eye, the app just loads it straight back in. We stopped adding the spacing, so the file is about a fifth to a third smaller and saves a bit faster, especially at the moments the app briefly pauses to save (opening a terminal, closing a tab, quitting). Nothing about *what* is saved or how it's protected changed.

Made with [Orca](https://github.com/stablyai/orca) 🐋
