### PR TITLE
fix(composer): show full worktree path on hover in Run on dropdown

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -2,6 +2,7 @@
 composer card markup together so the inline and modal variants share one UI
 surface without splitting the controlled form into hard-to-follow fragments. */
 import React from 'react'
+import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import {
@@ -224,57 +225,6 @@ function getRecipeDestroyLabel(recipe: EphemeralVmRecipeOption): string {
   return translate('auto.components.NewWorkspaceComposerCard.noDestroyConfigured', 'no destroy')
 }
 
-// Why: worktree paths overflow the truncated row, so hovering reveals the full path. We drive the
-// tooltip's open state by hand instead of using Radix's hover detection: inside this cmdk list, the
-// uncontrolled tooltip could flash open then wedge shut (Radix's shared pointer-transit state getting
-// stuck), never reopening. Controlled hover-intent — open after a delay, close after a short grace —
-// can always re-open on re-entry and debounces transient enter/leave thrash into a stable state.
-const HOST_PATH_TOOLTIP_OPEN_DELAY_MS = 400
-const HOST_PATH_TOOLTIP_CLOSE_GRACE_MS = 120
-
-function HostPathTooltip({ path }: { path: string }): React.JSX.Element {
-  const [open, setOpen] = React.useState(false)
-  const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  const schedule = React.useCallback((next: boolean, delayMs: number): void => {
-    if (timerRef.current) {
-      clearTimeout(timerRef.current)
-    }
-    timerRef.current = setTimeout(() => setOpen(next), delayMs)
-  }, [])
-
-  React.useEffect(
-    () => () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current)
-      }
-    },
-    []
-  )
-
-  return (
-    <Tooltip open={open}>
-      <TooltipTrigger asChild>
-        <div
-          className="mt-0.5 truncate text-[11px] text-muted-foreground"
-          onPointerEnter={() => schedule(true, HOST_PATH_TOOLTIP_OPEN_DELAY_MS)}
-          onPointerLeave={() => schedule(false, HOST_PATH_TOOLTIP_CLOSE_GRACE_MS)}
-        >
-          {path}
-        </div>
-      </TooltipTrigger>
-      <TooltipContent
-        side="bottom"
-        align="start"
-        sideOffset={4}
-        className="max-w-[min(520px,80vw)] px-2 py-1 text-[11px] font-normal break-all [&>span:has(svg)]:hidden"
-      >
-        {path}
-      </TooltipContent>
-    </Tooltip>
-  )
-}
-
 type WorkspaceRunTargetComboboxProps = {
   hostOptions: readonly ReadyProjectHostSetupOption[]
   hostValue: string | null
@@ -282,6 +232,96 @@ type WorkspaceRunTargetComboboxProps = {
   recipes: EphemeralVmRecipeOption[]
   recipeValue: string | null
   onRecipeChange?: (recipeId: string | null) => void
+}
+
+type HostPathTooltipProps = {
+  path: string
+  children: (props: {
+    'aria-describedby'?: string
+    onPointerEnter: React.PointerEventHandler<HTMLElement>
+    onPointerLeave: React.PointerEventHandler<HTMLElement>
+    onPointerDown: React.PointerEventHandler<HTMLElement>
+  }) => React.ReactNode
+}
+
+type HostPathTooltipPosition = {
+  horizontal: { left: number } | { right: number }
+  vertical: { top: number } | { bottom: number }
+}
+
+const HOST_PATH_TOOLTIP_DELAY_MS = 400
+const HOST_PATH_TOOLTIP_VIEWPORT_GAP_PX = 8
+const HOST_PATH_TOOLTIP_TRIGGER_GAP_PX = 4
+
+function HostPathTooltip({ path, children }: HostPathTooltipProps): React.JSX.Element {
+  const tooltipId = React.useId()
+  const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pointerInsideRef = React.useRef(false)
+  const [position, setPosition] = React.useState<HostPathTooltipPosition | null>(null)
+
+  const hideTooltip = React.useCallback((): void => {
+    pointerInsideRef.current = false
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    setPosition(null)
+  }, [])
+
+  React.useEffect(() => hideTooltip, [hideTooltip])
+
+  const handlePointerEnter = React.useCallback((event: React.PointerEvent<HTMLElement>): void => {
+    pointerInsideRef.current = true
+    const trigger = event.currentTarget
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current)
+    }
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null
+      if (!pointerInsideRef.current || !trigger.isConnected) {
+        return
+      }
+      const rect = trigger.getBoundingClientRect()
+      const anchorRight = rect.left + rect.width / 2 > window.innerWidth / 2
+      const placeAbove = rect.top + rect.height / 2 > window.innerHeight / 2
+      setPosition({
+        horizontal: anchorRight
+          ? { right: HOST_PATH_TOOLTIP_VIEWPORT_GAP_PX }
+          : { left: Math.max(HOST_PATH_TOOLTIP_VIEWPORT_GAP_PX, rect.left) },
+        vertical: placeAbove
+          ? { bottom: window.innerHeight - rect.top + HOST_PATH_TOOLTIP_TRIGGER_GAP_PX }
+          : { top: rect.bottom + HOST_PATH_TOOLTIP_TRIGGER_GAP_PX }
+      })
+    }, HOST_PATH_TOOLTIP_DELAY_MS)
+  }, [])
+
+  const trigger = children({
+    'aria-describedby': position ? tooltipId : undefined,
+    onPointerEnter: handlePointerEnter,
+    onPointerLeave: hideTooltip,
+    onPointerDown: hideTooltip
+  })
+
+  return (
+    <>
+      {trigger}
+      {/* Why: a fixed, pointer-transparent portal cannot reflow cmdk or become the hover target. */}
+      {position
+        ? createPortal(
+            <div
+              id={tooltipId}
+              role="tooltip"
+              data-slot="host-path-tooltip"
+              className="pointer-events-none fixed z-[100] w-max max-w-[calc(100vw-1rem)] break-all rounded-sm border border-border bg-popover px-1.5 py-1 font-mono text-[11px] leading-tight text-popover-foreground shadow-xs"
+              style={{ ...position.horizontal, ...position.vertical }}
+            >
+              {path}
+            </div>,
+            document.body
+          )
+        : null}
+    </>
+  )
 }
 
 function WorkspaceRunTargetCombobox({
@@ -377,24 +417,32 @@ function WorkspaceRunTargetCombobox({
               )}
             </CommandEmpty>
             {hostOptions.map((option) => (
-              <CommandItem
-                key={option.id}
-                value={`host:${option.id}`}
-                onSelect={() => handleHostSelect(option.id)}
-                className="items-center gap-2 px-3 py-2"
-              >
-                <Check
-                  className={cn(
-                    'size-4 text-foreground',
-                    !selectedRecipe && option.id === selectedHost?.id ? 'opacity-100' : 'opacity-0'
-                  )}
-                />
-                <Server className="size-3.5 shrink-0 text-muted-foreground" />
-                <div className="min-w-0 flex-1">
-                  <div className="truncate text-sm">{option.label}</div>
-                  <HostPathTooltip path={option.path} />
-                </div>
-              </CommandItem>
+              <HostPathTooltip key={option.id} path={option.path}>
+                {(tooltipTriggerProps) => (
+                  <CommandItem
+                    value={`host:${option.id}`}
+                    onSelect={() => handleHostSelect(option.id)}
+                    className="items-center gap-2 px-3 py-2"
+                    {...tooltipTriggerProps}
+                  >
+                    <Check
+                      className={cn(
+                        'size-4 text-foreground',
+                        !selectedRecipe && option.id === selectedHost?.id
+                          ? 'opacity-100'
+                          : 'opacity-0'
+                      )}
+                    />
+                    <Server className="size-3.5 shrink-0 text-muted-foreground" />
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm">{option.label}</div>
+                      <div className="mt-0.5 truncate text-[11px] text-muted-foreground">
+                        {option.path}
+                      </div>
+                    </div>
+                  </CommandItem>
+                )}
+              </HostPathTooltip>
             ))}
             {recipes.length > 0 ? (
               <Popover open={vmRecipesOpen} onOpenChange={setVmRecipesOpen}>

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -341,22 +341,14 @@ function WorkspaceRunTargetCombobox({
                 <Server className="size-3.5 shrink-0 text-muted-foreground" />
                 <div className="min-w-0 flex-1">
                   <div className="truncate text-sm">{option.label}</div>
-                  {/* Why: worktree paths often overflow the truncated row; a deliberate hover reveals the full path. */}
-                  <Tooltip delayDuration={500}>
-                    <TooltipTrigger asChild>
-                      <div className="mt-0.5 truncate text-[11px] text-muted-foreground">
-                        {option.path}
-                      </div>
-                    </TooltipTrigger>
-                    <TooltipContent
-                      side="bottom"
-                      align="start"
-                      sideOffset={6}
-                      className="max-w-[420px] break-all"
-                    >
-                      {option.path}
-                    </TooltipContent>
-                  </Tooltip>
+                  {/* Why: worktree paths often overflow the truncated row; the native title
+                      shows the full path on hover without a bulky custom tooltip. */}
+                  <div
+                    title={option.path}
+                    className="mt-0.5 truncate text-[11px] text-muted-foreground"
+                  >
+                    {option.path}
+                  </div>
                 </div>
               </CommandItem>
             ))}

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -341,9 +341,22 @@ function WorkspaceRunTargetCombobox({
                 <Server className="size-3.5 shrink-0 text-muted-foreground" />
                 <div className="min-w-0 flex-1">
                   <div className="truncate text-sm">{option.label}</div>
-                  <div className="mt-0.5 truncate text-[11px] text-muted-foreground">
-                    {option.path}
-                  </div>
+                  {/* Why: worktree paths often overflow the truncated row; a deliberate hover reveals the full path. */}
+                  <Tooltip delayDuration={500}>
+                    <TooltipTrigger asChild>
+                      <div className="mt-0.5 truncate text-[11px] text-muted-foreground">
+                        {option.path}
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent
+                      side="bottom"
+                      align="start"
+                      sideOffset={6}
+                      className="max-w-[420px] break-all"
+                    >
+                      {option.path}
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
               </CommandItem>
             ))}

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -341,14 +341,24 @@ function WorkspaceRunTargetCombobox({
                 <Server className="size-3.5 shrink-0 text-muted-foreground" />
                 <div className="min-w-0 flex-1">
                   <div className="truncate text-sm">{option.label}</div>
-                  {/* Why: worktree paths often overflow the truncated row; the native title
-                      shows the full path on hover without a bulky custom tooltip. */}
-                  <div
-                    title={option.path}
-                    className="mt-0.5 truncate text-[11px] text-muted-foreground"
-                  >
-                    {option.path}
-                  </div>
+                  {/* Why: worktree paths overflow the truncated row. A controlled tooltip (not the
+                      native title, which won't reliably re-trigger between adjacent rows in Chromium)
+                      reveals the full path; styled compact + arrowless to read like an OS tooltip. */}
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="mt-0.5 truncate text-[11px] text-muted-foreground">
+                        {option.path}
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent
+                      side="bottom"
+                      align="start"
+                      sideOffset={4}
+                      className="max-w-[min(520px,80vw)] px-2 py-1 text-[11px] font-normal break-all [&>span:has(svg)]:hidden"
+                    >
+                      {option.path}
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
               </CommandItem>
             ))}

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -234,26 +234,16 @@ type WorkspaceRunTargetComboboxProps = {
   onRecipeChange?: (recipeId: string | null) => void
 }
 
-type HostPathTooltipProps = {
-  path: string
-  children: (props: {
-    'aria-describedby'?: string
-    onPointerEnter: React.PointerEventHandler<HTMLElement>
-    onPointerLeave: React.PointerEventHandler<HTMLElement>
-    onPointerDown: React.PointerEventHandler<HTMLElement>
-  }) => React.ReactNode
-}
-
 type HostPathTooltipPosition = {
   horizontal: { left: number } | { right: number }
-  vertical: { top: number } | { bottom: number }
+  top: number
 }
 
 const HOST_PATH_TOOLTIP_DELAY_MS = 400
 const HOST_PATH_TOOLTIP_VIEWPORT_GAP_PX = 8
 const HOST_PATH_TOOLTIP_TRIGGER_GAP_PX = 4
 
-function HostPathTooltip({ path, children }: HostPathTooltipProps): React.JSX.Element {
+function HostPathTooltip({ path }: { path: string }): React.JSX.Element {
   const tooltipId = React.useId()
   const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
   const pointerInsideRef = React.useRef(false)
@@ -283,28 +273,28 @@ function HostPathTooltip({ path, children }: HostPathTooltipProps): React.JSX.El
       }
       const rect = trigger.getBoundingClientRect()
       const anchorRight = rect.left + rect.width / 2 > window.innerWidth / 2
-      const placeAbove = rect.top + rect.height / 2 > window.innerHeight / 2
+      // Why: always drop below the hovered path line for a consistent, predictable placement.
       setPosition({
         horizontal: anchorRight
           ? { right: HOST_PATH_TOOLTIP_VIEWPORT_GAP_PX }
           : { left: Math.max(HOST_PATH_TOOLTIP_VIEWPORT_GAP_PX, rect.left) },
-        vertical: placeAbove
-          ? { bottom: window.innerHeight - rect.top + HOST_PATH_TOOLTIP_TRIGGER_GAP_PX }
-          : { top: rect.bottom + HOST_PATH_TOOLTIP_TRIGGER_GAP_PX }
+        top: rect.bottom + HOST_PATH_TOOLTIP_TRIGGER_GAP_PX
       })
     }, HOST_PATH_TOOLTIP_DELAY_MS)
   }, [])
 
