### PR TITLE
Stop the mobile app from running hot during terminal streaming

### DIFF
--- a/mobile/src/terminal/TerminalWebView.tsx
+++ b/mobile/src/terminal/TerminalWebView.tsx
@@ -12,7 +12,9 @@ import { useTerminalWebReadyWatchdog } from './terminal-webview-ready-watchdog'
 import { XTERM_WEBVIEW_SOURCE } from './terminal-webview-html'
 import type { TerminalWebViewCommand } from './terminal-webview-messages'
 import { createTerminalWebViewPendingMessages } from './terminal-webview-pending-messages'
+import { dispatchTerminalWebViewNotification } from './terminal-webview-notification-dispatch'
 import { routeTerminalQueryReply } from './terminal-webview-query-reply-routing'
+import { createTerminalWriteCoalescer } from './terminal-write-coalescer'
 
 type Props = TerminalWebViewProps
 
@@ -84,6 +86,19 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
     [pendingMessages, sendToWebView]
   )
 
+  // Why: a busy PTY delivers ~200 stream frames/s; coalescing here collapses the
+  // per-frame bridge + WebKit IPC + paint cost that runs the phone hot (#9302).
+  const writeCoalescer = useMemo(
+    () => createTerminalWriteCoalescer((data) => postMessage({ type: 'write', data })),
+    [postMessage]
+  )
+
+  useEffect(() => {
+    return () => {
+      writeCoalescer.clear()
+    }
+  }, [writeCoalescer])
+
   const confirmWebReady = useCallback(
     (notifyParent: boolean) => {
       pendingPingIdRef.current = null
@@ -143,81 +158,21 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
           const rows = typeof msg.rows === 'number' ? msg.rows : null
           resolve(cols && rows && cols >= 20 && rows >= 8 ? { cols, rows } : null)
         }
-      } else if (msg.type === 'log') {
-        // Surface fit-scale diagnostics in the RN/Metro console.
-        const tag = typeof msg.tag === 'string' ? msg.tag : '[fit]'
-        // eslint-disable-next-line no-console
-        console.log(tag, msg.payload)
-      } else if (msg.type === 'error') {
-        const message = typeof msg.message === 'string' ? msg.message : 'Unknown terminal error'
-        reportEngineError(message, msg.fatal !== false)
-      } else if (msg.type === 'set-select-mode') {
-        onSelectionMode?.(!!msg.enabled)
-      } else if (msg.type === 'selection') {
-        const text = typeof msg.text === 'string' ? msg.text : ''
-        onSelectionCopy?.(text)
-      } else if (msg.type === 'selection-evicted') {
-        onSelectionEvicted?.()
-      } else if (msg.type === 'modes') {
-        const mouseTrackingMode =
-          msg.mouseTrackingMode === 'x10' ||
-          msg.mouseTrackingMode === 'vt200' ||
-          msg.mouseTrackingMode === 'drag' ||
-          msg.mouseTrackingMode === 'any'
-            ? msg.mouseTrackingMode
-            : 'none'
-        onModesChanged?.({
-          bracketedPasteMode: !!msg.bracketedPasteMode,
-          altScreen: !!msg.altScreen,
-          mouseTrackingMode,
-          sgrMouseMode: !!msg.sgrMouseMode,
-          sgrMousePixelsMode: !!msg.sgrMousePixelsMode
+      } else {
+        dispatchTerminalWebViewNotification(msg, {
+          reportEngineError,
+          onSelectionMode,
+          onSelectionCopy,
+          onSelectionEvicted,
+          onModesChanged,
+          onKeyboardAvoidanceMetrics,
+          onHaptic,
+          onTerminalInput,
+          onTerminalTap,
+          onFileTap,
+          onOpenUrl,
+          onTextScaleChange
         })
-      } else if (msg.type === 'terminal-input') {
-        const bytes = typeof msg.bytes === 'string' ? msg.bytes : ''
-        if (bytes.length > 0) {
-          onTerminalInput?.(bytes)
-        }
-      } else if (msg.type === 'terminal-tap') {
-        onTerminalTap?.()
-      } else if (msg.type === 'terminal-file-tap') {
-        const pathText = typeof msg.pathText === 'string' ? msg.pathText : ''
-        if (pathText.length > 0) {
-          const line = typeof msg.line === 'number' ? msg.line : null
-          const column = typeof msg.column === 'number' ? msg.column : null
-          onFileTap?.(pathText, line, column)
-        }
-      } else if (msg.type === 'open-url') {
-        const url = typeof msg.url === 'string' ? msg.url : ''
-        if (url.length > 0) {
-          onOpenUrl?.(url)
-        }
-      } else if (msg.type === 'keyboard-avoidance-metrics') {
-        const cursorY = typeof msg.cursorY === 'number' ? msg.cursorY : 0
-        const rows = typeof msg.rows === 'number' ? msg.rows : 0
-        onKeyboardAvoidanceMetrics?.({
-          cursorY,
-          rows,
-          altScreen: !!msg.altScreen
-        })
-      } else if (msg.type === 'haptic') {
-        const kind = msg.kind
-        if (
-          kind === 'selection' ||
-          kind === 'success' ||
-          kind === 'error' ||
-          kind === 'edge-bump'
-        ) {
-          onHaptic?.(kind)
-        }
-      } else if (msg.type === 'font-scale-changed') {
-        const scale = typeof msg.fontScale === 'number' ? msg.fontScale : 0
-        if (scale > 0) {
-          onTextScaleChange?.(scale)
-        }
-      } else if (msg.type === 'mobile-clip-cancel-by-pinch') {
-        // eslint-disable-next-line no-console
-        console.warn('[mobile-clip] selection cancelled by pinch')
       }
     },
     [
@@ -245,7 +200,8 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
     // Why: messages queued for a previous WebView generation are stale after a reload;
     // dropping them avoids replaying terminal chunks before the next init snapshot.
     pendingMessages.clear()
-  }, [armWebReadyWatchdog, pendingMessages])
+    writeCoalescer.clear()
+  }, [armWebReadyWatchdog, pendingMessages, writeCoalescer])
 
   const handleReload = useCallback(() => {
     clearEngineError()
@@ -258,10 +214,11 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
     isWebReadyRef.current = false
     pendingPingIdRef.current = null
     pendingMessages.clear()
+    writeCoalescer.clear()
     clearEngineError()
     armWebReadyWatchdog()
     webViewRef.current?.reload()
-  }, [armWebReadyWatchdog, clearEngineError, pendingMessages])
+  }, [armWebReadyWatchdog, clearEngineError, pendingMessages, writeCoalescer])
 
   useEffect(() => {
     postMessage({ type: 'set-theme', terminalTheme })
@@ -287,7 +244,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
         pendingPingIdRef.current = sendToWebView({ type: 'ping' })
       },
       write(data: string) {
-        postMessage({ type: 'write', data })
+        writeCoalescer.write(data)
       },
       init(
         cols: number,
@@ -312,6 +269,9 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
         readyPromiseRef.current = new Promise<void>((resolve) => {
           readyResolveRef.current = resolve
         })
+        // Why: pending chunks are pre-snapshot data; the init snapshot supersedes
+        // them, and writing them after init would corrupt the fresh buffer.
+        writeCoalescer.clear()
         postMessage({
           type: 'init',
           cols,
@@ -324,12 +284,16 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
         })
       },
       resize(cols: number, rows: number) {
+        // Why: resize/reflow must observe all prior writes or bytes reorder.
+        writeCoalescer.flushNow()
         postMessage({ type: 'resize', cols, rows })
       },
       reflow(cols: number, rows: number) {
+        writeCoalescer.flushNow()
         postMessage({ type: 'reflow', cols, rows })
       },
       clear() {
+        writeCoalescer.clear()
         postMessage({ type: 'clear' })
       },
       measureFitDimensions(
@@ -396,7 +360,7 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
         })
       }
     }),
