### PR TITLE
feat(file-explorer): opt-in setting to follow symlinked directories

### DIFF
--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -1048,6 +1048,48 @@ describe('registerFilesystemHandlers', () => {
     expect(statMock).not.toHaveBeenCalledWith(modelLinkPath)
   })
 
+  it('classifies symlinked directories as directories when followSymlinkedDirectories is on', async () => {
+    const modelLinkPath = path.join(REPO_PATH, 'Model')
+    const followStore = {
+      ...store,
+      getSettings: () => ({ workspaceDir: WORKSPACE_DIR, followSymlinkedDirectories: true })
+    }
+    readdirMock.mockResolvedValue([
+      dirEntry({ name: 'README.md', file: true }),
+      dirEntry({ name: 'Model', directory: true, symlink: true })
+    ])
+    // stat (not lstat) resolves the link, so the target reports as a directory.
+    statMock.mockImplementation(async (targetPath: string) => ({
+      size: 10,
+      isDirectory: () => targetPath === modelLinkPath,
+      mtimeMs: 123
+    }))
+
+    registerFilesystemHandlers(followStore as never)
+
+    await expect(handlers.get('fs:readDir')!(null, { dirPath: REPO_PATH })).resolves.toEqual([
+      { name: 'Model', isDirectory: true, isSymlink: true },
+      { name: 'README.md', isDirectory: false, isSymlink: false }
+    ])
+    expect(statMock).toHaveBeenCalledWith(modelLinkPath)
+  })
+
+  it('keeps broken symlinks file-like when followSymlinkedDirectories is on', async () => {
+    const followStore = {
+      ...store,
+      getSettings: () => ({ workspaceDir: WORKSPACE_DIR, followSymlinkedDirectories: true })
+    }
+    readdirMock.mockResolvedValue([dirEntry({ name: 'Dangling', directory: true, symlink: true })])
+    // A broken link's target cannot be stat'd; it must fall back to file-like.
+    statMock.mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }))
+
+    registerFilesystemHandlers(followStore as never)
+
+    await expect(handlers.get('fs:readDir')!(null, { dirPath: REPO_PATH })).resolves.toEqual([
+      { name: 'Dangling', isDirectory: false, isSymlink: true }
+    ])
+  })
+
   it('returns false from pathExists when a local authorized path is missing', async () => {
     const targetPath = path.join(REPO_PATH, 'untitled-7.md')
     statMock.mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }))

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -456,18 +456,30 @@ async function isBinaryFilePrefix(filePath: string): Promise<boolean> {
 async function isDirectoryEntry(
   dirPath: string,
   entry: { name: string; isDirectory(): boolean; isSymbolicLink(): boolean },
-  _resolveEntryPath: (entryPath: string) => Promise<string>
+  resolveEntryPath: (entryPath: string) => Promise<string>,
+  followSymlinkedDirectories: boolean
 ): Promise<boolean> {
-  // Why: following a symlink in readDir can touch macOS TCC-protected containers; treat links as file-like until explicitly opened.
-  void _resolveEntryPath
-  if (entry.isSymbolicLink()) {
-    void dirPath
-    return false
-  }
   if (entry.isDirectory()) {
     return true
   }
-  return false
+  if (!entry.isSymbolicLink()) {
+    return false
+  }
+  // Why: following a symlink just to decorate readDir can touch macOS
+  // TCC-protected app containers, so links stay file-like unless the user
+  // opts in via followSymlinkedDirectories.
+  if (!followSymlinkedDirectories) {
+    return false
+  }
+  try {
+    // Resolve to the link's authorized target and classify by the target type,
+    // mirroring the relay file handler. Broken links or targets outside allowed
+    // roots throw and fall back to file-like.
+    const resolvedTarget = await resolveEntryPath(join(dirPath, entry.name))
+    return (await stat(resolvedTarget)).isDirectory()
+  } catch {
+    return false
+  }
 }
 
 export function registerFilesystemHandlers(
@@ -518,11 +530,15 @@ export function registerFilesystemHandlers(
         const dirPath = await resolveAuthorizedPath(args.dirPath, store)
         throwSite = 'readdir'
         const entries = await readdir(dirPath, { withFileTypes: true })
+        const followSymlinkedDirectories = store.getSettings().followSymlinkedDirectories ?? false
         const mapped = await Promise.all(
           entries.map(async (entry) => ({
             name: entry.name,
-            isDirectory: await isDirectoryEntry(dirPath, entry, (entryPath) =>
-              resolveAuthorizedPath(entryPath, store)
+            isDirectory: await isDirectoryEntry(
+              dirPath,
+              entry,
+              (entryPath) => resolveAuthorizedPath(entryPath, store),
+              followSymlinkedDirectories
             ),
             isSymlink: entry.isSymbolicLink()
           }))

--- a/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
@@ -18,6 +18,7 @@ import {
   getStatusBarToggles,
   getUsagePercentageDisplayEntry
 } from './appearance-search'
+import { FollowSymlinkedDirectoriesSetting } from './FollowSymlinkedDirectoriesSetting'
 import { USAGE_PERCENTAGE_DISPLAY_SETTING_ID } from './appearance-usage-percentage-search'
 import { LeftSidebarAppearanceSetting } from './LeftSidebarAppearanceSetting'
 import {
@@ -379,6 +380,11 @@ export function AppearanceWindowSidebarSection({
                       }
                     />
                   </SearchableSetting>
+
+                  <FollowSymlinkedDirectoriesSetting
+                    settings={settings}
+                    updateSettings={updateSettings}
+                  />
                 </div>
               </div>
             ) : null}

--- a/src/renderer/src/components/settings/FollowSymlinkedDirectoriesSetting.tsx
+++ b/src/renderer/src/components/settings/FollowSymlinkedDirectoriesSetting.tsx
@@ -1,0 +1,38 @@
+import type React from 'react'
+import type { GlobalSettings } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+import { SearchableSetting } from './SearchableSetting'
+import { SettingsSwitchRow } from './SettingsFormControls'
+import { getFollowSymlinkedDirectoriesEntry } from './appearance-search'
+
+type FollowSymlinkedDirectoriesSettingProps = {
+  settings: Pick<GlobalSettings, 'followSymlinkedDirectories'>
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function FollowSymlinkedDirectoriesSetting({
+  settings,
+  updateSettings
+}: FollowSymlinkedDirectoriesSettingProps): React.JSX.Element {
+  const entry = getFollowSymlinkedDirectoriesEntry()
+  const enabled = settings.followSymlinkedDirectories === true
+
+  return (
+    <SearchableSetting title={entry.title} description={entry.description} keywords={entry.keywords}>
+      <SettingsSwitchRow
+        label={translate(
+          'auto.components.settings.AppearancePane.followSymlinkedDirectories.title',
+          'Follow symlinked directories in file explorer'
+        )}
+        // Why: name the macOS permission-prompt tradeoff; the location (file
+        // explorer) is obvious from the section header.
+        description={translate(
+          'auto.components.settings.AppearancePane.followSymlinkedDirectories.description',
+          'Expand symlinked directories instead of showing them as files. May trigger a macOS permission prompt.'
+        )}
+        checked={enabled}
+        onChange={() => updateSettings({ followSymlinkedDirectories: !enabled })}
+      />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -115,6 +115,41 @@ export const getTypographyEntries = createLocalizedCatalog((): SettingsSearchEnt
   }
 ])
 
+export const getFollowSymlinkedDirectoriesEntry = createLocalizedCatalog(
+  (): SettingsSearchEntry => ({
+    title: translate(
+      'auto.components.settings.appearance.search.followSymlinkedDirectories.title',
+      'Follow Symlinked Directories'
+    ),
+    description: translate(
+      'auto.components.settings.appearance.search.followSymlinkedDirectories.description',
+      'Let the file explorer expand into symlinked directories instead of showing them as files. May trigger a macOS permission prompt.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.followSymlinkedDirectories.symlink',
+        'symlink'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.followSymlinkedDirectories.symbolicLink',
+        'symbolic link'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.followSymlinkedDirectories.alias',
+        'alias'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.followSymlinkedDirectories.fileExplorer',
+        'file explorer'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.followSymlinkedDirectories.follow',
+        'follow'
+      )
+    ]
+  })
+)
+
 export const getLayoutEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
   {
     title: translate(
@@ -139,7 +174,8 @@ export const getLayoutEntries = createLocalizedCatalog((): SettingsSearchEntry[]
       ...translateSearchKeyword('auto.components.settings.appearance.search.5bff6a2ef0', 'sidebar'),
       ...translateSearchKeyword('auto.components.settings.appearance.search.648eeada79', 'hide')
     ]
-  }
+  },
+  getFollowSymlinkedDirectoriesEntry()
 ])
 
 export const getTitlebarEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5370,6 +5370,10 @@
           "showPinnedWorktreesInGroups": {
             "title": "Also show pinned worktrees in their original lists",
             "description": "Pinned worktrees stay in Pinned and also appear in All, Project, Status, and PR."
+          },
+          "followSymlinkedDirectories": {
+            "title": "Follow symlinked directories in file explorer",
+            "description": "Expand symlinked directories instead of showing them as files. May trigger a macOS permission prompt."
           }
         },
         "AutoRenameBranchFromWorkSetting": {
@@ -7662,7 +7666,11 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "Usage percentages",
-            "usagePercentageDisplayDescription": "Choose whether provider limits show the percentage used or remaining."
+            "usagePercentageDisplayDescription": "Choose whether provider limits show the percentage used or remaining.",
+            "followSymlinkedDirectories": {
+              "title": "Follow Symlinked Directories",
+              "description": "Let the file explorer expand into symlinked directories instead of showing them as files. May trigger a macOS permission prompt."
+            }
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5347,6 +5347,10 @@
           "showPinnedWorktreesInGroups": {
             "title": "Mostrar también los worktrees fijados en sus listas originales",
             "description": "Los worktrees fijados permanecen en Fijados y también aparecen en Todos, Proyecto, Estado y PR."
+          },
+          "followSymlinkedDirectories": {
+            "title": "Follow symlinked directories in file explorer",
+            "description": "Expand symlinked directories instead of showing them as files. May trigger a macOS permission prompt."
           }
         },
         "AutoRenameBranchFromWorkSetting": {
@@ -7602,7 +7606,11 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "Porcentajes de uso",
-            "usagePercentageDisplayDescription": "Elige si los límites del proveedor muestran el porcentaje usado o restante."
+            "usagePercentageDisplayDescription": "Elige si los límites del proveedor muestran el porcentaje usado o restante.",
+            "followSymlinkedDirectories": {
+              "title": "Follow Symlinked Directories",
+              "description": "Let the file explorer expand into symlinked directories instead of showing them as files. May trigger a macOS permission prompt."
+            }
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5332,6 +5332,10 @@
           "showPinnedWorktreesInGroups": {
             "title": "ピン留めしたワークツリーを元のリストにも表示",
             "description": "ピン留めしたワークツリーを Pinned に残したまま、すべて、プロジェクト、ステータス、PR にも表示します。"
+          },
+          "followSymlinkedDirectories": {
+            "title": "Follow symlinked directories in file explorer",
+            "description": "Expand symlinked directories instead of showing them as files. May trigger a macOS permission prompt."
           }
         },
         "AutoRenameBranchFromWorkSetting": {
@@ -7624,7 +7628,11 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "使用率",
-            "usagePercentageDisplayDescription": "プロバイダーの制限を使用済みまたは残りの割合で表示するかを選択します。"
+            "usagePercentageDisplayDescription": "プロバイダーの制限を使用済みまたは残りの割合で表示するかを選択します。",
+            "followSymlinkedDirectories": {
+              "title": "Follow Symlinked Directories",
+              "description": "Let the file explorer expand into symlinked directories instead of showing them as files. May trigger a macOS permission prompt."
+            }
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5332,6 +5332,10 @@
           "showPinnedWorktreesInGroups": {
             "title": "고정된 워크트리를 원래 목록에도 표시",
             "description": "고정된 워크트리는 Pinned에 유지하면서 전체, 프로젝트, 상태 및 PR에도 표시합니다."
+          },
+          "followSymlinkedDirectories": {
+            "title": "Follow symlinked directories in file explorer",
+            "description": "Expand symlinked directories instead of showing them as files. May trigger a macOS permission prompt."
           }
         },
         "AutoRenameBranchFromWorkSetting": {
@@ -7587,7 +7591,11 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "사용량 백분율",
-            "usagePercentageDisplayDescription": "공급자 한도를 사용한 비율 또는 남은 비율로 표시할지 선택합니다."
+            "usagePercentageDisplayDescription": "공급자 한도를 사용한 비율 또는 남은 비율로 표시할지 선택합니다.",
+            "followSymlinkedDirectories": {
+              "title": "Follow Symlinked Directories",
+              "description": "Let the file explorer expand into symlinked directories instead of showing them as files. May trigger a macOS permission prompt."
+            }
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5332,6 +5332,10 @@
           "showPinnedWorktreesInGroups": {
             "title": "也在原来的列表中显示已固定的工作树",
             "description": "已固定的工作树会保留在 Pinned 中，同时也显示在全部、项目、状态和 PR 中。"
+          },
+          "followSymlinkedDirectories": {
+            "title": "Follow symlinked directories in file explorer",
+            "description": "Expand symlinked directories instead of showing them as files. May trigger a macOS permission prompt."
           }
         },
         "AutoRenameBranchFromWorkSetting": {
@@ -7587,7 +7591,11 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "用量百分比",
-            "usagePercentageDisplayDescription": "选择以已用或剩余百分比显示提供商限额。"
+            "usagePercentageDisplayDescription": "选择以已用或剩余百分比显示提供商限额。",
+            "followSymlinkedDirectories": {
+              "title": "Follow Symlinked Directories",
+              "description": "Let the file explorer expand into symlinked directories instead of showing them as files. May trigger a macOS permission prompt."
+            }
           }
         },
         "auto": {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -269,6 +269,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     openInApplications: [...DEFAULT_OPEN_IN_APPLICATIONS],
     rightSidebarOpenByDefault: true,
     showGitIgnoredFiles: true,
+    followSymlinkedDirectories: false,
     sourceControlViewMode: 'list',
     sourceControlGroupOrder: DEFAULT_SOURCE_CONTROL_GROUP_ORDER,
     sourceControlCompareAgainstUpstream: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2799,6 +2799,11 @@ export type GlobalSettings = {
   /** Deprecated: migration/backward-compat only. Use PersistedUIState.rightSidebarOpen. */
   rightSidebarOpenByDefault: boolean
   showGitIgnoredFiles?: boolean
+  /** Why: opt-in. When on, the file explorer classifies a symlinked entry by its
+   *  target type so a link to a directory expands instead of opening as a file.
+   *  Off by default because resolving link targets can touch macOS TCC-protected
+   *  locations and surface a permission prompt. */
+  followSymlinkedDirectories?: boolean
   /** Preferred Source Control changes layout. Per-user, not per-workspace. */
   sourceControlViewMode: SourceControlViewMode
   /** Preferred Source Control group order. Per-user, not per-workspace. */


### PR DESCRIPTION
# Add opt-in "Follow symlinked directories" setting for the file explorer

> **Note on CI lint:** CI lint may flag two pre-existing issues in `src/main/browser/agent-browser-bridge.test.ts` (`no-unsafe-function-type`) and `src/renderer/src/components/skills/skill-freshness-group.tsx` (`switch-exhaustiveness-check`) that also exist on `main` and are unrelated to this change. This PR touches neither file.

## What this changes (user-visible)

Adds a new **File Explorer** setting — **"Follow symlinked directories in file explorer"** (default **off**). When enabled, the local file explorer classifies a symlinked directory by its *target* type, so a link that points at a directory expands like a folder instead of opening as a plain file. When off (the default), behavior is unchanged: symlinks stay file-like.

Settings → Appearance → File Explorer:

- **Follow symlinked directories in file explorer** — *Expand symlinked directories instead of showing them as files. May trigger a macOS permission prompt.*

## Why opt-in (and why this is safe)

Today `isDirectoryEntry` in `src/main/ipc/filesystem.ts` deliberately treats every symlink as file-like:

```ts
// Why: following a symlink just to decorate readDir can touch macOS
// TCC-protected app containers. Treat links as file-like until the user
// explicitly opens them.
if (entry.isSymbolicLink()) {
  return false
}
```

That is a deliberate macOS **TCC** safety choice: `stat()`-ing a link target during a plain directory listing can reach into TCC-protected locations (Desktop, Documents, Downloads, external volumes) and surface a permission prompt the user never asked for. Removing it outright would regress that safety, which is exactly why issue #8983 scoped the local file explorer out as "intentional."

An **opt-in setting, default off**, resolves this: users who keep the default get today's TCC-safe behavior with zero change, while users who knowingly want symlinked folders to expand can turn it on and accept the possible prompt. The correct classification pattern already exists and is accepted in the relay handler (`src/relay/fs-handler.ts` `isDirectoryEntry`, covered by the test *"readDir reports symlinked directories as directories"*); this change reuses that pattern behind the flag for the local surface, including its broken-link handling.

The opt-in path resolves the link through the existing `resolveAuthorizedPath` resolver (already wired into the call site) before `stat`, so following stays inside already-authorized roots and broken links or out-of-root targets safely fall back to file-like.

## Relationship to #8983

#8983 ("Add Project" browser) is a **different surface** and explicitly excluded the local file explorer as intentional. This PR does not touch the Add Project browser; it adds a separate, conservative, off-by-default toggle for the local explorer only. The two are complementary and do not overlap.

## Changed files

- `src/shared/types.ts` — add `followSymlinkedDirectories?: boolean` to `GlobalSettings` (optional, so existing profiles fall back to off).
- `src/shared/constants.ts` — default `followSymlinkedDirectories: false` in `getDefaultSettings`.
- `src/main/ipc/filesystem.ts` — `isDirectoryEntry` now takes the setting; when on, it resolves the link's authorized target and classifies by target type (broken/denied → file-like). The `fs:readDir` handler reads the setting once per listing and passes it down.
- `src/renderer/src/components/settings/appearance-search.ts` — new `getFollowSymlinkedDirectoriesEntry()` search entry, added to the File Explorer layout catalog so the toggle is searchable and its subsection reveals on search.
- `src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx` — render the toggle in the existing **File Explorer** subsection, next to *Show Git-Ignored Files*.
- `src/renderer/src/i18n/locales/*.json` — catalog keys for the new label/description (generated via `pnpm sync:localization-catalog`).
- `src/main/ipc/filesystem.test.ts` — new tests (below).

## Tests

- Existing *"does not follow symlinks when classifying readDir entries"* now doubles as the **setting-off** guarantee (symlinked dir → file-like; target is never `stat`-ed).
- **New:** *"classifies symlinked directories as directories when followSymlinkedDirectories is on"* — with the flag on, a symlink whose target is a directory reports `isDirectory: true`.
- **New:** *"keeps broken symlinks file-like when followSymlinkedDirectories is on"* — a dangling link (target `stat` throws `ENOENT`) falls back to `isDirectory: false`.

## AI coding-agent review summary

- **Cross-platform (macOS/Linux/Windows):** No platform-specific branches; uses `path.join` and Node `fs/promises.stat`. The symlink-following logic is identical across platforms and matches the already-cross-platform relay handler. Behavior is unchanged on all platforms when the flag is off (the default). The macOS TCC prompt is the only platform-specific *consequence*, and it only occurs when a user opts in — called out in the setting's description.
- **SSH / remote / local:** The `fs:readDir` handler returns early for SSH via `provider.readDir` before this code path, so remote listings are untouched. The setting affects the local surface only; the relay/SSH handler already classifies symlinked directories as directories independently.
- **Agent / integration / git-provider compatibility:** No agent-, integration-, or provider-specific logic; this is generic filesystem classification.
- **Performance:** When off (default), the symlink branch returns before any extra syscall — zero added cost on the hot listing path. When on, at most one `resolveAuthorizedPath` + `stat` per symlink entry, matching the relay handler; non-symlink entries are unaffected.
- **UI quality:** Uses the existing `SettingsSwitchRow` / `SearchableSetting` primitives and the existing File Explorer subsection; integrates with settings search. No new tokens or components. Light/dark inherited from shared primitives.
- **Security:** Opt-in and default-off preserves the TCC posture. Following resolves through `resolveAuthorizedPath`, so classification stays within authorized roots; broken links and out-of-root targets fall back to file-like via the `try/catch`. Read/enumeration access control at open time is unchanged — this only affects display classification.

## Platform / testing notes

- **macOS:** With the flag on, listing a directory that contains a symlink to a TCC-protected location may trigger a one-time permission prompt — this is the documented tradeoff and the reason the setting is off by default.
- **Linux/Windows:** No permission-prompt behavior; the flag simply toggles whether symlinked directories expand.
- Verified via unit tests for off/on/broken-link paths (see Tests). No visual regressions expected outside the new toggle.

## Visual change

Yes — one new toggle row in Settings → Appearance → File Explorer.

X (Twitter) handle: N/A

## ELI5

An opt-in file explorer setting follows symlinked directories into their targets. Off by default so trees stay safe and shallow; turn it on when you need to browse through symlink folders.
