### PR TITLE
feat(cli): add --repo scoping to worktree ps and terminal list

### DIFF
--- a/src/cli/handlers/terminal.test.ts
+++ b/src/cli/handlers/terminal.test.ts
@@ -61,3 +61,26 @@ describe('terminal close CLI', () => {
     expect(help).toContain('durable persistence')
   })
 })
+
+describe('terminal list handler', () => {
+  it('forwards repo scope while preserving an explicit worktree selector', async () => {
+    const call = vi.fn().mockResolvedValue({ result: { terminals: [] } })
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await TERMINAL_HANDLERS['terminal list']({
+      flags: new Map([
+        ['repo', 'id:repo-a'],
+        ['worktree', 'id:repo-a::/worktree']
+      ]),
+      client: { isRemote: false, call } as unknown as RuntimeClient,
+      cwd: '/worktree',
+      json: true
+    })
+
+    expect(call).toHaveBeenCalledWith('terminal.list', {
+      worktree: 'id:repo-a::/worktree',
+      repo: 'id:repo-a',
+      limit: undefined
+    })
+  })
+})

--- a/src/cli/handlers/terminal.ts
+++ b/src/cli/handlers/terminal.ts
@@ -34,6 +34,7 @@ import { RuntimeClientError } from '../runtime-client'
 import {
   getBrowserWorktreeSelector,
   getOptionalWorktreeSelector,
+  resolveRepoSelectorFlag,
   getRequiredWorktreeSelector,
   getTerminalHandle
 } from '../selectors'
