### PR TITLE
fix(win): launch Store-installed PowerShell 7 in terminals

### DIFF
--- a/src/main/providers/windows-powershell-executable.test.ts
+++ b/src/main/providers/windows-powershell-executable.test.ts
@@ -19,6 +19,8 @@ const WINDOWS_POWERSHELL = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powe
 // The Microsoft Store App Execution Alias stub for pwsh — a zero-byte reparse
 // point under WindowsApps that ConPTY's CreateProcessW rejects with error 5.
 const PWSH_STORE_ALIAS = 'C:\\Users\\dev\\AppData\\Local\\Microsoft\\WindowsApps\\pwsh.exe'
+const PWSH_STORE_EXE =
+  'C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.3.0_x64__8wekyb3d8bbwe\\pwsh.exe'
 
 describe('resolveWindowsPowerShellExecutablePath', () => {
   it('returns null on non-Windows platforms', () => {
@@ -80,6 +82,35 @@ describe('resolveWindowsPowerShellExecutablePath', () => {
     expect(resolved).not.toBe(PWSH_STORE_ALIAS)
   })
 
+  it('repro: resolves a Store App Execution Alias to its real package executable', () => {
+    const resolved = resolveWindowsPowerShellExecutablePath('pwsh.exe', {
+      platform: 'win32',
+      env: {
+        ...WIN_ENV,
+        Path: 'C:\\Users\\dev\\AppData\\Local\\Microsoft\\WindowsApps'
+      },
+      isRealExecutable: (p) => p === PWSH_STORE_EXE,
+      resolveAppExecutionAlias: (p) => (p === PWSH_STORE_ALIAS ? PWSH_STORE_EXE : null)
+    })
+    expect(resolved).toBe(PWSH_STORE_EXE)
+  })
+
+  it.each(['pwsh.exe', PWSH_STORE_ALIAS, 'C:\\Tools\\powershell.exe'])(
+    'rejects unsafe Store alias target %s',
+    (target) => {
+      const resolved = resolveWindowsPowerShellExecutablePath('pwsh.exe', {
+        platform: 'win32',
+        env: {
+          ...WIN_ENV,
+          Path: 'C:\\Users\\dev\\AppData\\Local\\Microsoft\\WindowsApps'
+        },
+        isRealExecutable: (p) => p === target,
+        resolveAppExecutionAlias: (p) => (p === PWSH_STORE_ALIAS ? target : null)
+      })
+      expect(resolved).toBeNull()
+    }
+  )
+
   it('returns null for pwsh when no real executable is found', () => {
     expect(
       resolveWindowsPowerShellExecutablePath('pwsh.exe', {
@@ -110,6 +141,19 @@ describe('resolveWindowsPowerShellSpawnChain', () => {
     })
     expect(chain).toEqual([WINDOWS_POWERSHELL, WIN_ENV.ComSpec])
     expect(chain).not.toContain(PWSH_STORE_ALIAS)
+  })
+
+  it('uses the real Store package executable ahead of Windows PowerShell', () => {
+    const chain = resolveWindowsPowerShellSpawnChain('pwsh.exe', {
+      platform: 'win32',
+      env: {
+        ...WIN_ENV,
+        Path: 'C:\\Users\\dev\\AppData\\Local\\Microsoft\\WindowsApps'
+      },
+      isRealExecutable: (p) => p === PWSH_STORE_EXE || p === WINDOWS_POWERSHELL,
+      resolveAppExecutionAlias: (p) => (p === PWSH_STORE_ALIAS ? PWSH_STORE_EXE : null)
+    })
+    expect(chain).toEqual([PWSH_STORE_EXE, WINDOWS_POWERSHELL, WIN_ENV.ComSpec])
   })
 
   it('orders PATH-resolved pwsh before Windows PowerShell when standard roots miss', () => {

--- a/src/main/providers/windows-powershell-executable.ts
+++ b/src/main/providers/windows-powershell-executable.ts
@@ -1,4 +1,4 @@
-import { existsSync, statSync } from 'node:fs'
+import { existsSync, readlinkSync, statSync } from 'node:fs'
 import { win32 as pathWin32 } from 'node:path'
 
 /** Dependency seams so the resolver can be unit-tested without a real Windows
@@ -7,6 +7,8 @@ export type WindowsPowerShellResolveOptions = {
   env?: NodeJS.ProcessEnv
   /** Returns true when the candidate path is a real, non-empty executable. */
   isRealExecutable?: (path: string) => boolean
+  /** Resolves a Store App Execution Alias to its package executable. */
+  resolveAppExecutionAlias?: (path: string) => string | null
   platform?: NodeJS.Platform
 }
 
@@ -34,6 +36,15 @@ function defaultIsRealExecutable(candidate: string): boolean {
     return stat.isFile() && stat.size > 0
   } catch {
     return false
+  }
+}
+
+function defaultResolveAppExecutionAlias(candidate: string): string | null {
+  try {
+    const target = readlinkSync(candidate)
+    return pathWin32.resolve(pathWin32.dirname(candidate), target)
+  } catch {
+    return null
   }
 }
 
@@ -154,6 +165,8 @@ export function resolveWindowsPowerShellExecutablePath(
   }
   const env = options.env ?? process.env
   const isRealExecutable = options.isRealExecutable ?? defaultIsRealExecutable
+  const resolveAppExecutionAlias =
+    options.resolveAppExecutionAlias ?? defaultResolveAppExecutionAlias
 
   if (family === 'powershell.exe') {
     const windowsPowerShell = getWindowsPowerShellPath(env)
@@ -161,7 +174,22 @@ export function resolveWindowsPowerShellExecutablePath(
   }
 
   for (const candidate of getPwshCandidatePaths(env)) {
-    if (!isWindowsAppExecutionAliasPath(candidate) && isRealExecutable(candidate)) {
+    if (isWindowsAppExecutionAliasPath(candidate)) {
+      const target = resolveAppExecutionAlias(candidate)
+      // Why: ConPTY cannot launch the alias reparse point, but its real Store
+      // package target is a normal executable that preserves the user's pwsh choice.
+      if (
+        target &&
+        pathWin32.isAbsolute(target) &&
+        pathWin32.basename(target).toLowerCase() === 'pwsh.exe' &&
+        !isWindowsAppExecutionAliasPath(target) &&
+        isRealExecutable(target)
+      ) {
+        return pathWin32.normalize(target)
+      }
+      continue
+    }
+    if (isRealExecutable(candidate)) {
       return candidate
     }
   }

--- a/src/main/providers/windows-powershell-executable.ts
+++ b/src/main/providers/windows-powershell-executable.ts
@@ -151,9 +151,8 @@ export function getWindowsCmdPath(env: NodeJS.ProcessEnv = process.env): string 
 /**
  * Resolve a PowerShell family name to a real absolute executable path.
  *
- * Returns null when no real executable can be found for the family (e.g. pwsh.exe
- * is only present as a Store App Execution Alias stub). Callers fall back to the
- * next link in the Windows shell chain when this returns null.
+ * Returns null when no real executable or safely resolvable Store alias target
+ * can be found for the family. Callers then try the next Windows shell fallback.
  */
 export function resolveWindowsPowerShellExecutablePath(
   family: 'pwsh.exe' | 'powershell.exe',


### PR DESCRIPTION
## Summary

Fix Windows terminals configured for automatic PowerShell selection when PowerShell 7 is installed from the Microsoft Store.

Orca's availability probe could launch the Store App Execution Alias (`%LOCALAPPDATA%\Microsoft\WindowsApps\pwsh.exe`), but the ConPTY path resolver correctly rejected that zero-byte reparse point and then failed to find the real package executable. The spawn chain therefore fell back silently to inbox Windows PowerShell 5.1.

On the reproduced machine, that fallback changed the effective execution-policy behavior:

- PowerShell 7.6.3: `RemoteSigned`; `codex.ps1` runs
- Windows PowerShell 5.1: every policy scope `Undefined`, which defaults to `Restricted`; the profile and `codex.ps1` are blocked

This change follows the Store alias reparse point to the actual package executable, then accepts it only when the target is:

- absolute
- named `pwsh.exe`
- outside the App Execution Alias directory
- a real, non-empty file

If resolution or validation fails, the existing Windows PowerShell -> cmd.exe fallback chain remains unchanged. Orca does not set, bypass, or otherwise weaken the user's execution policy.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — changed-file Oxlint and pre-commit checks pass; the repository-wide command remains blocked by unrelated baseline failures: a non-exhaustive switch in `skill-freshness-group.tsx` and stale generated skill manifests
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the repository-wide run exceeded the 5-minute harness limit; no result is claimed
- [ ] `pnpm build` — not run; no bundling or dependency surface changed
- [x] Added or updated high-quality tests that would catch regressions

Focused regression coverage:

- 120/120 tests passed across:
  - `windows-powershell-executable.test.ts`
  - `windows-shell-fallback-chain.test.ts`
  - `windows-shell-args.test.ts`
  - `local-pty-provider.test.ts`
- New tests cover Store-target resolution, spawn-chain ordering, and rejection of relative, recursive-alias, and wrong-executable targets.
- `git diff --check` passed.
- Husky/lint-staged pre-commit checks passed.

Live Windows verification on the reported machine:

1. Restricted the resolver input PATH to the Store alias directory so the normal package-directory PATH entry could not mask the bug.
2. The patched production resolver returned `C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.3.0_x64__8wekyb3d8bbwe\pwsh.exe`.
3. Spawned that exact path through the same `node-pty`/ConPTY mechanism Orca uses.
4. Confirmed `Get-ExecutionPolicy` returned `RemoteSigned`.
5. Executed the exact npm `codex.ps1` shim; it returned `codex-cli 0.144.6` and exit code 0.

## AI Review Report

An independent agent reviewed the diagnosis, implementation, tests, and live reproduction. It confirmed that the fix is scoped at the actual mismatch: automatic PowerShell 7 detection succeeded, but executable resolution could not turn the Store alias into a ConPTY-launchable path.

The review checked:

- alias/reparse-point handling and fail-safe fallback behavior
- local-provider and daemon-provider use of the shared resolver
- Store update behavior (the target is resolved dynamically rather than version-hardcoded)
- Windows path normalization and executable identity checks
- accidental execution-policy weakening
- macOS/Linux behavior (the resolver returns before any Windows-specific work on non-Windows platforms)
- SSH/relay behavior (unchanged; no assumptions or launch changes were added to remote shells)
- Electron/ConPTY behavior using a real PTY spawn
- UI shortcuts, labels, and rendering (not touched)

It suggested explicit malformed-target coverage; those cases were added before commit. No unresolved issue was found in the changed code.

## Security Audit

- No execution-policy override or `Bypass` flag is introduced.
- The zero-byte App Execution Alias is still never passed to ConPTY.
- A resolved target must be absolute, retain the expected `pwsh.exe` basename, not point back into the alias directory, and pass the existing real/non-empty executable check.
- Reparse resolution and filesystem inspection failures are caught and fail closed into the existing PowerShell 5.1/cmd fallback chain.
- No new command interpolation, shell input, IPC, authentication, secret, network, or dependency surface is added.
- PATH is already an input to executable discovery; this patch does not broaden accepted executable names and adds validation around the newly followed target.

## Notes

This specifically fixes Store-installed PowerShell 7. MSI/per-user installs and explicit Windows PowerShell selections keep their existing behavior. Because the alias target is read during resolution, Microsoft Store upgrades that change the versioned package directory are picked up without hardcoded paths.