### PR TITLE
fix(sidebar): activate workspace number shortcuts by rendered sidebar order

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -77,7 +77,6 @@ import {
 } from './smart-attention'
 import { track } from '@/lib/telemetry'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
-import { deriveRunningAgentSendTargets } from '@/lib/running-agent-targets'
 import { rightSidebarShowsPullRequestData } from '@/lib/right-sidebar-visibility'
 import {
   type Row,
@@ -117,6 +116,7 @@ import { useWorkspaceStatusDocumentDrop } from './use-workspace-status-drop'
 import {
   computeClearFilterActions,
   computeVisibleWorktreeIds,
+  registerVisibleWorktreeIdsPublisher,
   setVisibleWorktreeIds,
   sidebarHasActiveFilters
 } from './visible-worktrees'
@@ -127,6 +127,10 @@ import {
   getVisibleWorktreeTerminalActivityTabs
 } from './visible-worktree-activity-inputs'
 import { selectWorktreeListReviewCacheInputs } from './worktree-list-review-cache-inputs'
+import {
+  getAgentSendEffectiveCollapsedGroups,
+  getEligibleAgentSendTargetWorktreeId
+} from './rendered-workspace-shortcut-order'
 import {
   VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT,
   useVirtualizedScrollAnchor,
@@ -5237,19 +5241,13 @@ const WorktreeList = React.memo(function WorktreeList({
     if (!agentSendPopoverTargetMode) {
       return null
     }
-    const targets = deriveRunningAgentSendTargets(
-      {
-        agentStatusByPaneKey: agentTargetStatusByPaneKey,
-        tabsByWorktree: agentTargetTabsByWorktree,
-        terminalLayoutsByTabId: agentTargetTerminalLayoutsByTabId,
-        ptyIdsByTabId: agentTargetPtyIdsByTabId,
-        runtimePaneTitlesByTabId: agentTargetRuntimePaneTitlesByTabId
-      },
-      agentSendPopoverTargetMode.worktreeId
-    )
-    return targets.some((target) => target.status === 'eligible')
-      ? agentSendPopoverTargetMode.worktreeId
-      : null
+    return getEligibleAgentSendTargetWorktreeId(agentSendPopoverTargetMode, {
+      agentStatusByPaneKey: agentTargetStatusByPaneKey,
+      tabsByWorktree: agentTargetTabsByWorktree,
+      terminalLayoutsByTabId: agentTargetTerminalLayoutsByTabId,
+      ptyIdsByTabId: agentTargetPtyIdsByTabId,
+      runtimePaneTitlesByTabId: agentTargetRuntimePaneTitlesByTabId
+    })
   }, [
     // Why: eligibility can flip when the stale-boundary scheduler bumps this epoch without replacing the status map.
     agentTargetStatusEpoch,
@@ -5531,63 +5529,35 @@ const WorktreeList = React.memo(function WorktreeList({
   )
   const projectGroups = useAppStore((s) => s.projectGroups ?? EMPTY_PROJECT_GROUPS)
   const folderWorkspaces = useAppStore((s) => s.folderWorkspaces)
-  const effectiveCollapsedGroups = useMemo(() => {
-    if (!agentSendTargetWorktreeId) {
-      return collapsedGroups
-    }
-    const targetWorktree = worktreeMap.get(agentSendTargetWorktreeId)
-    if (!targetWorktree) {
-      return collapsedGroups
-    }
-    const next = new Set(collapsedGroups)
-    if (targetWorktree.isPinned) {
-      next.delete(PINNED_GROUP_KEY)
-    } else {
-      for (const groupKey of getGroupKeysForWorktree(
+  const effectiveCollapsedGroups = useMemo(
+    () =>
+      getAgentSendEffectiveCollapsedGroups({
+        targetWorktreeId: agentSendTargetWorktreeId,
+        collapsedGroups,
         groupBy,
-        targetWorktree,
+        worktreeMap,
         repoMap,
         prCache,
         workspaceStatuses,
         settings,
         projectGroups,
-        projectGrouping
-      )) {
-        next.delete(groupKey)
-      }
-    }
-
-    const seen = new Set<string>()
-    let current: Worktree | undefined = targetWorktree
-    while (current && !seen.has(current.id)) {
-      seen.add(current.id)
-      const lineage = worktreeLineageById[current.id]
-      const parent = lineage ? worktreeMap.get(lineage.parentWorktreeId) : undefined
-      if (
-        !lineage ||
-        !parent ||
-        current.instanceId !== lineage.worktreeInstanceId ||
-        parent.instanceId !== lineage.parentWorktreeInstanceId
-      ) {
-        break
-      }
-      next.delete(getLineageGroupKey(parent.id))
-      current = parent
-    }
-    return next
-  }, [
-    agentSendTargetWorktreeId,
-    collapsedGroups,
-    groupBy,
-    prCache,
-    projectGroups,
-    projectGrouping,
-    repoMap,
-    settings,
-    workspaceStatuses,
-    worktreeLineageById,
-    worktreeMap
-  ])
+        projectGrouping,
+        worktreeLineageById
+      }),
+    [
+      agentSendTargetWorktreeId,
+      collapsedGroups,
+      groupBy,
+      prCache,
+      projectGroups,
+      projectGrouping,
+      repoMap,
+      settings,
+      workspaceStatuses,
+      worktreeLineageById,
+      worktreeMap
+    ]
+  )
   const defaultHostId = getSettingsFocusedExecutionHostId(settings)
   const visibleHostIdSet = useMemo(() => {
     const visibleHostIds =
@@ -5936,10 +5906,11 @@ const WorktreeList = React.memo(function WorktreeList({
     activeView === 'tasks' || activeView === 'activity' ? null : currentSidebarWorktreeId
 
   // Why layout effect: the Cmd/Ctrl+1–9 handler can fire right after commit; publishing after paint would leave the shortcut cache stale.
+  useLayoutEffect(registerVisibleWorktreeIdsPublisher, [])
   useLayoutEffect(() => {
+    // Why: this last rendered order remains authoritative while the sidebar is
+    // closed; clearing it on unmount makes shortcuts bypass Smart sort settling.
     setVisibleWorktreeIds(renderedWorktreeIds)
-    // Why: unmounting the list clears the rendered-order cache so shortcuts fall back to the live store snapshot.
-    return () => setVisibleWorktreeIds([])
   }, [renderedWorktreeIds])
 
   const handleCreateForRepo = useCallback(

--- a/src/renderer/src/components/sidebar/rendered-workspace-shortcut-order.ts
+++ b/src/renderer/src/components/sidebar/rendered-workspace-shortcut-order.ts
@@ -1,0 +1,281 @@
+import type {
+  FolderWorkspace,
+  ProjectGroup,
+  Repo,
+  Worktree,
+  WorktreeLineage,
+  WorkspaceStatusDefinition
+} from '../../../../shared/types'
+import type { AppState } from '@/store/types'
+import {
+  deriveRunningAgentSendTargets,
+  type RunningAgentTargetState
+} from '@/lib/running-agent-targets'
+import {
+  getProjectHostSetupProjectionFromState,
+  getRepoMapFromState,
+  getWorktreeMapFromState
+} from '@/store/selectors'
+import {
+  ALL_EXECUTION_HOSTS_SCOPE,
+  getRepoExecutionHostId,
+  getSettingsFocusedExecutionHostId,
+  type ExecutionHostId
+} from '../../../../shared/execution-host'
+import { getHostDisplayLabelOverrides } from '../../../../shared/host-setting-overrides'
+import { addHostSectionRows } from './host-section-rows'
+import { getEmptyProjectPlaceholderRepoIds } from './empty-project-placeholder-repos'
+import { buildImportedWorktreesCardCandidates } from './imported-worktrees-card-candidates'
+import { buildNewExternalWorktreesInboxCandidates } from './new-external-worktrees-inbox-candidates'
+import { orderHostSectionOptions } from './host-section-order'
+import { getLogicalRepoOrderRankById } from './project-header-drop'
+import { buildSidebarHostOptions } from './sidebar-host-options'
+import {
+  buildRows,
+  getGroupKeysForWorktree,
+  getLineageGroupKey,
+  getPinnedWorktreeDisplayPolicy,
+  PINNED_GROUP_KEY,
+  type ProjectGroupingModel,
+  type WorktreeGroupBy
+} from './worktree-list-groups'
+import {
+  getFolderWorkspaceExecutionHostIdForRows,
+  getProjectGroupExecutionHostIdForRows
+} from './worktree-list-host-filtering'
+import { getRenderedWorktreesInSidebarOrder } from './worktree-sidebar-row-preference'
+
+export function getEligibleAgentSendTargetWorktreeId(
+  mode: AppState['agentSendPopoverTargetMode'],
+  state: RunningAgentTargetState
+): string | null {
+  if (!mode) {
+    return null
+  }
+  const targets = deriveRunningAgentSendTargets(state, mode.worktreeId)
+  return targets.some((target) => target.status === 'eligible') ? mode.worktreeId : null
+}
+
+export function getAgentSendEffectiveCollapsedGroups(args: {
+  targetWorktreeId: string | null
+  collapsedGroups: Set<string>
+  groupBy: WorktreeGroupBy
+  worktreeMap: Map<string, Worktree>
+  repoMap: Map<string, Repo>
+  prCache: Record<string, unknown> | null
+  workspaceStatuses: readonly WorkspaceStatusDefinition[]
+  settings: AppState['settings']
+  projectGroups: readonly ProjectGroup[]
+  projectGrouping: ProjectGroupingModel
+  worktreeLineageById: Record<string, WorktreeLineage>
+}): Set<string> {
+  const targetWorktree = args.targetWorktreeId
+    ? args.worktreeMap.get(args.targetWorktreeId)
+    : undefined
+  if (!targetWorktree) {
+    return args.collapsedGroups
+  }
+
+  const next = new Set(args.collapsedGroups)
+  if (targetWorktree.isPinned) {
+    next.delete(PINNED_GROUP_KEY)
+  } else {
+    for (const groupKey of getGroupKeysForWorktree(
+      args.groupBy,
+      targetWorktree,
+      args.repoMap,
+      args.prCache,
+      args.workspaceStatuses,
+      args.settings,
+      args.projectGroups,
+      args.projectGrouping
+    )) {
+      next.delete(groupKey)
+    }
+  }
+
+  const seen = new Set<string>()
+  let current: Worktree | undefined = targetWorktree
+  while (current && !seen.has(current.id)) {
+    seen.add(current.id)
+    const lineage = args.worktreeLineageById[current.id]
+    const parent = lineage ? args.worktreeMap.get(lineage.parentWorktreeId) : undefined
+    if (
+      !lineage ||
+      !parent ||
+      current.instanceId !== lineage.worktreeInstanceId ||
+      parent.instanceId !== lineage.parentWorktreeInstanceId
+    ) {
+      break
+    }
+    next.delete(getLineageGroupKey(parent.id))
+    current = parent
+  }
+  return next
+}
+
+function getVisibleHostIdSet(state: AppState): Set<ExecutionHostId> | null {
+  const ids =
+    state.visibleWorkspaceHostIds ??
+    (state.workspaceHostScope === ALL_EXECUTION_HOSTS_SCOPE ? null : [state.workspaceHostScope])
+  return ids ? new Set(ids) : null
+}
+
+function getVisibleProjectGroups(
+  state: AppState,
+  visibleHostIds: ReadonlySet<ExecutionHostId> | null,
+  defaultHostId: ExecutionHostId
+): ProjectGroup[] {
+  if (!visibleHostIds) {
+    return state.projectGroups
+  }
+  return state.projectGroups.filter((group) =>
+    visibleHostIds.has(getProjectGroupExecutionHostIdForRows(group, defaultHostId))
+  )
+}
+
+function getVisibleFolderWorkspaces(
+  state: AppState,
+  visibleHostIds: ReadonlySet<ExecutionHostId> | null,
+  defaultHostId: ExecutionHostId
+): FolderWorkspace[] {
+  if (!visibleHostIds) {
+    return state.folderWorkspaces
+  }
+  const projectGroupById = new Map(state.projectGroups.map((group) => [group.id, group]))
+  return state.folderWorkspaces.filter((folderWorkspace) =>
+    visibleHostIds.has(
+      getFolderWorkspaceExecutionHostIdForRows({
+        folderWorkspace,
+        projectGroup: projectGroupById.get(folderWorkspace.projectGroupId),
+        defaultHostId
+      })
+    )
+  )
+}
+
+function getVisibleRepos(
+  state: AppState,
+  visibleHostIds: ReadonlySet<ExecutionHostId> | null,
+  defaultHostId: ExecutionHostId
+) {
+  if (!visibleHostIds) {
+    return state.repos
+  }
+  return state.repos.filter((repo) => {
+    const hostId =
+      repo.connectionId || repo.executionHostId ? getRepoExecutionHostId(repo) : defaultHostId
+    return visibleHostIds.has(hostId)
+  })
+}
+
+export function getRenderedWorkspaceShortcutIds(
+  state: AppState,
+  visibleWorktreeIds: readonly string[]
+): string[] {
+  const defaultHostId = getSettingsFocusedExecutionHostId(state.settings)
+  const visibleHostIds = getVisibleHostIdSet(state)
+  const repoMap = getRepoMapFromState(state)
+  const worktreeMap = getWorktreeMapFromState(state)
+  const agentSendTargetWorktreeId = getEligibleAgentSendTargetWorktreeId(
+    state.agentSendPopoverTargetMode,
+    state
+  )
+  const effectiveVisibleWorktreeIds = [...visibleWorktreeIds]
+  if (
+    agentSendTargetWorktreeId &&
+    !effectiveVisibleWorktreeIds.includes(agentSendTargetWorktreeId) &&
+    worktreeMap.has(agentSendTargetWorktreeId)
+  ) {
+    effectiveVisibleWorktreeIds.push(agentSendTargetWorktreeId)
+  }
+  const visibleWorktrees = effectiveVisibleWorktreeIds
+    .map((id) => worktreeMap.get(id))
+    .filter((worktree): worktree is Worktree => worktree !== undefined)
+  const visibleRepos = getVisibleRepos(state, visibleHostIds, defaultHostId)
+  const projection = getProjectHostSetupProjectionFromState(state)
+  const projectGrouping: ProjectGroupingModel = {
+    projects: projection.projects,
+    projectHostSetups: projection.setups
+  }
+  const effectiveCollapsedGroups = getAgentSendEffectiveCollapsedGroups({
+    targetWorktreeId: agentSendTargetWorktreeId,
+    collapsedGroups: state.collapsedGroups,
+    groupBy: state.groupBy,
+    worktreeMap,
+    repoMap,
+    prCache: state.prCache,
+    workspaceStatuses: state.workspaceStatuses,
+    settings: state.settings,
+    projectGroups: state.projectGroups,
+    projectGrouping,
+    worktreeLineageById: state.worktreeLineageById
+  })
+  const hostOptions = orderHostSectionOptions(
+    buildSidebarHostOptions({
+      repos: state.repos,
+      sshTargetLabels: state.sshTargetLabels,
+      sshConnectionStates: state.sshConnectionStates,
+      settings: state.settings,
+      runtimeEnvironments: state.runtimeEnvironments,
+      runtimeStatusByEnvironmentId: state.runtimeStatusByEnvironmentId,
+      hostLabelOverrides: getHostDisplayLabelOverrides(state.settings)
+    }),
+    state.workspaceHostOrder
+  )
+  const rows = buildRows(
+    state.groupBy,
+    visibleWorktrees,
+    repoMap,
+    state.prCache,
+    effectiveCollapsedGroups,
+    getLogicalRepoOrderRankById(state.repos.map((repo) => repo.id)),
+    state.workspaceStatuses,
+    state.projectOrderBy,
+    state.worktreeLineageById,
+    worktreeMap,
+    true,
+    state.settings,
+    getVisibleProjectGroups(state, visibleHostIds, defaultHostId),
+    getEmptyProjectPlaceholderRepoIds({
+      groupBy: state.groupBy,
+      repos: visibleRepos,
+      worktreesByRepo: state.worktreesByRepo,
+      visibleWorktrees,
+      filterRepoIds: state.filterRepoIds
+    }),
+    buildImportedWorktreesCardCandidates({
+      repos: visibleRepos,
+      detectedWorktreesByRepo: state.detectedWorktreesByRepo,
+      filterRepoIds: state.filterRepoIds
+    }),
+    buildNewExternalWorktreesInboxCandidates({
+      repos: visibleRepos,
+      detectedWorktreesByRepo: state.detectedWorktreesByRepo,
+      filterRepoIds: state.filterRepoIds
+    }),
+    Object.values(state.pendingWorktreeCreations).map((creation) => ({
+      creationId: creation.creationId,
+      repoId: creation.request.repoId
+    })),
+    projectGrouping,
+    getVisibleFolderWorkspaces(state, visibleHostIds, defaultHostId),
+    new Map(hostOptions.map((host) => [host.id, host.label])),
+    defaultHostId,
+    getPinnedWorktreeDisplayPolicy(state.settings)
+  )
+  const sectionRows = addHostSectionRows({
+    rows,
+    hostOptions,
+    workspaceHostScope: state.workspaceHostScope,
+    visibleWorkspaceHostIds: state.visibleWorkspaceHostIds,
+    defaultHostId,
+    collapsedHostKeys: effectiveCollapsedGroups,
+    preferProjectGrouping: true
+  })
+
+  return getRenderedWorktreesInSidebarOrder(
+    sectionRows,
+    getPinnedWorktreeDisplayPolicy(state.settings)
+  ).map((worktree) => worktree.id)
+}

--- a/src/renderer/src/components/sidebar/visible-worktree-shortcut-order.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktree-shortcut-order.test.ts
@@ -1,0 +1,516 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { StoreApi } from 'zustand'
+import type {
+  FolderWorkspace,
+  ProjectGroup,
+  Repo,
+  TerminalTab,
+  Worktree
+} from '../../../../shared/types'
+import type { AppState } from '@/store/types'
+import type { AgentSendPopoverTargetMode } from '@/store/slices/ui'
+import type { PendingWorktreeCreation } from '@/lib/pending-worktree-creation'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+
+type AppStore = Pick<StoreApi<AppState>, 'getState' | 'setState'>
+
+const repo: Repo = {
+  id: 'repo',
+  path: '/repo',
+  displayName: 'Repo',
+  badgeColor: '#000000',
+  addedAt: 0
+}
+
+const remoteRepo: Repo = {
+  ...repo,
+  id: 'remote-repo',
+  path: '/remote/repo',
+  displayName: 'Remote Repo',
+  connectionId: 'remote'
+}
+
+function makeWorktree(id: string, sortOrder: number, lastActivityAt: number): Worktree {
+  return {
+    id,
+    repoId: repo.id,
+    path: `/repo/${id}`,
+    head: 'abc123',
+    branch: id,
+    isBare: false,
+    isMainWorktree: false,
+    displayName: id,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder,
+    lastActivityAt
+  }
+}
+
+function makeFolderWorkspace(id: string): FolderWorkspace {
+  return {
+    id,
+    projectGroupId: 'group',
+    name: id,
+    folderPath: `/folders/${id}`,
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    createdAt: 0,
+    updatedAt: 0
+  }
+}
+
+function makeProjectGroup(id = 'group'): ProjectGroup {
+  return {
+    id,
+    name: 'Group',
+    parentPath: '/folders',
+    parentGroupId: null,
+    createdFrom: 'folder-scan',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 0,
+    updatedAt: 0
+  }
+}
+
+function makeAgentSendMode(worktreeId: string): AgentSendPopoverTargetMode {
+  return {
+    id: 'mode-1',
+    instanceId: 'instance-1',
+    worktreeId,
+    source: 'diff-notes',
+    prompt: 'Review this',
+    label: 'Send',
+    launchSource: 'sidebar',
+    eligiblePaneKeys: [],
+    disabledPaneKeys: {},
+    status: 'open'
+  }
+}
+
+function makeEligibleAgentState(worktreeId: string): Partial<AppState> {
+  const tabId = `${worktreeId}-tab`
+  const leafId = '11111111-1111-4111-8111-111111111111'
+  const paneKey = makePaneKey(tabId, leafId)
+  const tab: TerminalTab = {
+    id: tabId,
+    ptyId: `${worktreeId}-pty`,
+    worktreeId,
+    title: 'Terminal',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+  return {
+    agentSendPopoverTargetMode: makeAgentSendMode(worktreeId),
+    tabsByWorktree: { [worktreeId]: [tab] },
+    terminalLayoutsByTabId: {
+      [tabId]: {
+        root: { type: 'leaf', leafId },
+        activeLeafId: leafId,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [leafId]: tab.ptyId! }
+      }
+    },
+    ptyIdsByTabId: { [tabId]: [tab.ptyId!] },
+    agentStatusByPaneKey: {
+      [paneKey]: {
+        paneKey,
+        state: 'working',
+        prompt: 'Working',
+        updatedAt: Date.now(),
+        stateStartedAt: Date.now(),
+        agentType: 'codex',
+        stateHistory: []
+      }
+    }
+  }
+}
+
+function makePendingCreation(creationId: string, repoId: string): PendingWorktreeCreation {
+  return {
+    creationId,
+    phase: 'fetching',
+    status: 'creating',
+    startedAt: 0,
+    indeterminate: false,
+    loaderVisible: false,
+    request: {
+      repoId,
+      name: 'feature',
+      setupDecision: 'inherit',
+      agent: null,
+      pendingFirstAgentMessageRename: false,
+      note: '',
+      startupPlan: null,
+      quickPrompt: '',
+      quickTelemetry: null
+    }
+  }
+}
+
+function setVisibleState(
+  store: AppStore,
+  worktrees: Worktree[],
+  overrides: Partial<AppState> = {}
+): void {
+  store.setState({
+    repos: [repo],
+    worktreesByRepo: { [repo.id]: worktrees },
+    folderWorkspaces: [],
+    projectGroups: [],
+    sortBy: 'name',
+    filterRepoIds: [],
+    showSleepingWorkspaces: true,
+    tabsByWorktree: {},
+    ptyIdsByTabId: {},
+    browserTabsByWorktree: {},
+    agentStatusByPaneKey: {},
+    runtimePaneTitlesByTabId: {},
+    migrationUnsupportedByPtyId: {},
+    terminalLayoutsByTabId: {},
+    hideDefaultBranchWorkspace: false,
+    hideAutomationGeneratedWorkspaces: false,
+    workspaceHostScope: 'all',
+    visibleWorkspaceHostIds: null,
+    worktreeLineageById: {},
+    collapsedGroups: new Set(),
+    ...overrides
+  })
+}
+
+async function loadFreshOrderState(): Promise<{
+  store: AppStore
+  getVisibleWorktreeIds: () => string[]
+  registerVisibleWorktreeIdsPublisher: () => () => void
+  setVisibleWorktreeIds: (ids: string[]) => void
+}> {
+  vi.resetModules()
+  const [{ useAppStore }, orderState] = await Promise.all([
+    import('@/store'),
+    import('./visible-worktrees')
+  ])
+  return { store: useAppStore, ...orderState }
+}
+
+describe('visible worktree shortcut order', () => {
+  it('uses the published order directly while the sidebar publisher is mounted', async () => {
+    const first = makeWorktree('first', 1, 0)
+    const {
+      store,
+      getVisibleWorktreeIds,
+      registerVisibleWorktreeIdsPublisher,
+      setVisibleWorktreeIds
+    } = await loadFreshOrderState()
+    setVisibleState(store, [first], { groupBy: 'none' })
+    setVisibleWorktreeIds([first.id])
+    const unregisterPublisher = registerVisibleWorktreeIdsPublisher()
+
+    setVisibleState(store, [first], {
+      groupBy: 'none',
+      collapsedGroups: new Set(['all'])
+    })
+
+    expect(getVisibleWorktreeIds()).toEqual([first.id])
+    unregisterPublisher()
+    expect(getVisibleWorktreeIds()).toEqual([])
+  })
+
+  it('keeps a rendered empty order instead of falling back to live state', async () => {
+    const first = makeWorktree('first', 1, 0)
+    const { store, getVisibleWorktreeIds, setVisibleWorktreeIds } = await loadFreshOrderState()
+    setVisibleState(store, [first], { groupBy: 'none', collapsedGroups: new Set(['all']) })
+
+    setVisibleWorktreeIds([])
+
+    expect(getVisibleWorktreeIds()).toEqual([])
+  })
+
+  it('removes ineligible cached worktrees without reordering survivors', async () => {
+    const first = makeWorktree('first', 1, 0)
+    const second = makeWorktree('second', 2, 0)
+    const { store, getVisibleWorktreeIds, setVisibleWorktreeIds } = await loadFreshOrderState()
+    setVisibleState(store, [first, second])
+    setVisibleWorktreeIds([second.id, first.id])
+
+    setVisibleState(store, [{ ...first, isArchived: true }, second])
+
+    expect(getVisibleWorktreeIds()).toEqual([second.id])
+  })
+
+  it('keeps folder workspaces in their published shortcut positions', async () => {
+    const first = makeWorktree('first', 1, 0)
+    const folder = makeFolderWorkspace('folder-one')
+    const { store, getVisibleWorktreeIds, setVisibleWorktreeIds } = await loadFreshOrderState()
+    setVisibleState(store, [first], {
+      folderWorkspaces: [folder],
+      projectGroups: [makeProjectGroup()]
+    })
+
+    setVisibleWorktreeIds([`folder:${folder.id}`, first.id])
+
+    expect(getVisibleWorktreeIds()).toEqual([`folder:${folder.id}`, first.id])
+  })
+
+  it('appends worktrees discovered while the sidebar is closed', async () => {
+    const first = makeWorktree('first', 1, 0)
+    const second = makeWorktree('second', 2, 0)
+    const { store, getVisibleWorktreeIds, setVisibleWorktreeIds } = await loadFreshOrderState()
+    setVisibleState(store, [first])
+    setVisibleWorktreeIds([first.id])
+
+    setVisibleState(store, [first, second])
+
+    expect(getVisibleWorktreeIds()).toEqual([first.id, second.id])
+  })
+
+  it('removes survivors and additions hidden under a collapsed group', async () => {
+    const first = makeWorktree('first', 1, 0)
+    const second = makeWorktree('second', 2, 0)
+    const { store, getVisibleWorktreeIds, setVisibleWorktreeIds } = await loadFreshOrderState()
+    setVisibleState(store, [first], { groupBy: 'none' })
+    setVisibleWorktreeIds([first.id])
+
+    setVisibleState(store, [first, second], { groupBy: 'none', collapsedGroups: new Set(['all']) })
+
+    expect(getVisibleWorktreeIds()).toEqual([])
+  })
+
+  it('does not append worktrees hidden under a collapsed lineage parent', async () => {
+    const first = { ...makeWorktree('first', 1, 0), instanceId: 'first-instance' }
+    const second = { ...makeWorktree('second', 2, 0), instanceId: 'second-instance' }
+    const lineage = {
+      worktreeId: second.id,
+      worktreeInstanceId: 'second-instance',
+      parentWorktreeId: first.id,
+      parentWorktreeInstanceId: 'first-instance',
+      origin: 'cli' as const,
+      capture: { source: 'cwd-context' as const, confidence: 'inferred' as const },
+      createdAt: 0
+    }
+    const { store, getVisibleWorktreeIds, setVisibleWorktreeIds } = await loadFreshOrderState()
+    setVisibleState(store, [first], { collapsedGroups: new Set([`lineage:${first.id}`]) })
+    setVisibleWorktreeIds([first.id])
+
+    setVisibleState(store, [first, second], {
+      collapsedGroups: new Set([`lineage:${first.id}`]),
+      worktreeLineageById: { [second.id]: lineage }
+    })
+
+    expect(getVisibleWorktreeIds()).toEqual([first.id])
+  })
+
+  it('does not append worktrees hidden under a collapsed host section', async () => {
+    const remote = { ...makeWorktree('remote', 1, 0), repoId: remoteRepo.id }
+    const local = makeWorktree('local', 2, 0)
+    const hostOverrides: Partial<AppState> = {
+      repos: [repo, remoteRepo],
+      visibleWorkspaceHostIds: ['local', 'ssh:remote'],
+      collapsedGroups: new Set(['host:local'])
+    }
+    const { store, getVisibleWorktreeIds, setVisibleWorktreeIds } = await loadFreshOrderState()
+    setVisibleState(store, [], {
+      ...hostOverrides,
+      worktreesByRepo: { [repo.id]: [], [remoteRepo.id]: [remote] }
+    })
+    setVisibleWorktreeIds([remote.id])
+
+    setVisibleState(store, [], {
+      ...hostOverrides,
+      worktreesByRepo: { [repo.id]: [local], [remoteRepo.id]: [remote] }
+    })
+
+    expect(getVisibleWorktreeIds()).toEqual([remote.id])
+
+    setVisibleState(store, [local], {
+      ...hostOverrides,
+      repos: [repo]
+    })
+
+    expect(getVisibleWorktreeIds()).toEqual([local.id])
+  })
+
+  it('reconsiders catalog worktrees hidden when the sidebar published', async () => {
+    const remote = { ...makeWorktree('remote', 1, 0), repoId: remoteRepo.id }
+    const local = makeWorktree('local', 2, 0)
+    const { store, getVisibleWorktreeIds, setVisibleWorktreeIds } = await loadFreshOrderState()
+    setVisibleState(store, [], {
+      repos: [repo, remoteRepo],
+      worktreesByRepo: { [repo.id]: [local], [remoteRepo.id]: [remote] },
+      visibleWorkspaceHostIds: ['local', 'ssh:remote'],
+      collapsedGroups: new Set(['host:local'])
+    })
+    setVisibleWorktreeIds([remote.id])
+
+    setVisibleState(store, [local], {
+      repos: [repo],
+      visibleWorkspaceHostIds: ['local', 'ssh:remote'],
+      collapsedGroups: new Set(['host:local'])
+    })
+
+    expect(getVisibleWorktreeIds()).toEqual([local.id])
+  })
+
+  it('counts pending creation rows when applying collapsed host sections', async () => {
+    const local = makeWorktree('local', 1, 0)
+    const pending = makePendingCreation('pending-remote', remoteRepo.id)
+    const overrides: Partial<AppState> = {
+      repos: [repo, remoteRepo],
+      visibleWorkspaceHostIds: ['local', 'ssh:remote'],
+      collapsedGroups: new Set(['host:local']),
+      pendingWorktreeCreations: { [pending.creationId]: pending }
+    }
+    const { store, getVisibleWorktreeIds, setVisibleWorktreeIds } = await loadFreshOrderState()
+    setVisibleState(store, [], overrides)
+    setVisibleWorktreeIds([])
+
+    setVisibleState(store, [local], overrides)
+
+    expect(getVisibleWorktreeIds()).toEqual([])
+  })
+
+  it('adds only an eligible filtered agent target and expands its group', async () => {
+    const first = makeWorktree('first', 1, 0)
+    const { store, getVisibleWorktreeIds, setVisibleWorktreeIds } = await loadFreshOrderState()
+    setVisibleState(store, [first], {
+      filterRepoIds: ['another-repo'],
+      groupBy: 'none',
+      collapsedGroups: new Set(['all'])
+    })
+    setVisibleWorktreeIds([])
+
+    setVisibleState(store, [first], {
+      filterRepoIds: ['another-repo'],
+      groupBy: 'none',
+      collapsedGroups: new Set(['all']),
+      ...makeEligibleAgentState(first.id)
+    })
+
+    expect(getVisibleWorktreeIds()).toEqual([first.id])
+
+    setVisibleState(store, [first], {
+      filterRepoIds: ['another-repo'],
+      groupBy: 'none',
+      collapsedGroups: new Set(['all']),
+      agentSendPopoverTargetMode: makeAgentSendMode(first.id)
+    })
+
+    expect(getVisibleWorktreeIds()).toEqual([])
+  })
+
+  it('keeps the shortcut slot of an archived but still-rendered agent target', async () => {
+    const first = makeWorktree('first', 1, 0)
+    const second = makeWorktree('second', 2, 0)
+    const { store, getVisibleWorktreeIds, setVisibleWorktreeIds } = await loadFreshOrderState()
+    setVisibleState(store, [first, second])
+    setVisibleWorktreeIds([first.id, second.id])
+
+    const archivedSecond = { ...second, isArchived: true }
+    setVisibleState(store, [first, archivedSecond], makeEligibleAgentState(second.id))
+
+    expect(getVisibleWorktreeIds()).toEqual([first.id, second.id])
+
+    setVisibleState(store, [first, archivedSecond])
+
+    expect(getVisibleWorktreeIds()).toEqual([first.id])
+  })
+
+  it('keeps the rendered order while live smart-sort state changes', async () => {
+    const first = makeWorktree('first', 2, 0)
+    const second = makeWorktree('second', 1, 100)
+    const secondTab: TerminalTab = {
+      id: 'second-tab',
+      ptyId: 'second-pty',
+      worktreeId: second.id,
+      title: 'Terminal',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: 0
+    }
+    const { store, getVisibleWorktreeIds, setVisibleWorktreeIds } = await loadFreshOrderState()
+    setVisibleState(store, [first, second], {
+      sortBy: 'smart',
+      tabsByWorktree: { [first.id]: [], [second.id]: [secondTab] },
+      ptyIdsByTabId: { [secondTab.id]: [secondTab.ptyId!] }
+    })
+
+    setVisibleWorktreeIds([first.id, second.id])
+
+    expect(getVisibleWorktreeIds()).toEqual([first.id, second.id])
+  })
+
+  it('removes cached survivors hidden by a filter while the sidebar is closed', async () => {
+    const active = makeWorktree('active', 1, 0)
+    const sleeping = makeWorktree('sleeping', 2, 0)
+    const last = makeWorktree('last', 3, 0)
+    const activeTab: TerminalTab = {
+      id: 'active-tab',
+      ptyId: 'active-pty',
+      worktreeId: active.id,
+      title: 'Terminal',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: 0
+    }
+    const activityState: Partial<AppState> = {
+      tabsByWorktree: {
+        [active.id]: [activeTab],
+        [sleeping.id]: [],
+        [last.id]: [{ ...activeTab, id: 'last-tab', ptyId: 'last-pty', worktreeId: last.id }]
+      },
+      ptyIdsByTabId: { [activeTab.id]: [activeTab.ptyId!], 'last-tab': ['last-pty'] }
+    }
+    const { store, getVisibleWorktreeIds, setVisibleWorktreeIds } = await loadFreshOrderState()
+    setVisibleState(store, [active, sleeping, last], activityState)
+    setVisibleWorktreeIds([active.id, sleeping.id, last.id])
+
+    setVisibleState(store, [active, sleeping, last], {
+      ...activityState,
+      showSleepingWorkspaces: false
+    })
+
+    expect(getVisibleWorktreeIds()).toEqual([active.id, last.id])
+
+    setVisibleState(store, [active, sleeping, last], activityState)
+
+    expect(getVisibleWorktreeIds()).toEqual([active.id, sleeping.id, last.id])
+  })
+
+  it('uses live sorting before the sidebar publishes an order', async () => {
+    const first = makeWorktree('first', 2, 0)
+    const second = makeWorktree('second', 1, 100)
+    const secondTab: TerminalTab = {
+      id: 'second-tab',
+      ptyId: 'second-pty',
+      worktreeId: second.id,
+      title: 'Terminal',
+      customTitle: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: 0
+    }
+    const { store, getVisibleWorktreeIds } = await loadFreshOrderState()
+    setVisibleState(store, [first, second], {
+      sortBy: 'smart',
+      tabsByWorktree: { [first.id]: [], [second.id]: [secondTab] },
+      ptyIdsByTabId: { [secondTab.id]: [secondTab.ptyId!] }
+    })
+
+    expect(getVisibleWorktreeIds()).toEqual([second.id, first.id])
+  })
+})

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -2,6 +2,7 @@ import type { Worktree, Repo, TerminalTab, WorktreeLineage } from '../../../../s
 import { buildWorktreeComparator, sortWorktreesSmart } from './smart-sort'
 import { getWorktreeIdsWithLiveAgent, isInactiveWorkspace } from '@/lib/worktree-activity-state'
 import { useAppStore } from '@/store'
+import type { AppState } from '@/store/types'
 import { getAllWorktreesFromState, getRepoMapFromState } from '@/store/selectors'
 import { DEFAULT_SHOW_SLEEPING_WORKSPACES } from '../../../../shared/constants'
 import {
@@ -11,6 +12,8 @@ import {
   type ExecutionHostId,
   type ExecutionHostScope
 } from '../../../../shared/execution-host'
+import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
+import { getRenderedWorkspaceShortcutIds } from './rendered-workspace-shortcut-order'
 
 /**
  * Whether a worktree represents the repo's default-branch row that the
@@ -246,60 +249,51 @@ function addVisibleLineageAncestors(
  * position. By caching the IDs that WorktreeList actually rendered, the
  * shortcut numbering always matches the sidebar card order.
  */
-let _cachedVisibleIds: string[] = []
+let _cachedOrderIds: string[] | null = null
+let _cachedCatalogIds: Set<string> | null = null
+let _visibleIdsPublisherCount = 0
+
+function getWorkspaceCatalogIds(state: AppState): string[] {
+  const ids = getAllWorktreesFromState(state)
+    .filter((worktree) => !worktree.isArchived)
+    .map((worktree) => worktree.id)
+  for (const folderWorkspace of state.folderWorkspaces ?? []) {
+    if (!folderWorkspace.isArchived) {
+      ids.push(folderWorkspaceKey(folderWorkspace.id))
+    }
+  }
+  return ids
+}
 
 /**
  * Called by WorktreeList after computing visible worktrees so the Cmd+1–9
  * handler can read the exact same ordering the user sees on screen.
  */
 export function setVisibleWorktreeIds(ids: string[]): void {
-  _cachedVisibleIds = ids
+  _cachedOrderIds = [...ids]
+  const catalogIds = new Set(getWorkspaceCatalogIds(useAppStore.getState()))
+  // Hidden catalog rows remain pending so host/group changes can make them
+  // eligible after the sidebar unmounts.
+  _cachedCatalogIds = new Set(ids.filter((id) => catalogIds.has(id)))
 }
 
-/**
- * Compute the visible worktree IDs on-demand from the current Zustand store
- * state. Called by the App-level Cmd+1–9 handler (not a React hook — reads
- * store snapshot at call time).
- *
- * If WorktreeList has rendered at least once, returns the cached IDs so the
- * shortcut numbering matches the sidebar. Falls back to a live recomputation
- * only before WorktreeList's first render (e.g. app startup).
- */
-export function getVisibleWorktreeIds(): string[] {
-  // Prefer the cached IDs that mirror the rendered sidebar order.
-  if (_cachedVisibleIds.length > 0) {
-    return _cachedVisibleIds
+export function registerVisibleWorktreeIdsPublisher(): () => void {
+  _visibleIdsPublisherCount += 1
+  let registered = true
+  return () => {
+    if (!registered) {
+      return
+    }
+    registered = false
+    _visibleIdsPublisherCount -= 1
   }
+}
 
-  // Fallback: live recomputation for the window before WorktreeList renders.
-  const state = useAppStore.getState()
-  const allWorktrees = getAllWorktreesFromState(state).filter((w) => !w.isArchived)
-
-  // Hoist repoMap so it's built once and reused across all branches below.
-  const repoMap = getRepoMapFromState(state)
-
-  let sortedIds: string[]
-
-  if (state.sortBy === 'smart') {
-    sortedIds = sortWorktreesSmart(
-      allWorktrees,
-      state.tabsByWorktree,
-      repoMap,
-      state.agentStatusByPaneKey,
-      state.runtimePaneTitlesByTabId,
-      state.ptyIdsByTabId,
-      state.migrationUnsupportedByPtyId,
-      state.terminalLayoutsByTabId
-    ).map((w) => w.id)
-  } else {
-    // Why empty map: non-smart branches don't read attentionByWorktree, but
-    // the param is required to keep smart-mode callers honest at the type level.
-    const sorted = [...allWorktrees].sort(
-      buildWorktreeComparator(state.sortBy, repoMap, Date.now(), new Map())
-    )
-    sortedIds = sorted.map((w) => w.id)
-  }
-
+function computeStoreVisibleWorktreeIds(
+  state: AppState,
+  sortedIds: string[],
+  repoMap: Map<string, Repo>
+): string[] {
   return computeVisibleWorktreeIds(state.worktreesByRepo, sortedIds, {
     filterRepoIds: state.filterRepoIds,
     showSleepingWorkspaces: state.showSleepingWorkspaces,
@@ -319,4 +313,83 @@ export function getVisibleWorktreeIds(): string[] {
     defaultHostId: getSettingsFocusedExecutionHostId(state.settings),
     worktreeLineageById: state.worktreeLineageById
   })
+}
+
+function getLiveSortedWorktreeIds(
+  state: AppState,
+  allWorktrees: Worktree[],
+  repoMap: Map<string, Repo>
+): string[] {
+  if (state.sortBy === 'smart') {
+    return sortWorktreesSmart(
+      allWorktrees,
+      state.tabsByWorktree,
+      repoMap,
+      state.agentStatusByPaneKey,
+      state.runtimePaneTitlesByTabId,
+      state.ptyIdsByTabId,
+      state.migrationUnsupportedByPtyId,
+      state.terminalLayoutsByTabId
+    ).map((worktree) => worktree.id)
+  }
+
+  return [...allWorktrees]
+    .sort(buildWorktreeComparator(state.sortBy, repoMap, Date.now(), new Map()))
+    .map((worktree) => worktree.id)
+}
+
+/**
+ * Compute the visible worktree IDs on-demand from the current Zustand store
+ * state. Called by the App-level Cmd+1–9 handler (not a React hook — reads
+ * store snapshot at call time).
+ *
+ * If WorktreeList has rendered at least once, returns the cached IDs so the
+ * shortcut numbering matches the sidebar. Falls back to a live recomputation
+ * only before WorktreeList's first render (e.g. app startup).
+ */
+export function getVisibleWorktreeIds(): string[] {
+  // Why: only the mounted renderer knows transient row state such as host drag collapse.
+  if (_visibleIdsPublisherCount > 0 && _cachedOrderIds !== null) {
+    return _cachedOrderIds
+  }
+
+  const state = useAppStore.getState()
+  const allWorktrees = getAllWorktreesFromState(state).filter((w) => !w.isArchived)
+  const repoMap = getRepoMapFromState(state)
+  const currentCatalogIds = getWorkspaceCatalogIds(state)
+
+  if (_cachedOrderIds !== null) {
+    const currentCatalogIdSet = new Set(currentCatalogIds)
+    const liveSortedIds = getLiveSortedWorktreeIds(state, allWorktrees, repoMap)
+    const liveVisibleWorktreeIds = computeStoreVisibleWorktreeIds(state, liveSortedIds, repoMap)
+    const renderedIds = getRenderedWorkspaceShortcutIds(state, liveVisibleWorktreeIds)
+    const renderedIdSet = new Set(renderedIds)
+    // Agent-send can intentionally render an otherwise ineligible target.
+    // Keep that temporary row addressable until the shared renderer drops it.
+    for (const id of renderedIds) {
+      currentCatalogIdSet.add(id)
+    }
+    const knownCatalogIds = _cachedCatalogIds ?? new Set<string>()
+    _cachedOrderIds = _cachedOrderIds.filter((id) => currentCatalogIdSet.has(id))
+    _cachedCatalogIds = new Set([...knownCatalogIds].filter((id) => currentCatalogIdSet.has(id)))
+    for (const id of renderedIds) {
+      if (!currentCatalogIdSet.has(id) || _cachedCatalogIds.has(id)) {
+        continue
+      }
+      _cachedOrderIds.push(id)
+      _cachedCatalogIds.add(id)
+    }
+
+    // Why: the sidebar is unmounted while closed. Reconcile catalog changes
+    // without discarding the slots of rows hidden by temporary filters.
+    _cachedOrderIds = [...new Set(_cachedOrderIds)]
+    return _cachedOrderIds.filter((id) => renderedIdSet.has(id))
+  }
+
+  // Fallback: live recomputation only before WorktreeList's first render.
+  const sortedIds = getLiveSortedWorktreeIds(state, allWorktrees, repoMap)
+  return getRenderedWorkspaceShortcutIds(
+    state,
+    computeStoreVisibleWorktreeIds(state, sortedIds, repoMap)
+  )
 }

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -19,6 +19,7 @@ import { hasRegisteredRuntimeTerminalTab } from '@/runtime/sync-runtime-graph'
 import type { SplitTerminalPaneDetail, CloseTerminalPaneDetail } from '@/constants/terminal'
 import { getVisibleWorktreeIds } from '@/components/sidebar/visible-worktrees'
 import { activateTabNumberShortcut } from '@/lib/tab-number-shortcuts'
+import { activateWorkspaceNumberShortcut } from '@/lib/workspace-number-shortcut-activation'
 import { nextEditorFontZoomLevel, computeEditorFontSize } from '@/lib/editor-font-zoom'
 import type {
   TerminalLayoutSnapshot,
@@ -1327,7 +1328,7 @@ export function useIpcEvents(): void {
         }
         const visibleIds = getVisibleWorktreeIds()
         if (index < visibleIds.length) {
-          activateAndRevealWorktree(visibleIds[index])
+          activateWorkspaceNumberShortcut(visibleIds[index])
         }
       })
     )

--- a/src/renderer/src/lib/workspace-number-shortcut-activation.test.ts
+++ b/src/renderer/src/lib/workspace-number-shortcut-activation.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  activateAndRevealFolderWorkspace: vi.fn(),
+  activateAndRevealWorktree: vi.fn()
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealFolderWorkspace: mocks.activateAndRevealFolderWorkspace,
+  activateAndRevealWorktree: mocks.activateAndRevealWorktree
+}))
+
+import { activateWorkspaceNumberShortcut } from './workspace-number-shortcut-activation'
+
+describe('workspace number shortcut activation', () => {
+  beforeEach(() => {
+    mocks.activateAndRevealFolderWorkspace.mockClear()
+    mocks.activateAndRevealWorktree.mockClear()
+  })
+
+  it('routes folder workspace keys through folder activation', () => {
+    activateWorkspaceNumberShortcut('folder:folder-1')
+
+    expect(mocks.activateAndRevealFolderWorkspace).toHaveBeenCalledWith('folder-1')
+    expect(mocks.activateAndRevealWorktree).not.toHaveBeenCalled()
+  })
+
+  it('keeps bare worktree ids on the existing activation path', () => {
+    activateWorkspaceNumberShortcut('worktree-1')
+
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('worktree-1')
+    expect(mocks.activateAndRevealFolderWorkspace).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/workspace-number-shortcut-activation.ts
+++ b/src/renderer/src/lib/workspace-number-shortcut-activation.ts
@@ -1,0 +1,16 @@
+import {
+  activateAndRevealFolderWorkspace,
+  activateAndRevealWorktree
+} from '@/lib/worktree-activation'
+import { parseWorkspaceKey } from '../../../shared/workspace-scope'
+
+export function activateWorkspaceNumberShortcut(workspaceId: string): void {
+  const scope = parseWorkspaceKey(workspaceId)
+  if (scope?.type === 'folder') {
+    // Folder activation performs path/runtime checks that ordinary worktrees do not need.
+    activateAndRevealFolderWorkspace(scope.folderWorkspaceId)
+    return
+  }
+
+  activateAndRevealWorktree(scope?.type === 'worktree' ? scope.worktreeId : workspaceId)
+}


### PR DESCRIPTION
## What

Fixes #9497.

Cmd/Ctrl+1..9 workspace shortcuts now activate the Nth row exactly as rendered in the sidebar, and folder workspaces activate through the dedicated folder path instead of the plain worktree path.

## Why

The shortcut handler previously recomputed workspace order from the Zustand store (sorting/grouping/filtering). That order could disagree with the rows actually on screen — component-local state such as host drag collapse, collapsed groups, and import cards is invisible to the store — so pressing a number could jump to the wrong workspace. Folder workspaces were also mis-activated as regular worktrees.

## How

- `WorktreeList` publishes its rendered row order from a layout effect (`setVisibleWorktreeIds`), and registers itself as the order publisher while mounted (`registerVisibleWorktreeIdsPublisher`).
- While the sidebar is mounted, the shortcut path trusts the published order directly (O(1) lookup). Only after unmount does it fall back to reconciling against the store, so shortcuts still work with the sidebar closed while dropping rows that no longer exist.
- `workspace-number-shortcut-activation.ts` routes folder workspaces through `activateAndRevealFolderWorkspace`.

No visual change.

## Tests

- New regression tests: `visible-worktree-shortcut-order.test.ts` (published-order trust while mounted, reconciliation after unmount, empty-order handling) and `workspace-number-shortcut-activation.test.ts` (folder vs worktree activation routing). All were written red-first.
- Focused suites: 133/133 passed. Full `pnpm typecheck` passed. `pnpm build` passed. Full `pnpm test`: identical pass/fail set to `main` on the same machine (remaining failures are pre-existing local-environment issues on `main`, e.g. missing optional `windows-native-registry`).

## AI code review summary

Reviewed by a Codex reviewer agent over the full diff; final verdict: no actionable findings.

- Cross-platform: shortcut handling keeps the existing metaKey/ctrlKey runtime platform check; no hardcoded modifiers or paths.
- SSH/remote/local: activation goes through the existing `worktree-activation` paths, which are host-agnostic; no assumptions of local-only execution.
- Agents/integrations & git providers: no provider-specific logic touched; ordering is purely renderer-side.
- Performance: mounted path is O(1) per keypress; full reconstruction only runs when the sidebar is unmounted.
- UI: no visual change; behavior verified via unit/integration tests.
- Security: no new inputs, IPC surfaces, or shell/git command construction.

## Platform / remote notes

Verified on macOS. The change is renderer-only ordering logic behind the existing platform-checked shortcut handler, so no platform- or SSH-specific behavior differences are expected.

X handle: (contributor: add your handle here)

