### PR TITLE
Add ABAP to editor file language detection

### DIFF
--- a/src/renderer/src/lib/language-detect.test.ts
+++ b/src/renderer/src/lib/language-detect.test.ts
@@ -38,6 +38,11 @@ describe('detectLanguage', () => {
     expect(detectLanguage('C:\\rtl\\TOP.SV')).toBe('systemverilog')
   })
 
+  it('maps ABAP files to the Monaco built-in abap language id (case-insensitive)', () => {
+    expect(detectLanguage('src/zcor0260.prog.abap')).toBe('abap')
+    expect(detectLanguage('C:\\repo\\src\\ZCL_DEMO.CLAS.ABAP')).toBe('abap')
+  })
+
   it('maps .proto files to the Monaco built-in proto language id, not the alias', () => {
     expect(detectLanguage('api/v1/service.proto')).toBe('proto')
   })

--- a/src/renderer/src/lib/language-detect.ts
+++ b/src/renderer/src/lib/language-detect.ts
@@ -93,6 +93,7 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
   '.nimble': 'nim',
   '.tf': 'hcl',
   '.hcl': 'hcl',
+  '.abap': 'abap',
   '.prisma': 'graphql',
   '.csv': 'csv',
   '.tsv': 'tsv'


### PR DESCRIPTION
## Summary

`.abap` files currently render as plaintext in the file viewer and diff views. Monaco already bundles the ABAP tokenizer (the full `monaco-editor` import registers language id `abap` with extension `.abap`), but `detectLanguage()` in `src/renderer/src/lib/language-detect.ts` only consults its own extension map and falls back to `plaintext` for anything unlisted. This adds the missing `'.abap': 'abap'` entry so ABAP sources (e.g. abapGit-style `*.prog.abap` / `*.clas.abap` files) get Monaco's stock ABAP colorization.

## Screenshots

No screenshot — the change enables Monaco's built-in ABAP colorization for `.abap` files; no layout or interaction changes.

## Testing

- [x] `oxlint` clean on the two changed files (full `pnpm lint` includes repo-wide verify scripts not run here)
- [x] `pnpm typecheck` — `tsc --noEmit -p config/tsconfig.tc.web.json` passes
- [x] `pnpm test` — `vitest run src/renderer/src/lib/language-detect.test.ts`: 11 tests pass, including the new ABAP case
- [ ] `pnpm build` — not run (deps installed with `--ignore-scripts`, no Electron runtime in this environment)
- [x] Added a test covering `.abap` mapping, including a Windows path with an uppercase extension

## AI Review Report

Reviewed with Claude Code. Verified against monaco-editor 0.55.1 (the pinned version) that `esm/vs/basic-languages/abap/abap.contribution.js` registers `{ id: 'abap', extensions: ['.abap'] }`, so the language id used here resolves to a bundled tokenizer and no new grammar registration is needed. Cross-platform: the change is a pure string-map entry; `detectLanguage()` already lowercases extensions and handles both `/` and `\\` separators, and the new test exercises a Windows-style path with an uppercase extension. `mobile/src/session/mobile-file-language.ts` was intentionally left unchanged: mobile highlights via lowlight's `common` bundle, which ships no ABAP grammar, so mapping the extension there would have no effect.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes — a static entry in an extension-to-language lookup table plus a test.

## Notes

If ABAP highlighting on mobile is wanted later, it needs a highlight.js ABAP grammar (third-party) registered into lowlight; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI5

Files ending in .abap were shown as plain text even though the editor already knows ABAP. Adding the extension mapping means ABAP source gets proper language highlighting in the file viewer and diffs.
