### PR TITLE
fix(terminal): throttle WebGL atlas recovery

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -214,7 +214,6 @@ type MockTransport = {
 
 const scheduleRuntimeGraphSync = vi.fn()
 const shouldSeedCacheTimerOnInitialTitle = vi.fn(() => false)
-const scheduleTerminalWebglAtlasRecovery = vi.fn()
 
 let mockStoreState: StoreState
 let transportFactoryQueue: MockTransport[] = []
@@ -235,10 +234,6 @@ vi.mock('@/store', () => ({
       }
     }
   }
-}))
-
-vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery
 }))
 
 function notifyStoreSubscribers(): void {
@@ -6584,52 +6579,6 @@ describe('connectPanePty', () => {
     }
   })
 
-  it('schedules WebGL atlas recovery after hidden synchronized output parses', async () => {
-    const { connectPanePty } = await import('./pty-connection')
-    const transport = createMockTransport('pty-id')
-    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
-    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
-      capturedDataCallback.current = callbacks.onData ?? null
-      return 'pty-id'
-    })
-    transportFactoryQueue.push(transport)
-
-    const pane = createPane(1)
-    const { writes, parseCallbacks } = captureCallbackTerminalWrites(pane)
-
-    connectPanePty(
-      pane as never,
-      createManager(1) as never,
-      createDeps({
-        isVisibleRef: { current: false }
-      }) as never
-    )
-    await flushAsyncTicks(6)
-
-    vi.useFakeTimers()
-    try {
-      const startChunk = '\x1b[?2026h'
-      const plainRowChunk = '| hidden Claude row |\r\n'
-      const endChunk = '\x1b[?2026l'
-
-      capturedDataCallback.current?.(startChunk)
-      capturedDataCallback.current?.(plainRowChunk)
-      capturedDataCallback.current?.(endChunk)
-
-      expect(writes).toEqual([])
-      vi.advanceTimersByTime(50)
-
-      expect(writes).toEqual([`${startChunk}${plainRowChunk}${endChunk}`])
-      expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
-
-      parseCallbacks[0]?.()
-
-      expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(3)
-    } finally {
-      vi.useRealTimers()
-    }
-  })
-
   it('recognizes hidden synchronized output markers split across PTY chunks', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('pty-id')
@@ -6662,87 +6611,8 @@ describe('connectPanePty', () => {
       vi.advanceTimersByTime(50)
 
       expect(writes.join('')).toBe('\x1b[?2026hbody row\r\ntail\x1b[?2026l')
-      expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
 
       parseCallbacks[0]?.()
-
-      expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(3)
-    } finally {
-      vi.useRealTimers()
-    }
-  })
-
-  it('does not schedule hidden atlas recovery for ordinary rich text or metadata output', async () => {
-    const { connectPanePty } = await import('./pty-connection')
-    const transport = createMockTransport('pty-id')
-    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
-    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
-      capturedDataCallback.current = callbacks.onData ?? null
-      return 'pty-id'
-    })
-    transportFactoryQueue.push(transport)
-
-    const pane = createPane(1)
-    const { parseCallbacks } = captureCallbackTerminalWrites(pane)
-
-    connectPanePty(
-      pane as never,
-      createManager(1) as never,
-      createDeps({
-        isVisibleRef: { current: false }
-      }) as never
-    )
-    await flushAsyncTicks(6)
-
-    vi.useFakeTimers()
-    try {
-      capturedDataCallback.current?.('plain hidden emoji 😀 and CJK 没改什么\r\n')
-      capturedDataCallback.current?.('\x1b[48;2;52;52;52mcolored shell text\x1b[0m\r\n')
-      capturedDataCallback.current?.('\x1b]0;hidden title\x07\x1b]133;A\x07')
-
-      vi.advanceTimersByTime(50)
-      for (const callback of parseCallbacks) {
-        callback()
-      }
-
-      expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
-    } finally {
-      vi.useRealTimers()
-    }
-  })
-
-  it('schedules hidden atlas recovery for high-confidence TUI redraw controls', async () => {
-    const { connectPanePty } = await import('./pty-connection')
-    const transport = createMockTransport('pty-id')
-    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
-    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
-      capturedDataCallback.current = callbacks.onData ?? null
-      return 'pty-id'
-    })
-    transportFactoryQueue.push(transport)
-
-    const pane = createPane(1)
-    const { parseCallbacks } = captureCallbackTerminalWrites(pane)
-
-    connectPanePty(
-      pane as never,
-      createManager(1) as never,
-      createDeps({
-        isVisibleRef: { current: false }
-      }) as never
-    )
-    await flushAsyncTicks(6)
-
-    vi.useFakeTimers()
-    try {
-      capturedDataCallback.current?.('\x1b[2J\x1b[Hredrawn hidden table\x1b[K')
-
-      vi.advanceTimersByTime(50)
-      expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
-
-      parseCallbacks[0]?.()
-
-      expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
     } finally {
       vi.useRealTimers()
     }
