### PR TITLE
Clear a removed remote host's leftover repos and worktrees from the sidebar

### DIFF
--- a/src/renderer/src/store/slices/purge-stale-runtime-host-state.test.ts
+++ b/src/renderer/src/store/slices/purge-stale-runtime-host-state.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Action coverage for `purgeStaleRuntimeHostState` (#8881).
+ *
+ * Removing a runtime identity must retire the repos/setups/rows/detected rows and
+ * cascaded tab state it owned, while leaving local, ssh, and — the P1 regression —
+ * a *never-saved* runtime-stamped LOCAL repo (a serving instance's own row)
+ * untouched. The action is scoped to the removal diff, so it must no-op (no
+ * sortEpoch bump) for an empty diff or an env that matches nothing.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { toRuntimeExecutionHostId } from '../../../../shared/execution-host'
+import type { ProjectHostSetup, DetectedWorktreeListResult } from '../../../../shared/types'
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn() }
+}))
+
+vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
+  restorePtyDataHandlersAfterFailedShutdown: vi.fn(),
+  unregisterPtyDataHandlers: vi.fn()
+}))
+
+// @ts-expect-error -- minimal window.api stub for the store under test
+globalThis.window = { api: {} }
+
+import { createTestStore, seedStore, makeWorktree, makeTab, TEST_REPO } from './store-test-helpers'
+
+const RUNTIME_A = toRuntimeExecutionHostId('env-a')
+const RUNTIME_NEVER_SAVED = toRuntimeExecutionHostId('env-serving-client')
+
+function setup(overrides: Partial<ProjectHostSetup> & { id: string }): ProjectHostSetup {
+  return {
+    projectId: 'p',
+    hostId: 'local',
+    repoId: '',
+    path: '/tmp',
+    displayName: 'setup',
+    setupState: 'ready',
+    setupMethod: 'existing',
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides
+  } as ProjectHostSetup
+}
+
+function detectedResult(
+  repoId: string,
+  worktrees: DetectedWorktreeListResult['worktrees']
+): DetectedWorktreeListResult {
+  return { repoId, authoritative: true, source: 'git', worktrees }
+}
+
+function detected(
+  id: string,
+  repoId: string,
+  hostId: ReturnType<typeof toRuntimeExecutionHostId> | 'local'
+): DetectedWorktreeListResult['worktrees'][number] {
+  return {
+    ...makeWorktree({ id, repoId, hostId }),
+    ownership: 'orca-managed',
+    selectedCheckout: true,
+    visible: true
+  } as DetectedWorktreeListResult['worktrees'][number]
+}
+
+describe('purgeStaleRuntimeHostState', () => {
+  it('purges the removed env and preserves local + never-saved runtime-stamped repos', () => {
+    const store = createTestStore()
+    const WT_A = 'repoA::/wt-a'
+    const TAB_A = 'tab-a'
+    seedStore(store, {
+      // A local repo, a runtime:env-a repo (the removed one), and the P1 regression
+      // case: a LOCAL repo carrying a runtime stamp whose env was never saved.
+      repos: [
+        TEST_REPO,
+        {
+          id: 'repoA',
+          path: '/repoA',
+          displayName: 'A',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: RUNTIME_A
+        },
+        {
+          id: 'repoServing',
+          path: '/repoServing',
+          displayName: 'Serving',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: RUNTIME_NEVER_SAVED
+        }
+      ],
+      projectHostSetups: [
+        setup({ id: 's-local', repoId: 'repo1', hostId: 'local' }),
+        setup({ id: 's-a', repoId: 'repoA', hostId: RUNTIME_A }),
+        setup({ id: 's-a-repoless', repoId: '', hostId: RUNTIME_A }),
+        setup({ id: 's-serving', repoId: 'repoServing', hostId: RUNTIME_NEVER_SAVED })
+      ],
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: 'repo1::/wt-local', repoId: 'repo1', hostId: 'local' })],
+        repoA: [makeWorktree({ id: WT_A, repoId: 'repoA', path: '/wt-a', hostId: RUNTIME_A })],
+        repoServing: [
+          makeWorktree({
+            id: 'repoServing::/wt-s',
+            repoId: 'repoServing',
+            hostId: RUNTIME_NEVER_SAVED
+          })
+        ]
+      },
+      detectedWorktreesByRepo: {
+        repoA: detectedResult('repoA', [detected(WT_A, 'repoA', RUNTIME_A)])
+      },
+      tabsByWorktree: { [WT_A]: [makeTab({ id: TAB_A, worktreeId: WT_A })] }
+    })
+    const epochBefore = store.getState().sortEpoch
+
+    store.getState().purgeStaleRuntimeHostState(['env-a'])
+
+    const s = store.getState()
+    // Removed env's repo/setups/rows/detected/tab all gone.
+    expect(s.repos.map((r) => r.id)).toEqual(['repo1', 'repoServing'])
+    expect(s.projectHostSetups.map((x) => x.id).sort()).toEqual(['s-local', 's-serving'])
+    expect(s.worktreesByRepo.repoA).toEqual([])
+    expect(s.detectedWorktreesByRepo.repoA.worktrees).toEqual([])
+    expect(s.tabsByWorktree[WT_A]).toBeUndefined()
+    // Local repo AND the never-saved runtime-stamped local repo BOTH survive.
+    expect(s.worktreesByRepo.repo1).toHaveLength(1)
+    expect(s.worktreesByRepo.repoServing).toHaveLength(1)
+    // sortEpoch bumped because rows changed.
+    expect(s.sortEpoch).toBe(epochBefore + 1)
+  })
+
+  it('keeps a still-saved sibling runtime env when another runtime env is removed', () => {
+    const store = createTestStore()
+    const RUNTIME_B = toRuntimeExecutionHostId('env-b')
+    seedStore(store, {
+      repos: [
+        {
+          id: 'repoA',
+          path: '/repoA',
+          displayName: 'A',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: RUNTIME_A
+        },
+        {
+          id: 'repoB',
+          path: '/repoB',
+          displayName: 'B',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: RUNTIME_B
+        }
+      ],
+      worktreesByRepo: {
+        repoA: [makeWorktree({ id: 'repoA::/wt-a', repoId: 'repoA', hostId: RUNTIME_A })],
+        repoB: [makeWorktree({ id: 'repoB::/wt-b', repoId: 'repoB', hostId: RUNTIME_B })]
+      }
+    })
+
+    // Only env-a is removed; env-b is a still-saved sibling runtime host.
+    store.getState().purgeStaleRuntimeHostState(['env-a'])
+
+    const s = store.getState()
+    expect(s.repos.map((r) => r.id)).toEqual(['repoB'])
+    expect(s.worktreesByRepo.repoB).toHaveLength(1)
+    expect(s.worktreesByRepo.repoA).toEqual([])
+  })
+
+  it('is a no-op (no sortEpoch bump) for an empty removed set and for a non-matching env', () => {
+    const store = createTestStore()
+    seedStore(store, {
+      repos: [TEST_REPO],
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: 'repo1::/wt', repoId: 'repo1', hostId: 'local' })]
+      }
+    })
+    const before = store.getState()
+    const epochBefore = before.sortEpoch
+    const worktreesRef = before.worktreesByRepo
+    const reposRef = before.repos
+
+    store.getState().purgeStaleRuntimeHostState([])
+    store.getState().purgeStaleRuntimeHostState(['env-does-not-exist'])
+
+    const s = store.getState()
+    expect(s.sortEpoch).toBe(epochBefore)
+    // Nothing stale => the reducer returns state untouched (same references).
+    expect(s.worktreesByRepo).toBe(worktreesRef)
+    expect(s.repos).toBe(reposRef)
+  })
+
+  it('same-repoId-on-two-hosts: keeps the local row and the repo key after purge', () => {
+    const store = createTestStore()
+    // repoId 'shared' exists under both local and runtime:env-a in worktreesByRepo.
+    seedStore(store, {
+      repos: [
+        { id: 'shared', path: '/shared', displayName: 'shared', badgeColor: '#000', addedAt: 0 },
+        {
+          id: 'sharedRuntime',
+          path: '/shared',
+          displayName: 'shared',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: RUNTIME_A
+        }
+      ],
+      worktreesByRepo: {
+        shared: [
+          makeWorktree({ id: 'shared::/wt-local', repoId: 'shared', hostId: 'local' }),
+          makeWorktree({ id: 'shared::/wt-a', repoId: 'shared', hostId: RUNTIME_A })
+        ]
+      }
+    })
+
+    store.getState().purgeStaleRuntimeHostState(['env-a'])
+
+    const s = store.getState()
+    expect(s.worktreesByRepo).toHaveProperty('shared')
+    expect(s.worktreesByRepo.shared.map((w) => w.id)).toEqual(['shared::/wt-local'])
+  })
+
+  it('clears activeRepoId and drops the purged id from filterRepoIds', () => {
+    const store = createTestStore()
+    seedStore(store, {
+      repos: [
+        TEST_REPO,
+        {
+          id: 'repoA',
+          path: '/repoA',
+          displayName: 'A',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: RUNTIME_A
+        }
+      ],
+      worktreesByRepo: {
+        repoA: [makeWorktree({ id: 'repoA::/wt-a', repoId: 'repoA', hostId: RUNTIME_A })]
+      },
+      activeRepoId: 'repoA',
+      filterRepoIds: ['repo1', 'repoA']
+    })
+
+    store.getState().purgeStaleRuntimeHostState(['env-a'])
+
+    const s = store.getState()
+    expect(s.activeRepoId).toBeNull()
+    expect(s.filterRepoIds).toEqual(['repo1'])
+  })
+})

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -85,6 +85,7 @@ import {
   toSshExecutionHostId,
   type ExecutionHostId
 } from '../../../../shared/execution-host'
