### PR TITLE
fix(i18n): use full-sentence keys in RemoveFolderDialog description

### DIFF
--- a/src/renderer/src/components/sidebar/RemoveFolderDialog.tsx
+++ b/src/renderer/src/components/sidebar/RemoveFolderDialog.tsx
@@ -11,6 +11,10 @@ import { Button } from '@/components/ui/button'
 import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
 
+// Why: interpolated into the sentence so locales control where the name sits;
+// U+0000 cannot appear in a real project name, so the split is unambiguous.
+const NAME_TOKEN = '\u0000'
+
 const RemoveFolderDialog = React.memo(function RemoveFolderDialog() {
   const activeModal = useAppStore((s) => s.activeModal)
   const modalData = useAppStore((s) => s.modalData)
@@ -37,6 +41,22 @@ const RemoveFolderDialog = React.memo(function RemoveFolderDialog() {
     )
   })
 
+  // Why: fragment concatenation around the styled name cannot be reordered by
+  // SOV locales (#9294). Translate one full sentence with the name as a
+  // sentinel token, then split on it to re-apply the inline emphasis.
+  const description = sshHostLabel
+    ? translate(
+        'auto.components.sidebar.RemoveFolderDialog.removeDescriptionSsh',
+        'This only removes {{name}} from Orca. Its files stay on {{host}} — re-add that SSH host to recover it.',
+        { name: NAME_TOKEN, host: sshHostLabel }
+      )
+    : translate(
+        'auto.components.sidebar.RemoveFolderDialog.removeDescriptionLocal',
+        'This only removes {{name}} from Orca. It is still on your disk.',
+        { name: NAME_TOKEN }
+      )
+  const [descriptionBeforeName, descriptionAfterName] = description.split(NAME_TOKEN)
+
   const handleConfirm = useCallback(() => {
     if (repoId) {
       void removeProject(repoId)
@@ -61,21 +81,9 @@ const RemoveFolderDialog = React.memo(function RemoveFolderDialog() {
             {translate('auto.components.sidebar.RemoveFolderDialog.b79b39d865', 'Remove Project')}
           </DialogTitle>
           <DialogDescription className="text-xs">
-            {translate(
-              'auto.components.sidebar.RemoveFolderDialog.e62415c3d0',
-              'This only removes'
-            )}{' '}
-            <span className="break-all font-medium text-foreground">{displayName}</span>{' '}
-            {sshHostLabel
-              ? translate(
-                  'auto.components.sidebar.RemoveFolderDialog.fromOrcaSsh',
-                  'from Orca. Its files stay on {{value0}} — re-add that SSH host to recover it.',
-                  { value0: sshHostLabel }
-                )
-              : translate(
-                  'auto.components.sidebar.RemoveFolderDialog.8c097ef04e',
-                  'from Orca. It is still on your disk.'
-                )}
+            {descriptionBeforeName}
+            <span className="break-all font-medium text-foreground">{displayName}</span>
+            {descriptionAfterName}
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3985,10 +3985,9 @@
         "RemoveFolderDialog": {
           "4dc5b5065b": "Remove",
           "d36883e046": "Cancel",
-          "8c097ef04e": "from Orca. It is still on your disk.",
-          "e62415c3d0": "This only removes",
           "b79b39d865": "Remove Project",
-          "fromOrcaSsh": "from Orca. Its files stay on {{value0}} — re-add that SSH host to recover it."
+          "removeDescriptionSsh": "This only removes {{name}} from Orca. Its files stay on {{host}} — re-add that SSH host to recover it.",
+          "removeDescriptionLocal": "This only removes {{name}} from Orca. It is still on your disk."
         },
         "ScrollToCurrentWorkspaceToolbarButton": {
           "23989bb663": "Reveal active workspace"

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3947,10 +3947,9 @@
         "RemoveFolderDialog": {
           "4dc5b5065b": "Quitar",
           "d36883e046": "Cancelar",
-          "8c097ef04e": "de Orca. Sigue estando en tu disco.",
-          "e62415c3d0": "Esto solo quita",
           "b79b39d865": "Quitar proyecto",
-          "fromOrcaSsh": "from Orca. Its files stay on {{value0}} — re-add that SSH host to recover it."
+          "removeDescriptionSsh": "Esto solo elimina {{name}} de Orca. Sus archivos permanecen en {{host}}; vuelve a añadir ese host SSH para recuperarlo.",
+          "removeDescriptionLocal": "Esto solo elimina {{name}} de Orca. Sigue estando en tu disco."
         },
         "ScrollToCurrentWorkspaceToolbarButton": {
           "23989bb663": "Mostrar espacio de trabajo activo"

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3928,10 +3928,9 @@
         "RemoveFolderDialog": {
           "4dc5b5065b": "削除",
           "d36883e046": "キャンセル",
-          "8c097ef04e": "Orca から。それはまだディスク上にあります。",
-          "e62415c3d0": "これは削除するだけです",
           "b79b39d865": "プロジェクトの削除",
-          "fromOrcaSsh": "from Orca. Its files stay on {{value0}} — re-add that SSH host to recover it."
+          "removeDescriptionSsh": "この操作は {{name}} を Orca から削除するだけです。ファイルは {{host}} に残っており、その SSH ホストを再追加すれば復元できます。",
+          "removeDescriptionLocal": "この操作は {{name}} を Orca から削除するだけです。ファイルはディスクに残っています。"
         },
         "ScrollToCurrentWorkspaceToolbarButton": {
           "23989bb663": "アクティブなワークスペースを表示する"

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3928,10 +3928,9 @@
         "RemoveFolderDialog": {
           "4dc5b5065b": "제거",
           "d36883e046": "취소",
-          "8c097ef04e": "Orca에서. 아직 디스크에 있습니다.",
-          "e62415c3d0": "다음 항목만 제거합니다",
           "b79b39d865": "프로젝트 제거",
-          "fromOrcaSsh": "from Orca. Its files stay on {{value0}} — re-add that SSH host to recover it."
+          "removeDescriptionSsh": "이 작업은 {{name}}을(를) Orca에서 제거만 합니다. 파일은 {{host}}에 그대로 남아 있으며, 해당 SSH 호스트를 다시 추가하면 복구할 수 있습니다.",
+          "removeDescriptionLocal": "이 작업은 {{name}}을(를) Orca에서 제거만 합니다. 파일은 디스크에 그대로 남아 있습니다."
         },
         "ScrollToCurrentWorkspaceToolbarButton": {
           "23989bb663": "활성 워크스페이스로 이동"

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3928,10 +3928,9 @@
         "RemoveFolderDialog": {
           "4dc5b5065b": "移除",
           "d36883e046": "取消",
-          "8c097ef04e": "来自 Orca。它仍保留在您的磁盘上。",
-          "e62415c3d0": "这仅删除",
           "b79b39d865": "删除项目",
-          "fromOrcaSsh": "从 Orca 中移除。其文件保留在 {{value0}} 上 — 重新添加该 SSH 主机即可恢复。"
+          "removeDescriptionSsh": "此操作仅将 {{name}} 从 Orca 中移除。文件仍保留在 {{host}} 上 — 重新添加该 SSH 主机即可恢复。",
+          "removeDescriptionLocal": "此操作仅将 {{name}} 从 Orca 中移除。文件仍保留在您的磁盘上。"
         },
         "ScrollToCurrentWorkspaceToolbarButton": {
           "23989bb663": "显示活动工作区"


### PR DESCRIPTION
## Summary

First slice of #9294. The Remove Project dialog description was assembled from three concatenated fragments:

```tsx
{translate('...', 'This only removes')} <span ...>{displayName}</span> {translate('...', 'from Orca. ...')}
```

No SOV-order locale (Korean, Japanese, ...) can translate these fragments into a grammatical sentence — in Korean the verb belongs at the end and the name mid-sentence. These keys were deliberately left untranslated in #9019 for exactly this reason.

This replaces the fragments with **one full-sentence key per variant** interpolating the project name (`{{name}}`) and SSH host (`{{host}}`). The inline emphasis on the name is preserved by interpolating a U+0000 sentinel and splitting the translated sentence on it — locales can now place the name anywhere in the sentence and the styled span follows.

Also:
- adds hand-written Korean, Japanese, Chinese, and Spanish translations for the two new keys (Korean reviewed by a native speaker)
- removes the three orphaned fragment keys from all five catalogs

## Screenshots

English rendering is unchanged (same sentence, same styled name — the sentence is just no longer assembled from fragments). Korean now shows a grammatical sentence: `이 작업은 ⟨name⟩을(를) Orca에서 제거만 합니다. ...` instead of English fragments around the name.

## Testing

- [x] `pnpm run verify:localization-catalog` — key references and 5-locale parity verified (10,837 keys)
- [x] `pnpm run verify:localization-coverage` — passed with 0 allowlisted candidates
- [x] `oxlint` (incl. react-doctor) and `oxfmt` clean via lint-staged
- [x] `pnpm tc:web`
- [x] Sidebar renderer test suite: 1,478 passed; the 13 failures in `SidebarToolbar.test.tsx`/`LinearAgentSkillSetupPrompt.reminder-toast.test.tsx` are pre-existing on unmodified `main` in my environment (`window.localStorage.clear is not a function` under Node 25) and unrelated to this change

## Code Review Summary

- Cross-platform: string/JSX-only change; no platform-specific code paths.
- Local/remote/SSH: both dialog variants (local disk vs SSH host) covered; the SSH variant keeps the host label including the removed-target (ghost) fallback.
- Agents/integrations/providers: not applicable.
- Performance: two string ops per dialog render; negligible.
- UI quality: identical visual output in English; the styled project name span is preserved in all locales via the sentinel split. U+0000 cannot occur in a real project name, so the split is unambiguous.
- Security: no code paths beyond string formatting; no dependencies.

## Notes

- Remaining fragment sites from #9294 (`{{value0}} PR #{{value1}}?` verb-interpolation dialogs) can follow the same pattern in a follow-up.