### PR TITLE
fix(agent-status): don't fire "Task complete" while a Codex tool is still running

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -1368,6 +1368,121 @@ describe('agent completion coordinator', () => {
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
   })
 
+  it('defers a Codex hook done while the pane is still producing output (#9333)', async () => {
+    // Regression for #9333: during a multi-step, tool-driven Codex turn the hook
+    // status goes working -> done -> working as Codex ends each intermediate
+    // response. If the gap between that 'done' and the next tool exceeds the
+    // 1.5s quiet window, Orca fired a premature "Task complete". Output still
+    // arriving means the turn is mid-flight, not finished.
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(async () => processResult('codex')),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    coordinator.startProcessTracking()
+    vi.advanceTimersByTime(2_000)
+    await flushAsyncTicks()
+
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'multi-step task',
+      agentType: 'codex'
+    })
+    coordinator.observeHookStatus({
+      state: 'done',
+      prompt: 'multi-step task',
+      agentType: 'codex'
+    })
+    expect(coordinator.hasPendingHookDoneCompletion()).toBe(true)
+
+    // Codex keeps streaming tool output past the quiet window; the intermediate
+    // 'done' must not fire a completion while that output keeps arriving.
+    for (let i = 0; i < 8; i++) {
+      vi.advanceTimersByTime(1_000)
+      coordinator.observeOutputActivity()
+      await flushAsyncTicks()
+    }
+    expect(dispatchCompletion).not.toHaveBeenCalled()
+
+    // Output stops and the turn is genuinely idle; now the completion fires.
+    for (let i = 0; i < 4; i++) {
+      vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+      await flushAsyncTicks()
+    }
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+    expect(dispatchCompletion).toHaveBeenCalledWith(
+      'codex',
+      expect.objectContaining({ source: 'hook' })
+    )
+  })
+
+  it('still fires a Codex done when the agent TUI never stops redrawing (#9333)', async () => {
+    // Why: the deferral must delay a completion, never swallow it. A pane that
+    // prints forever still notifies once the ceiling is spent, so the user is
+    // never left waiting on a notification that never arrives.
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-2',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(async () => processResult('codex')),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    coordinator.startProcessTracking()
+    vi.advanceTimersByTime(2_000)
+    await flushAsyncTicks()
+
+    coordinator.observeHookStatus({ state: 'working', prompt: 'task', agentType: 'codex' })
+    coordinator.observeHookStatus({ state: 'done', prompt: 'task', agentType: 'codex' })
+
+    // 60s of unbroken output — far past the deferral ceiling.
+    for (let i = 0; i < 120; i++) {
+      vi.advanceTimersByTime(500)
+      coordinator.observeOutputActivity()
+      await flushAsyncTicks()
+    }
+
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires a Codex done exactly once when Stop repeats across a turn (#9333)', async () => {
+    // Why: #9333 is about *repeated* "Task complete" notifications; a burst of
+    // Stop hooks in one turn must still collapse to a single notification.
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-3',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(async () => processResult('codex')),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    coordinator.startProcessTracking()
+    vi.advanceTimersByTime(2_000)
+    await flushAsyncTicks()
+
+    coordinator.observeHookStatus({ state: 'working', prompt: 'task', agentType: 'codex' })
+    for (let i = 0; i < 5; i++) {
+      coordinator.observeHookStatus({ state: 'done', prompt: 'task', agentType: 'codex' })
+      vi.advanceTimersByTime(200)
+      await flushAsyncTicks()
+    }
+    for (let i = 0; i < 4; i++) {
+      vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+      await flushAsyncTicks()
+    }
+
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+  })
+
   it('still fires a pending Pi done when process inspection sees the agent exit first', async () => {
     // Why: a process-exit probe landing inside the quiet window must not tear
     // down agent evidence, or the pending hook 'done' would be silently dropped.

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -49,6 +49,10 @@ const PENDING_TITLE_TTL_MS = Math.max(2_000, INSPECTION_TIMEOUT_MS + 500)
 const PENDING_TITLE_MAX_TTL_MS = Math.max(30_000, PENDING_TITLE_TTL_MS)
 const COMPLETION_REPLAY_GUARD_MS = 1_000
 const HOOK_DONE_QUIET_MS = 1_500
+// Why: Codex emits Stop between intermediate responses, so a 'done' followed by more output is a mid-task turn boundary, not the end of the request (#9333).
+const HOOK_DONE_OUTPUT_QUIET_MS = 1_500
+// Why: ceiling on that deferral. A TUI that never stops redrawing must delay the notification, never swallow it — no completion is worse than an early one (#9333).
+const HOOK_DONE_MAX_DEFER_MS = 15_000
 // Why: under "Approve for me" Codex resumes almost immediately, so debounce the OS attention notification so a self-resolving pause raises no false banner (#8387).
 const CODEX_ATTENTION_QUIET_MS = 1_500
 
@@ -111,6 +115,9 @@ export function createAgentCompletionCoordinator(
   // Why: cadence tier the armed poll timer was scheduled at, so a shift to a faster tier can re-arm promptly instead of waiting out the long delay.
   let pollTimerTier: PollCadenceTier | null = null
   let lastPaneActivityAt = 0
+  // Why: output after a hook 'done' means the turn is still producing work (#9333); the deadline bounds how long that may defer the notification.
+  let lastOutputActivityAt = 0
+  let pendingHookDoneDeadline = 0
 
   function clearPollTimer(): void {
     if (pollTimer === null) {
@@ -136,6 +143,13 @@ export function createAgentCompletionCoordinator(
     }
     pendingHookDoneTitle = null
     pendingHookDonePayload = null
+    pendingHookDoneDeadline = 0
+  }
+
+  // Why: defer only while output is still arriving AND the ceiling is unspent, so a permanently chatty pane cannot swallow the completion (#9333).
+  function hookDoneShouldDeferForOutput(): boolean {
+    const now = Date.now()
+    return now < pendingHookDoneDeadline && now - lastOutputActivityAt < HOOK_DONE_OUTPUT_QUIET_MS
   }
 
   function clearPendingCodexAttention(): void {
@@ -350,6 +364,9 @@ export function createAgentCompletionCoordinator(
   function scheduleHookDoneCompletion(title: string, payload: AgentCompletionStatusSnapshot): void {
     pendingHookDoneTitle = title
     pendingHookDonePayload = payload
+    if (pendingHookDoneDeadline === 0) {
+      pendingHookDoneDeadline = Date.now() + HOOK_DONE_MAX_DEFER_MS
+    }
     if (pendingHookDoneTimer !== null) {
       return
     }
@@ -361,6 +378,11 @@ export function createAgentCompletionCoordinator(
       pendingHookDoneTitle = null
       pendingHookDonePayload = null
       if (pendingTitle) {
+        if (pendingPayload && hookDoneShouldDeferForOutput()) {
+          // Why: the pane is still printing, so this 'done' was an intermediate Codex Stop. Re-arm; the deadline guarantees it still fires (#9333).
+          scheduleHookDoneCompletion(pendingTitle, pendingPayload)
+          return
+        }
         const hookIdentity = pendingPayload ? hookCompletionIdentity(pendingPayload) : null
         dispatchCompletion('hook', pendingTitle, {
           quietedHookDone: true,
@@ -681,6 +703,7 @@ export function createAgentCompletionCoordinator(
   }
 
   function observeOutputActivity(): void {
+    lastOutputActivityAt = Date.now()
     recordPaneActivity()
   }
 


### PR DESCRIPTION
## Summary

Codex emits a Stop hook between intermediate responses within a single turn, not only at the end of a request. The completion coordinator treated every `done` as end-of-turn, so a multi-step Codex task fired "Task complete" repeatedly while it was still working — the user got a notification, went to look, and found the agent mid-tool-call.

The fix defers a hook `done` while the pane is still producing output: if more output arrives within `HOOK_DONE_OUTPUT_QUIET_MS` (1.5s), the `done` is treated as a mid-task turn boundary and the timer re-arms. Critically, the deferral is bounded by `HOOK_DONE_MAX_DEFER_MS` (15s), so the notification can be delayed but **never swallowed**.

Closes #9333

## ELI5

Codex says "I'm done" several times while working through one request — it means "done with this step", but Orca heard "done with everything" and pinged you each time. Now Orca waits a moment: if Codex keeps typing, it knows that wasn't really the end and stays quiet. And there's a hard 15-second limit on that waiting, so if something goes strange you still get told your task finished — the worst outcome would be silence, not an early ping.

## Proof of fix

**On `origin/main` (test kept, coordinator reverted) — fails:**

```
$ git checkout origin/main -- src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
$ npx vitest run --config config/vitest.config.ts \
    src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts

 × defers a Codex hook done while the pane is still producing output (#9333)

      Tests  1 failed | 74 passed (75)
```

**With this PR:**

```
$ git checkout HEAD -- src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
$ npx vitest run --config config/vitest.config.ts \
    src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts

 Test Files  1 passed (1)
      Tests  75 passed (75)
```

Three tests were added, and the second is the one that matters most for review:

- `defers a Codex hook done while the pane is still producing output (#9333)` — the bug itself.
- **`still fires a Codex done when the agent TUI never stops redrawing (#9333)`** — the guard against the mirror-image bug. If a pane never goes quiet, the 15s ceiling fires the notification anyway. **Silently swallowing a real completion would be worse than the spurious one being fixed**, because the user waits forever with no signal; this test pins that it cannot happen.
- `fires a Codex done exactly once when Stop repeats across a turn (#9333)` — covers the "repeated" half of the reported symptom, not just the timing.

## Proof of no regressions

```
$ npx vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/
 Test Files  186 passed (186)
      Tests  2434 passed (2434)

$ npx tsc --noEmit -p config/tsconfig.tc.web.json      # exit 0
$ npx oxlint src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts \
             src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
(no findings)
```

User-visible behavior that changes:

- A Codex "Task complete" notification may now arrive **up to 1.5s later** than before (longer only while output keeps arriving, hard-capped at 15s). This is the intended trade: a slightly later notification that is correct, instead of an immediate one that is wrong.
- Repeated mid-turn Stop signals no longer produce repeated notifications.
- **No completion is ever dropped.** The deferral re-arms a timer; it does not cancel the dispatch.

Agents other than Codex are unaffected in practice: the deferral only engages when a hook `done` is followed by continued output within the quiet window, which is the Codex intermediate-Stop pattern. A turn that genuinely ends goes quiet and dispatches on the existing path.

## Compatibility

- **Platforms:** macOS / Linux / Windows. Pure renderer-side timer/state logic with no platform branch, no paths, no shell behavior, no Electron API, and no key handling.
- **SSH / remote:** hook events arrive over the relay and can be delayed or dropped. This is precisely why the change is a *bounded* deferral rather than a gate: a missing follow-up event cannot strand the notification, because `HOOK_DONE_MAX_DEFER_MS` dispatches regardless. A dropped intermediate Stop simply means the notification fires on the normal path.
- **Performance:** No hot-path change. `observeOutputActivity()` gains a single `Date.now()` assignment; there is no added allocation, listener, subscription, or re-render trigger. The deferral reuses the existing `pendingHookDoneTimer` rather than adding a new one, so no extra timer is created per pane.

## Screenshots

No visual change beyond *when* an OS notification appears. The behavior is asserted in `agent-completion-coordinator.test.ts` with fake timers — including the never-swallow ceiling — rather than captured as an image, so the guarantee is enforced in CI. I did not record a screen capture of a live Codex turn; noting that plainly rather than implying a manual check that was not performed.

## Testing

- [ ] `pnpm lint` — not run in full. Ran `npx oxlint` on both changed files: no findings.
- [x] `pnpm typecheck` — `npx tsc --noEmit -p config/tsconfig.tc.web.json`, exit 0.
- [ ] `pnpm test` — not run in full (30+ min). Ran the whole touched directory: `src/renderer/src/components/terminal-pane/` → 186 files, 2434 tests passed.
- [ ] `pnpm build` — not run.
- [x] Added or updated high-quality tests that would catch regressions — three tests covering the deferral, the never-swallow ceiling, and single-fire dedupe across repeated Stops.

## AI Review Report

Reviewed with Claude Code (Opus 5) and independently re-verified. Risks checked:

- **Swallowing a real completion — the dominant risk.** A guard that waits for "the tool to finish" can wait forever if the tool crashes, is killed, produces no terminating marker, or its event is dropped over SSH. The user then gets *no* notification at all, which is worse than the spurious one. Verified the design is a bounded deferral with a hard `HOOK_DONE_MAX_DEFER_MS` ceiling, and pinned it with a dedicated test (`never stops redrawing`). The completion is delayed, never cancelled.
- **Timer accounting:** the deferral re-arms the existing `pendingHookDoneTimer` and resets `pendingHookDoneDeadline` in the same `clear` path as the rest of the pending state, so there is no orphaned timer or leaked deadline when a pane closes mid-defer.
- **Deadline is set once per pending done** (`if (pendingHookDoneDeadline === 0)`), so continued output extends the quiet check but cannot push the ceiling forward indefinitely — otherwise a chatty pane would defer forever, reintroducing the swallow.
- **Repeated-Stop dedupe:** the reported symptom is *repeated* notifications, so single-fire across a turn is tested explicitly rather than assumed from the timing fix.
- **Agent scoping:** the file is a generic coordinator. Verified the deferral engages only on the hook-`done`-then-more-output pattern and that the full 2434-test terminal-pane suite — which covers the other agents' completion paths — is unchanged.
- **Cross-platform (macOS / Linux / Windows):** no platform-dependent code, shortcut labels, paths, or shell behavior in this diff.

## Security Audit

- **Input handling:** none added. The change reads existing hook payloads and an output-activity timestamp; no new parsing of untrusted terminal bytes.
- **Command execution:** none. This only affects when a local notification is dispatched.
- **Path handling:** none.
- **Auth / secrets:** none touched. Note the notification payload is unchanged — this PR alters timing only, not content, so nothing new is surfaced to the OS notification layer.
- **Dependencies:** none added or changed.
- **IPC:** no new channel or payload.

## Notes

- The constants are deliberately conservative: 1.5s matches the existing `HOOK_DONE_QUIET_MS` cadence already used in this file, and 15s is a ceiling rather than a tuning knob — it exists to make "never swallow" structurally true, not to be hit in normal operation.
- Adjacent in-flight work touching neighbouring agent-status paths, worth sequencing against: **#10116** (SSH interrupt inference) and **#9716** (dead-PTY writes). No file overlap with either, but all three shape when a pane's agent status changes.

Original patch by @choihjin.
