### PR TITLE
fix(native-chat): surface Claude thinking as collapsed reasoning instead of plain assistant prose

### DIFF
--- a/src/main/native-chat/transcript-line-decoders-claude.ts
+++ b/src/main/native-chat/transcript-line-decoders-claude.ts
@@ -79,9 +79,7 @@ function claudeMessageRole(
   return isThinkingOnlyContent(content) ? 'reasoning' : role
 }
 
-// The decoded blocks are plain text either way, so the raw content array is the
-// only place the thinking origin survives. redacted_thinking decodes to no
-// block, but tolerating it keeps a mixed thinking+redacted turn on reasoning.
+// Why: decoded text loses thinking provenance; inspect raw content while tolerating redacted siblings.
 function isThinkingOnlyContent(content: unknown): boolean {
   if (!Array.isArray(content)) {
     return false

--- a/src/main/native-chat/transcript-line-decoders-claude.ts
+++ b/src/main/native-chat/transcript-line-decoders-claude.ts
@@ -80,7 +80,8 @@ function claudeMessageRole(
 }
 
 // The decoded blocks are plain text either way, so the raw content array is the
-// only place the thinking origin survives.
+// only place the thinking origin survives. redacted_thinking decodes to no
+// block, but tolerating it keeps a mixed thinking+redacted turn on reasoning.
 function isThinkingOnlyContent(content: unknown): boolean {
   if (!Array.isArray(content)) {
     return false

--- a/src/main/native-chat/transcript-line-decoders-claude.ts
+++ b/src/main/native-chat/transcript-line-decoders-claude.ts
@@ -58,7 +58,7 @@ export function decodeClaudeTranscriptLine(
   const messageId = extractString(record.uuid) ?? extractString(message?.id)
   return {
     id: messageId ?? fallbackId,
-    role: claudeMessageRole(role, blocks),
+    role: claudeMessageRole(role, blocks, message?.content),
     blocks,
     timestamp,
     source: 'transcript'
@@ -69,13 +69,40 @@ export function decodeClaudeTranscriptLine(
 // up solely of reasoning, surface it as a reasoning-role message.
 function claudeMessageRole(
   role: 'user' | 'assistant',
-  blocks: NativeChatBlock[]
+  blocks: NativeChatBlock[],
+  content: unknown
 ): NativeChatMessage['role'] {
   if (role === 'user') {
     const onlyToolResults = blocks.every((block) => block.type === 'tool-result')
     return onlyToolResults && blocks.length > 0 ? 'tool' : 'user'
   }
-  return role
+  return isThinkingOnlyContent(content) ? 'reasoning' : role
+}
+
+// The decoded blocks are plain text either way, so the raw content array is the
+// only place the thinking origin survives.
+function isThinkingOnlyContent(content: unknown): boolean {
+  if (!Array.isArray(content)) {
+    return false
+  }
+  let sawThinking = false
+  for (const item of content) {
+    if (typeof item === 'string') {
+      if (item.trim()) {
+        return false
+      }
+      continue
+    }
+    const record = asRecord(item)
+    if (!record) {
+      continue
+    }
+    if (record.type !== 'thinking' && record.type !== 'redacted_thinking') {
+      return false
+    }
+    sawThinking = true
+  }
+  return sawThinking
 }
 
 function parseTimestamp(value: unknown): number | null {

--- a/src/main/native-chat/transcript-reader.test.ts
+++ b/src/main/native-chat/transcript-reader.test.ts
@@ -187,7 +187,30 @@ describe('readNativeChatTranscript (claude)', () => {
     if (!('messages' in result)) {
       throw new Error('expected messages')
     }
+    expect(result.messages[0].role).toBe('reasoning')
     expect(result.messages[0].blocks[0]).toEqual({ type: 'text', text: 'pondering' })
+  })
+
+  it('keeps mixed thinking-and-text assistant content on the assistant role', async () => {
+    const filePath = await writeFixture('orca-native-chat-claude-mixed-', [
+      {
+        type: 'assistant',
+        uuid: 'a-mixed',
+        timestamp: '2026-06-01T10:00:00.000Z',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'pondering' },
+            { type: 'text', text: 'the answer' }
+          ]
+        }
+      }
+    ])
+    const result = await readNativeChatTranscript('claude', 'sess', { filePath })
+    if (!('messages' in result)) {
+      throw new Error('expected messages')
+    }
+    expect(result.messages[0].role).toBe('assistant')
   })
 })
 

--- a/src/main/native-chat/transcript-reader.test.ts
+++ b/src/main/native-chat/transcript-reader.test.ts
@@ -212,6 +212,31 @@ describe('readNativeChatTranscript (claude)', () => {
     }
     expect(result.messages[0].role).toBe('assistant')
   })
+
+  it('keeps thinking with a redacted sibling on the reasoning role', async () => {
+    const filePath = await writeFixture('orca-native-chat-claude-redacted-thinking-', [
+      {
+        type: 'assistant',
+        uuid: 'a-redacted-thinking',
+        timestamp: '2026-06-01T10:00:00.000Z',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: 'pondering' },
+            { type: 'redacted_thinking', data: 'opaque' }
+          ]
+        }
+      }
+    ])
+    const result = await readNativeChatTranscript('claude', 'sess', { filePath })
+    if (!('messages' in result)) {
+      throw new Error('expected messages')
+    }
+    expect(result.messages[0]).toMatchObject({
+      role: 'reasoning',
+      blocks: [{ type: 'text', text: 'pondering' }]
+    })
+  })
 })
 
 describe('readNativeChatTranscript (codex)', () => {

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import type { NativeChatLiveSession } from './use-native-chat-live-session'
+import { NativeChatMessageList } from './NativeChatMessageList'
+
+function liveSession(messages: NativeChatMessage[]): NativeChatLiveSession {
+  return {
+    messages,
+    status: 'ready',
+    sessionId: 'sess',
+    agent: 'claude',
+    hasMore: false,
+    loadingEarlier: false,
+    loadEarlier: () => {}
+  }
+}
+
+function renderList(messages: NativeChatMessage[]): void {
+  render(
+    <NativeChatMessageList
+      session={liveSession(messages)}
+      isWorking={false}
+      expandSignal={false}
+      fontScale={1}
+    />
+  )
+}
+
+const reasoningMessage: NativeChatMessage = {
+  id: 'r-1',
+  role: 'reasoning',
+  blocks: [{ type: 'text', text: 'pondering the fix quietly' }],
+  timestamp: 1,
+  source: 'transcript'
+}
+
+describe('NativeChatMessageList reasoning rows', () => {
+  afterEach(cleanup)
+
+  it('collapses reasoning to a disclosure line by default', () => {
+    renderList([reasoningMessage])
+
+    const disclosure = screen.getByRole('button', { name: /Thinking/ })
+    expect(disclosure).toBeInTheDocument()
+    // The full reasoning body (markdown paragraph) is unmounted until expanded;
+    // only the one-line preview inside the disclosure shows.
+    expect(
+      screen.queryByText('pondering the fix quietly', { selector: 'p' })
+    ).not.toBeInTheDocument()
+    expect(disclosure).toHaveTextContent('pondering the fix quietly')
+  })
+
+  it('expands and re-collapses the reasoning body on click', () => {
+    renderList([reasoningMessage])
+
+    const disclosure = screen.getByRole('button', { name: /Thinking/ })
+    fireEvent.click(disclosure)
+    expect(screen.getByText('pondering the fix quietly', { selector: 'p' })).toBeInTheDocument()
+
+    fireEvent.click(disclosure)
+    expect(
+      screen.queryByText('pondering the fix quietly', { selector: 'p' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps assistant prose rendered in full, not collapsed', () => {
+    renderList([
+      {
+        id: 'a-1',
+        role: 'assistant',
+        blocks: [{ type: 'text', text: 'the actual answer' }],
+        timestamp: 1,
+        source: 'transcript'
+      }
+    ])
+
+    expect(screen.getByText('the actual answer')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Thinking/ })).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
@@ -59,7 +59,9 @@ describe('NativeChatMessageList reasoning rows', () => {
     renderList([reasoningMessage])
 
     const disclosure = screen.getByRole('button', { name: /Thinking/ })
+    expect(disclosure).toHaveAttribute('aria-expanded', 'false')
     fireEvent.click(disclosure)
+    expect(disclosure).toHaveAttribute('aria-expanded', 'true')
     expect(screen.getByText('pondering the fix quietly', { selector: 'p' })).toBeInTheDocument()
 
     fireEvent.click(disclosure)

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -17,6 +17,7 @@ import { stripNoiseMessages } from './native-chat-noise'
 import { foldToolMessages, splitNativeChatBlocks } from './native-chat-tool-fold'
 import { isNearBottom, shouldShowJumpToLatest, type ScrollGeometry } from './native-chat-autoscroll'
 import { isNativeChatPastedImagePath } from './native-chat-image-paste'
+import { NativeChatReasoningRow } from './NativeChatReasoningRow'
 import { NativeChatToolRun } from './NativeChatToolRun'
 import { NativeChatCopyButton } from './NativeChatCopyButton'
 import { NATIVE_CHAT_STREAMING_ID } from '../../../../shared/native-chat-streaming'
@@ -197,17 +198,28 @@ function MessageRow({
     )
   }
 
-  // Plain assistant prose is the copyable unit; reasoning/system asides stay
-  // chrome-free. The controls reveal on hover (and on keyboard focus-within).
-  const showControls = !isReasoning && !isSystem && markdown.length > 0
+  if (isReasoning) {
+    return (
+      <div ref={rowRef} className="max-w-full text-sm leading-relaxed">
+        <NativeChatReasoningRow
+          markdown={markdown}
+          expandSignal={expandSignal}
+          onLinkClick={onLinkClick}
+          allowFileUriLinks={allowFileUriLinks}
+        />
+      </div>
+    )
+  }
+
+  // Plain assistant prose is the copyable unit; system asides stay chrome-free.
+  // The controls reveal on hover (and on keyboard focus-within).
+  const showControls = !isSystem && markdown.length > 0
 
   return (
     <div
       ref={rowRef}
       className={cn(
         'group relative max-w-full text-sm leading-relaxed text-foreground',
-        // Reasoning is the agent thinking aloud — quieter, italic, like an aside.
-        isReasoning && 'border-l-2 border-border/60 pl-3 italic text-muted-foreground',
         isSystem && 'text-xs text-muted-foreground'
       )}
     >

--- a/src/renderer/src/components/native-chat/NativeChatReasoningRow.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatReasoningRow.tsx
@@ -1,10 +1,25 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { ChevronRight } from 'lucide-react'
 import CommentMarkdown, {
   type CommentMarkdownLinkClickHandler
 } from '@/components/sidebar/CommentMarkdown'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
+
+function firstNonEmptyLinePreview(markdown: string): string {
+  let start = 0
+  while (start < markdown.length) {
+    const newline = markdown.indexOf('\n', start)
+    const end = newline === -1 ? markdown.length : newline
+    const line = markdown.slice(start, end)
+    if (line.trim()) {
+      return line.slice(0, 80)
+    }
+    start = end + 1
+  }
+  return ''
+}
 
 /** Reasoning folds to a one-line disclosure like a tool run — thinking is
  *  process, not answer, so it stays out of the way until asked for. */
@@ -21,22 +36,15 @@ export function NativeChatReasoningRow({
   allowFileUriLinks?: boolean
 }): React.JSX.Element {
   const [open, setOpen] = useState(expandSignal)
-  // Re-sync when the global toolbar toggle flips.
   useEffect(() => setOpen(expandSignal), [expandSignal])
 
-  const preview =
-    markdown
-      .split('\n')
-      .find((line) => line.trim())
-      ?.slice(0, 80) ?? ''
+  const preview = useMemo(() => firstNonEmptyLinePreview(markdown), [markdown])
 
   return (
-    <div>
-      <button
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger
         type="button"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        className="group flex w-full items-center gap-1.5 py-0.5 text-left"
+        className="group flex w-full items-center gap-1.5 rounded-sm py-0.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         <span className="shrink-0 font-mono text-[11px] font-bold text-muted-foreground transition-colors group-hover:text-foreground/80">
           {translate('components.native-chat.reasoning.label', 'Thinking')}
@@ -59,8 +67,8 @@ export function NativeChatReasoningRow({
               : 'opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100'
           )}
         />
-      </button>
-      {open ? (
+      </CollapsibleTrigger>
+      <CollapsibleContent>
         <div className="mt-1 border-l-2 border-border/60 pl-3 italic text-muted-foreground">
           <CommentMarkdown
             content={markdown}
@@ -70,7 +78,7 @@ export function NativeChatReasoningRow({
             allowFileUriLinks={allowFileUriLinks}
           />
         </div>
-      ) : null}
-    </div>
+      </CollapsibleContent>
+    </Collapsible>
   )
 }

--- a/src/renderer/src/components/native-chat/NativeChatReasoningRow.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatReasoningRow.tsx
@@ -35,6 +35,7 @@ export function NativeChatReasoningRow({
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
         className="group flex w-full items-center gap-1.5 py-0.5 text-left"
       >
         <span className="shrink-0 font-mono text-[11px] font-bold text-muted-foreground transition-colors group-hover:text-foreground/80">
@@ -48,12 +49,14 @@ export function NativeChatReasoningRow({
             {preview}
           </span>
         ) : null}
-        {/* Chevron on the right, revealed on hover when collapsed and pointing
-            down when open — matches the tool-run disclosure. */}
+        {/* Chevron on the right, revealed on hover/keyboard focus when collapsed
+            and pointing down when open — matches the tool-run disclosure. */}
         <ChevronRight
           className={cn(
             'size-3.5 shrink-0 text-muted-foreground transition-all',
-            open ? 'rotate-90 opacity-100' : 'opacity-0 group-hover:opacity-100'
+            open
+              ? 'rotate-90 opacity-100'
+              : 'opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100'
           )}
         />
       </button>

--- a/src/renderer/src/components/native-chat/NativeChatReasoningRow.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatReasoningRow.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react'
+import { ChevronRight } from 'lucide-react'
+import CommentMarkdown, {
+  type CommentMarkdownLinkClickHandler
+} from '@/components/sidebar/CommentMarkdown'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+
+/** Reasoning folds to a one-line disclosure like a tool run — thinking is
+ *  process, not answer, so it stays out of the way until asked for. */
+export function NativeChatReasoningRow({
+  markdown,
+  expandSignal,
+  onLinkClick,
+  allowFileUriLinks
+}: {
+  markdown: string
+  /** Toolbar-driven desired open state. Each change re-syncs this row's state. */
+  expandSignal: boolean
+  onLinkClick?: CommentMarkdownLinkClickHandler
+  allowFileUriLinks?: boolean
+}): React.JSX.Element {
+  const [open, setOpen] = useState(expandSignal)
+  // Re-sync when the global toolbar toggle flips.
+  useEffect(() => setOpen(expandSignal), [expandSignal])
+
+  const preview =
+    markdown
+      .split('\n')
+      .find((line) => line.trim())
+      ?.slice(0, 80) ?? ''
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="group flex w-full items-center gap-1.5 py-0.5 text-left"
+      >
+        <span className="shrink-0 font-mono text-[11px] font-bold text-muted-foreground transition-colors group-hover:text-foreground/80">
+          {translate('components.native-chat.reasoning.label', 'Thinking')}
+        </span>
+        {!open && preview ? (
+          <span
+            className="min-w-0 truncate font-mono text-[11px] italic text-muted-foreground transition-colors group-hover:text-foreground/70"
+            title={preview}
+          >
+            {preview}
+          </span>
+        ) : null}
+        {/* Chevron on the right, revealed on hover when collapsed and pointing
+            down when open — matches the tool-run disclosure. */}
+        <ChevronRight
+          className={cn(
+            'size-3.5 shrink-0 text-muted-foreground transition-all',
+            open ? 'rotate-90 opacity-100' : 'opacity-0 group-hover:opacity-100'
+          )}
+        />
+      </button>
+      {open ? (
+        <div className="mt-1 border-l-2 border-border/60 pl-3 italic text-muted-foreground">
+          <CommentMarkdown
+            content={markdown}
+            variant="document"
+            className="text-sm"
+            onLinkClick={onLinkClick}
+            allowFileUriLinks={allowFileUriLinks}
+          />
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/native-chat/native-chat-tool-fold.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-tool-fold.test.ts
@@ -46,6 +46,18 @@ describe('foldToolMessages', () => {
     expect(folded.map((m) => m.id)).toEqual(['u', 't'])
   })
 
+  it('keeps a tool run separate from a preceding reasoning turn', () => {
+    // Claude emits thinking and tool_use as separate records; reasoning is not
+    // the turn's prose, so the tool run must not fold under it.
+    const folded = foldToolMessages([
+      msg({ id: 'r', role: 'reasoning', blocks: [{ type: 'text', text: 'pondering' }] }),
+      msg({ id: 'c', role: 'assistant', blocks: [{ type: 'tool-call', name: 'Bash', input: {} }] }),
+      msg({ id: 't', role: 'tool', blocks: [{ type: 'tool-result', output: 'ok' }] })
+    ])
+    expect(folded.map((m) => m.id)).toEqual(['r', 'c'])
+    expect(folded[1]?.blocks).toHaveLength(2)
+  })
+
   it('does not fold a message carrying prose alongside a tool block', () => {
     const folded = foldToolMessages([
       msg({ id: 'a', role: 'assistant', blocks: [{ type: 'text', text: 'first' }] }),

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -13364,7 +13364,10 @@
         "allow": "Allow",
         "deny": "Deny"
       },
-      "launchPromptNotDelivered": "Not delivered — check the terminal"
+      "launchPromptNotDelivered": "Not delivered — check the terminal",
+      "reasoning": {
+        "label": "Thinking"
+      }
     },
     "tab": {
       "bar": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -13341,7 +13341,10 @@
         "allow": "Permitir",
         "deny": "Denegar"
       },
-      "launchPromptNotDelivered": "No entregado — revisa la terminal"
+      "launchPromptNotDelivered": "No entregado — revisa la terminal",
+      "reasoning": {
+        "label": "Pensando"
+      }
     },
     "tab": {
       "bar": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -13341,7 +13341,10 @@
         "allow": "許可する",
         "deny": "拒否"
       },
-      "launchPromptNotDelivered": "配信されませんでした — ターミナルを確認してください"
+      "launchPromptNotDelivered": "配信されませんでした — ターミナルを確認してください",
+      "reasoning": {
+        "label": "思考中"
+      }
     },
     "tab": {
       "bar": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -13341,7 +13341,10 @@
         "allow": "허용하다",
         "deny": "부인하다"
       },
-      "launchPromptNotDelivered": "전달되지 않음 — 터미널을 확인하세요"
+      "launchPromptNotDelivered": "전달되지 않음 — 터미널을 확인하세요",
+      "reasoning": {
+        "label": "생각 중"
+      }
     },
     "tab": {
       "bar": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -13341,7 +13341,10 @@
         "allow": "允许",
         "deny": "拒绝"
       },
-      "launchPromptNotDelivered": "未送达 — 请检查终端"
+      "launchPromptNotDelivered": "未送达 — 请检查终端",
+      "reasoning": {
+        "label": "思考中"
+      }
     },
     "tab": {
       "bar": {


### PR DESCRIPTION
## Summary

Claude Code sessions in the experimental native chat rendered internal `thinking` blocks as normal assistant prose — indistinguishable from the actual answer, so long reasoning paragraphs flooded the transcript.

Two changes:

1. **Decoder** (`transcript-line-decoders-claude.ts`): assistant turns whose content is made up solely of `thinking` (or `redacted_thinking`) blocks are now surfaced with the `reasoning` role. The comment above `claudeMessageRole` already promised this, and the Grok/Codex decoders already do it — Claude was the odd one out.
2. **UI** (`NativeChatReasoningRow.tsx`): `reasoning` messages now fold into a one-line `Thinking` disclosure — collapsed by default with a truncated preview, expandable in place — following the same disclosure pattern as `NativeChatToolRun`. This benefits Claude, Grok, and Codex reasoning alike.

## Screenshots

![Before/after: Claude thinking rendered as plain prose vs. collapsed Thinking disclosure](https://raw.githubusercontent.com/kaynansc/orca/pr-assets-native-chat-thinking/native-chat-thinking-comparison.png)

Captured with the repo's E2E harness (`--mode e2e` build) by seeding a Claude transcript containing a thinking block and toggling the terminal tab to chat view.

## Testing

- [x] `pnpm lint` — all changed files clean; one pre-existing failure unrelated to this PR (`skill-freshness-group.tsx` switch-exhaustiveness, reproduces on a clean `origin/main` checkout)
- [x] `pnpm typecheck`
- [x] `pnpm test` — 31k+ tests pass; the only failing file (`src/relay/agent-exec-handler.test.ts`, 2 tests) also fails on a clean `origin/main` checkout locally (environment-dependent), untouched by this PR
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Tests:

- Strengthened the existing decoder test ("marks thinking-only assistant content as a reasoning surface") to actually assert the `reasoning` role — it previously only checked the block text, which is why the regression shipped silently. Fails on `main`, passes with the fix.
- New decoder test: mixed thinking-and-text assistant content stays on the `assistant` role.
- New `NativeChatMessageList.test.tsx`: reasoning rows collapse to a disclosure by default, expand/re-collapse on click, and assistant prose stays fully rendered.

## AI Review Report

Ran a two-axis AI review (standards + spec) with parallel agents, plus an adversarial verification of the decoder/fold interaction:

- **Correctness**: the regression tests were verified to fail on `main` and pass on this branch. The decoder change only affects Claude assistant turns whose raw content is thinking-only; mixed thinking+text turns keep the `assistant` role (covered by a test).
- **Tool-fold interaction**: `foldToolMessages` only folds tool-only messages into a preceding *assistant* turn, so a tool run after a (now) reasoning turn renders as its own collapsible run instead of folding under the thinking — same shape Codex reasoning already produces. Added a fold test documenting this.
- **Cross-platform (macOS/Linux/Windows)**: no shortcuts, paths, shell, or Electron platform APIs touched; pure decode + render logic.
- **SSH/remote**: the decoder runs in the main process on already-read transcript lines; no assumptions about local files added.
- **Agent/integration compatibility**: provider-neutral — the `reasoning` role and collapsed row are shared with Grok and Codex (their decoders already emitted the role); no provider-specific branching added in the renderer.
- **Performance**: `isThinkingOnlyContent` is a single linear pass over the raw content array during decode; the reasoning row renders *less* by default (collapsed) than before.
- **UI quality**: reuses the exact disclosure pattern and design tokens of `NativeChatToolRun` (mono 11px label, hover-revealed chevron, muted italic body) — no new colors/sizes.
- Review flagged (accepted, not changed): the disclosure markup intentionally mirrors `NativeChatToolRun` rather than extracting a shared component — kept surgical; worth extracting if a third disclosure appears. The `Thinking` label uses `translate()` with an English fallback, matching existing native-chat strings like `tool.countOne` that are not in the locale catalogs.

## Security Audit

- **Input handling**: the decoder parses untrusted transcript JSONL; `isThinkingOnlyContent` only inspects `type` fields defensively (`asRecord`/`Array.isArray` guards, no property access on unknown shapes) and cannot throw on malformed content.
- **Rendering**: reasoning text goes through the same `CommentMarkdown` renderer already used for assistant prose — no new HTML injection surface, no `dangerouslySetInnerHTML`.
- **No command execution, path handling, auth, secrets, dependency, or IPC changes.** No new IPC endpoints; the change consumes the existing transcript-read pipeline.
- No follow-up needed.

## Notes

- Provider-neutral: the `reasoning` role and the collapsed row are shared across Claude, Grok, and Codex; only the Claude decoder gained the role mapping the other two already had.
- Mobile (`MobileNativeChatMessage.tsx`) already styles `reasoning` messages as a de-emphasized aside, so the decoder fix improves mobile rendering of Claude thinking too; the collapsed disclosure itself is desktop-only.
- Streaming previews (`native-chat-streaming.ts`) only surface assistant text, so no streaming change was needed.
- Turns that mix `thinking` and `text` blocks in a single JSONL record keep the `assistant` role (Claude Code emits them as separate records in practice).

X handle: [@KaynanSampaio1](https://x.com/KaynanSampaio1)

## ELI5

Claude's internal thinking blocks showed up in native chat as normal assistant text, flooding the transcript. Pure thinking turns are now shown as collapsed reasoning, separate from the actual answer.