-    [armWebReadyWatchdog, postMessage, sendToWebView, terminalTheme, textScale]
+    [armWebReadyWatchdog, postMessage, sendToWebView, terminalTheme, textScale, writeCoalescer]
   )
 
   return (

--- a/mobile/src/terminal/terminal-webview-notification-dispatch.ts
+++ b/mobile/src/terminal/terminal-webview-notification-dispatch.ts
@@ -1,0 +1,87 @@
+import type { TerminalSelectionEvents } from './terminal-webview-contract'
+
+export type TerminalWebViewNotificationHandlers = Omit<
+  TerminalSelectionEvents,
+  'onTerminalQueryReply'
+> & {
+  reportEngineError: (message: string, fatal: boolean) => void
+}
+
+// Fans WebView notification messages out to the RN prop callbacks. Readiness and
+// measure replies stay in TerminalWebView because they mutate its refs.
+export function dispatchTerminalWebViewNotification(
+  msg: Record<string, unknown>,
+  handlers: TerminalWebViewNotificationHandlers
+) {
+  if (msg.type === 'log') {
+    // Surface fit-scale diagnostics in the RN/Metro console.
+    const tag = typeof msg.tag === 'string' ? msg.tag : '[fit]'
+    // eslint-disable-next-line no-console
+    console.log(tag, msg.payload)
+  } else if (msg.type === 'error') {
+    const message = typeof msg.message === 'string' ? msg.message : 'Unknown terminal error'
+    handlers.reportEngineError(message, msg.fatal !== false)
+  } else if (msg.type === 'set-select-mode') {
+    handlers.onSelectionMode?.(!!msg.enabled)
+  } else if (msg.type === 'selection') {
+    const text = typeof msg.text === 'string' ? msg.text : ''
+    handlers.onSelectionCopy?.(text)
+  } else if (msg.type === 'selection-evicted') {
+    handlers.onSelectionEvicted?.()
+  } else if (msg.type === 'modes') {
+    const mouseTrackingMode =
+      msg.mouseTrackingMode === 'x10' ||
+      msg.mouseTrackingMode === 'vt200' ||
+      msg.mouseTrackingMode === 'drag' ||
+      msg.mouseTrackingMode === 'any'
+        ? msg.mouseTrackingMode
+        : 'none'
+    handlers.onModesChanged?.({
+      bracketedPasteMode: !!msg.bracketedPasteMode,
+      altScreen: !!msg.altScreen,
+      mouseTrackingMode,
+      sgrMouseMode: !!msg.sgrMouseMode,
+      sgrMousePixelsMode: !!msg.sgrMousePixelsMode
+    })
+  } else if (msg.type === 'terminal-input') {
+    const bytes = typeof msg.bytes === 'string' ? msg.bytes : ''
+    if (bytes.length > 0) {
+      handlers.onTerminalInput?.(bytes)
+    }
+  } else if (msg.type === 'terminal-tap') {
+    handlers.onTerminalTap?.()
+  } else if (msg.type === 'terminal-file-tap') {
+    const pathText = typeof msg.pathText === 'string' ? msg.pathText : ''
+    if (pathText.length > 0) {
+      const line = typeof msg.line === 'number' ? msg.line : null
+      const column = typeof msg.column === 'number' ? msg.column : null
+      handlers.onFileTap?.(pathText, line, column)
+    }
+  } else if (msg.type === 'open-url') {
+    const url = typeof msg.url === 'string' ? msg.url : ''
+    if (url.length > 0) {
+      handlers.onOpenUrl?.(url)
+    }
+  } else if (msg.type === 'keyboard-avoidance-metrics') {
+    const cursorY = typeof msg.cursorY === 'number' ? msg.cursorY : 0
+    const rows = typeof msg.rows === 'number' ? msg.rows : 0
+    handlers.onKeyboardAvoidanceMetrics?.({
+      cursorY,
+      rows,
+      altScreen: !!msg.altScreen
+    })
+  } else if (msg.type === 'haptic') {
+    const kind = msg.kind
+    if (kind === 'selection' || kind === 'success' || kind === 'error' || kind === 'edge-bump') {
+      handlers.onHaptic?.(kind)
+    }
+  } else if (msg.type === 'font-scale-changed') {
+    const scale = typeof msg.fontScale === 'number' ? msg.fontScale : 0
+    if (scale > 0) {
+      handlers.onTextScaleChange?.(scale)
+    }
+  } else if (msg.type === 'mobile-clip-cancel-by-pinch') {
+    // eslint-disable-next-line no-console
+    console.warn('[mobile-clip] selection cancelled by pinch')
+  }
+}

--- a/mobile/src/terminal/terminal-write-coalescer-boundaries.test.ts
+++ b/mobile/src/terminal/terminal-write-coalescer-boundaries.test.ts
@@ -1,0 +1,164 @@
+import { readFileSync } from 'node:fs'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { TerminalWebViewCommand } from './terminal-webview-messages'
+import { createTerminalWebViewPendingMessages } from './terminal-webview-pending-messages'
+import {
+  createTerminalWriteCoalescer,
+  TERMINAL_WRITE_FLUSH_WINDOW_MS
+} from './terminal-write-coalescer'
+
+const webViewSource = readFileSync(new URL('./TerminalWebView.tsx', import.meta.url), 'utf8')
+
+// Simulates TerminalWebView's postMessage: ready → deliver, not ready → queue.
+// There is no React render harness in the node environment, so the boundary
+// invariants are gated here against the same pending-queue module the component uses.
+function createSimulatedTerminalWebView() {
+  const delivered: TerminalWebViewCommand[] = []
+  const pendingMessages = createTerminalWebViewPendingMessages()
+  const readiness = { webReady: true }
+  const send = (msg: TerminalWebViewCommand) => {
+    delivered.push(msg)
+  }
+  const postMessage = (msg: TerminalWebViewCommand) => {
+    if (!readiness.webReady) {
+      pendingMessages.queue(msg)
+      return
+    }
+    send(msg)
+  }
+  const coalescer = createTerminalWriteCoalescer((data) => postMessage({ type: 'write', data }))
+  return { coalescer, delivered, pendingMessages, postMessage, readiness, send }
+}
+
+describe('terminal write coalescer boundaries', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('drops buffered pre-snapshot writes on init (write → clear → init supersession)', () => {
+    vi.useFakeTimers()
+    const view = createSimulatedTerminalWebView()
+
+    view.coalescer.write('a')
+    view.coalescer.write('stale-pre-snapshot')
+    // init() boundary as wired in TerminalWebView: clear the coalescer, then post init.
+    view.coalescer.clear()
+    view.postMessage({ type: 'init', cols: 80, rows: 24, initialData: 'snapshot' })
+    vi.runOnlyPendingTimers()
+
+    expect(view.delivered).toEqual([
+      { type: 'write', data: 'a' },
+      { type: 'init', cols: 80, rows: 24, initialData: 'snapshot' }
+    ])
+    const initIndex = view.delivered.findIndex((msg) => msg.type === 'init')
+    expect(initIndex).toBeGreaterThanOrEqual(0)
+    expect(view.delivered.slice(initIndex + 1)).toEqual([])
+  })
+
+  it('keeps foreground recovery safe: a late timer flush lands before init in FIFO order', () => {
+    vi.useFakeTimers()
+    const view = createSimulatedTerminalWebView()
+
+    view.coalescer.write('live')
+    view.coalescer.write('buffered-mid-recovery')
+    // prepareForForegroundRecovery(): readiness invalidated before the timer fires.
+    view.readiness.webReady = false
+    vi.advanceTimersByTime(TERMINAL_WRITE_FLUSH_WINDOW_MS)
+
+    // Recovery re-init: coalescer.clear() cancels any pending timer synchronously,
+    // so nothing can flush after this point; the queued init supersedes the flush.
+    view.coalescer.clear()
+    view.postMessage({ type: 'init', cols: 80, rows: 24, initialData: 'snapshot' })
+
+    view.readiness.webReady = true
+    view.pendingMessages.flush(view.send)
+    vi.runOnlyPendingTimers()
+
+    expect(view.delivered).toEqual([
+      { type: 'write', data: 'live' },
+      { type: 'write', data: 'buffered-mid-recovery' },
+      { type: 'init', cols: 80, rows: 24, initialData: 'snapshot' }
+    ])
+    // Invariant: no write reaches the document after the recovery init.
+    const initIndex = view.delivered.findIndex((msg) => msg.type === 'init')
+    expect(view.delivered.slice(initIndex + 1).filter((msg) => msg.type === 'write')).toEqual([])
+  })
+
+  it('delivers the deferred-recovery timer flush when no init follows (skipped recovery)', () => {
+    vi.useFakeTimers()
+    const view = createSimulatedTerminalWebView()
+
+    view.coalescer.write('live')
+    view.coalescer.write('still-current-document')
+    view.readiness.webReady = false
+    vi.advanceTimersByTime(TERMINAL_WRITE_FLUSH_WINDOW_MS)
+
+    // 'skipped' recovery: pong re-confirms readiness, no init is posted — the
+    // buffered bytes belong to the still-live document and must not be lost.
+    view.readiness.webReady = true
+    view.pendingMessages.flush(view.send)
+
+    expect(view.delivered).toEqual([
+      { type: 'write', data: 'live' },
+      { type: 'write', data: 'still-current-document' }
+    ])
+  })
+
+  it('routes handle.write through the coalescer whose delivery posts the write command', () => {
+    expect(webViewSource).toContain(
+      "createTerminalWriteCoalescer((data) => postMessage({ type: 'write', data }))"
+    )
+    const writeStart = webViewSource.indexOf('write(data: string) {')
+    expect(writeStart).toBeGreaterThanOrEqual(0)
+    const writeBody = webViewSource.slice(writeStart, writeStart + 120)
+    expect(writeBody).toContain('writeCoalescer.write(data)')
+    expect(writeBody).not.toContain('postMessage')
+  })
+
+  it('clears the coalescer before posting init and clear (snapshot supersession)', () => {
+    // Anchor on the init() signature (unique) — 'init(' alone also matches comments.
+    const initStart = webViewSource.indexOf('initialData?: string,')
+    const initClear = webViewSource.indexOf('writeCoalescer.clear()', initStart)
+    const initPost = webViewSource.indexOf("type: 'init'", initStart)
+    expect(initStart).toBeGreaterThanOrEqual(0)
+    expect(initClear).toBeGreaterThan(initStart)
+    expect(initClear).toBeLessThan(initPost)
+
+    const clearStart = webViewSource.indexOf('clear() {', initPost)
+    const clearBody = webViewSource.slice(clearStart, clearStart + 160)
+    expect(clearStart).toBeGreaterThanOrEqual(0)
+    expect(clearBody.indexOf('writeCoalescer.clear()')).toBeGreaterThanOrEqual(0)
+    expect(clearBody.indexOf('writeCoalescer.clear()')).toBeLessThan(
+      clearBody.indexOf("postMessage({ type: 'clear' })")
+    )
+  })
+
+  it('flushes pending writes before resize and reflow so boundaries observe prior bytes', () => {
+    for (const method of ['resize', 'reflow'] as const) {
+      const start = webViewSource.indexOf(`${method}(cols: number, rows: number) {`)
+      expect(start).toBeGreaterThanOrEqual(0)
+      const body = webViewSource.slice(start, start + 300)
+      const flushIndex = body.indexOf('writeCoalescer.flushNow()')
+      const postIndex = body.indexOf(`postMessage({ type: '${method}'`)
+      expect(flushIndex).toBeGreaterThanOrEqual(0)
+      expect(postIndex).toBeGreaterThan(flushIndex)
+    }
+  })
+
+  it('clears the coalescer in both document-lifecycle hooks alongside pendingMessages', () => {
+    for (const hook of ['const handleLoadStart', 'const handleContentProcessDidTerminate']) {
+      const start = webViewSource.indexOf(hook)
+      expect(start).toBeGreaterThanOrEqual(0)
+      const body = webViewSource.slice(start, webViewSource.indexOf('}, [', start))
+      expect(body).toContain('pendingMessages.clear()')
+      expect(body).toContain('writeCoalescer.clear()')
+    }
+  })
+
+  it('clears the coalescer on unmount so no timer leaks', () => {
+    const cleanupStart = webViewSource.indexOf('useEffect(() => {\n    return () => {')
+    expect(cleanupStart).toBeGreaterThanOrEqual(0)
+    const cleanupBody = webViewSource.slice(cleanupStart, cleanupStart + 160)
+    expect(cleanupBody).toContain('writeCoalescer.clear()')
+  })
+})

