### PR TITLE
feat(status-bar): keep unpinned providers in usage roster

### DIFF
--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -63,6 +63,7 @@ import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon } from 
 import { AgentIcon } from '@/lib/agent-catalog'
 import { UsageRosterPanel, getTightestUsageSection } from './UsageRosterPanel'
 import { getUsageProviderAccountsSectionId } from './usage-provider-settings-target'
+import { getPinnedUsageProviders, getUsageRosterProviders } from './usage-roster-provider-selection'
 import { formatRateLimitWindowChipLabel } from '@/lib/window-label-formatter'
 import { useResetCountdownClock } from '@/hooks/useResetCountdownClock'
 import {
@@ -74,7 +75,7 @@ import { SkillUpdateStatusSegment } from './SkillUpdateStatusSegment'
 import { CaffeinateStatusSegment } from './CaffeinateStatusSegment'
 import { RemoteServerUpdateStatusSegment } from './RemoteServerUpdateStatusSegment'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
-import { getVisibleUsageProvider, isUsageEmptyState } from './status-bar-provider-visibility'
+import { isUsageEmptyState } from './status-bar-provider-visibility'
 import { StatusBarUsageEmptyCta } from './StatusBarUsageEmptyCta'
 import { UsagePercentageDisplayChangeNotice } from './UsagePercentageDisplayChangeNotice'
 import {
@@ -1325,7 +1326,12 @@ export function ProviderSegment({
           showLabel={!compact}
         />
       ) : null}
-      {isStale && <AlertTriangle size={11} className="text-muted-foreground/80" />}
+      {isStale ? (
+        <>
+          <span className="sr-only">{statusLabel}</span>
+          <AlertTriangle aria-hidden size={11} className="text-muted-foreground/80" />
+        </>
+      ) : null}
     </span>
   )
 }
@@ -2121,57 +2127,33 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     minimaxCookieConfigured: rateLimits.minimaxCookieConfigured,
     grokAuthConfigured: rateLimits.grokAuthConfigured
   }
-  const visibleClaude = getVisibleUsageProvider('claude', claude, usageSettings)
-  const visibleCodex = getVisibleUsageProvider('codex', codex, usageSettings)
-  const visibleGemini = getVisibleUsageProvider('gemini', gemini, usageSettings)
-  const visibleKimi = getVisibleUsageProvider('kimi', kimi, usageSettings)
-  const visibleAntigravity = getVisibleUsageProvider('antigravity', antigravity, usageSettings)
-  const visibleMiniMax = getVisibleUsageProvider('minimax', minimax, usageSettings)
-  const visibleGrok = getVisibleUsageProvider('grok', grok, usageSettings)
-  const showClaude =
-    visibleClaude !== null &&
-    statusBarItems.includes('claude') &&
-    isStatusBarItemAvailable('claude', detectedAgentIds)
-  const showCodex =
-    visibleCodex !== null &&
-    statusBarItems.includes('codex') &&
-    isStatusBarItemAvailable('codex', detectedAgentIds)
-  const showGemini =
-    visibleGemini !== null &&
-    statusBarItems.includes('gemini') &&
-    isStatusBarItemAvailable('gemini', detectedAgentIds)
-  const showKimi =
-    visibleKimi !== null &&
-    statusBarItems.includes('kimi') &&
-    isStatusBarItemAvailable('kimi', detectedAgentIds)
-  const showAntigravity =
-    visibleAntigravity !== null &&
-    statusBarItems.includes('antigravity') &&
-    isStatusBarItemAvailable('antigravity', detectedAgentIds)
-  // Why: MiniMax is cookie-auth, not a CLI on PATH, so detection-gating doesn't apply.
-  const showMiniMax = visibleMiniMax !== null && statusBarItems.includes('minimax')
-  const showGrok =
-    visibleGrok !== null &&
-    statusBarItems.includes('grok') &&
-    isStatusBarItemAvailable('grok', detectedAgentIds)
-  // Why: OpenCode Go is web/cookie-auth, not a CLI on PATH, so detection-gating doesn't apply.
-  const visibleOpencodeGo = getVisibleUsageProvider('opencode-go', opencodeGo, usageSettings)
-  const showOpencodeGo = visibleOpencodeGo !== null && statusBarItems.includes('opencode-go')
+  // Why: pinning controls footer density, not whether configured providers are
+  // available in the on-demand roster.
+  const rosterProviders = getUsageRosterProviders({
+    snapshots: {
+      claude,
+      codex,
+      gemini,
+      antigravity,
+      'opencode-go': opencodeGo,
+      kimi,
+      minimax,
+      grok
+    },
+    settings: usageSettings
+  })
+  const pinnedUsageProviders = getPinnedUsageProviders({
+    rosterProviders,
+    statusBarItems,
+    detectedAgentIds
+  })
   const showSsh = statusBarItems.includes('ssh')
   const showResourceUsage = statusBarItems.includes('resource-usage')
   const showPorts = statusBarItems.includes('ports')
   const showFloatingTerminalToggle =
     floatingTerminalEnabled && floatingTerminalTriggerLocation === 'status-bar'
   // Why: meter-only children (excludes resource-usage) so the % display callout anchors to a real meter cluster.