+import { isRemovedRuntimeHostId } from './stale-runtime-host-rows'
 import { cleanupEphemeralVmRuntimesForDeleted } from '@/lib/ephemeral-vm-runtime-cleanup'
 import { folderWorkspaceKey, parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import { formatFolderWorkspaceCreateError } from '../../lib/folder-workspace-path-status'
@@ -1562,6 +1563,13 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       }
       let finalizedHostRepos: Repo[] = []
       set((s) => {
+        // Why: an in-flight fetch for a just-removed runtime env would otherwise
+        // re-add purged repos/rows and stick — nothing re-triggers the purge. Skip
+        // only when the catalog's env was actually removed (tombstoned), not merely
+        // absent from the not-yet-hydrated saved list (#8881).
+        if (isRemovedRuntimeHostId(catalog.hostId, s.removedRuntimeEnvironmentIds)) {
+          return s
+        }
         // Why: after re-adoption re-points a repo onto a re-added SSH target, the
         // per-host merge leaves the stale row on the old (removed) target id — a
         // ghost a terminal pane can bind to and fail with "SSH target not found".
@@ -1616,6 +1624,11 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       const catalog = await fetchRepoCatalogForTarget(target)
       let finalizedHostRepos: Repo[] = []
       set((s) => {
+        // Why: skip a merge for a runtime env removed while this Connect-flow fetch
+        // was in flight, so purged repos/rows are not re-added (#8881).
+        if (isRemovedRuntimeHostId(catalog.hostId, s.removedRuntimeEnvironmentIds)) {
+          return s
+        }
         const result = mergeFetchedRepoCatalog(catalog, s.repos)
         const reconciliation = reconcileSupersededSshRepos(result.repos, s)
         const finalizedRepos = applyManualRepoOrder(reconciliation.repos, s.manualRepoOrder)
@@ -1682,6 +1695,12 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       }
       let hostRepos: Repo[] = []
       set((s) => {
+        // Why: an all-host refresh can still be merging a host removed mid-load;
+        // skip a catalog whose env was tombstoned by a removal, not one merely
+        // absent from the not-yet-hydrated saved list (#8881).
+        if (isRemovedRuntimeHostId(catalog.hostId, s.removedRuntimeEnvironmentIds)) {
+          return s
+        }
         const result = mergeFetchedRepoCatalog(catalog, s.repos)
         const reconciliation = reconcileSupersededSshRepos(result.repos, s)
         const finalizedRepos = applyManualRepoOrder(reconciliation.repos, s.manualRepoOrder)

--- a/src/renderer/src/store/slices/runtime-catalog-merge-removed-env-guard.test.ts
+++ b/src/renderer/src/store/slices/runtime-catalog-merge-removed-env-guard.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Catalog-merge guard coverage for #8881: an in-flight catalog fetch for a runtime
+ * env removed mid-load must NOT re-add the purged repos, because nothing
+ * re-triggers the purge afterwards. The guard keys on `catalog.hostId` and the
+ * *tombstone* set (`removedRuntimeEnvironmentIds`), so only a genuinely-removed env
+ * is skipped — a runtime env merely absent from a not-yet-hydrated saved list still
+ * merges (else boot would drop legitimate runtime repos), and a still-saved env or a
+ * `hostId: 'local'` catalog whose repos carry runtime stamps also merges.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import type * as RuntimeRpcClientModule from '@/runtime/runtime-rpc-client'
+import type { Repo } from '../../../../shared/types'
+import type { PublicKnownRuntimeEnvironment } from '../../../../shared/runtime-environments'
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn() }
+}))
+
+vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
+  restorePtyDataHandlersAfterFailedShutdown: vi.fn(),
+  unregisterPtyDataHandlers: vi.fn()
+}))
+
+// Every runtime RPC (repo.list, project.list, projectHostSetup.list, capability
+// probes) resolves this shape — repo.list reads `.repos`; the compatibility probes
+// read `.projects` / `.setups`; anything else falls back safely.
+const rpcResult = vi.hoisted(() => ({ current: { repos: [] as Repo[], projects: [], setups: [] } }))
+
+vi.mock('@/runtime/runtime-rpc-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof RuntimeRpcClientModule>()
+  return { ...actual, callRuntimeRpc: vi.fn(async () => rpcResult.current) }
+})
+
+const localReposList = vi.fn<() => Promise<Repo[]>>()
+
+// @ts-expect-error -- minimal window.api stub for the store under test
+globalThis.window = { api: { repos: { list: localReposList } } }
+
+import { createTestStore, seedStore, TEST_REPO } from './store-test-helpers'
+
+function env(id: string): PublicKnownRuntimeEnvironment {
+  return { id } as unknown as PublicKnownRuntimeEnvironment
+}
+
+function repo(id: string, extra: Partial<Repo> = {}): Repo {
+  return {
+    id,
+    path: `/${id}`,
+    displayName: id,
+    badgeColor: '#000',
+    addedAt: 0,
+    ...extra
+  } as Repo
+}
+
+describe('environment-catalog merge guard drops catalogs for a removed env', () => {
+  it('fetchRuntimeEnvironmentRepos skips the merge when the catalog env was removed (tombstoned)', async () => {
+    const store = createTestStore()
+    seedStore(store, {
+      repos: [TEST_REPO],
+      runtimeEnvironments: [env('env-gone'), env('env-b')]
+    })
+    // Remove env-gone from the saved list → tombstoned. A catalog fetch for it that
+    // was already in flight across the removal must not re-add its repos.
+    store.getState().setRuntimeEnvironments([env('env-b')])
+    rpcResult.current = { repos: [repo('ghost')], projects: [], setups: [] }
+
+    await store.getState().fetchRuntimeEnvironmentRepos('env-gone')
+
+    expect(store.getState().repos.map((r) => r.id)).toEqual(['repo1'])
+  })
+
+  it('fetchRuntimeEnvironmentRepos merges a catalog whose env is absent but not tombstoned (not yet hydrated)', async () => {
+    // The P1 the tombstone fixes: on boot the saved list can still be empty while a
+    // runtime catalog is enumerated from disk. Absence must NOT skip the merge.
+    const store = createTestStore()
+    seedStore(store, { repos: [TEST_REPO], runtimeEnvironments: [] })
+    rpcResult.current = { repos: [repo('fresh')], projects: [], setups: [] }
+
+    await store.getState().fetchRuntimeEnvironmentRepos('env-hydrating')
+
+    expect(
+      store
+        .getState()
+        .repos.map((r) => r.id)
+        .sort()
+    ).toEqual(['fresh', 'repo1'])
+  })
+
+  it('fetchRuntimeEnvironmentRepos merges the catalog for a still-saved env id', async () => {
+    const store = createTestStore()
+    seedStore(store, { repos: [TEST_REPO], runtimeEnvironments: [env('env-saved')] })
+    rpcResult.current = { repos: [repo('fresh')], projects: [], setups: [] }
+
+    await store.getState().fetchRuntimeEnvironmentRepos('env-saved')
+
+    expect(
+      store
+        .getState()
+        .repos.map((r) => r.id)
+        .sort()
+    ).toEqual(['fresh', 'repo1'])
+  })
+
+  it("fetchRepos merges a 'local' catalog even when its repos carry runtime stamps", async () => {
+    const store = createTestStore()
+    seedStore(store, { repos: [TEST_REPO], runtimeEnvironments: [] })
+    // A serving instance's own local catalog: hostId 'local', repos runtime-stamped.
+    localReposList.mockResolvedValue([
+      repo('localStamped', { executionHostId: 'runtime:some-client' })
+    ])
+
+    await store.getState().fetchRepos()
+
+    expect(store.getState().repos.map((r) => r.id)).toContain('localStamped')
+  })
+})

