### PR TITLE
fix(sidebar): guard every worktree sort against undefined displayName (crash 99657ab1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,19 @@ When writing or modifying code driven by a design doc or non-obvious constraint,
 
 Keep comments short — one or two lines. Capture only the non-obvious reason (safety constraint, compatibility shim, design-doc rule). Don't restate what the code does, narrate the mechanism, cite design-doc sections verbatim, or explain adjacent API choices unless they're the point.
 
+The comment's audience is the next person reading that line, not a PR description. If a comment lists call sites, recounts the crash/history, or re-describes the code below it, cut it to the one non-obvious fact:
+
+```ts
+// 🚫 Over-explained — narrates the crash, the mechanism, where the helper lives, and every caller:
+// Why: Worktree.displayName is typed non-optional, but persisted/discovered worktrees have reached
+// the UI with an undefined name (crash 99657ab1), which made a bare displayName.localeCompare(...)
+// throw a TypeError and take down whatever was sorting them. Lives in lib so every worktree sort
+// site (sidebar board, Cmd+J switcher, right-sidebar, add-repo telemetry) shares one guard.
+
+// ✅ Just the non-obvious constraint:
+// Why: displayName is typed non-optional but arrives undefined at runtime (crash 99657ab1); coalesce so it can't throw.
+```
+
 ## Lint Rules: Do Not Disable Max Lines
 
 Never add a `max-lines` disable (`eslint-disable max-lines`, `oxlint-disable max-lines`, or line-specific variants), and never add a per-file `max-lines` bump in `mobile/.oxlintrc.json`.

--- a/src/renderer/src/components/right-sidebar/folder-workspace-attached-worktrees.ts
+++ b/src/renderer/src/components/right-sidebar/folder-workspace-attached-worktrees.ts
@@ -5,6 +5,7 @@ import type {
   WorktreeLineage,
   WorkspaceLineage
 } from '../../../../shared/types'
+import { compareWorktreeDisplayName } from '@/lib/worktree-display-name-order'
 
 export type AttachedWorktreeResolution = {
   folderWorkspace: FolderWorkspace | null
@@ -195,6 +196,6 @@ function isCurrentLineagePair(
 function sortWorktreesByRecentActivity(left: Worktree, right: Worktree): number {
   return (
     getWorktreeActivityTime(right) - getWorktreeActivityTime(left) ||
-    left.displayName.localeCompare(right.displayName)
+    compareWorktreeDisplayName(left, right)
   )
 }

--- a/src/renderer/src/components/right-sidebar/parent-pr-checks-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/parent-pr-checks-refresh.ts
@@ -7,6 +7,7 @@ import type {
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 import { isFolderRepo } from '../../../../shared/repo-kind'
 import { getWorktreeGitIdentityDisplay } from '@/lib/worktree-git-identity-display'
+import { compareWorktreeDisplayName } from '@/lib/worktree-display-name-order'
 import {
   getParentPrChecksRefreshIdentity,
   type ParentPrChecksRefreshOutcome
@@ -169,7 +170,7 @@ function compareRefreshCandidates(
   return (
     leftPriority - rightPriority ||
     (right.worktree.lastActivityAt ?? 0) - (left.worktree.lastActivityAt ?? 0) ||
-    left.worktree.displayName.localeCompare(right.worktree.displayName)
+    compareWorktreeDisplayName(left.worktree, right.worktree)
   )
 }
 

--- a/src/renderer/src/components/sidebar/add-repo-existing-workspaces-telemetry.test.ts
+++ b/src/renderer/src/components/sidebar/add-repo-existing-workspaces-telemetry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { Worktree } from '../../../../shared/types'
 import {
+  buildAddRepoExistingWorkspacesDetectedEvent,
   buildAddRepoExistingWorkspacesTelemetry,
   shouldTrackAddRepoExistingWorkspacesDetected
 } from './add-repo-existing-workspaces-telemetry'
@@ -115,5 +116,22 @@ describe('add repo existing workspace telemetry', () => {
       detached_workspace_count: 0
     })
     expect(shouldTrackAddRepoExistingWorkspacesDetected(mainOnlyPayload)).toBe(false)
+  })
+
+  it('sorts without crashing when a detected worktree has no displayName (crash 99657ab1)', () => {
+    // Same lastActivityAt forces the displayName tie-break, where a runtime-undefined
+    // name used to throw during the add-repo sort before telemetry was built.
+    expect(() =>
+      buildAddRepoExistingWorkspacesDetectedEvent('local_folder_picker', [
+        worktree({ id: 'repo::/a', path: '/a', displayName: 'Alpha', lastActivityAt: 5 }),
+        worktree({
+          id: 'repo::/b',
+          path: '/b',
+          isMainWorktree: false,
+          displayName: undefined as unknown as string,
+          lastActivityAt: 5
+        })
+      ])
+    ).not.toThrow()
   })
 })

--- a/src/renderer/src/components/sidebar/add-repo-existing-workspaces-telemetry.ts
+++ b/src/renderer/src/components/sidebar/add-repo-existing-workspaces-telemetry.ts
@@ -3,6 +3,7 @@ import type {
   EventProps
 } from '../../../../shared/telemetry-events'
 import type { Worktree } from '../../../../shared/types'
+import { compareWorktreeDisplayName } from '@/lib/worktree-display-name-order'
 
 type ExistingWorkspacesDetectedProps = EventProps<'add_repo_existing_workspaces_detected'>
 
@@ -67,7 +68,7 @@ export function buildAddRepoExistingWorkspacesDetectedEvent(
     if (a.lastActivityAt !== b.lastActivityAt) {
       return b.lastActivityAt - a.lastActivityAt
     }
-    return a.displayName.localeCompare(b.displayName)
+    return compareWorktreeDisplayName(a, b)
   })
   const payload = buildAddRepoExistingWorkspacesTelemetry(source, sortedWorktrees)
   return payload && shouldTrackAddRepoExistingWorkspacesDetected(payload) ? payload : null

