### PR TITLE
perf(window): re-enable macOS main-window background throttling

### DIFF
--- a/src/main/startup/configure-process.test.ts
+++ b/src/main/startup/configure-process.test.ts
@@ -297,6 +297,20 @@ describe('enableMainProcessGpuFeatures', () => {
     expect(app.commandLine.appendSwitch).not.toHaveBeenCalledWith('enable-unsafe-webgpu')
   })
 
+  it('opts hidden pages out of intensive wake-up throttling', async () => {
+    const { app } = await import('electron')
+    const { enableMainProcessGpuFeatures } = await import('./configure-process')
+
+    delete process.env.ORCA_E2E_USER_DATA_DIR
+    vi.mocked(app.commandLine.appendSwitch).mockClear()
+    enableMainProcessGpuFeatures()
+
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith(
+      'disable-features',
+      'IntensiveWakeUpThrottling'
+    )
+  })
+
   it('raises the WebGL context budget above the 16-context Blink default', async () => {
     const { app } = await import('electron')
     const { enableMainProcessGpuFeatures } = await import('./configure-process')

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -349,7 +349,9 @@ export function enableMainProcessGpuFeatures(): void {
   // Why: with main-window background throttling on, Chromium's intensive mode
   // clamps hidden-page timers to 1/min after 5 minutes, delaying agent-done and
   // bell notifications by up to 60s. Keep the normal 1s hidden clamp (rAF and
-  // rendering still stop) but opt out of the 1/min tier.
+  // rendering still stop) but opt out of the 1/min tier. Callers skip this
+  // function under GPU fallback (win32-only today); if throttling ever extends
+  // to Windows, this opt-out must move out of the GPU-gated path.
   const disabledFeatures = ['IntensiveWakeUpThrottling', existingDisabledFeatures]
     .filter(Boolean)
     .join(',')

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -344,4 +344,14 @@ export function enableMainProcessGpuFeatures(): void {
   if (features) {
     app.commandLine.appendSwitch('enable-features', features)
   }
+
+  const existingDisabledFeatures = app.commandLine.getSwitchValue('disable-features')
+  // Why: with main-window background throttling on, Chromium's intensive mode
+  // clamps hidden-page timers to 1/min after 5 minutes, delaying agent-done and
+  // bell notifications by up to 60s. Keep the normal 1s hidden clamp (rAF and
+  // rendering still stop) but opt out of the 1/min tier.
+  const disabledFeatures = ['IntensiveWakeUpThrottling', existingDisabledFeatures]
+    .filter(Boolean)
+    .join(',')
+  app.commandLine.appendSwitch('disable-features', disabledFeatures)
 }

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -357,16 +357,18 @@ describe('createMainWindow', () => {
     vi.advanceTimersByTime(32)
     expect(browserWindowInstance.setSize).toHaveBeenNthCalledWith(2, 1200, 800)
 
-    // Focus 100ms later re-arms the debounced late repaint instead of stacking.
-    vi.advanceTimersByTime(68)
-    windowHandlers.get('focus')?.[0]?.()
-    expect(webContents.invalidate).toHaveBeenCalledTimes(2)
-
-    vi.advanceTimersByTime(249)
-    expect(webContents.invalidate).toHaveBeenCalledTimes(2)
+    vi.advanceTimersByTime(217)
+    expect(webContents.invalidate).toHaveBeenCalledTimes(1)
 
     vi.advanceTimersByTime(1)
+    expect(webContents.invalidate).toHaveBeenCalledTimes(2)
+
+    // Focus covers occlusion-uncover with invalidate only — no setSize jiggle
+    // that would resize terminals on every window focus.
+    const setSizeCalls = browserWindowInstance.setSize.mock.calls.length
+    windowHandlers.get('focus')?.[0]?.()
     expect(webContents.invalidate).toHaveBeenCalledTimes(3)
+    expect(browserWindowInstance.setSize.mock.calls.length).toBe(setSizeCalls)
   })
 
   it('supports all minus key variants for terminal zoom out', () => {

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -365,12 +365,12 @@ describe('createMainWindow', () => {
     vi.advanceTimersByTime(1)
     expect(webContents.invalidate).toHaveBeenCalledTimes(3)
 
-    // Focus covers occlusion-uncover with invalidate only — no setSize jiggle
-    // that would resize terminals on every window focus.
+    // Why: focus covers occlusion-uncover with invalidate only — no setSize
+    // jiggle that would resize terminals on every window focus.
     const setSizeCalls = browserWindowInstance.setSize.mock.calls.length
     windowHandlers.get('focus')?.[0]?.()
     expect(webContents.invalidate).toHaveBeenCalledTimes(4)
-    expect(browserWindowInstance.setSize.mock.calls.length).toBe(setSizeCalls)
+    expect(browserWindowInstance.setSize).toHaveBeenCalledTimes(setSizeCalls)
   })
 
   it('supports all minus key variants for terminal zoom out', () => {

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -299,6 +299,76 @@ describe('createMainWindow', () => {
     }
   })
 
+  it('keeps main-window background throttling enabled while repainting macOS visibility transitions', () => {
+    vi.useFakeTimers()
+    const windowHandlers = new Map<string, ((...args: any[]) => void)[]>()
+    const webContents = {
+      on: vi.fn(),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn(),
+      isDevToolsOpened: vi.fn(),
+      openDevTools: vi.fn(),
+      closeDevTools: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+        const handlers = windowHandlers.get(event) ?? []
+        handlers.push(handler)
+        windowHandlers.set(event, handlers)
+      }),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => false),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    createMainWindow(null)
+
+    // Why: throttling-off pins visibilityState 'visible' and renders occluded
+    // windows at full rate; this guards against reintroducing it.
+    expect(webContents.setBackgroundThrottling).not.toHaveBeenCalledWith(false)
+
+    if (process.platform !== 'darwin') {
+      return
+    }
+
+    expect(webContents.setBackgroundThrottling).toHaveBeenCalledWith(true)
+    expect(windowHandlers.get('restore')).toHaveLength(1)
+    expect(windowHandlers.get('show')).toHaveLength(1)
+    expect(windowHandlers.get('focus')).toHaveLength(1)
+
+    windowHandlers.get('show')?.[0]?.()
+
+    expect(webContents.invalidate).toHaveBeenCalledTimes(1)
+    expect(browserWindowInstance.setSize).toHaveBeenNthCalledWith(1, 1201, 800)
+
+    vi.advanceTimersByTime(32)
+    expect(browserWindowInstance.setSize).toHaveBeenNthCalledWith(2, 1200, 800)
+
+    // Focus 100ms later re-arms the debounced late repaint instead of stacking.
+    vi.advanceTimersByTime(68)
+    windowHandlers.get('focus')?.[0]?.()
+    expect(webContents.invalidate).toHaveBeenCalledTimes(2)
+
+    vi.advanceTimersByTime(249)
+    expect(webContents.invalidate).toHaveBeenCalledTimes(2)
+
+    vi.advanceTimersByTime(1)
+    expect(webContents.invalidate).toHaveBeenCalledTimes(3)
+  })
+
   it('supports all minus key variants for terminal zoom out', () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -302,6 +302,7 @@ describe('createMainWindow', () => {
   it('keeps main-window background throttling enabled while repainting macOS visibility transitions', () => {
     vi.useFakeTimers()
     const windowHandlers = new Map<string, ((...args: any[]) => void)[]>()
+    let windowSize: [number, number] = [1200, 800]
     const webContents = {
       on: vi.fn(),
       setZoomLevel: vi.fn(),
@@ -324,8 +325,10 @@ describe('createMainWindow', () => {
       isDestroyed: vi.fn(() => false),
       isMaximized: vi.fn(() => false),
       isFullScreen: vi.fn(() => false),
-      getSize: vi.fn(() => [1200, 800]),
-      setSize: vi.fn(),
+      getSize: vi.fn(() => windowSize),
+      setSize: vi.fn((width: number, height: number) => {
+        windowSize = [width, height]
+      }),
       maximize: vi.fn(),
       show: vi.fn(),
       loadFile: vi.fn(),
@@ -335,15 +338,11 @@ describe('createMainWindow', () => {
       return browserWindowInstance
     })
 
-    createMainWindow(null)
+    withPlatform('darwin', () => createMainWindow(null))
 
     // Why: throttling-off pins visibilityState 'visible' and renders occluded
     // windows at full rate; this guards against reintroducing it.
     expect(webContents.setBackgroundThrottling).not.toHaveBeenCalledWith(false)
-
-    if (process.platform !== 'darwin') {
-      return
-    }
 
     expect(webContents.setBackgroundThrottling).toHaveBeenCalledWith(true)
     expect(windowHandlers.get('restore')).toHaveLength(1)
@@ -351,24 +350,26 @@ describe('createMainWindow', () => {
     expect(windowHandlers.get('focus')).toHaveLength(1)
 
     windowHandlers.get('show')?.[0]?.()
+    windowHandlers.get('restore')?.[0]?.()
 
-    expect(webContents.invalidate).toHaveBeenCalledTimes(1)
+    expect(webContents.invalidate).toHaveBeenCalledTimes(2)
     expect(browserWindowInstance.setSize).toHaveBeenNthCalledWith(1, 1201, 800)
+    expect(browserWindowInstance.setSize).toHaveBeenCalledTimes(1)
 
     vi.advanceTimersByTime(32)
     expect(browserWindowInstance.setSize).toHaveBeenNthCalledWith(2, 1200, 800)
 
     vi.advanceTimersByTime(217)
-    expect(webContents.invalidate).toHaveBeenCalledTimes(1)
+    expect(webContents.invalidate).toHaveBeenCalledTimes(2)
 
     vi.advanceTimersByTime(1)
-    expect(webContents.invalidate).toHaveBeenCalledTimes(2)
+    expect(webContents.invalidate).toHaveBeenCalledTimes(3)
 
     // Focus covers occlusion-uncover with invalidate only — no setSize jiggle
     // that would resize terminals on every window focus.
     const setSizeCalls = browserWindowInstance.setSize.mock.calls.length
     windowHandlers.get('focus')?.[0]?.()
-    expect(webContents.invalidate).toHaveBeenCalledTimes(3)
+    expect(webContents.invalidate).toHaveBeenCalledTimes(4)
     expect(browserWindowInstance.setSize.mock.calls.length).toBe(setSizeCalls)
   })
 

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -307,6 +307,7 @@ describe('createMainWindow', () => {
       setZoomLevel: vi.fn(),
       setBackgroundThrottling: vi.fn(),
       invalidate: vi.fn(),
+      isDestroyed: vi.fn(() => false),
       setWindowOpenHandler: vi.fn(),
       send: vi.fn(),
       isDevToolsOpened: vi.fn(),

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -51,7 +51,9 @@ import { clearTrustedUIRendererWebContentsId, setTrustedUIRendererWebContentsId 
 import { resolveWindowCloseAction } from './window-close-decision'
 
 function forceRepaint(window: BrowserWindow): void {
-  if (window.isDestroyed()) {
+  // Why: webContents can be destroyed a beat before the BrowserWindow during
+  // close, and this runs from timers/focus events that can land in that gap.
+  if (window.isDestroyed() || window.webContents.isDestroyed()) {
     return
   }
   window.webContents.invalidate()
@@ -94,7 +96,7 @@ function installMacosVisibilityRepaint(window: BrowserWindow): void {
   // signal. Invalidate only — the setSize jiggle would SIGWINCH every terminal
   // on each Cmd+Tab.
   window.on('focus', () => {
-    if (!window.isDestroyed()) {
+    if (!window.isDestroyed() && !window.webContents.isDestroyed()) {
       window.webContents.invalidate()
     }
   })

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -67,6 +67,33 @@ function forceRepaint(window: BrowserWindow): void {
   }, 32)
 }
 
+function installMacosVisibilityRepaint(window: BrowserWindow): void {
+  let delayedRepaintTimer: ReturnType<typeof setTimeout> | null = null
+  const repaintAfterVisibilityTransition = (): void => {
+    forceRepaint(window)
+    if (delayedRepaintTimer) {
+      clearTimeout(delayedRepaintTimer)
+    }
+    // Why: macOS can finish restoring webview compositor layers after Electron's
+    // show/restore event, so a second paint catches late black-surface recovery.
+    delayedRepaintTimer = setTimeout(() => {
+      delayedRepaintTimer = null
+      forceRepaint(window)
+    }, 250)
+  }
+  const clearDelayedRepaint = (): void => {
+    if (delayedRepaintTimer) {
+      clearTimeout(delayedRepaintTimer)
+      delayedRepaintTimer = null
+    }
+  }
+
+  window.on('restore', repaintAfterVisibilityTransition)
+  window.on('show', repaintAfterVisibilityTransition)
+  window.on('focus', repaintAfterVisibilityTransition)
+  window.on('closed', clearDelayedRepaint)
+}
+
 function isMacAppPasteInput(input: Electron.Input): boolean {
   return (
     process.platform === 'darwin' &&
@@ -293,18 +320,13 @@ export function createMainWindow(
   setTrustedUIRendererWebContentsId(rendererWebContentsId)
 
   if (process.platform === 'darwin') {
-    // Why: persistent browser webviews use separate compositor layers, and on
-    // recent macOS releases those layers can fail to repaint after occlusion or
-    // restore. Disabling main-window throttling and forcing a repaint on
-    // visibility transitions hardens Orca against black-surface failures during
-    // browser-tab restore and tab switching.
-    mainWindow.webContents.setBackgroundThrottling(false)
-    mainWindow.on('restore', () => {
-      forceRepaint(mainWindow)
-    })
-    mainWindow.on('show', () => {
-      forceRepaint(mainWindow)
-    })
+    // Why: browser-guest surfaces are kept alive by their own per-guest
+    // unthrottle (browser-manager attach), so the main window can throttle
+    // normally while hidden/occluded instead of rendering at full rate.
+    // Toggling must happen only while visible: flipping it on a hidden window
+    // desyncs Chromium's frame evictor and blanks the surface (electron#42378).
+    mainWindow.webContents.setBackgroundThrottling(true)
+    installMacosVisibilityRepaint(mainWindow)
   }
 
   // Why: a focus-preserving system/display wake fires no window focus or

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -90,7 +90,14 @@ function installMacosVisibilityRepaint(window: BrowserWindow): void {
 
   window.on('restore', repaintAfterVisibilityTransition)
   window.on('show', repaintAfterVisibilityTransition)
-  window.on('focus', repaintAfterVisibilityTransition)
+  // Why: occlusion-uncover fires neither restore nor show; focus is the only
+  // signal. Invalidate only — the setSize jiggle would SIGWINCH every terminal
+  // on each Cmd+Tab.
+  window.on('focus', () => {
+    if (!window.isDestroyed()) {
+      window.webContents.invalidate()
+    }
+  })
   window.on('closed', clearDelayedRepaint)
 }
 

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -50,6 +50,10 @@ import { buildEditableContextMenuTemplate } from './editable-context-menu'
 import { clearTrustedUIRendererWebContentsId, setTrustedUIRendererWebContentsId } from '../ipc/ui'
 import { resolveWindowCloseAction } from './window-close-decision'
 
+// Why: show/restore/resume can overlap before the size nudge resets; never
+// capture the temporary width as the next repaint's baseline.
+const activeRepaintJiggles = new WeakSet<BrowserWindow>()
+
 function forceRepaint(window: BrowserWindow): void {
   // Why: webContents can be destroyed a beat before the BrowserWindow during
   // close, and this runs from timers/focus events that can land in that gap.
@@ -57,15 +61,17 @@ function forceRepaint(window: BrowserWindow): void {
     return
   }
   window.webContents.invalidate()
-  if (window.isMaximized() || window.isFullScreen()) {
+  if (window.isMaximized() || window.isFullScreen() || activeRepaintJiggles.has(window)) {
     return
   }
+  activeRepaintJiggles.add(window)
   const [width, height] = window.getSize()
   window.setSize(width + 1, height)
   setTimeout(() => {
     if (!window.isDestroyed()) {
       window.setSize(width, height)
     }
+    activeRepaintJiggles.delete(window)
   }, 32)
 }
 


### PR DESCRIPTION
## TL;DR

Re-enables macOS main-window background throttling — removing the `setBackgroundThrottling(false)` workaround that has kept every hidden/occluded Orca window rendering at ~60fps since the in-app browser shipped (#430). Browser webviews stay protected by their own per-guest unthrottle, and the black-surface hardening is kept as repaint-on-transition. Adds a Chromium feature opt-out so hidden-window timers keep 1s granularity instead of degrading to 1/min after 5 minutes.

**Measured: hidden-window renderer drops from continuous 60fps compositing to 0fps / ~0.0% CPU, with zero timer degradation and no webview black-surface regression through 6.5-minute eviction soaks.**

## Why the workaround is no longer needed

Deep-dive into Electron/Chromium internals (`disable_hidden.patch`, `frame_eviction_manager.cc`, electron#42378):

- `setBackgroundThrottling(false)` works by making `RenderWidgetHostImpl::WasHidden()` a no-op — a **per-RenderWidgetHost** flag. The browser guests get their own `setBackgroundThrottling(false)` at webview attach (`browser-manager.ts`, needed anyway for CDP screenshots while backgrounded), so **guest webview surfaces are never enrolled for frame eviction regardless of the main window's setting**. The main-window call was redundant for its stated purpose.
- The one macOS occlusion bug with a real upstream fix (electron#50579, synthetic occlusion events) shipped in Electron ≥42 — already in our ^43.1.0.
- The open upstream bug (electron#42378, frame evictor desync → blank after ~5-10 min) is triggered specifically by **toggling** `setBackgroundThrottling` while a window is hidden. We never toggle: the value is set once at window creation, while visible. The new code comment documents this trap.

Costs of the old workaround (both verified in the July 2026 perf audit): occluded-but-visible windows render at full frame rate (the biggest remaining battery cost), and `document.visibilityState` is pinned `'visible'` forever, suppressing every renderer visibility gate.

## What changed

- `createMainWindow.ts`: `setBackgroundThrottling(true)` on darwin. Black-surface hardening kept and extended: repaint on `restore`/`show` plus a debounced 250ms late repaint (macOS can finish restoring webview layers after Electron's event), and `invalidate()`-only on `focus` to cover occlusion-uncover (which fires neither `restore` nor `show`). Focus deliberately does **not** run the `setSize` jiggle — that would SIGWINCH every terminal on each Cmd+Tab.
- `configure-process.ts`: `--disable-features=IntensiveWakeUpThrottling`. With throttling back on, Chromium's intensive mode clamps hidden-page timers to 1/min after 5 minutes hidden, which would delay agent-done/bell notifications by up to 60s. This keeps the normal 1s hidden clamp (rAF and rendering still stop — the perf win is untouched) while timers stay usable.
- Regression tests: main-window `setBackgroundThrottling(false)` now fails a unit test; focus-repaint asserts no `setSize` calls; `IntensiveWakeUpThrottling` opt-out asserted in configure-process tests.

## Verification (live dev app on macOS, CDP-driven)

Instrumented the real renderer with rAF/timer/visibilitychange probes, drove hide/occlude/restore cycles via System Events, captured OS-level (`screencapture -l`) window pixels:

| Check | Before (main) | After (this PR) |
|---|---|---|
| Hidden window: renderer rAF | 60/s forever | 0/s (throttled) ✅ |
| Hidden window: renderer CPU | continuous compositing | ~0.0% (5-sample avg) |
| `visibilitychange` events | never fire | fire correctly on hide/show ✅ |
| Guest webview rAF while embedder hidden | 60/s | 60/s (unchanged — per-guest unthrottle intact) ✅ |
| Webview after 6.5 min hidden (past the 5-min `FrameEvictor` culling delay), OS-level pixel capture | n/a | renders correctly, no black surface ✅ (2 independent soaks) |
| Webview after 20s full occlusion by another app's window | n/a | stays visible+rendering (occlusion didn't even throttle in practice; focus-invalidate covers the uncover path) ✅ |
| 1.5s renderer timer chain through 6.5 min hidden | n/a | before feature flag: 60s gaps in intensive mode; **after: 213/213 intervals at ~1.5s, max gap 2s** ✅ |
| Terminal output produced while hidden 45s | n/a | all 60 TICK lines present and ordered on restore ✅ |

Suites: main 12,826 ✅ · renderer 14,642 ✅ · preload+shared 2,571 ✅ · typecheck ✅ · `git diff --check` ✅. (Repo-wide `pnpm lint` has a pre-existing failure on main in `skill-freshness-group.tsx`, unrelated.)

## Accepted behavior changes (deliberate, degrade-not-break)

- Hidden-terminal output beyond the backlog cap goes lossy (the cap + ack-credit-before-drop design in `pane-terminal-output-scheduler.ts` was built for exactly this; the shell cannot wedge — credits fire before dropping).
- Renderer visibility gates now actually engage while hidden (git polls, useNow, spinner clocks stop) — that's the point.
- Notification quiet-gates (~1.5s renderer `setTimeout`s) can slip to ~2s while hidden — covered by the intensive-throttling opt-out; verified max 2s.

## Adversarial review findings (subagent, addressed or accepted)

- **Fixed — focus jiggle:** an early draft ran the full `forceRepaint` (incl. the ±1px `setSize` jiggle) on every window focus, which would have twitched the window edge and poked terminal ResizeObservers on each Cmd+Tab. Final code invalidates only on focus; a test asserts no `setSize`.
- **Fixed — use-after-destroy:** `forceRepaint`/focus-invalidate now also check `webContents.isDestroyed()` (webContents can die a beat before its BrowserWindow during close, and these run from timers/focus events).
- **Accepted — newly-active visibility handlers:** `visibilitychange` handlers that were dead on macOS now run on real hide/show flips: `refreshAllGitHub()` on become-visible (has its own throttle; macOS only flips visibility on ~full occlusion or hide, so frequency is bounded) and the heavy wake-recovery path (glyph-atlas clear + refit) on visibility flips. Both are the intended design finally engaging on macOS, same as they already do on Windows/Linux.
- **Residual risk — occlusion-uncover without focus:** Electron exposes no occlusion event; dragging a covering window away without clicking Orca produces neither `restore`/`show`/`focus` nor (in my live test, where full occlusion by another app never even flipped visibility) a `visibilitychange`. The window then relies on Chromium's own occlusion→repaint. Mitigations: full-occlusion flips that *do* change visibility trigger the in-tree wake-recovery self-heal, and my 20s full-occlusion test showed frames never stopped in practice. This narrow case is the main thing perf-rc soaking should watch.

## History

Supersedes stalled PR #5486 (same core shape; this adds the focus/occlusion-uncover path, the no-jiggle-on-focus fix, and the `IntensiveWakeUpThrottling` opt-out). The original workaround shipped inside #430 with no linked issue; the "floating Claude stuck" concern that motivated keeping renderers unthrottled (#5829) was resolved by #7214's hidden-delivery pipeline, and #5829 was closed as obsolete.

Recommend soaking on the perf-rc channel (#7336) before stable, since the original black-surface reports were never captured as issues.
