### PR TITLE
fix: don't hydrate a headless mobile session for a repo that no longer exists

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4092,7 +4092,17 @@ export class OrcaRuntimeService {
       worktreeId !== undefined
         ? ([[worktreeId, session.tabsByWorktree[worktreeId] ?? []]] as const)
         : Object.entries(session.tabsByWorktree ?? {})
+    // Why: workspaceSession keys are `${repoId}::${path}` and are not pruned when
+    // a repo disappears from this client's view (e.g. removed on another client,
+    // or a stale browser-persisted session). Hydrating such a key would surface a
+    // phantom "unknown"/duplicate workspace with no live repo behind it. Only
+    // hydrate sessions whose repo still exists; leave unparseable keys alone.
+    const liveRepoIds = new Set((this.store?.getRepos?.() ?? []).map((repo) => repo.id))
     for (const [entryWorktreeId, persistedTabs] of entries) {
+      const ownerRepoId = splitWorktreeIdForFilesystem(entryWorktreeId)?.repoId
+      if (ownerRepoId && !liveRepoIds.has(ownerRepoId)) {
+        continue
+      }
       const existing = this.mobileSessionTabsByWorktree.get(entryWorktreeId)
       if (
         existing &&


### PR DESCRIPTION
## Summary

Stops a deleted project from reappearing in the mobile/headless sidebar as a phantom "unknown" or duplicate workspace on boot.

**ELI5:** When you delete a project, some leftover bookkeeping could quietly bring it back the next time the app started up. This makes the app skip that stale leftover so the deleted project stays gone.

**Root cause & fix:** `hydrateHeadlessMobileSessionTabsFromWorkspaceSession` rebuilt session tabs by iterating every `workspaceSession.tabsByWorktree` entry with no repo gate. Those keys (`${repoId}::${path}`) are not pruned when a repo disappears from the client's view (e.g. removed on another client, or a stale browser-persisted session), so a leftover key re-materialized a phantom workspace with no live repo behind it. The fix computes `liveRepoIds` from `store.getRepos()` and early-`continue`s on any entry whose parsed `repoId` is no longer live; unparseable keys (no `::`, where `splitWorktreeIdForFilesystem` returns `null`) are left alone. This mirrors the pre-existing `getKnownWorkspaceSessionWorktreeIds()` gate in the same file — same source of truth, established pattern.

Scope: one file changed, `src/main/runtime/orca-runtime.ts` (+10 lines). Pure fix, no trade-offs; the guard is a local, conservative early-continue.

*Original fix by @PannenetsF. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved.*

## Screenshots

No visual change. This is a main-process hydration-logic change (`src/main/runtime/orca-runtime.ts`); no renderer UI is touched.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests (or explained why not)

Author's reported validation (not the full `pnpm` gates above):
- `npx oxlint src/main/runtime/orca-runtime.ts` exited 0 with no warnings.
- Existing hydrate tests confirm the guard does not drop legitimate tabs (repo live -> tabs still hydrate):
  - `graph-sync-mobile-snapshot-gating.test.ts` — 21 passed
  - `orca-runtime.test.ts -t "hydrate"` — 22 passed
- No dedicated phantom-skip test was added; that specific branch is verified by code inspection against the established `getRepos()`-gate pattern rather than a new test.

## AI Review Report

I reviewed this diff directly. The change adds a repo-liveness guard inside the `tabsByWorktree` iteration loop:

- **Correctness:** `liveRepoIds` is built from `this.store?.getRepos?.() ?? []` (optional-chained, empty-array fallback — no crash if store/method is absent). Each entry's `repoId` comes from `splitWorktreeIdForFilesystem(entryWorktreeId)?.repoId`. The guard `if (ownerRepoId && !liveRepoIds.has(ownerRepoId)) continue` only skips entries whose repo is confirmed missing. I verified in `src/shared/worktree-id.ts` that `splitWorktreeIdForFilesystem` returns `null` for keys without the `::` separator, so `ownerRepoId` is `undefined` for unparseable keys and the guard falls through — they hydrate as before. Consistent with the description.
- **Edge cases:** Empty repo store means an empty `liveRepoIds`, so all parseable entries would be skipped — acceptable, since with no live repos there is no legitimate workspace to hydrate. Folder-workspace UUID-suffixed IDs still parse to the correct `repoId` (the suffix only affects `worktreePath`), so those are gated by repo identity as intended.
- **Cross-platform (macOS/Linux/Windows):** Checked. No keyboard shortcuts, shortcut labels, filesystem path construction, shell invocation, or Electron main/renderer boundary behavior is touched. The change is pure in-memory set/string logic and behaves identically on all three platforms. Notably relevant to the SSH/headless case (this is the headless mobile hydration path) and behaves the same there.

No fabricated results; the two test runs cited above are the author's, not re-run here.

## Security Audit

Reviewed against the diff. No new input handling, command execution, path handling, authentication, secret, dependency, or IPC surface changes. The change reads existing in-memory repo IDs and filters an existing iteration; it is strictly more restrictive (it can only skip entries, never add or widen access). No security concerns.

## Notes

- Affects the headless/mobile session hydration path specifically, which is relevant to the SSH/remote use case.
- Follow-up: no test covers the phantom-skip branch itself; a targeted test would close the residual coverage gap noted above.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
