### PR TITLE
fix(source-control): bound Create PR eligibility probe so it can't hang

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.host-context-boundary.test.ts
+++ b/src/renderer/src/components/right-sidebar/SourceControl.host-context-boundary.test.ts
@@ -68,9 +68,22 @@ describe('SourceControl host-context boundaries', () => {
       '// Why: reset to null so that effectiveBaseRef becomes falsy until the IPC',
       'const normalizedWorktreeBaseRef ='
     )
-    expect(baseRefSection).toContain('activeRepoId')
-    expect(baseRefSection).toContain('activeRepoRuntimeEnvironmentId')
-    expect(baseRefSection).not.toContain('[activeRepo,')
-    expect(baseRefSection).not.toContain('activeRepoSettings')
+    expect(baseRefSection).toContain(
+      'getRuntimeRepoBaseRefDefault(\n      { activeRuntimeEnvironmentId: activeRepoRuntimeEnvironmentId },\n      activeRepoId'
+    )
+    const dependencyBlock = sourceBetween(baseRefSection, '  }, [', '  ])')
+    const dependencyEntries = dependencyBlock
+      .split('\n')
+      .slice(1)
+      .map((line) => line.trim().replace(/,$/, ''))
+      .filter((line) => line.length > 0 && !line.startsWith('//'))
+    expect(dependencyEntries).toEqual([
+      'activeRepoConnectionId',
+      'activeRepoExecutionHostId',
+      'activeRepoId',
+      'activeRepoRuntimeEnvironmentId',
+      'isBranchVisible',
+      'isFolder'
+    ])
   })
 })

--- a/src/renderer/src/components/right-sidebar/SourceControl.host-context-boundary.test.ts
+++ b/src/renderer/src/components/right-sidebar/SourceControl.host-context-boundary.test.ts
@@ -51,4 +51,26 @@ describe('SourceControl host-context boundaries', () => {
     expect(requestContext).toContain('settings,')
     expect(requestContext).not.toContain('useAppStore.getState().settings')
   })
