### PR TITLE
fix(agents): keep-awake + sidebar attribution from foreground process evidence

### DIFF
--- a/src/main/agent-awake-foreground-evidence.ts
+++ b/src/main/agent-awake-foreground-evidence.ts
@@ -1,0 +1,75 @@
+// Why: foreground-agent scans are event-driven (title status transitions,
+// session listing sweeps), not periodic. The TTL only bridges gaps between
+// them; expiry revalidates against the runtime's cached foreground state
+// instead of forcing a new process scan.
+export const AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS = 5 * 60 * 1000
+
+type ForegroundAgentEvidence = {
+  // Last time a real scan reported this PTY's recognized foreground agent.
+  reportedAt: number
+  // Refreshed by scans AND by cache revalidation at TTL expiry.
+  observedAt: number
+}
+
+/**
+ * Per-PTY keep-awake evidence for recognized foreground agents (wrapper
+ * claude etc.) that emit no hook statuses. Only recognized agents are ever
+ * reported here — arbitrary processes never grant wake eligibility.
+ */
+export class ForegroundAgentEvidenceLedger {
+  private readonly evidenceByPtyId = new Map<string, ForegroundAgentEvidence>()
+  private readonly now: () => number
+  private readonly revalidate: ((ptyId: string) => boolean) | null
+
+  constructor(args: { now: () => number; revalidate?: (ptyId: string) => boolean }) {
+    this.now = args.now
+    this.revalidate = args.revalidate ?? null
+  }
+
+  /** Returns true when the report changed the ledger (caller should refresh). */
+  report(ptyId: string, agent: string | null): boolean {
+    if (agent === null) {
+      return this.evidenceByPtyId.delete(ptyId)
+    }
+    const now = this.now()
+    this.evidenceByPtyId.set(ptyId, { reportedAt: now, observedAt: now })
+    return true
+  }
+
+  /** Drops expired evidence; counts what remains toward wake eligibility. */
+  pruneAndCount(staleAfterMs: number): number {
+    const now = this.now()
+    for (const [ptyId, evidence] of this.evidenceByPtyId) {
+      if (now - evidence.observedAt <= AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS) {
+        continue
+      }
+      // Why: renew from the runtime's live cache (never a scan), hard-capped by
+      // the same 2h window hook statuses get so a stale cache cannot block
+      // sleep indefinitely. Anything else expires with the TTL.
+      if (now - evidence.reportedAt <= staleAfterMs && this.revalidate?.(ptyId) === true) {
+        evidence.observedAt = now
+      } else {
+        this.evidenceByPtyId.delete(ptyId)
+      }
+    }
+    return this.evidenceByPtyId.size
+  }
+
+  /** Earliest upcoming expiry among live evidence, or null when none. */
+  nextExpiry(staleAfterMs: number): number | null {
+    const now = this.now()
+    let earliest: number | null = null
+    for (const evidence of this.evidenceByPtyId.values()) {
+      // Why: the TTL expiry drives revalidation; the 2h cap is the backstop.
+      const expiry = Math.min(
+        evidence.observedAt + AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS,
+        evidence.reportedAt + staleAfterMs
+      )
+      if (expiry <= now) {
+        continue
+      }
+      earliest = earliest === null ? expiry : Math.min(earliest, expiry)
+    }
+    return earliest
+  }
+}

