### PR TITLE
Feat/adal cli integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Works with **any CLI agent** — if it runs in a terminal, it runs in Orca.
 <p>
   <a href="https://docs.anthropic.com/claude/docs/claude-code"><kbd><img src="docs/assets/claude-logo.svg" alt="Claude Code logo" width="16" valign="middle" /> Claude Code</kbd></a> &nbsp;
   <a href="https://github.com/openai/codex"><kbd><img src="https://www.google.com/s2/favicons?domain=openai.com&sz=64" alt="Codex logo" width="16" valign="middle" /> Codex</kbd></a> &nbsp;
-  <a href="https://github.com/SylphAI-Inc/adal"><kbd>AdaL</kbd></a> &nbsp;
+  <a href="https://docs.sylph.ai/"><kbd><img src="https://www.google.com/s2/favicons?domain=sylph.ai&sz=64" alt="AdaL logo" width="16" valign="middle" /> AdaL</kbd></a> &nbsp;
   <a href="https://x.ai/cli"><kbd><img src="https://www.google.com/s2/favicons?domain=x.ai&sz=64" alt="Grok logo" width="16" valign="middle" /> Grok</kbd></a> &nbsp;
   <a href="https://cursor.com/cli"><kbd><img src="https://www.google.com/s2/favicons?domain=cursor.com&sz=64" alt="Cursor logo" width="16" valign="middle" /> Cursor</kbd></a> &nbsp;
   <a href="https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli"><kbd><img src="https://www.google.com/s2/favicons?domain=github.com&sz=64" alt="GitHub Copilot logo" width="16" valign="middle" /> GitHub Copilot</kbd></a> &nbsp;

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Works with **any CLI agent** — if it runs in a terminal, it runs in Orca.
 <p>
   <a href="https://docs.anthropic.com/claude/docs/claude-code"><kbd><img src="docs/assets/claude-logo.svg" alt="Claude Code logo" width="16" valign="middle" /> Claude Code</kbd></a> &nbsp;
   <a href="https://github.com/openai/codex"><kbd><img src="https://www.google.com/s2/favicons?domain=openai.com&sz=64" alt="Codex logo" width="16" valign="middle" /> Codex</kbd></a> &nbsp;
+  <a href="https://github.com/SylphAI-Inc/adal"><kbd>AdaL</kbd></a> &nbsp;
   <a href="https://x.ai/cli"><kbd><img src="https://www.google.com/s2/favicons?domain=x.ai&sz=64" alt="Grok logo" width="16" valign="middle" /> Grok</kbd></a> &nbsp;
   <a href="https://cursor.com/cli"><kbd><img src="https://www.google.com/s2/favicons?domain=cursor.com&sz=64" alt="Cursor logo" width="16" valign="middle" /> Cursor</kbd></a> &nbsp;
   <a href="https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli"><kbd><img src="https://www.google.com/s2/favicons?domain=github.com&sz=64" alt="GitHub Copilot logo" width="16" valign="middle" /> GitHub Copilot</kbd></a> &nbsp;

