### PR TITLE
test(e2e): deliver node burst via temp file so PowerShell quoting can't break OSC title (#8521)

### DIFF
--- a/tests/e2e/artificial-opencode-scroll-scenario.ts
+++ b/tests/e2e/artificial-opencode-scroll-scenario.ts
@@ -12,7 +12,8 @@ import {
   getResponsiveScrollPath,
   type ScrollAttemptMeasurement
 } from './artificial-opencode-scroll-measurement'
-import { sendToTerminal, waitForTerminalOutput } from './helpers/terminal'
+import { runNodeScriptInTerminal } from './helpers/run-node-script-in-terminal'
+import { waitForTerminalOutput } from './helpers/terminal'
 
 export { getResponsiveScrollPath }
 
@@ -50,8 +51,16 @@ export async function seedActiveTerminalScrollback(
     `for (let i = 0; i < 420; i++) console.log('OPENCODE_SCROLL_${runId}_' + i)`,
     `console.log('${marker}')`
   ].join(';')
-  await sendToTerminal(page, ptyId, `node -e ${JSON.stringify(script)}\r`)
-  await waitForTerminalOutput(page, marker, 10_000)
+  // Why: delivered via a temp file — `node -e` quoting is not PowerShell-safe (#8521).
+  const staged = await runNodeScriptInTerminal(page, ptyId, script, {
+    prefix: 'orca-opencode-scroll-seed'
+  })
+  try {
+    await waitForTerminalOutput(page, marker, 10_000)
+  } finally {
+    // Why: the ready marker proves node already loaded the script.
+    staged.cleanup()
+  }
   await scrollActiveTerminalToBottom(page)
 }
 

--- a/tests/e2e/helpers/run-node-script-in-terminal.ts
+++ b/tests/e2e/helpers/run-node-script-in-terminal.ts
@@ -1,0 +1,51 @@
+import { randomUUID } from 'node:crypto'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import type { Page } from '@stablyai/playwright-test'
+import { sendToTerminal } from './terminal'
+
+export type StagedTerminalNodeScript = {
+  /**
+   * Shell-agnostic command (no trailing `\r`): `node "<forward-slash path>"`.
+   */
+  command: string
+  scriptPath: string
+  /** Removes the staged temp file. Only call after the script has started. */
+  cleanup: () => void
+}
+
+// Why: `node -e ${JSON.stringify(script)}` breaks under PowerShell PTYs on
+// Windows — PowerShell does not honor \" escapes, so it re-splits the program
+// on `;` and node throws before emitting the payload (#8521). Staging the
+// program in a temp .cjs file removes shell quoting from the picture entirely
+// while emitting byte-identical output on every shell.
+export function stageNodeScriptForTerminal(
+  source: string,
+  options: { dir?: string; prefix?: string } = {}
+): StagedTerminalNodeScript {
+  const dir = options.dir ?? tmpdir()
+  mkdirSync(dir, { recursive: true })
+  const prefix = options.prefix ?? 'orca-e2e-terminal-node'
+  const scriptPath = path.join(dir, `${prefix}-${randomUUID()}.cjs`)
+  writeFileSync(scriptPath, source)
+  // Why: forward slashes are valid for node on Windows and parse identically in
+  // PowerShell, cmd, and POSIX shells; raw backslashes would be eaten by bash.
+  const command = `node "${scriptPath.replaceAll('\\', '/')}"`
+  return {
+    command,
+    scriptPath,
+    cleanup: () => rmSync(scriptPath, { force: true })
+  }
+}
+
+export async function runNodeScriptInTerminal(
+  page: Page,
+  ptyId: string,
+  source: string,
+  options: { dir?: string; prefix?: string } = {}
+): Promise<StagedTerminalNodeScript> {
+  const staged = stageNodeScriptForTerminal(source, options)
+  await sendToTerminal(page, ptyId, `${staged.command}\r`)
+  return staged
+}

--- a/tests/e2e/terminal-codex-hidden-startup-background.spec.ts
+++ b/tests/e2e/terminal-codex-hidden-startup-background.spec.ts
@@ -2,6 +2,7 @@ import { Buffer } from 'node:buffer'
 import { PNG } from 'pngjs'
 import type { Page } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
