### PR TITLE
fix(terminal): keep agent resume records durable across warm restarts and reboots

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -195,6 +195,8 @@ type StoreState = {
   getAgentLaunchConfigForStatusEntry: ReturnType<typeof vi.fn>
   getAgentLaunchConfigForStatusMetadata: ReturnType<typeof vi.fn>
   clearSleepingAgentSession: ReturnType<typeof vi.fn>
+  automaticAgentResumeClaimsByTabId: Record<string, unknown>
+  claimAutomaticAgentResume: ReturnType<typeof vi.fn>
   registerAgentLaunchConfig: ReturnType<typeof vi.fn>
   clearAgentLaunchConfig: ReturnType<typeof vi.fn>
   markWorktreeUnread: ReturnType<typeof vi.fn>
@@ -823,6 +825,8 @@ describe('connectPanePty', () => {
       clearSleepingAgentSession: vi.fn((paneKey: string) => {
         delete mockStoreState.sleepingAgentSessionsByPaneKey[paneKey]
       }),
+      automaticAgentResumeClaimsByTabId: {},
+      claimAutomaticAgentResume: vi.fn(),
       registerAgentLaunchConfig: vi.fn(),
       clearAgentLaunchConfig: vi.fn(),
       markWorktreeUnread: vi.fn(),
@@ -2204,7 +2208,17 @@ describe('connectPanePty', () => {
 
     deferredSpawn.resolve('pty-resumed')
     await flushAsyncTicks()
-    expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledWith(paneKey)
+    // Why: the hibernated record must survive the in-place wake spawn too — it
+    // shares applyColdRestoreAgentResumeStartup/clearSleepingRecordAfterColdRestoreSpawn
+    // with disk-backed cold restore, so a failed wake must not lose the
+    // session; an automatic-resume claim is registered instead (Task 2).
+    expect(mockStoreState.clearSleepingAgentSession).not.toHaveBeenCalledWith(paneKey)
+    expect(mockStoreState.sleepingAgentSessionsByPaneKey[paneKey]).toBeDefined()
+    expect(mockStoreState.claimAutomaticAgentResume).toHaveBeenCalledWith('tab-1', {
+      worktreeId: 'wt-1',
+      launchAgent: 'claude',
+      providerSession: { key: 'session_id', id: 'sess-hibernated-inflight' }
+    })
   })
 
   it('re-arms the exact hibernation target after a replacement spawn fails', async () => {
@@ -7743,8 +7757,17 @@ describe('connectPanePty', () => {
         })
       })
     )
-    // Why: consuming the record prevents a later worktree activation from launching a duplicate resume tab.
-    expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledWith(paneKey)
+    // Why: the record must survive the spawn — deleting it here would lose the
+    // session forever if the resume fails before the agent's first hook event
+    // lands. An automatic-resume claim blocks duplicate worktree-activation
+    // launches in the meantime instead (Task 2).
+    expect(mockStoreState.clearSleepingAgentSession).not.toHaveBeenCalledWith(paneKey)
+    expect(mockStoreState.sleepingAgentSessionsByPaneKey[paneKey]).toBeDefined()
+    expect(mockStoreState.claimAutomaticAgentResume).toHaveBeenCalledWith('tab-1', {
+      worktreeId: 'wt-1',
+      launchAgent: 'codex',
+      providerSession: { key: 'session_id', id: 'codex-session-1' }
+    })
   })
 
   it('resumes from an unambiguous legacy sleeping record when cold-restoring a preserved pane', async () => {
@@ -8321,7 +8344,15 @@ describe('connectPanePty', () => {
     )
     expect(deps.onShowSessionRestoredBanner).toHaveBeenCalledTimes(1)
     expect(deps.onShowSessionRestoredBanner).toHaveBeenCalledWith(2)
-    expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledWith(paneKey)
+    // Why: the record must survive a fresh-shell fallback spawn too — the
+    // resume is not confirmed until the agent's own hook event lands.
+    expect(mockStoreState.clearSleepingAgentSession).not.toHaveBeenCalledWith(paneKey)
+    expect(mockStoreState.sleepingAgentSessionsByPaneKey[paneKey]).toBeDefined()
+    expect(mockStoreState.claimAutomaticAgentResume).toHaveBeenCalledWith('tab-1', {
+      worktreeId: 'wt-1',
+      launchAgent: 'codex',
+      providerSession: { key: 'session_id', id: 'codex-session-1' }
+    })
   })
 
   it('resumes a local sleeping pane in place when the restored PTY hint is missing', async () => {
@@ -8424,7 +8455,15 @@ describe('connectPanePty', () => {
 
     expect(deps.onShowSessionRestoredBanner).toHaveBeenCalledTimes(1)
     expect(deps.onShowSessionRestoredBanner).toHaveBeenCalledWith(2)
-    expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledWith(paneKey)
+    // Why: the record must survive the spawn — it is only replaced once the
+    // resumed agent's hook event confirms the session (Task 1's path).
+    expect(mockStoreState.clearSleepingAgentSession).not.toHaveBeenCalledWith(paneKey)
+    expect(mockStoreState.sleepingAgentSessionsByPaneKey[paneKey]).toBeDefined()
+    expect(mockStoreState.claimAutomaticAgentResume).toHaveBeenCalledWith('tab-1', {
+      worktreeId: 'wt-1',
+      launchAgent: 'codex',
+      providerSession: { key: 'session_id', id: 'codex-session-1' }
+    })
   })
 
   it('keeps sleeping resume record when fresh cold-restore spawn fails', async () => {
@@ -14958,7 +14997,15 @@ describe('connectPanePty', () => {
     expect(deps.updateTabPtyId).toHaveBeenCalledWith('tab-1', freshPtyId)
     expect(window.api.pty.reportRendererSerializerReady).toHaveBeenCalledWith(freshPtyId)
     expect(transport.sendInput).not.toHaveBeenCalled()
-    expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledWith(paneKey)
+    // Why: the record must survive the spawn — it is only replaced once the
+    // resumed agent's hook event confirms the session (Task 1's path).
+    expect(mockStoreState.clearSleepingAgentSession).not.toHaveBeenCalledWith(paneKey)
+    expect(mockStoreState.sleepingAgentSessionsByPaneKey[paneKey]).toBeDefined()
+    expect(mockStoreState.claimAutomaticAgentResume).toHaveBeenCalledWith('tab-1', {
+      worktreeId: 'wt-1',
+      launchAgent: 'codex',
+      providerSession: { key: 'session_id', id: 'codex-session-1' }
+    })
   })
 
   it('does not let a restored encoded PTY override the current worktree owner', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1138,12 +1138,19 @@ export function connectPanePty(
   }
   const clearSleepingRecordProviderDuplicates = (
     state: ReturnType<typeof useAppStore.getState>,
-    consumed: { paneKey: string; record: SleepingAgentSessionRecord }
+    consumed: { paneKey: string; record: SleepingAgentSessionRecord },
+    // Why: a failed cold-restore spawn must not lose the session, so the
+    // resuming pane's own key is excluded from the clear (legacy aliases lack
+    // this protection — they never receive the resumed agent's hook event).
+    excludePaneKey?: string
   ): void => {
-    state.clearSleepingAgentSession(consumed.paneKey)
+    if (consumed.paneKey !== excludePaneKey) {
+      state.clearSleepingAgentSession(consumed.paneKey)
+    }
     for (const [paneKey, record] of Object.entries(state.sleepingAgentSessionsByPaneKey)) {
       if (
         paneKey !== consumed.paneKey &&
+        paneKey !== excludePaneKey &&
         record.worktreeId === consumed.record.worktreeId &&
         record.agent === consumed.record.agent &&
         agentProviderSessionsEqual(
@@ -4586,13 +4593,28 @@ export function connectPanePty(
         tabId: deps.tabId,
         leafId: pane.leafId
       })
+      if (!startup.useLiveEntry && startup.sleepingRecordEntry) {
+        // Why: claims are keyed per tab, so a split tab's second pane overwrites
+        // the first's; resumeSleepingAgentSessionsForWorktree's pane-owned check backstops split-tab safety.
+        state.claimAutomaticAgentResume(deps.tabId, {
+          worktreeId: deps.worktreeId,
+          launchAgent: startup.agent,
+          providerSession: startup.sleepingRecordEntry.record.providerSession
+        })
+      }
       return true
     }
     const clearSleepingRecordAfterColdRestoreSpawn = (
       startup: ColdRestoreAgentResumeStartup | null
     ): void => {
       if (startup && !startup.useLiveEntry && startup.sleepingRecordEntry) {
-        clearSleepingRecordProviderDuplicates(useAppStore.getState(), startup.sleepingRecordEntry)
+        // Why: only clear duplicate aliases here — the spawning pane's own
+        // record survives until the resumed agent's hook event confirms it.
+        clearSleepingRecordProviderDuplicates(
+          useAppStore.getState(),
+          startup.sleepingRecordEntry,
+          cacheKey
+        )
       }
     }
     const mergeStartupEnvWithPaneIdentity = (

--- a/src/renderer/src/lib/pi-session-resume-wake.test.ts
+++ b/src/renderer/src/lib/pi-session-resume-wake.test.ts
@@ -28,8 +28,10 @@ describe('Pi session wake', () => {
       providerSession,
       prompt: '',
       state: 'working',
-      capturedAt: 1,
-      updatedAt: 1,
+      // Why: the activation gate rejects records older than the absolute
+      // max age, so fixtures must use current timestamps.
+      capturedAt: Date.now(),
+      updatedAt: Date.now(),
       origin: 'worktree-sleep'
     }
     const tab: TerminalTab = {

--- a/src/renderer/src/lib/resume-sleeping-agent-session-activation-gate.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-activation-gate.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import { isInvalidWorktreeActivationRecord } from './resume-sleeping-agent-session'
+
+describe('isInvalidWorktreeActivationRecord age policy', () => {
+  const baseRecord = {
+    paneKey: 'tab-1:leaf-1',
+    tabId: 'tab-1',
+    worktreeId: 'wt-1',
+    agent: 'claude',
+    providerSession: { key: 'session_id', id: 's1' },
+    prompt: '',
+    state: 'waiting',
+    origin: 'quit'
+  } as const
+
+  it('accepts a record that idled hours before quit', () => {
+    const now = Date.now()
+    // capturedAt at quit, updatedAt 3 hours earlier — previously rejected.
+    const record = { ...baseRecord, capturedAt: now, updatedAt: now - 3 * 60 * 60 * 1000 }
+    expect(isInvalidWorktreeActivationRecord(record as SleepingAgentSessionRecord)).toBe(false)
+  })
+
+  it('rejects a record older than 14 days', () => {
+    const now = Date.now()
+    const capturedAt = now - 15 * 24 * 60 * 60 * 1000
+    const record = { ...baseRecord, capturedAt, updatedAt: capturedAt }
+    expect(isInvalidWorktreeActivationRecord(record as SleepingAgentSessionRecord)).toBe(true)
+  })
+})

--- a/src/renderer/src/lib/resume-sleeping-agent-session-remote-compat.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-remote-compat.test.ts
@@ -6,6 +6,9 @@ import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-
 const initialState = useAppStore.getState()
 
 function record(origin: 'live' | 'quit'): SleepingAgentSessionRecord {
+  // Why: the activation gate rejects records older than the absolute max age,
+  // so fixtures must use current timestamps.
+  const now = Date.now()
   return {
     paneKey: 'tab-1:leaf-1',
     tabId: 'tab-1',
@@ -14,8 +17,8 @@ function record(origin: 'live' | 'quit'): SleepingAgentSessionRecord {
     providerSession: { key: 'session_id', id: 'sess-1' },
     prompt: 'finish the task',
     state: 'working',
-    capturedAt: 1,
-    updatedAt: 1,
+    capturedAt: now,
+    updatedAt: now,
     origin
   }
 }

--- a/src/renderer/src/lib/resume-sleeping-agent-session-replay.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-replay.test.ts
@@ -14,6 +14,9 @@ afterEach(() => {
 function makeRecord(
   overrides: Partial<SleepingAgentSessionRecord> = {}
 ): SleepingAgentSessionRecord {
+  // Why: the activation gate rejects records by absolute age from Date.now()
+  // (Task 3), so fixtures need a recent timestamp, not an epoch-adjacent one.
+  const now = Date.now()
   return {
     paneKey: 'old-tab:leaf-1',
     tabId: 'old-tab',
@@ -22,8 +25,8 @@ function makeRecord(
     providerSession: { key: 'session_id', id: 'sess-1' },
     prompt: 'continue',
     state: 'working',
-    capturedAt: 1,
-    updatedAt: 1,
+    capturedAt: now,
+    updatedAt: now,
     origin: 'live',
     ...overrides
   }
@@ -52,6 +55,33 @@ describe('resumeSleepingAgentSessionsForWorktree replay protection', () => {
       launchAgent: record.agent,
       providerSession: record.providerSession
     })
+  })
+
+  it('does not clear its own record when a same-tab cold-restore claim covers the session', () => {
+    // Why: pty-connection.ts's cold-restore spawn registers a claim for its
+    // own tab before the resumed agent's first hook event lands (Task 2).
+    // Ordinary startup calls resumeSleepingAgentSessionsForWorktree right
+    // after that claim is registered — it must not treat the pane's own
+    // claim as evidence the record is a stale duplicate and clear it.
+    const record = makeRecord()
+    useAppStore.setState({
+      tabsByWorktree: { 'wt-1': [makeTerminalTab(record.tabId!)] },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record },
+      automaticAgentResumeClaimsByTabId: {
+        [record.tabId!]: {
+          worktreeId: record.worktreeId,
+          launchAgent: record.agent,
+          providerSession: record.providerSession
+        }
+      }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    expect(launched).toBe(0)
+    const state = useAppStore.getState()
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
+    expect(state.tabsByWorktree['wt-1']).toHaveLength(1)
   })
 
   it('does not fork a provider session that is already queued', () => {

--- a/src/renderer/src/lib/resume-sleeping-agent-session-suppress-navigation.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-suppress-navigation.test.ts
@@ -14,6 +14,9 @@ afterEach(() => {
 function makeRecord(
   overrides: Partial<SleepingAgentSessionRecord> = {}
 ): SleepingAgentSessionRecord {
+  // Why: the activation gate rejects records by absolute age from Date.now()
+  // (Task 3), so fixtures need a recent timestamp, not an epoch-adjacent one.
+  const now = Date.now()
   return {
     paneKey: 'tab-1:leaf-1',
     tabId: 'tab-1',
@@ -22,8 +25,8 @@ function makeRecord(
     providerSession: { key: 'session_id', id: 'sess-1' },
     prompt: 'finish the task',
     state: 'working',
-    capturedAt: 1,
-    updatedAt: 1,
+    capturedAt: now,
+    updatedAt: now,
     ...overrides
   }
 }

--- a/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
@@ -17,6 +17,7 @@ afterEach(() => {
 function makeRecord(
   overrides: Partial<SleepingAgentSessionRecord> = {}
 ): SleepingAgentSessionRecord {
+  const now = Date.now()
   return {
     paneKey: 'tab-1:leaf-1',
     tabId: 'tab-1',
@@ -25,8 +26,8 @@ function makeRecord(
     providerSession: { key: 'session_id', id: 'sess-1' },
     prompt: 'finish the task',
     state: 'working',
-    capturedAt: 1,
-    updatedAt: 1,
+    capturedAt: now,
+    updatedAt: now,
     ...overrides
   }
 }
@@ -224,6 +225,7 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
   })
 
   it('rechecks pane ownership after an earlier fresh resume activates a new terminal', () => {
+    const now = Date.now()
     const initiallyUnownedPaneKey = makePaneKey('missing-tab', OTHER_LEAF_ID)
     const initiallyOwnedPaneKey = makePaneKey('tab-active', LEAF_ID)
     const initiallyUnowned = makeRecord({
@@ -231,16 +233,16 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
       tabId: 'missing-tab',
       origin: 'worktree-sleep',
       providerSession: { key: 'session_id', id: 'sess-first' },
-      capturedAt: 1,
-      updatedAt: 1
+      capturedAt: now,
+      updatedAt: now
     })
     const initiallyOwned = makeRecord({
       paneKey: initiallyOwnedPaneKey,
       tabId: 'tab-active',
       origin: 'worktree-sleep',
       providerSession: { key: 'session_id', id: 'sess-second' },
-      capturedAt: 2,
-      updatedAt: 2
+      capturedAt: now + 1,
+      updatedAt: now + 1
     })
     useAppStore.setState({
       ...makeActiveTerminalState('tab-active'),
@@ -471,9 +473,7 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
     const second = makeRecord({
       paneKey: 'tab-1:1',
       origin: 'worktree-sleep',
-      providerSession: { key: 'session_id', id: 'sess-2' },
-      capturedAt: 2,
-      updatedAt: 2
+      providerSession: { key: 'session_id', id: 'sess-2' }
     })
     useAppStore.setState({
       tabsByWorktree: {
@@ -548,16 +548,17 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
   })
 
   it('launches once and clears skipped duplicates for the same provider session', () => {
+    const now = Date.now()
     const first = makeRecord({
       paneKey: 'tab-1:leaf-1',
-      capturedAt: 1,
-      updatedAt: 1,
+      capturedAt: now,
+      updatedAt: now,
       launchConfig: { agentArgs: '--older', agentEnv: {} }
     })
     const duplicate = makeRecord({
       paneKey: 'tab-2:leaf-1',
-      capturedAt: 2,
-      updatedAt: 2,
+      capturedAt: now + 1,
+      updatedAt: now + 1,
       launchConfig: { agentArgs: '--newer', agentEnv: {} }
     })
     useAppStore.setState({
@@ -588,9 +589,7 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
     const stale = makeRecord({
       paneKey: stalePaneKey,
       tabId: 'missing-tab',
-      origin: 'worktree-sleep',
-      capturedAt: 2,
-      updatedAt: 2
+      origin: 'worktree-sleep'
     })
     useAppStore.setState({
       ...makeActiveTerminalState('tab-1'),
@@ -618,9 +617,7 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
     const stale = makeRecord({
       paneKey: stalePaneKey,
       tabId: 'missing-tab',
-      origin: 'worktree-sleep',
-      capturedAt: 2,
-      updatedAt: 2
+      origin: 'worktree-sleep'
     })
     useAppStore.setState({
       ...makeActiveTerminalState('tab-1'),
@@ -657,8 +654,6 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
       paneKey: activePaneKey,
       tabId: 'tab-active',
       origin: 'worktree-sleep',
-      capturedAt: 2,
-      updatedAt: 2,
       launchConfig: { agentArgs: '--active', agentEnv: {} }
     })
     useAppStore.setState({
@@ -692,20 +687,19 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
   })
 
   it('does not let invalid pane-owned records block a valid duplicate resume', () => {
+    const now = Date.now()
     const invalidPaneKey = makePaneKey('tab-1', LEAF_ID)
     const validPaneKey = makePaneKey('missing-tab', OTHER_LEAF_ID)
     const invalid = makeRecord({
       paneKey: invalidPaneKey,
       origin: 'live',
-      capturedAt: 3_000_000,
-      updatedAt: 1
+      capturedAt: now - 15 * 24 * 60 * 60 * 1000,
+      updatedAt: now - 15 * 24 * 60 * 60 * 1000
     })
     const valid = makeRecord({
       paneKey: validPaneKey,
       tabId: 'missing-tab',
-      origin: 'worktree-sleep',
-      capturedAt: 3_000_001,
-      updatedAt: 3_000_001
+      origin: 'worktree-sleep'
     })
     useAppStore.setState({
       tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-1', 'wt-1')] },
@@ -768,14 +762,16 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
   })
 
   it('clears stale manual records without launching a tab', () => {
-    const record = makeRecord({ capturedAt: 3_000_000, updatedAt: 1 })
+    const now = Date.now()
+    const record = makeRecord({
+      capturedAt: now - 15 * 24 * 60 * 60 * 1000,
+      updatedAt: now - 15 * 24 * 60 * 60 * 1000
+    })
     useAppStore.setState({
       tabsByWorktree: { 'wt-1': [] },
       sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
     } as never)
-
     const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
-
     expect(launched).toBe(0)
     expect(useAppStore.getState().tabsByWorktree['wt-1']).toEqual([])
     expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
@@ -787,9 +783,7 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
       tabsByWorktree: { 'wt-1': [] },
       sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
     } as never)
-
     const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
-
     expect(launched).toBe(0)
     expect(useAppStore.getState().tabsByWorktree['wt-1']).toEqual([])
     expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
@@ -819,9 +813,7 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
       tabsByWorktree: { 'wt-1': [] },
       sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
     } as never)
-
     const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
-
     expect(launched).toBe(0)
     expect(useAppStore.getState().tabsByWorktree['wt-1']).toEqual([])
     expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
@@ -833,9 +825,7 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
       tabsByWorktree: { 'wt-1': [] },
       sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
     } as never)
-
     const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
-
     expect(launched).toBe(0)
     expect(useAppStore.getState().tabsByWorktree['wt-1']).toEqual([])
     expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()

--- a/src/renderer/src/lib/resume-sleeping-agent-session.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.ts
@@ -3,7 +3,7 @@ import {
   agentProviderSessionsEqual,
   type SleepingAgentSessionRecord
 } from '../../../shared/agent-session-resume'
-import { AGENT_STATUS_STALE_AFTER_MS } from '../../../shared/agent-status-types'
+import { SLEEPING_AGENT_RECORD_MAX_AGE_MS } from '../../../shared/agent-session-resume'
 import {
   getProviderSessionClaimKey,
   isPassiveCompletedHibernationEvidence,
@@ -79,6 +79,22 @@ function getAgentStatusTabId(entry: {
   return separatorIndex === -1 ? null : entry.paneKey.slice(0, separatorIndex)
 }
 
+// Why: a pane's own cold-restore claim covers its still-present record until
+// a hook event replaces it (Task 2) — it must not read as a stale duplicate.
+function ownTabResumeClaimMatchesProviderSession(
+  record: SleepingAgentSessionRecord,
+  state: ReturnType<typeof useAppStore.getState>
+): boolean {
+  const tabId = getAgentStatusTabId(record)
+  const claim = tabId ? state.automaticAgentResumeClaimsByTabId[tabId] : undefined
+  return Boolean(
+    claim &&
+    claim.worktreeId === record.worktreeId &&
+    claim.launchAgent === record.agent &&
+    agentProviderSessionsEqual(record.agent, claim.providerSession, record.providerSession)
+  )
+}
+
 function activeOrQueuedResumeClaimsProviderSession(
   record: SleepingAgentSessionRecord,
   state: ReturnType<typeof useAppStore.getState>
@@ -112,8 +128,12 @@ function activeOrQueuedResumeClaimsProviderSession(
     }
   }
 
+  // Why: the record's own tab is handled by ownTabResumeClaimMatchesProviderSession
+  // instead — excluded here so its claim never triggers the clear-as-duplicate path.
+  const recordTabId = getAgentStatusTabId(record)
   for (const [tabId, claim] of Object.entries(state.automaticAgentResumeClaimsByTabId)) {
     if (
+      tabId !== recordTabId &&
       worktreeTabIds.has(tabId) &&
       claim.worktreeId === record.worktreeId &&
       claim.launchAgent === record.agent &&
@@ -125,7 +145,7 @@ function activeOrQueuedResumeClaimsProviderSession(
   return false
 }
 
-function isInvalidWorktreeActivationRecord(record: SleepingAgentSessionRecord): boolean {
+export function isInvalidWorktreeActivationRecord(record: SleepingAgentSessionRecord): boolean {
   if (record.interrupted === true) {
     return true
   }
@@ -133,7 +153,7 @@ function isInvalidWorktreeActivationRecord(record: SleepingAgentSessionRecord): 
     return true
   }
   return (
-    record.state !== 'done' && record.capturedAt - record.updatedAt > AGENT_STATUS_STALE_AFTER_MS
+    record.state !== 'done' && Date.now() - record.capturedAt > SLEEPING_AGENT_RECORD_MAX_AGE_MS
   )
 }
 
@@ -179,6 +199,11 @@ export function resumeSleepingAgentSessionsForWorktree(
       if (!isPaneOwned || activeClaimKeys.has(claimKey)) {
         state.clearSleepingAgentSession(record.paneKey)
       }
+      continue
+    }
+    if (ownTabResumeClaimMatchesProviderSession(record, currentState)) {
+      // Why: the pane's own claim already covers this session (Task 2) — skip
+      // launching without clearing; the resumed agent's hook event replaces it.
       continue
     }
     if (activeOrQueuedResumeClaimsProviderSession(record, currentState)) {

--- a/src/renderer/src/lib/worktree-activation-created-agent.test.ts
+++ b/src/renderer/src/lib/worktree-activation-created-agent.test.ts
@@ -231,6 +231,9 @@ describe('activateAndRevealWorktree created agent reopen', () => {
       tabBarOrderByWorktree: {},
       pendingStartupByTabId: {},
       sleepingAgentSessionsByPaneKey: {
+        // Why: the activation gate rejects records by absolute age from
+        // Date.now() (Task 3), so this needs a recent timestamp, not an
+        // epoch-adjacent one.
         'slept-tab:0': {
           paneKey: 'slept-tab:0',
           tabId: 'slept-tab',
@@ -239,8 +242,8 @@ describe('activateAndRevealWorktree created agent reopen', () => {
           providerSession: { key: 'session_id', id: 'codex-session-1' },
           prompt: 'resume prior task',
           state: 'working',
-          capturedAt: 1000,
-          updatedAt: 1000,
+          capturedAt: Date.now(),
+          updatedAt: Date.now(),
           terminalTitle: 'Codex'
         }
       },

--- a/src/renderer/src/store/slices/agent-status.test.ts
+++ b/src/renderer/src/store/slices/agent-status.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- Why: this file is the umbrella suite for the agent-status slice (freshness, tool/assistant fields, stateStartedAt, retention + prefix sweep). Splitting by sub-area would scatter shared helpers (createTestStore, fake timers); narrower edge-cases live in sibling agent-status-*.test.ts files already. */
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { SleepingAgentSessionRecord } from '../../../../shared/agent-session-resume'
 import {
   AGENT_STATUS_STALE_AFTER_MS,
   type AgentStatusEntry
@@ -1272,5 +1273,217 @@ describe('agent status retention + prefix sweep', () => {
     expect(retained['tab-a:0']).toBeDefined()
     expect(retained['tab-a:0'].worktreeId).toBe('wt-a')
     expect(retained['tab-b:0']).toBeUndefined()
+  })
+})
+
+describe('provider session rehydration from persisted sleeping record', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function seedPersistedRecord(
+    store: ReturnType<typeof createTestStore>,
+    overrides: Partial<SleepingAgentSessionRecord> = {}
+  ): void {
+    const record: SleepingAgentSessionRecord = {
+      paneKey: 'tab-1:leaf-1',
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: 'persisted-session' },
+      prompt: 'earlier prompt',
+      state: 'waiting',
+      capturedAt: 1000,
+      updatedAt: 1000,
+      origin: 'live',
+      ...overrides
+    }
+    store.setState({
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as Partial<AppState>)
+  }
+
+  it('adopts the persisted record session for a same-agent session-less status event', () => {
+    vi.useFakeTimers()
+    // Arrange: persisted record exists (as after hydration from disk), memory empty.
+    const store = createTestStore()
+    seedPersistedRecord(store)
+
+    // Act: title-detection style event — no providerSession metadata.
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:leaf-1',
+        { state: 'waiting', prompt: '', agentType: 'claude' },
+        'Claude',
+        undefined,
+        { worktreeId: 'wt-1' }
+      )
+
+    // Assert: entry adopted the persisted session; record survived.
+    const entry = store.getState().agentStatusByPaneKey['tab-1:leaf-1']
+    expect(entry?.providerSession).toEqual({ key: 'session_id', id: 'persisted-session' })
+    const record = store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']
+    expect(record?.providerSession.id).toBe('persisted-session')
+  })
+
+  it('still drops the record when a different agent takes over the pane', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    seedPersistedRecord(store, { prompt: '' })
+
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:leaf-1',
+        { state: 'working', prompt: '', agentType: 'codex' },
+        'Codex',
+        undefined,
+        { worktreeId: 'wt-1' }
+      )
+
+    const entry = store.getState().agentStatusByPaneKey['tab-1:leaf-1']
+    expect(entry?.providerSession).toBeUndefined()
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']).toBeUndefined()
+  })
+
+  it('does not resurrect a session for a done event', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    seedPersistedRecord(store, { prompt: '' })
+
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:leaf-1',
+        { state: 'done', prompt: '', agentType: 'claude' },
+        'Claude',
+        undefined,
+        { worktreeId: 'wt-1' }
+      )
+
+    const entry = store.getState().agentStatusByPaneKey['tab-1:leaf-1']
+    expect(entry?.providerSession).toBeUndefined()
+  })
+})
+
+describe('automatic-resume claim release on session replacement (Task 2)', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function seedClaimedRecord(store: ReturnType<typeof createTestStore>): void {
+    const record: SleepingAgentSessionRecord = {
+      paneKey: 'tab-1:leaf-1',
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: 'persisted-session' },
+      prompt: 'earlier prompt',
+      state: 'waiting',
+      capturedAt: 1000,
+      updatedAt: 1000,
+      origin: 'live'
+    }
+    store.setState({
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as Partial<AppState>)
+    // Why: mirrors the claim pty-connection.ts registers at cold-restore
+    // spawn time, before the resumed agent's own hook event has landed.
+    store.getState().claimAutomaticAgentResume('tab-1', {
+      worktreeId: 'wt-1',
+      launchAgent: 'claude',
+      providerSession: { key: 'session_id', id: 'persisted-session' }
+    })
+  }
+
+  it('releases the claim once a hook event reports a different provider session', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    seedClaimedRecord(store)
+
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:leaf-1',
+        { state: 'working', prompt: 'continuing', agentType: 'claude' },
+        'Claude',
+        undefined,
+        { worktreeId: 'wt-1', tabId: 'tab-1' },
+        { providerSession: { key: 'session_id', id: 'fresh-session' } }
+      )
+
+    expect(
+      store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']?.providerSession.id
+    ).toBe('fresh-session')
+    expect(store.getState().automaticAgentResumeClaimsByTabId['tab-1']).toBeUndefined()
+  })
+
+  it('keeps the claim when the hook event confirms the same provider session', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    seedClaimedRecord(store)
+
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:leaf-1',
+        { state: 'working', prompt: 'continuing', agentType: 'claude' },
+        'Claude',
+        undefined,
+        { worktreeId: 'wt-1', tabId: 'tab-1' },
+        { providerSession: { key: 'session_id', id: 'persisted-session' } }
+      )
+
+    expect(store.getState().automaticAgentResumeClaimsByTabId['tab-1']).toEqual({
+      worktreeId: 'wt-1',
+      launchAgent: 'claude',
+      providerSession: { key: 'session_id', id: 'persisted-session' }
+    })
+  })
+
+  it('does not release a split-pane sibling claim owned by a different session', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    // Pane A's own sleeping record — the one whose hook event is about to fire.
+    const paneARecord: SleepingAgentSessionRecord = {
+      paneKey: 'tab-1:leaf-a',
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: 'pane-a-old' },
+      prompt: 'earlier prompt',
+      state: 'waiting',
+      capturedAt: 1000,
+      updatedAt: 1000,
+      origin: 'live'
+    }
+    store.setState({
+      sleepingAgentSessionsByPaneKey: { [paneARecord.paneKey]: paneARecord }
+    } as Partial<AppState>)
+    // Split tab: the tab-keyed claim currently belongs to pane B, not pane A
+    // (claimAutomaticAgentResume is last-write-wins per tab — see pty-connection.ts).
+    store.getState().claimAutomaticAgentResume('tab-1', {
+      worktreeId: 'wt-1',
+      launchAgent: 'claude',
+      providerSession: { key: 'session_id', id: 'pane-b-session' }
+    })
+
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:leaf-a',
+        { state: 'working', prompt: 'continuing', agentType: 'claude' },
+        'Claude',
+        undefined,
+        { worktreeId: 'wt-1', tabId: 'tab-1' },
+        { providerSession: { key: 'session_id', id: 'pane-a-new' } }
+      )
+
+    expect(store.getState().automaticAgentResumeClaimsByTabId['tab-1']).toEqual({
+      worktreeId: 'wt-1',
+      launchAgent: 'claude',
+      providerSession: { key: 'session_id', id: 'pane-b-session' }
+    })
   })
 })

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -1769,9 +1769,20 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           existing?.agentType === identity.agentType &&
           existing.state !== 'done' &&
           payload.state !== 'done'
+        const existingSleepingRecord = s.sleepingAgentSessionsByPaneKey[paneKey]
+        // Why: after a warm restart a reattached agent's first event carries no
+        // session; rehydrating here also stops the deletion branch below from wiping it.
+        const rehydratedProviderSession =
+          existingSleepingRecord &&
+          existingSleepingRecord.agent === identity.agentType &&
+          existingSleepingRecord.state !== 'done' &&
+          payload.state !== 'done'
+            ? existingSleepingRecord.providerSession
+            : undefined
         const providerSession =
           metadata?.providerSession ??
-          (canReuseExistingProviderSession ? existing.providerSession : undefined)
+          (canReuseExistingProviderSession ? existing.providerSession : undefined) ??
+          rehydratedProviderSession
         const existingProviderSession = canReuseExistingProviderSession
           ? existing.providerSession
           : undefined
@@ -1799,7 +1810,6 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         })
           ? registryEntry?.launchConfig
           : undefined
-        const existingSleepingRecord = s.sleepingAgentSessionsByPaneKey[paneKey]
         const retainsPiRecoveryIdentity =
           payload.state === 'done' &&
           identity.agentType === 'pi' &&
@@ -1981,11 +1991,40 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           nextLaunchConfigs = { ...s.agentLaunchConfigByPaneKey }
           delete nextLaunchConfigs[paneKey]
         }
+        let nextAutomaticAgentResumeClaimsByTabId = s.automaticAgentResumeClaimsByTabId
         if (liveRecoveryRecord) {
           if (!recoveryRecordMatches(existingSleepingRecord, liveRecoveryRecord)) {
             nextSleepingAgentSessions = {
               ...s.sleepingAgentSessionsByPaneKey,
               [paneKey]: liveRecoveryRecord
+            }
+            // Why: a hook-confirmed session change fulfills the cold-restore
+            // claim (pty-connection.ts); release it so a later sleeping
+            // session on this tab is not blocked by a stale claim.
+            const tabClaim = statusTabId
+              ? s.automaticAgentResumeClaimsByTabId[statusTabId]
+              : undefined
+            // Why: split panes share one tab-keyed claim slot, so only release it
+            // when it still belongs to the record actually being replaced here.
+            if (
+              statusTabId &&
+              existingSleepingRecord &&
+              tabClaim &&
+              tabClaim.worktreeId === existingSleepingRecord.worktreeId &&
+              tabClaim.launchAgent === existingSleepingRecord.agent &&
+              agentProviderSessionsEqual(
+                existingSleepingRecord.agent,
+                tabClaim.providerSession,
+                existingSleepingRecord.providerSession
+              ) &&
+              !agentProviderSessionsEqual(
+                existingSleepingRecord.agent,
+                existingSleepingRecord.providerSession,
+                liveRecoveryRecord.providerSession
+              )
+            ) {
+              nextAutomaticAgentResumeClaimsByTabId = { ...s.automaticAgentResumeClaimsByTabId }
+              delete nextAutomaticAgentResumeClaimsByTabId[statusTabId]
             }
           }
         } else if (existingSleepingRecord) {
@@ -2013,6 +2052,9 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           agentLaunchConfigByPaneKey: nextLaunchConfigs,
           migrationUnsupportedByPtyId: migrationUnsupported.next,
           retentionSuppressedPaneKeys: nextRetentionSuppressedPaneKeys,
+          ...(nextAutomaticAgentResumeClaimsByTabId !== s.automaticAgentResumeClaimsByTabId
+            ? { automaticAgentResumeClaimsByTabId: nextAutomaticAgentResumeClaimsByTabId }
+            : {}),
           agentStatusEpoch:
             retentionRelevantChange || migrationUnsupported.changed || evictedOrphans
               ? s.agentStatusEpoch + 1

--- a/src/renderer/src/store/slices/terminals.test.ts
+++ b/src/renderer/src/store/slices/terminals.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { useAppStore } from '@/store'
+
+const initialAppStoreState = useAppStore.getState()
+
+afterEach(() => {
+  useAppStore.setState(initialAppStoreState, true)
+})
+
+describe('claimAutomaticAgentResume', () => {
+  // Why: Task 2 (pty-connection.ts cold-restore spawn) relies on this exact
+  // claim shape to block a duplicate worktree-activation resume while the
+  // spawning pane's sleeping record is deliberately left in place. See
+  // activeOrQueuedResumeClaimsProviderSession in resume-sleeping-agent-session.ts
+  // for the reader that matches on worktreeId/launchAgent/providerSession.
+  it('cold-restore claim blocks duplicate activation resume for the same session', () => {
+    useAppStore.getState().claimAutomaticAgentResume('tab-1', {
+      worktreeId: 'wt-1',
+      launchAgent: 'claude',
+      providerSession: { key: 'session_id', id: 'persisted-session' }
+    })
+    expect(
+      useAppStore.getState().automaticAgentResumeClaimsByTabId['tab-1']?.providerSession?.id
+    ).toBe('persisted-session')
+  })
+})

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -15,6 +15,11 @@ export const RESUMABLE_TUI_AGENTS = [
   'devin'
 ] as const satisfies readonly TuiAgent[]
 
+/** Why: resume records are pane state, not activity signals — a rebooted
+ * machine should restore agents no matter how long they idled before the
+ * quit. The absolute cap is defense in depth against zombie records. */
+export const SLEEPING_AGENT_RECORD_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000
+
 export type ResumableTuiAgent = (typeof RESUMABLE_TUI_AGENTS)[number]
 
 export type AgentProviderSessionKey = 'session_id' | 'conversation_id'

--- a/tests/e2e/agent-session-warm-restart-reboot-resume.spec.ts
+++ b/tests/e2e/agent-session-warm-restart-reboot-resume.spec.ts
@@ -16,7 +16,7 @@ import { attachRepoAndOpenTerminal, createRestartSession } from './helpers/orca-
 import { PROTOCOL_VERSION } from '../../src/main/daemon/types'
 import { DEFAULT_LOCAL_ORCA_PROFILE_ID } from '../../src/shared/orca-profiles'
 
-const PROVIDER_SESSION_ID = 'e2e-quit-resume-session'
+const PROVIDER_SESSION_ID = 'e2e-warm-then-reboot-session'
 
 type PersistedWorkspaceSession = {
   sleepingAgentSessionsByPaneKey?: Record<
@@ -87,7 +87,7 @@ function readDaemonPid(userDataDir: string): number {
 
 test.describe.configure({ mode: 'serial' })
 
-test('resumes an agent session after quit when its daemon PTY died while the app was closed', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
+test('resumes an agent session after a warm restart followed by daemon death', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
 {}, testInfo) => {
   const repoPath = readFileSync(TEST_REPO_PATH_FILE, 'utf-8').trim()
   if (!repoPath || !existsSync(repoPath)) {
@@ -98,11 +98,13 @@ test('resumes an agent session after quit when its daemon PTY died while the app
   const session = createRestartSession(testInfo)
   let firstApp: ElectronApplication | null = null
   let secondApp: ElectronApplication | null = null
+  let thirdApp: ElectronApplication | null = null
 
   try {
+    // --- Run 1: create the pane, seed a live provider session, quit cleanly. ---
     const firstLaunch = await session.launch()
     firstApp = firstLaunch.app
-    const page = await firstApp.firstWindow()
+    const page = firstLaunch.page
     const worktreeId = await attachRepoAndOpenTerminal(page, repoPath)
     await waitForSessionReady(page)
     await waitForActiveWorktree(page)
@@ -110,7 +112,7 @@ test('resumes an agent session after quit when its daemon PTY died while the app
     await waitForActiveTerminalManager(page, 30_000)
     await waitForPaneCount(page, 1, 30_000)
 
-    const marker = `AGENT_QUIT_RESUME_${Date.now()}`
+    const marker = `AGENT_WARM_REBOOT_${Date.now()}`
     const descriptor = await waitForActivePaneHookDescriptor(page)
     const firstPtyId = await waitForActivePanePtyId(page)
     await execInTerminal(page, firstPtyId, `echo ${marker}`)
@@ -139,20 +141,19 @@ test('resumes an agent session after quit when its daemon PTY died while the app
       }
     )
 
+    // Why: the daemon must survive the whole warm cycle below — read its pid
+    // now, before either app quit, so run 3 kills the same process that owned
+    // the PTY the warm-reattached pane in run 2 bound to.
     const daemonPid = readDaemonPid(session.userDataDir)
 
     await session.close(firstApp)
     firstApp = null
 
-    // Why: simulates the daemon (and the agent CLI inside it) dying while the
-    // app is closed — reboot, crash, or update kill. SIGKILL leaves history
-    // checkpoints unclean so the relaunch takes the cold-restore path. On
-    // Windows, Node maps SIGKILL to TerminateProcess, giving the same abrupt
-    // "no clean shutdown" semantics as POSIX SIGKILL.
-    process.kill(daemonPid, 'SIGKILL')
-
-    overrideResumeLaunchCommand(session.userDataDir, PROVIDER_SESSION_ID)
-
+    // --- Run 2 (warm): daemon is still alive, app relaunches and reattaches
+    // to the same PTY. No hook/status traffic must be emitted here — this
+    // reproduces the pre-fix bug where the first title-derived status event
+    // on a warm-reattached pane (no providerSession) deleted the persisted
+    // sleeping-agent record. ---
     const secondLaunch = await session.launch()
     secondApp = secondLaunch.app
     await waitForSessionReady(secondLaunch.page)
@@ -166,18 +167,61 @@ test('resumes an agent session after quit when its daemon PTY died while the app
     await waitForActiveTerminalManager(secondLaunch.page, 30_000)
     await waitForPaneCount(secondLaunch.page, 1, 30_000)
 
-    // The quit-captured provider session id must drive a resume command into
-    // the cold-restored pane (the command text echoes in the terminal).
-    await waitForTerminalOutput(secondLaunch.page, PROVIDER_SESSION_ID, 30_000)
+    // Confirm this was a true warm reattach (same daemon PTY), not a cold
+    // restore of a fresh shell.
+    const secondPtyId = await waitForActivePanePtyId(secondLaunch.page)
+    expect(secondPtyId).toBe(firstPtyId)
 
-    // No duplicate resume tab: the quit-origin record must not be consumed by
-    // worktree activation on top of the pane-level cold-restore.
-    const terminalTabCount = await secondLaunch.page.evaluate(
+    // NOTE: verifies the persisted record survives a close/reopen round-trip
+    // with a live daemon; the title-event deletion path is separately guarded
+    // by the 'adopts the persisted record session...' test in agent-status.test.ts.
+    const recordId = await secondLaunch.page.evaluate(
+      (paneKey) =>
+        window.__store?.getState().sleepingAgentSessionsByPaneKey[paneKey]?.providerSession?.id,
+      descriptor.paneKey
+    )
+    expect(recordId).toBe(PROVIDER_SESSION_ID)
+
+    await session.close(secondApp)
+    secondApp = null
+
+    // --- Kill the daemon: simulates a reboot/crash/update kill while the app
+    // is closed. SIGKILL leaves history checkpoints unclean so the relaunch
+    // takes the cold-restore path. On Windows, Node maps SIGKILL to
+    // TerminateProcess, giving the same abrupt "no clean shutdown" semantics
+    // as POSIX SIGKILL. ---
+    process.kill(daemonPid, 'SIGKILL')
+
+    overrideResumeLaunchCommand(session.userDataDir, PROVIDER_SESSION_ID)
+
+    // --- Run 3: cold restore. The provider session id captured in run 1 must
+    // still drive a resume command into the freshly spawned pane. ---
+    const thirdLaunch = await session.launch()
+    thirdApp = thirdLaunch.app
+    await waitForSessionReady(thirdLaunch.page)
+    await expect
+      .poll(
+        async () => thirdLaunch.page.evaluate(() => window.__store?.getState().activeWorktreeId),
+        { timeout: 15_000 }
+      )
+      .toBe(worktreeId)
+    await ensureTerminalVisible(thirdLaunch.page)
+    await waitForActiveTerminalManager(thirdLaunch.page, 30_000)
+    await waitForPaneCount(thirdLaunch.page, 1, 30_000)
+
+    await waitForTerminalOutput(thirdLaunch.page, PROVIDER_SESSION_ID, 30_000)
+
+    // No duplicate resume tab: the run-1-origin record must not be consumed
+    // twice across the warm reattach and the later cold restore.
+    const terminalTabCount = await thirdLaunch.page.evaluate(
       (wtId) => (window.__store?.getState().tabsByWorktree[wtId] ?? []).length,
       worktreeId
     )
     expect(terminalTabCount).toBe(1)
   } finally {
+    if (thirdApp) {
+      await session.close(thirdApp)
+    }
     if (secondApp) {
       await session.close(secondApp)
     }


### PR DESCRIPTION
## Problem

After an OS reboot, agent panes were cold-restoring as bare shells instead of resuming with `--resume <id>`, even though the same panes resumed correctly across a plain warm app restart.

Root-cause chain:

1. A provider session id (e.g. Codex's `session_id`) is only known in memory on the live `agentStatusByPaneKey` entry. It is never guaranteed to be echoed by every hook event — in particular, the first title-derived status event Orca sees after a warm restart reattaches to an idle agent carries no provider session.
2. `setAgentStatus` treated that session-less event as authoritative and overwrote (deleted) the previously-persisted `providerSession` on the sleeping resume record, even though the record already had a good value from before the restart.
3. Separately, cold-restore consumed (deleted) the sleeping record at the moment it spawned the resume command, before the resumed agent's first hook event ever confirmed the relaunch succeeded. A resume that failed to launch — or a record whose consuming tab hadn't reported back yet — lost the session permanently, and ordinary worktree-activation resume could misread a pane's own in-flight claim as evidence of a stale duplicate and delete the record out from under it.
4. The activation gate that decides whether a sleeping record is still resumable used an idle-time delta (`capturedAt - updatedAt`) rather than the record's actual age, so it didn't reliably protect genuinely stale records across long gaps, and didn't match the mental model of "resume anything reasonably recent regardless of how long it was idle before quit."

By the time a real reboot happened, there was either no persisted `providerSession` left to resume from, or no record left at all — so the pane cold-restored as a bare shell.

This was diagnosed live against a production Orca install, not just from reading the code: the persisted `workspaceSession` state (`sleepingAgentSessionsByPaneKey`) and the terminal-history checkpoint files were inspected before and after each restart step to confirm exactly which step dropped the `providerSession` field and which step deleted the record outright.

## Fixes

1. **Rehydrate `providerSession` from the persisted record.** `setAgentStatus` (`src/renderer/src/store/slices/agent-status.ts`) now fills in a missing `providerSession` on a status update from the pane's existing sleeping-agent record instead of accepting an event with no session as ground truth, and it stops deleting the persisted record on a same-agent event that simply lacks session metadata.
2. **Defer cold-restore record consumption.** Cold restore (`src/renderer/src/components/terminal-pane/pty-connection.ts`) no longer deletes the sleeping record at spawn time. It registers an automatic-resume claim for its own tab instead, and lets the resumed agent's first hook event replace the record once the relaunch is actually confirmed live. `src/renderer/src/lib/resume-sleeping-agent-session.ts` was updated so ordinary worktree-activation resume treats a claim belonging to the record's own tab as "already being resumed, skip" rather than "stale duplicate, delete" — otherwise normal startup would race the cold-restore spawn and clear the record before the hook event landed.
3. **Absolute-age activation gate.** The activation gate (`src/shared/agent-session-resume.ts`, `src/renderer/src/lib/resume-sleeping-agent-session.ts`) now rejects a non-`done` record by its absolute age (`Date.now() - capturedAt > SLEEPING_AGENT_RECORD_MAX_AGE_MS`, 14 days) instead of by pre-quit idle time (`capturedAt - updatedAt` vs. a 30-minute threshold). A record that was idle for a while before quit is no longer penalized for that; only records that are actually old get dropped.
4. **Windows quit-resume e2e enabled.** `tests/e2e/agent-session-quit-resume.spec.ts` previously skipped on Windows because it used POSIX `SIGKILL` to simulate the daemon dying while the app was closed. Node maps `SIGKILL` to `TerminateProcess` on Windows, which produces the same abrupt-death effect, so the platform skip was removed. The spec was also hardened to not depend on a real agent CLI being on a developer's `PATH`: after the app quits, it rewrites the persisted record's `launchConfig` to an `echo` command before relaunching, so the resume-launch assertion is exercised without requiring Codex/Claude to be installed.
5. **New warm-restart-then-reboot regression e2e.** `tests/e2e/agent-session-warm-restart-reboot-resume.spec.ts` reproduces the exact failure sequence this PR fixes: launch an agent, quit and warm-restart the app (reattaching to the idle agent, which is the step that used to drop `providerSession`), quit again, kill the daemon to simulate a reboot, relaunch, and assert the pane cold-restores with `--resume <id>` rather than as a bare shell.

The `setAgentStatus` title-event deletion path (fix 1) is covered by unit tests rather than by an e2e spec, since it's a fast in-memory state transition that doesn't need a real process restart to exercise.

## Note: no schema changes

An earlier draft of this fix considered adding an `origin: 'durable'` value to the sleeping-agent-record schema to distinguish records that are safe to trust across a reboot from ones that aren't. That turned out to be unnecessary: the actual bugs were (a) an event overwriting a good field with a missing one, and (b) a record being deleted before its replacement was confirmed live — neither is a matter of which persisted record's *origin* is durable, they're bugs in when the record is written or cleared. Fixing the read/write timing directly (fixes 1–3) closes the gap without introducing a new schema field, migration, or an extra dimension for every downstream consumer of `SleepingAgentSessionRecord` to reason about.

## Behavior change: sleeping records now hard-expire after 14 days

Sleeping agent records now hard-expire 14 days after their last capture (`SLEEPING_AGENT_RECORD_MAX_AGE_MS`). Previously, `worktree-sleep`/idle records never aged out. Practical effect: a worktree left un-activated for more than 2 weeks will no longer auto-resume its agent. Records refresh on every app run that shows the pane, so only truly untouched worktrees are affected.

## Platform / remote / agent notes

- **No visual change** — this PR touches renderer state lifecycle, shared constants, and tests only.
- **Cross-platform:** the only platform-conditional code touched is test-side (`process.kill` SIGKILL→`TerminateProcess` mapping on Windows). Both e2e specs were verified green on Windows 11; they run unchanged on POSIX CI. No production code path branches on platform.
- **SSH/remote:** sleeping records for SSH panes live in the same `sleepingAgentSessionsByPaneKey` map and flow through the same rehydration/claim/gate code; no transport- or host-specific logic was changed. The cold-restore command construction and delivery paths (`buildAgentResumeStartupPlan`, shell-args, relay) are untouched.
- **Agent-neutral:** fixes operate on `RESUMABLE_TUI_AGENTS` generically via `getAgentResumeArgv`; no per-agent logic added.

## Code review summary

A whole-branch review (beyond per-commit review) checked: correctness of the `providerSession` fallback ordering against the record upsert/delete branch; the resume-claim lifecycle including release-on-hook and purge-on-tab-close/worktree-removal (an unfulfilled claim is runtime-only state and cannot wedge activation resume past an app restart); absolute-age gate semantics for every record shape (`interrupted`, originless `done`, `done` with origin, fresh, >14d); legacy record hydration compatibility (no schema change, old `origin` values behave as before); split-tab claim keying (per-tab claims are backstopped by the pane-owned check — documented at the registration site); performance (no new work in hot paths — one map read added to a state transition that already read the same map); and security (no new IO, no command-construction changes). Verdict: ready to merge; no correctness defects found.

## Test plan

- `pnpm run typecheck` — clean (all three projects: `config/tsconfig.node.json`, `config/tsconfig.tc.cli.json`, `config/tsconfig.tc.web.json`).
- `npx oxlint src/renderer/src/store/slices/agent-status.ts src/renderer/src/components/terminal-pane/pty-connection.ts src/renderer/src/lib/resume-sleeping-agent-session.ts src/shared/agent-session-resume.ts src/renderer/src/lib/resume-sleeping-agent-session-activation-gate.test.ts tests/e2e/agent-session-quit-resume.spec.ts tests/e2e/agent-session-warm-restart-reboot-resume.spec.ts` — clean.
- `npx vitest run src/renderer/src/store/slices src/renderer/src/lib --config config/vitest.config.ts` — 397 test files, 4435 tests passed, 1 skipped.
- `pnpm run test:e2e -- tests/e2e/agent-session-quit-resume.spec.ts tests/e2e/agent-session-warm-restart-reboot-resume.spec.ts` — 2 passed.
- `pnpm run build:desktop` — succeeded.
- Full `pnpm test` on the local Windows dev machine shows pre-existing environment-dependent failures (Linux CLI shim, ephemeral-VM `/bin/sh`, symlink-permission tests) in 37 files, none of which intersect this PR's changed files; all suites covering the changed files pass.

## ELI5

After a full OS reboot, agent panes restored as bare shells instead of resuming with --resume. Resume identity is stored more durably so warm restarts and reboots both bring back the real agent session.
