### PR TITLE
fix(gitlab): stop refresh button overlapping dialog close X

### DIFF
--- a/src/renderer/src/components/GitLabItemDialog.tsx
+++ b/src/renderer/src/components/GitLabItemDialog.tsx
@@ -24,7 +24,13 @@ import {
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
-import { Sheet, SheetContent, SheetDescription, SheetTitle } from '@/components/ui/sheet'
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetTitle
+} from '@/components/ui/sheet'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { VisuallyHidden } from 'radix-ui'
 import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
@@ -1008,7 +1014,12 @@ export default function GitLabItemDialog({
 
   return (
     <Sheet open={item !== null} onOpenChange={(open) => !open && onClose()}>
-      <SheetContent side="right" className="flex w-full flex-col gap-0 p-0 sm:max-w-2xl">
+      {/* Why: the sheet's absolute default close control would overlap this header's actions. */}
+      <SheetContent
+        side="right"
+        showCloseButton={false}
+        className="flex w-full flex-col gap-0 p-0 sm:max-w-2xl"
+      >
         <VisuallyHidden.Root>
           <SheetTitle>
             {item
@@ -1022,7 +1033,7 @@ export default function GitLabItemDialog({
 
         {item ? (
           <>
-            <header className="flex-none border-b border-border/40 py-4 pl-5 pr-10">
+            <header className="flex-none border-b border-border/40 px-5 py-4">
               <div className="flex items-start gap-3">
                 <Icon className="mt-0.5 size-5 text-muted-foreground" />
                 <div className="min-w-0 flex-1">
@@ -1055,20 +1066,32 @@ export default function GitLabItemDialog({
                     </div>
                   ) : null}
                 </div>
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  aria-label={translate('auto.components.GitLabItemDialog.b3c156dd51', 'Refresh')}
-                  disabled={loading}
-                  onClick={handleRefresh}
-                  className="-mt-1.5 size-7"
-                >
-                  {loading ? (
-                    <LoaderCircle className="size-3.5 animate-spin" />
-                  ) : (
-                    <RefreshCw className="size-3.5" />
-                  )}
-                </Button>
+                <div className="flex shrink-0 items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label={translate('auto.components.GitLabItemDialog.b3c156dd51', 'Refresh')}
+                    disabled={loading}
+                    onClick={handleRefresh}
+                    className="size-7"
+                  >
+                    {loading ? (
+                      <LoaderCircle className="size-3.5 animate-spin" />
+                    ) : (
+                      <RefreshCw className="size-3.5" />
+                    )}
+                  </Button>
+                  <SheetClose asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      className="size-7"
+                      aria-label={translate('auto.components.GitLabItemDialog.a199eb364b', 'Close')}
+                    >
+                      <X className="size-3.5" />
+                    </Button>
+                  </SheetClose>
+                </div>
               </div>
             </header>
 

--- a/src/renderer/src/components/GitLabItemDialog.tsx
+++ b/src/renderer/src/components/GitLabItemDialog.tsx
@@ -1022,7 +1022,7 @@ export default function GitLabItemDialog({
 
         {item ? (
           <>
-            <header className="flex-none border-b border-border/40 px-5 py-4">
+            <header className="flex-none border-b border-border/40 py-4 pl-5 pr-10">
               <div className="flex items-start gap-3">
                 <Icon className="mt-0.5 size-5 text-muted-foreground" />
                 <div className="min-w-0 flex-1">
@@ -1061,7 +1061,7 @@ export default function GitLabItemDialog({
                   aria-label={translate('auto.components.GitLabItemDialog.b3c156dd51', 'Refresh')}
                   disabled={loading}
                   onClick={handleRefresh}
-                  className="size-7"
+                  className="-mt-1.5 size-7"
                 >
                   {loading ? (
                     <LoaderCircle className="size-3.5 animate-spin" />


### PR DESCRIPTION

## Summary

In the GitLab item dialog, the header refresh button overlapped the sheet's built-in close (X) in the top-right corner. This reserves right-side space on the header (px-5 → pl-5 pr-10) so the refresh button clears the close X, and lifts the refresh button (-mt-1.5) so its icon aligns with the close X on the same line. The Sheet's close button is unchanged.

## Screenshots

Before:

<img width="664" height="347" alt="2026-07-19_14-04-00" src="https://github.com/user-attachments/assets/29bf2521-001b-43a8-b7d3-ef4b0c640c10" />

After:

<img width="675" height="342" alt="image" src="https://github.com/user-attachments/assets/d364d6d9-dcdb-4f0b-b0f7-b2afad61fb3b" />

## Testing

- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] Manually verified.

## AI Review Report

> Reviewed the class change for layout correctness: confirmed the close X geometry and that pr-10 (40px) clears it. No JS/logic touched. Cross-platform: Tailwind padding rendered by Chromium/Electron identically on macOS, Linux, Windows — no shortcuts, paths, shell, or platform APIs. Holds at the sheet's responsive widths (w-full, sm:max-w-2xl).


## Security Audit

No security surface.