### PR TITLE
feat(source-control): add custom git server support (self-hosted, pluggable API flavor)

### DIFF
--- a/src/main/custom-git-server/api-flavor-client.ts
+++ b/src/main/custom-git-server/api-flavor-client.ts
@@ -1,0 +1,51 @@
+import type {
+  CreateHostedReviewInput,
+  CreateHostedReviewResult,
+  HostedReviewInfo
+} from '../../shared/hosted-review'
+import type { CustomGitServer } from '../../shared/custom-git-server'
+
+/** A repository on a configured custom server: the matched server + its owner/repo. */
+export type CustomGitServerRepoRef = {
+  server: CustomGitServer
+  owner: string
+  repo: string
+}
+
+/** Result of verifying a token against a server. */
+export type CustomGitServerVerifyResult = {
+  /** Login/username, or null when authenticated but the account is unknown. */
+  account: string | null
+}
+
+/**
+ * The pluggable seam for a custom git server's API. Each API "flavor" (GitLab,
+ * and later GitHub/Gitea/…) implements this once and is registered in
+ * api-flavor.ts. Clients are pure: given a server + token they hit the REST API;
+ * persistence and remote resolution live elsewhere.
+ */
+export type CustomGitServerFlavorClient = {
+  /** Verify the token. Returns the account on success, null when invalid/unreachable. */
+  verify(server: CustomGitServer, token: string): Promise<CustomGitServerVerifyResult | null>
+  /** Review for a branch (by source branch, falling back to a linked number). */
+  getReviewForBranch(
+    ref: CustomGitServerRepoRef,
+    token: string | null,
+    branch: string,
+    linkedNumber: number | null
+  ): Promise<HostedReviewInfo | null>
+  /** Review by its number/iid. */
+  getReviewByNumber(
+    ref: CustomGitServerRepoRef,
+    token: string | null,
+    number: number
+  ): Promise<HostedReviewInfo | null>
+  /** Open a new review (merge/pull request) for the given input. */
+  createReview(
+    ref: CustomGitServerRepoRef,
+    token: string | null,
+    input: CreateHostedReviewInput,
+    repoPath: string,
+    connectionId?: string | null
+  ): Promise<CreateHostedReviewResult>
+}

--- a/src/main/custom-git-server/api-flavor.ts
+++ b/src/main/custom-git-server/api-flavor.ts
@@ -1,0 +1,17 @@
+import type { CustomGitServerApiFlavor } from '../../shared/custom-git-server'
+import type { CustomGitServerFlavorClient } from './api-flavor-client'
+import { gitlabCompatFlavorClient } from './gitlab-compat-client'
+
+// The registry of API-flavor clients. To support a new custom-server API, add a
+// value to CustomGitServerApiFlavor, implement CustomGitServerFlavorClient, and
+// register it here — nothing else in the provider/persistence/UI plumbing changes.
+const FLAVOR_CLIENTS: Record<CustomGitServerApiFlavor, CustomGitServerFlavorClient> = {
+  gitlab: gitlabCompatFlavorClient
+}
+
+/** The registered API client for a server's flavor. */
+export function getCustomGitServerFlavorClient(
+  flavor: CustomGitServerApiFlavor
+): CustomGitServerFlavorClient {
+  return FLAVOR_CLIENTS[flavor]
+}

--- a/src/main/custom-git-server/gitlab-compat-client.test.ts
+++ b/src/main/custom-git-server/gitlab-compat-client.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Defined inside vi.hoisted so the vi.mock factory (hoisted above imports) can
+// reference the fake error class.
+const { requestJsonMock, FakeHostedReviewApiRequestError } = vi.hoisted(() => {
+  class FakeHostedReviewApiRequestError extends Error {
+    status: number | null
+    timedOut: boolean
+    constructor(message: string, options: { status?: number | null; timedOut?: boolean } = {}) {
+      super(message)
+      this.status = options.status ?? null
+      this.timedOut = options.timedOut ?? false
+    }
+  }
+  return { requestJsonMock: vi.fn(), FakeHostedReviewApiRequestError }
+})
+
+vi.mock('../source-control/hosted-review-api-request', () => ({
+  requestHostedReviewJson: requestJsonMock,
+  HostedReviewApiRequestError: FakeHostedReviewApiRequestError
+}))
+
+vi.mock('../source-control/pull-request-template', () => ({
+  readHostedPullRequestTemplate: vi.fn(async () => '')
+}))
+
+import { gitlabCompatFlavorClient } from './gitlab-compat-client'
+import type { CustomGitServerRepoRef } from './api-flavor-client'
+
+const ref: CustomGitServerRepoRef = {
+  server: {
+    id: 'srv',
+    name: 'My Git Server',
+    host: 'git.example.com',
+    apiBaseUrl: 'https://git.example.com',
+    apiFlavor: 'gitlab'
+  },
+  owner: 'team',
+  repo: 'orca'
+}
+
+function rawMr(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    iid: 7,
+    title: 'My change',
+    state: 'opened',
+    web_url: 'https://git.example.com/team/orca/-/merge_requests/7',
+    updated_at: '2026-01-01T00:00:00Z',
+    sha: 'abc123',
+    target_branch: 'main',
+    head_pipeline: { status: 'success' },
+    ...overrides
+  }
+}
+
+describe('gitlabCompatFlavorClient', () => {
+  beforeEach(() => {
+    requestJsonMock.mockReset()
+  })
+
+  it('verify returns the account on success', async () => {
+    requestJsonMock.mockResolvedValueOnce({ username: 'fanyunqian' })
+    await expect(gitlabCompatFlavorClient.verify(ref.server, 'tok')).resolves.toEqual({
+      account: 'fanyunqian'
+    })
+    // Hits the GitLab v4 /user endpoint with the token.
+    const [url, init] = requestJsonMock.mock.calls[0]
+    expect(String(url)).toBe('https://git.example.com/api/v4/user')
+    expect((init.headers as Record<string, string>)['PRIVATE-TOKEN']).toBe('tok')
+  })
+
+  it('verify returns null when the request fails', async () => {
+    requestJsonMock.mockRejectedValueOnce(new Error('401'))
+    await expect(gitlabCompatFlavorClient.verify(ref.server, 'tok')).resolves.toBeNull()
+  })
+
+  it('maps a branch MR to a custom-provider HostedReviewInfo', async () => {
+    // First call: list by source_branch. Second: single MR (full detail).
+    requestJsonMock.mockResolvedValueOnce([rawMr()]).mockResolvedValueOnce(rawMr())
+    const review = await gitlabCompatFlavorClient.getReviewForBranch(ref, 'tok', 'feature/x', null)
+    expect(review).toMatchObject({
+      provider: 'custom',
+      number: 7,
+      state: 'open',
+      status: 'success',
+      url: 'https://git.example.com/team/orca/-/merge_requests/7',
+      headSha: 'abc123',
+      baseRefName: 'main'
+    })
+  })
+
+  it('returns null when no MR matches the branch and no linked number', async () => {
+    requestJsonMock.mockResolvedValueOnce([])
+    await expect(
+      gitlabCompatFlavorClient.getReviewForBranch(ref, 'tok', 'feature/x', null)
+    ).resolves.toBeNull()
+  })
+
+  it('creates a merge request and returns its number/url', async () => {
+    requestJsonMock.mockResolvedValueOnce(rawMr({ iid: 8, web_url: 'https://git.example.com/mr/8' }))
+    const result = await gitlabCompatFlavorClient.createReview(
+      ref,
+      'tok',
+      { provider: 'custom', base: 'main', head: 'feature/x', title: 'New' },
+      '/repo',
+      null
+    )
+    expect(result).toEqual({ ok: true, number: 8, url: 'https://git.example.com/mr/8' })
+  })
+
+  it('classifies a 401 create failure as auth_required', async () => {
+    requestJsonMock.mockRejectedValueOnce(
+      new FakeHostedReviewApiRequestError('unauthorized', { status: 401 })
+    )
+    const result = await gitlabCompatFlavorClient.createReview(
+      ref,
+      'tok',
+      { provider: 'custom', base: 'main', head: 'feature/x', title: 'New' },
+      '/repo',
+      null
+    )
+    expect(result).toMatchObject({ ok: false, code: 'auth_required' })
+  })
+})

--- a/src/main/custom-git-server/gitlab-compat-client.ts
+++ b/src/main/custom-git-server/gitlab-compat-client.ts
@@ -4,7 +4,7 @@ import type {
   HostedReviewState
 } from '../../shared/hosted-review'
 import type { CustomGitServer } from '../../shared/custom-git-server'
