### PR TITLE
Keep lineage children with their parent when dragging to another status lane

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.status-lane-lineage-drop.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.status-lane-lineage-drop.test.tsx
@@ -1,0 +1,438 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  Repo,
+  WorkspaceStatus,
+  Worktree,
+  WorktreeCardProperty,
+  WorktreeLineage,
+  WorktreeMeta
+} from '../../../../shared/types'
+import { DEFAULT_WORKSPACE_STATUSES } from '../../../../shared/workspace-status-defaults'
+import {
+  WORKSPACE_STATUS_DRAG_IDS_TYPE,
+  WORKSPACE_STATUS_DRAG_TYPE
+} from './workspace-status-drag-data'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const mockStore = vi.hoisted(() => ({
+  state: {} as Record<string, unknown>,
+  activateWorktreeFromSidebar: vi.fn(),
+  openModal: vi.fn(),
+  updateWorktreeMeta: vi.fn(),
+  updateWorktreesMeta: vi.fn(),
+  setSortBy: vi.fn(),
+  fetchHostedReviewForBranch: vi.fn(),
+  fetchIssue: vi.fn(),
+  fetchLinearIssue: vi.fn(),
+  openTaskPage: vi.fn()
+}))
+
+type WorktreeListComponent = React.ComponentType<{
+  scrollOffsetRef: React.RefObject<number>
+  scrollAnchorRef: React.RefObject<unknown>
+}>
+
+let WorktreeList: WorktreeListComponent
+
+function makeFolderWorkspacePathStatusMockState(): Record<string, unknown> {
+  return {
+    fetchFolderWorkspacePathStatus: vi.fn(),
+    folderWorkspaces: [],
+    folderWorkspacePathStatuses: {},
+    getFolderWorkspacePathStatusCacheKey: (request: unknown) => JSON.stringify(request),
+    getFreshFolderWorkspacePathStatus: () => null
+  }
+}
+
+vi.mock('@/store', () => {
+  const useAppStore = ((selector: (state: Record<string, unknown>) => unknown) =>
+    selector(mockStore.state)) as ((
+    selector: (state: Record<string, unknown>) => unknown
+  ) => unknown) & {
+    getState: () => Record<string, unknown>
+  }
+  useAppStore.getState = () => mockStore.state
+  return { useAppStore }
+})
+
+vi.mock('@tanstack/react-virtual', () => ({
+  defaultRangeExtractor: ({ startIndex, endIndex }: { startIndex: number; endIndex: number }) =>
+    Array.from({ length: endIndex - startIndex + 1 }, (_, index) => startIndex + index),
+  measureElement: () => 32,
+  useVirtualizer: ({ count }: { count: number }) => ({
+    elementsCache: new Map(),
+    getTotalSize: () => count * 96,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        index,
+        key: `row-${index}`,
+        start: index * 96
+      })),
+    measureElement: vi.fn(),
+    scrollToIndex: vi.fn()
+  })
+}))
+
+vi.mock('@/hooks/useVirtualizedScrollAnchor', () => ({
+  VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT: 'orca:test-record-scroll-anchor',
+  useVirtualizedScrollAnchor: vi.fn()
+}))
+
+vi.mock('./project-header-drag', () => ({
+  useRepoHeaderDrag: () => ({
+    state: { draggingRepoId: null, dropIndicatorY: null },
+    onHandlePointerDown: vi.fn()
+  }),
+  isRepoHeaderActionTarget: () => false
+}))
+
+vi.mock('@/components/ui/hover-card', () => ({
+  HoverCard: ({ children }: { children: ReactNode }) => <>{children}</>,
+  HoverCardContent: ({ children }: { children: ReactNode }) => (
+    <div data-hover-card-content="">{children}</div>
+  ),
+  HoverCardTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, onSelect }: { children: ReactNode; onSelect?: () => void }) => (
+    <button onClick={onSelect}>{children}</button>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuSub: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuSubContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuSubTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/lib/sidebar-worktree-activation', () => ({
+  activateWorktreeFromSidebar: mockStore.activateWorktreeFromSidebar
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: vi.fn()
+}))
+
+vi.mock('@/runtime/runtime-rpc-client', () => ({
+  getActiveRuntimeTarget: () => ({ kind: 'local' }),
+  callRuntimeRpc: vi.fn()
+}))
+
+vi.mock('./CacheTimer', () => ({
+  default: () => null,
+  usePromptCacheCountdownStartedAt: () => null
+}))
+
+vi.mock('./WorktreeCardAgents', () => ({
+  default: ({ worktreeId }: { worktreeId: string }) => (
+    <div data-agent-worktree-id={worktreeId}>Agent row</div>
+  ),
+  SUPPRESS_WORKTREE_LIST_SCROLL_ADJUSTMENT_EVENT: 'orca:test-suppress-scroll-adjustment'
+}))
+
+vi.mock('./SshDisconnectedDialog', () => ({
+  SshDisconnectedDialog: () => null
+}))
+
+vi.mock('./WorktreeContextMenu', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+  CLOSE_ALL_CONTEXT_MENUS_EVENT: 'orca:test-close-context-menus',
+  WORKTREE_CONTEXT_MENU_SCOPE_ATTR: 'data-orca-context-menu-scope',
+  WORKTREE_NATIVE_CONTEXT_MENU_ATTR: 'data-worktree-native-context-menu'
+}))
+
+function makeRepo(): Repo {
+  return {
+    id: 'repo-1',
+    path: '/tmp/status-lane-lineage',
+    displayName: 'status-lane-lineage',
+    badgeColor: '#999999',
+    addedAt: 1
+  }
+}
+
+function makeWorktree(args: {
+  id: string
+  displayName: string
+  branch: string
+  sortOrder: number
+  instanceId: string
+  workspaceStatus: WorkspaceStatus
+}): Worktree {
+  return {
+    id: args.id,
+    instanceId: args.instanceId,
+    repoId: 'repo-1',
+    path: `/tmp/status-lane-lineage/${args.id}`,
+    displayName: args.displayName,
+    branch: args.branch,
+    head: 'abc123',
+    isBare: false,
+    isMainWorktree: false,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: args.sortOrder,
+    lastActivityAt: args.sortOrder,
+    workspaceStatus: args.workspaceStatus
+  }
+}
+
+function makeLineage(worktree: Worktree, parent: Worktree): WorktreeLineage {
+  return {
+    worktreeId: worktree.id,
+    worktreeInstanceId: worktree.instanceId!,
+    parentWorktreeId: parent.id,
+    parentWorktreeInstanceId: parent.instanceId!,
+    origin: 'orchestration',
+    capture: { source: 'orchestration-context', confidence: 'explicit' },
+    createdAt: 1
+  }
+}
+
+function makeFolderWorkspacePathStatusState(): Record<string, unknown> {
+  return {
+    fetchFolderWorkspacePathStatus: vi.fn(),
+    folderWorkspacePathStatuses: {},
+    folderWorkspaces: [],
+    getFolderWorkspacePathStatusCacheKey: (request: unknown) => JSON.stringify(request),
+    getFreshFolderWorkspacePathStatus: vi.fn(() => null)
+  }
+}
+
+// Grouped by workspace status: parent + its visible lineage child both live in the
+// "in-progress" lane; an unrelated bystander sits in "todo".
+function setStatusLaneState(): void {
+  const repo = makeRepo()
+  const parent = makeWorktree({
+    id: 'parent',
+    instanceId: 'parent-instance',
+    displayName: 'lineage parent',
+    branch: 'parent-branch',
+    sortOrder: 30,
+    workspaceStatus: 'in-progress'
+  })
+  const child = makeWorktree({
+    id: 'child',
+    instanceId: 'child-instance',
+    displayName: 'lineage child',
+    branch: 'child-branch',
+    sortOrder: 20,
+    workspaceStatus: 'in-progress'
+  })
+  const bystander = makeWorktree({
+    id: 'bystander',
+    instanceId: 'bystander-instance',
+    displayName: 'bystander',
+    branch: 'bystander-branch',
+    sortOrder: 10,
+    workspaceStatus: 'todo'
+  })
+  mockStore.state = {
+    ...makeFolderWorkspacePathStatusMockState(),
+    activeModal: '',
+    activeView: 'terminal',
+    activeWorktreeId: null,
+    agentStatusByPaneKey: {},
+    agentStatusEpoch: 0,
+    browserTabsByWorktree: {},
+    clearPendingRevealWorktreeId: vi.fn(),
+    collapsedGroups: new Set<string>(),
+    deleteStateByWorktreeId: {},
+    detectedWorktreesByRepo: {},
+    fetchHostedReviewForBranch: mockStore.fetchHostedReviewForBranch,
+    fetchIssue: mockStore.fetchIssue,
+    fetchLinearIssue: mockStore.fetchLinearIssue,
+    filterRepoIds: [],
+    ...makeFolderWorkspacePathStatusState(),
+    gitConflictOperationByWorktree: {},
+    groupBy: 'workspace-status',
+    hideDefaultBranchWorkspace: false,
+    hostedReviewCache: {},
+    issueCache: {},
+    linearIssueCache: {},
+    linearStatus: null,
+    migrationUnsupportedByPtyId: {},
+    openModal: mockStore.openModal,
+    openSettingsPage: vi.fn(),
+    openSettingsTarget: null,
+    openTaskPage: mockStore.openTaskPage,
+    pendingRevealWorktree: null,
+    prCache: {},
+    projectGroups: [],
+    ptyIdsByTabId: {},
+    recordFeatureInteraction: vi.fn(),
+    remoteBranchConflictByWorktreeId: {},
+    reorderRepos: vi.fn(),
+    reportVisibleGitHubPRRefreshCandidates: vi.fn(),
+    repos: [repo],
+    retainedAgentsByPaneKey: {},
+    revealWorktreeInSidebar: vi.fn(),
+    runtimePaneTitlesByTabId: {},
+    setFilterRepoIds: vi.fn(),
+    setHideDefaultBranchWorkspace: vi.fn(),
+    setRenamingWorktreeId: vi.fn(),
+    setShowSleepingWorkspaces: vi.fn(),
+    setSortBy: mockStore.setSortBy,
+    setWorktreesPinnedAndReveal: vi.fn(),
+    settings: null,
+    showSleepingWorkspaces: true,
+    sortBy: 'manual',
+    sortEpoch: 0,
+    sshConnectedGeneration: 0,
+    sshConnectionStates: new Map(),
+    sshTargetLabels: new Map(),
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {},
+    toggleCollapsedGroup: vi.fn(),
+    updateRepo: vi.fn(),
+    updateWorktreeMeta: mockStore.updateWorktreeMeta,
+    updateWorktreesMeta: mockStore.updateWorktreesMeta,
+    workspaceHostScope: 'all',
+    workspacePortScan: null,
+    workspaceStatuses: [...DEFAULT_WORKSPACE_STATUSES],
+    worktreeCardProperties: [
+      'status',
+      'pr',
+      'comment',
+      'inline-agents'
+    ] satisfies WorktreeCardProperty[],
+    worktreeLineageById: { [child.id]: makeLineage(child, parent) },
+    worktreesByRepo: { [repo.id]: [parent, child, bystander] }
+  }
+}
+
+const mountedRoots: Root[] = []
+
+async function renderWorktreeList(): Promise<HTMLDivElement> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  mountedRoots.push(root)
+  await act(async () => {
+    root.render(
+      <WorktreeList scrollOffsetRef={{ current: 0 }} scrollAnchorRef={{ current: null }} />
+    )
+  })
+  return container
+}
+
+// A minimal DataTransfer stand-in: the native-drop commit path only reads the
+// worktree-id payloads and the type list off it.
+function makeWorktreeIdDataTransfer(worktreeIds: readonly string[]): DataTransfer {
+  const [firstId] = worktreeIds
+  const data: Record<string, string> = {
+    [WORKSPACE_STATUS_DRAG_TYPE]: firstId ?? '',
+    [WORKSPACE_STATUS_DRAG_IDS_TYPE]: JSON.stringify(worktreeIds),
+    'text/plain': firstId ?? ''
+  }
+  return {
+    effectAllowed: 'move',
+    types: Object.keys(data),
+    getData: (type: string) => data[type] ?? '',
+    setData: () => {}
+  } as unknown as DataTransfer
+}
+
+function findStatusLaneHeader(container: HTMLElement, status: WorkspaceStatus): HTMLElement {
+  const header = container.querySelector<HTMLElement>(
+    `[data-workspace-status-drop-target][data-workspace-status="${status}"]`
+  )
+  if (!header) {
+    throw new Error(`No status lane header rendered for "${status}"`)
+  }
+  return header
+}
+
+async function dropWorktreesOnStatusLane(
+  header: HTMLElement,
+  worktreeIds: readonly string[]
+): Promise<void> {
+  const event = new Event('drop', { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'dataTransfer', {
+    value: makeWorktreeIdDataTransfer(worktreeIds)
+  })
+  await act(async () => {
+    header.dispatchEvent(event)
+  })
+}
+
+function committedStatusUpdates(): Map<string, Partial<WorktreeMeta>> {
+  expect(mockStore.updateWorktreesMeta).toHaveBeenCalledTimes(1)
+  return mockStore.updateWorktreesMeta.mock.calls[0]![0] as Map<string, Partial<WorktreeMeta>>
+}
+
+describe('WorktreeList status-lane drop carries visible lineage children (#9083)', () => {
+  beforeAll(async () => {
+    WorktreeList = (await import('./WorktreeList')).default as WorktreeListComponent
+  }, 60_000)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setStatusLaneState()
+  })
+
+  afterEach(async () => {
+    await act(async () => {
+      for (const root of mountedRoots.splice(0)) {
+        root.unmount()
+      }
+    })
+    document.body.innerHTML = ''
+  })
+
+  it('moves a dragged parent and its visible lineage child to the dropped lane', async () => {
+    const container = await renderWorktreeList()
+    const todoHeader = findStatusLaneHeader(container, 'todo')
+
+    // Only the parent id rides on the native drag payload; the wrapper must expand it.
+    await dropWorktreesOnStatusLane(todoHeader, ['parent'])
+
+    const updates = committedStatusUpdates()
+    expect(updates.get('parent')).toEqual({ workspaceStatus: 'todo' })
+    expect(updates.get('child')).toEqual({ workspaceStatus: 'todo' })
+  })
+
+  it('leaves worktrees in other lanes untouched', async () => {
+    const container = await renderWorktreeList()
+    const todoHeader = findStatusLaneHeader(container, 'todo')
+
+    await dropWorktreesOnStatusLane(todoHeader, ['parent'])
+
+    const updates = committedStatusUpdates()
+    expect(updates.has('bystander')).toBe(false)
+    expect(updates.size).toBe(2)
+  })
+
+  it('commits only itself when a childless worktree is dropped onto another lane', async () => {
+    const container = await renderWorktreeList()
+    const inProgressHeader = findStatusLaneHeader(container, 'in-progress')
+
+    await dropWorktreesOnStatusLane(inProgressHeader, ['bystander'])
+
+    const updates = committedStatusUpdates()
+    expect(updates.get('bystander')).toEqual({
+      workspaceStatus: 'in-progress'
+    })
+    expect(updates.has('parent')).toBe(false)
+    expect(updates.has('child')).toBe(false)
+    expect(updates.size).toBe(1)
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -2844,7 +2844,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       y: drag.currentY,
       shouldShowDropIndicator: (target) =>
         Boolean(
-          target.status && shouldShowWorkspaceBoardDropIndicator(drag.draggedIds, target.status)
+          target.status &&
+          shouldShowWorkspaceBoardDropIndicator(drag.reorderDraggedIds, target.status)
         )
     })
     drag.latestBoardDropTarget = {
@@ -2919,7 +2920,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         ? computeWorktreeStatusDrop({
             pointerY: drag.currentY,
             status: preferredStatusTarget.status,
-            draggedIds: drag.draggedIds
+            draggedIds: drag.reorderDraggedIds
           })
         : null
       if (statusDrop) {
@@ -2967,7 +2968,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         ? computeWorktreeStatusDrop({
             pointerY: drag.currentY,
             status: target.status,
-            draggedIds: drag.draggedIds
+            draggedIds: drag.reorderDraggedIds
           })
         : null
       if (statusDrop) {
@@ -3258,7 +3259,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         onPinWorktrees(drag.draggedIds)
       } else if (boardDropTarget.status) {
         onDropWorktreesOnWorkspaceBoard({
-          worktreeIds: drag.draggedIds,
+          worktreeIds: drag.reorderDraggedIds,
           status: boardDropTarget.status,
           dropIndex: boardDropTarget.dropIndex,
           groups: getWorkspaceKanbanSidebarDropGroups()
@@ -3290,7 +3291,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
             ? computeWorktreeStatusDrop({
                 pointerY: event.clientY,
                 status: preferredStatusTarget.status,
-                draggedIds: drag.draggedIds
+                draggedIds: drag.reorderDraggedIds
               })
             : null
           if (preferredStatusTarget.isPinDrop) {
@@ -3298,13 +3299,13 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
           } else if (preferredStatusTarget.status) {
             if (statusDrop) {
               onMoveWorktreesToStatusAtIndex({
-                worktreeIds: drag.draggedIds,
+                worktreeIds: drag.reorderDraggedIds,
                 status: preferredStatusTarget.status,
                 dropIndex: statusDrop.dropIndex,
                 groups: worktreeDragGroups
               })
             } else {
-              onMoveWorktreesToStatus(drag.draggedIds, preferredStatusTarget.status)
+              onMoveWorktreesToStatus(drag.reorderDraggedIds, preferredStatusTarget.status)
             }
           }
           clearWorktreeDrag()
@@ -3332,7 +3333,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
             ? computeWorktreeStatusDrop({
                 pointerY: event.clientY,
                 status: currentTarget.status,
-                draggedIds: drag.draggedIds
+                draggedIds: drag.reorderDraggedIds
               })
             : null
           const { target, preview: statusDrop } = resolveWorktreeSidebarStatusDropCommitTarget({
@@ -3349,13 +3350,13 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
           } else if (target.status) {
             if (statusDrop) {
               onMoveWorktreesToStatusAtIndex({
-                worktreeIds: drag.draggedIds,
+                worktreeIds: drag.reorderDraggedIds,
                 status: target.status,
                 dropIndex: statusDrop.dropIndex,
                 groups: worktreeDragGroups
               })
             } else {
-              onMoveWorktreesToStatus(drag.draggedIds, target.status)
+              onMoveWorktreesToStatus(drag.reorderDraggedIds, target.status)
             }
           }
         }
@@ -3454,7 +3455,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
             ? computeWorktreeStatusDrop({
                 pointerY: point.clientY,
                 status: target.status,
-                draggedIds: session.draggedIds
+                draggedIds: session.reorderDraggedIds
               })
             : null
           if (statusDrop) {
@@ -3603,7 +3604,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
           ? computeWorktreeStatusDrop({
               pointerY: event.clientY,
               status: target.status,
-              draggedIds: session.draggedIds
+              draggedIds: session.reorderDraggedIds
             })
           : null
         if (statusDrop) {
@@ -3701,14 +3702,14 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
           ? computeWorktreeStatusDrop({
               pointerY: event.clientY,
               status: target.status,
-              draggedIds: session.draggedIds
+              draggedIds: session.reorderDraggedIds
             })
           : null
         if (target.status && statusDrop) {
           event.preventDefault()
           event.stopPropagation()
           onMoveWorktreesToStatusAtIndex({
-            worktreeIds: session.draggedIds,
+            worktreeIds: session.reorderDraggedIds,
             status: target.status,
             dropIndex: statusDrop.dropIndex,
             groups: worktreeDragGroups
@@ -3896,14 +3897,14 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         ? computeWorktreeStatusDrop({
             pointerY: event.clientY,
             status,
-            draggedIds: session.draggedIds
+            draggedIds: session.reorderDraggedIds
           })
         : null
       setDragOverStatus(null)
       if (session && statusDrop) {
         event.stopPropagation()
         onMoveWorktreesToStatusAtIndex({
-          worktreeIds: session.draggedIds,
+          worktreeIds: session.reorderDraggedIds,
           status,
           dropIndex: statusDrop.dropIndex,
           groups: worktreeDragGroups
@@ -3911,11 +3912,17 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         clearWorktreeDrag()
         return
       }
-      onMoveWorktreesToStatus(worktreeIds, status)
+      // Match the status-drop scope to the drag-preview scope (#9083): with a live session use its
+      // precomputed expanded set; the session-less foreign-origin case expands the dataTransfer ids live.
+      onMoveWorktreesToStatus(
+        session ? session.reorderDraggedIds : getReorderDraggedIds(worktreeIds),
+        status
+      )
     },
     [
       clearWorktreeDrag,
       computeWorktreeStatusDrop,
+      getReorderDraggedIds,
       onMoveWorktreesToStatus,
       onMoveWorktreesToStatusAtIndex,
       worktreeDragGroups
@@ -3956,14 +3963,14 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
           ? computeWorktreeStatusDrop({
               pointerY: event.clientY,
               status: target.status,
-              draggedIds: session.draggedIds
+              draggedIds: session.reorderDraggedIds
             })
           : null
         if (target.status && statusDrop) {
           event.preventDefault()
           event.stopPropagation()
           onMoveWorktreesToStatusAtIndex({
-            worktreeIds: session.draggedIds,
+            worktreeIds: session.reorderDraggedIds,
             status: target.status,
             dropIndex: statusDrop.dropIndex,
             groups: worktreeDragGroups
@@ -4034,6 +4041,15 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
   }, [clearWorktreeDrag])
 
+  // Why: this session-less capture-phase committer is the primary native-drop path in packaged
+  // Electron. Expand at this call site (not in the shared hook, which WorkspaceKanbanDrawer uses for
+  // its flat board) so a dropped parent carries its visible lineage children (#9083).
+  const moveWorktreesToStatusForDocumentDrop = useCallback(
+    (ids: readonly string[], status: WorkspaceStatus) =>
+      onMoveWorktreesToStatus(getReorderDraggedIds(ids), status),
+    [getReorderDraggedIds, onMoveWorktreesToStatus]
+  )
+
   useWorkspaceStatusDocumentDrop(
     scrollRef,
     onMoveWorktreeToStatus,
@@ -4041,7 +4057,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     handleWorkspaceStatusDragFinish,
     hasWorkspaceDropTargets,
     {
-      onMoveWorktreesToStatus,
+      onMoveWorktreesToStatus: moveWorktreesToStatusForDocumentDrop,
       onPinWorktrees
     }
   )


### PR DESCRIPTION
Fixes #9083.

**What changes:** Dragging a parent worktree card to a different status lane in the sidebar (grouped by workspace status) now moves its visible lineage children with it — matching what the drag preview already shows. Before, only the parent's status changed: the children were left behind in the old lane and rendered as orphaned top-level cards, silently breaking the visual nesting.

**What does not change:** Pin drops still pin only the directly dragged card; drops that nest a card under a parent still re-parent only the directly dragged cards; the expanded workspace kanban board (flat cards, no nesting) is untouched; hidden/collapsed children do not follow (same "visible lineage" semantics the reorder path has always had); the context-menu "Move to status" single-card action is unchanged.

## Design approach

Both sidebar drag sessions (custom pointer drag and native HTML5 drag) already precompute a lineage-expanded dragged set (`reorderDraggedIds`, via `expandDraggedWorktreeIdsForVisibleLineage`) that the drag preview and the reorder commit use. The bug was that every status-lane / board commit path read the raw dragged ids instead. The fix swaps those commit sites (and their hover-preview computations) to the same expanded set — no new helpers, no new state. Two session-less commit paths expand the ids at commit time through the same helper: the status-drop fallback and the capture-phase document-drop committer (`useWorkspaceStatusDocumentDrop`), which is the primary native-drop path in packaged Electron. That wrapper lives at the `WorktreeList` call site only, so the `WorkspaceKanbanDrawer`'s flat board keeps committing raw ids.

## Review and verification pipeline (Brennan's PR process)

- **Design review:** delegated review loop over the design doc, 2 full rounds + 1 focused verification; final verdict clean. It added two findings folded into the fix: the packaged-Electron document-drop committer and the board drop-indicator predicate, plus a dual-case fix for the status-drop fallback (it also fires when a session exists but no drop preview could be computed).
- **Implementation:** all 7 design items in `src/renderer/src/components/sidebar/WorktreeList.tsx` (+36/−20) plus a new regression test. One deviation from the validation plan, allowed by the design doc: the pointer-path DOM drag simulation was skipped in favor of driving the real native document-drop committer (happy-dom lacks a usable `elementFromPoint`).
- **Completeness verification:** independent read-only pass — verdict *complete-with-accepted-deviations*; all 7 items implemented as specified, intentionally-raw sites confirmed intact, no unapproved narrowing.
- **Headline behavior:** **implemented** (not partial). Live-verified in the running dev app: parent dragged from "In progress" to "Todo" carries its visible child; child stays nested under the parent in the new lane.
- **Broad app consistency:** source of truth is the drag-preview scope (parent + visible children move as one unit). Sidebar lane headers, in-lane insertion drops, sidebar→collapsed-board drops, both capture-phase document committers, and the board drop indicator now all use that scope. Deliberately preserved mismatches: pin drops stay parent-only (pre-existing, cosmetic preview mismatch remains there), expanded kanban board stays flat, collapsed children stay behind (same as reorder).
- **Performance audit:** clean. The expanded set is precomputed at drag start; per-frame paths only read it. The two new expansion calls are one-shot at commit time. The new `useCallback` wrapper's deps track worktree-list changes, not drag frames.
- **Code-review loop:** 1 round, two independent reviewers, both clean. One recorded non-actionable `P2` residual: the new test guards the document-drop committer (the packaged-app path); the session-path commit sites are guarded against systemic reverts but not a single-site hand-revert — an isolated pointer-drag DOM test would need a brittle new harness, judged net-negative for now.
- **Merge-confidence validation:** verdict **land**. Live pointer-drag scenarios in the dev app: core parent+child lane move (fixed), childless card moves alone, in-lane reorder with children following still works; store-level assertions plus full-window screenshots for each; console clean.

## Tests and checks run

- New: `WorktreeList.status-lane-lineage-drop.test.tsx` — renders the real `WorktreeList` grouped by workspace status (parent + visible lineage child, bystander in another lane) and drives a native drop carrying only the parent id onto a lane header; asserts both parent and child commit to the target status, other lanes untouched, and a childless drop commits only itself. 3/3 pass.
- Regression suites (worktree-manual-order, lineage card tests, kanban sidebar drop, WorkspaceKanbanDrawer task-status sync, and neighbors): all green.
- Typecheck (`tsc` web config) clean; oxlint/oxfmt clean.

## Manual validation evidence

Screenshots (bug repro pre-fix, and post-fix drags) are attached in a PR comment below — not committed to the repo.

## Risks / accepted gaps

- The packaged-build document-drop committer is exercised by the new unit test (real DOM drop through the real hook), but the live drag re-verify used the dev app's pointer path; no packaged build was launched for this PR.
- `handleWorktreeDrop`'s row-level status commit is unreachable today (the capture-phase document handler pre-empts it); it was swapped defensively for consistency.
- The board drop-indicator swap is a no-op under workspace-status grouping and only changes indicator behavior when nested children hold mixed statuses under other groupings — reasoned, not live-tested.
- SSH: not applicable — renderer-only commit scope; status updates flow through the existing host-aware batched meta update, just with more ids. Mobile: no sidebar drag surface.


## Senior review live re-validation (2026-07-19)

Re-ran the real sidebar pointer gesture in an isolated Electron dev profile on this PR branch. The drag emitted one batched update containing exactly `parent-tree` and its visible `child-tree`; both moved from **In progress** to **Todo**, the child remained visibly nested, and the unrelated `bystander` was untouched.

### Before

![Before: parent and visible child nested in In progress](https://github.com/user-attachments/assets/29220d85-fe3f-4359-b4b3-446c054844e9)

### Mid-drag

![Mid-drag: lineage drag preview over Todo](https://github.com/user-attachments/assets/7d8b3589-3dbf-4161-a795-91a085b679df)

### After

![After: parent and child remain nested together in Todo](https://github.com/user-attachments/assets/11524f4a-6c6e-49a1-8d3f-5eb92b75028b)