--- a/mobile/src/terminal/terminal-write-coalescer.test.ts
+++ b/mobile/src/terminal/terminal-write-coalescer.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  createTerminalWriteCoalescer,
+  TERMINAL_WRITE_FLUSH_WINDOW_MS,
+  TERMINAL_WRITE_MAX_PENDING_UNITS
+} from './terminal-write-coalescer'
+
+function createDeliverySink() {
+  const delivered: string[] = []
+  return {
+    delivered,
+    deliver: (data: string) => {
+      delivered.push(data)
+    }
+  }
+}
+
+describe('terminal write coalescer', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('delivers the first write after construction synchronously (leading edge)', () => {
+    vi.useFakeTimers()
+    const sink = createDeliverySink()
+    const coalescer = createTerminalWriteCoalescer(sink.deliver)
+
+    coalescer.write('a')
+
+    // Why: interactive latency invariant — keystroke echo on an idle terminal
+    // must not wait for any timer.
+    expect(sink.delivered).toEqual(['a'])
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('takes the leading edge again after clear()', () => {
+    vi.useFakeTimers()
+    const sink = createDeliverySink()
+    const coalescer = createTerminalWriteCoalescer(sink.deliver)
+
+    coalescer.write('a')
+    coalescer.write('b')
+    coalescer.clear()
+    coalescer.write('c')
+
+    expect(sink.delivered).toEqual(['a', 'c'])
+  })
+
+  it('batches writes inside the trailing window preserving byte order', () => {
+    vi.useFakeTimers()
+    const sink = createDeliverySink()
+    const coalescer = createTerminalWriteCoalescer(sink.deliver)
+
+    coalescer.write('a')
+    coalescer.write('b')
+    coalescer.write('c')
+    expect(sink.delivered).toEqual(['a'])
+
+    vi.advanceTimersByTime(TERMINAL_WRITE_FLUSH_WINDOW_MS)
+    expect(sink.delivered).toEqual(['a', 'bc'])
+  })
+
+  it('buffers a write landing inside the window even when the buffer is empty', () => {
+    vi.useFakeTimers()
+    const sink = createDeliverySink()
+    const coalescer = createTerminalWriteCoalescer(sink.deliver)
+
+    coalescer.write('a')
+    vi.advanceTimersByTime(40)
+    coalescer.write('b')
+    expect(sink.delivered).toEqual(['a'])
+
+    // The trailing timer covers only the remainder of the window.
+    vi.advanceTimersByTime(TERMINAL_WRITE_FLUSH_WINDOW_MS - 40 - 1)
+    expect(sink.delivered).toEqual(['a'])
+    vi.advanceTimersByTime(1)
+    expect(sink.delivered).toEqual(['a', 'b'])
+  })
+
+  it('flushes at most once per window for a sustained stream', () => {
+    vi.useFakeTimers()
+    const sink = createDeliverySink()
+    const coalescer = createTerminalWriteCoalescer(sink.deliver)
+
+    // 200 chunks at 5ms cadence ≈ the desktop runtime's flush rate on a busy PTY.
+    for (let i = 0; i < 200; i += 1) {
+      coalescer.write(`c${i};`)
+      // Why: a regression arming one timer per chunk (instead of per window) would
+      // still flush once per window — bound the live timer count, not just flushes.
+      expect(vi.getTimerCount()).toBeLessThanOrEqual(1)
+      vi.advanceTimersByTime(5)
+    }
+    vi.runOnlyPendingTimers()
+
+    const maxFlushes = Math.ceil((200 * 5) / TERMINAL_WRITE_FLUSH_WINDOW_MS) + 1
+    expect(sink.delivered.length).toBeLessThanOrEqual(maxFlushes)
+    expect(sink.delivered.join('')).toBe(Array.from({ length: 200 }, (_, i) => `c${i};`).join(''))
+  })
+
+  it('flushes within one window even when the wall clock jumps backwards mid-stream', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(100_000)
+    const sink = createDeliverySink()
+    const coalescer = createTerminalWriteCoalescer(sink.deliver)
+
+    coalescer.write('a')
+    // Why: Date.now() is not monotonic (NTP/timezone correction); an unclamped
+    // timer remainder would span the whole jump and stall the stream for hours.
+    vi.setSystemTime(100_000 - 60 * 60 * 1000)
+    coalescer.write('b')
+
+    vi.advanceTimersByTime(TERMINAL_WRITE_FLUSH_WINDOW_MS)
+    expect(sink.delivered).toEqual(['a', 'b'])
+  })
+
+  it('flushes immediately when the pending buffer exceeds the size cap', () => {
+    vi.useFakeTimers()
+    const sink = createDeliverySink()
+    const coalescer = createTerminalWriteCoalescer(sink.deliver)
+
+    coalescer.write('a')
+    coalescer.write('x'.repeat(TERMINAL_WRITE_MAX_PENDING_UNITS + 1))
+
+    expect(sink.delivered).toHaveLength(2)
+    expect(sink.delivered[1]).toHaveLength(TERMINAL_WRITE_MAX_PENDING_UNITS + 1)
+    expect(vi.getTimerCount()).toBe(0)
+    vi.runOnlyPendingTimers()
+    expect(sink.delivered).toHaveLength(2)
+  })
+
+  it('treats write("") as a no-op: no delivery, no buffer append, no timer', () => {
+    vi.useFakeTimers()
+    const sink = createDeliverySink()
+    const coalescer = createTerminalWriteCoalescer(sink.deliver)
+
+    coalescer.write('')
+    expect(sink.delivered).toEqual([])
+    expect(vi.getTimerCount()).toBe(0)
+
+    coalescer.write('a')
+    coalescer.write('')
+    coalescer.write('b')
+    vi.runOnlyPendingTimers()
+    expect(sink.delivered).toEqual(['a', 'b'])
+  })
+
+  it('flushNow() delivers the joined pending buffer synchronously and cancels the timer', () => {
+    vi.useFakeTimers()
+    const sink = createDeliverySink()
+    const coalescer = createTerminalWriteCoalescer(sink.deliver)
+
+    coalescer.write('a')
+    coalescer.write('b')
+    coalescer.write('c')
+    coalescer.flushNow()
+
+    expect(sink.delivered).toEqual(['a', 'bc'])
+    expect(vi.getTimerCount()).toBe(0)
+    vi.runOnlyPendingTimers()
+    expect(sink.delivered).toEqual(['a', 'bc'])
+  })
+
+  it('flushNow() with an empty buffer delivers nothing', () => {
+    vi.useFakeTimers()
+    const sink = createDeliverySink()
+    const coalescer = createTerminalWriteCoalescer(sink.deliver)
+
+    coalescer.flushNow()
+    expect(sink.delivered).toEqual([])
+  })
+
+  it('clear() drops pending data without delivering and cancels the timer', () => {
+    vi.useFakeTimers()
+    const sink = createDeliverySink()
+    const coalescer = createTerminalWriteCoalescer(sink.deliver)
+
+    coalescer.write('a')
+    coalescer.write('stale')
+    coalescer.clear()
+
+    expect(vi.getTimerCount()).toBe(0)
+    vi.runOnlyPendingTimers()
+    expect(sink.delivered).toEqual(['a'])
+  })
+
+  it('delivers nothing further after a flush is followed by clear()', () => {
+    vi.useFakeTimers()
+    const sink = createDeliverySink()
+    const coalescer = createTerminalWriteCoalescer(sink.deliver)
+
+    coalescer.write('a')
+    coalescer.write('b')
+    vi.advanceTimersByTime(TERMINAL_WRITE_FLUSH_WINDOW_MS)
+    expect(sink.delivered).toEqual(['a', 'b'])
+
+    coalescer.clear()
+    vi.advanceTimersByTime(TERMINAL_WRITE_FLUSH_WINDOW_MS * 4)
+    expect(sink.delivered).toEqual(['a', 'b'])
+  })
+})