--- a/src/main/agent-awake-foreground-evidence.ts
+++ b/src/main/agent-awake-foreground-evidence.ts
@@ -1,7 +1,5 @@
-// Why: foreground-agent scans are event-driven (title status transitions,
-// session listing sweeps), not periodic. The TTL only bridges gaps between
-// them; expiry revalidates against the runtime's cached foreground state
-// instead of forcing a new process scan.
+// Why: scans are event-driven, so expiry revalidates cached foreground state
+// without adding process scans.
 export const AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS = 5 * 60 * 1000
 
 type ForegroundAgentEvidence = {
@@ -11,11 +9,7 @@ type ForegroundAgentEvidence = {
   observedAt: number
 }
 
-/**
- * Per-PTY keep-awake evidence for recognized foreground agents (wrapper
- * claude etc.) that emit no hook statuses. Only recognized agents are ever
- * reported here — arbitrary processes never grant wake eligibility.
- */
+/** Per-PTY keep-awake evidence for recognized agents that emit no hook statuses. */
 export class ForegroundAgentEvidenceLedger {
   private readonly evidenceByPtyId = new Map<string, ForegroundAgentEvidence>()
   private readonly now: () => number
@@ -40,9 +34,8 @@ export class ForegroundAgentEvidenceLedger {
   pruneAndCount(staleAfterMs: number): number {
     const now = this.now()
     for (const [ptyId, evidence] of this.evidenceByPtyId) {
-      // Why: the 2h cap is unconditional — revalidation renews observedAt, so a
-      // TTL-only prune would keep a capped entry alive with no timer scheduled
-      // (nextExpiry treats the cap as expired) and block sleep forever.
+      // Why: revalidation renews observedAt, so only an unconditional cap can
+      // prevent evidence from surviving after its final timer.
       if (now - evidence.reportedAt >= staleAfterMs) {
         this.evidenceByPtyId.delete(ptyId)
         continue

--- a/src/main/agent-awake-foreground-evidence.ts
+++ b/src/main/agent-awake-foreground-evidence.ts
@@ -1,6 +1,7 @@
 // Why: scans are event-driven, so expiry revalidates cached foreground state
 // without adding process scans.
 export const AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS = 5 * 60 * 1000
+const FOREGROUND_AGENT_REPORT_REFRESH_QUANTUM_MS = 5_000
 
 type ForegroundAgentEvidence = {
   // Last time a real scan reported this PTY's recognized foreground agent.
@@ -26,6 +27,10 @@ export class ForegroundAgentEvidenceLedger {
       return this.evidenceByPtyId.delete(ptyId)
     }
     const now = this.now()
+    const existing = this.evidenceByPtyId.get(ptyId)
+    if (existing && now - existing.reportedAt < FOREGROUND_AGENT_REPORT_REFRESH_QUANTUM_MS) {
+      return false
+    }
     this.evidenceByPtyId.set(ptyId, { reportedAt: now, observedAt: now })
     return true
   }

--- a/src/main/agent-awake-foreground-evidence.ts
+++ b/src/main/agent-awake-foreground-evidence.ts
@@ -40,13 +40,21 @@ export class ForegroundAgentEvidenceLedger {
   pruneAndCount(staleAfterMs: number): number {
     const now = this.now()
     for (const [ptyId, evidence] of this.evidenceByPtyId) {
-      if (now - evidence.observedAt <= AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS) {
+      // Why: the 2h cap is unconditional — revalidation renews observedAt, so a
+      // TTL-only prune would keep a capped entry alive with no timer scheduled
+      // (nextExpiry treats the cap as expired) and block sleep forever.
+      if (now - evidence.reportedAt >= staleAfterMs) {
+        this.evidenceByPtyId.delete(ptyId)
         continue
       }
-      // Why: renew from the runtime's live cache (never a scan), hard-capped by
-      // the same 2h window hook statuses get so a stale cache cannot block
-      // sleep indefinitely. Anything else expires with the TTL.
-      if (now - evidence.reportedAt <= staleAfterMs && this.revalidate?.(ptyId) === true) {
+      // Why: strict `<` mirrors nextExpiry's `expiry <= now`, so a timer firing
+      // exactly at the TTL boundary always renews or deletes, never stalls.
+      if (now - evidence.observedAt < AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS) {
+        continue
+      }
+      // Why: renew from the runtime's live cache (never a scan); anything the
+      // cache no longer confirms expires with the TTL.
+      if (this.revalidate?.(ptyId) === true) {
         evidence.observedAt = now
       } else {
         this.evidenceByPtyId.delete(ptyId)

--- a/src/main/agent-awake-service.test.ts
+++ b/src/main/agent-awake-service.test.ts
@@ -309,6 +309,29 @@ describe('AgentAwakeService', () => {
     expect(blocker.start).toHaveBeenCalledTimes(1)
   })
 
+  it('does not reschedule expiry for repeated foreground evidence inside the refresh quantum', () => {
+    vi.useFakeTimers()
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    let now = 1_000
+    const blocker = createBlocker()
+    const service = createService(() => now, blocker)
+
+    service.setEnabled(true)
+    service.reportForegroundAgentEvidence('pty-1', 'claude')
+    const scheduledAfterFirstReport = setTimeoutSpy.mock.calls.length
+
+    now += 750
+    service.reportForegroundAgentEvidence('pty-1', 'claude')
+
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(scheduledAfterFirstReport)
+
+    now += 5_000
+    service.reportForegroundAgentEvidence('pty-1', 'claude')
+
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(scheduledAfterFirstReport + 1)
+    service.dispose()
+  })
+
   it('revokes wake eligibility when foreground-agent evidence is cleared', () => {
     const blocker = createBlocker()
     const service = createService(() => 1_000, blocker)

--- a/src/main/agent-awake-service.test.ts
+++ b/src/main/agent-awake-service.test.ts
@@ -364,6 +364,43 @@ describe('AgentAwakeService', () => {
     service.dispose()
   })
 
+  it('drops foreground-agent evidence at the 2h cap even while revalidation keeps confirming', () => {
+    vi.useFakeTimers()
+    let now = 1_000
+    const blocker = createBlocker()
+    const service = createService(
+      () => now,
+      blocker,
+      createMacosAssertion(),
+      createLinuxAssertion(),
+      null,
+      () => true
+    )
+
+    service.setEnabled(true)
+    service.reportForegroundAgentEvidence('pty-1', 'claude')
+    now += AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS
+    vi.advanceTimersByTime(AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS)
+
+    expect(blocker.stop).not.toHaveBeenCalled()
+
+    // Why: revalidation renews observedAt every TTL, so only the reportedAt cap
+    // can end this evidence. The timer firing at the cap must both drop it and
+    // stop the blocker (regression: it survived the prune with no next timer).
+    while (now < 1_000 + AGENT_AWAKE_STATUS_STALE_AFTER_MS) {
+      const step = Math.min(
+        AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS,
+        1_000 + AGENT_AWAKE_STATUS_STALE_AFTER_MS - now
+      )
+      now += step
+      vi.advanceTimersByTime(step)
+    }
+
+    expect(blocker.stop).toHaveBeenCalledWith(1)
+    expect(vi.getTimerCount()).toBe(0)
+    service.dispose()
+  })
+
   it('unsubscribes the resume listener on dispose', () => {
     const blocker = createBlocker()
     const macosAssertion = createMacosAssertion()

--- a/src/main/agent-awake-service.test.ts
+++ b/src/main/agent-awake-service.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { AgentAwakeService, AGENT_AWAKE_STATUS_STALE_AFTER_MS } from './agent-awake-service'
+import {
+  AgentAwakeService,
+  AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS,
+  AGENT_AWAKE_STATUS_STALE_AFTER_MS
+} from './agent-awake-service'
 import type { AgentAwakeStatus } from './agent-awake-service'
 
 vi.mock('electron', () => ({
@@ -78,7 +82,8 @@ function createService(
   blocker = createBlocker(),
   macosAssertion = createMacosAssertion(),
   linuxAssertion = createLinuxAssertion(),
-  powerMonitor: ReturnType<typeof createPowerMonitor> | null = null
+  powerMonitor: ReturnType<typeof createPowerMonitor> | null = null,
+  revalidateForegroundAgent?: (ptyId: string) => boolean
 ): AgentAwakeService {
   return new AgentAwakeService({
     blocker,
@@ -86,6 +91,7 @@ function createService(
     macosAssertion,
     now,
     powerMonitor,
+    revalidateForegroundAgent,
     logger: {
       debug: vi.fn(),
       warn: vi.fn()
@@ -291,6 +297,71 @@ describe('AgentAwakeService', () => {
     expect(blocker.start).toHaveBeenCalledTimes(2)
     expect(macosAssertion.start).toHaveBeenCalledTimes(2)
     expect(linuxAssertion.start).toHaveBeenCalledTimes(2)
+  })
+
+  it('grants wake eligibility for reported recognized foreground-agent evidence', () => {
+    const blocker = createBlocker()
+    const service = createService(() => 1_000, blocker)
+
+    service.setEnabled(true)
+    service.reportForegroundAgentEvidence('pty-1', 'claude')
+
+    expect(blocker.start).toHaveBeenCalledTimes(1)
+  })
+
+  it('revokes wake eligibility when foreground-agent evidence is cleared', () => {
+    const blocker = createBlocker()
+    const service = createService(() => 1_000, blocker)
+
+    service.setEnabled(true)
+    service.reportForegroundAgentEvidence('pty-1', 'claude')
+    service.reportForegroundAgentEvidence('pty-1', null)
+
+    expect(blocker.stop).toHaveBeenCalledWith(1)
+  })
+
+  it('expires foreground-agent evidence at its TTL without a revalidator', () => {
+    vi.useFakeTimers()
+    let now = 1_000
+    const blocker = createBlocker()
+    const service = createService(() => now, blocker)
+
+    service.setEnabled(true)
+    service.reportForegroundAgentEvidence('pty-1', 'claude')
+    now = 1_000 + AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS + 1
+    vi.advanceTimersByTime(AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS)
+
+    expect(blocker.stop).toHaveBeenCalledWith(1)
+    service.dispose()
+  })
+
+  it('renews foreground-agent evidence at TTL expiry while revalidation confirms the agent', () => {
+    vi.useFakeTimers()
+    let now = 1_000
+    let stillForeground = true
+    const blocker = createBlocker()
+    const service = createService(
+      () => now,
+      blocker,
+      createMacosAssertion(),
+      createLinuxAssertion(),
+      null,
+      () => stillForeground
+    )
+
+    service.setEnabled(true)
+    service.reportForegroundAgentEvidence('pty-1', 'claude')
+    now = 1_000 + AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS + 1
+    vi.advanceTimersByTime(AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS)
+
+    expect(blocker.stop).not.toHaveBeenCalled()
+
+    stillForeground = false
+    now += AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS + 1
+    vi.advanceTimersByTime(AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS + 1_000)
+
+    expect(blocker.stop).toHaveBeenCalledWith(1)
+    service.dispose()
   })
 
   it('unsubscribes the resume listener on dispose', () => {

--- a/src/main/agent-awake-service.ts
+++ b/src/main/agent-awake-service.ts
@@ -105,9 +105,8 @@ export class AgentAwakeService {
     this.refresh('status-change')
   }
 
-  // Why: wrapper-launched/manual agents recognized by the foreground scan can
-  // run without hook statuses; their evidence holds wake eligibility too.
-  // Only recognized agents reach here — arbitrary processes never grant wake.
+  // Why: recognized wrapper/manual agents may lack hooks; arbitrary processes
+  // never reach this evidence path.
   reportForegroundAgentEvidence(ptyId: string, agent: string | null): void {
     if (this.foregroundAgentEvidence.report(ptyId, agent)) {
       this.refresh('foreground-agent-evidence')

--- a/src/main/agent-awake-service.ts
+++ b/src/main/agent-awake-service.ts
@@ -1,9 +1,11 @@
 import { powerMonitor, powerSaveBlocker } from 'electron'
 import type { AgentStatusState } from '../shared/agent-status-types'
+import { ForegroundAgentEvidenceLedger } from './agent-awake-foreground-evidence'
 import { LinuxLidSleepAssertion } from './linux-lid-sleep-assertion'
 import { MacosSystemSleepAssertion } from './macos-system-sleep-assertion'
 
 export const AGENT_AWAKE_STATUS_STALE_AFTER_MS = 2 * 60 * 60 * 1000
+export { AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS } from './agent-awake-foreground-evidence'
 
 export type AgentAwakeStatus = {
   state: AgentStatusState
@@ -37,11 +39,16 @@ type AgentAwakeServiceOptions = {
   macosAssertion?: PlatformAwakeAssertion
   now?: () => number
   powerMonitor?: PowerMonitorEventSource | null
+  /** Cache-only check (no process scan) that the PTY is still connected with a
+   *  recognized foreground agent; used to renew evidence at TTL expiry. */
+  revalidateForegroundAgent?: (ptyId: string) => boolean
 }
 
 export class AgentAwakeService {
   private enabled = false
   private statuses: AgentAwakeStatus[] = []
+  private readonly foregroundAgentEvidence: ForegroundAgentEvidenceLedger
+  private eligibleForegroundAgentCount = 0
   private blockerId: number | null = null
   private staleTimer: ReturnType<typeof setTimeout> | null = null
   private readonly blocker: PowerSaveBlocker
@@ -55,6 +62,10 @@ export class AgentAwakeService {
     this.blocker = options.blocker ?? powerSaveBlocker
     this.logger = options.logger ?? console
     this.now = options.now ?? Date.now
+    this.foregroundAgentEvidence = new ForegroundAgentEvidenceLedger({
+      now: this.now,
+      revalidate: options.revalidateForegroundAgent
+    })
     // Windows lid close is intentionally not modeled as an assertion here:
     // keeping it awake requires mutating the user's global power plan.
     this.linuxAssertion =
@@ -94,6 +105,15 @@ export class AgentAwakeService {
     this.refresh('status-change')
   }
 
+  // Why: wrapper-launched/manual agents recognized by the foreground scan can
+  // run without hook statuses; their evidence holds wake eligibility too.
+  // Only recognized agents reach here — arbitrary processes never grant wake.
+  reportForegroundAgentEvidence(ptyId: string, agent: string | null): void {
+    if (this.foregroundAgentEvidence.report(ptyId, agent)) {
+      this.refresh('foreground-agent-evidence')
+    }
+  }
+
   dispose(): void {
     this.clearStaleTimer()
     this.unsubscribeResume?.()
@@ -103,8 +123,12 @@ export class AgentAwakeService {
   }
 
   private refresh(reason: string): void {
+    this.eligibleForegroundAgentCount = this.foregroundAgentEvidence.pruneAndCount(
+      AGENT_AWAKE_STATUS_STALE_AFTER_MS
+    )
     this.scheduleStaleTimer()
-    const runningStatusCount = this.getEligibleRunningStatusCount()
+    const runningStatusCount =
+      this.getEligibleRunningStatusCount() + this.eligibleForegroundAgentCount
     const shouldBlock = this.enabled && runningStatusCount > 0
     if (shouldBlock) {
       this.startBlocker(reason, runningStatusCount)
@@ -148,6 +172,13 @@ export class AgentAwakeService {
         continue
       }
       earliestExpiry = earliestExpiry === null ? expiry : Math.min(earliestExpiry, expiry)
+    }
+    const evidenceExpiry = this.foregroundAgentEvidence.nextExpiry(
+      AGENT_AWAKE_STATUS_STALE_AFTER_MS
+    )
+    if (evidenceExpiry !== null) {
+      earliestExpiry =
+        earliestExpiry === null ? evidenceExpiry : Math.min(earliestExpiry, evidenceExpiry)
     }
     if (earliestExpiry === null) {
       return

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2108,7 +2108,11 @@ void app.whenReady().then(async () => {
     profileDirectory: activeOrcaProfile.profileDirectory
   })
   unsubscribeSystemResumeBroadcast = registerSystemResumeBroadcast()
-  agentAwakeService = new AgentAwakeService()
+  // Why: revalidation reads the runtime's cached foreground state (no process
+  // scan); `runtime` is assigned later in this init, hence the late-bound read.
+  agentAwakeService = new AgentAwakeService({
+    revalidateForegroundAgent: (ptyId) => runtime?.hasWakeEligibleForegroundAgent(ptyId) === true
+  })
   agentAwakeService.setEnabled(store.getSettings().keepComputerAwakeWhileAgentsRun)
   // Why: start from empty — disk-hydrated status rows are UI continuity only; only this runtime's hook events keep the computer awake.
   agentAwakeService.setStatuses([])
@@ -2349,7 +2353,14 @@ void app.whenReady().then(async () => {
     getLocalProvider: () => getLocalPtyProvider(),
     // Why: SSH relay providers register after construction and may reconnect, so destructive cleanup must resolve the current generation.
     getSshProvider: (connectionId) => getSshPtyProvider(connectionId),
-    onPtyStopped: clearProviderPtyState,
+    onPtyStopped: (ptyId) => {
+      clearProviderPtyState(ptyId)
+      // Why: a dead PTY's foreground-agent evidence must stop holding wake now,
+      // not at TTL expiry.
+      agentAwakeService?.reportForegroundAgentEvidence(ptyId, null)
+    },
+    onPtyForegroundAgentEvidence: (ptyId, agent) =>
+      agentAwakeService?.reportForegroundAgentEvidence(ptyId, agent),
     onTerminalAgentStatus: (event) => {
       agentHookServer.ingestTerminalStatus(event)
     },

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -7525,6 +7525,82 @@ describe('registerPtyHandlers', () => {
     })
   })
 
+  it('reuses renderer foreground inspections as runtime wake evidence', async () => {
+    const getForegroundProcess = vi.fn(async () => 'claude')
+    const confirmForegroundProcess = vi.fn(async () => 'claude')
+    setLocalPtyProvider({
+      getForegroundProcess,
+      confirmForegroundProcess,
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => [])
+    } as never)
+    const runtime = {
+      setPtyController: vi.fn(),
+      recordPtyForegroundProcessObservation: vi.fn()
+    }
+    registerPtyHandlers(mainWindow as never, runtime as never)
+    restorePtyIncarnation('pty-known-launch', 'incarnation-known-launch')
+
+    try {
+      await expect(
+        handlers.get('pty:getForegroundProcess')!(null, { id: 'pty-known-launch' })
+      ).resolves.toBe('claude')
+      await expect(
+        handlers.get('pty:confirmForegroundProcess')!(null, { id: 'pty-known-launch' })
+      ).resolves.toBe('claude')
+
+      expect(runtime.recordPtyForegroundProcessObservation).toHaveBeenNthCalledWith(
+        1,
+        'pty-known-launch',
+        'claude'
+      )
+      expect(runtime.recordPtyForegroundProcessObservation).toHaveBeenNthCalledWith(
+        2,
+        'pty-known-launch',
+        'claude'
+      )
+    } finally {
+      clearProviderPtyState('pty-known-launch')
+    }
+  })
+
+  it('does not record foreground evidence after a PTY id is reused during inspection', async () => {
+    let resolveForegroundProcess: ((value: string | null) => void) | undefined
+    const foregroundProcess = new Promise<string | null>((resolve) => {
+      resolveForegroundProcess = resolve
+    })
+    setLocalPtyProvider({
+      getForegroundProcess: vi.fn(() => foregroundProcess),
+      confirmForegroundProcess: vi.fn(() => foregroundProcess),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => [])
+    } as never)
+    const runtime = {
+      setPtyController: vi.fn(),
+      recordPtyForegroundProcessObservation: vi.fn()
+    }
+    registerPtyHandlers(mainWindow as never, runtime as never)
+    const ptyId = 'pty-reused-during-inspection'
+    restorePtyIncarnation(ptyId, 'incarnation-before-inspection')
+
+    try {
+      const foreground = handlers.get('pty:getForegroundProcess')!(null, { id: ptyId })
+      const confirmation = handlers.get('pty:confirmForegroundProcess')!(null, { id: ptyId })
+      restorePtyIncarnation(ptyId, 'incarnation-after-inspection')
+      resolveForegroundProcess?.('claude')
+
+      await expect(foreground).resolves.toBe('claude')
+      await expect(confirmation).resolves.toBe('claude')
+      expect(runtime.recordPtyForegroundProcessObservation).not.toHaveBeenCalled()
+    } finally {
+      clearProviderPtyState(ptyId)
+    }
+  })
+
   // Why: daemon resize is fire-and-forget, so pty:getSize must report the APPLIED size, not the requested one (Claude-Code split-pane desync).
   describe('pty:getSize reports applied size, not requested size', () => {
     function setupProviderWithAppliedSize(args: {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -7561,6 +7561,7 @@ describe('registerPtyHandlers', () => {
         'pty-known-launch',
         'claude'
       )
+      expect(runtime.recordPtyForegroundProcessObservation).toHaveBeenCalledTimes(2)
     } finally {
       clearProviderPtyState('pty-known-launch')
     }

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -7194,7 +7194,17 @@ export function registerPtyHandlers(
       if (!hasPtyProviderForInspection(args.id)) {
         return null
       }
-      return getProviderForPty(args.id).getForegroundProcess(args.id)
+      const inspectedIncarnationId = ptyIncarnationById.get(args.id)
+      const foregroundProcess = await getProviderForPty(args.id).getForegroundProcess(args.id)
+      // Why: launched-agent runtime probes are skipped; reuse this scan for wake
+      // evidence instead of adding another provider query.
+      if (
+        inspectedIncarnationId !== undefined &&
+        ptyIncarnationById.get(args.id) === inspectedIncarnationId
+      ) {
+        runtime?.recordPtyForegroundProcessObservation(args.id, foregroundProcess)
+      }
+      return foregroundProcess
     }
   )
 
@@ -7210,7 +7220,18 @@ export function registerPtyHandlers(
       }
       const provider = getProviderForPty(args.id)
       // Why: the cached foreground API would turn stale process identity into shell/agent authority at a command boundary.
-      return provider.confirmForegroundProcess?.(args.id) ?? null
+      if (!provider.confirmForegroundProcess) {
+        return null
+      }
+      const inspectedIncarnationId = ptyIncarnationById.get(args.id)
+      const foregroundProcess = await provider.confirmForegroundProcess(args.id)
+      if (
+        inspectedIncarnationId !== undefined &&
+        ptyIncarnationById.get(args.id) === inspectedIncarnationId
+      ) {
+        runtime?.recordPtyForegroundProcessObservation(args.id, foregroundProcess)
+      }
+      return foregroundProcess
     }
   )
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -23339,6 +23339,26 @@ describe('OrcaRuntimeService', () => {
     expect(getForegroundProcess).not.toHaveBeenCalled()
   })
 
+  it('accepts foreground evidence from an existing renderer scan for a known launch agent', async () => {
+    const onPtyForegroundAgentEvidence = vi.fn()
+    const runtime = new OrcaRuntimeService(store, undefined, { onPtyForegroundAgentEvidence })
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-claude' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: vi.fn()
+    })
+    await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'claude',
+      launchAgent: 'claude',
+      title: 'Claude'
+    })
+
+    expect(runtime.recordPtyForegroundProcessObservation('pty-claude', 'claude')).toBe(true)
+    expect(onPtyForegroundAgentEvidence).toHaveBeenCalledWith('pty-claude', 'claude')
+    expect(runtime.hasWakeEligibleForegroundAgent('pty-claude')).toBe(true)
+  })
+
   it('probes the foreground process only on a status transition for unknown launch agents', async () => {
     const getForegroundProcess = vi.fn(async () => 'omp')
     const runtime = createRuntime()

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -11667,7 +11667,6 @@ describe('OrcaRuntimeService', () => {
 
   it.each([
     ['shell', async () => 'pwsh.exe'],
-    ['non-agent', async () => 'vim'],
     ['unavailable', async () => null],
     [
       'failure',
@@ -11686,6 +11685,23 @@ describe('OrcaRuntimeService', () => {
       handle,
       isRunningAgent: false,
       status: null
+    })
+    expect(confirmForegroundProcess).toHaveBeenCalledOnce()
+  })
+
+  // Why: a wrapper/fork agent binary is unrecognized but is NOT a shell; the
+  // hook-status gate must treat that confirmed foreground as busy, not idle.
+  it('keeps hook state running when confirmation reports an unrecognized non-shell foreground', async () => {
+    const confirmForegroundProcess = vi.fn(async () => 'my-agent-fork')
+    const { runtime, handle } = await createExplicitAgentStatusHarness({
+      getForegroundProcess: async () => 'zsh',
+      confirmForegroundProcess
+    })
+
+    await expect(runtime.getTerminalAgentStatus(handle)).resolves.toEqual({
+      handle,
+      isRunningAgent: true,
+      status: 'working'
     })
     expect(confirmForegroundProcess).toHaveBeenCalledOnce()
   })

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -23368,6 +23368,42 @@ describe('OrcaRuntimeService', () => {
     expect(getForegroundProcess).toHaveBeenCalledTimes(2)
   })
 
+  it('reports recognized foreground-agent evidence from the existing status-transition probe', async () => {
+    const onPtyForegroundAgentEvidence = vi.fn()
+    const runtime = new OrcaRuntimeService(store, undefined, { onPtyForegroundAgentEvidence })
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'claude'
+    })
+    syncSinglePty(runtime, 'pty-wake')
+
+    runtime.onPtyData('pty-wake', '\x1b]0;⠋ compiling\x07alpha\n', 100)
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(onPtyForegroundAgentEvidence).toHaveBeenCalledWith('pty-wake', 'claude')
+    expect(runtime.hasWakeEligibleForegroundAgent('pty-wake')).toBe(true)
+  })
+
+  // Why: keep-awake evidence is recognized-agent-only — an arbitrary non-shell
+  // process (vim, tail -f) must never hold the machine awake.
+  it('reports null foreground-agent evidence for an unrecognized foreground process', async () => {
+    const onPtyForegroundAgentEvidence = vi.fn()
+    const runtime = new OrcaRuntimeService(store, undefined, { onPtyForegroundAgentEvidence })
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'vim'
+    })
+    syncSinglePty(runtime, 'pty-wake')
+
+    runtime.onPtyData('pty-wake', '\x1b]0;⠋ compiling\x07alpha\n', 100)
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(onPtyForegroundAgentEvidence).toHaveBeenCalledWith('pty-wake', null)
+    expect(runtime.hasWakeEligibleForegroundAgent('pty-wake')).toBe(false)
+  })
+
   it('normalizes Pi-compatible mobile session status to OMP for an unknown-launch foreground omp PTY', async () => {
     const spawn = vi.fn().mockResolvedValue({ id: 'pty-typed-omp' })
     const getForegroundProcess = vi.fn(async () => 'omp')

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -16648,10 +16648,8 @@ export class OrcaRuntimeService {
       return true
     }
     this.assertTerminalAgentStatusPtyBinding(handle, ptyId)
-    // Why: only a confirmed real shell proves the agent left. An unrecognized
-    // NON-shell foreground (wrapper/fork agent binary) must keep fresh hook
-    // state alive instead of counting as idle; an unavailable confirmation
-    // stays fail-closed like the catch path above.
+    // Why: only a confirmed shell proves exit; unknown non-shell processes may
+    // be wrapper/fork agents, while unavailable confirmation stays fail-closed.
     return confirmedProcess === null || isShellProcess(confirmedProcess)
   }
 
@@ -16865,16 +16863,24 @@ export class OrcaRuntimeService {
     if (!foregroundRead) {
       return false
     }
-    const result = await foregroundRead
+const result = await foregroundRead
     if (result.controller !== this.ptyController || !result.available) {
       return false
     }
     const foregroundProcess = result.process
+    return this.recordPtyForegroundProcessObservation(ptyId, foregroundProcess)
+  }
+
+  /** Reuses a completed provider inspection for runtime identity and wake evidence. */
+  recordPtyForegroundProcessObservation(ptyId: string, foregroundProcess: string | null): boolean {
+    const pty = this.ptysById.get(ptyId)
+    if (!pty?.connected) {
+      return false
+    }
     const foregroundAgent = foregroundProcess
       ? (recognizeAgentProcess(foregroundProcess)?.agent ?? null)
       : null
-    // Why: report before the unchanged early-return so every completed scan
-    // renews the keep-awake TTL for a still-running recognized agent.
+    // Why: every completed scan renews wake evidence, even when cached identity is unchanged.
     this.onPtyForegroundAgentEvidence?.(ptyId, foregroundAgent)
     if (pty.foregroundAgent === foregroundAgent) {
       return false

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3259,6 +3259,9 @@ export class OrcaRuntimeService {
   private readonly getLocalProviderFn: (() => IPtyProvider) | null
   private readonly getSshProviderFn: ((connectionId: string) => IPtyProvider | undefined) | null
   private readonly onPtyStopped: ((ptyId: string) => void) | null
+  private readonly onPtyForegroundAgentEvidence:
+    | ((ptyId: string, agent: TuiAgent | null) => void)
+    | null
   private readonly onTerminalAgentStatus: ((event: RuntimeTerminalAgentStatusEvent) => void) | null
   private readonly onTerminalSideEffects: ((batch: TerminalSideEffectBatch) => void) | null
   private terminalSideEffectLocalConsumerAvailable = false
@@ -3331,6 +3334,9 @@ export class OrcaRuntimeService {
       getLocalProvider?: () => IPtyProvider
       getSshProvider?: (connectionId: string) => IPtyProvider | undefined
       onPtyStopped?: (ptyId: string) => void
+      // Why: keep-awake needs recognized-foreground-agent evidence (wrapper
+      // claude etc.) from the existing scans; fired per completed scan result.
+      onPtyForegroundAgentEvidence?: (ptyId: string, agent: TuiAgent | null) => void
       onTerminalAgentStatus?: (event: RuntimeTerminalAgentStatusEvent) => void
       onTerminalSideEffects?: (batch: TerminalSideEffectBatch) => void
       // Why: agent status mostly arrives via hooks (agent-hooks/server), not OSC
@@ -3405,6 +3411,7 @@ export class OrcaRuntimeService {
     this.getLocalProviderFn = deps?.getLocalProvider ?? null
     this.getSshProviderFn = deps?.getSshProvider ?? null
     this.onPtyStopped = deps?.onPtyStopped ?? null
+    this.onPtyForegroundAgentEvidence = deps?.onPtyForegroundAgentEvidence ?? null
     this.onTerminalAgentStatus = deps?.onTerminalAgentStatus ?? null
     this.buildAgentHookPtyEnv = deps?.buildAgentHookPtyEnv ?? null
     this.getDesktopWindowStatusFn = deps?.getDesktopWindowStatus ?? (() => 'openable')
@@ -16866,12 +16873,22 @@ export class OrcaRuntimeService {
     const foregroundAgent = foregroundProcess
       ? (recognizeAgentProcess(foregroundProcess)?.agent ?? null)
       : null
+    // Why: report before the unchanged early-return so every completed scan
+    // renews the keep-awake TTL for a still-running recognized agent.
+    this.onPtyForegroundAgentEvidence?.(ptyId, foregroundAgent)
     if (pty.foregroundAgent === foregroundAgent) {
       return false
     }
     pty.foregroundAgent = foregroundAgent
     this.touchMobileSessionSnapshotsForPty(ptyId)
     return true
+  }
+
+  /** Cache-only keep-awake revalidation: is this PTY still connected with a
+   *  recognized foreground agent? Never triggers a process scan. */
+  hasWakeEligibleForegroundAgent(ptyId: string): boolean {
+    const pty = this.ptysById.get(ptyId)
+    return pty?.connected === true && pty.foregroundAgent !== null
   }
 
   private getFreshExplicitAgentStatusForHandle(handle: string): {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -16641,9 +16641,11 @@ export class OrcaRuntimeService {
       return true
     }
     this.assertTerminalAgentStatusPtyBinding(handle, ptyId)
-    // Why: hook identity is generic; strong provider evidence only needs to
-    // prove that some recognized agent still owns this exact PTY.
-    return recognizeAgentProcess(confirmedProcess) === null
+    // Why: only a confirmed real shell proves the agent left. An unrecognized
+    // NON-shell foreground (wrapper/fork agent binary) must keep fresh hook
+    // state alive instead of counting as idle; an unavailable confirmation
+    // stays fail-closed like the catch path above.
+    return confirmedProcess === null || isShellProcess(confirmedProcess)
   }
 
   private shouldDelayPtyBackedMobileSnapshotForForegroundAgent(

--- a/src/renderer/src/components/sidebar/use-pane-foreground-agent-evidence-expiry.test.ts
+++ b/src/renderer/src/components/sidebar/use-pane-foreground-agent-evidence-expiry.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS } from '@/store/slices/pane-foreground-agent'
+import {
+  earliestPaneForegroundAgentEvidenceExpiry,
+  usePaneForegroundAgentEvidenceExpiryTick
+} from './use-pane-foreground-agent-evidence-expiry'
+
+describe('earliestPaneForegroundAgentEvidenceExpiry', () => {
+  it('returns the earliest future expiry and ignores agent-less, unstamped, and expired entries', () => {
+    const now = 100_000
+    expect(
+      earliestPaneForegroundAgentEvidenceExpiry(
+        {
+          a: { agent: 'claude', shellForeground: false, observedAt: now - 1_000 },
+          b: { agent: 'codex', shellForeground: false, observedAt: now - 500 },
+          shell: { agent: null, shellForeground: true, observedAt: now },
+          unstamped: { agent: 'claude', shellForeground: false },
+          expired: {
+            agent: 'claude',
+            shellForeground: false,
+            observedAt: now - PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS
+          }
+        },
+        now
+      )
+    ).toBe(now - 1_000 + PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS)
+  })
+
+  it('returns null when no entry has a future expiry', () => {
+    expect(earliestPaneForegroundAgentEvidenceExpiry({}, 1_000)).toBeNull()
+  })
+})
+
+describe('usePaneForegroundAgentEvidenceExpiryTick', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('bumps once when the only evidence entry crosses its TTL', () => {
+    const entries = {
+      pane: { agent: 'claude' as const, shellForeground: false, observedAt: Date.now() }
+    }
+    const { result } = renderHook(() => usePaneForegroundAgentEvidenceExpiryTick(entries))
+
+    expect(result.current).toBe(0)
+    act(() => {
+      vi.advanceTimersByTime(PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS + 1)
+    })
+    expect(result.current).toBe(1)
+
+    // Why: past the TTL there is no future expiry left, so no timer re-arms.
+    act(() => {
+      vi.advanceTimersByTime(PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS + 1)
+    })
+    expect(result.current).toBe(1)
+  })
+
+  it('schedules nothing for entries without attributable evidence', () => {
+    const entries = {
+      pane: { agent: null, shellForeground: true, observedAt: Date.now() }
+    }
+    const { result } = renderHook(() => usePaneForegroundAgentEvidenceExpiryTick(entries))
+
+    act(() => {
+      vi.advanceTimersByTime(PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS * 2)
+    })
+    expect(result.current).toBe(0)
+  })
+})

--- a/src/renderer/src/components/sidebar/use-pane-foreground-agent-evidence-expiry.ts
+++ b/src/renderer/src/components/sidebar/use-pane-foreground-agent-evidence-expiry.ts
@@ -23,19 +23,12 @@ export function earliestPaneForegroundAgentEvidenceExpiry(
   return earliest
 }
 
-/**
- * Re-render trigger for TTL-gated process-identity attribution: store updates
- * only happen when evidence is (re)published, so nothing re-renders when the
- * last publish silently crosses its TTL. Returns a tick that bumps just past
- * the earliest upcoming expiry; consumers add it to their memo deps so a
- * past-TTL working ring/row drops without waiting for unrelated store churn.
- */
+/** Re-render trigger that expires process attribution without unrelated store writes. */
 export function usePaneForegroundAgentEvidenceExpiryTick(
   entries: Record<string, PaneForegroundAgentEntry>
 ): number {
   const [tick, setTick] = useState(0)
-  // Why: `tick` is a dep so the effect re-arms for the next-earliest expiry
-  // after firing (entries observed at different times expire independently).
+  // Why: tick re-arms the next expiry when entries were observed at different times.
   useEffect(() => {
     const now = Date.now()
     const earliest = earliestPaneForegroundAgentEvidenceExpiry(entries, now)

--- a/src/renderer/src/components/sidebar/use-pane-foreground-agent-evidence-expiry.ts
+++ b/src/renderer/src/components/sidebar/use-pane-foreground-agent-evidence-expiry.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react'
+import {
+  PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS,
+  type PaneForegroundAgentEntry
+} from '@/store/slices/pane-foreground-agent'
+
+/** Earliest upcoming attribution-evidence expiry among entries, or null. */
+export function earliestPaneForegroundAgentEvidenceExpiry(
+  entries: Record<string, PaneForegroundAgentEntry>,
+  now: number
+): number | null {
+  let earliest: number | null = null
+  for (const entry of Object.values(entries)) {
+    if (!entry.agent || entry.observedAt === undefined) {
+      continue
+    }
+    const expiry = entry.observedAt + PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS
+    if (expiry <= now) {
+      continue
+    }
+    earliest = earliest === null ? expiry : Math.min(earliest, expiry)
+  }
+  return earliest
+}
+
+/**
+ * Re-render trigger for TTL-gated process-identity attribution: store updates
+ * only happen when evidence is (re)published, so nothing re-renders when the
+ * last publish silently crosses its TTL. Returns a tick that bumps just past
+ * the earliest upcoming expiry; consumers add it to their memo deps so a
+ * past-TTL working ring/row drops without waiting for unrelated store churn.
+ */
+export function usePaneForegroundAgentEvidenceExpiryTick(
+  entries: Record<string, PaneForegroundAgentEntry>
+): number {
+  const [tick, setTick] = useState(0)
+  // Why: `tick` is a dep so the effect re-arms for the next-earliest expiry
+  // after firing (entries observed at different times expire independently).
+  useEffect(() => {
+    const now = Date.now()
+    const earliest = earliestPaneForegroundAgentEvidenceExpiry(entries, now)
+    if (earliest === null) {
+      return
+    }
+    const timer = setTimeout(() => setTick((value) => value + 1), earliest - now + 1)
+    return () => clearTimeout(timer)
+  }, [entries, tick])
+  return tick
+}

--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
@@ -9,6 +9,7 @@ import {
   selectRuntimePaneTitlesForWorktree
 } from './worktree-card-status-inputs'
 import { selectWorktreeAgentActivitySummary } from './worktree-agent-activity-summary'
+import { usePaneForegroundAgentEvidenceExpiryTick } from './use-pane-foreground-agent-evidence-expiry'
 
 export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
   const tabs = useAppStore((s) => s.tabsByWorktree[worktreeId] ?? EMPTY_TABS)
@@ -30,6 +31,10 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
     agentStatusPaneIdsByTabId,
     paneForegroundAgentByPaneKey
   } = useAppStore(useShallow((s) => selectWorktreeAgentActivitySummary(s, worktreeId)))
+  // Why: process-identity evidence decays by wall clock, not by store writes;
+  // this tick forces one recompute at the earliest TTL boundary so a stale
+  // working ring drops even when tracker/coordinator go silent.
+  const evidenceExpiryTick = usePaneForegroundAgentEvidenceExpiryTick(paneForegroundAgentByPaneKey)
 
   // Why: compact and detailed cards need the same status-dot semantics:
   // runtime liveness gates title-derived states, then explicit agent rows can
@@ -49,7 +54,11 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
         hasLiveDone,
         hasRetainedDone
       }),
+    // Why: evidenceExpiryTick is an extra dep on purpose — it forces the
+    // Date.now() read inside resolveWorktreeStatus to re-evaluate at the TTL.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
+      evidenceExpiryTick,
       tabs,
       browserTabs,
       ptyIdsForWorktree,

--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
@@ -22,8 +22,14 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
   const terminalLayoutRootsByTabId = useAppStore(
     useShallow((s) => selectTerminalLayoutRootsForWorktree(s, worktreeId))
   )
-  const { hasPermission, hasLiveWorking, hasLiveDone, hasRetainedDone, agentStatusPaneIdsByTabId } =
-    useAppStore(useShallow((s) => selectWorktreeAgentActivitySummary(s, worktreeId)))
+  const {
+    hasPermission,
+    hasLiveWorking,
+    hasLiveDone,
+    hasRetainedDone,
+    agentStatusPaneIdsByTabId,
+    paneForegroundAgentByPaneKey
+  } = useAppStore(useShallow((s) => selectWorktreeAgentActivitySummary(s, worktreeId)))
 
   // Why: compact and detailed cards need the same status-dot semantics:
   // runtime liveness gates title-derived states, then explicit agent rows can
@@ -37,6 +43,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
         runtimePaneTitlesByTabId: runtimePaneTitlesForWorktree,
         agentStatusPaneIdsByTabId,
         terminalLayoutRootsByTabId,
+        paneForegroundAgentByPaneKey,
         hasPermission,
         hasLiveWorking,
         hasLiveDone,
@@ -49,6 +56,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
       runtimePaneTitlesForWorktree,
       agentStatusPaneIdsByTabId,
       terminalLayoutRootsByTabId,
+      paneForegroundAgentByPaneKey,
       hasPermission,
       hasLiveWorking,
       hasLiveDone,

--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
@@ -31,9 +31,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
     agentStatusPaneIdsByTabId,
     paneForegroundAgentByPaneKey
   } = useAppStore(useShallow((s) => selectWorktreeAgentActivitySummary(s, worktreeId)))
-  // Why: process-identity evidence decays by wall clock, not by store writes;
-  // this tick forces one recompute at the earliest TTL boundary so a stale
-  // working ring drops even when tracker/coordinator go silent.
+  // Why: evidence decays by wall clock, so recompute at expiry even without a store write.
   const evidenceExpiryTick = usePaneForegroundAgentEvidenceExpiryTick(paneForegroundAgentByPaneKey)
 
   // Why: compact and detailed cards need the same status-dot semantics:
@@ -54,8 +52,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
         hasLiveDone,
         hasRetainedDone
       }),
-    // Why: evidenceExpiryTick is an extra dep on purpose — it forces the
-    // Date.now() read inside resolveWorktreeStatus to re-evaluate at the TTL.
+    // Why: the tick forces resolveWorktreeStatus to re-read time at expiry.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       evidenceExpiryTick,

--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
@@ -20,6 +20,10 @@ import {
   createWorktreeAgentFreshnessSelector,
   EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE
 } from './worktree-agent-freshness-selector'
+import {
+  EMPTY_PANE_FOREGROUND_AGENTS,
+  selectWorktreeAgentActivitySummary
+} from './worktree-agent-activity-summary'
 
 export { buildWorktreeAgentRows } from './worktree-agent-rows'
 export {
@@ -74,6 +78,14 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
   const runtimeAgentOrchestrationByPaneKey = useAppStore(
     useShallow((s) => (active ? selectRuntimeAgentOrchestrationForWorktree(s, worktreeId) : {}))
   )
+  // Why: the activity summary already narrows the process-identity slice per
+  // worktree with stable references; reuse it instead of subscribing to the
+  // whole paneForegroundAgentByPaneKey map (O(worktrees) render amplification).
+  const paneForegroundAgentByPaneKey = useAppStore((s) =>
+    active
+      ? selectWorktreeAgentActivitySummary(s, worktreeId).paneForegroundAgentByPaneKey
+      : EMPTY_PANE_FOREGROUND_AGENTS
+  )
   const agentFreshnessSignature = useAppStore((s) =>
     active ? selectAgentFreshness(s) : EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE
   )
@@ -104,6 +116,7 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
         ptyIdsByTabId,
         terminalLayoutsByTabId,
         runtimeAgentOrchestrationByPaneKey,
+        paneForegroundAgentByPaneKey,
         now
       })
     )
@@ -118,6 +131,7 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
     ptyIdsByTabId,
     terminalLayoutsByTabId,
     runtimeAgentOrchestrationByPaneKey,
+    paneForegroundAgentByPaneKey,
     agentFreshnessSignature
   ])
 }

--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
@@ -24,6 +24,7 @@ import {
   EMPTY_PANE_FOREGROUND_AGENTS,
   selectWorktreeAgentActivitySummary
 } from './worktree-agent-activity-summary'
+import { usePaneForegroundAgentEvidenceExpiryTick } from './use-pane-foreground-agent-evidence-expiry'
 
 export { buildWorktreeAgentRows } from './worktree-agent-rows'
 export {
@@ -89,6 +90,10 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
   const agentFreshnessSignature = useAppStore((s) =>
     active ? selectAgentFreshness(s) : EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE
   )
+  // Why: process-identity evidence decays by wall clock, not by store writes;
+  // this tick forces one recompute at the earliest TTL boundary so a stale row
+  // drops even when tracker/coordinator go silent after the last publish.
+  const evidenceExpiryTick = usePaneForegroundAgentEvidenceExpiryTick(paneForegroundAgentByPaneKey)
 
   return useMemo<DashboardAgentRow[]>(() => {
     if (!active) {
@@ -132,6 +137,7 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
     terminalLayoutsByTabId,
     runtimeAgentOrchestrationByPaneKey,
     paneForegroundAgentByPaneKey,
-    agentFreshnessSignature
+    agentFreshnessSignature,
+    evidenceExpiryTick
   ])
 }

--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
@@ -79,9 +79,7 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
   const runtimeAgentOrchestrationByPaneKey = useAppStore(
     useShallow((s) => (active ? selectRuntimeAgentOrchestrationForWorktree(s, worktreeId) : {}))
   )
-  // Why: the activity summary already narrows the process-identity slice per
-  // worktree with stable references; reuse it instead of subscribing to the
-  // whole paneForegroundAgentByPaneKey map (O(worktrees) render amplification).
+  // Why: reuse the stable per-worktree summary to avoid whole-map render amplification.
   const paneForegroundAgentByPaneKey = useAppStore((s) =>
     active
       ? selectWorktreeAgentActivitySummary(s, worktreeId).paneForegroundAgentByPaneKey
@@ -90,9 +88,7 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
   const agentFreshnessSignature = useAppStore((s) =>
     active ? selectAgentFreshness(s) : EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE
   )
-  // Why: process-identity evidence decays by wall clock, not by store writes;
-  // this tick forces one recompute at the earliest TTL boundary so a stale row
-  // drops even when tracker/coordinator go silent after the last publish.
+  // Why: evidence decays by wall clock, so recompute at expiry even without a store write.
   const evidenceExpiryTick = usePaneForegroundAgentEvidenceExpiryTick(paneForegroundAgentByPaneKey)
 
   return useMemo<DashboardAgentRow[]>(() => {

--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary.test.ts
@@ -91,6 +91,41 @@ describe('selectWorktreeAgentActivitySummary', () => {
     expect(nowSpy).toHaveBeenCalledTimes(1)
   })
 
+  it('narrows process-identity entries to their worktree and skips agent-less entries', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(2_000)
+    const firstPaneKey = makePaneKey('tab-1', LEAF_ID)
+    const secondPaneKey = makePaneKey('tab-2', LEAF_ID)
+    const claudeEntry = {
+      agent: 'claude',
+      shellForeground: false,
+      observedAt: 1_900,
+      ptyId: 'pty-claude'
+    } as const
+    const state: AgentActivityInput = {
+      tabsByWorktree: {
+        'repo::/wt-1': [makeTab('tab-1', 'repo::/wt-1')],
+        'repo::/wt-2': [makeTab('tab-2', 'repo::/wt-2')]
+      },
+      agentStatusEpoch: 0,
+      agentStatusByPaneKey: {},
+      migrationUnsupportedByPtyId: {},
+      runtimeAgentOrchestrationByPaneKey: {},
+      retainedAgentsByPaneKey: {},
+      paneForegroundAgentByPaneKey: {
+        [firstPaneKey]: claudeEntry,
+        // Shell-foreground (agent gone) entries carry no attribution value.
+        [secondPaneKey]: { agent: null, shellForeground: true, observedAt: 1_900 }
+      }
+    }
+
+    expect(
+      selectWorktreeAgentActivitySummary(state, 'repo::/wt-1').paneForegroundAgentByPaneKey
+    ).toEqual({ [firstPaneKey]: claudeEntry })
+    expect(
+      selectWorktreeAgentActivitySummary(state, 'repo::/wt-2').paneForegroundAgentByPaneKey
+    ).toEqual({})
+  })
+
   it('reuses the cached summary when same-state agent pings only clone the status map', () => {
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(2_000)
     const paneKey = makePaneKey('tab-1', LEAF_ID)

--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
@@ -11,6 +11,7 @@ import {
   type AgentStatusEntry,
   type AgentStatusOrchestrationContext
 } from '../../../../shared/agent-status-types'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 
 export type WorktreeAgentActivitySummary = {
   hasPermission: boolean
@@ -18,16 +19,22 @@ export type WorktreeAgentActivitySummary = {
   hasLiveDone: boolean
   hasRetainedDone: boolean
   agentStatusPaneIdsByTabId: Record<string, ReadonlySet<string>>
+  /** Process-table identity entries narrowed to this worktree's panes.
+   *  Freshness (TTL) is NOT applied here — this cache is invalidated by
+   *  references, so consumers must gate with their own clock. */
+  paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry>
 }
 
 const EMPTY_AGENT_STATUS_PANE_IDS_BY_TAB_ID: Record<string, ReadonlySet<string>> = {}
+export const EMPTY_PANE_FOREGROUND_AGENTS: Record<string, PaneForegroundAgentEntry> = {}
 
 const EMPTY_SUMMARY: WorktreeAgentActivitySummary = {
   hasPermission: false,
   hasLiveWorking: false,
   hasLiveDone: false,
   hasRetainedDone: false,
-  agentStatusPaneIdsByTabId: EMPTY_AGENT_STATUS_PANE_IDS_BY_TAB_ID
+  agentStatusPaneIdsByTabId: EMPTY_AGENT_STATUS_PANE_IDS_BY_TAB_ID,
+  paneForegroundAgentByPaneKey: EMPTY_PANE_FOREGROUND_AGENTS
 }
 
 type AgentActivityTabsByWorktree = Record<string, readonly { id: string }[]>
@@ -41,6 +48,7 @@ export type AgentActivityInput = Pick<
 > & {
   tabsByWorktree: AgentActivityTabsByWorktree
   runtimeAgentOrchestrationByPaneKey?: AppState['runtimeAgentOrchestrationByPaneKey']
+  paneForegroundAgentByPaneKey?: AppState['paneForegroundAgentByPaneKey']
 }
 
 type AgentActivityCache = {
@@ -49,6 +57,7 @@ type AgentActivityCache = {
   migrationUnsupportedByPtyId: AppState['migrationUnsupportedByPtyId']
   retainedAgentsByPaneKey: AppState['retainedAgentsByPaneKey']
   runtimeAgentOrchestrationByPaneKey: AppState['runtimeAgentOrchestrationByPaneKey'] | undefined
+  paneForegroundAgentByPaneKey: AppState['paneForegroundAgentByPaneKey'] | undefined
   summaries: Map<string, WorktreeAgentActivitySummary>
 }
 
@@ -65,13 +74,15 @@ function getWorktreeAgentActivitySummaries(
   state: AgentActivityInput
 ): Map<string, WorktreeAgentActivitySummary> {
   const runtimeAgentOrchestrationByPaneKey = state.runtimeAgentOrchestrationByPaneKey
+  const paneForegroundAgentByPaneKey = state.paneForegroundAgentByPaneKey
   if (
     agentActivityCache &&
     agentActivityCache.tabsByWorktree === state.tabsByWorktree &&
     agentActivityCache.agentStatusEpoch === state.agentStatusEpoch &&
     agentActivityCache.migrationUnsupportedByPtyId === state.migrationUnsupportedByPtyId &&
     agentActivityCache.retainedAgentsByPaneKey === state.retainedAgentsByPaneKey &&
-    agentActivityCache.runtimeAgentOrchestrationByPaneKey === runtimeAgentOrchestrationByPaneKey
+    agentActivityCache.runtimeAgentOrchestrationByPaneKey === runtimeAgentOrchestrationByPaneKey &&
+    agentActivityCache.paneForegroundAgentByPaneKey === paneForegroundAgentByPaneKey
   ) {
     return agentActivityCache.summaries
   }
@@ -133,6 +144,23 @@ function getWorktreeAgentActivitySummaries(
     }
   }
 
+  // Why: narrow process-table identity to each worktree so cards can attribute
+  // title-derived rows/ring without subscribing to the whole slice map.
+  for (const [paneKey, entry] of Object.entries(paneForegroundAgentByPaneKey ?? {})) {
+    if (!entry.agent) {
+      continue
+    }
+    const worktreeId = worktreeIdForPaneKey(paneKey, tabIdToWorktreeId)
+    if (!worktreeId) {
+      continue
+    }
+    const summary = summaryForWorktree(worktreeId)
+    if (summary.paneForegroundAgentByPaneKey === EMPTY_PANE_FOREGROUND_AGENTS) {
+      summary.paneForegroundAgentByPaneKey = {}
+    }
+    summary.paneForegroundAgentByPaneKey[paneKey] = entry
+  }
+
   for (const retained of Object.values(state.retainedAgentsByPaneKey ?? {})) {
     const summary = summaryForWorktree(retained.worktreeId)
     summary.hasRetainedDone = true
@@ -165,6 +193,7 @@ function getWorktreeAgentActivitySummaries(
     migrationUnsupportedByPtyId: state.migrationUnsupportedByPtyId,
     retainedAgentsByPaneKey: state.retainedAgentsByPaneKey,
     runtimeAgentOrchestrationByPaneKey,
+    paneForegroundAgentByPaneKey,
     summaries
   }
   return summaries
@@ -182,8 +211,28 @@ function summariesEqual(
     agentStatusPaneIdsByTabIdEqual(
       previous.agentStatusPaneIdsByTabId,
       next.agentStatusPaneIdsByTabId
+    ) &&
+    paneForegroundAgentsEqual(
+      previous.paneForegroundAgentByPaneKey,
+      next.paneForegroundAgentByPaneKey
     )
   )
+}
+
+function paneForegroundAgentsEqual(
+  previous: Record<string, PaneForegroundAgentEntry>,
+  next: Record<string, PaneForegroundAgentEntry>
+): boolean {
+  if (previous === next) {
+    return true
+  }
+  const previousKeys = Object.keys(previous)
+  if (previousKeys.length !== Object.keys(next).length) {
+    return false
+  }
+  // Why: entry objects are immutable in the slice, so reference equality is
+  // exact — and observedAt bumps must NOT be equal, or freshness would freeze.
+  return previousKeys.every((paneKey) => previous[paneKey] === next[paneKey])
 }
 
 function agentStatusPaneIdsByTabIdEqual(

--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
@@ -19,9 +19,7 @@ export type WorktreeAgentActivitySummary = {
   hasLiveDone: boolean
   hasRetainedDone: boolean
   agentStatusPaneIdsByTabId: Record<string, ReadonlySet<string>>
-  /** Process-table identity entries narrowed to this worktree's panes.
-   *  Freshness (TTL) is NOT applied here — this cache is invalidated by
-   *  references, so consumers must gate with their own clock. */
+  /** Process identity narrowed by worktree; consumers apply wall-clock freshness. */
   paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry>
 }
 
@@ -230,8 +228,7 @@ function paneForegroundAgentsEqual(
   if (previousKeys.length !== Object.keys(next).length) {
     return false
   }
-  // Why: entry objects are immutable in the slice, so reference equality is
-  // exact — and observedAt bumps must NOT be equal, or freshness would freeze.
+  // Why: immutable entry identity is exact, and observedAt bumps must invalidate freshness.
   return previousKeys.every((paneKey) => previous[paneKey] === next[paneKey])
 }
 

--- a/src/renderer/src/components/sidebar/worktree-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-rows.ts
@@ -1,6 +1,7 @@
 import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
 import type { RetainedAgentEntry } from '@/store/slices/agent-status'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 import {
   AGENT_STATUS_STALE_AFTER_MS,
   type AgentType,
@@ -209,6 +210,7 @@ export function buildWorktreeAgentRows(args: {
   ptyIdsByTabId?: Record<string, string[]>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
+  paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
   now: number
 }): DashboardAgentRow[] {
   const rows: DashboardAgentRow[] = []

--- a/src/renderer/src/components/sidebar/worktree-section-activity.ts
+++ b/src/renderer/src/components/sidebar/worktree-section-activity.ts
@@ -32,6 +32,7 @@ export type WorktreeSectionActivityState = Pick<
   tabsByWorktree: Record<string, readonly Pick<TerminalTab, 'id' | 'title'>[]>
   browserTabsByWorktree: Record<string, readonly BrowserActivityTab[]>
   terminalLayoutRootsByTabId: Record<string, TerminalPaneLayoutNode | null | undefined>
+  paneForegroundAgentByPaneKey?: AppState['paneForegroundAgentByPaneKey']
 }
 
 export type WorktreeSectionActivitySummary = {
@@ -107,6 +108,7 @@ function getSectionWorktreeStatus(
     ptyIdsByTabId: selectLivePtyIdsForWorktree(state, worktreeId),
     runtimePaneTitlesByTabId: selectRuntimePaneTitlesForWorktree(state, worktreeId),
     agentStatusPaneIdsByTabId: agentSummary.agentStatusPaneIdsByTabId,
+    paneForegroundAgentByPaneKey: agentSummary.paneForegroundAgentByPaneKey,
     terminalLayoutRootsByTabId: state.terminalLayoutRootsByTabId,
     hasPermission: agentSummary.hasPermission,
     hasLiveWorking: agentSummary.hasLiveWorking,

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { applyAgentRowLineage } from '@/components/dashboard/agent-row-lineage'
+import { PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS } from '@/store/slices/pane-foreground-agent'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import type { TerminalLayoutSnapshot, TerminalTab, TuiAgent } from '../../../../shared/types'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { buildWorktreeAgentRows } from './worktree-agent-rows'
@@ -255,6 +257,118 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(rows).toHaveLength(0)
   })
 
+  // Why: wrapper-launched claude (zsh function exec'ing the real binary) emits
+  // Claude activity titles without the literal "claude" token; fresh process
+  // identity must attribute the row instead.
+  it('builds a Claude row for a token-less Claude activity title with fresh claude process identity', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID_1)
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: 'orca-wrapper' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: '⠐ refactor split-pane status' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-claude'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      paneForegroundAgentByPaneKey: {
+        [paneKey]: {
+          agent: 'claude',
+          shellForeground: false,
+          observedAt: 1_900,
+          ptyId: 'pty-claude'
+        }
+      },
+      now: 2_000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state])).toEqual([['claude', 'working']])
+    expect(rows[0].paneKey).toBe(paneKey)
+  })
+
+  it('does not attribute Claude from stale (past-TTL) process evidence', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID_1)
+    const now = 100_000
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: 'orca-wrapper' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: '⠐ refactor split-pane status' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-claude'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      paneForegroundAgentByPaneKey: {
+        [paneKey]: {
+          agent: 'claude',
+          shellForeground: false,
+          observedAt: now - PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS - 1,
+          ptyId: 'pty-claude'
+        }
+      },
+      now
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
+  it('does not attribute Claude from evidence whose PTY is no longer live', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID_1)
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: 'orca-wrapper' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: '⠐ refactor split-pane status' }
+      },
+      // The pane respawned onto a different PTY; the old evidence must not bind.
+      ptyIdsByTabId: { 'tab-1': ['pty-respawned'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      paneForegroundAgentByPaneKey: {
+        [paneKey]: { agent: 'claude', shellForeground: false, observedAt: 1_900, ptyId: 'pty-dead' }
+      },
+      now: 2_000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
+  it('keeps the hook row (not a duplicate title-derived row) when both exist for a pane', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID_1)
+    const hookEntry: AgentStatusEntry = {
+      paneKey,
+      state: 'working',
+      prompt: '',
+      updatedAt: 1_900,
+      stateStartedAt: 1_900,
+      stateHistory: [],
+      agentType: 'codex'
+    }
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: 'orca-wrapper' })],
+      entries: [hookEntry],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: '⠐ refactor split-pane status' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-claude'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      paneForegroundAgentByPaneKey: {
+        [paneKey]: {
+          agent: 'claude',
+          shellForeground: false,
+          observedAt: 1_900,
+          ptyId: 'pty-claude'
+        }
+      },
+      now: 2_000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.rowSource])).toEqual([['codex', 'live']])
+  })
+
+  // Why: non-braille Claude activity markers without a Claude token must not
+  // invent a Claude row from launchAgent alone (split-pane residual risk).
   it('does not turn generic Codex-launched task titles into Claude Code rows', () => {
     const launchAgent: TuiAgent = 'codex'
     const rows = buildWorktreeAgentRows({

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -368,21 +368,32 @@ describe('buildTitleDerivedAgentRows', () => {
   })
 
   // Why: non-braille Claude activity markers without a Claude token must not
-  // invent a Claude row from launchAgent alone (split-pane residual risk).
-  it('does not turn generic Codex-launched task titles into Claude Code rows', () => {
-    const launchAgent: TuiAgent = 'codex'
-    const rows = buildWorktreeAgentRows({
-      tabs: [makeTab('tab-1', { launchAgent })],
-      entries: [],
-      retained: [],
-      runtimePaneTitlesByTabId: {
-        'tab-1': { 1: '✳ refactor split-pane status' }
-      },
-      ptyIdsByTabId: { 'tab-1': ['pty-codex'] },
-      terminalLayoutsByTabId: { 'tab-1': makeSplitLayout() },
-      now: 2000
-    })
+  // invent a Claude row from launchAgent alone. Braille-only titles may fall
+  // back to launchAgent (Codex over SSH, #8711) — still never Claude.
+  it.each([
+    ['✳ refactor split-pane status', null],
+    ['⠐ refactor split-pane status', 'codex']
+  ] as const)(
+    'does not turn generic Codex-launched task title %s into Claude Code rows',
+    (title, expectedAgent) => {
+      const launchAgent: TuiAgent = 'codex'
+      const rows = buildWorktreeAgentRows({
+        tabs: [makeTab('tab-1', { launchAgent })],
+        entries: [],
+        retained: [],
+        runtimePaneTitlesByTabId: {
+          'tab-1': { 1: title }
+        },
+        ptyIdsByTabId: { 'tab-1': ['pty-codex'] },
+        terminalLayoutsByTabId: { 'tab-1': makeSplitLayout() },
+        now: 2000
+      })
 
-    expect(rows).toHaveLength(0)
-  })
+      if (expectedAgent === null) {
+        expect(rows).toHaveLength(0)
+      } else {
+        expect(rows.map((row) => row.agentType)).toEqual([expectedAgent])
+      }
+    }
+  )
 })

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -3,6 +3,10 @@ import { formatAgentTypeLabel, isClaudeManagementTitle } from '@/lib/agent-statu
 import { containsBrailleSpinner } from '../../../../shared/agent-title-core'
 import { classifyTitleActivity, resolveTitleActivityLabel } from '@/lib/pane-agent-evidence'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
+import {
+  resolveFreshPaneForegroundAgent,
+  type PaneForegroundAgentEntry
+} from '@/store/slices/pane-foreground-agent'
 import type {
   AgentStatusEntry,
   AgentStatusOrchestrationContext,
@@ -13,7 +17,8 @@ import { isTerminalLeafId, makePaneKey } from '../../../../shared/stable-pane-id
 import type {
   TerminalLayoutSnapshot,
   TerminalPaneLayoutNode,
-  TerminalTab
+  TerminalTab,
+  TuiAgent
 } from '../../../../shared/types'
 import {
   normalizeCompatibleAgentTitleForOwner,
@@ -50,6 +55,7 @@ export function buildTitleDerivedAgentRows(args: {
   ptyIdsByTabId?: Record<string, string[]>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
+  paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
   seenPaneKeys: Set<string>
   now: number
 }): DashboardAgentRow[] {
@@ -85,7 +91,15 @@ export function buildTitleDerivedAgentRows(args: {
           leafId,
           title,
           now: args.now,
-          runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
+          runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey,
+          processAgent: freshProcessAgentForLeaf({
+            tabId: tab.id,
+            leafId,
+            layout,
+            livePtyIds: ptyIdsByTabId[tab.id],
+            paneForegroundAgentByPaneKey: args.paneForegroundAgentByPaneKey,
+            now: args.now
+          })
         })
         if (!row || args.seenPaneKeys.has(row.paneKey)) {
           continue
@@ -105,7 +119,15 @@ export function buildTitleDerivedAgentRows(args: {
       leafId,
       title: tab.title,
       now: args.now,
-      runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
+      runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey,
+      processAgent: freshProcessAgentForLeaf({
+        tabId: tab.id,
+        leafId,
+        layout,
+        livePtyIds: ptyIdsByTabId[tab.id],
+        paneForegroundAgentByPaneKey: args.paneForegroundAgentByPaneKey,
+        now: args.now
+      })
     })
     if (!row || args.seenPaneKeys.has(row.paneKey)) {
       continue
@@ -127,6 +149,7 @@ function buildTitleDerivedAgentRow(args: {
   title: string
   now: number
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
+  processAgent?: TuiAgent | null
 }): DashboardAgentRow | null {
   const title = normalizeCompatibleAgentTitleForOwner(args.title, args.tab.launchAgent)
   const isClaudeAgentsTitle = isClaudeManagementTitle(title)
@@ -143,7 +166,9 @@ function buildTitleDerivedAgentRow(args: {
   }
   const paneKey = makePaneKey(args.tab.id, args.leafId)
   const orchestration = args.runtimeAgentOrchestrationByPaneKey?.[paneKey]
-  const titleAgentType = isClaudeAgentsTitle ? 'claude' : resolveTitleDerivedAgentType(title, label)
+  const titleAgentType = isClaudeAgentsTitle
+    ? 'claude'
+    : resolveTitleDerivedAgentType(title, label, args.processAgent)
   // Why: a braille spinner proves activity, not identity, so the resolver drops
   // it. Hook-less agents over SSH (Codex, #8711) surface only spinner+cwd titles;
   // fall back to the tab's launch identity instead of hiding the pane. Gated on
@@ -184,15 +209,24 @@ function buildTitleDerivedAgentRow(args: {
   }
 }
 
-export function resolveTitleDerivedAgentType(title: string, label: string): AgentType | null {
+export function resolveTitleDerivedAgentType(
+  title: string,
+  label: string,
+  processAgent?: AgentType | null
+): AgentType | null {
   const agentType = TITLE_AGENT_LABEL_TO_TYPE[label] ?? 'unknown'
   if (agentType !== 'claude') {
     return agentType
   }
   // Why: Claude's task-title spinner heuristic has no provider identity. In
   // split panes it can match arbitrary terminal spinners, so sidebar rows only
-  // accept Claude when the title itself names Claude.
-  return CLAUDE_AGENT_TOKEN_RE.test(title) ? agentType : null
+  // accept Claude when the title itself names Claude — or when fresh
+  // process-table identity proves a claude foreground (wrapper launches via a
+  // shell function never put the literal token in the title).
+  if (CLAUDE_AGENT_TOKEN_RE.test(title)) {
+    return agentType
+  }
+  return processAgent === 'claude' ? agentType : null
 }
 
 /**
@@ -201,7 +235,8 @@ export function resolveTitleDerivedAgentType(title: string, label: string): Agen
  */
 export function resolveAgentTypeFromTerminalTitle(
   title: string | null | undefined,
-  ownerAgentType?: AgentType | null
+  ownerAgentType?: AgentType | null,
+  processAgent?: AgentType | null
 ): AgentType | null {
   if (!title) {
     return null
@@ -210,10 +245,34 @@ export function resolveAgentTypeFromTerminalTitle(
   const label = resolveTitleActivityLabel(normalizedTitle)
   return label
     ? (resolveCompatibleAgentTypeForOwner(
-        resolveTitleDerivedAgentType(normalizedTitle, label),
+        resolveTitleDerivedAgentType(normalizedTitle, label, processAgent),
         ownerAgentType
       ) ?? null)
     : null
+}
+
+/**
+ * TTL- and liveness-gated process identity for one pane, used to attribute
+ * title-derived rows (and the worktree ring, via worktree-status) when the
+ * title alone cannot name the agent.
+ */
+export function freshProcessAgentForLeaf(args: {
+  tabId: string
+  leafId: string
+  layout: TerminalLayoutSnapshot | undefined
+  livePtyIds: readonly string[] | undefined
+  paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry> | undefined
+  now: number
+}): TuiAgent | null {
+  if (!args.paneForegroundAgentByPaneKey || !isTerminalLeafId(args.leafId)) {
+    return null
+  }
+  const entry = args.paneForegroundAgentByPaneKey[makePaneKey(args.tabId, args.leafId)]
+  return resolveFreshPaneForegroundAgent(entry, {
+    now: args.now,
+    paneBoundPtyId: args.layout?.ptyIdsByLeafId?.[args.leafId],
+    liveTabPtyIds: args.livePtyIds
+  })
 }
 
 function titleStatusToRowState(

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -218,11 +218,8 @@ export function resolveTitleDerivedAgentType(
   if (agentType !== 'claude') {
     return agentType
   }
-  // Why: Claude's task-title spinner heuristic has no provider identity. In
-  // split panes it can match arbitrary terminal spinners, so sidebar rows only
-  // accept Claude when the title itself names Claude — or when fresh
-  // process-table identity proves a claude foreground (wrapper launches via a
-  // shell function never put the literal token in the title).
+  // Why: generic spinner titles may be unrelated; require either a Claude token
+  // or fresh Claude process identity before attributing them.
   if (CLAUDE_AGENT_TOKEN_RE.test(title)) {
     return agentType
   }

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
@@ -35,10 +35,8 @@ export type AgentCompletionCoordinatorOptions = {
     replacement: RecognizedAgentProcess
   ) => boolean
   shouldSuppressConfirmedProcessExitCompletion?: (exited: RecognizedAgentProcess) => boolean
-  // Why: each inspection that recognizes a foreground agent is fresh identity
-  // evidence; callers use it to keep TTL-gated attribution alive without
-  // adding scans of their own. `inspectedPtyId` is the PTY the inspection ran
-  // against, so evidence can be bound to it (the pane may rebind meanwhile).
+  // Why: existing inspections refresh attribution without added scans; include
+  // the inspected PTY so a concurrent pane rebind cannot inherit the evidence.
   onForegroundAgentInspected?: (process: RecognizedAgentProcess, inspectedPtyId: string) => void
   isLive: () => boolean
   shouldPollProcessCadence?: () => boolean

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
@@ -35,6 +35,10 @@ export type AgentCompletionCoordinatorOptions = {
     replacement: RecognizedAgentProcess
   ) => boolean
   shouldSuppressConfirmedProcessExitCompletion?: (exited: RecognizedAgentProcess) => boolean
+  // Why: each inspection that recognizes a foreground agent is fresh identity
+  // evidence; callers use it to keep TTL-gated attribution alive without
+  // adding scans of their own.
+  onForegroundAgentInspected?: (process: RecognizedAgentProcess) => void
   isLive: () => boolean
   shouldPollProcessCadence?: () => boolean
   // Why: on hosts where one inspection forks a whole-process-table scan (local

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
@@ -37,8 +37,9 @@ export type AgentCompletionCoordinatorOptions = {
   shouldSuppressConfirmedProcessExitCompletion?: (exited: RecognizedAgentProcess) => boolean
   // Why: each inspection that recognizes a foreground agent is fresh identity
   // evidence; callers use it to keep TTL-gated attribution alive without
-  // adding scans of their own.
-  onForegroundAgentInspected?: (process: RecognizedAgentProcess) => void
+  // adding scans of their own. `inspectedPtyId` is the PTY the inspection ran
+  // against, so evidence can be bound to it (the pane may rebind meanwhile).
+  onForegroundAgentInspected?: (process: RecognizedAgentProcess, inspectedPtyId: string) => void
   isLive: () => boolean
   shouldPollProcessCadence?: () => boolean
   // Why: on hosts where one inspection forks a whole-process-table scan (local

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -98,6 +98,40 @@ describe('agent completion coordinator', () => {
     expect(inspectProcess).toHaveBeenCalledTimes(1)
   })
 
+  // Why: consumers keep TTL-gated attribution fresh from these existing
+  // inspections; only recognized agents may be reported.
+  it('notifies onForegroundAgentInspected only for recognized inspections', async () => {
+    let foregroundProcess = 'codex'
+    const inspectProcess = vi.fn(async () => processResult(foregroundProcess))
+    const onForegroundAgentInspected = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess,
+      dispatchCompletion: vi.fn(),
+      isLive: () => true,
+      onForegroundAgentInspected
+    })
+
+    coordinator.startProcessTracking()
+    vi.advanceTimersByTime(2_000)
+    await flushAsyncTicks()
+
+    expect(onForegroundAgentInspected).toHaveBeenCalledWith({
+      agent: 'codex',
+      processName: 'codex'
+    })
+
+    onForegroundAgentInspected.mockClear()
+    foregroundProcess = 'vim'
+    vi.advanceTimersByTime(2_000)
+    await flushAsyncTicks()
+
+    expect(onForegroundAgentInspected).not.toHaveBeenCalled()
+    coordinator.dispose()
+  })
+
   // Why: regression guard for the hidden-pane throttle (follow-up to #6288 /
   // PR #6667). A hidden pane with a live agent kept polling the OS process
   // table at full 750ms cadence purely as a backstop, wasting idle CPU on

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -118,10 +118,13 @@ describe('agent completion coordinator', () => {
     vi.advanceTimersByTime(2_000)
     await flushAsyncTicks()
 
-    expect(onForegroundAgentInspected).toHaveBeenCalledWith({
-      agent: 'codex',
-      processName: 'codex'
-    })
+    expect(onForegroundAgentInspected).toHaveBeenCalledWith(
+      {
+        agent: 'codex',
+        processName: 'codex'
+      },
+      'pty-1'
+    )
 
     onForegroundAgentInspected.mockClear()
     foregroundProcess = 'vim'

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -481,6 +481,7 @@ export function createAgentCompletionCoordinator(
     consecutiveInspectionErrors = 0
     const recognized = recognizeAgentProcess(result.foregroundProcess)
     if (recognized) {
+      options.onForegroundAgentInspected?.(recognized)
       handleRecognizedProcess(recognized)
       return true
     }

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -470,7 +470,10 @@ export function createAgentCompletionCoordinator(
     establishAgentEvidence()
   }
 
-  function handleProcessInspectionResult(result: RuntimeTerminalProcessInspection): boolean {
+  function handleProcessInspectionResult(
+    result: RuntimeTerminalProcessInspection,
+    inspectedPtyId: string
+  ): boolean {
     if (result.unavailable === true) {
       // Why: unknown liveness breaks the consecutive-idle proof without erasing known agent ownership.
       pendingProcessExitAgent = null
@@ -481,7 +484,9 @@ export function createAgentCompletionCoordinator(
     consecutiveInspectionErrors = 0
     const recognized = recognizeAgentProcess(result.foregroundProcess)
     if (recognized) {
-      options.onForegroundAgentInspected?.(recognized)
+      // Why: pass the PTY the inspection actually ran against so consumers can
+      // bind the evidence — the pane may have rebound to a new PTY meanwhile.
+      options.onForegroundAgentInspected?.(recognized, inspectedPtyId)
       handleRecognizedProcess(recognized)
       return true
     }
@@ -554,7 +559,7 @@ export function createAgentCompletionCoordinator(
               !pendingTitle ||
               (priority === 'pending-title' && pendingTitle.id === pendingTitleIdAtRequest)
             if (appliesToCurrentPendingTitle) {
-              inspectedRecognizedAgent = handleProcessInspectionResult(result)
+              inspectedRecognizedAgent = handleProcessInspectionResult(result, ptyId)
             }
             inspectionSucceeded = true
           }

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -250,6 +250,7 @@ type StoreState = {
   dropAgentStatus: ReturnType<typeof vi.fn>
   retireAgentPaneAuthority: ReturnType<typeof vi.fn>
   setPaneForegroundAgent: ReturnType<typeof vi.fn>
+  refreshPaneForegroundAgentObservation: ReturnType<typeof vi.fn>
   clearPaneForegroundAgent: ReturnType<typeof vi.fn>
   markTerminalTabUnread: ReturnType<typeof vi.fn>
   markTerminalPaneUnread: ReturnType<typeof vi.fn>
@@ -979,6 +980,9 @@ describe('connectPanePty', () => {
       setPaneForegroundAgent: vi.fn((paneKey: string, entry: PaneForegroundAgentEntry) => {
         mockStoreState.paneForegroundAgentByPaneKey[paneKey] = entry
       }),
+      // Why: observation bumps only touch observedAt; keeping this a no-op keeps
+      // the exact entry assertions below about publish payloads, not freshness.
+      refreshPaneForegroundAgentObservation: vi.fn(),
       clearPaneForegroundAgent: vi.fn((paneKey: string) => {
         delete mockStoreState.paneForegroundAgentByPaneKey[paneKey]
       }),
@@ -7007,6 +7011,7 @@ describe('connectPanePty', () => {
     expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('alt-enter')
     await vi.advanceTimersByTimeAsync(1200)
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: 'droid',
       routingTrusted: true,
       shellForeground: false
@@ -7038,6 +7043,7 @@ describe('connectPanePty', () => {
 
     expect(window.api.pty.confirmForegroundProcess).toHaveBeenCalledWith(ptyId)
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: 'droid',
       routingTrusted: true,
       shellForeground: false
@@ -7078,6 +7084,7 @@ describe('connectPanePty', () => {
 
     expect(window.api.pty.confirmForegroundProcess).toHaveBeenCalledWith(ptyId)
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: 'droid',
       routingTrusted: true,
       shellForeground: false
@@ -7114,6 +7121,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks()
 
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: 'droid',
       routingTrusted: true,
       shellForeground: false
@@ -7148,6 +7156,7 @@ describe('connectPanePty', () => {
 
     // Benign miss: shell never latched as foreground; encoding still safe fallback.
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: null,
       shellForeground: false
     })
@@ -7160,6 +7169,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks()
 
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: 'droid',
       routingTrusted: true,
       shellForeground: false
@@ -7190,6 +7200,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks()
 
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: 'droid',
       routingRevoked: true,
       shellForeground: false
@@ -7199,6 +7210,7 @@ describe('connectPanePty', () => {
     await vi.advanceTimersByTimeAsync(350 + 1200 + 6000)
 
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: null,
       shellForeground: true
     })
@@ -7339,6 +7351,7 @@ describe('connectPanePty', () => {
       dataCallbackRef.current?.('\x1b]133;C\x07')
 
       expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+        ptyId,
         agent: null,
         shellForeground: false
       })
@@ -7427,6 +7440,7 @@ describe('connectPanePty', () => {
     expect(getForegroundProcess).toHaveBeenCalledTimes(readsBeforeFinish + 1)
     expect(mockStoreState.clearAgentLaunchConfig).not.toHaveBeenCalled()
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: 'droid',
       routingTrusted: true,
       shellForeground: false
@@ -7467,6 +7481,7 @@ describe('connectPanePty', () => {
     await vi.advanceTimersByTimeAsync(350)
     expect(mockStoreState.clearAgentLaunchConfig).toHaveBeenCalledExactlyOnceWith(paneKey)
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: null,
       shellForeground: true
     })
@@ -7590,6 +7605,7 @@ describe('connectPanePty', () => {
 
     expect(mockStoreState.clearAgentLaunchConfig).toHaveBeenCalledExactlyOnceWith(paneKey)
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: null,
       shellForeground: false
     })
@@ -19841,6 +19857,12 @@ describe('connectPanePty', () => {
       paneKey: makePaneKey('tab-1', LEAF_1)
     })
     expect(window.api.pty.inspectProcess).toHaveBeenCalledWith('pty-codex')
+    // Why: recognized inspections must also keep the pane's process-identity
+    // observation fresh for TTL-gated sidebar attribution (no new scans).
+    expect(mockStoreState.refreshPaneForegroundAgentObservation).toHaveBeenCalledWith(
+      makePaneKey('tab-1', LEAF_1),
+      'codex'
+    )
   })
 
   it('does not dispatch generic spinner completions when process inspection finds no agent', async () => {
@@ -23460,6 +23482,7 @@ describe('connectPanePty', () => {
 
       expect(foregroundReadCallsFor(ptyId)).toEqual([[ptyId]])
       expect(mockStoreState.setPaneForegroundAgent).toHaveBeenCalledWith(cacheKey, {
+        ptyId,
         agent: 'codex',
         shellForeground: false
       })
@@ -23544,6 +23567,7 @@ describe('connectPanePty', () => {
 
       await vi.advanceTimersByTimeAsync(1)
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        ptyId,
         agent: 'droid',
         routingRevoked: true,
         shellForeground: false
@@ -23553,6 +23577,7 @@ describe('connectPanePty', () => {
       await flushAsyncTicks()
       expect(window.api.pty.confirmForegroundProcess).toHaveBeenCalledWith(ptyId)
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        ptyId,
         agent: 'droid',
         routingTrusted: true,
         shellForeground: false
@@ -23562,6 +23587,7 @@ describe('connectPanePty', () => {
       await vi.advanceTimersByTimeAsync(700)
       await flushAsyncTicks()
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        ptyId,
         agent: 'droid',
         routingTrusted: true,
         shellForeground: false
@@ -23634,6 +23660,7 @@ describe('connectPanePty', () => {
       })
       expect(mockStoreState.registerAgentLaunchConfig).not.toHaveBeenCalled()
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        ptyId,
         agent: 'droid',
         shellForeground: false
       })
@@ -23642,6 +23669,7 @@ describe('connectPanePty', () => {
       await advanceVisibleForegroundRead()
 
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        ptyId,
         agent: 'droid',
         routingTrusted: true,
         shellForeground: false
@@ -23673,6 +23701,7 @@ describe('connectPanePty', () => {
         vi.mocked(window.api.pty.confirmForegroundProcess).mock.calls.length
       ).toBeGreaterThanOrEqual(3)
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        ptyId,
         agent: null,
         shellForeground: true
       })
@@ -23761,6 +23790,7 @@ describe('connectPanePty', () => {
 
       expect(foregroundReadCallsFor(ptyId).length).toBeGreaterThanOrEqual(3)
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        ptyId,
         agent: null,
         shellForeground: true
       })
@@ -23889,6 +23919,7 @@ describe('connectPanePty', () => {
       await advanceVisibleForegroundRead()
 
       expect(mockStoreState.setPaneForegroundAgent).toHaveBeenCalledWith(cacheKey, {
+        ptyId,
         agent: null,
         shellForeground: true
       })
@@ -23934,10 +23965,12 @@ describe('connectPanePty', () => {
 
       expect(foregroundReadCallsFor(ptyId)).toEqual([[ptyId]])
       expect(mockStoreState.setPaneForegroundAgent).not.toHaveBeenCalledWith(cacheKey, {
+        ptyId,
         agent: null,
         shellForeground: true
       })
       expect(mockStoreState.setPaneForegroundAgent).toHaveBeenCalledWith(cacheKey, {
+        ptyId,
         agent: 'droid',
         routingTrusted: true,
         shellForeground: false

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -19858,10 +19858,12 @@ describe('connectPanePty', () => {
     })
     expect(window.api.pty.inspectProcess).toHaveBeenCalledWith('pty-codex')
     // Why: recognized inspections must also keep the pane's process-identity
-    // observation fresh for TTL-gated sidebar attribution (no new scans).
+    // observation fresh for TTL-gated sidebar attribution (no new scans), and
+    // must bind the evidence to the PTY the inspection ran against.
     expect(mockStoreState.refreshPaneForegroundAgentObservation).toHaveBeenCalledWith(
       makePaneKey('tab-1', LEAF_1),
-      'codex'
+      'codex',
+      'pty-codex'
     )
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -7262,6 +7262,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks()
 
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: null,
       shellForeground: true
     })
@@ -23615,6 +23616,7 @@ describe('connectPanePty', () => {
       binding.sampleForegroundAgentOnFocus()
 
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        ptyId,
         agent: 'pi',
         routingRevoked: true,
         shellForeground: false
@@ -23626,6 +23628,7 @@ describe('connectPanePty', () => {
       )
       await flushAsyncTicks()
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        ptyId,
         agent: null,
         shellForeground: true
       })

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2214,7 +2214,7 @@ export function connectPanePty(
     // Why: cmd.exe and Git Bash have no OSC command boundaries. Keep the icon
     // as a hint, but revoke bytes until one current provider confirmation lands.
     useAppStore.getState().setPaneForegroundAgent(cacheKey, {
-agent: foreground.agent,
+      agent: foreground.agent,
       routingRevoked: true,
       shellForeground: false,
       ptyId: transport.getPtyId() ?? undefined

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1316,7 +1316,8 @@ export function connectPanePty(
         // closed. Use it to request confirmation, never as current byte authority.
         useAppStore.getState().setPaneForegroundAgent(cacheKey, {
           agent: metadata.launchAgent,
-          shellForeground: false
+          shellForeground: false,
+          ptyId: transport.getPtyId() ?? undefined
         })
       }
       return
@@ -2096,7 +2097,13 @@ export function connectPanePty(
     isTrackablePtyId: isForegroundTrackingAllowed,
     readForegroundProcess: (id) => window.api.pty.getForegroundProcess(id),
     confirmForegroundProcess: (id) => window.api.pty.confirmForegroundProcess(id),
-    publish: (entry) => useAppStore.getState().setPaneForegroundAgent(cacheKey, entry),
+    // Why: bind the evidence to the PTY it was read from — the tracker skips
+    // publishes across rebinds, so the current transport PTY is that PTY.
+    publish: (entry) =>
+      useAppStore.getState().setPaneForegroundAgent(cacheKey, {
+        ...entry,
+        ptyId: transport.getPtyId() ?? undefined
+      }),
     hasKnownAgentIdentity: paneHasKnownAgentIdentity,
     onConfirmedShellForeground: (reason) => {
       clearStaleAgentTabTitleOnConfirmedShell()
@@ -2207,9 +2214,10 @@ export function connectPanePty(
     // Why: cmd.exe and Git Bash have no OSC command boundaries. Keep the icon
     // as a hint, but revoke bytes until one current provider confirmation lands.
     useAppStore.getState().setPaneForegroundAgent(cacheKey, {
-      agent: foreground.agent,
+agent: foreground.agent,
       routingRevoked: true,
-      shellForeground: false
+      shellForeground: false,
+      ptyId: transport.getPtyId() ?? undefined
     })
     visibleForegroundSamplePending = false
     visibleForegroundSampleSettled = false
@@ -2397,6 +2405,15 @@ export function connectPanePty(
       return (
         isFreshNonDoneAgentStatus(currentStatus) && currentAgentForReplacement === replacement.agent
       )
+    },
+    onForegroundAgentInspected: (process) => {
+      const inspectedPtyId = transport.getPtyId()
+      // Why: same local-only gate as the tracker — remote/WSL inspections must
+      // not become renderer process evidence for this pane.
+      if (!inspectedPtyId || !isForegroundTrackingAllowed(inspectedPtyId)) {
+        return
+      }
+      useAppStore.getState().refreshPaneForegroundAgentObservation(cacheKey, process.agent)
     },
     shouldSuppressConfirmedProcessExitCompletion: (exited) => {
       const currentStatus = useAppStore.getState().agentStatusByPaneKey[cacheKey]

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2406,14 +2406,16 @@ agent: foreground.agent,
         isFreshNonDoneAgentStatus(currentStatus) && currentAgentForReplacement === replacement.agent
       )
     },
-    onForegroundAgentInspected: (process) => {
-      const inspectedPtyId = transport.getPtyId()
+    onForegroundAgentInspected: (process, inspectedPtyId) => {
       // Why: same local-only gate as the tracker — remote/WSL inspections must
-      // not become renderer process evidence for this pane.
-      if (!inspectedPtyId || !isForegroundTrackingAllowed(inspectedPtyId)) {
+      // not become renderer process evidence for this pane — and an inspection
+      // of a PTY the pane no longer owns (respawn race) must not either.
+      if (!isForegroundTrackingAllowed(inspectedPtyId) || transport.getPtyId() !== inspectedPtyId) {
         return
       }
-      useAppStore.getState().refreshPaneForegroundAgentObservation(cacheKey, process.agent)
+      useAppStore
+        .getState()
+        .refreshPaneForegroundAgentObservation(cacheKey, process.agent, inspectedPtyId)
     },
     shouldSuppressConfirmedProcessExitCompletion: (exited) => {
       const currentStatus = useAppStore.getState().agentStatusByPaneKey[cacheKey]

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2407,9 +2407,8 @@ agent: foreground.agent,
       )
     },
     onForegroundAgentInspected: (process, inspectedPtyId) => {
-      // Why: same local-only gate as the tracker — remote/WSL inspections must
-      // not become renderer process evidence for this pane — and an inspection
-      // of a PTY the pane no longer owns (respawn race) must not either.
+      // Why: only local evidence for the pane's current PTY may refresh identity;
+      // remote/WSL or pre-respawn results cannot bind to this pane.
       if (!isForegroundTrackingAllowed(inspectedPtyId) || transport.getPtyId() !== inspectedPtyId) {
         return
       }

--- a/src/renderer/src/lib/worktree-status.test.ts
+++ b/src/renderer/src/lib/worktree-status.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest'
+import { PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS } from '@/store/slices/pane-foreground-agent'
+import { makePaneKey } from '../../../shared/stable-pane-id'
 import type { TerminalLayoutSnapshot } from '../../../shared/types'
 import { getWorktreeStatus, getWorktreeStatusLabel, resolveWorktreeStatus } from './worktree-status'
 
@@ -137,6 +139,97 @@ describe('getWorktreeStatus', () => {
     )
 
     expect(status).toBe('working')
+  })
+
+  // Why: wrapper-launched claude emits activity titles without the "claude"
+  // token; fresh process-table identity supplies the attribution the token
+  // gate would otherwise demand — state still comes from the title.
+  describe('process-identity attribution', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID_1)
+    const soleLeafRoot = { type: 'leaf', leafId: LEAF_ID_1 } as const
+    const freshEntry = {
+      agent: 'claude',
+      shellForeground: false,
+      observedAt: 9_500,
+      ptyId: 'pty-claude'
+    } as const
+
+    it('spins on an unattributable working tab title when fresh process identity names claude', () => {
+      const status = getWorktreeStatus(
+        [{ id: 'tab-1', title: '⠐ Review branch for regressions' }],
+        [],
+        { 'tab-1': ['pty-claude'] },
+        {},
+        {
+          terminalLayoutRootsByTabId: { 'tab-1': soleLeafRoot },
+          paneForegroundAgentByPaneKey: { [paneKey]: freshEntry },
+          now: 10_000
+        }
+      )
+
+      expect(status).toBe('working')
+    })
+
+    it('spins on an unattributable working pane title when fresh process identity names claude', () => {
+      const status = getWorktreeStatus(
+        [{ id: 'tab-1', title: 'bash' }],
+        [],
+        { 'tab-1': ['pty-claude'] },
+        { 'tab-1': { 1: '⠐ Review branch for regressions' } },
+        {
+          terminalLayoutRootsByTabId: { 'tab-1': soleLeafRoot },
+          paneForegroundAgentByPaneKey: { [paneKey]: freshEntry },
+          now: 10_000
+        }
+      )
+
+      expect(status).toBe('working')
+    })
+
+    it('does not spin on stale (past-TTL) process evidence', () => {
+      const now = 10_000 + PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS
+      const status = getWorktreeStatus(
+        [{ id: 'tab-1', title: '⠐ Review branch for regressions' }],
+        [],
+        { 'tab-1': ['pty-claude'] },
+        {},
+        {
+          terminalLayoutRootsByTabId: { 'tab-1': soleLeafRoot },
+          paneForegroundAgentByPaneKey: {
+            [paneKey]: {
+              ...freshEntry,
+              observedAt: now - PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS - 1
+            }
+          },
+          now
+        }
+      )
+
+      expect(status).toBe('active')
+    })
+
+    it('does not spin when the pane is bound to a different live PTY than the evidence', () => {
+      const status = getWorktreeStatus(
+        [{ id: 'tab-1', title: '⠐ Review branch for regressions' }],
+        [],
+        { 'tab-1': ['pty-respawned'] },
+        {},
+        {
+          terminalLayoutsByTabId: {
+            'tab-1': {
+              root: soleLeafRoot,
+              activeLeafId: LEAF_ID_1,
+              expandedLeafId: null,
+              ptyIdsByLeafId: { [LEAF_ID_1]: 'pty-respawned' }
+            }
+          },
+          paneForegroundAgentByPaneKey: { [paneKey]: freshEntry },
+          now: 10_000
+        }
+      )
+
+      expect(status).toBe('active')
+    })
   })
 })
 

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -1,8 +1,12 @@
-import { resolveAgentTypeFromTerminalTitle } from '@/components/sidebar/worktree-title-derived-agent-rows'
+import {
+  freshProcessAgentForLeaf,
+  resolveAgentTypeFromTerminalTitle
+} from '@/components/sidebar/worktree-title-derived-agent-rows'
 import { classifyTitleActivity } from '@/lib/pane-agent-evidence'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import { resolveRuntimePaneTitleLeafIdFromRoot } from '@/lib/runtime-pane-title-leaf-id'
 import { containsBrailleSpinner } from '../../../shared/agent-title-core'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 import type {
   TerminalLayoutSnapshot,
   TerminalPaneLayoutNode,
@@ -18,6 +22,8 @@ type WorktreeStatusHeuristicOptions = {
   agentStatusPaneIdsByTabId?: Record<string, ReadonlySet<string>>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   terminalLayoutRootsByTabId?: Record<string, TerminalPaneLayoutNode | null | undefined>
+  paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
+  now?: number
 }
 
 const STATUS_LABELS: Record<WorktreeStatus, string> = {
@@ -40,7 +46,9 @@ export function getWorktreeStatus(
 
   // Why: tab.title tracks only the most-recently-focused pane (onActivePaneChange in use-terminal-pane-lifecycle.ts); consult per-pane titles so the spinner reflects aggregate tab state.
   const hasStatus = (status: 'permission' | 'working'): boolean =>
-    liveTabs.some((tab) => tabHasStatus(tab, runtimePaneTitlesByTabId, status, options))
+    liveTabs.some((tab) =>
+      tabHasStatus(tab, runtimePaneTitlesByTabId, status, options, ptyIdsByTabId)
+    )
 
   if (options.liveAgentStatus === 'permission' || hasStatus('permission')) {
     return 'permission'
@@ -59,9 +67,21 @@ function tabHasStatus(
   tab: Pick<TerminalTab, 'id' | 'title' | 'launchAgent'>,
   runtimePaneTitlesByTabId: Record<string, Record<number, string>>,
   status: 'permission' | 'working',
-  options: WorktreeStatusHeuristicOptions
+  options: WorktreeStatusHeuristicOptions,
+  ptyIdsByTabId: Record<string, string[]>
 ): boolean {
   const agentStatusPaneIds = options.agentStatusPaneIdsByTabId?.[tab.id]
+  const processAgentForLeaf = (leafId: string | null): TuiAgent | null =>
+    leafId === null
+      ? null
+      : freshProcessAgentForLeaf({
+          tabId: tab.id,
+          leafId,
+          layout: options.terminalLayoutsByTabId?.[tab.id],
+          livePtyIds: ptyIdsByTabId[tab.id],
+          paneForegroundAgentByPaneKey: options.paneForegroundAgentByPaneKey,
+          now: options.now ?? Date.now()
+        })
   const paneTitles = runtimePaneTitlesByTabId[tab.id]
   if (paneTitles && Object.keys(paneTitles).length > 0) {
     const tabLayoutRoot =
@@ -81,7 +101,7 @@ function tabHasStatus(
       }
       if (
         classifyTitleActivity(title) === status &&
-        titleStatusIsAgentAttributable(title, tab.launchAgent)
+        titleStatusIsAgentAttributable(title, processAgentForLeaf(leafId), tab.launchAgent)
       ) {
         return true
       }
@@ -94,13 +114,33 @@ function tabHasStatus(
   }
   return (
     classifyTitleActivity(tab.title) === status &&
-    titleStatusIsAgentAttributable(tab.title, tab.launchAgent)
+    // Why: a tab-level title can only borrow pane process identity when the
+    // layout proves the tab has exactly one pane.
+    titleStatusIsAgentAttributable(
+      tab.title,
+      processAgentForLeaf(resolveSoleLeafId(tab.id, options)),
+      tab.launchAgent
+    )
   )
 }
 
+function resolveSoleLeafId(tabId: string, options: WorktreeStatusHeuristicOptions): string | null {
+  const root =
+    options.terminalLayoutRootsByTabId?.[tabId] ?? options.terminalLayoutsByTabId?.[tabId]?.root
+  return root ? soleLeafIdOfNode(root) : null
+}
+
+function soleLeafIdOfNode(node: TerminalPaneLayoutNode): string | null {
+  return node.type === 'leaf' ? node.leafId : null
+}
+
 // Why: require agent attribution so a bare never-cleared spinner title can't spin the dot "0 agents" forever with no matching sidebar row.
-function titleStatusIsAgentAttributable(title: string, launchAgent?: TuiAgent | null): boolean {
-  if (resolveAgentTypeFromTerminalTitle(title) !== null) {
+function titleStatusIsAgentAttributable(
+  title: string,
+  processAgent?: TuiAgent | null,
+  launchAgent?: TuiAgent | null
+): boolean {
+  if (resolveAgentTypeFromTerminalTitle(title, undefined, processAgent) !== null) {
     return true
   }
   // Why: a spinner proves activity but not identity (Claude's thinking title has no provider
@@ -121,6 +161,7 @@ export function getWorktreeStatusLabel(status: WorktreeStatus): string {
  * Map args are narrowed to this worktree. `hasPermission`/`hasLiveWorking`/
  * `hasLiveDone` are fresh hook entries ({blocked,waiting} / {working} / {done});
  * `hasRetainedDone` is a retained-agent snapshot scoped to this worktreeId.
+ * Process evidence only attributes title-derived state; it never invents one.
  */
 export function resolveWorktreeStatus(args: {
   tabs: readonly Pick<TerminalTab, 'id' | 'title' | 'launchAgent'>[]
@@ -130,6 +171,8 @@ export function resolveWorktreeStatus(args: {
   agentStatusPaneIdsByTabId?: Record<string, ReadonlySet<string>>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   terminalLayoutRootsByTabId?: Record<string, TerminalPaneLayoutNode | null | undefined>
+  paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
+  now?: number
   hasPermission: boolean
   hasLiveWorking: boolean
   hasLiveDone: boolean
@@ -143,7 +186,9 @@ export function resolveWorktreeStatus(args: {
     {
       agentStatusPaneIdsByTabId: args.agentStatusPaneIdsByTabId,
       terminalLayoutsByTabId: args.terminalLayoutsByTabId,
-      terminalLayoutRootsByTabId: args.terminalLayoutRootsByTabId
+      terminalLayoutRootsByTabId: args.terminalLayoutRootsByTabId,
+      paneForegroundAgentByPaneKey: args.paneForegroundAgentByPaneKey,
+      now: args.now
     }
   )
   if (args.hasPermission) {

--- a/src/renderer/src/store/slices/pane-foreground-agent.test.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.test.ts
@@ -168,16 +168,39 @@ describe('pane foreground agent slice', () => {
     expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toBe(initial)
   })
 
-  it('creates identity-only evidence from an observation on a pane without an entry', () => {
+  it('creates identity-only evidence bound to the inspected PTY on a pane without an entry', () => {
     vi.spyOn(Date, 'now').mockReturnValue(10_000)
     const store = createTestStore()
 
-    store.getState().refreshPaneForegroundAgentObservation('tab-1:leaf-1', 'claude')
+    store.getState().refreshPaneForegroundAgentObservation('tab-1:leaf-1', 'claude', 'pty-1')
 
     expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toEqual({
       agent: 'claude',
       shellForeground: false,
-      observedAt: 10_000
+      observedAt: 10_000,
+      ptyId: 'pty-1'
+    })
+  })
+
+  it('rebinds evidence held for a previous PTY instead of keeping it fresh across a respawn', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000)
+    const store = createTestStore()
+    store.getState().setPaneForegroundAgent('tab-1:leaf-1', {
+      agent: 'claude',
+      shellForeground: false,
+      routingTrusted: true,
+      ptyId: 'pty-old'
+    })
+
+    nowSpy.mockReturnValue(20_000)
+    store.getState().refreshPaneForegroundAgentObservation('tab-1:leaf-1', 'claude', 'pty-new')
+
+    // Why: identity-only rebind — routing trust belonged to the old PTY.
+    expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toEqual({
+      agent: 'claude',
+      shellForeground: false,
+      observedAt: 20_000,
+      ptyId: 'pty-new'
     })
   })
 })

--- a/src/renderer/src/store/slices/pane-foreground-agent.test.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.test.ts
@@ -91,13 +91,11 @@ describe('pane foreground agent slice', () => {
   it('stamps observedAt when evidence is published and re-stamps past the refresh quantum', () => {
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000)
     const store = createTestStore()
-    store
-      .getState()
-      .setPaneForegroundAgent('tab-1:leaf-1', {
-        agent: 'claude',
-        shellForeground: false,
-        ptyId: 'pty-1'
-      })
+    store.getState().setPaneForegroundAgent('tab-1:leaf-1', {
+      agent: 'claude',
+      shellForeground: false,
+      ptyId: 'pty-1'
+    })
     expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toEqual({
       agent: 'claude',
       shellForeground: false,
@@ -108,23 +106,19 @@ describe('pane foreground agent slice', () => {
 
     // Within the quantum: identical publish keeps the reference (no churn).
     nowSpy.mockReturnValue(11_000)
-    store
-      .getState()
-      .setPaneForegroundAgent('tab-1:leaf-1', {
-        agent: 'claude',
-        shellForeground: false,
-        ptyId: 'pty-1'
-      })
+    store.getState().setPaneForegroundAgent('tab-1:leaf-1', {
+      agent: 'claude',
+      shellForeground: false,
+      ptyId: 'pty-1'
+    })
     expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toBe(initial)
 
     nowSpy.mockReturnValue(20_000)
-    store
-      .getState()
-      .setPaneForegroundAgent('tab-1:leaf-1', {
-        agent: 'claude',
-        shellForeground: false,
-        ptyId: 'pty-1'
-      })
+    store.getState().setPaneForegroundAgent('tab-1:leaf-1', {
+      agent: 'claude',
+      shellForeground: false,
+      ptyId: 'pty-1'
+    })
     expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']?.observedAt).toBe(20_000)
   })
 
@@ -150,16 +144,35 @@ describe('pane foreground agent slice', () => {
     })
   })
 
+  it('binds matching unbound evidence to the inspected PTY inside the refresh quantum', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000)
+    const store = createTestStore()
+    store.getState().setPaneForegroundAgent('tab-1:leaf-1', {
+      agent: 'claude',
+      shellForeground: false,
+      routingTrusted: true
+    })
+
+    nowSpy.mockReturnValue(10_750)
+    store.getState().refreshPaneForegroundAgentObservation('tab-1:leaf-1', 'claude', 'pty-1')
+
+    expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toEqual({
+      agent: 'claude',
+      shellForeground: false,
+      routingTrusted: true,
+      observedAt: 10_750,
+      ptyId: 'pty-1'
+    })
+  })
+
   it('ignores a coordinator observation whose identity differs from the tracked entry', () => {
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000)
     const store = createTestStore()
-    store
-      .getState()
-      .setPaneForegroundAgent('tab-1:leaf-1', {
-        agent: null,
-        shellForeground: true,
-        ptyId: 'pty-1'
-      })
+    store.getState().setPaneForegroundAgent('tab-1:leaf-1', {
+      agent: null,
+      shellForeground: true,
+      ptyId: 'pty-1'
+    })
     const initial = store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']
 
     nowSpy.mockReturnValue(20_000)

--- a/src/renderer/src/store/slices/pane-foreground-agent.test.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.test.ts
@@ -1,6 +1,15 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createTestStore } from './store-test-helpers'
 import type { TerminalTab } from '../../../../shared/types'
+import {
+  PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS,
+  resolveFreshPaneForegroundAgent,
+  type PaneForegroundAgentEntry
+} from './pane-foreground-agent'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 function terminalTab(id: string, worktreeId: string): TerminalTab {
   return {
@@ -77,5 +86,159 @@ describe('pane foreground agent slice', () => {
     store.getState().clearPaneForegroundAgentByWorktree('wt-1')
 
     expect(Object.keys(store.getState().paneForegroundAgentByPaneKey)).toEqual(['tab-3:leaf-1'])
+  })
+
+  it('stamps observedAt when evidence is published and re-stamps past the refresh quantum', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000)
+    const store = createTestStore()
+    store
+      .getState()
+      .setPaneForegroundAgent('tab-1:leaf-1', {
+        agent: 'claude',
+        shellForeground: false,
+        ptyId: 'pty-1'
+      })
+    expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toEqual({
+      agent: 'claude',
+      shellForeground: false,
+      ptyId: 'pty-1',
+      observedAt: 10_000
+    })
+    const initial = store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']
+
+    // Within the quantum: identical publish keeps the reference (no churn).
+    nowSpy.mockReturnValue(11_000)
+    store
+      .getState()
+      .setPaneForegroundAgent('tab-1:leaf-1', {
+        agent: 'claude',
+        shellForeground: false,
+        ptyId: 'pty-1'
+      })
+    expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toBe(initial)
+
+    nowSpy.mockReturnValue(20_000)
+    store
+      .getState()
+      .setPaneForegroundAgent('tab-1:leaf-1', {
+        agent: 'claude',
+        shellForeground: false,
+        ptyId: 'pty-1'
+      })
+    expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']?.observedAt).toBe(20_000)
+  })
+
+  it('bumps observedAt from a matching coordinator observation without touching other fields', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000)
+    const store = createTestStore()
+    store.getState().setPaneForegroundAgent('tab-1:leaf-1', {
+      agent: 'claude',
+      shellForeground: false,
+      routingTrusted: true,
+      ptyId: 'pty-1'
+    })
+
+    nowSpy.mockReturnValue(20_000)
+    store.getState().refreshPaneForegroundAgentObservation('tab-1:leaf-1', 'claude')
+
+    expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toEqual({
+      agent: 'claude',
+      shellForeground: false,
+      routingTrusted: true,
+      ptyId: 'pty-1',
+      observedAt: 20_000
+    })
+  })
+
+  it('ignores a coordinator observation whose identity differs from the tracked entry', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000)
+    const store = createTestStore()
+    store
+      .getState()
+      .setPaneForegroundAgent('tab-1:leaf-1', {
+        agent: null,
+        shellForeground: true,
+        ptyId: 'pty-1'
+      })
+    const initial = store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']
+
+    nowSpy.mockReturnValue(20_000)
+    store.getState().refreshPaneForegroundAgentObservation('tab-1:leaf-1', 'claude')
+
+    expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toBe(initial)
+  })
+
+  it('creates identity-only evidence from an observation on a pane without an entry', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(10_000)
+    const store = createTestStore()
+
+    store.getState().refreshPaneForegroundAgentObservation('tab-1:leaf-1', 'claude')
+
+    expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toEqual({
+      agent: 'claude',
+      shellForeground: false,
+      observedAt: 10_000
+    })
+  })
+})
+
+describe('resolveFreshPaneForegroundAgent', () => {
+  const entry = (overrides: Partial<PaneForegroundAgentEntry> = {}): PaneForegroundAgentEntry => ({
+    agent: 'claude',
+    shellForeground: false,
+    observedAt: 10_000,
+    ptyId: 'pty-1',
+    ...overrides
+  })
+
+  it('returns the agent for fresh evidence bound to a live pane PTY', () => {
+    expect(resolveFreshPaneForegroundAgent(entry(), { now: 10_500, paneBoundPtyId: 'pty-1' })).toBe(
+      'claude'
+    )
+  })
+
+  it('rejects evidence past the TTL or without an observation timestamp', () => {
+    expect(
+      resolveFreshPaneForegroundAgent(entry(), {
+        now: 10_000 + PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS + 1,
+        paneBoundPtyId: 'pty-1'
+      })
+    ).toBeNull()
+    expect(
+      resolveFreshPaneForegroundAgent(entry({ observedAt: undefined }), {
+        now: 10_500,
+        paneBoundPtyId: 'pty-1'
+      })
+    ).toBeNull()
+  })
+
+  it('rejects evidence bound to a PTY the pane no longer runs', () => {
+    expect(
+      resolveFreshPaneForegroundAgent(entry(), { now: 10_500, paneBoundPtyId: 'pty-2' })
+    ).toBeNull()
+    expect(
+      resolveFreshPaneForegroundAgent(entry(), { now: 10_500, liveTabPtyIds: ['pty-2'] })
+    ).toBeNull()
+  })
+
+  it('rejects evidence when the tab has no live PTY at all', () => {
+    expect(
+      resolveFreshPaneForegroundAgent(entry({ ptyId: undefined }), {
+        now: 10_500,
+        liveTabPtyIds: []
+      })
+    ).toBeNull()
+  })
+
+  it('falls back to tab-level liveness when no pane binding is known', () => {
+    expect(
+      resolveFreshPaneForegroundAgent(entry(), { now: 10_500, liveTabPtyIds: ['pty-1'] })
+    ).toBe('claude')
+    expect(
+      resolveFreshPaneForegroundAgent(entry({ ptyId: undefined }), {
+        now: 10_500,
+        liveTabPtyIds: ['pty-9']
+      })
+    ).toBe('claude')
   })
 })

--- a/src/renderer/src/store/slices/pane-foreground-agent.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.ts
@@ -117,6 +117,14 @@ current.routingRevoked === entry.routingRevoked &&
         if (current.agent !== agent) {
           return s
         }
+        if (ptyId !== undefined && current.ptyId === undefined) {
+          return {
+            paneForegroundAgentByPaneKey: {
+              ...s.paneForegroundAgentByPaneKey,
+              [paneKey]: { ...current, observedAt: now, ptyId }
+            }
+          }
+        }
         // Why: evidence bound to a previous PTY must not be kept fresh across
         // a respawn — rebind it as identity-only evidence of the inspected PTY.
         if (ptyId !== undefined && current.ptyId !== undefined && current.ptyId !== ptyId) {

--- a/src/renderer/src/store/slices/pane-foreground-agent.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.ts
@@ -2,6 +2,15 @@ import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import type { TuiAgent } from '../../../../shared/types'
 
+// Why: attribution consumers (sidebar rows, worktree ring) must not trust
+// process identity forever — an exited agent's entry could otherwise fake a
+// working state. 30s sits above the completion coordinator's slowest cadences
+// (3s hidden backstop, 15s no-evidence poll), which re-arm the observation.
+export const PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS = 30_000
+// Why: active-tier inspections land every ~750ms; re-stamping each one would
+// churn the store, so freshness bumps are quantized well below the TTL.
+const OBSERVATION_REFRESH_QUANTUM_MS = 5_000
+
 export type PaneForegroundAgentEntry = {
   /** Recognized agent process in the pane's foreground; null when unknown. */
   agent: TuiAgent | null
@@ -12,6 +21,10 @@ export type PaneForegroundAgentEntry = {
   /** True once the foreground is proven back at the shell (OSC 133;D) —
    *  process-grade launched-agent exit evidence, independent of titles. */
   shellForeground: boolean
+  /** When this evidence was recorded; attribution consumers gate on the TTL. */
+  observedAt?: number
+  /** PTY the evidence was read from, when the publisher knows it. */
+  ptyId?: string
 }
 
 /**
@@ -22,11 +35,39 @@ export type PaneForegroundAgentEntry = {
 export type PaneForegroundAgentSlice = {
   paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry>
   setPaneForegroundAgent: (paneKey: string, entry: PaneForegroundAgentEntry) => void
+  /** Freshness bump from the completion coordinator's existing inspections —
+   *  identity only, never routing trust; a differing identity is ignored so
+   *  the tracker keeps sole ownership of identity changes. */
+  refreshPaneForegroundAgentObservation: (paneKey: string, agent: TuiAgent) => void
   clearPaneForegroundAgent: (paneKey: string) => void
   /** Wholesale teardown sweeps (tab close, worktree sleep/remove) retire pane
    *  keys without per-pane close events — clear their entries too. */
   clearPaneForegroundAgentByTabPrefix: (tabIdPrefix: string) => void
   clearPaneForegroundAgentByWorktree: (worktreeId: string) => void
+}
+
+/**
+ * Attribution-grade read of a pane's process identity: the agent counts only
+ * while the evidence is fresh (TTL) and the pane still has a live PTY — at the
+ * finest liveness granularity the caller can supply.
+ */
+export function resolveFreshPaneForegroundAgent(
+  entry: PaneForegroundAgentEntry | undefined,
+  args: { now: number; paneBoundPtyId?: string; liveTabPtyIds?: readonly string[] }
+): TuiAgent | null {
+  if (!entry?.agent || entry.observedAt === undefined) {
+    return null
+  }
+  if (args.now - entry.observedAt > PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS) {
+    return null
+  }
+  if (args.paneBoundPtyId !== undefined) {
+    return entry.ptyId === undefined || entry.ptyId === args.paneBoundPtyId ? entry.agent : null
+  }
+  if (entry.ptyId !== undefined) {
+    return args.liveTabPtyIds?.includes(entry.ptyId) === true ? entry.agent : null
+  }
+  return (args.liveTabPtyIds?.length ?? 0) > 0 ? entry.agent : null
 }
 
 export const createPaneForegroundAgentSlice: StateCreator<
@@ -38,18 +79,68 @@ export const createPaneForegroundAgentSlice: StateCreator<
   paneForegroundAgentByPaneKey: {},
   setPaneForegroundAgent: (paneKey, entry) => {
     set((s) => {
+      const now = Date.now()
       const current = s.paneForegroundAgentByPaneKey[paneKey]
       if (
         current &&
         current.agent === entry.agent &&
         current.routingTrusted === entry.routingTrusted &&
-        current.routingRevoked === entry.routingRevoked &&
-        current.shellForeground === entry.shellForeground
+current.routingRevoked === entry.routingRevoked &&
+        current.shellForeground === entry.shellForeground &&
+        current.ptyId === entry.ptyId
       ) {
-        return s
+        // Why: an identical re-publish is still fresh evidence; bump the
+        // observation quantized so repeated confirmations don't churn the store.
+        if (
+          current.observedAt !== undefined &&
+          now - current.observedAt < OBSERVATION_REFRESH_QUANTUM_MS
+        ) {
+          return s
+        }
+        return {
+          paneForegroundAgentByPaneKey: {
+            ...s.paneForegroundAgentByPaneKey,
+            [paneKey]: { ...current, observedAt: now }
+          }
+        }
       }
       return {
-        paneForegroundAgentByPaneKey: { ...s.paneForegroundAgentByPaneKey, [paneKey]: entry }
+        paneForegroundAgentByPaneKey: {
+          ...s.paneForegroundAgentByPaneKey,
+          // Why: stamp centrally so every publisher gets TTL-gated evidence.
+          [paneKey]: { ...entry, observedAt: entry.observedAt ?? now }
+        }
+      }
+    })
+  },
+  refreshPaneForegroundAgentObservation: (paneKey, agent) => {
+    set((s) => {
+      const now = Date.now()
+      const current = s.paneForegroundAgentByPaneKey[paneKey]
+      if (current) {
+        if (current.agent !== agent) {
+          return s
+        }
+        if (
+          current.observedAt !== undefined &&
+          now - current.observedAt < OBSERVATION_REFRESH_QUANTUM_MS
+        ) {
+          return s
+        }
+        return {
+          paneForegroundAgentByPaneKey: {
+            ...s.paneForegroundAgentByPaneKey,
+            [paneKey]: { ...current, observedAt: now }
+          }
+        }
+      }
+      // Why: coordinator inspections also cover panes whose tracker read raced
+      // or whose shell emits no OSC 133 — identity evidence only, no routing.
+      return {
+        paneForegroundAgentByPaneKey: {
+          ...s.paneForegroundAgentByPaneKey,
+          [paneKey]: { agent, shellForeground: false, observedAt: now }
+        }
       }
     })
   },

--- a/src/renderer/src/store/slices/pane-foreground-agent.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.ts
@@ -37,8 +37,9 @@ export type PaneForegroundAgentSlice = {
   setPaneForegroundAgent: (paneKey: string, entry: PaneForegroundAgentEntry) => void
   /** Freshness bump from the completion coordinator's existing inspections —
    *  identity only, never routing trust; a differing identity is ignored so
-   *  the tracker keeps sole ownership of identity changes. */
-  refreshPaneForegroundAgentObservation: (paneKey: string, agent: TuiAgent) => void
+   *  the tracker keeps sole ownership of identity changes. `ptyId` is the PTY
+   *  the inspection ran against; it binds created/rebound evidence. */
+  refreshPaneForegroundAgentObservation: (paneKey: string, agent: TuiAgent, ptyId?: string) => void
   clearPaneForegroundAgent: (paneKey: string) => void
   /** Wholesale teardown sweeps (tab close, worktree sleep/remove) retire pane
    *  keys without per-pane close events — clear their entries too. */
@@ -113,13 +114,23 @@ current.routingRevoked === entry.routingRevoked &&
       }
     })
   },
-  refreshPaneForegroundAgentObservation: (paneKey, agent) => {
+  refreshPaneForegroundAgentObservation: (paneKey, agent, ptyId) => {
     set((s) => {
       const now = Date.now()
       const current = s.paneForegroundAgentByPaneKey[paneKey]
       if (current) {
         if (current.agent !== agent) {
           return s
+        }
+        // Why: evidence bound to a previous PTY must not be kept fresh across
+        // a respawn — rebind it as identity-only evidence of the inspected PTY.
+        if (ptyId !== undefined && current.ptyId !== undefined && current.ptyId !== ptyId) {
+          return {
+            paneForegroundAgentByPaneKey: {
+              ...s.paneForegroundAgentByPaneKey,
+              [paneKey]: { agent, shellForeground: false, observedAt: now, ptyId }
+            }
+          }
         }
         if (
           current.observedAt !== undefined &&
@@ -139,7 +150,12 @@ current.routingRevoked === entry.routingRevoked &&
       return {
         paneForegroundAgentByPaneKey: {
           ...s.paneForegroundAgentByPaneKey,
-          [paneKey]: { agent, shellForeground: false, observedAt: now }
+          [paneKey]: {
+            agent,
+            shellForeground: false,
+            observedAt: now,
+            ...(ptyId !== undefined ? { ptyId } : {})
+          }
         }
       }
     })

--- a/src/renderer/src/store/slices/pane-foreground-agent.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.ts
@@ -2,10 +2,8 @@ import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import type { TuiAgent } from '../../../../shared/types'
 
-// Why: attribution consumers (sidebar rows, worktree ring) must not trust
-// process identity forever — an exited agent's entry could otherwise fake a
-// working state. 30s sits above the completion coordinator's slowest cadences
-// (3s hidden backstop, 15s no-evidence poll), which re-arm the observation.
+// Why: expire identity after the coordinator's slowest 15s cadence so exited
+// agents cannot leave false working state indefinitely.
 export const PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS = 30_000
 // Why: active-tier inspections land every ~750ms; re-stamping each one would
 // churn the store, so freshness bumps are quantized well below the TTL.
@@ -35,10 +33,7 @@ export type PaneForegroundAgentEntry = {
 export type PaneForegroundAgentSlice = {
   paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry>
   setPaneForegroundAgent: (paneKey: string, entry: PaneForegroundAgentEntry) => void
-  /** Freshness bump from the completion coordinator's existing inspections —
-   *  identity only, never routing trust; a differing identity is ignored so
-   *  the tracker keeps sole ownership of identity changes. `ptyId` is the PTY
-   *  the inspection ran against; it binds created/rebound evidence. */
+  /** Refresh identity from an existing inspection, never routing trust. */
   refreshPaneForegroundAgentObservation: (paneKey: string, agent: TuiAgent, ptyId?: string) => void
   clearPaneForegroundAgent: (paneKey: string) => void
   /** Wholesale teardown sweeps (tab close, worktree sleep/remove) retire pane

--- a/src/renderer/src/store/slices/terminal-pane-detach-agent-identity.test.ts
+++ b/src/renderer/src/store/slices/terminal-pane-detach-agent-identity.test.ts
@@ -85,7 +85,10 @@ describe('syncPaneDetachPtyOwnership agent identity', () => {
     expect(state.paneForegroundAgentByPaneKey[targetPaneKey]).toEqual({
       agent: 'droid',
       routingTrusted: true,
-      shellForeground: false
+      shellForeground: false,
+      // Why: setPaneForegroundAgent stamps observedAt centrally; the transfer
+      // preserves the entry (TTL keeps gating attribution on the new key).
+      observedAt: expect.any(Number)
     })
     expect(state.agentLaunchConfigByPaneKey[sourcePaneKey]).toBeUndefined()
     expect(state.agentLaunchConfigByPaneKey[targetPaneKey]?.identity).toMatchObject({
@@ -111,7 +114,8 @@ describe('syncPaneDetachPtyOwnership agent identity', () => {
     expect(state.agentStatusEpoch).toBeGreaterThan(epochBeforeDetach)
     expect(state.paneForegroundAgentByPaneKey[siblingPaneKey]).toEqual({
       agent: 'antigravity',
-      shellForeground: false
+      shellForeground: false,
+      observedAt: expect.any(Number)
     })
     expect(resolveWindowsShiftEnterEncodingForPane(state, targetPaneKey)).toBe('csi-u')
     expect(resolveWindowsShiftEnterEncodingForPane(state, siblingPaneKey)).toBe('alt-enter')


### PR DESCRIPTION
Part of #9414

Keep-awake and sidebar attribution now follow foreground-process evidence, so the machine is less likely to sleep and a tab is less likely to read idle while a real agent is still the process in front — including wrapper-launched agents with no recognizable title.

## Status (2026-08-06 restack note)

An earlier note here said the busy half was fully superseded by main. Re-checked against main (79896cb): only the first half is.

- **Already on main** — the pre-confirmation gate classifies shell vs non-shell. `src/main/runtime/orca-runtime.ts:16630` returns false for any non-shell foreground process, so a plain unrecognized foreground already counts as busy.
- **Still open on main** — the confirmation branch ignores unrecognized processes. When a stronger provider re-reads the foreground, `src/main/runtime/orca-runtime.ts:16647` returns `recognizeAgentProcess(confirmedProcess) === null`, so an unrecognized-but-alive process is read as "no agent" and the terminal is reported not running. This PR narrows that to `confirmedProcess === null || isShellProcess(confirmedProcess)`: only a confirmed shell proves the agent exited.

The branch carries brennanb2025's `fix(awake): reuse existing foreground inspections` (11b6ed4), preserved through the latest rebase.

## Problem

- Keep-awake can drop while a real agent is in the foreground if hooks and title are quiet
- The sidebar misses wrapper-launched Claude (and similar) when OSC/title identity is empty
- Foreground confirmation discards a live agent it cannot name

## Solution

- Report foreground agent evidence with freshness (`observedAt` / TTL), reusing completed provider inspections rather than adding scans
- Drive keep-awake and sidebar / worktree-ring attribution from that evidence
- Treat a confirmed non-shell foreground as still running, recognized or not

## Stack

- Follow-ups (draft): **#9434** renamed binaries via executable image → **#9435** structured foreground result + unknown-alive tab presence
- Independent of closed #8872 close-intent work

## Test plan

- [ ] Wrapper-launched Claude appears in the sidebar without an agent title
- [ ] Keep-awake holds while foreground evidence is fresh; expires on TTL
- [ ] A confirmed unrecognized non-shell foreground keeps the terminal busy
- [ ] Rebase clean

Focused suites re-run post-rebase at 5f08623ce (2026-08-06): agent-awake-service, pane-foreground-agent, worktree-title-derived-agent-rows, ipc/pty, orca-runtime — 1586 passed / 1 skipped.
## ELI5

Keep-awake and sidebar busy state now lean on real foreground-process evidence. Orca is less likely to sleep the machine or mislabel a tab while an agent it cannot name by title is still the process in front.
