### PR TITLE
fix(composer): keep the imported group as the target after a grouped nested import

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -129,7 +129,8 @@ function QuickTabBody({
     nameInputRef,
     submitQuick,
     createDisabled,
-    selectAddedProjectRepo
+    selectAddedProjectRepo,
+    selectAddedProjectGroup
   } = useComposerState({
     initialName: modalData.prefilledName ?? '',
     // Why: the modal is quick-create only now, so prompt-prefill state is
@@ -207,6 +208,11 @@ function QuickTabBody({
     },
     [selectAddedProjectRepo]
   )
+  const handleProjectGroupImported = useCallback(
+    (projectGroupId: string): boolean => selectAddedProjectGroup(projectGroupId),
+    [selectAddedProjectGroup]
+  )
+
   const handleAddProjectCloseAutoFocus = useCallback(
     (event: Event): void => {
       // Why: after adding a project the next step is naming the worktree.
@@ -223,9 +229,10 @@ function QuickTabBody({
       open: addProjectOpen,
       onOpenChange: setAddProjectOpen,
       onProjectAdded: handleProjectAdded,
+      onProjectGroupImported: handleProjectGroupImported,
       onCloseAutoFocus: handleAddProjectCloseAutoFocus
     }),
-    [addProjectOpen, handleAddProjectCloseAutoFocus, handleProjectAdded]
+    [addProjectOpen, handleAddProjectCloseAutoFocus, handleProjectAdded, handleProjectGroupImported]
   )
   const selectedProjectOption = cardProps.projectOptions.find(
     (option) => option.id === cardProps.selectedProjectId

--- a/src/renderer/src/components/sidebar/use-add-repo-hosted-controller.test.ts
+++ b/src/renderer/src/components/sidebar/use-add-repo-hosted-controller.test.ts
@@ -85,12 +85,57 @@ describe('useAddRepoHostedController', () => {
       onOpenChange,
       onProjectAdded
     })
-    await finishProjectAdd?.('repo-1')
+    await finishProjectAdd?.('repo-1', 'local_folder_picker')
     expect(mocks.markOnboardingProjectAdded).toHaveBeenCalledWith('addedRepo')
     expect(onProjectAdded).toHaveBeenCalledWith('repo-1')
     // Why: closing before selection keeps the composer visible under the
     // dialog's close animation while the new project lands in the picker.
     expect(order).toEqual(['close', 'added'])
+  })
+
+  it('hands an imported group to the host instead of one member project', async () => {
+    const onProjectAdded = vi.fn()
+    const onProjectGroupImported = vi.fn(() => true)
+    const { finishProjectAdd } = useAddRepoHostedController({
+      open: true,
+      onOpenChange: vi.fn(),
+      onProjectAdded,
+      onProjectGroupImported
+    })
+    await finishProjectAdd?.('repo-1', 'local_folder_picker', {
+      importedProjectGroupId: 'group-1'
+    })
+    expect(onProjectGroupImported).toHaveBeenCalledWith('group-1')
+    // Why: the user asked to import as a group, so a member project is not
+    // the target they chose.
+    expect(onProjectAdded).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the project when the imported group is not selectable', async () => {
+    const onProjectAdded = vi.fn()
+    const { finishProjectAdd } = useAddRepoHostedController({
+      open: true,
+      onOpenChange: vi.fn(),
+      onProjectAdded,
+      onProjectGroupImported: vi.fn(() => false)
+    })
+    await finishProjectAdd?.('repo-1', 'local_folder_picker', {
+      importedProjectGroupId: 'group-1'
+    })
+    expect(onProjectAdded).toHaveBeenCalledWith('repo-1')
+  })
+
+  it('falls back to the project when the host cannot select groups', async () => {
+    const onProjectAdded = vi.fn()
+    const { finishProjectAdd } = useAddRepoHostedController({
+      open: true,
+      onOpenChange: vi.fn(),
+      onProjectAdded
+    })
+    await finishProjectAdd?.('repo-1', 'local_folder_picker', {
+      importedProjectGroupId: 'group-1'
+    })
+    expect(onProjectAdded).toHaveBeenCalledWith('repo-1')
   })
 
   it('SSH settings navigation closes both hosted dialog and composer modal', () => {

--- a/src/renderer/src/components/sidebar/use-add-repo-hosted-controller.ts
+++ b/src/renderer/src/components/sidebar/use-add-repo-hosted-controller.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react'
 import { useAppStore } from '@/store'
 import { markOnboardingProjectAdded } from '@/lib/onboarding-project-checklist'
+import type { CompleteGitRepoAdd } from './use-complete-git-repo-add'
 
 /** Contract a host surface (e.g. the workspace composer modal) passes to
  *  AddRepoDialog to nest it as a layered dialog instead of the store modal. */
@@ -10,6 +11,11 @@ export type AddRepoDialogHostedController = {
   /** Called after a Git project is added; the host selects the new project
    *  instead of running the default-checkout navigation handoff. */
   onProjectAdded: (repoId: string) => void | Promise<void>
+  /** Called after a nested folder import created a project group, so the host
+   *  can select the group the user asked for instead of one member project.
+   *  Returns false when the group is not selectable, which sends the caller
+   *  back to the single-project handoff. */
+  onProjectGroupImported?: (projectGroupId: string) => boolean
   /** Radix close-autofocus hook for the nested dialog. Lets the host redirect
    *  focus (e.g. to the composer's name field) instead of Radix restoring it
    *  to the already-unmounted combobox row that opened the dialog. */
@@ -23,7 +29,7 @@ export function useAddRepoHostedController(hosted: AddRepoDialogHostedController
    *  composer selection. Hosted mode must close the composer too — leaving it
    *  open would hide the navigation behind a stale project selection. */
   closeForFolderHandoff: () => void
-  finishProjectAdd: ((repoId: string) => Promise<void>) | undefined
+  finishProjectAdd: CompleteGitRepoAdd | undefined
   handleOpenSshSettings: () => void
 } {
   const storeCloseModal = useAppStore((s) => s.closeModal)
@@ -31,22 +37,29 @@ export function useAddRepoHostedController(hosted: AddRepoDialogHostedController
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
   const hostedOnOpenChange = hosted?.onOpenChange
   const hostedOnProjectAdded = hosted?.onProjectAdded
+  const hostedOnProjectGroupImported = hosted?.onProjectGroupImported
   // Why: hosted mode (nested inside the workspace composer) must close only
   // this dialog, never the composer modal that lives in the activeModal slot.
   const closeModal = useMemo(
     () => (hostedOnOpenChange ? () => hostedOnOpenChange(false) : storeCloseModal),
     [hostedOnOpenChange, storeCloseModal]
   )
-  const finishProjectAdd = useMemo(
+  const finishProjectAdd = useMemo<CompleteGitRepoAdd | undefined>(
     () =>
       hostedOnOpenChange && hostedOnProjectAdded
-        ? async (repoId: string): Promise<void> => {
+        ? async (repoId, _source, outcome): Promise<void> => {
             await markOnboardingProjectAdded('addedRepo')
             hostedOnOpenChange(false)
+            // Why: "import as group" picked the group as the target, so select
+            // it and fall back to the project only when it is not selectable.
+            const groupId = outcome?.importedProjectGroupId
+            if (groupId && hostedOnProjectGroupImported?.(groupId)) {
+              return
+            }
             await hostedOnProjectAdded(repoId)
           }
         : undefined,
-    [hostedOnOpenChange, hostedOnProjectAdded]
+    [hostedOnOpenChange, hostedOnProjectAdded, hostedOnProjectGroupImported]
   )
   const closeForFolderHandoff = useMemo(
     () =>

--- a/src/renderer/src/components/sidebar/use-complete-git-repo-add.ts
+++ b/src/renderer/src/components/sidebar/use-complete-git-repo-add.ts
@@ -9,27 +9,37 @@ import {
 import { compareWorktreeDisplayName } from '@/lib/worktree-display-name-order'
 import { finishProjectAddWithDefaultCheckout } from './project-added-default-checkout'
 
+/** Extra outcome the add flow carries into the handoff. */
+export type GitRepoAddOutcome = {
+  /** Root group a nested folder import created, when the user chose to import
+   *  as a group. Hosts that can target a group prefer it over a member. */
+  importedProjectGroupId?: string | undefined
+}
+
+export type CompleteGitRepoAdd = (
+  repoId: string,
+  source: AddRepoExistingWorkspaceSource,
+  outcome?: GitRepoAddOutcome
+) => Promise<void>
+
 type CompleteGitRepoAddOptions = {
   closeModal: () => void
   setHideDefaultBranchWorkspace: (hide: boolean) => void
   /** Why: the nested Add Project flow (hosted inside the workspace composer)
    *  keeps the composer open and selects the new project instead of running
    *  the default-checkout navigation handoff. Telemetry above still applies. */
-  finishProjectAdd?: (repoId: string, source: AddRepoExistingWorkspaceSource) => Promise<void>
+  finishProjectAdd?: CompleteGitRepoAdd
 }
 
 export function useCompleteGitRepoAdd({
   closeModal,
   setHideDefaultBranchWorkspace,
   finishProjectAdd
-}: CompleteGitRepoAddOptions): (
-  repoId: string,
-  source: AddRepoExistingWorkspaceSource
-) => Promise<void> {
+}: CompleteGitRepoAddOptions): CompleteGitRepoAdd {
   const detectedTelemetryTrackedRef = useRef<Set<string>>(new Set())
 
   return useCallback(
-    async (repoId: string, source: AddRepoExistingWorkspaceSource): Promise<void> => {
+    async (repoId, source, outcome): Promise<void> => {
       const worktrees = useAppStore.getState().worktreesByRepo[repoId] ?? []
       const sortedWorktrees = [...worktrees].sort((a, b) => {
         if (a.lastActivityAt !== b.lastActivityAt) {
@@ -50,7 +60,7 @@ export function useCompleteGitRepoAdd({
         track('add_repo_existing_workspaces_detected', existingWorkspaceTelemetry)
       }
       if (finishProjectAdd) {
-        await finishProjectAdd(repoId, source)
+        await finishProjectAdd(repoId, source, outcome)
         return
       }
       await finishProjectAddWithDefaultCheckout({

--- a/src/renderer/src/components/sidebar/use-complete-git-repo-add.ts
+++ b/src/renderer/src/components/sidebar/use-complete-git-repo-add.ts
@@ -16,6 +16,8 @@ export type GitRepoAddOutcome = {
   importedProjectGroupId?: string | undefined
 }
 
+/** Completion handoff shared by the add-repo flows: the added repo, its
+ *  telemetry source, and any extra outcome hosts may act on. */
 export type CompleteGitRepoAdd = (
   repoId: string,
   source: AddRepoExistingWorkspaceSource,

--- a/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.test.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.test.ts
@@ -50,6 +50,7 @@ vi.mock('@/lib/telemetry', () => ({
   track: vi.fn()
 }))
 
+import { toast } from 'sonner'
 import { track } from '@/lib/telemetry'
 import { useAddRepoNestedImportFlow } from './useAddRepoNestedImportFlow'
 
@@ -64,6 +65,51 @@ const scan: NestedRepoScanResult = {
   maxDepth: 3,
   maxRepos: 100,
   timeoutMs: null
+}
+
+const gitRepo: Repo = {
+  id: 'app',
+  path: '/workspace/platform/app',
+  displayName: 'app',
+  badgeColor: '#999999',
+  addedAt: 2,
+  kind: 'git'
+}
+
+const groupImportResult: ProjectGroupImportResult = {
+  group: {
+    id: 'group-1',
+    name: 'platform',
+    parentPath: '/workspace/platform',
+    parentGroupId: null,
+    createdFrom: 'folder-scan',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 3,
+    updatedAt: 3
+  },
+  projects: [{ path: '/workspace/platform/app', projectId: 'app', status: 'imported' }],
+  importedCount: 1,
+  alreadyKnownCount: 0,
+  failedCount: 0
+}
+
+const apiRepo: Repo = {
+  id: 'api',
+  path: '/workspace/platform/api',
+  displayName: 'api',
+  badgeColor: '#999999',
+  addedAt: 2,
+  kind: 'git'
+}
+
+const twoRepoScan: NestedRepoScanResult = {
+  ...scan,
+  repos: [
+    { path: '/workspace/platform/app', displayName: 'app', depth: 1 },
+    { path: '/workspace/platform/api', displayName: 'api', depth: 1 }
+  ]
 }
 
 function useTestAddRepoNestedImportFlow(
@@ -151,6 +197,136 @@ describe('useAddRepoNestedImportFlow open folder fallback', () => {
     expect(mocks.state.openModal).toHaveBeenCalledWith('confirm-non-git-folder', {
       folderPath: '/workspace/platform',
       connectionId: 'ssh-builder'
+    })
+  })
+})
+
+describe('useAddRepoNestedImportFlow grouped import handoff', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.state.repos = [gitRepo]
+  })
+
+  it('carries the created group into the handoff so the group stays the target', async () => {
+    const onGitRepoReady = vi.fn()
+    const { handleImportNestedRepos } = useTestAddRepoNestedImportFlow({
+      nestedSelectedPaths: new Set(['/workspace/platform/app']),
+      importNestedRepos: vi.fn(() => Promise.resolve(groupImportResult)),
+      onGitRepoReady
+    })
+
+    await handleImportNestedRepos('group')
+
+    expect(onGitRepoReady).toHaveBeenCalledWith('app', 'local_folder_picker', {
+      importedProjectGroupId: 'group-1'
+    })
+  })
+
+  it('reveals every imported member and hands off the first repo in scan order', async () => {
+    const onGitRepoReady = vi.fn()
+    const fetchWorktrees = vi.fn()
+    const importNestedRepos = vi.fn(() =>
+      Promise.resolve({
+        ...groupImportResult,
+        projects: [
+          { path: '/workspace/platform/app', projectId: 'app', status: 'imported' as const },
+          { path: '/workspace/platform/api', projectId: 'api', status: 'imported' as const }
+        ],
+        importedCount: 2
+      })
+    )
+    mocks.state.repos = [gitRepo, apiRepo]
+    const { handleImportNestedRepos } = useTestAddRepoNestedImportFlow({
+      nestedScan: twoRepoScan,
+      // Why: Set insertion order is deliberately reversed — the handoff must
+      // follow the scan order users reviewed, not selection order.
+      nestedSelectedPaths: new Set(['/workspace/platform/api', '/workspace/platform/app']),
+      importNestedRepos,
+      fetchWorktrees,
+      onGitRepoReady
+    })
+
+    await handleImportNestedRepos('group')
+
+    expect(importNestedRepos).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectPaths: ['/workspace/platform/app', '/workspace/platform/api']
+      })
+    )
+    expect(fetchWorktrees).toHaveBeenCalledTimes(2)
+    expect(fetchWorktrees).toHaveBeenCalledWith('app', { requireAuthoritative: true })
+    expect(fetchWorktrees).toHaveBeenCalledWith('api', { requireAuthoritative: true })
+    expect(onGitRepoReady).toHaveBeenCalledTimes(1)
+    expect(onGitRepoReady).toHaveBeenCalledWith('app', 'local_folder_picker', {
+      importedProjectGroupId: 'group-1'
+    })
+  })
+
+  it('keeps the group as the handoff target when part of the import fails', async () => {
+    const onGitRepoReady = vi.fn()
+    const { handleImportNestedRepos } = useTestAddRepoNestedImportFlow({
+      nestedScan: twoRepoScan,
+      nestedSelectedPaths: new Set(['/workspace/platform/app', '/workspace/platform/api']),
+      importNestedRepos: vi.fn(() =>
+        Promise.resolve({
+          ...groupImportResult,
+          projects: [
+            { path: '/workspace/platform/app', projectId: 'app', status: 'imported' as const },
+            { path: '/workspace/platform/api', status: 'failed' as const, error: 'clone failed' }
+          ],
+          failedCount: 1
+        })
+      ),
+      onGitRepoReady
+    })
+
+    await handleImportNestedRepos('group')
+
+    // Why: the group still exists with its surviving member, so a partial
+    // failure warns without downgrading the target to a lone project.
+    expect(toast.warning).toHaveBeenCalledTimes(1)
+    expect(onGitRepoReady).toHaveBeenCalledWith('app', 'local_folder_picker', {
+      importedProjectGroupId: 'group-1'
+    })
+  })
+
+  it('never reaches the handoff when every import fails', async () => {
+    const onGitRepoReady = vi.fn()
+    const { handleImportNestedRepos } = useTestAddRepoNestedImportFlow({
+      nestedSelectedPaths: new Set(['/workspace/platform/app']),
+      importNestedRepos: vi.fn(() =>
+        Promise.resolve({
+          ...groupImportResult,
+          projects: [
+            { path: '/workspace/platform/app', status: 'failed' as const, error: 'clone failed' }
+          ],
+          importedCount: 0,
+          failedCount: 1
+        })
+      ),
+      onGitRepoReady
+    })
+
+    await handleImportNestedRepos('group')
+
+    // Why: with zero imported repos the flow surfaces the first failure and
+    // stops, so composer group selection can never see an all-failed import.
+    expect(toast.error).toHaveBeenCalledWith(expect.any(String), { description: 'clone failed' })
+    expect(onGitRepoReady).not.toHaveBeenCalled()
+  })
+
+  it('carries no group for separate imports, which create none', async () => {
+    const onGitRepoReady = vi.fn()
+    const { handleImportNestedRepos } = useTestAddRepoNestedImportFlow({
+      nestedSelectedPaths: new Set(['/workspace/platform/app']),
+      importNestedRepos: vi.fn(() => Promise.resolve({ ...groupImportResult, group: undefined })),
+      onGitRepoReady
+    })
+
+    await handleImportNestedRepos('separate')
+
+    expect(onGitRepoReady).toHaveBeenCalledWith('app', 'local_folder_picker', {
+      importedProjectGroupId: undefined
     })
   })
 })

--- a/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoNestedImportFlow.ts
@@ -10,6 +10,7 @@ import {
   type NestedRepoTelemetryRuntimeKind
 } from '../../../../shared/nested-repo-telemetry'
 import type { AddRepoExistingWorkspaceSource } from '../../../../shared/telemetry-events'
+import type { CompleteGitRepoAdd } from './use-complete-git-repo-add'
 import type { NestedRepoScanResult, ProjectGroupImportResult } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
 
@@ -50,7 +51,7 @@ export function useAddRepoNestedImportFlow({
     mode: 'group' | 'separate'
   }) => Promise<ProjectGroupImportResult | null>
   getNestedRepoRuntimeKind: (connectionId: string | null) => NestedRepoTelemetryRuntimeKind
-  onGitRepoReady: (repoId: string, source: AddRepoExistingWorkspaceSource) => Promise<void>
+  onGitRepoReady: CompleteGitRepoAdd
   setIsAdding: (isAdding: boolean) => void
 }): {
   handleImportNestedRepos: (mode: 'group' | 'separate') => Promise<void>
@@ -198,7 +199,9 @@ export function useAddRepoNestedImportFlow({
             : activeRuntimeEnvironmentId?.trim()
               ? 'runtime_server_path'
               : 'local_folder_picker'
-          await onGitRepoReady(repo.id, source)
+          // Why: "import as group" chose the group as the target, so the
+          // handoff must offer it instead of one arbitrary member project.
+          await onGitRepoReady(repo.id, source, { importedProjectGroupId: result.group?.id })
         }
       } catch (err) {
         if (gen === nestedImportGenRef.current) {

--- a/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
+++ b/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
@@ -565,7 +565,7 @@ describe('useComposerState host-context boundaries', () => {
   it('preserves Jira linked items when switching from repo target to folder target', () => {
     const section = sourceBetween(
       HOOK_SOURCE,
-      'const handleProjectChange = useCallback',
+      'const applyProjectGroupSelection = useCallback',
       'const handleSmartGitHubItemSelect'
     )
     expect(section).toContain("linkedProvider !== 'linear' && linkedProvider !== 'jira'")

--- a/src/renderer/src/hooks/useComposerState-project-group-target.test.ts
+++ b/src/renderer/src/hooks/useComposerState-project-group-target.test.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import type { ProjectGroup, Repo } from '../../../shared/types'
+import { resolveProjectGroupComposerTarget } from './useComposerState'
+
+const HOOK_SOURCE = readFileSync(join(__dirname, 'useComposerState.ts'), 'utf8')
+
+function hookSourceBetween(startMarker: string, endMarker: string): string {
+  const start = HOOK_SOURCE.indexOf(startMarker)
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = HOOK_SOURCE.indexOf(endMarker, start)
+  expect(end).toBeGreaterThan(start)
+  return HOOK_SOURCE.slice(start, end)
+}
+
+function makeProjectGroup(overrides: Partial<ProjectGroup> = {}): ProjectGroup {
+  return {
+    id: 'group-1',
+    name: 'platform',
+    parentPath: '/workspace/platform',
+    parentGroupId: null,
+    createdFrom: 'folder-scan',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'app',
+    path: '/workspace/platform/app',
+    displayName: 'app',
+    badgeColor: '#999999',
+    addedAt: 1,
+    kind: 'git',
+    projectGroupId: 'group-1',
+    ...overrides
+  }
+}
+
+describe('resolveProjectGroupComposerTarget', () => {
+  it('resolves a folder-backed group to its first source project', () => {
+    const group = makeProjectGroup()
+    const repo = makeRepo()
+
+    expect(
+      resolveProjectGroupComposerTarget({
+        projectGroupId: 'group-1',
+        projectGroups: [group],
+        repos: [repo]
+      })
+    ).toEqual({ projectGroup: group, sourceRepoId: 'app' })
+  })
+
+  it('resolves a group whose member projects are gone, with an empty source repo', () => {
+    const group = makeProjectGroup()
+
+    // Why: members can be removed while a selection is in flight; the folder
+    // target itself stays valid, as handleProjectChange has always allowed.
+    expect(
+      resolveProjectGroupComposerTarget({
+        projectGroupId: 'group-1',
+        projectGroups: [group],
+        repos: []
+      })
+    ).toEqual({ projectGroup: group, sourceRepoId: '' })
+  })
+
+  it('rejects a group that is no longer known', () => {
+    expect(
+      resolveProjectGroupComposerTarget({
+        projectGroupId: 'group-gone',
+        projectGroups: [makeProjectGroup()],
+        repos: [makeRepo()]
+      })
+    ).toBeNull()
+  })
+
+  it('rejects a group with no folder root, which cannot back a workspace', () => {
+    expect(
+      resolveProjectGroupComposerTarget({
+        projectGroupId: 'group-1',
+        projectGroups: [makeProjectGroup({ parentPath: '   ' })],
+        repos: [makeRepo()]
+      })
+    ).toBeNull()
+  })
+})
+
+describe('selectAddedProjectGroup', () => {
+  it('resolves the imported group from live store state, not the render closure', () => {
+    const section = hookSourceBetween('const selectAddedProjectGroup = useCallback', 'return true')
+    // Why: the group and its projects land during the import this callback
+    // completes, so a closure read would miss both and silently fall back.
+    expect(section).toContain('useAppStore.getState()')
+    expect(section).toContain('projectGroups: state.projectGroups')
+    expect(section).toContain('repos: state.repos')
+  })
+
+  it('selects the group through the same path as a manual combobox pick', () => {
+    const applyCall = 'applyProjectGroupSelection(selection.projectGroup, selection.sourceRepoId)'
+    // Why: sharing applyProjectGroupSelection keeps the import handoff
+    // behaviorally identical to picking the group in the project combobox,
+    // whose state resets the host-context-boundaries suite already pins.
+    expect(
+      hookSourceBetween('const selectAddedProjectGroup = useCallback', 'return true')
+    ).toContain(applyCall)
+    expect(
+      hookSourceBetween('const handleProjectChange = useCallback', 'const selectAddedProjectRepo')
+    ).toContain(applyCall)
+  })
+
+  it('marks the initial group applied so a late initial selection cannot override the import', () => {
+    const section = hookSourceBetween('const selectAddedProjectGroup = useCallback', 'return true')
+    expect(section).toContain('initialProjectGroupAppliedRef.current = true')
+  })
+
+  it('bails out before applying any composer state when the group is not selectable', () => {
+    const section = hookSourceBetween('const selectAddedProjectGroup = useCallback', 'return true')
+    expect(section.indexOf('return false')).toBeGreaterThanOrEqual(0)
+    expect(section.indexOf('applyProjectGroupSelection')).toBeGreaterThan(
+      section.indexOf('return false')
+    )
+  })
+})

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -53,7 +53,8 @@ import type {
   WorktreeMeta,
   WorkspaceStatus,
   WorkspaceCreateTelemetrySource,
-  ProjectGroup
+  ProjectGroup,
+  Repo
 } from '../../../shared/types'
 import { isWorkspaceStatusId } from '../../../shared/workspace-statuses'
 import {
@@ -394,6 +395,10 @@ export type UseComposerStateResult = {
   /** Selects the repo a nested Add Project flow just added, clearing any
    *  folder-group target so the composer lands on the new project. */
   selectAddedProjectRepo: (repoId: string) => void
+  /** Selects the project group a nested folder import just created. Returns
+   *  false when the group is no longer selectable, so the caller can fall back
+   *  to the single-project handoff. */
+  selectAddedProjectGroup: (projectGroupId: string) => boolean
 }
 
 export type InitialWorkspaceRunSeedInput = {
@@ -535,6 +540,30 @@ export function getInitialAutoManagedWorkspaceName({
   const candidateName = draftName ?? initialName
   const seedName = getLinkedWorkItemSeedName(draftLinkedWorkItem ?? initialLinkedWorkItem)
   return candidateName && seedName && candidateName === seedName ? candidateName : ''
+}
+
+export function resolveProjectGroupComposerTarget({
+  projectGroupId,
+  projectGroups,
+  repos
+}: {
+  projectGroupId: string
+  projectGroups: readonly ProjectGroup[]
+  repos: readonly Repo[]
+}): { projectGroup: ProjectGroup; sourceRepoId: string } | null {
+  // Why: only folder-backed groups are composer targets, and the group can
+  // already be gone by selection time (deleted while a handoff was in flight;
+  // an all-failed import never reaches this — the flow stops with a toast).
+  const projectGroup = projectGroups.find(
+    (group) => group.id === projectGroupId && Boolean(group.parentPath?.trim())
+  )
+  if (!projectGroup) {
+    return null
+  }
+  return {
+    projectGroup,
+    sourceRepoId: getFolderSourceRepos(repos, projectGroups, projectGroup)[0]?.id ?? ''
+  }
 }
 
 // Why: both the full-page TaskPage composer and the Cmd+J modal can be
@@ -2742,15 +2771,45 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     },
     [handleRepoChange, projectHostSetupOptions]
   )
+  const applyProjectGroupSelection = useCallback(
+    (nextProjectGroup: ProjectGroup, nextSourceRepoId: string): void => {
+      setSelectedProjectGroupId(nextProjectGroup.id)
+      setProjectError(null)
+      setRepoId(nextSourceRepoId)
+      setLinkedIssue('')
+      setLinkedPR(null)
+      setLinkedGitLabIssue(null)
+      setLinkedGitLabMR(null)
+      const linkedProvider = linkedWorkItem ? getLinkedWorkItemProvider(linkedWorkItem) : null
+      if (linkedWorkItem && linkedProvider !== 'linear' && linkedProvider !== 'jira') {
+        setLinkedWorkItem(null)
+      }
+      setSparseEnabled(false)
+      setSparseDirectories('')
+      setSparseSelectedPresetId(null)
+      setBaseBranch(undefined)
+      setPushTarget(undefined)
+      setBranchNameOverride(undefined)
+      // Why (#5181): clear branch-scoped reuse state on a project switch too.
+      setBranchNameOverridePreservesNameEdits(false)
+      setReuseEligibleBranch(null)
+      setReuseSelectedBranch(false)
+      setForkPushWarning(null)
+      setStartFromResetHint(null)
+    },
+    [linkedWorkItem, setRepoId]
+  )
   const handleProjectChange = useCallback(
     (projectId: string): void => {
       initialProjectGroupAppliedRef.current = true
       const projectGroupId = getProjectGroupIdFromNewWorkspaceOptionId(projectId)
       if (projectGroupId) {
-        const nextProjectGroup = projectGroups.find(
-          (group) => group.id === projectGroupId && Boolean(group.parentPath?.trim())
-        )
-        if (!nextProjectGroup) {
+        const selection = resolveProjectGroupComposerTarget({
+          projectGroupId,
+          projectGroups,
+          repos
+        })
+        if (!selection) {
           setSelectedProjectGroupId(null)
           setProjectError(
             translate(
@@ -2760,30 +2819,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           )
           return
         }
-        const nextSourceRepo = getFolderSourceRepos(repos, projectGroups, nextProjectGroup)[0]
-        setSelectedProjectGroupId(nextProjectGroup.id)
-        setProjectError(null)
-        setRepoId(nextSourceRepo?.id ?? '')
-        setLinkedIssue('')
-        setLinkedPR(null)
-        setLinkedGitLabIssue(null)
-        setLinkedGitLabMR(null)
-        const linkedProvider = linkedWorkItem ? getLinkedWorkItemProvider(linkedWorkItem) : null
-        if (linkedWorkItem && linkedProvider !== 'linear' && linkedProvider !== 'jira') {
-          setLinkedWorkItem(null)
-        }
-        setSparseEnabled(false)
-        setSparseDirectories('')
-        setSparseSelectedPresetId(null)
-        setBaseBranch(undefined)
-        setPushTarget(undefined)
-        setBranchNameOverride(undefined)
-        // Why (#5181): clear branch-scoped reuse state on a project switch too.
-        setBranchNameOverridePreservesNameEdits(false)
-        setReuseEligibleBranch(null)
-        setReuseSelectedBranch(false)
-        setForkPushWarning(null)
-        setStartFromResetHint(null)
+        applyProjectGroupSelection(selection.projectGroup, selection.sourceRepoId)
         return
       }
 
@@ -2809,15 +2845,14 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       handleRepoChange(nextRepoId, { forceResetStartFrom: isProjectGroupTarget })
     },
     [
+      applyProjectGroupSelection,
       eligibleRepos,
       handleRepoChange,
       isProjectGroupTarget,
-      linkedWorkItem,
       projectGroups,
       projectHostSetups,
       projects,
       repos,
-      setRepoId,
       selectedWorkspaceTarget,
       workspaceHostScope
     ]
@@ -2833,6 +2868,26 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       handleRepoChange(nextRepoId)
     },
     [handleRepoChange]
+  )
+  const selectAddedProjectGroup = useCallback(
+    (projectGroupId: string): boolean => {
+      // Why: the group and its projects were created by the import this call
+      // is completing, so the render-time `projectGroups`/`repos` closures are
+      // still behind the store and would not find either.
+      const state = useAppStore.getState()
+      const selection = resolveProjectGroupComposerTarget({
+        projectGroupId,
+        projectGroups: state.projectGroups,
+        repos: state.repos
+      })
+      if (!selection) {
+        return false
+      }
+      initialProjectGroupAppliedRef.current = true
+      applyProjectGroupSelection(selection.projectGroup, selection.sourceRepoId)
+      return true
+    },
+    [applyProjectGroupSelection]
   )
 
   const showProjectRequiredError = useCallback((): void => {
@@ -4457,6 +4512,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     submit,
     submitQuick,
     createDisabled,
-    selectAddedProjectRepo
+    selectAddedProjectRepo,
+    selectAddedProjectGroup
   }
 }


### PR DESCRIPTION
Part A of #9529.

## Summary

When Add Project (hosted inside the new-workspace composer) scans a folder and the user picks **"Yes, import as group"**, the main process creates the project group and returns it in `ProjectGroupImportResult.group` — but the renderer handoff dropped it: `selectAddedProjectRepo` cleared any folder-group target and selected only the first imported repo. The user explicitly imported a group, yet the composer ended up targeting an arbitrary member project and the new group had to be re-found manually in the combobox.

Now the created root group is carried through the completion path and the composer selects the group's folder-workspace target:

- `useAddRepoNestedImportFlow` passes `result.group?.id` into the completion callback as `GitRepoAddOutcome.importedProjectGroupId` on the shared `CompleteGitRepoAdd` contract.
- The hosted controller prefers the new optional `onProjectGroupImported(groupId)` host callback; when the host declines (group no longer selectable) or does not provide it, the existing first-repo handoff runs unchanged.
- `useComposerState.selectAddedProjectGroup` resolves the group from live store state (the render closure predates the import) and applies the exact same selection path as picking the group in the project combobox — `applyProjectGroupSelection`, extracted from `handleProjectChange` so both entry points share one implementation.
- "Import separately" and the sidebar (store-modal) default-checkout handoff keep their current behavior.

## Screenshots

No new visual components — this reuses the existing project-group ("Shared Folder") selection UI; only which target gets selected after the import changes. I could not capture a recording in this headless session; the repro in #9529 (composer → Add Project → folder with 2+ git repos → "Yes, import as group") now lands on the group target instead of the first repo.

## Testing

- [ ] `pnpm lint` — fails only on 2 pre-existing `lint:switch-exhaustiveness` errors in `src/renderer/src/components/skills/skill-freshness-group.tsx` and `src/main/daemon/daemon-server.ts`; both files are byte-identical to base `main` (5fcf77761), so the failures reproduce without this PR. Every other lint step passes (oxlint, react-doctor, styled-scrollbars, reliability gates, max-lines ratchet, skill guides, localization catalog/coverage).
- [x] `pnpm typecheck` (node, cli, web — all clean)
- [x] `pnpm test`
- [x] `pnpm build` — ran the `build:electron-vite` bundling stage (main/preload/renderer); the full desktop pipeline (relay/cli/native/web) is left to CI as this change is renderer-only.
- [x] Added or updated high-quality tests that would catch regressions

New/updated tests:

- `useAddRepoNestedImportFlow`: group id carried on grouped import; none for separate imports; multi-repo import reveals every member and hands off the first repo in scan order (not Set insertion order); partial failure keeps the group as the target and surfaces a warning; an all-failed import stops with an error toast before the handoff.
- `use-add-repo-hosted-controller`: imported group preferred over a member project; fallback to the project when the host declines or cannot select groups.
- `useComposerState-project-group-target` (new file): behavioral tests for `resolveProjectGroupComposerTarget` (folder-backed group, group with no remaining members, unknown group, group without a folder root) plus source-pinned invariants for `selectAddedProjectGroup` (live-store read, shared selection path with the combobox, initial-selection override guard, bail-out before applying state).

## AI Review Report

Reviewed with Claude Code. Main risks checked and outcomes:

- **Stale-closure handoff**: the group and its projects are created by the import the callback completes, so `selectAddedProjectGroup` reads `useAppStore.getState()` instead of render-time props; a source-pinned test guards this.
- **Fallback correctness**: every degenerate path (no group created, group deleted mid-flight, host cannot select groups, host declines) falls back to the pre-existing first-repo handoff; covered by tests.
- **Behavior parity**: import-selection and combobox-selection share `applyProjectGroupSelection`, so the state resets pinned by the existing host-context-boundaries suite (Linear/Jira link preservation, sparse checkout, branch reuse, #5181) apply identically to both.
- **Hook dependency arrays**: `linkedWorkItem`/`setRepoId` moved with the extracted callback; verified no remaining direct references in `handleProjectChange`.
- **Cross-platform (macOS/Linux/Windows)**: no keyboard shortcuts, labels, path joins, shell, or Electron platform branches touched; repo/group ids are opaque strings and paths flow through the existing scan/import IPC unchanged. Test fixtures use literal strings only.
- **SSH**: source mapping (`ssh_remote_path` / `runtime_server_path` / `local_folder_picker`) is untouched; the group handoff is source-agnostic, so SSH imports take the same path.
- **Git compatibility / providers**: no Git commands or provider-specific behavior touched.

Flagged and fixed during review: a misleading resolver comment/test claiming an "all imports failed" state can reach composer selection — it cannot (the flow stops with an error toast first); the comment, test description, and a new reachability test now document the real degenerate states.

## Security Audit

Renderer-only state handoff; no new IPC surface, command execution, file/path handling, auth, secrets, or dependencies. The only new input is the group id returned by the existing `projectGroups:importNested` IPC result, and it is never trusted directly: `resolveProjectGroupComposerTarget` re-resolves it against current store state (must exist and be folder-backed) before any selection is applied, so a deleted or unknown id degrades to the existing single-project handoff. No follow-up needed.

## Notes

- Deliberate contract decision for #9529 Part B: the handoff carries only `importedProjectGroupId`, not the imported repo-id list. Missions store a `repoIds` snapshot taken at selection time (decision recorded in #9529), and a Mission-hosted flow can read the full `ProjectGroupImportResult.projects` directly, so adding repo ids here would be dead code in this PR.
- The sidebar (non-hosted) flow intentionally keeps its default-checkout handoff, per the fix direction in #9529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI5

When you import a folder as a project group, Orca was still aiming the new-workspace composer at a random member repo instead of the group you just created. After this fix, the composer stays on that imported group as the target.