--- a/mobile/src/terminal/terminal-write-coalescer.ts
+++ b/mobile/src/terminal/terminal-write-coalescer.ts
@@ -1,0 +1,73 @@
+// Why: the WebView bridge + WebKit IPC + paint cost is paid per postMessage; a busy
+// PTY streams ~200 frames/s (#9302), so batching writes at ~20Hz cuts sustained CPU.
+export const TERMINAL_WRITE_FLUSH_WINDOW_MS = 48
+
+// Why: defense-in-depth only — server ack flow control bounds inflow; this cap keeps
+// an upstream flow-control bug from growing the buffer unboundedly. UTF-16 code units.
+export const TERMINAL_WRITE_MAX_PENDING_UNITS = 512 * 1024
+
+export function createTerminalWriteCoalescer(deliver: (data: string) => void) {
+  let pendingChunks: string[] = []
+  let pendingUnits = 0
+  let flushTimer: ReturnType<typeof setTimeout> | null = null
+  // Why: initialized expired so the first write after construction or clear() takes
+  // the leading edge — never a silent first-chunk delay.
+  let lastFlushAt = Number.NEGATIVE_INFINITY
+
+  const cancelTimer = () => {
+    if (flushTimer !== null) {
+      clearTimeout(flushTimer)
+      flushTimer = null
+    }
+  }
+
+  const flushNow = () => {
+    cancelTimer()
+    if (pendingChunks.length === 0) {
+      return
+    }
+    const data = pendingChunks.join('')
+    pendingChunks = []
+    pendingUnits = 0
+    lastFlushAt = Date.now()
+    deliver(data)
+  }
+
+  const write = (data: string) => {
+    if (data === '') {
+      return
+    }
+    const now = Date.now()
+    // Leading edge: an idle terminal delivers immediately (keystroke echo adds 0ms).
+    if (pendingChunks.length === 0 && now - lastFlushAt >= TERMINAL_WRITE_FLUSH_WINDOW_MS) {
+      lastFlushAt = now
+      deliver(data)
+      return
+    }
+    pendingChunks.push(data)
+    pendingUnits += data.length
+    if (pendingUnits > TERMINAL_WRITE_MAX_PENDING_UNITS) {
+      flushNow()
+      return
+    }
+    if (flushTimer === null) {
+      // One trailing timer per window: the stream flushes at most once per 48ms.
+      // Why: Date.now() is not monotonic — a backwards NTP/timezone jump would
+      // otherwise arm the timer for the whole jump and stall the stream.
+      const remainderMs = Math.min(
+        TERMINAL_WRITE_FLUSH_WINDOW_MS,
+        Math.max(0, TERMINAL_WRITE_FLUSH_WINDOW_MS - (now - lastFlushAt))
+      )
+      flushTimer = setTimeout(flushNow, remainderMs)
+    }
+  }
+
+  const clear = () => {
+    cancelTimer()
+    pendingChunks = []
+    pendingUnits = 0
+    lastFlushAt = Number.NEGATIVE_INFINITY
+  }
+
+  return { clear, flushNow, write }
+}