+
+  it('keeps eligibility base refreshes scoped to repo execution ownership', () => {
+    const ownerSettingsSection = sourceBetween(
+      SOURCE_CONTROL_SOURCE,
+      'const activeRepoSettings = useMemo(',
+      'const updateSettings = useAppStore'
+    )
+    expect(ownerSettingsSection).not.toContain('activeRepo ?? null')
+    expect(ownerSettingsSection).toContain(
+      '[activeRepoConnectionId, activeRepoExecutionHostId, activeRepoId, settings]'
+    )
+
+    const baseRefSection = sourceBetween(
+      SOURCE_CONTROL_SOURCE,
+      '// Why: reset to null so that effectiveBaseRef becomes falsy until the IPC',
+      'const normalizedWorktreeBaseRef ='
+    )
+    expect(baseRefSection).toContain('activeRepoId')
+    expect(baseRefSection).toContain('activeRepoRuntimeEnvironmentId')
+    expect(baseRefSection).not.toContain('[activeRepo,')
+    expect(baseRefSection).not.toContain('activeRepoSettings')
+  })
 })

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from 'react'
 import {
   ArrowDownUp,
   AlertTriangle,
@@ -266,7 +266,8 @@ import { resolveVisibleCreatePrHeaderAction } from './source-control-create-pr-i
 import { resolveBlockedCreateReviewNoticeMessage } from './source-control-create-review-blocked-action'
 import {
   buildLoadingHostedReviewCreationEligibility,
-  buildLocalBlockerHostedReviewCreationEligibility
+  buildLocalBlockerHostedReviewCreationEligibility,
+  resolveHostedReviewCreationProviderForTarget
 } from './source-control-hosted-review-creation-eligibility-snapshot'
 import {
   resolveCreatePrHeaderAction,
@@ -826,6 +827,8 @@ function SourceControlInner(): React.JSX.Element {
   const worktreeMap = useWorktreeMap()
   const rightSidebarTab = useAppStore((s) => s.rightSidebarTab)
   const activeRepo = useRepoById(activeWorktree?.repoId ?? null)
+  const activeRepoId = activeRepo?.id ?? null
+  const activeRepoPath = activeRepo?.path ?? null
   const gitIdentityDisplay = activeWorktree ? getWorktreeGitIdentityDisplay(activeWorktree) : null
   const detachedHeadDisplay = gitIdentityDisplay?.kind === 'detached' ? gitIdentityDisplay : null
   const branchName = gitIdentityDisplay?.kind === 'branch' ? gitIdentityDisplay.branchName : ''
@@ -1608,11 +1611,13 @@ function SourceControlInner(): React.JSX.Element {
       remoteInferredHostedReviewProvider
     ]
   )
-  // Why: the eligibility probe's failure fallback needs the current provider
-  // without adding it to the probe effect's deps (which would re-run the probe
-  // on every provider recompute).
-  const provisionalHostedReviewProviderRef = useRef(provisionalHostedReviewProvider)
-  provisionalHostedReviewProviderRef.current = provisionalHostedReviewProvider
+  const resolveCurrentHostedReviewCreationProvider = useEffectEvent(() =>
+    resolveHostedReviewCreationProviderForTarget(
+      hostedReviewCreationProviderHintRef.current,
+      { repoId: activeRepoId, worktreeId: activeWorktreeId ?? null, branch: branchName },
+      provisionalHostedReviewProvider
+    )
+  )
   useEffect(() => {
     const hasConcreteProviderHint =
       hostedReview !== null ||
@@ -1651,18 +1656,16 @@ function SourceControlInner(): React.JSX.Element {
     // upstream/dirty/base state is reconciling after commit or push, while
     // preserving provider copy from the previous safe snapshot.
     if (isHostedReviewCreationLoading) {
-      const providerHint = hostedReviewCreationProviderHintRef.current
-      const provider =
-        providerHint.repoId === (activeRepo?.id ?? null) &&
-        providerHint.worktreeId === (activeWorktreeId ?? null) &&
-        providerHint.branch === branchName
-          ? providerHint.provider
-          : provisionalHostedReviewProvider
+      const provider = resolveHostedReviewCreationProviderForTarget(
+        hostedReviewCreationProviderHintRef.current,
+        { repoId: activeRepoId, worktreeId: activeWorktreeId ?? null, branch: branchName },
+        provisionalHostedReviewProvider
+      )
       return buildLoadingHostedReviewCreationEligibility(provider)
     }
     return hostedReviewCreation
   }, [
-    activeRepo?.id,
+    activeRepoId,
     activeWorktreeId,
     branchName,
     hostedReviewCreation,
@@ -3240,7 +3243,14 @@ function SourceControlInner(): React.JSX.Element {
   ])
 
   useEffect(() => {
-    if (!isBranchVisible || !activeRepo || isFolder || !branchName || !activeWorktreeId) {
+    if (
+      !isBranchVisible ||
+      !activeRepoId ||
+      !activeRepoPath ||
+      isFolder ||
+      !branchName ||
+      !activeWorktreeId
+    ) {
       setHostedReviewCreationState(null)
       setHostedReviewCreationRequestState(null)
       return
@@ -3255,7 +3265,7 @@ function SourceControlInner(): React.JSX.Element {
     }
     let stale = false
     setHostedReviewCreationRequestState({
-      repoId: activeRepo.id,
+      repoId: activeRepoId,
       worktreeId: activeWorktreeId,
       branch: branchName,
       status: 'loading'
@@ -3264,8 +3274,8 @@ function SourceControlInner(): React.JSX.Element {
     // to click while the new preflight is still resolving.
     setHostedReviewCreationState(null)
     void getHostedReviewCreationEligibility({
-      repoPath: activeRepo.path,
-      repoId: activeRepo.id,
+      repoPath: activeRepoPath,
+      repoId: activeRepoId,
       ...(worktreePath ? { worktreePath } : {}),
       branch: branchName,
       base: effectiveBaseRef ?? null,
@@ -3283,7 +3293,7 @@ function SourceControlInner(): React.JSX.Element {
       .then((result) => {
         if (!stale) {
           setHostedReviewCreationState({
-            repoId: activeRepo.id,
+            repoId: activeRepoId,
             worktreeId: activeWorktreeId,
             branch: branchName,
             data: result
@@ -3301,7 +3311,7 @@ function SourceControlInner(): React.JSX.Element {
         // upstream, needs push/sync), surface the actionable preparation intent;
         // otherwise fall back to the retryable failed state.
         const localBlocker = buildLocalBlockerHostedReviewCreationEligibility(
-          provisionalHostedReviewProviderRef.current,
+          resolveCurrentHostedReviewCreationProvider(),
           {
             branch: branchName,
             baseRef: effectiveBaseRef,
@@ -3313,7 +3323,7 @@ function SourceControlInner(): React.JSX.Element {
         )
         if (localBlocker) {
           setHostedReviewCreationState({
-            repoId: activeRepo.id,
+            repoId: activeRepoId,
             worktreeId: activeWorktreeId,
             branch: branchName,
             data: localBlocker
@@ -3323,7 +3333,7 @@ function SourceControlInner(): React.JSX.Element {
         }
         setHostedReviewCreationState(null)
         setHostedReviewCreationRequestState({
-          repoId: activeRepo.id,
+          repoId: activeRepoId,
           worktreeId: activeWorktreeId,
           branch: branchName,
           status: 'failed'
@@ -3333,7 +3343,9 @@ function SourceControlInner(): React.JSX.Element {
       stale = true
     }
   }, [
-    activeRepo,
+    // Why: unrelated repo metadata replacement must not restart a hung probe's timeout.
+    activeRepoId,
+    activeRepoPath,
     branchName,
     effectiveBaseRef,
     getHostedReviewCreationEligibility,

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -285,6 +285,7 @@ import {
   resolveHostedReviewStateForActions
 } from './source-control-hosted-review-push-target'
 import { buildSourceControlManualReviewUrlFromContext } from './source-control-manual-review-url'
+import { parseRemoteRepo } from './source-control-remote-repo'
 export { HostedReviewHeaderLink } from './hosted-review-header-chrome'
 import {
   createRunningCommitMessageGenerationRecord,
@@ -1568,6 +1569,13 @@ function SourceControlInner(): React.JSX.Element {
     hostedReviewCreationRequestMatchesCurrent &&
     hostedReviewCreationRequestState.status === 'loading' &&
     hostedReview === null
+  // Why: without a linked review or probe result the provider is unknown; infer
+  // it from the remote host so a GitLab (etc.) repo shows its own review copy
+  // instead of the GitHub default during loading and after a probe failure.
+  const remoteInferredHostedReviewProvider = useMemo(
+    () => parseRemoteRepo(activeRepo?.gitRemoteIdentity?.remoteUrl ?? '')?.provider ?? null,
+    [activeRepo?.gitRemoteIdentity?.remoteUrl]
+  )
   const provisionalHostedReviewProvider = useMemo(
     () =>
       resolveProvisionalHostedReviewProvider({
@@ -1584,7 +1592,8 @@ function SourceControlInner(): React.JSX.Element {
         linkedGitLabMR,
         linkedBitbucketPR,
         linkedAzureDevOpsPR,
-        linkedGiteaPR
+        linkedGiteaPR,
+        remoteInferredProvider: remoteInferredHostedReviewProvider
       }),
     [
       activeRepo?.id,
@@ -1595,7 +1604,8 @@ function SourceControlInner(): React.JSX.Element {
       linkedBitbucketPR,
       linkedGitHubPR,
       linkedGitLabMR,
-      linkedGiteaPR
+      linkedGiteaPR,
+      remoteInferredHostedReviewProvider
     ]
   )
   // Why: the eligibility probe's failure fallback needs the current provider
@@ -3293,6 +3303,8 @@ function SourceControlInner(): React.JSX.Element {
         const localBlocker = buildLocalBlockerHostedReviewCreationEligibility(
           provisionalHostedReviewProviderRef.current,
           {
+            branch: branchName,
+            baseRef: effectiveBaseRef,
             hasUncommittedChanges: hasUncommittedEntries,
             hasUpstream: remoteStatus?.hasUpstream,
             ahead: remoteStatus?.ahead,

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -829,6 +829,8 @@ function SourceControlInner(): React.JSX.Element {
   const activeRepo = useRepoById(activeWorktree?.repoId ?? null)
   const activeRepoId = activeRepo?.id ?? null
   const activeRepoPath = activeRepo?.path ?? null
+  const activeRepoConnectionId = activeRepo?.connectionId ?? null
+  const activeRepoExecutionHostId = activeRepo?.executionHostId ?? null
   const gitIdentityDisplay = activeWorktree ? getWorktreeGitIdentityDisplay(activeWorktree) : null
   const detachedHeadDisplay = gitIdentityDisplay?.kind === 'detached' ? gitIdentityDisplay : null
   const branchName = gitIdentityDisplay?.kind === 'branch' ? gitIdentityDisplay.branchName : ''
@@ -897,9 +899,20 @@ function SourceControlInner(): React.JSX.Element {
   // Why: git/file mutations and repo metadata requests belong to the repo
   // OWNER host, not the currently focused host in the sidebar.
   const activeRepoSettings = useMemo(
-    () => getRepoOwnerRoutedSettings(settings, activeRepo ?? null),
-    [activeRepo, settings]
+    () =>
+      getRepoOwnerRoutedSettings(
+        settings,
+        activeRepoId
+          ? {
+              id: activeRepoId,
+              connectionId: activeRepoConnectionId,
+              executionHostId: activeRepoExecutionHostId
+            }
+          : null
+      ),
+    [activeRepoConnectionId, activeRepoExecutionHostId, activeRepoId, settings]
   )
+  const activeRepoRuntimeEnvironmentId = activeRepoSettings?.activeRuntimeEnvironmentId ?? null
   const updateSettings = useAppStore((s) => s.updateSettings)
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
@@ -1246,7 +1259,7 @@ function SourceControlInner(): React.JSX.Element {
   const generateError =
     activeCommitMessageGenerationRecord?.error ?? generateErrors[activeWorktreeId ?? ''] ?? null
   const activeConnectionId = activeWorktreeId
-    ? (getConnectionId(activeWorktreeId) ?? activeRepo?.connectionId ?? null)
+    ? (getConnectionId(activeWorktreeId) ?? activeRepoConnectionId)
     : null
   const activeSourceControlLaunchPlatform = resolveSourceControlLaunchPlatform({
     connectionId: activeConnectionId,
@@ -1423,7 +1436,7 @@ function SourceControlInner(): React.JSX.Element {
   )
 
   useEffect(() => {
-    if (!isBranchVisible || !activeRepo || isFolder) {
+    if (!isBranchVisible || !activeRepoId || isFolder) {
       return
     }
 
@@ -1435,7 +1448,10 @@ function SourceControlInner(): React.JSX.Element {
     setDefaultBaseRef(null)
 
     let stale = false
-    void getRuntimeRepoBaseRefDefault(activeRepoSettings, activeRepo.id)
+    void getRuntimeRepoBaseRefDefault(
+      { activeRuntimeEnvironmentId: activeRepoRuntimeEnvironmentId },
+      activeRepoId
+    )
       .then((result) => {
         if (!stale) {
           // Why: IPC now returns a `{ defaultBaseRef, remoteCount }` envelope;
@@ -1457,7 +1473,16 @@ function SourceControlInner(): React.JSX.Element {
     return () => {
       stale = true
     }
-  }, [activeRepo, activeRepoSettings, isBranchVisible, isFolder])
+  }, [
+    // Why: only repo/host ownership changes should reset the base; unrelated
+    // repo metadata churn must not indirectly restart eligibility's timeout.
+    activeRepoConnectionId,
+    activeRepoExecutionHostId,
+    activeRepoId,
+    activeRepoRuntimeEnvironmentId,
+    isBranchVisible,
+    isFolder
+  ])
 
   const normalizedWorktreeBaseRef = activeWorktree?.baseRef?.trim() || null
   const normalizedRepoBaseRef = activeRepo?.worktreeBaseRef?.trim() || null
@@ -3344,6 +3369,8 @@ function SourceControlInner(): React.JSX.Element {
     }
   }, [
     // Why: unrelated repo metadata replacement must not restart a hung probe's timeout.
+    activeRepoConnectionId,
+    activeRepoExecutionHostId,
     activeRepoId,
     activeRepoPath,
     branchName,

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -266,6 +266,9 @@ import { resolveVisibleCreatePrHeaderAction } from './source-control-create-pr-i
 import { resolveBlockedCreateReviewNoticeMessage } from './source-control-create-review-blocked-action'
 import {
   buildLoadingHostedReviewCreationEligibility,
+  buildLocalBlockerHostedReviewCreationEligibility
+} from './source-control-hosted-review-creation-eligibility-snapshot'
+import {
   resolveCreatePrHeaderAction,
   resolveProvisionalHostedReviewProvider
 } from './source-control-primary-create-pr-intent-action'
@@ -1595,6 +1598,11 @@ function SourceControlInner(): React.JSX.Element {
       linkedGiteaPR
     ]
   )
+  // Why: the eligibility probe's failure fallback needs the current provider
+  // without adding it to the probe effect's deps (which would re-run the probe
+  // on every provider recompute).
+  const provisionalHostedReviewProviderRef = useRef(provisionalHostedReviewProvider)
+  provisionalHostedReviewProviderRef.current = provisionalHostedReviewProvider
   useEffect(() => {
     const hasConcreteProviderHint =
       hostedReview !== null ||
@@ -3275,15 +3283,39 @@ function SourceControlInner(): React.JSX.Element {
       })
       .catch((error) => {
         console.warn('[SourceControl] hosted review creation eligibility failed', error)
-        if (!stale) {
-          setHostedReviewCreationState(null)
-          setHostedReviewCreationRequestState({
+        if (stale) {
+          return
+        }
+        // Why: a failed/timed-out remote probe must not leave an inert disabled
+        // button. When the local git status determines a blocker (dirty, no
+        // upstream, needs push/sync), surface the actionable preparation intent;
+        // otherwise fall back to the retryable failed state.
+        const localBlocker = buildLocalBlockerHostedReviewCreationEligibility(
+          provisionalHostedReviewProviderRef.current,
+          {
+            hasUncommittedChanges: hasUncommittedEntries,
+            hasUpstream: remoteStatus?.hasUpstream,
+            ahead: remoteStatus?.ahead,
+            behind: remoteStatus?.behind
+          }
+        )
+        if (localBlocker) {
+          setHostedReviewCreationState({
             repoId: activeRepo.id,
             worktreeId: activeWorktreeId,
             branch: branchName,
-            status: 'failed'
+            data: localBlocker
           })
+          setHostedReviewCreationRequestState(null)
+          return
         }
+        setHostedReviewCreationState(null)
+        setHostedReviewCreationRequestState({
+          repoId: activeRepo.id,
+          worktreeId: activeWorktreeId,
+          branch: branchName,
+          status: 'failed'
+        })
       })
     return () => {
       stale = true

--- a/src/renderer/src/components/right-sidebar/source-control-hosted-review-creation-eligibility-snapshot.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-hosted-review-creation-eligibility-snapshot.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from 'vitest'
 import { buildLocalBlockerHostedReviewCreationEligibility } from './source-control-hosted-review-creation-eligibility-snapshot'
 import { resolveCreatePrIntentEligibility } from './source-control-create-pr-intent-state'
 
+const featureBranch = { branch: 'feature/create-pr', baseRef: 'main' }
+
 describe('buildLocalBlockerHostedReviewCreationEligibility', () => {
   it('reports dirty when there are uncommitted changes', () => {
     const eligibility = buildLocalBlockerHostedReviewCreationEligibility('github', {
+      ...featureBranch,
       hasUncommittedChanges: true,
       hasUpstream: false,
       ahead: 0,
@@ -29,6 +32,7 @@ describe('buildLocalBlockerHostedReviewCreationEligibility', () => {
   it('prefers dirty over no_upstream when both apply, matching main-process ordering', () => {
     expect(
       buildLocalBlockerHostedReviewCreationEligibility('gitlab', {
+        ...featureBranch,
         hasUncommittedChanges: true,
         hasUpstream: false,
         ahead: 0,
@@ -40,6 +44,7 @@ describe('buildLocalBlockerHostedReviewCreationEligibility', () => {
   it('reports no_upstream for a clean unpublished branch', () => {
     expect(
       buildLocalBlockerHostedReviewCreationEligibility('github', {
+        ...featureBranch,
         hasUncommittedChanges: false,
         hasUpstream: false,
         ahead: 0,
@@ -51,6 +56,7 @@ describe('buildLocalBlockerHostedReviewCreationEligibility', () => {
   it('reports needs_sync when the branch is behind its upstream', () => {
     expect(
       buildLocalBlockerHostedReviewCreationEligibility('github', {
+        ...featureBranch,
         hasUncommittedChanges: false,
         hasUpstream: true,
         ahead: 1,
@@ -59,20 +65,50 @@ describe('buildLocalBlockerHostedReviewCreationEligibility', () => {
     ).toMatchObject({ blockedReason: 'needs_sync', nextAction: 'sync' })
   })
 
-  it('reports needs_push when the branch is ahead of an up-to-date upstream', () => {
+  it('returns null for an ahead-only branch, matching main which will not offer an un-auth-checked push', () => {
     expect(
       buildLocalBlockerHostedReviewCreationEligibility('github', {
+        ...featureBranch,
         hasUncommittedChanges: false,
         hasUpstream: true,
         ahead: 2,
         behind: 0
       })
-    ).toMatchObject({ blockedReason: 'needs_push', nextAction: 'push' })
+    ).toBeNull()
+  })
+
+  it('returns null on the default branch even when dirty, so it cannot enable a commit onto the base branch', () => {
+    // Guards the regression where a failed probe on the default branch
+    // synthesized dirty/commit and surfaced an enabled Create PR.
+    expect(
+      buildLocalBlockerHostedReviewCreationEligibility('github', {
+        branch: 'main',
+        baseRef: 'origin/main',
+        hasUncommittedChanges: true,
+        hasUpstream: true,
+        ahead: 0,
+        behind: 0
+      })
+    ).toBeNull()
+  })
+
+  it('returns null for a detached HEAD', () => {
+    expect(
+      buildLocalBlockerHostedReviewCreationEligibility('github', {
+        branch: 'HEAD',
+        baseRef: 'main',
+        hasUncommittedChanges: true,
+        hasUpstream: false,
+        ahead: 0,
+        behind: 0
+      })
+    ).toBeNull()
   })
 
   it('returns null when the local status cannot determine a blocker', () => {
     expect(
       buildLocalBlockerHostedReviewCreationEligibility('github', {
+        ...featureBranch,
         hasUncommittedChanges: false,
         hasUpstream: true,
         ahead: 0,
@@ -81,9 +117,36 @@ describe('buildLocalBlockerHostedReviewCreationEligibility', () => {
     ).toBeNull()
   })
 
+  it('returns null when upstream status is unknown, matching main which treats it as retryable', () => {
+    expect(
+      buildLocalBlockerHostedReviewCreationEligibility('github', {
+        ...featureBranch,
+        hasUncommittedChanges: false,
+        hasUpstream: undefined,
+        ahead: undefined,
+        behind: undefined
+      })
+    ).toBeNull()
+  })
+
+  it('does not synthesize needs_sync when upstream is unknown but a stale behind count is set', () => {
+    // The needs_sync branch is gated on hasUpstream === true so an unknown
+    // upstream stays retryable, matching main's `hasUpstream !== true` → null.
+    expect(
+      buildLocalBlockerHostedReviewCreationEligibility('github', {
+        ...featureBranch,
+        hasUncommittedChanges: false,
+        hasUpstream: undefined,
+        ahead: 0,
+        behind: 2
+      })
+    ).toBeNull()
+  })
+
   it('returns null for providers that do not support hosted review creation', () => {
     expect(
       buildLocalBlockerHostedReviewCreationEligibility('bitbucket', {
+        ...featureBranch,
         hasUncommittedChanges: true,
         hasUpstream: false,
         ahead: 0,

--- a/src/renderer/src/components/right-sidebar/source-control-hosted-review-creation-eligibility-snapshot.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-hosted-review-creation-eligibility-snapshot.test.ts
@@ -1,8 +1,35 @@
 import { describe, expect, it } from 'vitest'
-import { buildLocalBlockerHostedReviewCreationEligibility } from './source-control-hosted-review-creation-eligibility-snapshot'
+import {
+  buildLocalBlockerHostedReviewCreationEligibility,
+  resolveHostedReviewCreationProviderForTarget
+} from './source-control-hosted-review-creation-eligibility-snapshot'
 import { resolveCreatePrIntentEligibility } from './source-control-create-pr-intent-state'
 
 const featureBranch = { branch: 'feature/create-pr', baseRef: 'main' }
+
+describe('resolveHostedReviewCreationProviderForTarget', () => {
+  const target = { repoId: 'repo-1', worktreeId: 'worktree-1', branch: 'feature/create-pr' }
+
+  it('preserves a known self-hosted provider for the same target', () => {
+    expect(
+      resolveHostedReviewCreationProviderForTarget(
+        { ...target, provider: 'gitlab' },
+        target,
+        'github'
+      )
+    ).toBe('gitlab')
+  })
+
+  it('does not leak a provider hint across worktrees', () => {
+    expect(
+      resolveHostedReviewCreationProviderForTarget(
+        { ...target, provider: 'gitlab' },
+        { ...target, worktreeId: 'worktree-2' },
+        'github'
+      )
+    ).toBe('github')
+  })
+})
 
 describe('buildLocalBlockerHostedReviewCreationEligibility', () => {
   it('reports dirty when there are uncommitted changes', () => {

--- a/src/renderer/src/components/right-sidebar/source-control-hosted-review-creation-eligibility-snapshot.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-hosted-review-creation-eligibility-snapshot.ts
@@ -1,4 +1,5 @@
 import { supportsHostedReviewCreation } from '../../../../shared/hosted-review-creation-providers'
+import { normalizeHostedReviewBaseRef } from '../../../../shared/hosted-review-refs'
 import type {
   HostedReviewCreationEligibility,
   HostedReviewProvider
@@ -18,22 +19,40 @@ export function buildLoadingHostedReviewCreationEligibility(
 
 /**
  * Local-status-only eligibility used when the remote creation probe fails or
- * times out. Mirrors the main-process local-blocker ordering (dirty →
- * no_upstream → needs_sync → needs_push) so a failed probe still offers the
- * actionable commit/publish/push/sync preparation action instead of leaving an
- * inert disabled button. Returns null when the local status cannot determine a
- * blocker (e.g. a fully-synced branch), so the caller can surface a retry.
+ * times out, so a failed probe still offers the actionable commit/publish/sync
+ * preparation action instead of leaving an inert disabled button.
+ *
+ * Mirrors the main process's own lookup-failure fallback exactly — both its
+ * `canReturnLocalBlocker` guard and its blocker ordering
+ * (`src/main/source-control/hosted-review-creation.ts`). The guard is
+ * load-bearing: without it a failed probe on the default branch or a detached
+ * HEAD would synthesize `dirty`/`commit` and surface an *enabled* Create PR
+ * that commits onto the base branch, where the real probe returns
+ * `default_branch`/`detached_head` (disabled). Returns null when no local
+ * blocker is determinable (unknown upstream, ahead-only, fully synced) so the
+ * caller can surface the retryable state — matching main, which won't offer a
+ * push it can't first auth-check.
  */
 export function buildLocalBlockerHostedReviewCreationEligibility(
   provider: HostedReviewProvider,
   status: {
+    branch: string | null | undefined
+    baseRef: string | null | undefined
     hasUncommittedChanges: boolean
     hasUpstream: boolean | undefined
     ahead: number | undefined
     behind: number | undefined
   }
 ): HostedReviewCreationEligibility | null {
-  if (!supportsHostedReviewCreation(provider)) {
+  const branch = status.branch?.trim() ?? ''
+  const baseBranch = normalizeHostedReviewBaseRef(status.baseRef ?? '').trim()
+  const canReturnLocalBlocker =
+    branch !== '' &&
+    branch !== 'HEAD' &&
+    supportsHostedReviewCreation(provider) &&
+    (baseBranch === '' || branch.toLowerCase() !== baseBranch.toLowerCase()) &&
+    (status.hasUncommittedChanges || status.hasUpstream !== true || (status.behind ?? 0) > 0)
+  if (!canReturnLocalBlocker) {
     return null
   }
   const base = {
@@ -41,7 +60,7 @@ export function buildLocalBlockerHostedReviewCreationEligibility(
     review: null,
     canCreate: false as const,
     defaultBaseRef: null,
-    head: null
+    head: branch
   }
   if (status.hasUncommittedChanges) {
     return { ...base, blockedReason: 'dirty', nextAction: 'commit' }
@@ -49,11 +68,10 @@ export function buildLocalBlockerHostedReviewCreationEligibility(
   if (status.hasUpstream === false) {
     return { ...base, blockedReason: 'no_upstream', nextAction: 'publish' }
   }
-  if ((status.behind ?? 0) > 0) {
+  // Unknown upstream (hasUpstream !== true) is retryable, not an actionable
+  // blocker — mirror main, which returns a null blocker there.
+  if (status.hasUpstream === true && (status.behind ?? 0) > 0) {
     return { ...base, blockedReason: 'needs_sync', nextAction: 'sync' }
-  }
-  if (status.hasUpstream === true && (status.ahead ?? 0) > 0) {
-    return { ...base, blockedReason: 'needs_push', nextAction: 'push' }
   }
   return null
 }

--- a/src/renderer/src/components/right-sidebar/source-control-hosted-review-creation-eligibility-snapshot.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-hosted-review-creation-eligibility-snapshot.ts
@@ -17,6 +17,23 @@ export function buildLoadingHostedReviewCreationEligibility(
   }
 }
 
+export function resolveHostedReviewCreationProviderForTarget(
+  hint: {
+    repoId: string | null
+    worktreeId: string | null
+    branch: string
+    provider: HostedReviewProvider
+  },
+  target: { repoId: string | null; worktreeId: string | null; branch: string },
+  fallback: HostedReviewProvider
+): HostedReviewProvider {
+  return hint.repoId === target.repoId &&
+    hint.worktreeId === target.worktreeId &&
+    hint.branch === target.branch
+    ? hint.provider
+    : fallback
+}
+
 /**
  * Local-status-only eligibility used when the remote creation probe fails or
  * times out, so a failed probe still offers the actionable commit/publish/sync

--- a/src/renderer/src/components/right-sidebar/source-control-hosted-review-creation-eligibility-snapshot.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-hosted-review-creation-eligibility-snapshot.ts
@@ -1,0 +1,59 @@
+import { supportsHostedReviewCreation } from '../../../../shared/hosted-review-creation-providers'
+import type {
+  HostedReviewCreationEligibility,
+  HostedReviewProvider
+} from '../../../../shared/hosted-review'
+
+export function buildLoadingHostedReviewCreationEligibility(
+  provider: HostedReviewProvider
+): HostedReviewCreationEligibility {
+  return {
+    provider,
+    review: null,
+    canCreate: false,
+    blockedReason: null,
+    nextAction: null
+  }
+}
+
+/**
+ * Local-status-only eligibility used when the remote creation probe fails or
+ * times out. Mirrors the main-process local-blocker ordering (dirty →
+ * no_upstream → needs_sync → needs_push) so a failed probe still offers the
+ * actionable commit/publish/push/sync preparation action instead of leaving an
+ * inert disabled button. Returns null when the local status cannot determine a
+ * blocker (e.g. a fully-synced branch), so the caller can surface a retry.
+ */
+export function buildLocalBlockerHostedReviewCreationEligibility(
+  provider: HostedReviewProvider,
+  status: {
+    hasUncommittedChanges: boolean
+    hasUpstream: boolean | undefined
+    ahead: number | undefined
+    behind: number | undefined
+  }
+): HostedReviewCreationEligibility | null {
+  if (!supportsHostedReviewCreation(provider)) {
+    return null
+  }
+  const base = {
+    provider,
+    review: null,
+    canCreate: false as const,
+    defaultBaseRef: null,
+    head: null
+  }
+  if (status.hasUncommittedChanges) {
+    return { ...base, blockedReason: 'dirty', nextAction: 'commit' }
+  }
+  if (status.hasUpstream === false) {
+    return { ...base, blockedReason: 'no_upstream', nextAction: 'publish' }
+  }
+  if ((status.behind ?? 0) > 0) {
+    return { ...base, blockedReason: 'needs_sync', nextAction: 'sync' }
+  }
+  if (status.hasUpstream === true && (status.ahead ?? 0) > 0) {
+    return { ...base, blockedReason: 'needs_push', nextAction: 'push' }
+  }
+  return null
+}

--- a/src/renderer/src/components/right-sidebar/source-control-local-blocker-eligibility.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-local-blocker-eligibility.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import { buildLocalBlockerHostedReviewCreationEligibility } from './source-control-hosted-review-creation-eligibility-snapshot'
+import { resolveCreatePrIntentEligibility } from './source-control-create-pr-intent-state'
+
+describe('buildLocalBlockerHostedReviewCreationEligibility', () => {
+  it('reports dirty when there are uncommitted changes', () => {
+    const eligibility = buildLocalBlockerHostedReviewCreationEligibility('github', {
+      hasUncommittedChanges: true,
+      hasUpstream: false,
+      ahead: 0,
+      behind: 0
+    })
+    expect(eligibility).toMatchObject({ blockedReason: 'dirty', nextAction: 'commit' })
+    // The synthesized blocker must drive the actionable Create PR intent so a
+    // failed remote probe still offers commit/publish preparation.
+    expect(
+      resolveCreatePrIntentEligibility({
+        stagedCount: 1,
+        hasStageableChanges: true,
+        hasMessage: true,
+        hasUnresolvedConflicts: false,
+        upstreamStatus: { hasUpstream: false, ahead: 0, behind: 0 },
+        hostedReviewCreation: eligibility,
+        branchCommitsAhead: 0
+      })
+    ).toEqual({ eligible: true, kind: 'dirty' })
+  })
+
+  it('prefers dirty over no_upstream when both apply, matching main-process ordering', () => {
+    expect(
+      buildLocalBlockerHostedReviewCreationEligibility('gitlab', {
+        hasUncommittedChanges: true,
+        hasUpstream: false,
+        ahead: 0,
+        behind: 0
+      })
+    ).toMatchObject({ provider: 'gitlab', blockedReason: 'dirty' })
+  })
+
+  it('reports no_upstream for a clean unpublished branch', () => {
+    expect(
+      buildLocalBlockerHostedReviewCreationEligibility('github', {
+        hasUncommittedChanges: false,
+        hasUpstream: false,
+        ahead: 0,
+        behind: 0
+      })
+    ).toMatchObject({ blockedReason: 'no_upstream', nextAction: 'publish' })
+  })
+
+  it('reports needs_sync when the branch is behind its upstream', () => {
+    expect(
+      buildLocalBlockerHostedReviewCreationEligibility('github', {
+        hasUncommittedChanges: false,
+        hasUpstream: true,
+        ahead: 1,
+        behind: 3
+      })
+    ).toMatchObject({ blockedReason: 'needs_sync', nextAction: 'sync' })
+  })
+
+  it('reports needs_push when the branch is ahead of an up-to-date upstream', () => {
+    expect(
+      buildLocalBlockerHostedReviewCreationEligibility('github', {
+        hasUncommittedChanges: false,
+        hasUpstream: true,
+        ahead: 2,
+        behind: 0
+      })
+    ).toMatchObject({ blockedReason: 'needs_push', nextAction: 'push' })
+  })
+
+  it('returns null when the local status cannot determine a blocker', () => {
+    expect(
+      buildLocalBlockerHostedReviewCreationEligibility('github', {
+        hasUncommittedChanges: false,
+        hasUpstream: true,
+        ahead: 0,
+        behind: 0
+      })
+    ).toBeNull()
+  })
+
+  it('returns null for providers that do not support hosted review creation', () => {
+    expect(
+      buildLocalBlockerHostedReviewCreationEligibility('bitbucket', {
+        hasUncommittedChanges: true,
+        hasUpstream: false,
+        ahead: 0,
+        behind: 0
+      })
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control-primary-create-pr-intent-action.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-create-pr-intent-action.ts
@@ -52,18 +52,6 @@ export function resolveProvisionalHostedReviewProvider(input: {
   return 'github'
 }
 
-export function buildLoadingHostedReviewCreationEligibility(
-  provider: HostedReviewProvider
-): HostedReviewCreationEligibility {
-  return {
-    provider,
-    review: null,
-    canCreate: false,
-    blockedReason: null,
-    nextAction: null
-  }
-}
-
 function shouldOfferCreatePrHeaderChrome(
   hostedReviewCreation: HostedReviewCreationEligibility | null | undefined
 ): hostedReviewCreation is HostedReviewCreationEligibility {

--- a/src/renderer/src/components/right-sidebar/source-control-primary-create-pr-intent-action.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-create-pr-intent-action.ts
@@ -26,6 +26,10 @@ export function resolveProvisionalHostedReviewProvider(input: {
   linkedBitbucketPR?: number | null
   linkedAzureDevOpsPR?: number | null
   linkedGiteaPR?: number | null
+  // Provider inferred from the repo's remote URL host; used before the GitHub
+  // default so a GitLab (etc.) repo with no linked review still gets its own
+  // review copy while a probe is loading or after it fails.
+  remoteInferredProvider?: HostedReviewProvider | null
 }): HostedReviewProvider {
   if (input.hostedReview?.provider && supportsHostedReviewCreation(input.hostedReview.provider)) {
     return input.hostedReview.provider
@@ -48,6 +52,9 @@ export function resolveProvisionalHostedReviewProvider(input: {
   }
   if (input.linkedGitHubPR != null || input.fallbackGitHubPR != null) {
     return 'github'
+  }
+  if (input.remoteInferredProvider && supportsHostedReviewCreation(input.remoteInferredProvider)) {
+    return input.remoteInferredProvider
   }
   return 'github'
 }

--- a/src/renderer/src/store/slices/hosted-review.test.ts
+++ b/src/renderer/src/store/slices/hosted-review.test.ts
@@ -393,6 +393,27 @@ describe('hosted review slice', () => {
     )
     await vi.advanceTimersByTimeAsync(30_000)
     await assertion
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('clears the timeout as soon as a local eligibility probe settles', async () => {
+    vi.useFakeTimers()
+    mockApi.hostedReview.getCreationEligibility.mockResolvedValueOnce({
+      provider: 'github',
+      review: null,
+      canCreate: true,
+      blockedReason: null,
+      nextAction: null
+    })
+
+    const store = makeStore()
+    await store.getState().getHostedReviewCreationEligibility({
+      repoPath: '/repo',
+      branch: 'feature/create-pr',
+      base: 'main'
+    })
+
+    expect(vi.getTimerCount()).toBe(0)
   })
 
   it('uses the selected worktree selector for runtime pull request creation', async () => {

--- a/src/renderer/src/store/slices/hosted-review.test.ts
+++ b/src/renderer/src/store/slices/hosted-review.test.ts
@@ -4,6 +4,7 @@ import type { AppState } from '../types'
 import {
   createHostedReviewSlice,
   getHostedReviewCacheKey,
+  HostedReviewCreationEligibilityTimeoutError,
   refreshHostedReviewCard
 } from './hosted-review'
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
@@ -387,7 +388,9 @@ describe('hosted review slice', () => {
       branch: 'feature/create-pr',
       base: 'main'
     })
-    const assertion = expect(pending).rejects.toThrow(/Timed out checking pull request creation/)
+    const assertion = expect(pending).rejects.toBeInstanceOf(
+      HostedReviewCreationEligibilityTimeoutError
+    )
     await vi.advanceTimersByTimeAsync(30_000)
     await assertion
   })

--- a/src/renderer/src/store/slices/hosted-review.test.ts
+++ b/src/renderer/src/store/slices/hosted-review.test.ts
@@ -376,6 +376,22 @@ describe('hosted review slice', () => {
     })
   })
 
+  it('rejects a never-settling local eligibility probe after the timeout', async () => {
+    vi.useFakeTimers()
+    // A hung git/gh subprocess never resolves; the store must not wait forever.
+    mockApi.hostedReview.getCreationEligibility.mockReturnValueOnce(new Promise(() => {}))
+    const store = makeStore()
+
+    const pending = store.getState().getHostedReviewCreationEligibility({
+      repoPath: '/repo',
+      branch: 'feature/create-pr',
+      base: 'main'
+    })
+    const assertion = expect(pending).rejects.toThrow(/Timed out checking pull request creation/)
+    await vi.advanceTimersByTimeAsync(30_000)
+    await assertion
+  })
+
   it('uses the selected worktree selector for runtime pull request creation', async () => {
     runtimeRpc.callRuntimeRpc.mockResolvedValueOnce({
       ok: true,

--- a/src/renderer/src/store/slices/hosted-review.ts
+++ b/src/renderer/src/store/slices/hosted-review.ts
@@ -32,6 +32,40 @@ type CreateHostedReviewStoreInput = CreateHostedReviewInput & { repoId?: string 
 
 const CACHE_TTL_MS = 60_000
 const HOSTED_REVIEW_CACHE_MAX = 500
+// Why: the runtime path is bounded by callRuntimeRpc's own timeout; the local
+// Electron path had none, so a hung git/gh subprocess (e.g. a stalled Windows
+// credential probe) could leave the Create PR header stuck in its "Checking…"
+// loading state forever. Mirror the runtime bound so a never-settling probe
+// rejects and the UI can fall back to an actionable/retryable state.
+const CREATION_ELIGIBILITY_TIMEOUT_MS = 30_000
+
+export class HostedReviewCreationEligibilityTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Timed out checking pull request creation eligibility after ${timeoutMs}ms`)
+    this.name = 'HostedReviewCreationEligibilityTimeoutError'
+  }
+}
+
+function withCreationEligibilityTimeout(
+  promise: Promise<HostedReviewCreationEligibility>,
+  timeoutMs = CREATION_ELIGIBILITY_TIMEOUT_MS
+): Promise<HostedReviewCreationEligibility> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new HostedReviewCreationEligibilityTimeoutError(timeoutMs))
+    }, timeoutMs)
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (error) => {
+        clearTimeout(timer)
+        reject(error)
+      }
+    )
+  })
+}
 
 const inflightHostedReviewRequests = new Map<
   string,
@@ -259,11 +293,13 @@ export const createHostedReviewSlice: StateCreator<AppState, [], [], HostedRevie
         { timeoutMs: 30_000 }
       )
     }
-    return window.api.hostedReview.getCreationEligibility({
-      ...args,
-      repoId: repo?.id ?? args.repoId,
-      connectionId: repo?.connectionId ?? null
-    })
+    return withCreationEligibilityTimeout(
+      window.api.hostedReview.getCreationEligibility({
+        ...args,
+        repoId: repo?.id ?? args.repoId,
+        connectionId: repo?.connectionId ?? null
+      })
+    )
   },
 
   createHostedReview: async (repoPath, input) => {


### PR DESCRIPTION
## Summary

Fixes Source Control getting stuck forever on “Checking whether this branch can create a pull request…” when the local/SSH hosted-review eligibility IPC never settles.

- Bounds the local/SSH eligibility request to the same 30-second limit as the runtime-hosted path, allowing the renderer to leave `loading` on a wedged subprocess.
- Uses known local Git status after a timeout/failure to keep dirty or unpublished branches actionable, while preserving provider-aware behavior and refusing to synthesize eligibility when the provider or default-branch state is unsafe.
- Keys repository routing, base-ref refresh, and eligibility effects to stable repository/host ownership so unrelated metadata churn cannot reset the base ref, restart the timeout, or fan out duplicate requests.
- Adds regression coverage for timeout handling, blocker ordering, provider/default-branch guards, host ownership, and the exact base-ref effect dependencies.

## Screenshots

No visual change. The change prevents an existing loading state from remaining permanent and preserves the existing actionable/failed UI states; no new layout or styling was introduced.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

PR Checks passed the full lint, typecheck, Git compatibility, test, unpacked-build, and CLI smoke suite on the reviewed implementation. The follow-up CodeRabbit test assertion also passes its focused Vitest run (3/3), oxlint, React Doctor, and oxfmt checks.

## AI Review Report

The review traced both eligibility paths and the downstream state transitions, then checked timeout cleanup, stale async results, request identity, provider fallback, default-branch handling, and retry behavior. It found and fixed a second-order timeout reset: broad repository/settings object identities could rerun the base-ref lookup, temporarily clear `effectiveBaseRef`, and restart the eligibility probe's 30-second timer. The effects now depend only on the repository and execution-host identities that actually change routing.

The review also checked performance implications. Metadata churn no longer restarts the base-ref or eligibility probes, avoiding redundant IPC/RPC and Git/provider work; no polling, new render loop, or hot-path computation was added.

Cross-platform behavior was explicitly reviewed for macOS, Linux, and Windows, including Electron IPC/runtime routing, paths, shell and Git behavior, shortcut/label impact, and host identity. This PR adds no shortcuts or labels, changes no path construction or Git commands, and preserves the Git 2.25 baseline. SSH remains on the local `window.api` path and now receives the same renderer-side bound; runtime-hosted behavior remains bounded by `callRuntimeRpc`. GitLab and other supported providers remain behind provider-aware eligibility checks rather than GitHub-only assumptions.

## Security Audit

Reviewed the IPC/RPC boundary, async input/state identity, repository/worktree/path propagation, provider authentication behavior, command execution, and secrets/dependencies. The change adds no new commands, dependencies, authentication flows, secret handling, or user-controlled command construction. Existing repository and worktree identifiers continue through established APIs. No security follow-up is required.

## Notes

- The original live Windows hang from an actually wedged `git`/provider subprocess was not reproduced end-to-end in Electron; the never-settling promise and all renderer state transitions are covered deterministically by tests.
- The renderer timeout does not terminate an already-wedged main-process child process. It guarantees the UI is no longer permanently disabled, and stable effect identities prevent metadata churn from spawning additional requests.
- No Git commands changed, so native, WSL, SSH, and relay Git-version compatibility is unaffected.
