### PR TITLE
Fix diff editor flashing "Loading…" on every save

### DIFF
--- a/src/renderer/src/components/diff-comments/useDiffCommentDecorator.model-lifecycle.test.tsx
+++ b/src/renderer/src/components/diff-comments/useDiffCommentDecorator.model-lifecycle.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { editor as MonacoEditor } from 'monaco-editor'
+
+const storeFixture = vi.hoisted(() => ({
+  activeGroupIdByWorktree: {},
+  clearDeliveredDiffComments: vi.fn()
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: typeof storeFixture) => unknown) => selector(storeFixture)
+}))
+
+import { useDiffCommentDecorator } from './useDiffCommentDecorator'
+
+afterEach(() => {
+  document.body.replaceChildren()
+  vi.clearAllMocks()
+})
+
+describe('useDiffCommentDecorator model lifecycle', () => {
+  it('rebuilds model-scoped resources when a retained editor swaps models', () => {
+    const editorDomNode = document.createElement('div')
+    document.body.appendChild(editorDomNode)
+    const disposeMouseMove = vi.fn()
+    const disposeMouseLeave = vi.fn()
+    const disposeScroll = vi.fn()
+    const editor = {
+      getDomNode: () => editorDomNode,
+      getOption: () => 19,
+      onMouseMove: () => ({ dispose: disposeMouseMove }),
+      onMouseLeave: () => ({ dispose: disposeMouseLeave }),
+      onDidScrollChange: () => ({ dispose: disposeScroll }),
+      changeViewZones: (callback: (accessor: object) => void) => callback({})
+    } as unknown as MonacoEditor.ICodeEditor
+    const hook = renderHook(
+      ({ monacoModelIdentity }) =>
+        useDiffCommentDecorator({
+          editor,
+          monacoModelIdentity,
+          filePath: 'notes.ts',
+          worktreeId: 'worktree-1',
+          comments: [],
+          onAddCommentClick: vi.fn(),
+          onDeleteComment: vi.fn()
+        }),
+      { initialProps: { monacoModelIdentity: 'modified-v1' } }
+    )
+    const firstButton = editorDomNode.querySelector('.orca-diff-comment-add-btn')
+
+    hook.rerender({ monacoModelIdentity: 'modified-v2' })
+
+    const replacementButton = editorDomNode.querySelector('.orca-diff-comment-add-btn')
+    expect(replacementButton).not.toBeNull()
+    expect(replacementButton).not.toBe(firstButton)
+    expect(disposeMouseMove).toHaveBeenCalledOnce()
+    expect(disposeMouseLeave).toHaveBeenCalledOnce()
+    expect(disposeScroll).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
+++ b/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
@@ -36,6 +36,9 @@ export type DecoratedDiffComment = DiffComment & {
 
 type DecoratorArgs = {
   editor: monacoEditor.ICodeEditor | null
+  // Why: Monaco destroys model-scoped view zones when a retained editor swaps
+  // models, so the decorator must rebuild even though the editor object is stable.
+  monacoModelIdentity?: string
   filePath: string
   worktreeId: string
   comments: readonly DecoratedDiffComment[]
@@ -119,6 +122,7 @@ function getSingleCommentSendScopes(
 
 export function useDiffCommentDecorator({
   editor,
+  monacoModelIdentity,
   filePath,
   worktreeId,
   comments,
@@ -424,7 +428,7 @@ export function useDiffCommentDecorator({
       pendingScrollRef.current = null
       scrollToZoneRef.current = null
     }
-  }, [addButtonLabel, cancelScrollToZoneFrame, commentableLineSet, editor])
+  }, [addButtonLabel, cancelScrollToZoneFrame, commentableLineSet, editor, monacoModelIdentity])
 
   useEffect(() => {
     if (!editor) {
@@ -686,6 +690,7 @@ export function useDiffCommentDecorator({
     editor,
     filePath,
     formatCommentPrompt,
+    monacoModelIdentity,
     worktreeId,
     comments
   ])
@@ -729,5 +734,13 @@ export function useDiffCommentDecorator({
     }
     // If !laidOut we wait — onDomNodeTop on the zone will pick the request
     // up and call scrollToZone once Monaco's render pass places the zone.
-  }, [cancelScrollToZoneFrame, editor, comments, pendingScrollCommentId, filePath, worktreeId])
+  }, [
+    cancelScrollToZoneFrame,
+    editor,
+    comments,
+    pendingScrollCommentId,
+    filePath,
+    monacoModelIdentity,
+    worktreeId
+  ])
 }

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -106,6 +106,7 @@ export default function DiffViewer({
   // updateDiffComment is only wired for local diffs (worktreeId present).
   useDiffCommentDecorator({
     editor: hasLineCommentAction ? modifiedEditor : null,
+    monacoModelIdentity: modifiedModelKey ?? modelKey,
     filePath: relativePath,
     worktreeId: worktreeId ?? '',
     comments: worktreeId ? diffComments : [],

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -65,10 +65,8 @@ export default function DiffViewer({
     () => (allDiffComments ?? []).filter((c) => c.filePath === relativePath && isDiffComment(c)),
     [allDiffComments, relativePath]
   )
-  const diffEditorFontSize = computeDiffEditorFontSize(
-    settings?.terminalFontSize ?? 13,
-    editorFontZoomLevel
-  )
+  const terminalFontSize = settings?.terminalFontSize ?? 13
+  const diffEditorFontSize = computeDiffEditorFontSize(terminalFontSize, editorFontZoomLevel)
   const isDark =
     settings?.theme === 'dark' ||
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
@@ -311,6 +309,7 @@ export default function DiffViewer({
     modelKey,
     originalModelKey,
     modifiedModelKey,
+    diffEditorRef,
     onEnterFallback: handleEnterLargeDiffFallback
   })
 

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -25,6 +25,7 @@ import { getDiffViewerLargeDiffSaveAction } from './diff-viewer-large-diff-save-
 import type { DiffViewerProps } from './diff-viewer-props'
 import { buildDiffEditorWordWrapOptions } from './diff-editor-word-wrap-options'
 import { useDiffEditorRegistration } from './diff-navigation-context'
+import { preserveDiffViewStateAcrossModelSwaps } from './diff-model-swap-view-state'
 
 export default function DiffViewer({
   modelKey,
@@ -322,6 +323,7 @@ export default function DiffViewer({
 
       const originalEditor = diffEditor.getOriginalEditor()
       const modifiedEditor = diffEditor.getModifiedEditor()
+      diffEditor.onDidDispose(preserveDiffViewStateAcrossModelSwaps(diffEditor).dispose)
 
       setupCopy(originalEditor, monaco, filePath, propsRef)
       setupCopy(modifiedEditor, monaco, filePath, propsRef)

--- a/src/renderer/src/components/editor/EditorContent.monaco-lifecycle.test.tsx
+++ b/src/renderer/src/components/editor/EditorContent.monaco-lifecycle.test.tsx
@@ -14,6 +14,19 @@ vi.mock('@/lib/lazy-with-retry', async () => {
   const { syncContentOnMount } = await import('./monaco-content-sync')
   return {
     lazyWithRetry: (factory: () => Promise<unknown>) => {
+      if (factory.toString().includes('/DiffViewer.tsx')) {
+        return function MockDiffViewer(props: { filePath: string }) {
+          /* oxlint-disable react-hooks/exhaustive-deps -- Mount-only by design: a prop-effect would hide a missing outer React remount. */
+          React.useEffect(() => {
+            lifecycle.events.push(`mount-diff:${props.filePath}`)
+            return () => {
+              lifecycle.events.push(`unmount-diff:${props.filePath}`)
+            }
+          }, [])
+          /* oxlint-enable react-hooks/exhaustive-deps */
+          return null
+        }
+      }
       if (!factory.toString().includes('/MonacoEditor.tsx')) {
         return () => null
       }
@@ -144,6 +157,21 @@ function props(activeFile: OpenFile, content: string) {
   }
 }
 
+function diffProps(activeFile: OpenFile, modifiedContent: string) {
+  return {
+    ...props(activeFile, ''),
+    diffContents: {
+      [activeFile.id]: {
+        kind: 'text' as const,
+        originalContent: '',
+        modifiedContent,
+        originalIsBinary: false as const,
+        modifiedIsBinary: false as const
+      }
+    }
+  }
+}
+
 afterEach(() => {
   cleanup()
   lifecycle.events.length = 0
@@ -174,6 +202,18 @@ describe('EditorContent Monaco lifecycle boundary', () => {
       content: 'first with edits',
       undo: ['first undo']
     })
+  })
+
+  it('keeps the diff editor mounted when a save updates the modified content', () => {
+    // Why: the DiffViewer key must not embed the modified-content signature, or
+    // every save remounts Monaco (blank "Loading…" flash + lost scroll/undo).
+    // The in-place model rotation handles content refresh without a remount.
+    const diff = file('/repo/notes.ts', { mode: 'diff', diffSource: 'unstaged' })
+
+    const view = render(<EditorContent {...diffProps(diff, 'first save')} />)
+    view.rerender(<EditorContent {...diffProps(diff, 'second save')} />)
+
+    expect(lifecycle.events).toEqual(['mount-diff:/repo/notes.ts'])
   })
 
   it('passes live-tail ownership only for a read-only live log', () => {

--- a/src/renderer/src/components/editor/EditorContent.monaco-lifecycle.test.tsx
+++ b/src/renderer/src/components/editor/EditorContent.monaco-lifecycle.test.tsx
@@ -5,6 +5,7 @@ import type { OpenFile } from '@/store/slices/editor'
 
 const lifecycle = vi.hoisted(() => ({
   events: [] as string[],
+  diffModelKeys: [] as string[],
   models: new Map<string, { content: string; undo: string[] }>(),
   mountedProps: [] as { filePath: string; readOnly?: boolean; liveTail?: boolean }[]
 }))
@@ -15,7 +16,8 @@ vi.mock('@/lib/lazy-with-retry', async () => {
   return {
     lazyWithRetry: (factory: () => Promise<unknown>) => {
       if (factory.toString().includes('/DiffViewer.tsx')) {
-        return function MockDiffViewer(props: { filePath: string }) {
+        return function MockDiffViewer(props: { filePath: string; modifiedModelKey?: string }) {
+          lifecycle.diffModelKeys.push(props.modifiedModelKey ?? '')
           /* oxlint-disable react-hooks/exhaustive-deps -- Mount-only by design: a prop-effect would hide a missing outer React remount. */
           React.useEffect(() => {
             lifecycle.events.push(`mount-diff:${props.filePath}`)
@@ -175,6 +177,7 @@ function diffProps(activeFile: OpenFile, modifiedContent: string) {
 afterEach(() => {
   cleanup()
   lifecycle.events.length = 0
+  lifecycle.diffModelKeys.length = 0
   lifecycle.models.clear()
   lifecycle.mountedProps.length = 0
 })
@@ -205,15 +208,31 @@ describe('EditorContent Monaco lifecycle boundary', () => {
   })
 
   it('keeps the diff editor mounted when a save updates the modified content', () => {
-    // Why: the DiffViewer key must not embed the modified-content signature, or
-    // every save remounts Monaco (blank "Loading…" flash + lost scroll/undo).
-    // The in-place model rotation handles content refresh without a remount.
+    // Why: saves must rotate the retained model for freshness without remounting
+    // the editor and flashing Monaco's loading placeholder.
     const diff = file('/repo/notes.ts', { mode: 'diff', diffSource: 'unstaged' })
 
     const view = render(<EditorContent {...diffProps(diff, 'first save')} />)
     view.rerender(<EditorContent {...diffProps(diff, 'second save')} />)
 
     expect(lifecycle.events).toEqual(['mount-diff:/repo/notes.ts'])
+    expect(lifecycle.diffModelKeys).toHaveLength(2)
+    expect(lifecycle.diffModelKeys[1]).not.toBe(lifecycle.diffModelKeys[0])
+  })
+
+  it('still remounts the diff editor for an explicit reload request', () => {
+    const diff = file('/repo/notes.ts', { mode: 'diff', diffSource: 'unstaged' })
+    const view = render(<EditorContent {...diffProps(diff, 'saved content')} />)
+
+    view.rerender(
+      <EditorContent {...diffProps({ ...diff, diffContentReloadNonce: 1 }, 'saved content')} />
+    )
+
+    expect(lifecycle.events).toEqual([
+      'mount-diff:/repo/notes.ts',
+      'unmount-diff:/repo/notes.ts',
+      'mount-diff:/repo/notes.ts'
+    ])
   })
 
   it('passes live-tail ownership only for a read-only live log', () => {

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -963,7 +963,9 @@ export function EditorContent({
   const modifiedModelKey = `${diffViewStateKey}:modified:${getDiffContentSignature(dc.modifiedContent)}:${diffReloadNonce}`
   const diffViewer = (
     <DiffViewer
-      key={`${viewStateScopeId}:${diffReloadNonce}:${getDiffContentSignature(dc.modifiedContent)}`}
+      // Why: content already refreshes in place via modifiedModelKey below, so
+      // keying the component off content too remounts Monaco every save (flash + lost undo).
+      key={`${viewStateScopeId}:${diffReloadNonce}`}
       modelKey={diffViewStateKey}
       originalModelKey={originalModelKey}
       modifiedModelKey={modifiedModelKey}

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -964,7 +964,7 @@ export function EditorContent({
   const diffViewer = (
     <DiffViewer
       // Why: content already refreshes in place via modifiedModelKey below, so
-      // keying the component off content too remounts Monaco every save (flash + lost undo).
+      // keying the component off content too remounts Monaco and flashes on every save.
       key={`${viewStateScopeId}:${diffReloadNonce}`}
       modelKey={diffViewStateKey}
       originalModelKey={originalModelKey}

--- a/src/renderer/src/components/editor/diff-model-swap-view-state.test.ts
+++ b/src/renderer/src/components/editor/diff-model-swap-view-state.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { editor } from 'monaco-editor'
+import { preserveDiffViewStateAcrossModelSwaps } from './diff-model-swap-view-state'
+
+type ModelListener = () => void
+
+function modelEditorFixture() {
+  let willChangeListener: ModelListener = () => {}
+  let didChangeListener: ModelListener = () => {}
+  const disposeWillChange = vi.fn()
+  const disposeDidChange = vi.fn()
+  return {
+    editor: {
+      onWillChangeModel: (listener: ModelListener) => {
+        willChangeListener = listener
+        return { dispose: disposeWillChange }
+      },
+      onDidChangeModel: (listener: ModelListener) => {
+        didChangeListener = listener
+        return { dispose: disposeDidChange }
+      }
+    } as unknown as editor.ICodeEditor,
+    fireWillChange: () => willChangeListener(),
+    fireDidChange: () => didChangeListener(),
+    disposeWillChange,
+    disposeDidChange
+  }
+}
+
+describe('diff model swap view state', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('coalesces a two-sided model rotation into one view-state restore', () => {
+    const original = modelEditorFixture()
+    const modified = modelEditorFixture()
+    const viewState = { original: {}, modified: {} } as editor.IDiffEditorViewState
+    const diffEditor = {
+      getOriginalEditor: () => original.editor,
+      getModifiedEditor: () => modified.editor,
+      getModel: () => ({ original: {}, modified: {} }),
+      saveViewState: vi.fn(() => viewState),
+      restoreViewState: vi.fn()
+    } as unknown as editor.IStandaloneDiffEditor
+    const scheduledFrames: FrameRequestCallback[] = []
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      scheduledFrames.push(callback)
+      return scheduledFrames.length
+    })
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+
+    preserveDiffViewStateAcrossModelSwaps(diffEditor)
+    original.fireWillChange()
+    original.fireDidChange()
+    modified.fireWillChange()
+    modified.fireDidChange()
+
+    expect(diffEditor.saveViewState).toHaveBeenCalledOnce()
+    expect(window.cancelAnimationFrame).toHaveBeenCalledWith(1)
+    scheduledFrames[1](0)
+    expect(diffEditor.restoreViewState).toHaveBeenCalledOnce()
+    expect(diffEditor.restoreViewState).toHaveBeenCalledWith(viewState)
+  })
+
+  it('cancels pending work and listeners when the editor is disposed', () => {
+    const original = modelEditorFixture()
+    const modified = modelEditorFixture()
+    const diffEditor = {
+      getOriginalEditor: () => original.editor,
+      getModifiedEditor: () => modified.editor,
+      saveViewState: () => ({ original: {}, modified: {} }),
+      restoreViewState: vi.fn()
+    } as unknown as editor.IStandaloneDiffEditor
+    vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(7)
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+    const subscription = preserveDiffViewStateAcrossModelSwaps(diffEditor)
+
+    modified.fireWillChange()
+    modified.fireDidChange()
+    subscription.dispose()
+
+    expect(window.cancelAnimationFrame).toHaveBeenCalledWith(7)
+    expect(original.disposeWillChange).toHaveBeenCalledOnce()
+    expect(original.disposeDidChange).toHaveBeenCalledOnce()
+    expect(modified.disposeWillChange).toHaveBeenCalledOnce()
+    expect(modified.disposeDidChange).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/components/editor/diff-model-swap-view-state.ts
+++ b/src/renderer/src/components/editor/diff-model-swap-view-state.ts
@@ -1,0 +1,52 @@
+import type { IDisposable, editor } from 'monaco-editor'
+
+export function preserveDiffViewStateAcrossModelSwaps(
+  diffEditor: editor.IStandaloneDiffEditor
+): IDisposable {
+  let pendingViewState: editor.IDiffEditorViewState | null = null
+  let restoreFrame: number | null = null
+
+  const captureViewState = (): void => {
+    // Why: Monaco resets cursor and scroll state when a retained editor swaps
+    // models, so capture once before either diff side starts rotating.
+    pendingViewState ??= diffEditor.saveViewState()
+  }
+  const scheduleRestore = (): void => {
+    if (!pendingViewState) {
+      return
+    }
+    if (restoreFrame !== null) {
+      cancelAnimationFrame(restoreFrame)
+    }
+    restoreFrame = requestAnimationFrame(() => {
+      restoreFrame = null
+      const viewState = pendingViewState
+      pendingViewState = null
+      if (viewState && diffEditor.getModel()) {
+        diffEditor.restoreViewState(viewState)
+      }
+    })
+  }
+
+  const originalEditor = diffEditor.getOriginalEditor()
+  const modifiedEditor = diffEditor.getModifiedEditor()
+  const subscriptions = [
+    originalEditor.onWillChangeModel(captureViewState),
+    originalEditor.onDidChangeModel(scheduleRestore),
+    modifiedEditor.onWillChangeModel(captureViewState),
+    modifiedEditor.onDidChangeModel(scheduleRestore)
+  ]
+
+  return {
+    dispose: () => {
+      for (const subscription of subscriptions) {
+        subscription.dispose()
+      }
+      if (restoreFrame !== null) {
+        cancelAnimationFrame(restoreFrame)
+      }
+      restoreFrame = null
+      pendingViewState = null
+    }
+  }
+}

--- a/src/renderer/src/components/editor/useDiffViewerLargeDiffLifecycle.test.tsx
+++ b/src/renderer/src/components/editor/useDiffViewerLargeDiffLifecycle.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { act, renderHook } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
+import type { editor } from 'monaco-editor'
 
 const monacoFixture = vi.hoisted(() => {
   const models = new Map<
@@ -30,6 +31,26 @@ function detachedModel(): {
   return { dispose: vi.fn(), isAttachedToEditor: () => false }
 }
 
+function diffEditorFixture(
+  original: unknown,
+  modified: unknown
+): {
+  current: editor.IStandaloneDiffEditor
+  setModel: ReturnType<typeof vi.fn>
+} {
+  let models = { original, modified }
+  const setModel = vi.fn((nextModels: typeof models) => {
+    models = nextModels
+  })
+  return {
+    current: {
+      getModel: () => models,
+      setModel
+    } as unknown as editor.IStandaloneDiffEditor,
+    setModel
+  }
+}
+
 describe('useDiffViewerLargeDiffLifecycle', () => {
   it('keeps repeated content rotations bounded to the current Monaco models', async () => {
     const modelKey = 'diff-tab'
@@ -46,9 +67,12 @@ describe('useDiffViewerLargeDiffLifecycle', () => {
     const firstModel = detachedModel()
     const secondModel = detachedModel()
     const currentModel = detachedModel()
+    const originalModel = detachedModel()
+    monacoFixture.models.set(paths[0].originalModelPath, originalModel)
     monacoFixture.models.set(paths[0].modifiedModelPath, firstModel)
     monacoFixture.models.set(paths[1].modifiedModelPath, secondModel)
     monacoFixture.models.set(paths[2].modifiedModelPath, currentModel)
+    const retainedEditor = diffEditorFixture(originalModel, firstModel)
 
     const hook = renderHook(
       ({ modifiedModelKey }) =>
@@ -57,20 +81,64 @@ describe('useDiffViewerLargeDiffLifecycle', () => {
           modelKey,
           originalModelKey,
           modifiedModelKey,
+          diffEditorRef: retainedEditor,
           onEnterFallback
         }),
       { initialProps: { modifiedModelKey: 'modified-v1' } }
     )
 
     hook.rerender({ modifiedModelKey: 'modified-v2' })
-    await act(() => new Promise<void>((resolve) => queueMicrotask(resolve)))
+    await act(() => Promise.resolve())
     hook.rerender({ modifiedModelKey: 'modified-v3' })
-    await act(() => new Promise<void>((resolve) => queueMicrotask(resolve)))
+    await act(() => Promise.resolve())
 
     expect(firstModel.dispose).toHaveBeenCalledOnce()
     expect(secondModel.dispose).toHaveBeenCalledOnce()
     expect(currentModel.dispose).not.toHaveBeenCalled()
+    expect(retainedEditor.setModel).toHaveBeenCalledTimes(2)
     expect(hook.result.current).toEqual(paths[2])
     expect(onEnterFallback).not.toHaveBeenCalled()
+  })
+
+  it('resets the owning diff widget before disposing a superseded model', async () => {
+    const modelKey = 'diff-tab'
+    const paths = ['modified-v1', 'modified-v2'].map((modifiedModelKey) =>
+      getDiffViewerMonacoModelPaths({
+        modelKey,
+        modifiedModelKey,
+        generationSuffix: ''
+      })
+    )
+    const supersededModel = detachedModel()
+    const originalModel = detachedModel()
+    const currentModel = detachedModel()
+    monacoFixture.models.set(paths[0].originalModelPath, originalModel)
+    monacoFixture.models.set(paths[0].modifiedModelPath, supersededModel)
+    monacoFixture.models.set(paths[1].modifiedModelPath, currentModel)
+    const retainedEditor = diffEditorFixture(originalModel, supersededModel)
+
+    const hook = renderHook(
+      ({ modifiedModelKey }) =>
+        useDiffViewerLargeDiffLifecycle({
+          limited: false,
+          modelKey,
+          modifiedModelKey,
+          diffEditorRef: retainedEditor,
+          onEnterFallback: vi.fn()
+        }),
+      { initialProps: { modifiedModelKey: 'modified-v1' } }
+    )
+
+    hook.rerender({ modifiedModelKey: 'modified-v2' })
+    await act(() => Promise.resolve())
+
+    expect(retainedEditor.setModel).toHaveBeenCalledWith({
+      original: originalModel,
+      modified: currentModel
+    })
+    expect(supersededModel.dispose).toHaveBeenCalledOnce()
+    expect(retainedEditor.setModel.mock.invocationCallOrder[0]).toBeLessThan(
+      supersededModel.dispose.mock.invocationCallOrder[0]
+    )
   })
 })

--- a/src/renderer/src/components/editor/useDiffViewerLargeDiffLifecycle.test.tsx
+++ b/src/renderer/src/components/editor/useDiffViewerLargeDiffLifecycle.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+const monacoFixture = vi.hoisted(() => {
+  const models = new Map<
+    string,
+    { dispose: ReturnType<typeof vi.fn>; isAttachedToEditor: () => boolean }
+  >()
+  return {
+    models,
+    monaco: {
+      Uri: { parse: (value: string) => value },
+      editor: {
+        getModel: (path: string) => models.get(path) ?? null
+      }
+    }
+  }
+})
+
+vi.mock('@/lib/monaco-setup', () => ({ monaco: monacoFixture.monaco }))
+
+import { getDiffViewerMonacoModelPaths } from './diff-monaco-model-disposal'
+import { useDiffViewerLargeDiffLifecycle } from './useDiffViewerLargeDiffLifecycle'
+
+function detachedModel(): {
+  dispose: ReturnType<typeof vi.fn>
+  isAttachedToEditor: () => boolean
+} {
+  return { dispose: vi.fn(), isAttachedToEditor: () => false }
+}
+
+describe('useDiffViewerLargeDiffLifecycle', () => {
+  it('keeps repeated content rotations bounded to the current Monaco models', async () => {
+    const modelKey = 'diff-tab'
+    const originalModelKey = 'original-v1'
+    const onEnterFallback = vi.fn()
+    const paths = ['modified-v1', 'modified-v2', 'modified-v3'].map((modifiedModelKey) =>
+      getDiffViewerMonacoModelPaths({
+        modelKey,
+        originalModelKey,
+        modifiedModelKey,
+        generationSuffix: ''
+      })
+    )
+    const firstModel = detachedModel()
+    const secondModel = detachedModel()
+    const currentModel = detachedModel()
+    monacoFixture.models.set(paths[0].modifiedModelPath, firstModel)
+    monacoFixture.models.set(paths[1].modifiedModelPath, secondModel)
+    monacoFixture.models.set(paths[2].modifiedModelPath, currentModel)
+
+    const hook = renderHook(
+      ({ modifiedModelKey }) =>
+        useDiffViewerLargeDiffLifecycle({
+          limited: false,
+          modelKey,
+          originalModelKey,
+          modifiedModelKey,
+          onEnterFallback
+        }),
+      { initialProps: { modifiedModelKey: 'modified-v1' } }
+    )
+
+    hook.rerender({ modifiedModelKey: 'modified-v2' })
+    await act(() => new Promise<void>((resolve) => queueMicrotask(resolve)))
+    hook.rerender({ modifiedModelKey: 'modified-v3' })
+    await act(() => new Promise<void>((resolve) => queueMicrotask(resolve)))
+
+    expect(firstModel.dispose).toHaveBeenCalledOnce()
+    expect(secondModel.dispose).toHaveBeenCalledOnce()
+    expect(currentModel.dispose).not.toHaveBeenCalled()
+    expect(hook.result.current).toEqual(paths[2])
+    expect(onEnterFallback).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/editor/useDiffViewerLargeDiffLifecycle.ts
+++ b/src/renderer/src/components/editor/useDiffViewerLargeDiffLifecycle.ts
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import type { RefObject } from 'react'
+import type { editor } from 'monaco-editor'
 import { monaco } from '@/lib/monaco-setup'
 import {
   disposeUnattachedDiffViewerMonacoModels,
@@ -11,6 +13,7 @@ type DiffViewerLargeDiffLifecycleInput = {
   modelKey: string
   originalModelKey?: string
   modifiedModelKey?: string
+  diffEditorRef: RefObject<editor.IStandaloneDiffEditor | null>
   onEnterFallback: () => void
 }
 
@@ -19,6 +22,7 @@ export function useDiffViewerLargeDiffLifecycle({
   modelKey,
   originalModelKey,
   modifiedModelKey,
+  diffEditorRef,
   onEnterFallback
 }: DiffViewerLargeDiffLifecycleInput): {
   originalModelPath: string
@@ -55,12 +59,26 @@ export function useDiffViewerLargeDiffLifecycle({
     if (supersededModelPaths.length === 0) {
       return
     }
-    // Why: keepCurrent*Model retains path-rotated blobs; defer until Monaco
-    // attaches the replacement, then release only detached superseded versions.
-    queueMicrotask(() => {
-      disposeUnattachedMonacoModelPaths(monaco, supersededModelPaths)
-    })
-  }, [currentDiffModelPaths])
+    const diffEditor = diffEditorRef.current
+    if (diffEditor) {
+      const originalModel = monaco.editor.getModel(
+        monaco.Uri.parse(currentDiffModelPaths.originalModelPath)
+      )
+      const modifiedModel = monaco.editor.getModel(
+        monaco.Uri.parse(currentDiffModelPaths.modifiedModelPath)
+      )
+      if (!originalModel || !modifiedModel) {
+        return
+      }
+      const activeModels = diffEditor.getModel()
+      if (activeModels?.original !== originalModel || activeModels.modified !== modifiedModel) {
+        // Why: @monaco-editor/react swaps the two child models separately, but
+        // Monaco's diff widget must release its old pair before either is disposed.
+        diffEditor.setModel({ original: originalModel, modified: modifiedModel })
+      }
+    }
+    disposeUnattachedMonacoModelPaths(monaco, supersededModelPaths)
+  }, [currentDiffModelPaths, diffEditorRef])
 
   useEffect(() => {
     if (!limited) {

--- a/src/renderer/src/components/editor/useDiffViewerLargeDiffLifecycle.ts
+++ b/src/renderer/src/components/editor/useDiffViewerLargeDiffLifecycle.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { monaco } from '@/lib/monaco-setup'
 import {
   disposeUnattachedDiffViewerMonacoModels,
+  disposeUnattachedMonacoModelPaths,
   getDiffViewerMonacoModelPaths
 } from './diff-monaco-model-disposal'
 
@@ -38,6 +39,28 @@ export function useDiffViewerLargeDiffLifecycle({
   )
   const currentDiffModelPathsRef = useRef(currentDiffModelPaths)
   currentDiffModelPathsRef.current = currentDiffModelPaths
+  const previousDiffModelPathsRef = useRef(currentDiffModelPaths)
+
+  useEffect(() => {
+    const previousModelPaths = previousDiffModelPathsRef.current
+    previousDiffModelPathsRef.current = currentDiffModelPaths
+    const supersededModelPaths = [
+      previousModelPaths.originalModelPath !== currentDiffModelPaths.originalModelPath
+        ? previousModelPaths.originalModelPath
+        : null,
+      previousModelPaths.modifiedModelPath !== currentDiffModelPaths.modifiedModelPath
+        ? previousModelPaths.modifiedModelPath
+        : null
+    ].filter((modelPath): modelPath is string => modelPath !== null)
+    if (supersededModelPaths.length === 0) {
+      return
+    }
+    // Why: keepCurrent*Model retains path-rotated blobs; defer until Monaco
+    // attaches the replacement, then release only detached superseded versions.
+    queueMicrotask(() => {
+      disposeUnattachedMonacoModelPaths(monaco, supersededModelPaths)
+    })
+  }, [currentDiffModelPaths])
 
   useEffect(() => {
     if (!limited) {


### PR DESCRIPTION
## Problem

Saving a file that's open in a single-file diff tab (⌘S) flashed a centered "Loading…" placeholder across the editor pane for a frame before the diff repainted — on **every** content-changing save.

## Root cause

The `<DiffViewer>` React `key` in `EditorContent.tsx` embedded the modified-content signature:

```ts
key={`${viewStateScopeId}:${diffReloadNonce}:${getDiffContentSignature(dc.modifiedContent)}`}
```

Each save updates `dc.modifiedContent`, which changed the key and forced React to unmount and remount the Monaco diff editor. A freshly mounted diff editor renders its built-in loading placeholder while it re-initializes, causing the flash.

The `modifiedModelKey` → `modifiedModelPath` rotation already refreshes diff content in place, which keeps diffs current on file and tree changes. The content signature in the outer key was therefore redundant.

## Fix

Drop the content signature from the outer key; keep the view-state scope and explicit reload nonce for a stable per-tab identity:

```ts
key={`${viewStateScopeId}:${diffReloadNonce}`}
```

This removes the save-triggered remount and loading flash while preserving the existing in-place model refresh. An explicit reload still remounts as intended.

The follow-up lifecycle hardening also:

- rebuilds model-scoped diff comment decorations and view zones when Monaco rotates a model;
- disposes superseded detached models after the replacement is attached, avoiding model accumulation across repeated saves;
- rechecks editor attachment before disposal so rapid model rotations and rotate-backs remain safe.

## Testing

- Added lifecycle coverage proving a save does not remount `DiffViewer`, while the modified Monaco model identity still rotates and explicit reload still remounts.
- Added diff-comment coverage proving model-scoped decorations and view zones are rebuilt after model rotation.
- Added model-disposal coverage for repeated rotations, rapid rotations, attached models, and rotate-back behavior.
- 57 focused editor, watcher, decorator, and model-lifecycle tests pass.
- `pnpm run typecheck:web`, changed-file oxlint, `oxfmt --check`, max-lines ratchet, and `git diff --check` pass.

## Manual Electron validation

Validated the editable unstaged Markdown diff in an isolated Electron profile on macOS. During save, the same Monaco diff editor DOM node remained connected; 180 animation-frame samples observed no `Loading…` placeholder and no blank pane; the dirty flag cleared; the new text persisted; and no fresh console error was emitted.

The manual pass also exposed and fixed a retained-model disposal race that could blank the pane after save (`0c89bc213`). The owning Monaco diff widget now adopts the replacement model pair before superseded detached models are disposed.

**Before save (dirty edit):**

![Editable Markdown diff before save](https://github.com/user-attachments/assets/efc64344-b1db-49c7-98ec-dab15d0cf0b1)

**After save (same editor, content retained):**

![Editable Markdown diff after save](https://github.com/user-attachments/assets/eb3c124e-c188-432a-8a03-e6f587410a2b)
