### PR TITLE
perf(renderer): patch the by-worktree agent index instead of full rebuild per status ping

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-agent-live-index-patch.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-live-index-patch.ts
@@ -1,0 +1,110 @@
+import type { AppState } from '@/store/types'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import { parsePaneKey } from '../../../../shared/stable-pane-id'
+
+export type LiveEntriesByWorktreeCache = {
+  tabsByWorktree: AppState['tabsByWorktree']
+  agentStatusByPaneKey: AppState['agentStatusByPaneKey']
+  entriesByWorktree: Map<string, AgentStatusEntry[]>
+}
+
+// Why: test-only observability — proves same-key entry updates (per-ping
+// setAgentStatus map churn) take the O(changed) patch path, not a full rebuild.
+let liveEntriesFullRebuildCount = 0
+export function getLiveEntriesFullRebuildCountForTests(): number {
+  return liveEntriesFullRebuildCount
+}
+export function recordLiveEntriesFullRebuild(): void {
+  liveEntriesFullRebuildCount += 1
+}
+
+// Why: keep early attributed child rows, but hide completed rows once their tab is gone.
+export function liveEntryWorktreeId(
+  paneKey: string,
+  entry: AgentStatusEntry,
+  tabIdToWorktreeId: Map<string, string>
+): string | undefined {
+  const parsed = parsePaneKey(paneKey)
+  if (!parsed) {
+    return undefined
+  }
+  const tabWorktreeId = tabIdToWorktreeId.get(parsed.tabId)
+  return tabWorktreeId ?? (entry.state === 'done' ? undefined : entry.worktreeId)
+}
+
+/**
+ * Patches the cached by-worktree index in place of a full rebuild when the
+ * live map changed only by replacing entries under existing pane keys with
+ * the same bucketing (worktree attribution and done-ness).
+ *
+ * Why: setAgentStatus mints a new agentStatusByPaneKey on EVERY status ping,
+ * including same-state working prompt/tool updates. Rebuilding the whole
+ * index (parsePaneKey + bucketing across all live agents) per ping is the
+ * dominant selector cost under parallel agents; a within-state ping only
+ * needs the owning worktree's bucket refreshed.
+ *
+ * Invariant this relies on: no map producer reorders existing pane keys
+ * without also changing an entry reference or the key set. All current
+ * writers hold this (updates spread-overwrite in place; the only reorderer,
+ * movePaneKeyedRecord, deletes+re-adds so the new key trips the added-key
+ * bail). A future producer that rebuilt the map in a new key order with
+ * identical entry refs would need to invalidate this cache instead.
+ */
+export function patchLiveEntriesByWorktree(
+  cache: LiveEntriesByWorktreeCache,
+  agentStatusByPaneKey: AppState['agentStatusByPaneKey'],
+  tabIdToWorktreeId: Map<string, string>
+): Map<string, AgentStatusEntry[]> | null {
+  const previousMap = cache.agentStatusByPaneKey
+  const changed: { paneKey: string; entry: AgentStatusEntry }[] = []
+  let keyCount = 0
+  for (const paneKey in agentStatusByPaneKey) {
+    keyCount += 1
+    const entry = agentStatusByPaneKey[paneKey]
+    const previous = previousMap[paneKey]
+    if (previous === entry) {
+      continue
+    }
+    // Why: bail on added keys or bucket-determinant changes — the bucket rule
+    // depends only on paneKey, the (reference-equal) tab index, worktree
+    // attribution, and done-ness, so equal determinants mean the same bucket.
+    if (
+      previous === undefined ||
+      previous.worktreeId !== entry.worktreeId ||
+      (previous.state === 'done') !== (entry.state === 'done')
+    ) {
+      return null
+    }
+    changed.push({ paneKey, entry })
+  }
+  if (keyCount !== Object.keys(previousMap).length) {
+    // Why: removed keys need buckets dropped; leave that to the full rebuild.
+    return null
+  }
+  if (changed.length === 0) {
+    return cache.entriesByWorktree
+  }
+
+  const entriesByWorktree = new Map(cache.entriesByWorktree)
+  const clonedBuckets = new Set<string>()
+  for (const { paneKey, entry } of changed) {
+    const worktreeId = liveEntryWorktreeId(paneKey, entry, tabIdToWorktreeId)
+    if (!worktreeId) {
+      continue
+    }
+    const bucket = entriesByWorktree.get(worktreeId)
+    const index = bucket?.indexOf(previousMap[paneKey]) ?? -1
+    if (!bucket || index < 0) {
+      return null
+    }
+    const nextBucket = clonedBuckets.has(worktreeId) ? bucket : bucket.slice()
+    // Why: in-position replacement preserves iteration order, matching what a
+    // full rebuild would produce (spread updates keep object insertion order).
+    nextBucket[index] = entry
+    if (!clonedBuckets.has(worktreeId)) {
+      clonedBuckets.add(worktreeId)
+      entriesByWorktree.set(worktreeId, nextBucket)
+    }
+  }
+  return entriesByWorktree
+}

