### PR TITLE
fix(terminal): wait for shell readiness on Codex account restart

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -126,6 +126,7 @@ import {
 } from '@/runtime/web-runtime-session'
 import { isPrimarySelectionEnabled, readPrimarySelectionText } from '@/lib/primary-selection'
 import { APP_MENU_PASTE_EVENT } from '@/lib/app-menu-paste'
+import { CODEX_ACCOUNT_RESTART_STARTUP } from '@/lib/codex-session-restart'
 import { WORKSPACE_FILE_PATH_MIME, WORKSPACE_FILE_PATHS_MIME } from '@/lib/workspace-file-drag'
 import { isTerminalSessionStateSaveFailure } from '../../../../shared/terminal-session-state-save-failure'
 import { isTerminalZeroDimensionsDiagnostic } from '../../../../shared/terminal-zero-dimensions-diagnostic'
@@ -1616,7 +1617,7 @@ export default function TerminalPane({
         tabId,
         worktreeId,
         cwd,
-        startup: { command: 'codex' },
+        startup: CODEX_ACCOUNT_RESTART_STARTUP,
         paneTransportsRef,
         paneMode2031Ref,
         paneKittyKeyboardModesRef,

--- a/src/renderer/src/lib/codex-session-restart.test.ts
+++ b/src/renderer/src/lib/codex-session-restart.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAppStore } from '@/store'
-import { markLiveCodexSessionsForRestart } from './codex-session-restart'
+import { shouldUseShellReadyStartupDelivery } from '../../../shared/codex-startup-delivery'
+import {
+  CODEX_ACCOUNT_RESTART_STARTUP,
+  markLiveCodexSessionsForRestart
+} from './codex-session-restart'
 import {
   createCompatibleRuntimeStatusResponseIfNeeded,
   type RuntimeEnvironmentCallRequest
@@ -10,6 +14,16 @@ import { clearRuntimeCompatibilityCacheForTests } from '@/runtime/runtime-rpc-cl
 const ACCOUNT_A = 'account-a@example.com'
 const ACCOUNT_B = 'account-b@example.com'
 const ACCOUNT_C = 'account-c@example.com'
+
+describe('CODEX_ACCOUNT_RESTART_STARTUP', () => {
+  it('waits for shell readiness before relaunching Codex after an account switch', () => {
+    expect(CODEX_ACCOUNT_RESTART_STARTUP).toEqual({
+      command: 'codex',
+      startupCommandDelivery: 'shell-ready'
+    })
+    expect(shouldUseShellReadyStartupDelivery(CODEX_ACCOUNT_RESTART_STARTUP)).toBe(true)
+  })
+})
 
 describe('markLiveCodexSessionsForRestart', () => {
   const originalWindow = (globalThis as { window?: typeof window }).window

--- a/src/renderer/src/lib/codex-session-restart.ts
+++ b/src/renderer/src/lib/codex-session-restart.ts
@@ -2,6 +2,13 @@ import type { AppState } from '@/store'
 import { useAppStore } from '@/store'
 import { inspectRuntimeTerminalProcess } from '@/runtime/runtime-terminal-inspection'
 
+// Why: prompt integrations such as Starship can outlast the daemon's 300ms
+// Codex fast-path timeout; account restarts must wait until the shell accepts input.
+export const CODEX_ACCOUNT_RESTART_STARTUP = {
+  command: 'codex',
+  startupCommandDelivery: 'shell-ready'
+} as const
+
 function normalizeProcessName(processName: string | null): string | null {
   if (!processName) {
     return null


### PR DESCRIPTION
## Summary

Fixes a race where switching Codex accounts could drop, mangle, or leave unsubmitted the `codex` command in the restarted terminal pane.

## ELI5

When you switch Codex accounts, Orca reopens the terminal and types `codex` for you. Sometimes it typed too early — before the shell was ready — so the command got garbled. Now it waits until the shell is actually listening.

## Root cause & fix

The account-switch restart relaunched panes with `startup: { command: 'codex' }`, which used the default "fast" delivery (a 300 ms daemon fast-path). Slow prompt integrations like Starship can still be rendering the first prompt past that boundary, so the command could be delivered before the shell accepts input. The fix introduces a shared constant `CODEX_ACCOUNT_RESTART_STARTUP = { command: 'codex', startupCommandDelivery: 'shell-ready' }` and uses it at the relaunch site — matching the fresh-launch behavior already defined for codex in `shared/tui-agent-startup.ts`. Ordinary blank Codex launches keep the low-latency fast path.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- Test: `codex-session-restart.test.ts` via `npx vitest run --config config/vitest.config.ts src/renderer/src/lib/codex-session-restart.test.ts`
- On branch: **Test Files 1 passed (1) | Tests 10 passed (10)**
- Fix files reverted to main (test kept): **1 failed | 9 passed** — proving the test locks the fix:

```
AssertionError: expected undefined to deeply equal
  { command: 'codex', startupCommandDelivery: 'shell-ready' }
  (CODEX_ACCOUNT_RESTART_STARTUP is undefined without the fix)
```

- Fix restored → back to green.
- `startupCommandDelivery` is a recognized startup field, read in `pty-connection.ts` and honored by `shouldUseShellReadyStartupDelivery` in `shared/codex-startup-delivery.ts`.
- Lint: `npx oxlint TerminalPane.tsx codex-session-restart.ts` → exit 0, no warnings/errors.
- Rebase: clean onto merge-base `7ab601487c`; branch diff against it is exactly the 3 PR files, no conflicts.

## Trade-offs

The account-switch restart may wait for the remaining shell initialization time before starting Codex. This is intentional — the new process must reliably inherit the selected `CODEX_HOME` — and transport-specific bounded fallbacks (local, daemon, SSH, remote) still apply, so there is no unbounded wait.

## Regression risk

Near-zero. Only the account-switch restart branch changes delivery mode; ordinary blank Codex launches and all non-affected paths are byte-identical. The regression test proves the corrected descriptor and fails when the fix is reverted.

_Credit to @kazu-42 for the original fix. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved._
