### PR TITLE
fix(rate-limits): surface Codex auth failures instead of PTY timeout

### DIFF
--- a/src/main/rate-limits/codex-fetcher-auth-errors.test.ts
+++ b/src/main/rate-limits/codex-fetcher-auth-errors.test.ts
@@ -153,6 +153,54 @@ describe('fetchCodexRateLimits auth errors', () => {
     expect(ptySpawnMock).not.toHaveBeenCalled()
   })
 
+  it('returns token_invalidated usage API failures without starting PTY fallback', async () => {
+    const rpcChild = makeRpcChild()
+    // Why: newer app-server versions wrap invalidated sessions as JSON-RPC errors
+    // with "signing in again" wording that older patterns missed.
+    const authError =
+      'failed to fetch codex rate limits: GET https://chatgpt.com/backend-api/wham/usage failed: 401 Unauthorized; content-type=text/plain; body={"error":{"message":"Your authentication token has been invalidated. Please try signing in again.","code":"token_invalidated"}}'
+
+    childSpawnMock.mockReturnValue(rpcChild)
+    rpcChild.stdin.write.mockImplementation((line: string) => {
+      const msg = JSON.parse(line) as { id?: number; method?: string }
+      if (msg.method === 'initialize') {
+        setTimeout(() => {
+          rpcChild.stdout.emit(
+            'data',
+            Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: {} })}\n`)
+          )
+        }, 0)
+      }
+      if (msg.method === 'account/rateLimits/read') {
+        setTimeout(() => {
+          rpcChild.stdout.emit(
+            'data',
+            Buffer.from(
+              `${JSON.stringify({
+                jsonrpc: '2.0',
+                id: msg.id,
+                error: { code: -32603, message: authError }
+              })}\n`
+            )
+          )
+        }, 0)
+      }
+    })
+
+    const resultPromise = fetchCodexRateLimits()
+    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      provider: 'codex',
+      session: null,
+      weekly: null,
+      status: 'error',
+      error: authError
+    })
+    expect(ptySpawnMock).not.toHaveBeenCalled()
+  })
+
   it('preserves Codex PTY auth errors when the CLI exits before status is available', async () => {
     const ptyHandlers: { onData?: (data: string) => void; onExit?: () => void } = {}
     const authError =

--- a/src/main/rate-limits/codex-fetcher-pty-settle.test.ts
+++ b/src/main/rate-limits/codex-fetcher-pty-settle.test.ts
@@ -98,7 +98,6 @@ describe('fetchCodexRateLimits PTY settle timers', () => {
     const resultPromise = fetchCodexRateLimits()
     await vi.advanceTimersByTimeAsync(0)
 
-<<<<<<< HEAD
     const onPtyData = ptyHandlers.onData
     if (!onPtyData) {
       throw new Error('PTY data handler was not registered')

--- a/src/main/rate-limits/codex-fetcher-pty-settle.test.ts
+++ b/src/main/rate-limits/codex-fetcher-pty-settle.test.ts
@@ -98,6 +98,7 @@ describe('fetchCodexRateLimits PTY settle timers', () => {
     const resultPromise = fetchCodexRateLimits()
     await vi.advanceTimersByTimeAsync(0)
 
+<<<<<<< HEAD
     const onPtyData = ptyHandlers.onData
     if (!onPtyData) {
       throw new Error('PTY data handler was not registered')
@@ -295,6 +296,84 @@ describe('fetchCodexRateLimits PTY settle timers', () => {
       session: null,
       weekly: { usedPercent: 76 },
       status: 'ok'
+    })
+  })
+
+  it('retries /status once when Codex reports an async refresh-pending panel', async () => {
+    const ptyHandlers: { onData?: (data: string) => void } = {}
+    const writeMock = vi.fn()
+
+    childSpawnMock.mockImplementation(() => {
+      throw new Error('rpc unavailable')
+    })
+    ptySpawnMock.mockReturnValue({
+      onData: vi.fn((callback) => {
+        ptyHandlers.onData = callback
+        return makeDisposable()
+      }),
+      onExit: vi.fn(() => makeDisposable()),
+      write: writeMock,
+      kill: vi.fn()
+    })
+
+    const resultPromise = fetchCodexRateLimits()
+    await vi.advanceTimersByTimeAsync(0)
+
+    const onPtyData = ptyHandlers.onData
+    if (!onPtyData) {
+      throw new Error('PTY data handler was not registered')
+    }
+
+    onPtyData('>')
+    expect(writeMock).toHaveBeenCalledWith('/status')
+    await vi.advanceTimersByTimeAsync(350)
+    expect(writeMock).toHaveBeenCalledWith('\r')
+
+    onPtyData('Limits: refresh requested; run /status again shortly.\n')
+    await vi.advanceTimersByTimeAsync(750)
+
+    expect(writeMock.mock.calls.filter((call) => call[0] === '/status')).toHaveLength(2)
+
+    // Styled percentages exercise the same ANSI-stripped buffer used for pending detection.
+    onPtyData('5h limit: \u001B[33m41\u001B[0m%\nWeekly limit: \u001B[34m9\u001B[0m%\n')
+    await vi.advanceTimersByTimeAsync(500)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      session: { usedPercent: 41 },
+      weekly: { usedPercent: 9 },
+      status: 'ok',
+      error: null
+    })
+    await vi.advanceTimersByTimeAsync(750)
+    expect(writeMock.mock.calls.filter((call) => call[0] === '/status')).toHaveLength(2)
+  })
+
+  it('reports a pending-refresh error instead of a generic PTY timeout', async () => {
+    const ptyHandlers: { onData?: (data: string) => void } = {}
+
+    childSpawnMock.mockImplementation(() => {
+      throw new Error('rpc unavailable')
+    })
+    ptySpawnMock.mockReturnValue({
+      onData: vi.fn((callback) => {
+        ptyHandlers.onData = callback
+        return makeDisposable()
+      }),
+      onExit: vi.fn(() => makeDisposable()),
+      write: vi.fn(),
+      kill: vi.fn()
+    })
+
+    const resultPromise = fetchCodexRateLimits()
+    await vi.advanceTimersByTimeAsync(0)
+
+    ptyHandlers.onData?.('>')
+    ptyHandlers.onData?.('Limits: refresh requested; run /status again shortly.\n')
+    await vi.advanceTimersByTimeAsync(15_000)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      status: 'error',
+      error: 'Codex usage refresh still pending — try again shortly'
     })
   })
 })

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -1179,6 +1179,7 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
           clearPtyTimers()
           cleanupHiddenRateLimitPty(term, termDisposables, { kill: true })
 
+          // Re-strip after the settle delay so trailing chunks are included.
           const settledClean = stripPtyControlSequences(output)
           const { session, weekly } = parsePtyStatus(settledClean)
 

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -892,6 +892,12 @@ const FIVE_HOUR_RE = /(?<![\w-][^\S\r\n]{0,4})5h\s+limit[^\d%\r\n]*(\d+)%(?:\s*(
 const WEEKLY_RE = /(?<![\w-][^\S\r\n]{0,4})weekly\s+limit[^\d%\r\n]*(\d+)%(?:\s*(used|left))?/i
 // Why: model-scoped limit rows must still stop a per-window reset-text scan.
 const ANY_LIMIT_LABEL_RE = /(?:5h|weekly)\s+limit/i
+// Why: Codex 0.144+ often answers the first /status with an async placeholder
+// ("refresh requested; run /status again shortly") before percent limits appear.
+const STATUS_REFRESH_PENDING_RE = /refresh requested|run\s+\/status\s+again/i
+const STATUS_RETRY_DELAY_MS = 750
+const MAX_STATUS_ATTEMPTS = 2
+const STATUS_REFRESH_PENDING_ERROR = 'Codex usage refresh still pending — try again shortly'
 
 // eslint-disable-next-line no-control-regex
 const PTY_CONTROL_SEQUENCE_RE = /\x1b\[[0-?]*[ -/]*[@-~]/g
@@ -951,6 +957,20 @@ function parsePtyStatus(output: string): {
   return { session, weekly }
 }
 
+function describePtyStatusFailure(output: string, fallback: string): string {
+  const clean = stripPtyControlSequences(output)
+  const authError = extractCodexAuthError(clean)
+  if (authError) {
+    return authError
+  }
+  // Why: distinguish "CLI never answered" from "CLI answered but limits were
+  // still pending" so the status bar does not blame a false PTY hang.
+  if (STATUS_REFRESH_PENDING_RE.test(clean)) {
+    return STATUS_REFRESH_PENDING_ERROR
+  }
+  return withMacTailscaleDnsHint(fallback, clean)
+}
+
 async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<ProviderRateLimits> {
   if (options?.signal?.aborted) {
     return abortedCodexRateLimitResult()
@@ -971,6 +991,8 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
     let output = ''
     let resolved = false
     let sentStatus = false
+    let statusAttempts = 0
+    let statusRetryTimer: ReturnType<typeof setTimeout> | null = null
     let settleTimer: ReturnType<typeof setTimeout> | null = null
     let timeout: ReturnType<typeof setTimeout> | null = null
 
@@ -990,6 +1012,7 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
     let statusEnter: ReturnType<typeof setTimeout> | null = null
     function sendStatusCommand(): void {
       sentStatus = true
+      statusAttempts += 1
       if (statusNudge) {
         clearTimeout(statusNudge)
         statusNudge = null
@@ -1034,11 +1057,7 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
       }
     })
 
-    function settleAborted(): void {
-      if (resolved) {
-        return
-      }
-      resolved = true
+    function clearPtyTimers(): void {
       if (timeout) {
         clearTimeout(timeout)
         timeout = null
@@ -1047,8 +1066,35 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
         clearTimeout(settleTimer)
         settleTimer = null
       }
+      if (statusRetryTimer) {
+        clearTimeout(statusRetryTimer)
+        statusRetryTimer = null
+      }
+    }
+
+    function settleAborted(): void {
+      if (resolved) {
+        return
+      }
+      resolved = true
+      clearPtyTimers()
       cleanupHiddenRateLimitPty(term, termDisposables, { kill: true })
       resolve(abortedCodexRateLimitResult())
+    }
+
+    function scheduleStatusRetry(): void {
+      if (resolved || statusRetryTimer || statusAttempts >= MAX_STATUS_ATTEMPTS) {
+        return
+      }
+      // Why: first /status often only queues a backend refresh; one delayed
+      // retry is enough for the second panel to include percent limits.
+      statusRetryTimer = setTimeout(() => {
+        statusRetryTimer = null
+        if (resolved || statusAttempts >= MAX_STATUS_ATTEMPTS) {
+          return
+        }
+        sendStatusCommand()
+      }, STATUS_RETRY_DELAY_MS)
     }
 
     if (options?.signal) {
@@ -1065,17 +1111,14 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
     timeout = setTimeout(() => {
       if (!resolved) {
         resolved = true
-        if (settleTimer) {
-          clearTimeout(settleTimer)
-          settleTimer = null
-        }
+        clearPtyTimers()
         cleanupHiddenRateLimitPty(term, termDisposables, { kill: true })
         resolve({
           provider: 'codex',
           session: null,
           weekly: null,
           updatedAt: Date.now(),
-          error: extractCodexAuthError(output) ?? withMacTailscaleDnsHint('PTY timeout', output),
+          error: describePtyStatusFailure(output, 'PTY timeout'),
           status: 'error'
         })
       }
@@ -1091,14 +1134,7 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
       const authError = extractCodexAuthError(output)
       if (authError) {
         resolved = true
-        if (timeout) {
-          clearTimeout(timeout)
-          timeout = null
-        }
-        if (settleTimer) {
-          clearTimeout(settleTimer)
-          settleTimer = null
-        }
+        clearPtyTimers()
         cleanupHiddenRateLimitPty(term, termDisposables, { kill: true })
         resolve({
           provider: 'codex',
@@ -1119,10 +1155,20 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
         return
       }
 
+      // Why: pending-refresh and limit detection must both survive styled TUI output.
+      const clean = sentStatus ? stripPtyControlSequences(output) : ''
+
+      if (
+        sentStatus &&
+        statusAttempts < MAX_STATUS_ATTEMPTS &&
+        STATUS_REFRESH_PENDING_RE.test(clean)
+      ) {
+        scheduleStatusRetry()
+      }
+
       // Check if we have parseable output
       // Why: colored meter bars embed digits inside CSI sequences, so probe cleaned text.
-      const probe = sentStatus && !settleTimer ? stripPtyControlSequences(output) : null
-      if (probe !== null && (FIVE_HOUR_RE.test(probe) || WEEKLY_RE.test(probe))) {
+      if (sentStatus && !settleTimer && (FIVE_HOUR_RE.test(clean) || WEEKLY_RE.test(clean))) {
         // Why: the TUI keeps streaming after status is parseable; one settle timer lets the panel finish flushing.
         settleTimer = setTimeout(() => {
           settleTimer = null
@@ -1130,14 +1176,11 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
             return
           }
           resolved = true
-          if (timeout) {
-            clearTimeout(timeout)
-            timeout = null
-          }
+          clearPtyTimers()
           cleanupHiddenRateLimitPty(term, termDisposables, { kill: true })
 
-          const clean = stripPtyControlSequences(output)
-          const { session, weekly } = parsePtyStatus(clean)
+          const settledClean = stripPtyControlSequences(output)
+          const { session, weekly } = parsePtyStatus(settledClean)
 
           resolve({
             provider: 'codex',
@@ -1147,7 +1190,7 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
             error:
               session || weekly
                 ? null
-                : withMacTailscaleDnsHint('Failed to parse CLI output', clean),
+                : withMacTailscaleDnsHint('Failed to parse CLI output', settledClean),
             status: session || weekly ? 'ok' : 'error'
           })
         }, 500)
@@ -1159,16 +1202,9 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
 
     const onExitDisposable = term.onExit(() => {
       cleanupHiddenRateLimitPty(term, termDisposables, { kill: false })
-      if (settleTimer) {
-        clearTimeout(settleTimer)
-        settleTimer = null
-      }
       if (!resolved) {
         resolved = true
-        if (timeout) {
-          clearTimeout(timeout)
-          timeout = null
-        }
+        clearPtyTimers()
         const clean = stripPtyControlSequences(output)
         const { session, weekly } = parsePtyStatus(clean)
         resolve({
@@ -1179,8 +1215,7 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
           error:
             session || weekly
               ? null
-              : (extractCodexAuthError(clean) ??
-                withMacTailscaleDnsHint('CLI exited before status was available', clean)),
+              : describePtyStatusFailure(output, 'CLI exited before status was available'),
           status: session || weekly ? 'ok' : 'error'
         })
       }

--- a/src/renderer/src/components/settings/codex-account-auth-warning.test.ts
+++ b/src/renderer/src/components/settings/codex-account-auth-warning.test.ts
@@ -29,6 +29,11 @@ describe('codex account auth warning', () => {
         'Error loading configuration: Your authentication session could not be refreshed automatically.'
       )
     ).toBe(true)
+    expect(
+      isCodexAuthError(
+        'Your authentication token has been invalidated. Please try signing in again.'
+      )
+    ).toBe(true)
   })
 
   it('does not treat generic Codex availability failures as auth errors', () => {

--- a/src/shared/codex-auth-errors.test.ts
+++ b/src/shared/codex-auth-errors.test.ts
@@ -12,6 +12,21 @@ describe('isCodexAuthError', () => {
     expect(isCodexAuthError('plain provider error')).toBe(false)
     expect(isCodexAuthError(null)).toBe(false)
   })
+
+  it('matches token_invalidated / signing-in-again usage API failures', () => {
+    expect(
+      isCodexAuthError(
+        'Your authentication token has been invalidated. Please try signing in again.'
+      )
+    ).toBe(true)
+    expect(isCodexAuthError('auth error code: token_invalidated')).toBe(true)
+    expect(
+      isCodexAuthError(
+        'failed to fetch codex rate limits: GET https://chatgpt.com/backend-api/wham/usage failed: 401 Unauthorized; body={"error":{"message":"Your authentication token has been invalidated. Please try signing in again.","code":"token_invalidated"}}'
+      )
+    ).toBe(true)
+    expect(isCodexAuthError('RPC timeout')).toBe(false)
+  })
 })
 
 describe('extractCodexAuthError', () => {

--- a/src/shared/codex-auth-errors.ts
+++ b/src/shared/codex-auth-errors.ts
@@ -1,9 +1,16 @@
+// Why: Codex surface text drifts across app-server vs CLI (e.g. "sign in" vs
+// "signing in", plus machine codes like token_invalidated). Keep this list
+// broad enough that quota refresh stops at re-auth instead of PTY fallback.
 const CODEX_AUTH_ERROR_PATTERNS = [
   /access token could not be refreshed/i,
   /authentication session could not be refreshed/i,
+  /authentication token has been invalidated/i,
+  /token_invalidated/i,
   /refresh token (?:has expired|was already used|was revoked)/i,
   /you have since logged out or signed in to another account/i,
-  /please (?:log out and )?sign in again/i,
+  // "Please sign in again" / "Please log out and sign in again" /
+  // "Please try signing in again" (Codex 0.144+ usage API wording)
+  /please (?:try )?(?:log out and )?sign(?:ing)? in again/i,
   /please reauthenticate/i,
   /not logged in/i,
   /sign in with chatgpt/i,

--- a/src/shared/codex-auth-errors.ts
+++ b/src/shared/codex-auth-errors.ts
@@ -1,6 +1,4 @@
-// Why: Codex surface text drifts across app-server vs CLI (e.g. "sign in" vs
-// "signing in", plus machine codes like token_invalidated). Keep this list
-// broad enough that quota refresh stops at re-auth instead of PTY fallback.
+// Why: auth wording drifts across app-server and CLI; match stable machine codes and known user-facing variants.
 const CODEX_AUTH_ERROR_PATTERNS = [
   /access token could not be refreshed/i,
   /authentication session could not be refreshed/i,
@@ -8,8 +6,7 @@ const CODEX_AUTH_ERROR_PATTERNS = [
   /token_invalidated/i,
   /refresh token (?:has expired|was already used|was revoked)/i,
   /you have since logged out or signed in to another account/i,
-  // "Please sign in again" / "Please log out and sign in again" /
-  // "Please try signing in again" (Codex 0.144+ usage API wording)
+  // Covers "sign in", "log out and sign in", and "try signing in" variants.
   /please (?:try )?(?:log out and )?sign(?:ing)? in again/i,
   /please reauthenticate/i,
   /not logged in/i,


### PR DESCRIPTION
## Summary

Fixes Codex status-bar usage refresh showing **Refresh failed / PTY timeout** when the real problem is an invalidated token, and when Codex 0.144+ answers `/status` with an async "refresh requested" placeholder instead of percent limits.

- Classify `token_invalidated` / "Please try **signing** in again" as auth errors so RPC failures stop at re-auth instead of falling through to the hidden PTY fallback.
- On PTY fallback, retry `/status` once when Codex reports `refresh requested; run /status again shortly`.
- Prefer a pending-refresh error over a generic **PTY timeout** when limits never arrive.

Fixes #9377

## User-visible change

- Invalidated Codex sessions surface a re-auth-style error instead of a misleading **PTY timeout**.
- Valid sessions on Codex 0.144+ are more likely to get usage after the async `/status` retry.
- Timeout path is clearer when usage is still pending.

## Test plan

- [x] `vitest` for `codex-auth-errors`, `codex-fetcher-auth-errors`, `codex-fetcher-pty-settle`, `codex-account-auth-warning`, `codex-fetcher` (34 tests)
- [ ] Manual: with invalidated token, status-bar refresh shows auth error and does not wait ~15s for PTY
- [ ] Manual: after `codex login`, usage refresh succeeds without PTY timeout
- [ ] Manual: Codex 0.144+ first `/status` "refresh requested" path recovers on retry when auth is valid

## AI coding-agent review summary

- **Cross-platform:** Auth classification is shared TS; PTY retry remains macOS/Linux-only (Windows already disables Codex PTY fallback).
- **SSH/remote:** Unchanged; WSL/host paths still go through the same fetcher options.
- **Agent/integration:** Only quota refresh / status-bar path; does not change agent spawn or session resume.
- **Performance:** Skips a 15s hidden PTY spawn on classified auth failures; one extra `/status` write only when the pending-refresh panel is seen.
- **UI quality:** Clearer error strings for pending refresh vs hang; re-auth warnings can now match the live Codex wording.
- **Security:** No secrets logged; patterns match public CLI/API error text only.

## Platform / remote notes

- Reproduced on macOS arm64 with Codex CLI 0.144.6 and Orca-managed `CODEX_HOME`.
- Does not require host PTY exhaustion; can fail with healthy PTY counts when auth is invalidated.

## ELI5

When Codex auth was bad, the status bar said "PTY timeout" instead of asking you to sign in again. Auth failures are classified properly, and newer Codex "refresh requested" answers get a sensible retry instead of a fake timeout.