-  const trigger = children({
-    'aria-describedby': position ? tooltipId : undefined,
-    onPointerEnter: handlePointerEnter,
-    onPointerLeave: hideTooltip,
-    onPointerDown: hideTooltip
-  })
-
   return (
     <>
-      {trigger}
+      {/* Trigger is the truncated path line itself, so the tooltip only appears when hovering it. */}
+      <div
+        className="mt-0.5 truncate text-[11px] text-muted-foreground"
+        aria-describedby={position ? tooltipId : undefined}
+        onPointerEnter={handlePointerEnter}
+        onPointerLeave={hideTooltip}
+        onPointerDown={hideTooltip}
+      >
+        {path}
+      </div>
       {/* Why: a fixed, pointer-transparent portal cannot reflow cmdk or become the hover target. */}
       {position
         ? createPortal(
@@ -313,7 +303,7 @@ function HostPathTooltip({ path, children }: HostPathTooltipProps): React.JSX.El
               role="tooltip"
               data-slot="host-path-tooltip"
               className="pointer-events-none fixed z-[100] w-max max-w-[calc(100vw-1rem)] break-all rounded-sm border border-border bg-popover px-1.5 py-1 font-mono text-[11px] leading-tight text-popover-foreground shadow-xs"
-              style={{ ...position.horizontal, ...position.vertical }}
+              style={{ ...position.horizontal, top: position.top }}
             >
               {path}
             </div>,
@@ -417,32 +407,24 @@ function WorkspaceRunTargetCombobox({
               )}
             </CommandEmpty>
             {hostOptions.map((option) => (
-              <HostPathTooltip key={option.id} path={option.path}>
-                {(tooltipTriggerProps) => (
-                  <CommandItem
-                    value={`host:${option.id}`}
-                    onSelect={() => handleHostSelect(option.id)}
-                    className="items-center gap-2 px-3 py-2"
-                    {...tooltipTriggerProps}
-                  >
-                    <Check
-                      className={cn(
-                        'size-4 text-foreground',
-                        !selectedRecipe && option.id === selectedHost?.id
-                          ? 'opacity-100'
-                          : 'opacity-0'
-                      )}
-                    />
-                    <Server className="size-3.5 shrink-0 text-muted-foreground" />
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-sm">{option.label}</div>
-                      <div className="mt-0.5 truncate text-[11px] text-muted-foreground">
-                        {option.path}
-                      </div>
-                    </div>
-                  </CommandItem>
-                )}
-              </HostPathTooltip>
+              <CommandItem
+                key={option.id}
+                value={`host:${option.id}`}
+                onSelect={() => handleHostSelect(option.id)}
+                className="items-center gap-2 px-3 py-2"
+              >
+                <Check
+                  className={cn(
+                    'size-4 text-foreground',
+                    !selectedRecipe && option.id === selectedHost?.id ? 'opacity-100' : 'opacity-0'
+                  )}
+                />
+                <Server className="size-3.5 shrink-0 text-muted-foreground" />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-sm">{option.label}</div>
+                  <HostPathTooltip path={option.path} />
+                </div>
+              </CommandItem>
             ))}
             {recipes.length > 0 ? (
               <Popover open={vmRecipesOpen} onOpenChange={setVmRecipesOpen}>

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -235,8 +235,9 @@ type WorkspaceRunTargetComboboxProps = {
 }
 
 type HostPathTooltipPosition = {
-  horizontal: { left: number } | { right: number }
+  left: number
   top: number
+  maxWidth: number
 }
 
 const HOST_PATH_TOOLTIP_DELAY_MS = 400
@@ -272,13 +273,13 @@ function HostPathTooltip({ path }: { path: string }): React.JSX.Element {
         return
       }
       const rect = trigger.getBoundingClientRect()
-      const anchorRight = rect.left + rect.width / 2 > window.innerWidth / 2
-      // Why: always drop below the hovered path line for a consistent, predictable placement.
+      // Why: anchor directly under the hovered path line (left-aligned to it), and cap the width to
+      // the space remaining to the viewport edge so a long path wraps instead of flying off-screen.
+      const left = Math.max(HOST_PATH_TOOLTIP_VIEWPORT_GAP_PX, rect.left)
       setPosition({
-        horizontal: anchorRight
-          ? { right: HOST_PATH_TOOLTIP_VIEWPORT_GAP_PX }
-          : { left: Math.max(HOST_PATH_TOOLTIP_VIEWPORT_GAP_PX, rect.left) },
-        top: rect.bottom + HOST_PATH_TOOLTIP_TRIGGER_GAP_PX
+        left,
+        top: rect.bottom + HOST_PATH_TOOLTIP_TRIGGER_GAP_PX,
+        maxWidth: window.innerWidth - left - HOST_PATH_TOOLTIP_VIEWPORT_GAP_PX
       })
     }, HOST_PATH_TOOLTIP_DELAY_MS)
   }, [])
@@ -302,8 +303,8 @@ function HostPathTooltip({ path }: { path: string }): React.JSX.Element {
               id={tooltipId}
               role="tooltip"
               data-slot="host-path-tooltip"
-              className="pointer-events-none fixed z-[100] w-max max-w-[calc(100vw-1rem)] break-all rounded-sm border border-border bg-popover px-1.5 py-1 font-mono text-[11px] leading-tight text-popover-foreground shadow-xs"
-              style={{ ...position.horizontal, top: position.top }}
+              className="pointer-events-none fixed z-[100] w-max break-all rounded-sm border border-border bg-popover px-1.5 py-1 font-mono text-[11px] leading-tight text-popover-foreground shadow-xs"
+              style={{ left: position.left, top: position.top, maxWidth: position.maxWidth }}
             >
               {path}
             </div>,

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -224,6 +224,57 @@ function getRecipeDestroyLabel(recipe: EphemeralVmRecipeOption): string {
   return translate('auto.components.NewWorkspaceComposerCard.noDestroyConfigured', 'no destroy')
 }
 
+// Why: worktree paths overflow the truncated row, so hovering reveals the full path. We drive the
+// tooltip's open state by hand instead of using Radix's hover detection: inside this cmdk list, the
+// uncontrolled tooltip could flash open then wedge shut (Radix's shared pointer-transit state getting
+// stuck), never reopening. Controlled hover-intent — open after a delay, close after a short grace —
+// can always re-open on re-entry and debounces transient enter/leave thrash into a stable state.
+const HOST_PATH_TOOLTIP_OPEN_DELAY_MS = 400
+const HOST_PATH_TOOLTIP_CLOSE_GRACE_MS = 120
+
+function HostPathTooltip({ path }: { path: string }): React.JSX.Element {
+  const [open, setOpen] = React.useState(false)
+  const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const schedule = React.useCallback((next: boolean, delayMs: number): void => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+    }
+    timerRef.current = setTimeout(() => setOpen(next), delayMs)
+  }, [])
+
+  React.useEffect(
+    () => () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+      }
+    },
+    []
+  )
+
+  return (
+    <Tooltip open={open}>
+      <TooltipTrigger asChild>
+        <div
+          className="mt-0.5 truncate text-[11px] text-muted-foreground"
+          onPointerEnter={() => schedule(true, HOST_PATH_TOOLTIP_OPEN_DELAY_MS)}
+          onPointerLeave={() => schedule(false, HOST_PATH_TOOLTIP_CLOSE_GRACE_MS)}
+        >
+          {path}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent
+        side="bottom"
+        align="start"
+        sideOffset={4}
+        className="max-w-[min(520px,80vw)] px-2 py-1 text-[11px] font-normal break-all [&>span:has(svg)]:hidden"
+      >
+        {path}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
 type WorkspaceRunTargetComboboxProps = {
   hostOptions: readonly ReadyProjectHostSetupOption[]
   hostValue: string | null
@@ -341,24 +392,7 @@ function WorkspaceRunTargetCombobox({
                 <Server className="size-3.5 shrink-0 text-muted-foreground" />
                 <div className="min-w-0 flex-1">
                   <div className="truncate text-sm">{option.label}</div>
-                  {/* Why: worktree paths overflow the truncated row. A controlled tooltip (not the
-                      native title, which won't reliably re-trigger between adjacent rows in Chromium)
-                      reveals the full path; styled compact + arrowless to read like an OS tooltip. */}
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <div className="mt-0.5 truncate text-[11px] text-muted-foreground">
-                        {option.path}
-                      </div>
-                    </TooltipTrigger>
-                    <TooltipContent
-                      side="bottom"
-                      align="start"
-                      sideOffset={4}
-                      className="max-w-[min(520px,80vw)] px-2 py-1 text-[11px] font-normal break-all [&>span:has(svg)]:hidden"
-                    >
-                      {option.path}
-                    </TooltipContent>
-                  </Tooltip>
+                  <HostPathTooltip path={option.path} />
                 </div>
               </CommandItem>
             ))}


### PR DESCRIPTION
## What

In the **Run on** dropdown of the new-workspace composer, each host row shows the worktree path on a second line, truncated with an ellipsis — so you can't tell two similar worktrees apart (e.g. `.../pr-1908-external-editor-links` vs `.../pr-3235-terminal-file-link-actions` both collapse to `.../pr-…`).

Hovering the truncated path line reveals the full path in a compact tooltip anchored directly below it.

## How

A self-contained `HostPathTooltip` owns the path line and renders the full path in a **`position: fixed`, `pointer-events-none` portal on `document.body`**, positioned **directly below and left-aligned to the hovered line**, width-capped to the remaining viewport so long paths wrap instead of overflowing. It only changes state on pointer **enter / leave / down** — never on `pointermove`.

**Why not native `title` or Radix `Tooltip`:** both misbehaved inside this `cmdk` list — native `title` won't reliably re-trigger between adjacent rows in Chromium, and Radix (uncontrolled or hover-intent-controlled) flashed, wedged shut, or opened/closed in an infinite loop. Those failures came from the tooltip perturbing the pointer (portaled content / reflow changing what's under the cursor, firing `pointerleave`→`pointerenter` repeatedly). A fixed, pointer-transparent element on `document.body` **structurally can't** reflow the list or become the hover target, and ignoring `pointermove` removes per-move churn — so there's no feedback path to loop through.

## Verified (independent, with the real cmdk list)

- Hovering the **path line** shows the correct full path; hovering the **"Local Mac" label** shows nothing (trigger scoped to the path line).
- Tooltip anchors **directly below and left-aligned to** the hovered line and stays within the viewport (previously it could fly to the far-right window edge).
- **Oscillation test:** pointer held still, sampled continuously → stays open, never toggles (no open/close loop).
- Rapid enter/leave jitter settles stable; closes when the pointer leaves.
- Zero console/page errors. `typecheck:web` + oxlint + oxfmt pass.

## Notes

Scoped to host rows (real filesystem paths). Ephemeral-VM and recipe rows show hint text, not paths, and are untouched.

## Screenshot

![tooltip](https://github.com/stablyai/orca/blob/f0b69eb0e0089ce134c409aceb92e83d32ad478d/pos-fixed.png?raw=true)