### PR TITLE
fix(runtime): surface hook-captured providerSession in headless session tabs so web-client Show chat view loads the conversation

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -16944,6 +16944,69 @@ describe('OrcaRuntimeService', () => {
     expect(result.tabs[0]).not.toHaveProperty('launchAgent')
   })
 
+  it('attaches hook-captured providerSession to headless mobile session tabs', async () => {
+    // Why: a headless Remote Orca Server has no renderer graph publishing
+    // tab.agentStatus, so paired web clients only get title-derived status.
+    // Without the hook-captured providerSession the native chat view resolves
+    // sessionId null and shows the empty new-chat state (#9452).
+    const paneKey = makePaneKey('host-tab', HEADLESS_LEAF_ID)
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: 'host-tab',
+              ptyId: 'persisted-pty',
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'Persisted Terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1,
+              launchAgent: 'codex'
+            }
+          ]
+        }
+      })
+    )
+    const runtime = new OrcaRuntimeService(runtimeStore as never, undefined, {
+      getAgentStatusSnapshot: () => [
+        {
+          paneKey,
+          state: 'done',
+          prompt: 'fix the bug',
+          agentType: 'codex',
+          connectionId: null,
+          receivedAt: Date.now(),
+          stateStartedAt: Date.now(),
+          tabId: 'host-tab',
+          worktreeId: TEST_WORKTREE_ID,
+          providerSession: {
+            key: 'session_id',
+            id: 'codex-session-1',
+            transcriptPath: '/tmp/rollout.jsonl'
+          }
+        }
+      ]
+    })
+
+    const result = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+
+    const terminalTab = result.tabs.find((tab) => tab.type === 'terminal')
+    expect(terminalTab).toEqual(
+      expect.objectContaining({
+        agentStatus: expect.objectContaining({
+          agentType: 'codex',
+          providerSession: {
+            key: 'session_id',
+            id: 'codex-session-1',
+            transcriptPath: '/tmp/rollout.jsonl'
+          }
+        })
+      })
+    )
+  })
+
   it('keeps renderer-vetted mobile agent status for custom-titled terminals', async () => {
     const runtime = new OrcaRuntimeService(store)
     const leafId = '11111111-1111-4111-8111-111111111111'

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -17007,6 +17007,119 @@ describe('OrcaRuntimeService', () => {
     )
   })
 
+  it('demotes stale hydrated hook status to identity-only in the headless fallback', async () => {
+    // Why: hook rows hydrate from last-status.json for up to 7 days across
+    // restarts; a stale 'working' state must not resurface as live activity,
+    // but providerSession must survive so native chat still resolves.
+    const paneKey = makePaneKey('host-tab', HEADLESS_LEAF_ID)
+    const staleReceivedAt = Date.now() - 60 * 60 * 1000
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: 'host-tab',
+              ptyId: 'persisted-pty',
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'Persisted Terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1,
+              launchAgent: 'codex'
+            }
+          ]
+        }
+      })
+    )
+    const runtime = new OrcaRuntimeService(runtimeStore as never, undefined, {
+      getAgentStatusSnapshot: () => [
+        {
+          paneKey,
+          state: 'working',
+          prompt: 'old prompt',
+          interactivePrompt: '{"questions":[]}',
+          toolName: 'Bash',
+          agentType: 'codex',
+          connectionId: null,
+          receivedAt: staleReceivedAt,
+          stateStartedAt: staleReceivedAt,
+          tabId: 'host-tab',
+          worktreeId: TEST_WORKTREE_ID,
+          providerSession: { key: 'session_id', id: 'codex-session-1' }
+        }
+      ]
+    })
+
+    const result = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+
+    const terminalTab = result.tabs.find((tab) => tab.type === 'terminal')
+    const agentStatus =
+      terminalTab && 'agentStatus' in terminalTab ? terminalTab.agentStatus : undefined
+    expect(agentStatus).toMatchObject({
+      state: 'done',
+      agentType: 'codex',
+      providerSession: { key: 'session_id', id: 'codex-session-1' }
+    })
+    expect(agentStatus).not.toHaveProperty('interactivePrompt')
+    expect(agentStatus).not.toHaveProperty('toolName')
+  })
+
+  it('does not consult the hook fallback for non-headless publications', async () => {
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    const paneKey = makePaneKey('tab-1', leafId)
+    const runtime = new OrcaRuntimeService(store, undefined, {
+      getAgentStatusSnapshot: () => [
+        {
+          paneKey,
+          state: 'working',
+          prompt: 'live prompt',
+          agentType: 'codex',
+          connectionId: null,
+          receivedAt: Date.now(),
+          stateStartedAt: Date.now(),
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          providerSession: { key: 'session_id', id: 'codex-session-1' }
+        }
+      ]
+    })
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [],
+      leaves: [],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'epoch-1',
+          snapshotVersion: 1,
+          activeGroupId: 'group-1',
+          activeTabId: `tab-1::${leafId}`,
+          activeTabType: 'terminal',
+          tabs: [
+            {
+              type: 'terminal',
+              id: `tab-1::${leafId}`,
+              parentTabId: 'tab-1',
+              leafId,
+              title: 'Terminal 1',
+              isActive: true
+            }
+          ]
+        }
+      ]
+    })
+
+    const result = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+
+    // Renderer-published snapshots omit agentStatus deliberately; the hook
+    // fallback is headless-only and must not fill it in here.
+    const terminalTab = result.tabs.find((tab) => tab.type === 'terminal')
+    const agentStatus =
+      terminalTab && 'agentStatus' in terminalTab ? terminalTab.agentStatus : undefined
+    expect(agentStatus ?? undefined).toBeUndefined()
+  })
+
   it('keeps renderer-vetted mobile agent status for custom-titled terminals', async () => {
     const runtime = new OrcaRuntimeService(store)
     const leafId = '11111111-1111-4111-8111-111111111111'

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -6951,6 +6951,25 @@ export class OrcaRuntimeService {
         providerSessionOnly: _providerSessionOnly,
         ...statusFields
       } = entry
+      // Why: hook rows hydrate from last-status.json for up to 7 days across
+      // restarts; keep resume identity for native chat but never resurrect a
+      // stale working/prompt state as live activity on paired clients.
+      if (Date.now() - receivedAt > AGENT_STATUS_STALE_AFTER_MS && statusFields.state !== 'done') {
+        return {
+          state: 'done',
+          prompt: '',
+          updatedAt: receivedAt,
+          stateStartedAt: statusFields.stateStartedAt,
+          paneKey: statusFields.paneKey,
+          stateHistory: [],
+          ...(statusFields.agentType ? { agentType: statusFields.agentType } : {}),
+          ...(statusFields.providerSession
+            ? { providerSession: statusFields.providerSession }
+            : {}),
+          ...(statusFields.tabId ? { tabId: statusFields.tabId } : {}),
+          ...(statusFields.worktreeId ? { worktreeId: statusFields.worktreeId } : {})
+        }
+      }
       return { ...statusFields, updatedAt: receivedAt, stateHistory: [] }
     }
     return null

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -6936,6 +6936,26 @@ export class OrcaRuntimeService {
     return retainedChanged
   }
 
+  /** Latest hook-server status for a pane, reshaped to the AgentStatusEntry the
+   *  session-tabs snapshot carries. Headless-only fallback: a renderer-published
+   *  tab.agentStatus stays authoritative when present. */
+  private findHookAgentStatusEntryForPaneKey(paneKey: string): AgentStatusEntry | null {
+    for (const entry of this.getAgentStatusSnapshotFn?.() ?? []) {
+      if (entry.paneKey !== paneKey) {
+        continue
+      }
+      const {
+        receivedAt,
+        connectionId: _connectionId,
+        launchToken: _launchToken,
+        providerSessionOnly: _providerSessionOnly,
+        ...statusFields
+      } = entry
+      return { ...statusFields, updatedAt: receivedAt, stateHistory: [] }
+    }
+    return null
+  }
+
   private retainAgentRowSnapshot(
     ptyId: string,
     paneKey: string,
@@ -22342,8 +22362,16 @@ export class OrcaRuntimeService {
       )
       const liveTitleEvidence = leafTitle ?? ptyTitle
       const liveTitleEvidenceClassification = classifyAgentTitle(liveTitleEvidence)
-      const normalizedTabAgentStatus = tab.agentStatus
-        ? normalizeCompatibleAgentStatusEntryForOwner(tab.agentStatus, ownerAgent)
+      // Why: headless serve has no renderer publishing tab.agentStatus, so
+      // hook-captured identity (providerSession) would never reach paired
+      // clients and native chat could not resolve a session id (#9452).
+      const sourceAgentStatus =
+        tab.agentStatus ??
+        (this.isHeadlessMobileSessionPublication(snapshot.publicationEpoch)
+          ? this.findHookAgentStatusEntryForPaneKey(paneKey)
+          : null)
+      const normalizedTabAgentStatus = sourceAgentStatus
+        ? normalizeCompatibleAgentStatusEntryForOwner(sourceAgentStatus, ownerAgent)
         : null
       // Why: keep the rich hook-driven status when the agent has a live
       // interactive prompt or an active tool — those are authoritative agent


### PR DESCRIPTION
Fixes #9452

## Summary

On a web client paired to a headless Remote Orca Server, right-clicking a live Codex terminal and choosing **Show chat view** opened the empty "Start a chat with Codex" state instead of the existing conversation.

Root cause: the headless session-tabs snapshot never carried hook-captured agent status. The agent-hook-server does capture the Codex `session_id` + `transcript_path` in serve mode, but its listener only targets the Electron main window (absent headless) and the web preload shim stubs the `agentStatus` API. The only channel reaching the web client — the session-tabs snapshot — was built from the persisted workspace session with `launchAgent` (which is why the menu item still appeared) but no `agentStatus`, so `providerSession` never arrived and the chat pane resolved `sessionId === null`.

Fix: in `toMobileSessionTabsResult`, when the publication is headless and the tab has no renderer-published `agentStatus`, resolve the entry from the agent-hook-server snapshot by paneKey (new `findHookAgentStatusEntryForPaneKey`). Renderer-published status stays authoritative; desktop behavior is unchanged. Hardening: hook rows hydrate from `last-status.json` for up to 7 days across restarts, so entries older than `AGENT_STATUS_STALE_AFTER_MS` are demoted to identity-only (`state: 'done'`, keeping `agentType` + `providerSession`) instead of resurfacing a stale `working`/`interactivePrompt` state as live activity.

## Screenshots

No visual change (the fix makes the existing native chat view load the conversation on paired remote setups; no new/changed UI surfaces).

## Testing

- [ ] `pnpm lint` — fails on a pre-existing, unrelated file untouched by this PR (`src/renderer/src/components/skills/skill-freshness-group.tsx`, switch-exhaustiveness). `oxlint` is clean on the changed files.
- [x] `pnpm typecheck`
- [ ] `pnpm test` — full suite not run locally; targeted suites pass: full `orca-runtime.test.ts` (760 tests) plus `mobile-subscribe-integration`, `session-tabs` (RPC), and `web-session-tabs-sync`.
- [ ] `pnpm build` — not run locally.
- [x] Added tests that would catch regressions: headless tabs carry the hook-captured `providerSession`; stale hydrated entries are demoted to identity-only; the fallback is never consulted for non-headless publications.

Not yet verified end-to-end on a real paired headless VPS + web client + live Codex session — happy to iterate if that surfaces anything.

## AI Review Report

Multi-agent review (correctness, testing, maintainability, project-standards, adversarial, api-contract personas) plus an independent adversarial pass through a second model family (Codex CLI), with per-finding independent validation:

- Flagged and fixed (second commit): stale hydrated hook rows (up to 7 days old) could resurface as live `working` status after a headless restart — corroborated by three independent reviewers including the cross-model pass; now demoted to identity-only past `AGENT_STATUS_STALE_AFTER_MS`.
- Flagged and rejected after validation: `providerSessionOnly` placeholder rows being served as real status — the single production wiring site (`src/main/index.ts:1969-1970`) already filters them before the runtime sees the snapshot.
- Wire-contract check: the `AgentStatusIpcPayload -> AgentStatusEntry` reshape strips transport-only fields (`connectionId`, `launchToken`, `providerSessionOnly`); no breaking change for existing mobile/web clients — they simply see a populated `agentStatus` where they previously saw none.
- Cross-platform: explicitly checked for macOS/Linux/Windows — the change is platform-agnostic main-process state plumbing (no shortcuts, labels, path construction, shell, or Electron platform-specific behavior touched). The SSH/remote-host case is the subject of the fix and follows the existing hook-ingest path.

## Security Audit

- No new input handling, command execution, auth, secrets, dependency, or IPC surface. The change only joins already-collected hook-server state onto an existing snapshot payload.
- `providerSession.transcriptPath` (a host filesystem path) now reaches paired clients for headless tabs — the same exposure class the desktop renderer path already ships for non-headless tabs; clients treat it as an opaque locator for the already-remote-routed `nativeChat.readSession/subscribe`. No new leak class.
- Placeholder (`providerSessionOnly`) rows are filtered upstream before the runtime snapshot (validated during review).

## Notes

- The stale-demotion keeps resume identity so native chat still resolves after restarts, while preventing phantom "working" spinners on paired clients.
- Pre-existing gap left untouched: Pi `providerSessionOnly` session-start rows are filtered out of the snapshot, so identity-only Pi rows on headless remain uncovered (predates this PR).
- Side note from the issue, out of scope here: the CLI has no `--version` flag.

https://claude.ai/code/session_019kJhEhHbPtSzK4iUcSaUej

## ELI5

On a web client talking to a headless remote server, "Show chat view" opened an empty Codex start screen instead of the live conversation. Hook-captured session info is now included in headless tab snapshots so chat can load the real transcript.
