### PR TITLE
fix: reconcile a stale activeWorktreeId against live worktrees on hydration

### DIFF
--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -7015,6 +7015,34 @@ describe('markWorktreeVisited', () => {
     })
   })
 
+  it('pruneLastVisitedTimestamps clears a stale activeWorktreeId gone from a hydrated repo', () => {
+    const store = createTestStore()
+    const wt = makeWorktree({ id: 'repo1::/a', repoId: 'repo1', path: '/a' })
+    store.setState({
+      worktreesByRepo: { repo1: [wt] },
+      activeWorktreeId: 'repo1::/gone',
+      lastVisitedAtByWorktreeId: {}
+    } as Partial<AppState>)
+    store.getState().pruneLastVisitedTimestamps()
+    expect(store.getState().activeWorktreeId).toBeNull()
+  })
+
+  it('pruneLastVisitedTimestamps keeps a live activeWorktreeId and defers unhydrated repos', () => {
+    const store = createTestStore()
+    const wt = makeWorktree({ id: 'repo1::/a', repoId: 'repo1', path: '/a' })
+    store.setState({
+      worktreesByRepo: { repo1: [wt] },
+      activeWorktreeId: 'repo1::/a'
+    } as Partial<AppState>)
+    store.getState().pruneLastVisitedTimestamps()
+    expect(store.getState().activeWorktreeId).toBe('repo1::/a')
+
+    // A pointer into a not-yet-hydrated (e.g. SSH pre-connect) repo is deferred.
+    store.setState({ activeWorktreeId: 'ssh-repo::/b' } as Partial<AppState>)
+    store.getState().pruneLastVisitedTimestamps()
+    expect(store.getState().activeWorktreeId).toBe('ssh-repo::/b')
+  })
+
   it('pruneLastVisitedTimestamps defers when the detected list is non-authoritative', () => {
     const store = createTestStore()
     store.setState({

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -4314,7 +4314,27 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           changed = true
         }
       }
-      return changed ? { lastVisitedAtByWorktreeId: next } : {}
+      const patch: { lastVisitedAtByWorktreeId?: Record<string, number>; activeWorktreeId?: null } =
+        {}
+      if (changed) {
+        patch.lastVisitedAtByWorktreeId = next
+      }
+      // Why: the persisted active-worktree pointer is a `${repoId}::${path}` id
+      // that nothing else reconciles here. The main-process Store clears a stale
+      // pointer when a repo is removed (removeWorkspaceSessionOwner nulls
+      // activeWorktreeId), but the web client keeps it in localStorage and gets
+      // no such load-time GC — so a pointer to a worktree the server no longer
+      // reports lingers and can surface a phantom/duplicate workspace. Clear it
+      // once its repo is hydrated and the worktree is confirmed gone (defer while
+      // the repo is unhydrated, mirroring the timestamp rule above).
+      const activeId = s.activeWorktreeId
+      if (activeId) {
+        const activeRepoWorktreeIds = validIdsByRepo.get(getRepoIdFromWorktreeId(activeId))
+        if (activeRepoWorktreeIds && !activeRepoWorktreeIds.has(activeId)) {
+          patch.activeWorktreeId = null
+        }
+      }
+      return Object.keys(patch).length > 0 ? patch : {}
     })
   },
 


### PR DESCRIPTION
## Summary

Fixes a bug where, on the **web client**, a deleted project could reappear as a phantom/duplicate workspace that survived reloads. The stale active-worktree pointer is now cleared during hydration so it stops coming back.

**Root cause & fix.** The desktop app persists session state in the main-process `Store`, which self-heals on load and nulls a stale `activeWorktreeId` via `removeWorkspaceSessionOwner`. The web client persists in `localStorage` with no load-time GC, and the renderer's `pruneLastVisitedTimestamps` reconcile dropped stale timestamps but never reconciled `activeWorktreeId`. This PR extends that same hydration-time reconcile to also clear `activeWorktreeId` when its repo is hydrated/authoritative and the worktree is confirmed gone, while deferring for unhydrated repos (mirroring the existing SSH pre-connect protection for timestamps).

