### PR TITLE
fix(pi): prevent duplicate resumes for live background panes

### DIFF
--- a/src/renderer/src/lib/pi-session-resume-wake.test.ts
+++ b/src/renderer/src/lib/pi-session-resume-wake.test.ts
@@ -3,11 +3,14 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
 import type { TerminalTab } from '../../../shared/types'
+import { makePaneKey } from '../../../shared/stable-pane-id'
 import { useAppStore } from '@/store'
 import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
 
 const initialAppStoreState = useAppStore.getState()
 const PI_TRANSCRIPT_PATH = join(tmpdir(), 'pi-session-1.jsonl')
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const OTHER_LEAF_ID = '22222222-2222-4222-8222-222222222222'
 
 afterEach(() => {
   useAppStore.setState(initialAppStoreState, true)
@@ -57,5 +60,84 @@ describe('Pi session wake', () => {
       providerSession
     )
     expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+  })
+
+  it('keeps a live Pi session in its hidden pane when the exact PTY is still alive', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID)
+    const providerSession = {
+      key: 'session_id' as const,
+      id: 'pi-session-1',
+      transcriptPath: PI_TRANSCRIPT_PATH
+    }
+    const record: SleepingAgentSessionRecord = {
+      paneKey,
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      agent: 'pi',
+      providerSession,
+      prompt: 'finish the task',
+      state: 'working',
+      capturedAt: 1,
+      updatedAt: 1,
+      origin: 'live'
+    }
+    const hiddenTab: TerminalTab = {
+      id: 'tab-1',
+      ptyId: null,
+      worktreeId: 'wt-1',
+      title: 'Pi ready',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: 1
+    }
+    const activeTab: TerminalTab = {
+      ...hiddenTab,
+      id: 'tab-2',
+      title: 'shell',
+      sortOrder: 1
+    }
+    useAppStore.setState({
+      activeWorktreeId: 'wt-1',
+      activeTabType: 'terminal',
+      activeTabId: 'tab-2',
+      activeTabIdByWorktree: { 'wt-1': 'tab-2' },
+      tabsByWorktree: { 'wt-1': [hiddenTab, activeTab] },
+      ptyIdsByTabId: { 'tab-1': ['pty-1'], 'tab-2': ['pty-2'] },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: 'pty-1' }
+        },
+        'tab-2': {
+          root: { type: 'leaf', leafId: OTHER_LEAF_ID },
+          activeLeafId: OTHER_LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [OTHER_LEAF_ID]: 'pty-2' }
+        }
+      },
+      agentStatusByPaneKey: {
+        [paneKey]: {
+          paneKey,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          state: 'done',
+          prompt: 'finish the task',
+          agentType: 'pi',
+          providerSession
+        }
+      },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    const state = useAppStore.getState()
+    expect(launched).toBe(0)
+    expect(state.tabsByWorktree['wt-1']).toHaveLength(2)
+    expect(state.pendingStartupByTabId).toEqual({})
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
   })
 })

--- a/src/renderer/src/lib/sleeping-agent-pane-ownership.ts
+++ b/src/renderer/src/lib/sleeping-agent-pane-ownership.ts
@@ -78,6 +78,16 @@ function hasRestorableStablePanePty(
   )
 }
 
