### PR TITLE
fix(source-control): preserve section collapse state

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -115,6 +115,7 @@ import {
   type SourceControlEntryGroups,
   type SourceControlSectionArea
 } from './source-control-section-order'
+import { useSourceControlSectionCollapseState } from './source-control-section-collapse-state'
 import { SourceControlVirtualFileList } from './source-control-virtual-file-list'
 import { selectReviewCacheData, selectReviewCacheEntry } from './review-cache-entry-selection'
 import {
@@ -544,17 +545,12 @@ const SOURCE_CONTROL_TREE_INDENT_PX = 12
 const SOURCE_CONTROL_TREE_DIRECTORY_PADDING_PX = 8
 const SOURCE_CONTROL_TREE_FILE_PADDING_PX = 20
 const EMPTY_GIT_HISTORY_STATE: GitHistoryPanelState = { status: 'idle' }
-const DEFAULT_COLLAPSED_SECTIONS = ['history'] as const
 const SUBMODULE_WORKTREE_ONLY_LABEL = 'Stage inside submodule'
 const SUBMODULE_WORKTREE_ONLY_TOOLTIP =
   'The parent repo (including Stage All) cannot stage file changes inside a submodule'
 const SUBMODULE_LOADING_LABEL = 'Loading submodule changes…'
 const SUBMODULE_EMPTY_LABEL = 'No changes in submodule'
 const SUBMODULE_ERROR_LABEL = 'Failed to load submodule changes'
-
-function createDefaultCollapsedSections(): Set<string> {
-  return new Set(DEFAULT_COLLAPSED_SECTIONS)
-}
 
 function useCopyFeedbackState<T>(resetValue: T): [T, (value: T) => void] {
   const [value, setValue] = useState(resetValue)
@@ -1054,9 +1050,8 @@ function SourceControlInner(): React.JSX.Element {
   ])
 
   const [filterExpanded, setFilterExpanded] = useState(false)
-  const [collapsedSections, setCollapsedSections] = useState<Set<string>>(
-    createDefaultCollapsedSections
-  )
+  const { collapsedSections, toggleSection } =
+    useSourceControlSectionCollapseState(activeWorktreeId)
   const persistedSourceControlViewMode = normalizeSourceControlViewMode(
     settings?.sourceControlViewMode
   )
@@ -2074,7 +2069,6 @@ function SourceControlInner(): React.JSX.Element {
   // worktree's UI state doesn't leak into the new one.
   useEffect(() => {
     setFilterExpanded(false)
-    setCollapsedSections(createDefaultCollapsedSections())
     setCollapsedTreeDirs(new Set())
     setBaseRefDialogOpen(false)
     setPendingDiscard(null)
@@ -5105,18 +5099,6 @@ function SourceControlInner(): React.JSX.Element {
     isFolder,
     worktreePath
   ])
-
-  const toggleSection = useCallback((section: string) => {
-    setCollapsedSections((prev) => {
-      const next = new Set(prev)
-      if (next.has(section)) {
-        next.delete(section)
-      } else {
-        next.add(section)
-      }
-      return next
-    })
-  }, [])
 
   const toggleTreeDir = useCallback((key: string) => {
     setCollapsedTreeDirs((prev) => {

--- a/src/renderer/src/components/right-sidebar/SourceControl.virtual-file-list.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.virtual-file-list.test.tsx
@@ -371,6 +371,7 @@ describe('SourceControl virtualized changed-files list', () => {
     const remountedChangesHeader = Array.from(container.querySelectorAll('button')).find((button) =>
       button.textContent?.includes('Changes')
     )
+    expect(remountedChangesHeader).toBeTruthy()
     act(() => {
       remountedChangesHeader?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })

--- a/src/renderer/src/components/right-sidebar/SourceControl.virtual-file-list.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.virtual-file-list.test.tsx
@@ -11,6 +11,7 @@ import {
   SOURCE_CONTROL_FILE_ROW_OVERSCAN,
   SOURCE_CONTROL_VIRTUALIZE_MIN_ROWS
 } from './source-control-virtual-file-list'
+import { clearSourceControlSectionCollapseStateForTests } from './source-control-section-collapse-state'
 
 const mocks = vi.hoisted(() => {
   const activeRepo = {
@@ -195,6 +196,7 @@ class NoopResizeObserver {
 
 beforeEach(() => {
   globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  clearSourceControlSectionCollapseStateForTests()
   resetState()
   container = document.createElement('div')
   document.body.appendChild(container)
@@ -235,6 +237,7 @@ beforeEach(() => {
 afterEach(() => {
   act(() => root.unmount())
   container.remove()
+  clearSourceControlSectionCollapseStateForTests()
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
 })
@@ -339,7 +342,7 @@ describe('SourceControl virtualized changed-files list', () => {
     expect(row('src/file-000.ts')?.className).toContain('bg-accent/60')
   })
 
-  it('collapses and re-expands a virtualized section', () => {
+  it('keeps a virtualized section collapsed across a Source Control remount', () => {
     resetState({
       gitStatusByWorktree: { [mocks.activeWorktree.id]: manyEntries(500) }
     })
@@ -357,8 +360,19 @@ describe('SourceControl virtualized changed-files list', () => {
     expect(mountedRows().length).toBe(0)
     expect(virtualList()).toBeNull()
 
+    // Simulate visiting Explorer or Checks, which fully unmounts Source Control.
+    act(() => root.unmount())
+    root = createRoot(container)
+    renderSourceControl()
+
+    expect(mountedRows().length).toBe(0)
+    expect(virtualList()).toBeNull()
+
+    const remountedChangesHeader = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Changes')
+    )
     act(() => {
-      changesHeader?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      remountedChangesHeader?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
     expect(mountedRows().length).toBeGreaterThan(0)
     expect(mountedRows().length).toBeLessThanOrEqual(MAX_MOUNTED_ROWS)

--- a/src/renderer/src/components/right-sidebar/source-control-section-collapse-state.test.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control-section-collapse-state.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  clearSourceControlSectionCollapseStateForTests,
+  getSourceControlSectionCollapseStateCountForTests,
+  MAX_PERSISTED_SOURCE_CONTROL_SECTION_STATES,
+  seedSourceControlSectionCollapseStateForTests,
+  useSourceControlSectionCollapseState,
+  type SourceControlCollapsibleSectionId
+} from './source-control-section-collapse-state'
+
+let container: HTMLDivElement
+let root: Root
+
+function Probe({
+  worktreeId,
+  section
+}: {
+  worktreeId: string
+  section: SourceControlCollapsibleSectionId
+}): React.JSX.Element {
+  const { collapsedSections, toggleSection } = useSourceControlSectionCollapseState(worktreeId)
+  return (
+    <button
+      type="button"
+      data-collapsed={collapsedSections.has(section) ? 'true' : 'false'}
+      onClick={() => toggleSection(section)}
+    >
+      toggle
+    </button>
+  )
+}
+
+function renderProbe(worktreeId: string, section: SourceControlCollapsibleSectionId): void {
+  act(() => root.render(<Probe worktreeId={worktreeId} section={section} />))
+}
+
+function readCollapsed(): string | null {
+  return container.querySelector('button')?.getAttribute('data-collapsed') ?? null
+}
+
+function toggle(): void {
+  act(() => {
+    container.querySelector('button')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+describe('useSourceControlSectionCollapseState', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    clearSourceControlSectionCollapseStateForTests()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    clearSourceControlSectionCollapseStateForTests()
+  })
+
+  it('restores a worktree section after the hook consumer remounts', () => {
+    renderProbe('wt-a', 'unstaged')
+    expect(readCollapsed()).toBe('false')
+
+    toggle()
+    expect(readCollapsed()).toBe('true')
+
+    act(() => root.unmount())
+    root = createRoot(container)
+    renderProbe('wt-a', 'unstaged')
+
+    expect(readCollapsed()).toBe('true')
+  })
+
+  it('isolates disclosure choices between worktrees', () => {
+    renderProbe('wt-a', 'unstaged')
+    toggle()
+    expect(readCollapsed()).toBe('true')
+
+    renderProbe('wt-b', 'unstaged')
+    expect(readCollapsed()).toBe('false')
+
+    renderProbe('wt-a', 'unstaged')
+    expect(readCollapsed()).toBe('true')
+  })
+
+  it('keeps history collapsed by default and drops restored defaults from the cache', () => {
+    renderProbe('wt-a', 'history')
+    expect(readCollapsed()).toBe('true')
+
+    toggle()
+    expect(readCollapsed()).toBe('false')
+    expect(getSourceControlSectionCollapseStateCountForTests()).toBe(1)
+
+    toggle()
+    expect(readCollapsed()).toBe('true')
+    expect(getSourceControlSectionCollapseStateCountForTests()).toBe(0)
+  })
+
+  it('bounds non-default worktree state retained by the renderer session', () => {
+    const newestIndex = MAX_PERSISTED_SOURCE_CONTROL_SECTION_STATES + 24
+    for (let index = 0; index <= newestIndex; index++) {
+      seedSourceControlSectionCollapseStateForTests(`wt-${index}`, new Set(['history', 'unstaged']))
+    }
+
+    expect(getSourceControlSectionCollapseStateCountForTests()).toBe(
+      MAX_PERSISTED_SOURCE_CONTROL_SECTION_STATES
+    )
+
+    renderProbe('wt-0', 'unstaged')
+    expect(readCollapsed()).toBe('false')
+    renderProbe(`wt-${newestIndex}`, 'unstaged')
+    expect(readCollapsed()).toBe('true')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control-section-collapse-state.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-section-collapse-state.ts
@@ -7,9 +7,8 @@ const DEFAULT_COLLAPSED_SECTIONS: ReadonlySet<SourceControlCollapsibleSectionId>
   'history'
 ])
 
-// Why: Source Control unmounts when another right-sidebar tab is selected.
-// Keep disclosure choices in a bounded renderer-session cache so tab and
-// worktree round trips restore them without turning transient UI into settings.
+// Why: Source Control unmounts with its sidebar tab, so a bounded session cache restores
+// disclosure choices without promoting transient UI state to persistent settings.
 export const MAX_PERSISTED_SOURCE_CONTROL_SECTION_STATES = 512
 const collapsedSectionsByWorktreeId = new Map<
   string,

--- a/src/renderer/src/components/right-sidebar/source-control-section-collapse-state.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-section-collapse-state.ts
@@ -1,0 +1,111 @@
+import { useCallback, useState } from 'react'
+import type { SourceControlDisplaySectionId } from './source-control-section-order'
+
+export type SourceControlCollapsibleSectionId = SourceControlDisplaySectionId | 'branch' | 'history'
+
+const DEFAULT_COLLAPSED_SECTIONS: ReadonlySet<SourceControlCollapsibleSectionId> = new Set([
+  'history'
+])
+
+// Why: Source Control unmounts when another right-sidebar tab is selected.
+// Keep disclosure choices in a bounded renderer-session cache so tab and
+// worktree round trips restore them without turning transient UI into settings.
+export const MAX_PERSISTED_SOURCE_CONTROL_SECTION_STATES = 512
+const collapsedSectionsByWorktreeId = new Map<
+  string,
+  ReadonlySet<SourceControlCollapsibleSectionId>
+>()
+
+function trimPersistedSectionStates(): void {
+  while (collapsedSectionsByWorktreeId.size > MAX_PERSISTED_SOURCE_CONTROL_SECTION_STATES) {
+    const oldestWorktreeId = collapsedSectionsByWorktreeId.keys().next().value
+    if (oldestWorktreeId === undefined) {
+      break
+    }
+    collapsedSectionsByWorktreeId.delete(oldestWorktreeId)
+  }
+}
+
+function matchesDefaultState(
+  collapsedSections: ReadonlySet<SourceControlCollapsibleSectionId>
+): boolean {
+  return (
+    collapsedSections.size === DEFAULT_COLLAPSED_SECTIONS.size &&
+    Array.from(DEFAULT_COLLAPSED_SECTIONS).every((section) => collapsedSections.has(section))
+  )
+}
+
+function readCollapsedSections(
+  worktreeId: string | null
+): ReadonlySet<SourceControlCollapsibleSectionId> {
+  return worktreeId
+    ? (collapsedSectionsByWorktreeId.get(worktreeId) ?? DEFAULT_COLLAPSED_SECTIONS)
+    : DEFAULT_COLLAPSED_SECTIONS
+}
+
+function persistCollapsedSections(
+  worktreeId: string,
+  collapsedSections: ReadonlySet<SourceControlCollapsibleSectionId>
+): void {
+  collapsedSectionsByWorktreeId.delete(worktreeId)
+  if (matchesDefaultState(collapsedSections)) {
+    return
+  }
+  collapsedSectionsByWorktreeId.set(worktreeId, collapsedSections)
+  trimPersistedSectionStates()
+}
+
+export type SourceControlSectionCollapseControls = {
+  collapsedSections: ReadonlySet<SourceControlCollapsibleSectionId>
+  toggleSection: (section: SourceControlCollapsibleSectionId) => void
+}
+
+export function useSourceControlSectionCollapseState(
+  worktreeId: string | null
+): SourceControlSectionCollapseControls {
+  const [rendered, setRendered] = useState<{
+    worktreeId: string | null
+    collapsedSections: ReadonlySet<SourceControlCollapsibleSectionId>
+  }>(() => ({ worktreeId, collapsedSections: readCollapsedSections(worktreeId) }))
+
+  // Why: the component stays mounted across worktree switches, so read the
+  // incoming worktree's cache instead of briefly exposing the previous state.
+  const collapsedSections =
+    rendered.worktreeId === worktreeId
+      ? rendered.collapsedSections
+      : readCollapsedSections(worktreeId)
+
+  const toggleSection = useCallback(
+    (section: SourceControlCollapsibleSectionId): void => {
+      if (!worktreeId) {
+        return
+      }
+      const next = new Set(readCollapsedSections(worktreeId))
+      if (next.has(section)) {
+        next.delete(section)
+      } else {
+        next.add(section)
+      }
+      persistCollapsedSections(worktreeId, next)
+      setRendered({ worktreeId, collapsedSections: next })
+    },
+    [worktreeId]
+  )
+
+  return { collapsedSections, toggleSection }
+}
+
+export function clearSourceControlSectionCollapseStateForTests(): void {
+  collapsedSectionsByWorktreeId.clear()
+}
+
+export function getSourceControlSectionCollapseStateCountForTests(): number {
+  return collapsedSectionsByWorktreeId.size
+}
+
+export function seedSourceControlSectionCollapseStateForTests(
+  worktreeId: string,
+  collapsedSections: ReadonlySet<SourceControlCollapsibleSectionId>
+): void {
+  persistCollapsedSections(worktreeId, collapsedSections)
+}


### PR DESCRIPTION
## Summary

- preserve top-level Source Control section disclosure choices when Explorer or Checks unmounts the panel
- scope the renderer-session cache per worktree, retain the existing default of collapsed Commits, and bound non-default entries with LRU eviction
- add remount, worktree-isolation, default restoration, eviction, and real Source Control regression coverage

Part of #9403.

Companion PR: #9419 (Agent Session History).

Merge order: merge this PR before #9419. The companion PR carries the closing keyword so the canonical issue closes only after both surfaces land.

## Screenshots

Captured from an isolated Electron E2E profile backed by a synthetic Git repository. No personal repositories, paths, sessions, or account data are shown.

### Before navigating away

`Changes` and `Untracked Files` are collapsed, while `Staged Changes` remains expanded.

<img width="350" height="936" alt="Source Control before navigating away" src="https://github.com/user-attachments/assets/c9d25d3b-144a-462d-a682-3ba69c430808" />

### Explorer

The right sidebar is switched to Explorer, which unmounts the Source Control panel.

<img width="350" height="936" alt="Explorer between Source Control visits" src="https://github.com/user-attachments/assets/dc47913d-8020-463c-ac86-dded5b6ce116" />

### After returning

Returning to Source Control restores the same mixed disclosure state. The Before and After captures are byte-identical.

<img width="350" height="936" alt="Source Control after returning from Explorer" src="https://github.com/user-attachments/assets/0b3ed58c-a5b3-4af9-8b4b-e11075a89a63" />

## Testing

- [ ] `pnpm lint`
  - Changed-file oxlint, react-doctor, and type-aware lint pass. The full switch-exhaustiveness run currently fails on the unrelated existing `src/renderer/src/components/skills/skill-freshness-group.tsx:101`.
- [x] `pnpm typecheck`
  - Node, CLI, and Web TypeScript projects pass.
- [ ] `pnpm test`
  - Source Control scope passes: 47 test files / 429 tests. The full suite did not complete because native runtime install scripts were intentionally skipped; unrelated PTY, daemon, and Electron-backed suites failed during setup.
- [ ] `pnpm build`
  - The full production build was not run because the local environment does not have all required native runtime artifacts. The Electron E2E build passes with Node 26 using `electron-vite build --mode e2e`.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Mock-data Electron verification passes on macOS: `Source Control → Explorer → Source Control` with DOM assertions that the collapsed `Changes` and `Untracked Files` entries stay hidden while the expanded staged entry remains visible (`1 passed`).

Additional checks: changed files are formatted; max-lines ratchet, reliability gate manifest, styled scrollbar check, and `git diff --check` pass.

## AI Review Report

Two independent AI reviews found no blocking correctness issues. The reviews explicitly checked remount behavior, rapid toggle semantics, worktree transitions and isolation, bounded cache behavior, performance, and regression coverage. A low-severity review note observed that the cache test only checked its final size, so the test was strengthened to verify that the oldest entry is actually evicted while the newest remains.

Runtime verification was performed through Electron E2E on macOS with an isolated mock repository. Linux, Windows, WSL, and SSH were not manually exercised. Cross-platform code review covered those environments: this change does not touch shortcuts, labels, paths, shell behavior, Git commands, or Electron platform APIs. SSH/local/remote behavior remains neutral because the state is keyed by the existing worktree identity and lives only in renderer memory.

No Git-provider integration path is changed; GitHub, GitLab, and other supported providers retain the same behavior. No agent or integration behavior changes.

UI quality is unchanged: there are no layout, color, typography, spacing, design-token, or component-selection changes. Existing disclosure controls and their default states are retained.

Residual non-blocking risks reviewed: the cache assumes the current single Source Control consumer, and recreating an identical worktree path in the same renderer session can restore its previous transient disclosure choice. Both match existing renderer-session disclosure patterns and are bounded by the 512-entry LRU.

## Security Audit

The change stores only typed section identifiers in a bounded in-memory Map. It adds no user-input parsing, command execution, path handling, network access, auth/secrets handling, IPC, persistence schema, or dependencies. No security follow-up is required.

## Notes

- Disclosure choices intentionally reset on app reload; this fix targets navigation/remount loss within the current renderer session.
- Default behavior for a newly visited worktree is unchanged.
- I don't have an X account.

## ELI5

Collapsing or expanding Source Control sections was lost whenever Explorer or Checks remounted the panel. Your open/closed choices now stick for that worktree during the session.
