### PR TITLE
fix(browser): gate certificate proceed on runtime capability

### DIFF
--- a/src/main/browser/browser-certificate-identity.ts
+++ b/src/main/browser/browser-certificate-identity.ts
@@ -1,14 +1,11 @@
 import { createHash } from 'node:crypto'
 
+import { normalizeCertificateError } from '../../shared/browser-certificate-errors'
+
+export { normalizeCertificateError }
+
 export const SUPPORTED_CERTIFICATE_ERROR = 'ERR_CERT_AUTHORITY_INVALID'
 export const SUPPORTED_CERTIFICATE_ERROR_CODE = -202
-
-export function normalizeCertificateError(error: string): string {
-  return error
-    .trim()
-    .replace(/^net::/i, '')
-    .toUpperCase()
-}
 
 export function getSupportedCertificateErrorCode(error: string): number | null {
   return normalizeCertificateError(error) === SUPPORTED_CERTIFICATE_ERROR

--- a/src/main/browser/browser-certificate-trust-controller.ts
+++ b/src/main/browser/browser-certificate-trust-controller.ts
@@ -107,7 +107,11 @@ export class BrowserCertificateTrustController {
         })
       }
       answer(false)
-    } catch {
+    } catch (error) {
+      // Why: fail closed, but log first — a throw in challenge recording would
+      // otherwise present as "the cert prompt never appears" with no trace,
+      // matching the logging catch in browser-manager's guest-state notifier.
+      console.error('[browser-certificate-trust-controller] handleCertificateError failed', error)
       answer(false)
     }
   }

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -891,11 +891,11 @@ export class BrowserManager {
         return
       }
       this.clearedLoadErrorsByGuestId.delete(guest.id)
-      const loadError = {
-        code: errorCode,
-        description: errorDescription || 'This site could not be reached.',
-        validatedUrl: redactKagiSessionToken(validatedURL || guest.getURL() || 'about:blank')
-      }
+      const loadError = this.buildLoadError(
+        errorCode,
+        errorDescription || 'This site could not be reached.',
+        validatedURL || guest.getURL() || 'about:blank'
+      )
       this.loadErrorsByGuestId.set(guest.id, loadError)
       this.forwardOrQueueGuestLoadFailure(guest.id, loadError)
       this.notifyBrowserGuestStateChanged(guest.id)
@@ -1299,17 +1299,24 @@ export class BrowserManager {
     }
   }
 
