### PR TITLE
feat(sidebar): reveal a rename action on worktree card hover

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx
@@ -24,12 +24,13 @@ let settings: Partial<GlobalSettings> | null = null
 let projectGroups: unknown[] = []
 let workspaceDeleteModifierPressed = false
 let gitConflictOperationByWorktree: Record<string, GitConflictOperation> = {}
+let deleteStateByWorktreeId: Record<string, { isDeleting: boolean }> = {}
 let WorktreeCard: typeof WorktreeCardComponent
 
 vi.mock('@/store', () => ({
   useAppStore: (selector: (state: unknown) => unknown) =>
     selector({
-      deleteStateByWorktreeId: {},
+      deleteStateByWorktreeId,
       fetchHostedReviewForBranch,
       fetchIssue,
       gitConflictOperationByWorktree,
@@ -148,6 +149,7 @@ describe('WorktreeCard quick actions', () => {
     projectGroups = []
     workspaceDeleteModifierPressed = false
     gitConflictOperationByWorktree = {}
+    deleteStateByWorktreeId = {}
   })
 
   it('marks the unread toggle as a workspace-board-preserving action', () => {
@@ -286,6 +288,58 @@ describe('WorktreeCard quick actions', () => {
     expect(markup).toContain('aria-label="Auto-rename failed: view error"')
     expect(markup).toContain('rename failed')
     expect(markup).not.toContain('rename pending')
+  })
+
+  it('renders the rename quick action as a workspace-board-preserving action', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} />
+    )
+
+    expect(markup).toContain('aria-label="Rename workspace"')
+    expect(markup).toContain('data-worktree-rename-quick-action=""')
+  })
+
+  it('keeps the rename quick action collapsed until the card is hovered or focused', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} />
+    )
+
+    const button = markup
+      .match(/<button[^>]*>/g)
+      ?.find((tag) => tag.includes('data-worktree-rename-quick-action'))
+    expect(button).toBeDefined()
+    // Why: opacity alone would still reserve the button's width plus the group's
+    // trailing gutter, shifting every row that renders no other header action.
+    expect(button).toContain('max-w-0')
+    expect(button).toContain('opacity-0')
+    expect(button).toContain('group-hover/worktree-card:max-w-4')
+    expect(button).toContain('group-focus-within/worktree-card:max-w-4')
+    expect(markup).toContain('group-hover/worktree-card:pr-1.5')
+  })
+
+  it('does not render the rename quick action while the workspace is being deleted', () => {
+    deleteStateByWorktreeId = {
+      'repo-1::/repo/worktrees/quick-action': { isDeleting: true }
+    }
+
+    const markup = renderToStaticMarkup(
+      <WorktreeCard worktree={makeWorktree()} repo={makeRepo()} isActive={false} />
+    )
+
+    expect(markup).not.toContain('data-worktree-rename-quick-action')
+  })
+
+  it('does not render the rename quick action in affiliate list mode', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCard
+        worktree={makeWorktree()}
+        repo={makeRepo()}
+        isActive={false}
+        affiliateListMode
+      />
+    )
+
+    expect(markup).not.toContain('data-worktree-rename-quick-action')
   })
 
   it('renders the migrated branch metadata row when branch is enabled', () => {

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -27,6 +27,10 @@ import { LinearAgentSkillSetupPrompt } from './LinearAgentSkillSetupPrompt'
 import WorktreeCardAgents from './WorktreeCardAgents'
 import { useWorktreeAgentRows } from './useWorktreeAgentRows'
 import { WorktreeCardStatusSlot } from './WorktreeCardStatusSlot'
+import {
+  WorktreeRenameQuickAction,
+  worktreeHeaderActionsPaddingClass
+} from './WorktreeRenameQuickAction'
 import { cn } from '@/lib/utils'
 import { activateWorktreeFromSidebar } from '@/lib/sidebar-worktree-activation'
 import { isFolderRepo } from '../../../../shared/repo-kind'
@@ -962,6 +966,16 @@ const WorktreeCard = React.memo(function WorktreeCard({
       worktree.id
     ]
   )
+  // Why: routes through the same store request the workspace.rename shortcut uses,
+  // so the inline editor stays the single owner of save/cancel/IME handling.
+  const handleRenameQuickAction = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault()
+      event.stopPropagation()
+      setRenamingWorktreeId(worktree.id)
+    },
+    [setRenamingWorktreeId, worktree.id]
+  )
   const handleOpenRenameErrorDialog = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault()
     event.stopPropagation()
@@ -1200,7 +1214,10 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const hasMetaRow = compactCards
     ? hasMetadataBadge || cacheStartedAt != null
     : hasDetailedMetaRowContent
-  const showHeaderActions = showTitleRowPrimary || showDeleteQuickAction
+  // Why: inline rename is otherwise reachable only by double-click, the "Update"
+  // metadata modal, or a shortcut that has no default binding off macOS.
+  const showRenameQuickAction = !affiliateListMode && !isDeleting
+  const showHeaderActions = showTitleRowPrimary || showDeleteQuickAction || showRenameQuickAction
   // Why: normalize the title once so title/branch de-dupe and identity-only hover eligibility stay in sync.
   const trimmedVisibleCardTitle = visibleCardTitle.trim()
   const showBranchIdentityHover = newCardStyle
@@ -1574,7 +1591,12 @@ const WorktreeCard = React.memo(function WorktreeCard({
           </div>
 
           {showHeaderActions && (
-            <div className="ml-auto flex shrink-0 items-center justify-center gap-1 pr-1.5">
+            <div
+              className={cn(
+                'ml-auto flex shrink-0 items-center justify-center gap-1',
+                worktreeHeaderActionsPaddingClass(showTitleRowPrimary || showDeleteQuickAction)
+              )}
+            >
               {showTitleRowPrimary && (
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -1595,6 +1617,14 @@ const WorktreeCard = React.memo(function WorktreeCard({
                     )}
                   </TooltipContent>
                 </Tooltip>
+              )}
+
+              {showRenameQuickAction && (
+                <WorktreeRenameQuickAction
+                  hasPrecedingAction={showTitleRowPrimary}
+                  onPointerDown={stopQuickActionPointerPropagation}
+                  onRename={handleRenameQuickAction}
+                />
               )}
 
               {showDeleteQuickAction && (

--- a/src/renderer/src/components/sidebar/WorktreeRenameQuickAction.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeRenameQuickAction.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  WorktreeRenameQuickAction,
+  worktreeHeaderActionsPaddingClass
+} from './WorktreeRenameQuickAction'
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+function renderAction(props: Partial<Parameters<typeof WorktreeRenameQuickAction>[0]> = {}): {
+  onRename: ReturnType<typeof vi.fn>
+  onPointerDown: ReturnType<typeof vi.fn>
+  button: HTMLButtonElement
+} {
+  const onRename = vi.fn()
+  const onPointerDown = vi.fn()
+  act(() => {
+    root.render(
+      <WorktreeRenameQuickAction
+        hasPrecedingAction={false}
+        onPointerDown={onPointerDown}
+        onRename={onRename}
+        {...props}
+      />
+    )
+  })
+  const button = container.querySelector<HTMLButtonElement>('[data-worktree-rename-quick-action]')
+  expect(button).not.toBeNull()
+  return { onRename, onPointerDown, button: button! }
+}
+
+describe('WorktreeRenameQuickAction', () => {
+  it('invokes the rename handler on click', () => {
+    const { onRename, button } = renderAction()
+
+    act(() => {
+      button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(onRename).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels the flex gap only when another action renders before it', () => {
+    const { button: withoutSibling } = renderAction({ hasPrecedingAction: false })
+    expect(withoutSibling.className).not.toContain('-ml-1')
+
+    act(() => root.unmount())
+    root = createRoot(container)
+
+    const { button: withSibling } = renderAction({ hasPrecedingAction: true })
+    // Why: a zero-width sibling still contributes the parent's gap-1, which would
+    // shift the primary-star row by 4px if it were not cancelled while collapsed.
+    expect(withSibling.className).toContain('-ml-1')
+    expect(withSibling.className).toContain('group-hover/worktree-card:ml-0')
+  })
+})
+
+describe('worktreeHeaderActionsPaddingClass', () => {
+  it('reserves the trailing gutter when an always-visible action is present', () => {
+    expect(worktreeHeaderActionsPaddingClass(true)).toBe('pr-1.5')
+  })
+
+  it('defers the trailing gutter to hover when rename is the only action', () => {
+    const className = worktreeHeaderActionsPaddingClass(false)
+
+    expect(className).toContain('pr-0')
+    expect(className).toContain('group-hover/worktree-card:pr-1.5')
+    expect(className).toContain('group-focus-within/worktree-card:pr-1.5')
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeRenameQuickAction.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeRenameQuickAction.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { Pencil } from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+
+// Why: the rename action is the only header action revealed by plain hover, so it
+// must occupy zero width at rest — otherwise every row that previously rendered no
+// header actions gains a permanent gutter. Collapsing opacity alone is not enough:
+// the flex `gap-1` between siblings and the group's trailing `pr-1.5` both survive a
+// zero-opacity child, so those are collapsed alongside the button's own width.
+const RENAME_REVEAL_CLASS =
+  'max-w-0 overflow-hidden opacity-0 group-hover/worktree-card:max-w-4 group-hover/worktree-card:opacity-100 group-focus-within/worktree-card:max-w-4 group-focus-within/worktree-card:opacity-100 focus-visible:max-w-4 focus-visible:opacity-100'
+
+// Why: a collapsed sibling still contributes the parent's flex gap, so cancel it
+// while collapsed and restore it on reveal.
+const RENAME_GAP_COLLAPSE_CLASS =
+  '-ml-1 group-hover/worktree-card:ml-0 group-focus-within/worktree-card:ml-0 focus-visible:ml-0'
+
+/**
+ * Trailing gutter for the header-action group. Applied by the parent so the group
+ * reserves no width until the rename action is revealed.
+ */
+export function worktreeHeaderActionsPaddingClass(hasAlwaysVisibleAction: boolean): string {
+  return hasAlwaysVisibleAction
+    ? 'pr-1.5'
+    : 'pr-0 group-hover/worktree-card:pr-1.5 group-focus-within/worktree-card:pr-1.5'
+}
+
+type WorktreeRenameQuickActionProps = {
+  /** True when a always-visible action (the primary star) renders before this one. */
+  hasPrecedingAction: boolean
+  onPointerDown: (event: React.PointerEvent<HTMLButtonElement>) => void
+  onRename: (event: React.MouseEvent<HTMLButtonElement>) => void
+}
+
+export function WorktreeRenameQuickAction({
+  hasPrecedingAction,
+  onPointerDown,
+  onRename
+}: WorktreeRenameQuickActionProps): React.JSX.Element {
+  const label = translate(
+    'auto.components.sidebar.WorktreeRenameQuickAction.renameWorkspace',
+    'Rename workspace'
+  )
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          data-workspace-board-preserve-open=""
+          data-worktree-rename-quick-action=""
+          onPointerDown={onPointerDown}
+          onClick={onRename}
+          className={cn(
+            'inline-flex size-4 shrink-0 items-center justify-center rounded bg-transparent',
+            'transition-[max-width,opacity,margin,color,background-color]',
+            RENAME_REVEAL_CLASS,
+            hasPrecedingAction && RENAME_GAP_COLLAPSE_CLASS,
+            'text-muted-foreground hover:bg-accent/70 hover:text-foreground',
+            'focus-visible:bg-accent/70 focus-visible:text-foreground'
+          )}
+          aria-label={label}
+        >
+          <Pencil className="size-3.5" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="right" sideOffset={8}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4306,6 +4306,9 @@
           "branchFolderPathIdentity": "Branch or folder path",
           "ef18787206": "Queued for deletion"
         },
+        "WorktreeRenameQuickAction": {
+          "renameWorkspace": "Rename workspace"
+        },
         "WorktreeCardAgents": {
           "1b0a156717": "Agents"
         },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4260,6 +4260,9 @@
           "branchFolderPathIdentity": "Rama o ruta de carpeta",
           "ef18787206": "En cola para eliminación"
         },
+        "WorktreeRenameQuickAction": {
+          "renameWorkspace": "Cambiar nombre del espacio de trabajo"
+        },
         "WorktreeCardAgents": {
           "1b0a156717": "Agents"
         },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4241,6 +4241,9 @@
           "branchFolderPathIdentity": "ブランチまたはフォルダパス",
           "ef18787206": "削除待ち"
         },
+        "WorktreeRenameQuickAction": {
+          "renameWorkspace": "ワークスペース名の変更"
+        },
         "WorktreeCardAgents": {
           "1b0a156717": "エージェント"
         },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4241,6 +4241,9 @@
           "branchFolderPathIdentity": "브랜치 또는 폴더 경로",
           "ef18787206": "삭제 대기 중"
         },
+        "WorktreeRenameQuickAction": {
+          "renameWorkspace": "워크스페이스 이름 바꾸기"
+        },
         "WorktreeCardAgents": {
           "1b0a156717": "에이전트"
         },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4241,6 +4241,9 @@
           "branchFolderPathIdentity": "分支或文件夹路径",
           "ef18787206": "已排队删除"
         },
+        "WorktreeRenameQuickAction": {
+          "renameWorkspace": "重命名工作区"
+        },
         "WorktreeCardAgents": {
           "1b0a156717": "智能体"
         },


### PR DESCRIPTION
## Summary

Renaming a workspace from the sidebar already worked three ways, but none of them is visible:

1. **Double-clicking the title** — the inline editor (`WorktreeTitleInlineRename.tsx`). No hint it exists.
2. **Right-click → "Update"** — opens the heavier `edit-meta` modal focused on the name. Reasonably labeled "Update", since that modal also edits the linked issue, PR, and comment — but it means the menu has no plain "rename".
3. **The `workspace.rename` shortcut** — `Mod+Alt+R` on macOS, and `[]` on Linux and Windows, where `keybindings.ts` documents that the safe chords are already taken.

Meanwhile the title row has no ordinary hover chrome at all: the one quick action living there (delete) is deliberately gated behind holding Option/Alt because it is destructive.

This adds a pencil button at the right end of the worktree card's title row, revealed on hover, that opens the **existing** inline editor. It dispatches the same `setRenamingWorktreeId` request the shortcut uses, so save, cancel, trim/no-op handling, the saving spinner, IME composition guarding, and error toasts all stay owned by `WorktreeTitleInlineRename` — no second rename path to keep in sync.

Ordering in the action group is `Star (indicator) → pencil (ordinary action) → trash (destructive, Alt-gated)`.

### Layout note

The action collapses to **zero width** at rest rather than only fading out. `showHeaderActions` previously rendered only for a compact-mode main worktree or while Alt was held, so most rows had no action group at all; a plain `opacity-0` child would still contribute its own width, the group's flex `gap-1`, and its trailing `pr-1.5`, shifting the details/ports lane on every row. The button therefore collapses `max-w`, cancels the flex gap when a sibling precedes it, and the group defers its trailing gutter to hover. This mirrors the existing `repo-header-action-button-class.ts` reveal pattern, which exists for the same reason.

## Screenshots

Captured by driving the real app through the Electron E2E harness (`_electron.launch()` against the seeded test repo).

**Row at rest** — unchanged from today; the action occupies no width:

<img width="547" alt="Worktree row at rest, no rename icon" src="https://raw.githubusercontent.com/Jaeyoung22/orca/pr-assets-sidebar-rename/row-at-rest.png" />

**Row hovered** — pencil revealed at the right end. Note the title and metadata sit at exactly the same position as at rest, which is the layout-shift concern described above:

<img width="547" alt="Worktree row hovered, rename icon revealed at the right end" src="https://raw.githubusercontent.com/Jaeyoung22/orca/pr-assets-sidebar-rename/row-hovered.png" />

**Clicking it opens the existing inline editor:**

<img width="547" alt="Inline rename editor open with new text typed" src="https://raw.githubusercontent.com/Jaeyoung22/orca/pr-assets-sidebar-rename/row-editing.png" />

**After committing the rename:**

<img width="547" alt="Row showing the committed new name" src="https://raw.githubusercontent.com/Jaeyoung22/orca/pr-assets-sidebar-rename/row-after-rename.png" />

## Testing

- [x] `pnpm lint` — passes for the touched files. The full script exits on a **pre-existing** failure in `src/renderer/src/components/skills/skill-freshness-group.tsx:101` (`switch-exhaustiveness-check`) that reproduces on a clean `main` and is untouched here.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm test` — all renderer suites pass, including the new ones. The full run reports 2 failures in `src/main/` (`terminal-attribution`, `ssh-system-transport.integration`); both pass in isolation on this branch, and a full run on clean `main` in the same environment fails **19** tests across 8 files (relay/pty/git subprocess suites), so these are load-sensitive environment flakes rather than regressions from this change.
- [x] `pnpm build` — `build:desktop` (renderer + web) succeeds. `build:native` fails locally in the Swift `computer-use-macos` manifest step, which needs a full Xcode toolchain and is unrelated to this TypeScript change.
- [x] Added tests that would catch regressions:
  - rename button renders with its aria-label and the workspace-board-preserving attribute
  - it stays collapsed (`max-w-0`, `opacity-0`) until hover/focus-within, and the group defers `pr-1.5` — this is the test that catches the layout shift described above
  - it is absent while deleting and in affiliate list mode
  - the flex-gap cancel applies only when another action precedes it
  - clicking invokes the rename handler (happy-dom)
- [x] Verified in the running app, not just in unit tests: launched Electron through the E2E harness and drove the full path — hover reveals the action, clicking it opens the inline editor, typing and pressing Enter commits the new name (screenshots above).

## AI Review Report

Reviewed with Claude. Risks checked and outcomes:

- **Cross-platform (macOS / Linux / Windows)**: the reveal is pure CSS hover/focus-within — no `metaKey`/`ctrlKey` branching, no accelerators, no path handling, no shell invocation. Nothing platform-conditional was added. The review specifically flagged that this change deliberately does *not* fill in the empty Windows/Linux `workspace.rename` bindings, since those defaults are intentional per `keybindings.ts`.
- **Layout regression**: flagged during review that collapsing opacity alone leaves the flex gap and the group's trailing padding intact, which would move the details/ports lane on rows that previously rendered no header actions. Fixed by collapsing width plus gap plus gutter, and pinned with a dedicated test.
- **SSH / remote / local**: rename is renderer-local state plus the existing `updateWorktreeMeta` call. No new host round-trips, so local, SSH, and remote-server workspaces behave identically.
- **Agent / integration / git provider**: no provider- or agent-specific code paths touched; nothing GitHub- or GitLab-specific involved.
- **Performance**: one extra button per rendered sidebar row, reveal handled by CSS rather than React state, so no new re-render or hover-tracking work in a hot list.
- **UI quality**: follows `docs/STYLEGUIDE.md` — reuses existing tokens (`text-muted-foreground`, `bg-accent/70`) and the sibling delete button's sizing, tooltip, and event-hygiene conventions. No new color values or shadow tiers.
- **Accessibility**: `group-focus-within` and `focus-visible` mirror the delete button, so the action is keyboard-reachable rather than hover-only, and it carries a translated `aria-label`. Touch has no hover, but all three existing rename paths are untouched, so nothing regresses there.

## Security Audit

Low surface. No input parsing, command execution, path handling, auth, secrets, or new IPC. The button dispatches an existing renderer store action with a worktree id already in scope; persistence flows through the existing `updateWorktreeMeta` path with its existing validation. No dependencies added. Click handling stops propagation so it cannot be used to trigger row activation or the Kanban dismissal path unexpectedly.

## Notes

- Deliberately out of scope, since each needs a maintainer product call and would stall an otherwise mechanical change:
  - splitting a plain "Rename" item out of the context menu's "Update" modal
  - filling in Windows/Linux defaults for `workspace.rename`
- `WorktreeCard.tsx` is already grandfathered in `config/max-lines-baseline.txt`, so the button lives in its own `WorktreeRenameQuickAction.tsx` rather than growing that file further. No new `max-lines` suppression is introduced.

## ELI5

Worktree cards in the sidebar now show a clear Rename action when you hover them. You could already rename via double-click, context menu, or a shortcut, but none of those were obvious; this makes rename discoverable.
