### PR TITLE
feat(grok): default disable Grok trace_upload on Orca launch

### DIFF
--- a/src/shared/tui-agent-launch-defaults.test.ts
+++ b/src/shared/tui-agent-launch-defaults.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getTuiAgentDefaultEnv,
+  resolveTuiAgentLaunchEnv
+} from './tui-agent-launch-defaults'
+
+describe('Grok launch privacy defaults', () => {
+  it('opts Orca-launched Grok out of trace upload by default', () => {
+    expect(getTuiAgentDefaultEnv('grok')).toEqual({
+      GROK_TELEMETRY_TRACE_UPLOAD: '0'
+    })
+    expect(resolveTuiAgentLaunchEnv('grok', undefined)).toEqual({
+      GROK_TELEMETRY_TRACE_UPLOAD: '0'
+    })
+    // Other agents' configured env does not block Grok defaults.
+    expect(resolveTuiAgentLaunchEnv('grok', { goose: { GOOSE_MODE: 'auto' } })).toEqual({
+      GROK_TELEMETRY_TRACE_UPLOAD: '0'
+    })
+  })
+
+  it('honors an explicit empty or custom Grok agentDefaultEnv override', () => {
+    expect(resolveTuiAgentLaunchEnv('grok', { grok: {} })).toEqual({})
+    expect(
+      resolveTuiAgentLaunchEnv('grok', {
+        grok: { GROK_TELEMETRY_TRACE_UPLOAD: '1', GROK_HOME: '/tmp/g' }
+      })
+    ).toEqual({ GROK_TELEMETRY_TRACE_UPLOAD: '1', GROK_HOME: '/tmp/g' })
+  })
+})

--- a/src/shared/tui-agent-launch-defaults.ts
+++ b/src/shared/tui-agent-launch-defaults.ts
@@ -9,8 +9,18 @@ const UNSUPPORTED_TUI_AGENT_ARGS: Partial<Record<TuiAgent, readonly string[]>> =
 
 export const DEFAULT_TUI_AGENT_ARGS: Partial<Record<TuiAgent, string>> = YOLO_TUI_AGENT_ARGS
 
-export const DEFAULT_TUI_AGENT_ENV: Partial<Record<TuiAgent, Record<string, string>>> =
-  YOLO_TUI_AGENT_ENV
+// Why: privacy-sensitive defaults that are not permission/YOLO modes. Grok Build
+// can upload session traces when trace_upload is on; Orca-launched Grok sessions
+// opt out by default (users can override via Settings → agent default env).
+// See open-source xai-org/grok-build telemetry config + GROK_TELEMETRY_TRACE_UPLOAD.
+const GROK_LAUNCH_PRIVACY_ENV: Record<string, string> = {
+  GROK_TELEMETRY_TRACE_UPLOAD: '0'
+}
+
+export const DEFAULT_TUI_AGENT_ENV: Partial<Record<TuiAgent, Record<string, string>>> = {
+  ...YOLO_TUI_AGENT_ENV,
+  grok: { ...GROK_LAUNCH_PRIVACY_ENV }
+}
 
 function argPattern(arg: string): RegExp {
   return new RegExp(`(^|\\s)${arg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?=\\s|$)`, 'g')


### PR DESCRIPTION
## Summary

Grok sessions launched from Orca default to `GROK_TELEMETRY_TRACE_UPLOAD=0`, so session traces are not uploaded unless the user opts back in. The default is applied through `DEFAULT_TUI_AGENT_ENV.grok` / `resolveTuiAgentLaunchEnv`.

## Upstream semantics

`xai-org/grok-build` reads the variable in the telemetry config and parses it with a local `env_bool`, pinned to a commit rather than a branch:

- read: [`crates/codegen/xai-grok-telemetry/src/config.rs#L172-L174`](https://github.com/xai-org/grok-build/blob/a5727c5960452e7527a154b25cb5bf00cda0545e/crates/codegen/xai-grok-telemetry/src/config.rs#L172-L174)
- parse: [`env_bool`, same file `#L203-L211`](https://github.com/xai-org/grok-build/blob/a5727c5960452e7527a154b25cb5bf00cda0545e/crates/codegen/xai-grok-telemetry/src/config.rs#L203-L211)

`env_bool` lowercases and trims, then maps `1 | true | yes | on | enabled` to true and `0 | false | no | off | disabled` to false; an unset, empty, or unrecognised value returns `None` and leaves `trace_upload` at its config value. `0` is therefore an accepted off value, not a silent no-op.

## What this deliberately does not touch

- `grok` is **not** added to `YOLO_TUI_AGENT_ENV` (`src/shared/tui-agent-permissions.ts:34-36`, still `goose` only). `PERMISSION_AGENT_IDS` is derived from `YOLO_TUI_AGENT_ARGS` / `YOLO_TUI_AGENT_ENV` at `:38-40`, so it is unchanged, and `applyAgentPermissionMode` and the permission badge behave exactly as before. The only structural change is that `DEFAULT_TUI_AGENT_ENV` stops being a bare alias of `YOLO_TUI_AGENT_ENV` and gains its own `grok` entry.
- `resolveTuiAgentLaunchEnv` returns a copy of the configured value whenever the agent key is present — `return { ...configuredEnv[agent] }` at `src/shared/tui-agent-launch-defaults.ts:100-101` — so a user-set Settings → agent default env for `grok` wins outright, including `{}` to clear the default and `GROK_TELEMETRY_TRACE_UPLOAD=1` to re-enable uploads.
- `GROK_TELEMETRY_ENABLED` is not forced; product events stay user-configurable.

## Testing

- [x] `vitest` `tui-agent-launch-defaults.test.ts` + `constants.test.ts`
- [ ] full repository Vitest suite

## Notes

A launch-time default only; existing Grok processes are unchanged until relaunched.

## ELI5

Grok sessions started from Orca turn off session-trace upload by default. You can still override that per agent in Settings, and product telemetry stays under your own control.
