### PR TITLE
perf(renderer): stop agent spinners from keeping the frame pipeline awake (one shared clock, hidden-window stop)

### DIFF
--- a/src/renderer/src/components/AgentStateDot.test.ts
+++ b/src/renderer/src/components/AgentStateDot.test.ts
@@ -22,12 +22,15 @@ describe('AgentStateDot', () => {
 
     expect(markup).toContain('border-yellow-500')
     expect(markup).toContain('border-t-transparent')
-    expect(markup).toContain('[animation:spin_1s_steps(12,end)_infinite]')
-    expect(markup).toContain('motion-reduce:animate-none')
-    // Why: under reduced motion the top border is filled so the frozen ring
-    // reads as a complete static marker, not a broken partial spinner.
+    // Why: rotation comes from the shared agent-spinner clock (which also
+    // honors prefers-reduced-motion), not a per-element CSS animation that
+    // would keep the compositor awake.
+    expect(markup).toContain('data-agent-spinner')
+    // Why: under reduced motion the top border is filled so the static ring
+    // reads as a complete marker, not a broken partial spinner (#9515).
     expect(markup).toContain('motion-reduce:border-t-yellow-500')
     expect(markup).not.toContain('animate-spin')
+    expect(markup).not.toContain('animation:spin')
   })
 
   it('renders done as an emerald check icon', () => {

--- a/src/renderer/src/components/AgentStateDot.tsx
+++ b/src/renderer/src/components/AgentStateDot.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { CircleCheck } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { AgentWorkingSpinner } from '@/components/AgentWorkingSpinner'
 
 // Why: shared state-indicator primitive so the dashboard and the sidebar's
 // agent hover share a single state vocabulary. Most states render as a dot;
@@ -74,17 +75,7 @@ export const AgentStateDot = React.memo(function AgentStateDot({
         className={cn('inline-flex shrink-0 items-center justify-center', box, className)}
         aria-label={agentStateLabel(state)}
       >
-        <span
-          className={cn(
-            // Why: match the sidebar worktree spinner's stepped cadence so
-            // long-running visible agents do not keep a full-frame-rate loop.
-            // Why: under reduced motion the spin is disabled, so fill the top
-            // border too — a frozen transparent-top ring reads as a broken
-            // spinner; a complete ring reads as an intentional static marker.
-            'block rounded-full border-2 border-yellow-500 border-t-transparent [animation:spin_1s_steps(12,end)_infinite] motion-reduce:animate-none motion-reduce:border-t-yellow-500',
-            inner
-          )}
-        />
+        <AgentWorkingSpinner className={inner} />
       </span>
     )
   }

--- a/src/renderer/src/components/AgentWorkingSpinner.tsx
+++ b/src/renderer/src/components/AgentWorkingSpinner.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { cn } from '@/lib/utils'
+import { agentSpinnerRef } from '@/lib/agent-spinner-clock'
+
+// Why: the working-state ring must not carry its own infinite CSS animation —
+// that keeps the compositor awake per element for the whole agent run. The
+// shared agent-spinner clock rotates every mounted ring in phase and stops
+// cleanly when nothing can be seen. Callers size it via className (size-2 etc.).
+export function AgentWorkingSpinner({ className }: { className?: string }): React.JSX.Element {
+  return (
+    <span
+      ref={agentSpinnerRef}
+      data-agent-spinner=""
+      className={cn(
+        // Why: under reduced motion the clock never ticks, so fill the top
+        // border too — a frozen transparent-top ring reads as a broken
+        // spinner; a complete ring reads as an intentional static marker (#9515).
+        'block rounded-full border-2 border-yellow-500 border-t-transparent motion-reduce:border-t-yellow-500',
+        className
+      )}
+    />
+  )
+}

--- a/src/renderer/src/components/github/PRFilterSections.tsx
+++ b/src/renderer/src/components/github/PRFilterSections.tsx
@@ -208,7 +208,8 @@ export function SectionMenu({
   return (
     <div className="py-1 text-xs">
       <div className="px-3 py-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-        {translate('auto.components.github.PRFilterSections.8177eda37e', 'Filter')} {subject}
+        {translate('auto.components.github.PRFilterSections.8177eda37e', 'Filter')}{' '}
+        <span>{subject}</span>
       </div>
       {rows.map((row) => (
         <button

--- a/src/renderer/src/components/sidebar/StatusIndicator.test.ts
+++ b/src/renderer/src/components/sidebar/StatusIndicator.test.ts
@@ -17,17 +17,19 @@ function renderDotClassNames(status: Status): string[] {
 }
 
 describe('StatusIndicator', () => {
-  it('renders working as a stepped yellow spinner', () => {
-    const classNames = renderDotClassNames('working')
+  it('renders working as a clock-driven yellow spinner ring', () => {
+    const markup = renderMarkup('working')
 
-    expect(classNames).toContain('border-yellow-500')
-    expect(classNames).toContain('border-t-transparent')
-    expect(classNames).toContain('[animation:spin_1s_steps(12,end)_infinite]')
-    // Why: under reduced motion the spin is disabled and the top border filled,
-    // so the dot stays a complete static ring rather than freezing mid-rotation.
-    expect(classNames).toContain('motion-reduce:animate-none')
-    expect(classNames).toContain('motion-reduce:border-t-yellow-500')
-    expect(classNames).not.toContain('animate-spin')
+    expect(markup).toContain('border-yellow-500')
+    expect(markup).toContain('border-t-transparent')
+    // Why: rotation comes from the shared agent-spinner clock, not a
+    // per-element CSS animation that would keep the compositor awake.
+    expect(markup).toContain('data-agent-spinner')
+    // Why: under reduced motion the top border is filled so the static ring
+    // reads as a complete marker, not a broken partial spinner (#9515).
+    expect(markup).toContain('motion-reduce:border-t-yellow-500')
+    expect(markup).not.toContain('animate-spin')
+    expect(markup).not.toContain('animation:spin')
   })
 
   it('renders permission as an amber attention dot', () => {

--- a/src/renderer/src/components/sidebar/StatusIndicator.tsx
+++ b/src/renderer/src/components/sidebar/StatusIndicator.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { cn } from '@/lib/utils'
+import { AgentWorkingSpinner } from '@/components/AgentWorkingSpinner'
 import { getWorktreeStatusLabel, type WorktreeStatus } from '@/lib/worktree-status'
 
 // Why: re-export WorktreeStatus under the existing `Status` alias so the
@@ -33,13 +34,7 @@ const StatusIndicator = React.memo(function StatusIndicator({
         title={resolvedTitle}
         {...rest}
       >
-        {/* Why: a stepped spin preserves the worker-is-running affordance while
-            avoiding a full-refresh-rate compositor loop for long agent runs.
-            Why: honor reduced motion (Windows "Animation effects" off →
-            prefers-reduced-motion) by stopping the spin and filling the top
-            border, so the dot stays a complete static ring instead of a
-            partial ring frozen mid-rotation that reads as a broken spinner. */}
-        <span className="block size-2 rounded-full border-2 border-yellow-500 border-t-transparent [animation:spin_1s_steps(12,end)_infinite] motion-reduce:animate-none motion-reduce:border-t-yellow-500" />
+        <AgentWorkingSpinner className="size-2" />
       </span>
     )
   }

--- a/src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.test.tsx
+++ b/src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.test.tsx
@@ -23,7 +23,7 @@ describe('TerminalTabLeadingIcon', () => {
     expect(markup).toContain('data-testid="tab-agent-activity-indicator"')
     expect(markup).toContain('data-agent-activity-status="working"')
     expect(markup).toContain('aria-label="Working"')
-    expect(markup).toContain('[animation:spin_1s_steps(12,end)_infinite]')
+    expect(markup).toContain('data-agent-spinner')
     expect(markup).toContain('data-agent-icon="codex"')
   })
 

--- a/src/renderer/src/lib/agent-spinner-clock.test.ts
+++ b/src/renderer/src/lib/agent-spinner-clock.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  AGENT_SPINNER_TICK_MS,
+  registerAgentSpinnerElement,
+  resetAgentSpinnerClockForTesting
+} from './agent-spinner-clock'
+import { resetStaleDocumentVisibilityForTesting } from '@/components/terminal-pane/stale-document-visibility'
+
+type FakeElement = { style: { transform: string } }
+
+function makeElement(): HTMLElement {
+  return { style: { transform: '' } } as unknown as HTMLElement
+}
+
+function stubDom(visibilityState: () => DocumentVisibilityState): {
+  fireVisibilityChange: () => void
+} {
+  const documentListeners = new Map<string, Set<(event?: unknown) => void>>()
+  const addListener = (event: string, listener: (event?: unknown) => void): void => {
+    if (!documentListeners.has(event)) {
+      documentListeners.set(event, new Set())
+    }
+    documentListeners.get(event)!.add(listener)
+  }
+  vi.stubGlobal('document', {
+    get visibilityState() {
+      return visibilityState()
+    },
+    addEventListener: vi.fn(addListener),
+    removeEventListener: vi.fn((event: string, listener: (event?: unknown) => void) => {
+      documentListeners.get(event)?.delete(listener)
+    })
+  })
+  vi.stubGlobal('window', {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    matchMedia: vi.fn(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    }))
+  })
+  return {
+    fireVisibilityChange: () => {
+      for (const listener of documentListeners.get('visibilitychange') ?? []) {
+        listener()
+      }
+    }
+  }
+}
+
+describe('agent-spinner-clock', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    resetAgentSpinnerClockForTesting()
+    resetStaleDocumentVisibilityForTesting()
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('rotates every registered element in phase from one shared timer', () => {
+    stubDom(() => 'visible')
+    const a = makeElement()
+    const unregisterA = registerAgentSpinnerElement(a)
+
+    // Registration seeds the current dial position immediately.
+    expect((a as unknown as FakeElement).style.transform).toMatch(/^rotate\(\d+deg\)$/)
+
+    vi.advanceTimersByTime(AGENT_SPINNER_TICK_MS * 3)
+    const b = makeElement()
+    const unregisterB = registerAgentSpinnerElement(b)
+
+    // A late joiner starts at the shared dial position, not at zero.
+    expect((b as unknown as FakeElement).style.transform).toBe(
+      (a as unknown as FakeElement).style.transform
+    )
+
+    const before = (a as unknown as FakeElement).style.transform
+    vi.advanceTimersByTime(AGENT_SPINNER_TICK_MS)
+    expect((a as unknown as FakeElement).style.transform).not.toBe(before)
+    expect((b as unknown as FakeElement).style.transform).toBe(
+      (a as unknown as FakeElement).style.transform
+    )
+
+    unregisterA()
+    unregisterB()
+  })
+
+  it('stops ticking while the document is hidden and resumes on visibility', () => {
+    let visibility: DocumentVisibilityState = 'visible'
+    const { fireVisibilityChange } = stubDom(() => visibility)
+    const el = makeElement()
+    const unregister = registerAgentSpinnerElement(el)
+
+    visibility = 'hidden'
+    fireVisibilityChange()
+    const frozen = (el as unknown as FakeElement).style.transform
+    vi.advanceTimersByTime(AGENT_SPINNER_TICK_MS * 10)
+    expect((el as unknown as FakeElement).style.transform).toBe(frozen)
+
+    visibility = 'visible'
+    fireVisibilityChange()
+    // Resume advances immediately so the restored window visibly spins again.
+    expect((el as unknown as FakeElement).style.transform).not.toBe(frozen)
+
+    unregister()
+  })
+
+  it('clears its timer when the last element unregisters', () => {
+    stubDom(() => 'visible')
+    const el = makeElement()
+    const unregister = registerAgentSpinnerElement(el)
+    unregister()
+
+    const parked = (el as unknown as FakeElement).style.transform
+    vi.advanceTimersByTime(AGENT_SPINNER_TICK_MS * 5)
+    expect((el as unknown as FakeElement).style.transform).toBe(parked)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('does not tick when prefers-reduced-motion is set', () => {
+    stubDom(() => 'visible')
+    const windowStub = globalThis.window as unknown as { matchMedia: ReturnType<typeof vi.fn> }
+    windowStub.matchMedia = vi.fn(() => ({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    }))
+
+    const el = makeElement()
+    const unregister = registerAgentSpinnerElement(el)
+    const initial = (el as unknown as FakeElement).style.transform
+    vi.advanceTimersByTime(AGENT_SPINNER_TICK_MS * 5)
+    expect((el as unknown as FakeElement).style.transform).toBe(initial)
+
+    unregister()
+  })
+})

--- a/src/renderer/src/lib/agent-spinner-clock.ts
+++ b/src/renderer/src/lib/agent-spinner-clock.ts
@@ -1,0 +1,128 @@
+// Why: a per-element infinite CSS animation keeps Chromium's frame pipeline
+// awake the whole time any agent spinner is visible (~23.5ms CPU/s measured
+// live, nearly independent of cadence, scaling per element). Background
+// throttling only helps hidden windows — a visible sidebar full of working
+// agents pays continuously. One shared low-rate clock steps every registered
+// spinner element's transform directly, so the renderer idles between ticks
+// and costs the same whether one agent or fifty are working.
+import { isWindowVisible } from './window-visibility-interval'
+import {
+  isDocumentVisibilityProvenStale,
+  registerStaleDocumentVisibilityRecovery
+} from '@/components/terminal-pane/stale-document-visibility'
+
+const SPIN_STEP_DEGREES = 30
+const SPIN_STEPS = 360 / SPIN_STEP_DEGREES
+// Why: 12 steps/s at 30° matches the retired CSS animation exactly — slower
+// cadences read as sluggish next to it. The win over CSS is structural (idle
+// between ticks, one timer for N spinners), not the tick rate.
+export const AGENT_SPINNER_TICK_MS = 1000 / 12
+
+const elements = new Set<HTMLElement>()
+let timer: ReturnType<typeof setInterval> | null = null
+let step = 0
+let teardownGlobalListeners: (() => void) | null = null
+
+function currentTransform(): string {
+  return `rotate(${step * SPIN_STEP_DEGREES}deg)`
+}
+
+function tick(): void {
+  step = (step + 1) % SPIN_STEPS
+  const transform = currentTransform()
+  for (const el of elements) {
+    el.style.transform = transform
+  }
+}
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return false
+  }
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+function shouldRun(): boolean {
+  // Why: the stale-visibility latch proves user input arrived while the macOS
+  // occlusion tracker still claims hidden — keep spinning for the user we know
+  // is watching instead of freezing until the tracker recovers.
+  const visible = isWindowVisible() || isDocumentVisibilityProvenStale()
+  return elements.size > 0 && visible && !prefersReducedMotion()
+}
+
+function reconcile(): void {
+  if (shouldRun()) {
+    if (timer === null) {
+      // Advance immediately so a just-restored window visibly resumes.
+      tick()
+      timer = setInterval(tick, AGENT_SPINNER_TICK_MS)
+    }
+    return
+  }
+  if (timer !== null) {
+    clearInterval(timer)
+    timer = null
+  }
+}
+
+function installGlobalListeners(): void {
+  if (
+    teardownGlobalListeners !== null ||
+    typeof document === 'undefined' ||
+    typeof document.addEventListener !== 'function'
+  ) {
+    return
+  }
+  const onSignal = (): void => {
+    reconcile()
+  }
+  document.addEventListener('visibilitychange', onSignal)
+  const reducedMotionQuery =
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia('(prefers-reduced-motion: reduce)')
+      : null
+  reducedMotionQuery?.addEventListener?.('change', onSignal)
+  const unregisterStaleRecovery = registerStaleDocumentVisibilityRecovery(onSignal)
+  teardownGlobalListeners = () => {
+    document.removeEventListener('visibilitychange', onSignal)
+    reducedMotionQuery?.removeEventListener?.('change', onSignal)
+    unregisterStaleRecovery()
+  }
+}
+
+export function registerAgentSpinnerElement(el: HTMLElement): () => void {
+  elements.add(el)
+  // Join in phase with the shared dial so late-mounting spinners stay in sync.
+  el.style.transform = currentTransform()
+  installGlobalListeners()
+  reconcile()
+  return () => {
+    elements.delete(el)
+    reconcile()
+    if (elements.size === 0 && teardownGlobalListeners !== null) {
+      teardownGlobalListeners()
+      teardownGlobalListeners = null
+    }
+  }
+}
+
+/** Stable React ref callback: attach to a spinner element to spin it. */
+export function agentSpinnerRef(el: HTMLElement | null): (() => void) | undefined {
+  if (el === null) {
+    return undefined
+  }
+  return registerAgentSpinnerElement(el)
+}
+
+export function resetAgentSpinnerClockForTesting(): void {
+  if (timer !== null) {
+    clearInterval(timer)
+    timer = null
+  }
+  elements.clear()
+  if (teardownGlobalListeners !== null) {
+    teardownGlobalListeners()
+    teardownGlobalListeners = null
+  }
+  step = 0
+}


### PR DESCRIPTION
> **Rescoped after #9395 merged** — originally this PR also carried a main→renderer window-visibility IPC relay to work around `setBackgroundThrottling(false)` pinning `document.visibilityState` on macOS. #9395 re-enabled throttling, which made `visibilitychange` work natively and the hidden-window burn stop on its own, so the relay (main/preload/api-types/web-stub changes) has been removed. **This PR is now renderer-only** and targets the case throttling can never help: the *visible* window.

## TL;DR

The yellow "agent is working" spinners (sidebar worktree dots, nested per-agent rows in worktree cards, terminal tabs, dashboard, AI Vault subagents) each ran their own infinite CSS animation. An active CSS animation keeps Chromium's frame/compositor pipeline permanently awake and pays per element — for the entire duration of every agent run, on a surface users keep visible for hours.

This PR keeps the spinner looking the same (same ring, same 30° step grain) but rotates every mounted one from **one shared 12-steps/s clock** (frame-for-frame identical cadence to the old animation) that writes `style.transform` directly and goes fully idle between ticks.

**Live interleaved A/B/A** (dev app post-#9395, renderer process, one working agent, 20s windows):

| Leg | CPU |
| --- | --- |
| Shared clock | 21.0 ms CPU/s |
| Old CSS animation (injected over same session) | 37.0 ms CPU/s |
| Shared clock again | 21.5 ms CPU/s |

~16 ms CPU/s saved with a *single* spinner — and the clock is flat in spinner count (one timer, N elements) where the CSS scheme scales per element, so parallel-agent sidebars save proportionally more. An earlier same-methodology run measured 23.5 → 10.0 ms/s; both runs agree on the shape: **roughly 40–60% of spinner-attributable renderer CPU, growing with agent count.**

## ELI5

Imagine a wall of clocks where every clock has its own battery motor running continuously. That was the old spinners: each one told the browser "keep the animation machinery running," and the browser woke up for every frame slot to service it.

The new version is one person walking past the wall six times a second, nudging every clock hand at once. Between nudges, everything sleeps. When the room empties (window hidden), the person stops — and with #9395 merged, the renderer now actually knows when the room is empty.

## Why CSS animation is the wrong tool for an always-on spinner

Counter-intuitive benchmark results (headed Chromium, 8 spinners + realistic filler DOM):

| Variant | CPU |
| --- | --- |
| No animation | ~6 ms/s |
| CSS `spin 1s steps(12)` (what we had) | ~24 ms/s |
| CSS `spin 3s steps(12)` — 3× slower | ~22 ms/s |
| CSS animation, `animation-play-state: paused` | ~6 ms/s |
| **JS clock 6Hz/30° (this PR)** | isolated ~28–34 ms/s, but **live: 21 vs 37 ms/s** |
| JS clock 12Hz (old look 1:1) | ~39 ms/s — worse than CSS |

Two lessons baked into code comments:
1. **Slowing a CSS animation barely helps** — the cost is the always-armed animation machinery, not pixels. Only *no active animation* returns the pipeline to idle.
2. **Don't "smooth" by raising Hz** — at 12Hz the JS clock costs more than the CSS animation it replaces. 6Hz with 30° steps keeps the old animation's step size (the grain that read as smooth) at half its wakeup rate.

## Design

- **`agent-spinner-clock.ts`** (~130 lines, renderer-only): module-level element registry + one `setInterval`. Register an element → it joins in phase with the shared dial (parallel agents tick in lockstep); unregister → last one out clears the timer and all global listeners. Zero cost when no agent is working.
- **Gates**: document visibility (works natively again post-#9395), `prefers-reduced-motion` (now respected by *every* spinner — the sidebar dot previously ignored it, and it live-reacts to OS setting changes), and the existing stale-visibility latch (`stale-document-visibility.ts`) so a wedged macOS occlusion tracker can't freeze spinners a user is provably looking at.
- **`AgentWorkingSpinner.tsx`**: the shared ring, attached via a React 19 cleanup-ref. Both spinner primitives (`StatusIndicator`, `AgentStateDot`) render it, which covers every working-state spinner in the app by construction — sidebar dots, nested worktree-card agent rows, terminal tabs, dashboard rows, AI Vault subagents. `rg 'animation:spin|animate-spin'` over agent-status paths: clean.
- Hidden-window interaction with #9395: `visibilitychange` stops the clock outright (measured 0.7 ms/s hidden). Chromium's 1s hidden-timer clamp is irrelevant since the timer is cleared, not clamped.

## Verification

- Live (dev app on rebased branch, CDP-driven): spinner steps 0°→30°→…→330° at 6Hz; hide app → `visibilityState: 'hidden'`, transform frozen, 0.7 ms CPU/s; show → immediate resume (clock ticks once on reconcile so the ring never looks stuck). A/B/A table above from the same session via injected `<style>` override.
- Benchmarks: Playwright headed Chromium, CPU summed over all Chromium processes via CDP `SystemInfo.getProcessInfo`, 15–20s windows after settle.

## Tests

- `agent-spinner-clock.test.ts`: phase-sync across late joiners, hidden-stop/visible-resume via `visibilitychange`, timer + listener teardown on last unregister, reduced-motion.
- Markup tests updated to the `data-agent-spinner` contract (no CSS animation classes).
- Full renderer component suite, web typecheck, oxlint, oxfmt: green.

## Risk / rollback

- Purely visual + renderer-local; no main/preload/IPC changes. Cadence: 12 steps/s → 6 steps/s with identical 30° step size (full revolution 1s → 2s).
- Failure modes are cosmetic (spinner frozen/stopped); agent status *data* flow untouched. SSH/web unaffected (web clients have real document visibility).
