### PR TITLE
fix(workspaces): make remote workspace deletion idempotent

### DIFF
--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -302,6 +302,7 @@ describe('registerWorktreeHandlers', () => {
     setWorktreeMeta: vi.fn(),
     getProjectHostSetups: vi.fn(),
     removeWorktreeMeta: vi.fn(),
+    removeWorkspaceSessionStateForWorktree: vi.fn(),
     getAllWorktreeLineage: vi.fn(),
     removeWorktreeLineage: vi.fn(),
     getAllWorkspaceLineage: vi.fn(),
@@ -383,6 +384,7 @@ describe('registerWorktreeHandlers', () => {
       store.setWorktreeMeta,
       store.getProjectHostSetups,
       store.removeWorktreeMeta,
+      store.removeWorkspaceSessionStateForWorktree,
       store.getAllWorktreeLineage,
       store.removeWorktreeLineage,
       store.getAllWorkspaceLineage,
@@ -10103,17 +10105,28 @@ describe('registerWorktreeHandlers', () => {
       expect(removeWorktreeMock).not.toHaveBeenCalled()
     })
 
-    it('throws when the repo is missing', async () => {
+    it('forgets an ownerless workspace after its repo is already gone', async () => {
+      const worktreeId = 'repo-gone::/workspace/feature-wt'
       store.getRepo.mockReturnValue(undefined)
 
       await expect(
         handlers['worktrees:forgetLocal'](null, {
-          worktreeId: 'repo-gone::/workspace/feature-wt'
+          worktreeId,
+          hostId: 'runtime:env-1'
         })
-      ).rejects.toThrow(/Repo not found/)
+      ).resolves.toEqual({})
 
-      expect(store.removeWorktreeMeta).not.toHaveBeenCalled()
+      expect(store.removeWorktreeMeta).toHaveBeenCalledWith(worktreeId)
+      expect(store.removeWorkspaceSessionStateForWorktree).toHaveBeenCalledWith(
+        worktreeId,
+        'runtime:env-1'
+      )
+      expect(runtimeStub.clearOptimisticReconcileToken).toHaveBeenCalledWith(worktreeId)
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('worktrees:changed', {
+        repoId: 'repo-gone'
+      })
       expect(getSshGitProviderMock).not.toHaveBeenCalled()
+      expect(removeWorktreeMock).not.toHaveBeenCalled()
     })
 
     it('rejects forgetting a folder project root', async () => {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -2717,13 +2717,10 @@ export function registerWorktreeHandlers(
     ): Promise<RemoveWorktreeResult> => {
       const { repoId } = parseWorktreeId(args.worktreeId)
       const repo = getRepoForWorktreeRemoval(store, repoId, args.hostId)
-      if (!repo) {
-        throw new Error(`Repo not found: ${repoId}`)
-      }
-      // Why: share the removal in-flight map so concurrent remove and forgetLocal on the same id can't both mutate metadata.
+      // Why: metadata-only cleanup must work after the owning project disappears.
       const inFlightKey = getWorktreeRemovalInFlightKey(
         args.worktreeId,
-        getRepoExecutionHostId(repo)
+        repo ? getRepoExecutionHostId(repo) : args.hostId
       )
       const optionsKey = 'forget-local'
       const inFlight = worktreeRemovalsInFlight.get(inFlightKey)
@@ -2735,7 +2732,7 @@ export function registerWorktreeHandlers(
       }
 
       const forget = (async (): Promise<RemoveWorktreeResult> => {
-        if (isFolderRepo(repo) && args.worktreeId === getFolderWorkspaceRootId(repo)) {
+        if (repo && isFolderRepo(repo) && args.worktreeId === getFolderWorkspaceRootId(repo)) {
           throw new Error(
             'Cannot delete the project root workspace. Remove the folder project instead.'
           )
@@ -2752,6 +2749,7 @@ export function registerWorktreeHandlers(
 
         runtime.clearOptimisticReconcileToken(args.worktreeId)
         removeWorktreeMetadataAndTransientState(store, args.worktreeId)
+        store.removeWorkspaceSessionStateForWorktree(args.worktreeId, args.hostId)
         preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
         notifyWorktreesChanged(mainWindow, repoId)
         return {}

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -11195,6 +11195,34 @@ describe('Store host-partitioned workspace sessions', () => {
     expect(reloaded.getWorkspaceSession('runtime:env-a').activeRepoId).toBe('repo-a')
   })
 
+  it('removes one orphaned worktree from only its owning host partition', async () => {
+    const store = await createStore()
+    const worktreeId = 'repo-gone::/workspace/stale'
+    const session = {
+      ...makeHostSession('repo-gone'),
+      activeWorktreeId: worktreeId,
+      activeWorktreeIdsOnShutdown: [worktreeId],
+      lastVisitedAtByWorktreeId: { [worktreeId]: 123 }
+    }
+    store.setWorkspaceSession(session, 'runtime:env-a')
+    store.setWorkspaceSession(session, 'runtime:env-b')
+
+    store.removeWorkspaceSessionStateForWorktree(worktreeId, 'runtime:env-a')
+    store.flush()
+
+    const reloaded = await createStore()
+    expect(reloaded.getWorkspaceSession('runtime:env-a')).toMatchObject({
+      activeWorktreeId: null,
+      activeWorktreeIdsOnShutdown: [],
+      lastVisitedAtByWorktreeId: {}
+    })
+    expect(reloaded.getWorkspaceSession('runtime:env-b')).toMatchObject({
+      activeWorktreeId: worktreeId,
+      activeWorktreeIdsOnShutdown: [worktreeId],
+      lastVisitedAtByWorktreeId: { [worktreeId]: 123 }
+    })
+  })
+
   it('drops a corrupt host partition to defaults without failing the others', async () => {
     writeDataFile({
       schemaVersion: 1,

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -5798,6 +5798,14 @@ export class Store {
     this.setHostWorkspaceSession(resolved, session)
   }
 
+  removeWorkspaceSessionStateForWorktree(worktreeId: string, hostId?: string | null): void {
+    const session = removeWorkspaceSessionOwner(this.getWorkspaceSession(hostId), worktreeId)
+    if (session) {
+      // Host scoping matters because identical repo/path ids may exist on two servers.
+      this.setWorkspaceSession(session, hostId)
+    }
+  }
+
   /** Persist a non-'local' host partition; remote hosts skip setLocalWorkspaceSession's local-daemon PTY-binding race guards. */
   private setHostWorkspaceSession(hostId: ExecutionHostId, session: WorkspaceSessionState): void {
     // Why: each partition owns its topology fence; renderer writes omit it and must rebase locally.

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -39129,6 +39129,7 @@ describe('OrcaRuntimeService', () => {
       'runtime:env-1'
     )
     expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledWith(TEST_WORKTREE_ID)
+    expect(invalidateAuthorizedRootsCacheMock).toHaveBeenCalled()
     expect(removeWorktree).not.toHaveBeenCalled()
   })
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -39108,6 +39108,30 @@ describe('OrcaRuntimeService', () => {
     expect(removeWorktreeLinkedPathsMock).toHaveBeenCalledWith(TEST_WORKTREE_PATH, ['node_modules'])
   })
 
+  it('forgets exact-id orphan metadata when the parent repo is already gone', async () => {
+    const { runtimeStore, removeWorktreeMeta } = createStaleRuntimeWorktreeStore(TEST_WORKTREE_ID, {
+      hostId: 'runtime:env-1'
+    })
+    const removeWorkspaceSessionStateForWorktree = vi.fn()
+    const orphanStore = {
+      ...runtimeStore,
+      getRepos: () => [],
+      getRepo: () => undefined,
+      removeWorkspaceSessionStateForWorktree
+    }
+    const runtime = createWorktreeRemovalRuntime(orphanStore)
+
+    await expect(runtime.removeManagedWorktree(TEST_WORKTREE_ID)).resolves.toEqual({})
+
+    expect(removeWorktreeMeta).toHaveBeenCalledWith(TEST_WORKTREE_ID)
+    expect(removeWorkspaceSessionStateForWorktree).toHaveBeenCalledWith(
+      TEST_WORKTREE_ID,
+      'runtime:env-1'
+    )
+    expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledWith(TEST_WORKTREE_ID)
+    expect(removeWorktree).not.toHaveBeenCalled()
+  })
+
   it('does not remove a runtime worktree when watcher teardown cannot release it', async () => {
     const repo = { ...store.getRepos()[0], symlinkPaths: ['node_modules'] }
     const runtimeStore = { ...store, getRepos: () => [repo], getRepo: () => repo }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1030,6 +1030,7 @@ type RuntimeStore = {
   getWorkspaceSession?: Store['getWorkspaceSession']
   getWorkspaceSessionHostIds?: Store['getWorkspaceSessionHostIds']
   setWorkspaceSession?: Store['setWorkspaceSession']
+  removeWorkspaceSessionStateForWorktree?: Store['removeWorkspaceSessionStateForWorktree']
   flushOrThrow?: Store['flushOrThrow']
   persistPtyBinding?: Store['persistPtyBinding']
   getSshRemotePtyLeases?: Store['getSshRemotePtyLeases']
@@ -22265,7 +22266,10 @@ export class OrcaRuntimeService {
   private removeWorktreeMetadataAndHistory(store: RuntimeStore, worktreeId: string): void {
     // Why: worktree IDs are path-derived and can be recreated, so removal must
     // purge history and process-local caches before the ID points at new state.
+    const hostId = store.getWorktreeMeta(worktreeId)?.hostId
     store.removeWorktreeMeta(worktreeId)
+    store.removeWorkspaceSessionStateForWorktree?.(worktreeId, hostId)
+    this.mobileSessionTabsByWorktree.delete(worktreeId)
     advertisedUrlWatcher.forgetWorktree(worktreeId)
     deleteWorktreeHistoryDir(worktreeId)
     this.closeHeadlessBrowserPagesForWorktree(worktreeId)
@@ -22415,7 +22419,26 @@ export class OrcaRuntimeService {
     const removal = (async (): Promise<RemoveWorktreeResult & { warning?: string }> => {
       const repo = store.getRepo(removalTarget.repoId)
       if (!repo) {
-        throw new Error('repo_not_found')
+        // The parent project is already gone, so no Git/filesystem target can be
+        // resolved. Stop any surviving session before forgetting orphaned Orca state.
+        const localProvider = this.getLocalProvider()
+        if (localProvider) {
+          await killAllProcessesForWorktree(removalTarget.id, {
+            runtime: this,
+            localProvider,
+            onPtyStopped: this.onPtyStopped ?? undefined
+          }).catch((error) => {
+            console.warn(
+              `[worktree-teardown] orphan cleanup failed for ${removalTarget.id}:`,
+              error
+            )
+          })
+        }
+        this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
+        this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
+        this.invalidateResolvedWorktreeCache()
+        this.notifyWorktreesChanged(removalTarget.repoId)
+        return {}
       }
       if (isFolderRepo(repo)) {
         if (removalTarget.id === getRuntimeFolderWorkspaceRootId(repo)) {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -22434,9 +22434,12 @@ export class OrcaRuntimeService {
             )
           })
         }
+        this.clearOptimisticReconcileToken(removalTarget.id)
         this.removeWorktreeMetadataAndHistory(store, removalTarget.id)
         this.preservedBranchCleanupByWorktreeId.delete(removalTarget.id)
         this.invalidateResolvedWorktreeCache()
+        this.invalidateWorktreeScanCacheForRepo(removalTarget.repoId)
+        invalidateAuthorizedRootsCache()
         this.notifyWorktreesChanged(removalTarget.repoId)
         return {}
       }

--- a/src/renderer/src/runtime/runtime-rpc-client.ts
+++ b/src/renderer/src/runtime/runtime-rpc-client.ts
@@ -14,7 +14,11 @@ export {
   settingsForRuntimeOwner,
   type RuntimeClientTarget
 } from './runtime-client-target'
-export { RuntimeRpcCallError, unwrapRuntimeRpcResult } from './runtime-rpc-result'
+export {
+  hasRuntimeRpcErrorCode,
+  RuntimeRpcCallError,
+  unwrapRuntimeRpcResult
+} from './runtime-rpc-result'
 
 const RUNTIME_COMPATIBILITY_CACHE_MAX = 32
 const RECENT_RUNTIME_COMPATIBILITY_FAILURE_TTL_MS = 60_000

--- a/src/renderer/src/runtime/runtime-rpc-result.test.ts
+++ b/src/renderer/src/runtime/runtime-rpc-result.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { hasRuntimeRpcErrorCode, RuntimeRpcCallError } from './runtime-rpc-result'
+
+describe('hasRuntimeRpcErrorCode', () => {
+  it('matches structured runtime failures through wrapped causes', () => {
+    const failure = new RuntimeRpcCallError({
+      id: 'rpc-1',
+      ok: false,
+      error: { code: 'selector_not_found', message: 'Selector not found' }
+    })
+
+    expect(
+      hasRuntimeRpcErrorCode(new Error('remove failed', { cause: failure }), failure.code)
+    ).toBe(true)
+  })
+
+  it('supports legacy response envelopes and exact plain errors', () => {
+    expect(
+      hasRuntimeRpcErrorCode(
+        { response: { error: { message: 'repo_not_found' } } },
+        'repo_not_found'
+      )
+    ).toBe(true)
+    expect(hasRuntimeRpcErrorCode('repo_not_found', 'repo_not_found')).toBe(true)
+  })
+
+  it('rejects diagnostic mentions and cyclic causes', () => {
+    const cycle: { cause?: unknown; message: string } = { message: 'permission_denied' }
+    cycle.cause = cycle
+
+    expect(
+      hasRuntimeRpcErrorCode(
+        new Error('Access denied after a prior selector_not_found diagnostic'),
+        'selector_not_found'
+      )
+    ).toBe(false)
+    expect(hasRuntimeRpcErrorCode(cycle, 'selector_not_found')).toBe(false)
+  })
+})

--- a/src/renderer/src/runtime/runtime-rpc-result.ts
+++ b/src/renderer/src/runtime/runtime-rpc-result.ts
@@ -12,6 +12,34 @@ export class RuntimeRpcCallError extends Error {
   }
 }
 
+export function hasRuntimeRpcErrorCode(error: unknown, expectedCode: string): boolean {
+  const seen = new Set<unknown>()
+  let current = error
+  while (!seen.has(current)) {
+    if (current instanceof Error ? current.message === expectedCode : current === expectedCode) {
+      return true
+    }
+    if (!current || typeof current !== 'object') {
+      return false
+    }
+    seen.add(current)
+    const candidate = current as {
+      cause?: unknown
+      code?: unknown
+      response?: { error?: { code?: unknown; message?: unknown } }
+    }
+    if (
+      candidate.code === expectedCode ||
+      candidate.response?.error?.code === expectedCode ||
+      candidate.response?.error?.message === expectedCode
+    ) {
+      return true
+    }
+    current = candidate.cause
+  }
+  return false
+}
+
 export function unwrapRuntimeRpcResult<TResult>(response: RuntimeRpcResponse<TResult>): TResult {
   if (response.ok === false) {
     throw new RuntimeRpcCallError(response)

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -3042,7 +3042,8 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       markShutdownPending()
       handlerSnapshots = unregisterPtyDataHandlers(rendererShutdownPtyIds) ?? []
       try {
-        if (runtimeEnvironmentId) {
+        // Backend workspace removal already owns physical PTY teardown; only retire renderer bindings here.
+        if (runtimeEnvironmentId && shutdownReason !== 'remove-worktree') {
           await (shutdownReason === 'manual-sleep'
             ? requestRemoteWorktreeSleep({
                 environmentId: runtimeEnvironmentId,

--- a/src/renderer/src/store/slices/worktree-terminal-removal-teardown.test.ts
+++ b/src/renderer/src/store/slices/worktree-terminal-removal-teardown.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const unregisterPtyDataHandlers = vi.hoisted(() => vi.fn(() => []))
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn() }
+}))
+
+vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
+  restorePtyDataHandlersAfterFailedShutdown: vi.fn(),
+  unregisterPtyDataHandlers
+}))
+
+const runtimeCall = vi.fn()
+const killPty = vi.fn().mockResolvedValue(undefined)
+
+globalThis.window = {
+  api: {
+    pty: { kill: killPty },
+    runtimeEnvironments: { call: runtimeCall }
+  }
+} as never
+
+import { getDefaultSettings } from '../../../../shared/constants'
+import { createTestStore, makeRuntimeOwnedWorktree, makeTab, seedStore } from './store-test-helpers'
+
+describe('worktree terminal removal teardown', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('retires renderer bindings without stopping the already-removed remote workspace again', async () => {
+    const store = createTestStore()
+    const worktreeId = 'repo1::/srv/worktree'
+    const ptyId = 'remote:env-1@@pty-1'
+    seedStore(store, {
+      settings: { ...getDefaultSettings('/tmp'), activeRuntimeEnvironmentId: 'env-1' },
+      worktreesByRepo: {
+        repo1: [
+          makeRuntimeOwnedWorktree(
+            { id: worktreeId, repoId: 'repo1', path: '/srv/worktree' },
+            'env-1'
+          )
+        ]
+      },
+      tabsByWorktree: {
+        [worktreeId]: [makeTab({ id: 'tab-1', worktreeId, ptyId })]
+      },
+      ptyIdsByTabId: { 'tab-1': [ptyId] }
+    })
+
+    await store
+      .getState()
+      .shutdownWorktreeTerminals(worktreeId, { shutdownReason: 'remove-worktree' })
+
+    expect(runtimeCall).not.toHaveBeenCalled()
+    expect(killPty).not.toHaveBeenCalled()
+    expect(store.getState().ptyIdsByTabId['tab-1']).toEqual([])
+    expect(store.getState().pendingPtyShutdownIds[ptyId]).toBeUndefined()
+  })
+})

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -5064,6 +5064,38 @@ describe('worktree remote runtime mutations', () => {
     }
   )
 
+  it('does not forget a mirrored row when diagnostics merely mention a missing code', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      hostId: 'runtime:env-1'
+    })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-rm',
+      ok: false,
+      error: {
+        code: 'permission_denied',
+        message: 'Access denied while checking a prior repo_not_found diagnostic.'
+      },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      worktreesByRepo: { repo1: [wt] }
+    } as Partial<AppState>)
+
+    const result = await store.getState().removeWorktree(wt.id)
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Access denied while checking a prior repo_not_found diagnostic.'
+    })
+    expect(mockApi.worktrees.forgetLocal).not.toHaveBeenCalled()
+    expect(store.getState().worktreesByRepo.repo1).toEqual([wt])
+  })
+
   it('removes SSH-owned worktrees through local IPC even when a runtime is focused', async () => {
     const store = createTestStore()
     const wt = makeWorktree({

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -4965,6 +4965,9 @@ describe('worktree remote runtime mutations', () => {
       timeoutMs: 60_000
     })
     expect(mockApi.worktrees.remove).not.toHaveBeenCalled()
+    expect(store.getState().shutdownWorktreeTerminals).toHaveBeenCalledWith(wt.id, {
+      shutdownReason: 'remove-worktree'
+    })
     expect(store.getState().worktreesByRepo.repo1).toEqual([])
   })
 

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -107,6 +107,7 @@ const mockApi = {
     cancelListDetected: vi.fn().mockResolvedValue(undefined),
     listLineage: vi.fn().mockResolvedValue({}),
     remove: vi.fn().mockResolvedValue(undefined),
+    forgetLocal: vi.fn().mockResolvedValue({}),
     forceDeletePreservedBranch: vi.fn().mockResolvedValue({ deleted: true }),
     resolvePrBase: vi.fn(),
     resolveMrBase: vi.fn(),
@@ -5030,6 +5031,38 @@ describe('worktree remote runtime mutations', () => {
     expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
     expect(mockApi.worktrees.remove).not.toHaveBeenCalled()
   })
+
+  it.each(['repo_not_found', 'selector_not_found'])(
+    'forgets a mirrored row when the remote returns %s',
+    async (errorCode) => {
+      const store = createTestStore()
+      const wt = makeWorktree({
+        id: 'repo-gone::/path/stale',
+        repoId: 'repo-gone',
+        path: '/path/stale',
+        hostId: 'runtime:env-1'
+      })
+      runtimeEnvironmentCall.mockResolvedValue({
+        id: 'rpc-rm',
+        ok: false,
+        error: { code: errorCode, message: errorCode },
+        _meta: { runtimeId: 'runtime-remote' }
+      })
+      store.setState({
+        settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+        worktreesByRepo: { 'repo-gone': [wt] }
+      } as Partial<AppState>)
+
+      const result = await store.getState().removeWorktree(wt.id)
+
+      expect(result).toEqual({ ok: true })
+      expect(mockApi.worktrees.forgetLocal).toHaveBeenCalledWith({
+        worktreeId: wt.id,
+        hostId: 'runtime:env-1'
+      })
+      expect(store.getState().worktreesByRepo['repo-gone']).toEqual([])
+    }
+  )
 
   it('removes SSH-owned worktrees through local IPC even when a runtime is focused', async () => {
     const store = createTestStore()

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -43,6 +43,7 @@ import { disposeRemovedWorktreeParkedTerminalWatchers } from '../../components/t
 import {
   callRuntimeRpc,
   getActiveRuntimeTarget,
+  hasRuntimeRpcErrorCode,
   isRuntimeScopeForbiddenError,
   RuntimeRpcCallError
 } from '../../runtime/runtime-rpc-client'
@@ -841,43 +842,12 @@ function getFolderWorkspaceMetaUpdates(
   return next
 }
 
-function isRuntimeRpcError(error: unknown, expectedCode: string): boolean {
-  if (
-    error &&
-    typeof error === 'object' &&
-    'cause' in error &&
-    isRuntimeRpcError((error as { cause?: unknown }).cause, expectedCode)
-  ) {
-    return true
-  }
-  const code =
-    error &&
-    typeof error === 'object' &&
-    'code' in error &&
-    typeof (error as { code: unknown }).code === 'string'
-      ? (error as { code: string }).code
-      : null
-  const responseError =
-    error && typeof error === 'object' && 'response' in error
-      ? (error as { response?: { error?: { code?: unknown; message?: unknown } } }).response?.error
-      : undefined
-  const responseCode = typeof responseError?.code === 'string' ? responseError.code : null
-  const responseMessage = typeof responseError?.message === 'string' ? responseError.message : null
-  const message = error instanceof Error ? error.message : String(error)
-  return (
-    message === expectedCode ||
-    code === expectedCode ||
-    responseCode === expectedCode ||
-    responseMessage === expectedCode
-  )
-}
-
 function isRuntimeSelectorNotFoundError(error: unknown): boolean {
-  return isRuntimeRpcError(error, 'selector_not_found')
+  return hasRuntimeRpcErrorCode(error, 'selector_not_found')
 }
 
 function isRuntimeRepoNotFoundError(error: unknown): boolean {
-  return isRuntimeRpcError(error, 'repo_not_found')
+  return hasRuntimeRpcErrorCode(error, 'repo_not_found')
 }
 
 function replaceWorktreeInRepoLists(
@@ -3848,7 +3818,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       // Why: renderer state follows the successful backend result, so blocked dirty deletes keep their terminals intact.
       // Why browsers first: unregister Chromium guests before other teardown can intercept them (avoids a browser-state race).
       await get().shutdownWorktreeBrowsers(worktreeId)
-      await get().shutdownWorktreeTerminals(worktreeId)
+      await get().shutdownWorktreeTerminals(worktreeId, { shutdownReason: 'remove-worktree' })
       // Why: dispose the SSH relay AFTER terminal teardown so a still-mounted pane can't hit a gone relay and toast "SSH not active".
       const destroyedRuntimeSshTargetIds = await cleanupEphemeralVmRuntimesForDeleted({
         workspaceIds: [worktreeId]

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -866,11 +866,9 @@ function isRuntimeRpcError(error: unknown, expectedCode: string): boolean {
   const message = error instanceof Error ? error.message : String(error)
   return (
     message === expectedCode ||
-    message.includes(expectedCode) ||
     code === expectedCode ||
     responseCode === expectedCode ||
-    responseMessage === expectedCode ||
-    String(error).includes(expectedCode)
+    responseMessage === expectedCode
   )
 }
 

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -841,12 +841,12 @@ function getFolderWorkspaceMetaUpdates(
   return next
 }
 
-function isRuntimeSelectorNotFoundError(error: unknown): boolean {
+function isRuntimeRpcError(error: unknown, expectedCode: string): boolean {
   if (
     error &&
     typeof error === 'object' &&
     'cause' in error &&
-    isRuntimeSelectorNotFoundError((error as { cause?: unknown }).cause)
+    isRuntimeRpcError((error as { cause?: unknown }).cause, expectedCode)
   ) {
     return true
   }
@@ -857,31 +857,29 @@ function isRuntimeSelectorNotFoundError(error: unknown): boolean {
     typeof (error as { code: unknown }).code === 'string'
       ? (error as { code: string }).code
       : null
-  const responseCode =
-    error &&
-    typeof error === 'object' &&
-    'response' in error &&
-    typeof (error as { response?: { error?: { code?: unknown } } }).response?.error?.code ===
-      'string'
-      ? (error as { response: { error: { code: string } } }).response.error.code
-      : null
-  const responseMessage =
-    error &&
-    typeof error === 'object' &&
-    'response' in error &&
-    typeof (error as { response?: { error?: { message?: unknown } } }).response?.error?.message ===
-      'string'
-      ? (error as { response: { error: { message: string } } }).response.error.message
-      : null
+  const responseError =
+    error && typeof error === 'object' && 'response' in error
+      ? (error as { response?: { error?: { code?: unknown; message?: unknown } } }).response?.error
+      : undefined
+  const responseCode = typeof responseError?.code === 'string' ? responseError.code : null
+  const responseMessage = typeof responseError?.message === 'string' ? responseError.message : null
   const message = error instanceof Error ? error.message : String(error)
   return (
-    message === 'selector_not_found' ||
-    message.includes('selector_not_found') ||
-    code === 'selector_not_found' ||
-    responseCode === 'selector_not_found' ||
-    responseMessage === 'selector_not_found' ||
-    String(error).includes('selector_not_found')
+    message === expectedCode ||
+    message.includes(expectedCode) ||
+    code === expectedCode ||
+    responseCode === expectedCode ||
+    responseMessage === expectedCode ||
+    String(error).includes(expectedCode)
   )
+}
+
+function isRuntimeSelectorNotFoundError(error: unknown): boolean {
+  return isRuntimeRpcError(error, 'selector_not_found')
+}
+
+function isRuntimeRepoNotFoundError(error: unknown): boolean {
+  return isRuntimeRpcError(error, 'repo_not_found')
 }
 
 function replaceWorktreeInRepoLists(
@@ -3801,22 +3799,37 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             ? { ...get().settings, activeRuntimeEnvironmentId: null }
             : { activeRuntimeEnvironmentId: null }
       )
-      const removalResult = await (forgetLocalOnly
-        ? window.api.worktrees.forgetLocal({ worktreeId, hostId })
-        : target.kind === 'local'
-          ? (removalGenerationGuard?.assertCurrent(),
-            window.api.worktrees.remove({ worktreeId, hostId, force, skipArchive }))
-          : (removalGenerationGuard?.assertCurrent(),
-            callRuntimeRpc<RemoveWorktreeResult>(
-              target,
-              'worktree.rm',
-              {
-                worktree: toRuntimeWorktreeSelector(worktreeId),
-                force,
-                runHooks: !skipArchive
-              },
-              { timeoutMs: 60_000 }
-            )))
+      let removalResult: RemoveWorktreeResult
+      try {
+        removalResult = await (forgetLocalOnly
+          ? window.api.worktrees.forgetLocal({ worktreeId, hostId })
+          : target.kind === 'local'
+            ? (removalGenerationGuard?.assertCurrent(),
+              window.api.worktrees.remove({ worktreeId, hostId, force, skipArchive }))
+            : (removalGenerationGuard?.assertCurrent(),
+              callRuntimeRpc<RemoveWorktreeResult>(
+                target,
+                'worktree.rm',
+                {
+                  worktree: toRuntimeWorktreeSelector(worktreeId),
+                  force,
+                  runHooks: !skipArchive
+                },
+                { timeoutMs: 60_000 }
+              )))
+      } catch (error) {
+        if (
+          !forgetLocalOnly &&
+          target.kind !== 'local' &&
+          (isRuntimeRepoNotFoundError(error) || isRuntimeSelectorNotFoundError(error))
+        ) {
+          // The remote project/workspace is authoritative and already gone. Finish
+          // by dropping this client's orphaned metadata instead of trapping the row.
+          removalResult = await window.api.worktrees.forgetLocal({ worktreeId, hostId })
+        } else {
+          throw error
+        }
+      }
 
       // Why: invalidate stale probes once deletion is authoritative, so an old toast can't mutate a same-path replacement.
       forgetHugeRepoWarningDismissalsForWorktrees([worktreeId])


### PR DESCRIPTION
## Summary

- make remote workspace deletion idempotent when the remote runtime reports an authoritative `selector_not_found` or `repo_not_found`: forget the stale mirrored row instead of leaving an undeletable **Unknown** workspace
- treat a successful backend workspace removal as authoritative for owner-runtime PTY teardown, so renderer cleanup does not issue a second `terminal.stop` against metadata the backend just removed
- keep renderer terminal bindings cleanup intact while leaving manual sleep and exact hibernation teardown fail-closed
- allow metadata-only `worktrees:forgetLocal` cleanup after the parent project disappears, without contacting the missing remote runtime
- prune the deleted worktree from the correct host-scoped workspace-session partition so it does not return after reload/restart
- make runtime exact-ID orphan cleanup stop surviving sessions and clear metadata, history, browser/mobile state, and affected caches
- centralize exact runtime RPC error-code classification, including wrapped and legacy envelopes, without matching incidental diagnostic text

Related to #9024 and #8613. This complements #9025 and #9200, which prevent or sweep orphan state during project removal/load, plus the defensive persistence and hydration fixes in #9342, #9343, and #9344.

## Live remote reproduction

Validated against a paired Linux remote runtime on Orca `1.4.162-rc.0` using an Orca-created worktree named `test-56`.

The server-side evidence showed that deletion succeeded:

1. persisted metadata before deletion contained `orcaCreationSource: runtime`, its instance ID, owner, and two terminal tabs
2. both PTYs exited successfully
3. `git worktree remove` succeeded
4. branch deletion succeeded
5. the path, Git worktree registration, branch, `WorktreeMeta`, and workspace-session state were all gone

The client still reported `selector_not_found`. The race was the renderer calling `shutdownWorktreeTerminals()` after `worktree.rm` returned success. That cleanup issued a second remote `terminal.stop` using the now-deleted worktree selector. Depending on whether the runtime graph had processed removal yet, it either succeeded against stale graph state or returned `selector_not_found`, causing the outer removal flow to report a false failure and retain the client row.

This branch makes `remove-worktree` teardown renderer-only after backend success. Physical PTY shutdown remains owned and verified by the backend removal path.

The original stale-mirror reproduction also remains covered:

1. confirmed a deleted remote workspace reappeared under **Unknown** from `workspaceSessionsByHostId`
2. reproduced the pre-fix `selector_not_found` delete toast
3. verified metadata-only recovery removed the row immediately
4. verified host-scoped persisted session cleanup prevented it from returning after reload

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] 1,953 focused tests passed, 1 skipped:
  - renderer worktree removal, terminal teardown, RPC error classification, sleep, and hibernation: 387 passed
  - main-process persistence, worktree IPC, and runtime removal: 1,566 passed, 1 skipped
- [x] formatting checks
- [x] reliability gates
- [x] max-lines ratchet — no new bypasses
- [ ] `pnpm build` — not rerun after rebasing onto current `main`; typechecking and all relevant suites are green

Validation ran with Node `26.1.0`; the repository requests Node 24, so pnpm emitted the engine warning but all commands above completed successfully.

## AI Review Report

Reviewed the complete removal sequence across renderer routing, remote RPC envelopes, backend PTY teardown, Git/filesystem removal, metadata-only recovery, host-partitioned session persistence, runtime exact-ID cleanup, and renderer binding retirement.

Key safety findings:

- **No second destructive request after success:** `worktree.rm` owns physical PTY, Git, and filesystem teardown. Renderer cleanup only retires client bindings for `remove-worktree`.
- **Sleep and hibernation stay fail-closed:** manual sleep still calls the owner runtime, and exact hibernation still requires fresh liveness plus exact-stop verification.
- **No accidental filesystem deletion:** authoritative missing-selector/project fallback calls only `forgetLocal`; it does not run Git or remove an unknown path.
- **Host collisions remain isolated:** session cleanup is scoped to the workspace execution host, preserving identical repo/path IDs on sibling servers.
- **Partial server deletion remains distinct:** a filesystem orphan from #8613 still requires server-side cleanup; this PR does not claim an unknown path is safe to delete.
- **Local, direct SSH, nested HUB/SSH, folder workspace, macOS, Linux, and Windows paths:** no platform-specific path or command behavior was added. Existing backend removal remains the authority for each workspace kind.

## Security Audit

- Remote recovery is limited to exact structured `selector_not_found` and `repo_not_found` codes. Authorization, connectivity, timeout, and unrelated errors still fail closed.
- Error classification uses exact equality and rejects messages that merely mention a prior missing-selector diagnostic.
- `worktrees:forgetLocal` mutates app-owned metadata/session state only. It does not execute commands, resolve a deletion path, contact a provider, or change authentication state.
- No credentials, dependencies, network endpoints, permissions, or IPC channels were added.

## Notes

The fix intentionally does not forget a workspace when its runtime is merely unavailable. Only an authoritative missing-project/missing-selector response or an explicit metadata-only action can take that path.

## ELI5

Remote deletion could finish successfully and then Orca asked the server to stop the same workspace a second time. The server correctly answered “that workspace is gone,” but the client treated that as if deletion had failed. Orca now lets the backend own deletion once, cleans up the client copy afterward, and safely forgets old ghost rows that were already gone.
