### PR TITLE
Bump mobile app.json to 0.0.32

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.31",
+    "version": "0.0.32",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
## Summary
- Bump `mobile/app.json` `expo.version` to `0.0.32` to match the release.
- Leave the CI-managed iOS build number and Android version code unchanged.

## Verification
- `pnpm --dir mobile typecheck`
- `pnpm --dir mobile lint`
- `pnpm --dir mobile format:check`
- `pnpm --dir mobile test` (2,046 passed, 2 skipped)
- `git diff --check`