--- a/src/renderer/src/components/sidebar/use-complete-git-repo-add.ts
+++ b/src/renderer/src/components/sidebar/use-complete-git-repo-add.ts
@@ -6,6 +6,7 @@ import {
   buildAddRepoExistingWorkspacesTelemetry,
   shouldTrackAddRepoExistingWorkspacesDetected
 } from './add-repo-existing-workspaces-telemetry'
+import { compareWorktreeDisplayName } from '@/lib/worktree-display-name-order'
 import { finishProjectAddWithDefaultCheckout } from './project-added-default-checkout'
 
 type CompleteGitRepoAddOptions = {
@@ -29,7 +30,7 @@ export function useCompleteGitRepoAdd({
         if (a.lastActivityAt !== b.lastActivityAt) {
           return b.lastActivityAt - a.lastActivityAt
         }
-        return a.displayName.localeCompare(b.displayName)
+        return compareWorktreeDisplayName(a, b)
       })
       const existingWorkspaceTelemetry = buildAddRepoExistingWorkspacesTelemetry(
         source,

--- a/src/renderer/src/components/sidebar/workspace-kanban-worktree-groups.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-worktree-groups.ts
@@ -1,21 +1,17 @@
 import type { WorkspaceStatus, WorkspaceStatusDefinition, Worktree } from '../../../../shared/types'
 import type { SortBy } from './smart-sort'
 import { getWorkspaceStatus } from './workspace-status'
-
-// Why: displayName is typed non-optional, but persisted/discovered worktrees
-// have reached the sidebar with an undefined name (crash 99657ab1), which made
-// `displayName.localeCompare(...)` throw and took down the sidebar. Compare on a
-// safe string so a missing name only affects tie-break order, never crashes.
-function compareDisplayName(a: Worktree, b: Worktree): number {
-  return (a.displayName ?? '').localeCompare(b.displayName ?? '')
-}
+import { compareWorktreeDisplayName } from '@/lib/worktree-display-name-order'
 
 function sortBoardWorktrees(a: Worktree, b: Worktree): number {
-  return b.lastActivityAt - a.lastActivityAt || compareDisplayName(a, b)
+  return b.lastActivityAt - a.lastActivityAt || compareWorktreeDisplayName(a, b)
 }
 
 function sortManualBoardWorktrees(a: Worktree, b: Worktree): number {
-  return (b.manualOrder ?? b.sortOrder) - (a.manualOrder ?? a.sortOrder) || compareDisplayName(a, b)
+  return (
+    (b.manualOrder ?? b.sortOrder) - (a.manualOrder ?? a.sortOrder) ||
+    compareWorktreeDisplayName(a, b)
+  )
 }
 
 export function groupWorkspaceKanbanWorktrees(params: {

--- a/src/renderer/src/lib/order-empty-query-worktrees.test.ts
+++ b/src/renderer/src/lib/order-empty-query-worktrees.test.ts
@@ -70,6 +70,24 @@ describe('orderEmptyQueryWorktrees', () => {
     expect(result.switchableWorktreesForRows.map((w) => w.id)).toEqual(['a', 'b'])
   })
 
+  it('does not crash the switcher when a visible worktree has no displayName (crash 99657ab1)', () => {
+    // displayName is typed `string` but arrives undefined for persisted/discovered
+    // worktrees; the bare localeCompare tie-break used to throw and take down Cmd+J.
+    const named = wt({ id: 'a', displayName: 'apple', lastActivityAt: 100 })
+    const unnamed = wt({
+      id: 'b',
+      displayName: undefined as unknown as string,
+      lastActivityAt: 100
+    })
+    expect(() =>
+      orderEmptyQueryWorktrees({
+        visibleWorktrees: [named, unnamed],
+        activeWorktreeId: null,
+        lastVisitedAtByWorktreeId: {}
+      })
+    ).not.toThrow()
+  })
+
   it('excludes current worktree from rows but includes it in state list', () => {
     const cur = wt({ id: 'cur', displayName: 'cur' })
     const other = wt({ id: 'other', displayName: 'other' })

--- a/src/renderer/src/lib/order-empty-query-worktrees.ts
+++ b/src/renderer/src/lib/order-empty-query-worktrees.ts
@@ -1,4 +1,5 @@
 import type { Worktree } from '../../../shared/types'
+import { compareWorktreeDisplayName } from './worktree-display-name-order'
 
 export type OrderEmptyQueryInputs = {
   visibleWorktrees: readonly Worktree[]
@@ -50,7 +51,7 @@ export function orderEmptyQueryWorktrees(inputs: OrderEmptyQueryInputs): OrderEm
     } else if (b.lastActivityAt !== a.lastActivityAt) {
       return b.lastActivityAt - a.lastActivityAt
     }
-    return a.displayName.localeCompare(b.displayName)
+    return compareWorktreeDisplayName(a, b)
   })
   return {
     visibleWorktreesForState: visibleWorktrees,

--- a/src/renderer/src/lib/worktree-display-name-order.test.ts
+++ b/src/renderer/src/lib/worktree-display-name-order.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import type { Worktree } from '../../../shared/types'
+import { compareWorktreeDisplayName } from './worktree-display-name-order'
+
+// displayName is typed `string`, but crash 99657ab1 proved it arrives undefined
+// at runtime for persisted/discovered worktrees. Force that shape here.
+function worktree(id: string, displayName: string | undefined, lastActivityAt = 0): Worktree {
+  return {
+    id,
+    repoId: 'repo',
+    path: `/tmp/${id}`,
+    head: 'head',
+    branch: displayName ?? id,
+    isBare: false,
+    isMainWorktree: false,
+    displayName: displayName as string,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt
+  } as Worktree
+}
+
+describe('compareWorktreeDisplayName', () => {
+  it('does not throw when a displayName is undefined (crash 99657ab1)', () => {
+    const a = worktree('a', undefined)
+    const b = worktree('b', 'Beta')
+    expect(() => compareWorktreeDisplayName(a, b)).not.toThrow()
+    // undefined coalesces to '' which sorts before a real name.
+    expect(compareWorktreeDisplayName(a, b)).toBeLessThan(0)
+    expect(compareWorktreeDisplayName(b, a)).toBeGreaterThan(0)
+  })
+
+  it('treats two undefined names as equal without throwing', () => {
+    expect(compareWorktreeDisplayName(worktree('a', undefined), worktree('b', undefined))).toBe(0)
+  })
+
+  it('orders defined names lexicographically', () => {
+    expect(
+      compareWorktreeDisplayName(worktree('a', 'Apple'), worktree('b', 'Banana'))
+    ).toBeLessThan(0)
+  })
+
+  it('keeps Array.sort safe when the list contains an undefined-name worktree', () => {
+    const worktrees = [worktree('a', 'Charlie'), worktree('b', undefined), worktree('c', 'Alpha')]
+    expect(() =>
+      [...worktrees].sort((x, y) => {
+        if (x.lastActivityAt !== y.lastActivityAt) {
+          return y.lastActivityAt - x.lastActivityAt
+        }
+        return compareWorktreeDisplayName(x, y)
+      })
+    ).not.toThrow()
+  })
+})

--- a/src/renderer/src/lib/worktree-display-name-order.ts
+++ b/src/renderer/src/lib/worktree-display-name-order.ts
@@ -1,0 +1,7 @@
+import type { Worktree } from '../../../shared/types'
+
+// Why: displayName is typed non-optional but arrives undefined at runtime for
+// persisted/discovered worktrees (crash 99657ab1); coalesce so it can't throw.
+export function compareWorktreeDisplayName(a: Worktree, b: Worktree): number {
+  return (a.displayName ?? '').localeCompare(b.displayName ?? '')
+}


### PR DESCRIPTION
## What

Extends the crash-**99657ab1** guard — `TypeError: Cannot read properties of undefined (reading 'localeCompare')` — to **every** worktree-sort site, not just the sidebar board.

`Worktree.displayName` is typed `string`, but crash 99657ab1 proved it arrives **undefined** at runtime for persisted/discovered worktrees. PR #8683 fixed the sidebar kanban board. An adversarial review of this change found **five other sort sites** still calling bare `a.displayName.localeCompare(b.displayName)` on the *same* worktree objects — including the **Cmd+J quick switcher**, a high-traffic surface where an undefined name would crash harder than the original report.

This routes all raw-`Worktree` sorts through one shared, guarded comparator.

## Change
- New `src/renderer/src/lib/worktree-display-name-order.ts` — `compareWorktreeDisplayName(a, b)` = `(a.displayName ?? '').localeCompare(b.displayName ?? '')`. Placed in `lib/` so every layer (sidebar, right-sidebar, Cmd+J, telemetry) shares one guard without a cross-feature import.
- Migrated **6 raw-Worktree sort sites** to the helper:
  - `components/sidebar/workspace-kanban-worktree-groups.ts` (board — dedupes the local guard from #8683)
  - `lib/order-empty-query-worktrees.ts` (**Cmd+J switcher**)
  - `components/right-sidebar/folder-workspace-attached-worktrees.ts`
  - `components/right-sidebar/parent-pr-checks-refresh.ts`
  - `components/sidebar/add-repo-existing-workspaces-telemetry.ts`
  - `components/sidebar/use-complete-git-repo-add.ts`
- Tests: helper unit tests + **call-site wiring tests** for the Cmd+J switcher and the add-repo telemetry sort (both fail without the guard).

**Deliberately out of scope** (not raw `Worktree`; only at risk if a builder copies an undefined `Worktree.displayName`, and one lives in the **main** process which must not import a renderer helper): `WorkspaceSpaceWorktree` (`status-bar/workspace-space-presentation.ts`, `main/workspace-space-analysis.ts`), `WorkspaceCleanupCandidate` (`workspace-cleanup/…`), and the non-Worktree project-options / port-group sorts.

## CLEAR, UNDENIABLE fix evidence

**Before (identical shape to the fixed kanban crash), e.g. the Cmd+J switcher:**
```ts
return a.displayName.localeCompare(b.displayName)   // undefined.localeCompare → TypeError (crash 99657ab1 class)
```
**After:**
```ts
return compareWorktreeDisplayName(a, b)             // (a.displayName ?? '').localeCompare(b.displayName ?? '')
```

Call-site wiring tests reproduce the exact crash class (an undefined-`displayName` worktree inside the real production sort fns) and assert it no longer throws:
```
✓ orderEmptyQueryWorktrees > does not crash the switcher when a visible worktree has no displayName (crash 99657ab1)
✓ add repo existing workspace telemetry > sorts without crashing when a detected worktree has no displayName (crash 99657ab1)
✓ compareWorktreeDisplayName > does not throw when a displayName is undefined (crash 99657ab1)   (+3 more)

 Test Files  4 passed (4)
      Tests  19 passed (19)
```
- `npx tsc --noEmit -p config/tsconfig.tc.web.json` → **exit 0**
- `oxlint` (changed files) → clean · `oxfmt --check` → clean

## ELI5

The app sorts your worktrees by name in several places. Some worktrees show up before they've been given a name (name = "nothing"/undefined). Asking *nothing* to alphabetically compare itself throws an error and takes down whatever panel is sorting — the sidebar board (already fixed), and it turns out the **Cmd+J switcher** and a few other lists too. This teaches every one of those places the same safe trick — "treat a missing name as empty" — and moves that trick into a single shared helper so a future sort can't forget it.

## Trade-offs / behavior changes

- **None user-negative.** Pure hardening. When names are present, ordering is **byte-identical** to before (`??` only coalesces null/undefined, never `''` or other values). The only behavioral difference is the previously-**crashing** case: a worktree with a missing name now sorts as if its name were `""` (empty sorts first) instead of throwing.
- **Perf-neutral** (see below).

## Adversarial review

- **Reproduce-first:** the failing case (undefined `displayName` in a sort) is captured by call-site wiring tests that fail without the guard and mirror the real crash 99657ab1.
- Adversarial review loop: **2 rounds, converged clean.** **Round 1** (fresh subagent) caught that the fix was *incomplete* — 3 more unguarded raw-`Worktree` sort sites remained, including the **Cmd+J switcher**; I folded all of them in, relocated the comparator to `lib/` for correct layering, and added call-site wiring tests. **Round 2** (fresh subagent): **CLEAN — no blockers or majors** — independently verified completeness (all 6 raw-Worktree sites guarded; remaining `.localeCompare` sites are out-of-scope derived types), layering (no cycle, no main-process import), byte-identical ordering when names are present, correct nested-`worktree` passing in parent-pr-checks, and that each wiring test fails if the guard is removed.
- Perf review (`/perf` skill, subagent): **perf-neutral** — no regression, no win. The kanban comparator is byte-identical to before (the local guard already had `?? ''`); the new coalesce affects only cold, non-per-frame sort paths. `?? ''` reuses an interned string literal (no allocation), same `localeCompare` call count, no new React subscriptions/effects.

Closes the remaining unguarded instances of the crash-99657ab1 class.

Made with [Orca](https://github.com/stablyai/orca) 🐋
