### PR TITLE
feat(foreground): structured foreground result + neutral unknown-alive tab presence

### DIFF
--- a/src/main/agent-awake-foreground-evidence.ts
+++ b/src/main/agent-awake-foreground-evidence.ts
@@ -1,0 +1,75 @@
+// Why: foreground-agent scans are event-driven (title status transitions,
+// session listing sweeps), not periodic. The TTL only bridges gaps between
+// them; expiry revalidates against the runtime's cached foreground state
+// instead of forcing a new process scan.
+export const AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS = 5 * 60 * 1000
+
+type ForegroundAgentEvidence = {
+  // Last time a real scan reported this PTY's recognized foreground agent.
+  reportedAt: number
+  // Refreshed by scans AND by cache revalidation at TTL expiry.
+  observedAt: number
+}
+
+/**
+ * Per-PTY keep-awake evidence for recognized foreground agents (wrapper
+ * claude etc.) that emit no hook statuses. Only recognized agents are ever
+ * reported here — arbitrary processes never grant wake eligibility.
+ */
+export class ForegroundAgentEvidenceLedger {
+  private readonly evidenceByPtyId = new Map<string, ForegroundAgentEvidence>()
+  private readonly now: () => number
+  private readonly revalidate: ((ptyId: string) => boolean) | null
+
+  constructor(args: { now: () => number; revalidate?: (ptyId: string) => boolean }) {
+    this.now = args.now
+    this.revalidate = args.revalidate ?? null
+  }
+
+  /** Returns true when the report changed the ledger (caller should refresh). */
+  report(ptyId: string, agent: string | null): boolean {
+    if (agent === null) {
+      return this.evidenceByPtyId.delete(ptyId)
+    }
+    const now = this.now()
+    this.evidenceByPtyId.set(ptyId, { reportedAt: now, observedAt: now })
+    return true
+  }
+
+  /** Drops expired evidence; counts what remains toward wake eligibility. */
+  pruneAndCount(staleAfterMs: number): number {
+    const now = this.now()
+    for (const [ptyId, evidence] of this.evidenceByPtyId) {
+      if (now - evidence.observedAt <= AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS) {
+        continue
+      }
+      // Why: renew from the runtime's live cache (never a scan), hard-capped by
+      // the same 2h window hook statuses get so a stale cache cannot block
+      // sleep indefinitely. Anything else expires with the TTL.
+      if (now - evidence.reportedAt <= staleAfterMs && this.revalidate?.(ptyId) === true) {
+        evidence.observedAt = now
+      } else {
+        this.evidenceByPtyId.delete(ptyId)
+      }
+    }
+    return this.evidenceByPtyId.size
+  }
+
+  /** Earliest upcoming expiry among live evidence, or null when none. */
+  nextExpiry(staleAfterMs: number): number | null {
+    const now = this.now()
+    let earliest: number | null = null
+    for (const evidence of this.evidenceByPtyId.values()) {
+      // Why: the TTL expiry drives revalidation; the 2h cap is the backstop.
+      const expiry = Math.min(
+        evidence.observedAt + AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS,
+        evidence.reportedAt + staleAfterMs
+      )
+      if (expiry <= now) {
+        continue
+      }
+      earliest = earliest === null ? expiry : Math.min(earliest, expiry)
+    }
+    return earliest
+  }
+}