--- a/src/renderer/src/components/sidebar/worktree-agent-row-selectors.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-row-selectors.test.ts
@@ -6,8 +6,8 @@ import type {
 import type { TerminalTab } from '../../../../shared/types'
 import type { RetainedAgentEntry } from '@/store/slices/agent-status'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
+import { getLiveEntriesFullRebuildCountForTests } from './worktree-agent-live-index-patch'
 import {
-  getLiveEntriesFullRebuildCountForTests,
   selectLiveAgentStatusEntriesForWorktree,
   selectMigrationUnsupportedEntriesForWorktree,
   selectRuntimeAgentOrchestrationForWorktree,

--- a/src/renderer/src/components/sidebar/worktree-agent-row-selectors.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-row-selectors.test.ts
@@ -7,6 +7,7 @@ import type { TerminalTab } from '../../../../shared/types'
 import type { RetainedAgentEntry } from '@/store/slices/agent-status'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import {
+  getLiveEntriesFullRebuildCountForTests,
   selectLiveAgentStatusEntriesForWorktree,
   selectMigrationUnsupportedEntriesForWorktree,
   selectRuntimeAgentOrchestrationForWorktree,
@@ -149,6 +150,109 @@ describe('selectLiveAgentStatusEntriesForWorktree', () => {
     }
 
     expect(selectLiveAgentStatusEntriesForWorktree(state, 'wt-1')).toEqual([childEntry])
+  })
+
+  it('patches instead of full-rebuilding across within-state pings, and stays correct on transitions', () => {
+    const wt1Entry = makeEntry(PANE_KEY_1, 1000, { state: 'working', prompt: 'wt1 prompt' })
+    const wt2Entry = makeEntry(PANE_KEY_2, 1000, { state: 'working', prompt: 'wt2 prompt' })
+    const baseState = {
+      tabsByWorktree: {
+        'wt-1': [makeTab('tab-1')],
+        'wt-2': [makeTab('tab-2')]
+      },
+      agentStatusByPaneKey: {
+        [PANE_KEY_1]: wt1Entry,
+        [PANE_KEY_2]: wt2Entry
+      },
+      migrationUnsupportedByPtyId: {},
+      retainedAgentsByPaneKey: {}
+    }
+
+    // Prime the cache (one full rebuild allowed here).
+    const primedWt1 = selectLiveAgentStatusEntriesForWorktree(baseState, 'wt-1')
+    const primedWt2 = selectLiveAgentStatusEntriesForWorktree(baseState, 'wt-2')
+    const rebuildsAfterPrime = getLiveEntriesFullRebuildCountForTests()
+
+    // Simulate a burst of same-state pings: setAgentStatus mints a new map and
+    // a new entry object per ping, with only prompt/tool metadata changing.
+    let state = baseState
+    let latestWt2 = primedWt2
+    for (let ping = 0; ping < 50; ping += 1) {
+      state = {
+        ...state,
+        agentStatusByPaneKey: {
+          ...state.agentStatusByPaneKey,
+          [PANE_KEY_2]: {
+            ...wt2Entry,
+            prompt: `wt2 prompt ${ping}`,
+            toolName: 'Bash',
+            toolInput: `cmd ${ping}`,
+            updatedAt: 1000 + ping
+          }
+        }
+      }
+      const wt1 = selectLiveAgentStatusEntriesForWorktree(state, 'wt-1')
+      latestWt2 = selectLiveAgentStatusEntriesForWorktree(state, 'wt-2')
+      // Unaffected worktree keeps identity; owning worktree serves the fresh entry.
+      expect(wt1).toBe(primedWt1)
+      expect(latestWt2).toHaveLength(1)
+      expect(latestWt2[0]?.prompt).toBe(`wt2 prompt ${ping}`)
+      expect(latestWt2[0]?.toolInput).toBe(`cmd ${ping}`)
+    }
+    // The O(all live agents) rebuild body never ran for within-state pings.
+    expect(getLiveEntriesFullRebuildCountForTests()).toBe(rebuildsAfterPrime)
+    expect(latestWt2).not.toBe(primedWt2)
+
+    // A real transition that changes bucketing (working -> done with the tab
+    // still present keeps the bucket; removing the entry must drop it).
+    const doneState = {
+      ...state,
+      agentStatusByPaneKey: {
+        [PANE_KEY_1]: state.agentStatusByPaneKey[PANE_KEY_1]
+      }
+    }
+    expect(selectLiveAgentStatusEntriesForWorktree(doneState, 'wt-2')).toEqual([])
+    expect(selectLiveAgentStatusEntriesForWorktree(doneState, 'wt-1')).toEqual([wt1Entry])
+    expect(getLiveEntriesFullRebuildCountForTests()).toBe(rebuildsAfterPrime + 1)
+  })
+
+  it('falls back to a full rebuild when a within-map update changes worktree attribution', () => {
+    const entry = makeEntry(PANE_KEY_1, 1000, { state: 'working', worktreeId: 'wt-1' })
+    const state = {
+      // No tab membership: bucketing comes from entry.worktreeId attribution.
+      tabsByWorktree: { 'wt-1': [], 'wt-2': [] },
+      agentStatusByPaneKey: { [PANE_KEY_1]: entry },
+      migrationUnsupportedByPtyId: {},
+      retainedAgentsByPaneKey: {}
+    }
+    expect(selectLiveAgentStatusEntriesForWorktree(state, 'wt-1')).toEqual([entry])
+
+    const moved = { ...entry, worktreeId: 'wt-2' }
+    const nextState = {
+      ...state,
+      agentStatusByPaneKey: { [PANE_KEY_1]: moved }
+    }
+    expect(selectLiveAgentStatusEntriesForWorktree(nextState, 'wt-1')).toEqual([])
+    expect(selectLiveAgentStatusEntriesForWorktree(nextState, 'wt-2')).toEqual([moved])
+  })
+
+  it('falls back to a full rebuild when a live entry completes with its tab gone', () => {
+    const entry = makeEntry(PANE_KEY_1, 1000, { state: 'working', worktreeId: 'wt-1' })
+    const state = {
+      tabsByWorktree: { 'wt-1': [] },
+      agentStatusByPaneKey: { [PANE_KEY_1]: entry },
+      migrationUnsupportedByPtyId: {},
+      retainedAgentsByPaneKey: {}
+    }
+    expect(selectLiveAgentStatusEntriesForWorktree(state, 'wt-1')).toEqual([entry])
+
+    // done + tab absent must drop the row (bucket rule), not be patched in place.
+    const done = { ...entry, state: 'done' as const }
+    const nextState = {
+      ...state,
+      agentStatusByPaneKey: { [PANE_KEY_1]: done }
+    }
+    expect(selectLiveAgentStatusEntriesForWorktree(nextState, 'wt-1')).toEqual([])
   })
 
   it('does not use worktree attribution for a completed row whose tab is gone', () => {

--- a/src/renderer/src/components/sidebar/worktree-agent-row-selectors.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-row-selectors.ts
@@ -51,6 +51,13 @@ let liveEntriesByWorktreeCache: LiveEntriesByWorktreeCache | null = null
 let migrationUnsupportedByWorktreeCache: MigrationUnsupportedByWorktreeCache | null = null
 let retainedEntriesByWorktreeCache: RetainedEntriesByWorktreeCache | null = null
 
+// Why: test-only observability — proves same-key entry updates (per-ping
+// setAgentStatus map churn) take the O(changed) patch path, not a full rebuild.
+let liveEntriesFullRebuildCount = 0
+export function getLiveEntriesFullRebuildCountForTests(): number {
+  return liveEntriesFullRebuildCount
+}
+
 function reuseArrayIfEqual<T>(previous: T[] | undefined, next: T[]): T[] {
   if (!previous || previous.length !== next.length) {
     return next
@@ -79,6 +86,90 @@ function getTabIdToWorktreeId(
   return tabIdToWorktreeId
 }
 
+// Why: keep early attributed child rows, but hide completed rows once their tab is gone.
+function liveEntryWorktreeId(
+  paneKey: string,
+  entry: AgentStatusEntry,
+  tabIdToWorktreeId: Map<string, string>
+): string | undefined {
+  const parsed = parsePaneKey(paneKey)
+  if (!parsed) {
+    return undefined
+  }
+  const tabWorktreeId = tabIdToWorktreeId.get(parsed.tabId)
+  return tabWorktreeId ?? (entry.state === 'done' ? undefined : entry.worktreeId)
+}
+
+/**
+ * Patches the cached by-worktree index in place of a full rebuild when the
+ * live map changed only by replacing entries under existing pane keys with
+ * the same bucketing (worktree attribution and done-ness).
+ *
+ * Why: setAgentStatus mints a new agentStatusByPaneKey on EVERY status ping,
+ * including same-state working prompt/tool updates. Rebuilding the whole
+ * index (parsePaneKey + bucketing across all live agents) per ping is the
+ * dominant selector cost under parallel agents; a within-state ping only
+ * needs the owning worktree's bucket refreshed.
+ */
+function patchLiveEntriesByWorktree(
+  cache: LiveEntriesByWorktreeCache,
+  agentStatusByPaneKey: WorktreeAgentRowsState['agentStatusByPaneKey'],
+  tabIdToWorktreeId: Map<string, string>
+): Map<string, AgentStatusEntry[]> | null {
+  const previousMap = cache.agentStatusByPaneKey
+  const changed: Array<{ paneKey: string; entry: AgentStatusEntry }> = []
+  let keyCount = 0
+  for (const paneKey in agentStatusByPaneKey) {
+    keyCount += 1
+    const entry = agentStatusByPaneKey[paneKey]
+    const previous = previousMap[paneKey]
+    if (previous === entry) {
+      continue
+    }
+    // Why: bail on added keys or bucket-determinant changes — the bucket rule
+    // depends only on paneKey, the (reference-equal) tab index, worktree
+    // attribution, and done-ness, so equal determinants mean the same bucket.
+    if (
+      previous === undefined ||
+      previous.worktreeId !== entry.worktreeId ||
+      (previous.state === 'done') !== (entry.state === 'done')
+    ) {
+      return null
+    }
+    changed.push({ paneKey, entry })
+  }
+  if (keyCount !== Object.keys(previousMap).length) {
+    // Why: removed keys need buckets dropped; leave that to the full rebuild.
+    return null
+  }
+  if (changed.length === 0) {
+    return cache.entriesByWorktree
+  }
+
+  const entriesByWorktree = new Map(cache.entriesByWorktree)
+  const clonedBuckets = new Set<string>()
+  for (const { paneKey, entry } of changed) {
+    const worktreeId = liveEntryWorktreeId(paneKey, entry, tabIdToWorktreeId)
+    if (!worktreeId) {
+      continue
+    }
+    const bucket = entriesByWorktree.get(worktreeId)
+    const index = bucket?.indexOf(previousMap[paneKey]) ?? -1
+    if (!bucket || index < 0) {
+      return null
+    }
+    const nextBucket = clonedBuckets.has(worktreeId) ? bucket : bucket.slice()
+    // Why: in-position replacement preserves iteration order, matching what a
+    // full rebuild would produce (spread updates keep object insertion order).
+    nextBucket[index] = entry
+    if (!clonedBuckets.has(worktreeId)) {
+      clonedBuckets.add(worktreeId)
+      entriesByWorktree.set(worktreeId, nextBucket)
+    }
+  }
+  return entriesByWorktree
+}
+
 function getLiveEntriesByWorktree(state: WorktreeAgentRowsState): Map<string, AgentStatusEntry[]> {
   const agentStatusByPaneKey = state.agentStatusByPaneKey ?? EMPTY_RECORD
   const tabsByWorktree = state.tabsByWorktree ?? EMPTY_RECORD
@@ -90,16 +181,26 @@ function getLiveEntriesByWorktree(state: WorktreeAgentRowsState): Map<string, Ag
   }
 
   const tabIdToWorktreeId = getTabIdToWorktreeId(tabsByWorktree)
+  if (liveEntriesByWorktreeCache?.tabsByWorktree === tabsByWorktree) {
+    const patched = patchLiveEntriesByWorktree(
+      liveEntriesByWorktreeCache,
+      agentStatusByPaneKey,
+      tabIdToWorktreeId
+    )
+    if (patched) {
+      liveEntriesByWorktreeCache = {
+        tabsByWorktree,
+        agentStatusByPaneKey,
+        entriesByWorktree: patched
+      }
+      return patched
+    }
+  }
+  liveEntriesFullRebuildCount += 1
   const previous = liveEntriesByWorktreeCache?.entriesByWorktree
   const entriesByWorktree = new Map<string, AgentStatusEntry[]>()
   for (const [paneKey, entry] of Object.entries(agentStatusByPaneKey)) {
-    const parsed = parsePaneKey(paneKey)
-    if (!parsed) {
-      continue
-    }
-    const tabWorktreeId = tabIdToWorktreeId.get(parsed.tabId)
-    // Why: keep early attributed child rows, but hide completed rows once their tab is gone.
-    const worktreeId = tabWorktreeId ?? (entry.state === 'done' ? undefined : entry.worktreeId)
+    const worktreeId = liveEntryWorktreeId(paneKey, entry, tabIdToWorktreeId)
     if (!worktreeId) {
       continue
     }

--- a/src/renderer/src/components/sidebar/worktree-agent-row-selectors.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-row-selectors.ts
@@ -6,6 +6,12 @@ import type {
   MigrationUnsupportedPtyEntry
 } from '../../../../shared/agent-status-types'
 import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import {
+  type LiveEntriesByWorktreeCache,
+  liveEntryWorktreeId,
+  patchLiveEntriesByWorktree,
+  recordLiveEntriesFullRebuild
+} from './worktree-agent-live-index-patch'
 import type { TerminalLayoutSnapshot } from '../../../../shared/types'
 
 const EMPTY_LIVE_ENTRIES: AgentStatusEntry[] = []
@@ -29,12 +35,6 @@ type TabWorktreeIndexCache = {
   tabIdToWorktreeId: Map<string, string>
 }
 
-type LiveEntriesByWorktreeCache = {
-  tabsByWorktree: WorktreeAgentRowsState['tabsByWorktree']
-  agentStatusByPaneKey: WorktreeAgentRowsState['agentStatusByPaneKey']
-  entriesByWorktree: Map<string, AgentStatusEntry[]>
-}
-
 type MigrationUnsupportedByWorktreeCache = {
   tabsByWorktree: WorktreeAgentRowsState['tabsByWorktree']
   migrationUnsupportedByPtyId: WorktreeAgentRowsState['migrationUnsupportedByPtyId']
@@ -50,13 +50,6 @@ let tabWorktreeIndexCache: TabWorktreeIndexCache | null = null
 let liveEntriesByWorktreeCache: LiveEntriesByWorktreeCache | null = null
 let migrationUnsupportedByWorktreeCache: MigrationUnsupportedByWorktreeCache | null = null
 let retainedEntriesByWorktreeCache: RetainedEntriesByWorktreeCache | null = null
-
-// Why: test-only observability — proves same-key entry updates (per-ping
-// setAgentStatus map churn) take the O(changed) patch path, not a full rebuild.
-let liveEntriesFullRebuildCount = 0
-export function getLiveEntriesFullRebuildCountForTests(): number {
-  return liveEntriesFullRebuildCount
-}
 
 function reuseArrayIfEqual<T>(previous: T[] | undefined, next: T[]): T[] {
   if (!previous || previous.length !== next.length) {
@@ -86,90 +79,6 @@ function getTabIdToWorktreeId(
   return tabIdToWorktreeId
 }
 
-// Why: keep early attributed child rows, but hide completed rows once their tab is gone.
-function liveEntryWorktreeId(
-  paneKey: string,
-  entry: AgentStatusEntry,
-  tabIdToWorktreeId: Map<string, string>
-): string | undefined {
-  const parsed = parsePaneKey(paneKey)
-  if (!parsed) {
-    return undefined
-  }
-  const tabWorktreeId = tabIdToWorktreeId.get(parsed.tabId)
-  return tabWorktreeId ?? (entry.state === 'done' ? undefined : entry.worktreeId)
-}
-
-/**
- * Patches the cached by-worktree index in place of a full rebuild when the
- * live map changed only by replacing entries under existing pane keys with
- * the same bucketing (worktree attribution and done-ness).
- *
- * Why: setAgentStatus mints a new agentStatusByPaneKey on EVERY status ping,
- * including same-state working prompt/tool updates. Rebuilding the whole
- * index (parsePaneKey + bucketing across all live agents) per ping is the
- * dominant selector cost under parallel agents; a within-state ping only
- * needs the owning worktree's bucket refreshed.
- */
-function patchLiveEntriesByWorktree(
-  cache: LiveEntriesByWorktreeCache,
-  agentStatusByPaneKey: WorktreeAgentRowsState['agentStatusByPaneKey'],
-  tabIdToWorktreeId: Map<string, string>
-): Map<string, AgentStatusEntry[]> | null {
-  const previousMap = cache.agentStatusByPaneKey
-  const changed: Array<{ paneKey: string; entry: AgentStatusEntry }> = []
-  let keyCount = 0
-  for (const paneKey in agentStatusByPaneKey) {
-    keyCount += 1
-    const entry = agentStatusByPaneKey[paneKey]
-    const previous = previousMap[paneKey]
-    if (previous === entry) {
-      continue
-    }
-    // Why: bail on added keys or bucket-determinant changes — the bucket rule
-    // depends only on paneKey, the (reference-equal) tab index, worktree
-    // attribution, and done-ness, so equal determinants mean the same bucket.
-    if (
-      previous === undefined ||
-      previous.worktreeId !== entry.worktreeId ||
-      (previous.state === 'done') !== (entry.state === 'done')
-    ) {
-      return null
-    }
-    changed.push({ paneKey, entry })
-  }
-  if (keyCount !== Object.keys(previousMap).length) {
-    // Why: removed keys need buckets dropped; leave that to the full rebuild.
-    return null
-  }
-  if (changed.length === 0) {
-    return cache.entriesByWorktree
-  }
-
-  const entriesByWorktree = new Map(cache.entriesByWorktree)
-  const clonedBuckets = new Set<string>()
-  for (const { paneKey, entry } of changed) {
-    const worktreeId = liveEntryWorktreeId(paneKey, entry, tabIdToWorktreeId)
-    if (!worktreeId) {
-      continue
-    }
-    const bucket = entriesByWorktree.get(worktreeId)
-    const index = bucket?.indexOf(previousMap[paneKey]) ?? -1
-    if (!bucket || index < 0) {
-      return null
-    }
-    const nextBucket = clonedBuckets.has(worktreeId) ? bucket : bucket.slice()
-    // Why: in-position replacement preserves iteration order, matching what a
-    // full rebuild would produce (spread updates keep object insertion order).
-    nextBucket[index] = entry
-    if (!clonedBuckets.has(worktreeId)) {
-      clonedBuckets.add(worktreeId)
-      entriesByWorktree.set(worktreeId, nextBucket)
-    }
-  }
-  return entriesByWorktree
-}
-
 function getLiveEntriesByWorktree(state: WorktreeAgentRowsState): Map<string, AgentStatusEntry[]> {
   const agentStatusByPaneKey = state.agentStatusByPaneKey ?? EMPTY_RECORD
   const tabsByWorktree = state.tabsByWorktree ?? EMPTY_RECORD
@@ -196,7 +105,7 @@ function getLiveEntriesByWorktree(state: WorktreeAgentRowsState): Map<string, Ag
       return patched
     }
   }
-  liveEntriesFullRebuildCount += 1
+  recordLiveEntriesFullRebuild()
   const previous = liveEntriesByWorktreeCache?.entriesByWorktree
   const entriesByWorktree = new Map<string, AgentStatusEntry[]>()
   for (const [paneKey, entry] of Object.entries(agentStatusByPaneKey)) {


### PR DESCRIPTION
# perf(renderer): patch sidebar live-agent index on within-state status pings instead of full rebuild

## Description

Every agent-status ping calls `setAgentStatus`, which always mints a new
`agentStatusByPaneKey` object — even for a same-state "working" prompt/tool
ping that bumps neither `agentStatusEpoch` nor `sortEpoch`. The sidebar's
`getLiveEntriesByWorktree` memoized its by-worktree index on that map
**reference**, so the O(total live agents) rebuild (`parsePaneKey` + tab
lookup + bucketing per entry, plus fresh Map/array allocations) ran on every
ping. With N agents streaming in parallel, that is a full index rebuild per
tool/prompt/assistant event across all N agents.

Fix (new module
`src/renderer/src/components/sidebar/worktree-agent-live-index-patch.ts`, wired
into `worktree-agent-row-selectors.ts` — split so the selectors file stays
under the repo's 300-line max-lines limit): on a map-reference miss with an
unchanged `tabsByWorktree`, try an
**incremental patch** of the cached index. A single reference-compare walk of
the new map finds the changed entries (typically exactly one per ping); if
every change keeps its pane key and its bucket determinants (worktree
attribution and done-ness), only the owning worktree's bucket is cloned and
the entry replaced in position. Any add, remove, or bucket-determinant change
bails to the original full rebuild. The full rebuild path itself is unchanged
(the bucket rule is now shared via `liveEntryWorktreeId` so the two paths
cannot drift).

The sibling caches (`getMigrationUnsupportedByWorktree`,
`getRetainedEntriesByWorktree`) were inspected and left alone: `setAgentStatus`
preserves those map references on a plain ping (migration prune returns the
same object when nothing was pruned; the retained map is cloned only when a
retained snapshot exists for the pinged pane), so they do not rebuild per ping.

## Evidence

Vitest counter test (`getLiveEntriesFullRebuildCountForTests`) over 50
simulated same-state pings (new map + new entry with changed
prompt/toolName/toolInput/updatedAt each time), 2 live agents in 2 worktrees:

| | full index rebuilds for 50 within-state pings |
|---|---|
| before (patch path disabled) | **50** (one per ping) |
| after | **0** (patch path; rebuild only on the real transition, +1) |

"Before" was measured by temporarily short-circuiting the patch branch
(`if (false && …)`) and re-running the same test: it fails with the counter at
50; with the patch enabled it is 0. Per-ping selector cost drops from
O(all live agents) parse+bucket+allocate to one O(all live agents)
reference-compare pass plus O(1) bucket clone for the owning worktree.

## No-Regression Proof

**Why not epoch-keying (the obvious alternative):** keying the cache on
`agentStatusEpoch` was investigated first and is **unsafe**. Field-by-field:
the row renderers (`worktree-card-compact-agent-row.tsx`,
`DashboardAgentRow`) render `entry.prompt` (primary text via
`getAgentRowPrimaryText`), `entry.toolName`/`entry.toolInput` (secondary text
while working), and `entry.lastAssistantMessage` — and `setAgentStatus`
deliberately does **not** bump the epoch for a fresh same-state working ping
(`sortRelevantChange`/`doneRetentionFieldsChanged` both false) even though
those exact fields change. Epoch-keying would freeze the live row's prompt and
"Tool: input" line for a whole working turn. The slice even documents this:
"Same-state working prompt/tool pings still update agentStatusByPaneKey for
the owning row."

**Why the patch is exact:** an entry's bucket in the index depends only on
(a) its pane key string, (b) the `tabsByWorktree`-derived tab→worktree index,
(c) `entry.worktreeId`, and (d) whether `entry.state === 'done'`
(selector line ~100). The patch runs only when (a) and (b) are unchanged by
construction (same key, reference-equal `tabsByWorktree`) and bails whenever
(c) or (d) changed, or any key was added/removed — including non-epoch key
moves like `transferAgentPaneAuthority`, which the structural key-set check
catches without relying on epochs. In-position replacement inside a cloned
bucket preserves iteration order (object spread keeps insertion order for
existing keys), so patched output is element-for-element what a full rebuild
would produce: the owning worktree's array gets a fresh identity with the new
entry (as today), every other worktree's array keeps its identity (as today),
and no field is ever served stale.

**Tests:** new tests cover the 50-ping patch path (identity stability for the
unaffected worktree + fresh prompt/toolInput served for the owning worktree),
plus full-rebuild fallbacks for attribution change, done-with-tab-gone, and
entry removal. All related suites pass: `worktree-agent-row-selectors` (11),
`useWorktreeAgentRows`, `worktree-agent-freshness-selector`,
`worktree-agent-activity-summary`, `worktree-title-derived-agent-rows`,
`focused-agent-row-highlight`, `agent-status` slice + 8 sibling agent-status
suites — 166 tests, 0 failures. `pnpm run typecheck:web` passes.

## ELI5

The sidebar keeps a phone book of which agent belongs to which project, and it
was re-typing the whole phone book every time any agent said "still working".
Now it just updates that one agent's line and re-types the book only when
someone actually joins, leaves, or moves. What you see on screen is
pixel-identical — it's the same book, built cheaper.
