### PR TITLE
feat(usage): surface pay-as-you-go credit balances (Claude usage credits, OpenCode Go Zen balance, Codex credits)

### DIFF
--- a/src/main/rate-limits/claude-fetcher-extra-usage.test.ts
+++ b/src/main/rate-limits/claude-fetcher-extra-usage.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { fetchClaudeRateLimits } from './claude-fetcher'
+import { primeClaudeFetcherMocks, restorePlatform } from './claude-fetcher-test-harness'
+import { readActiveClaudeKeychainCredentialsStrict } from '../claude-accounts/keychain'
+import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
+
+const { netFetchMock, readFileMock, resolveProxyMock, setProxyMock, appGetPathMock } = vi.hoisted(
+  () => ({
+    netFetchMock: vi.fn(),
+    readFileMock: vi.fn(),
+    resolveProxyMock: vi.fn(),
+    setProxyMock: vi.fn(),
+    appGetPathMock: vi.fn()
+  })
+)
+
+vi.mock('node:fs/promises', () => ({
+  readFile: readFileMock
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: appGetPathMock
+  },
+  net: {
+    fetch: netFetchMock
+  },
+  session: {
+    defaultSession: {
+      resolveProxy: resolveProxyMock,
+      setProxy: setProxyMock
+    }
+  }
+}))
+
+vi.mock('./claude-pty', () => ({
+  fetchViaPty: vi.fn()
+}))
+
+vi.mock('../claude-accounts/keychain', () => ({
+  deleteActiveClaudeKeychainCredentialsStrict: vi.fn(),
+  readActiveClaudeKeychainCredentials: vi.fn(),
+  readActiveClaudeKeychainCredentialsStrict: vi.fn(),
+  readManagedClaudeKeychainCredentials: vi.fn(),
+  writeActiveClaudeKeychainCredentials: vi.fn(),
+  writeManagedClaudeKeychainCredentials: vi.fn()
+}))
+
+function oauthPrep(): ClaudeRuntimeAuthPreparation {
+  return {
+    configDir: '/Users/test/.claude',
+    envPatch: { CLAUDE_CONFIG_DIR: '/Users/test/.claude' },
+    stripAuthEnv: false,
+    provenance: 'system'
+  }
+}
+
+describe('fetchClaudeRateLimits extra usage', () => {
+  beforeEach(() => {
+    primeClaudeFetcherMocks({
+      netFetchMock,
+      readFileMock,
+      resolveProxyMock,
+      setProxyMock,
+      appGetPathMock
+    })
+  })
+
+  afterEach(() => {
+    restorePlatform()
+  })
+
+  it('maps the usage-credits spend object into a capped balance in major units', async () => {
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockResolvedValueOnce(
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'oauth-token',
+          expiresAt: Date.now() + 60_000
+        }
+      })
+    )
+    netFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          five_hour: { utilization: 10 },
+          spend: {
+            used: { amount_minor: 5000, currency: 'EUR', exponent: 2 },
+            limit: { amount_minor: 200000, currency: 'EUR', exponent: 2 },
+            percent: 2.5,
+            enabled: true,
+            balance: { amount_minor: 1000, currency: 'EUR', exponent: 2 }
+          }
+        }),
+        { status: 200 }
+      )
+    )
+
+    await expect(fetchClaudeRateLimits({ authPreparation: oauthPrep() })).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'ok',
+      extraUsage: {
+        balance: 10,
+        spent: 50,
+        spendLimit: 2000,
+        spentPercent: 2.5,
+        currencyCode: 'EUR',
+        enabled: true,
+        disabledReason: null,
+        resetsAt: null
+      }
+    })
+  })
+
+  it('keeps the usage-credits cap visible but disabled when out of credits', async () => {
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockResolvedValueOnce(
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'oauth-token',
+          expiresAt: Date.now() + 60_000
+        }
+      })
+    )
+    netFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          five_hour: { utilization: 10 },
+          spend: {
+            used: { amount_minor: 0, currency: 'EUR', exponent: 2 },
+            limit: { amount_minor: 200000, currency: 'EUR', exponent: 2 },
+            percent: 0,
+            enabled: false,
+            disabled_reason: 'out_of_credits',
+            balance: null
+          }
+        }),
+        { status: 200 }
+      )
+    )
+
+    await expect(fetchClaudeRateLimits({ authPreparation: oauthPrep() })).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'ok',
+      extraUsage: {
+        balance: 0,
+        spent: 0,
+        spendLimit: 2000,
+        spentPercent: 0,
+        currencyCode: 'EUR',
+        enabled: false,
+        disabledReason: 'out_of_credits'
+      }
+    })
+  })
+
+  it('falls back to the legacy extra_usage shape when spend is absent', async () => {
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockResolvedValueOnce(
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'oauth-token',
+          expiresAt: Date.now() + 60_000
+        }
+      })
+    )
+    netFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          five_hour: { utilization: 10 },
+          extra_usage: {
+            is_enabled: true,
+            monthly_limit: 200000,
+            used_credits: 5000,
+            utilization: 2.5,
+            currency: 'EUR',
+            decimal_places: 2
+          }
+        }),
+        { status: 200 }
+      )
+    )
+
+    await expect(fetchClaudeRateLimits({ authPreparation: oauthPrep() })).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'ok',
+      extraUsage: {
+        balance: 0,
+        spent: 50,
+        spendLimit: 2000,
+        spentPercent: 2.5,
+        currencyCode: 'EUR',
+        enabled: true
+      }
+    })
+  })
+})

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -409,6 +409,8 @@ function mapSpend(spend: OAuthSpend | undefined): ExtraUsageBalance | null {
         : null
   return {
     balance,
+    unit: 'currency',
+    unlimited: false,
     currencyCode:
       spend.used?.currency ?? spend.limit?.currency ?? spend.cap?.money?.currency ?? 'USD',
     enabled: spend.enabled === true,
@@ -436,6 +438,8 @@ function mapLegacyExtraUsage(extra: OAuthExtraUsage | undefined): ExtraUsageBala
         : null
   return {
     balance: 0,
+    unit: 'currency',
+    unlimited: false,
     currencyCode: extra.currency?.trim() || 'USD',
     enabled: extra.is_enabled === true,
     disabledReason: extra.disabled_reason ?? null,

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -5,6 +5,7 @@ import { homedir } from 'node:os'
 import path from 'node:path'
 import { net, session } from 'electron'
 import type {
+  ExtraUsageBalance,
   ProviderRateLimits,
   RateLimitWindow,
   UsageRateLimitFailureKind,
@@ -289,12 +290,45 @@ type OAuthUsageLimit = {
   scope?: { model?: { display_name?: string } | null } | null
 }
 
+// Money is reported as minor units plus an exponent (e.g. 200000 @ exp 2 = €2000).
+type OAuthMoney = {
+  amount_minor?: number
+  currency?: string
+  exponent?: number
+}
+
+// The current "usage credits" shape: spent/limit as money, a live balance, and
+// whether spending is currently possible. This is what Claude Code's own /usage
+// panel renders as "Usage credits" (monthly spend limit + current balance).
+type OAuthSpend = {
+  used?: OAuthMoney
+  limit?: OAuthMoney
+  percent?: number
+  enabled?: boolean
+  disabled_reason?: string | null
+  cap?: { money?: OAuthMoney | null } | null
+  balance?: OAuthMoney | number | null
+}
+
+// Legacy shape kept as a fallback for older responses that only send `extra_usage`.
+type OAuthExtraUsage = {
+  is_enabled?: boolean
+  monthly_limit?: number
+  used_credits?: number
+  utilization?: number
+  currency?: string
+  decimal_places?: number
+  disabled_reason?: string | null
+}
+
 type OAuthUsageResponse = {
   five_hour?: OAuthUsageWindow
   seven_day?: OAuthUsageWindow
   fable_weekly?: OAuthUsageWindow
   fable_seven_day?: OAuthUsageWindow
   seven_day_fable?: OAuthUsageWindow
+  spend?: OAuthSpend
+  extra_usage?: OAuthExtraUsage
   limits?: OAuthUsageLimit[] | null
 }
 
@@ -334,6 +368,82 @@ function mapFableWeeklyWindow(data: OAuthUsageResponse): RateLimitWindow | null 
     mapClaudeUsageWindow(data.fable_seven_day, 10080) ??
     mapClaudeUsageWindow(data.seven_day_fable, 10080)
   )
+}
+
+function clampPercent(value: number): number {
+  return Math.min(100, Math.max(0, value))
+}
+
+function moneyToMajor(money: OAuthMoney | number | null | undefined): number | null {
+  if (typeof money === 'number') {
+    return Number.isFinite(money) ? money : null
+  }
+  if (!money || typeof money.amount_minor !== 'number') {
+    return null
+  }
+  const exponent = typeof money.exponent === 'number' ? money.exponent : 2
+  return money.amount_minor / 10 ** exponent
+}
+
+// Prefer the richer `spend` object; fall back to the legacy `extra_usage` shape.
+function mapClaudeExtraUsage(data: OAuthUsageResponse): ExtraUsageBalance | null {
+  return mapSpend(data.spend) ?? mapLegacyExtraUsage(data.extra_usage)
+}
+
+function mapSpend(spend: OAuthSpend | undefined): ExtraUsageBalance | null {
+  if (!spend) {
+    return null
+  }
+  const spent = moneyToMajor(spend.used)
+  const spendLimit = moneyToMajor(spend.limit) ?? moneyToMajor(spend.cap?.money)
+  const balance = moneyToMajor(spend.balance) ?? 0
+  // Nothing worth showing when the account has neither a configured cap nor a balance.
+  if (spendLimit === null && balance === 0) {
+    return null
+  }
+  const spentPercent =
+    typeof spend.percent === 'number'
+      ? clampPercent(spend.percent)
+      : spendLimit !== null && spendLimit > 0 && spent !== null
+        ? clampPercent((spent / spendLimit) * 100)
+        : null
+  return {
+    balance,
+    currencyCode:
+      spend.used?.currency ?? spend.limit?.currency ?? spend.cap?.money?.currency ?? 'USD',
+    enabled: spend.enabled === true,
+    disabledReason: spend.disabled_reason ?? null,
+    spent,
+    spendLimit,
+    spentPercent,
+    resetsAt: null
+  }
+}
+
+function mapLegacyExtraUsage(extra: OAuthExtraUsage | undefined): ExtraUsageBalance | null {
+  if (!extra || typeof extra.monthly_limit !== 'number') {
+    return null
+  }
+  // Amounts are minor units; `decimal_places` gives the exponent (default cents).
+  const divisor = 10 ** (typeof extra.decimal_places === 'number' ? extra.decimal_places : 2)
+  const spendLimit = extra.monthly_limit / divisor
+  const spent = typeof extra.used_credits === 'number' ? extra.used_credits / divisor : null
+  const spentPercent =
+    typeof extra.utilization === 'number'
+      ? clampPercent(extra.utilization)
+      : spendLimit > 0 && spent !== null
+        ? clampPercent((spent / spendLimit) * 100)
+        : null
+  return {
+    balance: 0,
+    currencyCode: extra.currency?.trim() || 'USD',
+    enabled: extra.is_enabled === true,
+    disabledReason: extra.disabled_reason ?? null,
+    spent,
+    spendLimit,
+    spentPercent,
+    resetsAt: null
+  }
 }
 
 async function fetchViaOAuth(token: string, signal?: AbortSignal): Promise<ProviderRateLimits> {
@@ -376,6 +486,7 @@ async function fetchViaOAuth(token: string, signal?: AbortSignal): Promise<Provi
       session: mapClaudeUsageWindow(data.five_hour, 300),
       weekly: mapClaudeUsageWindow(data.seven_day, 10080),
       fableWeekly: mapFableWeeklyWindow(data),
+      extraUsage: mapClaudeExtraUsage(data),
       updatedAt: Date.now(),
       error: null,
       status: 'ok'
@@ -517,7 +628,9 @@ function mergeClaudeUsageWindows(
     ...primary,
     session: primary.session ?? supplement.session,
     weekly: primary.weekly ?? supplement.weekly,
-    fableWeekly: primary.fableWeekly ?? supplement.fableWeekly ?? null
+    fableWeekly: primary.fableWeekly ?? supplement.fableWeekly ?? null,
+    // Only OAuth reports the extra-usage cap; keep it when the CLI supplements windows.
+    extraUsage: primary.extraUsage ?? supplement.extraUsage ?? null
   }
 }
 

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -378,10 +378,13 @@ function moneyToMajor(money: OAuthMoney | number | null | undefined): number | n
   if (typeof money === 'number') {
     return Number.isFinite(money) ? money : null
   }
-  if (!money || typeof money.amount_minor !== 'number') {
+  if (!money || typeof money.amount_minor !== 'number' || !Number.isFinite(money.amount_minor)) {
     return null
   }
   const exponent = typeof money.exponent === 'number' ? money.exponent : 2
+  if (!Number.isInteger(exponent) || exponent < 0 || exponent > 6) {
+    return null
+  }
   return money.amount_minor / 10 ** exponent
 }
 
@@ -410,7 +413,6 @@ function mapSpend(spend: OAuthSpend | undefined): ExtraUsageBalance | null {
   return {
     balance,
     unit: 'currency',
-    unlimited: false,
     currencyCode:
       spend.used?.currency ?? spend.limit?.currency ?? spend.cap?.money?.currency ?? 'USD',
     enabled: spend.enabled === true,
@@ -439,7 +441,6 @@ function mapLegacyExtraUsage(extra: OAuthExtraUsage | undefined): ExtraUsageBala
   return {
     balance: 0,
     unit: 'currency',
-    unlimited: false,
     currencyCode: extra.currency?.trim() || 'USD',
     enabled: extra.is_enabled === true,
     disabledReason: extra.disabled_reason ?? null,

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -496,6 +496,44 @@ describe('fetchCodexRateLimits', () => {
     })
   })
 
+  it('maps the RPC credits object into a Codex credit-count balance', async () => {
+    const rpcChild = makeRpcChild()
+    childSpawnMock.mockReturnValue(rpcChild)
+    respondToRpcRateLimitRead(rpcChild, {
+      primary: { usedPercent: 20, windowDurationMins: 10079 },
+      secondary: null,
+      credits: { hasCredits: true, unlimited: false, balance: '500' }
+    })
+
+    const resultPromise = fetchCodexRateLimits({ allowPtyFallback: false })
+    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(1)
+    const result = await resultPromise
+
+    expect(result.extraUsage).toMatchObject({
+      balance: 500,
+      unit: 'credits',
+      unlimited: false,
+      enabled: true
+    })
+  })
+
+  it('omits the Codex balance when the account has no credits', async () => {
+    const rpcChild = makeRpcChild()
+    childSpawnMock.mockReturnValue(rpcChild)
+    respondToRpcRateLimitRead(rpcChild, {
+      primary: { usedPercent: 20, windowDurationMins: 10079 },
+      credits: { hasCredits: false, unlimited: false, balance: '0' }
+    })
+
+    const resultPromise = fetchCodexRateLimits({ allowPtyFallback: false })
+    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(1)
+    const result = await resultPromise
+
+    expect(result.extraUsage ?? null).toBeNull()
+  })
+
   it('fills reset-credit count from the backend when the installed app-server omits it', async () => {
     const rpcChild = makeRpcChild()
     childSpawnMock.mockReturnValue(rpcChild)

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines -- Why: keep Codex RPC and PTY fallback paths together to audit protocol/parsing differences and shared account-scoped env handling. */
 import type {
   CodexRateLimitResetOutcome,
+  ExtraUsageBalance,
   ProviderRateLimits,
   RateLimitWindow
 } from '../../shared/rate-limit-types'
@@ -92,6 +93,10 @@ type RateLimitResetCredits = {
     grantedAt: number | null
   }[]
 }
+
+// Codex's pay-as-you-go credit balance, reported alongside the rate windows.
+// `balance` is a plain credit count (string), not a currency amount.
+type RpcCredits = NonNullable<CodexRateLimitWindowsSnapshot['credits']>
 
 // Why: the Codex app-server wraps rate limit data as { rateLimits: { primary, secondary, ... } }.
 type RpcRateLimitsResponse = {
@@ -506,6 +511,29 @@ function mapRpcWindow(
   }
 }
 
+// Codex credits are a unitless count, not currency. Only surface the balance
+// when the account actually has credits (or unlimited) so accounts that never
+// bought any don't get an empty "0 credits" row.
+function mapCodexCredits(raw: RpcCredits | null | undefined): ExtraUsageBalance | null {
+  if (!raw || (raw.hasCredits !== true && raw.unlimited !== true)) {
+    return null
+  }
+  const parsed = typeof raw.balance === 'string' ? Number(raw.balance) : raw.balance
+  const balance = typeof parsed === 'number' && Number.isFinite(parsed) ? Math.max(0, parsed) : 0
+  return {
+    balance,
+    unit: 'credits',
+    unlimited: raw.unlimited === true,
+    currencyCode: 'USD',
+    enabled: raw.hasCredits === true || raw.unlimited === true,
+    disabledReason: null,
+    spent: null,
+    spendLimit: null,
+    spentPercent: null,
+    resetsAt: null
+  }
+}
+
 function backendWindowToSnapshot(
   raw: BackendRateLimitWindow | null | undefined
 ): CodexRateWindowSnapshot | null {
@@ -809,6 +837,7 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
             const rateLimitResetCredits = mapRpcRateLimitResetCredits(
               wrapper?.rateLimitResetCredits
             )
+            const extraUsage = mapCodexCredits(result?.credits)
 
             settle(
               {
@@ -816,6 +845,7 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
                 session,
                 weekly,
                 ...(rateLimitResetCredits !== undefined ? { rateLimitResetCredits } : {}),
+                ...(extraUsage ? { extraUsage } : {}),
                 updatedAt: Date.now(),
                 error: null,
                 status: 'ok'

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -524,12 +524,8 @@ function mapCodexCredits(raw: RpcCredits | null | undefined): ExtraUsageBalance 
     balance,
     unit: 'credits',
     unlimited: raw.unlimited === true,
-    currencyCode: 'USD',
     enabled: raw.hasCredits === true || raw.unlimited === true,
     disabledReason: null,
-    spent: null,
-    spendLimit: null,
-    spentPercent: null,
     resetsAt: null
   }
 }

--- a/src/main/rate-limits/codex-rate-limit-window-classification.ts
+++ b/src/main/rate-limits/codex-rate-limit-window-classification.ts
@@ -13,6 +13,12 @@ export type CodexRateWindowSnapshot = {
 export type CodexRateLimitWindowsSnapshot = {
   primary?: CodexRateWindowSnapshot | null
   secondary?: CodexRateWindowSnapshot | null
+  /** Pay-as-you-go credit balance, when the app-server reports one. */
+  credits?: {
+    hasCredits?: boolean
+    unlimited?: boolean
+    balance?: string | number
+  } | null
 }
 
 type MappableCodexRateWindowSnapshot = CodexRateWindowSnapshot & { usedPercent: number }

--- a/src/main/rate-limits/opencode-go-page-scraper.test.ts
+++ b/src/main/rate-limits/opencode-go-page-scraper.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { parseZenBalanceUsd } from './opencode-go-page-scraper'
+import { parseSubscriptionFromPageText, parseZenBalanceUsd } from './opencode-go-page-scraper'
 
 describe('parseZenBalanceUsd', () => {
   it('parses a scaled balance from a React Flight billing object', () => {
-    // Balance is serialized in 1e-8 USD units alongside a real customerID.
     const text = '($R=>$R[0]=$R[1]={customerID:"cus_test",balance:$R[2]=2375000000,reload:!1})'
     expect(parseZenBalanceUsd(text)).toBe(23.75)
   })
@@ -18,19 +17,27 @@ describe('parseZenBalanceUsd', () => {
     expect(parseZenBalanceUsd(text)).toBeNull()
   })
 
-  it('parses an explicit whole-USD balance key with thousands separators', () => {
-    const text = '{"balanceEnabled":true,"zenBalance":"1,042.75"}'
-    expect(parseZenBalanceUsd(text)).toBe(1042.75)
+  it('keeps the balance scoped to the billing record', () => {
+    const text = [
+      '$R[0]={customerID:"cus_test",reload:!1}',
+      '$R[1]={metrics:{balance:4200000000}}'
+    ].join('')
+    expect(parseZenBalanceUsd(text)).toBeNull()
   })
 
-  it('does not treat balance metadata as the amount', () => {
-    const text = '{"balanceUpdatedAt":1800000000,"balanceRefreshInterval":60,"zenBalance":"42.50"}'
-    expect(parseZenBalanceUsd(text)).toBe(42.5)
+  it('skips nested balances before the billing record balance', () => {
+    const text =
+      '$R[0]={customerID:"cus_test",metrics:{balance:9900000000},balance:1250000000,reload:!1}'
+    expect(parseZenBalanceUsd(text)).toBe(12.5)
   })
 
-  it('parses a human-readable balance string as a last resort', () => {
-    const text = '<html><body><h2>Current balance $1,234.56</h2></body></html>'
-    expect(parseZenBalanceUsd(text)).toBe(1234.56)
+  it('surfaces granted credit without requiring a payment customer', () => {
+    const text = '$R[0]={customerID:null,balance:500000000,reload:!1,reloadAmount:2000000000}'
+    expect(parseZenBalanceUsd(text)).toBe(5)
+  })
+
+  it('does not infer a balance from human-readable page copy', () => {
+    expect(parseZenBalanceUsd('<h2>Current balance $1,234.56</h2>')).toBeNull()
   })
 
   it('returns null when no balance is present', () => {
@@ -39,5 +46,27 @@ describe('parseZenBalanceUsd', () => {
 
   it('guards against oversized payloads', () => {
     expect(parseZenBalanceUsd('x'.repeat(10_000_001))).toBeNull()
+  })
+})
+
+describe('parseSubscriptionFromPageText', () => {
+  it.each([
+    ['!0', true],
+    ['true', true],
+    ['!1', false],
+    ['false', false]
+  ])('parses useBalance %s from the subscription record', (wireValue, expected) => {
+    const text = `$R[0]={note:"brace } stays data",useBalance:${wireValue},rollingUsage:$R[1]={usagePercent:20,resetInSec:60},weeklyUsage:$R[2]={usagePercent:30,resetInSec:120},monthlyUsage:null}`
+    expect(parseSubscriptionFromPageText(text)).toMatchObject({
+      rollingUsagePercent: 20,
+      weeklyUsagePercent: 30,
+      useBalance: expected
+    })
+  })
+
+  it('does not borrow useBalance from an unrelated object', () => {
+    const text =
+      '$R[0]={useBalance:!0}$R[1]={rollingUsage:$R[2]={usagePercent:20,resetInSec:60},weeklyUsage:$R[3]={usagePercent:30,resetInSec:120}}'
+    expect(parseSubscriptionFromPageText(text)).toMatchObject({ useBalance: null })
   })
 })

--- a/src/main/rate-limits/opencode-go-page-scraper.test.ts
+++ b/src/main/rate-limits/opencode-go-page-scraper.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { parseZenBalanceUsd } from './opencode-go-page-scraper'
+
+describe('parseZenBalanceUsd', () => {
+  it('parses a scaled balance from a React Flight billing object', () => {
+    // Balance is serialized in 1e-8 USD units alongside a real customerID.
+    const text = '($R=>$R[0]=$R[1]={customerID:"cus_test",balance:$R[2]=2375000000,reload:!1})'
+    expect(parseZenBalanceUsd(text)).toBe(23.75)
+  })
+
+  it('ignores balances when billing is disabled (null customerID)', () => {
+    const text = '$R[0]={customerID:null,balance:0,reload:!1}'
+    expect(parseZenBalanceUsd(text)).toBeNull()
+  })
+
+  it('ignores unrelated balance metadata with no customerID or amount', () => {
+    const text = '$R[0]={balanceEnabled:!0,balanceUpdatedAt:1800000000}'
+    expect(parseZenBalanceUsd(text)).toBeNull()
+  })
+
+  it('parses an explicit whole-USD balance key with thousands separators', () => {
+    const text = '{"balanceEnabled":true,"zenBalance":"1,042.75"}'
+    expect(parseZenBalanceUsd(text)).toBe(1042.75)
+  })
+
+  it('does not treat balance metadata as the amount', () => {
+    const text = '{"balanceUpdatedAt":1800000000,"balanceRefreshInterval":60,"zenBalance":"42.50"}'
+    expect(parseZenBalanceUsd(text)).toBe(42.5)
+  })
+
+  it('parses a human-readable balance string as a last resort', () => {
+    const text = '<html><body><h2>Current balance $1,234.56</h2></body></html>'
+    expect(parseZenBalanceUsd(text)).toBe(1234.56)
+  })
+
+  it('returns null when no balance is present', () => {
+    expect(parseZenBalanceUsd('<html><body>no billing here</body></html>')).toBeNull()
+  })
+
+  it('guards against oversized payloads', () => {
+    expect(parseZenBalanceUsd('x'.repeat(10_000_001))).toBeNull()
+  })
+})

--- a/src/main/rate-limits/opencode-go-page-scraper.ts
+++ b/src/main/rate-limits/opencode-go-page-scraper.ts
@@ -124,6 +124,99 @@ type ParsedSubscription = {
   monthlyResetInSec: number | null
 }
 
+// The billing server serializes the Zen (pay-as-you-go) balance in units of
+// 1e-8 USD (e.g. 2_375_000_000 → $23.75), so scale it back to dollars.
+const ZEN_BILLING_SCALE = 100_000_000
+
+// Explicit balance fields the page may expose already in whole USD (not scaled).
+// More specific keys are listed first so `\b` boundaries never mis-match a
+// longer name (e.g. `currentBalance` inside `currentBalanceUsd`).
+const EXPLICIT_ZEN_BALANCE_KEYS = [
+  'zenCurrentBalance',
+  'zenBalance',
+  'currentBalanceUsd',
+  'currentBalanceUSD',
+  'currentBalance',
+  'balanceUsd',
+  'balanceUSD',
+  'usdBalance'
+]
+
+/**
+ * Extract the Zen pay-as-you-go balance (in USD) from the opencode.ai workspace
+ * page. The page embeds billing context in the same React Flight payload as the
+ * usage data, so this reuses the already-fetched text — no extra request.
+ * Returns null when no balance is present (billing disabled or not on the page).
+ */
+export function parseZenBalanceUsd(text: string): number | null {
+  if (!text || text.length > 10_000_000) {
+    return null
+  }
+  // 1. Billing object: {customerID:"cus_...",balance:$R[N]=NNNN,...}, scaled 1e8.
+  const scaled = parseScaledBillingBalance(text)
+  if (scaled !== null) {
+    return scaled
+  }
+  // 2. Explicit USD balance keys (already major units, may be quoted with commas).
+  const explicit = parseExplicitZenBalance(text)
+  if (explicit !== null) {
+    return explicit
+  }
+  // 3. Human-readable "current balance $X" copy as a last resort.
+  return parseDollarBalanceText(text)
+}
+
+function parseScaledBillingBalance(text: string): number | null {
+  // Require a real customerID so `customerID:null` / billing-disabled payloads
+  // (which still carry a `balance:0`) don't register as a live balance.
+  const customerRegex = /(?:"customerID"|customerID)\s*:\s*(?:\$R\[\d+\]\s*=\s*)?"[^"]+"/
+  if (!customerRegex.test(text)) {
+    return null
+  }
+  const balanceRegex = /(?:"balance"|balance)\s*:\s*(?:\$R\[\d+\]\s*=\s*)?(-?[0-9]+(?:\.[0-9]+)?)/
+  const match = balanceRegex.exec(text)
+  if (!match) {
+    return null
+  }
+  const raw = Number.parseFloat(match[1])
+  return Number.isFinite(raw) ? raw / ZEN_BILLING_SCALE : null
+}
+
+function parseExplicitZenBalance(text: string): number | null {
+  for (const key of EXPLICIT_ZEN_BALANCE_KEYS) {
+    // Key may be quoted (JSON) or bare (JS object); value may be a bare number
+    // or a quoted string with thousands separators.
+    const regex = new RegExp(
+      `(?:"${key}"|\\b${key}\\b)\\s*:\\s*(?:\\$R\\[\\d+\\]\\s*=\\s*)?"?([0-9][0-9,]*(?:\\.[0-9]+)?)"?`
+    )
+    const match = regex.exec(text)
+    if (match) {
+      const value = Number.parseFloat(match[1].replace(/,/g, ''))
+      if (Number.isFinite(value)) {
+        return value
+      }
+    }
+  }
+  return null
+}
+
+function parseDollarBalanceText(text: string): number | null {
+  const patterns = [
+    /(?:current\s+balance|zen\s+balance|現在の残高)[^$]{0,80}\$\s*([0-9][0-9,]*(?:\.[0-9]+)?)/i,
+    /(?:balance|残高)[\s\S]{0,120}?\$\s*([0-9][0-9,]*(?:\.[0-9]+)?)/i
+  ]
+  for (const pattern of patterns) {
+    const match = pattern.exec(text)
+    if (match) {
+      const value = Number.parseFloat(match[1].replace(/,/g, ''))
+      if (Number.isFinite(value)) {
+        return value
+      }
+    }
+  }
+  return null
+}
+
 export function parseSubscriptionFromPageText(text: string): ParsedSubscription | null {
   // Why: OpenCode usage is scraped from HTML-embedded JS (React Flight wire
   // format). Defensive size check prevents runaway parsing on unexpected payloads.

--- a/src/main/rate-limits/opencode-go-page-scraper.ts
+++ b/src/main/rate-limits/opencode-go-page-scraper.ts
@@ -1,118 +1,36 @@
-// Why: the opencode.ai page is rendered with React Server Components. The
-// embedded JS uses a wire format where object references look like:
-//   key:$R[28]={field:value,...}
-// rather than plain `key:{field:value,...}`. A single key (e.g. monthlyUsage)
-// can appear multiple times — once with real data and once as `null` inside a
-// different component's props. We must find the occurrence that is an object
-// with both usagePercent and resetInSec, not the null one.
+import {
+  extractEmbeddedObjectAfterKey,
+  extractEnclosingEmbeddedObject,
+  findEmbeddedTopLevelMatch
+} from './opencode-page-object-parser'
 
-/**
- * Finds the brace-balanced object block assigned to `key` anywhere in `text`.
- * Skips React Flight assignment tokens (e.g. `$R[N]=`) between the colon and
- * the opening brace. Returns the first block that contains `usagePercent` AND
- * `resetInSec` as direct numeric properties (not nested), so that placeholder
- * `null` occurrences and billing-context duplicates are ignored.
- */
-function extractUsageBlock(text: string, key: string): string | null {
-  // Match every occurrence of `key:` (with optional $R[N]= assignment)
-  // Why: React Flight wire format embeds object references between the colon
-  // and the literal brace, so we skip over any `$R[N]=` tokens to reach `{`.
-  const keyRegex = new RegExp(`\\b${key}\\b\\s*:`, 'g')
-  let keyMatch: RegExpExecArray | null
+const MAX_PAGE_LENGTH = 10_000_000
+const REACT_FLIGHT_REFERENCE = '(?:\\$R\\[\\d+\\]\\s*=\\s*)?'
+const USAGE_KEY_PATTERNS = {
+  rollingUsage: /(?:"rollingUsage"|\brollingUsage\b)\s*:/g,
+  weeklyUsage: /(?:"weeklyUsage"|\bweeklyUsage\b)\s*:/g,
+  monthlyUsage: /(?:"monthlyUsage"|\bmonthlyUsage\b)\s*:/g
+} as const
+const USAGE_PERCENT_FIELD = /^(?:"usagePercent"|usagePercent)\s*:\s*(-?[0-9]+(?:\.[0-9]+)?)/
+const RESET_SECONDS_FIELD = /^(?:"resetInSec"|resetInSec)\s*:\s*(-?[0-9]+(?:\.[0-9]+)?)/
+const USE_BALANCE_CANDIDATE = /(?:"useBalance"|\buseBalance\b)\s*:/g
+const USE_BALANCE_FIELD = /^(?:"useBalance"|useBalance)\s*:\s*(!0|!1|true|false)/
+const ROLLING_USAGE_FIELD = /^(?:"rollingUsage"|rollingUsage)\s*:/
+const WEEKLY_USAGE_FIELD = /^(?:"weeklyUsage"|weeklyUsage)\s*:/
 
-  while ((keyMatch = keyRegex.exec(text)) !== null) {
-    // Scan forward from after the colon to find the opening `{`,
-    // allowing for the `$R[N]=` token or plain whitespace in between.
-    // We only scan a short window so we don't accidentally land on the
-    // next occurrence of the key.
-    const searchStart = keyMatch.index + keyMatch[0].length
-    const searchWindow = text.slice(searchStart, searchStart + 30)
-    const braceOffset = searchWindow.indexOf('{')
-    if (braceOffset === -1) {
-      // This occurrence has no object (e.g. `monthlyUsage:null`) — skip.
-      continue
-    }
-
-    const openBrace = searchStart + braceOffset
-    // Extract the balanced block
-    // Why: this brace-depth parser does not skip string literals. React Flight's
-    // current format does not emit raw { } inside strings, but this is a scraper
-    // against HTML we don't control — treat as fragile.
-    let depth = 0
-    let block: string | null = null
-    for (let i = openBrace; i < text.length; i++) {
-      if (text[i] === '{') {
-        depth++
-      } else if (text[i] === '}') {
-        depth--
-        if (depth === 0) {
-          block = text.slice(openBrace, i + 1)
-          break
-        }
-      }
-    }
-
-    if (!block) {
-      continue
-    }
-
-    // Verify this block has both required numeric fields as direct properties
-    // (depth 1 within the block). This rejects billing/plan objects that share
-    // the key name but lack usage data.
-    if (
-      hasDirectNumericField(block, 'usagePercent') &&
-      hasDirectNumericField(block, 'resetInSec')
-    ) {
-      return block
-    }
-  }
-
-  return null
+function extractTopLevelNumber(objectText: string, fieldPattern: RegExp): number | null {
+  const match = findEmbeddedTopLevelMatch(objectText, fieldPattern)
+  const value = match ? Number.parseFloat(match[1]) : Number.NaN
+  return Number.isFinite(value) ? value : null
 }
 
-/**
- * Returns true if `fieldName` exists as a direct (depth-1) numeric property
- * of the object string `objText`.
- */
-function hasDirectNumericField(objText: string, fieldName: string): boolean {
-  return extractTopLevelNumber(objText, fieldName) !== null
-}
-
-/**
- * Extracts a numeric field at depth 1 of `objText` — ignores the same field
- * inside nested sub-objects.
- * Why: without depth tracking, a regex matches the first occurrence regardless
- * of nesting, returning wrong values when a sub-object contains the same name.
- */
-function extractTopLevelNumber(objText: string, fieldName: string): number | null {
-  const fieldRegex = new RegExp(`\\b${fieldName}\\b\\s*:\\s*(-?[0-9]+(?:\\.[0-9]+)?)`)
-  // Why: this brace-depth parser does not skip string literals. React Flight's
-  // current format does not emit raw { } inside strings, but this is a scraper
-  // against HTML we don't control — treat as fragile.
-  let depth = 0
-
-  for (let i = 0; i < objText.length; i++) {
-    const ch = objText[i]
-    if (ch === '{') {
-      depth++
-      continue
-    }
-    if (ch === '}') {
-      depth--
-      continue
-    }
-
-    // Only match at depth 1 (direct property of the root object).
-    if (depth === 1) {
-      const slice = objText.slice(i, i + fieldName.length + 30)
-      const m = fieldRegex.exec(slice)
-      if (m && m.index === 0) {
-        const n = Number.parseFloat(m[1])
-        return Number.isFinite(n) ? n : null
-      }
-    }
-  }
-  return null
+function extractUsageBlock(text: string, key: keyof typeof USAGE_KEY_PATTERNS): string | null {
+  return extractEmbeddedObjectAfterKey(text, USAGE_KEY_PATTERNS[key], (block) => {
+    return (
+      extractTopLevelNumber(block, USAGE_PERCENT_FIELD) !== null &&
+      extractTopLevelNumber(block, RESET_SECONDS_FIELD) !== null
+    )
+  })
 }
 
 type ParsedSubscription = {
@@ -122,97 +40,76 @@ type ParsedSubscription = {
   rollingResetInSec: number
   weeklyResetInSec: number
   monthlyResetInSec: number | null
+  useBalance: boolean | null
 }
 
 // The billing server serializes the Zen (pay-as-you-go) balance in units of
 // 1e-8 USD (e.g. 2_375_000_000 → $23.75), so scale it back to dollars.
 const ZEN_BILLING_SCALE = 100_000_000
 
-// Explicit balance fields the page may expose already in whole USD (not scaled).
-// More specific keys are listed first so `\b` boundaries never mis-match a
-// longer name (e.g. `currentBalance` inside `currentBalanceUsd`).
-const EXPLICIT_ZEN_BALANCE_KEYS = [
-  'zenCurrentBalance',
-  'zenBalance',
-  'currentBalanceUsd',
-  'currentBalanceUSD',
-  'currentBalance',
-  'balanceUsd',
-  'balanceUSD',
-  'usdBalance'
+const BILLING_BALANCE_CANDIDATE = /(?:"balance"|\bbalance\b)\s*:/g
+const BILLING_BALANCE_FIELD = new RegExp(
+  `^(?:"balance"|balance)\\s*:\\s*${REACT_FLIGHT_REFERENCE}(-?[0-9]+(?:\\.[0-9]+)?)`
+)
+const BILLING_RECORD_FIELDS = [
+  /^(?:"customerID"|customerID)\s*:/,
+  /^(?:"paymentMethodID"|paymentMethodID)\s*:/,
+  /^(?:"reload"|reload)\s*:/,
+  /^(?:"reloadAmount"|reloadAmount)\s*:/,
+  /^(?:"monthlyLimit"|monthlyLimit)\s*:/,
+  /^(?:"lite"|lite)\s*:/
 ]
+const CONFIGURED_BILLING_FIELD = new RegExp(
+  `^(?:"(?:customerID|paymentMethodID)"|customerID|paymentMethodID)\\s*:\\s*${REACT_FLIGHT_REFERENCE}"[^"]+"`
+)
 
-/**
- * Extract the Zen pay-as-you-go balance (in USD) from the opencode.ai workspace
- * page. The page embeds billing context in the same React Flight payload as the
- * usage data, so this reuses the already-fetched text — no extra request.
- * Returns null when no balance is present (billing disabled or not on the page).
- */
+// The balance shares the already-fetched usage payload, so no extra request is needed.
 export function parseZenBalanceUsd(text: string): number | null {
-  if (!text || text.length > 10_000_000) {
+  if (!text || text.length > MAX_PAGE_LENGTH) {
     return null
   }
-  // 1. Billing object: {customerID:"cus_...",balance:$R[N]=NNNN,...}, scaled 1e8.
-  const scaled = parseScaledBillingBalance(text)
-  if (scaled !== null) {
-    return scaled
-  }
-  // 2. Explicit USD balance keys (already major units, may be quoted with commas).
-  const explicit = parseExplicitZenBalance(text)
-  if (explicit !== null) {
-    return explicit
-  }
-  // 3. Human-readable "current balance $X" copy as a last resort.
-  return parseDollarBalanceText(text)
+  return parseScaledBillingBalance(text)
 }
 
 function parseScaledBillingBalance(text: string): number | null {
-  // Require a real customerID so `customerID:null` / billing-disabled payloads
-  // (which still carry a `balance:0`) don't register as a live balance.
-  const customerRegex = /(?:"customerID"|customerID)\s*:\s*(?:\$R\[\d+\]\s*=\s*)?"[^"]+"/
-  if (!customerRegex.test(text)) {
-    return null
-  }
-  const balanceRegex = /(?:"balance"|balance)\s*:\s*(?:\$R\[\d+\]\s*=\s*)?(-?[0-9]+(?:\.[0-9]+)?)/
-  const match = balanceRegex.exec(text)
-  if (!match) {
-    return null
-  }
-  const raw = Number.parseFloat(match[1])
-  return Number.isFinite(raw) ? raw / ZEN_BILLING_SCALE : null
-}
-
-function parseExplicitZenBalance(text: string): number | null {
-  for (const key of EXPLICIT_ZEN_BALANCE_KEYS) {
-    // Key may be quoted (JSON) or bare (JS object); value may be a bare number
-    // or a quoted string with thousands separators.
-    const regex = new RegExp(
-      `(?:"${key}"|\\b${key}\\b)\\s*:\\s*(?:\\$R\\[\\d+\\]\\s*=\\s*)?"?([0-9][0-9,]*(?:\\.[0-9]+)?)"?`
-    )
-    const match = regex.exec(text)
-    if (match) {
-      const value = Number.parseFloat(match[1].replace(/,/g, ''))
-      if (Number.isFinite(value)) {
-        return value
-      }
+  for (const candidate of text.matchAll(BILLING_BALANCE_CANDIDATE)) {
+    const block = extractEnclosingEmbeddedObject(text, candidate.index ?? 0)
+    if (!block) {
+      continue
     }
+    const discriminatorCount = BILLING_RECORD_FIELDS.filter((field) =>
+      findEmbeddedTopLevelMatch(block, field)
+    ).length
+    if (discriminatorCount < 2) {
+      continue
+    }
+    const match = findEmbeddedTopLevelMatch(block, BILLING_BALANCE_FIELD)
+    const raw = match ? Number.parseFloat(match[1]) : Number.NaN
+    if (!Number.isFinite(raw)) {
+      continue
+    }
+    // Why: zero is ubiquitous for unconfigured billing, while granted credit can
+    // be positive without a payment customer.
+    if (raw <= 0 && !findEmbeddedTopLevelMatch(block, CONFIGURED_BILLING_FIELD)) {
+      return null
+    }
+    return raw / ZEN_BILLING_SCALE
   }
   return null
 }
 
-function parseDollarBalanceText(text: string): number | null {
-  const patterns = [
-    /(?:current\s+balance|zen\s+balance|現在の残高)[^$]{0,80}\$\s*([0-9][0-9,]*(?:\.[0-9]+)?)/i,
-    /(?:balance|残高)[\s\S]{0,120}?\$\s*([0-9][0-9,]*(?:\.[0-9]+)?)/i
-  ]
-  for (const pattern of patterns) {
-    const match = pattern.exec(text)
-    if (match) {
-      const value = Number.parseFloat(match[1].replace(/,/g, ''))
-      if (Number.isFinite(value)) {
-        return value
-      }
+function parseUseBalance(text: string): boolean | null {
+  for (const candidate of text.matchAll(USE_BALANCE_CANDIDATE)) {
+    const block = extractEnclosingEmbeddedObject(text, candidate.index ?? 0)
+    if (
+      !block ||
+      !findEmbeddedTopLevelMatch(block, ROLLING_USAGE_FIELD) ||
+      !findEmbeddedTopLevelMatch(block, WEEKLY_USAGE_FIELD)
+    ) {
+      continue
     }
+    const raw = findEmbeddedTopLevelMatch(block, USE_BALANCE_FIELD)?.[1]
+    return raw === '!0' || raw === 'true' ? true : raw === '!1' || raw === 'false' ? false : null
   }
   return null
 }
@@ -220,7 +117,7 @@ function parseDollarBalanceText(text: string): number | null {
 export function parseSubscriptionFromPageText(text: string): ParsedSubscription | null {
   // Why: OpenCode usage is scraped from HTML-embedded JS (React Flight wire
   // format). Defensive size check prevents runaway parsing on unexpected payloads.
-  if (!text || text.length > 10_000_000) {
+  if (!text || text.length > MAX_PAGE_LENGTH) {
     return null
   }
 
@@ -232,12 +129,13 @@ export function parseSubscriptionFromPageText(text: string): ParsedSubscription 
   const monthlyBlock = extractUsageBlock(text, 'monthlyUsage')
 
   const rollingPercent =
-    rollingBlock !== null ? extractTopLevelNumber(rollingBlock, 'usagePercent') : null
+    rollingBlock !== null ? extractTopLevelNumber(rollingBlock, USAGE_PERCENT_FIELD) : null
   const rollingReset =
-    rollingBlock !== null ? extractTopLevelNumber(rollingBlock, 'resetInSec') : null
+    rollingBlock !== null ? extractTopLevelNumber(rollingBlock, RESET_SECONDS_FIELD) : null
   const weeklyPercent =
-    weeklyBlock !== null ? extractTopLevelNumber(weeklyBlock, 'usagePercent') : null
-  const weeklyReset = weeklyBlock !== null ? extractTopLevelNumber(weeklyBlock, 'resetInSec') : null
+    weeklyBlock !== null ? extractTopLevelNumber(weeklyBlock, USAGE_PERCENT_FIELD) : null
+  const weeklyReset =
+    weeklyBlock !== null ? extractTopLevelNumber(weeklyBlock, RESET_SECONDS_FIELD) : null
 
   if (
     rollingPercent === null ||
@@ -249,9 +147,9 @@ export function parseSubscriptionFromPageText(text: string): ParsedSubscription 
   }
 
   const monthlyPercent =
-    monthlyBlock !== null ? extractTopLevelNumber(monthlyBlock, 'usagePercent') : null
+    monthlyBlock !== null ? extractTopLevelNumber(monthlyBlock, USAGE_PERCENT_FIELD) : null
   const monthlyReset =
-    monthlyBlock !== null ? extractTopLevelNumber(monthlyBlock, 'resetInSec') : null
+    monthlyBlock !== null ? extractTopLevelNumber(monthlyBlock, RESET_SECONDS_FIELD) : null
 
   return {
     rollingUsagePercent: Math.min(100, Math.max(0, rollingPercent)),
@@ -260,6 +158,7 @@ export function parseSubscriptionFromPageText(text: string): ParsedSubscription 
       monthlyPercent !== null ? Math.min(100, Math.max(0, monthlyPercent)) : null,
     rollingResetInSec: rollingReset,
     weeklyResetInSec: weeklyReset,
-    monthlyResetInSec: monthlyReset
+    monthlyResetInSec: monthlyReset,
+    useBalance: parseUseBalance(text)
   }
 }

--- a/src/main/rate-limits/opencode-go-usage-fetcher.test.ts
+++ b/src/main/rate-limits/opencode-go-usage-fetcher.test.ts
@@ -302,6 +302,31 @@ describe('fetchOpenCodeGoRateLimits', () => {
     expect(result.monthly).toBeNull()
   })
 
+  it.each([
+    ['!0', true, null],
+    ['!1', false, 'not_enabled']
+  ])(
+    'maps useBalance %s to spendability on the billing balance',
+    async (wireValue, enabled, disabledReason) => {
+      const page = `
+        $R[20]={useBalance:${wireValue},rollingUsage:$R[21]={resetInSec:3600,usagePercent:100},weeklyUsage:$R[22]={resetInSec:86400,usagePercent:20}};
+        $R[30]={customerID:null,balance:1250000000,reload:!1,reloadAmount:2000000000};
+      `
+      netFetchMock
+        .mockResolvedValueOnce(makeResponse(WORKSPACES_RESPONSE))
+        .mockResolvedValueOnce(makeResponse(page))
+
+      const result = await fetchOpenCodeGoRateLimits('auth=token')
+
+      expect(result.extraUsage).toMatchObject({
+        balance: 12.5,
+        unit: 'currency',
+        enabled,
+        disabledReason
+      })
+    }
+  )
+
   it('caps usedPercent at 100 and floors at 0', async () => {
     const page = `
       rollingUsage: { usagePercent: 150, resetInSec: 3600 }

--- a/src/main/rate-limits/opencode-go-usage-fetcher.ts
+++ b/src/main/rate-limits/opencode-go-usage-fetcher.ts
@@ -79,17 +79,19 @@ function parseWorkspaceIds(text: string): string[] {
 
 // The Zen balance is pay-as-you-go credit with no cap or reset — represent it
 // as an uncapped balance (only `balance` set) so the UI shows a plain amount.
-function makeZenBalance(balanceUsd: number | null): ExtraUsageBalance | null {
+function makeZenBalance(
+  balanceUsd: number | null,
+  useBalance: boolean | null
+): ExtraUsageBalance | null {
   if (balanceUsd === null) {
     return null
   }
   return {
     balance: Math.max(0, balanceUsd),
     unit: 'currency',
-    unlimited: false,
     currencyCode: 'USD',
-    enabled: true,
-    disabledReason: null,
+    enabled: useBalance === true,
+    disabledReason: useBalance === true ? null : useBalance === false ? 'not_enabled' : 'unknown',
     spent: null,
     spendLimit: null,
     spentPercent: null,
@@ -288,7 +290,7 @@ async function fetchOpenCodeGoRateLimitsWithSession(
           session: makeWindow(parsed.rollingUsagePercent, parsed.rollingResetInSec, 300),
           weekly: makeWindow(parsed.weeklyUsagePercent, parsed.weeklyResetInSec, 10080),
           monthly,
-          extraUsage: makeZenBalance(parseZenBalanceUsd(pageText)),
+          extraUsage: makeZenBalance(parseZenBalanceUsd(pageText), parsed.useBalance),
           updatedAt: Date.now(),
           error: null,
           status: 'ok'

--- a/src/main/rate-limits/opencode-go-usage-fetcher.ts
+++ b/src/main/rate-limits/opencode-go-usage-fetcher.ts
@@ -85,6 +85,8 @@ function makeZenBalance(balanceUsd: number | null): ExtraUsageBalance | null {
   }
   return {
     balance: Math.max(0, balanceUsd),
+    unit: 'currency',
+    unlimited: false,
     currencyCode: 'USD',
     enabled: true,
     disabledReason: null,

--- a/src/main/rate-limits/opencode-go-usage-fetcher.ts
+++ b/src/main/rate-limits/opencode-go-usage-fetcher.ts
@@ -1,13 +1,17 @@
 import type { Session } from 'electron'
 import { randomUUID } from 'node:crypto'
 import type { NetworkProxySettings } from '../../shared/network-proxy'
-import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limit-types'
+import type {
+  ExtraUsageBalance,
+  ProviderRateLimits,
+  RateLimitWindow
+} from '../../shared/rate-limit-types'
 import {
   clearOpenCodeSessionCookies,
   createOpenCodeRequestSession,
   OPENCODE_BASE_URL
 } from './opencode-go-request-session'
-import { parseSubscriptionFromPageText } from './opencode-go-page-scraper'
+import { parseSubscriptionFromPageText, parseZenBalanceUsd } from './opencode-go-page-scraper'
 
 const OPENCODE_SERVER_URL = 'https://opencode.ai/_server'
 const API_TIMEOUT_MS = 15_000
@@ -71,6 +75,24 @@ function parseWorkspaceIds(text: string): string[] {
     }
   }
   return ids
+}
+
+// The Zen balance is pay-as-you-go credit with no cap or reset — represent it
+// as an uncapped balance (only `balance` set) so the UI shows a plain amount.
+function makeZenBalance(balanceUsd: number | null): ExtraUsageBalance | null {
+  if (balanceUsd === null) {
+    return null
+  }
+  return {
+    balance: Math.max(0, balanceUsd),
+    currencyCode: 'USD',
+    enabled: true,
+    disabledReason: null,
+    spent: null,
+    spendLimit: null,
+    spentPercent: null,
+    resetsAt: null
+  }
 }
 
 function makeWindow(
@@ -264,6 +286,7 @@ async function fetchOpenCodeGoRateLimitsWithSession(
           session: makeWindow(parsed.rollingUsagePercent, parsed.rollingResetInSec, 300),
           weekly: makeWindow(parsed.weeklyUsagePercent, parsed.weeklyResetInSec, 10080),
           monthly,
+          extraUsage: makeZenBalance(parseZenBalanceUsd(pageText)),
           updatedAt: Date.now(),
           error: null,
           status: 'ok'

--- a/src/main/rate-limits/opencode-page-object-parser.ts
+++ b/src/main/rate-limits/opencode-page-object-parser.ts
@@ -1,0 +1,119 @@
+const OBJECT_LOOKBACK_LIMIT = 100_000
+const OBJECT_FORWARD_LIMIT = 100_000
+const OBJECT_CANDIDATE_LIMIT = 64
+const FIELD_SCAN_LENGTH = 256
+
+function findObjectEnd(text: string, openBrace: number): number | null {
+  let depth = 0
+  let quote: '"' | "'" | '`' | null = null
+  let escaped = false
+
+  const scanEnd = Math.min(text.length, openBrace + OBJECT_FORWARD_LIMIT)
+  for (let index = openBrace; index < scanEnd; index++) {
+    const character = text[index]
+    if (quote) {
+      if (escaped) {
+        escaped = false
+      } else if (character === '\\') {
+        escaped = true
+      } else if (character === quote) {
+        quote = null
+      }
+      continue
+    }
+    if (character === '"' || character === "'" || character === '`') {
+      quote = character
+    } else if (character === '{') {
+      depth++
+    } else if (character === '}' && --depth === 0) {
+      return index
+    }
+  }
+  return null
+}
+
+function extractEmbeddedObjectAt(text: string, openBrace: number): string | null {
+  if (text[openBrace] !== '{') {
+    return null
+  }
+  const end = findObjectEnd(text, openBrace)
+  return end === null ? null : text.slice(openBrace, end + 1)
+}
+
+export function extractEmbeddedObjectAfterKey(
+  text: string,
+  keyPattern: RegExp,
+  isExpectedObject: (block: string) => boolean
+): string | null {
+  for (const match of text.matchAll(keyPattern)) {
+    const searchStart = (match.index ?? 0) + match[0].length
+    const braceOffset = text.slice(searchStart, searchStart + 40).indexOf('{')
+    if (braceOffset < 0) {
+      continue
+    }
+    const block = extractEmbeddedObjectAt(text, searchStart + braceOffset)
+    if (block && isExpectedObject(block)) {
+      return block
+    }
+  }
+  return null
+}
+
+export function extractEnclosingEmbeddedObject(text: string, offset: number): string | null {
+  const earliestStart = Math.max(0, offset - OBJECT_LOOKBACK_LIMIT)
+  let candidatesChecked = 0
+  for (
+    let openBrace = text.lastIndexOf('{', offset);
+    openBrace >= earliestStart && candidatesChecked < OBJECT_CANDIDATE_LIMIT;
+    openBrace = text.lastIndexOf('{', openBrace - 1)
+  ) {
+    candidatesChecked++
+    const end = findObjectEnd(text, openBrace)
+    if (end !== null && end >= offset) {
+      return text.slice(openBrace, end + 1)
+    }
+  }
+  return null
+}
+
+export function findEmbeddedTopLevelMatch(
+  objectText: string,
+  fieldPattern: RegExp
+): RegExpExecArray | null {
+  let depth = 0
+  let quote: '"' | "'" | '`' | null = null
+  let escaped = false
+
+  for (let index = 0; index < objectText.length; index++) {
+    const character = objectText[index]
+    if (quote) {
+      if (escaped) {
+        escaped = false
+      } else if (character === '\\') {
+        escaped = true
+      } else if (character === quote) {
+        quote = null
+      }
+      continue
+    }
+    if (depth === 1) {
+      const match = fieldPattern.exec(objectText.slice(index, index + FIELD_SCAN_LENGTH))
+      if (match?.index === 0) {
+        return match
+      }
+    }
+    if (character === '"' || character === "'" || character === '`') {
+      quote = character
+      continue
+    }
+    if (character === '{') {
+      depth++
+      continue
+    }
+    if (character === '}') {
+      depth--
+      continue
+    }
+  }
+  return null
+}

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -59,6 +59,7 @@ import {
   getProviderDisplayName,
   getProviderUsageStatusLabel
 } from './tooltip'
+import { formatCurrencyAmount } from '../../../../shared/currency-format'
 import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { UsageRosterPanel, getTightestUsageSection } from './UsageRosterPanel'
@@ -1247,6 +1248,23 @@ function VerboseProviderUsage({
   )
 }
 
+// A plan spends into its overage balance only once an included window is
+// exhausted. Treat ~100% as capped to tolerate provider rounding.
+const CAP_THRESHOLD_PERCENT = 99.5
+
+// Why: the overage balance stays hidden in the compact bar until the plan is
+// actually spending it — the balance must be spendable (enabled) and a
+// session/weekly/monthly window must be capped — so it appears (and visibly
+// counts down) exactly when it matters.
+function isExtraUsageActive(p: ProviderRateLimits): boolean {
+  if (!p.extraUsage || !p.extraUsage.enabled) {
+    return false
+  }
+  return [p.session, p.weekly, p.monthly, p.fableWeekly].some(
+    (w) => w != null && clampUsedPercent(w.usedPercent) >= CAP_THRESHOLD_PERCENT
+  )
+}
+
 export function ProviderSegment({
   p,
   compact,
@@ -1305,6 +1323,7 @@ export function ProviderSegment({
 
   // Has data (ok, fetching with stale data, or error with stale data)
   const isStale = p.status === 'error'
+  const showBalance = isExtraUsageActive(p)
 
   return (
     <span className="inline-flex items-center gap-1.5">
@@ -1323,6 +1342,15 @@ export function ProviderSegment({
           display={display}
           showLabel={!compact}
         />
+      ) : null}
+      {showBalance && p.extraUsage ? (
+        <>
+          <span className="text-muted-foreground">·</span>
+          <span className="tabular-nums">
+            {formatCurrencyAmount(p.extraUsage.balance, p.extraUsage.currencyCode)}{' '}
+            {translate('auto.components.status.bar.StatusBar.4fba7dc1e7', 'bal')}
+          </span>
+        </>
       ) : null}
       {isStale && <AlertTriangle size={11} className="text-muted-foreground/80" />}
     </span>

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -60,6 +60,7 @@ import {
   getProviderUsageStatusLabel
 } from './tooltip'
 import { formatCurrencyAmount } from '../../../../shared/currency-format'
+import { formatCreditCount } from '../../../../shared/credit-count-format'
 import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { UsageRosterPanel, getTightestUsageSection } from './UsageRosterPanel'
@@ -1252,10 +1253,7 @@ function VerboseProviderUsage({
 // exhausted. Treat ~100% as capped to tolerate provider rounding.
 const CAP_THRESHOLD_PERCENT = 99.5
 
-// Why: the overage balance stays hidden in the compact bar until the plan is
-// actually spending it — the balance must be spendable (enabled) and a
-// session/weekly/monthly window must be capped — so it appears (and visibly
-// counts down) exactly when it matters.
+// Why: only reveal the compact balance once a capped window can spend it.
 function isExtraUsageActive(p: ProviderRateLimits): boolean {
   if (!p.extraUsage || !p.extraUsage.enabled) {
     return false
@@ -1272,7 +1270,7 @@ function formatCompactExtraUsage(balance: ProviderRateLimits['extraUsage']): str
   if (balance.unit === 'credits') {
     return balance.unlimited
       ? translate('auto.components.status.bar.StatusBar.4025a6f62f', 'Unlimited')
-      : `${balance.balance} ${translate('auto.components.status.bar.StatusBar.a95969101f', 'credits')}`
+      : `${formatCreditCount(balance.balance)} ${translate('auto.components.status.bar.StatusBar.a95969101f', 'credits')}`
   }
   return `${formatCurrencyAmount(balance.balance, balance.currencyCode)} ${translate('auto.components.status.bar.StatusBar.4fba7dc1e7', 'bal')}`
 }

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -1265,6 +1265,18 @@ function isExtraUsageActive(p: ProviderRateLimits): boolean {
   )
 }
 
+function formatCompactExtraUsage(balance: ProviderRateLimits['extraUsage']): string {
+  if (!balance) {
+    return ''
+  }
+  if (balance.unit === 'credits') {
+    return balance.unlimited
+      ? translate('auto.components.status.bar.StatusBar.4025a6f62f', 'Unlimited')
+      : `${balance.balance} ${translate('auto.components.status.bar.StatusBar.a95969101f', 'credits')}`
+  }
+  return `${formatCurrencyAmount(balance.balance, balance.currencyCode)} ${translate('auto.components.status.bar.StatusBar.4fba7dc1e7', 'bal')}`
+}
+
 export function ProviderSegment({
   p,
   compact,
@@ -1346,10 +1358,7 @@ export function ProviderSegment({
       {showBalance && p.extraUsage ? (
         <>
           <span className="text-muted-foreground">·</span>
-          <span className="tabular-nums">
-            {formatCurrencyAmount(p.extraUsage.balance, p.extraUsage.currencyCode)}{' '}
-            {translate('auto.components.status.bar.StatusBar.4fba7dc1e7', 'bal')}
-          </span>
+          <span className="tabular-nums">{formatCompactExtraUsage(p.extraUsage)}</span>
         </>
       ) : null}
       {isStale && <AlertTriangle size={11} className="text-muted-foreground/80" />}

--- a/src/renderer/src/components/status-bar/provider-segment-balance.test.tsx
+++ b/src/renderer/src/components/status-bar/provider-segment-balance.test.tsx
@@ -1,0 +1,104 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
+
+vi.mock('@/i18n/i18n', () => ({
+  i18n: { language: 'en' },
+  translate: (_key: string, fallback: string, values?: Record<string, string>) => {
+    let result = fallback
+    for (const [key, value] of Object.entries(values ?? {})) {
+      result = result.replace(`{{${key}}}`, value)
+    }
+    return result
+  }
+}))
+
+vi.mock('@/lib/agent-catalog', () => ({
+  AgentIcon: () => null
+}))
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: { usagePercentageDisplay: 'used' | 'remaining' }) => unknown) =>
+    selector({ usagePercentageDisplay: 'used' })
+}))
+
+function openCodeGo(sessionUsedPercent: number): ProviderRateLimits {
+  return {
+    provider: 'opencode-go',
+    session: {
+      usedPercent: sessionUsedPercent,
+      windowMinutes: 300,
+      resetsAt: null,
+      resetDescription: null
+    },
+    weekly: { usedPercent: 40, windowMinutes: 10080, resetsAt: null, resetDescription: null },
+    extraUsage: {
+      balance: 12.4,
+      currencyCode: 'USD',
+      enabled: true,
+      disabledReason: null,
+      spent: null,
+      spendLimit: null,
+      spentPercent: null,
+      resetsAt: null
+    },
+    updatedAt: Date.now(),
+    error: null,
+    status: 'ok'
+  }
+}
+
+function claudeDisabledCredits(): ProviderRateLimits {
+  return {
+    provider: 'claude',
+    session: { usedPercent: 100, windowMinutes: 300, resetsAt: null, resetDescription: null },
+    weekly: { usedPercent: 80, windowMinutes: 10080, resetsAt: null, resetDescription: null },
+    extraUsage: {
+      balance: 0,
+      currencyCode: 'EUR',
+      enabled: false,
+      disabledReason: 'out_of_credits',
+      spent: 0,
+      spendLimit: 2000,
+      spentPercent: 0,
+      resetsAt: null
+    },
+    updatedAt: Date.now(),
+    error: null,
+    status: 'ok'
+  }
+}
+
+describe('ProviderSegment extra-usage balance token', () => {
+  it('reveals the remaining balance once a plan window is capped', async () => {
+    const { ProviderSegment } = await import('./StatusBar')
+
+    const markup = renderToStaticMarkup(
+      <ProviderSegment p={openCodeGo(100)} compact={false} display="used" />
+    )
+
+    expect(markup).toContain('$12.40')
+    expect(markup).toContain('bal')
+  })
+
+  it('hides the balance while plan windows still have headroom', async () => {
+    const { ProviderSegment } = await import('./StatusBar')
+
+    const markup = renderToStaticMarkup(
+      <ProviderSegment p={openCodeGo(20)} compact={false} display="used" />
+    )
+
+    expect(markup).not.toContain('$12.40')
+    expect(markup).not.toContain('bal')
+  })
+
+  it('does not reveal a disabled balance even when a window is capped', async () => {
+    const { ProviderSegment } = await import('./StatusBar')
+
+    const markup = renderToStaticMarkup(
+      <ProviderSegment p={claudeDisabledCredits()} compact={false} display="used" />
+    )
+
+    expect(markup).not.toContain('bal')
+  })
+})

--- a/src/renderer/src/components/status-bar/provider-segment-balance.test.tsx
+++ b/src/renderer/src/components/status-bar/provider-segment-balance.test.tsx
@@ -35,7 +35,6 @@ function openCodeGo(sessionUsedPercent: number): ProviderRateLimits {
     extraUsage: {
       balance: 12.4,
       unit: 'currency',
-      unlimited: false,
       currencyCode: 'USD',
       enabled: true,
       disabledReason: null,
@@ -64,12 +63,8 @@ function codexCredits(sessionUsedPercent: number): ProviderRateLimits {
       balance: 500,
       unit: 'credits',
       unlimited: false,
-      currencyCode: 'USD',
       enabled: true,
       disabledReason: null,
-      spent: null,
-      spendLimit: null,
-      spentPercent: null,
       resetsAt: null
     },
     updatedAt: Date.now(),
@@ -86,7 +81,6 @@ function claudeDisabledCredits(): ProviderRateLimits {
     extraUsage: {
       balance: 0,
       unit: 'currency',
-      unlimited: false,
       currencyCode: 'EUR',
       enabled: false,
       disabledReason: 'out_of_credits',

--- a/src/renderer/src/components/status-bar/provider-segment-balance.test.tsx
+++ b/src/renderer/src/components/status-bar/provider-segment-balance.test.tsx
@@ -34,6 +34,36 @@ function openCodeGo(sessionUsedPercent: number): ProviderRateLimits {
     weekly: { usedPercent: 40, windowMinutes: 10080, resetsAt: null, resetDescription: null },
     extraUsage: {
       balance: 12.4,
+      unit: 'currency',
+      unlimited: false,
+      currencyCode: 'USD',
+      enabled: true,
+      disabledReason: null,
+      spent: null,
+      spendLimit: null,
+      spentPercent: null,
+      resetsAt: null
+    },
+    updatedAt: Date.now(),
+    error: null,
+    status: 'ok'
+  }
+}
+
+function codexCredits(sessionUsedPercent: number): ProviderRateLimits {
+  return {
+    provider: 'codex',
+    session: {
+      usedPercent: sessionUsedPercent,
+      windowMinutes: 300,
+      resetsAt: null,
+      resetDescription: null
+    },
+    weekly: { usedPercent: 40, windowMinutes: 10080, resetsAt: null, resetDescription: null },
+    extraUsage: {
+      balance: 500,
+      unit: 'credits',
+      unlimited: false,
       currencyCode: 'USD',
       enabled: true,
       disabledReason: null,
@@ -55,6 +85,8 @@ function claudeDisabledCredits(): ProviderRateLimits {
     weekly: { usedPercent: 80, windowMinutes: 10080, resetsAt: null, resetDescription: null },
     extraUsage: {
       balance: 0,
+      unit: 'currency',
+      unlimited: false,
       currencyCode: 'EUR',
       enabled: false,
       disabledReason: 'out_of_credits',
@@ -99,6 +131,18 @@ describe('ProviderSegment extra-usage balance token', () => {
       <ProviderSegment p={claudeDisabledCredits()} compact={false} display="used" />
     )
 
+    expect(markup).not.toContain('bal')
+  })
+
+  it('reveals a Codex credit count (not a currency amount) when a window caps', async () => {
+    const { ProviderSegment } = await import('./StatusBar')
+
+    const markup = renderToStaticMarkup(
+      <ProviderSegment p={codexCredits(100)} compact={false} display="used" />
+    )
+
+    expect(markup).toContain('500 credits')
+    expect(markup).not.toContain('$500')
     expect(markup).not.toContain('bal')
   })
 })

--- a/src/renderer/src/components/status-bar/tooltip.test.ts
+++ b/src/renderer/src/components/status-bar/tooltip.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import type * as ReactModule from 'react'
 import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
@@ -465,7 +466,6 @@ describe('ProviderPanel extra-usage rendering', () => {
       extraUsage: {
         balance: 10,
         unit: 'currency',
-        unlimited: false,
         currencyCode: 'EUR',
         enabled: true,
         disabledReason: null,
@@ -476,7 +476,7 @@ describe('ProviderPanel extra-usage rendering', () => {
       }
     })
 
-    const markup = renderToStaticMarkup(ProviderPanel({ p }))
+    const markup = renderToStaticMarkup(createElement(ProviderPanel, { p }))
 
     expect(markup).toContain('Usage credits')
     expect(markup).toContain('€2,000.00')
@@ -492,7 +492,6 @@ describe('ProviderPanel extra-usage rendering', () => {
       extraUsage: {
         balance: 0,
         unit: 'currency',
-        unlimited: false,
         currencyCode: 'EUR',
         enabled: false,
         disabledReason: 'out_of_credits',
@@ -503,7 +502,7 @@ describe('ProviderPanel extra-usage rendering', () => {
       }
     })
 
-    const markup = renderToStaticMarkup(ProviderPanel({ p }))
+    const markup = renderToStaticMarkup(createElement(ProviderPanel, { p }))
 
     expect(markup).toContain('Usage credits')
     expect(markup).toContain('€0.00 / €2,000.00')
@@ -518,7 +517,6 @@ describe('ProviderPanel extra-usage rendering', () => {
       extraUsage: {
         balance: 12.4,
         unit: 'currency',
-        unlimited: false,
         currencyCode: 'USD',
         enabled: true,
         disabledReason: null,
@@ -529,7 +527,7 @@ describe('ProviderPanel extra-usage rendering', () => {
       }
     })
 
-    const markup = renderToStaticMarkup(ProviderPanel({ p }))
+    const markup = renderToStaticMarkup(createElement(ProviderPanel, { p }))
 
     expect(markup).toContain('Zen balance')
     expect(markup).toContain('$12.40')
@@ -545,17 +543,13 @@ describe('ProviderPanel extra-usage rendering', () => {
         balance: 500,
         unit: 'credits',
         unlimited: false,
-        currencyCode: 'USD',
         enabled: true,
         disabledReason: null,
-        spent: null,
-        spendLimit: null,
-        spentPercent: null,
         resetsAt: null
       }
     })
 
-    const markup = renderToStaticMarkup(ProviderPanel({ p }))
+    const markup = renderToStaticMarkup(createElement(ProviderPanel, { p }))
 
     expect(markup).toContain('Credits')
     expect(markup).toContain('500 credits available')
@@ -572,17 +566,13 @@ describe('ProviderPanel extra-usage rendering', () => {
         balance: 0,
         unit: 'credits',
         unlimited: true,
-        currencyCode: 'USD',
         enabled: true,
         disabledReason: null,
-        spent: null,
-        spendLimit: null,
-        spentPercent: null,
         resetsAt: null
       }
     })
 
-    const markup = renderToStaticMarkup(ProviderPanel({ p }))
+    const markup = renderToStaticMarkup(createElement(ProviderPanel, { p }))
 
     expect(markup).toContain('Unlimited')
   })
@@ -593,7 +583,7 @@ describe('ProviderPanel extra-usage rendering', () => {
       session: { usedPercent: 40, windowMinutes: 300, resetsAt: null, resetDescription: null }
     })
 
-    const markup = renderToStaticMarkup(ProviderPanel({ p }))
+    const markup = renderToStaticMarkup(createElement(ProviderPanel, { p }))
 
     expect(markup).not.toContain('Usage credits')
     expect(markup).not.toContain('Zen balance')
@@ -616,7 +606,7 @@ describe('ProviderPanel reset rendering', () => {
       }
     })
 
-    const markup = renderToStaticMarkup(ProviderPanel({ p }))
+    const markup = renderToStaticMarkup(createElement(ProviderPanel, { p }))
 
     expect(markup).toContain('Fable')
     expect(markup).toContain('Resets in 6d 17h')
@@ -636,7 +626,7 @@ describe('ProviderPanel reset rendering', () => {
       }
     })
 
-    const markup = renderToStaticMarkup(ProviderPanel({ p }))
+    const markup = renderToStaticMarkup(createElement(ProviderPanel, { p }))
 
     // Why: bars show consumption (% used), matching harness meters (#7551).
     expect(markup).toContain('35%')
@@ -658,7 +648,7 @@ describe('ProviderPanel reset rendering', () => {
       }
     })
 
-    const markup = renderToStaticMarkup(ProviderPanel({ p }))
+    const markup = renderToStaticMarkup(createElement(ProviderPanel, { p }))
 
     expect(markup).toContain('100%')
     expect(markup).toContain('% used')
@@ -678,7 +668,7 @@ describe('ProviderPanel reset rendering', () => {
       }
     })
 
-    const markup = renderToStaticMarkup(ProviderPanel({ p }))
+    const markup = renderToStaticMarkup(createElement(ProviderPanel, { p }))
 
     expect(markup).toContain('100%')
     expect(markup).toContain('width:100%')
@@ -697,7 +687,9 @@ describe('ProviderPanel reset rendering', () => {
       }
     })
 
-    const markup = renderToStaticMarkup(ProviderPanel({ p, usagePercentageDisplay: 'remaining' }))
+    const markup = renderToStaticMarkup(
+      createElement(ProviderPanel, { p, usagePercentageDisplay: 'remaining' })
+    )
 
     expect(markup).toContain('75% left')
     expect(markup).toContain('width:75%')
@@ -731,7 +723,7 @@ describe('barColor', () => {
 
 describe('ProviderIcon', () => {
   it('renders the Antigravity agent icon for the antigravity provider', () => {
-    const markup = renderToStaticMarkup(ProviderIcon({ provider: 'antigravity' }))
+    const markup = renderToStaticMarkup(createElement(ProviderIcon, { provider: 'antigravity' }))
     expect(markup).toContain('data-agent-icon="antigravity"')
   })
 
@@ -739,7 +731,7 @@ describe('ProviderIcon', () => {
     // Why: the icon must travel to the status bar / tooltip unchanged so the
     // user recognises the brand. We pin it to an <img> with a non-empty
     // resource URL and aria-hidden so the icon stays purely decorative.
-    const markup = renderToStaticMarkup(ProviderIcon({ provider: 'minimax' }))
+    const markup = renderToStaticMarkup(createElement(ProviderIcon, { provider: 'minimax' }))
     expect(markup.startsWith('<img')).toBe(true)
     expect(markup).toContain('aria-hidden="true"')
     expect(markup).toMatch(/src="[^"]+"/)

--- a/src/renderer/src/components/status-bar/tooltip.test.ts
+++ b/src/renderer/src/components/status-bar/tooltip.test.ts
@@ -452,7 +452,8 @@ describe('getExtraUsageLabel', () => {
   it('names the balance per provider', () => {
     expect(getExtraUsageLabel('claude')).toBe('Usage credits')
     expect(getExtraUsageLabel('opencode-go')).toBe('Zen balance')
-    expect(getExtraUsageLabel('codex')).toBe('Balance')
+    expect(getExtraUsageLabel('codex')).toBe('Credits')
+    expect(getExtraUsageLabel('gemini')).toBe('Balance')
   })
 })
 
@@ -463,6 +464,8 @@ describe('ProviderPanel extra-usage rendering', () => {
       session: { usedPercent: 100, windowMinutes: 300, resetsAt: null, resetDescription: null },
       extraUsage: {
         balance: 10,
+        unit: 'currency',
+        unlimited: false,
         currencyCode: 'EUR',
         enabled: true,
         disabledReason: null,
@@ -488,6 +491,8 @@ describe('ProviderPanel extra-usage rendering', () => {
       session: { usedPercent: 100, windowMinutes: 300, resetsAt: null, resetDescription: null },
       extraUsage: {
         balance: 0,
+        unit: 'currency',
+        unlimited: false,
         currencyCode: 'EUR',
         enabled: false,
         disabledReason: 'out_of_credits',
@@ -512,6 +517,8 @@ describe('ProviderPanel extra-usage rendering', () => {
       session: { usedPercent: 20, windowMinutes: 300, resetsAt: null, resetDescription: null },
       extraUsage: {
         balance: 12.4,
+        unit: 'currency',
+        unlimited: false,
         currencyCode: 'USD',
         enabled: true,
         disabledReason: null,
@@ -527,6 +534,57 @@ describe('ProviderPanel extra-usage rendering', () => {
     expect(markup).toContain('Zen balance')
     expect(markup).toContain('$12.40')
     expect(markup).toContain('available')
+  })
+
+  it('renders a Codex credit count as a plain "N credits available" line', () => {
+    const p = provider({
+      provider: 'codex',
+      status: 'ok',
+      session: { usedPercent: 20, windowMinutes: 300, resetsAt: null, resetDescription: null },
+      extraUsage: {
+        balance: 500,
+        unit: 'credits',
+        unlimited: false,
+        currencyCode: 'USD',
+        enabled: true,
+        disabledReason: null,
+        spent: null,
+        spendLimit: null,
+        spentPercent: null,
+        resetsAt: null
+      }
+    })
+
+    const markup = renderToStaticMarkup(ProviderPanel({ p }))
+
+    expect(markup).toContain('Credits')
+    expect(markup).toContain('500 credits available')
+    // A credit count is not a currency amount.
+    expect(markup).not.toContain('$500')
+  })
+
+  it('renders unlimited Codex credits as "Unlimited"', () => {
+    const p = provider({
+      provider: 'codex',
+      status: 'ok',
+      session: { usedPercent: 20, windowMinutes: 300, resetsAt: null, resetDescription: null },
+      extraUsage: {
+        balance: 0,
+        unit: 'credits',
+        unlimited: true,
+        currencyCode: 'USD',
+        enabled: true,
+        disabledReason: null,
+        spent: null,
+        spendLimit: null,
+        spentPercent: null,
+        resetsAt: null
+      }
+    })
+
+    const markup = renderToStaticMarkup(ProviderPanel({ p }))
+
+    expect(markup).toContain('Unlimited')
   })
 
   it('omits the balance row when no extra usage is reported', () => {

--- a/src/renderer/src/components/status-bar/tooltip.test.ts
+++ b/src/renderer/src/components/status-bar/tooltip.test.ts
@@ -27,6 +27,7 @@ import {
   formatResetCreditExpiry,
   formatResetCountdown,
   getProviderUsageErrorMessage,
+  getExtraUsageLabel,
   getProviderUsageStatusLabel,
   getWindowSections,
   ProviderIcon,
@@ -444,6 +445,100 @@ describe('getWindowSections', () => {
     expect(sections[0].label).toBe('Pro')
     expect(sections[0].window!.resetsAt).toBe(18000000)
     expect(sections[0].window!.resetDescription).toBe('5:00 PM')
+  })
+})
+
+describe('getExtraUsageLabel', () => {
+  it('names the balance per provider', () => {
+    expect(getExtraUsageLabel('claude')).toBe('Usage credits')
+    expect(getExtraUsageLabel('opencode-go')).toBe('Zen balance')
+    expect(getExtraUsageLabel('codex')).toBe('Balance')
+  })
+})
+
+describe('ProviderPanel extra-usage rendering', () => {
+  it('renders the Claude usage-credits cap as a spent/limit meter plus balance', () => {
+    const p = provider({
+      status: 'ok',
+      session: { usedPercent: 100, windowMinutes: 300, resetsAt: null, resetDescription: null },
+      extraUsage: {
+        balance: 10,
+        currencyCode: 'EUR',
+        enabled: true,
+        disabledReason: null,
+        spent: 50,
+        spendLimit: 2000,
+        spentPercent: 2.5,
+        resetsAt: null
+      }
+    })
+
+    const markup = renderToStaticMarkup(ProviderPanel({ p }))
+
+    expect(markup).toContain('Usage credits')
+    expect(markup).toContain('€2,000.00')
+    expect(markup).toContain('€50.00')
+    expect(markup).toContain('% used')
+    expect(markup).toContain('Balance €10.00')
+  })
+
+  it('renders a disabled, out-of-credits cap with a zero balance', () => {
+    const p = provider({
+      status: 'ok',
+      session: { usedPercent: 100, windowMinutes: 300, resetsAt: null, resetDescription: null },
+      extraUsage: {
+        balance: 0,
+        currencyCode: 'EUR',
+        enabled: false,
+        disabledReason: 'out_of_credits',
+        spent: 0,
+        spendLimit: 2000,
+        spentPercent: 0,
+        resetsAt: null
+      }
+    })
+
+    const markup = renderToStaticMarkup(ProviderPanel({ p }))
+
+    expect(markup).toContain('Usage credits')
+    expect(markup).toContain('€0.00 / €2,000.00')
+    expect(markup).toContain('Balance €0.00')
+  })
+
+  it('renders an uncapped OpenCode Go balance as a plain available amount', () => {
+    const p = provider({
+      provider: 'opencode-go',
+      status: 'ok',
+      session: { usedPercent: 20, windowMinutes: 300, resetsAt: null, resetDescription: null },
+      extraUsage: {
+        balance: 12.4,
+        currencyCode: 'USD',
+        enabled: true,
+        disabledReason: null,
+        spent: null,
+        spendLimit: null,
+        spentPercent: null,
+        resetsAt: null
+      }
+    })
+
+    const markup = renderToStaticMarkup(ProviderPanel({ p }))
+
+    expect(markup).toContain('Zen balance')
+    expect(markup).toContain('$12.40')
+    expect(markup).toContain('available')
+  })
+
+  it('omits the balance row when no extra usage is reported', () => {
+    const p = provider({
+      status: 'ok',
+      session: { usedPercent: 40, windowMinutes: 300, resetsAt: null, resetDescription: null }
+    })
+
+    const markup = renderToStaticMarkup(ProviderPanel({ p }))
+
+    expect(markup).not.toContain('Usage credits')
+    expect(markup).not.toContain('Zen balance')
   })
 })
 

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -326,13 +326,10 @@ export function ProviderPanel({
       ? formatResetCreditExpiry(p.rateLimitResetCredits?.nextExpiresAt, resetCreditCount)
       : null
 
-  const PanelBalanceSection = ({
-    balance,
-    label
-  }: {
-    balance: ExtraUsageBalance
-    label: string
-  }): React.JSX.Element => {
+  // Why: a plain render function, not a nested component — defining a component
+  // inside ProviderPanel would remount it every render and kill the bar's
+  // width transition.
+  const renderBalanceSection = (balance: ExtraUsageBalance, label: string): React.JSX.Element => {
     // Capped balances (Claude usage credits) render a spent/limit meter plus the
     // current balance; uncapped balances (OpenCode Go Zen credit) render a plain
     // available amount.
@@ -416,9 +413,7 @@ export function ProviderPanel({
         />
       ))}
 
-      {p.extraUsage ? (
-        <PanelBalanceSection balance={p.extraUsage} label={getExtraUsageLabel(p.provider)} />
-      ) : null}
+      {p.extraUsage ? renderBalanceSection(p.extraUsage, getExtraUsageLabel(p.provider)) : null}
 
       {p.error ? (
         <ErrorMessage

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -8,6 +8,7 @@ import {
   formatResetDuration
 } from '../../../../shared/rate-limit-reset-format'
 import { formatCurrencyAmount } from '../../../../shared/currency-format'
+import { formatCreditCount } from '../../../../shared/credit-count-format'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
 import { translate } from '@/i18n/i18n'
@@ -199,7 +200,7 @@ export function getExtraUsageLabel(provider: ProviderRateLimits['provider']): st
 
 // The uncapped balance line reads differently by denomination: a currency
 // amount (Zen balance), a credit count (Codex), or "Unlimited".
-function renderUncappedBalanceLine(balance: ExtraUsageBalance, currencyText: string): string {
+function renderUncappedBalanceLine(balance: ExtraUsageBalance): string {
   if (balance.unit === 'credits') {
     if (balance.unlimited) {
       return translate('auto.components.status.bar.tooltip.56c0d70577', 'Unlimited')
@@ -207,9 +208,10 @@ function renderUncappedBalanceLine(balance: ExtraUsageBalance, currencyText: str
     return translate(
       'auto.components.status.bar.tooltip.87b5bda4d3',
       '{{value0}} credits available',
-      { value0: String(balance.balance) }
+      { value0: formatCreditCount(balance.balance) }
     )
   }
+  const currencyText = formatCurrencyAmount(balance.balance, balance.currencyCode)
   return translate('auto.components.status.bar.tooltip.f6a27a3c0a', '{{value0}} available', {
     value0: currencyText
   })
@@ -351,9 +353,14 @@ export function ProviderPanel({
   // inside ProviderPanel would remount it every render and kill the bar's
   // width transition.
   const renderBalanceSection = (balance: ExtraUsageBalance, label: string): React.JSX.Element => {
-    // Capped balances (Claude usage credits) render a spent/limit meter plus the
-    // current balance; uncapped balances (OpenCode Go Zen credit) render a plain
-    // available amount.
+    if (balance.unit === 'credits') {
+      return (
+        <div className="space-y-1">
+          <div className={`font-medium ${textClass}`}>{label}</div>
+          <div className={mutedClass}>{renderUncappedBalanceLine(balance)}</div>
+        </div>
+      )
+    }
     const capped = balance.spendLimit !== null && balance.spentPercent !== null
     const balanceText = formatCurrencyAmount(balance.balance, balance.currencyCode)
 
@@ -361,7 +368,7 @@ export function ProviderPanel({
       return (
         <div className="space-y-1">
           <div className={`font-medium ${textClass}`}>{label}</div>
-          <div className={mutedClass}>{renderUncappedBalanceLine(balance, balanceText)}</div>
+          <div className={mutedClass}>{renderUncappedBalanceLine(balance)}</div>
         </div>
       )
     }

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -191,7 +191,28 @@ export function getExtraUsageLabel(provider: ProviderRateLimits['provider']): st
   if (provider === 'opencode-go') {
     return translate('auto.components.status.bar.tooltip.fbc80d8be2', 'Zen balance')
   }
+  if (provider === 'codex') {
+    return translate('auto.components.status.bar.tooltip.f21b2ba897', 'Credits')
+  }
   return translate('auto.components.status.bar.tooltip.c03c61f53f', 'Balance')
+}
+
+// The uncapped balance line reads differently by denomination: a currency
+// amount (Zen balance), a credit count (Codex), or "Unlimited".
+function renderUncappedBalanceLine(balance: ExtraUsageBalance, currencyText: string): string {
+  if (balance.unit === 'credits') {
+    if (balance.unlimited) {
+      return translate('auto.components.status.bar.tooltip.56c0d70577', 'Unlimited')
+    }
+    return translate(
+      'auto.components.status.bar.tooltip.87b5bda4d3',
+      '{{value0}} credits available',
+      { value0: String(balance.balance) }
+    )
+  }
+  return translate('auto.components.status.bar.tooltip.f6a27a3c0a', '{{value0}} available', {
+    value0: currencyText
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -340,11 +361,7 @@ export function ProviderPanel({
       return (
         <div className="space-y-1">
           <div className={`font-medium ${textClass}`}>{label}</div>
-          <div className={mutedClass}>
-            {translate('auto.components.status.bar.tooltip.f6a27a3c0a', '{{value0}} available', {
-              value0: balanceText
-            })}
-          </div>
+          <div className={mutedClass}>{renderUncappedBalanceLine(balance, balanceText)}</div>
         </div>
       )
     }

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -1,8 +1,13 @@
-import type { ProviderRateLimits, RateLimitWindow } from '../../../../shared/rate-limit-types'
+import type {
+  ExtraUsageBalance,
+  ProviderRateLimits,
+  RateLimitWindow
+} from '../../../../shared/rate-limit-types'
 import {
   formatResetCountdown,
   formatResetDuration
 } from '../../../../shared/rate-limit-reset-format'
+import { formatCurrencyAmount } from '../../../../shared/currency-format'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
 import { translate } from '@/i18n/i18n'
@@ -176,6 +181,19 @@ export function getWindowSections(
   return sections
 }
 
+// Why: the overage balance is named per provider (Claude calls it "Usage
+// credits"; OpenCode Go exposes a pay-as-you-go "Zen balance"), so the copy is
+// chosen in the renderer — the shared data model stays provider-agnostic.
+export function getExtraUsageLabel(provider: ProviderRateLimits['provider']): string {
+  if (provider === 'claude') {
+    return translate('auto.components.status.bar.tooltip.7404abbece', 'Usage credits')
+  }
+  if (provider === 'opencode-go') {
+    return translate('auto.components.status.bar.tooltip.fbc80d8be2', 'Zen balance')
+  }
+  return translate('auto.components.status.bar.tooltip.c03c61f53f', 'Balance')
+}
+
 // ---------------------------------------------------------------------------
 // Tooltip — progress bar section for a single window
 // ---------------------------------------------------------------------------
@@ -308,6 +326,57 @@ export function ProviderPanel({
       ? formatResetCreditExpiry(p.rateLimitResetCredits?.nextExpiresAt, resetCreditCount)
       : null
 
+  const PanelBalanceSection = ({
+    balance,
+    label
+  }: {
+    balance: ExtraUsageBalance
+    label: string
+  }): React.JSX.Element => {
+    // Capped balances (Claude usage credits) render a spent/limit meter plus the
+    // current balance; uncapped balances (OpenCode Go Zen credit) render a plain
+    // available amount.
+    const capped = balance.spendLimit !== null && balance.spentPercent !== null
+    const balanceText = formatCurrencyAmount(balance.balance, balance.currencyCode)
+
+    if (!capped) {
+      return (
+        <div className="space-y-1">
+          <div className={`font-medium ${textClass}`}>{label}</div>
+          <div className={mutedClass}>
+            {translate('auto.components.status.bar.tooltip.f6a27a3c0a', '{{value0}} available', {
+              value0: balanceText
+            })}
+          </div>
+        </div>
+      )
+    }
+
+    const spentPct = clampUsedPercent(balance.spentPercent ?? 0)
+    const spent = formatCurrencyAmount(balance.spent ?? 0, balance.currencyCode)
+    const limit = formatCurrencyAmount(balance.spendLimit ?? 0, balance.currencyCode)
+    return (
+      <div className="space-y-1">
+        <div className={`font-medium ${textClass}`}>{label}</div>
+        <div className={`h-[6px] w-full overflow-hidden rounded-full ${emptyBarClass}`}>
+          <div
+            className={`h-full rounded-full ${barColor(spentPct)} transition-all duration-300`}
+            style={{ width: `${spentPct}%` }}
+          />
+        </div>
+        <div className={`flex justify-between ${mutedClass}`}>
+          <span>{`${spent} / ${limit}`}</span>
+          <span>{formatUsagePercentageLabel(spentPct, usagePercentageDisplay)}</span>
+        </div>
+        <div className={faintClass}>
+          {translate('auto.components.status.bar.tooltip.473d45cd0f', 'Balance {{value0}}', {
+            value0: balanceText
+          })}
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className={`${className ?? 'w-full'} space-y-3 text-xs`}>
       <div>
@@ -346,6 +415,10 @@ export function ProviderPanel({
           usagePercentageDisplay={usagePercentageDisplay}
         />
       ))}
+
+      {p.extraUsage ? (
+        <PanelBalanceSection balance={p.extraUsage} label={getExtraUsageLabel(p.provider)} />
+      ) : null}
 
       {p.error ? (
         <ErrorMessage

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3448,7 +3448,9 @@
             "grokUsageAria": "Open Grok usage details",
             "grokUsageMenu": "Grok Usage",
             "floatingTerminalNewActivity": "{{label}}, new activity",
-            "4fba7dc1e7": "bal"
+            "4fba7dc1e7": "bal",
+            "4025a6f62f": "Unlimited",
+            "a95969101f": "credits"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Connect an account",
@@ -3632,7 +3634,10 @@
             "c03c61f53f": "Balance",
             "f6a27a3c0a": "{{value0}} available",
             "7404abbece": "Usage credits",
-            "473d45cd0f": "Balance {{value0}}"
+            "473d45cd0f": "Balance {{value0}}",
+            "f21b2ba897": "Credits",
+            "56c0d70577": "Unlimited",
+            "87b5bda4d3": "{{value0}} credits available"
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH Host"

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3447,7 +3447,8 @@
             "antigravityUsageDetails": "Open Antigravity usage details",
             "grokUsageAria": "Open Grok usage details",
             "grokUsageMenu": "Grok Usage",
-            "floatingTerminalNewActivity": "{{label}}, new activity"
+            "floatingTerminalNewActivity": "{{label}}, new activity",
+            "4fba7dc1e7": "bal"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Connect an account",
@@ -3626,7 +3627,12 @@
             "e2c6a4f917": "Run Grok to refresh",
             "d1b7f509ac": "Run grok in a terminal on the computer running Orca and wait for it to start. If prompted, complete sign-in, then retry usage. You do not need to send a chat message.",
             "f90b3d7a16": "Run Kimi to refresh",
-            "a37e8c15d4": "Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage."
+            "a37e8c15d4": "Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage.",
+            "fbc80d8be2": "Zen balance",
+            "c03c61f53f": "Balance",
+            "f6a27a3c0a": "{{value0}} available",
+            "7404abbece": "Usage credits",
+            "473d45cd0f": "Balance {{value0}}"
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH Host"

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3271,7 +3271,7 @@
             "grokUsageAria": "Abrir detalles de uso de Grok",
             "grokUsageMenu": "Uso de Grok",
             "floatingTerminalNewActivity": "{{label}}, nueva actividad",
-            "4fba7dc1e7": "bal"
+            "4fba7dc1e7": "saldo"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Conectar una cuenta",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3270,7 +3270,8 @@
             "antigravityUsageDetails": "Abrir detalles de uso de Antigravity",
             "grokUsageAria": "Abrir detalles de uso de Grok",
             "grokUsageMenu": "Uso de Grok",
-            "floatingTerminalNewActivity": "{{label}}, nueva actividad"
+            "floatingTerminalNewActivity": "{{label}}, nueva actividad",
+            "4fba7dc1e7": "bal"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Conectar una cuenta",
@@ -3433,7 +3434,12 @@
             "e2c6a4f917": "Run Grok to refresh",
             "d1b7f509ac": "Run grok in a terminal on the computer running Orca and wait for it to start. If prompted, complete sign-in, then retry usage. You do not need to send a chat message.",
             "f90b3d7a16": "Run Kimi to refresh",
-            "a37e8c15d4": "Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage."
+            "a37e8c15d4": "Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage.",
+            "fbc80d8be2": "Zen balance",
+            "c03c61f53f": "Balance",
+            "f6a27a3c0a": "{{value0}} available",
+            "7404abbece": "Usage credits",
+            "473d45cd0f": "Balance {{value0}}"
           },
           "SshTargetStatusRow": {
             "sshHost": "Host SSH"

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3271,7 +3271,9 @@
             "grokUsageAria": "Abrir detalles de uso de Grok",
             "grokUsageMenu": "Uso de Grok",
             "floatingTerminalNewActivity": "{{label}}, nueva actividad",
-            "4fba7dc1e7": "saldo"
+            "4fba7dc1e7": "saldo",
+            "4025a6f62f": "Unlimited",
+            "a95969101f": "credits"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Conectar una cuenta",
@@ -3439,7 +3441,10 @@
             "c03c61f53f": "Balance",
             "f6a27a3c0a": "{{value0}} available",
             "7404abbece": "Usage credits",
-            "473d45cd0f": "Balance {{value0}}"
+            "473d45cd0f": "Balance {{value0}}",
+            "f21b2ba897": "Credits",
+            "56c0d70577": "Unlimited",
+            "87b5bda4d3": "{{value0}} credits available"
           },
           "SshTargetStatusRow": {
             "sshHost": "Host SSH"

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3271,7 +3271,7 @@
             "grokUsageAria": "Grok の使用状況詳細を開く",
             "grokUsageMenu": "Grok の使用状況",
             "floatingTerminalNewActivity": "{{label}}、新規アクティビティ",
-            "4fba7dc1e7": "bal"
+            "4fba7dc1e7": "残高"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "アカウントを接続する",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3270,7 +3270,8 @@
             "antigravityUsageDetails": "Antigravity の使用状況詳細を開く",
             "grokUsageAria": "Grok の使用状況詳細を開く",
             "grokUsageMenu": "Grok の使用状況",
-            "floatingTerminalNewActivity": "{{label}}、新規アクティビティ"
+            "floatingTerminalNewActivity": "{{label}}、新規アクティビティ",
+            "4fba7dc1e7": "bal"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "アカウントを接続する",
@@ -3433,7 +3434,12 @@
             "e2c6a4f917": "Grok を実行して更新",
             "d1b7f509ac": "Orca を実行しているコンピュータのターミナルで grok を実行し、起動するまで待ってください。サインインを求められた場合は完了してから、使用状況を再取得してください。チャットメッセージを送る必要はありません。",
             "f90b3d7a16": "Kimi を実行して更新",
-            "a37e8c15d4": "Orca を実行しているコンピュータのターミナルで kimi を実行し、起動するまで待ってから、使用状況を再取得してください。"
+            "a37e8c15d4": "Orca を実行しているコンピュータのターミナルで kimi を実行し、起動するまで待ってから、使用状況を再取得してください。",
+            "fbc80d8be2": "Zen balance",
+            "c03c61f53f": "Balance",
+            "f6a27a3c0a": "{{value0}} available",
+            "7404abbece": "Usage credits",
+            "473d45cd0f": "Balance {{value0}}"
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH ホスト"

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3271,7 +3271,9 @@
             "grokUsageAria": "Grok の使用状況詳細を開く",
             "grokUsageMenu": "Grok の使用状況",
             "floatingTerminalNewActivity": "{{label}}、新規アクティビティ",
-            "4fba7dc1e7": "残高"
+            "4fba7dc1e7": "残高",
+            "4025a6f62f": "Unlimited",
+            "a95969101f": "credits"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "アカウントを接続する",
@@ -3439,7 +3441,10 @@
             "c03c61f53f": "Balance",
             "f6a27a3c0a": "{{value0}} available",
             "7404abbece": "Usage credits",
-            "473d45cd0f": "Balance {{value0}}"
+            "473d45cd0f": "Balance {{value0}}",
+            "f21b2ba897": "Credits",
+            "56c0d70577": "Unlimited",
+            "87b5bda4d3": "{{value0}} credits available"
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH ホスト"

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3271,7 +3271,7 @@
             "grokUsageAria": "Grok 사용량 세부 정보 열기",
             "grokUsageMenu": "Grok 사용량",
             "floatingTerminalNewActivity": "{{label}}, 새 활동",
-            "4fba7dc1e7": "bal"
+            "4fba7dc1e7": "잔액"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "계정 연결",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3270,7 +3270,8 @@
             "antigravityUsageDetails": "Antigravity 사용량 세부 정보 열기",
             "grokUsageAria": "Grok 사용량 세부 정보 열기",
             "grokUsageMenu": "Grok 사용량",
-            "floatingTerminalNewActivity": "{{label}}, 새 활동"
+            "floatingTerminalNewActivity": "{{label}}, 새 활동",
+            "4fba7dc1e7": "bal"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "계정 연결",
@@ -3433,7 +3434,12 @@
             "e2c6a4f917": "Run Grok to refresh",
             "d1b7f509ac": "Run grok in a terminal on the computer running Orca and wait for it to start. If prompted, complete sign-in, then retry usage. You do not need to send a chat message.",
             "f90b3d7a16": "Run Kimi to refresh",
-            "a37e8c15d4": "Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage."
+            "a37e8c15d4": "Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage.",
+            "fbc80d8be2": "Zen balance",
+            "c03c61f53f": "Balance",
+            "f6a27a3c0a": "{{value0}} available",
+            "7404abbece": "Usage credits",
+            "473d45cd0f": "Balance {{value0}}"
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH 호스트"

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3271,7 +3271,9 @@
             "grokUsageAria": "Grok 사용량 세부 정보 열기",
             "grokUsageMenu": "Grok 사용량",
             "floatingTerminalNewActivity": "{{label}}, 새 활동",
-            "4fba7dc1e7": "잔액"
+            "4fba7dc1e7": "잔액",
+            "4025a6f62f": "Unlimited",
+            "a95969101f": "credits"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "계정 연결",
@@ -3439,7 +3441,10 @@
             "c03c61f53f": "Balance",
             "f6a27a3c0a": "{{value0}} available",
             "7404abbece": "Usage credits",
-            "473d45cd0f": "Balance {{value0}}"
+            "473d45cd0f": "Balance {{value0}}",
+            "f21b2ba897": "Credits",
+            "56c0d70577": "Unlimited",
+            "87b5bda4d3": "{{value0}} credits available"
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH 호스트"

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3283,7 +3283,9 @@
             "grokUsageAria": "打开 Grok 使用详情",
             "grokUsageMenu": "Grok 使用情况",
             "floatingTerminalNewActivity": "{{label}}，有新活动",
-            "4fba7dc1e7": "余额"
+            "4fba7dc1e7": "余额",
+            "4025a6f62f": "Unlimited",
+            "a95969101f": "credits"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "连接账户",
@@ -3451,7 +3453,10 @@
             "c03c61f53f": "Balance",
             "f6a27a3c0a": "{{value0}} available",
             "7404abbece": "Usage credits",
-            "473d45cd0f": "Balance {{value0}}"
+            "473d45cd0f": "Balance {{value0}}",
+            "f21b2ba897": "Credits",
+            "56c0d70577": "Unlimited",
+            "87b5bda4d3": "{{value0}} credits available"
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH 主机"

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3282,7 +3282,8 @@
             "antigravityUsageDetails": "打开 Antigravity 使用详情",
             "grokUsageAria": "打开 Grok 使用详情",
             "grokUsageMenu": "Grok 使用情况",
-            "floatingTerminalNewActivity": "{{label}}，有新活动"
+            "floatingTerminalNewActivity": "{{label}}，有新活动",
+            "4fba7dc1e7": "bal"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "连接账户",
@@ -3445,7 +3446,12 @@
             "e2c6a4f917": "运行 Grok 以刷新",
             "d1b7f509ac": "在运行 Orca 的电脑上的终端中运行 grok，并等待其启动。如有提示，请完成登录，然后重试用量检查。您无需发送聊天消息。",
             "f90b3d7a16": "运行 Kimi 以刷新",
-            "a37e8c15d4": "在运行 Orca 的电脑上的终端中运行 kimi，等待其启动，然后重试用量检查。"
+            "a37e8c15d4": "在运行 Orca 的电脑上的终端中运行 kimi，等待其启动，然后重试用量检查。",
+            "fbc80d8be2": "Zen balance",
+            "c03c61f53f": "Balance",
+            "f6a27a3c0a": "{{value0}} available",
+            "7404abbece": "Usage credits",
+            "473d45cd0f": "Balance {{value0}}"
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH 主机"

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3283,7 +3283,7 @@
             "grokUsageAria": "打开 Grok 使用详情",
             "grokUsageMenu": "Grok 使用情况",
             "floatingTerminalNewActivity": "{{label}}，有新活动",
-            "4fba7dc1e7": "bal"
+            "4fba7dc1e7": "余额"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "连接账户",

--- a/src/shared/credit-count-format.test.ts
+++ b/src/shared/credit-count-format.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { formatCreditCount } from './credit-count-format'
+
+describe('formatCreditCount', () => {
+  it('uses the viewer locale for grouped credit counts', () => {
+    const expected = new Intl.NumberFormat(undefined, { maximumFractionDigits: 20 }).format(1234)
+    expect(formatCreditCount(1234)).toBe(expected)
+  })
+
+  it('normalizes invalid and negative counts', () => {
+    expect(formatCreditCount(Number.NaN)).toBe('0')
+    expect(formatCreditCount(-5)).toBe('0')
+  })
+})

--- a/src/shared/credit-count-format.ts
+++ b/src/shared/credit-count-format.ts
@@ -1,0 +1,6 @@
+const CREDIT_COUNT_FORMATTER = new Intl.NumberFormat(undefined, { maximumFractionDigits: 20 })
+
+export function formatCreditCount(count: number): string {
+  const safeCount = Number.isFinite(count) ? Math.max(0, count) : 0
+  return CREDIT_COUNT_FORMATTER.format(safeCount)
+}

--- a/src/shared/currency-format.test.ts
+++ b/src/shared/currency-format.test.ts
@@ -5,7 +5,7 @@ describe('formatCurrencyAmount', () => {
   it('formats USD amounts with the dollar symbol', () => {
     // Force a stable locale-independent expectation by asserting substrings.
     const formatted = formatCurrencyAmount(12.4, 'USD')
-    expect(formatted).toContain('12.40')
+    expect(formatted).toMatch(/12[.,]40/)
     expect(formatted).toContain('$')
   })
 
@@ -25,6 +25,6 @@ describe('formatCurrencyAmount', () => {
   })
 
   it('treats non-finite amounts as zero', () => {
-    expect(formatCurrencyAmount(Number.NaN, 'USD')).toContain('0.00')
+    expect(formatCurrencyAmount(Number.NaN, 'USD')).toMatch(/0[.,]00/)
   })
 })

--- a/src/shared/currency-format.test.ts
+++ b/src/shared/currency-format.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { formatCurrencyAmount } from './currency-format'
+
+describe('formatCurrencyAmount', () => {
+  it('formats USD amounts with the dollar symbol', () => {
+    // Force a stable locale-independent expectation by asserting substrings.
+    const formatted = formatCurrencyAmount(12.4, 'USD')
+    expect(formatted).toContain('12.40')
+    expect(formatted).toContain('$')
+  })
+
+  it('formats EUR amounts with the euro symbol and thousands separator', () => {
+    const formatted = formatCurrencyAmount(2000, 'EUR')
+    expect(formatted).toContain('€')
+    expect(formatted).toMatch(/2[.,]000/)
+  })
+
+  it('falls back to code + amount for a malformed currency code', () => {
+    // A non-3-letter code makes Intl.NumberFormat throw, exercising the fallback.
+    expect(formatCurrencyAmount(9.5, 'ZZ')).toBe('ZZ 9.50')
+  })
+
+  it('defaults blank currency codes to USD', () => {
+    expect(formatCurrencyAmount(1, '   ')).toContain('$')
+  })
+
+  it('treats non-finite amounts as zero', () => {
+    expect(formatCurrencyAmount(Number.NaN, 'USD')).toContain('0.00')
+  })
+})

--- a/src/shared/currency-format.ts
+++ b/src/shared/currency-format.ts
@@ -1,0 +1,21 @@
+/**
+ * Format a major-unit amount (e.g. 12.4) as a localized currency string
+ * (e.g. "$12.40"). Shared by the usage popover and the compact status-bar
+ * balance token so both render identically.
+ *
+ * Why: `Intl.NumberFormat` throws on an unrecognized currency code (the code
+ * comes from a provider API we don't control), so fall back to a plain
+ * "<CODE> <amount>" rendering rather than crashing the status bar.
+ */
+export function formatCurrencyAmount(amount: number, currencyCode: string): string {
+  const safeAmount = Number.isFinite(amount) ? amount : 0
+  const code = currencyCode.trim() || 'USD'
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency: code
+    }).format(safeAmount)
+  } catch {
+    return `${code} ${safeAmount.toFixed(2)}`
+  }
+}

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -11,6 +11,32 @@ export type RateLimitWindow = {
 
 export type ProviderRateLimitStatus = 'idle' | 'fetching' | 'ok' | 'error' | 'unavailable'
 
+/**
+ * Pay-as-you-go / overage balance that a plan spends into once its included
+ * usage windows are exhausted (Claude "usage credits", OpenCode Go "Zen
+ * balance"). Two shapes share these fields: a capped balance with a monthly
+ * spend limit (Claude — `spendLimit`/`spentPercent` set) and an uncapped raw
+ * balance (OpenCode Go — only `balance` set).
+ */
+export type ExtraUsageBalance = {
+  /** Current spendable credit balance in major currency units. */
+  balance: number
+  /** ISO 4217 currency code, e.g. "USD" or "EUR". */
+  currencyCode: string
+  /** Whether the provider can currently spend into this balance. */
+  enabled: boolean
+  /** Machine-readable reason spending is unavailable (e.g. "out_of_credits"), or null. */
+  disabledReason: string | null
+  /** Amount spent against the monthly cap this period (major units); null when uncapped. */
+  spent: number | null
+  /** Monthly spend cap in major units; null when uncapped (raw balance only). */
+  spendLimit: number | null
+  /** Percent of the monthly cap spent (0–100); null when uncapped. */
+  spentPercent: number | null
+  /** Unix ms timestamp when the cap resets, if known. */
+  resetsAt: number | null
+}
+
 export type RateLimitBucket = RateLimitWindow & {
   name: string
 }
@@ -63,6 +89,12 @@ export type ProviderRateLimits = {
   fableWeekly?: RateLimitWindow | null
   /** 30-day monthly window (OpenCode Go, Grok unified billing), null if not available. */
   monthly?: RateLimitWindow | null
+  /**
+   * Overage / pay-as-you-go balance the plan spends into once its windows are
+   * capped (Claude "extra usage" cap, OpenCode Go "Zen balance"), null when the
+   * provider reports none or extra usage is disabled.
+   */
+  extraUsage?: ExtraUsageBalance | null
   /** Named per-model buckets (Gemini only). */
   buckets?: RateLimitBucket[]
   /** Available earned Codex rate-limit reset credits, if reported. */

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -11,38 +11,29 @@ export type RateLimitWindow = {
 
 export type ProviderRateLimitStatus = 'idle' | 'fetching' | 'ok' | 'error' | 'unavailable'
 
-/**
- * Pay-as-you-go / overage balance that a plan spends into once its included
- * usage windows are exhausted (Claude "usage credits", OpenCode Go "Zen
- * balance"). Two shapes share these fields: a capped balance with a monthly
- * spend limit (Claude — `spendLimit`/`spentPercent` set) and an uncapped raw
- * balance (OpenCode Go — only `balance` set).
- */
-export type ExtraUsageBalance = {
-  /**
-   * Current spendable balance — a currency amount (major units) when `unit` is
-   * "currency", or a unitless credit count when `unit` is "credits".
-   */
+type ExtraUsageBalanceBase = {
   balance: number
-  /** How `balance` is denominated: a currency amount or a plain credit count. */
-  unit: 'currency' | 'credits'
-  /** True when the balance is effectively unlimited (render "Unlimited"). */
-  unlimited: boolean
-  /** ISO 4217 currency code; only meaningful when `unit` is "currency". */
-  currencyCode: string
-  /** Whether the provider can currently spend into this balance. */
   enabled: boolean
-  /** Machine-readable reason spending is unavailable (e.g. "out_of_credits"), or null. */
   disabledReason: string | null
-  /** Amount spent against the monthly cap this period (major units); null when uncapped. */
-  spent: number | null
-  /** Monthly spend cap in major units; null when uncapped (raw balance only). */
-  spendLimit: number | null
-  /** Percent of the monthly cap spent (0–100); null when uncapped. */
-  spentPercent: number | null
-  /** Unix ms timestamp when the cap resets, if known. */
   resetsAt: number | null
 }
+
+type CurrencyExtraUsageBalance = ExtraUsageBalanceBase & {
+  unit: 'currency'
+  currencyCode: string
+  spent: number | null
+  spendLimit: number | null
+  spentPercent: number | null
+}
+
+type CreditExtraUsageBalance = ExtraUsageBalanceBase & {
+  unit: 'credits'
+  unlimited: boolean
+}
+
+// Why: currency and unitless credits have different metadata; the discriminator
+// prevents consumers from inventing dummy currency or spend-limit values.
+export type ExtraUsageBalance = CurrencyExtraUsageBalance | CreditExtraUsageBalance
 
 export type RateLimitBucket = RateLimitWindow & {
   name: string
@@ -97,9 +88,7 @@ export type ProviderRateLimits = {
   /** 30-day monthly window (OpenCode Go, Grok unified billing), null if not available. */
   monthly?: RateLimitWindow | null
   /**
-   * Overage / pay-as-you-go balance the plan spends into once its windows are
-   * capped (Claude "extra usage" cap, OpenCode Go "Zen balance"), null when the
-   * provider reports none or extra usage is disabled.
+   * Overage / pay-as-you-go balance the plan spends into once its windows cap.
    */
   extraUsage?: ExtraUsageBalance | null
   /** Named per-model buckets (Gemini only). */

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -19,9 +19,16 @@ export type ProviderRateLimitStatus = 'idle' | 'fetching' | 'ok' | 'error' | 'un
  * balance (OpenCode Go — only `balance` set).
  */
 export type ExtraUsageBalance = {
-  /** Current spendable credit balance in major currency units. */
+  /**
+   * Current spendable balance — a currency amount (major units) when `unit` is
+   * "currency", or a unitless credit count when `unit` is "credits".
+   */
   balance: number
-  /** ISO 4217 currency code, e.g. "USD" or "EUR". */
+  /** How `balance` is denominated: a currency amount or a plain credit count. */
+  unit: 'currency' | 'credits'
+  /** True when the balance is effectively unlimited (render "Unlimited"). */
+  unlimited: boolean
+  /** ISO 4217 currency code; only meaningful when `unit` is "currency". */
   currencyCode: string
   /** Whether the provider can currently spend into this balance. */
   enabled: boolean


### PR DESCRIPTION
## Summary

Adds a **pay-as-you-go credit balance** to the provider usage summaries for the three providers that expose one in data Orca already fetches — no new network call and no new credential:

- **Claude → "Usage credits":** parses the `spend` object from the OAuth usage response Orca already fetches (monthly spend limit + current balance), with the legacy `extra_usage` shape as a fallback. This is the same data Claude Code's own `/usage` panel shows, including the disabled / "out of credits" state (rendered honestly, not mislabeled "off").
- **OpenCode Go → "Zen balance":** parses the pay-as-you-go Zen balance from the workspace page Orca already scrapes.
- **Codex → "Credits":** parses `rateLimits.credits` from the same app-server RPC Orca already uses for Codex windows. Codex credits are a **unitless count** (e.g. 500 credits), not a currency, so the shared model gained a `unit: 'currency' | 'credits'` discriminator plus an `unlimited` flag. Hidden for accounts that never bought credits (`hasCredits: false`).

Behaviour:

- **Popover** always shows the balance row so it's discoverable at 0% used. Claude renders a spent/limit meter plus current balance; OpenCode Go renders a plain available amount; Codex renders "N credits available" (or "Unlimited"). The row reuses the existing panel tokens (label weight, bar colours, muted/faint text) so it matches Session/Weekly exactly.
- **Compact status-bar segment** stays hidden normally and reveals the remaining balance (counting down) only once a plan window caps **and** the balance is actually spendable — so it appears exactly when the plan starts spending into it.
- **Denomination** is taken from the provider response: currency amounts are formatted with `Intl.NumberFormat` so they adapt to the account's currency and the viewer's locale (`€2,000.00`, `$12.40`, `¥2000`, `2.000,00 €`, …); Codex renders a plain localized credit count. Nothing is hardcoded to `$`/EUR.

Fixes #9362

## Screenshots

_Compact status-bar segment, Claude "Usage credits" popover, and the row in context:_

<img width="336" height="80" alt="Compact status-bar segment" src="https://github.com/user-attachments/assets/b42c94bf-4e8d-4102-bb55-8cce51add23b" />
<img width="317" height="426" alt="Claude Usage credits row in the popover" src="https://github.com/user-attachments/assets/012275d5-cc71-4f02-9c1f-11bd6d00bc72" />
<img width="350" height="477" alt="Usage credits row alongside Session and Weekly" src="https://github.com/user-attachments/assets/d980cd2c-ee0b-485f-84f0-534ecfb937d9" />

_Codex "Credits" row:_

<img width="308" height="437" alt="Codex Credits row showing 500 credits available" src="https://github.com/user-attachments/assets/2b302a08-77b0-4fc3-b434-3e739b5b8e3f" />

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Notes on `pnpm test`: the touched areas pass in full (Claude `spend` mapping incl. disabled/out-of-credits and the legacy fallback, the OpenCode Go Zen-balance parser, the currency formatter, popover rendering for enabled/disabled/uncapped, and the compact reveal incl. "disabled stays hidden"). The wider suite has a handful of failures in unrelated modules (PR-comment list, Linear prompt toast, sidebar toolbar, a flaky terminal-PTY test); these were confirmed pre-existing by re-running them with this branch's changes stashed.

New/updated tests:
- `src/shared/currency-format.test.ts` — locale-safe currency formatting + malformed-code fallback.
- `src/main/rate-limits/opencode-go-page-scraper.test.ts` — Zen-balance parsing (scaled billing object, explicit USD keys, human-readable text, disabled/no-balance cases, size guard).
- `src/main/rate-limits/claude-fetcher.test.ts` — `spend` → capped balance, disabled out-of-credits stays visible, legacy `extra_usage` fallback.
- `src/main/rate-limits/codex-fetcher.test.ts` — `rateLimits.credits` → credit-count balance; hidden when `hasCredits: false`.
- `src/renderer/src/components/status-bar/tooltip.test.ts` — popover render for capped/disabled/uncapped + credit-count + unlimited + per-provider labels.
- `src/renderer/src/components/status-bar/provider-segment-balance.test.tsx` — compact reveal on cap, hidden with headroom, hidden when disabled, credit-count vs currency.

## AI Review Report

Reviewed with the AI agent that wrote the change. Focus areas and outcomes:

- **Cross-platform (macOS / Linux / Windows):** the change is pure TypeScript/React with no platform branches, keyboard shortcuts, shortcut labels, path handling, or shell execution. Currency rendering uses `Intl.NumberFormat`, which is available and locale-aware across all Electron targets. No `metaKey`/path/`/`-vs-`\` assumptions were added.
- **SSH / remote:** the fetchers run in the main process via Electron `net.fetch` (Claude) and the existing OpenCode page scrape — same execution model as the current usage code, with no new local-only assumptions. The new field flows through the existing `ProviderRateLimits` IPC payload as a plain serializable object.
- **Git provider compatibility:** N/A — no source-control/review code touched.
- **Data-model safety:** `extraUsage` is additive and optional on `ProviderRateLimits`; existing providers that don't set it render unchanged (verified by an "omits the balance row" test).
- **Parsing robustness:** the Zen-balance scraper reuses the existing size guard (10 MB) and uses bounded regex quantifiers; the `customerID` gate prevents billing-disabled payloads (`customerID:null`, `balance:0`) from registering as a live balance.
- **Flagged & addressed during review:** initial version matched CodexBar and hid the row unless `is_enabled`, which hid a configured-but-disabled cap; reworked to show the real state after inspecting the live response. Switched from the minimal `extra_usage` field to the richer `spend` object (with fallback) so amounts, currency, and enabled state are exact. Removed temporary debug logging before commit.

## Security Audit

- **Untrusted input:** both parsers consume provider-controlled responses (OAuth JSON, scraped HTML). No `eval`/dynamic code; regexes are size-guarded and bounded. The currency code from the API is passed to `Intl.NumberFormat`, which throws on malformed codes — caught and replaced with a plain `<CODE> <amount>` fallback (tested).
- **Secrets:** no secrets are logged or persisted; the temporary debug logging used during investigation was removed. No credential handling changed — the feature reuses the existing OAuth token and OpenCode session cookie already in use.
- **Command execution / paths / IPC:** none added. No new IPC channels; the balance rides the existing usage payload.
- **Follow-up:** none required for this PR.

## Notes

- **Claude API Console org credits** (platform.claude.com) are a different billing system from subscription usage credits and are not covered here.
- **Codex credit unit:** the app-server reports `balance` as a plain credit count (verified against a live account: a $20 / 500-credit purchase surfaced as `balance: "500"`), so it renders as "500 credits", not a dollar amount.
- The compact balance token reveals only when a plan window is at ~100% and the balance is spendable, so it is inherently hard to exercise without hitting a real limit; the popover row is the always-visible surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y891yaV8gJpLycZEX6G5gm

## ELI5

Usage summaries can show pay-as-you-go credit balances for Claude, OpenCode Go Zen, and Codex when that data is already in the API response. You see remaining credits next to rate limits without extra logins.
