### PR TITLE
fix(sidebar): stop agent 'working' spinner freezing as a broken ring under reduced motion

### DIFF
--- a/src/renderer/src/components/AgentStateDot.test.ts
+++ b/src/renderer/src/components/AgentStateDot.test.ts
@@ -24,6 +24,9 @@ describe('AgentStateDot', () => {
     expect(markup).toContain('border-t-transparent')
     expect(markup).toContain('[animation:spin_1s_steps(12,end)_infinite]')
     expect(markup).toContain('motion-reduce:animate-none')
+    // Why: under reduced motion the top border is filled so the frozen ring
+    // reads as a complete static marker, not a broken partial spinner.
+    expect(markup).toContain('motion-reduce:border-t-yellow-500')
     expect(markup).not.toContain('animate-spin')
   })
 

--- a/src/renderer/src/components/AgentStateDot.tsx
+++ b/src/renderer/src/components/AgentStateDot.tsx
@@ -78,7 +78,10 @@ export const AgentStateDot = React.memo(function AgentStateDot({
           className={cn(
             // Why: match the sidebar worktree spinner's stepped cadence so
             // long-running visible agents do not keep a full-frame-rate loop.
-            'block rounded-full border-2 border-yellow-500 border-t-transparent [animation:spin_1s_steps(12,end)_infinite] motion-reduce:animate-none',
+            // Why: under reduced motion the spin is disabled, so fill the top
+            // border too — a frozen transparent-top ring reads as a broken
+            // spinner; a complete ring reads as an intentional static marker.
+            'block rounded-full border-2 border-yellow-500 border-t-transparent [animation:spin_1s_steps(12,end)_infinite] motion-reduce:animate-none motion-reduce:border-t-yellow-500',
             inner
           )}
         />

--- a/src/renderer/src/components/sidebar/StatusIndicator.test.ts
+++ b/src/renderer/src/components/sidebar/StatusIndicator.test.ts
@@ -23,6 +23,10 @@ describe('StatusIndicator', () => {
     expect(classNames).toContain('border-yellow-500')
     expect(classNames).toContain('border-t-transparent')
     expect(classNames).toContain('[animation:spin_1s_steps(12,end)_infinite]')
+    // Why: under reduced motion the spin is disabled and the top border filled,
+    // so the dot stays a complete static ring rather than freezing mid-rotation.
+    expect(classNames).toContain('motion-reduce:animate-none')
+    expect(classNames).toContain('motion-reduce:border-t-yellow-500')
     expect(classNames).not.toContain('animate-spin')
   })
 

--- a/src/renderer/src/components/sidebar/StatusIndicator.tsx
+++ b/src/renderer/src/components/sidebar/StatusIndicator.tsx
@@ -34,8 +34,12 @@ const StatusIndicator = React.memo(function StatusIndicator({
         {...rest}
       >
         {/* Why: a stepped spin preserves the worker-is-running affordance while
-            avoiding a full-refresh-rate compositor loop for long agent runs. */}
-        <span className="block size-2 rounded-full border-2 border-yellow-500 border-t-transparent [animation:spin_1s_steps(12,end)_infinite]" />
+            avoiding a full-refresh-rate compositor loop for long agent runs.
+            Why: honor reduced motion (Windows "Animation effects" off →
+            prefers-reduced-motion) by stopping the spin and filling the top
+            border, so the dot stays a complete static ring instead of a
+            partial ring frozen mid-rotation that reads as a broken spinner. */}
+        <span className="block size-2 rounded-full border-2 border-yellow-500 border-t-transparent [animation:spin_1s_steps(12,end)_infinite] motion-reduce:animate-none motion-reduce:border-t-yellow-500" />
       </span>
     )
   }


### PR DESCRIPTION
## Description

On **Windows**, the agent **"working" spinner** appeared frozen/stuck in both the **terminal tab** and the **worktree card**, while other loading spinners kept spinning.

**Root cause:** the agent-status spinner is a CSS ring with a transparent top border (`border-t-transparent` + `[animation:spin_1s_steps(12,end)_infinite]`), and `AgentStateDot` carries `motion-reduce:animate-none`. When Windows **Settings → Accessibility → Visual effects → "Animation effects"** is off, Chromium reports `prefers-reduced-motion: reduce`, so `animate-none` halts the spin — freezing the ring **mid-rotation as a partial (3/4) ring**, which reads as a *broken* spinner. Other spinners use `animate-spin` with no reduced-motion guard, so they keep moving — hence the asymmetry ("top-level spinner spins, agent spinner stuck").

**Fix:** under reduced motion, also fill the top border so the ring becomes a **complete static circle** — an intentional "working" marker rather than a broken partial spinner. Applied to both spinner primitives:

- `AgentStateDot.tsx` — added `motion-reduce:border-t-yellow-500` (fixes the terminal tab + worktree-card agent rows + dashboard/AI-Vault rows).
- `StatusIndicator.tsx` — added `motion-reduce:animate-none motion-reduce:border-t-yellow-500` so the sidebar/worktree status dot honors reduced motion **consistently** (previously it kept stepping — the outlier that caused the visible split).

This reuses the pattern already established in `feature-tour-preview-glyphs.tsx` (`reducedMotion ? 'border-t-yellow-500' : 'animate-spin border-t-transparent'`). Normal-motion rendering is completely unchanged (both new declarations live only inside `@media (prefers-reduced-motion: reduce)`).

## Evidence of fix

- **Reproduced deterministically** — DevTools → Rendering → "Emulate CSS media feature `prefers-reduced-motion` = reduce" freezes the pre-fix ring as a partial arc; `matchMedia('(prefers-reduced-motion: reduce)').matches` is `true` on a Windows box with Animation effects off. Also reproducible by toggling the Windows OS setting directly.
- **Cascade proven by compilation** (adversarial review): compiled the exact class set with the repo-pinned `tailwindcss@4.2.4`. Both `motion-reduce:` rules sort **last** in `@layer utilities` at equal specificity (0,1,0), so inside the media query they override `border-t-transparent` and the arbitrary `animation` utility by source order. `--color-yellow-500` is defined (no `--color-*: initial` reset in `main.css`).
- **`tailwind-merge@3.5.0` proven not to drop the class** — ran `twMerge` on the exact `cn(...)` string; the `motion-reduce:` modifier lands in a separate conflict bucket, so `border-t-transparent` **and** `motion-reduce:border-t-yellow-500` are both kept. (`StatusIndicator`'s span is a raw literal, not routed through `cn`, so it can't be merged at all.)
- **Tests** — `AgentStateDot.test.ts` / `StatusIndicator.test.ts` assert the new classes are present in the rendered markup (the `AgentStateDot` one runs post-`cn`, so it also guards against tailwind-merge stripping). Note: string-level tests don't validate compiled CSS — the compile/merge proofs above cover that gap.
- **Consumers audited** — all 17 `AgentStateDot` + 12 `StatusIndicator` call sites: `className` reaches only the outer wrapper; the inner spinner classes are hardcoded and unreachable by callers, so no caller can strip or re-color the fix.

> ⚠️ CI note: `node_modules` isn't installed in this worktree, so `pnpm test` / `oxlint` / `oxfmt` were **not** run locally here — relying on PR CI. Changes are literal-string edits with matching test assertions and no type changes.

## ELI5

The little "I'm working" circle is drawn as a ring with **one piece of its edge left invisible** — normally it spins so fast you just see a moving gap, like a chasing tail. Windows has a setting that says "stop animations." When that's on, the spin stops **but the gap stays** — so you're left staring at a broken-looking three-quarter circle that never moves, and it looks like the agent is stuck.

This change says: *if we're not allowed to spin, then color in that missing piece too* — so instead of a frozen broken ring you get a clean, whole yellow ring. It's obviously "a status light that's on," not "a spinner that died." The other tiny loading spinners around the app were never told to stop, which is why they kept twirling next to the frozen one and made it look extra broken.

## User regression / tradeoff list

Aiming for zero. What actually changes:

| Change | Who sees it | Assessment |
|---|---|---|
| Normal-motion rendering | Everyone with animations on (default, incl. all macOS defaults) | **No change** — new CSS is media-query-scoped to `prefers-reduced-motion: reduce`. |
| Frozen partial ring → complete static ring | Reduced-motion users (e.g. Windows Animation effects off) | **Fix, not regression** — was already frozen; now it looks intentional. |
| Sidebar `StatusIndicator` stops stepping under reduced motion | Reduced-motion users only | **Intended** — it now honors the OS setting (it was the inconsistent outlier). Liveness is still conveyed by the `title="Working"` tooltip + `sr-only` labels; only the motion cue is dropped, which is exactly what `prefers-reduced-motion` requests. |

**One honest visual tradeoff (non-blocking, flagged by adversarial review):** at the small (`sm`, 6px) `AgentStateDot` size, the filled ring has only a ~2px center hole, so a static "working" ring is a bit closer to the solid amber `waiting`/`permission` dot than the old gapped ring was. Mitigated by: the hole still shows the background through, the hue differs (yellow vs amber), and every dot is paired with a tooltip/`aria-label`. The `md` size and `StatusIndicator` (8px, 4px hole) are unambiguous. A stronger small-size distinguisher would be a separate design decision.

**Out-of-scope follow-ups (not regressions):** generic `Loader2 animate-spin` loaders and `TasksAnimatedVisual.tsx:297` still don't honor reduced motion app-wide — a possible future consistency sweep.

## Relationship to #9380

#9380 (perf: shared spinner clock) does **not** fix this — it preserves (and broadens) the reduced-motion freeze, so a partial ring would still look broken there. If #9380 lands, its `AgentWorkingSpinner` should adopt this same "complete ring under reduced motion" treatment.

Made with [Orca](https://github.com/stablyai/orca) 🐋
