### PR TITLE
Preserve surviving workspace state when removing a runtime host

### DIFF
--- a/src/renderer/src/store/slices/purge-stale-runtime-host-ownership.test.ts
+++ b/src/renderer/src/store/slices/purge-stale-runtime-host-ownership.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest'
+import { toRuntimeExecutionHostId } from '../../../../shared/execution-host'
+import { worktreeWorkspaceKey } from '../../../../shared/workspace-scope'
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn() }
+}))
+
+vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
+  restorePtyDataHandlersAfterFailedShutdown: vi.fn(),
+  unregisterPtyDataHandlers: vi.fn()
+}))
+
+// @ts-expect-error -- minimal window.api stub for the store under test
+globalThis.window = { api: {} }
+
+import { createTestStore, makeTab, makeWorktree, seedStore } from './store-test-helpers'
+
+const RUNTIME_A = toRuntimeExecutionHostId('env-a')
+const RUNTIME_B = toRuntimeExecutionHostId('env-b')
+
+describe('purgeStaleRuntimeHostState ownership evidence', () => {
+  it('uses an explicit removed-host worktree as owner evidence before catalogs load', () => {
+    const store = createTestStore()
+    const removedWorktreeId = 'repoA::/hosted'
+    const legacyWorktreeId = 'repoA::/legacy'
+    seedStore(store, {
+      repos: [],
+      worktreesByRepo: {
+        repoA: [
+          makeWorktree({ id: removedWorktreeId, repoId: 'repoA', hostId: RUNTIME_A }),
+          makeWorktree({ id: legacyWorktreeId, repoId: 'repoA', hostId: undefined })
+        ]
+      },
+      tabsByWorktree: {
+        [legacyWorktreeId]: [makeTab({ id: 'legacy-tab', worktreeId: legacyWorktreeId })]
+      }
+    })
+
+    store.getState().purgeStaleRuntimeHostState(['env-a'])
+
+    expect(store.getState().worktreesByRepo.repoA).toEqual([])
+    expect(store.getState().tabsByWorktree[legacyWorktreeId]).toBeUndefined()
+  })
+
+  it('purges restored session state owned by the removed host despite an exact-id survivor', () => {
+    const store = createTestStore()
+    const worktreeId = 'shared::/same/path'
+    seedStore(store, {
+      repos: [
+        {
+          id: 'shared',
+          path: '/shared-a',
+          displayName: 'A',
+          executionHostId: RUNTIME_A
+        } as never,
+        {
+          id: 'shared',
+          path: '/shared-b',
+          displayName: 'B',
+          executionHostId: RUNTIME_B
+        } as never
+      ],
+      worktreesByRepo: {
+        shared: [
+          makeWorktree({ id: worktreeId, repoId: 'shared', hostId: RUNTIME_A }),
+          makeWorktree({ id: worktreeId, repoId: 'shared', hostId: RUNTIME_B })
+        ]
+      },
+      tabsByWorktree: {
+        [worktreeId]: [
+          makeTab({ id: 'removed-host-tab', worktreeId, ptyId: 'remote:env-a@@terminal-a' })
+        ]
+      },
+      restoredRuntimeHostIdByWorkspaceSessionKey: { [worktreeId]: RUNTIME_A },
+      activeWorktreeId: worktreeId,
+      activeWorkspaceKey: worktreeWorkspaceKey(worktreeId)
+    })
+
+    store.getState().purgeStaleRuntimeHostState(['env-a'])
+
+    const state = store.getState()
+    expect(state.worktreesByRepo.shared).toHaveLength(1)
+    expect(state.worktreesByRepo.shared[0]?.hostId).toBe(RUNTIME_B)
+    expect(state.tabsByWorktree[worktreeId]).toBeUndefined()
+    expect(state.restoredRuntimeHostIdByWorkspaceSessionKey[worktreeId]).toBeUndefined()
+    expect(state.activeWorktreeId).toBeNull()
+    expect(state.activeWorkspaceKey).toBeNull()
+  })
+
+  it('purges a removed host session after its catalog rows have already disappeared', () => {
+    const store = createTestStore()
+    const worktreeId = 'repoA::/session-only'
+    seedStore(store, {
+      repos: [],
+      worktreesByRepo: {},
+      tabsByWorktree: {
+        [worktreeId]: [makeTab({ id: 'removed-host-tab', worktreeId })]
+      },
+      restoredRuntimeHostIdByWorkspaceSessionKey: { [worktreeId]: RUNTIME_A }
+    })
+
+    store.getState().purgeStaleRuntimeHostState(['env-a'])
+
+    const state = store.getState()
+    expect(state.tabsByWorktree[worktreeId]).toBeUndefined()
+    expect(state.restoredRuntimeHostIdByWorkspaceSessionKey[worktreeId]).toBeUndefined()
+  })
+})

--- a/src/renderer/src/store/slices/purge-stale-runtime-host-ownership.test.ts
+++ b/src/renderer/src/store/slices/purge-stale-runtime-host-ownership.test.ts
@@ -106,4 +106,42 @@ describe('purgeStaleRuntimeHostState ownership evidence', () => {
     expect(state.tabsByWorktree[worktreeId]).toBeUndefined()
     expect(state.restoredRuntimeHostIdByWorkspaceSessionKey[worktreeId]).toBeUndefined()
   })
+
+  it('preserves a surviving restored session before its catalog rows load', () => {
+    const store = createTestStore()
+    const removedWorktreeId = 'shared::/removed-host'
+    const survivingWorktreeId = 'shared::/surviving-host'
+    const survivingTabs = [
+      makeTab({
+        id: 'surviving-host-tab',
+        worktreeId: survivingWorktreeId,
+        ptyId: 'remote:env-b@@terminal-b'
+      })
+    ]
+    seedStore(store, {
+      repos: [],
+      worktreesByRepo: {},
+      tabsByWorktree: {
+        [removedWorktreeId]: [makeTab({ id: 'removed-host-tab', worktreeId: removedWorktreeId })],
+        [survivingWorktreeId]: survivingTabs
+      },
+      restoredRuntimeHostIdByWorkspaceSessionKey: {
+        [removedWorktreeId]: RUNTIME_A,
+        [survivingWorktreeId]: RUNTIME_B
+      },
+      activeWorktreeId: survivingWorktreeId,
+      activeWorkspaceKey: worktreeWorkspaceKey(survivingWorktreeId)
+    })
+
+    store.getState().purgeStaleRuntimeHostState(['env-a'])
+
+    const state = store.getState()
+    expect(state.tabsByWorktree[removedWorktreeId]).toBeUndefined()
+    expect(state.tabsByWorktree[survivingWorktreeId]).toBe(survivingTabs)
+    expect(state.restoredRuntimeHostIdByWorkspaceSessionKey).toEqual({
+      [survivingWorktreeId]: RUNTIME_B
+    })
+    expect(state.activeWorktreeId).toBe(survivingWorktreeId)
+    expect(state.activeWorkspaceKey).toBe(worktreeWorkspaceKey(survivingWorktreeId))
+  })
 })

