### PR TITLE
fix(tab-bar): detect new-tab menu agents on the host that owns the workspace

### DIFF
--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.test.ts
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.test.ts
@@ -3,26 +3,32 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { QuickLaunchAgentMenuItems, shouldShowLaunchWatchdogTimeout } from './QuickLaunchButton'
 
-const { shortcutLabelMock, storeState, openSettingsPageMock, openSettingsTargetMock } = vi.hoisted(
-  () => ({
-    shortcutLabelMock: vi.fn<() => string | null>(),
-    storeState: {
-      settings: {
-        defaultTuiAgent: 'codex' as 'claude' | 'codex' | 'gemini' | 'blank' | null,
-        disabledTuiAgents: [] as string[]
-      },
-      worktreesByRepo: {},
-      repos: [],
-      openSettingsPage: vi.fn(),
-      openSettingsTarget: vi.fn()
+const {
+  shortcutLabelMock,
+  storeState,
+  openSettingsPageMock,
+  openSettingsTargetMock,
+  useDetectedAgentsMock
+} = vi.hoisted(() => ({
+  shortcutLabelMock: vi.fn<() => string | null>(),
+  storeState: {
+    settings: {
+      defaultTuiAgent: 'codex' as 'claude' | 'codex' | 'gemini' | 'blank' | null,
+      disabledTuiAgents: [] as string[],
+      activeRuntimeEnvironmentId: null as string | null
     },
-    openSettingsPageMock: vi.fn(),
-    openSettingsTargetMock: vi.fn()
-  })
-)
+    worktreesByRepo: {} as Record<string, { id: string; repoId: string; hostId?: string | null }[]>,
+    repos: [] as { id: string; connectionId: string | null; executionHostId: string | null }[],
+    openSettingsPage: vi.fn(),
+    openSettingsTarget: vi.fn()
+  },
+  openSettingsPageMock: vi.fn(),
+  openSettingsTargetMock: vi.fn(),
+  useDetectedAgentsMock: vi.fn()
+}))
 
 vi.mock('@/hooks/useDetectedAgents', () => ({
-  useDetectedAgents: () => ({ detectedIds: ['claude', 'codex', 'gemini'] })
+  useDetectedAgents: useDetectedAgentsMock
 }))
 
 vi.mock('@/hooks/useShortcutLabel', () => ({
@@ -89,10 +95,10 @@ vi.mock('@/lib/launch-agent-in-new-tab', () => ({
   launchAgentInNewTab: vi.fn()
 }))
 
-function renderAgentMenuItems(): string {
+function renderAgentMenuItems(worktreeId = 'worktree-1'): string {
   return renderToStaticMarkup(
     React.createElement(QuickLaunchAgentMenuItems, {
-      worktreeId: 'worktree-1',
+      worktreeId,
       groupId: 'group-1',
       onFocusTerminal: vi.fn()
     })
@@ -113,8 +119,11 @@ beforeEach(() => {
   shortcutLabelMock.mockReturnValue(null)
   openSettingsPageMock.mockReset()
   openSettingsTargetMock.mockReset()
+  useDetectedAgentsMock.mockReset()
+  useDetectedAgentsMock.mockReturnValue({ detectedIds: ['claude', 'codex', 'gemini'] })
   storeState.settings.defaultTuiAgent = 'codex'
   storeState.settings.disabledTuiAgents = []
+  storeState.settings.activeRuntimeEnvironmentId = null
   storeState.worktreesByRepo = {}
   storeState.repos = []
   storeState.openSettingsPage = openSettingsPageMock
@@ -149,6 +158,48 @@ describe('QuickLaunchAgentMenuItems', () => {
 
     storeState.settings.defaultTuiAgent = 'blank'
     expect(renderAgentMenuItems()).not.toContain('data-dropdown-shortcut="true"')
+  })
+
+  it('detects agents on the runtime environment that owns the worktree', () => {
+    // Why: regression — runtime-hosted workspaces have no SSH connection id;
+    // the menu used to fall back to local detection and offer agents that are
+    // not installed on the remote machine.
+    storeState.repos = [{ id: 'repo-1', connectionId: null, executionHostId: 'runtime:env-1' }]
+    storeState.worktreesByRepo = {
+      'repo-1': [{ id: 'repo-1::wt-1', repoId: 'repo-1', hostId: null }]
+    }
+
+    renderAgentMenuItems('repo-1::wt-1')
+
+    expect(useDetectedAgentsMock).toHaveBeenCalledWith({ kind: 'runtime', environmentId: 'env-1' })
+  })
+
+  it('detects agents on the SSH host that owns the worktree', () => {
+    storeState.repos = [{ id: 'repo-1', connectionId: 'conn-1', executionHostId: null }]
+    storeState.worktreesByRepo = {
+      'repo-1': [{ id: 'repo-1::wt-1', repoId: 'repo-1', hostId: null }]
+    }
+
+    renderAgentMenuItems('repo-1::wt-1')
+
+    expect(useDetectedAgentsMock).toHaveBeenCalledWith({ kind: 'ssh', connectionId: 'conn-1' })
+  })
+
+  it('detects agents locally for local worktrees', () => {
+    storeState.repos = [{ id: 'repo-1', connectionId: null, executionHostId: null }]
+    storeState.worktreesByRepo = {
+      'repo-1': [{ id: 'repo-1::wt-1', repoId: 'repo-1', hostId: null }]
+    }
+
+    renderAgentMenuItems('repo-1::wt-1')
+
+    expect(useDetectedAgentsMock).toHaveBeenCalledWith({ kind: 'local' })
+  })
+
+  it('does not fall back to local detection while the owning repo hydrates', () => {
+    renderAgentMenuItems('missing-repo::wt-1')
+
+    expect(useDetectedAgentsMock).toHaveBeenCalledWith(undefined)
   })
 })
 

--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
@@ -4,7 +4,7 @@ import { toast } from 'sonner'
 import { DropdownMenuItem, DropdownMenuShortcut } from '@/components/ui/dropdown-menu'
 import { getAgentCatalog, AgentIcon } from '@/lib/agent-catalog'
 import { useAppStore } from '@/store'
-import { getConnectionIdFromState } from '@/lib/connection-context'
+import { useAgentDetectionTarget } from '@/hooks/useAgentDetectionTarget'
 import { useDetectedAgents } from '@/hooks/useDetectedAgents'
 import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 import { launchAgentInNewTab } from '@/lib/launch-agent-in-new-tab'
@@ -100,12 +100,13 @@ function QuickLaunchAgentMenuItemsInner({
   launchSource,
   onPromptDelivered
 }: QuickLaunchAgentMenuItemsProps): React.JSX.Element | null {
-  // Why: must be a reactive selector (not getConnectionId() which reads a
-  // snapshot via getState()). This ensures the component re-renders when the
-  // SSH connection state changes. Returns undefined when the worktree isn't
-  // found (store not hydrated), null for local repos, string for remote.
-  const connectionId = useAppStore((s) => getConnectionIdFromState(s, worktreeId))
-  const { detectedIds } = useDetectedAgents(connectionId)
+  // Why: resolve the host that owns this worktree (local, SSH, or runtime
+  // environment) so the menu only offers agents installed on that host.
+  // Previously this only checked the SSH connection id, so runtime-hosted
+  // workspaces fell back to local detection and surfaced agents that do not
+  // exist on the remote machine.
+  const agentDetectionTarget = useAgentDetectionTarget(worktreeId)
+  const { detectedIds } = useDetectedAgents(agentDetectionTarget)
   const defaultAgent = useAppStore((s) => s.settings?.defaultTuiAgent)
   const disabledAgents = useAppStore((s) => s.settings?.disabledTuiAgents ?? [])
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)

--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -42,7 +42,8 @@ import TabBarCreateEntry from './TabBarCreateEntry'
 import { ShellIcon } from './shell-icons'
 import { resolveWindowsShellLaunchTarget } from './windows-shell-launch'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
-import { type AgentDetectionTarget, useDetectedAgents } from '@/hooks/useDetectedAgents'
+import { useDetectedAgents } from '@/hooks/useDetectedAgents'
+import { useAgentDetectionTarget } from '@/hooks/useAgentDetectionTarget'
 import { launchAgentInNewTab } from '@/lib/launch-agent-in-new-tab'
 import { normalizeRelativePath } from '@/lib/path'
 import {
@@ -95,7 +96,6 @@ type GitStatusEntries = ReturnType<typeof useAppStore.getState>['gitStatusByWork
 const EMPTY_GIT_STATUS_ENTRIES: GitStatusEntries = []
 const EMPTY_AGENT_CMD_OVERRIDES: Partial<Record<TuiAgent, string>> = {}
 const EMPTY_UNIFIED_TABS: readonly Tab[] = []
-const AGENT_DETECTION_LOCAL_TARGET_KEY = 'local'
 
 function getProjectRuntimeShellMenuMode(
   projectRuntime: ProjectExecutionRuntimeResolution | undefined
@@ -331,36 +331,7 @@ function TabBarInner({
   const agentCmdOverrides = useAppStore(
     (s) => s.settings?.agentCmdOverrides ?? EMPTY_AGENT_CMD_OVERRIDES
   )
-  const agentDetectionTargetKey = useAppStore((s): string | undefined => {
-    const connectionId = getConnectionIdFromState(s, worktreeId)
-    if (connectionId === undefined) {
-      return undefined
-    }
-    const normalizedConnectionId = connectionId?.trim()
-    if (normalizedConnectionId) {
-      return `ssh:${normalizedConnectionId}`
-    }
-    const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(s, worktreeId)?.trim()
-    if (runtimeEnvironmentId) {
-      return `runtime:${runtimeEnvironmentId}`
-    }
-    return AGENT_DETECTION_LOCAL_TARGET_KEY
-  })
-  const agentDetectionTarget = useMemo<AgentDetectionTarget | undefined>(() => {
-    if (agentDetectionTargetKey === undefined) {
-      return undefined
-    }
-    if (agentDetectionTargetKey === AGENT_DETECTION_LOCAL_TARGET_KEY) {
-      return { kind: 'local' }
-    }
-    if (agentDetectionTargetKey.startsWith('ssh:')) {
-      return { kind: 'ssh', connectionId: agentDetectionTargetKey.slice('ssh:'.length) }
-    }
-    if (agentDetectionTargetKey.startsWith('runtime:')) {
-      return { kind: 'runtime', environmentId: agentDetectionTargetKey.slice('runtime:'.length) }
-    }
-    return { kind: 'local' }
-  }, [agentDetectionTargetKey])
+  const agentDetectionTarget = useAgentDetectionTarget(worktreeId)
   const { detectedIds } = useDetectedAgents(agentDetectionTarget)
   const agentLaunchOptions = useMemo(
     () =>

--- a/src/renderer/src/hooks/useAgentDetectionTarget.test.ts
+++ b/src/renderer/src/hooks/useAgentDetectionTarget.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENT_DETECTION_LOCAL_TARGET_KEY,
+  agentDetectionTargetFromKey,
+  getAgentDetectionTargetKeyFromState,
+  type AgentDetectionTargetState
+} from './useAgentDetectionTarget'
+
+function buildState(overrides: {
+  repos: readonly { id: string; connectionId?: string | null; executionHostId?: string | null }[]
+  worktreesByRepo?: Record<
+    string,
+    readonly { id: string; repoId: string; hostId?: string | null }[]
+  >
+  activeRuntimeEnvironmentId?: string | null
+}): AgentDetectionTargetState {
+  return {
+    folderWorkspaces: [],
+    projectGroups: [],
+    repos: overrides.repos.map((repo) => ({
+      connectionId: null,
+      executionHostId: null,
+      ...repo
+    })),
+    worktreesByRepo: overrides.worktreesByRepo ?? {},
+    settings: { activeRuntimeEnvironmentId: overrides.activeRuntimeEnvironmentId ?? null }
+  } as unknown as AgentDetectionTargetState
+}
+
+const LOCAL_STATE = buildState({
+  repos: [{ id: 'repo-1' }],
+  worktreesByRepo: { 'repo-1': [{ id: 'repo-1::wt-1', repoId: 'repo-1' }] }
+})
+
+describe('getAgentDetectionTargetKeyFromState', () => {
+  it('returns undefined while the owning repo has not hydrated', () => {
+    expect(getAgentDetectionTargetKeyFromState(LOCAL_STATE, 'missing-repo::wt-1')).toBeUndefined()
+  })
+
+  it('targets the local host for a local repo', () => {
+    expect(getAgentDetectionTargetKeyFromState(LOCAL_STATE, 'repo-1::wt-1')).toBe(
+      AGENT_DETECTION_LOCAL_TARGET_KEY
+    )
+  })
+
+  it('targets the SSH host for a repo with a connection', () => {
+    const state = buildState({
+      repos: [{ id: 'repo-1', connectionId: 'conn-1' }],
+      worktreesByRepo: { 'repo-1': [{ id: 'repo-1::wt-1', repoId: 'repo-1' }] }
+    })
+
+    expect(getAgentDetectionTargetKeyFromState(state, 'repo-1::wt-1')).toBe('ssh:conn-1')
+  })
+
+  it('targets the runtime environment that owns the repo', () => {
+    const state = buildState({
+      repos: [{ id: 'repo-1', executionHostId: 'runtime:env-1' }],
+      worktreesByRepo: { 'repo-1': [{ id: 'repo-1::wt-1', repoId: 'repo-1' }] }
+    })
+
+    expect(getAgentDetectionTargetKeyFromState(state, 'repo-1::wt-1')).toBe('runtime:env-1')
+  })
+
+  it('lets a worktree-level runtime host override the repo owner', () => {
+    const state = buildState({
+      repos: [{ id: 'repo-1' }],
+      worktreesByRepo: {
+        'repo-1': [{ id: 'repo-1::wt-1', repoId: 'repo-1', hostId: 'runtime:env-wt' }]
+      }
+    })
+
+    expect(getAgentDetectionTargetKeyFromState(state, 'repo-1::wt-1')).toBe('runtime:env-wt')
+  })
+
+  it('falls back to the focused runtime environment for unowned repos', () => {
+    const state = buildState({
+      repos: [{ id: 'repo-1' }],
+      worktreesByRepo: { 'repo-1': [{ id: 'repo-1::wt-1', repoId: 'repo-1' }] },
+      activeRuntimeEnvironmentId: 'env-active'
+    })
+
+    expect(getAgentDetectionTargetKeyFromState(state, 'repo-1::wt-1')).toBe('runtime:env-active')
+  })
+
+  it('prefers the SSH connection over a runtime owner', () => {
+    const state = buildState({
+      repos: [{ id: 'repo-1', connectionId: 'conn-1', executionHostId: 'runtime:env-1' }],
+      worktreesByRepo: { 'repo-1': [{ id: 'repo-1::wt-1', repoId: 'repo-1' }] }
+    })
+
+    expect(getAgentDetectionTargetKeyFromState(state, 'repo-1::wt-1')).toBe('ssh:conn-1')
+  })
+})
+
+describe('agentDetectionTargetFromKey', () => {
+  it('parses each target kind', () => {
+    expect(agentDetectionTargetFromKey(undefined)).toBeUndefined()
+    expect(agentDetectionTargetFromKey(AGENT_DETECTION_LOCAL_TARGET_KEY)).toEqual({
+      kind: 'local'
+    })
+    expect(agentDetectionTargetFromKey('ssh:conn-1')).toEqual({
+      kind: 'ssh',
+      connectionId: 'conn-1'
+    })
+    expect(agentDetectionTargetFromKey('runtime:env-1')).toEqual({
+      kind: 'runtime',
+      environmentId: 'env-1'
+    })
+  })
+
+  it('treats unknown keys as local', () => {
+    expect(agentDetectionTargetFromKey('unexpected')).toEqual({ kind: 'local' })
+  })
+})

--- a/src/renderer/src/hooks/useAgentDetectionTarget.ts
+++ b/src/renderer/src/hooks/useAgentDetectionTarget.ts
@@ -1,0 +1,77 @@
+import { useMemo } from 'react'
+import { useAppStore } from '@/store'
+import {
+  getConnectionIdFromState,
+  type ConnectionOwnerState
+} from '@/lib/connection-owner-resolution'
+import {
+  getRuntimeEnvironmentIdForWorktree,
+  type WorktreeRuntimeOwnerState
+} from '@/lib/worktree-runtime-owner'
+import type { AgentDetectionTarget } from './useDetectedAgents'
+
+export const AGENT_DETECTION_LOCAL_TARGET_KEY = 'local'
+
+export type AgentDetectionTargetState = ConnectionOwnerState & WorktreeRuntimeOwnerState
+
+/**
+ * Single resolver for the host that agent detection must probe for a worktree.
+ *
+ * Why: every agent-launch surface (tab-bar dropdown, searchable create entry,
+ * send menus) must agree on local vs. SSH vs. runtime — a second hand-rolled
+ * resolver once fell back to local for runtime-hosted worktrees, surfacing
+ * agents that only exist on the client machine.
+ *
+ * Returns a string key (not the target object) so retained Zustand selectors
+ * keep a stable primitive reference; parse with agentDetectionTargetFromKey.
+ * Undefined means the owning repo has not hydrated yet — callers must not
+ * treat that as local.
+ */
+export function getAgentDetectionTargetKeyFromState(
+  state: AgentDetectionTargetState,
+  worktreeId: string | null
+): string | undefined {
+  const connectionId = getConnectionIdFromState(state, worktreeId)
+  if (connectionId === undefined) {
+    return undefined
+  }
+  const normalizedConnectionId = connectionId?.trim()
+  if (normalizedConnectionId) {
+    return `ssh:${normalizedConnectionId}`
+  }
+  const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(state, worktreeId)?.trim()
+  if (runtimeEnvironmentId) {
+    return `runtime:${runtimeEnvironmentId}`
+  }
+  return AGENT_DETECTION_LOCAL_TARGET_KEY
+}
+
+export function agentDetectionTargetFromKey(
+  key: string | undefined
+): AgentDetectionTarget | undefined {
+  if (key === undefined) {
+    return undefined
+  }
+  if (key === AGENT_DETECTION_LOCAL_TARGET_KEY) {
+    return { kind: 'local' }
+  }
+  if (key.startsWith('ssh:')) {
+    return { kind: 'ssh', connectionId: key.slice('ssh:'.length) }
+  }
+  if (key.startsWith('runtime:')) {
+    return { kind: 'runtime', environmentId: key.slice('runtime:'.length) }
+  }
+  return { kind: 'local' }
+}
+
+/**
+ * Resolve the agent-detection host for a worktree. Undefined while the owning
+ * repo is not hydrated (loading — do not flash local agents); otherwise the
+ * SSH connection, runtime environment, or local host that owns the worktree.
+ */
+export function useAgentDetectionTarget(
+  worktreeId: string | null
+): AgentDetectionTarget | undefined {
+  const targetKey = useAppStore((s) => getAgentDetectionTargetKeyFromState(s, worktreeId))
+  return useMemo(() => agentDetectionTargetFromKey(targetKey), [targetKey])
+}

--- a/src/renderer/src/lib/connection-owner-resolution.ts
+++ b/src/renderer/src/lib/connection-owner-resolution.ts
@@ -12,7 +12,7 @@ import {
   getFolderWorkspaceConnectionId
 } from './folder-workspace-connection'
 
-type ConnectionOwnerState = Pick<
+export type ConnectionOwnerState = Pick<
   AppState,
   'folderWorkspaces' | 'projectGroups' | 'repos' | 'worktreesByRepo'
 >


### PR DESCRIPTION
Closes #9370.

## Summary

For workspaces hosted on a remote server (runtime environment, no SSH connection), the tab-bar `+` menu's agent section resolved the agent-detection host from the repo's SSH connection id only. That came back `null` for runtime-hosted workspaces, so detection silently probed the **local** machine and offered agents that are not installed remotely — launching one failed immediately (e.g. `zsh: command not found: pi`).

The searchable create-entry in the same dropdown already resolved SSH → runtime → local correctly; the two menu variants had drifted. This PR extracts that resolution into a shared `useAgentDetectionTarget(worktreeId)` hook (`src/renderer/src/hooks/useAgentDetectionTarget.ts`) and uses it in both places, so the static menu, the searchable entry, and the review-notes send menu (which reuses the component) cannot drift again. `undefined` while the owning repo hydrates is preserved, so local agents never flash for remote workspaces.

## Screenshots

After the fix — a workspace on a remote server lists only the agents actually detected on the remote host (compare with the broken behavior in #9370, where locally-installed agents like Pi/OMP/Droid were offered and then failed with `command not found`):

<img width="1328" height="1180" alt="New-tab agent menu on a remote workspace showing only remotely detected agents" src="https://github.com/user-attachments/assets/df6d13c9-e6e7-4876-bed5-f97e2b4b4d3f" />

No visual change to the menu UI itself — only which agents are listed changes.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 29,550 passed; 28 failures in 4 unrelated files (`pr-comments-list-selection`, `pr-comment-presentation`, `LinearAgentSkillSetupPrompt.reminder-toast`, `SidebarToolbar`) reproduce identically without this change — they fail on `window.localStorage` being undefined under Node 26 (repo engines want Node 24). None of them import anything touched here.
- [ ] `pnpm build` — not run; full `tsc` typecheck passes across node/cli/web configs and the dev app (`pnpm dev`) builds and launches cleanly with the fix verified manually against a remote workspace.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New tests: 7 resolver cases in `useAgentDetectionTarget.test.ts` (local / SSH / runtime repo owner / worktree-level override / focused-runtime fallback / SSH-over-runtime precedence / hydration-pending) and 4 regression tests in `QuickLaunchButton.test.ts` asserting the menu probes the runtime environment, the SSH host, local, and never falls back to local while the owning repo hydrates.

## AI Review Report

Review covered: (1) both tab-bar menu variants plus the `ReviewNotesSendMenuContent` reuse of `QuickLaunchAgentMenuItems` — all now share the one resolver; (2) host-ownership precedence matches `TabBar`'s pre-existing order (SSH connection id first, then runtime environment, then local, undefined while unhydrated); (3) the resolver returns a stable string key from the Zustand selector with the object memoized from the key, so retained tab strips don't re-render on unrelated store writes; (4) cross-platform compatibility — no platform-specific behavior introduced: detection itself continues to run through the existing per-host paths (local PATH probing incl. WSL targeting, SSH relay `preflight.detectAgents` on the remote host, runtime-daemon RPC), and no shortcuts, labels, paths, or shell behavior were touched. Flagged and addressed: the type-only `ConnectionOwnerState` export is erased at runtime, so main-process behavior is untouched.

## Security Audit

No new IPC surface, command execution, path handling, auth, or secrets. The change is pure renderer state reads (repo/worktree ownership) choosing among three **existing** detection channels: local preflight IPC, the authenticated SSH relay's `preflight.detectAgents`, and the runtime-daemon RPC allowlist (`preflight.detectAgents` was already allowlisted and used by the searchable create entry). No user input is parsed; no dependencies added. No follow-up needed.

## Notes

- First menu open on a remote workspace triggers one fresh probe against the remote host (cached afterward), so the list may briefly show "No agents detected" on first open — same behavior the searchable create entry already had.
- SSH-connected repos are behaviorally unchanged (same target as before); only runtime-hosted workspaces move from local to remote detection.

## ELI5

On remote-server workspaces, the new-tab menu listed agents installed on your laptop, not on the remote host — so launching one failed with command not found. Agent detection now uses the host that owns the workspace.
