### PR TITLE
fix(relay): honor the remote OpenSSH login shell for Windows SSH terminals

### DIFF
--- a/src/relay/pty-shell-utils.test.ts
+++ b/src/relay/pty-shell-utils.test.ts
@@ -51,6 +51,7 @@ async function withProcessPlatform<T>(
 }
 
 beforeEach(() => {
+  vi.resetModules()
   execFileMock.mockReset()
   execFileSyncMock.mockReset()
   resetProcessTableSnapshotForTests()
@@ -141,6 +142,51 @@ describe('resolveWindowsDefaultShell', () => {
       ['query', 'HKLM\\SOFTWARE\\OpenSSH', '/v', 'DefaultShell'],
       { encoding: 'utf8', timeout: 3000, windowsHide: true }
     )
+  })
+
+  it('treats malformed OpenSSH DefaultShell output as empty and preserves the fallback chain', async () => {
+    execFileSyncMock.mockReturnValue(
+      [
+        'HKEY_LOCAL_MACHINE\\SOFTWARE\\OpenSSH',
+        '    DefaultShellCommandOption    REG_SZ    /c'
+      ].join('\n')
+    )
+
+    const { readOpenSshDefaultShell } = await import('./pty-shell-utils')
+    const powershell = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+
+    expect(readOpenSshDefaultShell()).toBe('')
+    expect(
+      resolveWindowsDefaultShell(
+        {
+          SystemRoot: 'C:\\Windows',
+          ComSpec: 'C:\\Windows\\System32\\cmd.exe'
+        },
+        (path) => path === powershell || path === 'C:\\Windows\\System32\\cmd.exe',
+        readOpenSshDefaultShell
+      )
+    ).toBe(powershell)
+  })
+
+  it('treats reg.exe failures as empty and preserves the fallback chain', async () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error('reg.exe failed')
+    })
+
+    const { readOpenSshDefaultShell } = await import('./pty-shell-utils')
+    const powershell = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+
+    expect(readOpenSshDefaultShell()).toBe('')
+    expect(
+      resolveWindowsDefaultShell(
+        {
+          SystemRoot: 'C:\\Windows',
+          ComSpec: 'C:\\Windows\\System32\\cmd.exe'
+        },
+        (path) => path === powershell || path === 'C:\\Windows\\System32\\cmd.exe',
+        readOpenSshDefaultShell
+      )
+    ).toBe(powershell)
   })
 
   it('preserves the fallback chain for an invalid OpenSSH DefaultShell', () => {

--- a/src/relay/pty-shell-utils.test.ts
+++ b/src/relay/pty-shell-utils.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { execFileMock } = vi.hoisted(() => ({
-  execFileMock: vi.fn()
+const { execFileMock, execFileSyncMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  execFileSyncMock: vi.fn()
 }))
 
 vi.mock('child_process', () => ({
-  execFile: execFileMock
+  execFile: execFileMock,
+  execFileSync: execFileSyncMock
 }))
 
 import { resetWindowsProcessRowsSnapshotForTests } from '../main/providers/windows-foreground-process-rows'
@@ -50,6 +52,7 @@ async function withProcessPlatform<T>(
 
 beforeEach(() => {
   execFileMock.mockReset()
+  execFileSyncMock.mockReset()
   resetProcessTableSnapshotForTests()
   resetWindowsProcessRowsSnapshotForTests()
 })
@@ -97,9 +100,77 @@ describe('resolveWindowsDefaultShell', () => {
           SystemRoot: 'C:\\Windows',
           ComSpec: 'C:\\Windows\\System32\\cmd.exe'
         },
-        (path) => path === 'C:\\Tools\\pwsh.exe'
+        (path) => path === 'C:\\Tools\\pwsh.exe',
+        () => {
+          throw new Error('DefaultShell should not be read when SHELL wins')
+        }
       )
     ).toBe('C:\\Tools\\pwsh.exe')
+  })
+
+  it('uses an existing OpenSSH DefaultShell path', () => {
+    const powershell7 = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe'
+
+    expect(
+      resolveWindowsDefaultShell(
+        {
+          SystemRoot: 'C:\\Windows',
+          ComSpec: 'C:\\Windows\\System32\\cmd.exe'
+        },
+        (path) => path === powershell7,
+        () => powershell7
+      )
+    ).toBe(powershell7)
+  })
+
+  it('reads and memoizes the OpenSSH DefaultShell registry value', async () => {
+    execFileSyncMock.mockReturnValue(
+      [
+        'HKEY_LOCAL_MACHINE\\SOFTWARE\\OpenSSH',
+        '    DefaultShell    REG_SZ    C:\\Program Files\\PowerShell\\7\\pwsh.exe'
+      ].join('\n')
+    )
+
+    const { readOpenSshDefaultShell } = await import('./pty-shell-utils')
+
+    expect(readOpenSshDefaultShell()).toBe('C:\\Program Files\\PowerShell\\7\\pwsh.exe')
+    expect(readOpenSshDefaultShell()).toBe('C:\\Program Files\\PowerShell\\7\\pwsh.exe')
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1)
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      'reg.exe',
+      ['query', 'HKLM\\SOFTWARE\\OpenSSH', '/v', 'DefaultShell'],
+      { encoding: 'utf8', timeout: 3000, windowsHide: true }
+    )
+  })
+
+  it('preserves the fallback chain for an invalid OpenSSH DefaultShell', () => {
+    const powershell = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+
+    expect(
+      resolveWindowsDefaultShell(
+        {
+          SystemRoot: 'C:\\Windows',
+          ComSpec: 'C:\\Windows\\System32\\cmd.exe'
+        },
+        (path) => path === powershell,
+        () => 'C:\\missing\\pwsh.exe'
+      )
+    ).toBe(powershell)
+  })
+
+  it('honors a deliberate OpenSSH PowerShell 5.1 DefaultShell value', () => {
+    const powershell = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+
+    expect(
+      resolveWindowsDefaultShell(
+        {
+          SystemRoot: 'C:\\Windows',
+          ComSpec: 'C:\\Windows\\System32\\cmd.exe'
+        },
+        (path) => path === powershell,
+        () => powershell
+      )
+    ).toBe(powershell)
   })
 
   it('prefers inbox PowerShell before ComSpec for an interactive Windows PTY', () => {
@@ -111,7 +182,8 @@ describe('resolveWindowsDefaultShell', () => {
           SystemRoot: 'C:\\Windows',
           ComSpec: 'C:\\Windows\\System32\\cmd.exe'
         },
-        (path) => path === powershell || path === 'C:\\Windows\\System32\\cmd.exe'
+        (path) => path === powershell || path === 'C:\\Windows\\System32\\cmd.exe',
+        () => ''
       )
     ).toBe(powershell)
   })
