### PR TITLE
fix: preserve completed agent conversations across restarts

### DIFF
--- a/.github/workflows/windows-terminal-restart-e2e.yml
+++ b/.github/workflows/windows-terminal-restart-e2e.yml
@@ -19,6 +19,8 @@ on:
       - 'tests/e2e/global-setup.ts'
       - 'tests/e2e/global-teardown.ts'
       - 'tests/e2e/helpers/**'
+      - 'tests/e2e/agent-session-completed-force-exit-resume.spec.ts'
+      - 'tests/e2e/agent-session-live-force-exit-resume.spec.ts'
       - 'tests/e2e/restart-restore-terminal-input.spec.ts'
       - 'tests/e2e/restored-terminal-input-readiness.unit.test.ts'
       - 'tests/e2e/terminal-probe-input-sequence.ts'
@@ -30,8 +32,15 @@ on:
       - 'src/main/pty/**'
       - 'src/preload/**'
       - 'src/renderer/src/components/terminal-pane/**'
+      - 'src/renderer/src/lib/agent-hibernation-planner.ts'
+      - 'src/renderer/src/lib/completed-agent-recovery.ts'
+      - 'src/renderer/src/lib/resume-sleeping-agent-session.ts'
+      - 'src/renderer/src/lib/sleeping-agent-pane-ownership.ts'
       - 'src/renderer/src/lib/pane-manager/**'
+      - 'src/renderer/src/store/slices/agent-status.ts'
+      - 'src/shared/agent-session-resume.ts'
       - 'src/shared/pty-session-id-format.ts'
+      - 'src/shared/workspace-session-sleeping-agents.ts'
   workflow_dispatch:
     inputs:
       ref:
@@ -88,9 +97,11 @@ jobs:
         # grep and worker flags positional filters instead of CLI options.
         run: >-
           pnpm run test:e2e
+          tests/e2e/agent-session-completed-force-exit-resume.spec.ts
+          tests/e2e/agent-session-live-force-exit-resume.spec.ts
           tests/e2e/restart-restore-terminal-input.spec.ts
           tests/e2e/terminal-restart-persistence.spec.ts
-          --grep "clean restart with a live daemon session|cold-restored pane accepts typing|daemon snapshot relaunch preserves"
+          --grep "completed conversation resumes in its original pane|resumes a live agent record|clean restart with a live daemon session|cold-restored pane accepts typing|daemon snapshot relaunch preserves"
           --workers=1
 
       - name: Upload Playwright traces

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -7412,7 +7412,7 @@ describe('connectPanePty', () => {
     }
   })
 
-  it('resumes the provider agent session when daemon reattach cold-restores a fresh shell', async () => {
+  it('resumes a completed provider conversation when daemon reattach cold-restores a shell', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('fresh-pty')
     transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
@@ -7435,16 +7435,19 @@ describe('connectPanePty', () => {
         ...mockStoreState.settings,
         agentCmdOverrides: {}
       },
-      agentStatusByPaneKey: {
+      agentStatusByPaneKey: {},
+      sleepingAgentSessionsByPaneKey: {
         [paneKey]: {
-          state: 'working',
-          prompt: 'finish the task',
-          agentType: 'codex',
           paneKey,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          agent: 'codex',
+          providerSession: { key: 'session_id', id: 'codex-session-1' },
+          prompt: 'finish the task',
+          state: 'done',
+          capturedAt: 2,
           updatedAt: 1,
-          stateStartedAt: 1,
-          stateHistory: [],
-          providerSession: { key: 'session_id', id: 'codex-session-1' }
+          origin: 'completed'
         }
       }
     } as StoreState
@@ -7479,6 +7482,9 @@ describe('connectPanePty', () => {
         })
       })
     )
+    expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledWith(paneKey)
+    expect(mockStoreState.sleepingAgentSessionsByPaneKey[paneKey]).toBeUndefined()
+    expect(mockStoreState.tabsByWorktree['wt-1']).toHaveLength(1)
   })
 
   it('uses WSL quoting for cold-restored agent resume in Windows-path WSL projects', async () => {

--- a/src/renderer/src/lib/agent-hibernation-planner.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.test.ts
@@ -400,6 +400,30 @@ describe('agent sleep planner', () => {
     ).toEqual([piEntry.paneKey])
   })
 
+  it('still hibernates panes that only retain passive completed recovery identity', () => {
+    const completedEntry = entry()
+    expect(
+      plannedPaneKeys(
+        snapshot({
+          sleepingAgentSessionsByPaneKey: {
+            [completedEntry.paneKey]: {
+              paneKey: completedEntry.paneKey,
+              tabId: 'tab-1',
+              worktreeId: 'wt-bg',
+              agent: 'claude',
+              providerSession: completedEntry.providerSession!,
+              prompt: completedEntry.prompt,
+              state: 'done',
+              capturedAt: OLD,
+              updatedAt: OLD,
+              origin: 'completed'
+            }
+          }
+        })
+      )
+    ).toEqual([completedEntry.paneKey])
+  })
+
   it('rejects mobile-driven panes because paired clients can send input outside desktop xterm', () => {
     expect(plannedWorktrees(snapshot({ mobileLockedPtyIds: ['pty-1'] }))).toEqual([])
   })

--- a/src/renderer/src/lib/agent-hibernation-planner.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.ts
@@ -1,12 +1,12 @@
 import type { AgentStatusEntry } from '../../../shared/agent-status-types'
 import {
-  agentProviderSessionsEqual,
   getAgentResumeArgv,
   isResumableTuiAgent,
   type SleepingAgentSessionRecord
 } from '../../../shared/agent-session-resume'
 import { parsePaneKey } from '../../../shared/stable-pane-id'
 import { lastInputBlocksHibernation } from './agent-hibernation-input-guard'
+import { isCompletedAgentRecoveryIdentity } from './completed-agent-recovery'
 import type { GlobalSettings, TerminalLayoutSnapshot, TerminalTab } from '../../../shared/types'
 import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
 
@@ -133,20 +133,15 @@ function getEligiblePane(args: {
     mobileLockedPtyIds
   } = args
   const sleepingRecord = sleepingAgentSessionsByPaneKey[entry.paneKey]
-  // Why: Pi's done hook ends a turn, not its TUI. Its live recovery checkpoint
-  // must not make the still-running pane look already hibernated.
-  const hasOnlyLivePiRecoveryIdentity = Boolean(
-    entry.agentType === 'pi' &&
-    entry.providerSession &&
-    sleepingRecord?.agent === 'pi' &&
-    sleepingRecord.origin === 'live' &&
-    sleepingRecord.worktreeId === tab.worktreeId &&
-    agentProviderSessionsEqual('pi', entry.providerSession, sleepingRecord.providerSession)
-  )
+  // Why: recovery identity exists before hibernation and must not make the
+  // still-running pane look already asleep.
+  const hasOnlyCompletedRecoveryIdentity =
+    sleepingRecord?.worktreeId === tab.worktreeId &&
+    isCompletedAgentRecoveryIdentity(entry, sleepingRecord)
   if (
     entry.state !== 'done' ||
     entry.interrupted === true ||
-    (sleepingRecord && !hasOnlyLivePiRecoveryIdentity)
+    (sleepingRecord && !hasOnlyCompletedRecoveryIdentity)
   ) {
     return null
   }

--- a/src/renderer/src/lib/completed-agent-recovery.ts
+++ b/src/renderer/src/lib/completed-agent-recovery.ts
@@ -1,0 +1,38 @@
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+import {
+  agentProviderSessionsEqual,
+  getAgentResumeArgv,
+  isResumableTuiAgent,
+  type SleepingAgentSessionRecord
+} from '../../../shared/agent-session-resume'
+
+export function isCompletedRecoveryRecord(
+  record: SleepingAgentSessionRecord | undefined
+): record is SleepingAgentSessionRecord {
+  return Boolean(
+    record &&
+    ((record.origin === 'completed' && record.state === 'done') ||
+      (record.agent === 'pi' && record.origin === 'live'))
+  )
+}
+
+export function isCompletedAgentRecoveryIdentity(
+  entry: AgentStatusEntry | undefined,
+  record: SleepingAgentSessionRecord | undefined
+): record is SleepingAgentSessionRecord {
+  if (
+    entry?.state !== 'done' ||
+    entry.interrupted === true ||
+    !isResumableTuiAgent(entry.agentType) ||
+    !entry.providerSession ||
+    record?.agent !== entry.agentType ||
+    (entry.worktreeId !== undefined && entry.worktreeId !== record.worktreeId) ||
+    !agentProviderSessionsEqual(entry.agentType, entry.providerSession, record.providerSession) ||
+    !getAgentResumeArgv(record.agent, record.providerSession)
+  ) {
+    return false
+  }
+  // Why: Pi's done event ends a turn without ending its TUI, so its equivalent
+  // recovery identity intentionally remains live instead of completed.
+  return isCompletedRecoveryRecord(record)
+}

--- a/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
@@ -420,9 +420,9 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
     expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
   })
 