--- a/src/renderer/src/store/slices/purge-stale-runtime-host-state.test.ts
+++ b/src/renderer/src/store/slices/purge-stale-runtime-host-state.test.ts
@@ -9,6 +9,7 @@
  */
 import { describe, it, expect, vi } from 'vitest'
 import { toRuntimeExecutionHostId } from '../../../../shared/execution-host'
+import { worktreeWorkspaceKey } from '../../../../shared/workspace-scope'
 import type { ProjectHostSetup, DetectedWorktreeListResult } from '../../../../shared/types'
 
 vi.mock('sonner', () => ({
@@ -190,14 +191,14 @@ describe('purgeStaleRuntimeHostState', () => {
     expect(s.repos).toBe(reposRef)
   })
 
-  it('same-repoId-on-two-hosts: keeps the local row and the repo key after purge', () => {
+  it('same-repoId-on-two-hosts: keeps an ambiguous unhosted row and the repo key', () => {
     const store = createTestStore()
     // repoId 'shared' exists under both local and runtime:env-a in worktreesByRepo.
     seedStore(store, {
       repos: [
         { id: 'shared', path: '/shared', displayName: 'shared', badgeColor: '#000', addedAt: 0 },
         {
-          id: 'sharedRuntime',
+          id: 'shared',
           path: '/shared',
           displayName: 'shared',
           badgeColor: '#000',
@@ -207,7 +208,7 @@ describe('purgeStaleRuntimeHostState', () => {
       ],
       worktreesByRepo: {
         shared: [
-          makeWorktree({ id: 'shared::/wt-local', repoId: 'shared', hostId: 'local' }),
+          makeWorktree({ id: 'shared::/wt-local', repoId: 'shared', hostId: undefined }),
           makeWorktree({ id: 'shared::/wt-a', repoId: 'shared', hostId: RUNTIME_A })
         ]
       }
@@ -218,6 +219,79 @@ describe('purgeStaleRuntimeHostState', () => {
     const s = store.getState()
     expect(s.worktreesByRepo).toHaveProperty('shared')
     expect(s.worktreesByRepo.shared.map((w) => w.id)).toEqual(['shared::/wt-local'])
+    expect(s.worktreesByRepo.shared[0]?.hostId).toBeUndefined()
+  })
+
+  it('preserves worktree-scoped state when the exact same id survives on another host', () => {
+    const store = createTestStore()
+    const RUNTIME_B = toRuntimeExecutionHostId('env-b')
+    const worktreeId = 'shared::/same/path'
+    const tabs = [makeTab({ id: 'tab-surviving', worktreeId })]
+    seedStore(store, {
+      repos: [
+        {
+          id: 'shared',
+          path: '/shared',
+          displayName: 'shared',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: RUNTIME_A
+        },
+        {
+          id: 'shared',
+          path: '/shared',
+          displayName: 'shared',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: RUNTIME_B
+        }
+      ],
+      worktreesByRepo: {
+        shared: [
+          makeWorktree({ id: worktreeId, repoId: 'shared', hostId: RUNTIME_A }),
+          makeWorktree({ id: worktreeId, repoId: 'shared', hostId: RUNTIME_B })
+        ]
+      },
+      tabsByWorktree: { [worktreeId]: tabs },
+      activeWorktreeId: worktreeId,
+      activeWorkspaceKey: worktreeWorkspaceKey(worktreeId)
+    })
+
+    store.getState().purgeStaleRuntimeHostState(['env-a'])
+
+    const s = store.getState()
+    expect(s.worktreesByRepo.shared).toHaveLength(1)
+    expect(s.worktreesByRepo.shared[0]?.hostId).toBe(RUNTIME_B)
+    expect(s.tabsByWorktree[worktreeId]).toBe(tabs)
+    expect(s.activeWorktreeId).toBe(worktreeId)
+    expect(s.activeWorkspaceKey).toBe(worktreeWorkspaceKey(worktreeId))
+  })
+
+  it('purges a legacy unhosted row when its sole repo owner was removed', () => {
+    const store = createTestStore()
+    const worktreeId = 'repoA::/legacy'
+    seedStore(store, {
+      repos: [
+        {
+          id: 'repoA',
+          path: '/repoA',
+          displayName: 'A',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: RUNTIME_A
+        }
+      ],
+      worktreesByRepo: {
+        repoA: [makeWorktree({ id: worktreeId, repoId: 'repoA', hostId: undefined })]
+      },
+      tabsByWorktree: { [worktreeId]: [makeTab({ id: 'legacy-tab', worktreeId })] }
+    })
+
+    store.getState().purgeStaleRuntimeHostState(['env-a'])
+
+    const s = store.getState()
+    expect(s.worktreesByRepo.repoA).toEqual([])
+    expect(s.tabsByWorktree[worktreeId]).toBeUndefined()
   })
 
   it('clears activeRepoId and drops the purged id from filterRepoIds', () => {

--- a/src/renderer/src/store/slices/purge-stale-runtime-host-state.test.ts
+++ b/src/renderer/src/store/slices/purge-stale-runtime-host-state.test.ts
@@ -172,6 +172,7 @@ describe('purgeStaleRuntimeHostState', () => {
     const store = createTestStore()
     seedStore(store, {
       repos: [TEST_REPO],
+      projectHostSetups: [setup({ id: 's-local', repoId: 'repo1', hostId: 'local' })],
       worktreesByRepo: {
         repo1: [makeWorktree({ id: 'repo1::/wt', repoId: 'repo1', hostId: 'local' })]
       }
@@ -180,6 +181,7 @@ describe('purgeStaleRuntimeHostState', () => {
     const epochBefore = before.sortEpoch
     const worktreesRef = before.worktreesByRepo
     const reposRef = before.repos
+    const setupsRef = before.projectHostSetups
 
     store.getState().purgeStaleRuntimeHostState([])
     store.getState().purgeStaleRuntimeHostState(['env-does-not-exist'])
@@ -189,6 +191,7 @@ describe('purgeStaleRuntimeHostState', () => {
     // Nothing stale => the reducer returns state untouched (same references).
     expect(s.worktreesByRepo).toBe(worktreesRef)
     expect(s.repos).toBe(reposRef)
+    expect(s.projectHostSetups).toBe(setupsRef)
   })
 
   it('same-repoId-on-two-hosts: keeps an ambiguous unhosted row and the repo key', () => {
@@ -292,6 +295,58 @@ describe('purgeStaleRuntimeHostState', () => {
     const s = store.getState()
     expect(s.worktreesByRepo.repoA).toEqual([])
     expect(s.tabsByWorktree[worktreeId]).toBeUndefined()
+  })
+
+  it('uses a removed host setup to purge an unhosted row before its repo loads', () => {
+    const store = createTestStore()
+    const worktreeId = 'repoA::/legacy'
+    seedStore(store, {
+      repos: [],
+      projectHostSetups: [setup({ id: 's-a', repoId: 'repoA', hostId: RUNTIME_A })],
+      worktreesByRepo: {
+        repoA: [makeWorktree({ id: worktreeId, repoId: 'repoA', hostId: undefined })]
+      },
+      tabsByWorktree: { [worktreeId]: [makeTab({ id: 'legacy-tab', worktreeId })] }
+    })
+
+    store.getState().purgeStaleRuntimeHostState(['env-a'])
+
+    const s = store.getState()
+    expect(s.projectHostSetups).toEqual([])
+    expect(s.worktreesByRepo.repoA).toEqual([])
+    expect(s.tabsByWorktree[worktreeId]).toBeUndefined()
+  })
+
+  it('preserves an unhosted row when a setup proves another host still owns it', () => {
+    const store = createTestStore()
+    const RUNTIME_B = toRuntimeExecutionHostId('env-b')
+    const worktreeId = 'shared::/legacy'
+    const tabs = [makeTab({ id: 'surviving-tab', worktreeId })]
+    seedStore(store, {
+      repos: [
+        {
+          id: 'shared',
+          path: '/shared-a',
+          displayName: 'A',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: RUNTIME_A
+        }
+      ],
+      projectHostSetups: [setup({ id: 's-b', repoId: 'shared', hostId: RUNTIME_B })],
+      worktreesByRepo: {
+        shared: [makeWorktree({ id: worktreeId, repoId: 'shared', hostId: undefined })]
+      },
+      tabsByWorktree: { [worktreeId]: tabs }
+    })
+
+    store.getState().purgeStaleRuntimeHostState(['env-a'])
+
+    const s = store.getState()
+    expect(s.repos).toEqual([])
+    expect(s.projectHostSetups).toHaveLength(1)
+    expect(s.worktreesByRepo.shared).toHaveLength(1)
+    expect(s.tabsByWorktree[worktreeId]).toBe(tabs)
   })
 
   it('purges a legacy unhosted row when every repo owner is removed together', () => {

--- a/src/renderer/src/store/slices/purge-stale-runtime-host-state.test.ts
+++ b/src/renderer/src/store/slices/purge-stale-runtime-host-state.test.ts
@@ -317,6 +317,71 @@ describe('purgeStaleRuntimeHostState', () => {
     expect(s.tabsByWorktree[worktreeId]).toBeUndefined()
   })
 
+  it('purges hydrated worktree state before its worktree row loads', () => {
+    const store = createTestStore()
+    const worktreeId = 'repoA::/session-only'
+    seedStore(store, {
+      repos: [
+        {
+          id: 'repoA',
+          path: '/repoA',
+          displayName: 'A',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: RUNTIME_A
+        }
+      ],
+      worktreesByRepo: {},
+      tabsByWorktree: { [worktreeId]: [makeTab({ id: 'hydrated-tab', worktreeId })] },
+      activeWorktreeId: worktreeId,
+      activeWorkspaceKey: worktreeWorkspaceKey(worktreeId)
+    })
+
+    store.getState().purgeStaleRuntimeHostState(['env-a'])
+
+    const s = store.getState()
+    expect(s.tabsByWorktree[worktreeId]).toBeUndefined()
+    expect(s.activeWorktreeId).toBeNull()
+    expect(s.activeWorkspaceKey).toBeNull()
+  })
+
+  it('uses an explicit surviving worktree row as owner evidence during catalog loading', () => {
+    const store = createTestStore()
+    const RUNTIME_B = toRuntimeExecutionHostId('env-b')
+    const legacyWorktreeId = 'shared::/legacy'
+    const survivingWorktreeId = 'shared::/host-b'
+    const tabs = [makeTab({ id: 'surviving-tab', worktreeId: legacyWorktreeId })]
+    seedStore(store, {
+      repos: [
+        {
+          id: 'shared',
+          path: '/shared-a',
+          displayName: 'A',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: RUNTIME_A
+        }
+      ],
+      worktreesByRepo: {
+        shared: [makeWorktree({ id: legacyWorktreeId, repoId: 'shared', hostId: undefined })]
+      },
+      detectedWorktreesByRepo: {
+        shared: detectedResult('shared', [detected(survivingWorktreeId, 'shared', RUNTIME_B)])
+      },
+      tabsByWorktree: { [legacyWorktreeId]: tabs }
+    })
+
+    store.getState().purgeStaleRuntimeHostState(['env-a'])
+
+    const s = store.getState()
+    expect(s.repos).toEqual([])
+    expect(s.worktreesByRepo.shared.map((worktree) => worktree.id)).toEqual([legacyWorktreeId])
+    expect(s.detectedWorktreesByRepo.shared.worktrees.map((worktree) => worktree.id)).toEqual([
+      survivingWorktreeId
+    ])
+    expect(s.tabsByWorktree[legacyWorktreeId]).toBe(tabs)
+  })
+
   it('preserves an unhosted row when a setup proves another host still owns it', () => {
     const store = createTestStore()
     const RUNTIME_B = toRuntimeExecutionHostId('env-b')

--- a/src/renderer/src/store/slices/purge-stale-runtime-host-state.test.ts
+++ b/src/renderer/src/store/slices/purge-stale-runtime-host-state.test.ts
@@ -256,9 +256,11 @@ describe('purgeStaleRuntimeHostState', () => {
         ]
       },
       tabsByWorktree: { [worktreeId]: tabs },
+      restoredRuntimeHostIdByWorkspaceSessionKey: { [worktreeId]: RUNTIME_B },
       activeWorktreeId: worktreeId,
       activeWorkspaceKey: worktreeWorkspaceKey(worktreeId)
     })
+    const restoredOwners = store.getState().restoredRuntimeHostIdByWorkspaceSessionKey
 
     store.getState().purgeStaleRuntimeHostState(['env-a'])
 
@@ -266,6 +268,8 @@ describe('purgeStaleRuntimeHostState', () => {
     expect(s.worktreesByRepo.shared).toHaveLength(1)
     expect(s.worktreesByRepo.shared[0]?.hostId).toBe(RUNTIME_B)
     expect(s.tabsByWorktree[worktreeId]).toBe(tabs)
+    expect(s.restoredRuntimeHostIdByWorkspaceSessionKey).toBe(restoredOwners)
+    expect(s.restoredRuntimeHostIdByWorkspaceSessionKey[worktreeId]).toBe(RUNTIME_B)
     expect(s.activeWorktreeId).toBe(worktreeId)
     expect(s.activeWorkspaceKey).toBe(worktreeWorkspaceKey(worktreeId))
   })

--- a/src/renderer/src/store/slices/purge-stale-runtime-host-state.test.ts
+++ b/src/renderer/src/store/slices/purge-stale-runtime-host-state.test.ts
@@ -54,7 +54,7 @@ function detectedResult(
 function detected(
   id: string,
   repoId: string,
-  hostId: ReturnType<typeof toRuntimeExecutionHostId> | 'local'
+  hostId: ReturnType<typeof toRuntimeExecutionHostId> | 'local' | undefined
 ): DetectedWorktreeListResult['worktrees'][number] {
   return {
     ...makeWorktree({ id, repoId, hostId }),
@@ -291,6 +291,47 @@ describe('purgeStaleRuntimeHostState', () => {
 
     const s = store.getState()
     expect(s.worktreesByRepo.repoA).toEqual([])
+    expect(s.tabsByWorktree[worktreeId]).toBeUndefined()
+  })
+
+  it('purges a legacy unhosted row when every repo owner is removed together', () => {
+    const store = createTestStore()
+    const RUNTIME_B = toRuntimeExecutionHostId('env-b')
+    const worktreeId = 'shared::/legacy'
+    seedStore(store, {
+      repos: [
+        {
+          id: 'shared',
+          path: '/shared-a',
+          displayName: 'A',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: RUNTIME_A
+        },
+        {
+          id: 'shared',
+          path: '/shared-b',
+          displayName: 'B',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: RUNTIME_B
+        }
+      ],
+      worktreesByRepo: {
+        shared: [makeWorktree({ id: worktreeId, repoId: 'shared', hostId: undefined })]
+      },
+      detectedWorktreesByRepo: {
+        shared: detectedResult('shared', [detected(worktreeId, 'shared', undefined)])
+      },
+      tabsByWorktree: { [worktreeId]: [makeTab({ id: 'legacy-tab', worktreeId })] }
+    })
+
+    store.getState().purgeStaleRuntimeHostState(['env-a', 'env-b'])
+
+    const s = store.getState()
+    expect(s.repos).toEqual([])
+    expect(s.worktreesByRepo.shared).toEqual([])
+    expect(s.detectedWorktreesByRepo.shared.worktrees).toEqual([])
     expect(s.tabsByWorktree[worktreeId]).toBeUndefined()
   })
 

--- a/src/renderer/src/store/slices/stale-runtime-host-rows.test.ts
+++ b/src/renderer/src/store/slices/stale-runtime-host-rows.test.ts
@@ -97,4 +97,20 @@ describe('dropWorktreeRowsForRemovedRuntimeEnvironments', () => {
     expect(result.rowsByRepo.repoChanging).not.toBe(changing)
     expect(result.rowsByRepo.repoChanging).toEqual([row('w-keep', 'local')])
   })
+
+  it('drops unhosted rows only for an unambiguously removed sole-owner repo', () => {
+    const rowsByRepo = {
+      removedRepo: [row('w-legacy')],
+      ambiguousRepo: [row('w-ambiguous')]
+    }
+    const result = dropWorktreeRowsForRemovedRuntimeEnvironments(
+      rowsByRepo,
+      new Set(['env-a']),
+      new Set(['removedRepo'])
+    )
+
+    expect(result.rowsByRepo.removedRepo).toEqual([])
+    expect(result.rowsByRepo.ambiguousRepo).toEqual([row('w-ambiguous')])
+    expect(result.removedWorktreeIds).toEqual(['w-legacy'])
+  })
 })

--- a/src/renderer/src/store/slices/stale-runtime-host-rows.ts
+++ b/src/renderer/src/store/slices/stale-runtime-host-rows.ts
@@ -21,19 +21,18 @@ export type DropRuntimeRowsResult<T> = {
 }
 
 /**
- * Drops rows whose `hostId` is a removed-env runtime host from a
- * `worktreesByRepo`-shaped map. Returns the SAME reference when nothing changed
- * (render-churn guard). Repo keys are kept even when their row list empties — the
- * repo itself is purged from `repos`, so grouping never references an empty entry,
- * and keeping keys avoids threading a cross-slice "does this repo survive" callback
- * into a pure helper. Generic so it serves both `Worktree[]` and the detected
- * worktrees' `.worktrees` arrays.
+ * Drops rows owned by a removed-env runtime host from a `worktreesByRepo`-shaped
+ * map. Legacy unhosted rows are dropped only when their repo had one unambiguous
+ * removed owner. Returns the SAME reference when nothing changed (render-churn
+ * guard). Repo keys are kept even when their row list empties. Generic so it serves
+ * both `Worktree[]` and the detected worktrees' `.worktrees` arrays.
  */
 export function dropWorktreeRowsForRemovedRuntimeEnvironments<
   T extends { id: string; hostId?: ExecutionHostId }
 >(
   rowsByRepo: Record<string, T[]>,
-  removedEnvironmentIds: ReadonlySet<string>
+  removedEnvironmentIds: ReadonlySet<string>,
+  removedSoleOwnerRepoIds?: ReadonlySet<string>
 ): DropRuntimeRowsResult<T> {
   if (removedEnvironmentIds.size === 0) {
     return { rowsByRepo, removedWorktreeIds: [] }
@@ -43,7 +42,10 @@ export function dropWorktreeRowsForRemovedRuntimeEnvironments<
   const next: Record<string, T[]> = {}
   for (const [repoId, rows] of Object.entries(rowsByRepo)) {
     const survivors = rows.filter((row) => {
-      if (isRemovedRuntimeHostId(row.hostId, removedEnvironmentIds)) {
+      if (
+        isRemovedRuntimeHostId(row.hostId, removedEnvironmentIds) ||
+        (row.hostId === undefined && removedSoleOwnerRepoIds?.has(repoId) === true)
+      ) {
         removedWorktreeIds.push(row.id)
         return false
       }

--- a/src/renderer/src/store/slices/stale-runtime-host-rows.ts
+++ b/src/renderer/src/store/slices/stale-runtime-host-rows.ts
@@ -22,8 +22,8 @@ export type DropRuntimeRowsResult<T> = {
 
 /**
  * Drops rows owned by a removed-env runtime host from a `worktreesByRepo`-shaped
- * map. Legacy unhosted rows are dropped only when their repo had one unambiguous
- * removed owner. Returns the SAME reference when nothing changed (render-churn
+ * map. Legacy unhosted rows are dropped only when their repo had removed owners
+ * and none survive. Returns the SAME reference when nothing changed (render-churn
  * guard). Repo keys are kept even when their row list empties. Generic so it serves
  * both `Worktree[]` and the detected worktrees' `.worktrees` arrays.
  */
@@ -32,7 +32,7 @@ export function dropWorktreeRowsForRemovedRuntimeEnvironments<
 >(
   rowsByRepo: Record<string, T[]>,
   removedEnvironmentIds: ReadonlySet<string>,
-  removedSoleOwnerRepoIds?: ReadonlySet<string>
+  repoIdsWithoutSurvivingOwners?: ReadonlySet<string>
 ): DropRuntimeRowsResult<T> {
   if (removedEnvironmentIds.size === 0) {
     return { rowsByRepo, removedWorktreeIds: [] }
@@ -44,7 +44,7 @@ export function dropWorktreeRowsForRemovedRuntimeEnvironments<
     const survivors = rows.filter((row) => {
       if (
         isRemovedRuntimeHostId(row.hostId, removedEnvironmentIds) ||
-        (row.hostId === undefined && removedSoleOwnerRepoIds?.has(repoId) === true)
+        (row.hostId === undefined && repoIdsWithoutSurvivingOwners?.has(repoId) === true)
       ) {
         removedWorktreeIds.push(row.id)
         return false

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -4983,6 +4983,12 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       return
     }
     set((s) => {
+      const removedSoleOwnerRepoIds = new Set<string>()
+      for (const [repoId, owner] of getRepoHostSummaries(s.repos)) {
+        if (owner.count === 1 && isRemovedRuntimeHostId(owner.onlyHostId, removed)) {
+          removedSoleOwnerRepoIds.add(repoId)
+        }
+      }
       const survivingRepos = s.repos.filter(
         (repo) => !isRemovedRuntimeHostId(getRepoExecutionHostId(repo), removed)
       )
@@ -4996,7 +5002,11 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       )
       const setupsChanged = survivingSetups.length !== s.projectHostSetups.length
 
-      const worktreeDrop = dropWorktreeRowsForRemovedRuntimeEnvironments(s.worktreesByRepo, removed)
+      const worktreeDrop = dropWorktreeRowsForRemovedRuntimeEnvironments(
+        s.worktreesByRepo,
+        removed,
+        removedSoleOwnerRepoIds
+      )
       const detectedRows: Record<string, DetectedWorktreeListResult['worktrees']> =
         Object.fromEntries(
           Object.entries(s.detectedWorktreesByRepo).map(([repoId, result]) => [
@@ -5004,7 +5014,11 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             result.worktrees
           ])
         )
-      const detectedDrop = dropWorktreeRowsForRemovedRuntimeEnvironments(detectedRows, removed)
+      const detectedDrop = dropWorktreeRowsForRemovedRuntimeEnvironments(
+        detectedRows,
+        removed,
+        removedSoleOwnerRepoIds
+      )
 
       const worktreesChanged = worktreeDrop.rowsByRepo !== s.worktreesByRepo
       const detectedChanged = detectedDrop.rowsByRepo !== detectedRows
@@ -5016,6 +5030,19 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         ...worktreeDrop.removedWorktreeIds,
         ...detectedDrop.removedWorktreeIds
       ])
+      // Why: worktree-scoped UI state is keyed by bare worktree id, not host. If
+      // the same id survives on another host, it now belongs to that unambiguous
+      // survivor and must not lose its live tabs/editor/terminal state.
+      for (const rows of Object.values(worktreeDrop.rowsByRepo)) {
+        for (const row of rows) {
+          removedWorktreeIds.delete(row.id)
+        }
+      }
+      for (const rows of Object.values(detectedDrop.rowsByRepo)) {
+        for (const row of rows) {
+          removedWorktreeIds.delete(row.id)
+        }
+      }
       const purgeState =
         removedWorktreeIds.size > 0 ? buildWorktreePurgeState(s, [...removedWorktreeIds]) : {}
 

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -4985,6 +4985,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     set((s) => {
       const repoIdsWithoutSurvivingOwners = new Set<string>()
       const survivingRepoIds = new Set<string>()
+      const repoIdsWithSurvivingOwners = new Set<string>()
       const survivingRepos: AppState['repos'] = []
       for (const repo of s.repos) {
         if (isRemovedRuntimeHostId(getRepoExecutionHostId(repo), removed)) {
@@ -4992,22 +4993,33 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         } else {
           survivingRepos.push(repo)
           survivingRepoIds.add(repo.id)
+          repoIdsWithSurvivingOwners.add(repo.id)
         }
-      }
-      // Why: an unhosted legacy row is safe to retire whenever every known repo
-      // owner was removed together, including duplicate or multi-host catalog rows.
-      for (const repoId of survivingRepoIds) {
-        repoIdsWithoutSurvivingOwners.delete(repoId)
       }
       const reposChanged = survivingRepos.length !== s.repos.length
 
       // Why: broader than filterSetupsForPrunedRepoRows — a repoId-less setup on
       // the removed host can still flip projectIdsRequiringSetupGroups and split a
       // surviving project group, so drop every setup owned by the removed host.
-      const survivingSetups = s.projectHostSetups.filter(
-        (setup) => !isRemovedRuntimeHostId(setup.hostId, removed)
-      )
+      const survivingSetups: AppState['projectHostSetups'] = []
+      for (const setup of s.projectHostSetups) {
+        if (isRemovedRuntimeHostId(setup.hostId, removed)) {
+          if (setup.repoId) {
+            repoIdsWithoutSurvivingOwners.add(setup.repoId)
+          }
+        } else {
+          survivingSetups.push(setup)
+          if (setup.repoId) {
+            repoIdsWithSurvivingOwners.add(setup.repoId)
+          }
+        }
+      }
       const setupsChanged = survivingSetups.length !== s.projectHostSetups.length
+      // Why: legacy rows predate host stamps; repo rows and host setups are the
+      // persisted owner records that prove whether another host still owns them.
+      for (const repoId of repoIdsWithSurvivingOwners) {
+        repoIdsWithoutSurvivingOwners.delete(repoId)
+      }
 
       const worktreeDrop = dropWorktreeRowsForRemovedRuntimeEnvironments(
         s.worktreesByRepo,

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -5048,12 +5048,18 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         s.restoredRuntimeHostIdByWorkspaceSessionKey
       )) {
         const scope = parseWorkspaceKey(workspaceKey)
-        if (scope?.type === 'folder' || !isRemovedRuntimeHostId(hostId, removed)) {
+        if (scope?.type === 'folder') {
           continue
         }
         const worktreeId = scope?.type === 'worktree' ? scope.worktreeId : workspaceKey
+        const repoId = getRepoIdFromWorktreeId(worktreeId)
+        if (!isRemovedRuntimeHostId(hostId, removed)) {
+          // Why: restored sessions can be the only surviving-owner evidence before catalogs load.
+          repoIdsWithSurvivingOwners.add(repoId)
+          continue
+        }
         sessionWorktreeIdsOwnedByRemovedHosts.add(worktreeId)
-        repoIdsWithRemovedOwners.add(getRepoIdFromWorktreeId(worktreeId))
+        repoIdsWithRemovedOwners.add(repoId)
         if (survivingRestoredSessionOwners === s.restoredRuntimeHostIdByWorkspaceSessionKey) {
           survivingRestoredSessionOwners = { ...survivingRestoredSessionOwners }
         }

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -4983,15 +4983,22 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       return
     }
     set((s) => {
-      const removedSoleOwnerRepoIds = new Set<string>()
-      for (const [repoId, owner] of getRepoHostSummaries(s.repos)) {
-        if (owner.count === 1 && isRemovedRuntimeHostId(owner.onlyHostId, removed)) {
-          removedSoleOwnerRepoIds.add(repoId)
+      const repoIdsWithoutSurvivingOwners = new Set<string>()
+      const survivingRepoIds = new Set<string>()
+      const survivingRepos: AppState['repos'] = []
+      for (const repo of s.repos) {
+        if (isRemovedRuntimeHostId(getRepoExecutionHostId(repo), removed)) {
+          repoIdsWithoutSurvivingOwners.add(repo.id)
+        } else {
+          survivingRepos.push(repo)
+          survivingRepoIds.add(repo.id)
         }
       }
-      const survivingRepos = s.repos.filter(
-        (repo) => !isRemovedRuntimeHostId(getRepoExecutionHostId(repo), removed)
-      )
+      // Why: an unhosted legacy row is safe to retire whenever every known repo
+      // owner was removed together, including duplicate or multi-host catalog rows.
+      for (const repoId of survivingRepoIds) {
+        repoIdsWithoutSurvivingOwners.delete(repoId)
+      }
       const reposChanged = survivingRepos.length !== s.repos.length
 
       // Why: broader than filterSetupsForPrunedRepoRows — a repoId-less setup on
@@ -5005,7 +5012,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       const worktreeDrop = dropWorktreeRowsForRemovedRuntimeEnvironments(
         s.worktreesByRepo,
         removed,
-        removedSoleOwnerRepoIds
+        repoIdsWithoutSurvivingOwners
       )
       const detectedRows: Record<string, DetectedWorktreeListResult['worktrees']> =
         Object.fromEntries(
@@ -5017,7 +5024,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       const detectedDrop = dropWorktreeRowsForRemovedRuntimeEnvironments(
         detectedRows,
         removed,
-        removedSoleOwnerRepoIds
+        repoIdsWithoutSurvivingOwners
       )
 
       const worktreesChanged = worktreeDrop.rowsByRepo !== s.worktreesByRepo
@@ -5056,7 +5063,6 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         : s.detectedWorktreesByRepo
 
       const rowsChanged = worktreesChanged || detectedChanged
-      const survivingRepoIds = new Set(survivingRepos.map((repo) => repo.id))
       return {
         ...purgeState,
         ...(reposChanged ? { repos: survivingRepos } : {}),

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -5015,17 +5015,6 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         }
       }
       const setupsChanged = survivingSetups.length !== s.projectHostSetups.length
-      // Why: legacy rows predate host stamps; repo rows and host setups are the
-      // persisted owner records that prove whether another host still owns them.
-      for (const repoId of repoIdsWithSurvivingOwners) {
-        repoIdsWithoutSurvivingOwners.delete(repoId)
-      }
-
-      const worktreeDrop = dropWorktreeRowsForRemovedRuntimeEnvironments(
-        s.worktreesByRepo,
-        removed,
-        repoIdsWithoutSurvivingOwners
-      )
       const detectedRows: Record<string, DetectedWorktreeListResult['worktrees']> =
         Object.fromEntries(
           Object.entries(s.detectedWorktreesByRepo).map(([repoId, result]) => [
@@ -5033,6 +5022,33 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             result.worktrees
           ])
         )
+      if (repoIdsWithoutSurvivingOwners.size > 0) {
+        // Why: repo/setup catalogs can lag session hydration; an explicitly hosted
+        // surviving worktree row is owner evidence during that loading gap too.
+        const recordSurvivingWorktreeOwners = (
+          rowsByRepo: Record<string, readonly { hostId?: ExecutionHostId }[]>
+        ): void => {
+          for (const [repoId, rows] of Object.entries(rowsByRepo)) {
+            if (rows.some((row) => row.hostId && !isRemovedRuntimeHostId(row.hostId, removed))) {
+              repoIdsWithSurvivingOwners.add(repoId)
+            }
+          }
+        }
+        recordSurvivingWorktreeOwners(s.worktreesByRepo)
+        recordSurvivingWorktreeOwners(detectedRows)
+
+        // Why: legacy rows predate host stamps; every available owner record must
+        // agree that no other host survives before an unhosted row can be retired.
+        for (const repoId of repoIdsWithSurvivingOwners) {
+          repoIdsWithoutSurvivingOwners.delete(repoId)
+        }
+      }
+
+      const worktreeDrop = dropWorktreeRowsForRemovedRuntimeEnvironments(
+        s.worktreesByRepo,
+        removed,
+        repoIdsWithoutSurvivingOwners
+      )
       const detectedDrop = dropWorktreeRowsForRemovedRuntimeEnvironments(
         detectedRows,
         removed,
@@ -5049,6 +5065,20 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         ...worktreeDrop.removedWorktreeIds,
         ...detectedDrop.removedWorktreeIds
       ])
+      // Why: terminal tabs hydrate before worktree metadata; session-only ids for
+      // repos whose owners are all gone still need the full worktree-state purge.
+      if (repoIdsWithoutSurvivingOwners.size > 0) {
+        for (const worktreeId of Object.keys(s.tabsByWorktree)) {
+          const scope = parseWorkspaceKey(worktreeId)
+          const rawWorktreeId = scope?.type === 'worktree' ? scope.worktreeId : worktreeId
+          if (
+            scope?.type !== 'folder' &&
+            repoIdsWithoutSurvivingOwners.has(getRepoIdFromWorktreeId(rawWorktreeId))
+          ) {
+            removedWorktreeIds.add(rawWorktreeId)
+          }
+        }
+      }
       // Why: worktree-scoped UI state is keyed by bare worktree id, not host. If
       // the same id survives on another host, it now belongs to that unambiguous
       // survivor and must not lose its live tabs/editor/terminal state.

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -4983,13 +4983,13 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       return
     }
     set((s) => {
-      const repoIdsWithoutSurvivingOwners = new Set<string>()
+      const repoIdsWithRemovedOwners = new Set<string>()
       const survivingRepoIds = new Set<string>()
       const repoIdsWithSurvivingOwners = new Set<string>()
       const survivingRepos: AppState['repos'] = []
       for (const repo of s.repos) {
         if (isRemovedRuntimeHostId(getRepoExecutionHostId(repo), removed)) {
-          repoIdsWithoutSurvivingOwners.add(repo.id)
+          repoIdsWithRemovedOwners.add(repo.id)
         } else {
           survivingRepos.push(repo)
           survivingRepoIds.add(repo.id)
@@ -5005,7 +5005,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       for (const setup of s.projectHostSetups) {
         if (isRemovedRuntimeHostId(setup.hostId, removed)) {
           if (setup.repoId) {
-            repoIdsWithoutSurvivingOwners.add(setup.repoId)
+            repoIdsWithRemovedOwners.add(setup.repoId)
           }
         } else {
           survivingSetups.push(setup)
@@ -5022,26 +5022,49 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             result.worktrees
           ])
         )
-      if (repoIdsWithoutSurvivingOwners.size > 0) {
-        // Why: repo/setup catalogs can lag session hydration; an explicitly hosted
-        // surviving worktree row is owner evidence during that loading gap too.
-        const recordSurvivingWorktreeOwners = (
-          rowsByRepo: Record<string, readonly { hostId?: ExecutionHostId }[]>
-        ): void => {
-          for (const [repoId, rows] of Object.entries(rowsByRepo)) {
-            if (rows.some((row) => row.hostId && !isRemovedRuntimeHostId(row.hostId, removed))) {
-              repoIdsWithSurvivingOwners.add(repoId)
+      // Why: repo/setup catalogs can lag session hydration; hosted worktree rows
+      // are ownership evidence during that loading gap too.
+      const recordWorktreeOwners = (
+        rowsByRepo: Record<string, readonly { hostId?: ExecutionHostId }[]>
+      ): void => {
+        for (const [repoId, rows] of Object.entries(rowsByRepo)) {
+          for (const row of rows) {
+            if (!row.hostId) {
+              continue
             }
+            const ownerSet = isRemovedRuntimeHostId(row.hostId, removed)
+              ? repoIdsWithRemovedOwners
+              : repoIdsWithSurvivingOwners
+            ownerSet.add(repoId)
           }
         }
-        recordSurvivingWorktreeOwners(s.worktreesByRepo)
-        recordSurvivingWorktreeOwners(detectedRows)
+      }
+      recordWorktreeOwners(s.worktreesByRepo)
+      recordWorktreeOwners(detectedRows)
 
-        // Why: legacy rows predate host stamps; every available owner record must
-        // agree that no other host survives before an unhosted row can be retired.
-        for (const repoId of repoIdsWithSurvivingOwners) {
-          repoIdsWithoutSurvivingOwners.delete(repoId)
+      const sessionWorktreeIdsOwnedByRemovedHosts = new Set<string>()
+      let survivingRestoredSessionOwners = s.restoredRuntimeHostIdByWorkspaceSessionKey
+      for (const [workspaceKey, hostId] of Object.entries(
+        s.restoredRuntimeHostIdByWorkspaceSessionKey
+      )) {
+        const scope = parseWorkspaceKey(workspaceKey)
+        if (scope?.type === 'folder' || !isRemovedRuntimeHostId(hostId, removed)) {
+          continue
         }
+        const worktreeId = scope?.type === 'worktree' ? scope.worktreeId : workspaceKey
+        sessionWorktreeIdsOwnedByRemovedHosts.add(worktreeId)
+        repoIdsWithRemovedOwners.add(getRepoIdFromWorktreeId(worktreeId))
+        if (survivingRestoredSessionOwners === s.restoredRuntimeHostIdByWorkspaceSessionKey) {
+          survivingRestoredSessionOwners = { ...survivingRestoredSessionOwners }
+        }
+        delete survivingRestoredSessionOwners[workspaceKey]
+      }
+
+      // Why: legacy rows predate host stamps; every available owner record must
+      // agree that no other host survives before an unhosted row can be retired.
+      const repoIdsWithoutSurvivingOwners = new Set(repoIdsWithRemovedOwners)
+      for (const repoId of repoIdsWithSurvivingOwners) {
+        repoIdsWithoutSurvivingOwners.delete(repoId)
       }
 
       const worktreeDrop = dropWorktreeRowsForRemovedRuntimeEnvironments(
@@ -5057,13 +5080,11 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
 
       const worktreesChanged = worktreeDrop.rowsByRepo !== s.worktreesByRepo
       const detectedChanged = detectedDrop.rowsByRepo !== detectedRows
-      if (!reposChanged && !setupsChanged && !worktreesChanged && !detectedChanged) {
-        return s
-      }
 
       const removedWorktreeIds = new Set([
         ...worktreeDrop.removedWorktreeIds,
-        ...detectedDrop.removedWorktreeIds
+        ...detectedDrop.removedWorktreeIds,
+        ...sessionWorktreeIdsOwnedByRemovedHosts
       ])
       // Why: terminal tabs hydrate before worktree metadata; session-only ids for
       // repos whose owners are all gone still need the full worktree-state purge.
@@ -5079,21 +5100,37 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           }
         }
       }
-      // Why: worktree-scoped UI state is keyed by bare worktree id, not host. If
-      // the same id survives on another host, it now belongs to that unambiguous
-      // survivor and must not lose its live tabs/editor/terminal state.
+      // Why: bare-id state follows an exact survivor unless the restored session
+      // partition proves that state belonged to the removed host.
       for (const rows of Object.values(worktreeDrop.rowsByRepo)) {
         for (const row of rows) {
-          removedWorktreeIds.delete(row.id)
+          if (!sessionWorktreeIdsOwnedByRemovedHosts.has(row.id)) {
+            removedWorktreeIds.delete(row.id)
+          }
         }
       }
       for (const rows of Object.values(detectedDrop.rowsByRepo)) {
         for (const row of rows) {
-          removedWorktreeIds.delete(row.id)
+          if (!sessionWorktreeIdsOwnedByRemovedHosts.has(row.id)) {
+            removedWorktreeIds.delete(row.id)
+          }
         }
       }
       const purgeState =
         removedWorktreeIds.size > 0 ? buildWorktreePurgeState(s, [...removedWorktreeIds]) : {}
+
+      const restoredSessionOwnersChanged =
+        survivingRestoredSessionOwners !== s.restoredRuntimeHostIdByWorkspaceSessionKey
+      if (
+        !reposChanged &&
+        !setupsChanged &&
+        !worktreesChanged &&
+        !detectedChanged &&
+        !restoredSessionOwnersChanged &&
+        removedWorktreeIds.size === 0
+      ) {
+        return s
+      }
 
       const detectedWorktreesByRepo = detectedChanged
         ? Object.fromEntries(
@@ -5111,6 +5148,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         ...(setupsChanged ? { projectHostSetups: survivingSetups } : {}),
         ...(worktreesChanged ? { worktreesByRepo: worktreeDrop.rowsByRepo } : {}),
         ...(detectedChanged ? { detectedWorktreesByRepo } : {}),
+        ...(restoredSessionOwnersChanged
+          ? { restoredRuntimeHostIdByWorkspaceSessionKey: survivingRestoredSessionOwners }
+          : {}),
         ...(rowsChanged ? { sortEpoch: s.sortEpoch + 1 } : {}),
         // Why: mirror validateRepoScopedUi's repo-scoped UI subset so a filtered or
         // active sidebar can't be left referencing a purged repo id.


### PR DESCRIPTION
## What changes

Follow-up to #9463 after an adversarial correctness and performance review found host-identity edge cases:

- Keep worktree-scoped tab, terminal, browser, and editor state when an exact worktree ID and its restored session owner survive on another host.
- Purge restored tabs and PTY bindings when the session partition proves they came from the removed host, even if another host has the same bare worktree ID.
- Treat repo rows, project host setups, hosted worktree rows, detected rows, and restored session-owner records as ownership evidence. This closes catalog-loading and catalog-already-removed races that otherwise leave legacy unhosted duplicates or session-only state behind.
- Purge legacy unhosted worktree and detected-worktree rows only when at least one known owner was removed and no owner survives.

## Reliability contract

- **Invariant (`runtime-host.session-ownership`):** removing a saved `runtime:<envId>` must retire only state owned by that host. An exact-ID sibling keeps its state only when ownership is surviving or unknown; a restored partition explicitly owned by the removed host cannot transfer its tabs, PTYs, browser/editor state, or resume authority to the sibling.
- **Failure source:** #8881 and the #9463 follow-up review. The concrete regressions were catalog gaps that left legacy rows behind and bare-ID collisions that preserved removed-host PTY/session state.
- **Oracle:** deterministic reducer tests assert removed-only, surviving-only, batch-removal, catalog-loading, catalog-already-gone, same-ID surviving-owner, and same-ID removed-owner outcomes. The removed-owner collision includes a runtime PTY binding and verifies the active workspace and restored owner are cleared.
- **Gate:** `agent-session.provider-ownership` is experimental/partial and passes. There is no exact runtime-host-removal gate yet; the focused ownership reducer suite is the accepted lower-layer coverage for this PR.
- **Provider/platform coverage:** remote-runtime ownership decisions are covered in renderer-state tests. Local, daemon, SSH, WSL, relay/mobile, and Git execution paths are unaffected: this change makes no provider call, filesystem assumption, path transformation, or subprocess request. Tests ran on macOS; live Linux/Windows/WSL/SSH journeys remain gaps.
- **Performance budget:** removal remains event-driven and linear over in-memory repos, setups, worktree rows, detected rows, restored-owner records, and state maps. A temporary 10,000-row worst-case probe completed the purge in 17.15 ms locally; it added no polling, IPC, network calls, provider inventories, or subprocesses. Unchanged restored-owner maps preserve reference identity.
- **Diagnostics:** `removedRuntimeEnvironmentIds` remains the inspectable removal tombstone, while focused failures identify the exact owner evidence and state surface that diverged. No raw terminal output or large state is logged.
- **Residual gaps:** project-group/folder-workspace cleanup and physical-host reconciliation while two identities remain saved are separate non-goals. Live cross-platform remote-runtime removal is not exercised here.

## Verification

- 343 relevant reducer, worktree, hydration, session-partition, leak, runtime-status, and provider-ownership tests pass.
- Full node, CLI, and web typecheck passes.
- Changed-file oxlint/React Doctor/oxfmt, max-lines ratchet, and reliability-manifest checks pass.
- The local environment is Node 26 while the repository requires Node 24; PR CI supplies the supported environment.

## Screenshots

No visual changes. The live sidebar behavior was validated in #9463; this PR hardens ownership races below that UI.

## Security audit

No new external input, privileges, persistence authority, network requests, IPC, or subprocesses. Removal remains scoped to environment IDs that just left the saved list.

## AI review report

The review found and fixed two substantive issues: missing removed-owner evidence from hosted worktree rows, and ignored restored-session ownership during exact-ID collisions/catalog gaps. Low-value loop micro-optimizations were intentionally not applied because the path is removal-event-only, bounded, and measured.

## Notes

Aggregate lint remains blocked on current `main` by the unrelated non-exhaustive switch in `src/renderer/src/components/skills/skill-freshness-group.tsx`; changed-file lint passes.
