### PR TITLE
fix: pass allowExceedingIndices to applyPatches to avoid crash on multi-byte files

### DIFF
--- a/src/renderer/src/components/editor/rich-markdown-source-reconcile.ts
+++ b/src/renderer/src/components/editor/rich-markdown-source-reconcile.ts
@@ -107,7 +107,14 @@ export function reconcileSerializedMarkdown({
     diffs = cleanupEfficiency(diffs)
   }
   const patches = makePatches(baseLf, diffs)
-  const [reconciledLf, results] = applyPatches(patches, originalSourceLf)
+  // Why: adjustIndiciesToUcs2 treats patch.start1 (character index) as a UTF-8
+  // byte offset. For multi-byte codepoints (中文, emoji, accented Latin) this
+  // causes advanceTo to overshoot and throw. allowExceedingIndices makes it
+  // return the nearest index instead — fuzzy match in apply() still locates the
+  // correct position, and branch 6's round-trip proof catches any misplacement.
+  const [reconciledLf, results] = applyPatches(patches, originalSourceLf, {
+    allowExceedingIndices: true
+  })
 
   // Branch 5: a hunk that failed to locate in the non-canonical source → the
   // fuzzy match is unreliable here, so fall back to canonical.


### PR DESCRIPTION
## Summary

Fixes #9492: reconcileSerializedMarkdown crashes when saving files with multi-byte characters (中文, emoji, accented Latin).

## Root Cause

`adjustIndiciesToUcs2` in `@sanity/diff-match-patch` treats `patch.start1` (a character index) as a UTF-8 byte offset. For multi-byte codepoints, the byte offset can overshoot the target character index, causing `advanceTo` to throw `"Failed to determine byte offset"`.

## Fix

Pass `allowExceedingIndices: true` to `applyPatches`. This makes `advanceTo` return the nearest index instead of throwing.

## Why This Is Safe

- The subsequent fuzzy match in `apply()` still locates the correct position via context search
- Branch 6's round-trip proof catches any misplacement by re-parsing the reconciled output and comparing against the editor document
- Pure ASCII files are unaffected (character index == byte offset)