+  // Why: both the did-fail-load path and the synthesized certificate failure
+  // build a load error from an untrusted URL; centralize the redaction so a
+  // future third site cannot forget to strip Kagi session tokens.
+  private buildLoadError(code: number, description: string, rawUrl: string): BrowserLoadError {
+    return {
+      code,
+      description,
+      validatedUrl: redactKagiSessionToken(rawUrl)
+    }
+  }
+
   notifyCertificateFailureChanged(
     webContentsId: number,
     failure: BrowserCertificateFailure | null,
     navigationUrl?: string
   ): void {
     if (failure && navigationUrl) {
-      const loadError = {
-        code: failure.errorCode ?? -1,
-        description: failure.error,
-        validatedUrl: redactKagiSessionToken(navigationUrl)
-      }
+      const loadError = this.buildLoadError(failure.errorCode ?? -1, failure.error, navigationUrl)
       this.loadErrorsByGuestId.set(webContentsId, loadError)
       this.forwardOrQueueGuestLoadFailure(webContentsId, loadError)
     }

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -61,6 +61,7 @@ import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { useAppStore } from '@/store'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { ORCA_BROWSER_BLANK_URL, ORCA_BROWSER_PARTITION } from '../../../../shared/constants'
+import { BROWSER_CERTIFICATE_TRUST_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
 import { getOrcaProfileBrowserDefaultPartition } from '../../../../shared/orca-profiles'
 import type {
   BrowserCertificateProceedResult,
@@ -151,6 +152,7 @@ import {
 } from '@/runtime/runtime-file-client'
 import {
   callRuntimeRpc,
+  runtimeEnvironmentSupportsCapability,
   RuntimeRpcCallError,
   type RuntimeClientTarget
 } from '@/runtime/runtime-rpc-client'
@@ -946,6 +948,38 @@ function RemoteBrowserPagePane({
   const closeBrowserPage = useAppStore((s) => s.closeBrowserPage)
   const closeBrowserTab = useAppStore((s) => s.closeBrowserTab)
   const keybindings = useAppStore((state) => state.keybindings)
+
+  // Why: a remote runtime that predates browser.certificate-trust.v1 cannot
+  // honor a proceed request, so the "Proceed Anyway (Unsafe)" affordance stays
+  // hidden until the connected runtime positively advertises support (design
+  // doc: older runtimes never show an enabled proceed action).
+  const [remoteCertificateTrustSupported, setRemoteCertificateTrustSupported] = useState(false)
+  const remoteCertificateEnvironmentId = remotePageHandle?.environmentId ?? null
+  const certificateChallengeId = certificateFailure?.challengeId ?? null
+  useEffect(() => {
+    if (!remoteCertificateEnvironmentId || !certificateChallengeId) {
+      setRemoteCertificateTrustSupported(false)
+      return
+    }
+    let cancelled = false
+    void runtimeEnvironmentSupportsCapability(
+      remoteCertificateEnvironmentId,
+      BROWSER_CERTIFICATE_TRUST_RUNTIME_CAPABILITY
+    )
+      .then((supported) => {
+        if (!cancelled) {
+          setRemoteCertificateTrustSupported(supported)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setRemoteCertificateTrustSupported(false)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [remoteCertificateEnvironmentId, certificateChallengeId])
 
   currentBrowserTabIdRef.current = browserTab.id
   currentBrowserTabUrlRef.current = browserTab.url
@@ -2696,7 +2730,7 @@ function RemoteBrowserPagePane({
             onTryHttps={(url) => void runRemoteNavigation('browser.goto', url)}
             onCopy={(url) => void window.api.ui.writeClipboardText(url)}
             onOpenExternal={(url) => void window.api.shell.openUrl(url)}
-            certificateFailure={certificateFailure}
+            certificateFailure={remoteCertificateTrustSupported ? certificateFailure : null}
             expectedBrowserPageId={
               remotePageHandle?.environmentId === activeRuntimeEnvironmentId
                 ? remotePageHandle.remotePageId

--- a/src/renderer/src/components/browser-pane/browser-load-failure-overlay.tsx
+++ b/src/renderer/src/components/browser-pane/browser-load-failure-overlay.tsx
@@ -10,6 +10,7 @@ import type {
   BrowserLoadError
 } from '../../../../shared/types'
 import { isEligibleLocalCertificateHost } from '../../../../shared/browser-url'
+import { normalizeCertificateError } from '../../../../shared/browser-certificate-errors'
 import {
   formatLoadFailureDescription,
   formatLoadFailureRecoveryHint,
@@ -49,13 +50,6 @@ function getLoadErrorMetadata(loadError: BrowserLoadError): LoadFailureMeta {
   } catch {
     return { host: null, isLocalhostLike: false }
   }
-}
-
-function normalizeCertificateError(error: string): string {
-  return error
-    .trim()
-    .replace(/^net::/i, '')
-    .toUpperCase()
 }
 
 function getMatchingCertificateFailure(args: {

--- a/src/shared/browser-certificate-errors.ts
+++ b/src/shared/browser-certificate-errors.ts
@@ -7,3 +7,13 @@ const CHROMIUM_CERTIFICATE_ERROR_CODES = new Set([
 export function isChromiumCertificateErrorCode(code: number): boolean {
   return CHROMIUM_CERTIFICATE_ERROR_CODES.has(code)
 }
+
+// Why: main (certificate-error handler) and the renderer overlay both compare
+// Chromium error strings; keep one normalizer so their challenge-matching can
+// never silently diverge.
+export function normalizeCertificateError(error: string): string {
+  return error
+    .trim()
+    .replace(/^net::/i, '')
+    .toUpperCase()
+}


### PR DESCRIPTION
Follow-up to #9104.

## Summary

- hide `Proceed Anyway (Unsafe)` for remote runtimes that do not advertise `browser.certificate-trust.v1`
- centralize Chromium certificate-error normalization across main and renderer
- centralize Kagi token redaction for browser load-error construction
- log certificate challenge-recording failures while continuing to fail closed

## Testing

- `pnpm run typecheck`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/browser/browser-certificate-trust-controller.test.ts src/main/browser/browser-manager.test.ts src/main/runtime/orca-runtime.test.ts src/renderer/src/components/browser-pane/browser-load-failure-overlay.test.tsx src/shared/browser-url.test.ts` (848 tests passed)
- `git diff --check 02ff7c746..HEAD`