### PR TITLE
perf(preflight): fs-based PATH resolution for agent detection (no where/which spawn) (#9297)

### DIFF
--- a/src/main/ipc/command-path-resolver.test.ts
+++ b/src/main/ipc/command-path-resolver.test.ts
@@ -1,0 +1,110 @@
+import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { isCommandOnLocalPath } from './command-path-resolver'
+
+describe('isCommandOnLocalPath', () => {
+  it('returns false for an empty command', async () => {
+    await expect(isCommandOnLocalPath('')).resolves.toBe(false)
+  })
+
+  // POSIX semantics: executable bit + absolute-only + symlink follow.
+  describe.skipIf(process.platform === 'win32')('posix', () => {
+    let dir = ''
+    beforeAll(async () => {
+      dir = await mkdtemp(path.join(tmpdir(), 'cmd-resolver-posix-'))
+      await writeFile(path.join(dir, 'runme'), '#!/bin/sh\n')
+      await chmod(path.join(dir, 'runme'), 0o755)
+      await writeFile(path.join(dir, 'plain'), 'not executable\n')
+      await chmod(path.join(dir, 'plain'), 0o644)
+      await mkdir(path.join(dir, 'adir'))
+      await symlink(path.join(dir, 'runme'), path.join(dir, 'linkme'))
+    })
+    afterAll(async () => {
+      await rm(dir, { recursive: true, force: true })
+    })
+
+    it('finds an executable file on PATH', async () => {
+      await expect(
+        isCommandOnLocalPath('runme', { platform: 'linux', env: { PATH: dir } })
+      ).resolves.toBe(true)
+    })
+
+    it('rejects a non-executable file on PATH', async () => {
+      await expect(
+        isCommandOnLocalPath('plain', { platform: 'linux', env: { PATH: dir } })
+      ).resolves.toBe(false)
+    })
+
+    it('rejects a directory whose name matches the command', async () => {
+      await expect(
+        isCommandOnLocalPath('adir', { platform: 'linux', env: { PATH: dir } })
+      ).resolves.toBe(false)
+    })
+
+    it('follows a symlink to an executable', async () => {
+      await expect(
+        isCommandOnLocalPath('linkme', { platform: 'linux', env: { PATH: dir } })
+      ).resolves.toBe(true)
+    })
+
+    it('returns false when PATH is empty', async () => {
+      await expect(
+        isCommandOnLocalPath('runme', { platform: 'linux', env: { PATH: '' } })
+      ).resolves.toBe(false)
+    })
+
+    it('resolves an absolute command path directly', async () => {
+      await expect(
+        isCommandOnLocalPath(path.join(dir, 'runme'), { platform: 'linux', env: { PATH: '' } })
+      ).resolves.toBe(true)
+    })
+
+    it('rejects a match reached via a relative PATH entry (absolute-only gate)', async () => {
+      await expect(
+        isCommandOnLocalPath('runme', { platform: 'linux', env: { PATH: '.' }, cwd: dir })
+      ).resolves.toBe(false)
+    })
+  })
+
+  // Win32 semantics tested cross-platform via the explicit `platform` option:
+  // PATHEXT resolution + case-insensitive `Path` key.
+  describe('win32 (synthetic)', () => {
+    let dir = ''
+    beforeAll(async () => {
+      dir = await mkdtemp(path.join(tmpdir(), 'cmd-resolver-win32-'))
+      await writeFile(path.join(dir, 'tool.cmd'), '@echo off\n')
+    })
+    afterAll(async () => {
+      await rm(dir, { recursive: true, force: true })
+    })
+
+    it('resolves a bare command via PATHEXT using the case-insensitive Path key', async () => {
+      await expect(
+        isCommandOnLocalPath('tool', {
+          platform: 'win32',
+          env: { Path: dir, PATHEXT: '.COM;.EXE;.CMD;.BAT' }
+        })
+      ).resolves.toBe(true)
+    })
+
+    it('returns false when PATHEXT excludes the only available extension', async () => {
+      await expect(
+        isCommandOnLocalPath('tool', {
+          platform: 'win32',
+          env: { Path: dir, PATHEXT: '.EXE;.COM' }
+        })
+      ).resolves.toBe(false)
+    })
+
+    it('matches an exact name with extension already present', async () => {
+      await expect(
+        isCommandOnLocalPath('tool.cmd', {
+          platform: 'win32',
+          env: { Path: dir, PATHEXT: '.EXE' }
+        })
+      ).resolves.toBe(true)
+    })
+  })
+})

--- a/src/main/ipc/command-path-resolver.test.ts
+++ b/src/main/ipc/command-path-resolver.test.ts
@@ -74,7 +74,12 @@ describe('isCommandOnLocalPath', () => {
     let dir = ''
     beforeAll(async () => {
       dir = await mkdtemp(path.join(tmpdir(), 'cmd-resolver-win32-'))
-      await writeFile(path.join(dir, 'tool.cmd'), '@echo off\n')
+      // Why: the fixture extension matches a PATHEXT entry's case exactly so these
+      // tests are filesystem-portable. Real Windows resolves `.CMD` vs `.cmd`
+      // case-insensitively via the FS itself (same as where.exe); we deliberately
+      // do NOT emulate that in the resolver, so we must not depend on a
+      // case-insensitive FS here — this suite also runs on case-sensitive Linux CI.
+      await writeFile(path.join(dir, 'tool.CMD'), '@echo off\n')
     })
     afterAll(async () => {
       await rm(dir, { recursive: true, force: true })
@@ -100,7 +105,7 @@ describe('isCommandOnLocalPath', () => {
 
     it('matches an exact name with extension already present', async () => {
       await expect(
-        isCommandOnLocalPath('tool.cmd', {
+        isCommandOnLocalPath('tool.CMD', {
           platform: 'win32',
           env: { Path: dir, PATHEXT: '.EXE' }
         })

--- a/src/main/ipc/command-path-resolver.ts
+++ b/src/main/ipc/command-path-resolver.ts
@@ -1,0 +1,106 @@
+import { access, constants as fsConstants, stat } from 'node:fs/promises'
+import path from 'node:path'
+
+export type ResolveCommandOptions = {
+  /** Defaults to `process.platform`. Lets tests exercise the win32 lookup on posix. */
+  platform?: NodeJS.Platform
+  /** Env whose PATH/PATHEXT to search. Defaults to `process.env`. */
+  env?: NodeJS.ProcessEnv
+  /** CWD used only for the win32 "search current directory first" rule. */
+  cwd?: string
+}
+
+// Why: Windows env keys are case-insensitive (PATH is usually stored as `Path`,
+// PATHEXT as `PathExt`), but the merged env object we search is a plain,
+// case-sensitive Record — so look the key up case-insensitively.
+function readEnvCaseInsensitive(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const direct = env[key]
+  if (direct !== undefined) {
+    return direct
+  }
+  const lowerKey = key.toLowerCase()
+  for (const [envKey, value] of Object.entries(env)) {
+    if (envKey.toLowerCase() === lowerKey) {
+      return value
+    }
+  }
+  return undefined
+}
+
+function getWindowsExtensions(env: NodeJS.ProcessEnv, command: string): string[] {
+  const pathext = readEnvCaseInsensitive(env, 'PATHEXT') ?? '.EXE;.CMD;.BAT;.COM'
+  const extensions = pathext.split(';').filter((ext) => ext.length > 0)
+  // Why: when the command already carries an extension (e.g. `node.exe`), an
+  // exact-name match must be allowed alongside the PATHEXT permutations.
+  if (command.includes('.')) {
+    extensions.unshift('')
+  }
+  return extensions
+}
+
+async function isExecutableFile(candidate: string, isWin: boolean): Promise<boolean> {
+  try {
+    // Why: stat (not lstat) so symlinked CLIs resolve to their real target.
+    const stats = await stat(candidate)
+    if (stats.isDirectory()) {
+      // Why: PATH dirs carry the search/exec bit; reject them like `[ ! -d ]`.
+      return false
+    }
+    if (isWin) {
+      // Extension membership already enforced by the PATHEXT permutation.
+      return stats.isFile()
+    }
+    await access(candidate, fsConstants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Resolve whether `command` is an executable on PATH using only `node:fs`
+ * — zero `where`/`which` subprocess spawns. Mirrors the canonical
+ * which(1)/where.exe lookup, including the current preflight quirk that only
+ * counts matches which resolve to an ABSOLUTE path (so relative PATH entries
+ * and relative command paths stay not-found, exactly as before).
+ */
+export async function isCommandOnLocalPath(
+  command: string,
+  options: ResolveCommandOptions = {}
+): Promise<boolean> {
+  if (!command) {
+    return false
+  }
+  const platform = options.platform ?? process.platform
+  const env = options.env ?? process.env
+  const cwd = options.cwd ?? process.cwd()
+  const isWin = platform === 'win32'
+  // Why: apply platform-correct absolute-path semantics (e.g. `C:\..` is
+  // absolute on win32 but not posix) for the same-as-before isAbsolute gate.
+  const isAbsolute = isWin ? path.win32.isAbsolute : path.posix.isAbsolute
+  const delimiter = isWin ? ';' : ':'
+
+  const hasPathSeparator = command.includes('/') || (isWin && command.includes('\\'))
+  const pathDirs = (readEnvCaseInsensitive(env, 'PATH') ?? '').split(delimiter)
+  // Why: a slash short-circuits PATH (resolve the command directly), matching
+  // which(1). On win32, where.exe searches the current directory first.
+  const searchDirs = hasPathSeparator ? [''] : isWin ? [cwd, ...pathDirs] : pathDirs
+  const extensions = isWin ? getWindowsExtensions(env, command) : ['']
+
+  for (const dir of searchDirs) {
+    for (const ext of extensions) {
+      // Why: forward-slash joins so candidates are statable on every platform
+      // (Windows fs accepts `/`), keeping the win32 lookup testable off-Windows.
+      const candidate = path.posix.join(dir, command) + ext
+      // Why: preserve the prior `.some(line => path.isAbsolute(line))` filter
+      // over where/which stdout — only absolute resolutions count.
+      if (!isAbsolute(candidate)) {
+        continue
+      }
+      if (await isExecutableFile(candidate, isWin)) {
+        return true
+      }
+    }
+  }
+  return false
+}

--- a/src/main/ipc/preflight-agent-detection-no-subprocess.test.ts
+++ b/src/main/ipc/preflight-agent-detection-no-subprocess.test.ts
@@ -1,0 +1,117 @@
+/* Regression pin for #9297: local agent detection must resolve executables
+ * against PATH with fs and spawn ZERO where/which subprocesses. On unfixed
+ * code this fails because detectInstalledAgents spawns one `where`/`which`
+ * process per probe command (>=20). See the read-only repro in comment-scan:
+ * repro-9297-where-per-agent-probe.test.ts (which pins the OLD, buggy count).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  handleMock,
+  execFileMock,
+  execFileAsyncMock,
+  hydrateShellPathMock,
+  mergePathSegmentsMock,
+  getActiveMultiplexerMock,
+  getBitbucketAuthStatusMock,
+  getAzureDevOpsAuthStatusMock,
+  getGiteaAuthStatusMock,
+  detectCommandsInInstallDirsMock,
+  mergePersistedWindowsPathMock
+} = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  execFileMock: vi.fn(),
+  execFileAsyncMock: vi.fn(),
+  hydrateShellPathMock: vi.fn(),
+  mergePathSegmentsMock: vi.fn(),
+  getActiveMultiplexerMock: vi.fn(),
+  getBitbucketAuthStatusMock: vi.fn(),
+  getAzureDevOpsAuthStatusMock: vi.fn(),
+  getGiteaAuthStatusMock: vi.fn(),
+  detectCommandsInInstallDirsMock: vi.fn(),
+  mergePersistedWindowsPathMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({ ipcMain: { handle: handleMock } }))
+
+vi.mock('child_process', () => {
+  const execFileWithPromisify = Object.assign(execFileMock, {
+    [Symbol.for('nodejs.util.promisify.custom')]: execFileAsyncMock
+  })
+  return { execFile: execFileWithPromisify, spawn: vi.fn() }
+})
+
+vi.mock('../startup/hydrate-shell-path', () => ({
+  hydrateShellPath: hydrateShellPathMock,
+  mergePathSegments: mergePathSegmentsMock
+}))
+
+vi.mock('./ssh', () => ({ getActiveMultiplexer: getActiveMultiplexerMock }))
+vi.mock('../bitbucket/client', () => ({ getBitbucketAuthStatus: getBitbucketAuthStatusMock }))
+vi.mock('../azure-devops/client', () => ({
+  getAzureDevOpsAuthStatus: getAzureDevOpsAuthStatusMock
+}))
+vi.mock('../gitea/client', () => ({ getGiteaAuthStatus: getGiteaAuthStatusMock }))
+
+// Isolate the subprocess-spawn assertion from the fs-based install-dir fallback.
+vi.mock('./local-agent-install-dir-detection', () => ({
+  detectCommandsInInstallDirs: detectCommandsInInstallDirsMock
+}))
+
+// Win32 preflight env merge reads persisted registry PATH; stub it out.
+vi.mock('../pty/windows-environment-path', () => ({
+  mergePersistedWindowsPath: mergePersistedWindowsPathMock
+}))
+
+import { _resetPreflightCache, detectInstalledAgents } from './preflight'
+import {
+  getTuiAgentDetectionProbeCommands,
+  KNOWN_TUI_AGENT_DETECTION_COMMANDS
+} from './tui-agent-detection-commands'
+
+describe('#9297: local agent detection spawns zero where/which subprocesses', () => {
+  const originalPlatform = process.platform
+  const originalPath = process.env.PATH
+
+  beforeEach(() => {
+    execFileAsyncMock.mockReset()
+    execFileMock.mockReset()
+    // Any spawn attempt is the bug; make it explode so a regression is loud.
+    execFileAsyncMock.mockImplementation(async (command: string) => {
+      throw new Error(`unexpected subprocess spawn: ${command}`)
+    })
+    detectCommandsInInstallDirsMock.mockReset()
+    detectCommandsInInstallDirsMock.mockReturnValue(new Set<string>())
+    // Empty PATH -> deterministic "no agents found" regardless of the host's
+    // real installed CLIs, so the assertion is stable on any dev machine.
+    process.env.PATH = ''
+    _resetPreflightCache()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    process.env.PATH = originalPath
+  })
+
+  for (const platform of ['win32', 'darwin'] as const) {
+    it(`resolves via fs (no where/which spawn) on ${platform}`, async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+
+      const probeCommands = getTuiAgentDetectionProbeCommands(
+        KNOWN_TUI_AGENT_DETECTION_COMMANDS,
+        platform
+      )
+      // Guardrail: the candidate list is large, so the old one-spawn-per-probe
+      // path multiplied a gated where.exe across dozens of startups.
+      expect(probeCommands.length).toBeGreaterThanOrEqual(20)
+
+      const agents = await detectInstalledAgents()
+
+      // Perf-win lock: before the fix this was probeCommands.length (>=20);
+      // after the fix it is exactly 0.
+      expect(execFileAsyncMock).toHaveBeenCalledTimes(0)
+      // Behavior preserved: empty PATH resolves nothing.
+      expect(agents).toEqual([])
+    })
+  }
+})

--- a/src/main/ipc/preflight-command-exec.ts
+++ b/src/main/ipc/preflight-command-exec.ts
@@ -2,6 +2,7 @@ import { execFile } from 'node:child_process'
 import path from 'node:path'
 import { promisify } from 'node:util'
 import { buildPosixCommandPathLookupScript } from '../../shared/posix-command-path-lookup'
+import { isCommandOnLocalPath } from './command-path-resolver'
 import { buildLocalPreflightEnv } from './preflight-local-env'
 import { runPreflightCommandInWsl } from './preflight-wsl-command'
 import type { WslPreflightTarget } from './preflight-wsl-agent-detection'
@@ -80,34 +81,32 @@ export async function isCommandOnPath(
   command: string,
   wslTarget?: WslPreflightTarget
 ): Promise<boolean> {
-  const finder = process.platform === 'win32' ? 'where' : 'which'
+  if (!wslTarget) {
+    // Why (#9297): resolve against PATH with fs instead of spawning one
+    // where/which subprocess per probe — privilege-management software gates
+    // each spawn and stalls startup. buildLocalPreflightEnv() supplies the same
+    // registry-merged PATH the child process previously saw (undefined = posix
+    // process.env), so the found/not-found result is identical.
+    return isCommandOnLocalPath(command, { env: buildLocalPreflightEnv() })
+  }
   try {
-    const { stdout } = wslTarget
-      ? // Why: preflight must validate the executable on PATH, not a shell alias or function.
-        await execCommandInWsl(
-          wslTarget,
-          [
-            buildPosixCommandPathLookupScript({ kind: 'literal', value: command }),
-            'if [ -n "$resolved" ]; then',
-            `printf '${WSL_COMMAND_PATH_SENTINEL}%s\\n' "$resolved"`,
-            'fi'
-          ].join('\n')
-        )
-      : await execLocalPreflightCommand(finder, [command])
-    if (wslTarget) {
-      // Why: WSL startup chatter can contain unrelated absolute paths.
-      return stdout
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .filter((line) => line.startsWith(WSL_COMMAND_PATH_SENTINEL))
-        .map((line) => line.slice(WSL_COMMAND_PATH_SENTINEL.length))
-        .some((line) => path.posix.isAbsolute(line))
-    }
-
+    // Why: preflight must validate the executable on PATH, not a shell alias or function.
+    const { stdout } = await execCommandInWsl(
+      wslTarget,
+      [
+        buildPosixCommandPathLookupScript({ kind: 'literal', value: command }),
+        'if [ -n "$resolved" ]; then',
+        `printf '${WSL_COMMAND_PATH_SENTINEL}%s\\n' "$resolved"`,
+        'fi'
+      ].join('\n')
+    )
+    // Why: WSL startup chatter can contain unrelated absolute paths.
     return stdout
       .split(/\r?\n/)
       .map((line) => line.trim())
-      .some((line) => path.isAbsolute(line))
+      .filter((line) => line.startsWith(WSL_COMMAND_PATH_SENTINEL))
+      .map((line) => line.slice(WSL_COMMAND_PATH_SENTINEL.length))
+      .some((line) => path.posix.isAbsolute(line))
   } catch {
     return false
   }

--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- Why: preflight tests share expensive process/preload mocks across
    install, auth, agent detection, and refresh branches. */
+import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
@@ -13,6 +14,7 @@ const {
   getAzureDevOpsAuthStatusMock,
   getGiteaAuthStatusMock,
   resolveCliCommandsMock,
+  isCommandOnLocalPathMock,
   mergePersistedWindowsPathMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
@@ -25,6 +27,7 @@ const {
   getAzureDevOpsAuthStatusMock: vi.fn(),
   getGiteaAuthStatusMock: vi.fn(),
   resolveCliCommandsMock: vi.fn(),
+  isCommandOnLocalPathMock: vi.fn(),
   mergePersistedWindowsPathMock: vi.fn()
 }))
 
@@ -51,6 +54,13 @@ vi.mock('../startup/hydrate-shell-path', () => ({
 
 vi.mock('../codex-cli/command', () => ({
   resolveCliCommands: resolveCliCommandsMock
+}))
+
+// Why (#9297): local PATH resolution is now fs-based (no where/which spawn).
+// These tests express "which commands are on PATH" via the where/which mock,
+// so route the resolver through that same mock to preserve their intent.
+vi.mock('./command-path-resolver', () => ({
+  isCommandOnLocalPath: isCommandOnLocalPathMock
 }))
 
 vi.mock('../pty/windows-environment-path', () => ({
@@ -119,6 +129,22 @@ describe('preflight', () => {
     resolveCliCommandsMock.mockImplementation(
       (commands: string[]) => new Map(commands.map((command) => [command, command]))
     )
+    // Why: reproduce the pre-#9297 local PATH check (spawn where/which, keep
+    // only absolute resolutions) so cases that stub the where/which mock still
+    // drive detection identically without a real subprocess.
+    isCommandOnLocalPathMock.mockReset()
+    isCommandOnLocalPathMock.mockImplementation(async (command: string) => {
+      const finder = process.platform === 'win32' ? 'where' : 'which'
+      try {
+        const { stdout } = await execFileAsyncMock(finder, [command])
+        return String(stdout)
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .some((line) => path.isAbsolute(line))
+      } catch {
+        return false
+      }
+    })
     getBitbucketAuthStatusMock.mockResolvedValue(defaultBitbucketStatus)
     getAzureDevOpsAuthStatusMock.mockResolvedValue(defaultAzureDevOpsStatus)
     getGiteaAuthStatusMock.mockResolvedValue(defaultGiteaStatus)


### PR DESCRIPTION
## Description

On startup Orca probes for ~34 known agent CLIs to see which are installed. Each probe called `isCommandOnPath`, which spawned **one `where.exe` (win32) / `which` (posix) subprocess per candidate** — dozens of child processes during main-process boot.

Under corporate privilege-management / endpoint-security software that gates every process spawn behind an interactive approval, those dozens of gated `where.exe` spawns stall main-process startup (issue reports up to ~5 min). Same class of root cause as the macOS #5657 shell-out storm.

Root cause: `isCommandOnPath` in `src/main/ipc/preflight-command-exec.ts` (previously lines 80-96) chose `where`/`which` and ran `execLocalPreflightCommand(finder, [command])`, and `detectInstalledAgents` in `src/main/ipc/preflight.ts` calls it once for every probe command.

Fix: resolve executables against `PATH` using `node:fs` only — **zero `where`/`which` subprocess spawns** — in a new `src/main/ipc/command-path-resolver.ts` (`isCommandOnLocalPath`). It mirrors the canonical `which(1)`/`where.exe` lookup while preserving the exact found/not-found result of the old subprocess path:

- Searches each `PATH` directory; on win32 honors `PATHEXT` and case-insensitive env keys (`Path`/`PathExt`), and searches the current directory first like `where.exe`.
- On posix honors the executable bit (`X_OK`); `stat` (not `lstat`) so symlinked CLIs resolve to their real target; rejects directories.
- Preserves the prior preflight quirk that only counted matches resolving to an **absolute** path (relative PATH entries / relative command paths stay not-found), using platform-correct `isAbsolute` semantics.
- The win32 registry-merged PATH (`buildLocalPreflightEnv()`) that the child process previously inherited is passed straight to the resolver, so the search space is identical.

The WSL branch is untouched (it must run inside the WSL shell), so it still uses the existing in-shell lookup.

Fixes #9297

## Evidence (proof of improvement)

New regression pin `src/main/ipc/preflight-agent-detection-no-subprocess.test.ts` imports the real `detectInstalledAgents`, makes any subprocess spawn throw, and asserts `execFileAsync` is called **0** times on both win32 and darwin while behavior is preserved (empty PATH → `[]`):

```
✓ #9297: local agent detection spawns zero where/which subprocesses > resolves via fs (no where/which spawn) on win32 8ms
✓ #9297: local agent detection spawns zero where/which subprocesses > resolves via fs (no where/which spawn) on darwin 0ms
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Before/after spawn count (per startup, with ≥20 — actually ~34 — probe commands):

| | `where`/`which` subprocesses at startup |
|---|---|
| Before (this bug) | one per probe command (≥20; ~34 in practice) |
| After (this fix)  | **0** |

The read-only repro in the sibling worktree (`repro-9297-where-per-agent-probe.test.ts`) pins the OLD behavior: it asserts `execFileAsync` is called exactly `expectedProbes.length` times (one `where` spawn per candidate) — the behavior this PR eliminates.

New unit tests `src/main/ipc/command-path-resolver.test.ts` cover the resolver directly (posix exec-bit / directory / symlink / empty-PATH / absolute-path / relative-PATH-gate; win32 PATHEXT / case-insensitive `Path` key / exact-name-with-extension). 13 tests pass with the no-subprocess suite.

## Proof of no regression

- **Full `src/main/ipc` suite: 128 files, 1945 passed / 9 skipped.** Includes the existing `preflight.test.ts` and `preflight-command-exec.test.ts` (43 tests) which exercise install/auth/agent-detection/refresh branches.
- `preflight.test.ts` was updated to route its "which commands are on PATH" expectations through the resolver mock, reproducing the exact pre-#9297 semantics (spawn `where`/`which`, keep only absolute resolutions) so every existing detection case still drives identically — only the mechanism (fs vs subprocess) changed.
- `typecheck:tsc` for the touched `node` project (`tsconfig.node.json`): passed (exit 0).
- `oxlint` on all 5 changed/added files: passed (exit 0). Pre-commit hook (oxlint + react-doctor + oxfmt) ran clean.

Unchanged behaviors and why: WSL path resolution is untouched (still runs in-shell); the absolute-only match filter, the win32 registry-merged PATH source, and the `--version`-based `isCommandAvailable` remain exactly as before. Only the local `where`/`which` subprocess was removed.

## ELI5

When Orca starts, it checks which coding assistants you have installed by asking the operating system "where is this program?" once for each of ~34 tools — launching dozens of little helper programs. On locked-down work computers, security software pops up an approval for every single launch, which could freeze Orca's startup for up to five minutes. Now Orca just looks the programs up directly by reading the list of folders it already knows about, launching nothing extra — same answer, no freeze.

Made with [Orca](https://github.com/stablyai/orca) 🐋
