### PR TITLE
fix(terminal): recover from transient macOS login preflight failures

### DIFF
--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -127,7 +127,17 @@ async function main(): Promise<void> {
     socketPath,
     tokenPath,
     log: daemonLog,
-    preparePtySpawn: prepareMacosTccLoginShell,
+    preparePtySpawn: () =>
+      prepareMacosTccLoginShell((result) => {
+        // Why: detached daemon stderr is unavailable after startup; record only
+        // capability metadata so PAM output and account details never reach logs.
+        daemonLog.log('macos-login-preflight', {
+          enabled: result.enabled,
+          reason: result.reason,
+          retryable: result.retryable,
+          ...(result.retryAfterMs !== undefined ? { retryAfterMs: result.retryAfterMs } : {})
+        })
+      }),
     spawnSubprocess: (opts) => createPtySubprocess(opts)
   })
 

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -49,6 +49,7 @@ function createMockSubprocess(): SubprocessHandle & {
 
 type DaemonServerPrivate = {
   server: Server | null
+  pendingPtySpawnPreparations: Map<string, Set<unknown>>
   host: {
     kill: (sessionId: string, opts?: { immediate?: boolean }) => void | Promise<void>
   }
@@ -307,6 +308,44 @@ describe('DaemonServer', () => {
       await canceledCreate
       await shutdown
       expect(spawnSubprocess).not.toHaveBeenCalled()
+    })
+
+    it('cancels a pending subprocess when its control client disconnects', async () => {
+      let finishPreparation!: () => void
+      const preparation = new Promise<void>((resolve) => {
+        finishPreparation = resolve
+      })
+      const preparePtySpawn = vi.fn().mockImplementationOnce(() => preparation)
+      const spawnSubprocess = vi.fn(() => createMockSubprocess())
+      server = new DaemonServer({ socketPath, tokenPath, preparePtySpawn, spawnSubprocess })
+      await server.start()
+      const c = await connectClient()
+      const daemon = server as unknown as DaemonServerPrivate
+
+      const create = c.request('createOrAttach', {
+        sessionId: 'disconnected-preparation',
+        cols: 80,
+        rows: 24
+      })
+      const disconnectedCreate = expect(create).rejects.toThrow('Disconnected')
+      await vi.waitFor(() => expect(preparePtySpawn).toHaveBeenCalledOnce())
+
+      c.disconnect()
+      await disconnectedCreate
+      await vi.waitFor(() => expect(daemon.clients.size).toBe(0))
+      finishPreparation()
+      await vi.waitFor(() => expect(daemon.pendingPtySpawnPreparations.size).toBe(0))
+      expect(spawnSubprocess).not.toHaveBeenCalled()
+
+      await c.ensureConnected()
+      await expect(
+        c.request('createOrAttach', {
+          sessionId: 'disconnected-preparation',
+          cols: 80,
+          rows: 24
+        })
+      ).resolves.toMatchObject({ isNew: true })
+      expect(spawnSubprocess).toHaveBeenCalledOnce()
     })
 
     it('persists only an allowlisted launch identity across reattach', async () => {

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -57,6 +57,7 @@ type ConnectedClient = {
 
 type PendingPtySpawnPreparation = {
   canceled: boolean
+  clientId: string
 }
 
 export class DaemonServer {
@@ -249,6 +250,7 @@ export class DaemonServer {
       this.clients.set(hello.clientId, client)
       this.setupControlSocket(socket, hello.clientId)
       if (previous) {
+        this.cancelPendingPtySpawnPreparationsForClient(hello.clientId)
         // Why: a reconnect can reuse a clientId before the old sockets notice
         // their close. Tear them down after installing the new owner so stale
         // close events cannot delete the replacement client entry.
@@ -286,6 +288,7 @@ export class DaemonServer {
         return
       }
       this.streamDataBatcher.clear(clientId)
+      this.cancelPendingPtySpawnPreparationsForClient(clientId)
       client.streamSocket?.destroy()
       this.clients.delete(clientId)
     })
@@ -345,8 +348,8 @@ export class DaemonServer {
     }
   }
 
-  private async preparePtySpawnUnlessCanceled(sessionId: string): Promise<void> {
-    const preparation: PendingPtySpawnPreparation = { canceled: false }
+  private async preparePtySpawnUnlessCanceled(sessionId: string, clientId: string): Promise<void> {
+    const preparation: PendingPtySpawnPreparation = { canceled: false, clientId }
     const pending = this.pendingPtySpawnPreparations.get(sessionId) ?? new Set()
     pending.add(preparation)
     this.pendingPtySpawnPreparations.set(sessionId, pending)
@@ -382,13 +385,23 @@ export class DaemonServer {
     }
   }
 
+  private cancelPendingPtySpawnPreparationsForClient(clientId: string): void {
+    for (const pending of this.pendingPtySpawnPreparations.values()) {
+      for (const preparation of pending) {
+        if (preparation.clientId === clientId) {
+          preparation.canceled = true
+        }
+      }
+    }
+  }
+
   private async routeRequest(clientId: string, request: DaemonRequest): Promise<unknown> {
     const client = this.clients.get(clientId)
 
     switch (request.type) {
       case 'createOrAttach': {
         const p = request.payload
-        await this.preparePtySpawnUnlessCanceled(p.sessionId)
+        await this.preparePtySpawnUnlessCanceled(p.sessionId, clientId)
         const result = await this.host.createOrAttach({
           sessionId: p.sessionId,
           cols: p.cols,

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -267,6 +267,69 @@ describe('LocalPtyProvider', () => {
       expect(spawnMock).toHaveBeenCalledOnce()
     })
 
+    it('dedupes concurrent creation of the same stable session id', async () => {
+      spawnMock.mockClear()
+      let finishPreparation!: () => void
+      prepareMacosTccLoginShellMock.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishPreparation = resolve
+          })
+      )
+
+      const first = provider.spawn({ cols: 80, rows: 24, sessionId: 'shared-session' })
+      const second = provider.spawn({ cols: 132, rows: 44, sessionId: 'shared-session' })
+      await vi.waitFor(() => expect(prepareMacosTccLoginShellMock).toHaveBeenCalledOnce())
+      expect(spawnMock).not.toHaveBeenCalled()
+
+      finishPreparation()
+      await expect(Promise.all([first, second])).resolves.toEqual([
+        { id: 'shared-session', pid: 12345 },
+        { id: 'shared-session', pid: 12345, isReattach: true }
+      ])
+      expect(spawnMock).toHaveBeenCalledOnce()
+      expect(mockProc.resize).toHaveBeenCalledWith(132, 44)
+    })
+
+    it('cancels a pending spawn owned by an older renderer generation', async () => {
+      spawnMock.mockClear()
+      let finishPreparation!: () => void
+      prepareMacosTccLoginShellMock.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishPreparation = resolve
+          })
+      )
+
+      const spawn = provider.spawn({ cols: 80, rows: 24, sessionId: 'reload-pending' })
+      const canceledSpawn = expect(spawn).rejects.toThrow('PTY spawn canceled: reload-pending')
+      await vi.waitFor(() => expect(prepareMacosTccLoginShellMock).toHaveBeenCalledOnce())
+
+      const generation = provider.advanceGeneration()
+      expect(provider.killOrphanedPtys(generation)).toEqual([{ id: 'reload-pending' }])
+      finishPreparation()
+      await canceledSpawn
+      expect(spawnMock).not.toHaveBeenCalled()
+    })
+
+    it('cancels a stale replacement waiting for the previous PTY to exit', async () => {
+      const first = await provider.spawn({ cols: 80, rows: 24, sessionId: 'reload-replacement' })
+      spawnMock.mockClear()
+      mockProc.kill = vi.fn()
+      const shutdown = provider.shutdown(first.id, { immediate: true })
+      const replacement = provider.spawn({ cols: 100, rows: 30, sessionId: first.id })
+      const canceledReplacement = expect(replacement).rejects.toThrow(
+        'PTY spawn canceled: reload-replacement'
+      )
+
+      const generation = provider.advanceGeneration()
+      expect(provider.killOrphanedPtys(generation)).toEqual([{ id: first.id }])
+      exitCb?.({ exitCode: 137 })
+      await shutdown
+      await canceledReplacement
+      expect(spawnMock).not.toHaveBeenCalled()
+    })
+
     it('calls node-pty spawn with correct args', async () => {
       await provider.spawn({ cols: 120, rows: 40, cwd: '/tmp' })
       expect(spawnMock).toHaveBeenCalledWith(

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -93,8 +93,10 @@ type PtyShutdownOperation = {
 const ptyShutdownOperations = new Map<string, PtyShutdownOperation>()
 type PendingLocalPtySpawn = {
   canceled: boolean
+  generation: number
 }
 const pendingLocalPtySpawns = new Map<string, Set<PendingLocalPtySpawn>>()
+const pendingStableLocalPtySpawnResults = new Map<string, Promise<PtySpawnResult>>()
 const ptyShellName = new Map<string, string>()
 const ptyAgentForegroundContextPaths = new Map<string, string[]>()
 // Why: remembers the last positively-recognized agent foreground per PTY so a
@@ -318,8 +320,8 @@ function allocatePtyId(sessionId: string | undefined): string {
   return id
 }
 
-async function prepareLocalPtySpawn(id: string): Promise<void> {
-  const pendingSpawn: PendingLocalPtySpawn = { canceled: false }
+async function prepareLocalPtySpawn(id: string, generation: number): Promise<void> {
+  const pendingSpawn: PendingLocalPtySpawn = { canceled: false, generation }
   const pending = pendingLocalPtySpawns.get(id) ?? new Set()
   pending.add(pendingSpawn)
   pendingLocalPtySpawns.set(id, pending)
@@ -509,11 +511,46 @@ export class LocalPtyProvider implements IPtyProvider {
    * method preserves that state so the stdin fallback only runs when needed.
    */
   async spawn(args: PtySpawnOptions): Promise<PtySpawnResult> {
+    const stableId = normalizeLocalCallerSessionId(args.sessionId)
+    if (!stableId) {
+      return this.spawnOnce(args)
+    }
+
+    const pending = pendingStableLocalPtySpawnResults.get(stableId)
+    if (pending) {
+      const result = await pending
+      const existing = ptyProcesses.get(stableId)
+      try {
+        existing?.resize(args.cols, args.rows)
+      } catch {
+        /* Existing PTY may reject resize during teardown; preserve reattach semantics. */
+      }
+      return { id: stableId, pid: existing?.pid ?? result.pid, isReattach: true }
+    }
+
+    const spawnResult = this.spawnOnce(args)
+    pendingStableLocalPtySpawnResults.set(stableId, spawnResult)
+    try {
+      return await spawnResult
+    } finally {
+      if (pendingStableLocalPtySpawnResults.get(stableId) === spawnResult) {
+        pendingStableLocalPtySpawnResults.delete(stableId)
+      }
+    }
+  }
+
+  private async spawnOnce(args: PtySpawnOptions): Promise<PtySpawnResult> {
+    const spawnGeneration = loadGeneration
     const reattachId = normalizeLocalCallerSessionId(args.sessionId)
     if (reattachId) {
       const pendingShutdown = ptyShutdownOperations.get(reattachId)
       if (pendingShutdown) {
         await pendingShutdown.promise
+        // Why: orphan cleanup can run while this spawn waits for an older PTY
+        // owner; do not register the replacement under a stale page load.
+        if (spawnGeneration < loadGeneration) {
+          throw new Error(`PTY spawn canceled: ${reattachId}`)
+        }
       }
       const existing = ptyProcesses.get(reattachId)
       if (existing) {
@@ -836,7 +873,7 @@ export class LocalPtyProvider implements IPtyProvider {
       logHistoryInjection(worktreeId, historyResult)
     }
 
-    await prepareLocalPtySpawn(id)
+    await prepareLocalPtySpawn(id, spawnGeneration)
     const spawnResult = spawnShellWithFallback({
       shellPath,
       shellArgs,
@@ -887,7 +924,7 @@ export class LocalPtyProvider implements IPtyProvider {
       id,
       getAgentForegroundContextPaths({ cwd: args.cwd, worktreeId: args.worktreeId })
     )
-    ptyLoadGeneration.set(id, loadGeneration)
+    ptyLoadGeneration.set(id, spawnGeneration)
     this.opts.onSpawned?.(id)
 
     // Shell-ready startup command support
@@ -1364,10 +1401,24 @@ export class LocalPtyProvider implements IPtyProvider {
   /** Kill orphaned PTYs from previous page loads. */
   killOrphanedPtys(currentGeneration: number): { id: string }[] {
     const killed: { id: string }[] = []
+    const killedIds = new Set<string>()
+    for (const [id, pendingSpawns] of pendingLocalPtySpawns) {
+      for (const pendingSpawn of pendingSpawns) {
+        if (pendingSpawn.generation < currentGeneration) {
+          pendingSpawn.canceled = true
+          killedIds.add(id)
+        }
+      }
+    }
+    for (const id of killedIds) {
+      killed.push({ id })
+    }
     for (const [id, proc] of ptyProcesses) {
       if ((ptyLoadGeneration.get(id) ?? -1) < currentGeneration) {
         requestPtyTermination(id, proc)
-        killed.push({ id })
+        if (!killedIds.has(id)) {
+          killed.push({ id })
+        }
       }
     }
     return killed
@@ -1411,6 +1462,7 @@ export class LocalPtyProvider implements IPtyProvider {
 export function _resetLocalPtyProviderStateForTest(): void {
   cancelAllPendingLocalPtySpawns()
   pendingLocalPtySpawns.clear()
+  pendingStableLocalPtySpawnResults.clear()
   for (const id of ptyProcesses.keys()) {
     clearPtyState(id)
   }

--- a/src/main/providers/macos-tcc-login-shell.test.ts
+++ b/src/main/providers/macos-tcc-login-shell.test.ts
@@ -17,7 +17,11 @@ import {
   wrapShellSpawnForMacosTccAttribution
 } from './macos-tcc-login-shell'
 
-type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void
+type ExecFileCallback = (
+  error: (Error & { code?: string; killed?: boolean }) | null,
+  stdout: string,
+  stderr: string
+) => void
 
 describe('wrapShellSpawnForMacosTccAttribution', () => {
   let origPlatform: PropertyDescriptor | undefined
@@ -51,6 +55,7 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     } else {
       process.env.ORCA_DISABLE_MACOS_LOGIN_SHELL = origDisable
     }
+    vi.restoreAllMocks()
     vi.clearAllMocks()
   })
 
@@ -92,15 +97,27 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
       args: ['-l']
     })
     expect(console.warn).toHaveBeenCalledWith(
-      '[pty] macOS login(1) preflight failed; spawning shells directly'
+      '[pty] macOS login(1) preflight pam-rejected; spawning shells directly'
     )
+    await prepareMacosTccLoginShell()
+    expect(execFileMock).toHaveBeenCalledOnce()
   })
 
-  it('caches a failed login preflight for later terminal spawns', async () => {
+  it('retries a timeout after backoff instead of caching the fallback permanently', async () => {
     setPlatform('darwin')
+    let now = 1_000
+    vi.spyOn(Date, 'now').mockImplementation(() => now)
     execFileMock.mockImplementation(
       (_file: string, _args: string[], _options: unknown, callback: ExecFileCallback) => {
-        callback(new Error('timed out'), '', '')
+        if (execFileMock.mock.calls.length === 1) {
+          callback(
+            Object.assign(new Error('timed out'), { code: 'ETIMEDOUT', killed: true }),
+            '',
+            ''
+          )
+        } else {
+          callback(null, 'ORCA_LOGIN_PREFLIGHT_OK', '')
+        }
         return { stdin: { end: stdinEndMock } }
       }
     )
@@ -109,9 +126,13 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     await prepareMacosTccLoginShell()
     await prepareMacosTccLoginShell()
     expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l']).file).toBe('/bin/zsh')
-    expect(wrapShellSpawnForMacosTccAttribution('/bin/bash', ['-l']).file).toBe('/bin/bash')
     expect(execFileMock).toHaveBeenCalledTimes(1)
     expect(console.warn).toHaveBeenCalledTimes(1)
+
+    now += 5_000
+    await prepareMacosTccLoginShell()
+    expect(execFileMock).toHaveBeenCalledTimes(2)
+    expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l']).file).toBe('/usr/bin/login')
   })
 
   it('rejects a marker emitted by a preflight that does not exit cleanly', async () => {
@@ -132,6 +153,62 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l'])).toEqual({
       file: '/bin/zsh',
       args: ['-l']
+    })
+
+    await prepareMacosTccLoginShell()
+    expect(execFileMock).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    [
+      Object.assign(new Error('too much output'), { code: 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER' }),
+      '',
+      'output-limit'
+    ],
+    [null, 'unexpected clean output', 'unexpected-output'],
+    [Object.assign(new Error('spawn failed'), { code: 'EAGAIN' }), '', 'exec-error']
+  ] as const)('treats %s as a transient %s failure', async (error, stdout, reason) => {
+    setPlatform('darwin')
+    let now = 10_000
+    vi.spyOn(Date, 'now').mockImplementation(() => now)
+    const report = vi.fn()
+    execFileMock.mockImplementation(
+      (_file: string, _args: string[], _options: unknown, callback: ExecFileCallback) => {
+        callback(error, stdout, '')
+        return { stdin: { end: stdinEndMock } }
+      }
+    )
+
+    await prepareMacosTccLoginShell(report)
+    await prepareMacosTccLoginShell(report)
+    expect(execFileMock).toHaveBeenCalledOnce()
+    expect(report).toHaveBeenCalledWith({
+      enabled: false,
+      reason,
+      retryable: true,
+      retryAfterMs: 5_000
+    })
+
+    now += 5_000
+    await prepareMacosTccLoginShell(report)
+    expect(execFileMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('reports one safe result per actual attempt and ignores reporter failures', async () => {
+    setPlatform('darwin')
+    const report = vi.fn(() => {
+      throw new Error('log unavailable')
+    })
+
+    await expect(
+      Promise.all([prepareMacosTccLoginShell(report), prepareMacosTccLoginShell(report)])
+    ).resolves.toEqual([undefined, undefined])
+    expect(execFileMock).toHaveBeenCalledOnce()
+    expect(report).toHaveBeenCalledOnce()
+    expect(report).toHaveBeenCalledWith({
+      enabled: true,
+      reason: 'supported',
+      retryable: false
     })
   })
 

--- a/src/main/providers/macos-tcc-login-shell.ts
+++ b/src/main/providers/macos-tcc-login-shell.ts
@@ -8,6 +8,8 @@ const MACOS_PRINTF_PATH = '/usr/bin/printf'
 const LOGIN_PREFLIGHT_TIMEOUT_MS = 500
 const LOGIN_PREFLIGHT_MARKER = 'ORCA_LOGIN_PREFLIGHT_OK'
 const LOGIN_PREFLIGHT_MAX_BUFFER_BYTES = 1024
+const LOGIN_PREFLIGHT_RETRY_BASE_MS = 5_000
+const LOGIN_PREFLIGHT_RETRY_MAX_MS = 5 * 60_000
 
 /**
  * Env escape hatch to force the plain (unwrapped) spawn. Set to `1`/`true` if a
@@ -16,15 +18,76 @@ const LOGIN_PREFLIGHT_MAX_BUFFER_BYTES = 1024
  */
 const DISABLE_ENV_VAR = 'ORCA_DISABLE_MACOS_LOGIN_SHELL'
 
-let cachedLoginPreflightResult: boolean | null = null
-let loginPreflightInFlight: Promise<boolean> | null = null
+export type MacosTccLoginPreflightReason =
+  | 'supported'
+  | 'pam-rejected'
+  | 'timeout'
+  | 'output-limit'
+  | 'unexpected-output'
+  | 'exec-error'
+
+export type MacosTccLoginPreflightResult = {
+  enabled: boolean
+  reason: MacosTccLoginPreflightReason
+  retryable: boolean
+  retryAfterMs?: number
+}
+
+type LoginPreflightError = Error & {
+  code?: string | number | null
+  killed?: boolean
+}
+
+type TransientLoginPreflightFailure = {
+  failureCount: number
+  reason: MacosTccLoginPreflightReason
+  retryAtMs: number
+}
+
+let cachedLoginPreflightResult: MacosTccLoginPreflightResult | null = null
+let transientLoginPreflightFailure: TransientLoginPreflightFailure | null = null
+let loginPreflightInFlight: Promise<MacosTccLoginPreflightResult> | null = null
 
 function isDisabledByEnv(): boolean {
   const value = process.env[DISABLE_ENV_VAR]
   return value === '1' || value === 'true'
 }
 
-function runLoginPreflight(username: string, accountHome: string): Promise<boolean> {
+function retryDelayMs(failureCount: number): number {
+  return Math.min(
+    LOGIN_PREFLIGHT_RETRY_MAX_MS,
+    LOGIN_PREFLIGHT_RETRY_BASE_MS * 2 ** Math.max(0, failureCount - 1)
+  )
+}
+
+function classifyLoginPreflight(
+  error: LoginPreflightError | null,
+  stdout: string
+): Omit<MacosTccLoginPreflightResult, 'retryAfterMs'> {
+  // Why: the probe uses pipes while production uses a PTY. Treat ambiguous
+  // output as retryable so a tty-sensitive PAM stack is never disabled forever.
+  if (error?.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') {
+    return { enabled: false, reason: 'output-limit', retryable: true }
+  }
+  if (error?.code === 'ETIMEDOUT' || error?.killed) {
+    return { enabled: false, reason: 'timeout', retryable: true }
+  }
+  if (!error && stdout === LOGIN_PREFLIGHT_MARKER) {
+    return { enabled: true, reason: 'supported', retryable: false }
+  }
+  if (/Login incorrect|(?:^|\n)login:\s*/i.test(stdout)) {
+    return { enabled: false, reason: 'pam-rejected', retryable: false }
+  }
+  if (error) {
+    return { enabled: false, reason: 'exec-error', retryable: true }
+  }
+  return { enabled: false, reason: 'unexpected-output', retryable: true }
+}
+
+function runLoginPreflight(
+  username: string,
+  accountHome: string
+): Promise<Omit<MacosTccLoginPreflightResult, 'retryAfterMs'>> {
   return new Promise((resolve) => {
     try {
       const child = execFile(
@@ -44,46 +107,85 @@ function runLoginPreflight(username: string, accountHome: string): Promise<boole
         (error, stdout) => {
           // login(1) can return zero after an EOF-driven failed prompt, so only the
           // requested child program's output plus a clean exit proves PAM accepted it.
-          resolve(error === null && stdout === LOGIN_PREFLIGHT_MARKER)
+          resolve(classifyLoginPreflight(error, stdout))
         }
       )
       // Why: login(1) must see immediate EOF, not an interactive pipe, so a PAM
       // rejection exits instead of waiting at `login:` until the timeout.
       child.stdin?.end()
-    } catch {
-      resolve(false)
+    } catch (error) {
+      resolve(classifyLoginPreflight(error as LoginPreflightError, ''))
     }
   })
 }
 
-function loginPreflightSucceeds(username: string, accountHome: string): Promise<boolean> {
-  if (cachedLoginPreflightResult !== null) {
+function getLoginPreflightResult(
+  username: string,
+  accountHome: string,
+  report?: (result: MacosTccLoginPreflightResult) => void
+): Promise<MacosTccLoginPreflightResult> {
+  if (cachedLoginPreflightResult) {
     return Promise.resolve(cachedLoginPreflightResult)
   }
+
+  const now = Date.now()
+  if (transientLoginPreflightFailure && now < transientLoginPreflightFailure.retryAtMs) {
+    return Promise.resolve({
+      enabled: false,
+      reason: transientLoginPreflightFailure.reason,
+      retryable: true,
+      retryAfterMs: transientLoginPreflightFailure.retryAtMs - now
+    })
+  }
+
   if (!loginPreflightInFlight) {
     // Why: simultaneous pane restores share one PAM child instead of multiplying
     // subprocesses at exactly the point terminal startup is already busiest.
-    loginPreflightInFlight = runLoginPreflight(username, accountHome).then((result) => {
-      cachedLoginPreflightResult = result
-      if (!result) {
-        console.warn('[pty] macOS login(1) preflight failed; spawning shells directly')
-      }
-      return result
-    })
+    loginPreflightInFlight = runLoginPreflight(username, accountHome)
+      .then((attempt) => {
+        let result: MacosTccLoginPreflightResult = attempt
+        if (attempt.retryable) {
+          const failureCount = (transientLoginPreflightFailure?.failureCount ?? 0) + 1
+          const delayMs = retryDelayMs(failureCount)
+          transientLoginPreflightFailure = {
+            failureCount,
+            reason: attempt.reason,
+            retryAtMs: Date.now() + delayMs
+          }
+          result = { ...attempt, retryAfterMs: delayMs }
+        } else {
+          cachedLoginPreflightResult = attempt
+          transientLoginPreflightFailure = null
+        }
+
+        try {
+          report?.(result)
+        } catch {
+          // Diagnostics must never affect whether a user's shell can spawn.
+        }
+        if (!report && !result.enabled) {
+          console.warn(`[pty] macOS login(1) preflight ${result.reason}; spawning shells directly`)
+        }
+        return result
+      })
+      .finally(() => {
+        loginPreflightInFlight = null
+      })
   }
   return loginPreflightInFlight
 }
 
 /**
- * Resolves the one-time PAM capability check before a fresh PTY is spawned.
- * Callers await this at their async request boundary so existing terminals and
- * the Electron main thread remain responsive while login(1) runs.
+ * Resolves the PAM capability check before a fresh PTY is spawned. Deterministic
+ * outcomes are cached; environmental failures fail open and retry with backoff.
  */
-export async function prepareMacosTccLoginShell(): Promise<void> {
+export async function prepareMacosTccLoginShell(
+  report?: (result: MacosTccLoginPreflightResult) => void
+): Promise<void> {
   if (process.platform !== 'darwin' || isDisabledByEnv()) {
     return
   }
-  if (cachedLoginPreflightResult !== null) {
+  if (cachedLoginPreflightResult) {
     return
   }
   if (!existsSync(MACOS_LOGIN_PATH)) {
@@ -102,11 +204,12 @@ export async function prepareMacosTccLoginShell(): Promise<void> {
   if (!username || !accountHome) {
     return
   }
-  await loginPreflightSucceeds(username, accountHome)
+  await getLoginPreflightResult(username, accountHome, report)
 }
 
 export function resetMacosLoginShellPreflightForTests(): void {
   cachedLoginPreflightResult = null
+  transientLoginPreflightFailure = null
   loginPreflightInFlight = null
 }
 
@@ -149,7 +252,7 @@ export function wrapShellSpawnForMacosTccAttribution(
   }
   // Why: an unprepared or failed host must fail open to a usable direct shell;
   // production fresh-spawn boundaries await prepareMacosTccLoginShell first.
-  if (cachedLoginPreflightResult !== true) {
+  if (!cachedLoginPreflightResult?.enabled) {
     return { file, args }
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #9301. This keeps the macOS TCC attribution fix enabled after temporary PAM probe failures and closes the small spawn-lifecycle races identified in post-merge review.

- Cache only deterministic outcomes: successful support or explicit PAM rejection.
- Treat timeout, output-limit, unexpected-output, and process-launch failures as transient.
- Fail open to a direct shell, then retry with exponential backoff from 5 seconds to a 5 minute cap.
- Emit a structured `macos-login-preflight` daemon event containing only `enabled`, `reason`, `retryable`, and optional `retryAfterMs`.
- Deduplicate concurrent local spawns with the same stable session id.
- Cancel pending local spawns during renderer orphan cleanup and pending daemon spawns when their control client disconnects.

## ELI5

The first version asks macOS whether Orca can launch shells in the privacy-friendly way. If macOS was merely slow once, Orca remembered that as a permanent no until restart. This follow-up remembers only real yes/no answers. Temporary failures use the normal shell so terminals still open, then Orca tries again later.

It also makes sure two requests cannot accidentally create two shells for the same terminal, and that a request abandoned by a reload or disconnect cannot finish in the background.

## Safety and performance

- Healthy and explicitly rejected PAM results remain process-cached, so normal terminal startup still probes once.
- Concurrent callers share one probe.
- Persistent transient failures can add at most the existing 500 ms probe timeout when a later terminal request crosses the backoff boundary; backoff grows to 5 minutes.
- Probe diagnostics never include username, home directory, cwd, stdout, stderr, or other PAM/account data.
- The PAM path remains Darwin-gated. Linux, Windows, WSL, and SSH shell wrapping behavior is unchanged.
- Legacy v22 hibernated-session wake behavior remains intentionally unchanged because it is transitional and self-healing.

## Validation

- Real macOS `/usr/bin/login` preflight: success in 56 ms with the production 500 ms timeout and 1 KiB output cap.
- Focused post-rebase suite: 137 tests passed.
- Broader PTY/daemon/IPC suite: 453 tests passed.
- `pnpm run typecheck:node`
- `pnpm exec oxlint` on all changed files
- `pnpm exec oxfmt --check` on all changed files
- `pnpm run check:max-lines-ratchet`
- `pnpm run check:reliability-gates`
- `git diff --check`

## Screenshots

No visual change.

## AI Review Report

- CodeRabbit initial review: no actionable comments.
- Manual review additionally found and closed the stale-generation window while a replacement waits for the previous local PTY to exit.
- Final-head CI is green; CodeRabbit posted no actionable comments.

## Security Audit

- The probe still uses fixed absolute binaries and literal argv elements with no shell interpolation.
- PAM output, account identity, environment, and paths are not logged.
- Failure remains fail-open to the pre-#9301 direct-shell behavior.
- Disconnect and reload cancellation reduce untracked shell lifetime rather than expanding process authority.

## Notes

- No protocol change is required.
- Legacy v22 hibernated-session wake behavior is out of scope because it is transitional and self-healing.
- The automated docstring-coverage suggestion was not applied because these are short private lifecycle helpers and boilerplate comments would not improve maintainability.

