### PR TITLE
feat(native-chat): drop workspace folders into chat

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatComposer.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.tsx
@@ -25,6 +25,7 @@ import {
 } from './native-chat-composer-target'
 import { useNativeChatComposerAttachments } from './use-native-chat-composer-attachments'
 import { useNativeChatComposerPaste } from './use-native-chat-composer-paste'
+import { useNativeChatWorkspaceDrop } from './use-native-chat-workspace-drop'
 import { useNativeChatExternalAttachments } from './use-native-chat-external-attachments'
 import { useNativeChatComposerKeyDown } from './use-native-chat-composer-keydown'
 import { useNativeChatSendLifecycle } from './use-native-chat-send-lifecycle'
@@ -190,6 +191,11 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
       attachResolvedPaths,
       insertTypedText,
       setCaret,
+      setNotice
+    })
+    const { onDragOver, onDrop } = useNativeChatWorkspaceDrop({
+      disabled,
+      insertTypedText,
       setNotice
     })
 
@@ -385,6 +391,8 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
           isComposingRef.current = false
         }}
         onPaste={handlePaste}
+        onDragOver={onDragOver}
+        onDrop={onDrop}
         pickerListboxId={picker.listboxId}
         onChoosePickerItem={completeItem}
         onRetrySkills={picker.retrySkills}

--- a/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
@@ -1,6 +1,7 @@
 import type {
   ClipboardEventHandler,
   CompositionEventHandler,
+  DragEventHandler,
   KeyboardEventHandler,
   RefObject
 } from 'react'
