### PR TITLE
fix(agent-status): stamp renderer SSH ownership

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -149,6 +149,7 @@ type StoreState = {
       | { kind: 'wsl'; distro: string }
   }[]
   sshConnectionStates: Map<string, { status: string }>
+  transientClearedAgentStatusConnectionIds: Record<string, true>
   cacheTimerByKey: Record<string, number | null>
   settings: {
     theme?: 'system' | 'dark' | 'light'
@@ -800,6 +801,7 @@ describe('connectPanePty', () => {
       repos: [{ id: 'repo1', connectionId: null, displayName: 'orca' }],
       projects: [],
       sshConnectionStates: new Map(),
+      transientClearedAgentStatusConnectionIds: {},
       cacheTimerByKey: {},
       // Why: terminalMainSideEffectAuthority false pins the legacy renderer
       // byte-parser wiring this suite asserts on (onTitleChange/onBell on the

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -18,6 +18,7 @@ import { resolveWindowsShiftEnterEncodingForPane } from './terminal-windows-shif
 import type * as UseNotificationDispatchModule from './use-notification-dispatch'
 import { getEagerPtyBufferHandle } from './pty-dispatcher'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
+import { toAppSshPtyId } from '../../../../shared/ssh-pty-id'
 import type { TerminalLayoutSnapshot, TuiAgent } from '../../../../shared/types'
 import { YOLO_TUI_AGENT_ARGS } from '../../../../shared/tui-agent-permissions'
 import { SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV } from '../../../../shared/setup-agent-sequencing'
@@ -546,7 +547,16 @@ function createDeps(overrides: Record<string, unknown> = {}) {
     updateTabTitle: vi.fn(),
     setRuntimePaneTitle: vi.fn(),
     clearRuntimePaneTitle: vi.fn(),
-    updateTabPtyId: vi.fn(),
+    updateTabPtyId: vi.fn((tabId: string, ptyId: string, replacedPtyId?: string) => {
+      const current = mockStoreState.ptyIdsByTabId?.[tabId] ?? []
+      const next =
+        replacedPtyId && current.includes(replacedPtyId)
+          ? current.map((candidate) => (candidate === replacedPtyId ? ptyId : candidate))
+          : current.includes(ptyId)
+            ? current
+            : [...current, ptyId]
+      mockStoreState.ptyIdsByTabId = { ...mockStoreState.ptyIdsByTabId, [tabId]: next }
+    }),
     markWorktreeUnread: vi.fn(),
     markTerminalTabUnread: vi.fn(),
     markTerminalPaneUnread: vi.fn(),
@@ -556,7 +566,12 @@ function createDeps(overrides: Record<string, unknown> = {}) {
     dispatchNotification: vi.fn(),
     onShowSessionRestoredBanner: vi.fn(),
     setCacheTimerStartedAt: vi.fn(),
-    syncPanePtyLayoutBinding: vi.fn(),
+    syncPanePtyLayoutBinding: vi.fn((paneId: number, ptyId: string) => {
+      const layout = mockStoreState.terminalLayoutsByTabId?.['tab-1']
+      if (layout) {
+        layout.ptyIdsByLeafId = { ...layout.ptyIdsByLeafId, [leafIdForPane(paneId)]: ptyId }
+      }
+    }),
     clearExitedPanePtyLayoutBinding: vi.fn(),
     ...overrides
   }
@@ -826,11 +841,18 @@ describe('connectPanePty', () => {
       observeTerminalGitHubPullRequestLink: vi.fn(),
       recordTerminalInput: vi.fn(),
       setAgentStatus: vi.fn(
-        (paneKey: string, payload: Record<string, unknown>, terminalTitle?: string | null) => {
+        (
+          paneKey: string,
+          payload: Record<string, unknown>,
+          terminalTitle?: string | null,
+          _timing?: unknown,
+          routing?: { connectionId?: string | null }
+        ) => {
           mockStoreState.agentStatusByPaneKey[paneKey] = {
             ...payload,
             paneKey,
             ...(terminalTitle ? { terminalTitle } : {}),
+            ...(routing?.connectionId !== undefined ? { connectionId: routing.connectionId } : {}),
             updatedAt: Date.now(),
             stateStartedAt: Date.now(),
             stateHistory: []
@@ -1725,11 +1747,11 @@ describe('connectPanePty', () => {
     const paneKey = makePaneKey('tab-1', LEAF_1)
     const dataCallbackRef: { current: ((data: string) => void) | null } = { current: null }
     const pane = createPane(1)
-    const transport = createMockTransport('remote:web-env-1@@pty-command-finished')
+    const transport = createMockTransport('remote:env-1@@pty-command-finished')
     transport.connect.mockImplementation(
       async ({ callbacks }: { callbacks?: ConnectCallbacks }) => {
         dataCallbackRef.current = callbacks?.onData ?? null
-        return 'remote:web-env-1@@pty-command-finished'
+        return 'remote:env-1@@pty-command-finished'
       }
     )
     transportFactoryQueue.push(transport)
@@ -2662,12 +2684,15 @@ describe('connectPanePty', () => {
 
   it('seeds a working status for Command Code startup prompts after spawn', async () => {
     const { connectPanePty } = await import('./pty-connection')
-    const transport = createMockTransport('pty-command-code')
+    const sshPtyId = toAppSshPtyId('ssh-a', 'pty-command-code')
+    const transport = createMockTransport(sshPtyId)
+    transport.getConnectionId.mockReturnValue('ssh-a')
     transportFactoryQueue.push(transport)
     mockStoreState = {
       ...mockStoreState,
       tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
-      repos: [{ id: 'repo1', connectionId: null }]
+      repos: [{ id: 'repo1', connectionId: 'ssh-a' }],
+      sshConnectionStates: new Map([['ssh-a', { status: 'connected' }]])
     }
 
     const pane = createPane(1)
@@ -2685,7 +2710,7 @@ describe('connectPanePty', () => {
       | ((ptyId: string) => void)
       | undefined
     expect(onPtySpawn).toBeTypeOf('function')
-    onPtySpawn?.('pty-command-code')
+    onPtySpawn?.(sshPtyId)
 
     expect(mockStoreState.setAgentStatus).toHaveBeenCalledWith(
       makePaneKey('tab-1', LEAF_1),
@@ -2694,19 +2719,25 @@ describe('connectPanePty', () => {
         prompt: 'Fix the status',
         agentType: 'command-code'
       },
-      undefined
+      undefined,
+      undefined,
+      { connectionId: 'ssh-a' }
     )
   })
 
   it('seeds a working status from Command Code thinking output without a startup prompt', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
-    const transport = createMockTransport()
+    const sshPtyId = toAppSshPtyId('ssh-a', 'pty-command-code')
+    const transport = createMockTransport(sshPtyId)
+    transport.getConnectionId.mockReturnValue('ssh-a')
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
       capturedDataCallback.current = callbacks.onData ?? null
-      return 'pty-command-code'
+      return sshPtyId
     })
     transportFactoryQueue.push(transport)
+    mockStoreState.repos = [{ id: 'repo1', connectionId: 'ssh-a' }]
+    mockStoreState.sshConnectionStates = new Map([['ssh-a', { status: 'connected' }]])
 
     const pane = createPane(1)
     const manager = createManager(1)
@@ -2730,15 +2761,47 @@ describe('connectPanePty', () => {
         prompt: 'Fix the spinner',
         agentType: 'command-code'
       },
-      undefined
+      undefined,
+      undefined,
+      { connectionId: 'ssh-a' }
     )
+  })
+
+  it('ignores delayed Command Code output after the leaf rebinds to another SSH host', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    const oldPtyId = toAppSshPtyId('ssh-a', 'pty-command-code')
+    const newPtyId = toAppSshPtyId('ssh-b', 'pty-command-code')
+    const transport = createMockTransport(oldPtyId)
+    transport.getConnectionId.mockReturnValue('ssh-a')
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return oldPtyId
+    })
+    transportFactoryQueue.push(transport)
+    mockStoreState.repos = [{ id: 'repo1', connectionId: 'ssh-a' }]
+    mockStoreState.sshConnectionStates = new Map([['ssh-a', { status: 'connected' }]])
+
+    connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps({ startup: { command: 'command-code --trust' } }) as never
+    )
+    await flushAsyncTicks()
+    mockStoreState.setAgentStatus.mockClear()
+    mockStoreState.ptyIdsByTabId = { 'tab-1': [oldPtyId, newPtyId] }
+    mockStoreState.terminalLayoutsByTabId!['tab-1'].ptyIdsByLeafId = { [LEAF_1]: newPtyId }
+
+    capturedDataCallback.current?.('❯ stale prompt\r\n\x1b[35m✻ Thinking...\x1b[0m')
+
+    expect(mockStoreState.setAgentStatus).not.toHaveBeenCalled()
   })
 
   it('marks a Command Code no-tool turn done after the idle prompt settles', async () => {
     vi.useFakeTimers()
     const { connectPanePty } = await import('./pty-connection')
     const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
-    const transport = createMockTransport()
+    const transport = createMockTransport('pty-command-code')
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
       capturedDataCallback.current = callbacks.onData ?? null
       return 'pty-command-code'
@@ -2788,7 +2851,7 @@ describe('connectPanePty', () => {
     vi.useFakeTimers()
     const { connectPanePty } = await import('./pty-connection')
     const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
-    const transport = createMockTransport()
+    const transport = createMockTransport('pty-command-code')
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
       capturedDataCallback.current = callbacks.onData ?? null
       return 'pty-command-code'
@@ -2825,7 +2888,7 @@ describe('connectPanePty', () => {
   it('does not downgrade a completed Command Code turn back to working from stale TUI output', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
-    const transport = createMockTransport()
+    const transport = createMockTransport('pty-command-code')
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
       capturedDataCallback.current = callbacks.onData ?? null
       return 'pty-command-code'
@@ -2866,7 +2929,7 @@ describe('connectPanePty', () => {
   it('starts a new Command Code turn after done when TUI output carries a different prompt', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
-    const transport = createMockTransport()
+    const transport = createMockTransport('pty-command-code')
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
       capturedDataCallback.current = callbacks.onData ?? null
       return 'pty-command-code'
@@ -2905,7 +2968,9 @@ describe('connectPanePty', () => {
         prompt: 'Fix the green done state',
         agentType: 'command-code'
       },
-      undefined
+      undefined,
+      undefined,
+      { connectionId: null }
     )
   })
 
@@ -16125,6 +16190,8 @@ describe('connectPanePty', () => {
     const transport = createMockTransport('pty-hook')
     transportFactoryQueue.push(transport)
     enableActiveRuntimeEnvironment()
+    mockStoreState.ptyIdsByTabId = { 'tab-1': ['pty-hook'] }
+    mockStoreState.terminalLayoutsByTabId!['tab-1'].ptyIdsByLeafId = { [LEAF_1]: 'pty-hook' }
 
     vi.useFakeTimers()
     const pane = createPane(1)
@@ -16383,7 +16450,9 @@ describe('connectPanePty', () => {
         prompt: 'fix the remote title',
         agentType: 'omp'
       },
-      '\u280b OMP'
+      '\u280b OMP',
+      undefined,
+      { connectionId: null }
     )
 
     mockStoreState.tabsByWorktree = {
@@ -16402,7 +16471,9 @@ describe('connectPanePty', () => {
         prompt: 'keep the remote title',
         agentType: 'omp'
       },
-      '\u280b OMP'
+      '\u280b OMP',
+      undefined,
+      { connectionId: null }
     )
   })
 
@@ -16477,6 +16548,8 @@ describe('connectPanePty', () => {
     const transport = createMockTransport('pty-hook')
     transportFactoryQueue.push(transport)
     enableActiveRuntimeEnvironment()
+    mockStoreState.ptyIdsByTabId = { 'tab-1': ['pty-hook'] }
+    mockStoreState.terminalLayoutsByTabId!['tab-1'].ptyIdsByLeafId = { [LEAF_1]: 'pty-hook' }
 
     vi.useFakeTimers()
     const pane = createPane(1)
@@ -16543,9 +16616,11 @@ describe('connectPanePty', () => {
 
   it('restores a suppressed terminal bell when a delayed hook completion resumes work', async () => {
     const { connectPanePty } = await import('./pty-connection')
-    const transport = createMockTransport('pty-hook')
+    const transport = createMockTransport('tab-pty')
     transportFactoryQueue.push(transport)
     enableActiveRuntimeEnvironment()
+    mockStoreState.ptyIdsByTabId = { 'tab-1': ['tab-pty'] }
+    mockStoreState.terminalLayoutsByTabId!['tab-1'].ptyIdsByLeafId = { [LEAF_1]: 'tab-pty' }
 
     vi.useFakeTimers()
     const pane = createPane(1)
@@ -16604,6 +16679,8 @@ describe('connectPanePty', () => {
     const transport = createMockTransport('pty-hook')
     transportFactoryQueue.push(transport)
     enableActiveRuntimeEnvironment()
+    mockStoreState.ptyIdsByTabId = { 'tab-1': ['pty-hook'] }
+    mockStoreState.terminalLayoutsByTabId!['tab-1'].ptyIdsByLeafId = { [LEAF_1]: 'pty-hook' }
 
     vi.useFakeTimers()
     const pane = createPane(1)
@@ -17490,6 +17567,8 @@ describe('connectPanePty', () => {
     const transport = createMockTransport('pty-hook')
     transportFactoryQueue.push(transport)
     enableActiveRuntimeEnvironment()
+    mockStoreState.ptyIdsByTabId = { 'tab-1': ['pty-hook'] }
+    mockStoreState.terminalLayoutsByTabId!['tab-1'].ptyIdsByLeafId = { [LEAF_1]: 'pty-hook' }
     vi.useFakeTimers()
     mockStoreState.settings = {
       ...mockStoreState.settings,

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -5,6 +5,11 @@ import type { IBuffer, IDisposable } from '@xterm/xterm'
 import { resolveCursorAgentImeAnchor } from '@/lib/pane-manager/terminal-ime-anchor'
 import { detectAgentStatusFromTitle, agentTypeToIconAgent, isClaudeAgent } from '@/lib/agent-status'
 import { resolvePaneTitleDecision } from './terminal-title-evidence'
+import {
+  isAgentStatusPanePtyBindingCurrent,
+  isAgentStatusPtyLiveForPane,
+  resolveAgentStatusConnectionRouting
+} from '@/lib/agent-status-connection-ownership'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { useAppStore } from '@/store'
 import { getWorktreeMapFromState } from '@/store/selectors'
@@ -2565,6 +2570,26 @@ export function connectPanePty(
   let hasConsideredInitialCacheTimerSeed = false
   let allowInitialIdleCacheSeed = false
 
+  const resolveCurrentAgentStatusRouting = () => {
+    const ptyId = activePanePtyBinding ?? transport.getPtyId()
+    const state = useAppStore.getState()
+    // Why: durable pane bindings survive SSH disconnect; the live PTY index
+    // prevents a queued renderer callback from recreating a cleared row.
+    if (
+      disposed ||
+      !ptyId ||
+      !isAgentStatusPtyLiveForPane(state.ptyIdsByTabId, cacheKey, ptyId) ||
+      !isAgentStatusPanePtyBindingCurrent(state.terminalLayoutsByTabId, cacheKey, ptyId)
+    ) {
+      return undefined
+    }
+    return resolveAgentStatusConnectionRouting({
+      ptyId,
+      expectedConnectionId: worktreeConnectionId,
+      runtimeEnvironmentId: transport.getRuntimeEnvironmentId?.() ?? runtimeEnvironmentId
+    })
+  }
+
   const onTitleChange = (
     title: string,
     rawTitle: string,
@@ -2631,7 +2656,8 @@ export function connectPanePty(
 
   const applyInitialAgentStatus = (terminalTitle?: string): void => {
     const initialStatus = paneStartup?.initialAgentStatus
-    if (!initialStatus) {
+    const routing = resolveCurrentAgentStatusRouting()
+    if (!initialStatus || !routing) {
       return
     }
     const statusPayload = {
@@ -2645,17 +2671,23 @@ export function connectPanePty(
     if (paneStartup.launchConfig) {
       useAppStore
         .getState()
-        .setAgentStatus(cacheKey, statusPayload, terminalTitle, undefined, undefined, {
+        .setAgentStatus(cacheKey, statusPayload, terminalTitle, undefined, routing, {
           launchConfig: paneStartup.launchConfig,
           ...(launchToken ? { launchToken } : {})
         })
       return
     }
-    useAppStore.getState().setAgentStatus(cacheKey, statusPayload, terminalTitle)
+    useAppStore
+      .getState()
+      .setAgentStatus(cacheKey, statusPayload, terminalTitle, undefined, routing)
   }
 
   const seedCommandCodeOutputWorkingStatus = (prompt: string): void => {
     clearCommandCodeOutputDoneTimer()
+    const routing = resolveCurrentAgentStatusRouting()
+    if (!routing) {
+      return
+    }
     const currentState = useAppStore.getState()
     const currentEntry = currentState.agentStatusByPaneKey[cacheKey]
     const currentTitle = currentState.runtimePaneTitlesByTabId?.[deps.tabId]?.[pane.id]
@@ -2674,7 +2706,9 @@ export function connectPanePty(
         prompt: normalizedPrompt || (currentEntry?.state === 'working' ? currentEntry.prompt : ''),
         agentType: 'command-code'
       },
-      currentTitle
+      currentTitle,
+      undefined,
+      routing
     )
   }
 
@@ -2699,6 +2733,10 @@ export function connectPanePty(
         return
       }
       const currentState = useAppStore.getState()
+      const routing = resolveCurrentAgentStatusRouting()
+      if (!routing) {
+        return
+      }
       const currentEntry = currentState.agentStatusByPaneKey[cacheKey]
       if (currentEntry?.agentType !== 'command-code' || currentEntry.state !== 'working') {
         return
@@ -2715,7 +2753,9 @@ export function connectPanePty(
           prompt: currentPrompt || normalizedPrompt,
           agentType: 'command-code'
         },
-        currentTitle
+        currentTitle,
+        undefined,
+        routing
       )
     }, COMMAND_CODE_OUTPUT_DONE_SETTLE_MS)
   }
@@ -3136,7 +3176,8 @@ export function connectPanePty(
   // Why: folder workspaces can inherit their SSH target from child repos, so
   // use the shared resolver instead of only looking up repo-backed worktrees.
   const worktree = getWorktreeMapFromState(state).get(deps.worktreeId)
-  const connectionId = getConnectionId(deps.worktreeId) ?? null
+  const worktreeConnectionId = getConnectionId(deps.worktreeId)
+  const connectionId = worktreeConnectionId ?? null
   const tab = (state.tabsByWorktree[deps.worktreeId] ?? []).find((t) => t.id === deps.tabId)
   const shellOverride = tab?.shellOverride
   // Why: a serve/remote-runtime pane has no SSH connectionId and a Linux cwd, so
@@ -3350,6 +3391,10 @@ export function connectPanePty(
             // shift (OSC title update landing in between) and the status would
             // be stored against a title that was never paired with it.
             const currentState = useAppStore.getState()
+            const routing = resolveCurrentAgentStatusRouting()
+            if (!routing) {
+              return
+            }
             const title = currentState.runtimePaneTitlesByTabId?.[deps.tabId]?.[pane.id]
             const authoritativePaneAgent = getAuthoritativePaneAgent()
             const agentType = resolveCompatibleAgentTypeForOwner(
@@ -3371,13 +3416,13 @@ export function connectPanePty(
                 statusPayload,
                 statusTitle,
                 undefined,
-                undefined,
+                routing,
                 {
                   launchToken
                 }
               )
             } else {
-              currentState.setAgentStatus(cacheKey, statusPayload, statusTitle)
+              currentState.setAgentStatus(cacheKey, statusPayload, statusTitle, undefined, routing)
             }
             const trackingEnabled = syncAgentTaskCompleteTrackingEnabled()
             if (payload.state === 'working' && trackingEnabled) {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -5,11 +5,7 @@ import type { IBuffer, IDisposable } from '@xterm/xterm'
 import { resolveCursorAgentImeAnchor } from '@/lib/pane-manager/terminal-ime-anchor'
 import { detectAgentStatusFromTitle, agentTypeToIconAgent, isClaudeAgent } from '@/lib/agent-status'
 import { resolvePaneTitleDecision } from './terminal-title-evidence'
-import {
-  isAgentStatusPanePtyBindingCurrent,
-  isAgentStatusPtyLiveForPane,
-  resolveAgentStatusConnectionRouting
-} from '@/lib/agent-status-connection-ownership'
+import { resolveLiveAgentStatusConnectionRouting } from '@/lib/agent-status-connection-ownership'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { useAppStore } from '@/store'
 import { getWorktreeMapFromState } from '@/store/selectors'
@@ -2573,17 +2569,12 @@ export function connectPanePty(
   const resolveCurrentAgentStatusRouting = () => {
     const ptyId = activePanePtyBinding ?? transport.getPtyId()
     const state = useAppStore.getState()
-    // Why: durable pane bindings survive SSH disconnect; the live PTY index
-    // prevents a queued renderer callback from recreating a cleared row.
-    if (
-      disposed ||
-      !ptyId ||
-      !isAgentStatusPtyLiveForPane(state.ptyIdsByTabId, cacheKey, ptyId) ||
-      !isAgentStatusPanePtyBindingCurrent(state.terminalLayoutsByTabId, cacheKey, ptyId)
-    ) {
+    if (disposed || !ptyId) {
       return undefined
     }
-    return resolveAgentStatusConnectionRouting({
+    return resolveLiveAgentStatusConnectionRouting({
+      state,
+      paneKey: cacheKey,
       ptyId,
       expectedConnectionId: worktreeConnectionId,
       runtimeEnvironmentId: transport.getRuntimeEnvironmentId?.() ?? runtimeEnvironmentId

--- a/src/renderer/src/lib/agent-status-connection-ownership.test.ts
+++ b/src/renderer/src/lib/agent-status-connection-ownership.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import { toAppSshPtyId } from '../../../shared/ssh-pty-id'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+import {
+  isAgentStatusPanePtyBindingCurrent,
+  isAgentStatusPtyLiveForPane,
+  resolveAgentStatusConnectionRouting
+} from './agent-status-connection-ownership'
+
+const LEAF = '11111111-1111-4111-8111-111111111111'
+const PANE = makePaneKey('tab-1', LEAF)
+
+describe('agent status connection ownership', () => {
+  it('uses exact SSH PTY ownership and rejects contradictory routing', () => {
+    const ptyId = toAppSshPtyId('ssh-a', 'pty-1')
+
+    expect(resolveAgentStatusConnectionRouting({ ptyId, expectedConnectionId: 'ssh-a' })).toEqual({
+      connectionId: 'ssh-a'
+    })
+    expect(
+      resolveAgentStatusConnectionRouting({ ptyId, expectedConnectionId: 'ssh-b' })
+    ).toBeUndefined()
+    expect(
+      resolveAgentStatusConnectionRouting({ ptyId, expectedConnectionId: null })
+    ).toBeUndefined()
+    expect(resolveAgentStatusConnectionRouting({ ptyId: 'ssh:ssh-a@broken' })).toBeUndefined()
+  })
+
+  it('marks known local, WSL, and remote-runtime PTYs as non-SSH', () => {
+    expect(
+      resolveAgentStatusConnectionRouting({ ptyId: 'pty-local-1', expectedConnectionId: null })
+    ).toEqual({ connectionId: null })
+    expect(
+      resolveAgentStatusConnectionRouting({ ptyId: 'pty-wsl-1', expectedConnectionId: null })
+    ).toEqual({ connectionId: null })
+    expect(
+      resolveAgentStatusConnectionRouting({
+        ptyId: 'remote:env-a@@terminal-1',
+        expectedConnectionId: null,
+        runtimeEnvironmentId: 'env-a'
+      })
+    ).toEqual({ connectionId: null })
+  })
+
+  it('fails closed for missing, malformed, and cross-runtime ownership', () => {
+    expect(resolveAgentStatusConnectionRouting({ ptyId: null })).toBeUndefined()
+    expect(resolveAgentStatusConnectionRouting({ ptyId: 'remote:' })).toBeUndefined()
+    expect(
+      resolveAgentStatusConnectionRouting({
+        ptyId: 'remote:env-a@@terminal-1',
+        expectedConnectionId: 'ssh-a',
+        runtimeEnvironmentId: 'env-a'
+      })
+    ).toBeUndefined()
+    expect(
+      resolveAgentStatusConnectionRouting({
+        ptyId: 'remote:env-a@@terminal-1',
+        expectedConnectionId: null,
+        runtimeEnvironmentId: 'env-b'
+      })
+    ).toBeUndefined()
+  })
+
+  it('requires the exact pane-to-PTY binding', () => {
+    const layouts = {
+      'tab-1': { ptyIdsByLeafId: { [LEAF]: toAppSshPtyId('ssh-a', 'pty-1') } }
+    }
+
+    expect(
+      isAgentStatusPanePtyBindingCurrent(layouts, PANE, layouts['tab-1'].ptyIdsByLeafId[LEAF])
+    ).toBe(true)
+    expect(isAgentStatusPanePtyBindingCurrent(layouts, PANE, toAppSshPtyId('ssh-b', 'pty-1'))).toBe(
+      false
+    )
+  })
+
+  it('requires the exact PTY to remain live for the pane tab', () => {
+    const ptyId = toAppSshPtyId('ssh-a', 'pty-1')
+
+    expect(isAgentStatusPtyLiveForPane({ 'tab-1': [ptyId] }, PANE, ptyId)).toBe(true)
+    expect(isAgentStatusPtyLiveForPane({ 'tab-1': [] }, PANE, ptyId)).toBe(false)
+    expect(isAgentStatusPtyLiveForPane({ 'tab-2': [ptyId] }, PANE, ptyId)).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/agent-status-connection-ownership.test.ts
+++ b/src/renderer/src/lib/agent-status-connection-ownership.test.ts
@@ -3,9 +3,8 @@ import { describe, expect, it } from 'vitest'
 import { toAppSshPtyId } from '../../../shared/ssh-pty-id'
 import { makePaneKey } from '../../../shared/stable-pane-id'
 import {
-  isAgentStatusPanePtyBindingCurrent,
-  isAgentStatusPtyLiveForPane,
-  resolveAgentStatusConnectionRouting
+  resolveAgentStatusConnectionRouting,
+  resolveLiveAgentStatusConnectionRouting
 } from './agent-status-connection-ownership'
 
 const LEAF = '11111111-1111-4111-8111-111111111111'
@@ -62,24 +61,34 @@ describe('agent status connection ownership', () => {
     ).toBeUndefined()
   })
 
-  it('requires the exact pane-to-PTY binding', () => {
-    const layouts = {
-      'tab-1': { ptyIdsByLeafId: { [LEAF]: toAppSshPtyId('ssh-a', 'pty-1') } }
+  it('requires one exact live pane binding', () => {
+    const ptyId = toAppSshPtyId('ssh-a', 'pty-1')
+    const state = {
+      terminalLayoutsByTabId: { 'tab-1': { ptyIdsByLeafId: { [LEAF]: ptyId } } },
+      ptyIdsByTabId: { 'tab-1': [ptyId] },
+      sshConnectionStates: new Map([['ssh-a', { status: 'connected' }]]),
+      transientClearedAgentStatusConnectionIds: {}
     }
 
-    expect(
-      isAgentStatusPanePtyBindingCurrent(layouts, PANE, layouts['tab-1'].ptyIdsByLeafId[LEAF])
-    ).toBe(true)
-    expect(isAgentStatusPanePtyBindingCurrent(layouts, PANE, toAppSshPtyId('ssh-b', 'pty-1'))).toBe(
-      false
-    )
+    expect(resolveLiveAgentStatusConnectionRouting({ state, paneKey: PANE, ptyId })).toEqual({
+      connectionId: 'ssh-a'
+    })
+    state.terminalLayoutsByTabId['tab-1'].ptyIdsByLeafId[LEAF] = toAppSshPtyId('ssh-b', 'pty-1')
+    expect(resolveLiveAgentStatusConnectionRouting({ state, paneKey: PANE, ptyId })).toBeUndefined()
   })
 
-  it('requires the exact PTY to remain live for the pane tab', () => {
+  it('rejects stale SSH routing after clear and throughout transient reconnect', () => {
     const ptyId = toAppSshPtyId('ssh-a', 'pty-1')
+    const state = {
+      terminalLayoutsByTabId: { 'tab-1': { ptyIdsByLeafId: { [LEAF]: ptyId } } },
+      ptyIdsByTabId: { 'tab-1': [ptyId] },
+      sshConnectionStates: new Map([['ssh-a', { status: 'connected' }]]),
+      transientClearedAgentStatusConnectionIds: { 'ssh-a': true } as Record<string, true>
+    }
 
-    expect(isAgentStatusPtyLiveForPane({ 'tab-1': [ptyId] }, PANE, ptyId)).toBe(true)
-    expect(isAgentStatusPtyLiveForPane({ 'tab-1': [] }, PANE, ptyId)).toBe(false)
-    expect(isAgentStatusPtyLiveForPane({ 'tab-2': [ptyId] }, PANE, ptyId)).toBe(false)
+    expect(resolveLiveAgentStatusConnectionRouting({ state, paneKey: PANE, ptyId })).toBeUndefined()
+    state.transientClearedAgentStatusConnectionIds = {}
+    state.sshConnectionStates = new Map([['ssh-a', { status: 'reconnecting' }]])
+    expect(resolveLiveAgentStatusConnectionRouting({ state, paneKey: PANE, ptyId })).toBeUndefined()
   })
 })

--- a/src/renderer/src/lib/agent-status-connection-ownership.ts
+++ b/src/renderer/src/lib/agent-status-connection-ownership.ts
@@ -4,6 +4,15 @@ import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
 
 export type AgentStatusConnectionRouting = { connectionId: string | null }
 
+type AgentStatusRoutingState = {
+  terminalLayoutsByTabId:
+    | Record<string, { ptyIdsByLeafId?: Record<string, string | undefined> } | undefined>
+    | undefined
+  ptyIdsByTabId: Record<string, string[] | undefined> | undefined
+  sshConnectionStates: ReadonlyMap<string, { status: string }>
+  transientClearedAgentStatusConnectionIds: Record<string, true>
+}
+
 export function resolveAgentStatusConnectionRouting(args: {
   ptyId: string | null | undefined
   expectedConnectionId?: string | null
@@ -54,24 +63,33 @@ export function resolveAgentStatusConnectionRouting(args: {
   return { connectionId: null }
 }
 
-export function isAgentStatusPanePtyBindingCurrent(
-  terminalLayoutsByTabId:
-    | Record<string, { ptyIdsByLeafId?: Record<string, string | undefined> } | undefined>
-    | undefined,
-  paneKey: string,
+export function resolveLiveAgentStatusConnectionRouting(args: {
+  state: AgentStatusRoutingState
+  paneKey: string
   ptyId: string
-): boolean {
-  const pane = parsePaneKey(paneKey)
-  return pane
-    ? terminalLayoutsByTabId?.[pane.tabId]?.ptyIdsByLeafId?.[pane.leafId] === ptyId
-    : false
-}
-
-export function isAgentStatusPtyLiveForPane(
-  ptyIdsByTabId: Record<string, string[] | undefined> | undefined,
-  paneKey: string,
-  ptyId: string
-): boolean {
-  const pane = parsePaneKey(paneKey)
-  return pane ? Boolean(ptyIdsByTabId?.[pane.tabId]?.includes(ptyId)) : false
+  expectedConnectionId?: string | null
+  runtimeEnvironmentId?: string | null
+}): AgentStatusConnectionRouting | undefined {
+  const pane = parsePaneKey(args.paneKey)
+  if (
+    !pane ||
+    !args.state.ptyIdsByTabId?.[pane.tabId]?.includes(args.ptyId) ||
+    args.state.terminalLayoutsByTabId?.[pane.tabId]?.ptyIdsByLeafId?.[pane.leafId] !== args.ptyId
+  ) {
+    return undefined
+  }
+  const routing = resolveAgentStatusConnectionRouting(args)
+  if (!routing) {
+    return undefined
+  }
+  // Why: transient relay reconnect clears statuses without dropping durable
+  // PTY bindings; old renderer callbacks must stay blocked until reconnect.
+  if (
+    routing.connectionId !== null &&
+    (args.state.sshConnectionStates.get(routing.connectionId)?.status !== 'connected' ||
+      routing.connectionId in args.state.transientClearedAgentStatusConnectionIds)
+  ) {
+    return undefined
+  }
+  return routing
 }

--- a/src/renderer/src/lib/agent-status-connection-ownership.ts
+++ b/src/renderer/src/lib/agent-status-connection-ownership.ts
@@ -1,0 +1,77 @@
+import { parseAppSshPtyId } from '../../../shared/ssh-pty-id'
+import { parsePaneKey } from '../../../shared/stable-pane-id'
+import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
+
+export type AgentStatusConnectionRouting = { connectionId: string | null }
+
+export function resolveAgentStatusConnectionRouting(args: {
+  ptyId: string | null | undefined
+  expectedConnectionId?: string | null
+  runtimeEnvironmentId?: string | null
+}): AgentStatusConnectionRouting | undefined {
+  const ptyId = args.ptyId?.trim()
+  if (!ptyId) {
+    return undefined
+  }
+  const expectedConnectionId = args.expectedConnectionId?.trim() || args.expectedConnectionId
+  const sshPty = parseAppSshPtyId(ptyId)
+  if (sshPty) {
+    if (
+      typeof args.runtimeEnvironmentId === 'string' ||
+      expectedConnectionId === null ||
+      (typeof expectedConnectionId === 'string' && expectedConnectionId !== sshPty.connectionId)
+    ) {
+      return undefined
+    }
+    return { connectionId: sshPty.connectionId }
+  }
+  if (ptyId.startsWith('ssh:')) {
+    return undefined
+  }
+
+  const runtimePty = parseRemoteRuntimePtyId(ptyId)
+  if (runtimePty?.handle) {
+    if (
+      typeof expectedConnectionId === 'string' ||
+      args.runtimeEnvironmentId === null ||
+      (typeof args.runtimeEnvironmentId === 'string' &&
+        runtimePty.environmentId !== null &&
+        runtimePty.environmentId !== args.runtimeEnvironmentId)
+    ) {
+      return undefined
+    }
+    return { connectionId: null }
+  }
+  if (ptyId.startsWith('remote:')) {
+    return undefined
+  }
+
+  // Why: app-wide SSH and remote-runtime PTY IDs are namespaced; a remaining
+  // concrete PTY is authoritative local/WSL ownership, never an SSH guess.
+  if (typeof expectedConnectionId === 'string') {
+    return undefined
+  }
+  return { connectionId: null }
+}
+
+export function isAgentStatusPanePtyBindingCurrent(
+  terminalLayoutsByTabId:
+    | Record<string, { ptyIdsByLeafId?: Record<string, string | undefined> } | undefined>
+    | undefined,
+  paneKey: string,
+  ptyId: string
+): boolean {
+  const pane = parsePaneKey(paneKey)
+  return pane
+    ? terminalLayoutsByTabId?.[pane.tabId]?.ptyIdsByLeafId?.[pane.leafId] === ptyId
+    : false
+}
+
+export function isAgentStatusPtyLiveForPane(
+  ptyIdsByTabId: Record<string, string[] | undefined> | undefined,
+  paneKey: string,
+  ptyId: string
+): boolean {
+  const pane = parsePaneKey(paneKey)
+  return pane ? Boolean(ptyIdsByTabId?.[pane.tabId]?.includes(ptyId)) : false
+}

--- a/src/renderer/src/lib/automation-session-observer.test.ts
+++ b/src/renderer/src/lib/automation-session-observer.test.ts
@@ -16,6 +16,8 @@ const state = {
     { ptyIdsByLeafId?: Record<string, string | undefined> }
   >,
   ptyIdsByTabId: {} as Record<string, string[]>,
+  sshConnectionStates: new Map<string, { status: string }>(),
+  transientClearedAgentStatusConnectionIds: {} as Record<string, true>,
   setAgentStatus: vi.fn()
 }
 
@@ -55,6 +57,8 @@ describe('observeExistingAutomationSession', () => {
     }
     state.terminalLayoutsByTabId = {}
     state.ptyIdsByTabId = {}
+    state.sshConnectionStates = new Map()
+    state.transientClearedAgentStatusConnectionIds = {}
     mockSubscribeToPtyData.mockReturnValue(vi.fn())
     mockSubscribeToPtyExit.mockReturnValue(vi.fn())
     mockCallRuntimeRpc.mockReturnValue(new Promise(() => {}))
@@ -152,6 +156,7 @@ describe('observeExistingAutomationSession', () => {
   it('stamps the exact SSH PTY in the legacy renderer fallback', async () => {
     state.settings.terminalMainSideEffectAuthority = false
     const ptyId = toAppSshPtyId('ssh-a', 'pty-1')
+    state.sshConnectionStates = new Map([['ssh-a', { status: 'connected' }]])
     state.terminalLayoutsByTabId = {
       'tab-1': { ptyIdsByLeafId: { [LEAF_ID]: ptyId } }
     }

--- a/src/renderer/src/lib/automation-session-observer.test.ts
+++ b/src/renderer/src/lib/automation-session-observer.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toAppSshPtyId } from '../../../shared/ssh-pty-id'
 
 const mockSubscribeToPtyData = vi.fn()
 const mockSubscribeToPtyExit = vi.fn()
@@ -10,6 +11,11 @@ const state = {
     activeRuntimeEnvironmentId: null as string | null,
     terminalMainSideEffectAuthority: undefined as boolean | undefined
   },
+  terminalLayoutsByTabId: {} as Record<
+    string,
+    { ptyIdsByLeafId?: Record<string, string | undefined> }
+  >,
+  ptyIdsByTabId: {} as Record<string, string[]>,
   setAgentStatus: vi.fn()
 }
 
@@ -37,6 +43,8 @@ vi.mock('@/runtime/remote-runtime-terminal-multiplexer', () => ({
 }))
 
 const DONE_STATUS_OSC = '\x1b]9999;{"state":"done","prompt":"ok","agentType":"codex"}\x07'
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const PANE_KEY = `tab-1:${LEAF_ID}`
 
 describe('observeExistingAutomationSession', () => {
   beforeEach(() => {
@@ -45,6 +53,8 @@ describe('observeExistingAutomationSession', () => {
       activeRuntimeEnvironmentId: null,
       terminalMainSideEffectAuthority: undefined
     }
+    state.terminalLayoutsByTabId = {}
+    state.ptyIdsByTabId = {}
     mockSubscribeToPtyData.mockReturnValue(vi.fn())
     mockSubscribeToPtyExit.mockReturnValue(vi.fn())
     mockCallRuntimeRpc.mockReturnValue(new Promise(() => {}))
@@ -59,7 +69,7 @@ describe('observeExistingAutomationSession', () => {
 
     await observeExistingAutomationSession({
       ptyId: 'pty-local-1',
-      paneKey: 'tab-1:leaf-1',
+      paneKey: PANE_KEY,
       runId: 'run-1',
       onData: vi.fn(),
       onAgentStatus,
@@ -77,12 +87,16 @@ describe('observeExistingAutomationSession', () => {
 
   it('keeps the legacy OSC store write when the kill switch is off', async () => {
     state.settings.terminalMainSideEffectAuthority = false
+    state.terminalLayoutsByTabId = {
+      'tab-1': { ptyIdsByLeafId: { [LEAF_ID]: 'pty-local-1' } }
+    }
+    state.ptyIdsByTabId = { 'tab-1': ['pty-local-1'] }
     const onAgentStatus = vi.fn()
     const { observeExistingAutomationSession } = await import('./automation-session-observer')
 
     await observeExistingAutomationSession({
       ptyId: 'pty-local-1',
-      paneKey: 'tab-1:leaf-1',
+      paneKey: PANE_KEY,
       runId: 'run-1',
       onData: vi.fn(),
       onAgentStatus,
@@ -93,20 +107,26 @@ describe('observeExistingAutomationSession', () => {
     handleData(DONE_STATUS_OSC)
 
     expect(state.setAgentStatus).toHaveBeenCalledWith(
-      'tab-1:leaf-1',
+      PANE_KEY,
       expect.objectContaining({ state: 'done', prompt: 'ok', agentType: 'codex' }),
-      undefined
+      undefined,
+      undefined,
+      { connectionId: null }
     )
     expect(onAgentStatus).toHaveBeenCalledTimes(1)
   })
 
   it('keeps the OSC store write for remote-runtime PTYs (bytes never transit local main)', async () => {
+    state.terminalLayoutsByTabId = {
+      'tab-1': { ptyIdsByLeafId: { [LEAF_ID]: 'remote:env-1@@terminal-9' } }
+    }
+    state.ptyIdsByTabId = { 'tab-1': ['remote:env-1@@terminal-9'] }
     const onAgentStatus = vi.fn()
     const { observeExistingAutomationSession } = await import('./automation-session-observer')
 
     await observeExistingAutomationSession({
       ptyId: 'remote:env-1@@terminal-9',
-      paneKey: 'tab-1:leaf-1',
+      paneKey: PANE_KEY,
       runId: 'run-1',
       onData: vi.fn(),
       onAgentStatus,
@@ -120,10 +140,90 @@ describe('observeExistingAutomationSession', () => {
     callbacks.onData(DONE_STATUS_OSC)
 
     expect(state.setAgentStatus).toHaveBeenCalledWith(
-      'tab-1:leaf-1',
+      PANE_KEY,
       expect.objectContaining({ state: 'done', prompt: 'ok', agentType: 'codex' }),
-      undefined
+      undefined,
+      undefined,
+      { connectionId: null }
     )
     expect(onAgentStatus).toHaveBeenCalledTimes(1)
+  })
+
+  it('stamps the exact SSH PTY in the legacy renderer fallback', async () => {
+    state.settings.terminalMainSideEffectAuthority = false
+    const ptyId = toAppSshPtyId('ssh-a', 'pty-1')
+    state.terminalLayoutsByTabId = {
+      'tab-1': { ptyIdsByLeafId: { [LEAF_ID]: ptyId } }
+    }
+    state.ptyIdsByTabId = { 'tab-1': [ptyId] }
+    const { observeExistingAutomationSession } = await import('./automation-session-observer')
+
+    await observeExistingAutomationSession({
+      ptyId,
+      paneKey: PANE_KEY,
+      runId: 'run-1',
+      onData: vi.fn(),
+      onAgentStatus: vi.fn(),
+      onExit: vi.fn()
+    })
+    const handleData = mockSubscribeToPtyData.mock.calls[0]?.[1] as (data: string) => void
+    handleData(DONE_STATUS_OSC)
+
+    expect(state.setAgentStatus).toHaveBeenCalledWith(
+      PANE_KEY,
+      expect.objectContaining({ state: 'done' }),
+      undefined,
+      undefined,
+      { connectionId: 'ssh-a' }
+    )
+  })
+
+  it('leaves the row unchanged after the pane rebinds to another SSH host', async () => {
+    state.settings.terminalMainSideEffectAuthority = false
+    const oldPtyId = toAppSshPtyId('ssh-a', 'pty-1')
+    state.terminalLayoutsByTabId = {
+      'tab-1': {
+        ptyIdsByLeafId: { [LEAF_ID]: toAppSshPtyId('ssh-b', 'pty-1') }
+      }
+    }
+    state.ptyIdsByTabId = { 'tab-1': [toAppSshPtyId('ssh-b', 'pty-1')] }
+    const { observeExistingAutomationSession } = await import('./automation-session-observer')
+
+    await observeExistingAutomationSession({
+      ptyId: oldPtyId,
+      paneKey: PANE_KEY,
+      runId: 'run-1',
+      onData: vi.fn(),
+      onAgentStatus: vi.fn(),
+      onExit: vi.fn()
+    })
+    const handleData = mockSubscribeToPtyData.mock.calls[0]?.[1] as (data: string) => void
+    handleData(DONE_STATUS_OSC)
+
+    expect(state.setAgentStatus).not.toHaveBeenCalled()
+  })
+
+  it('ignores a delayed callback after disconnect clears the live PTY index', async () => {
+    state.settings.terminalMainSideEffectAuthority = false
+    const ptyId = toAppSshPtyId('ssh-a', 'pty-1')
+    state.terminalLayoutsByTabId = {
+      'tab-1': { ptyIdsByLeafId: { [LEAF_ID]: ptyId } }
+    }
+    state.ptyIdsByTabId = { 'tab-1': [ptyId] }
+    const { observeExistingAutomationSession } = await import('./automation-session-observer')
+
+    await observeExistingAutomationSession({
+      ptyId,
+      paneKey: PANE_KEY,
+      runId: 'run-1',
+      onData: vi.fn(),
+      onAgentStatus: vi.fn(),
+      onExit: vi.fn()
+    })
+    const handleData = mockSubscribeToPtyData.mock.calls[0]?.[1] as (data: string) => void
+    state.ptyIdsByTabId = { 'tab-1': [] }
+    handleData(DONE_STATUS_OSC)
+
+    expect(state.setAgentStatus).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/lib/automation-session-observer.ts
+++ b/src/renderer/src/lib/automation-session-observer.ts
@@ -11,6 +11,11 @@ import { useAppStore } from '@/store'
 import { createAgentStatusOscProcessor } from '../../../shared/agent-status-osc'
 import type { ParsedAgentStatusPayload } from '../../../shared/agent-status-types'
 import { isMainTerminalSideEffectAuthorityForPty } from '@/components/terminal-pane/terminal-side-effect-facts-handler'
+import {
+  isAgentStatusPanePtyBindingCurrent,
+  isAgentStatusPtyLiveForPane,
+  resolveAgentStatusConnectionRouting
+} from '@/lib/agent-status-connection-ownership'
 
 export async function observeExistingAutomationSession(args: {
   ptyId: string
@@ -38,7 +43,17 @@ export async function observeExistingAutomationSession(args: {
     const processed = processAgentStatus(data)
     for (const payload of processed.payloads) {
       if (!mainOwnsAgentStatusWrites) {
-        useAppStore.getState().setAgentStatus(paneKey, payload, undefined)
+        const state = useAppStore.getState()
+        const routing = resolveAgentStatusConnectionRouting({ ptyId })
+        // Why: a delayed reuse observer must not write into a pane that has
+        // since rebound to another host's colliding tab/pane identifiers.
+        if (
+          routing &&
+          isAgentStatusPanePtyBindingCurrent(state.terminalLayoutsByTabId, paneKey, ptyId) &&
+          isAgentStatusPtyLiveForPane(state.ptyIdsByTabId, paneKey, ptyId)
+        ) {
+          state.setAgentStatus(paneKey, payload, undefined, undefined, routing)
+        }
       }
       args.onAgentStatus(payload)
     }

--- a/src/renderer/src/lib/automation-session-observer.ts
+++ b/src/renderer/src/lib/automation-session-observer.ts
@@ -11,11 +11,7 @@ import { useAppStore } from '@/store'
 import { createAgentStatusOscProcessor } from '../../../shared/agent-status-osc'
 import type { ParsedAgentStatusPayload } from '../../../shared/agent-status-types'
 import { isMainTerminalSideEffectAuthorityForPty } from '@/components/terminal-pane/terminal-side-effect-facts-handler'
-import {
-  isAgentStatusPanePtyBindingCurrent,
-  isAgentStatusPtyLiveForPane,
-  resolveAgentStatusConnectionRouting
-} from '@/lib/agent-status-connection-ownership'
+import { resolveLiveAgentStatusConnectionRouting } from '@/lib/agent-status-connection-ownership'
 
 export async function observeExistingAutomationSession(args: {
   ptyId: string
@@ -44,14 +40,10 @@ export async function observeExistingAutomationSession(args: {
     for (const payload of processed.payloads) {
       if (!mainOwnsAgentStatusWrites) {
         const state = useAppStore.getState()
-        const routing = resolveAgentStatusConnectionRouting({ ptyId })
+        const routing = resolveLiveAgentStatusConnectionRouting({ state, paneKey, ptyId })
         // Why: a delayed reuse observer must not write into a pane that has
         // since rebound to another host's colliding tab/pane identifiers.
-        if (
-          routing &&
-          isAgentStatusPanePtyBindingCurrent(state.terminalLayoutsByTabId, paneKey, ptyId) &&
-          isAgentStatusPtyLiveForPane(state.ptyIdsByTabId, paneKey, ptyId)
-        ) {
+        if (routing) {
           state.setAgentStatus(paneKey, payload, undefined, undefined, routing)
         }
       }

--- a/src/renderer/src/lib/background-agent-status-consumer.ts
+++ b/src/renderer/src/lib/background-agent-status-consumer.ts
@@ -2,9 +2,7 @@ import { useAppStore } from '@/store'
 import { createAgentStatusOscProcessor } from '../../../shared/agent-status-osc'
 import type { ParsedAgentStatusPayload } from '../../../shared/agent-status-types'
 import {
-  isAgentStatusPanePtyBindingCurrent,
-  isAgentStatusPtyLiveForPane,
-  resolveAgentStatusConnectionRouting,
+  resolveLiveAgentStatusConnectionRouting,
   type AgentStatusConnectionRouting
 } from './agent-status-connection-ownership'
 
@@ -24,16 +22,13 @@ export function createBackgroundAgentStatusConsumer(args: {
   const resolveRouting = (): AgentStatusConnectionRouting | undefined => {
     const ptyId = args.getPtyId()
     const state = useAppStore.getState()
-    const routing = resolveAgentStatusConnectionRouting({
+    return resolveLiveAgentStatusConnectionRouting({
+      state,
+      paneKey: args.paneKey,
       ptyId,
       expectedConnectionId: args.expectedConnectionId,
       runtimeEnvironmentId: args.runtimeEnvironmentId
     })
-    return routing &&
-      isAgentStatusPanePtyBindingCurrent(state.terminalLayoutsByTabId, args.paneKey, ptyId) &&
-      isAgentStatusPtyLiveForPane(state.ptyIdsByTabId, args.paneKey, ptyId)
-      ? routing
-      : undefined
   }
   const consume = (data: string): void => {
     const processed = processAgentStatus(data)

--- a/src/renderer/src/lib/background-agent-status-consumer.ts
+++ b/src/renderer/src/lib/background-agent-status-consumer.ts
@@ -1,0 +1,57 @@
+import { useAppStore } from '@/store'
+import { createAgentStatusOscProcessor } from '../../../shared/agent-status-osc'
+import type { ParsedAgentStatusPayload } from '../../../shared/agent-status-types'
+import {
+  isAgentStatusPanePtyBindingCurrent,
+  isAgentStatusPtyLiveForPane,
+  resolveAgentStatusConnectionRouting,
+  type AgentStatusConnectionRouting
+} from './agent-status-connection-ownership'
+
+export function createBackgroundAgentStatusConsumer(args: {
+  paneKey: string
+  launchToken: string
+  mainOwnsAgentStatusWrites: boolean
+  expectedConnectionId: string | null | undefined
+  runtimeEnvironmentId: string | null
+  getPtyId: () => string
+  onAgentStatus?: (payload: ParsedAgentStatusPayload) => void
+}): {
+  consume: (data: string) => void
+  resolveRouting: () => AgentStatusConnectionRouting | undefined
+} {
+  const processAgentStatus = createAgentStatusOscProcessor()
+  const resolveRouting = (): AgentStatusConnectionRouting | undefined => {
+    const ptyId = args.getPtyId()
+    const state = useAppStore.getState()
+    const routing = resolveAgentStatusConnectionRouting({
+      ptyId,
+      expectedConnectionId: args.expectedConnectionId,
+      runtimeEnvironmentId: args.runtimeEnvironmentId
+    })
+    return routing &&
+      isAgentStatusPanePtyBindingCurrent(state.terminalLayoutsByTabId, args.paneKey, ptyId) &&
+      isAgentStatusPtyLiveForPane(state.ptyIdsByTabId, args.paneKey, ptyId)
+      ? routing
+      : undefined
+  }
+  const consume = (data: string): void => {
+    const processed = processAgentStatus(data)
+    for (const payload of processed.payloads) {
+      if (!args.mainOwnsAgentStatusWrites) {
+        const routing = resolveRouting()
+        // Why: hidden callbacks can outlive tab reuse; only the exact current
+        // pane-to-PTY binding may update its status ownership.
+        if (routing) {
+          useAppStore
+            .getState()
+            .setAgentStatus(args.paneKey, payload, undefined, undefined, routing, {
+              launchToken: args.launchToken
+            })
+        }
+      }
+      args.onAgentStatus?.(payload)
+    }
+  }
+  return { consume, resolveRouting }
+}

--- a/src/renderer/src/lib/command-code-prompt-status-seed.ts
+++ b/src/renderer/src/lib/command-code-prompt-status-seed.ts
@@ -1,23 +1,46 @@
 import { useAppStore } from '@/store'
 import { makePaneKey } from '../../../shared/stable-pane-id'
+import { getConnectionIdFromState } from './connection-owner-resolution'
+import {
+  isAgentStatusPtyLiveForPane,
+  resolveAgentStatusConnectionRouting
+} from './agent-status-connection-ownership'
 
 /**
  * Why: Command Code has no prompt-submit hook, so when Orca submits a generated
  * prompt after the TUI is ready, seed `working` at delivery time so sidebar and
  * activity surfaces don't stay idle until the first real hook event arrives.
  */
-export function seedCommandCodeSubmittedPromptStatus(tabId: string, prompt: string): void {
+export function seedCommandCodeSubmittedPromptStatus(
+  worktreeId: string,
+  tabId: string,
+  prompt: string
+): void {
   const state = useAppStore.getState()
   const leafId = state.terminalLayoutsByTabId[tabId]?.activeLeafId
-  if (!leafId) {
+  if (!leafId || !(state.tabsByWorktree[worktreeId] ?? []).some((tab) => tab.id === tabId)) {
+    return
+  }
+  const paneKey = makePaneKey(tabId, leafId)
+  const ptyId = state.terminalLayoutsByTabId[tabId]?.ptyIdsByLeafId?.[leafId]
+  if (!ptyId || !isAgentStatusPtyLiveForPane(state.ptyIdsByTabId, paneKey, ptyId)) {
+    return
+  }
+  const routing = resolveAgentStatusConnectionRouting({
+    ptyId,
+    expectedConnectionId: getConnectionIdFromState(state, worktreeId)
+  })
+  if (!routing) {
     return
   }
   try {
-    state.setAgentStatus(makePaneKey(tabId, leafId), {
-      state: 'working',
-      prompt,
-      agentType: 'command-code'
-    })
+    state.setAgentStatus(
+      paneKey,
+      { state: 'working', prompt, agentType: 'command-code' },
+      undefined,
+      undefined,
+      routing
+    )
   } catch {
     // Best-effort UI seed. Real hooks still own refinement/completion.
   }

--- a/src/renderer/src/lib/command-code-prompt-status-seed.ts
+++ b/src/renderer/src/lib/command-code-prompt-status-seed.ts
@@ -1,10 +1,7 @@
 import { useAppStore } from '@/store'
 import { makePaneKey } from '../../../shared/stable-pane-id'
 import { getConnectionIdFromState } from './connection-owner-resolution'
-import {
-  isAgentStatusPtyLiveForPane,
-  resolveAgentStatusConnectionRouting
-} from './agent-status-connection-ownership'
+import { resolveLiveAgentStatusConnectionRouting } from './agent-status-connection-ownership'
 
 /**
  * Why: Command Code has no prompt-submit hook, so when Orca submits a generated
@@ -23,10 +20,12 @@ export function seedCommandCodeSubmittedPromptStatus(
   }
   const paneKey = makePaneKey(tabId, leafId)
   const ptyId = state.terminalLayoutsByTabId[tabId]?.ptyIdsByLeafId?.[leafId]
-  if (!ptyId || !isAgentStatusPtyLiveForPane(state.ptyIdsByTabId, paneKey, ptyId)) {
+  if (!ptyId) {
     return
   }
-  const routing = resolveAgentStatusConnectionRouting({
+  const routing = resolveLiveAgentStatusConnectionRouting({
+    state,
+    paneKey,
     ptyId,
     expectedConnectionId: getConnectionIdFromState(state, worktreeId)
   })

--- a/src/renderer/src/lib/launch-agent-background-session.test.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.test.ts
@@ -3,6 +3,7 @@ import { BACKGROUND_MOUNT_TERMINAL_WORKTREE_EVENT } from '@/constants/terminal'
 import { createCompatibleRuntimeStatusResponseIfNeeded } from '@/runtime/runtime-compatibility-test-fixture'
 import { clearRuntimeCompatibilityCacheForTests } from '@/runtime/runtime-rpc-client'
 import { resetRemoteRuntimeTerminalMultiplexersForTests } from '@/runtime/remote-runtime-terminal-multiplexer'
+import { toAppSshPtyId } from '../../../shared/ssh-pty-id'
 
 const mockSpawn = vi.fn()
 const mockKill = vi.fn()
@@ -69,6 +70,11 @@ const state = {
     ]
   },
   tabsByWorktree: { 'wt-1': [] as { id: string; title: string }[] },
+  terminalLayoutsByTabId: {} as Record<
+    string,
+    { ptyIdsByLeafId?: Record<string, string | undefined> }
+  >,
+  ptyIdsByTabId: {} as Record<string, string[]>,
   allWorktrees: vi.fn(() => state.worktreesByRepo['repo-1']),
   createTab: mockCreateTab,
   setTabCustomTitle: mockSetTabCustomTitle,
@@ -145,6 +151,8 @@ describe('launchAgentBackgroundSession', () => {
       ]
     }
     state.tabsByWorktree = { 'wt-1': [] }
+    state.terminalLayoutsByTabId = {}
+    state.ptyIdsByTabId = {}
     mockCreateTab.mockImplementation(() => {
       const tab = { id: 'tab-1', title: 'Terminal 1' }
       state.tabsByWorktree['wt-1'].push(tab)
@@ -152,6 +160,12 @@ describe('launchAgentBackgroundSession', () => {
     })
     mockCloseTab.mockImplementation((tabId: string) => {
       state.tabsByWorktree['wt-1'] = state.tabsByWorktree['wt-1'].filter((tab) => tab.id !== tabId)
+    })
+    mockSetTabLayout.mockImplementation((tabId: string, layout) => {
+      state.terminalLayoutsByTabId[tabId] = layout
+    })
+    mockUpdateTabPtyId.mockImplementation((tabId: string, ptyId: string) => {
+      state.ptyIdsByTabId[tabId] = [ptyId]
     })
     mockSpawn.mockResolvedValue({ id: 'pty-1' })
     mockRuntimeEnvironmentCall.mockResolvedValue({
@@ -440,35 +454,28 @@ describe('launchAgentBackgroundSession', () => {
     expect(mockSpawn).toHaveBeenCalled()
   })
 
-  it('parses agent status from hidden PTY output when the kill switch is off', async () => {
+  it('stamps hidden SSH status from renderer fallback when the kill switch is off', async () => {
     // Why: with main side-effect authority disabled, this sidecar is the only
-    // OSC 9999 → store path for hidden local sessions.
+    // OSC 9999 → store path for hidden SSH sessions.
     state.settings.terminalMainSideEffectAuthority = false
-    const onAgentStatus = vi.fn()
+    state.repos = [{ id: 'repo-1', connectionId: 'ssh-a', path: '/repo' }]
+    mockSpawn.mockResolvedValue({ id: toAppSshPtyId('ssh-a', 'pty-1') })
     const { launchAgentBackgroundSession } = await import('./launch-agent-background-session')
 
     await launchAgentBackgroundSession({
       agent: 'claude',
       worktreeId: 'wt-1',
-      prompt: 'run the automation',
-      onAgentStatus
+      prompt: 'run the automation'
     })
 
     const dataSidecar = mockSubscribeToPtyData.mock.calls[0]?.[1] as (data: string) => void
     dataSidecar('\x1b]9999;{"state":"done","prompt":"ok","agentType":"codex"}\x07')
 
-    const paneKey = expectStablePaneSpawn()
-    expect(state.setAgentStatus).toHaveBeenCalledWith(
-      paneKey,
-      expect.objectContaining({ state: 'done', prompt: 'ok', agentType: 'codex' }),
-      undefined,
-      undefined,
-      undefined,
-      { launchToken: expect.stringMatching(UUID_RE) }
-    )
-    expect(onAgentStatus).toHaveBeenCalledWith(
-      expect.objectContaining({ state: 'done', prompt: 'ok', agentType: 'codex' })
-    )
+    expectStablePaneSpawn()
+    expect(state.setAgentStatus.mock.calls.at(-1)?.[4]).toEqual({ connectionId: 'ssh-a' })
+    expect(state.setAgentStatus.mock.calls.at(-1)?.[5]).toEqual({
+      launchToken: expect.stringMatching(UUID_RE)
+    })
   })
 
   it('skips the duplicate OSC store write under main side-effect authority', async () => {
@@ -494,7 +501,9 @@ describe('launchAgentBackgroundSession', () => {
     )
   })
 
-  it('seeds a working status for Command Code prompt launches', async () => {
+  it('stamps a working status for SSH Command Code prompt launches', async () => {
+    state.repos = [{ id: 'repo-1', connectionId: 'ssh-a', path: '/repo' }]
+    mockSpawn.mockResolvedValue({ id: toAppSshPtyId('ssh-a', 'pty-1') })
     const { launchAgentBackgroundSession } = await import('./launch-agent-background-session')
 
     await launchAgentBackgroundSession({
@@ -503,26 +512,16 @@ describe('launchAgentBackgroundSession', () => {
       prompt: 'check the status spinner'
     })
 
-    const paneKey = expectStablePaneSpawn()
-    expect(state.setAgentStatus).toHaveBeenCalledWith(
-      paneKey,
-      {
-        state: 'working',
-        prompt: 'check the status spinner',
-        agentType: 'command-code'
+    expectStablePaneSpawn()
+    expect(state.setAgentStatus.mock.calls.at(-1)?.[4]).toEqual({ connectionId: 'ssh-a' })
+    expect(state.setAgentStatus.mock.calls.at(-1)?.[5]).toEqual({
+      launchConfig: {
+        agentCommand: "command-code --trust '--yolo'",
+        agentArgs: '--yolo',
+        agentEnv: {}
       },
-      undefined,
-      undefined,
-      undefined,
-      {
-        launchConfig: {
-          agentCommand: "command-code --trust '--yolo'",
-          agentArgs: '--yolo',
-          agentEnv: {}
-        },
-        launchToken: expect.stringMatching(UUID_RE)
-      }
-    )
+      launchToken: expect.stringMatching(UUID_RE)
+    })
   })
 
   it('uses a sidecar exit watcher so completion survives terminal attachment', async () => {

--- a/src/renderer/src/lib/launch-agent-background-session.test.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.test.ts
@@ -75,6 +75,8 @@ const state = {
     { ptyIdsByLeafId?: Record<string, string | undefined> }
   >,
   ptyIdsByTabId: {} as Record<string, string[]>,
+  sshConnectionStates: new Map<string, { status: string }>(),
+  transientClearedAgentStatusConnectionIds: {} as Record<string, true>,
   allWorktrees: vi.fn(() => state.worktreesByRepo['repo-1']),
   createTab: mockCreateTab,
   setTabCustomTitle: mockSetTabCustomTitle,
@@ -153,6 +155,8 @@ describe('launchAgentBackgroundSession', () => {
     state.tabsByWorktree = { 'wt-1': [] }
     state.terminalLayoutsByTabId = {}
     state.ptyIdsByTabId = {}
+    state.sshConnectionStates = new Map()
+    state.transientClearedAgentStatusConnectionIds = {}
     mockCreateTab.mockImplementation(() => {
       const tab = { id: 'tab-1', title: 'Terminal 1' }
       state.tabsByWorktree['wt-1'].push(tab)
@@ -459,6 +463,7 @@ describe('launchAgentBackgroundSession', () => {
     // OSC 9999 → store path for hidden SSH sessions.
     state.settings.terminalMainSideEffectAuthority = false
     state.repos = [{ id: 'repo-1', connectionId: 'ssh-a', path: '/repo' }]
+    state.sshConnectionStates = new Map([['ssh-a', { status: 'connected' }]])
     mockSpawn.mockResolvedValue({ id: toAppSshPtyId('ssh-a', 'pty-1') })
     const { launchAgentBackgroundSession } = await import('./launch-agent-background-session')
 
@@ -503,6 +508,7 @@ describe('launchAgentBackgroundSession', () => {
 
   it('stamps a working status for SSH Command Code prompt launches', async () => {
     state.repos = [{ id: 'repo-1', connectionId: 'ssh-a', path: '/repo' }]
+    state.sshConnectionStates = new Map([['ssh-a', { status: 'connected' }]])
     mockSpawn.mockResolvedValue({ id: toAppSshPtyId('ssh-a', 'pty-1') })
     const { launchAgentBackgroundSession } = await import('./launch-agent-background-session')
 

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -33,13 +33,13 @@ import {
   subscribeToRuntimeTerminalData,
   toRemoteRuntimePtyId
 } from '@/runtime/runtime-terminal-stream'
-import { createAgentStatusOscProcessor } from '../../../shared/agent-status-osc'
 import type { RuntimeTerminalCreate } from '../../../shared/runtime-types'
 import { createSshBackgroundStartupDelivery } from '@/lib/ssh-background-startup-delivery'
 import { shouldUseShellReadyStartupDelivery } from '../../../shared/codex-startup-delivery'
 import { isMainTerminalSideEffectAuthorityForPty } from '@/components/terminal-pane/terminal-side-effect-facts-handler'
 import { resolveLocalWindowsAgentStartupShell } from '../../../shared/windows-terminal-shell'
 import { runBestEffortAgentBackgroundCleanups } from '@/lib/agent-background-session-cleanup'
+import { createBackgroundAgentStatusConsumer } from '@/lib/background-agent-status-consumer'
 
 export async function launchAgentBackgroundSession(
   args: LaunchAgentBackgroundSessionArgs
@@ -172,20 +172,20 @@ export async function launchAgentBackgroundSession(
     settings: store.settings,
     runtimeEnvironmentId: runtimeTarget.kind === 'environment' ? runtimeTarget.environmentId : null
   })
-  const processAgentStatus = createAgentStatusOscProcessor()
+  const agentStatusConsumer = createBackgroundAgentStatusConsumer({
+    paneKey,
+    launchToken,
+    mainOwnsAgentStatusWrites,
+    expectedConnectionId: repo ? (repo.connectionId ?? null) : undefined,
+    runtimeEnvironmentId: runtimeTarget.kind === 'environment' ? runtimeTarget.environmentId : null,
+    getPtyId: () => ptyId,
+    onAgentStatus
+  })
   const handleData = (data: string): void => {
     data = sshStartupDelivery.handleData(data)
     onData?.(data)
     sshStartupDelivery.schedule(ptyId)
-    const processed = processAgentStatus(data)
-    for (const payload of processed.payloads) {
-      if (!mainOwnsAgentStatusWrites) {
-        useAppStore.getState().setAgentStatus(paneKey, payload, undefined, undefined, undefined, {
-          launchToken
-        })
-      }
-      onAgentStatus?.(payload)
-    }
+    agentStatusConsumer.consume(data)
   }
   try {
     if (runtimeTarget.kind === 'environment') {
@@ -263,18 +263,17 @@ export async function launchAgentBackgroundSession(
     if (agent === 'command-code' && hasPrompt && !isFollowupPath) {
       // Why: Command Code does not expose a prompt-start hook; seed working for
       // hidden prompt launches so sidebar/activity surfaces do not stay idle.
-      store.setAgentStatus(
-        paneKey,
-        {
-          state: 'working',
-          prompt: trimmedPrompt,
-          agentType: agent
-        },
-        undefined,
-        undefined,
-        undefined,
-        { launchConfig: startupPlan.launchConfig, launchToken }
-      )
+      const routing = agentStatusConsumer.resolveRouting()
+      if (routing) {
+        store.setAgentStatus(
+          paneKey,
+          { state: 'working', prompt: trimmedPrompt, agentType: agent },
+          undefined,
+          undefined,
+          routing,
+          { launchConfig: startupPlan.launchConfig, launchToken }
+        )
+      }
     }
 
     if (runtimeTarget.kind === 'environment') {

--- a/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toAppSshPtyId } from '../../../shared/ssh-pty-id'
 
 const mockCreateTab = vi.fn()
 const mockQueueTabStartupCommand = vi.fn()
@@ -61,7 +62,11 @@ const store = {
   openFiles: [] as { id: string; worktreeId: string }[],
   browserTabsByWorktree: {} as Record<string, { id: string }[]>,
   tabBarOrderByWorktree: {} as Record<string, string[]>,
-  terminalLayoutsByTabId: {} as Record<string, { activeLeafId: string | null }>,
+  terminalLayoutsByTabId: {} as Record<
+    string,
+    { activeLeafId: string | null; ptyIdsByLeafId?: Record<string, string> }
+  >,
+  ptyIdsByTabId: {} as Record<string, string[]>,
   createTab: mockCreateTab,
   closeTab: vi.fn(),
   queueTabStartupCommand: mockQueueTabStartupCommand,
@@ -148,6 +153,7 @@ describe('launchAgentInNewTab', () => {
     store.browserTabsByWorktree = {}
     store.tabBarOrderByWorktree = {}
     store.terminalLayoutsByTabId = {}
+    store.ptyIdsByTabId = {}
     mockCreateTab.mockReturnValue({ id: 'tab-1' })
     mockPasteDraftWhenAgentReady.mockResolvedValue(true)
   })
@@ -678,6 +684,7 @@ describe('launchAgentInNewTab', () => {
   })
 
   it('seeds working after Command Code submit-after-ready prompt delivery', async () => {
+    store.repos = [{ id: 'repo-1', connectionId: 'ssh-a', path: '/repo' }]
     const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
 
     const result = launchAgentInNewTab({
@@ -686,7 +693,13 @@ describe('launchAgentInNewTab', () => {
       prompt: 'large generated prompt',
       promptDelivery: 'submit-after-ready'
     })
-    store.terminalLayoutsByTabId = { 'tab-1': { activeLeafId: LEAF_ID } }
+    store.terminalLayoutsByTabId = {
+      'tab-1': {
+        activeLeafId: LEAF_ID,
+        ptyIdsByLeafId: { [LEAF_ID]: toAppSshPtyId('ssh-a', 'pty-1') }
+      }
+    }
+    store.ptyIdsByTabId = { 'tab-1': [toAppSshPtyId('ssh-a', 'pty-1')] }
     await expect(result?.promptDeliveryResult).resolves.toEqual({
       delivered: true,
       failureNotified: false
@@ -709,12 +722,50 @@ describe('launchAgentInNewTab', () => {
         forcePaste: true
       })
     )
-    expect(mockSetAgentStatus).toHaveBeenCalledWith(`tab-1:${LEAF_ID}`, {
-      state: 'working',
-      prompt: 'large generated prompt',
-      agentType: 'command-code'
-    })
+    expect(mockSetAgentStatus).toHaveBeenCalledWith(
+      `tab-1:${LEAF_ID}`,
+      {
+        state: 'working',
+        prompt: 'large generated prompt',
+        agentType: 'command-code'
+      },
+      undefined,
+      undefined,
+      { connectionId: 'ssh-a' }
+    )
     expect(mockTrack).not.toHaveBeenCalledWith('agent_prompt_sent', expect.anything())
+  })
+
+  it('does not recreate SSH status when disconnect wins a pending prompt delivery', async () => {
+    let finishDelivery: ((delivered: boolean) => void) | undefined
+    mockPasteDraftWhenAgentReady.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        finishDelivery = resolve
+      })
+    )
+    store.repos = [{ id: 'repo-1', connectionId: 'ssh-a', path: '/repo' }]
+    const ptyId = toAppSshPtyId('ssh-a', 'pty-1')
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    const result = launchAgentInNewTab({
+      agent: 'command-code',
+      worktreeId: 'wt-1',
+      prompt: 'pending prompt',
+      promptDelivery: 'submit-after-ready'
+    })
+    store.terminalLayoutsByTabId = {
+      'tab-1': { activeLeafId: LEAF_ID, ptyIdsByLeafId: { [LEAF_ID]: ptyId } }
+    }
+    store.ptyIdsByTabId = { 'tab-1': [ptyId] }
+
+    store.ptyIdsByTabId = { 'tab-1': [] }
+    finishDelivery?.(true)
+    await expect(result?.promptDeliveryResult).resolves.toEqual({
+      delivered: true,
+      failureNotified: false
+    })
+
+    expect(mockSetAgentStatus).not.toHaveBeenCalled()
   })
 
   it('does not track prompt-sent when submit-after-ready delivery fails', async () => {

--- a/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
@@ -44,6 +44,8 @@ const store = {
       | { kind: 'wsl'; distro: string | null }
   }[],
   repos: [{ id: 'repo-1', connectionId: null as string | null, path: '/repo' }],
+  sshConnectionStates: new Map([['ssh-a', { status: 'connected' }]]),
+  transientClearedAgentStatusConnectionIds: {} as Record<string, true>,
   worktreesByRepo: {
     'repo-1': [
       {
@@ -137,6 +139,8 @@ describe('launchAgentInNewTab', () => {
       }
     ]
     store.repos = [{ id: 'repo-1', connectionId: null, path: '/repo' }]
+    store.sshConnectionStates = new Map([['ssh-a', { status: 'connected' }]])
+    store.transientClearedAgentStatusConnectionIds = {}
     store.worktreesByRepo = {
       'repo-1': [
         {
@@ -736,7 +740,7 @@ describe('launchAgentInNewTab', () => {
     expect(mockTrack).not.toHaveBeenCalledWith('agent_prompt_sent', expect.anything())
   })
 
-  it('does not recreate SSH status when disconnect wins a pending prompt delivery', async () => {
+  it('does not recreate SSH status when clear arrives before disconnect state', async () => {
     let finishDelivery: ((delivered: boolean) => void) | undefined
     mockPasteDraftWhenAgentReady.mockReturnValue(
       new Promise<boolean>((resolve) => {
@@ -758,7 +762,9 @@ describe('launchAgentInNewTab', () => {
     }
     store.ptyIdsByTabId = { 'tab-1': [ptyId] }
 
-    store.ptyIdsByTabId = { 'tab-1': [] }
+    // Why: explicit disconnect sends the transient clear before its state
+    // event, while the old connection can still appear connected and bound.
+    store.transientClearedAgentStatusConnectionIds = { 'ssh-a': true }
     finishDelivery?.(true)
     await expect(result?.promptDeliveryResult).resolves.toEqual({
       delivered: true,

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -324,7 +324,7 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
         if (agent === 'command-code' && submitPastedPrompt) {
           // Why: Command Code has no prompt-submit hook; when Orca submits a
           // generated prompt after readiness, seed working at delivery time.
-          seedCommandCodeSubmittedPromptStatus(tab.id, trimmedPrompt)
+          seedCommandCodeSubmittedPromptStatus(worktreeId, tab.id, trimmedPrompt)
         }
         onPromptDelivered?.()
       }

--- a/src/renderer/src/store/slices/agent-status-ssh-connection-clear.test.ts
+++ b/src/renderer/src/store/slices/agent-status-ssh-connection-clear.test.ts
@@ -106,6 +106,29 @@ describe('agent status cleanup for a lost SSH connection', () => {
     expect(store.getState().agentStatusByPaneKey[paneKey]?.connectionId).toBe('ssh-a')
   })
 
+  it('blocks renderer callbacks at clear time until a later reconnect', () => {
+    const store = createTestStore()
+
+    store.getState().clearTransientAgentStatuses('ssh-a', 10)
+
+    expect(store.getState().transientClearedAgentStatusConnectionIds['ssh-a']).toBe(true)
+    store.getState().setSshConnectionState('ssh-a', {
+      targetId: 'ssh-a',
+      status: 'disconnected',
+      error: null,
+      reconnectAttempt: 0
+    })
+    expect(store.getState().transientClearedAgentStatusConnectionIds['ssh-a']).toBe(true)
+
+    store.getState().setSshConnectionState('ssh-a', {
+      targetId: 'ssh-a',
+      status: 'connected',
+      error: null,
+      reconnectAttempt: 0
+    })
+    expect(store.getState().transientClearedAgentStatusConnectionIds['ssh-a']).toBeUndefined()
+  })
+
   it('moves a colliding pane to newer authoritative ownership', () => {
     const store = createTestStore()
     const paneKey = 'tab-a:11111111-1111-4111-8111-111111111111'

--- a/src/renderer/src/store/slices/agent-status-ssh-connection-clear.test.ts
+++ b/src/renderer/src/store/slices/agent-status-ssh-connection-clear.test.ts
@@ -17,6 +17,7 @@ describe('agent status cleanup for a lost SSH connection', () => {
     const newerA = 'tab-new:33333333-3333-4333-8333-333333333333'
     const siblingB = 'tab-b:44444444-4444-4444-8444-444444444444'
     const unstamped = 'tab-legacy:55555555-5555-4555-8555-555555555555'
+    const local = 'tab-local:66666666-6666-4666-8666-666666666666'
     for (const [paneKey, updatedAt, connectionId] of [
       [oldA, 10, 'ssh-a'],
       [secondA, 20, 'ssh-a'],
@@ -40,6 +41,15 @@ describe('agent status cleanup for a lost SSH connection', () => {
         { state: 'working', prompt: 'legacy', agentType: 'claude' },
         undefined,
         { updatedAt: 5 }
+      )
+    store
+      .getState()
+      .setAgentStatus(
+        local,
+        { state: 'working', prompt: 'local', agentType: 'codex' },
+        undefined,
+        { updatedAt: 6 },
+        { connectionId: null }
       )
     store.setState({
       agentLaunchConfigByPaneKey: {
@@ -66,6 +76,7 @@ describe('agent status cleanup for a lost SSH connection', () => {
     expect(store.getState().agentStatusByPaneKey[newerA]).toBeDefined()
     expect(store.getState().agentStatusByPaneKey[siblingB]).toBeDefined()
     expect(store.getState().agentStatusByPaneKey[unstamped]).toBeDefined()
+    expect(store.getState().agentStatusByPaneKey[local]?.connectionId).toBeNull()
     expect(store.getState().agentLaunchConfigByPaneKey[oldA]).toBeDefined()
     expect(store.getState().acknowledgedAgentsByPaneKey[oldA]).toBe(2)
     expect(store.getState().retentionSuppressedPaneKeys[oldA]).toBe(true)
@@ -93,5 +104,35 @@ describe('agent status cleanup for a lost SSH connection', () => {
       )
 
     expect(store.getState().agentStatusByPaneKey[paneKey]?.connectionId).toBe('ssh-a')
+  })
+
+  it('moves a colliding pane to newer authoritative ownership', () => {
+    const store = createTestStore()
+    const paneKey = 'tab-a:11111111-1111-4111-8111-111111111111'
+    store
+      .getState()
+      .setAgentStatus(
+        paneKey,
+        { state: 'working', prompt: 'host a', agentType: 'codex' },
+        undefined,
+        { updatedAt: 1 },
+        { connectionId: 'ssh-a' }
+      )
+    store
+      .getState()
+      .setAgentStatus(
+        paneKey,
+        { state: 'working', prompt: 'host b', agentType: 'codex' },
+        undefined,
+        { updatedAt: 2 },
+        { connectionId: 'ssh-b' }
+      )
+
+    store.getState().clearTransientAgentStatuses('ssh-a', 3)
+
+    expect(store.getState().agentStatusByPaneKey[paneKey]).toMatchObject({
+      prompt: 'host b',
+      connectionId: 'ssh-b'
+    })
   })
 })

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -117,6 +117,9 @@ export type AgentStatusSlice = {
   migrationUnsupportedByPtyId: Record<string, MigrationUnsupportedPtyEntry>
   /** Monotonic tick that advances when agent-status freshness boundaries pass. */
   agentStatusEpoch: number
+  /** SSH connections whose transient rows were cleared and must reject renderer callbacks
+   *  until a later reconnect establishes a new connection lifecycle. */
+  transientClearedAgentStatusConnectionIds: Record<string, true>
   /** Arm the shared freshness timer after an external mirror writes live rows. */
   scheduleAgentStatusFreshness: () => void
 
@@ -1156,6 +1159,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
     runtimeAgentOrchestrationByPaneKey: {},
     migrationUnsupportedByPtyId: {},
     agentStatusEpoch: 0,
+    transientClearedAgentStatusConnectionIds: {},
     retainedAgentsByPaneKey: {},
     sleepingAgentSessionsByPaneKey: {},
     agentLaunchConfigByPaneKey: {},
@@ -2209,16 +2213,24 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           next ??= { ...s.agentStatusByPaneKey }
           delete next[paneKey]
         }
-        if (!next) {
+        const wasAlreadyBlocked = connectionId in s.transientClearedAgentStatusConnectionIds
+        if (!next && wasAlreadyBlocked) {
           return s
         }
-        removed = true
+        removed = next !== null
         // Why: transport loss is reversible. Keep launch, resume, retention,
         // and acknowledgement maps intact for same-pane relay replay.
         return {
-          agentStatusByPaneKey: next,
-          agentStatusEpoch: s.agentStatusEpoch + 1,
-          sortEpoch: s.sortEpoch + 1
+          ...(next
+            ? {
+                agentStatusByPaneKey: next,
+                agentStatusEpoch: s.agentStatusEpoch + 1,
+                sortEpoch: s.sortEpoch + 1
+              }
+            : {}),
+          transientClearedAgentStatusConnectionIds: wasAlreadyBlocked
+            ? s.transientClearedAgentStatusConnectionIds
+            : { ...s.transientClearedAgentStatusConnectionIds, [connectionId]: true }
         }
       })
       if (removed) {

--- a/src/renderer/src/store/slices/ssh-target-cleanup.ts
+++ b/src/renderer/src/store/slices/ssh-target-cleanup.ts
@@ -141,6 +141,14 @@ export function buildRemovedSshTargetCleanupPatch(
   }
 
   const nextDeferredTargets = state.deferredSshReconnectTargets.filter((id) => id !== targetId)
+  const nextTransientClearedConnections = {
+    ...state.transientClearedAgentStatusConnectionIds
+  }
+  const removedTransientClearBlock = Object.prototype.hasOwnProperty.call(
+    nextTransientClearedConnections,
+    targetId
+  )
+  delete nextTransientClearedConnections[targetId]
   const nextConnectionStates = new Map(state.sshConnectionStates)
   const removedConnectionState = nextConnectionStates.delete(targetId)
   const nextLabels = new Map(state.sshTargetLabels)
@@ -170,6 +178,7 @@ export function buildRemovedSshTargetCleanupPatch(
   const removedDeferredTarget =
     nextDeferredTargets.length !== state.deferredSshReconnectTargets.length
   const changed =
+    removedTransientClearBlock ||
     removedConnectionState ||
     removedLabel ||
     removedHydrated ||
@@ -185,6 +194,9 @@ export function buildRemovedSshTargetCleanupPatch(
   }
 
   return {
+    ...(removedTransientClearBlock
+      ? { transientClearedAgentStatusConnectionIds: nextTransientClearedConnections }
+      : {}),
     ...(removedConnectionState ? { sshConnectionStates: nextConnectionStates } : {}),
     ...(removedLabel ? { sshTargetLabels: nextLabels } : {}),
     ...(removedHydrated ? { remoteWorkspaceHydratedTargetIds: nextHydrated } : {}),

--- a/src/renderer/src/store/slices/ssh.test.ts
+++ b/src/renderer/src/store/slices/ssh.test.ts
@@ -98,6 +98,10 @@ describe('createSshSlice', () => {
         { requestId: 'req-2', targetId: otherTargetId, kind: 'password', detail: 'password' }
       ],
       deferredSshReconnectTargets: [targetId, otherTargetId],
+      transientClearedAgentStatusConnectionIds: {
+        [targetId]: true,
+        [otherTargetId]: true
+      },
       deferredSshSessionIdsByTabId: {
         'tab-ssh': 'legacy-session-without-target-prefix',
         'tab-stale-encoded': toAppSshPtyId(targetId, 'pty-1'),
@@ -116,6 +120,9 @@ describe('createSshSlice', () => {
     expect(state.detectedPortsByConnection[targetId]).toBeUndefined()
     expect(state.sshCredentialQueue.map((req) => req.targetId)).toEqual([otherTargetId])
     expect(state.deferredSshReconnectTargets).toEqual([otherTargetId])
+    expect(state.transientClearedAgentStatusConnectionIds).toEqual({
+      [otherTargetId]: true
+    })
     expect(state.deferredSshSessionIdsByTabId).toEqual({
       'tab-other': toAppSshPtyId(otherTargetId, 'pty-2')
     })
@@ -221,6 +228,15 @@ describe('createSshSlice', () => {
     store.getState().clearRemovedSshTargetState('missing-target')
 
     expect(store.getState()).toBe(previousState)
+  })
+
+  it("removes a transient-clear block when it is the target's only remaining state", () => {
+    const store = createTestStore()
+    store.setState({ transientClearedAgentStatusConnectionIds: { 'ssh-1': true } })
+
+    store.getState().clearRemovedSshTargetState('ssh-1')
+
+    expect(store.getState().transientClearedAgentStatusConnectionIds).toEqual({})
   })
 
   it('preserves untouched cleanup slice references while removing deferred target metadata', () => {

--- a/src/renderer/src/store/slices/ssh.ts
+++ b/src/renderer/src/store/slices/ssh.ts
@@ -92,12 +92,18 @@ export const createSshSlice: StateCreator<AppState, [], [], SshSlice> = (set) =>
         return s
       }
       next.set(targetId, state)
+      const didReconnect = previous?.status !== 'connected' && state.status === 'connected'
+      let blockedConnections = s.transientClearedAgentStatusConnectionIds
+      if (didReconnect && targetId in blockedConnections) {
+        blockedConnections = { ...blockedConnections }
+        delete blockedConnections[targetId]
+      }
       return {
         sshConnectionStates: next,
-        sshConnectedGeneration:
-          previous?.status !== 'connected' && state.status === 'connected'
-            ? s.sshConnectedGeneration + 1
-            : s.sshConnectedGeneration
+        sshConnectedGeneration: didReconnect
+          ? s.sshConnectedGeneration + 1
+          : s.sshConnectedGeneration,
+        transientClearedAgentStatusConnectionIds: blockedConnections
       }
     }),
 


### PR DESCRIPTION
## Summary

Renderer-created agent-status rows now carry the SSH connection ID only when exact, authoritative PTY routing proves which connection owns the pane. This covers optimistic launches, Command Code prompt/output status, hidden background sessions, and reused automation fallback paths.

Stamping ownership when the row is created is safer than guessing during disconnect: creation has the exact app-wide PTY ID and live leaf binding, while disconnect-time tab/worktree inference can confuse sibling SSH hosts or identifier collisions. This follow-up lets the connection-scoped cleanup merged in #9484 remove these rows without broadening that cleanup.

All renderer producers use one live-routing resolver that requires the PTY to remain live, remain bound to the exact leaf, and—when SSH-owned—belong to a currently connected lifecycle that has not been transiently cleared. This prevents delayed callbacks from recreating rows during relay reconnect or the brief explicit-disconnect window before renderer connection state updates.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` (full repository lint not run; changed-file checks passed)
- [x] `pnpm typecheck`
- [ ] `pnpm test` (full repository suite not run; focused suites passed)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Verification completed:

- 610 focused tests across 9 files, including PTY connection, optimistic launch, Command Code, background/reuse fallback, IPC, dispatch, SSH cleanup, connection lifecycle, and target-removal suites
- changed-file `oxlint`
- changed-file React Doctor lint
- `oxfmt --check`
- max-lines ratchet
- `git diff --check`

## AI Review Report

The implementation received three adversarial correctness/fix rounds plus independent producer-surface, elegance, and performance reviews. The review audited every production `setAgentStatus` producer and checked exact SSH ownership, local/WSL/remote-runtime isolation, sibling-host collisions, ownership replacement/preservation, reconnect cutoffs, launch/resume/provider metadata, target lifecycle cleanup, and delayed renderer callbacks.

Review found and fixed four issues:

1. Durable layout bindings survive SSH disconnect, so a delayed renderer callback could recreate a cleared row unless the PTY was also required to remain live.
2. Tab-level liveness alone allowed a stale callback when its PTY remained live in a sibling split; writes now require the exact current leaf binding.
3. Relay reconnect can retain live PTY/layout state, and explicit disconnect emits the transient clear before renderer SSH state changes. A per-connection clear block now closes both windows until a later connected lifecycle.
4. Removing an SSH target now also removes its transient-clear marker, including when that marker is the target's only remaining renderer state.

The final review found no remaining proven issue and concluded the centralized producer-side resolver plus per-connection lifecycle block is the best scoped design. Cross-platform review covered macOS, Linux, and Windows behavior; this change adds no shortcuts, labels, filesystem paths, shell commands, or Electron platform branches, and preserves local, WSL, SSH, and remote-runtime routing distinctions.

## Security Audit

No new command execution, path handling, authentication, secrets, dependencies, or IPC surface was added. PTY identifiers are parsed with existing namespaced parsers, malformed or contradictory evidence fails closed, and no ownership is inferred from pane/tab prefixes, focus, or ambiguous worktree state.

## Notes

Genuinely old or ambiguous unstamped rows are intentionally not cleared by SSH disconnect; they remain until normal pane/PTY teardown. This is the safe caveat of connection-scoped cleanup.

Live disconnect/reconnect testing against two real SSH hosts, including relay loss during prompt delivery, was not run locally. Deterministic tests cover those ordering and collision cases.
