### PR TITLE
fix(renderer): preserve workspace shortcut order when sidebar closes

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.lineage-child-real-card.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.lineage-child-real-card.test.tsx
@@ -17,6 +17,8 @@ import {
   LINEAGE_NESTED_ROW_SURFACE_INSET,
   WORKTREE_CARD_SURFACE_MARGIN
 } from './worktree-list-indentation'
+import { ALL_GROUP_KEY } from './worktree-list-groups'
+import { getVisibleWorktreeIds } from './visible-worktrees'
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true
 
@@ -231,7 +233,12 @@ function makeFolderWorkspacePathStatusState(): Record<string, unknown> {
 }
 
 function setLineageState(
-  options: { deletingChild?: boolean; includeGrandchild?: boolean } = {}
+  options: {
+    collapseAll?: boolean
+    deletingChild?: boolean
+    includeGrandchild?: boolean
+    pinChild?: boolean
+  } = {}
 ): void {
   const repo = makeRepo()
   const parent = makeWorktree({
@@ -248,6 +255,7 @@ function setLineageState(
     branch: 'child-branch',
     sortOrder: 10,
     overrides: {
+      isPinned: options.pinChild ?? false,
       linkedGitLabMR: 42,
       comment: 'Child handoff note'
     }
@@ -275,7 +283,7 @@ function setLineageState(
     agentStatusEpoch: 0,
     browserTabsByWorktree: {},
     clearPendingRevealWorktreeId: vi.fn(),
-    collapsedGroups: new Set<string>(),
+    collapsedGroups: new Set<string>(options.collapseAll ? [ALL_GROUP_KEY] : []),
     deleteStateByWorktreeId: options.deletingChild
       ? { [child.id]: { isDeleting: true, error: null, canForceDelete: false } }
       : {},
@@ -409,6 +417,37 @@ describe('WorktreeList real child WorktreeCard integration', () => {
     expect(childOption?.textContent).toContain('MR #42')
     expect(childOption?.textContent).toContain('Child GitLab MR')
     expect(childOption?.textContent).toContain('Child handoff note')
+  })
+
+  it('keeps workspace number order after the sidebar list unmounts', async () => {
+    setLineageState({ pinChild: true })
+    await renderWorktreeList()
+    const mountedOrder = getVisibleWorktreeIds()
+
+    expect(mountedOrder).toEqual(['child', 'parent'])
+
+    const root = mountedRoots.pop()
+    expect(root).toBeDefined()
+    await act(async () => {
+      root!.unmount()
+    })
+
+    expect(getVisibleWorktreeIds()).toEqual(mountedOrder)
+  })
+
+  it('keeps collapsed workspaces out of the number order after unmount', async () => {
+    setLineageState({ collapseAll: true })
+    await renderWorktreeList()
+
+    expect(getVisibleWorktreeIds()).toEqual([])
+
+    const root = mountedRoots.pop()
+    expect(root).toBeDefined()
+    await act(async () => {
+      root!.unmount()
+    })
+
+    expect(getVisibleWorktreeIds()).toEqual([])
   })
 
   it('keeps expanded child cards in the parent title column', async () => {

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -119,6 +119,7 @@ import { useWorkspaceStatusDocumentDrop } from './use-workspace-status-drop'
 import {
   computeClearFilterActions,
   computeVisibleWorktreeIds,
+  releaseVisibleWorktreeOrder,
   setVisibleWorktreeIds,
   sidebarHasActiveFilters
 } from './visible-worktrees'
@@ -5952,8 +5953,8 @@ const WorktreeList = React.memo(function WorktreeList({
   // Why layout effect: the Cmd/Ctrl+1–9 handler can fire right after commit; publishing after paint would leave the shortcut cache stale.
   useLayoutEffect(() => {
     setVisibleWorktreeIds(renderedWorktreeIds)
-    // Why: unmounting the list clears the rendered-order cache so shortcuts fall back to the live store snapshot.
-    return () => setVisibleWorktreeIds([])
+    // 原因：侧栏隐藏后仍需保留最后渲染顺序，实时回退只负责剔除失效项。
+    return releaseVisibleWorktreeOrder
   }, [renderedWorktreeIds])
 
   const handleCreateForRepo = useCallback(

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest'
 import {
   computeClearFilterActions,
   computeVisibleWorktreeIds,
+  getVisibleWorktreeIds,
   isDefaultBranchWorkspace,
+  pruneVisibleWorktreeOrder,
+  releaseVisibleWorktreeOrder,
+  setVisibleWorktreeIds,
   sidebarHasActiveFilters
 } from './visible-worktrees'
 import type { Repo, TerminalTab, Worktree, WorktreeLineage } from '../../../../shared/types'
@@ -692,6 +696,49 @@ describe('computeVisibleWorktreeIds', () => {
     )
 
     expect(result).toEqual([child.id])
+  })
+})
+
+describe('pruneVisibleWorktreeOrder', () => {
+  it('serves the published order directly while the rendered list is mounted', () => {
+    setVisibleWorktreeIds(['rendered-b', 'rendered-a'])
+    try {
+      expect(getVisibleWorktreeIds()).toEqual(['rendered-b', 'rendered-a'])
+    } finally {
+      releaseVisibleWorktreeOrder()
+    }
+  })
+
+  it('preserves the rendered grouped order when the fallback order differs', () => {
+    expect(
+      pruneVisibleWorktreeOrder(
+        ['pinned', 'repo-b-first', 'repo-a-first'],
+        ['repo-a-first', 'pinned', 'repo-b-first']
+      )
+    ).toEqual(['pinned', 'repo-b-first', 'repo-a-first'])
+  })
+
+  it('drops unavailable ids and duplicates without adding unrendered ids', () => {
+    expect(
+      pruneVisibleWorktreeOrder(
+        ['removed', 'existing-b', 'existing-b', 'existing-a'],
+        ['existing-a', 'existing-b', 'new-worktree']
+      )
+    ).toEqual(['existing-b', 'existing-a'])
+  })
+
+  it('retains folder workspace ids that are absent from the worktree fallback', () => {
+    expect(
+      pruneVisibleWorktreeOrder(
+        ['folder:project', 'worktree-a'],
+        ['worktree-a'],
+        new Set(['folder:project'])
+      )
+    ).toEqual(['folder:project', 'worktree-a'])
+  })
+
+  it('keeps an empty rendered order empty when fallback worktrees exist', () => {
+    expect(pruneVisibleWorktreeOrder([], ['worktree-b', 'worktree-a'])).toEqual([])
   })
 })
 

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -11,6 +11,7 @@ import {
   type ExecutionHostId,
   type ExecutionHostScope
 } from '../../../../shared/execution-host'
+import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
 import {
   getCyclicProjectedWorktreeLineageIds,
   getLineageRenderInfo
@@ -258,7 +259,8 @@ function addVisibleLineageAncestors(
  * position. By caching the IDs that WorktreeList actually rendered, the
  * shortcut numbering always matches the sidebar card order.
  */
-let _cachedVisibleIds: string[] = []
+let _cachedVisibleIds: string[] | null = null
+let _isRenderedOrderActive = false
 
 /**
  * Called by WorktreeList after computing visible worktrees so the Cmd+1–9
@@ -266,6 +268,29 @@ let _cachedVisibleIds: string[] = []
  */
 export function setVisibleWorktreeIds(ids: string[]): void {
   _cachedVisibleIds = ids
+  _isRenderedOrderActive = true
+}
+
+export function releaseVisibleWorktreeOrder(): void {
+  _isRenderedOrderActive = false
+}
+
+export function pruneVisibleWorktreeOrder(
+  renderedIds: readonly string[],
+  currentVisibleIds: readonly string[],
+  retainedIds: ReadonlySet<string> = new Set()
+): string[] {
+  const eligibleIds = new Set([...currentVisibleIds, ...retainedIds])
+  const prunedIds: string[] = []
+  const seenIds = new Set<string>()
+
+  for (const id of renderedIds) {
+    if (eligibleIds.has(id) && !seenIds.has(id)) {
+      prunedIds.push(id)
+      seenIds.add(id)
+    }
+  }
+  return prunedIds
 }
 
 /**
@@ -273,14 +298,15 @@ export function setVisibleWorktreeIds(ids: string[]): void {
  * state. Called by the App-level Cmd+1–9 handler (not a React hook — reads
  * store snapshot at call time).
  *
- * If WorktreeList has rendered at least once, returns the cached IDs so the
- * shortcut numbering matches the sidebar. Falls back to a live recomputation
- * only before WorktreeList's first render (e.g. app startup).
+ * WorktreeList 渲染后保留其顺序，并用实时可见集合剔除失效项；
+ * 首次渲染前直接使用实时计算结果。
  */
 export function getVisibleWorktreeIds(): string[] {
-  // Prefer the cached IDs that mirror the rendered sidebar order.
-  if (_cachedVisibleIds.length > 0) {
-    return _cachedVisibleIds
+  if (_isRenderedOrderActive) {
+    return _cachedVisibleIds ?? []
+  }
+  if (_cachedVisibleIds?.length === 0) {
+    return []
   }
 
   // Fallback: live recomputation for the window before WorktreeList renders.
@@ -312,7 +338,7 @@ export function getVisibleWorktreeIds(): string[] {
     sortedIds = sorted.map((w) => w.id)
   }
 
-  return computeVisibleWorktreeIds(state.worktreesByRepo, sortedIds, {
+  const currentVisibleIds = computeVisibleWorktreeIds(state.worktreesByRepo, sortedIds, {
     filterRepoIds: state.filterRepoIds,
     showSleepingWorkspaces: state.showSleepingWorkspaces,
     tabsByWorktree: state.tabsByWorktree,
@@ -331,4 +357,15 @@ export function getVisibleWorktreeIds(): string[] {
     defaultHostId: getSettingsFocusedExecutionHostId(state.settings),
     worktreeLineageById: state.worktreeLineageById
   })
+
+  if (_cachedVisibleIds === null) {
+    return currentVisibleIds
+  }
+
+  // 文件夹工作区不在 worktreesByRepo 中，不能因实时回退列表缺席而丢失其渲染位置。
+  const retainedFolderWorkspaceIds = new Set(
+    state.folderWorkspaces.map((workspace) => folderWorkspaceKey(workspace.id))
+  )
+  // 侧栏隐藏时没有新的渲染位置可依据，只收缩既有顺序，避免折叠项被重新追加。
+  return pruneVisibleWorktreeOrder(_cachedVisibleIds, currentVisibleIds, retainedFolderWorkspaceIds)
 }


### PR DESCRIPTION
## Summary

- Keep the last rendered sidebar workspace order authoritative after the sidebar unmounts.
- While the sidebar is hidden, prune workspaces that are no longer eligible without reintroducing collapsed or otherwise unrendered rows.
- Preserve folder workspaces and the latest mainline lineage projection, cycle detection, forced visibility, and ancestor injection behavior.

Fixes #9497

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
  - Touched-file Oxlint passed.
- [ ] `pnpm typecheck`
  - `pnpm typecheck:web` passed.
- [ ] `pnpm test`
  - Rebase regression tests passed: 2 files, 56 tests.
- [ ] `pnpm build`
  - Not rerun after the latest rebase; this change does not alter build configuration or bundled assets.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional repository gates passed: touched-file Oxfmt, `git diff --check`, max-lines ratchet, and reliability gates.

## AI Review Report

The review checked the rendered-order lifecycle when the sidebar mounts and unmounts, stale-ID pruning, duplicate removal, collapsed groups, empty rendered orders, pinned children, and folder-workspace retention. The rebase conflict was resolved by retaining both sides of the contract: the PR cache lifecycle and prune-only fallback, plus mainline lineage projection, cycle handling, `forcedVisibleWorktreeIds`, and `injectLineageAncestors`.

Cross-platform compatibility was reviewed for macOS, Linux, and Windows. The change only manages renderer-side workspace IDs and does not alter shortcuts, labels, filesystem paths, shell behavior, Electron platform branches, SSH execution, or Git-provider behavior.

## Security Audit

This change only reads and filters in-memory workspace IDs. It adds no command execution, path handling, authentication, secrets, dependencies, network access, or IPC behavior. IDs remain opaque and are deduplicated with sets. No follow-up security work is needed.

## Notes

- Rebased onto current `upstream/main` at `41751dd90`.
- No platform-specific, remote-only, agent-specific, integration-specific, or Git-provider-specific behavior is introduced.
- X/Twitter: N/A (no account)
