### PR TITLE
feat(native-chat): show Claude task progress

### DIFF
--- a/src/main/native-chat/transcript-reader.test.ts
+++ b/src/main/native-chat/transcript-reader.test.ts
@@ -8,6 +8,7 @@ import {
   readNativeChatTranscriptTail,
   readNativeChatTranscriptTailFile
 } from './transcript-tail-reader'
+import { deriveNativeChatTasks } from '../../shared/native-chat-task-list'
 
 let tempRoots: string[] = []
 
@@ -188,6 +189,82 @@ describe('readNativeChatTranscript (claude)', () => {
       throw new Error('expected messages')
     }
     expect(result.messages[0].blocks[0]).toEqual({ type: 'text', text: 'pondering' })
+  })
+
+  it('preserves Claude task tools so the latest checklist can be rebuilt', async () => {
+    const filePath = await writeFixture('orca-native-chat-claude-tasks-', [
+      {
+        type: 'assistant',
+        uuid: 'task-create',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'create-1',
+              name: 'TaskCreate',
+              input: { subject: 'Implement task list', activeForm: 'Implementing task list' }
+            }
+          ]
+        }
+      },
+      {
+        type: 'user',
+        uuid: 'task-create-result',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'create-1',
+              content: { task: { id: '1', subject: 'Implement task list' } }
+            }
+          ]
+        }
+      },
+      {
+        type: 'assistant',
+        uuid: 'task-update',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'update-1',
+              name: 'TaskUpdate',
+              input: { taskId: '1', status: 'in_progress' }
+            }
+          ]
+        }
+      },
+      {
+        type: 'user',
+        uuid: 'task-update-result',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'update-1',
+              content: 'updated'
+            }
+          ]
+        }
+      }
+    ])
+    const result = await readNativeChatTranscript('claude', 'sess', { filePath })
+    if (!('messages' in result)) {
+      throw new Error('expected messages')
+    }
+
+    expect(deriveNativeChatTasks(result.messages)).toEqual([
+      {
+        id: '1',
+        subject: 'Implement task list',
+        activeForm: 'Implementing task list',
+        status: 'in_progress'
+      }
+    ])
   })
 })
 

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tasks.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tasks.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AgentType, NativeChatMessage } from '../../../../shared/native-chat-types'
+import type { NativeChatLiveSession } from './use-native-chat-live-session'
+import { NativeChatMessageList } from './NativeChatMessageList'
+
+afterEach(() => cleanup())
+
+const taskMessages: NativeChatMessage[] = [
+  {
+    id: 'task-create',
+    role: 'assistant',
+    timestamp: 1,
+    source: 'transcript',
+    blocks: [
+      { type: 'tool-call', name: 'TaskCreate', input: { subject: 'Add tests' } },
+      { type: 'tool-result', output: '{"task":{"id":"7","subject":"Add tests"}}' }
+    ]
+  }
+]
+
+function session(agent: AgentType): NativeChatLiveSession {
+  return {
+    agent,
+    sessionId: 'session',
+    status: 'ready',
+    messages: taskMessages,
+    hasMore: false,
+    loadingEarlier: false,
+    loadEarlier: vi.fn()
+  }
+}
+
+describe('NativeChatMessageList Claude tasks', () => {
+  it('leaves identically named tools untouched for non-Claude agents', () => {
+    render(
+      <NativeChatMessageList
+        session={session('codex')}
+        isWorking={false}
+        expandSignal
+        fontScale={1}
+      />
+    )
+
+    expect(screen.getByText('TaskCreate')).toBeInTheDocument()
+    expect(screen.queryByRole('region', { name: /task \(/i })).not.toBeInTheDocument()
+  })
+
+  it('renders OpenClaude task tools as a checklist without duplicate tool rows', () => {
+    render(
+      <NativeChatMessageList
+        session={session('openclaude')}
+        isWorking={false}
+        expandSignal
+        fontScale={1}
+      />
+    )
+
+    expect(
+      screen.getByRole('region', { name: '1 task (0 done, 0 in progress, 1 open)' })
+    ).toBeInTheDocument()
+    expect(screen.queryByText('TaskCreate')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -20,6 +20,12 @@ import { isNativeChatPastedImagePath } from './native-chat-image-paste'
 import { NativeChatToolRun } from './NativeChatToolRun'
 import { NativeChatCopyButton } from './NativeChatCopyButton'
 import { NATIVE_CHAT_STREAMING_ID } from '../../../../shared/native-chat-streaming'
+import {
+  deriveNativeChatTasks,
+  withoutNativeChatTaskToolBlocks
+} from '../../../../shared/native-chat-task-list'
+import { resolveNativeChatTranscriptAgent } from '../../../../shared/native-chat-agent-support'
+import { NativeChatTaskList } from './NativeChatTaskList'
 
 function geometryOf(el: HTMLElement): ScrollGeometry {
   return { scrollTop: el.scrollTop, scrollHeight: el.scrollHeight, clientHeight: el.clientHeight }
@@ -125,6 +131,7 @@ function TypingIndicatorRow(): React.JSX.Element {
 function MessageRow({
   message,
   expandSignal,
+  hideTaskTools,
   onScrollMessageToTop,
   onLinkClick,
   allowFileUriLinks = false,
@@ -132,6 +139,7 @@ function MessageRow({
 }: {
   message: NativeChatMessage
   expandSignal: boolean
+  hideTaskTools: boolean
   /** Align this message's top to the top of the scroll viewport. */
   onScrollMessageToTop: (el: HTMLElement) => void
   onLinkClick?: CommentMarkdownLinkClickHandler
@@ -139,7 +147,11 @@ function MessageRow({
   deliveryFailed?: boolean
 }): React.JSX.Element | null {
   const rowRef = useRef<HTMLDivElement | null>(null)
-  const { prose, tools } = useMemo(() => splitNativeChatBlocks(message.blocks), [message.blocks])
+  const renderBlocks = useMemo(
+    () => (hideTaskTools ? withoutNativeChatTaskToolBlocks(message.blocks) : message.blocks),
+    [hideTaskTools, message.blocks]
+  )
+  const { prose, tools } = useMemo(() => splitNativeChatBlocks(renderBlocks), [renderBlocks])
   const markdown = proseToMarkdown(prose)
   const hasImages = prose.some((block) => block.type === 'image-ref')
   const isUser = message.role === 'user'
@@ -274,6 +286,11 @@ export function NativeChatMessageList({
     () => foldToolMessages(orderNativeChatMessages(stripNoiseMessages(session.messages))),
     [session.messages]
   )
+  const rendersClaudeTasks = resolveNativeChatTranscriptAgent(session.agent) === 'claude'
+  const tasks = useMemo(
+    () => (rendersClaudeTasks ? deriveNativeChatTasks(messages) : []),
+    [messages, rendersClaudeTasks]
+  )
   const showTypingIndicator =
     isWorking && !messages.some((message) => message.id === NATIVE_CHAT_STREAMING_ID)
 
@@ -404,12 +421,14 @@ export function NativeChatMessageList({
               key={message.id}
               message={message}
               expandSignal={expandSignal}
+              hideTaskTools={tasks.length > 0}
               onScrollMessageToTop={scrollMessageToTop}
               onLinkClick={onLinkClick}
               allowFileUriLinks={allowFileUriLinks}
               deliveryFailed={failedDeliveryMessageIds?.has(message.id) === true}
             />
           ))}
+          <NativeChatTaskList tasks={tasks} />
           {showTypingIndicator ? <TypingIndicatorRow /> : null}
         </div>
       </div>

--- a/src/renderer/src/components/native-chat/NativeChatTaskList.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatTaskList.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { NativeChatTask } from '../../../../shared/native-chat-task-list'
+import { NativeChatTaskList } from './NativeChatTaskList'
+
+afterEach(() => cleanup())
+
+describe('NativeChatTaskList', () => {
+  it('prioritizes active work and caps the visible list like Claude', () => {
+    const tasks: NativeChatTask[] = [
+      ...Array.from({ length: 7 }, (_unused, index) => ({
+        id: String(index),
+        subject: `Completed phase ${index}`,
+        status: 'completed' as const
+      })),
+      {
+        id: 'active',
+        subject: 'Monitor the PR',
+        activeForm: 'Monitoring the PR until merge',
+        status: 'in_progress'
+      }
+    ]
+
+    render(<NativeChatTaskList tasks={tasks} />)
+
+    expect(
+      screen.getByRole('region', { name: '8 tasks (7 done, 1 in progress, 0 open)' })
+    ).toBeInTheDocument()
+    expect(screen.getByText('Monitoring the PR until merge')).toBeInTheDocument()
+    expect(screen.queryByText('Monitor the PR')).not.toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(5)
+    expect(screen.getByText('+3 completed')).toBeInTheDocument()
+  })
+
+  it('shows pending tasks ahead of completed history', () => {
+    render(
+      <NativeChatTaskList
+        tasks={[
+          { id: 'done', subject: 'Finished', status: 'completed' },
+          { id: 'next', subject: 'Next', status: 'pending' }
+        ]}
+      />
+    )
+
+    const items = screen.getAllByRole('listitem')
+    expect(items.map((item) => item.textContent)).toEqual(['Next', 'Finished'])
+  })
+})

--- a/src/renderer/src/components/native-chat/NativeChatTaskList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatTaskList.tsx
@@ -1,0 +1,108 @@
+import { Check, Square } from 'lucide-react'
+import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+import type { NativeChatTask, NativeChatTaskStatus } from '../../../../shared/native-chat-task-list'
+
+// Why: Claude caps the terminal checklist at five rows; matching that density
+// keeps task progress useful without displacing the conversation.
+const MAX_VISIBLE_TASKS = 5
+
+const TASK_STATUS_ORDER: Record<NativeChatTaskStatus, number> = {
+  in_progress: 0,
+  pending: 1,
+  completed: 2
+}
+
+function taskTitle(task: NativeChatTask): string {
+  return task.status === 'in_progress' && task.activeForm ? task.activeForm : task.subject
+}
+
+export function NativeChatTaskList({
+  tasks
+}: {
+  tasks: readonly NativeChatTask[]
+}): React.JSX.Element | null {
+  if (tasks.length === 0) {
+    return null
+  }
+
+  const counts = { pending: 0, in_progress: 0, completed: 0 }
+  for (const task of tasks) {
+    counts[task.status] += 1
+  }
+  const sorted = [...tasks].sort(
+    (left, right) => TASK_STATUS_ORDER[left.status] - TASK_STATUS_ORDER[right.status]
+  )
+  const visible = sorted.slice(0, MAX_VISIBLE_TASKS)
+  const hidden = sorted.slice(MAX_VISIBLE_TASKS)
+  const summary = translate(
+    tasks.length === 1
+      ? 'components.native-chat.tasks.summaryOne'
+      : 'components.native-chat.tasks.summary',
+    tasks.length === 1
+      ? '1 task ({{value1}} done, {{value2}} in progress, {{value3}} open)'
+      : '{{value0}} tasks ({{value1}} done, {{value2}} in progress, {{value3}} open)',
+    {
+      value0: tasks.length,
+      value1: counts.completed,
+      value2: counts.in_progress,
+      value3: counts.pending
+    }
+  )
+  const hiddenCompleted = hidden.every((task) => task.status === 'completed')
+
+  return (
+    <section
+      aria-label={summary}
+      className="rounded-lg border border-border bg-card px-3 py-2.5 text-xs shadow-xs"
+    >
+      <div className="mb-1.5 font-mono text-muted-foreground">{summary}</div>
+      <ul className="space-y-1 font-mono">
+        {visible.map((task) => {
+          const completed = task.status === 'completed'
+          const inProgress = task.status === 'in_progress'
+          return (
+            <li
+              key={task.id}
+              data-status={task.status}
+              aria-current={inProgress ? 'step' : undefined}
+              className={cn(
+                'flex min-w-0 items-start gap-2',
+                completed ? 'text-muted-foreground' : 'text-foreground'
+              )}
+            >
+              {completed ? (
+                <Check className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+              ) : (
+                <Square
+                  className={cn('mt-0.5 size-3 shrink-0', inProgress && 'fill-current')}
+                  aria-hidden="true"
+                />
+              )}
+              <span
+                className={cn(
+                  'min-w-0 break-words',
+                  inProgress && 'font-semibold',
+                  completed && 'line-through decoration-border'
+                )}
+              >
+                {taskTitle(task)}
+              </span>
+            </li>
+          )
+        })}
+      </ul>
+      {hidden.length > 0 ? (
+        <div className="mt-1.5 font-mono text-muted-foreground">
+          {hiddenCompleted
+            ? translate('components.native-chat.tasks.moreCompleted', '+{{value0}} completed', {
+                value0: hidden.length
+              })
+            : translate('components.native-chat.tasks.more', '+{{value0}} more', {
+                value0: hidden.length
+              })}
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -13326,6 +13326,12 @@
         "running": "Running…",
         "result": "Result"
       },
+      "tasks": {
+        "summaryOne": "1 task ({{value1}} done, {{value2}} in progress, {{value3}} open)",
+        "summary": "{{value0}} tasks ({{value1}} done, {{value2}} in progress, {{value3}} open)",
+        "moreCompleted": "+{{value0}} completed",
+        "more": "+{{value0}} more"
+      },
       "status": {
         "responding": "Agent is responding"
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -13303,6 +13303,12 @@
         "running": "Ejecutando…",
         "result": "Resultado"
       },
+      "tasks": {
+        "summaryOne": "1 tarea ({{value1}} completada, {{value2}} en curso, {{value3}} pendiente)",
+        "summary": "{{value0}} tareas ({{value1}} completadas, {{value2}} en curso, {{value3}} pendientes)",
+        "moreCompleted": "+{{value0}} completadas",
+        "more": "+{{value0}} más"
+      },
       "status": {
         "responding": "El agente está respondiendo"
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -13303,6 +13303,12 @@
         "running": "実行中…",
         "result": "結果"
       },
+      "tasks": {
+        "summaryOne": "タスク1件（完了{{value1}}件、進行中{{value2}}件、未着手{{value3}}件）",
+        "summary": "タスク{{value0}}件（完了{{value1}}件、進行中{{value2}}件、未着手{{value3}}件）",
+        "moreCompleted": "+{{value0}}件完了",
+        "more": "+{{value0}}件"
+      },
       "status": {
         "responding": "Agent が応答中です"
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -13303,6 +13303,12 @@
         "running": "실행 중…",
         "result": "결과"
       },
+      "tasks": {
+        "summaryOne": "작업 1개 (완료 {{value1}}개, 진행 중 {{value2}}개, 대기 {{value3}}개)",
+        "summary": "작업 {{value0}}개 (완료 {{value1}}개, 진행 중 {{value2}}개, 대기 {{value3}}개)",
+        "moreCompleted": "+{{value0}}개 완료",
+        "more": "+{{value0}}개 더 보기"
+      },
       "status": {
         "responding": "Agent이 응답 중입니다."
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -13303,6 +13303,12 @@
         "running": "正在运行…",
         "result": "结果"
       },
+      "tasks": {
+        "summaryOne": "1 个任务（{{value1}} 个已完成，{{value2}} 个进行中，{{value3}} 个待处理）",
+        "summary": "{{value0}} 个任务（{{value1}} 个已完成，{{value2}} 个进行中，{{value3}} 个待处理）",
+        "moreCompleted": "+{{value0}} 个已完成",
+        "more": "+{{value0}} 个更多任务"
+      },
       "status": {
         "responding": "智能体正在回复"
       },

--- a/src/renderer/src/i18n/native-chat-locales.test.ts
+++ b/src/renderer/src/i18n/native-chat-locales.test.ts
@@ -50,6 +50,11 @@ describe('native chat locale copy', () => {
       for (const key of ['on', 'off'] as const) {
         expect(composer.optionValue[key].trim()).not.toBe('')
       }
+      const tasks = catalog.components['native-chat'].tasks
+      for (const key of ['summaryOne', 'summary', 'moreCompleted', 'more'] as const) {
+        expect(tasks[key].trim()).not.toBe('')
+        expect(tasks[key]).not.toBe(en.components['native-chat'].tasks[key])
+      }
     }
   )
 })

--- a/src/shared/native-chat-task-list.test.ts
+++ b/src/shared/native-chat-task-list.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest'
+import type { NativeChatBlock, NativeChatMessage } from './native-chat-types'
+import { deriveNativeChatTasks, withoutNativeChatTaskToolBlocks } from './native-chat-task-list'
+
+function message(id: string, blocks: NativeChatBlock[]): NativeChatMessage {
+  return { id, role: 'assistant', blocks, timestamp: 0, source: 'transcript' }
+}
+
+describe('deriveNativeChatTasks', () => {
+  it('uses the latest legacy TodoWrite snapshot', () => {
+    const tasks = deriveNativeChatTasks([
+      message('todos', [
+        {
+          type: 'tool-call',
+          name: 'TodoWrite',
+          input: {
+            todos: [
+              { content: 'Inspect the decoder', status: 'completed' },
+              {
+                content: 'Render the task list',
+                activeForm: 'Rendering the task list',
+                status: 'in_progress'
+              }
+            ]
+          }
+        }
+      ])
+    ])
+
+    expect(tasks).toMatchObject([
+      { subject: 'Inspect the decoder', status: 'completed' },
+      {
+        subject: 'Render the task list',
+        activeForm: 'Rendering the task list',
+        status: 'in_progress'
+      }
+    ])
+  })
+
+  it('accumulates TaskCreate results and applies TaskUpdate patches by id', () => {
+    const tasks = deriveNativeChatTasks([
+      message('create', [
+        {
+          type: 'tool-call',
+          name: 'TaskCreate',
+          input: { subject: 'Add tests', activeForm: 'Adding tests' }
+        }
+      ]),
+      message('create-result', [
+        { type: 'tool-result', output: '{"task":{"id":"7","subject":"Add tests"}}' }
+      ]),
+      message('update', [
+        {
+          type: 'tool-call',
+          name: 'TaskUpdate',
+          input: { taskId: '7', status: 'in_progress' }
+        },
+        { type: 'tool-result', output: 'updated' }
+      ])
+    ])
+
+    expect(tasks).toEqual([
+      { id: '7', subject: 'Add tests', activeForm: 'Adding tests', status: 'in_progress' }
+    ])
+  })
+
+  it.each(['task_id', 'id'] as const)(
+    'accepts repaired %s keys preserved in streamed TaskUpdate input',
+    (taskIdKey) => {
+      const tasks = deriveNativeChatTasks([
+        message('create', [
+          { type: 'tool-call', name: 'TaskCreate', input: { subject: 'Add tests' } },
+          { type: 'tool-result', output: '{"task":{"id":"7","subject":"Add tests"}}' }
+        ]),
+        message('update', [
+          {
+            type: 'tool-call',
+            name: 'TaskUpdate',
+            input: { [taskIdKey]: '7', status: 'completed' }
+          },
+          { type: 'tool-result', output: 'updated' }
+        ])
+      ])
+
+      expect(tasks).toEqual([{ id: '7', subject: 'Add tests', status: 'completed' }])
+    }
+  )
+
+  it('replaces partial accumulated state with a TaskList snapshot', () => {
+    const tasks = deriveNativeChatTasks([
+      message('create', [
+        { type: 'tool-call', name: 'TaskCreate', input: { subject: 'Partial' } },
+        { type: 'tool-result', output: 'Task #1 created successfully' }
+      ]),
+      message('list', [
+        { type: 'tool-call', name: 'TaskList', input: {} },
+        {
+          type: 'tool-result',
+          output: JSON.stringify({
+            tasks: [
+              { id: '2', subject: 'Current work', status: 'in_progress' },
+              { id: '3', subject: 'Next work', status: 'pending' }
+            ]
+          })
+        }
+      ])
+    ])
+
+    expect(tasks).toEqual([
+      { id: '2', subject: 'Current work', status: 'in_progress' },
+      { id: '3', subject: 'Next work', status: 'pending' }
+    ])
+  })
+
+  it('ignores failed task mutations', () => {
+    const tasks = deriveNativeChatTasks([
+      message('failed', [
+        { type: 'tool-call', name: 'TaskCreate', input: { subject: 'Never created' } },
+        { type: 'tool-result', output: 'validation failed', isError: true }
+      ])
+    ])
+
+    expect(tasks).toEqual([])
+  })
+
+  it('clears accumulated state when TaskList reports no tasks', () => {
+    const tasks = deriveNativeChatTasks([
+      message('create', [
+        { type: 'tool-call', name: 'TaskCreate', input: { subject: 'Temporary' } },
+        { type: 'tool-result', output: 'Task #1 created successfully' }
+      ]),
+      message('list', [
+        { type: 'tool-call', name: 'TaskList', input: {} },
+        { type: 'tool-result', output: 'No tasks found.' }
+      ])
+    ])
+
+    expect(tasks).toEqual([])
+  })
+})
+
+describe('withoutNativeChatTaskToolBlocks', () => {
+  it('removes task calls and their FIFO results while preserving other tools', () => {
+    const blocks: NativeChatBlock[] = [
+      { type: 'text', text: 'Working' },
+      { type: 'tool-call', name: 'TaskUpdate', input: { taskId: '1' } },
+      { type: 'tool-call', name: 'Bash', input: { command: 'pnpm test' } },
+      { type: 'tool-result', output: 'task updated' },
+      { type: 'tool-result', output: 'tests passed' }
+    ]
+
+    expect(withoutNativeChatTaskToolBlocks(blocks)).toEqual([
+      { type: 'text', text: 'Working' },
+      { type: 'tool-call', name: 'Bash', input: { command: 'pnpm test' } },
+      { type: 'tool-result', output: 'tests passed' }
+    ])
+  })
+})

--- a/src/shared/native-chat-task-list.ts
+++ b/src/shared/native-chat-task-list.ts
@@ -1,0 +1,307 @@
+import { pairToolBlocks, type NativeChatToolPair } from './native-chat-tool-fold'
+import type { NativeChatBlock, NativeChatMessage } from './native-chat-types'
+
+export const NATIVE_CHAT_TASK_STATUSES = ['pending', 'in_progress', 'completed'] as const
+export type NativeChatTaskStatus = (typeof NATIVE_CHAT_TASK_STATUSES)[number]
+
+export type NativeChatTask = {
+  id: string
+  subject: string
+  activeForm?: string
+  status: NativeChatTaskStatus
+}
+
+const TASK_TOOL_NAMES = new Set(['TodoWrite', 'TaskCreate', 'TaskGet', 'TaskList', 'TaskUpdate'])
+
+export function isNativeChatTaskToolName(name: string): boolean {
+  return TASK_TOOL_NAMES.has(name)
+}
+
+/** Rebuild Claude's latest task snapshot from its transcript tool stream. */
+export function deriveNativeChatTasks(messages: readonly NativeChatMessage[]): NativeChatTask[] {
+  // Why: current Claude sessions emit task mutations rather than a full checklist;
+  // replaying them keeps native chat aligned with the terminal's latest state.
+  const blocks = messages.flatMap((message) => message.blocks)
+  const tasks = new Map<string, NativeChatTask>()
+
+  for (const [index, pair] of pairToolBlocks(blocks).entries()) {
+    applyTaskToolPair(tasks, pair, index)
+  }
+
+  return [...tasks.values()]
+}
+
+/** Remove task-management calls once their richer list is visible. */
+export function withoutNativeChatTaskToolBlocks(
+  blocks: readonly NativeChatBlock[]
+): NativeChatBlock[] {
+  const output: NativeChatBlock[] = []
+  const taskCalls: boolean[] = []
+  let resultOrdinal = 0
+
+  for (const block of blocks) {
+    if (block.type === 'tool-call') {
+      const isTaskCall = isNativeChatTaskToolName(block.name)
+      taskCalls.push(isTaskCall)
+      if (!isTaskCall) {
+        output.push(block)
+      }
+      continue
+    }
+    if (block.type === 'tool-result') {
+      const belongsToTaskCall = taskCalls[resultOrdinal]
+      if (belongsToTaskCall !== undefined) {
+        resultOrdinal += 1
+      }
+      if (belongsToTaskCall !== true) {
+        output.push(block)
+      }
+      continue
+    }
+    output.push(block)
+  }
+
+  return output
+}
+
+function applyTaskToolPair(
+  tasks: Map<string, NativeChatTask>,
+  pair: NativeChatToolPair,
+  pairIndex: number
+): void {
+  const call = pair.call
+  if (!call || !isNativeChatTaskToolName(call.name) || pair.result?.isError === true) {
+    return
+  }
+
+  if (call.name === 'TodoWrite') {
+    const snapshot = legacyTodoSnapshot(call.input)
+    if (snapshot) {
+      replaceTasks(tasks, snapshot)
+    }
+    return
+  }
+
+  if (call.name === 'TaskList') {
+    const snapshot = taskSnapshotFromOutput(pair.result?.output)
+    if (snapshot) {
+      replaceTasks(tasks, snapshot)
+    }
+    return
+  }
+
+  if (call.name === 'TaskGet') {
+    const task = taskFromToolOutput(pair.result?.output)
+    if (task) {
+      upsertTask(tasks, task)
+    }
+    return
+  }
+
+  if (call.name === 'TaskCreate') {
+    applyTaskCreate(tasks, call.input, pair.result?.output, pairIndex)
+    return
+  }
+
+  applyTaskUpdate(tasks, call.input, pair.result?.output)
+}
+
+function applyTaskCreate(
+  tasks: Map<string, NativeChatTask>,
+  input: unknown,
+  output: string | undefined,
+  pairIndex: number
+): void {
+  const inputRecord = recordOf(input)
+  const subject = stringOf(inputRecord?.subject)
+  if (!subject) {
+    return
+  }
+  const resultTask = taskFromToolOutput(output)
+  const id = resultTask?.id ?? taskIdFromOutput(output) ?? `pending:${pairIndex}:${subject}`
+  upsertTask(tasks, {
+    id,
+    subject: resultTask?.subject ?? subject,
+    status: resultTask?.status ?? 'pending',
+    ...optionalActiveForm(resultTask?.activeForm ?? activeFormOf(inputRecord))
+  })
+}
+
+function applyTaskUpdate(
+  tasks: Map<string, NativeChatTask>,
+  input: unknown,
+  output: string | undefined
+): void {
+  const inputRecord = recordOf(input)
+  const resultTask = taskFromToolOutput(output)
+  const id = taskIdOf(inputRecord) ?? resultTask?.id
+  if (!id) {
+    return
+  }
+  if (inputRecord?.status === 'deleted') {
+    tasks.delete(id)
+    return
+  }
+
+  const current = tasks.get(id)
+  const subject = stringOf(inputRecord?.subject) ?? resultTask?.subject ?? current?.subject
+  if (!subject) {
+    return
+  }
+  const status =
+    taskStatusOf(inputRecord?.status) ?? resultTask?.status ?? current?.status ?? 'pending'
+  upsertTask(tasks, {
+    id,
+    subject,
+    status,
+    ...optionalActiveForm(
+      activeFormOf(inputRecord) ?? resultTask?.activeForm ?? current?.activeForm
+    )
+  })
+}
+
+function replaceTasks(tasks: Map<string, NativeChatTask>, snapshot: NativeChatTask[]): void {
+  tasks.clear()
+  for (const task of snapshot) {
+    tasks.set(task.id, task)
+  }
+}
+
+function upsertTask(tasks: Map<string, NativeChatTask>, task: NativeChatTask): void {
+  const current = tasks.get(task.id)
+  tasks.set(task.id, current ? { ...current, ...task } : task)
+}
+
+function legacyTodoSnapshot(input: unknown): NativeChatTask[] | null {
+  const todos = recordOf(input)?.todos
+  if (!Array.isArray(todos)) {
+    return null
+  }
+  const snapshot: NativeChatTask[] = []
+  for (const [index, value] of todos.entries()) {
+    const record = recordOf(value)
+    const subject = stringOf(record?.content) ?? stringOf(record?.subject)
+    if (!subject) {
+      continue
+    }
+    snapshot.push({
+      id: stringOf(record?.id) ?? `todo:${index}:${subject}`,
+      subject,
+      status: taskStatusOf(record?.status) ?? 'pending',
+      ...optionalActiveForm(activeFormOf(record))
+    })
+  }
+  return snapshot
+}
+
+function taskSnapshotFromOutput(output: string | undefined): NativeChatTask[] | null {
+  if (!output) {
+    return null
+  }
+  const parsed = parseToolOutput(output)
+  const record = recordOf(parsed)
+  const values = Array.isArray(parsed) ? parsed : record?.tasks
+  if (Array.isArray(values)) {
+    const tasks = values
+      .map((value, index) => taskFromUnknown(value, `task:${index}`))
+      .filter((task): task is NativeChatTask => task !== null)
+    return tasks
+  }
+  return taskSnapshotFromText(output)
+}
+
+function taskSnapshotFromText(output: string): NativeChatTask[] | null {
+  if (/^no tasks(?: found)?[.!]?$/i.test(output.trim())) {
+    return []
+  }
+  const tasks: NativeChatTask[] = []
+  for (const line of output.split('\n')) {
+    const match = line
+      .trim()
+      .match(/^#?([^\s.]+)[.)]?\s+\[(pending|in_progress|completed)\]\s+(.+)$/)
+    if (!match) {
+      continue
+    }
+    tasks.push({ id: match[1]!, status: match[2] as NativeChatTaskStatus, subject: match[3]! })
+  }
+  return tasks.length > 0 ? tasks : null
+}
+
+function taskFromToolOutput(output: string | undefined): NativeChatTask | null {
+  if (!output) {
+    return null
+  }
+  const parsed = parseToolOutput(output)
+  const record = recordOf(parsed)
+  return taskFromUnknown(record?.task ?? parsed)
+}
+
+function taskFromUnknown(value: unknown, fallbackId?: string): NativeChatTask | null {
+  const record = recordOf(value)
+  if (!record) {
+    return null
+  }
+  const subject = stringOf(record.subject) ?? stringOf(record.content)
+  const id = taskIdOf(record) ?? fallbackId
+  if (!subject || !id) {
+    return null
+  }
+  return {
+    id,
+    subject,
+    status: taskStatusOf(record.status) ?? 'pending',
+    ...optionalActiveForm(activeFormOf(record))
+  }
+}
+
+function taskIdFromOutput(output: string | undefined): string | null {
+  if (!output) {
+    return null
+  }
+  return (
+    output.match(/\btask\s+#([^\s,:]+)/i)?.[1] ??
+    output.match(/\btask(?:\s+id)?\s*[:=]\s*([^\s,]+)/i)?.[1] ??
+    null
+  )
+}
+
+function parseToolOutput(output: string): unknown {
+  const trimmed = output.trim()
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i)?.[1] ?? trimmed
+  try {
+    return JSON.parse(fenced) as unknown
+  } catch {
+    return null
+  }
+}
+
+function taskStatusOf(value: unknown): NativeChatTaskStatus | null {
+  return value === 'pending' || value === 'in_progress' || value === 'completed' ? value : null
+}
+
+function activeFormOf(record: Record<string, unknown> | null | undefined): string | undefined {
+  return stringOf(record?.activeForm) ?? stringOf(record?.active_form) ?? undefined
+}
+
+function taskIdOf(record: Record<string, unknown> | null | undefined): string | null {
+  // Why: Claude streams repaired task inputs with either camelCase or snake_case keys.
+  return stringOf(record?.taskId) ?? stringOf(record?.task_id) ?? stringOf(record?.id)
+}
+
+function optionalActiveForm(activeForm: string | undefined): { activeForm?: string } {
+  return activeForm ? { activeForm } : {}
+}
+
+function recordOf(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function stringOf(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed || null
+  }
+  return typeof value === 'number' && Number.isFinite(value) ? String(value) : null
+}


### PR DESCRIPTION
## Summary

- Rebuild Claude's latest task state from legacy `TodoWrite` and current `TaskCreate`, `TaskUpdate`, `TaskGet`, and `TaskList` transcript operations.
- Render a compact native-chat checklist with summary counts, active/pending/completed ordering, active-form copy, and Claude's five-row cap.
- Replace duplicate raw task-tool activity only for Claude/OpenClaude sessions; identically named tools from Codex and other agents remain untouched.
- Localize the task UI across all five desktop catalogs and add parser, transcript, renderer, provider-isolation, and locale coverage.

## Screenshots

| Light | Dark |
| --- | --- |
| ![Claude task progress in native chat, light theme](https://raw.githubusercontent.com/kaynansc/orca/pr-assets-native-chat-claude-tasks/native-chat-task-list-light.png) | ![Claude task progress in native chat, dark theme](https://raw.githubusercontent.com/kaynansc/orca/pr-assets-native-chat-claude-tasks/native-chat-task-list-dark.png) |

## Testing

- [ ] `pnpm lint` — the changed files pass oxlint, type-aware lint, formatting, locale catalog validation, and locale coverage. The repository-wide command remains blocked by an existing `switch-exhaustiveness-check` error in untouched `src/renderer/src/components/skills/skill-freshness-group.tsx:101`.
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the focused suite passes (5 files, 27 tests). The repository-wide suite reaches 3,007 passing files / 31,891 passing tests but an existing untouched installer test, `drains stdin when the managed script is executable but unreadable`, blocks on `cat >/dev/null`; terminating that subprocess records the single failure.
- [x] `pnpm build`
- [x] Electron/Playwright visual E2E passes in light and dark themes (1 test) and produced the screenshots above.
- [x] Added high-quality tests for the new behavior.

## AI Review Report

- Standards review: `VERDICT: OK`
- Spec review: `VERDICT: OK`
- Cross-platform: no OS-specific shortcuts, paths, commands, or Git behavior were added.
- Local/SSH: task reconstruction consumes the existing normalized native-chat transcript model, after the current local/SSH transport boundary.
- Agents/integrations: task rendering is gated through `resolveNativeChatTranscriptAgent(...) === 'claude'`, covering Claude/OpenClaude while preserving Codex, Grok, and custom tool rows.
- Performance: reconstruction is a linear pass over the already-loaded transcript window; rendered output is capped at five rows.
- UI/UX: uses existing semantic tokens and typography/spacing conventions; verified visually in light and dark themes.

## Security Audit

- Treats transcript payloads as untrusted data with record/string/status guards and fail-closed JSON parsing.
- Renders task copy as React text only; no raw HTML, command execution, path access, IPC surface, dependency, or authentication changes.
- Failed tool mutations are ignored, so unsuccessful operations do not alter displayed task state.

## Notes

- Claude documents that streamed task updates may retain `taskId`, `task_id`, or repaired `id` keys; the parser accepts all three and has regression coverage.
- No source-control or Git-provider behavior changed.
- X: @KaynanSampaio1

## ELI5

Native chat can show Claude's task checklist while work is running. You get a compact progress list of pending, active, and done tasks instead of only raw tool chatter, so it is easier to see what Claude is still working on.
