### PR TITLE
fix(emulator): support Xcode 27 SimulatorKit relocation

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "posthog-node": "^5.33.3",
     "qrcode": "^1.5.4",
     "react-i18next": "^17.0.8",
-    "serve-sim": "^0.1.40",
+    "serve-sim": "^0.1.42",
     "sherpa-onnx": "1.12.37",
     "ssh2": "^1.17.0",
     "tweetnacl": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,8 +74,8 @@ importers:
         specifier: ^17.0.8
         version: 17.0.8(i18next@26.3.1(typescript@7.0.2))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@7.0.2)
       serve-sim:
-        specifier: ^0.1.40
-        version: 0.1.40(typescript@7.0.2)
+        specifier: ^0.1.42
+        version: 0.1.42(typescript@7.0.2)
       sherpa-onnx:
         specifier: 1.12.37
         version: 1.12.37
@@ -6121,8 +6121,8 @@ packages:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
 
-  serve-sim@0.1.40:
-    resolution: {integrity: sha512-32JSUriN/EnNR3zx6fmiOKjuFrbA8VHWR2J3dX8T51Z/xkSmrSLOwaz/3W9lPiCIaF2O3LT4qpAhLkp0f1kVaw==}
+  serve-sim@0.1.42:
+    resolution: {integrity: sha512-QhIR2IX4FK46wg5XTVcGAG9fEbdE/lOKNGnjNW+ZCMSrWvGMZPeeUuSltxB9xqO3a3RWIIWf9OUysGgIx2L/kg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -12862,11 +12862,14 @@ snapshots:
       type-fest: 0.13.1
     optional: true
 
-  serve-sim@0.1.40(typescript@7.0.2):
+  serve-sim@0.1.42(typescript@7.0.2):
     dependencies:
       inspect-webkit: 0.0.5(typescript@7.0.2)
+      ws: 8.21.0
     transitivePeerDependencies:
+      - bufferutil
       - typescript
+      - utf-8-validate
 
   serve-static@2.2.1:
     dependencies:

--- a/src/main/emulator/serve-sim-execution.ts
+++ b/src/main/emulator/serve-sim-execution.ts
@@ -77,6 +77,7 @@ function resolveMaterializedServeSimPackageDir(bundledPackageDir: string): strin
   }
   materializedServeSimPackageDir = materializeServeSimRuntime({
     bundledPackageDir,
+    bundledNodeModulesDir: join(dirname(bundledPackageDir), 'node_modules'),
     targetRootDir: join(app.getPath('userData'), 'serve-sim-runtime'),
     version: app.getVersion()
   })

--- a/src/main/emulator/serve-sim-runtime-materializer.test.ts
+++ b/src/main/emulator/serve-sim-runtime-materializer.test.ts
@@ -19,6 +19,7 @@ async function createBundledServeSimPackage(root: string): Promise<string> {
     mode: 0o644
   })
   await writeFile(join(packageDir, 'bin', 'serve-sim-bin'), 'bin', { mode: 0o644 })
+  await writeFile(join(packageDir, 'package.json'), JSON.stringify({ dependencies: {} }))
   return packageDir
 }
 
