### PR TITLE
fix(terminal): preserve macOS IME Enter submission

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-ime-composition-tracker.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-composition-tracker.test.ts
@@ -19,10 +19,13 @@ type TrackerHarness = {
   blur: () => void
 }
 
-function installTracker(): TrackerHarness {
+function installTracker(options?: { isMac?: boolean }): TrackerHarness {
   let now = 0
   const element = document.createElement('div')
-  const tracker = installTerminalImeCompositionTracker(element, { now: () => now })
+  const tracker = installTerminalImeCompositionTracker(element, {
+    isMac: options?.isMac,
+    now: () => now
+  })
   return {
     tracker,
     element,
@@ -86,6 +89,54 @@ describe('installTerminalImeCompositionTracker', () => {
     harness.blur()
     expect(harness.tracker.isActive()).toBe(false)
     expect(harness.tracker.isCandidateKeyGuardActive()).toBe(false)
+  })
+
+  it('clears stale macOS composition state immediately on plain Enter', () => {
+    const harness = installTracker({ isMac: true })
+    harness.composition('compositionstart', '')
+    const enter = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+    Object.defineProperty(enter, 'keyCode', { value: 13 })
+
+    harness.element.dispatchEvent(enter)
+
+    expect(harness.tracker.isActive()).toBe(false)
+    expect(harness.tracker.isCandidateKeyGuardActive()).toBe(false)
+  })
+
+  it('keeps Process/229 and modified Enter owned by the active macOS IME', () => {
+    for (const event of [
+      { keyCode: 0 },
+      { keyCode: 229 },
+      { keyCode: 13, shiftKey: true },
+      { keyCode: 13, ctrlKey: true },
+      { keyCode: 13, altKey: true },
+      { keyCode: 13, metaKey: true }
+    ]) {
+      const harness = installTracker({ isMac: true })
+      harness.composition('compositionstart', '')
+      const enter = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true,
+        ...event
+      })
+      Object.defineProperty(enter, 'keyCode', { value: event.keyCode })
+
+      harness.element.dispatchEvent(enter)
+
+      expect(harness.tracker.isActive()).toBe(true)
+      harness.tracker.dispose()
+    }
+  })
+
+  it('does not clear a non-macOS composition on plain Enter', () => {
+    const harness = installTracker()
+    harness.composition('compositionstart', '')
+    const enter = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+    Object.defineProperty(enter, 'keyCode', { value: 13 })
+
+    harness.element.dispatchEvent(enter)
+
+    expect(harness.tracker.isActive()).toBe(true)
   })
 
   describe('candidate key guard', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-ime-composition-tracker.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-composition-tracker.ts
@@ -19,7 +19,7 @@ export const TERMINAL_IME_CANDIDATE_GUARD_POST_COMPOSITION_MS = 250
 
 export function installTerminalImeCompositionTracker(
   terminalElement: HTMLElement | null | undefined,
-  options?: { now?: () => number }
+  options?: { isMac?: boolean; now?: () => number }
 ): TerminalImeCompositionTracker {
   const now = options?.now ?? ((): number => Date.now())
   let active = false
@@ -94,12 +94,28 @@ export function installTerminalImeCompositionTracker(
     compositionEndedAt = null
     sawEmptyCompositionUpdate = false
   }
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    // Why: xterm finalizes macOS composition on plain Enter even when Chromium
+    // misses compositionend; release Orca's guard with the same exact event.
+    if (
+      options?.isMac &&
+      event.key === 'Enter' &&
+      event.keyCode === 13 &&
+      !event.metaKey &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      !event.shiftKey
+    ) {
+      markInactive()
+    }
+  }
 
   terminalElement.addEventListener('compositionstart', markActive, true)
   terminalElement.addEventListener('compositionupdate', updateComposition, true)
   terminalElement.addEventListener('compositionend', handleCompositionEnd, true)
   terminalElement.addEventListener('input', handleInput, true)
   terminalElement.addEventListener('blur', markInactive, true)
+  terminalElement.addEventListener('keydown', handleKeyDown, true)
 
   return {
     isActive: () => isActiveAt(now()),
@@ -110,6 +126,7 @@ export function installTerminalImeCompositionTracker(
       terminalElement.removeEventListener('compositionend', handleCompositionEnd, true)
       terminalElement.removeEventListener('input', handleInput, true)
       terminalElement.removeEventListener('blur', markInactive, true)
+      terminalElement.removeEventListener('keydown', handleKeyDown, true)
     }
   }
 }

--- a/src/renderer/src/components/terminal-pane/terminal-ime-xterm-enter-submit.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-xterm-enter-submit.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment happy-dom
+import { Terminal } from '@xterm/xterm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  shouldSuppressTerminalImeKeyboardEvent,
+  type XtermImeKeyboardOptions
+} from './xterm-bypass-policy'
+import { installTerminalImeCompositionTracker } from './terminal-ime-composition-tracker'
+
+const MAC_COMPOSING_OPTIONS: XtermImeKeyboardOptions = {
+  compositionActive: true,
+  candidateKeyGuardActive: true,
+  pendingCandidateKeyReleaseActive: false,
+  isMac: true,
+  isLinux: false
+}
+
+function nextEventLoop(): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, 0))
+}
+
+function openTerminal(options?: { useProductionTracker?: boolean }): {
+  compositionActive: () => boolean
+  dispose: () => void
+  emitted: string[]
+  terminal: Terminal
+  textarea: HTMLTextAreaElement
+} {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const terminal = new Terminal()
+  terminal.open(container)
+  const textarea = terminal.textarea
+  if (!textarea) {
+    throw new Error('xterm helper textarea was not created')
+  }
+  const emitted: string[] = []
+  terminal.onData((data) => emitted.push(data))
+  const tracker = options?.useProductionTracker
+    ? installTerminalImeCompositionTracker(terminal.element, { isMac: true })
+    : null
+  terminal.attachCustomKeyEventHandler(
+    (event) =>
+      !shouldSuppressTerminalImeKeyboardEvent(
+        event,
+        tracker
+          ? {
+              ...MAC_COMPOSING_OPTIONS,
+              compositionActive: tracker.isActive(),
+              candidateKeyGuardActive: tracker.isCandidateKeyGuardActive()
+            }
+          : MAC_COMPOSING_OPTIONS
+      )
+  )
+  return {
+    compositionActive: () => tracker?.isActive() ?? false,
+    dispose: () => {
+      tracker?.dispose()
+      terminal.dispose()
+    },
+    emitted,
+    terminal,
+    textarea
+  }
+}
+
+function startComposition(textarea: HTMLTextAreaElement, text: string): void {
+  textarea.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))
+  textarea.dispatchEvent(new CompositionEvent('compositionupdate', { data: text, bubbles: true }))
+  textarea.value = text
+}
+
+function pressEnter(
+  textarea: HTMLTextAreaElement,
+  options: { isComposing: boolean; keyCode: number; shiftKey?: boolean }
+): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Enter',
+    code: 'Enter',
+    bubbles: true,
+    shiftKey: options.shiftKey ?? false
+  })
+  Object.defineProperty(event, 'isComposing', { value: options.isComposing })
+  Object.defineProperty(event, 'keyCode', { value: options.keyCode })
+  textarea.dispatchEvent(event)
+  return event
+}
+
+describe('macOS IME Enter submission through xterm', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      measureText: () => ({ width: 10 })
+    } as unknown as CanvasRenderingContext2D)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.body.replaceChildren()
+  })
+
+  it('emits committed Hangul before the plain Enter submission', async () => {
+    const { dispose, emitted, textarea } = openTerminal()
+    startComposition(textarea, '한')
+    await nextEventLoop()
+
+    pressEnter(textarea, { isComposing: true, keyCode: 13 })
+    await nextEventLoop()
+
+    expect(emitted).toEqual(['한', '\r'])
+    dispose()
+  })
+
+  it('lets a plain Enter submit when only the production Orca tracker remains active', () => {
+    const { compositionActive, dispose, emitted, terminal, textarea } = openTerminal({
+      useProductionTracker: true
+    })
+    // Why: target Orca's tracker element directly so xterm's own CompositionHelper
+    // stays inactive, matching a stale tracker after a missed compositionend.
+    terminal.element?.dispatchEvent(new CompositionEvent('compositionstart'))
+    expect(compositionActive()).toBe(true)
+
+    pressEnter(textarea, { isComposing: false, keyCode: 13 })
+
+    expect(emitted).toEqual(['\r'])
+    expect(compositionActive()).toBe(false)
+    dispose()
+  })
+
+  it('commits on Process/229 Enter and waits for the following plain Enter to submit', async () => {
+    const { dispose, emitted, textarea } = openTerminal()
+    startComposition(textarea, '한')
+    await nextEventLoop()
+
+    const processEnter = pressEnter(textarea, { isComposing: true, keyCode: 229 })
+    await nextEventLoop()
+
+    expect(processEnter.defaultPrevented).toBe(false)
+    expect(emitted).toEqual([])
+
+    textarea.dispatchEvent(new CompositionEvent('compositionend', { data: '한', bubbles: true }))
+    await nextEventLoop()
+    expect(emitted).toEqual(['한'])
+
+    pressEnter(textarea, { isComposing: false, keyCode: 13 })
+    expect(emitted).toEqual(['한', '\r'])
+    dispose()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -907,7 +907,9 @@ export function useTerminalPaneLifecycle({
           ? installTerminalImeLinuxCandidateState(pane.terminal.element)
           : null
         const macNativeTextInputSourceTracker = isMac ? getMacNativeTextInputSourceTracker() : null
-        const imeCompositionTracker = installTerminalImeCompositionTracker(pane.terminal.element)
+        const imeCompositionTracker = installTerminalImeCompositionTracker(pane.terminal.element, {
+          isMac
+        })
         imeCompositionDisposablesRef.current.set(pane.id, {
           dispose: () => {
             imeCompositionTracker.dispose()

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts
@@ -229,6 +229,59 @@ describe('shouldSuppressTerminalImeKeyboardEvent — macOS', () => {
     ).toBe(true)
   })
 
+  it('lets plain Enter reach xterm so macOS can finalize and submit the composition', () => {
+    expect(
+      shouldSuppressTerminalImeKeyboardEvent(
+        event({ key: 'Enter', code: 'Enter', keyCode: 13, isComposing: true }),
+        composing
+      )
+    ).toBe(false)
+    expect(
+      shouldSuppressTerminalImeKeyboardEvent(
+        event({ key: 'Enter', code: 'Enter', keyCode: 13 }),
+        composing
+      )
+    ).toBe(false)
+  })
+
+  it('keeps Process Enter and modified Enter owned by the active macOS IME', () => {
+    expect(
+      shouldSuppressTerminalImeKeyboardEvent(
+        event({ key: 'Enter', code: 'Enter', keyCode: 229, isComposing: true }),
+        composing
+      )
+    ).toBe(true)
+    for (const modifier of ['metaKey', 'ctrlKey', 'altKey', 'shiftKey'] as const) {
+      expect(
+        shouldSuppressTerminalImeKeyboardEvent(
+          event({ key: 'Enter', code: 'Enter', keyCode: 13, [modifier]: true }),
+          composing
+        )
+      ).toBe(true)
+    }
+    expect(
+      shouldSuppressTerminalImeKeyboardEvent(
+        event({ type: 'keyup', key: 'Enter', code: 'Enter', keyCode: 13 }),
+        composing
+      )
+    ).toBe(true)
+  })
+
+  it('keeps unidentified Enter events owned by the active macOS IME', () => {
+    expect(
+      shouldSuppressTerminalImeKeyboardEvent(
+        event({ key: 'Enter', code: 'Enter', keyCode: 0, isComposing: true }),
+        composing
+      )
+    ).toBe(true)
+    expect(
+      shouldSuppressTerminalImeKeyboardEvent(
+        event({ key: 'Enter', code: 'Enter', isComposing: true }),
+        composing
+      )
+    ).toBe(true)
+  })
+
   it('does not suppress ordinary text keys solely because composition is active', () => {
     expect(
       shouldSuppressTerminalImeKeyboardEvent(event({ key: 'a', code: 'KeyA' }), composing)

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
@@ -87,6 +87,22 @@ function isXtermHandledKeyEvent(type: string): boolean {
   return type === 'keydown' || type === 'keyup'
 }
 
+function shouldLetXtermFinalizeMacComposition(
+  event: XtermBypassEvent,
+  options: XtermImeKeyboardOptions
+): boolean {
+  return (
+    options.isMac &&
+    event.type === 'keydown' &&
+    event.key === 'Enter' &&
+    event.keyCode === 13 &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    !event.shiftKey
+  )
+}
+
 /** Returns whether xterm must not process an IME-owned keyboard event. */
 export function shouldSuppressTerminalImeKeyboardEvent(
   event: XtermBypassEvent,
@@ -114,6 +130,11 @@ export function shouldSuppressTerminalImeKeyboardEvent(
     return suppressCandidateKey
   }
   if (!isXtermHandledKeyEvent(event.type)) {
+    return false
+  }
+  // Why: xterm's CompositionHelper must see macOS plain Enter so it can emit
+  // the final Hangul before CR; Process/229 Enter remains owned by the IME.
+  if (shouldLetXtermFinalizeMacComposition(event, options)) {
     return false
   }
   // Why: IMEs own Process-key / composing keystrokes — letting xterm translate

--- a/tests/e2e/chinese-ime-chat-input-repro.spec.ts
+++ b/tests/e2e/chinese-ime-chat-input-repro.spec.ts
@@ -3,6 +3,7 @@ import { rmSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import type { CDPSession, Page, TestInfo } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
+import { waitForRestoredTerminalInputReady } from './helpers/restored-terminal-input-readiness'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 import {
   focusActiveTerminalInput,
@@ -79,6 +80,8 @@ function stripTerminalControls(value: string): string {
 const CODEX_READY_RE = /Ask Codex|OpenAI/i
 const CODEX_TRUST_PROMPT_RE = /Do you trust|trust this folder|Trust this/i
 const CODEX_UPDATE_PROMPT_RE = /update available|install update|Skip for now/i
+const MAC_IME_POLICY_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36 Chrome/146 Safari/537.36'
 const LINUX_IME_POLICY_USER_AGENT =
   'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/146 Safari/537.36'
 
@@ -244,17 +247,21 @@ async function readImeEventLog(page: Page): Promise<ImeEventLogEntry[]> {
   })
 }
 
-async function reloadWithLinuxImePolicy(page: Page): Promise<void> {
+async function reloadWithImePolicyUserAgent(page: Page, userAgent: string): Promise<void> {
   await page.addInitScript((userAgent) => {
     Object.defineProperty(navigator, 'userAgent', {
       get: () => userAgent,
       configurable: true
     })
-  }, LINUX_IME_POLICY_USER_AGENT)
-  // Why: the Sogou repro validates Linux-gated terminal IME policy on macOS
-  // runners; reload before the terminal pane mounts so lifecycle code sees it.
+  }, userAgent)
+  // Why: IME policy is selected while the terminal pane mounts; reload after
+  // installing the deterministic UA so this repro does not depend on CI OS.
   await page.reload({ waitUntil: 'domcontentloaded' })
   await page.waitForFunction(() => Boolean(window.__store), null, { timeout: 30_000 })
+}
+
+async function reloadWithLinuxImePolicy(page: Page): Promise<void> {
+  await reloadWithImePolicyUserAgent(page, LINUX_IME_POLICY_USER_AGENT)
 }
 
 async function readPromptState(page: Page): Promise<TerminalPromptState | null> {
@@ -335,6 +342,30 @@ async function dispatchImeProcessKey(session: CDPSession, code: string): Promise
     nativeVirtualKeyCode: 229,
     text: '',
     unmodifiedText: ''
+  })
+}
+
+async function dispatchImeEnter(
+  session: CDPSession,
+  keyCode: 13 | 229,
+  commitBetweenKeys?: () => Promise<void>
+): Promise<void> {
+  await session.send('Input.dispatchKeyEvent', {
+    type: 'keyDown',
+    key: 'Enter',
+    code: 'Enter',
+    windowsVirtualKeyCode: keyCode,
+    nativeVirtualKeyCode: keyCode,
+    text: '',
+    unmodifiedText: ''
+  })
+  await commitBetweenKeys?.()
+  await session.send('Input.dispatchKeyEvent', {
+    type: 'keyUp',
+    key: 'Enter',
+    code: 'Enter',
+    windowsVirtualKeyCode: keyCode,
+    nativeVirtualKeyCode: keyCode
   })
 }
 
@@ -479,6 +510,117 @@ async function launchCodexTui(page: Page, ptyId: string): Promise<void> {
 }
 
 test.describe('Chinese IME terminal chat input repro', () => {
+  test('submits active Korean composition exactly once on macOS Enter and keeps Process/229 IME-owned', async ({
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    await reloadWithImePolicyUserAgent(orcaPage, MAC_IME_POLICY_USER_AGENT)
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    const runId = randomUUID()
+    const scriptPath = path.join(testRepoPath, `.orca-korean-ime-harness-${runId}.cjs`)
+    let session: CDPSession | null = null
+    let harnessStarted = false
+
+    try {
+      expect(
+        await waitForRestoredTerminalInputReady(orcaPage, ptyId, 30_000),
+        'reloaded terminal did not become ready for keyboard input'
+      ).toBe(true)
+      writeFileSync(scriptPath, terminalImeHarnessScript(runId))
+      session = await orcaPage.context().newCDPSession(orcaPage)
+      await sendToTerminal(orcaPage, ptyId, `node ${JSON.stringify(scriptPath)}\r`)
+      harnessStarted = true
+      await waitForTerminalOutput(orcaPage, `IME_HARNESS_READY_${runId}`, 10_000, 20_000)
+      await focusActiveTerminalInput(orcaPage)
+      await installImeEventProbe(orcaPage)
+
+      const submitLogStart = (await readImeEventLog(orcaPage)).length
+      await setImeComposition(session, '한글')
+      // Why: xterm updates the composition range on the next event loop before
+      // Enter finalizes it; wait for that deterministic boundary, not wall time.
+      await orcaPage.evaluate(() => new Promise<void>((resolve) => window.setTimeout(resolve, 0)))
+      await dispatchImeEnter(session, 13)
+
+      await expect
+        .poll(async () => (await readPromptState(orcaPage))?.submitted ?? [], {
+          timeout: 5_000,
+          message: 'macOS plain Enter did not submit the active Korean composition exactly once'
+        })
+        .toEqual(['한글'])
+
+      // Why: missed compositionend used to leave Orca's candidate guard stale
+      // for 10 seconds after a successful submit, swallowing these next keys.
+      await dispatchCandidateSelectionKey(session, { key: ' ', code: 'Space', keyCode: 32 })
+      await dispatchCandidateSelectionKey(session, { key: '1', code: 'Digit1', keyCode: 49 })
+      await waitForLivePrompt(orcaPage, ' 1')
+      await orcaPage.keyboard.press('Backspace')
+      await orcaPage.keyboard.press('Backspace')
+      await waitForLivePrompt(orcaPage, '')
+
+      const submitLog = await readImeEventLog(orcaPage)
+      const compositionStartIndex = submitLog.findIndex(
+        (entry, index) => index >= submitLogStart && entry.type === 'compositionstart'
+      )
+      const submitEnterIndex = submitLog.findIndex(
+        (entry, index) =>
+          index > compositionStartIndex &&
+          entry.type === 'keydown' &&
+          entry.key === 'Enter' &&
+          entry.keyCode === 13
+      )
+      expect(
+        compositionStartIndex,
+        'Korean repro must start composition before the submit Enter'
+      ).toBeGreaterThanOrEqual(submitLogStart)
+      expect(
+        submitEnterIndex,
+        'plain Enter must arrive while the Korean composition is active'
+      ).toBeGreaterThan(compositionStartIndex)
+      expect(submitLog[submitEnterIndex]?.isComposing).toBe(true)
+
+      // End the CDP composition session after xterm has synchronously finalized
+      // its own range, so the Process/229 case starts from a clean boundary.
+      await setImeComposition(session, '')
+      await commitImeText(session, '')
+
+      const processLogStart = (await readImeEventLog(orcaPage)).length
+      await setImeComposition(session, '입력중')
+      await orcaPage.evaluate(() => new Promise<void>((resolve) => window.setTimeout(resolve, 0)))
+      await dispatchImeEnter(session, 229, () => commitImeText(session!, '입력중'))
+      await waitForLivePrompt(orcaPage, '입력중')
+
+      const promptState = await readPromptState(orcaPage)
+      expect(
+        promptState?.submitted,
+        'Process/229 Enter must commit through the IME without submitting a second prompt'
+      ).toEqual(['한글'])
+      const processLog = await readImeEventLog(orcaPage)
+      const processEnter = processLog.find(
+        (entry, index) =>
+          index >= processLogStart &&
+          entry.type === 'keydown' &&
+          entry.key === 'Enter' &&
+          entry.keyCode === 229
+      )
+      expect(processEnter?.isComposing).toBe(true)
+      await attachImeEvidence(orcaPage, testInfo, 'korean-enter-boundaries')
+    } finally {
+      await attachImeEvidence(orcaPage, testInfo, 'korean-enter-final-evidence').catch(
+        () => undefined
+      )
+      await session?.detach().catch(() => undefined)
+      if (harnessStarted) {
+        await sendToTerminal(orcaPage, ptyId, '\x03').catch(() => undefined)
+      }
+      rmSync(scriptPath, { force: true })
+    }
+  })
+
   test('keeps composed Chinese text, cursor movement, and Backspace stable in the agent input surface', async ({
     orcaPage,
     testRepoPath


### PR DESCRIPTION
## Summary

- Let the exact macOS plain Enter key reach xterm while Korean IME composition is active so xterm can finalize the composition and emit the submit CR.
- Clear Orca's stale composition tracker on that same Enter boundary when Chromium misses `compositionend`, preventing the next Space or digit from being swallowed for up to 10 seconds.
- Keep Process/229, keyCode 0, modified Enter, keyup, Linux, and Windows behavior unchanged.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` (changed files passed oxlint and oxfmt; full CI remains authoritative)
- [ ] `pnpm typecheck` (`pnpm run typecheck:web` passed)
- [ ] `pnpm test` (14 relevant files, 232 tests passed on latest `main`)
- [ ] `pnpm build` (`pnpm run build:mac` passed for the integrated local candidate before the latest-main refresh; CI remains authoritative)
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Regression coverage includes the production composition tracker, real xterm input, macOS plain Enter, Process/229, keyCode 0, modifier boundaries, non-macOS behavior, and an Electron+PTY assertion that Space and Digit1 reach the next prompt immediately after Korean submission.

Local installation verification kept all pre-existing PTYs across restart: 12/12 connected and writable, with no missing or replacement PTYs. The installed app matched the built candidate and passed deep strict code-sign verification.

## AI Review Report

An independent review checked event ordering, xterm propagation, listener cleanup, SSH behavior, and macOS/Linux/Windows boundaries. It found no code-correctness blockers after the exact `keyCode === 13` guard and real-xterm regression test were included. It also required this IME fix to remain separate from #9264 because that PR addresses heavy-test admission rather than runtime input handling.

## Security Audit

The change does not add command execution, paths, auth, secrets, dependencies, IPC, or persisted user input. Keyboard handling is narrowed to an exact macOS plain Enter predicate; the capture listener only clears in-memory composition state and does not stop event propagation. Listener disposal is covered.

## Notes

- This is intentionally macOS-only. Linux and Windows continue using their existing IME ownership rules.
- SSH terminals use the local renderer input policy, so remote host behavior is unchanged.
- The automated physical macOS two-set Korean keyboard probe remains unavailable because of a separate local Accessibility permission-detection issue. Unit, real-xterm, Electron+PTY, signed local installation, and live Korean submission provide the current evidence.
