### PR TITLE
fix: don't mint worktreeMeta from a sidebar sort-order snapshot

### DIFF
--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -540,6 +540,22 @@ describe('registerWorktreeHandlers', () => {
     expect(handlers['worktrees:getBranchRenameFailureOutput']).toBeDefined()
   })
 
+  it('persistSortOrder only reorders existing worktrees and never mints meta for a stale id', () => {
+    const liveId = 'repo-1::/workspace/repo'
+    const staleId = 'removed-repo::/workspace/gone'
+    // Only the live worktree has meta; the stale id (e.g. a removed repo the
+    // renderer still lists) has none and must be skipped, not created.
+    store.getWorktreeMeta.mockImplementation((id: string) =>
+      id === liveId ? ({ instanceId: 'x' } as never) : undefined
+    )
+
+    handlers['worktrees:persistSortOrder'](null, { orderedIds: [liveId, staleId] })
+
+    const orderedTargets = store.setWorktreeMeta.mock.calls.map((call) => call[0])
+    expect(orderedTargets).toContain(liveId)
+    expect(orderedTargets).not.toContain(staleId)
+  })
+
   it('prefetches the local default create base through the runtime refresh cache', async () => {
     const repo = {
       id: 'repo-1',

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -2067,6 +2067,14 @@ export function registerWorktreeHandlers(
     }
     const now = Date.now()
     for (let i = 0; i < args.orderedIds.length; i++) {
+      // Why: a sidebar-order snapshot must only reorder worktrees that already
+      // exist — it must never create one. Without this guard a stale id the
+      // renderer still lists (e.g. a removed repo's `${repoId}::${path}`) gets a
+      // fresh worktreeMeta entry minted here, resurrecting an orphan/duplicate
+      // workspace on the next launch. setWorktreeMeta has no repo-existence check.
+      if (!store.getWorktreeMeta(args.orderedIds[i])) {
+        continue
+      }
       // Descending timestamps: first item gets highest sortOrder so b - a sorts first-wins on cold start.
       store.setWorktreeMeta(args.orderedIds[i], { sortOrder: now - i * 1000 })
     }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -19970,6 +19970,12 @@ export class OrcaRuntimeService {
     const now = Date.now()
     let updated = 0
     for (let i = 0; i < orderedIds.length; i++) {
+      // Why: a sort-order snapshot must only reorder existing worktrees, never
+      // mint new meta — a stale id would otherwise resurrect an orphan workspace
+      // (setWorktreeMeta has no repo-existence check).
+      if (!this.store.getWorktreeMeta(orderedIds[i])) {
+        continue
+      }
       this.store.setWorktreeMeta(orderedIds[i], { sortOrder: now - i * 1000 })
       updated++
     }


### PR DESCRIPTION
## Summary

Stops a deleted or orphaned workspace from silently reappearing as a duplicate/"unknown" project whenever the sidebar snapshots its sort order.

**In plain terms:** the app was accidentally re-creating projects you had already deleted, just because it was saving the order they appear in the sidebar. It now only reorders projects that still actually exist.

**Root cause & fix:** Both `worktrees:persistSortOrder` (`src/main/ipc/worktrees.ts`) and `persistManagedWorktreeSortOrder` (`src/main/runtime/orca-runtime.ts`) looped over the renderer's `orderedIds` and called `store.setWorktreeMeta(...)`, which has no repo-existence check — it merges onto defaults and mints a fresh `instanceId` for any key. A stale id in the client's order (a repo removed elsewhere, or an already-orphaned id) therefore got re-created on every snapshot. The fix guards both call sites with an early `continue` on ids that have no existing `worktreeMeta`, so a snapshot can only reorder existing worktrees, never fabricate one.

**Trade-offs / regression risk:** None expected. Legitimate worktrees always have meta stamped before their order is snapshotted, so no real ordering is dropped. The guard only adds an early-`continue` on ids that lack existing meta — exactly the ids that previously would have been fabricated. Existing worktrees follow the identical `setWorktreeMeta` path as before.

Credit to @PannenetsF (Yunqian Fan) for the original fix. Validated and rebased onto latest main during a bug-bash triage on 2026-07-23; original fix design preserved.

## Screenshots

No visual change. The fix is entirely in the main process (IPC handler and runtime service); no renderer UI is touched. The observable behavioral effect is indirect: deleted/orphaned projects no longer resurface as duplicate/"unknown" entries in the sidebar after a relaunch.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests for the change, or explained why not

Author-reported testing (I cannot run pnpm in this environment, so the unchecked boxes above reflect that the full gates were not confirmed as run):

- Added a guard regression test: `persistSortOrder only reorders existing worktrees and never mints meta for a stale id` in `src/main/ipc/worktrees.test.ts`.
- Author reports `src/main/ipc/worktrees.test.ts` passes on-branch (Test Files 1 passed, Tests 200 passed) and that reverting both fix files to `origin/main` fails the new guard assertion.
- Author reports `oxlint` on both source files and the test exits 0 (note: `pnpm lint` full run not confirmed, so left unchecked).

## AI Review Report

I reviewed this diff directly. The change is small and well-scoped: an identical early-`continue` guard added to two loops that call `store.setWorktreeMeta(...)`, plus one added unit test.

- **Correctness:** The guard `if (!store.getWorktreeMeta(id)) continue` correctly prevents minting new meta for ids without existing entries, which is the documented root cause. Both call sites (`worktrees.ts` and `orca-runtime.ts`) are guarded consistently.
- **Edge cases:** In `orca-runtime.ts`, the `updated` counter now only increments for ids that already had meta — this is the intended behavior (it should reflect actual reorders, not attempted ones). One minor consideration: the guard adds a `getWorktreeMeta` read per id inside the loop; for large `orderedIds` this is O(n) extra store reads, but sidebar orderings are small and this is negligible. Sort-order semantics (descending timestamps, `now - i * 1000`) are unchanged.
- **Cross-platform (macOS/Linux/Windows):** Confirmed checked. This is pure main-process JavaScript logic with no OS-specific code — no keyboard shortcuts, no shortcut labels, no filesystem path construction, no shell/command execution, and no Electron API surface that differs by platform. The worktree ids are opaque `${repoId}::${path}` strings compared by identity, not parsed as paths. No platform-specific behavior was touched.

No correctness or portability issues found beyond the negligible per-loop read noted above.

## Security Audit

Reviewed for security-relevant surface:

- **Input handling:** `orderedIds` from the renderer are treated as opaque keys and only used to look up / write store meta; the guard actually tightens input trust by rejecting ids that don't already exist. No new parsing or deserialization.
- **Command execution / shell:** None. No child processes or Git commands added.
- **Path handling:** None. Ids are compared by identity, not resolved as filesystem paths.
- **Auth / secrets / dependencies:** No changes.
- **IPC:** The existing `worktrees:persistSortOrder` IPC handler signature is unchanged; the change only makes it more conservative about what it persists.

No security concerns identified.

## Notes

- No platform-specific behavior; safe across macOS, Linux, and Windows, and unaffected by the SSH use case (main-process store logic only).
- Follow-up (optional, out of scope): the underlying `setWorktreeMeta` still has no repo-existence check of its own — this PR guards the two known callers rather than hardening the store itself, so any future caller must apply the same guard.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
