### PR TITLE
feat: make worktree tooling bare-repository aware

### DIFF
--- a/docs/reference/git-compatibility.md
+++ b/docs/reference/git-compatibility.md
@@ -41,6 +41,34 @@ authority.
 | `merge-tree-write-tree` | Derive real-merge conflicts and no-op tree proofs | Omit the conflict summary and keep conservative branch cleanup behavior before Git 2.38 |
 | `merge-tree-merge-base` | Supply the already-resolved merge base            | Use the older two-commit `merge-tree --write-tree` form                                 |
 
+## Bare Repositories
+
+A repo added from a bare directory (`git clone --bare` / `git init --bare`)
+has no working tree: `repo.path` is the git dir itself. Orca models this with
+`Repo.isBare`, stamped at add time by `rev-parse --is-bare-repository` (with a
+filesystem-marker fallback when git cannot answer) on every execution host,
+and lazily backfilled when a worktree listing reports a `bare` first entry.
+
+Rules for code that touches a repo root:
+
+- Never treat `repo.path` as a checkout. `git worktree list` reports the bare
+  entry first with the `bare` attribute; it is filtered out of every
+  detected-workspace listing and must never receive working-tree commands
+  (`status`, `pull`, `checkout`) or working-tree reads/writes (`orca.yaml`,
+  `.gitignore`, icons).
+- Path plumbing differs: the git dir is `repo.path` itself (not
+  `<repo>/.git`), and the linked-worktree admin dir is `<repo>/worktrees`
+  (not `<repo>/.git/worktrees`).
+- Relative workspace dirs resolve beside the bare dir, not inside it — a
+  relative `worktrees` value would otherwise collide with git's admin dir.
+- Default base-ref resolution cannot rely on `refs/remotes/origin/*` or
+  `origin/HEAD`; bare clones fetch straight into `refs/heads/*`. After the
+  probe list, `symbolic-ref HEAD` (verified against a real ref) is the final
+  fallback. An unborn HEAD still resolves to no default, which fails loudly.
+- All commands involved (`worktree list --porcelain` `bare` attribute,
+  `rev-parse --is-bare-repository`, `symbolic-ref HEAD`) are within the
+  Git 2.25 baseline; no capability probe is needed for bareness itself.
+
 ## Why Not `simple-git`
 
 `simple-git` is a process wrapper around the installed Git binary. Its custom

--- a/src/main/git/repo-detection.test.ts
+++ b/src/main/git/repo-detection.test.ts
@@ -11,7 +11,7 @@ import {
 import { tmpdir } from 'node:os'
 import * as path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { getGitRepoRoot, isGitRepo, normalizeGitRepoRootForInputPath } from './repo'
+import { getGitRepoRoot, isBareGitRepo, isGitRepo, normalizeGitRepoRootForInputPath } from './repo'
 
 function git(cwd: string, args: string[]): string {
   return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] })
@@ -326,6 +326,49 @@ describe('isGitRepo', () => {
     git(tmpDir, ['init', '--bare', '--quiet', bareRepo])
 
     expect(getGitRepoRoot(bareRepo)).toBe(bareRepo)
+  })
+})
+
+describe('isBareGitRepo', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'orca-repo-detect-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns true for a bare repository', () => {
+    const bareRepo = path.join(tmpDir, 'bare.git')
+    git(tmpDir, ['init', '--bare', '--quiet', bareRepo])
+
+    expect(isBareGitRepo(bareRepo)).toBe(true)
+  })
+
+  it('returns false for a regular checkout', () => {
+    const realRepo = path.join(tmpDir, 'real')
+    mkdirSync(realRepo)
+    git(realRepo, ['init', '--quiet'])
+
+    expect(isBareGitRepo(realRepo)).toBe(false)
+  })
+
+  it('returns false for a plain directory', () => {
+    const plainDir = path.join(tmpDir, 'plain')
+    mkdirSync(plainDir)
+
+    expect(isBareGitRepo(plainDir)).toBe(false)
+  })
+
+  it('recognizes a bare repository via markers when git itself cannot be run', () => {
+    const bareRepo = path.join(tmpDir, 'bare-fallback.git')
+    git(tmpDir, ['init', '--bare', '--quiet', bareRepo])
+
+    withGitUnavailable(() => {
+      expect(isBareGitRepo(bareRepo)).toBe(true)
+    })
   })
 })
 

--- a/src/main/git/repo.test.ts
+++ b/src/main/git/repo.test.ts
@@ -529,6 +529,44 @@ describe('getDefaultBaseRef (regression — unchanged behavior)', () => {
   })
 })
 
+describe('getDefaultBaseRef (bare repos)', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'orca-repo-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('falls back to the HEAD branch for a bare clone with a nonstandard default branch', () => {
+    // Why: `git clone --bare` populates refs/heads/* directly — no
+    // refs/remotes/origin/* and no origin/HEAD — so with a default branch
+    // that is neither main nor master, every probe misses and only HEAD
+    // names the branch.
+    const srcDir = path.join(tmpDir, 'src')
+    git(tmpDir, ['init', '--quiet', 'src'])
+    git(srcDir, ['symbolic-ref', 'HEAD', 'refs/heads/trunk'])
+    git(srcDir, ['config', 'user.email', 'test@test.com'])
+    git(srcDir, ['config', 'user.name', 'Test'])
+    git(srcDir, ['commit', '--allow-empty', '-m', 'initial', '--quiet'])
+    git(tmpDir, ['clone', '--bare', '--quiet', srcDir, 'hub.git'])
+
+    const result = getDefaultBaseRef(path.join(tmpDir, 'hub.git'))
+
+    expect(result).toBe('trunk')
+  })
+
+  it('returns null for a fresh bare init whose HEAD is unborn', () => {
+    git(tmpDir, ['init', '--bare', '--quiet', 'empty.git'])
+
+    const result = getDefaultBaseRef(path.join(tmpDir, 'empty.git'))
+
+    expect(result).toBeNull()
+  })
+})
+
 describe('resolveDefaultBaseRefViaExec', () => {
   it('falls through from a stale origin/HEAD target to the probe list', async () => {
     const calls: string[][] = []
@@ -573,6 +611,38 @@ describe('resolveDefaultBaseRefViaExec', () => {
       ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main'],
       ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/master']
     ])
+  })
+
+  it('falls back to the HEAD branch when origin/HEAD and every probe are missing', async () => {
+    const calls: string[][] = []
+    const exec = async (argv: string[]): Promise<{ stdout: string }> => {
+      calls.push(argv)
+      if (argv[0] === 'symbolic-ref' && argv.at(-1) === 'HEAD') {
+        return { stdout: 'refs/heads/trunk\n' }
+      }
+      if (argv[0] === 'rev-parse' && argv.at(-1) === 'refs/heads/trunk') {
+        return { stdout: 'trunk-sha\n' }
+      }
+      throw new Error('missing ref')
+    }
+
+    await expect(resolveDefaultBaseRefViaExec(exec)).resolves.toBe('trunk')
+
+    expect(calls.at(-2)).toEqual(['symbolic-ref', '--quiet', 'HEAD'])
+    expect(calls.at(-1)).toEqual(['rev-parse', '--verify', '--quiet', 'refs/heads/trunk'])
+  })
+
+  it('stays null when HEAD points at an unborn branch', async () => {
+    // Why: a fresh `git init --bare` has a symbolic HEAD but no commits;
+    // worktree creation must still fail loudly rather than get a bad ref.
+    const exec = async (argv: string[]): Promise<{ stdout: string }> => {
+      if (argv[0] === 'symbolic-ref' && argv.at(-1) === 'HEAD') {
+        return { stdout: 'refs/heads/main\n' }
+      }
+      throw new Error('missing ref')
+    }
+
+    await expect(resolveDefaultBaseRefViaExec(exec)).resolves.toBeNull()
   })
 })
 