@@ -6776,20 +6646,15 @@ describe('connectPanePty', () => {
       vi.advanceTimersByTime(50)
       expect(writes).toEqual(['prompt rewrite\r'])
       parseCallbacks.shift()?.()
-      expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
 
       capturedDataCallback.current?.('\x1b[?2026hredraw frame\x1b[?2026l')
       vi.advanceTimersByTime(50)
       expect(writes).toEqual(['prompt rewrite\r', '\x1b[?2026hredraw frame\x1b[?2026l'])
       parseCallbacks.shift()?.()
-      expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
-      scheduleTerminalWebglAtlasRecovery.mockClear()
 
       capturedDataCallback.current?.('plain after frame')
       vi.advanceTimersByTime(50)
       parseCallbacks.shift()?.()
-
-      expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
     } finally {
       vi.useRealTimers()
     }
@@ -6825,8 +6690,7 @@ describe('connectPanePty', () => {
       capturedDataCallback.current?.('\x1b[?2026h')
       vi.advanceTimersByTime(50)
       parseCallbacks.shift()?.()
-      expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
-      scheduleTerminalWebglAtlasRecovery.mockClear()
+
       writes.length = 0
 
       isVisibleRef.current = true
@@ -6841,7 +6705,6 @@ describe('connectPanePty', () => {
       parseCallbacks.shift()?.()
 
       expect(writes).toEqual(['plain after skipped close\r\n'])
-      expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
     } finally {
       vi.useRealTimers()
     }
@@ -10014,7 +9877,6 @@ describe('connectPanePty', () => {
 
     expect(manager.markPaneHasComplexScriptOutput).not.toHaveBeenCalled()
     expect(refresh).toHaveBeenCalledWith(0, 39, true)
-    expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
   })
 
   it('forces a viewport refresh for foreground CJK output without CSI', async () => {
@@ -10043,375 +9905,6 @@ describe('connectPanePty', () => {
     capturedDataCallback.current?.('没改什么(护城河)\r\n')
 
     expect(refresh).toHaveBeenCalledWith(0, 39, true)
-    expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
-  })
-
-  it('schedules WebGL atlas recovery after renderer-risk foreground output parses', async () => {
-    const { connectPanePty } = await import('./pty-connection')
-    const transport = createMockTransport()
-    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
-    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
-      capturedDataCallback.current = callbacks.onData ?? null
-      return 'pty-id'
-    })
-    transportFactoryQueue.push(transport)
-
-    const pane = createPane(1)
-    const refresh = vi.fn()
-    let parseCallback: (() => void) | undefined
-    const terminal = pane.terminal as typeof pane.terminal & {
-      _core?: { refresh: typeof refresh }
-    }
-    terminal._core = { refresh }
-    terminal.write = vi.fn((_data: string, callback?: () => void) => {
-      parseCallback = callback
-    })
-
-    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
-    await flushAsyncTicks(6)
-
-    capturedDataCallback.current?.('没改什么(护城河)\r\n')
-
-    expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
-    expect(refresh).not.toHaveBeenCalled()
-    parseCallback?.()
-    expect(refresh).toHaveBeenCalledWith(0, 39, true)
-    expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
-  })
-
-  it('schedules WebGL atlas recovery for Vim-style foreground alternate-screen redraws', async () => {
-    const restoreNavigator = temporarilySetNavigatorUserAgent('Mozilla/5.0 (Macintosh)')
-    try {
-      const { connectPanePty } = await import('./pty-connection')
-      const transport = createMockTransport()
-      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
-      transport.connect.mockImplementation(
-        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
-          capturedDataCallback.current = callbacks.onData ?? null
-          return 'pty-id'
-        }
-      )
-      transportFactoryQueue.push(transport)
-
-      const pane = createPane(1)
-      ;(pane.terminal.buffer.active as { type: 'normal' | 'alternate' }).type = 'alternate'
-      const refresh = vi.fn()
-      let parseCallback: (() => void) | undefined
-      const terminal = pane.terminal as typeof pane.terminal & {
-        _core?: { refresh: typeof refresh }
-      }
-      terminal._core = { refresh }
-      terminal.write = vi.fn((_data: string, callback?: () => void) => {
-        parseCallback = callback
-      })
-
-      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
-      await flushAsyncTicks(6)
-
-      capturedDataCallback.current?.(
-        '\x1b[2J\x1b[H{"name":"eepo"}\r\n\x1b[2;1H{"name":"expo"}\x1b[K'
-      )
-
-      expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
-      parseCallback?.()
-      expect(refresh).toHaveBeenCalledWith(0, 39, true)
-      expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
-    } finally {
-      restoreNavigator()
-    }
-  })
-
-  it('schedules WebGL atlas recovery when a foreground rewrite enters alternate screen', async () => {
-    const restoreNavigator = temporarilySetNavigatorUserAgent('Mozilla/5.0 (Macintosh)')
-    try {
-      const { connectPanePty } = await import('./pty-connection')
-      const transport = createMockTransport()
-      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
-      transport.connect.mockImplementation(
-        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
-          capturedDataCallback.current = callbacks.onData ?? null
-          return 'pty-id'
-        }
-      )
-      transportFactoryQueue.push(transport)
-
-      const pane = createPane(1)
-      const refresh = vi.fn()
-      let parseCallback: (() => void) | undefined
-      const terminal = pane.terminal as typeof pane.terminal & {
-        _core?: { refresh: typeof refresh }
-      }
-      terminal._core = { refresh }
-      terminal.write = vi.fn((_data: string, callback?: () => void) => {
-        parseCallback = callback
-      })
-
-      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
-      await flushAsyncTicks(6)
-
-      capturedDataCallback.current?.('\x1b[?1049h\x1b[2J\x1b[HVim package.json')
-
-      expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
-      // Why: xterm switches to the alternate buffer while parsing the chunk;
-      // the write callback observes the post-parse buffer state.
-      ;(pane.terminal.buffer.active as { type: 'normal' | 'alternate' }).type = 'alternate'
-      parseCallback?.()
-      expect(refresh).toHaveBeenCalledWith(0, 39, true)
-      expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
-    } finally {
-      restoreNavigator()
-    }
-  })
-
-  it('schedules WebGL atlas recovery when the alternate-screen enter sequence splits across chunks', async () => {
-    const restoreNavigator = temporarilySetNavigatorUserAgent('Mozilla/5.0 (Macintosh)')
-    try {
-      const { connectPanePty } = await import('./pty-connection')
-      const transport = createMockTransport()
-      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
-      transport.connect.mockImplementation(
-        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
-          capturedDataCallback.current = callbacks.onData ?? null
-          return 'pty-id'
-        }
-      )
-      transportFactoryQueue.push(transport)
-
-      const pane = createPane(1)
-      const refresh = vi.fn()
-      let parseCallback: (() => void) | undefined
-      const terminal = pane.terminal as typeof pane.terminal & {
-        _core?: { refresh: typeof refresh }
-      }
-      terminal._core = { refresh }
-      terminal.write = vi.fn((_data: string, callback?: () => void) => {
-        parseCallback = callback
-      })
-
-      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
-      await flushAsyncTicks(6)
-
-      // Why: PTY reads split CSI sequences at arbitrary byte boundaries (real
-      // vim sessions split cursor moves at 1024-byte chunk edges), so the
-      // enter sequence itself can straddle two onData chunks.
-      capturedDataCallback.current?.('\x1b[?104')
-      parseCallback?.()
-      expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
-
-      capturedDataCallback.current?.('9h\x1b[2J\x1b[H~\x1b[K')
-      ;(pane.terminal.buffer.active as { type: 'normal' | 'alternate' }).type = 'alternate'
-      parseCallback?.()
-      expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
-    } finally {
-      restoreNavigator()
-    }
-  })
-
-  it('schedules WebGL atlas recovery when a foreground rewrite leaves alternate screen', async () => {
-    const restoreNavigator = temporarilySetNavigatorUserAgent('Mozilla/5.0 (Macintosh)')
-    try {
-      const { connectPanePty } = await import('./pty-connection')
-      const transport = createMockTransport()
-      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
-      transport.connect.mockImplementation(
-        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
-          capturedDataCallback.current = callbacks.onData ?? null
-          return 'pty-id'
-        }
-      )
-      transportFactoryQueue.push(transport)
-
-      const pane = createPane(1)
-      ;(pane.terminal.buffer.active as { type: 'normal' | 'alternate' }).type = 'alternate'
-      const refresh = vi.fn()
-      let parseCallback: (() => void) | undefined
-      const terminal = pane.terminal as typeof pane.terminal & {
-        _core?: { refresh: typeof refresh }
-      }
-      terminal._core = { refresh }
-      terminal.write = vi.fn((_data: string, callback?: () => void) => {
-        parseCallback = callback
-      })
-
-      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
-      await flushAsyncTicks(6)
-
-      // Vim's final frame erases the status line and restores the normal
-      // buffer in one chunk; the atlas must still rebuild for the restored
-      // prompt even though the post-parse buffer is back to normal.
-      capturedDataCallback.current?.('\x1b[34;1H\x1b[K\x1b[34;1H\x1b[?1049l\x1b[?25h')
-      ;(pane.terminal.buffer.active as { type: 'normal' | 'alternate' }).type = 'normal'
-      parseCallback?.()
-      expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
-    } finally {
-      restoreNavigator()
-    }
-  })
-
-  it('schedules WebGL atlas recovery when one chunk enters and exits alternate screen', async () => {
-    const restoreNavigator = temporarilySetNavigatorUserAgent('Mozilla/5.0 (Macintosh)')
-    try {
-      const { connectPanePty } = await import('./pty-connection')
-      const transport = createMockTransport()
-      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
-      transport.connect.mockImplementation(
-        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
-          capturedDataCallback.current = callbacks.onData ?? null
-          return 'pty-id'
-        }
-      )
-      transportFactoryQueue.push(transport)
-
-      const pane = createPane(1)
-      let bufferChangeListener: (() => void) | undefined
-      ;(
-        pane.terminal.buffer as {
-          onBufferChange?: (listener: () => void) => { dispose: () => void }
-        }
-      ).onBufferChange = (listener) => {
-        bufferChangeListener = listener
-        return { dispose: vi.fn() }
-      }
-      const refresh = vi.fn()
-      let parseCallback: (() => void) | undefined
-      const terminal = pane.terminal as typeof pane.terminal & {
-        _core?: { refresh: typeof refresh }
-      }
-      terminal._core = { refresh }
-      terminal.write = vi.fn((_data: string, callback?: () => void) => {
-        parseCallback = callback
-      })
-
-      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
-      await flushAsyncTicks(6)
-
-      // A coalesced backlog flush can parse a whole enter -> draw -> exit TUI
-      // interaction in one write, netting buffer type back to 'normal'; the
-      // buffer-switch count is what still marks it as alternate-screen work.
-      capturedDataCallback.current?.('\x1b[?1049h\x1b[2J\x1b[Hpager frame\x1b[K\x1b[?1049l')
-      bufferChangeListener?.()
-      bufferChangeListener?.()
-      parseCallback?.()
-      expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
-    } finally {
-      restoreNavigator()
-    }
-  })
-
-  it('schedules WebGL atlas recovery for real captured Vim redraw chunks split mid-sequence', async () => {
-    const restoreNavigator = temporarilySetNavigatorUserAgent('Mozilla/5.0 (Macintosh)')
-    try {
-      const { connectPanePty } = await import('./pty-connection')
-      const transport = createMockTransport()
-      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
-      transport.connect.mockImplementation(
-        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
-          capturedDataCallback.current = callbacks.onData ?? null
-          return 'pty-id'
-        }
-      )
-      transportFactoryQueue.push(transport)
-
-      const pane = createPane(1)
-      ;(pane.terminal.buffer.active as { type: 'normal' | 'alternate' }).type = 'alternate'
-      const refresh = vi.fn()
-      let parseCallback: (() => void) | undefined
-      const terminal = pane.terminal as typeof pane.terminal & {
-        _core?: { refresh: typeof refresh }
-      }
-      terminal._core = { refresh }
-      terminal.write = vi.fn((_data: string, callback?: () => void) => {
-        parseCallback = callback
-      })
-
-      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
-      await flushAsyncTicks(6)
-
-      // Captured from a real `vim package.json` session: a 1024-byte PTY read
-      // boundary cuts the cursor move \x1b[30;5H into "\x1b[30" + ";5H".
-      capturedDataCallback.current?.('"rules": {\x1b[29;15H\x1b[K\x1b[30')
-      parseCallback?.()
-      expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
-
-      capturedDataCallback.current?.(
-        ';5H  "js-combine-iterations": "off"\r\n    }\x1b[31;6H\x1b[K\x1b[33;1H\x1b[?25h'
-      )
-      parseCallback?.()
-      expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(2)
-    } finally {
-      restoreNavigator()
-    }
-  })
-
-  it('does not schedule WebGL atlas recovery for ordinary foreground shell rewrites', async () => {
-    const restoreNavigator = temporarilySetNavigatorUserAgent('Mozilla/5.0 (Macintosh)')
-    try {
-      const { connectPanePty } = await import('./pty-connection')
-      const transport = createMockTransport()
-      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
-      transport.connect.mockImplementation(
-        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
-          capturedDataCallback.current = callbacks.onData ?? null
-          return 'pty-id'
-        }
-      )
-      transportFactoryQueue.push(transport)
-
-      const pane = createPane(1)
-      const refresh = vi.fn()
-      let parseCallback: (() => void) | undefined
-      const terminal = pane.terminal as typeof pane.terminal & {
-        _core?: { refresh: typeof refresh }
-      }
-      terminal._core = { refresh }
-      terminal.write = vi.fn((_data: string, callback?: () => void) => {
-        parseCallback = callback
-      })
-
-      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
-      await flushAsyncTicks(6)
-
-      capturedDataCallback.current?.('\r\x1b[Korca % npm test')
-
-      parseCallback?.()
-      expect(refresh).toHaveBeenCalledWith(0, 39, true)
-      expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
-    } finally {
-      restoreNavigator()
-    }
-  })
-
-  it('does not schedule WebGL atlas recovery for plain synchronized foreground frames', async () => {
-    const restoreNavigator = temporarilySetNavigatorUserAgent('Mozilla/5.0 (Macintosh)')
-    try {
-      const { connectPanePty } = await import('./pty-connection')
-      const transport = createMockTransport()
-      const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
-      transport.connect.mockImplementation(
-        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
-          capturedDataCallback.current = callbacks.onData ?? null
-          return 'pty-id'
-        }
-      )
-      transportFactoryQueue.push(transport)
-
-      const pane = createPane(1)
-      let parseCallback: (() => void) | undefined
-      pane.terminal.write = vi.fn((_data: string, callback?: () => void) => {
-        parseCallback = callback
-      })
-
-      connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
-      await flushAsyncTicks(6)
-
-      capturedDataCallback.current?.('\x1b[?2026hplain claude frame\x1b[?2026l')
-
-      expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
-      parseCallback?.()
-      expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
-    } finally {
-      restoreNavigator()
-    }
   })
 
   it('forces a viewport refresh when foreground background SGR is split across PTY chunks', async () => {
@@ -10445,7 +9938,6 @@ describe('connectPanePty', () => {
 
     expect(manager.markPaneHasComplexScriptOutput).not.toHaveBeenCalled()
     expect(refresh).toHaveBeenCalledWith(0, 39, true)
-    expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
   })
 
   it('forces a viewport refresh when the foreground CSI introducer is split across PTY chunks', async () => {
@@ -10479,7 +9971,6 @@ describe('connectPanePty', () => {
 
     expect(manager.markPaneHasComplexScriptOutput).not.toHaveBeenCalled()
     expect(refresh).toHaveBeenCalledWith(0, 39, true)
-    expect(scheduleTerminalWebglAtlasRecovery).toHaveBeenCalledTimes(1)
   })
 
   it('does not keep forcing viewport refresh after completed background redraws', async () => {
@@ -10509,11 +10000,10 @@ describe('connectPanePty', () => {
     expect(refresh).toHaveBeenCalledWith(0, 39, true)
 
     refresh.mockClear()
-    scheduleTerminalWebglAtlasRecovery.mockClear()
+
     capturedDataCallback.current?.('plain follow-up output\r\n')
 
     expect(refresh).not.toHaveBeenCalled()
-    expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
   })
 
   it('forces a viewport refresh for native Windows CJK foreground output after terminal input', async () => {
@@ -10624,7 +10114,6 @@ describe('connectPanePty', () => {
       capturedDataCallback.current?.('abc 123 ✓')
 
       expect(refresh).not.toHaveBeenCalled()
-      expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
     } finally {
       restoreNavigator()
     }
@@ -10704,7 +10193,6 @@ describe('connectPanePty', () => {
       capturedDataCallback.current?.('abc 123 ✓')
 
       expect(refresh).not.toHaveBeenCalled()
-      expect(scheduleTerminalWebglAtlasRecovery).not.toHaveBeenCalled()
     } finally {
       restoreNavigator()
     }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -200,7 +200,6 @@ const HIDDEN_OUTPUT_RESTORE_FOREGROUND_TIMEOUT_MS = 750
 const TERMINAL_RENDERER_RISK_SCAN_TAIL_CHARS = 256
 const SYNCHRONIZED_OUTPUT_START_SEQUENCE = '\x1b[?2026h'
 const SYNCHRONIZED_OUTPUT_END_SEQUENCE = '\x1b[?2026l'
-const SYNCHRONIZED_OUTPUT_MARKER_TAIL_CHARS = SYNCHRONIZED_OUTPUT_START_SEQUENCE.length - 1
 const CURSOR_SHOW_SEQUENCE = '\x1b[?25h'
 const CURSOR_HIDE_SEQUENCE = '\x1b[?25l'
 const TERMINAL_FOCUS_IN_SEQUENCE = '\x1b[I'
@@ -3833,96 +3832,6 @@ export function connectPanePty(
       return prefersRefresh
     }
 
-    function resetHiddenRendererRiskState(ptyId: string | null = null): void {
-      hiddenRiskPtyId = ptyId
-      hiddenSynchronizedOutputActive = false
-      hiddenSynchronizedOutputMarkerTail = ''
-      hiddenRewriteChunkEndedWithCarriageReturn = false
-      hiddenRewriteCsiScanTail = ''
-    }
-
-    function ensureHiddenRendererRiskStateForCurrentPty(): void {
-      const ptyId = transport.getPtyId()
-      if (hiddenRiskPtyId === ptyId) {
-        return
-      }
-      resetHiddenRendererRiskState(ptyId)
-    }
-
-    function resetSkippedHiddenRendererRiskState(): void {
-      // Why: skipped/backlog bytes were not parsed by xterm; reset any live hidden
-      // frame instead of letting dropped DEC starts make later plain bytes risky.
-      resetHiddenRendererRiskState(transport.getPtyId())
-    }
-
-    function hiddenSynchronizedOutputTouchesParsedFrame(data: string): boolean {
-      const scanData = hiddenSynchronizedOutputMarkerTail
-        ? `${hiddenSynchronizedOutputMarkerTail}${data}`
-        : data
-      const currentChunkStartIndex = scanData.length - data.length
-      let active = hiddenSynchronizedOutputActive
-      let touchesParsedFrame = active && data.length > 0
-      let offset = 0
-
-      while (offset < scanData.length) {
-        const startIndex = scanData.indexOf(SYNCHRONIZED_OUTPUT_START_SEQUENCE, offset)
-        const endIndex = scanData.indexOf(SYNCHRONIZED_OUTPUT_END_SEQUENCE, offset)
-        if (startIndex === -1 && endIndex === -1) {
-          break
-        }
-        if (endIndex !== -1 && (startIndex === -1 || endIndex < startIndex)) {
-          if (
-            active &&
-            endIndex + SYNCHRONIZED_OUTPUT_END_SEQUENCE.length > currentChunkStartIndex
-          ) {
-            touchesParsedFrame = true
-          }
-          active = false
-          offset = endIndex + SYNCHRONIZED_OUTPUT_END_SEQUENCE.length
-          continue
-        }
-        if (startIndex !== -1) {
-          active = true
-          if (startIndex + SYNCHRONIZED_OUTPUT_START_SEQUENCE.length > currentChunkStartIndex) {
-            touchesParsedFrame = true
-          }
-          offset = startIndex + SYNCHRONIZED_OUTPUT_START_SEQUENCE.length
-          continue
-        }
-      }
-
-      if (active && data.length > 0) {
-        touchesParsedFrame = true
-      }
-      hiddenSynchronizedOutputActive = active
-      hiddenSynchronizedOutputMarkerTail = scanData.slice(-SYNCHRONIZED_OUTPUT_MARKER_TAIL_CHARS)
-      return touchesParsedFrame
-    }
-
-    function hiddenTuiRedrawOutputPrefersAtlasRecovery(data: string): boolean {
-      if (!data) {
-        return false
-      }
-      const scanData = hiddenRewriteCsiScanTail ? `${hiddenRewriteCsiScanTail}${data}` : data
-      const decision = terminalRewriteOutputRenderRefreshDecision(data, {
-        previousChunkEndsWithCarriageReturn: hiddenRewriteChunkEndedWithCarriageReturn,
-        previousRewriteCsiScanTail: hiddenRewriteCsiScanTail
-      })
-      hiddenRewriteChunkEndedWithCarriageReturn = decision.nextChunkEndsWithCarriageReturn
-      hiddenRewriteCsiScanTail = decision.nextRewriteCsiScanTail
-      return decision.prefersRenderRefresh || containsCursorPositionSequence(scanData)
-    }
-
-    function hiddenOutputNeedsAtlasRecoveryAfterParse(data: string): boolean {
-      if (!data) {
-        return false
-      }
-      ensureHiddenRendererRiskStateForCurrentPty()
-      const synchronizedOutputTouchesParsedFrame = hiddenSynchronizedOutputTouchesParsedFrame(data)
-      const tuiRedrawOutputPrefersAtlasRecovery = hiddenTuiRedrawOutputPrefersAtlasRecovery(data)
-      return synchronizedOutputTouchesParsedFrame || tuiRedrawOutputPrefersAtlasRecovery
-    }
-
     // The replay path uses the guard so xterm auto-replies to embedded query
     // sequences don't leak into the shell. xterm.write() buffers internally
     // regardless of DOM visibility and the guard stays engaged via the
@@ -4094,11 +4003,6 @@ export function connectPanePty(
     const shouldSnapshotHiddenCodexOutput = shouldKeepHiddenStartupRendererQueriesLive(paneStartup)
     let hiddenStartupRendererQueryPending = ''
     let hiddenRendererStateDirty = false
-    let hiddenRiskPtyId: string | null = null
-    let hiddenSynchronizedOutputActive = false
-    let hiddenSynchronizedOutputMarkerTail = ''
-    let hiddenRewriteChunkEndedWithCarriageReturn = false
-    let hiddenRewriteCsiScanTail = ''
     let rendererOrderedPtyId: string | null = null
     let rendererOrderedSeq: number | null = null
     let rendererChannelSeqPtyId: string | null = null
@@ -4228,11 +4132,8 @@ export function connectPanePty(
       return decision.prefersRenderRefresh
     }
 
-    // Why: Vim-style TUI redraws are plain-ASCII in-place rewrites whose erased
-    // cells can keep stale WebGL glyphs until the shared atlas rebuilds. Whether
-    // a rewrite touched the alternate screen is only authoritative once xterm
-    // parses the chunk (enter/exit sequences can split across PTY chunks), so
-    // capture the pre-parse state and decide the rest at parse completion.
+    // Why: plain-ASCII alternate-screen rewrites can leave stale atlas cells,
+    // but the active buffer is authoritative only after xterm parses the chunk.
     function alternateScreenRewriteAtlasRecoveryOnParsed(): () => void {
       const wasAlternateScreenBuffer = pane.terminal.buffer.active.type === 'alternate'
       const switchesBeforeParse = alternateScreenBufferSwitches
@@ -4296,7 +4197,6 @@ export function connectPanePty(
     ): void {
       if (foreground) {
         resetHiddenOutputRestoreIfPtyChanged()
-        resetHiddenRendererRiskState()
       }
       const parseHiddenStartupOutput =
         !foreground &&
@@ -4330,18 +4230,13 @@ export function connectPanePty(
       const renderRefreshDecision = foregroundOutput
         ? shouldForceForegroundRenderRefresh(data)
         : { refresh: false, inPlaceRewrite: false, recoverWebglAtlasAfterParse: false }
-      const recoverHiddenWebglAtlasAfterParse =
-        !foregroundOutput && hiddenOutputNeedsAtlasRecoveryAfterParse(data)
-      const recoverWebglAtlasAfterParse =
-        renderRefreshDecision.recoverWebglAtlasAfterParse || recoverHiddenWebglAtlasAfterParse
-      // Why: atlas recovery must repaint from the parsed xterm buffer, not a
-      // pre-write snapshot that a late TUI redraw can immediately stale.
-      const onParsedAtlasRecovery = recoverWebglAtlasAfterParse
-        ? scheduleTerminalWebglAtlasRecovery
-        : renderRefreshDecision.inPlaceRewrite
-          ? alternateScreenRewriteAtlasRecoveryOnParsed()
-          : undefined
       const foregroundRenderRefreshNeeded = renderRefreshDecision.refresh
+      const onParsedAtlasRecovery =
+        foreground && renderRefreshDecision.recoverWebglAtlasAfterParse
+          ? scheduleTerminalWebglAtlasRecovery
+          : foreground && renderRefreshDecision.inPlaceRewrite
+            ? alternateScreenRewriteAtlasRecoveryOnParsed()
+            : undefined
       // Why: see nativeWindowsRewriteNeedsFollowupRenderRefresh — Claude Code's
       // in-place prompt redraws on Windows ConPTY can paint one frame late, so a
       // follow-up repaint corrects the column desync without a window resize.
@@ -4405,7 +4300,6 @@ export function connectPanePty(
     }
 
     function markHiddenOutputRestoreNeeded(): void {
-      resetSkippedHiddenRendererRiskState()
       const ptyId = transport.getPtyId()
       if (!canUseHiddenOutputSnapshot(ptyId)) {
         return
@@ -4792,7 +4686,6 @@ export function connectPanePty(
       hiddenOutputRestoreScheduled = false
       hiddenStartupRendererQueryPending = ''
       hiddenRendererStateDirty = false
-      resetHiddenRendererRiskState()
       cancelScheduledHiddenOutputRestore(pane.terminal)
       clearHiddenOutputRestoreDeferredRetryTimer()
       clearHiddenOutputRestoreForegroundDeadlineTimer()
@@ -4843,7 +4736,6 @@ export function connectPanePty(
       clearPendingLiveChunksDuringRestore()
       hiddenStartupRendererQueryPending = ''
       hiddenRendererStateDirty = false
-      resetHiddenRendererRiskState()
       hiddenOutputRestoreNeeded = false
       hiddenOutputRestorePtyId = null
       hiddenOutputRestoreGeneration += 1
@@ -4876,7 +4768,6 @@ export function connectPanePty(
     function skipBackgroundAlternateScreenOutput(data: string): void {
       writeHiddenStartupRendererQueries(data)
       respondToSkippedMode2031Subscribe(data)
-      resetSkippedHiddenRendererRiskState()
       hiddenRendererStateDirty = true
       recordHiddenRendererSkip(data.length)
       const ptyId = transport.getPtyId()
@@ -5237,7 +5128,6 @@ export function connectPanePty(
           queueLiveChunkDuringRestore(orderedRendererData, rendererMeta)
           requestHiddenOutputRestoreIfNeeded()
         } else if (hiddenOutputRestoreInFlight) {
-          resetSkippedHiddenRendererRiskState()
           hiddenOutputRestoreNeeded = true
           hiddenOutputRestoreFreshSnapshotNeeded = true
         }

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
@@ -21,7 +21,7 @@ vi.mock('./pane-helpers', () => ({
   focusActivePane: vi.fn()
 }))
 vi.mock('./terminal-webgl-atlas-recovery', () => ({
-  scheduleTerminalWebglAtlasRecovery: vi.fn()
+  scheduleTabRevealWebglAtlasRecovery: vi.fn()
 }))
 
 type FakeManager = {

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -7,7 +7,7 @@ import {
 } from '@/lib/pane-manager/pane-terminal-output-scheduler'
 import { enforceTerminalCurrentScrollIntent } from '@/lib/pane-manager/terminal-scroll-intent'
 import { fitAndFocusPanes, fitPanes, focusActivePane } from './pane-helpers'
-import { scheduleTerminalWebglAtlasRecovery } from './terminal-webgl-atlas-recovery'
+import { scheduleTabRevealWebglAtlasRecovery } from './terminal-webgl-atlas-recovery'
 
 const VISIBLE_RESUME_FLUSH_CHARS = 256 * 1024
 const WINDOW_WAKE_FLUSH_CHARS = 64 * 1024
@@ -62,7 +62,7 @@ export function resumeTerminalVisibility({
       // overlay's delayed geometry fit. Still request hidden-output recovery:
       // agent TUIs can suppress hidden bytes until the pane is foregrounded.
       requestLightTabBacklogRecovery(manager)
-      scheduleTerminalWebglAtlasRecovery()
+      scheduleTabRevealWebglAtlasRecovery()
       if (isActive) {
         focusActivePane(manager)
       }

--- a/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts
@@ -5,6 +5,7 @@ import {
 } from '@/lib/pane-manager/pane-manager-registry'
 import {
   scheduleImagePasteWebglAtlasRecovery,
+  scheduleTabRevealWebglAtlasRecovery,
   scheduleTerminalWebglAtlasRecovery
 } from './terminal-webgl-atlas-recovery'
 
@@ -28,6 +29,7 @@ describe('terminal WebGL atlas recovery', () => {
     for (const manager of registeredManagers.splice(0)) {
       unregisterLivePaneManager(manager)
     }
+    vi.clearAllTimers()
     vi.useRealTimers()
     vi.unstubAllGlobals()
   })
@@ -145,7 +147,28 @@ describe('terminal WebGL atlas recovery', () => {
     expect(manager.refreshAllPanes).not.toHaveBeenCalled()
   })
 
-  it('coalesces terminal-output atlas recovery across a redraw burst', () => {
+  it('runs tab-reveal recovery immediately without an output-settle timer', () => {
+    vi.useFakeTimers()
+    const rafCallbacks: FrameRequestCallback[] = []
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        rafCallbacks.push(callback)
+        return rafCallbacks.length
+      })
+    )
+    const manager = registerManager()
+
+    scheduleTabRevealWebglAtlasRecovery()
+
+    expect(manager.resetWebglTextureAtlases).not.toHaveBeenCalled()
+    rafCallbacks[0]?.(0)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(500)
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(3)
+    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(3)
+  })
+  it('rate-limits output recovery independently of terminal throughput', () => {
     vi.useFakeTimers()
     vi.stubGlobal(
       'requestAnimationFrame',
@@ -158,24 +181,15 @@ describe('terminal WebGL atlas recovery', () => {
 
     scheduleTerminalWebglAtlasRecovery()
     scheduleTerminalWebglAtlasRecovery()
-    scheduleTerminalWebglAtlasRecovery()
-
-    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
-    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(1)
-    vi.advanceTimersByTime(120)
-    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(2)
-    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(2)
-    scheduleTerminalWebglAtlasRecovery()
-    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(2)
-    vi.advanceTimersByTime(380)
+    vi.advanceTimersByTime(500)
     expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(3)
-    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(3)
 
+    vi.advanceTimersByTime(29_499)
+    scheduleTerminalWebglAtlasRecovery()
+    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(3)
+
+    vi.advanceTimersByTime(1)
     scheduleTerminalWebglAtlasRecovery()
     expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(4)
-    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(4)
-    vi.advanceTimersByTime(500)
-    expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(6)
-    expect(manager.refreshAllPanes).toHaveBeenCalledTimes(6)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.ts
@@ -1,8 +1,10 @@
 import { resetAndRefreshAllTerminalWebglAtlases } from '@/lib/pane-manager/pane-manager-registry'
 
 const ATLAS_RECOVERY_DELAYS_MS = [120, 500]
+const TERMINAL_OUTPUT_RECOVERY_COOLDOWN_MS = 30_000
 
-let terminalOutputRecoveryScheduled = false
+let terminalOutputRecoveryCoolingDown = false
+let terminalOutputRecoveryPending = false
 
 function scheduleNextFrame(callback: () => void): void {
   if (typeof globalThis.requestAnimationFrame === 'function') {
@@ -22,32 +24,39 @@ function resetAtlasesAndRefreshPanes(): void {
   }
 }
 
-function scheduleAtlasRecoveryBurst(onComplete?: () => void): void {
+function scheduleAtlasRecoveryBurst(): void {
   scheduleNextFrame(() => resetAtlasesAndRefreshPanes())
-  for (const [index, delayMs] of ATLAS_RECOVERY_DELAYS_MS.entries()) {
-    globalThis.setTimeout(() => {
-      resetAtlasesAndRefreshPanes()
-      if (index === ATLAS_RECOVERY_DELAYS_MS.length - 1) {
-        onComplete?.()
-      }
-    }, delayMs)
+  for (const delayMs of ATLAS_RECOVERY_DELAYS_MS) {
+    globalThis.setTimeout(() => resetAtlasesAndRefreshPanes(), delayMs)
   }
+}
+export function scheduleTerminalWebglAtlasRecovery(): void {
+  if (terminalOutputRecoveryCoolingDown) {
+    terminalOutputRecoveryPending = true
+    return
+  }
+  terminalOutputRecoveryCoolingDown = true
+  terminalOutputRecoveryPending = false
+  // Why: renderer-risk output can corrupt xterm's shared glyph atlas without a
+  // context-loss event. Recover promptly, then coalesce throughput-coupled
+  // requests into one trailing rebuild after the global cooldown.
+  scheduleAtlasRecoveryBurst()
+  globalThis.setTimeout(() => {
+    terminalOutputRecoveryCoolingDown = false
+    if (terminalOutputRecoveryPending) {
+      scheduleTerminalWebglAtlasRecovery()
+    }
+  }, TERMINAL_OUTPUT_RECOVERY_COOLDOWN_MS)
 }
 
 export function scheduleImagePasteWebglAtlasRecovery(): void {
-  // Why: image chips can redraw after bracketed paste parsing, so cover the
-  // short post-paste paint window with a few cheap atlas rebuilds.
+  // Why: image paste is a one-shot renderer lifecycle event, so its recovery
+  // can rebuild the shared atlas without coupling cost to PTY throughput.
   scheduleAtlasRecoveryBurst()
 }
 
-export function scheduleTerminalWebglAtlasRecovery(): void {
-  if (terminalOutputRecoveryScheduled) {
-    return
-  }
-  terminalOutputRecoveryScheduled = true
-  // Why: TUI redraw bursts can corrupt xterm's shared WebGL glyph atlas without
-  // a context-loss event; coalesce resets so output storms do not queue timers.
-  scheduleAtlasRecoveryBurst(() => {
-    terminalOutputRecoveryScheduled = false
-  })
+export function scheduleTabRevealWebglAtlasRecovery(): void {
+  // Why: tab reveal is also one-shot; repaint after layout without putting any
+  // shared-atlas work on the routine terminal-output path.
+  scheduleAtlasRecoveryBurst()
 }

--- a/src/renderer/src/lib/pane-manager/pane-terminal-foreground-render-settle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-foreground-render-settle.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  discardForegroundRenderSettle,
+  writeForegroundTerminalChunk,
+  type ForegroundTerminalOutputTarget
+} from './pane-terminal-foreground-render-settle'
+
+type TestTerminal = ForegroundTerminalOutputTarget & {
+  _core: { refresh: ReturnType<typeof vi.fn> }
+  write: ReturnType<typeof vi.fn>
+}
+
+function createTerminal(): TestTerminal {
+  return {
+    rows: 40,
+    buffer: { active: { baseY: 0, cursorY: 10, viewportY: 0 } },
+    _core: { refresh: vi.fn() },
+    write: vi.fn((_data: string, callback?: () => void) => callback?.())
+  }
+}
+
+describe('foreground terminal render settle', () => {
+  const frameCallbacks: FrameRequestCallback[] = []
+
+  afterEach(() => {
+    frameCallbacks.length = 0
+    vi.unstubAllGlobals()
+  })
+
+  function installAnimationFrames(): void {
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        frameCallbacks.push(callback)
+        return frameCallbacks.length
+      })
+    )
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  }
+
+  it('parses every write immediately but refreshes at most once per frame', () => {
+    installAnimationFrames()
+    const terminal = createTerminal()
+
+    for (let index = 0; index < 100; index += 1) {
+      writeForegroundTerminalChunk(terminal, `frame ${index}`, { forceViewportRefresh: true })
+    }
+
+    expect(terminal.write).toHaveBeenCalledTimes(100)
+    expect(terminal._core.refresh).not.toHaveBeenCalled()
+    expect(frameCallbacks).toHaveLength(1)
+
+    frameCallbacks.shift()?.(0)
+    expect(terminal._core.refresh).toHaveBeenCalledTimes(1)
+    expect(terminal._core.refresh).toHaveBeenCalledWith(0, 39, true)
+  })
+
+  it('keeps a fixed frame cadence while output continues', () => {
+    installAnimationFrames()
+    const terminal = createTerminal()
+
+    writeForegroundTerminalChunk(terminal, 'first', { forceViewportRefresh: true })
+    expect(terminal._core.refresh).not.toHaveBeenCalled()
+    frameCallbacks.shift()?.(0)
+    expect(terminal._core.refresh).toHaveBeenCalledTimes(1)
+
+    writeForegroundTerminalChunk(terminal, 'second', { forceViewportRefresh: true })
+    expect(frameCallbacks).toHaveLength(1)
+    frameCallbacks.shift()?.(16)
+    expect(terminal._core.refresh).toHaveBeenCalledTimes(2)
+  })
+
+  it('preserves a requested follow-up without duplicating the first frame', () => {
+    installAnimationFrames()
+    const terminal = createTerminal()
+
+    writeForegroundTerminalChunk(terminal, 'first', {
+      forceViewportRefresh: true,
+      followupViewportRefresh: true
+    })
+    writeForegroundTerminalChunk(terminal, 'second', { forceViewportRefresh: true })
+
+    expect(terminal._core.refresh).not.toHaveBeenCalled()
+    expect(frameCallbacks).toHaveLength(1)
+    frameCallbacks.shift()?.(0)
+    expect(terminal._core.refresh).toHaveBeenCalledTimes(1)
+    expect(frameCallbacks).toHaveLength(1)
+    frameCallbacks.shift()?.(16)
+    expect(terminal._core.refresh).toHaveBeenCalledTimes(2)
+  })
+
+  it('refreshes the full viewport when output scrolls', () => {
+    installAnimationFrames()
+    const terminal = createTerminal()
+    terminal.write.mockImplementation((_data: string, callback?: () => void) => {
+      if (terminal.buffer?.active) {
+        terminal.buffer.active.baseY = 1
+        terminal.buffer.active.cursorY = 39
+        terminal.buffer.active.viewportY = 1
+      }
+      callback?.()
+    })
+
+    writeForegroundTerminalChunk(terminal, 'scrolled', { forceViewportRefresh: true })
+    frameCallbacks.shift()?.(0)
+
+    expect(terminal._core.refresh).toHaveBeenCalledWith(0, 39, true)
+  })
+
+  it('cancels a pending refresh when the terminal is discarded', () => {
+    installAnimationFrames()
+    const terminal = createTerminal()
+
+    writeForegroundTerminalChunk(terminal, 'data', {
+      forceViewportRefresh: true,
+      followupViewportRefresh: true
+    })
+    discardForegroundRenderSettle(terminal)
+    frameCallbacks.shift()?.(0)
+
+    expect(cancelAnimationFrame).toHaveBeenCalledTimes(1)
+    expect(terminal._core.refresh).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-terminal-foreground-render-settle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-foreground-render-settle.ts
@@ -20,9 +20,14 @@ type ForegroundTerminalWriteOptions = {
   onParsed?: () => void
 }
 
+type PendingViewportRefresh = {
+  followup: boolean
+  handle?: { kind: 'raf'; id: number } | { kind: 'timeout'; id: ReturnType<typeof setTimeout> }
+}
+
 const pendingViewportSettleRefreshByTerminal = new WeakMap<
   ForegroundTerminalOutputTarget,
-  { kind: 'raf'; id: number } | { kind: 'timeout'; id: ReturnType<typeof setTimeout> }
+  PendingViewportRefresh
 >()
 
 type ViewportSnapshot = {
@@ -34,18 +39,15 @@ function refreshVisibleRowsNow(terminal: ForegroundTerminalOutputTarget): void {
   if (typeof terminal.rows !== 'number' || terminal.rows < 1) {
     return
   }
-
-  const start = 0
   const end = Math.max(0, terminal.rows - 1)
   try {
-    // Why: xterm's DOM renderer batches row paints; Windows ConPTY CR-style
-    // rewrites can leave stale CJK glyph cells until a resize unless we paint
-    // the parsed foreground state before Chromium's next frame.
+    // Why: forced refreshes cover arbitrary cursor-addressed and screen-wide
+    // controls, so cursor movement cannot safely narrow the invalidated rows.
     if (typeof terminal._core?.refresh === 'function') {
-      terminal._core.refresh(start, end, true)
+      terminal._core.refresh(0, end, true)
       return
     }
-    terminal.refresh?.(start, end)
+    terminal.refresh?.(0, end)
   } catch {
     // Ignore disposed terminals; PTY output can race pane teardown.
   }
@@ -79,31 +81,53 @@ function cancelScheduledViewportSettleRefresh(terminal: ForegroundTerminalOutput
     return
   }
   pendingViewportSettleRefreshByTerminal.delete(terminal)
-  if (pending.kind === 'raf') {
+  if (pending.handle?.kind === 'raf') {
     if (typeof cancelAnimationFrame === 'function') {
-      cancelAnimationFrame(pending.id)
+      cancelAnimationFrame(pending.handle.id)
     }
     return
   }
-  clearTimeout(pending.id)
+  if (pending.handle) {
+    clearTimeout(pending.handle.id)
+  }
 }
 
-function scheduleViewportSettleRefresh(terminal: ForegroundTerminalOutputTarget): void {
-  cancelScheduledViewportSettleRefresh(terminal)
-  if (typeof requestAnimationFrame === 'function') {
-    const id = requestAnimationFrame(() => {
+function scheduleViewportRefreshFrame(
+  terminal: ForegroundTerminalOutputTarget,
+  pending: PendingViewportRefresh
+): void {
+  const run = (): void => {
+    if (pendingViewportSettleRefreshByTerminal.get(terminal) !== pending) {
+      return
+    }
+    refreshVisibleRowsNow(terminal)
+    if (!pending.followup) {
       pendingViewportSettleRefreshByTerminal.delete(terminal)
-      refreshVisibleRowsNow(terminal)
-    })
-    pendingViewportSettleRefreshByTerminal.set(terminal, { kind: 'raf', id })
-    return
+      return
+    }
+    pending.followup = false
+    scheduleViewportRefreshFrame(terminal, pending)
   }
 
-  const id = setTimeout(() => {
-    pendingViewportSettleRefreshByTerminal.delete(terminal)
-    refreshVisibleRowsNow(terminal)
-  }, 16)
-  pendingViewportSettleRefreshByTerminal.set(terminal, { kind: 'timeout', id })
+  if (typeof requestAnimationFrame === 'function') {
+    pending.handle = { kind: 'raf', id: requestAnimationFrame(run) }
+    return
+  }
+  pending.handle = { kind: 'timeout', id: setTimeout(run, 16) }
+}
+
+function scheduleViewportSettleRefresh(
+  terminal: ForegroundTerminalOutputTarget,
+  followup: boolean
+): void {
+  const pending = pendingViewportSettleRefreshByTerminal.get(terminal)
+  if (pending) {
+    pending.followup ||= followup
+    return
+  }
+  const next: PendingViewportRefresh = { followup }
+  pendingViewportSettleRefreshByTerminal.set(terminal, next)
+  scheduleViewportRefreshFrame(terminal, next)
 }
 
 function settleForegroundRender(
@@ -111,16 +135,19 @@ function settleForegroundRender(
   beforeWriteViewport: ViewportSnapshot,
   options: ForegroundTerminalWriteOptions
 ): void {
-  refreshVisibleRowsNow(terminal)
-  // Why: when output advances the viewport, Chromium can paint the freshly
-  // scrolled top row one frame later than xterm finishes parsing. Repaint once
-  // more after the scroll settles so the user doesn't need to jiggle the window.
-  if (
-    options.followupViewportRefresh ||
-    viewportChangedDuringWrite(terminal, beforeWriteViewport)
-  ) {
-    scheduleViewportSettleRefresh(terminal)
+  // Why: PTY chunks can arrive much faster than the display can paint. xterm
+  // parses them continuously; collapse corrective full-viewport repaints to
+  // the next animation frame without assuming cursor motion bounds mutations.
+  const followup =
+    options.followupViewportRefresh || viewportChangedDuringWrite(terminal, beforeWriteViewport)
+  if (typeof requestAnimationFrame !== 'function') {
+    refreshVisibleRowsNow(terminal)
+    if (followup) {
+      scheduleViewportSettleRefresh(terminal, false)
+    }
+    return
   }
+  scheduleViewportSettleRefresh(terminal, followup)
 }
 
 export function writeForegroundTerminalChunk(


### PR DESCRIPTION
## Summary

- coalesce corrective foreground terminal refreshes to one full-viewport repaint per animation frame
- rate-limit foreground WebGL atlas recovery to one burst per 30 seconds while preserving one trailing request
- move skipped hidden-output atlas recovery to the existing tab-reveal lifecycle path
- remove throughput-coupled hidden renderer-risk state and its obsolete tests

The glyph atlas is shared across same-config terminals, so each recovery resets and repaints every live pane. The previous output-driven debounce repeatedly ran global recovery bursts under sustained TUI output. This keeps recovery for actual renderer-risk output, but makes its cost independent of PTY throughput and preserves a trailing repair if corruption occurs during the cooldown.

Fixes #9579

## Performance

Identical 10-second Instruments Time Profiler captures of a 60 Hz synchronized, cursor-addressed redraw workload:

- current `v1.4.124`: 5,178 CPU samples
- patched steady state: 134 CPU samples
- reduction: 97.4% (38.6x)

The initial patched recovery window still performs its prompt three-step recovery burst; subsequent requests coalesce behind the 30-second cooldown.

## Verification

- `pnpm exec vitest run src/renderer/src/components/terminal-pane/terminal-webgl-atlas-recovery.test.ts src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts src/renderer/src/lib/pane-manager/pane-terminal-foreground-render-settle.test.ts --config config/vitest.config.ts` — 14 passed
- `pnpm exec vitest run src/renderer/src/components/terminal-pane/pty-connection.test.ts --config config/vitest.config.ts -t 'queues visible bulk output|keeps ANSI redraws|keeps large ANSI redraws|OpenTUI-style small ANSI redraw bursts'` — 4 passed
- targeted `oxlint` on all eight changed files — passed
- live WebGL smoke test with sustained synchronized redraws — output remained complete with no stale or blank rows
- autoreview (`gpt-5.6-sol`, high) — clean, no accepted/actionable findings
