### PR TITLE
fix(pet): mirror Codex's settle-into-idle player semantics

### DIFF
--- a/src/main/ipc/pet.test.ts
+++ b/src/main/ipc/pet.test.ts
@@ -129,7 +129,17 @@ describe('registerPetHandlers', () => {
   }
 
   async function writeSpriteBundle(
-    animations: Record<string, { row: number; frames: number; frameDurationsMs?: number[] }>
+    animations: Record<
+      string,
+      {
+        row: number
+        frames: number
+        frameDurationsMs?: number[]
+        repeat?: number
+        settleTo?: string
+      }
+    >,
+    sheetWidth = 4
   ): Promise<string> {
     const bundleDir = join(tempDir, 'durations.codex-pet')
     await mkdir(bundleDir, { recursive: true })
@@ -143,7 +153,7 @@ describe('registerPetHandlers', () => {
         animations
       })
     )
-    await writeFile(join(bundleDir, 'sheet.webp'), webpVp8x(4, 2))
+    await writeFile(join(bundleDir, 'sheet.webp'), webpVp8x(sheetWidth, 2))
     return bundleDir
   }
 
@@ -170,6 +180,51 @@ describe('registerPetHandlers', () => {
 
     await expect(getHandler('pet:importPetBundle')({ sender: {} })).rejects.toThrow(
       'declares 1 frame durations but 2 frames'
+    )
+  })
+
+  it('imports repeat and settleTo so app states can settle into idle', async () => {
+    const bundleDir = await writeSpriteBundle({
+      idle: { row: 0, frames: 2 },
+      running: { row: 0, frames: 2, repeat: 3, settleTo: 'idle' }
+    })
+    showOpenDialogMock.mockResolvedValue({ canceled: false, filePaths: [bundleDir] })
+
+    const result = (await getHandler('pet:importPetBundle')({ sender: {} })) as CustomPet
+
+    expect(result.sprite?.animations?.running).toEqual({
+      row: 0,
+      frames: 2,
+      repeat: 3,
+      settleTo: 'idle'
+    })
+  })
+
+  it('rejects a settleTo that names a missing animation', async () => {
+    const bundleDir = await writeSpriteBundle({
+      idle: { row: 0, frames: 2, settleTo: 'nap' }
+    })
+    showOpenDialogMock.mockResolvedValue({ canceled: false, filePaths: [bundleDir] })
+
+    await expect(getHandler('pet:importPetBundle')({ sender: {} })).rejects.toThrow(
+      'settles to "nap" which is not in animations'
+    )
+  })
+
+  it('rejects repeats whose expanded frame count exceeds the keyframe cap', async () => {
+    // A 2048px sheet gives 1024 columns, so 512 frames pass the column check
+    // and only the repeat product trips.
+    const bundleDir = await writeSpriteBundle(
+      {
+        idle: { row: 0, frames: 2 },
+        running: { row: 0, frames: 512, repeat: 2, settleTo: 'idle' }
+      },
+      2048
+    )
+    showOpenDialogMock.mockResolvedValue({ canceled: false, filePaths: [bundleDir] })
+
+    await expect(getHandler('pet:importPetBundle')({ sender: {} })).rejects.toThrow(
+      'exceeding the 512 keyframe cap'
     )
   })
 })