--- a/src/renderer/src/store/slices/runtime-host-purge-session-partition-split.test.ts
+++ b/src/renderer/src/store/slices/runtime-host-purge-session-partition-split.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Directly covers the "stops new stale-partition writes" claim of #8881: once the
+ * purge removes a removed-env runtime worktree row + repo, `buildHostIdByWorktreeId`
+ * must resolve that worktree to 'local' (its owner is gone) and
+ * `patchWorkspaceSessionByHost` must no longer route a write to the removed runtime
+ * partition.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { toRuntimeExecutionHostId } from '../../../../shared/execution-host'
+import type { WorkspaceSessionPatch } from '../../../../shared/types'
+import {
+  buildHostIdByWorktreeId,
+  patchWorkspaceSessionByHost,
+  type HostPersistenceState
+} from '@/lib/workspace-session-host-persistence'
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn() }
+}))
+
+vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
+  restorePtyDataHandlersAfterFailedShutdown: vi.fn(),
+  unregisterPtyDataHandlers: vi.fn()
+}))
+
+// @ts-expect-error -- minimal window.api stub for the store under test
+globalThis.window = { api: {} }
+
+import { createTestStore, seedStore, makeWorktree, TEST_REPO } from './store-test-helpers'
+
+const RUNTIME_A = toRuntimeExecutionHostId('env-a')
+const WT_A = 'repoA::/wt-a'
+
+function seedRuntimeRow(store: ReturnType<typeof createTestStore>): void {
+  seedStore(store, {
+    repos: [
+      TEST_REPO,
+      {
+        id: 'repoA',
+        path: '/repoA',
+        displayName: 'A',
+        badgeColor: '#000',
+        addedAt: 0,
+        executionHostId: RUNTIME_A
+      }
+    ],
+    worktreesByRepo: {
+      repoA: [makeWorktree({ id: WT_A, repoId: 'repoA', path: '/wt-a', hostId: RUNTIME_A })]
+    }
+  })
+}
+
+describe('purge stops routing session writes to the removed runtime partition', () => {
+  it('buildHostIdByWorktreeId resolves the removed worktree to local after purge', () => {
+    const store = createTestStore()
+    seedRuntimeRow(store)
+
+    // Before: the row is owned by the runtime host.
+    expect(buildHostIdByWorktreeId(store.getState() as HostPersistenceState)(WT_A)).toBe(RUNTIME_A)
+
+    store.getState().purgeStaleRuntimeHostState(['env-a'])
+
+    // After: its owner is gone, so it falls back to the local partition.
+    expect(buildHostIdByWorktreeId(store.getState() as HostPersistenceState)(WT_A)).toBe('local')
+  })
+
+  it('patchWorkspaceSessionByHost no longer writes the runtime partition after purge', async () => {
+    const store = createTestStore()
+    seedRuntimeRow(store)
+    const api = {
+      get: vi.fn().mockResolvedValue({}),
+      patch: vi.fn().mockResolvedValue(undefined),
+      setSync: vi.fn()
+    }
+    const patch = { activeWorktreeIdsOnShutdown: [WT_A] } as unknown as WorkspaceSessionPatch
+
+    await patchWorkspaceSessionByHost(api, patch, store.getState() as HostPersistenceState)
+    const runtimeWritesBefore = api.patch.mock.calls.filter(([, hostId]) => hostId === RUNTIME_A)
+    expect(runtimeWritesBefore).toHaveLength(1)
+
+    store.getState().purgeStaleRuntimeHostState(['env-a'])
+    api.patch.mockClear()
+
+    await patchWorkspaceSessionByHost(api, patch, store.getState() as HostPersistenceState)
+    const runtimeWritesAfter = api.patch.mock.calls.filter(([, hostId]) => hostId === RUNTIME_A)
+    expect(runtimeWritesAfter).toHaveLength(0)
+    // The local write still happens.
+    expect(api.patch).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -23,7 +23,14 @@ export type RuntimeStatusSlice = {
   /** Keyed by runtime environment id. Fed into buildExecutionHostRegistry so
    * compat verdicts/blocked health show live in the sidebar host pickers. */
   runtimeStatusByEnvironmentId: Map<string, RuntimeEnvironmentStatus>
-  /** Replaces the saved-environment list and trims stale status entries. */
+  /** Tombstones of runtime environment ids that were removed from the saved list
+   * this session and not yet re-added. Distinct from "absent from
+   * `runtimeEnvironments`", which also matches not-yet-hydrated envs — a
+   * catalog-merge guard keyed on mere absence would drop legitimate runtime repos
+   * during boot before the saved list hydrates (#8881). */
+  removedRuntimeEnvironmentIds: ReadonlySet<string>
+  /** Replaces the saved-environment list, trims stale status entries, and
+   * retires state owned by any environment that just left the saved list. */
   setRuntimeEnvironments: (environments: PublicKnownRuntimeEnvironment[]) => void
   /** Merges one environment's status. Replaces the prior entry for that id. */
   setRuntimeEnvironmentStatus: (environmentId: string, status: RuntimeEnvironmentStatus) => void
@@ -44,8 +51,16 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
 ) => ({
   runtimeEnvironments: [],
   runtimeStatusByEnvironmentId: new Map(),
+  removedRuntimeEnvironmentIds: new Set(),
 
   setRuntimeEnvironments: (environments) => {
+    // Why: diff against the accumulated in-memory saved list (not a second disk
+    // read) so a main-initiated removal that never calls setRuntimeEnvironments
+    // still enters the diff on the next list read. #8881.
+    const nextIds = new Set(environments.map((environment) => environment.id))
+    const removedIds = get()
+      .runtimeEnvironments.map((environment) => environment.id)
+      .filter((id) => !nextIds.has(id))
     set((s) => {
       const keep = new Set(environments.map((environment) => environment.id))
       const nextStatuses = new Map(s.runtimeStatusByEnvironmentId)
@@ -56,9 +71,26 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
           statusesChanged = true
         }
       }
+      // Add just-removed ids as tombstones and clear any that were re-added, so an
+      // in-flight catalog merge for a removed env can be dropped without mistaking a
+      // not-yet-hydrated env for a removed one (#8881).
+      const nextRemoved = new Set(s.removedRuntimeEnvironmentIds)
+      let removedChanged = false
+      for (const id of removedIds) {
+        if (!nextRemoved.has(id)) {
+          nextRemoved.add(id)
+          removedChanged = true
+        }
+      }
+      for (const id of nextIds) {
+        if (nextRemoved.delete(id)) {
+          removedChanged = true
+        }
+      }
       return {
         runtimeEnvironments: environments,
-        ...(statusesChanged ? { runtimeStatusByEnvironmentId: nextStatuses } : {})
+        ...(statusesChanged ? { runtimeStatusByEnvironmentId: nextStatuses } : {}),
+        ...(removedChanged ? { removedRuntimeEnvironmentIds: nextRemoved } : {})
       }
     })
     // Why: evict detected-agent caches for environments that no longer exist so
@@ -68,6 +100,13 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
     get().retainRuntimeDetectedAgents?.(environments.map((environment) => environment.id))
     // A detached environment's mirrored SSH state must not outlive it.
     get().retainEnvironmentSshState?.(environments.map((environment) => environment.id))
+    // Retire repos/setups/worktree rows owned by a just-removed runtime identity so
+    // the same checkout stops duplicating in the sidebar. Scoped to the removal diff
+    // (not an absolute keep-set) to spare a serving instance's local runtime-stamped
+    // repos, whose env id was never in this instance's saved list.
+    if (removedIds.length > 0) {
+      get().purgeStaleRuntimeHostState?.(removedIds)
+    }
   },
 
   setRuntimeEnvironmentStatus: (environmentId, status) => {

--- a/src/renderer/src/store/slices/set-runtime-environments-purge-wiring.test.ts
+++ b/src/renderer/src/store/slices/set-runtime-environments-purge-wiring.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Wiring coverage for #8881: `setRuntimeEnvironments` must fire the stale-runtime
+ * purge on the removal diff. Load-bearing because the call is optional-chained
+ * (`get().purgeStaleRuntimeHostState?.(removedIds)`) — a rename/omission would
+ * silently no-op while every pure-helper unit test still passed.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { toRuntimeExecutionHostId } from '../../../../shared/execution-host'
+import type { ProjectHostSetup } from '../../../../shared/types'
+import type { PublicKnownRuntimeEnvironment } from '../../../../shared/runtime-environments'
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn() }
+}))
+
+vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
+  restorePtyDataHandlersAfterFailedShutdown: vi.fn(),
+  unregisterPtyDataHandlers: vi.fn()
+}))
+
+// @ts-expect-error -- minimal window.api stub for the store under test
+globalThis.window = { api: {} }
+
+import { createTestStore, seedStore, makeWorktree, makeTab, TEST_REPO } from './store-test-helpers'
+
+const RUNTIME_A = toRuntimeExecutionHostId('env-a')
+
+function env(id: string): PublicKnownRuntimeEnvironment {
+  return { id } as unknown as PublicKnownRuntimeEnvironment
+}
+
+function seedStale(store: ReturnType<typeof createTestStore>): void {
+  const WT_A = 'repoA::/wt-a'
+  seedStore(store, {
+    // In-memory previous saved list — the diff is computed against this.
+    runtimeEnvironments: [env('env-a'), env('env-b')],
+    repos: [
+      TEST_REPO,
+      {
+        id: 'repoA',
+        path: '/repoA',
+        displayName: 'A',
+        badgeColor: '#000',
+        addedAt: 0,
+        executionHostId: RUNTIME_A
+      }
+    ],
+    projectHostSetups: [
+      {
+        id: 's-a',
+        projectId: 'p',
+        hostId: RUNTIME_A,
+        repoId: 'repoA',
+        path: '/repoA',
+        displayName: 'A',
+        setupState: 'ready',
+        setupMethod: 'imported-existing-folder',
+        createdAt: 0,
+        updatedAt: 0
+      } as ProjectHostSetup
+    ],
+    worktreesByRepo: {
+      repoA: [makeWorktree({ id: WT_A, repoId: 'repoA', path: '/wt-a', hostId: RUNTIME_A })]
+    },
+    tabsByWorktree: { [WT_A]: [makeTab({ id: 'tab-a', worktreeId: WT_A })] }
+  })
+}
+
+describe('setRuntimeEnvironments removal diff fires the stale-runtime purge', () => {
+  it('purges the removed env owned repo/rows/setup/tab', () => {
+    const store = createTestStore()
+    seedStale(store)
+
+    // env-a removed; env-b remains.
+    store.getState().setRuntimeEnvironments([env('env-b')])
+
+    const s = store.getState()
+    expect(s.repos.map((r) => r.id)).toEqual(['repo1'])
+    expect(s.projectHostSetups).toEqual([])
+    expect(s.worktreesByRepo.repoA).toEqual([])
+    expect(s.tabsByWorktree['repoA::/wt-a']).toBeUndefined()
+    // The saved list itself was updated.
+    expect(s.runtimeEnvironments.map((e) => e.id)).toEqual(['env-b'])
+  })
+
+  it('is a no-op for repos/rows when no environment was removed', () => {
+    const store = createTestStore()
+    seedStale(store)
+    const reposRef = store.getState().repos
+    const worktreesRef = store.getState().worktreesByRepo
+
+    // Same set (order irrelevant) => empty removal diff => purge never runs.
+    store.getState().setRuntimeEnvironments([env('env-a'), env('env-b')])
+
+    const s = store.getState()
+    expect(s.repos).toBe(reposRef)
+    expect(s.worktreesByRepo).toBe(worktreesRef)
+    expect(s.repos.map((r) => r.id)).toEqual(['repo1', 'repoA'])
+  })
+})