-  const hasVisibleUsageMeters =
-    showClaude ||
-    showCodex ||
-    showGemini ||
-    showOpencodeGo ||
-    showKimi ||
-    showAntigravity ||
-    showMiniMax ||
-    showGrok
+  const hasVisibleUsageMeters = pinnedUsageProviders.length > 0
   const anyVisible = hasVisibleUsageMeters || showResourceUsage
   // Why: include Settings so durable managed accounts count — a configured user isn't shown the empty state while snapshots hydrate.
   const isEmptyUsageState = isUsageEmptyState(
@@ -2196,19 +2178,6 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     ? 'Minimize Floating Workspace'
     : 'Show Floating Workspace'
   const showFloatingWorkspaceAttentionDot = !floatingTerminalOpen && hasFloatingUnread
-
-  // Why: the roster must contain only status items the user left visible;
-  // otherwise an empty trigger would bypass those visibility controls.
-  const rosterProviders = [
-    showClaude ? visibleClaude : null,
-    showCodex ? visibleCodex : null,
-    showGemini ? visibleGemini : null,
-    showAntigravity ? visibleAntigravity : null,
-    showOpencodeGo ? visibleOpencodeGo : null,
-    showKimi ? visibleKimi : null,
-    showMiniMax ? visibleMiniMax : null,
-    showGrok ? visibleGrok : null
-  ].filter((p): p is ProviderRateLimits => p !== null)
 
   const handleManageAccounts = (): void => {
     setUsageMenuOpen(false)
@@ -2258,8 +2227,8 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
           showEmptyUsageCta ? (
             <StatusBarUsageEmptyCta />
           ) : null
-        ) : hasVisibleUsageMeters ? (
-          // Consolidated roster pill → opens the all-agents Usage popover (mock parity).
+        ) : rosterProviders.length > 0 ? (
+          // Consolidated roster pill → opens configured providers, including unpinned ones.
           <UsagePercentageDisplayChangeNotice hasVisibleUsageMeters={hasVisibleUsageMeters}>
             <DropdownMenu
               open={usageMenuOpen}
@@ -2275,7 +2244,12 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
                     'Usage'
                   )}
                 >
