### PR TITLE
Stop attaching stale closed PRs/MRs to default-branch checkouts

### DIFF
--- a/src/main/azure-devops/client.test.ts
+++ b/src/main/azure-devops/client.test.ts
@@ -6,12 +6,29 @@ import {
   normalizeAzureDevOpsApiBaseUrl
 } from './client'
 import { _resetAzureDevOpsRepoRefCache } from './repository-ref'
+import { __resetRepoDefaultBranchCacheForTests } from '../source-control/repo-default-branch'
 
 const gitExecFileAsyncMock = vi.hoisted(() => vi.fn())
 
 vi.mock('../git/runner', () => ({
   gitExecFileAsync: gitExecFileAsyncMock
 }))
+
+/** Serve the remote URL plus the #9171 default-branch resolver probes. */
+function primeGitExecWithDefaultBranch(defaultRef = 'refs/remotes/origin/main'): void {
+  gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+    if (args[0] === 'remote') {
+      return { stdout: 'https://dev.azure.com/acme/Project/_git/repo\n', stderr: '' }
+    }
+    if (args[0] === 'symbolic-ref' && args.includes('refs/remotes/origin/HEAD')) {
+      return { stdout: `${defaultRef}\n`, stderr: '' }
+    }
+    if (args[0] === 'rev-parse' && args[1] === '--verify' && args.includes(defaultRef)) {
+      return { stdout: 'default-oid\n', stderr: '' }
+    }
+    throw new Error(`unexpected git call: ${args.join(' ')}`)
+  })
+}
 
 const OLD_ENV = process.env
 const OLD_FETCH = globalThis.fetch
