### PR TITLE
fix(rate-limits): refetch claude usage when the last live Claude PTY exits

### DIFF
--- a/src/main/claude-accounts/live-pty-gate.test.ts
+++ b/src/main/claude-accounts/live-pty-gate.test.ts
@@ -8,6 +8,7 @@ import {
   isClaudeAuthSwitchInProgress,
   markClaudePtyExited,
   markClaudePtySpawned,
+  onLiveClaudePtysDrained,
   seedLiveClaudePtysFromPersistence
 } from './live-pty-gate'
 
@@ -75,6 +76,53 @@ describe('Claude live PTY gate', () => {
     confirmSeededClaudeLivePtys([])
 
     expect(hasLiveClaudePtys()).toBe(true)
+  })
+
+  it('notifies drain listeners only when the last live Claude PTY exits', () => {
+    const onDrained = vi.fn()
+    const unsubscribe = onLiveClaudePtysDrained(onDrained)
+    try {
+      markClaudePtySpawned('live-claude-pty')
+      markClaudePtySpawned('seeded-pty-1')
+
+      markClaudePtyExited('live-claude-pty')
+      expect(onDrained).not.toHaveBeenCalled()
+
+      markClaudePtyExited('seeded-pty-1')
+      expect(onDrained).toHaveBeenCalledTimes(1)
+
+      // Why: exits with no live PTYs left must not fire again — the drain
+      // signal marks the 1 -> 0 transition, not every teardown call.
+      markClaudePtyExited('seeded-pty-1')
+      expect(onDrained).toHaveBeenCalledTimes(1)
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  it('notifies drain listeners when seed reconciliation releases the last live id', () => {
+    const onDrained = vi.fn()
+    const unsubscribe = onLiveClaudePtysDrained(onDrained)
+    try {
+      seedLiveClaudePtysFromPersistence(['seeded-pty-1'])
+
+      confirmSeededClaudeLivePtys([])
+
+      expect(onDrained).toHaveBeenCalledTimes(1)
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  it('stops notifying an unsubscribed drain listener', () => {
+    const onDrained = vi.fn()
+    const unsubscribe = onLiveClaudePtysDrained(onDrained)
+    unsubscribe()
+
+    markClaudePtySpawned('live-claude-pty')
+    markClaudePtyExited('live-claude-pty')
+
+    expect(onDrained).not.toHaveBeenCalled()
   })
 
   it('persists spawns and exits when persistence is attached', () => {

--- a/src/main/claude-accounts/live-pty-gate.ts
+++ b/src/main/claude-accounts/live-pty-gate.ts
@@ -17,6 +17,26 @@ export function attachClaudeLivePtyPersistence(target: ClaudeLivePtyPersistence 
   persistence = target
 }
 
+// Why: a live claude defers the managed OAuth refresh ("Waiting for Claude
+// session"); consumers need the 1 -> 0 transition to recover promptly instead
+// of waiting out the usage-fetch failure backoff.
+type LiveClaudePtyDrainListener = () => void
+const drainListeners = new Set<LiveClaudePtyDrainListener>()
+
+export function onLiveClaudePtysDrained(listener: LiveClaudePtyDrainListener): () => void {
+  drainListeners.add(listener)
+  return () => drainListeners.delete(listener)
+}
+
+function notifyDrainedOnTransition(hadLivePtys: boolean): void {
+  if (!hadLivePtys || liveClaudePtyIds.size > 0) {
+    return
+  }
+  for (const listener of drainListeners) {
+    listener()
+  }
+}
+
 export function seedLiveClaudePtysFromPersistence(sessionIds: readonly string[]): void {
   for (const sessionId of sessionIds) {
     liveClaudePtyIds.add(sessionId)
@@ -35,6 +55,7 @@ export function hasSeededUnconfirmedClaudePtys(): boolean {
  * their pane never reattaches: that daemon process still owns the credentials.
  */
 export function confirmSeededClaudeLivePtys(aliveSessionIds: readonly string[]): void {
+  const hadLivePtys = liveClaudePtyIds.size > 0
   const alive = new Set(aliveSessionIds)
   for (const sessionId of seededUnconfirmedPtyIds) {
     if (!alive.has(sessionId)) {
@@ -43,6 +64,7 @@ export function confirmSeededClaudeLivePtys(aliveSessionIds: readonly string[]):
     }
   }
   seededUnconfirmedPtyIds.clear()
+  notifyDrainedOnTransition(hadLivePtys)
 }
 
 export function markClaudePtySpawned(ptyId: string): void {
@@ -52,9 +74,11 @@ export function markClaudePtySpawned(ptyId: string): void {
 }
 
 export function markClaudePtyExited(ptyId: string): void {
+  const hadLivePtys = liveClaudePtyIds.size > 0
   liveClaudePtyIds.delete(ptyId)
   seededUnconfirmedPtyIds.delete(ptyId)
   persistence?.removeClaudeLivePtySessionId(ptyId)
+  notifyDrainedOnTransition(hadLivePtys)
 }
 
 export function hasLiveClaudePtys(): boolean {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -174,6 +174,7 @@ import { ClaudeAccountService } from './claude-accounts/service'
 import { ClaudeRuntimeAuthService } from './claude-accounts/runtime-auth-service'
 import {
   attachClaudeLivePtyPersistence,
+  onLiveClaudePtysDrained,
   seedLiveClaudePtysFromPersistence
 } from './claude-accounts/live-pty-gate'
 import { StarNagService } from './star-nag/service'
@@ -1830,6 +1831,12 @@ app.whenReady().then(async () => {
   })
   // Why: run before ClaudeRuntimeAuthService's constructor sync — a surviving daemon Claude CLI holds the single-use refresh token; early refresh rotates it out mid-session.
   attachClaudeLivePtyPersistence(store)
+  // Why: while a live claude defers the managed OAuth refresh, usage shows
+  // "Waiting for Claude session"; refetch when the last live PTY exits so the
+  // error clears immediately instead of after the failure backoff.
+  onLiveClaudePtysDrained(() => {
+    void rateLimits?.refreshAfterClaudeLivePtysDrained()
+  })
   const persistedClaudePtyIds = store.getClaudeLivePtySessionIds()
   seedLiveClaudePtysFromPersistence(persistedClaudePtyIds)
   if (persistedClaudePtyIds.length > 0) {

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -2150,4 +2150,51 @@ describe('RateLimitService', () => {
     expect(state.minimax?.error).toBe('MiniMax session cookie could not be decrypted')
     expect(state.claude?.status).toBe('ok')
   })
+
+  describe('refreshAfterClaudeLivePtysDrained', () => {
+    function deferredClaudeResult(): ProviderRateLimits {
+      return {
+        ...errorProvider('claude', 'Waiting for Claude session'),
+        usageMetadata: {
+          failureKind: 'deferred-by-live-session',
+          deferredByLiveClaudeSession: true
+        }
+      }
+    }
+
+    it('refetches Claude usage when the current result was deferred by a live session', async () => {
+      const service = new RateLimitService()
+      vi.mocked(fetchClaudeRateLimits).mockResolvedValueOnce(deferredClaudeResult())
+      await service.refresh()
+      expect(service.getState().claude?.usageMetadata?.deferredByLiveClaudeSession).toBe(true)
+      vi.mocked(fetchClaudeRateLimits).mockClear()
+      vi.mocked(fetchClaudeRateLimits).mockResolvedValueOnce(okProvider('claude', 10, Date.now()))
+
+      await service.refreshAfterClaudeLivePtysDrained()
+
+      expect(fetchClaudeRateLimits).toHaveBeenCalledTimes(1)
+      expect(service.getState().claude?.status).toBe('ok')
+    })
+
+    it('does not refetch when the current Claude result was not deferred', async () => {
+      const service = new RateLimitService()
+      vi.mocked(fetchClaudeRateLimits).mockResolvedValueOnce(
+        errorProvider('claude', 'Token expired')
+      )
+      await service.refresh()
+      vi.mocked(fetchClaudeRateLimits).mockClear()
+
+      await service.refreshAfterClaudeLivePtysDrained()
+
+      expect(fetchClaudeRateLimits).not.toHaveBeenCalled()
+    })
+
+    it('does not refetch when there is no Claude state yet', async () => {
+      const service = new RateLimitService()
+
+      await service.refreshAfterClaudeLivePtysDrained()
+
+      expect(fetchClaudeRateLimits).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -486,6 +486,17 @@ export class RateLimitService {
     return this.getState()
   }
 
+  async refreshAfterClaudeLivePtysDrained(): Promise<void> {
+    // Why: "Waiting for Claude session" can only recover once no live claude
+    // owns the credentials. Refetch on the last PTY exit instead of leaving
+    // the stale terminal error up until the failure backoff elapses.
+    if (!this.state.claude?.usageMetadata?.deferredByLiveClaudeSession) {
+      return
+    }
+    this.activeFailureStreakByProvider.claude = 0
+    await this.fetchClaudeOnly({ force: true })
+  }
+
   async fetchInactiveClaudeAccountsOnOpen(): Promise<void> {
     if (Date.now() - this.lastInactiveClaudeFetchAt < INACTIVE_FETCH_DEBOUNCE_MS) {
       return


### PR DESCRIPTION
## Summary

Fixes the Claude usage panel getting stuck on "Waiting for Claude session" for up to ~15 minutes (indefinitely if unfocused) after the last live `claude` terminal exits.

## ELI5

When you close your last Claude terminal, the app should immediately refresh how much Claude usage you have left. Before, it sat showing a stale "waiting" message for a long time; now it updates right away.

## Root cause & fix

While a live Claude CLI owns the single-use OAuth refresh token, the managed usage fetch is deferred and returns a terminal-classified error (`usageMetadata.deferredByLiveClaudeSession=true`) that only clears after the 15-minute failure backoff, and retries are window-focus-gated. The fix adds a drain-listener to `live-pty-gate` that fires on the live-Claude-PTY 1→0 transition — covering both `markClaudePtyExited` and `confirmSeededClaudeLivePtys` reconciliation. It is wired in `index.ts` to `RateLimitService.refreshAfterClaudeLivePtysDrained()`, which — only when the current claude result was deferred by a live session — resets the failure streak and force-refetches immediately.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23. Clean rebase onto `origin/main`.

- Suites: `live-pty-gate.test.ts` and `rate-limits/service.test.ts`.
- On branch: **74/74 tests passing** across both files.
- Reverting the fix files (keeping tests) fails as expected — proving the tests exercise the fix:

```
On branch:  Test Files 2 passed (2), Tests 74 passed (74).

Fix reverted:  Test Files 2 failed (2), Tests 6 failed | 68 passed (74).
  - live-pty-gate: onLiveClaudePtysDrained is not a function
  - service: service.refreshAfterClaudeLivePtysDrained is not a function
```

- `oxlint` clean (exit 0) on the three changed source files.

## Trade-offs

None — pure fix.

## Regression risk

Zero-regression by design: the new refetch path is gated on `deferredByLiveClaudeSession`, making it a no-op for every non-deferred/absent claude state (covered by two negative tests). The drain signal only fires on the true 1→0 transition (`hadLivePtys && size===0`), verified not to re-fire on redundant exits, and listener registration uses optional chaining on `rateLimits`. No residual risk found.

_Credit to original author @xianjianlf2. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved. No additional fix was layered on this session._
