### PR TITLE
fix(ssh): mirror local workspace layout for SSH project creation and worktree placement

### DIFF
--- a/src/main/ipc/worktree-base-directory-watch-targets.ts
+++ b/src/main/ipc/worktree-base-directory-watch-targets.ts
@@ -16,10 +16,12 @@ import {
 import { isWslUncPath } from '../../shared/wsl-paths'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import {
+  computeRemoteHomeWorkspaceRoot,
   computeWorkspaceRoot,
   getWorktreePathSettings,
   hasRepoWorktreeBasePath
 } from './worktree-logic'
+import { resolveSshRemoteHome } from '../ssh/ssh-remote-home'
 import { shouldEmitBoundedWarning } from './bounded-warning-dedupe'
 import { resolveWorktreeCommonGitDirectory } from './worktree-common-git-directory'
 import type {
@@ -99,25 +101,33 @@ function isRuntimePathAbsoluteForRepo(repoPath: string, pathValue: string): bool
   return isRuntimePathAbsolute(pathValue, pathFlavor)
 }
 
-function getBaseWatchLayout(
+async function getBaseWatchLayouts(
   repo: Repo,
   pathSettings: Pick<GlobalSettings, 'workspaceDir' | 'nestWorkspaces'>,
   connectionId: string | undefined
-): { workspaceRoot: string; nestWorkspaces: boolean } {
+): Promise<{ workspaceRoot: string; nestWorkspaces: boolean }[]> {
   if (
     connectionId &&
     !hasRepoWorktreeBasePath(repo) &&
     isRuntimePathAbsoluteForRepo(repo.path, pathSettings.workspaceDir)
   ) {
-    // Why: SSH creates default worktrees beside the remote repo when the
-    // global workspace dir is a desktop-local absolute path.
-    return { workspaceRoot: resolveRuntimePath(repo.path, '..'), nestWorkspaces: false }
+    // Why: SSH default placement mirrors the workspace layout under the remote
+    // home when the relay can resolve it, while worktrees created before that
+    // (or via older relays) sit beside the remote repo — watch both roots.
+    const layouts = [{ workspaceRoot: resolveRuntimePath(repo.path, '..'), nestWorkspaces: false }]
+    const remoteRoot = computeRemoteHomeWorkspaceRoot(await resolveSshRemoteHome(connectionId))
+    if (remoteRoot) {
+      layouts.push({ workspaceRoot: remoteRoot, nestWorkspaces: pathSettings.nestWorkspaces })
+    }
+    return layouts
   }
 
-  return {
-    workspaceRoot: computeWorkspaceRoot(repo.path, pathSettings),
-    nestWorkspaces: pathSettings.nestWorkspaces
-  }
+  return [
+    {
+      workspaceRoot: computeWorkspaceRoot(repo.path, pathSettings),
+      nestWorkspaces: pathSettings.nestWorkspaces
+    }
+  ]
 }
 
 async function maybeAddBaseTarget(
@@ -127,39 +137,43 @@ async function maybeAddBaseTarget(
   connectionId?: string
 ): Promise<void> {
   const pathSettings = getWorktreePathSettings(repo, settings)
-  const { workspaceRoot, nestWorkspaces } = getBaseWatchLayout(repo, pathSettings, connectionId)
-  // Why: WSL UNC roots are unreliable for native watching; avoid project-level polling.
-  if (isWslUncPath(workspaceRoot) || isWslUncPath(repo.path)) {
-    const key = `${repo.id}:${workspaceRoot}`
-    if (shouldEmitBoundedWarning(skippedWslWarnings, key)) {
-      console.warn(
-        `[worktree-base-watcher] skipping WSL worktree root watcher for ${workspaceRoot}`
-      )
-    }
-    return
-  }
-
-  const config = {
-    repoId: repo.id,
-    repoName: getRuntimePathBasename(repo.path).replace(/\.git$/, ''),
-    nestWorkspaces
-  }
+  const layouts = await getBaseWatchLayouts(repo, pathSettings, connectionId)
   const remoteProvider = getRemoteProvider(connectionId)
   if (connectionId && !remoteProvider) {
     return
   }
-  try {
-    const rootStat = remoteProvider
-      ? await remoteProvider.stat(workspaceRoot)
-      : await stat(workspaceRoot)
-    if (isDirectoryStat(rootStat)) {
-      await addTarget(targets, 'base', workspaceRoot, config, connectionId)
+  const repoName = getRuntimePathBasename(repo.path).replace(/\.git$/, '')
+  let config: { repoId: string; repoName: string; nestWorkspaces: boolean } | undefined
+  for (const { workspaceRoot, nestWorkspaces } of layouts) {
+    // Why: WSL UNC roots are unreliable for native watching; avoid project-level polling.
+    if (isWslUncPath(workspaceRoot) || isWslUncPath(repo.path)) {
+      const key = `${repo.id}:${workspaceRoot}`
+      if (shouldEmitBoundedWarning(skippedWslWarnings, key)) {
+        console.warn(
+          `[worktree-base-watcher] skipping WSL worktree root watcher for ${workspaceRoot}`
+        )
+      }
+      continue
     }
-  } catch {
-    const key = normalizeWatchKey(workspaceRoot)
-    if (shouldEmitBoundedWarning(missingRootWarnings, key)) {
-      console.warn(`[worktree-base-watcher] worktree root unavailable: ${workspaceRoot}`)
+
+    const layoutConfig = { repoId: repo.id, repoName, nestWorkspaces }
+    config ??= layoutConfig
+    try {
+      const rootStat = remoteProvider
+        ? await remoteProvider.stat(workspaceRoot)
+        : await stat(workspaceRoot)
+      if (isDirectoryStat(rootStat)) {
+        await addTarget(targets, 'base', workspaceRoot, layoutConfig, connectionId)
+      }
+    } catch {
+      const key = normalizeWatchKey(workspaceRoot)
+      if (shouldEmitBoundedWarning(missingRootWarnings, key)) {
+        console.warn(`[worktree-base-watcher] worktree root unavailable: ${workspaceRoot}`)
+      }
     }
+  }
+  if (!config) {
+    return
   }
 
   const commonDir = await resolveWorktreeCommonGitDirectory(

--- a/src/main/ipc/worktree-base-directory-watch-targets.ts
+++ b/src/main/ipc/worktree-base-directory-watch-targets.ts
@@ -7,8 +7,6 @@ import type { GlobalSettings, Repo } from '../../shared/types'
 import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
 import { isFolderRepo } from '../../shared/repo-kind'
 import {
-  isRuntimePathAbsolute,
-  isWindowsAbsolutePathLike,
   getRuntimePathBasename,
   normalizeRuntimePathForComparison,
   resolveRuntimePath
@@ -19,7 +17,8 @@ import {
   computeRemoteHomeWorkspaceRoot,
   computeWorkspaceRoot,
   getWorktreePathSettings,
-  hasRepoWorktreeBasePath
+  hasRepoWorktreeBasePath,
+  remoteWorktreePathUsesRemoteHome
 } from './worktree-logic'
 import { resolveSshRemoteHome } from '../ssh/ssh-remote-home'
 import { shouldEmitBoundedWarning } from './bounded-warning-dedupe'
@@ -93,14 +92,6 @@ function getRemoteProvider(connectionId: string | undefined): IFilesystemProvide
   return connectionId ? getSshFilesystemProvider(connectionId) : undefined
 }
 
-function isRuntimePathAbsoluteForRepo(repoPath: string, pathValue: string): boolean {
-  const pathFlavor =
-    isWindowsAbsolutePathLike(repoPath) || isWindowsAbsolutePathLike(pathValue)
-      ? 'windows'
-      : 'posix'
-  return isRuntimePathAbsolute(pathValue, pathFlavor)
-}
-
 async function getBaseWatchLayouts(
   repo: Repo,
   pathSettings: Pick<GlobalSettings, 'workspaceDir' | 'nestWorkspaces'>,
@@ -108,8 +99,9 @@ async function getBaseWatchLayouts(
 ): Promise<{ workspaceRoot: string; nestWorkspaces: boolean }[]> {
   if (
     connectionId &&
-    !hasRepoWorktreeBasePath(repo) &&
-    isRuntimePathAbsoluteForRepo(repo.path, pathSettings.workspaceDir)
+    remoteWorktreePathUsesRemoteHome(repo.path, pathSettings, {
+      useConfiguredAbsolutePath: hasRepoWorktreeBasePath(repo)
+    })
   ) {
     // Why: SSH default placement mirrors the workspace layout under the remote
     // home when the relay can resolve it, while worktrees created before that
@@ -143,10 +135,11 @@ async function maybeAddBaseTarget(
     return
   }
   const repoName = getRuntimePathBasename(repo.path).replace(/\.git$/, '')
+  const repoOnWslFilesystem = isWslUncPath(repo.path)
   let config: { repoId: string; repoName: string; nestWorkspaces: boolean } | undefined
   for (const { workspaceRoot, nestWorkspaces } of layouts) {
     // Why: WSL UNC roots are unreliable for native watching; avoid project-level polling.
-    if (isWslUncPath(workspaceRoot) || isWslUncPath(repo.path)) {
+    if (isWslUncPath(workspaceRoot) || repoOnWslFilesystem) {
       const key = `${repo.id}:${workspaceRoot}`
       if (shouldEmitBoundedWarning(skippedWslWarnings, key)) {
         console.warn(

--- a/src/main/ipc/worktree-base-directory-watcher.test.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.test.ts
@@ -23,11 +23,16 @@ vi.mock('../providers/ssh-filesystem-dispatch', () => ({
   getSshFilesystemProvider: vi.fn()
 }))
 
+vi.mock('./ssh', () => ({
+  getActiveMultiplexer: vi.fn()
+}))
+
 vi.mock('./worktree-head-identity-reader', () => ({
   readGitCommonHeadIdentities: vi.fn(async () => [])
 }))
 
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
+import { getActiveMultiplexer } from './ssh'
 import {
   notifyWorktreeGitStatusMetadataChanged,
   notifyWorktreeHeadIdentitiesChanged,
@@ -507,6 +512,42 @@ describe('worktree base directory watcher', () => {
     expect(notifyWorktreesChanged).toHaveBeenCalledWith(expect.anything(), 'repo-1')
     await disposeWorktreeBaseDirectoryWatchers()
     expect(remoteUnwatch).toHaveBeenCalled()
+  })
+
+  it('also watches the remote home workspace root when the relay resolves it', async () => {
+    const remoteCallbacks = new Map<string, (events: never[]) => void>()
+    const remoteWatch = vi.fn(async (root: string, callback: (events: never[]) => void) => {
+      remoteCallbacks.set(root, callback)
+      return vi.fn()
+    })
+    vi.mocked(getSshFilesystemProvider).mockReturnValue({
+      stat: vi.fn(async () => ({ type: 'directory', size: 0, mtime: 0 })),
+      realpath: vi.fn(async (path: string) => path),
+      readFile: vi.fn(async () => ({ content: '', isBinary: false })),
+      watch: remoteWatch
+    } as never)
+    vi.mocked(getActiveMultiplexer).mockReturnValue({
+      request: vi.fn(async (method: string) =>
+        method === 'session.resolveHome' ? { resolvedPath: '/home/alice' } : undefined
+      )
+    } as never)
+
+    await syncWorktreeBaseDirectoryWatchers(
+      makeStore([makeRepo({ connectionId: 'ssh-1', path: '/home/alice/work/project' })]) as never,
+      makeWindow() as never
+    )
+
+    expect(remoteWatch).toHaveBeenCalledWith('/home/alice/work', expect.any(Function))
+    expect(remoteWatch).toHaveBeenCalledWith('/home/alice/orca/workspaces', expect.any(Function))
+    remoteCallbacks.get('/home/alice/orca/workspaces')?.([
+      {
+        kind: 'create',
+        absolutePath: '/home/alice/orca/workspaces/project/feature-x/.git'
+      }
+    ] as never[])
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(notifyWorktreesChanged).toHaveBeenCalledWith(expect.anything(), 'repo-1')
   })
 
   it('treats remote index renames as status-only and overflow as structural', async () => {

--- a/src/main/ipc/worktree-logic.test.ts
+++ b/src/main/ipc/worktree-logic.test.ts
@@ -7,10 +7,13 @@ import {
   computeBranchName,
   getConfiguredBranchPrefix,
   computeWorktreePath,
+  computeRemoteHomeWorkspaceRoot,
   computeRemoteWorktreePath,
   computeWorkspaceRoot,
+  getRemoteWorktreeCreationLayout,
   getWorktreeCreationLayout,
   getWorktreePathSettings,
+  remoteWorktreePathUsesRemoteHome,
   shouldSetDisplayName,
   mergeWorktree,
   parseWorktreeId,
@@ -242,13 +245,113 @@ describe('computeWorktreePath', () => {
     ).toBe('C:\\Projects\\app\\worktrees\\feature')
   })
 
-  it('keeps legacy SSH sibling paths for global absolute workspace directories', () => {
+  it('keeps legacy SSH sibling paths when the remote home is unavailable', () => {
     expect(
       computeRemoteWorktreePath('feature', '/remote/repo', {
         nestWorkspaces: false,
         workspaceDir: '/local/workspaces'
       })
     ).toBe('/remote/feature')
+    expect(
+      computeRemoteWorktreePath(
+        'feature',
+        '/remote/repo',
+        { nestWorkspaces: true, workspaceDir: '/local/workspaces' },
+        { remoteHome: null }
+      )
+    ).toBe('/remote/feature')
+  })
+
+  it('mirrors the workspace layout under the SSH home for global absolute workspace directories', () => {
+    expect(
+      computeRemoteWorktreePath(
+        'feature',
+        '/remote/work/repo',
+        { nestWorkspaces: true, workspaceDir: '/local/workspaces' },
+        { remoteHome: '/home/user' }
+      )
+    ).toBe('/home/user/orca/workspaces/repo/feature')
+    expect(
+      computeRemoteWorktreePath(
+        'feature',
+        '/remote/work/repo.git',
+        { nestWorkspaces: true, workspaceDir: '/local/workspaces' },
+        { remoteHome: '/home/user/' }
+      )
+    ).toBe('/home/user/orca/workspaces/repo/feature')
+    expect(
+      computeRemoteWorktreePath(
+        'feature',
+        '/remote/work/repo',
+        { nestWorkspaces: false, workspaceDir: '/local/workspaces' },
+        { remoteHome: '/home/user' }
+      )
+    ).toBe('/home/user/orca/workspaces/feature')
+  })
+
+  it('mirrors the workspace layout under a Windows SSH home', () => {
+    expect(
+      computeRemoteWorktreePath(
+        'feature',
+        'C:\\Remote\\repo',
+        { nestWorkspaces: true, workspaceDir: '/local/workspaces' },
+        { remoteHome: 'C:\\Users\\user' }
+      )
+    ).toBe('C:\\Users\\user\\orca\\workspaces\\repo\\feature')
+  })
+
+  it('ignores non-absolute or empty remote homes', () => {
+    expect(computeRemoteHomeWorkspaceRoot('')).toBeNull()
+    expect(computeRemoteHomeWorkspaceRoot('  ')).toBeNull()
+    expect(computeRemoteHomeWorkspaceRoot('relative/home')).toBeNull()
+    expect(computeRemoteHomeWorkspaceRoot('/home/user')).toBe('/home/user/orca/workspaces')
+  })
+
+  it('reports when SSH placement needs the remote home', () => {
+    expect(
+      remoteWorktreePathUsesRemoteHome('/remote/repo', { workspaceDir: '/local/workspaces' })
+    ).toBe(true)
+    expect(remoteWorktreePathUsesRemoteHome('/remote/repo', { workspaceDir: '../worktrees' })).toBe(
+      false
+    )
+    expect(
+      remoteWorktreePathUsesRemoteHome(
+        '/remote/repo',
+        { workspaceDir: '/local/workspaces' },
+        { useConfiguredAbsolutePath: true }
+      )
+    ).toBe(false)
+  })
+
+  it('records the remote home layout in SSH creation metadata', () => {
+    const repo = { path: '/remote/work/repo' } as Parameters<
+      typeof getRemoteWorktreeCreationLayout
+    >[0]
+    expect(
+      getRemoteWorktreeCreationLayout(
+        repo,
+        { nestWorkspaces: true, workspaceDir: '/local/workspaces' },
+        '/home/user'
+      )
+    ).toEqual({ path: '/home/user/orca/workspaces', nestWorkspaces: true })
+    // Why: without a resolved home the worktree lands at the legacy sibling
+    // path, so keep recording the desktop layout exactly as before.
+    expect(
+      getRemoteWorktreeCreationLayout(
+        repo,
+        { nestWorkspaces: true, workspaceDir: '/local/workspaces' },
+        null
+      )
+    ).toEqual({ path: '/local/workspaces', nestWorkspaces: true })
+    expect(
+      getRemoteWorktreeCreationLayout(
+        { path: '/remote/work/repo', worktreeBasePath: '../worktrees' } as Parameters<
+          typeof getRemoteWorktreeCreationLayout
+        >[0],
+        { nestWorkspaces: true, workspaceDir: '/local/workspaces' },
+        '/home/user'
+      )
+    ).toEqual({ path: '../worktrees', nestWorkspaces: true })
   })
 
   it('applies repo-specific SSH workspace directories on the remote path', () => {

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -106,11 +106,15 @@ export function computeWorkspaceRoot(repoPath: string, settings: { workspaceDir:
       // Mirror absolute local desktop workspace roots inside the distro so
       // terminals stay on the WSL filesystem; repo-relative roots can resolve
       // directly against the WSL repo path.
-      return win32.join(wslHome, 'orca', 'workspaces')
+      return win32.join(wslHome, ...HOME_WORKSPACE_SEGMENTS)
     }
   }
   return resolveWorkspaceDirForRepo(repoPath, settings.workspaceDir)
 }
+
+// Why: the "<hostHome>/orca/workspaces" mirror layout is shared by the WSL and
+// SSH placements (and matches the desktop default in shared/constants.ts).
+const HOME_WORKSPACE_SEGMENTS = ['orca', 'workspaces'] as const
 
 export function computeRemoteWorktreePath(
   sanitizedName: string,
@@ -118,10 +122,7 @@ export function computeRemoteWorktreePath(
   settings: WorktreePathSettings,
   options: { useConfiguredAbsolutePath?: boolean; remoteHome?: string | null } = {}
 ): string {
-  if (
-    options.useConfiguredAbsolutePath ||
-    isWorkspaceDirRelativeToRepo(repoPath, settings.workspaceDir)
-  ) {
+  if (!remoteWorktreePathUsesRemoteHome(repoPath, settings, options)) {
     return computeWorktreePath(sanitizedName, repoPath, settings)
   }
   // Why: absolute global workspaceDir values belong to the desktop machine.
@@ -162,7 +163,7 @@ export function computeRemoteHomeWorkspaceRoot(
   if (!pathOps.isAbsolute(trimmed)) {
     return null
   }
-  return pathOps.join(trimmed, 'orca', 'workspaces')
+  return pathOps.join(trimmed, ...HOME_WORKSPACE_SEGMENTS)
 }
 
 export function getWorktreePathSettings(

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -116,7 +116,7 @@ export function computeRemoteWorktreePath(
   sanitizedName: string,
   repoPath: string,
   settings: WorktreePathSettings,
-  options: { useConfiguredAbsolutePath?: boolean } = {}
+  options: { useConfiguredAbsolutePath?: boolean; remoteHome?: string | null } = {}
 ): string {
   if (
     options.useConfiguredAbsolutePath ||
@@ -125,9 +125,44 @@ export function computeRemoteWorktreePath(
     return computeWorktreePath(sanitizedName, repoPath, settings)
   }
   // Why: absolute global workspaceDir values belong to the desktop machine.
-  // SSH worktrees keep the legacy repo-sibling root unless a repo-specific
-  // path opts into a remote-host location.
+  // Mirror the local workspace layout under the SSH host's home instead (like
+  // the WSL mirror) so nestWorkspaces isolates repos and same-named worktrees
+  // from sibling repos cannot collide on one path.
+  const remoteRoot = computeRemoteHomeWorkspaceRoot(options.remoteHome)
+  if (remoteRoot) {
+    return computeWorktreePath(sanitizedName, repoPath, {
+      nestWorkspaces: settings.nestWorkspaces,
+      workspaceDir: remoteRoot
+    })
+  }
+  // Why: older relays cannot resolve the remote home; keep the legacy
+  // repo-sibling root so creation still succeeds.
   return getRuntimePathOps(repoPath, repoPath).join(repoPath, '..', sanitizedName)
+}
+
+export function remoteWorktreePathUsesRemoteHome(
+  repoPath: string,
+  settings: Pick<WorktreePathSettings, 'workspaceDir'>,
+  options: { useConfiguredAbsolutePath?: boolean } = {}
+): boolean {
+  return (
+    !options.useConfiguredAbsolutePath &&
+    !isWorkspaceDirRelativeToRepo(repoPath, settings.workspaceDir)
+  )
+}
+
+export function computeRemoteHomeWorkspaceRoot(
+  remoteHome: string | null | undefined
+): string | null {
+  const trimmed = remoteHome?.trim()
+  if (!trimmed) {
+    return null
+  }
+  const pathOps = isWindowsAbsolutePathLike(trimmed) ? win32 : posix
+  if (!pathOps.isAbsolute(trimmed)) {
+    return null
+  }
+  return pathOps.join(trimmed, 'orca', 'workspaces')
 }
 
 export function getWorktreePathSettings(
@@ -148,6 +183,24 @@ export function getWorktreeCreationLayout(
     path: getEffectiveWorktreeBasePath(repo, settings),
     nestWorkspaces: settings.nestWorkspaces
   }
+}
+
+export function getRemoteWorktreeCreationLayout(
+  repo: WorktreeBasePathRepo,
+  settings: WorktreePathSettings,
+  remoteHome: string | null | undefined
+): OrcaWorkspaceLayout {
+  // Why: persisted creation meta should record the root the worktree actually
+  // lives under on the SSH host, not the desktop workspaceDir it mirrors.
+  const remoteRoot = remoteWorktreePathUsesRemoteHome(repo.path, settings, {
+    useConfiguredAbsolutePath: hasRepoWorktreeBasePath(repo)
+  })
+    ? computeRemoteHomeWorkspaceRoot(remoteHome)
+    : null
+  if (remoteRoot) {
+    return { path: remoteRoot, nestWorkspaces: settings.nestWorkspaces }
+  }
+  return getWorktreeCreationLayout(repo, settings)
 }
 
 export function hasRepoWorktreeBasePath(repo: Pick<Repo, 'worktreeBasePath'>): boolean {

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -69,6 +69,7 @@ import {
   registerOptionalSshWorktreeCreateRoots,
   registerRequiredSshWorktreeCreateRoots
 } from './ssh-worktree-create-root-registration'
+import { resolveSshRemoteHome } from '../ssh/ssh-remote-home'
 
 type CreateWorktreeArgsWithSystemProvenance = CreateWorktreeArgs & {
   automationProvenance?: AutomationWorkspaceProvenance
@@ -81,9 +82,11 @@ import {
   computeRemoteWorktreePath,
   computeWorkspaceRoot,
   ensurePathWithinWorkspace,
+  getRemoteWorktreeCreationLayout,
   getWorktreeCreationLayout,
   getWorktreePathSettings,
   hasRepoWorktreeBasePath,
+  remoteWorktreePathUsesRemoteHome,
   shouldSetDisplayName,
   mergeWorktree,
   areWorktreePathsEqual
@@ -1567,6 +1570,14 @@ export async function createRemoteWorktree(
 
   const settings = store.getSettings()
   const worktreePathSettings = getWorktreePathSettings(repo, settings)
+  const useConfiguredAbsolutePath = hasRepoWorktreeBasePath(repo)
+  // Why: the desktop workspaceDir cannot apply on the SSH host; resolve the
+  // remote home once so placement can mirror the local workspace layout there.
+  const remoteHome = remoteWorktreePathUsesRemoteHome(repo.path, worktreePathSettings, {
+    useConfiguredAbsolutePath
+  })
+    ? await resolveSshRemoteHome(repo.connectionId!)
+    : null
   let effectiveRequestedName = args.name
   const sanitizedName = sanitizeWorktreeName(args.name)
   let effectiveSanitizedName = sanitizedName
@@ -1655,7 +1666,8 @@ export async function createRemoteWorktree(
       repo.path,
       worktreePathSettings,
       {
-        useConfiguredAbsolutePath: hasRepoWorktreeBasePath(repo)
+        useConfiguredAbsolutePath,
+        remoteHome
       }
     )
     if (!(await remotePathExists(fsProvider, remotePath))) {
@@ -1882,7 +1894,7 @@ export async function createRemoteWorktree(
     createdAt: now,
     orcaCreatedAt: now,
     orcaCreationSource: 'ssh',
-    orcaCreationWorkspaceLayout: getWorktreeCreationLayout(repo, settings),
+    orcaCreationWorkspaceLayout: getRemoteWorktreeCreationLayout(repo, settings, remoteHome),
     ...(args.automationProvenance ? { automationProvenance: args.automationProvenance } : {}),
     baseRef: metadataBaseRef,
     ...(checkoutExistingBranch ? { preserveBranchOnDelete: true } : {}),

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -3116,6 +3116,166 @@ describe('registerWorktreeHandlers', () => {
     })
   })
 
+  it('nests SSH worktrees under the remote home workspace root when the relay resolves it', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/work/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    const expectedPath = '/home/user/orca/workspaces/repo/improve-dashboard'
+    const provider = {
+      exec: vi.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'remote') {
+          return { stdout: 'origin\n', stderr: '' }
+        }
+        return { stdout: '', stderr: '' }
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/work/repo',
+          head: 'base123',
+          branch: 'refs/heads/main',
+          isBare: false,
+          isMainWorktree: true
+        },
+        {
+          path: expectedPath,
+          head: 'abc123',
+          branch: 'refs/heads/improve-dashboard',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ]),
+      worktreeIsClean: vi.fn().mockResolvedValue({ clean: true })
+    }
+    const mux = {
+      request: vi.fn().mockImplementation(async (method: string) => {
+        if (method === 'session.resolveHome') {
+          return { resolvedPath: '/home/user' }
+        }
+        return undefined
+      }),
+      notify: vi.fn()
+    }
+    store.getSettings.mockReturnValue({
+      branchPrefix: 'none',
+      nestWorkspaces: true,
+      refreshLocalBaseRefOnWorktreeCreate: false,
+      workspaceDir: '/workspace'
+    })
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+
+    const result = await handlers['worktrees:create'](null, {
+      repoId: 'repo-ssh',
+      name: 'improve-dashboard'
+    })
+
+    expect(mux.request).toHaveBeenCalledWith('session.resolveHome', { path: '~' })
+    expect(provider.addWorktree).toHaveBeenCalledWith(
+      '/remote/work/repo',
+      'improve-dashboard',
+      expectedPath,
+      expect.anything()
+    )
+    expect(mux.request).toHaveBeenCalledWith('session.registerRoot', { rootPath: expectedPath })
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(
+      `repo-ssh::${expectedPath}`,
+      expect.objectContaining({
+        orcaCreationWorkspaceLayout: { path: '/home/user/orca/workspaces', nestWorkspaces: true }
+      })
+    )
+    expect(result).toMatchObject({
+      worktree: expect.objectContaining({ path: expectedPath })
+    })
+  })
+
+  it('keeps the legacy SSH sibling path when the relay cannot resolve the remote home', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/work/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    const expectedPath = '/remote/work/improve-dashboard'
+    const provider = {
+      exec: vi.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'remote') {
+          return { stdout: 'origin\n', stderr: '' }
+        }
+        return { stdout: '', stderr: '' }
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/work/repo',
+          head: 'base123',
+          branch: 'refs/heads/main',
+          isBare: false,
+          isMainWorktree: true
+        },
+        {
+          path: expectedPath,
+          head: 'abc123',
+          branch: 'refs/heads/improve-dashboard',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ]),
+      worktreeIsClean: vi.fn().mockResolvedValue({ clean: true })
+    }
+    // Why: older relays reject session.resolveHome; creation must degrade to
+    // the pre-existing sibling placement instead of failing.
+    const mux = {
+      request: vi.fn().mockImplementation(async (method: string) => {
+        if (method === 'session.resolveHome') {
+          throw new Error('Method not found')
+        }
+        return undefined
+      }),
+      notify: vi.fn()
+    }
+    store.getSettings.mockReturnValue({
+      branchPrefix: 'none',
+      nestWorkspaces: true,
+      refreshLocalBaseRefOnWorktreeCreate: false,
+      workspaceDir: '/workspace'
+    })
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+
+    const result = await handlers['worktrees:create'](null, {
+      repoId: 'repo-ssh',
+      name: 'improve-dashboard'
+    })
+
+    expect(provider.addWorktree).toHaveBeenCalledWith(
+      '/remote/work/repo',
+      'improve-dashboard',
+      expectedPath,
+      expect.anything()
+    )
+    expect(result).toMatchObject({
+      worktree: expect.objectContaining({ path: expectedPath })
+    })
+  })
+
   it('returns SSH local base refresh skip status when the owning worktree is dirty', async () => {
     const repo = {
       id: 'repo-ssh',

--- a/src/main/remote-agent-trust-presets.ts
+++ b/src/main/remote-agent-trust-presets.ts
@@ -1,19 +1,15 @@
 import type { AgentTrustPreset } from './agent-trust-presets'
 import { upsertProjectTrustLevelInContent } from './codex/config-toml-trust'
-import { getActiveMultiplexer } from './ipc/ssh'
 import { getSshFilesystemProvider } from './providers/ssh-filesystem-dispatch'
 import type { IFilesystemProvider } from './providers/types'
-import {
-  isWindowsAbsolutePathLike,
-  normalizeRuntimePathSeparators
-} from '../shared/cross-platform-path'
+import { resolveSshRemoteHome } from './ssh/ssh-remote-home'
 
 export async function markRemoteAgentWorkspaceTrusted(args: {
   preset: AgentTrustPreset
   connectionId: string
   workspacePath: string
 }): Promise<void> {
-  const home = await resolveRemoteHome(args.connectionId)
+  const home = await resolveSshRemoteHome(args.connectionId)
   const fsProvider = getSshFilesystemProvider(args.connectionId)
   if (!home || !fsProvider) {
     return
@@ -27,29 +23,6 @@ export async function markRemoteAgentWorkspaceTrusted(args: {
   } else if (args.preset === 'copilot') {
     await markRemoteCopilotFolderTrusted(fsProvider, home, workspacePath)
   }
-}
-
-async function resolveRemoteHome(connectionId: string): Promise<string | null> {
-  const mux = getActiveMultiplexer(connectionId)
-  if (!mux || mux.isDisposed?.()) {
-    return null
-  }
-  const result = (await mux.request('session.resolveHome', { path: '~' })) as {
-    resolvedPath?: unknown
-  }
-  const home =
-    typeof result.resolvedPath === 'string'
-      ? normalizeRuntimePathSeparators(result.resolvedPath.trim())
-      : ''
-  return home &&
-    (home.startsWith('/') || isWindowsAbsolutePathLike(home)) &&
-    !hasRemotePathControlCharacter(home)
-    ? home.replace(/\/$/, '')
-    : null
-}
-
-function hasRemotePathControlCharacter(value: string): boolean {
-  return value.includes(String.fromCharCode(0)) || value.includes('\r') || value.includes('\n')
 }
 
 async function canonicalizeRemoteWorkspacePath(

--- a/src/main/ssh/ssh-remote-home.ts
+++ b/src/main/ssh/ssh-remote-home.ts
@@ -1,0 +1,66 @@
+import { getActiveMultiplexer } from '../ipc/ssh'
+import type { SshChannelMultiplexer } from './ssh-channel-multiplexer'
+import {
+  isWindowsAbsolutePathLike,
+  normalizeRuntimePathSeparators
+} from '../../shared/cross-platform-path'
+
+type RemoteHomeResolution = { home: string | null; definitive: boolean }
+
+// Why: the home directory is immutable for a connection's lifetime, and the
+// base-directory watcher re-resolves it on every rebuild. Key the cache by the
+// multiplexer instance so reconnects naturally start fresh.
+const remoteHomeByMultiplexer = new WeakMap<object, Promise<RemoteHomeResolution>>()
+
+/**
+ * Resolve the SSH host's home directory via the relay.
+ * Returns null when the connection is gone, the relay predates
+ * session.resolveHome, or the reported path is not a usable absolute path.
+ */
+export async function resolveSshRemoteHome(connectionId: string): Promise<string | null> {
+  const mux = getActiveMultiplexer(connectionId)
+  if (!mux || mux.isDisposed?.()) {
+    return null
+  }
+  let pending = remoteHomeByMultiplexer.get(mux)
+  if (!pending) {
+    pending = requestRemoteHome(mux)
+    remoteHomeByMultiplexer.set(mux, pending)
+    // Why: only definitive answers may stay cached. A transient request
+    // failure must not pin the legacy fallback for the connection's lifetime.
+    void pending.then((resolution) => {
+      if (!resolution.definitive && remoteHomeByMultiplexer.get(mux) === pending) {
+        remoteHomeByMultiplexer.delete(mux)
+      }
+    })
+  }
+  return (await pending).home
+}
+
+async function requestRemoteHome(mux: SshChannelMultiplexer): Promise<RemoteHomeResolution> {
+  let resolvedPath: unknown
+  try {
+    const result = (await mux.request('session.resolveHome', { path: '~' })) as {
+      resolvedPath?: unknown
+    }
+    resolvedPath = result.resolvedPath
+  } catch (error) {
+    // Why: older relays lack session.resolveHome — that answer is permanent
+    // for the connection; any other failure may be transient.
+    const unsupported = error instanceof Error && error.message.includes('Method not found')
+    return { home: null, definitive: unsupported }
+  }
+  const home =
+    typeof resolvedPath === 'string' ? normalizeRuntimePathSeparators(resolvedPath.trim()) : ''
+  const validHome =
+    home &&
+    (home.startsWith('/') || isWindowsAbsolutePathLike(home)) &&
+    !hasRemotePathControlCharacter(home)
+      ? home.replace(/\/$/, '')
+      : null
+  return { home: validHome, definitive: true }
+}
+
+function hasRemotePathControlCharacter(value: string): boolean {
+  return value.includes(String.fromCharCode(0)) || value.includes('\r') || value.includes('\n')
+}

--- a/src/renderer/src/components/sidebar/AddRepoCreateStep.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoCreateStep.tsx
@@ -108,8 +108,10 @@ export function CreateStep({
   )
   const showGitFallback = gitAvailability === 'unavailable'
   const showGitChecking = gitAvailability === 'checking'
-  const showRuntimeMissingParent =
-    runtimeEnvironmentId && !createParent.trim() && runtimeParentStatus !== 'checking'
+  // Why: SSH shares the runtime path — any remote host needs a chosen parent,
+  // and the default may not have filled (probe failed/timed out).
+  const showRemoteMissingParent =
+    isRemoteHost && !createParent.trim() && runtimeParentStatus !== 'checking'
 
   if (browsingParent && (runtimeEnvironmentId || sshTargetId)) {
     return (
@@ -207,7 +209,7 @@ export function CreateStep({
                     'Git is required to create a project.'
                   )}
                 </p>
-              ) : showRuntimeMissingParent ? (
+              ) : showRemoteMissingParent ? (
                 <p className="mt-0.5 text-[11px] text-muted-foreground">
                   {translate(
                     'auto.components.sidebar.AddRepoCreateStep.c234df77f7',

--- a/src/renderer/src/components/sidebar/useCreateProjectDefaults.test.ts
+++ b/src/renderer/src/components/sidebar/useCreateProjectDefaults.test.ts
@@ -9,7 +9,8 @@ const mocks = vi.hoisted(() => ({
   browseRuntimeServerDirectory: vi.fn(),
   callRuntimeRpc: vi.fn(),
   isGitAvailable: vi.fn(),
-  getDefaultCreateProjectParent: vi.fn()
+  getDefaultCreateProjectParent: vi.fn(),
+  sshBrowseDir: vi.fn()
 }))
 
 vi.mock('react', async (importOriginal) => {
@@ -54,6 +55,8 @@ import { useCreateProjectDefaults } from './useCreateProjectDefaults'
 const DEFAULT_PARENT_STATE = 0
 const GIT_AVAILABILITY_STATE = 1
 const RUNTIME_PARENT_STATUS_STATE = 2
+// Ref order inside the hook: [autoFilled marker, autoFilledParent, provenance, ...].
+const PROVENANCE_REF = 2
 
 function flushAsync(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0))
@@ -85,6 +88,9 @@ describe('useCreateProjectDefaults', () => {
         repos: {
           isGitAvailable: mocks.isGitAvailable,
           getDefaultCreateProjectParent: mocks.getDefaultCreateProjectParent
+        },
+        ssh: {
+          browseDir: mocks.sshBrowseDir
         }
       }
     })
@@ -242,17 +248,65 @@ describe('useCreateProjectDefaults', () => {
     expect(setCreateParent).not.toHaveBeenCalled()
   })
 
-  it('does not use client defaults or Git probing for SSH targets', async () => {
+  it('resolves the SSH default parent from the host home without client probing', async () => {
     mocks.isGitAvailable.mockResolvedValue(true)
+    mocks.sshBrowseDir.mockResolvedValue({ entries: [], resolvedPath: '/home/alice' })
 
     const { setCreateParent } = useHarness({ sshTargetId: 'ssh-1' })
     await flushAsync()
 
-    expect(setCreateParent).not.toHaveBeenCalled()
+    expect(mocks.sshBrowseDir).toHaveBeenCalledWith({ targetId: 'ssh-1', dirPath: '~' })
+    expect(setCreateParent).toHaveBeenCalledWith('/home/alice/orca/projects')
+    expect(mocks.stateValues[DEFAULT_PARENT_STATE]).toBe('/home/alice/orca/projects')
+    expect(mocks.stateValues[RUNTIME_PARENT_STATUS_STATE]).toBe('idle')
+    // Why: SSH creation runs on the host relay, so client Git and local/runtime
+    // parent lookups must stay untouched and Git availability stays unknown.
+    expect(mocks.stateValues[GIT_AVAILABILITY_STATE]).toBe('unknown')
     expect(mocks.getDefaultCreateProjectParent).not.toHaveBeenCalled()
     expect(mocks.isGitAvailable).not.toHaveBeenCalled()
     expect(mocks.callRuntimeRpc).not.toHaveBeenCalled()
-    expect(mocks.stateValues[GIT_AVAILABILITY_STATE]).toBe('unknown')
+    // Provenance is recorded so a later target switch can detect the stale value.
+    expect(mocks.refValues[PROVENANCE_REF].current).toEqual({
+      parent: '/home/alice/orca/projects',
+      targetKey: 'ssh:ssh-1'
+    })
+  })
+
+  it('marks the SSH parent lookup failed without filling a parent', async () => {
+    mocks.sshBrowseDir.mockRejectedValue(new Error('disconnected'))
+
+    const { setCreateParent } = useHarness({ sshTargetId: 'ssh-1' })
+    await flushAsync()
+
+    expect(mocks.stateValues[RUNTIME_PARENT_STATUS_STATE]).toBe('failed')
+    expect(setCreateParent).not.toHaveBeenCalled()
+  })
+
+  it('does not replace a touched parent with the SSH default', async () => {
+    mocks.sshBrowseDir.mockResolvedValue({ entries: [], resolvedPath: '/home/alice' })
+
+    const ssh = useHarness({ sshTargetId: 'ssh-1', createParent: '/home/alice/custom' })
+    ssh.result.markCreateParentTouched('/home/alice/custom')
+
+    const sshTouched = useHarness({ sshTargetId: 'ssh-1', createParent: '/home/alice/custom' })
+    await flushAsync()
+
+    expect(mocks.sshBrowseDir).not.toHaveBeenCalled()
+    expect(sshTouched.setCreateParent).not.toHaveBeenCalled()
+  })
+
+  it('clears the stale SSH default when switching to a local target', async () => {
+    mocks.isGitAvailable.mockResolvedValue(true)
+    mocks.sshBrowseDir.mockResolvedValue({ entries: [], resolvedPath: '/home/alice' })
+
+    const ssh = useHarness({ sshTargetId: 'ssh-1' })
+    await flushAsync()
+    expect(ssh.setCreateParent).toHaveBeenCalledWith('/home/alice/orca/projects')
+
+    const local = useHarness({ createParent: '/home/alice/orca/projects' })
+
+    expect(local.result.createParentDefaultPending).toBe(true)
+    expect(local.setCreateParent).toHaveBeenCalledWith('')
   })
 
   it('does nothing outside the create step', async () => {

--- a/src/renderer/src/components/sidebar/useCreateProjectDefaults.ts
+++ b/src/renderer/src/components/sidebar/useCreateProjectDefaults.ts
@@ -1,5 +1,5 @@
 // Default-driven create-project state for AddRepoDialog: resolves the default
-// parent (local/runtime host home) and probes Git
+// parent (local/runtime/SSH host home) and probes Git
 // availability, guarding against stale async results when the target changes.
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { browseRuntimeServerDirectory } from '@/runtime/runtime-server-directory-browser'
@@ -189,17 +189,23 @@ export function useCreateProjectDefaults({
       return
     }
     const runtimeEnvironmentId = activeCreateParentRuntimeEnvironmentId
-    if (!runtimeEnvironmentId || activeCreateParentSshTargetId) {
+    const sshTargetId = activeCreateParentSshTargetId
+    // Why: this effect resolves the default for exactly one active remote target.
+    // Local mode and the ambiguous both-set case stay idle (old runtime behavior).
+    if (Boolean(runtimeEnvironmentId) === Boolean(sshTargetId)) {
       setCreateRuntimeParentStatus('idle')
       return
     }
+    const targetKey = runtimeEnvironmentId
+      ? `runtime:${runtimeEnvironmentId}`
+      : `ssh:${sshTargetId}`
     if (!canReplaceCreateParentDefault(createParent)) {
       setCreateRuntimeParentStatus('idle')
       return
     }
     if (
       createParent.trim() &&
-      autoFilledCreateParentRef.current?.targetKey !== `runtime:${runtimeEnvironmentId}` &&
+      autoFilledCreateParentRef.current?.targetKey !== targetKey &&
       autoFilledCreateParentRef.current?.parent === createParent.trim()
     ) {
       setCreateDefaultParent('')
@@ -208,7 +214,7 @@ export function useCreateProjectDefaults({
       return
     }
     if (
-      autoFilledCreateParentRef.current?.targetKey === `runtime:${runtimeEnvironmentId}` &&
+      autoFilledCreateParentRef.current?.targetKey === targetKey &&
       autoFilledCreateParentRef.current.parent === createParent.trim()
     ) {
       setCreateRuntimeParentStatus('idle')
@@ -218,10 +224,12 @@ export function useCreateProjectDefaults({
 
     const gen = ++createParentDefaultGenRef.current
     setCreateRuntimeParentStatus('checking')
-    void withTimeout(
-      browseRuntimeServerDirectory(runtimeEnvironmentId, '~'),
-      RUNTIME_GIT_AVAILABILITY_TIMEOUT_MS
-    )
+    // Why: same short renderer-side timeout for both hosts so the dialog can't
+    // hang on a slow remote home lookup.
+    const probe = runtimeEnvironmentId
+      ? browseRuntimeServerDirectory(runtimeEnvironmentId, '~')
+      : window.api.ssh.browseDir({ targetId: sshTargetId as string, dirPath: '~' })
+    void withTimeout(probe, RUNTIME_GIT_AVAILABILITY_TIMEOUT_MS)
       .then((result) => {
         if (
           gen !== createParentDefaultGenRef.current ||
@@ -231,8 +239,8 @@ export function useCreateProjectDefaults({
         }
         const parent = getDefaultCreateProjectParent(result.resolvedPath)
         createStepAutoFilledRef.current = true
-        autoFilledCreateParentRef.current = { parent, targetKey: `runtime:${runtimeEnvironmentId}` }
-        createParentProvenanceRef.current = { parent, targetKey: `runtime:${runtimeEnvironmentId}` }
+        autoFilledCreateParentRef.current = { parent, targetKey }
+        createParentProvenanceRef.current = { parent, targetKey }
         setCreateDefaultParent(parent)
         setCreateParent(parent)
         setCreateRuntimeParentStatus('idle')
@@ -241,6 +249,7 @@ export function useCreateProjectDefaults({
         if (gen !== createParentDefaultGenRef.current) {
           return
         }
+        // Leave the field empty on failure so the user can type or browse.
         setCreateRuntimeParentStatus('failed')
       })
   }, [

--- a/src/renderer/src/components/sidebar/useCreateProjectDefaults.ts
+++ b/src/renderer/src/components/sidebar/useCreateProjectDefaults.ts
@@ -196,9 +196,10 @@ export function useCreateProjectDefaults({
       setCreateRuntimeParentStatus('idle')
       return
     }
-    const targetKey = runtimeEnvironmentId
-      ? `runtime:${runtimeEnvironmentId}`
-      : `ssh:${sshTargetId}`
+    // Why: exactly one remote target is active past the guard, so the
+    // hook-level key already carries the right `runtime:`/`ssh:` value —
+    // keep the key construction in one place.
+    const targetKey = activeCreateParentTargetKey
     if (!canReplaceCreateParentDefault(createParent)) {
       setCreateRuntimeParentStatus('idle')
       return
@@ -256,6 +257,7 @@ export function useCreateProjectDefaults({
     activeRuntimeEnvironmentId,
     activeCreateParentRuntimeEnvironmentId,
     activeCreateParentSshTargetId,
+    activeCreateParentTargetKey,
     canReplaceCreateParentDefault,
     createParent,
     setCreateParent,


### PR DESCRIPTION
## Summary

SSH hosts now mirror the local workspace layout for both project creation and worktree placement, fixing a cross-project branch-name collision that only existed over SSH.

**The problem.** Local and SSH behaved differently in two ways:

1. **Create project**: locally the dialog pre-fills the default parent (`~/orca/projects`); runtime hosts resolve `~` and do the same. On SSH the location field stayed empty and the user had to type or browse a host folder every time.
2. **Worktree placement**: locally (default settings: absolute `workspaceDir`, `nestWorkspaces: true`) worktrees are isolated per project under `~/orca/workspaces/<repo>/<name>`. On SSH the same settings were silently ignored — `computeRemoteWorktreePath` treated the absolute desktop `workspaceDir` as unusable and fell back to a **flat repo-sibling** path: `<repoParent>/<name>`.

Because of (2), two SSH projects that live in the same parent directory (e.g. `~/work/project-a`, `~/work/project-b`) **collide when you create same-named worktrees/branches for cross-project work**: both resolve to `~/work/feature-x`. The second creation hits the path-exists retry loop and gets renamed to `feature-x-2` — which also renames its branch — so you simply cannot keep branch names aligned across projects on SSH, while the identical flow works fine locally.

**The fix.** When the global `workspaceDir` is an absolute desktop path (the default), SSH worktree creation now resolves the remote host's home via the relay (`session.resolveHome`) and mirrors the local layout there, exactly like the existing WSL mirror:

- `nestWorkspaces: true` → `<remoteHome>/orca/workspaces/<repo>/<name>` (per-project isolation, no collisions)
- `nestWorkspaces: false` → `<remoteHome>/orca/workspaces/<name>` (same flat semantics as local)
- per-repo `worktreeBasePath` and repo-relative `workspaceDir` values behave exactly as before

And the SSH create-project dialog now resolves the remote home the same way runtime hosts do and pre-fills `<remoteHome>/orca/projects`, keeping manual entry and the host file browser available.

**Backward compatibility.**

- Existing SSH worktrees are untouched: they are tracked by their stored paths and stay `orca-managed` via persisted metadata. Only newly created worktrees use the new placement.
- Older relays that don't support `session.resolveHome` (and any home-resolution failure) degrade safely to the legacy repo-sibling placement — creation never fails because of this change. Every pre-existing test for the legacy placement passes unmodified.
- The worktree base-directory watcher now watches **both** the legacy sibling root and the new remote-home root, so old and new worktrees keep getting freshness events.
- In the create-project dialog, if the SSH home probe fails or times out (3s), the field is left empty with the existing "Choose or enter a host parent folder" hint — the pre-change UX.

**Main changes.**

- `src/main/ssh/ssh-remote-home.ts` (new): shared `resolveSshRemoteHome()` — relay-backed home resolution with per-connection caching, absolute-path/control-character validation, `null` on any failure. `remote-agent-trust-presets.ts` now reuses it instead of its private copy.
- `src/main/ipc/worktree-logic.ts`: `computeRemoteWorktreePath()` accepts `remoteHome` and mirrors the local layout under `<remoteHome>/orca/workspaces`; new `remoteWorktreePathUsesRemoteHome()` predicate and `getRemoteWorktreeCreationLayout()` so persisted creation metadata records the layout the worktree actually lives under.
- `src/main/ipc/worktree-remote.ts`: `createRemoteWorktree()` resolves the remote home once (only when the placement needs it) and threads it into path computation and creation metadata.
- `src/main/ipc/worktree-base-directory-watch-targets.ts`: SSH repos with default placement now produce both watch roots (legacy sibling + remote-home).
- `src/renderer/src/components/sidebar/useCreateProjectDefaults.ts`: the runtime-host default-parent effect is generalized to one shared effect covering runtime **and** SSH targets (SSH resolves `~` via `window.api.ssh.browseDir`); user-typed values are never clobbered.
- `src/renderer/src/components/sidebar/AddRepoCreateStep.tsx`: the "choose a host parent folder" hint now shows for any remote host, not just runtime hosts.

## Screenshots

No screenshots (SSH host required to reproduce). UI delta in words:

- **Create a new project (SSH host)**: the Location field auto-fills with `<remoteHome>/orca/projects` (previously empty); Change/Browse still work; a failed probe leaves the field empty with the existing hint.
- No other visual changes.

## Testing

- [ ] `pnpm lint` — passes for this change; fails on a **pre-existing** `switch-exhaustiveness-check` error in `src/renderer/src/components/skills/skill-freshness-group.tsx:101` that also fails on a clean checkout of `main` (verified via `git stash`).
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

New/updated tests:

- `worktree-logic.test.ts`: remote-home mirroring (nested/flat), Windows SSH home joins, null/relative/empty home fallbacks, `remoteWorktreePathUsesRemoteHome`, creation-layout recording.
- `worktrees.test.ts`: end-to-end SSH create placing the worktree at `<home>/orca/workspaces/<repo>/<name>` (asserts `session.resolveHome`, `git worktree add` target, `session.registerRoot`, persisted layout), and an explicit legacy-fallback test where the relay rejects `session.resolveHome`.
- `worktree-base-directory-watcher.test.ts`: dual-root watching (sibling + remote-home) with a nested completion event.
- `useCreateProjectDefaults.test.ts`: SSH default fill from `browseDir('~').resolvedPath`, probe failure → `failed` status with empty field, user-touched value never replaced, stale autofill cleared when switching targets.
- All pre-existing tests pass unmodified (legacy placement, ownership classification, trust presets).

## AI Review Report

An adversarial review agent (Claude Opus) read the full diff plus surrounding code paths (event filter, multiplexer lifecycle, both callers of the refactored trust-preset helper, the SSH browse handler, path-computation internals) across five dimensions: correctness/races, backward compatibility, cross-platform, security, and the shared-helper refactor.

- **1 confirmed finding (LOW), fixed before this PR**: `resolveSshRemoteHome` cached its promise per multiplexer, so a *transient* `session.resolveHome` failure would pin the legacy-sibling fallback for the connection's entire lifetime. Fixed: only definitive answers stay cached (successful responses, and "Method not found" from older relays — the same narrow-predicate pattern as `GitCapabilityCache`); transient failures evict the entry so the next call retries. In-flight dedupe is preserved.
- Verified clean: `computeRemoteWorktreePath` branch logic (per-repo base path short-circuits home resolution; the only settings-divergence case is forced onto the unchanged branch), the watcher loop rewrite (git-common classification uses only repoId, per-layout `nestWorkspaces` is honored, no drift for local/WSL repos), the merged renderer effect's generation guards and status machine (no stuck `checking` state, in-flight probes invalidated on target switch), and backward compatibility (existing worktree paths are never recomputed; both watch roots covered; trust-preset callers already treated failures as best-effort).
- **Cross-platform** (macOS/Linux/Windows explicitly checked): Windows SSH homes handled — `computeRemoteHomeWorkspaceRoot` picks win32/posix ops via `isWindowsAbsolutePathLike`, the browse handler emits forward-slash `resolvedPath` under PowerShell, and `getDefaultCreateProjectParent` derives its separator from the input path. No hardcoded separators introduced; no shortcut/label/shell/Electron platform surface touched.

## Security Audit

- The relay-resolved home is validated before use: must be `/`-rooted or drive-rooted, NUL/CR/LF rejected (`hasRemotePathControlCharacter`), trailing slash normalized. It then flows into git as structured argv (`git worktree add` via the relay's arg-array exec, never shell interpolation) and into `session.registerRoot` as a plain parameter — no new injection surface, and the path is the SSH user's own home on their own host.
- The renderer's new call is the pre-existing `window.api.ssh.browseDir` IPC (already exposed for the host file browser) pointed at `~`; no new IPC channel, no privilege change, 3s renderer-side timeout on top of the handler's own 15s cap.
- No secrets, auth, or dependency changes. Worktree paths registered with the relay are exactly the paths git will operate on, same as before.

## Notes

- Placement decision (confirmed with the repo owner): mirror the local layout under the remote home for both `nestWorkspaces` on **and** off, with legacy sibling only as a fallback for old relays. The remote home is a safe default because SSH login guarantees a home directory and the relay already runs from it; restricted accounts fall back to the legacy path if home resolution fails.
- `getWorktreeCreationLayout` is still used for local/runtime creation; only the SSH path records the remote layout.
- The pre-existing `skill-freshness-group.tsx` lint error is unrelated to this PR and reproduces on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI5

Creating projects and worktrees over SSH did not match local layout, so empty default folders and flat worktree paths caused branch-name collisions across projects. SSH now uses the same parent defaults and per-project worktree placement as local.
