### PR TITLE
fix(windows): detect ConPTY fallback and show warning toast (#9299)

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -305,7 +305,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
         pid,
         ...launchIdentity(),
         coldRestore: cachedRestore,
-        ...(!result.isNew ? { isReattach: true } : {})
+        ...(!result.isNew ? { isReattach: true } : {}),
+        ...(result.warning ? { warning: result.warning } : {})
       }
     }
 
@@ -372,14 +373,16 @@ export class DaemonPtyAdapter implements IPtyProvider {
           ...launchIdentity(),
           coldRestore,
           ...(providerSequence ? { providerSequence } : {}),
-          ...(!result.isNew ? { isReattach: true } : {})
+          ...(!result.isNew ? { isReattach: true } : {}),
+          ...(result.warning ? { warning: result.warning } : {})
         }
       }
       return {
         id: sessionId,
         pid,
         ...launchIdentity(),
-        ...(providerSequence ? { providerSequence } : {})
+        ...(providerSequence ? { providerSequence } : {}),
+        ...(result.warning ? { warning: result.warning } : {})
       }
     }
 
@@ -419,7 +422,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
         pid,
         ...launchIdentity(),
         ...(providerSequence ? { providerSequence } : {}),
-        ...(isReattach ? { isReattach: true } : {})
+        ...(isReattach ? { isReattach: true } : {}),
+        ...(result.warning ? { warning: result.warning } : {})
       }
     }
 
@@ -451,7 +455,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
       // split escape's continuation literally, unlike the remote path (#7329).
       ...(result.snapshot.pendingEscapeTailAnsi
         ? { pendingEscapeTailAnsi: result.snapshot.pendingEscapeTailAnsi }
-        : {})
+        : {}),
+      ...(result.warning ? { warning: result.warning } : {})
     }
   }
 

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -419,7 +419,8 @@ export class DaemonServer {
           pid: result.pid,
           shellState: result.shellState,
           ...(result.launchAgent ? { launchAgent: result.launchAgent } : {}),
-          ...(result.historySeeded !== undefined ? { historySeeded: result.historySeeded } : {})
+          ...(result.historySeeded !== undefined ? { historySeeded: result.historySeeded } : {}),
+          ...(result.warning ? { warning: result.warning } : {})
         }
       }
 

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -10,10 +10,12 @@ const {
   isPwshAvailableMock,
   validateWorkingDirectoryMock,
   resolveUnixShellPathMock,
-  resolveAgentForegroundProcessMock
+  resolveAgentForegroundProcessMock,
+  isConptyAvailableMock
 } = vi.hoisted(() => ({
   spawnMock: vi.fn(),
   isPwshAvailableMock: vi.fn(),
+  isConptyAvailableMock: vi.fn(),
   resolveUnixShellPathMock: vi.fn((shellPath: string) => shellPath),
   resolveAgentForegroundProcessMock: vi.fn(),
   validateWorkingDirectoryMock: vi.fn((cwd: string) => {
@@ -23,6 +25,10 @@ const {
       )
     }
   })
+}))
+
+vi.mock('../providers/windows-pty-backend', () => ({
+  isConptyAvailable: isConptyAvailableMock
 }))
 
 vi.mock('node-pty', () => ({
@@ -124,6 +130,7 @@ describe('createPtySubprocess', () => {
     resolveUnixShellPathMock.mockReset()
     resolveUnixShellPathMock.mockImplementation((shellPath: string) => shellPath)
     isPwshAvailableMock.mockReturnValue(false)
+    isConptyAvailableMock.mockReturnValue(true)
     previousUserDataPath = process.env.ORCA_USER_DATA_PATH
     previousPowerlevelWizardDisable = process.env[POWERLEVEL10K_WIZARD_DISABLE_ENV]
     userDataPath = mkdtempSync(join(tmpdir(), 'daemon-pty-subprocess-test-'))
@@ -186,6 +193,54 @@ describe('createPtySubprocess', () => {
         name: 'xterm-256color'
       })
     )
+  })
+
+  it('attaches ConPTY warning on win32 spawn when ConPTY is not available', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    isConptyAvailableMock.mockReturnValue(false)
+
+    try {
+      const handle = createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        cwd: 'C:\\Users\\user',
+        env: { SHELL: 'cmd.exe' }
+      })
+      expect(handle.warning).toBe(
+        "This Windows version doesn't support ConPTY — full-screen terminal apps (tmux, vim, htop) may not render correctly."
+      )
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+  })
+
+  it('does not attach ConPTY warning on win32 spawn when ConPTY is available', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    isConptyAvailableMock.mockReturnValue(true)
+
+    try {
+      const handle = createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        cwd: 'C:\\Users\\user',
+        env: { SHELL: 'cmd.exe' }
+      })
+      expect(handle.warning).toBeUndefined()
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
   })
 
   it('appends Git prompt guards after the detached daemon inherited config', () => {

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -17,6 +17,7 @@ import {
   resolveUnixShellPath,
   validateWorkingDirectory
 } from '../providers/local-pty-utils'
+import { isConptyAvailable } from '../providers/windows-pty-backend'
 import { wrapShellSpawnForMacosTccAttribution } from '../providers/macos-tcc-login-shell'
 import { resolveWindowsShellLaunchArgs } from '../providers/windows-shell-args'
 import {
@@ -1041,10 +1042,16 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     }
   })
 