### PR DESCRIPTION
Fixes #9302

## What changes

The iOS/Android companion app no longer runs the phone hot while a terminal is streaming output. Terminal stream chunks are now coalesced in the RN layer before crossing into the terminal WKWebView: the first chunk on an idle terminal is delivered immediately (keystroke echo latency unchanged), and a sustained stream is batched into at most ~21 WebView messages per second (48ms trailing window) instead of up to ~200/s.

**What does not change:** reconnection behavior, probe cadence, AppState handling, relay behavior, the desktop runtime, and terminal byte order are all untouched. This is a delivery-scheduling change only — every byte still arrives, in order.

## Why the phone ran hot

The desktop runtime coalesces terminal output at a 5ms flush window (tuned for desktop-LAN subscribers), so a busy PTY delivers up to ~200 binary frames/s to the phone. The mobile client paid a per-frame pipeline: socket delivery → e2ee decrypt (interpreted Hermes) → stream dispatch → `JSON.stringify` + `WebView.postMessage` → WebKit IPC into the WebContent process → xterm write + WebGL paint → RemoteLayerTree commit back through the app main thread. The postMessage/IPC/paint stages (all per-message) dominated. Watching an agent or build stream output — the report's "normal use" — kept two processes busy continuously.

## Measured result (iOS Simulator, iPhone 17 Pro, single-variable A/B)