+function hasLiveStablePanePty(
+  tabId: string,
+  leafId: string,
+  ptyIdsByTabId: Record<string, string[] | undefined>,
+  terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot | undefined>
+): boolean {
+  const leafPtyId = terminalLayoutsByTabId[tabId]?.ptyIdsByLeafId?.[leafId]
+  return Boolean(leafPtyId && ptyIdsByTabId[tabId]?.includes(leafPtyId))
+}
+
 function paneWillConnectOnActivation(
   worktreeId: string,
   tabId: string,
@@ -115,6 +125,13 @@ export function recordPaneIsOwnedByPreservedPane(
     const tab = worktreeTabs.find((candidate) => candidate.id === tabId) ?? null
     if (!tab || !hasMatchingStablePaneLayout(tabId, stable.leafId, state.terminalLayoutsByTabId)) {
       return false
+    }
+    // Why: hidden tabs do not mount during activation, but their exact pane PTY
+    // may still be alive and already own the provider session.
+    if (
+      hasLiveStablePanePty(tabId, stable.leafId, state.ptyIdsByTabId, state.terminalLayoutsByTabId)
+    ) {
+      return true
     }
     if (isPassiveCompletedHibernationEvidence(record)) {
       return true


### PR DESCRIPTION
## Summary

Prevent Orca from launching a second `pi --session <transcript>` tab when the original Pi pane is backgrounded but its PTY is still alive.

Pi reports `done` after a turn while its TUI process remains live. That means the existing active-status provider-session claim no longer protects an idle Pi pane. If that pane is also hidden during worktree activation, `paneWillConnectOnActivation()` returns false and Orca can treat the live session as unowned, creating a duplicate `Pi ready` tab attached to the same transcript.

This change treats a preserved stable pane as owning recovery when its exact leaf PTY is present in the live `ptyIdsByTabId` map. The check is leaf-specific, so a sibling split-pane PTY cannot claim the session. If the exact PTY is gone, the existing automatic Pi resume path remains unchanged.

This is a Pi-specific reproduction of the live-background ownership class discussed in #6960 and hardened in #6945, exposed by Pi session resume support from #8876.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — touched-file `oxlint` and `oxfmt --check` pass. The full command reaches `lint:switch-exhaustiveness`, then fails on two unrelated current-`main` errors in `skill-freshness-group.tsx` and `daemon-server.ts`; both reproduce from a detached clean `upstream/main` worktree at `2e67af82d`.
- [x] `pnpm typecheck`
- [ ] `pnpm test` — 32,357 passed, 56 skipped, 5 unrelated failures. Three failures pass when rerun in isolation; the remaining Git merge/hook fixture failures reproduce unchanged on detached clean `upstream/main` at `2e67af82d`.
- [x] `pnpm build`
- [x] Added a regression test that reproduces the duplicate launch on the parent implementation (`launched === 1`) and passes with this fix (`launched === 0`), while retaining the existing dead-PTY resume and sibling-split-PTY coverage.

Focused validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/resume-sleeping-agent-session.test.ts src/renderer/src/lib/pi-session-resume-wake.test.ts` — 32/32 passed.
- Touched-file `oxlint`, `oxfmt --check`, and `git diff --check` passed.

## AI Review Report

The review traced provider-session ownership through `activeOrQueuedResumeClaimsProviderSession()`, `recordPaneIsOwnedByPreservedPane()`, `paneWillConnectOnActivation()`, and `resumeSleepingAgentSessionsForWorktree()`.

Main risk checked: broadening ownership based only on tab-level PTY presence could suppress legitimate recovery or let a sibling split pane claim the wrong provider session. The implementation therefore requires the PTY mapped to the record's exact stable leaf to also appear in that tab's live-PTY map. Existing coverage confirms a sibling PTY does not claim the record and a mapped-but-not-live PTY still resumes normally.

Cross-platform review covered macOS, Linux, and Windows. The change compares opaque in-memory PTY identifiers and does not alter shortcuts, labels, filesystem paths, shell quoting, resume argv, IPC, Electron main-process behavior, or local/SSH/runtime PTY identifier construction. Remote identifiers are compared in the same renderer namespace already used by the layout and live-PTY maps.

## Security Audit

No new input, command execution, path handling, authentication, secret, dependency, or IPC surface is introduced. The change only compares existing store identifiers. Pi transcript paths remain handled by the existing validated/quoted resume path and are not inspected or executed by this ownership check.

The main availability risk was falsely retaining a dead session. Requiring exact leaf-to-live-PTY membership keeps dead panes on the existing fresh-resume path.

## Notes

- Automatic Pi resume is preserved when the original PTY is absent.
- No persisted schema or migration changes.
- No new issue was opened because #6960 already documents the same background-pane ownership gap; this PR is the Pi idle-status variant introduced after #8876.
- X handle: N/A
