### PR TITLE
perf(git): reduce WSL status subprocess overhead

### DIFF
--- a/src/main/diagnostics/main-thread-churn-probe.test.ts
+++ b/src/main/diagnostics/main-thread-churn-probe.test.ts
@@ -38,6 +38,17 @@ describe('classifySubprocessCommand', () => {
       classifySubprocessCommand('wsl.exe', ['-d', 'Ubuntu', '--', 'git', 'status', '--porcelain'])
     ).toBe('git status')
     expect(classifySubprocessCommand('wsl.exe', ['-d', 'Ubuntu'])).toBe('wsl')
+    expect(
+      classifySubprocessCommand('wsl.exe', [
+        '-d',
+        'Ubuntu',
+        '--',
+        '/bin/sh',
+        '-c',
+        "cd '/repo' && exec '/usr/bin/git' 'status'",
+        'orca:git status'
+      ])
+    ).toBe('git status')
   })
 
   it('falls back to the binary name when no subcommand exists', () => {

--- a/src/main/diagnostics/main-thread-churn-probe.ts
+++ b/src/main/diagnostics/main-thread-churn-probe.ts
@@ -49,6 +49,15 @@ export function classifySubprocessCommand(command: string, args: readonly string
       return 'wsl'
     }
     binary = binaryName(unwrapped)
+    if (binary === 'sh') {
+      const commandIndex = rest.findIndex((arg) => arg === '-c' || arg === '-lc')
+      const shellName = commandIndex < 0 ? undefined : rest[commandIndex + 2]
+      // Why: cached WSL git uses a non-login shell to preserve a version
+      // manager shim's cwd; its explicit $0 keeps churn evidence under git.
+      if (shellName?.startsWith('orca:git')) {
+        return shellName.slice('orca:'.length)
+      }
+    }
   }
   if (!SUBCOMMAND_BINARIES.has(binary)) {
     return binary

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -319,7 +319,7 @@ function createAbortError(): Error {
   return error
 }
 
-function killSpawnedCommandTree(child: ChildProcess): void {
+export function killSpawnedCommandTree(child: ChildProcess): void {
   const pid = child.pid
   if (!pid || process.platform !== 'win32') {
     child.kill()

--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -30,24 +30,40 @@ const {
 vi.mock('./runner', () => ({
   gitExecFileAsync: gitExecFileAsyncMock,
   gitExecFileAsyncBuffer: gitExecFileAsyncBufferMock,
-  // Why: getStatus now streams status output. The mock pulls the next queued
-  // stdout from gitExecFileAsyncMock and feeds it to onStdout, so existing tests
-  // that seed the status call via `gitExecFileAsyncMock.mockResolvedValueOnce`
-  // keep working unchanged and call ordering (status, then numstat) is preserved.
-  gitStreamStdout: async (
-    args: string[],
-    options: { onStdout: (chunk: string) => boolean | void }
-  ) => {
-    // Forward args so arg-routing mock implementations (e.g. `args.includes`)
-    // still match the status read.
-    const { stdout } = await gitExecFileAsyncMock(args)
-    const stoppedEarly = options.onStdout(stdout ?? '') === true
-    return { stoppedEarly }
-  },
   gitOptionalLocksDisabledEnv: (env: NodeJS.ProcessEnv = process.env) => ({
     ...env,
     GIT_OPTIONAL_LOCKS: '0'
   })
+}))
+
+vi.mock('./wsl-status-runner', () => ({
+  gitStatusExecFileAsync: gitExecFileAsyncMock
+}))
+
+vi.mock('./wsl-status-stream', () => ({
+  gitStatusStreamStdout: async (
+    args: string[],
+    options: { onStdout: (chunk: string) => boolean | void }
+  ) => {
+    const { stdout } = await gitExecFileAsyncMock(args)
+    return { stoppedEarly: options.onStdout(stdout ?? '') === true }
+  }
+}))
+
+vi.mock('./wsl-status-batch', () => ({
+  gitStatusExecBatchAsync: (commands: string[][], options: { signal?: AbortSignal }) =>
+    Promise.all(
+      commands.map(async (args) => {
+        try {
+          return await gitExecFileAsyncMock(args, options)
+        } catch (error) {
+          if (options.signal?.aborted) {
+            throw error
+          }
+          return null
+        }
+      })
+    )
 }))
 
 vi.mock('fs/promises', () => ({

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -31,12 +31,10 @@ import {
   type GitLineStats
 } from '../../shared/git-uncommitted-line-stats'
 import { decodeGitCQuotedPath } from '../../shared/git-cquoted-path'
-import {
-  gitExecFileAsync,
-  gitExecFileAsyncBuffer,
-  gitOptionalLocksDisabledEnv,
-  gitStreamStdout
-} from './runner'
+import { gitExecFileAsync, gitExecFileAsyncBuffer, gitOptionalLocksDisabledEnv } from './runner'
+import { gitStatusExecBatchAsync } from './wsl-status-batch'
+import { gitStatusExecFileAsync } from './wsl-status-runner'
+import { gitStatusStreamStdout } from './wsl-status-stream'
 import { StatusPorcelainParser } from './status-porcelain-parser'
 import { DEFAULT_GIT_STATUS_LIMIT } from '../../shared/git-status-limit'
 import { describeMaxBufferOverflowError, isMaxBufferOverflowError } from './max-buffer-overflow'
@@ -300,7 +298,7 @@ async function runGetStatus(
   const conflictOperation = await conflictPromise
 
   try {
-    const { stoppedEarly } = await gitStreamStdout(statusArgs, {
+    const { stoppedEarly } = await gitStatusStreamStdout(statusArgs, {
       cwd: worktreePath,
       wslDistro: options.wslDistro,
       // Why: status polling is read-like; avoid refreshing the index and racing
@@ -553,18 +551,10 @@ async function runNumstat(
   options: GitRuntimeOptions = {}
 ): Promise<Map<string, GitLineStats> | null> {
   try {
-    const { stdout } = await gitExecFileAsync(
-      [
-        '-c',
-        'core.quotePath=false',
-        'diff',
-        '-z',
-        ...(cached ? ['--cached'] : []),
-        '--numstat',
-        '-M'
-      ],
-      { ...gitOptionsForWorktree(worktreePath, options), env: gitOptionalLocksDisabledEnv() }
-    )
+    const { stdout } = await gitStatusExecFileAsync(numstatArgs(cached), {
+      ...gitOptionsForWorktree(worktreePath, options),
+      env: gitOptionalLocksDisabledEnv()
+    })
     return parseNumstat(stdout)
   } catch (error) {
     // Why: an aborted pass must reject so a cancelled scan is never treated as
@@ -578,6 +568,41 @@ async function runNumstat(
     // map) tells the caller the pass is incomplete and must not be cached.
     return null
   }
+}
+
+function numstatArgs(cached: boolean): string[] {
+  return [
+    '-c',
+    'core.quotePath=false',
+    'diff',
+    '-z',
+    ...(cached ? ['--cached'] : []),
+    '--numstat',
+    '-M'
+  ]
+}
+
+async function runTrackedNumstats(
+  worktreePath: string,
+  hasStaged: boolean,
+  hasUnstaged: boolean,
+  options: GitRuntimeOptions
+): Promise<[Map<string, GitLineStats> | null, Map<string, GitLineStats> | null]> {
+  const emptyStats = new Map<string, GitLineStats>()
+  if (!hasStaged || !hasUnstaged) {
+    return Promise.all([
+      hasStaged ? runNumstat(worktreePath, true, options) : Promise.resolve(emptyStats),
+      hasUnstaged ? runNumstat(worktreePath, false, options) : Promise.resolve(emptyStats)
+    ])
+  }
+  const results = await gitStatusExecBatchAsync([numstatArgs(true), numstatArgs(false)], {
+    ...gitOptionsForWorktree(worktreePath, options),
+    env: gitOptionalLocksDisabledEnv()
+  })
+  return [
+    results[0] ? parseNumstat(results[0].stdout) : null,
+    results[1] ? parseNumstat(results[1].stdout) : null
+  ]
 }
 
 /** Returns false when a numstat pass failed, so callers skip caching it. */
@@ -594,12 +619,11 @@ async function attachLineStats(
   const untrackedPaths = entries
     .filter((entry) => entry.area === 'untracked')
     .map((entry) => entry.path)
-  const emptyStats = new Map<string, GitLineStats>()
-  const [stagedStats, unstagedStats, untrackedStats] = await Promise.all([
-    hasStaged ? runNumstat(worktreePath, true, options) : Promise.resolve(emptyStats),
-    hasUnstaged ? runNumstat(worktreePath, false, options) : Promise.resolve(emptyStats),
+  const [[stagedStats, unstagedStats], untrackedStats] = await Promise.all([
+    runTrackedNumstats(worktreePath, hasStaged, hasUnstaged, options),
     collectUntrackedAdditions(worktreePath, untrackedPaths, options.signal)
   ])
+  const emptyStats = new Map<string, GitLineStats>()
   for (const entry of entries) {
     applyLineStats(
       entry,
@@ -804,7 +828,7 @@ async function probeOrRevalidateEffectiveUpstreamStatus(
   } else if (cached) {
     try {
       const status = await getGitUpstreamStatusForUpstreamName(
-        (args) => gitExecFileAsync(args, gitOptionsForWorktree(worktreePath, options)),
+        (args) => gitStatusExecFileAsync(args, gitOptionsForWorktree(worktreePath, options)),
         cached.upstreamName
       )
       return { status, probedSameNameOriginRef: false }
@@ -842,7 +866,7 @@ async function probeEffectiveUpstreamStatus(
 ): Promise<{ status: GitUpstreamStatus; probedSameNameOriginRef: boolean }> {
   let probedSameNameOriginRef = false
   const snapshotRunner = createGitConfigSnapshotRunner((args) =>
-    gitExecFileAsync(args, gitOptionsForWorktree(worktreePath, options))
+    gitStatusExecFileAsync(args, gitOptionsForWorktree(worktreePath, options))
   )
   const status = await getEffectiveGitUpstreamStatus((args) => {
     if (args[0] === 'rev-parse' && args.includes(`refs/remotes/origin/${branchName}`)) {

--- a/src/main/git/wsl-status-batch.test.ts
+++ b/src/main/git/wsl-status-batch.test.ts
@@ -1,0 +1,292 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  commandExecFileAsyncMock,
+  gitExecFileAsyncMock,
+  invalidateEnvironmentMock,
+  isCachedGitUnavailableMock,
+  readEnvironmentMock,
+  resolveTargetMock,
+  runLoginShellMock
+} = vi.hoisted(() => ({
+  commandExecFileAsyncMock: vi.fn(),
+  gitExecFileAsyncMock: vi.fn(),
+  invalidateEnvironmentMock: vi.fn(),
+  isCachedGitUnavailableMock: vi.fn(),
+  readEnvironmentMock: vi.fn(),
+  resolveTargetMock: vi.fn(),
+  runLoginShellMock: vi.fn()
+}))
+
+vi.mock('./runner', () => ({
+  DEFAULT_GIT_MAX_BUFFER: 10 * 1024 * 1024,
+  commandExecFileAsync: commandExecFileAsyncMock,
+  gitExecFileAsync: gitExecFileAsyncMock,
+  nonInteractiveGitEnv: (env: NodeJS.ProcessEnv = {}) => ({ ...env, GIT_TERMINAL_PROMPT: '0' })
+}))
+
+vi.mock('./wsl-status-environment', () => ({
+  invalidateWslStatusEnvironment: invalidateEnvironmentMock
+}))
+
+vi.mock('./wsl-status-runner', () => ({
+  cachedGitVerificationCommand: (gitPath: string) => `[ -x '${gitPath}' ] || exit 127`,
+  gitStatusExecFileAsync: gitExecFileAsyncMock,
+  isCachedGitUnavailable: isCachedGitUnavailableMock,
+  readWslStatusEnvironment: readEnvironmentMock,
+  resolveWslStatusTarget: resolveTargetMock,
+  runWslStatusLoginShellGit: runLoginShellMock,
+  translateWslStatusArg: (arg: string) => arg,
+  wslStatusEnvironmentAssignments: () => [
+    'PATH=/usr/bin',
+    'GIT_OPTIONAL_LOCKS=0',
+    'GIT_TERMINAL_PROMPT=0'
+  ]
+}))
+
+vi.mock('../observability/instrumentation', () => ({
+  withGitSpan: (_attributes: unknown, run: () => unknown) => run()
+}))
+
+import {
+  clearWslStatusBatchUnsafeCacheForTests,
+  gitStatusExecBatchAsync,
+  parseWslStatusBatchOutput
+} from './wsl-status-batch'
+
+const target = { distro: 'Ubuntu', linuxCwd: '/repo' }
+const environment = { gitPath: '/usr/bin/git', path: '/usr/bin' }
+const commands = [
+  ['diff', '--cached', '--numstat', '-z'],
+  ['diff', '--numstat', '-z']
+]
+const options = {
+  cwd: 'C:\\repo',
+  env: { GIT_OPTIONAL_LOCKS: '0' },
+  wslDistro: 'Ubuntu'
+}
+
+function framedOutput(script: string, outputs: string[], exitCodes = [0, 0]): string {
+  const token = script.match(/orca-status-batch-[a-f0-9]+/)?.[0]
+  if (!token) {
+    throw new Error('batch token missing from shell command')
+  }
+  return outputs
+    .map(
+      (output, index) =>
+        `${Buffer.from(output, 'utf8').toString('latin1')}\0\0${token}:${index}:rc=${exitCodes[index]}\0`
+    )
+    .join('')
+}
+
+beforeEach(() => {
+  clearWslStatusBatchUnsafeCacheForTests()
+  commandExecFileAsyncMock.mockReset()
+  gitExecFileAsyncMock.mockReset()
+  invalidateEnvironmentMock.mockReset()
+  isCachedGitUnavailableMock.mockReset()
+  readEnvironmentMock.mockReset().mockResolvedValue(environment)
+  resolveTargetMock.mockReset().mockReturnValue(target)
+  runLoginShellMock.mockReset()
+})
+
+describe('parseWslStatusBatchOutput', () => {
+  it('preserves NUL-delimited rename payloads behind collision-proof frames', () => {
+    const first = '1\t0\t\0old-name\0new-name\0'
+    const second = '3\t4\tsrc/file.ts\0'
+    const stdout = `${first}\0\0token:0:rc=0\0${second}\0\0token:1:rc=1\0`
+
+    expect(parseWslStatusBatchOutput(stdout, 'token', 2)).toEqual([
+      { output: first, exitCode: 0 },
+      { output: second, exitCode: 1 }
+    ])
+  })
+
+  it('rejects missing, reordered, or trailing frames', () => {
+    expect(parseWslStatusBatchOutput('\0\0token:1:rc=0\0', 'token', 2)).toBeNull()
+    expect(parseWslStatusBatchOutput('\0\0token:0:rc=0\0trailing', 'token', 1)).toBeNull()
+  })
+})
+
+describe('gitStatusExecBatchAsync', () => {
+  it('runs both numstats in one guarded WSL crossing and preserves an independent failure', async () => {
+    commandExecFileAsyncMock.mockImplementation(async (_binary: string, args: string[]) => ({
+      stdout: framedOutput(args[5], ['1\t0\ta.ts\0', ''], [0, 1]),
+      stderr: framedOutput(args[5], ['', ''], [0, 1])
+    }))
+
+    await expect(gitStatusExecBatchAsync(commands, options)).resolves.toEqual([
+      { stdout: '1\t0\ta.ts\0', stderr: '' },
+      null
+    ])
+    expect(commandExecFileAsyncMock).toHaveBeenCalledOnce()
+    const args = commandExecFileAsyncMock.mock.calls[0][1] as string[]
+    expect(args.slice(0, 5)).toEqual(['-d', 'Ubuntu', '--', '/bin/sh', '-c'])
+    expect(args[5]).toContain("cd '/repo'")
+    expect(args[5]).toContain("'GIT_OPTIONAL_LOCKS=0'")
+    expect(args[5]).toContain("'GIT_TERMINAL_PROMPT=0'")
+    expect(args[5]).toContain("'--cached'")
+    expect(args[5]).toContain("'--numstat'")
+    expect(args[5]).not.toContain('&&')
+  })
+
+  it('caches a direct fallback when framing is structurally invalid', async () => {
+    commandExecFileAsyncMock.mockResolvedValue({ stdout: 'not framed', stderr: '' })
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => ({
+      stdout: args.includes('--cached') ? 'staged' : 'unstaged',
+      stderr: ''
+    }))
+
+    const expected = [
+      { stdout: 'staged', stderr: '' },
+      { stdout: 'unstaged', stderr: '' }
+    ]
+    await expect(gitStatusExecBatchAsync(commands, options)).resolves.toEqual(expected)
+    await expect(gitStatusExecBatchAsync(commands, options)).resolves.toEqual(expected)
+    expect(commandExecFileAsyncMock).toHaveBeenCalledOnce()
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('enforces each command byte cap while preserving the other framed result', async () => {
+    commandExecFileAsyncMock.mockImplementation(async (_binary: string, args: string[]) => ({
+      stdout: framedOutput(args[5], ['é'.repeat(6), 'small']),
+      stderr: framedOutput(args[5], ['', ''])
+    }))
+
+    await expect(gitStatusExecBatchAsync(commands, { ...options, maxBuffer: 10 })).resolves.toEqual(
+      [null, { stdout: 'small', stderr: '' }]
+    )
+    const execOptions = commandExecFileAsyncMock.mock.calls[0][2] as { maxBuffer: number }
+    expect(execOptions.maxBuffer).toBeGreaterThan(20)
+  })
+
+  it('adds frame headroom when both command payloads reach their byte cap', async () => {
+    commandExecFileAsyncMock.mockImplementation(async (_binary: string, args: string[]) => ({
+      stdout: framedOutput(args[5], ['a'.repeat(10), 'b'.repeat(10)]),
+      stderr: framedOutput(args[5], ['', ''])
+    }))
+
+    await expect(gitStatusExecBatchAsync(commands, { ...options, maxBuffer: 10 })).resolves.toEqual(
+      [
+        { stdout: 'a'.repeat(10), stderr: '' },
+        { stdout: 'b'.repeat(10), stderr: '' }
+      ]
+    )
+  })
+
+  it('reruns separately when aggregate stdout overflow prevents a later command', async () => {
+    commandExecFileAsyncMock.mockImplementation(
+      async (_binary: string, args: string[], execOptions: { maxBuffer: number }) => {
+        const stdout = framedOutput(args[5], ['a'.repeat(21), 'small'])
+        expect(Buffer.byteLength(stdout)).toBeGreaterThan(execOptions.maxBuffer)
+        throw new Error('stdout exceeded maxBuffer')
+      }
+    )
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args.includes('--cached')) {
+        throw new Error('stdout exceeded maxBuffer')
+      }
+      return { stdout: 'small', stderr: '' }
+    })
+
+    const overflowOptions = { ...options, maxBuffer: 10 }
+    await expect(gitStatusExecBatchAsync(commands, overflowOptions)).resolves.toEqual([
+      null,
+      { stdout: 'small', stderr: '' }
+    ])
+    await expect(gitStatusExecBatchAsync(commands, overflowOptions)).resolves.toEqual([
+      null,
+      { stdout: 'small', stderr: '' }
+    ])
+    expect(commandExecFileAsyncMock).toHaveBeenCalledOnce()
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('preserves stderr attribution and independent caps without rerunning warnings', async () => {
+    commandExecFileAsyncMock.mockImplementation(async (_binary: string, args: string[]) => ({
+      stdout: framedOutput(args[5], ['batched staged', 'batched unstaged']),
+      stderr: framedOutput(args[5], ['warning from one command', ''])
+    }))
+
+    await expect(gitStatusExecBatchAsync(commands, options)).resolves.toEqual([
+      { stdout: 'batched staged', stderr: 'warning from one command' },
+      { stdout: 'batched unstaged', stderr: '' }
+    ])
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects only the command whose framed stderr exceeds its byte cap', async () => {
+    commandExecFileAsyncMock.mockImplementation(async (_binary: string, args: string[]) => ({
+      stdout: framedOutput(args[5], ['staged', 'unstaged']),
+      stderr: framedOutput(args[5], ['warning too large', ''])
+    }))
+
+    await expect(gitStatusExecBatchAsync(commands, { ...options, maxBuffer: 10 })).resolves.toEqual(
+      [null, { stdout: 'unstaged', stderr: '' }]
+    )
+  })
+
+  it('preserves a literal replacement character without an ambiguous rerun', async () => {
+    commandExecFileAsyncMock.mockImplementation(async (_binary: string, args: string[]) => ({
+      stdout: framedOutput(args[5], ['bad\uFFFDname', 'batched']),
+      stderr: framedOutput(args[5], ['', ''])
+    }))
+
+    await expect(gitStatusExecBatchAsync(commands, options)).resolves.toEqual([
+      { stdout: 'bad\uFFFDname', stderr: '' },
+      { stdout: 'batched', stderr: '' }
+    ])
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('invalidates and uses guarded fallbacks when the cached executable cannot launch', async () => {
+    const unavailable = Object.assign(new Error('missing cached git'), { code: 127 })
+    commandExecFileAsyncMock.mockRejectedValue(unavailable)
+    isCachedGitUnavailableMock.mockReturnValue(true)
+    runLoginShellMock.mockResolvedValue({ stdout: 'fallback', stderr: '' })
+
+    await expect(gitStatusExecBatchAsync(commands, options)).resolves.toEqual([
+      { stdout: 'fallback', stderr: '' },
+      { stdout: 'fallback', stderr: '' }
+    ])
+    expect(invalidateEnvironmentMock).toHaveBeenCalledWith('Ubuntu', environment)
+    expect(runLoginShellMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retry a genuine Git or batch-process failure', async () => {
+    commandExecFileAsyncMock.mockRejectedValue(
+      Object.assign(new Error('git failed'), { code: 128 })
+    )
+    isCachedGitUnavailableMock.mockReturnValue(false)
+
+    await expect(gitStatusExecBatchAsync(commands, options)).resolves.toEqual([null, null])
+    expect(runLoginShellMock).not.toHaveBeenCalled()
+    expect(invalidateEnvironmentMock).not.toHaveBeenCalled()
+  })
+
+  it('delegates native and SSH-provider-style execution without WSL batching', async () => {
+    resolveTargetMock.mockReturnValue(null)
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'native', stderr: '' })
+
+    await expect(gitStatusExecBatchAsync(commands, { cwd: '/repo' })).resolves.toEqual([
+      { stdout: 'native', stderr: '' },
+      { stdout: 'native', stderr: '' }
+    ])
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    expect(commandExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('propagates cancellation without starting fallbacks', async () => {
+    const controller = new AbortController()
+    const aborted = Object.assign(new Error('aborted'), { name: 'AbortError' })
+    commandExecFileAsyncMock.mockImplementation(async () => {
+      controller.abort()
+      throw aborted
+    })
+
+    await expect(
+      gitStatusExecBatchAsync(commands, { ...options, signal: controller.signal })
+    ).rejects.toBe(aborted)
+    expect(runLoginShellMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/git/wsl-status-batch.ts
+++ b/src/main/git/wsl-status-batch.ts
@@ -1,0 +1,262 @@
+import { randomBytes } from 'node:crypto'
+import { escapeWslShCommandForWindows, quotePosixShell } from '../../shared/wsl-login-shell-command'
+import { withGitSpan } from '../observability/instrumentation'
+import {
+  DEFAULT_GIT_MAX_BUFFER,
+  commandExecFileAsync,
+  gitExecFileAsync,
+  nonInteractiveGitEnv
+} from './runner'
+import { isMaxBufferOverflowError } from './max-buffer-overflow'
+import { invalidateWslStatusEnvironment, type WslStatusEnvironment } from './wsl-status-environment'
+import {
+  cachedGitVerificationCommand,
+  gitStatusExecFileAsync,
+  isCachedGitUnavailable,
+  readWslStatusEnvironment,
+  resolveWslStatusTarget,
+  runWslStatusLoginShellGit,
+  translateWslStatusArg,
+  wslStatusEnvironmentAssignments,
+  type WslStatusGitOptions,
+  type WslStatusTarget
+} from './wsl-status-runner'
+
+type GitResult = { stdout: string; stderr: string }
+type BatchFrame = { output: string; exitCode: number }
+
+const MAX_BATCH_UNSAFE_WORKTREES = 128
+const batchUnsafeWorktrees = new Map<string, true>()
+
+function batchWorktreeKey(target: WslStatusTarget): string {
+  return `${target.distro}\0${target.linuxCwd}`
+}
+
+function isBatchUnsafe(target: WslStatusTarget): boolean {
+  const key = batchWorktreeKey(target)
+  if (!batchUnsafeWorktrees.delete(key)) {
+    return false
+  }
+  batchUnsafeWorktrees.set(key, true)
+  return true
+}
+
+function markBatchUnsafe(target: WslStatusTarget): void {
+  const key = batchWorktreeKey(target)
+  batchUnsafeWorktrees.delete(key)
+  batchUnsafeWorktrees.set(key, true)
+  if (batchUnsafeWorktrees.size > MAX_BATCH_UNSAFE_WORKTREES) {
+    batchUnsafeWorktrees.delete(batchUnsafeWorktrees.keys().next().value!)
+  }
+}
+
+async function runSeparately(
+  commands: string[][],
+  options: WslStatusGitOptions,
+  run: (args: string[]) => Promise<GitResult>
+): Promise<(GitResult | null)[]> {
+  return Promise.all(
+    commands.map(async (args) => {
+      try {
+        return await run(args)
+      } catch (error) {
+        if (options.signal?.aborted) {
+          throw error
+        }
+        return null
+      }
+    })
+  )
+}
+
+function batchMarkerPrefix(token: string, index: number): string {
+  return `\0\0${token}:${index}:rc=`
+}
+
+function batchFramingHeadroom(token: string, commandCount: number): number {
+  let bytes = 0
+  for (let index = 0; index < commandCount; index += 1) {
+    // Shell exit statuses are 0..255; include the trailing NUL as well.
+    bytes += Buffer.byteLength(`${batchMarkerPrefix(token, index)}255\0`)
+  }
+  return bytes
+}
+
+export function parseWslStatusBatchOutput(
+  stdout: string,
+  token: string,
+  commandCount: number
+): BatchFrame[] | null {
+  const frames: BatchFrame[] = []
+  let cursor = 0
+  for (let index = 0; index < commandCount; index += 1) {
+    const prefix = batchMarkerPrefix(token, index)
+    const markerIndex = stdout.indexOf(prefix, cursor)
+    if (markerIndex < 0) {
+      return null
+    }
+    const codeStart = markerIndex + prefix.length
+    const codeEnd = stdout.indexOf('\0', codeStart)
+    const codeText = codeEnd < 0 ? '' : stdout.slice(codeStart, codeEnd)
+    if (!/^(?:0|[1-9]\d{0,2})$/.test(codeText)) {
+      return null
+    }
+    frames.push({ output: stdout.slice(cursor, markerIndex), exitCode: Number(codeText) })
+    cursor = codeEnd + 1
+  }
+  return cursor === stdout.length ? frames : null
+}
+
+function buildBatchCommand(
+  target: WslStatusTarget,
+  environment: WslStatusEnvironment,
+  commands: string[][],
+  spawnEnv: NodeJS.ProcessEnv,
+  token: string
+): string {
+  const prefix = [
+    '/usr/bin/env',
+    ...wslStatusEnvironmentAssignments(spawnEnv, environment.path),
+    environment.gitPath
+  ]
+    .map(quotePosixShell)
+    .join(' ')
+  const framedCommands = commands.map((args, index) => {
+    const command = `${prefix} ${args.map(translateWslStatusArg).map(quotePosixShell).join(' ')}`
+    const marker = `${token}:${index}:rc=`
+    // Why: numstat -z cannot contain a double-NUL field boundary, so this
+    // frame is collision-proof even when a repository controls path names.
+    // Why: Git warnings are text, so a random NUL-prefixed boundary preserves
+    // per-command stderr without rerunning warned-about commands.
+    const frame = `printf '\\000\\000%s%s\\000' ${quotePosixShell(marker)} "$_orca_rc"`
+    return `{ ${command}; _orca_rc=$?; ${frame}; ${frame} >&2; }`
+  })
+  return [
+    `cd ${quotePosixShell(target.linuxCwd)} || exit $?`,
+    cachedGitVerificationCommand(environment.gitPath),
+    ...framedCommands
+  ].join('; ')
+}
+
+function batchWslArgs(
+  target: WslStatusTarget,
+  environment: WslStatusEnvironment,
+  commands: string[][],
+  spawnEnv: NodeJS.ProcessEnv,
+  token: string
+): string[] {
+  const command = buildBatchCommand(target, environment, commands, spawnEnv, token)
+  return [
+    '-d',
+    target.distro,
+    '--',
+    '/bin/sh',
+    '-c',
+    escapeWslShCommandForWindows(command),
+    'orca:git diff'
+  ]
+}
+
+function cachedLaunchFailed(
+  frames: BatchFrame[],
+  stderr: string,
+  environment: WslStatusEnvironment
+): boolean {
+  if (!frames.every(({ exitCode }) => exitCode === 126 || exitCode === 127)) {
+    return false
+  }
+  const error = Object.assign(new Error(stderr), { code: frames[0].exitCode, stderr })
+  return isCachedGitUnavailable(error, environment.gitPath)
+}
+
+export async function gitStatusExecBatchAsync(
+  commands: string[][],
+  options: WslStatusGitOptions
+): Promise<(GitResult | null)[]> {
+  const target = resolveWslStatusTarget(options)
+  if (!target) {
+    return runSeparately(commands, options, (args) => gitExecFileAsync(args, options))
+  }
+  if (commands.length < 2) {
+    return runSeparately(commands, options, (args) => gitStatusExecFileAsync(args, options))
+  }
+  return withGitSpan({ args: commands[0], cwd: options.cwd }, async () => {
+    const spawnEnv = nonInteractiveGitEnv(options.env)
+    const cachedSeparateFallback = (): Promise<(GitResult | null)[]> =>
+      runSeparately(commands, options, (args) => gitStatusExecFileAsync(args, options))
+    const loginShellFallback = (): Promise<(GitResult | null)[]> =>
+      runSeparately(commands, options, (args) =>
+        runWslStatusLoginShellGit(target, args, options, spawnEnv)
+      )
+    if (isBatchUnsafe(target)) {
+      return cachedSeparateFallback()
+    }
+    const environment = await readWslStatusEnvironment(target, options.signal)
+    if (!environment) {
+      return loginShellFallback()
+    }
+    const token = `orca-status-batch-${randomBytes(16).toString('hex')}`
+    const perCommandMaxBuffer = options.maxBuffer ?? DEFAULT_GIT_MAX_BUFFER
+    let result: GitResult
+    try {
+      result = await commandExecFileAsync(
+        'wsl.exe',
+        batchWslArgs(target, environment, commands, spawnEnv, token),
+        {
+          env: spawnEnv,
+          encoding: 'latin1',
+          maxBuffer:
+            perCommandMaxBuffer * commands.length + batchFramingHeadroom(token, commands.length),
+          signal: options.signal,
+          timeout: options.timeout
+        }
+      )
+    } catch (error) {
+      if (options.signal?.aborted) {
+        throw error
+      }
+      if (isCachedGitUnavailable(error, environment.gitPath)) {
+        invalidateWslStatusEnvironment(target.distro, environment)
+        return loginShellFallback()
+      }
+      if (isMaxBufferOverflowError(error)) {
+        markBatchUnsafe(target)
+        return cachedSeparateFallback()
+      }
+      return commands.map(() => null)
+    }
+    const frames = parseWslStatusBatchOutput(result.stdout, token, commands.length)
+    const stderrFrames = parseWslStatusBatchOutput(result.stderr, token, commands.length)
+    if (
+      !frames ||
+      !stderrFrames ||
+      frames.some(({ exitCode }, index) => exitCode !== stderrFrames[index].exitCode)
+    ) {
+      markBatchUnsafe(target)
+      return cachedSeparateFallback()
+    }
+    const decode = (output: string): string => Buffer.from(output, 'latin1').toString('utf8')
+    const decodedStderr = stderrFrames.map(({ output }) => decode(output)).join('\n')
+    if (cachedLaunchFailed(frames, decodedStderr, environment)) {
+      invalidateWslStatusEnvironment(target.distro, environment)
+      return loginShellFallback()
+    }
+    return frames.map(({ output, exitCode }, index) => {
+      const stderr = stderrFrames[index].output
+      // Why: batching must preserve the old independent maxBuffer contract;
+      // one oversized area should not consume the other area's allowance.
+      if (
+        exitCode !== 0 ||
+        Buffer.byteLength(output, 'latin1') > perCommandMaxBuffer ||
+        Buffer.byteLength(stderr, 'latin1') > perCommandMaxBuffer
+      ) {
+        return null
+      }
+      return { stdout: decode(output), stderr: decode(stderr) }
+    })
+  })
+}
+
+export function clearWslStatusBatchUnsafeCacheForTests(): void {
+  batchUnsafeWorktrees.clear()
+}

--- a/src/main/git/wsl-status-environment.test.ts
+++ b/src/main/git/wsl-status-environment.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildWslStatusEnvironmentProbeCommand,
+  clearWslStatusEnvironmentCacheForTests,
+  invalidateWslStatusEnvironment,
+  parseWslStatusEnvironmentProbe,
+  resolveWslStatusEnvironment,
+  type WslStatusEnvironment
+} from './wsl-status-environment'
+
+const ubuntuEnvironment = { gitPath: '/usr/bin/git', path: '/usr/local/bin:/usr/bin' }
+
+afterEach(() => {
+  clearWslStatusEnvironmentCacheForTests()
+  vi.useRealTimers()
+})
+
+describe('WSL status environment probe', () => {
+  it('prints and parses a login-shell-resolved absolute git and PATH', () => {
+    expect(buildWslStatusEnvironmentProbeCommand()).toContain('command -v git')
+    expect(
+      parseWslStatusEnvironmentProbe(
+        `rc noise\n\0orca-wsl-status-environment-v1\0/usr/bin/git\0/usr/local/bin:/usr/bin\0`
+      )
+    ).toEqual(ubuntuEnvironment)
+    expect(parseWslStatusEnvironmentProbe('missing marker')).toBeNull()
+    expect(
+      parseWslStatusEnvironmentProbe(`\0orca-wsl-status-environment-v1\0relative/git\0/usr/bin\0`)
+    ).toBeNull()
+  })
+})
+
+describe('resolveWslStatusEnvironment', () => {
+  it('reuses the first result per distro and isolates different distros', async () => {
+    const probe = vi.fn(async (distro: string) =>
+      distro === 'Ubuntu'
+        ? ubuntuEnvironment
+        : { gitPath: '/opt/git/bin/git', path: '/opt/git/bin:/usr/bin' }
+    )
+
+    await expect(resolveWslStatusEnvironment('Ubuntu', probe)).resolves.toBe(ubuntuEnvironment)
+    await expect(resolveWslStatusEnvironment('Ubuntu', probe)).resolves.toBe(ubuntuEnvironment)
+    await expect(resolveWslStatusEnvironment('Debian', probe)).resolves.toEqual({
+      gitPath: '/opt/git/bin/git',
+      path: '/opt/git/bin:/usr/bin'
+    })
+
+    expect(probe).toHaveBeenCalledTimes(2)
+  })
+
+  it('coalesces concurrent probes for the same distro', async () => {
+    let finishProbe!: (environment: WslStatusEnvironment) => void
+    const pending = new Promise<WslStatusEnvironment>((resolve) => {
+      finishProbe = resolve
+    })
+    const probe = vi.fn(() => pending)
+
+    const first = resolveWslStatusEnvironment('Ubuntu', probe)
+    const second = resolveWslStatusEnvironment('Ubuntu', probe)
+    finishProbe(ubuntuEnvironment)
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      ubuntuEnvironment,
+      ubuntuEnvironment
+    ])
+    expect(probe).toHaveBeenCalledOnce()
+  })
+
+  it('lets one caller abort without cancelling or evicting the shared probe', async () => {
+    let finishProbe!: (environment: WslStatusEnvironment) => void
+    const pending = new Promise<WslStatusEnvironment>((resolve) => {
+      finishProbe = resolve
+    })
+    const probe = vi.fn(() => pending)
+    const controller = new AbortController()
+
+    const owner = resolveWslStatusEnvironment('Ubuntu', probe)
+    const waiter = resolveWslStatusEnvironment('Ubuntu', probe, controller.signal)
+    controller.abort()
+
+    await expect(waiter).rejects.toMatchObject({ name: 'AbortError' })
+    finishProbe(ubuntuEnvironment)
+    await expect(owner).resolves.toBe(ubuntuEnvironment)
+    await expect(resolveWslStatusEnvironment('Ubuntu', probe)).resolves.toBe(ubuntuEnvironment)
+    expect(probe).toHaveBeenCalledOnce()
+  })
+
+  it('negative-caches a rejected probe instead of doubling every fallback', async () => {
+    const probe = vi.fn().mockRejectedValue(new Error('broken login rc'))
+
+    await expect(resolveWslStatusEnvironment('Ubuntu', probe)).resolves.toBeNull()
+    await expect(resolveWslStatusEnvironment('Ubuntu', probe)).resolves.toBeNull()
+
+    expect(probe).toHaveBeenCalledOnce()
+  })
+
+  it('invalidates only the exact cached environment instance', async () => {
+    const probe = vi.fn().mockResolvedValue(ubuntuEnvironment)
+    await resolveWslStatusEnvironment('Ubuntu', probe)
+
+    invalidateWslStatusEnvironment('Ubuntu', { ...ubuntuEnvironment })
+    await resolveWslStatusEnvironment('Ubuntu', probe)
+    expect(probe).toHaveBeenCalledOnce()
+
+    invalidateWslStatusEnvironment('Ubuntu', ubuntuEnvironment)
+    await resolveWslStatusEnvironment('Ubuntu', probe)
+    expect(probe).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/git/wsl-status-environment.ts
+++ b/src/main/git/wsl-status-environment.ts
@@ -1,0 +1,121 @@
+const WSL_STATUS_ENVIRONMENT_MARKER = 'orca-wsl-status-environment-v1'
+
+export type WslStatusEnvironment = {
+  gitPath: string
+  path: string
+}
+
+type WslStatusEnvironmentProbe = (distro: string) => Promise<WslStatusEnvironment | null>
+
+const environmentsByDistro = new Map<string, WslStatusEnvironment | null>()
+const unavailableUntilByDistro = new Map<string, number>()
+const environmentProbesByDistro = new Map<string, Promise<WslStatusEnvironment | null>>()
+
+// Why: a broken login rc must not add a failed probe before every fallback,
+// but a transient distro startup failure should recover without restarting Orca.
+const WSL_STATUS_ENVIRONMENT_RETRY_MS = 5 * 60 * 1000
+
+function createAbortError(): Error {
+  const error = new Error('The operation was aborted.')
+  error.name = 'AbortError'
+  return error
+}
+
+function waitForProbe(
+  probe: Promise<WslStatusEnvironment | null>,
+  signal?: AbortSignal
+): Promise<WslStatusEnvironment | null> {
+  if (!signal) {
+    return probe
+  }
+  if (signal.aborted) {
+    return Promise.reject(createAbortError())
+  }
+  return new Promise((resolve, reject) => {
+    const onAbort = (): void => {
+      signal.removeEventListener('abort', onAbort)
+      reject(createAbortError())
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+    probe.then(resolve, reject).finally(() => signal.removeEventListener('abort', onAbort))
+  })
+}
+
+export function buildWslStatusEnvironmentProbeCommand(): string {
+  return [
+    '_orca_git_path=$(command -v git) || exit 127',
+    'case "$_orca_git_path" in /*) ;; *) exit 127 ;; esac',
+    '[ -x "$_orca_git_path" ] || exit 127',
+    `printf '\\000${WSL_STATUS_ENVIRONMENT_MARKER}\\000%s\\000%s\\000' "$_orca_git_path" "$PATH"`
+  ].join('\n')
+}
+
+export function parseWslStatusEnvironmentProbe(stdout: string): WslStatusEnvironment | null {
+  const marker = `\0${WSL_STATUS_ENVIRONMENT_MARKER}\0`
+  const markerIndex = stdout.lastIndexOf(marker)
+  if (markerIndex < 0) {
+    return null
+  }
+  const fields = stdout.slice(markerIndex + marker.length).split('\0')
+  const [gitPath, path] = fields
+  if (!gitPath?.startsWith('/') || gitPath.includes('\n') || !path) {
+    return null
+  }
+  return { gitPath, path }
+}
+
+export async function resolveWslStatusEnvironment(
+  distro: string,
+  probe: WslStatusEnvironmentProbe,
+  signal?: AbortSignal
+): Promise<WslStatusEnvironment | null> {
+  if (environmentsByDistro.has(distro)) {
+    const cached = environmentsByDistro.get(distro) ?? null
+    const unavailableUntil = unavailableUntilByDistro.get(distro) ?? 0
+    if (cached || unavailableUntil > Date.now()) {
+      return cached
+    }
+    environmentsByDistro.delete(distro)
+    unavailableUntilByDistro.delete(distro)
+  }
+  const activeProbe = environmentProbesByDistro.get(distro)
+  if (activeProbe) {
+    return waitForProbe(activeProbe, signal)
+  }
+
+  // Why: source-control reads from multiple worktrees can start together;
+  // source the distro's login files only once for the whole burst.
+  const nextProbe = probe(distro)
+    .catch(() => null)
+    .then((environment) => {
+      environmentsByDistro.set(distro, environment)
+      if (environment) {
+        unavailableUntilByDistro.delete(distro)
+      } else {
+        unavailableUntilByDistro.set(distro, Date.now() + WSL_STATUS_ENVIRONMENT_RETRY_MS)
+      }
+      return environment
+    })
+    .finally(() => {
+      if (environmentProbesByDistro.get(distro) === nextProbe) {
+        environmentProbesByDistro.delete(distro)
+      }
+    })
+  environmentProbesByDistro.set(distro, nextProbe)
+  return waitForProbe(nextProbe, signal)
+}
+
+export function invalidateWslStatusEnvironment(
+  distro: string,
+  expected: WslStatusEnvironment
+): void {
+  if (environmentsByDistro.get(distro) === expected) {
+    environmentsByDistro.delete(distro)
+  }
+}
+
+export function clearWslStatusEnvironmentCacheForTests(): void {
+  environmentsByDistro.clear()
+  unavailableUntilByDistro.clear()
+  environmentProbesByDistro.clear()
+}

--- a/src/main/git/wsl-status-runner.test.ts
+++ b/src/main/git/wsl-status-runner.test.ts
@@ -1,0 +1,238 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { commandExecFileAsyncMock, gitExecFileAsyncMock, nonInteractiveGitEnvMock } = vi.hoisted(
+  () => ({
+    commandExecFileAsyncMock: vi.fn(),
+    gitExecFileAsyncMock: vi.fn(),
+    nonInteractiveGitEnvMock: vi.fn((env: NodeJS.ProcessEnv = {}) => ({
+      ...env,
+      LANGUAGE: 'en',
+      LC_ALL: 'en_US.UTF-8',
+      LANG: 'en_US.UTF-8',
+      GIT_TERMINAL_PROMPT: '0',
+      GIT_ASKPASS: '',
+      SSH_ASKPASS: '',
+      GCM_INTERACTIVE: 'never',
+      GIT_SSH_COMMAND: 'ssh -o BatchMode=yes',
+      GIT_CONFIG_COUNT: '2',
+      GIT_CONFIG_KEY_0: 'credential.interactive',
+      GIT_CONFIG_VALUE_0: 'false',
+      GIT_CONFIG_KEY_1: 'credential.guiPrompt',
+      GIT_CONFIG_VALUE_1: 'false'
+    }))
+  })
+)
+
+vi.mock('./runner', () => ({
+  commandExecFileAsync: commandExecFileAsyncMock,
+  extractExecError: (error: unknown) => {
+    const detail = error as { stderr?: unknown; stdout?: unknown; message?: unknown }
+    return {
+      stderr: typeof detail?.stderr === 'string' ? detail.stderr : String(detail?.message ?? ''),
+      stdout: typeof detail?.stdout === 'string' ? detail.stdout : ''
+    }
+  },
+  gitExecFileAsync: gitExecFileAsyncMock,
+  nonInteractiveGitEnv: nonInteractiveGitEnvMock
+}))
+
+vi.mock('../observability/instrumentation', () => ({
+  withGitSpan: (_attributes: unknown, run: () => unknown) => run()
+}))
+
+import { clearWslStatusEnvironmentCacheForTests } from './wsl-status-environment'
+import {
+  directWslGitArgs,
+  gitStatusExecFileAsync,
+  loginShellWslGitArgs,
+  resolveWslStatusTarget
+} from './wsl-status-runner'
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+const probeOutput = '\0orca-wsl-status-environment-v1\0/usr/bin/git\0/home/me/.local/bin:/usr/bin\0'
+
+function stubPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+}
+
+function wslOptions(distro = 'Ubuntu'): {
+  cwd: string
+  env: NodeJS.ProcessEnv
+  wslDistro: string
+} {
+  return { cwd: 'C:\\repo', env: { GIT_OPTIONAL_LOCKS: '0' }, wslDistro: distro }
+}
+
+beforeEach(() => {
+  stubPlatform('win32')
+  clearWslStatusEnvironmentCacheForTests()
+  commandExecFileAsyncMock.mockReset()
+  gitExecFileAsyncMock.mockReset()
+  nonInteractiveGitEnvMock.mockClear()
+})
+
+afterAll(() => {
+  if (originalPlatform) {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  }
+})
+
+describe('resolveWslStatusTarget', () => {
+  it('supports both UNC forms and an explicit distro for drive paths', () => {
+    expect(resolveWslStatusTarget({ cwd: '\\\\wsl.localhost\\Ubuntu\\home\\me\\repo' })).toEqual({
+      distro: 'Ubuntu',
+      linuxCwd: '/home/me/repo'
+    })
+    expect(resolveWslStatusTarget({ cwd: '\\\\wsl$\\Debian\\srv\\repo' })).toEqual({
+      distro: 'Debian',
+      linuxCwd: '/srv/repo'
+    })
+    expect(resolveWslStatusTarget({ cwd: 'D:\\src\\repo', wslDistro: 'Ubuntu' })).toEqual({
+      distro: 'Ubuntu',
+      linuxCwd: '/mnt/d/src/repo'
+    })
+  })
+
+  it('leaves native and SSH-style local execution unchanged', () => {
+    stubPlatform('linux')
+    expect(resolveWslStatusTarget({ cwd: '/repo', wslDistro: 'Ubuntu' })).toBeNull()
+  })
+})
+
+describe('directWslGitArgs', () => {
+  it('runs from the repository cwd with cached PATH and all guards inside WSL', () => {
+    const args = directWslGitArgs(
+      { distro: 'Ubuntu', linuxCwd: '/home/me/repo' },
+      { gitPath: '/home/me/.local/share/mise/shims/git', path: '/home/me/.local/bin:/usr/bin' },
+      ['status', '--porcelain=v2'],
+      nonInteractiveGitEnvMock({ GIT_OPTIONAL_LOCKS: '1' })
+    )
+    const command = args[5]
+
+    expect(args.slice(0, 5)).toEqual(['-d', 'Ubuntu', '--', '/bin/sh', '-c'])
+    expect(args[6]).toBe('orca:git status')
+    expect(command).toContain("cd '/home/me/repo'")
+    expect(command).toContain("'PATH=/home/me/.local/bin:/usr/bin'")
+    expect(command).toContain("'/home/me/.local/share/mise/shims/git' 'status'")
+    expect(command).toContain("'GIT_OPTIONAL_LOCKS=0'")
+    expect(command).toContain("'GIT_TERMINAL_PROMPT=0'")
+    expect(command).toContain("'GIT_SSH_COMMAND=ssh -o BatchMode=yes'")
+    expect(command).toContain("'GIT_CONFIG_KEY_0=credential.interactive'")
+    expect(command).not.toContain("'-C'")
+  })
+
+  it('keeps login-shell git functions available in the guarded fallback', () => {
+    const args = loginShellWslGitArgs(
+      { distro: 'Ubuntu', linuxCwd: '/repo' },
+      ['status'],
+      nonInteractiveGitEnvMock({ GIT_OPTIONAL_LOCKS: '1' })
+    )
+    const command = args[5]
+
+    expect(command).toContain(String.raw`GIT_OPTIONAL_LOCKS='\''0'\''`)
+    expect(command).toContain(String.raw`GIT_TERMINAL_PROMPT='\''0'\''`)
+    expect(command).toContain(String.raw`'\''git'\'' '\''status'\''`)
+    expect(command).not.toContain("'/usr/bin/env'")
+  })
+})
+
+describe('gitStatusExecFileAsync', () => {
+  it('resolves once and reuses the cached environment for later calls', async () => {
+    commandExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: probeOutput, stderr: '' })
+      .mockResolvedValue({ stdout: 'ok', stderr: '' })
+
+    await gitStatusExecFileAsync(['status'], wslOptions())
+    await gitStatusExecFileAsync(['rev-list', '--count', 'HEAD'], wslOptions())
+
+    expect(commandExecFileAsyncMock).toHaveBeenCalledTimes(3)
+    const scripts = commandExecFileAsyncMock.mock.calls.map(([, args]) => args as string[])
+    const probes = scripts.filter((args) => args[5]?.includes('orca-wsl-status-environment-v1'))
+    expect(probes).toHaveLength(1)
+    expect(scripts.filter((args) => args[4] === '-c')).toHaveLength(2)
+  })
+
+  it('keeps environment probes isolated per distro', async () => {
+    commandExecFileAsyncMock.mockImplementation(async (_command: string, args: string[]) =>
+      args[5]?.includes('orca-wsl-status-environment-v1')
+        ? { stdout: probeOutput, stderr: '' }
+        : { stdout: 'ok', stderr: '' }
+    )
+
+    await gitStatusExecFileAsync(['status'], wslOptions('Ubuntu'))
+    await gitStatusExecFileAsync(['status'], wslOptions('Debian'))
+
+    const probes = commandExecFileAsyncMock.mock.calls.filter(([, args]) =>
+      (args as string[])[5]?.includes('orca-wsl-status-environment-v1')
+    )
+    expect(probes.map(([, args]) => (args as string[])[1])).toEqual(['Ubuntu', 'Debian'])
+  })
+
+  it('uses a guarded login-shell fallback and negative-caches a failed probe', async () => {
+    commandExecFileAsyncMock
+      .mockRejectedValueOnce(new Error('login rc failed'))
+      .mockResolvedValue({ stdout: 'fallback', stderr: '' })
+
+    await expect(gitStatusExecFileAsync(['status'], wslOptions())).resolves.toEqual({
+      stdout: 'fallback',
+      stderr: ''
+    })
+    await gitStatusExecFileAsync(['status'], wslOptions())
+
+    expect(commandExecFileAsyncMock).toHaveBeenCalledTimes(3)
+    const fallbackArgs = commandExecFileAsyncMock.mock.calls[1][1] as string[]
+    expect(fallbackArgs[4]).toBe('-lc')
+    expect(fallbackArgs[5]).toContain(String.raw`GIT_OPTIONAL_LOCKS='\''0'\''`)
+    expect(fallbackArgs[5]).toContain(String.raw`GIT_TERMINAL_PROMPT='\''0'\''`)
+    expect(fallbackArgs[5]).toContain(String.raw`GIT_CONFIG_KEY_1='\''credential.guiPrompt'\''`)
+  })
+
+  it('invalidates a missing cached executable and retries once through login resolution', async () => {
+    const unavailable = Object.assign(new Error('cached git missing'), {
+      code: 127,
+      stderr: 'orca-wsl-status-cached-git-unavailable:/usr/bin/git'
+    })
+    commandExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: probeOutput, stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'first', stderr: '' })
+      .mockRejectedValueOnce(unavailable)
+      .mockResolvedValueOnce({ stdout: 'fallback', stderr: '' })
+      .mockResolvedValueOnce({ stdout: probeOutput, stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'third', stderr: '' })
+
+    await gitStatusExecFileAsync(['status'], wslOptions())
+    await expect(gitStatusExecFileAsync(['status'], wslOptions())).resolves.toMatchObject({
+      stdout: 'fallback'
+    })
+    await expect(gitStatusExecFileAsync(['status'], wslOptions())).resolves.toMatchObject({
+      stdout: 'third'
+    })
+
+    expect(commandExecFileAsyncMock).toHaveBeenCalledTimes(6)
+    expect((commandExecFileAsyncMock.mock.calls[3][1] as string[])[4]).toBe('-lc')
+  })
+
+  it('does not retry a genuine Git error', async () => {
+    const gitError = Object.assign(new Error('fatal: bad revision'), {
+      code: 128,
+      stderr: 'fatal: bad revision'
+    })
+    commandExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: probeOutput, stderr: '' })
+      .mockRejectedValueOnce(gitError)
+
+    await expect(gitStatusExecFileAsync(['rev-list', 'bad'], wslOptions())).rejects.toBe(gitError)
+    expect(commandExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('delegates native execution to the unchanged generic runner', async () => {
+    stubPlatform('linux')
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'native', stderr: '' })
+
+    await expect(gitStatusExecFileAsync(['status'], { cwd: '/repo' })).resolves.toMatchObject({
+      stdout: 'native'
+    })
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['status'], { cwd: '/repo' })
+    expect(commandExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/git/wsl-status-runner.ts
+++ b/src/main/git/wsl-status-runner.ts
@@ -1,0 +1,293 @@
+import { UNTRANSLATED_GIT_OUTPUT_ENV } from '../../shared/git-output-locale'
+import { readValidGitConfigEnvCount } from '../../shared/git-credential-prompt-env'
+import {
+  buildWslLoginShellCommand,
+  escapeWslShCommandForWindows,
+  quotePosixShell
+} from '../../shared/wsl-login-shell-command'
+import { withGitSpan } from '../observability/instrumentation'
+import { parseWslPath } from '../wsl'
+import {
+  commandExecFileAsync,
+  extractExecError,
+  gitExecFileAsync,
+  nonInteractiveGitEnv
+} from './runner'
+import {
+  buildWslStatusEnvironmentProbeCommand,
+  invalidateWslStatusEnvironment,
+  parseWslStatusEnvironmentProbe,
+  resolveWslStatusEnvironment,
+  type WslStatusEnvironment
+} from './wsl-status-environment'
+
+export type WslStatusGitOptions = {
+  cwd: string
+  env?: NodeJS.ProcessEnv
+  maxBuffer?: number
+  signal?: AbortSignal
+  timeout?: number
+  wslDistro?: string
+}
+
+export type WslStatusTarget = {
+  distro: string
+  linuxCwd: string
+}
+
+const DEFAULT_WSL_SSH_COMMAND = 'ssh -o BatchMode=yes'
+const WSL_STATUS_ENVIRONMENT_PROBE_TIMEOUT_MS = 15_000
+const CACHED_GIT_UNAVAILABLE_MARKER = 'orca-wsl-status-cached-git-unavailable:'
+const GIT_VALUE_FLAGS = new Set(['-C', '-c', '--git-dir', '--work-tree', '--exec-path'])
+
+export function translateWslStatusArg(arg: string): string {
+  const wslPath = parseWslPath(arg)
+  if (wslPath) {
+    return wslPath.linuxPath
+  }
+  const drivePath = arg.match(/^([A-Za-z]):[/\\](.*)$/)
+  if (!drivePath) {
+    return arg
+  }
+  return `/mnt/${drivePath[1].toLowerCase()}/${drivePath[2].replace(/\\/g, '/')}`
+}
+
+export function resolveWslStatusTarget(options: WslStatusGitOptions): WslStatusTarget | null {
+  if (process.platform !== 'win32') {
+    return null
+  }
+  const cwdWsl = parseWslPath(options.cwd)
+  const distro = cwdWsl?.distro ?? options.wslDistro
+  if (!distro) {
+    return null
+  }
+  return { distro, linuxCwd: cwdWsl?.linuxPath ?? translateWslStatusArg(options.cwd) }
+}
+
+export function wslStatusEnvironmentAssignments(
+  spawnEnv: NodeJS.ProcessEnv,
+  path?: string
+): string[] {
+  const assignments = [
+    ...(path ? [`PATH=${path}`] : []),
+    ...Object.entries(UNTRANSLATED_GIT_OUTPUT_ENV).map(([key, value]) => `${key}=${value}`),
+    'GIT_OPTIONAL_LOCKS=0',
+    'GIT_TERMINAL_PROMPT=0',
+    'GIT_ASKPASS=',
+    'SSH_ASKPASS=',
+    'GCM_INTERACTIVE=never'
+  ]
+  // Why: forward only Orca's Linux-safe default; a caller may have supplied a
+  // Windows-specific ssh path which must not leak into the distro.
+  if (spawnEnv.GIT_SSH_COMMAND === DEFAULT_WSL_SSH_COMMAND) {
+    assignments.push(`GIT_SSH_COMMAND=${DEFAULT_WSL_SSH_COMMAND}`)
+  }
+  const configCount = readValidGitConfigEnvCount(spawnEnv)
+  if (configCount === null) {
+    return assignments
+  }
+  assignments.push(`GIT_CONFIG_COUNT=${configCount}`)
+  for (let index = 0; index < configCount; index += 1) {
+    assignments.push(`GIT_CONFIG_KEY_${index}=${spawnEnv[`GIT_CONFIG_KEY_${index}`]}`)
+    assignments.push(`GIT_CONFIG_VALUE_${index}=${spawnEnv[`GIT_CONFIG_VALUE_${index}`]}`)
+  }
+  return assignments
+}
+
+async function probeWslStatusEnvironment(distro: string): Promise<WslStatusEnvironment | null> {
+  // Why: this cache is distro-scoped; resolving from one repository would
+  // leak its directory-specific PATH into every other worktree in the distro.
+  const command = buildWslLoginShellCommand(buildWslStatusEnvironmentProbeCommand())
+  const { stdout } = await commandExecFileAsync(
+    'wsl.exe',
+    ['-d', distro, '--', '/bin/sh', '-lc', escapeWslShCommandForWindows(command)],
+    {
+      env: nonInteractiveGitEnv(),
+      maxBuffer: 256 * 1024,
+      timeout: WSL_STATUS_ENVIRONMENT_PROBE_TIMEOUT_MS
+    }
+  )
+  return parseWslStatusEnvironmentProbe(stdout)
+}
+
+export async function readWslStatusEnvironment(
+  target: WslStatusTarget,
+  signal?: AbortSignal
+): Promise<WslStatusEnvironment | null> {
+  return resolveWslStatusEnvironment(target.distro, probeWslStatusEnvironment, signal)
+}
+
+function gitDiagnosticShellName(args: string[]): string {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (!arg.startsWith('-')) {
+      return `orca:git ${arg.slice(0, 40)}`
+    }
+    if (GIT_VALUE_FLAGS.has(arg)) {
+      index++
+    }
+  }
+  return 'orca:git'
+}
+
+function buildShellGitCommand(
+  target: WslStatusTarget,
+  executable: string,
+  args: string[],
+  assignments: string[],
+  verifyCachedExecutable: boolean
+): string {
+  const commandArgs = [executable, ...args.map(translateWslStatusArg)]
+    .map(quotePosixShell)
+    .join(' ')
+  const command = verifyCachedExecutable
+    ? `exec ${['/usr/bin/env', ...assignments].map(quotePosixShell).join(' ')} ${commandArgs}`
+    : `${assignments.map(quoteShellEnvironmentAssignment).join(' ')} ${commandArgs}`
+  const verification = verifyCachedExecutable ? `${cachedGitVerificationCommand(executable)}; ` : ''
+  // Why: cd before invoking a cached mise/asdf shim; git -C changes Git's cwd
+  // only after a version-manager shim has already selected its binary.
+  return `cd ${quotePosixShell(target.linuxCwd)} || exit $?; ${verification}${command}`
+}
+
+function quoteShellEnvironmentAssignment(assignment: string): string {
+  const separator = assignment.indexOf('=')
+  const key = assignment.slice(0, separator)
+  const value = assignment.slice(separator + 1)
+  return `${key}=${quotePosixShell(value)}`
+}
+
+export function cachedGitVerificationCommand(executable: string): string {
+  return `[ -x ${quotePosixShell(executable)} ] || { printf '%s%s\\n' ${quotePosixShell(CACHED_GIT_UNAVAILABLE_MARKER)} ${quotePosixShell(executable)} >&2; exit 127; }`
+}
+
+function shellWslArgs(target: WslStatusTarget, command: string, args: string[]): string[] {
+  return [
+    '-d',
+    target.distro,
+    '--',
+    '/bin/sh',
+    '-c',
+    escapeWslShCommandForWindows(command),
+    gitDiagnosticShellName(args)
+  ]
+}
+
+export function directWslGitArgs(
+  target: WslStatusTarget,
+  environment: WslStatusEnvironment,
+  args: string[],
+  spawnEnv: NodeJS.ProcessEnv
+): string[] {
+  return shellWslArgs(
+    target,
+    buildShellGitCommand(
+      target,
+      environment.gitPath,
+      args,
+      wslStatusEnvironmentAssignments(spawnEnv, environment.path),
+      true
+    ),
+    args
+  )
+}
+
+export function loginShellWslGitArgs(
+  target: WslStatusTarget,
+  args: string[],
+  spawnEnv: NodeJS.ProcessEnv
+): string[] {
+  const command = buildShellGitCommand(
+    target,
+    'git',
+    args,
+    wslStatusEnvironmentAssignments(spawnEnv),
+    false
+  )
+  return [
+    '-d',
+    target.distro,
+    '--',
+    '/bin/sh',
+    '-lc',
+    escapeWslShCommandForWindows(buildWslLoginShellCommand(command)),
+    gitDiagnosticShellName(args)
+  ]
+}
+
+function errorExitCode(error: unknown): number | null {
+  if (!error || typeof error !== 'object') {
+    return null
+  }
+  const code = (error as { code?: unknown }).code
+  if (typeof code === 'number') {
+    return code
+  }
+  return typeof code === 'string' && /^\d+$/.test(code) ? Number(code) : null
+}
+
+export function isCachedGitUnavailable(error: unknown, gitPath: string): boolean {
+  const code = errorExitCode(error)
+  if (code !== 126 && code !== 127) {
+    return false
+  }
+  const { stderr } = extractExecError(error)
+  const detail = `${stderr}\n${error instanceof Error ? error.message : ''}`.toLowerCase()
+  const normalizedPath = gitPath.toLowerCase()
+  return (
+    detail.includes(`${CACHED_GIT_UNAVAILABLE_MARKER}${normalizedPath}`) ||
+    (detail.includes(normalizedPath) &&
+      (detail.includes('no such file or directory') ||
+        detail.includes('permission denied') ||
+        detail.includes('not found') ||
+        detail.includes('cannot execute')))
+  )
+}
+
+export async function runWslStatusLoginShellGit(
+  target: WslStatusTarget,
+  args: string[],
+  options: WslStatusGitOptions,
+  spawnEnv: NodeJS.ProcessEnv
+): Promise<{ stdout: string; stderr: string }> {
+  return commandExecFileAsync('wsl.exe', loginShellWslGitArgs(target, args, spawnEnv), {
+    env: spawnEnv,
+    maxBuffer: options.maxBuffer,
+    signal: options.signal,
+    timeout: options.timeout
+  })
+}
+
+export async function gitStatusExecFileAsync(
+  args: string[],
+  options: WslStatusGitOptions
+): Promise<{ stdout: string; stderr: string }> {
+  const target = resolveWslStatusTarget(options)
+  if (!target) {
+    return gitExecFileAsync(args, options)
+  }
+  return withGitSpan({ args, cwd: options.cwd }, async () => {
+    const spawnEnv = nonInteractiveGitEnv(options.env)
+    const environment = await readWslStatusEnvironment(target, options.signal)
+    if (!environment) {
+      return runWslStatusLoginShellGit(target, args, options, spawnEnv)
+    }
+    try {
+      return await commandExecFileAsync(
+        'wsl.exe',
+        directWslGitArgs(target, environment, args, spawnEnv),
+        {
+          env: spawnEnv,
+          maxBuffer: options.maxBuffer,
+          signal: options.signal,
+          timeout: options.timeout
+        }
+      )
+    } catch (error) {
+      if (options.signal?.aborted || !isCachedGitUnavailable(error, environment.gitPath)) {
+        throw error
+      }
+      invalidateWslStatusEnvironment(target.distro, environment)
+      return runWslStatusLoginShellGit(target, args, options, spawnEnv)
+    }
+  })
+}

--- a/src/main/git/wsl-status-stream.test.ts
+++ b/src/main/git/wsl-status-stream.test.ts
@@ -1,0 +1,248 @@
+import { EventEmitter } from 'node:events'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as WslStatusEnvironmentModule from './wsl-status-environment'
+import type * as WslStatusRunnerModule from './wsl-status-runner'
+
+const {
+  gitStreamStdoutMock,
+  invalidateEnvironmentMock,
+  killSpawnedCommandTreeMock,
+  readEnvironmentMock,
+  wslAwareSpawnMock
+} = vi.hoisted(() => ({
+  gitStreamStdoutMock: vi.fn(),
+  invalidateEnvironmentMock: vi.fn(),
+  killSpawnedCommandTreeMock: vi.fn(),
+  readEnvironmentMock: vi.fn(),
+  wslAwareSpawnMock: vi.fn()
+}))
+
+vi.mock('../observability/instrumentation', () => ({
+  withGitSpan: (_details: unknown, operation: () => unknown) => operation()
+}))
+
+vi.mock('./runner', () => ({
+  DEFAULT_GIT_MAX_BUFFER: 1024,
+  commandExecFileAsync: vi.fn(),
+  extractExecError: (error: unknown) => {
+    const detail = error as { message?: unknown; stderr?: unknown; stdout?: unknown }
+    return {
+      stderr:
+        typeof detail?.stderr === 'string'
+          ? detail.stderr
+          : typeof detail?.message === 'string'
+            ? detail.message
+            : '',
+      stdout: typeof detail?.stdout === 'string' ? detail.stdout : ''
+    }
+  },
+  gitExecFileAsync: vi.fn(),
+  gitStreamStdout: gitStreamStdoutMock,
+  killSpawnedCommandTree: killSpawnedCommandTreeMock,
+  nonInteractiveGitEnv: (env: NodeJS.ProcessEnv = {}) => ({
+    ...env,
+    GIT_OPTIONAL_LOCKS: '0',
+    GIT_TERMINAL_PROMPT: '0',
+    GIT_SSH_COMMAND: 'ssh -o BatchMode=yes'
+  }),
+  wslAwareSpawn: wslAwareSpawnMock
+}))
+
+vi.mock('./wsl-status-environment', async (importOriginal) => {
+  const actual = await importOriginal<typeof WslStatusEnvironmentModule>()
+  return { ...actual, invalidateWslStatusEnvironment: invalidateEnvironmentMock }
+})
+
+vi.mock('./wsl-status-runner', async (importOriginal) => {
+  const actual = await importOriginal<typeof WslStatusRunnerModule>()
+  return { ...actual, readWslStatusEnvironment: readEnvironmentMock }
+})
+
+import { gitStatusStreamStdout } from './wsl-status-stream'
+
+type MockChildProcess = EventEmitter & {
+  stdout: EventEmitter
+  stderr: EventEmitter
+}
+
+const environment = {
+  gitPath: '/opt/git/bin/git',
+  path: '/opt/git/bin:/usr/bin:/bin'
+}
+
+function createChild(): MockChildProcess {
+  const child = new EventEmitter() as MockChildProcess
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  return child
+}
+
+function streamOptions(overrides: Record<string, unknown> = {}) {
+  return {
+    cwd: '\\\\wsl.localhost\\Ubuntu\\repo',
+    onStdout: vi.fn(),
+    ...overrides
+  }
+}
+
+async function waitForSpawn(count: number): Promise<void> {
+  await vi.waitFor(() => expect(wslAwareSpawnMock).toHaveBeenCalledTimes(count))
+}
+
+function queueChildren(...children: MockChildProcess[]): void {
+  wslAwareSpawnMock.mockImplementation(() => children.shift())
+}
+
+describe('gitStatusStreamStdout', () => {
+  const originalPlatform = process.platform
+
+  beforeAll(() => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+  })
+
+  afterAll(() => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: originalPlatform
+    })
+  })
+
+  beforeEach(() => {
+    gitStreamStdoutMock.mockReset()
+    invalidateEnvironmentMock.mockReset()
+    killSpawnedCommandTreeMock.mockReset()
+    readEnvironmentMock.mockReset()
+    wslAwareSpawnMock.mockReset()
+    readEnvironmentMock.mockResolvedValue(environment)
+  })
+
+  it('delegates native worktrees to the existing stream runner', async () => {
+    const options = streamOptions({ cwd: 'C:\\repo' })
+    gitStreamStdoutMock.mockResolvedValue({ stoppedEarly: true })
+
+    await expect(gitStatusStreamStdout(['status'], options)).resolves.toEqual({
+      stoppedEarly: true
+    })
+
+    expect(gitStreamStdoutMock).toHaveBeenCalledWith(['status'], options)
+    expect(readEnvironmentMock).not.toHaveBeenCalled()
+    expect(wslAwareSpawnMock).not.toHaveBeenCalled()
+  })
+
+  it('uses a guarded login shell when environment resolution is unavailable', async () => {
+    const child = createChild()
+    const onStdout = vi.fn()
+    readEnvironmentMock.mockResolvedValue(null)
+    queueChildren(child)
+
+    const promise = gitStatusStreamStdout(['status', '--porcelain=v2'], streamOptions({ onStdout }))
+    await waitForSpawn(1)
+    child.stdout.emit('data', Buffer.from('1 .M file.txt\n'))
+    child.emit('close', 0)
+
+    await expect(promise).resolves.toEqual({ stoppedEarly: false })
+    expect(onStdout).toHaveBeenCalledWith('1 .M file.txt\n')
+    const args = wslAwareSpawnMock.mock.calls[0][1] as string[]
+    const command = args.join(' ')
+    expect(args.slice(0, 5)).toEqual(['-d', 'Ubuntu', '--', '/bin/sh', '-lc'])
+    expect(command).toContain(String.raw`GIT_OPTIONAL_LOCKS='\''0'\''`)
+    expect(command).toContain(String.raw`GIT_TERMINAL_PROMPT='\''0'\''`)
+    expect(command).toContain('GIT_ASKPASS=')
+    expect(command).toContain('SSH_ASKPASS=')
+    expect(command).toContain(String.raw`GCM_INTERACTIVE='\''never'\''`)
+  })
+
+  it.each([126, 127])(
+    'retries cached Git exit %i once through the login shell before stdout',
+    async (exitCode) => {
+      const direct = createChild()
+      const fallback = createChild()
+      queueChildren(direct, fallback)
+
+      const promise = gitStatusStreamStdout(['status'], streamOptions())
+      await waitForSpawn(1)
+      direct.stderr.emit(
+        'data',
+        Buffer.from('orca-wsl-status-cached-git-unavailable:/opt/git/bin/git\n')
+      )
+      direct.emit('close', exitCode)
+      await waitForSpawn(2)
+      fallback.emit('close', 0)
+
+      await expect(promise).resolves.toEqual({ stoppedEarly: false })
+      expect(wslAwareSpawnMock).toHaveBeenCalledTimes(2)
+      expect(invalidateEnvironmentMock).toHaveBeenCalledWith('Ubuntu', environment)
+      const directArgs = wslAwareSpawnMock.mock.calls[0][1] as string[]
+      const fallbackArgs = wslAwareSpawnMock.mock.calls[1][1] as string[]
+      expect(directArgs[4]).toBe('-c')
+      expect(fallbackArgs[4]).toBe('-lc')
+    }
+  )
+
+  it('does not retry a cached-launch error after streaming any stdout', async () => {
+    const child = createChild()
+    const onStdout = vi.fn()
+    queueChildren(child)
+
+    const promise = gitStatusStreamStdout(['status'], streamOptions({ onStdout }))
+    const rejection = expect(promise).rejects.toMatchObject({ code: 127, sawStdout: true })
+    await waitForSpawn(1)
+    child.stdout.emit('data', Buffer.from('partial'))
+    child.stderr.emit(
+      'data',
+      Buffer.from('orca-wsl-status-cached-git-unavailable:/opt/git/bin/git\n')
+    )
+    child.emit('close', 127)
+
+    await rejection
+    expect(onStdout).toHaveBeenCalledWith('partial')
+    expect(wslAwareSpawnMock).toHaveBeenCalledTimes(1)
+    expect(invalidateEnvironmentMock).not.toHaveBeenCalled()
+  })
+
+  it('kills an active WSL command and rejects on abort without retrying', async () => {
+    const child = createChild()
+    const controller = new AbortController()
+    queueChildren(child)
+
+    const promise = gitStatusStreamStdout(['status'], streamOptions({ signal: controller.signal }))
+    const rejection = expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+    await waitForSpawn(1)
+    controller.abort()
+
+    await rejection
+    expect(killSpawnedCommandTreeMock).toHaveBeenCalledWith(child)
+    expect(wslAwareSpawnMock).toHaveBeenCalledTimes(1)
+    expect(invalidateEnvironmentMock).not.toHaveBeenCalled()
+  })
+
+  it('enforces maxBuffer without falling back', async () => {
+    const child = createChild()
+    queueChildren(child)
+
+    const promise = gitStatusStreamStdout(['status'], streamOptions({ maxBuffer: 3 }))
+    const rejection = expect(promise).rejects.toThrow('git stdout exceeded maxBuffer.')
+    await waitForSpawn(1)
+    child.stdout.emit('data', Buffer.from('four'))
+
+    await rejection
+    expect(killSpawnedCommandTreeMock).toHaveBeenCalledWith(child)
+    expect(wslAwareSpawnMock).toHaveBeenCalledTimes(1)
+    expect(invalidateEnvironmentMock).not.toHaveBeenCalled()
+  })
+
+  it('does not retry non-Git spawn errors', async () => {
+    const child = createChild()
+    const spawnError = new Error('wsl.exe could not start')
+    queueChildren(child)
+
+    const promise = gitStatusStreamStdout(['status'], streamOptions())
+    const rejection = expect(promise).rejects.toBe(spawnError)
+    await waitForSpawn(1)
+    child.emit('error', spawnError)
+
+    await rejection
+    expect(wslAwareSpawnMock).toHaveBeenCalledTimes(1)
+    expect(invalidateEnvironmentMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/git/wsl-status-stream.ts
+++ b/src/main/git/wsl-status-stream.ts
@@ -1,0 +1,173 @@
+import { StringDecoder } from 'node:string_decoder'
+import { withGitSpan } from '../observability/instrumentation'
+import {
+  DEFAULT_GIT_MAX_BUFFER,
+  gitStreamStdout,
+  killSpawnedCommandTree,
+  nonInteractiveGitEnv,
+  wslAwareSpawn,
+  type GitStreamResult
+} from './runner'
+import { invalidateWslStatusEnvironment } from './wsl-status-environment'
+import {
+  directWslGitArgs,
+  isCachedGitUnavailable,
+  loginShellWslGitArgs,
+  readWslStatusEnvironment,
+  resolveWslStatusTarget,
+  type WslStatusGitOptions
+} from './wsl-status-runner'
+
+type WslStatusStreamOptions = WslStatusGitOptions & {
+  onStdout: (chunk: string) => boolean | void
+}
+
+function createAbortError(): Error {
+  const error = new Error('The operation was aborted.')
+  error.name = 'AbortError'
+  return error
+}
+
+function streamWslGit(
+  resolvedArgs: string[],
+  spawnEnv: NodeJS.ProcessEnv,
+  options: WslStatusStreamOptions
+): Promise<GitStreamResult> {
+  const maxBuffer = options.maxBuffer ?? DEFAULT_GIT_MAX_BUFFER
+  return new Promise<GitStreamResult>((resolve, reject) => {
+    if (options.signal?.aborted) {
+      reject(createAbortError())
+      return
+    }
+    const child = wslAwareSpawn('wsl.exe', resolvedArgs, {
+      env: spawnEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true
+    })
+    let settled = false
+    let stoppedEarly = false
+    let sawStdout = false
+    let stdoutBytes = 0
+    let stderrBytes = 0
+    let stderr = ''
+    let timer: NodeJS.Timeout | null = null
+    const stdoutDecoder = new StringDecoder('utf8')
+    const stderrDecoder = new StringDecoder('utf8')
+    const cleanup = (): void => {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+      child.stdout?.off('data', onStdoutData)
+      child.stderr?.off('data', onStderrData)
+      child.off('error', onError)
+      child.off('close', onClose)
+      options.signal?.removeEventListener('abort', onAbort)
+      stdoutDecoder.end()
+      stderrDecoder.end()
+    }
+    const finish = (error: Error | null): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      if (error) {
+        reject(Object.assign(error, { stderr, sawStdout }))
+        return
+      }
+      resolve({ stoppedEarly })
+    }
+    function onStdoutData(chunk: Buffer): void {
+      sawStdout ||= chunk.byteLength > 0
+      stdoutBytes += chunk.byteLength
+      if (stdoutBytes > maxBuffer) {
+        killSpawnedCommandTree(child)
+        finish(new Error('git stdout exceeded maxBuffer.'))
+        return
+      }
+      const decoded = stdoutDecoder.write(chunk)
+      try {
+        if (decoded && options.onStdout(decoded) === true) {
+          stoppedEarly = true
+          killSpawnedCommandTree(child)
+          finish(null)
+        }
+      } catch (error) {
+        killSpawnedCommandTree(child)
+        finish(error instanceof Error ? error : new Error(String(error)))
+      }
+    }
+    function onStderrData(chunk: Buffer): void {
+      stderrBytes += chunk.byteLength
+      if (stderrBytes > maxBuffer) {
+        killSpawnedCommandTree(child)
+        finish(new Error('git stderr exceeded maxBuffer.'))
+        return
+      }
+      stderr += stderrDecoder.write(chunk)
+    }
+    function onError(error: Error): void {
+      finish(error)
+    }
+    function onClose(code: number | null): void {
+      const error = Object.assign(new Error(`git exited with ${code}: ${stderr}`), { code })
+      finish(stoppedEarly || code === 0 ? null : error)
+    }
+    function onAbort(): void {
+      killSpawnedCommandTree(child)
+      finish(createAbortError())
+    }
+    child.stdout?.on('data', onStdoutData)
+    child.stderr?.on('data', onStderrData)
+    child.on('error', onError)
+    child.on('close', onClose)
+    options.signal?.addEventListener('abort', onAbort, { once: true })
+    timer = options.timeout
+      ? setTimeout(() => {
+          killSpawnedCommandTree(child)
+          finish(new Error('wsl.exe timed out.'))
+        }, options.timeout)
+      : null
+    if (options.signal?.aborted) {
+      onAbort()
+    }
+  })
+}
+
+export async function gitStatusStreamStdout(
+  args: string[],
+  options: WslStatusStreamOptions
+): Promise<GitStreamResult> {
+  const target = resolveWslStatusTarget(options)
+  if (!target) {
+    return gitStreamStdout(args, options)
+  }
+  return withGitSpan({ args, cwd: options.cwd }, async () => {
+    const spawnEnv = nonInteractiveGitEnv(options.env)
+    const loginShellFallback = (): Promise<GitStreamResult> =>
+      streamWslGit(loginShellWslGitArgs(target, args, spawnEnv), spawnEnv, options)
+    const environment = await readWslStatusEnvironment(target, options.signal)
+    if (!environment) {
+      return loginShellFallback()
+    }
+    try {
+      return await streamWslGit(
+        directWslGitArgs(target, environment, args, spawnEnv),
+        spawnEnv,
+        options
+      )
+    } catch (error) {
+      const detail = error as { sawStdout?: unknown }
+      if (
+        options.signal?.aborted ||
+        detail.sawStdout === true ||
+        !isCachedGitUnavailable(error, environment.gitPath)
+      ) {
+        throw error
+      }
+      invalidateWslStatusEnvironment(target.distro, environment)
+      return loginShellFallback()
+    }
+  })
+}


### PR DESCRIPTION
## Description

WSL status polling previously paid for an interactive login shell and its rc files on every Git invocation. This change resolves the user's login-shell `PATH` and absolute Git binary once per distro (`src/main/git/wsl-status-environment.ts:44`, `:67`), then reuses that environment for buffered and streamed status reads (`src/main/git/wsl-status-runner.ts:67`, `:260`; `src/main/git/wsl-status-stream.ts:138`). Cached execution still changes to the repository before invoking mise/asdf-style shims and falls back to the guarded login-shell path when the cached executable cannot launch.

The status path now also batches staged and unstaged numstats into one WSL crossing (`src/main/git/status.ts:585`; `src/main/git/wsl-status-batch.ts:172`). Random double-NUL frames preserve each command's stdout, stderr, exit status, and independent byte cap; ambiguous aggregate overflow or malformed framing switches that distro/worktree to bounded cached-direct fallbacks. Native and SSH provider execution still delegates to the existing runners unchanged.

This also fixes the WSL environment-boundary bug: `GIT_OPTIONAL_LOCKS=0`, credential-prompt guards, output locale, supported Git config env, and Orca's safe SSH batch default are injected inside the distro command rather than only into `wsl.exe`'s Windows environment (`src/main/git/wsl-status-runner.ts:67`). Churn diagnostics recognize the new shell-wrapped status commands as Git work (`src/main/diagnostics/main-thread-churn-probe.ts:37`).

## Evidence

Measured on Windows 11 + WSL2 Ubuntu with Git 2.53.0. The dirty repo was `\\wsl.localhost\Ubuntu\root\orca-wsl-status-bench\repo`, with staged, unstaged, and untracked changes plus an upstream one commit ahead and one behind.

### Isolated login-rc tax

Twenty PowerShell repetitions of the requested commands:

| Command | Median | p95 |
| --- | ---: | ---: |
| Login-shell status | 176.7 ms | 210.1 ms |
| Direct distro Git status | 145.3 ms | 166.4 ms |

The login-shell/rc delta was 31.4 ms per status invocation on this machine.

### Dirty status poll

The original implementation measured 410.7, 463.7, 475.4, 477.6, and 592.0 ms: **475.4 ms median**, three `wsl.exe` crossings, three Git invocations, and approximately 24 WSL wrapper/process stages.

An independent final-RC run retained all ten warm samples: 468.15, 332.11, 335.91, 297.27, 347.42, 304.21, 311.74, 877.96, 313.28, and 330.99 ms: **331.55 ms median**. Every poll recorded exactly two crossings (`git status` once and the batched `git diff` once). The Git invocation count remains **three**, because the batch crossing contains both numstats.

To control for machine variance, the final run alternated those current polls with ten legacy-equivalent polls (login-shell streamed status plus two separate concurrent login-shell numstats): 368.15, 428.08, 432.14, 540.87, 497.64, 425.65, 803.88, 376.92, 416.78, and 441.36 ms: **430.11 ms median**. The paired median reduction is **22.9%**. The 878 ms current and 804 ms legacy outliers are included rather than discarded. A separate earlier after-run measured 411.2 ms median, further illustrating normal WSL variance.

`strace` process evidence for a current poll:

- status crossing: one Linux PID, exec images `/bin/sh` -> `/usr/bin/env` -> Git
- batch crossing: three Linux PIDs, five exec images (`sh`, two `env`, two Git)
- total: two `wsl.exe` crossings, two shell stages, three env stages, and three Git stages

The churn probe's median combined synchronous spawn-init `blockMs` was 16.29 ms in the final run (approximately 14.4 ms before; an earlier after-run measured 18.59 ms). This change does **not** claim a UI-jank improvement: Git status remains async. The measured benefit is fresher WSL status with less repeated login-rc work and fewer background crossings, bounded by the existing active/idle/hidden polling gates.

### Behavior equivalence

- Resolved login-shell Git binary: `/usr/bin/git`
- Legacy and cached status SHA-256: `1522b9681e37e9ce3ddb7e4522457c1fa5a9ba125237b8f0df7e6b9d156d783f`
- Legacy and cached staged numstat SHA-256: `dd9e8e0ced944f54cab5a21dbc9658ef54123e86d6e0af3cabc1c815b7bac488`
- Legacy and cached unstaged numstat SHA-256: `edc63af3367f2ac1f76b1b75a9d8da013d4f878b138cb68a3c88bd659150d07d`
- A real WSL run with forced Git fsmonitor warnings verified per-command stderr attribution without duplicate reruns.

## Proof of no regressions

- [x] `pnpm typecheck`
- [x] 125 focused status/WSL/churn tests
- [x] Changed-file oxlint and type-aware switch-exhaustiveness lint
- [x] `pnpm run check:max-lines-ratchet`
- [x] `git diff --check`
- [x] Broad `src/main/git` suite: 1,148 passed, 8 skipped
- [x] Added per-distro tests for first resolution, cached reuse, concurrent probes, caller-local abort, timeout/negative caching, fallback, and distro isolation; plus stream, batch framing, warning, byte-cap, and native/SSH delegation cases
- [x] Two consecutive post-fix independent adversarial review rounds returned `CLEAN`

The broad Git suite has two unrelated existing Windows slash-normalization failures in `src/main/git/repo-detection.test.ts`. Full `pnpm lint` reaches an unrelated pre-existing switch-exhaustiveness failure at `src/renderer/src/components/skills/skill-freshness-group.tsx:101`. A full repository test run timed out after ten minutes without a task-related failure. No build was run.

## AI Review Report

The adversarial loop reviewed login-shell semantic fidelity, mise/asdf shim cwd behavior, rc-defined `git()` fallbacks, WSL env forwarding, credential/lock guards, cancellation and probe coalescing, launch-only retries, stream safety, collision-resistant framing, independent stdout/stderr byte caps, invalid UTF-8, cache isolation, Git 2.25 compatibility, and native/SSH delegation. Earlier rounds found concrete issues in abort/timeout handling, in-WSL guards, framing, retry scope, shim cwd, shell-function fallback, optional-lock behavior, max-buffer/stderr handling, and recurring warning reruns; each was fixed and retested. The final two full rounds were consecutively clean.

Cross-platform review confirmed the new path is gated to Windows WSL targets. Native macOS/Linux/Windows execution and SSH provider execution continue through their existing runners; no renderer shortcuts, labels, or UI behavior changed.

## Security Audit

All distro, cwd, executable, environment-assignment, and Git-argument values continue through the existing POSIX/Windows quoting functions. The cache accepts only an absolute executable reported by the user's login shell and verifies it before warm execution; prompt guards are now enforced inside WSL. Batch frames use an unpredictable 128-bit token and ordered double-NUL boundaries, buffers remain capped, and fallbacks avoid retrying commands after streamed output. No dependency, auth, secret, IPC, or network surface was added.

## Screenshots

No visual change.

## Notes

This first PR is deliberately scoped to Git status. `gh`/`glab` routing is unchanged. The first status call per distro still pays for one login-shell probe; login-rc functions or an unavailable cached executable use the legacy guarded path. One `wsl.exe` spawn remains for status and one for the batched follow-ups, so this does not attempt the larger persistent-relay lifecycle of Option 3.

## ELI5

Orca used to reopen and fully set up your WSL shell before every small status check. It now remembers which Git that shell chose, reuses it safely, and sends two related diff checks together, so WSL status refreshes do less repeated setup work.