@@ -21,6 +38,7 @@ describe('Azure DevOps client', () => {
     process.env = { ...OLD_ENV, ORCA_AZURE_DEVOPS_TOKEN: 'pat-token' }
     gitExecFileAsyncMock.mockReset()
     _resetAzureDevOpsRepoRefCache()
+    __resetRepoDefaultBranchCacheForTests()
   })
 
   afterEach(() => {
@@ -176,6 +194,131 @@ describe('Azure DevOps client', () => {
       state: 'merged',
       headSha: 'newsha'
     })
+  })
+
+  it('hides a stale completed/abandoned PR whose source branch is the repo default branch (#9171)', async () => {
+    primeGitExecWithDefaultBranch()
+    globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(String(input))
+      const response = (body: unknown): Response =>
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+
+      if (url.pathname === '/acme/Project/_apis/git/repositories/repo') {
+        return response({ id: 'repo-guid' })
+      }
+      if (url.pathname === '/acme/Project/_apis/git/repositories/repo-guid/pullRequests') {
+        return response({
+          value: [
+            {
+              pullRequestId: 30,
+              title: 'Accidental PR from main',
+              status: 'abandoned',
+              creationDate: '2026-05-10T00:00:00Z',
+              closedDate: '2026-05-11T00:00:00Z',
+              lastMergeSourceCommit: { commitId: 'stale-main-oid' }
+            }
+          ]
+        })
+      }
+      return new Response(JSON.stringify({ message: 'not found' }), { status: 404 })
+    }) as never
+
+    await expect(getAzureDevOpsPullRequestForBranch('/repo', 'refs/heads/main')).resolves.toBeNull()
+  })
+
+  it('discards a completed default-branch shadow and refetches the linked PR (#9171)', async () => {
+    primeGitExecWithDefaultBranch()
+    globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(String(input))
+      const response = (body: unknown): Response =>
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+
+      if (url.pathname === '/acme/Project/_apis/git/repositories/repo') {
+        return response({ id: 'repo-guid' })
+      }
+      if (url.pathname === '/acme/Project/_apis/git/repositories/repo-guid/pullRequests') {
+        return response({
+          value: [
+            {
+              pullRequestId: 32,
+              title: 'Completed PR from main',
+              status: 'completed',
+              creationDate: '2026-05-10T00:00:00Z',
+              closedDate: '2026-05-12T00:00:00Z',
+              lastMergeSourceCommit: { commitId: 'shadow-oid' }
+            }
+          ]
+        })
+      }
+      if (url.pathname === '/acme/Project/_apis/git/repositories/repo-guid/pullRequests/40') {
+        return response({
+          pullRequestId: 40,
+          title: 'Linked PR',
+          status: 'active',
+          creationDate: '2026-05-13T00:00:00Z',
+          mergeStatus: 'succeeded',
+          lastMergeSourceCommit: { commitId: 'linked-oid' }
+        })
+      }
+      if (
+        url.pathname === '/acme/Project/_apis/git/repositories/repo-guid/pullRequests/40/statuses'
+      ) {
+        return response({ value: [{ state: 'succeeded' }] })
+      }
+      return new Response(JSON.stringify({ message: 'not found' }), { status: 404 })
+    }) as never
+
+    await expect(
+      getAzureDevOpsPullRequestForBranch('/repo', 'refs/heads/main', 40)
+    ).resolves.toMatchObject({ number: 40, state: 'open' })
+  })
+
+  it('keeps an active PR whose source branch is the repo default branch', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: 'https://dev.azure.com/acme/Project/_git/repo\n'
+    })
+    globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(String(input))
+      const response = (body: unknown): Response =>
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' }
+        })
+
+      if (url.pathname === '/acme/Project/_apis/git/repositories/repo') {
+        return response({ id: 'repo-guid' })
+      }
+      if (url.pathname === '/acme/Project/_apis/git/repositories/repo-guid/pullRequests') {
+        return response({
+          value: [
+            {
+              pullRequestId: 31,
+              title: 'main → release',
+              status: 'active',
+              creationDate: '2026-05-10T00:00:00Z',
+              mergeStatus: 'succeeded',
+              lastMergeSourceCommit: { commitId: 'main-head-oid' }
+            }
+          ]
+        })
+      }
+      if (
+        url.pathname === '/acme/Project/_apis/git/repositories/repo-guid/pullRequests/31/statuses'
+      ) {
+        return response({ value: [{ state: 'succeeded' }] })
+      }
+      return new Response(JSON.stringify({ message: 'not found' }), { status: 404 })
+    }) as never
+
+    await expect(
+      getAzureDevOpsPullRequestForBranch('/repo', 'refs/heads/main')
+    ).resolves.toMatchObject({ number: 31, state: 'open' })
   })
 
   it('cancels unread error-response bodies so bundled undici cannot crash on socket close', async () => {

--- a/src/main/azure-devops/client.ts
+++ b/src/main/azure-devops/client.ts
@@ -1,10 +1,12 @@
 import {
   deriveAzureDevOpsStatus,
   mapAzureDevOpsPullRequest,
+  mapAzureDevOpsPullRequestState,
   type AzureDevOpsPullRequestInfo,
   type RawAzureDevOpsPullRequest,
   type RawAzureDevOpsStatus
 } from './pull-request-mappers'
+import { shouldHideNonOpenReviewOnDefaultBranch } from '../source-control/repo-default-branch'
 import { getAzureDevOpsRepoRef, type AzureDevOpsRepoRef } from './repository-ref'
 import {
   getHostedReviewLocalGitOptions,
@@ -228,7 +230,20 @@ export async function getAzureDevOpsPullRequestForBranch(
     )
     const raw = (list?.value ?? []).sort(sortPullRequestsForBranch)[0]
     if (raw) {
-      return normalizePullRequest(repo, repository.idOrName, repository.webBaseUrl, raw)
+      // Why (#9171): discard a non-open implicit branch match on the repo
+      // default branch and fall through to the linked-number fallback below.
+      const hideOnDefaultBranch = await shouldHideNonOpenReviewOnDefaultBranch({
+        state: mapAzureDevOpsPullRequestState(raw),
+        reviewNumber: raw.pullRequestId ?? null,
+        linkedReviewNumber: linkedPRNumber,
+        branchName,
+        repoPath,
+        connectionId,
+        localGitOptions: getHostedReviewLocalGitOptions(options)
+      })
+      if (!hideOnDefaultBranch) {
+        return normalizePullRequest(repo, repository.idOrName, repository.webBaseUrl, raw)
+      }
     }
   }
 

--- a/src/main/bitbucket/client.test.ts
+++ b/src/main/bitbucket/client.test.ts
@@ -11,6 +11,23 @@ vi.mock('../git/runner', () => ({
 
 import { getBitbucketAuthStatus, getBitbucketPullRequestForBranch } from './client'
 import { _resetBitbucketRepoRefCache } from './repository-ref'
+import { __resetRepoDefaultBranchCacheForTests } from '../source-control/repo-default-branch'
+
+/** Serve the remote URL plus the #9171 default-branch resolver probes. */
+function primeGitExecWithDefaultBranch(defaultRef = 'refs/remotes/origin/main'): void {
+  gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+    if (args[0] === 'remote') {
+      return { stdout: 'git@bitbucket.org:team/repo.git\n', stderr: '' }
+    }
+    if (args[0] === 'symbolic-ref' && args.includes('refs/remotes/origin/HEAD')) {
+      return { stdout: `${defaultRef}\n`, stderr: '' }
+    }
+    if (args[0] === 'rev-parse' && args[1] === '--verify' && args.includes(defaultRef)) {
+      return { stdout: 'default-oid\n', stderr: '' }
+    }
+    throw new Error(`unexpected git call: ${args.join(' ')}`)
+  })
+}
 
 const OLD_ENV = process.env
 
@@ -46,7 +63,61 @@ describe('Bitbucket client', () => {
       stderr: ''
     })
     _resetBitbucketRepoRefCache()
+    __resetRepoDefaultBranchCacheForTests()
     vi.unstubAllGlobals()
+  })
+
+  it('hides a stale DECLINED PR whose source branch is the repo default branch (#9171)', async () => {
+    primeGitExecWithDefaultBranch()
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/statuses/build')) {
+        return Response.json({ values: [] })
+      }
+      return Response.json({
+        values: [{ ...bitbucketPr(7), state: 'DECLINED', source: { branch: { name: 'main' } } }]
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getBitbucketPullRequestForBranch('/repo', 'refs/heads/main')).resolves.toBeNull()
+  })
+
+  it('keeps an OPEN PR whose source branch is the repo default branch', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/statuses/build')) {
+        return Response.json({ values: [{ state: 'SUCCESSFUL' }] })
+      }
+      return Response.json({
+        values: [
+          { ...bitbucketPr(8), source: { branch: { name: 'main' }, commit: { hash: 'abc123' } } }
+        ]
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      getBitbucketPullRequestForBranch('/repo', 'refs/heads/main')
+    ).resolves.toMatchObject({ number: 8, state: 'open' })
+  })
+
+  it('discards a MERGED default-branch shadow and refetches the linked PR via the fallback (#9171)', async () => {
+    primeGitExecWithDefaultBranch()
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/statuses/build')) {
+        return Response.json({ values: [] })
+      }
+      if (url.endsWith('/pullrequests/42')) {
+        return Response.json(bitbucketPr(42))
+      }
+      return Response.json({
+        values: [{ ...bitbucketPr(7), state: 'MERGED', source: { branch: { name: 'main' } } }]
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      getBitbucketPullRequestForBranch('/repo', 'refs/heads/main', 42)
+    ).resolves.toMatchObject({ number: 42 })
   })
 
   it('fetches a branch pull request and commit build status', async () => {

--- a/src/main/bitbucket/client.ts
+++ b/src/main/bitbucket/client.ts
@@ -3,10 +3,12 @@ import type { CheckStatus } from '../../shared/types'
 import {
   deriveBitbucketBuildStatus,
   mapBitbucketPullRequest,
+  mapBitbucketPullRequestState,
   type BitbucketPullRequestInfo,
   type RawBitbucketBuildStatus,
   type RawBitbucketPullRequest
 } from './pull-request-mappers'
+import { shouldHideNonOpenReviewOnDefaultBranch } from '../source-control/repo-default-branch'
 import { getBitbucketRepoRef, type BitbucketRepoRef } from './repository-ref'
 import {
   getHostedReviewLocalGitOptions,
@@ -218,7 +220,20 @@ export async function getBitbucketPullRequestForBranch(
     )
     const raw = list?.values?.[0]
     if (raw) {
-      return normalizePullRequest(repo, raw)
+      // Why (#9171): discard a non-open implicit branch match on the repo
+      // default branch and fall through to the linked-number fallback below.
+      const hideOnDefaultBranch = await shouldHideNonOpenReviewOnDefaultBranch({
+        state: mapBitbucketPullRequestState(raw.state),
+        reviewNumber: raw.id ?? null,
+        linkedReviewNumber: linkedPRNumber,
+        branchName,
+        repoPath,
+        connectionId,
+        localGitOptions: getHostedReviewLocalGitOptions(options)
+      })
+      if (!hideOnDefaultBranch) {
+        return normalizePullRequest(repo, raw)
+      }
     }
   }
 

--- a/src/main/gitea/client.test.ts
+++ b/src/main/gitea/client.test.ts
@@ -20,8 +20,25 @@ import {
   _resetGiteaPullRequestScanCache,
   scanGiteaPullRequests
 } from './pull-request-scan-cache'
+import { __resetRepoDefaultBranchCacheForTests } from '../source-control/repo-default-branch'
 
 const OLD_ENV = process.env
+
+/** Serve the remote URL plus the #9171 default-branch resolver probes. */
+function primeGitExecWithDefaultBranch(defaultRef = 'refs/remotes/origin/main'): void {
+  gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+    if (args[0] === 'remote') {
+      return { stdout: 'https://git.example.com/team/repo.git\n', stderr: '' }
+    }
+    if (args[0] === 'symbolic-ref' && args.includes('refs/remotes/origin/HEAD')) {
+      return { stdout: `${defaultRef}\n`, stderr: '' }
+    }
+    if (args[0] === 'rev-parse' && args[1] === '--verify' && args.includes(defaultRef)) {
+      return { stdout: 'default-oid\n', stderr: '' }
+    }
+    throw new Error(`unexpected git call: ${args.join(' ')}`)
+  })
+}
 
 function giteaPr(index = 7, branch = 'feature/gitea') {
   return {
@@ -51,7 +68,71 @@ describe('Gitea client', () => {
     })
     _resetGiteaRepoRefCache()
     _resetGiteaPullRequestScanCache()
+    __resetRepoDefaultBranchCacheForTests()
     vi.unstubAllGlobals()
+  })
+
+  it('hides a stale closed PR whose source branch is the repo default branch (#9171)', async () => {
+    primeGitExecWithDefaultBranch()
+    const fetchMock = vi.fn(async (url: string) => {
+      const parsed = new URL(url)
+      if (parsed.pathname.endsWith('/status')) {
+        return Response.json({ state: 'success' })
+      }
+      return Response.json([{ ...giteaPr(7, 'main'), state: 'closed' }])
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getGiteaPullRequestForBranch('/repo', 'refs/heads/main')).resolves.toBeNull()
+  })
+
+  it('hides a stale merged PR on the default branch but keeps an open one', async () => {
+    primeGitExecWithDefaultBranch()
+    const fetchMock = vi.fn(async (url: string) => {
+      const parsed = new URL(url)
+      if (parsed.pathname.endsWith('/status')) {
+        return Response.json({ state: 'success' })
+      }
+      return Response.json([{ ...giteaPr(9, 'main'), merged: true }])
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getGiteaPullRequestForBranch('/repo', 'refs/heads/main')).resolves.toBeNull()
+
+    _resetGiteaPullRequestScanCache()
+    __resetRepoDefaultBranchCacheForTests()
+    const openFetchMock = vi.fn(async (url: string) => {
+      const parsed = new URL(url)
+      if (parsed.pathname.endsWith('/status')) {
+        return Response.json({ state: 'success' })
+      }
+      return Response.json([giteaPr(10, 'main')])
+    })
+    vi.stubGlobal('fetch', openFetchMock)
+
+    await expect(getGiteaPullRequestForBranch('/repo', 'refs/heads/main')).resolves.toMatchObject({
+      number: 10,
+      state: 'open'
+    })
+  })
+
+  it('discards a closed default-branch shadow and refetches the linked PR via the fallback (#9171)', async () => {
+    primeGitExecWithDefaultBranch()
+    const fetchMock = vi.fn(async (url: string) => {
+      const parsed = new URL(url)
+      if (parsed.pathname.endsWith('/status')) {
+        return Response.json({ state: 'success' })
+      }
+      if (parsed.pathname.endsWith('/pulls/42')) {
+        return Response.json(giteaPr(42, 'main'))
+      }
+      return Response.json([{ ...giteaPr(7, 'main'), state: 'closed' }])
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      getGiteaPullRequestForBranch('/repo', 'refs/heads/main', 42)
+    ).resolves.toMatchObject({ number: 42 })
   })
 
   it('normalizes Gitea API base URLs', () => {

--- a/src/main/gitea/client.ts
+++ b/src/main/gitea/client.ts
@@ -1,10 +1,12 @@
 import {
   deriveGiteaCommitStatus,
   mapGiteaPullRequest,
+  mapGiteaPullRequestState,
   type GiteaPullRequestInfo,
   type RawGiteaCombinedStatus,
   type RawGiteaPullRequest
 } from './pull-request-mappers'
+import { shouldHideNonOpenReviewOnDefaultBranch } from '../source-control/repo-default-branch'
 import { getGiteaRepoRef, type GiteaRepoRef } from './repository-ref'
 import { invalidateGiteaPullRequestScan, scanGiteaPullRequests } from './pull-request-scan-cache'
 import {
@@ -261,7 +263,20 @@ export async function getGiteaPullRequestForBranch(
     )
     const raw = pullRequests.find((item) => matchesBranch(item, branchName))
     if (raw) {
-      return normalizePullRequest(repo, raw)
+      // Why (#9171): discard a non-open implicit branch match on the repo
+      // default branch and fall through to the linked-number fallback below.
+      const hideOnDefaultBranch = await shouldHideNonOpenReviewOnDefaultBranch({
+        state: mapGiteaPullRequestState(raw),
+        reviewNumber: raw.number ?? null,
+        linkedReviewNumber: linkedPRNumber,
+        branchName,
+        repoPath,
+        connectionId,
+        localGitOptions: getHostedReviewLocalGitOptions(options)
+      })
+      if (!hideOnDefaultBranch) {
+        return normalizePullRequest(repo, raw)
+      }
     }
   }
 

--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -126,6 +126,7 @@ import {
 } from './client'
 import { __resetPRConflictSummaryCachesForTests } from './conflict-summary'
 import { resetMergedPRCommitMembershipCacheForTest } from './merged-pr-commit-membership'
+import { __resetRepoDefaultBranchCacheForTests } from '../source-control/repo-default-branch'
 
 describe('checkOrcaStarred', () => {
   beforeEach(() => {
@@ -198,6 +199,9 @@ describe('getPRForBranch', () => {
     __resetTrackedUpstreamBranchCacheForTests()
     __resetPRConflictSummaryCachesForTests()
     resetMergedPRCommitMembershipCacheForTest()
+    // Why: the #9171 guard caches default-branch resolutions per repoPath;
+    // reset so non-open implicit lookups stay order-independent across tests.
+    __resetRepoDefaultBranchCacheForTests()
   })
 
   it('queries GitHub by head branch when the remote is on github.com', async () => {
@@ -924,7 +928,14 @@ describe('getPRForBranch', () => {
       }
     )
 
-    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+    // Why: the merged-implicit head probe must use the supplied oid — no
+    // `rev-parse HEAD` shell-out. (The #9171 guard may still probe the repo
+    // default branch for this non-open implicit result; that is unrelated.)
+    expect(
+      gitExecFileAsyncMock.mock.calls.some(
+        (call) => call[0][0] === 'rev-parse' && call[0][1] === 'HEAD'
+      )
+    ).toBe(false)
     expect(outcome).toMatchObject({
       kind: 'found',
       pr: {

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -73,6 +73,7 @@ import {
   getHostedReviewLocalGitOptions,
   type HostedReviewExecutionOptions
 } from '../source-control/hosted-review-git-options'
+import { shouldHideNonOpenReviewOnDefaultBranch } from '../source-control/repo-default-branch'
 import { readLocalGitConfigSignature } from './local-git-config-signature'
 import {
   getRememberedGhCwdResolutionFailure,
@@ -3192,6 +3193,23 @@ export async function getPRForBranchOutcome(
     // marks the fallback as visible review state, keep its lifecycle fresh even
     // if GitHub no longer reports it by branch (for example deleted heads).
     if ((await hideMergedImplicitPR(data, dataRepo)) && !shouldPreserveMergedFallback) {
+      return { kind: 'no-pr', fetchedAt: Date.now() }
+    }
+    // Why (#9171): on the default branch an implicit branch/fallback match must
+    // never surface a non-open PR — it overrides the merged-fallback
+    // preservation and merged-at-head carve-out on the trunk only. An exact
+    // linked lookup returns the linked number, so linked PRs are exempt.
+    if (
+      await shouldHideNonOpenReviewOnDefaultBranch({
+        state: mapPRState(data.state, data.isDraft),
+        reviewNumber: data.number,
+        linkedReviewNumber: linkedPRNumber,
+        branchName,
+        repoPath,
+        connectionId,
+        localGitOptions
+      })
+    ) {
       return { kind: 'no-pr', fetchedAt: Date.now() }
     }
 

--- a/src/main/github/default-branch-stale-pr.test.ts
+++ b/src/main/github/default-branch-stale-pr.test.ts
@@ -1,0 +1,388 @@
+/*
+ * Issue #9171 — "Wrong PR diffs displayed when checking out the default branch".
+ *
+ * A repo's default branch is `master`. In the past someone opened a PR whose
+ * HEAD was `master` (accidentally opening a PR *from* the default branch); it
+ * was closed long ago. getPRForBranch looks a PR up purely by head branch name
+ * with `state=all`, so without a guard that stale closed PR gets attached to
+ * the default-branch checkout, surfacing its wrong diffs and checks.
+ *
+ * These tests assert the CORRECT behavior: an implicit (non-linked) branch or
+ * fallback-number match on the repo default branch never surfaces a non-open
+ * PR, while open PRs on the trunk and closed/merged PRs on feature branches
+ * keep today's behavior. The default branch is resolved by the REAL
+ * resolveDefaultBaseRefViaExec over the mocked git exec layer, so the
+ * symbolic-ref / rev-parse plumbing and the `origin/` strip are exercised.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type RateLimitGuardResult =
+  | { blocked: false }
+  | { blocked: true; remaining: number; limit: number; resetAt: number }
+
+const {
+  execFileAsyncMock,
+  ghExecFileAsyncMock,
+  getOwnerRepoMock,
+  getIssueOwnerRepoMock,
+  getOwnerRepoForRemoteMock,
+  resolvePRRepositoryCandidatesMock,
+  getRemoteUrlForRepoMock,
+  gitExecFileAsyncMock,
+  getRateLimitMock,
+  rateLimitGuardMock,
+  noteRateLimitSpendMock,
+  ghRepoExecOptionsMock,
+  githubRepoContextMock,
+  getSshGitProviderMock,
+  readLocalGitConfigSignatureMock,
+  acquireMock,
+  releaseMock
+} = vi.hoisted(() => ({
+  execFileAsyncMock: vi.fn(),
+  ghExecFileAsyncMock: vi.fn(),
+  getOwnerRepoMock: vi.fn(),
+  getIssueOwnerRepoMock: vi.fn(),
+  getOwnerRepoForRemoteMock: vi.fn(),
+  resolvePRRepositoryCandidatesMock: vi.fn(),
+  getRemoteUrlForRepoMock: vi.fn(),
+  gitExecFileAsyncMock: vi.fn(),
+  getRateLimitMock: vi.fn(),
+  rateLimitGuardMock: vi.fn<(bucket?: string) => RateLimitGuardResult>(() => ({
+    blocked: false
+  })),
+  noteRateLimitSpendMock: vi.fn(),
+  ghRepoExecOptionsMock: vi.fn((context) =>
+    context.connectionId
+      ? {}
+      : {
+          cwd: context.repoPath,
+          ...(context.wslDistro ? { wslDistro: context.wslDistro } : {})
+        }
+  ),
+  githubRepoContextMock: vi.fn((repoPath, connectionId, localGitOptions) => ({
+    repoPath,
+    connectionId: connectionId ?? null,
+    ...localGitOptions
+  })),
+  getSshGitProviderMock: vi.fn(),
+  readLocalGitConfigSignatureMock: vi.fn(),
+  acquireMock: vi.fn(),
+  releaseMock: vi.fn()
+}))
+
+vi.mock('./gh-utils', () => ({
+  execFileAsync: execFileAsyncMock,
+  ghExecFileAsync: ghExecFileAsyncMock,
+  getOwnerRepo: getOwnerRepoMock,
+  getIssueOwnerRepo: getIssueOwnerRepoMock,
+  getOwnerRepoForRemote: getOwnerRepoForRemoteMock,
+  resolvePRRepositoryCandidates: resolvePRRepositoryCandidatesMock,
+  getRemoteUrlForRepo: getRemoteUrlForRepoMock,
+  gitExecFileAsync: gitExecFileAsyncMock,
+  ghRepoExecOptions: ghRepoExecOptionsMock,
+  githubRepoContext: githubRepoContextMock,
+  classifyGhError: (stderr: string) => {
+    const lower = stderr.toLowerCase()
+    if (lower.includes('not found') || stderr.includes('HTTP 404')) {
+      return { type: 'not_found', message: stderr }
+    }
+    if (lower.includes('rate limit')) {
+      return { type: 'rate_limited', message: stderr }
+    }
+    return { type: 'unknown', message: stderr }
+  },
+  parseGitHubOwnerRepo: (remoteUrl: string) => {
+    const match = remoteUrl.trim().match(/github\.com[:/]([^/]+)\/([^/]+?)(?:\.git)?$/)
+    return match ? { owner: match[1], repo: match[2] } : null
+  },
+  acquire: acquireMock,
+  release: releaseMock,
+  _resetOwnerRepoCache: vi.fn()
+}))
+
+vi.mock('../git/runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock
+}))
+
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: getSshGitProviderMock
+}))
+
+vi.mock('./local-git-config-signature', () => ({
+  readLocalGitConfigSignature: readLocalGitConfigSignatureMock
+}))
+
+vi.mock('./rate-limit', () => ({
+  getRateLimit: getRateLimitMock,
+  rateLimitGuard: rateLimitGuardMock,
+  noteRateLimitSpend: noteRateLimitSpendMock
+}))
+
+import {
+  getPRForBranch,
+  getPRForBranchOutcome,
+  _resetOwnerRepoCache,
+  _resetMergeQueueCacheForTests,
+  __resetTrackedUpstreamBranchCacheForTests
+} from './client'
+import { __resetPRConflictSummaryCachesForTests } from './conflict-summary'
+import { resetMergedPRCommitMembershipCacheForTest } from './merged-pr-commit-membership'
+import { __resetRepoDefaultBranchCacheForTests } from '../source-control/repo-default-branch'
+
+const DEFAULT_BRANCH_REF = 'refs/remotes/origin/master'
+
+/**
+ * Answer the real resolveDefaultBaseRefViaExec probes (origin/HEAD
+ * symbolic-ref + rev-parse verification), the merged-at-head `rev-parse HEAD`
+ * probe, and the tracked-upstream `for-each-ref` snapshot.
+ */
+function primeGitExecForDefaultBranch({
+  defaultRef = DEFAULT_BRANCH_REF,
+  headOid = 'checkout-head-oid'
+}: { defaultRef?: string; headOid?: string } = {}): void {
+  gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+    if (args[0] === 'symbolic-ref' && args.includes('refs/remotes/origin/HEAD')) {
+      return { stdout: `${defaultRef}\n`, stderr: '' }
+    }
+    if (args[0] === 'rev-parse' && args[1] === '--verify') {
+      if (args.includes(defaultRef)) {
+        return { stdout: 'default-branch-oid\n', stderr: '' }
+      }
+      throw new Error(`fatal: Needed a single revision: ${args.join(' ')}`)
+    }
+    if (args[0] === 'rev-parse' && args[1] === 'HEAD') {
+      return { stdout: `${headOid}\n`, stderr: '' }
+    }
+    if (args[0] === 'for-each-ref') {
+      return { stdout: '', stderr: '' }
+    }
+    throw new Error(`unexpected git call: ${args.join(' ')}`)
+  })
+}
+
+type RestPRShape = {
+  number?: number
+  state?: string
+  merged_at?: string | null
+  head_ref?: string
+  head_sha?: string
+}
+
+function restPR({
+  number = 7,
+  state = 'closed',
+  merged_at = null,
+  head_ref = 'master',
+  head_sha = 'stale-master-oid'
+}: RestPRShape = {}): Record<string, unknown> {
+  return {
+    number,
+    title: 'Historical PR',
+    state,
+    merged_at,
+    html_url: `https://github.com/acme/widgets/pull/${number}`,
+    updated_at: '2024-01-01T00:00:00Z',
+    draft: false,
+    mergeable: null,
+    base: { ref: 'old-release', sha: 'base-oid' },
+    head: { ref: head_ref, sha: head_sha }
+  }
+}
+
+/** Route the REST head-branch lookup; every other gh call fails so branch data
+ *  is kept as-is (hydration falls back to the branch payload). */
+function primeGhExecWithBranchList(list: Record<string, unknown>[]): void {
+  ghExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+    if (args[0] === 'api' && args[1]?.includes('pulls?head=')) {
+      return { stdout: JSON.stringify(list) }
+    }
+    throw new Error(`gh unavailable: ${args.join(' ')}`)
+  })
+}
+
+describe('issue #9171: default-branch checkout must not attach a stale non-open PR', () => {
+  beforeEach(() => {
+    execFileAsyncMock.mockReset()
+    ghExecFileAsyncMock.mockReset()
+    getOwnerRepoMock.mockReset()
+    getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+    getIssueOwnerRepoMock.mockReset()
+    getOwnerRepoForRemoteMock.mockReset()
+    resolvePRRepositoryCandidatesMock.mockReset()
+    resolvePRRepositoryCandidatesMock.mockImplementation(async (repoPath, connectionId) => {
+      const origin = await getOwnerRepoMock(repoPath, connectionId)
+      return { candidates: origin ? [origin] : [], headRepo: origin }
+    })
+    getRemoteUrlForRepoMock.mockReset()
+    gitExecFileAsyncMock.mockReset()
+    getRateLimitMock.mockReset()
+    getRateLimitMock.mockResolvedValue({ resources: {} })
+    rateLimitGuardMock.mockReset()
+    rateLimitGuardMock.mockReturnValue({ blocked: false })
+    noteRateLimitSpendMock.mockReset()
+    ghRepoExecOptionsMock.mockClear()
+    githubRepoContextMock.mockClear()
+    getSshGitProviderMock.mockReset()
+    readLocalGitConfigSignatureMock.mockReset()
+    readLocalGitConfigSignatureMock.mockResolvedValue(undefined)
+    acquireMock.mockReset()
+    releaseMock.mockReset()
+    acquireMock.mockResolvedValue(undefined)
+    _resetOwnerRepoCache()
+    _resetMergeQueueCacheForTests()
+    __resetTrackedUpstreamBranchCacheForTests()
+    __resetPRConflictSummaryCachesForTests()
+    resetMergedPRCommitMembershipCacheForTest()
+    __resetRepoDefaultBranchCacheForTests()
+  })
+
+  it('hides a stale CLOSED PR when checked out on the default branch (master)', async () => {
+    primeGitExecForDefaultBranch()
+    primeGhExecWithBranchList([restPR({ number: 7, state: 'closed' })])
+
+    const pr = await getPRForBranch('/repo-root', 'master')
+
+    // The head-branch lookup still runs (state=all) and sees the closed PR…
+    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
+      ['api', 'repos/acme/widgets/pulls?head=acme%3Amaster&state=all&per_page=1'],
+      { cwd: '/repo-root' }
+    )
+    // …but the default-branch guard discards it: no PR on the trunk (#9171).
+    expect(pr).toBeNull()
+  })
+
+  it('reports kind="no-pr" from getPRForBranchOutcome on the default branch', async () => {
+    primeGitExecForDefaultBranch()
+    primeGhExecWithBranchList([restPR({ number: 7, state: 'closed' })])
+
+    const outcome = await getPRForBranchOutcome('/repo-root', 'master')
+
+    expect(outcome.kind).toBe('no-pr')
+  })
+
+  it('keeps a genuinely OPEN PR on the default branch visible', async () => {
+    primeGitExecForDefaultBranch()
+    primeGhExecWithBranchList([restPR({ number: 8, state: 'open' })])
+
+    const pr = await getPRForBranch('/repo-root', 'master')
+
+    expect(pr?.number).toBe(8)
+    expect(pr?.state).toBe('open')
+    // Open results never consult git for the default branch (lazy resolution).
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps a CLOSED PR on a feature branch visible (behavior preserved)', async () => {
+    primeGitExecForDefaultBranch()
+    primeGhExecWithBranchList([
+      restPR({ number: 9, state: 'closed', head_ref: 'feature-x', head_sha: 'feature-oid' })
+    ])
+
+    const pr = await getPRForBranch('/repo-root', 'feature-x')
+
+    expect(pr?.number).toBe(9)
+    expect(pr?.state).toBe('closed')
+  })
+
+  it('preserves the merged-at-head carve-out on a feature branch', async () => {
+    // Worktree HEAD is exactly the merged PR's final head commit.
+    primeGitExecForDefaultBranch({ headOid: 'merged-head-oid' })
+    primeGhExecWithBranchList([
+      restPR({
+        number: 10,
+        state: 'closed',
+        merged_at: '2024-02-02T00:00:00Z',
+        head_ref: 'feature-x',
+        head_sha: 'merged-head-oid'
+      })
+    ])
+
+    const pr = await getPRForBranch('/repo-root', 'feature-x')
+
+    expect(pr?.number).toBe(10)
+    expect(pr?.state).toBe('merged')
+  })
+
+  it('hides a CLOSED fallback-number PR on the default branch (self-heal for persisted stale PRs)', async () => {
+    primeGitExecForDefaultBranch()
+    ghExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'api' && args[1]?.includes('pulls?head=')) {
+        return { stdout: '[]' }
+      }
+      if (args[0] === 'pr' && args[1] === 'view' && args[2] === '7') {
+        return {
+          stdout: JSON.stringify({
+            number: 7,
+            title: 'Historical PR',
+            state: 'CLOSED',
+            url: 'https://github.com/acme/widgets/pull/7',
+            statusCheckRollup: [],
+            updatedAt: '2024-01-01T00:00:00Z',
+            isDraft: false,
+            mergeable: 'UNKNOWN',
+            baseRefName: 'old-release',
+            headRefName: 'master',
+            baseRefOid: 'base-oid',
+            headRefOid: 'stale-master-oid'
+          })
+        }
+      }
+      throw new Error(`gh unavailable: ${args.join(' ')}`)
+    })
+
+    const outcome = await getPRForBranchOutcome('/repo-root', 'master', null, null, 7)
+
+    expect(outcome.kind).toBe('no-pr')
+  })
+
+  it('overrides acceptMergedFallbackPR preservation for a merged fallback PR on the default branch', async () => {
+    primeGitExecForDefaultBranch()
+    ghExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'api' && args[1]?.includes('pulls?head=')) {
+        return { stdout: '[]' }
+      }
+      if (args[0] === 'pr' && args[1] === 'view' && args[2] === '7') {
+        return {
+          stdout: JSON.stringify({
+            number: 7,
+            title: 'Historical PR',
+            state: 'MERGED',
+            url: 'https://github.com/acme/widgets/pull/7',
+            statusCheckRollup: [],
+            updatedAt: '2024-01-01T00:00:00Z',
+            isDraft: false,
+            mergeable: 'UNKNOWN',
+            baseRefName: 'old-release',
+            headRefName: 'master',
+            baseRefOid: 'base-oid',
+            headRefOid: 'stale-master-oid'
+          })
+        }
+      }
+      throw new Error(`gh unavailable: ${args.join(' ')}`)
+    })
+
+    const outcome = await getPRForBranchOutcome('/repo-root', 'master', null, null, 7, {
+      acceptMergedFallbackPR: true
+    })
+
+    expect(outcome.kind).toBe('no-pr')
+  })
+
+  it('fails open when the default branch cannot be resolved (stale PR still returned)', async () => {
+    // Every git probe fails: no origin/HEAD, no main/master refs.
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'for-each-ref') {
+        return { stdout: '', stderr: '' }
+      }
+      throw new Error(`fatal: git unavailable: ${args.join(' ')}`)
+    })
+    primeGhExecWithBranchList([restPR({ number: 7, state: 'closed' })])
+
+    const pr = await getPRForBranch('/repo-root', 'master')
+
+    expect(pr?.number).toBe(7)
+    expect(pr?.state).toBe('closed')
+  })
+})

--- a/src/main/gitlab/client-mr.test.ts
+++ b/src/main/gitlab/client-mr.test.ts
@@ -474,6 +474,23 @@ describe('gitlab client — MR operations', () => {
       await expect(getMergeRequestForBranch('/repo', 'main')).resolves.toBeNull()
     })
 
+    it('hides a stuck-locked MR whose source branch is the repo default branch (#9171)', async () => {
+      getProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'g/p' })
+      glabExecFileAsyncMock.mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            iid: 9,
+            title: 'Wedged mid-merge MR from main',
+            state: 'locked',
+            sha: 'locked-main-oid',
+            head_pipeline: { status: 'success' }
+          }
+        ])
+      })
+
+      await expect(getMergeRequestForBranch('/repo', 'main')).resolves.toBeNull()
+    })
+
     it('keeps an open MR whose source branch is the repo default branch', async () => {
       getProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'g/p' })
       glabExecFileAsyncMock.mockResolvedValueOnce({

--- a/src/main/gitlab/client-mr.test.ts
+++ b/src/main/gitlab/client-mr.test.ts
@@ -10,7 +10,8 @@ const {
   getProjectRefMock,
   resolveIssueSourceMock,
   acquireMock,
-  releaseMock
+  releaseMock,
+  gitExecFileAsyncMock
 } = vi.hoisted(() => ({
   glabExecFileAsyncMock: vi.fn(),
   glabApiWithHeadersMock: vi.fn(),
@@ -18,7 +19,14 @@ const {
   getProjectRefMock: vi.fn(),
   resolveIssueSourceMock: vi.fn(),
   acquireMock: vi.fn(),
-  releaseMock: vi.fn()
+  releaseMock: vi.fn(),
+  gitExecFileAsyncMock: vi.fn()
+}))
+
+// Why: the #9171 default-branch guard resolves the repo default branch via
+// git; keep those probes hermetic instead of spawning real git processes.
+vi.mock('../git/runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock
 }))
 
 vi.mock('./gl-utils', async () => {
@@ -55,6 +63,20 @@ import {
   updateMR,
   updateMRReviewers
 } from './client'
+import { __resetRepoDefaultBranchCacheForTests } from '../source-control/repo-default-branch'
+
+/** Answer the real default-branch resolver probes (#9171 guard). */
+function primeGitDefaultBranch(defaultRef = 'refs/remotes/origin/main'): void {
+  gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+    if (args[0] === 'symbolic-ref' && args.includes('refs/remotes/origin/HEAD')) {
+      return { stdout: `${defaultRef}\n`, stderr: '' }
+    }
+    if (args[0] === 'rev-parse' && args[1] === '--verify' && args.includes(defaultRef)) {
+      return { stdout: 'default-oid\n', stderr: '' }
+    }
+    throw new Error(`unexpected git call: ${args.join(' ')}`)
+  })
+}
 
 describe('gitlab client — MR operations', () => {
   beforeEach(() => {
@@ -66,6 +88,9 @@ describe('gitlab client — MR operations', () => {
     acquireMock.mockReset()
     releaseMock.mockReset()
     acquireMock.mockResolvedValue(undefined)
+    gitExecFileAsyncMock.mockReset()
+    primeGitDefaultBranch()
+    __resetRepoDefaultBranchCacheForTests()
     _resetGitLabRateLimitCache()
     getGlabKnownHostsMock.mockResolvedValue(['gitlab.com'])
     resolveIssueSourceMock.mockResolvedValue({
@@ -430,6 +455,115 @@ describe('gitlab client — MR operations', () => {
         cwd: '/repo',
         wslDistro: 'Ubuntu'
       })
+    })
+
+    it('hides a stale closed MR whose source branch is the repo default branch (#9171)', async () => {
+      getProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'g/p' })
+      glabExecFileAsyncMock.mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            iid: 7,
+            title: 'Accidental MR from main',
+            state: 'closed',
+            sha: 'stale-main-oid',
+            head_pipeline: { status: 'success' }
+          }
+        ])
+      })
+
+      await expect(getMergeRequestForBranch('/repo', 'main')).resolves.toBeNull()
+    })
+
+    it('keeps an open MR whose source branch is the repo default branch', async () => {
+      getProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'g/p' })
+      glabExecFileAsyncMock.mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            iid: 8,
+            title: 'main → release',
+            state: 'opened',
+            sha: 'abc',
+            head_pipeline: { status: 'success' }
+          }
+        ])
+      })
+
+      const mr = await getMergeRequestForBranch('/repo', 'main')
+      expect(mr?.number).toBe(8)
+      // Open results never consult git for the default branch (lazy resolution).
+      expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+    })
+
+    it('keeps a closed MR on a feature branch (behavior preserved)', async () => {
+      getProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'g/p' })
+      glabExecFileAsyncMock.mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            iid: 9,
+            title: 'Rejected work',
+            state: 'closed',
+            sha: 'def',
+            head_pipeline: { status: 'failed' }
+          }
+        ])
+      })
+
+      const mr = await getMergeRequestForBranch('/repo', 'feature/rejected')
+      expect(mr?.number).toBe(9)
+      expect(mr?.state).toBe('closed')
+    })
+
+    it('discards a closed default-branch shadow and refetches the linked MR via the fallback (#9171)', async () => {
+      getProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'g/p' })
+      glabExecFileAsyncMock
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify([
+            {
+              iid: 7,
+              title: 'Accidental MR from main',
+              state: 'closed',
+              sha: 'stale-main-oid',
+              head_pipeline: { status: 'success' }
+            }
+          ])
+        })
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify({
+            iid: 42,
+            title: 'Linked MR',
+            state: 'merged',
+            pipeline: { status: 'success' }
+          })
+        })
+
+      const mr = await getMergeRequestForBranch('/repo', 'main', 42)
+
+      expect(mr).toMatchObject({ number: 42, state: 'merged' })
+      expect(glabExecFileAsyncMock).toHaveBeenLastCalledWith(
+        ['api', 'projects/g%2Fp/merge_requests/42'],
+        { cwd: '/repo' }
+      )
+    })
+
+    it('keeps a non-open branch match on the default branch when it IS the linked MR', async () => {
+      getProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'g/p' })
+      glabExecFileAsyncMock.mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            iid: 7,
+            title: 'Linked trunk MR',
+            state: 'merged',
+            sha: 'abc',
+            head_pipeline: { status: 'success' }
+          }
+        ])
+      })
+
+      const mr = await getMergeRequestForBranch('/repo', 'main', 7)
+
+      expect(mr).toMatchObject({ number: 7, state: 'merged' })
+      // Exempted by linked-number match — no fallback refetch needed.
+      expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(1)
     })
 
     it('returns null for an empty / detached-HEAD branch arg', async () => {

--- a/src/main/gitlab/client.ts
+++ b/src/main/gitlab/client.ts
@@ -47,6 +47,7 @@ import {
   getHostedReviewLocalGitOptions,
   type HostedReviewExecutionOptions
 } from '../source-control/hosted-review-git-options'
+import { shouldHideNonOpenReviewOnDefaultBranch } from '../source-control/repo-default-branch'
 
 // Why: glab REST API addresses projects by URL-encoded path. Centralized
 // so call sites don't forget the slash escapes for nested groups.
@@ -346,7 +347,21 @@ export async function getMergeRequestForBranch(
         // Why: older GitLab list payloads expose `pipeline` instead of
         // `head_pipeline`, matching the detail endpoint compatibility path.
         const pipelineStatus = derivePipelineStatus(raw.head_pipeline ?? raw.pipeline ?? null)
-        return mapMRInfo(raw, pipelineStatus)
+        const info = mapMRInfo(raw, pipelineStatus)
+        // Why (#9171): discard a non-open implicit branch match on the repo
+        // default branch and fall through to the linked-iid fallback below.
+        const hideOnDefaultBranch = await shouldHideNonOpenReviewOnDefaultBranch({
+          state: info.state,
+          reviewNumber: info.number,
+          linkedReviewNumber: linkedMRIid,
+          branchName,
+          repoPath,
+          connectionId,
+          localGitOptions
+        })
+        if (!hideOnDefaultBranch) {
+          return info
+        }
       }
     }
     if (typeof linkedMRIid !== 'number') {

--- a/src/main/source-control/repo-default-branch.test.ts
+++ b/src/main/source-control/repo-default-branch.test.ts
@@ -126,7 +126,7 @@ describe('shouldHideNonOpenReviewOnDefaultBranch', () => {
   })
 
   it('never resolves the default branch for open or draft reviews (lazy)', async () => {
-    for (const state of ['open', 'opened', 'draft', 'locked']) {
+    for (const state of ['open', 'opened', 'draft']) {
       await expect(
         shouldHideNonOpenReviewOnDefaultBranch({
           state,
@@ -145,6 +145,19 @@ describe('shouldHideNonOpenReviewOnDefaultBranch', () => {
     await expect(
       shouldHideNonOpenReviewOnDefaultBranch({
         state: 'closed',
+        reviewNumber: 7,
+        branchName: 'master',
+        repoPath: '/repo'
+      })
+    ).resolves.toBe(true)
+  })
+
+  it('hides a stuck-locked review whose branch is the repo default branch', async () => {
+    primeLocalGitExec('refs/remotes/origin/master')
+
+    await expect(
+      shouldHideNonOpenReviewOnDefaultBranch({
+        state: 'locked',
         reviewNumber: 7,
         branchName: 'master',
         repoPath: '/repo'

--- a/src/main/source-control/repo-default-branch.test.ts
+++ b/src/main/source-control/repo-default-branch.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock, getSshGitProviderMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn(),
+  getSshGitProviderMock: vi.fn()
+}))
+
+vi.mock('../git/runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock
+}))
+
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: getSshGitProviderMock
+}))
+
+import {
+  getRepoDefaultBranchName,
+  shouldHideNonOpenReviewOnDefaultBranch,
+  __resetRepoDefaultBranchCacheForTests
+} from './repo-default-branch'
+
+function primeLocalGitExec(defaultRef = 'refs/remotes/origin/master'): void {
+  gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+    if (args[0] === 'symbolic-ref' && args.includes('refs/remotes/origin/HEAD')) {
+      return { stdout: `${defaultRef}\n`, stderr: '' }
+    }
+    if (args[0] === 'rev-parse' && args[1] === '--verify' && args.includes(defaultRef)) {
+      return { stdout: 'default-oid\n', stderr: '' }
+    }
+    throw new Error(`unexpected git call: ${args.join(' ')}`)
+  })
+}
+
+describe('getRepoDefaultBranchName', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+    getSshGitProviderMock.mockReset()
+    __resetRepoDefaultBranchCacheForTests()
+  })
+
+  it('resolves the default branch name locally, stripping the origin/ remote prefix', async () => {
+    primeLocalGitExec('refs/remotes/origin/master')
+
+    await expect(getRepoDefaultBranchName('/repo')).resolves.toBe('master')
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'],
+      // Why: the timeout keeps a dead filesystem from wedging the serial PR
+      // refresh drain — assert it stays armed on the local path.
+      { cwd: '/repo', timeout: expect.any(Number) }
+    )
+  })
+
+  it('forwards the WSL distro to the local git exec options', async () => {
+    primeLocalGitExec('refs/remotes/origin/main')
+
+    await expect(getRepoDefaultBranchName('/repo', null, { wslDistro: 'Ubuntu' })).resolves.toBe(
+      'main'
+    )
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'],
+      { cwd: '/repo', wslDistro: 'Ubuntu', timeout: expect.any(Number) }
+    )
+  })
+
+  it('routes resolution through the SSH provider exec and never local git', async () => {
+    const provider = {
+      exec: vi.fn(async (args: string[], repoPath: string) => {
+        expect(repoPath).toBe('/remote/repo')
+        if (args[0] === 'symbolic-ref') {
+          return { stdout: 'refs/remotes/origin/trunk\n' }
+        }
+        return { stdout: 'oid\n' }
+      })
+    }
+    getSshGitProviderMock.mockReturnValue(provider)
+
+    await expect(getRepoDefaultBranchName('/remote/repo', 'ssh-1')).resolves.toBe('trunk')
+    expect(getSshGitProviderMock).toHaveBeenCalledWith('ssh-1')
+    expect(provider.exec).toHaveBeenCalled()
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('returns null without running local git when the SSH provider is unavailable', async () => {
+    getSshGitProviderMock.mockReturnValue(undefined)
+
+    await expect(getRepoDefaultBranchName('/remote/repo', 'ssh-gone')).resolves.toBeNull()
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('returns null when no default branch is resolvable (fail open)', async () => {
+    gitExecFileAsyncMock.mockRejectedValue(new Error('fatal: not a git repository'))
+
+    await expect(getRepoDefaultBranchName('/repo')).resolves.toBeNull()
+  })
+
+  it('serves cached results within the TTL and re-executes after a reset', async () => {
+    primeLocalGitExec('refs/remotes/origin/master')
+
+    await expect(getRepoDefaultBranchName('/repo')).resolves.toBe('master')
+    const callsAfterFirst = gitExecFileAsyncMock.mock.calls.length
+    await expect(getRepoDefaultBranchName('/repo')).resolves.toBe('master')
+    expect(gitExecFileAsyncMock.mock.calls.length).toBe(callsAfterFirst)
+
+    __resetRepoDefaultBranchCacheForTests()
+    await expect(getRepoDefaultBranchName('/repo')).resolves.toBe('master')
+    expect(gitExecFileAsyncMock.mock.calls.length).toBeGreaterThan(callsAfterFirst)
+  })
+
+  it('scopes the cache per runtime so WSL and host resolutions do not collide', async () => {
+    primeLocalGitExec('refs/remotes/origin/master')
+    await expect(getRepoDefaultBranchName('/repo')).resolves.toBe('master')
+
+    primeLocalGitExec('refs/remotes/origin/main')
+    // Same repoPath, different runtime key → fresh resolution, not the host's.
+    await expect(getRepoDefaultBranchName('/repo', null, { wslDistro: 'Ubuntu' })).resolves.toBe(
+      'main'
+    )
+  })
+})
+
+describe('shouldHideNonOpenReviewOnDefaultBranch', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+    getSshGitProviderMock.mockReset()
+    __resetRepoDefaultBranchCacheForTests()
+  })
+
+  it('never resolves the default branch for open or draft reviews (lazy)', async () => {
+    for (const state of ['open', 'opened', 'draft', 'locked']) {
+      await expect(
+        shouldHideNonOpenReviewOnDefaultBranch({
+          state,
+          reviewNumber: 1,
+          branchName: 'master',
+          repoPath: '/repo'
+        })
+      ).resolves.toBe(false)
+    }
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('hides a closed review whose branch is the repo default branch', async () => {
+    primeLocalGitExec('refs/remotes/origin/master')
+
+    await expect(
+      shouldHideNonOpenReviewOnDefaultBranch({
+        state: 'closed',
+        reviewNumber: 7,
+        branchName: 'master',
+        repoPath: '/repo'
+      })
+    ).resolves.toBe(true)
+  })
+
+  it('keeps a closed review on a non-default branch', async () => {
+    primeLocalGitExec('refs/remotes/origin/master')
+
+    await expect(
+      shouldHideNonOpenReviewOnDefaultBranch({
+        state: 'closed',
+        reviewNumber: 7,
+        branchName: 'feature-x',
+        repoPath: '/repo'
+      })
+    ).resolves.toBe(false)
+  })
+
+  it('exempts the explicitly linked review without resolving the default branch', async () => {
+    await expect(
+      shouldHideNonOpenReviewOnDefaultBranch({
+        state: 'merged',
+        reviewNumber: 7,
+        linkedReviewNumber: 7,
+        branchName: 'master',
+        repoPath: '/repo'
+      })
+    ).resolves.toBe(false)
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('still hides a non-open shadow whose number differs from the linked review', async () => {
+    primeLocalGitExec('refs/remotes/origin/master')
+
+    await expect(
+      shouldHideNonOpenReviewOnDefaultBranch({
+        state: 'merged',
+        reviewNumber: 7,
+        linkedReviewNumber: 42,
+        branchName: 'master',
+        repoPath: '/repo'
+      })
+    ).resolves.toBe(true)
+  })
+
+  it('fails open when the default branch is unresolvable', async () => {
+    gitExecFileAsyncMock.mockRejectedValue(new Error('fatal: not a git repository'))
+
+    await expect(
+      shouldHideNonOpenReviewOnDefaultBranch({
+        state: 'closed',
+        reviewNumber: 7,
+        branchName: 'master',
+        repoPath: '/repo'
+      })
+    ).resolves.toBe(false)
+  })
+})

--- a/src/main/source-control/repo-default-branch.test.ts
+++ b/src/main/source-control/repo-default-branch.test.ts
@@ -76,8 +76,35 @@ describe('getRepoDefaultBranchName', () => {
 
     await expect(getRepoDefaultBranchName('/remote/repo', 'ssh-1')).resolves.toBe('trunk')
     expect(getSshGitProviderMock).toHaveBeenCalledWith('ssh-1')
-    expect(provider.exec).toHaveBeenCalled()
+    expect(provider.exec).toHaveBeenCalledWith(
+      ['symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'],
+      '/remote/repo',
+      { timeoutMs: expect.any(Number) }
+    )
     expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('shares one wall-clock timeout budget across all fallback probes', async () => {
+    let now = 1_000
+    const dateNow = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    gitExecFileAsyncMock.mockImplementation(async (_args, options: { timeout: number }) => {
+      now += options.timeout
+      throw new Error('git timed out.')
+    })
+
+    try {
+      await expect(getRepoDefaultBranchName('/repo')).resolves.toBeNull()
+
+      // Once the first probe consumes the budget, fallback refs fail open
+      // without spawning four more equally slow git processes.
+      expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+      expect(gitExecFileAsyncMock.mock.calls[0]?.[1]).toEqual({
+        cwd: '/repo',
+        timeout: 15_000
+      })
+    } finally {
+      dateNow.mockRestore()
+    }
   })
 
   it('returns null without running local git when the SSH provider is unavailable', async () => {

--- a/src/main/source-control/repo-default-branch.test.ts
+++ b/src/main/source-control/repo-default-branch.test.ts
@@ -133,6 +133,31 @@ describe('getRepoDefaultBranchName', () => {
     expect(gitExecFileAsyncMock.mock.calls.length).toBeGreaterThan(callsAfterFirst)
   })
 
+  it('coalesces concurrent resolutions for the same repo and runtime', async () => {
+    let releaseSymbolicRef: (() => void) | undefined
+    const symbolicRefGate = new Promise<void>((resolve) => {
+      releaseSymbolicRef = resolve
+    })
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'symbolic-ref') {
+        await symbolicRefGate
+        return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
+      }
+      if (args[0] === 'rev-parse') {
+        return { stdout: 'default-oid\n', stderr: '' }
+      }
+      throw new Error(`unexpected git call: ${args.join(' ')}`)
+    })
+
+    const first = getRepoDefaultBranchName('/repo')
+    const second = getRepoDefaultBranchName('/repo')
+    await vi.waitFor(() => expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1))
+    releaseSymbolicRef?.()
+
+    await expect(Promise.all([first, second])).resolves.toEqual(['main', 'main'])
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
   it('scopes the cache per runtime so WSL and host resolutions do not collide', async () => {
     primeLocalGitExec('refs/remotes/origin/master')
     await expect(getRepoDefaultBranchName('/repo')).resolves.toBe('master')

--- a/src/main/source-control/repo-default-branch.ts
+++ b/src/main/source-control/repo-default-branch.ts
@@ -1,0 +1,133 @@
+import { resolveDefaultBaseRefViaExec, resolveDefaultBaseRefWithLocalGit } from '../git/repo'
+import { getSshGitProvider } from '../providers/ssh-git-dispatch'
+import type { HostedReviewLocalGitOptions } from './hosted-review-git-options'
+
+// Why: bounded like TRACKED_UPSTREAM_SNAPSHOT_CACHE in github/client.ts — PR
+// refresh ticks re-ask per repo, and worktree churn can mint unbounded keys.
+const REPO_DEFAULT_BRANCH_CACHE_TTL_MS = 30_000
+const REPO_DEFAULT_BRANCH_CACHE_MAX_ENTRIES = 512
+
+type RepoDefaultBranchCacheEntry = {
+  expiresAt: number
+  branchName: string | null
+}
+
+const repoDefaultBranchCache = new Map<string, RepoDefaultBranchCacheEntry>()
+
+function getRepoDefaultBranchCacheKey(
+  repoPath: string,
+  connectionId?: string | null,
+  localGitOptions: HostedReviewLocalGitOptions = {}
+): string {
+  // Why: scope per executing git host (native/WSL/SSH) so hosts with
+  // different clones of the "same" path cannot cross-contaminate.
+  const runtimeKey = connectionId
+    ? `ssh:${connectionId}`
+    : `local:${localGitOptions.wslDistro ?? 'host'}`
+  return [runtimeKey, repoPath].join('\0')
+}
+
+function pruneRepoDefaultBranchCache(now: number): void {
+  for (const [key, entry] of repoDefaultBranchCache) {
+    if (entry.expiresAt <= now) {
+      repoDefaultBranchCache.delete(key)
+    }
+  }
+  while (repoDefaultBranchCache.size > REPO_DEFAULT_BRANCH_CACHE_MAX_ENTRIES) {
+    const oldestKey = repoDefaultBranchCache.keys().next().value
+    if (oldestKey === undefined) {
+      break
+    }
+    repoDefaultBranchCache.delete(oldestKey)
+  }
+}
+
+/**
+ * Resolve the repository's default branch NAME (`main`, `master`, …) over the
+ * transport the surrounding hosted-review call already uses. Returns null when
+ * unresolvable so callers fail open (#9171 guard skipped, current behavior).
+ */
+export async function getRepoDefaultBranchName(
+  repoPath: string,
+  connectionId?: string | null,
+  localGitOptions: HostedReviewLocalGitOptions = {}
+): Promise<string | null> {
+  const cacheKey = getRepoDefaultBranchCacheKey(repoPath, connectionId, localGitOptions)
+  const now = Date.now()
+  const cached = repoDefaultBranchCache.get(cacheKey)
+  if (cached && cached.expiresAt > now) {
+    return cached.branchName
+  }
+  let branchName: string | null = null
+  try {
+    const provider = connectionId ? getSshGitProvider(connectionId) : null
+    if (connectionId && !provider) {
+      // Why: a dropped SSH provider must not fall back to local git — the
+      // repoPath is remote, so a local run could answer for the wrong repo.
+      return null
+    }
+    // Why: the local/WSL path must stay probe-time-bounded — an unbounded git
+    // exec here would wedge the serial PR refresh drain on a dead filesystem.
+    const baseRef = provider
+      ? await resolveDefaultBaseRefViaExec((argv) => provider.exec(argv, repoPath))
+      : await resolveDefaultBaseRefWithLocalGit({
+          cwd: repoPath,
+          ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {})
+        })
+    // Same base-ref → branch-name normalization as git/repo.ts getRemoteFileUrl.
+    branchName = baseRef ? baseRef.replace(/^origin\//, '') : null
+  } catch {
+    branchName = null
+  }
+  // Why: null (failure or genuinely no default) is cached too — the resolver
+  // cannot tell them apart, and the short TTL bounds the fail-open window
+  // without re-probing git on every refresh tick.
+  pruneRepoDefaultBranchCache(now)
+  repoDefaultBranchCache.set(cacheKey, {
+    branchName,
+    expiresAt: now + REPO_DEFAULT_BRANCH_CACHE_TTL_MS
+  })
+  pruneRepoDefaultBranchCache(now)
+  return branchName
+}
+
+/**
+ * #9171 invariant, applied by every provider client at its branch-lookup choke
+ * point: an implicit branch-name match on the repository's default branch must
+ * never surface a non-open review. The explicitly linked review is exempt.
+ * Resolves the default branch lazily — only for non-open, non-linked results —
+ * so the common refresh path adds zero git calls.
+ */
+export async function shouldHideNonOpenReviewOnDefaultBranch(input: {
+  /** Provider-normalized review state ('closed' / 'merged' are the non-open terminal states). */
+  state: string
+  reviewNumber: number | null
+  linkedReviewNumber?: number | null
+  branchName: string
+  repoPath: string
+  connectionId?: string | null
+  localGitOptions?: HostedReviewLocalGitOptions
+}): Promise<boolean> {
+  if (input.state !== 'closed' && input.state !== 'merged') {
+    return false
+  }
+  if (
+    typeof input.linkedReviewNumber === 'number' &&
+    input.reviewNumber === input.linkedReviewNumber
+  ) {
+    return false
+  }
+  if (!input.branchName) {
+    return false
+  }
+  const defaultBranchName = await getRepoDefaultBranchName(
+    input.repoPath,
+    input.connectionId,
+    input.localGitOptions
+  )
+  return defaultBranchName !== null && input.branchName === defaultBranchName
+}
+
+export function __resetRepoDefaultBranchCacheForTests(): void {
+  repoDefaultBranchCache.clear()
+}

--- a/src/main/source-control/repo-default-branch.ts
+++ b/src/main/source-control/repo-default-branch.ts
@@ -15,6 +15,7 @@ type RepoDefaultBranchCacheEntry = {
 }
 
 const repoDefaultBranchCache = new Map<string, RepoDefaultBranchCacheEntry>()
+const repoDefaultBranchInFlight = new Map<string, Promise<string | null>>()
 
 function getRepoDefaultBranchCacheKey(
   repoPath: string,
@@ -60,45 +61,63 @@ export async function getRepoDefaultBranchName(
   if (cached && cached.expiresAt > now) {
     return cached.branchName
   }
-  let branchName: string | null = null
-  try {
-    const provider = connectionId ? getSshGitProvider(connectionId) : null
-    if (connectionId && !provider) {
-      // Why: a dropped SSH provider must not fall back to local git — the
-      // repoPath is remote, so a local run could answer for the wrong repo.
-      return null
-    }
-    const resolutionDeadline = Date.now() + REPO_DEFAULT_BRANCH_RESOLUTION_BUDGET_MS
-    // Why: the resolver can try five refs; share one deadline so an unhealthy
-    // local/WSL/SSH host cannot multiply the refresh delay per fallback probe.
-    const baseRef = await resolveDefaultBaseRefViaExec((argv) => {
-      const timeoutMs = resolutionDeadline - Date.now()
-      if (timeoutMs <= 0) {
-        return Promise.reject(new Error('Default branch resolution timed out.'))
-      }
-      return provider
-        ? provider.exec(argv, repoPath, { timeoutMs })
-        : gitExecFileAsync(argv, {
-            cwd: repoPath,
-            ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {}),
-            timeout: timeoutMs
-          })
-    })
-    // Same base-ref → branch-name normalization as git/repo.ts getRemoteFileUrl.
-    branchName = baseRef ? baseRef.replace(/^origin\//, '') : null
-  } catch {
-    branchName = null
+  const pending = repoDefaultBranchInFlight.get(cacheKey)
+  if (pending) {
+    return pending
   }
-  // Why: null (failure or genuinely no default) is cached too — the resolver
-  // cannot tell them apart, and the short TTL bounds the fail-open window
-  // without re-probing git on every refresh tick.
-  pruneRepoDefaultBranchCache(now)
-  repoDefaultBranchCache.set(cacheKey, {
-    branchName,
-    expiresAt: now + REPO_DEFAULT_BRANCH_CACHE_TTL_MS
-  })
-  pruneRepoDefaultBranchCache(now)
-  return branchName
+
+  // Why: simultaneous refresh paths for one checkout should share the same
+  // Git/SSH subprocess chain instead of multiplying cold-cache probes.
+  const resolution = (async (): Promise<string | null> => {
+    let branchName: string | null = null
+    try {
+      const provider = connectionId ? getSshGitProvider(connectionId) : null
+      if (connectionId && !provider) {
+        // Why: a dropped SSH provider must not fall back to local git — the
+        // repoPath is remote, so a local run could answer for the wrong repo.
+        return null
+      }
+      const resolutionDeadline = Date.now() + REPO_DEFAULT_BRANCH_RESOLUTION_BUDGET_MS
+      // Why: the resolver can try five refs; share one deadline so an unhealthy
+      // local/WSL/SSH host cannot multiply the refresh delay per fallback probe.
+      const baseRef = await resolveDefaultBaseRefViaExec((argv) => {
+        const timeoutMs = resolutionDeadline - Date.now()
+        if (timeoutMs <= 0) {
+          return Promise.reject(new Error('Default branch resolution timed out.'))
+        }
+        return provider
+          ? provider.exec(argv, repoPath, { timeoutMs })
+          : gitExecFileAsync(argv, {
+              cwd: repoPath,
+              ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {}),
+              timeout: timeoutMs
+            })
+      })
+      // Same base-ref → branch-name normalization as git/repo.ts getRemoteFileUrl.
+      branchName = baseRef ? baseRef.replace(/^origin\//, '') : null
+    } catch {
+      branchName = null
+    }
+    const completedAt = Date.now()
+    // Why: null (failure or genuinely no default) is cached too — the resolver
+    // cannot tell them apart, and the short TTL bounds the fail-open window
+    // without re-probing git on every refresh tick.
+    pruneRepoDefaultBranchCache(completedAt)
+    repoDefaultBranchCache.set(cacheKey, {
+      branchName,
+      expiresAt: completedAt + REPO_DEFAULT_BRANCH_CACHE_TTL_MS
+    })
+    pruneRepoDefaultBranchCache(completedAt)
+    return branchName
+  })()
+  repoDefaultBranchInFlight.set(cacheKey, resolution)
+  try {
+    return await resolution
+  } finally {
+    if (repoDefaultBranchInFlight.get(cacheKey) === resolution) {
+      repoDefaultBranchInFlight.delete(cacheKey)
+    }
+  }
 }
 
 /**
@@ -142,4 +161,5 @@ export async function shouldHideNonOpenReviewOnDefaultBranch(input: {
 
 export function __resetRepoDefaultBranchCacheForTests(): void {
   repoDefaultBranchCache.clear()
+  repoDefaultBranchInFlight.clear()
 }

--- a/src/main/source-control/repo-default-branch.ts
+++ b/src/main/source-control/repo-default-branch.ts
@@ -1,4 +1,5 @@
-import { resolveDefaultBaseRefViaExec, resolveDefaultBaseRefWithLocalGit } from '../git/repo'
+import { resolveDefaultBaseRefViaExec } from '../git/repo'
+import { gitExecFileAsync } from '../git/runner'
 import { getSshGitProvider } from '../providers/ssh-git-dispatch'
 import type { HostedReviewLocalGitOptions } from './hosted-review-git-options'
 
@@ -6,6 +7,7 @@ import type { HostedReviewLocalGitOptions } from './hosted-review-git-options'
 // refresh ticks re-ask per repo, and worktree churn can mint unbounded keys.
 const REPO_DEFAULT_BRANCH_CACHE_TTL_MS = 30_000
 const REPO_DEFAULT_BRANCH_CACHE_MAX_ENTRIES = 512
+const REPO_DEFAULT_BRANCH_RESOLUTION_BUDGET_MS = 15_000
 
 type RepoDefaultBranchCacheEntry = {
   expiresAt: number
@@ -66,14 +68,22 @@ export async function getRepoDefaultBranchName(
       // repoPath is remote, so a local run could answer for the wrong repo.
       return null
     }
-    // Why: the local/WSL path must stay probe-time-bounded — an unbounded git
-    // exec here would wedge the serial PR refresh drain on a dead filesystem.
-    const baseRef = provider
-      ? await resolveDefaultBaseRefViaExec((argv) => provider.exec(argv, repoPath))
-      : await resolveDefaultBaseRefWithLocalGit({
-          cwd: repoPath,
-          ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {})
-        })
+    const resolutionDeadline = Date.now() + REPO_DEFAULT_BRANCH_RESOLUTION_BUDGET_MS
+    // Why: the resolver can try five refs; share one deadline so an unhealthy
+    // local/WSL/SSH host cannot multiply the refresh delay per fallback probe.
+    const baseRef = await resolveDefaultBaseRefViaExec((argv) => {
+      const timeoutMs = resolutionDeadline - Date.now()
+      if (timeoutMs <= 0) {
+        return Promise.reject(new Error('Default branch resolution timed out.'))
+      }
+      return provider
+        ? provider.exec(argv, repoPath, { timeoutMs })
+        : gitExecFileAsync(argv, {
+            cwd: repoPath,
+            ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {}),
+            timeout: timeoutMs
+          })
+    })
     // Same base-ref → branch-name normalization as git/repo.ts getRemoteFileUrl.
     branchName = baseRef ? baseRef.replace(/^origin\//, '') : null
   } catch {

--- a/src/main/source-control/repo-default-branch.ts
+++ b/src/main/source-control/repo-default-branch.ts
@@ -99,7 +99,7 @@ export async function getRepoDefaultBranchName(
  * so the common refresh path adds zero git calls.
  */
 export async function shouldHideNonOpenReviewOnDefaultBranch(input: {
-  /** Provider-normalized review state ('closed' / 'merged' are the non-open terminal states). */
+  /** Provider-normalized review state; 'closed' / 'merged' / 'locked' count as non-open. */
   state: string
   reviewNumber: number | null
   linkedReviewNumber?: number | null
@@ -108,7 +108,9 @@ export async function shouldHideNonOpenReviewOnDefaultBranch(input: {
   connectionId?: string | null
   localGitOptions?: HostedReviewLocalGitOptions
 }): Promise<boolean> {
-  if (input.state !== 'closed' && input.state !== 'merged') {
+  // Why: GitLab 'locked' is non-open too — normally a seconds-long merge
+  // transition, but a stuck-locked trunk MR would otherwise attach forever.
+  if (input.state !== 'closed' && input.state !== 'merged' && input.state !== 'locked') {
     return false
   }
   if (


### PR DESCRIPTION
Fixes #9171.

**What changes:** When the repository's default branch (e.g. `master`/`main`) is checked out, Orca no longer attaches a historical **closed or merged** PR/MR whose head ref happened to be the default branch name — so its wrong diffs and checks no longer appear in Source Control, the Checks tab, or the sidebar badge. **What does not change:** a genuinely **open** PR/MR whose head is the default branch stays visible, explicitly linked reviews are never hidden, and behavior on feature branches is untouched (closed PRs there still show; the merged-at-head carve-out still applies). **How validated:** a flipped regression test driving the real production lookup + real default-branch resolver, per-provider unit tests, and a live A/B against real GitHub remotes that reproduced the bug with the guard disabled and confirmed the fix with it enabled.

## Root cause

`getPRForBranchOutcome` resolved a PR for a checkout purely by head-branch name with `state=all` and no default-branch awareness; the only implicit filter hid merged PRs, so a closed-unmerged PR whose head was the trunk slipped through and attached to the default-branch checkout. The same list-first, any-state lookup shape exists in the GitLab, Bitbucket, Azure DevOps, and Gitea clients.

## Design approach

One invariant, applied at each provider client's branch-lookup choke point: an implicit branch-name match on the repository's default branch never surfaces a non-open review. A new shared module `src/main/source-control/repo-default-branch.ts` resolves the repo's default branch name through the existing `resolveDefaultBaseRefViaExec` (same source of truth as worktree creation) over the transport the surrounding call already uses (local / WSL / SSH), with a bounded 30s TTL cache, probe timeouts, and fail-open on unresolvable. Resolution is lazy — the state check runs first, so open results, linked reviews, and detached HEAD add **zero** git calls. The guard lives in the clients (not the forge layer) because the PR refresh coordinator and several IPC/runtime paths call the clients directly. On GitHub the guard also covers the persisted fallback-number path, so installs already showing the stale PR self-heal on the next refresh, and it overrides the merged-fallback preservation and merged-at-head carve-out on the trunk only.

## Pipeline results (Brennan's PR process)

- **Design review:** 3 iterations + an adversarial design challenge; final round clean on both reviewers. The challenge's forge-layer alternative was rejected on verified evidence (direct client call sites bypass it). Review expanded provider coverage from 2 to all 5 providers.
- **Implementation:** matches the reviewed design; two judgment calls (no local-git fallback when an SSH provider is gone — safer than answering for the wrong repo; null resolutions cached for the short TTL).
- **Completeness verification:** COMPLETE, no blockers; five advisory notes, all triaged (one produced the extra Azure test below).
- **Headline behavior:** **implemented** — all five providers guarded, self-heal covered, negative proof done (guard reverted → 14 tests fail across all providers; restored → green).
- **Perf audit:** one finding, fixed — the default-branch resolver could multiply its per-probe timeout across five fallback probes and wedge the serial PR-refresh drain for 75s locally/under WSL or 150s over SSH; the entire resolution now shares one 15s wall-clock budget, with a deterministic subprocess-count test (1 spawn after budget exhaustion, not 5). Verified non-findings: lazy ordering is real (zero-git assertions in tests), worst-case added subprocess load ≤ ~0.33 spawns/sec under the background budget, cache bounded (512 entries), no startup cost.
- **Code-review loop:** four independent review lanes across two rounds of reviewers — two CLEAN (with revert-checks proving 14 tests bite across all five providers, plus shuffled-seed runs), two no-P0/P1. Actionable residue: a test-parity nit (Azure discard-then-linked-fallback test, added) and the GitLab `locked` leak (reproduced by one lane; fixed in a follow-up commit with shared-module and GitLab client tests). The remaining P2 is the single-slot shadow non-goal below.
- **Merge-confidence validation:** verdict **land**. Mutation probes confirmed every guard test bites and behavior-preservation tests pass with the guard disabled. Live A/B: a public repo with the exact bug shape (default branch `master`, historical closed PR `#523` from it) returned that stale PR through the real production lookup with the guard disabled, and `no-pr` with it enabled; a second public repo with a real open PR from `master` stayed visible in both configurations.

## Risks, ambiguities, and non-goals

- **Interpretation surfaced for review:** the issue repro notes read "no PR on the trunk"; this fix implements "no *stale* PR on the trunk" — an open PR whose head is the default branch (e.g. trunk → release) remains visible. If the stricter reading is wanted, the guard's state check drops to unconditional (one line).
- **GitLab `locked` MRs are hidden on the trunk** (decided in review): `locked` is normally a seconds-long merge transition, but stuck-locked MRs are a known GitLab pathology and would otherwise re-create the bug; three review lanes flagged it and one reproduced the leak. A legitimately merging trunk MR just hides moments earlier than its `merged` state would have.
- **Single-slot shadow (non-goal):** every provider's branch query effectively takes one candidate, so a newer closed PR can shadow an older open one; the guard then hides the shadow and shows nothing instead of the open PR. Not a regression (previously the closed PR's wrong diffs showed and the open PR was equally invisible); fixing it needs an open-state re-query and is left as a follow-up.
- **State-transition chip loss on trunk:** a trunk-implicit PR that closes/merges while visible now disappears rather than flipping to a closed/merged chip.
- **Default-branch rename:** convergence bounded by local `origin/HEAD` (fails open on the new name — no new harm; converges after re-clone or `git remote set-head -a`).

## Validation

- New/updated tests: `src/main/github/default-branch-stale-pr.test.ts` (8 — hide/keep-open/feature-branch/carve-out/fallback-self-heal/preservation-override/fail-open, driving the real resolver via git-exec-layer mocks), `src/main/source-control/repo-default-branch.test.ts` (14 — transports, WSL, SSH, shared timeout budget, TTL cache, scoping, predicate), plus per-provider cases in the GitLab (+5), Bitbucket (+3), Azure DevOps (+3), Gitea (+3) client suites and a narrowed assertion in the GitHub client suite.
- `pnpm exec vitest run --config config/vitest.config.ts` over all touched suites: 58 files / 726 tests green (also green under shuffled test order, two seeds). `pnpm typecheck` clean; oxlint clean; max-lines ratchet clean.
- **Live Electron smoke (macOS):** launched this branch in a real dev Electron window and opened the persisted `main` / `primary` workspace. Source Control showed **Create PR** (not historical review state), and Checks settled to **No pull request found** after a real GitHub refresh. The exact historical closed-trunk fixture remains covered by the production-lookup regression test and the live API A/B above.
- SSH/remote path is unit-tested (provider-exec routing, provider-gone fail-open); not exercised against a live SSH host.


## Live Electron screenshots

Source Control on the default branch shows **Create PR** and normal local changes:

![Source Control on main showing Create PR](https://github.com/user-attachments/assets/c904dbe7-4818-4d61-b128-bf69a9cf2691)

Checks settles to **No pull request found** for the same `main` / `primary` workspace:

![Checks on main showing no pull request found](https://github.com/user-attachments/assets/ee4a5304-b053-4d1e-9fbc-f94b934efdfb)
