### PR TITLE
fix(github): load PR details on fork checkouts by preferring upstream (#7331)

### DIFF
--- a/src/main/github/client-create-pr.test.ts
+++ b/src/main/github/client-create-pr.test.ts
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises'
 const {
   ghExecFileAsyncMock,
   getOwnerRepoMock,
+  getOwnerRepoForRemoteMock,
   getEnterpriseGitHubRepoSlugMock,
   extractExecErrorMock,
   acquireMock,
@@ -12,6 +13,7 @@ const {
 } = vi.hoisted(() => ({
   ghExecFileAsyncMock: vi.fn(),
   getOwnerRepoMock: vi.fn(),
+  getOwnerRepoForRemoteMock: vi.fn(),
   getEnterpriseGitHubRepoSlugMock: vi.fn(),
   extractExecErrorMock: vi.fn((error: unknown) => {
     const value = error as { stderr?: string; stdout?: string; message?: string }
@@ -34,7 +36,7 @@ vi.mock('./gh-utils', () => ({
   ghExecFileAsync: ghExecFileAsyncMock,
   getOwnerRepo: getOwnerRepoMock,
   getIssueOwnerRepo: vi.fn(),
-  getOwnerRepoForRemote: vi.fn(),
+  getOwnerRepoForRemote: getOwnerRepoForRemoteMock,
   githubRepoContext: vi.fn((repoPath: string, connectionId?: string | null) => ({
     repoPath,
     connectionId: connectionId ?? null
@@ -64,6 +66,14 @@ describe('createGitHubPullRequest', () => {
   beforeEach(() => {
     ghExecFileAsyncMock.mockReset()
     getOwnerRepoMock.mockReset()
+    getOwnerRepoForRemoteMock.mockReset()
+    // Why: createGitHubPullRequest resolves its target via the explicit origin
+    // remote (getOwnerRepo became upstream-first in #7331). Delegate the origin
+    // probe to getOwnerRepoMock so existing tests keep defining it there.
+    getOwnerRepoForRemoteMock.mockImplementation(
+      async (repoPath: string, remoteName: string, connectionId?: string | null, opts = {}) =>
+        remoteName === 'origin' ? getOwnerRepoMock(repoPath, connectionId, opts) : null
+    )
     getEnterpriseGitHubRepoSlugMock.mockReset()
     getEnterpriseGitHubRepoSlugMock.mockResolvedValue(null)
     extractExecErrorMock.mockClear()
@@ -121,6 +131,40 @@ describe('createGitHubPullRequest', () => {
     })
     expect(acquireMock).toHaveBeenCalledOnce()
     expect(releaseMock).toHaveBeenCalledOnce()
+  })
+
+  it('targets the origin fork (not the upstream parent) on a fork checkout (#7331)', async () => {
+    // Fork checkout: origin is the personal fork, upstream is the parent. The
+    // head branch is unqualified and lives on the fork, so `gh pr create` must
+    // run with --repo <fork> even though PR reads prefer upstream since #7331.
+    getOwnerRepoForRemoteMock.mockImplementation(async (_repoPath: string, remoteName: string) =>
+      remoteName === 'origin'
+        ? { owner: 'fsdwen', repo: 'orca' }
+        : { owner: 'stablyai', repo: 'orca' }
+    )
+    ghExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({
+        number: 5,
+        url: 'https://github.com/fsdwen/orca/pull/5'
+      })
+    })
+
+    await expect(
+      createGitHubPullRequest('/repo-root', {
+        provider: 'github',
+        base: 'main',
+        head: 'my-branch',
+        title: 'Fork PR'
+      })
+    ).resolves.toEqual({
+      ok: true,
+      number: 5,
+      url: 'https://github.com/fsdwen/orca/pull/5'
+    })
+
+    const [args] = ghExecFileAsyncMock.mock.calls[0]
+    expect(args[args.indexOf('--repo') + 1]).toBe('fsdwen/orca')
+    expect(args[args.indexOf('--head') + 1]).toBe('my-branch')
   })
 
   it('host-qualifies --repo for a GHES remote so gh targets the Enterprise server (#8312)', async () => {
@@ -257,7 +301,7 @@ describe('createGitHubPullRequest', () => {
       url: 'https://github.com/acme/widgets/pull/45'
     })
 
-    expect(getOwnerRepoMock).toHaveBeenCalledWith('/remote/repo-root', 'ssh-1')
+    expect(getOwnerRepoForRemoteMock).toHaveBeenCalledWith('/remote/repo-root', 'origin', 'ssh-1')
     const [args, options] = ghExecFileAsyncMock.mock.calls[0]
     expect(args).toEqual(
       expect.arrayContaining([

--- a/src/main/github/client-issue-source.test.ts
+++ b/src/main/github/client-issue-source.test.ts
@@ -90,6 +90,16 @@ function decodedIssueSearchPath(callIndex: number): string {
   return decodeURIComponent(apiPath ?? '')
 }
 
+// Route resolvePrWorkItemSource's per-remote probes: origin delegates to
+// getOwnerRepoMock (so existing tests keep defining origin through it) and
+// upstream returns the given candidate.
+function mockUpstreamCandidate(upstream: { owner: string; repo: string } | null): void {
+  getOwnerRepoForRemoteMock.mockImplementation(
+    async (repoPath: string, remoteName: string, connectionId?: string | null, opts = {}) =>
+      remoteName === 'upstream' ? upstream : getOwnerRepoMock(repoPath, connectionId, opts)
+  )
+}
+
 describe('GitHub issue source split', () => {
   beforeEach(() => {
     execFileAsyncMock.mockReset()
@@ -113,10 +123,15 @@ describe('GitHub issue source split', () => {
       source: await getIssueOwnerRepoMock(),
       fellBack: false
     }))
-    // Default the upstream-candidate lookup to null so existing tests that
-    // only mock `getIssueOwnerRepo` + `getOwnerRepo` don't need to think
-    // about it. Tests that care set it explicitly.
-    getOwnerRepoForRemoteMock.mockResolvedValue(null)
+    // Why: since #7331 `resolvePrWorkItemSource` fetches origin through
+    // `getOwnerRepoForRemote` (getOwnerRepo became upstream-first). Route the
+    // origin probe to `getOwnerRepoMock` so existing tests keep defining the
+    // origin candidate through it; default upstream to null. Tests that care
+    // about upstream override with their own implementation.
+    getOwnerRepoForRemoteMock.mockImplementation(
+      async (repoPath: string, remoteName: string, connectionId?: string | null, opts = {}) =>
+        remoteName === 'origin' ? getOwnerRepoMock(repoPath, connectionId, opts) : null
+    )
     _resetOwnerRepoCache()
   })
 
@@ -265,7 +280,7 @@ describe('GitHub issue source split', () => {
       fellBack: false
     })
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'fork', repo: 'orca' })
-    getOwnerRepoForRemoteMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
+    mockUpstreamCandidate({ owner: 'stablyai', repo: 'orca' })
     ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' }).mockResolvedValueOnce({
       stdout: '[]'
     })
@@ -283,7 +298,7 @@ describe('GitHub issue source split', () => {
       fellBack: false
     })
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'fork', repo: 'orca' })
-    getOwnerRepoForRemoteMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
+    mockUpstreamCandidate({ owner: 'stablyai', repo: 'orca' })
     ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' })
 
     await listWorkItems('/repo-root', 10, 'is:pr is:open', undefined, 'upstream')
@@ -300,7 +315,7 @@ describe('GitHub issue source split', () => {
       fellBack: false
     })
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'fork', repo: 'orca' })
-    getOwnerRepoForRemoteMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
+    mockUpstreamCandidate({ owner: 'stablyai', repo: 'orca' })
     ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '9\n' })
 
     const count = await countWorkItems('/repo-root', 'is:pr is:open', 'upstream')
@@ -326,7 +341,8 @@ describe('GitHub issue source split', () => {
       fellBack: true
     })
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'fork', repo: 'orca' })
-    getOwnerRepoForRemoteMock.mockResolvedValueOnce(null)
+    // beforeEach default: upstream probe resolves null, origin delegates to
+    // getOwnerRepoMock.
     ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' })
 
     const result = await listWorkItems('/repo-root', 10, 'is:pr', undefined, 'upstream')
@@ -637,7 +653,7 @@ describe('GitHub issue source split', () => {
         fellBack: false
       })
       getOwnerRepoMock.mockResolvedValueOnce({ owner: 'fork', repo: 'orca' })
-      getOwnerRepoForRemoteMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
+      mockUpstreamCandidate({ owner: 'stablyai', repo: 'orca' })
       ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' }).mockResolvedValueOnce({
         stdout: '[]'
       })
@@ -658,7 +674,7 @@ describe('GitHub issue source split', () => {
         fellBack: false
       })
       getOwnerRepoMock.mockResolvedValueOnce({ owner: 'fork', repo: 'orca' })
-      getOwnerRepoForRemoteMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
+      mockUpstreamCandidate({ owner: 'stablyai', repo: 'orca' })
       ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' }).mockResolvedValueOnce({
         stdout: '[]'
       })

--- a/src/main/github/client-work-items.test.ts
+++ b/src/main/github/client-work-items.test.ts
@@ -98,7 +98,14 @@ describe('listWorkItems', () => {
       source: await getIssueOwnerRepoMock(),
       fellBack: false
     }))
-    getOwnerRepoForRemoteMock.mockResolvedValue(null)
+    // Why: since #7331 `resolvePrWorkItemSource` fetches origin through
+    // `getOwnerRepoForRemote` (getOwnerRepo became upstream-first). Delegate
+    // the origin probe to `getOwnerRepoMock` so existing tests keep defining
+    // the PR-side origin through it; default upstream to null.
+    getOwnerRepoForRemoteMock.mockImplementation(
+      async (repoPath: string, remoteName: string, connectionId?: string | null, opts = {}) =>
+        remoteName === 'origin' ? getOwnerRepoMock(repoPath, connectionId, opts) : null
+    )
     _resetOwnerRepoCache()
     _resetMergeQueueCacheForTests()
     _resetGhCwdRepoNegativeCache()
@@ -262,7 +269,10 @@ describe('listWorkItems', () => {
       fellBack: false
     })
     getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
-    getOwnerRepoForRemoteMock.mockResolvedValue(null)
+    getOwnerRepoForRemoteMock.mockImplementation(
+      async (repoPath: string, remoteName: string, connectionId?: string | null, opts = {}) =>
+        remoteName === 'origin' ? getOwnerRepoMock(repoPath, connectionId, opts) : null
+    )
     ghExecFileAsyncMock.mockResolvedValue({ stdout: '[]' })
 
     await listWorkItems(
@@ -282,7 +292,12 @@ describe('listWorkItems', () => {
       null,
       localGitOptions
     )
-    expect(getOwnerRepoMock).toHaveBeenCalledWith('/repo-root', null, localGitOptions)
+    expect(getOwnerRepoForRemoteMock).toHaveBeenCalledWith(
+      '/repo-root',
+      'origin',
+      null,
+      localGitOptions
+    )
     expect(getOwnerRepoForRemoteMock).toHaveBeenCalledWith(
       '/repo-root',
       'upstream',

--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -109,6 +109,7 @@ import {
   getPRComments,
   getPRForBranch,
   getPRForBranchOutcome,
+  getRepoSlug,
   getRepoUpstream,
   getWorkItem,
   getPullRequestPushTarget,
@@ -3498,9 +3499,24 @@ describe('getPRForBranch', () => {
     expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
   })
 
+  it('keeps getRepoSlug origin-based on a fork checkout (#7331)', async () => {
+    // The slug is the checkout's own identity (renderer display, icon
+    // autodetect); it must not flip to the upstream parent.
+    getOwnerRepoForRemoteMock.mockImplementation(async (_repoPath: string, remoteName: string) =>
+      remoteName === 'origin'
+        ? { owner: 'fsdwen', repo: 'orca' }
+        : { owner: 'stablyai', repo: 'orca' }
+    )
+
+    await expect(getRepoSlug('/repo-root')).resolves.toEqual({ owner: 'fsdwen', repo: 'orca' })
+    expect(getOwnerRepoForRemoteMock).toHaveBeenCalledWith('/repo-root', 'origin', undefined)
+  })
+
   it('resolves a distinct upstream remote as the repo upstream', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'tmchow', repo: 'orca' })
-    getOwnerRepoForRemoteMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
+    // getRepoUpstream probes origin then upstream via getOwnerRepoForRemote (#7331).
+    getOwnerRepoForRemoteMock
+      .mockResolvedValueOnce({ owner: 'tmchow', repo: 'orca' })
+      .mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
 
     await expect(getRepoUpstream('/repo-root')).resolves.toEqual({
       owner: 'stablyai',
@@ -3511,8 +3527,9 @@ describe('getPRForBranch', () => {
   })
 
   it('does not treat a same-repository upstream remote as a fork', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'StablyAI', repo: 'Orca' })
-    getOwnerRepoForRemoteMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
+    getOwnerRepoForRemoteMock
+      .mockResolvedValueOnce({ owner: 'StablyAI', repo: 'Orca' })
+      .mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
     ghExecFileAsyncMock.mockResolvedValueOnce({
       stdout: JSON.stringify({ isFork: false, parent: null })
     })
@@ -3526,17 +3543,20 @@ describe('getPRForBranch', () => {
   })
 
   it('does not mark an upstream-only GitHub remote as a fork', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce(null)
+    // Missing origin short-circuits before the upstream probe.
+    getOwnerRepoForRemoteMock.mockResolvedValueOnce(null)
 
     await expect(getRepoUpstream('/repo-root')).resolves.toBeNull()
 
-    expect(getOwnerRepoForRemoteMock).not.toHaveBeenCalled()
+    expect(getOwnerRepoForRemoteMock).toHaveBeenCalledTimes(1)
+    expect(getOwnerRepoForRemoteMock).toHaveBeenCalledWith('/repo-root', 'origin', undefined)
     expect(ghExecFileAsyncMock).not.toHaveBeenCalled()
   })
 
   it('falls back to the GitHub parent when no upstream remote is configured', async () => {
-    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'tmchow', repo: 'orca' })
-    getOwnerRepoForRemoteMock.mockResolvedValueOnce(null)
+    getOwnerRepoForRemoteMock
+      .mockResolvedValueOnce({ owner: 'tmchow', repo: 'orca' })
+      .mockResolvedValueOnce(null)
     ghExecFileAsyncMock.mockResolvedValueOnce({
       stdout: JSON.stringify({
         isFork: true,

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -1093,7 +1093,9 @@ async function resolvePrWorkItemSource(
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<ResolvedPrWorkItemSource> {
   const [originCandidate, upstreamCandidate] = await Promise.all([
-    getOwnerRepo(repoPath, connectionId, localGitOptions),
+    // Why: this caller combines both remotes itself, so it needs origin
+    // specifically (getOwnerRepo is upstream-first since #7331).
+    getOwnerRepoForRemote(repoPath, 'origin', connectionId, localGitOptions),
     getOwnerRepoForRemote(repoPath, 'upstream', connectionId, localGitOptions)
   ])
   const source =
@@ -1647,7 +1649,15 @@ export async function getRepoSlug(
   connectionId?: string | null,
   options: HostedReviewExecutionOptions = {}
 ): Promise<{ owner: string; repo: string } | null> {
-  return getOwnerRepo(repoPath, connectionId, ...hostedReviewLocalGitOptionArgs(options))
+  // Why: the slug is the checkout's own identity (renderer display, icon
+  // autodetect), so it must stay origin-based — getOwnerRepo became
+  // upstream-first for PR reads in #7331.
+  return getOwnerRepoForRemote(
+    repoPath,
+    'origin',
+    connectionId,
+    ...hostedReviewLocalGitOptionArgs(options)
+  )
 }
 
 /**
@@ -1665,7 +1675,9 @@ export async function getRepoUpstream(
 ): Promise<OwnerRepo | null> {
   const localGitArgs = hostedReviewLocalGitOptionArgs(options)
   const localGitOptions = localGitArgs[0] ?? {}
-  const origin = await getOwnerRepo(repoPath, connectionId, ...localGitArgs)
+  // Why: must be origin specifically — the fork-parent fast-path below compares
+  // it against the upstream remote (getOwnerRepo is upstream-first since #7331).
+  const origin = await getOwnerRepoForRemote(repoPath, 'origin', connectionId, ...localGitArgs)
   if (!origin) {
     return null
   }
@@ -1877,9 +1889,16 @@ export async function createGitHubPullRequest(
 
   // Why: github.com-only slug parsing returns null for GHES, so fall back to the
   // enterprise resolver (gh-authenticated custom host) before giving up (#8312).
+  // Creation targets origin: the head branch is unqualified, so `gh pr create`
+  // must run against the repo the branch was pushed to, not the fork parent
+  // (getOwnerRepo became upstream-first for PR reads in #7331).
   const ownerRepo =
-    (await getOwnerRepo(repoPath, connectionId, ...hostedReviewLocalGitOptionArgs(options))) ??
-    (await getEnterpriseGitHubRepoSlug(repoPath, connectionId, options))
+    (await getOwnerRepoForRemote(
+      repoPath,
+      'origin',
+      connectionId,
+      ...hostedReviewLocalGitOptionArgs(options)
+    )) ?? (await getEnterpriseGitHubRepoSlug(repoPath, connectionId, options))
   if (!ownerRepo) {
     return {
       ok: false,
@@ -2037,9 +2056,8 @@ export async function getWorkItem(
         return issue
       }
     } catch (err) {
-      // Why: the issue lookup now targets `upstream` while the PR lookup targets `origin`,
-      // so a transient upstream failure (5xx, rate limit, network flake) on issue #N would
-      // silently fall through to origin's PR #N — potentially a completely unrelated item.
+      // Why: a transient failure (5xx, rate limit, network flake) on issue #N would
+      // silently fall through to PR #N — potentially a completely unrelated item.
       // Only fall through when the issue genuinely doesn't exist (404); re-throw everything
       // else so the outer catch returns null and the caller sees a real failure instead of
       // a wrong item. classifyGhError centralizes the 404/"not found" pattern-matching.

--- a/src/main/github/gh-utils.test.ts
+++ b/src/main/github/gh-utils.test.ts
@@ -89,21 +89,23 @@ describe('github owner/repo resolution', () => {
     expect(parseGitHubOwnerRepo('https://ghe.acme.internal/acme/orca.git')).toBeNull()
   })
 
-  it('keeps getOwnerRepo origin-based', async () => {
+  it('prefers upstream for PR owner/repo resolution (#7331)', async () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({
-      stdout: 'git@github.com:fork/orca.git\n'
+      stdout: 'git@github.com:stablyai/orca.git\n'
     })
 
-    await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'fork', repo: 'orca' })
-    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], {
+    await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'stablyai', repo: 'orca' })
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'upstream'], {
       cwd: '/repo'
     })
   })
 
   it('resolves GitHub HTTPS origin remotes with user info and a default port', async () => {
-    gitExecFileAsyncMock.mockResolvedValueOnce({
-      stdout: 'https://alice@github.com:443/acme/widgets.git\n'
-    })
+    gitExecFileAsyncMock
+      .mockRejectedValueOnce(new Error("fatal: No such remote 'upstream'"))
+      .mockResolvedValueOnce({
+        stdout: 'https://alice@github.com:443/acme/widgets.git\n'
+      })
 
     await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'acme', repo: 'widgets' })
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], {
@@ -141,8 +143,14 @@ describe('github owner/repo resolution', () => {
       .mockResolvedValueOnce({ stdout: 'git@github.com:fork/orca.git\n' })
       .mockResolvedValueOnce({ stdout: 'git@github.com:stablyai/orca.git\n' })
 
-    await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'fork', repo: 'orca' })
-    await expect(getIssueOwnerRepo('/repo')).resolves.toEqual({ owner: 'stablyai', repo: 'orca' })
+    await expect(getOwnerRepoForRemote('/repo', 'origin')).resolves.toEqual({
+      owner: 'fork',
+      repo: 'orca'
+    })
+    await expect(getOwnerRepoForRemote('/repo', 'upstream')).resolves.toEqual({
+      owner: 'stablyai',
+      repo: 'orca'
+    })
   })
 
   it('coalesces concurrent missing remote probes for the same repo and remote', async () => {
@@ -171,7 +179,12 @@ describe('github owner/repo resolution', () => {
 
   it('resolves SSH repo remotes through the registered SSH git provider', async () => {
     const sshProvider = {
-      exec: vi.fn().mockResolvedValue({ stdout: 'git@github.com:stablyai/orca.git\n', stderr: '' })
+      exec: vi.fn(async (args: string[]) => {
+        if (args[2] === 'upstream') {
+          throw new Error("fatal: No such remote 'upstream'")
+        }
+        return { stdout: 'git@github.com:stablyai/orca.git\n', stderr: '' }
+      })
     }
     getSshGitProviderMock.mockReturnValue(sshProvider)
 
@@ -200,9 +213,18 @@ describe('github owner/repo resolution', () => {
   })
 
   it('keeps local host and local WSL owner/repo cache entries separate for the same path', async () => {
-    gitExecFileAsyncMock
-      .mockResolvedValueOnce({ stdout: 'git@github.com:host/orca.git\n' })
-      .mockResolvedValueOnce({ stdout: 'git@github.com:wsl/orca.git\n' })
+    gitExecFileAsyncMock.mockImplementation(
+      async (args: string[], options: { wslDistro?: string } = {}) => {
+        if (args[2] === 'upstream') {
+          throw new Error("fatal: No such remote 'upstream'")
+        }
+        return {
+          stdout: options.wslDistro
+            ? 'git@github.com:wsl/orca.git\n'
+            : 'git@github.com:host/orca.git\n'
+        }
+      }
+    )
 
     await expect(getOwnerRepo('/repo')).resolves.toEqual({ owner: 'host', repo: 'orca' })
     await expect(getOwnerRepo('/repo', null, { wslDistro: 'Ubuntu' })).resolves.toEqual({
@@ -214,11 +236,12 @@ describe('github owner/repo resolution', () => {
       repo: 'orca'
     })
 
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
-    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(1, ['remote', 'get-url', 'origin'], {
+    // 2 runtimes x (1 upstream miss + 1 origin hit); repeat WSL call is cached.
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(4)
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], {
       cwd: '/repo'
     })
-    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(2, ['remote', 'get-url', 'origin'], {
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], {
       cwd: '/repo',
       wslDistro: 'Ubuntu'
     })

--- a/src/main/github/github-repository-identity.fork-owner-repo.test.ts
+++ b/src/main/github/github-repository-identity.fork-owner-repo.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as GitRunner from '../git/runner'
+
+// Fix for issue #7331: PR details failed to load on fork checkouts because
+// getOwnerRepo() (the PR-lookup resolver) only consulted the `origin` remote
+// (the fork), while the PRs live on the upstream parent. getOwnerRepo now
+// prefers `upstream` when present, mirroring getIssueOwnerRepo.
+
+const { gitExecFileAsyncMock, ghExecFileAsyncMock, readLocalGitConfigSignatureMock } = vi.hoisted(
+  () => ({
+    gitExecFileAsyncMock: vi.fn(),
+    ghExecFileAsyncMock: vi.fn(),
+    readLocalGitConfigSignatureMock: vi.fn(async () => 'sig')
+  })
+)
+
+vi.mock('../git/runner', async (importOriginal) => ({
+  ...(await importOriginal<typeof GitRunner>()),
+  gitExecFileAsync: gitExecFileAsyncMock,
+  ghExecFileAsync: ghExecFileAsyncMock
+}))
+
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: () => null
+}))
+
+vi.mock('./local-git-config-signature', () => ({
+  readLocalGitConfigSignature: readLocalGitConfigSignatureMock
+}))
+
+import {
+  getOwnerRepo,
+  getIssueOwnerRepo,
+  getOwnerRepoForRemote,
+  _resetOwnerRepoCache
+} from './github-repository-identity'
+import { getRepoUpstream } from './client'
+
+const FORK_PATH = '/tmp/fork-checkout'
+const NON_FORK_PATH = '/tmp/plain-checkout'
+const SSH_FORK_PATH = '/tmp/ssh-fork-checkout'
+
+// origin -> personal fork, upstream -> parent (the classic fork checkout).
+const REMOTE_URLS_BY_REPO: Record<string, Record<string, string>> = {
+  [FORK_PATH]: {
+    origin: 'https://github.com/fsdwen/orca.git',
+    upstream: 'https://github.com/stablyai/orca.git'
+  },
+  [NON_FORK_PATH]: {
+    origin: 'https://github.com/stablyai/orca.git'
+  },
+  [SSH_FORK_PATH]: {
+    origin: 'git@github.com:fsdwen/orca.git',
+    upstream: 'git@github.com:stablyai/orca.git'
+  }
+}
+
+beforeEach(() => {
+  _resetOwnerRepoCache()
+  gitExecFileAsyncMock.mockReset()
+  ghExecFileAsyncMock.mockReset()
+  gitExecFileAsyncMock.mockImplementation(
+    async (args: string[], options: { cwd?: string } = {}) => {
+      // getRemoteUrlForRepo calls: ['remote', 'get-url', <remoteName>]
+      const remoteName = args[2]
+      const url = REMOTE_URLS_BY_REPO[options.cwd ?? '']?.[remoteName]
+      if (!url) {
+        const err = new Error(`fatal: No such remote '${remoteName}'`) as Error & { code?: number }
+        err.code = 128
+        throw err
+      }
+      return { stdout: url }
+    }
+  )
+})
+
+describe('issue #7331: fork PR owner/repo resolution', () => {
+  it('getOwnerRepo prefers the upstream parent on a fork checkout', async () => {
+    const prRepo = await getOwnerRepo(FORK_PATH)
+
+    // PRs live on the parent, so PR lookups must target it (matches
+    // getIssueOwnerRepo).
+    expect(prRepo).toEqual({ owner: 'stablyai', repo: 'orca' })
+  })
+
+  it('getOwnerRepo and getIssueOwnerRepo agree on a fork checkout', async () => {
+    const prRepo = await getOwnerRepo(FORK_PATH)
+    const issueRepo = await getIssueOwnerRepo(FORK_PATH)
+
+    expect(prRepo).toEqual(issueRepo)
+  })
+
+  it('getOwnerRepo falls back to origin when there is no upstream remote', async () => {
+    const prRepo = await getOwnerRepo(NON_FORK_PATH)
+
+    expect(prRepo).toEqual({ owner: 'stablyai', repo: 'orca' })
+  })
+
+  it('caches the missing-upstream probe so repeat lookups skip the git spawn', async () => {
+    await getOwnerRepo(NON_FORK_PATH)
+    const upstreamProbes = (): number =>
+      gitExecFileAsyncMock.mock.calls.filter(([args]) => args[2] === 'upstream').length
+    expect(upstreamProbes()).toBe(1)
+
+    await getOwnerRepo(NON_FORK_PATH)
+    // Second lookup within the negative-cache TTL must not respawn git for
+    // the missing upstream remote.
+    expect(upstreamProbes()).toBe(1)
+  })
+
+  it('resolves the upstream parent for SSH-style remote URLs', async () => {
+    const prRepo = await getOwnerRepo(SSH_FORK_PATH)
+
+    expect(prRepo).toEqual({ owner: 'stablyai', repo: 'orca' })
+  })
+
+  it('getOwnerRepoForRemote(origin) still resolves the fork itself', async () => {
+    // Callers that combine origin+upstream themselves (getRepoUpstream,
+    // resolvePrWorkItemSource) depend on an origin-only primitive.
+    const origin = await getOwnerRepoForRemote(FORK_PATH, 'origin')
+
+    expect(origin).toEqual({ owner: 'fsdwen', repo: 'orca' })
+  })
+
+  it('getRepoUpstream still resolves the fork parent offline (regression)', async () => {
+    // If getRepoUpstream compared upstream against an upstream-first
+    // getOwnerRepo, the remotes would look identical and the offline fork
+    // fast-path would be skipped.
+    const upstream = await getRepoUpstream(FORK_PATH)
+
+    expect(upstream).toEqual({ owner: 'stablyai', repo: 'orca' })
+    expect(ghExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/github/github-repository-identity.ts
+++ b/src/main/github/github-repository-identity.ts
@@ -208,6 +208,11 @@ export async function getOwnerRepo(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<OwnerRepo | null> {
+  // Why: on a fork checkout PRs live on the upstream parent, not origin (#7331).
+  const upstream = await getOwnerRepoForRemote(repoPath, 'upstream', connectionId, localGitOptions)
+  if (upstream) {
+    return upstream
+  }
   return getOwnerRepoForRemote(repoPath, 'origin', connectionId, localGitOptions)
 }
 

--- a/src/main/github/work-item-details.ts
+++ b/src/main/github/work-item-details.ts
@@ -822,9 +822,9 @@ async function getWorkItemParticipants(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<GitHubAssignableUser[]> {
-  // Why: issues in a fork live on the upstream remote, so participants must be
-  // resolved via getIssueOwnerRepo to stay consistent with getIssueBodyAndComments.
-  // PRs remain tied to origin via getOwnerRepo.
+  // Why: work items in a fork live on the upstream remote, so participants must
+  // be resolved via the same upstream-first resolvers the body/comment fetches
+  // use (getIssueOwnerRepo for issues, getOwnerRepo for PRs; see #7331).
   const ownerRepo =
     item.type === 'issue'
       ? await getIssueOwnerRepo(repoPath, connectionId, ...localGitOptionArgs(localGitOptions))


### PR DESCRIPTION
## Description

On a fork checkout — where `origin` points at your personal fork and `upstream` points at the parent repo — opening PR details failed to load. GitHub PRs live on the upstream parent, but the PR-lookup resolver only ever consulted the fork.

Root cause: `getOwnerRepo()` in `src/main/github/github-repository-identity.ts:206` resolved only the `origin` remote, so `gh pr view <N> --repo <fork>` targeted the fork and returned `Could not resolve to a PullRequest`. The sibling `getIssueOwnerRepo()` already preferred `upstream` first, so issues loaded but PRs did not — the exact divergence #7331 reports.

Fix: make `getOwnerRepo()` prefer the `upstream` remote when present and fall back to `origin` otherwise, mirroring `getIssueOwnerRepo()`. Repos with no `upstream` remote are unaffected (behavior unchanged).

Because `getOwnerRepo()` is also used by callers that specifically need the checkout's *own* (origin) identity, those call sites were switched to the origin-only primitive `getOwnerRepoForRemote(repoPath, 'origin', …)` so their behavior is preserved:
- `getRepoSlug` (`src/main/github/client.ts:1649`) — the slug is the checkout's own identity used for renderer display and icon autodetect; must stay origin-based.
- `getRepoUpstream` (`src/main/github/client.ts:1675`) — its offline fork-parent fast-path compares origin against the upstream remote; both must be distinct.
- `resolvePrWorkItemSource` (`src/main/github/client.ts:1093`) — combines origin + upstream itself, so it needs origin explicitly.
- `createGitHubPullRequest` (`src/main/github/client.ts:1889`) — the head branch is unqualified and lives on the fork, so `gh pr create` must run against origin.

Fixes #7331

## Evidence (proof of improvement)

New test: `src/main/github/github-repository-identity.fork-owner-repo.test.ts` (imports the real `github-repository-identity` and `client` modules; only the git runner / ssh dispatch / config-signature boundaries are mocked).

```
 RUN  v4.1.5

 Test Files  1 passed (1)
      Tests  7 passed (7)
```

Coverage:
- `getOwnerRepo` prefers the upstream parent on a fork checkout — returns `stablyai/orca`, not the fork `fsdwen/orca`.
- `getOwnerRepo` and `getIssueOwnerRepo` now agree on a fork checkout (the pre-fix discrepancy is gone).
- `getOwnerRepo` falls back to `origin` when there is no `upstream` remote (non-fork behavior unchanged).
- The missing-upstream probe is cached, so repeat lookups don't respawn git.
- SSH-style remote URLs (`git@github.com:…`) resolve the upstream parent too.
- `getOwnerRepoForRemote('origin')` still resolves the fork itself (origin-only primitive intact).
- `getRepoUpstream` still resolves the fork parent offline without any `gh` call (fast-path regression guard).

Failing-on-main → passing-on-fix reasoning: the reproduction test in the scan worktree pins the buggy behavior — on `main`, `getOwnerRepo(forkCheckout)` returns `{ owner: 'fsdwen', repo: 'orca' }` (the fork) while `getIssueOwnerRepo` returns `{ owner: 'stablyai', repo: 'orca' }`, and the two resolvers disagree. After this change `getOwnerRepo` returns the upstream parent and the two resolvers agree, which is what the new test asserts.

## Proof of no regression

- Full `src/main/github/` vitest suite: **27 files, 389 tests passed**.
- `typecheck:tsc:node` (`tsc --noEmit -p config/tsconfig.node.json`): clean, no errors.
- `oxlint` on all changed files: exit 0, no warnings/errors. Pre-commit hook (oxlint + react-doctor + oxfmt) passed.

Unchanged behaviors and why:
- Non-fork repos have no `upstream` remote, so `getOwnerRepo` falls through to the identical `origin` resolution — the negative `upstream` probe is cached to avoid extra git spawns.
- `getRepoSlug` continues returning the checkout's own (origin) identity, so renderer display and icon autodetect are untouched.
- `getRepoUpstream`'s offline fork-detection fast-path still compares a distinct origin vs. upstream, so fork parents still resolve without a network `gh` call.
- `createGitHubPullRequest` still targets origin, so PR creation pushes to the fork the branch actually lives on.
- Existing `github` tests that previously defined the origin candidate through `getOwnerRepo` were rerouted to the origin-only `getOwnerRepoForRemote` mock, asserting the same end-user outcomes.

## ELI5

When you copy someone else's project to your own account (a "fork") and then look at a pull request, the request actually lives on the original project, not your copy. The app was mistakenly looking in your copy, so the PR page came up empty. Now it looks in the original project first — just like it already did for issues — so pull requests load correctly, and everything works exactly as before for projects that aren't forks.

## Credit

This lands the fix community-identified in #7332 by @fsdwen (who also filed #7331 with the root-cause analysis) and hardened in #7513 by @brennanb2025. Both are credited as commit co-authors. This PR carries the same upstream-first core change plus an audit of every `getOwnerRepo` call site (notably keeping `getRepoSlug` on the checkout's own origin identity) against current main.

Made with [Orca](https://github.com/stablyai/orca) 🐋

