### PR TITLE
fix(cli): prevent Windows PATH status timeouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ out/
 /build/
 release/
 native/**/.build/
+graphify-out/
 
 # pnpm
 .pnpm-store/

--- a/src/main/cli/cli-installer.test.ts
+++ b/src/main/cli/cli-installer.test.ts
@@ -11,9 +11,7 @@ import {
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-
-const execFileMock = vi.hoisted(() => vi.fn())
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('electron', () => ({
   app: {
@@ -21,10 +19,6 @@ vi.mock('electron', () => ({
     getPath: () => tmpdir(),
     getAppPath: () => tmpdir()
   }
-}))
-
-vi.mock('node:child_process', () => ({
-  execFile: execFileMock
 }))
 
 import { CliInstaller } from './cli-installer'
@@ -55,10 +49,6 @@ async function createPackagedMacLauncher(root: string): Promise<string> {
 }
 
 describe('CliInstaller', () => {
-  beforeEach(() => {
-    execFileMock.mockReset()
-  })
-
   afterEach(() => {
     vi.useRealTimers()
     vi.restoreAllMocks()
@@ -428,36 +418,27 @@ describe('CliInstaller', () => {
     }
   )
 
-  it('settles when the Windows PATH query hangs', async () => {
-    vi.useFakeTimers()
+  it('reports an unavailable Windows PATH source without rejecting status', async () => {
     const fixture = await makeFixture()
     const installPath = join(fixture.root, 'Programs', 'Orca', 'bin', 'orca.cmd')
-    const killMock = vi.fn()
-    execFileMock.mockImplementation(() => ({ kill: killMock }))
     const installer = new CliInstaller({
       platform: 'win32',
       isPackaged: false,
       userDataPath: fixture.userDataPath,
       execPath: 'C:\\Users\\me\\AppData\\Local\\Orca\\Orca.exe',
       appPath: fixture.appPath,
-      commandPathOverride: installPath
+      commandPathOverride: installPath,
+      userPathReader: async () => {
+        throw new Error('Windows PATH command timed out after 5000ms.')
+      }
     })
 
-    const promise = installer.getStatus()
-    let settled = false
-    void promise
-      .catch(() => undefined)
-      .finally(() => {
-        settled = true
-      })
-
-    await vi.waitFor(() => expect(execFileMock).toHaveBeenCalled())
-    await vi.advanceTimersByTimeAsync(5_000)
-    await Promise.resolve()
-
-    expect(settled).toBe(true)
-    await expect(promise).rejects.toThrow('Windows PATH command timed out')
-    expect(killMock).toHaveBeenCalled()
+    await expect(installer.getStatus()).resolves.toMatchObject({
+      pathConfigured: false,
+      pathConfigurationError: 'Windows PATH command timed out after 5000ms.',
+      detail: 'Orca could not verify your user PATH. Refresh to try again.'
+    })
+    await expect(installer.install()).rejects.toThrow('Windows PATH command timed out')
   })
 
   // Why: this test creates a Unix symlink to /tmp/not-orca, which only applies on macOS/Linux.

--- a/src/main/cli/cli-installer.ts
+++ b/src/main/cli/cli-installer.ts
@@ -18,6 +18,7 @@ import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:pat
 import { promisify } from 'node:util'
 import type { CliInstallMethod, CliInstallStatus } from '../../shared/cli-install-types'
 import { buildAppImageCliWrapper } from './appimage-cli-wrapper'
+import { readWindowsUserPath, writeWindowsUserPath } from './windows-user-path'
 
 const execFileAsync = promisify(execFile)
 const DEFAULT_MAC_COMMAND_PATH = '/usr/local/bin/orca'
@@ -25,7 +26,10 @@ const DEV_COMMAND_NAME = 'orca-dev'
 const LINUX_COMMAND_NAME = 'orca-ide'
 const LEGACY_LINUX_COMMAND_NAME = 'orca'
 const DEV_LAUNCHER_DIR = ['cli', 'bin']
-const WINDOWS_PATH_COMMAND_TIMEOUT_MS = 5_000
+
+type GetStatusOptions = {
+  failOnPathReadError?: boolean
+}
 
 type CliInstallerOptions = {
   platform?: NodeJS.Platform
@@ -113,7 +117,7 @@ export class CliInstaller {
         : null
   }
 
-  async getStatus(): Promise<CliInstallStatus> {
+  async getStatus(options: GetStatusOptions = {}): Promise<CliInstallStatus> {
     const defaultSpec = this.resolveInstallSpec()
     if (!defaultSpec) {
       return {
@@ -164,12 +168,24 @@ export class CliInstaller {
           ? await this.inspectAppImageWrapper(spec.commandPath, launcherPath)
           : await this.inspectWindowsWrapper(spec.commandPath, launcherPath)
     const pathDirectory = dirname(spec.commandPath)
-    const pathConfigured = await this.isPathConfigured(pathDirectory)
-    return this.withPathInfo(baseStatus, pathDirectory, pathConfigured)
+    try {
+      const pathConfigured = await this.isPathConfigured(pathDirectory)
+      return this.withPathInfo(baseStatus, pathDirectory, pathConfigured)
+    } catch (error) {
+      if (options.failOnPathReadError) {
+        throw error
+      }
+      // Why: status is advisory UI data; an unavailable PATH source must not reject Settings IPC.
+      return {
+        ...this.withPathInfo(baseStatus, pathDirectory, false),
+        pathConfigurationError: error instanceof Error ? error.message : String(error),
+        detail: 'Orca could not verify your user PATH. Refresh to try again.'
+      }
+    }
   }
 
   async install(): Promise<CliInstallStatus> {
-    const status = await this.getStatus()
+    const status = await this.getStatus({ failOnPathReadError: true })
     if (!status.supported || !status.commandPath || !status.launcherPath || !status.installMethod) {
       throw new Error(status.detail ?? 'CLI registration is unavailable on this build.')
     }
@@ -203,11 +219,11 @@ export class CliInstaller {
       await this.ensureWindowsPathEntry(dirname(status.commandPath))
     }
 
-    return this.getStatus()
+    return this.getStatus({ failOnPathReadError: true })
   }
 
   async remove(): Promise<CliInstallStatus> {
-    const status = await this.getStatus()
+    const status = await this.getStatus({ failOnPathReadError: true })
     if (!status.supported || !status.commandPath || !status.launcherPath || !status.installMethod) {
       return status
     }
@@ -215,7 +231,7 @@ export class CliInstaller {
       await this.removeLegacyLinuxCommandIfManaged(status.launcherPath)
       if (this.platform === 'win32') {
         await this.removeWindowsPathEntry(dirname(status.commandPath))
-        return this.getStatus()
+        return this.getStatus({ failOnPathReadError: true })
       }
       return status
     }
@@ -236,7 +252,7 @@ export class CliInstaller {
       await this.removeWindowsPathEntry(dirname(status.commandPath))
     }
 
-    return this.getStatus()
+    return this.getStatus({ failOnPathReadError: true })
   }
 
   private resolveInstallSpec(): InstallSpec | null {
@@ -1106,72 +1122,6 @@ function isAbsoluteForPlatform(platform: NodeJS.Platform, value: string): boolea
     return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\')
   }
   return isAbsolute(value)
-}
-
-async function readWindowsUserPath(): Promise<string | null> {
-  const stdout = await runWindowsPathCommand([
-    '-NoProfile',
-    '-Command',
-    "[Environment]::GetEnvironmentVariable('Path','User')"
-  ])
-  return stdout.trim() || null
-}
-
-async function writeWindowsUserPath(value: string): Promise<void> {
-  await runWindowsPathCommand([
-    '-NoProfile',
-    '-Command',
-    // Why: PATH registration must stay user-scoped on Windows so the Orca
-    // desktop app can manage the public shell command without requiring
-    // elevation or mutating machine-wide environment state.
-    `[Environment]::SetEnvironmentVariable('Path', ${quotePowerShell(value)}, 'User')`
-  ])
-}
-
-function runWindowsPathCommand(args: string[]): Promise<string> {
-  return new Promise((resolve, reject) => {
-    let child: ReturnType<typeof execFile> | null = null
-    let settled = false
-
-    const finish = (error: Error | null, stdout = ''): void => {
-      if (settled) {
-        return
-      }
-      settled = true
-      clearTimeout(timeout)
-      if (error) {
-        reject(error)
-        return
-      }
-      resolve(stdout)
-    }
-
-    // Why: Windows PATH reads/writes back CLI Settings; wedged PowerShell must
-    // not keep command registration status or install/remove pending forever.
-    const timeout = setTimeout(() => {
-      child?.kill()
-      finish(
-        new Error(`Windows PATH command timed out after ${WINDOWS_PATH_COMMAND_TIMEOUT_MS}ms.`)
-      )
-    }, WINDOWS_PATH_COMMAND_TIMEOUT_MS)
-
-    try {
-      child = execFile(
-        'powershell',
-        args,
-        { encoding: 'utf8', timeout: WINDOWS_PATH_COMMAND_TIMEOUT_MS },
-        (error, stdout) => {
-          finish(error ?? null, stdout)
-        }
-      )
-    } catch (error) {
-      finish(error instanceof Error ? error : new Error(String(error)))
-    }
-  })
-}
-
-function quotePowerShell(value: string): string {
-  return `'${value.replaceAll("'", "''")}'`
 }
 
 export function getBundledLauncherPath(

--- a/src/main/cli/windows-user-path.test.ts
+++ b/src/main/cli/windows-user-path.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const execFileMock = vi.hoisted(() => vi.fn())
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock
+}))
+
+import { parseWindowsUserPath, readWindowsUserPath } from './windows-user-path'
+
+beforeEach(() => {
+  execFileMock.mockReset()
+})
+
+it('reads the user PATH through the native registry command', async () => {
+  execFileMock.mockImplementation((_command, _args, _options, callback) => {
+    callback(null, '\nHKEY_CURRENT_USER\\Environment\n    Path    REG_SZ    C:\\Tools\n')
+    return { kill: vi.fn() }
+  })
+
+  await expect(readWindowsUserPath()).resolves.toBe('C:\\Tools')
+  expect(execFileMock).toHaveBeenCalledWith(
+    'reg.exe',
+    ['query', 'HKCU\\Environment'],
+    expect.objectContaining({ encoding: 'utf8' }),
+    expect.any(Function)
+  )
+})
+
+describe('parseWindowsUserPath', () => {
+  it.each(['REG_SZ', 'REG_EXPAND_SZ'])(
+    'reads a %s user PATH from reg.exe output',
+    (registryType) => {
+      const stdout = `\nHKEY_CURRENT_USER\\Environment\n    TEMP    REG_EXPAND_SZ    %USERPROFILE%\\AppData\\Local\\Temp\n    Path    ${registryType}    C:\\Tools;C:\\Program Files\\Orca\n`
+
+      expect(parseWindowsUserPath(stdout)).toBe('C:\\Tools;C:\\Program Files\\Orca')
+    }
+  )
+
+  it('returns null when the user has no PATH registry value', () => {
+    expect(
+      parseWindowsUserPath('\nHKEY_CURRENT_USER\\Environment\n    TEMP    REG_SZ    C:\\Temp\n')
+    ).toBeNull()
+  })
+})

--- a/src/main/cli/windows-user-path.ts
+++ b/src/main/cli/windows-user-path.ts
@@ -1,0 +1,65 @@
+import { execFile } from 'node:child_process'
+
+const WINDOWS_PATH_COMMAND_TIMEOUT_MS = 5_000
+
+export async function readWindowsUserPath(): Promise<string | null> {
+  const stdout = await runWindowsPathCommand('reg.exe', ['query', 'HKCU\\Environment'])
+  return parseWindowsUserPath(stdout)
+}
+
+export async function writeWindowsUserPath(value: string): Promise<void> {
+  await runWindowsPathCommand('powershell', [
+    '-NoProfile',
+    '-Command',
+    // Why: PATH registration stays user-scoped so desktop registration never needs elevation.
+    `[Environment]::SetEnvironmentVariable('Path', ${quotePowerShell(value)}, 'User')`
+  ])
+}
+
+function runWindowsPathCommand(command: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let child: ReturnType<typeof execFile> | null = null
+    let settled = false
+
+    const finish = (error: Error | null, stdout = ''): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve(stdout)
+    }
+
+    // Why: a wedged OS command must not keep CLI status or registration pending forever.
+    const timeout = setTimeout(() => {
+      child?.kill()
+      finish(
+        new Error(`Windows PATH command timed out after ${WINDOWS_PATH_COMMAND_TIMEOUT_MS}ms.`)
+      )
+    }, WINDOWS_PATH_COMMAND_TIMEOUT_MS)
+
+    try {
+      child = execFile(
+        command,
+        args,
+        { encoding: 'utf8', timeout: WINDOWS_PATH_COMMAND_TIMEOUT_MS },
+        (error, stdout) => finish(error ?? null, stdout)
+      )
+    } catch (error) {
+      finish(error instanceof Error ? error : new Error(String(error)))
+    }
+  })
+}
+
+export function parseWindowsUserPath(stdout: string): string | null {
+  const match = stdout.match(/^\s*Path\s+REG_(?:EXPAND_)?SZ(?:\s+(.*))?$/imu)
+  return match?.[1]?.trim() || null
+}
+
+function quotePowerShell(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`
+}

--- a/src/renderer/src/components/emulator-pane/mobile-emulator-agent-setup-cli-state.ts
+++ b/src/renderer/src/components/emulator-pane/mobile-emulator-agent-setup-cli-state.ts
@@ -1,8 +1,15 @@
-import type { CliInstallStatus } from '../../../../shared/cli-install-types'
+import {
+  isCliPathVerificationUnavailable,
+  type CliInstallStatus
+} from '../../../../shared/cli-install-types'
 import type { StepState } from '../settings/BrowserUseStepBadge'
 
 export function getMobileEmulatorCliPathNeedsAttention(status: CliInstallStatus | null): boolean {
-  return status?.state === 'installed' && !status.pathConfigured
+  return (
+    !isCliPathVerificationUnavailable(status) &&
+    status?.state === 'installed' &&
+    !status.pathConfigured
+  )
 }
 
 export function getMobileEmulatorCliStepBadgeState(input: {

--- a/src/renderer/src/components/emulator-pane/use-mobile-emulator-agent-setup-state.ts
+++ b/src/renderer/src/components/emulator-pane/use-mobile-emulator-agent-setup-state.ts
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import type { CliInstallStatus } from '../../../../shared/cli-install-types'
+import {
+  isCliPathVerificationUnavailable,
+  type CliInstallStatus
+} from '../../../../shared/cli-install-types'
 import { ORCA_CLI_SKILL_NAME } from '@/lib/agent-feature-install-commands'
 import {
   ensureOrcaCliAvailableForAgentSkillTerminal,
@@ -122,10 +125,11 @@ export function useMobileEmulatorAgentSetupState(enabled = true): {
   }, [enabled, refreshCliSkill, refreshCliStatus])
 
   const cliEnabled = isOrcaCliAvailableOnPath(cliInstallStatus)
+  const cliVerificationUnavailable = isCliPathVerificationUnavailable(cliInstallStatus)
   const cliPathNeedsAttention = getMobileEmulatorCliPathNeedsAttention(cliInstallStatus)
-  const cliSupported = cliInstallStatus?.supported ?? false
+  const cliSupported = (cliInstallStatus?.supported ?? false) && !cliVerificationUnavailable
   const completedCount = [cliEnabled, cliSkillInstalled].filter(Boolean).length
-  const step2Blocked = !cliEnabled && !cliSkillInstalled
+  const step2Blocked = cliVerificationUnavailable || (!cliEnabled && !cliSkillInstalled)
   const setupComplete = cliEnabled && cliSkillInstalled
   const statusReady = !cliLoading && !cliSkillLoading
 

--- a/src/renderer/src/components/feature-tips/feature-tip-startup-gate.test.ts
+++ b/src/renderer/src/components/feature-tips/feature-tip-startup-gate.test.ts
@@ -240,6 +240,17 @@ describe('feature tip startup gate', () => {
     expect(isCliFeatureTipCompleted(makeCliStatus({ pathConfigured: false }))).toBe(false)
   })
 
+  it('suppresses the CLI feature tip when PATH verification is unavailable', () => {
+    expect(
+      isCliFeatureTipCompleted(
+        makeCliStatus({
+          pathConfigured: false,
+          pathConfigurationError: 'Windows PATH command timed out after 5000ms.'
+        })
+      )
+    ).toBe(true)
+  })
+
   it('treats unsupported CLI setup as completed for feature tips', () => {
     expect(
       isCliFeatureTipCompleted(

--- a/src/renderer/src/components/feature-tips/feature-tip-startup-gate.ts
+++ b/src/renderer/src/components/feature-tips/feature-tip-startup-gate.ts
@@ -3,7 +3,10 @@ import {
   getCompletedFeatureTipIds,
   getOrderedUnseenFeatureTips
 } from '../../../../shared/feature-tips'
-import type { CliInstallStatus } from '../../../../shared/cli-install-types'
+import {
+  isCliPathVerificationUnavailable,
+  type CliInstallStatus
+} from '../../../../shared/cli-install-types'
 import type { FeatureInteractionState } from '../../../../shared/feature-interactions'
 import type { GlobalSettings, OnboardingState } from '../../../../shared/types'
 import { shouldShowOnboarding } from '../onboarding/should-show-onboarding'
@@ -16,7 +19,11 @@ export type FeatureTipsAppOpenDecision =
 export function isCliFeatureTipCompleted(status: CliInstallStatus): boolean {
   // Why: unsupported launch modes cannot complete setup, but an installed
   // launcher still needs attention until it is reachable on PATH.
-  return !status.supported || (status.state === 'installed' && status.pathConfigured)
+  return (
+    !status.supported ||
+    isCliPathVerificationUnavailable(status) ||
+    (status.state === 'installed' && status.pathConfigured)
+  )
 }
 
 export function getFeatureTipsAppOpenDecision(args: {

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -32,6 +32,7 @@ import { detectLanguage } from '@/lib/language-detect'
 import { buildDuplicatedBrowserTabOptions } from '@/lib/duplicate-browser-tab-options'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import { isOrcaCliAvailableOnPath } from '@/lib/agent-skill-cli-prerequisite'
+import { isCliPathVerificationUnavailable } from '../../../../shared/cli-install-types'
 import {
   isFloatingWorkspacePanelShortcut,
   isFloatingWorkspaceTerminalInputTarget,
@@ -611,7 +612,9 @@ export function FloatingTerminalPanel({
     try {
       const status = await window.api.cli.getInstallStatus()
       if (mountedRef.current) {
-        setShowOrchestrationSetup(!isOrcaCliAvailableOnPath(status))
+        setShowOrchestrationSetup(
+          !isCliPathVerificationUnavailable(status) && !isOrcaCliAvailableOnPath(status)
+        )
       }
     } catch {
       if (mountedRef.current) {

--- a/src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts
+++ b/src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts
@@ -301,4 +301,26 @@ describe('onboarding feature setup runner', () => {
       installCli.mock.invocationCallOrder[0]
     )
   })
+
+  it('does not attempt CLI registration when PATH verification is unavailable', async () => {
+    const unavailableStatus: CliInstallStatus = {
+      ...INSTALLED_CLI_STATUS,
+      pathConfigured: false,
+      pathConfigurationError: 'Windows PATH command timed out after 5000ms.',
+      detail: 'Orca could not verify your user PATH. Refresh to try again.'
+    }
+    const deps = createDeps({
+      getCliStatus: vi.fn(async () => unavailableStatus)
+    })
+
+    const result = await runOnboardingFeatureSetup(
+      { browserUse: true, computerUse: false, orchestration: false, linearTickets: false },
+      deps
+    )
+
+    expect(result.cliTouched).toBe(false)
+    expect(result.warnings).toContainEqual({ featureId: 'cli', message: unavailableStatus.detail })
+    expect(deps.showCliRegistrationPrompt).not.toHaveBeenCalled()
+    expect(deps.installCli).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/components/onboarding/onboarding-feature-setup.ts
+++ b/src/renderer/src/components/onboarding/onboarding-feature-setup.ts
@@ -1,4 +1,7 @@
-import type { CliInstallStatus } from '../../../../shared/cli-install-types'
+import {
+  isCliPathVerificationUnavailable,
+  type CliInstallStatus
+} from '../../../../shared/cli-install-types'
 import type {
   ComputerUsePermissionSetupResult,
   ComputerUsePermissionStatusResult
@@ -220,7 +223,13 @@ export async function runOnboardingFeatureSetup(
 
   try {
     const status = await deps.getCliStatus()
-    if (!status.supported) {
+    if (isCliPathVerificationUnavailable(status)) {
+      warnings.push({
+        featureId: 'cli',
+        message:
+          status.detail ?? status.pathConfigurationError ?? 'Orca could not verify your user PATH.'
+      })
+    } else if (!status.supported) {
       warnings.push({
         featureId: 'cli',
         message: status.detail ?? 'Orca CLI registration is not available on this platform.'

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx
@@ -196,6 +196,28 @@ describe('AgentSkillSetupPanel', () => {
     expect(container?.textContent).not.toContain('Install CLI & Skill')
   })
 
+  it('disables setup when PATH verification is unavailable', async () => {
+    const detail = 'Orca could not verify your user PATH. Refresh to try again.'
+    await renderInteractivePanel({
+      preInstallNotice: 'Install the Orca CLI before running agent skill setup.',
+      getPrerequisiteStatus: vi.fn(
+        async () =>
+          ({
+            state: 'not_installed',
+            pathConfigured: false,
+            pathConfigurationError: 'Windows PATH command timed out after 5000ms.',
+            detail
+          }) as Awaited<ReturnType<typeof window.api.cli.getInstallStatus>>
+      )
+    })
+
+    expect(findButton('Install').disabled).toBe(true)
+    expect(container?.textContent).toContain(detail)
+    expect(container?.textContent).not.toContain(
+      'Install the Orca CLI before running agent skill setup.'
+    )
+  })
+
   it('can hide install after the skill is detected', () => {
     const html = renderPanel({ installed: true, showInstallWhenInstalled: false })
 

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
@@ -11,6 +11,7 @@ import { useMountedRef } from '@/hooks/useMountedRef'
 import { isOrcaCliAvailableOnPath } from '@/lib/agent-skill-cli-prerequisite'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
+import { isCliPathVerificationUnavailable } from '../../../../shared/cli-install-types'
 
 type AgentSkillSetupPanelVariant = 'card' | 'inline'
 type SkillPrerequisiteStatus = Awaited<ReturnType<typeof window.api.cli.getInstallStatus>>
@@ -93,6 +94,9 @@ export function AgentSkillSetupPanel({
   const [preInstallNoticeVisible, setPreInstallNoticeVisible] = useState(
     Boolean(preInstallNotice && !installed)
   )
+  const [prerequisiteUnavailableDetail, setPrerequisiteUnavailableDetail] = useState<string | null>(
+    null
+  )
   const mountedRef = useMountedRef()
   const readPrerequisiteStatus = useCallback(
     () => (getPrerequisiteStatus ?? window.api.cli.getInstallStatus)(),
@@ -114,7 +118,11 @@ export function AgentSkillSetupPanel({
       try {
         const status = await readPrerequisiteStatus()
         if (!canceled) {
-          setPreInstallNoticeVisible(!isPrerequisiteAvailable(status))
+          const unavailable = isCliPathVerificationUnavailable(status)
+          setPrerequisiteUnavailableDetail(
+            unavailable ? (status.detail ?? status.pathConfigurationError ?? null) : null
+          )
+          setPreInstallNoticeVisible(!unavailable && !isPrerequisiteAvailable(status))
         }
       } catch {
         if (!canceled) {
@@ -138,7 +146,11 @@ export function AgentSkillSetupPanel({
     try {
       const status = await readPrerequisiteStatus()
       if (mountedRef.current) {
-        setPreInstallNoticeVisible(!isPrerequisiteAvailable(status))
+        const unavailable = isCliPathVerificationUnavailable(status)
+        setPrerequisiteUnavailableDetail(
+          unavailable ? (status.detail ?? status.pathConfigurationError ?? null) : null
+        )
+        setPreInstallNoticeVisible(!unavailable && !isPrerequisiteAvailable(status))
       }
     } catch {
       if (mountedRef.current) {
@@ -197,7 +209,12 @@ export function AgentSkillSetupPanel({
               }
             })()
           }}
-          disabled={terminalOpen || installDisabled || terminalOpening}
+          disabled={
+            terminalOpen ||
+            installDisabled ||
+            prerequisiteUnavailableDetail !== null ||
+            terminalOpening
+          }
         >
           {terminalOpening ? (
             <Loader2 className="size-3.5 animate-spin" />
@@ -302,6 +319,11 @@ export function AgentSkillSetupPanel({
           <p className="text-[13px] leading-snug text-muted-foreground">{description}</p>
           {actionRow}
           {actionHint ? <div className="mt-2">{actionHint}</div> : null}
+          {prerequisiteUnavailableDetail ? (
+            <p className="mt-2 text-[12px] leading-snug text-muted-foreground">
+              {prerequisiteUnavailableDetail}
+            </p>
+          ) : null}
           {!installed && preInstallNotice && preInstallNoticeVisible ? (
             <p className="mt-3 text-[12px] leading-snug text-muted-foreground">
               {preInstallNotice}

--- a/src/renderer/src/components/settings/BrowserUsePane.tsx
+++ b/src/renderer/src/components/settings/BrowserUsePane.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import type { CliInstallStatus } from '../../../../shared/cli-install-types'
+import {
+  isCliPathVerificationUnavailable,
+  type CliInstallStatus
+} from '../../../../shared/cli-install-types'
 import {
   ORCA_CLI_SKILL_INSTALL_COMMAND,
   ORCA_CLI_SKILL_NAME,
@@ -128,8 +131,10 @@ export function BrowserUseSetup({
   const cookiesImported = !!defaultProfile?.source
 
   const cliEnabled = isOrcaCliAvailableOnPath(cliStatus)
-  const cliPathNeedsAttention = cliStatus?.state === 'installed' && !cliStatus.pathConfigured
-  const cliSupported = cliStatus?.supported ?? false
+  const cliVerificationUnavailable = isCliPathVerificationUnavailable(cliStatus)
+  const cliPathNeedsAttention =
+    !cliVerificationUnavailable && cliStatus?.state === 'installed' && !cliStatus.pathConfigured
+  const cliSupported = (cliStatus?.supported ?? false) && !cliVerificationUnavailable
 
   const {
     installed: skillDetected,
@@ -181,7 +186,9 @@ export function BrowserUseSetup({
   const showStep3 = matchesSettingsSearch(searchQuery, [getBrowserUsePaneSearchEntries()[2]])
   const completedCount = [cliEnabled, skillDetected, cookiesImported].filter(Boolean).length
   const step2Blocked =
-    Boolean(activeSkillRuntime.installDisabledReason) || (!cliEnabled && !skillDetected)
+    cliVerificationUnavailable ||
+    Boolean(activeSkillRuntime.installDisabledReason) ||
+    (!cliEnabled && !skillDetected)
   const step3Blocked = !cookiesImported && (!cliEnabled || !skillDetected)
 
   const sourceLabel = defaultProfile?.source

--- a/src/renderer/src/components/settings/CliSection.tsx
+++ b/src/renderer/src/components/settings/CliSection.tsx
@@ -286,11 +286,16 @@ export function CliSection({
               <button
                 role="switch"
                 aria-checked={isEnabled}
-                disabled={loading || !isSupported || busyAction !== null}
+                disabled={
+                  loading ||
+                  !isSupported ||
+                  Boolean(status?.pathConfigurationError) ||
+                  busyAction !== null
+                }
                 onClick={() => setDialogOpen(true)}
                 className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border border-transparent transition-colors ${
                   isEnabled ? 'bg-foreground' : 'bg-muted-foreground/30'
-                } ${loading || !isSupported || busyAction !== null ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}
+                } ${loading || !isSupported || status?.pathConfigurationError || busyAction !== null ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}
               >
                 <span
                   className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { RefreshCw, TicketCheck, X } from 'lucide-react'
-import type { CliInstallStatus } from '../../../../shared/cli-install-types'
+import {
+  isCliPathVerificationUnavailable,
+  type CliInstallStatus
+} from '../../../../shared/cli-install-types'
 import type { ProjectExecutionRuntimeResolution } from '../../../../shared/project-execution-runtime'
 import { Button } from '@/components/ui/button'
 import {
@@ -183,8 +186,15 @@ export function LinearAgentSkillSetupPrompt({
   }, [refreshCliStatus])
 
   const cliAvailable = isOrcaCliAvailableOnPath(cliStatus)
+  const cliVerificationUnavailable = isCliPathVerificationUnavailable(cliStatus)
   const setupReady = linked && !cliLoading && !skill.loading && cliAvailable && skill.installed
-  const missingSetup = linked && !localDismissed && !cliLoading && !skill.loading && !setupReady
+  const missingSetup =
+    linked &&
+    !localDismissed &&
+    !cliLoading &&
+    !skill.loading &&
+    !cliVerificationUnavailable &&
+    !setupReady
   const explicitCheckMatchesContext = activeSetupCheckIdentity === setupCheckIdentity
   const showCheckingModal =
     surface === 'modal' &&

--- a/src/renderer/src/lib/agent-skill-cli-prerequisite.test.ts
+++ b/src/renderer/src/lib/agent-skill-cli-prerequisite.test.ts
@@ -112,4 +112,34 @@ describe('ensureOrcaCliAvailableForAgentSkillTerminal', () => {
     await expect(pending).resolves.toBe(installed)
     expect(install).toHaveBeenCalledTimes(1)
   })
+
+  it('does not offer registration when PATH verification is unavailable', async () => {
+    const unavailable = cliStatus({
+      pathConfigured: false,
+      pathConfigurationError: 'Windows PATH command timed out after 5000ms.',
+      detail: 'Orca could not verify your user PATH. Refresh to try again.'
+    })
+    const getInstallStatus = vi.fn().mockResolvedValue(unavailable)
+    const install = vi.fn()
+
+    vi.stubGlobal('window', {
+      api: {
+        cli: {
+          getInstallStatus,
+          install
+        }
+      }
+    })
+
+    await expect(
+      ensureOrcaCliAvailableForAgentSkillTerminal({ registrationPromptDelayMs: 0 })
+    ).resolves.toBe(unavailable)
+
+    expect(install).not.toHaveBeenCalled()
+    expect(toast.message).not.toHaveBeenCalled()
+    expect(toast.warning).toHaveBeenCalledWith(
+      'Orca CLI registration is unavailable',
+      expect.objectContaining({ description: unavailable.detail })
+    )
+  })
 })

--- a/src/renderer/src/lib/agent-skill-cli-prerequisite.ts
+++ b/src/renderer/src/lib/agent-skill-cli-prerequisite.ts
@@ -1,5 +1,8 @@
 import { toast } from 'sonner'
-import type { CliInstallStatus } from '../../../shared/cli-install-types'
+import {
+  isCliPathVerificationUnavailable,
+  type CliInstallStatus
+} from '../../../shared/cli-install-types'
 import { translate } from '@/i18n/i18n'
 
 type EnsureOrcaCliAvailableOptions = {
@@ -27,6 +30,11 @@ export async function ensureOrcaCliAvailableForAgentSkillTerminal({
     onStatusChange?.(status)
 
     if (!status.supported) {
+      showCliPrerequisiteWarning(status)
+      return status
+    }
+
+    if (isCliPathVerificationUnavailable(status)) {
       showCliPrerequisiteWarning(status)
       return status
     }
@@ -70,6 +78,17 @@ function delay(ms: number): Promise<void> {
 }
 
 function showCliPrerequisiteWarning(status: CliInstallStatus): void {
+  if (isCliPathVerificationUnavailable(status)) {
+    toast.warning(
+      translate(
+        'auto.lib.agent.skill.cli.prerequisite.2db0bd7515',
+        'Orca CLI registration is unavailable'
+      ),
+      { description: status.detail ?? status.pathConfigurationError }
+    )
+    return
+  }
+
   if (!status.supported) {
     toast.warning(
       translate(

--- a/src/shared/cli-install-types.ts
+++ b/src/shared/cli-install-types.ts
@@ -13,6 +13,7 @@ export type CliInstallStatus = {
   commandPath: string | null
   pathDirectory: string | null
   pathConfigured: boolean
+  pathConfigurationError?: string | null
   launcherPath: string | null
   installMethod: CliInstallMethod | null
   supported: boolean

--- a/src/shared/cli-install-types.ts
+++ b/src/shared/cli-install-types.ts
@@ -22,3 +22,9 @@ export type CliInstallStatus = {
   unsupportedReason: CliInstallUnsupportedReason | null
   detail: string | null
 }
+
+export function isCliPathVerificationUnavailable(
+  status: Pick<CliInstallStatus, 'pathConfigurationError'> | null | undefined
+): boolean {
+  return Boolean(status?.pathConfigurationError)
+}

--- a/tests/e2e/windows-cli-path-timeout.spec.ts
+++ b/tests/e2e/windows-cli-path-timeout.spec.ts
@@ -1,0 +1,44 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { expect, test as base } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+
+const fakePowerShellDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-slow-powershell-'))
+writeFileSync(
+  path.join(fakePowerShellDir, 'powershell.cmd'),
+  '@echo off\r\nping -n 8 127.0.0.1 >nul\r\n'
+)
+
+const test = base.extend({
+  launchEnv: [
+    {
+      PATH: `${fakePowerShellDir}${path.delimiter}${process.env.PATH ?? ''}`
+    },
+    { option: true }
+  ]
+})
+
+test.afterAll(() => {
+  rmSync(fakePowerShellDir, { recursive: true, force: true })
+})
+
+test('Windows CLI status survives a slow PowerShell PATH probe', async ({ orcaPage }) => {
+  test.skip(process.platform !== 'win32', 'Windows PATH registration only runs on Windows.')
+  await waitForSessionReady(orcaPage)
+
+  await orcaPage.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+    store.getState().openSettingsTarget({ pane: 'general', repoId: null, sectionId: 'cli' })
+    store.getState().openSettingsPage()
+  })
+
+  await expect(orcaPage.getByRole('heading', { name: 'Orca CLI', exact: true })).toBeVisible()
+  await expect(orcaPage.getByText('Checking CLI registration…')).not.toBeVisible({
+    timeout: 10_000
+  })
+  await expect(orcaPage.getByText(/Windows PATH command timed out/)).toHaveCount(0)
+})


### PR DESCRIPTION
## Summary

Fixes #9462 by reading the Windows user PATH through the registry, gracefully handling PATH verification failures, disabling CLI actions when the PATH state is unavailable, and adding regression coverage for native and WSL CLI status flows.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions.

## AI Review Report

Reviewed PATH parsing, failure handling, IPC behavior, WSL status, and UI action safety. Cross-platform behavior was verified for Windows, WSL, macOS, and Linux. No shortcuts, labels, SSH behavior, or provider-specific behavior were affected.

## Security Audit

Reviewed command execution, PATH parsing, PowerShell escaping, and IPC handling. Commands use fixed executables and arguments, PATH writes remain user-scoped, and no auth, secrets, dependencies, or elevated permissions were introduced.

## Notes

Windows PATH reads now use `reg.exe`. User-scoped PATH writes continue using PowerShell.