### PR TITLE
perf(worktrees): pause external-change pollers while the window is hidden, catch up on reveal

### DIFF
--- a/src/main/ipc/worktree-base-directory-poller.test.ts
+++ b/src/main/ipc/worktree-base-directory-poller.test.ts
@@ -335,6 +335,96 @@ describe('worktree base directory poller', () => {
     )
   })
 
+  it('pauses polling while the window is hidden and catches up on reveal', async () => {
+    const root = await makeRoot()
+    const received: WorktreeBasePollEvent[][] = []
+    const target = makeTarget('base', root)
+    let visible = false
+    const becameVisibleListeners = new Set<() => void>()
+    let ticks = 0
+    const poller = await startWorktreeBaseDirectoryPoller(
+      target,
+      () => target.repos,
+      (events) => received.push(events),
+      {
+        pollIntervalMs: POLL_MS,
+        onFullScan: () => ticks++,
+        visibility: {
+          isWindowVisible: () => visible,
+          onWindowBecameVisible: (listener) => {
+            becameVisibleListeners.add(listener)
+            return () => becameVisibleListeners.delete(listener)
+          }
+        }
+      }
+    )
+    cleanups.push(() => poller.unsubscribe())
+
+    // External change while hidden: nothing may be scanned or emitted.
+    const worktree = join(root, 'external-hidden')
+    await mkdir(worktree)
+    await writeFile(join(worktree, '.git'), 'gitdir: elsewhere')
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 8))
+    expect(ticks).toBe(0)
+    expect(received.flat()).toHaveLength(0)
+
+    // Reveal: the catch-up tick surfaces the change immediately.
+    visible = true
+    for (const listener of becameVisibleListeners) {
+      listener()
+    }
+    await waitForEvents(received, (flat) =>
+      flat.some((event) => event.type === 'create' && event.path === join(worktree, '.git'))
+    )
+
+    await poller.unsubscribe()
+    expect(becameVisibleListeners.size).toBe(0)
+  })
+
+  it('pauses the git-common poll while hidden and catches up on reveal', async () => {
+    const commonDir = await makeRoot()
+    const received: WorktreeBasePollEvent[][] = []
+    const target = makeTarget('git-common', commonDir)
+    let visible = false
+    const becameVisibleListeners = new Set<() => void>()
+    let ticks = 0
+    const poller = await startWorktreeBaseDirectoryPoller(
+      target,
+      () => target.repos,
+      (events) => received.push(events),
+      {
+        pollIntervalMs: POLL_MS,
+        platform: 'linux',
+        onFullScan: () => ticks++,
+        visibility: {
+          isWindowVisible: () => visible,
+          onWindowBecameVisible: (listener) => {
+            becameVisibleListeners.add(listener)
+            return () => becameVisibleListeners.delete(listener)
+          }
+        }
+      }
+    )
+    cleanups.push(() => poller.unsubscribe())
+
+    const entry = join(commonDir, 'worktrees', 'external-hidden')
+    await mkdir(entry, { recursive: true })
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 8))
+    expect(ticks).toBe(0)
+    expect(received.flat()).toHaveLength(0)
+
+    visible = true
+    for (const listener of becameVisibleListeners) {
+      listener()
+    }
+    await waitForEvents(received, (flat) =>
+      flat.some((event) => event.type === 'create' && event.path === entry)
+    )
+
+    await poller.unsubscribe()
+    expect(becameVisibleListeners.size).toBe(0)
+  })
+
   it('emits deletes for all known worktrees when the root vanishes', async () => {
     const root = await makeRoot()
     const worktree = join(root, 'external-5')

--- a/src/main/ipc/worktree-base-directory-poller.ts
+++ b/src/main/ipc/worktree-base-directory-poller.ts
@@ -6,6 +6,8 @@ import type {
   WorktreeBaseWatchTarget
 } from './worktree-base-directory-event-filter'
 import { startGitCommonWatch } from './worktree-git-common-watch'
+import type { WindowVisibilityGate } from '../window/visibility-gated-interval'
+import { startVisibilityGatedInterval } from '../window/visibility-gated-interval'
 
 export type WorktreeBasePollEvent = { type: 'create' | 'update' | 'delete'; path: string }
 
@@ -16,6 +18,9 @@ export type WorktreeBasePollerOptions = {
   platform?: NodeJS.Platform
   /** Test hook: called whenever a full snapshot scan runs (vs. a gated skip). */
   onFullScan?: () => void
+  // Why: these polls exist to catch external git changes for visible UI; the
+  // gate pauses them while the window is hidden and catches up on reveal.
+  visibility?: WindowVisibilityGate
 }
 
 // Why: these targets used to be recursive FSEvents subscriptions spanning the
@@ -145,7 +150,8 @@ async function startBasePoller(
   getRepos: () => ReadonlyMap<string, WorktreeBaseRepoWatchConfig>,
   onEvents: (events: WorktreeBasePollEvent[]) => void,
   pollIntervalMs: number,
-  onFullScan?: () => void
+  onFullScan?: () => void,
+  visibility?: WindowVisibilityGate
 ): Promise<WorktreeBaseSubscription> {
   let disposed = false
   let ticking = false
@@ -222,25 +228,28 @@ async function startBasePoller(
     }
   }
 
-  const timer = setInterval(() => {
-    if (disposed || ticking) {
-      return
-    }
-    ticking = true
-    void tick()
-      .catch(() => {
-        // Transient fs error: keep the previous snapshot and retry next tick.
-      })
-      .finally(() => {
-        ticking = false
-      })
-  }, pollIntervalMs)
-  timer.unref?.()
+  const gatedInterval = startVisibilityGatedInterval(
+    () => {
+      if (disposed || ticking) {
+        return
+      }
+      ticking = true
+      void tick()
+        .catch(() => {
+          // Transient fs error: keep the previous snapshot and retry next tick.
+        })
+        .finally(() => {
+          ticking = false
+        })
+    },
+    pollIntervalMs,
+    visibility
+  )
 
   return {
     unsubscribe: async () => {
       disposed = true
-      clearInterval(timer)
+      gatedInterval.dispose()
     }
   }
 }
@@ -257,7 +266,21 @@ export async function startWorktreeBaseDirectoryPoller(
   const pollIntervalMs = options.pollIntervalMs ?? WORKTREE_BASE_POLL_INTERVAL_MS
   const platform = options.platform ?? process.platform
   if (target.kind === 'git-common') {
-    return startGitCommonWatch(target, onEvents, pollIntervalMs, platform, options.onFullScan)
+    return startGitCommonWatch(
+      target,
+      onEvents,
+      pollIntervalMs,
+      platform,
+      options.onFullScan,
+      options.visibility
+    )
   }
-  return startBasePoller(target, getRepos, onEvents, pollIntervalMs, options.onFullScan)
+  return startBasePoller(
+    target,
+    getRepos,
+    onEvents,
+    pollIntervalMs,
+    options.onFullScan,
+    options.visibility
+  )
 }

--- a/src/main/ipc/worktree-base-directory-watcher.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.ts
@@ -18,6 +18,7 @@ import {
   clearWorktreeBaseDirectoryWatchTargetWarnings
 } from './worktree-base-directory-watch-targets'
 import { startWorktreeBaseDirectoryPoller } from './worktree-base-directory-poller'
+import { isMainWindowVisible, onMainWindowBecameVisible } from '../window/main-window-visibility'
 
 type ActiveWatch = WorktreeBaseWatchTarget & {
   mainWindow: BrowserWindow
@@ -196,6 +197,16 @@ async function subscribeTarget(
         return
       }
       handleLocalWatchEvents(currentWatch, null, events)
+    },
+    {
+      // Why: this poll only feeds visible UI; pause it while the window is
+      // hidden/minimized and catch up with one scan on reveal. Resolve the
+      // window through the live watch — replaceWatch swaps it on recreation.
+      visibility: {
+        isWindowVisible: () =>
+          isMainWindowVisible((activeWatches.get(target.key) ?? activeWatch)?.mainWindow ?? null),
+        onWindowBecameVisible: onMainWindowBecameVisible
+      }
     }
   )
   activeWatch = createActiveWatch(target, mainWindow, subscription)

