### PR TITLE
Scale PR comment sidebar typography: 12px body, stepped headings

### DIFF
--- a/src/renderer/src/components/right-sidebar/pr-comment-presentation.test.ts
+++ b/src/renderer/src/components/right-sidebar/pr-comment-presentation.test.ts
@@ -15,7 +15,7 @@ describe('pr-comment-presentation', () => {
   it('returns card layout tokens for cards and focus variants', () => {
     const cards = getPRCommentPresentationClasses('cards')
     expect(cards.useCardLayout).toBe(true)
-    expect(cards.commentBody).toContain('text-[13px]')
+    expect(cards.commentBody).toContain('text-xs')
     expect(cards.commentBody).toContain('leading-relaxed')
     expect(cards.commentBody).toContain('text-foreground')
     expect(cards.group).toContain('bg-secondary')
@@ -25,9 +25,9 @@ describe('pr-comment-presentation', () => {
 
     const focus = getPRCommentPresentationClasses('focus')
     expect(focus.useCardLayout).toBe(true)
-    expect(focus.commentBody).toContain('text-[13px]')
+    expect(focus.commentBody).toContain('text-xs')
     expect(focus.commentBody).toContain('leading-relaxed')
-    expect(focus.commentBodyReply).toContain('text-[13px]')
+    expect(focus.commentBodyReply).toContain('text-xs')
     expect(focus.commentBodyReply).toContain('leading-relaxed')
     expect(focus.author).toContain('text-[13px]')
     expect(focus.list).toContain('gap-2')
@@ -61,7 +61,7 @@ describe('pr-comment-presentation', () => {
     expect(markdown).toContain('[&_pre]:text-xs')
     // Code inside a fence must track the fence, not shrink again.
     expect(markdown).toContain('[&_pre_code]:text-[1em]')
-    expect(markdown).toContain('[&_table]:text-[12px]')
+    expect(markdown).toContain('[&_table]:text-[11px]')
   })
 
   it('stops sub/sup small-print from compounding below the caption tier', () => {
@@ -79,20 +79,20 @@ describe('pr-comment-presentation', () => {
     expect(markdown).not.toContain('[&_sub]:bottom-0')
   })
 
-  it('gives headings a perceptible step over the 13px body', () => {
+  it('gives headings a perceptible step over the 12px body', () => {
     const markdown = getPRCommentPresentationClasses('cards').commentBodyMarkdown
-    // 13px headings over a 12px body was a 1.08x ratio — invisible. Match the
-    // document variant's scale instead.
-    expect(markdown).toContain('[&_.comment-md-h1]:text-[18px]')
-    expect(markdown).toContain('[&_.comment-md-h2]:text-[16px]')
-    expect(markdown).toContain('[&_.comment-md-h3]:text-[15px]')
-    expect(markdown).not.toContain('[&_.comment-md-h1]:text-[13px]')
+    // 13px headings over a 12px body was a 1.08x ratio — invisible. Step the
+    // headings up so the hierarchy reads.
+    expect(markdown).toContain('[&_.comment-md-h1]:text-[16px]')
+    expect(markdown).toContain('[&_.comment-md-h2]:text-[15px]')
+    expect(markdown).toContain('[&_.comment-md-h3]:text-[14px]')
+    expect(markdown).not.toContain('[&_.comment-md-h1]:text-[12px]')
   })
 
   it('promotes bold-then-linebreak labels but not mid-sentence emphasis', () => {
     const markdown = getPRCommentPresentationClasses('cards').commentBodyMarkdown
     const label = '[&_.comment-md-p>strong:first-child:has(+br)'
-    expect(markdown).toContain(`${label}]:text-[15px]`)
+    expect(markdown).toContain(`${label}]:text-[14px]`)
     expect(markdown).toContain(`${label}]:block`)
     expect(markdown).toContain('[&_.comment-md-p:first-child>strong:first-child:has(+br)]:mt-0')
     // Blocking the label makes its own <br> a duplicate break.

--- a/src/renderer/src/components/right-sidebar/pr-comment-presentation.ts
+++ b/src/renderer/src/components/right-sidebar/pr-comment-presentation.ts
@@ -80,18 +80,18 @@ const MARKDOWN_BASE = cn(
   // raw <div> between them otherwise breaks the chain and collapses the tail to zero gap.
   '[&_.comment-md-p]:block [&_.comment-md-p+.comment-md-p]:mt-2 [&>*+*]:mt-2 [&_details]:my-2',
   '[&_.comment-md-h]:mt-4 [&_.comment-md-h]:mb-1 [&_.comment-md-h]:block [&_.comment-md-h]:leading-tight [&_.comment-md-h:first-child]:mt-0',
-  // Why: the document variant's proven scale (18/16/15 over 13px body) — the sidebar was
+  // Why: 16/15/14 over a 12px body — the sidebar was
   // the only surface rendering this markdown with no perceptible heading step.
-  '[&_.comment-md-h1]:text-[18px] [&_.comment-md-h2]:text-[16px] [&_.comment-md-h3]:text-[15px]',
+  '[&_.comment-md-h1]:text-[16px] [&_.comment-md-h2]:text-[15px] [&_.comment-md-h3]:text-[14px]',
   // Why: bots write section titles as bold-then-linebreak, not headings, so those carry
   // the real hierarchy. :has(+br) promotes only those, never mid-sentence emphasis.
-  '[&_.comment-md-p>strong:first-child:has(+br)]:mt-3 [&_.comment-md-p>strong:first-child:has(+br)]:mb-0.5 [&_.comment-md-p>strong:first-child:has(+br)]:block [&_.comment-md-p>strong:first-child:has(+br)]:text-[15px] [&_.comment-md-p>strong:first-child:has(+br)]:leading-tight',
+  '[&_.comment-md-p>strong:first-child:has(+br)]:mt-3 [&_.comment-md-p>strong:first-child:has(+br)]:mb-0.5 [&_.comment-md-p>strong:first-child:has(+br)]:block [&_.comment-md-p>strong:first-child:has(+br)]:text-[14px] [&_.comment-md-p>strong:first-child:has(+br)]:leading-tight',
   '[&_.comment-md-p:first-child>strong:first-child:has(+br)]:mt-0',
   // The label's own <br> would double the break once it is block-level.
   '[&_.comment-md-p>strong:first-child:has(+br)+br]:hidden',
   // Why: compact sizes code/pre/tables at 10px inside the prose, shrinking the densest
   // content. 0.92em mirrors the document variant's inline-code ratio.
-  '[&_code]:text-[0.92em] [&_pre]:text-xs [&_pre_code]:text-[1em] [&_table]:text-[12px]',
+  '[&_code]:text-[0.92em] [&_pre]:text-xs [&_pre_code]:text-[1em] [&_table]:text-[11px]',
   // Why: bots use sub/sup as small-print, and the browser's 75% compounds when nested
   // (13px -> 7.3px). An absolute size stops the compounding at the caption tier.
   '[&_sub]:text-[11px] [&_sup]:text-[11px]',
@@ -117,9 +117,8 @@ const COMMENT_AVATAR =
 const RESOLVED_SECTION_LABEL =
   'text-[11px] font-semibold uppercase tracking-wider text-muted-foreground'
 
-// Why: matches the document-variant body (PullRequestPage/GitHubItemDialog) so the same
-// bot markdown reads the same everywhere; 12px left no room for a heading step above it.
-const CARD_COMMENT_BODY_SIZE = 'text-[13px] leading-relaxed'
+// Why: 12px keeps the narrow sidebar dense; the headings carry the hierarchy.
+const CARD_COMMENT_BODY_SIZE = 'text-xs leading-relaxed'
 const CARD_COMMENT_AUTHOR_SIZE = 'text-[13px]'
 const CARD_COMMENT_LIST_GAP = 'gap-2'
 const CARD_COMMENT_BODY_PADDING = 'px-4 py-2.5'


### PR DESCRIPTION
## Summary

Adjusts PR comment sidebar typography to improve hierarchy and readability. Reduces body text to 12px with stepped heading sizes (16/15/14px) to create perceptible visual hierarchy.

## Changes

- Body text: 13px → 12px (`text-xs`)
- H1 heading: 18px → 16px
- H2 heading: 16px → 15px  
- H3 heading: 15px → 14px
- Bold-then-linebreak labels: 15px → 14px
- Table text: 12px → 11px
- Updated test assertions to match new sizes

## Testing

- [x] Test assertions updated for new typography values
- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`

## Notes

Purely typographic refinement with no functional changes. Improves sidebar density while maintaining readable heading hierarchy.