-                  {rosterProviders.map((p) =>
+                  {pinnedUsageProviders.length === 0 ? (
+                    <span className="text-muted-foreground">
+                      {translate('auto.components.status.bar.UsageRosterPanel.title', 'Usage')}
+                    </span>
+                  ) : null}
+                  {pinnedUsageProviders.map((p) =>
                     iconOnly ? (
                       // Narrow status bar: fall back to main's compact letter badge.
                       <span key={p.provider} title={getProviderDisplayName(p.provider)}>

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -63,7 +63,12 @@ import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon } from 
 import { AgentIcon } from '@/lib/agent-catalog'
 import { UsageRosterPanel, getTightestUsageSection } from './UsageRosterPanel'
 import { getUsageProviderAccountsSectionId } from './usage-provider-settings-target'
-import { getPinnedUsageProviders, getUsageRosterProviders } from './usage-roster-provider-selection'
+import {
+  getPinnedUsageProviders,
+  getUsageRosterProviders,
+  isAntigravityUsageConfigured
+} from './usage-roster-provider-selection'
+import { getUsageRosterTriggerAriaLabel } from './usage-roster-trigger-accessibility'
 import { formatRateLimitWindowChipLabel } from '@/lib/window-label-formatter'
 import { useResetCountdownClock } from '@/hooks/useResetCountdownClock'
 import {
@@ -2115,11 +2120,9 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   const { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok } = rateLimits
 
   // Why: a bar is earned by a live snapshot or durable Settings setup; detection-gating hides per-CLI bars when the agent isn't on PATH.
-  // Why: Antigravity has no persisted credential, so a checked status item + detected CLI is the durable "show its slot" signal.
+  // Why: Antigravity has no persisted credential, so a detected CLI is its durable configured signal.
   // Why: Antigravity visibility also requires geminiCliOAuthEnabled because its usage snapshot mirrors the Gemini fetch.
-  const antigravityUsageConfigured =
-    statusBarItems.includes('antigravity') &&
-    isStatusBarItemAvailable('antigravity', detectedAgentIds)
+  const antigravityUsageConfigured = isAntigravityUsageConfigured(detectedAgentIds)
   // Why: thread non-GlobalSettings durability flags so bars stay visible across reloads and snapshot refreshes.
   const usageSettings = {
     ...settings,
@@ -2239,10 +2242,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
                 <button
                   type="button"
                   className="inline-flex items-center gap-3 rounded px-1 py-0.5 hover:bg-accent/70"
-                  aria-label={translate(
-                    'auto.components.status.bar.UsageRosterPanel.title',
-                    'Usage'
-                  )}
+                  aria-label={getUsageRosterTriggerAriaLabel(pinnedUsageProviders)}
                 >
                   {pinnedUsageProviders.length === 0 ? (
                     <span className="text-muted-foreground">

--- a/src/renderer/src/components/status-bar/UsageRosterPanel.test.tsx
+++ b/src/renderer/src/components/status-bar/UsageRosterPanel.test.tsx
@@ -87,6 +87,29 @@ describe('UsageRow', () => {
     expect(markup).not.toContain('width:25%')
   })
 
+  it('exposes stale usage to assistive technology', () => {
+    const markup = renderToStaticMarkup(
+      <UsageRow
+        p={{
+          ...signedOutCodex,
+          session: {
+            usedPercent: 25,
+            windowMinutes: 300,
+            resetsAt: null,
+            resetDescription: null
+          }
+        }}
+        display="used"
+        state={{ kind: 'usage', statusLabel: 'Refresh failed' }}
+        showSignInAction={false}
+        now={mocks.now}
+      />
+    )
+
+    expect(markup).toContain('Refresh failed')
+    expect(markup).toContain('aria-hidden="true"')
+  })
+
   it('uses one shared clock for live reset labels across the roster', () => {
     const sessionReset = mocks.now + 2 * 60_000
     const weeklyReset = mocks.now + 7 * 24 * 60 * 60_000

--- a/src/renderer/src/components/status-bar/UsageRosterPanel.tsx
+++ b/src/renderer/src/components/status-bar/UsageRosterPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ChevronRight, RefreshCw } from 'lucide-react'
+import { AlertTriangle, ChevronRight, RefreshCw } from 'lucide-react'
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu'
 import { SettingsSegmentedControl } from '@/components/settings/SettingsFormControls'
 import { useResetCountdownClock } from '@/hooks/useResetCountdownClock'
@@ -154,17 +154,33 @@ export function UsageRow({
             ) : null}
           </>
         ) : tightest ? (
-          <span className="ml-auto">
+          <span className="ml-auto flex items-center gap-1">
             <UsageMetric
               section={tightest}
               label={tightest.label}
               display={display}
               showBar={false}
             />
+            {state.statusLabel ? (
+              <>
+                <span className="sr-only">{state.statusLabel}</span>
+                <AlertTriangle aria-hidden className="size-3 shrink-0 text-muted-foreground/80" />
+              </>
+            ) : null}
           </span>
-        ) : reset ? (
-          <span className="shrink-0 text-[11px] text-muted-foreground">{reset}</span>
-        ) : null}
+        ) : (
+          <>
+            {reset ? (
+              <span className="shrink-0 text-[11px] text-muted-foreground">{reset}</span>
+            ) : null}
+            {state.statusLabel ? (
+              <>
+                <span className="sr-only">{state.statusLabel}</span>
+                <AlertTriangle aria-hidden className="size-3 shrink-0 text-muted-foreground/80" />
+              </>
+            ) : null}
+          </>
+        )}
       </div>
       {hasUsage && mode === 'verbose' ? (
         <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1 pl-[30px]">

--- a/src/renderer/src/components/status-bar/usage-roster-provider-selection.test.ts
+++ b/src/renderer/src/components/status-bar/usage-roster-provider-selection.test.ts
@@ -3,11 +3,13 @@ import type {
   ProviderRateLimits,
   ProviderRateLimitStatus
 } from '../../../../shared/rate-limit-types'
-import type { StatusBarItem, TuiAgent } from '../../../../shared/types'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import type { StatusBarItem } from '../../../../shared/ui-chrome-types'
 import type { UsageProviderSettings } from './status-bar-provider-visibility'
 import {
   getPinnedUsageProviders,
   getUsageRosterProviders,
+  isAntigravityUsageConfigured,
   type UsageProviderSnapshots
 } from './usage-roster-provider-selection'
 
@@ -73,6 +75,27 @@ describe('getUsageRosterProviders', () => {
     })
 
     expect(providers).toMatchObject([{ provider: 'minimax', status: 'fetching' }])
+  })
+
+  it('keeps detected Antigravity in the roster when unpinned with a null or unavailable snapshot', () => {
+    const providerSettings = settings({
+      antigravityUsageConfigured: isAntigravityUsageConfigured(['antigravity']),
+      geminiCliOAuthEnabled: true
+    })
+    for (const antigravity of [null, provider('antigravity', 'unavailable')]) {
+      const rosterProviders = getUsageRosterProviders({
+        snapshots: snapshots({ antigravity }),
+        settings: providerSettings
+      })
+      const pinnedProviders = getPinnedUsageProviders({
+        rosterProviders,
+        statusBarItems: [] as StatusBarItem[],
+        detectedAgentIds: ['antigravity']
+      })
+
+      expect(rosterProviders).toContainEqual(expect.objectContaining({ provider: 'antigravity' }))
+      expect(pinnedProviders).toEqual([])
+    }
   })
 
   it('omits unavailable providers without durable configuration', () => {

--- a/src/renderer/src/components/status-bar/usage-roster-provider-selection.test.ts
+++ b/src/renderer/src/components/status-bar/usage-roster-provider-selection.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  ProviderRateLimits,
+  ProviderRateLimitStatus
+} from '../../../../shared/rate-limit-types'
+import type { StatusBarItem, TuiAgent } from '../../../../shared/types'
+import type { UsageProviderSettings } from './status-bar-provider-visibility'
+import {
+  getPinnedUsageProviders,
+  getUsageRosterProviders,
+  type UsageProviderSnapshots
+} from './usage-roster-provider-selection'
+
+function provider(
+  providerId: ProviderRateLimits['provider'],
+  status: ProviderRateLimitStatus = 'ok'
+): ProviderRateLimits {
+  return {
+    provider: providerId,
+    session: null,
+    weekly: null,
+    updatedAt: 0,
+    error: null,
+    status
+  }
+}
+
+function snapshots(overrides: Partial<UsageProviderSnapshots> = {}): UsageProviderSnapshots {
+  return {
+    claude: null,
+    codex: null,
+    gemini: null,
+    antigravity: null,
+    'opencode-go': null,
+    kimi: null,
+    minimax: null,
+    grok: null,
+    ...overrides
+  }
+}
+
+function settings(overrides: Partial<UsageProviderSettings> = {}): UsageProviderSettings {
+  return {
+    codexManagedAccounts: [],
+    claudeManagedAccounts: [],
+    opencodeSessionCookie: '',
+    geminiCliOAuthEnabled: false,
+    antigravityUsageConfigured: false,
+    minimaxCookieConfigured: false,
+    grokAuthConfigured: false,
+    ...overrides
+  }
+}
+
+describe('getUsageRosterProviders', () => {
+  it('includes every configured provider in stable roster order', () => {
+    const providers = getUsageRosterProviders({
+      snapshots: snapshots({
+        grok: provider('grok'),
+        claude: provider('claude'),
+        minimax: provider('minimax')
+      }),
+      settings: settings()
+    })
+
+    expect(providers.map((entry) => entry.provider)).toEqual(['claude', 'minimax', 'grok'])
+  })
+
+  it('keeps durably configured providers while their first snapshot is pending', () => {
+    const providers = getUsageRosterProviders({
+      snapshots: snapshots(),
+      settings: settings({ minimaxCookieConfigured: true })
+    })
+
+    expect(providers).toMatchObject([{ provider: 'minimax', status: 'fetching' }])
+  })
+
+  it('omits unavailable providers without durable configuration', () => {
+    const providers = getUsageRosterProviders({
+      snapshots: snapshots({ codex: provider('codex', 'unavailable') }),
+      settings: settings()
+    })
+
+    expect(providers).toEqual([])
+  })
+})
+
+describe('getPinnedUsageProviders', () => {
+  it('limits the footer to pinned providers without removing unpinned providers from the roster', () => {
+    const rosterProviders = [provider('claude'), provider('codex')]
+    const pinned = getPinnedUsageProviders({
+      rosterProviders,
+      statusBarItems: ['claude'] as StatusBarItem[],
+      detectedAgentIds: ['claude', 'codex'] as TuiAgent[]
+    })
+
+    expect(pinned.map((entry) => entry.provider)).toEqual(['claude'])
+    expect(rosterProviders.map((entry) => entry.provider)).toEqual(['claude', 'codex'])
+  })
+
+  it('applies PATH detection only to the pinned footer', () => {
+    const rosterProviders = [provider('claude'), provider('minimax')]
+    const pinned = getPinnedUsageProviders({
+      rosterProviders,
+      statusBarItems: ['claude', 'minimax'] as StatusBarItem[],
+      detectedAgentIds: []
+    })
+
+    expect(pinned.map((entry) => entry.provider)).toEqual(['minimax'])
+    expect(rosterProviders.map((entry) => entry.provider)).toEqual(['claude', 'minimax'])
+  })
+})

--- a/src/renderer/src/components/status-bar/usage-roster-provider-selection.ts
+++ b/src/renderer/src/components/status-bar/usage-roster-provider-selection.ts
@@ -1,0 +1,44 @@
+import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
+import type { StatusBarItem, TuiAgent } from '../../../../shared/types'
+import { isStatusBarItemAvailable } from './status-bar-agent-gating'
+import {
+  getVisibleUsageProvider,
+  type UsageProviderSettings
+} from './status-bar-provider-visibility'
+
+type UsageProviderId = ProviderRateLimits['provider']
+
+export type UsageProviderSnapshots = Record<UsageProviderId, ProviderRateLimits | null>
+
+// Why: the roster order stays stable even when providers are pinned or unpinned.
+export const USAGE_ROSTER_PROVIDER_ORDER: readonly UsageProviderId[] = [
+  'claude',
+  'codex',
+  'gemini',
+  'antigravity',
+  'opencode-go',
+  'kimi',
+  'minimax',
+  'grok'
+]
+
+export function getUsageRosterProviders(args: {
+  snapshots: UsageProviderSnapshots
+  settings: Partial<UsageProviderSettings> | null | undefined
+}): ProviderRateLimits[] {
+  return USAGE_ROSTER_PROVIDER_ORDER.map((providerId) =>
+    getVisibleUsageProvider(providerId, args.snapshots[providerId], args.settings)
+  ).filter((provider): provider is ProviderRateLimits => provider !== null)
+}
+
+export function getPinnedUsageProviders(args: {
+  rosterProviders: ProviderRateLimits[]
+  statusBarItems: StatusBarItem[]
+  detectedAgentIds: TuiAgent[] | null
+}): ProviderRateLimits[] {
+  return args.rosterProviders.filter(
+    (provider) =>
+      args.statusBarItems.includes(provider.provider) &&
+      isStatusBarItemAvailable(provider.provider, args.detectedAgentIds)
+  )
+}

--- a/src/renderer/src/components/status-bar/usage-roster-provider-selection.ts
+++ b/src/renderer/src/components/status-bar/usage-roster-provider-selection.ts
@@ -1,5 +1,6 @@
 import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
-import type { StatusBarItem, TuiAgent } from '../../../../shared/types'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import type { StatusBarItem } from '../../../../shared/ui-chrome-types'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
 import {
   getVisibleUsageProvider,
@@ -9,6 +10,10 @@ import {
 type UsageProviderId = ProviderRateLimits['provider']
 
 export type UsageProviderSnapshots = Record<UsageProviderId, ProviderRateLimits | null>
+
+export function isAntigravityUsageConfigured(detectedAgentIds: TuiAgent[] | null): boolean {
+  return isStatusBarItemAvailable('antigravity', detectedAgentIds)
+}
 
 // Why: the roster order stays stable even when providers are pinned or unpinned.
 export const USAGE_ROSTER_PROVIDER_ORDER: readonly UsageProviderId[] = [

--- a/src/renderer/src/components/status-bar/usage-roster-row-state.test.ts
+++ b/src/renderer/src/components/status-bar/usage-roster-row-state.test.ts
@@ -98,7 +98,7 @@ describe('getUsageRosterRowState', () => {
   it('lets real usage data win over a stale error status', () => {
     expect(getUsageRosterRowState(provider({ status: 'error' }), true)).toEqual({
       kind: 'usage',
-      statusLabel: null
+      statusLabel: 'Refresh failed'
     })
   })
 })

--- a/src/renderer/src/components/status-bar/usage-roster-row-state.ts
+++ b/src/renderer/src/components/status-bar/usage-roster-row-state.ts
@@ -35,7 +35,11 @@ export function getUsageRosterRowState(
   hasUsage: boolean
 ): UsageRosterRowState {
   if (hasUsage) {
-    return { kind: 'usage', statusLabel: null }
+    return {
+      kind: 'usage',
+      // Why: stale values remain useful, but assistive technology must expose the refresh failure.
+      statusLabel: provider.status === 'error' ? getProviderUsageStatusLabel(provider) : null
+    }
   }
   if (provider.status === 'idle' || provider.status === 'fetching') {
     return {

--- a/src/renderer/src/components/status-bar/usage-roster-trigger-accessibility.test.tsx
+++ b/src/renderer/src/components/status-bar/usage-roster-trigger-accessibility.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
+import { getUsageRosterTriggerAriaLabel } from './usage-roster-trigger-accessibility'
+
+afterEach(cleanup)
+
+function provider(
+  providerId: ProviderRateLimits['provider'],
+  status: ProviderRateLimits['status'] = 'ok'
+): ProviderRateLimits {
+  return {
+    provider: providerId,
+    session: null,
+    weekly: null,
+    updatedAt: 0,
+    error: status === 'error' ? 'request failed' : null,
+    status
+  }
+}
+
+describe('getUsageRosterTriggerAriaLabel', () => {
+  it('includes pinned provider failures in the icon-only trigger accessible name', () => {
+    render(
+      <button
+        aria-label={getUsageRosterTriggerAriaLabel([provider('codex', 'error'), provider('grok')])}
+      >
+        <span aria-hidden>C</span>
+        <span aria-hidden>G</span>
+      </button>
+    )
+
+    expect(screen.getByRole('button', { name: 'Usage. Codex: Refresh failed' })).toBeDefined()
+  })
+
+  it('uses the concise title when no pinned provider failed', () => {
+    expect(getUsageRosterTriggerAriaLabel([provider('codex')])).toBe('Usage')
+  })
+})

--- a/src/renderer/src/components/status-bar/usage-roster-trigger-accessibility.ts
+++ b/src/renderer/src/components/status-bar/usage-roster-trigger-accessibility.ts
@@ -1,0 +1,14 @@
+import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
+import { translate } from '@/i18n/i18n'
+import { getProviderDisplayName, getProviderUsageStatusLabel } from './usage-error-copy'
+
+export function getUsageRosterTriggerAriaLabel(providers: ProviderRateLimits[]): string {
+  const title = translate('auto.components.status.bar.UsageRosterPanel.title', 'Usage')
+  const failures = providers
+    .filter((provider) => provider.status === 'error')
+    .map(
+      (provider) =>
+        `${getProviderDisplayName(provider.provider)}: ${getProviderUsageStatusLabel(provider)}`
+    )
+  return failures.length > 0 ? `${title}. ${failures.join('. ')}` : title
+}


### PR DESCRIPTION
## Summary

- Right-clicking the status bar keeps the existing pin controls for provider meters.
- Clicking the consolidated **Usage** trigger opens every configured provider, including providers that are not pinned in the footer; providers without a snapshot or durable configuration remain omitted.
- Refreshing usage keeps the roster open and updates its backing snapshots in place.
- Provider failures are included in the icon-only trigger's accessible name, and detected Antigravity remains configured independently of its footer pin.

Closes #9356

## Visual proof (macOS, final rebased head `da0196932e0`)

Pinned Grok is present in the footer and checked in the right-click context menu:

![Pinned provider context menu](https://github.com/user-attachments/assets/bcb74c2f-ca9a-4ffd-a203-1a4dfab689ca)

After unpinning, Grok is removed from the footer but remains in the configured-provider roster; refresh was invoked and the roster remained open:

![Unpinned provider retained in usage roster](https://github.com/user-attachments/assets/f6ed4f82-fb5a-4ca9-8784-a11cf076b76b)

Backing-state assertions on the same Electron/CDP run confirmed `grokAuthConfigured: true`, a live Grok `status: "ok"` snapshot, removal of `grok` from `statusBarItems` while the roster stayed open, a refreshed `updatedAt`, and the dynamic trigger label `Usage. Claude: Refreshing sign-in`. The original Grok pin was restored after capture.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar/UsageRosterPanel.test.tsx src/renderer/src/components/status-bar/usage-roster-row-state.test.ts src/renderer/src/components/status-bar/usage-roster-provider-selection.test.ts src/renderer/src/components/status-bar/usage-roster-trigger-accessibility.test.tsx` — 4 files, 23 tests passed
- [x] `pnpm typecheck`
- [x] `pnpm lint` — includes reliability, max-lines, Electron runtime, skill bundle, and localization gates
- [x] `pnpm build` — desktop/web, CLI, Linux/macOS/Windows relay targets, and native macOS helpers
- [x] Real Orca Electron app launched on macOS and exercised through Playwright CDP on the final rebased head

## Compatibility and security

This is renderer-only UI/state selection. It adds no dependencies, commands, IPC/wire fields, persistence migrations, credentials, secret handling, or provider-specific review logic. Folder workspaces, SSH execution ownership, mixed-version remote compatibility, mobile/data-loss, GitHub/GitLab neutrality, and macOS/Linux/Windows path/process behavior are unchanged.