@@ -52,8 +53,10 @@ const terminalFocusHandler: CommandHandler = async ({ flags, client, cwd, json }
 
 export const TERMINAL_HANDLERS: Record<string, CommandHandler> = {
   'terminal list': async ({ flags, client, cwd, json }) => {
+    const repo = await resolveRepoSelectorFlag(flags, cwd, client)
     const result = await client.call<RuntimeTerminalListResult>('terminal.list', {
       worktree: await getOptionalWorktreeSelector(flags, 'worktree', cwd, client),
+      ...(repo ? { repo } : {}),
       limit: getOptionalPositiveIntegerFlag(flags, 'limit')
     })
     printResult(result, json, formatTerminalList)

--- a/src/cli/handlers/worktree.test.ts
+++ b/src/cli/handlers/worktree.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RuntimeClient } from '../runtime-client'
+import { WORKTREE_HANDLERS } from './worktree'
+
+describe('worktree ps handler', () => {
+  it('resolves and forwards the active repo scope', async () => {
+    const call = vi
+      .fn()
+      .mockResolvedValueOnce({
+        result: { worktrees: [{ id: 'repo-a::/worktree', path: '/worktree' }] }
+      })
+      .mockResolvedValueOnce({ result: { worktrees: [], totalCount: 0, truncated: false } })
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await WORKTREE_HANDLERS['worktree ps']({
+      flags: new Map([['repo', 'active']]),
+      client: { isRemote: false, call } as unknown as RuntimeClient,
+      cwd: '/worktree/src',
+      json: true
+    })
+
+    expect(call).toHaveBeenNthCalledWith(1, 'worktree.list', { limit: 10_000 })
+    expect(call).toHaveBeenNthCalledWith(2, 'worktree.ps', {
+      repo: 'id:repo-a',
+      limit: undefined
+    })
+  })
+})

--- a/src/cli/handlers/worktree.ts
+++ b/src/cli/handlers/worktree.ts
@@ -17,8 +17,10 @@ import {
 } from '../flags'
 import {
   getOptionalWorktreeSelector,
+  getRepoSelectorFromWorktreeSelector,
   getRequiredWorktreeSelector,
-  resolveCurrentWorktreeSelector
+  resolveCurrentWorktreeSelector,
+  resolveRepoSelectorFlag
 } from '../selectors'
 import { isTuiAgent } from '../../shared/tui-agent-config'
 import { isWorkspaceKey, worktreeWorkspaceKey } from '../../shared/workspace-scope'
@@ -134,18 +136,6 @@ function getOptionalSetupDecision(
   return setup
 }
 
-function getRepoSelectorFromWorktreeSelector(selector: string | undefined): string | undefined {
-  if (!selector?.startsWith('id:')) {
-    return undefined
-  }
-  const worktreeId = selector.slice('id:'.length)
-  const separatorIndex = worktreeId.indexOf('::')
-  if (separatorIndex <= 0) {
-    return undefined
-  }
-  return `id:${worktreeId.slice(0, separatorIndex)}`
-}
-
 async function getCreateRepoSelector(
   flags: Map<string, string | boolean>,
   cwdParentWorktree: string | undefined,
@@ -170,8 +160,10 @@ async function getCreateRepoSelector(
 }
 
 export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
-  'worktree ps': async ({ flags, client, json }) => {
+  'worktree ps': async ({ flags, client, cwd, json }) => {
+    const repo = await resolveRepoSelectorFlag(flags, cwd, client)
     const result = await client.call<RuntimeWorktreePsResult>('worktree.ps', {
+      ...(repo ? { repo } : {}),
       limit: getOptionalPositiveIntegerFlag(flags, 'limit')
     })
     printResult(result, json, formatWorktreePs)

--- a/src/cli/selectors.test.ts
+++ b/src/cli/selectors.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getRepoSelectorFromWorktreeSelector, resolveRepoSelectorFlag } from './selectors'
+
+describe('repo selectors', () => {
+  it('extracts the repo from an explicit worktree id', () => {
+    expect(getRepoSelectorFromWorktreeSelector('id:repo-a::/worktree')).toBe('id:repo-a')
+  })
+
+  it('passes explicit repo selectors through unchanged', async () => {
+    const client = { isRemote: false, call: vi.fn() }
+    await expect(
+      resolveRepoSelectorFlag(new Map([['repo', 'name:repo-a']]), '/cwd', client as never)
+    ).resolves.toBe('name:repo-a')
+    expect(client.call).not.toHaveBeenCalled()
+  })
+
+  it('resolves active to the enclosing worktree repo', async () => {
+    const client = {
+      isRemote: false,
+      call: vi.fn().mockResolvedValue({
+        result: { worktrees: [{ id: 'repo-a::/worktree', path: '/worktree' }] }
+      })
+    }
+    await expect(
+      resolveRepoSelectorFlag(new Map([['repo', 'active']]), '/worktree/src', client as never)
+    ).resolves.toBe('id:repo-a')
+  })
+})

--- a/src/cli/selectors.test.ts
+++ b/src/cli/selectors.test.ts
@@ -4,6 +4,12 @@ import { getRepoSelectorFromWorktreeSelector, resolveRepoSelectorFlag } from './
 describe('repo selectors', () => {
   it('extracts the repo from an explicit worktree id', () => {
     expect(getRepoSelectorFromWorktreeSelector('id:repo-a::/worktree')).toBe('id:repo-a')
+    expect(getRepoSelectorFromWorktreeSelector('id:repo-a::/worktree::nested')).toBe('id:repo-a')
+  })
+
+  it('does not infer a repo from incomplete worktree selectors', () => {
+    expect(getRepoSelectorFromWorktreeSelector('id:repo-a')).toBeUndefined()
+    expect(getRepoSelectorFromWorktreeSelector('id:::/worktree')).toBeUndefined()
   })
 
   it('passes explicit repo selectors through unchanged', async () => {
@@ -23,6 +29,18 @@ describe('repo selectors', () => {
     }
     await expect(
       resolveRepoSelectorFlag(new Map([['repo', 'active']]), '/worktree/src', client as never)
+    ).resolves.toBe('id:repo-a')
+  })
+
+  it('resolves current as the same cwd shortcut', async () => {
+    const client = {
+      isRemote: false,
+      call: vi.fn().mockResolvedValue({
+        result: { worktrees: [{ id: 'repo-a::/worktree', path: '/worktree' }] }
+      })
+    }
+    await expect(
+      resolveRepoSelectorFlag(new Map([['repo', 'current']]), '/worktree/src', client as never)
     ).resolves.toBe('id:repo-a')
   })
 })

--- a/src/cli/selectors.ts
+++ b/src/cli/selectors.ts
@@ -5,6 +5,7 @@ import type {
   RuntimeWorktreeRecord
 } from '../shared/runtime-types'
 import { isPathInsideOrEqual } from '../shared/cross-platform-path'
+import { splitWorktreeId } from '../shared/worktree-id'
 import type { RuntimeClient } from './runtime-client'
 import { RuntimeClientError } from './runtime-client'
 import { getOptionalStringFlag, getRequiredStringFlag } from './flags'
@@ -104,12 +105,8 @@ export function getRepoSelectorFromWorktreeSelector(
   if (!selector?.startsWith('id:')) {
     return undefined
   }
-  const worktreeId = selector.slice('id:'.length)
-  const separatorIndex = worktreeId.indexOf('::')
-  if (separatorIndex <= 0) {
-    return undefined
-  }
-  return `id:${worktreeId.slice(0, separatorIndex)}`
+  const repoId = splitWorktreeId(selector.slice('id:'.length))?.repoId
+  return repoId ? `id:${repoId}` : undefined
 }
 
 export async function resolveRepoSelectorFlag(

--- a/src/cli/selectors.ts
+++ b/src/cli/selectors.ts
@@ -98,6 +98,35 @@ export async function getOptionalWorktreeSelector(
   return normalizeWorktreeSelector(value, cwd)
 }
 
+export function getRepoSelectorFromWorktreeSelector(
+  selector: string | undefined
+): string | undefined {
+  if (!selector?.startsWith('id:')) {
+    return undefined
+  }
+  const worktreeId = selector.slice('id:'.length)
+  const separatorIndex = worktreeId.indexOf('::')
+  if (separatorIndex <= 0) {
+    return undefined
+  }
+  return `id:${worktreeId.slice(0, separatorIndex)}`
+}
+
+export async function resolveRepoSelectorFlag(
+  flags: Map<string, string | boolean>,
+  cwd: string,
+  client: RuntimeClient
+): Promise<string | undefined> {
+  const value = getOptionalStringFlag(flags, 'repo')
+  if (!value) {
+    return undefined
+  }
+  if (value === 'active' || value === 'current') {
+    return getRepoSelectorFromWorktreeSelector(await resolveCurrentWorktreeSelector(cwd, client))
+  }
+  return value
+}
+
 export async function getRequiredWorktreeSelector(
   flags: Map<string, string | boolean>,
   name: string,

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -174,14 +174,14 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
   {
     path: ['worktree', 'ps'],
     summary: 'Show a compact orchestration summary across worktrees',
-    usage: 'orca worktree ps [--limit <n>] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'limit']
+    usage: 'orca worktree ps [--repo <selector>] [--limit <n>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'repo', 'limit']
   },
   {
     path: ['terminal', 'list'],
     summary: 'List live Orca-managed terminals',
-    usage: 'orca terminal list [--worktree <selector>] [--limit <n>] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'worktree', 'limit']
+    usage: 'orca terminal list [--worktree <selector>] [--repo <selector>] [--limit <n>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'worktree', 'repo', 'limit']
   },
   {
     path: ['terminal', 'show'],

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -19427,7 +19427,7 @@ describe('OrcaRuntimeService', () => {
           {
             path: repoBWorktreePath,
             head: 'def',
-            branch: 'feature/bar',
+            branch: 'feature/foo',
             isBare: false,
             isMainWorktree: false
           }
@@ -19495,6 +19495,36 @@ describe('OrcaRuntimeService', () => {
       'pty-fallback-a'
     ])
     expect(listed.terminals.map((terminal) => terminal.preview)).toEqual(['', 'repo a fallback'])
+
+    const scopedByBranch = await runtime.listTerminals('branch:feature/foo', undefined, {
+      repoSelector: `id:${TEST_REPO_ID}`
+    })
+    expect(scopedByBranch.terminals).toHaveLength(2)
+    expect(
+      scopedByBranch.terminals.every((terminal) => terminal.worktreeId === TEST_WORKTREE_ID)
+    ).toBe(true)
+  })
+
+  it('keeps repo scope authoritative when listing an explicit worktree', async () => {
+    const repoB = {
+      id: 'repo-2',
+      path: '/tmp/repo-b',
+      displayName: 'repo-b',
+      badgeColor: 'green',
+      addedAt: 2
+    }
+    const repos = [store.getRepos()[0]!, repoB]
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getRepos: () => repos,
+      getRepo: (id: string) => repos.find((repo) => repo.id === id)
+    } as never)
+
+    await expect(
+      runtime.listTerminals(`id:${TEST_WORKTREE_ID}`, undefined, {
+        repoSelector: `id:${repoB.id}`
+      })
+    ).rejects.toThrow('selector_not_found')
   })
 
   it('shows and resolves active PTY-backed mobile session terminals without a renderer graph', async () => {
@@ -23994,7 +24024,9 @@ describe('OrcaRuntimeService', () => {
       createFolderWorkspaceRuntimeStore(folderWorkspace, projectGroup) as never
     )
 
-    const listed = await runtime.getWorktreePs(`id:${TEST_REPO_ID}`)
+    const listed = await runtime.getWorktreePs(undefined, {
+      repoSelector: `id:${TEST_REPO_ID}`
+    })
 
     expect(
       listed.worktrees.find((worktree) => worktree.worktreeId === TEST_FOLDER_WORKSPACE_KEY)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -19395,6 +19395,108 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('filters renderer and PTY-only terminals by repo selector before counting', async () => {
+    const repoB = {
+      id: 'repo-2',
+      path: '/tmp/repo-b',
+      displayName: 'repo-b',
+      badgeColor: 'green',
+      addedAt: 2
+    }
+    const repoBWorktreePath = '/tmp/worktree-b'
+    const repoBWorktreeId = `${repoB.id}::${repoBWorktreePath}`
+    const metaById: Record<string, WorktreeMeta> = {
+      [TEST_WORKTREE_ID]: makeWorktreeMeta({ displayName: 'Repo A' }),
+      [repoBWorktreeId]: makeWorktreeMeta({ displayName: 'Repo B' })
+    }
+    const repos = [store.getRepos()[0]!, repoB]
+    const runtimeStore = {
+      ...store,
+      getRepos: () => repos,
+      getRepo: (id: string) => repos.find((repo) => repo.id === id),
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {
+        metaById[worktreeId] = { ...(metaById[worktreeId] ?? makeWorktreeMeta()), ...meta }
+        return metaById[worktreeId]
+      }
+    }
+    vi.mocked(listWorktrees).mockImplementation(async (repoPath: string) => {
+      if (repoPath === repoB.path) {
+        return [
+          {
+            path: repoBWorktreePath,
+            head: 'def',
+            branch: 'feature/bar',
+            isBare: false,
+            isMainWorktree: false
+          }
+        ]
+      }
+      return MOCK_GIT_WORKTREES
+    })
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-a',
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'Repo A graph',
+          activeLeafId: 'pane:1',
+          layout: null
+        },
+        {
+          tabId: 'tab-b',
+          worktreeId: repoBWorktreeId,
+          title: 'Repo B graph',
+          activeLeafId: 'pane:2',
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-a',
+          worktreeId: TEST_WORKTREE_ID,
+          leafId: 'pane:1',
+          paneRuntimeId: 1,
+          ptyId: 'pty-graph-a'
+        },
+        {
+          tabId: 'tab-b',
+          worktreeId: repoBWorktreeId,
+          leafId: 'pane:2',
+          paneRuntimeId: 1,
+          ptyId: 'pty-graph-b'
+        }
+      ]
+    })
+    runtime.registerPty('pty-fallback-a', TEST_WORKTREE_ID)
+    runtime.registerPty('pty-fallback-b', repoBWorktreeId)
+    runtime.onPtyData('pty-fallback-a', 'repo a fallback\r\n', 123)
+    runtime.onPtyData('pty-fallback-b', 'repo b fallback\r\n', 124)
+
+    const listed = await runtime.listTerminals(undefined, undefined, {
+      repoSelector: `id:${TEST_REPO_ID}`
+    })
+
+    expect(listed).toMatchObject({ totalCount: 2, truncated: false })
+    expect(listed.terminals).toHaveLength(2)
+    expect(listed.terminals.every((terminal) => terminal.worktreeId === TEST_WORKTREE_ID)).toBe(
+      true
+    )
+    expect(listed.terminals.map((terminal) => terminal.worktreePath)).toEqual([
+      TEST_WORKTREE_PATH,
+      TEST_WORKTREE_PATH
+    ])
+    expect(listed.terminals.map((terminal) => terminal.ptyId)).toEqual([
+      'pty-graph-a',
+      'pty-fallback-a'
+    ])
+    expect(listed.terminals.map((terminal) => terminal.preview)).toEqual(['', 'repo a fallback'])
+  })
+
   it('shows and resolves active PTY-backed mobile session terminals without a renderer graph', async () => {
     const spawn = vi.fn().mockResolvedValue({ id: 'laptop-created-pty' })
     const runtime = new OrcaRuntimeService(store)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -23984,6 +23984,25 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('excludes folder workspaces from repo-scoped compact worktree summaries', async () => {
+    const folderWorkspace = makeFolderWorkspace({
+      name: 'GG',
+      comment: 'dujiao-next-eval'
+    })
+    const projectGroup = makeFolderProjectGroup({ name: 'Store' })
+    const runtime = new OrcaRuntimeService(
+      createFolderWorkspaceRuntimeStore(folderWorkspace, projectGroup) as never
+    )
+
+    const listed = await runtime.getWorktreePs(`id:${TEST_REPO_ID}`)
+
+    expect(
+      listed.worktrees.find((worktree) => worktree.worktreeId === TEST_FOLDER_WORKSPACE_KEY)
+    ).toBeUndefined()
+    expect(listed.worktrees.every((worktree) => worktree.repoId === TEST_REPO_ID)).toBe(true)
+    expect(listed).toMatchObject({ totalCount: 1, truncated: false })
+  })
+
   it('attaches inline agent rows from the latest OSC 9999 status', async () => {
     const runtime = new OrcaRuntimeService(store)
     const leafId = '22222222-2222-4222-8222-222222222222'

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -10841,6 +10841,7 @@ export class OrcaRuntimeService {
       throw new Error('invalid_limit')
     }
     const graphEpoch = this.graphStatus === 'ready' ? this.rendererGraphEpoch : null
+    const repoId = opts.repoSelector ? (await this.resolveRepoSelector(opts.repoSelector)).id : null
     const explicitTargetWorktreeId = worktreeSelector
       ? this.getValidatedExplicitWorktreeIdSelector(worktreeSelector)
       : null
@@ -10860,8 +10861,12 @@ export class OrcaRuntimeService {
         : null
     const targetWorktree =
       worktreeSelector && !explicitTargetWorktreeId
-        ? await this.resolveWorktreeSelector(worktreeSelector)
+        ? await this.resolveWorktreeSelector(worktreeSelector, repoId)
         : (cachedExplicitTargetWorktree ?? parsedExplicitTargetWorktree)
+    // Why: repo scope is a safety boundary; a worktree from another repo must not bypass it.
+    if (targetWorktree && repoId !== null && targetWorktree.repoId !== repoId) {
+      throw new Error('selector_not_found')
+    }
     const targetWorktreeId = explicitTargetWorktreeId ?? targetWorktree?.id ?? null
     const classificationResolvedWorktreeCache = this.resolvedWorktreeCache
     const classificationResolvedWorktrees =
@@ -10875,10 +10880,6 @@ export class OrcaRuntimeService {
         : targetWorktreeId && explicitTargetWorktreeId
           ? this.listKnownResolvedWorktreesForExplicitTarget(targetWorktreeId, targetWorktree)
           : null
-    const repoId =
-      !targetWorktreeId && opts.repoSelector
-        ? (await this.resolveRepoSelector(opts.repoSelector)).id
-        : null
     const worktreesById =
       targetWorktreeId && targetWorktree
         ? new Map([[targetWorktree.id, targetWorktree]])
@@ -10893,7 +10894,7 @@ export class OrcaRuntimeService {
       this.assertStableReadyGraph(graphEpoch)
     }
 
-    const resolvedWorktrees =
+    const resolvedWorktrees = (
       targetWorktreeId && classificationResolvedWorktrees
         ? classificationResolvedWorktrees
         : targetWorktreeId && targetWorktree
@@ -10901,6 +10902,7 @@ export class OrcaRuntimeService {
           : targetWorktreeId
             ? []
             : [...worktreesById.values()]
+    ).filter((worktree) => repoId === null || worktree.repoId === repoId)
     const refreshedPtyLiveness = await this.refreshPtyWorktreeRecordsFromController(
       resolvedWorktrees,
       targetWorktreeId
@@ -12096,20 +12098,18 @@ export class OrcaRuntimeService {
   }
 
   async getWorktreePs(
-    repoSelectorOrLimit?: string | number,
-    requestedLimit = DEFAULT_WORKTREE_PS_LIMIT
+    limit = DEFAULT_WORKTREE_PS_LIMIT,
+    opts: { repoSelector?: string } = {}
   ): Promise<{
     worktrees: RuntimeWorktreePsSummary[]
     totalCount: number
     truncated: boolean
   }> {
-    const repoSelector = typeof repoSelectorOrLimit === 'string' ? repoSelectorOrLimit : undefined
-    const limit = typeof repoSelectorOrLimit === 'number' ? repoSelectorOrLimit : requestedLimit
     if (!Number.isInteger(limit) || limit <= 0) {
       throw new Error('invalid_limit')
     }
+    const repoId = opts.repoSelector ? (await this.resolveRepoSelector(opts.repoSelector)).id : null
     const resolvedWorktreeSnapshot = await this.listResolvedWorktreeSnapshot()
-    const repoId = repoSelector ? (await this.resolveRepoSelector(repoSelector)).id : null
     const resolvedWorktrees = resolvedWorktreeSnapshot.worktrees.filter(
       (worktree) =>
         this.isRuntimeWorktreeVisible(worktree) && (repoId === null || worktree.repoId === repoId)
@@ -20658,9 +20658,14 @@ export class OrcaRuntimeService {
     return worktreeId
   }
 
-  private async resolveWorktreeSelector(selector: string): Promise<ResolvedWorktree> {
+  private async resolveWorktreeSelector(
+    selector: string,
+    repoId: string | null = null
+  ): Promise<ResolvedWorktree> {
     const explicitWorktreeId = this.getValidatedExplicitWorktreeIdSelector(selector)
-    const worktrees = await this.listResolvedWorktrees()
+    const worktrees = (await this.listResolvedWorktrees()).filter(
+      (worktree) => repoId === null || worktree.repoId === repoId
+    )
     let candidates: ResolvedWorktree[]
 
     if (selector === 'active') {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -10835,7 +10835,7 @@ export class OrcaRuntimeService {
   async listTerminals(
     worktreeSelector?: string,
     limit = DEFAULT_TERMINAL_LIST_LIMIT,
-    opts: { requireFreshPtyLiveness?: boolean } = {}
+    opts: { requireFreshPtyLiveness?: boolean; repoSelector?: string } = {}
   ): Promise<RuntimeTerminalListResult> {
     if (!Number.isInteger(limit) || limit <= 0) {
       throw new Error('invalid_limit')
@@ -10875,12 +10875,20 @@ export class OrcaRuntimeService {
         : targetWorktreeId && explicitTargetWorktreeId
           ? this.listKnownResolvedWorktreesForExplicitTarget(targetWorktreeId, targetWorktree)
           : null
+    const repoId =
+      !targetWorktreeId && opts.repoSelector
+        ? (await this.resolveRepoSelector(opts.repoSelector)).id
+        : null
     const worktreesById =
       targetWorktreeId && targetWorktree
         ? new Map([[targetWorktree.id, targetWorktree]])
         : targetWorktreeId
           ? new Map()
-          : await this.getResolvedWorktreeMap()
+          : new Map(
+              [...(await this.getResolvedWorktreeMap())].filter(
+                ([, worktree]) => repoId === null || worktree.repoId === repoId
+              )
+            )
     if (graphEpoch !== null) {
       this.assertStableReadyGraph(graphEpoch)
     }
@@ -10915,6 +10923,9 @@ export class OrcaRuntimeService {
         if (targetWorktreeId && leaf.worktreeId !== targetWorktreeId) {
           continue
         }
+        if (repoId !== null && !worktreesById.has(leaf.worktreeId)) {
+          continue
+        }
         if (opts.requireFreshPtyLiveness && leaf.ptyId && !refreshedPtyLiveness?.has(leaf.ptyId)) {
           continue
         }
@@ -10939,6 +10950,9 @@ export class OrcaRuntimeService {
         continue
       }
       if (targetWorktreeId && pty.worktreeId !== targetWorktreeId) {
+        continue
+      }
+      if (repoId !== null && !worktreesById.has(pty.worktreeId)) {
         continue
       }
       terminals.push(this.buildPtyTerminalSummary(pty, worktreesById))
@@ -12081,17 +12095,24 @@ export class OrcaRuntimeService {
     })
   }
 
-  async getWorktreePs(limit = DEFAULT_WORKTREE_PS_LIMIT): Promise<{
+  async getWorktreePs(
+    repoSelectorOrLimit?: string | number,
+    requestedLimit = DEFAULT_WORKTREE_PS_LIMIT
+  ): Promise<{
     worktrees: RuntimeWorktreePsSummary[]
     totalCount: number
     truncated: boolean
   }> {
+    const repoSelector = typeof repoSelectorOrLimit === 'string' ? repoSelectorOrLimit : undefined
+    const limit = typeof repoSelectorOrLimit === 'number' ? repoSelectorOrLimit : requestedLimit
     if (!Number.isInteger(limit) || limit <= 0) {
       throw new Error('invalid_limit')
     }
     const resolvedWorktreeSnapshot = await this.listResolvedWorktreeSnapshot()
-    const resolvedWorktrees = resolvedWorktreeSnapshot.worktrees.filter((worktree) =>
-      this.isRuntimeWorktreeVisible(worktree)
+    const repoId = repoSelector ? (await this.resolveRepoSelector(repoSelector)).id : null
+    const resolvedWorktrees = resolvedWorktreeSnapshot.worktrees.filter(
+      (worktree) =>
+        this.isRuntimeWorktreeVisible(worktree) && (repoId === null || worktree.repoId === repoId)
     )
     // Why: worktree.ps backs the mobile sidebar, so it must use the same
     // host-owned imported-worktree visibility gate as worktree.list/desktop.

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -12208,6 +12208,9 @@ export class OrcaRuntimeService {
         continue
       }
       const worktree = folderWorkspaceToWorktree(folderWorkspace)
+      if (repoId !== null && worktree.repoId !== repoId) {
+        continue
+      }
       summaries.set(worktree.id, {
         // Why: folder workspaces use the same mobile grouping/order contract as
         // git worktrees, but legacy records may be missing order metadata.

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -824,6 +824,7 @@ const TerminalHandle = z.object({
 
 const TerminalListParams = z.object({
   worktree: OptionalString,
+  repo: OptionalString,
   limit: OptionalFiniteNumber,
   requireFreshPtyLiveness: z.boolean().optional()
 })
@@ -1100,6 +1101,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
     params: TerminalListParams,
     handler: async (params, { runtime }) =>
       runtime.listTerminals(params.worktree, params.limit, {
+        repoSelector: params.repo,
         requireFreshPtyLiveness: params.requireFreshPtyLiveness
       })
   }),

--- a/src/main/runtime/rpc/methods/worktree-schemas.test.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { WorktreeCreate } from './worktree-schemas'
+import { WorktreeCreate, WorktreePsParams } from './worktree-schemas'
 
 describe('worktree RPC schemas', () => {
   it('rejects invalid startup agent values', () => {
@@ -21,5 +21,12 @@ describe('worktree RPC schemas', () => {
     })
 
     expect(parsed.success).toBe(false)
+  })
+
+  it('accepts an optional repo selector for worktree ps', () => {
+    expect(WorktreePsParams.parse({ repo: 'id:repo-a', limit: 10 })).toEqual({
+      repo: 'id:repo-a',
+      limit: 10
+    })
   })
 })

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -41,6 +41,7 @@ export const WorktreeDetectedListParams = z.object({
 })
 
 export const WorktreePsParams = z.object({
+  repo: OptionalString,
   limit: OptionalFiniteNumber
 })
 

--- a/src/main/runtime/rpc/methods/worktree.test.ts
+++ b/src/main/runtime/rpc/methods/worktree.test.ts
@@ -34,7 +34,7 @@ describe('worktree RPC methods', () => {
 
     await dispatcher.dispatch(makeRequest('worktree.ps', { repo: 'id:repo-a', limit: 1 }))
 
-    expect(runtime.getWorktreePs).toHaveBeenCalledWith('id:repo-a', 1)
+    expect(runtime.getWorktreePs).toHaveBeenCalledWith(1, { repoSelector: 'id:repo-a' })
   })
 
   it('routes mobile session-only activation without notifying desktop clients', async () => {

--- a/src/main/runtime/rpc/methods/worktree.test.ts
+++ b/src/main/runtime/rpc/methods/worktree.test.ts
@@ -25,6 +25,18 @@ const passthroughDedupe = <T>(_repo: string, _id: string | undefined, run: () =>
   run()
 
 describe('worktree RPC methods', () => {
+  it('forwards worktree ps repo scope and limit', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      getWorktreePs: vi.fn().mockResolvedValue({ worktrees: [], totalCount: 0, truncated: false })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
+
+    await dispatcher.dispatch(makeRequest('worktree.ps', { repo: 'id:repo-a', limit: 1 }))
+
+    expect(runtime.getWorktreePs).toHaveBeenCalledWith('id:repo-a', 1)
+  })
+
   it('routes mobile session-only activation without notifying desktop clients', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -24,7 +24,8 @@ export const WORKTREE_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'worktree.ps',
     params: WorktreePsParams,
-    handler: async (params, { runtime }) => runtime.getWorktreePs(params.repo, params.limit)
+    handler: async (params, { runtime }) =>
+      runtime.getWorktreePs(params.limit, { repoSelector: params.repo })
   }),
   defineMethod({
     name: 'worktree.list',

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -24,7 +24,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'worktree.ps',
     params: WorktreePsParams,
-    handler: async (params, { runtime }) => runtime.getWorktreePs(params.limit)
+    handler: async (params, { runtime }) => runtime.getWorktreePs(params.repo, params.limit)
   }),
   defineMethod({
     name: 'worktree.list',

--- a/src/main/runtime/rpc/terminal-list.test.ts
+++ b/src/main/runtime/rpc/terminal-list.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { OrcaRuntimeService } from '../orca-runtime'
+import type { RpcRequest } from './core'
+import { RpcDispatcher } from './dispatcher'
+import { TERMINAL_METHODS } from './methods/terminal'
+
+describe('terminal list RPC', () => {
+  it('forwards repo scope with the worktree selector and list options', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      listTerminals: vi.fn().mockResolvedValue({ terminals: [], totalCount: 0, truncated: false })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+    const request: RpcRequest = {
+      id: 'req-1',
+      authToken: 'tok',
+      method: 'terminal.list',
+      params: {
+        worktree: 'id:repo-a::/worktree',
+        repo: 'id:repo-a',
+        limit: 5,
+        requireFreshPtyLiveness: true
+      }
+    }
+
+    await dispatcher.dispatch(request)
+
+    expect(runtime.listTerminals).toHaveBeenCalledWith('id:repo-a::/worktree', 5, {
+      repoSelector: 'id:repo-a',
+      requireFreshPtyLiveness: true
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds opt-in `--repo` scoping to `orca worktree ps` and `orca terminal list`. The default remains runtime-global, while `terminal list --worktree` remains the narrower explicit worktree selector. Scoped filtering happens before limits and truncation, using the runtime's existing repo selector authority and persisted worktree ownership.

Closes #9295

## Screenshots

No visual change.

## Testing

- `pnpm exec vitest run --config config/vitest.config.ts src/cli/selectors.test.ts src/cli/handlers/terminal.test.ts src/main/runtime/rpc/methods/worktree.test.ts src/main/runtime/rpc/methods/worktree-schemas.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "filters renderer and PTY-only terminals by repo selector before counting|excludes folder workspaces from repo-scoped compact worktree summaries"`
- `pnpm run typecheck:cli`
- `pnpm run typecheck:node`
- `pnpm exec oxlint src/cli/handlers/terminal.test.ts src/cli/handlers/terminal.ts src/cli/handlers/worktree.ts src/cli/selectors.test.ts src/cli/selectors.ts src/cli/specs/core.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/orca-runtime.ts src/main/runtime/rpc/methods/terminal.ts src/main/runtime/rpc/methods/worktree-schemas.test.ts src/main/runtime/rpc/methods/worktree-schemas.ts src/main/runtime/rpc/methods/worktree.test.ts src/main/runtime/rpc/methods/worktree.ts`
- `pnpm exec oxfmt --check src/cli/handlers/terminal.test.ts src/cli/handlers/terminal.ts src/cli/handlers/worktree.ts src/cli/selectors.test.ts src/cli/selectors.ts src/cli/specs/core.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/orca-runtime.ts src/main/runtime/rpc/methods/terminal.ts src/main/runtime/rpc/methods/worktree-schemas.test.ts src/main/runtime/rpc/methods/worktree-schemas.ts src/main/runtime/rpc/methods/worktree.test.ts src/main/runtime/rpc/methods/worktree.ts`

The focused coverage proves explicit and active repo selectors, CLI and RPC forwarding, runtime filtering before count and truncation, folder-workspace exclusion under repo scope, schema acceptance, and unchanged worktree selector precedence.

## AI Review Report

Reviewed the CLI selector path, RPC schemas and handlers, runtime worktree and terminal listing paths, truncation order, and direct runtime callers. The change is provider-neutral and does not add subprocesses, renderer behavior, task ownership, or destructive operations. macOS, Linux, Windows, SSH, and local execution use the same selector and runtime filtering path; no platform-specific branch was added.

## Security Audit

Repo selectors are resolved by the existing runtime authority. Filtering only narrows read-only listing results, and omitted selectors preserve existing global behavior. No shell commands, filesystem writes, credential handling, or new trust boundary were added.

## Notes

Orchestration task scoping remains out of scope because task rows do not yet persist stable repo or worktree ownership.

## ELI5

CLI commands `orca worktree ps` and `orca terminal list` accept an optional `--repo` filter. You can list only the worktrees or terminals for one repository without changing the default global behavior.
