### PR TITLE
fix(dev): stabilize macOS safeStorage Keychain key name across dev branches

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1758,7 +1758,11 @@ app.whenReady().then(async () => {
     }
   )
   electronApp.setAppUserModelId(devInstanceIdentity.appUserModelId)
-  app.setName(devInstanceIdentity.name)
+  // Why: setName drives the macOS safeStorage Keychain item name. Use the stable
+  // appName (not the per-branch `name`) so dev branches share one key and don't
+  // re-prompt per branch; the per-branch label still shows via window title,
+  // renderer identity, and the app-menu label passed to registerAppMenu below.
+  app.setName(devInstanceIdentity.appName)
 
   // Why: managed WSL launchers live outside the Windows app bundle, so keep
   // their launcher and bridge contract synchronized across app updates.
@@ -2130,6 +2134,7 @@ app.whenReady().then(async () => {
   logStartupMilestone('i18n-ready')
 
   registerAppMenu({
+    appMenuLabel: devInstanceIdentity.name,
     onCheckForUpdates: (options) => runUserInitiatedUpdateCheck(options),
     onBeforeReload: ({ ignoreCache, webContentsId }) => {
       if (mainWindow?.webContents.id === webContentsId) {

--- a/src/main/menu/register-app-menu.ts
+++ b/src/main/menu/register-app-menu.ts
@@ -37,6 +37,9 @@ type RegisterAppMenuOptions = {
   onToggleAppearance: (key: AppearanceMenuKey) => void
   getAppearanceState: () => AppearanceMenuState
   getKeybindings?: () => KeybindingOverrides | undefined
+  // Why: the macOS app-menu title. Passed the per-branch dev label since
+  // app.name is now pinned to a stable value for Keychain-key stability.
+  appMenuLabel?: string
 }
 
 function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
@@ -130,7 +133,7 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
   // redundant "Orca" entry with roles that don't apply, so we omit it there
   // and distribute its items across File / Help instead.
   const macAppMenu: Electron.MenuItemConstructorOptions = {
-    label: app.name,
+    label: options.appMenuLabel ?? app.name,
     submenu: [
       { role: 'about' },
       checkForUpdatesItem,

--- a/src/main/startup/dev-instance-identity.test.ts
+++ b/src/main/startup/dev-instance-identity.test.ts
@@ -5,11 +5,24 @@ describe('dev-instance-identity', () => {
   it('keeps packaged identity stable', () => {
     expect(getDevInstanceIdentity(false, {})).toMatchObject({
       name: 'Orca',
+      appName: 'Orca',
       isDev: false,
       devLabel: null,
       dockBadgeLabel: null,
       appUserModelId: 'com.stablyai.orca'
     })
+  })
+
+  it('pins a stable dev appName across branches so the safeStorage key does not churn', () => {
+    const a = getDevInstanceIdentity(true, { ORCA_DEV_BRANCH: 'feature/a' })
+    const b = getDevInstanceIdentity(true, { ORCA_DEV_BRANCH: 'feature/b' })
+
+    // Per-branch label differs (window title / app menu)...
+    expect(a.name).not.toBe(b.name)
+    // ...but the Keychain-driving appName is identical and distinct from prod.
+    expect(a.appName).toBe('Orca Dev')
+    expect(b.appName).toBe('Orca Dev')
+    expect(a.appName).not.toBe('Orca')
   })
 
   it('derives a readable dev label from worktree and branch env', () => {

--- a/src/main/startup/dev-instance-identity.ts
+++ b/src/main/startup/dev-instance-identity.ts
@@ -8,6 +8,11 @@ const MAX_LABEL_LENGTH = 80
 
 export type DevInstanceIdentity = AppIdentity & {
   appUserModelId: string
+  // Why: drives app.setName → the macOS safeStorage Keychain item name
+  // ("<appName> Safe Storage"). Kept stable across dev branches (unlike the
+  // per-branch `name`) so every dev instance shares one Keychain key instead of
+  // creating a new one per branch and re-prompting. Distinct from prod's 'Orca'.
+  appName: string
 }
 
 function cleanEnvValue(value: string | undefined): string | null {
@@ -50,6 +55,7 @@ export function getDevInstanceIdentity(
   if (!isDev) {
     return {
       name: BASE_APP_NAME,
+      appName: BASE_APP_NAME,
       isDev: false,
       devLabel: null,
       devBranch: null,
@@ -71,6 +77,10 @@ export function getDevInstanceIdentity(
 
   return {
     name: dockTitle,
+    // Why: one stable Keychain key ('Orca Dev Safe Storage') for all dev
+    // branches; the per-branch identity still shows via `name` (window title,
+    // app menu, renderer label).
+    appName: `${BASE_APP_NAME} Dev`,
     isDev: true,
     devLabel,
     devBranch: branch,


### PR DESCRIPTION
## What & why

On macOS, dev builds of Orca showed a jarring **"Orca wants to access key 'Orca Safe Storage'"** Keychain prompt — most visibly on **Create worktree** — and it kept coming back on every new branch even after clicking "Always Allow".

**Root cause:** the macOS `safeStorage` Keychain item is named `"<app.getName()> Safe Storage"`. In dev, `app.setName()` was called with a **per-branch** name (`"Orca: <branch>"`), so every dev branch created a *different* Keychain key. macOS grants "Always Allow" per key, so a fresh branch = a fresh key = another prompt, forever.

**Fix:** add a stable `appName` to the dev identity (`'Orca Dev'` in dev, `'Orca'` in prod) and `app.setName` **that** instead of the per-branch name. All dev branches — which already share one `orca-dev` userData dir — now share **one** `"Orca Safe Storage"`-style key (`"Orca Dev Safe Storage"`), so a single "Always Allow" sticks across every branch and rebuild. The per-branch label you use to tell instances apart still shows: the window title and renderer identity already read `devInstanceIdentity.name` directly, and the macOS app-menu label is now passed through `registerAppMenu`.

## Who this affects
- **End users (signed, notarized prod build): unaffected — and were never prompted.** macOS gates the key by code-signing identity, not binary bytes, so a stable Developer ID means silent access. Prod's app name stays `'Orca'`; the prod Keychain item is untouched.
- **Dev: the fix.** One stable key across branches → grant once, no churn.

## Why not also memoize the encryption?
An earlier draft of this PR also memoized `safeStorage.encryptString` to avoid re-encrypting unchanged secrets on every save. It was dropped: once the key is stable, that access is silent, macOS's OSCrypt already caches the key in-process (so there's no CPU win), and it added a ciphertext cache to the security-sensitive `persistence.ts` for near-zero benefit. Kept out to keep this a minimal, single-purpose fix. (It lives in git history if a real need surfaces.)

## Evidence
- `dev-instance-identity.test.ts`: asserts `appName` is identical across two different branches and distinct from prod `'Orca'`, while the per-branch `name` still differs.
- `pnpm exec vitest run` on affected suites (identity + menu) → **pass**. `tsc --noEmit` clean · `oxlint`/`oxfmt` clean · no `max-lines` disables.
- **Mechanism** is closed analytically: safeStorage's key name follows `app.getName()` (proven by the pre-fix churn itself); `setName(x)` → `getName()` returns `x` (Electron contract); there is exactly one `setName` call in the codebase, now fed the stable `appName`; userData is captured *before* `setName`, so the name change can't move any path. **Residual gap:** I did not complete a live-boot smoke test (a parallel dev instance fought the environment while another Orca was running) — trivially self-checkable by relaunching a dev instance on this branch.
- **Cosmetic caveat:** on macOS the OS may render the app-menu title from the bundle name regardless of our template `label`, in which case the per-branch app-menu label is a harmless no-op. The Keychain behavior is unaffected either way.

## ELI5
Each dev branch used to make its *own* differently-named lock in the Mac Keychain, so "Always Allow" never stuck — a new branch always re-asked. Now every dev branch shares one lock, so you grant it once and it's quiet after that. Nothing about how secrets are stored changes.

## User-facing regressions
**None intended.** Prod app name stays `'Orca'` (end users untouched). Per-branch window title / renderer label preserved. On-disk secret format unchanged. **One-time dev note:** existing dev secrets in the shared `orca-dev` file were encrypted under an old per-branch key; on first launch after this change they fail to decrypt once and get re-encrypted under the stable key (graceful, no crash — dev-only, re-enterable session values).