--- a/src/main/ipc/pet.test.ts
+++ b/src/main/ipc/pet.test.ts
@@ -185,8 +185,8 @@ describe('registerPetHandlers', () => {
 
   it('imports repeat and settleTo so app states can settle into idle', async () => {
     const bundleDir = await writeSpriteBundle({
-      idle: { row: 0, frames: 2 },
-      running: { row: 0, frames: 2, repeat: 3, settleTo: 'idle' }
+      idle: { row: 0, frames: 2, frameDurationsMs: [1680, 1920] },
+      running: { row: 0, frames: 2, frameDurationsMs: [120, 220], repeat: 3, settleTo: 'idle' }
     })
     showOpenDialogMock.mockResolvedValue({ canceled: false, filePaths: [bundleDir] })
 
@@ -195,9 +195,49 @@ describe('registerPetHandlers', () => {
     expect(result.sprite?.animations?.running).toEqual({
       row: 0,
       frames: 2,
+      frameDurationsMs: [120, 220],
       repeat: 3,
       settleTo: 'idle'
     })
+  })
+
+  it('rejects settle declarations the renderer would silently ignore', async () => {
+    const invalid: [Record<string, Parameters<typeof writeSpriteBundle>[0][string]>, string][] = [
+      // repeat without settleTo
+      [
+        { idle: { row: 0, frames: 2, frameDurationsMs: [100, 200], repeat: 3 } },
+        'needs both repeat and settleTo'
+      ],
+      // settling into itself
+      [
+        {
+          idle: { row: 0, frames: 2, frameDurationsMs: [100, 200], repeat: 3, settleTo: 'idle' }
+        },
+        'cannot settle to itself'
+      ],
+      // no durations on the settling row
+      [
+        {
+          idle: { row: 0, frames: 2, frameDurationsMs: [100, 200] },
+          running: { row: 0, frames: 2, repeat: 3, settleTo: 'idle' }
+        },
+        'must both carry frameDurationsMs'
+      ],
+      // no durations on the settle target
+      [
+        {
+          idle: { row: 0, frames: 2 },
+          running: { row: 0, frames: 2, frameDurationsMs: [120, 220], repeat: 3, settleTo: 'idle' }
+        },
+        'must both carry frameDurationsMs'
+      ]
+    ]
+    for (const [animations, message] of invalid) {
+      const bundleDir = await writeSpriteBundle(animations)
+      showOpenDialogMock.mockResolvedValue({ canceled: false, filePaths: [bundleDir] })
+
+      await expect(getHandler('pet:importPetBundle')({ sender: {} })).rejects.toThrow(message)
+    }
   })
 
   it('rejects a settleTo that names a missing animation', async () => {

--- a/src/main/ipc/pet.ts
+++ b/src/main/ipc/pet.ts
@@ -114,7 +114,11 @@ const PetManifestSchema = z
           row: z.number().int().min(0).max(256),
           frames: z.number().int().positive().max(512),
           // Why: cap each hold at 60s so a bad manifest can't freeze the overlay.
-          frameDurationsMs: z.array(z.number().positive().max(60_000)).max(512).optional()
+          frameDurationsMs: z.array(z.number().positive().max(60_000)).max(512).optional(),
+          // Why: repeat x frames becomes one keyframe stop each. The product
+          // cap is enforced with the other cross-field checks below.
+          repeat: z.number().int().min(1).max(64).optional(),
+          settleTo: z.string().min(1).max(64).optional()
         })
       )
       .optional()
@@ -399,6 +403,18 @@ export function registerPetHandlers(): void {
           if (anim.frameDurationsMs && anim.frameDurationsMs.length !== anim.frames) {
             throw new Error(
               `Animation "${name}" declares ${anim.frameDurationsMs.length} frame durations but ${anim.frames} frames.`
+            )
+          }
+          if (anim.settleTo && !manifest.animations[anim.settleTo]) {
+            throw new Error(
+              `Animation "${name}" settles to "${anim.settleTo}" which is not in animations.`
+            )
+          }
+          // Why: the renderer emits one keyframe stop per repeated frame, so
+          // the repeats must stay within the same 512 cap as the frame count.
+          if (anim.repeat !== undefined && anim.repeat * anim.frames > 512) {
+            throw new Error(
+              `Animation "${name}" repeats ${anim.repeat}x${anim.frames} frames, exceeding the 512 keyframe cap.`
             )
           }
         }

--- a/src/main/ipc/pet.ts
+++ b/src/main/ipc/pet.ts
@@ -417,6 +417,26 @@ export function registerPetHandlers(): void {
               `Animation "${name}" repeats ${anim.repeat}x${anim.frames} frames, exceeding the 512 keyframe cap.`
             )
           }
+          // Why: the renderer only settles complete declarations (both fields,
+          // explicit durations on both rows) and would silently loop otherwise,
+          // so reject the partial forms at import.
+          if (anim.repeat !== undefined || anim.settleTo !== undefined) {
+            if (anim.repeat === undefined || anim.settleTo === undefined) {
+              throw new Error(`Animation "${name}" needs both repeat and settleTo to settle.`)
+            }
+            if (anim.settleTo === name) {
+              throw new Error(`Animation "${name}" cannot settle to itself.`)
+            }
+            const settleTarget = manifest.animations[anim.settleTo]
+            if (
+              anim.frameDurationsMs === undefined ||
+              settleTarget.frameDurationsMs === undefined
+            ) {
+              throw new Error(
+                `Animation "${name}" declares repeat/settleTo, so "${name}" and "${anim.settleTo}" must both carry frameDurationsMs.`
+              )
+            }
+          }
         }
         if (manifest.defaultAnimation && !manifest.animations[manifest.defaultAnimation]) {
           throw new Error(`defaultAnimation "${manifest.defaultAnimation}" not in animations.`)

--- a/src/renderer/src/components/pet/DetectedSpriteFrame.tsx
+++ b/src/renderer/src/components/pet/DetectedSpriteFrame.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useMemo, useRef } from 'react'
+import type { DetectedSpriteCacheEntry } from './pet-blob-cache'
+
+// Why: when the manifest doesn't declare frame size, we auto-detect frames
+// from the keyed sheet. Render via canvas because the frames may be different
+// sizes; we scale each one to fit the overlay box and step through them at a
+// fixed fps. requestAnimationFrame is paused when `animate` is false so the
+// overlay respects reduced motion / hidden window.
+export function DetectedSpriteFrame({
+  detected,
+  animate,
+  maxSize
+}: {
+  detected: DetectedSpriteCacheEntry
+  animate: boolean
+  maxSize: number
+}): React.JSX.Element {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const frameIndexRef = useRef(0)
+  const lastTimeRef = useRef(0)
+  // Why: honor manifest fps captured at import time so bundles play at their
+  // intended speed; default to 8 only when the manifest didn't declare one.
+  const fps = detected.fps > 0 ? detected.fps : 8
+
+  // Why: size the canvas to one fixed footprint bounding the largest scaled
+  // frame so the drag wrapper hugs the pet instead of a maxSize square. A
+  // single size across frames avoids the jitter a per-frame resize would cause.
+  const { footprintW, footprintH } = useMemo(() => {
+    let w = 0
+    let h = 0
+    for (const f of detected.frames) {
+      const s = Math.min(maxSize / f.w, maxSize / f.h)
+      w = Math.max(w, f.w * s)
+      h = Math.max(h, f.h * s)
+    }
+    return { footprintW: Math.max(1, Math.round(w)), footprintH: Math.max(1, Math.round(h)) }
+  }, [detected, maxSize])
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) {
+      return
+    }
+    const ctx = canvas.getContext('2d')
+    if (!ctx) {
+      return
+    }
+    canvas.width = footprintW
+    canvas.height = footprintH
+    // Why: reset playback when the underlying sprite changes so the new
+    // animation starts from frame 0 rather than wherever the prior one stopped.
+    frameIndexRef.current = 0
+    lastTimeRef.current = 0
+    if (detected.frames.length === 0) {
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      return
+    }
+    let raf = 0
+    const draw = (): void => {
+      const f = detected.frames[frameIndexRef.current % detected.frames.length]
+      const bmp = detected.bitmaps[frameIndexRef.current % detected.bitmaps.length]
+      if (!f || !bmp) {
+        return
+      }
+      ctx.imageSmoothingEnabled = false
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      const scale = Math.min(maxSize / f.w, maxSize / f.h)
+      const w = f.w * scale
+      const h = f.h * scale
+      // Why: center each frame within the fixed footprint so frames of differing
+      // sizes stay aligned without resizing the canvas per frame.
+      ctx.drawImage(bmp, (footprintW - w) / 2, (footprintH - h) / 2, w, h)
+    }
+    const tick = (now: number): void => {
+      const dt = now - lastTimeRef.current
+      if (dt >= 1000 / fps) {
+        lastTimeRef.current = now
+        frameIndexRef.current = (frameIndexRef.current + 1) % detected.frames.length
+        draw()
+      }
+      if (animate) {
+        raf = requestAnimationFrame(tick)
+      }
+    }
+    draw()
+    if (animate) {
+      lastTimeRef.current = performance.now()
+      raf = requestAnimationFrame(tick)
+    }
+    return () => {
+      if (raf) {
+        cancelAnimationFrame(raf)
+      }
+    }
+  }, [detected, animate, footprintW, footprintH, maxSize, fps])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{ width: footprintW, height: footprintH, imageRendering: 'pixelated' }}
+    />
+  )
+}

--- a/src/renderer/src/components/pet/DetectedSpriteFrame.tsx
+++ b/src/renderer/src/components/pet/DetectedSpriteFrame.tsx
@@ -36,6 +36,14 @@ export function DetectedSpriteFrame({
     return { footprintW: Math.max(1, Math.round(w)), footprintH: Math.max(1, Math.round(h)) }
   }, [detected, maxSize])
 
