### PR TITLE
fix(terminal): deliver escape sequences to ConPTY conin atomically (backspace types a space after resume)

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2769,6 +2769,77 @@
       "demotionRule": "Cannot promote if standard-key behavior is inferred without PTY byte evidence."
     },
     {
+      "id": "terminal-input.windows-conpty-write-atomicity",
+      "title": "Escape sequences reach ConPTY conin whole, never split across writes",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "terminal-platform",
+      "layer": "daemon-session-write-path",
+      "surfaces": [
+        "Windows ConPTY",
+        "terminal input routing",
+        "bracketed paste",
+        "query replies",
+        "session resume"
+      ],
+      "platforms": [
+        "windows"
+      ],
+      "providers": [
+        "daemon",
+        "wsl"
+      ],
+      "coveredPlatforms": [
+        "windows"
+      ],
+      "coveredProviders": [
+        "daemon"
+      ],
+      "coverageNotes": "Deterministic unit coverage for the guard (join/hold/flush/ESC-disambiguation/cap) plus a real-ConPTY integration oracle that documents the raw defect (split CSI head swallowed, tail typed) and proves guarded whole-sequence delivery. WSL sessions share the daemon write path but have no dedicated live run.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/pull/9259"
+      ],
+      "invariant": "Any escape sequence written to a Windows ConPTY conin must be contained in a single write: conhost's input parser drops VT state at write boundaries, silently swallowing a split sequence's head and delivering its tail as literal keystrokes (stuck bracketed paste, composer corruption, backspace inserting blanks after session resume).",
+      "oracle": "Byte-level: a raw-stdin child under a real ConPTY receives exactly the joined sequence when the daemon guard is active, and receives the corrupted literal tail when writes are split without it.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/conin-atomic-sequence-writer.test.ts src/main/daemon/session.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/conin-atomic-sequence-writer.conpty.integration.test.ts"
+      ],
+      "testFiles": [
+        "src/main/daemon/conin-atomic-sequence-writer.test.ts",
+        "src/main/daemon/conin-atomic-sequence-writer.conpty.integration.test.ts",
+        "src/main/daemon/session.test.ts"
+      ],
+      "assertionRefs": [],
+      "evidenceRuns": [],
+      "runtimeBudget": {
+        "p95Seconds": 30,
+        "scope": "unit suite everywhere; real-ConPTY integration on Windows only"
+      },
+      "flakeHistory": {
+        "status": "not-started",
+        "evidence": "New gate; integration oracle ran green on Windows 11 26200 at authoring time."
+      },
+      "redGreenEvidence": {
+        "status": "captured",
+        "evidence": "The integration file's first test asserts the raw ConPTY defect (split \\x1b[?997;1 + n delivers literal n); the second asserts guarded whole-sequence delivery through the same ConPTY."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Guard is pass-through (no timer, no copy) for any write that ends parser-clean — the shape of every ordinary keystroke and paste; only a write ending mid-sequence arms one short timer."
+      },
+      "promotionCriteria": [
+        "Windows CI runs the real-ConPTY integration oracle without silent skips.",
+        "Field breadcrumbs (coninJoinedSplitSequence / coninFlushedDanglingPartial) confirm the guard engages on real resume storms."
+      ],
+      "knownGaps": [
+        "The upstream producer that emits split sequences in the field is not yet pinpointed; the guard neutralizes the class at the last hop.",
+        "WSL provider shares the code path but has no dedicated live-run evidence.",
+        "Renderer-to-daemon message loss during reconnect (fire-and-forget write notify) can still drop whole sequences; the guard cannot repair missing bytes."
+      ],
+      "demotionRule": "Demote if the ESC hold window measurably delays real Escape keypresses or the integration oracle flakes on Windows CI."
+    },
+    {
       "id": "terminal-input.windows-modified-enter-routing",
       "title": "Windows modified Enter routes agent-compatible bytes to the active pane",
       "maturity": "experimental",

--- a/src/main/daemon/conin-atomic-sequence-writer.conpty.integration.test.ts
+++ b/src/main/daemon/conin-atomic-sequence-writer.conpty.integration.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Real-ConPTY oracle for the conin atomic-sequence guard.
+ *
+ * Ground truth (measured on Windows 11 26200): conhost's VT input parser does
+ * NOT keep state across conin write boundaries. An escape sequence split
+ * across two writes loses its head (silently swallowed) and delivers its tail
+ * to the foreground app as literal keystrokes — the initiator of the
+ * "backspace types a space after session resume" composer corruption.
+ *
+ * The first test documents that raw ConPTY behavior (the guard's reason to
+ * exist); the second proves the guard restores whole-sequence delivery.
+ */
+import { describe, expect, it } from 'vitest'
+import { createRequire } from 'node:module'
+import { ConinAtomicSequenceWriter } from './conin-atomic-sequence-writer'
+
+const isWindows = process.platform === 'win32'
+
+type PtyChild = {
+  received: () => string
+  write: (data: string) => void
+  kill: () => void
+}
+
+async function spawnRawStdinDumper(): Promise<PtyChild> {
+  const require = createRequire(import.meta.url)
+  const pty = require('node-pty')
+  // Child echoes every raw stdin chunk as RECV[<json>] so the test can read
+  // exactly what conhost delivered to the application.
+  const childScript =
+    "process.stdin.setRawMode(true);process.stdin.on('data',(d)=>{process.stdout.write('RECV['+JSON.stringify(d.toString('latin1'))+']');});setTimeout(()=>process.exit(0),20000);"
+  const proc = pty.spawn(process.execPath, ['-e', childScript], {
+    name: 'xterm-256color',
+    cols: 100,
+    rows: 30,
+    cwd: process.cwd(),
+    env: process.env
+  })
+  let raw = ''
+  proc.onData((d: string) => {
+    raw += d
+  })
+  // Wait for the child's raw mode to engage (first prompt-less idle moment).
+  await new Promise((r) => setTimeout(r, 2000))
+  return {
+    received: () => {
+      const parts = [...raw.matchAll(/RECV\[("(?:[^"\\]|\\.)*")\]/g)]
+      return parts.map((m) => JSON.parse(m[1]) as string).join('')
+    },
+    write: (data: string) => proc.write(data),
+    kill: () => proc.kill()
+  }
+}
+
+const settle = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+describe.runIf(isWindows)('ConPTY conin write-boundary behavior', () => {
+  it('documents the defect: a split CSI loses its head and types its tail', async () => {
+    const child = await spawnRawStdinDumper()
+    try {
+      child.write('\x1b[?997;1')
+      child.write('n')
+      await settle(1200)
+      // Head swallowed, tail delivered literally — the corruption this guard
+      // exists to prevent. If a future ConPTY fixes this, the assertion below
+      // starts failing and the guard can be re-evaluated.
+      expect(child.received()).toBe('n')
+    } finally {
+      child.kill()
+    }
+  }, 30000)
+
+  it('guard restores whole-sequence delivery through a real ConPTY', async () => {
+    const child = await spawnRawStdinDumper()
+    try {
+      const writer = new ConinAtomicSequenceWriter((data) => child.write(data))
+      writer.write('\x1b[?997;1')
+      writer.write('n')
+      // Paste-end marker split (the claude stuck-paste initiator).
+      writer.write('\x1b[200~hi\x1b[')
+      writer.write('201~')
+      // A key after all of it must still arrive, in order. (A printable is
+      // asserted rather than \x7f because conhost translates a lone DEL into
+      // an empty read for this raw-stdin child — equally with or without the
+      // guard, so it proves nothing about sequence atomicity.)
+      writer.write('z')
+      await settle(1200)
+      expect(child.received()).toBe('\x1b[?997;1n\x1b[200~hi\x1b[201~z')
+      writer.dispose()
+    } finally {
+      child.kill()
+    }
+  }, 30000)
+})

--- a/src/main/daemon/conin-atomic-sequence-writer.test.ts
+++ b/src/main/daemon/conin-atomic-sequence-writer.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  CONIN_BARE_ESC_FLUSH_MS,
+  CONIN_PARTIAL_SEQUENCE_FLUSH_MS,
+  ConinAtomicSequenceWriter
+} from './conin-atomic-sequence-writer'
+import { MAX_PARTIAL_ESCAPE_TAIL_LENGTH } from '../../shared/terminal-partial-escape-tail'
+
+describe('ConinAtomicSequenceWriter', () => {
+  let written: string[]
+  let writer: ConinAtomicSequenceWriter
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    written = []
+    writer = new ConinAtomicSequenceWriter((data) => written.push(data))
+  })
+
+  afterEach(() => {
+    writer.dispose()
+    vi.useRealTimers()
+  })
+
+  it('passes complete chunks through unchanged with no added latency', () => {
+    writer.write('\x7f')
+    writer.write('hello')
+    writer.write('\x1b[A')
+    writer.write('\x1b[200~pasted text\x1b[201~')
+    expect(written).toEqual(['\x7f', 'hello', '\x1b[A', '\x1b[200~pasted text\x1b[201~'])
+  })
+
+  // The field failure: ConPTY swallows a split sequence's head and types its
+  // tail as literal keystrokes (repro: split `\x1b[?997;1` + `n` delivers "n").
+  it('joins a CSI split across two writes into one atomic write', () => {
+    writer.write('\x1b[?997;1')
+    expect(written).toEqual([])
+    writer.write('n')
+    expect(written).toEqual(['\x1b[?997;1n'])
+  })
+
+  it('joins a split bracketed-paste end marker', () => {
+    writer.write('\x1b[200~hi\x1b[')
+    expect(written).toEqual(['\x1b[200~hi'])
+    writer.write('201~')
+    expect(written).toEqual(['\x1b[200~hi', '\x1b[201~'])
+  })
+
+  it('joins a split DCS reply', () => {
+    writer.write('\x1bP>|xterm.js')
+    expect(written).toEqual([])
+    writer.write('(5.5.0)\x1b\\')
+    expect(written).toEqual(['\x1bP>|xterm.js(5.5.0)\x1b\\'])
+  })
+
+  it('flushes a bare ESC keypress after the short window', () => {
+    writer.write('\x1b')
+    expect(written).toEqual([])
+    vi.advanceTimersByTime(CONIN_BARE_ESC_FLUSH_MS)
+    expect(written).toEqual(['\x1b'])
+  })
+
+  it('does not fuse ESC with a following independent keypress into an Alt-chord', () => {
+    writer.write('\x1b')
+    writer.write('a')
+    // Two separate writes: ESC key, then the letter — never '\x1ba' (Alt+A).
+    expect(written).toEqual(['\x1b', 'a'])
+  })
+
+  it('does not fuse ESC with a following backspace into Alt+Backspace', () => {
+    writer.write('\x1b')
+    writer.write('\x7f')
+    expect(written).toEqual(['\x1b', '\x7f'])
+  })
+
+  it('joins ESC with a genuine sequence continuation', () => {
+    writer.write('\x1b')
+    writer.write('[I')
+    expect(written).toEqual(['\x1b[I'])
+  })
+
+  it('flushes a dangling non-ESC partial after the long window', () => {
+    writer.write('\x1b[?99')
+    vi.advanceTimersByTime(CONIN_PARTIAL_SEQUENCE_FLUSH_MS - 1)
+    expect(written).toEqual([])
+    vi.advanceTimersByTime(1)
+    expect(written).toEqual(['\x1b[?99'])
+  })
+
+  it('keeps a real Alt-chord sent as one write intact', () => {
+    writer.write('\x1ba')
+    expect(written).toEqual(['\x1ba'])
+  })
+
+  it('writes the complete prefix immediately while holding only the tail', () => {
+    writer.write('abc\x1b[?25h\x1b[?20')
+    expect(written).toEqual(['abc\x1b[?25h'])
+    writer.write('04h\x7f')
+    expect(written).toEqual(['abc\x1b[?25h', '\x1b[?2004h\x7f'])
+  })
+
+  it('stops guarding past the partial-tail cap', () => {
+    const hugeOsc = `\x1b]0;${'x'.repeat(MAX_PARTIAL_ESCAPE_TAIL_LENGTH + 10)}`
+    writer.write(hugeOsc)
+    expect(written).toEqual([hugeOsc])
+    // Subsequent writes pass through (tracking abandoned for that stream).
+    writer.write('y')
+    expect(written).toEqual([hugeOsc, 'y'])
+  })
+
+  it('drops held state on dispose without writing', () => {
+    writer.write('\x1b[?99')
+    writer.dispose()
+    vi.advanceTimersByTime(CONIN_PARTIAL_SEQUENCE_FLUSH_MS)
+    expect(written).toEqual([])
+    writer.write('x')
+    expect(written).toEqual([])
+  })
+
+  it('handles a three-way split of one sequence', () => {
+    writer.write('\x1b')
+    writer.write('[?9')
+    writer.write('97;1n\x7f')
+    expect(written).toEqual(['\x1b[?997;1n\x7f'])
+  })
+
+  it('flushes at most once per held tail when the timer races a continuation', () => {
+    writer.write('\x1b[?99')
+    vi.advanceTimersByTime(CONIN_PARTIAL_SEQUENCE_FLUSH_MS)
+    expect(written).toEqual(['\x1b[?99'])
+    // Continuation after the flush degrades to pre-guard behavior: literal tail.
+    writer.write('7;1n')
+    expect(written).toEqual(['\x1b[?99', '7;1n'])
+  })
+})

