### PR TITLE
fix(orchestration): treat ask as a long-poll so it survives the 30s socket idle wall

### DIFF
--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -3909,6 +3909,51 @@ describe('OrcaRuntimeRpcServer', () => {
       }
     })
 
+    it('emits keepalive frames while orchestration.ask blocks for a reply', async () => {
+      const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+      const runtime = new OrcaRuntimeService()
+      const db = new OrchestrationDb(':memory:')
+      runtime.setOrchestrationDb(db)
+      const server = new OrcaRuntimeRpcServer({
+        runtime,
+        userDataPath,
+        keepaliveIntervalMs: 50
+      })
+      await server.start()
+
+      try {
+        const metadata = readRuntimeMetadata(userDataPath)
+        // Why: no reply is ever sent, so ask blocks the full window on the same
+        // hold-the-socket path check --wait uses. Without ask in the long-poll
+        // set the 30s idle timer would tear this down before it keepalives.
+        const session = openFramedSession(metadata!.transports[0]!.endpoint, {
+          id: 'req_ask',
+          authToken: metadata!.authToken,
+          method: 'orchestration.ask',
+          params: {
+            to: 'term_nobody',
+            from: 'term_asker',
+            question: 'ping?',
+            timeoutMs: 300
+          }
+        })
+        await session.done
+
+        const keepalives = session.frames.filter((f) => f._keepalive === true)
+        const terminals = session.frames.filter((f) => f.ok !== undefined)
+        expect(terminals).toHaveLength(1)
+        expect(terminals[0]).toMatchObject({
+          id: 'req_ask',
+          ok: true,
+          result: { timedOut: true }
+        })
+        expect(keepalives.length).toBeGreaterThanOrEqual(3)
+      } finally {
+        db.close()
+        await server.stop()
+      }
+    })
+
     it('emits keepalive frames while terminal.wait blocks and returns its structured timeout', async () => {
       const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
       const runtime = new OrcaRuntimeService()

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -397,6 +397,14 @@ function isLongPollRequest(request: RpcRequest): boolean {
   if (request.method === 'terminal.wait') {
     return true
   }
+  // Why: orchestration.ask blocks unconditionally (default 600 s) holding the
+  // RPC open until a reply lands or the deadline passes, so it needs the same
+  // keepalive as check --wait or the 30 s socket idle timer tears it down. It
+  // also relies on the abort signal (only wired for long-polls) to release the
+  // waiter when the asking client disconnects.
+  if (request.method === 'orchestration.ask') {
+    return true
+  }
   if (request.method === 'orchestration.check') {
     const params = request.params as { wait?: unknown } | undefined
     return params?.wait === true


### PR DESCRIPTION
# fix(orchestration): treat `ask` as a long-poll so it survives the 30s socket idle wall

## Summary
Fixes `orchestration.ask` calls dying at 30 seconds with a misleading `runtime_unavailable` error regardless of the requested timeout.

## ELI5
When one agent asked another a question and waited for the answer, the connection was silently killed after 30 seconds even if you asked it to wait longer. This keeps the line open until a real reply arrives.

## Root cause & fix
`orchestration.ask` blocks server-side until a reply lands or its deadline (default 600s) passes, holding the RPC socket open exactly like `check --wait`. But `isLongPollRequest()` only classified `terminal.wait` and `check --wait` as long-polls, so `ask` fell through. That meant keepalive frames were never armed (the 30s socket idle timer then destroyed the connection) and the abort signal was never wired (so a client disconnect never released the waiter). The fix adds `orchestration.ask` to `isLongPollRequest()`, arming the existing keepalive machinery and abort wiring — no new `--wait`-style param gate is needed since `ask` blocks unconditionally.

## Evidence
Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- Clean rebase onto `origin/main` (base `7ab601487c`, head `1cd244d304`); changed files: `runtime-rpc.ts` (fix), `runtime-rpc.test.ts` (test).
- Test on branch: `orchestration.ask blocks` → **1 passed** (55 skipped).
- Reverting the fix only makes the test fail, proving it captures the bug:

```
AssertionError: expected 0 to be greater than or equal to 3
  at runtime-rpc.test.ts:3950  expect(keepalives.length).toBeGreaterThanOrEqual(3)
=> With the fix reverted, no keepalive frames are emitted while ask blocks.
```

- Lint clean: `oxlint src/main/runtime/runtime-rpc.ts` → exit 0.

## Trade-offs
None — pure fix.

## Regression risk
Zero-regression: the change is purely additive to the long-poll classifier. Short RPCs and non-`ask` paths are byte-identical and unaffected. `orchestration.ask` genuinely holds the socket, so keepalive/abort wiring is the correct treatment, proven by the passing test that fails when reverted.

---
*Credit to original author @averydev. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved.*
