### PR TITLE
fix(terminal): surface remote new-terminal failures (possible #9464)

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1535,12 +1535,23 @@ function Terminal(): React.JSX.Element | null {
         useAppStore.getState().groupsByWorktree[activeWorktreeId]?.[0]?.id
       const runtimeEnvironmentId = getActiveWorktreeRuntimeEnvironmentId(activeWorktreeId)
       if (isWebRuntimeSessionActive(runtimeEnvironmentId)) {
+        // Why: remote-owned tabs are host-authoritative; a failed host create
+        // must not look like a dead click (issue #9464).
         void createWebRuntimeSessionTerminal({
           worktreeId: activeWorktreeId,
           environmentId: runtimeEnvironmentId,
           targetGroupId,
           command: shellOverride,
           activate: true
+        }).then((created) => {
+          if (!created) {
+            toast.error(
+              translate(
+                'auto.components.Terminal.remote_terminal_create_failed',
+                'Could not create a new terminal on the remote server.'
+              )
+            )
+          }
         })
         return
       }

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1544,14 +1544,18 @@ function Terminal(): React.JSX.Element | null {
           command: shellOverride,
           activate: true
         }).then((created) => {
-          if (!created) {
-            toast.error(
-              translate(
-                'auto.components.Terminal.remote_terminal_create_failed',
-                'Could not create a new terminal on the remote server.'
-              )
-            )
+          if (created) {
+            // Why: local createTab records this; remote host create must too
+            // so feature-discovery telemetry stays consistent across entry points.
+            useAppStore.getState().recordFeatureInteraction?.('terminal-tabs')
+            return
           }
+          toast.error(
+            translate(
+              'auto.components.Terminal.remote_terminal_create_failed',
+              'Could not create a new terminal on the remote server.'
+            )
+          )
         })
         return
       }

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -669,6 +669,19 @@ export function useTabGroupWorkspaceModel({
           if (outcome.status === 'created' || isWebRuntimeSessionActive(environmentId)) {
             return
           }
+          // Why: remote-owned workspaces stay host-owned. Local shell fallback after
+          // a failed host create is a silent no-op or ghost tab (issue #9464).
+          if (environmentId) {
+            const { toast } = await import('sonner')
+            const { translate } = await import('@/i18n/i18n')
+            toast.error(
+              translate(
+                'auto.components.tab.group.remote_terminal_create_failed',
+                'Could not create a new terminal on the remote server.'
+              )
+            )
+            return
+          }
           const terminal = createTab(worktreeId, groupId, shellOverride)
           setActiveTab(terminal.id)
           setActiveTabType('terminal')

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -667,6 +667,11 @@ export function useTabGroupWorkspaceModel({
             activate: true
           })
           if (outcome.status === 'created' || isWebRuntimeSessionActive(environmentId)) {
+            if (outcome.status === 'created') {
+              // Why: local createTab records this; remote host create must too
+              // so feature-discovery telemetry stays consistent across entry points.
+              useAppStore.getState().recordFeatureInteraction?.('terminal-tabs')
+            }
             return
           }
           // Why: remote-owned workspaces stay host-owned. Local shell fallback after

--- a/src/renderer/src/hooks/ipc-events-terminal-create-test-harness.ts
+++ b/src/renderer/src/hooks/ipc-events-terminal-create-test-harness.ts
@@ -172,6 +172,9 @@ export async function setupTerminalCreateSurfacing(
   vi.doMock('@/lib/zoom-events', () => ({
     dispatchZoomLevelChanged: vi.fn()
   }))
+  vi.doMock('sonner', () => ({
+    toast: { error: vi.fn(), success: vi.fn(), message: vi.fn() }
+  }))
   vi.doMock('@/lib/floating-workspace-terminal-actions', () => ({
     createFloatingWorkspaceTerminalTab,
     isEmptyFloatingWorkspacePanelVisible: () => false,

--- a/src/renderer/src/hooks/useIpcEvents-terminal-create-surfacing.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents-terminal-create-surfacing.test.ts
@@ -44,6 +44,23 @@ describe('useIpcEvents updater integration', () => {
     expect(createTab).toHaveBeenCalledWith('wt-1')
     expect(setActiveTabType).toHaveBeenCalledWith('terminal')
 
+    // Why: issue #9464 — when the worktree is remote-owned and host create fails,
+    // do not fall through to a local createTab (silent no-op / ghost tab).
+    createWebRuntimeSessionTerminal.mockClear()
+    createTab.mockClear()
+    setActiveTabType.mockClear()
+    storeState.repos = [{ id: 'repo-1', connectionId: null, executionHostId: 'runtime:remote-env-1' }]
+    newTerminalTabListenerRef.current()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(createWebRuntimeSessionTerminal).toHaveBeenCalledWith({
+      worktreeId: 'wt-1',
+      environmentId: 'remote-env-1',
+      activate: true
+    })
+    expect(createTab).not.toHaveBeenCalled()
+    storeState.repos = [{ id: 'repo-1', connectionId: null, executionHostId: 'local' }]
+
     // Exact regression sequence: Local default -> connect/navigate Windows 2 ->
     // reveal a local terminal -> restart. Connection and navigation are transient.
     storeState.repos.push({

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2558,6 +2558,11 @@ export function useIpcEvents(): void {
             activate: true
           })
           if (outcome.status === 'created' || isWebRuntimeSessionActive(environmentId)) {
+            if (outcome.status === 'created') {
+              // Why: local createTab records this; remote host create must too
+              // so feature-discovery telemetry stays consistent across entry points.
+              useAppStore.getState().recordFeatureInteraction?.('terminal-tabs')
+            }
             return
           }
           // Why: remote-owned workspaces must stay host-owned. A failed host create

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2560,6 +2560,19 @@ export function useIpcEvents(): void {
           if (outcome.status === 'created' || isWebRuntimeSessionActive(environmentId)) {
             return
           }
+          // Why: remote-owned workspaces must stay host-owned. A failed host create
+          // used to fall through to a local tab that either never spawned or was
+          // wiped by the next session snapshot — looking like a silent no-op
+          // (issue #9464). Surface the failure instead.
+          if (environmentId) {
+            toast.error(
+              translate(
+                'auto.hooks.useIpcEvents.remote_terminal_create_failed',
+                'Could not create a new terminal on the remote server.'
+              )
+            )
+            return
+          }
           const newTab = store.createTab(worktreeId)
           store.setActiveTabType('terminal')
           // Why: mirror Terminal.tsx handleNewTab so a new tab appends at the end, not index 0, when tabBarOrder is unset.

--- a/src/renderer/src/store/slices/cmd-j-create-actions.test.ts
+++ b/src/renderer/src/store/slices/cmd-j-create-actions.test.ts
@@ -10,10 +10,15 @@ import {
 
 const createWebRuntimeSessionBrowserTabMock = vi.hoisted(() => vi.fn())
 const createWebRuntimeSessionTerminalMock = vi.hoisted(() => vi.fn())
+const toastErrorMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@/runtime/web-runtime-session', () => ({
   createWebRuntimeSessionBrowserTab: createWebRuntimeSessionBrowserTabMock,
   createWebRuntimeSessionTerminal: createWebRuntimeSessionTerminalMock
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: toastErrorMock, success: vi.fn(), message: vi.fn() }
 }))
 
 vi.mock('@/lib/focus-terminal-tab-surface', () => ({
@@ -62,6 +67,7 @@ describe('Cmd+J lifted creation actions', () => {
     pairedWebFlag.__ORCA_WEB_CLIENT__ = true
     createWebRuntimeSessionBrowserTabMock.mockReset()
     createWebRuntimeSessionTerminalMock.mockReset()
+    toastErrorMock.mockReset()
   })
 
   afterEach(() => {
@@ -189,6 +195,8 @@ describe('Cmd+J lifted creation actions', () => {
       activate: true
     })
     expect(store.getState().tabsByWorktree['wt-1'] ?? []).toEqual([])
+    // Why: issue #9464 — remote create failure must be visible, not a dead click.
+    expect(toastErrorMock).toHaveBeenCalled()
   })
 
   it('does not create a local folder terminal while paired ownership is unresolved', async () => {
@@ -274,6 +282,22 @@ describe('Cmd+J lifted creation actions', () => {
       targetGroupId: 'group-1',
       activate: true
     })
+    expect(store.getState().tabsByWorktree['wt-1'] ?? []).toEqual([])
+    expect(toastErrorMock).toHaveBeenCalled()
+  })
+
+  it('records interaction when remote terminal creation succeeds', async () => {
+    createWebRuntimeSessionTerminalMock.mockResolvedValue(true)
+    const store = createTestStore()
+    seedActiveWorkspace(store)
+    const recordFeatureInteraction = vi.fn()
+    store.setState({ recordFeatureInteraction })
+
+    await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
+
+    expect(createWebRuntimeSessionTerminalMock).toHaveBeenCalled()
+    expect(recordFeatureInteraction).toHaveBeenCalledWith('terminal-tabs')
+    expect(toastErrorMock).not.toHaveBeenCalled()
     expect(store.getState().tabsByWorktree['wt-1'] ?? []).toEqual([])
   })
 

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -1518,13 +1518,41 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       ? worktreeRoute.route.runtimeEnvironmentId
       : getRuntimeEnvironmentIdForWorktree(state, worktreeId)
     if (runtimeEnvironmentId) {
+      // Why: remote-owned workspaces are host-authoritative. Never fall back to a
+      // local tab (split ownership / silent ghost tabs — issue #5321 / #9464).
+      // Surface failure so Cmd+T / "+" is not a silent no-op when the host RPC fails.
       const { createWebRuntimeSessionTerminal } = await import('@/runtime/web-runtime-session')
-      await createWebRuntimeSessionTerminal({
-        worktreeId,
-        environmentId: runtimeEnvironmentId,
-        targetGroupId: groupId,
-        activate: true
-      })
+      const { toast } = await import('sonner')
+      const { translate } = await import('@/i18n/i18n')
+      try {
+        const created = await createWebRuntimeSessionTerminal({
+          worktreeId,
+          environmentId: runtimeEnvironmentId,
+          targetGroupId: groupId,
+          activate: true
+        })
+        if (created) {
+          get().recordFeatureInteraction?.('terminal-tabs')
+          return
+        }
+        toast.error(
+          translate(
+            'auto.store.slices.terminals.remote_terminal_create_failed',
+            'Could not create a new terminal on the remote server.'
+          )
+        )
+      } catch (error) {
+        console.warn(
+          '[terminals] remote terminal tab creation failed:',
+          error instanceof Error ? error.message : String(error)
+        )
+        toast.error(
+          translate(
+            'auto.store.slices.terminals.remote_terminal_create_failed',
+            'Could not create a new terminal on the remote server.'
+          )
+        )
+      }
       return
     }
     if (isWebClientLocation() && worktreeId !== FLOATING_TERMINAL_WORKTREE_ID) {


### PR DESCRIPTION
## Summary

Possible mitigation for [#9464](https://github.com/stablyai/orca/issues/9464): on **Remote Orca Server** workspaces, failed host-owned terminal creation no longer fails silently.

**User-visible change**
- `+` / Cmd-T / shell picker / menu new-terminal on a remote-owned worktree: if `session.tabs.createTerminal` fails, show an error toast instead of a dead click.
- Do not fall back to a local-only tab when the worktree is remote-owned (avoids ghost tabs / ownership split).
- Successful remote creates record the same terminal-tabs feature interaction as local creates.

### Investigation notes (could not fully reproduce)

We **could not reproduce** the reported silent UI failure on current desktop (1.4.147-rc.0) + Mac Mini remote:

| Check | Result |
|--------|--------|
| Host `session.tabs.createTerminal` / CLI `terminal.create` | Works |
| UI: Mac Mini active, open server-routed `foia-scrapers`, Cmd-T | New terminal tabs appear (UI tab count and remote PTY count increase) |

Host create itself is healthy in that environment. The code path still **silently returned** on host-create failure (`console.warn` only, no toast, and some entry points fell through to a local `createTab`). That matches the *feel* of #9464 if/when the host RPC fails, and is unsafe regardless of repro.

This PR hardens that path. It is **not** claimed as a proven root-cause fix of an unreproduced silent-no-request failure.

Fixes #9464

## Test plan

- [x] Unit: `cmd-j-create-actions.test.ts` (toast + no local fallback + success interaction)
- [x] Unit: `useIpcEvents.test.ts` (remote env: no local createTab after failed host create)
- [x] Unit: `web-runtime-session.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] Targeted oxlint on changed files
- [ ] Manual: Remote Orca Server workspace → force host create failure (disconnect) → confirm toast, no local ghost tab
- [ ] Manual: Remote workspace healthy → Cmd-T / `+` → new host terminal still works

## AI agent review summary

- **Cross-platform:** Toast + remote ownership guard only; no platform-specific shortcuts beyond existing paths.
- **SSH/remote:** Explicitly scoped to runtime-owned worktrees; local/SSH fallbacks unchanged when no runtime environment id.
- **Agent/integration:** Agent launch already toasted on web-host failure; this aligns manual new-terminal entry points.
- **Performance:** Negligible (toast + return).
- **UI quality:** Surfaces failure instead of silent no-op; STYLEGUIDE-neutral (existing sonner toast pattern).
- **Security:** No new trust boundaries; host remains authoritative for remote tabs.

## ELI5

On a remote Orca Server, creating a new terminal could fail with no feedback — a dead click. Failures now show an error toast, and Orca will not open a local ghost tab that is not owned by the remote host.