--- a/src/main/daemon/conin-atomic-sequence-writer.ts
+++ b/src/main/daemon/conin-atomic-sequence-writer.ts
@@ -1,0 +1,135 @@
+// Why this module exists: ConPTY's input parser does not keep VT parser state
+// across conin write boundaries. An escape sequence split across two writes
+// deterministically loses its head (silently swallowed) and delivers its tail
+// to the foreground app as literal keystrokes — e.g. a split `\x1b[?997;1` +
+// `n` types "n", and a split bracketed-paste end marker leaves the app stuck
+// in paste mode, where Backspace inserts a blank-rendering literal instead of
+// deleting ("backspace types a space" after session resume). Holding a
+// trailing partial sequence until its continuation arrives lets the daemon
+// hand ConPTY only whole sequences.
+import {
+  extractPartialEscapeTail,
+  MAX_PARTIAL_ESCAPE_TAIL_LENGTH
+} from '../../shared/terminal-partial-escape-tail'
+import { recordDaemonStreamBacklogEvent } from './daemon-stream-backlog-probe'
+
+// Why two windows: a bare ESC is (almost always) a real Escape keypress, so it
+// must flush fast enough that Escape stays responsive; a longer partial (CSI/
+// OSC/DCS body) can never be a bare human keypress, so it may wait longer for
+// its continuation under daemon load.
+export const CONIN_BARE_ESC_FLUSH_MS = 15
+export const CONIN_PARTIAL_SEQUENCE_FLUSH_MS = 150
+
+const ESC = '\x1b'
+// ESC continuation openers: CSI `[`, OSC `]`, SS3 `O`, DCS `P`, SOS `X`,
+// PM `^`, APC `_`. Anything else after a held bare ESC is treated as an
+// independent keypress (ESC key, then the next key) and flushed separately so
+// e.g. Escape followed quickly by a letter cannot be fused into an Alt-chord.
+const ESC_CONTINUATION_OPENERS = new Set(['[', ']', 'O', 'P', 'X', '^', '_'])
+
+export type ConinAtomicSequenceWriterOptions = {
+  sessionIdSuffix?: string
+  bareEscFlushMs?: number
+  partialSequenceFlushMs?: number
+}
+
+export class ConinAtomicSequenceWriter {
+  private heldTail = ''
+  private flushTimer: ReturnType<typeof setTimeout> | null = null
+  private disposed = false
+  private readonly sink: (data: string) => void
+  private readonly sessionIdSuffix: string
+  private readonly bareEscFlushMs: number
+  private readonly partialSequenceFlushMs: number
+
+  constructor(sink: (data: string) => void, opts: ConinAtomicSequenceWriterOptions = {}) {
+    this.sink = sink
+    this.sessionIdSuffix = opts.sessionIdSuffix ?? ''
+    this.bareEscFlushMs = opts.bareEscFlushMs ?? CONIN_BARE_ESC_FLUSH_MS
+    this.partialSequenceFlushMs = opts.partialSequenceFlushMs ?? CONIN_PARTIAL_SEQUENCE_FLUSH_MS
+  }
+
+  get pendingTail(): string {
+    return this.heldTail
+  }
+
+  write(data: string): void {
+    if (this.disposed) {
+      return
+    }
+    if (data.length === 0) {
+      return
+    }
+    if (this.heldTail === ESC && !ESC_CONTINUATION_OPENERS.has(data[0])) {
+      // Held bare ESC + a non-opener: two independent keypresses. Flush the
+      // ESC as its own write so they are not fused into an Alt-chord.
+      this.flushHeldTail('esc-then-key')
+    }
+    const combined = this.heldTail + data
+    this.clearFlushTimer()
+    const joinedFromHeldTail = this.heldTail.length > 0
+    const tail = extractPartialEscapeTail(combined)
+    if (tail.length > MAX_PARTIAL_ESCAPE_TAIL_LENGTH) {
+      // Pathological unterminated OSC/DCS: stop guarding, pass through.
+      this.heldTail = ''
+      this.sink(combined)
+      return
+    }
+    const complete = combined.slice(0, combined.length - tail.length)
+    this.heldTail = tail
+    if (complete.length > 0) {
+      if (joinedFromHeldTail) {
+        recordDaemonStreamBacklogEvent('coninJoinedSplitSequence', {
+          sessionIdSuffix: this.sessionIdSuffix,
+          joinedChars: complete.length
+        })
+      }
+      this.sink(complete)
+    }
+    if (this.heldTail.length > 0) {
+      this.armFlushTimer()
+    }
+  }
+
+  /** Write the held partial as-is (degrades to pre-guard behavior). */
+  private flushHeldTail(reason: 'timeout' | 'esc-then-key'): void {
+    this.clearFlushTimer()
+    const tail = this.heldTail
+    if (tail.length === 0) {
+      return
+    }
+    this.heldTail = ''
+    // A flushed bare ESC is a normal Escape keypress, not a corruption signal.
+    if (tail !== ESC) {
+      recordDaemonStreamBacklogEvent('coninFlushedDanglingPartial', {
+        sessionIdSuffix: this.sessionIdSuffix,
+        reason,
+        tailChars: tail.length
+      })
+    }
+    this.sink(tail)
+  }
+
+  private armFlushTimer(): void {
+    const delay = this.heldTail === ESC ? this.bareEscFlushMs : this.partialSequenceFlushMs
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null
+      this.flushHeldTail('timeout')
+    }, delay)
+    this.flushTimer.unref?.()
+  }
+
+  private clearFlushTimer(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer)
+      this.flushTimer = null
+    }
+  }
+
+  /** Drop held state without writing — the PTY is gone. */
+  dispose(): void {
+    this.disposed = true
+    this.clearFlushTimer()
+    this.heldTail = ''
+  }
+}

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -195,6 +195,44 @@ describe('Session', () => {
     })
   })
 