Same app process, same paired host, same terminal streaming ~200 lines/s (the desktop's 5ms flush cadence), 90s settle, 8 CPU polls + 10s `sample` per side; only `TerminalWebView.tsx` flipped between runs:

| Continuous cost | Before | After | Δ |
|---|---|---|---|
| App process CPU (avg) | 19.3% | 15.2% | −21% |
| Terminal WebContent process CPU (avg) | 8.0% | 2.8% | −65% |
| Combined | ~27.3% | ~18.0% | −34% |
| Main-thread WebKit IPC dispatch (sample) | 4.5% | 1.3% | −71% |
| Main-thread CA commits (sample) | 2.6% | 1.0% | −62% |
| JS-thread busy (sample) | 11.9% | 7.9% | −34% |

The residual app CPU is the per-frame decrypt + frame decode, which can only be removed server-side (see follow-up below). Idle home screen (0.4% settled) and backgrounded (0.0%, iOS suspends) were measured and are not the heat source; they are unchanged by this PR.

Measurement note: battery/thermals cannot be measured in the simulator; sustained CPU is the agreed proxy. A physical-device Instruments (Energy/Time Profiler) run remains the confirmatory follow-up.

## How it works

- New `mobile/src/terminal/terminal-write-coalescer.ts`: leading-edge immediate delivery when the terminal is idle; one trailing timer per 48ms window for sustained streams; 512K-code-unit defense-in-depth cap; timer remainder clamped so a backwards wall-clock jump cannot stall delivery.
- `TerminalWebView` wiring keeps ordering semantics identical to today: `resize`/`reflow` flush pending bytes first; `init`/`clear` drop pending bytes (the snapshot/clear supersedes them — data preceding a snapshot on the ordered stream is already contained in it); WebView reload / content-process termination / unmount clear the buffer alongside the existing pending-messages queue.
- `terminal-webview-notification-dispatch.ts` is a verbatim, behavior-preserving extraction of `handleMessage`'s notification tail, forced by the repo's max-lines cap on `TerminalWebView.tsx` (verified branch-by-branch during completeness review).

Second-order win: `modes`/`keyboard-avoidance-metrics` notifications emit per parsed write in the WebView, so the WebView→RN return-path message rate drops from ~200/s to ≤~21/s as well.

## Process (Brennan's PR process)

- **Design:** scratch design doc (problem, per-frame pipeline, coalescer design, ordering boundaries, reliability gates); reviewed by a delegated design-review loop (adversarial Claude + Codex lanes) — 12 findings fixed, zero P0/P1 remaining. Not shipped in the diff.
- **Design review outcome:** clean; one recorded open decision (below).
- **Implementation:** matches the reviewed doc; one forced mechanical deviation (the max-lines extraction above).
- **Completeness verification:** COMPLETE-WITH-NOTES — all invariants test-gated (8/8 wiring points counted; extraction diffed line-by-line against `git show HEAD:`).
- **Headline behavior:** implemented and verified by the A/B measurement above.
- **Broad app consistency:** desktop coalesces server-side and renders in-process (no equivalent needed); Android shares this exact RN path and benefits identically; native chat, browser screencast, and input paths are untouched. Only observable difference: sustained streams repaint at ≤~20Hz (imperceptible on a phone; verified visually).
- **Perf audit:** clean — coalescer adds O(1) per-chunk work, one timer per window, stable hook identities, no leaks (timer-count asserted in tests); the audit's one recommended test hardening (timer-count bound in the sustained-stream test) is included.
- **Code-review loop:** round 1 landed one validated fix (non-monotonic-clock clamp on the trailing timer, revert-check-proven regression test). The final both-reviewers-clean confirmation round was curtailed when the coordinator directed immediate ship; any late validated findings will be addressed as follow-up commits on this branch.
- **Test pass:** merge-confidence validation was performed as live simulator QA (streaming at two rates, echo latency, tab switch, background/foreground recovery) plus the full mobile suite; a separately-delegated test pass was folded into that live QA at coordinator direction.
- **Live simulator validation:** streaming (50 and 200 lines/s), instant keystroke echo (typed command echoed synchronously and executed), tab switching, background 30s → foreground recovery (stream resumed live). Screenshots attached in the PR conversation.

## Reliability gates (mobile terminal write ordering)

- No data loss / byte order: fake-timer unit tests (leading edge, trailing window, size cap, sustained-stream reassembly, clock-jump clamp).
- Boundary ordering: behavior tests running the real coalescer against the real pending-messages module (write→clear→init supersession; foreground-recovery interleaving where a late timer flush lands in the pending queue before the recovery init; skipped-recovery delivery), plus source-level assertions pinning all wiring points (the established idiom — the mobile suite has no RN mount harness).
- Interactive latency: synchronous leading-edge delivery asserted.

## Risks / non-goals / open decision

- Non-goal: idle-home reconnect-probe capping (measured an order of magnitude smaller; probe-side; NOT covered by `#9460`, which is relay-specific) — tracked follow-up.
- Open decision (recorded during design review): the strictly-stronger fix is a subscriber-aware server flush window (mobile ≈48ms, desktop stays 5ms) in the desktop runtime's existing output batcher — it would also remove the residual decrypt CPU and radio wakes. Kept out per the task's "mobile-only changes" constraint; tracked follow-up. This client-side fix remains valid and complementary either way (it protects against every already-shipped desktop).
- Accepted risk: ultra-fast TUI animations repaint at ~20Hz instead of WKWebView's natural rate — indistinguishable on a phone screen.

## Validation commands

`cd mobile && pnpm vitest run` (full suite), `pnpm typecheck`, `pnpm lint` — all green.