--- a/src/main/git/repo.ts
+++ b/src/main/git/repo.ts
@@ -152,6 +152,29 @@ function probeGitRepo(path: string): GitRepoProbeResult {
   return sawFailure ? 'indeterminate' : 'not-repo'
 }
 
+/**
+ * True when `path` is the root of a bare git repository (no working tree).
+ * Why: bare repos are valid projects but must never be treated as a
+ * workspace; callers stamp Repo.isBare from this at add time.
+ */
+export function isBareGitRepo(path: string): boolean {
+  try {
+    const bareRepo = gitExecFileSync(['rev-parse', '--is-bare-repository'], {
+      cwd: path
+    }).trim()
+    if (bareRepo === 'true') {
+      return true
+    }
+    if (bareRepo === 'false') {
+      return false
+    }
+  } catch {
+    // Why: mirror isGitRepo — a spawn/config failure is not a verdict; fall
+    // back to the filesystem marker so a genuine bare repo is still flagged.
+  }
+  return hasValidBareRepoMarkerSync(path)
+}
+
 export function getGitRepoRoot(path: string): string {
   try {
     if (!existsSync(path) || !statSync(path).isDirectory()) {

--- a/src/main/git/repo.ts
+++ b/src/main/git/repo.ts
@@ -391,7 +391,8 @@ function hasValidLinkedWorktreeGitDirectorySync(gitDir: string): boolean {
   }
 }
 
-function hasValidBareRepoMarkerSync(path: string): boolean {
+/** Filesystem-only bare-root check (no git spawn) for callers that must stay cheap. */
+export function hasValidBareRepoMarkerSync(path: string): boolean {
   return hasValidCommonGitDirectorySync(path) && !gitConfigDeclaresNonBare(path)
 }
 

--- a/src/main/git/repo.ts
+++ b/src/main/git/repo.ts
@@ -540,7 +540,27 @@ export function getDefaultBaseRef(path: string): string | null {
       return returnAs
     }
   }
-  return null
+  return getHeadBranchBaseRef(path)
+}
+
+/**
+ * Last-resort default: HEAD's symbolic target. Bare clones populate neither
+ * refs/remotes/origin/* nor origin/HEAD, and a nonstandard default branch
+ * misses the main/master probes; HEAD still names the branch git itself
+ * treats as default. Unborn HEAD fails the ref verify and stays null.
+ */
+function getHeadBranchBaseRef(path: string): string | null {
+  try {
+    const ref = gitExecFileSync(['symbolic-ref', '--quiet', 'HEAD'], {
+      cwd: path
+    }).trim()
+    if (!ref.startsWith('refs/heads/') || !hasGitRef(path, ref)) {
+      return null
+    }
+    return ref.slice('refs/heads/'.length)
+  } catch {
+    return null
+  }
 }
 
 export async function getBaseRefDefault(
@@ -678,7 +698,25 @@ export async function resolveDefaultBaseRefViaExec(exec: GitExec): Promise<strin
   if (originHeadBaseRef) {
     return originHeadBaseRef
   }
-  return resolveDefaultBaseRefFromProbes((ref) => hasGitRefViaExec(exec, ref))
+  const probed = await resolveDefaultBaseRefFromProbes((ref) => hasGitRefViaExec(exec, ref))
+  if (probed) {
+    return probed
+  }
+  return resolveHeadBranchBaseRefViaExec(exec)
+}
+
+/** Exec-callback twin of getHeadBranchBaseRef — keep the two in sync. */
+async function resolveHeadBranchBaseRefViaExec(exec: GitExec): Promise<string | null> {
+  try {
+    const { stdout } = await exec(['symbolic-ref', '--quiet', 'HEAD'])
+    const ref = stdout.trim()
+    if (!ref.startsWith('refs/heads/') || !(await hasGitRefViaExec(exec, ref))) {
+      return null
+    }
+    return ref.slice('refs/heads/'.length)
+  } catch {
+    return null
+  }
 }
 
 export function resolveDefaultBaseRefWithLocalGit(

--- a/src/main/git/status-resolve-git-dir.test.ts
+++ b/src/main/git/status-resolve-git-dir.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import * as path from 'node:path'
+import { resolveGitDir } from './status'
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] })
+}
+
+function initRepoWithCommit(parent: string, name: string): string {
+  const dir = path.join(parent, name)
+  git(parent, ['init', '--quiet', name])
+  git(dir, ['config', 'user.email', 'test@test.com'])
+  git(dir, ['config', 'user.name', 'Test'])
+  git(dir, ['commit', '--allow-empty', '-m', 'initial', '--quiet'])
+  return dir
+}
+
+describe('resolveGitDir', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'orca-resolve-git-dir-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns <path>/.git for a regular checkout', async () => {
+    const repo = path.join(tmpDir, 'repo')
+    git(tmpDir, ['init', '--quiet', 'repo'])
+
+    await expect(resolveGitDir(repo)).resolves.toBe(path.join(repo, '.git'))
+  })
+
+  it('resolves the gitdir file of a linked worktree', async () => {
+    const repo = initRepoWithCommit(tmpDir, 'repo')
+    const linked = path.join(tmpDir, 'linked')
+    git(repo, ['worktree', 'add', '--quiet', linked])
+
+    await expect(resolveGitDir(linked)).resolves.toBe(
+      path.join(repo, '.git', 'worktrees', 'linked')
+    )
+  })
+
+  it('returns the repo path itself for a bare repo', async () => {
+    // Why: a bare repo has no `.git` entry — the repo path IS the git dir.
+    // Returning the previous `<path>/.git` pointed consumers at a
+    // nonexistent location.
+    const bare = path.join(tmpDir, 'hub.git')
+    git(tmpDir, ['init', '--bare', '--quiet', 'hub.git'])
+
+    await expect(resolveGitDir(bare)).resolves.toBe(bare)
+  })
+
+  it('still returns <path>/.git for a missing path with no git markers', async () => {
+    const missing = path.join(tmpDir, 'missing')
+
+    await expect(resolveGitDir(missing)).resolves.toBe(path.join(missing, '.git'))
+  })
+})

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -1054,10 +1054,27 @@ export async function resolveGitDir(worktreePath: string): Promise<string> {
       return path.resolve(worktreePath, match[1])
     }
   } catch {
-    // `.git` is likely a directory in a non-worktree checkout.
+    // `.git` is likely a directory in a non-worktree checkout — or absent
+    // for a bare repo, whose git dir is the path itself.
+    if (await isBareGitDirRoot(worktreePath)) {
+      return worktreePath
+    }
   }
 
   return dotGitPath