@@ -123,7 +195,8 @@ describe('resolveWindowsDefaultShell', () => {
           SystemRoot: 'C:\\Windows',
           ComSpec: 'C:\\Windows\\System32\\cmd.exe'
         },
-        (path) => path === 'C:\\Windows\\System32\\cmd.exe'
+        (path) => path === 'C:\\Windows\\System32\\cmd.exe',
+        () => ''
       )
     ).toBe('C:\\Windows\\System32\\cmd.exe')
   })

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -1,4 +1,4 @@
-import { execFile as execFileCb } from 'node:child_process'
+import { execFile as execFileCb, execFileSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { win32 as pathWin32 } from 'node:path'
@@ -23,13 +23,42 @@ import {
 
 const execFile = promisify(execFileCb)
 
+const OPENSSH_REGISTRY_KEY = 'HKLM\\SOFTWARE\\OpenSSH'
+let openSshDefaultShell: string | undefined
+
+export function readOpenSshDefaultShell(): string {
+  if (openSshDefaultShell !== undefined) {
+    return openSshDefaultShell
+  }
+
+  try {
+    const output = execFileSync('reg.exe', ['query', OPENSSH_REGISTRY_KEY, '/v', 'DefaultShell'], {
+      encoding: 'utf8',
+      timeout: 3000,
+      windowsHide: true
+    })
+    const match = output.match(/^\s*DefaultShell\s+REG_\w+\s+(.+?)\s*$/im)
+    openSshDefaultShell = match?.[1] ?? ''
+  } catch {
+    openSshDefaultShell = ''
+  }
+
+  return openSshDefaultShell
+}
+
 export function resolveWindowsDefaultShell(
   env: NodeJS.ProcessEnv = process.env,
-  existsPath: (path: string) => boolean = existsSync
+  existsPath: (path: string) => boolean = existsSync,
+  readDefaultShell: () => string = readOpenSshDefaultShell
 ): string {
   const envShell = env.SHELL
   if (envShell && existsPath(envShell)) {
     return envShell
+  }
+
+  const configuredShell = readDefaultShell()
+  if (configuredShell && existsPath(configuredShell)) {
+    return configuredShell
   }
 
   const systemRoot = env.SystemRoot || env.WINDIR || env.windir || 'C:\\Windows'


### PR DESCRIPTION
## Summary

Windows SSH terminals now open the shell the remote host actually configured, honoring the OpenSSH `DefaultShell` registry value instead of always falling back to inbox PowerShell.

## ELI5

When you SSH into a Windows machine, it has a setting for which shell to launch. We were ignoring that setting and forcing PowerShell; now we read it and give you the shell the server was told to use.

## Root cause & fix

`resolveWindowsDefaultShell` never consulted the OpenSSH `DefaultShell` value in `HKLM\SOFTWARE\OpenSSH`, so a host configured for a different login shell was overridden by the inbox-PowerShell fallback. The fix adds an exported `readOpenSshDefaultShell()` that runs `reg.exe query`, parses and memoizes the value, and inserts it into the resolution chain between the `$SHELL` check and the PowerShell fallback. On failure, malformed output, or a missing path it returns `''`, so the existing `$SHELL` → WindowsPowerShell → `ComSpec` → `powershell.exe` order is preserved unchanged.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23. Rebase was clean onto merge-base `7ab601487c`; the PR touches only `src/relay/pty-shell-utils.ts` and its test.

- On branch: **27 tests passed** (1 file).
- Fix reverted to main, test kept: **4 failed | 23 passed** — new export/behavior absent on main (`TypeError: readOpenSshDefaultShell is not a function`).
- Failing assertions when reverted include "reads and memoizes the OpenSSH DefaultShell registry value", "treats malformed OpenSSH DefaultShell output as empty", and "treats reg.exe failures as empty".
- Lint clean: `oxlint src/relay/pty-shell-utils.ts` — no findings.

```
# on branch (fix present)
Test Files  1 passed   |  Tests 27 passed

# fix reverted to origin/main, test kept
Test Files  1 failed   |  Tests 4 failed | 23 passed
  x reads and memoizes the OpenSSH DefaultShell registry value
    TypeError: readOpenSshDefaultShell is not a function
```

## Trade-offs

None — pure fix.

## Regression risk

Zero-regression by construction: the registry lookup is reached only when `$SHELL` is unset/nonexistent, and empty or failed reads short-circuit to the prior fallback chain, so non-SSH and non-Windows paths are unchanged. The code path is gated behind `process.platform === 'win32'`, and the result is memoized in a module-scoped var (injectable in tests). Proven by the passing branch tests and the revert-fails check.

*Credit to @rodboev for the original fix. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved.*
