### PR TITLE
fix(status-bar): show live session reset countdown in collapsed usage bar (#5399)

### DIFF
--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -58,6 +58,7 @@ import {
 import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { formatRateLimitWindowChipLabel } from '@/lib/window-label-formatter'
+import { useResetCountdownClock } from '@/hooks/useResetCountdownClock'
 import { markLiveCodexSessionsForRestart } from '@/lib/codex-session-restart'
 import { UpdateStatusSegment } from './UpdateStatusSegment'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
@@ -979,6 +980,9 @@ export function InlineUsageBars({
   const display = normalizeUsagePercentageDisplay(
     useAppStore((state) => state.usagePercentageDisplay)
   )
+  // Why: tick the collapsed session countdown live (matches the popover) via one
+  // boundary-scheduled clock instead of only refreshing on the usage poll (#5399).
+  const now = useResetCountdownClock([limits.session?.resetsAt])
   const usageWindows = [
     limits.session
       ? {
@@ -986,7 +990,7 @@ export function InlineUsageBars({
           used: clampUsedPercent(limits.session.usedPercent),
           // Why: show the live reset countdown (matches the popover); '5h' window
           // length only when resetsAt is unknown (#5399).
-          label: formatRateLimitWindowChipLabel(limits.session)
+          label: formatRateLimitWindowChipLabel(limits.session, now)
         }
       : null,
     limits.weekly

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -984,7 +984,9 @@ export function InlineUsageBars({
       ? {
           key: 'session',
           used: clampUsedPercent(limits.session.usedPercent),
-          label: translate('auto.components.status.bar.StatusBar.d79c3362c4', '5h')
+          // Why: show the live reset countdown (matches the popover); '5h' window
+          // length only when resetsAt is unknown (#5399).
+          label: formatRateLimitWindowChipLabel(limits.session)
         }
       : null,
     limits.weekly

--- a/src/renderer/src/components/status-bar/inline-usage-bars.test.tsx
+++ b/src/renderer/src/components/status-bar/inline-usage-bars.test.tsx
@@ -71,6 +71,34 @@ describe('InlineUsageBars', () => {
     expect(markup).toContain('42% used Fable')
   })
 
+  it('derives the collapsed session label from resetsAt (#5399)', async () => {
+    const { InlineUsageBars } = await import('./StatusBar')
+
+    const limits = claudeLimits()
+    // ~1h 20m away; +5s buffer keeps the floor-based formatter at '1h 20m'
+    // across the few ms between snapshot and render.
+    limits.session!.resetsAt = Date.now() + 80 * 60_000 + 5_000
+
+    const markup = renderToStaticMarkup(<InlineUsageBars limits={limits} isFetching={false} />)
+
+    expect(markup).toContain('32% used 1h 20m')
+    expect(markup).not.toContain('32% used 5h')
+    // Non-session bars keep their fixed labels.
+    expect(markup).toContain('16% used wk')
+    expect(markup).toContain('42% used Fable')
+  })
+
+  it('shows "now" for an already-expired session reset', async () => {
+    const { InlineUsageBars } = await import('./StatusBar')
+
+    const limits = claudeLimits()
+    limits.session!.resetsAt = Date.now() - 1000
+
+    const markup = renderToStaticMarkup(<InlineUsageBars limits={limits} isFetching={false} />)
+
+    expect(markup).toContain('32% used now')
+  })
+
   it('shows remaining copy and remaining meter fill', async () => {
     mocks.usagePercentageDisplay = 'remaining'
     const { InlineUsageBars } = await import('./StatusBar')

--- a/src/renderer/src/hooks/useResetCountdownClock.test.ts
+++ b/src/renderer/src/hooks/useResetCountdownClock.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment happy-dom
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useResetCountdownClock } from './useResetCountdownClock'
+
+const START = 1_000_000_000
+const MIN = 60_000
+
+describe('useResetCountdownClock', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(START)
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('advances `now` just after the next label boundary', () => {
+    // 90m 30s away -> the minute label flips in 30s.
+    const resetAt = START + 90 * MIN + 30_000
+    const { result } = renderHook(() => useResetCountdownClock([resetAt]))
+    expect(result.current).toBe(START)
+
+    act(() => {
+      vi.advanceTimersByTime(30_000 + 1)
+    })
+    // Woke exactly once, at the boundary — not every second.
+    expect(result.current).toBe(START + 30_000 + 1)
+  })
+
+  it('does not schedule a tick when there is no future reset', () => {
+    const { result } = renderHook(() => useResetCountdownClock([START - 1000]))
+    expect(result.current).toBe(START)
+
+    act(() => {
+      vi.advanceTimersByTime(10 * MIN)
+    })
+    // Nothing to count down -> `now` stays put (no wasted wakeups).
+    expect(result.current).toBe(START)
+  })
+})

--- a/src/renderer/src/hooks/useResetCountdownClock.ts
+++ b/src/renderer/src/hooks/useResetCountdownClock.ts
@@ -1,0 +1,50 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { getResetCountdownNextTickDelay } from '../../../shared/rate-limit-reset-format'
+
+// Why: a single boundary-scheduled clock drives the status-bar reset countdowns
+// so the collapsed badge ticks live (matching the popover) without a per-second
+// interval. It wakes once, just after the next label boundary, and reschedules.
+
+function resetTimesKey(resetTimes: readonly (number | null | undefined)[]): string {
+  return resetTimes
+    .filter((resetAt): resetAt is number => resetAt != null && Number.isFinite(resetAt))
+    .sort((a, b) => a - b)
+    .join('|')
+}
+
+function parseResetTimesKey(key: string): number[] {
+  return key.length === 0 ? [] : key.split('|').map((value) => Number(value))
+}
+
+/**
+ * Returns a `now` timestamp that advances whenever the soonest reset countdown
+ * label is due to change. Pass the window `resetsAt` values; feed the returned
+ * `now` into the label formatter so it stays live.
+ */
+export function useResetCountdownClock(resetTimes: readonly (number | null | undefined)[]): number {
+  const [scheduledNow, setScheduledNow] = useState(() => Date.now())
+  const key = useMemo(() => resetTimesKey(resetTimes), [resetTimes])
+  const times = useMemo(() => parseResetTimesKey(key), [key])
+  const previousKeyRef = useRef(key)
+  const immediateNowRef = useRef(scheduledNow)
+
+  // Why: when the set of reset times changes, refresh `now` immediately so the
+  // label reflects the new window without waiting for the next scheduled tick.
+  if (previousKeyRef.current !== key) {
+    previousKeyRef.current = key
+    immediateNowRef.current = Date.now()
+  }
+
+  const now = Math.max(scheduledNow, immediateNowRef.current)
+
+  useEffect(() => {
+    const delayMs = getResetCountdownNextTickDelay(now, times)
+    if (delayMs === null) {
+      return
+    }
+    const timeout = window.setTimeout(() => setScheduledNow(Date.now()), delayMs)
+    return () => window.clearTimeout(timeout)
+  }, [now, times])
+
+  return now
+}

--- a/src/shared/rate-limit-reset-format.test.ts
+++ b/src/shared/rate-limit-reset-format.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { formatResetCountdown, formatResetDuration } from './rate-limit-reset-format'
+import {
+  formatResetCountdown,
+  formatResetDuration,
+  getResetCountdownNextTickDelay
+} from './rate-limit-reset-format'
 
 const MIN = 60_000
 const HOUR = 60 * MIN
@@ -26,5 +30,34 @@ describe('formatResetCountdown', () => {
     expect(formatResetCountdown(0)).toBe('Resets now')
     expect(formatResetCountdown(3 * HOUR + 54 * MIN)).toBe('Resets in 3h 54m')
     expect(formatResetCountdown(6 * DAY + 7 * HOUR)).toBe('Resets in 6d 7h')
+  })
+})
+
+describe('getResetCountdownNextTickDelay', () => {
+  const now = 1_000_000_000
+
+  it('returns null when there is nothing to count down', () => {
+    expect(getResetCountdownNextTickDelay(now, [])).toBeNull()
+    // Past / non-finite resets never schedule a tick.
+    expect(getResetCountdownNextTickDelay(now, [now - MIN, now])).toBeNull()
+    expect(getResetCountdownNextTickDelay(now, [Number.NaN, Number.POSITIVE_INFINITY])).toBeNull()
+  })
+
+  it('wakes just after the next minute boundary while under a day out', () => {
+    // 90m 30s away -> next label flip is at the 90m mark, i.e. after 30s.
+    expect(getResetCountdownNextTickDelay(now, [now + 90 * MIN + 30_000])).toBe(30_000 + 1)
+  })
+
+  it('ticks on hour boundaries when a reset is a day or more away', () => {
+    // 2d 3h 15m away -> hour-granular labels, next flip after 15m.
+    expect(getResetCountdownNextTickDelay(now, [now + 2 * DAY + 3 * HOUR + 15 * MIN])).toBe(
+      15 * MIN + 1
+    )
+  })
+
+  it('returns the soonest delay across multiple resets', () => {
+    const soon = now + 5 * MIN + 10_000 // 10s to next flip
+    const later = now + 42 * MIN + 40_000 // 40s to next flip
+    expect(getResetCountdownNextTickDelay(now, [later, soon])).toBe(10_000 + 1)
   })
 })

--- a/src/shared/rate-limit-reset-format.ts
+++ b/src/shared/rate-limit-reset-format.ts
@@ -30,3 +30,32 @@ export function formatResetCountdown(ms: number): string {
   const duration = formatResetDuration(ms)
   return duration === 'now' ? 'Resets now' : `Resets in ${duration}`
 }
+
+const MINUTE_MS = 60_000
+const HOUR_MS = 60 * MINUTE_MS
+const DAY_MS = 24 * HOUR_MS
+
+/**
+ * Delay (ms) until the soonest reset countdown label would change, or null when
+ * no future reset needs a tick. Because labels are floored to minutes (or hours
+ * past a day), a countdown clock only needs to wake just after the next unit
+ * boundary — not every second — so callers schedule one short-lived timeout
+ * instead of polling. Returns the minimum delay across all reset times.
+ */
+export function getResetCountdownNextTickDelay(
+  now: number,
+  resetTimes: readonly number[]
+): number | null {
+  let nextDelay: number | null = null
+  for (const resetAt of resetTimes) {
+    if (!Number.isFinite(resetAt) || resetAt <= now) {
+      continue
+    }
+    const remainingMs = resetAt - now
+    const tickUnitMs = remainingMs >= DAY_MS ? HOUR_MS : MINUTE_MS
+    // Why: +1ms so the timeout fires just past the boundary the label flips on.
+    const delayMs = (remainingMs % tickUnitMs) + 1
+    nextDelay = nextDelay === null ? delayMs : Math.min(nextDelay, delayMs)
+  }
+  return nextDelay
+}


### PR DESCRIPTION
## Description

Fixes #5399. Combines and supersedes #6252 (@gatsby74) and #6585 — see **Credits** below.

The collapsed usage/limits bar in the status bar always showed a hardcoded `5h` for the Claude session window, while the expanded popover showed the true countdown (e.g. `Resets in 1h 20m`). The two surfaces disagreed for the same window, and the collapsed value never moved.

**Root cause:** `InlineUsageBars` built the session chip label as `translate(..., '5h')` — the 300-minute *window length*, not time-until-reset — so it never changed as the reset approached.

**Fix (two parts, session window only):**
1. **Correct value:** derive the collapsed session label from `resetsAt` via the existing `formatRateLimitWindowChipLabel` helper (`src/renderer/src/lib/window-label-formatter.ts`) that the expanded chips already use. Falls back to the fixed `5h` window-length label only when `resetsAt` is `null`.
2. **Live tick:** a shared, boundary-scheduled countdown clock (`useResetCountdownClock` + `getResetCountdownNextTickDelay`) advances the badge in real time to match the popover. It wakes **once, just after the next minute/hour boundary** and reschedules — no per-second polling. This is @gatsby74's live-countdown contribution, re-based onto the current shared `rate-limit-reset-format` helpers.

Weekly / Fable chips keep their fixed labels — no non-session bar changes.

Changed:
- `src/shared/rate-limit-reset-format.ts` — add pure `getResetCountdownNextTickDelay(now, resetTimes)` boundary scheduler (+ tests).
- `src/renderer/src/hooks/useResetCountdownClock.ts` — shared status-bar countdown clock hook (+ tests).
- `src/renderer/src/components/status-bar/StatusBar.tsx` — `InlineUsageBars` derives the session label from `resetsAt` and passes a live `now`.

## Evidence (proof of improvement)

- `inline-usage-bars.test.tsx`: `resetsAt` ~1h20m out → markup shows `32% used 1h 20m`, not `5h`; expired reset → `now`. **These 2 assertions fail on `main` and pass on the fix** (verified by reverting `StatusBar.tsx` to `main`).
- `rate-limit-reset-format.test.ts`: `getResetCountdownNextTickDelay` wakes just past the next minute boundary (<1 day out), on hour boundaries (≥1 day out), returns the soonest across multiple resets, and `null` when nothing is pending.
- `useResetCountdownClock.test.ts`: fake-timer test proves `now` advances exactly once at the boundary (`+30s+1ms`), and does **not** advance when there is no future reset (no wasted wakeups).

## Proof of no regression

- `src/renderer/src/components/status-bar/` + `src/renderer/src/hooks/` + `src/shared/rate-limit-reset-format.test.ts`: **579 tests pass**.
- `typecheck:tsc:web`: clean. `oxlint` on all changed files: clean.
- Behavior unchanged for: weekly/Fable/monthly chips, the expanded popover, and any window with `resetsAt == null` (still `5h`). The only new runtime cost is a single boundary-scheduled `setTimeout` per status bar that already has a visible session countdown.

## ELI5

A little bar at the bottom shows how much of your usage you've used and when it resets. It always said "5h" no matter what, while the bigger popup showed the real time left like "1h 20m". Now the little bar shows the real time left **and** counts down live — but it's lazy about it: instead of updating every second, it sleeps until the display would actually change (once a minute), so it costs almost nothing.

## Credits

The live-countdown design is @gatsby74's work from #6252 (further refined in #6585). This PR re-bases that idea onto current `main` (which since gained the shared `formatResetDuration`/`formatRateLimitWindowChipLabel` helpers) and keeps the perf-conscious boundary-scheduled clock. Co-authored-by @gatsby74. Closes #6252 and #6585 as superseded.
