### PR TITLE
fix(mobile-relay): back off relay reconnects to stop cellular connect/disconnect churn

### DIFF
--- a/mobile/src/transport/mobile-endpoint-supervisor-contract.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor-contract.ts
@@ -1,0 +1,23 @@
+import type { MobileRelayEndpoint } from '../../../src/shared/mobile-relay-credential-contract'
+import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
+import type { MobileRelayRpcSession } from './mobile-relay-rpc-session'
+import type { resolveMobileRelayEndpoint } from './mobile-relay-resume-director'
+import type { RpcClient } from './rpc-client'
+import type { HostProfile } from './types'
+
+export type MobileEndpointSupervisorDependencies = {
+  openDirect: (endpoint: string) => RpcClient
+  openRelay: (
+    relay: MobileRelayEndpoint,
+    credential: { token: string; version: number },
+    confirmReqId: string
+  ) => MobileRelayRpcSession
+  resolveRelay: typeof resolveMobileRelayEndpoint
+  readBundle: (hostId: string) => Promise<MobileRelayCredentialBundle | null>
+  writeBundle: (bundle: MobileRelayCredentialBundle) => Promise<void>
+  saveHost: (host: HostProfile) => Promise<void>
+  now: () => number
+  randomBytes: (length: number) => Uint8Array
+  setTimer: typeof setTimeout
+  clearTimer: typeof clearTimeout
+}

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -143,6 +143,36 @@ function dependencies(
   }
 }
 
