### PR TITLE
fix(pi): preserve live background pane ownership

### DIFF
--- a/src/renderer/src/lib/pi-session-resume-wake.test.ts
+++ b/src/renderer/src/lib/pi-session-resume-wake.test.ts
@@ -3,11 +3,14 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
 import type { TerminalTab } from '../../../shared/types'
+import { makePaneKey } from '../../../shared/stable-pane-id'
 import { useAppStore } from '@/store'
 import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
 
 const initialAppStoreState = useAppStore.getState()
 const PI_TRANSCRIPT_PATH = join(tmpdir(), 'pi-session-1.jsonl')
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const OTHER_LEAF_ID = '22222222-2222-4222-8222-222222222222'
 
 afterEach(() => {
   useAppStore.setState(initialAppStoreState, true)
@@ -57,5 +60,86 @@ describe('Pi session wake', () => {
       providerSession
     )
     expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+  })
+
+  it('keeps a live Pi session in its hidden pane when the exact PTY is still alive', () => {
+    const paneKey = makePaneKey('tab-1', LEAF_ID)
+    const providerSession = {
+      key: 'session_id' as const,
+      id: 'pi-session-1',
+      transcriptPath: PI_TRANSCRIPT_PATH
+    }
+    const record: SleepingAgentSessionRecord = {
+      paneKey,
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      agent: 'pi',
+      providerSession,
+      prompt: 'finish the task',
+      state: 'working',
+      capturedAt: 1,
+      updatedAt: 1,
+      origin: 'live'
+    }
+    const hiddenTab: TerminalTab = {
+      id: 'tab-1',
+      ptyId: null,
+      worktreeId: 'wt-1',
+      title: 'Pi ready',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: 1
+    }
+    const activeTab: TerminalTab = {
+      ...hiddenTab,
+      id: 'tab-2',
+      title: 'shell',
+      sortOrder: 1
+    }
+    useAppStore.setState({
+      activeWorktreeId: 'wt-1',
+      activeTabType: 'terminal',
+      activeTabId: 'tab-2',
+      activeTabIdByWorktree: { 'wt-1': 'tab-2' },
+      tabsByWorktree: { 'wt-1': [hiddenTab, activeTab] },
+      ptyIdsByTabId: { 'tab-1': ['pty-1'], 'tab-2': ['pty-2'] },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: 'pty-1' }
+        },
+        'tab-2': {
+          root: { type: 'leaf', leafId: OTHER_LEAF_ID },
+          activeLeafId: OTHER_LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [OTHER_LEAF_ID]: 'pty-2' }
+        }
+      },
+      agentStatusByPaneKey: {
+        [paneKey]: {
+          paneKey,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          state: 'done',
+          prompt: 'finish the task',
+          updatedAt: 2,
+          stateStartedAt: 2,
+          agentType: 'pi',
+          providerSession
+        }
+      },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    const state = useAppStore.getState()
+    expect(launched).toBe(0)
+    expect(state.tabsByWorktree['wt-1']).toHaveLength(2)
+    expect(state.pendingStartupByTabId).toEqual({})
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
   })
 })

--- a/src/renderer/src/lib/sleeping-agent-pane-ownership.ts
+++ b/src/renderer/src/lib/sleeping-agent-pane-ownership.ts
@@ -78,6 +78,16 @@ function hasRestorableStablePanePty(
   )
 }
 
