### PR TITLE
fix(status-bar): tolerate missing provider snapshots

### DIFF
--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
@@ -30,6 +30,7 @@ function provider(
 describe('isProviderConfigured', () => {
   it('hides a provider whose state has not loaded yet', () => {
     expect(isProviderConfigured(null)).toBe(false)
+    expect(isProviderConfigured(undefined)).toBe(false)
   })
 
   it('hides an unconfigured (unavailable) provider', () => {
@@ -260,7 +261,14 @@ describe('getVisibleUsageProvider', () => {
 
   it('hides providers with no live data or durable configuration', () => {
     expect(getVisibleUsageProvider('codex', null, usageSettings())).toBe(null)
+    expect(getVisibleUsageProvider('grok', undefined, usageSettings())).toBe(null)
     expect(getVisibleUsageProvider('gemini', provider('fetching'), usageSettings())).toBe(null)
+  })
+
+  it('creates a pending snapshot when an older main process omits a configured provider', () => {
+    expect(
+      getVisibleUsageProvider('grok', undefined, usageSettings({ grokAuthConfigured: true }))
+    ).toMatchObject({ provider: 'grok', status: 'fetching' })
   })
 
   it('keeps MiniMax visible while the snapshot is pending when a cookie is configured', () => {
@@ -366,6 +374,24 @@ describe('isUsageEmptyState', () => {
           antigravity: null,
           minimax: null,
           grok: null
+        },
+        usageSettings()
+      )
+    ).toBe(false)
+  })
+
+  it('treats provider keys omitted by an older main process as pending', () => {
+    expect(
+      isUsageEmptyState(
+        {
+          claude: provider('unavailable', { provider: 'claude' }),
+          codex: provider('unavailable', { provider: 'codex' }),
+          gemini: provider('unavailable'),
+          opencodeGo: provider('unavailable', { provider: 'opencode-go' }),
+          kimi: provider('unavailable', { provider: 'kimi' }),
+          antigravity: undefined,
+          minimax: undefined,
+          grok: undefined
         },
         usageSettings()
       )

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
@@ -20,14 +20,14 @@ export type UsageProviderSettings = Pick<
 }
 
 type UsageProviderSnapshots = {
-  claude: ProviderRateLimits | null
-  codex: ProviderRateLimits | null
-  gemini: ProviderRateLimits | null
-  opencodeGo: ProviderRateLimits | null
-  kimi: ProviderRateLimits | null
-  antigravity: ProviderRateLimits | null
-  minimax: ProviderRateLimits | null
-  grok: ProviderRateLimits | null
+  claude: ProviderRateLimits | null | undefined
+  codex: ProviderRateLimits | null | undefined
+  gemini: ProviderRateLimits | null | undefined
+  opencodeGo: ProviderRateLimits | null | undefined
+  kimi: ProviderRateLimits | null | undefined
+  antigravity: ProviderRateLimits | null | undefined
+  minimax: ProviderRateLimits | null | undefined
+  grok: ProviderRateLimits | null | undefined
 }
 
 type UsageProviderId = ProviderRateLimits['provider']
@@ -42,8 +42,8 @@ function hasUsageData(provider: ProviderRateLimits): boolean {
   )
 }
 
-function isProviderSnapshotPending(provider: ProviderRateLimits | null): boolean {
-  return provider === null || (provider.status === 'fetching' && !hasUsageData(provider))
+function isProviderSnapshotPending(provider: ProviderRateLimits | null | undefined): boolean {
+  return provider == null || (provider.status === 'fetching' && !hasUsageData(provider))
 }
 
 // Why: a provider that returns `unavailable` is explicitly not configured
@@ -53,9 +53,11 @@ function isProviderSnapshotPending(provider: ProviderRateLimits | null): boolean
 // — that's a *configured* provider failing transiently, and hiding it would
 // make the bar flap on every refresh hiccup.
 export function isProviderConfigured(
-  provider: ProviderRateLimits | null
+  provider: ProviderRateLimits | null | undefined
 ): provider is ProviderRateLimits {
-  if (provider === null || provider.status === 'unavailable') {
+  // Why: renderer HMR can briefly run against an older main process whose rate-limit
+  // payload predates newer provider keys, so missing snapshots arrive as undefined.
+  if (provider == null || provider.status === 'unavailable') {
     return false
   }
   if (provider.status === 'fetching' && !hasUsageData(provider)) {
@@ -128,7 +130,7 @@ function createPendingProviderSnapshot(providerId: UsageProviderId): ProviderRat
 
 export function getVisibleUsageProvider(
   providerId: UsageProviderId,
-  provider: ProviderRateLimits | null,
+  provider: ProviderRateLimits | null | undefined,
   settings: Partial<UsageProviderSettings> | null | undefined
 ): ProviderRateLimits | null {
   if (isProviderConfigured(provider)) {


### PR DESCRIPTION
## Summary

Fixes a status-bar crash that occurred when a rate-limit snapshot from an older main process omitted a provider key.

## ELI5

Sometimes the app's bottom bar asked for provider info that hadn't arrived yet and choked on the empty answer. Now it waits calmly instead of crashing.

## Root cause & fix

`isProviderConfigured` and `isProviderSnapshotPending` used a strict `provider === null` check, so an `undefined` snapshot (which happens when an older main process omits newly added provider keys) slipped past the guard and crashed on `provider.status`. The fix switches to a loose `provider == null` check so both `null` and `undefined` snapshots are treated as pending. Configured providers stay visible while their snapshot loads; unconfigured providers stay hidden. No provider payloads or IPC contracts change.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- Test file: `src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts`
- Fix file: `src/renderer/src/components/status-bar/status-bar-provider-visibility.ts`
- On branch: all 29 tests pass.
- Reverting only the fix (keeping the new tests) reproduces the bug: 4 fail with `TypeError: Cannot read properties of undefined (reading 'status')`, including the older-main-process regression tests.
- Lint: `oxlint` on the fix source is clean; PR reports `pnpm typecheck` passing.

```
STEP 2a — on branch: Test Files 1 passed, Tests 29 passed.
STEP 2b — fix reverted: Tests 4 failed | 25 passed.
  TypeError: Cannot read properties of undefined (reading 'status')
  - getVisibleUsageProvider > creates a pending snapshot when an older main process omits a configured provider
  - isUsageEmptyState > treats provider keys omitted by an older main process as pending
```

## Trade-offs

None — pure fix.

## Regression risk

Zero-regression: the change only widens a null check to also catch `undefined`, so already-defined and `null` snapshots follow byte-identical paths. Behavior for configured, pending, and empty-state providers is unchanged and locked in by the passing 29-test suite. No IPC, payload, or platform-specific code is touched.

_Credit to @nsxdavid for the original fix. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved._