+function mockCredentialRotation(logical: FakeLogicalClient): void {
+  let installResult: Record<string, unknown> | null = null
+  logical.sendRequest.mockImplementation(async (method, params) => {
+    const request = params as { installReqId?: string; reqId?: string }
+    if (method === 'pairing.provisionRelay') {
+      installResult = {
+        v: 1,
+        reqId: request.reqId,
+        authorizationMode: 'authenticated-direct',
+        currentVersion: 3,
+        resumeExpiresAt: Date.now() + 300_000,
+        graceExpiresAt: Date.now() + 60_000
+      }
+      return { id: 'rpc-2', ok: true, result: installResult, _meta: { runtimeId: 'runtime-1' } }
+    }
+    return {
+      id: 'rpc-1',
+      ok: true,
+      result: {
+        v: 1,
+        relay,
+        installStatus: installResult
+          ? { v: 1, reqId: request.installReqId, state: 'committed', result: installResult }
+          : { v: 1, reqId: request.installReqId, state: 'not-found' }
+      },
+      _meta: { runtimeId: 'runtime-1' }
+    }
+  })
+}
+
 describe('mobile endpoint supervisor', () => {
   beforeEach(() => {
     vi.useFakeTimers()
@@ -604,33 +634,7 @@ describe('mobile endpoint supervisor', () => {
       .mockResolvedValue()
       .mockResolvedValueOnce()
       .mockReturnValueOnce(credentialWritePending)
-    let installResult: Record<string, unknown> | null = null
-    logical.sendRequest.mockImplementation(async (method, params) => {
-      const request = params as { installReqId?: string; reqId?: string }
-      if (method === 'pairing.provisionRelay') {
-        installResult = {
-          v: 1,
-          reqId: request.reqId,
-          authorizationMode: 'authenticated-direct',
-          currentVersion: 3,
-          resumeExpiresAt: Date.now() + 300_000,
-          graceExpiresAt: Date.now() + 60_000
-        }
-        return { id: 'rpc-2', ok: true, result: installResult, _meta: { runtimeId: 'runtime-1' } }
-      }
-      return {
-        id: 'rpc-1',
-        ok: true,
-        result: {
-          v: 1,
-          relay,
-          installStatus: installResult
-            ? { v: 1, reqId: request.installReqId, state: 'committed', result: installResult }
-            : { v: 1, reqId: request.installReqId, state: 'not-found' }
-        },
-        _meta: { runtimeId: 'runtime-1' }
-      }
-    })
+    mockCredentialRotation(logical)
     const deps = dependencies({ openRelay, writeBundle })
     const supervisor = new MobileEndpointSupervisor(logical, host, deps)
 
@@ -654,7 +658,54 @@ describe('mobile endpoint supervisor', () => {
     supervisor.stop()
   })
 
-  it('does not recreate a relay retry after an in-flight dial is backgrounded', async () => {
+  it('uses a scheduled credential rotation that finishes after relay rejection', async () => {
+    const logical = new FakeLogicalClient('connected', 'lan')
+    let finishCredentialWrite: (() => void) | undefined
+    const credentialWritePending = new Promise<void>((resolve) => {
+      finishCredentialWrite = resolve
+    })
+    const writeBundle = vi
+      .fn<(value: MobileRelayCredentialBundle) => Promise<void>>()
+      .mockResolvedValue()
+      .mockResolvedValueOnce()
+      .mockReturnValueOnce(credentialWritePending)
+    mockCredentialRotation(logical)
+    const openRelay = vi.fn(
+      (_relay, credential: { version: number }) =>
+        new FakeRelaySession(
+          credential.version === bundle.current.version ? 'disconnected' : 'connected',
+          credential.version === bundle.current.version ? new RelayOuterError(4401) : null
+        )
+    )
+    const deps = dependencies({
+      readBundle: vi.fn(async () => ({
+        ...bundle,
+        current: { ...bundle.current, expiresAt: Date.now() + 60_000 }
+      })),
+      openRelay,
+      writeBundle
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    logical.publishState('connected')
+    await vi.waitFor(() => expect(writeBundle).toHaveBeenCalledTimes(2))
+
+    // The expiring credential can be rejected while its replacement is waiting on SecureStore.
+    logical.publishState('disconnected')
+    await vi.waitFor(() => expect(openRelay).toHaveBeenCalledOnce())
+    finishCredentialWrite?.()
+
+    await vi.waitFor(() => expect(openRelay).toHaveBeenCalledTimes(2))
+    expect(openRelay).toHaveBeenLastCalledWith(
+      relay,
+      expect.objectContaining({ version: 3 }),
+      expect.any(String)
+    )
+    supervisor.stop()
+  })
+
+  it('does not open a resolved relay replacement after backgrounding', async () => {
     const logical = new FakeLogicalClient('disconnected', 'lan')
     let finishResolve: ((value: typeof relay) => void) | undefined
     const resolvePending = new Promise<typeof relay>((resolve) => {
@@ -676,7 +727,7 @@ describe('mobile endpoint supervisor', () => {
     finishResolve?.(relay)
     await starting
 
-    expect(openRelay).toHaveBeenCalledTimes(2)
+    expect(openRelay).toHaveBeenCalledOnce()
     expect(vi.getTimerCount()).toBe(0)
     supervisor.stop()
   })
@@ -703,8 +754,10 @@ describe('mobile endpoint supervisor', () => {
     await vi.waitFor(() => expect(deps.resolveRelay).toHaveBeenCalledOnce())
     supervisor.setForeground(false)
     finishResolve?.(relay)
-    await vi.waitFor(() => expect(openRelay).toHaveBeenCalledTimes(3))
+    await vi.waitFor(() => expect(deps.saveHost).toHaveBeenCalledOnce())
+    await vi.advanceTimersByTimeAsync(0)
 
+    expect(openRelay).toHaveBeenCalledTimes(2)
     expect(vi.getTimerCount()).toBe(0)
     supervisor.stop()
   })

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -344,6 +344,34 @@ describe('mobile endpoint supervisor', () => {
     supervisor.stop()
   })
 
+  it('escalates backoff when relay sessions connect and then drop repeatedly', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const openRelay = vi.fn(() => new FakeRelaySession('connected', new RelayOuterError(4408)))
+    const deps = dependencies({
+      openRelay,
+      randomBytes: () => new Uint8Array([128, 0])
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    logical.publishState('disconnected')
+    await vi.advanceTimersByTimeAsync(250)
+    expect(openRelay).toHaveBeenCalledTimes(2)
+
+    logical.publishState('disconnected')
+    await vi.advanceTimersByTimeAsync(499)
+    expect(openRelay).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(openRelay).toHaveBeenCalledTimes(3)
+
+    logical.publishState('disconnected')
+    await vi.advanceTimersByTimeAsync(999)
+    expect(openRelay).toHaveBeenCalledTimes(3)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(openRelay).toHaveBeenCalledTimes(4)
+    supervisor.stop()
+  })
+
   it('does not try a grace credential for a capacity failure before backing off', async () => {
     const logical = new FakeLogicalClient('disconnected', 'lan')
     const openRelay = vi.fn(() => new FakeRelaySession('disconnected', new RelayOuterError(4429)))

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -318,6 +318,52 @@ describe('mobile endpoint supervisor', () => {
     supervisor.stop()
   })
 
+  it('does not try a grace credential for a capacity failure before backing off', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const openRelay = vi.fn(() => new FakeRelaySession('disconnected', new RelayOuterError(4429)))
+    const deps = dependencies({
+      readBundle: vi.fn(async () => ({
+        ...bundle,
+        grace: { ...bundle.current, token: 'C'.repeat(43), hash: 'D'.repeat(43), version: 1 }
+      })),
+      openRelay,
+      randomBytes: () => new Uint8Array([128, 0])
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+
+    expect(openRelay).toHaveBeenCalledOnce()
+    await vi.advanceTimersByTimeAsync(249)
+    expect(openRelay).toHaveBeenCalledOnce()
+    await vi.advanceTimersByTimeAsync(1)
+    expect(openRelay).toHaveBeenCalledTimes(2)
+    supervisor.stop()
+  })
+
+  it('keeps an authenticated relay off the backoff path when persistence fails', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const openRelay = vi.fn(() => new FakeRelaySession('connected'))
+    const deps = dependencies({
+      readBundle: vi.fn(async () => ({
+        ...bundle,
+        grace: { ...bundle.current, token: 'C'.repeat(43), hash: 'D'.repeat(43), version: 1 }
+      })),
+      openRelay,
+      writeBundle: vi.fn(async () => {
+        throw new Error('secure store unavailable')
+      })
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    expect(openRelay).toHaveBeenCalledOnce()
+
+    logical.publishState('disconnected')
+    await vi.waitFor(() => expect(openRelay).toHaveBeenCalledTimes(2))
+    supervisor.stop()
+  })
+
   it('cancels a pending relay retry when the original direct path reconnects', async () => {
     const logical = new FakeLogicalClient('disconnected', 'lan')
     const deps = dependencies({

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -16,7 +16,7 @@ vi.mock('expo-crypto', () => ({ getRandomBytes: (length: number) => new Uint8Arr
 
 class FakeSession implements RpcClient {
   readonly sendRequest = vi.fn(
-    async (): Promise<RpcResponse> => ({
+    async (_method: string, _params?: unknown): Promise<RpcResponse> => ({
       id: 'rpc-1',
       ok: true,
       result: {},
@@ -473,6 +473,71 @@ describe('mobile endpoint supervisor', () => {
     supervisor.stop()
   })
 
+  it('keeps rejected relay credentials gated until their replacement is durable', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const openRelay = vi
+      .fn()
+      .mockReturnValueOnce(new FakeRelaySession('disconnected', new RelayOuterError(4401)))
+      .mockImplementation(() => new FakeRelaySession('connected'))
+    let finishCredentialWrite: (() => void) | undefined
+    const credentialWritePending = new Promise<void>((resolve) => {
+      finishCredentialWrite = resolve
+    })
+    const writeBundle = vi
+      .fn<(value: MobileRelayCredentialBundle) => Promise<void>>()
+      .mockResolvedValue()
+      .mockResolvedValueOnce()
+      .mockReturnValueOnce(credentialWritePending)
+    let installResult: Record<string, unknown> | null = null
+    logical.sendRequest.mockImplementation(async (method, params) => {
+      const request = params as { installReqId?: string; reqId?: string }
+      if (method === 'pairing.provisionRelay') {
+        installResult = {
+          v: 1,
+          reqId: request.reqId,
+          authorizationMode: 'authenticated-direct',
+          currentVersion: 3,
+          resumeExpiresAt: Date.now() + 300_000,
+          graceExpiresAt: Date.now() + 60_000
+        }
+        return { id: 'rpc-2', ok: true, result: installResult, _meta: { runtimeId: 'runtime-1' } }
+      }
+      return {
+        id: 'rpc-1',
+        ok: true,
+        result: {
+          v: 1,
+          relay,
+          installStatus: installResult
+            ? { v: 1, reqId: request.installReqId, state: 'committed', result: installResult }
+            : { v: 1, reqId: request.installReqId, state: 'not-found' }
+        },
+        _meta: { runtimeId: 'runtime-1' }
+      }
+    })
+    const deps = dependencies({ openRelay, writeBundle })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    logical.publishState('connected')
+    await vi.waitFor(() => expect(writeBundle).toHaveBeenCalledTimes(2))
+
+    // The direct socket can disappear after the server commits but before the
+    // replacement credential finishes its durable write.
+    logical.publishState('disconnected')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(openRelay).toHaveBeenCalledOnce()
+
+    finishCredentialWrite?.()
+    await vi.waitFor(() => expect(openRelay).toHaveBeenCalledTimes(2))
+    expect(openRelay).toHaveBeenLastCalledWith(
+      relay,
+      expect.objectContaining({ version: 3 }),
+      expect.any(String)
+    )
+    supervisor.stop()
+  })
+
   it('does not recreate a relay retry after an in-flight dial is backgrounded', async () => {
     const logical = new FakeLogicalClient('disconnected', 'lan')
     let finishResolve: ((value: typeof relay) => void) | undefined
@@ -496,6 +561,34 @@ describe('mobile endpoint supervisor', () => {
     await starting
 
     expect(openRelay).toHaveBeenCalledTimes(2)
+    expect(vi.getTimerCount()).toBe(0)
+    supervisor.stop()
+  })
+
+  it('does not recreate a lease retry after forced replacement is backgrounded', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    let finishResolve: ((value: typeof relay) => void) | undefined
+    const resolvePending = new Promise<typeof relay>((resolve) => {
+      finishResolve = resolve
+    })
+    const openRelay = vi
+      .fn()
+      .mockReturnValueOnce(new FakeRelaySession('connected', null, Date.now() + 31_000))
+      .mockReturnValueOnce(new FakeRelaySession('disconnected', new RelayOuterError(4409)))
+      .mockReturnValueOnce(new FakeRelaySession('disconnected', new RelayOuterError(4408)))
+    const deps = dependencies({
+      openRelay,
+      resolveRelay: vi.fn(() => resolvePending)
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.waitFor(() => expect(deps.resolveRelay).toHaveBeenCalledOnce())
+    supervisor.setForeground(false)
+    finishResolve?.(relay)
+    await vi.waitFor(() => expect(openRelay).toHaveBeenCalledTimes(3))
+
     expect(vi.getTimerCount()).toBe(0)
     supervisor.stop()
   })
@@ -616,6 +709,7 @@ describe('mobile endpoint supervisor', () => {
     supervisor.setForeground(false)
     expect(logical.suspendActiveSession).toHaveBeenCalledOnce()
     expect(logical.getState()).toBe('disconnected')
+    expect(vi.getTimerCount()).toBe(0)
 
     supervisor.setForeground(true)
     await vi.waitFor(() => expect(logical.migrateTo).toHaveBeenCalled())

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -83,6 +83,7 @@ class FakeLogicalClient extends FakeSession implements StableLogicalRpcClient {
     }
     this.path = path
     this.generation += 1
+    this.publishState('connected')
   })
   suspendActiveSession = vi.fn(() => this.publishState('disconnected'))
   getActivePath = () => this.path
@@ -228,6 +229,28 @@ describe('mobile endpoint supervisor', () => {
     supervisor.stop()
   })
 
+  it('recovers the relay when it drops during an unavailable direct probe', async () => {
+    const logical = new FakeLogicalClient('connected', 'relay')
+    const direct = new FakeSession('connecting')
+    const openRelay = vi.fn(() => new FakeRelaySession('connected'))
+    const deps = dependencies({
+      openDirect: vi.fn(() => direct),
+      openRelay
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+    await supervisor.start()
+
+    // Start the probe, then drop the active relay while the probe owns the
+    // operation mutex. The failed probe must hand recovery back to the relay.
+    await vi.advanceTimersByTimeAsync(15_000)
+    expect(deps.openDirect).toHaveBeenCalledOnce()
+    logical.publishState('disconnected')
+    direct.publishState('disconnected')
+
+    await vi.waitFor(() => expect(openRelay).toHaveBeenCalledOnce())
+    supervisor.stop()
+  })
+
   it('backs off instead of re-dialing the relay on every network-flap nudge', async () => {
     const logical = new FakeLogicalClient('disconnected', 'lan')
     // Relay cell keeps kicking the resume with PEER_DROPPED (4408) — the cellular
@@ -254,9 +277,11 @@ describe('mobile endpoint supervisor', () => {
     }
     expect(openRelay.mock.calls.length).toBe(afterStart)
 
-    // Once the backoff window elapses, a spaced retry fires on its own.
-    await vi.advanceTimersByTimeAsync(1000)
-    expect(openRelay.mock.calls.length).toBeGreaterThan(afterStart)
+    // Exactly one retry fires at the 250 ms deterministic backoff boundary.
+    await vi.advanceTimersByTimeAsync(249)
+    expect(openRelay.mock.calls.length).toBe(afterStart)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(openRelay.mock.calls.length).toBe(afterStart + 1)
     supervisor.stop()
   })
 

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
+import { hashMobileRelayCredential } from './mobile-relay-credential-hash'
 import { RelayOuterError } from './mobile-relay-e2ee-link'
 import type { MobileRelayRpcSession } from './mobile-relay-rpc-session'
 import {
@@ -366,6 +367,68 @@ describe('mobile endpoint supervisor', () => {
     supervisor.stop()
   })
 
+  it('does not redial a rejected current credential on grace cooldown retries', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const openRelay = vi.fn(
+      (_relay, credential: { version: number }) =>
+        new FakeRelaySession(
+          'disconnected',
+          new RelayOuterError(credential.version === bundle.current.version ? 4401 : 4429)
+        )
+    )
+    const deps = dependencies({
+      readBundle: vi.fn(async () => ({
+        ...bundle,
+        grace: { ...bundle.current, token: 'C'.repeat(43), hash: 'D'.repeat(43), version: 1 }
+      })),
+      openRelay,
+      randomBytes: () => new Uint8Array([128, 0])
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    expect(openRelay).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(250)
+    expect(openRelay).toHaveBeenCalledTimes(3)
+    expect(openRelay.mock.calls[2]?.[1]).toEqual(expect.objectContaining({ version: 1 }))
+    supervisor.stop()
+  })
+
+  it('rotates a rejected current credential after grace keeps relay recovery alive', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const current = {
+      ...bundle.current,
+      hash: hashMobileRelayCredential(bundle.current.token)
+    }
+    const writeBundle = vi.fn(async () => {})
+    const deps = dependencies({
+      readBundle: vi.fn(async () => ({
+        ...bundle,
+        current,
+        grace: { ...current, token: 'C'.repeat(43), hash: 'D'.repeat(43), version: 1 }
+      })),
+      openRelay: vi.fn(
+        (_relay, credential: { version: number }) =>
+          new FakeRelaySession(
+            credential.version === current.version ? 'disconnected' : 'connected',
+            credential.version === current.version ? new RelayOuterError(4401) : null
+          )
+      ),
+      writeBundle
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    writeBundle.mockClear()
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    expect(writeBundle).toHaveBeenCalledWith(
+      expect.objectContaining({ pending: expect.any(Object) })
+    )
+    supervisor.stop()
+  })
+
   it('does not duplicate transport failures across current and grace credentials', async () => {
     const logical = new FakeLogicalClient('disconnected', 'lan')
     const openRelay = vi.fn(() => new FakeRelaySession('disconnected', new Error('network down')))
@@ -650,6 +713,33 @@ describe('mobile endpoint supervisor', () => {
     expect(openRelay).toHaveBeenCalledTimes(2)
 
     await vi.advanceTimersByTimeAsync(5000)
+    expect(openRelay).toHaveBeenCalledTimes(2)
+    supervisor.stop()
+  })
+
+  it('keeps a fatal lease-replacement gate after the active relay later drops', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const openRelay = vi
+      .fn()
+      .mockReturnValueOnce(
+        new FakeRelaySession('connected', new RelayOuterError(4408), Date.now() + 31_000)
+      )
+      .mockReturnValueOnce(new FakeRelaySession('disconnected', new RelayOuterError(4401)))
+      .mockImplementation(() => new FakeRelaySession('connected'))
+    const deps = dependencies({
+      openRelay,
+      randomBytes: () => new Uint8Array([128, 0])
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(openRelay).toHaveBeenCalledTimes(2)
+
+    // The old relay can outlive its rejected lease replacement, then close separately.
+    logical.publishState('disconnected')
+    await vi.advanceTimersByTimeAsync(30_000)
+
     expect(openRelay).toHaveBeenCalledTimes(2)
     supervisor.stop()
   })

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -173,6 +173,10 @@ describe('mobile endpoint supervisor', () => {
     const supervisor = new MobileEndpointSupervisor(logical, host, deps)
     await supervisor.start()
 
+    logical.publishState('handshaking')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(deps.openRelay).not.toHaveBeenCalled()
+
     logical.publishState('reconnecting')
     await vi.waitFor(() => expect(logical.getActivePath()).toBe('relay'))
 

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -318,6 +318,22 @@ describe('mobile endpoint supervisor', () => {
     supervisor.stop()
   })
 
+  it('cancels a pending relay retry when the original direct path reconnects', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const deps = dependencies({
+      openRelay: vi.fn(() => new FakeRelaySession('disconnected', new RelayOuterError(4408))),
+      randomBytes: () => new Uint8Array([128, 0])
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    expect(vi.getTimerCount()).toBe(1)
+
+    logical.publishState('connected')
+    expect(vi.getTimerCount()).toBe(0)
+    supervisor.stop()
+  })
+
   it('recovers a relay drop while post-migration persistence owns the mutex', async () => {
     const logical = new FakeLogicalClient('disconnected', 'lan')
     let finishWrite: (() => void) | undefined
@@ -349,15 +365,130 @@ describe('mobile endpoint supervisor', () => {
 
   it('waits for an external signal instead of polling a host-offline relay', async () => {
     const logical = new FakeLogicalClient('disconnected', 'lan')
+    const openRelay = vi.fn(() => new FakeRelaySession('disconnected', new RelayOuterError(4404)))
     const deps = dependencies({
-      openRelay: vi.fn(() => new FakeRelaySession('disconnected', new RelayOuterError(4404)))
+      openRelay,
+      randomBytes: () => new Uint8Array([128, 0])
     })
     const supervisor = new MobileEndpointSupervisor(logical, host, deps)
 
     await supervisor.start()
 
-    expect(deps.openRelay).toHaveBeenCalledOnce()
+    expect(openRelay).toHaveBeenCalledOnce()
+    logical.publishState('disconnected')
     expect(vi.getTimerCount()).toBe(0)
+
+    supervisor.setForeground(true)
+    expect(vi.getTimerCount()).toBe(1)
+    await vi.advanceTimersByTimeAsync(250)
+    expect(openRelay).toHaveBeenCalledTimes(2)
+    expect(vi.getTimerCount()).toBe(0)
+    supervisor.stop()
+  })
+
+  it('waits for direct connectivity before replacing a rejected relay credential', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const openRelay = vi.fn(() => new FakeRelaySession('disconnected', new RelayOuterError(4401)))
+    const deps = dependencies({ openRelay })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    supervisor.setForeground(true)
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(openRelay).toHaveBeenCalledOnce()
+    expect(deps.writeBundle).not.toHaveBeenCalled()
+
+    logical.publishState('connected')
+    await vi.waitFor(() => expect(deps.writeBundle).toHaveBeenCalledOnce())
+    supervisor.stop()
+  })
+
+  it('does not recreate a relay retry after an in-flight dial is backgrounded', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    let finishResolve: ((value: typeof relay) => void) | undefined
+    const resolvePending = new Promise<typeof relay>((resolve) => {
+      finishResolve = resolve
+    })
+    const openRelay = vi
+      .fn()
+      .mockReturnValueOnce(new FakeRelaySession('disconnected', new RelayOuterError(4409)))
+      .mockReturnValueOnce(new FakeRelaySession('disconnected', new RelayOuterError(4408)))
+    const deps = dependencies({
+      openRelay,
+      resolveRelay: vi.fn(() => resolvePending)
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    const starting = supervisor.start()
+    await vi.waitFor(() => expect(deps.resolveRelay).toHaveBeenCalledOnce())
+    supervisor.setForeground(false)
+    finishResolve?.(relay)
+    await starting
+
+    expect(openRelay).toHaveBeenCalledTimes(2)
+    expect(vi.getTimerCount()).toBe(0)
+    supervisor.stop()
+  })
+
+  it('does not recreate a lease timer after stop races relay persistence', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    let finishWrite: (() => void) | undefined
+    const writePending = new Promise<void>((resolve) => {
+      finishWrite = resolve
+    })
+    const deps = dependencies({ writeBundle: vi.fn(() => writePending) })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    const starting = supervisor.start()
+    await vi.waitFor(() => expect(deps.writeBundle).toHaveBeenCalledOnce())
+    supervisor.stop()
+    finishWrite?.()
+    await starting
+
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('does not poll a host-offline relay through forced lease retries', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const openRelay = vi
+      .fn()
+      .mockReturnValueOnce(new FakeRelaySession('connected', null, Date.now() + 31_000))
+      .mockImplementation(() => new FakeRelaySession('disconnected', new RelayOuterError(4404)))
+    const deps = dependencies({ openRelay })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(openRelay).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(openRelay).toHaveBeenCalledTimes(2)
+    supervisor.stop()
+  })
+
+  it('keeps revival nudges inside a failed lease rotation cooldown', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const openRelay = vi
+      .fn()
+      .mockReturnValueOnce(new FakeRelaySession('connected', null, Date.now() + 31_000))
+      .mockReturnValueOnce(new FakeRelaySession('disconnected', new RelayOuterError(4429)))
+      .mockImplementation(() => new FakeRelaySession('connected'))
+    const deps = dependencies({
+      openRelay,
+      randomBytes: () => new Uint8Array([128, 0])
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(openRelay).toHaveBeenCalledTimes(2)
+
+    supervisor.setForeground(true)
+    await vi.advanceTimersByTimeAsync(249)
+    expect(openRelay).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(openRelay).toHaveBeenCalledTimes(3)
     supervisor.stop()
   })
 

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -341,6 +341,29 @@ describe('mobile endpoint supervisor', () => {
     supervisor.stop()
   })
 
+  it('does not duplicate transport failures across current and grace credentials', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const openRelay = vi.fn(() => new FakeRelaySession('disconnected', new Error('network down')))
+    const resolveRelay = vi.fn(async () => {
+      throw new Error('director unreachable')
+    })
+    const deps = dependencies({
+      readBundle: vi.fn(async () => ({
+        ...bundle,
+        grace: { ...bundle.current, token: 'C'.repeat(43), hash: 'D'.repeat(43), version: 1 }
+      })),
+      openRelay,
+      resolveRelay
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+
+    expect(openRelay).toHaveBeenCalledOnce()
+    expect(resolveRelay).toHaveBeenCalledOnce()
+    supervisor.stop()
+  })
+
   it('keeps an authenticated relay off the backoff path when persistence fails', async () => {
     const logical = new FakeLogicalClient('disconnected', 'lan')
     const openRelay = vi.fn(() => new FakeRelaySession('connected'))
@@ -535,6 +558,31 @@ describe('mobile endpoint supervisor', () => {
     expect(openRelay).toHaveBeenCalledTimes(2)
     await vi.advanceTimersByTimeAsync(1)
     expect(openRelay).toHaveBeenCalledTimes(3)
+    supervisor.stop()
+  })
+
+  it('keeps lease rotation inside an active relay failure cooldown', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const openRelay = vi
+      .fn()
+      .mockReturnValueOnce(
+        new FakeRelaySession('connected', new RelayOuterError(4429), Date.now() + 31_000)
+      )
+      .mockImplementation(() => new FakeRelaySession('connected'))
+    const deps = dependencies({
+      openRelay,
+      randomBytes: () => new Uint8Array([128, 0])
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    await vi.advanceTimersByTimeAsync(900)
+    logical.publishState('disconnected')
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(openRelay).toHaveBeenCalledOnce()
+    await vi.advanceTimersByTimeAsync(150)
+    expect(openRelay).toHaveBeenCalledTimes(2)
     supervisor.stop()
   })
 

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -228,6 +228,59 @@ describe('mobile endpoint supervisor', () => {
     supervisor.stop()
   })
 
+  it('backs off instead of re-dialing the relay on every network-flap nudge', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    // Relay cell keeps kicking the resume with PEER_DROPPED (4408) — the cellular
+    // churn signal. migrate fails because the session never reaches connected.
+    const openRelay = vi.fn(() => new FakeRelaySession('disconnected', new RelayOuterError(4408)))
+    const deps = dependencies({
+      openRelay,
+      // Keep direct unavailable so relay recovery stays the only path under test.
+      openDirect: vi.fn(() => new FakeSession('disconnected')),
+      // Deterministic full jitter: fraction 0.5 → half the backoff window.
+      randomBytes: () => new Uint8Array([128, 0])
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    const afterStart = openRelay.mock.calls.length
+    expect(afterStart).toBe(1)
+
+    // A flapping cellular link fires repeated revival nudges (setForeground(true)).
+    // Backoff must suppress the re-dials while the window is open.
+    for (let i = 0; i < 5; i++) {
+      supervisor.setForeground(true)
+      await vi.advanceTimersByTimeAsync(0)
+    }
+    expect(openRelay.mock.calls.length).toBe(afterStart)
+
+    // Once the backoff window elapses, a spaced retry fires on its own.
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(openRelay.mock.calls.length).toBeGreaterThan(afterStart)
+    supervisor.stop()
+  })
+
+  it('clears relay backoff on a genuine foreground so the retry is immediate', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const openRelay = vi.fn(() => new FakeRelaySession('disconnected', new RelayOuterError(4408)))
+    const deps = dependencies({
+      openRelay,
+      openDirect: vi.fn(() => new FakeSession('disconnected')),
+      randomBytes: () => new Uint8Array([128, 0])
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    const afterStart = openRelay.mock.calls.length
+
+    // Background → foreground is a fresh signal: dial now, not after the cooldown.
+    supervisor.setForeground(false)
+    supervisor.setForeground(true)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(openRelay.mock.calls.length).toBeGreaterThan(afterStart)
+    supervisor.stop()
+  })
+
   it('releases a background relay session and reconnects it on foreground', async () => {
     const logical = new FakeLogicalClient('connected', 'relay')
     const deps = dependencies()

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -251,11 +251,12 @@ describe('mobile endpoint supervisor', () => {
     supervisor.stop()
   })
 
-  it('backs off instead of re-dialing the relay on every network-flap nudge', async () => {
+  it('replaces a half-open relay on a network nudge, then backs off failed resumes', async () => {
     const logical = new FakeLogicalClient('disconnected', 'lan')
-    // Relay cell keeps kicking the resume with PEER_DROPPED (4408) — the cellular
-    // churn signal. migrate fails because the session never reaches connected.
-    const openRelay = vi.fn(() => new FakeRelaySession('disconnected', new RelayOuterError(4408)))
+    const openRelay = vi
+      .fn()
+      .mockReturnValueOnce(new FakeRelaySession('connected'))
+      .mockImplementation(() => new FakeRelaySession('disconnected', new RelayOuterError(4408)))
     const deps = dependencies({
       openRelay,
       // Keep direct unavailable so relay recovery stays the only path under test.
@@ -266,22 +267,93 @@ describe('mobile endpoint supervisor', () => {
     const supervisor = new MobileEndpointSupervisor(logical, host, deps)
 
     await supervisor.start()
-    const afterStart = openRelay.mock.calls.length
-    expect(afterStart).toBe(1)
+    expect(openRelay).toHaveBeenCalledOnce()
 
-    // A flapping cellular link fires repeated revival nudges (setForeground(true)).
-    // Backoff must suppress the re-dials while the window is open.
+    // The OS reports a network handoff, but the dead relay never published onclose.
+    supervisor.setForeground(true)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(logical.suspendActiveSession).toHaveBeenCalledOnce()
+    expect(openRelay).toHaveBeenCalledTimes(2)
+
+    // The relay cell rejects the replacement with PEER_DROPPED; more flap nudges
+    // must share the existing cooldown rather than opening more sockets.
     for (let i = 0; i < 5; i++) {
       supervisor.setForeground(true)
       await vi.advanceTimersByTimeAsync(0)
     }
-    expect(openRelay.mock.calls.length).toBe(afterStart)
+    expect(openRelay).toHaveBeenCalledTimes(2)
 
     // Exactly one retry fires at the 250 ms deterministic backoff boundary.
     await vi.advanceTimersByTimeAsync(249)
-    expect(openRelay.mock.calls.length).toBe(afterStart)
+    expect(openRelay).toHaveBeenCalledTimes(2)
     await vi.advanceTimersByTimeAsync(1)
-    expect(openRelay.mock.calls.length).toBe(afterStart + 1)
+    expect(openRelay).toHaveBeenCalledTimes(3)
+    supervisor.stop()
+  })
+
+  it('backs off a close from the active relay before opening its replacement', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const openRelay = vi
+      .fn()
+      .mockReturnValueOnce(new FakeRelaySession('connected', new RelayOuterError(4429)))
+      .mockImplementation(() => new FakeRelaySession('connected'))
+    const deps = dependencies({
+      openRelay,
+      randomBytes: () => new Uint8Array([128, 0])
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    logical.publishState('disconnected')
+
+    expect(openRelay).toHaveBeenCalledOnce()
+    await vi.advanceTimersByTimeAsync(249)
+    expect(openRelay).toHaveBeenCalledOnce()
+    await vi.advanceTimersByTimeAsync(1)
+    expect(openRelay).toHaveBeenCalledTimes(2)
+    supervisor.stop()
+  })
+
+  it('recovers a relay drop while post-migration persistence owns the mutex', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    let finishWrite: (() => void) | undefined
+    const writePending = new Promise<void>((resolve) => {
+      finishWrite = resolve
+    })
+    const openRelay = vi
+      .fn()
+      .mockReturnValueOnce(new FakeRelaySession('connected', new RelayOuterError(4408)))
+      .mockImplementation(() => new FakeRelaySession('connected'))
+    const deps = dependencies({
+      openRelay,
+      writeBundle: vi.fn(() => writePending),
+      randomBytes: () => new Uint8Array([128, 0])
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    const starting = supervisor.start()
+    await vi.waitFor(() => expect(deps.writeBundle).toHaveBeenCalledOnce())
+    logical.publishState('disconnected')
+    finishWrite?.()
+    await starting
+
+    expect(openRelay).toHaveBeenCalledOnce()
+    await vi.advanceTimersByTimeAsync(250)
+    expect(openRelay).toHaveBeenCalledTimes(2)
+    supervisor.stop()
+  })
+
+  it('waits for an external signal instead of polling a host-offline relay', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const deps = dependencies({
+      openRelay: vi.fn(() => new FakeRelaySession('disconnected', new RelayOuterError(4404)))
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+
+    expect(deps.openRelay).toHaveBeenCalledOnce()
+    expect(vi.getTimerCount()).toBe(0)
     supervisor.stop()
   })
 

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -177,6 +177,10 @@ describe('mobile endpoint supervisor', () => {
     await vi.advanceTimersByTimeAsync(0)
     expect(deps.openRelay).not.toHaveBeenCalled()
 
+    supervisor.setForeground(true)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(deps.openRelay).not.toHaveBeenCalled()
+
     logical.publishState('reconnecting')
     await vi.waitFor(() => expect(logical.getActivePath()).toBe('relay'))
 
@@ -193,6 +197,27 @@ describe('mobile endpoint supervisor', () => {
 
     expect(logical.migrateTo).toHaveBeenCalledWith(expect.any(FakeRelaySession), 'relay')
     expect(logical.getActivePath()).toBe('relay')
+    supervisor.stop()
+  })
+
+  it('does not spend a queued relay retry while direct authentication is progressing', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'lan')
+    const openRelay = vi.fn(() => new FakeRelaySession('disconnected', new RelayOuterError(4408)))
+    const deps = dependencies({
+      openRelay,
+      randomBytes: () => new Uint8Array([128, 0])
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    expect(openRelay).toHaveBeenCalledOnce()
+
+    logical.publishState('handshaking')
+    await vi.advanceTimersByTimeAsync(250)
+    expect(openRelay).toHaveBeenCalledOnce()
+
+    logical.publishState('disconnected')
+    await vi.waitFor(() => expect(openRelay).toHaveBeenCalledTimes(2))
     supervisor.stop()
   })
 

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -190,7 +190,8 @@ export class MobileEndpointSupervisor {
     token: string
     version: number
   }): Promise<{ ok: true } | { ok: false; error: Error }> {
-    if (!this.host.relay || !this.bundle) {
+    // Why: director resolution and grace fallback can finish after background/stop.
+    if (this.stopped || !this.foreground || !this.host.relay || !this.bundle) {
       return { ok: false, error: new Error('relay state missing') }
     }
     const session = this.dependencies.openRelay(
@@ -299,7 +300,8 @@ export class MobileEndpointSupervisor {
         randomBytes: this.dependencies.randomBytes
       })
       this.bundle = result.bundle
-      credentialRefreshed = force
+      // Why: a scheduled rotation can finish after the old credential enters the rejection gate.
+      credentialRefreshed = true
       this.host = await persistRelayHost(this.host, result.relay, this.dependencies.saveHost)
     } catch {
       // Why: pending material remains durable; the next authenticated direct

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -135,9 +135,6 @@ export class MobileEndpointSupervisor {
         const result = await this.tryRelayCredential(credential)
         if (result.ok) {
           retryAfterOperation = this.logical.getState() !== 'connected'
-          if (!retryAfterOperation) {
-            this.relayReconnect.reset()
-          }
           return
         }
         lastError = result.error

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -64,8 +64,7 @@ export class MobileEndpointSupervisor {
     this.unsubscribeState = this.logical.onStateChange((state) => {
       if (state === 'connected') {
         if (this.logical.getActivePath() !== 'relay') {
-          const forceCredentialRotation = this.relayReconnect.resetForDirectConnection()
-          void this.rotateCredentialIfNeeded(forceCredentialRotation)
+          void this.rotateCredentialIfNeeded(this.relayReconnect.resetForDirectConnection())
         }
         this.scheduleDirectProbe()
       } else {
@@ -128,9 +127,9 @@ export class MobileEndpointSupervisor {
     let lastError: Error | null = null
     let retryAfterOperation = false
     try {
-      const credentials = [this.bundle.current, this.bundle.grace].filter(
-        (credential): credential is NonNullable<typeof credential> =>
-          Boolean(credential && credential.expiresAt > this.dependencies.now())
+      const credentials = this.relayReconnect.eligibleCredentials(
+        this.bundle.current,
+        this.bundle.grace
       )
       for (const credential of credentials) {
         const result = await this.tryRelayCredential(credential)
@@ -142,7 +141,10 @@ export class MobileEndpointSupervisor {
           return
         }
         lastError = result.error
-        if (!this.relayReconnect.shouldTryGraceAfterRelayFailure(result.error)) {
+        if (this.relayReconnect.shouldTryGraceAfterRelayFailure(result.error)) {
+          // Why: a rejected version stays invalid; retry only the grace credential.
+          this.relayReconnect.recordRejectedCredential(credential.version)
+        } else {
           break
         }
       }
@@ -265,11 +267,10 @@ export class MobileEndpointSupervisor {
       }
       await this.logical.migrateTo(successful.client, successful.path)
       successful = null
-      const forceCredentialRotation = this.relayReconnect.resetForDirectConnection()
       this.hysteresis.recordMigration(this.dependencies.now())
       this.leaseRotation.clear()
       this.relayRotationPending = false
-      await this.rotateCredentialIfNeeded(forceCredentialRotation)
+      await this.rotateCredentialIfNeeded(this.relayReconnect.resetForDirectConnection())
     } finally {
       successful?.client.close()
       this.operationInFlight = false

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -94,6 +94,7 @@ export class MobileEndpointSupervisor {
       this.relayReconnect.suspendActiveRelay(this.logical)
       this.clearDirectProbeTimer()
       this.relayReconnect.clear()
+      this.leaseRotation.clear()
     }
   }
 
@@ -152,7 +153,7 @@ export class MobileEndpointSupervisor {
       }
     } finally {
       this.operationInFlight = false
-      if (forceReplacement && this.relayRotationPending && !this.stopped) {
+      if (forceReplacement && this.relayRotationPending && !this.stopped && this.foreground) {
         this.leaseRotation.armRetry(this.relayReconnect.retryDelayMs(5000))
       }
       // Why: the active relay can drop while migration follow-up still owns the mutex.
@@ -212,8 +213,10 @@ export class MobileEndpointSupervisor {
         // not open another socket or count against transport recovery backoff.
         await this.dependencies.writeBundle(this.bundle).catch(() => {})
       }
-      // Why: stop can race credential persistence after migration; never recreate its timer.
-      this.leaseRotation.scheduleFromLease(this.stopped ? null : session.getLeaseExpiresAt())
+      // Why: async persistence can finish after stop/background; never recreate a stale timer.
+      this.leaseRotation.scheduleFromLease(
+        this.stopped || !this.foreground ? null : session.getLeaseExpiresAt()
+      )
       this.scheduleDirectProbe()
       return { ok: true }
     } catch (error) {
@@ -288,6 +291,7 @@ export class MobileEndpointSupervisor {
       return
     }
     this.credentialRotationInFlight = true
+    let credentialRefreshed = false
     try {
       const result = await rotateMobileRelayCredential({
         client: this.logical,
@@ -296,12 +300,24 @@ export class MobileEndpointSupervisor {
         randomBytes: this.dependencies.randomBytes
       })
       this.bundle = result.bundle
+      credentialRefreshed = force
       this.host = await persistRelayHost(this.host, result.relay, this.dependencies.saveHost)
     } catch {
       // Why: pending material remains durable; the next authenticated direct
       // opportunity must reconcile it before creating another install key.
     } finally {
+      if (credentialRefreshed) {
+        this.relayReconnect.completeCredentialRefresh()
+      }
       this.credentialRotationInFlight = false
+      if (
+        credentialRefreshed &&
+        !this.stopped &&
+        this.foreground &&
+        this.relayReconnect.needsRecovery(this.logical.getState())
+      ) {
+        void this.recoverRelay()
+      }
     }
   }
 

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -1,6 +1,6 @@
 import type { MobileRelayEndpoint } from '../../../src/shared/mobile-relay-credential-contract'
 import { openAuthenticatedDirectEndpoint } from './mobile-direct-endpoint-probe'
-import { RelayReconnectBackoff } from './mobile-relay-reconnect-backoff'
+import { RelayReconnectController } from './mobile-relay-reconnect-controller'
 import { RelayLeaseRotationTimer } from './mobile-relay-lease-rotation-timer'
 import { MobileEndpointHysteresis } from './mobile-endpoint-hysteresis'
 import {
@@ -54,7 +54,7 @@ export class MobileEndpointSupervisor {
   private probeTimer: ReturnType<typeof setTimeout> | null = null
   private unsubscribeState: (() => void) | null = null
   private readonly hysteresis: MobileEndpointHysteresis
-  private readonly relayBackoff: RelayReconnectBackoff
+  private readonly relayReconnect: RelayReconnectController
   private readonly leaseRotation: RelayLeaseRotationTimer
 
   constructor(
@@ -69,7 +69,7 @@ export class MobileEndpointSupervisor {
       failureCooldownMs: FAILURE_COOLDOWN_MS,
       minimumDwellMs: MINIMUM_DWELL_MS
     })
-    this.relayBackoff = new RelayReconnectBackoff(dependencies, () => void this.recoverRelay())
+    this.relayReconnect = new RelayReconnectController(dependencies, this.recoverRelay.bind(this))
     this.leaseRotation = new RelayLeaseRotationTimer(dependencies, () => {
       this.relayRotationPending = true
       void this.recoverRelay(true)
@@ -87,18 +87,13 @@ export class MobileEndpointSupervisor {
           void this.rotateCredentialIfNeeded()
         }
         this.scheduleDirectProbe()
-      } else if (state === 'reconnecting' || state === 'disconnected' || state === 'auth-failed') {
+      } else {
         // Why: the direct client enters reconnecting after its first failed
         // dial and may never publish disconnected while its retry loop lives.
-        void this.recoverRelay()
+        this.relayReconnect.handleStateFailure(this.logical, state)
       }
     })
-    const initialState = this.logical.getState()
-    if (
-      initialState === 'reconnecting' ||
-      initialState === 'disconnected' ||
-      initialState === 'auth-failed'
-    ) {
+    if (this.relayReconnect.needsRecovery(this.logical.getState())) {
       // Why: the first direct dial can fail while encrypted relay credentials
       // are still loading, before the supervisor subscribes to state changes.
       await this.recoverRelay()
@@ -111,26 +106,16 @@ export class MobileEndpointSupervisor {
     const wasForeground = this.foreground
     this.foreground = foreground
     if (foreground) {
-      // Why: a real background→foreground transition is a fresh user signal;
-      // clear any relay backoff so the reconnect is immediate, not stuck waiting
-      // out a stale cellular-churn cooldown. Repeated network-flap nudges keep
-      // foreground true and so keep respecting the backoff window.
-      if (!wasForeground) {
-        this.relayBackoff.reset()
-      }
-      void this.recoverRelay(this.relayRotationPending)
+      this.relayReconnect.handleForeground(this.logical, wasForeground, this.relayRotationPending)
       this.scheduleDirectProbe(0)
     } else {
-      if (this.logical.getActivePath() === 'relay') {
-        // Why: background phones must not hold billed relay data splices; the
-        // stable client keeps subscriptions for authenticated foreground replay.
-        this.logical.suspendActiveSession()
-      }
+      // Why: background phones must not hold billed relay data splices.
+      this.relayReconnect.suspendActiveRelay(this.logical)
       if (this.probeTimer) {
         this.dependencies.clearTimer(this.probeTimer)
         this.probeTimer = null
       }
-      this.relayBackoff.clear()
+      this.relayReconnect.clear()
     }
   }
 
@@ -142,7 +127,7 @@ export class MobileEndpointSupervisor {
       this.dependencies.clearTimer(this.probeTimer)
       this.probeTimer = null
     }
-    this.relayBackoff.clear()
+    this.relayReconnect.clear()
     this.leaseRotation.clear()
   }
 
@@ -162,11 +147,12 @@ export class MobileEndpointSupervisor {
     // the backoff window keeps those nudges from re-dialing instantly and churning.
     // Lease rotation (forceReplacement) is a scheduled event, not a failure, so it
     // is exempt.
-    if (!forceReplacement && this.relayBackoff.shouldDefer()) {
+    if (!forceReplacement && this.relayReconnect.shouldDefer()) {
       return
     }
     this.operationInFlight = true
     let lastError: Error | null = null
+    let retryAfterOperation = false
     try {
       const credentials = [this.bundle.current, this.bundle.grace].filter(
         (credential): credential is NonNullable<typeof credential> =>
@@ -175,18 +161,25 @@ export class MobileEndpointSupervisor {
       for (const credential of credentials) {
         const result = await this.tryRelayCredential(credential)
         if (result.ok) {
-          this.relayBackoff.reset()
+          retryAfterOperation = this.logical.getState() !== 'connected'
+          if (!retryAfterOperation) {
+            this.relayReconnect.reset()
+          }
           return
         }
         lastError = result.error
       }
       if (credentials.length > 0) {
-        this.relayBackoff.registerFailure(lastError)
+        this.relayReconnect.registerFailure(lastError)
       }
     } finally {
       this.operationInFlight = false
       if (forceReplacement && this.relayRotationPending && !this.stopped) {
         this.leaseRotation.armRetry(5000)
+      }
+      // Why: the active relay can drop while migration follow-up still owns the mutex.
+      if (retryAfterOperation && !this.stopped && this.foreground) {
+        void this.recoverRelay()
       }
     }
   }
@@ -228,8 +221,9 @@ export class MobileEndpointSupervisor {
     )
     try {
       await this.logical.migrateTo(session, 'relay')
+      this.relayReconnect.setActiveSession(session)
       if (!this.foreground) {
-        this.logical.suspendActiveSession()
+        this.relayReconnect.suspendActiveRelay(this.logical)
       }
       this.relayRotationPending = false
       this.hysteresis.recordMigration(this.dependencies.now())
@@ -286,6 +280,7 @@ export class MobileEndpointSupervisor {
       }
       await this.logical.migrateTo(successful.client, successful.path)
       successful = null
+      this.relayReconnect.resetForDirectConnection()
       this.hysteresis.recordMigration(this.dependencies.now())
       this.leaseRotation.clear()
       this.relayRotationPending = false

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -117,12 +117,9 @@ export class MobileEndpointSupervisor {
     ) {
       return
     }
-    // Why: a flapping cellular link fires repeated revival nudges while the relay
-    // cell answers overlapping resumes with PEER_DROPPED/LIMIT_EXCEEDED; honoring
-    // the backoff window keeps those nudges from re-dialing instantly and churning.
-    // An initial lease rotation is scheduled work rather than a failure, so it may
-    // bypass the cooldown but never a policy gate requiring an external signal.
-    if (this.relayReconnect.shouldDefer(forceReplacement)) {
+    // Why: revival and lease timers can overlap resume failures; one shared cooldown
+    // prevents PEER_DROPPED/LIMIT_EXCEEDED reconnect churn.
+    if (this.relayReconnect.shouldDefer()) {
       return
     }
     this.operationInFlight = true

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -44,7 +44,6 @@ export type MobileEndpointSupervisorDependencies = {
 }
 
 export class MobileEndpointSupervisor {
-  private host: HostProfile
   private bundle: MobileRelayCredentialBundle | null = null
   private stopped = false
   private foreground = true
@@ -59,10 +58,9 @@ export class MobileEndpointSupervisor {
 
   constructor(
     private readonly logical: StableLogicalRpcClient,
-    host: HostProfile,
+    private host: HostProfile,
     private readonly dependencies: MobileEndpointSupervisorDependencies
   ) {
-    this.host = host
     this.hysteresis = new MobileEndpointHysteresis(dependencies.now(), {
       directSuccessesRequired: 3,
       directObservationMs: DIRECT_OBSERVATION_MS,
@@ -84,7 +82,8 @@ export class MobileEndpointSupervisor {
     this.unsubscribeState = this.logical.onStateChange((state) => {
       if (state === 'connected') {
         if (this.logical.getActivePath() !== 'relay') {
-          void this.rotateCredentialIfNeeded()
+          const forceCredentialRotation = this.relayReconnect.resetForDirectConnection()
+          void this.rotateCredentialIfNeeded(forceCredentialRotation)
         }
         this.scheduleDirectProbe()
       } else {
@@ -106,7 +105,7 @@ export class MobileEndpointSupervisor {
     const wasForeground = this.foreground
     this.foreground = foreground
     if (foreground) {
-      this.relayReconnect.handleForeground(this.logical, wasForeground, this.relayRotationPending)
+      this.relayReconnect.handleForeground(this.logical, wasForeground)
       this.scheduleDirectProbe(0)
     } else {
       // Why: background phones must not hold billed relay data splices.
@@ -145,9 +144,9 @@ export class MobileEndpointSupervisor {
     // Why: a flapping cellular link fires repeated revival nudges while the relay
     // cell answers overlapping resumes with PEER_DROPPED/LIMIT_EXCEEDED; honoring
     // the backoff window keeps those nudges from re-dialing instantly and churning.
-    // Lease rotation (forceReplacement) is a scheduled event, not a failure, so it
-    // is exempt.
-    if (!forceReplacement && this.relayReconnect.shouldDefer()) {
+    // An initial lease rotation is scheduled work rather than a failure, so it may
+    // bypass the cooldown but never a policy gate requiring an external signal.
+    if (this.relayReconnect.shouldDefer(forceReplacement)) {
       return
     }
     this.operationInFlight = true
@@ -170,12 +169,15 @@ export class MobileEndpointSupervisor {
         lastError = result.error
       }
       if (credentials.length > 0) {
-        this.relayReconnect.registerFailure(lastError)
+        // Why: cleanup may happen while a relay dial is awaiting the network;
+        // record its outcome without recreating a foreground retry timer.
+        const scheduleRetry = !forceReplacement && this.foreground && !this.stopped
+        this.relayReconnect.registerFailure(lastError, scheduleRetry)
       }
     } finally {
       this.operationInFlight = false
       if (forceReplacement && this.relayRotationPending && !this.stopped) {
-        this.leaseRotation.armRetry(5000)
+        this.leaseRotation.armRetry(this.relayReconnect.retryDelayMs(5000))
       }
       // Why: the active relay can drop while migration follow-up still owns the mutex.
       if (retryAfterOperation && !this.stopped && this.foreground) {
@@ -232,7 +234,8 @@ export class MobileEndpointSupervisor {
         this.bundle = applyResumeConfirmation(this.bundle, credential.version, confirmation)
         await this.dependencies.writeBundle(this.bundle)
       }
-      this.leaseRotation.scheduleFromLease(session.getLeaseExpiresAt())
+      // Why: stop can race credential persistence after migration; never recreate its timer.
+      this.leaseRotation.scheduleFromLease(this.stopped ? null : session.getLeaseExpiresAt())
       this.scheduleDirectProbe()
       return { ok: true }
     } catch (error) {
@@ -280,11 +283,11 @@ export class MobileEndpointSupervisor {
       }
       await this.logical.migrateTo(successful.client, successful.path)
       successful = null
-      this.relayReconnect.resetForDirectConnection()
+      const forceCredentialRotation = this.relayReconnect.resetForDirectConnection()
       this.hysteresis.recordMigration(this.dependencies.now())
       this.leaseRotation.clear()
       this.relayRotationPending = false
-      await this.rotateCredentialIfNeeded()
+      await this.rotateCredentialIfNeeded(forceCredentialRotation)
     } finally {
       successful?.client.close()
       this.operationInFlight = false
@@ -296,13 +299,13 @@ export class MobileEndpointSupervisor {
     }
   }
 
-  private async rotateCredentialIfNeeded(): Promise<void> {
+  private async rotateCredentialIfNeeded(force = false): Promise<void> {
     if (
       this.stopped ||
       this.credentialRotationInFlight ||
       !this.bundle ||
       this.logical.getActivePath() === 'relay' ||
-      !mobileRelayCredentialNeedsRotation(this.bundle, this.dependencies.now())
+      (!force && !mobileRelayCredentialNeedsRotation(this.bundle, this.dependencies.now()))
     ) {
       return
     }

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -293,8 +293,9 @@ export class MobileEndpointSupervisor {
     } finally {
       successful?.client.close()
       this.operationInFlight = false
-      if (this.relayRotationPending) {
-        void this.recoverRelay(true)
+      // Why: a relay drop or backoff timer can arrive while the direct probe owns the mutex.
+      if (this.relayRotationPending || this.logical.getState() !== 'connected') {
+        void this.recoverRelay(this.relayRotationPending)
       }
       this.scheduleDirectProbe()
     }

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -1,5 +1,7 @@
 import type { MobileRelayEndpoint } from '../../../src/shared/mobile-relay-credential-contract'
 import { openAuthenticatedDirectEndpoint } from './mobile-direct-endpoint-probe'
+import { RelayReconnectBackoff } from './mobile-relay-reconnect-backoff'
+import { RelayLeaseRotationTimer } from './mobile-relay-lease-rotation-timer'
 import { MobileEndpointHysteresis } from './mobile-endpoint-hysteresis'
 import {
   encodeBase64Url,
@@ -23,7 +25,6 @@ const DIRECT_PROBE_INTERVAL_MS = 15_000
 const DIRECT_OBSERVATION_MS = 30_000
 const MINIMUM_DWELL_MS = 60_000
 const FAILURE_COOLDOWN_MS = 60_000
-const LEASE_ROTATION_MARGIN_MS = 30_000
 
 export type MobileEndpointSupervisorDependencies = {
   openDirect: (endpoint: string) => RpcClient
@@ -51,9 +52,10 @@ export class MobileEndpointSupervisor {
   private credentialRotationInFlight = false
   private relayRotationPending = false
   private probeTimer: ReturnType<typeof setTimeout> | null = null
-  private leaseTimer: ReturnType<typeof setTimeout> | null = null
   private unsubscribeState: (() => void) | null = null
   private readonly hysteresis: MobileEndpointHysteresis
+  private readonly relayBackoff: RelayReconnectBackoff
+  private readonly leaseRotation: RelayLeaseRotationTimer
 
   constructor(
     private readonly logical: StableLogicalRpcClient,
@@ -66,6 +68,11 @@ export class MobileEndpointSupervisor {
       directObservationMs: DIRECT_OBSERVATION_MS,
       failureCooldownMs: FAILURE_COOLDOWN_MS,
       minimumDwellMs: MINIMUM_DWELL_MS
+    })
+    this.relayBackoff = new RelayReconnectBackoff(dependencies, () => void this.recoverRelay())
+    this.leaseRotation = new RelayLeaseRotationTimer(dependencies, () => {
+      this.relayRotationPending = true
+      void this.recoverRelay(true)
     })
   }
 
@@ -101,8 +108,16 @@ export class MobileEndpointSupervisor {
   }
 
   setForeground(foreground: boolean): void {
+    const wasForeground = this.foreground
     this.foreground = foreground
     if (foreground) {
+      // Why: a real background→foreground transition is a fresh user signal;
+      // clear any relay backoff so the reconnect is immediate, not stuck waiting
+      // out a stale cellular-churn cooldown. Repeated network-flap nudges keep
+      // foreground true and so keep respecting the backoff window.
+      if (!wasForeground) {
+        this.relayBackoff.reset()
+      }
       void this.recoverRelay(this.relayRotationPending)
       this.scheduleDirectProbe(0)
     } else {
@@ -115,6 +130,7 @@ export class MobileEndpointSupervisor {
         this.dependencies.clearTimer(this.probeTimer)
         this.probeTimer = null
       }
+      this.relayBackoff.clear()
     }
   }
 
@@ -126,7 +142,8 @@ export class MobileEndpointSupervisor {
       this.dependencies.clearTimer(this.probeTimer)
       this.probeTimer = null
     }
-    this.clearLeaseTimer()
+    this.relayBackoff.clear()
+    this.leaseRotation.clear()
   }
 
   private async recoverRelay(forceReplacement = false): Promise<void> {
@@ -140,24 +157,36 @@ export class MobileEndpointSupervisor {
     ) {
       return
     }
+    // Why: a flapping cellular link fires repeated revival nudges while the relay
+    // cell answers overlapping resumes with PEER_DROPPED/LIMIT_EXCEEDED; honoring
+    // the backoff window keeps those nudges from re-dialing instantly and churning.
+    // Lease rotation (forceReplacement) is a scheduled event, not a failure, so it
+    // is exempt.
+    if (!forceReplacement && this.relayBackoff.shouldDefer()) {
+      return
+    }
     this.operationInFlight = true
+    let lastError: Error | null = null
     try {
       const credentials = [this.bundle.current, this.bundle.grace].filter(
         (credential): credential is NonNullable<typeof credential> =>
           Boolean(credential && credential.expiresAt > this.dependencies.now())
       )
       for (const credential of credentials) {
-        if (await this.tryRelayCredential(credential)) {
+        const result = await this.tryRelayCredential(credential)
+        if (result.ok) {
+          this.relayBackoff.reset()
           return
         }
+        lastError = result.error
+      }
+      if (credentials.length > 0) {
+        this.relayBackoff.registerFailure(lastError)
       }
     } finally {
       this.operationInFlight = false
-      if (forceReplacement && this.relayRotationPending && !this.stopped && !this.leaseTimer) {
-        this.leaseTimer = this.dependencies.setTimer(() => {
-          this.leaseTimer = null
-          void this.recoverRelay(true)
-        }, 5000)
+      if (forceReplacement && this.relayRotationPending && !this.stopped) {
+        this.leaseRotation.armRetry(5000)
       }
     }
   }
@@ -165,13 +194,13 @@ export class MobileEndpointSupervisor {
   private async tryRelayCredential(credential: {
     token: string
     version: number
-  }): Promise<boolean> {
+  }): Promise<{ ok: true } | { ok: false; error: Error }> {
     const first = await this.openAndMigrateRelay(credential)
     if (first.ok) {
-      return true
+      return first
     }
     if (!isDirectorResolutionFailure(first.error) || !this.host.relay) {
-      return false
+      return first
     }
     try {
       const resolved = await this.dependencies.resolveRelay({
@@ -179,9 +208,9 @@ export class MobileEndpointSupervisor {
         resumeToken: credential.token
       })
       this.host = await persistRelayHost(this.host, resolved, this.dependencies.saveHost)
-      return (await this.openAndMigrateRelay(credential)).ok
-    } catch {
-      return false
+      return await this.openAndMigrateRelay(credential)
+    } catch (error) {
+      return { ok: false, error: toError(error) }
     }
   }
 
@@ -209,7 +238,7 @@ export class MobileEndpointSupervisor {
         this.bundle = applyResumeConfirmation(this.bundle, credential.version, confirmation)
         await this.dependencies.writeBundle(this.bundle)
       }
-      this.scheduleLeaseRotation(session)
+      this.leaseRotation.scheduleFromLease(session.getLeaseExpiresAt())
       this.scheduleDirectProbe()
       return { ok: true }
     } catch (error) {
@@ -258,7 +287,7 @@ export class MobileEndpointSupervisor {
       await this.logical.migrateTo(successful.client, successful.path)
       successful = null
       this.hysteresis.recordMigration(this.dependencies.now())
-      this.clearLeaseTimer()
+      this.leaseRotation.clear()
       this.relayRotationPending = false
       await this.rotateCredentialIfNeeded()
     } finally {
@@ -296,27 +325,6 @@ export class MobileEndpointSupervisor {
       // opportunity must reconcile it before creating another install key.
     } finally {
       this.credentialRotationInFlight = false
-    }
-  }
-
-  private scheduleLeaseRotation(session: MobileRelayRpcSession): void {
-    this.clearLeaseTimer()
-    const deadline = session.getLeaseExpiresAt()
-    if (!deadline) {
-      return
-    }
-    const delay = Math.max(1000, deadline - this.dependencies.now() - LEASE_ROTATION_MARGIN_MS)
-    this.leaseTimer = this.dependencies.setTimer(() => {
-      this.leaseTimer = null
-      this.relayRotationPending = true
-      void this.recoverRelay(true)
-    }, delay)
-  }
-
-  private clearLeaseTimer(): void {
-    if (this.leaseTimer) {
-      this.dependencies.clearTimer(this.leaseTimer)
-      this.leaseTimer = null
     }
   }
 }

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -1,5 +1,5 @@
-import type { MobileRelayEndpoint } from '../../../src/shared/mobile-relay-credential-contract'
 import { openAuthenticatedDirectEndpoint } from './mobile-direct-endpoint-probe'
+import type { MobileEndpointSupervisorDependencies } from './mobile-endpoint-supervisor-contract'
 import { RelayReconnectController } from './mobile-relay-reconnect-controller'
 import { RelayLeaseRotationTimer } from './mobile-relay-lease-rotation-timer'
 import { MobileEndpointHysteresis } from './mobile-endpoint-hysteresis'
@@ -15,33 +15,15 @@ import {
   rotateMobileRelayCredential
 } from './mobile-relay-credential-rotation'
 import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
-import type { MobileRelayRpcSession } from './mobile-relay-rpc-session'
-import { resolveMobileRelayEndpoint } from './mobile-relay-resume-director'
-import type { RpcClient } from './rpc-client'
 import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
 import type { HostProfile } from './types'
+
+export type { MobileEndpointSupervisorDependencies } from './mobile-endpoint-supervisor-contract'
 
 const DIRECT_PROBE_INTERVAL_MS = 15_000
 const DIRECT_OBSERVATION_MS = 30_000
 const MINIMUM_DWELL_MS = 60_000
 const FAILURE_COOLDOWN_MS = 60_000
-
-export type MobileEndpointSupervisorDependencies = {
-  openDirect: (endpoint: string) => RpcClient
-  openRelay: (
-    relay: MobileRelayEndpoint,
-    credential: { token: string; version: number },
-    confirmReqId: string
-  ) => MobileRelayRpcSession
-  resolveRelay: typeof resolveMobileRelayEndpoint
-  readBundle: (hostId: string) => Promise<MobileRelayCredentialBundle | null>
-  writeBundle: (bundle: MobileRelayCredentialBundle) => Promise<void>
-  saveHost: (host: HostProfile) => Promise<void>
-  now: () => number
-  randomBytes: (length: number) => Uint8Array
-  setTimer: typeof setTimeout
-  clearTimer: typeof clearTimeout
-}
 
 export class MobileEndpointSupervisor {
   private bundle: MobileRelayCredentialBundle | null = null
@@ -110,10 +92,7 @@ export class MobileEndpointSupervisor {
     } else {
       // Why: background phones must not hold billed relay data splices.
       this.relayReconnect.suspendActiveRelay(this.logical)
-      if (this.probeTimer) {
-        this.dependencies.clearTimer(this.probeTimer)
-        this.probeTimer = null
-      }
+      this.clearDirectProbeTimer()
       this.relayReconnect.clear()
     }
   }
@@ -122,10 +101,7 @@ export class MobileEndpointSupervisor {
     this.stopped = true
     this.unsubscribeState?.()
     this.unsubscribeState = null
-    if (this.probeTimer) {
-      this.dependencies.clearTimer(this.probeTimer)
-      this.probeTimer = null
-    }
+    this.clearDirectProbeTimer()
     this.relayReconnect.clear()
     this.leaseRotation.clear()
   }
@@ -167,6 +143,9 @@ export class MobileEndpointSupervisor {
           return
         }
         lastError = result.error
+        if (!this.relayReconnect.shouldTryGraceAfterRelayFailure(result.error)) {
+          break
+        }
       }
       if (credentials.length > 0) {
         // Why: cleanup may happen while a relay dial is awaiting the network;
@@ -232,7 +211,9 @@ export class MobileEndpointSupervisor {
       const confirmation = session.getResumeConfirmation()
       if (confirmation) {
         this.bundle = applyResumeConfirmation(this.bundle, credential.version, confirmation)
-        await this.dependencies.writeBundle(this.bundle)
+        // Why: the relay is already authenticated; a SecureStore failure must
+        // not open another socket or count against transport recovery backoff.
+        await this.dependencies.writeBundle(this.bundle).catch(() => {})
       }
       // Why: stop can race credential persistence after migration; never recreate its timer.
       this.leaseRotation.scheduleFromLease(this.stopped ? null : session.getLeaseExpiresAt())
@@ -324,6 +305,13 @@ export class MobileEndpointSupervisor {
       // opportunity must reconcile it before creating another install key.
     } finally {
       this.credentialRotationInFlight = false
+    }
+  }
+
+  private clearDirectProbeTimer(): void {
+    if (this.probeTimer) {
+      this.dependencies.clearTimer(this.probeTimer)
+      this.probeTimer = null
     }
   }
 }

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -108,13 +108,14 @@ export class MobileEndpointSupervisor {
   }
 
   private async recoverRelay(forceReplacement = false): Promise<void> {
+    // Why: connecting/handshaking is live direct progress; a relay dial would race it.
     if (
       this.stopped ||
       !this.foreground ||
       this.operationInFlight ||
       !this.bundle ||
       !this.host.relay ||
-      (!forceReplacement && this.logical.getState() === 'connected')
+      (!forceReplacement && !this.relayReconnect.needsRecovery(this.logical.getState()))
     ) {
       return
     }

--- a/mobile/src/transport/mobile-relay-lease-rotation-timer.ts
+++ b/mobile/src/transport/mobile-relay-lease-rotation-timer.ts
@@ -32,8 +32,8 @@ export class RelayLeaseRotationTimer {
 
   // Re-arm a short retry when a forced rotation's recovery did not complete.
   // Ignored while a timer is already pending so retries never stack.
-  armRetry(delayMs: number): void {
-    if (this.timer) {
+  armRetry(delayMs: number | null): void {
+    if (delayMs == null || this.timer) {
       return
     }
     this.arm(delayMs)

--- a/mobile/src/transport/mobile-relay-lease-rotation-timer.ts
+++ b/mobile/src/transport/mobile-relay-lease-rotation-timer.ts
@@ -1,0 +1,59 @@
+// Why: the relay resume lease expires; the phone must proactively re-resume a
+// little before the deadline (and retry shortly if a forced rotation didn't land)
+// so the session never lapses. Owns the single lease/rotation timer slot.
+const LEASE_ROTATION_MARGIN_MS = 30_000
+
+export type RelayLeaseRotationDependencies = {
+  now: () => number
+  setTimer: typeof setTimeout
+  clearTimer: typeof clearTimeout
+}
+
+export class RelayLeaseRotationTimer {
+  private timer: ReturnType<typeof setTimeout> | null = null
+
+  constructor(
+    private readonly dependencies: RelayLeaseRotationDependencies,
+    private readonly onRotate: () => void
+  ) {}
+
+  // Arm rotation a margin before the lease deadline. No-op with no deadline.
+  scheduleFromLease(leaseExpiresAt: number | null): void {
+    this.clear()
+    if (!leaseExpiresAt) {
+      return
+    }
+    const delay = Math.max(
+      1000,
+      leaseExpiresAt - this.dependencies.now() - LEASE_ROTATION_MARGIN_MS
+    )
+    this.arm(delay)
+  }
+
+  // Re-arm a short retry when a forced rotation's recovery did not complete.
+  // Ignored while a timer is already pending so retries never stack.
+  armRetry(delayMs: number): void {
+    if (this.timer) {
+      return
+    }
+    this.arm(delayMs)
+  }
+
+  get pending(): boolean {
+    return this.timer != null
+  }
+
+  clear(): void {
+    if (this.timer) {
+      this.dependencies.clearTimer(this.timer)
+      this.timer = null
+    }
+  }
+
+  private arm(delayMs: number): void {
+    this.timer = this.dependencies.setTimer(() => {
+      this.timer = null
+      this.onRotate()
+    }, delayMs)
+  }
+}

--- a/mobile/src/transport/mobile-relay-reconnect-backoff.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-backoff.ts
@@ -1,0 +1,104 @@
+import {
+  isMobileRelayCloseCode,
+  mobileRelayRecoveryFor
+} from '../../../src/shared/mobile-relay-close-codes'
+import { RelayOuterError } from './mobile-relay-e2ee-link'
+
+// Why: relay resume closes (4408 peer-dropped / 4429 limit-exceeded) and silent
+// cellular NAT rebinds otherwise re-dial instantly; a flapping cellular link then
+// ping-pongs connect/disconnect. Space retries with the fullJitter backoff the
+// mobileRelayRecoveryFor contract prescribes, floored so retries never busy-loop.
+const RELAY_BACKOFF_MIN_MS = 250
+const RELAY_BACKOFF_BASE_MS = 500
+const RELAY_BACKOFF_CEILING_MS = 30_000
+
+export type RelayReconnectBackoffDependencies = {
+  now: () => number
+  randomBytes: (length: number) => Uint8Array
+  setTimer: typeof setTimeout
+  clearTimer: typeof clearTimeout
+}
+
+// Encapsulates the relay reconnect cooldown: how long to wait after each failed
+// resume before the supervisor may re-dial, and the self-scheduled retry that
+// fires when no external signal (foreground/probe) would otherwise drive it.
+export class RelayReconnectBackoff {
+  private consecutiveFailures = 0
+  private nextAttemptAt = 0
+  private timer: ReturnType<typeof setTimeout> | null = null
+
+  constructor(
+    private readonly dependencies: RelayReconnectBackoffDependencies,
+    private readonly onRetry: () => void
+  ) {}
+
+  // True when the caller is still inside the cooldown window and must not
+  // re-dial. Arms the self-scheduled retry so recovery still happens on its own.
+  shouldDefer(): boolean {
+    if (this.dependencies.now() < this.nextAttemptAt) {
+      this.scheduleRetry()
+      return true
+    }
+    return false
+  }
+
+  registerFailure(error: Error | null): void {
+    this.consecutiveFailures += 1
+    // Why: honor the documented recovery contract (previously dead code). Every
+    // relay close code maps to a fullJitter/backoff recovery, so always debounce
+    // nudges by the backoff window.
+    const code = error instanceof RelayOuterError ? error.code : null
+    const recovery =
+      code != null && isMobileRelayCloseCode(code)
+        ? mobileRelayRecoveryFor(code, 'phone-resume')
+        : null
+    const delay = this.delayMs()
+    this.nextAttemptAt = this.dependencies.now() + delay
+    // Why: HOST_OFFLINE / BAD_OUTER_CREDENTIAL won't clear by retrying the same
+    // resume sooner; keep the debounce but let the next external signal
+    // (foreground, direct probe, or credential rotation) drive recovery instead.
+    if (
+      recovery?.kind === 'wait-for-host-revival' ||
+      recovery?.kind === 'disable-relay-credential'
+    ) {
+      return
+    }
+    this.scheduleRetry(delay)
+  }
+
+  reset(): void {
+    this.consecutiveFailures = 0
+    this.nextAttemptAt = 0
+    this.clear()
+  }
+
+  clear(): void {
+    if (this.timer) {
+      this.dependencies.clearTimer(this.timer)
+      this.timer = null
+    }
+  }
+
+  private scheduleRetry(delayMs?: number): void {
+    if (this.timer) {
+      return
+    }
+    const delay = delayMs ?? Math.max(0, this.nextAttemptAt - this.dependencies.now())
+    this.timer = this.dependencies.setTimer(() => {
+      this.timer = null
+      this.onRetry()
+    }, delay)
+  }
+
+  private delayMs(): number {
+    const exponent = Math.max(0, this.consecutiveFailures - 1)
+    const cap = Math.min(RELAY_BACKOFF_CEILING_MS, RELAY_BACKOFF_BASE_MS * 2 ** exponent)
+    // Full jitter (uniform in [0, cap)), floored so retries never busy-loop.
+    return Math.max(RELAY_BACKOFF_MIN_MS, Math.floor(cap * this.jitterFraction()))
+  }
+
+  private jitterFraction(): number {
+    const [high, low] = this.dependencies.randomBytes(2)
+    return (((high ?? 0) << 8) | (low ?? 0)) / 0x1_00_00
+  }
+}

--- a/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
@@ -65,6 +65,22 @@ describe('relay reconnect controller', () => {
     expect(vi.getTimerCount()).toBe(0)
   })
 
+  it('starts a new failure streak after one ceiling without a failure', () => {
+    const onRetry = vi.fn()
+    const reconnect = createController(onRetry)
+
+    reconnect.registerFailure(new RelayOuterError(4429))
+    vi.advanceTimersByTime(250)
+    expect(onRetry).toHaveBeenCalledOnce()
+
+    vi.advanceTimersByTime(30_000)
+    reconnect.registerFailure(new RelayOuterError(4429))
+    vi.advanceTimersByTime(249)
+    expect(onRetry).toHaveBeenCalledOnce()
+    vi.advanceTimersByTime(1)
+    expect(onRetry).toHaveBeenCalledTimes(2)
+  })
+
   it('uses grace only when the outer relay credential was rejected', () => {
     const reconnect = createController(vi.fn())
 

--- a/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MobileRelayRpcSession } from './mobile-relay-rpc-session'
 import { MobileE2EEAuthenticationError } from './mobile-e2ee-v2-physical-channel'
 import { RelayOuterError } from './mobile-relay-e2ee-link'
 import { RelayReconnectController } from './mobile-relay-reconnect-controller'
+import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
 
 vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
 vi.mock('expo-crypto', () => ({ getRandomBytes: (length: number) => new Uint8Array(length) }))
@@ -78,7 +80,7 @@ describe('relay reconnect controller', () => {
     expect(vi.getTimerCount()).toBe(0)
   })
 
-  it('starts a new failure streak after one ceiling without a failure', () => {
+  it('does not reset backoff merely because a failed attempt took one ceiling', () => {
     const onRetry = vi.fn()
     const reconnect = createController(onRetry)
 
@@ -88,6 +90,32 @@ describe('relay reconnect controller', () => {
 
     vi.advanceTimersByTime(30_000)
     reconnect.registerFailure(new RelayOuterError(4429))
+    vi.advanceTimersByTime(249)
+    expect(onRetry).toHaveBeenCalledOnce()
+    vi.advanceTimersByTime(1)
+    expect(onRetry).toHaveBeenCalledOnce()
+    vi.advanceTimersByTime(249)
+    expect(onRetry).toHaveBeenCalledOnce()
+    vi.advanceTimersByTime(1)
+    expect(onRetry).toHaveBeenCalledTimes(2)
+  })
+
+  it('resets backoff after an authenticated relay remains stable', () => {
+    const onRetry = vi.fn()
+    const reconnect = createController(onRetry)
+    const session = {
+      getFailure: () => new RelayOuterError(4408)
+    } as MobileRelayRpcSession
+    const logical = {
+      getActivePath: () => 'relay'
+    } as StableLogicalRpcClient
+
+    reconnect.registerFailure(new RelayOuterError(4429))
+    vi.advanceTimersByTime(250)
+    reconnect.setActiveSession(session)
+    vi.advanceTimersByTime(30_000)
+    reconnect.registerActiveFailure(logical)
+
     vi.advanceTimersByTime(249)
     expect(onRetry).toHaveBeenCalledOnce()
     vi.advanceTimersByTime(1)

--- a/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MobileE2EEAuthenticationError } from './mobile-e2ee-v2-physical-channel'
 import { RelayOuterError } from './mobile-relay-e2ee-link'
 import { RelayReconnectController } from './mobile-relay-reconnect-controller'
 
@@ -40,6 +41,18 @@ describe('relay reconnect controller', () => {
     reconnect.resetForDirectConnection()
     expect(vi.getTimerCount()).toBe(0)
     vi.runAllTimers()
+    expect(onRetry).not.toHaveBeenCalled()
+  })
+
+  it('waits for an external signal after rejected E2EE authentication', () => {
+    const onRetry = vi.fn()
+    const reconnect = createController(onRetry)
+
+    reconnect.registerFailure(new MobileE2EEAuthenticationError())
+
+    expect(reconnect.shouldDefer()).toBe(true)
+    expect(vi.getTimerCount()).toBe(0)
+    vi.advanceTimersByTime(60_000)
     expect(onRetry).not.toHaveBeenCalled()
   })
 

--- a/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
@@ -58,6 +58,9 @@ describe('relay reconnect controller', () => {
     const reconnect = createController(vi.fn())
 
     expect(reconnect.shouldTryGraceAfterRelayFailure(new RelayOuterError(4401))).toBe(true)
+    expect(reconnect.shouldTryGraceAfterRelayFailure(new Error('relay transport error'))).toBe(
+      false
+    )
     expect(reconnect.shouldTryGraceAfterRelayFailure(new RelayOuterError(4408))).toBe(false)
     expect(reconnect.shouldTryGraceAfterRelayFailure(new RelayOuterError(4429))).toBe(false)
   })

--- a/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
@@ -40,6 +40,20 @@ describe('relay reconnect controller', () => {
     vi.runAllTimers()
     expect(onRetry).not.toHaveBeenCalled()
   })
+
+  it('arms one debounced retry only after a host-revival signal', async () => {
+    const onRetry = vi.fn()
+    const reconnect = createController(onRetry)
+
+    reconnect.registerFailure(new RelayOuterError(4404))
+    expect(vi.getTimerCount()).toBe(0)
+
+    expect(reconnect.shouldDefer()).toBe(true)
+    expect(vi.getTimerCount()).toBe(1)
+    await vi.advanceTimersByTimeAsync(250)
+    expect(onRetry).toHaveBeenCalledOnce()
+    expect(vi.getTimerCount()).toBe(0)
+  })
 })
 
 function createController(onRetry: () => void): RelayReconnectController {

--- a/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RelayOuterError } from './mobile-relay-e2ee-link'
+import { RelayReconnectController } from './mobile-relay-reconnect-controller'
+
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
+vi.mock('expo-crypto', () => ({ getRandomBytes: (length: number) => new Uint8Array(length) }))
+
+describe('relay reconnect controller', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keeps one retry timer and cancels it when recovery needs an external signal', () => {
+    const onRetry = vi.fn()
+    const reconnect = createController(onRetry)
+
+    reconnect.registerFailure(new RelayOuterError(4429))
+    reconnect.registerFailure(new RelayOuterError(4408))
+    expect(vi.getTimerCount()).toBe(1)
+
+    reconnect.registerFailure(new RelayOuterError(4404))
+    expect(vi.getTimerCount()).toBe(0)
+    vi.runAllTimers()
+    expect(onRetry).not.toHaveBeenCalled()
+  })
+
+  it('drops a pending relay retry after direct connectivity wins', () => {
+    const onRetry = vi.fn()
+    const reconnect = createController(onRetry)
+
+    reconnect.registerFailure(new RelayOuterError(4408))
+    expect(vi.getTimerCount()).toBe(1)
+
+    reconnect.resetForDirectConnection()
+    expect(vi.getTimerCount()).toBe(0)
+    vi.runAllTimers()
+    expect(onRetry).not.toHaveBeenCalled()
+  })
+})
+
+function createController(onRetry: () => void): RelayReconnectController {
+  return new RelayReconnectController(
+    {
+      now: Date.now,
+      randomBytes: () => new Uint8Array([128, 0]),
+      setTimer: setTimeout,
+      clearTimer: clearTimeout
+    },
+    onRetry
+  )
+}

--- a/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
@@ -53,6 +53,14 @@ describe('relay reconnect controller', () => {
     expect(reconnect.retryDelayMs(5000)).toBe(8000)
     expect(vi.getTimerCount()).toBe(0)
   })
+
+  it('uses grace only when the outer relay credential was rejected', () => {
+    const reconnect = createController(vi.fn())
+
+    expect(reconnect.shouldTryGraceAfterRelayFailure(new RelayOuterError(4401))).toBe(true)
+    expect(reconnect.shouldTryGraceAfterRelayFailure(new RelayOuterError(4408))).toBe(false)
+    expect(reconnect.shouldTryGraceAfterRelayFailure(new RelayOuterError(4429))).toBe(false)
+  })
 })
 
 function createController(onRetry: () => void): RelayReconnectController {

--- a/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
@@ -43,6 +43,17 @@ describe('relay reconnect controller', () => {
     expect(onRetry).not.toHaveBeenCalled()
   })
 
+  it('upgrades host-revival gating to fresh credentials without later downgrading it', () => {
+    const reconnect = createController(vi.fn())
+
+    reconnect.registerFailure(new RelayOuterError(4404))
+    reconnect.registerFailure(new RelayOuterError(4401))
+    reconnect.registerFailure(new RelayOuterError(4408))
+
+    expect(reconnect.resetForDirectConnection()).toBe(true)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
   it('extends forced-rotation retries to the exponential cooldown', () => {
     const reconnect = createController(vi.fn())
 

--- a/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
@@ -24,6 +24,8 @@ describe('relay reconnect controller', () => {
 
     reconnect.registerFailure(new RelayOuterError(4404))
     expect(vi.getTimerCount()).toBe(0)
+    expect(reconnect.shouldDefer()).toBe(true)
+    expect(vi.getTimerCount()).toBe(0)
     vi.runAllTimers()
     expect(onRetry).not.toHaveBeenCalled()
   })
@@ -41,17 +43,14 @@ describe('relay reconnect controller', () => {
     expect(onRetry).not.toHaveBeenCalled()
   })
 
-  it('arms one debounced retry only after a host-revival signal', async () => {
-    const onRetry = vi.fn()
-    const reconnect = createController(onRetry)
+  it('extends forced-rotation retries to the exponential cooldown', () => {
+    const reconnect = createController(vi.fn())
 
-    reconnect.registerFailure(new RelayOuterError(4404))
-    expect(vi.getTimerCount()).toBe(0)
+    for (let failure = 0; failure < 6; failure++) {
+      reconnect.registerFailure(new RelayOuterError(4429), false)
+    }
 
-    expect(reconnect.shouldDefer()).toBe(true)
-    expect(vi.getTimerCount()).toBe(1)
-    await vi.advanceTimersByTimeAsync(250)
-    expect(onRetry).toHaveBeenCalledOnce()
+    expect(reconnect.retryDelayMs(5000)).toBe(8000)
     expect(vi.getTimerCount()).toBe(0)
   })
 })

--- a/mobile/src/transport/mobile-relay-reconnect-controller.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.ts
@@ -25,6 +25,7 @@ type RecoveryGate = 'host-revival' | 'fresh-credential'
 
 export class RelayReconnectController {
   private consecutiveFailures = 0
+  private lastFailureAt: number | null = null
   private nextAttemptAt = 0
   private timer: ReturnType<typeof setTimeout> | null = null
   private activeSession: MobileRelayRpcSession | null = null
@@ -79,6 +80,9 @@ export class RelayReconnectController {
 
   setActiveSession(session: MobileRelayRpcSession): void {
     this.activeSession = session
+    this.nextAttemptAt = 0
+    this.recoveryGate = null
+    this.clearTimer()
   }
 
   resetForDirectConnection(): boolean {
@@ -164,9 +168,16 @@ export class RelayReconnectController {
       this.clearTimer()
       return
     }
+    const now = this.dependencies.now()
+    if (this.lastFailureAt != null && now - this.lastFailureAt >= RELAY_BACKOFF_CEILING_MS) {
+      this.consecutiveFailures = 0
+    }
+    // Why: a relay can authenticate and collapse immediately; only a quiet
+    // ceiling-length window proves the prior failure streak has ended.
+    this.lastFailureAt = now
     this.consecutiveFailures += 1
     const delay = this.delayMs()
-    this.nextAttemptAt = this.dependencies.now() + delay
+    this.nextAttemptAt = now + delay
     if (recovery?.kind === 'wait-for-host-revival') {
       // Why: retrying HOST_OFFLINE without a revival signal is polling a known-negative state.
       this.recoveryGate = 'host-revival'
@@ -205,6 +216,7 @@ export class RelayReconnectController {
 
   reset(): void {
     this.consecutiveFailures = 0
+    this.lastFailureAt = null
     this.nextAttemptAt = 0
     this.recoveryGate = null
     this.clearTimer()

--- a/mobile/src/transport/mobile-relay-reconnect-controller.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.ts
@@ -14,6 +14,7 @@ import type { ConnectionState } from './types'
 const RELAY_BACKOFF_MIN_MS = 250
 const RELAY_BACKOFF_BASE_MS = 500
 const RELAY_BACKOFF_CEILING_MS = 30_000
+const RELAY_STABLE_CONNECTION_MS = RELAY_BACKOFF_CEILING_MS
 
 export type RelayReconnectDependencies = {
   now: () => number
@@ -26,7 +27,7 @@ type RecoveryGate = 'external-signal' | 'fresh-credential'
 
 export class RelayReconnectController {
   private consecutiveFailures = 0
-  private lastFailureAt: number | null = null
+  private activeRelayConnectedAt: number | null = null
   private nextAttemptAt = 0
   private timer: ReturnType<typeof setTimeout> | null = null
   private activeSession: MobileRelayRpcSession | null = null
@@ -76,11 +77,13 @@ export class RelayReconnectController {
       return
     }
     this.activeSession = null
+    this.activeRelayConnectedAt = null
     logical.suspendActiveSession()
   }
 
   setActiveSession(session: MobileRelayRpcSession): void {
     this.activeSession = session
+    this.activeRelayConnectedAt = this.dependencies.now()
     this.nextAttemptAt = 0
     this.recoveryGate = null
     this.clearTimer()
@@ -90,6 +93,7 @@ export class RelayReconnectController {
     const needsCredentialRefresh =
       this.recoveryGate === 'fresh-credential' || this.rejectedCredentialVersions.size > 0
     this.activeSession = null
+    this.activeRelayConnectedAt = null
     if (needsCredentialRefresh) {
       // Why: the rejected credential stays unusable until its replacement is durable.
       this.consecutiveFailures = 0
@@ -139,6 +143,8 @@ export class RelayReconnectController {
     if (failure) {
       // Why: active relay closes need the same cooldown as failed replacement dials.
       this.registerFailure(failure)
+    } else {
+      this.activeRelayConnectedAt = null
     }
   }
 
@@ -170,12 +176,15 @@ export class RelayReconnectController {
       return
     }
     const now = this.dependencies.now()
-    if (this.lastFailureAt != null && now - this.lastFailureAt >= RELAY_BACKOFF_CEILING_MS) {
+    if (
+      this.activeRelayConnectedAt != null &&
+      now - this.activeRelayConnectedAt >= RELAY_STABLE_CONNECTION_MS
+    ) {
       this.consecutiveFailures = 0
     }
-    // Why: a relay can authenticate and collapse immediately; only a quiet
-    // ceiling-length window proves the prior failure streak has ended.
-    this.lastFailureAt = now
+    // Why: elapsed time inside a slow failed dial is not evidence of recovery;
+    // only an authenticated relay that survived the stability window resets the streak.
+    this.activeRelayConnectedAt = null
     this.consecutiveFailures += 1
     const delay = this.delayMs()
     this.nextAttemptAt = now + delay
@@ -223,7 +232,7 @@ export class RelayReconnectController {
 
   reset(): void {
     this.consecutiveFailures = 0
-    this.lastFailureAt = null
+    this.activeRelayConnectedAt = null
     this.nextAttemptAt = 0
     this.recoveryGate = null
     this.clearTimer()
@@ -232,6 +241,7 @@ export class RelayReconnectController {
   clear(): void {
     this.clearTimer()
     this.activeSession = null
+    this.activeRelayConnectedAt = null
   }
 
   private clearTimer(): void {

--- a/mobile/src/transport/mobile-relay-reconnect-controller.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.ts
@@ -4,6 +4,7 @@ import {
   mobileRelayRecoveryFor
 } from '../../../src/shared/mobile-relay-close-codes'
 import type { MobileRelayRpcSession } from './mobile-relay-rpc-session'
+import { MobileE2EEAuthenticationError } from './mobile-e2ee-v2-physical-channel'
 import { RelayOuterError } from './mobile-relay-e2ee-link'
 import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
 import type { ConnectionState } from './types'
@@ -21,7 +22,7 @@ export type RelayReconnectDependencies = {
   clearTimer: typeof clearTimeout
 }
 
-type RecoveryGate = 'host-revival' | 'fresh-credential'
+type RecoveryGate = 'external-signal' | 'fresh-credential'
 
 export class RelayReconnectController {
   private consecutiveFailures = 0
@@ -43,7 +44,7 @@ export class RelayReconnectController {
       if (this.recoveryGate !== 'fresh-credential') {
         this.reset()
       }
-    } else if (this.recoveryGate === 'host-revival') {
+    } else if (this.recoveryGate === 'external-signal') {
       this.recoveryGate = null
     }
     if (
@@ -162,7 +163,7 @@ export class RelayReconnectController {
         : null
     if (
       this.recoveryGate === 'fresh-credential' ||
-      (this.recoveryGate === 'host-revival' && recovery?.kind !== 'disable-relay-credential')
+      (this.recoveryGate === 'external-signal' && recovery?.kind !== 'disable-relay-credential')
     ) {
       // Why: only the gate's external signal can make a known-fatal recovery retryable.
       this.clearTimer()
@@ -178,9 +179,15 @@ export class RelayReconnectController {
     this.consecutiveFailures += 1
     const delay = this.delayMs()
     this.nextAttemptAt = now + delay
+    if (error instanceof MobileE2EEAuthenticationError) {
+      // Why: pairing state cannot change on a timer; polling only wakes the radio.
+      this.recoveryGate = 'external-signal'
+      this.clearTimer()
+      return
+    }
     if (recovery?.kind === 'wait-for-host-revival') {
       // Why: retrying HOST_OFFLINE without a revival signal is polling a known-negative state.
-      this.recoveryGate = 'host-revival'
+      this.recoveryGate = 'external-signal'
       this.clearTimer()
       return
     }

--- a/mobile/src/transport/mobile-relay-reconnect-controller.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.ts
@@ -29,6 +29,7 @@ export class RelayReconnectController {
   private timer: ReturnType<typeof setTimeout> | null = null
   private activeSession: MobileRelayRpcSession | null = null
   private recoveryGate: RecoveryGate | null = null
+  private readonly rejectedCredentialVersions = new Set<number>()
 
   constructor(
     private readonly dependencies: RelayReconnectDependencies,
@@ -81,12 +82,14 @@ export class RelayReconnectController {
   }
 
   resetForDirectConnection(): boolean {
-    const needsCredentialRefresh = this.recoveryGate === 'fresh-credential'
+    const needsCredentialRefresh =
+      this.recoveryGate === 'fresh-credential' || this.rejectedCredentialVersions.size > 0
     this.activeSession = null
     if (needsCredentialRefresh) {
       // Why: the rejected credential stays unusable until its replacement is durable.
       this.consecutiveFailures = 0
       this.nextAttemptAt = 0
+      this.recoveryGate = 'fresh-credential'
       this.clearTimer()
     } else {
       this.reset()
@@ -96,8 +99,30 @@ export class RelayReconnectController {
 
   completeCredentialRefresh(): void {
     if (this.recoveryGate === 'fresh-credential') {
+      this.rejectedCredentialVersions.clear()
       this.reset()
     }
+  }
+
+  eligibleCredentials<T extends { expiresAt: number; version: number }>(
+    ...credentials: Array<T | null | undefined>
+  ): T[] {
+    const eligible = credentials.filter((credential): credential is T =>
+      Boolean(
+        credential &&
+        credential.expiresAt > this.dependencies.now() &&
+        !this.rejectedCredentialVersions.has(credential.version)
+      )
+    )
+    if (eligible.length === 0 && this.rejectedCredentialVersions.size > 0) {
+      this.recoveryGate = 'fresh-credential'
+      this.clearTimer()
+    }
+    return eligible
+  }
+
+  recordRejectedCredential(version: number): void {
+    this.rejectedCredentialVersions.add(version)
   }
 
   registerActiveFailure(logical: StableLogicalRpcClient): void {
@@ -126,12 +151,20 @@ export class RelayReconnectController {
   }
 
   registerFailure(error: Error | null, scheduleRetry = true): void {
-    this.consecutiveFailures += 1
     const code = error instanceof RelayOuterError ? error.code : null
     const recovery =
       code != null && isMobileRelayCloseCode(code)
         ? mobileRelayRecoveryFor(code, 'phone-resume')
         : null
+    if (
+      this.recoveryGate === 'fresh-credential' ||
+      (this.recoveryGate === 'host-revival' && recovery?.kind !== 'disable-relay-credential')
+    ) {
+      // Why: only the gate's external signal can make a known-fatal recovery retryable.
+      this.clearTimer()
+      return
+    }
+    this.consecutiveFailures += 1
     const delay = this.delayMs()
     this.nextAttemptAt = this.dependencies.now() + delay
     if (recovery?.kind === 'wait-for-host-revival') {

--- a/mobile/src/transport/mobile-relay-reconnect-controller.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.ts
@@ -55,7 +55,7 @@ export class RelayReconnectController {
   }
 
   needsRecovery(state: ConnectionState): boolean {
-    return state !== 'connected' && state !== 'connecting'
+    return state !== 'connected' && state !== 'connecting' && state !== 'handshaking'
   }
 
   suspendActiveRelay(logical: StableLogicalRpcClient): void {
@@ -106,7 +106,7 @@ export class RelayReconnectController {
         : null
     const delay = this.delayMs()
     this.nextAttemptAt = this.dependencies.now() + delay
-    // Why: these failures require host revival or fresh credentials, not a retry loop.
+    // Why: wait for an OS/direct-probe signal before arming one debounced retry.
     if (
       recovery?.kind === 'wait-for-host-revival' ||
       recovery?.kind === 'disable-relay-credential'

--- a/mobile/src/transport/mobile-relay-reconnect-controller.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.ts
@@ -83,8 +83,21 @@ export class RelayReconnectController {
   resetForDirectConnection(): boolean {
     const needsCredentialRefresh = this.recoveryGate === 'fresh-credential'
     this.activeSession = null
-    this.reset()
+    if (needsCredentialRefresh) {
+      // Why: the rejected credential stays unusable until its replacement is durable.
+      this.consecutiveFailures = 0
+      this.nextAttemptAt = 0
+      this.clearTimer()
+    } else {
+      this.reset()
+    }
     return needsCredentialRefresh
+  }
+
+  completeCredentialRefresh(): void {
+    if (this.recoveryGate === 'fresh-credential') {
+      this.reset()
+    }
   }
 
   registerActiveFailure(logical: StableLogicalRpcClient): void {

--- a/mobile/src/transport/mobile-relay-reconnect-controller.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.ts
@@ -20,30 +20,39 @@ export type RelayReconnectDependencies = {
   clearTimer: typeof clearTimeout
 }
 
+type RecoveryGate = 'host-revival' | 'fresh-credential'
+
 export class RelayReconnectController {
   private consecutiveFailures = 0
   private nextAttemptAt = 0
   private timer: ReturnType<typeof setTimeout> | null = null
   private activeSession: MobileRelayRpcSession | null = null
+  private recoveryGate: RecoveryGate | null = null
 
   constructor(
     private readonly dependencies: RelayReconnectDependencies,
     private readonly onRetry: (forceReplacement?: boolean) => void
   ) {}
 
-  handleForeground(
-    logical: StableLogicalRpcClient,
-    wasForeground: boolean,
-    forceReplacement: boolean
-  ): void {
+  handleForeground(logical: StableLogicalRpcClient, wasForeground: boolean): void {
     if (!wasForeground) {
       // Why: an app resume is a fresh signal, unlike repeated network-flap nudges.
-      this.reset()
-    } else if (logical.getState() === 'connected') {
+      if (this.recoveryGate !== 'fresh-credential') {
+        this.reset()
+      }
+    } else if (this.recoveryGate === 'host-revival') {
+      this.recoveryGate = null
+    }
+    if (
+      wasForeground &&
+      this.recoveryGate !== 'fresh-credential' &&
+      logical.getState() === 'connected'
+    ) {
       // Why: a network handoff can leave the relay half-open without publishing a close.
       this.suspendActiveRelay(logical)
     }
-    this.onRetry(forceReplacement)
+    // Why: revival nudges must honor failure cooldowns even when lease rotation is pending.
+    this.onRetry()
   }
 
   handleStateFailure(logical: StableLogicalRpcClient, state: ConnectionState): void {
@@ -70,9 +79,11 @@ export class RelayReconnectController {
     this.activeSession = session
   }
 
-  resetForDirectConnection(): void {
+  resetForDirectConnection(): boolean {
+    const needsCredentialRefresh = this.recoveryGate === 'fresh-credential'
     this.activeSession = null
     this.reset()
+    return needsCredentialRefresh
   }
 
   registerActiveFailure(logical: StableLogicalRpcClient): void {
@@ -89,7 +100,13 @@ export class RelayReconnectController {
 
   // True when the caller is still inside the cooldown window and must not
   // re-dial. Arms the self-scheduled retry so recovery still happens on its own.
-  shouldDefer(): boolean {
+  shouldDefer(ignoreCooldown = false): boolean {
+    if (this.recoveryGate) {
+      return true
+    }
+    if (ignoreCooldown) {
+      return false
+    }
     if (this.dependencies.now() < this.nextAttemptAt) {
       this.scheduleRetry()
       return true
@@ -97,7 +114,7 @@ export class RelayReconnectController {
     return false
   }
 
-  registerFailure(error: Error | null): void {
+  registerFailure(error: Error | null, scheduleRetry = true): void {
     this.consecutiveFailures += 1
     const code = error instanceof RelayOuterError ? error.code : null
     const recovery =
@@ -106,20 +123,37 @@ export class RelayReconnectController {
         : null
     const delay = this.delayMs()
     this.nextAttemptAt = this.dependencies.now() + delay
-    // Why: wait for an OS/direct-probe signal before arming one debounced retry.
-    if (
-      recovery?.kind === 'wait-for-host-revival' ||
-      recovery?.kind === 'disable-relay-credential'
-    ) {
+    if (recovery?.kind === 'wait-for-host-revival') {
+      // Why: retrying HOST_OFFLINE without a revival signal is polling a known-negative state.
+      this.recoveryGate = 'host-revival'
+      this.clearTimer()
+      return
+    }
+    if (recovery?.kind === 'disable-relay-credential') {
+      // Why: a rejected outer credential cannot recover until direct connectivity refreshes it.
+      this.recoveryGate = 'fresh-credential'
+      this.clearTimer()
+      return
+    }
+    this.recoveryGate = null
+    if (!scheduleRetry) {
       this.clearTimer()
       return
     }
     this.scheduleRetry(delay)
   }
 
+  retryDelayMs(minimumMs: number): number | null {
+    if (this.recoveryGate) {
+      return null
+    }
+    return Math.max(minimumMs, this.nextAttemptAt - this.dependencies.now())
+  }
+
   reset(): void {
     this.consecutiveFailures = 0
     this.nextAttemptAt = 0
+    this.recoveryGate = null
     this.clearTimer()
   }
 

--- a/mobile/src/transport/mobile-relay-reconnect-controller.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.ts
@@ -101,12 +101,9 @@ export class RelayReconnectController {
 
   // True when the caller is still inside the cooldown window and must not
   // re-dial. Arms the self-scheduled retry so recovery still happens on its own.
-  shouldDefer(ignoreCooldown = false): boolean {
+  shouldDefer(): boolean {
     if (this.recoveryGate) {
       return true
-    }
-    if (ignoreCooldown) {
-      return false
     }
     if (this.dependencies.now() < this.nextAttemptAt) {
       this.scheduleRetry()
@@ -148,7 +145,7 @@ export class RelayReconnectController {
     // Why: only a rejected outer credential can be repaired by the grace token;
     // retrying session/capacity close codes immediately recreates relay churn.
     return (
-      !(error instanceof RelayOuterError) ||
+      error instanceof RelayOuterError &&
       error.code === MOBILE_RELAY_CLOSE_CODE.BAD_OUTER_CREDENTIAL
     )
   }

--- a/mobile/src/transport/mobile-relay-reconnect-controller.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.ts
@@ -2,35 +2,90 @@ import {
   isMobileRelayCloseCode,
   mobileRelayRecoveryFor
 } from '../../../src/shared/mobile-relay-close-codes'
+import type { MobileRelayRpcSession } from './mobile-relay-rpc-session'
 import { RelayOuterError } from './mobile-relay-e2ee-link'
+import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
+import type { ConnectionState } from './types'
 
-// Why: relay resume closes (4408 peer-dropped / 4429 limit-exceeded) and silent
-// cellular NAT rebinds otherwise re-dial instantly; a flapping cellular link then
-// ping-pongs connect/disconnect. Space retries with the fullJitter backoff the
-// mobileRelayRecoveryFor contract prescribes, floored so retries never busy-loop.
+// Why: relay resume closes and silent cellular NAT rebinds otherwise cause
+// immediate re-dials that ping-pong the phone between connected and disconnected.
 const RELAY_BACKOFF_MIN_MS = 250
 const RELAY_BACKOFF_BASE_MS = 500
 const RELAY_BACKOFF_CEILING_MS = 30_000
 
-export type RelayReconnectBackoffDependencies = {
+export type RelayReconnectDependencies = {
   now: () => number
   randomBytes: (length: number) => Uint8Array
   setTimer: typeof setTimeout
   clearTimer: typeof clearTimeout
 }
 
-// Encapsulates the relay reconnect cooldown: how long to wait after each failed
-// resume before the supervisor may re-dial, and the self-scheduled retry that
-// fires when no external signal (foreground/probe) would otherwise drive it.
-export class RelayReconnectBackoff {
+export class RelayReconnectController {
   private consecutiveFailures = 0
   private nextAttemptAt = 0
   private timer: ReturnType<typeof setTimeout> | null = null
+  private activeSession: MobileRelayRpcSession | null = null
 
   constructor(
-    private readonly dependencies: RelayReconnectBackoffDependencies,
-    private readonly onRetry: () => void
+    private readonly dependencies: RelayReconnectDependencies,
+    private readonly onRetry: (forceReplacement?: boolean) => void
   ) {}
+
+  handleForeground(
+    logical: StableLogicalRpcClient,
+    wasForeground: boolean,
+    forceReplacement: boolean
+  ): void {
+    if (!wasForeground) {
+      // Why: an app resume is a fresh signal, unlike repeated network-flap nudges.
+      this.reset()
+    } else if (logical.getState() === 'connected') {
+      // Why: a network handoff can leave the relay half-open without publishing a close.
+      this.suspendActiveRelay(logical)
+    }
+    this.onRetry(forceReplacement)
+  }
+
+  handleStateFailure(logical: StableLogicalRpcClient, state: ConnectionState): void {
+    if (!this.needsRecovery(state)) {
+      return
+    }
+    this.registerActiveFailure(logical)
+    this.onRetry()
+  }
+
+  needsRecovery(state: ConnectionState): boolean {
+    return state !== 'connected' && state !== 'connecting'
+  }
+
+  suspendActiveRelay(logical: StableLogicalRpcClient): void {
+    if (logical.getActivePath() !== 'relay') {
+      return
+    }
+    this.activeSession = null
+    logical.suspendActiveSession()
+  }
+
+  setActiveSession(session: MobileRelayRpcSession): void {
+    this.activeSession = session
+  }
+
+  resetForDirectConnection(): void {
+    this.activeSession = null
+    this.reset()
+  }
+
+  registerActiveFailure(logical: StableLogicalRpcClient): void {
+    if (logical.getActivePath() !== 'relay') {
+      return
+    }
+    const failure = this.activeSession?.getFailure()
+    this.activeSession = null
+    if (failure) {
+      // Why: active relay closes need the same cooldown as failed replacement dials.
+      this.registerFailure(failure)
+    }
+  }
 
   // True when the caller is still inside the cooldown window and must not
   // re-dial. Arms the self-scheduled retry so recovery still happens on its own.
@@ -44,9 +99,6 @@ export class RelayReconnectBackoff {
 
   registerFailure(error: Error | null): void {
     this.consecutiveFailures += 1
-    // Why: honor the documented recovery contract (previously dead code). Every
-    // relay close code maps to a fullJitter/backoff recovery, so always debounce
-    // nudges by the backoff window.
     const code = error instanceof RelayOuterError ? error.code : null
     const recovery =
       code != null && isMobileRelayCloseCode(code)
@@ -54,13 +106,12 @@ export class RelayReconnectBackoff {
         : null
     const delay = this.delayMs()
     this.nextAttemptAt = this.dependencies.now() + delay
-    // Why: HOST_OFFLINE / BAD_OUTER_CREDENTIAL won't clear by retrying the same
-    // resume sooner; keep the debounce but let the next external signal
-    // (foreground, direct probe, or credential rotation) drive recovery instead.
+    // Why: these failures require host revival or fresh credentials, not a retry loop.
     if (
       recovery?.kind === 'wait-for-host-revival' ||
       recovery?.kind === 'disable-relay-credential'
     ) {
+      this.clearTimer()
       return
     }
     this.scheduleRetry(delay)
@@ -69,10 +120,15 @@ export class RelayReconnectBackoff {
   reset(): void {
     this.consecutiveFailures = 0
     this.nextAttemptAt = 0
-    this.clear()
+    this.clearTimer()
   }
 
   clear(): void {
+    this.clearTimer()
+    this.activeSession = null
+  }
+
+  private clearTimer(): void {
     if (this.timer) {
       this.dependencies.clearTimer(this.timer)
       this.timer = null

--- a/mobile/src/transport/mobile-relay-reconnect-controller.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.ts
@@ -1,5 +1,6 @@
 import {
   isMobileRelayCloseCode,
+  MOBILE_RELAY_CLOSE_CODE,
   mobileRelayRecoveryFor
 } from '../../../src/shared/mobile-relay-close-codes'
 import type { MobileRelayRpcSession } from './mobile-relay-rpc-session'
@@ -141,6 +142,15 @@ export class RelayReconnectController {
       return
     }
     this.scheduleRetry(delay)
+  }
+
+  shouldTryGraceAfterRelayFailure(error: Error): boolean {
+    // Why: only a rejected outer credential can be repaired by the grace token;
+    // retrying session/capacity close codes immediately recreates relay churn.
+    return (
+      !(error instanceof RelayOuterError) ||
+      error.code === MOBILE_RELAY_CLOSE_CODE.BAD_OUTER_CREDENTIAL
+    )
   }
 
   retryDelayMs(minimumMs: number): number | null {


### PR DESCRIPTION
## Summary

A phone using the relay on cellular could repeatedly connect and disconnect after a carrier NAT rebind or Wi-Fi/cellular handoff. Relay recovery had no backoff, and the close-code recovery contract in `mobileRelayRecoveryFor` had no production caller.

This PR now:

- uses a full-jitter exponential cooldown (250 ms floor, 30 s ceiling) for relay resume failures, including `PEER_DROPPED (4408)` and `LIMIT_EXCEEDED (4429)`;
- treats a network revival nudge as authority to replace an apparently connected relay, covering half-open sockets that never publish `onclose`;
- records close codes from the active relay before opening a replacement, not only failures from the replacement dial;
- preserves recovery when a relay drops while a direct probe or post-migration credential persistence owns the operation mutex;
- cancels stale retry timers when direct connectivity wins or recovery requires host revival/fresh credentials;
- keeps fatal recovery states event-gated and forces rejected-credential rotation only after direct connectivity returns;
- prevents revival nudges from bypassing failed lease-rotation cooldowns or async cleanup races from recreating timers; and
- keeps lease rotation and reconnect backoff in separate single-timer controllers.

## Screenshots

Not applicable; this is a transport lifecycle change with no UI changes.

## Testing

- `mobile`: 287 test files passed; 2,078 tests passed and 2 skipped.
- Deterministic regression coverage proves:
  - a half-open connected relay is replaced on a network handoff;
  - a direct `handshaking` state does not trigger relay failover;
  - five repeated revival nudges open zero additional sockets during cooldown;
  - current/grace bundles open one socket per cooldown for capacity failures;
  - a rejected current credential is skipped on grace cooldown retries and rotated after direct connectivity returns;
  - a fatal lease-replacement gate survives a later close from the still-active old relay;
  - generic transport/director failures do not spend a second attempt on the grace credential;
  - lease rotation cannot bypass an active relay failure cooldown;
  - post-auth credential persistence failures do not reopen healthy relays or poison backoff;
  - an active `4429` close waits for backoff before replacement;
  - rapid authenticated relay drops preserve the 250 → 500 → 1,000 ms exponential progression;
  - relay drops during both direct probing and post-migration persistence recover after the mutex is released;
  - `HOST_OFFLINE` does not create a polling timer;
  - retry state owns at most one timer and is cleared after direct connectivity wins;
  - host-offline and rejected-credential outcomes cannot re-arm from ordinary state checks or forced lease retries;
  - background/stop races leave zero reconnect or lease timers; and
  - revival nudges stay inside a failed forced-rotation cooldown.
- Shared mobile relay close-code contract: 4 tests passed.
- Mobile `tsc --noEmit`, full `oxlint`, and full `oxfmt --check`: clean.
- Earlier PR smoke evidence: the iOS simulator bundled and loaded the change. A simulator cannot reproduce a physical cellular NAT rebind.

## AI Review Report

The review found and fixed additional gaps beyond the original backoff implementation: the reported half-open socket path was not exercised, active relay close codes bypassed backoff, a relay drop during post-migration persistence could be lost behind the operation mutex, a transient direct `handshaking` state could be misclassified as a failover signal, and short-lived authenticated relay sessions reset the exponential streak before proving stability. It also removed stale timer wakes after direct recovery and non-retryable relay outcomes, kept fatal gates sticky across old-session closes, and stopped redialing credentials already rejected with `4401`.

## Security Audit

No credential format, storage, trust boundary, encryption, logging payload, or server API changed. Resume credentials remain in the existing secure-store path. The change only controls client-side connection lifecycle and timers.

## Reliability / performance

- **Invariant — `mobile-relay.recovery-liveness`:** while foregrounded and disconnected, relay recovery is in flight, cooldown-scheduled, waiting for an explicit external signal required by policy, or handed off when a competing operation releases the mutex.
- **Failure source:** cellular NAT/network handoffs, active relay `4408/4429` closes, and relay drops racing direct probes or credential persistence.
- **Oracle:** deterministic injected-clock tests assert exact socket-open counts and timer counts at the cooldown boundary.
- **Gate:** accepted manifest gap; `config/reliability-gates.jsonc` has no dedicated mobile-relay recovery gate. The provider-level tests and full mobile suite are the PR gate.
- **Provider/platform coverage:** mobile/relay is covered by injected-session tests. Local/daemon PTY, SSH/remote, WSL, and desktop macOS/Linux/Windows paths are unaffected; no filesystem, process, shell, or platform-specific path behavior changed.
- **Performance budget:** no polling, scans, subprocesses, provider fanout, persistent caches, or unbounded buffers were added. Repeated nudges reuse one bounded retry timer; direct success and non-retryable policy outcomes cancel it. Capacity/session and generic transport/director failures do not spend a second immediate socket attempt on the grace credential. A rejected current version is retained only for the bounded current/grace credential set, skipped on later cooldown attempts, and cleared after durable direct rotation. Lease rotation also honors an existing recovery cooldown. Rapid authenticated drops retain their failure streak; an authenticated relay that survives the ceiling-length stability window resets it without adding a timer.
- **Diagnostics:** relay close codes remain available as `RelayOuterError`, allowing recovery policy and tests to distinguish failure classes.
- **Residual gap:** physical cellular NAT rebinding and Wi-Fi/cellular handoff behavior remains unproved by an emulator.

## Notes

The relay cell service that emits `4408`/`4429` is outside this repository. Its behavior is represented by the shared close-code contract and deterministic client-side fault injection.