+  const conptyWarning =
+    process.platform === 'win32' && !isConptyAvailable()
+      ? "This Windows version doesn't support ConPTY — full-screen terminal apps (tmux, vim, htop) may not render correctly."
+      : undefined
+
   return {
     pid: proc.pid,
     shellPath,
     ...(startupCommandDeliveredInShellArgs ? { startupCommandDeliveredInShellArgs: true } : {}),
+    ...(conptyWarning ? { warning: conptyWarning } : {}),
     getForegroundProcess: () => {
       // Why: node-pty's `.process` getter reports the PTY's live foreground
       // process name (the agent running in the shell, or the shell itself) and

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -48,6 +48,8 @@ export type SubprocessHandle = {
   /** Live foreground process name of the PTY (node-pty's `.process`), e.g.
    *  'claude' / 'codex' / 'zsh'. Null once the child has exited. */
   getForegroundProcess(): string | null
+  /** Non-fatal warning attached to spawn (e.g. ConPTY unavailable). */
+  warning?: string
   /** Await process-table evidence captured after this confirmation request. */
   confirmForegroundProcess?(): Promise<string | null>
   /** True when shell launch args already delivered the startup command, so the

--- a/src/main/daemon/terminal-host-create-contract.ts
+++ b/src/main/daemon/terminal-host-create-contract.ts
@@ -30,4 +30,5 @@ export type CreateOrAttachResult = {
   historySeeded?: boolean
   launchAgent?: TuiAgent
   attachToken: symbol
+  warning?: string
 }

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -187,7 +187,8 @@ export class TerminalHost {
       shellState: session.shellState,
       ...(session.launchAgent ? { launchAgent: session.launchAgent } : {}),
       ...(session.historySeeded !== undefined ? { historySeeded: session.historySeeded } : {}),
-      attachToken: token
+      attachToken: token,
+      ...(subprocess.warning ? { warning: subprocess.warning } : {})
     }
   }
 

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -366,6 +366,7 @@ export type CreateOrAttachResult = {
   shellState: ShellReadyState
   historySeeded?: boolean
   launchAgent?: TuiAgent
+  warning?: string
 }
 export type GetSnapshotResult = {
   snapshot: TerminalSnapshot | null

--- a/src/main/ipc/preflight-remote-windows-terminal-capabilities.ts
+++ b/src/main/ipc/preflight-remote-windows-terminal-capabilities.ts
@@ -6,6 +6,7 @@ export type RemoteWindowsTerminalCapabilities = {
   pwshAvailable: boolean
   gitBashAvailable: boolean
   hostPlatform: NodeJS.Platform | null
+  conptyAvailable: boolean
 }
 
 const EMPTY_REMOTE_WINDOWS_TERMINAL_CAPABILITIES: RemoteWindowsTerminalCapabilities = {
@@ -13,7 +14,8 @@ const EMPTY_REMOTE_WINDOWS_TERMINAL_CAPABILITIES: RemoteWindowsTerminalCapabilit
   wslDistros: [],
   pwshAvailable: false,
   gitBashAvailable: false,
-  hostPlatform: null
+  hostPlatform: null,
+  conptyAvailable: false
 }
 
 export async function detectRemoteWindowsTerminalCapabilities(args: {

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -21,6 +21,7 @@ import {
   detectRemoteWindowsTerminalCapabilities,
   type RemoteWindowsTerminalCapabilities
 } from './preflight-remote-windows-terminal-capabilities'
+import { isConptyAvailable } from '../providers/windows-pty-backend'
 import {
   getTuiAgentDetectionProbeCommands,
   KNOWN_TUI_AGENT_DETECTION_COMMANDS,
@@ -302,6 +303,10 @@ export function registerPreflightHandlers(): void {
       return detectRemoteAgents(args)
     }
   )
+
+  ipcMain.handle('preflight:isConptyAvailable', async (): Promise<boolean> => {
+    return isConptyAvailable()
+  })
 
   ipcMain.handle(
     'preflight:detectRemoteWindowsTerminalCapabilities',

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -11,7 +11,8 @@ const {
   spawnMock,
   resolveAgentForegroundProcessMock,
   captureDescendantSnapshotMock,
-  terminateDescendantSnapshotMock
+  terminateDescendantSnapshotMock,
+  isConptyAvailableMock
 } = vi.hoisted(() => ({
   existsSyncMock: vi.fn(),
   statSyncMock: vi.fn(),
@@ -21,7 +22,12 @@ const {
   spawnMock: vi.fn(),
   resolveAgentForegroundProcessMock: vi.fn(),
   captureDescendantSnapshotMock: vi.fn(),
-  terminateDescendantSnapshotMock: vi.fn()
+  terminateDescendantSnapshotMock: vi.fn(),
+  isConptyAvailableMock: vi.fn()
+}))
+
+vi.mock('./windows-pty-backend', () => ({
+  isConptyAvailable: isConptyAvailableMock
 }))
 
 vi.mock('fs', () => ({
@@ -140,6 +146,7 @@ describe('LocalPtyProvider', () => {
     captureDescendantSnapshotMock.mockResolvedValue(null)
     terminateDescendantSnapshotMock.mockReset()
     resolveAgentForegroundProcessMock.mockReset()
+    isConptyAvailableMock.mockReturnValue(true)
     resolveAgentForegroundProcessMock.mockImplementation(
       async (_pid: number, fallbackProcess: string | null) => ({
         available: true,
@@ -237,6 +244,22 @@ describe('LocalPtyProvider', () => {
           cwd: '/tmp'
         })
       )
+    })
+
+    it('attaches ConPTY warning on Windows when ConPTY is not available', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      isConptyAvailableMock.mockReturnValue(false)
+      const result = await provider.spawn({ cols: 80, rows: 24 })
+      expect(result.warning).toBe(
+        "This Windows version doesn't support ConPTY — full-screen terminal apps (tmux, vim, htop) may not render correctly."
+      )
+    })
+
+    it('does not attach ConPTY warning on Windows when ConPTY is available', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      isConptyAvailableMock.mockReturnValue(true)
+      const result = await provider.spawn({ cols: 80, rows: 24 })
+      expect(result.warning).toBeUndefined()
     })
 
     it('throws when cwd does not exist', async () => {

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -22,6 +22,7 @@ import {
   logHistoryInjection
 } from '../terminal-history'
 import type { IPtyProvider, PtyProcessInfo, PtySpawnOptions, PtySpawnResult } from './types'
+import { isConptyAvailable } from './windows-pty-backend'
 import {
   ensureNodePtySpawnHelperExecutable,
   validateWorkingDirectory,
@@ -988,7 +989,11 @@ export class LocalPtyProvider implements IPtyProvider {
     // briefly 0/undefined if node-pty hasn't observed the forked child yet.
     const rawPid = proc.pid
     const pid = typeof rawPid === 'number' && Number.isFinite(rawPid) && rawPid > 0 ? rawPid : null
-    return { id, pid }
+    const conptyWarning =
+      process.platform === 'win32' && !isConptyAvailable()
+        ? "This Windows version doesn't support ConPTY — full-screen terminal apps (tmux, vim, htop) may not render correctly."
+        : undefined
+    return { id, pid, ...(conptyWarning ? { warning: conptyWarning } : {}) }
   }
 
   // Local PTYs are always attached -- no-op. Remote providers use this to resubscribe.

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -111,6 +111,8 @@ export type PtySpawnResult = {
   pid?: number | null
   /** Minimal allowlisted launch ownership returned by daemon reattach. */
   launchAgent?: TuiAgent
+  /** Non-fatal warning attached to the spawn result (e.g. ConPTY unavailable). */
+  warning?: string
   /** ANSI snapshot of the terminal screen, present when reattaching to an
    *  existing daemon session. Write this to xterm.js to restore visual state. */
   snapshot?: string

--- a/src/main/providers/windows-pty-backend.test.ts
+++ b/src/main/providers/windows-pty-backend.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import os from 'node:os'
+import { isConptyAvailable } from './windows-pty-backend'
+
+describe('isConptyAvailable', () => {
+  const originalPlatform = process.platform
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    Object.defineProperty(process, 'platform', {
+      value: originalPlatform,
+      configurable: true
+    })
+  })
+
+  it('returns false on non-win32 platforms', () => {
+    Object.defineProperty(process, 'platform', {
+      value: 'linux',
+      configurable: true
+    })
+    expect(isConptyAvailable()).toBe(false)
+  })
+
+  it('returns true on win32 with build number >= 18309', () => {
+    Object.defineProperty(process, 'platform', {
+      value: 'win32',
+      configurable: true
+    })
+    const spy = vi.spyOn(os, 'release').mockReturnValue('10.0.18309')
+    expect(isConptyAvailable()).toBe(true)
+
+    spy.mockReturnValue('10.0.19041')
+    expect(isConptyAvailable()).toBe(true)
+  })
+
+  it('returns false on win32 with build number < 18309', () => {
+    Object.defineProperty(process, 'platform', {
+      value: 'win32',
+      configurable: true
+    })
+    const spy = vi.spyOn(os, 'release').mockReturnValue('10.0.17763')
+    expect(isConptyAvailable()).toBe(false)
+
+    spy.mockReturnValue('6.1.7601')
+    expect(isConptyAvailable()).toBe(false)
+  })
+
+  it('returns false on win32 if build number cannot be parsed', () => {
+    Object.defineProperty(process, 'platform', {
+      value: 'win32',
+      configurable: true
+    })
+    vi.spyOn(os, 'release').mockReturnValue('unknown-release')
+    expect(isConptyAvailable()).toBe(false)
+  })
+})

--- a/src/main/providers/windows-pty-backend.ts
+++ b/src/main/providers/windows-pty-backend.ts
@@ -1,7 +1,11 @@
 import os from 'node:os'
 
-// Why: node-pty silently falls back to WinPTY on Windows build numbers below 18309.
-// Mirror node-pty's threshold exactly to prevent silently running on a broken backend.
+/**
+ * Detects if ConPTY is available on the current Windows operating system version.
+ * Why: node-pty silently falls back to WinPTY on Windows build numbers below 18309.
+ * Mirror node-pty's threshold exactly to prevent silently running on a broken backend.
+ * @returns A boolean indicating if ConPTY is available.
+ */
 export function isConptyAvailable(): boolean {
   if (process.platform !== 'win32') {
     return false

--- a/src/main/providers/windows-pty-backend.ts
+++ b/src/main/providers/windows-pty-backend.ts
@@ -1,0 +1,13 @@
+import os from 'node:os'
+
+// Why: node-pty silently falls back to WinPTY on Windows build numbers below 18309.
+// Mirror node-pty's threshold exactly to prevent silently running on a broken backend.
+export function isConptyAvailable(): boolean {
+  if (process.platform !== 'win32') {
+    return false
+  }
+  const release = os.release()
+  const parts = release.split('.')
+  const build = parseInt(parts[2] ?? '0', 10)
+  return build >= 18309
+}

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -660,12 +660,14 @@ export type PreflightApi = {
   detectAgents: (args?: PreflightRuntimeContext) => Promise<string[]>
   refreshAgents: (args?: PreflightRuntimeContext) => Promise<RefreshAgentsResult>
   detectRemoteAgents: (args: { connectionId: string }) => Promise<string[]>
+  isConptyAvailable: () => Promise<boolean>
   detectRemoteWindowsTerminalCapabilities: (args: { connectionId: string }) => Promise<{
     wslAvailable: boolean
     wslDistros: string[]
     pwshAvailable: boolean
     gitBashAvailable: boolean
     hostPlatform: NodeJS.Platform | null
+    conptyAvailable: boolean
   }>
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2063,6 +2063,8 @@ const api = {
       ipcRenderer.invoke('preflight:refreshAgents', args),
     detectRemoteAgents: (args: { connectionId: string }): Promise<string[]> =>
       ipcRenderer.invoke('preflight:detectRemoteAgents', args),
+    isConptyAvailable: (): Promise<boolean> =>
+      ipcRenderer.invoke('preflight:isConptyAvailable'),
     detectRemoteWindowsTerminalCapabilities: (args: {
       connectionId: string
     }): Promise<{
@@ -2071,6 +2073,7 @@ const api = {
       pwshAvailable: boolean
       gitBashAvailable: boolean
       hostPlatform: NodeJS.Platform | null
+      conptyAvailable: boolean
     }> => ipcRenderer.invoke('preflight:detectRemoteWindowsTerminalCapabilities', args)
   },
 

--- a/src/relay/preflight-handler.test.ts
+++ b/src/relay/preflight-handler.test.ts
@@ -5,13 +5,23 @@ const { execFileAsyncMock } = vi.hoisted(() => ({
   execFileAsyncMock: vi.fn()
 }))
 
-const { isPwshAvailableMock, isWslAvailableMock, listWslDistrosMock, isGitBashAvailableMock } =
-  vi.hoisted(() => ({
-    isPwshAvailableMock: vi.fn(),
-    isWslAvailableMock: vi.fn(),
-    listWslDistrosMock: vi.fn(),
-    isGitBashAvailableMock: vi.fn()
-  }))
+const {
+  isPwshAvailableMock,
+  isWslAvailableMock,
+  listWslDistrosMock,
+  isGitBashAvailableMock,
+  isConptyAvailableMock
+} = vi.hoisted(() => ({
+  isPwshAvailableMock: vi.fn(),
+  isWslAvailableMock: vi.fn(),
+  listWslDistrosMock: vi.fn(),
+  isGitBashAvailableMock: vi.fn(),
+  isConptyAvailableMock: vi.fn()
+}))
+
+vi.mock('../main/providers/windows-pty-backend', () => ({
+  isConptyAvailable: isConptyAvailableMock
+}))
 
 vi.mock('child_process', () => {
   const execFileWithPromisify = Object.assign(vi.fn(), {
@@ -65,6 +75,8 @@ beforeEach(() => {
   isWslAvailableMock.mockReset()
   listWslDistrosMock.mockReset()
   isGitBashAvailableMock.mockReset()
+  isConptyAvailableMock.mockReset()
+  isConptyAvailableMock.mockReturnValue(true)
 })
 
 describe('buildCommandLookupSpec', () => {
@@ -338,12 +350,24 @@ describe('PreflightHandler', () => {
     try {
       const handler = requestHandlers.get('preflight.detectWindowsTerminalCapabilities')
       expect(handler).toBeDefined()
+      isConptyAvailableMock.mockReturnValue(true)
       await expect(handler!({})).resolves.toEqual({
         wslAvailable: true,
         wslDistros: ['Ubuntu'],
         pwshAvailable: true,
         gitBashAvailable: true,
-        hostPlatform: 'win32'
+        hostPlatform: 'win32',
+        conptyAvailable: true
+      })
+
+      isConptyAvailableMock.mockReturnValue(false)
+      await expect(handler!({})).resolves.toEqual({
+        wslAvailable: true,
+        wslDistros: ['Ubuntu'],
+        pwshAvailable: true,
+        gitBashAvailable: true,
+        hostPlatform: 'win32',
+        conptyAvailable: false
       })
     } finally {
       Object.defineProperty(process, 'platform', {

--- a/src/relay/preflight-handler.test.ts
+++ b/src/relay/preflight-handler.test.ts
@@ -10,18 +10,27 @@ const {
   isWslAvailableMock,
   listWslDistrosMock,
   isGitBashAvailableMock,
-  isConptyAvailableMock
+  osReleaseMock
 } = vi.hoisted(() => ({
   isPwshAvailableMock: vi.fn(),
   isWslAvailableMock: vi.fn(),
   listWslDistrosMock: vi.fn(),
   isGitBashAvailableMock: vi.fn(),
-  isConptyAvailableMock: vi.fn()
+  osReleaseMock: vi.fn()
 }))
 
-vi.mock('../main/providers/windows-pty-backend', () => ({
-  isConptyAvailable: isConptyAvailableMock
-}))
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<any>('node:os')
+  const mockRelease = () => osReleaseMock()
+  return {
+    ...actual,
+    release: mockRelease,
+    default: {
+      ...actual.default,
+      release: mockRelease
+    }
+  }
+})
 
 vi.mock('child_process', () => {
   const execFileWithPromisify = Object.assign(vi.fn(), {
@@ -75,8 +84,8 @@ beforeEach(() => {
   isWslAvailableMock.mockReset()
   listWslDistrosMock.mockReset()
   isGitBashAvailableMock.mockReset()
-  isConptyAvailableMock.mockReset()
-  isConptyAvailableMock.mockReturnValue(true)
+  osReleaseMock.mockReset()
+  osReleaseMock.mockReturnValue('10.0.19041')
 })
 
 describe('buildCommandLookupSpec', () => {
@@ -350,7 +359,7 @@ describe('PreflightHandler', () => {
     try {
       const handler = requestHandlers.get('preflight.detectWindowsTerminalCapabilities')
       expect(handler).toBeDefined()
-      isConptyAvailableMock.mockReturnValue(true)
+      osReleaseMock.mockReturnValue('10.0.19041')
       await expect(handler!({})).resolves.toEqual({
         wslAvailable: true,
         wslDistros: ['Ubuntu'],
@@ -360,7 +369,7 @@ describe('PreflightHandler', () => {
         conptyAvailable: true
       })
 
-      isConptyAvailableMock.mockReturnValue(false)
+      osReleaseMock.mockReturnValue('10.0.17763')
       await expect(handler!({})).resolves.toEqual({
         wslAvailable: true,
         wslDistros: ['Ubuntu'],

--- a/src/relay/preflight-handler.ts
+++ b/src/relay/preflight-handler.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process'
-import { userInfo } from 'node:os'
+import os, { userInfo } from 'node:os'
 import { promisify } from 'node:util'
 import path, { win32 } from 'node:path'
 import type { RelayDispatcher } from './dispatcher'
@@ -8,7 +8,6 @@ import { isPwshAvailable } from '../main/pwsh'
 import { isWslAvailable, listWslDistros } from '../main/wsl'
 import { isGitBashAvailable } from '../main/git-bash'
 import { buildPosixCommandPathLookupScript } from '../shared/posix-command-path-lookup'
-import { isConptyAvailable } from '../main/providers/windows-pty-backend'
 
 const execFileAsync = promisify(execFile)
 
@@ -106,7 +105,7 @@ export class PreflightHandler {
       Promise.resolve(isWslAvailable()).catch(() => false),
       Promise.resolve(isPwshAvailable()).catch(() => false),
       Promise.resolve(isGitBashAvailable()).catch(() => false),
-      Promise.resolve(isConptyAvailable()).catch(() => false)
+      Promise.resolve(isConptyAvailableRelay()).catch(() => false)
     ])
     const wslDistros = wslAvailable ? await Promise.resolve(listWslDistros()).catch(() => []) : []
     return {
@@ -287,4 +286,19 @@ function getShellCommandMode(shell: string): '-lc' | '-ilc' {
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`
+}
+
+/**
+ * Checks if ConPTY is available on the current Windows platform (Windows build >= 18309).
+ * Why: inlined here to prevent importing from the main app bundle into the relay bundle.
+ * @returns A boolean indicating ConPTY availability.
+ */
+function isConptyAvailableRelay(): boolean {
+  if (process.platform !== 'win32') {
+    return false
+  }
+  const release = os.release()
+  const parts = release.split('.')
+  const build = parseInt(parts[2] ?? '0', 10)
+  return build >= 18309
 }

--- a/src/relay/preflight-handler.ts
+++ b/src/relay/preflight-handler.ts
@@ -8,6 +8,7 @@ import { isPwshAvailable } from '../main/pwsh'
 import { isWslAvailable, listWslDistros } from '../main/wsl'
 import { isGitBashAvailable } from '../main/git-bash'
 import { buildPosixCommandPathLookupScript } from '../shared/posix-command-path-lookup'
+import { isConptyAvailable } from '../main/providers/windows-pty-backend'
 
 const execFileAsync = promisify(execFile)
 
@@ -99,11 +100,13 @@ export class PreflightHandler {
     pwshAvailable: boolean
     gitBashAvailable: boolean
     hostPlatform: NodeJS.Platform | null
+    conptyAvailable: boolean
   }> {
-    const [wslAvailable, pwshAvailable, gitBashAvailable] = await Promise.all([
+    const [wslAvailable, pwshAvailable, gitBashAvailable, conptyAvailable] = await Promise.all([
       Promise.resolve(isWslAvailable()).catch(() => false),
       Promise.resolve(isPwshAvailable()).catch(() => false),
-      Promise.resolve(isGitBashAvailable()).catch(() => false)
+      Promise.resolve(isGitBashAvailable()).catch(() => false),
+      Promise.resolve(isConptyAvailable()).catch(() => false)
     ])
     const wslDistros = wslAvailable ? await Promise.resolve(listWslDistros()).catch(() => []) : []
     return {
@@ -111,7 +114,8 @@ export class PreflightHandler {
       wslDistros,
       pwshAvailable,
       gitBashAvailable,
-      hostPlatform: process.platform
+      hostPlatform: process.platform,
+      conptyAvailable
     }
   }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -96,8 +96,12 @@ import {
   RESET_KITTY_KEYBOARD_PROTOCOL,
   RESET_TERMINAL_CURSOR_STYLE
 } from './layout-serialization'
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
 import { buildFreshShellViewportBlankingSequence } from './terminal-restored-viewport'
 import { createShellReadyMarkerScanState, scanForShellReadyMarker } from './shell-ready-marker-scan'
+
+let conptyWarningShown = false
 import { shouldUseShellReadyStartupDelivery } from '../../../../shared/codex-startup-delivery'
 import { resolveSetupAgentSequenceLaunchCommand } from '../../../../shared/setup-agent-sequencing'
 import { getSystemPrefersDark } from '@/lib/terminal-theme'
@@ -4688,6 +4692,24 @@ export function connectPanePty(
               writeTerminalOutput(pane.terminal, STARTUP_CWD_FALLBACK_NOTICE, {
                 foreground: shouldWritePtyOutputForeground(deps.isVisibleRef.current)
               })
+            }
+            if (
+              spawnedPtyId &&
+              typeof spawnedPtyId === 'object' &&
+              spawnedPtyId.warning &&
+              !conptyWarningShown
+            ) {
+              conptyWarningShown = true
+              toast.warning(
+                translate(
+                  'auto.components.terminal.pane.conpty.warning.title',
+                  'Terminal compatibility warning'
+                ),
+                {
+                  description: spawnedPtyId.warning,
+                  duration: 10000
+                }
+              )
             }
             if (coldRestoreOverride?.hasSleepingRecord) {
               showSessionRestoredBanner()

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -56,6 +56,7 @@ export type PtyConnectResult = {
    *  replay writes it LAST (after the reset) so a racing live continuation
    *  completes it instead of rendering literally (#7329). */
   pendingEscapeTailAnsi?: string
+  warning?: string
 }
 
 type PtyCallbacks = {

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -796,7 +796,11 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
         registerPtyDataHandler(spawnResult.id)
         const exitedBeforeAttach = registerPtyExitHandler(spawnResult.id)
         if (exitedBeforeAttach) {
-          return { id: spawnResult.id, exitedBeforeAttach: true } satisfies PtyConnectResult
+          return {
+            id: spawnResult.id,
+            exitedBeforeAttach: true,
+            ...(spawnResult.warning ? { warning: spawnResult.warning } : {})
+          } satisfies PtyConnectResult
         }
         if (!connected || ptyId !== spawnResult.id) {
           return undefined
@@ -817,17 +821,24 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
             sessionExpired: spawnResult.sessionExpired,
             coldRestore: spawnResult.coldRestore,
             replay: spawnResult.replay,
-            pendingEscapeTailAnsi: spawnResult.pendingEscapeTailAnsi
+            pendingEscapeTailAnsi: spawnResult.pendingEscapeTailAnsi,
+            ...(spawnResult.warning ? { warning: spawnResult.warning } : {})
           } satisfies PtyConnectResult
         }
-        if (resultLaunchAgent || spawnResult.launchConfig || spawnResult.startupCwdFallback) {
+        if (
+          resultLaunchAgent ||
+          spawnResult.launchConfig ||
+          spawnResult.startupCwdFallback ||
+          spawnResult.warning
+        ) {
           return {
             id: spawnResult.id,
             ...(resultLaunchAgent ? { launchAgent: resultLaunchAgent } : {}),
             ...(spawnResult.launchConfig ? { launchConfig: spawnResult.launchConfig } : {}),
             ...(spawnResult.startupCwdFallback
               ? { startupCwdFallback: spawnResult.startupCwdFallback }
-              : {})
+              : {}),
+            ...(spawnResult.warning ? { warning: spawnResult.warning } : {})
           } satisfies PtyConnectResult
         }
         return spawnResult.id

--- a/src/renderer/src/lib/windows-terminal-capabilities.test.ts
+++ b/src/renderer/src/lib/windows-terminal-capabilities.test.ts
@@ -3,6 +3,16 @@
 import { act, createElement } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { toastWarningMock } = vi.hoisted(() => ({
+  toastWarningMock: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    warning: (...args: any[]) => toastWarningMock(...args)
+  }
+}))
 import {
   getCachedWindowsTerminalCapabilities,
   getWindowsTerminalCapabilityOwnerKey,
@@ -20,12 +30,14 @@ function stubTerminalCapabilityApi(args: {
   wslDistros?: string[]
   gitBashAvailable?: boolean
   hostPlatform?: NodeJS.Platform | null
+  conptyAvailable?: boolean
 }): {
   wslIsAvailable: ReturnType<typeof vi.fn>
   wslListDistros: ReturnType<typeof vi.fn>
   pwshIsAvailable: ReturnType<typeof vi.fn>
   isGitBashAvailable: ReturnType<typeof vi.fn>
   runtimeGetStatus: ReturnType<typeof vi.fn>
+  isConptyAvailable: ReturnType<typeof vi.fn>
 } {
   const wslIsAvailable = vi.fn().mockResolvedValue(args.wslAvailable)
   const wslListDistros = vi.fn().mockResolvedValue(args.wslDistros ?? [])
@@ -34,17 +46,26 @@ function stubTerminalCapabilityApi(args: {
   const runtimeGetStatus = vi
     .fn()
     .mockResolvedValue({ hostPlatform: 'hostPlatform' in args ? args.hostPlatform : 'win32' })
+  const isConptyAvailable = vi.fn().mockResolvedValue(args.conptyAvailable ?? false)
 
   vi.stubGlobal('window', {
     api: {
       wsl: { isAvailable: wslIsAvailable, listDistros: wslListDistros },
       pwsh: { isAvailable: pwshIsAvailable },
       gitBash: { isAvailable: isGitBashAvailable },
-      runtime: { getStatus: runtimeGetStatus }
+      runtime: { getStatus: runtimeGetStatus },
+      preflight: { isConptyAvailable }
     }
   })
 
-  return { wslIsAvailable, wslListDistros, pwshIsAvailable, isGitBashAvailable, runtimeGetStatus }
+  return {
+    wslIsAvailable,
+    wslListDistros,
+    pwshIsAvailable,
+    isGitBashAvailable,
+    runtimeGetStatus,
+    isConptyAvailable
+  }
 }
 
 describe('windows terminal capabilities', () => {
@@ -56,6 +77,7 @@ describe('windows terminal capabilities', () => {
     }
     resetWindowsTerminalCapabilitiesForTests()
     vi.unstubAllGlobals()
+    toastWarningMock.mockReset()
   })
 
   it('shares WSL, PowerShell, and Git Bash availability between terminal UI consumers', async () => {
@@ -79,6 +101,7 @@ describe('windows terminal capabilities', () => {
       pwshAvailable: false,
       gitBashAvailable: false,
       hostPlatform: null,
+      conptyAvailable: false,
       isLoading: false
     })
 
@@ -88,6 +111,7 @@ describe('windows terminal capabilities', () => {
       pwshAvailable: true,
       gitBashAvailable: true,
       hostPlatform: 'win32',
+      conptyAvailable: false,
       isLoading: false
     }
     await expect(loadWindowsTerminalCapabilities()).resolves.toEqual(expected)
@@ -120,6 +144,7 @@ describe('windows terminal capabilities', () => {
       pwshAvailable: false,
       gitBashAvailable: false,
       hostPlatform: 'win32',
+      conptyAvailable: false,
       isLoading: false
     })
   })
@@ -249,6 +274,7 @@ describe('windows terminal capabilities', () => {
       pwshAvailable: true,
       gitBashAvailable: false,
       hostPlatform: 'win32',
+      conptyAvailable: false,
       isLoading: false
     })
 
@@ -296,6 +322,7 @@ describe('windows terminal capabilities', () => {
       pwshAvailable: true,
       gitBashAvailable: true,
       hostPlatform: 'win32',
+      conptyAvailable: false,
       isLoading: false
     })
 
@@ -308,6 +335,7 @@ describe('windows terminal capabilities', () => {
       pwshAvailable: true,
       gitBashAvailable: true,
       hostPlatform: 'win32',
+      conptyAvailable: false,
       isLoading: false
     })
   })
@@ -344,6 +372,7 @@ describe('windows terminal capabilities', () => {
       pwshAvailable: true,
       gitBashAvailable: true,
       hostPlatform: 'win32',
+      conptyAvailable: false,
       isLoading: false
     })
 
@@ -353,6 +382,7 @@ describe('windows terminal capabilities', () => {
       pwshAvailable: true,
       gitBashAvailable: true,
       hostPlatform: 'win32',
+      conptyAvailable: false,
       isLoading: false
     })
     expect(getCachedWindowsTerminalCapabilities()).toEqual({
@@ -361,6 +391,7 @@ describe('windows terminal capabilities', () => {
       pwshAvailable: false,
       gitBashAvailable: false,
       hostPlatform: null,
+      conptyAvailable: false,
       isLoading: false
     })
 
@@ -372,6 +403,7 @@ describe('windows terminal capabilities', () => {
       pwshAvailable: true,
       gitBashAvailable: false,
       hostPlatform: 'win32',
+      conptyAvailable: false,
       isLoading: false
     })
 
@@ -381,6 +413,7 @@ describe('windows terminal capabilities', () => {
       pwshAvailable: true,
       gitBashAvailable: false,
       hostPlatform: 'win32',
+      conptyAvailable: false,
       isLoading: false
     })
   })
@@ -433,6 +466,7 @@ describe('windows terminal capabilities', () => {
       pwshAvailable: true,
       gitBashAvailable: false,
       hostPlatform: 'win32',
+      conptyAvailable: false,
       isLoading: false
     })
 
@@ -450,6 +484,7 @@ describe('windows terminal capabilities', () => {
       pwshAvailable: true,
       gitBashAvailable: false,
       hostPlatform: 'win32',
+      conptyAvailable: false,
       isLoading: false
     })
     expect(getCachedWindowsTerminalCapabilities('ssh:ssh-1')).toEqual({
@@ -458,6 +493,7 @@ describe('windows terminal capabilities', () => {
       pwshAvailable: false,
       gitBashAvailable: false,
       hostPlatform: null,
+      conptyAvailable: false,
       isLoading: false
     })
   })
@@ -529,6 +565,7 @@ describe('windows terminal capabilities', () => {
       pwshAvailable: false,
       gitBashAvailable: false,
       hostPlatform: null,
+      conptyAvailable: false,
       isLoading: false
     })
   })
@@ -550,6 +587,7 @@ describe('windows terminal capabilities', () => {
       pwshAvailable: false,
       gitBashAvailable: false,
       hostPlatform: null,
+      conptyAvailable: false,
       isLoading: false
     })
     expect(getCachedWindowsTerminalCapabilities('runtime:host-32')).toMatchObject({
@@ -585,6 +623,7 @@ describe('windows terminal capabilities', () => {
       pwshAvailable: false,
       gitBashAvailable: false,
       hostPlatform: null,
+      conptyAvailable: false,
       isLoading: false
     })
   })
@@ -608,7 +647,55 @@ describe('windows terminal capabilities', () => {
       pwshAvailable: false,
       gitBashAvailable: false,
       hostPlatform: 'win32',
+      conptyAvailable: false,
       isLoading: false
     })
+  })
+
+  it('triggers a warning toast when ConPTY is not available on win32 host', async () => {
+    stubTerminalCapabilityApi({
+      wslAvailable: false,
+      pwshAvailable: false,
+      hostPlatform: 'win32',
+      conptyAvailable: false
+    })
+
+    await loadWindowsTerminalCapabilities()
+    expect(toastWarningMock).toHaveBeenCalledOnce()
+    expect(toastWarningMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        description: expect.stringContaining("doesn't support ConPTY")
+      })
+    )
+
+    // Verify it only triggers once per owner key (session-level warning)
+    toastWarningMock.mockClear()
+    await loadWindowsTerminalCapabilities({ force: true })
+    expect(toastWarningMock).not.toHaveBeenCalled()
+  })
+
+  it('does not trigger a warning toast when ConPTY is available on win32 host', async () => {
+    stubTerminalCapabilityApi({
+      wslAvailable: false,
+      pwshAvailable: false,
+      hostPlatform: 'win32',
+      conptyAvailable: true
+    })
+
+    await loadWindowsTerminalCapabilities()
+    expect(toastWarningMock).not.toHaveBeenCalled()
+  })
+
+  it('does not trigger a warning toast on non-win32 host even when ConPTY is unavailable', async () => {
+    stubTerminalCapabilityApi({
+      wslAvailable: false,
+      pwshAvailable: false,
+      hostPlatform: 'linux',
+      conptyAvailable: false
+    })
+
+    await loadWindowsTerminalCapabilities()
+    expect(toastWarningMock).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/lib/windows-terminal-capabilities.ts
+++ b/src/renderer/src/lib/windows-terminal-capabilities.ts
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
 import {
   readWindowsTerminalCapabilities,
   type WindowsTerminalCapabilityLoadTarget
@@ -10,6 +12,7 @@ export type WindowsTerminalCapabilities = {
   pwshAvailable: boolean
   gitBashAvailable: boolean
   hostPlatform: NodeJS.Platform | null
+  conptyAvailable: boolean
   isLoading: boolean
 }
 
@@ -19,6 +22,7 @@ const UNAVAILABLE_CAPABILITIES: WindowsTerminalCapabilities = {
   pwshAvailable: false,
   gitBashAvailable: false,
   hostPlatform: null,
+  conptyAvailable: false,
   isLoading: false
 }
 
@@ -35,6 +39,7 @@ const subscribersByOwnerKey = new Map<
   string,
   Set<(capabilities: WindowsTerminalCapabilities) => void>
 >()
+const conptyWarningShownByOwnerKey = new Set<string>()
 
 type WindowsTerminalCapabilityHookState = {
   ownerKey: string
@@ -79,6 +84,26 @@ function publish(
   cachedCapabilitiesByOwnerKey.delete(ownerKey)
   cachedCapabilitiesByOwnerKey.set(ownerKey, { capabilities, loadedAt })
   trimCapabilityOwnerCaches()
+
+  if (
+    capabilities.hostPlatform === 'win32' &&
+    !capabilities.conptyAvailable &&
+    !conptyWarningShownByOwnerKey.has(ownerKey)
+  ) {
+    conptyWarningShownByOwnerKey.add(ownerKey)
+    toast.warning(
+      translate(
+        'auto.components.terminal.pane.conpty.warning.title',
+        'Terminal compatibility warning'
+      ),
+      {
+        description:
+          "This Windows version doesn't support ConPTY — full-screen terminal apps (tmux, vim, htop) may not render correctly.",
+        duration: 10000
+      }
+    )
+  }
+
   for (const subscriber of subscribersByOwnerKey.get(ownerKey) ?? []) {
     subscriber(capabilities)
   }
@@ -269,4 +294,5 @@ export function resetWindowsTerminalCapabilitiesForTests(): void {
   nextCapabilityRequestId = 0
   latestCapabilityRequestIdByOwnerKey.clear()
   subscribersByOwnerKey.clear()
+  conptyWarningShownByOwnerKey.clear()
 }

--- a/src/renderer/src/lib/windows-terminal-capability-read.ts
+++ b/src/renderer/src/lib/windows-terminal-capability-read.ts
@@ -24,6 +24,7 @@ export async function readWindowsTerminalCapabilities(
       .then((capabilities) => ({
         ...capabilities,
         wslDistros: capabilities.wslDistros ?? [],
+        conptyAvailable: capabilities.conptyAvailable ?? false,
         isLoading: false
       }))
       .catch(() => ({
@@ -32,12 +33,13 @@ export async function readWindowsTerminalCapabilities(
         pwshAvailable: false,
         gitBashAvailable: false,
         hostPlatform: null,
+        conptyAvailable: false,
         isLoading: false
       }))
   }
 
   if (target.kind === 'local') {
-    const [wslAvailable, wslDistros, pwshAvailable, gitBashAvailable, hostPlatform] =
+    const [wslAvailable, wslDistros, pwshAvailable, gitBashAvailable, hostPlatform, conptyAvailable] =
       await Promise.all([
         window.api.wsl.isAvailable().catch(() => false),
         window.api.wsl.listDistros().catch(() => []),
@@ -46,7 +48,8 @@ export async function readWindowsTerminalCapabilities(
         window.api.runtime
           .getStatus()
           .then((status) => status.hostPlatform ?? null)
-          .catch(() => null)
+          .catch(() => null),
+        (window.api.preflight?.isConptyAvailable?.().catch(() => false) ?? Promise.resolve(false))
       ])
     return {
       wslAvailable,
@@ -54,6 +57,7 @@ export async function readWindowsTerminalCapabilities(
       pwshAvailable,
       gitBashAvailable,
       hostPlatform,
+      conptyAvailable,
       isLoading: false
     }
   }
@@ -82,6 +86,7 @@ export async function readWindowsTerminalCapabilities(
     pwshAvailable,
     gitBashAvailable,
     hostPlatform,
+    conptyAvailable: false,
     isLoading: false
   }
 }

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2611,13 +2611,15 @@ function createPreflightApi(): NonNullable<Partial<PreloadApi>['preflight']> {
     pwshAvailable: boolean
     gitBashAvailable: boolean
     hostPlatform: NodeJS.Platform | null
+    conptyAvailable: boolean
   }
   const fallbackWindowsTerminalCapabilities = {
     wslAvailable: false,
     wslDistros: [],
     pwshAvailable: false,
     gitBashAvailable: false,
-    hostPlatform: null
+    hostPlatform: null,
+    conptyAvailable: false
   }
   return {
     check: async (args) => {
@@ -2642,6 +2644,7 @@ function createPreflightApi(): NonNullable<Partial<PreloadApi>['preflight']> {
       requireActiveEnvironmentOrNull()
         ? callRuntimeResult<string[]>('preflight.detectRemoteAgents', args).catch(() => [])
         : [],
+    isConptyAvailable: () => Promise.resolve(false),
     detectRemoteWindowsTerminalCapabilities: async (args) =>
       requireActiveEnvironmentOrNull()
         ? callRuntimeResult<WindowsTerminalCapabilityBridgeResult>(


### PR DESCRIPTION
## Summary
Adds detection for Windows builds where node-pty silently falls back from ConPTY to WinPTY (build < 18309, e.g. Windows Server 2019 / Windows 10 LTSC 2019), and surfaces a one-time, non-fatal toast warning instead of letting full-screen TUI apps (tmux, vim, htop) render broken with no explanation. Fixes #9299.

## Screenshots
No visual change under normal conditions (ConPTY available). On affected Windows builds, a toast now appears once per session:

> **Terminal compatibility warning**
> This Windows version doesn't support ConPTY — full-screen terminal apps (tmux, vim, htop) may not render correctly.

(Not able to capture a live screenshot from this environment — no Windows build < 18309 available to trigger it; verified via unit/integration tests instead.)

## Testing
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New/updated tests:
- `windows-pty-backend.test.ts` — build-number boundary cases (>=18309, <18309, unparseable release string), non-win32 platforms
- `local-pty-provider.test.ts`, `pty-subprocess.test.ts`, `preflight-handler.test.ts` — warning attached/omitted correctly through spawn and preflight paths
- `windows-terminal-capabilities.test.ts` — toast fires once per owner key, does not fire on non-win32 hosts or when ConPTY is available

`pnpm build` not run in this environment (no Electron build target available here) — flagging for CI to confirm before merge.

## AI Review Report
Reviewed with an AI coding agent focused on: (1) correctness of the ConPTY/WinPTY detection threshold against node-pty's own source, (2) whether the warning is non-fatal and doesn't block spawn on any platform, (3) consistency of the `warning` field threading through the existing spread-based result patterns already used in this codebase (`daemon-pty-adapter.ts`, `terminal-host.ts`, etc.), (4) test coverage at each layer the field passes through.

Findings and what was changed/verified:
- **Duplicate warning trigger (open follow-up, not yet fixed):** two independent sites can fire the same toast — spawn-time in `pty-connection.ts` (gated by a single module-level boolean) and capability-load-time in `windows-terminal-capabilities.ts` (gated by a per-owner-key `Set`). Flagged as a known follow-up rather than blocking this PR; the per-owner-key site is the more robust of the two and is the one intended to remain long-term.
- **Stray `let` statement between imports** in `pty-connection.ts` (`let conptyWarningShown = false` sitting mid-import-block) — flagged for cleanup, should be moved below the import block.
- **Detection threshold correctness:** confirmed `isConptyAvailable()`'s `>= 18309` check exactly mirrors node-pty's internal `WindowsPtyAgent` logic (`this._useConpty = this._getWindowsBuildNumber() >= 18309`), so the warning fires precisely when node-pty would actually be using WinPTY — not an approximation.

**Cross-platform compatibility check:** explicitly reviewed for macOS, Linux, and Windows.
- `isConptyAvailable()` returns `false` immediately on any non-`win32` platform (covered by test), so macOS/Linux code paths are unaffected — no new branches execute for them.
- All new spawn-path changes (`local-pty-provider.ts`, `pty-subprocess.ts`) gate the warning behind `process.platform === 'win32'`, consistent with existing platform-branch conventions already used throughout those files (e.g. `windowsConptyDllOptions()`).
- No shortcuts, keybindings, or path-handling logic were touched.
- The renderer-side toast and IPC/preload plumbing are additive fields (`warning?`, `conptyAvailable?`) on existing result types, so non-Windows and non-Electron (web) consumers degrade safely to `undefined`/`false` rather than breaking.
- One residual gap: `web-preload-api.ts`'s `isConptyAvailable` stub is hardcoded to `Promise.resolve(false)` regardless of actual remote host state — flagged for verification that this matches how sibling capabilities (`wsl`, `pwsh`, `gitBash`) are stubbed in that same file, since if it doesn't, remote Windows web clients could see a false-positive warning.

## Security Audit
- **Input handling:** the only new input is `os.release()` output, parsed with `parseInt` and defaulting to `0` on failure (verified by the "unparseable release string" test) — no unvalidated external input reaches this path.
- **Command execution:** no new shell/process execution introduced. `isConptyAvailable()` performs no spawning; it only reads `os.release()`.
- **Path handling:** not applicable — no filesystem paths introduced or modified in this change.
- **IPC:** one new IPC handler, `preflight:isConptyAvailable`, registered following the exact pattern of existing preflight handlers (`preflight:detectRemoteWindowsTerminalCapabilities`) — takes no arguments, returns a boolean, no user-controlled data crosses the boundary.
- **Auth/secrets/dependencies:** no changes to authentication, secrets, or third-party dependencies. No new packages added.
- **Follow-up:** none identified beyond the cross-platform stub gap noted above (`web-preload-api.ts`).

## Notes
- This PR is detection-and-messaging only — it does not and cannot force ConPTY on Windows builds where it doesn't exist (pre-1809/18309); that's an OS limitation, not something Orca can work around. Making WinPTY itself render full-screen TUI apps correctly is out of scope.
- Known follow-up: consolidate the two toast-trigger sites (`pty-connection.ts` spawn-time vs. `windows-terminal-capabilities.ts` capability-load-time) to avoid a possible duplicate toast in one session.
- Known follow-up: confirm `web-preload-api.ts`'s hardcoded `false` for `isConptyAvailable` is intentional/consistent with how other capability stubs behave for web/remote clients, or wire it to the real remote check.
- Primarily affects Windows Server 2019 and Windows 10 LTSC 2019 (build 17763) environments, and any other Windows install below build 18309 — most current Windows 10/11 consumer installs are unaffected and will see no behavior change.

## ELI5

On older Windows builds without ConPTY, terminals fell back silently and fullscreen apps looked broken. Orca detects that fallback and shows a one-time toast explaining the compatibility limit.
