### PR TITLE
fix(i18n): use explicit {' '} so PRFilterSections satisfies the JSX spacing guard

### DIFF
--- a/src/renderer/src/components/github/PRFilterSections.tsx
+++ b/src/renderer/src/components/github/PRFilterSections.tsx
@@ -208,7 +208,7 @@ export function SectionMenu({
   return (
     <div className="py-1 text-xs">
       <div className="px-3 py-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-        {translate('auto.components.github.PRFilterSections.8177eda37e', 'Filter')} {subject}
+        {translate('auto.components.github.PRFilterSections.8177eda37e', 'Filter')}{' '}{subject}
       </div>
       {rows.map((row) => (
         <button


### PR DESCRIPTION
## Description

`main` is currently **red** on `i18n-jsx-spacing-guard.test.ts` → *keeps an explicit space after "Filter pull requests" in `components/github/PRFilterSections.tsx`*.

**Root cause:** #9513 (`0d97653e3`) added that spacing-guard test **and** restored the `Filter <subject>` space in the same commit — but it used a **bare literal JSX space** where the guard requires the **explicit `{' '}`** form:

```jsx
{translate(…, 'Filter')} {subject}      // shipped in #9513 — renders fine, guard rejects
{translate(…, 'Filter')}{' '}{subject}  // this PR — same output, guard passes
```

So #9513 merged self-inconsistent. It stayed latent because the `verify` suite only runs on `pull_request`, not on pushes to `main`, so the redness only surfaces on the next PR that runs CI.

This is a one-line change: swap the bare space for `{' '}`. **Identical rendered output**, and it turns the guard green.

## Evidence

- The failing run (unrelated PR #9515): `Test Files 1 failed | 3038 passed` — the sole failure was this guard case.
- `git show 0d97653e3 -- .../PRFilterSections.tsx` shows the bare-space edit; the guard's regex (`i18n-jsx-spacing-guard.test.ts:118-127`) requires `)}` followed by `{' '}`.
- No behavior change: `{expr} {expr}` and `{expr}{' '}{expr}` render the same single space.

## User regression / tradeoff list

**Zero.** Pure DX/CI fix — same DOM output, no runtime or visual change. Not enabling auto-merge; please review and merge once its CI is green.

Made with [Orca](https://github.com/stablyai/orca) 🐋
