### PR TITLE
fix(new-workspace): ignore IME composition Enter in workspace name field

### DIFF
--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.ime-enter.test.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.ime-enter.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import SmartWorkspaceNameField from './SmartWorkspaceNameField'
+
+vi.mock('@/store', () => {
+  const state = {
+    repos: [],
+    addRepo: vi.fn(),
+    checkLinearConnection: vi.fn(),
+    fetchWorkItems: vi.fn(),
+    fetchWorkItemsAcrossRepos: vi.fn(),
+    getCachedWorkItems: vi.fn(() => null),
+    linearStatus: { connected: false },
+    linearStatusChecked: false,
+    listLinearIssues: vi.fn(),
+    preflightStatus: null,
+    preflightStatusChecked: false,
+    preflightStatusContextKey: null,
+    refreshPreflightStatus: vi.fn(),
+    searchLinearIssues: vi.fn(),
+    settings: null
+  }
+  const useAppStore = (selector: (s: typeof state) => unknown): unknown => selector(state)
+  useAppStore.getState = () => state
+  return { useAppStore }
+})
+
+vi.mock('@/lib/local-preflight-context', () => ({
+  getLocalPreflightContext: () => ({}),
+  localPreflightContextKey: () => 'test-preflight-context'
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, fallback?: string) => fallback ?? key })
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverAnchor: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}))
+
+vi.mock('@/components/ui/command', () => ({
+  Command: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CommandGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CommandItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CommandList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}))
+
+vi.mock('@/components/ui/tabs', () => ({
+  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+function renderField(onPlainEnter: () => void): HTMLInputElement {
+  act(() => {
+    root.render(
+      <SmartWorkspaceNameField
+        repos={[]}
+        repoId="repo-1"
+        onRepoChange={vi.fn()}
+        value="배포"
+        onValueChange={vi.fn()}
+        onGitHubItemSelect={vi.fn()}
+        onBranchSelect={vi.fn()}
+        onLinearIssueSelect={vi.fn()}
+        selectedSource={null}
+        onClearSelectedSource={vi.fn()}
+        onPlainEnter={onPlainEnter}
+        textOnly
+      />
+    )
+  })
+  const input = container.querySelector<HTMLInputElement>('[data-workspace-name-input="true"]')
+  if (!input) {
+    throw new Error('workspace name input not rendered')
+  }
+  return input
+}
+
+function pressEnter(
+  input: HTMLInputElement,
+  init?: KeyboardEventInit & { keyCode?: number }
+): void {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Enter',
+    bubbles: true,
+    cancelable: true,
+    ...init
+  })
+  if (init?.keyCode !== undefined) {
+    Object.defineProperty(event, 'keyCode', { value: init.keyCode })
+  }
+  act(() => {
+    input.dispatchEvent(event)
+  })
+}
+
+describe('SmartWorkspaceNameField IME Enter guard', () => {
+  it('ignores the Enter that commits a CJK IME composition (isComposing)', () => {
+    const onPlainEnter = vi.fn()
+    const input = renderField(onPlainEnter)
+
+    pressEnter(input, { isComposing: true })
+
+    expect(onPlainEnter).not.toHaveBeenCalled()
+  })
+
+  it('ignores the Enter reported as keyCode 229 by IMEs that skip isComposing', () => {
+    const onPlainEnter = vi.fn()
+    const input = renderField(onPlainEnter)
+
+    pressEnter(input, { keyCode: 229 })
+
+    expect(onPlainEnter).not.toHaveBeenCalled()
+  })
+
+  it('still forwards a plain Enter to onPlainEnter', () => {
+    const onPlainEnter = vi.fn()
+    const input = renderField(onPlainEnter)
+
+    pressEnter(input)
+
+    expect(onPlainEnter).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.ime-enter.test.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.ime-enter.test.tsx
@@ -117,6 +117,45 @@ function renderField(onPlainEnter: () => void): HTMLInputElement {
   return input
 }
 
+function renderSmartField(spies: {
+  onValueChange: () => void
+  onBranchSelect: () => void
+  onPlainEnter: () => void
+}): HTMLInputElement {
+  act(() => {
+    root.render(
+      <SmartWorkspaceNameField
+        repos={[]}
+        repoId="repo-1"
+        onRepoChange={vi.fn()}
+        value="배포"
+        onValueChange={spies.onValueChange}
+        onGitHubItemSelect={vi.fn()}
+        onBranchSelect={spies.onBranchSelect}
+        onLinearIssueSelect={vi.fn()}
+        selectedSource={null}
+        onClearSelectedSource={vi.fn()}
+        onPlainEnter={spies.onPlainEnter}
+      />
+    )
+  })
+  const input = container.querySelector<HTMLInputElement>('[data-workspace-name-input="true"]')
+  if (!input) {
+    throw new Error('workspace name input not rendered')
+  }
+  return input
+}
+
+// Why: the guard must short-circuit before the `open && rows.length > 0`
+// row-select branch, so drive the field into that state — smart mode with a
+// typed value synchronously yields a highlighted "use this name" row.
+function openSourcePopover(input: HTMLInputElement): void {
+  const event = new Event('pointerdown', { bubbles: true, cancelable: true })
+  act(() => {
+    input.dispatchEvent(event)
+  })
+}
+
 function pressEnter(
   input: HTMLInputElement,
   init?: KeyboardEventInit & { keyCode?: number }
@@ -161,5 +200,38 @@ describe('SmartWorkspaceNameField IME Enter guard', () => {
     pressEnter(input)
 
     expect(onPlainEnter).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not select the highlighted source row on an IME-composition Enter', () => {
+    const onValueChange = vi.fn()
+    const onBranchSelect = vi.fn()
+    const onPlainEnter = vi.fn()
+    const input = renderSmartField({ onValueChange, onBranchSelect, onPlainEnter })
+    openSourcePopover(input)
+
+    pressEnter(input, { isComposing: true })
+
+    // The guard runs before the row-select branch, so neither the row commit
+    // (onValueChange) nor the fall-through (onPlainEnter) should fire.
+    expect(onValueChange).not.toHaveBeenCalled()
+    expect(onBranchSelect).not.toHaveBeenCalled()
+    expect(onPlainEnter).not.toHaveBeenCalled()
+  })
+
+  it('selects the highlighted source row on a plain Enter (control for the guard)', () => {
+    const onValueChange = vi.fn()
+    const onBranchSelect = vi.fn()
+    const onPlainEnter = vi.fn()
+    const input = renderSmartField({ onValueChange, onBranchSelect, onPlainEnter })
+    openSourcePopover(input)
+
+    pressEnter(input)
+
+    // With the popover open and a highlighted "use this name" row, a plain
+    // Enter commits that row (onValueChange) and does NOT fall through to
+    // onPlainEnter — proving the composition case above was really suppressed
+    // at the row-select branch, not merely inert.
+    expect(onValueChange).toHaveBeenCalledWith('배포')
+    expect(onPlainEnter).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -47,6 +47,7 @@ import {
   lookupGitLabWorkItemByPathForSource
 } from '@/lib/gitlab-work-item-source-lookup'
 import { parseGitLabIssueOrMRLink } from '@/lib/gitlab-links'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { getLocalPreflightContext, localPreflightContextKey } from '@/lib/local-preflight-context'
 import { getRepoOwnerRoutedSettings } from '@/lib/repo-runtime-owner'
 import { cn } from '@/lib/utils'
@@ -1504,6 +1505,14 @@ export default function SmartWorkspaceNameField({
                         !event.ctrlKey &&
                         !event.shiftKey
                       ) {
+                        // Why: an Enter that only commits a CJK IME candidate
+                        // must not select a row or advance focus — moving focus
+                        // mid-composition makes Chromium re-commit the composed
+                        // character into the controlled input, duplicating the
+                        // last syllable (e.g. 배포 → 배포포).
+                        if (isImeCompositionKeyDown(event)) {
+                          return
+                        }
                         if (open && rows.length > 0) {
                           const row = rows.find((entry) => entry.value === resolvedCommandValue)
                           if (row) {


### PR DESCRIPTION

Fixes #9525

## Summary

Typing a CJK workspace name (Korean/Japanese/Chinese) in the create-worktree dialog and pressing Enter while the last syllable is still composing duplicates that syllable — `배포` becomes `배포포`, and the wrong name flows into the created workspace/branch.

**Root cause:** the Enter handler in `SmartWorkspaceNameField` treats the IME-composition Enter (the keypress that only finalizes the candidate) as a real Enter and runs `onPlainEnter()`, which moves focus to the Agent combobox. Moving focus mid-composition makes Chromium re-commit the composing character into the controlled input, appending it a second time.

**Fix:** guard the Enter branch with the existing shared helper `isImeCompositionKeyDown()` (`nativeEvent.isComposing || keyCode === 229`) — the exact pattern this codebase already uses in `WorktreeTitleInlineRename`, `AddRepoRemoteStep`, `AddRepoCloneStep`, `JiraIssueWorkspace`, and the TaskPage Enter handlers. The smart workspace-name field was the one Enter-commit path missing it. After the fix, the first Enter finalizes the composition (field keeps the correct text, focus stays put) and the next Enter advances focus as before — matching the inline-rename field's behavior.

Related: #8038 tracks the same missing-guard family in the desktop terminal. Tab/native focus traversal was verified unaffected (the browser-native focus move lets the IME finalize correctly; only the JS-initiated focus move triggered the re-commit).

## Screenshots

Before (Orca v1.4.146 stable, macOS Korean 2-Set IME) — typing `테스트`, pressing Enter mid-composition yields `테스트트`:


https://github.com/user-attachments/assets/0826bffe-45dc-42ed-83af-e815bedccc90


After (this branch, dev build, same IME) — same input, name stays `테스트`, focus advances on the following Enter:


https://github.com/user-attachments/assets/242aed22-f546-45c6-9c3f-cec32a44f2c3



## Testing

- [x] `pnpm typecheck` — clean (node, cli, web)
- [x] `pnpm test` — 32,326 passed, 56 skipped, 1 baseline-only failure (see below)
- [x] `pnpm lint` — my files clean; 2 baseline-only errors (see below)
- [ ] `pnpm build` — fails locally on an environment limitation only (see below)
- [x] Added `SmartWorkspaceNameField.ime-enter.test.tsx` (happy-dom render of the real component):
  - Enter with `isComposing: true` → `onPlainEnter` NOT called
  - Enter with `keyCode === 229` (IMEs that skip `isComposing` on keydown) → `onPlainEnter` NOT called
  - plain Enter → `onPlainEnter` called once (no regression)
  - Verified the two guard tests **fail on `main` and pass with this change**.
- [x] Manual verification on a local dev build with the macOS Korean IME (recording above): duplication gone, Enter-to-advance-focus still works, popover row selection via Enter unaffected for non-IME input.

Baseline-only failures — this branch differs from `main` by exactly the two files in this diff (`git diff main --name-only`), so all of the following reproduce identically on clean `main`:

- lint: `switch-exhaustiveness-check` in `src/main/daemon/daemon-server.ts:680` and `src/renderer/src/components/skills/skill-freshness-group.tsx:101` (the latter already noted as baseline in #9500).
- test: `src/renderer/src/lib/i18n-jsx-spacing-guard.test.ts` — "keeps an explicit space after 'Filter pull requests' in components/github/PRFilterSections.tsx" (same family as the recent #9511/#9513 spacing fixes).
- build: `native/computer-use-macos` requires `swift-tools-version: 6.0`; my local toolchain is Swift 5.10, so the native step fails before reaching any code in this diff.

## AI Review Report

Reviewed the diff with my AI coding agent. Main risks checked and results:

- **Cross-platform (macOS/Linux/Windows):** the guard uses standard DOM `KeyboardEvent.isComposing` plus the `keyCode === 229` fallback; no platform branches, no shortcuts/labels/paths/shell involvement. Behavior on Linux (IBus) and Windows (IME) IMEs follows the same keydown contract; non-IME input is unaffected because `isComposing` is false and `keyCode` is the real key.
- **SSH/remote/local:** renderer-only change in a local input handler; no daemon/relay/SSH surface touched.
- **Agents/integrations/git providers:** the guard sits before both Enter branches (source-row select and plain-Enter), so GitHub/GitLab/Linear/Jira source selection behavior is unchanged for non-composition Enter; no provider-specific logic added.
- **Performance:** one boolean check on Enter keydown; no hot-path impact.
- **UI quality:** no visual change; keyboard flow now matches the already-fixed inline-rename field.
- Flagged and accepted: an IME-composition Enter now does nothing beyond finalizing the composition (previously it advanced focus with corrupted text) — this is the intended, standard behavior for CJK inputs and matches `WorktreeTitleInlineRename`.

## Security Audit

- No new dependencies; no changes to IPC, network, filesystem, process spawning, or credential handling.
- Change is limited to interpreting a keyboard event in the renderer; no user data crosses any new boundary.

## Notes

- The same `isImeCompositionKeyDown` helper is intentionally reused rather than a new predicate, keeping IME-Enter semantics consistent across the app.
- No platform-specific code added; manually verified on macOS (the platform where the bug was reported).