The change is purely additive inside the existing `set()` updater: when `activeWorktreeId` is null, or its repo is unhydrated/non-authoritative, no clear happens (deferred).

**Changed files:** `src/renderer/src/store/slices/worktrees.ts` (fix, +21/-1) and `worktrees.test.ts` (tests, +28).

_Validated and rebased onto latest main during a bug-bash triage on 2026-07-23 (base `7ab601487c`, head `70e924774b`, clean rebase). Original fix design by @PannenetsF preserved._

## Screenshots

No visual change. This is renderer store/state logic with no UI markup change. The user-facing effect (a deleted project no longer reappearing as a duplicate workspace after reload on web) is not capturable as a static screenshot.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Testing notes from the author (verified against the diff):

- `worktrees.test.ts` → **219 tests passed (1 file)** on the branch.
- Reverting the fix but keeping the new test → **1 failed | 218 passed**, proving the test captures the bug:

  ```
  FAIL: pruneLastVisitedTimestamps clears a stale activeWorktreeId gone from a hydrated repo
  AssertionError: expected 'repo1::/gone' to be null
    - Expected: null
    + Received: "repo1::/gone"
  ```

- A second test covers the live-pointer case and the deferred SSH-pre-connect (unhydrated repo) case.
- `oxlint` on the changed file reports no findings.

`pnpm lint`, `pnpm typecheck`, and `pnpm build` were not run in this environment and are left unchecked. Two new tests were added and are described above.

## AI Review Report

I reviewed the full diff. Main points:

- **Correctness.** The new block reuses `validIdsByRepo`, which only contains repos that are hydrated or authoritative (non-authoritative and not-yet-hydrated repos are intentionally absent). For `activeWorktreeId`, it looks up the set by the pointer's repo id: if the set exists (repo authoritative) **and** does not contain the id, it clears the pointer; if the set is absent (unhydrated repo, e.g. SSH pre-connect), it defers. This correctly mirrors the existing timestamp-pruning rule directly above it, so the deferral semantics are consistent.
- **Edge cases.** A null `activeWorktreeId` is guarded (`if (activeId)`), so no work is done when there is no pointer. The patch object is only returned when non-empty, preserving the original "return `{}` to skip the update" behavior. A pointer that is still live is retained (covered by the second test). No unbounded iteration or new async introduced.
- **Cross-platform (macOS/Linux/Windows).** Explicitly checked. This PR touches no keyboard shortcuts, shortcut labels, filesystem path handling, shell invocation, or Electron main/renderer platform branches. Worktree ids are opaque `${repoId}::${path}` strings parsed with `getRepoIdFromWorktreeId`; no OS path-separator assumptions are made. No platform-specific code paths are affected.
- **SSH.** The unhydrated-repo deferral preserves SSH pre-connect behavior — a pointer into a not-yet-connected SSH repo is not cleared, which the second test asserts.

No issues requiring changes were found; the author's logic and tests read as correct.

## Security Audit

Low risk. The change operates entirely on in-memory Zustand store state within the renderer:

- No command execution, no shell, no new dependencies.
- No IPC surface change (this is a store slice, not a main/renderer bridge).
- No auth, secrets, or credential handling.
- No filesystem path handling — worktree ids are treated as opaque string keys, not resolved paths.
- Input is the app's own persisted `localStorage`/store state; the change only nulls a stale key, reducing rather than expanding state. No injection or untrusted-input concern introduced.

No follow-up security work needed.

## Notes

- Behavior differs by client by design: the desktop main-process `Store` already GCs the pointer via `removeWorkspaceSessionOwner`; this fix brings the web client (localStorage, no load-time GC) to parity at hydration time.
- SSH/unhydrated repos are intentionally deferred and not reconciled until authoritative — worth keeping in mind for any future change to the reconcile pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
