### PR TITLE
feat(image-viewer): add drag-to-pan gestures

### DIFF
--- a/src/renderer/src/components/editor/ImageViewer.test.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.test.tsx
@@ -132,13 +132,17 @@ function findPreviewImage(node: unknown): ReactElementLike {
   return image
 }
 
-async function renderExpandedImageViewer(content: string): Promise<unknown> {
+async function renderExpandedImageViewer(
+  content: string,
+  layout: 'fill' | 'intrinsic' = 'fill'
+): Promise<unknown> {
   reactHookRuntime.index = 0
   const module = await import('./ImageViewer')
   return expandNode(
     module.default({
       content,
       filePath: '/repo/preview.png',
+      layout,
       mimeType: 'image/png'
     })
   )
@@ -194,7 +198,7 @@ describe('ImageViewer preview source retry', () => {
     expect(findElementsByType(rendered, 'img')).toHaveLength(0)
   })
 
-  it('binds panning to both surfaces and disables native image dragging', async () => {
+  it('binds panning to both scrollable surfaces and disables native image dragging', async () => {
     const rendered = await renderExpandedImageViewer(pngBase64(1))
     const panSurfaces = findElementsByType(rendered, 'div').filter(
       (element) => element.props.onPointerDown && element.props.onClickCapture
@@ -211,5 +215,25 @@ describe('ImageViewer preview source retry', () => {
     for (const image of findElementsByType(rendered, 'img')) {
       expect(image.props.draggable).toBe(false)
     }
+  })
+
+  it('keeps intrinsic inline layout clickable without disabling popup panning', async () => {
+    const rendered = await renderExpandedImageViewer(pngBase64(1), 'intrinsic')
+    const inlineSurface = findElementsByType(rendered, 'div').find(
+      (element) => element.props.title === 'Open image in popup'
+    )
+    if (!inlineSurface) {
+      throw new Error('inline image surface not found')
+    }
+    const panSurfaces = findElementsByType(rendered, 'div').filter(
+      (element) => element.props.onPointerDown && element.props.onClickCapture
+    )
+
+    expect(inlineSurface.props.onClick).toBeTypeOf('function')
+    expect(inlineSurface.props.onClickCapture).toBeUndefined()
+    expect(inlineSurface.props.onPointerDown).toBeUndefined()
+    expect(inlineSurface.props.onPointerEnter).toBeUndefined()
+    expect(inlineSurface.props.onPointerLeave).toBeUndefined()
+    expect(panSurfaces).toHaveLength(1)
   })
 })

--- a/src/renderer/src/components/editor/ImageViewer.test.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.test.tsx
@@ -193,4 +193,23 @@ describe('ImageViewer preview source retry', () => {
     expect(findElementsByType(rendered, 'Image')).toHaveLength(1)
     expect(findElementsByType(rendered, 'img')).toHaveLength(0)
   })
+
+  it('binds panning to both surfaces and disables native image dragging', async () => {
+    const rendered = await renderExpandedImageViewer(pngBase64(1))
+    const panSurfaces = findElementsByType(rendered, 'div').filter(
+      (element) => element.props.onPointerDown && element.props.onClickCapture
+    )
+
+    expect(panSurfaces).toHaveLength(2)
+    for (const surface of panSurfaces) {
+      expect(surface.props.onPointerEnter).toBeTypeOf('function')
+      expect(surface.props.onPointerLeave).toBeTypeOf('function')
+    }
+    expect(panSurfaces[0].props.onPointerDown).toBe(panSurfaces[1].props.onPointerDown)
+    expect(panSurfaces[0].props.onClickCapture).toBe(panSurfaces[1].props.onClickCapture)
+    expect(findElementsByType(rendered, 'img')).toHaveLength(2)
+    for (const image of findElementsByType(rendered, 'img')) {
+      expect(image.props.draggable).toBe(false)
+    }
+  })
 })

--- a/src/renderer/src/components/editor/ImageViewer.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.tsx
@@ -61,6 +61,7 @@ export default function ImageViewer({
   }
   const isPdf = mimeType === 'application/pdf'
   const isIntrinsicLayout = layout === 'intrinsic'
+  const inlinePan = isIntrinsicLayout ? null : imagePan
   const previewSrc = useMemo(
     () => buildImageDataUri(mimeType, cleanedContent),
     [cleanedContent, mimeType]
@@ -255,16 +256,16 @@ export default function ImageViewer({
           ref={setInlineSurfaceRef}
           className={cn(
             'bg-muted/20',
-            imagePan.cursorClassName ?? 'cursor-pointer',
+            inlinePan?.cursorClassName ?? 'cursor-pointer',
             isIntrinsicLayout
               ? 'flex justify-center overflow-visible p-4'
               : 'flex-1 overflow-auto scrollbar-editor'
           )}
           onClick={openPopup}
-          onClickCapture={imagePan.onClickCapture}
-          onPointerDown={imagePan.onPointerDown}
-          onPointerEnter={imagePan.onPointerEnter}
-          onPointerLeave={imagePan.onPointerLeave}
+          onClickCapture={inlinePan?.onClickCapture}
+          onPointerDown={inlinePan?.onPointerDown}
+          onPointerEnter={inlinePan?.onPointerEnter}
+          onPointerLeave={inlinePan?.onPointerLeave}
           title={translate('auto.components.editor.ImageViewer.77bfc9b35a', 'Open image in popup')}
         >
           <div

--- a/src/renderer/src/components/editor/ImageViewer.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.tsx
@@ -19,6 +19,7 @@ import {
   type ImageViewerSurfaceSize,
   getZoomedImageLayoutSize
 } from './image-viewer-zoom'
+import { useImageViewerPanSurface } from './use-image-viewer-pan'
 import { translate } from '@/i18n/i18n'
 import { buildImageDataUri } from '../../../../shared/image-data-uri'
 
@@ -46,6 +47,7 @@ export default function ImageViewer({
   const [popupSurfaceSize, setPopupSurfaceSize] = useState<ImageViewerSurfaceSize | null>(null)
   const [imageDimensions, setImageDimensions] = useState<ImageViewerImageDimensions | null>(null)
   const [failedPreviewSrc, setFailedPreviewSrc] = useState<string | null>(null)
+  const imagePan = useImageViewerPanSurface()
 
   const filename = useMemo(() => filePath.split(/[/\\]/).pop() || filePath, [filePath])
   const cleanedContent = useMemo(() => content.replace(/\s/g, ''), [content])
@@ -252,12 +254,17 @@ export default function ImageViewer({
         <div
           ref={setInlineSurfaceRef}
           className={cn(
-            'cursor-pointer bg-muted/20',
+            'bg-muted/20',
+            imagePan.cursorClassName ?? 'cursor-pointer',
             isIntrinsicLayout
               ? 'flex justify-center overflow-visible p-4'
               : 'flex-1 overflow-auto scrollbar-editor'
           )}
           onClick={openPopup}
+          onClickCapture={imagePan.onClickCapture}
+          onPointerDown={imagePan.onPointerDown}
+          onPointerEnter={imagePan.onPointerEnter}
+          onPointerLeave={imagePan.onPointerLeave}
           title={translate('auto.components.editor.ImageViewer.77bfc9b35a', 'Open image in popup')}
         >
           <div
@@ -279,6 +286,7 @@ export default function ImageViewer({
               <img
                 src={previewSrc}
                 alt={filename}
+                draggable={false}
                 className={cn(
                   'object-contain',
                   isIntrinsicLayout
@@ -351,6 +359,7 @@ export default function ImageViewer({
         imageLayoutStyle={popupImageLayoutStyle}
         isOpen={isPopupOpen}
         onOpenChange={handlePopupOpenChange}
+        pan={imagePan}
         previewUrl={previewSrc}
         setSurfaceRef={setPopupSurfaceRef}
         zoomPercent={Math.round(popupZoom * 100)}

--- a/src/renderer/src/components/editor/ImageViewerPopup.tsx
+++ b/src/renderer/src/components/editor/ImageViewerPopup.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties, JSX } from 'react'
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
 import type { ImageViewerImageDimensions } from './image-viewer-zoom'
+import type { ImageViewerPanSurfaceBindings } from './use-image-viewer-pan'
 import { translate } from '@/i18n/i18n'
 
 type ImageViewerPopupProps = {
@@ -13,6 +14,7 @@ type ImageViewerPopupProps = {
   imageLayoutSize: ImageViewerImageDimensions | null
   imageLayoutStyle: CSSProperties | undefined
   onOpenChange: (open: boolean) => void
+  pan: ImageViewerPanSurfaceBindings
   setSurfaceRef: (surface: HTMLDivElement | null) => void
 }
 
@@ -24,6 +26,7 @@ export default function ImageViewerPopup({
   imageLayoutSize,
   imageLayoutStyle,
   onOpenChange,
+  pan,
   setSurfaceRef
 }: ImageViewerPopupProps): JSX.Element {
   return (
@@ -52,13 +55,21 @@ export default function ImageViewerPopup({
         </div>
         <div
           ref={setSurfaceRef}
-          className="min-h-0 flex-1 overflow-auto bg-muted/20 scrollbar-editor"
+          className={cn(
+            'min-h-0 flex-1 overflow-auto bg-muted/20 scrollbar-editor',
+            pan.cursorClassName
+          )}
+          onClickCapture={pan.onClickCapture}
+          onPointerDown={pan.onPointerDown}
+          onPointerEnter={pan.onPointerEnter}
+          onPointerLeave={pan.onPointerLeave}
         >
           <div className="flex h-max min-h-full w-max min-w-full items-center justify-center p-4">
             <div className="flex items-center justify-center" style={imageLayoutStyle}>
               <img
                 src={previewUrl}
                 alt={filename}
+                draggable={false}
                 className={cn(
                   'object-contain',
                   imageLayoutSize ? 'block h-full w-full' : 'block max-h-full max-w-full'

--- a/src/renderer/src/components/editor/image-viewer-dom-pan.test.ts
+++ b/src/renderer/src/components/editor/image-viewer-dom-pan.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest'
+import { beginImageViewerPan } from './image-viewer-dom-pan'
+
+class FakeEventTarget {
+  private readonly listeners = new Map<string, Set<EventListener>>()
+
+  addEventListener(type: string, listener: EventListener): void {
+    let listeners = this.listeners.get(type)
+    if (!listeners) {
+      listeners = new Set()
+      this.listeners.set(type, listeners)
+    }
+    listeners.add(listener)
+  }
+
+  removeEventListener(type: string, listener: EventListener): void {
+    this.listeners.get(type)?.delete(listener)
+  }
+
+  dispatch(type: string, event: Event = {} as Event): void {
+    for (const listener of Array.from(this.listeners.get(type) ?? [])) {
+      listener(event)
+    }
+  }
+
+  listenerCount(type: string): number {
+    return this.listeners.get(type)?.size ?? 0
+  }
+}
+
+class FakeSurface extends FakeEventTarget {
+  readonly capturedPointerIds = new Set<number>()
+  scrollLeft = 120
+  scrollTop = 80
+
+  setPointerCapture(pointerId: number): void {
+    this.capturedPointerIds.add(pointerId)
+  }
+
+  hasPointerCapture(pointerId: number): boolean {
+    return this.capturedPointerIds.has(pointerId)
+  }
+
+  releasePointerCapture(pointerId: number): void {
+    this.capturedPointerIds.delete(pointerId)
+  }
+}
+
+function pointerEvent(pointerId: number, clientX = 0, clientY = 0): PointerEvent {
+  return {
+    pointerId,
+    clientX,
+    clientY,
+    preventDefault: vi.fn()
+  } as unknown as PointerEvent
+}
+
+function createGesture() {
+  const surface = new FakeSurface()
+  const ownerWindow = new FakeEventTarget()
+  const onDraggingChange = vi.fn()
+  const onEnd = vi.fn()
+  const cleanup = beginImageViewerPan({
+    surface: surface as unknown as HTMLDivElement,
+    pointerId: 7,
+    trigger: 'space-left',
+    startPointer: { x: 50, y: 50 },
+    onDraggingChange,
+    onEnd,
+    ownerWindow: ownerWindow as unknown as Window
+  })
+
+  return { cleanup, onDraggingChange, onEnd, ownerWindow, surface }
+}
+
+describe('image viewer DOM pan', () => {
+  it('captures the pointer and pans only after the threshold is crossed', () => {
+    const { onDraggingChange, onEnd, ownerWindow, surface } = createGesture()
+
+    expect(surface.capturedPointerIds.has(7)).toBe(true)
+    expect(onDraggingChange).toHaveBeenCalledTimes(1)
+    expect(onDraggingChange).toHaveBeenCalledWith(true)
+
+    ownerWindow.dispatch('pointermove', pointerEvent(7, 52, 52))
+    expect({ left: surface.scrollLeft, top: surface.scrollTop }).toEqual({ left: 120, top: 80 })
+
+    const move = pointerEvent(7, 70, 30)
+    ownerWindow.dispatch('pointermove', move)
+    expect({ left: surface.scrollLeft, top: surface.scrollTop }).toEqual({ left: 100, top: 100 })
+    expect(move.preventDefault).toHaveBeenCalledTimes(1)
+
+    ownerWindow.dispatch('pointerup', pointerEvent(8))
+    expect(onEnd).not.toHaveBeenCalled()
+    ownerWindow.dispatch('pointerup', pointerEvent(7))
+
+    expect(surface.capturedPointerIds.has(7)).toBe(false)
+    expect(onDraggingChange).toHaveBeenCalledTimes(2)
+    expect(onDraggingChange).toHaveBeenLastCalledWith(false)
+    expect(onEnd).toHaveBeenCalledWith({
+      didDrag: true,
+      reason: 'pointerup',
+      trigger: 'space-left'
+    })
+    expect(ownerWindow.listenerCount('pointermove')).toBe(0)
+  })
+
+  it.each([
+    ['pointercancel', 'pointercancel'],
+    ['blur', 'blur'],
+    ['lostpointercapture', 'lostpointercapture']
+  ] as const)('cleans up on %s', (eventType, reason) => {
+    const { onEnd, ownerWindow, surface } = createGesture()
+
+    if (eventType === 'lostpointercapture') {
+      surface.dispatch(eventType, pointerEvent(7))
+    } else if (eventType === 'blur') {
+      ownerWindow.dispatch(eventType)
+    } else {
+      ownerWindow.dispatch(eventType, pointerEvent(7))
+    }
+
+    expect(surface.capturedPointerIds.has(7)).toBe(false)
+    expect(onEnd).toHaveBeenCalledWith({ didDrag: false, reason, trigger: 'space-left' })
+    expect(ownerWindow.listenerCount('pointermove')).toBe(0)
+    expect(surface.listenerCount('lostpointercapture')).toBe(0)
+  })
+
+  it('supports idempotent manual cleanup', () => {
+    const { cleanup, onEnd, surface } = createGesture()
+
+    cleanup()
+    cleanup()
+
+    expect(surface.capturedPointerIds.has(7)).toBe(false)
+    expect(onEnd).toHaveBeenCalledTimes(1)
+    expect(onEnd).toHaveBeenCalledWith({
+      didDrag: false,
+      reason: 'manual',
+      trigger: 'space-left'
+    })
+  })
+})

--- a/src/renderer/src/components/editor/image-viewer-dom-pan.test.ts
+++ b/src/renderer/src/components/editor/image-viewer-dom-pan.test.ts
@@ -106,15 +106,12 @@ describe('image viewer DOM pan', () => {
 
   it.each([
     ['pointercancel', 'pointercancel'],
-    ['blur', 'blur'],
     ['lostpointercapture', 'lostpointercapture']
   ] as const)('cleans up on %s', (eventType, reason) => {
     const { onEnd, ownerWindow, surface } = createGesture()
 
     if (eventType === 'lostpointercapture') {
       surface.dispatch(eventType, pointerEvent(7))
-    } else if (eventType === 'blur') {
-      ownerWindow.dispatch(eventType)
     } else {
       ownerWindow.dispatch(eventType, pointerEvent(7))
     }

--- a/src/renderer/src/components/editor/image-viewer-dom-pan.ts
+++ b/src/renderer/src/components/editor/image-viewer-dom-pan.ts
@@ -1,0 +1,122 @@
+import {
+  type ImageViewerPanPoint,
+  type ImageViewerPanTrigger,
+  getImageViewerPanScrollPosition,
+  hasImageViewerPanCrossedThreshold
+} from './image-viewer-pan'
+
+type ImageViewerPanWindow = Pick<Window, 'addEventListener' | 'removeEventListener'>
+
+export type ImageViewerPanEndReason =
+  | 'pointerup'
+  | 'pointercancel'
+  | 'lostpointercapture'
+  | 'blur'
+  | 'manual'
+
+export type ImageViewerPanEnd = {
+  didDrag: boolean
+  reason: ImageViewerPanEndReason
+  trigger: ImageViewerPanTrigger
+}
+
+export type ImageViewerPanCleanup = (reason?: ImageViewerPanEndReason) => void
+
+export function beginImageViewerPan({
+  surface,
+  pointerId,
+  trigger,
+  startPointer,
+  onDraggingChange,
+  onEnd,
+  ownerWindow = window
+}: {
+  surface: HTMLDivElement
+  pointerId: number
+  trigger: ImageViewerPanTrigger
+  startPointer: ImageViewerPanPoint
+  onDraggingChange: (dragging: boolean) => void
+  onEnd: (end: ImageViewerPanEnd) => void
+  ownerWindow?: ImageViewerPanWindow
+}): ImageViewerPanCleanup {
+  const startScroll = { x: surface.scrollLeft, y: surface.scrollTop }
+  let didDrag = false
+  let cleaned = false
+
+  const cleanup: ImageViewerPanCleanup = (reason = 'manual') => {
+    if (cleaned) {
+      return
+    }
+    cleaned = true
+    try {
+      if (surface.hasPointerCapture(pointerId)) {
+        surface.releasePointerCapture(pointerId)
+      }
+    } catch {
+      // 元素可能已卸载，清理仍需继续移除窗口监听器。
+    }
+    ownerWindow.removeEventListener('pointermove', handlePointerMove)
+    ownerWindow.removeEventListener('pointerup', handlePointerUp)
+    ownerWindow.removeEventListener('pointercancel', handlePointerCancel)
+    ownerWindow.removeEventListener('blur', handleWindowBlur)
+    surface.removeEventListener('lostpointercapture', handleLostPointerCapture)
+    onDraggingChange(false)
+    onEnd({ didDrag, reason, trigger })
+  }
+
+  const handlePointerMove = (event: Event): void => {
+    const pointerEvent = event as PointerEvent
+    if (pointerEvent.pointerId !== pointerId) {
+      return
+    }
+    const currentPointer = { x: pointerEvent.clientX, y: pointerEvent.clientY }
+    if (!didDrag) {
+      if (!hasImageViewerPanCrossedThreshold(startPointer, currentPointer)) {
+        return
+      }
+      didDrag = true
+    }
+    pointerEvent.preventDefault()
+    const nextScroll = getImageViewerPanScrollPosition({
+      startScroll,
+      startPointer,
+      currentPointer
+    })
+    surface.scrollLeft = nextScroll.x
+    surface.scrollTop = nextScroll.y
+  }
+
+  const handlePointerUp = (event: Event): void => {
+    if ((event as PointerEvent).pointerId === pointerId) {
+      cleanup('pointerup')
+    }
+  }
+
+  const handlePointerCancel = (event: Event): void => {
+    if ((event as PointerEvent).pointerId === pointerId) {
+      cleanup('pointercancel')
+    }
+  }
+
+  const handleLostPointerCapture = (event: Event): void => {
+    if ((event as PointerEvent).pointerId === pointerId) {
+      cleanup('lostpointercapture')
+    }
+  }
+
+  const handleWindowBlur = (): void => cleanup('blur')
+
+  onDraggingChange(true)
+  try {
+    surface.setPointerCapture(pointerId)
+  } catch {
+    // 捕获失败时窗口监听器仍能完成拖动和清理。
+  }
+  ownerWindow.addEventListener('pointermove', handlePointerMove)
+  ownerWindow.addEventListener('pointerup', handlePointerUp)
+  ownerWindow.addEventListener('pointercancel', handlePointerCancel)
+  ownerWindow.addEventListener('blur', handleWindowBlur)
+  surface.addEventListener('lostpointercapture', handleLostPointerCapture)
+
+  return cleanup
+}

--- a/src/renderer/src/components/editor/image-viewer-dom-pan.ts
+++ b/src/renderer/src/components/editor/image-viewer-dom-pan.ts
@@ -58,7 +58,6 @@ export function beginImageViewerPan({
     ownerWindow.removeEventListener('pointermove', handlePointerMove)
     ownerWindow.removeEventListener('pointerup', handlePointerUp)
     ownerWindow.removeEventListener('pointercancel', handlePointerCancel)
-    ownerWindow.removeEventListener('blur', handleWindowBlur)
     surface.removeEventListener('lostpointercapture', handleLostPointerCapture)
     onDraggingChange(false)
     onEnd({ didDrag, reason, trigger })
@@ -104,8 +103,6 @@ export function beginImageViewerPan({
     }
   }
 
-  const handleWindowBlur = (): void => cleanup('blur')
-
   onDraggingChange(true)
   try {
     surface.setPointerCapture(pointerId)
@@ -115,7 +112,6 @@ export function beginImageViewerPan({
   ownerWindow.addEventListener('pointermove', handlePointerMove)
   ownerWindow.addEventListener('pointerup', handlePointerUp)
   ownerWindow.addEventListener('pointercancel', handlePointerCancel)
-  ownerWindow.addEventListener('blur', handleWindowBlur)
   surface.addEventListener('lostpointercapture', handleLostPointerCapture)
 
   return cleanup

--- a/src/renderer/src/components/editor/image-viewer-pan.test.ts
+++ b/src/renderer/src/components/editor/image-viewer-pan.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  IMAGE_VIEWER_PAN_DRAG_THRESHOLD,
+  getImageViewerPanScrollPosition,
+  getImageViewerPanTrigger,
+  hasImageViewerPanCrossedThreshold
+} from './image-viewer-pan'
+
+describe('image viewer pan helpers', () => {
+  it('recognizes middle-button and Space-left-button gestures', () => {
+    expect(getImageViewerPanTrigger(1, false)).toBe('middle')
+    expect(getImageViewerPanTrigger(1, true)).toBe('middle')
+    expect(getImageViewerPanTrigger(0, true)).toBe('space-left')
+    expect(getImageViewerPanTrigger(0, false)).toBeNull()
+    expect(getImageViewerPanTrigger(2, true)).toBeNull()
+  })
+
+  it('requires the pointer to cross the drag threshold', () => {
+    const start = { x: 10, y: 20 }
+
+    expect(hasImageViewerPanCrossedThreshold(start, { x: 12, y: 22 })).toBe(false)
+    expect(
+      hasImageViewerPanCrossedThreshold(start, {
+        x: 10 + IMAGE_VIEWER_PAN_DRAG_THRESHOLD,
+        y: 20
+      })
+    ).toBe(true)
+  })
+
+  it('moves the image with the pointer', () => {
+    expect(
+      getImageViewerPanScrollPosition({
+        startScroll: { x: 120, y: 80 },
+        startPointer: { x: 50, y: 50 },
+        currentPointer: { x: 70, y: 30 }
+      })
+    ).toEqual({ x: 100, y: 100 })
+  })
+})

--- a/src/renderer/src/components/editor/image-viewer-pan.ts
+++ b/src/renderer/src/components/editor/image-viewer-pan.ts
@@ -1,0 +1,43 @@
+export const IMAGE_VIEWER_PAN_DRAG_THRESHOLD = 4
+
+export type ImageViewerPanTrigger = 'middle' | 'space-left'
+
+export type ImageViewerPanPoint = {
+  x: number
+  y: number
+}
+
+export function getImageViewerPanTrigger(
+  button: number,
+  isSpacePressed: boolean
+): ImageViewerPanTrigger | null {
+  if (button === 1) {
+    return 'middle'
+  }
+  if (button === 0 && isSpacePressed) {
+    return 'space-left'
+  }
+  return null
+}
+
+export function hasImageViewerPanCrossedThreshold(
+  start: ImageViewerPanPoint,
+  current: ImageViewerPanPoint
+): boolean {
+  return Math.hypot(current.x - start.x, current.y - start.y) >= IMAGE_VIEWER_PAN_DRAG_THRESHOLD
+}
+
+export function getImageViewerPanScrollPosition({
+  startScroll,
+  startPointer,
+  currentPointer
+}: {
+  startScroll: ImageViewerPanPoint
+  startPointer: ImageViewerPanPoint
+  currentPointer: ImageViewerPanPoint
+}): ImageViewerPanPoint {
+  return {
+    x: startScroll.x - (currentPointer.x - startPointer.x),
+    y: startScroll.y - (currentPointer.y - startPointer.y)
+  }
+}

--- a/src/renderer/src/components/editor/use-image-viewer-pan.test.tsx
+++ b/src/renderer/src/components/editor/use-image-viewer-pan.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { IMAGE_VIEWER_PAN_DRAG_THRESHOLD } from './image-viewer-pan'
+import { useImageViewerPanSurface } from './use-image-viewer-pan'
+
+function createSurface(): HTMLDivElement {
+  const capturedPointerIds = new Set<number>()
+  const surface = document.createElement('div')
+  surface.setPointerCapture = vi.fn((pointerId: number) => capturedPointerIds.add(pointerId))
+  surface.hasPointerCapture = vi.fn((pointerId: number) => capturedPointerIds.has(pointerId))
+  surface.releasePointerCapture = vi.fn((pointerId: number) => capturedPointerIds.delete(pointerId))
+  return surface
+}
+
+function pointerDownEvent(
+  surface: HTMLDivElement,
+  button: number,
+  pointerId = 1
+): React.PointerEvent<HTMLDivElement> {
+  return {
+    button,
+    clientX: 40,
+    clientY: 40,
+    currentTarget: surface,
+    pointerId,
+    preventDefault: vi.fn()
+  } as unknown as React.PointerEvent<HTMLDivElement>
+}
+
+function firePointer(type: string, pointerId: number, clientX = 40, clientY = 40): void {
+  act(() => {
+    window.dispatchEvent(new PointerEvent(type, { bubbles: true, clientX, clientY, pointerId }))
+  })
+}
+
+function fireSpace(type: 'keydown' | 'keyup', target: EventTarget = window): KeyboardEvent {
+  const event = new KeyboardEvent(type, { bubbles: true, cancelable: true, code: 'Space' })
+  act(() => target.dispatchEvent(event))
+  return event
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('useImageViewerPanSurface', () => {
+  it('uses grab cursors and suppresses the click after a Space-left drag', () => {
+    const surface = createSurface()
+    const { result } = renderHook(() => useImageViewerPanSurface())
+
+    act(() => result.current.onPointerEnter({} as React.PointerEvent<HTMLDivElement>))
+    fireSpace('keydown')
+    expect(result.current.cursorClassName).toBe('cursor-grab')
+
+    const pointerDown = pointerDownEvent(surface, 0)
+    act(() => result.current.onPointerDown(pointerDown))
+    expect(pointerDown.preventDefault).toHaveBeenCalledTimes(1)
+    expect(result.current.cursorClassName).toBe('cursor-grabbing')
+
+    firePointer('pointermove', 1, 40 + IMAGE_VIEWER_PAN_DRAG_THRESHOLD, 40)
+    firePointer('pointerup', 1)
+
+    const clickEvent = { preventDefault: vi.fn(), stopPropagation: vi.fn() }
+    act(() =>
+      result.current.onClickCapture(clickEvent as unknown as React.MouseEvent<HTMLDivElement>)
+    )
+    expect(clickEvent.preventDefault).toHaveBeenCalledTimes(1)
+    expect(clickEvent.stopPropagation).toHaveBeenCalledTimes(1)
+
+    fireSpace('keyup')
+    expect(result.current.cursorClassName).toBeUndefined()
+  })
+
+  it('keeps a plain left click available to open the popup', () => {
+    const surface = createSurface()
+    const { result } = renderHook(() => useImageViewerPanSurface())
+    const pointerDown = pointerDownEvent(surface, 0)
+
+    act(() => result.current.onPointerDown(pointerDown))
+    const clickEvent = { preventDefault: vi.fn(), stopPropagation: vi.fn() }
+    act(() =>
+      result.current.onClickCapture(clickEvent as unknown as React.MouseEvent<HTMLDivElement>)
+    )
+
+    expect(pointerDown.preventDefault).not.toHaveBeenCalled()
+    expect(clickEvent.preventDefault).not.toHaveBeenCalled()
+    expect(clickEvent.stopPropagation).not.toHaveBeenCalled()
+  })
+
+  it('ends a Space-left pan when Space is released', () => {
+    const surface = createSurface()
+    const { result } = renderHook(() => useImageViewerPanSurface())
+
+    act(() => result.current.onPointerEnter({} as React.PointerEvent<HTMLDivElement>))
+    fireSpace('keydown')
+    act(() => result.current.onPointerDown(pointerDownEvent(surface, 0, 9)))
+    firePointer('pointermove', 9, 80, 40)
+    fireSpace('keyup')
+
+    expect(surface.releasePointerCapture).toHaveBeenCalledWith(9)
+    expect(result.current.cursorClassName).toBeUndefined()
+  })
+
+  it('cleans up a middle-button pan when the window loses focus', () => {
+    const surface = createSurface()
+    const { result } = renderHook(() => useImageViewerPanSurface())
+
+    act(() => result.current.onPointerDown(pointerDownEvent(surface, 1, 12)))
+    expect(result.current.cursorClassName).toBe('cursor-grabbing')
+    act(() => window.dispatchEvent(new Event('blur')))
+
+    expect(surface.releasePointerCapture).toHaveBeenCalledWith(12)
+    expect(result.current.cursorClassName).toBeUndefined()
+  })
+
+  it('does not claim Space from another control unless the pointer is over the surface', () => {
+    const button = document.createElement('button')
+    document.body.append(button)
+    const { result } = renderHook(() => useImageViewerPanSurface())
+
+    fireSpace('keydown')
+    fireSpace('keydown', button)
+    expect(result.current.cursorClassName).toBeUndefined()
+
+    act(() => result.current.onPointerEnter({} as React.PointerEvent<HTMLDivElement>))
+    const handledSpace = fireSpace('keydown', button)
+    expect(handledSpace.defaultPrevented).toBe(true)
+    expect(result.current.cursorClassName).toBe('cursor-grab')
+
+    button.remove()
+  })
+})

--- a/src/renderer/src/components/editor/use-image-viewer-pan.ts
+++ b/src/renderer/src/components/editor/use-image-viewer-pan.ts
@@ -1,0 +1,127 @@
+import {
+  type MouseEventHandler,
+  type PointerEventHandler,
+  useCallback,
+  useEffect,
+  useRef,
+  useState
+} from 'react'
+import { type ImageViewerPanCleanup, beginImageViewerPan } from './image-viewer-dom-pan'
+import { type ImageViewerPanTrigger, getImageViewerPanTrigger } from './image-viewer-pan'
+
+export type ImageViewerPanSurfaceBindings = {
+  cursorClassName: 'cursor-grab' | 'cursor-grabbing' | undefined
+  onClickCapture: MouseEventHandler<HTMLDivElement>
+  onPointerDown: PointerEventHandler<HTMLDivElement>
+  onPointerEnter: PointerEventHandler<HTMLDivElement>
+  onPointerLeave: PointerEventHandler<HTMLDivElement>
+}
+
+function isSpaceKey(event: KeyboardEvent): boolean {
+  return event.code === 'Space'
+}
+
+export function useImageViewerPanSurface(): ImageViewerPanSurfaceBindings {
+  const [isSpacePressed, setIsSpacePressed] = useState(false)
+  const [isDragging, setIsDragging] = useState(false)
+  const isSpacePressedRef = useRef(false)
+  const isPointerInsideRef = useRef(false)
+  const activeTriggerRef = useRef<ImageViewerPanTrigger | null>(null)
+  const activeCleanupRef = useRef<ImageViewerPanCleanup | null>(null)
+  const suppressClickRef = useRef(false)
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (
+        !isSpaceKey(event) ||
+        event.altKey ||
+        event.ctrlKey ||
+        event.metaKey ||
+        !isPointerInsideRef.current
+      ) {
+        return
+      }
+      isSpacePressedRef.current = true
+      setIsSpacePressed(true)
+      event.preventDefault()
+    }
+
+    const handleKeyUp = (event: KeyboardEvent): void => {
+      if (!isSpaceKey(event)) {
+        return
+      }
+      isSpacePressedRef.current = false
+      setIsSpacePressed(false)
+      if (activeTriggerRef.current === 'space-left') {
+        activeCleanupRef.current?.()
+      }
+    }
+
+    const handleWindowBlur = (): void => {
+      isSpacePressedRef.current = false
+      setIsSpacePressed(false)
+      activeCleanupRef.current?.('blur')
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    window.addEventListener('keyup', handleKeyUp)
+    window.addEventListener('blur', handleWindowBlur)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('keyup', handleKeyUp)
+      window.removeEventListener('blur', handleWindowBlur)
+      activeCleanupRef.current?.()
+    }
+  }, [])
+
+  const onPointerDown = useCallback<PointerEventHandler<HTMLDivElement>>((event) => {
+    activeCleanupRef.current?.()
+    suppressClickRef.current = false
+    const trigger = getImageViewerPanTrigger(event.button, isSpacePressedRef.current)
+    if (!trigger) {
+      return
+    }
+
+    event.preventDefault()
+    activeTriggerRef.current = trigger
+    activeCleanupRef.current = beginImageViewerPan({
+      surface: event.currentTarget,
+      pointerId: event.pointerId,
+      trigger,
+      startPointer: { x: event.clientX, y: event.clientY },
+      onDraggingChange: setIsDragging,
+      onEnd: ({ didDrag, trigger: endedTrigger }) => {
+        activeCleanupRef.current = null
+        activeTriggerRef.current = null
+        if (didDrag && endedTrigger === 'space-left') {
+          suppressClickRef.current = true
+        }
+      }
+    })
+  }, [])
+
+  const onClickCapture = useCallback<MouseEventHandler<HTMLDivElement>>((event) => {
+    if (!suppressClickRef.current) {
+      return
+    }
+    suppressClickRef.current = false
+    event.preventDefault()
+    event.stopPropagation()
+  }, [])
+
+  const onPointerEnter = useCallback(() => {
+    isPointerInsideRef.current = true
+  }, [])
+
+  const onPointerLeave = useCallback(() => {
+    isPointerInsideRef.current = false
+  }, [])
+
+  return {
+    cursorClassName: isDragging ? 'cursor-grabbing' : isSpacePressed ? 'cursor-grab' : undefined,
+    onClickCapture,
+    onPointerDown,
+    onPointerEnter,
+    onPointerLeave
+  }
+}

--- a/src/renderer/src/components/editor/use-image-viewer-pan.ts
+++ b/src/renderer/src/components/editor/use-image-viewer-pan.ts
@@ -32,6 +32,7 @@ export function useImageViewerPanSurface(): ImageViewerPanSurfaceBindings {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
+      // 仅在指针位于图片面且无系统修饰键时接管空格，避免干扰全局快捷键。
       if (
         !isSpaceKey(event) ||
         event.altKey ||


### PR DESCRIPTION
## Summary

- Add middle-button drag and Space + left-button drag panning to the inline and popup image surfaces.
- Share one pointer-pan controller across both surfaces, with pointer capture, a 4 px drag threshold, click suppression, and `grab` / `grabbing` cursors.
- Preserve cursor-anchored Ctrl+wheel zooming and disable native image dragging.

Closes #9337

## Screenshots

Inline and popup screenshots at 244% zoom are attached in a follow-up PR comment.

## Testing

- [ ] `pnpm lint` (the full command is currently blocked by pre-existing switch-exhaustiveness errors in `skill-freshness-group.tsx` and `daemon-server.ts`; changed-file oxlint, React Doctor, and the remaining lint gates pass)
- [x] `pnpm typecheck`
- [ ] `pnpm test` (the focused image-viewer suite passes; the local full suite hit unrelated integration-test timeouts)
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional verification:

- 27 focused Vitest assertions across zoom, pan math, pointer lifecycle, hook behavior, and both rendered surfaces.
- Max-lines, styled-scrollbar, reliability, localization, bundled-skill, and manifest gates pass.
- Production Electron renderer build passes after the final refactor.
- Real Chromium interaction verified both drag gestures, scroll direction, cursor states, inline click suppression, ordinary click-to-open, popup panning, and zero console errors.

## AI Review Report

The review checked pointer event ordering, click suppression, capture loss, pointer cancellation, window blur, Space release, listener cleanup, and native image drag behavior. It flagged duplicate global keyboard listeners when inline and popup used separate controller instances; the implementation was changed to share one controller per image viewer and to update Space state only while a surface is hovered.

Cross-platform review covered macOS, Linux, and Windows. The implementation uses standard Pointer Events, `KeyboardEvent.code`, button values, and existing Tailwind cursor classes without platform-specific shortcut labels, filesystem paths, shell behavior, or Electron-only APIs. The behavior is renderer-local and unchanged for local, SSH, and remote worktrees. It does not interact with agents, integrations, or git providers. Performance review confirmed one controller per mounted viewer and deterministic listener cleanup. UI review confirmed no layout or token changes and verified inline and popup screenshots.

## Security Audit

The change processes only local pointer and keyboard events. It adds no command execution, path handling, network or IPC calls, authentication, secrets, dependencies, or persisted input. `preventDefault` is scoped to supported pan gestures or Space while the pointer is over an image surface, and all temporary window listeners are removed on every terminal path. No follow-up security work is needed.

## Notes

- Verified interactively on macOS with Chromium; the event APIs used are supported by the app's Chromium runtime on Linux and Windows as well.
- X handle: N/A

## ELI5

You can pan around zoomed images by dragging with the middle mouse button, or holding Space and dragging with the left button. It works in both the inline image view and the popup, with grab cursors so it feels like a normal image viewer.