+function hasLiveStablePanePty(
+  tabId: string,
+  leafId: string,
+  ptyIdsByTabId: Record<string, string[] | undefined>,
+  terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot | undefined>
+): boolean {
+  const leafPtyId = terminalLayoutsByTabId[tabId]?.ptyIdsByLeafId?.[leafId]
+  return Boolean(leafPtyId && ptyIdsByTabId[tabId]?.includes(leafPtyId))
+}
+
 function paneWillConnectOnActivation(
   worktreeId: string,
   tabId: string,
@@ -115,6 +125,13 @@ export function recordPaneIsOwnedByPreservedPane(
     const tab = worktreeTabs.find((candidate) => candidate.id === tabId) ?? null
     if (!tab || !hasMatchingStablePaneLayout(tabId, stable.leafId, state.terminalLayoutsByTabId)) {
       return false
+    }
+    // Why: hidden tabs do not mount during activation, but their exact pane PTY
+    // may still be alive and already own the provider session.
+    if (
+      hasLiveStablePanePty(tabId, stable.leafId, state.ptyIdsByTabId, state.terminalLayoutsByTabId)
+    ) {
+      return true
     }
     if (isPassiveCompletedHibernationEvidence(record)) {
       return true


### PR DESCRIPTION
## Summary

Prevent Orca from launching a duplicate `pi --session ...` tab when a live Pi pane is backgrounded during workspace/tab activation.

Pi reports `done` while its TUI remains open and idle. The automatic-resume claim check intentionally ignores `done` status rows, and the preserved-pane ownership check previously required the pane to mount during activation. A hidden tab therefore looked unowned even when its exact leaf PTY was still live, so Orca launched the same provider session again and created another `Pi ready` tab.

This change treats a preserved stable pane as the owner when its layout-bound leaf PTY is present in that tab's live PTY set. The check is leaf-specific: a sibling split-pane PTY cannot claim the session. Missing or dead PTYs still follow the existing automatic Pi resume path.

Related context: #8876, #6945, #6960, and #6910.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — not green on current `upstream/main`: `lint:switch-exhaustiveness` reports the same pre-existing missing cases in `daemon-server.ts` (`closeStartupQueryAuthority`) and `skill-freshness-group.tsx` (`undefined | "current" | "duplicate"`) from a clean `2e67af82d` worktree. Touched-file `oxlint` and `oxfmt --check` both pass.
- [x] `pnpm typecheck`
- [x] `pnpm test` — 32,364 passed, 54 skipped. Run with `GIT_CONFIG_GLOBAL=/dev/null` and inherited noninteractive `GIT_CONFIG_*` variables unset so local `core.hooksPath`, `merge.ff`, and injected credential settings did not affect Git fixture tests.
- [x] `pnpm build`
- [x] Added a Pi regression test that reproduces the duplicate launch on clean base (`launched` was `1`, expected `0`) and passes with this change. The focused resume suites pass: 40/40.

## AI Review Report

Reviewed the preserved-pane ownership and automatic-resume paths against the prior replay protection in #6945 and Pi resume support in #8876.

- Verified ownership requires both the exact `ptyIdsByLeafId[leafId]` binding and membership in `ptyIdsByTabId[tabId]`.
- Verified a sibling split-pane PTY cannot claim the record through the existing regression coverage.
- Verified a missing/dead PTY still launches a fresh Pi resume through the existing Pi wake test.
- Checked the change for stale layout bindings, inactive tabs, split panes, and accidental suppression of explicit user-triggered history resumes. The change only affects automatic sleeping-session ownership.
- Cross-platform review: this is renderer-only in-memory ID comparison. It adds no platform-specific paths, shell quoting, commands, shortcuts, labels, native APIs, or Electron main/IPC behavior. The test transcript path uses `tmpdir()`/`join()` and is portable across macOS, Linux, and Windows.

No actionable review findings remained after requiring the exact leaf-to-live-PTY match rather than accepting any tab-level PTY.

## Security Audit

No new command execution, path resolution, authentication, secrets, dependencies, network requests, or IPC surfaces are introduced. The change compares existing renderer-owned tab/leaf/PTY identifiers and does not consume new untrusted input. The existing quoted Pi resume command path remains unchanged and is still used when no live owning PTY exists.

## Notes

- The production symptom and daemon lifecycle were reproduced locally on Orca 1.4.146 with Pi 0.80.6. The regression is covered at the renderer/store boundary; a full source-build Electron tab-switch E2E was not run.
- X handle: not listed on the contributor's GitHub profile (`@PeraSite`).

## ELI5

If a Pi agent tab was in the background, Orca sometimes thought it was gone and opened a second copy of the same session. The fix treats a still-living background Pi pane as owned so you do not get duplicate tabs.