@@ -41,6 +42,8 @@ export type NativeChatComposerFieldProps = {
   onCompositionStart: CompositionEventHandler<HTMLTextAreaElement>
   onCompositionEnd: CompositionEventHandler<HTMLTextAreaElement>
   onPaste: ClipboardEventHandler<HTMLTextAreaElement>
+  onDragOver: DragEventHandler<HTMLDivElement>
+  onDrop: DragEventHandler<HTMLDivElement>
   pickerListboxId: string
   onChoosePickerItem: (item: NativeChatPickerItem) => void
   onRetrySkills: () => void
@@ -83,6 +86,8 @@ export function NativeChatComposerField({
   onCompositionStart,
   onCompositionEnd,
   onPaste,
+  onDragOver,
+  onDrop,
   pickerListboxId,
   onChoosePickerItem,
   onRetrySkills,
@@ -122,6 +127,8 @@ export function NativeChatComposerField({
           ) : null}
           <div
             data-native-file-drop-target={NATIVE_FILE_DROP_TARGET.composer}
+            onDragOver={onDragOver}
+            onDrop={onDrop}
             className={cn(
               // Why: always-on hairline (token-level border, not focus ring) —
               // no focus/click border flash. The box is a container, not a

--- a/src/renderer/src/components/native-chat/use-native-chat-workspace-drop.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-workspace-drop.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment happy-dom
+import { renderHook } from '@testing-library/react'
+import type { DragEvent } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { NATIVE_FILE_DROP_MAX_PATHS } from '../../../../shared/native-file-drop'
+import {
+  encodeWorkspaceFilePaths,
+  WORKSPACE_FILE_PATHS_MIME,
+  WORKSPACE_FILE_PATH_MIME
+} from '@/lib/workspace-file-drag'
+import { useNativeChatWorkspaceDrop } from './use-native-chat-workspace-drop'
+
+function dragEvent(
+  paths: readonly string[],
+  types = [WORKSPACE_FILE_PATHS_MIME]
+): {
+  event: DragEvent<HTMLDivElement>
+  preventDefault: ReturnType<typeof vi.fn>
+  stopPropagation: ReturnType<typeof vi.fn>
+  transfer: DataTransfer
+} {
+  const preventDefault = vi.fn()
+  const stopPropagation = vi.fn()
+  const payload = encodeWorkspaceFilePaths(paths)
+  const payloadType = types.includes(WORKSPACE_FILE_PATHS_MIME)
+    ? WORKSPACE_FILE_PATHS_MIME
+    : WORKSPACE_FILE_PATH_MIME
+  const transfer = {
+    dropEffect: 'none',
+    types,
+    getData: (type: string) => (type === payloadType ? payload : '')
+  } as unknown as DataTransfer
+  return {
+    event: {
+      dataTransfer: transfer,
+      preventDefault,
+      stopPropagation
+    } as unknown as DragEvent<HTMLDivElement>,
+    preventDefault,
+    stopPropagation,
+    transfer
+  }
+}
+
+function renderWorkspaceDrop(
+  options: {
+    disabled?: boolean
+    insertTypedText?: (text: string) => boolean
+    setNotice?: (notice: string | null) => void
+  } = {}
+): ReturnType<typeof useNativeChatWorkspaceDrop> {
+  const { result } = renderHook(() =>
+    useNativeChatWorkspaceDrop({
+      disabled: options.disabled ?? false,
+      insertTypedText: options.insertTypedText ?? (() => true),
+      setNotice: options.setNotice ?? (() => {})
+    })
+  )
+  return result.current
+}
+
+describe('useNativeChatWorkspaceDrop', () => {
+  it('advertises a copy drop only for supported workspace drags', () => {
+    const handlers = renderWorkspaceDrop()
+    const supported = dragEvent(['/repo'])
+    handlers.onDragOver(supported.event)
+    expect(supported.preventDefault).toHaveBeenCalledOnce()
+    expect(supported.stopPropagation).toHaveBeenCalledOnce()
+    expect(supported.transfer.dropEffect).toBe('copy')
+
+    const legacySinglePath = dragEvent(['/repo'], [WORKSPACE_FILE_PATH_MIME])
+    handlers.onDragOver(legacySinglePath.event)
+    expect(legacySinglePath.preventDefault).toHaveBeenCalledOnce()
+
+    const unrelated = dragEvent(['/repo'], ['text/plain'])
+    handlers.onDragOver(unrelated.event)
+    expect(unrelated.preventDefault).not.toHaveBeenCalled()
+    expect(unrelated.stopPropagation).not.toHaveBeenCalled()
+  })
+
+  it('preserves Windows paths, spaces, and Unicode as editable lines', () => {
+    const insertTypedText = vi.fn(() => true)
+    const setNotice = vi.fn()
+    const handlers = renderWorkspaceDrop({ insertTypedText, setNotice })
+    const dropped = dragEvent([
+      'C:\\Users\\muham\\Masaüstü\\KOHORT_TABLOLARI.md',
+      'C:\\Users\\muham\\Masaüstü\\Folder With Spaces'
+    ])
+    handlers.onDrop(dropped.event)
+    expect(insertTypedText).toHaveBeenCalledWith(
+      'C:\\Users\\muham\\Masaüstü\\KOHORT_TABLOLARI.md\n' +
+        'C:\\Users\\muham\\Masaüstü\\Folder With Spaces'
+    )
+    expect(setNotice).toHaveBeenCalledWith(null)
+  })
+
+  it('leaves disabled composers and unrelated drags untouched', () => {
+    const insertTypedText = vi.fn(() => true)
+    const handlers = renderWorkspaceDrop({ disabled: true, insertTypedText })
+    const dropped = dragEvent(['/repo'])
+    handlers.onDrop(dropped.event)
+    expect(dropped.preventDefault).not.toHaveBeenCalled()
+    expect(insertTypedText).not.toHaveBeenCalled()
+  })
+
+  it('surfaces bounded-decoder rejection without inserting partial paths', () => {
+    const insertTypedText = vi.fn(() => true)
+    const setNotice = vi.fn()
+    const handlers = renderWorkspaceDrop({ insertTypedText, setNotice })
+    const paths = Array.from(
+      { length: NATIVE_FILE_DROP_MAX_PATHS + 1 },
+      (_, index) => `/repo/${index}`
+    )
+    handlers.onDrop(dragEvent(paths).event)
+    expect(insertTypedText).not.toHaveBeenCalled()
+    expect(setNotice).toHaveBeenCalledWith('Drop contains too many paths.')
+  })
+
+  it('does not clear an existing notice when insertion is unavailable', () => {
+    const setNotice = vi.fn()
+    const handlers = renderWorkspaceDrop({ insertTypedText: () => false, setNotice })
+    handlers.onDrop(dragEvent(['/repo']).event)
+    expect(setNotice).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/native-chat/use-native-chat-workspace-drop.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-workspace-drop.ts
@@ -1,0 +1,63 @@
+import { useCallback } from 'react'
+import type { DragEventHandler } from 'react'
+import {
+  getWorkspaceFileDragRejectionMessage,
+  readWorkspaceFileDragPaths,
+  WORKSPACE_FILE_PATHS_MIME,
+  WORKSPACE_FILE_PATH_MIME
+} from '@/lib/workspace-file-drag'
+
+type UseNativeChatWorkspaceDropArgs = {
+  disabled: boolean
+  insertTypedText: (text: string) => boolean
+  setNotice: (notice: string | null) => void
+}
+
+function hasWorkspaceFileDragData(types: readonly string[]): boolean {
+  return types.includes(WORKSPACE_FILE_PATH_MIME) || types.includes(WORKSPACE_FILE_PATHS_MIME)
+}
+
+export function useNativeChatWorkspaceDrop({
+  disabled,
+  insertTypedText,
+  setNotice
+}: UseNativeChatWorkspaceDropArgs): {
+  onDragOver: DragEventHandler<HTMLDivElement>
+  onDrop: DragEventHandler<HTMLDivElement>
+} {
+  const onDragOver = useCallback<DragEventHandler<HTMLDivElement>>(
+    (event) => {
+      if (disabled || !hasWorkspaceFileDragData(event.dataTransfer.types)) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      event.dataTransfer.dropEffect = 'copy'
+    },
+    [disabled]
+  )
+
+  const onDrop = useCallback<DragEventHandler<HTMLDivElement>>(
+    (event) => {
+      if (disabled || !hasWorkspaceFileDragData(event.dataTransfer.types)) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      const result = readWorkspaceFileDragPaths(event.dataTransfer)
+      if (result.status === 'rejected') {
+        setNotice(getWorkspaceFileDragRejectionMessage(result.reason))
+        return
+      }
+      if (result.paths.length === 0) {
+        return
+      }
+      if (insertTypedText(result.paths.join('\n'))) {
+        setNotice(null)
+      }
+    },
+    [disabled, insertTypedText, setNotice]
+  )
+
+  return { onDragOver, onDrop }
+}

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -48,6 +48,7 @@ import {
 } from './WorktreeCardMeta'
 import { WorktreeCardPortsDetails, WorktreeCardPortsTrigger } from './WorktreeCardPorts'
 import { writeWorkspaceDragData } from './workspace-status'
+import { WORKSPACE_FILE_PATHS_MIME, encodeWorkspaceFilePaths } from '@/lib/workspace-file-drag'
 import {
   getWorktreeCardPrDisplay,
   isCachedMergedBranchPRCurrentForWorktree
@@ -966,14 +967,25 @@ const WorktreeCard = React.memo(function WorktreeCard({
         event.preventDefault()
         return
       }
-      const dragIds =
+      const selectedDragWorktrees =
         isMultiSelected && selectedWorktrees && selectedWorktrees.length > 1
-          ? selectedWorktrees.map((item) => item.id)
-          : worktree.id
+          ? selectedWorktrees
+          : null
+      const draggedIds = selectedDragWorktrees
+        ? selectedDragWorktrees.map((item) => item.id)
+        : [worktree.id]
+      const draggedPaths = selectedDragWorktrees
+        ? selectedDragWorktrees.map((item) => item.path)
+        : [worktree.path]
+      const dragIds = draggedIds.length > 1 ? draggedIds : worktree.id
       writeWorkspaceDragData(event.dataTransfer, dragIds)
-      onCardDragStart?.(event, worktree.id, Array.isArray(dragIds) ? dragIds : [dragIds])
+      // Why: the single-path channel opts into file moves; workspace cards provide
+      // path references while retaining move for card reordering and copy for targets.
+      event.dataTransfer.setData(WORKSPACE_FILE_PATHS_MIME, encodeWorkspaceFilePaths(draggedPaths))
+      event.dataTransfer.effectAllowed = 'copyMove'
+      onCardDragStart?.(event, worktree.id, draggedIds)
     },
-    [isDeleting, isMultiSelected, onCardDragStart, selectedWorktrees, worktree.id]
+    [isDeleting, isMultiSelected, onCardDragStart, selectedWorktrees, worktree.id, worktree.path]
   )
 
   const handleDragEnd = useCallback(


### PR DESCRIPTION
## What changed

- Include workspace folder/file paths in sidebar card drag payloads.
- Accept those internal paths in the native chat composer and insert the full path as editable text.
- Preserve multiple dropped paths on separate lines and show bounded-drop rejection feedback.

## Why

Dragging a folder from the left workspace sidebar into native chat previously only carried workspace-reordering metadata, so the composer could not receive the folder path.

## Validation

- Focused Vitest suites: 20 tests passed.
- Changed-file oxlint passed.
- Renderer typecheck reaches pre-existing TS6307 project-file errors in src/main unrelated to this change.

## ELI5

You can drag a workspace folder or file from the sidebar into native chat and drop its path into the composer as editable text. Multiple drops land on separate lines so you can point the agent at paths quickly.