--- a/src/main/agent-awake-foreground-evidence.ts
+++ b/src/main/agent-awake-foreground-evidence.ts
@@ -1,7 +1,5 @@
-// Why: foreground-agent scans are event-driven (title status transitions,
-// session listing sweeps), not periodic. The TTL only bridges gaps between
-// them; expiry revalidates against the runtime's cached foreground state
-// instead of forcing a new process scan.
+// Why: scans are event-driven, so expiry revalidates cached foreground state
+// without adding process scans.
 export const AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS = 5 * 60 * 1000
 
 type ForegroundAgentEvidence = {
@@ -11,11 +9,7 @@ type ForegroundAgentEvidence = {
   observedAt: number
 }
 
-/**
- * Per-PTY keep-awake evidence for recognized foreground agents (wrapper
- * claude etc.) that emit no hook statuses. Only recognized agents are ever
- * reported here — arbitrary processes never grant wake eligibility.
- */
+/** Per-PTY keep-awake evidence for recognized agents that emit no hook statuses. */
 export class ForegroundAgentEvidenceLedger {
   private readonly evidenceByPtyId = new Map<string, ForegroundAgentEvidence>()
   private readonly now: () => number
@@ -40,9 +34,8 @@ export class ForegroundAgentEvidenceLedger {
   pruneAndCount(staleAfterMs: number): number {
     const now = this.now()
     for (const [ptyId, evidence] of this.evidenceByPtyId) {
-      // Why: the 2h cap is unconditional — revalidation renews observedAt, so a
-      // TTL-only prune would keep a capped entry alive with no timer scheduled
-      // (nextExpiry treats the cap as expired) and block sleep forever.
+      // Why: revalidation renews observedAt, so only an unconditional cap can
+      // prevent evidence from surviving after its final timer.
       if (now - evidence.reportedAt >= staleAfterMs) {
         this.evidenceByPtyId.delete(ptyId)
         continue

--- a/src/main/agent-awake-foreground-evidence.ts
+++ b/src/main/agent-awake-foreground-evidence.ts
@@ -1,6 +1,7 @@
 // Why: scans are event-driven, so expiry revalidates cached foreground state
 // without adding process scans.
 export const AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS = 5 * 60 * 1000
+const FOREGROUND_AGENT_REPORT_REFRESH_QUANTUM_MS = 5_000
 
 type ForegroundAgentEvidence = {
   // Last time a real scan reported this PTY's recognized foreground agent.
@@ -26,6 +27,10 @@ export class ForegroundAgentEvidenceLedger {
       return this.evidenceByPtyId.delete(ptyId)
     }
     const now = this.now()
+    const existing = this.evidenceByPtyId.get(ptyId)
+    if (existing && now - existing.reportedAt < FOREGROUND_AGENT_REPORT_REFRESH_QUANTUM_MS) {
+      return false
+    }
     this.evidenceByPtyId.set(ptyId, { reportedAt: now, observedAt: now })
     return true
   }

--- a/src/main/agent-awake-foreground-evidence.ts
+++ b/src/main/agent-awake-foreground-evidence.ts
@@ -40,13 +40,21 @@ export class ForegroundAgentEvidenceLedger {
   pruneAndCount(staleAfterMs: number): number {
     const now = this.now()
     for (const [ptyId, evidence] of this.evidenceByPtyId) {
-      if (now - evidence.observedAt <= AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS) {
+      // Why: the 2h cap is unconditional — revalidation renews observedAt, so a
+      // TTL-only prune would keep a capped entry alive with no timer scheduled
+      // (nextExpiry treats the cap as expired) and block sleep forever.
+      if (now - evidence.reportedAt >= staleAfterMs) {
+        this.evidenceByPtyId.delete(ptyId)
         continue
       }
-      // Why: renew from the runtime's live cache (never a scan), hard-capped by
-      // the same 2h window hook statuses get so a stale cache cannot block
-      // sleep indefinitely. Anything else expires with the TTL.
-      if (now - evidence.reportedAt <= staleAfterMs && this.revalidate?.(ptyId) === true) {
+      // Why: strict `<` mirrors nextExpiry's `expiry <= now`, so a timer firing
+      // exactly at the TTL boundary always renews or deletes, never stalls.
+      if (now - evidence.observedAt < AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS) {
+        continue
+      }
+      // Why: renew from the runtime's live cache (never a scan); anything the
+      // cache no longer confirms expires with the TTL.
+      if (this.revalidate?.(ptyId) === true) {
         evidence.observedAt = now
       } else {
         this.evidenceByPtyId.delete(ptyId)

--- a/src/main/agent-awake-service.test.ts
+++ b/src/main/agent-awake-service.test.ts
@@ -309,6 +309,29 @@ describe('AgentAwakeService', () => {
     expect(blocker.start).toHaveBeenCalledTimes(1)
   })
 
+  it('does not reschedule expiry for repeated foreground evidence inside the refresh quantum', () => {
+    vi.useFakeTimers()
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    let now = 1_000
+    const blocker = createBlocker()
+    const service = createService(() => now, blocker)
+
+    service.setEnabled(true)
+    service.reportForegroundAgentEvidence('pty-1', 'claude')
+    const scheduledAfterFirstReport = setTimeoutSpy.mock.calls.length
+
+    now += 750
+    service.reportForegroundAgentEvidence('pty-1', 'claude')
+
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(scheduledAfterFirstReport)
+
+    now += 5_000
+    service.reportForegroundAgentEvidence('pty-1', 'claude')
+
+    expect(setTimeoutSpy).toHaveBeenCalledTimes(scheduledAfterFirstReport + 1)
+    service.dispose()
+  })
+
   it('revokes wake eligibility when foreground-agent evidence is cleared', () => {
     const blocker = createBlocker()
     const service = createService(() => 1_000, blocker)

--- a/src/main/agent-awake-service.test.ts
+++ b/src/main/agent-awake-service.test.ts
@@ -364,6 +364,43 @@ describe('AgentAwakeService', () => {
     service.dispose()
   })
 
+  it('drops foreground-agent evidence at the 2h cap even while revalidation keeps confirming', () => {
+    vi.useFakeTimers()
+    let now = 1_000
+    const blocker = createBlocker()
+    const service = createService(
+      () => now,
+      blocker,
+      createMacosAssertion(),
+      createLinuxAssertion(),
+      null,
+      () => true
+    )
+
+    service.setEnabled(true)
+    service.reportForegroundAgentEvidence('pty-1', 'claude')
+    now += AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS
+    vi.advanceTimersByTime(AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS)
+
+    expect(blocker.stop).not.toHaveBeenCalled()
+
+    // Why: revalidation renews observedAt every TTL, so only the reportedAt cap
+    // can end this evidence. The timer firing at the cap must both drop it and
+    // stop the blocker (regression: it survived the prune with no next timer).
+    while (now < 1_000 + AGENT_AWAKE_STATUS_STALE_AFTER_MS) {
+      const step = Math.min(
+        AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS,
+        1_000 + AGENT_AWAKE_STATUS_STALE_AFTER_MS - now
+      )
+      now += step
+      vi.advanceTimersByTime(step)
+    }
+
+    expect(blocker.stop).toHaveBeenCalledWith(1)
+    expect(vi.getTimerCount()).toBe(0)
+    service.dispose()
+  })
+
   it('unsubscribes the resume listener on dispose', () => {
     const blocker = createBlocker()
     const macosAssertion = createMacosAssertion()

--- a/src/main/agent-awake-service.test.ts
+++ b/src/main/agent-awake-service.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { AgentAwakeService, AGENT_AWAKE_STATUS_STALE_AFTER_MS } from './agent-awake-service'
+import {
+  AgentAwakeService,
+  AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS,
+  AGENT_AWAKE_STATUS_STALE_AFTER_MS
+} from './agent-awake-service'
 import type { AgentAwakeStatus } from './agent-awake-service'
 
 vi.mock('electron', () => ({
@@ -78,7 +82,8 @@ function createService(
   blocker = createBlocker(),
   macosAssertion = createMacosAssertion(),
   linuxAssertion = createLinuxAssertion(),
-  powerMonitor: ReturnType<typeof createPowerMonitor> | null = null
+  powerMonitor: ReturnType<typeof createPowerMonitor> | null = null,
+  revalidateForegroundAgent?: (ptyId: string) => boolean
 ): AgentAwakeService {
   return new AgentAwakeService({
     blocker,
@@ -86,6 +91,7 @@ function createService(
     macosAssertion,
     now,
     powerMonitor,
+    revalidateForegroundAgent,
     logger: {
       debug: vi.fn(),
       warn: vi.fn()
@@ -291,6 +297,71 @@ describe('AgentAwakeService', () => {
     expect(blocker.start).toHaveBeenCalledTimes(2)
     expect(macosAssertion.start).toHaveBeenCalledTimes(2)
     expect(linuxAssertion.start).toHaveBeenCalledTimes(2)
+  })
+
+  it('grants wake eligibility for reported recognized foreground-agent evidence', () => {
+    const blocker = createBlocker()
+    const service = createService(() => 1_000, blocker)
+
+    service.setEnabled(true)
+    service.reportForegroundAgentEvidence('pty-1', 'claude')
+
+    expect(blocker.start).toHaveBeenCalledTimes(1)
+  })
+
+  it('revokes wake eligibility when foreground-agent evidence is cleared', () => {
+    const blocker = createBlocker()
+    const service = createService(() => 1_000, blocker)
+
+    service.setEnabled(true)
+    service.reportForegroundAgentEvidence('pty-1', 'claude')
+    service.reportForegroundAgentEvidence('pty-1', null)
+
+    expect(blocker.stop).toHaveBeenCalledWith(1)
+  })
+
+  it('expires foreground-agent evidence at its TTL without a revalidator', () => {
+    vi.useFakeTimers()
+    let now = 1_000
+    const blocker = createBlocker()
+    const service = createService(() => now, blocker)
+
+    service.setEnabled(true)
+    service.reportForegroundAgentEvidence('pty-1', 'claude')
+    now = 1_000 + AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS + 1
+    vi.advanceTimersByTime(AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS)
+
+    expect(blocker.stop).toHaveBeenCalledWith(1)
+    service.dispose()
+  })
+
+  it('renews foreground-agent evidence at TTL expiry while revalidation confirms the agent', () => {
+    vi.useFakeTimers()
+    let now = 1_000
+    let stillForeground = true
+    const blocker = createBlocker()
+    const service = createService(
+      () => now,
+      blocker,
+      createMacosAssertion(),
+      createLinuxAssertion(),
+      null,
+      () => stillForeground
+    )
+
+    service.setEnabled(true)
+    service.reportForegroundAgentEvidence('pty-1', 'claude')
+    now = 1_000 + AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS + 1
+    vi.advanceTimersByTime(AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS)
+
+    expect(blocker.stop).not.toHaveBeenCalled()
+
+    stillForeground = false
+    now += AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS + 1
+    vi.advanceTimersByTime(AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS + 1_000)
+
+    expect(blocker.stop).toHaveBeenCalledWith(1)
+    service.dispose()
   })
 
   it('unsubscribes the resume listener on dispose', () => {

--- a/src/main/agent-awake-service.ts
+++ b/src/main/agent-awake-service.ts
@@ -105,9 +105,8 @@ export class AgentAwakeService {
     this.refresh('status-change')
   }
 
-  // Why: wrapper-launched/manual agents recognized by the foreground scan can
-  // run without hook statuses; their evidence holds wake eligibility too.
-  // Only recognized agents reach here — arbitrary processes never grant wake.
+  // Why: recognized wrapper/manual agents may lack hooks; arbitrary processes
+  // never reach this evidence path.
   reportForegroundAgentEvidence(ptyId: string, agent: string | null): void {
     if (this.foregroundAgentEvidence.report(ptyId, agent)) {
       this.refresh('foreground-agent-evidence')

--- a/src/main/agent-awake-service.ts
+++ b/src/main/agent-awake-service.ts
@@ -1,9 +1,11 @@
 import { powerMonitor, powerSaveBlocker } from 'electron'
 import type { AgentStatusState } from '../shared/agent-status-types'
+import { ForegroundAgentEvidenceLedger } from './agent-awake-foreground-evidence'
 import { LinuxLidSleepAssertion } from './linux-lid-sleep-assertion'
 import { MacosSystemSleepAssertion } from './macos-system-sleep-assertion'
 
 export const AGENT_AWAKE_STATUS_STALE_AFTER_MS = 2 * 60 * 60 * 1000
+export { AGENT_AWAKE_FOREGROUND_AGENT_TTL_MS } from './agent-awake-foreground-evidence'
 
 export type AgentAwakeStatus = {
   state: AgentStatusState
@@ -37,11 +39,16 @@ type AgentAwakeServiceOptions = {
   macosAssertion?: PlatformAwakeAssertion
   now?: () => number
   powerMonitor?: PowerMonitorEventSource | null
+  /** Cache-only check (no process scan) that the PTY is still connected with a
+   *  recognized foreground agent; used to renew evidence at TTL expiry. */
+  revalidateForegroundAgent?: (ptyId: string) => boolean
 }
 
 export class AgentAwakeService {
   private enabled = false
   private statuses: AgentAwakeStatus[] = []
+  private readonly foregroundAgentEvidence: ForegroundAgentEvidenceLedger
+  private eligibleForegroundAgentCount = 0
   private blockerId: number | null = null
   private staleTimer: ReturnType<typeof setTimeout> | null = null
   private readonly blocker: PowerSaveBlocker
@@ -55,6 +62,10 @@ export class AgentAwakeService {
     this.blocker = options.blocker ?? powerSaveBlocker
     this.logger = options.logger ?? console
     this.now = options.now ?? Date.now
+    this.foregroundAgentEvidence = new ForegroundAgentEvidenceLedger({
+      now: this.now,
+      revalidate: options.revalidateForegroundAgent
+    })
     // Windows lid close is intentionally not modeled as an assertion here:
     // keeping it awake requires mutating the user's global power plan.
     this.linuxAssertion =
@@ -94,6 +105,15 @@ export class AgentAwakeService {
     this.refresh('status-change')
   }
 
+  // Why: wrapper-launched/manual agents recognized by the foreground scan can
+  // run without hook statuses; their evidence holds wake eligibility too.
+  // Only recognized agents reach here — arbitrary processes never grant wake.
+  reportForegroundAgentEvidence(ptyId: string, agent: string | null): void {
+    if (this.foregroundAgentEvidence.report(ptyId, agent)) {
+      this.refresh('foreground-agent-evidence')
+    }
+  }
+
   dispose(): void {
     this.clearStaleTimer()
     this.unsubscribeResume?.()
@@ -103,8 +123,12 @@ export class AgentAwakeService {
   }
 
   private refresh(reason: string): void {
+    this.eligibleForegroundAgentCount = this.foregroundAgentEvidence.pruneAndCount(
+      AGENT_AWAKE_STATUS_STALE_AFTER_MS
+    )
     this.scheduleStaleTimer()
-    const runningStatusCount = this.getEligibleRunningStatusCount()
+    const runningStatusCount =
+      this.getEligibleRunningStatusCount() + this.eligibleForegroundAgentCount
     const shouldBlock = this.enabled && runningStatusCount > 0
     if (shouldBlock) {
       this.startBlocker(reason, runningStatusCount)
@@ -148,6 +172,13 @@ export class AgentAwakeService {
         continue
       }
       earliestExpiry = earliestExpiry === null ? expiry : Math.min(earliestExpiry, expiry)
+    }
+    const evidenceExpiry = this.foregroundAgentEvidence.nextExpiry(
+      AGENT_AWAKE_STATUS_STALE_AFTER_MS
+    )
+    if (evidenceExpiry !== null) {
+      earliestExpiry =
+        earliestExpiry === null ? evidenceExpiry : Math.min(earliestExpiry, evidenceExpiry)
     }
     if (earliestExpiry === null) {
       return

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2108,7 +2108,11 @@ void app.whenReady().then(async () => {
     profileDirectory: activeOrcaProfile.profileDirectory
   })
   unsubscribeSystemResumeBroadcast = registerSystemResumeBroadcast()
-  agentAwakeService = new AgentAwakeService()
+  // Why: revalidation reads the runtime's cached foreground state (no process
+  // scan); `runtime` is assigned later in this init, hence the late-bound read.
+  agentAwakeService = new AgentAwakeService({
+    revalidateForegroundAgent: (ptyId) => runtime?.hasWakeEligibleForegroundAgent(ptyId) === true
+  })
   agentAwakeService.setEnabled(store.getSettings().keepComputerAwakeWhileAgentsRun)
   // Why: start from empty — disk-hydrated status rows are UI continuity only; only this runtime's hook events keep the computer awake.
   agentAwakeService.setStatuses([])
@@ -2349,7 +2353,14 @@ void app.whenReady().then(async () => {
     getLocalProvider: () => getLocalPtyProvider(),
     // Why: SSH relay providers register after construction and may reconnect, so destructive cleanup must resolve the current generation.
     getSshProvider: (connectionId) => getSshPtyProvider(connectionId),
-    onPtyStopped: clearProviderPtyState,
+    onPtyStopped: (ptyId) => {
+      clearProviderPtyState(ptyId)
+      // Why: a dead PTY's foreground-agent evidence must stop holding wake now,
+      // not at TTL expiry.
+      agentAwakeService?.reportForegroundAgentEvidence(ptyId, null)
+    },
+    onPtyForegroundAgentEvidence: (ptyId, agent) =>
+      agentAwakeService?.reportForegroundAgentEvidence(ptyId, agent),
     onTerminalAgentStatus: (event) => {
       agentHookServer.ingestTerminalStatus(event)
     },

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -7525,6 +7525,82 @@ describe('registerPtyHandlers', () => {
     })
   })
 
+  it('reuses renderer foreground inspections as runtime wake evidence', async () => {
+    const getForegroundProcess = vi.fn(async () => 'claude')
+    const confirmForegroundProcess = vi.fn(async () => 'claude')
+    setLocalPtyProvider({
+      getForegroundProcess,
+      confirmForegroundProcess,
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => [])
+    } as never)
+    const runtime = {
+      setPtyController: vi.fn(),
+      recordPtyForegroundProcessObservation: vi.fn()
+    }
+    registerPtyHandlers(mainWindow as never, runtime as never)
+    restorePtyIncarnation('pty-known-launch', 'incarnation-known-launch')
+
+    try {
+      await expect(
+        handlers.get('pty:getForegroundProcess')!(null, { id: 'pty-known-launch' })
+      ).resolves.toBe('claude')
+      await expect(
+        handlers.get('pty:confirmForegroundProcess')!(null, { id: 'pty-known-launch' })
+      ).resolves.toBe('claude')
+
+      expect(runtime.recordPtyForegroundProcessObservation).toHaveBeenNthCalledWith(
+        1,
+        'pty-known-launch',
+        'claude'
+      )
+      expect(runtime.recordPtyForegroundProcessObservation).toHaveBeenNthCalledWith(
+        2,
+        'pty-known-launch',
+        'claude'
+      )
+    } finally {
+      clearProviderPtyState('pty-known-launch')
+    }
+  })
+
+  it('does not record foreground evidence after a PTY id is reused during inspection', async () => {
+    let resolveForegroundProcess: ((value: string | null) => void) | undefined
+    const foregroundProcess = new Promise<string | null>((resolve) => {
+      resolveForegroundProcess = resolve
+    })
+    setLocalPtyProvider({
+      getForegroundProcess: vi.fn(() => foregroundProcess),
+      confirmForegroundProcess: vi.fn(() => foregroundProcess),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => [])
+    } as never)
+    const runtime = {
+      setPtyController: vi.fn(),
+      recordPtyForegroundProcessObservation: vi.fn()
+    }
+    registerPtyHandlers(mainWindow as never, runtime as never)
+    const ptyId = 'pty-reused-during-inspection'
+    restorePtyIncarnation(ptyId, 'incarnation-before-inspection')
+
+    try {
+      const foreground = handlers.get('pty:getForegroundProcess')!(null, { id: ptyId })
+      const confirmation = handlers.get('pty:confirmForegroundProcess')!(null, { id: ptyId })
+      restorePtyIncarnation(ptyId, 'incarnation-after-inspection')
+      resolveForegroundProcess?.('claude')
+
+      await expect(foreground).resolves.toBe('claude')
+      await expect(confirmation).resolves.toBe('claude')
+      expect(runtime.recordPtyForegroundProcessObservation).not.toHaveBeenCalled()
+    } finally {
+      clearProviderPtyState(ptyId)
+    }
+  })
+
   // Why: daemon resize is fire-and-forget, so pty:getSize must report the APPLIED size, not the requested one (Claude-Code split-pane desync).
   describe('pty:getSize reports applied size, not requested size', () => {
     function setupProviderWithAppliedSize(args: {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -7561,6 +7561,7 @@ describe('registerPtyHandlers', () => {
         'pty-known-launch',
         'claude'
       )
+      expect(runtime.recordPtyForegroundProcessObservation).toHaveBeenCalledTimes(2)
     } finally {
       clearProviderPtyState('pty-known-launch')
     }

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -7194,7 +7194,17 @@ export function registerPtyHandlers(
       if (!hasPtyProviderForInspection(args.id)) {
         return null
       }
-      return getProviderForPty(args.id).getForegroundProcess(args.id)
+      const inspectedIncarnationId = ptyIncarnationById.get(args.id)
+      const foregroundProcess = await getProviderForPty(args.id).getForegroundProcess(args.id)
+      // Why: launched-agent runtime probes are skipped; reuse this scan for wake
+      // evidence instead of adding another provider query.
+      if (
+        inspectedIncarnationId !== undefined &&
+        ptyIncarnationById.get(args.id) === inspectedIncarnationId
+      ) {
+        runtime?.recordPtyForegroundProcessObservation(args.id, foregroundProcess)
+      }
+      return foregroundProcess
     }
   )
 
@@ -7210,7 +7220,18 @@ export function registerPtyHandlers(
       }
       const provider = getProviderForPty(args.id)
       // Why: the cached foreground API would turn stale process identity into shell/agent authority at a command boundary.
-      return provider.confirmForegroundProcess?.(args.id) ?? null
+      if (!provider.confirmForegroundProcess) {
+        return null
+      }
+      const inspectedIncarnationId = ptyIncarnationById.get(args.id)
+      const foregroundProcess = await provider.confirmForegroundProcess(args.id)
+      if (
+        inspectedIncarnationId !== undefined &&
+        ptyIncarnationById.get(args.id) === inspectedIncarnationId
+      ) {
+        runtime?.recordPtyForegroundProcessObservation(args.id, foregroundProcess)
+      }
+      return foregroundProcess
     }
   )
 

--- a/src/main/providers/agent-foreground-process.test.ts
+++ b/src/main/providers/agent-foreground-process.test.ts
@@ -9,11 +9,31 @@ vi.mock('child_process', () => ({
 }))
 
 import { resetProcessTableSnapshotForTests } from '../../shared/process-table-snapshot'
+import { resetProcessExecutablePathCacheForTests } from '../../shared/process-executable-recognition'
 import {
   resolveAgentForegroundProcess,
   resolveAgentForegroundProcessWithAvailability
 } from './agent-foreground-process'
 import { resetWindowsProcessRowsSnapshotForTests } from './windows-foreground-process-rows'
+
+// Why: the exe-evidence pass forks `lsof` on macOS for unrecognized non-shell
+// foreground candidates. Route `ps` and `lsof` through the one execFile mock.
+function mockPsAndLsof(psStdout: string, lsofByPid: Record<number, string> = {}): void {
+  execFileMock.mockImplementation((cmd: string, args: string[], _opts: unknown, cb: unknown) => {
+    const callback = cb as (err: unknown, result: { stdout: string; stderr: string }) => void
+    if (cmd === 'lsof') {
+      const pid = Number(args[args.indexOf('-p') + 1])
+      const image = lsofByPid[pid]
+      callback(null, { stdout: image ? `p${pid}\nn${image}` : '', stderr: '' })
+      return
+    }
+    callback(null, { stdout: psStdout, stderr: '' })
+  })
+}
+
+function lsofCallCount(): number {
+  return execFileMock.mock.calls.filter((call) => call[0] === 'lsof').length
+}
 
 // Why: the module wraps execFile with promisify, so the mock must honor the
 // Node callback contract — invoke the last arg with (err, { stdout, stderr }).
@@ -77,6 +97,7 @@ describe('resolveAgentForegroundProcess', () => {
   beforeEach(() => {
     execFileMock.mockReset()
     resetProcessTableSnapshotForTests()
+    resetProcessExecutablePathCacheForTests()
     // Why: the Windows rows reader caches across calls (500ms TTL), so each
     // case's execFile mock must not be answered by the previous case's rows.
     resetWindowsProcessRowsSnapshotForTests()
@@ -259,6 +280,44 @@ describe('resolveAgentForegroundProcess', () => {
     await expect(resolveAgentForegroundProcess(100, 'node')).resolves.toBe('codex')
   })
 
+  it('recognizes a renamed/forked agent binary via its executable image', async () => {
+    // argv0-renamed real binary: the command line hides the agent, but the
+    // executable image at ~/.local/bin/grok recognizes it.
+    mockPsAndLsof(['100 99 Ss   bash -i', '101 100 S+   my-cli --serve'].join('\n'), {
+      101: '/Users/dev/.local/bin/grok'
+    })
+
+    await expect(resolveAgentForegroundProcess(100, 'bash')).resolves.toBe('grok')
+    expect(lsofCallCount()).toBe(1)
+  })
+
+  it('does not run executable-image lookup when a candidate is recognized', async () => {
+    mockPsAndLsof(['100 99 Ss   bash -i', '101 100 S+   grok --serve'].join('\n'))
+
+    await expect(resolveAgentForegroundProcess(100, 'bash')).resolves.toBe('grok')
+    // Lazy: recognition succeeded on the command line, so no lsof fork.
+    expect(lsofCallCount()).toBe(0)
+  })
+
+  it('does not fabricate an agent when the executable image is an interpreter', async () => {
+    mockPsAndLsof(['100 99 Ss   bash -i', '101 100 S+   my-worker'].join('\n'), {
+      101: '/usr/local/bin/node'
+    })
+
+    await expect(resolveAgentForegroundProcess(100, 'bash')).resolves.toBe('bash')
+  })
+
+  it('does not probe suspended (non-foreground) candidates for executable evidence', async () => {
+    // '+' marks the shell as foreground; the stopped 'my-cli' child is not
+    // probed, so no lsof fork and no false agent identity.
+    mockPsAndLsof(['100 99 Ss+  bash -i', '101 100 T    my-cli --serve'].join('\n'), {
+      101: '/Users/dev/.local/bin/grok'
+    })
+
+    await expect(resolveAgentForegroundProcess(100, 'bash')).resolves.toBe('bash')
+    expect(lsofCallCount()).toBe(0)
+  })
+
   it('recognizes Windows wrapper-launched agents from descendant command lines', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
     execFileMock.mockImplementation(
@@ -336,6 +395,37 @@ describe('resolveAgentForegroundProcess', () => {
     )
 
     await expect(resolveAgentForegroundProcess(100, 'powershell.exe')).resolves.toBe('cursor-agent')
+  })
+
+  it('recognizes a renamed Windows agent binary from its ExecutablePath', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
+        const callback = cb as (err: unknown, result: { stdout: string; stderr: string }) => void
+        callback(null, {
+          stdout: windowsProcessJsonRows([
+            {
+              CommandLine: 'powershell.exe',
+              Name: 'powershell.exe',
+              ParentProcessId: 99,
+              ProcessId: 100
+            },
+            {
+              // argv0-renamed: neither command line nor node-pty name recognizes,
+              // but the CIM scan's ExecutablePath does.
+              CommandLine: 'my-cli --serve',
+              Name: 'my-cli.exe',
+              ParentProcessId: 100,
+              ProcessId: 101,
+              ExecutablePath: 'C:\\Users\\dev\\.local\\bin\\grok.exe'
+            }
+          ]),
+          stderr: ''
+        })
+      }
+    )
+
+    await expect(resolveAgentForegroundProcess(100, 'powershell.exe')).resolves.toBe('grok')
   })
 
   it('recognizes Windows Git Bash shell-rooted agent launches', async () => {

--- a/src/main/providers/agent-foreground-process.test.ts
+++ b/src/main/providers/agent-foreground-process.test.ts
@@ -428,6 +428,39 @@ describe('resolveAgentForegroundProcess', () => {
     await expect(resolveAgentForegroundProcess(100, 'powershell.exe')).resolves.toBe('grok')
   })
 
+  it('does not mislabel a generic orca ExecutablePath without the claude-teams subcommand', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
+        const callback = cb as (err: unknown, result: { stdout: string; stderr: string }) => void
+        callback(null, {
+          stdout: windowsProcessJsonRows([
+            {
+              CommandLine: 'powershell.exe',
+              Name: 'powershell.exe',
+              ParentProcessId: 99,
+              ProcessId: 100
+            },
+            {
+              // Bare `orca render` is not the agent TUI; command-aware recognition
+              // on the ExecutablePath preserves that guard (not basename-only).
+              CommandLine: 'orca render',
+              Name: 'orca.exe',
+              ParentProcessId: 100,
+              ProcessId: 101,
+              ExecutablePath: 'C:\\Program Files\\Orca\\orca.exe'
+            }
+          ]),
+          stderr: ''
+        })
+      }
+    )
+
+    await expect(resolveAgentForegroundProcess(100, 'powershell.exe')).resolves.toBe(
+      'powershell.exe'
+    )
+  })
+
   it('recognizes Windows Git Bash shell-rooted agent launches', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' })
     execFileMock.mockImplementation(

--- a/src/main/providers/agent-foreground-process.ts
+++ b/src/main/providers/agent-foreground-process.ts
@@ -1,10 +1,13 @@
 import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process-recognition'
+import { getFirstCommandToken } from '../../shared/command-token-scanner'
 import { resolveOuterWrapperForegroundProcess } from '../../shared/foreground-wrapper-agent'
+import { recognizeAgentFromExecutablePath } from '../../shared/process-executable-recognition'
 import {
   getFreshProcessTableSnapshot,
   getProcessTableSnapshot,
   type ProcessTableRow
 } from '../../shared/process-table-snapshot'
+import { isShellProcess } from '../../shared/shell-process-detection'
 import {
   resolveWindowsAgentForegroundProcessWithAvailability,
   shouldInspectWindowsAgentForeground,
@@ -99,7 +102,7 @@ export async function resolveAgentForegroundProcessWithAvailability(
     }
     return {
       available: true,
-      processName: resolveAgentForegroundProcessFromPs(rows, shellPid) ?? fallbackProcess
+      processName: (await resolveAgentForegroundProcessFromPs(rows, shellPid)) ?? fallbackProcess
     }
   } catch {
     // Why: a failed scan cannot prove fallback ownership; callers retain the last recognized agent.
@@ -107,10 +110,10 @@ export async function resolveAgentForegroundProcessWithAvailability(
   }
 }
 
-function resolveAgentForegroundProcessFromPs(
+async function resolveAgentForegroundProcessFromPs(
   rows: ProcessTableRow[],
   shellPid: number
-): string | null {
+): Promise<string | null> {
   const shellRow = rows.find((row) => row.pid === shellPid)
   const candidates = collectDescendants(rows, shellPid).sort(
     (a, b) => candidateScore(b) - candidateScore(a)
@@ -121,6 +124,7 @@ function resolveAgentForegroundProcessFromPs(
   const foregroundIsKnown =
     shellRow?.stat.includes('+') === true ||
     candidates.some((candidate) => candidate.stat.includes('+'))
+  const inspected: (ProcessTableRow & { depth: number })[] = []
   for (const candidate of candidates) {
     if (foregroundIsKnown && !candidate.stat.includes('+')) {
       continue
@@ -130,6 +134,28 @@ function resolveAgentForegroundProcessFromPs(
       // Why: return the outer wrapper (omp) rather than the deeper wrapped child
       // (pi) of a shell→omp→pi tree — see resolveOuterWrapperForegroundProcess.
       return resolveOuterWrapperForegroundProcess(recognized, candidate, candidates)
+    }
+    inspected.push(candidate)
+  }
+  return resolveForegroundAgentFromExecutableEvidence(inspected)
+}
+
+// Why: a renamed/forked agent binary (argv0 rename, native fork at a
+// non-standard path) shows an unrecognized command line, so the loop above
+// misses it. Lazily resolve the real executable image ONLY for the still-
+// unrecognized non-shell foreground candidates and re-run recognition on its
+// basename. Cost-guarded: `ps`-scan volume is untouched (no extra `ps`), the
+// lookup is per-PID cached, and only true foreground ('+') candidates probe.
+async function resolveForegroundAgentFromExecutableEvidence(
+  inspected: (ProcessTableRow & { depth: number })[]
+): Promise<string | null> {
+  for (const candidate of inspected) {
+    if (!candidate.stat.includes('+') || isShellProcess(getFirstCommandToken(candidate.command))) {
+      continue
+    }
+    const recognized = await recognizeAgentFromExecutablePath(candidate.pid)
+    if (recognized) {
+      return recognized.processName
     }
   }
   return null

--- a/src/main/providers/agent-foreground-process.ts
+++ b/src/main/providers/agent-foreground-process.ts
@@ -153,7 +153,7 @@ async function resolveForegroundAgentFromExecutableEvidence(
     if (!candidate.stat.includes('+') || isShellProcess(getFirstCommandToken(candidate.command))) {
       continue
     }
-    const recognized = await recognizeAgentFromExecutablePath(candidate.pid)
+    const recognized = await recognizeAgentFromExecutablePath(candidate.pid, candidate.command)
     if (recognized) {
       return recognized.processName
     }

--- a/src/main/providers/ssh-pty-provider.test.ts
+++ b/src/main/providers/ssh-pty-provider.test.ts
@@ -891,6 +891,44 @@ describe('SshPtyProvider', () => {
     expectRequest(mux.request, 'pty.inspectProcess', { id: 'pty-1' })
   })
 
+  it('confirmForegroundProcess requests a fresh relay read', async () => {
+    mux.request.mockResolvedValue('grok')
+    const result = await provider.confirmForegroundProcess(scopedPty1)
+    expect(result).toBe('grok')
+    expect(mux.request).toHaveBeenCalledWith('pty.confirmForegroundProcess', { id: 'pty-1' })
+  })
+
+  it('confirmForegroundProcess degrades to getForegroundProcess on an old relay', async () => {
+    const methodNotFound = Object.assign(
+      new Error('Method not found: pty.confirmForegroundProcess'),
+      {
+        code: -32601
+      }
+    )
+    mux.request.mockImplementation(async (method: string) => {
+      if (method === 'pty.confirmForegroundProcess') {
+        throw methodNotFound
+      }
+      return 'zsh'
+    })
+
+    await expect(provider.confirmForegroundProcess(scopedPty1)).resolves.toBe('zsh')
+    expect(mux.request).toHaveBeenCalledWith('pty.getForegroundProcess', { id: 'pty-1' })
+
+    // Latched: a second confirm skips the failing round-trip entirely.
+    mux.request.mockClear()
+    await expect(provider.confirmForegroundProcess(scopedPty1)).resolves.toBe('zsh')
+    expect(mux.request).not.toHaveBeenCalledWith('pty.confirmForegroundProcess', { id: 'pty-1' })
+    expect(mux.request).toHaveBeenCalledWith('pty.getForegroundProcess', { id: 'pty-1' })
+  })
+
+  it('confirmForegroundProcess rethrows non-method-not-found relay errors', async () => {
+    mux.request.mockRejectedValue(new Error('SSH_SESSION_EXPIRED'))
+    await expect(provider.confirmForegroundProcess(scopedPty1)).rejects.toThrow(
+      'SSH_SESSION_EXPIRED'
+    )
+  })
+
   it('serializes scoped app ids using raw relay ids', async () => {
     mux.request.mockResolvedValue('serialized')
 

--- a/src/main/providers/ssh-pty-provider.ts
+++ b/src/main/providers/ssh-pty-provider.ts
@@ -29,6 +29,15 @@ function relayTimeoutOptions(deadlineMs: number | undefined): { timeoutMs: numbe
   return deadlineMs === undefined ? undefined : { timeoutMs: Math.max(1, deadlineMs - Date.now()) }
 }
 
+// Why: the relay dispatcher rejects unknown methods with JSON-RPC code -32601;
+// the mux preserves the code and prefixes "Method not found". Detect either so
+// an old relay's missing method degrades gracefully instead of throwing.
+function isMethodNotFoundError(err: unknown): boolean {
+  const code = (err as { code?: number } | null)?.code
+  const message = err instanceof Error ? err.message : String(err)
+  return code === -32601 || /method not found/i.test(message)
+}
+
 /** Remote PTY provider that proxies IPtyProvider operations through the relay. */
 export class SshPtyProvider implements IPtyProvider {
   private mux: SshChannelMultiplexer
@@ -38,6 +47,9 @@ export class SshPtyProvider implements IPtyProvider {
   private readonly agentSessionCapabilities: SshAgentSessionCapabilities
   private spawnExitRaces = new SshPtySpawnExitRaceTracker()
   private readonly outputState: SshPtyProviderOutputState
+  // Why: latch once an old relay 404s pty.confirmForegroundProcess so later
+  // confirmations skip the failing round-trip and read foreground directly.
+  private confirmForegroundUnsupported = false
 
   constructor(
     connectionId: string,
@@ -271,6 +283,27 @@ export class SshPtyProvider implements IPtyProvider {
     return (await this.mux.request('pty.inspectProcess', {
       id: this.toRelayPtyId(id)
     })) as PtyProcessInspection
+  }
+
+  async confirmForegroundProcess(id: string): Promise<string | null> {
+    // Why: an older deployed relay does not implement this method. Feature-detect
+    // once and degrade to today's trusting getForegroundProcess read rather than
+    // erroring — the relay is a separately-versioned deployed binary.
+    if (this.confirmForegroundUnsupported) {
+      return this.getForegroundProcess(id)
+    }
+    try {
+      const result = await this.mux.request('pty.confirmForegroundProcess', {
+        id: this.toRelayPtyId(id)
+      })
+      return result as string | null
+    } catch (err) {
+      if (isMethodNotFoundError(err)) {
+        this.confirmForegroundUnsupported = true
+        return this.getForegroundProcess(id)
+      }
+      throw err
+    }
   }
 
   async serialize(ids: string[]): Promise<string> {

--- a/src/main/providers/windows-agent-foreground-process.ts
+++ b/src/main/providers/windows-agent-foreground-process.ts
@@ -9,6 +9,7 @@ import {
   resolveOuterWrapperForegroundProcess,
   shouldInspectOuterWrapperForegroundProcess
 } from '../../shared/foreground-wrapper-agent'
+import { recognizeAgentFromExecutableImage } from '../../shared/process-executable-recognition'
 import { isShellProcess } from '../../shared/shell-process-detection'
 import {
   queryWindowsProcessDescendants,
@@ -287,11 +288,15 @@ function recognizeWindowsCandidateAgent(
 ): RecognizedAgentProcess | null {
   // Why: a renamed/forked agent binary hides from its command line and node-pty
   // name, but the CIM scan already carries its real image path — recognize the
-  // executable basename with no extra probe (the ExecutablePath is free here).
+  // executable image with no extra probe (the ExecutablePath is free here).
+  // Pass the command so the image is recognized WITH its args, preserving the
+  // headless-one-shot and generic-`orca` guards instead of basename-only.
   return (
     recognizeAgentProcessFromCommandLine(candidate.command) ??
     recognizeAgentProcessFromCommandLine(candidate.name) ??
-    (candidate.executablePath ? recognizeAgentProcess(candidate.executablePath) : null)
+    (candidate.executablePath
+      ? recognizeAgentFromExecutableImage(candidate.executablePath, candidate.command)
+      : null)
   )
 }
 

--- a/src/main/providers/windows-agent-foreground-process.ts
+++ b/src/main/providers/windows-agent-foreground-process.ts
@@ -98,11 +98,7 @@ function windowsCandidatesContainRecognizedAgent(
   }
   return candidates
     .filter((candidate) => windowsCandidateMatchesFallbackWrapper(candidate, fallbackProcess))
-    .some(
-      (candidate) =>
-        recognizeAgentProcessFromCommandLine(candidate.command) !== null ||
-        recognizeAgentProcessFromCommandLine(candidate.name) !== null
-    )
+    .some((candidate) => recognizeWindowsCandidateAgent(candidate) !== null)
 }
 
 function resolveWindowsProcessName(
@@ -124,9 +120,7 @@ function resolveWindowsProcessName(
     )
   }
   const [candidate] = wrapperCandidates
-  const recognized =
-    recognizeAgentProcessFromCommandLine(candidate.command) ??
-    recognizeAgentProcessFromCommandLine(candidate.name)
+  const recognized = recognizeWindowsCandidateAgent(candidate)
   if (recognized) {
     return resolveOuterWrapperForegroundProcess(recognized, candidate, candidates)
   }
@@ -285,9 +279,19 @@ function commandLineContainsPath(haystack: string, contextPath: string): boolean
 function recognizeWindowsProcessCandidate(
   candidate: WindowsProcessRow
 ): RecognizedAgentProcess | null {
+  return recognizeWindowsCandidateAgent(candidate)
+}
+
+function recognizeWindowsCandidateAgent(
+  candidate: WindowsProcessRow
+): RecognizedAgentProcess | null {
+  // Why: a renamed/forked agent binary hides from its command line and node-pty
+  // name, but the CIM scan already carries its real image path — recognize the
+  // executable basename with no extra probe (the ExecutablePath is free here).
   return (
     recognizeAgentProcessFromCommandLine(candidate.command) ??
-    recognizeAgentProcessFromCommandLine(candidate.name)
+    recognizeAgentProcessFromCommandLine(candidate.name) ??
+    (candidate.executablePath ? recognizeAgentProcess(candidate.executablePath) : null)
   )
 }
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -23339,6 +23339,26 @@ describe('OrcaRuntimeService', () => {
     expect(getForegroundProcess).not.toHaveBeenCalled()
   })
 
+  it('accepts foreground evidence from an existing renderer scan for a known launch agent', async () => {
+    const onPtyForegroundAgentEvidence = vi.fn()
+    const runtime = new OrcaRuntimeService(store, undefined, { onPtyForegroundAgentEvidence })
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-claude' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: vi.fn()
+    })
+    await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'claude',
+      launchAgent: 'claude',
+      title: 'Claude'
+    })
+
+    expect(runtime.recordPtyForegroundProcessObservation('pty-claude', 'claude')).toBe(true)
+    expect(onPtyForegroundAgentEvidence).toHaveBeenCalledWith('pty-claude', 'claude')
+    expect(runtime.hasWakeEligibleForegroundAgent('pty-claude')).toBe(true)
+  })
+
   it('probes the foreground process only on a status transition for unknown launch agents', async () => {
     const getForegroundProcess = vi.fn(async () => 'omp')
     const runtime = createRuntime()

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -11667,7 +11667,6 @@ describe('OrcaRuntimeService', () => {
 
   it.each([
     ['shell', async () => 'pwsh.exe'],
-    ['non-agent', async () => 'vim'],
     ['unavailable', async () => null],
     [
       'failure',
@@ -11686,6 +11685,23 @@ describe('OrcaRuntimeService', () => {
       handle,
       isRunningAgent: false,
       status: null
+    })
+    expect(confirmForegroundProcess).toHaveBeenCalledOnce()
+  })
+
+  // Why: a wrapper/fork agent binary is unrecognized but is NOT a shell; the
+  // hook-status gate must treat that confirmed foreground as busy, not idle.
+  it('keeps hook state running when confirmation reports an unrecognized non-shell foreground', async () => {
+    const confirmForegroundProcess = vi.fn(async () => 'my-agent-fork')
+    const { runtime, handle } = await createExplicitAgentStatusHarness({
+      getForegroundProcess: async () => 'zsh',
+      confirmForegroundProcess
+    })
+
+    await expect(runtime.getTerminalAgentStatus(handle)).resolves.toEqual({
+      handle,
+      isRunningAgent: true,
+      status: 'working'
     })
     expect(confirmForegroundProcess).toHaveBeenCalledOnce()
   })

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -23368,6 +23368,42 @@ describe('OrcaRuntimeService', () => {
     expect(getForegroundProcess).toHaveBeenCalledTimes(2)
   })
 
+  it('reports recognized foreground-agent evidence from the existing status-transition probe', async () => {
+    const onPtyForegroundAgentEvidence = vi.fn()
+    const runtime = new OrcaRuntimeService(store, undefined, { onPtyForegroundAgentEvidence })
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'claude'
+    })
+    syncSinglePty(runtime, 'pty-wake')
+
+    runtime.onPtyData('pty-wake', '\x1b]0;⠋ compiling\x07alpha\n', 100)
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(onPtyForegroundAgentEvidence).toHaveBeenCalledWith('pty-wake', 'claude')
+    expect(runtime.hasWakeEligibleForegroundAgent('pty-wake')).toBe(true)
+  })
+
+  // Why: keep-awake evidence is recognized-agent-only — an arbitrary non-shell
+  // process (vim, tail -f) must never hold the machine awake.
+  it('reports null foreground-agent evidence for an unrecognized foreground process', async () => {
+    const onPtyForegroundAgentEvidence = vi.fn()
+    const runtime = new OrcaRuntimeService(store, undefined, { onPtyForegroundAgentEvidence })
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'vim'
+    })
+    syncSinglePty(runtime, 'pty-wake')
+
+    runtime.onPtyData('pty-wake', '\x1b]0;⠋ compiling\x07alpha\n', 100)
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(onPtyForegroundAgentEvidence).toHaveBeenCalledWith('pty-wake', null)
+    expect(runtime.hasWakeEligibleForegroundAgent('pty-wake')).toBe(false)
+  })
+
   it('normalizes Pi-compatible mobile session status to OMP for an unknown-launch foreground omp PTY', async () => {
     const spawn = vi.fn().mockResolvedValue({ id: 'pty-typed-omp' })
     const getForegroundProcess = vi.fn(async () => 'omp')

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -16648,10 +16648,8 @@ export class OrcaRuntimeService {
       return true
     }
     this.assertTerminalAgentStatusPtyBinding(handle, ptyId)
-    // Why: only a confirmed real shell proves the agent left. An unrecognized
-    // NON-shell foreground (wrapper/fork agent binary) must keep fresh hook
-    // state alive instead of counting as idle; an unavailable confirmation
-    // stays fail-closed like the catch path above.
+    // Why: only a confirmed shell proves exit; unknown non-shell processes may
+    // be wrapper/fork agents, while unavailable confirmation stays fail-closed.
     return confirmedProcess === null || isShellProcess(confirmedProcess)
   }
 
@@ -16865,16 +16863,24 @@ export class OrcaRuntimeService {
     if (!foregroundRead) {
       return false
     }
-    const result = await foregroundRead
+const result = await foregroundRead
     if (result.controller !== this.ptyController || !result.available) {
       return false
     }
     const foregroundProcess = result.process
+    return this.recordPtyForegroundProcessObservation(ptyId, foregroundProcess)
+  }
+
+  /** Reuses a completed provider inspection for runtime identity and wake evidence. */
+  recordPtyForegroundProcessObservation(ptyId: string, foregroundProcess: string | null): boolean {
+    const pty = this.ptysById.get(ptyId)
+    if (!pty?.connected) {
+      return false
+    }
     const foregroundAgent = foregroundProcess
       ? (recognizeAgentProcess(foregroundProcess)?.agent ?? null)
       : null
-    // Why: report before the unchanged early-return so every completed scan
-    // renews the keep-awake TTL for a still-running recognized agent.
+    // Why: every completed scan renews wake evidence, even when cached identity is unchanged.
     this.onPtyForegroundAgentEvidence?.(ptyId, foregroundAgent)
     if (pty.foregroundAgent === foregroundAgent) {
       return false

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3259,6 +3259,9 @@ export class OrcaRuntimeService {
   private readonly getLocalProviderFn: (() => IPtyProvider) | null
   private readonly getSshProviderFn: ((connectionId: string) => IPtyProvider | undefined) | null
   private readonly onPtyStopped: ((ptyId: string) => void) | null
+  private readonly onPtyForegroundAgentEvidence:
+    | ((ptyId: string, agent: TuiAgent | null) => void)
+    | null
   private readonly onTerminalAgentStatus: ((event: RuntimeTerminalAgentStatusEvent) => void) | null
   private readonly onTerminalSideEffects: ((batch: TerminalSideEffectBatch) => void) | null
   private terminalSideEffectLocalConsumerAvailable = false
@@ -3331,6 +3334,9 @@ export class OrcaRuntimeService {
       getLocalProvider?: () => IPtyProvider
       getSshProvider?: (connectionId: string) => IPtyProvider | undefined
       onPtyStopped?: (ptyId: string) => void
+      // Why: keep-awake needs recognized-foreground-agent evidence (wrapper
+      // claude etc.) from the existing scans; fired per completed scan result.
+      onPtyForegroundAgentEvidence?: (ptyId: string, agent: TuiAgent | null) => void
       onTerminalAgentStatus?: (event: RuntimeTerminalAgentStatusEvent) => void
       onTerminalSideEffects?: (batch: TerminalSideEffectBatch) => void
       // Why: agent status mostly arrives via hooks (agent-hooks/server), not OSC
@@ -3405,6 +3411,7 @@ export class OrcaRuntimeService {
     this.getLocalProviderFn = deps?.getLocalProvider ?? null
     this.getSshProviderFn = deps?.getSshProvider ?? null
     this.onPtyStopped = deps?.onPtyStopped ?? null
+    this.onPtyForegroundAgentEvidence = deps?.onPtyForegroundAgentEvidence ?? null
     this.onTerminalAgentStatus = deps?.onTerminalAgentStatus ?? null
     this.buildAgentHookPtyEnv = deps?.buildAgentHookPtyEnv ?? null
     this.getDesktopWindowStatusFn = deps?.getDesktopWindowStatus ?? (() => 'openable')
@@ -16866,12 +16873,22 @@ export class OrcaRuntimeService {
     const foregroundAgent = foregroundProcess
       ? (recognizeAgentProcess(foregroundProcess)?.agent ?? null)
       : null
+    // Why: report before the unchanged early-return so every completed scan
+    // renews the keep-awake TTL for a still-running recognized agent.
+    this.onPtyForegroundAgentEvidence?.(ptyId, foregroundAgent)
     if (pty.foregroundAgent === foregroundAgent) {
       return false
     }
     pty.foregroundAgent = foregroundAgent
     this.touchMobileSessionSnapshotsForPty(ptyId)
     return true
+  }
+
+  /** Cache-only keep-awake revalidation: is this PTY still connected with a
+   *  recognized foreground agent? Never triggers a process scan. */
+  hasWakeEligibleForegroundAgent(ptyId: string): boolean {
+    const pty = this.ptysById.get(ptyId)
+    return pty?.connected === true && pty.foregroundAgent !== null
   }
 
   private getFreshExplicitAgentStatusForHandle(handle: string): {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -16641,9 +16641,11 @@ export class OrcaRuntimeService {
       return true
     }
     this.assertTerminalAgentStatusPtyBinding(handle, ptyId)
-    // Why: hook identity is generic; strong provider evidence only needs to
-    // prove that some recognized agent still owns this exact PTY.
-    return recognizeAgentProcess(confirmedProcess) === null
+    // Why: only a confirmed real shell proves the agent left. An unrecognized
+    // NON-shell foreground (wrapper/fork agent binary) must keep fresh hook
+    // state alive instead of counting as idle; an unavailable confirmation
+    // stays fail-closed like the catch path above.
+    return confirmedProcess === null || isShellProcess(confirmedProcess)
   }
 
   private shouldDelayPtyBackedMobileSnapshotForForegroundAgent(

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -170,6 +170,7 @@ describe('PtyHandler', () => {
     expect(methods).toContain('pty.hasChildProcesses')
     expect(methods).toContain('pty.getForegroundProcess')
     expect(methods).toContain('pty.inspectProcess')
+    expect(methods).toContain('pty.confirmForegroundProcess')
     expect(methods).toContain('pty.listProcesses')
     expect(methods).toContain('pty.getDefaultShell')
 
@@ -461,6 +462,28 @@ describe('PtyHandler', () => {
       expect(message).not.toContain('python3')
       expect(message).toMatch(/reconnect/i)
     }
+  })
+
+  it('confirmForegroundProcess forces a fresh post-boundary foreground read', async () => {
+    const foregroundSpy = vi
+      .spyOn(ptyShellUtils, 'getForegroundProcessName')
+      .mockResolvedValue('grok')
+    const { id } = (await dispatcher.callRequest('pty.spawn', { cols: 80, rows: 24 })) as {
+      id: string
+    }
+
+    await expect(dispatcher.callRequest('pty.confirmForegroundProcess', { id })).resolves.toBe(
+      'grok'
+    )
+    expect(foregroundSpy).toHaveBeenCalledWith(process.pid, null, { fresh: true })
+    foregroundSpy.mockRestore()
+  })
+
+  it('confirmForegroundProcess returns null for an unknown pty', async () => {
+    await expect(
+      dispatcher.callRequest('pty.confirmForegroundProcess', { id: 'missing' })
+    ).resolves.toBeNull()
+  })
   })
 
   it('normalizes a missing native binding as degraded node-pty availability', async () => {

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -484,7 +484,6 @@ describe('PtyHandler', () => {
       dispatcher.callRequest('pty.confirmForegroundProcess', { id: 'missing' })
     ).resolves.toBeNull()
   })
-  })
 
   it('normalizes a missing native binding as degraded node-pty availability', async () => {
     mockPtySpawn.mockImplementationOnce(() => {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -783,6 +783,9 @@ export class PtyHandler {
     this.dispatcher.onRequest('pty.hasChildProcesses', (p) => this.hasChildProcesses(p))
     this.dispatcher.onRequest('pty.getForegroundProcess', (p) => this.getForegroundProcess(p))
     this.dispatcher.onRequest('pty.inspectProcess', (p) => this.inspectProcess(p))
+    this.dispatcher.onRequest('pty.confirmForegroundProcess', (p) =>
+      this.confirmForegroundProcess(p)
+    )
     this.dispatcher.onRequest('pty.getCapabilities', async () => ({
       startupIngressVersion: PTY_STARTUP_INGRESS_VERSION,
       agentSessionClaimVersion: AGENT_SESSION_EXECUTION_OWNER_PROTOCOL_VERSION,
@@ -1889,6 +1892,20 @@ export class PtyHandler {
       foregroundProcess,
       hasChildProcesses: await processHasChildren(managed.pty.pid)
     }
+  }
+
+  // Why: SSH parity with the daemon's confirmForegroundProcess. A confirmation
+  // forces a fresh post-boundary scan so orca-runtime stops trusting a possibly
+  // stale relay read (an idle-looking shell that still fronts a live agent).
+  private async confirmForegroundProcess(params: Record<string, unknown>): Promise<string | null> {
+    const id = params.id as string
+    const managed = this.ptys.get(id)
+    if (!managed || managed.disposed) {
+      return null
+    }
+    return await getForegroundProcessName(managed.pty.pid, managed.pty.process || null, {
+      fresh: true
+    })
   }
 
   private async listProcesses(): Promise<PtyProcessSummary[]> {

--- a/src/relay/pty-shell-utils.test.ts
+++ b/src/relay/pty-shell-utils.test.ts
@@ -516,6 +516,26 @@ describe('getForegroundProcessName', () => {
     })
   })
 
+  it('confirmation reads bypass the cached process table with a fresh scan', async () => {
+    await withProcessPlatform('linux', async () => {
+      let table = ['100 99 Ss   bash -l', '101 100 S+   node /home/dev/.local/bin/codex'].join('\n')
+      mockExecFile((_command, args) => {
+        if (args[0] === '-axo') {
+          return { stdout: table }
+        }
+        return new Error('unexpected command')
+      })
+
+      // Prime the shared <=500ms snapshot cache with codex as the foreground.
+      await expect(getForegroundProcessName(100, 'bash')).resolves.toBe('codex')
+
+      // The foreground changed to grok; a cached read would still report codex,
+      // but a fresh confirmation scan must see the new identity.
+      table = ['100 99 Ss   bash -l', '101 100 S+   node /home/dev/.local/bin/grok'].join('\n')
+      await expect(getForegroundProcessName(100, 'bash', { fresh: true })).resolves.toBe('grok')
+    })
+  })
+
   it('falls back to the root process command when descendant inspection fails', async () => {
     mockExecFile((_command, args) => {
       if (args[0] === '-axo') {

--- a/src/relay/pty-shell-utils.test.ts
+++ b/src/relay/pty-shell-utils.test.ts
@@ -12,6 +12,7 @@ vi.mock('child_process', () => ({
 
 import { resetWindowsProcessRowsSnapshotForTests } from '../main/providers/windows-foreground-process-rows'
 import { resetProcessTableSnapshotForTests } from '../shared/process-table-snapshot'
+import { resetProcessExecutablePathCacheForTests } from '../shared/process-executable-recognition'
 import {
   getForegroundProcessName,
   isProcessAlive,
@@ -56,6 +57,7 @@ beforeEach(() => {
   execFileSyncMock.mockReset()
   resetProcessTableSnapshotForTests()
   resetWindowsProcessRowsSnapshotForTests()
+  resetProcessExecutablePathCacheForTests()
 })
 
 describe('isProcessAlive', () => {
@@ -475,6 +477,42 @@ describe('getForegroundProcessName', () => {
       })
 
       await expect(getForegroundProcessName(100, 'pi')).resolves.toBe('pi')
+    })
+  })
+
+  it('recognizes a renamed SSH relay agent binary via its executable image', async () => {
+    // The shell reports a bash foreground, but a renamed/forked agent binary
+    // ('my-cli') holds the terminal foreground; its executable image resolves it.
+    await withProcessPlatform('darwin', async () => {
+      mockExecFile((command, args) => {
+        if (args[0] === '-axo') {
+          return {
+            stdout: ['100 99 Ss   bash -l', '101 100 S+   my-cli --serve'].join('\n')
+          }
+        }
+        if (command === 'lsof') {
+          return { stdout: 'p101\nn/Users/dev/.local/bin/grok' }
+        }
+        return new Error('unexpected command')
+      })
+
+      await expect(getForegroundProcessName(100, 'bash')).resolves.toBe('grok')
+    })
+  })
+
+  it('does not fork lsof when an SSH relay descendant is recognized by command line', async () => {
+    await withProcessPlatform('darwin', async () => {
+      mockExecFile((command, args) => {
+        if (args[0] === '-axo') {
+          return {
+            stdout: ['100 99 Ss   bash -l', '101 100 S+   grok --serve'].join('\n')
+          }
+        }
+        return new Error(`unexpected command ${command}`)
+      })
+
+      await expect(getForegroundProcessName(100, 'bash')).resolves.toBe('grok')
+      expect(execFileMock.mock.calls.some((call) => call[0] === 'lsof')).toBe(false)
     })
   })
 

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -10,6 +10,7 @@ import {
   recognizeAgentProcessFromCommandLine
 } from '../shared/agent-process-recognition'
 import { getFirstCommandToken } from '../shared/command-token-scanner'
+import { recognizeAgentFromExecutablePath } from '../shared/process-executable-recognition'
 import { getProcessTableSnapshot, type ProcessTableRow } from '../shared/process-table-snapshot'
 import {
   resolveOuterWrapperForegroundProcess,
@@ -268,6 +269,21 @@ async function getRecognizedForegroundDescendant(
         // Why: return the outer wrapper (omp) rather than the deeper wrapped child
         // (pi) of a shell→omp→pi tree — see resolveOuterWrapperForegroundProcess.
         return resolveOuterWrapperForegroundProcess(recognized, candidate, candidates)
+      }
+    }
+    // Why: a renamed/forked agent binary (argv0 rename, native fork at a
+    // non-standard path) hides from command-line recognition. Lazily resolve
+    // the real executable image for the still-unrecognized non-shell foreground
+    // candidates and re-run recognition — per-PID cached, foreground-only, no
+    // extra `ps` scan. Interpreter forks resolve to node/python and stay
+    // unrecognized (script CLIs are covered by argv recognition above).
+    for (const candidate of inspectionCandidates) {
+      if (!candidate.stat.includes('+') || isShellProcess(processCommandToken(candidate.command))) {
+        continue
+      }
+      const recognized = await recognizeAgentFromExecutablePath(candidate.pid)
+      if (recognized) {
+        return recognized.processName
       }
     }
   } catch {

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -11,7 +11,11 @@ import {
 } from '../shared/agent-process-recognition'
 import { getFirstCommandToken } from '../shared/command-token-scanner'
 import { recognizeAgentFromExecutablePath } from '../shared/process-executable-recognition'
-import { getProcessTableSnapshot, type ProcessTableRow } from '../shared/process-table-snapshot'
+import {
+  getFreshProcessTableSnapshot,
+  getProcessTableSnapshot,
+  type ProcessTableRow
+} from '../shared/process-table-snapshot'
 import {
   resolveOuterWrapperForegroundProcess,
   shouldInspectOuterWrapperForegroundProcess
@@ -234,10 +238,13 @@ function candidateMatchesFallbackWrapper(
 
 async function getRecognizedForegroundDescendant(
   pid: number,
-  fallbackProcess?: string | null
+  fallbackProcess?: string | null,
+  fresh = false
 ): Promise<string | null> {
   try {
-    const rows = await getProcessTableSnapshot()
+    // Why: a confirmation read (SSH parity with the daemon) must inspect a scan
+    // started after the caller's command boundary, not a <=500ms-stale cache.
+    const rows = fresh ? await getFreshProcessTableSnapshot() : await getProcessTableSnapshot()
     const root = rows.find((row) => row.pid === pid)
     const candidates = collectDescendants(rows, pid).sort(
       (a, b) => candidateScore(b) - candidateScore(a)
@@ -297,7 +304,8 @@ async function getRecognizedForegroundDescendant(
  */
 export async function getForegroundProcessName(
   pid: number,
-  fallbackProcess?: string | null
+  fallbackProcess?: string | null,
+  options: { fresh?: boolean } = {}
 ): Promise<string | null> {
   if (fallbackProcess) {
     const fallbackRecognition = recognizeAgentProcess(fallbackProcess)
@@ -323,14 +331,20 @@ export async function getForegroundProcessName(
         return fallbackProcess
       }
       return (
-        (await resolveWindowsAgentForegroundProcess(pid, fallbackProcess, {})) ?? fallbackProcess
+        (await resolveWindowsAgentForegroundProcess(
+          pid,
+          fallbackProcess,
+          // Why: a confirmation forces a post-boundary CIM scan so a stale cached
+          // read cannot hide a live agent behind a recognized-fallback shortcut.
+          options.fresh ? { fresh: true, forceProcessScan: true } : {}
+        )) ?? fallbackProcess
       )
     }
     if (!isShellProcess(fallbackProcess) && !isAgentForegroundWrapperProcess(fallbackProcess)) {
       return fallbackProcess
     }
   }
-  const recognized = await getRecognizedForegroundDescendant(pid, fallbackProcess)
+  const recognized = await getRecognizedForegroundDescendant(pid, fallbackProcess, options.fresh)
   if (recognized) {
     return recognized
   }

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -288,7 +288,7 @@ async function getRecognizedForegroundDescendant(
       if (!candidate.stat.includes('+') || isShellProcess(processCommandToken(candidate.command))) {
         continue
       }
-      const recognized = await recognizeAgentFromExecutablePath(candidate.pid)
+      const recognized = await recognizeAgentFromExecutablePath(candidate.pid, candidate.command)
       if (recognized) {
         return recognized.processName
       }

--- a/src/renderer/src/components/sidebar/use-pane-foreground-agent-evidence-expiry.test.ts
+++ b/src/renderer/src/components/sidebar/use-pane-foreground-agent-evidence-expiry.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS } from '@/store/slices/pane-foreground-agent'
+import {
+  earliestPaneForegroundAgentEvidenceExpiry,
+  usePaneForegroundAgentEvidenceExpiryTick
+} from './use-pane-foreground-agent-evidence-expiry'
+
+describe('earliestPaneForegroundAgentEvidenceExpiry', () => {
+  it('returns the earliest future expiry and ignores agent-less, unstamped, and expired entries', () => {
+    const now = 100_000
+    expect(
+      earliestPaneForegroundAgentEvidenceExpiry(
+        {
+          a: { agent: 'claude', shellForeground: false, observedAt: now - 1_000 },
+          b: { agent: 'codex', shellForeground: false, observedAt: now - 500 },
+          shell: { agent: null, shellForeground: true, observedAt: now },
+          unstamped: { agent: 'claude', shellForeground: false },
+          expired: {
+            agent: 'claude',
+            shellForeground: false,
+            observedAt: now - PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS
+          }
+        },
+        now
+      )
+    ).toBe(now - 1_000 + PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS)
+  })
+
+  it('returns null when no entry has a future expiry', () => {
+    expect(earliestPaneForegroundAgentEvidenceExpiry({}, 1_000)).toBeNull()
+  })
+})
+
+describe('usePaneForegroundAgentEvidenceExpiryTick', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('bumps once when the only evidence entry crosses its TTL', () => {
+    const entries = {
+      pane: { agent: 'claude' as const, shellForeground: false, observedAt: Date.now() }
+    }
+    const { result } = renderHook(() => usePaneForegroundAgentEvidenceExpiryTick(entries))
+
+    expect(result.current).toBe(0)
+    act(() => {
+      vi.advanceTimersByTime(PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS + 1)
+    })
+    expect(result.current).toBe(1)
+
+    // Why: past the TTL there is no future expiry left, so no timer re-arms.
+    act(() => {
+      vi.advanceTimersByTime(PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS + 1)
+    })
+    expect(result.current).toBe(1)
+  })
+
+  it('schedules nothing for entries without attributable evidence', () => {
+    const entries = {
+      pane: { agent: null, shellForeground: true, observedAt: Date.now() }
+    }
+    const { result } = renderHook(() => usePaneForegroundAgentEvidenceExpiryTick(entries))
+
+    act(() => {
+      vi.advanceTimersByTime(PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS * 2)
+    })
+    expect(result.current).toBe(0)
+  })
+})

--- a/src/renderer/src/components/sidebar/use-pane-foreground-agent-evidence-expiry.ts
+++ b/src/renderer/src/components/sidebar/use-pane-foreground-agent-evidence-expiry.ts
@@ -23,19 +23,12 @@ export function earliestPaneForegroundAgentEvidenceExpiry(
   return earliest
 }
 
-/**
- * Re-render trigger for TTL-gated process-identity attribution: store updates
- * only happen when evidence is (re)published, so nothing re-renders when the
- * last publish silently crosses its TTL. Returns a tick that bumps just past
- * the earliest upcoming expiry; consumers add it to their memo deps so a
- * past-TTL working ring/row drops without waiting for unrelated store churn.
- */
+/** Re-render trigger that expires process attribution without unrelated store writes. */
 export function usePaneForegroundAgentEvidenceExpiryTick(
   entries: Record<string, PaneForegroundAgentEntry>
 ): number {
   const [tick, setTick] = useState(0)
-  // Why: `tick` is a dep so the effect re-arms for the next-earliest expiry
-  // after firing (entries observed at different times expire independently).
+  // Why: tick re-arms the next expiry when entries were observed at different times.
   useEffect(() => {
     const now = Date.now()
     const earliest = earliestPaneForegroundAgentEvidenceExpiry(entries, now)

--- a/src/renderer/src/components/sidebar/use-pane-foreground-agent-evidence-expiry.ts
+++ b/src/renderer/src/components/sidebar/use-pane-foreground-agent-evidence-expiry.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react'
+import {
+  PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS,
+  type PaneForegroundAgentEntry
+} from '@/store/slices/pane-foreground-agent'
+
+/** Earliest upcoming attribution-evidence expiry among entries, or null. */
+export function earliestPaneForegroundAgentEvidenceExpiry(
+  entries: Record<string, PaneForegroundAgentEntry>,
+  now: number
+): number | null {
+  let earliest: number | null = null
+  for (const entry of Object.values(entries)) {
+    if (!entry.agent || entry.observedAt === undefined) {
+      continue
+    }
+    const expiry = entry.observedAt + PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS
+    if (expiry <= now) {
+      continue
+    }
+    earliest = earliest === null ? expiry : Math.min(earliest, expiry)
+  }
+  return earliest
+}
+
+/**
+ * Re-render trigger for TTL-gated process-identity attribution: store updates
+ * only happen when evidence is (re)published, so nothing re-renders when the
+ * last publish silently crosses its TTL. Returns a tick that bumps just past
+ * the earliest upcoming expiry; consumers add it to their memo deps so a
+ * past-TTL working ring/row drops without waiting for unrelated store churn.
+ */
+export function usePaneForegroundAgentEvidenceExpiryTick(
+  entries: Record<string, PaneForegroundAgentEntry>
+): number {
+  const [tick, setTick] = useState(0)
+  // Why: `tick` is a dep so the effect re-arms for the next-earliest expiry
+  // after firing (entries observed at different times expire independently).
+  useEffect(() => {
+    const now = Date.now()
+    const earliest = earliestPaneForegroundAgentEvidenceExpiry(entries, now)
+    if (earliest === null) {
+      return
+    }
+    const timer = setTimeout(() => setTick((value) => value + 1), earliest - now + 1)
+    return () => clearTimeout(timer)
+  }, [entries, tick])
+  return tick
+}

--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
@@ -9,6 +9,7 @@ import {
   selectRuntimePaneTitlesForWorktree
 } from './worktree-card-status-inputs'
 import { selectWorktreeAgentActivitySummary } from './worktree-agent-activity-summary'
+import { usePaneForegroundAgentEvidenceExpiryTick } from './use-pane-foreground-agent-evidence-expiry'
 
 export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
   const tabs = useAppStore((s) => s.tabsByWorktree[worktreeId] ?? EMPTY_TABS)
@@ -30,6 +31,10 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
     agentStatusPaneIdsByTabId,
     paneForegroundAgentByPaneKey
   } = useAppStore(useShallow((s) => selectWorktreeAgentActivitySummary(s, worktreeId)))
+  // Why: process-identity evidence decays by wall clock, not by store writes;
+  // this tick forces one recompute at the earliest TTL boundary so a stale
+  // working ring drops even when tracker/coordinator go silent.
+  const evidenceExpiryTick = usePaneForegroundAgentEvidenceExpiryTick(paneForegroundAgentByPaneKey)
 
   // Why: compact and detailed cards need the same status-dot semantics:
   // runtime liveness gates title-derived states, then explicit agent rows can
@@ -49,7 +54,11 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
         hasLiveDone,
         hasRetainedDone
       }),
+    // Why: evidenceExpiryTick is an extra dep on purpose — it forces the
+    // Date.now() read inside resolveWorktreeStatus to re-evaluate at the TTL.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
+      evidenceExpiryTick,
       tabs,
       browserTabs,
       ptyIdsForWorktree,

--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
@@ -22,8 +22,14 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
   const terminalLayoutRootsByTabId = useAppStore(
     useShallow((s) => selectTerminalLayoutRootsForWorktree(s, worktreeId))
   )
-  const { hasPermission, hasLiveWorking, hasLiveDone, hasRetainedDone, agentStatusPaneIdsByTabId } =
-    useAppStore(useShallow((s) => selectWorktreeAgentActivitySummary(s, worktreeId)))
+  const {
+    hasPermission,
+    hasLiveWorking,
+    hasLiveDone,
+    hasRetainedDone,
+    agentStatusPaneIdsByTabId,
+    paneForegroundAgentByPaneKey
+  } = useAppStore(useShallow((s) => selectWorktreeAgentActivitySummary(s, worktreeId)))
 
   // Why: compact and detailed cards need the same status-dot semantics:
   // runtime liveness gates title-derived states, then explicit agent rows can
@@ -37,6 +43,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
         runtimePaneTitlesByTabId: runtimePaneTitlesForWorktree,
         agentStatusPaneIdsByTabId,
         terminalLayoutRootsByTabId,
+        paneForegroundAgentByPaneKey,
         hasPermission,
         hasLiveWorking,
         hasLiveDone,
@@ -49,6 +56,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
       runtimePaneTitlesForWorktree,
       agentStatusPaneIdsByTabId,
       terminalLayoutRootsByTabId,
+      paneForegroundAgentByPaneKey,
       hasPermission,
       hasLiveWorking,
       hasLiveDone,

--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
@@ -31,9 +31,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
     agentStatusPaneIdsByTabId,
     paneForegroundAgentByPaneKey
   } = useAppStore(useShallow((s) => selectWorktreeAgentActivitySummary(s, worktreeId)))
-  // Why: process-identity evidence decays by wall clock, not by store writes;
-  // this tick forces one recompute at the earliest TTL boundary so a stale
-  // working ring drops even when tracker/coordinator go silent.
+  // Why: evidence decays by wall clock, so recompute at expiry even without a store write.
   const evidenceExpiryTick = usePaneForegroundAgentEvidenceExpiryTick(paneForegroundAgentByPaneKey)
 
   // Why: compact and detailed cards need the same status-dot semantics:
@@ -54,8 +52,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
         hasLiveDone,
         hasRetainedDone
       }),
-    // Why: evidenceExpiryTick is an extra dep on purpose — it forces the
-    // Date.now() read inside resolveWorktreeStatus to re-evaluate at the TTL.
+    // Why: the tick forces resolveWorktreeStatus to re-read time at expiry.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       evidenceExpiryTick,

--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
@@ -20,6 +20,10 @@ import {
   createWorktreeAgentFreshnessSelector,
   EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE
 } from './worktree-agent-freshness-selector'
+import {
+  EMPTY_PANE_FOREGROUND_AGENTS,
+  selectWorktreeAgentActivitySummary
+} from './worktree-agent-activity-summary'
 
 export { buildWorktreeAgentRows } from './worktree-agent-rows'
 export {
@@ -74,6 +78,14 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
   const runtimeAgentOrchestrationByPaneKey = useAppStore(
     useShallow((s) => (active ? selectRuntimeAgentOrchestrationForWorktree(s, worktreeId) : {}))
   )
+  // Why: the activity summary already narrows the process-identity slice per
+  // worktree with stable references; reuse it instead of subscribing to the
+  // whole paneForegroundAgentByPaneKey map (O(worktrees) render amplification).
+  const paneForegroundAgentByPaneKey = useAppStore((s) =>
+    active
+      ? selectWorktreeAgentActivitySummary(s, worktreeId).paneForegroundAgentByPaneKey
+      : EMPTY_PANE_FOREGROUND_AGENTS
+  )
   const agentFreshnessSignature = useAppStore((s) =>
     active ? selectAgentFreshness(s) : EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE
   )
@@ -104,6 +116,7 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
         ptyIdsByTabId,
         terminalLayoutsByTabId,
         runtimeAgentOrchestrationByPaneKey,
+        paneForegroundAgentByPaneKey,
         now
       })
     )
@@ -118,6 +131,7 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
     ptyIdsByTabId,
     terminalLayoutsByTabId,
     runtimeAgentOrchestrationByPaneKey,
+    paneForegroundAgentByPaneKey,
     agentFreshnessSignature
   ])
 }

--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
@@ -24,6 +24,7 @@ import {
   EMPTY_PANE_FOREGROUND_AGENTS,
   selectWorktreeAgentActivitySummary
 } from './worktree-agent-activity-summary'
+import { usePaneForegroundAgentEvidenceExpiryTick } from './use-pane-foreground-agent-evidence-expiry'
 
 export { buildWorktreeAgentRows } from './worktree-agent-rows'
 export {
@@ -89,6 +90,10 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
   const agentFreshnessSignature = useAppStore((s) =>
     active ? selectAgentFreshness(s) : EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE
   )
+  // Why: process-identity evidence decays by wall clock, not by store writes;
+  // this tick forces one recompute at the earliest TTL boundary so a stale row
+  // drops even when tracker/coordinator go silent after the last publish.
+  const evidenceExpiryTick = usePaneForegroundAgentEvidenceExpiryTick(paneForegroundAgentByPaneKey)
 
   return useMemo<DashboardAgentRow[]>(() => {
     if (!active) {
@@ -132,6 +137,7 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
     terminalLayoutsByTabId,
     runtimeAgentOrchestrationByPaneKey,
     paneForegroundAgentByPaneKey,
-    agentFreshnessSignature
+    agentFreshnessSignature,
+    evidenceExpiryTick
   ])
 }

--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
@@ -79,9 +79,7 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
   const runtimeAgentOrchestrationByPaneKey = useAppStore(
     useShallow((s) => (active ? selectRuntimeAgentOrchestrationForWorktree(s, worktreeId) : {}))
   )
-  // Why: the activity summary already narrows the process-identity slice per
-  // worktree with stable references; reuse it instead of subscribing to the
-  // whole paneForegroundAgentByPaneKey map (O(worktrees) render amplification).
+  // Why: reuse the stable per-worktree summary to avoid whole-map render amplification.
   const paneForegroundAgentByPaneKey = useAppStore((s) =>
     active
       ? selectWorktreeAgentActivitySummary(s, worktreeId).paneForegroundAgentByPaneKey
@@ -90,9 +88,7 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
   const agentFreshnessSignature = useAppStore((s) =>
     active ? selectAgentFreshness(s) : EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE
   )
-  // Why: process-identity evidence decays by wall clock, not by store writes;
-  // this tick forces one recompute at the earliest TTL boundary so a stale row
-  // drops even when tracker/coordinator go silent after the last publish.
+  // Why: evidence decays by wall clock, so recompute at expiry even without a store write.
   const evidenceExpiryTick = usePaneForegroundAgentEvidenceExpiryTick(paneForegroundAgentByPaneKey)
 
   return useMemo<DashboardAgentRow[]>(() => {

--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary.test.ts
@@ -91,6 +91,41 @@ describe('selectWorktreeAgentActivitySummary', () => {
     expect(nowSpy).toHaveBeenCalledTimes(1)
   })
 
+  it('narrows process-identity entries to their worktree and skips agent-less entries', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(2_000)
+    const firstPaneKey = makePaneKey('tab-1', LEAF_ID)
+    const secondPaneKey = makePaneKey('tab-2', LEAF_ID)
+    const claudeEntry = {
+      agent: 'claude',
+      shellForeground: false,
+      observedAt: 1_900,
+      ptyId: 'pty-claude'
+    } as const
+    const state: AgentActivityInput = {
+      tabsByWorktree: {
+        'repo::/wt-1': [makeTab('tab-1', 'repo::/wt-1')],
+        'repo::/wt-2': [makeTab('tab-2', 'repo::/wt-2')]
+      },
+      agentStatusEpoch: 0,
+      agentStatusByPaneKey: {},
+      migrationUnsupportedByPtyId: {},
+      runtimeAgentOrchestrationByPaneKey: {},
+      retainedAgentsByPaneKey: {},
+      paneForegroundAgentByPaneKey: {
+        [firstPaneKey]: claudeEntry,
+        // Shell-foreground (agent gone) entries carry no attribution value.
+        [secondPaneKey]: { agent: null, shellForeground: true, observedAt: 1_900 }
+      }
+    }
+
+    expect(
+      selectWorktreeAgentActivitySummary(state, 'repo::/wt-1').paneForegroundAgentByPaneKey
+    ).toEqual({ [firstPaneKey]: claudeEntry })
+    expect(
+      selectWorktreeAgentActivitySummary(state, 'repo::/wt-2').paneForegroundAgentByPaneKey
+    ).toEqual({})
+  })
+
   it('reuses the cached summary when same-state agent pings only clone the status map', () => {
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(2_000)
     const paneKey = makePaneKey('tab-1', LEAF_ID)

--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
@@ -11,6 +11,7 @@ import {
   type AgentStatusEntry,
   type AgentStatusOrchestrationContext
 } from '../../../../shared/agent-status-types'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 
 export type WorktreeAgentActivitySummary = {
   hasPermission: boolean
@@ -18,16 +19,22 @@ export type WorktreeAgentActivitySummary = {
   hasLiveDone: boolean
   hasRetainedDone: boolean
   agentStatusPaneIdsByTabId: Record<string, ReadonlySet<string>>
+  /** Process-table identity entries narrowed to this worktree's panes.
+   *  Freshness (TTL) is NOT applied here — this cache is invalidated by
+   *  references, so consumers must gate with their own clock. */
+  paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry>
 }
 
 const EMPTY_AGENT_STATUS_PANE_IDS_BY_TAB_ID: Record<string, ReadonlySet<string>> = {}
+export const EMPTY_PANE_FOREGROUND_AGENTS: Record<string, PaneForegroundAgentEntry> = {}
 
 const EMPTY_SUMMARY: WorktreeAgentActivitySummary = {
   hasPermission: false,
   hasLiveWorking: false,
   hasLiveDone: false,
   hasRetainedDone: false,
-  agentStatusPaneIdsByTabId: EMPTY_AGENT_STATUS_PANE_IDS_BY_TAB_ID
+  agentStatusPaneIdsByTabId: EMPTY_AGENT_STATUS_PANE_IDS_BY_TAB_ID,
+  paneForegroundAgentByPaneKey: EMPTY_PANE_FOREGROUND_AGENTS
 }
 
 type AgentActivityTabsByWorktree = Record<string, readonly { id: string }[]>
@@ -41,6 +48,7 @@ export type AgentActivityInput = Pick<
 > & {
   tabsByWorktree: AgentActivityTabsByWorktree
   runtimeAgentOrchestrationByPaneKey?: AppState['runtimeAgentOrchestrationByPaneKey']
+  paneForegroundAgentByPaneKey?: AppState['paneForegroundAgentByPaneKey']
 }
 
 type AgentActivityCache = {
@@ -49,6 +57,7 @@ type AgentActivityCache = {
   migrationUnsupportedByPtyId: AppState['migrationUnsupportedByPtyId']
   retainedAgentsByPaneKey: AppState['retainedAgentsByPaneKey']
   runtimeAgentOrchestrationByPaneKey: AppState['runtimeAgentOrchestrationByPaneKey'] | undefined
+  paneForegroundAgentByPaneKey: AppState['paneForegroundAgentByPaneKey'] | undefined
   summaries: Map<string, WorktreeAgentActivitySummary>
 }
 
@@ -65,13 +74,15 @@ function getWorktreeAgentActivitySummaries(
   state: AgentActivityInput
 ): Map<string, WorktreeAgentActivitySummary> {
   const runtimeAgentOrchestrationByPaneKey = state.runtimeAgentOrchestrationByPaneKey
+  const paneForegroundAgentByPaneKey = state.paneForegroundAgentByPaneKey
   if (
     agentActivityCache &&
     agentActivityCache.tabsByWorktree === state.tabsByWorktree &&
     agentActivityCache.agentStatusEpoch === state.agentStatusEpoch &&
     agentActivityCache.migrationUnsupportedByPtyId === state.migrationUnsupportedByPtyId &&
     agentActivityCache.retainedAgentsByPaneKey === state.retainedAgentsByPaneKey &&
-    agentActivityCache.runtimeAgentOrchestrationByPaneKey === runtimeAgentOrchestrationByPaneKey
+    agentActivityCache.runtimeAgentOrchestrationByPaneKey === runtimeAgentOrchestrationByPaneKey &&
+    agentActivityCache.paneForegroundAgentByPaneKey === paneForegroundAgentByPaneKey
   ) {
     return agentActivityCache.summaries
   }
@@ -133,6 +144,23 @@ function getWorktreeAgentActivitySummaries(
     }
   }
 
+  // Why: narrow process-table identity to each worktree so cards can attribute
+  // title-derived rows/ring without subscribing to the whole slice map.
+  for (const [paneKey, entry] of Object.entries(paneForegroundAgentByPaneKey ?? {})) {
+    if (!entry.agent) {
+      continue
+    }
+    const worktreeId = worktreeIdForPaneKey(paneKey, tabIdToWorktreeId)
+    if (!worktreeId) {
+      continue
+    }
+    const summary = summaryForWorktree(worktreeId)
+    if (summary.paneForegroundAgentByPaneKey === EMPTY_PANE_FOREGROUND_AGENTS) {
+      summary.paneForegroundAgentByPaneKey = {}
+    }
+    summary.paneForegroundAgentByPaneKey[paneKey] = entry
+  }
+
   for (const retained of Object.values(state.retainedAgentsByPaneKey ?? {})) {
     const summary = summaryForWorktree(retained.worktreeId)
     summary.hasRetainedDone = true
@@ -165,6 +193,7 @@ function getWorktreeAgentActivitySummaries(
     migrationUnsupportedByPtyId: state.migrationUnsupportedByPtyId,
     retainedAgentsByPaneKey: state.retainedAgentsByPaneKey,
     runtimeAgentOrchestrationByPaneKey,
+    paneForegroundAgentByPaneKey,
     summaries
   }
   return summaries
@@ -182,8 +211,28 @@ function summariesEqual(
     agentStatusPaneIdsByTabIdEqual(
       previous.agentStatusPaneIdsByTabId,
       next.agentStatusPaneIdsByTabId
+    ) &&
+    paneForegroundAgentsEqual(
+      previous.paneForegroundAgentByPaneKey,
+      next.paneForegroundAgentByPaneKey
     )
   )
+}
+
+function paneForegroundAgentsEqual(
+  previous: Record<string, PaneForegroundAgentEntry>,
+  next: Record<string, PaneForegroundAgentEntry>
+): boolean {
+  if (previous === next) {
+    return true
+  }
+  const previousKeys = Object.keys(previous)
+  if (previousKeys.length !== Object.keys(next).length) {
+    return false
+  }
+  // Why: entry objects are immutable in the slice, so reference equality is
+  // exact — and observedAt bumps must NOT be equal, or freshness would freeze.
+  return previousKeys.every((paneKey) => previous[paneKey] === next[paneKey])
 }
 
 function agentStatusPaneIdsByTabIdEqual(

--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
@@ -19,9 +19,7 @@ export type WorktreeAgentActivitySummary = {
   hasLiveDone: boolean
   hasRetainedDone: boolean
   agentStatusPaneIdsByTabId: Record<string, ReadonlySet<string>>
-  /** Process-table identity entries narrowed to this worktree's panes.
-   *  Freshness (TTL) is NOT applied here — this cache is invalidated by
-   *  references, so consumers must gate with their own clock. */
+  /** Process identity narrowed by worktree; consumers apply wall-clock freshness. */
   paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry>
 }
 
@@ -230,8 +228,7 @@ function paneForegroundAgentsEqual(
   if (previousKeys.length !== Object.keys(next).length) {
     return false
   }
-  // Why: entry objects are immutable in the slice, so reference equality is
-  // exact — and observedAt bumps must NOT be equal, or freshness would freeze.
+  // Why: immutable entry identity is exact, and observedAt bumps must invalidate freshness.
   return previousKeys.every((paneKey) => previous[paneKey] === next[paneKey])
 }
 

--- a/src/renderer/src/components/sidebar/worktree-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-rows.ts
@@ -1,6 +1,7 @@
 import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
 import type { RetainedAgentEntry } from '@/store/slices/agent-status'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 import {
   AGENT_STATUS_STALE_AFTER_MS,
   type AgentType,
@@ -209,6 +210,7 @@ export function buildWorktreeAgentRows(args: {
   ptyIdsByTabId?: Record<string, string[]>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
+  paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
   now: number
 }): DashboardAgentRow[] {
   const rows: DashboardAgentRow[] = []

--- a/src/renderer/src/components/sidebar/worktree-section-activity.ts
+++ b/src/renderer/src/components/sidebar/worktree-section-activity.ts
@@ -32,6 +32,7 @@ export type WorktreeSectionActivityState = Pick<
   tabsByWorktree: Record<string, readonly Pick<TerminalTab, 'id' | 'title'>[]>
   browserTabsByWorktree: Record<string, readonly BrowserActivityTab[]>
   terminalLayoutRootsByTabId: Record<string, TerminalPaneLayoutNode | null | undefined>
+  paneForegroundAgentByPaneKey?: AppState['paneForegroundAgentByPaneKey']
 }
 
 export type WorktreeSectionActivitySummary = {
@@ -107,6 +108,7 @@ function getSectionWorktreeStatus(
     ptyIdsByTabId: selectLivePtyIdsForWorktree(state, worktreeId),
     runtimePaneTitlesByTabId: selectRuntimePaneTitlesForWorktree(state, worktreeId),
     agentStatusPaneIdsByTabId: agentSummary.agentStatusPaneIdsByTabId,
+    paneForegroundAgentByPaneKey: agentSummary.paneForegroundAgentByPaneKey,
     terminalLayoutRootsByTabId: state.terminalLayoutRootsByTabId,
     hasPermission: agentSummary.hasPermission,
     hasLiveWorking: agentSummary.hasLiveWorking,

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { applyAgentRowLineage } from '@/components/dashboard/agent-row-lineage'
+import { PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS } from '@/store/slices/pane-foreground-agent'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import type { TerminalLayoutSnapshot, TerminalTab, TuiAgent } from '../../../../shared/types'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { buildWorktreeAgentRows } from './worktree-agent-rows'
@@ -255,6 +257,118 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(rows).toHaveLength(0)
   })
 
+  // Why: wrapper-launched claude (zsh function exec'ing the real binary) emits
+  // Claude activity titles without the literal "claude" token; fresh process
+  // identity must attribute the row instead.
+  it('builds a Claude row for a token-less Claude activity title with fresh claude process identity', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID_1)
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: 'orca-wrapper' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: '⠐ refactor split-pane status' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-claude'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      paneForegroundAgentByPaneKey: {
+        [paneKey]: {
+          agent: 'claude',
+          shellForeground: false,
+          observedAt: 1_900,
+          ptyId: 'pty-claude'
+        }
+      },
+      now: 2_000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state])).toEqual([['claude', 'working']])
+    expect(rows[0].paneKey).toBe(paneKey)
+  })
+
+  it('does not attribute Claude from stale (past-TTL) process evidence', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID_1)
+    const now = 100_000
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: 'orca-wrapper' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: '⠐ refactor split-pane status' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-claude'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      paneForegroundAgentByPaneKey: {
+        [paneKey]: {
+          agent: 'claude',
+          shellForeground: false,
+          observedAt: now - PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS - 1,
+          ptyId: 'pty-claude'
+        }
+      },
+      now
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
+  it('does not attribute Claude from evidence whose PTY is no longer live', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID_1)
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: 'orca-wrapper' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: '⠐ refactor split-pane status' }
+      },
+      // The pane respawned onto a different PTY; the old evidence must not bind.
+      ptyIdsByTabId: { 'tab-1': ['pty-respawned'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      paneForegroundAgentByPaneKey: {
+        [paneKey]: { agent: 'claude', shellForeground: false, observedAt: 1_900, ptyId: 'pty-dead' }
+      },
+      now: 2_000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
+  it('keeps the hook row (not a duplicate title-derived row) when both exist for a pane', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID_1)
+    const hookEntry: AgentStatusEntry = {
+      paneKey,
+      state: 'working',
+      prompt: '',
+      updatedAt: 1_900,
+      stateStartedAt: 1_900,
+      stateHistory: [],
+      agentType: 'codex'
+    }
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: 'orca-wrapper' })],
+      entries: [hookEntry],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: '⠐ refactor split-pane status' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-claude'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      paneForegroundAgentByPaneKey: {
+        [paneKey]: {
+          agent: 'claude',
+          shellForeground: false,
+          observedAt: 1_900,
+          ptyId: 'pty-claude'
+        }
+      },
+      now: 2_000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.rowSource])).toEqual([['codex', 'live']])
+  })
+
+  // Why: non-braille Claude activity markers without a Claude token must not
+  // invent a Claude row from launchAgent alone (split-pane residual risk).
   it('does not turn generic Codex-launched task titles into Claude Code rows', () => {
     const launchAgent: TuiAgent = 'codex'
     const rows = buildWorktreeAgentRows({

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -368,21 +368,32 @@ describe('buildTitleDerivedAgentRows', () => {
   })
 
   // Why: non-braille Claude activity markers without a Claude token must not
-  // invent a Claude row from launchAgent alone (split-pane residual risk).
-  it('does not turn generic Codex-launched task titles into Claude Code rows', () => {
-    const launchAgent: TuiAgent = 'codex'
-    const rows = buildWorktreeAgentRows({
-      tabs: [makeTab('tab-1', { launchAgent })],
-      entries: [],
-      retained: [],
-      runtimePaneTitlesByTabId: {
-        'tab-1': { 1: '✳ refactor split-pane status' }
-      },
-      ptyIdsByTabId: { 'tab-1': ['pty-codex'] },
-      terminalLayoutsByTabId: { 'tab-1': makeSplitLayout() },
-      now: 2000
-    })
+  // invent a Claude row from launchAgent alone. Braille-only titles may fall
+  // back to launchAgent (Codex over SSH, #8711) — still never Claude.
+  it.each([
+    ['✳ refactor split-pane status', null],
+    ['⠐ refactor split-pane status', 'codex']
+  ] as const)(
+    'does not turn generic Codex-launched task title %s into Claude Code rows',
+    (title, expectedAgent) => {
+      const launchAgent: TuiAgent = 'codex'
+      const rows = buildWorktreeAgentRows({
+        tabs: [makeTab('tab-1', { launchAgent })],
+        entries: [],
+        retained: [],
+        runtimePaneTitlesByTabId: {
+          'tab-1': { 1: title }
+        },
+        ptyIdsByTabId: { 'tab-1': ['pty-codex'] },
+        terminalLayoutsByTabId: { 'tab-1': makeSplitLayout() },
+        now: 2000
+      })
 
-    expect(rows).toHaveLength(0)
-  })
+      if (expectedAgent === null) {
+        expect(rows).toHaveLength(0)
+      } else {
+        expect(rows.map((row) => row.agentType)).toEqual([expectedAgent])
+      }
+    }
+  )
 })

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -3,6 +3,10 @@ import { formatAgentTypeLabel, isClaudeManagementTitle } from '@/lib/agent-statu
 import { containsBrailleSpinner } from '../../../../shared/agent-title-core'
 import { classifyTitleActivity, resolveTitleActivityLabel } from '@/lib/pane-agent-evidence'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
+import {
+  resolveFreshPaneForegroundAgent,
+  type PaneForegroundAgentEntry
+} from '@/store/slices/pane-foreground-agent'
 import type {
   AgentStatusEntry,
   AgentStatusOrchestrationContext,
@@ -13,7 +17,8 @@ import { isTerminalLeafId, makePaneKey } from '../../../../shared/stable-pane-id
 import type {
   TerminalLayoutSnapshot,
   TerminalPaneLayoutNode,
-  TerminalTab
+  TerminalTab,
+  TuiAgent
 } from '../../../../shared/types'
 import {
   normalizeCompatibleAgentTitleForOwner,
@@ -50,6 +55,7 @@ export function buildTitleDerivedAgentRows(args: {
   ptyIdsByTabId?: Record<string, string[]>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
+  paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
   seenPaneKeys: Set<string>
   now: number
 }): DashboardAgentRow[] {
@@ -85,7 +91,15 @@ export function buildTitleDerivedAgentRows(args: {
           leafId,
           title,
           now: args.now,
-          runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
+          runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey,
+          processAgent: freshProcessAgentForLeaf({
+            tabId: tab.id,
+            leafId,
+            layout,
+            livePtyIds: ptyIdsByTabId[tab.id],
+            paneForegroundAgentByPaneKey: args.paneForegroundAgentByPaneKey,
+            now: args.now
+          })
         })
         if (!row || args.seenPaneKeys.has(row.paneKey)) {
           continue
@@ -105,7 +119,15 @@ export function buildTitleDerivedAgentRows(args: {
       leafId,
       title: tab.title,
       now: args.now,
-      runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
+      runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey,
+      processAgent: freshProcessAgentForLeaf({
+        tabId: tab.id,
+        leafId,
+        layout,
+        livePtyIds: ptyIdsByTabId[tab.id],
+        paneForegroundAgentByPaneKey: args.paneForegroundAgentByPaneKey,
+        now: args.now
+      })
     })
     if (!row || args.seenPaneKeys.has(row.paneKey)) {
       continue
@@ -127,6 +149,7 @@ function buildTitleDerivedAgentRow(args: {
   title: string
   now: number
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
+  processAgent?: TuiAgent | null
 }): DashboardAgentRow | null {
   const title = normalizeCompatibleAgentTitleForOwner(args.title, args.tab.launchAgent)
   const isClaudeAgentsTitle = isClaudeManagementTitle(title)
@@ -143,7 +166,9 @@ function buildTitleDerivedAgentRow(args: {
   }
   const paneKey = makePaneKey(args.tab.id, args.leafId)
   const orchestration = args.runtimeAgentOrchestrationByPaneKey?.[paneKey]
-  const titleAgentType = isClaudeAgentsTitle ? 'claude' : resolveTitleDerivedAgentType(title, label)
+  const titleAgentType = isClaudeAgentsTitle
+    ? 'claude'
+    : resolveTitleDerivedAgentType(title, label, args.processAgent)
   // Why: a braille spinner proves activity, not identity, so the resolver drops
   // it. Hook-less agents over SSH (Codex, #8711) surface only spinner+cwd titles;
   // fall back to the tab's launch identity instead of hiding the pane. Gated on
@@ -184,15 +209,24 @@ function buildTitleDerivedAgentRow(args: {
   }
 }
 
-export function resolveTitleDerivedAgentType(title: string, label: string): AgentType | null {
+export function resolveTitleDerivedAgentType(
+  title: string,
+  label: string,
+  processAgent?: AgentType | null
+): AgentType | null {
   const agentType = TITLE_AGENT_LABEL_TO_TYPE[label] ?? 'unknown'
   if (agentType !== 'claude') {
     return agentType
   }
   // Why: Claude's task-title spinner heuristic has no provider identity. In
   // split panes it can match arbitrary terminal spinners, so sidebar rows only
-  // accept Claude when the title itself names Claude.
-  return CLAUDE_AGENT_TOKEN_RE.test(title) ? agentType : null
+  // accept Claude when the title itself names Claude — or when fresh
+  // process-table identity proves a claude foreground (wrapper launches via a
+  // shell function never put the literal token in the title).
+  if (CLAUDE_AGENT_TOKEN_RE.test(title)) {
+    return agentType
+  }
+  return processAgent === 'claude' ? agentType : null
 }
 
 /**
@@ -201,7 +235,8 @@ export function resolveTitleDerivedAgentType(title: string, label: string): Agen
  */
 export function resolveAgentTypeFromTerminalTitle(
   title: string | null | undefined,
-  ownerAgentType?: AgentType | null
+  ownerAgentType?: AgentType | null,
+  processAgent?: AgentType | null
 ): AgentType | null {
   if (!title) {
     return null
@@ -210,10 +245,34 @@ export function resolveAgentTypeFromTerminalTitle(
   const label = resolveTitleActivityLabel(normalizedTitle)
   return label
     ? (resolveCompatibleAgentTypeForOwner(
-        resolveTitleDerivedAgentType(normalizedTitle, label),
+        resolveTitleDerivedAgentType(normalizedTitle, label, processAgent),
         ownerAgentType
       ) ?? null)
     : null
+}
+
+/**
+ * TTL- and liveness-gated process identity for one pane, used to attribute
+ * title-derived rows (and the worktree ring, via worktree-status) when the
+ * title alone cannot name the agent.
+ */
+export function freshProcessAgentForLeaf(args: {
+  tabId: string
+  leafId: string
+  layout: TerminalLayoutSnapshot | undefined
+  livePtyIds: readonly string[] | undefined
+  paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry> | undefined
+  now: number
+}): TuiAgent | null {
+  if (!args.paneForegroundAgentByPaneKey || !isTerminalLeafId(args.leafId)) {
+    return null
+  }
+  const entry = args.paneForegroundAgentByPaneKey[makePaneKey(args.tabId, args.leafId)]
+  return resolveFreshPaneForegroundAgent(entry, {
+    now: args.now,
+    paneBoundPtyId: args.layout?.ptyIdsByLeafId?.[args.leafId],
+    liveTabPtyIds: args.livePtyIds
+  })
 }
 
 function titleStatusToRowState(

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -218,11 +218,8 @@ export function resolveTitleDerivedAgentType(
   if (agentType !== 'claude') {
     return agentType
   }
-  // Why: Claude's task-title spinner heuristic has no provider identity. In
-  // split panes it can match arbitrary terminal spinners, so sidebar rows only
-  // accept Claude when the title itself names Claude — or when fresh
-  // process-table identity proves a claude foreground (wrapper launches via a
-  // shell function never put the literal token in the title).
+  // Why: generic spinner titles may be unrelated; require either a Claude token
+  // or fresh Claude process identity before attributing them.
   if (CLAUDE_AGENT_TOKEN_RE.test(title)) {
     return agentType
   }

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { X, Minimize2, Pin } from 'lucide-react'
 import { stripLeadingAgentTitleDecoration } from '../../../../shared/agent-title-decoration'
-import { useTabAgent } from '@/lib/use-tab-agent'
+import { isUnknownLiveTabAgent, useTabAgent } from '@/lib/use-tab-agent'
 import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { Input } from '@/components/ui/input'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -110,17 +110,24 @@ export default function SortableTab({
   // Why: shellOverride is stamped at create time, so changing the default shell later won't repaint existing tabs.
   const shellForIcon = tab.shellOverride
 
-  // Why: use hook status + title evidence so the icon reflects the harness running now, not just the launch command.
-  const tabAgent = useTabAgent(tab)
+  // Why: hook status and title evidence make the tab icon reflect the
+  // coding harness currently running in the pane, not just the launch command.
+  const tabIdentity = useTabAgent(tab)
+  // Split the identity: a recognized provider vs an unrecognized live (fork)
+  // agent rendered with a neutral glyph and named by its raw process name.
+  const tabAgent = isUnknownLiveTabAgent(tabIdentity) ? null : tabIdentity
+  const unknownLiveProcess = isUnknownLiveTabAgent(tabIdentity) ? tabIdentity.label : null
 
-  // Why: with a provider icon shown, strip the agent's own leading glyph so the tab doesn't show two icons for one agent.
+  // Why: when an identity icon is already shown, stripping the agent's own
+  // leading status glyph keeps the tab from presenting two icons for one agent.
   const displayTitle =
-    tab.customTitle ?? (tabAgent ? stripLeadingAgentTitleDecoration(tab.title) : tab.title)
+    tab.customTitle ?? (tabIdentity ? stripLeadingAgentTitleDecoration(tab.title) : tab.title)
 
   const { attributes, listeners, setNodeRef } = useSortable({
     id: tab.id,
-    // Why: carry the resolved agent into the drag overlay so dragged tabs keep the same glyph without another store lookup.
-    data: { ...dragData, agent: tabAgent }
+    // Why: carry the resolved identity into the drag overlay so dragged tabs keep
+    // the same glyph as the tab strip without another store lookup.
+    data: { ...dragData, agent: tabAgent, unknownLiveProcess }
   })
 
   // Why: no transform/transition/opacity so tabs stay anchored during drag, only the insertion bar moves (see TabBar.tsx).
@@ -266,6 +273,7 @@ export default function SortableTab({
       )}
       <TerminalTabLeadingIcon
         agent={tabAgent}
+        unknownLiveProcess={unknownLiveProcess}
         activityStatus={activityStatus}
         shell={shellForIcon}
         showUnreadActivity={showUnreadActivity}

--- a/src/renderer/src/components/tab-bar/TabDragPreview.tsx
+++ b/src/renderer/src/components/tab-bar/TabDragPreview.tsx
@@ -4,7 +4,8 @@ import { AgentIcon } from '@/lib/agent-catalog'
 import type { TabDragItemData } from '../tab-group/useTabDragSplit'
 
 // Why: a terminal tab running an agent leads with the provider glyph so the
-// ghost matches the resting tab; plain terminals keep the generic icon.
+// ghost matches the resting tab; an unrecognized live (fork) agent and plain
+// terminals both keep the generic terminal glyph.
 function LeadingIcon({ drag }: { drag: TabDragItemData }): React.JSX.Element {
   if (drag.tabType === 'browser') {
     return <Globe className="h-3.5 w-3.5 shrink-0" />
@@ -15,6 +16,9 @@ function LeadingIcon({ drag }: { drag: TabDragItemData }): React.JSX.Element {
   }
   if (drag.agent) {
     return <AgentIcon agent={drag.agent} size={14} />
+  }
+  if (drag.unknownLiveProcess) {
+    return <TerminalIcon className="h-3.5 w-3.5 shrink-0" aria-label={drag.unknownLiveProcess} />
   }
   return <TerminalIcon className="h-3.5 w-3.5 shrink-0" />
 }

--- a/src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.test.tsx
+++ b/src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.test.tsx
@@ -67,6 +67,43 @@ describe('TerminalTabLeadingIcon', () => {
     expect(markup).not.toContain('data-testid="tab-agent-activity-indicator"')
   })
 
+  it('renders a neutral process glyph with the raw name for an unknown-live agent', () => {
+    const markup = renderToStaticMarkup(
+      <TerminalTabLeadingIcon
+        agent={null}
+        unknownLiveProcess="my-fork"
+        activityStatus="working"
+        shell={undefined}
+        showUnreadActivity={false}
+        isActive={false}
+      />
+    )
+
+    // Neutral glyph beside the working dot, labeled by the raw process name —
+    // never a provider logo, never the colored shell tile.
+    expect(markup).toContain('data-unknown-live-process="my-fork"')
+    expect(markup).toContain('title="my-fork"')
+    expect(markup).toContain('lucide-terminal')
+    expect(markup).not.toContain('data-agent-icon')
+    expect(markup).not.toContain('data-shell-icon')
+  })
+
+  it('prefers a recognized provider glyph over the unknown-live fallback', () => {
+    const markup = renderToStaticMarkup(
+      <TerminalTabLeadingIcon
+        agent="codex"
+        unknownLiveProcess="my-fork"
+        activityStatus="active"
+        shell={undefined}
+        showUnreadActivity={false}
+        isActive={false}
+      />
+    )
+
+    expect(markup).toContain('data-agent-icon="codex"')
+    expect(markup).not.toContain('data-unknown-live-process')
+  })
+
   it('keeps the unread bell in the icon slot after an unvisited completion', () => {
     const markup = renderToStaticMarkup(
       <TerminalTabLeadingIcon

--- a/src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.tsx
+++ b/src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.tsx
@@ -1,3 +1,4 @@
+import { Terminal } from 'lucide-react'
 import { AgentStateDot, type AgentDotState } from '@/components/AgentStateDot'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { cn } from '@/lib/utils'
@@ -9,6 +10,9 @@ import { translate } from '@/i18n/i18n'
 
 type TerminalTabLeadingIconProps = {
   agent: TuiAgent | null
+  /** Raw process name of an unrecognized live (fork) agent, rendered with a
+   *  neutral glyph when no recognized `agent` is present. */
+  unknownLiveProcess?: string | null
   activityStatus: TerminalTabActivityStatus
   shell: TerminalTab['shellOverride']
   showUnreadActivity: boolean
@@ -59,14 +63,57 @@ function TerminalTabAgentIdentityIcon({
   )
 }
 
+/**
+ * Neutral identity for an unrecognized live (renamed/fork) agent: a generic
+ * lucide terminal/process glyph — never a vendor logo. The raw process name is
+ * the tooltip so the tab still names what is running.
+ */
+function UnknownLiveTabIcon({
+  label,
+  isActive,
+  className
+}: {
+  label: string
+  isActive: boolean
+  className?: string
+}): React.JSX.Element {
+  return (
+    <span
+      className={cn('inline-flex', !isActive && 'opacity-70', className)}
+      data-unknown-live-process={label}
+      title={label}
+    >
+      <Terminal className="size-3" aria-hidden />
+    </span>
+  )
+}
+
 /** Render a terminal tab's current state without hiding its agent or shell identity. */
 export function TerminalTabLeadingIcon({
   agent,
+  unknownLiveProcess,
   activityStatus,
   shell,
   showUnreadActivity,
   isActive
 }: TerminalTabLeadingIconProps): React.JSX.Element {
+  // The pane's identity glyph: recognized provider logo, else the neutral
+  // process glyph for an unrecognized live agent, else nothing (shell handled
+  // by the fallback below).
+  const identityGlyph = (className?: string): React.JSX.Element | null => {
+    if (agent) {
+      return (
+        <TerminalTabAgentIdentityIcon agent={agent} isActive={isActive} className={className} />
+      )
+    }
+    if (unknownLiveProcess) {
+      return (
+        <UnknownLiveTabIcon label={unknownLiveProcess} isActive={isActive} className={className} />
+      )
+    }
+    return null
+  }
+
   if (showUnreadActivity) {
     return (
       <span
@@ -78,7 +125,7 @@ export function TerminalTabLeadingIcon({
         className="mr-1 inline-flex shrink-0 items-center gap-1"
       >
         <FilledBellIcon className="size-3 text-amber-500 drop-shadow-sm" />
-        {agent ? <TerminalTabAgentIdentityIcon agent={agent} isActive={isActive} /> : null}
+        {identityGlyph()}
       </span>
     )
   }
@@ -94,15 +141,14 @@ export function TerminalTabLeadingIcon({
         <AgentStateDot state={dotState} size="md" />
         {/* Why: status and identity answer different questions. Keep the agent
             logo beside the state glyph so parallel tabs remain scannable. */}
-        {agent ? <TerminalTabAgentIdentityIcon agent={agent} isActive={isActive} /> : null}
+        {identityGlyph()}
       </span>
     )
   }
 
-  if (agent) {
-    return (
-      <TerminalTabAgentIdentityIcon agent={agent} isActive={isActive} className="mr-1 shrink-0" />
-    )
+  const standaloneIdentity = identityGlyph('mr-1 shrink-0')
+  if (standaloneIdentity) {
+    return standaloneIdentity
   }
 
   // Why: ShellIcon renders a colored brand-style tile for PowerShell, CMD,

--- a/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
+++ b/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
@@ -91,7 +91,11 @@ vi.mock('../../../../shared/agent-title-decoration', () => ({
 }))
 
 vi.mock('@/lib/use-tab-agent', () => ({
-  useTabAgent: () => mockTabAgent
+  useTabAgent: () => mockTabAgent,
+  isUnknownLiveTabAgent: (identity: unknown) =>
+    typeof identity === 'object' &&
+    identity !== null &&
+    (identity as { kind?: string }).kind === 'unknown-live'
 }))
 
 vi.mock('../../store', () => ({

--- a/src/renderer/src/components/tab-group/tab-drag-data.ts
+++ b/src/renderer/src/components/tab-group/tab-drag-data.ts
@@ -14,6 +14,9 @@ export type TabDragItemData = {
   iconPath?: string
   color?: string | null
   agent?: TuiAgent | null
+  /** Raw process name of an unrecognized live (fork) agent, so the drag ghost
+   *  shows the same neutral glyph as the resting tab. */
+  unknownLiveProcess?: string | null
 }
 
 export type TabPaneDropData = {

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
@@ -35,10 +35,8 @@ export type AgentCompletionCoordinatorOptions = {
     replacement: RecognizedAgentProcess
   ) => boolean
   shouldSuppressConfirmedProcessExitCompletion?: (exited: RecognizedAgentProcess) => boolean
-  // Why: each inspection that recognizes a foreground agent is fresh identity
-  // evidence; callers use it to keep TTL-gated attribution alive without
-  // adding scans of their own. `inspectedPtyId` is the PTY the inspection ran
-  // against, so evidence can be bound to it (the pane may rebind meanwhile).
+  // Why: existing inspections refresh attribution without added scans; include
+  // the inspected PTY so a concurrent pane rebind cannot inherit the evidence.
   onForegroundAgentInspected?: (process: RecognizedAgentProcess, inspectedPtyId: string) => void
   isLive: () => boolean
   shouldPollProcessCadence?: () => boolean

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
@@ -35,6 +35,10 @@ export type AgentCompletionCoordinatorOptions = {
     replacement: RecognizedAgentProcess
   ) => boolean
   shouldSuppressConfirmedProcessExitCompletion?: (exited: RecognizedAgentProcess) => boolean
+  // Why: each inspection that recognizes a foreground agent is fresh identity
+  // evidence; callers use it to keep TTL-gated attribution alive without
+  // adding scans of their own.
+  onForegroundAgentInspected?: (process: RecognizedAgentProcess) => void
   isLive: () => boolean
   shouldPollProcessCadence?: () => boolean
   // Why: on hosts where one inspection forks a whole-process-table scan (local

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
@@ -37,8 +37,9 @@ export type AgentCompletionCoordinatorOptions = {
   shouldSuppressConfirmedProcessExitCompletion?: (exited: RecognizedAgentProcess) => boolean
   // Why: each inspection that recognizes a foreground agent is fresh identity
   // evidence; callers use it to keep TTL-gated attribution alive without
-  // adding scans of their own.
-  onForegroundAgentInspected?: (process: RecognizedAgentProcess) => void
+  // adding scans of their own. `inspectedPtyId` is the PTY the inspection ran
+  // against, so evidence can be bound to it (the pane may rebind meanwhile).
+  onForegroundAgentInspected?: (process: RecognizedAgentProcess, inspectedPtyId: string) => void
   isLive: () => boolean
   shouldPollProcessCadence?: () => boolean
   // Why: on hosts where one inspection forks a whole-process-table scan (local

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -98,6 +98,40 @@ describe('agent completion coordinator', () => {
     expect(inspectProcess).toHaveBeenCalledTimes(1)
   })
 
+  // Why: consumers keep TTL-gated attribution fresh from these existing
+  // inspections; only recognized agents may be reported.
+  it('notifies onForegroundAgentInspected only for recognized inspections', async () => {
+    let foregroundProcess = 'codex'
+    const inspectProcess = vi.fn(async () => processResult(foregroundProcess))
+    const onForegroundAgentInspected = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess,
+      dispatchCompletion: vi.fn(),
+      isLive: () => true,
+      onForegroundAgentInspected
+    })
+
+    coordinator.startProcessTracking()
+    vi.advanceTimersByTime(2_000)
+    await flushAsyncTicks()
+
+    expect(onForegroundAgentInspected).toHaveBeenCalledWith({
+      agent: 'codex',
+      processName: 'codex'
+    })
+
+    onForegroundAgentInspected.mockClear()
+    foregroundProcess = 'vim'
+    vi.advanceTimersByTime(2_000)
+    await flushAsyncTicks()
+
+    expect(onForegroundAgentInspected).not.toHaveBeenCalled()
+    coordinator.dispose()
+  })
+
   // Why: regression guard for the hidden-pane throttle (follow-up to #6288 /
   // PR #6667). A hidden pane with a live agent kept polling the OS process
   // table at full 750ms cadence purely as a backstop, wasting idle CPU on

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -118,10 +118,13 @@ describe('agent completion coordinator', () => {
     vi.advanceTimersByTime(2_000)
     await flushAsyncTicks()
 
-    expect(onForegroundAgentInspected).toHaveBeenCalledWith({
-      agent: 'codex',
-      processName: 'codex'
-    })
+    expect(onForegroundAgentInspected).toHaveBeenCalledWith(
+      {
+        agent: 'codex',
+        processName: 'codex'
+      },
+      'pty-1'
+    )
 
     onForegroundAgentInspected.mockClear()
     foregroundProcess = 'vim'

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -481,6 +481,7 @@ export function createAgentCompletionCoordinator(
     consecutiveInspectionErrors = 0
     const recognized = recognizeAgentProcess(result.foregroundProcess)
     if (recognized) {
+      options.onForegroundAgentInspected?.(recognized)
       handleRecognizedProcess(recognized)
       return true
     }

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -470,7 +470,10 @@ export function createAgentCompletionCoordinator(
     establishAgentEvidence()
   }
 
-  function handleProcessInspectionResult(result: RuntimeTerminalProcessInspection): boolean {
+  function handleProcessInspectionResult(
+    result: RuntimeTerminalProcessInspection,
+    inspectedPtyId: string
+  ): boolean {
     if (result.unavailable === true) {
       // Why: unknown liveness breaks the consecutive-idle proof without erasing known agent ownership.
       pendingProcessExitAgent = null
@@ -481,7 +484,9 @@ export function createAgentCompletionCoordinator(
     consecutiveInspectionErrors = 0
     const recognized = recognizeAgentProcess(result.foregroundProcess)
     if (recognized) {
-      options.onForegroundAgentInspected?.(recognized)
+      // Why: pass the PTY the inspection actually ran against so consumers can
+      // bind the evidence — the pane may have rebound to a new PTY meanwhile.
+      options.onForegroundAgentInspected?.(recognized, inspectedPtyId)
       handleRecognizedProcess(recognized)
       return true
     }
@@ -554,7 +559,7 @@ export function createAgentCompletionCoordinator(
               !pendingTitle ||
               (priority === 'pending-title' && pendingTitle.id === pendingTitleIdAtRequest)
             if (appliesToCurrentPendingTitle) {
-              inspectedRecognizedAgent = handleProcessInspectionResult(result)
+              inspectedRecognizedAgent = handleProcessInspectionResult(result, ptyId)
             }
             inspectionSucceeded = true
           }

--- a/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.test.ts
+++ b/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.test.ts
@@ -228,7 +228,7 @@ describe('createPaneForegroundAgentTracker', () => {
     expect(publish).toHaveBeenLastCalledWith({ agent: 'claude', shellForeground: false })
   })
 
-  it('stops after the ladder and publishes no identity for a persistent unknown process', async () => {
+  it('carries the raw name for a persistent unknown non-shell process (unknown-live source)', async () => {
     readForegroundProcess.mockResolvedValue('some-unknown-tool')
     const tracker = makeTracker()
 
@@ -238,7 +238,13 @@ describe('createPaneForegroundAgentTracker', () => {
     )
 
     expect(readForegroundProcess).toHaveBeenCalledTimes(3)
-    expect(publish).toHaveBeenLastCalledWith({ agent: null, shellForeground: false })
+    // Why: no recognized engine, but the live non-shell name is carried so the
+    // renderer can show a neutral live identity instead of a bare shell.
+    expect(publish).toHaveBeenLastCalledWith({
+      agent: null,
+      shellForeground: false,
+      rawProcessName: 'some-unknown-tool'
+    })
   })
 
   it('does not treat a nested shell seen mid-command as prompt proof', async () => {

--- a/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.ts
+++ b/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.ts
@@ -1,7 +1,5 @@
-import {
-  isAgentForegroundWrapperProcess,
-  recognizeAgentProcess
-} from '../../../../shared/agent-process-recognition'
+import { isAgentForegroundWrapperProcess } from '../../../../shared/agent-process-recognition'
+import { resolveForegroundProcess } from '../../../../shared/foreground-process-resolution'
 import { isShellProcess } from '../../../../shared/shell-process-detection'
 import type { TuiAgent } from '../../../../shared/types'
 import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
@@ -124,12 +122,20 @@ export function createPaneForegroundAgentTracker(deps: PaneForegroundAgentTracke
     if (disposed || generation !== readGeneration || trackablePtyId() !== ptyId) {
       return
     }
-    const recognized = recognizeAgentProcess(processName)
-    if (recognized) {
+    // Why: the structured resolution splits the read into engine (recognized
+    // agent) and an unknown-live raw name — a live, non-shell foreground with no
+    // recognized engine. Only that raw name is carried on the entry, so the
+    // renderer can show a neutral live identity instead of collapsing it to a
+    // bare shell. Recognized agents already publish their engine; shells need no
+    // raw name (the consumer rejects them).
+    const resolution = resolveForegroundProcess(processName)
+    const unknownLiveRawName =
+      !resolution.engine && !resolution.isShell ? resolution.rawProcessName : null
+    if (resolution.engine) {
       hasForegroundAgentEvidence = true
       hasAgentExpectation = false
       deps.publish({
-        agent: recognized.agent,
+        agent: resolution.engine,
         shellForeground: false,
         ...(requiresRoutingConfirmation ? { routingTrusted: true } : {})
       })
@@ -160,7 +166,14 @@ export function createPaneForegroundAgentTracker(deps: PaneForegroundAgentTracke
     }
     if (reason === 'command') {
       hasAgentExpectation = false
-      deps.publish({ agent: null, shellForeground: false })
+      // Why: an unrecognized but live non-shell foreground (a renamed/fork
+      // agent) reaches here after the retry ladder — carry its raw name so the
+      // renderer can render a neutral live identity for it.
+      deps.publish({
+        agent: null,
+        shellForeground: false,
+        ...(unknownLiveRawName !== null ? { rawProcessName: unknownLiveRawName } : {})
+      })
       return
     }
     if (reason === 'visible-pty') {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -250,6 +250,7 @@ type StoreState = {
   dropAgentStatus: ReturnType<typeof vi.fn>
   retireAgentPaneAuthority: ReturnType<typeof vi.fn>
   setPaneForegroundAgent: ReturnType<typeof vi.fn>
+  refreshPaneForegroundAgentObservation: ReturnType<typeof vi.fn>
   clearPaneForegroundAgent: ReturnType<typeof vi.fn>
   markTerminalTabUnread: ReturnType<typeof vi.fn>
   markTerminalPaneUnread: ReturnType<typeof vi.fn>
@@ -979,6 +980,9 @@ describe('connectPanePty', () => {
       setPaneForegroundAgent: vi.fn((paneKey: string, entry: PaneForegroundAgentEntry) => {
         mockStoreState.paneForegroundAgentByPaneKey[paneKey] = entry
       }),
+      // Why: observation bumps only touch observedAt; keeping this a no-op keeps
+      // the exact entry assertions below about publish payloads, not freshness.
+      refreshPaneForegroundAgentObservation: vi.fn(),
       clearPaneForegroundAgent: vi.fn((paneKey: string) => {
         delete mockStoreState.paneForegroundAgentByPaneKey[paneKey]
       }),
@@ -7007,6 +7011,7 @@ describe('connectPanePty', () => {
     expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('alt-enter')
     await vi.advanceTimersByTimeAsync(1200)
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: 'droid',
       routingTrusted: true,
       shellForeground: false
@@ -7038,6 +7043,7 @@ describe('connectPanePty', () => {
 
     expect(window.api.pty.confirmForegroundProcess).toHaveBeenCalledWith(ptyId)
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: 'droid',
       routingTrusted: true,
       shellForeground: false
@@ -7078,6 +7084,7 @@ describe('connectPanePty', () => {
 
     expect(window.api.pty.confirmForegroundProcess).toHaveBeenCalledWith(ptyId)
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: 'droid',
       routingTrusted: true,
       shellForeground: false
@@ -7114,6 +7121,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks()
 
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: 'droid',
       routingTrusted: true,
       shellForeground: false
@@ -7148,6 +7156,7 @@ describe('connectPanePty', () => {
 
     // Benign miss: shell never latched as foreground; encoding still safe fallback.
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: null,
       shellForeground: false
     })
@@ -7160,6 +7169,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks()
 
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: 'droid',
       routingTrusted: true,
       shellForeground: false
@@ -7190,6 +7200,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks()
 
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: 'droid',
       routingRevoked: true,
       shellForeground: false
@@ -7199,6 +7210,7 @@ describe('connectPanePty', () => {
     await vi.advanceTimersByTimeAsync(350 + 1200 + 6000)
 
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: null,
       shellForeground: true
     })
@@ -7339,6 +7351,7 @@ describe('connectPanePty', () => {
       dataCallbackRef.current?.('\x1b]133;C\x07')
 
       expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+        ptyId,
         agent: null,
         shellForeground: false
       })
@@ -7427,6 +7440,7 @@ describe('connectPanePty', () => {
     expect(getForegroundProcess).toHaveBeenCalledTimes(readsBeforeFinish + 1)
     expect(mockStoreState.clearAgentLaunchConfig).not.toHaveBeenCalled()
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: 'droid',
       routingTrusted: true,
       shellForeground: false
@@ -7467,6 +7481,7 @@ describe('connectPanePty', () => {
     await vi.advanceTimersByTimeAsync(350)
     expect(mockStoreState.clearAgentLaunchConfig).toHaveBeenCalledExactlyOnceWith(paneKey)
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: null,
       shellForeground: true
     })
@@ -7590,6 +7605,7 @@ describe('connectPanePty', () => {
 
     expect(mockStoreState.clearAgentLaunchConfig).toHaveBeenCalledExactlyOnceWith(paneKey)
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: null,
       shellForeground: false
     })
@@ -19841,6 +19857,12 @@ describe('connectPanePty', () => {
       paneKey: makePaneKey('tab-1', LEAF_1)
     })
     expect(window.api.pty.inspectProcess).toHaveBeenCalledWith('pty-codex')
+    // Why: recognized inspections must also keep the pane's process-identity
+    // observation fresh for TTL-gated sidebar attribution (no new scans).
+    expect(mockStoreState.refreshPaneForegroundAgentObservation).toHaveBeenCalledWith(
+      makePaneKey('tab-1', LEAF_1),
+      'codex'
+    )
   })
 
   it('does not dispatch generic spinner completions when process inspection finds no agent', async () => {
@@ -23460,6 +23482,7 @@ describe('connectPanePty', () => {
 
       expect(foregroundReadCallsFor(ptyId)).toEqual([[ptyId]])
       expect(mockStoreState.setPaneForegroundAgent).toHaveBeenCalledWith(cacheKey, {
+        ptyId,
         agent: 'codex',
         shellForeground: false
       })
@@ -23544,6 +23567,7 @@ describe('connectPanePty', () => {
 
       await vi.advanceTimersByTimeAsync(1)
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        ptyId,
         agent: 'droid',
         routingRevoked: true,
         shellForeground: false
@@ -23553,6 +23577,7 @@ describe('connectPanePty', () => {
       await flushAsyncTicks()
       expect(window.api.pty.confirmForegroundProcess).toHaveBeenCalledWith(ptyId)
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        ptyId,
         agent: 'droid',
         routingTrusted: true,
         shellForeground: false
@@ -23562,6 +23587,7 @@ describe('connectPanePty', () => {
       await vi.advanceTimersByTimeAsync(700)
       await flushAsyncTicks()
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        ptyId,
         agent: 'droid',
         routingTrusted: true,
         shellForeground: false
@@ -23634,6 +23660,7 @@ describe('connectPanePty', () => {
       })
       expect(mockStoreState.registerAgentLaunchConfig).not.toHaveBeenCalled()
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        ptyId,
         agent: 'droid',
         shellForeground: false
       })
@@ -23642,6 +23669,7 @@ describe('connectPanePty', () => {
       await advanceVisibleForegroundRead()
 
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        ptyId,
         agent: 'droid',
         routingTrusted: true,
         shellForeground: false
@@ -23673,6 +23701,7 @@ describe('connectPanePty', () => {
         vi.mocked(window.api.pty.confirmForegroundProcess).mock.calls.length
       ).toBeGreaterThanOrEqual(3)
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        ptyId,
         agent: null,
         shellForeground: true
       })
@@ -23761,6 +23790,7 @@ describe('connectPanePty', () => {
 
       expect(foregroundReadCallsFor(ptyId).length).toBeGreaterThanOrEqual(3)
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        ptyId,
         agent: null,
         shellForeground: true
       })
@@ -23889,6 +23919,7 @@ describe('connectPanePty', () => {
       await advanceVisibleForegroundRead()
 
       expect(mockStoreState.setPaneForegroundAgent).toHaveBeenCalledWith(cacheKey, {
+        ptyId,
         agent: null,
         shellForeground: true
       })
@@ -23934,10 +23965,12 @@ describe('connectPanePty', () => {
 
       expect(foregroundReadCallsFor(ptyId)).toEqual([[ptyId]])
       expect(mockStoreState.setPaneForegroundAgent).not.toHaveBeenCalledWith(cacheKey, {
+        ptyId,
         agent: null,
         shellForeground: true
       })
       expect(mockStoreState.setPaneForegroundAgent).toHaveBeenCalledWith(cacheKey, {
+        ptyId,
         agent: 'droid',
         routingTrusted: true,
         shellForeground: false

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -19858,10 +19858,12 @@ describe('connectPanePty', () => {
     })
     expect(window.api.pty.inspectProcess).toHaveBeenCalledWith('pty-codex')
     // Why: recognized inspections must also keep the pane's process-identity
-    // observation fresh for TTL-gated sidebar attribution (no new scans).
+    // observation fresh for TTL-gated sidebar attribution (no new scans), and
+    // must bind the evidence to the PTY the inspection ran against.
     expect(mockStoreState.refreshPaneForegroundAgentObservation).toHaveBeenCalledWith(
       makePaneKey('tab-1', LEAF_1),
-      'codex'
+      'codex',
+      'pty-codex'
     )
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -7262,6 +7262,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks()
 
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      ptyId,
       agent: null,
       shellForeground: true
     })
@@ -23615,6 +23616,7 @@ describe('connectPanePty', () => {
       binding.sampleForegroundAgentOnFocus()
 
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        ptyId,
         agent: 'pi',
         routingRevoked: true,
         shellForeground: false
@@ -23626,6 +23628,7 @@ describe('connectPanePty', () => {
       )
       await flushAsyncTicks()
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        ptyId,
         agent: null,
         shellForeground: true
       })

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2214,7 +2214,7 @@ export function connectPanePty(
     // Why: cmd.exe and Git Bash have no OSC command boundaries. Keep the icon
     // as a hint, but revoke bytes until one current provider confirmation lands.
     useAppStore.getState().setPaneForegroundAgent(cacheKey, {
-agent: foreground.agent,
+      agent: foreground.agent,
       routingRevoked: true,
       shellForeground: false,
       ptyId: transport.getPtyId() ?? undefined

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1316,7 +1316,8 @@ export function connectPanePty(
         // closed. Use it to request confirmation, never as current byte authority.
         useAppStore.getState().setPaneForegroundAgent(cacheKey, {
           agent: metadata.launchAgent,
-          shellForeground: false
+          shellForeground: false,
+          ptyId: transport.getPtyId() ?? undefined
         })
       }
       return
@@ -2096,7 +2097,13 @@ export function connectPanePty(
     isTrackablePtyId: isForegroundTrackingAllowed,
     readForegroundProcess: (id) => window.api.pty.getForegroundProcess(id),
     confirmForegroundProcess: (id) => window.api.pty.confirmForegroundProcess(id),
-    publish: (entry) => useAppStore.getState().setPaneForegroundAgent(cacheKey, entry),
+    // Why: bind the evidence to the PTY it was read from — the tracker skips
+    // publishes across rebinds, so the current transport PTY is that PTY.
+    publish: (entry) =>
+      useAppStore.getState().setPaneForegroundAgent(cacheKey, {
+        ...entry,
+        ptyId: transport.getPtyId() ?? undefined
+      }),
     hasKnownAgentIdentity: paneHasKnownAgentIdentity,
     onConfirmedShellForeground: (reason) => {
       clearStaleAgentTabTitleOnConfirmedShell()
@@ -2207,9 +2214,10 @@ export function connectPanePty(
     // Why: cmd.exe and Git Bash have no OSC command boundaries. Keep the icon
     // as a hint, but revoke bytes until one current provider confirmation lands.
     useAppStore.getState().setPaneForegroundAgent(cacheKey, {
-      agent: foreground.agent,
+agent: foreground.agent,
       routingRevoked: true,
-      shellForeground: false
+      shellForeground: false,
+      ptyId: transport.getPtyId() ?? undefined
     })
     visibleForegroundSamplePending = false
     visibleForegroundSampleSettled = false
@@ -2397,6 +2405,15 @@ export function connectPanePty(
       return (
         isFreshNonDoneAgentStatus(currentStatus) && currentAgentForReplacement === replacement.agent
       )
+    },
+    onForegroundAgentInspected: (process) => {
+      const inspectedPtyId = transport.getPtyId()
+      // Why: same local-only gate as the tracker — remote/WSL inspections must
+      // not become renderer process evidence for this pane.
+      if (!inspectedPtyId || !isForegroundTrackingAllowed(inspectedPtyId)) {
+        return
+      }
+      useAppStore.getState().refreshPaneForegroundAgentObservation(cacheKey, process.agent)
     },
     shouldSuppressConfirmedProcessExitCompletion: (exited) => {
       const currentStatus = useAppStore.getState().agentStatusByPaneKey[cacheKey]

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2406,14 +2406,16 @@ agent: foreground.agent,
         isFreshNonDoneAgentStatus(currentStatus) && currentAgentForReplacement === replacement.agent
       )
     },
-    onForegroundAgentInspected: (process) => {
-      const inspectedPtyId = transport.getPtyId()
+    onForegroundAgentInspected: (process, inspectedPtyId) => {
       // Why: same local-only gate as the tracker — remote/WSL inspections must
-      // not become renderer process evidence for this pane.
-      if (!inspectedPtyId || !isForegroundTrackingAllowed(inspectedPtyId)) {
+      // not become renderer process evidence for this pane — and an inspection
+      // of a PTY the pane no longer owns (respawn race) must not either.
+      if (!isForegroundTrackingAllowed(inspectedPtyId) || transport.getPtyId() !== inspectedPtyId) {
         return
       }
-      useAppStore.getState().refreshPaneForegroundAgentObservation(cacheKey, process.agent)
+      useAppStore
+        .getState()
+        .refreshPaneForegroundAgentObservation(cacheKey, process.agent, inspectedPtyId)
     },
     shouldSuppressConfirmedProcessExitCompletion: (exited) => {
       const currentStatus = useAppStore.getState().agentStatusByPaneKey[cacheKey]

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2407,9 +2407,8 @@ agent: foreground.agent,
       )
     },
     onForegroundAgentInspected: (process, inspectedPtyId) => {
-      // Why: same local-only gate as the tracker — remote/WSL inspections must
-      // not become renderer process evidence for this pane — and an inspection
-      // of a PTY the pane no longer owns (respawn race) must not either.
+      // Why: only local evidence for the pane's current PTY may refresh identity;
+      // remote/WSL or pre-respawn results cannot bind to this pane.
       if (!isForegroundTrackingAllowed(inspectedPtyId) || transport.getPtyId() !== inspectedPtyId) {
         return
       }

--- a/src/renderer/src/lib/use-tab-agent-process-signals.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-process-signals.test.ts
@@ -6,17 +6,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAppStore } from '@/store'
 import { makePaneKey } from '../../../shared/stable-pane-id'
 import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
-import type { TerminalTab, TuiAgent } from '../../../shared/types'
+import type { TerminalTab } from '../../../shared/types'
 import {
   resolveLaunchedAgentExitEvidence,
   resolveTabAgentFromSignals,
-  useTabAgent
+  useTabAgent,
+  type TabAgentIdentity
 } from './use-tab-agent'
 
 const initialAppState = useAppStore.getInitialState()
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
 const PANE_KEY = makePaneKey('tab-1', LEAF_ID)
-let latestHookAgent: TuiAgent | null | undefined
+let latestHookAgent: TabAgentIdentity | undefined
 const hookRoots: Root[] = []
 
 function HookProbe({ tab }: { tab: TerminalTab }): null {
@@ -128,6 +129,47 @@ describe('resolveTabAgentFromSignals process identity', () => {
   })
 })
 
+describe('resolveTabAgentFromSignals unknown-live identity', () => {
+  it('returns a neutral unknown-live identity for a live fork process with a working title', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: '⠸ my-fork building',
+        hookAgent: null,
+        processAgent: null,
+        unknownLiveProcessName: 'my-fork'
+      })
+    ).toEqual({ kind: 'unknown-live', label: 'my-fork' })
+  })
+
+  it('stays null for the same fork process without title activity (the vim/htop case)', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: 'my-fork ~/README.md',
+        hookAgent: null,
+        processAgent: null,
+        unknownLiveProcessName: 'my-fork'
+      })
+    ).toBeNull()
+  })
+
+  it('lets any recognized engine layer outrank the unknown-live fallback', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: '⠸ my-fork building',
+        hookAgent: 'claude',
+        processAgent: null,
+        unknownLiveProcessName: 'my-fork'
+      })
+    ).toBe('claude')
+  })
+})
+
 describe('resolveLaunchedAgentExitEvidence shell-foreground gate', () => {
   const baseArgs = {
     title: '✳ Claude Code',
@@ -224,5 +266,64 @@ describe('useTabAgent process signals', () => {
 
     expect(latestHookAgent).toBe('aider')
     expect(clearTabLaunchAgent).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a neutral unknown-live identity for a live fork process with a working title', async () => {
+    const forkTab = { ...baseTab, title: '⠸ my-fork building' }
+    await renderHookProbe(forkTab)
+
+    await setPaneForeground({
+      agent: null,
+      rawProcessName: 'my-fork',
+      shellForeground: false,
+      ptyId: 'pty-1'
+    })
+
+    expect(latestHookAgent).toEqual({ kind: 'unknown-live', label: 'my-fork' })
+  })
+
+  it('stays null for a full-screen TUI (vim) that reports a static, activity-free title', async () => {
+    const editorTab = { ...baseTab, title: 'vim README.md' }
+    await renderHookProbe(editorTab)
+
+    await setPaneForeground({
+      agent: null,
+      rawProcessName: 'vim',
+      shellForeground: false,
+      ptyId: 'pty-1'
+    })
+
+    expect(latestHookAgent).toBeNull()
+  })
+
+  it('ignores a shell raw process name even with a working title', async () => {
+    const forkTab = { ...baseTab, title: '⠸ working' }
+    await renderHookProbe(forkTab)
+
+    await setPaneForeground({
+      agent: null,
+      rawProcessName: 'zsh',
+      shellForeground: false,
+      ptyId: 'pty-1'
+    })
+
+    expect(latestHookAgent).toBeNull()
+  })
+
+  it('drops the unknown-live identity once its evidence is stale', async () => {
+    const forkTab = { ...baseTab, title: '⠸ my-fork building' }
+    await renderHookProbe(forkTab)
+
+    // Why: observedAt is preserved by the slice, so an ancient timestamp
+    // simulates evidence that fell outside the freshness TTL.
+    await setPaneForeground({
+      agent: null,
+      rawProcessName: 'my-fork',
+      shellForeground: false,
+      ptyId: 'pty-1',
+      observedAt: 1
+    })
+
+    expect(latestHookAgent).toBeNull()
   })
 })

--- a/src/renderer/src/lib/use-tab-agent-sleeping-session.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-sleeping-session.test.ts
@@ -9,12 +9,12 @@ import type {
   SleepingAgentSessionRecord
 } from '../../../shared/agent-session-resume'
 import { makePaneKey } from '../../../shared/stable-pane-id'
-import type { TerminalTab, TuiAgent } from '../../../shared/types'
-import { resolveTabAgentFromSignals, useTabAgent } from './use-tab-agent'
+import type { TerminalTab } from '../../../shared/types'
+import { resolveTabAgentFromSignals, useTabAgent, type TabAgentIdentity } from './use-tab-agent'
 
 const initialAppState = useAppStore.getInitialState()
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
-let latestHookAgent: TuiAgent | null | undefined
+let latestHookAgent: TabAgentIdentity | undefined
 const hookRoots: Root[] = []
 
 function HookProbe({ tab }: { tab: TerminalTab }): null {

--- a/src/renderer/src/lib/use-tab-agent.test.ts
+++ b/src/renderer/src/lib/use-tab-agent.test.ts
@@ -6,13 +6,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAppStore } from '@/store'
 import type { AgentStatusEntry } from '../../../shared/agent-status-types'
 import { makePaneKey } from '../../../shared/stable-pane-id'
-import type { TerminalLayoutSnapshot, TerminalTab, TuiAgent } from '../../../shared/types'
-import { resolveTabAgentFromSignals, useTabAgent } from './use-tab-agent'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../shared/types'
+import { resolveTabAgentFromSignals, useTabAgent, type TabAgentIdentity } from './use-tab-agent'
 
 const initialAppState = useAppStore.getInitialState()
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
 const SECOND_LEAF_ID = '22222222-2222-4222-8222-222222222222'
-let latestHookAgent: TuiAgent | null | undefined
+let latestHookAgent: TabAgentIdentity | undefined
 const hookRoots: Root[] = []
 
 function HookProbe({ tab }: { tab: TerminalTab }): null {

--- a/src/renderer/src/lib/use-tab-agent.ts
+++ b/src/renderer/src/lib/use-tab-agent.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
-import { isShellProcess } from '../../../shared/agent-detection'
+import { detectAgentStatusFromTitle, isShellProcess } from '../../../shared/agent-detection'
+import { resolveFreshPaneForegroundRawProcess } from '@/store/slices/pane-foreground-agent'
 import { worktreeUsesRemoteConnection } from '@/store/slices/terminals'
 import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
 import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
@@ -18,10 +19,30 @@ import { isOpenCodeNativeTitle } from '../../../shared/opencode-terminal-title'
 import { resolvePaneAgentOwner } from '../../../shared/pane-agent-owner'
 import type { TerminalTab, TuiAgent } from '../../../shared/types'
 
-// A shell name or the tab's neutral default title (where inferred-interrupt reset parks it); blank titles are no evidence.
+/** Neutral live identity for an unrecognized (renamed/fork) foreground agent —
+ *  never a fake TuiAgent, never a vendor name; the label is the raw process name. */
+export type UnknownLiveTabAgent = { kind: 'unknown-live'; label: string }
+/** A tab's resolved leading-icon identity. */
+export type TabAgentIdentity = TuiAgent | UnknownLiveTabAgent | null
+
+export function isUnknownLiveTabAgent(identity: TabAgentIdentity): identity is UnknownLiveTabAgent {
+  return typeof identity === 'object' && identity !== null && identity.kind === 'unknown-live'
+}
+
+// A shell name, or the tab's neutral default title — where Orca's
+// inferred-interrupt reset parks it. Blank titles are no evidence either way.
 function titleShowsNoAgent(title: string, defaultTitle?: string): boolean {
   const trimmed = title.trim()
   return trimmed.length > 0 && (isShellProcess(trimmed) || trimmed === defaultTitle?.trim())
+}
+
+// Why: a live spinner/working (or needs-input) title is what separates a fork
+// coding-agent from a plain full-screen TUI — vim and htop set static titles
+// that classify to no activity, so requiring it keeps text editors from ever
+// gaining agent presence.
+function titleShowsAgentActivity(title: string): boolean {
+  const status = detectAgentStatusFromTitle(title)
+  return status === 'working' || status === 'permission'
 }
 
 /**
@@ -79,7 +100,11 @@ export function resolveTabAgentFromSignals(args: {
   processShellForeground?: boolean
   sleepingSessionAgent?: TuiAgent | null
   launchAgent?: TuiAgent
-}): TuiAgent | null {
+  /** Fresh, non-shell raw foreground-process name with no recognized engine —
+   *  already TTL/PTY-gated by the caller. Only becomes the unknown-live identity
+   *  when the pane also shows title activity. */
+  unknownLiveProcessName?: string | null
+}): TabAgentIdentity {
   const launchAgent = args.launchAgent ?? null
   // Durable focused-pane owner (launch intent → hook → session); focused-pane-scoped so a sibling can't re-own the focused title (would mislabel a Pi pane as OMP).
   const owner = resolvePaneAgentOwner({
@@ -147,7 +172,15 @@ export function resolveTabAgentFromSignals(args: {
   const activeLaunchAgent = launchedAgentExited ? null : launchAgent
   // Why: re-own the foreground process within its title-identity group so OMP's nested pi (shell → omp → pi) can't flip an OMP-owned tab's icon.
   const processAgent = resolveSignalAgentForLaunchOwner(args.processAgent, owner)
-  // Identity-first precedence (see JSDoc): live hook > process > title > completed > sleeping > launch > sibling.
+  // Why: last-resort neutral identity — an unrecognized but live non-shell
+  // foreground (a renamed/fork agent) that is also actively working. It sits
+  // below every recognized layer, so any recognized engine still wins; the
+  // title-activity gate is what keeps a plain editor (vim/htop) from qualifying.
+  const unknownLiveIdentity: UnknownLiveTabAgent | null =
+    args.unknownLiveProcessName && titleShowsAgentActivity(args.title)
+      ? { kind: 'unknown-live', label: args.unknownLiveProcessName }
+      : null
+  // Identity-first precedence (see JSDoc): live hook > process > title > completed > sleeping > launch > sibling > unknown-live.
   return (
     liveFocusedIdentity ??
     processAgent ??
@@ -156,7 +189,8 @@ export function resolveTabAgentFromSignals(args: {
     sleepingSessionAgent ??
     activeLaunchAgent ??
     liveSiblingIdentity ??
-    idleSiblingIdentity
+    idleSiblingIdentity ??
+    unknownLiveIdentity
   )
 }
 
@@ -173,8 +207,11 @@ export function resolveTabAgentFromSignals(args: {
  * 5. Sleeping session identity — current provider-session ownership.
  * 6. launchAgent — bootstrap before any hook/process signal; cleared once exit evidence shows it left.
  * 7. Sibling-pane identity (live, then completed/retained) — split-tab fallback.
+ * 8. Unknown-live identity — a neutral, process-named live identity for an
+ *    unrecognized non-shell foreground that is actively working. Last resort,
+ *    below every recognized layer; runtime-only, never persisted.
  */
-export function useTabAgent(tab: TerminalTab): TuiAgent | null {
+export function useTabAgent(tab: TerminalTab): TabAgentIdentity {
   const focusedHookAgent = useAppStore((s) =>
     resolveFocusedTabAgent(s.agentStatusByPaneKey, s.terminalLayoutsByTabId[tab.id], tab.id)
   )
@@ -221,7 +258,14 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
       ? Boolean(s.paneForegroundAgentByPaneKey[focusedPaneKey]?.shellForeground)
       : false
   )
-  // Why: a hibernated pane's session record is the freshest identity once PTY, hook, and process signals are all gone.
+  // Why: the whole entry is needed to TTL/PTY-gate the unknown-live raw name;
+  // the reference is stable between publishes so it does not add churn.
+  const foregroundEvidence = useAppStore((s) =>
+    focusedPaneKey ? (s.paneForegroundAgentByPaneKey[focusedPaneKey] ?? null) : null
+  )
+  // Why: a hibernated pane's persisted session record is pane-scoped evidence of
+  // which agent actually ran here — the freshest identity once the PTY, hook,
+  // and process signals are all gone, and proof a stale launchAgent was reused.
   const sleepingSessionAgent = useAppStore((s) =>
     focusedPaneKey ? (s.sleepingAgentSessionsByPaneKey[focusedPaneKey]?.agent ?? null) : null
   )
@@ -324,6 +368,16 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
     tab.title
   ])
 
+  // Why: gate the unknown-live raw name through the same TTL/PTY freshness as the
+  // recognized agent read. Local only — remote panes produce no foreground
+  // process evidence — so the gate short-circuits there.
+  const unknownLiveProcessName = isRemoteLike
+    ? null
+    : resolveFreshPaneForegroundRawProcess(foregroundEvidence ?? undefined, {
+        now: Date.now(),
+        paneBoundPtyId: ptyId ?? undefined
+      })
+
   return resolveTabAgentFromSignals({
     hasObservedAgentSignal,
     isRemote: isRemoteLike,
@@ -336,6 +390,7 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
     processAgent,
     processShellForeground,
     sleepingSessionAgent,
-    launchAgent: tab.launchAgent
+    launchAgent: tab.launchAgent,
+    unknownLiveProcessName
   })
 }

--- a/src/renderer/src/lib/worktree-status.test.ts
+++ b/src/renderer/src/lib/worktree-status.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest'
+import { PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS } from '@/store/slices/pane-foreground-agent'
+import { makePaneKey } from '../../../shared/stable-pane-id'
 import type { TerminalLayoutSnapshot } from '../../../shared/types'
 import { getWorktreeStatus, getWorktreeStatusLabel, resolveWorktreeStatus } from './worktree-status'
 
@@ -137,6 +139,97 @@ describe('getWorktreeStatus', () => {
     )
 
     expect(status).toBe('working')
+  })
+
+  // Why: wrapper-launched claude emits activity titles without the "claude"
+  // token; fresh process-table identity supplies the attribution the token
+  // gate would otherwise demand — state still comes from the title.
+  describe('process-identity attribution', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID_1)
+    const soleLeafRoot = { type: 'leaf', leafId: LEAF_ID_1 } as const
+    const freshEntry = {
+      agent: 'claude',
+      shellForeground: false,
+      observedAt: 9_500,
+      ptyId: 'pty-claude'
+    } as const
+
+    it('spins on an unattributable working tab title when fresh process identity names claude', () => {
+      const status = getWorktreeStatus(
+        [{ id: 'tab-1', title: '⠐ Review branch for regressions' }],
+        [],
+        { 'tab-1': ['pty-claude'] },
+        {},
+        {
+          terminalLayoutRootsByTabId: { 'tab-1': soleLeafRoot },
+          paneForegroundAgentByPaneKey: { [paneKey]: freshEntry },
+          now: 10_000
+        }
+      )
+
+      expect(status).toBe('working')
+    })
+
+    it('spins on an unattributable working pane title when fresh process identity names claude', () => {
+      const status = getWorktreeStatus(
+        [{ id: 'tab-1', title: 'bash' }],
+        [],
+        { 'tab-1': ['pty-claude'] },
+        { 'tab-1': { 1: '⠐ Review branch for regressions' } },
+        {
+          terminalLayoutRootsByTabId: { 'tab-1': soleLeafRoot },
+          paneForegroundAgentByPaneKey: { [paneKey]: freshEntry },
+          now: 10_000
+        }
+      )
+
+      expect(status).toBe('working')
+    })
+
+    it('does not spin on stale (past-TTL) process evidence', () => {
+      const now = 10_000 + PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS
+      const status = getWorktreeStatus(
+        [{ id: 'tab-1', title: '⠐ Review branch for regressions' }],
+        [],
+        { 'tab-1': ['pty-claude'] },
+        {},
+        {
+          terminalLayoutRootsByTabId: { 'tab-1': soleLeafRoot },
+          paneForegroundAgentByPaneKey: {
+            [paneKey]: {
+              ...freshEntry,
+              observedAt: now - PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS - 1
+            }
+          },
+          now
+        }
+      )
+
+      expect(status).toBe('active')
+    })
+
+    it('does not spin when the pane is bound to a different live PTY than the evidence', () => {
+      const status = getWorktreeStatus(
+        [{ id: 'tab-1', title: '⠐ Review branch for regressions' }],
+        [],
+        { 'tab-1': ['pty-respawned'] },
+        {},
+        {
+          terminalLayoutsByTabId: {
+            'tab-1': {
+              root: soleLeafRoot,
+              activeLeafId: LEAF_ID_1,
+              expandedLeafId: null,
+              ptyIdsByLeafId: { [LEAF_ID_1]: 'pty-respawned' }
+            }
+          },
+          paneForegroundAgentByPaneKey: { [paneKey]: freshEntry },
+          now: 10_000
+        }
+      )
+
+      expect(status).toBe('active')
+    })
   })
 })
 

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -1,8 +1,12 @@
-import { resolveAgentTypeFromTerminalTitle } from '@/components/sidebar/worktree-title-derived-agent-rows'
+import {
+  freshProcessAgentForLeaf,
+  resolveAgentTypeFromTerminalTitle
+} from '@/components/sidebar/worktree-title-derived-agent-rows'
 import { classifyTitleActivity } from '@/lib/pane-agent-evidence'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import { resolveRuntimePaneTitleLeafIdFromRoot } from '@/lib/runtime-pane-title-leaf-id'
 import { containsBrailleSpinner } from '../../../shared/agent-title-core'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 import type {
   TerminalLayoutSnapshot,
   TerminalPaneLayoutNode,
@@ -18,6 +22,8 @@ type WorktreeStatusHeuristicOptions = {
   agentStatusPaneIdsByTabId?: Record<string, ReadonlySet<string>>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   terminalLayoutRootsByTabId?: Record<string, TerminalPaneLayoutNode | null | undefined>
+  paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
+  now?: number
 }
 
 const STATUS_LABELS: Record<WorktreeStatus, string> = {
@@ -40,7 +46,9 @@ export function getWorktreeStatus(
 
   // Why: tab.title tracks only the most-recently-focused pane (onActivePaneChange in use-terminal-pane-lifecycle.ts); consult per-pane titles so the spinner reflects aggregate tab state.
   const hasStatus = (status: 'permission' | 'working'): boolean =>
-    liveTabs.some((tab) => tabHasStatus(tab, runtimePaneTitlesByTabId, status, options))
+    liveTabs.some((tab) =>
+      tabHasStatus(tab, runtimePaneTitlesByTabId, status, options, ptyIdsByTabId)
+    )
 
   if (options.liveAgentStatus === 'permission' || hasStatus('permission')) {
     return 'permission'
@@ -59,9 +67,21 @@ function tabHasStatus(
   tab: Pick<TerminalTab, 'id' | 'title' | 'launchAgent'>,
   runtimePaneTitlesByTabId: Record<string, Record<number, string>>,
   status: 'permission' | 'working',
-  options: WorktreeStatusHeuristicOptions
+  options: WorktreeStatusHeuristicOptions,
+  ptyIdsByTabId: Record<string, string[]>
 ): boolean {
   const agentStatusPaneIds = options.agentStatusPaneIdsByTabId?.[tab.id]
+  const processAgentForLeaf = (leafId: string | null): TuiAgent | null =>
+    leafId === null
+      ? null
+      : freshProcessAgentForLeaf({
+          tabId: tab.id,
+          leafId,
+          layout: options.terminalLayoutsByTabId?.[tab.id],
+          livePtyIds: ptyIdsByTabId[tab.id],
+          paneForegroundAgentByPaneKey: options.paneForegroundAgentByPaneKey,
+          now: options.now ?? Date.now()
+        })
   const paneTitles = runtimePaneTitlesByTabId[tab.id]
   if (paneTitles && Object.keys(paneTitles).length > 0) {
     const tabLayoutRoot =
@@ -81,7 +101,7 @@ function tabHasStatus(
       }
       if (
         classifyTitleActivity(title) === status &&
-        titleStatusIsAgentAttributable(title, tab.launchAgent)
+        titleStatusIsAgentAttributable(title, processAgentForLeaf(leafId), tab.launchAgent)
       ) {
         return true
       }
@@ -94,13 +114,33 @@ function tabHasStatus(
   }
   return (
     classifyTitleActivity(tab.title) === status &&
-    titleStatusIsAgentAttributable(tab.title, tab.launchAgent)
+    // Why: a tab-level title can only borrow pane process identity when the
+    // layout proves the tab has exactly one pane.
+    titleStatusIsAgentAttributable(
+      tab.title,
+      processAgentForLeaf(resolveSoleLeafId(tab.id, options)),
+      tab.launchAgent
+    )
   )
 }
 
+function resolveSoleLeafId(tabId: string, options: WorktreeStatusHeuristicOptions): string | null {
+  const root =
+    options.terminalLayoutRootsByTabId?.[tabId] ?? options.terminalLayoutsByTabId?.[tabId]?.root
+  return root ? soleLeafIdOfNode(root) : null
+}
+
+function soleLeafIdOfNode(node: TerminalPaneLayoutNode): string | null {
+  return node.type === 'leaf' ? node.leafId : null
+}
+
 // Why: require agent attribution so a bare never-cleared spinner title can't spin the dot "0 agents" forever with no matching sidebar row.
-function titleStatusIsAgentAttributable(title: string, launchAgent?: TuiAgent | null): boolean {
-  if (resolveAgentTypeFromTerminalTitle(title) !== null) {
+function titleStatusIsAgentAttributable(
+  title: string,
+  processAgent?: TuiAgent | null,
+  launchAgent?: TuiAgent | null
+): boolean {
+  if (resolveAgentTypeFromTerminalTitle(title, undefined, processAgent) !== null) {
     return true
   }
   // Why: a spinner proves activity but not identity (Claude's thinking title has no provider
@@ -121,6 +161,7 @@ export function getWorktreeStatusLabel(status: WorktreeStatus): string {
  * Map args are narrowed to this worktree. `hasPermission`/`hasLiveWorking`/
  * `hasLiveDone` are fresh hook entries ({blocked,waiting} / {working} / {done});
  * `hasRetainedDone` is a retained-agent snapshot scoped to this worktreeId.
+ * Process evidence only attributes title-derived state; it never invents one.
  */
 export function resolveWorktreeStatus(args: {
   tabs: readonly Pick<TerminalTab, 'id' | 'title' | 'launchAgent'>[]
@@ -130,6 +171,8 @@ export function resolveWorktreeStatus(args: {
   agentStatusPaneIdsByTabId?: Record<string, ReadonlySet<string>>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   terminalLayoutRootsByTabId?: Record<string, TerminalPaneLayoutNode | null | undefined>
+  paneForegroundAgentByPaneKey?: Record<string, PaneForegroundAgentEntry>
+  now?: number
   hasPermission: boolean
   hasLiveWorking: boolean
   hasLiveDone: boolean
@@ -143,7 +186,9 @@ export function resolveWorktreeStatus(args: {
     {
       agentStatusPaneIdsByTabId: args.agentStatusPaneIdsByTabId,
       terminalLayoutsByTabId: args.terminalLayoutsByTabId,
-      terminalLayoutRootsByTabId: args.terminalLayoutRootsByTabId
+      terminalLayoutRootsByTabId: args.terminalLayoutRootsByTabId,
+      paneForegroundAgentByPaneKey: args.paneForegroundAgentByPaneKey,
+      now: args.now
     }
   )
   if (args.hasPermission) {

--- a/src/renderer/src/store/slices/pane-foreground-agent.test.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.test.ts
@@ -4,6 +4,7 @@ import type { TerminalTab } from '../../../../shared/types'
 import {
   PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS,
   resolveFreshPaneForegroundAgent,
+  resolveFreshPaneForegroundRawProcess,
   type PaneForegroundAgentEntry
 } from './pane-foreground-agent'
 
@@ -276,5 +277,60 @@ describe('resolveFreshPaneForegroundAgent', () => {
         liveTabPtyIds: ['pty-9']
       })
     ).toBe('claude')
+  })
+})
+
+describe('resolveFreshPaneForegroundRawProcess', () => {
+  const rawEntry = (
+    overrides: Partial<PaneForegroundAgentEntry> = {}
+  ): PaneForegroundAgentEntry => ({
+    agent: null,
+    rawProcessName: 'my-fork',
+    shellForeground: false,
+    observedAt: 10_000,
+    ptyId: 'pty-1',
+    ...overrides
+  })
+
+  it('returns a fresh, non-shell, engineless raw name bound to a live pane PTY', () => {
+    expect(
+      resolveFreshPaneForegroundRawProcess(rawEntry(), { now: 10_500, paneBoundPtyId: 'pty-1' })
+    ).toBe('my-fork')
+  })
+
+  it('rejects a raw name once its evidence is past the TTL', () => {
+    expect(
+      resolveFreshPaneForegroundRawProcess(rawEntry(), {
+        now: 10_000 + PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS + 1,
+        paneBoundPtyId: 'pty-1'
+      })
+    ).toBeNull()
+  })
+
+  it('rejects a raw name bound to a PTY the pane no longer runs', () => {
+    expect(
+      resolveFreshPaneForegroundRawProcess(rawEntry(), { now: 10_500, paneBoundPtyId: 'pty-2' })
+    ).toBeNull()
+  })
+
+  it('never treats a recognized engine or a shell as an unknown-live raw name', () => {
+    expect(
+      resolveFreshPaneForegroundRawProcess(rawEntry({ agent: 'claude' }), {
+        now: 10_500,
+        paneBoundPtyId: 'pty-1'
+      })
+    ).toBeNull()
+    expect(
+      resolveFreshPaneForegroundRawProcess(rawEntry({ rawProcessName: 'zsh' }), {
+        now: 10_500,
+        paneBoundPtyId: 'pty-1'
+      })
+    ).toBeNull()
+    expect(
+      resolveFreshPaneForegroundRawProcess(rawEntry({ rawProcessName: null }), {
+        now: 10_500,
+        paneBoundPtyId: 'pty-1'
+      })
+    ).toBeNull()
   })
 })

--- a/src/renderer/src/store/slices/pane-foreground-agent.test.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.test.ts
@@ -168,16 +168,39 @@ describe('pane foreground agent slice', () => {
     expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toBe(initial)
   })
 
-  it('creates identity-only evidence from an observation on a pane without an entry', () => {
+  it('creates identity-only evidence bound to the inspected PTY on a pane without an entry', () => {
     vi.spyOn(Date, 'now').mockReturnValue(10_000)
     const store = createTestStore()
 
-    store.getState().refreshPaneForegroundAgentObservation('tab-1:leaf-1', 'claude')
+    store.getState().refreshPaneForegroundAgentObservation('tab-1:leaf-1', 'claude', 'pty-1')
 
     expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toEqual({
       agent: 'claude',
       shellForeground: false,
-      observedAt: 10_000
+      observedAt: 10_000,
+      ptyId: 'pty-1'
+    })
+  })
+
+  it('rebinds evidence held for a previous PTY instead of keeping it fresh across a respawn', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000)
+    const store = createTestStore()
+    store.getState().setPaneForegroundAgent('tab-1:leaf-1', {
+      agent: 'claude',
+      shellForeground: false,
+      routingTrusted: true,
+      ptyId: 'pty-old'
+    })
+
+    nowSpy.mockReturnValue(20_000)
+    store.getState().refreshPaneForegroundAgentObservation('tab-1:leaf-1', 'claude', 'pty-new')
+
+    // Why: identity-only rebind — routing trust belonged to the old PTY.
+    expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toEqual({
+      agent: 'claude',
+      shellForeground: false,
+      observedAt: 20_000,
+      ptyId: 'pty-new'
     })
   })
 })

--- a/src/renderer/src/store/slices/pane-foreground-agent.test.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.test.ts
@@ -91,13 +91,11 @@ describe('pane foreground agent slice', () => {
   it('stamps observedAt when evidence is published and re-stamps past the refresh quantum', () => {
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000)
     const store = createTestStore()
-    store
-      .getState()
-      .setPaneForegroundAgent('tab-1:leaf-1', {
-        agent: 'claude',
-        shellForeground: false,
-        ptyId: 'pty-1'
-      })
+    store.getState().setPaneForegroundAgent('tab-1:leaf-1', {
+      agent: 'claude',
+      shellForeground: false,
+      ptyId: 'pty-1'
+    })
     expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toEqual({
       agent: 'claude',
       shellForeground: false,
@@ -108,23 +106,19 @@ describe('pane foreground agent slice', () => {
 
     // Within the quantum: identical publish keeps the reference (no churn).
     nowSpy.mockReturnValue(11_000)
-    store
-      .getState()
-      .setPaneForegroundAgent('tab-1:leaf-1', {
-        agent: 'claude',
-        shellForeground: false,
-        ptyId: 'pty-1'
-      })
+    store.getState().setPaneForegroundAgent('tab-1:leaf-1', {
+      agent: 'claude',
+      shellForeground: false,
+      ptyId: 'pty-1'
+    })
     expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toBe(initial)
 
     nowSpy.mockReturnValue(20_000)
-    store
-      .getState()
-      .setPaneForegroundAgent('tab-1:leaf-1', {
-        agent: 'claude',
-        shellForeground: false,
-        ptyId: 'pty-1'
-      })
+    store.getState().setPaneForegroundAgent('tab-1:leaf-1', {
+      agent: 'claude',
+      shellForeground: false,
+      ptyId: 'pty-1'
+    })
     expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']?.observedAt).toBe(20_000)
   })
 
@@ -150,16 +144,35 @@ describe('pane foreground agent slice', () => {
     })
   })
 
+  it('binds matching unbound evidence to the inspected PTY inside the refresh quantum', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000)
+    const store = createTestStore()
+    store.getState().setPaneForegroundAgent('tab-1:leaf-1', {
+      agent: 'claude',
+      shellForeground: false,
+      routingTrusted: true
+    })
+
+    nowSpy.mockReturnValue(10_750)
+    store.getState().refreshPaneForegroundAgentObservation('tab-1:leaf-1', 'claude', 'pty-1')
+
+    expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toEqual({
+      agent: 'claude',
+      shellForeground: false,
+      routingTrusted: true,
+      observedAt: 10_750,
+      ptyId: 'pty-1'
+    })
+  })
+
   it('ignores a coordinator observation whose identity differs from the tracked entry', () => {
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000)
     const store = createTestStore()
-    store
-      .getState()
-      .setPaneForegroundAgent('tab-1:leaf-1', {
-        agent: null,
-        shellForeground: true,
-        ptyId: 'pty-1'
-      })
+    store.getState().setPaneForegroundAgent('tab-1:leaf-1', {
+      agent: null,
+      shellForeground: true,
+      ptyId: 'pty-1'
+    })
     const initial = store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']
 
     nowSpy.mockReturnValue(20_000)

--- a/src/renderer/src/store/slices/pane-foreground-agent.test.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.test.ts
@@ -1,6 +1,15 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createTestStore } from './store-test-helpers'
 import type { TerminalTab } from '../../../../shared/types'
+import {
+  PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS,
+  resolveFreshPaneForegroundAgent,
+  type PaneForegroundAgentEntry
+} from './pane-foreground-agent'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 function terminalTab(id: string, worktreeId: string): TerminalTab {
   return {
@@ -77,5 +86,159 @@ describe('pane foreground agent slice', () => {
     store.getState().clearPaneForegroundAgentByWorktree('wt-1')
 
     expect(Object.keys(store.getState().paneForegroundAgentByPaneKey)).toEqual(['tab-3:leaf-1'])
+  })
+
+  it('stamps observedAt when evidence is published and re-stamps past the refresh quantum', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000)
+    const store = createTestStore()
+    store
+      .getState()
+      .setPaneForegroundAgent('tab-1:leaf-1', {
+        agent: 'claude',
+        shellForeground: false,
+        ptyId: 'pty-1'
+      })
+    expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toEqual({
+      agent: 'claude',
+      shellForeground: false,
+      ptyId: 'pty-1',
+      observedAt: 10_000
+    })
+    const initial = store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']
+
+    // Within the quantum: identical publish keeps the reference (no churn).
+    nowSpy.mockReturnValue(11_000)
+    store
+      .getState()
+      .setPaneForegroundAgent('tab-1:leaf-1', {
+        agent: 'claude',
+        shellForeground: false,
+        ptyId: 'pty-1'
+      })
+    expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toBe(initial)
+
+    nowSpy.mockReturnValue(20_000)
+    store
+      .getState()
+      .setPaneForegroundAgent('tab-1:leaf-1', {
+        agent: 'claude',
+        shellForeground: false,
+        ptyId: 'pty-1'
+      })
+    expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']?.observedAt).toBe(20_000)
+  })
+
+  it('bumps observedAt from a matching coordinator observation without touching other fields', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000)
+    const store = createTestStore()
+    store.getState().setPaneForegroundAgent('tab-1:leaf-1', {
+      agent: 'claude',
+      shellForeground: false,
+      routingTrusted: true,
+      ptyId: 'pty-1'
+    })
+
+    nowSpy.mockReturnValue(20_000)
+    store.getState().refreshPaneForegroundAgentObservation('tab-1:leaf-1', 'claude')
+
+    expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toEqual({
+      agent: 'claude',
+      shellForeground: false,
+      routingTrusted: true,
+      ptyId: 'pty-1',
+      observedAt: 20_000
+    })
+  })
+
+  it('ignores a coordinator observation whose identity differs from the tracked entry', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(10_000)
+    const store = createTestStore()
+    store
+      .getState()
+      .setPaneForegroundAgent('tab-1:leaf-1', {
+        agent: null,
+        shellForeground: true,
+        ptyId: 'pty-1'
+      })
+    const initial = store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']
+
+    nowSpy.mockReturnValue(20_000)
+    store.getState().refreshPaneForegroundAgentObservation('tab-1:leaf-1', 'claude')
+
+    expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toBe(initial)
+  })
+
+  it('creates identity-only evidence from an observation on a pane without an entry', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(10_000)
+    const store = createTestStore()
+
+    store.getState().refreshPaneForegroundAgentObservation('tab-1:leaf-1', 'claude')
+
+    expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toEqual({
+      agent: 'claude',
+      shellForeground: false,
+      observedAt: 10_000
+    })
+  })
+})
+
+describe('resolveFreshPaneForegroundAgent', () => {
+  const entry = (overrides: Partial<PaneForegroundAgentEntry> = {}): PaneForegroundAgentEntry => ({
+    agent: 'claude',
+    shellForeground: false,
+    observedAt: 10_000,
+    ptyId: 'pty-1',
+    ...overrides
+  })
+
+  it('returns the agent for fresh evidence bound to a live pane PTY', () => {
+    expect(resolveFreshPaneForegroundAgent(entry(), { now: 10_500, paneBoundPtyId: 'pty-1' })).toBe(
+      'claude'
+    )
+  })
+
+  it('rejects evidence past the TTL or without an observation timestamp', () => {
+    expect(
+      resolveFreshPaneForegroundAgent(entry(), {
+        now: 10_000 + PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS + 1,
+        paneBoundPtyId: 'pty-1'
+      })
+    ).toBeNull()
+    expect(
+      resolveFreshPaneForegroundAgent(entry({ observedAt: undefined }), {
+        now: 10_500,
+        paneBoundPtyId: 'pty-1'
+      })
+    ).toBeNull()
+  })
+
+  it('rejects evidence bound to a PTY the pane no longer runs', () => {
+    expect(
+      resolveFreshPaneForegroundAgent(entry(), { now: 10_500, paneBoundPtyId: 'pty-2' })
+    ).toBeNull()
+    expect(
+      resolveFreshPaneForegroundAgent(entry(), { now: 10_500, liveTabPtyIds: ['pty-2'] })
+    ).toBeNull()
+  })
+
+  it('rejects evidence when the tab has no live PTY at all', () => {
+    expect(
+      resolveFreshPaneForegroundAgent(entry({ ptyId: undefined }), {
+        now: 10_500,
+        liveTabPtyIds: []
+      })
+    ).toBeNull()
+  })
+
+  it('falls back to tab-level liveness when no pane binding is known', () => {
+    expect(
+      resolveFreshPaneForegroundAgent(entry(), { now: 10_500, liveTabPtyIds: ['pty-1'] })
+    ).toBe('claude')
+    expect(
+      resolveFreshPaneForegroundAgent(entry({ ptyId: undefined }), {
+        now: 10_500,
+        liveTabPtyIds: ['pty-9']
+      })
+    ).toBe('claude')
   })
 })

--- a/src/renderer/src/store/slices/pane-foreground-agent.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.ts
@@ -117,6 +117,14 @@ current.routingRevoked === entry.routingRevoked &&
         if (current.agent !== agent) {
           return s
         }
+        if (ptyId !== undefined && current.ptyId === undefined) {
+          return {
+            paneForegroundAgentByPaneKey: {
+              ...s.paneForegroundAgentByPaneKey,
+              [paneKey]: { ...current, observedAt: now, ptyId }
+            }
+          }
+        }
         // Why: evidence bound to a previous PTY must not be kept fresh across
         // a respawn — rebind it as identity-only evidence of the inspected PTY.
         if (ptyId !== undefined && current.ptyId !== undefined && current.ptyId !== ptyId) {

--- a/src/renderer/src/store/slices/pane-foreground-agent.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.ts
@@ -1,5 +1,6 @@
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
+import { isShellProcess } from '../../../../shared/shell-process-detection'
 import type { TuiAgent } from '../../../../shared/types'
 
 // Why: expire identity after the coordinator's slowest 15s cadence so exited
@@ -12,6 +13,10 @@ const OBSERVATION_REFRESH_QUANTUM_MS = 5_000
 export type PaneForegroundAgentEntry = {
   /** Recognized agent process in the pane's foreground; null when unknown. */
   agent: TuiAgent | null
+  /** Raw process-table basename behind this evidence, when a read produced one.
+   *  Lets a consumer render a neutral live identity for an unrecognized (fork)
+   *  agent instead of collapsing it to "bare shell". */
+  rawProcessName?: string | null
   /** True only when fresh provider evidence is safe for input-byte routing. */
   routingTrusted?: boolean
   /** True after exit/input evidence revokes routing until provider confirmation. */
@@ -42,6 +47,36 @@ export type PaneForegroundAgentSlice = {
   clearPaneForegroundAgentByWorktree: (worktreeId: string) => void
 }
 
+type PaneForegroundLivenessArgs = {
+  now: number
+  paneBoundPtyId?: string
+  liveTabPtyIds?: readonly string[]
+}
+
+/**
+ * The TTL + PTY-binding gate shared by every fresh-evidence read: evidence
+ * counts only while it is within the TTL and still bound to a live PTY, at the
+ * finest liveness granularity the caller can supply.
+ */
+function isFreshPaneForegroundEvidence(
+  entry: PaneForegroundAgentEntry,
+  args: PaneForegroundLivenessArgs
+): boolean {
+  if (entry.observedAt === undefined) {
+    return false
+  }
+  if (args.now - entry.observedAt > PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS) {
+    return false
+  }
+  if (args.paneBoundPtyId !== undefined) {
+    return entry.ptyId === undefined || entry.ptyId === args.paneBoundPtyId
+  }
+  if (entry.ptyId !== undefined) {
+    return args.liveTabPtyIds?.includes(entry.ptyId) === true
+  }
+  return (args.liveTabPtyIds?.length ?? 0) > 0
+}
+
 /**
  * Attribution-grade read of a pane's process identity: the agent counts only
  * while the evidence is fresh (TTL) and the pane still has a live PTY — at the
@@ -49,21 +84,32 @@ export type PaneForegroundAgentSlice = {
  */
 export function resolveFreshPaneForegroundAgent(
   entry: PaneForegroundAgentEntry | undefined,
-  args: { now: number; paneBoundPtyId?: string; liveTabPtyIds?: readonly string[] }
+  args: PaneForegroundLivenessArgs
 ): TuiAgent | null {
-  if (!entry?.agent || entry.observedAt === undefined) {
+  if (!entry?.agent) {
     return null
   }
-  if (args.now - entry.observedAt > PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS) {
+  return isFreshPaneForegroundEvidence(entry, args) ? entry.agent : null
+}
+
+/**
+ * Fresh unknown-live evidence: a live, non-shell foreground process with no
+ * recognized engine. Gated by the same TTL/PTY binding as the agent read so a
+ * dead fork process cannot keep painting the tab after the pane moved on.
+ */
+export function resolveFreshPaneForegroundRawProcess(
+  entry: PaneForegroundAgentEntry | undefined,
+  args: PaneForegroundLivenessArgs
+): string | null {
+  if (
+    !entry ||
+    entry.agent !== null ||
+    !entry.rawProcessName ||
+    isShellProcess(entry.rawProcessName)
+  ) {
     return null
   }
-  if (args.paneBoundPtyId !== undefined) {
-    return entry.ptyId === undefined || entry.ptyId === args.paneBoundPtyId ? entry.agent : null
-  }
-  if (entry.ptyId !== undefined) {
-    return args.liveTabPtyIds?.includes(entry.ptyId) === true ? entry.agent : null
-  }
-  return (args.liveTabPtyIds?.length ?? 0) > 0 ? entry.agent : null
+  return isFreshPaneForegroundEvidence(entry, args) ? entry.rawProcessName : null
 }
 
 export const createPaneForegroundAgentSlice: StateCreator<
@@ -80,6 +126,7 @@ export const createPaneForegroundAgentSlice: StateCreator<
       if (
         current &&
         current.agent === entry.agent &&
+        current.rawProcessName === entry.rawProcessName &&
         current.routingTrusted === entry.routingTrusted &&
 current.routingRevoked === entry.routingRevoked &&
         current.shellForeground === entry.shellForeground &&

--- a/src/renderer/src/store/slices/pane-foreground-agent.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.ts
@@ -2,6 +2,15 @@ import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import type { TuiAgent } from '../../../../shared/types'
 
+// Why: attribution consumers (sidebar rows, worktree ring) must not trust
+// process identity forever — an exited agent's entry could otherwise fake a
+// working state. 30s sits above the completion coordinator's slowest cadences
+// (3s hidden backstop, 15s no-evidence poll), which re-arm the observation.
+export const PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS = 30_000
+// Why: active-tier inspections land every ~750ms; re-stamping each one would
+// churn the store, so freshness bumps are quantized well below the TTL.
+const OBSERVATION_REFRESH_QUANTUM_MS = 5_000
+
 export type PaneForegroundAgentEntry = {
   /** Recognized agent process in the pane's foreground; null when unknown. */
   agent: TuiAgent | null
@@ -12,6 +21,10 @@ export type PaneForegroundAgentEntry = {
   /** True once the foreground is proven back at the shell (OSC 133;D) —
    *  process-grade launched-agent exit evidence, independent of titles. */
   shellForeground: boolean
+  /** When this evidence was recorded; attribution consumers gate on the TTL. */
+  observedAt?: number
+  /** PTY the evidence was read from, when the publisher knows it. */
+  ptyId?: string
 }
 
 /**
@@ -22,11 +35,39 @@ export type PaneForegroundAgentEntry = {
 export type PaneForegroundAgentSlice = {
   paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry>
   setPaneForegroundAgent: (paneKey: string, entry: PaneForegroundAgentEntry) => void
+  /** Freshness bump from the completion coordinator's existing inspections —
+   *  identity only, never routing trust; a differing identity is ignored so
+   *  the tracker keeps sole ownership of identity changes. */
+  refreshPaneForegroundAgentObservation: (paneKey: string, agent: TuiAgent) => void
   clearPaneForegroundAgent: (paneKey: string) => void
   /** Wholesale teardown sweeps (tab close, worktree sleep/remove) retire pane
    *  keys without per-pane close events — clear their entries too. */
   clearPaneForegroundAgentByTabPrefix: (tabIdPrefix: string) => void
   clearPaneForegroundAgentByWorktree: (worktreeId: string) => void
+}
+
+/**
+ * Attribution-grade read of a pane's process identity: the agent counts only
+ * while the evidence is fresh (TTL) and the pane still has a live PTY — at the
+ * finest liveness granularity the caller can supply.
+ */
+export function resolveFreshPaneForegroundAgent(
+  entry: PaneForegroundAgentEntry | undefined,
+  args: { now: number; paneBoundPtyId?: string; liveTabPtyIds?: readonly string[] }
+): TuiAgent | null {
+  if (!entry?.agent || entry.observedAt === undefined) {
+    return null
+  }
+  if (args.now - entry.observedAt > PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS) {
+    return null
+  }
+  if (args.paneBoundPtyId !== undefined) {
+    return entry.ptyId === undefined || entry.ptyId === args.paneBoundPtyId ? entry.agent : null
+  }
+  if (entry.ptyId !== undefined) {
+    return args.liveTabPtyIds?.includes(entry.ptyId) === true ? entry.agent : null
+  }
+  return (args.liveTabPtyIds?.length ?? 0) > 0 ? entry.agent : null
 }
 
 export const createPaneForegroundAgentSlice: StateCreator<
@@ -38,18 +79,68 @@ export const createPaneForegroundAgentSlice: StateCreator<
   paneForegroundAgentByPaneKey: {},
   setPaneForegroundAgent: (paneKey, entry) => {
     set((s) => {
+      const now = Date.now()
       const current = s.paneForegroundAgentByPaneKey[paneKey]
       if (
         current &&
         current.agent === entry.agent &&
         current.routingTrusted === entry.routingTrusted &&
-        current.routingRevoked === entry.routingRevoked &&
-        current.shellForeground === entry.shellForeground
+current.routingRevoked === entry.routingRevoked &&
+        current.shellForeground === entry.shellForeground &&
+        current.ptyId === entry.ptyId
       ) {
-        return s
+        // Why: an identical re-publish is still fresh evidence; bump the
+        // observation quantized so repeated confirmations don't churn the store.
+        if (
+          current.observedAt !== undefined &&
+          now - current.observedAt < OBSERVATION_REFRESH_QUANTUM_MS
+        ) {
+          return s
+        }
+        return {
+          paneForegroundAgentByPaneKey: {
+            ...s.paneForegroundAgentByPaneKey,
+            [paneKey]: { ...current, observedAt: now }
+          }
+        }
       }
       return {
-        paneForegroundAgentByPaneKey: { ...s.paneForegroundAgentByPaneKey, [paneKey]: entry }
+        paneForegroundAgentByPaneKey: {
+          ...s.paneForegroundAgentByPaneKey,
+          // Why: stamp centrally so every publisher gets TTL-gated evidence.
+          [paneKey]: { ...entry, observedAt: entry.observedAt ?? now }
+        }
+      }
+    })
+  },
+  refreshPaneForegroundAgentObservation: (paneKey, agent) => {
+    set((s) => {
+      const now = Date.now()
+      const current = s.paneForegroundAgentByPaneKey[paneKey]
+      if (current) {
+        if (current.agent !== agent) {
+          return s
+        }
+        if (
+          current.observedAt !== undefined &&
+          now - current.observedAt < OBSERVATION_REFRESH_QUANTUM_MS
+        ) {
+          return s
+        }
+        return {
+          paneForegroundAgentByPaneKey: {
+            ...s.paneForegroundAgentByPaneKey,
+            [paneKey]: { ...current, observedAt: now }
+          }
+        }
+      }
+      // Why: coordinator inspections also cover panes whose tracker read raced
+      // or whose shell emits no OSC 133 — identity evidence only, no routing.
+      return {
+        paneForegroundAgentByPaneKey: {
+          ...s.paneForegroundAgentByPaneKey,
+          [paneKey]: { agent, shellForeground: false, observedAt: now }
+        }
       }
     })
   },

--- a/src/renderer/src/store/slices/pane-foreground-agent.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.ts
@@ -37,8 +37,9 @@ export type PaneForegroundAgentSlice = {
   setPaneForegroundAgent: (paneKey: string, entry: PaneForegroundAgentEntry) => void
   /** Freshness bump from the completion coordinator's existing inspections —
    *  identity only, never routing trust; a differing identity is ignored so
-   *  the tracker keeps sole ownership of identity changes. */
-  refreshPaneForegroundAgentObservation: (paneKey: string, agent: TuiAgent) => void
+   *  the tracker keeps sole ownership of identity changes. `ptyId` is the PTY
+   *  the inspection ran against; it binds created/rebound evidence. */
+  refreshPaneForegroundAgentObservation: (paneKey: string, agent: TuiAgent, ptyId?: string) => void
   clearPaneForegroundAgent: (paneKey: string) => void
   /** Wholesale teardown sweeps (tab close, worktree sleep/remove) retire pane
    *  keys without per-pane close events — clear their entries too. */
@@ -113,13 +114,23 @@ current.routingRevoked === entry.routingRevoked &&
       }
     })
   },
-  refreshPaneForegroundAgentObservation: (paneKey, agent) => {
+  refreshPaneForegroundAgentObservation: (paneKey, agent, ptyId) => {
     set((s) => {
       const now = Date.now()
       const current = s.paneForegroundAgentByPaneKey[paneKey]
       if (current) {
         if (current.agent !== agent) {
           return s
+        }
+        // Why: evidence bound to a previous PTY must not be kept fresh across
+        // a respawn — rebind it as identity-only evidence of the inspected PTY.
+        if (ptyId !== undefined && current.ptyId !== undefined && current.ptyId !== ptyId) {
+          return {
+            paneForegroundAgentByPaneKey: {
+              ...s.paneForegroundAgentByPaneKey,
+              [paneKey]: { agent, shellForeground: false, observedAt: now, ptyId }
+            }
+          }
         }
         if (
           current.observedAt !== undefined &&
@@ -139,7 +150,12 @@ current.routingRevoked === entry.routingRevoked &&
       return {
         paneForegroundAgentByPaneKey: {
           ...s.paneForegroundAgentByPaneKey,
-          [paneKey]: { agent, shellForeground: false, observedAt: now }
+          [paneKey]: {
+            agent,
+            shellForeground: false,
+            observedAt: now,
+            ...(ptyId !== undefined ? { ptyId } : {})
+          }
         }
       }
     })

--- a/src/renderer/src/store/slices/pane-foreground-agent.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.ts
@@ -2,10 +2,8 @@ import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import type { TuiAgent } from '../../../../shared/types'
 
-// Why: attribution consumers (sidebar rows, worktree ring) must not trust
-// process identity forever — an exited agent's entry could otherwise fake a
-// working state. 30s sits above the completion coordinator's slowest cadences
-// (3s hidden backstop, 15s no-evidence poll), which re-arm the observation.
+// Why: expire identity after the coordinator's slowest 15s cadence so exited
+// agents cannot leave false working state indefinitely.
 export const PANE_FOREGROUND_AGENT_EVIDENCE_TTL_MS = 30_000
 // Why: active-tier inspections land every ~750ms; re-stamping each one would
 // churn the store, so freshness bumps are quantized well below the TTL.
@@ -35,10 +33,7 @@ export type PaneForegroundAgentEntry = {
 export type PaneForegroundAgentSlice = {
   paneForegroundAgentByPaneKey: Record<string, PaneForegroundAgentEntry>
   setPaneForegroundAgent: (paneKey: string, entry: PaneForegroundAgentEntry) => void
-  /** Freshness bump from the completion coordinator's existing inspections —
-   *  identity only, never routing trust; a differing identity is ignored so
-   *  the tracker keeps sole ownership of identity changes. `ptyId` is the PTY
-   *  the inspection ran against; it binds created/rebound evidence. */
+  /** Refresh identity from an existing inspection, never routing trust. */
   refreshPaneForegroundAgentObservation: (paneKey: string, agent: TuiAgent, ptyId?: string) => void
   clearPaneForegroundAgent: (paneKey: string) => void
   /** Wholesale teardown sweeps (tab close, worktree sleep/remove) retire pane

--- a/src/renderer/src/store/slices/terminal-pane-detach-agent-identity.test.ts
+++ b/src/renderer/src/store/slices/terminal-pane-detach-agent-identity.test.ts
@@ -85,7 +85,10 @@ describe('syncPaneDetachPtyOwnership agent identity', () => {
     expect(state.paneForegroundAgentByPaneKey[targetPaneKey]).toEqual({
       agent: 'droid',
       routingTrusted: true,
-      shellForeground: false
+      shellForeground: false,
+      // Why: setPaneForegroundAgent stamps observedAt centrally; the transfer
+      // preserves the entry (TTL keeps gating attribution on the new key).
+      observedAt: expect.any(Number)
     })
     expect(state.agentLaunchConfigByPaneKey[sourcePaneKey]).toBeUndefined()
     expect(state.agentLaunchConfigByPaneKey[targetPaneKey]?.identity).toMatchObject({
@@ -111,7 +114,8 @@ describe('syncPaneDetachPtyOwnership agent identity', () => {
     expect(state.agentStatusEpoch).toBeGreaterThan(epochBeforeDetach)
     expect(state.paneForegroundAgentByPaneKey[siblingPaneKey]).toEqual({
       agent: 'antigravity',
-      shellForeground: false
+      shellForeground: false,
+      observedAt: expect.any(Number)
     })
     expect(resolveWindowsShiftEnterEncodingForPane(state, targetPaneKey)).toBe('csi-u')
     expect(resolveWindowsShiftEnterEncodingForPane(state, siblingPaneKey)).toBe('alt-enter')

--- a/src/shared/foreground-process-resolution.test.ts
+++ b/src/shared/foreground-process-resolution.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { resolveForegroundProcess } from './foreground-process-resolution'
+
+describe('resolveForegroundProcess (old-relay string degradation)', () => {
+  it('recognizes a known agent binary as the engine', () => {
+    expect(resolveForegroundProcess('codex')).toEqual({
+      engine: 'codex',
+      rawProcessName: 'codex',
+      isShell: false
+    })
+  })
+
+  it('keeps an unrecognized non-shell process as a raw name with no engine', () => {
+    // Why: a renamed/fork agent is the unknown-live case — carry the raw name so
+    // the renderer can show a neutral live identity instead of a bare shell.
+    expect(resolveForegroundProcess('my-fork')).toEqual({
+      engine: null,
+      rawProcessName: 'my-fork',
+      isShell: false
+    })
+  })
+
+  it('flags a shell process so the consumer never treats it as unknown-live', () => {
+    expect(resolveForegroundProcess('zsh')).toEqual({
+      engine: null,
+      rawProcessName: 'zsh',
+      isShell: true
+    })
+  })
+
+  it('degrades an unavailable (null) read to an all-empty resolution', () => {
+    expect(resolveForegroundProcess(null)).toEqual({
+      engine: null,
+      rawProcessName: null,
+      isShell: false
+    })
+  })
+})

--- a/src/shared/foreground-process-resolution.ts
+++ b/src/shared/foreground-process-resolution.ts
@@ -1,0 +1,31 @@
+import { recognizeAgentProcess } from './agent-process-recognition'
+import { isShellProcess } from './shell-process-detection'
+import type { TuiAgent } from './types'
+
+/**
+ * Structured identity of a pane's foreground process, carried from the scan to
+ * the renderer so an unrecognized live process is no longer collapsed to "bare
+ * shell". `engine` is the recognized coding-harness agent (null when the process
+ * is not a known agent); `rawProcessName` is the process-table basename (null
+ * when inspection was unavailable); `isShell` is true when that name is a known
+ * shell binary.
+ */
+export type ForegroundProcessResolution = {
+  engine: TuiAgent | null
+  rawProcessName: string | null
+  isShell: boolean
+}
+
+/**
+ * Degrade a raw foreground-process string into the structured resolution. The
+ * deployed-relay wire contract stays `string | null` (parent-branch decision),
+ * so every consumer that only has the legacy string rebuilds the structure here
+ * instead of trusting an old relay to send it.
+ */
+export function resolveForegroundProcess(processName: string | null): ForegroundProcessResolution {
+  return {
+    engine: recognizeAgentProcess(processName)?.agent ?? null,
+    rawProcessName: processName,
+    isShell: processName !== null && isShellProcess(processName)
+  }
+}

--- a/src/shared/process-executable-recognition.test.ts
+++ b/src/shared/process-executable-recognition.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn()
+}))
+
+vi.mock('child_process', () => ({
+  execFile: execFileMock
+}))
+
+import {
+  recognizeAgentFromExecutablePath,
+  resetProcessExecutablePathCacheForTests,
+  resolveProcessExecutablePath
+} from './process-executable-recognition'
+
+// Why: the module wraps execFile with promisify, so the lsof mock must honor the
+// Node callback contract — invoke the last arg with (err, { stdout, stderr }).
+function mockLsof(stdout: string): void {
+  execFileMock.mockImplementation((_cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
+    const callback = cb as (err: unknown, result: { stdout: string; stderr: string }) => void
+    callback(null, { stdout, stderr: '' })
+  })
+}
+
+describe('process-executable-recognition', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+    resetProcessExecutablePathCacheForTests()
+  })
+
+  afterEach(() => {
+    resetProcessExecutablePathCacheForTests()
+  })
+
+  it('recognizes a renamed binary from the Linux /proc exe link', async () => {
+    const readLinuxExecutable = vi.fn(async () => '/home/dev/.local/bin/grok')
+    await expect(
+      recognizeAgentFromExecutablePath(1234, { platform: 'linux', readLinuxExecutable })
+    ).resolves.toEqual({ agent: 'grok', processName: 'grok' })
+    expect(readLinuxExecutable).toHaveBeenCalledTimes(1)
+  })
+
+  it('recognizes a renamed binary from the macOS lsof executable image', async () => {
+    // Why: `-d txt` lists the executable image first, then mapped dylibs; take
+    // the first `n/…` line and ignore the rest.
+    mockLsof(
+      ['p4321', 'n/Users/dev/.local/bin/grok', 'n/usr/lib/dyld', 'n/usr/lib/libSystem.dylib'].join(
+        '\n'
+      )
+    )
+    await expect(recognizeAgentFromExecutablePath(4321, { platform: 'darwin' })).resolves.toEqual({
+      agent: 'grok',
+      processName: 'grok'
+    })
+    expect(execFileMock).toHaveBeenCalledTimes(1)
+    const [cmd, args] = execFileMock.mock.calls[0] as [string, string[]]
+    expect(cmd).toBe('lsof')
+    expect(args).toEqual(['-a', '-p', '4321', '-d', 'txt', '-Fn'])
+  })
+
+  it('caches the executable path per PID so a second call skips the reader', async () => {
+    const readMacExecutable = vi.fn(async () => '/Users/dev/.local/bin/grok')
+    const deps = { platform: 'darwin' as const, readMacExecutable }
+    await expect(resolveProcessExecutablePath(777, deps)).resolves.toBe(
+      '/Users/dev/.local/bin/grok'
+    )
+    await expect(resolveProcessExecutablePath(777, deps)).resolves.toBe(
+      '/Users/dev/.local/bin/grok'
+    )
+    expect(readMacExecutable).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-reads after the cache TTL expires', async () => {
+    const readMacExecutable = vi.fn(async () => '/Users/dev/.local/bin/grok')
+    let now = 0
+    const deps = { platform: 'darwin' as const, readMacExecutable, now: () => now }
+    await resolveProcessExecutablePath(888, deps)
+    now = 5_001
+    await resolveProcessExecutablePath(888, deps)
+    expect(readMacExecutable).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not fake an engine for an interpreter fork (node/python script)', async () => {
+    await expect(
+      recognizeAgentFromExecutablePath(555, {
+        platform: 'linux',
+        readLinuxExecutable: async () => '/usr/local/bin/node'
+      })
+    ).resolves.toBeNull()
+  })
+
+  it('returns null on unsupported platforms without invoking a reader', async () => {
+    const readLinuxExecutable = vi.fn(async () => '/x/grok')
+    const readMacExecutable = vi.fn(async () => '/x/grok')
+    await expect(
+      resolveProcessExecutablePath(9, { platform: 'win32', readLinuxExecutable, readMacExecutable })
+    ).resolves.toBeNull()
+    expect(readLinuxExecutable).not.toHaveBeenCalled()
+    expect(readMacExecutable).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/process-executable-recognition.test.ts
+++ b/src/shared/process-executable-recognition.test.ts
@@ -1,14 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { execFileMock } = vi.hoisted(() => ({
-  execFileMock: vi.fn()
+const { execFileMock, readlinkSyncMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  readlinkSyncMock: vi.fn()
 }))
 
 vi.mock('child_process', () => ({
   execFile: execFileMock
 }))
 
+vi.mock('fs', () => ({
+  readlinkSync: readlinkSyncMock
+}))
+
 import {
+  readProcessExecutablePathCacheSizeForTests,
   recognizeAgentFromExecutablePath,
   resetProcessExecutablePathCacheForTests,
   resolveProcessExecutablePath
@@ -26,6 +32,7 @@ function mockLsof(stdout: string): void {
 describe('process-executable-recognition', () => {
   beforeEach(() => {
     execFileMock.mockReset()
+    readlinkSyncMock.mockReset()
     resetProcessExecutablePathCacheForTests()
   })
 
@@ -42,6 +49,21 @@ describe('process-executable-recognition', () => {
       })
     ).resolves.toEqual({ agent: 'grok', processName: 'grok' })
     expect(readLinuxExecutable).toHaveBeenCalledTimes(1)
+  })
+
+  it('reads /proc/PID/exe via the default Linux reader when none is injected', async () => {
+    readlinkSyncMock.mockReturnValue('/home/dev/.local/bin/grok')
+    await expect(resolveProcessExecutablePath(4242, { platform: 'linux' })).resolves.toBe(
+      '/home/dev/.local/bin/grok'
+    )
+    expect(readlinkSyncMock).toHaveBeenCalledWith('/proc/4242/exe')
+  })
+
+  it('returns null when the default Linux reader throws (process exited mid-read)', async () => {
+    readlinkSyncMock.mockImplementation(() => {
+      throw new Error('ENOENT')
+    })
+    await expect(resolveProcessExecutablePath(4243, { platform: 'linux' })).resolves.toBeNull()
   })
 
   it('recognizes a renamed binary from the macOS lsof executable image', async () => {
@@ -124,6 +146,53 @@ describe('process-executable-recognition', () => {
         readLinuxExecutable: async () => '/usr/local/bin/node'
       })
     ).resolves.toBeNull()
+  })
+
+  it('rejects a renamed headless one-shot even when argv0 is a quoted spaced path', async () => {
+    // Why: a quoted path with an internal space must not split mid-path — the
+    // dangling quote would otherwise swallow `--print`, bypassing the headless
+    // guard and mislabeling the image as an interactive agent.
+    await expect(
+      recognizeAgentFromExecutablePath(
+        3690,
+        '"C:\\Program Files\\tools\\my launcher.exe" --print "summarize"',
+        { platform: 'linux', readLinuxExecutable: async () => '/usr/local/bin/claude' }
+      )
+    ).resolves.toBeNull()
+  })
+
+  it('recognizes a genuine interactive agent behind a quoted spaced argv0', async () => {
+    await expect(
+      recognizeAgentFromExecutablePath(3691, '"C:\\Program Files\\tools\\my cli.exe" chat', {
+        platform: 'linux',
+        readLinuxExecutable: async () => '/usr/local/bin/claude'
+      })
+    ).resolves.toEqual({ agent: 'claude', processName: 'claude' })
+  })
+
+  it('recognizes orca claude-teams behind a quoted spaced argv0 (no false negative)', async () => {
+    // Why: the naive split also dropped the `claude-teams` subcommand into a
+    // dangling-quote token, making a genuine agent launch fail recognition.
+    await expect(
+      recognizeAgentFromExecutablePath(3692, '"C:\\Program Files\\x\\my orca.exe" claude-teams', {
+        platform: 'linux',
+        readLinuxExecutable: async () => '/usr/local/bin/orca'
+      })
+    ).resolves.toEqual({ agent: 'claude-agent-teams', processName: 'orca' })
+  })
+
+  it('bounds the cache: distinct never-reused PIDs do not accumulate past the cap', async () => {
+    let now = 0
+    const readLinuxExecutable = vi.fn(async () => '/usr/local/bin/node')
+    const deps = { platform: 'linux' as const, readLinuxExecutable, now: () => now }
+    // Fill past the soft cap with distinct PIDs, then advance beyond the TTL so
+    // the next insert sweeps the expired entries instead of growing unbounded.
+    for (let pid = 1; pid <= 512; pid += 1) {
+      await resolveProcessExecutablePath(pid, deps)
+    }
+    now = 5_001 // past the 5s cache TTL so the next insert sweeps expired entries
+    await resolveProcessExecutablePath(9999, deps)
+    expect(readProcessExecutablePathCacheSizeForTests()).toBeLessThan(512)
   })
 
   it('returns null on unsupported platforms without invoking a reader', async () => {

--- a/src/shared/process-executable-recognition.test.ts
+++ b/src/shared/process-executable-recognition.test.ts
@@ -36,7 +36,10 @@ describe('process-executable-recognition', () => {
   it('recognizes a renamed binary from the Linux /proc exe link', async () => {
     const readLinuxExecutable = vi.fn(async () => '/home/dev/.local/bin/grok')
     await expect(
-      recognizeAgentFromExecutablePath(1234, { platform: 'linux', readLinuxExecutable })
+      recognizeAgentFromExecutablePath(1234, 'my-cli --serve', {
+        platform: 'linux',
+        readLinuxExecutable
+      })
     ).resolves.toEqual({ agent: 'grok', processName: 'grok' })
     expect(readLinuxExecutable).toHaveBeenCalledTimes(1)
   })
@@ -49,7 +52,9 @@ describe('process-executable-recognition', () => {
         '\n'
       )
     )
-    await expect(recognizeAgentFromExecutablePath(4321, { platform: 'darwin' })).resolves.toEqual({
+    await expect(
+      recognizeAgentFromExecutablePath(4321, 'my-cli', { platform: 'darwin' })
+    ).resolves.toEqual({
       agent: 'grok',
       processName: 'grok'
     })
@@ -57,6 +62,37 @@ describe('process-executable-recognition', () => {
     const [cmd, args] = execFileMock.mock.calls[0] as [string, string[]]
     expect(cmd).toBe('lsof')
     expect(args).toEqual(['-a', '-p', '4321', '-d', 'txt', '-Fn'])
+  })
+
+  it('does not label a renamed headless one-shot as an interactive agent', async () => {
+    // The real image is `claude`, but `--print` is a headless one-shot that the
+    // command-aware guard rejects — basename-only recognition would mislabel it.
+    await expect(
+      recognizeAgentFromExecutablePath(2468, 'my-cli --print "summarize"', {
+        platform: 'linux',
+        readLinuxExecutable: async () => '/usr/local/bin/claude'
+      })
+    ).resolves.toBeNull()
+  })
+
+  it('does not label a generic orca invocation as claude-agent-teams', async () => {
+    // Bare `orca` (no `claude-teams` subcommand) is not the agent TUI; the
+    // command-aware guard preserves that, unlike basename-only recognition.
+    await expect(
+      recognizeAgentFromExecutablePath(1357, 'my-cli render', {
+        platform: 'linux',
+        readLinuxExecutable: async () => '/usr/local/bin/orca'
+      })
+    ).resolves.toBeNull()
+  })
+
+  it('recognizes a genuine orca claude-teams launch via its executable image', async () => {
+    await expect(
+      recognizeAgentFromExecutablePath(2469, 'my-cli claude-teams', {
+        platform: 'linux',
+        readLinuxExecutable: async () => '/usr/local/bin/orca'
+      })
+    ).resolves.toEqual({ agent: 'claude-agent-teams', processName: 'orca' })
   })
 
   it('caches the executable path per PID so a second call skips the reader', async () => {
@@ -83,7 +119,7 @@ describe('process-executable-recognition', () => {
 
   it('does not fake an engine for an interpreter fork (node/python script)', async () => {
     await expect(
-      recognizeAgentFromExecutablePath(555, {
+      recognizeAgentFromExecutablePath(555, 'my-worker', {
         platform: 'linux',
         readLinuxExecutable: async () => '/usr/local/bin/node'
       })

--- a/src/shared/process-executable-recognition.ts
+++ b/src/shared/process-executable-recognition.ts
@@ -18,6 +18,11 @@ const execFile = promisify(execFileCb)
 // PID-reuse risk).
 const EXECUTABLE_PATH_CACHE_TTL_MS = 5_000
 const EXECUTABLE_PATH_LOOKUP_TIMEOUT_MS = 3_000
+// Why: entries are keyed by PID and only overwritten on re-lookup, so PIDs never
+// probed again (every distinct non-shell foreground command — vim, git, node…)
+// would accumulate forever in a long-lived daemon. Sweep expired entries once
+// the map crosses this soft cap to keep it bounded to the active TTL window.
+const EXECUTABLE_PATH_CACHE_MAX_ENTRIES = 512
 
 export type ProcessExecutablePathDeps = {
   platform?: NodeJS.Platform
@@ -49,8 +54,19 @@ export async function resolveProcessExecutablePath(
   } else if (platform === 'darwin') {
     path = await (deps.readMacExecutable ?? readMacExecutableImage)(pid)
   }
+  if (executablePathCache.size >= EXECUTABLE_PATH_CACHE_MAX_ENTRIES) {
+    pruneExpiredExecutablePaths(now)
+  }
   executablePathCache.set(pid, { path, at: now })
   return path
+}
+
+function pruneExpiredExecutablePaths(now: number): void {
+  for (const [cachedPid, entry] of executablePathCache) {
+    if (now - entry.at >= EXECUTABLE_PATH_CACHE_TTL_MS) {
+      executablePathCache.delete(cachedPid)
+    }
+  }
 }
 
 /**
@@ -83,12 +99,28 @@ export function recognizeAgentFromExecutableImage(
   executablePath: string,
   command: string | null | undefined
 ): RecognizedAgentProcess | null {
-  const trimmed = (command ?? '').trim()
-  const firstWhitespace = trimmed.search(/\s/)
-  const args = firstWhitespace === -1 ? '' : trimmed.slice(firstWhitespace + 1).trim()
+  const args = stripLeadingArgv0(command ?? '')
   // Quote the path so a space inside it stays a single argv0 token.
   const argv0 = `"${executablePath.replace(/"/g, '')}"`
   return recognizeAgentProcessFromCommandLine(args ? `${argv0} ${args}` : argv0)
+}
+
+// Why: strip the original argv0 quote-aware. A quoted path with an internal
+// space (e.g. Windows `"C:\Program Files\x\renamed.exe" --print`) split on the
+// first whitespace would break mid-path and leave a dangling quote that
+// swallows the following tokens — burying `--print` so the headless-one-shot
+// guard we substitute argv0 to preserve gets bypassed and the image mislabeled.
+function stripLeadingArgv0(command: string): string {
+  const trimmed = command.trim()
+  const quote = trimmed[0]
+  if (quote === '"' || quote === "'") {
+    const close = trimmed.indexOf(quote, 1)
+    if (close !== -1) {
+      return trimmed.slice(close + 1).trim()
+    }
+  }
+  const firstWhitespace = trimmed.search(/\s/)
+  return firstWhitespace === -1 ? '' : trimmed.slice(firstWhitespace + 1).trim()
 }
 
 async function readLinuxProcExe(pid: number): Promise<string | null> {
@@ -130,4 +162,9 @@ async function readMacExecutableImage(pid: number): Promise<string | null> {
  */
 export function resetProcessExecutablePathCacheForTests(): void {
   executablePathCache.clear()
+}
+
+/** Test-only: observe the cache size to assert the map stays bounded. */
+export function readProcessExecutablePathCacheSizeForTests(): number {
+  return executablePathCache.size
 }

--- a/src/shared/process-executable-recognition.ts
+++ b/src/shared/process-executable-recognition.ts
@@ -1,16 +1,21 @@
 import { execFile as execFileCb } from 'node:child_process'
 import { promisify } from 'node:util'
-import { recognizeAgentProcess, type RecognizedAgentProcess } from './agent-process-recognition'
+import {
+  recognizeAgentProcessFromCommandLine,
+  type RecognizedAgentProcess
+} from './agent-process-recognition'
 
 const execFile = promisify(execFileCb)
 
 // Why: resolving a PID's real executable image forks lsof (macOS) or reads
 // /proc (Linux). Foreground scans on the completion cadence re-inspect the same
 // unrecognized pane, so cache the resolved path per PID behind a short TTL. No
-// process start-time in the key (not cheaply available cross-platform): a
-// recycled PID could serve a stale path for at most one TTL window, but the
-// caller re-runs pure agent recognition on it, so a mismatch merely fails to
-// recognize instead of mislabeling.
+// process start-time in the key (not cheaply available cross-platform), so a
+// recycled PID (or the same PID after exec) can serve a stale path for at most
+// one TTL window — and because recognition then runs on that stale path, a
+// recycled PID CAN be briefly mislabeled, not merely missed. The short TTL
+// bounds the window; keying by process generation is deferred (spec-accepted
+// PID-reuse risk).
 const EXECUTABLE_PATH_CACHE_TTL_MS = 5_000
 const EXECUTABLE_PATH_LOOKUP_TIMEOUT_MS = 3_000
 
@@ -58,10 +63,32 @@ export async function resolveProcessExecutablePath(
  */
 export async function recognizeAgentFromExecutablePath(
   pid: number,
+  command: string,
   deps: ProcessExecutablePathDeps = {}
 ): Promise<RecognizedAgentProcess | null> {
   const executablePath = await resolveProcessExecutablePath(pid, deps)
-  return executablePath ? recognizeAgentProcess(executablePath) : null
+  return executablePath ? recognizeAgentFromExecutableImage(executablePath, command) : null
+}
+
+/**
+ * Recognize an agent from a resolved executable image path while preserving the
+ * process's original arguments. Why not basename-only `recognizeAgentProcess`:
+ * it bypasses the command-aware guards in `recognizeAgentProcessFromCommandLine`
+ * (the headless one-shot filter and the generic `orca` vs `orca claude-teams`
+ * rule), so a renamed `claude --print` or a bare `orca` would be mislabeled as
+ * an interactive agent. Substitute the real executable as argv0, keep the args,
+ * and re-run command-line recognition so those guards still apply.
+ */
+export function recognizeAgentFromExecutableImage(
+  executablePath: string,
+  command: string | null | undefined
+): RecognizedAgentProcess | null {
+  const trimmed = (command ?? '').trim()
+  const firstWhitespace = trimmed.search(/\s/)
+  const args = firstWhitespace === -1 ? '' : trimmed.slice(firstWhitespace + 1).trim()
+  // Quote the path so a space inside it stays a single argv0 token.
+  const argv0 = `"${executablePath.replace(/"/g, '')}"`
+  return recognizeAgentProcessFromCommandLine(args ? `${argv0} ${args}` : argv0)
 }
 
 async function readLinuxProcExe(pid: number): Promise<string | null> {

--- a/src/shared/process-executable-recognition.ts
+++ b/src/shared/process-executable-recognition.ts
@@ -1,0 +1,106 @@
+import { execFile as execFileCb } from 'node:child_process'
+import { promisify } from 'node:util'
+import { recognizeAgentProcess, type RecognizedAgentProcess } from './agent-process-recognition'
+
+const execFile = promisify(execFileCb)
+
+// Why: resolving a PID's real executable image forks lsof (macOS) or reads
+// /proc (Linux). Foreground scans on the completion cadence re-inspect the same
+// unrecognized pane, so cache the resolved path per PID behind a short TTL. No
+// process start-time in the key (not cheaply available cross-platform): a
+// recycled PID could serve a stale path for at most one TTL window, but the
+// caller re-runs pure agent recognition on it, so a mismatch merely fails to
+// recognize instead of mislabeling.
+const EXECUTABLE_PATH_CACHE_TTL_MS = 5_000
+const EXECUTABLE_PATH_LOOKUP_TIMEOUT_MS = 3_000
+
+export type ProcessExecutablePathDeps = {
+  platform?: NodeJS.Platform
+  readLinuxExecutable?: (pid: number) => Promise<string | null>
+  readMacExecutable?: (pid: number) => Promise<string | null>
+  now?: () => number
+}
+
+const executablePathCache = new Map<number, { path: string | null; at: number }>()
+
+/**
+ * Resolve a process's real executable image path by PID. Linux reads
+ * `/proc/PID/exe`; macOS uses `lsof -d txt` (the executable image fds). Returns
+ * null on unsupported platforms or when the lookup fails. Cached per PID.
+ */
+export async function resolveProcessExecutablePath(
+  pid: number,
+  deps: ProcessExecutablePathDeps = {}
+): Promise<string | null> {
+  const now = (deps.now ?? Date.now)()
+  const cached = executablePathCache.get(pid)
+  if (cached && now - cached.at < EXECUTABLE_PATH_CACHE_TTL_MS) {
+    return cached.path
+  }
+  const platform = deps.platform ?? process.platform
+  let path: string | null = null
+  if (platform === 'linux') {
+    path = await (deps.readLinuxExecutable ?? readLinuxProcExe)(pid)
+  } else if (platform === 'darwin') {
+    path = await (deps.readMacExecutable ?? readMacExecutableImage)(pid)
+  }
+  executablePathCache.set(pid, { path, at: now })
+  return path
+}
+
+/**
+ * Recognize a renamed/forked agent binary from its real executable image: an
+ * argv0-renamed real binary or a native fork at a non-standard path shows an
+ * unrecognized command line, but its executable basename can still identify the
+ * agent. Interpreter forks (node/python launching a script) resolve to the
+ * interpreter and stay unrecognized here — script CLIs are covered by the
+ * existing argv/entrypoint recognition instead.
+ */
+export async function recognizeAgentFromExecutablePath(
+  pid: number,
+  deps: ProcessExecutablePathDeps = {}
+): Promise<RecognizedAgentProcess | null> {
+  const executablePath = await resolveProcessExecutablePath(pid, deps)
+  return executablePath ? recognizeAgentProcess(executablePath) : null
+}
+
+async function readLinuxProcExe(pid: number): Promise<string | null> {
+  // Why: skip an existsSync gate — the check+read pair races a concurrent exit
+  // anyway, and the catch already yields null. Mirrors resolveProcessCwd.
+  try {
+    const { readlinkSync } = await import('node:fs')
+    return readlinkSync(`/proc/${pid}/exe`)
+  } catch {
+    return null
+  }
+}
+
+async function readMacExecutableImage(pid: number): Promise<string | null> {
+  // Why: `-d txt` limits lsof to text (executable image) fds and `-a` ANDs it
+  // with `-p` so only THIS pid's entries return — the same same-uid per-PID
+  // pattern as resolveProcessCwd. macOS lists the main executable image as the
+  // first txt entry (mapped dylibs follow), so the first `n/…` line is the
+  // image; later entries are ignored defensively.
+  try {
+    const { stdout } = await execFile('lsof', ['-a', '-p', String(pid), '-d', 'txt', '-Fn'], {
+      encoding: 'utf-8',
+      timeout: EXECUTABLE_PATH_LOOKUP_TIMEOUT_MS
+    })
+    for (const line of stdout.split('\n')) {
+      if (line.startsWith('n') && line.includes('/')) {
+        return line.slice(1)
+      }
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Test-only: clear the per-PID executable-path cache so suites that mock the
+ * readers between cases don't have one case's path served to the next.
+ */
+export function resetProcessExecutablePathCacheForTests(): void {
+  executablePathCache.clear()
+}


### PR DESCRIPTION
# Structured foreground result + neutral unknown-alive presence

Part of #9414. Stacked on the `structured-foreground-resolution` branch — review
the commits after its tip (base: `orca/structured-foreground-resolution`).

## Problem

When a pane's foreground process is a live coding agent that Orca does **not**
recognize — a renamed or forked binary (a personal `claude` fork, a wrapper
named `my-agent`, etc.) — the tab-icon resolver collapsed it to a **bare shell**.
The scan result reaching the renderer was "recognized `TuiAgent` or `null`", so
an unrecognized-but-alive foreground was indistinguishable from an empty prompt.
The pane looked idle even while the fork agent was actively working.

The parent branch (server-side recognition of renamed binaries) deliberately
deferred two pieces that only make sense together — the type ships **with** its
consumer, so neither is speculative plumbing:

1. a **structured foreground result** that carries the raw process name, not just
   the recognized-or-null engine, and
2. a renderer layer that turns that raw name into a **neutral live identity**.

## Design (the two parts, shipped together)

**1. Structured foreground result.** New concretely-named shared module
`src/shared/foreground-process-resolution.ts` exports
`ForegroundProcessResolution { engine: TuiAgent | null; rawProcessName: string |
null; isShell: boolean }` and `resolveForegroundProcess(name)`. The deployed-relay
wire contract stays `string | null` (parent-branch decision); every consumer that
only has the legacy string rebuilds the structure locally via
`resolveForegroundProcess` — i.e. `{ engine: recognize(...), rawProcessName,
isShell: isShellProcess(...) }`. The path is threaded **only** where the consumer
needs it:

- `pane-foreground-agent-tracker.ts` publishes `rawProcessName` on the one entry
  the consumer reads — the command-path publish for a live, non-shell,
  unrecognized foreground. Recognized agents still publish their engine; shells
  carry no raw name (the consumer rejects them). No daemon cache rework.
- The `pane-foreground-agent` store slice: entries gain an optional
  `rawProcessName`, and a new `resolveFreshPaneForegroundRawProcess` reuses
  #9415's exact TTL + PTY-binding freshness gate (extracted into one shared
  helper, so the existing `resolveFreshPaneForegroundAgent` behavior is byte-for-
  byte unchanged).

**2. Neutral unknown-alive presence.** `use-tab-agent.ts` gains an additive
return type `TabAgentIdentity = TuiAgent | { kind: 'unknown-live'; label: string }
| null`. After every existing recognized layer resolves null, the precedence
chain falls through to an unknown-live identity **only** when the pane's fresh
(TTL/PTY-gated, local-only) foreground reports a non-shell `rawProcessName`
**and** the title shows agent activity (spinner/working/needs-input via the
existing `detectAgentStatusFromTitle` classification). The label is the raw
process name — never a fake `TuiAgent`, never a vendor name.

**The vim/htop boundary.** The title-activity requirement is exactly what
separates a fork agent from a full-screen text editor: vim and htop set static
titles that classify to *no* activity, so they never gain agent presence. This
is stated in a why-comment and tested at both the resolver and hook levels.

**3. UI.** `TerminalTabLeadingIcon` and the SortableTab drag overlay
(`TabDragPreview`) render the unknown-live identity with an existing neutral
glyph — the lucide `Terminal` icon (the same generic terminal/process glyph the
drag ghost already uses for plain terminals), with the raw process name as its
tooltip. Recognized agents render exactly as before.

## Non-goals (unchanged from #9415/parent)

- **No sidebar agent row** and **no worktree ring change** — those read the
  recognized-agent field (`resolveFreshPaneForegroundAgent`), which stays null
  for unknown-live evidence.
- **No busy / keep-awake change** — keep-awake holds on recognized engines only;
  an unknown-live entry has `agent: null`, so it never holds the machine awake.
- **No persistence** — unknown-live identity is runtime-derived evidence and is
  never written into workspace session persistence.

## Cross-platform / SSH / WSL

Unknown-live is strictly local: remote/SSH/WSL panes produce no foreground
process evidence (the tracker excludes non-trackable PTYs), and the hook
short-circuits `isRemoteLike`, so remote tabs degrade to their existing
title/hook identity with no behavior change.

## Tests

- `foreground-process-resolution.test.ts` — old-relay string degradation
  (recognized / unrecognized non-shell / shell / null).
- `pane-foreground-agent.test.ts` — entries carry `rawProcessName`;
  `resolveFreshPaneForegroundRawProcess` fresh/stale/PTY-mismatch/shell/engine
  gates; existing `resolveFreshPaneForegroundAgent` tests stay green untouched.
- `pane-foreground-agent-tracker.test.ts` — the persistent-unknown-process publish
  now carries the raw name (unknown-live source).
- `use-tab-agent-process-signals.test.ts` — resolver: working title → unknown-live,
  no activity → null (vim), engine wins; hook: non-shell raw name + working title
  → unknown-live, vim static title → null, shell raw name → null, stale evidence
  → null.
- `TerminalTabLeadingIcon.test.tsx` — unknown-live renders the neutral glyph +
  raw-name tooltip; recognized provider still wins.

Targeted vitest + typecheck (node/cli/web) + oxlint on touched files all green.

## ELI5

When a terminal is running an agent binary Orca does not recognize by name, the tab no longer pretends it is a bare shell. Unknown-but-alive agents get a neutral presence so status and icons stay honest.