-  it('skips hibernated stable panes after their live PTY binding is cleared', () => {
+  it('keeps passive completed recovery owned after its live PTY binding is cleared', () => {
     const paneKey = makePaneKey('tab-1', LEAF_ID)
-    const record = makeRecord({ paneKey, origin: 'worktree-sleep', state: 'done' })
+    const record = makeRecord({ paneKey, origin: 'completed', state: 'done' })
     useAppStore.setState({
       tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-1', 'wt-1')] },
       terminalLayoutsByTabId: {

--- a/src/renderer/src/store/slices/agent-status-completed-session-recovery.test.ts
+++ b/src/renderer/src/store/slices/agent-status-completed-session-recovery.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import type { AppState } from '../types'
+import { createTestStore, makeTab } from './store-test-helpers'
+
+const PANE_KEY = 'tab-1:leaf-1'
+const PROVIDER_SESSION = { key: 'session_id' as const, id: 'codex-session-1' }
+
+function seedCompletedCodex(store: ReturnType<typeof createTestStore>): void {
+  store.setState({
+    tabsByWorktree: { 'wt-1': [makeTab({ id: 'tab-1', worktreeId: 'wt-1' })] }
+  } as Partial<AppState>)
+  store
+    .getState()
+    .setAgentStatus(
+      PANE_KEY,
+      { state: 'done', prompt: 'finish the task', agentType: 'codex' },
+      'Codex',
+      { updatedAt: 20, stateStartedAt: 10 },
+      { tabId: 'tab-1', worktreeId: 'wt-1' },
+      { providerSession: PROVIDER_SESSION }
+    )
+}
+
+describe('completed agent conversation recovery', () => {
+  it('keeps a completed turn as passive recovery identity across quit capture', () => {
+    const store = createTestStore()
+    seedCompletedCodex(store)
+
+    expect(store.getState().sleepingAgentSessionsByPaneKey[PANE_KEY]).toMatchObject({
+      agent: 'codex',
+      providerSession: PROVIDER_SESSION,
+      state: 'done',
+      origin: 'completed'
+    })
+
+    store.getState().captureAllSleepingAgentSessions('quit')
+
+    expect(store.getState().sleepingAgentSessionsByPaneKey[PANE_KEY]).toMatchObject({
+      agent: 'codex',
+      providerSession: PROVIDER_SESSION,
+      state: 'done',
+      origin: 'completed'
+    })
+  })
+
+  it('replaces an active checkpoint with passive recovery when the turn completes', () => {
+    const store = createTestStore()
+    store.setState({
+      tabsByWorktree: { 'wt-1': [makeTab({ id: 'tab-1', worktreeId: 'wt-1' })] }
+    } as Partial<AppState>)
+
+    store
+      .getState()
+      .setAgentStatus(
+        PANE_KEY,
+        { state: 'working', prompt: 'finish the task', agentType: 'codex' },
+        'Codex',
+        { updatedAt: 10, stateStartedAt: 10 },
+        { tabId: 'tab-1', worktreeId: 'wt-1' },
+        { providerSession: PROVIDER_SESSION }
+      )
+    expect(store.getState().sleepingAgentSessionsByPaneKey[PANE_KEY]?.origin).toBe('live')
+
+    seedCompletedCodex(store)
+
+    expect(store.getState().sleepingAgentSessionsByPaneKey[PANE_KEY]).toMatchObject({
+      providerSession: PROVIDER_SESSION,
+      state: 'done',
+      origin: 'completed'
+    })
+  })
+
+  it('clears recovery identity after confirmed agent exit', () => {
+    const store = createTestStore()
+    seedCompletedCodex(store)
+
+    store.getState().dropAgentStatus(PANE_KEY)
+
+    expect(store.getState().sleepingAgentSessionsByPaneKey[PANE_KEY]).toBeUndefined()
+  })
+
+  it('does not retain an interrupted completed turn', () => {
+    const store = createTestStore()
+    seedCompletedCodex(store)
+
+    store.getState().setAgentStatus(
+      PANE_KEY,
+      {
+        state: 'done',
+        prompt: 'finish the task',
+        agentType: 'codex',
+        interrupted: true
+      },
+      'Codex',
+      { updatedAt: 30, stateStartedAt: 10 },
+      { tabId: 'tab-1', worktreeId: 'wt-1' },
+      { providerSession: PROVIDER_SESSION }
+    )
+
+    expect(store.getState().sleepingAgentSessionsByPaneKey[PANE_KEY]).toBeUndefined()
+  })
+})

--- a/src/renderer/src/store/slices/agent-status-drop.test.ts
+++ b/src/renderer/src/store/slices/agent-status-drop.test.ts
@@ -142,15 +142,23 @@ describe('dropAgentStatus + retention suppressor', () => {
     })
     store
       .getState()
-      .setAgentStatus('tab-closed:0', { state: 'done', prompt: 'closed', agentType: 'pi' })
+      .setAgentStatus(
+        'tab-closed:0',
+        { state: 'done', prompt: 'closed', agentType: 'codex' },
+        undefined,
+        undefined,
+        { tabId: 'tab-closed', worktreeId: 'wt-1' },
+        { providerSession: { key: 'session_id', id: 'closed-session' } }
+      )
     store
       .getState()
       .setAgentStatus(
         'tab-orphan:0',
-        { state: 'done', prompt: 'orphan', agentType: 'pi' },
+        { state: 'done', prompt: 'orphan', agentType: 'codex' },
         undefined,
         undefined,
-        { worktreeId: 'wt-1' }
+        { worktreeId: 'wt-1' },
+        { providerSession: { key: 'session_id', id: 'orphan-session' } }
       )
     store
       .getState()
@@ -180,12 +188,17 @@ describe('dropAgentStatus + retention suppressor', () => {
         { worktreeId: 'wt-2' }
       )
 
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-closed:0']).toBeDefined()
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-orphan:0']).toBeDefined()
+
     store.getState().closeTab('tab-closed')
 
     const s = store.getState()
     expect(s.tabsByWorktree['wt-1']?.some((tab) => tab.id === 'tab-closed')).toBe(false)
     expect(s.agentStatusByPaneKey['tab-closed:0']).toBeUndefined()
     expect(s.agentStatusByPaneKey['tab-orphan:0']).toBeUndefined()
+    expect(s.sleepingAgentSessionsByPaneKey['tab-closed:0']).toBeUndefined()
+    expect(s.sleepingAgentSessionsByPaneKey['tab-orphan:0']).toBeUndefined()
     // No suppressor for the orphan: its tab is already gone, so retention sync
     // never re-surfaces it and a suppressor would leak permanently.
     expect(s.retentionSuppressedPaneKeys['tab-orphan:0']).toBeUndefined()

--- a/src/renderer/src/store/slices/agent-status-manual-sleep-capture.test.ts
+++ b/src/renderer/src/store/slices/agent-status-manual-sleep-capture.test.ts
@@ -123,6 +123,34 @@ describe('manual sleep agent session capture', () => {
     })
   })
 
+  it('promotes passive completed recovery into a manual sleep record', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    const store = createTestStore()
+    seedTabs(store)
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:leaf-1',
+        { state: 'done', prompt: 'finished', agentType: 'codex' },
+        'Codex',
+        { updatedAt: NOW, stateStartedAt: NOW - 1_000 },
+        { tabId: 'tab-1', worktreeId: 'wt-1' },
+        { providerSession: { key: 'session_id', id: 'completed-session' } }
+      )
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']?.origin).toBe(
+      'completed'
+    )
+
+    store.getState().captureSleepingAgentSessionsByWorktree('wt-1')
+
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']).toMatchObject({
+      origin: 'worktree-sleep',
+      state: 'done',
+      providerSession: { key: 'session_id', id: 'completed-session' }
+    })
+  })
+
   it('clears pre-existing records for rows skipped by manual capture', () => {
     vi.useFakeTimers()
     vi.setSystemTime(NOW)

--- a/src/renderer/src/store/slices/agent-status-quit-capture.test.ts
+++ b/src/renderer/src/store/slices/agent-status-quit-capture.test.ts
@@ -686,7 +686,7 @@ describe('captureAllSleepingAgentSessions', () => {
     expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']).toBe(firstRecord)
   })
 
-  it('clears the live checkpoint when the agent finishes', () => {
+  it('keeps the conversation checkpoint when the current turn finishes', () => {
     const store = createTestStore()
     store.setState({
       tabsByWorktree: {
@@ -719,7 +719,7 @@ describe('captureAllSleepingAgentSessions', () => {
       { providerSession: { key: 'session_id', id: 'codex-session-1' } }
     )
 
-    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']).toBeUndefined()
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']).toBeDefined()
     expect(store.getState().agentLaunchConfigByPaneKey['tab-1:leaf-1']).toBeUndefined()
   })
 
@@ -817,7 +817,7 @@ describe('captureAllSleepingAgentSessions', () => {
     })
   })
 
-  it('skips done agents — there is no turn left to resume', () => {
+  it('captures an idle conversation after its current turn is done', () => {
     const store = createTestStore()
     const entry = makeAgentEntry({
       paneKey: 'tab-1:leaf-1',
@@ -834,7 +834,7 @@ describe('captureAllSleepingAgentSessions', () => {
 
     store.getState().captureAllSleepingAgentSessions('quit')
 
-    expect(store.getState().sleepingAgentSessionsByPaneKey).toEqual({})
+    expect(Object.keys(store.getState().sleepingAgentSessionsByPaneKey)).toEqual(['tab-1:leaf-1'])
   })
 
   it('skips agents without a resumable provider session', () => {

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -35,6 +35,10 @@ import {
   orchestrationLabelsMatchLiveDispatch
 } from '@/lib/agent-row-primary-text'
 import {
+  isCompletedAgentRecoveryIdentity,
+  isCompletedRecoveryRecord
+} from '@/lib/completed-agent-recovery'
+import {
   resolveAgentPaneAuthorityKey,
   retireAgentPaneAuthorityAliases,
   retireAgentPaneAuthorityAliasesByOwnerTab,
@@ -577,18 +581,19 @@ export function collectSleepingAgentSessionRecordsForWorktree(
       const liveEntry = state.agentStatusByPaneKey[existing.paneKey]
       if (
         existing.worktreeId !== worktreeId ||
-        existing.origin !== 'live' ||
-        (liveEntry !== undefined && !isCompletedPiWithLiveRecoveryRecord(liveEntry, existing)) ||
+        (liveEntry
+          ? !isCompletedAgentRecoveryIdentity(liveEntry, existing)
+          : !isCompletedRecoveryRecord(existing)) ||
         (allowedPaneKeys && !allowedPaneKeys.has(existing.paneKey)) ||
         !getAgentResumeArgv(existing.agent, existing.providerSession)
       ) {
         continue
       }
-      // Why: Pi identity is resumable with no turn row and while idle after done, so manual
-      // sleep must promote both instead of deleting the checkpoint.
+      // Why: done closes a turn while its TUI remains resumable, so manual sleep
+      // must promote the checkpoint instead of deleting the conversation.
       records[existing.paneKey] = {
         ...existing,
-        state: 'working',
+        state: existing.agent === 'pi' ? 'working' : 'done',
         capturedAt,
         updatedAt: capturedAt,
         origin: 'worktree-sleep'
@@ -1815,8 +1820,10 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           s.migrationUnsupportedByPtyId,
           (entry) => entry.paneKey === paneKey
         )
+        // Why: `done` closes a turn, not the interactive TUI. Preserve its
+        // provider identity until shell/teardown evidence explicitly drops it.
         const liveRecoveryWorktreeId =
-          entry.state === 'done' && !retainsPiRecoveryIdentity
+          entry.state === 'done' && entry.interrupted === true
             ? null
             : (entry.worktreeId ?? findAgentPaneWorktreeId(s, entry.paneKey))
         const liveRecoveryRecord = liveRecoveryWorktreeId
@@ -1829,7 +1836,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
               worktreeId: liveRecoveryWorktreeId,
               capturedAt: updatedAt,
               launchConfig: launchConfigSource,
-              origin: 'live'
+              origin: entry.state === 'done' && !retainsPiRecoveryIdentity ? 'completed' : 'live'
             })
           : null
         let nextSleepingAgentSessions = s.sleepingAgentSessionsByPaneKey
@@ -2118,6 +2125,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         const hasLive = paneKey in s.agentStatusByPaneKey
         liveExisted = hasLive
         const hasRetained = paneKey in s.retainedAgentsByPaneKey
+        const hasSleepingSession = paneKey in s.sleepingAgentSessionsByPaneKey
         const migrationUnsupported = pruneMigrationUnsupportedEntries(
           s.migrationUnsupportedByPtyId,
           (entry) => entry.paneKey === paneKey
@@ -2135,8 +2143,9 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         if (hasLaunchConfig) {
           delete nextLaunchConfigs[paneKey]
         }
-        // Why: short-circuit when there's nothing to change, but still flush a pending ack or launch-config cleanup if one is present.
-        if (!hasLive && !hasRetained && !migrationUnsupported.changed) {
+        // Why: short-circuit when there's nothing to change, but still flush pending
+        // ack, launch-config, or recovery cleanup.
+        if (!hasLive && !hasRetained && !hasSleepingSession && !migrationUnsupported.changed) {
           if (hasLaunchConfig) {
             return {
               agentLaunchConfigByPaneKey: nextLaunchConfigs,
@@ -2161,6 +2170,14 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         if (hasRetained) {
           delete nextRetained[paneKey]
         }
+        const nextSleepingSessions = hasSleepingSession
+          ? { ...s.sleepingAgentSessionsByPaneKey }
+          : s.sleepingAgentSessionsByPaneKey
+        if (hasSleepingSession) {
+          // Why: command-finished shell evidence and explicit dismissals mean
+          // the TUI exited, so a later restart must not relaunch it.
+          delete nextSleepingSessions[paneKey]
+        }
 
         // Why: explicit teardown must not let retention sync resurrect this row — plant a one-shot suppressor, but only when hasLive (a retained-only key has no live→gone transition to consume it, so it leaks) and not already present (re-spreading spuriously re-renders subscribers).
         const needsSuppressorWrite = hasLive && !(paneKey in s.retentionSuppressedPaneKeys)
@@ -2169,6 +2186,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           agentStatusByPaneKey: nextLive,
           agentLaunchConfigByPaneKey: nextLaunchConfigs,
           retainedAgentsByPaneKey: nextRetained,
+          sleepingAgentSessionsByPaneKey: nextSleepingSessions,
           migrationUnsupportedByPtyId: migrationUnsupported.next,
           ...(nextAck !== s.acknowledgedAgentsByPaneKey
             ? { acknowledgedAgentsByPaneKey: nextAck }
@@ -2219,6 +2237,9 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         const retainedKeys = Object.keys(s.retainedAgentsByPaneKey).filter(
           (k) => k.startsWith(prefix) || completedOrphanKeySet.has(k)
         )
+        const sleepingKeys = Object.keys(s.sleepingAgentSessionsByPaneKey).filter((k) =>
+          k.startsWith(prefix) || completedOrphanKeySet.has(k)
+        )
         const migrationUnsupported = pruneMigrationUnsupportedEntries(
           s.migrationUnsupportedByPtyId,
           (entry) => entry.paneKey?.startsWith(prefix) ?? false
@@ -2247,6 +2268,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           liveKeys.length === 0 &&
           launchConfigKeys.length === 0 &&
           retainedKeys.length === 0 &&
+          sleepingKeys.length === 0 &&
           !migrationUnsupported.changed
         ) {
           if (nextAck !== s.acknowledgedAgentsByPaneKey) {
@@ -2282,7 +2304,16 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           delete nextRetained[key]
         }
 
-        // Why: a suppressor is only consumed on a live→gone transition, so plant one only for live paneKeys and skip already-suppressed and completed-orphan keys — otherwise it leaks (mirrors dropAgentStatus).
+        const nextSleeping =
+          sleepingKeys.length > 0
+            ? { ...s.sleepingAgentSessionsByPaneKey }
+            : s.sleepingAgentSessionsByPaneKey
+        for (const key of sleepingKeys) {
+          delete nextSleeping[key]
+        }
+
+        // Why: a suppressor is only consumed on a live→gone transition, so skip
+        // retained-only, already-suppressed, and completed-orphan keys to avoid leaks.
         const suppressorAdds = liveKeys.filter(
           (k) => !completedOrphanKeySet.has(k) && !(k in s.retentionSuppressedPaneKeys)
         )
@@ -2298,6 +2329,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           agentStatusByPaneKey: nextLive,
           agentLaunchConfigByPaneKey: nextLaunchConfigs,
           retainedAgentsByPaneKey: nextRetained,
+          sleepingAgentSessionsByPaneKey: nextSleeping,
           migrationUnsupportedByPtyId: migrationUnsupported.next,
           retentionSuppressedPaneKeys: nextRetentionSuppressedPaneKeys,
           recentlyClosedAgentStatusTabIds: nextClosedTabs,
@@ -2606,11 +2638,16 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         }
         let changed = false
         for (const entry of Object.values(s.agentStatusByPaneKey)) {
-          if (entry.state === 'done') {
-            const existing = next[entry.paneKey]
-            if (!isCompletedPiWithLiveRecoveryRecord(entry, existing)) {
-              continue
-            }
+          const existing = next[entry.paneKey]
+          // Why: completed recovery is owned by the original pane, not by the
+          // shutdown snapshot; periodic and quit capture must not promote it.
+          if (
+            existing?.origin === 'completed' &&
+            isCompletedAgentRecoveryIdentity(entry, existing)
+          ) {
+            continue
+          }
+          if (entry.state === 'done' && isCompletedPiWithLiveRecoveryRecord(entry, existing)) {
             if (mode === 'periodic') {
               continue
             }
@@ -2619,6 +2656,9 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
               next[entry.paneKey] = record
               changed = true
             }
+            continue
+          }
+          if (entry.state === 'done' && entry.interrupted === true) {
             continue
           }
           const worktreeId = entry.worktreeId ?? findAgentPaneWorktreeId(s, entry.paneKey)
@@ -2633,8 +2673,8 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
             launchConfig: getLaunchConfigForEntry(s, entry),
             origin
           })
-          const existing = next[entry.paneKey]
-          // Why: a periodic timer must not downgrade a confirmed-quit shutdown snapshot; a live hook event supersedes it elsewhere.
+          // Why: a periodic timer must not downgrade a confirmed-quit shutdown
+          // snapshot; a live hook event supersedes it elsewhere.
           if (
             mode === 'periodic' &&
             existing?.origin === 'quit' &&

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -3117,6 +3117,8 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
         { tabId: 'tab-1', worktreeId: wt },
         { providerSession: { key: 'session_id', id: 'sess-rollback-1' } }
       )
+    const recoveryBefore = store.getState().sleepingAgentSessionsByPaneKey[targetPaneKey]
+    expect(recoveryBefore).toBeDefined()
     mockApi.pty.kill.mockRejectedValueOnce(new Error('kill_failed'))
 
     await expect(
@@ -3130,7 +3132,7 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
 
     const state = store.getState()
     expect(state.suppressedPtyExitIds['pty-agent']).toBeUndefined()
-    expect(state.sleepingAgentSessionsByPaneKey[targetPaneKey]).toBeUndefined()
+    expect(state.sleepingAgentSessionsByPaneKey[targetPaneKey]).toBe(recoveryBefore)
     expect(state.agentStatusByPaneKey[targetPaneKey]).toBeDefined()
   })
 
@@ -3257,6 +3259,8 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
         { tabId: 'tab-1', worktreeId: wt },
         { providerSession: { key: 'session_id', id: 'target-session' } }
       )
+    const recoveryBefore = store.getState().sleepingAgentSessionsByPaneKey[targetPaneKey]
+    expect(recoveryBefore).toBeDefined()
 
     await expect(
       store.getState().shutdownCompletedAgentPaneForHibernation(wt, {
@@ -3269,7 +3273,7 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
 
     const state = store.getState()
     expect(state.ptyIdsByTabId['tab-1']).toEqual(['pty-agent', 'pty-shell'])
-    expect(state.sleepingAgentSessionsByPaneKey[targetPaneKey]).toBeUndefined()
+    expect(state.sleepingAgentSessionsByPaneKey[targetPaneKey]).toBe(recoveryBefore)
     expect(state.agentStatusByPaneKey[targetPaneKey]).toBeDefined()
     expect(state.suppressedPtyExitIds['pty-agent']).toBeUndefined()
     expect(mockRestorePtyDataHandlersAfterFailedShutdown).toHaveBeenCalledWith(handlerSnapshots)
@@ -3550,6 +3554,8 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
         { tabId: 'tab-1', worktreeId: wt },
         { providerSession: { key: 'session_id', id: 'target-session' } }
       )
+    const recoveryBefore = store.getState().sleepingAgentSessionsByPaneKey[targetPaneKey]
+    expect(recoveryBefore).toBeDefined()
 
     await expect(
       store.getState().shutdownCompletedAgentPaneForHibernation(wt, {
@@ -3568,7 +3574,7 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
     ])
     expect(state.suppressedPtyExitIds['remote:env-1@@terminal-1']).toBeUndefined()
     expect(state.suppressedPtyExitIds['terminal-1']).toBeUndefined()
-    expect(state.sleepingAgentSessionsByPaneKey[targetPaneKey]).toBeUndefined()
+    expect(state.sleepingAgentSessionsByPaneKey[targetPaneKey]).toBe(recoveryBefore)
     expect(state.agentStatusByPaneKey[targetPaneKey]).toBeDefined()
   })
 
@@ -3806,6 +3812,8 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
       { tabId: 'tab-1', worktreeId: wt },
       { providerSession: { key: 'session_id', id: 'live-session' } }
     )
+    const recoveryBefore = store.getState().sleepingAgentSessionsByPaneKey['tab-1:live']
+    expect(recoveryBefore).toBeDefined()
 
     await expect(
       store.getState().shutdownWorktreeTerminals(wt, {
@@ -3815,7 +3823,7 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
       })
     ).rejects.toThrow('terminal_liveness_unavailable')
 
-    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:live']).toBeUndefined()
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:live']).toBe(recoveryBefore)
     expect(store.getState().agentStatusByPaneKey['tab-1:live']).toBeDefined()
     expect(store.getState().suppressedPtyExitIds['pty-1']).toBeUndefined()
     expect(mockApi.pty.kill).not.toHaveBeenCalled()
@@ -3860,6 +3868,8 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
       { tabId: 'tab-1', worktreeId: wt },
       { providerSession: { key: 'session_id', id: 'live-session' } }
     )
+    const recoveryBefore = store.getState().sleepingAgentSessionsByPaneKey['tab-1:live']
+    expect(recoveryBefore).toBeDefined()
 
     await expect(
       store.getState().shutdownWorktreeTerminals(wt, {
@@ -3869,7 +3879,7 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
       })
     ).rejects.toThrow('exact_terminal_stop_unverified')
 
-    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:live']).toBeUndefined()
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:live']).toBe(recoveryBefore)
     expect(store.getState().agentStatusByPaneKey['tab-1:live']).toBeDefined()
     expect(store.getState().suppressedPtyExitIds['pty-1']).toBeUndefined()
     expect(mockApi.pty.kill).not.toHaveBeenCalled()
@@ -4342,6 +4352,8 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
       { tabId: 'tab-1', worktreeId: wt },
       { providerSession: { key: 'session_id', id: 'live-session' } }
     )
+    const recoveryBefore = store.getState().sleepingAgentSessionsByPaneKey['tab-1:live']
+    expect(recoveryBefore).toBeDefined()
 
     await expect(
       store.getState().shutdownWorktreeTerminals(wt, {
@@ -4351,7 +4363,7 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
       })
     ).rejects.toThrow('stop failed')
 
-    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:live']).toBeUndefined()
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:live']).toBe(recoveryBefore)
     expect(store.getState().agentStatusByPaneKey['tab-1:live']).toBeDefined()
     expect(mockUnregisterPtyDataHandlers).not.toHaveBeenCalledWith(['pty-1'])
     expect(mockApi.pty.kill).not.toHaveBeenCalled()
@@ -4478,7 +4490,7 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
     })
   })
 
-  it('skips allowlisted done live sleeping pane sessions during manual sleep', async () => {
+  it('promotes allowlisted completed recovery during manual sleep', async () => {
     const store = createTestStore()
     const wt = 'repo1::/path/wt1'
 
@@ -4529,7 +4541,11 @@ describe('shutdownWorktreeTerminals (sleep) — agent status hygiene', () => {
     })
 
     const state = store.getState()
-    expect(state.sleepingAgentSessionsByPaneKey['tab-1:live']).toBeUndefined()
+    expect(state.sleepingAgentSessionsByPaneKey['tab-1:live']).toMatchObject({
+      origin: 'worktree-sleep',
+      state: 'done',
+      providerSession: { key: 'session_id', id: 'live-session' }
+    })
     expect(state.sleepingAgentSessionsByPaneKey['tab-1:retained']).toBeUndefined()
   })
 

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -53,11 +53,11 @@ export type SleepingAgentSessionRecord = {
   connectionId?: string | null
   launchConfig?: SleepingAgentLaunchConfig
   /** How the record was captured. Worktree-sleep records (legacy records have
-   *  no origin) are consumed by worktree activation, which opens a fresh tab.
-   *  Quit/live records describe panes that still exist in the restored session,
-   *  so only the pane's own cold-restore path may consume them — activation
-   *  launching a tab too would duplicate a warm-reattached session (#5232). */
-  origin?: 'worktree-sleep' | 'quit' | 'live'
+   *  no origin) are consumed by worktree activation. Quit/live records describe
+   *  active panes, while completed records preserve a finished conversation for
+   *  its original pane without authorizing activation to open another tab.
+   */
+  origin?: 'worktree-sleep' | 'quit' | 'live' | 'completed'
 }
 
 const RESUMABLE_TUI_AGENT_SET: ReadonlySet<string> = new Set(RESUMABLE_TUI_AGENTS)

--- a/src/shared/workspace-session-schema.sleeping-agent.test.ts
+++ b/src/shared/workspace-session-schema.sleeping-agent.test.ts
@@ -41,6 +41,35 @@ describe('parseWorkspaceSession sleeping agents', () => {
     }
   })
 
+  it('preserves passive completed recovery records', () => {
+    const result = parseWorkspaceSession({
+      activeRepoId: null,
+      activeWorktreeId: null,
+      activeTabId: null,
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {},
+      sleepingAgentSessionsByPaneKey: {
+        'tab1:pane-1': {
+          paneKey: 'tab1:pane-1',
+          tabId: 'tab1',
+          worktreeId: 'wt',
+          agent: 'codex',
+          providerSession: { key: 'session_id', id: 'codex-session' },
+          prompt: 'finished',
+          state: 'done',
+          capturedAt: 10,
+          updatedAt: 9,
+          origin: 'completed'
+        }
+      }
+    })
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.value.sleepingAgentSessionsByPaneKey?.['tab1:pane-1']?.origin).toBe('completed')
+    }
+  })
+
   it('preserves the authoritative Pi session file through hydration', () => {
     const result = parseWorkspaceSession({
       activeRepoId: null,

--- a/src/shared/workspace-session-sleeping-agents.ts
+++ b/src/shared/workspace-session-sleeping-agents.ts
@@ -88,7 +88,7 @@ const sleepingAgentSessionRecordSchema = z
     interrupted: z.boolean().optional(),
     connectionId: z.string().nullable().optional(),
     launchConfig: sleepingAgentLaunchConfigSchema.optional(),
-    origin: z.enum(['worktree-sleep', 'quit', 'live']).optional()
+    origin: z.enum(['worktree-sleep', 'quit', 'live', 'completed']).optional()
   })
   .refine(
     (record) => getAgentResumeArgv(record.agent, record.providerSession) !== null,

--- a/tests/e2e/agent-session-completed-force-exit-resume.spec.ts
+++ b/tests/e2e/agent-session-completed-force-exit-resume.spec.ts
@@ -1,0 +1,262 @@
+import { existsSync, readFileSync } from 'node:fs'
+import type { Page } from '@stablyai/playwright-test'
+import type { ElectronApplication } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { TEST_REPO_PATH_FILE } from './global-setup'
+import {
+  waitForActivePaneHookDescriptor,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager,
+  waitForPaneCount,
+  waitForTerminalOutput
+} from './helpers/terminal'
+import {
+  ensureTerminalVisible,
+  getActiveTabId,
+  waitForActiveWorktree,
+  waitForSessionReady
+} from './helpers/store'
+import { attachRepoAndOpenTerminal, createRestartSession } from './helpers/orca-restart'
+import {
+  forceKillElectronApp,
+  forceKillProcessTree,
+  readDaemonPid,
+  readPersistedData,
+  writePersistedData
+} from './helpers/force-exit-session'
+
+const PROVIDER_SESSION_ID = 'e2e-completed-force-exit-session'
+
+async function createTerminalTab(page: Page): Promise<string> {
+  const activeBefore = await getActiveTabId(page)
+  const tabId = await page.evaluate(() => {
+    const state = window.__store?.getState()
+    if (!state?.activeWorktreeId) {
+      throw new Error('Active worktree unavailable while creating the second terminal')
+    }
+    // Why: this restart proof targets pane ownership, so store creation avoids
+    // coupling it to tab-menu hit testing and viewport layout.
+    return state.createTab(state.activeWorktreeId).id
+  })
+  await expect
+    .poll(async () => (await getActiveTabId(page)) === tabId && tabId !== activeBefore, {
+      timeout: 10_000,
+      message: 'New terminal did not become active'
+    })
+    .toBe(true)
+  return tabId
+}
+
+function persistedCompletedRecordExists(
+  userDataDir: string,
+  paneKey: string,
+  tabId: string
+): boolean {
+  const record =
+    readPersistedData(userDataDir).workspaceSession?.sleepingAgentSessionsByPaneKey?.[paneKey]
+  return (
+    record?.paneKey === paneKey &&
+    record.tabId === tabId &&
+    record.state === 'done' &&
+    record.origin === 'completed' &&
+    record.providerSession?.id === PROVIDER_SESSION_ID
+  )
+}
+
+function makePersistedResumeHermetic(userDataDir: string, paneKey: string): void {
+  const data = readPersistedData(userDataDir)
+  const record = data.workspaceSession?.sleepingAgentSessionsByPaneKey?.[paneKey]
+  if (!record || record.providerSession?.id !== PROVIDER_SESSION_ID) {
+    throw new Error(`Completed recovery record ${paneKey} was not persisted`)
+  }
+  // Why: prove Orca builds and runs the resume command without requiring a
+  // developer or CI machine to have the real Codex binary installed.
+  record.launchConfig = { agentCommand: 'echo', agentArgs: '', agentEnv: {} }
+  writePersistedData(userDataDir, data)
+}
+
+async function activateTerminalTab(page: Page, tabId: string): Promise<void> {
+  await page.evaluate((targetTabId) => {
+    const state = window.__store?.getState()
+    if (!state) {
+      throw new Error('Store unavailable while activating completed conversation tab')
+    }
+    state.setActiveTabType('terminal')
+    state.setActiveTab(targetTabId)
+  }, tabId)
+  await expect.poll(() => getActiveTabId(page), { timeout: 10_000 }).toBe(tabId)
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test('completed conversation resumes in its original pane after force-exit restart', async (// oxlint-disable-next-line no-empty-pattern -- Playwright requires object destructuring to opt out of default fixtures.
+{}, testInfo) => {
+  const repoPath = readFileSync(TEST_REPO_PATH_FILE, 'utf-8').trim()
+  if (!repoPath || !existsSync(repoPath)) {
+    test.skip(true, 'Global setup did not produce a seeded test repo')
+    return
+  }
+
+  const session = createRestartSession(testInfo)
+  let firstApp: ElectronApplication | null = null
+  let secondApp: ElectronApplication | null = null
+
+  try {
+    const firstLaunch = await session.launch()
+    firstApp = firstLaunch.app
+    const page = firstLaunch.page
+    const worktreeId = await attachRepoAndOpenTerminal(page, repoPath)
+    await waitForSessionReady(page)
+    await expect
+      .poll(() => page.evaluate(() => window.__store?.getState().hydrationSucceeded === true), {
+        timeout: 30_000
+      })
+      .toBe(true)
+    await waitForActiveWorktree(page)
+    await ensureTerminalVisible(page)
+    await waitForActiveTerminalManager(page, 30_000)
+    await waitForPaneCount(page, 1, 30_000)
+
+    const original = await waitForActivePaneHookDescriptor(page)
+    const originalTabId = await getActiveTabId(page)
+    if (!originalTabId) {
+      throw new Error('Original completed-conversation tab id was unavailable')
+    }
+
+    await page.evaluate(
+      ({ paneKey, worktreeId: wtId, providerSessionId }) => {
+        const state = window.__store?.getState()
+        state?.setAgentStatus(
+          paneKey,
+          { state: 'working', prompt: 'finish the task', agentType: 'codex' },
+          'Codex',
+          undefined,
+          { tabId: paneKey.split(':')[0], worktreeId: wtId },
+          { providerSession: { key: 'session_id', id: providerSessionId } }
+        )
+        state?.setAgentStatus(
+          paneKey,
+          { state: 'done', prompt: 'finish the task', agentType: 'codex' },
+          'Codex',
+          undefined,
+          { tabId: paneKey.split(':')[0], worktreeId: wtId },
+          { providerSession: { key: 'session_id', id: providerSessionId } }
+        )
+      },
+      {
+        paneKey: original.paneKey,
+        worktreeId: original.worktreeId,
+        providerSessionId: PROVIDER_SESSION_ID
+      }
+    )
+
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            (paneKey) => window.__store?.getState().sleepingAgentSessionsByPaneKey[paneKey],
+            original.paneKey
+          ),
+        { timeout: 10_000 }
+      )
+      .toMatchObject({
+        paneKey: original.paneKey,
+        tabId: originalTabId,
+        state: 'done',
+        origin: 'completed',
+        providerSession: { id: PROVIDER_SESSION_ID }
+      })
+
+    await createTerminalTab(page)
+    await waitForActiveTerminalManager(page, 30_000)
+    await waitForActivePanePtyId(page, 30_000)
+
+    await expect
+      .poll(
+        () => persistedCompletedRecordExists(session.userDataDir, original.paneKey, originalTabId),
+        {
+          timeout: 30_000,
+          message: 'Completed recovery identity did not reach disk before force exit'
+        }
+      )
+      .toBe(true)
+
+    const daemonPid = readDaemonPid(session.userDataDir)
+    await forceKillElectronApp(firstApp)
+    firstApp = null
+    await forceKillProcessTree(daemonPid)
+    makePersistedResumeHermetic(session.userDataDir, original.paneKey)
+
+    const secondLaunch = await session.launch()
+    secondApp = secondLaunch.app
+    const restartedPage = secondLaunch.page
+    await waitForSessionReady(restartedPage)
+    await expect
+      .poll(() => restartedPage.evaluate(() => window.__store?.getState().activeWorktreeId), {
+        timeout: 15_000
+      })
+      .toBe(worktreeId)
+    await ensureTerminalVisible(restartedPage)
+    await waitForActiveTerminalManager(restartedPage, 30_000)
+
+    await expect
+      .poll(
+        () =>
+          restartedPage.evaluate(
+            ({ wtId, paneKey }) => {
+              const state = window.__store?.getState()
+              return {
+                tabCount: (state?.tabsByWorktree[wtId] ?? []).length,
+                recovery: state?.sleepingAgentSessionsByPaneKey[paneKey]
+              }
+            },
+            { wtId: worktreeId, paneKey: original.paneKey }
+          ),
+        { timeout: 15_000 }
+      )
+      .toMatchObject({
+        tabCount: 2,
+        recovery: { origin: 'completed', state: 'done' }
+      })
+
+    await activateTerminalTab(restartedPage, originalTabId)
+    await waitForActiveTerminalManager(restartedPage, 30_000)
+    await waitForTerminalOutput(restartedPage, PROVIDER_SESSION_ID, 30_000)
+
+    const resumed = await waitForActivePaneHookDescriptor(restartedPage)
+    expect(resumed.paneKey).toBe(original.paneKey)
+    // Why: the hermetic echo command emits no fresh agent hook, so the main
+    // hook cache restores the completed checkpoint after cold-restore consumes it.
+    await expect
+      .poll(
+        () =>
+          restartedPage.evaluate(
+            ({ wtId, paneKey }) => {
+              const state = window.__store?.getState()
+              return {
+                tabCount: (state?.tabsByWorktree[wtId] ?? []).length,
+                recovery: state?.sleepingAgentSessionsByPaneKey[paneKey]
+              }
+            },
+            { wtId: worktreeId, paneKey: original.paneKey }
+          ),
+        { timeout: 15_000 }
+      )
+      .toMatchObject({
+        tabCount: 2,
+        recovery: {
+          paneKey: original.paneKey,
+          origin: 'completed',
+          providerSession: { id: PROVIDER_SESSION_ID }
+        }
+      })
+  } finally {
+    if (secondApp) {
+      await session.close(secondApp)
+    }
+    if (firstApp) {
+      await forceKillElectronApp(firstApp)
+    }
+    await session.dispose()
+  }
+})

--- a/tests/e2e/agent-session-live-force-exit-resume.spec.ts
+++ b/tests/e2e/agent-session-live-force-exit-resume.spec.ts
@@ -1,7 +1,4 @@
-import { execFileSync } from 'node:child_process'
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
-import path from 'node:path'
-import type { ChildProcess } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
 import type { ElectronApplication } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
 import { TEST_REPO_PATH_FILE } from './global-setup'
@@ -15,104 +12,15 @@ import {
 } from './helpers/terminal'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 import { attachRepoAndOpenTerminal, createRestartSession } from './helpers/orca-restart'
-import { PROTOCOL_VERSION } from '../../src/main/daemon/types'
-import { DEFAULT_LOCAL_ORCA_PROFILE_ID } from '../../src/shared/orca-profiles'
+import {
+  forceKillElectronApp,
+  forceKillProcessTree,
+  readDaemonPid,
+  readPersistedData,
+  writePersistedData
+} from './helpers/force-exit-session'
 
 const PROVIDER_SESSION_ID = 'e2e-live-force-exit-session'
-
-type PersistedWorkspaceSession = {
-  tabsByWorktree?: Record<string, { id?: unknown; ptyId?: unknown }[]>
-  terminalLayoutsByTabId?: Record<string, unknown>
-  activeWorktreeIdsOnShutdown?: unknown
-  sleepingAgentSessionsByPaneKey?: Record<
-    string,
-    {
-      providerSession?: { id?: unknown }
-      launchConfig?: {
-        agentCommand?: string
-        agentArgs?: string
-        agentEnv?: Record<string, string>
-      }
-    }
-  >
-}
-
-type PersistedData = {
-  workspaceSession?: PersistedWorkspaceSession
-}
-
-function dataFilePath(userDataDir: string): string {
-  // Fresh sessions migrate the seeded legacy file, then persist only here.
-  return path.join(userDataDir, 'profiles', DEFAULT_LOCAL_ORCA_PROFILE_ID, 'orca-data.json')
-}
-
-function readPersistedData(userDataDir: string): PersistedData {
-  return JSON.parse(readFileSync(dataFilePath(userDataDir), 'utf8')) as PersistedData
-}
-
-function writePersistedData(userDataDir: string, data: PersistedData): void {
-  writeFileSync(dataFilePath(userDataDir), `${JSON.stringify(data, null, 2)}\n`, 'utf8')
-}
-
-function daemonPidPath(userDataDir: string): string {
-  return path.join(userDataDir, 'daemon', `daemon-v${PROTOCOL_VERSION}.pid`)
-}
-
-function readDaemonPid(userDataDir: string): number {
-  const raw = readFileSync(daemonPidPath(userDataDir), 'utf8')
-  const parsed = JSON.parse(raw) as { pid?: unknown }
-  if (typeof parsed.pid !== 'number') {
-    throw new Error(`Daemon pid file did not contain a numeric pid: ${raw}`)
-  }
-  return parsed.pid
-}
-
-function hasExited(proc: ChildProcess): boolean {
-  return proc.exitCode !== null || proc.signalCode !== null
-}
-
-function waitForExit(proc: ChildProcess, timeoutMs = 5000): Promise<void> {
-  if (hasExited(proc)) {
-    return Promise.resolve()
-  }
-  return new Promise((resolve) => {
-    const timeout = setTimeout(resolve, timeoutMs)
-    timeout.unref?.()
-    proc.once('exit', () => {
-      clearTimeout(timeout)
-      resolve()
-    })
-  })
-}
-
-async function forceKillElectronApp(app: ElectronApplication): Promise<void> {
-  const proc = app.process()
-  if (!proc.pid || hasExited(proc)) {
-    return
-  }
-  try {
-    if (process.platform === 'win32') {
-      execFileSync('taskkill', ['/pid', String(proc.pid), '/T', '/F'], { stdio: 'ignore' })
-    } else {
-      process.kill(proc.pid, 'SIGKILL')
-    }
-  } catch {
-    // Already gone.
-  }
-  await waitForExit(proc)
-}
-
-function killPid(pid: number): void {
-  try {
-    if (process.platform === 'win32') {
-      execFileSync('taskkill', ['/pid', String(pid), '/T', '/F'], { stdio: 'ignore' })
-      return
-    }
-    process.kill(pid, 'SIGKILL')
-  } catch {
-    // Already gone.
-  }
-}
 
 function stripPersistedPtyOwnership(userDataDir: string): void {
   const data = readPersistedData(userDataDir)
@@ -241,7 +149,7 @@ test('resumes a live agent record after force-exit restart when pane PTY ownersh
     const daemonPid = readDaemonPid(session.userDataDir)
     await forceKillElectronApp(firstApp)
     firstApp = null
-    killPid(daemonPid)
+    await forceKillProcessTree(daemonPid)
     stripPersistedPtyOwnership(session.userDataDir)
 
     const secondLaunch = await session.launch()

--- a/tests/e2e/helpers/force-exit-session.ts
+++ b/tests/e2e/helpers/force-exit-session.ts
@@ -1,0 +1,160 @@
+import { execFileSync } from 'node:child_process'
+import type { ChildProcess } from 'node:child_process'
+import { readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import type { ElectronApplication } from '@stablyai/playwright-test'
+import { PROTOCOL_VERSION } from '../../../src/main/daemon/types'
+import { DEFAULT_LOCAL_ORCA_PROFILE_ID } from '../../../src/shared/orca-profiles'
+
+const PROCESS_EXIT_TIMEOUT_MS = 5_000
+const PROCESS_EXIT_POLL_MS = 50
+
+export type PersistedWorkspaceSession = {
+  tabsByWorktree?: Record<string, { id?: unknown; ptyId?: unknown }[]>
+  terminalLayoutsByTabId?: Record<string, unknown>
+  activeWorktreeIdsOnShutdown?: unknown
+  sleepingAgentSessionsByPaneKey?: Record<
+    string,
+    {
+      paneKey?: unknown
+      tabId?: unknown
+      state?: unknown
+      origin?: unknown
+      providerSession?: { id?: unknown }
+      launchConfig?: {
+        agentCommand?: string
+        agentArgs?: string
+        agentEnv?: Record<string, string>
+      }
+    }
+  >
+}
+
+export type PersistedData = {
+  workspaceSession?: PersistedWorkspaceSession
+}
+
+export function readPersistedData(userDataDir: string): PersistedData {
+  // Fresh sessions migrate the seeded legacy file, then persist only here.
+  const filePath = path.join(
+    userDataDir,
+    'profiles',
+    DEFAULT_LOCAL_ORCA_PROFILE_ID,
+    'orca-data.json'
+  )
+  return JSON.parse(readFileSync(filePath, 'utf8')) as PersistedData
+}
+
+export function writePersistedData(userDataDir: string, data: PersistedData): void {
+  const filePath = path.join(
+    userDataDir,
+    'profiles',
+    DEFAULT_LOCAL_ORCA_PROFILE_ID,
+    'orca-data.json'
+  )
+  writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, 'utf8')
+}
+
+export function readDaemonPid(userDataDir: string): number {
+  const pidPath = path.join(userDataDir, 'daemon', `daemon-v${PROTOCOL_VERSION}.pid`)
+  const raw = readFileSync(pidPath, 'utf8')
+  const parsed = JSON.parse(raw) as { pid?: unknown }
+  if (typeof parsed.pid !== 'number') {
+    throw new Error(`Daemon pid file did not contain a numeric pid: ${raw}`)
+  }
+  return parsed.pid
+}
+
+function hasExited(proc: ChildProcess): boolean {
+  return proc.exitCode !== null || proc.signalCode !== null
+}
+
+function waitForExit(proc: ChildProcess, timeoutMs = PROCESS_EXIT_TIMEOUT_MS): Promise<boolean> {
+  if (hasExited(proc)) {
+    return Promise.resolve(true)
+  }
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (exited: boolean): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      proc.off('exit', onExit)
+      proc.off('close', onExit)
+      resolve(exited)
+    }
+    const onExit = (): void => finish(true)
+    const timeout = setTimeout(() => finish(false), timeoutMs)
+    proc.once('exit', onExit)
+    proc.once('close', onExit)
+  })
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+async function waitForPidExit(pid: number, timeoutMs = PROCESS_EXIT_TIMEOUT_MS): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (isProcessAlive(pid)) {
+    if (Date.now() >= deadline) {
+      return false
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, PROCESS_EXIT_POLL_MS)
+    })
+  }
+  return true
+}
+
+function terminationFailure(target: string, killError: unknown): Error {
+  const detail = killError instanceof Error ? ` Kill failed: ${killError.message}` : ''
+  return new Error(`Timed out waiting for ${target} to exit.${detail}`)
+}
+
+export async function forceKillElectronApp(app: ElectronApplication): Promise<void> {
+  const proc = app.process()
+  if (!proc.pid || hasExited(proc)) {
+    return
+  }
+  let killError: unknown
+  try {
+    if (process.platform === 'win32') {
+      execFileSync('taskkill', ['/pid', String(proc.pid), '/T', '/F'], { stdio: 'ignore' })
+    } else {
+      process.kill(proc.pid, 'SIGKILL')
+    }
+  } catch (error) {
+    killError = error
+  }
+  if (!(await waitForExit(proc))) {
+    throw terminationFailure(`Electron process ${proc.pid}`, killError)
+  }
+}
+
+export async function forceKillProcessTree(pid: number): Promise<void> {
+  if (!isProcessAlive(pid)) {
+    return
+  }
+  let killError: unknown
+  try {
+    if (process.platform === 'win32') {
+      execFileSync('taskkill', ['/pid', String(pid), '/T', '/F'], { stdio: 'ignore' })
+    } else {
+      process.kill(pid, 'SIGKILL')
+    }
+  } catch (error) {
+    killError = error
+  }
+  // Why: a restart test is meaningless if the old daemon survived the kill attempt.
+  if (!(await waitForPidExit(pid))) {
+    throw terminationFailure(`daemon process ${pid}`, killError)
+  }
+}


### PR DESCRIPTION
## Summary

- Preserve resumable provider identity when an agent reports a completed turn, so restarting Orca restores the exact Codex/Claude/Gemini/etc. conversation instead of leaving a plain shell.
- Keep completed recovery passive and owned by its original pane, preventing worktree activation from opening a duplicate tab.
- Preserve the existing Pi, manual-sleep, automatic-hibernation, natural-exit, explicit-close, WSL, and SSH lifecycle contracts.
- Run the completed-conversation force-exit/restart regression in the Windows terminal restart workflow.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — changed-file `oxlint`, reliability gates, max-lines ratchet, scrollbar check, bundled-skill guides, and localization checks pass. The repo-wide command remains blocked by unrelated current-tree failures in `skill-freshness-group.tsx` switch exhaustiveness and stale bundled-skill manifest artifacts.
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the full Windows run completed with 31,220 passing tests and exposed two related lifecycle failures; both were fixed and their suites rerun green. The remaining all-repo failures are unrelated Windows/baseline issues such as POSIX `/bin/sh`, symlink, path, and watcher assumptions.
- [x] `pnpm build` — typecheck plus relay, CLI, Electron desktop, web, and native build steps passed.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional evidence:

- 685 focused unit/integration tests pass across persistence, schema hydration, Pi, manual sleep, hibernation and rollback, tab/orphan cleanup, activation ownership, PTY cold restore, WSL quoting, and natural terminal retirement.
- Cross-platform Playwright E2E passes after force-killing both Electron and the daemon, restarting with the same profile, verifying no eager/duplicate tab, and resuming in the original `paneKey`.
- E2E-mode Electron build passes.
- `git diff --check` passes.

## AI Review Report

The final AI review found no actionable issues after checking:

- lifecycle correctness for `working → done → restart → resume`;
- passive pane ownership and provider-session deduplication;
- Pi's turn-completion semantics;
- manual sleep, completed-agent hibernation, rollback on failed local/runtime stops, natural PTY exit, explicit tab close, and completed orphan cleanup;
- macOS, Linux, and Windows behavior, including Electron process teardown, platform-neutral paths, and shell command construction;
- local, WSL, remote runtime, and SSH cold-restore paths;
- all resumable agent providers and malformed/non-resumable session metadata;
- performance impact (one small persisted record and existing debounced persistence; no polling added to production);
- UI behavior (no layout, shortcut, label, color, or styling changes).

The review initially flagged four integration defects in the first implementation: non-Pi hibernation became ineligible, manual sleep could discard completed recovery, activation could launch a duplicate tab, and completed orphan cleanup could leak recovery. This revision fixes all four and adds regression coverage for each. A full-suite run then exposed Pi-without-live-row and natural-terminal-retirement edge cases; both were fixed and rerun green.

## Security Audit

- No dependencies, permissions, IPC channels, authentication flows, secrets, or external network calls were added.
- Provider session IDs continue through the existing normalization and resumability checks; malformed, unsupported, control-character, and non-authoritative Pi records remain rejected.
- Resume commands continue to use the existing provider argv builder and platform-aware quoting for native Windows, WSL/Linux, and SSH hosts.
- Persisted launch configuration is existing trusted Orca launch metadata; the production change does not accept a new untrusted command source.
- Recovery records are removed on explicit dismissal/tab teardown and orphan cleanup, while natural terminal retirement preserves authority intentionally.
- The E2E substitutes `echo` only inside its isolated persisted test profile so CI does not require a real Codex installation.

No security follow-up is required.

## Notes

- This is not Windows-only: abrupt renderer/daemon loss can happen on every platform, while Windows reboot/update termination makes it easier to reproduce.
- Completed recovery uses a new optional persisted origin value. Older sessions remain schema-compatible.
- The Windows restart workflow now path-triggers on the completed-recovery code and runs both live-record and completed-record force-exit scenarios.
- GitHub created PR Checks and Windows restart runs for this head, but fork workflows are `action_required` until a maintainer approves them.
- X/Twitter: @mattemusacchio

## ELI5

After restarting Orca, finished agent chats could come back as empty shells instead of the same Codex/Claude conversation. Completed sessions keep enough identity to resume the real chat without opening a duplicate tab.
