### PR TITLE
Create PR: fast-forward behind-only branches with --ff-only

### DIFF
--- a/src/main/keybindings/keybinding-file.test.ts
+++ b/src/main/keybindings/keybinding-file.test.ts
@@ -370,13 +370,17 @@ describe('keybinding-file', () => {
 
   it('throws instead of freezing the seed when a legacy binding fails normalization', () => {
     // A dropped pin must not be silent: the service catches the throw and keeps
-    // the cohort pending so a corrected build can retry the seed.
+    // the cohort pending so a corrected build can retry the seed. Valid pins
+    // from the same batch are still written so users keep the good shortcuts.
     expect(() =>
       seedLegacyTabSwitchBindings(filePath, 'darwin', {
-        'tab.nextSameType': ['J']
+        'tab.nextSameType': ['J'],
+        'tab.previousSameType': ['Mod+Shift+BracketLeft']
       })
     ).toThrow(/normalize/i)
-    expect(readKeybindingFile(filePath, 'darwin').platformOverrides.darwin).toEqual({})
+    expect(readKeybindingFile(filePath, 'darwin').platformOverrides.darwin).toEqual({
+      'tab.previousSameType': ['Mod+Shift+BracketLeft']
+    })
   })
 
   it('does not replace an unreadable keybindings file while seeding', () => {

--- a/src/main/keybindings/keybinding-file.ts
+++ b/src/main/keybindings/keybinding-file.ts
@@ -353,26 +353,31 @@ export function seedLegacyTabSwitchBindings(
     return { seeded: false, snapshot: current }
   }
 
-  // Why: never freeze the one-shot after dropping a pin — a normalization
-  // failure must throw so the cohort stays pending and a fixed build retries.
-  const pins = toSeed.map((actionId) => {
+  // Why: seed every pin that normalizes, but never freeze the one-shot if any
+  // pin was dropped — throw after writing good pins so the cohort stays pending
+  // and a fixed build retries the failed action without wiping the others.
+  const pins: (readonly [KeybindingActionId, string[]])[] = []
+  const failedActionIds: KeybindingActionId[] = []
+  for (const actionId of toSeed) {
     const normalized = normalizeKeybindingArrayForAction(actionId, legacyBindings[actionId] ?? [])
     if (!Array.isArray(normalized)) {
-      throw new Error(`Could not normalize legacy binding for "${actionId}".`)
+      failedActionIds.push(actionId)
+      continue
     }
-    return [actionId, normalized] as const
-  })
-  const snapshot = writeActivePlatformSection(
-    path,
-    platform,
-    current.commonOverrides,
-    (activePlatform) => {
-      for (const [actionId, normalized] of pins) {
-        activePlatform[actionId] = normalized
-      }
-    }
-  )
-  return { seeded: true, snapshot }
+    pins.push([actionId, normalized])
+  }
+  const snapshot =
+    pins.length > 0
+      ? writeActivePlatformSection(path, platform, current.commonOverrides, (activePlatform) => {
+          for (const [actionId, normalized] of pins) {
+            activePlatform[actionId] = normalized
+          }
+        })
+      : current
+  if (failedActionIds.length > 0) {
+    throw new Error(`Could not normalize legacy binding for "${failedActionIds.join('", "')}".`)
+  }
+  return { seeded: pins.length > 0, snapshot }
 }
 
 // Why: the one-shot seed migration and Settings writes must produce the same

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -195,7 +195,10 @@ import { resolveCreateReviewDraftTitle } from './create-review-draft-title'
 import { GitHistoryPanel, type GitHistoryPanelState } from './GitHistoryPanel'
 import { useGitHistoryCommitActions } from './useGitHistoryCommitActions'
 import { normalizeHostedReviewHeadRef } from '../../../../shared/hosted-review-refs'
-import { shouldForcePushWithLeaseForUpstream } from '../../../../shared/git-upstream-status'
+import {
+  isBehindOnlyUpstream,
+  shouldForcePushWithLeaseForUpstream
+} from '../../../../shared/git-upstream-status'
 import type {
   DiffComment,
   GitBranchChangeEntry,
@@ -258,7 +261,6 @@ import {
   createPrIntentRunTokenMatches,
   getCreatePrIntentCommitFailureNoticeMessage,
   getCreatePrIntentStagePaths,
-  isCreatePrIntentSyncConflictError,
   resolveCreatePrIntentReviewBase,
   resolveCreatePrIntentRemoteStep,
   type CreatePrIntentRunToken
@@ -2469,6 +2471,16 @@ function SourceControlInner(): React.JSX.Element {
   // chevron dropdown can trigger. Keeps the error-swallow pattern in one
   // place — store slices already surface actionable toasts, so additional
   // try/catch here would duplicate the notification.
+  // Why: callers must distinguish real failures from "a newer remote action won
+  // the sequence" and "this call was a no-op (missing target/base)". Collapsing
+  // those into `{ ok: false, error: null }` made Create PR treat supersession as
+  // a destructive remote failure.
+  type RunRemoteActionResult =
+    | { status: 'ok' }
+    | { status: 'failed'; error: SourceControlActionError }
+    | { status: 'superseded' }
+    | { status: 'skipped' }
+
   const runRemoteAction = useCallback(
     async (
       kind:
@@ -2484,10 +2496,7 @@ function SourceControlInner(): React.JSX.Element {
         target?: SourceControlOperationTarget
         baseRef?: string | null
       }
-      // Why: return the failure inline (null error = success or superseded) so
-      // callers like the Create PR intent flow can classify it without a
-      // stale-prone mirror of remoteActionErrors.
-    ): Promise<{ ok: boolean; error: SourceControlActionError | null }> => {
+    ): Promise<RunRemoteActionResult> => {
       const target =
         options?.target ??
         (activeWorktreeId && worktreePath
@@ -2500,7 +2509,7 @@ function SourceControlInner(): React.JSX.Element {
             }
           : null)
       if (!target) {
-        return { ok: false, error: null }
+        return { status: 'skipped' }
       }
       const sequence = (remoteActionErrorSequenceByWorktreeRef.current[target.worktreeId] ?? 0) + 1
       remoteActionErrorSequenceByWorktreeRef.current[target.worktreeId] = sequence
@@ -2526,7 +2535,7 @@ function SourceControlInner(): React.JSX.Element {
             target.pushTarget,
             { runtimeTargetSettings: target.settings }
           )
-          return { ok: true, error: null }
+          return { status: 'ok' }
         }
         if (kind === 'push') {
           // Why: kind 'push' must stay a regular push. Force-with-lease is only
@@ -2541,7 +2550,7 @@ function SourceControlInner(): React.JSX.Element {
             target.pushTarget,
             { runtimeTargetSettings: target.settings }
           )
-          return { ok: true, error: null }
+          return { status: 'ok' }
         }
         if (kind === 'force_push') {
           await pushBranch(
@@ -2552,7 +2561,7 @@ function SourceControlInner(): React.JSX.Element {
             target.pushTarget,
             { forceWithLease: true, runtimeTargetSettings: target.settings }
           )
-          return { ok: true, error: null }
+          return { status: 'ok' }
         }
         if (kind === 'pull') {
           await pullBranch(
@@ -2564,7 +2573,7 @@ function SourceControlInner(): React.JSX.Element {
               runtimeTargetSettings: target.settings
             }
           )
-          return { ok: true, error: null }
+          return { status: 'ok' }
         }
         if (kind === 'fast_forward') {
           await fastForwardBranch(
@@ -2574,7 +2583,7 @@ function SourceControlInner(): React.JSX.Element {
             target.pushTarget,
             { runtimeTargetSettings: target.settings }
           )
-          return { ok: true, error: null }
+          return { status: 'ok' }
         }
         if (kind === 'fetch') {
           await fetchBranch(
@@ -2586,12 +2595,12 @@ function SourceControlInner(): React.JSX.Element {
               runtimeTargetSettings: target.settings
             }
           )
-          return { ok: true, error: null }
+          return { status: 'ok' }
         }
         if (kind === 'rebase') {
           const baseRef = options?.baseRef ?? effectiveBaseRef
           if (!baseRef) {
-            return { ok: false, error: null }
+            return { status: 'skipped' }
           }
           await rebaseFromBase(
             target.worktreeId,
@@ -2601,7 +2610,7 @@ function SourceControlInner(): React.JSX.Element {
             target.pushTarget,
             { runtimeTargetSettings: target.settings }
           )
-          return { ok: true, error: null }
+          return { status: 'ok' }
         }
         await syncBranch(
           target.worktreeId,
@@ -2615,14 +2624,14 @@ function SourceControlInner(): React.JSX.Element {
         if (remoteActionErrorSequenceByWorktreeRef.current[target.worktreeId] === sequence) {
           setRemoteActionErrors((prev) => ({ ...prev, [target.worktreeId]: null }))
         }
-        return { ok: true, error: null }
+        return { status: 'ok' }
       } catch (error) {
         // Why: remote action failures are surfaced by editor-slice actions to keep
         // one consistent toast path and avoid duplicate notifications in the UI.
         // Keep the latest failure inline too: dropdown-only actions like Fetch can
         // otherwise look like nothing happened once the menu closes.
         if (remoteActionErrorSequenceByWorktreeRef.current[target.worktreeId] !== sequence) {
-          return { ok: false, error: null }
+          return { status: 'superseded' }
         }
         const actionError: SourceControlActionError = {
           kind,
@@ -2636,7 +2645,7 @@ function SourceControlInner(): React.JSX.Element {
           sequence
         }
         setRemoteActionErrors((prev) => ({ ...prev, [target.worktreeId]: actionError }))
-        return { ok: false, error: actionError }
+        return { status: 'failed', error: actionError }
       } finally {
         if (!options?.target) {
           refreshSourceControlAfterRemoteAction({
@@ -3884,6 +3893,42 @@ function SourceControlInner(): React.JSX.Element {
         return
       }
 
+      // Why: fast-forward behind-only *before* commit so a dirty worktree does
+      // not become ahead+behind after Create PR commits, then dead-end at the
+      // explicit sync-first stop. --ff-only refuses if the branch diverged mid
+      // flight or local edits would be overwritten — never auto-merges.
+      if (isBehindOnlyUpstream(latestUpstreamStatus)) {
+        setCreatePrIntentNoticeForWorktree(token.worktreeId, {
+          tone: 'muted',
+          message: translate(
+            'auto.components.right.sidebar.SourceControl.createPrIntentFastForwarding',
+            'Updating branch…'
+          )
+        })
+        const earlyFfResult = await runRemoteAction('fast_forward', {
+          target: operationTarget
+        })
+        if (abortIfStale()) {
+          return
+        }
+        if (earlyFfResult.status === 'superseded') {
+          return
+        }
+        if (earlyFfResult.status !== 'ok') {
+          setCreatePrIntentNoticeForWorktree(token.worktreeId, {
+            tone: 'destructive',
+            message: translate(
+              'auto.components.right.sidebar.SourceControl.createPrIntentRemoteFailed',
+              'Could not update the remote branch. Retry Create PR.'
+            )
+          })
+          return
+        }
+        if (!(await refreshIntentSnapshot())) {
+          return
+        }
+      }
+
       if (!(await stageLatestIntentPaths())) {
         return
       }
@@ -4017,7 +4062,7 @@ function SourceControlInner(): React.JSX.Element {
       if (remoteStep === 'blocked' || remoteStep === 'none') {
         setCreatePrIntentNoticeForWorktree(token.worktreeId, {
           tone: 'muted',
-          // Why: a diverged branch is deliberately not auto-synced (that would
+          // Why: a diverged branch is deliberately not auto-prepared (that would
           // merge without consent), so keep the explicit sync-first guidance.
           message:
             eligibility.blockedReason === 'needs_sync'
@@ -4048,10 +4093,10 @@ function SourceControlInner(): React.JSX.Element {
                   'auto.components.right.sidebar.SourceControl.createPrIntentForcePushing',
                   'Force pushing with lease…'
                 )
-              : remoteStep === 'sync'
+              : remoteStep === 'fast_forward'
                 ? translate(
-                    'auto.components.right.sidebar.SourceControl.createPrIntentSyncing',
-                    'Syncing branch…'
+                    'auto.components.right.sidebar.SourceControl.createPrIntentFastForwarding',
+                    'Updating branch…'
                   )
                 : translate(
                     'auto.components.right.sidebar.SourceControl.createPrIntentPushing',
@@ -4065,20 +4110,17 @@ function SourceControlInner(): React.JSX.Element {
       if (abortIfStale()) {
         return
       }
-      if (!remoteResult.ok) {
-        // A sync push-stage rejection is not a conflict — it falls to the generic
-        // copy so the push-recovery panel drives the fix.
+      // Superseded by a newer remote action — drop quietly, same as target drift.
+      if (remoteResult.status === 'superseded') {
+        return
+      }
+      if (remoteResult.status !== 'ok') {
         setCreatePrIntentNoticeForWorktree(token.worktreeId, {
           tone: 'destructive',
-          message: isCreatePrIntentSyncConflictError(remoteResult.error)
-            ? translate(
-                'auto.components.right.sidebar.SourceControl.createPrIntentSyncConflicts',
-                'Sync hit conflicts. Resolve them, then retry Create PR.'
-              )
-            : translate(
-                'auto.components.right.sidebar.SourceControl.createPrIntentRemoteFailed',
-                'Could not update the remote branch. Retry Create PR.'
-              )
+          message: translate(
+            'auto.components.right.sidebar.SourceControl.createPrIntentRemoteFailed',
+            'Could not update the remote branch. Retry Create PR.'
+          )
         })
         return
       }

--- a/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts
@@ -7,7 +7,6 @@ import {
   createPrIntentRunTokenMatches,
   getCreatePrIntentCommitFailureNoticeMessage,
   getCreatePrIntentStagePaths,
-  isCreatePrIntentSyncConflictError,
   resolveCreatePrIntentReviewBase,
   resolveCreatePrIntentRemoteStep
 } from './source-control-create-pr-intent-flow'
@@ -230,9 +229,9 @@ describe('source-control Create PR intent flow helpers', () => {
     ).toBe('force_push')
   })
 
-  it('syncs behind-only branches, blocks diverged and unpublished-without-commits branches', () => {
-    // Genuinely diverged (local + non-equivalent remote commits): auto-syncing
-    // would merge without consent, so the intent flow keeps the explicit stop.
+  it('fast-forwards behind-only branches, blocks diverged and unpublished-without-commits branches', () => {
+    // Genuinely diverged (local + non-equivalent remote commits): auto-merging
+    // would reconcile without consent, so the intent flow keeps the explicit stop.
     expect(
       resolveCreatePrIntentRemoteStep({
         upstreamStatus: { hasUpstream: true, ahead: 1, behind: 1 },
@@ -247,7 +246,7 @@ describe('source-control Create PR intent flow helpers', () => {
       })
     ).toBe('blocked')
 
-    // Behind with no local commits (pure fast-forward case) auto-syncs.
+    // Behind with no local commits: pure --ff-only (never plain merge sync).
     expect(
       resolveCreatePrIntentRemoteStep({
         upstreamStatus: { hasUpstream: true, ahead: 0, behind: 3 },
@@ -260,7 +259,7 @@ describe('source-control Create PR intent flow helpers', () => {
           nextAction: 'sync'
         }
       })
-    ).toBe('sync')
+    ).toBe('fast_forward')
 
     expect(
       resolveCreatePrIntentRemoteStep({
@@ -295,82 +294,5 @@ describe('source-control Create PR intent flow helpers', () => {
         withSummary: (summary) => `localized ${summary}`
       })
     ).toBe('localized Pre-commit hook failed.')
-  })
-
-  it('treats only a genuine merge-conflict sync failure as a conflict for notice copy', () => {
-    // Pull/merge conflict from this sync: the user must resolve conflicts.
-    expect(
-      isCreatePrIntentSyncConflictError({
-        kind: 'sync',
-        syncPushStage: false,
-        rawError: 'CONFLICT (content): Merge conflict in src/app.ts'
-      })
-    ).toBe(true)
-    // An unconcluded prior merge also counts as a conflict to resolve.
-    expect(
-      isCreatePrIntentSyncConflictError({
-        kind: 'sync',
-        rawError: 'error: you have not concluded your merge (MERGE_HEAD exists).'
-      })
-    ).toBe(true)
-
-    // A fetch/network/auth failure during sync is NOT a conflict, even though it
-    // is not marked as the push stage — it must fall to the generic copy.
-    expect(
-      isCreatePrIntentSyncConflictError({
-        kind: 'sync',
-        syncPushStage: false,
-        rawError: 'fatal: Authentication failed for remote'
-      })
-    ).toBe(false)
-    // No raw error at all is not a conflict.
-    expect(isCreatePrIntentSyncConflictError({ kind: 'sync' })).toBe(false)
-
-    // Push-stage rejection during sync is a push failure, not a conflict.
-    expect(
-      isCreatePrIntentSyncConflictError({
-        kind: 'sync',
-        syncPushStage: true,
-        rawError: 'CONFLICT (content): Merge conflict in src/app.ts'
-      })
-    ).toBe(false)
-
-    // Non-sync remote failures never use the conflict copy.
-    expect(isCreatePrIntentSyncConflictError({ kind: 'push' })).toBe(false)
-    expect(
-      isCreatePrIntentSyncConflictError({
-        kind: 'force_push',
-        syncPushStage: false,
-        rawError: 'CONFLICT (content): Merge conflict in src/app.ts'
-      })
-    ).toBe(false)
-    expect(isCreatePrIntentSyncConflictError(null)).toBe(false)
-    expect(isCreatePrIntentSyncConflictError(undefined)).toBe(false)
-  })
-
-  it('recognizes every merge-conflict wording git can emit during sync', () => {
-    // The fresh-conflict pattern's other alternatives: "Automatic merge failed"
-    // and "fix conflicts" are the most common real pull output.
-    expect(
-      isCreatePrIntentSyncConflictError({
-        kind: 'sync',
-        syncPushStage: false,
-        rawError: 'Automatic merge failed; fix conflicts and then commit the result.'
-      })
-    ).toBe(true)
-    // The unconcluded-merge pattern's other alternatives: "unmerged files" and
-    // "needs merge".
-    expect(
-      isCreatePrIntentSyncConflictError({
-        kind: 'sync',
-        rawError: 'error: Pulling is not possible because you have unmerged files.'
-      })
-    ).toBe(true)
-    expect(
-      isCreatePrIntentSyncConflictError({
-        kind: 'sync',
-        rawError: "error: path 'src/app.ts' needs merge"
-      })
-    ).toBe(true)
   })
 })

--- a/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.ts
@@ -1,12 +1,13 @@
-import { shouldForcePushWithLeaseForUpstream } from '../../../../shared/git-upstream-status'
+import {
+  isBehindOnlyUpstream,
+  shouldForcePushWithLeaseForUpstream
+} from '../../../../shared/git-upstream-status'
 import type { HostedReviewCreationEligibility } from '../../../../shared/hosted-review'
 import {
   normalizeHostedReviewBaseRef,
   normalizeHostedReviewHeadRef
 } from '../../../../shared/hosted-review-refs'
 import type { GitStatusEntry, GitUpstreamStatus } from '../../../../shared/types'
-import { isMergeConflictErrorMessage } from '../../lib/source-control-remote-error'
-import type { SourceControlActionError } from './source-control-action-error'
 import { summarizeCommitFailure } from './commit-failure-summary'
 import { getStageAllPaths } from './discard-all-sequence'
 
@@ -14,7 +15,7 @@ export type CreatePrIntentRemoteStep =
   | 'publish'
   | 'push'
   | 'force_push'
-  | 'sync'
+  | 'fast_forward'
   | 'blocked'
   | 'none'
 
@@ -150,34 +151,15 @@ export function resolveCreatePrIntentRemoteStep({
     if (shouldForcePushWithLeaseForUpstream(upstreamStatus)) {
       return 'force_push'
     }
-    // Why: auto-sync only a behind-only branch, where the pull is a fast-forward
-    // that cannot create a merge commit or strand the worktree mid-merge. A
-    // genuinely diverged branch keeps the explicit sync-first stop so Create PR
-    // never merges without consent.
-    return upstreamStatus?.hasUpstream && upstreamStatus.ahead === 0 && upstreamStatus.behind > 0
-      ? 'sync'
-      : 'blocked'
+    // Why: auto-prepare only a behind-only branch, and only via `--ff-only`.
+    // Plain sync/merge could create a merge commit if the branch diverges mid
+    // flight or the user has pull.ff=no; --ff-only enforces the no-consent-
+    // merge invariant at execution time. Genuinely diverged branches keep the
+    // explicit sync-first stop.
+    return isBehindOnlyUpstream(upstreamStatus) ? 'fast_forward' : 'blocked'
   }
 
   return 'none'
-}
-
-export type CreatePrIntentRemoteFailure =
-  | (Pick<SourceControlActionError, 'kind' | 'syncPushStage'> &
-      Partial<Pick<SourceControlActionError, 'rawError'>>)
-  | null
-  | undefined
-
-export function isCreatePrIntentSyncConflictError(error: CreatePrIntentRemoteFailure): boolean {
-  // Why: only a genuine merge conflict earns the "resolve conflicts" copy. A
-  // sync push-stage rejection is a push failure, and a fetch/network/auth
-  // failure during sync is neither a conflict nor push-stage — both must fall
-  // to the generic remote-failed notice, so match the raw git output rather
-  // than assuming every non-push-stage sync failure is a conflict.
-  if (error?.kind !== 'sync' || error.syncPushStage === true) {
-    return false
-  }
-  return isMergeConflictErrorMessage(error.rawError ?? '')
 }
 
 export function getCreatePrIntentCommitFailureNoticeMessage(

--- a/src/renderer/src/components/right-sidebar/source-control-primary-action.create-pr-intent.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-action.create-pr-intent.test.ts
@@ -71,7 +71,7 @@ describe('resolvePrimaryAction Create PR intent', () => {
     expect(result.disabled).toBe(false)
   })
 
-  it('returns Create PR intent for a behind-only branch (fast-forward sync)', () => {
+  it('returns Create PR intent for a behind-only branch (fast-forward prepare)', () => {
     const input = inputs({
       upstreamStatus: {
         hasUpstream: true,

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -17578,64 +17578,69 @@ describe('connectPanePty', () => {
     // land in the first advance window, confirming exit before the replacement
     // hook owner is set and racing the very veto this test asserts.
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.5)
-    const getForegroundProcess = vi.mocked(window.api.pty.getForegroundProcess)
-    getForegroundProcess.mockResolvedValue('codex')
-    const paneKey = makePaneKey('tab-1', LEAF_1)
-    const pane = createPane(1)
-    const manager = createManager(1)
-    const deps = createDeps()
+    try {
+      const getForegroundProcess = vi.mocked(window.api.pty.getForegroundProcess)
+      getForegroundProcess.mockResolvedValue('codex')
+      const paneKey = makePaneKey('tab-1', LEAF_1)
+      const pane = createPane(1)
+      const manager = createManager(1)
+      const deps = createDeps()
 
-    connectPanePty(pane as never, manager as never, deps as never)
-    await flushAsyncTicks()
-    const titleHandler = createdTransportOptions[0]?.onTitleChange as
-      | ((title: string, rawTitle: string) => void)
-      | undefined
-    const idleHandler = createdTransportOptions[0]?.onAgentBecameIdle as
-      | ((title: string) => void)
-      | undefined
-    if (!titleHandler || !idleHandler) {
-      throw new Error('Expected title and idle handlers to be registered')
-    }
-
-    titleHandler('Codex working', 'Codex working')
-    await vi.advanceTimersByTimeAsync(2_500)
-    const inspectionsBeforeIdle = getForegroundProcess.mock.calls.length
-    getForegroundProcess.mockResolvedValue(null)
-    // Why: active process polling is jittered, so a fixed window can consume
-    // both null samples before the replacement hook row is installed.
-    for (
-      let attempts = 0;
-      getForegroundProcess.mock.calls.length === inspectionsBeforeIdle;
-      attempts += 1
-    ) {
-      if (attempts >= 10) {
-        throw new Error('Expected the first idle process inspection')
+      connectPanePty(pane as never, manager as never, deps as never)
+      await flushAsyncTicks()
+      const titleHandler = createdTransportOptions[0]?.onTitleChange as
+        | ((title: string, rawTitle: string) => void)
+        | undefined
+      const idleHandler = createdTransportOptions[0]?.onAgentBecameIdle as
+        | ((title: string) => void)
+        | undefined
+      if (!titleHandler || !idleHandler) {
+        throw new Error('Expected title and idle handlers to be registered')
       }
-      await vi.advanceTimersToNextTimerAsync()
-    }
-    expect(getForegroundProcess).toHaveBeenCalledTimes(inspectionsBeforeIdle + 1)
 
-    mockStoreState.agentStatusByPaneKey[paneKey] = {
-      state: 'working',
-      prompt: 'replacement agent turn',
-      updatedAt: Date.now(),
-      stateStartedAt: Date.now(),
-      agentType: 'claude',
-      paneKey,
-      stateHistory: []
-    }
-    idleHandler('Claude done')
-    await vi.advanceTimersByTimeAsync(800)
-    await vi.advanceTimersByTimeAsync(AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS)
+      titleHandler('Codex working', 'Codex working')
+      await vi.advanceTimersByTimeAsync(2_500)
+      const inspectionsBeforeIdle = getForegroundProcess.mock.calls.length
+      getForegroundProcess.mockResolvedValue(null)
+      // Why: active process polling is jittered, so a fixed window can consume
+      // both null samples before the replacement hook row is installed.
+      for (
+        let attempts = 0;
+        getForegroundProcess.mock.calls.length === inspectionsBeforeIdle;
+        attempts += 1
+      ) {
+        if (attempts >= 10) {
+          throw new Error('Expected the first idle process inspection')
+        }
+        await vi.advanceTimersToNextTimerAsync()
+      }
+      expect(getForegroundProcess).toHaveBeenCalledTimes(inspectionsBeforeIdle + 1)
 
-    expect(deps.dispatchNotification).not.toHaveBeenCalledWith(
-      expect.objectContaining({ source: 'agent-task-complete' })
-    )
-    expect(pane.terminal.write).not.toHaveBeenCalledWith(
-      RESET_TERMINAL_CURSOR_STYLE,
-      expect.any(Function)
-    )
-    randomSpy.mockRestore()
+      mockStoreState.agentStatusByPaneKey[paneKey] = {
+        state: 'working',
+        prompt: 'replacement agent turn',
+        updatedAt: Date.now(),
+        stateStartedAt: Date.now(),
+        agentType: 'claude',
+        paneKey,
+        stateHistory: []
+      }
+      idleHandler('Claude done')
+      await vi.advanceTimersByTimeAsync(800)
+      await vi.advanceTimersByTimeAsync(AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS)
+
+      expect(deps.dispatchNotification).not.toHaveBeenCalledWith(
+        expect.objectContaining({ source: 'agent-task-complete' })
+      )
+      expect(pane.terminal.write).not.toHaveBeenCalledWith(
+        RESET_TERMINAL_CURSOR_STYLE,
+        expect.any(Function)
+      )
+    } finally {
+      // Why: any assertion failure above must not pin Math.random for later tests
+      // in this large suite.
+      randomSpy.mockRestore()
+    }
   })
 
   it('preserves replacement-agent title side effects through the process replacement veto', async () => {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9690,6 +9690,7 @@
             "createPrIntentPublishing": "Publishing branch…",
             "createPrIntentForcePushing": "Force pushing with lease…",
             "createPrIntentPushing": "Pushing commits…",
+            "createPrIntentFastForwarding": "Updating branch…",
             "createPrIntentRemoteFailed": "Could not update the remote branch. Retry Create PR.",
             "createPrIntentGeneratingDetails": "Generating review details…",
             "createPrIntentBranchChangedDuringDetails": "Branch changed while generating review details. Retry Create PR.",
@@ -9722,9 +9723,7 @@
               "a9bf7c171a": "Push Failed",
               "834cb3f23d": "Fix with AI",
               "783a808870": "Close"
-            },
-            "createPrIntentSyncConflicts": "Sync hit conflicts. Resolve them, then retry Create PR.",
-            "createPrIntentSyncing": "Syncing branch…"
+            }
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "Could not start the selected agent.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9667,6 +9667,7 @@
             "createPrIntentPublishing": "Publicando rama…",
             "createPrIntentForcePushing": "Haciendo force push con lease…",
             "createPrIntentPushing": "Haciendo push de commits…",
+            "createPrIntentFastForwarding": "Actualizando rama…",
             "createPrIntentRemoteFailed": "No se pudo actualizar la rama remota. Vuelve a intentar Crear PR.",
             "createPrIntentGeneratingDetails": "Generando detalles de revisión…",
             "createPrIntentBranchChangedDuringDetails": "La rama cambió mientras se generaban los detalles de la revisión. Vuelve a intentar Crear PR.",
@@ -9699,9 +9700,7 @@
               "a9bf7c171a": "Push fallido",
               "834cb3f23d": "Corregir con AI",
               "783a808870": "Cerrar"
-            },
-            "createPrIntentSyncConflicts": "La sincronización encontró conflictos. Resuélvelos y vuelve a intentar Crear PR.",
-            "createPrIntentSyncing": "Sincronizando rama…"
+            }
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "No se pudo iniciar el agente seleccionado.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9667,6 +9667,7 @@
             "createPrIntentPublishing": "ブランチを公開中…",
             "createPrIntentForcePushing": "lease 付きで強制プッシュ中…",
             "createPrIntentPushing": "commits をプッシュ中…",
+            "createPrIntentFastForwarding": "ブランチを更新中…",
             "createPrIntentRemoteFailed": "リモートブランチを更新できませんでした。Create PR を再試行してください。",
             "createPrIntentGeneratingDetails": "レビューの詳細を生成中…",
             "createPrIntentBranchChangedDuringDetails": "レビューの詳細を生成中にブランチが変更されました。Create PR を再試行してください。",
@@ -9699,9 +9700,7 @@
               "a9bf7c171a": "プッシュ失敗",
               "834cb3f23d": "AIで修正",
               "783a808870": "閉じる"
-            },
-            "createPrIntentSyncConflicts": "同期で競合が発生しました。解決してから Create PR を再試行してください。",
-            "createPrIntentSyncing": "ブランチを同期中…"
+            }
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "選択した agent を開始できませんでした。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9667,6 +9667,7 @@
             "createPrIntentPublishing": "브랜치를 게시하는 중…",
             "createPrIntentForcePushing": "lease로 강제 푸시하는 중…",
             "createPrIntentPushing": "commits을 푸시하는 중…",
+            "createPrIntentFastForwarding": "브랜치를 업데이트하는 중…",
             "createPrIntentRemoteFailed": "원격 브랜치를 업데이트할 수 없습니다. Create PR을 다시 시도하세요.",
             "createPrIntentGeneratingDetails": "리뷰 세부 정보 생성 중…",
             "createPrIntentBranchChangedDuringDetails": "리뷰 세부 정보를 생성하는 동안 브랜치가 변경되었습니다. Create PR을 다시 시도하세요.",
@@ -9699,9 +9700,7 @@
               "a9bf7c171a": "푸시 실패",
               "834cb3f23d": "AI로 수정",
               "783a808870": "닫기"
-            },
-            "createPrIntentSyncConflicts": "동기화 중 충돌이 발생했습니다. 해결한 다음 Create PR을 다시 시도하세요.",
-            "createPrIntentSyncing": "브랜치를 동기화하는 중…"
+            }
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "선택한 agent를 시작할 수 없습니다.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9667,6 +9667,7 @@
             "createPrIntentPublishing": "正在发布分支…",
             "createPrIntentForcePushing": "正在使用 lease 强制推送…",
             "createPrIntentPushing": "正在推送提交…",
+            "createPrIntentFastForwarding": "正在更新分支…",
             "createPrIntentRemoteFailed": "无法更新远程分支。请重试创建 PR。",
             "createPrIntentGeneratingDetails": "正在生成审查详情…",
             "createPrIntentBranchChangedDuringDetails": "生成审查详情时分支已更改。请重试创建 PR。",
@@ -9699,9 +9700,7 @@
               "a9bf7c171a": "推送失败",
               "834cb3f23d": "使用 AI 修复",
               "783a808870": "关闭"
-            },
-            "createPrIntentSyncConflicts": "同步遇到冲突。请解决后重试创建 PR。",
-            "createPrIntentSyncing": "正在同步分支…"
+            }
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "无法启动选定的智能体。",

--- a/src/renderer/src/lib/source-control-remote-error.ts
+++ b/src/renderer/src/lib/source-control-remote-error.ts
@@ -110,23 +110,11 @@ export function isSyncPushStageError(error: unknown): boolean {
   )
 }
 
-// Why: shared patterns so conflict classification and toast copy cannot drift.
-// Unconcluded prior merge vs. a fresh conflict from this operation produce
-// different user-facing messages, but Create PR treats both as "sync conflict".
+// Why: shared patterns so unconcluded-merge vs fresh-conflict toast copy cannot
+// drift between the two branches below.
 const UNCONCLUDED_MERGE_ERROR_PATTERN =
   /unmerged files|needs merge|you have not concluded your merge/i
 const FRESH_MERGE_CONFLICT_ERROR_PATTERN = /automatic merge failed|CONFLICT \(|fix conflicts/i
-
-// Why: detects "the working tree has merge conflicts the user must resolve" —
-// both an unconcluded prior merge and a fresh conflict from this operation.
-// Lets the Create PR flow tell a real sync conflict apart from a
-// fetch/network/auth/push failure that only looks similar.
-export function isMergeConflictErrorMessage(message: string): boolean {
-  return (
-    UNCONCLUDED_MERGE_ERROR_PATTERN.test(message) ||
-    FRESH_MERGE_CONFLICT_ERROR_PATTERN.test(message)
-  )
-}
 
 export function resolveRemoteOperationErrorMessage(
   error: unknown,

--- a/src/shared/git-upstream-status.test.ts
+++ b/src/shared/git-upstream-status.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  isBehindOnlyUpstream,
   shouldForcePushWithLeaseForUpstream,
   upstreamOnlyCommitsArePatchEquivalent
 } from './git-upstream-status'
@@ -51,5 +52,39 @@ describe('shouldForcePushWithLeaseForUpstream', () => {
         behindCommitsArePatchEquivalent: false
       })
     ).toBe(false)
+  })
+})
+
+describe('isBehindOnlyUpstream', () => {
+  it('is true only when the branch tracks upstream and is purely behind', () => {
+    expect(
+      isBehindOnlyUpstream({
+        hasUpstream: true,
+        ahead: 0,
+        behind: 3
+      })
+    ).toBe(true)
+    expect(
+      isBehindOnlyUpstream({
+        hasUpstream: true,
+        ahead: 1,
+        behind: 2
+      })
+    ).toBe(false)
+    expect(
+      isBehindOnlyUpstream({
+        hasUpstream: true,
+        ahead: 0,
+        behind: 0
+      })
+    ).toBe(false)
+    expect(
+      isBehindOnlyUpstream({
+        hasUpstream: false,
+        ahead: 0,
+        behind: 3
+      })
+    ).toBe(false)
+    expect(isBehindOnlyUpstream(undefined)).toBe(false)
   })
 })

--- a/src/shared/git-upstream-status.ts
+++ b/src/shared/git-upstream-status.ts
@@ -46,3 +46,11 @@ export function shouldForcePushWithLeaseForUpstream(
     status.behindCommitsArePatchEquivalent === true
   )
 }
+
+// Why: behind-only is the only auto-prepare case Create PR can safely handle
+// with a pure fast-forward (no local unique commits to reconcile). Eligibility
+// and the intent remote-step resolver must share this predicate so the button
+// and the one-click flow never disagree on what "behind-only" means.
+export function isBehindOnlyUpstream(status: GitUpstreamStatus | undefined): boolean {
+  return status?.hasUpstream === true && status.ahead === 0 && status.behind > 0
+}

--- a/src/shared/source-control-create-review-intent.ts
+++ b/src/shared/source-control-create-review-intent.ts
@@ -1,4 +1,4 @@
-import { shouldForcePushWithLeaseForUpstream } from './git-upstream-status'
+import { isBehindOnlyUpstream, shouldForcePushWithLeaseForUpstream } from './git-upstream-status'
 import type { HostedReviewCreationEligibility } from './hosted-review'
 import { supportsHostedReviewCreation } from './hosted-review-creation-providers'
 import type { GitUpstreamStatus } from './git-status-types'
@@ -72,16 +72,11 @@ export function resolveCreateReviewIntentEligibility({
     return { eligible: true, kind: 'force_push' }
   }
 
-  // Why: a behind-only branch (no local commits) is safe to prepare with a
-  // fast-forward sync, so the intent flow can handle it in one click. A
-  // genuinely diverged branch stays ineligible — syncing it would merge
-  // without consent, so the user keeps the explicit sync-first step.
-  if (
-    hostedReviewCreation.blockedReason === 'needs_sync' &&
-    upstreamStatus?.hasUpstream === true &&
-    upstreamStatus.ahead === 0 &&
-    upstreamStatus.behind > 0
-  ) {
+  // Why: a behind-only branch is safe to prepare with `git pull --ff-only`, so
+  // the intent flow can handle it in one click. A genuinely diverged branch
+  // stays ineligible — auto-merging would reconcile without consent, so the
+  // user keeps the explicit sync-first step.
+  if (hostedReviewCreation.blockedReason === 'needs_sync' && isBehindOnlyUpstream(upstreamStatus)) {
     return { eligible: true, kind: 'needs_sync' }
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #8534. Behind-only Create PR prepare now uses **`git pull --ff-only`** (and runs it **before** commit), so the flow never auto-merges without consent even if the branch diverges mid-flight or the user has a merge-style pull config.

### Why
Adversarial review of #8534 found that routing behind-only through merge-capable `sync` / plain `git pull` only checked “behind-only” at decision time. A TOCTOU race (common with agents committing in worktrees) or `pull.ff=no` could still create and push a merge commit under a “Syncing…” notice.

### Changes
- Resolve behind-only `needs_sync` to remote step **`fast_forward`** (`--ff-only`), not `sync`
- Fast-forward **before** stage/commit so dirty behind-only worktrees don’t become ahead+behind and dead-end after commit
- Shared `isBehindOnlyUpstream()` so eligibility and the intent flow share one predicate
- `runRemoteAction` returns discriminated status: `ok` | `failed` | `superseded` | `skipped` (superseded no longer looks like a remote failure)
- Drop sync-conflict classifier / notice copy (unreachable under `--ff-only`; generic remote-failed + existing toasts cover real failures)
- Keybinding seed: still throw on bad pin so the cohort retries, but write valid pins from the same batch
- Restore `Math.random` spy in `try/finally` in the process-replacement test

## Test plan
- [x] `git-upstream-status` tests (`isBehindOnlyUpstream`)
- [x] Create PR intent remote-step tests (`fast_forward` for behind-only; `blocked` for diverged)
- [x] Primary-action Create PR intent eligibility for behind-only
- [x] Keybinding seed normalization-failure test
- [x] Localization catalog parity
- [ ] Manually: clean behind-only branch → Create PR updates via FF and continues
- [ ] Manually: dirty behind-only branch → FF first, then commit/push/create
- [ ] Manually: diverged branch still blocked with “Sync this branch first”
- [ ] Manually: agent commit during prepare → FF refuses; no unconsented merge on remote