@@ -81,6 +82,41 @@ describe('materializeServeSimRuntime', () => {
 
     expect(second).toBe(first)
     expect(clearQuarantine).toHaveBeenCalledTimes(1)
+  })
+
+  it('copies the runtime dependency closure beside the relocated ESM entry', async () => {
+    const root = await createRoot()
+    const bundledPackageDir = await createBundledServeSimPackage(root)
+    const bundledNodeModulesDir = join(root, 'node_modules')
+    await writeFile(
+      join(bundledPackageDir, 'package.json'),
+      JSON.stringify({ dependencies: { ws: '^8.0.0' } })
+    )
+    await mkdir(join(bundledNodeModulesDir, 'ws'), { recursive: true })
+    await writeFile(
+      join(bundledNodeModulesDir, 'ws', 'package.json'),
+      JSON.stringify({ dependencies: { transitive: '^1.0.0' } })
+    )
+    await mkdir(join(bundledNodeModulesDir, 'transitive'), { recursive: true })
+    await writeFile(
+      join(bundledNodeModulesDir, 'transitive', 'package.json'),
+      JSON.stringify({ dependencies: {} })
+    )
+
+    const materialized = materializeServeSimRuntime({
+      bundledPackageDir,
+      bundledNodeModulesDir,
+      targetRootDir: join(root, 'runtime'),
+      version: '1.2.3',
+      clearQuarantine: () => {}
+    })
+
+    await expect(
+      stat(join(materialized!, 'node_modules', 'ws', 'package.json'))
+    ).resolves.toBeDefined()
+    await expect(
+      stat(join(materialized!, 'node_modules', 'transitive', 'package.json'))
+    ).resolves.toBeDefined()
   })
 
   it('prunes runtimes left behind by older app versions', async () => {

--- a/src/main/emulator/serve-sim-runtime-materializer.ts
+++ b/src/main/emulator/serve-sim-runtime-materializer.ts
@@ -1,9 +1,19 @@
 import { execFileSync } from 'node:child_process'
-import { chmodSync, cpSync, existsSync, mkdirSync, readdirSync, renameSync, rmSync } from 'node:fs'
-import { join } from 'node:path'
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync
+} from 'node:fs'
+import { dirname, join } from 'node:path'
 
 export type ServeSimRuntimeMaterializerOptions = {
   bundledPackageDir: string
+  bundledNodeModulesDir?: string
   targetRootDir: string
   version: string
   clearQuarantine?: (dir: string) => void
@@ -13,6 +23,40 @@ const EXECUTABLE_RELATIVE_PATHS = [
   join('bin', 'serve-sim-bin'),
   join('dist', 'simcam', 'serve-sim-camera-helper')
 ]
+
+function packagePath(nodeModulesDir: string, packageName: string): string {
+  return join(nodeModulesDir, ...packageName.split('/'))
+}
+
+function readRuntimeDependencyNames(packageDir: string): string[] {
+  const packageJson = JSON.parse(readFileSync(join(packageDir, 'package.json'), 'utf8'))
+  return Object.keys(packageJson.dependencies ?? {})
+}
+
+function copyRuntimeDependencyClosure(
+  dependencyNames: string[],
+  bundledNodeModulesDir: string,
+  targetNodeModulesDir: string
+): void {
+  const copied = new Set<string>()
+  const copyDependency = (packageName: string): void => {
+    if (copied.has(packageName)) {
+      return
+    }
+    copied.add(packageName)
+    const sourceDir = packagePath(bundledNodeModulesDir, packageName)
+    const targetDir = packagePath(targetNodeModulesDir, packageName)
+    const dependencies = readRuntimeDependencyNames(sourceDir)
+    mkdirSync(dirname(targetDir), { recursive: true })
+    cpSync(sourceDir, targetDir, { recursive: true })
+    for (const dependencyName of dependencies) {
+      copyDependency(dependencyName)
+    }
+  }
+  for (const dependencyName of dependencyNames) {
+    copyDependency(dependencyName)
+  }
+}
 
 function defaultClearQuarantine(dir: string): void {
   if (process.platform !== 'darwin') {
@@ -56,7 +100,7 @@ function pruneStaleServeSimRuntimes(targetRootDir: string, keepVersion: string):
 export function materializeServeSimRuntime(
   options: ServeSimRuntimeMaterializerOptions
 ): string | null {
-  const { bundledPackageDir, targetRootDir, version } = options
+  const { bundledNodeModulesDir, bundledPackageDir, targetRootDir, version } = options
   const clearQuarantine = options.clearQuarantine ?? defaultClearQuarantine
   const targetDir = join(targetRootDir, version)
   const entryPath = join(targetDir, 'dist', 'serve-sim.js')
@@ -70,6 +114,15 @@ export function materializeServeSimRuntime(
     rmSync(stagingDir, { recursive: true, force: true })
     rmSync(targetDir, { recursive: true, force: true })
     cpSync(bundledPackageDir, stagingDir, { recursive: true })
+    if (bundledNodeModulesDir) {
+      // Why: serve-sim is executed from this relocated ESM package, so Node cannot
+      // resolve dependencies that remain beside the original app-bundle copy.
+      copyRuntimeDependencyClosure(
+        readRuntimeDependencyNames(bundledPackageDir),
+        bundledNodeModulesDir,
+        join(stagingDir, 'node_modules')
+      )
+    }
     for (const relativePath of EXECUTABLE_RELATIVE_PATHS) {
       const executablePath = join(stagingDir, relativePath)
       if (existsSync(executablePath)) {


### PR DESCRIPTION
## Summary

Update `serve-sim` from 0.1.40 to 0.1.42 so Orca's iOS emulator helper works with Xcode 27, and materialize the package's runtime dependency closure alongside the relocated helper.

## Root cause

The helper bundled by `serve-sim` 0.1.40 links `SimulatorKit` through an `@rpath` that points to Xcode's former `Developer/Library/PrivateFrameworks` location. Xcode 27 moved the framework to `Contents/SharedFrameworks`, so the helper exits before starting with `dyld: Library not loaded: @rpath/SimulatorKit.framework`.

`serve-sim` 0.1.42 includes EvanBacon/serve-sim#90. That change removes the version-specific load command and loads the simulator frameworks dynamically from the active Xcode installation.

Unlike 0.1.40, version 0.1.42 imports runtime packages such as `ws`. Orca runs a materialized copy of `serve-sim` from Application Support, outside the app bundle, so Node's ESM resolver cannot find dependencies that remain under `Orca.app/Contents/Resources/node_modules`. The materializer now copies the dependency closure declared by `serve-sim` into the relocated runtime.

## User impact

The embedded iOS simulator stream can start under Xcode 27 without requiring a global `DYLD_FRAMEWORK_PATH` workaround.

## Validation

- Confirmed the installed dependency resolves to `serve-sim` 0.1.42.
- Confirmed `otool -L node_modules/serve-sim/bin/serve-sim-bin` no longer contains an `@rpath/SimulatorKit` load command.
- Started the helper against a booted iOS 27 iPhone 17 Pro using Xcode 27.0 (27A5218g); framebuffer capture, HID setup, JPEG encoding, and the HTTP stream all started successfully.
- Exercised the materialized helper through the installed Orca Electron-as-Node executable; attach, list, and kill all succeeded.
- Emulator-focused tests: 23 passed, including a regression test for direct and transitive runtime dependencies.
- Full test suite: 31,655 passed, 52 skipped.
- `pnpm typecheck`: passed.
- `pnpm build:desktop`: passed.
- `git diff --check`: passed.

### Existing baseline issues observed

- `pnpm lint` reaches an existing switch-exhaustiveness error in `src/renderer/src/components/skills/skill-freshness-group.tsx`. This PR does not modify that file.
- `pnpm build` completes the desktop build, then the existing Xcode 27 native helper build fails when `lipo` looks for architecture-specific outputs under paths that Swift no longer produced. This PR does not modify the native build scripts.

## AI code review summary

The diff contains the dependency bump, materializer support for the declared runtime dependency closure, and a regression test. The copy is driven by package metadata and is limited to packages already bundled with Orca. No UI code changes.

## Security audit

This updates an existing direct dependency from the same publisher and preserves lockfile integrity metadata. Materialization copies only the package.json-declared dependency closure already present in the signed app resources; it performs no runtime downloads. No permissions, network endpoints, credentials, or executable invocation arguments are changed by this PR.

## Visual changes

None.

## X handle

N/A (no X handle configured on the contributor's GitHub profile).

## ELI5

Xcode 27 moved SimulatorKit, so Orca's iOS emulator helper failed to start. Bumping serve-sim and its dependencies restores the helper against the new framework location.