--- a/src/renderer/src/store/slices/stale-runtime-host-rows.test.ts
+++ b/src/renderer/src/store/slices/stale-runtime-host-rows.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit coverage for the pure predicates/reducer behind the #8881 store purge.
+ *
+ * The removal-diff scoping is the load-bearing safety property: `isRemovedRuntimeHostId`
+ * may only match runtime hosts whose env id is in the *removed* (tombstoned) set —
+ * never local/ssh/unhosted, and never a runtime host merely absent from a
+ * not-yet-hydrated saved list. The reducer must preserve reference identity when
+ * nothing changed so it never churns the render pipeline.
+ */
+import { describe, it, expect } from 'vitest'
+import { toRuntimeExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
+import {
+  isRemovedRuntimeHostId,
+  dropWorktreeRowsForRemovedRuntimeEnvironments
+} from './stale-runtime-host-rows'
+
+const runtimeA = toRuntimeExecutionHostId('env-a')
+const runtimeB = toRuntimeExecutionHostId('env-b')
+
+type Row = { id: string; hostId?: ExecutionHostId }
+
+function row(id: string, hostId?: ExecutionHostId): Row {
+  return { id, hostId }
+}
+
+describe('isRemovedRuntimeHostId', () => {
+  it('is true for a runtime host whose env id is in the removed set', () => {
+    expect(isRemovedRuntimeHostId(runtimeA, new Set(['env-a']))).toBe(true)
+  })
+
+  it('is false for a runtime host NOT in the removed set', () => {
+    expect(isRemovedRuntimeHostId(runtimeB, new Set(['env-a']))).toBe(false)
+  })
+
+  it('is false for local, ssh, and undefined host ids', () => {
+    const removed = new Set(['env-a'])
+    expect(isRemovedRuntimeHostId('local', removed)).toBe(false)
+    expect(isRemovedRuntimeHostId('ssh:my-server', removed)).toBe(false)
+    expect(isRemovedRuntimeHostId(undefined, removed)).toBe(false)
+    expect(isRemovedRuntimeHostId(null, removed)).toBe(false)
+  })
+
+  it('is false when the removed set is empty', () => {
+    expect(isRemovedRuntimeHostId(runtimeA, new Set())).toBe(false)
+  })
+
+  it("is false for a 'local' catalog host even when a serving instance's repos carry runtime stamps", () => {
+    // The catalog-merge guard keys on catalog.hostId (the fetch *target*). A serving
+    // instance's own catalog is fetched as hostId 'local' regardless of the runtime:
+    // stamps its repos carry, so it is exempt by construction.
+    expect(isRemovedRuntimeHostId('local', new Set(['env-a']))).toBe(false)
+  })
+})
+
+describe('dropWorktreeRowsForRemovedRuntimeEnvironments', () => {
+  it('drops matching runtime rows and reports their ids', () => {
+    const rowsByRepo = {
+      repo1: [row('w-local', 'local'), row('w-a', runtimeA)]
+    }
+    const result = dropWorktreeRowsForRemovedRuntimeEnvironments(rowsByRepo, new Set(['env-a']))
+    expect(result.rowsByRepo.repo1).toEqual([row('w-local', 'local')])
+    expect(result.removedWorktreeIds).toEqual(['w-a'])
+  })
+
+  it('returns the SAME reference with empty ids when nothing matches', () => {
+    const rowsByRepo = { repo1: [row('w-local', 'local'), row('w-b', runtimeB)] }
+    const result = dropWorktreeRowsForRemovedRuntimeEnvironments(rowsByRepo, new Set(['env-a']))
+    expect(result.rowsByRepo).toBe(rowsByRepo)
+    expect(result.removedWorktreeIds).toEqual([])
+  })
+
+  it('returns the SAME reference with empty ids when the removed set is empty', () => {
+    const rowsByRepo = { repo1: [row('w-a', runtimeA)] }
+    const result = dropWorktreeRowsForRemovedRuntimeEnvironments(rowsByRepo, new Set())
+    expect(result.rowsByRepo).toBe(rowsByRepo)
+    expect(result.removedWorktreeIds).toEqual([])
+  })
+
+  it('keeps the repo key even when all of its rows drop', () => {
+    const rowsByRepo = { repoA: [row('w-a1', runtimeA), row('w-a2', runtimeA)] }
+    const result = dropWorktreeRowsForRemovedRuntimeEnvironments(rowsByRepo, new Set(['env-a']))
+    expect(Object.keys(result.rowsByRepo)).toEqual(['repoA'])
+    expect(result.rowsByRepo.repoA).toEqual([])
+    expect(result.removedWorktreeIds).toEqual(['w-a1', 'w-a2'])
+  })
+
+  it('gives only the changed repo a new array; unchanged repos keep their reference', () => {
+    const unchanged = [row('w-local', 'local')]
+    const changing = [row('w-keep', 'local'), row('w-a', runtimeA)]
+    const rowsByRepo = { repoUnchanged: unchanged, repoChanging: changing }
+    const result = dropWorktreeRowsForRemovedRuntimeEnvironments(rowsByRepo, new Set(['env-a']))
+    // A change anywhere returns a new top-level map...
+    expect(result.rowsByRepo).not.toBe(rowsByRepo)
+    // ...the untouched repo keeps its exact original array reference...
+    expect(result.rowsByRepo.repoUnchanged).toBe(unchanged)
+    // ...and only the changed repo gets a fresh filtered array.
+    expect(result.rowsByRepo.repoChanging).not.toBe(changing)
+    expect(result.rowsByRepo.repoChanging).toEqual([row('w-keep', 'local')])
+  })
+})

--- a/src/renderer/src/store/slices/stale-runtime-host-rows.ts
+++ b/src/renderer/src/store/slices/stale-runtime-host-rows.ts
@@ -1,0 +1,58 @@
+import { parseExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
+
+/**
+ * True iff `hostId` names a `runtime:<envId>` host whose environment id is in the
+ * removed set. Local, SSH, and unhosted (`hostId` undefined) rows never match.
+ * Removal-diff scoping (not "absent from the saved list") is load-bearing: a
+ * serving instance's locally-persisted runtime-stamped repos carry an env id that
+ * was never in this instance's saved list, so it can never enter the removed diff.
+ */
+export function isRemovedRuntimeHostId(
+  hostId: string | null | undefined,
+  removedEnvironmentIds: ReadonlySet<string>
+): boolean {
+  const parsed = parseExecutionHostId(hostId)
+  return parsed?.kind === 'runtime' && removedEnvironmentIds.has(parsed.environmentId)
+}
+
+export type DropRuntimeRowsResult<T> = {
+  rowsByRepo: Record<string, T[]>
+  removedWorktreeIds: string[]
+}
+
+/**
+ * Drops rows whose `hostId` is a removed-env runtime host from a
+ * `worktreesByRepo`-shaped map. Returns the SAME reference when nothing changed
+ * (render-churn guard). Repo keys are kept even when their row list empties — the
+ * repo itself is purged from `repos`, so grouping never references an empty entry,
+ * and keeping keys avoids threading a cross-slice "does this repo survive" callback
+ * into a pure helper. Generic so it serves both `Worktree[]` and the detected
+ * worktrees' `.worktrees` arrays.
+ */
+export function dropWorktreeRowsForRemovedRuntimeEnvironments<
+  T extends { id: string; hostId?: ExecutionHostId }
+>(
+  rowsByRepo: Record<string, T[]>,
+  removedEnvironmentIds: ReadonlySet<string>
+): DropRuntimeRowsResult<T> {
+  if (removedEnvironmentIds.size === 0) {
+    return { rowsByRepo, removedWorktreeIds: [] }
+  }
+  let changed = false
+  const removedWorktreeIds: string[] = []
+  const next: Record<string, T[]> = {}
+  for (const [repoId, rows] of Object.entries(rowsByRepo)) {
+    const survivors = rows.filter((row) => {
+      if (isRemovedRuntimeHostId(row.hostId, removedEnvironmentIds)) {
+        removedWorktreeIds.push(row.id)
+        return false
+      }
+      return true
+    })
+    next[repoId] = survivors.length === rows.length ? rows : survivors
+    if (survivors.length !== rows.length) {
+      changed = true
+    }
+  }
+  return changed ? { rowsByRepo: next, removedWorktreeIds } : { rowsByRepo, removedWorktreeIds: [] }
+}

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -262,6 +262,15 @@ export type WorktreeSlice = {
    */
   purgeWorktreeTerminalState: (worktreeIds: string[]) => void
   /**
+   * Retires every client-store row (repos, project host setups, worktree +
+   * detected-worktree rows, and their tab/PTY/browser/editor cascade) owned by a
+   * runtime host whose environment id was just removed from the saved list.
+   * Scoped to the removal diff so a serving instance's locally-persisted
+   * runtime-stamped repos — whose env id was never saved here — are never torn
+   * down. No-op when the removed set is empty or nothing matched (#8881).
+   */
+  purgeStaleRuntimeHostState: (removedEnvironmentIds: Iterable<string>) => void
+  /**
    * Re-key every worktree-scoped map + pointer from `oldWorktreeId` to
    * `newWorktreeId` after a folder rename changed the worktree's path-derived id.
    * The inverse of purge: move state instead of dropping it, so the live worktree

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -26,6 +26,10 @@ import {
   type WorktreeSlice
 } from './worktree-helpers'
 import { findRepoForHost } from './repo-host-identity'
+import {
+  dropWorktreeRowsForRemovedRuntimeEnvironments,
+  isRemovedRuntimeHostId
+} from './stale-runtime-host-rows'
 import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
 import { cleanupEphemeralVmRuntimesForDeleted } from '@/lib/ephemeral-vm-runtime-cleanup'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
@@ -4884,6 +4888,79 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       return
     }
     set((s) => buildWorktreePurgeState(s, purgeableWorktreeIds))
+  },
+
+  purgeStaleRuntimeHostState: (removedEnvironmentIds) => {
+    const removed = new Set(removedEnvironmentIds)
+    if (removed.size === 0) {
+      return
+    }
+    set((s) => {
+      const survivingRepos = s.repos.filter(
+        (repo) => !isRemovedRuntimeHostId(getRepoExecutionHostId(repo), removed)
+      )
+      const reposChanged = survivingRepos.length !== s.repos.length
+
+      // Why: broader than filterSetupsForPrunedRepoRows — a repoId-less setup on
+      // the removed host can still flip projectIdsRequiringSetupGroups and split a
+      // surviving project group, so drop every setup owned by the removed host.
+      const survivingSetups = s.projectHostSetups.filter(
+        (setup) => !isRemovedRuntimeHostId(setup.hostId, removed)
+      )
+      const setupsChanged = survivingSetups.length !== s.projectHostSetups.length
+
+      const worktreeDrop = dropWorktreeRowsForRemovedRuntimeEnvironments(s.worktreesByRepo, removed)
+      const detectedRows: Record<string, DetectedWorktreeListResult['worktrees']> =
+        Object.fromEntries(
+          Object.entries(s.detectedWorktreesByRepo).map(([repoId, result]) => [
+            repoId,
+            result.worktrees
+          ])
+        )
+      const detectedDrop = dropWorktreeRowsForRemovedRuntimeEnvironments(detectedRows, removed)
+
+      const worktreesChanged = worktreeDrop.rowsByRepo !== s.worktreesByRepo
+      const detectedChanged = detectedDrop.rowsByRepo !== detectedRows
+      if (!reposChanged && !setupsChanged && !worktreesChanged && !detectedChanged) {
+        return s
+      }
+
+      const removedWorktreeIds = new Set([
+        ...worktreeDrop.removedWorktreeIds,
+        ...detectedDrop.removedWorktreeIds
+      ])
+      const purgeState =
+        removedWorktreeIds.size > 0 ? buildWorktreePurgeState(s, [...removedWorktreeIds]) : {}
+
+      const detectedWorktreesByRepo = detectedChanged
+        ? Object.fromEntries(
+            Object.entries(s.detectedWorktreesByRepo).map(([repoId, result]) => [
+              repoId,
+              { ...result, worktrees: detectedDrop.rowsByRepo[repoId] }
+            ])
+          )
+        : s.detectedWorktreesByRepo
+
+      const rowsChanged = worktreesChanged || detectedChanged
+      const survivingRepoIds = new Set(survivingRepos.map((repo) => repo.id))
+      return {
+        ...purgeState,
+        ...(reposChanged ? { repos: survivingRepos } : {}),
+        ...(setupsChanged ? { projectHostSetups: survivingSetups } : {}),
+        ...(worktreesChanged ? { worktreesByRepo: worktreeDrop.rowsByRepo } : {}),
+        ...(detectedChanged ? { detectedWorktreesByRepo } : {}),
+        ...(rowsChanged ? { sortEpoch: s.sortEpoch + 1 } : {}),
+        // Why: mirror validateRepoScopedUi's repo-scoped UI subset so a filtered or
+        // active sidebar can't be left referencing a purged repo id.
+        ...(reposChanged
+          ? {
+              activeRepoId:
+                s.activeRepoId && survivingRepoIds.has(s.activeRepoId) ? s.activeRepoId : null,
+              filterRepoIds: s.filterRepoIds.filter((repoId) => survivingRepoIds.has(repoId))
+            }
+          : {})
+      }
+    })
   },
 
   migrateWorktreeIdentity: (oldWorktreeId: string, newWorktreeId: string) => {


### PR DESCRIPTION
## What changes

When a remote runtime host is removed from the saved list (e.g. after re-pairing mints a new `runtime:<envId>` identity and the superseded one is removed), Orca now retires the repos, project host setups, and worktree rows that identity owned in the client store. Previously those lingered for the rest of the session, so the same physical checkout rendered two or three times under one project header in the sidebar.

**What does NOT change:** two runtime identities for the same physical host that are *both still saved* still duplicate until one is removed — linking them at pairing time (by pinned public key) is a separate follow-up. This PR removes the state left behind by identities the user has already removed.

Fixes #8881.

## Design approach

`setRuntimeEnvironments` is the renderer's single "saved environment list changed" entry point (boot hydration, the Settings runtime pane after add/remove/re-pair, the Add Remote Host dialog, the SSH status dropdown). It already retires per-environment status, detected-agent caches, and mirrored SSH state for removed environments — but never touched repos/setups/worktree rows. This adds them to that cascade:

- A new `purgeStaleRuntimeHostState` action (worktrees slice) drops repos, project host setups, `worktreesByRepo`/`detectedWorktreesByRepo` rows, and the active/filter repo pointers owned by a removed runtime identity, routed through the existing `buildWorktreePurgeState` cascade so tab/PTY/browser/editor/agent maps can't leak.
- It is **scoped to the removal diff** (env ids that just left the saved list), not an absolute keep-set. This is load-bearing: a serving / self-paired instance persists client-minted `runtime:<envId>` stamps into its own local repos, whose env id was never in this instance's saved list — an absolute keep-set would tear those real local repos down on every boot. The removal diff can never include them.
- A tombstone set (`removedRuntimeEnvironmentIds`) guards the three repo-catalog merges so an in-flight catalog fetch for a just-removed env can't re-add the purged repos. Keying on a tombstone (not "absent from the in-memory saved list") is required so a runtime env merely *not yet hydrated* at boot still merges normally.

## Design review

Ran an adversarial design-review loop before implementation. It reshaped the core decision from an absolute keep-set to removal-diff scoping (the serving-instance case above) and added the in-flight catalog-merge guard and the repo-scoped-UI pointer cleanup. No unresolved design findings.

## Implementation / deviations

Implemented as designed. One deviation surfaced in review and was fixed (see below): the catalog-merge guard's first cut keyed on "absent from `runtimeEnvironments`", which also matches a not-yet-hydrated env and would have dropped legitimate runtime repos at boot; it now keys on the tombstone set.

## Completeness verification

Full pass: the purge is wired into the production removal path (Settings Remove → `runtimeEnvironments.remove` → `loadEnvironments` → `setRuntimeEnvironments`), the removal diff is computed from the pre-replacement in-memory list, all promised state is filtered, and no incident attribution is over-claimed in code or comments.

## Headline behavior status

**Implemented.** Removing a runtime host purges its leftover repos/worktree rows from the sidebar in the running app (verified live, screenshots below).

## Broad app consistency

Source-of-truth behavior ("environment removed ⇒ its client-mirrored state is retired") already existed for runtime status, detected agents, and mirrored SSH state; this extends it to repos/setups/worktree rows. **Known remaining surface:** runtime-hosted *folder workspaces* and *project groups* use the same per-host merge and can still duplicate on re-pair — deferred as a non-goal (different row type + removal cascade). When that follow-up lands it must also guard the parallel project-group / folder-workspace catalog merges.

## Risks, ambiguities, non-goals

- Non-goal: pairing-time physical-host reconcile for two *still-saved* identities (needs the pinned-public-key signal; follow-up).
- Non-goal: row migration on re-pair (SSH readoption renames rows to keep tabs; runtime re-pair has no linkage signal here, so superseded-identity rows are retired — their transport is already gone).
- Non-goal: deleting stale on-disk workspace-session partition files (boot already leaves them unread on a pure client; this stops new stale writes). 
- Non-goal: folder-workspace / project-group retention (above).
- Incident attribution: per the reporter's follow-up, this fixes the code-verified duplication hazard; it does not claim to explain the specific incident's 3→6 rendering (pending a controlled re-pair repro).

## perf

Audited before code review. No-op by default (empty removal diff → no `set()`), all added work bounded by repo/env/row counts already iterated elsewhere, reference identity preserved for unchanged slices, `sortEpoch` bumped only when rows change, `buildWorktreePurgeState` invoked only when rows are actually removed. No P0–P2 findings.

## Code review

Two independent reviewers. One found a P1: the catalog-merge guard was over-broad (skipped legitimate runtime-catalog merges during boot before the saved list hydrated, dropping remote repos — proven by ~14 net-new regressions in neighboring repo suites). Fixed with the tombstone approach and re-reviewed clean; the previously-regressing suites (`repos-all-hosts`, `repos-all-hosts-generation`, `repos-runtime-project-groups`, `repos`) all pass again. The other reviewer returned no blockers.

## Tests / static checks

- 6 new test files (helpers, action, `setRuntimeEnvironments` wiring, catalog-merge tombstone guard incl. the boot-regression case, session-partition split): green.
- Neighboring repo suites reviewer A flagged: green.
- Full typecheck (node + cli + web) and oxlint/oxfmt: clean.

## Manual validation

Live Electron A/B on a fresh profile: injected a stale `runtime:env-a` identity duplicating three physical checkouts (sidebar shows 6 rows under one header), then removed the environment — the duplicates purge and only the real rows remain, with no orphaned/"Unknown" groups. Before/after screenshots attached in a PR comment.

## Post-PR stabilization

Pending CodeRabbit + CI after open.