+}
+
+async function isBareGitDirRoot(worktreePath: string): Promise<boolean> {
+  try {
+    const [headStat, objectsStat, refsStat] = await Promise.all([
+      stat(path.join(worktreePath, 'HEAD')),
+      stat(path.join(worktreePath, 'objects')),
+      stat(path.join(worktreePath, 'refs'))
+    ])
+    return headStat.isFile() && objectsStat.isDirectory() && refsStat.isDirectory()
+  } catch {
+    return false
+  }
 }
 
 /**

--- a/src/main/hooks.test.ts
+++ b/src/main/hooks.test.ts
@@ -13,7 +13,8 @@ vi.mock('fs', () => ({
   mkdirSync: vi.fn(),
   writeFileSync: vi.fn(),
   rmSync: vi.fn(),
-  chmodSync: vi.fn()
+  chmodSync: vi.fn(),
+  statSync: vi.fn()
 }))
 
 const { execMock, execFileMock, gitExecFileSyncMock } = vi.hoisted(() => ({
@@ -433,6 +434,38 @@ describe('writeIssueCommand', () => {
     expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
       TEST_ISSUE_COMMAND_PATH,
       'local command\n',
+      'utf-8'
+    )
+  })
+
+  it('skips the .gitignore write when the repo path is a bare git dir', async () => {
+    const fs = await import('node:fs')
+    const bareRepoPath = join('/test/bare.git')
+    vi.mocked(fs.existsSync).mockImplementation((path) => path === join(bareRepoPath, '.orca'))
+    vi.mocked(fs.statSync).mockImplementation(((path: string) => {
+      if (path === join(bareRepoPath, 'HEAD')) {
+        return { isFile: () => true, isDirectory: () => false }
+      }
+      if (path === join(bareRepoPath, 'objects') || path === join(bareRepoPath, 'refs')) {
+        return { isFile: () => false, isDirectory: () => true }
+      }
+      throw new Error('ENOENT')
+    }) as never)
+    vi.mocked(fs.readFileSync).mockImplementation(() => {
+      throw new Error('ENOENT')
+    })
+
+    const { writeIssueCommand } = await import('./hooks')
+    writeIssueCommand(bareRepoPath, 'local command')
+
+    expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+      join(bareRepoPath, '.orca', 'issue-command'),
+      'local command\n',
+      'utf-8'
+    )
+    expect(vi.mocked(fs.writeFileSync)).not.toHaveBeenCalledWith(
+      join(bareRepoPath, '.gitignore'),
+      expect.anything(),
       'utf-8'
     )
   })

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -9,6 +9,7 @@ import { shouldWaitForSetupBeforeAgentStartup } from '../shared/setup-agent-star
 import { TERMINAL_GIT_CREDENTIAL_GUARD_POLICY_ENV } from '../shared/terminal-git-credential-guard'
 import { parseOrcaYaml } from '../shared/orca-yaml'
 import { gitExecFileSync, promptGuardShellEnv } from './git/runner'
+import { hasValidBareRepoMarkerSync } from './git/repo'
 import { isWslPath, parseWslPath, toWindowsWslPath, toLinuxPath } from './wsl'
 import type {
   HookCommandSourcePolicy,
@@ -182,6 +183,11 @@ export function writeIssueCommand(repoPath: string, content: string): void {
  * directory is never accidentally committed.
  */
 function ensureOrcaDirIgnored(repoPath: string): void {
+  // Why: a bare repo path is its git dir — nothing there can be committed,
+  // and a .gitignore written into it is inert junk.
+  if (hasValidBareRepoMarkerSync(repoPath)) {
+    return
+  }
   const gitignorePath = join(repoPath, '.gitignore')
   try {
     if (existsSync(gitignorePath)) {

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -60,6 +60,7 @@ import {
 import { createNestedRepoImportTargetResolver } from '../project-groups/nested-repo-import-target'
 import {
   isGitRepo,
+  isBareGitRepo,
   getGitRepoRoot,
   getRepoName,
   getBaseRefDefault,
@@ -215,6 +216,7 @@ async function addLocalRepoFromPath(
   }
 
   const detected = await detectRepoIconAndUpstream({ repoPath: resolvedPath, kind: repoKind })
+  const isBare = repoKind === 'git' && isBareGitRepo(resolvedPath)
   const repo: Repo = {
     id: randomUUID(),
     path: resolvedPath,
@@ -223,6 +225,7 @@ async function addLocalRepoFromPath(
     ...detected,
     addedAt: Date.now(),
     kind: repoKind,
+    ...(isBare ? { isBare: true } : {}),
     ...(repoKind === 'git'
       ? {
           externalWorktreeVisibility: 'hide' as const,
@@ -314,6 +317,7 @@ async function addRemoteRepoFromPath(
     kind: repoKind,
     connectionId: args.connectionId
   })
+  const isBare = repoKind === 'git' && (await remoteRepoIsBare(gitProvider, resolvedPath))
   const repo: Repo = {
     id: randomUUID(),
     path: resolvedPath,
@@ -323,6 +327,7 @@ async function addRemoteRepoFromPath(
     addedAt: Date.now(),
     kind: repoKind,
     connectionId: args.connectionId,
+    ...(isBare ? { isBare: true } : {}),
     ...(repoKind === 'git'
       ? {
           externalWorktreeVisibility: 'hide' as const,
@@ -339,6 +344,20 @@ async function addRemoteRepoFromPath(
   }
 
   return { repo, alreadyExisted: false }
+}
+
+async function remoteRepoIsBare(
+  gitProvider: { exec: (args: string[], cwd: string) => Promise<{ stdout: string }> },
+  remotePath: string
+): Promise<boolean> {
+  try {
+    const result = await gitProvider.exec(['rev-parse', '--is-bare-repository'], remotePath)
+    return result.stdout.trim() === 'true'
+  } catch {
+    // Why: bareness is an enhancement, not a validity gate — the repo already
+    // passed isGitRepoAsync, so a failed probe just means "treat as non-bare".
+    return false
+  }
 }
 
 function getRemoteRepoFolderName(remotePath: string): string {

--- a/src/main/ipc/worktree-logic.test.ts
+++ b/src/main/ipc/worktree-logic.test.ts
@@ -216,6 +216,42 @@ describe('computeWorktreePath', () => {
     ).toBe(posix.resolve('/projects/app/worktrees/feature'))
   })
 
+  it('resolves relative workspace directories beside a bare repo, not inside it', () => {
+    // Why: the bare repo path IS its git dir — a relative 'worktrees' root
+    // resolved inside it would collide with git's own admin dir.
+    expect(
+      computeWorkspaceRoot('/projects/app.git', { workspaceDir: 'worktrees', repoIsBare: true })
+    ).toBe(posix.resolve('/projects/worktrees'))
+    expect(
+      computeWorktreePath('feature', '/projects/app.git', {
+        nestWorkspaces: false,
+        workspaceDir: 'worktrees',
+        repoIsBare: true
+      })
+    ).toBe(posix.resolve('/projects/worktrees/feature'))
+  })
+
+  it('keeps absolute workspace directories unchanged for bare repos', () => {
+    expect(
+      computeWorkspaceRoot('/projects/app.git', { workspaceDir: '/workspaces', repoIsBare: true })
+    ).toBe('/workspaces')
+  })
+
+  it('stamps repoIsBare into worktree path settings from the repo', () => {
+    expect(
+      getWorktreePathSettings(
+        { path: '/projects/app.git', isBare: true },
+        { nestWorkspaces: false, workspaceDir: '/workspaces' }
+      )
+    ).toEqual({ nestWorkspaces: false, workspaceDir: '/workspaces', repoIsBare: true })
+    expect(
+      getWorktreePathSettings(
+        { path: '/projects/app' },
+        { nestWorkspaces: false, workspaceDir: '/workspaces' }
+      )
+    ).toEqual({ nestWorkspaces: false, workspaceDir: '/workspaces', repoIsBare: false })
+  })
+
   it('scopes the same relative repo override to each repo root', () => {
     const settings = { nestWorkspaces: false, workspaceDir: '/global/workspaces' }
     const repoA = { path: '/projects/a/repo', worktreeBasePath: '../worktrees' }

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -6,7 +6,9 @@ import { splitWorktreeId } from '../../shared/worktree-id'
 import { getWslHome, parseWslPath } from '../wsl'
 
 type WorktreePathSettings = Pick<GlobalSettings, 'nestWorkspaces' | 'workspaceDir'>
-type WorktreeBasePathRepo = Pick<Repo, 'path' | 'worktreeBasePath'>
+/** WorktreePathSettings enriched by getWorktreePathSettings with the repo's bareness. */
+type WorktreePathComputationSettings = WorktreePathSettings & { repoIsBare?: boolean }
+type WorktreeBasePathRepo = Pick<Repo, 'path' | 'worktreeBasePath' | 'isBare'>
 
 export { computeBranchName, getConfiguredBranchPrefix } from './worktree-branch-name'
 export { mergeWorktree } from './worktree-metadata-merge'
@@ -85,7 +87,7 @@ export function ensurePathWithinWorkspace(targetPath: string, workspaceDir: stri
 export function computeWorktreePath(
   sanitizedName: string,
   repoPath: string,
-  settings: WorktreePathSettings
+  settings: WorktreePathComputationSettings
 ): string {
   const workspaceRoot = computeWorkspaceRoot(repoPath, settings)
   const pathOps = getRuntimePathOps(repoPath, workspaceRoot)
@@ -97,7 +99,10 @@ export function computeWorktreePath(
   return pathOps.join(workspaceRoot, sanitizedName)
 }
 
-export function computeWorkspaceRoot(repoPath: string, settings: { workspaceDir: string }): string {
+export function computeWorkspaceRoot(
+  repoPath: string,
+  settings: { workspaceDir: string; repoIsBare?: boolean }
+): string {
   const wsl = parseWslPath(repoPath)
   if (wsl && shouldMirrorWorkspaceDirInsideWsl(repoPath, settings.workspaceDir)) {
     const wslHome = getWslHome(wsl.distro)
@@ -109,13 +114,13 @@ export function computeWorkspaceRoot(repoPath: string, settings: { workspaceDir:
       return win32.join(wslHome, 'orca', 'workspaces')
     }
   }
-  return resolveWorkspaceDirForRepo(repoPath, settings.workspaceDir)
+  return resolveWorkspaceDirForRepo(repoPath, settings.workspaceDir, settings.repoIsBare === true)
 }
 
 export function computeRemoteWorktreePath(
   sanitizedName: string,
   repoPath: string,
-  settings: WorktreePathSettings,
+  settings: WorktreePathComputationSettings,
   options: { useConfiguredAbsolutePath?: boolean } = {}
 ): string {
   if (
@@ -133,10 +138,11 @@ export function computeRemoteWorktreePath(
 export function getWorktreePathSettings(
   repo: WorktreeBasePathRepo,
   settings: WorktreePathSettings
-): WorktreePathSettings {
+): WorktreePathComputationSettings {
   return {
     nestWorkspaces: settings.nestWorkspaces,
-    workspaceDir: getEffectiveWorktreeBasePath(repo, settings)
+    workspaceDir: getEffectiveWorktreeBasePath(repo, settings),
+    repoIsBare: repo.isBare === true
   }
 }
 
@@ -163,11 +169,19 @@ function getRuntimePathOps(
     : posix
 }
 
-function resolveWorkspaceDirForRepo(repoPath: string, workspaceDir: string): string {
+function resolveWorkspaceDirForRepo(
+  repoPath: string,
+  workspaceDir: string,
+  repoIsBare = false
+): string {
   const pathOps = getRuntimePathOps(repoPath, workspaceDir)
-  return pathOps.isAbsolute(workspaceDir)
-    ? pathOps.normalize(workspaceDir)
-    : resolveRuntimePath(repoPath, workspaceDir)
+  if (pathOps.isAbsolute(workspaceDir)) {
+    return pathOps.normalize(workspaceDir)
+  }
+  // Why: a bare repo's path is its git dir; a relative workspace dir must
+  // resolve beside it, not inside it ('worktrees' would collide with git's
+  // own admin dir).
+  return resolveRuntimePath(repoPath, repoIsBare ? pathOps.join('..', workspaceDir) : workspaceDir)
 }
 
 function isWorkspaceDirRelativeToRepo(repoPath: string, workspaceDir: string): boolean {

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -273,6 +273,7 @@ describe('registerWorktreeHandlers', () => {
   const store = {
     getRepos: vi.fn(),
     getRepo: vi.fn(),
+    updateRepo: vi.fn(),
     getProjects: vi.fn(),
     getSparsePresets: vi.fn(),
     getSettings: vi.fn(),
@@ -348,6 +349,7 @@ describe('registerWorktreeHandlers', () => {
       mainWindow.webContents.send,
       store.getRepos,
       store.getRepo,
+      store.updateRepo,
       store.getProjects,
       store.getSparsePresets,
       store.getSettings,
@@ -2279,6 +2281,60 @@ describe('registerWorktreeHandlers', () => {
       branchNameOverride: 'feature/add-feature',
       pushTarget: { remoteName: 'origin', branchName: 'feature/add-feature' }
     })
+  })
+
+  it('filters the bare entry out of detected worktrees and backfills repo.isBare', async () => {
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/repo',
+        head: '',
+        branch: '',
+        isBare: true,
+        isMainWorktree: true
+      },
+      {
+        path: '/workspace/feature',
+        head: 'abc123',
+        branch: 'refs/heads/feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const result = (await handlers['worktrees:listDetected'](null, { repoId: 'repo-1' })) as {
+      worktrees: { path: string }[]
+    }
+
+    expect(result.worktrees.map((worktree) => worktree.path)).toEqual(['/workspace/feature'])
+    expect(store.updateRepo).toHaveBeenCalledWith('repo-1', { isBare: true })
+  })
+
+  it('does not re-stamp isBare on a repo already marked bare', async () => {
+    store.getRepo.mockReturnValue({
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      worktreeBaseRef: null,
+      isBare: true
+    })
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/repo',
+        head: '',
+        branch: '',
+        isBare: true,
+        isMainWorktree: true
+      }
+    ])
+
+    const result = (await handlers['worktrees:listDetected'](null, { repoId: 'repo-1' })) as {
+      worktrees: { path: string }[]
+    }
+
+    expect(result.worktrees).toEqual([])
+    expect(store.updateRepo).not.toHaveBeenCalled()
   })
 
   it('lists detected worktrees through the selected WSL project runtime', async () => {

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -906,7 +906,8 @@ describe('registerWorktreeHandlers', () => {
 
     expect(computeWorktreePathMock).toHaveBeenCalledWith('feature', '/workspace/repo', {
       nestWorkspaces: false,
-      workspaceDir: '../worktrees'
+      workspaceDir: '../worktrees',
+      repoIsBare: false
     })
     expect(addWorktreeMock).toHaveBeenCalledWith(
       '/workspace/repo',

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -703,12 +703,15 @@ function createSshWorktreeMetaIndex(entries: [string, WorktreeMeta][]): SshWorkt
 }
 
 function synthesizeSshGitWorktree(repo: Repo, path: string, meta: WorktreeMeta): GitWorktreeInfo {
+  const isRepoRootPath = areWorktreePathsEqual(path, repo.path)
   return {
     path,
     head: '',
     branch: '',
-    isBare: false,
-    isMainWorktree: areWorktreePathsEqual(path, repo.path),
+    // Why: a bare repo's root is its git dir, not a checkout; only the root
+    // path can be the bare entry — linked worktrees always have working trees.
+    isBare: repo.isBare === true && isRepoRootPath,
+    isMainWorktree: isRepoRootPath,
     ...(meta.sparseDirectories !== undefined ||
     meta.sparseBaseRef !== undefined ||
     meta.sparsePresetId !== undefined
@@ -751,9 +754,19 @@ function buildDetectedGitWorktrees(
   const settings = store.getSettings()
   const knownOrcaLayouts = buildKnownOrcaWorkspaceLayouts(settings, repo)
   const isLegacyRepoForVisibility = isLegacyRepoForExternalWorktreeVisibility(repo)
+  // Why: the bare entry `git worktree list` emits for a bare repo is the git
+  // dir itself — it has no working tree and must never surface as a workspace.
+  // Its presence is also the lazy backfill signal for repos added before
+  // Repo.isBare existed.
+  const bareEntry = gitWorktrees.find((gitWorktree) => gitWorktree.isBare)
+  if (bareEntry && repo.isBare !== true && repo.kind !== 'folder') {
+    store.updateRepo(repo.id, { isBare: true })
+  }
   // Why: a prunable registration has no working directory (issue #8389); only
   // this listing omits it — removal/cleanup flows list worktrees separately.
-  const liveWorktrees = gitWorktrees.filter((gitWorktree) => !gitWorktree.prunable)
+  const liveWorktrees = gitWorktrees.filter(
+    (gitWorktree) => !gitWorktree.prunable && !gitWorktree.isBare
+  )
   return dedupeWorktreesByPath(liveWorktrees).map((gitWorktree) => {
     const worktreeId = `${repo.id}::${gitWorktree.path}`
     let meta = store.getWorktreeMeta(worktreeId)

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -1429,10 +1429,14 @@ function sanitizeRepoUpdatesForPersistence<
       | 'worktreeBasePath'
       | 'projectHostSetupMethod'
       | 'forkSyncMode'
+      | 'isBare'
     >
   >
 >(updates: T): T {
   const sanitized = { ...updates }
+  if ('isBare' in sanitized && typeof sanitized.isBare !== 'boolean') {
+    delete sanitized.isBare
+  }
   if ('badgeColor' in sanitized) {
     const badgeColor = normalizeRepoBadgeColor(sanitized.badgeColor)
     if (!badgeColor) {
@@ -4439,6 +4443,7 @@ export class Store {
         | 'worktreeBaseRef'
         | 'worktreeBasePath'
         | 'kind'
+        | 'isBare'
         | 'executionHostId'
         | 'symlinkPaths'
         | 'issueSourcePreference'

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -620,6 +620,7 @@ import {
   getDefaultRemote,
   getBranchConflictKind,
   isGitRepo,
+  isBareGitRepo,
   getRepoName,
   searchBaseRefDetails,
   getRemoteCount,
@@ -13081,6 +13082,7 @@ export class OrcaRuntimeService {
     }
 
     const detected = await detectRepoIconAndUpstream({ repoPath: path, kind })
+    const isBare = kind === 'git' && isBareGitRepo(path)
     const repo: Repo = {
       id: randomUUID(),
       path,
@@ -13090,6 +13092,7 @@ export class OrcaRuntimeService {
       ...detected,
       addedAt: Date.now(),
       kind,
+      ...(isBare ? { isBare: true } : {}),
       ...(kind === 'git'
         ? {
             externalWorktreeVisibility: 'hide' as const,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -15149,20 +15149,24 @@ export class OrcaRuntimeService {
     if (scan.ok) {
       this.pruneLineageForMissingRepoWorktrees(repo, scan.worktrees)
     }
-    const detected = scan.worktrees.map((gitWorktree) => {
-      const worktreeId = `${repo.id}::${gitWorktree.path}`
-      const meta = this.store?.getWorktreeMeta(worktreeId)
-      const worktree = mergeWorktree(repo.id, gitWorktree, meta, repo.displayName)
-      const detectedWorktree = this.toRuntimeDetectedWorktree(repo, worktree)
-      if (scan.ok) {
-        return detectedWorktree
-      }
-      return {
-        ...detectedWorktree,
-        visible: true,
-        ownership: detectedWorktree.ownership === 'orca-managed' ? 'orca-managed' : 'unknown-legacy'
-      } satisfies DetectedWorktree
-    })
+    // Why: a bare repo's own entry is its git dir, not a workspace.
+    const detected = scan.worktrees
+      .filter((gitWorktree) => !gitWorktree.isBare)
+      .map((gitWorktree) => {
+        const worktreeId = `${repo.id}::${gitWorktree.path}`
+        const meta = this.store?.getWorktreeMeta(worktreeId)
+        const worktree = mergeWorktree(repo.id, gitWorktree, meta, repo.displayName)
+        const detectedWorktree = this.toRuntimeDetectedWorktree(repo, worktree)
+        if (scan.ok) {
+          return detectedWorktree
+        }
+        return {
+          ...detectedWorktree,
+          visible: true,
+          ownership:
+            detectedWorktree.ownership === 'orca-managed' ? 'orca-managed' : 'unknown-legacy'
+        } satisfies DetectedWorktree
+      })
     return {
       repoId: repo.id,
       authoritative: scan.ok,
@@ -21283,32 +21287,35 @@ export class OrcaRuntimeService {
         if (scan.ok) {
           this.pruneLineageForMissingRepoWorktrees(repo, gitWorktrees)
         }
-        return gitWorktrees.map((gitWorktree) => {
-          const worktreeId = `${repo.id}::${gitWorktree.path}`
-          // Why: lineage validation needs a durable instance ID even when the
-          // runtime sees a workspace before the renderer's discovery-stamp path.
-          const existingMeta = metaById[worktreeId]
-          const meta =
-            existingMeta && existingMeta.instanceId
-              ? existingMeta
-              : this.store?.setWorktreeMeta(worktreeId, {})
-          const merged = mergeWorktree(repo.id, gitWorktree, meta, repo.displayName)
-          return {
-            ...merged,
-            parentWorktreeId: null,
-            childWorktreeIds: [],
-            lineage: null,
-            git: {
-              path: gitWorktree.path,
-              head: gitWorktree.head,
-              branch: gitWorktree.branch,
-              isBare: gitWorktree.isBare,
-              isMainWorktree: gitWorktree.isMainWorktree
-            },
-            displayName: merged.displayName,
-            comment: merged.comment
-          }
-        })
+        // Why: a bare repo's own entry is its git dir, not a workspace.
+        return gitWorktrees
+          .filter((gitWorktree) => !gitWorktree.isBare)
+          .map((gitWorktree) => {
+            const worktreeId = `${repo.id}::${gitWorktree.path}`
+            // Why: lineage validation needs a durable instance ID even when the
+            // runtime sees a workspace before the renderer's discovery-stamp path.
+            const existingMeta = metaById[worktreeId]
+            const meta =
+              existingMeta && existingMeta.instanceId
+                ? existingMeta
+                : this.store?.setWorktreeMeta(worktreeId, {})
+            const merged = mergeWorktree(repo.id, gitWorktree, meta, repo.displayName)
+            return {
+              ...merged,
+              parentWorktreeId: null,
+              childWorktreeIds: [],
+              lineage: null,
+              git: {
+                path: gitWorktree.path,
+                head: gitWorktree.head,
+                branch: gitWorktree.branch,
+                isBare: gitWorktree.isBare,
+                isMainWorktree: gitWorktree.isMainWorktree
+              },
+              displayName: merged.displayName,
+              comment: merged.comment
+            }
+          })
       })
     )
     const worktrees = this.attachLineageToResolvedWorktrees(perRepoWorktrees.flat())

--- a/src/main/worktree-orphan-gitdir-proof.ts
+++ b/src/main/worktree-orphan-gitdir-proof.ts
@@ -102,9 +102,39 @@ async function resolveRepoWorktreesPath(
       return parentPath
     }
     return pathOps.join(resolvedRepoGitdirPath, 'worktrees')
-  } catch {
+  } catch (error) {
+    // Why: a bare repo has no `.git` entry at all; its linked-worktree admin
+    // dir lives directly at `<repo>/worktrees`.
+    if (isMissingPathError(error) && (await isBareRepoRootDirectory(repoPath, pathOps, statPath))) {
+      return pathOps.resolve(repoPath, 'worktrees')
+    }
     return null
   }
+}
+
+async function isBareRepoRootDirectory(
+  repoPath: string,
+  pathOps: PathOps,
+  statPath: StatPath
+): Promise<boolean> {
+  try {
+    const [headEntry, objectsEntry, refsEntry] = await Promise.all([
+      statPath(pathOps.join(repoPath, 'HEAD')),
+      statPath(pathOps.join(repoPath, 'objects')),
+      statPath(pathOps.join(repoPath, 'refs'))
+    ])
+    return isGitFileStat(headEntry) && isDirectoryStat(objectsEntry) && isDirectoryStat(refsEntry)
+  } catch {
+    return false
+  }
+}
+
+function isDirectoryStat(stat: unknown): boolean {
+  const dirStat =
+    stat && typeof stat === 'object'
+      ? (stat as { isDirectory?: () => boolean; type?: unknown })
+      : null
+  return !!dirStat && (dirStat.isDirectory?.() === true || dirStat.type === 'directory')
 }
 
 async function repoGitdirIsLinkedWorktreeAdminEntry(

--- a/src/main/worktree-removal-safety.test.ts
+++ b/src/main/worktree-removal-safety.test.ts
@@ -97,6 +97,41 @@ describe('getRegisteredDeletableWorktree', () => {
 })
 
 describe('canSafelyRemoveOrphanedWorktreeDirectory', () => {
+  it('accepts a linked worktree of a bare repo whose admin dir is <repo>/worktrees', async () => {
+    // Why: a bare repo has no `.git` entry; its linked-worktree admin dir
+    // lives directly under the repo path.
+    await expect(
+      canSafelyRemoveOrphanedWorktreeDirectory(
+        '/workspaces/orphan',
+        '/repo.git',
+        makeStatPath(
+          ['/workspaces/orphan/.git', '/repo.git/HEAD'],
+          ['/repo.git/objects', '/repo.git/refs']
+        ),
+        makeReadPath([
+          ['/workspaces/orphan/.git', 'gitdir: /repo.git/worktrees/orphan\n'],
+          ['/repo.git/worktrees/orphan/gitdir', '/workspaces/orphan/.git\n']
+        ])
+      )
+    ).resolves.toBe(true)
+  })
+
+  it('rejects a bare-style admin path when the repo dir lacks bare markers', async () => {
+    // Why: without HEAD/objects/refs at the repo path, `<repo>/worktrees`
+    // is just a directory name — not Git's linked-worktree admin dir.
+    await expect(
+      canSafelyRemoveOrphanedWorktreeDirectory(
+        '/workspaces/orphan',
+        '/repo.git',
+        makeStatPath(['/workspaces/orphan/.git']),
+        makeReadPath([
+          ['/workspaces/orphan/.git', 'gitdir: /repo.git/worktrees/orphan\n'],
+          ['/repo.git/worktrees/orphan/gitdir', '/workspaces/orphan/.git\n']
+        ])
+      )
+    ).resolves.toBe(false)
+  })
+
   it('accepts a linked worktree .git file that points at this repo worktrees entry', async () => {
     await expect(
       canSafelyRemoveOrphanedWorktreeDirectory(

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -201,6 +201,7 @@ import {
 } from './worktree-lineage-drag-drop'
 import { resolveProjectGroupHeaderColor } from './project-header-color'
 import {
+  REPO_HEADER_ACTION_ALWAYS_VISIBLE_CLASS,
   REPO_HEADER_ACTION_BUTTON_CLASS,
   REPO_HEADER_ACTION_REVEAL_CLASS
 } from './repo-header-action-button-class'
@@ -4711,7 +4712,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                               <span
                                 className={cn(
                                   'inline-flex cursor-not-allowed transition-[margin,max-width,opacity]',
-                                  REPO_HEADER_ACTION_REVEAL_CLASS
+                                  REPO_HEADER_ACTION_REVEAL_CLASS,
+                                  row.count === 0 && REPO_HEADER_ACTION_ALWAYS_VISIBLE_CLASS
                                 )}
                                 data-repo-header-action=""
                                 tabIndex={0}
@@ -4736,7 +4738,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                                 type="button"
                                 variant="ghost"
                                 size="icon-xs"
-                                className={REPO_HEADER_ACTION_BUTTON_CLASS}
+                                className={cn(
+                                  REPO_HEADER_ACTION_BUTTON_CLASS,
+                                  row.count === 0 && REPO_HEADER_ACTION_ALWAYS_VISIBLE_CLASS
+                                )}
                                 data-repo-header-action=""
                                 aria-label={
                                   createState?.ariaLabel ??

--- a/src/renderer/src/components/sidebar/repo-header-action-button-class.ts
+++ b/src/renderer/src/components/sidebar/repo-header-action-button-class.ts
@@ -1,4 +1,9 @@
 export const REPO_HEADER_ACTION_REVEAL_CLASS =
   'min-w-0 max-w-0 -ml-1.5 overflow-hidden opacity-0 focus:ml-0 focus:max-w-5 focus:opacity-100 group-hover:ml-0 group-hover:max-w-5 group-hover:opacity-100'
 
+// Why: an empty project (e.g. a freshly added bare repo) renders nothing under
+// its header, so the create button is its only affordance — keep it visible
+// instead of hover-revealed. Merged over the reveal class via cn/tailwind-merge.
+export const REPO_HEADER_ACTION_ALWAYS_VISIBLE_CLASS = 'ml-0 max-w-5 opacity-100'
+
 export const REPO_HEADER_ACTION_BUTTON_CLASS = `size-5 shrink-0 ${REPO_HEADER_ACTION_REVEAL_CLASS} rounded-md text-muted-foreground transition-[margin,max-width,opacity,background-color,color] hover:bg-accent/70 hover:text-foreground data-[state=open]:ml-0 data-[state=open]:max-w-5 data-[state=open]:opacity-100`

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -241,6 +241,9 @@ export type Repo = {
   upstream?: GitHubRepositoryIdentity | null
   addedAt: number
   kind?: RepoKind
+  /** True when the repo is a bare git repository (no working tree at `path`);
+   *  the repo is a worktree hub only. Absent = non-bare or not yet probed. */
+  isBare?: boolean
   gitUsername?: string
   worktreeBaseRef?: string
   /** Optional repo-scoped workspace root override. Relative paths resolve from `path`. */

--- a/src/shared/worktree-ownership-worktree-base-path.test.ts
+++ b/src/shared/worktree-ownership-worktree-base-path.test.ts
@@ -59,6 +59,30 @@ describe('repo-specific worktree ownership layouts', () => {
     ).toBe('external')
   })
 
+  it('resolves relative layouts beside a bare repo, matching creation', () => {
+    const settings = makeSettings({ nestWorkspaces: false })
+    const bareRepo = makeRepo({
+      path: '/projects/a/repo.git',
+      isBare: true,
+      worktreeBasePath: 'worktrees'
+    })
+
+    expect(buildKnownOrcaWorkspaceLayouts(settings, bareRepo)[0]).toEqual({
+      path: '/projects/a/worktrees',
+      nestWorkspaces: false
+    })
+    // Why: under the (flat) Orca root beside the bare dir → not external. If
+    // the layout had wrongly resolved inside the git dir, this would flip.
+    expect(
+      classifyWorktreeOwnership({
+        repo: bareRepo,
+        settings,
+        worktree: makeWorktree('/projects/a/worktrees/feature'),
+        knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, bareRepo)
+      })
+    ).toBe('unknown-legacy')
+  })
+
   it('uses repo-specific nested layouts for Windows-style paths', () => {
     const repo = makeRepo({
       path: 'C:\\projects\\App\\repo',

--- a/src/shared/worktree-ownership.ts
+++ b/src/shared/worktree-ownership.ts
@@ -46,20 +46,24 @@ export function effectiveExternalWorktreeVisibility(
 
 export function buildKnownOrcaWorkspaceLayouts(
   settings: Pick<GlobalSettings, 'workspaceDir' | 'nestWorkspaces' | 'workspaceDirHistory'>,
-  repo?: Pick<Repo, 'path' | 'connectionId' | 'worktreeBasePath'>
+  repo?: Pick<Repo, 'path' | 'connectionId' | 'worktreeBasePath' | 'isBare'>
 ): OrcaWorkspaceLayout[] {
   const layouts: OrcaWorkspaceLayout[] = []
   const repoBasePath = getRepoWorktreeBasePath(repo)
+  // Why: creation resolves relative workspace dirs beside a bare repo's git
+  // dir (worktree-logic.ts); ownership classification must mirror that or
+  // bare-repo worktrees would read as external.
+  const repoIsBare = repo?.isBare === true
   if (repo && repoBasePath) {
     layouts.push({
-      path: resolveWorkspaceLayoutPath(repo.path, repoBasePath),
+      path: resolveWorkspaceLayoutPath(repo.path, repoBasePath, repoIsBare),
       nestWorkspaces: settings.nestWorkspaces
     })
   }
   if (settings.workspaceDir && shouldIncludeWorkspaceLayout(repo, settings.workspaceDir)) {
     layouts.push({
       path: repo
-        ? resolveWorkspaceLayoutPath(repo.path, settings.workspaceDir)
+        ? resolveWorkspaceLayoutPath(repo.path, settings.workspaceDir, repoIsBare)
         : settings.workspaceDir,
       nestWorkspaces: settings.nestWorkspaces
     })
@@ -69,7 +73,7 @@ export function buildKnownOrcaWorkspaceLayouts(
         .filter((layout) => shouldIncludeWorkspaceLayout(repo, layout.path))
         .map((layout) => ({
           ...layout,
-          path: repo ? resolveWorkspaceLayoutPath(repo.path, layout.path) : layout.path
+          path: repo ? resolveWorkspaceLayoutPath(repo.path, layout.path, repoIsBare) : layout.path
         }))
     )
   }
@@ -106,10 +110,15 @@ function getRepoWorktreeBasePath(
   return trimmed || undefined
 }
 
-function resolveWorkspaceLayoutPath(repoPath: string, layoutPath: string): string {
-  return isRuntimePathAbsoluteForRepo(repoPath, layoutPath)
-    ? normalizeRuntimePathSeparators(layoutPath)
-    : resolveRuntimePath(repoPath, layoutPath)
+function resolveWorkspaceLayoutPath(
+  repoPath: string,
+  layoutPath: string,
+  repoIsBare = false
+): string {
+  if (isRuntimePathAbsoluteForRepo(repoPath, layoutPath)) {
+    return normalizeRuntimePathSeparators(layoutPath)
+  }
+  return resolveRuntimePath(repoPath, repoIsBare ? `../${layoutPath}` : layoutPath)
 }
 
 function isRuntimePathAbsoluteForRepo(repoPath: string, layoutPath: string): boolean {


### PR DESCRIPTION
## Summary

Makes Orca aware of **bare Git repositories** end to end — from adding a repo, through worktree creation and discovery, to the hooks and UI that assume a normal working tree.

## Changes

- **feat(repos):** model bare repositories with `Repo.isBare`, stamped at add time.
- **feat(worktrees):** stop surfacing a bare repo's own entry as a workspace.
- **fix(git):** fall back to `HEAD`'s branch when default base-ref probes miss.
- **fix(git):** resolve a bare repo path as its own git dir.
- **fix(worktrees):** prove orphaned worktrees of bare repos via `<repo>/worktrees`.
- **fix(worktrees):** resolve relative workspace dirs beside a bare repo, not inside it.
- **fix(hooks):** never write `.gitignore` into a bare repo's git dir.
- **feat(sidebar):** keep the create button visible on empty project headers.
- **docs:** add bare-repository rules to the git compatibility policy.

## Testing

- [ ] Add a bare repo and confirm it is not listed as a workspace
- [ ] Create a worktree from a bare repo and verify layout beside the repo
- [ ] Confirm no `.gitignore` is written into the bare git dir

## ELI5

Orca understands bare Git repositories end to end. Adding them, creating worktrees, and UI that assumed a normal checkout now treat bare repos correctly instead of showing confusing workspace rows or wrong paths.