-import type { MRInfo } from '../../shared/types'
+import type { MRInfo } from '../../shared/gitlab-types'
 import {
   normalizeHostedReviewBaseRef,
   normalizeHostedReviewHeadRef

--- a/src/main/custom-git-server/gitlab-compat-client.ts
+++ b/src/main/custom-git-server/gitlab-compat-client.ts
@@ -1,0 +1,297 @@
+import type {
+  CreateHostedReviewResult,
+  HostedReviewInfo,
+  HostedReviewState
+} from '../../shared/hosted-review'
+import type { CustomGitServer } from '../../shared/custom-git-server'
+import type { MRInfo } from '../../shared/types'
+import {
+  normalizeHostedReviewBaseRef,
+  normalizeHostedReviewHeadRef
+} from '../../shared/hosted-review-refs'
+import { derivePipelineStatus, mapMRInfo } from '../gitlab/mappers'
+import {
+  HostedReviewApiRequestError,
+  requestHostedReviewJson
+} from '../source-control/hosted-review-api-request'
+import { readHostedPullRequestTemplate } from '../source-control/pull-request-template'
+import type {
+  CustomGitServerFlavorClient,
+  CustomGitServerRepoRef,
+  CustomGitServerVerifyResult
+} from './api-flavor-client'
+
+const REQUEST_TIMEOUT_MS = 8000
+const CREATE_REQUEST_TIMEOUT_MS = 60_000
+const LIST_PER_PAGE = 20
+
+// Raw GitLab v4 merge-request payload — only the fields mapMRInfo /
+// derivePipelineStatus read. GitLab-compatible servers (e.g. git.example.com)
+// return the same shape, so the GitLab mappers are reused verbatim.
+type RawGitLabMergeRequest = {
+  iid?: number
+  title: string
+  state: string
+  draft?: boolean
+  web_url?: string
+  updated_at?: string
+  sha?: string
+  has_conflicts?: boolean
+  detailed_merge_status?: string
+  target_branch?: string
+  description?: string | null
+  author?: { username?: string | null; avatar_url?: string | null } | null
+  head_pipeline?: { status?: string } | null
+  pipeline?: { status?: string } | null
+}
+
+/** Append the GitLab v4 API path to the server's web/API origin. */
+function apiBaseUrl(server: CustomGitServer): string {
+  const trimmed = server.apiBaseUrl.replace(/\/+$/, '')
+  return /\/api\/v4$/i.test(trimmed) ? trimmed : `${trimmed}/api/v4`
+}
+
+function authHeaders(token: string | null): Record<string, string> {
+  return token ? { 'PRIVATE-TOKEN': token } : {}
+}
+
+/** URL-encode the full `namespace/project` path (nested groups included). */
+function projectId(ref: CustomGitServerRepoRef): string {
+  return encodeURIComponent(`${ref.owner}/${ref.repo}`)
+}
+
+function apiUrl(
+  server: CustomGitServer,
+  path: string,
+  searchParams?: Record<string, string | number>
+): URL {
+  const url = new URL(`${apiBaseUrl(server)}${path}`)
+  if (searchParams) {
+    for (const [key, value] of Object.entries(searchParams)) {
+      url.searchParams.set(key, String(value))
+    }
+  }
+  return url
+}
+
+/** GET returning null on any non-OK / transport error (status-poll friendly). */
+async function requestJson<T>(
+  server: CustomGitServer,
+  token: string | null,
+  path: string,
+  searchParams?: Record<string, string | number>
+): Promise<T | null> {
+  try {
+    return await requestHostedReviewJson<T>(
+      apiUrl(server, path, searchParams),
+      { headers: { Accept: 'application/json', ...authHeaders(token) } },
+      REQUEST_TIMEOUT_MS
+    )
+  } catch {
+    return null
+  }
+}
+
+function mapReviewState(state: MRInfo['state']): HostedReviewState {
+  if (state === 'opened' || state === 'locked') {
+    return 'open'
+  }
+  return state
+}
+
+// Mirror mapGitLabReview (forge-review-mappers) but stamp provider 'custom'.
+function mapCustomReview(mr: MRInfo): HostedReviewInfo {
+  return {
+    provider: 'custom',
+    number: mr.number,
+    title: mr.title,
+    state: mapReviewState(mr.state),
+    url: mr.url,
+    status: mr.pipelineStatus,
+    updatedAt: mr.updatedAt,
+    mergeable: mr.mergeable,
+    ...(mr.headSha ? { headSha: mr.headSha } : {}),
+    ...(mr.baseRefName ? { baseRefName: mr.baseRefName } : {}),
+    ...(mr.conflictSummary ? { conflictSummary: mr.conflictSummary } : {})
+  }
+}
+
+function toReviewInfo(raw: RawGitLabMergeRequest): HostedReviewInfo {
+  const pipelineStatus = derivePipelineStatus(raw.head_pipeline ?? raw.pipeline ?? null)
+  return mapCustomReview(mapMRInfo(raw, pipelineStatus))
+}
+
+async function fetchMergeRequest(
+  ref: CustomGitServerRepoRef,
+  token: string | null,
+  iid: number
+): Promise<HostedReviewInfo | null> {
+  const raw = await requestJson<RawGitLabMergeRequest>(
+    ref.server,
+    token,
+    `/projects/${projectId(ref)}/merge_requests/${iid}`
+  )
+  return raw ? toReviewInfo(raw) : null
+}
+
+function classifyCreateError(error: unknown): CreateHostedReviewResult {
+  const message = error instanceof Error ? error.message : String(error)
+  if (message) {
+    console.warn('createCustomGitServerMergeRequest failed:', message)
+  }
+  const lower = message.toLowerCase()
+  const status = error instanceof HostedReviewApiRequestError ? error.status : null
+  if (
+    status === 401 ||
+    status === 403 ||
+    lower.includes('unauthorized') ||
+    lower.includes('forbidden') ||
+    lower.includes('authentication')
+  ) {
+    return {
+      ok: false,
+      code: 'auth_required',
+      error:
+        'Create MR failed: the custom server rejected the token. Update the token for this server in Settings → Integrations.'
+    }
+  }
+  if (
+    status === 409 ||
+    lower.includes('already exists') ||
+    lower.includes('already open') ||
+    // GitLab's duplicate-MR validation message.
+    lower.includes('another open merge request already exists')
+  ) {
+    return {
+      ok: false,
+      code: 'already_exists',
+      error: 'A merge request already exists for this branch.'
+    }
+  }
+  if (error instanceof HostedReviewApiRequestError && error.timedOut) {
+    return {
+      ok: false,
+      code: 'unknown_completion',
+      error: 'MR creation may have completed. Refreshing branch review state...'
+    }
+  }
+  if (status === 400 || status === 422 || lower.includes('validation')) {
+    return {
+      ok: false,
+      code: 'validation',
+      error:
+        'Create MR failed: the server rejected the merge request. Check the base branch and branch state, then try again.'
+    }
+  }
+  return {
+    ok: false,
+    code: 'unknown',
+    error: 'Create MR failed: the custom server could not create the merge request. Try again in a moment.'
+  }
+}
+
+/** Flavor client for GitLab-compatible servers (GitLab v4 merge-request API). */
+export const gitlabCompatFlavorClient: CustomGitServerFlavorClient = {
+  async verify(server, token): Promise<CustomGitServerVerifyResult | null> {
+    const user = await requestJson<{ username?: string | null; name?: string | null }>(
+      server,
+      token,
+      '/user'
+    )
+    if (!user) {
+      return null
+    }
+    return { account: user.username ?? user.name ?? null }
+  },
+
+  async getReviewForBranch(ref, token, branch, linkedNumber): Promise<HostedReviewInfo | null> {
+    const branchName = branch.replace(/^refs\/heads\//, '')
+    if (branchName) {
+      const list = await requestJson<RawGitLabMergeRequest[]>(
+        ref.server,
+        token,
+        `/projects/${projectId(ref)}/merge_requests`,
+        {
+          source_branch: branchName,
+          state: 'all',
+          order_by: 'updated_at',
+          sort: 'desc',
+          per_page: LIST_PER_PAGE
+        }
+      )
+      // Server filters by source_branch; most-recently-updated wins. Refetch the
+      // single MR so head_pipeline / conflict detail (omitted from list) are present.
+      const iid = list?.[0]?.iid
+      if (typeof iid === 'number') {
+        return fetchMergeRequest(ref, token, iid)
+      }
+    }
+    if (typeof linkedNumber === 'number') {
+      return fetchMergeRequest(ref, token, linkedNumber)
+    }
+    return null
+  },
+
+  getReviewByNumber(ref, token, number): Promise<HostedReviewInfo | null> {
+    return fetchMergeRequest(ref, token, number)
+  },
+
+  async createReview(ref, token, input, repoPath, connectionId): Promise<CreateHostedReviewResult> {
+    const base = normalizeHostedReviewBaseRef(input.base)
+    const head = input.head ? normalizeHostedReviewHeadRef(input.head) : ''
+    const rawTitle = input.title.trim()
+    if (!base || !head || !rawTitle) {
+      return {
+        ok: false,
+        code: 'validation',
+        error: 'Create MR failed: base branch, head branch, and title are required.'
+      }
+    }
+    if (head.toLowerCase() === base.toLowerCase()) {
+      return {
+        ok: false,
+        code: 'validation',
+        error: 'Create MR failed: choose a different base branch before creating a merge request.'
+      }
+    }
+
+    const body =
+      input.useTemplate && !input.body?.trim()
+        ? await readHostedPullRequestTemplate(repoPath, connectionId)
+        : (input.body ?? '')
+    // GitLab has no `draft` create flag — the convention is a `Draft:` title prefix.
+    const title = input.draft && !/^draft:\s*/i.test(rawTitle) ? `Draft: ${rawTitle}` : rawTitle
+
+    try {
+      const raw = await requestHostedReviewJson<RawGitLabMergeRequest>(
+        apiUrl(ref.server, `/projects/${projectId(ref)}/merge_requests`),
+        {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            ...authHeaders(token)
+          },
+          body: JSON.stringify({
+            source_branch: head,
+            target_branch: base,
+            title,
+            description: body
+          })
+        },
+        CREATE_REQUEST_TIMEOUT_MS
+      )
+      const created = toReviewInfo(raw)
+      if (created.number > 0) {
+        return { ok: true, number: created.number, url: created.url }
+      }
+      return {
+        ok: false,
+        code: 'unknown_completion',
+        error: 'MR creation may have completed. Refreshing branch review state...'
+      }
+    } catch (error) {
+      return classifyCreateError(error)
+    }
+  }
+}

--- a/src/main/custom-git-server/repository-ref.test.ts
+++ b/src/main/custom-git-server/repository-ref.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { parseCustomGitServerRemote } from './repository-ref'
+
+describe('parseCustomGitServerRemote', () => {
+  it('parses an https remote', () => {
+    expect(parseCustomGitServerRemote('https://git.example.com/team/orca.git')).toEqual({
+      host: 'git.example.com',
+      owner: 'team',
+      repo: 'orca'
+    })
+  })
+
+  it('parses an scp-like ssh remote', () => {
+    expect(parseCustomGitServerRemote('git@git.example.com:team/orca.git')).toEqual({
+      host: 'git.example.com',
+      owner: 'team',
+      repo: 'orca'
+    })
+  })
+
+  it('keeps nested groups in the owner path', () => {
+    expect(parseCustomGitServerRemote('https://git.example.com/group/sub/orca.git')).toEqual({
+      host: 'git.example.com',
+      owner: 'group/sub',
+      repo: 'orca'
+    })
+  })
+
+  it('keeps the http(s) port in the host', () => {
+    expect(parseCustomGitServerRemote('https://git.example.com:8443/team/orca')).toEqual({
+      host: 'git.example.com:8443',
+      owner: 'team',
+      repo: 'orca'
+    })
+  })
+
+  it('drops the ssh transport port from the host', () => {
+    expect(parseCustomGitServerRemote('ssh://git@git.example.com:2222/team/orca.git')).toEqual({
+      host: 'git.example.com',
+      owner: 'team',
+      repo: 'orca'
+    })
+  })
+
+  it('returns null for a path without owner/repo', () => {
+    expect(parseCustomGitServerRemote('https://git.example.com/orca')).toBeNull()
+  })
+
+  it('returns null for an unsupported protocol', () => {
+    expect(parseCustomGitServerRemote('ftp://git.example.com/team/orca')).toBeNull()
+  })
+})

--- a/src/main/custom-git-server/repository-ref.test.ts
+++ b/src/main/custom-git-server/repository-ref.test.ts
@@ -1,5 +1,19 @@
-import { describe, expect, it } from 'vitest'
-import { parseCustomGitServerRemote } from './repository-ref'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  _resetCustomGitServerRepoRefCache,
+  getCustomGitServerRepoRef,
+  parseCustomGitServerRemote
+} from './repository-ref'
+
+const gitExecFileAsync = vi.fn()
+vi.mock('../git/runner', () => ({ gitExecFileAsync: (...args: unknown[]) => gitExecFileAsync(...args) }))
+vi.mock('../providers/ssh-git-dispatch', () => ({ getSshGitProvider: () => undefined }))
+
+const server = { id: 's1', name: 'S', host: 'git.example.com', apiBaseUrl: 'https://git.example.com', apiFlavor: 'gitlab' as const }
+vi.mock('./server-config-store', () => ({
+  listCustomGitServers: () => [server],
+  getCustomGitServerForHost: (host: string) => (host === server.host ? server : null)
+}))
 
 describe('parseCustomGitServerRemote', () => {
   it('parses an https remote', () => {
@@ -48,5 +62,33 @@ describe('parseCustomGitServerRemote', () => {
 
   it('returns null for an unsupported protocol', () => {
     expect(parseCustomGitServerRemote('ftp://git.example.com/team/orca')).toBeNull()
+  })
+})
+
+describe('getCustomGitServerRepoRef cache TTL', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    gitExecFileAsync.mockReset()
+    _resetCustomGitServerRepoRefCache()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('re-reads a changed origin after the TTL elapses', async () => {
+    gitExecFileAsync
+      .mockResolvedValueOnce({ stdout: 'https://git.example.com/team/orca.git', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'https://git.example.com/team/renamed.git', stderr: '' })
+
+    expect(await getCustomGitServerRepoRef('/repo')).toEqual({ server, owner: 'team', repo: 'orca' })
+    // Within the TTL the cached value is reused (no second git call).
+    vi.advanceTimersByTime(29_000)
+    expect(await getCustomGitServerRepoRef('/repo')).toEqual({ server, owner: 'team', repo: 'orca' })
+    expect(gitExecFileAsync).toHaveBeenCalledTimes(1)
+
+    // Past the TTL the origin is re-read and the new repo is reflected.
+    vi.advanceTimersByTime(2_000)
+    expect(await getCustomGitServerRepoRef('/repo')).toEqual({ server, owner: 'team', repo: 'renamed' })
+    expect(gitExecFileAsync).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/main/custom-git-server/repository-ref.ts
+++ b/src/main/custom-git-server/repository-ref.ts
@@ -1,0 +1,166 @@
+import { gitExecFileAsync } from '../git/runner'
+import { getSshGitProvider } from '../providers/ssh-git-dispatch'
+import { getCustomGitServerForHost, listCustomGitServers } from './server-config-store'
+import type { CustomGitServerRepoRef } from './api-flavor-client'
+
+type LocalGitExecOptions = {
+  wslDistro?: string
+}
+
+type ParsedRemote = { host: string; owner: string; repo: string }
+
+const REPO_REF_CACHE_MAX_ENTRIES = 512
+// Why: cache the (stable) parsed remote, NOT the server match — the configured
+// server list changes at runtime (user adds a server), so the host→server match
+// must be re-evaluated every call against the live config.
+const remoteCache = new Map<string, ParsedRemote | null>()
+
+/** @internal - exposed for tests only */
+export function _resetCustomGitServerRepoRefCache(): void {
+  remoteCache.clear()
+}
+
+function rememberCacheEntry(cacheKey: string, value: ParsedRemote | null): void {
+  remoteCache.set(cacheKey, value)
+  while (remoteCache.size > REPO_REF_CACHE_MAX_ENTRIES) {
+    const oldestKey = remoteCache.keys().next().value
+    if (oldestKey === undefined) {
+      return
+    }
+    remoteCache.delete(oldestKey)
+  }
+}
+
+function decodeSegment(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+/** Parse owner/repo from a remote path. owner may span nested groups. */
+function parseOwnerRepo(pathname: string): { owner: string; repo: string } | null {
+  const parts = pathname
+    .replace(/\/+$/, '')
+    .replace(/\.git$/i, '')
+    .split('/')
+    .map((part) => part.trim())
+    .filter(Boolean)
+  if (parts.length < 2) {
+    return null
+  }
+  const owner = decodeSegment(parts.slice(0, -1).join('/'))
+  const repo = decodeSegment(parts.at(-1) ?? '')
+  return owner && repo ? { owner, repo } : null
+}
+
+/** Parse a remote URL into `{ host, owner, repo }`. */
+export function parseCustomGitServerRemote(remoteUrl: string): ParsedRemote | null {
+  const trimmed = remoteUrl.trim()
+  // scp-like: [user@]host:owner/repo(.git)
+  if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+    const scpLike = trimmed.match(/^(?:[^@/:]+@)?([^:\s/]+):([^\s]+?)(?:\.git)?$/)
+    if (scpLike) {
+      const owner = parseOwnerRepo(scpLike[2])
+      return owner ? { host: scpLike[1].toLowerCase(), ...owner } : null
+    }
+    return null
+  }
+  try {
+    const url = new URL(trimmed)
+    const protocol = url.protocol.toLowerCase()
+    if (!['http:', 'https:', 'ssh:', 'git+ssh:', 'git:'].includes(protocol)) {
+      return null
+    }
+    const parsed = parseOwnerRepo(url.pathname)
+    if (!parsed) {
+      return null
+    }
+    // http(s) endpoint identity includes the port; ssh port is transport-only.
+    const host = protocol === 'http:' || protocol === 'https:' ? url.host : url.hostname
+    return { host: host.toLowerCase(), ...parsed }
+  } catch {
+    return null
+  }
+}
+
+async function getOriginUrl(
+  repoPath: string,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): Promise<string | null> {
+  const sshGitProvider = connectionId ? getSshGitProvider(connectionId) : null
+  if (connectionId && !sshGitProvider) {
+    return null
+  }
+  const { stdout } = sshGitProvider
+    ? await sshGitProvider.exec(['remote', 'get-url', 'origin'], repoPath)
+    : await gitExecFileAsync(['remote', 'get-url', 'origin'], {
+        cwd: repoPath,
+        ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {})
+      })
+  return stdout
+}
+
+/**
+ * Resolve the repository against configured custom servers. Reads the origin
+ * remote (via the repo's own git/ssh runtime) and returns a ref only when the
+ * remote host matches a saved server. API calls themselves originate in main.
+ */
+export async function getCustomGitServerRepoRef(
+  repoPath: string,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): Promise<CustomGitServerRepoRef | null> {
+  const runtimeKey = connectionId ?? `local:${localGitOptions.wslDistro ?? 'host'}`
+  const cacheKey = `${runtimeKey}\0${repoPath}`
+  // Why: when no custom servers are configured, skip the remote probe entirely —
+  // the feature is off, so there's no point spawning `git remote get-url` (and it
+  // keeps unrelated forge-provider detection tests from touching git).
+  if (listCustomGitServers().length === 0) {
+    return null
+  }
+  let parsed: ParsedRemote | null
+  if (remoteCache.has(cacheKey)) {
+    parsed = remoteCache.get(cacheKey)!
+  } else {
+    try {
+      const stdout = await getOriginUrl(repoPath, connectionId, localGitOptions)
+      parsed = stdout ? parseCustomGitServerRemote(stdout) : null
+      // Don't cache under a connection — its tunnel/get-url can be transiently flaky.
+      if (!connectionId) {
+        rememberCacheEntry(cacheKey, parsed)
+      }
+    } catch {
+      return null
+    }
+  }
+  if (!parsed) {
+    return null
+  }
+  // Re-match against the live server list every call so a newly added server is
+  // picked up without a cache invalidation.
+  const server = getCustomGitServerForHost(parsed.host)
+  return server ? { server, owner: parsed.owner, repo: parsed.repo } : null
+}
+
+/** Whether the repo's matched custom server has a usable saved token. */
+export async function isCustomGitServerAuthenticatedForRepo(
+  repoPath: string,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): Promise<boolean> {
+  const ref = await getCustomGitServerRepoRef(repoPath, connectionId, localGitOptions)
+  if (!ref) {
+    return false
+  }
+  try {
+    // Lazy so the electron-backed token store stays out of this module's static
+    // graph (which forge-provider detection depends on).
+    const { getCustomGitServerToken } = await import('./token-store')
+    return getCustomGitServerToken(ref.server.id) !== null
+  } catch {
+    return false
+  }
+}

--- a/src/main/custom-git-server/repository-ref.ts
+++ b/src/main/custom-git-server/repository-ref.ts
@@ -10,10 +10,12 @@ type LocalGitExecOptions = {
 type ParsedRemote = { host: string; owner: string; repo: string }
 
 const REPO_REF_CACHE_MAX_ENTRIES = 512
+// Why: bound staleness so an external `git remote set-url` is re-read soon, not held until eviction.
+const REPO_REF_CACHE_TTL_MS = 30_000
 // Why: cache the (stable) parsed remote, NOT the server match — the configured
 // server list changes at runtime (user adds a server), so the host→server match
 // must be re-evaluated every call against the live config.
-const remoteCache = new Map<string, ParsedRemote | null>()
+const remoteCache = new Map<string, { at: number; value: ParsedRemote | null }>()
 
 /** @internal - exposed for tests only */
 export function _resetCustomGitServerRepoRefCache(): void {
@@ -21,7 +23,7 @@ export function _resetCustomGitServerRepoRefCache(): void {
 }
 
 function rememberCacheEntry(cacheKey: string, value: ParsedRemote | null): void {
-  remoteCache.set(cacheKey, value)
+  remoteCache.set(cacheKey, { at: Date.now(), value })
   while (remoteCache.size > REPO_REF_CACHE_MAX_ENTRIES) {
     const oldestKey = remoteCache.keys().next().value
     if (oldestKey === undefined) {
@@ -122,8 +124,10 @@ export async function getCustomGitServerRepoRef(
     return null
   }
   let parsed: ParsedRemote | null
-  if (remoteCache.has(cacheKey)) {
-    parsed = remoteCache.get(cacheKey)!
+  const cached = remoteCache.get(cacheKey)
+  // Treat a stale entry (past its TTL) as a miss so an external origin change is re-read.
+  if (cached && Date.now() - cached.at <= REPO_REF_CACHE_TTL_MS) {
+    parsed = cached.value
   } else {
     try {
       const stdout = await getOriginUrl(repoPath, connectionId, localGitOptions)

--- a/src/main/custom-git-server/server-config-store.ts
+++ b/src/main/custom-git-server/server-config-store.ts
@@ -108,12 +108,15 @@ function getFile(): CustomGitServerFile {
 /** Persist the full server list to disk (0600) and refresh the cache. */
 export function writeCustomGitServerConfig(servers: CustomGitServer[]): void {
   ensureOrcaDir()
-  cachedFile = { version: 1, servers }
-  fileLoaded = true
-  writeFileSync(getServerFilePath(), JSON.stringify(cachedFile, null, 2), {
+  const nextFile: CustomGitServerFile = { version: 1, servers }
+  writeFileSync(getServerFilePath(), JSON.stringify(nextFile, null, 2), {
     encoding: 'utf-8',
     mode: 0o600
   })
+  // Why: adopt the new state into the cache only after the write succeeds, so a
+  // failed write leaves the cache consistent with what's actually on disk.
+  cachedFile = nextFile
+  fileLoaded = true
 }
 
 /**

--- a/src/main/custom-git-server/server-config-store.ts
+++ b/src/main/custom-git-server/server-config-store.ts
@@ -1,0 +1,154 @@
+import { createHash } from 'node:crypto'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import {
+  DEFAULT_CUSTOM_GIT_SERVER_API_FLAVOR,
+  isCustomGitServerApiFlavor,
+  matchCustomGitServerForHost,
+  normalizeCustomGitServerApiBaseUrl,
+  normalizeCustomGitServerHost,
+  type CustomGitServer,
+  type CustomGitServerApiFlavor,
+  type CustomGitServerDraft
+} from '../../shared/custom-git-server'
+
+// Why: this module is deliberately electron-free (no safeStorage). Repo/provider
+// detection needs only the server list + host match, so keeping tokens out of
+// this path lets forge-provider detection load without pulling `electron` into
+// unrelated test graphs. Token I/O lives in token-store.ts.
+
+type CustomGitServerFile = {
+  version: 1
+  servers: CustomGitServer[]
+}
+
+let cachedFile: CustomGitServerFile | null = null
+let fileLoaded = false
+
+/** @internal - exposed for tests only */
+export function _resetCustomGitServerStoreCache(): void {
+  cachedFile = null
+  fileLoaded = false
+}
+
+/** Orca's per-user config directory (~/.orca), where server config and tokens live. */
+export function getOrcaDir(): string {
+  return join(homedir(), '.orca')
+}
+
+function getServerFilePath(): string {
+  return join(getOrcaDir(), 'custom-git-servers.json')
+}
+
+function ensureOrcaDir(): void {
+  const dir = getOrcaDir()
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+}
+
+function emptyFile(): CustomGitServerFile {
+  return { version: 1, servers: [] }
+}
+
+function normalizeServerRecord(input: unknown): CustomGitServer | null {
+  if (!input || typeof input !== 'object') {
+    return null
+  }
+  const record = input as Record<string, unknown>
+  if (
+    typeof record.id !== 'string' ||
+    typeof record.name !== 'string' ||
+    typeof record.host !== 'string' ||
+    typeof record.apiBaseUrl !== 'string'
+  ) {
+    return null
+  }
+  const apiFlavor: CustomGitServerApiFlavor = isCustomGitServerApiFlavor(record.apiFlavor)
+    ? record.apiFlavor
+    : DEFAULT_CUSTOM_GIT_SERVER_API_FLAVOR
+  return {
+    id: record.id,
+    name: record.name,
+    host: record.host,
+    apiBaseUrl: record.apiBaseUrl,
+    apiFlavor
+  }
+}
+
+function readFileFromDisk(): CustomGitServerFile {
+  const path = getServerFilePath()
+  if (!existsSync(path)) {
+    return emptyFile()
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(path, { encoding: 'utf-8' })) as Partial<
+      CustomGitServerFile
+    >
+    const servers = Array.isArray(parsed.servers)
+      ? parsed.servers
+          .map((server) => normalizeServerRecord(server))
+          .filter((server): server is CustomGitServer => server !== null)
+      : []
+    return { version: 1, servers }
+  } catch {
+    return emptyFile()
+  }
+}
+
+function getFile(): CustomGitServerFile {
+  if (!fileLoaded || !cachedFile) {
+    cachedFile = readFileFromDisk()
+    fileLoaded = true
+  }
+  return cachedFile
+}
+
+/** Persist the full server list to disk (0600) and refresh the cache. */
+export function writeCustomGitServerConfig(servers: CustomGitServer[]): void {
+  ensureOrcaDir()
+  cachedFile = { version: 1, servers }
+  fileLoaded = true
+  writeFileSync(getServerFilePath(), JSON.stringify(cachedFile, null, 2), {
+    encoding: 'utf-8',
+    mode: 0o600
+  })
+}
+
+/**
+ * Deterministic id from host+apiBaseUrl so re-adding the same server is
+ * idempotent (same id → in-place replace, one token file).
+ */
+export function computeCustomGitServerId(host: string, apiBaseUrl: string): string {
+  return createHash('sha256').update(`${host}\n${apiBaseUrl}`).digest('base64url').slice(0, 24)
+}
+
+/** Trim/normalize a UI draft's fields into a storable server shape. */
+export function normalizeCustomGitServerDraft(
+  draft: CustomGitServerDraft
+): Pick<CustomGitServer, 'name' | 'host' | 'apiBaseUrl' | 'apiFlavor'> {
+  return {
+    name: draft.name.trim(),
+    host: normalizeCustomGitServerHost(draft.host),
+    apiBaseUrl: normalizeCustomGitServerApiBaseUrl(draft.apiBaseUrl),
+    apiFlavor: isCustomGitServerApiFlavor(draft.apiFlavor)
+      ? draft.apiFlavor
+      : DEFAULT_CUSTOM_GIT_SERVER_API_FLAVOR
+  }
+}
+
+/** All configured servers (a copy, safe to mutate). */
+export function listCustomGitServers(): CustomGitServer[] {
+  return [...getFile().servers]
+}
+
+/** Look up a configured server by id, or null if none. */
+export function getCustomGitServerById(id: string): CustomGitServer | null {
+  return getFile().servers.find((server) => server.id === id) ?? null
+}
+
+/** Resolve the configured server (if any) that owns `remoteHost`. */
+export function getCustomGitServerForHost(remoteHost: string): CustomGitServer | null {
+  return matchCustomGitServerForHost(remoteHost, getFile().servers)
+}

--- a/src/main/custom-git-server/store.test.ts
+++ b/src/main/custom-git-server/store.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import type * as NodeOs from 'node:os'
+import { join } from 'node:path'
+
+const { homeHolder, safeStorageMock, verifyMock } = vi.hoisted(() => ({
+  homeHolder: { path: '' },
+  safeStorageMock: {
+    isEncryptionAvailable: vi.fn(() => true),
+    encryptString: vi.fn((value: string) => Buffer.from(`enc:${value}`, 'utf-8')),
+    decryptString: vi.fn((value: Buffer) => value.toString('utf-8').replace(/^enc:/, ''))
+  },
+  verifyMock: vi.fn()
+}))
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeOs>()
+  return { ...actual, homedir: () => homeHolder.path }
+})
+
+vi.mock('electron', () => ({ safeStorage: safeStorageMock }))
+
+vi.mock('./api-flavor', () => ({
+  getCustomGitServerFlavorClient: () => ({ verify: verifyMock })
+}))
+
+import {
+  getCustomGitServerById,
+  getCustomGitServerForHost,
+  getCustomGitServerStatuses,
+  getCustomGitServerToken,
+  listCustomGitServers,
+  removeCustomGitServer,
+  saveCustomGitServer,
+  testCustomGitServerConnection,
+  _resetCustomGitServerStore
+} from './store'
+
+const draft = {
+  name: 'My Git Server',
+  host: 'git.example.com',
+  apiBaseUrl: 'https://git.example.com',
+  apiFlavor: 'gitlab' as const,
+  token: 'secret-token'
+}
+
+describe('custom git server store', () => {
+  beforeEach(() => {
+    homeHolder.path = mkdtempSync(join(tmpdir(), 'orca-cgs-'))
+    _resetCustomGitServerStore()
+    verifyMock.mockReset()
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    rmSync(homeHolder.path, { recursive: true, force: true })
+  })
+
+  it('saves, lists, and resolves a server by host', () => {
+    const server = saveCustomGitServer(draft)
+    expect(server.host).toBe('git.example.com')
+    expect(listCustomGitServers()).toHaveLength(1)
+    expect(getCustomGitServerForHost('git@git.example.com:team/repo.git')?.id).toBe(server.id)
+    expect(getCustomGitServerToken(server.id)).toBe('secret-token')
+  })
+
+  it('persists across a cache reset (reads back from disk)', () => {
+    const server = saveCustomGitServer(draft)
+    _resetCustomGitServerStore()
+    expect(listCustomGitServers().map((s) => s.id)).toEqual([server.id])
+    expect(getCustomGitServerToken(server.id)).toBe('secret-token')
+  })
+
+  it('keeps the existing token when updating without one', () => {
+    const server = saveCustomGitServer(draft)
+    saveCustomGitServer({ id: server.id, ...draft, name: 'Renamed', token: '' })
+    expect(getCustomGitServerToken(server.id)).toBe('secret-token')
+    expect(getCustomGitServerById(server.id)?.name).toBe('Renamed')
+  })
+
+  it('removes a server and its token', () => {
+    const server = saveCustomGitServer(draft)
+    removeCustomGitServer(server.id)
+    expect(listCustomGitServers()).toHaveLength(0)
+    expect(getCustomGitServerToken(server.id)).toBeNull()
+  })
+
+  it('reports authenticated status when the flavor verify succeeds', async () => {
+    verifyMock.mockResolvedValue({ account: 'fanyunqian' })
+    saveCustomGitServer(draft)
+    const [status] = await getCustomGitServerStatuses()
+    expect(status).toMatchObject({
+      host: 'git.example.com',
+      configured: true,
+      authenticated: true,
+      account: 'fanyunqian'
+    })
+  })
+
+  it('reports not-authenticated when verify returns null', async () => {
+    verifyMock.mockResolvedValue(null)
+    saveCustomGitServer(draft)
+    const [status] = await getCustomGitServerStatuses()
+    expect(status).toMatchObject({ configured: true, authenticated: false, account: null })
+  })
+
+  it('tests a draft connection without persisting', async () => {
+    verifyMock.mockResolvedValue({ account: 'me' })
+    const result = await testCustomGitServerConnection(draft)
+    expect(result).toEqual({ ok: true, account: 'me' })
+    expect(listCustomGitServers()).toHaveLength(0)
+  })
+
+  it('rejects a draft test with no token', async () => {
+    const result = await testCustomGitServerConnection({ ...draft, token: '' })
+    expect(result.ok).toBe(false)
+  })
+})

--- a/src/main/custom-git-server/store.test.ts
+++ b/src/main/custom-git-server/store.test.ts
@@ -2,16 +2,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import type * as NodeOs from 'node:os'
+import type * as ServerConfigStore from './server-config-store'
 import { join } from 'node:path'
 
-const { homeHolder, safeStorageMock, verifyMock } = vi.hoisted(() => ({
+const { homeHolder, secretStoreMock, verifyMock, writeConfigMock } = vi.hoisted(() => ({
   homeHolder: { path: '' },
-  safeStorageMock: {
+  secretStoreMock: {
     isEncryptionAvailable: vi.fn(() => true),
     encryptString: vi.fn((value: string) => Buffer.from(`enc:${value}`, 'utf-8')),
-    decryptString: vi.fn((value: Buffer) => value.toString('utf-8').replace(/^enc:/, ''))
+    decryptString: vi.fn((value: Buffer) => value.toString('utf-8').replace(/^enc:/, '')),
+    describeProtectionGap: vi.fn(() => null)
   },
-  verifyMock: vi.fn()
+  verifyMock: vi.fn(),
+  // Wraps the real config writer so a single test can force a disk-write
+  // failure and assert the token store stays consistent (rollback / no-orphan).
+  writeConfigMock: vi.fn()
 }))
 
 vi.mock('node:os', async (importOriginal) => {
@@ -19,12 +24,21 @@ vi.mock('node:os', async (importOriginal) => {
   return { ...actual, homedir: () => homeHolder.path }
 })
 
-vi.mock('electron', () => ({ safeStorage: safeStorageMock }))
-
 vi.mock('./api-flavor', () => ({
   getCustomGitServerFlavorClient: () => ({ verify: verifyMock })
 }))
 
+vi.mock('./server-config-store', async (importOriginal) => {
+  const actual = await importOriginal<typeof ServerConfigStore>()
+  return {
+    ...actual,
+    writeCustomGitServerConfig: (
+      servers: Parameters<typeof actual.writeCustomGitServerConfig>[0]
+    ) => writeConfigMock(servers, actual.writeCustomGitServerConfig)
+  }
+})
+
+import { setSecretStore } from '../../shared/secret-store'
 import {
   getCustomGitServerById,
   getCustomGitServerForHost,
@@ -48,9 +62,13 @@ const draft = {
 describe('custom git server store', () => {
   beforeEach(() => {
     homeHolder.path = mkdtempSync(join(tmpdir(), 'orca-cgs-'))
+    setSecretStore(secretStoreMock)
     _resetCustomGitServerStore()
     verifyMock.mockReset()
-    safeStorageMock.isEncryptionAvailable.mockReturnValue(true)
+    // Default: call through to the real writer so a failing test opts in explicitly.
+    writeConfigMock.mockReset()
+    writeConfigMock.mockImplementation((servers, actual) => actual(servers))
+    secretStoreMock.isEncryptionAvailable.mockReturnValue(true)
   })
 
   afterEach(() => {
@@ -84,6 +102,41 @@ describe('custom git server store', () => {
     removeCustomGitServer(server.id)
     expect(listCustomGitServers()).toHaveLength(0)
     expect(getCustomGitServerToken(server.id)).toBeNull()
+  })
+
+  it('rolls the new token back when the config write fails on first save', () => {
+    writeConfigMock.mockImplementationOnce(() => {
+      throw new Error('disk full')
+    })
+    expect(() => saveCustomGitServer(draft)).toThrow('disk full')
+    // Config never committed, so the token must not linger for a phantom server.
+    const id = listCustomGitServers()[0]?.id
+    expect(id).toBeUndefined()
+    _resetCustomGitServerStore()
+    expect(listCustomGitServers()).toHaveLength(0)
+  })
+
+  it('restores the prior token when the config write fails on update', () => {
+    const server = saveCustomGitServer(draft)
+    writeConfigMock.mockImplementationOnce(() => {
+      throw new Error('disk full')
+    })
+    expect(() => saveCustomGitServer({ id: server.id, ...draft, token: 'rotated-token' })).toThrow(
+      'disk full'
+    )
+    // The failed rotation must leave the previously stored token intact.
+    expect(getCustomGitServerToken(server.id)).toBe('secret-token')
+  })
+
+  it('keeps the token when the config write fails during removal', () => {
+    const server = saveCustomGitServer(draft)
+    writeConfigMock.mockImplementationOnce(() => {
+      throw new Error('disk full')
+    })
+    expect(() => removeCustomGitServer(server.id)).toThrow('disk full')
+    // Config write is the source of truth: a failed removal leaves both stores.
+    expect(listCustomGitServers().map((s) => s.id)).toEqual([server.id])
+    expect(getCustomGitServerToken(server.id)).toBe('secret-token')
   })
 
   it('reports authenticated status when the flavor verify succeeds', async () => {
@@ -160,5 +213,27 @@ describe('custom git server store', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('shares one in-flight verify across concurrent status polls', async () => {
+    let resolveVerify: (value: { account: string }) => void = () => {}
+    verifyMock.mockReturnValue(
+      new Promise<{ account: string }>((resolve) => {
+        resolveVerify = resolve
+      })
+    )
+    saveCustomGitServer(draft)
+
+    // Two concurrent polls before the first verify settles must share it, not
+    // each fire their own request at the configured host.
+    const first = getCustomGitServerStatuses()
+    const second = getCustomGitServerStatuses()
+    expect(verifyMock).toHaveBeenCalledTimes(1)
+
+    resolveVerify({ account: 'fanyunqian' })
+    const [[firstStatus], [secondStatus]] = await Promise.all([first, second])
+    expect(firstStatus).toMatchObject({ authenticated: true, account: 'fanyunqian' })
+    expect(secondStatus).toMatchObject({ authenticated: true, account: 'fanyunqian' })
+    expect(verifyMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/custom-git-server/store.test.ts
+++ b/src/main/custom-git-server/store.test.ts
@@ -116,4 +116,49 @@ describe('custom git server store', () => {
     const result = await testCustomGitServerConnection({ ...draft, token: '' })
     expect(result.ok).toBe(false)
   })
+
+  it('caches a successful verify within the TTL and refreshes after it expires', async () => {
+    vi.useFakeTimers()
+    try {
+      verifyMock.mockResolvedValue({ account: 'fanyunqian' })
+      saveCustomGitServer(draft)
+
+      await getCustomGitServerStatuses()
+      await getCustomGitServerStatuses()
+      expect(verifyMock).toHaveBeenCalledTimes(1)
+
+      vi.advanceTimersByTime(30_000 + 1)
+      await getCustomGitServerStatuses()
+      expect(verifyMock).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not cache a failed verify so a transient outage self-heals next tick', async () => {
+    verifyMock.mockResolvedValueOnce(null).mockResolvedValue({ account: 'fanyunqian' })
+    saveCustomGitServer(draft)
+
+    const [first] = await getCustomGitServerStatuses()
+    expect(first).toMatchObject({ authenticated: false })
+    const [second] = await getCustomGitServerStatuses()
+    expect(second).toMatchObject({ authenticated: true, account: 'fanyunqian' })
+    expect(verifyMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('invalidates the cached verify when the server is re-saved', async () => {
+    vi.useFakeTimers()
+    try {
+      verifyMock.mockResolvedValue({ account: 'fanyunqian' })
+      saveCustomGitServer(draft)
+      await getCustomGitServerStatuses()
+      expect(verifyMock).toHaveBeenCalledTimes(1)
+
+      saveCustomGitServer(draft)
+      await getCustomGitServerStatuses()
+      expect(verifyMock).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/src/main/custom-git-server/store.ts
+++ b/src/main/custom-git-server/store.ts
@@ -65,12 +65,32 @@ export function saveCustomGitServer(
   const id = draft.id ?? computeCustomGitServerId(normalized.host, normalized.apiBaseUrl)
   const server: CustomGitServer = { id, ...normalized }
 
-  if (draft.token && draft.token.trim()) {
-    saveCustomGitServerToken(id, draft.token.trim())
+  const writingToken = Boolean(draft.token && draft.token.trim())
+  // Why: config + token live in two stores. Write the token first, but if the
+  // config write then fails, roll the token back so a failed save leaves both
+  // stores as they were rather than mutating the token for an unchanged config.
+  let tokenRollback: (() => void) | null = null
+  if (writingToken) {
+    const hadToken = hasStoredCustomGitServerToken(id)
+    const priorToken = hadToken ? safeReadToken(id) : null
+    saveCustomGitServerToken(id, draft.token!.trim())
+    tokenRollback = () => {
+      if (priorToken !== null) {
+        saveCustomGitServerToken(id, priorToken)
+      } else if (!hadToken) {
+        deleteCustomGitServerToken(id)
+      }
+    }
   }
 
   const servers = listCustomGitServers().filter((existing) => existing.id !== id)
-  writeCustomGitServerConfig([...servers, server])
+  try {
+    writeCustomGitServerConfig([...servers, server])
+  } catch (error) {
+    // Undo the token mutation so the failure is atomic from the caller's view.
+    tokenRollback?.()
+    throw error
+  }
   // Why: config/token just changed, so a cached auth result for this id is stale.
   invalidateServerVerification(id)
   return server
@@ -78,9 +98,22 @@ export function saveCustomGitServer(
 
 /** Delete a server and its stored token. */
 export function removeCustomGitServer(id: string): void {
-  deleteCustomGitServerToken(id)
+  // Why: config is the source of truth, so drop it first. If this throws the
+  // token is left intact (config still references the server). Deleting the
+  // token only after the config write commits means a delete failure there
+  // leaves a harmless orphaned token, never a configured server with no token.
   writeCustomGitServerConfig(listCustomGitServers().filter((server) => server.id !== id))
+  deleteCustomGitServerToken(id)
   invalidateServerVerification(id)
+}
+
+/** Read a token without throwing on an undecryptable value (used for rollback). */
+function safeReadToken(id: string): string | null {
+  try {
+    return getCustomGitServerToken(id)
+  } catch {
+    return null
+  }
 }
 
 async function verifyServer(

--- a/src/main/custom-git-server/store.ts
+++ b/src/main/custom-git-server/store.ts
@@ -1,0 +1,127 @@
+import type {
+  CustomGitServer,
+  CustomGitServerDraft,
+  CustomGitServerStatus,
+  CustomGitServerTestResult
+} from '../../shared/custom-git-server'
+import {
+  computeCustomGitServerId,
+  getCustomGitServerById,
+  getCustomGitServerForHost,
+  listCustomGitServers,
+  normalizeCustomGitServerDraft,
+  writeCustomGitServerConfig,
+  _resetCustomGitServerStoreCache
+} from './server-config-store'
+import {
+  deleteCustomGitServerToken,
+  getCustomGitServerToken,
+  hasStoredCustomGitServerToken,
+  saveCustomGitServerToken,
+  _resetCustomGitServerTokenCache
+} from './token-store'
+import { getCustomGitServerFlavorClient } from './api-flavor'
+
+// Facade over the electron-free config store and the electron-backed token
+// store. IPC + preflight consume this; forge-provider detection deliberately
+// depends only on the config store (host match) to stay electron-free.
+export {
+  getCustomGitServerById,
+  getCustomGitServerForHost,
+  getCustomGitServerToken,
+  listCustomGitServers
+}
+
+/** @internal - exposed for tests only */
+export function _resetCustomGitServerStore(): void {
+  _resetCustomGitServerStoreCache()
+  _resetCustomGitServerTokenCache()
+}
+
+/**
+ * Create or update a server. When `id` is provided the record is updated in
+ * place (identity preserved); otherwise a deterministic id from host+apiBaseUrl
+ * is used (idempotent upsert). A non-empty `token` is saved; omitting it keeps
+ * any existing token.
+ */
+export function saveCustomGitServer(
+  draft: CustomGitServerDraft & { id?: string }
+): CustomGitServer {
+  const normalized = normalizeCustomGitServerDraft(draft)
+  const id = draft.id ?? computeCustomGitServerId(normalized.host, normalized.apiBaseUrl)
+  const server: CustomGitServer = { id, ...normalized }
+
+  if (draft.token && draft.token.trim()) {
+    saveCustomGitServerToken(id, draft.token.trim())
+  }
+
+  const servers = listCustomGitServers().filter((existing) => existing.id !== id)
+  writeCustomGitServerConfig([...servers, server])
+  return server
+}
+
+/** Delete a server and its stored token. */
+export function removeCustomGitServer(id: string): void {
+  deleteCustomGitServerToken(id)
+  writeCustomGitServerConfig(listCustomGitServers().filter((server) => server.id !== id))
+}
+
+async function verifyServer(
+  server: CustomGitServer,
+  token: string
+): Promise<CustomGitServerTestResult> {
+  try {
+    const result = await getCustomGitServerFlavorClient(server.apiFlavor).verify(server, token)
+    return result
+      ? { ok: true, account: result.account }
+      : { ok: false, error: 'The server rejected the token or could not be reached.' }
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+/** Verify a token against a server definition without persisting anything. */
+export async function testCustomGitServerConnection(
+  draft: CustomGitServerDraft & { token: string }
+): Promise<CustomGitServerTestResult> {
+  const normalized = normalizeCustomGitServerDraft(draft)
+  if (!normalized.host || !normalized.apiBaseUrl) {
+    return { ok: false, error: 'Host and API base URL are required.' }
+  }
+  const token = draft.token.trim()
+  if (!token) {
+    return { ok: false, error: 'A token is required to test the connection.' }
+  }
+  return verifyServer({ id: 'test', ...normalized }, token)
+}
+
+async function statusForServer(server: CustomGitServer): Promise<CustomGitServerStatus> {
+  const base: Omit<CustomGitServerStatus, 'authenticated' | 'account'> = {
+    id: server.id,
+    name: server.name,
+    host: server.host,
+    apiBaseUrl: server.apiBaseUrl,
+    apiFlavor: server.apiFlavor,
+    configured: hasStoredCustomGitServerToken(server.id)
+  }
+  if (!base.configured) {
+    return { ...base, authenticated: false, account: null }
+  }
+  let token: string | null
+  try {
+    token = getCustomGitServerToken(server.id)
+  } catch {
+    // Undecryptable token: configured but not usable.
+    return { ...base, authenticated: false, account: null }
+  }
+  if (!token) {
+    return { ...base, authenticated: false, account: null }
+  }
+  const result = await verifyServer(server, token)
+  return { ...base, authenticated: result.ok, account: result.ok ? result.account : null }
+}
+
+/** Status of every configured server (token presence + live auth check). */
+export function getCustomGitServerStatuses(): Promise<CustomGitServerStatus[]> {
+  return Promise.all(listCustomGitServers().map((server) => statusForServer(server)))
+}

--- a/src/main/custom-git-server/store.ts
+++ b/src/main/custom-git-server/store.ts
@@ -36,6 +36,20 @@ export {
 export function _resetCustomGitServerStore(): void {
   _resetCustomGitServerStoreCache()
   _resetCustomGitServerTokenCache()
+  verificationCache.clear()
+}
+
+// Why: preflight polls getCustomGitServerStatuses, so cache each server's live
+// verify() briefly to avoid hammering the configured host on every tick. The
+// in-flight promise is cached so concurrent ticks share one request.
+const STATUS_VERIFY_TTL_MS = 30_000
+const verificationCache = new Map<
+  string,
+  { expiresAt: number; result: Promise<CustomGitServerTestResult> }
+>()
+
+function invalidateServerVerification(id: string): void {
+  verificationCache.delete(id)
 }
 
 /**
@@ -57,6 +71,8 @@ export function saveCustomGitServer(
 
   const servers = listCustomGitServers().filter((existing) => existing.id !== id)
   writeCustomGitServerConfig([...servers, server])
+  // Why: config/token just changed, so a cached auth result for this id is stale.
+  invalidateServerVerification(id)
   return server
 }
 
@@ -64,6 +80,7 @@ export function saveCustomGitServer(
 export function removeCustomGitServer(id: string): void {
   deleteCustomGitServerToken(id)
   writeCustomGitServerConfig(listCustomGitServers().filter((server) => server.id !== id))
+  invalidateServerVerification(id)
 }
 
 async function verifyServer(
@@ -117,8 +134,30 @@ async function statusForServer(server: CustomGitServer): Promise<CustomGitServer
   if (!token) {
     return { ...base, authenticated: false, account: null }
   }
-  const result = await verifyServer(server, token)
+  const result = await verifyServerCached(server, token)
   return { ...base, authenticated: result.ok, account: result.ok ? result.account : null }
+}
+
+// Reuse a recent verify() for `server` within the TTL; refresh once it expires.
+function verifyServerCached(
+  server: CustomGitServer,
+  token: string
+): Promise<CustomGitServerTestResult> {
+  const cached = verificationCache.get(server.id)
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.result
+  }
+  const result = verifyServer(server, token)
+  verificationCache.set(server.id, { expiresAt: Date.now() + STATUS_VERIFY_TTL_MS, result })
+  // Don't cache a rejected/failed probe so a transient outage self-heals next tick.
+  void result
+    .then((outcome) => {
+      if (!outcome.ok) {
+        invalidateServerVerification(server.id)
+      }
+    })
+    .catch(() => invalidateServerVerification(server.id))
+  return result
 }
 
 /** Status of every configured server (token presence + live auth check). */

--- a/src/main/custom-git-server/token-store.ts
+++ b/src/main/custom-git-server/token-store.ts
@@ -82,13 +82,18 @@ export function saveCustomGitServerToken(serverId: string, token: string): void 
 
 /** Remove a server's stored token from disk and cache. */
 export function deleteCustomGitServerToken(serverId: string): void {
-  cachedTokens.delete(serverId)
-  credentialErrors.delete(serverId)
   try {
     unlinkSync(getTokenPath(serverId))
-  } catch {
-    // Token may not exist — safe to ignore.
+  } catch (error) {
+    // Why: only a missing file is safe to ignore. Surface any other failure
+    // (locked file, permissions) instead of leaving an orphaned token on disk
+    // while the caller believes it was removed.
+    if ((error as NodeJS.ErrnoException | null)?.code !== 'ENOENT') {
+      throw error
+    }
   }
+  cachedTokens.delete(serverId)
+  credentialErrors.delete(serverId)
 }
 
 /** Whether a token is stored for this server (no decryption). */

--- a/src/main/custom-git-server/token-store.ts
+++ b/src/main/custom-git-server/token-store.ts
@@ -1,0 +1,97 @@
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { safeStorage } from 'electron'
+import {
+  CredentialDecryptionError,
+  credentialFileHasContent,
+  readStoredCredentialToken
+} from '../integration-credential-file'
+import { getOrcaDir } from './server-config-store'
+
+// Why: safeStorage / credential I/O is isolated here so the electron dependency
+// stays out of forge-provider detection and other unrelated import graphs.
+
+const cachedTokens = new Map<string, string>()
+// Why: decrypt failures are recorded per server so status polling can report a
+// failing read without re-hitting the keychain on every poll.
+const credentialErrors = new Map<string, string>()
+
+/** @internal - exposed for tests only */
+export function _resetCustomGitServerTokenCache(): void {
+  cachedTokens.clear()
+  credentialErrors.clear()
+}
+
+function getTokenDir(): string {
+  return join(getOrcaDir(), 'custom-git-server-tokens')
+}
+
+function getTokenPath(serverId: string): string {
+  return join(getTokenDir(), `${Buffer.from(serverId).toString('base64url')}.enc`)
+}
+
+function ensureDir(dir: string): void {
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+}
+
+function writeEncryptedToken(path: string, token: string): void {
+  if (safeStorage.isEncryptionAvailable()) {
+    writeFileSync(path, safeStorage.encryptString(token), { mode: 0o600 })
+    return
+  }
+  console.warn('[custom-git-server] safeStorage encryption unavailable — storing token in plaintext')
+  writeFileSync(path, token, { encoding: 'utf-8', mode: 0o600 })
+}
+
+/** Read the stored token; throws CredentialDecryptionError on undecryptable data. */
+export function getCustomGitServerToken(serverId: string): string | null {
+  const cached = cachedTokens.get(serverId)
+  if (cached !== undefined) {
+    return cached
+  }
+  const path = getTokenPath(serverId)
+  if (!existsSync(path)) {
+    return null
+  }
+  try {
+    const token = readStoredCredentialToken('CustomGitServer', readFileSync(path))
+    if (token) {
+      cachedTokens.set(serverId, token)
+    }
+    credentialErrors.delete(serverId)
+    return token
+  } catch (error) {
+    if (error instanceof CredentialDecryptionError) {
+      credentialErrors.set(serverId, error.message)
+      throw error
+    }
+    return null
+  }
+}
+
+/** Encrypt and persist a server's token, updating the cache. */
+export function saveCustomGitServerToken(serverId: string, token: string): void {
+  ensureDir(getOrcaDir())
+  ensureDir(getTokenDir())
+  writeEncryptedToken(getTokenPath(serverId), token)
+  cachedTokens.set(serverId, token)
+  credentialErrors.delete(serverId)
+}
+
+/** Remove a server's stored token from disk and cache. */
+export function deleteCustomGitServerToken(serverId: string): void {
+  cachedTokens.delete(serverId)
+  credentialErrors.delete(serverId)
+  try {
+    unlinkSync(getTokenPath(serverId))
+  } catch {
+    // Token may not exist — safe to ignore.
+  }
+}
+
+/** Whether a token is stored for this server (no decryption). */
+export function hasStoredCustomGitServerToken(serverId: string): boolean {
+  return cachedTokens.has(serverId) || credentialFileHasContent(getTokenPath(serverId))
+}

--- a/src/main/custom-git-server/token-store.ts
+++ b/src/main/custom-git-server/token-store.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { safeStorage } from 'electron'
+import { getSecretStore } from '../../shared/secret-store'
 import {
   CredentialDecryptionError,
   credentialFileHasContent,
@@ -37,8 +37,8 @@ function ensureDir(dir: string): void {
 }
 
 function writeEncryptedToken(path: string, token: string): void {
-  if (safeStorage.isEncryptionAvailable()) {
-    writeFileSync(path, safeStorage.encryptString(token), { mode: 0o600 })
+  if (getSecretStore().isEncryptionAvailable()) {
+    writeFileSync(path, getSecretStore().encryptString(token), { mode: 0o600 })
     return
   }
   console.warn('[custom-git-server] safeStorage encryption unavailable — storing token in plaintext')

--- a/src/main/ipc/custom-git-server.ts
+++ b/src/main/ipc/custom-git-server.ts
@@ -1,0 +1,72 @@
+import { ipcMain } from 'electron'
+import type {
+  CustomGitServerApiFlavor,
+  CustomGitServerDraft
+} from '../../shared/custom-git-server'
+import {
+  DEFAULT_CUSTOM_GIT_SERVER_API_FLAVOR,
+  isCustomGitServerApiFlavor
+} from '../../shared/custom-git-server'
+import {
+  getCustomGitServerStatuses,
+  listCustomGitServers,
+  removeCustomGitServer,
+  saveCustomGitServer,
+  testCustomGitServerConnection
+} from '../custom-git-server/store'
+import { _resetCustomGitServerRepoRefCache } from '../custom-git-server/repository-ref'
+import { _resetPreflightCache } from './preflight'
+
+function str(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function apiFlavor(value: unknown): CustomGitServerApiFlavor {
+  return isCustomGitServerApiFlavor(value) ? value : DEFAULT_CUSTOM_GIT_SERVER_API_FLAVOR
+}
+
+function normalizeDraft(input: unknown): CustomGitServerDraft & { id?: string; token?: string } {
+  const record = (input ?? {}) as Record<string, unknown>
+  return {
+    ...(typeof record.id === 'string' && record.id ? { id: record.id } : {}),
+    name: str(record.name),
+    host: str(record.host),
+    apiBaseUrl: str(record.apiBaseUrl),
+    apiFlavor: apiFlavor(record.apiFlavor),
+    ...(typeof record.token === 'string' ? { token: record.token } : {})
+  }
+}
+
+/** Register IPC handlers for listing, saving, removing, and testing custom git servers. */
+export function registerCustomGitServerHandlers(): void {
+  ipcMain.handle('customGitServer:list', async () => listCustomGitServers())
+
+  ipcMain.handle('customGitServer:status', async () => getCustomGitServerStatuses())
+
+  ipcMain.handle('customGitServer:save', async (_event, input: unknown) => {
+    const draft = normalizeDraft(input)
+    if (!draft.name.trim() || !draft.host.trim() || !draft.apiBaseUrl.trim()) {
+      throw new Error('Name, host, and API base URL are required.')
+    }
+    const server = saveCustomGitServer(draft)
+    // A changed server list can flip which provider a repo resolves to.
+    _resetCustomGitServerRepoRefCache()
+    _resetPreflightCache()
+    return server
+  })
+
+  ipcMain.handle('customGitServer:remove', async (_event, args: { id?: unknown }) => {
+    const id = str(args?.id)
+    if (!id) {
+      return
+    }
+    removeCustomGitServer(id)
+    _resetCustomGitServerRepoRefCache()
+    _resetPreflightCache()
+  })
+
+  ipcMain.handle('customGitServer:test', async (_event, input: unknown) => {
+    const draft = normalizeDraft(input)
+    return testCustomGitServerConnection({ ...draft, token: str(draft.token) })
+  })
+}

--- a/src/main/ipc/preflight-agent-detection-no-subprocess.test.ts
+++ b/src/main/ipc/preflight-agent-detection-no-subprocess.test.ts
@@ -54,6 +54,7 @@ vi.mock('../azure-devops/client', () => ({
   getAzureDevOpsAuthStatus: getAzureDevOpsAuthStatusMock
 }))
 vi.mock('../gitea/client', () => ({ getGiteaAuthStatus: getGiteaAuthStatusMock }))
+vi.mock('../custom-git-server/store', () => ({ getCustomGitServerStatuses: async () => [] }))
 
 // Isolate the subprocess-spawn assertion from the fs-based install-dir fallback.
 vi.mock('./local-agent-install-dir-detection', () => ({

--- a/src/main/ipc/preflight-host-cli-status.test.ts
+++ b/src/main/ipc/preflight-host-cli-status.test.ts
@@ -11,6 +11,7 @@ const {
   getBitbucketAuthStatusMock,
   getAzureDevOpsAuthStatusMock,
   getGiteaAuthStatusMock,
+  getCustomGitServerStatusesMock,
   resolveCliCommandsMock,
   isCommandOnLocalPathMock,
   mergePersistedWindowsPathAsyncMock,
@@ -26,6 +27,7 @@ const {
   getBitbucketAuthStatusMock: vi.fn(),
   getAzureDevOpsAuthStatusMock: vi.fn(),
   getGiteaAuthStatusMock: vi.fn(),
+  getCustomGitServerStatusesMock: vi.fn(),
   resolveCliCommandsMock: vi.fn(),
   isCommandOnLocalPathMock: vi.fn(),
   mergePersistedWindowsPathAsyncMock: vi.fn(),
@@ -88,6 +90,10 @@ vi.mock('../gitea/client', () => ({
   getGiteaAuthStatus: getGiteaAuthStatusMock
 }))
 
+vi.mock('../custom-git-server/store', () => ({
+  getCustomGitServerStatuses: getCustomGitServerStatusesMock
+}))
+
 import { _resetPreflightCache, registerPreflightHandlers, runPreflightCheck } from './preflight'
 import {
   defaultAzureDevOpsStatus,
@@ -113,6 +119,7 @@ describe('preflight', () => {
         getBitbucketAuthStatusMock,
         getAzureDevOpsAuthStatusMock,
         getGiteaAuthStatusMock,
+        getCustomGitServerStatusesMock,
         resolveCliCommandsMock,
         isCommandOnLocalPathMock,
         mergePersistedWindowsPathAsyncMock,
@@ -148,7 +155,8 @@ describe('preflight', () => {
       glab: { installed: true, authenticated: true },
       bitbucket: defaultBitbucketStatus,
       azureDevOps: defaultAzureDevOpsStatus,
-      gitea: defaultGiteaStatus
+      gitea: defaultGiteaStatus,
+      customGitServers: []
     })
     expect(execFileAsyncMock).toHaveBeenNthCalledWith(4, 'gh', ['auth', 'status'], {
       encoding: 'utf-8',
@@ -671,7 +679,8 @@ describe('preflight', () => {
       glab: { installed: true, authenticated: true },
       bitbucket: defaultBitbucketStatus,
       azureDevOps: defaultAzureDevOpsStatus,
-      gitea: defaultGiteaStatus
+      gitea: defaultGiteaStatus,
+      customGitServers: []
     })
   })
 
@@ -699,7 +708,8 @@ describe('preflight', () => {
       glab: { installed: true, authenticated: true },
       bitbucket: defaultBitbucketStatus,
       azureDevOps: defaultAzureDevOpsStatus,
-      gitea: defaultGiteaStatus
+      gitea: defaultGiteaStatus,
+      customGitServers: []
     })
     expect(refreshedStatus).toEqual({
       git: { installed: true },
@@ -707,7 +717,8 @@ describe('preflight', () => {
       glab: { installed: true, authenticated: true },
       bitbucket: defaultBitbucketStatus,
       azureDevOps: defaultAzureDevOpsStatus,
-      gitea: defaultGiteaStatus
+      gitea: defaultGiteaStatus,
+      customGitServers: []
     })
   })
 

--- a/src/main/ipc/preflight-test-harness.ts
+++ b/src/main/ipc/preflight-test-harness.ts
@@ -14,7 +14,7 @@ export type PreflightMocks = {
   getBitbucketAuthStatusMock: Mock
   getAzureDevOpsAuthStatusMock: Mock
   getGiteaAuthStatusMock: Mock
-  getCustomGitServerStatusesMock: Mock
+  getCustomGitServerStatusesMock?: Mock
   resolveCliCommandsMock: Mock
   isCommandOnLocalPathMock: Mock
   mergePersistedWindowsPathAsyncMock: Mock
@@ -96,7 +96,7 @@ export function resetPreflightMocks(mocks: PreflightMocks, handlers: HandlerMap)
   getBitbucketAuthStatusMock.mockResolvedValue(defaultBitbucketStatus)
   getAzureDevOpsAuthStatusMock.mockResolvedValue(defaultAzureDevOpsStatus)
   getGiteaAuthStatusMock.mockResolvedValue(defaultGiteaStatus)
-  getCustomGitServerStatusesMock.mockResolvedValue([])
+  getCustomGitServerStatusesMock?.mockResolvedValue([])
   _resetPreflightCache()
   Object.defineProperty(process, 'platform', {
     configurable: true,

--- a/src/main/ipc/preflight-test-harness.ts
+++ b/src/main/ipc/preflight-test-harness.ts
@@ -14,6 +14,7 @@ export type PreflightMocks = {
   getBitbucketAuthStatusMock: Mock
   getAzureDevOpsAuthStatusMock: Mock
   getGiteaAuthStatusMock: Mock
+  getCustomGitServerStatusesMock: Mock
   resolveCliCommandsMock: Mock
   isCommandOnLocalPathMock: Mock
   mergePersistedWindowsPathAsyncMock: Mock
@@ -50,6 +51,7 @@ export function resetPreflightMocks(mocks: PreflightMocks, handlers: HandlerMap)
     getBitbucketAuthStatusMock,
     getAzureDevOpsAuthStatusMock,
     getGiteaAuthStatusMock,
+    getCustomGitServerStatusesMock,
     resolveCliCommandsMock,
     isCommandOnLocalPathMock,
     mergePersistedWindowsPathAsyncMock,
@@ -94,6 +96,7 @@ export function resetPreflightMocks(mocks: PreflightMocks, handlers: HandlerMap)
   getBitbucketAuthStatusMock.mockResolvedValue(defaultBitbucketStatus)
   getAzureDevOpsAuthStatusMock.mockResolvedValue(defaultAzureDevOpsStatus)
   getGiteaAuthStatusMock.mockResolvedValue(defaultGiteaStatus)
+  getCustomGitServerStatusesMock.mockResolvedValue([])
   _resetPreflightCache()
   Object.defineProperty(process, 'platform', {
     configurable: true,

--- a/src/main/ipc/register-core-handlers/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers/register-core-handlers.ts
@@ -15,6 +15,7 @@ import { registerHostedReviewHandlers } from '../hosted-review'
 import { registerLinearHandlers } from '../linear'
 import { registerJiraHandlers } from '../jira'
 import { registerBitbucketHandlers } from '../bitbucket'
+import { registerCustomGitServerHandlers } from '../custom-git-server'
 import { registerFeedbackHandlers } from '../feedback'
 import { registerCrashReportingHandlers } from '../crash-reporting'
 import { registerExportHandlers } from '../export'
@@ -155,6 +156,7 @@ export function registerCoreHandlers(
   registerLinearHandlers()
   registerJiraHandlers()
   registerBitbucketHandlers()
+  registerCustomGitServerHandlers()
   registerFeedbackHandlers()
   if (crashReports) {
     registerCrashReportingHandlers(crashReports)

--- a/src/main/preflight/agent-detection.ts
+++ b/src/main/preflight/agent-detection.ts
@@ -13,6 +13,7 @@ import { hydrateShellPath, mergePathSegments } from '../startup/hydrate-shell-pa
 import { getAzureDevOpsAuthStatus } from '../azure-devops/client'
 import { getBitbucketAuthStatus } from '../bitbucket/client'
 import { getGiteaAuthStatus } from '../gitea/client'
+import { getCustomGitServerStatuses } from '../custom-git-server/store'
 import { _resetKnownHostsCache } from '../gitlab/gl-utils'
 import { mergePersistedWindowsPathAsync } from '../pty/windows-environment-path'
 import { getActiveMultiplexer } from '../ssh/ssh-target-registry'
@@ -45,6 +46,7 @@ import {
   resolveDetectedTuiAgentIds
 } from '../ipc/tui-agent-detection-commands'
 import { invalidateWslGuestEnvironment } from '../wsl/wsl-guest-environment'
+import type { CustomGitServerStatus } from '../../shared/custom-git-server'
 
 export type PreflightStatus = {
   git: { installed: boolean }
@@ -69,6 +71,9 @@ export type PreflightStatus = {
     baseUrl: string | null
     tokenConfigured: boolean
   }
+  // User-configured self-hosted servers. Optional so runtimes that predate the
+  // field keep typechecking; consumers default to an empty list.
+  customGitServers?: CustomGitServerStatus[]
 }
 
 export { detectRemoteWindowsTerminalCapabilities }
@@ -365,13 +370,15 @@ async function executePreflightCheck(
     detectCommandRuntime('glab', context)
   ])
 
-  const [ghAuthenticated, glabAuthenticated, bitbucket, azureDevOps, gitea] = await Promise.all([
-    ghProbe.installed ? isGhAuthenticated(ghProbe.wslTarget) : Promise.resolve(false),
-    glabProbe.installed ? isGlabAuthenticated(glabProbe.wslTarget) : Promise.resolve(false),
-    getBitbucketAuthStatus(),
-    getAzureDevOpsAuthStatus(),
-    getGiteaAuthStatus()
-  ])
+  const [ghAuthenticated, glabAuthenticated, bitbucket, azureDevOps, gitea, customGitServers] =
+    await Promise.all([
+      ghProbe.installed ? isGhAuthenticated(ghProbe.wslTarget) : Promise.resolve(false),
+      glabProbe.installed ? isGlabAuthenticated(glabProbe.wslTarget) : Promise.resolve(false),
+      getBitbucketAuthStatus(),
+      getAzureDevOpsAuthStatus(),
+      getGiteaAuthStatus(),
+      getCustomGitServerStatuses()
+    ])
 
   const result = {
     git: { installed: gitProbe.installed },
@@ -379,7 +386,8 @@ async function executePreflightCheck(
     glab: { installed: glabProbe.installed, authenticated: glabAuthenticated },
     bitbucket,
     azureDevOps,
-    gitea
+    gitea,
+    customGitServers
   }
 
   return result

--- a/src/main/source-control/forge-provider.test.ts
+++ b/src/main/source-control/forge-provider.test.ts
@@ -186,6 +186,7 @@ describe('forge provider interface', () => {
     expect(
       FORGE_PROVIDERS.map((provider) => [provider.id, provider.supportsReviewCreation])
     ).toEqual([
+      ['custom', true],
       ['gitlab', true],
       ['github', true],
       ['bitbucket', true],

--- a/src/main/source-control/forge-provider.ts
+++ b/src/main/source-control/forge-provider.ts
@@ -23,6 +23,8 @@ import {
   getGiteaRepoSlug
 } from '../gitea/client'
 import { createGiteaPullRequest } from '../gitea/pull-request-creation'
+import { getCustomGitServerFlavorClient } from '../custom-git-server/api-flavor'
+import { getCustomGitServerRepoRef } from '../custom-git-server/repository-ref'
 import {
   createGitHubPullRequest,
   getGitHubPRLookupRateLimitBlock,
@@ -312,9 +314,87 @@ const giteaForgeProvider = {
   createReview: createGiteaPullRequest
 } satisfies ForgeProvider
 
+// User-configured self-hosted servers (e.g. git.example.com). Claims a repo only
+// when its origin host matches a saved server; dispatches to the server's
+// configured API flavor (GitLab-compatible, extensible). Native REST — no CLI.
+async function resolveCustomGitServerRef(
+  context: ForgeProviderRepositoryContext
+): ReturnType<typeof getCustomGitServerRepoRef> {
+  return getCustomGitServerRepoRef(
+    context.repoPath,
+    forgeConnectionId(context),
+    getHostedReviewLocalGitOptions(context)
+  )
+}
+
+function customGitServerToken(serverId: string): Promise<string | null> {
+  // Lazy so the electron-backed token store stays out of forge-provider's static
+  // import graph; only reached once a repo actually matches a custom server.
+  return import('../custom-git-server/token-store')
+    .then((mod) => {
+      try {
+        return mod.getCustomGitServerToken(serverId)
+      } catch {
+        // Undecryptable token — treat as unauthenticated rather than throwing.
+        return null
+      }
+    })
+    .catch(() => null)
+}
+
+const customForgeProvider = {
+  id: 'custom',
+  supportsReviewCreation: true,
+  resolveRepository: (context) => resolveCustomGitServerRef(context),
+  async getReviewForBranch(input) {
+    const ref = await resolveCustomGitServerRef(input)
+    if (!ref) {
+      return null
+    }
+    return getCustomGitServerFlavorClient(ref.server.apiFlavor).getReviewForBranch(
+      ref,
+      await customGitServerToken(ref.server.id),
+      input.branch,
+      input.linkedReviewNumber ?? null
+    )
+  },
+  async getReviewByNumber(input) {
+    const ref = await resolveCustomGitServerRef(input)
+    if (!ref) {
+      return null
+    }
+    return getCustomGitServerFlavorClient(ref.server.apiFlavor).getReviewByNumber(
+      ref,
+      await customGitServerToken(ref.server.id),
+      input.number
+    )
+  },
+  async createReview(repoPath, input, executionHostId, options) {
+    const ref = await resolveCustomGitServerRef({ repoPath, executionHostId, ...options })
+    if (!ref) {
+      return {
+        ok: false,
+        code: 'unsupported_provider',
+        error: 'Creating reviews requires a configured custom git server for this remote.'
+      }
+    }
+    return getCustomGitServerFlavorClient(ref.server.apiFlavor).createReview(
+      ref,
+      await customGitServerToken(ref.server.id),
+      input,
+      repoPath,
+      hostedReviewSshConnectionId(executionHostId)
+    )
+  }
+} satisfies ForgeProvider
+
 // Why: provider order preserves existing branch-status behavior when remotes
-// could be interpreted by more than one hosting integration.
+// could be interpreted by more than one hosting integration. The custom
+// provider is first so a user-configured self-hosted host wins over Gitea's
+// greedy unknown-host fallback; it only claims remotes matching a saved server,
+// so github.com/gitlab.com/etc. remotes still fall through unaffected.
 export const FORGE_PROVIDERS = [
+  customForgeProvider,
   gitLabForgeProvider,
   gitHubForgeProvider,
   bitbucketForgeProvider,

--- a/src/main/source-control/hosted-review-creation-provider.ts
+++ b/src/main/source-control/hosted-review-creation-provider.ts
@@ -3,6 +3,7 @@ import type { HostedReviewProvider } from '../../shared/hosted-review'
 import type { HostedReviewCreationProvider } from '../../shared/hosted-review-creation-providers'
 import { isAzureDevOpsReviewCreationAuthenticated } from '../azure-devops/pull-request-creation'
 import { isBitbucketReviewCreationAuthenticated } from '../bitbucket/pull-request-creation'
+import { isCustomGitServerAuthenticatedForRepo } from '../custom-git-server/repository-ref'
 import { isGiteaReviewCreationAuthenticated } from '../gitea/pull-request-creation'
 import { getEnterpriseGitHubRepoSlug } from '../github/github-enterprise-repository'
 import { acquire, ghExecFileAsync, release } from '../github/gh-utils'
@@ -107,6 +108,16 @@ export function reviewCopy(provider: HostedReviewProvider): {
       authInstruction: 'Connect Bitbucket in Settings > Integrations'
     }
   }
+  if (provider === 'custom') {
+    // GitLab-compatible custom servers use merge requests; token lives in the
+    // per-server credential store, configured from Settings → Integrations.
+    return {
+      shortLabel: 'MR',
+      reviewLabel: 'merge request',
+      providerName: 'custom git server',
+      authInstruction: 'Add a token for this server in Settings → Integrations'
+    }
+  }
   return {
     shortLabel: 'PR',
     reviewLabel: 'pull request',
@@ -135,6 +146,13 @@ export async function isProviderAuthenticated(
   // Only the CLI-backed probes read a host: `gh` and `glab` run here, and the SSH target only
   // routes the git reads under them. The token-backed forges never touch the repository at all.
   const connectionId = hostedReviewSshConnectionId(executionHostId)
+  if (provider === 'custom') {
+    return isCustomGitServerAuthenticatedForRepo(
+      repoPath,
+      connectionId,
+      getHostedReviewLocalGitOptions(options)
+    )
+  }
   if (provider === 'gitlab') {
     return isGitLabAuthenticated(repoPath, connectionId, options)
   }

--- a/src/main/source-control/hosted-review-creation.ts
+++ b/src/main/source-control/hosted-review-creation.ts
@@ -132,6 +132,7 @@ export async function getHostedReviewCreationEligibility(
       linkedBitbucketPR: args.linkedBitbucketPR ?? null,
       linkedAzureDevOpsPR: args.linkedAzureDevOpsPR ?? null,
       linkedGiteaPR: args.linkedGiteaPR ?? null,
+      linkedCustomPR: args.linkedCustomPR ?? null,
       executionHostId: args.executionHostId,
       // Why: eligibility is only ever asked for the worktree the user is acting
       // on, so it earns the fast tier. Without it a review opened outside Orca

--- a/src/main/source-control/hosted-review.ts
+++ b/src/main/source-control/hosted-review.ts
@@ -27,6 +27,8 @@ function reviewLinkForProvider(
       return { linkedReviewNumber: input.linkedAzureDevOpsPR ?? null }
     case 'gitea':
       return { linkedReviewNumber: input.linkedGiteaPR ?? null }
+    case 'custom':
+      return { linkedReviewNumber: input.linkedCustomPR ?? null }
   }
 }
 
@@ -41,6 +43,7 @@ export async function getHostedReviewForBranch(
     linkedBitbucketPR?: number | null
     linkedAzureDevOpsPR?: number | null
     linkedGiteaPR?: number | null
+    linkedCustomPR?: number | null
     currentHeadOid?: string | null
     /**
      * Set by surfaces that only ever render the selected worktree, which is the
@@ -59,7 +62,8 @@ export async function getHostedReviewForBranch(
     input.linkedGitLabMR == null &&
     input.linkedBitbucketPR == null &&
     input.linkedAzureDevOpsPR == null &&
-    input.linkedGiteaPR == null
+    input.linkedGiteaPR == null &&
+    input.linkedCustomPR == null
   ) {
     return null
   }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -21,6 +21,7 @@ import type { AutomationsApi } from './api/automation-api'
 import type { BrowserApi } from './api/browser-api'
 import type { CliApi } from './api/cli-install-api'
 import type { CrashReportsApi, FeedbackApi } from './api/crash-report-api'
+import type { CustomGitServerApi } from './api/custom-git-server-api'
 import type { DashboardApi, TerminalPreviewApi } from './api/dashboard-api'
 import type { DocPreviewApi } from './api/doc-preview-api'
 import type { EmulatorApi } from './api/emulator-api'
@@ -106,6 +107,7 @@ export type PreloadApi = {
   codexConfigSync: CodexConfigSyncApi
   agentTrust: AgentTrustApi
   preflight: PreflightApi
+  customGitServer: CustomGitServerApi
   notifications: NotificationsApi
   onboarding: OnboardingApi
   dashboard: DashboardApi

--- a/src/preload/api/custom-git-server-api.ts
+++ b/src/preload/api/custom-git-server-api.ts
@@ -1,0 +1,14 @@
+import type {
+  CustomGitServer,
+  CustomGitServerDraft,
+  CustomGitServerStatus,
+  CustomGitServerTestResult
+} from '../../shared/custom-git-server'
+
+export type CustomGitServerApi = {
+  list: () => Promise<CustomGitServer[]>
+  save: (draft: CustomGitServerDraft & { id?: string }) => Promise<CustomGitServer>
+  remove: (args: { id: string }) => Promise<void>
+  test: (draft: CustomGitServerDraft & { token: string }) => Promise<CustomGitServerTestResult>
+  status: () => Promise<CustomGitServerStatus[]>
+}

--- a/src/preload/api/preflight-api.ts
+++ b/src/preload/api/preflight-api.ts
@@ -3,6 +3,7 @@ import type {
   PathSource,
   ShellHydrationFailureReason
 } from '../../shared/shell-path-hydration-types'
+import type { CustomGitServerStatus } from '../../shared/custom-git-server'
 
 export type PreflightStatus = {
   git: { installed: boolean }
@@ -24,6 +25,9 @@ export type PreflightStatus = {
     baseUrl: string | null
     tokenConfigured: boolean
   }
+  /** User-configured self-hosted servers. Optional for payload back-compat;
+   *  consumers default to an empty list. */
+  customGitServers?: CustomGitServerStatus[]
 }
 
 export type RefreshAgentsResult = {

--- a/src/renderer/src/components/right-sidebar/parent-pr-checks-hosted-review-cache.ts
+++ b/src/renderer/src/components/right-sidebar/parent-pr-checks-hosted-review-cache.ts
@@ -75,6 +75,9 @@ function getLinkedReviewNumberForProvider(
       return worktree.linkedAzureDevOpsPR ?? null
     case 'gitea':
       return worktree.linkedGiteaPR ?? null
+    // Custom-server reviews aren't persisted by number (discovered by branch).
+    case 'custom':
+      return null
     case 'unsupported':
       return null
   }

--- a/src/renderer/src/components/right-sidebar/source-control-create-review-blocked-action.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-create-review-blocked-action.ts
@@ -36,6 +36,9 @@ export function resolveHostedReviewAuthInstruction(provider: HostedReviewProvide
   if (provider === 'bitbucket') {
     return 'Connect Bitbucket in Settings > Integrations'
   }
+  if (provider === 'custom') {
+    return 'Add a token for this server in Settings → Integrations'
+  }
   return 'Run gh auth login'
 }
 

--- a/src/renderer/src/components/right-sidebar/source-control-created-review-link.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-created-review-link.ts
@@ -39,6 +39,8 @@ export function resolveCreatedHostedReviewLink(
       return { worktree: { linkedGiteaPR: number }, lookup: { linkedGiteaPR: number } }
     case 'bitbucket':
       return { worktree: { linkedBitbucketPR: number }, lookup: { linkedBitbucketPR: number } }
+    // Custom-server reviews are discovered by branch, not persisted by number.
+    case 'custom':
     case 'unsupported':
       return { worktree: {}, lookup: {} }
   }

--- a/src/renderer/src/components/right-sidebar/source-control/review/manual-review-url.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/review/manual-review-url.ts
@@ -169,8 +169,8 @@ export function buildSourceControlManualReviewUrl(input: ManualReviewUrlInput): 
         githubHeadRef(baseRepo, headRepo, headBranch)
       )}?expand=1`
     case 'gitlab':
-    // Custom servers are GitLab-compatible in v1 — same new-MR URL shape.
     case 'custom':
+      // Custom servers are GitLab-compatible in v1 — same new-MR URL shape.
       // Why: the source branch lives in the head repo, so the New-MR page must
       // be opened on that project — a fork's branch is invisible to the base
       // project and its /-/merge_requests/new page would 404 the source_branch.

--- a/src/renderer/src/components/right-sidebar/source-control/review/manual-review-url.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/review/manual-review-url.ts
@@ -169,6 +169,8 @@ export function buildSourceControlManualReviewUrl(input: ManualReviewUrlInput): 
         githubHeadRef(baseRepo, headRepo, headBranch)
       )}?expand=1`
     case 'gitlab':
+    // Custom servers are GitLab-compatible in v1 — same new-MR URL shape.
+    case 'custom':
       // Why: the source branch lives in the head repo, so the New-MR page must
       // be opened on that project — a fork's branch is invisible to the base
       // project and its /-/merge_requests/new page would 404 the source_branch.

--- a/src/renderer/src/components/settings/CustomGitServerCards.tsx
+++ b/src/renderer/src/components/settings/CustomGitServerCards.tsx
@@ -1,0 +1,400 @@
+import { useMemo, useState } from 'react'
+import {
+  AlertCircle,
+  CheckCircle2,
+  GitPullRequestArrow,
+  LoaderCircle,
+  Pencil,
+  Plus,
+  Trash2
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import { useMountedRef } from '@/hooks/useMountedRef'
+import { getLocalPreflightContext, localPreflightContextKey } from '@/lib/local-preflight-context'
+import { useAppStore } from '@/store'
+import {
+  CUSTOM_GIT_SERVER_API_FLAVORS,
+  DEFAULT_CUSTOM_GIT_SERVER_API_FLAVOR,
+  type CustomGitServerApiFlavor,
+  type CustomGitServerStatus
+} from '../../../../shared/custom-git-server'
+import { IntegrationCardDetails, IntegrationCardShell } from './integration-card-shell'
+import { translate } from '@/i18n/i18n'
+
+const API_FLAVOR_LABELS: Record<CustomGitServerApiFlavor, string> = {
+  gitlab: 'GitLab (v4)'
+}
+
+type FormState = {
+  id?: string
+  name: string
+  host: string
+  apiBaseUrl: string
+  apiFlavor: CustomGitServerApiFlavor
+  token: string
+}
+
+type TestResult = { state: 'ok'; account: string | null } | { state: 'error'; error: string }
+
+function emptyForm(): FormState {
+  return {
+    name: '',
+    host: '',
+    apiBaseUrl: '',
+    apiFlavor: DEFAULT_CUSTOM_GIT_SERVER_API_FLAVOR,
+    token: ''
+  }
+}
+
+function formFromServer(server: CustomGitServerStatus): FormState {
+  return {
+    id: server.id,
+    name: server.name,
+    host: server.host,
+    apiBaseUrl: server.apiBaseUrl,
+    apiFlavor: server.apiFlavor,
+    token: ''
+  }
+}
+
+function CustomGitServerForm(props: {
+  initial: FormState
+  onDone: () => void
+}): React.JSX.Element {
+  const saveCustomGitServer = useAppStore((s) => s.saveCustomGitServer)
+  const testCustomGitServer = useAppStore((s) => s.testCustomGitServer)
+  const mountedRef = useMountedRef()
+  const [form, setForm] = useState<FormState>(props.initial)
+  const [testResult, setTestResult] = useState<TestResult | null>(null)
+  const [busy, setBusy] = useState<'test' | 'save' | null>(null)
+  const editing = props.initial.id !== undefined
+
+  const canSubmit =
+    form.name.trim().length > 0 &&
+    form.host.trim().length > 0 &&
+    form.apiBaseUrl.trim().length > 0 &&
+    // A token is required to create; editing may keep the existing one.
+    (editing || form.token.trim().length > 0)
+
+  const update = (patch: Partial<FormState>): void => {
+    setForm((prev) => ({ ...prev, ...patch }))
+    setTestResult(null)
+  }
+
+  const handleTest = async (): Promise<void> => {
+    setBusy('test')
+    setTestResult(null)
+    const result = await testCustomGitServer({ ...form, token: form.token.trim() })
+    if (!mountedRef.current) {
+      return
+    }
+    setTestResult(
+      result.ok ? { state: 'ok', account: result.account } : { state: 'error', error: result.error }
+    )
+    setBusy(null)
+  }
+
+  const handleSave = async (): Promise<void> => {
+    setBusy('save')
+    try {
+      await saveCustomGitServer({
+        ...(form.id ? { id: form.id } : {}),
+        name: form.name.trim(),
+        host: form.host.trim(),
+        apiBaseUrl: form.apiBaseUrl.trim(),
+        apiFlavor: form.apiFlavor,
+        // Blank token on edit keeps the stored one.
+        ...(form.token.trim() ? { token: form.token.trim() } : {})
+      })
+      if (mountedRef.current) {
+        props.onDone()
+      }
+    } catch (error) {
+      if (mountedRef.current) {
+        setTestResult({ state: 'error', error: error instanceof Error ? error.message : String(error) })
+        setBusy(null)
+      }
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1">
+          <Label htmlFor="cgs-name">
+            {translate('settings.customGitServer.field.name', 'Name')}
+          </Label>
+          <Input
+            id="cgs-name"
+            value={form.name}
+            placeholder={translate('settings.customGitServer.placeholder.name', 'My Git Server')}
+            onChange={(event) => update({ name: event.target.value })}
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="cgs-host">
+            {translate('settings.customGitServer.field.host', 'Host')}
+          </Label>
+          <Input
+            id="cgs-host"
+            value={form.host}
+            placeholder={translate('settings.customGitServer.placeholder.host', 'git.example.com')}
+            onChange={(event) => update({ host: event.target.value })}
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="cgs-base">
+            {translate('settings.customGitServer.field.apiBaseUrl', 'API base URL')}
+          </Label>
+          <Input
+            id="cgs-base"
+            value={form.apiBaseUrl}
+            placeholder={translate(
+              'settings.customGitServer.placeholder.apiBaseUrl',
+              'https://git.example.com'
+            )}
+            onChange={(event) => update({ apiBaseUrl: event.target.value })}
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="cgs-flavor">
+            {translate('settings.customGitServer.field.apiType', 'API type')}
+          </Label>
+          <Select
+            value={form.apiFlavor}
+            onValueChange={(value) => update({ apiFlavor: value as CustomGitServerApiFlavor })}
+          >
+            <SelectTrigger id="cgs-flavor" size="sm" className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {CUSTOM_GIT_SERVER_API_FLAVORS.map((flavor) => (
+                <SelectItem key={flavor} value={flavor}>
+                  {API_FLAVOR_LABELS[flavor]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor="cgs-token">
+          {translate('settings.customGitServer.field.token', 'Token')}
+        </Label>
+        <Input
+          id="cgs-token"
+          type="password"
+          value={form.token}
+          placeholder={
+            editing
+              ? translate('settings.customGitServer.token.keep', 'Leave blank to keep existing token')
+              : translate('settings.customGitServer.token.new', 'Personal access token')
+          }
+          onChange={(event) => update({ token: event.target.value })}
+        />
+        <p className="text-[11px] text-muted-foreground">
+          {translate(
+            'settings.customGitServer.token.help',
+            'Stored locally and encrypted when your OS keychain is available.'
+          )}
+        </p>
+      </div>
+      {testResult ? (
+        <p
+          className={
+            testResult.state === 'ok'
+              ? 'flex items-center gap-1.5 text-xs text-status-success'
+              : 'flex items-center gap-1.5 text-xs text-amber-700 dark:text-amber-300'
+          }
+        >
+          {testResult.state === 'ok' ? (
+            <>
+              <CheckCircle2 className="size-3.5" />
+              {testResult.account
+                ? translate('settings.customGitServer.test.okAccount', 'Connected as {{value0}}', {
+                    value0: testResult.account
+                  })
+                : translate('settings.customGitServer.test.ok', 'Connection succeeded')}
+            </>
+          ) : (
+            <>
+              <AlertCircle className="size-3.5" />
+              {testResult.error}
+            </>
+          )}
+        </p>
+      ) : null}
+      <div className="flex flex-wrap items-center gap-2">
+        <Button size="sm" onClick={handleSave} disabled={!canSubmit || busy !== null}>
+          {busy === 'save' ? <LoaderCircle className="size-3.5 animate-spin" /> : null}
+          {translate('settings.customGitServer.action.save', 'Save')}
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleTest}
+          disabled={
+            busy !== null ||
+            !form.host.trim() ||
+            !form.apiBaseUrl.trim() ||
+            !form.token.trim()
+          }
+        >
+          {busy === 'test' ? <LoaderCircle className="size-3.5 animate-spin" /> : null}
+          {translate('settings.customGitServer.action.test', 'Test connection')}
+        </Button>
+        <Button variant="ghost" size="sm" onClick={props.onDone} disabled={busy !== null}>
+          {translate('settings.customGitServer.action.cancel', 'Cancel')}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function CustomGitServerRow(props: {
+  server: CustomGitServerStatus
+  onEdit: () => void
+}): React.JSX.Element {
+  const removeCustomGitServer = useAppStore((s) => s.removeCustomGitServer)
+  const [removing, setRemoving] = useState(false)
+  const connected = props.server.authenticated
+  const statusLabel = connected
+    ? 'Connected'
+    : props.server.configured
+      ? 'Auth failed'
+      : 'Not configured'
+  const accountSuffix = connected && props.server.account ? ` · ${props.server.account}` : ''
+
+  const handleRemove = async (): Promise<void> => {
+    setRemoving(true)
+    await removeCustomGitServer(props.server.id)
+  }
+
+  return (
+    <IntegrationCardShell
+      icon={<GitPullRequestArrow className="size-5" />}
+      name={props.server.name}
+      description={`${props.server.host}${accountSuffix} · ${API_FLAVOR_LABELS[props.server.apiFlavor]}`}
+      statusTone={connected ? 'connected' : 'attention'}
+      statusLabel={statusLabel}
+      actions={
+        <>
+          <Button variant="ghost" size="sm" onClick={props.onEdit}>
+            <Pencil className="size-3.5" />
+            {translate('settings.customGitServer.action.edit', 'Edit')}
+          </Button>
+          <Button variant="ghost" size="sm" onClick={handleRemove} disabled={removing}>
+            {removing ? (
+              <LoaderCircle className="size-3.5 animate-spin" />
+            ) : (
+              <Trash2 className="size-3.5" />
+            )}
+            {translate('settings.customGitServer.action.remove', 'Remove')}
+          </Button>
+        </>
+      }
+    />
+  )
+}
+
+export function CustomGitServerSection(): React.JSX.Element {
+  const preflightStatus = useAppStore((s) => s.preflightStatus)
+  const preflightStatusChecked = useAppStore((s) => s.preflightStatusChecked)
+  const preflightStatusContextKey = useAppStore((s) => s.preflightStatusContextKey)
+  const preflightStatusLoading = useAppStore((s) => s.preflightStatusLoading)
+  const expectedContextKey = useAppStore((s) =>
+    localPreflightContextKey(getLocalPreflightContext(s))
+  )
+  const [editing, setEditing] = useState<FormState | null>(null)
+
+  const current = preflightStatusContextKey === expectedContextKey
+  const checking = preflightStatusLoading || !preflightStatusChecked || !current
+  const servers = useMemo<CustomGitServerStatus[]>(
+    () => (current ? (preflightStatus?.customGitServers ?? []) : []),
+    [current, preflightStatus]
+  )
+
+  return (
+    <section className="space-y-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold text-foreground">
+            {translate('settings.customGitServer.title', 'Custom git servers')}
+          </h3>
+          <p className="text-xs text-muted-foreground">
+            {translate(
+              'settings.customGitServer.description',
+              'Add self-hosted or internal git servers (e.g. git.example.com) for pull/merge requests and review status.'
+            )}
+          </p>
+        </div>
+        {editing === null ? (
+          <Button variant="outline" size="sm" onClick={() => setEditing(emptyForm())}>
+            <Plus className="size-3.5" />
+            {translate('settings.customGitServer.action.add', 'Add custom git server')}
+          </Button>
+        ) : null}
+      </div>
+
+      {editing !== null && editing.id === undefined ? (
+        <IntegrationCardShell
+          icon={<GitPullRequestArrow className="size-5" />}
+          name={translate('settings.customGitServer.add', 'Add custom git server')}
+          description={translate(
+            'settings.customGitServer.addHint',
+            'Enter the server host, API base URL, and a token.'
+          )}
+          statusTone="neutral"
+          statusLabel="New"
+        >
+          <IntegrationCardDetails>
+            <CustomGitServerForm initial={editing} onDone={() => setEditing(null)} />
+          </IntegrationCardDetails>
+        </IntegrationCardShell>
+      ) : null}
+
+      {checking && servers.length === 0 ? (
+        <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <LoaderCircle className="size-3.5 animate-spin" />
+          {translate('settings.customGitServer.checking', 'Checking configured servers…')}
+        </p>
+      ) : null}
+
+      <div className="space-y-3">
+        {servers.map((server) =>
+          editing?.id === server.id ? (
+            <IntegrationCardShell
+              key={server.id}
+              icon={<GitPullRequestArrow className="size-5" />}
+              name={translate('settings.customGitServer.edit', 'Edit {{value0}}', {
+                value0: server.name
+              })}
+              description={server.host}
+              statusTone="neutral"
+              statusLabel="Editing"
+            >
+              <IntegrationCardDetails>
+                <CustomGitServerForm initial={editing} onDone={() => setEditing(null)} />
+              </IntegrationCardDetails>
+            </IntegrationCardShell>
+          ) : (
+            <CustomGitServerRow
+              key={server.id}
+              server={server}
+              onEdit={() => setEditing(formFromServer(server))}
+            />
+          )
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/renderer/src/components/settings/CustomGitServerCards.tsx
+++ b/src/renderer/src/components/settings/CustomGitServerCards.tsx
@@ -8,6 +8,7 @@ import {
   Plus,
   Trash2
 } from 'lucide-react'
+import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -93,14 +94,20 @@ function CustomGitServerForm(props: {
   const handleTest = async (): Promise<void> => {
     setBusy('test')
     setTestResult(null)
-    const result = await testCustomGitServer({ ...form, token: form.token.trim() })
-    if (!mountedRef.current) {
-      return
+    // Why: a rejected IPC call must still clear the busy state and report an error.
+    let next: TestResult
+    try {
+      const result = await testCustomGitServer({ ...form, token: form.token.trim() })
+      next = result.ok
+        ? { state: 'ok', account: result.account }
+        : { state: 'error', error: result.error }
+    } catch (error) {
+      next = { state: 'error', error: error instanceof Error ? error.message : String(error) }
     }
-    setTestResult(
-      result.ok ? { state: 'ok', account: result.account } : { state: 'error', error: result.error }
-    )
-    setBusy(null)
+    if (mountedRef.current) {
+      setTestResult(next)
+      setBusy(null)
+    }
   }
 
   const handleSave = async (): Promise<void> => {
@@ -265,6 +272,7 @@ function CustomGitServerRow(props: {
   onEdit: () => void
 }): React.JSX.Element {
   const removeCustomGitServer = useAppStore((s) => s.removeCustomGitServer)
+  const mountedRef = useMountedRef()
   const [removing, setRemoving] = useState(false)
   const connected = props.server.authenticated
   const statusLabel = connected
@@ -276,7 +284,18 @@ function CustomGitServerRow(props: {
 
   const handleRemove = async (): Promise<void> => {
     setRemoving(true)
-    await removeCustomGitServer(props.server.id)
+    try {
+      await removeCustomGitServer(props.server.id)
+    } catch (error) {
+      // Why: reset on failure so the Remove button isn't stuck if the IPC rejects.
+      if (mountedRef.current) {
+        setRemoving(false)
+      }
+      toast.error(
+        translate('settings.customGitServer.error.remove', 'Failed to remove server'),
+        { description: error instanceof Error ? error.message : String(error) }
+      )
+    }
   }
 
   return (

--- a/src/renderer/src/components/settings/IntegrationsPane.tsx
+++ b/src/renderer/src/components/settings/IntegrationsPane.tsx
@@ -6,6 +6,7 @@ import {
   GitLabIntegrationCard
 } from './source-control-integration-cards'
 import { JiraIntegrationCard, LinearIntegrationCard } from './task-tracker-integration-cards'
+import { CustomGitServerSection } from './CustomGitServerCards'
 import { useIntegrationProviderStatusRefresh } from './use-integration-provider-status-refresh'
 import { translate } from '@/i18n/i18n'
 export { getIntegrationsPaneSearchEntries } from './integrations-search'
@@ -35,6 +36,8 @@ export function IntegrationsPane(): React.JSX.Element {
           <GiteaIntegrationCard />
         </div>
       </section>
+
+      <CustomGitServerSection />
 
       <section className="space-y-3">
         <div className="space-y-1">

--- a/src/renderer/src/components/sidebar/use-worktree-card-secondary-details.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-card-secondary-details.ts
@@ -212,6 +212,7 @@ export function useWorktreeCardSecondaryDetails({
       case 'gitea':
         void updateWorktreeMeta(worktree.id, { linkedGiteaPR: null }, options)
         break
+      case 'custom':
       case 'unsupported':
       case undefined:
         break

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
@@ -62,6 +62,9 @@ function getLinkedReviewNumber(
       return links.linkedAzureDevOpsPR
     case 'gitea':
       return links.linkedGiteaPR
+    // Custom-server reviews are discovered by branch, not persisted by number.
+    case 'custom':
+      return null
   }
 }
 
@@ -70,7 +73,7 @@ function makeLinkedReviewFallback(
   number: number,
   review: HostedReviewInfo | null | undefined
 ): WorktreeCardPrDisplay {
-  const label = provider === 'gitlab' ? 'MR' : 'PR'
+  const label = provider === 'gitlab' || provider === 'custom' ? 'MR' : 'PR'
   return {
     provider,
     number,

--- a/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
+++ b/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
@@ -6,7 +6,8 @@ import { PullRequestIcon } from './WorktreeCardHelpers'
 import type { WorktreeCardPrDisplay } from './worktree-card-pr-display'
 
 export function getReviewLabel(review: WorktreeCardPrDisplay): 'MR' | 'PR' {
-  return review.provider === 'gitlab' ? 'MR' : 'PR'
+  // Custom servers are GitLab-compatible in v1, so they use merge-request copy.
+  return review.provider === 'gitlab' || review.provider === 'custom' ? 'MR' : 'PR'
 }
 
 export function getProviderName(review: WorktreeCardPrDisplay): string {
@@ -21,6 +22,9 @@ export function getProviderName(review: WorktreeCardPrDisplay): string {
   }
   if (review.provider === 'gitea') {
     return 'Gitea'
+  }
+  if (review.provider === 'custom') {
+    return 'Custom git server'
   }
   return 'GitHub'
 }
@@ -72,7 +76,9 @@ export function ReviewIcon({
   variant?: 'provider' | 'generic'
 }): React.JSX.Element {
   const providerIcon =
-    variant === 'provider' && review.provider === 'gitlab' ? GitMerge : PullRequestIcon
+    variant === 'provider' && (review.provider === 'gitlab' || review.provider === 'custom')
+      ? GitMerge
+      : PullRequestIcon
   const Icon = getReviewStateIcon(review.state) ?? providerIcon
   return createElement(Icon, {
     className: cn(className, getCheckTone(review) ?? getStateTone(review.state))

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-labels.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-labels.ts
@@ -105,6 +105,8 @@ export function getWorkspaceCleanupReviewProviderLabel(provider: HostedReviewPro
       return 'Azure DevOps'
     case 'gitea':
       return 'Gitea'
+    case 'custom':
+      return 'Custom git server'
     case 'unsupported':
       return translate('components.workspace.cleanup.browse.review.otherProvider', 'Other')
   }

--- a/src/renderer/src/i18n/hosted-review-localized-copy.ts
+++ b/src/renderer/src/i18n/hosted-review-localized-copy.ts
@@ -31,6 +31,18 @@ export function localizedHostedReviewCopy(
       providerName: translate('auto.i18n.hostedReview.copy.91b5c8d7e6', 'GitLab')
     }
   }
+  if (provider === 'custom') {
+    // Custom servers are GitLab-compatible in v1, so they use merge-request copy.
+    return {
+      shortLabel: translate('auto.i18n.hostedReview.copy.c4e8f1a2b9', 'MR'),
+      reviewLabel: translate('auto.i18n.hostedReview.copy.b3d7e0f1a8', 'merge request'),
+      titleLabel: translate('auto.i18n.hostedReview.copy.a2c6d9e0f7', 'Merge Request'),
+      providerName: translate(
+        'settings.customGitServer.providerName',
+        'Custom git server'
+      )
+    }
+  }
   if (provider === 'azure-devops') {
     return {
       shortLabel: translate('auto.i18n.hostedReview.copy.f0a4b8c2d1', 'PR'),

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -183,6 +183,44 @@
         "heading": "Remote browsing",
         "headingDescription": "Where remote workspace pages render, and where their network traffic leaves from."
       }
+    },
+    "customGitServer": {
+      "title": "Custom git servers",
+      "description": "Add self-hosted or internal git servers (e.g. git.example.com) for pull/merge requests and review status.",
+      "add": "Add custom git server",
+      "addHint": "Enter the server host, API base URL, and a token.",
+      "checking": "Checking configured servers…",
+      "edit": "Edit {{value0}}",
+      "providerName": "Custom git server",
+      "field": {
+        "name": "Name",
+        "host": "Host",
+        "apiBaseUrl": "API base URL",
+        "apiType": "API type",
+        "token": "Token"
+      },
+      "placeholder": {
+        "name": "My Git Server",
+        "host": "git.example.com",
+        "apiBaseUrl": "https://git.example.com"
+      },
+      "token": {
+        "keep": "Leave blank to keep existing token",
+        "new": "Personal access token",
+        "help": "Stored locally and encrypted when your OS keychain is available."
+      },
+      "test": {
+        "ok": "Connection succeeded",
+        "okAccount": "Connected as {{value0}}"
+      },
+      "action": {
+        "add": "Add custom git server",
+        "cancel": "Cancel",
+        "edit": "Edit",
+        "remove": "Remove",
+        "save": "Save",
+        "test": "Test connection"
+      }
     }
   },
   "menu": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -220,6 +220,9 @@
         "remove": "Remove",
         "save": "Save",
         "test": "Test connection"
+      },
+      "error": {
+        "remove": "Failed to remove server"
       }
     }
   },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -40,6 +40,44 @@
         "title": "Mostrar icono en la barra de menús",
         "description": "Mantén un acceso directo de Orca e indicador de actividad en la barra de menús de macOS."
       }
+    },
+    "customGitServer": {
+      "title": "Custom git servers",
+      "description": "Add self-hosted or internal git servers (e.g. git.example.com) for pull/merge requests and review status.",
+      "add": "Add custom git server",
+      "addHint": "Enter the server host, API base URL, and a token.",
+      "checking": "Checking configured servers…",
+      "edit": "Edit {{value0}}",
+      "providerName": "Custom git server",
+      "field": {
+        "name": "Name",
+        "host": "Host",
+        "apiBaseUrl": "API base URL",
+        "apiType": "API type",
+        "token": "Token"
+      },
+      "placeholder": {
+        "name": "My Git Server",
+        "host": "git.example.com",
+        "apiBaseUrl": "https://git.example.com"
+      },
+      "token": {
+        "keep": "Leave blank to keep existing token",
+        "new": "Personal access token",
+        "help": "Stored locally and encrypted when your OS keychain is available."
+      },
+      "test": {
+        "ok": "Connection succeeded",
+        "okAccount": "Connected as {{value0}}"
+      },
+      "action": {
+        "add": "Add custom git server",
+        "cancel": "Cancel",
+        "edit": "Edit",
+        "remove": "Remove",
+        "save": "Save",
+        "test": "Test connection"
+      }
     }
   },
   "menu": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -77,6 +77,9 @@
         "remove": "Remove",
         "save": "Save",
         "test": "Test connection"
+      },
+      "error": {
+        "remove": "Failed to remove server"
       }
     }
   },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -77,6 +77,9 @@
         "remove": "Remove",
         "save": "Save",
         "test": "Test connection"
+      },
+      "error": {
+        "remove": "Failed to remove server"
       }
     }
   },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -40,6 +40,44 @@
         "title": "メニューバーアイコンを表示",
         "description": "macOS メニューバーに Orca のショートカットとアクティビティインジケーターを表示します。"
       }
+    },
+    "customGitServer": {
+      "title": "Custom git servers",
+      "description": "Add self-hosted or internal git servers (e.g. git.example.com) for pull/merge requests and review status.",
+      "add": "Add custom git server",
+      "addHint": "Enter the server host, API base URL, and a token.",
+      "checking": "Checking configured servers…",
+      "edit": "Edit {{value0}}",
+      "providerName": "Custom git server",
+      "field": {
+        "name": "Name",
+        "host": "Host",
+        "apiBaseUrl": "API base URL",
+        "apiType": "API type",
+        "token": "Token"
+      },
+      "placeholder": {
+        "name": "My Git Server",
+        "host": "git.example.com",
+        "apiBaseUrl": "https://git.example.com"
+      },
+      "token": {
+        "keep": "Leave blank to keep existing token",
+        "new": "Personal access token",
+        "help": "Stored locally and encrypted when your OS keychain is available."
+      },
+      "test": {
+        "ok": "Connection succeeded",
+        "okAccount": "Connected as {{value0}}"
+      },
+      "action": {
+        "add": "Add custom git server",
+        "cancel": "Cancel",
+        "edit": "Edit",
+        "remove": "Remove",
+        "save": "Save",
+        "test": "Test connection"
+      }
     }
   },
   "menu": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -77,6 +77,9 @@
         "remove": "Remove",
         "save": "Save",
         "test": "Test connection"
+      },
+      "error": {
+        "remove": "Failed to remove server"
       }
     }
   },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -40,6 +40,44 @@
         "title": "메뉴 바 아이콘 표시",
         "description": "macOS 메뉴 바에 Orca 바로가기 및 활동 표시기를 유지합니다."
       }
+    },
+    "customGitServer": {
+      "title": "Custom git servers",
+      "description": "Add self-hosted or internal git servers (e.g. git.example.com) for pull/merge requests and review status.",
+      "add": "Add custom git server",
+      "addHint": "Enter the server host, API base URL, and a token.",
+      "checking": "Checking configured servers…",
+      "edit": "Edit {{value0}}",
+      "providerName": "Custom git server",
+      "field": {
+        "name": "Name",
+        "host": "Host",
+        "apiBaseUrl": "API base URL",
+        "apiType": "API type",
+        "token": "Token"
+      },
+      "placeholder": {
+        "name": "My Git Server",
+        "host": "git.example.com",
+        "apiBaseUrl": "https://git.example.com"
+      },
+      "token": {
+        "keep": "Leave blank to keep existing token",
+        "new": "Personal access token",
+        "help": "Stored locally and encrypted when your OS keychain is available."
+      },
+      "test": {
+        "ok": "Connection succeeded",
+        "okAccount": "Connected as {{value0}}"
+      },
+      "action": {
+        "add": "Add custom git server",
+        "cancel": "Cancel",
+        "edit": "Edit",
+        "remove": "Remove",
+        "save": "Save",
+        "test": "Test connection"
+      }
     }
   },
   "menu": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -77,6 +77,9 @@
         "remove": "Remove",
         "save": "Save",
         "test": "Test connection"
+      },
+      "error": {
+        "remove": "Failed to remove server"
       }
     }
   },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -40,6 +40,44 @@
         "title": "显示菜单栏图标",
         "description": "在 macOS 菜单栏中保留 Orca 快捷方式和活动指示器。"
       }
+    },
+    "customGitServer": {
+      "title": "Custom git servers",
+      "description": "Add self-hosted or internal git servers (e.g. git.example.com) for pull/merge requests and review status.",
+      "add": "Add custom git server",
+      "addHint": "Enter the server host, API base URL, and a token.",
+      "checking": "Checking configured servers…",
+      "edit": "Edit {{value0}}",
+      "providerName": "Custom git server",
+      "field": {
+        "name": "Name",
+        "host": "Host",
+        "apiBaseUrl": "API base URL",
+        "apiType": "API type",
+        "token": "Token"
+      },
+      "placeholder": {
+        "name": "My Git Server",
+        "host": "git.example.com",
+        "apiBaseUrl": "https://git.example.com"
+      },
+      "token": {
+        "keep": "Leave blank to keep existing token",
+        "new": "Personal access token",
+        "help": "Stored locally and encrypted when your OS keychain is available."
+      },
+      "test": {
+        "ok": "Connection succeeded",
+        "okAccount": "Connected as {{value0}}"
+      },
+      "action": {
+        "add": "Add custom git server",
+        "cancel": "Cancel",
+        "edit": "Edit",
+        "remove": "Remove",
+        "save": "Save",
+        "test": "Test connection"
+      }
     }
   },
   "menu": {

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -13,6 +13,7 @@ import { createHostedReviewSlice } from './slices/hosted-review'
 import { createLinearSlice } from './slices/linear'
 import { createPreflightSlice } from './slices/preflight'
 import { createJiraSlice } from './slices/jira'
+import { createCustomGitServerSlice } from './slices/custom-git-server'
 import { createEditorSlice } from './slices/editor'
 import { createStatsSlice } from './slices/stats'
 import { createMemorySlice } from './slices/memory'
@@ -87,6 +88,7 @@ export const useAppStore = create<AppState>()(
         ...createLinearSlice(...a),
         ...createPreflightSlice(...a),
         ...createJiraSlice(...a),
+        ...createCustomGitServerSlice(...a),
         ...createEditorSlice(...a),
         ...createStatsSlice(...a),
         ...createMemorySlice(...a),

--- a/src/renderer/src/store/slices/custom-git-server.ts
+++ b/src/renderer/src/store/slices/custom-git-server.ts
@@ -1,0 +1,36 @@
+import type { StateCreator } from 'zustand'
+import type { AppState } from '../types'
+import type {
+  CustomGitServer,
+  CustomGitServerDraft,
+  CustomGitServerTestResult
+} from '../../../../shared/custom-git-server'
+
+// The custom-git-server config is stored on the local main process (like the
+// Jira/Linear connection stores), so mutations go straight through window.api.
+// Per-server auth STATUS is surfaced via preflight (preflightStatus.customGitServers);
+// save/remove trigger a forced preflight refresh so cards update immediately.
+export type CustomGitServerSlice = {
+  saveCustomGitServer: (draft: CustomGitServerDraft & { id?: string }) => Promise<CustomGitServer>
+  removeCustomGitServer: (id: string) => Promise<void>
+  testCustomGitServer: (
+    draft: CustomGitServerDraft & { token: string }
+  ) => Promise<CustomGitServerTestResult>
+}
+
+/** Store slice for custom-git-server save/remove/test, forcing a preflight refresh on mutation. */
+export const createCustomGitServerSlice: StateCreator<AppState, [], [], CustomGitServerSlice> = (
+  _set,
+  get
+) => ({
+  saveCustomGitServer: async (draft) => {
+    const server = await window.api.customGitServer.save(draft)
+    await get().refreshPreflightStatus({ force: true })
+    return server
+  },
+  removeCustomGitServer: async (id) => {
+    await window.api.customGitServer.remove({ id })
+    await get().refreshPreflightStatus({ force: true })
+  },
+  testCustomGitServer: (draft) => window.api.customGitServer.test(draft)
+})

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -17,6 +17,7 @@ import { createHostedReviewSlice } from './hosted-review'
 import { createLinearSlice } from './linear'
 import { createPreflightSlice } from './preflight'
 import { createJiraSlice } from './jira'
+import { createCustomGitServerSlice } from './custom-git-server'
 import { createEditorSlice } from './editor'
 import { createStatsSlice } from './stats'
 import { createMemorySlice } from './memory'
@@ -74,6 +75,7 @@ export function createTestStore() {
     ...createLinearSlice(...a),
     ...createPreflightSlice(...a),
     ...createJiraSlice(...a),
+    ...createCustomGitServerSlice(...a),
     ...createEditorSlice(...a),
     ...createStatsSlice(...a),
     ...createMemorySlice(...a),

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -11,6 +11,7 @@ import type { HostedReviewSlice } from './slices/hosted-review'
 import type { LinearSlice } from './slices/linear'
 import type { PreflightSlice } from './slices/preflight'
 import type { JiraSlice } from './slices/jira'
+import type { CustomGitServerSlice } from './slices/custom-git-server'
 import type { EditorSlice } from './slices/editor'
 import type { StatsSlice } from './slices/stats'
 import type { MemorySlice } from './slices/memory'
@@ -57,6 +58,7 @@ export type AppState = RepoSlice &
   LinearSlice &
   PreflightSlice &
   JiraSlice &
+  CustomGitServerSlice &
   EditorSlice &
   StatsSlice &
   MemorySlice &

--- a/src/shared/custom-git-server.test.ts
+++ b/src/shared/custom-git-server.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isCustomGitServerApiFlavor,
+  matchCustomGitServerForHost,
+  normalizeCustomGitServerApiBaseUrl,
+  normalizeCustomGitServerHost
+} from './custom-git-server'
+
+describe('normalizeCustomGitServerHost', () => {
+  it('lowercases a bare host', () => {
+    expect(normalizeCustomGitServerHost('Git.Example.Com')).toBe('git.example.com')
+  })
+
+  it('extracts the host from an https URL (keeping the port)', () => {
+    expect(normalizeCustomGitServerHost('https://git.example.com/team/repo')).toBe('git.example.com')
+    expect(normalizeCustomGitServerHost('https://git.example.com:8443/x')).toBe(
+      'git.example.com:8443'
+    )
+  })
+
+  it('extracts the host from an scp-like remote', () => {
+    expect(normalizeCustomGitServerHost('git@git.example.com:team/repo.git')).toBe('git.example.com')
+  })
+
+  it('drops a pasted trailing path from a bare host', () => {
+    expect(normalizeCustomGitServerHost('git.example.com/')).toBe('git.example.com')
+  })
+
+  it('returns empty for blank input', () => {
+    expect(normalizeCustomGitServerHost('   ')).toBe('')
+  })
+})
+
+describe('normalizeCustomGitServerApiBaseUrl', () => {
+  it('adds https:// when no scheme is present', () => {
+    expect(normalizeCustomGitServerApiBaseUrl('git.example.com')).toBe('https://git.example.com')
+  })
+
+  it('trims trailing slashes and keeps an explicit scheme', () => {
+    expect(normalizeCustomGitServerApiBaseUrl('http://git.example.com/')).toBe(
+      'http://git.example.com'
+    )
+  })
+})
+
+describe('isCustomGitServerApiFlavor', () => {
+  it('accepts known flavors and rejects others', () => {
+    expect(isCustomGitServerApiFlavor('gitlab')).toBe(true)
+    expect(isCustomGitServerApiFlavor('github')).toBe(false)
+    expect(isCustomGitServerApiFlavor(null)).toBe(false)
+  })
+})
+
+describe('matchCustomGitServerForHost', () => {
+  const servers = [
+    { id: '1', host: 'git.example.com' },
+    { id: '2', host: 'ci.example.org:8443' }
+  ]
+
+  it('matches an exact host regardless of remote-URL form', () => {
+    expect(matchCustomGitServerForHost('git@git.example.com:team/repo.git', servers)?.id).toBe('1')
+    expect(matchCustomGitServerForHost('https://git.example.com/team/repo', servers)?.id).toBe('1')
+  })
+
+  it('falls back to a hostname match when the saved host has no port', () => {
+    expect(matchCustomGitServerForHost('https://git.example.com:9000/x', servers)?.id).toBe('1')
+  })
+
+  it('does not match a different port when the saved host pins one', () => {
+    expect(matchCustomGitServerForHost('https://ci.example.org/x', servers)).toBeNull()
+    expect(matchCustomGitServerForHost('https://ci.example.org:8443/x', servers)?.id).toBe('2')
+  })
+
+  it('returns null for an unconfigured host', () => {
+    expect(matchCustomGitServerForHost('github.com', servers)).toBeNull()
+  })
+})

--- a/src/shared/custom-git-server.ts
+++ b/src/shared/custom-git-server.ts
@@ -1,0 +1,138 @@
+// Shared types for user-configured "custom git servers" — self-hosted / internal
+// hosts (e.g. https://git.example.com) that Orca talks to over a native REST API.
+// The API "flavor" is pluggable so new server APIs can be added without touching
+// the provider/persistence/UI plumbing; GitLab-compatible is the first flavor.
+
+/** Which REST API a custom server speaks. Extensible: add a value here plus a
+ *  flavor client in src/main/custom-git-server/api-flavor.ts. */
+export type CustomGitServerApiFlavor = 'gitlab'
+
+/** All supported API flavors (the runtime counterpart of CustomGitServerApiFlavor). */
+export const CUSTOM_GIT_SERVER_API_FLAVORS: readonly CustomGitServerApiFlavor[] = ['gitlab']
+
+/** Flavor used when none is specified or a stored value is invalid. */
+export const DEFAULT_CUSTOM_GIT_SERVER_API_FLAVOR: CustomGitServerApiFlavor = 'gitlab'
+
+/** Persisted server definition (the token is stored separately, encrypted). */
+export type CustomGitServer = {
+  id: string
+  /** User-facing label, e.g. "My Git Server". */
+  name: string
+  /** Normalized remote host, e.g. "git.example.com" (may include :port). */
+  host: string
+  /** Web/API origin, e.g. "https://git.example.com". Flavor clients append their
+   *  own API path (e.g. /api/v4) to this. */
+  apiBaseUrl: string
+  apiFlavor: CustomGitServerApiFlavor
+}
+
+/** A server definition submitted from the UI before it has an id. */
+export type CustomGitServerDraft = {
+  name: string
+  host: string
+  apiBaseUrl: string
+  apiFlavor: CustomGitServerApiFlavor
+  /** Optional on update (keep existing token when omitted). */
+  token?: string
+}
+
+/** Renderer-facing status for one configured server. */
+export type CustomGitServerStatus = {
+  id: string
+  name: string
+  host: string
+  apiBaseUrl: string
+  apiFlavor: CustomGitServerApiFlavor
+  /** A token is saved for this server. */
+  configured: boolean
+  /** The saved token authenticated against the server. */
+  authenticated: boolean
+  account: string | null
+}
+
+export type CustomGitServerTestResult =
+  | { ok: true; account: string | null }
+  | { ok: false; error: string }
+
+/** Type guard for a known API flavor. */
+export function isCustomGitServerApiFlavor(value: unknown): value is CustomGitServerApiFlavor {
+  return typeof value === 'string' && (CUSTOM_GIT_SERVER_API_FLAVORS as readonly string[]).includes(value)
+}
+
+/**
+ * Normalize a host or URL to a comparable host token: lowercase hostname with an
+ * optional `:port`, protocol/path/credentials stripped. Accepts bare hosts
+ * ("git.example.com"), URLs ("https://git.example.com/x"), and scp-like remotes
+ * ("git@git.example.com:owner/repo.git").
+ */
+export function normalizeCustomGitServerHost(value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return ''
+  }
+  // URL form (has a scheme).
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+    try {
+      const url = new URL(trimmed)
+      const protocol = url.protocol.toLowerCase()
+      // For http(s) the URL port identifies the endpoint; for ssh it's transport.
+      const host = protocol === 'http:' || protocol === 'https:' ? url.host : url.hostname
+      return host.toLowerCase()
+    } catch {
+      return ''
+    }
+  }
+  // scp-like form: [user@]host:path — but a bare `host:port` (no user, numeric
+  // or non-path suffix) is NOT scp, so only strip to host when there's a user@
+  // prefix or a `/` path after the colon; otherwise keep it as host[:port].
+  const scpLike = trimmed.match(/^([^@/:]+@)?([^:\s/]+):([^\s]+)$/)
+  if (scpLike) {
+    const [, user, host, rest] = scpLike
+    if (user || rest.includes('/')) {
+      return host.toLowerCase()
+    }
+  }
+  // Bare host, possibly `host:port`, possibly with a trailing path the user pasted.
+  return trimmed.replace(/\/.*$/, '').replace(/\/+$/, '').toLowerCase()
+}
+
+/** Strip a trailing `:port` so hostname-only comparisons can fall back. */
+function hostnameOf(host: string): string {
+  return host.replace(/:\d+$/, '')
+}
+
+/** Trim/normalize the stored API base URL: ensure a scheme, drop trailing slashes. */
+export function normalizeCustomGitServerApiBaseUrl(value: string): string {
+  const trimmed = value.trim().replace(/\/+$/, '')
+  if (!trimmed) {
+    return ''
+  }
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`
+}
+
+/**
+ * Find the configured server whose host matches `remoteHost`. Matches an exact
+ * normalized host, and falls back to a hostname-only match so a server saved
+ * without a port still claims a remote on the same hostname.
+ */
+export function matchCustomGitServerForHost<T extends { host: string }>(
+  remoteHost: string,
+  servers: readonly T[]
+): T | null {
+  const normalized = normalizeCustomGitServerHost(remoteHost)
+  if (!normalized) {
+    return null
+  }
+  const normalizedHostname = hostnameOf(normalized)
+  for (const server of servers) {
+    const serverHost = normalizeCustomGitServerHost(server.host)
+    if (serverHost === normalized) {
+      return server
+    }
+    // Only relax to hostname when the saved host carries no explicit port.
+    if (hostnameOf(serverHost) === serverHost && serverHost === normalizedHostname) {
+      return server
+    }
+  }
+  return null
+}

--- a/src/shared/hosted-review-creation-providers.ts
+++ b/src/shared/hosted-review-creation-providers.ts
@@ -6,6 +6,7 @@ export type HostedReviewCreationProvider =
   | 'bitbucket'
   | 'azure-devops'
   | 'gitea'
+  | 'custom'
 
 export function supportsHostedReviewCreation(
   provider: HostedReviewProvider | null | undefined
@@ -15,7 +16,8 @@ export function supportsHostedReviewCreation(
     provider === 'gitlab' ||
     provider === 'bitbucket' ||
     provider === 'azure-devops' ||
-    provider === 'gitea'
+    provider === 'gitea' ||
+    provider === 'custom'
   )
 }
 

--- a/src/shared/hosted-review.ts
+++ b/src/shared/hosted-review.ts
@@ -12,6 +12,9 @@ export type HostedReviewProvider =
   | 'bitbucket'
   | 'azure-devops'
   | 'gitea'
+  // User-configured self-hosted server; the concrete API flavor lives in the
+  // custom-git-server config, not in this id, so adding a flavor never grows this.
+  | 'custom'
   | 'unsupported'
 
 export type HostedReviewState = 'open' | 'closed' | 'merged' | 'draft'
@@ -65,6 +68,7 @@ export type HostedReviewForBranchArgs = {
   linkedBitbucketPR?: number | null
   linkedAzureDevOpsPR?: number | null
   linkedGiteaPR?: number | null
+  linkedCustomPR?: number | null
   // The worktree's checked-out HEAD oid (GitHub merged-at-head visibility).
   currentHeadOid?: string | null
   /**
@@ -205,6 +209,7 @@ export type HostedReviewCreationEligibilityArgs = {
   linkedBitbucketPR?: number | null
   linkedAzureDevOpsPR?: number | null
   linkedGiteaPR?: number | null
+  linkedCustomPR?: number | null
 }
 
 export type HostedReviewDecision = 'approved' | 'changes_requested' | 'review_required' | null

--- a/src/shared/integration-credential-errors.ts
+++ b/src/shared/integration-credential-errors.ts
@@ -1,4 +1,4 @@
-export type IntegrationCredentialService = 'Linear' | 'Jira' | 'Bitbucket'
+export type IntegrationCredentialService = 'Linear' | 'Jira' | 'Bitbucket' | 'CustomGitServer'
 
 export function credentialDecryptionMessage(service: IntegrationCredentialService): string {
   return `Could not decrypt saved ${service} credential. Approve Keychain access or reconnect ${service}.`
@@ -11,6 +11,7 @@ export function isIntegrationCredentialDecryptionError(error: unknown): boolean 
   return (
     message.includes(credentialDecryptionMessage('Linear')) ||
     message.includes(credentialDecryptionMessage('Jira')) ||
-    message.includes(credentialDecryptionMessage('Bitbucket'))
+    message.includes(credentialDecryptionMessage('Bitbucket')) ||
+    message.includes(credentialDecryptionMessage('CustomGitServer'))
   )
 }

--- a/src/shared/pull-request-generation.ts
+++ b/src/shared/pull-request-generation.ts
@@ -51,6 +51,7 @@ const PROVIDER_LABELS: Record<HostedReviewProvider, string> = {
   bitbucket: 'Bitbucket',
   'azure-devops': 'Azure DevOps',
   gitea: 'Gitea',
+  custom: 'Custom Git Server',
   unsupported: 'hosted-review'
 }
 

--- a/src/shared/rpc-contract/hosted-review-params.ts
+++ b/src/shared/rpc-contract/hosted-review-params.ts
@@ -37,7 +37,7 @@ export const HostedReviewCreationEligibility = z.object({
 export const HostedReviewCreate = z.object({
   repo: requiredString('Missing repo selector'),
   worktree: z.string().min(1, 'Missing worktree selector').optional(),
-  provider: z.enum(['github', 'gitlab', 'bitbucket', 'azure-devops', 'gitea', 'unsupported']),
+  provider: z.enum(['github', 'gitlab', 'bitbucket', 'azure-devops', 'gitea', 'custom', 'unsupported']),
   base: requiredString('Missing base branch'),
   head: z.string().optional(),
   title: requiredString('Missing title'),


### PR DESCRIPTION
## Summary

Review providers were limited to a fixed set (GitHub, GitLab, Bitbucket, Azure DevOps, Gitea) with no way to point Orca at a self-hosted / internal git server. This adds a **user-managed "Custom git servers"** integration so any GitLab-compatible host can be used for merge requests, checks, and review status.

**What it does**

- New **Custom git servers** section in **Settings → Integrations → Review providers** with an add/edit form: name, host, API base URL, **API type**, and token.
- Config persists to `~/.orca/custom-git-servers.json`; the token is encrypted per-server via the OS keychain (`safeStorage`), mirroring the existing Jira/Linear connection store and shared credential helper.
- A `custom` `ForgeProvider` claims a repo **only when its origin host matches a configured server** — evaluated first so a configured host wins over Gitea's greedy unknown-host fallback, while `github.com` / `gitlab.com` / etc. still fall through unaffected. When no servers are configured it short-circuits (no remote probe).
- Native token-REST (no `gh`/`glab` CLI), so it works over SSH/remote runtimes. Review discovery, status, and creation route through the matched server.

**Extensible by design**

The API integration is a pluggable **flavor** (`CustomGitServerFlavorClient` + a registry). **GitLab-compatible `/api/v4`** is the first flavor, reusing the existing GitLab REST→`MRInfo` mappers. Adding another flavor (GitHub Enterprise, Gitea, or a bespoke REST shape) is a matter of implementing one interface and registering it — the provider id stays a single `custom` value (the flavor lives in per-server config), so the `HostedReviewProvider` union doesn't grow per flavor.

## Screenshots

No screenshots attached (none available in this environment). This PR does change user-visible renderer UI:

- **New** "Custom git servers" section in Settings → Integrations, with an "Add custom git server" button, an inline add/edit card (name, host, API base URL, API type dropdown, password token field, Test connection / Save / Cancel), and per-server rows showing a connected/auth-failed/not-configured status badge plus account.
- Worktree cards and review chips now recognize the `custom` provider: it renders merge-request copy ("MR", "merge request", `GitMerge` icon, provider name "Custom git server"), matching the existing GitLab treatment. **Before:** custom-server remotes had no review UI. **After:** they display MR status/labels like GitLab.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

`pnpm typecheck` (node/cli/web) and `pnpm lint` (oxlint + localization catalog parity + coverage) pass. `pnpm test` was not run in full — targeted suites pass: shared host-normalization/matching, remote parsing, store round-trip (incl. `safeStorage`), GitLab-compat client mapping/creation, and the existing forge-provider / hosted-review / preflight suites. Also verified against a live GitLab v4 server (gitlab.com): fetched and correctly mapped a real public merge request, and confirmed config-persistence + real-`git` remote detection routes a matching host to the custom provider (and ignores unconfigured hosts). `pnpm build` was not run in this environment.

## AI Review Report

I reviewed this diff for correctness, provider compatibility, and cross-platform behavior. Focus areas and findings:

- **Provider resolution / ordering.** `customForgeProvider` is placed first in `FORGE_PROVIDERS`, but `getCustomGitServerRepoRef` returns `null` unless (a) at least one server is configured and (b) the origin host matches a saved server. It short-circuits before any `git remote get-url` when no servers exist. This correctly prevents it from stealing `github.com` / `gitlab.com` remotes or triggering git probes for users who never configure a server. Verified by the new forge-provider ordering test.
- **Git provider compatibility.** v1 ships only the GitLab-compatible `/api/v4` flavor, and the `custom` provider is treated as GitLab-flavored throughout the renderer (MR copy, `GitMerge` icon, and the manual-review URL builder emitting GitLab's `/-/merge_requests/new` shape). This is correct today because `gitlab` is the only registered flavor, but it is a **forward-compat coupling**: adding a non-GitLab flavor would require revisiting the hardcoded MR labels/icon and the manual-review URL. Flagged as a follow-up, not a blocker.
- **Host matching edge cases.** `matchCustomGitServerForHost` does exact normalized-host match first, then relaxes to a hostname-only match *only when the saved host has no explicit port*. This means a server saved without a port claims remotes on the same hostname regardless of the remote's port — intentional and documented, but worth noting it can over-claim if the same hostname serves an unrelated service on another port. Covered by tests.
- **Remote parsing.** `parseCustomGitServerRemote` handles https, scp-like, and `ssh://` forms, keeps the port for http(s) but drops it for ssh (transport-only), preserves nested-group owners, and rejects unsupported protocols. Cache stores the parsed remote (not the server match) so a newly added server is picked up without invalidation; connection-backed lookups are deliberately not cached (flaky tunnels). Reasonable.
- **Error handling.** GET requests swallow transport/non-OK errors and return `null` (status-poll friendly); `createReview` classifies 401/403 → `auth_required`, 409/duplicate → `already_exists`, timeout → `unknown_completion`, 400/422 → `validation`. `classifyCreateError` logs the error message but not the token. Looks sound.

**Cross-platform (macOS / Linux / Windows):** Explicitly checked. **No keyboard shortcuts** are added, so no `metaKey`/`ctrlKey` or accelerator concerns. All filesystem paths use `node:path` `join` plus `os.homedir()` — no hardcoded separators. Git remote reads go through `gitExecFileAsync` / the SSH git provider with argument arrays (no shell string interpolation), so they are shell- and SSH-safe. `safeStorage` is used only in the Electron main process (`token-store.ts`), isolated from the electron-free config store so provider detection doesn't pull Electron into unrelated import graphs. One minor platform note: `writeFileSync(..., { mode: 0o600 })` is effectively a no-op on Windows (POSIX perms are ignored there) — harmless but not a real ACL restriction.

No fabricated results; the above is based solely on the diff.

## Security Audit

Based on the diff:

- **Input handling.** IPC handlers (`src/main/ipc/custom-git-server.ts`) coerce all fields via `str()` and validate `apiFlavor` against the known set, requiring name/host/apiBaseUrl before saving. `normalizeServerRecord` re-validates records loaded from disk and drops malformed entries. Reasonable.
- **URL / endpoint handling.** `apiBaseUrl` is normalized (scheme enforced, trailing slashes trimmed) and the flavor client appends `/api/v4`; the project path is `encodeURIComponent`-escaped and query params go through `URLSearchParams`, so there's no path/query injection. Remote parsing enforces a protocol allowlist. **Note:** `normalizeCustomGitServerApiBaseUrl` accepts `http://` (not only https). This is intentional for internal hosts, but a token sent over plaintext HTTP is exposed on the wire — worth calling out for users pointing at non-TLS internal servers.
- **Command execution.** Only `git remote get-url origin` is run, via `execFile`-style argument arrays through the repo's git/SSH runtime — no shell, no interpolation of untrusted input. Safe.
- **Auth / tokens / secrets.** Tokens are sent as the GitLab `PRIVATE-TOKEN` header, stored per-server encrypted via `safeStorage` with file mode `0o600` and a base64url-encoded filename (no path traversal from the server id). Tokens are never returned to the renderer (status exposes only account/booleans) and are not logged in the create-error path. **Fallback risk:** when `safeStorage` is unavailable (e.g., a Linux box without a keychain), the token is written in **plaintext** with a `console.warn`. This matches the existing credential-store pattern but should be noted.
- **Dependencies.** No new dependencies added.
- **IPC.** Five new channels (`customGitServer:list|status|save|remove|test`); inputs validated as above, and cache resets are triggered on save/remove. No new renderer-exposed surface beyond typed wrappers.

No critical issues found. Follow-ups: consider warning in the UI when `apiBaseUrl` is `http://`, and surfacing the plaintext-token fallback to the user.

## Notes

- **v1 targets the GitLab v4 API**; the API-type selector is wired for future flavors, but the renderer currently assumes GitLab-style merge-request copy and URLs for the `custom` provider — revisit those spots when a second flavor lands.
- **Git provider compatibility:** this only affects the new opt-in `custom` provider and does not change GitHub/GitLab/Bitbucket/Azure DevOps/Gitea behavior; unconfigured hosts are untouched.
- **SSH / remote runtimes:** review discovery, status, and creation use native REST (no `gh`/`glab` CLI), and remote detection runs through the repo's own git/SSH runtime, so the feature works over SSH.
- **Plaintext-token fallback** when the OS keychain is unavailable, and **`http://` API base URLs**, are the two security items to keep an eye on (see Security Audit).
- All strings are localized (keys added to all 5 locale catalogs; non-English catalogs currently carry the English source strings pending translation).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI5

You can connect Orca to self-hosted git servers, not only the big public hosts. Settings lets you add a custom server with host, API URL, API type, and token so merge requests and checks work against internal GitLab-style hosts.

