### PR TITLE
fix(status-bar): show compact usage meter for weekly-only Grok

### DIFF
--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -86,6 +86,7 @@ import {
   type UsagePercentageDisplay
 } from '../../../../shared/usage-percentage-display'
 import { formatUsagePercentageLabel } from './usage-percentage-label'
+import { getPrimaryUsageMeterWindow } from './status-bar-primary-meter-window'
 
 type StatusBarProps = {
   floatingTerminalOpen: boolean
@@ -1234,11 +1235,16 @@ export function ProviderSegment({
       : null
   ].filter((w): w is { key: string; window: RateLimitWindow; label: string } => w !== null)
 
+  // Why: MiniBar used to require session only, so weekly-only providers (Grok)
+  // showed percent text without the compact meter even though the details panel
+  // already draws bars for weekly credits.
+  const primaryMeter = getPrimaryUsageMeterWindow(p)
+
   return (
     <span className="inline-flex items-center gap-1.5">
       <ProviderIcon provider={provider} />
-      {p.session && !compact && (
-        <MiniBar usedPct={clampUsedPercent(p.session.usedPercent)} display={display} />
+      {primaryMeter && !compact && (
+        <MiniBar usedPct={clampUsedPercent(primaryMeter.usedPercent)} display={display} />
       )}
       {visibleWindows.map((window, index) => (
         <React.Fragment key={window.key}>

--- a/src/renderer/src/components/status-bar/provider-segment-monthly-window.test.tsx
+++ b/src/renderer/src/components/status-bar/provider-segment-monthly-window.test.tsx
@@ -43,6 +43,19 @@ function grokMonthlyLimits(status: ProviderRateLimits['status']): ProviderRateLi
   }
 }
 
+// Typical Grok credit plan: weekly only (no session window).
+function grokWeeklyLimits(): ProviderRateLimits {
+  return {
+    provider: 'grok',
+    session: null,
+    weekly: windowOf(27, 10_080),
+    monthly: null,
+    updatedAt: Date.now(),
+    error: null,
+    status: 'ok'
+  }
+}
+
 describe('ProviderSegment monthly window', () => {
   it('renders a monthly-only snapshot in the chip instead of a bare icon', async () => {
     const { ProviderSegment } = await import('./StatusBar')
@@ -52,6 +65,30 @@ describe('ProviderSegment monthly window', () => {
     )
 
     expect(markup).toContain('25% used 30d')
+    // Why: monthly-only Grok still needs the compact meter next to the icon.
+    expect(markup).toContain('width:25%')
+  })
+
+  it('renders the compact meter for weekly-only Grok (no session window)', async () => {
+    const { ProviderSegment } = await import('./StatusBar')
+
+    const markup = renderToStaticMarkup(
+      <ProviderSegment p={grokWeeklyLimits()} compact={false} display="used" />
+    )
+
+    expect(markup).toContain('27% used')
+    expect(markup).toContain('width:27%')
+  })
+
+  it('hides the compact meter in compact layout even when weekly data exists', async () => {
+    const { ProviderSegment } = await import('./StatusBar')
+
+    const markup = renderToStaticMarkup(
+      <ProviderSegment p={grokWeeklyLimits()} compact={true} display="used" />
+    )
+
+    expect(markup).toContain('27% used')
+    expect(markup).not.toContain('width:27%')
   })
 
   it('shows monthly data while fetching instead of the loading placeholder', async () => {

--- a/src/renderer/src/components/status-bar/status-bar-primary-meter-window.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-primary-meter-window.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import type { ProviderRateLimits, RateLimitWindow } from '../../../../shared/rate-limit-types'
+import { getPrimaryUsageMeterWindow } from './status-bar-primary-meter-window'
+
+function window(usedPercent: number): RateLimitWindow {
+  return {
+    usedPercent,
+    windowMinutes: 10_080,
+    resetsAt: null,
+    resetDescription: null
+  }
+}
+
+function limits(
+  overrides: Partial<
+    Pick<ProviderRateLimits, 'session' | 'weekly' | 'fableWeekly' | 'monthly'>
+  > = {}
+): Pick<ProviderRateLimits, 'session' | 'weekly' | 'fableWeekly' | 'monthly'> {
+  return {
+    session: null,
+    weekly: null,
+    fableWeekly: null,
+    monthly: null,
+    ...overrides
+  }
+}
+
+describe('getPrimaryUsageMeterWindow', () => {
+  it('prefers the session window when present', () => {
+    const session = window(10)
+    expect(
+      getPrimaryUsageMeterWindow(
+        limits({
+          session,
+          weekly: window(40),
+          fableWeekly: window(50),
+          monthly: window(60)
+        })
+      )
+    ).toBe(session)
+  })
+
+  it('falls back to weekly for Grok-style providers with no session window', () => {
+    const weekly = window(27)
+    expect(getPrimaryUsageMeterWindow(limits({ weekly }))).toBe(weekly)
+  })
+
+  it('falls back through fable weekly then monthly', () => {
+    const fableWeekly = window(33)
+    expect(getPrimaryUsageMeterWindow(limits({ fableWeekly, monthly: window(70) }))).toBe(
+      fableWeekly
+    )
+    const monthly = window(70)
+    expect(getPrimaryUsageMeterWindow(limits({ monthly }))).toBe(monthly)
+  })
+
+  it('returns null when no usage windows are available', () => {
+    expect(getPrimaryUsageMeterWindow(limits())).toBeNull()
+  })
+})

--- a/src/renderer/src/components/status-bar/status-bar-primary-meter-window.ts
+++ b/src/renderer/src/components/status-bar/status-bar-primary-meter-window.ts
@@ -1,0 +1,14 @@
+import type { ProviderRateLimits, RateLimitWindow } from '../../../../shared/rate-limit-types'
+
+/**
+ * Window used for the single compact meter next to a provider icon.
+ *
+ * Why: Claude/Codex report a session window first; Grok and similar providers
+ * only report weekly (or monthly) credits. The status bar still needs one
+ * meter whenever any window is available — matching the details modal bars.
+ */
+export function getPrimaryUsageMeterWindow(
+  p: Pick<ProviderRateLimits, 'session' | 'weekly' | 'fableWeekly' | 'monthly'>
+): RateLimitWindow | null {
+  return p.session ?? p.weekly ?? p.fableWeekly ?? p.monthly ?? null
+}


### PR DESCRIPTION
## Summary

Fixes #9366.

Grok status-bar chips showed percent text (e.g. `73% left 5d 20h`) but omitted the compact grey progress meter that Claude/Codex show next to the icon. The Grok details popover already drew a Weekly bar — only the chip was missing it.

**Cause:** `ProviderSegment` gated `MiniBar` on `p.session` only. Grok’s fetcher always sets `session: null` and fills `weekly` (or sometimes `monthly`).

**Fix:** Select a primary meter window with session → weekly → fable weekly → monthly fallback, and use that for the chip meter. Unit tests cover weekly-only and monthly-only Grok chip rendering.

## User-visible change

- Grok (and other weekly/monthly-only usage plans) now show the same compact usage meter in the status bar as session-based providers.
- Details/tooltip panels unchanged.

## Screenshot

<img width="1108" height="356" alt="CleanShot 2026-07-18 at 8 38 18@2x" src="https://github.com/user-attachments/assets/b9854b2c-71da-4114-9a99-73bbfaeb216f" />

Grok chip now includes the compact grey progress meter next to the icon (alongside Claude/Codex).

## Test plan

- [x] `pnpm exec vitest run --config config/vitest.config.ts` for:
  - `status-bar-primary-meter-window.test.ts`
  - `provider-segment-monthly-window.test.tsx`
  - `inline-usage-bars.test.tsx`
- [x] Manual: with Grok weekly credits configured, confirm the status-bar Grok chip shows the grey mini bar + percent label, matching other providers.
- [ ] Manual: open Grok details — Weekly bar still correct.
- [ ] Manual: Claude/Codex still use session for the mini bar when both session and weekly exist.

## AI-agent review summary

- **Cross-platform:** Pure React status-bar rendering; no platform-specific APIs.
- **SSH/remote:** Usage chips are desktop status-bar UI; no remote host path changes.
- **Agent/integration:** Grok rate-limit fetch path unchanged; only chip meter selection.
- **Performance:** O(1) window fallback per provider chip.
- **UI quality:** Aligns chip meter with existing details-panel bars and Claude/Codex chip pattern.
- **Security:** No credentials or network changes.

## ELI5

Grok's status-bar chip showed a percent left but not the small progress bar Claude and Codex show. The chip now picks a weekly or monthly window for that meter so Grok matches the other providers.
