### PR TITLE
fix(create-worktree): keep composer open when adding a project from the dialog

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -154,6 +154,9 @@ type NewWorkspaceComposerCardProps = {
   sparseSelectedPresetId: string | null
   onSparseSelectPreset: (preset: SparsePreset | null) => void
   sparseControlsEnabled?: boolean
+  /** When set, "Add project" opens a host-provided flow (e.g. a nested dialog
+   *  over the composer modal) instead of swapping the store's active modal. */
+  onAddProjectOverride?: () => void
 }
 
 const SSH_STATUS_LABELS: Partial<Record<SshConnectionStatus, string>> = {
@@ -615,7 +618,8 @@ export default function NewWorkspaceComposerCard({
   sparsePresets,
   sparseSelectedPresetId,
   onSparseSelectPreset,
-  sparseControlsEnabled = true
+  sparseControlsEnabled = true,
+  onAddProjectOverride
 }: NewWorkspaceComposerCardProps): React.JSX.Element {
   // Why: this form uses the lightweight translate() helper directly; subscribe
   // so an already-open create dialog repaints when the UI language changes.
@@ -728,8 +732,14 @@ export default function NewWorkspaceComposerCard({
   }, [detectedAgentIds, disabledTuiAgents])
 
   const handleAddRepo = React.useCallback((): void => {
+    // Why: inside the composer modal, swapping activeModal would abruptly
+    // unmount the composer; the override layers Add Project on top instead.
+    if (onAddProjectOverride) {
+      onAddProjectOverride()
+      return
+    }
     openModal('add-repo')
-  }, [openModal])
+  }, [onAddProjectOverride, openModal])
   const handleNotePaste = React.useCallback((event: React.ClipboardEvent<HTMLTextAreaElement>) => {
     const text = event.clipboardData.getData('text/plain')
     const byteLengthMeasurement = measureTextControlPasteByteLength(text, {

--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -204,19 +204,28 @@ function QuickTabBody({
   const handleProjectAdded = useCallback(
     (repoId: string): void => {
       selectAddedProjectRepo(repoId)
-      // Why: land keyboard flow on the name field, mirroring what picking a
-      // project from the combobox does.
-      requestAnimationFrame(() => nameInputRef?.current?.focus())
     },
-    [nameInputRef, selectAddedProjectRepo]
+    [selectAddedProjectRepo]
+  )
+  const handleAddProjectCloseAutoFocus = useCallback(
+    (event: Event): void => {
+      // Why: after adding a project the next step is naming the worktree.
+      // Radix would try to restore focus to the (unmounted) combobox row that
+      // opened the dialog; send it to the name field instead — the same place
+      // picking a project from the combobox lands.
+      event.preventDefault()
+      nameInputRef?.current?.focus()
+    },
+    [nameInputRef]
   )
   const addProjectController = useMemo<AddRepoDialogHostedController>(
     () => ({
       open: addProjectOpen,
       onOpenChange: setAddProjectOpen,
-      onProjectAdded: handleProjectAdded
+      onProjectAdded: handleProjectAdded,
+      onCloseAutoFocus: handleAddProjectCloseAutoFocus
     }),
-    [addProjectOpen, handleProjectAdded]
+    [addProjectOpen, handleAddProjectCloseAutoFocus, handleProjectAdded]
   )
   const selectedProjectOption = cardProps.projectOptions.find(
     (option) => option.id === cardProps.selectedProjectId

--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -1,5 +1,6 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
 import { useAppStore } from '@/store'
+import { lazyWithRetry } from '@/lib/lazy-with-retry'
 import {
   Dialog,
   DialogContent,
@@ -9,6 +10,7 @@ import {
 } from '@/components/ui/dialog'
 import NewWorkspaceComposerCard from '@/components/NewWorkspaceComposerCard'
 import AgentSettingsDialog from '@/components/agent/AgentSettingsDialog'
+import type { AddRepoDialogHostedController } from '@/components/sidebar/use-add-repo-hosted-controller'
 import { useComposerState } from '@/hooks/useComposerState'
 import {
   pickQuickWorkspaceAgent,
@@ -26,6 +28,12 @@ import type { TaskSourceContext } from '../../../shared/task-source-context'
 import { translate } from '@/i18n/i18n'
 import { getWorkspaceComposerInitialFocusTarget } from '@/lib/workspace-composer-initial-focus'
 import { getFolderWorkspacePrimaryActionLabel } from '@/components/sidebar/folder-workspace-composer-helpers'
+
+// Why: match App-level AddRepoDialog loading — the add flow is off the hot
+// path for the composer, so keep its clone/SSH machinery out of the entry render.
+const HostedAddRepoDialog = lazyWithRetry(() => import('@/components/sidebar/AddRepoDialog'), {
+  reloadKey: 'composer-add-repo'
+})
 
 type ComposerModalData = {
   prefilledName?: string
@@ -120,7 +128,8 @@ function QuickTabBody({
     onComposerNodeChange,
     nameInputRef,
     submitQuick,
-    createDisabled
+    createDisabled,
+    selectAddedProjectRepo
   } = useComposerState({
     initialName: modalData.prefilledName ?? '',
     // Why: the modal is quick-create only now, so prompt-prefill state is
@@ -180,6 +189,35 @@ function QuickTabBody({
   const handleCreate = useCallback(async (): Promise<void> => {
     await submitQuick(quickAgent)
   }, [quickAgent, submitQuick])
+  // Why: Add Project layers over the composer as a nested dialog instead of
+  // replacing it in the activeModal slot — closing the composer mid-flow (and
+  // losing the typed name/prompt) was the old, abrupt behavior. Once opened it
+  // stays mounted so cancel/complete plays the close animation and the
+  // dialog's close effects can abort in-flight clone/scan work. (Folder/non-git
+  // outcomes still navigate away and tear the whole modal down.)
+  const [addProjectOpen, setAddProjectOpen] = useState(false)
+  const [addProjectMounted, setAddProjectMounted] = useState(false)
+  const handleOpenAddProject = useCallback((): void => {
+    setAddProjectMounted(true)
+    setAddProjectOpen(true)
+  }, [])
+  const handleProjectAdded = useCallback(
+    (repoId: string): void => {
+      selectAddedProjectRepo(repoId)
+      // Why: land keyboard flow on the name field, mirroring what picking a
+      // project from the combobox does.
+      requestAnimationFrame(() => nameInputRef?.current?.focus())
+    },
+    [nameInputRef, selectAddedProjectRepo]
+  )
+  const addProjectController = useMemo<AddRepoDialogHostedController>(
+    () => ({
+      open: addProjectOpen,
+      onOpenChange: setAddProjectOpen,
+      onProjectAdded: handleProjectAdded
+    }),
+    [addProjectOpen, handleProjectAdded]
+  )
   const selectedProjectOption = cardProps.projectOptions.find(
     (option) => option.id === cardProps.selectedProjectId
   )
@@ -191,8 +229,12 @@ function QuickTabBody({
       : translate('auto.components.NewWorkspaceComposerModal.createWorkspace', 'Create workspace')
 
   // Cmd/Ctrl+Enter submits, Esc first blurs the focused input (like the full page).
+  const nestedDialogOpen = agentSettingsOpen || addProjectOpen
   useEffect(() => {
-    if (!active) {
+    if (!active || nestedDialogOpen) {
+      // Why: while a nested dialog (Add Project / Agents) is layered on top,
+      // this capture-phase handler must not steal its Escape (which should
+      // close only the nested dialog) or fire composer submit underneath it.
       return
     }
     const onKeyDown = (event: KeyboardEvent): void => {
@@ -236,7 +278,7 @@ function QuickTabBody({
     }
     window.addEventListener('keydown', onKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
-  }, [active, composerRef, createDisabled, handleCreate, onClose])
+  }, [active, composerRef, createDisabled, handleCreate, nestedDialogOpen, onClose])
 
   return (
     <>
@@ -271,8 +313,14 @@ function QuickTabBody({
         primaryActionLabel={primaryActionLabel}
         onOpenAgentSettings={() => setAgentSettingsOpen(true)}
         onCreate={() => void handleCreate()}
+        onAddProjectOverride={handleOpenAddProject}
       />
       <AgentSettingsDialog open={agentSettingsOpen} onOpenChange={setAgentSettingsOpen} />
+      {addProjectMounted ? (
+        <Suspense fallback={null}>
+          <HostedAddRepoDialog hosted={addProjectController} />
+        </Suspense>
+      ) : null}
     </>
   )
 }

--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -16,24 +16,32 @@ import { useAddRepoHostChangeReset } from './use-add-repo-host-change-reset'
 import { AddRepoDialogChrome } from './AddRepoDialogChrome'
 import { AddRepoHostSelectorSlot } from './AddRepoHostSelectorSlot'
 import { useAddRepoRemoteNestedScan } from './use-add-repo-remote-nested-scan'
+import {
+  useAddRepoHostedController,
+  type AddRepoDialogHostedController
+} from './use-add-repo-hosted-controller'
 
-const AddRepoDialog = React.memo(function AddRepoDialog() {
+const AddRepoDialog = React.memo(function AddRepoDialog({
+  hosted
+}: {
+  hosted?: AddRepoDialogHostedController
+}) {
   const activeModal = useAppStore((s) => s.activeModal)
   const modalData = useAppStore((s) => s.modalData)
-  const closeModal = useAppStore((s) => s.closeModal)
   const addRepoPath = useAppStore((s) => s.addRepoPath)
   const scanNestedRepos = useAppStore((s) => s.scanNestedRepos)
   const cancelNestedRepoScan = useAppStore((s) => s.cancelNestedRepoScan)
   const importNestedRepos = useAppStore((s) => s.importNestedRepos)
   const repos = useAppStore((s) => s.repos)
   const fetchWorktrees = useAppStore((s) => s.fetchWorktrees)
-  const openSettingsPage = useAppStore((s) => s.openSettingsPage)
-  const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
   const setHideDefaultBranchWorkspace = useAppStore((s) => s.setHideDefaultBranchWorkspace)
   const settings = useAppStore((s) => s.settings)
+  const { closeModal, closeForFolderHandoff, finishProjectAdd, handleOpenSshSettings } =
+    useAddRepoHostedController(hosted)
   const completeGitRepoAdd = useCompleteGitRepoAdd({
     closeModal,
-    setHideDefaultBranchWorkspace
+    setHideDefaultBranchWorkspace,
+    finishProjectAdd
   })
 
   const [step, setStep] = useState<AddRepoDialogStep>('add')
@@ -63,7 +71,8 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     setStep
   })
 
-  const hostSelection = useAddRepoHostSelection({ isOpen: activeModal === 'add-repo', setStep })
+  const isOpen = hosted ? hosted.open : activeModal === 'add-repo'
+  const hostSelection = useAddRepoHostSelection({ isOpen, setStep })
   const selectedRuntimeEnvironmentId =
     hostSelection.selectedParsedHost?.kind === 'runtime'
       ? hostSelection.selectedParsedHost.environmentId
@@ -90,7 +99,8 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
   } = useRemoteRepo(
     fetchWorktrees,
     setStep,
-    closeModal,
+    // Why: useRemoteRepo closes only for the non-git → confirm-dialog handoff.
+    closeForFolderHandoff,
     (repoId) => completeGitRepoAdd(repoId, 'ssh_remote_path'),
     scanNestedRepos,
     showRemoteNestedRepoReview,
@@ -110,7 +120,8 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     handleCreate
   } = useCreateRepo(
     fetchWorktrees,
-    closeModal,
+    // Why: useCreateRepo closes only after a folder (non-git) create.
+    closeForFolderHandoff,
     (repoId) => completeGitRepoAdd(repoId, 'create_project'),
     {
       hostId: hostSelection.selectedHostId,
@@ -155,9 +166,10 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     onGitRepoReady: completeGitRepoAdd
   })
 
-  const isOpen = activeModal === 'add-repo'
+  // Why: hosted mode never receives dropped paths through modalData — that
+  // channel belongs to the store-modal instance.
   const droppedLocalPath =
-    typeof modalData.droppedLocalPath === 'string' ? modalData.droppedLocalPath : ''
+    !hosted && typeof modalData.droppedLocalPath === 'string' ? modalData.droppedLocalPath : ''
   const isRuntimeEnvironmentActive = Boolean(selectedRuntimeEnvironmentId)
   const selectedHostKind = hostSelection.selectedParsedHost?.kind
   const { handleBrowse, resetLocalFolderFlow } = useAddRepoLocalFolderFlow({
@@ -165,7 +177,8 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     droppedLocalPath,
     activeRuntimeEnvironmentId: selectedRuntimeEnvironmentId,
     addRepoPath,
-    closeModal,
+    // Why: this flow's closes are all folder/non-git outcomes that navigate.
+    closeModal: closeForFolderHandoff,
     fetchWorktrees,
     scanNestedRepos,
     setActiveNestedScanId,
@@ -183,7 +196,8 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     handleAddServerPath
   } = useAddRepoServerPathFlow({
     addRepoPath,
-    closeModal,
+    // Why: closes only after a folder add, which activates the folder workspace.
+    closeModal: closeForFolderHandoff,
     fetchWorktrees,
     getNestedRepoRuntimeKind,
     scanNestedRepos,
@@ -207,6 +221,9 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
     nestedGroupName,
     nestedImportScanId,
     activeRuntimeEnvironmentId: selectedRuntimeEnvironmentId,
+    // Why: open-as-folder outcomes navigate; git imports finish via
+    // completeGitRepoAdd instead.
+    closeModal: closeForFolderHandoff,
     fetchWorktrees,
     importNestedRepos,
     getNestedRepoRuntimeKind,
@@ -365,11 +382,7 @@ const AddRepoDialog = React.memo(function AddRepoDialog() {
           setRemoteError(null)
         }}
         onAddRemoteRepo={handleAddRemoteRepo}
-        onOpenSshSettings={() => {
-          closeModal()
-          openSettingsTarget({ pane: 'ssh', repoId: null, sectionId: 'ssh' })
-          openSettingsPage()
-        }}
+        onOpenSshSettings={handleOpenSshSettings}
         onConnectTarget={handleConnectTarget}
         onStopRemoteNestedScan={stopRemoteNestedScan}
         onCloneUrlChange={(value) => {

--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -26,8 +26,12 @@ const AddRepoDialog = React.memo(function AddRepoDialog({
 }: {
   hosted?: AddRepoDialogHostedController
 }) {
-  const activeModal = useAppStore((s) => s.activeModal)
-  const modalData = useAppStore((s) => s.modalData)
+  const isOpen = useAppStore((s) => (hosted ? hosted.open : s.activeModal === 'add-repo'))
+  // Why: hosted mode never receives dropped paths through modalData — that
+  // channel belongs to the store-modal instance.
+  const droppedLocalPath = useAppStore((s) =>
+    !hosted && typeof s.modalData.droppedLocalPath === 'string' ? s.modalData.droppedLocalPath : ''
+  )
   const addRepoPath = useAppStore((s) => s.addRepoPath)
   const scanNestedRepos = useAppStore((s) => s.scanNestedRepos)
   const cancelNestedRepoScan = useAppStore((s) => s.cancelNestedRepoScan)
@@ -71,7 +75,6 @@ const AddRepoDialog = React.memo(function AddRepoDialog({
     setStep
   })
 
-  const isOpen = hosted ? hosted.open : activeModal === 'add-repo'
   const hostSelection = useAddRepoHostSelection({ isOpen, setStep })
   const selectedRuntimeEnvironmentId =
     hostSelection.selectedParsedHost?.kind === 'runtime'
@@ -166,10 +169,6 @@ const AddRepoDialog = React.memo(function AddRepoDialog({
     onGitRepoReady: completeGitRepoAdd
   })
 
-  // Why: hosted mode never receives dropped paths through modalData — that
-  // channel belongs to the store-modal instance.
-  const droppedLocalPath =
-    !hosted && typeof modalData.droppedLocalPath === 'string' ? modalData.droppedLocalPath : ''
   const isRuntimeEnvironmentActive = Boolean(selectedRuntimeEnvironmentId)
   const selectedHostKind = hostSelection.selectedParsedHost?.kind
   const { handleBrowse, resetLocalFolderFlow } = useAddRepoLocalFolderFlow({
@@ -306,6 +305,7 @@ const AddRepoDialog = React.memo(function AddRepoDialog({
       step={step}
       isAdding={isAdding}
       onBack={handleBack}
+      onCloseAutoFocus={hosted?.onCloseAutoFocus}
       onOpenChange={handleOpenChange}
     >
       <AddRepoDialogStepContent

--- a/src/renderer/src/components/sidebar/AddRepoDialogChrome.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialogChrome.tsx
@@ -8,6 +8,7 @@ export function AddRepoDialogChrome({
   isAdding,
   isOpen,
   onBack,
+  onCloseAutoFocus,
   onOpenChange,
   step
 }: {
@@ -15,12 +16,14 @@ export function AddRepoDialogChrome({
   isAdding: boolean
   isOpen: boolean
   onBack: () => void
+  onCloseAutoFocus?: (event: Event) => void
   onOpenChange: (open: boolean) => void
   step: AddRepoDialogStep
 }) {
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
+        onCloseAutoFocus={onCloseAutoFocus}
         className={`min-w-0 overflow-hidden sm:max-w-lg [&>*]:min-w-0 ${
           step === 'nested' ? 'max-h-[calc(100vh-2rem)] grid-rows-[auto_auto_minmax(0,1fr)]' : ''
         }`}

--- a/src/renderer/src/components/sidebar/use-add-repo-hosted-controller.test.ts
+++ b/src/renderer/src/components/sidebar/use-add-repo-hosted-controller.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ReactModule from 'react'
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactModule>()
+  return {
+    ...actual,
+    useCallback: <T extends (...args: never[]) => unknown>(fn: T) => fn,
+    useMemo: <T>(factory: () => T) => factory()
+  }
+})
+
+const mocks = vi.hoisted(() => ({
+  state: {
+    closeModal: vi.fn(),
+    openSettingsPage: vi.fn(),
+    openSettingsTarget: vi.fn()
+  },
+  markOnboardingProjectAdded: vi.fn(() => Promise.resolve())
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign(
+    (selector: (state: typeof mocks.state) => unknown) => selector(mocks.state),
+    { getState: () => mocks.state }
+  )
+}))
+
+vi.mock('@/lib/onboarding-project-checklist', () => ({
+  markOnboardingProjectAdded: mocks.markOnboardingProjectAdded
+}))
+
+import { useAddRepoHostedController } from './use-add-repo-hosted-controller'
+
+describe('useAddRepoHostedController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('falls back to the store closeModal without a hosted controller', () => {
+    const { closeModal, closeForFolderHandoff, finishProjectAdd } =
+      useAddRepoHostedController(undefined)
+    closeModal()
+    expect(mocks.state.closeModal).toHaveBeenCalledTimes(1)
+    closeForFolderHandoff()
+    expect(mocks.state.closeModal).toHaveBeenCalledTimes(2)
+    expect(finishProjectAdd).toBeUndefined()
+  })
+
+  it('closes only the hosted dialog, never the store modal slot', () => {
+    const onOpenChange = vi.fn()
+    const { closeModal } = useAddRepoHostedController({
+      open: true,
+      onOpenChange,
+      onProjectAdded: vi.fn()
+    })
+    closeModal()
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+    expect(mocks.state.closeModal).not.toHaveBeenCalled()
+  })
+
+  it('folder handoffs close both the hosted dialog and the composer modal', () => {
+    const onOpenChange = vi.fn()
+    const { closeForFolderHandoff } = useAddRepoHostedController({
+      open: true,
+      onOpenChange,
+      onProjectAdded: vi.fn()
+    })
+    // Why: folder/non-git outcomes navigate (folder-workspace activation or
+    // the confirm-non-git-folder store modal); leaving the composer open
+    // would hide that navigation behind a stale project selection.
+    closeForFolderHandoff()
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+    expect(mocks.state.closeModal).toHaveBeenCalledTimes(1)
+  })
+
+  it('finishProjectAdd closes the hosted dialog and hands the repo to the host', async () => {
+    const order: string[] = []
+    const onOpenChange = vi.fn(() => order.push('close'))
+    const onProjectAdded = vi.fn(() => {
+      order.push('added')
+    })
+    const { finishProjectAdd } = useAddRepoHostedController({
+      open: true,
+      onOpenChange,
+      onProjectAdded
+    })
+    await finishProjectAdd?.('repo-1')
+    expect(mocks.markOnboardingProjectAdded).toHaveBeenCalledWith('addedRepo')
+    expect(onProjectAdded).toHaveBeenCalledWith('repo-1')
+    // Why: closing before selection keeps the composer visible under the
+    // dialog's close animation while the new project lands in the picker.
+    expect(order).toEqual(['close', 'added'])
+  })
+
+  it('SSH settings navigation closes both hosted dialog and composer modal', () => {
+    const onOpenChange = vi.fn()
+    const { handleOpenSshSettings } = useAddRepoHostedController({
+      open: true,
+      onOpenChange,
+      onProjectAdded: vi.fn()
+    })
+    handleOpenSshSettings()
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+    expect(mocks.state.closeModal).toHaveBeenCalledTimes(1)
+    expect(mocks.state.openSettingsTarget).toHaveBeenCalledWith({
+      pane: 'ssh',
+      repoId: null,
+      sectionId: 'ssh'
+    })
+    expect(mocks.state.openSettingsPage).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/sidebar/use-add-repo-hosted-controller.ts
+++ b/src/renderer/src/components/sidebar/use-add-repo-hosted-controller.ts
@@ -1,0 +1,68 @@
+import { useCallback, useMemo } from 'react'
+import { useAppStore } from '@/store'
+import { markOnboardingProjectAdded } from '@/lib/onboarding-project-checklist'
+
+/** Contract a host surface (e.g. the workspace composer modal) passes to
+ *  AddRepoDialog to nest it as a layered dialog instead of the store modal. */
+export type AddRepoDialogHostedController = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Called after a Git project is added; the host selects the new project
+   *  instead of running the default-checkout navigation handoff. */
+  onProjectAdded: (repoId: string) => void | Promise<void>
+}
+
+export function useAddRepoHostedController(hosted: AddRepoDialogHostedController | undefined): {
+  closeModal: () => void
+  /** Close for folder/non-git outcomes, which end in folder-workspace
+   *  activation (or the confirm-non-git-folder store modal) instead of a
+   *  composer selection. Hosted mode must close the composer too — leaving it
+   *  open would hide the navigation behind a stale project selection. */
+  closeForFolderHandoff: () => void
+  finishProjectAdd: ((repoId: string) => Promise<void>) | undefined
+  handleOpenSshSettings: () => void
+} {
+  const storeCloseModal = useAppStore((s) => s.closeModal)
+  const openSettingsPage = useAppStore((s) => s.openSettingsPage)
+  const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
+  const hostedOnOpenChange = hosted?.onOpenChange
+  const hostedOnProjectAdded = hosted?.onProjectAdded
+  // Why: hosted mode (nested inside the workspace composer) must close only
+  // this dialog, never the composer modal that lives in the activeModal slot.
+  const closeModal = useMemo(
+    () => (hostedOnOpenChange ? () => hostedOnOpenChange(false) : storeCloseModal),
+    [hostedOnOpenChange, storeCloseModal]
+  )
+  const finishProjectAdd = useMemo(
+    () =>
+      hostedOnOpenChange && hostedOnProjectAdded
+        ? async (repoId: string): Promise<void> => {
+            await markOnboardingProjectAdded('addedRepo')
+            hostedOnOpenChange(false)
+            await hostedOnProjectAdded(repoId)
+          }
+        : undefined,
+    [hostedOnOpenChange, hostedOnProjectAdded]
+  )
+  const closeForFolderHandoff = useMemo(
+    () =>
+      hostedOnOpenChange
+        ? () => {
+            hostedOnOpenChange(false)
+            storeCloseModal()
+          }
+        : storeCloseModal,
+    [hostedOnOpenChange, storeCloseModal]
+  )
+  const handleOpenSshSettings = useCallback((): void => {
+    closeModal()
+    // Why: Settings is a full page; in hosted mode the composer modal in the
+    // activeModal slot would otherwise stay open on top of it.
+    if (hostedOnOpenChange) {
+      storeCloseModal()
+    }
+    openSettingsTarget({ pane: 'ssh', repoId: null, sectionId: 'ssh' })
+    openSettingsPage()
+  }, [closeModal, hostedOnOpenChange, openSettingsPage, openSettingsTarget, storeCloseModal])
+  return { closeModal, closeForFolderHandoff, finishProjectAdd, handleOpenSshSettings }
+}

--- a/src/renderer/src/components/sidebar/use-add-repo-hosted-controller.ts
+++ b/src/renderer/src/components/sidebar/use-add-repo-hosted-controller.ts
@@ -10,6 +10,10 @@ export type AddRepoDialogHostedController = {
   /** Called after a Git project is added; the host selects the new project
    *  instead of running the default-checkout navigation handoff. */
   onProjectAdded: (repoId: string) => void | Promise<void>
+  /** Radix close-autofocus hook for the nested dialog. Lets the host redirect
+   *  focus (e.g. to the composer's name field) instead of Radix restoring it
+   *  to the already-unmounted combobox row that opened the dialog. */
+  onCloseAutoFocus?: (event: Event) => void
 }
 
 export function useAddRepoHostedController(hosted: AddRepoDialogHostedController | undefined): {

--- a/src/renderer/src/components/sidebar/use-complete-git-repo-add.ts
+++ b/src/renderer/src/components/sidebar/use-complete-git-repo-add.ts
@@ -11,11 +11,16 @@ import { finishProjectAddWithDefaultCheckout } from './project-added-default-che
 type CompleteGitRepoAddOptions = {
   closeModal: () => void
   setHideDefaultBranchWorkspace: (hide: boolean) => void
+  /** Why: the nested Add Project flow (hosted inside the workspace composer)
+   *  keeps the composer open and selects the new project instead of running
+   *  the default-checkout navigation handoff. Telemetry above still applies. */
+  finishProjectAdd?: (repoId: string, source: AddRepoExistingWorkspaceSource) => Promise<void>
 }
 
 export function useCompleteGitRepoAdd({
   closeModal,
-  setHideDefaultBranchWorkspace
+  setHideDefaultBranchWorkspace,
+  finishProjectAdd
 }: CompleteGitRepoAddOptions): (
   repoId: string,
   source: AddRepoExistingWorkspaceSource
@@ -43,6 +48,10 @@ export function useCompleteGitRepoAdd({
         detectedTelemetryTrackedRef.current.add(repoId)
         track('add_repo_existing_workspaces_detected', existingWorkspaceTelemetry)
       }
+      if (finishProjectAdd) {
+        await finishProjectAdd(repoId, source)
+        return
+      }
       await finishProjectAddWithDefaultCheckout({
         repoId,
         source,
@@ -50,6 +59,6 @@ export function useCompleteGitRepoAdd({
         setHideDefaultBranchWorkspace
       })
     },
-    [closeModal, setHideDefaultBranchWorkspace]
+    [closeModal, finishProjectAdd, setHideDefaultBranchWorkspace]
   )
 }

--- a/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.test.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.test.ts
@@ -78,6 +78,7 @@ function useTestAddRepoNestedImportFlow(
     nestedGroupName: 'platform',
     nestedImportScanId: 'scan-1',
     activeRuntimeEnvironmentId: null,
+    closeModal: mocks.state.closeModal,
     fetchWorktrees: vi.fn(),
     importNestedRepos: vi.fn<() => Promise<ProjectGroupImportResult | null>>(),
     getNestedRepoRuntimeKind: vi.fn(() => 'local' as const),

--- a/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.ts
@@ -22,6 +22,7 @@ export function useAddRepoNestedImportFlow({
   nestedGroupName,
   nestedImportScanId,
   activeRuntimeEnvironmentId,
+  closeModal,
   fetchWorktrees,
   importNestedRepos,
   getNestedRepoRuntimeKind,
@@ -36,6 +37,9 @@ export function useAddRepoNestedImportFlow({
   nestedGroupName: string
   nestedImportScanId: string | null
   activeRuntimeEnvironmentId: string | null | undefined
+  /** Why: hosted (composer-nested) mode routes this to closing only the
+   *  nested dialog; store-modal mode routes it to the activeModal slot. */
+  closeModal: () => void
   fetchWorktrees: (repoId: string, options?: { requireAuthoritative?: boolean }) => Promise<unknown>
   importNestedRepos: (args: {
     parentPath: string
@@ -260,7 +264,10 @@ export function useAddRepoNestedImportFlow({
     try {
       const state = useAppStore.getState()
       if (nestedConnectionId) {
-        state.closeModal()
+        // Why: the non-git confirm dialog is a store-modal handoff that ends
+        // in folder-workspace activation; close this add flow (nested dialog
+        // or store modal) before handing over.
+        closeModal()
         state.openModal('confirm-non-git-folder', {
           folderPath: path,
           connectionId: nestedConnectionId
@@ -274,7 +281,7 @@ export function useAddRepoNestedImportFlow({
         return
       }
       if (repo) {
-        useAppStore.getState().closeModal()
+        closeModal()
       }
     } catch (err) {
       if (gen === nestedImportGenRef.current) {
@@ -287,6 +294,7 @@ export function useAddRepoNestedImportFlow({
     }
   }, [
     activeRuntimeEnvironmentId,
+    closeModal,
     getNestedRepoRuntimeKind,
     nestedAttemptId,
     nestedConnectionId,

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -391,6 +391,9 @@ export type UseComposerStateResult = {
   submitQuick: (agent: TuiAgent | null) => Promise<void>
   /** Invoked by the Enter handler to re-check whether submission should fire. */
   createDisabled: boolean
+  /** Selects the repo a nested Add Project flow just added, clearing any
+   *  folder-group target so the composer lands on the new project. */
+  selectAddedProjectRepo: (repoId: string) => void
 }
 
 export type InitialWorkspaceRunSeedInput = {
@@ -2819,6 +2822,19 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       workspaceHostScope
     ]
   )
+  const selectAddedProjectRepo = useCallback(
+    (nextRepoId: string): void => {
+      // Why: the nested Add Project flow hands back a repo id. Selecting it
+      // must also clear a folder-group target, whose onRepoChange handler
+      // only accepts repos inside the selected group.
+      initialProjectGroupAppliedRef.current = true
+      setSelectedProjectGroupId(null)
+      setProjectError(null)
+      handleRepoChange(nextRepoId)
+    },
+    [handleRepoChange]
+  )
+
   const showProjectRequiredError = useCallback((): void => {
     setProjectError('Choose or add a project before creating a workspace.')
     requestAnimationFrame(() => {
@@ -4440,6 +4456,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     nameInputRef,
     submit,
     submitQuick,
-    createDisabled
+    createDisabled,
+    selectAddedProjectRepo
   }
 }


### PR DESCRIPTION
## Problem

From the **Create worktree** dialog, clicking **Add project** (header button or the "Add a new project" row in the project combobox) swapped the store's single `activeModal` slot to `add-repo`. That abruptly unmounted the Create worktree dialog — no close animation, and any typed workspace name/prompt was lost. After the add finished, the app navigated away to the new project's default checkout instead of returning to worktree creation.

## Fix

`AddRepoDialog` gains an optional **hosted mode** (`hosted: { open, onOpenChange, onProjectAdded }`). The composer modal now lazy-mounts it as a nested dialog **layered over** the still-open Create worktree dialog:

- The composer stays open (and keeps its state) the whole time.
- On a successful **Git** project add, only the nested dialog closes and the new project is **selected in the composer** (`selectAddedProjectRepo`), with focus moved to the name field — so you can immediately create the worktree.
- **Folder/non-git** outcomes still navigate (folder-workspace activation or the `confirm-non-git-folder` handoff), so those deliberately close both dialogs via `closeForFolderHandoff` instead of leaving the composer open over a background navigation.
- Escape / outside-click close only the topmost (nested) dialog; the composer's capture-phase Escape/⌘-Enter handler stands down while a nested dialog is open.
- The classic sidebar **Add Project** path (store modal) is unchanged.

## Flow

### 1. Create worktree dialog (typed name preserved throughout)
![01](6ccab4a70025ed5fd9d8c292157ff32c88c0fd43/01-create-worktree-dialog.png?raw=true)

### 2. Project combobox → "Add a new project"
![02](6ccab4a70025ed5fd9d8c292157ff32c88c0fd43/02-project-combobox-open.png?raw=true)

### 3. Add-project dialog layers over the composer — no abrupt close
![03](6ccab4a70025ed5fd9d8c292157ff32c88c0fd43/03-add-project-layered-over-composer.png?raw=true)

### 4. Create a new project (nested step)
![04](6ccab4a70025ed5fd9d8c292157ff32c88c0fd43/04-create-new-project-step.png?raw=true)

### 5. Back in the composer: new project selected, ready to create
![05](6ccab4a70025ed5fd9d8c292157ff32c88c0fd43/05-composer-back-with-new-project-selected.png?raw=true)

### 6. Escape closes only the nested dialog (composer + typed name intact)
![06](6ccab4a70025ed5fd9d8c292157ff32c88c0fd43/06-escape-closes-only-nested.png?raw=true)

### 7. Sidebar Add Project path unchanged
![07](6ccab4a70025ed5fd9d8c292157ff32c88c0fd43/07-sidebar-add-project-unchanged.png?raw=true)

### 8. End-to-end after review fixes: name preserved + new project selected
![08](6ccab4a70025ed5fd9d8c292157ff32c88c0fd43/08-post-review-fix-name-preserved-project-selected.png?raw=true)

### 9. Focus lands on the "Name or 'Create From'" field right after the add (follow-up commit)
![09](https://github.com/stablyai/orca/blob/b41151e94ddc67544cccf6bbcb0b90b3922f6f72/09-autofocus-name-field-after-add.png?raw=true)

## Verification

- Live-driven in the dev app via CDP: composer stays open behind the nested dialog (`activeModal` stays `new-workspace-composer`, 2 stacked `DialogContent`s), create-project completes → nested closes, combobox shows the new repo, typed name preserved; Escape from a nested input closes only the nested dialog; reopening lands on a fresh "Add a project" step (state reset works with the always-mounted hosted instance).
- Review loop with sub-agents until clean: round 1 found 2 real bugs (non-git outcomes clobbered the composer via the store-modal handoff; folder adds left the composer open on a stale selection while navigating behind it) — both fixed via `closeForFolderHandoff`; round 2 verified the fixes; round 3 came back CLEAN.
- Final perf review (per `.claude/skills/perf`): CLEAN — no keystroke-path re-renders (memo holds; controller identity stable per keystroke), no entry-bundle growth (both lazy imports share one chunk), no listener/timer leaks, no new polling/IPC.
- `pnpm typecheck` clean, oxlint clean (no max-lines bypass — hosted glue extracted to `use-add-repo-hosted-controller.ts`), 1,879 renderer tests pass incl. new unit tests for the hosted controller.

- Follow-up commit d9db5e6d29: nested dialog's `onCloseAutoFocus` now redirects focus to the composer's name field after a project add (live-verified: `document.activeElement` is the name input).