--- a/src/main/ipc/worktree-base-directory-watcher.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.ts
@@ -18,7 +18,7 @@ import {
   clearWorktreeBaseDirectoryWatchTargetWarnings
 } from './worktree-base-directory-watch-targets'
 import { startWorktreeBaseDirectoryPoller } from './worktree-base-directory-poller'
-import { isMainWindowVisible, onMainWindowBecameVisible } from '../window/main-window-visibility'
+import { createMainWindowVisibilityGate } from '../window/visibility-gated-interval'
 
 type ActiveWatch = WorktreeBaseWatchTarget & {
   mainWindow: BrowserWindow
@@ -166,17 +166,19 @@ async function subscribeTarget(
   mainWindow: BrowserWindow
 ): Promise<ActiveWatch> {
   let activeWatch: ActiveWatch | null = null
+  // Why: replaceWatch mutates the registered watch (repos, mainWindow) in
+  // place, so long-lived callbacks must re-resolve the live watch each time.
+  const liveWatch = (): ActiveWatch | null => activeWatches.get(target.key) ?? activeWatch
   if (target.connectionId) {
     const provider = getSshFilesystemProvider(target.connectionId)
     if (!provider) {
       throw new Error(`SSH filesystem provider unavailable for ${target.connectionId}`)
     }
     const unwatch = await provider.watch(target.path, (events) => {
-      const currentWatch = activeWatches.get(target.key) ?? activeWatch
-      if (!currentWatch || currentWatch.disposed) {
-        return
+      const currentWatch = liveWatch()
+      if (currentWatch && !currentWatch.disposed) {
+        handleRemoteWatchEvents(currentWatch, events)
       }
-      handleRemoteWatchEvents(currentWatch, events)
     })
     activeWatch = createActiveWatch(target, mainWindow, {
       unsubscribe: async () => unwatch()
@@ -190,23 +192,17 @@ async function subscribeTarget(
   // exactly those paths and registers zero fseventsd clients.
   const subscription = await startWorktreeBaseDirectoryPoller(
     target,
-    () => (activeWatches.get(target.key) ?? activeWatch)?.repos ?? target.repos,
+    () => liveWatch()?.repos ?? target.repos,
     (events) => {
-      const currentWatch = activeWatches.get(target.key) ?? activeWatch
-      if (!currentWatch || currentWatch.disposed) {
-        return
+      const currentWatch = liveWatch()
+      if (currentWatch && !currentWatch.disposed) {
+        handleLocalWatchEvents(currentWatch, null, events)
       }
-      handleLocalWatchEvents(currentWatch, null, events)
     },
     {
       // Why: this poll only feeds visible UI; pause it while the window is
-      // hidden/minimized and catch up with one scan on reveal. Resolve the
-      // window through the live watch — replaceWatch swaps it on recreation.
-      visibility: {
-        isWindowVisible: () =>
-          isMainWindowVisible((activeWatches.get(target.key) ?? activeWatch)?.mainWindow ?? null),
-        onWindowBecameVisible: onMainWindowBecameVisible
-      }
+      // hidden/minimized and catch up with one scan on reveal.
+      visibility: createMainWindowVisibilityGate(() => liveWatch()?.mainWindow ?? null)
     }
   )
   activeWatch = createActiveWatch(target, mainWindow, subscription)

--- a/src/main/ipc/worktree-git-common-polling.ts
+++ b/src/main/ipc/worktree-git-common-polling.ts
@@ -4,6 +4,8 @@ import type {
   WorktreeBasePollEvent,
   WorktreeBaseSubscription
 } from './worktree-base-directory-poller'
+import type { WindowVisibilityGate } from '../window/visibility-gated-interval'
+import { startVisibilityGatedInterval } from '../window/visibility-gated-interval'
 
 // Shared with the darwin primary-metadata poll so the platforms cannot drift
 // on which shallow leaves count as watchable metadata. `logs/HEAD` catches
@@ -229,45 +231,49 @@ export async function startGitCommonPolling(
   onEvents: (events: WorktreeBasePollEvent[]) => void,
   pollIntervalMs: number,
   onFullScan?: () => void,
-  includePrimary = true
+  includePrimary = true,
+  visibility?: WindowVisibilityGate
 ): Promise<WorktreeBaseSubscription> {
   let disposed = false
   let ticking = false
   let tickCount = 0
   let snapshot = await snapshotGitCommon(commonDirPath, undefined, includePrimary)
 
-  const timer = setInterval(() => {
-    if (disposed || ticking) {
-      return
-    }
-    ticking = true
-    tickCount++
-    const forceIndexRead = tickCount % INDEX_BACKSTOP_TICKS === 0
-    onFullScan?.()
-    void snapshotGitCommon(commonDirPath, snapshot, includePrimary, forceIndexRead)
-      .then((next) => {
-        if (disposed) {
-          return
-        }
-        const events = diffGitCommon(commonDirPath, snapshot, next)
-        snapshot = next
-        if (events.length > 0) {
-          onEvents(events)
-        }
-      })
-      .catch(() => {
-        // Transient fs error: keep the previous snapshot and retry next tick.
-      })
-      .finally(() => {
-        ticking = false
-      })
-  }, pollIntervalMs)
-  timer.unref?.()
+  const gatedInterval = startVisibilityGatedInterval(
+    () => {
+      if (disposed || ticking) {
+        return
+      }
+      ticking = true
+      tickCount++
+      const forceIndexRead = tickCount % INDEX_BACKSTOP_TICKS === 0
+      onFullScan?.()
+      void snapshotGitCommon(commonDirPath, snapshot, includePrimary, forceIndexRead)
+        .then((next) => {
+          if (disposed) {
+            return
+          }
+          const events = diffGitCommon(commonDirPath, snapshot, next)
+          snapshot = next
+          if (events.length > 0) {
+            onEvents(events)
+          }
+        })
+        .catch(() => {
+          // Transient fs error: keep the previous snapshot and retry next tick.
+        })
+        .finally(() => {
+          ticking = false
+        })
+    },
+    pollIntervalMs,
+    visibility
+  )
 
   return {
     unsubscribe: async () => {
       disposed = true
-      clearInterval(timer)
+      gatedInterval.dispose()
     }
   }
 }

--- a/src/main/ipc/worktree-git-common-watch.ts
+++ b/src/main/ipc/worktree-git-common-watch.ts
@@ -10,6 +10,8 @@ import {
   PRIMARY_CHECKOUT_METADATA_FILES,
   startGitCommonPolling
 } from './worktree-git-common-polling'
+import type { WindowVisibilityGate } from '../window/visibility-gated-interval'
+import { startVisibilityGatedInterval } from '../window/visibility-gated-interval'
 
 // Watches a repo's `<common>/.git/worktrees` metadata plus the primary
 // checkout's shallow branch/index files — the only paths the git-common event
@@ -69,42 +71,46 @@ async function startSnapshotDiffPoller(
   takeSnapshot: () => Promise<Map<string, number>>,
   onEvents: (events: WorktreeBasePollEvent[]) => void,
   pollIntervalMs: number,
-  onFullScan?: () => void
+  onFullScan?: () => void,
+  visibility?: WindowVisibilityGate
 ): Promise<WorktreeBaseSubscription> {
   let disposed = false
   let ticking = false
   let snapshot = await takeSnapshot()
 
-  const timer = setInterval(() => {
-    if (disposed || ticking) {
-      return
-    }
-    ticking = true
-    onFullScan?.()
-    void takeSnapshot()
-      .then((next) => {
-        if (disposed) {
-          return
-        }
-        const events = diffMtimeMap(snapshot, next)
-        snapshot = next
-        if (events.length > 0) {
-          onEvents(events)
-        }
-      })
-      .catch(() => {
-        // Transient fs error: keep the previous snapshot and retry next tick.
-      })
-      .finally(() => {
-        ticking = false
-      })
-  }, pollIntervalMs)
-  timer.unref?.()
+  const gatedInterval = startVisibilityGatedInterval(
+    () => {
+      if (disposed || ticking) {
+        return
+      }
+      ticking = true
+      onFullScan?.()
+      void takeSnapshot()
+        .then((next) => {
+          if (disposed) {
+            return
+          }
+          const events = diffMtimeMap(snapshot, next)
+          snapshot = next
+          if (events.length > 0) {
+            onEvents(events)
+          }
+        })
+        .catch(() => {
+          // Transient fs error: keep the previous snapshot and retry next tick.
+        })
+        .finally(() => {
+          ticking = false
+        })
+    },
+    pollIntervalMs,
+    visibility
+  )
 
   return {
     unsubscribe: async () => {
       disposed = true
-      clearInterval(timer)
+      gatedInterval.dispose()
     }
   }
 }
@@ -246,7 +252,8 @@ export async function startGitCommonWatch(
   onEvents: (events: WorktreeBasePollEvent[]) => void,
   pollIntervalMs: number,
   platform: NodeJS.Platform,
-  onFullScan?: () => void
+  onFullScan?: () => void,
+  visibility?: WindowVisibilityGate
 ): Promise<WorktreeBaseSubscription> {
   if (platform === 'darwin') {
     const [narrowWatch, primaryMetadataPoll] = await Promise.all([
@@ -255,7 +262,8 @@ export async function startGitCommonWatch(
         () => snapshotPrimaryCheckoutMetadata(target.path),
         onEvents,
         pollIntervalMs,
-        onFullScan
+        onFullScan,
+        visibility
       )
     ])
     return {
@@ -264,5 +272,5 @@ export async function startGitCommonWatch(
       }
     }
   }
-  return startGitCommonPolling(target.path, onEvents, pollIntervalMs, onFullScan)
+  return startGitCommonPolling(target.path, onEvents, pollIntervalMs, onFullScan, true, visibility)
 }

--- a/src/main/window/visibility-gated-interval.test.ts
+++ b/src/main/window/visibility-gated-interval.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { startVisibilityGatedInterval } from './visibility-gated-interval'
+
+const INTERVAL_MS = 2_000
+
+describe('startVisibilityGatedInterval', () => {
+  let visible: boolean
+  let becameVisibleListeners: Set<() => void>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    visible = true
+    becameVisibleListeners = new Set()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function makeGate(): Parameters<typeof startVisibilityGatedInterval>[2] {
+    return {
+      isWindowVisible: () => visible,
+      onWindowBecameVisible: (listener) => {
+        becameVisibleListeners.add(listener)
+        return () => becameVisibleListeners.delete(listener)
+      }
+    }
+  }
+
+  function notifyBecameVisible(): void {
+    for (const listener of becameVisibleListeners) {
+      listener()
+    }
+  }
+
+  it('ticks at the normal cadence while visible', () => {
+    const tick = vi.fn()
+    const gated = startVisibilityGatedInterval(tick, INTERVAL_MS, makeGate())
+    vi.advanceTimersByTime(INTERVAL_MS * 3)
+    expect(tick).toHaveBeenCalledTimes(3)
+    gated.dispose()
+  })
+
+  it('stops ticking entirely while the window is hidden', () => {
+    const tick = vi.fn()
+    const gated = startVisibilityGatedInterval(tick, INTERVAL_MS, makeGate())
+    visible = false
+    // First hidden fire tears the timer down without running the tick; from
+    // then on there are zero wakeups no matter how long we stay hidden.
+    vi.advanceTimersByTime(INTERVAL_MS * 30)
+    expect(tick).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+    gated.dispose()
+  })
+
+  it('runs exactly one immediate catch-up tick on became-visible and resumes the cadence', () => {
+    const tick = vi.fn()
+    const gated = startVisibilityGatedInterval(tick, INTERVAL_MS, makeGate())
+    visible = false
+    vi.advanceTimersByTime(INTERVAL_MS * 5)
+    expect(tick).not.toHaveBeenCalled()
+
+    visible = true
+    notifyBecameVisible()
+    expect(tick).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(INTERVAL_MS * 2)
+    expect(tick).toHaveBeenCalledTimes(3)
+    gated.dispose()
+  })
+
+  it('ignores became-visible while the timer is still running (no double scheduling)', () => {
+    const tick = vi.fn()
+    const gated = startVisibilityGatedInterval(tick, INTERVAL_MS, makeGate())
+    notifyBecameVisible()
+    expect(tick).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(INTERVAL_MS)
+    expect(tick).toHaveBeenCalledTimes(1)
+    gated.dispose()
+  })
+
+  it('removes the became-visible listener and timer on dispose', () => {
+    const tick = vi.fn()
+    const gated = startVisibilityGatedInterval(tick, INTERVAL_MS, makeGate())
+    expect(becameVisibleListeners.size).toBe(1)
+    gated.dispose()
+    expect(becameVisibleListeners.size).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+    notifyBecameVisible()
+    vi.advanceTimersByTime(INTERVAL_MS * 3)
+    expect(tick).not.toHaveBeenCalled()
+  })
+
+  it('does not resume after dispose even if hidden-then-visible races teardown', () => {
+    const tick = vi.fn()
+    const gated = startVisibilityGatedInterval(tick, INTERVAL_MS, makeGate())
+    visible = false
+    vi.advanceTimersByTime(INTERVAL_MS)
+    const listeners = [...becameVisibleListeners]
+    gated.dispose()
+    visible = true
+    // Simulate a stale listener reference firing after dispose.
+    for (const listener of listeners) {
+      listener()
+    }
+    vi.advanceTimersByTime(INTERVAL_MS * 3)
+    expect(tick).not.toHaveBeenCalled()
+  })
+
+  it('runs unconditionally when no gate is provided', () => {
+    const tick = vi.fn()
+    const gated = startVisibilityGatedInterval(tick, INTERVAL_MS)
+    vi.advanceTimersByTime(INTERVAL_MS * 2)
+    expect(tick).toHaveBeenCalledTimes(2)
+    gated.dispose()
+    vi.advanceTimersByTime(INTERVAL_MS * 2)
+    expect(tick).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/window/visibility-gated-interval.ts
+++ b/src/main/window/visibility-gated-interval.ts
@@ -1,0 +1,58 @@
+// Why: background pollers that only exist to keep visible UI fresh (worktree
+// base/git-common scans) waste CPU while the main window is hidden or
+// minimized. This gate stops the timer entirely while hidden and re-arms with
+// one immediate catch-up tick on reveal, so no external change is missed.
+// Occlusion is undetectable (BrowserWindow.isVisible() stays true when merely
+// covered), so this only helps the hidden/minimized case — that's expected.
+export type WindowVisibilityGate = {
+  /** Omitted means always-visible: the interval never pauses (test doubles, headless). */
+  isWindowVisible?: () => boolean
+  /** Process-global became-visible signal (survives window recreation); returns an unsubscribe. */
+  onWindowBecameVisible?: (listener: () => void) => () => void
+}
+
+export function startVisibilityGatedInterval(
+  tick: () => void,
+  intervalMs: number,
+  gate: WindowVisibilityGate = {}
+): { dispose: () => void } {
+  const { isWindowVisible, onWindowBecameVisible } = gate
+  let disposed = false
+  let timer: ReturnType<typeof setInterval> | null = null
+
+  const startTimer = (): void => {
+    const interval = setInterval(() => {
+      if (isWindowVisible && !isWindowVisible()) {
+        // Hidden: stop entirely (zero further wakeups, no scan on this tick);
+        // the became-visible listener re-arms.
+        clearInterval(interval)
+        timer = null
+        return
+      }
+      tick()
+    }, intervalMs)
+    interval.unref?.()
+    timer = interval
+  }
+  startTimer()
+
+  const stopBecameVisible = onWindowBecameVisible?.(() => {
+    if (disposed || timer !== null) {
+      return
+    }
+    // Catch up once on changes made while hidden, then resume the cadence.
+    tick()
+    startTimer()
+  })
+
+  return {
+    dispose: () => {
+      disposed = true
+      stopBecameVisible?.()
+      if (timer !== null) {
+        clearInterval(timer)
+        timer = null
+      }
+    }
+  }
+}

--- a/src/main/window/visibility-gated-interval.ts
+++ b/src/main/window/visibility-gated-interval.ts
@@ -4,11 +4,24 @@
 // one immediate catch-up tick on reveal, so no external change is missed.
 // Occlusion is undetectable (BrowserWindow.isVisible() stays true when merely
 // covered), so this only helps the hidden/minimized case — that's expected.
+import { isMainWindowVisible, onMainWindowBecameVisible } from './main-window-visibility'
+
 export type WindowVisibilityGate = {
   /** Omitted means always-visible: the interval never pauses (test doubles, headless). */
   isWindowVisible?: () => boolean
   /** Process-global became-visible signal (survives window recreation); returns an unsubscribe. */
   onWindowBecameVisible?: (listener: () => void) => () => void
+}
+
+// Why: keeps the isMainWindowVisible/onMainWindowBecameVisible plumbing out of
+// callers; getWindow is re-resolved per check so a recreated window is honored.
+export function createMainWindowVisibilityGate(
+  getWindow: () => Parameters<typeof isMainWindowVisible>[0]
+): WindowVisibilityGate {
+  return {
+    isWindowVisible: () => isMainWindowVisible(getWindow()),
+    onWindowBecameVisible: onMainWindowBecameVisible
+  }
 }
 
 export function startVisibilityGatedInterval(


### PR DESCRIPTION
# perf(worktrees): pause external-change pollers while the window is hidden, catch up on reveal

## Description

Two main-process pollers ran a scan every 2 seconds unconditionally, even with the main window hidden or minimized:

- `src/main/ipc/worktree-base-directory-poller.ts` — workspace-root rescan (gate-dir stats, plus periodic readdir+stat backstop) per base target.
- `src/main/ipc/worktree-git-common-polling.ts` — the Linux/Windows git-common metadata poll (readdir + per-worktree stat fan-out per repo). The macOS companion primary-metadata stat poll in `worktree-git-common-watch.ts` is gated too.

These pollers exist only to notice worktree/git changes made outside Orca so the visible UI stays fresh. Nobody consumes their output while the window is hidden.

This PR adds `src/main/window/visibility-gated-interval.ts`: a small reusable gate that stops the interval timer entirely once it observes the window hidden (zero further wakeups), and — via the process-global `onMainWindowBecameVisible` signal, which survives macOS window recreation — runs one immediate catch-up tick on reveal and resumes the normal cadence. The production wiring lives in `worktree-base-directory-watcher.ts` via the `createMainWindowVisibilityGate(getWindow)` factory (also in `visibility-gated-interval.ts`), which binds `isMainWindowVisible`/`onMainWindowBecameVisible`; the window is re-resolved through `activeWatches` on every check, so a recreated window is honored. The macOS narrow parcel-watcher stream is untouched (it is event-driven, not a poll); its existence poll and the SSH watch path are also unchanged.

## Evidence

Per poller instance, at the production 2s interval:

- Before: 30 scans/min while hidden (each a readdir+stat fan-out or gate-dir stat pass), per base target and per repo git-common poll.
- After: 0 scans/min while hidden — the interval timer is torn down, so there are zero timer wakeups at all — plus exactly 1 catch-up scan the moment the window becomes visible again.

## No-Regression Proof

- New unit suite `src/main/window/visibility-gated-interval.test.ts` (fake timers): normal cadence while visible; zero ticks and zero live timers while hidden; exactly one immediate tick on became-visible then cadence resumes; became-visible while already running does not double-schedule; dispose removes the listener and timer; stale listener firing after dispose is inert; no gate = unchanged always-on behavior.
- New integration tests in `src/main/ipc/worktree-base-directory-poller.test.ts` (real fs, fake window): an external worktree add made while hidden produces no scans and no events, then is reported immediately on reveal — for both the base poller and the Linux git-common poll; unsubscribe removes the visibility listener.
- Full suites pass: `visibility-gated-interval.test.ts`, `worktree-base-directory-poller.test.ts`, `worktree-git-common-watch.test.ts`, `worktree-base-directory-watcher.test.ts` — 49/49 tests green.
- `pnpm run typecheck:node` clean.
- Behavior while visible is byte-for-byte the old tick body (same cadence, same mtime gate, same backstop rescan/index re-stat counters, same ticking/disposed guards). Callers that pass no gate (all existing tests, SSH path) get the identical always-on interval. Note: `BrowserWindow.isVisible()` stays true when the window is merely occluded by another window, so this targets the hidden/minimized case only — occlusion behavior is unchanged by design.

## ELI5

Orca checks every 2 seconds whether you ran git commands outside the app, so its sidebar stays up to date. It kept doing that even when the window was hidden and nobody could see the sidebar. Now it naps while the window is hidden and does one quick check the instant you bring the window back, so you never see stale info.

## Known follow-up (not in this PR)

The macOS narrow-watch's existence re-poll (`armExistencePoll` in `worktree-git-common-watch.ts`) is a separate plain 2s `setInterval` that still ticks (a single `stat()`) while hidden for repos with no linked worktrees. It's correctness-neutral and small; gating it can follow in a separate change to keep this PR's surface tight.
