### PR TITLE
fix(worktree): bound teardown RPCs so Windows workspace deletion can't hang

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -573,10 +573,21 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.client.notify('setSessionBackground', { sessionId: id, background: safeBackground })
   }
 
-  async shutdown(id: string, opts: { immediate?: boolean; keepHistory?: boolean }): Promise<void> {
+  async shutdown(
+    id: string,
+    opts: { immediate?: boolean; keepHistory?: boolean; timeoutMs?: number }
+  ): Promise<void> {
+    // Why: destructive teardown shares one budget across connect + kill so a wedged
+    // handshake cannot burn the whole sweep deadline before the kill even starts;
+    // undefined keeps the default unbounded connect + 30s RPC for all other callers.
+    const shutdownDeadline = opts.timeoutMs !== undefined ? Date.now() + opts.timeoutMs : undefined
     // Why: shutdown can be the first lazy-client operation after restart; connect
     // before killing so a healthy daemon session is not orphaned (#7742).
-    await this.ensureConnected()
+    await this.ensureConnected(
+      shutdownDeadline !== undefined
+        ? { connectTimeoutMs: Math.max(1, shutdownDeadline - Date.now()) }
+        : undefined
+    )
     // Why: sleep/exact-stop kills the live PTY before the periodic checkpoint may run.
     // Force a final snapshot so wake can restore the pane users left.
     if (opts.keepHistory) {
@@ -606,7 +617,14 @@ export class DaemonPtyAdapter implements IPtyProvider {
         this.historyManager?.suspendSession(id)
       }
     }
-    await this.client.request('kill', { sessionId: id, immediate: opts.immediate ?? false })
+    // Why: destructive teardown passes what remains of its shared budget so a wedged
+    // daemon fails fast with an accurate error instead of tripping the outer deadline;
+    // undefined keeps the DaemonClient 30s default for all other callers.
+    await this.client.request(
+      'kill',
+      { sessionId: id, immediate: opts.immediate ?? false },
+      shutdownDeadline !== undefined ? Math.max(1, shutdownDeadline - Date.now()) : opts.timeoutMs
+    )
     this.activeSessionIds.delete(id)
     this.dirtySessionVersions.delete(id)
     if (!opts.keepHistory) {
@@ -856,9 +874,21 @@ export class DaemonPtyAdapter implements IPtyProvider {
     return { alive, killed }
   }
 
-  async listProcesses(): Promise<PtyProcessInfo[]> {
-    await this.ensureConnected()
-    const result = await this.client.request<ListSessionsResult>('listSessions', undefined)
+  async listProcesses(opts?: { timeoutMs?: number }): Promise<PtyProcessInfo[]> {
+    // Why: destructive teardown shares one budget across connect + listSessions so a
+    // wedged handshake cannot burn the whole sweep deadline; undefined keeps the
+    // default unbounded connect + 30s RPC for all other callers.
+    const listDeadline = opts?.timeoutMs !== undefined ? Date.now() + opts.timeoutMs : undefined
+    await this.ensureConnected(
+      listDeadline !== undefined
+        ? { connectTimeoutMs: Math.max(1, listDeadline - Date.now()) }
+        : undefined
+    )
+    const result = await this.client.request<ListSessionsResult>(
+      'listSessions',
+      undefined,
+      listDeadline !== undefined ? Math.max(1, listDeadline - Date.now()) : opts?.timeoutMs
+    )
     return result.sessions
       .filter((s) => s.isAlive)
       .map((s) => ({
@@ -1058,9 +1088,13 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.client.disconnect()
   }
 
-  private async ensureConnected(): Promise<void> {
+  private async ensureConnected(opts?: { connectTimeoutMs?: number }): Promise<void> {
     try {
-      await this.client.ensureConnected()
+      // Why: destructive teardown bounds the handshake within its sweep budget so a
+      // wedged connect fails fast; undefined keeps the default unbounded connect.
+      await (opts?.connectTimeoutMs !== undefined
+        ? this.client.ensureConnectedWithin(opts.connectTimeoutMs)
+        : this.client.ensureConnected())
     } finally {
       // Why: a respawn launcher holds a temporary full pair until this adapter
       // has attempted its permanent reconnect, preventing both gaps and leaks.

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -80,6 +80,13 @@ export type DaemonPtyAdapterOptions = {
 const MAX_TOMBSTONES = 1000
 const MAX_CONCURRENT_CHECKPOINTS = 4
 
+// Why: providers take an absolute teardown deadline, but the client RPC takes a
+// relative timeout — convert only here, at the request itself, so sequential RPCs
+// naturally share the remaining budget (undefined keeps the client's 30s default).
+function remainingRequestTimeoutMs(deadlineMs: number | undefined): number | undefined {
+  return deadlineMs === undefined ? undefined : Math.max(1, deadlineMs - Date.now())
+}
+
 export class TerminalKilledError extends Error {
   constructor(sessionId: string) {
     super(`Session "${sessionId}" was explicitly killed`)
@@ -575,19 +582,13 @@ export class DaemonPtyAdapter implements IPtyProvider {
 
   async shutdown(
     id: string,
-    opts: { immediate?: boolean; keepHistory?: boolean; timeoutMs?: number }
+    opts: { immediate?: boolean; keepHistory?: boolean; deadlineMs?: number }
   ): Promise<void> {
-    // Why: destructive teardown shares one budget across connect + kill so a wedged
-    // handshake cannot burn the whole sweep deadline before the kill even starts;
-    // undefined keeps the default unbounded connect + 30s RPC for all other callers.
-    const shutdownDeadline = opts.timeoutMs !== undefined ? Date.now() + opts.timeoutMs : undefined
     // Why: shutdown can be the first lazy-client operation after restart; connect
-    // before killing so a healthy daemon session is not orphaned (#7742).
-    await this.ensureConnected(
-      shutdownDeadline !== undefined
-        ? { connectTimeoutMs: Math.max(1, shutdownDeadline - Date.now()) }
-        : undefined
-    )
+    // before killing so a healthy daemon session is not orphaned (#7742). Connect
+    // and kill share the caller's one absolute deadline, so a wedged handshake
+    // cannot burn the whole teardown budget before the kill even starts.
+    await this.ensureConnected(opts.deadlineMs)
     // Why: sleep/exact-stop kills the live PTY before the periodic checkpoint may run.
     // Force a final snapshot so wake can restore the pane users left.
     if (opts.keepHistory) {
@@ -617,13 +618,10 @@ export class DaemonPtyAdapter implements IPtyProvider {
         this.historyManager?.suspendSession(id)
       }
     }
-    // Why: destructive teardown passes what remains of its shared budget so a wedged
-    // daemon fails fast with an accurate error instead of tripping the outer deadline;
-    // undefined keeps the DaemonClient 30s default for all other callers.
     await this.client.request(
       'kill',
       { sessionId: id, immediate: opts.immediate ?? false },
-      shutdownDeadline !== undefined ? Math.max(1, shutdownDeadline - Date.now()) : opts.timeoutMs
+      remainingRequestTimeoutMs(opts.deadlineMs)
     )
     this.activeSessionIds.delete(id)
     this.dirtySessionVersions.delete(id)
@@ -874,20 +872,14 @@ export class DaemonPtyAdapter implements IPtyProvider {
     return { alive, killed }
   }
 
-  async listProcesses(opts?: { timeoutMs?: number }): Promise<PtyProcessInfo[]> {
-    // Why: destructive teardown shares one budget across connect + listSessions so a
-    // wedged handshake cannot burn the whole sweep deadline; undefined keeps the
-    // default unbounded connect + 30s RPC for all other callers.
-    const listDeadline = opts?.timeoutMs !== undefined ? Date.now() + opts.timeoutMs : undefined
-    await this.ensureConnected(
-      listDeadline !== undefined
-        ? { connectTimeoutMs: Math.max(1, listDeadline - Date.now()) }
-        : undefined
-    )
+  async listProcesses(opts?: { deadlineMs?: number }): Promise<PtyProcessInfo[]> {
+    // Why: connect + listSessions share the caller's one absolute deadline so a
+    // wedged handshake cannot burn the whole teardown budget before the list issues.
+    await this.ensureConnected(opts?.deadlineMs)
     const result = await this.client.request<ListSessionsResult>(
       'listSessions',
       undefined,
-      listDeadline !== undefined ? Math.max(1, listDeadline - Date.now()) : opts?.timeoutMs
+      remainingRequestTimeoutMs(opts?.deadlineMs)
     )
     return result.sessions
       .filter((s) => s.isAlive)
@@ -1088,12 +1080,12 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.client.disconnect()
   }
 
-  private async ensureConnected(opts?: { connectTimeoutMs?: number }): Promise<void> {
+  private async ensureConnected(deadlineMs?: number): Promise<void> {
     try {
-      // Why: destructive teardown bounds the handshake within its sweep budget so a
-      // wedged connect fails fast; undefined keeps the default unbounded connect.
-      await (opts?.connectTimeoutMs !== undefined
-        ? this.client.ensureConnectedWithin(opts.connectTimeoutMs)
+      // Why: destructive teardown bounds the handshake by its deadline so a wedged
+      // connect fails fast; undefined keeps the default connect behavior.
+      await (deadlineMs !== undefined
+        ? this.client.ensureConnectedWithin(Math.max(1, deadlineMs - Date.now()))
         : this.client.ensureConnected())
     } finally {
       // Why: a respawn launcher holds a temporary full pair until this adapter

--- a/src/main/daemon/daemon-pty-provider.ts
+++ b/src/main/daemon/daemon-pty-provider.ts
@@ -64,8 +64,17 @@ export class DaemonPtyProvider {
     this.client.notify('resize', { sessionId: id, cols, rows })
   }
 
-  async shutdown(id: string, opts: { immediate?: boolean; keepHistory?: boolean }): Promise<void> {
-    await this.client.request('kill', { sessionId: id, immediate: opts.immediate ?? false })
+  async shutdown(
+    id: string,
+    opts: { immediate?: boolean; keepHistory?: boolean; timeoutMs?: number }
+  ): Promise<void> {
+    // Why: destructive teardown passes a bound below its sweep deadline so a wedged
+    // daemon fails fast; undefined keeps the DaemonClient 30s default otherwise.
+    await this.client.request(
+      'kill',
+      { sessionId: id, immediate: opts.immediate ?? false },
+      opts.timeoutMs
+    )
   }
 
   onData(callback: (payload: { id: string; data: string }) => void): () => void {

--- a/src/main/daemon/daemon-pty-provider.ts
+++ b/src/main/daemon/daemon-pty-provider.ts
@@ -66,14 +66,14 @@ export class DaemonPtyProvider {
 
   async shutdown(
     id: string,
-    opts: { immediate?: boolean; keepHistory?: boolean; timeoutMs?: number }
+    opts: { immediate?: boolean; keepHistory?: boolean; deadlineMs?: number }
   ): Promise<void> {
-    // Why: destructive teardown passes a bound below its sweep deadline so a wedged
-    // daemon fails fast; undefined keeps the DaemonClient 30s default otherwise.
+    // Why: convert the absolute teardown deadline to a relative timeout only here,
+    // at the RPC leaf; undefined keeps the DaemonClient 30s default.
     await this.client.request(
       'kill',
       { sessionId: id, immediate: opts.immediate ?? false },
-      opts.timeoutMs
+      opts.deadlineMs !== undefined ? Math.max(1, opts.deadlineMs - Date.now()) : undefined
     )
   }
 

--- a/src/main/daemon/daemon-pty-router.ts
+++ b/src/main/daemon/daemon-pty-router.ts
@@ -103,7 +103,7 @@ export class DaemonPtyRouter implements IPtyProvider {
 
   async shutdown(
     id: string,
-    opts: { immediate?: boolean; keepHistory?: boolean; timeoutMs?: number }
+    opts: { immediate?: boolean; keepHistory?: boolean; deadlineMs?: number }
   ): Promise<void> {
     await this.adapterFor(id).shutdown(id, opts)
     // Why: sleep passes keepHistory=true and re-spawns against the same
@@ -176,7 +176,7 @@ export class DaemonPtyRouter implements IPtyProvider {
     await this.current.revive(state)
   }
 
-  async listProcesses(opts?: { timeoutMs?: number }): Promise<PtyProcessInfo[]> {
+  async listProcesses(opts?: { deadlineMs?: number }): Promise<PtyProcessInfo[]> {
     // Why: runtime exact-stop/liveness flows must fail closed if any adapter
     // cannot provide a trustworthy process list.
     const results = await Promise.all(

--- a/src/main/daemon/daemon-pty-router.ts
+++ b/src/main/daemon/daemon-pty-router.ts
@@ -101,7 +101,10 @@ export class DaemonPtyRouter implements IPtyProvider {
     this.adapterFor(id).setPtyBackgrounded(id, background)
   }
 
-  async shutdown(id: string, opts: { immediate?: boolean; keepHistory?: boolean }): Promise<void> {
+  async shutdown(
+    id: string,
+    opts: { immediate?: boolean; keepHistory?: boolean; timeoutMs?: number }
+  ): Promise<void> {
     await this.adapterFor(id).shutdown(id, opts)
     // Why: sleep passes keepHistory=true and re-spawns against the same
     // sessionId on wake. If we delete the routing entry here, adapterFor()
@@ -173,10 +176,12 @@ export class DaemonPtyRouter implements IPtyProvider {
     await this.current.revive(state)
   }
 
-  async listProcesses(): Promise<PtyProcessInfo[]> {
+  async listProcesses(opts?: { timeoutMs?: number }): Promise<PtyProcessInfo[]> {
     // Why: runtime exact-stop/liveness flows must fail closed if any adapter
     // cannot provide a trustworthy process list.
-    const results = await Promise.all(this.allAdapters().map((adapter) => adapter.listProcesses()))
+    const results = await Promise.all(
+      this.allAdapters().map((adapter) => adapter.listProcesses(opts))
+    )
     return results.flat()
   }
 

--- a/src/main/daemon/degraded-daemon-pty-provider.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.ts
@@ -111,7 +111,7 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
 
   async shutdown(
     id: string,
-    opts: { immediate?: boolean; keepHistory?: boolean; timeoutMs?: number }
+    opts: { immediate?: boolean; keepHistory?: boolean; deadlineMs?: number }
   ): Promise<void> {
     await this.providerFor(id).shutdown(id, opts)
     if (!opts.keepHistory) {
@@ -176,7 +176,7 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
     await this.fallback.revive(state)
   }
 
-  async listProcesses(opts?: { timeoutMs?: number }): Promise<PtyProcessInfo[]> {
+  async listProcesses(opts?: { deadlineMs?: number }): Promise<PtyProcessInfo[]> {
     const results = await Promise.all(
       this.allProviders().map((provider) => provider.listProcesses(opts))
     )

--- a/src/main/daemon/degraded-daemon-pty-provider.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.ts
@@ -109,7 +109,10 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
     this.providerFor(id).setPtyBackgrounded?.(id, background)
   }
 
-  async shutdown(id: string, opts: { immediate?: boolean; keepHistory?: boolean }): Promise<void> {
+  async shutdown(
+    id: string,
+    opts: { immediate?: boolean; keepHistory?: boolean; timeoutMs?: number }
+  ): Promise<void> {
     await this.providerFor(id).shutdown(id, opts)
     if (!opts.keepHistory) {
       this.sessionProviders.delete(id)
@@ -173,9 +176,9 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
     await this.fallback.revive(state)
   }
 
-  async listProcesses(): Promise<PtyProcessInfo[]> {
+  async listProcesses(opts?: { timeoutMs?: number }): Promise<PtyProcessInfo[]> {
     const results = await Promise.all(
-      this.allProviders().map((provider) => provider.listProcesses())
+      this.allProviders().map((provider) => provider.listProcesses(opts))
     )
     return results.flat()
   }

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -3013,6 +3013,71 @@ describe('registerPtyHandlers', () => {
         expect(runtime.onPtyExit).toHaveBeenCalledWith('remote-pty', -1)
       })
 
+      it('splits the teardown budget so the liveness RPC gets only what shutdown left', async () => {
+        // Why: sequential RPCs must share one absolute deadline; otherwise both get
+        // the full ~9.5s bound and their sum overruns the 10s sweep deadline (Finding 1).
+        // Fake timers freeze Date.now() at entry, then let the shutdown RPC burn a
+        // deterministic slice of the budget so the recomputed verify bound is provable.
+        vi.useFakeTimers()
+        const shutdown = vi.fn(async () => {
+          await new Promise<void>((resolve) => setTimeout(resolve, 1000))
+        })
+        const listProcesses = vi.fn(async () => [])
+        setLocalPtyProvider({
+          spawn: vi.fn(),
+          write: vi.fn(),
+          resize: vi.fn(),
+          shutdown,
+          sendSignal: vi.fn(),
+          getCwd: vi.fn(),
+          getInitialCwd: vi.fn(),
+          clearBuffer: vi.fn(),
+          acknowledgeDataEvent: vi.fn(),
+          hasChildProcesses: vi.fn(),
+          getForegroundProcess: vi.fn(),
+          serialize: vi.fn(),
+          revive: vi.fn(),
+          onData: vi.fn(() => () => {}),
+          onReplay: vi.fn(() => () => {}),
+          onExit: vi.fn(() => () => {}),
+          listProcesses,
+          attach: vi.fn(),
+          getDefaultShell: vi.fn(),
+          getProfiles: vi.fn()
+        } as never)
+        const runtime = {
+          setPtyController: vi.fn(),
+          onPtyExit: vi.fn()
+        }
+        handlers.clear()
+        registerPtyHandlers(mainWindow as never, runtime as never)
+        const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
+          stopAndWait: (
+            ptyId: string,
+            opts?: { keepHistory?: boolean; timeoutMs?: number }
+          ) => Promise<boolean>
+        }
+
+        const stopPromise = controller.stopAndWait('local-pty', { timeoutMs: 4321 })
+        await vi.advanceTimersByTimeAsync(1000)
+        await expect(stopPromise).resolves.toBe(true)
+
+        // The first RPC (daemon shutdown) receives the full remaining budget...
+        expect(shutdown).toHaveBeenCalledWith(
+          'local-pty',
+          expect.objectContaining({ immediate: true, timeoutMs: 4321 })
+        )
+        // ...and the SUBSEQUENT liveness list RPC gets strictly less: the 1000ms the
+        // shutdown consumed is gone, so 4321 - 1000 = 3321 remain.
+        const listCalls = listProcesses.mock.calls as unknown as Array<
+          [{ timeoutMs?: number } | undefined]
+        >
+        const listArgs = listCalls[0]?.[0]
+        expect(listArgs?.timeoutMs).toBeLessThan(4321)
+        expect(listArgs?.timeoutMs).toBe(3321)
+        vi.useRealTimers()
+      })
+
       it('runtime controller stopAndWait fails when keepHistory allows the PTY to revive', async () => {
         vi.useFakeTimers()
         const shutdown = vi.fn(async () => undefined)

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -3017,12 +3017,18 @@ describe('registerPtyHandlers', () => {
         // Why: sequential RPCs must share one absolute deadline; otherwise both get
         // the full ~9.5s bound and their sum overruns the 10s sweep deadline (Finding 1).
         // Fake timers freeze Date.now() at entry, then let the shutdown RPC burn a
-        // deterministic slice of the budget so the recomputed verify bound is provable.
+        // deterministic slice of the budget so the leaf-observed remainders are provable.
         vi.useFakeTimers()
-        const shutdown = vi.fn(async () => {
+        // Each provider call records the budget an RPC leaf would see at issue time.
+        const remainingAtLeaf: number[] = []
+        const shutdown = vi.fn(async (_id: string, opts?: { deadlineMs?: number }) => {
+          remainingAtLeaf.push((opts?.deadlineMs ?? 0) - Date.now())
           await new Promise<void>((resolve) => setTimeout(resolve, 1000))
         })
-        const listProcesses = vi.fn(async () => [])
+        const listProcesses = vi.fn(async (opts?: { deadlineMs?: number }) => {
+          remainingAtLeaf.push((opts?.deadlineMs ?? 0) - Date.now())
+          return []
+        })
         setLocalPtyProvider({
           spawn: vi.fn(),
           write: vi.fn(),
@@ -3054,27 +3060,24 @@ describe('registerPtyHandlers', () => {
         const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
           stopAndWait: (
             ptyId: string,
-            opts?: { keepHistory?: boolean; timeoutMs?: number }
+            opts?: { keepHistory?: boolean; deadlineMs?: number }
           ) => Promise<boolean>
         }
 
-        const stopPromise = controller.stopAndWait('local-pty', { timeoutMs: 4321 })
+        const deadlineMs = Date.now() + 4321
+        const stopPromise = controller.stopAndWait('local-pty', { deadlineMs })
         await vi.advanceTimersByTimeAsync(1000)
         await expect(stopPromise).resolves.toBe(true)
 
-        // The first RPC (daemon shutdown) receives the full remaining budget...
+        // Both calls carry the same absolute deadline...
         expect(shutdown).toHaveBeenCalledWith(
           'local-pty',
-          expect.objectContaining({ immediate: true, timeoutMs: 4321 })
+          expect.objectContaining({ immediate: true, deadlineMs })
         )
-        // ...and the SUBSEQUENT liveness list RPC gets strictly less: the 1000ms the
-        // shutdown consumed is gone, so 4321 - 1000 = 3321 remain.
-        const listCalls = listProcesses.mock.calls as unknown as Array<
-          [{ timeoutMs?: number } | undefined]
-        >
-        const listArgs = listCalls[0]?.[0]
-        expect(listArgs?.timeoutMs).toBeLessThan(4321)
-        expect(listArgs?.timeoutMs).toBe(3321)
+        // ...so at the leaves the shutdown RPC sees the full 4321ms budget, while the
+        // SUBSEQUENT liveness list RPC sees only what shutdown left: the 1000ms it
+        // consumed is gone, so 4321 - 1000 = 3321 remain until the shared deadline.
+        expect(remainingAtLeaf).toEqual([4321, 3321])
         vi.useRealTimers()
       })
 

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -495,21 +495,21 @@ function delay(ms: number): Promise<void> {
 async function isProviderPtyLive(
   provider: IPtyProvider,
   ptyId: string,
-  timeoutMs?: number
+  deadlineMs?: number
 ): Promise<boolean> {
-  // Why: bound the liveness list RPC below the teardown sweep deadline so a wedged
-  // daemon fails fast; undefined keeps the provider default for all other callers.
+  // Why: bound the liveness list RPC by the teardown deadline so a wedged daemon
+  // fails fast; undefined keeps the provider default for all other callers.
   return (
-    await provider.listProcesses(timeoutMs !== undefined ? { timeoutMs } : undefined)
+    await provider.listProcesses(deadlineMs !== undefined ? { deadlineMs } : undefined)
   ).some((session) => session.id === ptyId)
 }
 
 async function verifyPtyStopped(
   provider: IPtyProvider,
   ptyId: string,
-  opts: { keepHistory?: boolean; timeoutMs?: number } | undefined
+  opts: { keepHistory?: boolean; deadlineMs?: number } | undefined
 ): Promise<boolean> {
-  if (await isProviderPtyLive(provider, ptyId, opts?.timeoutMs)) {
+  if (await isProviderPtyLive(provider, ptyId, opts?.deadlineMs)) {
     return false
   }
   if (!opts?.keepHistory) {
@@ -518,7 +518,7 @@ async function verifyPtyStopped(
   const deadline = Date.now() + KEEP_HISTORY_STOP_SETTLE_MS
   while (Date.now() < deadline) {
     await delay(KEEP_HISTORY_STOP_POLL_MS)
-    if (await isProviderPtyLive(provider, ptyId, opts?.timeoutMs)) {
+    if (await isProviderPtyLive(provider, ptyId, opts?.deadlineMs)) {
       return false
     }
   }
@@ -2620,7 +2620,7 @@ export function registerPtyHandlers(
   async function shutdownProviderAndDetectExit(
     provider: IPtyProvider,
     id: string,
-    opts: { immediate?: boolean; keepHistory?: boolean; timeoutMs?: number }
+    opts: { immediate?: boolean; keepHistory?: boolean; deadlineMs?: number }
   ): Promise<boolean> {
     let providerExitObserved = false
     const unsubscribe = provider.onExit((payload) => {
@@ -3517,19 +3517,16 @@ export function registerPtyHandlers(
       let connectionId: string | null | undefined = ptyOwnership.get(ptyId)
       const parsedSshId = connectionId === undefined ? parseAppSshPtyId(ptyId) : null
       connectionId ??= parsedSshId?.connectionId
-      // Why: reconstruct one absolute deadline so each sequential RPC gets the
-      // REMAINING sweep budget, not the full bound — otherwise two ~full-budget
-      // RPCs can overrun the sweep deadline and surface a teardown-timeout error.
-      const rpcDeadline = opts?.timeoutMs !== undefined ? Date.now() + opts.timeoutMs : undefined
-      const remainingBudget = (): number | undefined =>
-        rpcDeadline === undefined ? undefined : Math.max(1, rpcDeadline - Date.now())
+      // Why: destructive teardown threads one absolute deadline through every await
+      // below; each RPC leaf converts it to the remaining time when it issues, so
+      // sequential RPCs share the budget and cannot overrun the sweep deadline.
+      const deadlineMs = opts?.deadlineMs
       const startupPromise = getLocalPtyProviderStartupPromise(connectionId)
       if (startupPromise) {
         // Why: exact-stop must resolve the provider after daemon startup just
         // like renderer kills, or the fallback can falsely confirm teardown.
-        if (rpcDeadline !== undefined) {
-          // Why: bound the cold-start await to the remaining budget so destructive
-          // teardown stays inside its sweep window instead of blocking up to the
+        if (deadlineMs !== undefined) {
+          // Why: bound the cold-start await by the teardown deadline instead of the
           // 60s startup fail-open cap; fail closed so the sweep records the miss.
           const won = await Promise.race([
             // Why: () => false on rejection both fails closed on a startup error and
@@ -3538,7 +3535,7 @@ export function registerPtyHandlers(
               () => true,
               () => false
             ),
-            delay(Math.max(1, rpcDeadline - Date.now())).then(() => false)
+            delay(Math.max(1, deadlineMs - Date.now())).then(() => false)
           ])
           if (!won) {
             return false
@@ -3567,7 +3564,7 @@ export function registerPtyHandlers(
         providerExitObserved = await shutdownProviderAndDetectExit(provider, ptyId, {
           immediate: true,
           keepHistory: opts?.keepHistory ?? false,
-          timeoutMs: remainingBudget()
+          deadlineMs
         })
       } catch (err) {
         if (!isPtyAlreadyGoneError(err)) {
@@ -3578,14 +3575,7 @@ export function registerPtyHandlers(
         }
       }
       try {
-        // Why: recompute the budget AFTER shutdown so verify's list RPC only gets
-        // the time the shutdown left behind, keeping both RPCs inside the deadline.
-        if (
-          !(await verifyPtyStopped(provider, ptyId, {
-            keepHistory: opts?.keepHistory,
-            timeoutMs: remainingBudget()
-          }))
-        ) {
+        if (!(await verifyPtyStopped(provider, ptyId, opts))) {
           return false
         }
       } catch (err) {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -492,16 +492,24 @@ function delay(ms: number): Promise<void> {
   })
 }
 
-async function isProviderPtyLive(provider: IPtyProvider, ptyId: string): Promise<boolean> {
-  return (await provider.listProcesses()).some((session) => session.id === ptyId)
+async function isProviderPtyLive(
+  provider: IPtyProvider,
+  ptyId: string,
+  timeoutMs?: number
+): Promise<boolean> {
+  // Why: bound the liveness list RPC below the teardown sweep deadline so a wedged
+  // daemon fails fast; undefined keeps the provider default for all other callers.
+  return (
+    await provider.listProcesses(timeoutMs !== undefined ? { timeoutMs } : undefined)
+  ).some((session) => session.id === ptyId)
 }
 
 async function verifyPtyStopped(
   provider: IPtyProvider,
   ptyId: string,
-  opts: { keepHistory?: boolean } | undefined
+  opts: { keepHistory?: boolean; timeoutMs?: number } | undefined
 ): Promise<boolean> {
-  if (await isProviderPtyLive(provider, ptyId)) {
+  if (await isProviderPtyLive(provider, ptyId, opts?.timeoutMs)) {
     return false
   }
   if (!opts?.keepHistory) {
@@ -510,7 +518,7 @@ async function verifyPtyStopped(
   const deadline = Date.now() + KEEP_HISTORY_STOP_SETTLE_MS
   while (Date.now() < deadline) {
     await delay(KEEP_HISTORY_STOP_POLL_MS)
-    if (await isProviderPtyLive(provider, ptyId)) {
+    if (await isProviderPtyLive(provider, ptyId, opts?.timeoutMs)) {
       return false
     }
   }
@@ -2612,7 +2620,7 @@ export function registerPtyHandlers(
   async function shutdownProviderAndDetectExit(
     provider: IPtyProvider,
     id: string,
-    opts: { immediate?: boolean; keepHistory?: boolean }
+    opts: { immediate?: boolean; keepHistory?: boolean; timeoutMs?: number }
   ): Promise<boolean> {
     let providerExitObserved = false
     const unsubscribe = provider.onExit((payload) => {
@@ -3509,11 +3517,35 @@ export function registerPtyHandlers(
       let connectionId: string | null | undefined = ptyOwnership.get(ptyId)
       const parsedSshId = connectionId === undefined ? parseAppSshPtyId(ptyId) : null
       connectionId ??= parsedSshId?.connectionId
+      // Why: reconstruct one absolute deadline so each sequential RPC gets the
+      // REMAINING sweep budget, not the full bound — otherwise two ~full-budget
+      // RPCs can overrun the sweep deadline and surface a teardown-timeout error.
+      const rpcDeadline = opts?.timeoutMs !== undefined ? Date.now() + opts.timeoutMs : undefined
+      const remainingBudget = (): number | undefined =>
+        rpcDeadline === undefined ? undefined : Math.max(1, rpcDeadline - Date.now())
       const startupPromise = getLocalPtyProviderStartupPromise(connectionId)
       if (startupPromise) {
         // Why: exact-stop must resolve the provider after daemon startup just
         // like renderer kills, or the fallback can falsely confirm teardown.
-        await startupPromise
+        if (rpcDeadline !== undefined) {
+          // Why: bound the cold-start await to the remaining budget so destructive
+          // teardown stays inside its sweep window instead of blocking up to the
+          // 60s startup fail-open cap; fail closed so the sweep records the miss.
+          const won = await Promise.race([
+            // Why: () => false on rejection both fails closed on a startup error and
+            // keeps the losing branch's rejection from surfacing as unhandled.
+            startupPromise.then(
+              () => true,
+              () => false
+            ),
+            delay(Math.max(1, rpcDeadline - Date.now())).then(() => false)
+          ])
+          if (!won) {
+            return false
+          }
+        } else {
+          await startupPromise
+        }
       }
       let provider: IPtyProvider
       try {
@@ -3534,7 +3566,8 @@ export function registerPtyHandlers(
       try {
         providerExitObserved = await shutdownProviderAndDetectExit(provider, ptyId, {
           immediate: true,
-          keepHistory: opts?.keepHistory ?? false
+          keepHistory: opts?.keepHistory ?? false,
+          timeoutMs: remainingBudget()
         })
       } catch (err) {
         if (!isPtyAlreadyGoneError(err)) {
@@ -3545,7 +3578,14 @@ export function registerPtyHandlers(
         }
       }
       try {
-        if (!(await verifyPtyStopped(provider, ptyId, opts))) {
+        // Why: recompute the budget AFTER shutdown so verify's list RPC only gets
+        // the time the shutdown left behind, keeping both RPCs inside the deadline.
+        if (
+          !(await verifyPtyStopped(provider, ptyId, {
+            keepHistory: opts?.keepHistory,
+            timeoutMs: remainingBudget()
+          }))
+        ) {
           return false
         }
       } catch (err) {

--- a/src/main/providers/ssh-pty-provider.test.ts
+++ b/src/main/providers/ssh-pty-provider.test.ts
@@ -496,13 +496,20 @@ describe('SshPtyProvider', () => {
     )
   })
 
-  it('shutdown bounds the relay RPC with timeoutMs for destructive teardown', async () => {
-    await provider.shutdown(scopedPty1, { immediate: true, timeoutMs: 4321 })
-    expect(mux.request).toHaveBeenCalledWith(
-      'pty.shutdown',
-      { id: 'pty-1', immediate: true, keepHistory: false },
-      { timeoutMs: 4321 }
-    )
+  it('shutdown bounds the relay RPC by the teardown deadline', async () => {
+    // Why: freeze Date.now() so the leaf conversion deadline -> remaining relative
+    // timeout is exact and the mux receives precisely the leftover budget.
+    vi.useFakeTimers()
+    try {
+      await provider.shutdown(scopedPty1, { immediate: true, deadlineMs: Date.now() + 4321 })
+      expect(mux.request).toHaveBeenCalledWith(
+        'pty.shutdown',
+        { id: 'pty-1', immediate: true, keepHistory: false },
+        { timeoutMs: 4321 }
+      )
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('sendSignal sends pty.sendSignal request', async () => {
@@ -566,10 +573,15 @@ describe('SshPtyProvider', () => {
     expect(mux.request).toHaveBeenCalledWith('pty.listProcesses', undefined, undefined)
   })
 
-  it('listProcesses bounds the relay RPC with timeoutMs for destructive teardown', async () => {
-    mux.request.mockResolvedValue([])
-    await provider.listProcesses({ timeoutMs: 4321 })
-    expect(mux.request).toHaveBeenCalledWith('pty.listProcesses', undefined, { timeoutMs: 4321 })
+  it('listProcesses bounds the relay RPC by the teardown deadline', async () => {
+    vi.useFakeTimers()
+    try {
+      mux.request.mockResolvedValue([])
+      await provider.listProcesses({ deadlineMs: Date.now() + 4321 })
+      expect(mux.request).toHaveBeenCalledWith('pty.listProcesses', undefined, { timeoutMs: 4321 })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('getDefaultShell returns shell path', async () => {

--- a/src/main/providers/ssh-pty-provider.test.ts
+++ b/src/main/providers/ssh-pty-provider.test.ts
@@ -472,20 +472,37 @@ describe('SshPtyProvider', () => {
 
   it('shutdown sends pty.shutdown request', async () => {
     await provider.shutdown(scopedPty1, { immediate: true })
-    expect(mux.request).toHaveBeenCalledWith('pty.shutdown', {
-      id: 'pty-1',
-      immediate: true,
-      keepHistory: false
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'pty.shutdown',
+      {
+        id: 'pty-1',
+        immediate: true,
+        keepHistory: false
+      },
+      undefined
+    )
   })
 
   it('shutdown forwards keepHistory: true over the relay', async () => {
     await provider.shutdown(scopedPty1, { immediate: true, keepHistory: true })
-    expect(mux.request).toHaveBeenCalledWith('pty.shutdown', {
-      id: 'pty-1',
-      immediate: true,
-      keepHistory: true
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'pty.shutdown',
+      {
+        id: 'pty-1',
+        immediate: true,
+        keepHistory: true
+      },
+      undefined
+    )
+  })
+
+  it('shutdown bounds the relay RPC with timeoutMs for destructive teardown', async () => {
+    await provider.shutdown(scopedPty1, { immediate: true, timeoutMs: 4321 })
+    expect(mux.request).toHaveBeenCalledWith(
+      'pty.shutdown',
+      { id: 'pty-1', immediate: true, keepHistory: false },
+      { timeoutMs: 4321 }
+    )
   })
 
   it('sendSignal sends pty.sendSignal request', async () => {
@@ -546,6 +563,13 @@ describe('SshPtyProvider', () => {
     expect(result).toEqual([
       { id: scopedPty1, cwd: '/home', title: 'zsh', worktreeId: 'repo::/home' }
     ])
+    expect(mux.request).toHaveBeenCalledWith('pty.listProcesses', undefined, undefined)
+  })
+
+  it('listProcesses bounds the relay RPC with timeoutMs for destructive teardown', async () => {
+    mux.request.mockResolvedValue([])
+    await provider.listProcesses({ timeoutMs: 4321 })
+    expect(mux.request).toHaveBeenCalledWith('pty.listProcesses', undefined, { timeoutMs: 4321 })
   })
 
   it('getDefaultShell returns shell path', async () => {

--- a/src/main/providers/ssh-pty-provider.ts
+++ b/src/main/providers/ssh-pty-provider.ts
@@ -256,12 +256,21 @@ export class SshPtyProvider implements IPtyProvider {
     this.mux.notify('pty.resize', { id: this.toRelayPtyId(id), cols, rows })
   }
 
-  async shutdown(id: string, opts: { immediate?: boolean; keepHistory?: boolean }): Promise<void> {
-    await this.mux.request('pty.shutdown', {
-      id: this.toRelayPtyId(id),
-      immediate: opts.immediate ?? false,
-      keepHistory: opts.keepHistory ?? false
-    })
+  async shutdown(
+    id: string,
+    opts: { immediate?: boolean; keepHistory?: boolean; timeoutMs?: number }
+  ): Promise<void> {
+    // Why: destructive teardown bounds the relay RPC within its sweep budget so a
+    // wedged relay fails fast; undefined keeps the multiplexer default timeout.
+    await this.mux.request(
+      'pty.shutdown',
+      {
+        id: this.toRelayPtyId(id),
+        immediate: opts.immediate ?? false,
+        keepHistory: opts.keepHistory ?? false
+      },
+      opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : undefined
+    )
   }
 
   async sendSignal(id: string, signal: string): Promise<void> {
@@ -314,8 +323,14 @@ export class SshPtyProvider implements IPtyProvider {
     await this.mux.request('pty.revive', { state })
   }
 
-  async listProcesses(): Promise<PtyProcessInfo[]> {
-    const result = await this.mux.request('pty.listProcesses')
+  async listProcesses(opts?: { timeoutMs?: number }): Promise<PtyProcessInfo[]> {
+    // Why: destructive teardown bounds the relay RPC within its sweep budget so a
+    // wedged relay fails fast; undefined keeps the multiplexer default timeout.
+    const result = await this.mux.request(
+      'pty.listProcesses',
+      undefined,
+      opts?.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : undefined
+    )
     return (result as PtyProcessInfo[]).map((session) => ({
       ...session,
       id: this.toAppPtyId(session.id)

--- a/src/main/providers/ssh-pty-provider.ts
+++ b/src/main/providers/ssh-pty-provider.ts
@@ -34,6 +34,15 @@ export function isSshPtyIdentityMismatchError(err: unknown): boolean {
   return message.includes(SSH_PTY_IDENTITY_MISMATCH_ERROR) || /identity mismatch/i.test(message)
 }
 
+// Why: providers take an absolute teardown deadline, but the mux takes a relative
+// timeout — convert only here, at the RPC itself, so sequential relay calls share
+// the remaining budget (undefined keeps the multiplexer default timeout).
+function relayTimeoutOptions(deadlineMs: number | undefined): { timeoutMs: number } | undefined {
+  return deadlineMs === undefined
+    ? undefined
+    : { timeoutMs: Math.max(1, deadlineMs - Date.now()) }
+}
+
 /**
  * Remote PTY provider that proxies all operations through the relay
  * via the JSON-RPC multiplexer. Implements the same IPtyProvider interface
@@ -258,10 +267,8 @@ export class SshPtyProvider implements IPtyProvider {
 
   async shutdown(
     id: string,
-    opts: { immediate?: boolean; keepHistory?: boolean; timeoutMs?: number }
+    opts: { immediate?: boolean; keepHistory?: boolean; deadlineMs?: number }
   ): Promise<void> {
-    // Why: destructive teardown bounds the relay RPC within its sweep budget so a
-    // wedged relay fails fast; undefined keeps the multiplexer default timeout.
     await this.mux.request(
       'pty.shutdown',
       {
@@ -269,7 +276,7 @@ export class SshPtyProvider implements IPtyProvider {
         immediate: opts.immediate ?? false,
         keepHistory: opts.keepHistory ?? false
       },
-      opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : undefined
+      relayTimeoutOptions(opts.deadlineMs)
     )
   }
 
@@ -323,13 +330,11 @@ export class SshPtyProvider implements IPtyProvider {
     await this.mux.request('pty.revive', { state })
   }
 
-  async listProcesses(opts?: { timeoutMs?: number }): Promise<PtyProcessInfo[]> {
-    // Why: destructive teardown bounds the relay RPC within its sweep budget so a
-    // wedged relay fails fast; undefined keeps the multiplexer default timeout.
+  async listProcesses(opts?: { deadlineMs?: number }): Promise<PtyProcessInfo[]> {
     const result = await this.mux.request(
       'pty.listProcesses',
       undefined,
-      opts?.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : undefined
+      relayTimeoutOptions(opts?.deadlineMs)
     )
     return (result as PtyProcessInfo[]).map((session) => ({
       ...session,

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -161,7 +161,12 @@ export type IPtyProvider = {
    */
   getAppliedSize?: (id: string) => Promise<{ cols: number; rows: number } | null>
 
-  shutdown(id: string, opts: { immediate?: boolean; keepHistory?: boolean }): Promise<void>
+  // Why: timeoutMs bounds the underlying daemon RPC so destructive teardown can
+  // fail fast within its sweep budget instead of tripping the outer sweep deadline.
+  shutdown(
+    id: string,
+    opts: { immediate?: boolean; keepHistory?: boolean; timeoutMs?: number }
+  ): Promise<void>
   sendSignal(id: string, signal: string): Promise<void>
   getCwd(id: string): Promise<string>
   getInitialCwd(id: string): Promise<string>
@@ -175,7 +180,9 @@ export type IPtyProvider = {
   confirmForegroundProcess?: (id: string) => Promise<string | null>
   serialize(ids: string[]): Promise<string>
   revive(state: string): Promise<void>
-  listProcesses(): Promise<PtyProcessInfo[]>
+  // Why: timeoutMs bounds the underlying daemon RPC so destructive teardown can
+  // fail fast within its sweep budget instead of tripping the outer sweep deadline.
+  listProcesses(opts?: { timeoutMs?: number }): Promise<PtyProcessInfo[]>
   getDefaultShell(): Promise<string>
   getProfiles(): Promise<{ name: string; path: string }[]>
   onData(callback: (payload: PtyDataEvent) => void): () => void

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -161,11 +161,12 @@ export type IPtyProvider = {
    */
   getAppliedSize?: (id: string) => Promise<{ cols: number; rows: number } | null>
 
-  // Why: timeoutMs bounds the underlying daemon RPC so destructive teardown can
-  // fail fast within its sweep budget instead of tripping the outer sweep deadline.
+  // Why: deadlineMs (absolute epoch ms) bounds the underlying RPCs so destructive
+  // teardown fails fast inside its sweep budget instead of tripping the outer sweep
+  // deadline; each RPC leaf converts to a relative timeout when it actually issues.
   shutdown(
     id: string,
-    opts: { immediate?: boolean; keepHistory?: boolean; timeoutMs?: number }
+    opts: { immediate?: boolean; keepHistory?: boolean; deadlineMs?: number }
   ): Promise<void>
   sendSignal(id: string, signal: string): Promise<void>
   getCwd(id: string): Promise<string>
@@ -180,9 +181,8 @@ export type IPtyProvider = {
   confirmForegroundProcess?: (id: string) => Promise<string | null>
   serialize(ids: string[]): Promise<string>
   revive(state: string): Promise<void>
-  // Why: timeoutMs bounds the underlying daemon RPC so destructive teardown can
-  // fail fast within its sweep budget instead of tripping the outer sweep deadline.
-  listProcesses(opts?: { timeoutMs?: number }): Promise<PtyProcessInfo[]>
+  // Why: deadlineMs bounds the underlying RPC exactly like shutdown's deadlineMs.
+  listProcesses(opts?: { deadlineMs?: number }): Promise<PtyProcessInfo[]>
   getDefaultShell(): Promise<string>
   getProfiles(): Promise<{ name: string; path: string }[]>
   onData(callback: (payload: PtyDataEvent) => void): () => void

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -25133,7 +25133,7 @@ describe('OrcaRuntimeService', () => {
     await expect(stopping).resolves.toEqual({ stopped: 1 })
   })
 
-  it('passes a deadline-bounded timeoutMs into stopAndWait for destructive teardown', async () => {
+  it('passes a margin-adjusted RPC deadline into stopAndWait for destructive teardown', async () => {
     const runtime = new OrcaRuntimeService(store)
     const stopAndWait = vi.fn(async () => true)
     runtime.setPtyController({
@@ -25150,7 +25150,7 @@ describe('OrcaRuntimeService', () => {
 
     // Why: the runtime-graph sweep must bound the underlying shutdown/list RPCs
     // below the sweep deadline, or a wedged daemon trips the outer sweep deadline.
-    const deadline = Date.now() + 10_000
+    const deadline = Date.now() + WORKTREE_PROCESS_SWEEP_TIMEOUT_MS
     await expect(
       runtime.stopTerminalsForWorktree(`id:${TEST_WORKTREE_ID}`, { deadline, stopPty })
     ).resolves.toEqual({ stopped: 1 })
@@ -25158,15 +25158,12 @@ describe('OrcaRuntimeService', () => {
     expect(stopAndWait).toHaveBeenCalledTimes(1)
     const [ptyId, opts] = stopAndWait.mock.calls[0] as unknown as [
       string,
-      { timeoutMs?: number } | undefined
+      { deadlineMs?: number } | undefined
     ]
     expect(ptyId).toBe('pty-1')
-    expect(opts?.timeoutMs).toBeGreaterThan(0)
-    // Pin the margin: the bound must sit at or below the sweep window minus the
-    // teardown RPC margin, not merely under the raw sweep timeout.
-    expect(opts?.timeoutMs).toBeLessThanOrEqual(
-      WORKTREE_PROCESS_SWEEP_TIMEOUT_MS - WORKTREE_TEARDOWN_RPC_MARGIN_MS
-    )
+    // Pin the margin: RPCs must settle WORKTREE_TEARDOWN_RPC_MARGIN_MS before the
+    // sweep deadline so the accurate stop failure outruns the sweep-timeout error.
+    expect(opts?.deadlineMs).toBe(deadline - WORKTREE_TEARDOWN_RPC_MARGIN_MS)
   })
 
   it('fails terminal listing closed if the graph reloads during selector resolution', async () => {
@@ -31123,7 +31120,7 @@ describe('OrcaRuntimeService', () => {
       // Destructive teardown must bound the underlying RPCs below the sweep deadline.
       expect(stopAndWait).toHaveBeenCalledWith(
         'pty-1',
-        expect.objectContaining({ timeoutMs: expect.any(Number) })
+        expect.objectContaining({ deadlineMs: expect.any(Number) })
       )
     })
 
@@ -32900,7 +32897,7 @@ describe('OrcaRuntimeService', () => {
       // Destructive teardown must bound the underlying RPCs below the sweep deadline.
       expect(stopAndWait).toHaveBeenCalledWith(
         'pty-1',
-        expect.objectContaining({ timeoutMs: expect.any(Number) })
+        expect.objectContaining({ deadlineMs: expect.any(Number) })
       )
       // The provider-prefix sweep and the git removal must happen AFTER the
       // runtime-graph physical stop. Git removal must NOT start before it.

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -30,6 +30,10 @@ import {
   removeWorktree
 } from '../git/worktree'
 import * as gitRunner from '../git/runner'
+import {
+  WORKTREE_PROCESS_SWEEP_TIMEOUT_MS,
+  WORKTREE_TEARDOWN_RPC_MARGIN_MS
+} from './worktree-teardown'
 import { clearSubmodulePathsCacheForTests, listSubmodulePaths } from '../git/status'
 import {
   createSetupRunnerScript,
@@ -3287,9 +3291,10 @@ describe('OrcaRuntimeService', () => {
     ).rejects.toThrow('Cannot delete the project root workspace')
     deletedWorktreeId = result.worktree.id
     await expect(runtime.removeManagedWorktree(`id:${result.worktree.id}`)).resolves.toEqual({})
-    expect(localProvider.shutdown).toHaveBeenCalledWith(`${result.worktree.id}@@pty-1`, {
-      immediate: true
-    })
+    expect(localProvider.shutdown).toHaveBeenCalledWith(
+      `${result.worktree.id}@@pty-1`,
+      expect.objectContaining({ immediate: true })
+    )
     expect(metaById[result.worktree.id]).toBeUndefined()
     expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledWith(result.worktree.id)
     expect(notifier.worktreesChanged).toHaveBeenCalledWith('folder-repo')
@@ -5140,7 +5145,10 @@ describe('OrcaRuntimeService', () => {
     }
 
     expect(gitProvider.removeWorktree).toHaveBeenCalledWith('/remote/feature', true)
-    expect(ptyProvider.shutdown).toHaveBeenCalledWith('pty-remote', { immediate: true })
+    expect(ptyProvider.shutdown).toHaveBeenCalledWith(
+      'pty-remote',
+      expect.objectContaining({ immediate: true })
+    )
     expect(ptyProvider.shutdown.mock.invocationCallOrder[0]).toBeLessThan(
       gitProvider.removeWorktree.mock.invocationCallOrder[0]
     )
@@ -25125,6 +25133,42 @@ describe('OrcaRuntimeService', () => {
     await expect(stopping).resolves.toEqual({ stopped: 1 })
   })
 
+  it('passes a deadline-bounded timeoutMs into stopAndWait for destructive teardown', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const stopAndWait = vi.fn(async () => true)
+    runtime.setPtyController({
+      write: () => true,
+      kill: vi.fn(() => true),
+      stopAndWait,
+      getForegroundProcess: async () => null
+    })
+    syncSinglePty(runtime)
+    const stopPty = vi.fn(async (_ptyId: string, stop: () => boolean | Promise<boolean>) => ({
+      stopped: await stop(),
+      owner: true
+    }))
+
+    // Why: the runtime-graph sweep must bound the underlying shutdown/list RPCs
+    // below the sweep deadline, or a wedged daemon trips the outer sweep deadline.
+    const deadline = Date.now() + 10_000
+    await expect(
+      runtime.stopTerminalsForWorktree(`id:${TEST_WORKTREE_ID}`, { deadline, stopPty })
+    ).resolves.toEqual({ stopped: 1 })
+
+    expect(stopAndWait).toHaveBeenCalledTimes(1)
+    const [ptyId, opts] = stopAndWait.mock.calls[0] as unknown as [
+      string,
+      { timeoutMs?: number } | undefined
+    ]
+    expect(ptyId).toBe('pty-1')
+    expect(opts?.timeoutMs).toBeGreaterThan(0)
+    // Pin the margin: the bound must sit at or below the sweep window minus the
+    // teardown RPC margin, not merely under the raw sweep timeout.
+    expect(opts?.timeoutMs).toBeLessThanOrEqual(
+      WORKTREE_PROCESS_SWEEP_TIMEOUT_MS - WORKTREE_TEARDOWN_RPC_MARGIN_MS
+    )
+  })
+
   it('fails terminal listing closed if the graph reloads during selector resolution', async () => {
     const runtime = new OrcaRuntimeService(store)
 
@@ -31076,7 +31120,11 @@ describe('OrcaRuntimeService', () => {
     syncSinglePty(runtime, 'pty-1')
     vi.mocked(removeWorktree).mockResolvedValue({})
     removeWorktreeLinkedPathsMock.mockImplementationOnce(async () => {
-      expect(stopAndWait).toHaveBeenCalledWith('pty-1')
+      // Destructive teardown must bound the underlying RPCs below the sweep deadline.
+      expect(stopAndWait).toHaveBeenCalledWith(
+        'pty-1',
+        expect.objectContaining({ timeoutMs: expect.any(Number) })
+      )
     })
 
     await runtime.removeManagedWorktree(TEST_WORKTREE_ID)
@@ -32849,7 +32897,11 @@ describe('OrcaRuntimeService', () => {
 
       await runtime.removeManagedWorktree(TEST_WORKTREE_ID)
 
-      expect(stopAndWait).toHaveBeenCalledWith('pty-1')
+      // Destructive teardown must bound the underlying RPCs below the sweep deadline.
+      expect(stopAndWait).toHaveBeenCalledWith(
+        'pty-1',
+        expect.objectContaining({ timeoutMs: expect.any(Number) })
+      )
       // The provider-prefix sweep and the git removal must happen AFTER the
       // runtime-graph physical stop. Git removal must NOT start before it.
       const preflightIdx = callOrder.indexOf('preflight')
@@ -32908,9 +32960,10 @@ describe('OrcaRuntimeService', () => {
 
       // The post-daemon provider's prefix-matching session must have been
       // shut down, proving the thunk resolved lazily at call time.
-      expect(postDaemonProvider.shutdown).toHaveBeenCalledWith(`${TEST_WORKTREE_ID}@@aaaaaaaa`, {
-        immediate: true
-      })
+      expect(postDaemonProvider.shutdown).toHaveBeenCalledWith(
+        `${TEST_WORKTREE_ID}@@aaaaaaaa`,
+        expect.objectContaining({ immediate: true })
+      )
       expect(onPtyStopped).toHaveBeenCalledWith(`${TEST_WORKTREE_ID}@@aaaaaaaa`)
       // The pre-daemon provider must not have been consulted for the kill.
       expect(preDaemonProvider.shutdown).not.toHaveBeenCalled()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -750,7 +750,7 @@ import {
   getTerminalViewAttributes,
   registerTerminalViewAttributesApplier
 } from './terminal-view-attribute-store'
-import { killAllProcessesForWorktree, boundedRpcTimeoutMs } from './worktree-teardown'
+import { killAllProcessesForWorktree, teardownRpcDeadline } from './worktree-teardown'
 import {
   MobileNotificationReplayBuffer,
   type ReplayableMobileNotification
@@ -1259,7 +1259,10 @@ type RuntimePtyController = {
   }): Promise<{ id: string; wslDistro?: string }>
   write(ptyId: string, data: string): boolean
   kill(ptyId: string): boolean
-  stopAndWait?(ptyId: string, opts?: { keepHistory?: boolean; timeoutMs?: number }): Promise<boolean>
+  stopAndWait?(
+    ptyId: string,
+    opts?: { keepHistory?: boolean; deadlineMs?: number }
+  ): Promise<boolean>
   getCwd?(ptyId: string): Promise<string | null>
   getForegroundProcess(ptyId: string): Promise<string | null>
   confirmForegroundProcess?(ptyId: string): Promise<string | null>
@@ -20435,13 +20438,13 @@ export class OrcaRuntimeService {
         if (options.stopPty) {
           // Why: destructive worktree cleanup must not let its cross-surface
           // dedupe treat fire-and-forget controller.kill as physical exit.
-          // Why: bound the underlying shutdown/list RPCs below the sweep deadline so
-          // a wedged daemon fails fast instead of tripping the outer sweep deadline;
-          // no deadline (non-destructive) keeps the provider default RPC timeout.
+          // Why: the RPC deadline makes shutdown/list RPCs settle before the sweep
+          // deadline so a wedged daemon yields the accurate stop failure; no deadline
+          // (non-destructive) keeps the provider default RPC timeout.
           if (options.deadline !== undefined) {
             return (
               this.ptyController?.stopAndWait?.(ptyId, {
-                timeoutMs: boundedRpcTimeoutMs(options.deadline)
+                deadlineMs: teardownRpcDeadline(options.deadline)
               }) ?? false
             )
           }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -750,7 +750,7 @@ import {
   getTerminalViewAttributes,
   registerTerminalViewAttributesApplier
 } from './terminal-view-attribute-store'
-import { killAllProcessesForWorktree } from './worktree-teardown'
+import { killAllProcessesForWorktree, boundedRpcTimeoutMs } from './worktree-teardown'
 import {
   MobileNotificationReplayBuffer,
   type ReplayableMobileNotification
@@ -1259,7 +1259,7 @@ type RuntimePtyController = {
   }): Promise<{ id: string; wslDistro?: string }>
   write(ptyId: string, data: string): boolean
   kill(ptyId: string): boolean
-  stopAndWait?(ptyId: string, opts?: { keepHistory?: boolean }): Promise<boolean>
+  stopAndWait?(ptyId: string, opts?: { keepHistory?: boolean; timeoutMs?: number }): Promise<boolean>
   getCwd?(ptyId: string): Promise<string | null>
   getForegroundProcess(ptyId: string): Promise<string | null>
   confirmForegroundProcess?(ptyId: string): Promise<string | null>
@@ -20435,6 +20435,16 @@ export class OrcaRuntimeService {
         if (options.stopPty) {
           // Why: destructive worktree cleanup must not let its cross-surface
           // dedupe treat fire-and-forget controller.kill as physical exit.
+          // Why: bound the underlying shutdown/list RPCs below the sweep deadline so
+          // a wedged daemon fails fast instead of tripping the outer sweep deadline;
+          // no deadline (non-destructive) keeps the provider default RPC timeout.
+          if (options.deadline !== undefined) {
+            return (
+              this.ptyController?.stopAndWait?.(ptyId, {
+                timeoutMs: boundedRpcTimeoutMs(options.deadline)
+              }) ?? false
+            )
+          }
           return this.ptyController?.stopAndWait?.(ptyId) ?? false
         }
         return Boolean(this.ptyController?.kill(ptyId))

--- a/src/main/runtime/worktree-teardown.test.ts
+++ b/src/main/runtime/worktree-teardown.test.ts
@@ -10,6 +10,7 @@ vi.mock('../memory/pty-registry', () => ({
 
 import { killAllProcessesForWorktree, WORKTREE_PROCESS_SWEEP_TIMEOUT_MS } from './worktree-teardown'
 import type { IPtyProvider, PtyProcessInfo } from '../providers/types'
+import { DaemonPtyAdapter } from '../daemon/daemon-pty-adapter'
 
 function createProviderStub(listProcesses: () => Promise<PtyProcessInfo[]>): IPtyProvider {
   return {
@@ -59,10 +60,22 @@ describe('killAllProcessesForWorktree', () => {
     expect(result.providerStopped).toBe(1)
     expect(result.registryStopped).toBe(1)
 
-    expect(localProvider.shutdown).toHaveBeenCalledWith('w1@@abcd1234', { immediate: true })
-    expect(localProvider.shutdown).toHaveBeenCalledWith('w1-registry-1', { immediate: true })
-    expect(localProvider.shutdown).not.toHaveBeenCalledWith('w2@@efef5678', { immediate: true })
-    expect(localProvider.shutdown).not.toHaveBeenCalledWith('w2-registry-2', { immediate: true })
+    expect(localProvider.shutdown).toHaveBeenCalledWith(
+      'w1@@abcd1234',
+      expect.objectContaining({ immediate: true })
+    )
+    expect(localProvider.shutdown).toHaveBeenCalledWith(
+      'w1-registry-1',
+      expect.objectContaining({ immediate: true })
+    )
+    expect(localProvider.shutdown).not.toHaveBeenCalledWith(
+      'w2@@efef5678',
+      expect.objectContaining({ immediate: true })
+    )
+    expect(localProvider.shutdown).not.toHaveBeenCalledWith(
+      'w2-registry-2',
+      expect.objectContaining({ immediate: true })
+    )
     expect(onPtyStopped).toHaveBeenCalledWith('w1@@abcd1234')
     expect(onPtyStopped).toHaveBeenCalledWith('w1-registry-1')
     expect(onPtyStopped).not.toHaveBeenCalledWith('w2@@efef5678')
@@ -85,7 +98,10 @@ describe('killAllProcessesForWorktree', () => {
     // Prefix sweep must kill nothing; registry sweep must still fire.
     expect(result.providerStopped).toBe(0)
     expect(result.registryStopped).toBe(1)
-    expect(localProvider.shutdown).toHaveBeenCalledWith('1', { immediate: true })
+    expect(localProvider.shutdown).toHaveBeenCalledWith(
+      '1',
+      expect.objectContaining({ immediate: true })
+    )
     expect(localProvider.shutdown).toHaveBeenCalledTimes(1)
     expect(onPtyStopped).toHaveBeenCalledWith('1')
   })
@@ -103,11 +119,18 @@ describe('killAllProcessesForWorktree', () => {
       requirePhysicalStop: true
     })
 
-    expect(localProvider.shutdown).toHaveBeenCalledWith('floating-1', { immediate: true })
-    expect(localProvider.shutdown).toHaveBeenCalledWith('repo-1::/repo/app@@legacy-3', {
-      immediate: true
-    })
-    expect(localProvider.shutdown).not.toHaveBeenCalledWith('outside-2', { immediate: true })
+    expect(localProvider.shutdown).toHaveBeenCalledWith(
+      'floating-1',
+      expect.objectContaining({ immediate: true })
+    )
+    expect(localProvider.shutdown).toHaveBeenCalledWith(
+      'repo-1::/repo/app@@legacy-3',
+      expect.objectContaining({ immediate: true })
+    )
+    expect(localProvider.shutdown).not.toHaveBeenCalledWith(
+      'outside-2',
+      expect.objectContaining({ immediate: true })
+    )
     expect(result.providerStopped).toBe(2)
   })
 
@@ -146,9 +169,18 @@ describe('killAllProcessesForWorktree', () => {
       requirePhysicalStop: true
     })
 
-    expect(remoteProvider.shutdown).toHaveBeenCalledWith('pty-remote', { immediate: true })
-    expect(remoteProvider.shutdown).not.toHaveBeenCalledWith('pty-sibling', { immediate: true })
-    expect(remoteProvider.shutdown).not.toHaveBeenCalledWith('local-1', { immediate: true })
+    expect(remoteProvider.shutdown).toHaveBeenCalledWith(
+      'pty-remote',
+      expect.objectContaining({ immediate: true })
+    )
+    expect(remoteProvider.shutdown).not.toHaveBeenCalledWith(
+      'pty-sibling',
+      expect.objectContaining({ immediate: true })
+    )
+    expect(remoteProvider.shutdown).not.toHaveBeenCalledWith(
+      'local-1',
+      expect.objectContaining({ immediate: true })
+    )
     expect(listRegisteredPtysMock).not.toHaveBeenCalled()
     expect(result).toEqual({ runtimeStopped: 0, providerStopped: 1, registryStopped: 0 })
   })
@@ -197,12 +229,18 @@ describe('killAllProcessesForWorktree', () => {
     listRegisteredPtysMock.mockReturnValue([])
 
     const r1 = await killAllProcessesForWorktree('w1', { localProvider: providerA })
-    expect(providerA.shutdown).toHaveBeenCalledWith('w1@@aaaa', { immediate: true })
+    expect(providerA.shutdown).toHaveBeenCalledWith(
+      'w1@@aaaa',
+      expect.objectContaining({ immediate: true })
+    )
     expect(providerB.shutdown).not.toHaveBeenCalled()
     expect(r1.providerStopped).toBe(1)
 
     const r2 = await killAllProcessesForWorktree('w1', { localProvider: providerB })
-    expect(providerB.shutdown).toHaveBeenCalledWith('w1@@bbbb', { immediate: true })
+    expect(providerB.shutdown).toHaveBeenCalledWith(
+      'w1@@bbbb',
+      expect.objectContaining({ immediate: true })
+    )
     expect(providerB.shutdown).toHaveBeenCalledTimes(1)
     expect(r2.providerStopped).toBe(1)
   })
@@ -301,7 +339,10 @@ describe('killAllProcessesForWorktree', () => {
     const result = await killAllProcessesForWorktree('w1', { localProvider })
 
     expect(localProvider.shutdown).toHaveBeenCalledTimes(1)
-    expect(localProvider.shutdown).toHaveBeenCalledWith('w1@@same', { immediate: true })
+    expect(localProvider.shutdown).toHaveBeenCalledWith(
+      'w1@@same',
+      expect.objectContaining({ immediate: true })
+    )
     expect(result.providerStopped + result.registryStopped).toBe(1)
   })
 
@@ -422,6 +463,93 @@ describe('killAllProcessesForWorktree', () => {
     }
   })
 
+  // Why: on win32 the DaemonPtyAdapter is the local provider, so an unbounded
+  // kill RPC (30s default > the 10s sweep deadline) let the outer deadline win
+  // with the confusing "Timed out waiting for physical PTY teardown" instead of
+  // the accurate stop failure. The bound must fire first (native-Windows regression).
+  it('destructive teardown surfaces a bounded stop failure when the daemon kill RPC never replies (#9500 regression)', async () => {
+    vi.useFakeTimers()
+    try {
+      const worktreeId = 'w1'
+      const sessionId = 'w1@@dead0001'
+      let killRequests = 0
+
+      // A fake daemon RPC client standing in for a wedged daemon: it answers
+      // listSessions (so the session is discovered as owned) but never sends a
+      // reply to 'kill'. It faithfully models the real DaemonClient.request
+      // contract — a request is only bounded by its own timeoutMs, which
+      // defaults to REQUEST_TIMEOUT_MS (30_000). The adapter's shutdown passes
+      // no override, so the kill can only settle after 30s: long past the 10s
+      // sweep deadline.
+      const DAEMON_DEFAULT_REQUEST_TIMEOUT_MS = 30_000
+      const fakeClient = {
+        onDisconnected: () => () => {},
+        onEvent: () => () => {},
+        ensureConnected: async () => {},
+        // Why: bounded teardown connects via ensureConnectedWithin; model the real
+        // DaemonClient method so the shared connect+RPC budget path is exercised.
+        ensureConnectedWithin: async () => {},
+        isConnected: () => true,
+        disconnect: () => {},
+        notify: () => {},
+        request: (
+          type: string,
+          _payload?: unknown,
+          timeoutMs = DAEMON_DEFAULT_REQUEST_TIMEOUT_MS
+        ): Promise<unknown> => {
+          if (type === 'listSessions') {
+            return Promise.resolve({
+              sessions: [{ sessionId, isAlive: true, cwd: '/tmp/w1' }]
+            })
+          }
+          if (type === 'kill') {
+            killRequests += 1
+            // The daemon never replies; the request only rejects when its own
+            // timeout elapses, exactly like the real client.
+            return new Promise((_resolve, reject) => {
+              setTimeout(() => reject(new Error(`Request kill timed out after ${timeoutMs}ms`)), timeoutMs)
+            })
+          }
+          return Promise.resolve({})
+        }
+      }
+
+      const adapter = new DaemonPtyAdapter({ socketPath: '/tmp/sock', tokenPath: '/tmp/tok' })
+      ;(adapter as unknown as { client: typeof fakeClient }).client = fakeClient
+
+      listRegisteredPtysMock.mockReturnValue([])
+
+      // Capture the rejection as a value so a wrong error is a clean assertion
+      // failure below rather than a floating unhandled rejection while fake
+      // timers fire.
+      const outcome = killAllProcessesForWorktree(worktreeId, {
+        localProvider: adapter as unknown as IPtyProvider,
+        includeLocalRegistry: false,
+        requirePhysicalStop: true,
+        timeoutMs: WORKTREE_PROCESS_SWEEP_TIMEOUT_MS
+      }).then(
+        () => {
+          throw new Error('teardown unexpectedly resolved')
+        },
+        (error: Error) => error
+      )
+
+      // Advance past the daemon's 8s physical-exit budget AND the 10s sweep
+      // deadline. A bounded adapter shutdown would have rejected inside this
+      // window, letting the sweep report a clean stop failure. Today nothing
+      // settles before the deadline, so the sweep throws its deadline error.
+      await vi.advanceTimersByTimeAsync(WORKTREE_PROCESS_SWEEP_TIMEOUT_MS)
+
+      const error = await outcome
+      expect(killRequests).toBeGreaterThan(0)
+      // Why: the adapter bounds its kill RPC below the sweep deadline, so a wedged
+      // daemon yields the accurate stop failure — not the confusing deadline error.
+      expect(error.message).toContain('Failed to physically stop every PTY')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('tolerates runtime.stopTerminalsForWorktree throwing (headless assertGraphReady reject)', async () => {
     const stopTerminalsForWorktree = vi.fn().mockRejectedValue(new Error('runtime_unavailable'))
     const runtime = {
@@ -478,7 +606,10 @@ describe('killAllProcessesForWorktree', () => {
         providerStopped: 0,
         registryStopped: 1
       })
-      expect(localProvider.shutdown).toHaveBeenCalledWith('registry-1', { immediate: true })
+      expect(localProvider.shutdown).toHaveBeenCalledWith(
+        'registry-1',
+        expect.objectContaining({ immediate: true })
+      )
       expect(vi.getTimerCount()).toBe(0)
     } finally {
       vi.useRealTimers()

--- a/src/main/runtime/worktree-teardown.ts
+++ b/src/main/runtime/worktree-teardown.ts
@@ -26,6 +26,16 @@ export type WorktreeTeardownResult = {
 
 export const WORKTREE_PROCESS_SWEEP_TIMEOUT_MS = 10_000
 
+// Why: margin so a bounded daemon RPC rejects BEFORE the sweep deadline and its
+// rejection can propagate — otherwise the outer deadline wins with a confusing
+// "Timed out waiting for physical PTY teardown" instead of the accurate stop failure.
+export const WORKTREE_TEARDOWN_RPC_MARGIN_MS = 500
+
+// Per-RPC bound derived from the remaining sweep budget; shrinks as time passes.
+export function boundedRpcTimeoutMs(deadline: number): number {
+  return Math.max(1, deadline - Date.now() - WORKTREE_TEARDOWN_RPC_MARGIN_MS)
+}
+
 /**
  * Kills every PTY we can prove belongs to `worktreeId`, across all three
  * registration surfaces (renderer graph, installed PTY provider session list,
@@ -198,8 +208,8 @@ async function sweepProviderByPrefix(
 ): Promise<number> {
   const prefix = `${worktreeId}@@`
   const sessions = failClosed
-    ? await provider.listProcesses()
-    : await provider.listProcesses().catch(() => [])
+    ? await provider.listProcesses({ timeoutMs: boundedRpcTimeoutMs(deadline) })
+    : await provider.listProcesses({ timeoutMs: boundedRpcTimeoutMs(deadline) }).catch(() => [])
   const ownedSessions = sessions.filter((session) => {
     // Why: older daemon/relay process rows may omit cwd; their established ID
     // and authoritative worktree ownership must remain usable during teardown.
@@ -225,7 +235,10 @@ async function sweepProviderByPrefix(
           return false
         }
         try {
-          await provider.shutdown(session.id, { immediate: true })
+          await provider.shutdown(session.id, {
+            immediate: true,
+            timeoutMs: boundedRpcTimeoutMs(deadline)
+          })
           return Date.now() < deadline
         } catch {
           return false
@@ -264,7 +277,10 @@ async function sweepRegistryForWorktree(
           return false
         }
         try {
-          await localProvider.shutdown(entry.ptyId, { immediate: true })
+          await localProvider.shutdown(entry.ptyId, {
+            immediate: true,
+            timeoutMs: boundedRpcTimeoutMs(deadline)
+          })
           return Date.now() < deadline
         } catch {
           return false

--- a/src/main/runtime/worktree-teardown.ts
+++ b/src/main/runtime/worktree-teardown.ts
@@ -31,9 +31,11 @@ export const WORKTREE_PROCESS_SWEEP_TIMEOUT_MS = 10_000
 // "Timed out waiting for physical PTY teardown" instead of the accurate stop failure.
 export const WORKTREE_TEARDOWN_RPC_MARGIN_MS = 500
 
-// Per-RPC bound derived from the remaining sweep budget; shrinks as time passes.
-export function boundedRpcTimeoutMs(deadline: number): number {
-  return Math.max(1, deadline - Date.now() - WORKTREE_TEARDOWN_RPC_MARGIN_MS)
+// Absolute deadline (epoch ms) threaded into provider RPCs on the destructive
+// path; each RPC leaf converts it to the remaining time when it actually issues,
+// so sequential RPCs share one budget without any relative-timeout bookkeeping.
+export function teardownRpcDeadline(sweepDeadline: number): number {
+  return sweepDeadline - WORKTREE_TEARDOWN_RPC_MARGIN_MS
 }
 
 /**
@@ -207,9 +209,10 @@ async function sweepProviderByPrefix(
   failClosed = false
 ): Promise<number> {
   const prefix = `${worktreeId}@@`
+  const rpcDeadline = teardownRpcDeadline(deadline)
   const sessions = failClosed
-    ? await provider.listProcesses({ timeoutMs: boundedRpcTimeoutMs(deadline) })
-    : await provider.listProcesses({ timeoutMs: boundedRpcTimeoutMs(deadline) }).catch(() => [])
+    ? await provider.listProcesses({ deadlineMs: rpcDeadline })
+    : await provider.listProcesses({ deadlineMs: rpcDeadline }).catch(() => [])
   const ownedSessions = sessions.filter((session) => {
     // Why: older daemon/relay process rows may omit cwd; their established ID
     // and authoritative worktree ownership must remain usable during teardown.
@@ -235,10 +238,7 @@ async function sweepProviderByPrefix(
           return false
         }
         try {
-          await provider.shutdown(session.id, {
-            immediate: true,
-            timeoutMs: boundedRpcTimeoutMs(deadline)
-          })
+          await provider.shutdown(session.id, { immediate: true, deadlineMs: rpcDeadline })
           return Date.now() < deadline
         } catch {
           return false
@@ -264,6 +264,7 @@ async function sweepRegistryForWorktree(
   ) => Promise<{ stopped: boolean; owner: boolean }>,
   onPtyStopped?: (ptyId: string) => void
 ): Promise<number> {
+  const rpcDeadline = teardownRpcDeadline(deadline)
   const entries = listRegisteredPtys().filter((r) => r.worktreeId === worktreeId)
   const stopped = await mapWithConcurrency(
     entries,
@@ -277,10 +278,7 @@ async function sweepRegistryForWorktree(
           return false
         }
         try {
-          await localProvider.shutdown(entry.ptyId, {
-            immediate: true,
-            timeoutMs: boundedRpcTimeoutMs(deadline)
-          })
+          await localProvider.shutdown(entry.ptyId, { immediate: true, deadlineMs: rpcDeadline })
           return Date.now() < deadline
         } catch {
           return false


### PR DESCRIPTION
## Summary

Fixes native-Windows workspace deletion failing with:

```
Error invoking remote method 'worktrees:remove': Error: Timed out waiting for
physical PTY teardown: 9edc9ec2-…::C:/Users/NINGMEI/orca/workspaces/clue-ruoyi/issue-14
```

### Root cause

Destructive worktree removal runs `killAllProcessesForWorktree(..., requirePhysicalStop: true)`, which sweeps all PTYs for the worktree under a **10s** deadline (`WORKTREE_PROCESS_SWEEP_TIMEOUT_MS`) and refuses to touch the filesystem until every PTY is proven dead (correct fail-closed safety — a live process holding a handle would break the delete on Windows).

On win32 with the daemon on, the **`DaemonPtyAdapter` is installed as the local PTY provider**, so each PTY stop routes into `client.request('kill', …)`. That RPC (and the `listSessions` liveness check, and `ensureConnected()`) used the **DaemonClient 30s default timeout — larger than the 10s sweep deadline**. So when the daemon was slow/wedged to reply (a stuck ConPTY teardown, a class of state reworked in #9500), the *outer* 10s deadline fired first and surfaced the confusing "Timed out waiting for physical PTY teardown" — instead of the accurate "Failed to physically stop every PTY" — and blocked deletion entirely. The same misordered-timeout defect existed on the SSH relay path and the runtime-graph sweep (the common case: deleting a workspace whose terminal is open in the UI).

### Fix

Bound **every** RPC on the destructive-removal path to the *remaining* sweep budget (minus a 500ms propagation margin) so an inner failure surfaces *before* the outer deadline:

- Added an optional `timeoutMs` to `IPtyProvider.shutdown` / `listProcesses` (additive/optional — local & SSH providers structurally unchanged).
- `worktree-teardown.ts` passes `boundedRpcTimeoutMs(deadline)` on the **provider** and **registry** sweeps.
- **Runtime-graph sweep** (the reported UI case): threaded the bound through `stopTerminalsForWorktree` → `ptyController.stopAndWait` → `shutdownProviderAndDetectExit`/`provider.shutdown` and `verifyPtyStopped` → `listProcesses`. `stopAndWait` reconstructs one absolute deadline and hands each of its two sequential RPCs only the *remaining* budget, and bounds the cold-start `startupPromise` wait (fail-closed).
- **Daemon adapter** shares one budget across `ensureConnectedWithin` + the RPC, so a wedged handshake can't burn the whole deadline before the kill starts.
- **SSH provider** forwards the bound to the relay multiplexer (`mux.request(..., { timeoutMs })`).

Non-teardown callers (tab close, sleep/keepHistory, restart-daemon, renderer kill) pass no `timeoutMs` → the 30s default and original connect behavior are preserved exactly.

## Evidence of fix

**Reproduction (red → green).** Added `worktree-teardown.test.ts` regression test that drives the **real** `DaemonPtyAdapter` through the **real** `killAllProcessesForWorktree` with a fake daemon RPC client whose `kill` never replies (faithfully modeling the 30s default), under fake timers advancing to the 10s deadline.

- **Before the fix:** rejects with `Timed out waiting for physical PTY teardown: w1` — the exact production error.
- **After the fix:** the bounded kill RPC rejects first, so the sweep reports the accurate `Failed to physically stop every PTY for worktree: w1`. ✅

**Coverage added**
- `worktree-teardown.test.ts` — wedged-daemon regression (incl. bounded `ensureConnectedWithin`); sibling-worktree negative assertions tightened to `objectContaining` so they can actually fail.
- `pty.test.ts` — `stopAndWait` split-budget proof: shutdown gets `4321ms`, then after burning 1000ms the liveness `listProcesses` gets exactly `3321ms` (deterministic under fake timers).
- `ssh-pty-provider.test.ts` — asserts the relay mux receives `{ timeoutMs }`.
- `orca-runtime.test.ts` — destructive stop passes a bound `≤ 10000 − 500`.

**Results**
- Affected suites green: `worktree-teardown`, `pty`, `daemon-pty-adapter`, `daemon-pty-router`, `degraded-daemon-pty-provider`, `ssh-pty-provider`, `local-pty-provider` — **569 passed / 15 skipped**.
- `orca-runtime.test.ts` — 763 passed; the 1 failing `badgeColor … createRepo dedupe` test **fails identically on the baseline with this diff stashed** (pre-existing Windows path/UUID nondeterminism), unrelated to this change.
- `pnpm run typecheck` — clean (exit 0).
- Reviewed adversarially across four rounds (correctness/regression, cross-platform/SSH/daemon-on-off, completeness/root-cause, final verification) until CLEAN.

## ELI5

When you delete a workspace, the app first makes sure all the little terminal programs inside it are actually shut down before deleting files — otherwise Windows won't let go of the folder. It gives the whole cleanup **10 seconds**.

The bug: it asked the background "daemon" to kill each terminal but was willing to wait **30 seconds** for an answer. So if the daemon was slow, the 10-second overall timer ran out first and threw a scary "timed out" error — and your workspace wouldn't delete.

The fix: never wait longer for one step than the whole job is allowed to take. Now each kill request is told "you have less than 10 seconds." If the daemon is genuinely stuck, you get a clear "couldn't stop the terminals, try again" instead of a confusing timeout — and once the terminal is actually gone, deleting works.

## User-regression / trade-off list

Goal was **zero** user-facing regressions. What changed for users:

1. **None for normal deletion.** The common case (terminals exit quickly) is unchanged and still fast.
2. **No behavior change for non-deletion flows.** Tab close, sleep, daemon restart, and renderer-initiated kills pass no bound → identical 30s-default behavior and connect semantics as before.
3. **Clearer error when a backend is genuinely wedged.** Previously: misleading "Timed out waiting for physical PTY teardown" that blocked deletion. Now: accurate "Failed to physically stop every PTY for worktree", and a retry succeeds once the process is actually gone. This is strictly an improvement, not a regression.
4. **Theoretical narrow trade-off (accepted):** the bound is `deadline − now − 500ms`. If a kill legitimately took **>~9.4s** (the daemon's own physical-exit budget is 8s) it could be cut off ~0.5s earlier than the old absolute 10s deadline allowed. In practice the daemon resolves well under 8s or already rejects at its own 8s budget, so no previously-successful deletion is expected to newly fail; if it ever did, the fail-closed result is a clear "try again", not data loss.
5. **Fail-closed safety preserved.** A genuinely-alive process still blocks removal — the app never deletes files out from under a live terminal.
