### PR TITLE
Suggest Tailscale tailnet peers when adding an SSH target

### DIFF
--- a/src/main/ipc/tailscale.ts
+++ b/src/main/ipc/tailscale.ts
@@ -1,0 +1,14 @@
+import { ipcMain } from 'electron'
+import { discoverTailnetPeers } from '../network/tailscale-peer-discovery'
+
+const TAILSCALE_IPC_CHANNELS = ['tailscale:discoverPeers'] as const
+
+export function registerTailscaleHandlers(): void {
+  // Why: macOS re-activation re-attaches window services, and ipcMain.handle()
+  // throws if a handler is already registered.
+  for (const channel of TAILSCALE_IPC_CHANNELS) {
+    ipcMain.removeHandler(channel)
+  }
+
+  ipcMain.handle('tailscale:discoverPeers', () => discoverTailnetPeers())
+}

--- a/src/main/ipc/tailscale.ts
+++ b/src/main/ipc/tailscale.ts
@@ -3,6 +3,10 @@ import { discoverTailnetPeers } from '../network/tailscale-peer-discovery'
 
 const TAILSCALE_IPC_CHANNELS = ['tailscale:discoverPeers'] as const
 
+/**
+ * Registers the `tailscale:discoverPeers` IPC handler, replacing any existing
+ * registration so repeated window re-attachment on macOS stays idempotent.
+ */
 export function registerTailscaleHandlers(): void {
   // Why: macOS re-activation re-attaches window services, and ipcMain.handle()
   // throws if a handler is already registered.

--- a/src/main/network/tailscale-peer-discovery.test.ts
+++ b/src/main/network/tailscale-peer-discovery.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  __resetTailnetPeerDiscoveryForTests,
+  discoverTailnetPeers,
+  parseTailscaleStatusPeers
+} from './tailscale-peer-discovery'
+
+function statusJson(peers: Record<string, unknown>): string {
+  return JSON.stringify({
+    Version: '1.86.0',
+    BackendState: 'Running',
+    Self: { HostName: 'my-laptop', DNSName: 'my-laptop.tail1234.ts.net.' },
+    MagicDNSSuffix: 'tail1234.ts.net',
+    Peer: peers
+  })
+}
+
+describe('parseTailscaleStatusPeers', () => {
+  it('maps peers to suggestions with trimmed MagicDNS names and tailnet IPv4', () => {
+    const peers = parseTailscaleStatusPeers(
+      statusJson({
+        'nodekey:aa': {
+          HostName: 'sezerchicago',
+          DNSName: 'sezerchicago.tail1234.ts.net.',
+          OS: 'linux',
+          TailscaleIPs: ['fd7a:115c:a1e0::1', '100.96.7.56'],
+          Online: true,
+          sshHostKeys: ['ssh-ed25519 AAAA...']
+        }
+      })
+    )
+
+    expect(peers).toEqual([
+      {
+        hostName: 'sezerchicago',
+        dnsName: 'sezerchicago.tail1234.ts.net',
+        ipv4: '100.96.7.56',
+        os: 'linux',
+        online: true,
+        tailscaleSsh: true
+      }
+    ])
+  })
+
+  it('sorts online peers first, then by host name', () => {
+    const peers = parseTailscaleStatusPeers(
+      statusJson({
+        'nodekey:aa': { HostName: 'zeta', DNSName: 'zeta.ts.net.', Online: true },
+        'nodekey:bb': { HostName: 'alpha', DNSName: 'alpha.ts.net.', Online: false },
+        'nodekey:cc': { HostName: 'beta', DNSName: 'beta.ts.net.', Online: true }
+      })
+    )
+
+    expect(peers.map((peer) => peer.hostName)).toEqual(['beta', 'zeta', 'alpha'])
+    expect(peers.map((peer) => peer.online)).toEqual([true, true, false])
+  })
+
+  it('filters Mullvad exit nodes and entries with no usable address', () => {
+    const peers = parseTailscaleStatusPeers(
+      statusJson({
+        'nodekey:aa': {
+          HostName: 'de-ber-wg-001',
+          DNSName: 'de-ber-wg-001.mullvad.ts.net.',
+          TailscaleIPs: ['100.127.0.1'],
+          Online: true
+        },
+        'nodekey:bb': { HostName: 'no-address', TailscaleIPs: ['192.168.1.5'], Online: true },
+        'nodekey:cc': 'not-an-object',
+        'nodekey:dd': { HostName: 'kept', DNSName: 'kept.tail1234.ts.net.', Online: true }
+      })
+    )
+
+    expect(peers.map((peer) => peer.hostName)).toEqual(['kept'])
+  })
+
+  it('falls back to the MagicDNS label, then the IPv4, when HostName is missing', () => {
+    const peers = parseTailscaleStatusPeers(
+      statusJson({
+        'nodekey:aa': { DNSName: 'named-by-dns.tail1234.ts.net.', Online: true },
+        'nodekey:bb': { TailscaleIPs: ['100.64.0.9'], Online: false }
+      })
+    )
+
+    expect(peers.map((peer) => peer.hostName)).toEqual(['named-by-dns', '100.64.0.9'])
+  })
+
+  it('returns an empty list for malformed or peer-less status output', () => {
+    expect(parseTailscaleStatusPeers('not json')).toEqual([])
+    expect(parseTailscaleStatusPeers('{}')).toEqual([])
+    expect(parseTailscaleStatusPeers(JSON.stringify({ Peer: null }))).toEqual([])
+  })
+})
+
+describe('discoverTailnetPeers', () => {
+  beforeEach(() => {
+    __resetTailnetPeerDiscoveryForTests()
+  })
+
+  it('reports available with parsed peers when the CLI responds', async () => {
+    const runStatus = vi
+      .fn()
+      .mockResolvedValue(
+        statusJson({
+          'nodekey:aa': { HostName: 'peer-a', DNSName: 'peer-a.ts.net.', Online: true }
+        })
+      )
+
+    const discovery = await discoverTailnetPeers(runStatus)
+
+    expect(discovery.available).toBe(true)
+    expect(discovery.peers.map((peer) => peer.hostName)).toEqual(['peer-a'])
+  })
+
+  it('reports unavailable without throwing when the CLI is missing', async () => {
+    const runStatus = vi.fn().mockRejectedValue(new Error('spawn tailscale ENOENT'))
+
+    await expect(discoverTailnetPeers(runStatus)).resolves.toEqual({
+      available: false,
+      peers: []
+    })
+  })
+
+  it('serves cached results inside the TTL instead of re-running the CLI', async () => {
+    const runStatus = vi.fn().mockResolvedValue(statusJson({}))
+
+    await discoverTailnetPeers(runStatus)
+    await discoverTailnetPeers(runStatus)
+
+    expect(runStatus).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/network/tailscale-peer-discovery.ts
+++ b/src/main/network/tailscale-peer-discovery.ts
@@ -1,0 +1,156 @@
+import { execFile } from 'node:child_process'
+import path from 'node:path'
+import { isTailnetIPv4Address } from '../../shared/tailnet-address'
+import type { TailnetPeerDiscovery, TailnetPeerSuggestion } from '../../shared/tailnet-peers'
+
+const CACHE_TTL_MS = 15 * 1000
+const STATUS_TIMEOUT_MS = 3000
+const STATUS_MAX_BUFFER_BYTES = 8 * 1024 * 1024
+
+type CacheEntry = {
+  expiresAt: number
+  discovery: TailnetPeerDiscovery
+}
+
+let cache: CacheEntry | null = null
+let workingBinary: string | null = null
+
+function tailscaleBinaryCandidates(): string[] {
+  // Why: the macOS standalone app and the Windows installer ship the CLI inside
+  // their install directory without adding it to PATH, so a bare `tailscale`
+  // lookup misses those installs.
+  const candidates = ['tailscale']
+  if (process.platform === 'darwin') {
+    candidates.push('/Applications/Tailscale.app/Contents/MacOS/Tailscale')
+  }
+  if (process.platform === 'win32') {
+    const programFiles = process.env['ProgramFiles'] ?? 'C:\\Program Files'
+    candidates.push(path.join(programFiles, 'Tailscale', 'tailscale.exe'))
+  }
+  return candidates
+}
+
+function runTailscaleStatus(binary: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      binary,
+      ['status', '--json'],
+      {
+        timeout: STATUS_TIMEOUT_MS,
+        maxBuffer: STATUS_MAX_BUFFER_BYTES,
+        windowsHide: true,
+        encoding: 'utf8'
+      },
+      (error, stdout) => (error ? reject(error) : resolve(stdout))
+    )
+  })
+}
+
+type RawPeerStatus = {
+  HostName?: unknown
+  DNSName?: unknown
+  OS?: unknown
+  TailscaleIPs?: unknown
+  Online?: unknown
+  sshHostKeys?: unknown
+}
+
+function firstTailnetIPv4(ips: unknown): string | null {
+  if (!Array.isArray(ips)) {
+    return null
+  }
+  for (const ip of ips) {
+    if (typeof ip === 'string' && isTailnetIPv4Address(ip)) {
+      return ip
+    }
+  }
+  return null
+}
+
+function normalizeDnsName(dnsName: unknown): string {
+  return typeof dnsName === 'string' ? dnsName.replace(/\.$/, '') : ''
+}
+
+export function parseTailscaleStatusPeers(statusJson: string): TailnetPeerSuggestion[] {
+  let status: unknown
+  try {
+    status = JSON.parse(statusJson)
+  } catch {
+    return []
+  }
+  const peerMap =
+    typeof status === 'object' && status !== null ? (status as { Peer?: unknown }).Peer : null
+  if (typeof peerMap !== 'object' || peerMap === null) {
+    return []
+  }
+
+  const suggestions: TailnetPeerSuggestion[] = []
+  for (const raw of Object.values(peerMap)) {
+    if (typeof raw !== 'object' || raw === null) {
+      continue
+    }
+    const peer = raw as RawPeerStatus
+    const dnsName = normalizeDnsName(peer.DNSName)
+    // Why: Mullvad exit nodes are tailnet peers too, but they never accept SSH
+    // and would flood the list on tailnets with the exit-node add-on enabled.
+    if (dnsName.endsWith('.mullvad.ts.net')) {
+      continue
+    }
+    const ipv4 = firstTailnetIPv4(peer.TailscaleIPs)
+    if (!dnsName && !ipv4) {
+      continue
+    }
+    const shortDnsLabel = dnsName.split('.')[0]
+    const hostName =
+      typeof peer.HostName === 'string' && peer.HostName !== ''
+        ? peer.HostName
+        : shortDnsLabel || (ipv4 as string)
+    suggestions.push({
+      hostName,
+      dnsName,
+      ipv4,
+      os: typeof peer.OS === 'string' ? peer.OS : '',
+      online: peer.Online === true,
+      tailscaleSsh: Array.isArray(peer.sshHostKeys) && peer.sshHostKeys.length > 0
+    })
+  }
+
+  suggestions.sort(
+    (a, b) => Number(b.online) - Number(a.online) || a.hostName.localeCompare(b.hostName)
+  )
+  return suggestions
+}
+
+export async function discoverTailnetPeers(
+  runStatus: (binary: string) => Promise<string> = runTailscaleStatus
+): Promise<TailnetPeerDiscovery> {
+  const now = Date.now()
+  if (cache && cache.expiresAt > now) {
+    return cache.discovery
+  }
+
+  let discovery: TailnetPeerDiscovery = { available: false, peers: [] }
+  const candidates = workingBinary ? [workingBinary] : tailscaleBinaryCandidates()
+  for (const binary of candidates) {
+    try {
+      const output = await runStatus(binary)
+      discovery = { available: true, peers: parseTailscaleStatusPeers(output) }
+      workingBinary = binary
+      break
+    } catch {
+      // Not installed at this location (or the daemon is down) — a normal,
+      // silent outcome; the UI simply shows no suggestions.
+    }
+  }
+  if (!discovery.available) {
+    workingBinary = null
+  }
+
+  cache = { expiresAt: now + CACHE_TTL_MS, discovery }
+  return discovery
+}
+
+export function __resetTailnetPeerDiscoveryForTests(): void {
+  cache = null
+  workingBinary = null
+}

--- a/src/main/network/tailscale-peer-discovery.ts
+++ b/src/main/network/tailscale-peer-discovery.ts
@@ -71,6 +71,13 @@ function normalizeDnsName(dnsName: unknown): string {
   return typeof dnsName === 'string' ? dnsName.replace(/\.$/, '') : ''
 }
 
+/**
+ * Parses `tailscale status --json` output into SSH-target suggestions.
+ *
+ * Skips Mullvad exit nodes and peers with neither a MagicDNS name nor a tailnet
+ * IPv4, then sorts online peers first and alphabetically by host name. Returns an
+ * empty array on malformed or unexpected JSON.
+ */
 export function parseTailscaleStatusPeers(statusJson: string): TailnetPeerSuggestion[] {
   let status: unknown
   try {
@@ -121,6 +128,14 @@ export function parseTailscaleStatusPeers(statusJson: string): TailnetPeerSugges
   return suggestions
 }
 
+/**
+ * Discovers online tailnet peers by running the Tailscale CLI, probing known
+ * install locations until one succeeds and caching the result for a short TTL.
+ *
+ * @param runStatus - Override for invoking `tailscale status` (injected in tests).
+ * @returns Discovery result; `available` is false when the CLI is missing or the
+ * daemon is unreachable.
+ */
 export async function discoverTailnetPeers(
   runStatus: (binary: string) => Promise<string> = runTailscaleStatus
 ): Promise<TailnetPeerDiscovery> {
@@ -150,6 +165,7 @@ export async function discoverTailnetPeers(
   return discovery
 }
 
+/** Clears the discovery cache and remembered binary path so tests start clean. */
 export function __resetTailnetPeerDiscoveryForTests(): void {
   cache = null
   workingBinary = null

--- a/src/main/runtime/rpc/methods/host-capabilities.test.ts
+++ b/src/main/runtime/rpc/methods/host-capabilities.test.ts
@@ -3,16 +3,24 @@ import { RpcDispatcher } from '../dispatcher'
 import type { RpcRequest } from '../core'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 
-const { isPwshAvailable, isWslAvailable, listWslDistros, isGitBashAvailable } = vi.hoisted(() => ({
+const {
+  isPwshAvailable,
+  isWslAvailable,
+  listWslDistros,
+  isGitBashAvailable,
+  discoverTailnetPeers
+} = vi.hoisted(() => ({
   isPwshAvailable: vi.fn(),
   isWslAvailable: vi.fn(),
   listWslDistros: vi.fn(),
-  isGitBashAvailable: vi.fn()
+  isGitBashAvailable: vi.fn(),
+  discoverTailnetPeers: vi.fn()
 }))
 
 vi.mock('../../../pwsh', () => ({ isPwshAvailable }))
 vi.mock('../../../wsl', () => ({ isWslAvailable, listWslDistros }))
 vi.mock('../../../git-bash', () => ({ isGitBashAvailable }))
+vi.mock('../../../network/tailscale-peer-discovery', () => ({ discoverTailnetPeers }))
 
 import { HOST_CAPABILITY_METHODS } from './host-capabilities'
 
@@ -26,6 +34,7 @@ describe('host capability RPC methods', () => {
     isWslAvailable.mockReset()
     listWslDistros.mockReset()
     isGitBashAvailable.mockReset()
+    discoverTailnetPeers.mockReset()
   })
 
   it('reports Windows shell capability probes through explicit methods', async () => {
@@ -53,6 +62,32 @@ describe('host capability RPC methods', () => {
     ).resolves.toMatchObject({
       ok: true,
       result: true
+    })
+  })
+
+  it('reports tailnet peer discovery from the host tailscale CLI', async () => {
+    const discovery = {
+      available: true,
+      peers: [
+        {
+          hostName: 'peer-a',
+          dnsName: 'peer-a.tail1234.ts.net',
+          ipv4: '100.64.0.2',
+          os: 'linux',
+          online: true,
+          tailscaleSsh: false
+        }
+      ]
+    }
+    discoverTailnetPeers.mockResolvedValue(discovery)
+    const runtime = { getRuntimeId: () => 'test-runtime' } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: HOST_CAPABILITY_METHODS })
+
+    await expect(
+      dispatcher.dispatch(makeRequest('host.tailscale.discoverPeers'))
+    ).resolves.toMatchObject({
+      ok: true,
+      result: discovery
     })
   })
 })

--- a/src/main/runtime/rpc/methods/host-capabilities.ts
+++ b/src/main/runtime/rpc/methods/host-capabilities.ts
@@ -2,6 +2,7 @@ import { defineMethod, type RpcMethod } from '../core'
 import { isPwshAvailable } from '../../../pwsh'
 import { isWslAvailable, listWslDistros } from '../../../wsl'
 import { isGitBashAvailable } from '../../../git-bash'
+import { discoverTailnetPeers } from '../../../network/tailscale-peer-discovery'
 
 export const HOST_CAPABILITY_METHODS: RpcMethod[] = [
   defineMethod({
@@ -23,6 +24,11 @@ export const HOST_CAPABILITY_METHODS: RpcMethod[] = [
     name: 'host.pwsh.isAvailable',
     params: null,
     handler: async () => isPwshAvailable()
+  }),
+  defineMethod({
+    name: 'host.tailscale.discoverPeers',
+    params: null,
+    handler: async () => discoverTailnetPeers()
   }),
   defineMethod({
     name: 'host.gitBash.isAvailable',

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -297,6 +297,7 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'host.gitBash.isAvailable',
   'host.platform',
   'host.pwsh.isAvailable',
+  'host.tailscale.discoverPeers',
   'host.wsl.isAvailable',
   'host.wsl.listDistros',
   'hostedReview.create',

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -15,6 +15,7 @@ import { registerWorkspaceCleanupHandlers } from '../ipc/workspace-cleanup'
 import { getLocalPtyProvider, registerPtyHandlers } from '../ipc/pty'
 import { registerDaemonManagementHandlers } from '../ipc/pty-management'
 import { registerSshHandlers } from '../ipc/ssh'
+import { registerTailscaleHandlers } from '../ipc/tailscale'
 import { registerRemoteWorkspaceHandlers } from '../ipc/remote-workspace'
 import { browserManager } from '../browser/browser-manager'
 import { hasSystemMediaAccess, requestSystemMediaAccess } from '../browser/browser-media-access'
@@ -137,6 +138,7 @@ export function attachMainWindowServices(
       })
   }
   registerSshHandlers(store, () => mainWindow, runtime)
+  registerTailscaleHandlers()
   registerRemoteWorkspaceHandlers(store, () => mainWindow)
   registerFileDropRelay(mainWindow)
   // Why: setupAutoUpdater's first getAutoUpdater() call synchronously

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -404,6 +404,7 @@ import type {
   PortForwardEntry,
   EnrichedDetectedPort
 } from '../shared/ssh-types'
+import type { TailnetPeerDiscovery } from '../shared/tailnet-peers'
 import type {
   CodexUsageBreakdownKind,
   CodexUsageBreakdownRow,
@@ -3109,6 +3110,11 @@ export type PreloadApi = {
   }
   grokAccounts: {
     getStatus: () => Promise<GrokAccountStatus>
+  }
+  tailscale: {
+    // Tailnet machines suggested as SSH targets. Unavailable (not an error)
+    // when the Tailscale CLI is absent or the daemon is down.
+    discoverPeers: () => Promise<TailnetPeerDiscovery>
   }
   ssh: {
     listTargets: () => Promise<SshTarget[]>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -141,6 +141,7 @@ import type {
   PortForwardEntry,
   EnrichedDetectedPort
 } from '../shared/ssh-types'
+import type { TailnetPeerDiscovery } from '../shared/tailnet-peers'
 import type {
   AgentStatusIpcPayload,
   MigrationUnsupportedPtyEntry
@@ -4133,6 +4134,11 @@ const api = {
 
   grokAccounts: {
     getStatus: (): Promise<GrokAccountStatus> => ipcRenderer.invoke('grokAccounts:getStatus')
+  },
+
+  tailscale: {
+    discoverPeers: (): Promise<TailnetPeerDiscovery> =>
+      ipcRenderer.invoke('tailscale:discoverPeers')
   },
 
   ssh: {

--- a/src/renderer/src/components/settings/SshTargetForm.tsx
+++ b/src/renderer/src/components/settings/SshTargetForm.tsx
@@ -8,7 +8,12 @@ import {
   hasAdvancedConnectionValues
 } from './SshTargetAdvancedConnectionSection'
 import { SshTargetTerminalPersistenceSection } from './SshTargetTerminalPersistenceSection'
-import { applyParsedSshHostInput, type EditingTarget } from './ssh-target-draft'
+import { TailnetPeerSuggestionSection } from './TailnetPeerSuggestionSection'
+import {
+  applyParsedSshHostInput,
+  applyTailnetPeerToDraft,
+  type EditingTarget
+} from './ssh-target-draft'
 import { translate } from '@/i18n/i18n'
 export { EMPTY_FORM, type EditingTarget } from './ssh-target-draft'
 
@@ -56,6 +61,11 @@ export function SshTargetForm({
       </p>
 
       <div className="grid grid-cols-2 gap-4">
+        {editingId === null && (
+          <TailnetPeerSuggestionSection
+            onPick={(peer) => onFormChange((f) => applyTailnetPeerToDraft(f, peer))}
+          />
+        )}
         <div className="space-y-1.5">
           <Label>{translate('auto.components.settings.SshTargetForm.298de87a88', 'Label')}</Label>
           <Input

--- a/src/renderer/src/components/settings/TailnetPeerSuggestionSection.tsx
+++ b/src/renderer/src/components/settings/TailnetPeerSuggestionSection.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react'
+import type { TailnetPeerSuggestion } from '../../../../shared/tailnet-peers'
+import { useMountedRef } from '@/hooks/useMountedRef'
+import { Button } from '../ui/button'
+import { Label } from '../ui/label'
+import { translate } from '@/i18n/i18n'
+
+// Why: large corporate tailnets can have dozens of peers; cap the chips so the
+// form stays a form. The remainder is still reachable by typing the host.
+const MAX_SUGGESTED_PEERS = 8
+
+type TailnetPeerSuggestionSectionProps = {
+  onPick: (peer: TailnetPeerSuggestion) => void
+}
+
+export function TailnetPeerSuggestionSection({
+  onPick
+}: TailnetPeerSuggestionSectionProps): React.JSX.Element | null {
+  const [peers, setPeers] = useState<TailnetPeerSuggestion[]>([])
+  const mountedRef = useMountedRef()
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const discovery = await window.api.tailscale.discoverPeers()
+        if (!mountedRef.current) {
+          return
+        }
+        // Why: offline peers can't be reached, so suggesting them invites
+        // connects that are guaranteed to fail.
+        setPeers(discovery.peers.filter((peer) => peer.online))
+      } catch {
+        // No Tailscale on this machine — the section simply stays hidden.
+      }
+    })()
+  }, [mountedRef])
+
+  if (peers.length === 0) {
+    return null
+  }
+
+  const visiblePeers = peers.slice(0, MAX_SUGGESTED_PEERS)
+  const hiddenCount = peers.length - visiblePeers.length
+
+  return (
+    <div className="col-span-2 space-y-1.5">
+      <Label>
+        {translate(
+          'auto.components.settings.TailnetPeerSuggestionSection.7a2f6fb0a5',
+          'Tailscale peers'
+        )}
+      </Label>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {visiblePeers.map((peer) => (
+          <Button
+            key={peer.dnsName || peer.ipv4 || peer.hostName}
+            type="button"
+            variant="outline"
+            size="sm"
+            title={[peer.dnsName || peer.ipv4, peer.os].filter(Boolean).join(' · ')}
+            onClick={() => onPick(peer)}
+          >
+            {peer.hostName}
+          </Button>
+        ))}
+        {hiddenCount > 0 && (
+          <span className="text-[11px] text-muted-foreground">
+            {translate(
+              'auto.components.settings.TailnetPeerSuggestionSection.60d02530dc',
+              '+{{count}} more on your tailnet',
+              { count: hiddenCount }
+            )}
+          </span>
+        )}
+      </div>
+      <p className="text-[11px] text-muted-foreground">
+        {translate(
+          'auto.components.settings.TailnetPeerSuggestionSection.c812f9f26b',
+          'Online machines on your tailnet. Click one to prefill the form.'
+        )}
+      </p>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/TailnetPeerSuggestionSection.tsx
+++ b/src/renderer/src/components/settings/TailnetPeerSuggestionSection.tsx
@@ -13,6 +13,13 @@ type TailnetPeerSuggestionSectionProps = {
   onPick: (peer: TailnetPeerSuggestion) => void
 }
 
+/**
+ * Renders clickable chips for online tailnet peers to prefill the SSH target
+ * form. Returns null when no peers are discovered — e.g. Tailscale isn't
+ * installed — so the section stays hidden rather than empty.
+ *
+ * @param onPick - Called with the chosen peer when a chip is clicked.
+ */
 export function TailnetPeerSuggestionSection({
   onPick
 }: TailnetPeerSuggestionSectionProps): React.JSX.Element | null {

--- a/src/renderer/src/components/settings/ssh-target-draft.test.ts
+++ b/src/renderer/src/components/settings/ssh-target-draft.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from 'vitest'
 import {
   EMPTY_FORM,
   applyParsedSshHostInput,
+  applyTailnetPeerToDraft,
   getEditingTargetForSshTarget,
   getSshTargetDraftConnectionFields,
   parseRelayGracePeriodSeconds,
   parseSshHostInput
 } from './ssh-target-draft'
+import type { TailnetPeerSuggestion } from '../../../../shared/tailnet-peers'
 
 describe('parseSshHostInput', () => {
   it('parses scp-style user, host, and port input', () => {
@@ -242,5 +244,41 @@ describe('getEditingTargetForSshTarget', () => {
 
     expect(draft.relayKeepAliveUntilReset).toBe(false)
     expect(draft.relayGracePeriodSeconds).toBe('600')
+  })
+})
+
+describe('applyTailnetPeerToDraft', () => {
+  const peer: TailnetPeerSuggestion = {
+    hostName: 'sezerchicago',
+    dnsName: 'sezerchicago.tail1234.ts.net',
+    ipv4: '100.96.7.56',
+    os: 'linux',
+    online: true,
+    tailscaleSsh: true
+  }
+
+  it('prefills the host with the MagicDNS name and the label with the host name', () => {
+    const draft = applyTailnetPeerToDraft(EMPTY_FORM, peer)
+
+    expect(draft.host).toBe('sezerchicago.tail1234.ts.net')
+    expect(draft.label).toBe('sezerchicago')
+    expect(draft.port).toBe('22')
+  })
+
+  it('falls back to the tailnet IPv4 when MagicDNS is disabled', () => {
+    const draft = applyTailnetPeerToDraft(EMPTY_FORM, { ...peer, dnsName: '' })
+
+    expect(draft.host).toBe('100.96.7.56')
+  })
+
+  it('keeps a label and username the user already typed', () => {
+    const draft = applyTailnetPeerToDraft(
+      { ...EMPTY_FORM, label: 'My Oracle box', username: 'ubuntu' },
+      peer
+    )
+
+    expect(draft.label).toBe('My Oracle box')
+    expect(draft.username).toBe('ubuntu')
+    expect(draft.host).toBe('sezerchicago.tail1234.ts.net')
   })
 })

--- a/src/renderer/src/components/settings/ssh-target-draft.ts
+++ b/src/renderer/src/components/settings/ssh-target-draft.ts
@@ -112,6 +112,10 @@ export function applyParsedSshHostInput(draft: EditingTarget): EditingTarget {
   }
 }
 
+/**
+ * Prefills a draft from a picked tailnet peer, preferring the MagicDNS name over
+ * the raw tailnet IP and only filling the label when the user hasn't set one.
+ */
 export function applyTailnetPeerToDraft(
   draft: EditingTarget,
   peer: TailnetPeerSuggestion

--- a/src/renderer/src/components/settings/ssh-target-draft.ts
+++ b/src/renderer/src/components/settings/ssh-target-draft.ts
@@ -5,6 +5,7 @@ import {
   MIN_SSH_RELAY_GRACE_PERIOD_SECONDS,
   type SshTarget
 } from '../../../../shared/ssh-types'
+import type { TailnetPeerSuggestion } from '../../../../shared/tailnet-peers'
 
 export type EditingTarget = {
   label: string
@@ -108,6 +109,19 @@ export function applyParsedSshHostInput(draft: EditingTarget): EditingTarget {
     username: draft.username.trim() || parsed.username || '',
     port:
       parsed.port !== undefined && isDefaultPortDraft(draft.port) ? String(parsed.port) : draft.port
+  }
+}
+
+export function applyTailnetPeerToDraft(
+  draft: EditingTarget,
+  peer: TailnetPeerSuggestion
+): EditingTarget {
+  return {
+    ...draft,
+    // Why: MagicDNS names survive IP churn; the raw 100.x address is only a
+    // fallback for tailnets with MagicDNS disabled.
+    host: peer.dnsName || peer.ipv4 || draft.host,
+    label: draft.label.trim() ? draft.label : peer.hostName
   }
 }
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9238,6 +9238,11 @@
           "howToUseDescription": "Ask an agent working a Linear-linked worktree to read context, post updates, move the ticket, or attach the PR.",
           "terminalTitle": "Linear skill setup",
           "terminalAriaLabel": "Linear skill install terminal"
+        },
+        "TailnetPeerSuggestionSection": {
+          "7a2f6fb0a5": "Tailscale peers",
+          "60d02530dc": "+{{count}} more on your tailnet",
+          "c812f9f26b": "Online machines on your tailnet. Click one to prefill the form."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9215,6 +9215,11 @@
           "howToUseDescription": "Ask an agent working a Linear-linked worktree to read context, post updates, move the ticket, or attach the PR.",
           "terminalTitle": "Linear skill setup",
           "terminalAriaLabel": "Linear skill install terminal"
+        },
+        "TailnetPeerSuggestionSection": {
+          "7a2f6fb0a5": "Tailscale peers",
+          "60d02530dc": "+{{count}} more on your tailnet",
+          "c812f9f26b": "Online machines on your tailnet. Click one to prefill the form."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9215,6 +9215,11 @@
           "howToUseDescription": "Ask an agent working a Linear-linked worktree to read context, post updates, move the ticket, or attach the PR.",
           "terminalTitle": "Linear skill setup",
           "terminalAriaLabel": "Linear skill install terminal"
+        },
+        "TailnetPeerSuggestionSection": {
+          "7a2f6fb0a5": "Tailscale peers",
+          "60d02530dc": "+{{count}} more on your tailnet",
+          "c812f9f26b": "Online machines on your tailnet. Click one to prefill the form."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9215,6 +9215,11 @@
           "howToUseDescription": "Ask an agent working a Linear-linked worktree to read context, post updates, move the ticket, or attach the PR.",
           "terminalTitle": "Linear skill setup",
           "terminalAriaLabel": "Linear skill install terminal"
+        },
+        "TailnetPeerSuggestionSection": {
+          "7a2f6fb0a5": "Tailscale peers",
+          "60d02530dc": "+{{count}} more on your tailnet",
+          "c812f9f26b": "Online machines on your tailnet. Click one to prefill the form."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9215,6 +9215,11 @@
           "howToUseDescription": "Ask an agent working a Linear-linked worktree to read context, post updates, move the ticket, or attach the PR.",
           "terminalTitle": "Linear skill setup",
           "terminalAriaLabel": "Linear skill install terminal"
+        },
+        "TailnetPeerSuggestionSection": {
+          "7a2f6fb0a5": "Tailscale peers",
+          "60d02530dc": "+{{count}} more on your tailnet",
+          "c812f9f26b": "Online machines on your tailnet. Click one to prefill the form."
         }
       },
       "right": {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -36,6 +36,7 @@ import type {
 import type { SkillDiscoveryResult } from '../../../shared/skills'
 import type { SkillFreshnessInventory } from '../../../shared/skill-freshness'
 import type { SshConnectionState, SshTarget } from '../../../shared/ssh-types'
+import type { TailnetPeerDiscovery } from '../../../shared/tailnet-peers'
 import {
   getDefaultOnboardingState,
   getDefaultSettings,
@@ -739,6 +740,16 @@ function createWebPreloadApi(): Partial<PreloadApi> {
     skills: createSkillsApi(),
     pty: createPtyApi(),
     ssh: createSshApi(),
+    tailscale: {
+      // Why: suggestions come from the serve host's tailscale CLI — the machine
+      // that will run the SSH connection. Older hosts without the RPC method
+      // degrade to "unavailable" instead of erroring.
+      discoverPeers: () =>
+        callRuntimeResult<TailnetPeerDiscovery>('host.tailscale.discoverPeers').catch(() => ({
+          available: false,
+          peers: []
+        }))
+    },
     wsl: {
       isAvailable: () => callRuntimeResult<boolean>('host.wsl.isAvailable').catch(() => false),
       listDistros: () => callRuntimeResult<string[]>('host.wsl.listDistros').catch(() => [])

--- a/src/shared/tailnet-peers.ts
+++ b/src/shared/tailnet-peers.ts
@@ -1,0 +1,18 @@
+export type TailnetPeerSuggestion = {
+  hostName: string
+  /** MagicDNS name without the trailing dot, e.g. `my-mac.tail1234.ts.net`.
+   *  Empty when MagicDNS is disabled on the tailnet. */
+  dnsName: string
+  /** First Tailscale IPv4 (100.64.0.0/10) of the peer, if any. */
+  ipv4: string | null
+  os: string
+  online: boolean
+  /** Peer advertises Tailscale SSH host keys, so tailscaled itself serves SSH. */
+  tailscaleSsh: boolean
+}
+
+export type TailnetPeerDiscovery = {
+  /** False when the Tailscale CLI is missing or `tailscale status` failed. */
+  available: boolean
+  peers: TailnetPeerSuggestion[]
+}


### PR DESCRIPTION
## What

When adding a **New SSH Target** (Settings → SSH), Orca now suggests machines from the user's Tailscale tailnet. Clicking a suggestion prefills the form with the peer's MagicDNS name (falling back to its `100.x` IP when MagicDNS is disabled) and uses the peer's hostname as the label. The section renders only when the Tailscale CLI is present, the daemon responds, and at least one peer is online — on machines without Tailscale nothing changes.

This completes a direction the codebase already leans into: tailnet-first sorting for mobile pairing, the "Connect with your own tailnet" pairing accordion, `*.ts.net` placeholder copy, and Tailscale hints on remote-runtime connection failures. What was missing was actually asking `tailscale` who's on the tailnet.

## How

- **`src/main/network/tailscale-peer-discovery.ts`** — runs `tailscale status --json` (async `execFile`, 3s timeout, 15s TTL cache, modeled on `macos-tailscale-dns-diagnostic.ts`) and parses `Peer` into suggestions: hostname, trimmed MagicDNS name, first tailnet IPv4 (via the existing `isTailnetIPv4Address`), OS, online flag, and whether the peer advertises Tailscale SSH host keys. Mullvad exit nodes are filtered. Binary lookup checks PATH plus the macOS app-bundle and Windows Program Files locations. Any failure degrades silently to `{ available: false }`.
- **IPC** — `tailscale:discoverPeers` registered in `attach-main-window-services.ts` alongside `registerSshHandlers`, with the same remove-before-handle re-registration guard.
- **Runtime RPC** — `host.tailscale.discoverPeers` added to `HOST_CAPABILITY_METHODS` and the method allowlist, so the web client asks the **serve host's** tailscale — the machine that will actually run the SSH connection. `web-preload-api.ts` proxies it with a `.catch` fallback, so older serve hosts degrade to "unavailable" instead of erroring.
- **UI** — `TailnetPeerSuggestionSection.tsx`, rendered at the top of `SshTargetForm` only for new targets. Online peers only, capped at 8 chips with a "+N more" note; tooltip shows the MagicDNS name and OS. `applyTailnetPeerToDraft` in `ssh-target-draft.ts` fills only the gaps — a label or username the user already typed is kept, and the existing `applyParsedSshHostInput` / save-payload flow is untouched.

Suggested targets are saved as ordinary `manual` targets — no new `SshTarget.source` value, no transport changes, and the `ssh -G` / config-import precedence contract is untouched.

## Tests

- `tailscale-peer-discovery.test.ts` — parsing (MagicDNS trim, IPv4 selection, Mullvad filter, online-first sort, hostname fallbacks, malformed JSON), discovery degradation when the CLI is missing, and TTL caching.
- `ssh-target-draft.test.ts` — prefill semantics including the MagicDNS→IPv4 fallback and keeping user-typed label/username.
- `host-capabilities.test.ts` — the new RPC method dispatches and returns the discovery result.

## AI code review summary (Claude)

- **Cross-platform**: binary candidates cover macOS (`/Applications/Tailscale.app/...`), Windows (`%ProgramFiles%\Tailscale\tailscale.exe`, `windowsHide`, path built with `path.join`), and Linux/PATH. No shell invocation, no hardcoded separators.
- **SSH/remote/local**: desktop asks the local CLI; web/`orca serve` clients ask the serve host via runtime RPC with graceful fallback on older hosts. Suggestions feed the existing manual-target flow only.
- **Agent/integration/provider compatibility**: not applicable — no agent CLIs, git providers, or integrations are touched.
- **Performance**: discovery runs only when the New Target form mounts; 3s exec timeout, 15s cache, 8MB maxBuffer; failures are cached too, so a missing binary is probed at most once per TTL per form open. Nothing added to hot paths.
- **UI quality**: shadcn `Button`/`Label` primitives and existing token classes only; all strings localized via `translate()` with catalog entries synced for all five locales; section hidden (not empty-state) when there's nothing to suggest.
- **Security**: `execFile` with a fixed argv (no shell, no user input in the command); output is JSON-parsed defensively; no data leaves the machine — the tailnet is queried locally.

## Notes

- No telemetry, settings, or persisted-state changes; no new dependencies.
- Visual change: yes — one new optional section in the New SSH Target form. Screenshot to follow from a tailnet-connected machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI5

When you add a new SSH target, Orca can suggest online machines from your Tailscale network. Click one to fill MagicDNS name (or IP) and label; if Tailscale is not installed, the form looks exactly as before.
