### PR TITLE
fix(sidebar): avoid duplicate GitHub review polling

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.hosted-review-refresh.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.hosted-review-refresh.test.tsx
@@ -10,6 +10,9 @@ const fetchIssue = vi.fn()
 const fetchLinearIssue = vi.fn()
 const openModal = vi.fn()
 const updateWorktreeMeta = vi.fn()
+const hoverCardState = vi.hoisted(() => ({
+  onOpenChange: undefined as ((open: boolean) => void) | undefined
+}))
 
 let worktreeCardProperties: WorktreeCardProperty[] = ['status']
 let root: Root | null = null
@@ -52,6 +55,21 @@ vi.mock('@/components/ui/tooltip', () => ({
   Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
   TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
   TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/ui/hover-card', () => ({
+  HoverCard: ({
+    children,
+    onOpenChange
+  }: {
+    children: ReactNode
+    onOpenChange?: (open: boolean) => void
+  }) => {
+    hoverCardState.onOpenChange = onOpenChange
+    return <>{children}</>
+  },
+  HoverCardContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  HoverCardTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
 }))
 
 vi.mock('./CacheTimer', () => ({
@@ -137,6 +155,7 @@ describe('WorktreeCard hosted review refresh', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.clearAllMocks()
+    hoverCardState.onOpenChange = undefined
     worktreeCardProperties = ['status']
     container = document.createElement('div')
     document.body.appendChild(container)
@@ -233,5 +252,29 @@ describe('WorktreeCard hosted review refresh', () => {
     })
 
     expect(fetchHostedReviewForBranch).toHaveBeenCalledTimes(2)
+  })
+
+  it('refreshes coordinator-owned GitHub review details on demand when status is hidden', async () => {
+    worktreeCardProperties = []
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    act(() => {
+      root?.render(
+        <WorktreeCard
+          worktree={makeWorktree()}
+          repo={makeGitHubRepo()}
+          isActive={false}
+          coordinatedGitHubRefresh
+        />
+      )
+    })
+
+    expect(fetchHostedReviewForBranch).not.toHaveBeenCalled()
+
+    act(() => {
+      hoverCardState.onOpenChange?.(true)
+    })
+
+    expect(fetchHostedReviewForBranch).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeCard.hosted-review-refresh.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.hosted-review-refresh.test.tsx
@@ -88,6 +88,28 @@ function makeRepo(): Repo {
   }
 }
 
+function makeGitHubRepo(): Repo {
+  return {
+    ...makeRepo(),
+    gitRemoteIdentity: {
+      canonicalKey: 'github.com/stablyai/orca',
+      remoteName: 'origin',
+      remoteUrl: 'https://github.com/stablyai/orca.git'
+    }
+  }
+}
+
+function makeGitLabRepo(): Repo {
+  return {
+    ...makeRepo(),
+    gitRemoteIdentity: {
+      canonicalKey: 'gitlab.com/stablyai/orca',
+      remoteName: 'origin',
+      remoteUrl: 'git@gitlab.com:stablyai/orca.git'
+    }
+  }
+}
+
 function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
   return {
     id: 'repo-1::/repo/worktrees/branch',
@@ -131,11 +153,13 @@ describe('WorktreeCard hosted review refresh', () => {
     vi.useRealTimers()
   })
 
-  it('polls visible hosted review cards after a cached branch miss', async () => {
+  it('keeps polling visible GitLab review cards after a cached branch miss', async () => {
     const { default: WorktreeCard } = await import('./WorktreeCard')
 
     act(() => {
-      root?.render(<WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} />)
+      root?.render(
+        <WorktreeCard worktree={makeWorktree()} repo={makeGitLabRepo()} isActive={false} />
+      )
     })
 
     expect(fetchHostedReviewForBranch).toHaveBeenCalledTimes(1)
@@ -163,6 +187,22 @@ describe('WorktreeCard hosted review refresh', () => {
 
     act(() => {
       root?.render(<WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} />)
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(60_000)
+    })
+
+    expect(fetchHostedReviewForBranch).not.toHaveBeenCalled()
+  })
+
+  it('leaves GitHub-backed card refreshes to the batched PR coordinator', async () => {
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    act(() => {
+      root?.render(
+        <WorktreeCard worktree={makeWorktree()} repo={makeGitHubRepo()} isActive={false} />
+      )
     })
 
     act(() => {

--- a/src/renderer/src/components/sidebar/WorktreeCard.hosted-review-refresh.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.hosted-review-refresh.test.tsx
@@ -201,7 +201,12 @@ describe('WorktreeCard hosted review refresh', () => {
 
     act(() => {
       root?.render(
-        <WorktreeCard worktree={makeWorktree()} repo={makeGitHubRepo()} isActive={false} />
+        <WorktreeCard
+          worktree={makeWorktree()}
+          repo={makeGitHubRepo()}
+          isActive={false}
+          coordinatedGitHubRefresh
+        />
       )
     })
 
@@ -210,5 +215,23 @@ describe('WorktreeCard hosted review refresh', () => {
     })
 
     expect(fetchHostedReviewForBranch).not.toHaveBeenCalled()
+  })
+
+  it('keeps polling GitHub-backed cards outside the coordinator-owned list', async () => {
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    act(() => {
+      root?.render(
+        <WorktreeCard worktree={makeWorktree()} repo={makeGitHubRepo()} isActive={false} />
+      )
+    })
+
+    expect(fetchHostedReviewForBranch).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      vi.advanceTimersByTime(60_000)
+    })
+
+    expect(fetchHostedReviewForBranch).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -83,6 +83,7 @@ import { recordRendererCrashBreadcrumb } from '@/lib/crash-diagnostics'
 import { folderWorkspaceKey, parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import { isRuntimeOwnedSshTargetId, parseExecutionHostId } from '../../../../shared/execution-host'
 import { DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE } from '../../../../shared/constants'
+import { isGitHubBackedRepo } from '../../../../shared/project-host-setup-projection'
 
 type WorktreeRenameRequest = {
   worktreeId: string
@@ -597,6 +598,9 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const showComment = cardProps.includes('comment')
   const showPorts = cardProps.includes('ports')
   const shouldRefreshHostedReview = newCardStyle ? showStatus : showPR
+  // Why: GitHub card refreshes are already batched by WorktreeList's coordinator;
+  // per-card hosted-review polling bypasses that budget and creates a startup stampede.
+  const usesCoordinatedGitHubRefresh = repo ? isGitHubBackedRepo(repo) : false
   const detailsHoverControl = useWorktreeCardDetailsHoverControl()
   const hoverDetailsOpen = detailsHoverControl.hoverOpen
 
@@ -612,6 +616,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
       worktree.isBare ||
       !hostedReviewCacheKey ||
       !shouldRefreshHostedReview ||
+      usesCoordinatedGitHubRefresh ||
       isMacAppDataPath(repo.path)
     ) {
       return
@@ -651,7 +656,8 @@ const WorktreeCard = React.memo(function WorktreeCard({
     fetchHostedReviewForBranch,
     branch,
     hostedReviewCacheKey,
-    shouldRefreshHostedReview
+    shouldRefreshHostedReview,
+    usesCoordinatedGitHubRefresh
   ])
 
   useEffect(() => {
@@ -664,6 +670,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
       isFolder ||
       worktree.isBare ||
       !hostedReviewCacheKey ||
+      usesCoordinatedGitHubRefresh ||
       isMacAppDataPath(repo.path)
     ) {
       return
@@ -698,7 +705,8 @@ const WorktreeCard = React.memo(function WorktreeCard({
     linkedGiteaPR,
     fetchHostedReviewForBranch,
     branch,
-    hostedReviewCacheKey
+    hostedReviewCacheKey,
+    usesCoordinatedGitHubRefresh
   ])
 
   // Why: same as above for issues — hidden-surface polling only burns GitHub calls for invisible data.

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -673,12 +673,12 @@ const WorktreeCard = React.memo(function WorktreeCard({
       isFolder ||
       worktree.isBare ||
       !hostedReviewCacheKey ||
-      usesCoordinatedGitHubRefresh ||
       isMacAppDataPath(repo.path)
     ) {
       return
     }
-    // Why: hidden card metadata is revealed on whole-card hover, so fetch lazily instead of always-on polling.
+    // Why: the list coordinator excludes hidden metadata; keep this one-shot
+    // hover refresh card-owned without restoring background polling.
     void fetchHostedReviewForBranch(repo.path, branch, {
       repoId: repo.id,
       linkedGitHubPR: worktree.linkedPR ?? null,
@@ -708,8 +708,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
     linkedGiteaPR,
     fetchHostedReviewForBranch,
     branch,
-    hostedReviewCacheKey,
-    usesCoordinatedGitHubRefresh
+    hostedReviewCacheKey
   ])
 
   // Why: same as above for issues — hidden-surface polling only burns GitHub calls for invisible data.

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -132,6 +132,7 @@ type WorktreeCardProps = {
   nativeDragEnabled?: boolean
   affiliateListMode?: boolean
   statusPrDisplay?: WorktreeCardPrDisplay | null
+  coordinatedGitHubRefresh?: boolean
 }
 
 const EMPTY_WORKSPACE_PORTS = []
@@ -223,7 +224,8 @@ const WorktreeCard = React.memo(function WorktreeCard({
   onLineageToggle,
   isLineageDropTarget = false,
   affiliateListMode = false,
-  statusPrDisplay = null
+  statusPrDisplay = null,
+  coordinatedGitHubRefresh = false
 }: WorktreeCardProps) {
   const openModal = useAppStore((s) => s.openModal)
   const openTaskPage = useAppStore((s) => s.openTaskPage)
@@ -598,9 +600,10 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const showComment = cardProps.includes('comment')
   const showPorts = cardProps.includes('ports')
   const shouldRefreshHostedReview = newCardStyle ? showStatus : showPR
-  // Why: GitHub card refreshes are already batched by WorktreeList's coordinator;
-  // per-card hosted-review polling bypasses that budget and creates a startup stampede.
-  const usesCoordinatedGitHubRefresh = repo ? isGitHubBackedRepo(repo) : false
+  // Why: only sidebar rows are registered with WorktreeList's coordinator;
+  // standalone surfaces must retain their own refresh path.
+  const usesCoordinatedGitHubRefresh =
+    coordinatedGitHubRefresh && repo ? isGitHubBackedRepo(repo) : false
   const detailsHoverControl = useWorktreeCardDetailsHoverControl()
   const hoverDetailsOpen = detailsHoverControl.hoverOpen
 

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -4865,6 +4865,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                     // Why: pinned worktrees mix repos in one section, so only it needs the leading repo identity chip.
                     hostContextLabel={itemRow.hostContextLabel}
                     inPinnedSection={isPinnedOverlayRow}
+                    coordinatedGitHubRefresh
                     renameRowKey={itemRow.rowKey}
                     lineageChildCount={itemRow.lineageChildCount}
                     lineageCollapsed={itemRow.lineageCollapsed}


### PR DESCRIPTION
## Summary

GitHub worktree cards in the sidebar were refreshing review data twice: once from each card and once from the list refresh coordinator.

This change disables per-card GitHub refreshes only when the list coordinator owns them. GitHub cards rendered elsewhere keep their existing polling behavior. GitLab and other hosted review providers are unchanged.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added regression tests for coordinated GitHub cards, standalone GitHub cards, GitLab cards, and hidden review surfaces

The focused regression test passes all 4 cases on the current commit.

Full fork PR verification passed on the current commit, including lint, typecheck, Git compatibility, the full test suite, the unpacked build, and the packaged CLI smoke test.

## AI Review Report

The review checked refresh ownership, React effect dependencies, provider behavior, API usage, and standalone card rendering.

The first version stopped polling for GitHub cards outside the sidebar list. That was fixed by making coordinated refresh an explicit option used only by `WorktreeList`. A regression test now covers standalone GitHub cards.

No shortcuts, paths, shell commands, or platform-specific Electron behavior changed. Local, remote, and SSH worktrees use the same renderer path. No agent behavior changed. GitLab and other hosted review providers keep their existing refresh behavior.

## Security Audit

This change does not touch user input, command execution, file paths, IPC, authentication, credentials, secrets, or dependencies. It only changes which existing renderer path owns GitHub review refreshes.

No security follow-up is needed.

## Notes

No platform-specific behavior changed.

X: @nsxdavid

## ELI5

GitHub review data on worktree cards was fetched twice — once per card and once by the list coordinator. Cards now skip their own poll when the list already owns refresh, cutting duplicate network work.
