### PR TITLE
fix(codex): survive lingering Windows codex login processes in add-account

### DIFF
--- a/config/scripts/run-codex-real-account-validation.mjs
+++ b/config/scripts/run-codex-real-account-validation.mjs
@@ -76,7 +76,18 @@ export function createValidationEnv(inheritedEnv, layout) {
 
 export async function createValidationLayout(options = {}) {
   const primaryHome = path.resolve(options.primaryHome ?? os.homedir())
-  const tempRoot = await mkdtemp(path.join(options.tempParent ?? os.tmpdir(), 'orca-codex-real-'))
+  const envTempParent = process.env.ORCA_CODEX_VALIDATION_TEMP_PARENT?.trim()
+  const tempParent = path.resolve(options.tempParent ?? (envTempParent || os.tmpdir()))
+  // Why: on Windows the default %TEMP% lives inside %USERPROFILE%, which the
+  // disposable-home guard below rightly refuses. Fail before creating anything
+  // and point at the overrides instead of aborting with an opaque guard error.
+  if (samePath(tempParent, primaryHome) || isWithin(tempParent, primaryHome)) {
+    throw new Error(
+      `Refusing to place the disposable validation root inside the primary home (${primaryHome}). ` +
+        'Pass --temp-parent <dir> or set ORCA_CODEX_VALIDATION_TEMP_PARENT to a directory outside it.'
+    )
+  }
+  const tempRoot = await mkdtemp(path.join(tempParent, 'orca-codex-real-'))
   const homeDir = path.join(tempRoot, 'home')
   const userDataDir = path.join(tempRoot, 'user-data')
   await Promise.all([
@@ -233,7 +244,8 @@ function parseArgs(argv) {
     keep: false,
     reportPath: null,
     primaryHome: os.homedir(),
-    configTemplate: null
+    configTemplate: null,
+    tempParent: null
   }
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]
@@ -253,6 +265,8 @@ function parseArgs(argv) {
       options.primaryHome = path.resolve(readValue())
     } else if (arg === '--config-template') {
       options.configTemplate = path.resolve(readValue())
+    } else if (arg === '--temp-parent') {
+      options.tempParent = path.resolve(readValue())
     } else if (arg === '--dry-run') {
       options.dryRun = true
     } else if (arg === '--close-after-launch') {
@@ -263,7 +277,7 @@ function parseArgs(argv) {
       options.keep = true
     } else if (arg === '--help') {
       console.log(
-        'Usage: node config/scripts/run-codex-real-account-validation.mjs [--scenario mixed|managed-only|codex-lb] [--config-template <path>] [--skip-build] [--dry-run] [--close-after-launch] [--keep] [--report <path>]'
+        'Usage: node config/scripts/run-codex-real-account-validation.mjs [--scenario mixed|managed-only|codex-lb] [--config-template <path>] [--temp-parent <dir>] [--skip-build] [--dry-run] [--close-after-launch] [--keep] [--report <path>]'
       )
       process.exit(0)
     } else {
@@ -399,7 +413,10 @@ async function runInteractiveSession(context) {
 async function main() {
   const options = parseArgs(process.argv.slice(2))
   const repoRoot = process.cwd()
-  const layout = await createValidationLayout({ primaryHome: options.primaryHome })
+  const layout = await createValidationLayout({
+    primaryHome: options.primaryHome,
+    tempParent: options.tempParent ?? undefined
+  })
   const reportPath =
     options.reportPath ??
     path.join(os.tmpdir(), `orca-codex-real-account-${options.scenario}-${Date.now()}.json`)

--- a/config/scripts/run-codex-real-account-validation.test.ts
+++ b/config/scripts/run-codex-real-account-validation.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { rm } from 'node:fs/promises'
+import { mkdtemp, rm } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -82,13 +82,53 @@ describe('Codex real-account validation harness', () => {
     expect(JSON.stringify(snapshot)).not.toContain('system-secret')
     expect(JSON.stringify(snapshot)).not.toContain('never-report-me')
   })
+
+  it('honors a disposable temp parent override outside the primary home', async () => {
+    const tempParent = await mkdtemp(path.join(os.tmpdir(), 'orca-temp-parent-'))
+    cleanupPaths.push(tempParent)
+    const { layout } = runValidationModule<{ layout: { tempRoot: string } }>(
+      `
+        const { createValidationLayout } = await import(process.argv[1])
+        const layout = await createValidationLayout({ primaryHome: process.argv[2] })
+        console.log(JSON.stringify({ layout }))
+      `,
+      [path.join(os.tmpdir(), 'orca-primary-home-sentinel')],
+      { ORCA_CODEX_VALIDATION_TEMP_PARENT: tempParent }
+    )
+
+    expect(path.dirname(layout.tempRoot)).toBe(tempParent)
+  })
+
+  it('refuses a temp parent inside the primary home and points at the overrides', () => {
+    // Why: matches Windows, where the default %TEMP% lives inside %USERPROFILE%.
+    const { error } = runValidationModule<{ error: string | null }>(
+      `
+        const { createValidationLayout } = await import(process.argv[1])
+        try {
+          const layout = await createValidationLayout({ primaryHome: process.argv[2] })
+          console.log(JSON.stringify({ error: null, layout }))
+        } catch (caught) {
+          console.log(JSON.stringify({ error: caught.message }))
+        }
+      `,
+      [os.tmpdir()]
+    )
+
+    expect(error).toContain('Refusing to place the disposable validation root')
+    expect(error).toContain('--temp-parent')
+    expect(error).toContain('ORCA_CODEX_VALIDATION_TEMP_PARENT')
+  })
 })
 
-function runValidationModule<T>(source: string, args: string[]): T {
+function runValidationModule<T>(source: string, args: string[], env?: Record<string, string>): T {
   const stdout = execFileSync(
     process.execPath,
     ['--input-type=module', '--eval', source, validationModuleUrl, ...args],
-    { encoding: 'utf8' }
+    {
+      encoding: 'utf8',
+      // Why: an ambient temp-parent override must not redirect unrelated cases.
+      env: { ...process.env, ORCA_CODEX_VALIDATION_TEMP_PARENT: '', ...env }
+    }
   )
   return JSON.parse(stdout.trim()) as T
 }

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -1928,6 +1928,167 @@ describe('CodexAccountService config sync', () => {
     }
   })
 
+  it('force-kills a lingering Windows codex login tree once auth.json exists', async () => {
+    vi.resetModules()
+    vi.useFakeTimers()
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: PassThrough
+      stderr: PassThrough
+      kill: () => void
+      pid: number
+      exitCode: number | null
+      signalCode: string | null
+    }
+    child.stdout = new PassThrough()
+    child.stderr = new PassThrough()
+    child.kill = vi.fn()
+    child.pid = 4242
+    child.exitCode = null
+    child.signalCode = null
+    const execFileSyncMock = vi.fn()
+    const spawnMock = vi.fn(() => child)
+    vi.doMock('node:child_process', () => ({
+      execFileSync: execFileSyncMock,
+      spawn: spawnMock
+    }))
+    vi.doMock('../codex-cli/command', () => ({
+      resolveCodexCommand: () => 'codex'
+    }))
+
+    try {
+      const store = createStore(createSettings())
+      const rateLimits = createRateLimits()
+      const runtimeHome = createRuntimeHome()
+      const { CodexAccountService } = await import('./service')
+      const service = new CodexAccountService(
+        store as never,
+        rateLimits as never,
+        runtimeHome as never
+      )
+      const loginPromise = (
+        service as unknown as {
+          runCodexLogin(managedHomePath: string): Promise<void>
+        }
+      ).runCodexLogin(testState.fakeHomeDir)
+
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(execFileSyncMock).not.toHaveBeenCalled()
+
+      // Codex finishes the login (auth.json exists) but never exits on its own.
+      writeFileSync(
+        join(testState.fakeHomeDir, 'auth.json'),
+        createCodexAuthJson('user@example.com', 'provider-account-1', 'refresh-token'),
+        'utf-8'
+      )
+      await vi.advanceTimersByTimeAsync(6_000)
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        'taskkill',
+        ['/pid', '4242', '/t', '/f'],
+        expect.objectContaining({ windowsHide: true, stdio: 'ignore' })
+      )
+      expect(child.kill).not.toHaveBeenCalled()
+
+      // The forced non-zero exit still counts as a successful login.
+      child.emit('close', 1)
+      await expect(loginPromise).resolves.toBeUndefined()
+    } finally {
+      Object.defineProperty(process, 'platform', originalPlatform)
+      vi.useRealTimers()
+      vi.doUnmock('node:child_process')
+      vi.doUnmock('../codex-cli/command')
+    }
+  })
+
+  it('removes managed homes with bounded rm retries for transient Windows locks', async () => {
+    vi.resetModules()
+    const actualFs = await vi.importActual<typeof import('node:fs')>('node:fs') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
+    const rmSyncSpy = vi.fn(actualFs.rmSync)
+    vi.doMock('node:fs', () => ({ ...actualFs, rmSync: rmSyncSpy }))
+
+    try {
+      // Why realpath: assertManagedHomePath canonicalizes before rmSync, so the
+      // spy sees /private/var-style paths on macOS.
+      const managedHomePath = actualFs.realpathSync(
+        createManagedHome(testState.userDataDir, 'account-1')
+      )
+      const store = createStore(createSettings())
+      const rateLimits = createRateLimits()
+      const runtimeHome = createRuntimeHome()
+      const { CodexAccountService } = await import('./service')
+      const service = new CodexAccountService(
+        store as never,
+        rateLimits as never,
+        runtimeHome as never
+      )
+
+      ;(
+        service as unknown as {
+          safeRemoveManagedHome(candidatePath: string, expectedAccountId: string): void
+        }
+      ).safeRemoveManagedHome(managedHomePath, 'account-1')
+
+      expect(existsSync(managedHomePath)).toBe(false)
+      const homeRemoval = rmSyncSpy.mock.calls.find(([target]) => target === managedHomePath)
+      expect(homeRemoval?.[1]).toMatchObject({
+        recursive: true,
+        force: true,
+        maxRetries: 8,
+        retryDelay: 150
+      })
+    } finally {
+      vi.doUnmock('node:fs')
+    }
+  })
+
+  it('does not throw when managed home removal keeps failing on a held handle', async () => {
+    vi.resetModules()
+    const actualFs = await vi.importActual<typeof import('node:fs')>('node:fs') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
+    let managedHomePath = ''
+    const lockedError = Object.assign(new Error('ENOTEMPTY: directory not empty'), {
+      code: 'ENOTEMPTY'
+    })
+    const rmSyncSpy = vi.fn((target: Parameters<typeof actualFs.rmSync>[0], options) => {
+      if (target === managedHomePath) {
+        throw lockedError
+      }
+      actualFs.rmSync(target, options)
+    })
+    vi.doMock('node:fs', () => ({ ...actualFs, rmSync: rmSyncSpy }))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      managedHomePath = actualFs.realpathSync(
+        createManagedHome(testState.userDataDir, 'account-1')
+      )
+      const store = createStore(createSettings())
+      const rateLimits = createRateLimits()
+      const runtimeHome = createRuntimeHome()
+      const { CodexAccountService } = await import('./service')
+      const service = new CodexAccountService(
+        store as never,
+        rateLimits as never,
+        runtimeHome as never
+      )
+
+      expect(() =>
+        (
+          service as unknown as {
+            safeRemoveManagedHome(candidatePath: string, expectedAccountId: string): void
+          }
+        ).safeRemoveManagedHome(managedHomePath, 'account-1')
+      ).not.toThrow()
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[codex-accounts] Failed to remove managed home:',
+        lockedError
+      )
+    } finally {
+      warnSpy.mockRestore()
+      vi.doUnmock('node:fs')
+    }
+  })
+
   describe('system-default identity', () => {
     const systemCodexHomeDir = () => join(testState.fakeHomeDir, '.codex')
     const systemAuthPath = () => join(systemCodexHomeDir(), 'auth.json')

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -2,7 +2,7 @@
 account lifecycle, path safety, login, and identity parsing in one audited
 main-process module so the managed-account boundary stays explicit. */
 import { randomUUID } from 'node:crypto'
-import { execFileSync, spawn } from 'node:child_process'
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process'
 import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, join, resolve, sep } from 'node:path'
 import { homedir } from 'node:os'
@@ -49,6 +49,13 @@ import { assertOwnedHostCodexManagedHomePath } from './host-codex-managed-home-o
 
 const LOGIN_TIMEOUT_MS = 120_000
 const MAX_LOGIN_OUTPUT_CHARS = 4_000
+// Why: mirrors the Windows rm retry policy in local-worktree-filesystem — a
+// just-terminated codex login can briefly keep handles inside a managed home.
+const WINDOWS_RM_MAX_RETRIES = 8
+const WINDOWS_RM_RETRY_DELAY_MS = 150
+const WINDOWS_LOGIN_AUTH_POLL_INTERVAL_MS = 500
+const WINDOWS_LOGIN_POST_AUTH_EXIT_GRACE_MS = 5_000
+const WINDOWS_LOGIN_TREE_KILL_TIMEOUT_MS = 5_000
 
 type CodexOAuthCredentials = {
   idToken: string | null
@@ -84,6 +91,43 @@ type ManagedHomeLocation = {
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`
+}
+
+function removeManagedHomeTreeSync(targetPath: string): void {
+  // Why: codex login descendants can briefly keep Windows handles on files in
+  // the managed home (e.g. log/codex-login.log); bounded retries absorb the
+  // transient lock instead of failing with ENOTEMPTY and orphaning the home.
+  rmSync(targetPath, {
+    recursive: true,
+    force: true,
+    maxRetries: WINDOWS_RM_MAX_RETRIES,
+    retryDelay: WINDOWS_RM_RETRY_DELAY_MS
+  })
+}
+
+function killLoginProcessTree(child: ChildProcess): void {
+  if (
+    process.platform === 'win32' &&
+    typeof child.pid === 'number' &&
+    child.exitCode === null &&
+    child.signalCode === null
+  ) {
+    try {
+      // Why: child.kill() only reaches the direct child (cmd.exe for npm .cmd
+      // shims); taskkill /t also ends codex descendants whose open handles on
+      // the managed home make post-login file operations fail with ENOTEMPTY.
+      execFileSync('taskkill', ['/pid', String(child.pid), '/t', '/f'], {
+        windowsHide: true,
+        timeout: WINDOWS_LOGIN_TREE_KILL_TIMEOUT_MS,
+        stdio: 'ignore'
+      })
+      return
+    } catch {
+      // Why: taskkill can race an already-exited tree; fall back to the plain
+      // signal so the direct child never outlives its deadline.
+    }
+  }
+  child.kill()
 }
 
 export class CodexAccountService {
@@ -926,11 +970,18 @@ export class CodexAccountService {
       return
     }
 
-    rmSync(managedHomePath, { recursive: true, force: true })
+    try {
+      removeManagedHomeTreeSync(managedHomePath)
+    } catch (error) {
+      // Why: this runs from error-cleanup paths; a still-held Windows handle
+      // must not mask the original failure with an ENOTEMPTY from rmSync.
+      console.warn('[codex-accounts] Failed to remove managed home:', error)
+      return
+    }
 
     if (parseWslUncPath(managedHomePath)) {
       try {
-        rmSync(dirname(managedHomePath), { recursive: true, force: true })
+        removeManagedHomeTreeSync(dirname(managedHomePath))
       } catch {
         // Best-effort cleanup
       }
@@ -946,7 +997,7 @@ export class CodexAccountService {
       // macOS where userData resolves through /private/var.
       const root = realpathSync(this.getManagedAccountsRoot())
       if (parentDir.startsWith(root + sep) && parentDir !== root) {
-        rmSync(parentDir, { recursive: true, force: true })
+        removeManagedHomeTreeSync(parentDir)
       }
     } catch {
       // Best-effort cleanup
@@ -1003,10 +1054,22 @@ export class CodexAccountService {
       }
 
       let timeout: ReturnType<typeof setTimeout> | null = null
+      let authWatchInterval: ReturnType<typeof setInterval> | null = null
+      let postAuthExitTimeout: ReturnType<typeof setTimeout> | null = null
+      let loginTreeKilledAfterAuth = false
+      const authJsonPath = join(managedHomePath, 'auth.json')
       const cleanupListeners = (): void => {
         if (timeout) {
           clearTimeout(timeout)
           timeout = null
+        }
+        if (authWatchInterval) {
+          clearInterval(authWatchInterval)
+          authWatchInterval = null
+        }
+        if (postAuthExitTimeout) {
+          clearTimeout(postAuthExitTimeout)
+          postAuthExitTimeout = null
         }
         child.stdout.off('data', appendOutput)
         child.stderr.off('data', appendOutput)
@@ -1025,11 +1088,31 @@ export class CodexAccountService {
 
       const timeoutError = new Error('Codex sign-in took too long to finish. Please try again.')
       timeout = setTimeout(() => {
-        child.kill()
+        killLoginProcessTree(child)
         settle(() => {
           rejectPromise(timeoutError)
         })
       }, LOGIN_TIMEOUT_MS)
+
+      // Why: on Windows the codex login CLI can linger after writing auth.json,
+      // and its open handles on the managed home (log/codex-login.log) make the
+      // post-login file operations fail with ENOTEMPTY. Once auth.json exists,
+      // give the tree a short grace period to exit, then force it down.
+      if (process.platform === 'win32' && !wslInfo) {
+        authWatchInterval = setInterval(() => {
+          if (!existsSync(authJsonPath)) {
+            return
+          }
+          if (authWatchInterval) {
+            clearInterval(authWatchInterval)
+            authWatchInterval = null
+          }
+          postAuthExitTimeout = setTimeout(() => {
+            loginTreeKilledAfterAuth = true
+            killLoginProcessTree(child)
+          }, WINDOWS_LOGIN_POST_AUTH_EXIT_GRACE_MS)
+        }, WINDOWS_LOGIN_AUTH_POLL_INTERVAL_MS)
+      }
 
       const onError = (error: Error): void => {
         settle(() => {
@@ -1049,7 +1132,10 @@ export class CodexAccountService {
 
       const onClose = (code: number | null): void => {
         settle(() => {
-          if (code === 0) {
+          // Why: the post-auth tree kill is a success path — auth.json already
+          // exists and codex only failed to exit on its own, so the forced
+          // non-zero exit must not surface as a login failure.
+          if (code === 0 || (loginTreeKilledAfterAuth && existsSync(authJsonPath))) {
             resolvePromise()
             return
           }


### PR DESCRIPTION
## Root cause

A native-Windows validation run of the Codex multi-account add flow (`codexAccounts.add({runtime:'host'})`) proved that `codex login` (spawned by `runCodexLogin`) leaves a **lingering process tree holding OS file handles** on the per-account managed home — specifically `<home>\log\codex-login.log`. On Windows, held handles make directory removal fail, so `doAddAccount`'s error-cleanup path (`safeRemoveManagedHome` → `rmSync`) died with **ENOTEMPTY (errno 41, syscall rm)** and left an orphaned `codex-accounts\<id>\home`.

Proof this is the only bug: driving the same add while a background killer terminated the lingering codex processes the instant `auth.json` appeared made the entire add succeed (account persisted, active, email resolved, per-account home + auth correct). Without the kill it failed deterministically (5–6 repros). Process-lifecycle/file-lock bug, not a logic flaw.

## Fix (two prongs)

**1. Release the handle before post-login file ops (`runCodexLogin`, primary)**
- On Windows (host runtime only), poll for `auth.json` in the managed home. Once it exists, give the login tree a short grace period (5s) to exit on its own; if it lingers, force-kill the whole tree with `taskkill /pid <pid> /t /f` (plain `child.kill()` only reaches the direct child — e.g. the `cmd.exe` shim for `codex.cmd` — and leaves descendants holding handles).
- The forced non-zero exit after `auth.json` exists is treated as a **successful** login, so the kill never surfaces as a spurious failure.
- The existing 120s login timeout now also kills the full tree on Windows instead of only the direct child, so a timed-out login can't strand handle-holding descendants either.
- macOS/Linux: no behavioral change (the watcher is gated on `win32`; the timeout path still uses `child.kill()` there).

**2. Windows-lock-resilient removal (`safeRemoveManagedHome`, defensive)**
- All managed-home `rmSync` calls now pass `maxRetries: 8, retryDelay: 150` (mirroring the `WINDOWS_RM_MAX_RETRIES` policy in `local-worktree-filesystem.ts` and the `chromium-cookie-snapshot.ts` precedent), so a transient handle retries instead of throwing. This also fixes the secondary orphaned-home bug.
- A removal that still fails after retries is warned and swallowed instead of thrown, so cleanup can no longer mask the original add/login error with an ENOTEMPTY stack.
- Post-login config writes were already lock-resilient via `writeFileAtomically` → `renameFileWithWindowsRetry`; no change needed there.

## Tooling fix

`config/scripts/run-codex-real-account-validation.mjs` placed its disposable root under `os.tmpdir()`, which on Windows is inside `%USERPROFILE%`, so its own real-home-protection guard always aborted. It now honors `--temp-parent <dir>` / `ORCA_CODEX_VALIDATION_TEMP_PARENT` for the disposable root, and fails fast with an actionable message (before creating anything) when the temp parent is inside the primary home. The guard that refuses the real home / real `~/.codex` is unchanged and still enforced.

## Tests

Added:
- `service.test.ts`: force-kills a lingering Windows login tree once `auth.json` exists (fake `win32` platform, asserts the `taskkill /pid <pid> /t /f` invocation and that the forced non-zero exit resolves the login as success).
- `service.test.ts`: `safeRemoveManagedHome` passes `maxRetries`/`retryDelay` to `rmSync` and removes the home.
- `service.test.ts`: a persistently locked home (ENOTEMPTY) no longer throws out of `safeRemoveManagedHome` (warns instead).
- `run-codex-real-account-validation.test.ts`: temp-parent override is honored; a temp parent inside the primary home is refused with the override hint.

Ran (macOS):
- `npx vitest run --config config/vitest.config.ts src/main/codex-accounts/service.test.ts` — 38/38 pass
- `npx vitest run --config config/vitest.config.ts config/scripts/run-codex-real-account-validation.test.ts` — 4/4 pass
- `tsc --noEmit -p config/tsconfig.node.json` — clean
- `oxlint` on changed files + `check:max-lines-ratchet` — clean

## Windows re-test needed (blocking before merge)

This was implemented on macOS; the bug is Windows-only and **no end-to-end Windows verification has been done on this branch**. On a native Windows machine (validation harness with `--temp-parent` outside the profile):

- [ ] Repro run: `codexAccounts.add({runtime:'host'})` now succeeds **without** any external process killer (previously deterministic ENOTEMPTY failure)
- [ ] Two distinct accounts: add account A, then account B (A ≠ B); both persist with correct per-account homes, auth.json, and emails
- [ ] Concurrent panes: panes running under different accounts get the right per-account `CODEX_HOME` while adds/switches happen
- [ ] Orphaned-home cleanup: a deliberately failed add (e.g. cancel login) leaves **no** orphaned `codex-accounts\<id>\home` directory
- [ ] Failure-path UX: when login genuinely fails, the surfaced error is the login error, not an ENOTEMPTY cleanup error
- [ ] Validation harness itself starts on Windows with `--temp-parent D:\some\dir` (or `ORCA_CODEX_VALIDATION_TEMP_PARENT`) and the tripwire stays clean

## Caveats

- The tree kill only works while the direct login child is still alive. If codex's main process exits 0 but leaves a fully **detached** descendant holding the log handle, `taskkill /t` on the dead parent can't reach it; the rmSync retries (~1.2s of backoff) plus warn-instead-of-throw are the backstop for that shape. The proven repro (lingering tree killable at `auth.json` time) is fully covered.
- Grace period is 5s after `auth.json` appears; if codex needs longer than that to finish post-auth writes on very slow machines, it gets force-killed — validation showed killing at `auth.json` time is safe (add succeeds end-to-end).
- WSL-runtime logins are intentionally untouched (handles there are held by Linux-side processes that `taskkill` can't reach; the proven bug is host-runtime).

Do not merge until the Windows checklist above passes.