+  describe('win32 conin atomic sequence guard', () => {
+    const realPlatform = process.platform
+    const setPlatform = (value: NodeJS.Platform) =>
+      Object.defineProperty(process, 'platform', { value, configurable: true })
+
+    afterEach(() => {
+      setPlatform(realPlatform)
+    })
+
+    // Why: ConPTY drops VT input-parser state at conin write boundaries — a
+    // split sequence's head is swallowed and its tail typed as literal
+    // keystrokes (the "backspace types a space" resume corruption).
+    it('joins an escape sequence split across writes into one conin write', () => {
+      setPlatform('win32')
+      createSession({ shellReadySupported: false })
+      session.write('\x1b[?997;1')
+      expect(subprocess.written).toEqual([])
+      session.write('n')
+      expect(subprocess.written).toEqual(['\x1b[?997;1n'])
+    })
+
+    it('flushes a held partial on the flush window instead of holding forever', () => {
+      setPlatform('win32')
+      createSession({ shellReadySupported: false })
+      session.write('\x1b[?99')
+      vi.advanceTimersByTime(1000)
+      expect(subprocess.written).toEqual(['\x1b[?99'])
+    })
+
+    it('leaves non-Windows write granularity untouched', () => {
+      setPlatform('linux')
+      createSession({ shellReadySupported: false })
+      session.write('\x1b[?997;1')
+      session.write('n')
+      expect(subprocess.written).toEqual(['\x1b[?997;1', 'n'])
+    })
+  })
+
   describe('emulator does not reply to terminal queries', () => {
     // Why: daemon emulator parses in-process synchronously — before
     // handleSubprocessData forwards bytes onward — so any auto-reply it

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -1,5 +1,6 @@
 /* oxlint-disable max-lines */
 import { HeadlessEmulator } from './headless-emulator'
+import { ConinAtomicSequenceWriter } from './conin-atomic-sequence-writer'
 import { isValidPtySize, normalizePtySize } from './daemon-pty-size'
 import { PostReadyFlushGate } from './post-ready-flush-gate'
 import {
@@ -133,6 +134,9 @@ export class Session {
   private forceKillSent = false
   private subprocessDisposed = false
   private readonly physicalExit = new PhysicalExitTracker()
+  // Why win32-only: ConPTY's input parser drops VT state at conin write
+  // boundaries, turning a split escape sequence into literal keystrokes.
+  private readonly coninWriter: ConinAtomicSequenceWriter | null
 
   constructor(opts: SessionOptions) {
     this.sessionId = opts.sessionId
@@ -164,6 +168,13 @@ export class Session {
     } else {
       this._shellState = 'unsupported'
     }
+
+    this.coninWriter =
+      process.platform === 'win32'
+        ? new ConinAtomicSequenceWriter((data) => this.subprocess.write(data), {
+            sessionIdSuffix: this.sessionId.slice(-10)
+          })
+        : null
 
     this.postReadyFlushGate = new PostReadyFlushGate(() => this.flushPreReadyQueue())
     this.subprocess.onData((data) => this.handleSubprocessData(data))
@@ -225,6 +236,16 @@ export class Session {
       return
     }
 
+    this.writeToSubprocess(data)
+  }
+
+  // Why: on Windows every conin write funnels through the atomic-sequence
+  // guard so a split escape sequence cannot reach ConPTY across two writes.
+  private writeToSubprocess(data: string): void {
+    if (this.coninWriter) {
+      this.coninWriter.write(data)
+      return
+    }
     this.subprocess.write(data)
   }
 
@@ -510,7 +531,8 @@ export class Session {
     if (!this.emulator.isCursorOnEmptyPromptLine()) {
       return
     }
-    this.subprocess.write('\x0c')
+    // Why through the guard: bypassing it could reorder around a held tail.
+    this.writeToSubprocess('\x0c')
   }
 
   prepareForFinalSnapshot(): string {
@@ -594,6 +616,8 @@ export class Session {
       return
     }
     this._disposed = true
+    // Why: drop any held partial input — the PTY is going away.
+    this.coninWriter?.dispose()
     // Why: never leave a paused fd behind on any teardown path — the handle's
     // own dead-guard makes this a no-op when the child is already reaped.
     this.releaseProducerPause({ resume: true })
@@ -694,6 +718,7 @@ export class Session {
     this._exitCode = code
     this._state = 'exited'
     this._isTerminating = false
+    this.coninWriter?.dispose()
     // Why resume:false — the child is reaped, so there is nothing to unblock;
     // only the failsafe timer must not outlive the session.
     this.releaseProducerPause({ resume: false })
@@ -767,7 +792,7 @@ export class Session {
     const queued = this.preReadyStdinQueue
     this.preReadyStdinQueue = []
     for (const data of queued) {
-      this.subprocess.write(data)
+      this.writeToSubprocess(data)
     }
   }
 


### PR DESCRIPTION
Fixes the recurring **"backspace types a space in my terminal after I come back + resume sessions"** report (native Windows, daemon ConPTY panes; prior partial fix: #9259).

## Root cause (empirically established on Windows 11 26200)

ConPTY's input parser does **not** keep VT parser state across conin write boundaries. Measured with a raw-stdin child under a real ConPTY:

- `\x1b[?997;1` + `n` written as two writes (any gap, including immediate) → the head is **silently swallowed** and the app receives literal `"n"`. Deterministic, 3/3.
- A bracketed-paste end marker split as `…\x1b[` + `201~` → the paste never closes app-side. In Claude Code's composer this leaves paste-buffering stuck: subsequent keystrokes buffer invisibly and Backspace stops deleting / inserts a blank-rendering literal — exactly the field symptom (the reporter's live session history log shows caret-advance-with-no-glyph per keypress, then self-healing after a full composer redraw).
- The same corruption class covers every escape-shaped injection Orca legitimately writes into conin: query auto-replies (DA1/CPR/OSC color/XTVERSION DCS), mode-2031 color-scheme reports, focus reports, paste markers. Resume storms (multi-workspace reattach, the reporter had 5 sessions created in ~80s) are when these injections cluster.

## Fix

`ConinAtomicSequenceWriter`, wired into the daemon `Session` write path for win32 sessions only:

- passes through any write that ends parser-clean unchanged (every ordinary keystroke/paste — zero added latency, no copies);
- holds a trailing partial escape sequence and joins its continuation into **one atomic conin write**;
- flushes a held bare ESC after 15 ms (a real Escape keypress; never fused with a following independent key, so ESC+Backspace cannot become Alt+Backspace);
- flushes other dangling partials after 150 ms (degrades to pre-fix behavior, breadcrumbed);
- caps held state at the shared 4 KB partial-tail limit (reuses `terminal-partial-escape-tail`, the scanner already trusted on the output path);
- drops held state on session exit/teardown.

## Reliability contract

- **Touched class:** `terminal-input.windows-conpty-write-atomicity` (new manifest gate, `experimental`, wired commands).
- **Invariant:** every escape sequence written to a ConPTY conin is contained in a single write.
- **Failure source:** live field repro (this report), prior #9259, ConPTY behavior measured in `conin-atomic-sequence-writer.conpty.integration.test.ts`.
- **Product change type:** product runtime hardening + diagnostics + gate.
- **Oracle:** byte-level — a raw-stdin child under a real ConPTY receives the joined sequence with the guard and the corrupted literal tail without it (the integration file keeps the raw defect as a pinned red so a future ConPTY fix is visible).
- **Provider/platform matrix:** Windows daemon: covered (unit + real-ConPTY integration). WSL: shares the daemon write path, no dedicated live run (accepted gap). macOS/Linux: guard not constructed, write granularity untouched (covered by test). SSH: input never traverses local conhost — unaffected. Mobile/relay: reach the same daemon write path once on the host — covered by the same guard.
- **Performance budget:** pass-through fast path for parser-clean writes (no timer armed, no string copy beyond the existing concat of an empty held tail); scanner is O(len) over keystroke-sized inputs. No polling, no per-key session listing, no hidden-pane work.
- **Diagnostics:** env-gated breadcrumbs `coninJoinedSplitSequence` / `coninFlushedDanglingPartial` (ORCA_DAEMON_STREAM_BACKLOG_FILE) to identify the upstream split producer in the field.

## Verification

- `vitest run src/main/daemon/conin-atomic-sequence-writer.test.ts src/main/daemon/session.test.ts` — 84+ tests green (join/hold/flush/ESC-disambiguation/cap/dispose, win32 session routing, non-win32 granularity untouched).
- `vitest run src/main/daemon/conin-atomic-sequence-writer.conpty.integration.test.ts` — green on Windows 11 26200 against a **real ConPTY**: documents the raw defect and proves guarded whole-sequence delivery.
- End-to-end against a real Claude Code composer under ConPTY: with the guard, a split-paste write pattern leaves the composer healthy (`pastedab` → 2× Backspace → `pasted`); unguarded, the same pattern reproduces the stuck-composer corruption (timing-dependent, matching the intermittent field behavior).
- `pnpm run typecheck:node` and `oxlint` clean. Pre-existing unrelated failure on this Windows host: `osc7-file-uri.test.ts` (fails identically on clean HEAD).

## Residual gaps

- The upstream producer of split/dangling sequences in the field is not yet pinpointed; the guard neutralizes the class at the last hop and the breadcrumbs are designed to attribute it.
- Renderer→daemon input uses a fire-and-forget notify that silently drops whole messages while disconnected/mid-respawn; a dropped paste message is unrecoverable by this guard (follow-up candidate).
- A ~15 ms hold on bare ESC keypresses (below perception threshold; demotion rule covers regressions).