### PR TITLE
fix(terminal): bypass rejected macOS login sessions

### DIFF
--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -12,6 +12,7 @@ import { warmWindowsConptyOnce } from './windows-conpty-warmup'
 import { warmPwshAvailabilityCache } from '../pwsh'
 import { createDaemonFileLog, createNoopDaemonFileLog } from './daemon-file-log'
 import { PROTOCOL_VERSION } from './types'
+import { prepareMacosTccLoginShell } from '../providers/macos-tcc-login-shell'
 
 export type ParsedDaemonArgs = {
   socketPath: string
@@ -126,6 +127,7 @@ async function main(): Promise<void> {
     socketPath,
     tokenPath,
     log: daemonLog,
+    preparePtySpawn: prepareMacosTccLoginShell,
     spawnSubprocess: (opts) => createPtySubprocess(opts)
   })
 

--- a/src/main/daemon/daemon-main.ts
+++ b/src/main/daemon/daemon-main.ts
@@ -5,6 +5,7 @@ export type DaemonStartOptions = {
   socketPath: string
   tokenPath: string
   spawnSubprocess: DaemonServerOptions['spawnSubprocess']
+  preparePtySpawn?: DaemonServerOptions['preparePtySpawn']
   log?: DaemonFileLog
 }
 
@@ -17,6 +18,7 @@ export async function startDaemon(opts: DaemonStartOptions): Promise<DaemonHandl
     socketPath: opts.socketPath,
     tokenPath: opts.tokenPath,
     spawnSubprocess: opts.spawnSubprocess,
+    ...(opts.preparePtySpawn ? { preparePtySpawn: opts.preparePtySpawn } : {}),
     ...(opts.log ? { log: opts.log } : {})
   })
 

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -219,6 +219,63 @@ describe('DaemonServer', () => {
       expect(spawnSubprocess).toHaveBeenCalledOnce()
     })
 
+    it.each(['cancelCreateOrAttach', 'kill'] as const)(
+      'prevents a pending subprocess after %s and permits later session reuse',
+      async (requestType) => {
+        let finishPreparation!: () => void
+        const preparation = new Promise<void>((resolve) => {
+          finishPreparation = resolve
+        })
+        const preparePtySpawn = vi.fn(() => preparation)
+        const spawnSubprocess = vi.fn(() => createMockSubprocess())
+        server = new DaemonServer({
+          socketPath,
+          tokenPath,
+          preparePtySpawn,
+          spawnSubprocess
+        })
+        await server.start()
+        const c = await connectClient()
+
+        const creates = [
+          c.request('createOrAttach', {
+            sessionId: 'canceled-preparation',
+            cols: 80,
+            rows: 24
+          }),
+          c.request('createOrAttach', {
+            sessionId: 'canceled-preparation',
+            cols: 80,
+            rows: 24
+          })
+        ]
+        const canceledCreates = Promise.all(
+          creates.map((create) =>
+            expect(create).rejects.toThrow('Attach canceled for session canceled-preparation')
+          )
+        )
+        await vi.waitFor(() => expect(preparePtySpawn).toHaveBeenCalledTimes(2))
+
+        const cancelRequest =
+          requestType === 'kill'
+            ? c.request('kill', { sessionId: 'canceled-preparation', immediate: true })
+            : c.request('cancelCreateOrAttach', { sessionId: 'canceled-preparation' })
+        await expect(cancelRequest).resolves.toEqual({})
+        finishPreparation()
+        await canceledCreates
+        expect(spawnSubprocess).not.toHaveBeenCalled()
+
+        await expect(
+          c.request('createOrAttach', {
+            sessionId: 'canceled-preparation',
+            cols: 80,
+            rows: 24
+          })
+        ).resolves.toMatchObject({ isNew: true })
+        expect(spawnSubprocess).toHaveBeenCalledOnce()
+      }
+    )
+
     it('persists only an allowlisted launch identity across reattach', async () => {
       await startServer()
       const c = await connectClient()

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -181,6 +181,44 @@ describe('DaemonServer', () => {
       })
     })
 