+import { stageNodeScriptForTerminal } from './helpers/run-node-script-in-terminal'
 import {
   ensureTerminalVisible,
   getActiveWorktreeId,
@@ -26,7 +27,8 @@ const COMPOSER_BG = { red: 72, green: 72, blue: 72 }
 
 function codexLikeStartupCommand(marker: string): string {
   const script = [
-    'const marker = process.argv[1];',
+    // Why: embedded as a literal — an argv marker would need per-shell quoting.
+    `const marker = ${JSON.stringify(marker)};`,
     'const width = Math.max(60, process.stdout.columns || 100);',
     'const pad = (text) => (text + " ".repeat(width)).slice(0, width);',
     'const bg = "\\x1b[48;2;72;72;72m\\x1b[38;2;235;235;235m";',
@@ -54,7 +56,8 @@ function codexLikeStartupCommand(marker: string): string {
     'setTimeout(render, 100);',
     'setInterval(() => {}, 1000);'
   ].join('')
-  return `node -e ${JSON.stringify(script)} ${JSON.stringify(marker)}`
+  // Why: delivered via a temp file — `node -e` quoting is not PowerShell-safe (#8521).
+  return stageNodeScriptForTerminal(script, { prefix: 'orca-codex-startup-bg' }).command
 }
 
 async function waitForHiddenTabPtyId(page: Page, tabId: string): Promise<string> {

--- a/tests/e2e/terminal-hidden-tui-visual-restore.spec.ts
+++ b/tests/e2e/terminal-hidden-tui-visual-restore.spec.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto'
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { test, expect } from './helpers/orca-app'
+import { runNodeScriptInTerminal } from './helpers/run-node-script-in-terminal'
 import {
   ensureTerminalVisible,
   getActiveWorktreeId,
@@ -205,7 +206,8 @@ async function writeHiddenSideEffectBurst(
 ): Promise<void> {
   const payload = `\x07\x1b]0;${title}\x07${marker}\n`
   const script = `process.stdout.write(${JSON.stringify(payload)}); setTimeout(() => process.exit(0), 30000)`
-  await sendToTerminal(page, ptyId, `node -e ${JSON.stringify(script)}\r`)
+  // Why: delivered via a temp file — `node -e` quoting is not PowerShell-safe (#8521).
+  await runNodeScriptInTerminal(page, ptyId, script, { prefix: 'orca-hidden-side-effect' })
 }
 
 test.describe('Hidden terminal TUI visual restore', () => {

--- a/tests/e2e/terminal-hidden-view-parking.spec.ts
+++ b/tests/e2e/terminal-hidden-view-parking.spec.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto'
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { test, expect } from './helpers/orca-app'
+import { runNodeScriptInTerminal } from './helpers/run-node-script-in-terminal'
 import {
   ensureTerminalVisible,
   getActiveTabId,
@@ -336,7 +337,10 @@ test.describe('Terminal hidden view parking', () => {
       // proves the revealed terminal accepts input end-to-end, not just echo.
       const typedMarker = `PARKED_TYPED_OK_${runId}`
       const typedProbeScript = `console.log('PARKED_TYPED_OK_' + '${runId}')`
-      await sendToTerminal(orcaPage, tabAPtyId, `node -e ${JSON.stringify(typedProbeScript)}\r`)
+      // Why: delivered via a temp file — `node -e` quoting is not PowerShell-safe (#8521).
+      await runNodeScriptInTerminal(orcaPage, tabAPtyId, typedProbeScript, {
+        prefix: 'orca-parked-typed-probe'
+      })
       await expect
         .poll(() => getTerminalContent(orcaPage, 12_000), {
           timeout: 10_000,
@@ -374,7 +378,10 @@ test.describe('Terminal hidden view parking', () => {
     // before the store assertion lands.
     const payload = `\x1b]0;${parkedTitle}\x07\x07${marker}\n`
     const sideEffectScript = `process.stdout.write(${JSON.stringify(payload)}); setTimeout(() => process.exit(0), 30000)`
-    await sendToTerminal(orcaPage, tabAPtyId, `node -e ${JSON.stringify(sideEffectScript)}\r`)
+    // Why: delivered via a temp file — `node -e` quoting is not PowerShell-safe (#8521).
+    await runNodeScriptInTerminal(orcaPage, tabAPtyId, sideEffectScript, {
+      prefix: 'orca-parked-side-effect'
+    })
 
     await expect
       .poll(() => getTerminalTabTitle(orcaPage, worktreeId, tabAId), {

--- a/tests/e2e/terminal-tab-switch-sigwinch-restore.spec.ts
+++ b/tests/e2e/terminal-tab-switch-sigwinch-restore.spec.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
+import { stageNodeScriptForTerminal } from './helpers/run-node-script-in-terminal'
 import {
   ensureTerminalVisible,
   getActiveTabId,
@@ -56,7 +57,8 @@ function buildSigwinchResetProbeCommand(): string {
     "process.on('SIGWINCH',()=>{if(armed===false)return;page=0;paint(topLabel)})",
     'setInterval(()=>{},1000)'
   ].join(';')
-  return `node -e ${JSON.stringify(script)}`
+  // Why: delivered via a temp file — `node -e` quoting is not PowerShell-safe (#8521).
+  return stageNodeScriptForTerminal(script, { prefix: 'orca-sigwinch-probe' }).command
 }
 
 function buildSigwinchResetProbeSnapshot(label: string): string {

--- a/tests/e2e/terminal-tab-switch-visual-restore.spec.ts
+++ b/tests/e2e/terminal-tab-switch-visual-restore.spec.ts
@@ -1,5 +1,6 @@
 import type { Page, TestInfo } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
+import { runNodeScriptInTerminal } from './helpers/run-node-script-in-terminal'
 import {
   ensureTerminalVisible,
   getActiveTabId,
@@ -360,7 +361,8 @@ async function startHiddenPtyOutputBurst(page: Page, ptyId: string, runId: strin
     '},1);',
     '},30);'
   ].join('')
-  await sendToTerminal(page, ptyId, `node -e ${JSON.stringify(script)}\r`)
+  // Why: delivered via a temp file — `node -e` quoting is not PowerShell-safe (#8521).
+  await runNodeScriptInTerminal(page, ptyId, script, { prefix: 'orca-tab-switch-burst' })
 }
 
 async function writeStaticTabContent(


### PR DESCRIPTION
## What & why

Fixes #8521. Several Windows e2e specs that assert an OSC-0 terminal title fail deterministically because the helpers deliver a Node program to the PTY as `node -e ${JSON.stringify(script)}`. `JSON.stringify` produces POSIX-style double-quoted, backslash-escaped source; the default Windows PTY shell is **PowerShell**, which does not honor `\"` inside a double-quoted argument and re-splits the command on the payload's `;`. Node then gets mangled source and throws before emitting the `\x07\x1b]0;<title>\x07` burst, so the pane title never updates and the assertions fail. macOS/Linux (bash/zsh) accept the JSON form, so it only breaks on Windows.

**Change (test-infrastructure only — zero product code):** a shared helper `tests/e2e/helpers/run-node-script-in-terminal.ts` stages the JS into a temp `.cjs` file and sends `node "<forward-slash path>"`, which parses identically in PowerShell, cmd, and bash. All 6 affected call sites are migrated. The one site that previously passed a marker via `process.argv` (`terminal-codex-hidden-startup-background`) has the marker inlined into the script body so no argument quoting remains.

## Evidence (proof of improvement)

Standalone byte proof on Windows 11 (payload staged under a path *with a space*, run through each shell):

- **Old delivery** (`node -e "<json>"`): PowerShell → **0 bytes**, `SyntaxError: Expected unicode escape`; bash → correct bytes. (Reproduces #8521.)
- **New delivery** (`node "<file>"`): PowerShell, cmd, **and** bash all emit byte-identical output:
  ```
  07 1b 5d 30 3b … 07 4d 41 52 4b 45 52 … 0a   (BEL, OSC 0;title, BEL, marker, LF)
  ```

## Proof of no regression

- **Zero product-code changes** — `git diff main...HEAD --name-only` is entirely under `tests/e2e/**` (6 specs + 1 new helper). Zero user-facing surface.
- macOS/Linux behavior unchanged: `path.replaceAll('\','/')` is a no-op on POSIX; the emitted bytes are identical to before on those shells.
- `.cjs` forces CommonJS parsing regardless of a nearby `"type":"module"`, matching `node -e`'s default semantics (a correctness improvement, not a change).
- `pnpm run typecheck` (node+cli+web) clean; `oxlint` on all changed files clean.
- Adversarially reviewed (independent Sonnet pass): verdict CLEAN — reproduced the original failure and the byte-identical fix across PowerShell/cmd/bash, and confirmed every remaining `node -e` site in `tests/e2e/` either embeds no literal `"` or targets a POSIX-only remote container.
- Full Playwright e2e was not run (needs an Electron build); the shell-level byte proof + typecheck are the evidence.

## Known follow-up (non-blocking)

The staged temp `.cjs` files are only explicitly `.cleanup()`-ed at 1 of 6 sites; the rest rely on OS temp reaping. They're a few hundred bytes with `randomUUID` names (no collision/flake risk); immediate per-call cleanup is unsafe (race with node reading the file), so a proper fix is a suite-scoped teardown — left as a follow-up.

## ELI5

The tests used to type an entire little JavaScript program onto the command line wrapped in Unix-style quotes. PowerShell (Windows' shell) reads those quotes differently, chops the program in half, and Node crashes before printing the special "set the tab title" characters the test is waiting for — so the test fails only on Windows. Now the test saves the program to a small temp file and just types `node "that-file"`, which every shell understands the same way.
