### PR TITLE
fix(settings): gate project path setup on host connection

### DIFF
--- a/src/renderer/src/components/settings/RepositoryHostSetupActions.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupActions.tsx
@@ -68,11 +68,16 @@ export function RepositoryHostSetupActions({
   const [isCloning, setIsCloning] = useState(false)
   const [isCreatingPendingSetup, setIsCreatingPendingSetup] = useState(false)
   const defaultSetupHostOption =
-    setupHostOptions.find((option) => option.isAvailable) ?? setupHostOptions[0] ?? null
+    setupHostOptions.find((option) => option.isAvailable && option.canUsePathActions) ??
+    setupHostOptions.find((option) => option.isAvailable) ??
+    setupHostOptions[0] ??
+    null
   const setupTargetHostId = selectedSetupHostId ?? defaultSetupHostOption?.id ?? null
   const setupTargetHostOption =
     setupHostOptions.find((option) => option.id === setupTargetHostId) ?? null
   const canUseSetupTargetHost = setupTargetHostOption?.isAvailable ?? false
+  const canUsePathActions =
+    canUseSetupTargetHost && (setupTargetHostOption?.canUsePathActions ?? false)
 
   if (setupHostOptions.length === 0) {
     return null
@@ -88,7 +93,7 @@ export function RepositoryHostSetupActions({
   }
 
   const handleExistingFolder = async (): Promise<void> => {
-    if (!setupTargetHostId || !canUseSetupTargetHost || !setupPath.trim()) {
+    if (!setupTargetHostId || !canUsePathActions || !setupPath.trim()) {
       return
     }
     setIsSettingUp(true)
@@ -110,12 +115,7 @@ export function RepositoryHostSetupActions({
   }
 
   const handleClone = async (): Promise<void> => {
-    if (
-      !setupTargetHostId ||
-      !canUseSetupTargetHost ||
-      !cloneUrl.trim() ||
-      !cloneDestination.trim()
-    ) {
+    if (!setupTargetHostId || !canUsePathActions || !cloneUrl.trim() || !cloneDestination.trim()) {
       return
     }
     setIsCloning(true)
@@ -229,7 +229,7 @@ export function RepositoryHostSetupActions({
               <SelectItem key={option.id} value={option.id} disabled={!option.isAvailable}>
                 <span className="min-w-0">
                   <span className="block truncate">{option.label}</span>
-                  {!option.isAvailable ? (
+                  {!option.isAvailable || !option.canUsePathActions ? (
                     <span className="block truncate text-[11px] text-muted-foreground">
                       {option.detail}
                     </span>
@@ -239,14 +239,15 @@ export function RepositoryHostSetupActions({
             ))}
           </SelectContent>
         </Select>
-        {!canUseSetupTargetHost && setupTargetHostOption ? (
+        {(!canUseSetupTargetHost || !canUsePathActions) && setupTargetHostOption ? (
           <p className="text-xs text-muted-foreground">{setupTargetHostOption.detail}</p>
         ) : null}
       </div>
 
       {step === 'choose' ? (
         <HostSetupStartActions
-          disabled={!canUseSetupTargetHost}
+          pathActionsDisabled={!canUsePathActions}
+          planDisabled={!canUseSetupTargetHost}
           onBrowse={() => setStep('existing')}
           onClone={() => setStep('clone')}
           onPlan={() => setStep('planned')}
@@ -256,7 +257,7 @@ export function RepositoryHostSetupActions({
         <HostSetupExistingFolderStep
           setupPath={setupPath}
           setupKind={setupKind}
-          disabled={!canUseSetupTargetHost}
+          disabled={!canUsePathActions}
           isSettingUp={isSettingUp}
           onBack={() => setStep('choose')}
           onPathChange={setSetupPath}
@@ -268,7 +269,7 @@ export function RepositoryHostSetupActions({
         <HostSetupCloneStep
           cloneUrl={cloneUrl}
           cloneDestination={cloneDestination}
-          disabled={!canUseSetupTargetHost}
+          disabled={!canUsePathActions}
           isCloning={isCloning}
           onBack={() => setStep('choose')}
           onCloneUrlChange={setCloneUrl}

--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx
@@ -567,7 +567,7 @@ describe('RepositoryHostSetupsSection', () => {
     expect(openSettingsTarget).not.toHaveBeenCalled()
   })
 
-  it('blocks path setup on a disconnected SSH host but keeps placeholders available', () => {
+  it('blocks path setup until an SSH host connects but keeps placeholders available', () => {
     const localRepo = makeRepo({
       id: 'local-repo',
       displayName: 'Orca',
@@ -597,6 +597,13 @@ describe('RepositoryHostSetupsSection', () => {
     expect(findButton('Browse folder')?.disabled).toBe(true)
     expect(findButton('Clone from URL')?.disabled).toBe(true)
     expect(findButton('Add host placeholder')?.disabled).toBe(false)
+
+    act(() => {
+      useAppStore.getState().setSshConnectionState('openclaw 2', connectedSshState('openclaw 2'))
+    })
+
+    expect(findButton('Browse folder')?.disabled).toBe(false)
+    expect(findButton('Clone from URL')?.disabled).toBe(false)
   })
 
   it('creates pending setup metadata for a known host without requiring a path', async () => {

--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx
@@ -54,6 +54,15 @@ function makeSetup(
   }
 }
 
+function connectedSshState(targetId: string) {
+  return {
+    targetId,
+    status: 'connected' as const,
+    error: null,
+    reconnectAttempt: 0
+  }
+}
+
 beforeEach(() => {
   useAppStore.setState(useAppStore.getInitialState(), true)
   container = document.createElement('div')
@@ -437,6 +446,7 @@ describe('RepositoryHostSetupsSection', () => {
         })
       ],
       sshTargetLabels: new Map([['openclaw 2', 'openclaw 2']]),
+      sshConnectionStates: new Map([['openclaw 2', connectedSshState('openclaw 2')]]),
       openSettingsPage,
       openSettingsTarget,
       setSettingsProjectHostSelection,
@@ -513,6 +523,7 @@ describe('RepositoryHostSetupsSection', () => {
         })
       ],
       sshTargetLabels: new Map([['openclaw 2', 'openclaw 2']]),
+      sshConnectionStates: new Map([['openclaw 2', connectedSshState('openclaw 2')]]),
       openSettingsPage,
       openSettingsTarget,
       setSettingsProjectHostSelection,
@@ -554,6 +565,38 @@ describe('RepositoryHostSetupsSection', () => {
     )
     expect(openSettingsPage).not.toHaveBeenCalled()
     expect(openSettingsTarget).not.toHaveBeenCalled()
+  })
+
+  it('blocks path setup on a disconnected SSH host but keeps placeholders available', () => {
+    const localRepo = makeRepo({
+      id: 'local-repo',
+      displayName: 'Orca',
+      path: '/Users/alice/orca'
+    })
+    useAppStore.setState({
+      repos: [localRepo],
+      projects: [makeProject({ id: 'github:stablyai/orca' })],
+      projectHostSetups: [
+        makeSetup({
+          id: 'local-repo',
+          projectId: 'github:stablyai/orca',
+          repoId: 'local-repo',
+          hostId: 'local',
+          path: '/Users/alice/orca'
+        })
+      ],
+      sshTargetLabels: new Map([['openclaw 2', 'openclaw 2']])
+    })
+
+    renderSection(localRepo)
+    clickButton('Add to another host')
+
+    expect(container.textContent).toContain(
+      'Connect this host before importing or cloning the project'
+    )
+    expect(findButton('Browse folder')?.disabled).toBe(true)
+    expect(findButton('Clone from URL')?.disabled).toBe(true)
+    expect(findButton('Add host placeholder')?.disabled).toBe(false)
   })
 
   it('creates pending setup metadata for a known host without requiring a path', async () => {

--- a/src/renderer/src/components/settings/repository-host-add-project-steps.tsx
+++ b/src/renderer/src/components/settings/repository-host-add-project-steps.tsx
@@ -7,12 +7,14 @@ import { Input } from '../ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 
 export function HostSetupStartActions({
-  disabled,
+  pathActionsDisabled,
+  planDisabled,
   onBrowse,
   onClone,
   onPlan
 }: {
-  disabled: boolean
+  pathActionsDisabled: boolean
+  planDisabled: boolean
   onBrowse: () => void
   onClone: () => void
   onPlan: () => void
@@ -26,7 +28,7 @@ export function HostSetupStartActions({
           'auto.components.settings.RepositoryPane.browseFolderHelp',
           'Use an existing checkout or folder on this host.'
         )}
-        disabled={disabled}
+        disabled={pathActionsDisabled}
         selected
         onClick={onBrowse}
       />
@@ -45,7 +47,7 @@ export function HostSetupStartActions({
               'auto.components.settings.RepositoryPane.cloneFromUrlHelp',
               'Clone this repository onto the selected host.'
             )}
-            disabled={disabled}
+            disabled={pathActionsDisabled}
             onClick={onClone}
             className="rounded-t-md"
           />
@@ -59,7 +61,7 @@ export function HostSetupStartActions({
               'auto.components.settings.RepositoryPane.addPlannedHostHelp',
               'Remember this host and finish adding the project later.'
             )}
-            disabled={disabled}
+            disabled={planDisabled}
             onClick={onPlan}
             className="rounded-b-md border-t border-border/70"
           />

--- a/src/renderer/src/components/settings/repository-host-setup-options.test.ts
+++ b/src/renderer/src/components/settings/repository-host-setup-options.test.ts
@@ -28,7 +28,46 @@ function runtimeHost(
   } as ExecutionHostRegistryEntry
 }
 
+function sshHost(health: ExecutionHostRegistryEntry['health']): ExecutionHostRegistryEntry {
+  return {
+    id: 'ssh:ssh-1',
+    kind: 'ssh',
+    label: 'SSH Host',
+    detail: 'SSH',
+    health
+  }
+}
+
 describe('buildSetupHostOptions', () => {
+  it('enables connected SSH hosts', () => {
+    expect(
+      buildSetupHostOptions({
+        projectHostSetups: [],
+        hostOptions: [sshHost('available')]
+      })[0]
+    ).toMatchObject({
+      isAvailable: true,
+      canUsePathActions: true,
+      detail: 'SSH'
+    })
+  })
+
+  it.each(['disconnected', 'connecting', 'error'] as const)(
+    'disables path actions for %s SSH hosts',
+    (health) => {
+      expect(
+        buildSetupHostOptions({
+          projectHostSetups: [],
+          hostOptions: [sshHost(health)]
+        })[0]
+      ).toMatchObject({
+        isAvailable: true,
+        canUsePathActions: false,
+        detail: 'Connect this host before importing or cloning the project'
+      })
+    }
+  )
+
   it('disables runtime hosts while capabilities are unknown', () => {
     expect(
       buildSetupHostOptions({

--- a/src/renderer/src/components/settings/repository-host-setup-options.ts
+++ b/src/renderer/src/components/settings/repository-host-setup-options.ts
@@ -12,6 +12,7 @@ export type SetupHostOption = {
   label: string
   detail: string
   isAvailable: boolean
+  canUsePathActions: boolean
 }
 
 export function getSetupStateLabel(setupState: ProjectHostSetupState): string {
@@ -50,11 +51,21 @@ export function buildSetupHostOptions({
     .filter((host) => !setupHostIds.has(host.id))
     .map((host) => {
       const availability = getHostSetupAvailability(host)
+      // Why: import and clone require live remote providers, while an offline
+      // host can still be recorded as a placeholder for later setup.
+      const canUsePathActions = host.health === 'local' || host.health === 'available'
       return {
         id: host.id,
         label: host.label || getExecutionHostLabel(host.id),
-        detail: availability.detail,
-        isAvailable: availability.isAvailable
+        detail:
+          availability.isAvailable && !canUsePathActions
+            ? translate(
+                'auto.components.settings.RepositoryPane.hostSetupConnectionRequired',
+                'Connect this host before importing or cloning the project'
+              )
+            : availability.detail,
+        isAvailable: availability.isAvailable,
+        canUsePathActions
       }
     })
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6358,6 +6358,7 @@
           "removeSetup": "Remove",
           "hostSetupBlockedVersion": "Orca server version is incompatible",
           "hostSetupMissingCapability": "Update Orca on this host to set up projects",
+          "hostSetupConnectionRequired": "Connect this host before importing or cloning the project",
           "setupProjectOnHost": "Set up on another host",
           "setupProjectOnHostHelp": "Choose a host, then import an existing checkout, clone the repository there, or track a setup that will be provisioned later.",
           "setupExistingFolder": "Import existing folder",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -6299,6 +6299,7 @@
           "removeSetup": "Eliminar",
           "hostSetupBlockedVersion": "La versión del servidor Orca no es compatible",
           "hostSetupMissingCapability": "Actualiza Orca en este host para configurar proyectos",
+          "hostSetupConnectionRequired": "Conecta este host antes de importar o clonar el proyecto",
           "setupProjectOnHost": "Configurar en otro host",
           "setupProjectOnHostHelp": "Elige un host y luego importa un checkout existente, clona el repositorio allí o registra una configuración que se aprovisionará más tarde.",
           "setupExistingFolder": "Importar carpeta existente",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -6321,6 +6321,7 @@
           "removeSetup": "削除",
           "hostSetupBlockedVersion": "Orca server version is incompatible",
           "hostSetupMissingCapability": "Update Orca on this host to set up projects",
+          "hostSetupConnectionRequired": "プロジェクトをインポートまたはクローンする前に、このホストに接続してください",
           "setupProjectOnHost": "別のホストで設定",
           "setupProjectOnHostHelp": "Choose a host, then import an existing checkout, clone the repository there, or track a setup that will be provisioned later.",
           "setupExistingFolder": "既存フォルダをインポート",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -6284,6 +6284,7 @@
           "removeSetup": "제거",
           "hostSetupBlockedVersion": "Orca 서버 버전이 호환되지 않습니다.",
           "hostSetupMissingCapability": "프로젝트를 설정하려면 이 호스트의 Orca를 업데이트하세요.",
+          "hostSetupConnectionRequired": "프로젝트를 가져오거나 클론하기 전에 이 호스트에 연결하세요.",
           "setupProjectOnHost": "다른 호스트에 설정",
           "setupProjectOnHostHelp": "호스트를 선택한 뒤 기존 체크아웃을 가져오거나, repos를 클론하거나, 나중에 준비될 설정을 추적합니다.",
           "setupExistingFolder": "기존 폴더 가져오기",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -6284,6 +6284,7 @@
           "removeSetup": "移除",
           "hostSetupBlockedVersion": "Orca 服务器版本不兼容",
           "hostSetupMissingCapability": "在此主机上更新 Orca 以设置项目",
+          "hostSetupConnectionRequired": "请先连接此主机，再导入或克隆项目",
           "setupProjectOnHost": "在其他主机上设置",
           "setupProjectOnHostHelp": "选择一台主机，然后导入已有检出、在那里克隆仓库，或跟踪稍后才配置的设置。",
           "setupExistingFolder": "导入现有文件夹",


### PR DESCRIPTION
## Summary

Prevents project import and clone actions from starting while the selected remote (SSH) host is disconnected, connecting, or errored, so they no longer fail with `SSH connection ... not found or not connected`.

## ELI5

If your remote computer isn't actually connected yet, the "browse folder" and "clone from URL" buttons now stay off and tell you to connect first — instead of letting you click them and hit a confusing error.

## Root cause & fix

GSSAPI authentication can succeed even though Orca's remote provider isn't connected, yet the setup UI gated path actions on host *capability* alone and never checked provider *availability*. This change adds a health check when building the host options: connected hosts keep full path actions, while disconnected/connecting/errored hosts have path actions disabled with localized recovery guidance. The offline "Add host placeholder" flow stays enabled so users can still record work for later.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- Rebase clean onto `origin/main`; PR touches 10 files (3 source, 5 i18n locales with the new `hostSetupConnectionRequired` key, 2 tests).
- Tests: `repository-host-setup-options.test.ts` + `RepositoryHostSetupsSection.test.tsx`.
- On branch: **18/18 pass.** Reverting the 3 fix files → **5 fail / 13 pass**, e.g. `buildSetupHostOptions > enables connected SSH hosts` expected `canUsePathActions:true` + connect guidance but got detail `'SSH'` / `canUsePathActions` undefined; the 3 disconnected/connecting/error cases and the component-level `blocks path setup until SSH host connects` also fail.
- Lint: `oxlint` on the 3 changed source files → clean (0 warnings, 0 errors).

```
On branch:      Test Files 2 passed (2) | Tests 18 passed (18)
Fix reverted:   Test Files 2 failed (2) | Tests 5 failed | 13 passed (18)
```

## Trade-offs

None — pure fix. Adds one constant-time health check while mapping the existing host list; no new IPC, network, or polling.

## Regression risk

Zero-regression by construction: only the disconnected/connecting/errored branch changes behavior. Local hosts and connected remote hosts keep their existing treatment, and reconnecting automatically restores actions. The passing branch tests plus fail-on-revert confirm the gate is the only behavioral change.

*Original fix by @s546126; validated, rebased, and reviewed via automated bug-bash triage — original fix design preserved, no additional fix required.*