+    it('keeps RPC responsive and creates one subprocess while spawn preparation is pending', async () => {
+      let finishPreparation!: () => void
+      const preparation = new Promise<void>((resolve) => {
+        finishPreparation = resolve
+      })
+      const preparePtySpawn = vi.fn(() => preparation)
+      const spawnSubprocess = vi.fn(() => createMockSubprocess())
+      server = new DaemonServer({
+        socketPath,
+        tokenPath,
+        preparePtySpawn,
+        spawnSubprocess
+      })
+      await server.start()
+      const c = await connectClient()
+
+      const firstCreate = c.request<{ isNew: boolean }>('createOrAttach', {
+        sessionId: 'prepared-session',
+        cols: 80,
+        rows: 24
+      })
+      const concurrentCreate = c.request<{ isNew: boolean }>('createOrAttach', {
+        sessionId: 'prepared-session',
+        cols: 80,
+        rows: 24
+      })
+      await vi.waitFor(() => expect(preparePtySpawn).toHaveBeenCalledTimes(2))
+
+      // The old spawnSync probe blocked this ping and all live PTY traffic.
+      await expect(c.request('ping', undefined)).resolves.toEqual({ pong: true })
+      expect(spawnSubprocess).not.toHaveBeenCalled()
+
+      finishPreparation()
+      const results = await Promise.all([firstCreate, concurrentCreate])
+      expect(results.map((result) => result.isNew).sort()).toEqual([false, true])
+      expect(spawnSubprocess).toHaveBeenCalledOnce()
+    })
+
     it('persists only an allowlisted launch identity across reattach', async () => {
       await startServer()
       const c = await connectClient()

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -276,6 +276,39 @@ describe('DaemonServer', () => {
       }
     )
 
+    it('cancels pending subprocess preparation during daemon shutdown', async () => {
+      let finishPreparation!: () => void
+      const preparation = new Promise<void>((resolve) => {
+        finishPreparation = resolve
+      })
+      const preparePtySpawn = vi.fn(() => preparation)
+      const spawnSubprocess = vi.fn(() => createMockSubprocess())
+      server = new DaemonServer({
+        socketPath,
+        tokenPath,
+        preparePtySpawn,
+        spawnSubprocess
+      })
+      await server.start()
+      const daemon = server as unknown as DaemonServerPrivate
+
+      const create = daemon.routeRequest('shutdown-client', {
+        id: 'shutdown-create',
+        type: 'createOrAttach',
+        payload: { sessionId: 'shutdown-pending', cols: 80, rows: 24 }
+      })
+      const canceledCreate = expect(create).rejects.toThrow(
+        'Attach canceled for session shutdown-pending'
+      )
+      await vi.waitFor(() => expect(preparePtySpawn).toHaveBeenCalledOnce())
+
+      const shutdown = server.shutdown()
+      finishPreparation()
+      await canceledCreate
+      await shutdown
+      expect(spawnSubprocess).not.toHaveBeenCalled()
+    })
+
     it('persists only an allowlisted launch identity across reattach', async () => {
       await startServer()
       const c = await connectClient()

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -35,6 +35,7 @@ export type DaemonServerOptions = {
   socketPath: string
   tokenPath: string
   ptySpawnHealthCheck?: () => Promise<void>
+  preparePtySpawn?: () => Promise<void>
   log?: DaemonFileLog
   spawnSubprocess: (opts: {
     sessionId: string
@@ -60,6 +61,7 @@ export class DaemonServer {
   private socketPath: string
   private tokenPath: string
   private ptySpawnHealthCheck: () => Promise<void>
+  private preparePtySpawn: () => Promise<void>
   private log: DaemonFileLog
 
   private clients = new Map<string, ConnectedClient>()
@@ -111,6 +113,7 @@ export class DaemonServer {
     this.token = randomUUID()
     this.host = new TerminalHost({ spawnSubprocess: opts.spawnSubprocess })
     this.ptySpawnHealthCheck = opts.ptySpawnHealthCheck ?? checkPtySpawnHealth
+    this.preparePtySpawn = opts.preparePtySpawn ?? (() => Promise.resolve())
     this.stopStreamBacklogProbe = startDaemonStreamBacklogProbe(() => ({
       clients: Array.from(this.clients.values(), (client) => ({
         clientId: client.clientId,
@@ -341,6 +344,9 @@ export class DaemonServer {
     switch (request.type) {
       case 'createOrAttach': {
         const p = request.payload
+        // Why: keep capability probes outside TerminalHost's synchronous create
+        // section so concurrent requests cannot create two subprocess generations.
+        await this.preparePtySpawn()
         const result = await this.host.createOrAttach({
           sessionId: p.sessionId,
           cols: p.cols,

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -27,6 +27,7 @@ import {
   PROTOCOL_VERSION,
   NOTIFY_PREFIX,
   SessionNotFoundError,
+  TerminalAttachCanceledError,
   type HelloMessage,
   type DaemonRequest
 } from './types'
@@ -52,6 +53,10 @@ type ConnectedClient = {
   clientId: string
   controlSocket: Socket
   streamSocket: Socket | null
+}
+
+type PendingPtySpawnPreparation = {
+  canceled: boolean
 }
 
 export class DaemonServer {
@@ -98,6 +103,7 @@ export class DaemonServer {
   })
   private streamClientIdBySessionId = new Map<string, string>()
   private lastInputAtBySessionId = new Map<string, number>()
+  private pendingPtySpawnPreparations = new Map<string, Set<PendingPtySpawnPreparation>>()
   private stopStreamBacklogProbe: () => void = () => {}
 
   // Why: main-process PTY IPC has the same recent-input bypass, but daemon
@@ -338,15 +344,44 @@ export class DaemonServer {
     }
   }
 
+  private async preparePtySpawnUnlessCanceled(sessionId: string): Promise<void> {
+    const preparation: PendingPtySpawnPreparation = { canceled: false }
+    const pending = this.pendingPtySpawnPreparations.get(sessionId) ?? new Set()
+    pending.add(preparation)
+    this.pendingPtySpawnPreparations.set(sessionId, pending)
+    try {
+      // Why: registration precedes the async capability probe so a concurrent
+      // close can cancel this exact creation before a subprocess exists.
+      await this.preparePtySpawn()
+      if (preparation.canceled) {
+        throw new TerminalAttachCanceledError(sessionId)
+      }
+    } finally {
+      pending.delete(preparation)
+      if (pending.size === 0) {
+        this.pendingPtySpawnPreparations.delete(sessionId)
+      }
+    }
+  }
+
+  private cancelPendingPtySpawnPreparations(sessionId: string): boolean {
+    const pending = this.pendingPtySpawnPreparations.get(sessionId)
+    if (!pending) {
+      return false
+    }
+    for (const preparation of pending) {
+      preparation.canceled = true
+    }
+    return true
+  }
+
   private async routeRequest(clientId: string, request: DaemonRequest): Promise<unknown> {
     const client = this.clients.get(clientId)
 
     switch (request.type) {
       case 'createOrAttach': {
         const p = request.payload
-        // Why: keep capability probes outside TerminalHost's synchronous create
-        // section so concurrent requests cannot create two subprocess generations.
-        await this.preparePtySpawn()
+        await this.preparePtySpawnUnlessCanceled(p.sessionId)
         const result = await this.host.createOrAttach({
           sessionId: p.sessionId,
           cols: p.cols,
@@ -430,6 +465,7 @@ export class DaemonServer {
       }
 
       case 'cancelCreateOrAttach':
+        this.cancelPendingPtySpawnPreparations(request.payload.sessionId)
         return {}
 
       case 'write':
@@ -507,12 +543,23 @@ export class DaemonServer {
       }
 
       case 'kill':
+        const canceledPendingSpawn = this.cancelPendingPtySpawnPreparations(
+          request.payload.sessionId
+        )
         this.lastInputAtBySessionId.delete(request.payload.sessionId)
         this.log.log('session-killed', {
           sessionId: request.payload.sessionId,
           immediate: request.payload.immediate === true
         })
-        await this.host.kill(request.payload.sessionId, { immediate: request.payload.immediate })
+        try {
+          await this.host.kill(request.payload.sessionId, { immediate: request.payload.immediate })
+        } catch (error) {
+          // Why: a kill that wins before session registration has already
+          // canceled the pending spawn and therefore completed its intent.
+          if (!(canceledPendingSpawn && error instanceof SessionNotFoundError)) {
+            throw error
+          }
+        }
         return {}
 
       case 'signal':

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -158,6 +158,7 @@ export class DaemonServer {
   async shutdown(): Promise<void> {
     this.stopStreamBacklogProbe()
     this.transientFactRelay.dispose()
+    this.cancelAllPendingPtySpawnPreparations()
     try {
       await this.host.dispose()
     } catch (err) {
@@ -375,6 +376,12 @@ export class DaemonServer {
     return true
   }
 
+  private cancelAllPendingPtySpawnPreparations(): void {
+    for (const sessionId of this.pendingPtySpawnPreparations.keys()) {
+      this.cancelPendingPtySpawnPreparations(sessionId)
+    }
+  }
+
   private async routeRequest(clientId: string, request: DaemonRequest): Promise<unknown> {
     const client = this.clients.get(clientId)
 
@@ -542,7 +549,7 @@ export class DaemonServer {
         return {}
       }
 
-      case 'kill':
+      case 'kill': {
         const canceledPendingSpawn = this.cancelPendingPtySpawnPreparations(
           request.payload.sessionId
         )
@@ -561,6 +568,7 @@ export class DaemonServer {
           }
         }
         return {}
+      }
 
       case 'signal':
         this.host.signal(request.payload.sessionId, request.payload.signal)

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -324,9 +324,9 @@ describe('createPtySubprocess', () => {
     expect(Object.values(spawnEnv)).toContain('credential.guiPrompt')
   })
 
-  it('uses a new daemon protocol for post-merge Git guard behavior', () => {
-    expect(PROTOCOL_VERSION).toBeGreaterThan(21)
-    expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(21)
+  it('uses a new daemon protocol for the macOS login preflight host behavior', () => {
+    expect(PROTOCOL_VERSION).toBeGreaterThan(22)
+    expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(22)
   })
 
   it('resolves a missing Unix default before spawning node-pty', () => {
@@ -518,17 +518,11 @@ describe('createPtySubprocess', () => {
       }
     }
 
-    // On macOS the shell is spawned through /usr/bin/login so terminal children
-    // carry their own TCC identity (#6996); the real shell rides behind it, and
-    // env(1) re-asserts the SHELL that login(1) would overwrite.
+    // The sync subprocess layer consumes the capability prepared by its async
+    // daemon boundary; this cwd-repair test deliberately exercises it unprepared.
     expect(spawnMock).toHaveBeenCalledWith(
-      '/usr/bin/login',
-      expect.arrayContaining([
-        '-flpq',
-        '/usr/bin/env',
-        expect.stringMatching(/^SHELL=/),
-        '/bin/bash'
-      ]),
+      '/bin/bash',
+      expect.any(Array),
       expect.objectContaining({ cwd: originalCwd })
     )
   })

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -16,10 +16,10 @@ import type { TuiAgent } from '../../shared/types'
 // when daemon-baked behavior cannot be delivered by on-disk wrapper refresh.
 // Why: bump when adding daemon wire behavior so same-version old daemons do
 // not silently accept the handshake and then reject new RPCs.
-export const PROTOCOL_VERSION = 22
+export const PROTOCOL_VERSION = 23
 export const GIT_CREDENTIAL_GUARD_HOST_PROTOCOL_VERSION = 22
 export const PREVIOUS_DAEMON_PROTOCOL_VERSIONS = [
-  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21
+  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22
 ] as const
 
 // ─── Session State Machine ──────────────────────────────────────────

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -41,6 +41,7 @@ const {
   writeFileSyncMock,
   chmodSyncMock,
   getPathMock,
+  loginPreflightSpawnSyncMock,
   spawnMock,
   openCodeBuildPtyEnvMock,
   openCodeClearPtyMock,
@@ -72,6 +73,7 @@ const {
   writeFileSyncMock: vi.fn(),
   chmodSyncMock: vi.fn(),
   getPathMock: vi.fn(),
+  loginPreflightSpawnSyncMock: vi.fn(),
   spawnMock: vi.fn(),
   openCodeBuildPtyEnvMock: vi.fn(),
   mimoCodeBuildPtyEnvMock: vi.fn(),
@@ -127,6 +129,13 @@ vi.mock('fs', () => ({
 
 vi.mock('node-pty', () => ({
   spawn: spawnMock
+}))
+
+// Why: this suite forces darwin on non-macOS hosts; isolate the PAM probe
+// while preserving every other child_process API used by the IPC graph.
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  spawnSync: loginPreflightSpawnSyncMock
 }))
 
 vi.mock('../opencode/hook-service', () => ({
@@ -206,6 +215,7 @@ import {
   getLocalPtyProvider
 } from './pty'
 import { _resetLocalPtyProviderStateForTest } from '../providers/local-pty-provider'
+import { resetMacosLoginShellPreflightForTests } from '../providers/macos-tcc-login-shell'
 import {
   _resetHiddenRendererPtyDeliveryGateForTest,
   isHiddenRendererPty
@@ -326,6 +336,7 @@ describe('registerPtyHandlers', () => {
     writeFileSyncMock.mockReset()
     chmodSyncMock.mockReset()
     getPathMock.mockReset()
+    loginPreflightSpawnSyncMock.mockReset()
     spawnMock.mockReset()
     openCodeBuildPtyEnvMock.mockReset()
     mimoCodeBuildPtyEnvMock.mockReset()
@@ -7203,6 +7214,11 @@ describe('registerPtyHandlers', () => {
     // Re-enable the TCC login wrapper the suite-level beforeEach disables.
     delete process.env.ORCA_DISABLE_MACOS_LOGIN_SHELL
     process.env.SHELL = '/bin/zsh'
+    loginPreflightSpawnSyncMock.mockReturnValue({
+      status: 0,
+      stdout: 'ORCA_LOGIN_PREFLIGHT_OK'
+    })
+    resetMacosLoginShellPreflightForTests()
 
     try {
       const [file, args, options] = await spawnAndGetCall({ cwd: '/tmp' })
@@ -7218,6 +7234,7 @@ describe('registerPtyHandlers', () => {
       // The spawn env keeps the real shell so identity/name logic is intact.
       expect(options.env.SHELL).toBe('/bin/zsh')
     } finally {
+      resetMacosLoginShellPreflightForTests()
       process.env.ORCA_DISABLE_MACOS_LOGIN_SHELL = '1'
       if (originalShell === undefined) {
         delete process.env.SHELL

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -41,7 +41,7 @@ const {
   writeFileSyncMock,
   chmodSyncMock,
   getPathMock,
-  loginPreflightSpawnSyncMock,
+  loginPreflightExecFileMock,
   spawnMock,
   openCodeBuildPtyEnvMock,
   openCodeClearPtyMock,
@@ -73,7 +73,7 @@ const {
   writeFileSyncMock: vi.fn(),
   chmodSyncMock: vi.fn(),
   getPathMock: vi.fn(),
-  loginPreflightSpawnSyncMock: vi.fn(),
+  loginPreflightExecFileMock: vi.fn(),
   spawnMock: vi.fn(),
   openCodeBuildPtyEnvMock: vi.fn(),
   mimoCodeBuildPtyEnvMock: vi.fn(),
@@ -135,7 +135,7 @@ vi.mock('node-pty', () => ({
 // while preserving every other child_process API used by the IPC graph.
 vi.mock('node:child_process', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
-  spawnSync: loginPreflightSpawnSyncMock
+  execFile: loginPreflightExecFileMock
 }))
 
 vi.mock('../opencode/hook-service', () => ({
@@ -336,7 +336,7 @@ describe('registerPtyHandlers', () => {
     writeFileSyncMock.mockReset()
     chmodSyncMock.mockReset()
     getPathMock.mockReset()
-    loginPreflightSpawnSyncMock.mockReset()
+    loginPreflightExecFileMock.mockReset()
     spawnMock.mockReset()
     openCodeBuildPtyEnvMock.mockReset()
     mimoCodeBuildPtyEnvMock.mockReset()
@@ -7214,10 +7214,17 @@ describe('registerPtyHandlers', () => {
     // Re-enable the TCC login wrapper the suite-level beforeEach disables.
     delete process.env.ORCA_DISABLE_MACOS_LOGIN_SHELL
     process.env.SHELL = '/bin/zsh'
-    loginPreflightSpawnSyncMock.mockReturnValue({
-      status: 0,
-      stdout: 'ORCA_LOGIN_PREFLIGHT_OK'
-    })
+    loginPreflightExecFileMock.mockImplementation(
+      (
+        _file: string,
+        _args: string[],
+        _options: unknown,
+        callback: (error: Error | null, stdout: string, stderr: string) => void
+      ) => {
+        callback(null, 'ORCA_LOGIN_PREFLIGHT_OK', '')
+        return { stdin: { end: vi.fn() } }
+      }
+    )
     resetMacosLoginShellPreflightForTests()
 
     try {

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable max-lines */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { delimiter } from 'node:path'
+import type * as MacosTccLoginShell from './macos-tcc-login-shell'
 
 const {
   existsSyncMock,
@@ -9,6 +10,7 @@ const {
   mkdirSyncMock,
   writeFileSyncMock,
   spawnMock,
+  prepareMacosTccLoginShellMock,
   resolveAgentForegroundProcessMock,
   captureDescendantSnapshotMock,
   terminateDescendantSnapshotMock
@@ -19,6 +21,7 @@ const {
   mkdirSyncMock: vi.fn(),
   writeFileSyncMock: vi.fn(),
   spawnMock: vi.fn(),
+  prepareMacosTccLoginShellMock: vi.fn(),
   resolveAgentForegroundProcessMock: vi.fn(),
   captureDescendantSnapshotMock: vi.fn(),
   terminateDescendantSnapshotMock: vi.fn()
@@ -42,6 +45,11 @@ vi.mock('electron', () => ({
 
 vi.mock('node-pty', () => ({
   spawn: spawnMock
+}))
+
+vi.mock('./macos-tcc-login-shell', async (importOriginal) => ({
+  ...(await importOriginal<typeof MacosTccLoginShell>()),
+  prepareMacosTccLoginShell: prepareMacosTccLoginShellMock
 }))
 
 vi.mock('../pty-descendant-termination', () => ({
@@ -139,6 +147,8 @@ describe('LocalPtyProvider', () => {
     captureDescendantSnapshotMock.mockReset()
     captureDescendantSnapshotMock.mockResolvedValue(null)
     terminateDescendantSnapshotMock.mockReset()
+    prepareMacosTccLoginShellMock.mockReset()
+    prepareMacosTccLoginShellMock.mockResolvedValue(undefined)
     resolveAgentForegroundProcessMock.mockReset()
     resolveAgentForegroundProcessMock.mockImplementation(
       async (_pid: number, fallbackProcess: string | null) => ({
@@ -223,6 +233,37 @@ describe('LocalPtyProvider', () => {
 
       expect(second.id).not.toBe(first.id)
       expect(second.isReattach).toBeUndefined()
+      expect(spawnMock).toHaveBeenCalledOnce()
+    })
+
+    it('does not spawn after shutdown cancels a pending stable session id', async () => {
+      let finishPreparation!: () => void
+      spawnMock.mockClear()
+      prepareMacosTccLoginShellMock.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishPreparation = resolve
+          })
+      )
+
+      const spawn = provider.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'pending-local-session'
+      })
+      const canceledSpawn = expect(spawn).rejects.toThrow(
+        'PTY spawn canceled: pending-local-session'
+      )
+      await vi.waitFor(() => expect(prepareMacosTccLoginShellMock).toHaveBeenCalledOnce())
+
+      await provider.shutdown('pending-local-session', { immediate: true })
+      finishPreparation()
+      await canceledSpawn
+      expect(spawnMock).not.toHaveBeenCalled()
+
+      await expect(
+        provider.spawn({ cols: 80, rows: 24, sessionId: 'pending-local-session' })
+      ).resolves.toMatchObject({ id: 'pending-local-session' })
       expect(spawnMock).toHaveBeenCalledOnce()
     })
 

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -91,6 +91,10 @@ type PtyShutdownOperation = {
   proc: pty.IPty
 }
 const ptyShutdownOperations = new Map<string, PtyShutdownOperation>()
+type PendingLocalPtySpawn = {
+  canceled: boolean
+}
+const pendingLocalPtySpawns = new Map<string, Set<PendingLocalPtySpawn>>()
 const ptyShellName = new Map<string, string>()
 const ptyAgentForegroundContextPaths = new Map<string, string[]>()
 // Why: remembers the last positively-recognized agent foreground per PTY so a
@@ -312,6 +316,42 @@ function allocatePtyId(sessionId: string | undefined): string {
     id = String(++ptyCounter)
   } while (ptyProcesses.has(id))
   return id
+}
+
+async function prepareLocalPtySpawn(id: string): Promise<void> {
+  const pendingSpawn: PendingLocalPtySpawn = { canceled: false }
+  const pending = pendingLocalPtySpawns.get(id) ?? new Set()
+  pending.add(pendingSpawn)
+  pendingLocalPtySpawns.set(id, pending)
+  try {
+    // Why: shutdown must be able to cancel a stable session id while the
+    // asynchronous macOS capability probe runs and before node-pty exists.
+    await prepareMacosTccLoginShell()
+    if (pendingSpawn.canceled) {
+      throw new Error(`PTY spawn canceled: ${id}`)
+    }
+  } finally {
+    pending.delete(pendingSpawn)
+    if (pending.size === 0) {
+      pendingLocalPtySpawns.delete(id)
+    }
+  }
+}
+
+function cancelPendingLocalPtySpawns(id: string): void {
+  const pending = pendingLocalPtySpawns.get(id)
+  if (!pending) {
+    return
+  }
+  for (const pendingSpawn of pending) {
+    pendingSpawn.canceled = true
+  }
+}
+
+function cancelAllPendingLocalPtySpawns(): void {
+  for (const id of pendingLocalPtySpawns.keys()) {
+    cancelPendingLocalPtySpawns(id)
+  }
 }
 
 /**
@@ -796,9 +836,7 @@ export class LocalPtyProvider implements IPtyProvider {
       logHistoryInjection(worktreeId, historyResult)
     }
 
-    // Why: PAM can take hundreds of milliseconds. Await its one-time probe at
-    // the async provider boundary so Electron stays responsive during fallback spawns.
-    await prepareMacosTccLoginShell()
+    await prepareLocalPtySpawn(id)
     const spawnResult = spawnShellWithFallback({
       shellPath,
       shellArgs,
@@ -1041,6 +1079,7 @@ export class LocalPtyProvider implements IPtyProvider {
   }
 
   async shutdown(id: string, opts: { immediate?: boolean; keepHistory?: boolean }): Promise<void> {
+    cancelPendingLocalPtySpawns(id)
     const pending = ptyShutdownOperations.get(id)
     if (pending) {
       if (opts.immediate === true) {
@@ -1346,6 +1385,7 @@ export class LocalPtyProvider implements IPtyProvider {
 
   /** Kill all in-process local PTYs. Call on app quit. */
   killAll(): void {
+    cancelAllPendingLocalPtySpawns()
     for (const [id, proc] of ptyProcesses) {
       runPtyCleanup(id)
       disposePtyListeners(id)
@@ -1369,6 +1409,8 @@ export class LocalPtyProvider implements IPtyProvider {
 }
 
 export function _resetLocalPtyProviderStateForTest(): void {
+  cancelAllPendingLocalPtySpawns()
+  pendingLocalPtySpawns.clear()
   for (const id of ptyProcesses.keys()) {
     clearPtyState(id)
   }

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -27,6 +27,7 @@ import {
   validateWorkingDirectory,
   spawnShellWithFallback
 } from './local-pty-utils'
+import { prepareMacosTccLoginShell } from './macos-tcc-login-shell'
 import {
   getAttributionShellLaunchConfig,
   getShellReadyLaunchConfig,
@@ -795,6 +796,9 @@ export class LocalPtyProvider implements IPtyProvider {
       logHistoryInjection(worktreeId, historyResult)
     }
 
+    // Why: PAM can take hundreds of milliseconds. Await its one-time probe at
+    // the async provider boundary so Electron stays responsive during fallback spawns.
+    await prepareMacosTccLoginShell()
     const spawnResult = spawnShellWithFallback({
       shellPath,
       shellArgs,

--- a/src/main/providers/macos-tcc-login-shell.test.ts
+++ b/src/main/providers/macos-tcc-login-shell.test.ts
@@ -54,7 +54,12 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     expect(spawnSyncMock).toHaveBeenCalledWith(
       '/usr/bin/login',
       ['-flpq', 'ada', '/usr/bin/printf', 'ORCA_LOGIN_PREFLIGHT_OK'],
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 2_000 }
+      {
+        encoding: 'utf8',
+        killSignal: 'SIGKILL',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 500
+      }
     )
   })
 
@@ -81,6 +86,21 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     expect(wrapShellSpawnForMacosTccAttribution('/bin/bash', ['-l']).file).toBe('/bin/bash')
     expect(spawnSyncMock).toHaveBeenCalledTimes(1)
     expect(console.warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a marker emitted by a preflight that does not exit cleanly', () => {
+    setPlatform('darwin')
+    spawnSyncMock.mockReturnValue({
+      status: null,
+      error: Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' }),
+      stdout: 'ORCA_LOGIN_PREFLIGHT_OK'
+    })
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l'])).toEqual({
+      file: '/bin/zsh',
+      args: ['-l']
+    })
   })
 
   it('caches a successful login preflight for later terminal spawns', () => {

--- a/src/main/providers/macos-tcc-login-shell.test.ts
+++ b/src/main/providers/macos-tcc-login-shell.test.ts
@@ -1,19 +1,23 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { existsSyncMock, userInfoMock, spawnSyncMock } = vi.hoisted(() => ({
+const { existsSyncMock, userInfoMock, execFileMock, stdinEndMock } = vi.hoisted(() => ({
   existsSyncMock: vi.fn(),
   userInfoMock: vi.fn(),
-  spawnSyncMock: vi.fn()
+  execFileMock: vi.fn(),
+  stdinEndMock: vi.fn()
 }))
 
 vi.mock('node:fs', () => ({ existsSync: existsSyncMock }))
 vi.mock('node:os', () => ({ userInfo: userInfoMock }))
-vi.mock('node:child_process', () => ({ spawnSync: spawnSyncMock }))
+vi.mock('node:child_process', () => ({ execFile: execFileMock }))
 
 import {
+  prepareMacosTccLoginShell,
   resetMacosLoginShellPreflightForTests,
   wrapShellSpawnForMacosTccAttribution
 } from './macos-tcc-login-shell'
+
+type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void
 
 describe('wrapShellSpawnForMacosTccAttribution', () => {
   let origPlatform: PropertyDescriptor | undefined
@@ -28,8 +32,13 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     origDisable = process.env.ORCA_DISABLE_MACOS_LOGIN_SHELL
     delete process.env.ORCA_DISABLE_MACOS_LOGIN_SHELL
     existsSyncMock.mockReturnValue(true)
-    userInfoMock.mockReturnValue({ username: 'ada' })
-    spawnSyncMock.mockReturnValue({ status: 0, stdout: 'ORCA_LOGIN_PREFLIGHT_OK' })
+    userInfoMock.mockReturnValue({ username: 'ada', homedir: '/Users/ada' })
+    execFileMock.mockImplementation(
+      (_file: string, _args: string[], _options: unknown, callback: ExecFileCallback) => {
+        callback(null, 'ORCA_LOGIN_PREFLIGHT_OK', '')
+        return { stdin: { end: stdinEndMock } }
+      }
+    )
     resetMacosLoginShellPreflightForTests()
   })
 
@@ -45,29 +54,39 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     vi.clearAllMocks()
   })
 
-  it('wraps the shell in /usr/bin/login on macOS, preserving the shell args behind it', () => {
+  it('wraps the shell in /usr/bin/login on macOS, preserving the shell args behind it', async () => {
     setPlatform('darwin')
+    await prepareMacosTccLoginShell()
     expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l'])).toEqual({
       file: '/usr/bin/login',
       args: ['-flpq', 'ada', '/usr/bin/env', 'SHELL=/bin/zsh', '/bin/zsh', '-l']
     })
-    expect(spawnSyncMock).toHaveBeenCalledWith(
+    expect(execFileMock).toHaveBeenCalledWith(
       '/usr/bin/login',
       ['-flpq', 'ada', '/usr/bin/printf', 'ORCA_LOGIN_PREFLIGHT_OK'],
       {
+        cwd: '/Users/ada',
         encoding: 'utf8',
         killSignal: 'SIGKILL',
-        stdio: ['ignore', 'pipe', 'pipe'],
+        maxBuffer: 1024,
         timeout: 500
-      }
+      },
+      expect.any(Function)
     )
+    expect(stdinEndMock).toHaveBeenCalledOnce()
   })
 
-  it('spawns the shell directly when login PAM policy rejects the current user', () => {
+  it('spawns the shell directly when login PAM policy rejects the current user', async () => {
     setPlatform('darwin')
-    spawnSyncMock.mockReturnValue({ status: 0, stdout: 'Login incorrect\nlogin: ' })
+    execFileMock.mockImplementation(
+      (_file: string, _args: string[], _options: unknown, callback: ExecFileCallback) => {
+        callback(null, 'Login incorrect\nlogin: ', '')
+        return { stdin: { end: stdinEndMock } }
+      }
+    )
     vi.spyOn(console, 'warn').mockImplementation(() => {})
 
+    await prepareMacosTccLoginShell()
     expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l'])).toEqual({
       file: '/bin/zsh',
       args: ['-l']
@@ -77,42 +96,57 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     )
   })
 
-  it('caches a failed login preflight for later terminal spawns', () => {
+  it('caches a failed login preflight for later terminal spawns', async () => {
     setPlatform('darwin')
-    spawnSyncMock.mockReturnValue({ status: null, error: new Error('timed out') })
+    execFileMock.mockImplementation(
+      (_file: string, _args: string[], _options: unknown, callback: ExecFileCallback) => {
+        callback(new Error('timed out'), '', '')
+        return { stdin: { end: stdinEndMock } }
+      }
+    )
     vi.spyOn(console, 'warn').mockImplementation(() => {})
 
+    await prepareMacosTccLoginShell()
+    await prepareMacosTccLoginShell()
     expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l']).file).toBe('/bin/zsh')
     expect(wrapShellSpawnForMacosTccAttribution('/bin/bash', ['-l']).file).toBe('/bin/bash')
-    expect(spawnSyncMock).toHaveBeenCalledTimes(1)
+    expect(execFileMock).toHaveBeenCalledTimes(1)
     expect(console.warn).toHaveBeenCalledTimes(1)
   })
 
-  it('rejects a marker emitted by a preflight that does not exit cleanly', () => {
+  it('rejects a marker emitted by a preflight that does not exit cleanly', async () => {
     setPlatform('darwin')
-    spawnSyncMock.mockReturnValue({
-      status: null,
-      error: Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' }),
-      stdout: 'ORCA_LOGIN_PREFLIGHT_OK'
-    })
+    execFileMock.mockImplementation(
+      (_file: string, _args: string[], _options: unknown, callback: ExecFileCallback) => {
+        callback(
+          Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' }),
+          'ORCA_LOGIN_PREFLIGHT_OK',
+          ''
+        )
+        return { stdin: { end: stdinEndMock } }
+      }
+    )
     vi.spyOn(console, 'warn').mockImplementation(() => {})
 
+    await prepareMacosTccLoginShell()
     expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l'])).toEqual({
       file: '/bin/zsh',
       args: ['-l']
     })
   })
 
-  it('caches a successful login preflight for later terminal spawns', () => {
+  it('dedupes concurrent successful preflights and caches later terminal spawns', async () => {
     setPlatform('darwin')
 
+    await Promise.all([prepareMacosTccLoginShell(), prepareMacosTccLoginShell()])
     expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l']).file).toBe('/usr/bin/login')
     expect(wrapShellSpawnForMacosTccAttribution('/bin/bash', ['-l']).file).toBe('/usr/bin/login')
-    expect(spawnSyncMock).toHaveBeenCalledTimes(1)
+    expect(execFileMock).toHaveBeenCalledTimes(1)
   })
 
-  it('keeps bash rcfile args intact after the shell path', () => {
+  it('keeps bash rcfile args intact after the shell path', async () => {
     setPlatform('darwin')
+    await prepareMacosTccLoginShell()
     expect(
       wrapShellSpawnForMacosTccAttribution('/bin/bash', ['--rcfile', '/orca/bash/rcfile'])
     ).toEqual({
@@ -129,8 +163,9 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     })
   })
 
-  it('re-asserts the spawn env SHELL that login(1) would overwrite', () => {
+  it('re-asserts the spawn env SHELL that login(1) would overwrite', async () => {
     setPlatform('darwin')
+    await prepareMacosTccLoginShell()
     expect(
       wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l'], { SHELL: '/opt/homebrew/bin/fish' })
     ).toEqual({
@@ -139,25 +174,30 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     })
   })
 
-  it('falls back to the spawned shell for SHELL when the env value is empty', () => {
+  it('falls back to the spawned shell for SHELL when the env value is empty', async () => {
     setPlatform('darwin')
+    await prepareMacosTccLoginShell()
     expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l'], { SHELL: '' })).toEqual({
       file: '/usr/bin/login',
       args: ['-flpq', 'ada', '/usr/bin/env', 'SHELL=/bin/zsh', '/bin/zsh', '-l']
     })
   })
 
-  it('skips the env(1) interposition when the shell path would parse as an assignment', () => {
+  it('skips the env(1) interposition when the shell path would parse as an assignment', async () => {
     setPlatform('darwin')
+    await prepareMacosTccLoginShell()
     expect(wrapShellSpawnForMacosTccAttribution('/odd=dir/zsh', ['-l'])).toEqual({
       file: '/usr/bin/login',
       args: ['-flpq', 'ada', '/odd=dir/zsh', '-l']
     })
   })
 
-  it('still wraps with login when /usr/bin/env is missing, without interposition', () => {
+  it('still wraps with login when /usr/bin/env is missing, without interposition', async () => {
     setPlatform('darwin')
-    existsSyncMock.mockImplementation((path: string) => path === '/usr/bin/login')
+    existsSyncMock.mockImplementation(
+      (path: string) => path === '/usr/bin/login' || path === '/usr/bin/printf'
+    )
+    await prepareMacosTccLoginShell()
     expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l'])).toEqual({
       file: '/usr/bin/login',
       args: ['-flpq', 'ada', '/bin/zsh', '-l']
@@ -203,7 +243,7 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
 
   it('falls back to the plain spawn when the username is empty', () => {
     setPlatform('darwin')
-    userInfoMock.mockReturnValue({ username: '' })
+    userInfoMock.mockReturnValue({ username: '', homedir: '/Users/ada' })
     expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l'])).toEqual({
       file: '/bin/zsh',
       args: ['-l']
@@ -217,6 +257,6 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
       file: '/bin/zsh',
       args: ['-l']
     })
-    expect(spawnSyncMock).not.toHaveBeenCalled()
+    expect(execFileMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/providers/macos-tcc-login-shell.test.ts
+++ b/src/main/providers/macos-tcc-login-shell.test.ts
@@ -1,14 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { existsSyncMock, userInfoMock } = vi.hoisted(() => ({
+const { existsSyncMock, userInfoMock, spawnSyncMock } = vi.hoisted(() => ({
   existsSyncMock: vi.fn(),
-  userInfoMock: vi.fn()
+  userInfoMock: vi.fn(),
+  spawnSyncMock: vi.fn()
 }))
 
 vi.mock('node:fs', () => ({ existsSync: existsSyncMock }))
 vi.mock('node:os', () => ({ userInfo: userInfoMock }))
+vi.mock('node:child_process', () => ({ spawnSync: spawnSyncMock }))
 
-import { wrapShellSpawnForMacosTccAttribution } from './macos-tcc-login-shell'
+import {
+  resetMacosLoginShellPreflightForTests,
+  wrapShellSpawnForMacosTccAttribution
+} from './macos-tcc-login-shell'
 
 describe('wrapShellSpawnForMacosTccAttribution', () => {
   let origPlatform: PropertyDescriptor | undefined
@@ -24,6 +29,8 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     delete process.env.ORCA_DISABLE_MACOS_LOGIN_SHELL
     existsSyncMock.mockReturnValue(true)
     userInfoMock.mockReturnValue({ username: 'ada' })
+    spawnSyncMock.mockReturnValue({ status: 0, stdout: 'ORCA_LOGIN_PREFLIGHT_OK' })
+    resetMacosLoginShellPreflightForTests()
   })
 
   afterEach(() => {
@@ -44,6 +51,44 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
       file: '/usr/bin/login',
       args: ['-flpq', 'ada', '/usr/bin/env', 'SHELL=/bin/zsh', '/bin/zsh', '-l']
     })
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      '/usr/bin/login',
+      ['-flpq', 'ada', '/usr/bin/printf', 'ORCA_LOGIN_PREFLIGHT_OK'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 2_000 }
+    )
+  })
+
+  it('spawns the shell directly when login PAM policy rejects the current user', () => {
+    setPlatform('darwin')
+    spawnSyncMock.mockReturnValue({ status: 0, stdout: 'Login incorrect\nlogin: ' })
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l'])).toEqual({
+      file: '/bin/zsh',
+      args: ['-l']
+    })
+    expect(console.warn).toHaveBeenCalledWith(
+      '[pty] macOS login(1) preflight failed; spawning shells directly'
+    )
+  })
+
+  it('caches a failed login preflight for later terminal spawns', () => {
+    setPlatform('darwin')
+    spawnSyncMock.mockReturnValue({ status: null, error: new Error('timed out') })
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l']).file).toBe('/bin/zsh')
+    expect(wrapShellSpawnForMacosTccAttribution('/bin/bash', ['-l']).file).toBe('/bin/bash')
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1)
+    expect(console.warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('caches a successful login preflight for later terminal spawns', () => {
+    setPlatform('darwin')
+
+    expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l']).file).toBe('/usr/bin/login')
+    expect(wrapShellSpawnForMacosTccAttribution('/bin/bash', ['-l']).file).toBe('/usr/bin/login')
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1)
   })
 
   it('keeps bash rcfile args intact after the shell path', () => {
@@ -152,5 +197,6 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
       file: '/bin/zsh',
       args: ['-l']
     })
+    expect(spawnSyncMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/providers/macos-tcc-login-shell.ts
+++ b/src/main/providers/macos-tcc-login-shell.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process'
+import { execFile } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { userInfo } from 'node:os'
 
@@ -7,6 +7,7 @@ const MACOS_ENV_PATH = '/usr/bin/env'
 const MACOS_PRINTF_PATH = '/usr/bin/printf'
 const LOGIN_PREFLIGHT_TIMEOUT_MS = 500
 const LOGIN_PREFLIGHT_MARKER = 'ORCA_LOGIN_PREFLIGHT_OK'
+const LOGIN_PREFLIGHT_MAX_BUFFER_BYTES = 1024
 
 /**
  * Env escape hatch to force the plain (unwrapped) spawn. Set to `1`/`true` if a
@@ -16,48 +17,97 @@ const LOGIN_PREFLIGHT_MARKER = 'ORCA_LOGIN_PREFLIGHT_OK'
 const DISABLE_ENV_VAR = 'ORCA_DISABLE_MACOS_LOGIN_SHELL'
 
 let cachedLoginPreflightResult: boolean | null = null
+let loginPreflightInFlight: Promise<boolean> | null = null
 
 function isDisabledByEnv(): boolean {
   const value = process.env[DISABLE_ENV_VAR]
   return value === '1' || value === 'true'
 }
 
-function loginPreflightSucceeds(username: string): boolean {
+function runLoginPreflight(username: string, accountHome: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    try {
+      const child = execFile(
+        MACOS_LOGIN_PATH,
+        ['-flpq', username, MACOS_PRINTF_PATH, LOGIN_PREFLIGHT_MARKER],
+        {
+          // Why: detached daemons can outlive their launch worktree. The PAM
+          // probe must not inherit a deleted cwd before PTY spawn repairs it.
+          cwd: accountHome,
+          encoding: 'utf8',
+          // Why: PAM policy can wait indefinitely. Bound both child lifetime and
+          // captured diagnostics without blocking the PTY host's event loop.
+          killSignal: 'SIGKILL',
+          maxBuffer: LOGIN_PREFLIGHT_MAX_BUFFER_BYTES,
+          timeout: LOGIN_PREFLIGHT_TIMEOUT_MS
+        },
+        (error, stdout) => {
+          // login(1) can return zero after an EOF-driven failed prompt, so only the
+          // requested child program's output plus a clean exit proves PAM accepted it.
+          resolve(error === null && stdout === LOGIN_PREFLIGHT_MARKER)
+        }
+      )
+      // Why: login(1) must see immediate EOF, not an interactive pipe, so a PAM
+      // rejection exits instead of waiting at `login:` until the timeout.
+      child.stdin?.end()
+    } catch {
+      resolve(false)
+    }
+  })
+}
+
+function loginPreflightSucceeds(username: string, accountHome: string): Promise<boolean> {
   if (cachedLoginPreflightResult !== null) {
-    return cachedLoginPreflightResult
+    return Promise.resolve(cachedLoginPreflightResult)
   }
-
-  try {
-    // Why: login(1) still runs PAM account/session policy under -f. Probe it
-    // without a TTY so a rejection cannot strand the real PTY at `login:`.
-    const result = spawnSync(
-      MACOS_LOGIN_PATH,
-      ['-flpq', username, MACOS_PRINTF_PATH, LOGIN_PREFLIGHT_MARKER],
-      {
-        encoding: 'utf8',
-        // Why: this runs once on the Electron main thread; bound UI impact and
-        // use SIGKILL because spawnSync waits past timeouts when PAM ignores SIGTERM.
-        killSignal: 'SIGKILL',
-        stdio: ['ignore', 'pipe', 'pipe'],
-        timeout: LOGIN_PREFLIGHT_TIMEOUT_MS
+  if (!loginPreflightInFlight) {
+    // Why: simultaneous pane restores share one PAM child instead of multiplying
+    // subprocesses at exactly the point terminal startup is already busiest.
+    loginPreflightInFlight = runLoginPreflight(username, accountHome).then((result) => {
+      cachedLoginPreflightResult = result
+      if (!result) {
+        console.warn('[pty] macOS login(1) preflight failed; spawning shells directly')
       }
-    )
-    // login(1) can return zero after an EOF-driven failed prompt, so only the
-    // requested child program's output plus a clean exit proves PAM accepted it.
-    cachedLoginPreflightResult =
-      result.error === undefined && result.status === 0 && result.stdout === LOGIN_PREFLIGHT_MARKER
-  } catch {
-    cachedLoginPreflightResult = false
+      return result
+    })
+  }
+  return loginPreflightInFlight
+}
+
+/**
+ * Resolves the one-time PAM capability check before a fresh PTY is spawned.
+ * Callers await this at their async request boundary so existing terminals and
+ * the Electron main thread remain responsive while login(1) runs.
+ */
+export async function prepareMacosTccLoginShell(): Promise<void> {
+  if (process.platform !== 'darwin' || isDisabledByEnv()) {
+    return
+  }
+  if (cachedLoginPreflightResult !== null) {
+    return
+  }
+  if (!existsSync(MACOS_LOGIN_PATH)) {
+    return
   }
 
-  if (!cachedLoginPreflightResult) {
-    console.warn('[pty] macOS login(1) preflight failed; spawning shells directly')
+  let username: string
+  let accountHome: string
+  try {
+    const account = userInfo()
+    username = account.username
+    accountHome = account.homedir
+  } catch {
+    return
   }
-  return cachedLoginPreflightResult
+  if (!username || !accountHome) {
+    return
+  }
+  await loginPreflightSucceeds(username, accountHome)
 }
 
 export function resetMacosLoginShellPreflightForTests(): void {
   cachedLoginPreflightResult = null
+  loginPreflightInFlight = null
 }
 
 /**
@@ -97,7 +147,9 @@ export function wrapShellSpawnForMacosTccAttribution(
   if (!username) {
     return { file, args }
   }
-  if (!loginPreflightSucceeds(username)) {
+  // Why: an unprepared or failed host must fail open to a usable direct shell;
+  // production fresh-spawn boundaries await prepareMacosTccLoginShell first.
+  if (cachedLoginPreflightResult !== true) {
     return { file, args }
   }
 

--- a/src/main/providers/macos-tcc-login-shell.ts
+++ b/src/main/providers/macos-tcc-login-shell.ts
@@ -5,7 +5,7 @@ import { userInfo } from 'node:os'
 const MACOS_LOGIN_PATH = '/usr/bin/login'
 const MACOS_ENV_PATH = '/usr/bin/env'
 const MACOS_PRINTF_PATH = '/usr/bin/printf'
-const LOGIN_PREFLIGHT_TIMEOUT_MS = 2_000
+const LOGIN_PREFLIGHT_TIMEOUT_MS = 500
 const LOGIN_PREFLIGHT_MARKER = 'ORCA_LOGIN_PREFLIGHT_OK'
 
 /**
@@ -35,13 +35,17 @@ function loginPreflightSucceeds(username: string): boolean {
       ['-flpq', username, MACOS_PRINTF_PATH, LOGIN_PREFLIGHT_MARKER],
       {
         encoding: 'utf8',
+        // Why: this runs once on the Electron main thread; bound UI impact and
+        // use SIGKILL because spawnSync waits past timeouts when PAM ignores SIGTERM.
+        killSignal: 'SIGKILL',
         stdio: ['ignore', 'pipe', 'pipe'],
         timeout: LOGIN_PREFLIGHT_TIMEOUT_MS
       }
     )
     // login(1) can return zero after an EOF-driven failed prompt, so only the
-    // requested child program's output proves PAM accepted the session.
-    cachedLoginPreflightResult = result.stdout === LOGIN_PREFLIGHT_MARKER
+    // requested child program's output plus a clean exit proves PAM accepted it.
+    cachedLoginPreflightResult =
+      result.error === undefined && result.status === 0 && result.stdout === LOGIN_PREFLIGHT_MARKER
   } catch {
     cachedLoginPreflightResult = false
   }

--- a/src/main/providers/macos-tcc-login-shell.ts
+++ b/src/main/providers/macos-tcc-login-shell.ts
@@ -1,8 +1,12 @@
+import { spawnSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { userInfo } from 'node:os'
 
 const MACOS_LOGIN_PATH = '/usr/bin/login'
 const MACOS_ENV_PATH = '/usr/bin/env'
+const MACOS_PRINTF_PATH = '/usr/bin/printf'
+const LOGIN_PREFLIGHT_TIMEOUT_MS = 2_000
+const LOGIN_PREFLIGHT_MARKER = 'ORCA_LOGIN_PREFLIGHT_OK'
 
 /**
  * Env escape hatch to force the plain (unwrapped) spawn. Set to `1`/`true` if a
@@ -11,9 +15,45 @@ const MACOS_ENV_PATH = '/usr/bin/env'
  */
 const DISABLE_ENV_VAR = 'ORCA_DISABLE_MACOS_LOGIN_SHELL'
 
+let cachedLoginPreflightResult: boolean | null = null
+
 function isDisabledByEnv(): boolean {
   const value = process.env[DISABLE_ENV_VAR]
   return value === '1' || value === 'true'
+}
+
+function loginPreflightSucceeds(username: string): boolean {
+  if (cachedLoginPreflightResult !== null) {
+    return cachedLoginPreflightResult
+  }
+
+  try {
+    // Why: login(1) still runs PAM account/session policy under -f. Probe it
+    // without a TTY so a rejection cannot strand the real PTY at `login:`.
+    const result = spawnSync(
+      MACOS_LOGIN_PATH,
+      ['-flpq', username, MACOS_PRINTF_PATH, LOGIN_PREFLIGHT_MARKER],
+      {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: LOGIN_PREFLIGHT_TIMEOUT_MS
+      }
+    )
+    // login(1) can return zero after an EOF-driven failed prompt, so only the
+    // requested child program's output proves PAM accepted the session.
+    cachedLoginPreflightResult = result.stdout === LOGIN_PREFLIGHT_MARKER
+  } catch {
+    cachedLoginPreflightResult = false
+  }
+
+  if (!cachedLoginPreflightResult) {
+    console.warn('[pty] macOS login(1) preflight failed; spawning shells directly')
+  }
+  return cachedLoginPreflightResult
+}
+
+export function resetMacosLoginShellPreflightForTests(): void {
+  cachedLoginPreflightResult = null
 }
 
 /**
@@ -26,7 +66,8 @@ function isDisabledByEnv(): boolean {
  * under -p, so `/usr/bin/env SHELL=<shell>` re-asserts the shell Orca actually runs
  * without disturbing login's attribution (skipped when the shell path contains `=`).
  *
- * No-op off macOS, when already wrapped, or when disabled via {@link DISABLE_ENV_VAR}.
+ * No-op off macOS, when already wrapped, when disabled via {@link DISABLE_ENV_VAR},
+ * or when the login(1) PAM preflight rejects this process's user.
  */
 export function wrapShellSpawnForMacosTccAttribution(
   file: string,
@@ -50,6 +91,9 @@ export function wrapShellSpawnForMacosTccAttribution(
     return { file, args }
   }
   if (!username) {
+    return { file, args }
+  }
+  if (!loginPreflightSucceeds(username)) {
     return { file, args }
   }
 


### PR DESCRIPTION
## Summary

- Probe the macOS `login(1)` account/session path before using it to launch a terminal shell.
- Run the one-time probe asynchronously so PAM cannot block Electron's main loop or the daemon's existing terminal/RPC traffic.
- Require both a child-emitted marker and a clean exit because `login(1)` can return zero after an EOF-driven failed authentication prompt.
- Send EOF immediately, cap captured output at 1 KiB, and enforce a 500 ms `SIGKILL` timeout; cache and deduplicate the result per PTY-host process.
- Fall back to direct shell spawning when PAM rejects or the probe cannot run, preventing terminals from getting stranded at `Login incorrect` / `login:`.
- Run the probe from the account home so a detached daemon whose launch worktree was deleted still works.
- Bump the daemon protocol to v23 so old v22 sessions can remain attached while new terminal sessions route through a daemon with the fixed spawn behavior.
- Preserve the TCC-attributed `login(1)` launch path on compatible macOS accounts.

## ELI5

On macOS, Orca starts terminal shells through a system login helper so command-line tools can keep the right privacy permissions. On some Macs, account policy rejects that helper even though the user is already signed in. The terminal then gets stuck showing “Login incorrect” instead of opening a shell.

This change gives the helper one quick test before using it. If the test succeeds, Orca keeps the permission-friendly behavior. If it fails or hangs, Orca safely opens the shell the normal way. The test runs only once, does not freeze the app, and has a half-second hard limit. The daemon version is also bumped so an old background process cannot keep using the broken behavior.

## Electron + real Codex account proof

Tested in the Electron build from this PR worktree with the machine's real ChatGPT-backed Codex login. Orca spawned Codex CLI 0.144.5 through a fresh visible terminal, and the authenticated model returned the deterministic response `ORCA_E2E_AUTH_OK`.

![Electron terminal spawning an authenticated Codex CLI session](https://github.com/user-attachments/assets/bdd10a38-a61b-4891-b956-eaedf25bbff9)

The screenshot contains no token, email address, account ID, or other credential.

## Reliability contract

- **Invariant:** every fresh terminal reaches the configured shell; a rejected or hung PAM session must never leave the PTY at a `login:` prompt. Existing terminals and unrelated daemon RPCs stay responsive during detection.
- **Failure sources:** PAM rejection/hang, misleading zero exit after EOF, excessive child output, deleted daemon cwd, concurrent restores, and a still-running pre-fix daemon.
- **Success oracle:** only the exact fixed marker from the requested child program plus a clean process exit enables the wrapper.
- **Reliability gate:** stdin EOF is immediate, lifetime is capped at 500 ms with `SIGKILL`, output is capped at 1 KiB, concurrent callers share one child, pending creations are cancelable before subprocess registration, and failure is cached as direct-spawn fallback.
- **Coverage:** both the in-process local provider and detached daemon await preparation at their async fresh-spawn boundary. Non-macOS paths are unchanged; SSH/remote macOS evaluates capability in the PTY-host process that actually launches the shell.
- **Performance budget:** no synchronous child process remains. Healthy live probes completed in roughly 55-70 ms on the test Mac, once per PTY-host process; the hard worst-case delay is 500 ms and concurrent restores do not multiply probes.
- **Diagnostics / accepted gap:** one warning records fallback without logging PAM output. `ORCA_DISABLE_MACOS_LOGIN_SHELL=1` remains the escape hatch. A mid-process account-policy change takes effect after PTY-host restart; until then the cached result deliberately favors a usable direct shell.

## Testing

- [x] Changed-file `oxfmt` and `oxlint` pass (10 files)
- [x] `pnpm run typecheck:node`
- [x] 445 focused tests across the wrapper, local fallback, daemon server/main/entry, and IPC suites
- [x] Daemon protocol gate test
- [x] Daemon concurrency test proves `ping` remains responsive while preparation is pending and concurrent creates yield one PTY subprocess
- [x] Cancellation tests prove daemon `kill` / `cancelCreateOrAttach` / shutdown and local shutdown prevent pending subprocess creation, cancel all concurrent generations, and permit later session-ID reuse
- [x] Reliability-gate manifest and max-lines ratchet checks
- [x] Live healthy macOS preflight (roughly 55-70 ms)
- [x] Live rejected-user probe exits without enabling the wrapper
- [x] Real Electron terminal + authenticated Codex CLI spawn, shown above
- [ ] Full `pnpm lint` reaches an unrelated existing exhaustiveness error in `src/renderer/src/components/skills/skill-freshness-group.tsx:101`; changed-file lint passes
- [ ] Full `pty-subprocess.test.ts` has two existing deleted-cwd cases that exceed Vitest's 5 s timeout on this Mac; the changed protocol assertion passes and the macOS case already took about 9 s before this update
- [x] Fresh PR CI: full repository test suite, unpacked Electron build, packaged CLI smoke, Windows terminal restart E2E, and Linux/Windows native smoke
- [ ] Full local `pnpm build` not run; node typecheck, local Electron dev build, CLI build, and macOS computer-use sidecar build pass

## AI Review Report

A deeper review found and fixed three material regressions in the initial implementation:

1. `spawnSync` could stall Electron or the daemon event loop for 40-500 ms, freezing UI and live terminal traffic. The probe is now async, bounded, and deduplicated.
2. Keeping daemon protocol v22 allowed an already-running buggy v22 daemon to accept the updated client and continue creating broken terminals. Protocol v23 forces new sessions onto the fixed daemon while retaining legacy-session discovery.
3. Moving the probe to an async boundary created a close-during-preparation race. Pending creations are now generation-scoped and canceled before any subprocess can be registered.

The final review covered local and daemon spawn boundaries, concurrency, process cleanup, caching, deleted-cwd behavior, daemon migration, shell fallback, cross-platform gates, SSH execution, and failure diagnostics. No additional change met the bar for a meaningful senior-level fix.

## Security audit

The probe uses fixed absolute system binaries, passes the resolved username as a literal argv element without shell interpolation, bounds time and captured output, closes stdin, and never logs captured output. No secrets, credentials, dependencies, IPC schemas, or persisted settings are added. A rejected probe only reduces behavior to the established direct-shell path.
