### PR TITLE
fix(terminal): clear stale search highlights when find closes

### DIFF
--- a/src/renderer/src/components/TerminalSearch.test.tsx
+++ b/src/renderer/src/components/TerminalSearch.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import type { SearchAddon } from '@xterm/addon-search'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import TerminalSearch from './TerminalSearch'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+afterEach(cleanup)
+
+function createSearchAddon(): SearchAddon {
+  return {
+    findNext: vi.fn(() => true),
+    findPrevious: vi.fn(() => true),
+    clearDecorations: vi.fn()
+  } as unknown as SearchAddon
+}
+
+function renderSearch(searchAddon: SearchAddon): ReturnType<typeof render> {
+  return render(
+    <TerminalSearch
+      isOpen
+      onClose={vi.fn()}
+      searchAddon={searchAddon}
+      searchStateRef={{ current: { query: '', caseSensitive: false, regex: false } }}
+    />
+  )
+}
+
+describe('TerminalSearch cleanup', () => {
+  it('clears the current addon when the query is erased', async () => {
+    const addon = createSearchAddon()
+    const view = renderSearch(addon)
+
+    fireEvent.change(view.getByPlaceholderText('Search...'), { target: { value: 'needle' } })
+    await waitFor(() => expect(addon.findNext).toHaveBeenCalled())
+    vi.mocked(addon.clearDecorations).mockClear()
+    vi.mocked(addon.findNext).mockClear()
+
+    fireEvent.change(view.getByPlaceholderText('Search...'), { target: { value: '' } })
+
+    await waitFor(() => expect(addon.clearDecorations).toHaveBeenCalledTimes(1))
+    expect(addon.findNext).toHaveBeenCalledWith('')
+  })
+
+  it('clears the previous addon when the search moves to another pane', async () => {
+    const previousAddon = createSearchAddon()
+    const nextAddon = createSearchAddon()
+    const view = renderSearch(previousAddon)
+
+    fireEvent.change(view.getByPlaceholderText('Search...'), { target: { value: 'needle' } })
+    await waitFor(() => expect(previousAddon.findNext).toHaveBeenCalled())
+    vi.mocked(previousAddon.clearDecorations).mockClear()
+    vi.mocked(previousAddon.findNext).mockClear()
+
+    view.rerender(
+      <TerminalSearch
+        isOpen
+        onClose={vi.fn()}
+        searchAddon={nextAddon}
+        searchStateRef={{ current: { query: '', caseSensitive: false, regex: false } }}
+      />
+    )
+
+    expect(previousAddon.clearDecorations).toHaveBeenCalledTimes(1)
+    expect(previousAddon.findNext).toHaveBeenCalledWith('')
+  })
+
+  it('clears the addon when the search portal unmounts', async () => {
+    const addon = createSearchAddon()
+    const view = renderSearch(addon)
+
+    fireEvent.change(view.getByPlaceholderText('Search...'), { target: { value: 'needle' } })
+    await waitFor(() => expect(addon.findNext).toHaveBeenCalled())
+    vi.mocked(addon.clearDecorations).mockClear()
+    vi.mocked(addon.findNext).mockClear()
+
+    view.unmount()
+
+    expect(addon.clearDecorations).toHaveBeenCalledTimes(1)
+    expect(addon.findNext).toHaveBeenCalledWith('')
+  })
+})

--- a/src/renderer/src/components/TerminalSearch.tsx
+++ b/src/renderer/src/components/TerminalSearch.tsx
@@ -14,6 +14,15 @@ type TerminalSearchProps = {
   searchStateRef: React.RefObject<SearchState>
 }
 
+function clearTerminalSearch(searchAddon: SearchAddon | null): void {
+  if (!searchAddon) {
+    return
+  }
+  searchAddon.clearDecorations()
+  // Why: xterm keeps the active match selected after decorations are cleared.
+  searchAddon.findNext('')
+}
+
 export default function TerminalSearch({
   isOpen,
   onClose,
@@ -72,17 +81,24 @@ export default function TerminalSearch({
     input?.focus()
   }, [])
 
+  useEffect(
+    () => () => {
+      clearTerminalSearch(searchAddon)
+    },
+    [searchAddon]
+  )
+
   useEffect(() => {
     // Keep the ref in sync so the keyboard handler (Cmd+G / Cmd+Shift+G)
     // can read the current search state without lifting it to parent state.
     searchStateRef.current = { query: requestQuery ?? '', caseSensitive, regex }
 
     if (!isOpen) {
-      searchAddon?.clearDecorations()
+      clearTerminalSearch(searchAddon)
       return
     }
     if (!requestQuery) {
-      searchAddon?.clearDecorations()
+      clearTerminalSearch(searchAddon)
       return
     }
     if (searchAddon) {


### PR DESCRIPTION
# fix(terminal): clear stale search highlights when find closes

## Summary
Fixes stale terminal find highlights that lingered after the query was erased, the active pane changed, or the search overlay unmounted.

## ELI5
When you searched in the terminal and then cleared or closed the search, the highlighted match sometimes stayed lit up. Now it disappears the moment the search stops.

## Root cause & fix
`SearchAddon.clearDecorations()` removes xterm's painted match decorations but leaves the *active* match still selected, and `TerminalSearch` never cleaned up the previous addon when its portal moved to another pane or unmounted. The fix adds a `clearTerminalSearch()` helper that pairs `clearDecorations()` with a `findNext('')` empty-find request — xterm's path for dropping the active selection — and applies it on query erase, search-closed, addon change, and portal unmount. A separate addon-lifecycle effect keyed on `searchAddon` cleans the previous pane without resetting incremental search on every keystroke.

## Evidence
Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- Rebase: clean onto `origin/main` (base `8a23618310`, head `b20b6ecbc2`).
- Test file `src/renderer/src/components/TerminalSearch.test.tsx` (new) — **3/3 pass on branch**.
- Reverting only the fix (`TerminalSearch.tsx`) while keeping the test → **3/3 fail**, proving the tests catch the regression:

```
On branch:  Test Files 1 passed (1); Tests 3 passed (3)
Fix reverted:
  Test Files 1 failed (1); Tests 3 failed (3)
  - "clears the current addon when the query is erased":
      expected findNext called with [''], Number of calls: 0
  - "clears the previous addon when the search moves to another pane":
      expected clearDecorations called 1 time, got 0
  - "clears the addon when the search portal unmounts":
      expected clearDecorations called 1 time, got 0
```

- Lint: `npx oxlint src/renderer/src/components/TerminalSearch.tsx` — clean (no warnings/errors).

## Trade-offs
None — pure fix. (Searching history owned internally by an alternate-screen TUI remains a separate, pre-existing limitation, since that history is not in xterm's active buffer.)

## Regression risk
Effectively zero. The change is renderer-only and scoped to the terminal-search cleanup path: cleanup runs only when search is cleared/closed, the addon changes, or the portal unmounts. Non-affected code paths are byte-identical to `origin/main`, and the empty-find call short-circuits without scanning the buffer. The three regression tests prove correct behavior across all three failure paths.

_Credit to @kaynansc for the original fix. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved._