+  // Why: reset playback only when the sprite itself changes so a new animation
+  // starts from frame 0. The draw effect below also reruns on animate/footprint
+  // toggles (pause, resize, drag holds), and those must resume, not snap back.
+  useEffect(() => {
+    frameIndexRef.current = 0
+    lastTimeRef.current = 0
+  }, [detected])
+
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) {
@@ -47,10 +55,6 @@ export function DetectedSpriteFrame({
     }
     canvas.width = footprintW
     canvas.height = footprintH
-    // Why: reset playback when the underlying sprite changes so the new
-    // animation starts from frame 0 rather than wherever the prior one stopped.
-    frameIndexRef.current = 0
-    lastTimeRef.current = 0
     if (detected.frames.length === 0) {
       ctx.clearRect(0, 0, canvas.width, canvas.height)
       return

--- a/src/renderer/src/components/pet/PetOverlay.held-animation.test.tsx
+++ b/src/renderer/src/components/pet/PetOverlay.held-animation.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const storeState = vi.hoisted(() => ({
+  agentStatusByPaneKey: {} as Record<string, { state: string; updatedAt: number }>,
+  agentStatusEpoch: 0,
+  retainedAgentsByPaneKey: {},
+  petSize: 180
+}))
+
+vi.mock('../../store', () => ({
+  useAppStore: Object.assign(
+    <T,>(selector: (state: typeof storeState) => T): T => selector(storeState),
+    { getState: () => storeState }
+  )
+}))
+
+// A Codex-shaped sprite: the app-state rows burst three times and then rest on
+// idle, exactly as `codex-rs/tui/src/pets/model.rs` builds them.
+vi.mock('./usePetUrl', () => ({
+  usePetUrl: () => ({
+    url: 'blob:custom-pet',
+    ready: true,
+    sprite: {
+      frameWidth: 192,
+      frameHeight: 208,
+      columns: 8,
+      rows: 9,
+      sheetWidth: 1536,
+      sheetHeight: 1872,
+      fps: 8,
+      defaultAnimation: 'idle',
+      animations: {
+        idle: { row: 0, frames: 6, frameDurationsMs: [1680, 660, 660, 840, 840, 1920] },
+        jumping: {
+          row: 4,
+          frames: 5,
+          frameDurationsMs: [140, 140, 140, 140, 280],
+          repeat: 3,
+          settleTo: 'idle'
+        },
+        running: {
+          row: 7,
+          frames: 6,
+          frameDurationsMs: [120, 120, 120, 120, 120, 220],
+          repeat: 3,
+          settleTo: 'idle'
+        }
+      }
+    },
+    detected: null
+  })
+}))
+
+import { PetOverlay } from './PetOverlay'
+
+function renderPetOverlay(): { container: HTMLDivElement; root: Root } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => {
+    root.render(<PetOverlay />)
+  })
+  return { container, root }
+}
+
+function installLocalStorage(): void {
+  const values = new Map<string, string>()
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      clear: () => values.clear(),
+      getItem: (key: string) => values.get(key) ?? null,
+      removeItem: (key: string) => values.delete(key),
+      setItem: (key: string, value: string) => values.set(key, value)
+    }
+  })
+}
+
+function spriteAnimation(container: HTMLElement): string {
+  const div = Array.from(container.querySelectorAll('div')).find(
+    (candidate) => candidate.style.backgroundImage !== ''
+  )
+  if (!div) {
+    throw new Error('sprite div not found')
+  }
+  return div.style.animation
+}
+
+function firePointer(target: Element, type: string): void {
+  act(() => {
+    target.dispatchEvent(new PointerEvent(type, { button: 0, pointerId: 1, bubbles: true }))
+  })
+}
+
+describe('PetOverlay pointer-held animations', () => {
+  let root: Root | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    installLocalStorage()
+  })
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount())
+    }
+    container?.remove()
+    root = null
+    container = null
+  })
+
+  it('loops a hovered row instead of settling, then settles again on release', () => {
+    ;({ container, root } = renderPetOverlay())
+    const wrapper = container.querySelector('.pointer-events-auto')
+    if (!wrapper) {
+      throw new Error('draggable wrapper not found')
+    }
+
+    // Idle is not an app state, so it just loops. React synthesizes
+    // onPointerEnter/Leave from pointerover/pointerout.
+    expect(spriteAnimation(container)).toContain('6.6s step-end infinite')
+
+    // Hover holds `jumping`. Codex settles an app state because the state fires
+    // once; a held pointer must keep the row playing, so no burst/rest pair.
+    firePointer(wrapper, 'pointerover')
+    const hovered = spriteAnimation(container)
+    expect(hovered).toContain('0.84s step-end infinite')
+    expect(hovered).not.toContain('-burst')
+    expect(hovered).not.toContain('-rest')
+
+    firePointer(wrapper, 'pointerout')
+    expect(spriteAnimation(container)).toContain('6.6s step-end infinite')
+  })
+
+  it('replays the burst only on a state change, resuming after pointer overrides', () => {
+    // Only Date is faked. Faking timers too would stall React's scheduler.
+    vi.useFakeTimers({ toFake: ['Date'] })
+    try {
+      vi.setSystemTime(1_000_000)
+      ;({ container, root } = renderPetOverlay())
+      expect(spriteAnimation(container)).toContain('6.6s step-end infinite')
+
+      // The agent starts working: a genuine state change plays the burst.
+      vi.setSystemTime(1_005_000)
+      storeState.agentStatusByPaneKey = { pane: { state: 'working', updatedAt: 1_005_000 } }
+      act(() => root?.render(<PetOverlay />))
+      expect(spriteAnimation(container)).toContain('-burst 2.46s step-end 0s 1')
+
+      // Hover 10s later, then leave. The state never changed, so the re-minted
+      // track must resume past the burst rather than replay it.
+      vi.setSystemTime(1_015_000)
+      const wrapper = container.querySelector('.pointer-events-auto')
+      if (!wrapper) {
+        throw new Error('draggable wrapper not found')
+      }
+      firePointer(wrapper, 'pointerover')
+      expect(spriteAnimation(container)).toContain('0.84s step-end infinite')
+      firePointer(wrapper, 'pointerout')
+      const resumed = spriteAnimation(container)
+      expect(resumed).toContain('-burst 2.46s step-end -2.46s 1')
+      expect(resumed).toContain('-rest 6.6s step-end -7.54s infinite')
+    } finally {
+      storeState.agentStatusByPaneKey = {}
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/renderer/src/components/pet/PetOverlay.pointer-interaction.test.tsx
+++ b/src/renderer/src/components/pet/PetOverlay.pointer-interaction.test.tsx
@@ -75,8 +75,8 @@ function spriteDiv(container: HTMLElement): HTMLDivElement {
   return div
 }
 
-// The @keyframes name is `pet-<useId>-<row>-<frames>-<dragGeneration>`: the
-// resolved track keeps a switched-to row from reusing the prior timeline, and
+// The @keyframes name is `pet-<useId>-<row>-<frames>-<settleRow>-<dragGeneration>`:
+// the resolved track keeps a switched-to row from reusing the prior timeline, and
 // the generation suffix restarts a same-row grab from frame 0.
 function animationName(container: HTMLElement): string {
   return spriteDiv(container).style.animation.split(' ')[0]

--- a/src/renderer/src/components/pet/PetOverlay.tsx
+++ b/src/renderer/src/components/pet/PetOverlay.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useMemo, useState } from 'react'
 import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion'
 import { usePetUrl } from './usePetUrl'
-import type { DetectedSpriteCacheEntry } from './pet-blob-cache'
+import { DetectedSpriteFrame } from './DetectedSpriteFrame'
 import type { CustomPet } from '../../../../shared/types'
 import { useAppStore } from '../../store'
 import { AGENT_STATUS_STALE_AFTER_MS } from '../../../../shared/agent-status-types'
@@ -15,11 +15,11 @@ import { buildSpriteAnimationCss } from './sprite-animation-css'
 
 type Sprite = NonNullable<CustomPet['sprite']>
 
-function usePetAnimationName(
+function usePetAnimationNames(
   dragging: boolean,
   dragAnimation: PetDragAnimation,
   hovering: boolean
-): PetAnimationName {
+): { shown: PetAnimationName; base: PetAnimationName } {
   const agentStatusByPaneKey = useAppStore((s) => s.agentStatusByPaneKey)
   const agentStatusEpoch = useAppStore((s) => s.agentStatusEpoch)
   const retainedAgentsByPaneKey = useAppStore((s) => s.retainedAgentsByPaneKey)
@@ -28,15 +28,23 @@ function usePetAnimationName(
   // driving pet animations even if no other store value changes.
   void agentStatusEpoch
 
-  return selectPetAnimationName({
+  const input = {
     entries: Object.values(agentStatusByPaneKey),
     retainedCount: Object.keys(retainedAgentsByPaneKey).length,
-    dragging,
-    dragAnimation,
-    hovering,
     now: Date.now(),
     staleAfterMs: AGENT_STATUS_STALE_AFTER_MS
-  })
+  }
+  // Why: `base` is the agent-driven state with pointer overrides stripped. It
+  // anchors burst timing, which belongs to state changes, not pointer ones.
+  return {
+    shown: selectPetAnimationName({ ...input, dragging, dragAnimation, hovering }),
+    base: selectPetAnimationName({
+      ...input,
+      dragging: false,
+      dragAnimation: null,
+      hovering: false
+    })
+  }
 }
 
 // Why: pet bundles ship a sprite sheet — animate by stepping a CSS background
@@ -50,7 +58,9 @@ function SpriteFrame({
   animate,
   maxSize,
   animationName,
-  restartKey
+  restartKey,
+  held,
+  stateStartedAt
 }: {
   url: string
   sprite: Sprite
@@ -60,6 +70,12 @@ function SpriteFrame({
   // Why: folded into the keyframes name, so bumping it mints a fresh animation
   // that restarts from frame 0 even when the state row is unchanged.
   restartKey: number
+  // Why: the pointer is holding this state (drag/hover) rather than an agent
+  // event having fired it, so it must keep playing for as long as it is held.
+  held: boolean
+  // Why: when the agent-driven state began. Settling tracks fast-forward by
+  // this age so a re-mint resumes the timeline instead of replaying the burst.
+  stateStartedAt: number
 }): React.JSX.Element {
   const baseId = useId().replace(/[^a-zA-Z0-9_-]/g, '')
   const anim =
@@ -70,11 +86,18 @@ function SpriteFrame({
   // Why: clamp to >=1 so an empty/invalid manifest can't produce steps(0),
   // which is rejected as invalid CSS and freezes the animation.
   const frames = Math.max(1, anim?.frames ?? sprite.columns ?? 1)
+  // Why: the row this state rests on once its repeats run out. Pointer-held
+  // rows keep looping until release, and self-references are dropped so a
+  // track cannot settle into itself.
+  const settleAnim =
+    !held && anim?.settleTo && anim.settleTo !== animationName
+      ? sprite.animations?.[anim.settleTo]
+      : undefined
   // Why: name the @keyframes by the RESOLVED track (+restartKey for same-row
   // grabs), so a genuine row change starts at frame 0 while a state that falls
   // back to the same row (e.g. hover on a pet without a jumping row) doesn't
-  // needlessly restart.
-  const animKeyframesId = `${baseId}-${row}-${frames}-${restartKey}`
+  // needlessly restart. The settle row is part of the resolved track.
+  const animKeyframesId = `${baseId}-${row}-${frames}-${settleAnim?.row ?? 'x'}-${restartKey}`
   // Why: allow fractional downscaling so frames larger than maxSize shrink to
   // fit instead of overflowing the overlay; mirrors DetectedSpriteFrame's math.
   const scale = Math.min(maxSize / sprite.frameWidth, maxSize / sprite.frameHeight)
@@ -84,15 +107,41 @@ function SpriteFrame({
   const bgH = sprite.sheetHeight * scale
   const startX = 0
   const startY = -(row * sprite.frameHeight * scale)
-  const { keyframesCss, animationCss } = buildSpriteAnimationCss({
-    keyframesId: animKeyframesId,
-    frames,
-    fps: sprite.fps,
-    frameWidth: sprite.frameWidth,
-    scale,
-    rowOffsetY: startY,
-    frameDurationsMs: anim?.frameDurationsMs
-  })
+  // Why: minted once per resolved track. Reading Date.now every render would
+  // change the animation shorthand and restart the sprite mid flight.
+  const { keyframesCss, animationCss } = useMemo(
+    () =>
+      buildSpriteAnimationCss({
+        keyframesId: animKeyframesId,
+        frames,
+        fps: sprite.fps,
+        frameWidth: sprite.frameWidth,
+        scale,
+        rowOffsetY: startY,
+        frameDurationsMs: anim?.frameDurationsMs,
+        repeat: anim?.repeat,
+        settle: settleAnim
+          ? {
+              frames: Math.max(1, settleAnim.frames),
+              rowOffsetY: -(settleAnim.row * sprite.frameHeight * scale),
+              frameDurationsMs: settleAnim.frameDurationsMs
+            }
+          : undefined,
+        settleElapsedMs: Date.now() - stateStartedAt
+      }),
+    [
+      animKeyframesId,
+      frames,
+      sprite.fps,
+      sprite.frameWidth,
+      sprite.frameHeight,
+      scale,
+      startY,
+      anim,
+      settleAnim,
+      stateStartedAt
+    ]
+  )
   return (
     <>
       <style>{keyframesCss}</style>
@@ -110,107 +159,6 @@ function SpriteFrame({
         }}
       />
     </>
-  )
-}
-
-// Why: when the manifest doesn't declare frame size, we auto-detect frames
-// from the keyed sheet. Render via canvas because the frames may be different
-// sizes; we scale each one to fit the overlay box and step through them at a
-// fixed fps. requestAnimationFrame is paused when `animate` is false so the
-// overlay respects reduced motion / hidden window.
-function DetectedSpriteFrame({
-  detected,
-  animate,
-  maxSize
-}: {
-  detected: DetectedSpriteCacheEntry
-  animate: boolean
-  maxSize: number
-}): React.JSX.Element {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null)
-  const frameIndexRef = useRef(0)
-  const lastTimeRef = useRef(0)
-  // Why: honor manifest fps captured at import time so bundles play at their
-  // intended speed; default to 8 only when the manifest didn't declare one.
-  const fps = detected.fps > 0 ? detected.fps : 8
-
-  // Why: size the canvas to one fixed footprint bounding the largest scaled
-  // frame so the drag wrapper hugs the pet instead of a maxSize square. A
-  // single size across frames avoids the jitter a per-frame resize would cause.
-  const { footprintW, footprintH } = useMemo(() => {
-    let w = 0
-    let h = 0
-    for (const f of detected.frames) {
-      const s = Math.min(maxSize / f.w, maxSize / f.h)
-      w = Math.max(w, f.w * s)
-      h = Math.max(h, f.h * s)
-    }
-    return { footprintW: Math.max(1, Math.round(w)), footprintH: Math.max(1, Math.round(h)) }
-  }, [detected, maxSize])
-
-  useEffect(() => {
-    const canvas = canvasRef.current
-    if (!canvas) {
-      return
-    }
-    const ctx = canvas.getContext('2d')
-    if (!ctx) {
-      return
-    }
-    canvas.width = footprintW
-    canvas.height = footprintH
-    // Why: reset playback when the underlying sprite changes so the new
-    // animation starts from frame 0 rather than wherever the prior one stopped.
-    frameIndexRef.current = 0
-    lastTimeRef.current = 0
-    if (detected.frames.length === 0) {
-      ctx.clearRect(0, 0, canvas.width, canvas.height)
-      return
-    }
-    let raf = 0
-    const draw = (): void => {
-      const f = detected.frames[frameIndexRef.current % detected.frames.length]
-      const bmp = detected.bitmaps[frameIndexRef.current % detected.bitmaps.length]
-      if (!f || !bmp) {
-        return
-      }
-      ctx.imageSmoothingEnabled = false
-      ctx.clearRect(0, 0, canvas.width, canvas.height)
-      const scale = Math.min(maxSize / f.w, maxSize / f.h)
-      const w = f.w * scale
-      const h = f.h * scale
-      // Why: center each frame within the fixed footprint so frames of differing
-      // sizes stay aligned without resizing the canvas per frame.
-      ctx.drawImage(bmp, (footprintW - w) / 2, (footprintH - h) / 2, w, h)
-    }
-    const tick = (now: number): void => {
-      const dt = now - lastTimeRef.current
-      if (dt >= 1000 / fps) {
-        lastTimeRef.current = now
-        frameIndexRef.current = (frameIndexRef.current + 1) % detected.frames.length
-        draw()
-      }
-      if (animate) {
-        raf = requestAnimationFrame(tick)
-      }
-    }
-    draw()
-    if (animate) {
-      lastTimeRef.current = performance.now()
-      raf = requestAnimationFrame(tick)
-    }
-    return () => {
-      if (raf) {
-        cancelAnimationFrame(raf)
-      }
-    }
-  }, [detected, animate, footprintW, footprintH, maxSize, fps])
-
-  return (
-    <canvas
-      ref={canvasRef}
-      style={{ width: footprintW, height: footprintH, imageRendering: 'pixelated' }}
-    />
   )
 }
 
@@ -376,7 +324,20 @@ export function PetOverlay(): React.JSX.Element {
   // horizontal drag keeps animating so the running rows show. Bob always pauses.
   const spriteAnimate = motionAllowed && (!dragging || dragAnimation !== null)
   const bobAnimate = motionAllowed && !dragging
-  const animationName = usePetAnimationName(dragging, dragAnimation, hovering)
+  const { shown: animationName, base: baseAnimationName } = usePetAnimationNames(
+    dragging,
+    dragAnimation,
+    hovering
+  )
+  // Why: bursts belong to agent-driven state changes. Anchoring their timing to
+  // when the base state changed lets a drag or hover end without replaying them.
+  const [baseStart, setBaseStart] = useState(() => ({
+    name: baseAnimationName,
+    at: Date.now()
+  }))
+  if (baseStart.name !== baseAnimationName) {
+    setBaseStart({ name: baseAnimationName, at: Date.now() })
+  }
 
   return (
     // Why: the outer box and middle layer stay pointer-events-none so app chrome
@@ -419,6 +380,8 @@ export function PetOverlay(): React.JSX.Element {
               maxSize={size}
               animationName={animationName}
               restartKey={dragGeneration}
+              held={dragging || hovering}
+              stateStartedAt={baseStart.at}
             />
           ) : detected ? (
             <DetectedSpriteFrame detected={detected} animate={spriteAnimate} maxSize={size} />

--- a/src/renderer/src/components/pet/sprite-animation-css.test.ts
+++ b/src/renderer/src/components/pet/sprite-animation-css.test.ts
@@ -73,6 +73,78 @@ describe('buildSpriteAnimationCss', () => {
     }
   })
 
+  it('plays the row `repeat` times then loops the settle track, matching Codex', () => {
+    // Codex's "running": row 7 x3 (820ms each) settling into idle's 6.6s loop.
+    const { keyframesCss, animationCss } = buildSpriteAnimationCss({
+      ...BASE,
+      frames: 6,
+      fps: 8,
+      frameDurationsMs: [120, 120, 120, 120, 120, 220],
+      repeat: 3,
+      settle: {
+        frames: 6,
+        rowOffsetY: 0,
+        frameDurationsMs: [1680, 660, 660, 840, 840, 1920]
+      }
+    })
+
+    expect(animationCss).toBe(
+      'pet-kf-burst 2.46s step-end 0s 1, pet-kf-rest 6.6s step-end 2.46s infinite'
+    )
+    // The burst replays the same six cells three times, so x wraps per rep.
+    expect(keyframesCss).toContain('0% { background-position: 0px -200px; }')
+    expect(keyframesCss).toContain('33.3333% { background-position: 0px -200px; }')
+    expect(keyframesCss).toContain('66.6667% { background-position: 0px -200px; }')
+    // The rest track sits on the settle row, not the burst row.
+    expect(keyframesCss).toContain('@keyframes pet-kf-rest')
+    expect(keyframesCss).toContain('25.4545% { background-position: -100px 0px; }')
+  })
+
+  it('fast-forwards a re-minted track by settleElapsedMs instead of replaying', () => {
+    const input = {
+      ...BASE,
+      frames: 6,
+      fps: 8,
+      frameDurationsMs: [120, 120, 120, 120, 120, 220],
+      repeat: 3,
+      settle: {
+        frames: 6,
+        rowOffsetY: 0,
+        frameDurationsMs: [1680, 660, 660, 840, 840, 1920]
+      }
+    }
+
+    // Mid-burst: resume 1s in, rest starts after the remaining 1.46s.
+    expect(buildSpriteAnimationCss({ ...input, settleElapsedMs: 1000 }).animationCss).toBe(
+      'pet-kf-burst 2.46s step-end -1s 1, pet-kf-rest 6.6s step-end 1.46s infinite'
+    )
+    // Past the burst: it is skipped whole and the rest loop keeps its phase.
+    expect(buildSpriteAnimationCss({ ...input, settleElapsedMs: 10_000 }).animationCss).toBe(
+      'pet-kf-burst 2.46s step-end -2.46s 1, pet-kf-rest 6.6s step-end -7.54s infinite'
+    )
+  })
+
+  it('loops the row itself when settle data is absent or unusable', () => {
+    for (const extra of [
+      {},
+      { repeat: 3 },
+      { repeat: 0, settle: { frames: 2, rowOffsetY: 0, frameDurationsMs: [100, 100] } },
+      { repeat: 1.5, settle: { frames: 2, rowOffsetY: 0, frameDurationsMs: [100, 100] } },
+      // Settle track whose durations fail validation must not strand the burst.
+      { repeat: 3, settle: { frames: 2, rowOffsetY: 0, frameDurationsMs: undefined } },
+      { repeat: 3, settle: { frames: 2, rowOffsetY: 0, frameDurationsMs: [100] } }
+    ]) {
+      const { animationCss } = buildSpriteAnimationCss({
+        ...BASE,
+        frames: 2,
+        fps: 8,
+        frameDurationsMs: [100, 300],
+        ...extra
+      })
+      expect(animationCss).toBe('pet-kf 0.4s step-end infinite')
+    }
+  })
+
   it('renders a genuinely short-but-representable frame as its own stop', () => {
     const { keyframesCss } = buildSpriteAnimationCss({
       ...BASE,

--- a/src/renderer/src/components/pet/sprite-animation-css.ts
+++ b/src/renderer/src/components/pet/sprite-animation-css.ts
@@ -10,6 +10,10 @@ export type SpriteAnimationCss = {
   animationCss: string
 }
 
+// Why: repeat x frames becomes one stop each, so bound the emitted keyframe set
+// the same way the importer bounds frames.
+const MAX_REPEATED_STOPS = 512
+
 export type SpriteAnimationCssInput = {
   // Sanitized `@keyframes` identifier; folded with the restart key by the caller.
   keyframesId: string
@@ -21,6 +25,17 @@ export type SpriteAnimationCssInput = {
   rowOffsetY: number
   // Per-frame holds in ms; uneven pacing renders when they pass validation.
   frameDurationsMs: number[] | undefined
+  // How many times the row plays before `settle` takes over.
+  repeat?: number
+  // Resolved track that becomes the steady loop; absent means the row loops.
+  settle?: {
+    frames: number
+    rowOffsetY: number
+    frameDurationsMs: number[] | undefined
+  }
+  // Ms already spent in this state when the track is minted. Fast-forwards the
+  // played part of the burst so a re-minted track resumes instead of replaying.
+  settleElapsedMs?: number
 }
 
 // Why: sprite keyframes are runtime CSS, not user-visible copy; translated CSS
@@ -32,19 +47,35 @@ export function buildSpriteAnimationCss({
   frameWidth,
   scale,
   rowOffsetY,
-  frameDurationsMs
+  frameDurationsMs,
+  repeat,
+  settle,
+  settleElapsedMs
 }: SpriteAnimationCssInput): SpriteAnimationCss {
   const name = `pet-${keyframesId}`
   const durations = validFrameDurations(frameDurationsMs, frames)
   if (durations) {
-    const totalMs = durations.reduce((sum, ms) => sum + ms, 0)
+    const settled = buildSettlingCss({
+      name,
+      durations,
+      frames,
+      frameWidth,
+      scale,
+      rowOffsetY,
+      repeat,
+      settle,
+      settleElapsedMs
+    })
+    if (settled) {
+      return settled
+    }
     // Why: Codex pets hold frames unevenly (idle rests ~1.9s on its last frame).
     // steps() can't express that, so emit one step-end stop per frame.
-    const stops = stepEndStops(durations, totalMs, frameWidth, scale, rowOffsetY)
-    if (stops) {
+    const track = buildTrack(name, durations, frames, frameWidth, scale, rowOffsetY)
+    if (track) {
       return {
-        keyframesCss: `@keyframes ${name} { ${stops.join(' ')} }`,
-        animationCss: `${name} ${totalMs / 1000}s step-end infinite`
+        keyframesCss: track.keyframesCss,
+        animationCss: `${name} ${track.totalMs / 1000}s step-end infinite`
       }
     }
   }
@@ -74,12 +105,95 @@ function validFrameDurations(
   return null
 }
 
-// Cumulative step-end stops, one per frame. Returns null (→ uniform fallback)
-// when a frame is too short to survive 4-decimal precision (two stops collapse,
-// or the final stop rounds to 100%) so no frame is silently dropped.
+// Why: Codex's app-state rows play a few times and then rest on idle forever
+// (`app_state_animation` sets loop_start past the repeats). CSS can't loop part
+// of one timeline, so emit the repeats and the resting track as two animations
+// and start the resting one on a delay equal to the repeats.
+function buildSettlingCss({
+  name,
+  durations,
+  frames,
+  frameWidth,
+  scale,
+  rowOffsetY,
+  repeat,
+  settle,
+  settleElapsedMs
+}: {
+  name: string
+  durations: number[]
+  frames: number
+  frameWidth: number
+  scale: number
+  rowOffsetY: number
+  repeat: number | undefined
+  settle: SpriteAnimationCssInput['settle']
+  settleElapsedMs: number | undefined
+}): SpriteAnimationCss | null {
+  if (
+    !settle ||
+    !Number.isInteger(repeat) ||
+    repeat === undefined ||
+    repeat < 1 ||
+    repeat * frames > MAX_REPEATED_STOPS
+  ) {
+    return null
+  }
+  const settleDurations = validFrameDurations(settle.frameDurationsMs, settle.frames)
+  if (!settleDurations) {
+    return null
+  }
+  const burstDurations = Array.from({ length: repeat }, () => durations).flat()
+  const burst = buildTrack(`${name}-burst`, burstDurations, frames, frameWidth, scale, rowOffsetY)
+  const rest = buildTrack(
+    `${name}-rest`,
+    settleDurations,
+    settle.frames,
+    frameWidth,
+    scale,
+    settle.rowOffsetY
+  )
+  if (!burst || !rest) {
+    return null
+  }
+  // Why: aligned with Codex's player, which measures elapsed from when the
+  // state started. Negative delays fast-forward a re-minted track by the time
+  // already played, so ending a drag or hover resumes rather than replays.
+  const elapsedMs = Math.max(0, settleElapsedMs ?? 0)
+  const burstDelayS = -Math.round(Math.min(elapsedMs, burst.totalMs)) / 1000
+  const restDelayS = Math.round(burst.totalMs - elapsedMs) / 1000
+  return {
+    keyframesCss: `${burst.keyframesCss} ${rest.keyframesCss}`,
+    animationCss:
+      `${name}-burst ${burst.totalMs / 1000}s step-end ${burstDelayS}s 1, ` +
+      `${name}-rest ${rest.totalMs / 1000}s step-end ${restDelayS}s infinite`
+  }
+}
+
+function buildTrack(
+  name: string,
+  durations: number[],
+  columns: number,
+  frameWidth: number,
+  scale: number,
+  rowOffsetY: number
+): { keyframesCss: string; totalMs: number } | null {
+  const totalMs = durations.reduce((sum, ms) => sum + ms, 0)
+  const stops = stepEndStops(durations, totalMs, columns, frameWidth, scale, rowOffsetY)
+  if (!stops) {
+    return null
+  }
+  return { keyframesCss: `@keyframes ${name} { ${stops.join(' ')} }`, totalMs }
+}
+
+// Cumulative step-end stops, one per frame. `columns` wraps the x offset so a
+// repeated row replays its own cells. Returns null (→ uniform fallback) when a
+// frame is too short to survive 4-decimal precision (two stops collapse, or the
+// final stop rounds to 100%) so no frame is silently dropped.
 function stepEndStops(
   durations: number[],
   totalMs: number,
+  columns: number,
   frameWidth: number,
   scale: number,
   rowOffsetY: number
@@ -93,7 +207,7 @@ function stepEndStops(
       return null
     }
     previousPct = pct
-    const x = -(index * frameWidth * scale)
+    const x = -((index % columns) * frameWidth * scale)
     stops.push(`${pct}% { background-position: ${x}px ${rowOffsetY}px; }`)
     elapsedMs += durations[index]
   }

--- a/src/shared/codex-pet-sprite-defaults.ts
+++ b/src/shared/codex-pet-sprite-defaults.ts
@@ -11,23 +11,40 @@ export const CODEX_PET_DEFAULT_FPS = 8
 // Codex sheets are 8 columns wide (its widest rows run 8 frames).
 export const CODEX_PET_DEFAULT_COLUMNS = 8
 
+// Codex repeats an app-state row 3x and sets loop_start past those repeats, so
+// the state bursts and then rests on idle until it changes.
+const APP_STATE_REPEAT = 3
+
 // Codex's `app_state_animation`: every non-final frame holds `frameMs`, the last
 // holds `finalMs`. Values below mirror `codex-rs/tui/src/pets/model.rs` exactly.
-function appStateDurations(frames: number, frameMs: number, finalMs: number): number[] {
-  return Array.from({ length: frames }, (_, i) => (i === frames - 1 ? finalMs : frameMs))
+function appStateAnimation(
+  row: number,
+  frames: number,
+  frameMs: number,
+  finalMs: number
+): SpriteAnimation {
+  return {
+    row,
+    frames,
+    frameDurationsMs: Array.from({ length: frames }, (_, i) =>
+      i === frames - 1 ? finalMs : frameMs
+    ),
+    repeat: APP_STATE_REPEAT,
+    settleTo: CODEX_PET_DEFAULT_ANIMATION
+  }
 }
 
 export const CODEX_PET_ANIMATIONS: Record<string, SpriteAnimation> = {
   // Idle is the ambient loop: long holds on the bookend frames, 6.6s cycle.
   idle: { row: 0, frames: 6, frameDurationsMs: [1680, 660, 660, 840, 840, 1920] },
-  'running-right': { row: 1, frames: 8, frameDurationsMs: appStateDurations(8, 120, 220) },
-  'running-left': { row: 2, frames: 8, frameDurationsMs: appStateDurations(8, 120, 220) },
-  waving: { row: 3, frames: 4, frameDurationsMs: appStateDurations(4, 140, 280) },
-  jumping: { row: 4, frames: 5, frameDurationsMs: appStateDurations(5, 140, 280) },
-  failed: { row: 5, frames: 8, frameDurationsMs: appStateDurations(8, 140, 240) },
-  waiting: { row: 6, frames: 6, frameDurationsMs: appStateDurations(6, 150, 260) },
-  running: { row: 7, frames: 6, frameDurationsMs: appStateDurations(6, 120, 220) },
-  review: { row: 8, frames: 6, frameDurationsMs: appStateDurations(6, 150, 280) }
+  'running-right': appStateAnimation(1, 8, 120, 220),
+  'running-left': appStateAnimation(2, 8, 120, 220),
+  waving: appStateAnimation(3, 4, 140, 280),
+  jumping: appStateAnimation(4, 5, 140, 280),
+  failed: appStateAnimation(5, 8, 140, 240),
+  waiting: appStateAnimation(6, 6, 150, 260),
+  running: appStateAnimation(7, 6, 120, 220),
+  review: appStateAnimation(8, 6, 150, 280)
 }
 
 /** The Codex row layout paced uniformly at `fps` (each frame held 1000/fps ms).
@@ -38,22 +55,31 @@ export const CODEX_PET_ANIMATIONS: Record<string, SpriteAnimation> = {
 export function codexAnimationsAtUniformFps(fps: number): Record<string, SpriteAnimation> {
   const frameMs = 1000 / fps
   return Object.fromEntries(
-    Object.entries(CODEX_PET_ANIMATIONS).map(([name, { row, frames }]) => [
+    Object.entries(CODEX_PET_ANIMATIONS).map(([name, { row, frames, repeat, settleTo }]) => [
       name,
-      { row, frames, frameDurationsMs: Array.from({ length: frames }, () => frameMs) }
+      {
+        row,
+        frames,
+        frameDurationsMs: Array.from({ length: frames }, () => frameMs),
+        // Why: the fps pin retimes frames. Repeat/settle is structural in Codex
+        // and applies at any pacing, so carry it through.
+        repeat,
+        settleTo
+      }
     ])
   )
 }
 
 export type CustomPetSprite = NonNullable<CustomPet['sprite']>
 
-/** The exact sprite an old Orca build baked for an imported Codex bundle:
+/** The exact sprite an older Orca build baked for an imported Codex bundle:
  *  192x208 frames on an 8-wide sheet at the flat 8 fps rate, idle default, and
- *  the nine Codex rows carrying no per-frame durations. Matching the full
- *  geometry (not just the row map) keeps a hand-authored 8 fps sheet that merely
- *  reuses those rows from being silently retimed. A pet deliberately built on
- *  the Codex layout that wants to keep uniform pacing opts out by declaring any
- *  frameDurationsMs of its own.
+ *  the nine Codex rows carrying either no per-frame durations (pre-durations
+ *  builds) or exactly the preset ones (built before repeat/settle existed).
+ *  Matching the full geometry (not just the row map) keeps a hand-authored 8 fps
+ *  sheet that merely reuses those rows from being silently retimed. A pet built
+ *  on the Codex layout opts out by declaring any pacing of its own: durations
+ *  that differ from the presets, or a repeat/settleTo.
  *
  *  Rows/sheet height are intentionally excluded so v2 (11-row) Codex sheets,
  *  which still bake these nine animations, upgrade too. */
@@ -83,9 +109,26 @@ function isLegacyCodexSprite(sprite: CustomPetSprite): boolean {
       !!anim &&
       anim.row === preset.row &&
       anim.frames === preset.frames &&
-      anim.frameDurationsMs === undefined
+      anim.repeat === undefined &&
+      anim.settleTo === undefined &&
+      isAbsentOrPresetDurations(anim.frameDurationsMs, preset.frameDurationsMs)
     )
   })
+}
+
+function isAbsentOrPresetDurations(
+  actual: number[] | undefined,
+  preset: number[] | undefined
+): boolean {
+  if (actual === undefined) {
+    return true
+  }
+  return (
+    Array.isArray(actual) &&
+    !!preset &&
+    actual.length === preset.length &&
+    actual.every((ms, index) => ms === preset[index])
+  )
 }
 
 /** Pets imported before per-frame durations existed persist the legacy Codex

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3632,6 +3632,10 @@ export type SpriteAnimation = {
   frames: number
   /** Per-frame holds in ms (length === frames). Absent means uniform sheet fps. */
   frameDurationsMs?: number[]
+  /** Plays the row this many times before `settleTo` takes over. Absent loops the row. */
+  repeat?: number
+  /** Animation whose frames become the steady loop once `repeat` runs out. */
+  settleTo?: string
 }
 
 export type PersistedTrustedOrcaHookEntry = {


### PR DESCRIPTION
## Summary

Fixes #9555

Follow-up to #8730: that PR ported Codex's per-frame durations, this one ports the player structure around them.

Codex builds app-state animations as `row ×3 + idle frames` with `loop_start` past the repeats, and its player measures elapsed from when the state started (`codex-rs/tui/src/pets/model.rs`, upstream test `app_running_animation_repeats_then_settles_into_idle`). Orca ported the durations but not that structure, so every app-state row loops its own frames forever — a working agent keeps the pet cycling its ~0.8 s run row indefinitely.

- `SpriteAnimation` gains optional `repeat`/`settleTo`; the Codex defaults mark every app-state row `repeat: 3, settleTo: 'idle'`, mirroring `app_state_animation` exactly.
- CSS cannot loop part of one timeline, so `SpriteFrame` emits two `step-end` animations: a burst (`row ×repeat`, plays once) and a rest loop (infinite, delayed by the burst). The keyframe x-offset wraps per repetition.
- Rows held by the pointer skip settling and loop until release: Codex settles because an app state fires once, but Orca also drives `running-left`/`running-right` from a drag and `jumping` from hover, and a held pointer must keep its row playing.
- Burst timing is anchored to when the agent-driven state changed, mirroring Codex's elapsed-from-state-start player. Re-minted tracks fast-forward with negative animation delays, so releasing a drag resumes the settled timeline instead of replaying the burst.
- The render-time upgrade now also matches pets imported after #8730 (preset durations baked, no `repeat`/`settleTo`), so existing imports settle without a re-import. Hand-authored bundles that declare their own pacing pass through untouched.
- The importer validates that `settleTo` names an existing animation and that `repeat × frames` stays within the 512 keyframe cap.
- `DetectedSpriteFrame` moves to its own file to keep `PetOverlay` within the max-lines budget (move-only).

## Screenshots

| Before (v1.4.146) | After (this PR) |
| :---: | :---: |
| <img width="480" alt="Before" src="https://github.com/user-attachments/assets/f58effe2-bbf1-4f35-ba61-d7de64f6f569" /> | <img width="480" alt="After" src="https://github.com/user-attachments/assets/3aef4c02-9c7d-456e-9c4e-8313a3fd543d" /> |
| Agent working: the run row loops indefinitely | Runs 3×, then rests on idle until the state changes |

## Testing

- [x] `pnpm typecheck`
- [x] `pnpm lint` — passes except one pre-existing `switch-exhaustiveness` error in `skill-freshness-group.tsx` that fails identically on `main`
- [x] `pnpm test` — 32 236 passed; the 41 locally-failing tests (7 files, browser-pane/right-sidebar/sidebar) fail identically on `main` in this environment
- [x] `pnpm build`
- [x] Added regression tests: burst/rest CSS emission with per-repetition x-wrap, fast-forward delay math (mid-burst resume, past-burst skip with rest-phase carry), held rows looping instead of settling, burst-only-on-state-change at the overlay level (fake-`Date` clock), importer round-trip of `repeat`/`settleTo`, missing-`settleTo` rejection, and keyframe-cap rejection. Each behavioral fix was verified to fail with its guard reverted.
- [x] **Live verification** (CDP against the built app): before — release re-minted the burst at `delay: 0s` and the row replayed for ~2.5–3 s; after — drag shows the run row looping (`1.06s infinite`), release re-mints with `delay: -3.09s, -8.5s` (burst skipped whole, rest phase carried), and a fresh agent-state change still plays its burst from `0s`

## AI Review Report

- Verified the delay math edge cases: `-0` serialization, `animation-fill-mode: none` leaving the finished burst inert, and negative rest delays carrying the idle phase across re-mints.
- Verified memo stability: the legacy-upgrade path returns a fresh sprite object per render, but animation entries keep preset identity, so the `useMemo` never re-mints (confirmed live over 60 s of sampling).
- Found and closed an importer gap during self-review: the zod `repeat` bound alone did not cap `repeat × frames`, so a manifest could declare more expanded keyframes than the renderer accepts; now rejected at import with a clear error.
- Settle-chain edge cases (self-reference, missing target, unusable settle durations) all degrade to the plain row loop and are covered by tests.

## Security Audit

New manifest fields are bounded by zod (`repeat` 1–64 integer, `settleTo` 1–64 chars) plus cross-field checks (`settleTo` must exist, `repeat × frames ≤ 512`) with clear errors. No new IPC channels or dependencies. Generated CSS still interpolates only numbers that passed the existing finite/positive render guards, and untrusted persisted sprites keep falling back to uniform pacing.

## Notes

- The rest loop's phase carries across re-mints (negative delay), matching Codex's elapsed-based player rather than restarting idle at frame 0 after every interaction.
- Renderer CSS and standard Pointer Events only: platform-neutral, and pet assets still load from local `userData` over IPC, so SSH-hosted workspaces are unaffected.

## ELI5

The desktop pet's app-state animations kept looping the whole sequence instead of settling into idle like Codex does. This mirrors Codex's player structure so the pet plays intro frames a few times then rests on idle.
