### PR TITLE
fix(speech): avoid system tar for Windows model extraction

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -173,7 +173,9 @@ export default defineConfig({
       // directory cannot reach into app.asar, so pure-JS dependencies used
       // by the daemon must be bundled rather than externalized.
       externalizeDeps: {
-        exclude: ['@xterm/headless', '@xterm/addon-serialize']
+        // Why: the extraction worker runs from app.asar and cannot resolve
+        // dependencies copied beside the archive. Bundle its pure-JS pipeline.
+        exclude: ['@xterm/headless', '@xterm/addon-serialize', 'tar', 'unbzip2-stream']
       },
       rollupOptions: {
         input: {
@@ -181,6 +183,7 @@ export default defineConfig({
           'daemon-entry': resolve('src/main/daemon/daemon-entry.ts'),
           'computer-sidecar': resolve('src/main/computer/sidecar-entry.ts'),
           'stt-worker': resolve('src/main/speech/stt-worker.ts'),
+          'speech-model-archive-worker': resolve('src/main/speech/speech-model-archive-worker.ts'),
           'warp-theme-parser-worker': resolve('src/main/warp-themes/warp-theme-parser-worker.ts'),
           'session-scanner-opencode-sqlite-worker-entry': resolve(
             'src/main/ai-vault/session-scanner-opencode-sqlite-worker-entry.ts'

--- a/package.json
+++ b/package.json
@@ -125,7 +125,9 @@
     "serve-sim": "^0.1.40",
     "sherpa-onnx": "1.12.37",
     "ssh2": "^1.17.0",
+    "tar": "7.5.20",
     "tweetnacl": "^1.0.3",
+    "unbzip2-stream": "1.4.3",
     "ws": "^8.21.0",
     "yaml": "^2.8.4",
     "zod": "~4.4.3"
@@ -165,6 +167,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@types/ssh2": "^1.15.5",
+    "@types/unbzip2-stream": "1.4.3",
     "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^5.2.0",
     "@xterm/addon-fit": "0.12.0-beta.287",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,15 @@ importers:
       ssh2:
         specifier: ^1.17.0
         version: 1.17.0
+      tar:
+        specifier: 7.5.20
+        version: 7.5.20
       tweetnacl:
         specifier: ^1.0.3
         version: 1.0.3
+      unbzip2-stream:
+        specifier: 1.4.3
+        version: 1.4.3
       ws:
         specifier: ^8.21.0
         version: 8.21.0
@@ -198,6 +204,9 @@ importers:
       '@types/ssh2':
         specifier: ^1.15.5
         version: 1.15.5
+      '@types/unbzip2-stream':
+        specifier: 1.4.3
+        version: 1.4.3
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -3031,8 +3040,14 @@ packages:
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
+  '@types/through@0.0.33':
+    resolution: {integrity: sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unbzip2-stream@1.4.3':
+    resolution: {integrity: sha512-D8X5uuJRISqc8YtwL8jNW2FpPdUOCYXbfD6zNROCTbVXK9nawucxh10tVXE3MPjnHdRA1LvB0zDxVya/lBsnYw==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -3426,6 +3441,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   buildcheck@0.0.7:
     resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
@@ -4532,6 +4550,9 @@ packages:
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -6157,6 +6178,9 @@ packages:
     resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
     engines: {node: '>=6.0.0'}
 
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
 
@@ -6267,6 +6291,9 @@ packages:
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  unbzip2-stream@1.4.3:
+    resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
@@ -9082,8 +9109,16 @@ snapshots:
   '@types/statuses@2.0.6':
     optional: true
 
+  '@types/through@0.0.33':
+    dependencies:
+      '@types/node': 25.9.5
+
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/unbzip2-stream@1.4.3':
+    dependencies:
+      '@types/through': 0.0.33
 
   '@types/unist@2.0.11': {}
 
@@ -9445,6 +9480,11 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   buildcheck@0.0.7:
     optional: true
@@ -10751,6 +10791,8 @@ snapshots:
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -12759,6 +12801,8 @@ snapshots:
       mkdirp: 0.5.6
       rimraf: 2.6.3
 
+  through@2.3.8: {}
+
   tiny-async-pool@1.3.0:
     dependencies:
       semver: 5.7.2
@@ -12874,6 +12918,11 @@ snapshots:
       '@typescript/typescript-win32-x64': 7.0.2
 
   ufo@1.6.4: {}
+
+  unbzip2-stream@1.4.3:
+    dependencies:
+      buffer: 5.7.1
+      through: 2.3.8
 
   undici-types@5.26.5: {}
 

--- a/src/main/speech/model-manager.test.ts
+++ b/src/main/speech/model-manager.test.ts
@@ -44,7 +44,8 @@ type ModelManagerInternals = {
     archivePath: string,
     destDir: string,
     modelId: string,
-    isAborted: () => boolean
+    isAborted: () => boolean,
+    signal: AbortSignal
   ) => Promise<void>
 }
 
@@ -399,6 +400,7 @@ describe('ModelManager', () => {
   })
 
   it('clears extraction abort polling when the child does not close', async () => {
+    const platformMock = vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
     vi.useFakeTimers()
     const dir = mkdtempSync(join(tmpdir(), 'orca-model-manager-'))
     try {
@@ -434,7 +436,13 @@ describe('ModelManager', () => {
       spawnMock.mockReturnValue(child)
       const manager = new ModelManager(dir) as unknown as ModelManagerInternals
 
-      const extraction = manager.extractArchive(join(dir, 'model.tar.bz2'), dir, 'm', () => true)
+      const extraction = manager.extractArchive(
+        join(dir, 'model.tar.bz2'),
+        dir,
+        'm',
+        () => true,
+        new AbortController().signal
+      )
       const rejection = expect(extraction).rejects.toThrow('Aborted')
       await vi.advanceTimersByTimeAsync(250)
       await rejection
@@ -448,6 +456,7 @@ describe('ModelManager', () => {
       vi.advanceTimersByTime(1000)
       expect(child.kill).toHaveBeenCalledTimes(1)
     } finally {
+      platformMock.mockRestore()
       vi.useRealTimers()
       rmSync(dir, { recursive: true, force: true })
     }

--- a/src/main/speech/model-manager.ts
+++ b/src/main/speech/model-manager.ts
@@ -13,6 +13,7 @@ import { readdir, rm } from 'node:fs/promises'
 import { createHash } from 'node:crypto'
 import { pipeline } from 'node:stream/promises'
 import { spawn } from 'node:child_process'
+import { Worker } from 'node:worker_threads'
 import type {
   SpeechModelManifest,
   SpeechModelState,
@@ -57,6 +58,54 @@ const MAX_RETRY_AFTER_MS = 120_000
 const RETRYABLE_NET_ERROR =
   /net::ERR_(CONTENT_LENGTH_MISMATCH|INCOMPLETE_CHUNKED_ENCODING|CONNECTION_(RESET|CLOSED|ABORTED|REFUSED|TIMED_OUT)|EMPTY_RESPONSE|NETWORK_CHANGED|TIMED_OUT|INTERNET_DISCONNECTED|ADDRESS_UNREACHABLE|NAME_NOT_RESOLVED|SOCKET_NOT_CONNECTED|HTTP2_PROTOCOL_ERROR|QUIC_PROTOCOL_ERROR)\b/
 const RETRYABLE_HTTP_STATUSES = new Set([408, 416, 425, 429, 500, 502, 503, 504])
+
+function extractWindowsArchive(
+  archivePath: string,
+  destinationDir: string,
+  signal: AbortSignal
+): Promise<void> {
+  if (signal.aborted) {
+    return Promise.reject(new Error('Aborted'))
+  }
+  return new Promise((resolve, reject) => {
+    const workerPath = app.isPackaged
+      ? join(process.resourcesPath, 'app.asar', 'out', 'main', 'speech-model-archive-worker.js')
+      : join(__dirname, 'speech-model-archive-worker.js')
+    const worker = new Worker(workerPath, { workerData: { archivePath, destinationDir } })
+    let settled = false
+
+    const finish = (error?: Error): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      signal.removeEventListener('abort', onAbort)
+      worker.removeAllListeners()
+      void worker.terminate().then(
+        () => (error ? reject(error) : resolve()),
+        (cause: unknown) => reject(error ?? new Error(String(cause)))
+      )
+    }
+    const onAbort = (): void => finish(new Error('Aborted'))
+    signal.addEventListener('abort', onAbort, { once: true })
+    worker.once('message', (message: unknown) => {
+      const result = message as { ok?: unknown; error?: unknown }
+      if (result.ok === true) {
+        finish()
+      } else {
+        finish(new Error(typeof result.error === 'string' ? result.error : 'Extraction failed'))
+      }
+    })
+    worker.once('error', (error) =>
+      finish(error instanceof Error ? error : new Error(String(error)))
+    )
+    worker.once('exit', (code) => {
+      if (!settled) {
+        finish(new Error(`Extraction worker exited before completion: ${code}`))
+      }
+    })
+  })
+}
 
 function isRetryableDownloadError(error: unknown): boolean {
   if (!(error instanceof Error)) {
@@ -329,7 +378,13 @@ export class ModelManager {
       }
 
       this.updateState(modelId, 'extracting')
-      await this.extractArchive(archivePath, this.modelsDir, modelId, () => aborted)
+      await this.extractArchive(
+        archivePath,
+        this.modelsDir,
+        modelId,
+        () => aborted,
+        abortController.signal
+      )
 
       if (aborted) {
         this.cleanup(modelId, archivePath)
@@ -818,10 +873,15 @@ export class ModelManager {
     archivePath: string,
     destDir: string,
     modelId: string,
-    isAborted: () => boolean
+    isAborted: () => boolean,
+    signal: AbortSignal
   ): Promise<void> {
     const modelDir = join(destDir, modelId)
     mkdirSync(modelDir, { recursive: true })
+
+    if (process.platform === 'win32') {
+      return extractWindowsArchive(archivePath, modelDir, signal)
+    }
 
     return new Promise((resolve, reject) => {
       // Why: spawn (not exec) so slow bzip2 stderr can't overflow exec's 1MB maxBuffer and silently kill the process.

--- a/src/main/speech/speech-model-archive-worker.test.ts
+++ b/src/main/speech/speech-model-archive-worker.test.ts
@@ -1,0 +1,64 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { extractSpeechModelArchive } from './speech-model-archive-worker'
+
+const HAPPY_ARCHIVE =
+  'QlpoOTFBWSZTWd2zR1sAALH/gMmAAIBAAfeAAIBAEG5PnkAISCAAkgypkm/USaDRmpiNPU9PSgikofqmTQ00BtQDQfvmWq4vh0HqBXxYgphJ7aFLh2UIbWVEgGAnKzvBgSISwK441zq86zQgiLyrS3MdpBQGqcTI0++iH+AJ6/nplAiT96utjc5JgG6UYpVLmmBgqlRyIIH8XckU4UJDds0dbA=='
+const TRAVERSAL_ARCHIVE =
+  'QlpoOTFBWSZTWbpIYDYAAHV9gMmAAAJAAe+AACBmJ57ACAggAHQaJGQNAPKNGjT1BJRDQGnqAAA+6qHoQZSoQiPLUF1dM6BDgcMMabPL4CgYIK4gtSHiqQeYSMprM/H9U9VqR+a90mzENSIgPxdyRThQkLpIYDY='
+const SYMLINK_ARCHIVE =
+  'QlpoOTFBWSZTWSYy/ysAAHV/gMiAABBAAfcAAACBACYvnkAACCAAVDKnqAPU002oMj1NBJKD1AYgaAH3k6BIL6kIRLuVpcO6BDAxKMSbcM4nYI5QhJNrsvAxLT9oHi8mpk9rr9VUnWOG5JA/F3JFOFCQJjL/Kw=='
+
+function writeArchive(dir: string, base64: string): string {
+  const archivePath = join(dir, 'model.tar.bz2')
+  writeFileSync(archivePath, Buffer.from(base64, 'base64'))
+  return archivePath
+}
+
+describe('extractSpeechModelArchive', () => {
+  it('extracts regular files after stripping the archive wrapper directory', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-speech-extractor-'))
+    try {
+      const destination = join(dir, 'model')
+      const archivePath = writeArchive(dir, HAPPY_ARCHIVE)
+
+      await extractSpeechModelArchive(archivePath, destination)
+
+      expect(readFileSync(join(destination, 'tokens.txt'), 'utf8')).toBe('hello')
+      expect(readFileSync(join(destination, 'nested', 'encoder.onnx'), 'utf8')).toBe('model')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects traversal paths before they can escape the destination', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-speech-extractor-'))
+    try {
+      const destination = join(dir, 'model')
+      const archivePath = writeArchive(dir, TRAVERSAL_ARCHIVE)
+
+      await expect(extractSpeechModelArchive(archivePath, destination)).rejects.toThrow(
+        'Unsafe speech model archive path'
+      )
+      expect(existsSync(join(dir, 'outside.txt'))).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects links from model archives', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-speech-extractor-'))
+    try {
+      const destination = join(dir, 'model')
+      const archivePath = writeArchive(dir, SYMLINK_ARCHIVE)
+
+      await expect(extractSpeechModelArchive(archivePath, destination)).rejects.toThrow(
+        'Unsupported speech model archive entry type'
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/speech/speech-model-archive-worker.ts
+++ b/src/main/speech/speech-model-archive-worker.ts
@@ -5,10 +5,12 @@ import { isMainThread, parentPort, workerData } from 'node:worker_threads'
 import { x as extractTar } from 'tar'
 import unbzip2Stream from 'unbzip2-stream'
 
+// Why: reject links that could redirect extraction outside the model directory.
 const ALLOWED_ENTRY_TYPES = new Set(['File', 'OldFile', 'Directory'])
 
 function assertSafeEntry(path: string, type: string): void {
   const normalized = path.replaceAll('\\', '/')
+  // Why: validate the path tar writes after strip removes the archive wrapper directory.
   const stripped = normalized.split('/').slice(1).join('/')
   if (
     normalized.includes('\0') ||

--- a/src/main/speech/speech-model-archive-worker.ts
+++ b/src/main/speech/speech-model-archive-worker.ts
@@ -1,0 +1,63 @@
+import { createReadStream, mkdirSync } from 'node:fs'
+import { posix, win32 } from 'node:path'
+import { pipeline } from 'node:stream/promises'
+import { isMainThread, parentPort, workerData } from 'node:worker_threads'
+import { x as extractTar } from 'tar'
+import unbzip2Stream from 'unbzip2-stream'
+
+const ALLOWED_ENTRY_TYPES = new Set(['File', 'OldFile', 'Directory'])
+
+function assertSafeEntry(path: string, type: string): void {
+  const normalized = path.replaceAll('\\', '/')
+  const stripped = normalized.split('/').slice(1).join('/')
+  if (
+    normalized.includes('\0') ||
+    posix.isAbsolute(normalized) ||
+    win32.isAbsolute(normalized) ||
+    posix.isAbsolute(stripped) ||
+    win32.isAbsolute(stripped) ||
+    stripped.split('/').includes('..')
+  ) {
+    throw new Error(`Unsafe speech model archive path: ${path}`)
+  }
+  if (!ALLOWED_ENTRY_TYPES.has(type)) {
+    throw new Error(`Unsupported speech model archive entry type: ${type}`)
+  }
+}
+
+export async function extractSpeechModelArchive(
+  archivePath: string,
+  destinationDir: string
+): Promise<void> {
+  mkdirSync(destinationDir, { recursive: true })
+  await pipeline(
+    createReadStream(archivePath),
+    unbzip2Stream(),
+    extractTar({
+      cwd: destinationDir,
+      strip: 1,
+      strict: true,
+      preservePaths: false,
+      filter: (path, entry) => {
+        assertSafeEntry(path, (entry as { type?: string }).type ?? 'Unsupported')
+        return true
+      }
+    })
+  )
+}
+
+if (!isMainThread) {
+  const port = parentPort
+  const { archivePath, destinationDir } = workerData as Record<string, unknown>
+  if (!port || typeof archivePath !== 'string' || typeof destinationDir !== 'string') {
+    throw new Error('Speech model extraction worker received invalid input.')
+  }
+  void extractSpeechModelArchive(archivePath, destinationDir).then(
+    () => port.postMessage({ ok: true }),
+    (error: unknown) =>
+      port.postMessage({
+        ok: false,
+        error: error instanceof Error ? error.message : String(error)
+      })
+  )
+}


### PR DESCRIPTION
## Summary

On Windows, extract `.tar.bz2` speech models in a worker thread instead of calling `C:\Windows\System32\tar.exe`.

The Windows bsdtar on the affected system did not finish extracting the Parakeet archive before Orca's 10-minute timeout. The streaming JavaScript extractor completed the same archive in about 113 seconds without blocking Electron's main thread.

macOS and Linux continue to use the existing system `tar` path.

Related issue: https://github.com/stablyai/orca/issues/9231

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
  - The changed files pass `oxlint`.
  - The repository-wide command stops on existing switch-exhaustiveness errors in `src/main/daemon/daemon-server.ts` and `src/renderer/src/components/skills/skill-freshness-group.tsx`.
- [x] `pnpm typecheck`
- [ ] `pnpm test`
  - The focused speech-model suite passes: 12 tests.
  - The full Windows suite has unrelated platform and baseline failures.
- [x] `pnpm build`
- [x] Added tests for successful `.tar.bz2` extraction, path traversal rejection, and link rejection

A built-worker smoke test also extracted a real `.tar.bz2` fixture from `out/main/speech-model-archive-worker.js`.

## AI Review Report

The review checked Windows, macOS, and Linux behavior; Electron worker packaging; local and SSH compatibility; agent and integration compatibility; performance; cancellation cleanup; and archive security.

The implementation changes only the Windows extraction path. macOS and Linux retain their current `tar` command. Speech models live in Orca's local application cache, so remote repositories and SSH worktrees do not use this path. The change does not affect CLI agents, Git providers, integrations, shortcuts, labels, or UI behavior.

The review identified two main risks:

- JavaScript bzip2 decompression could block Electron's main thread. The extractor runs in a worker thread.
- Archive entries could escape the model directory or create links. The extractor rejects absolute paths, `..` traversal, symbolic links, hard links, and unsupported entry types.

Cancellation terminates the worker before `ModelManager` removes partial files.

## Security Audit

Orca verifies the downloaded archive against its catalog SHA-256 before extraction.

The extractor also:

- rejects POSIX and Windows absolute paths
- rejects path traversal after stripping the archive wrapper directory
- rejects symbolic links, hard links, and special entries
- avoids shell command construction on Windows
- accepts archive and destination paths only through internal worker data

`tar` and `unbzip2-stream` are bundled into the worker, so the packaged application does not resolve them from an external runtime directory. This change does not handle credentials, authentication data, secrets, or external IPC.

## Notes

Windows uses the worker-based extractor. macOS and Linux keep the existing system `tar` implementation.

No remote, SSH, agent, integration, Git-provider, or UI behavior changes.

X: No account