--- a/docs/adal-cli-integration.md
+++ b/docs/adal-cli-integration.md
@@ -1,0 +1,386 @@
+# AdaL CLI in Orca
+
+AdaL CLI is a terminal-first AI coding agent. Orca can show AdaL in the default-agent picker, detect it when it is installed, and launch it inside an Orca-managed worktree.
+
+AdaL supports codebase understanding, implementation, debugging, project context, multiple AI models, MCP servers, skills, plugins, web search, image generation, and local models. See the [AdaL documentation](https://docs.sylph.ai/) for the complete feature set.
+
+## Before you begin
+
+You need:
+
+- Orca installed.
+- A project or Git repository to work on.
+- A supported terminal environment.
+- An AdaL account with an active plan. Eligible new users can claim a 7-day free Pro trial from the [AdaL Dashboard](https://adal.sylph.ai/dashboard).
+
+A Git repository is recommended because Orca uses isolated worktrees for parallel development.
+
+## Step 1: Install AdaL CLI
+
+Native installation is recommended because it manages AdaL's runtime and updates consistently across platforms.
+
+### macOS, Linux, and WSL
+
+Run this command in a terminal:
+
+```bash
+curl -fsSL https://adal.sylph.ai/install.sh | bash
+```
+
+### Windows PowerShell
+
+```powershell
+irm https://adal.sylph.ai/install/windows | iex
+```
+
+### Windows Command Prompt
+
+```cmd
+powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://adal.sylph.ai/install/windows | iex"
+```
+
+If `irm` is not recognized, you are probably using Command Prompt instead of PowerShell. Use the Command Prompt command above or open PowerShell.
+
+Official installation reference: [AdaL Quickstart](https://docs.sylph.ai/getting-started/quickstart).
+
+## Step 2: Verify AdaL
+
+Open a new terminal after installation and run:
+
+```bash
+adal --help
+```
+
+On macOS, Linux, or WSL, you can also verify the executable location:
+
+```bash
+command -v adal
+```
+
+On Windows PowerShell:
+
+```powershell
+Get-Command adal
+```
+
+If Orca was already open while AdaL was installed, restart Orca so its desktop process receives the updated `PATH`.
+
+## Step 3: Authenticate AdaL
+
+Run AdaL from any project directory:
+
+```bash
+adal
+```
+
+On first launch, AdaL opens a browser window for authentication. Complete sign-in and return to the terminal.
+
+AdaL requires an active plan to use the CLI. Review available plans at [Pricing](https://adalagent.ai/#pricing).
+
+## Step 4: Select AdaL in Orca
+
+In Orca's **Pick your default agent** onboarding step:
+
+1. Find **AdaL** in the agent list.
+2. Select the AdaL card.
+3. Continue through onboarding.
+
+### When AdaL is installed
+
+AdaL appears in:
+
+```text
+Detected on your system
+```
+
+### When AdaL is not installed
+
+AdaL remains available in the additional-agent list. You can select the card and use Orca's **Install instructions** link to open the official AdaL documentation.
+
+After installing AdaL, restart Orca and return to the agent picker. AdaL should then appear as detected.
+
+## Step 5: Launch AdaL from an Orca worktree
+
+When AdaL is selected for a project, Orca:
+
+1. Creates or selects the Git worktree.
+2. Opens a terminal whose working directory is that worktree.
+3. Launches AdaL interactively:
+
+   ```bash
+   adal
+   ```
+
+4. Delivers the initial task through Orca's terminal startup flow.
+
+The workspace context is inherited through the working directory:
+
+```text
+Orca worktree
+    ↓
+Terminal current working directory
+    ↓
+AdaL process working directory
+    ↓
+AdaL project/session context
+```
+
+AdaL continues to own its normal authentication, session, streaming, and runtime lifecycle.
+
+## What you can do with AdaL in Orca
+
+Once AdaL is running, you can use its normal CLI capabilities.
+
+### Understand and modify a codebase
+
+Try prompts such as:
+
+```text
+Summarize this codebase
+```
+
+```text
+Find the authentication flow and explain how it works
+```
+
+```text
+Add validation to the user registration endpoint and update the tests
+```
+
+AdaL can inspect project files, plan changes, implement edits, and help debug issues.
+
+### Initialize project context
+
+Use:
+
+```text
+/init
+```
+
+AdaL generates project context in `AGENTS.md`, which can capture repository conventions and instructions for future work.
+
+### Use multiple models
+
+Use:
+
+```text
+/model
+```
+
+to switch the active AI model. AdaL supports Claude, GPT, Gemini, GLM, MiniMax, and local models; availability depends on the account and configuration.
+
+### Use files and shell commands as context
+
+Target a file with `@`:
+
+```text
+@src/api.ts add request validation
+```
+
+Run a shell command with `!`:
+
+```text
+!git status
+```
+
+### Use planning and research modes
+
+Press `Tab` to switch between:
+
+```text
+Regular → Plan → Deep Research
+```
+
+Use Plan mode for larger changes that benefit from an explicit implementation plan before editing.
+
+### Continue in the AdaL IDE
+
+Use:
+
+```text
+/ide
+```
+
+to open the same session in the AdaL agentic IDE. If AdaL Desktop is installed, it opens the Desktop app; otherwise, AdaL opens the browser workspace.
+
+This is useful for visual work, diff review, and tasks that benefit from an IDE-style layout.
+
+### Use MCP servers, skills, and plugins
+
+AdaL supports:
+
+- MCP servers.
+- Skills and plugins.
+- Web search.
+- Image generation.
+- Local models.
+- Project context through `AGENTS.md`.
+
+Configure these through the relevant features documented at [docs.sylph.ai](https://docs.sylph.ai/).
+
+## Essential AdaL commands
+
+| Command | What it does |
+| --- | --- |
+| `/help` | Show all commands |
+| `/model` | Switch the AI model |
+| `/init` | Generate project context in `AGENTS.md` |
+| `/ide` | Open the same session in AdaL Desktop or the browser workspace |
+| `/resume` | Resume a previous conversation |
+| `/compact` | Compress memory when the context is full |
+| `/quit` | Exit AdaL |
+
+## Essential shortcuts
+
+| Shortcut | What it does |
+| --- | --- |
+| `?` | Show all shortcuts |
+| `Tab` | Toggle Regular, Plan, and Deep Research modes |
+| `Shift+Tab` | Toggle auto-accept edits |
+| `Ctrl+C` | Cancel agent streaming or a running operation |
+| `Esc` | Clear the input |
+
+## Input prefixes
+
+| Prefix | What it does | Example |
+| --- | --- | --- |
+| `@` | Add a file as context | `@src/api.ts add validation` |
+| `!` | Run a shell command | `!git status` |
+
+## Worktree management
+
+AdaL also provides worktree commands for users who want to manage branches from the CLI:
+
+```bash
+adal worktree create -b <name>
+adal worktree create -b <name> <start-point>
+adal worktree list
+adal worktree delete <name>
+```
+
+When AdaL is launched by Orca, Orca remains responsible for the Orca-managed worktree and terminal lifecycle.
+
+## Terminal setup
+
+AdaL works in modern native terminals and integrated terminals, including:
+
+- iTerm2.
+- cmux.
+- VS Code terminal.
+- Windows Terminal.
+- Linux terminals.
+- macOS Terminal on macOS 26 or later for full theme support.
+
+A larger terminal window gives AdaL more room to display code and diffs.
+
+AdaL themes require truecolor support. Check your terminal with:
+
+```bash
+echo $COLORTERM
+```
+
+The output should be `truecolor` or `24bit`.
+
+If necessary, enable truecolor in `.zshrc` or `.bashrc`:
+
+```bash
+export COLORTERM=truecolor
+```
+
+## Interactive mode in Orca
+
+Orca launches the interactive command:
+
+```bash
+adal
+```
+
+It does not use AdaL's one-shot query mode as the default worktree terminal because Orca needs a persistent interactive session for:
+
+- Ongoing conversation.
+- Approvals.
+- Slash commands.
+- Queued messages.
+- Session continuation.
+- Follow-up tasks.
+
+## Troubleshooting
+
+### AdaL does not appear as detected
+
+Verify the command outside Orca:
+
+```bash
+adal --help
+```
+
+Then restart Orca. The Orca desktop process may have been started before AdaL was added to `PATH`.
+
+### AdaL is listed but Orca shows it as unavailable
+
+This means AdaL is present in Orca's catalog but was not found in the environment visible to Orca. Install AdaL using the official instructions, restart Orca, and refresh the agent selection.
+
+### Authentication does not open
+
+Run AdaL directly:
+
+```bash
+adal
+```
+
+Complete browser authentication and confirm that the CLI works before launching it from Orca.
+
+### AdaL cannot use the project
+
+Confirm that the project path is accessible and that AdaL works directly from the same directory:
+
+```bash
+cd /path/to/project
+adal
+```
+
+When launched from an Orca worktree, AdaL receives that worktree as its current working directory.
+
+### Colors or layout look incorrect
+
+Use a modern terminal with truecolor support. Check:
+
+```bash
+echo $COLORTERM
+```
+
+For macOS Terminal, AdaL recommends macOS 26 or later for full theme support; iTerm2 or the VS Code terminal are alternatives.
+
+### The initial task does not appear
+
+Confirm that AdaL reaches its interactive input screen when run directly. Then close and relaunch the Orca worktree so the terminal startup flow can run again.
+
+## Current Orca integration scope
+
+The Orca integration provides:
+
+- AdaL in the default-agent onboarding catalog.
+- AdaL detection through the installed `adal` command.
+- Default-agent selection and persistence.
+- AdaL launch inside an Orca-managed worktree.
+- Interactive terminal hosting.
+- Generic launch and process metadata.
+
+The current integration does not add:
+
+- A native AdaL chat panel inside Orca.
+- AdaL-specific status hooks.
+- AdaL session-history scanning in Orca.
+- AdaL model, account, or usage controls inside Orca.
+- AdaL-specific orchestration APIs.
+
+These are separate future integrations and are not required for AdaL to be selected and launched from Orca.
+
+## Official AdaL references
+
+- [AdaL documentation](https://docs.sylph.ai/)
+- [AdaL Quickstart](https://docs.sylph.ai/getting-started/quickstart)
+- [Workflows and examples](https://docs.sylph.ai/getting-started/workflows-and-examples)
+- [Slash commands](https://docs.sylph.ai/features/slash-commands)
+- [Keyboard shortcuts](https://docs.sylph.ai/features/keyboard-shortcuts)
+- [AdaL Dashboard](https://adal.sylph.ai/dashboard)

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -349,6 +349,7 @@
           "706b0fe68b": "GitHub Copilot",
           "0baad2d5d2": "Grok",
           "760bc6883d": "Codex",
+          "ffd09bf891": "AdaL",
           "a5fc0cb622": "OpenClaude",
           "bf53f09bf8": "Claude Agent Teams",
           "0708ed89f1": "Claude",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -326,6 +326,7 @@
           "706b0fe68b": "GitHub Copilot",
           "0baad2d5d2": "Grok",
           "760bc6883d": "Codex",
+          "ffd09bf891": "AdaL",
           "a5fc0cb622": "OpenClaude",
           "bf53f09bf8": "Claude Agent Teams",
           "0708ed89f1": "Claude",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -326,6 +326,7 @@
           "706b0fe68b": "GitHub Copilot",
           "0baad2d5d2": "Grok",
           "760bc6883d": "Codex",
+          "ffd09bf891": "AdaL",
           "a5fc0cb622": "OpenClaude",
           "bf53f09bf8": "Claude Agent Teams",
           "0708ed89f1": "Claude",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -326,6 +326,7 @@
           "706b0fe68b": "GitHub Copilot",
           "0baad2d5d2": "Grok",
           "760bc6883d": "Codex",
+          "ffd09bf891": "AdaL",
           "a5fc0cb622": "OpenClaude",
           "bf53f09bf8": "Claude Agent Teams",
           "0708ed89f1": "Claude",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -326,6 +326,7 @@
           "706b0fe68b": "GitHub Copilot",
           "0baad2d5d2": "Grok",
           "760bc6883d": "Codex",
+          "ffd09bf891": "AdaL",
           "a5fc0cb622": "OpenClaude",
           "bf53f09bf8": "Claude Agent Teams",
           "0708ed89f1": "Claude",

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -72,6 +72,12 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
     homepageUrl: 'https://github.com/openai/codex'
   },
   {
+    id: 'adal',
+    label: translate('auto.lib.agent.catalog.adal', 'AdaL'),
+    cmd: 'adal',
+    homepageUrl: 'https://github.com/SylphAI-Inc/adal'
+  },
+  {
     id: 'grok',
     label: translate('auto.lib.agent.catalog.0baad2d5d2', 'Grok'),
     cmd: 'grok',

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -75,6 +75,7 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
     id: 'adal',
     label: translate('auto.lib.agent.catalog.ffd09bf891', 'AdaL'),
     cmd: 'adal',
+    faviconDomain: 'adalagent.ai',
     homepageUrl: 'https://docs.sylph.ai/getting-started/quickstart'
   },
   {

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -73,9 +73,9 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
   },
   {
     id: 'adal',
-    label: translate('auto.lib.agent.catalog.adal', 'AdaL'),
+    label: translate('auto.lib.agent.catalog.ffd09bf891', 'AdaL'),
     cmd: 'adal',
-    homepageUrl: 'https://github.com/SylphAI-Inc/adal'
+    homepageUrl: 'https://docs.sylph.ai/getting-started/quickstart'
   },
   {
     id: 'grok',

--- a/src/renderer/src/lib/agent-status.ts
+++ b/src/renderer/src/lib/agent-status.ts
@@ -127,6 +127,7 @@ const ICONABLE_AGENT_TYPES: Record<TuiAgent, true> = {
   'claude-agent-teams': true,
   openclaude: true,
   codex: true,
+  adal: true,
   autohand: true,
   opencode: true,
   'mimo-code': true,

--- a/src/shared/agent-kind.test.ts
+++ b/src/shared/agent-kind.test.ts
@@ -29,6 +29,11 @@ describe('tuiAgentToAgentKind', () => {
     expect(tuiAgentToAgentKind('claude')).toBe('claude-code')
     expect(tuiAgentToAgentKind('pi')).toBe('pi')
   })
+
+  it('maps AdaL to its concrete telemetry identity', () => {
+    expect(tuiAgentToAgentKind('adal')).toBe('adal')
+    expect(agentKindToTuiAgent('adal')).toBe('adal')
+  })
 })
 
 describe('agentKindToTuiAgent', () => {

--- a/src/shared/agent-kind.ts
+++ b/src/shared/agent-kind.ts
@@ -18,6 +18,7 @@ const TUI_AGENT_KIND_BY_AGENT = {
   'claude-agent-teams': 'claude-agent-teams',
   openclaude: 'openclaude',
   codex: 'codex',
+  adal: 'adal',
   autohand: 'autohand',
   opencode: 'opencode',
   'mimo-code': 'mimo-code',

--- a/src/shared/agent-process-recognition.test.ts
+++ b/src/shared/agent-process-recognition.test.ts
@@ -25,6 +25,20 @@ describe('agent process recognition', () => {
     expect(isExpectedAgentProcess('/usr/local/bin/openclaude', 'claude')).toBe(false)
   })
 
+  it('recognizes the AdaL foreground process and rejects lookalike names', () => {
+    expect(recognizeAgentProcess('adal')).toEqual({
+      agent: 'adal',
+      processName: 'adal'
+    })
+    expect(recognizeAgentProcess('/usr/local/bin/adal')).toEqual({
+      agent: 'adal',
+      processName: 'adal'
+    })
+    expect(isExpectedAgentProcess('/usr/local/bin/adal', 'adal')).toBe(true)
+    expect(recognizeAgentProcess('adal-helper')).toBeNull()
+    expect(recognizeAgentProcess('adal-project')).toBeNull()
+  })
+
   it('recognizes the Droid foreground process on Windows', () => {
     expect(recognizeAgentProcess(String.raw`C:\Users\dev\AppData\Roaming\npm\droid.cmd`)).toEqual({
       agent: 'droid',

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -73,6 +73,7 @@ export const AGENT_KIND_VALUES = [
   'claude-agent-teams',
   'openclaude',
   'codex',
+  'adal',
   'autohand',
   'opencode',
   'mimo-code',

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -115,6 +115,14 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     preflightTrust: 'codex',
     draftPasteReadySignal: 'codex-composer-prompt'
   },
+  adal: {
+    detectCmd: 'adal',
+    launchCmd: 'adal',
+    expectedProcess: 'adal',
+    // AdaL's interactive mode is launched without -q; prompt delivery uses
+    // Orca's generic post-start path rather than unsupported positional args.
+    promptInjectionMode: 'stdin-after-start'
+  },
   autohand: {
     detectCmd: 'autohand',
     launchCmd: 'autohand',

--- a/src/shared/tui-agent-display-names.ts
+++ b/src/shared/tui-agent-display-names.ts
@@ -10,6 +10,7 @@ export const TUI_AGENT_DISPLAY_NAMES: Record<TuiAgent, string> = {
   'claude-agent-teams': 'Claude Agent Teams',
   openclaude: 'OpenClaude',
   codex: 'Codex',
+  adal: 'AdaL',
   devin: 'Devin',
   ante: 'Ante',
   autohand: 'Autohand Code',

--- a/src/shared/tui-agent-selection.ts
+++ b/src/shared/tui-agent-selection.ts
@@ -8,6 +8,7 @@ export const TUI_AGENT_AUTO_PICK_ORDER = [
   'claude-agent-teams',
   'openclaude',
   'codex',
+  'adal',
   'grok',
   'copilot',
   'opencode',

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -29,6 +29,19 @@ function unwrapPowerShellScript(command: string | undefined): string {
 }
 
 describe('tui agent startup plans', () => {
+  it('uses AdaL interactive startup without adding unsupported CLI arguments', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'adal',
+      prompt: 'fix the bug',
+      cmdOverrides: {},
+      platform: 'linux'
+    })
+
+    expect(plan?.launchConfig.agentCommand).toBe('adal')
+    expect(plan?.launchCommand).toBe('adal')
+    expect(plan?.followupPrompt).toBe('fix the bug')
+  })
+
   it.each(['powershell', 'cmd'] as const)(
     'keeps the established invalid-quote error on %s',
     (shell) => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2404,6 +2404,7 @@ export type TuiAgent =
   | 'claude-agent-teams' // Claude Code Agent Teams via Orca native panes
   | 'openclaude' // OpenClaude
   | 'codex' // OpenAI Codex
+  | 'adal' // AdaL CLI
   | 'autohand' // Autohand Code CLI
   | 'opencode' // OpenCode
   | 'mimo-code'


### PR DESCRIPTION
## TL;DR
Adds AdaL CLI as a first-class supported agent in Orca — wired into the shared agent registry 
  (detection, launch, telemetry), the onboarding agent picker, and the README badge list — plus 
  a standalone setup/usage guide.

## What changed
### Core agent registry (`feat: add AdaL to shared agent registry`)
- Added `adal` as a new `TuiAgent` in `src/shared/types.ts`.
- Registered detection/launch config in `src/shared/tui-agent-config.ts` (`detectCmd: 'adal'`,
  `promptInjectionMode: 'stdin-after-start'` since AdaL's interactive mode has no supported 
  positional-argv prompt flag).
- Added `adal` to `agent-kind.ts`/`telemetry-events.ts` (telemetry identity mapping), 
  `tui-agent-display-names.ts` (display name "AdaL"), `tui-agent-selection.ts` (auto-pick 
  order), and `agent-status.ts` (`ICONABLE_AGENT_TYPES`).
- Added unit test coverage: `agent-kind.test.ts` (telemetry mapping), 
  `agent-process-recognition.test.ts` (recognizes `adal` process, rejects lookalikes like 
  `adal-helper`), `tui-agent-startup.test.ts` (verifies startup plan builds `adal` launch 
  command correctly).

### Onboarding & catalog (`feat(agent-catalog): correct AdaL homepageUrl and i18n key`, `fix: 
  AdaL logo faviconDomain`)
- Added AdaL entry to `agent-catalog.tsx` (used by the onboarding agent picker), with:
  - `homepageUrl: 'https://docs.sylph.ai/getting-started/quickstart'` — opened by the "Install
  instructions" button when AdaL isn't detected on PATH.
  - `faviconDomain: 'sylph.ai'` — so the agent card renders AdaL's real logo instead of 
  falling back to a plain letter glyph.
  - Translation key generated via the project's standard SHA-1 hash convention (
  `auto.lib.agent.catalog.ffd09bf891`), matching every other catalog entry, instead of a 
  hand-typed key.
- Added translations for the new label across all 5 locales (`en`, `es`, `ja`, `ko`, `zh`).

### Docs
- New `docs/adal-cli-integration.md`: a full setup/usage guide for AdaL in Orca — install 
  steps, verification, onboarding selection, launch flow, essential commands/shortcuts, 
  troubleshooting, and current integration scope (what's included vs. not yet built).
- Fixed the AdaL badge in `README.md`'s "Supported Agents" list: added a favicon logo image 
  and pointed the link at `docs.sylph.ai` instead of the bare GitHub source repo, matching the 
  pattern used by every sibling badge (Claude, Grok, Copilot, etc.).

## Why
AdaL is a supported terminal-first coding agent (from SylphAI) and should be discoverable and 
  launchable from Orca the same way Claude, Codex, and other CLI agents already are — detected 
  via PATH, selectable in onboarding, and documented for setup.

## Testing
- `agent-kind.test.ts`, `agent-process-recognition.test.ts`, `tui-agent-startup.test.ts`, 
  `AgentStep.test.tsx`, `telemetry-events.test.ts` — all passing (138 tests).
- `npm run typecheck` — no AdaL-related type errors (one pre-existing, unrelated monaco-editor
  path-resolution error in this nested worktree).
- All 5 locale JSON files validated as parseable.
- Manually verified locally via `npm run dev` with `adal` installed on PATH:
  - AdaL appears in "Detected on your system" in the onboarding agent picker.
  - Logo renders correctly (favicon fallback, not a placeholder letter).
  - Selecting AdaL persists as the default agent.

## Not included (future work)
Per `docs/adal-cli-integration.md`'s "Current Orca integration scope": no native AdaL chat 
  panel, AdaL-specific status hooks, session-history scanning, or model/account/usage controls 
  inside Orca. These are separate future integrations.