### PR TITLE
feat(dev-tooling): local multi-host test-mode harness (pnpm dev:mode)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ docs/**
 !docs/agent-skill-sharing-installation-plan.md
 !docs/ai-vault-process-isolation-plan.md
 !docs/mobile-terminal-shortcut-bar.md
+!docs/local-multi-host-test-modes.md
 !docs/reference/
 !docs/reference/git-compatibility.md
 !docs/reference/headless-linux-server.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,10 @@ All changes must consider folder workspaces as well as git worktrees. Don't assu
 
 Clients and remote Orca servers update independently, so mixed versions are the normal state. Before changing anything a paired client and host exchange — RPC params, stream frames, or the content either side publishes over them — follow [`docs/reference/remote-wire-compatibility.md`](./docs/reference/remote-wire-compatibility.md). A new optional field is safe; a new stream opcode must be capability-negotiated because decoders drop unknown opcodes silently; and changing what the host publishes reaches old clients even with no wire change.
 
+## Testing Across Execution Hosts
+
+Bugs that only appear on a remote/SSH host are invisible when you only test locally. To reproduce Orca's host topologies (local, remote `runtime:` server, `ssh:` host, and combinations) on one machine, use `pnpm dev:mode <mode>` — see [`docs/local-multi-host-test-modes.md`](./docs/local-multi-host-test-modes.md).
+
 ## Git Binary Compatibility
 
 Orca runs the user's Git binary on native, WSL, and SSH hosts, which may all have different versions. Treat Git 2.25 as the core-workflow baseline and follow [`docs/reference/git-compatibility.md`](./docs/reference/git-compatibility.md).

--- a/config/scripts/local-test-modes.mjs
+++ b/config/scripts/local-test-modes.mjs
@@ -396,7 +396,6 @@ function parseArgs(argv) {
     dryRun: false,
     keep: false,
     noBuild: false,
-    web: false,
     ssh: 'localhost',
     help: false
   }
@@ -409,8 +408,6 @@ function parseArgs(argv) {
       out.keep = true
     } else if (arg === '--no-build') {
       out.noBuild = true
-    } else if (arg === '--web') {
-      out.web = true
     } else if (arg === '--ssh=docker') {
       out.ssh = 'docker'
     } else if (arg === '--ssh=localhost') {

--- a/config/scripts/local-test-modes.mjs
+++ b/config/scripts/local-test-modes.mjs
@@ -1,0 +1,509 @@
+#!/usr/bin/env node
+
+// Launches Orca in a chosen local host topology so features (native chat, source
+// control, terminals, …) can be exercised across execution hosts on one machine:
+//
+//   local              a single desktop app (local host only)
+//   remote             a headless `orca serve` runtime + an auto-paired web client
+//   local-remote       a desktop app + a runtime server, pre-seeded into the app
+//   local-ssh          a desktop app + prep for adding a localhost SSH host
+//   local-remote-ssh   desktop + runtime server + SSH prep
+//
+// Each host gets its own isolated userData profile so instances never collide.
+// It composes the existing building blocks (run-electron-vite-dev.mjs,
+// serve-headless-fresh-profile-pairing.mjs, orca-dev.mjs) rather than reinventing
+// them. See docs/local-multi-host-test-modes.md.
+
+import { spawn, spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { createInterface } from 'node:readline'
+
+const scriptDir = import.meta.dirname
+const repoRoot = path.resolve(scriptDir, '..', '..')
+const orcaDevScript = path.join(scriptDir, 'orca-dev.mjs')
+const serveScript = path.join(scriptDir, 'serve-headless-fresh-profile-pairing.mjs')
+const runDevScript = path.join(scriptDir, 'run-electron-vite-dev.mjs')
+const ensureRuntimeScript = path.join(scriptDir, 'ensure-native-runtime.mjs')
+
+/** Each mode is a set of host "arms". `seedRemote` wires the serve arm's pairing
+ *  code into the desktop arm's saved-server list so it appears in the app. */
+const MODES = {
+  local: { arms: ['desktop'], seedRemote: false },
+  remote: { arms: ['serve', 'web'], seedRemote: false },
+  'local-remote': { arms: ['serve', 'desktop'], seedRemote: true },
+  'local-ssh': { arms: ['desktop', 'ssh'], seedRemote: false },
+  'local-remote-ssh': { arms: ['serve', 'desktop', 'ssh'], seedRemote: true }
+}
+
+// Avoid 6768 (packaged serve default) and 6769 (pnpm dev). First serve arm → 6780.
+const SERVE_PORT_BASE = 6780
+const REMOTE_ENV_NAME = 'mode-remote'
+const SERVE_READY_TIMEOUT_MS = 180_000
+
+const cli = parseArgs(process.argv.slice(2))
+if (cli.help || !cli.mode) {
+  printHelp()
+  process.exit(cli.mode ? 0 : cli.help ? 0 : 2)
+}
+const mode = MODES[cli.mode]
+if (!mode) {
+  console.error(
+    `local-test-modes: unknown mode "${cli.mode}". Known: ${Object.keys(MODES).join(', ')}`
+  )
+  process.exit(2)
+}
+
+const runId = Math.random().toString(36).slice(2, 8)
+// Why: macOS binds the daemon at <profile>/daemon/daemon-v24.sock and the sun_path
+// limit is ~104 bytes; the OS temp dir (/var/folders/…) already blows past it, so
+// anchor profiles at a short path. Windows uses named pipes and has no such limit.
+const baseDir = path.join(process.platform === 'win32' ? tmpdir() : '/tmp', 'orca-modes', runId)
+
+const children = []
+let tornDown = false
+
+async function main() {
+  console.error(`[modes] mode=${cli.mode} arms=${mode.arms.join('+')} base=${baseDir}`)
+  if (cli.dryRun) {
+    printPlan()
+    return
+  }
+
+  mkdirSync(baseDir, { recursive: true })
+  installSignalHandlers()
+
+  if (!cli.noBuild) {
+    ensurePrerequisites(mode.arms)
+  }
+
+  let pairing = null
+  // Serve first: the desktop-seed and web arms both consume its pairing code.
+  if (mode.arms.includes('serve')) {
+    pairing = await startServeArm(path.join(baseDir, 'server'), SERVE_PORT_BASE)
+  }
+
+  if (mode.seedRemote && pairing?.pairingUrl) {
+    seedDesktopRuntimeEnvironment(path.join(baseDir, 'desk'), pairing.pairingUrl)
+  }
+
+  if (mode.arms.includes('web')) {
+    openWebClient(pairing)
+  }
+
+  if (mode.arms.includes('ssh')) {
+    prepareSshArm()
+  }
+
+  if (mode.arms.includes('desktop')) {
+    startDesktopArm(path.join(baseDir, 'desk'))
+  }
+
+  printNextSteps(pairing)
+
+  if (children.length === 0) {
+    // A web-only remote mode with no long-lived child we own (browser detaches):
+    // nothing to wait on, so exit cleanly after printing the URL.
+    return
+  }
+  // Keep the orchestrator alive so Ctrl+C tears down every arm together.
+  await new Promise(() => {})
+}
+
+// ── Arms ────────────────────────────────────────────────────────────────────
+
+/** Runs the headless serve wrapper against an isolated profile and resolves once
+ *  it prints its pairing URL. Returns the parsed pairing/web/endpoint strings. */
+function startServeArm(profileDir, port) {
+  mkdirSync(profileDir, { recursive: true })
+  const args = [serveScript, '--port', String(port), '--pairing-address', '127.0.0.1']
+  console.error(`[modes] serve → port ${port}, profile ${profileDir}`)
+  const child = spawn(process.execPath, args, {
+    cwd: repoRoot,
+    detached: process.platform !== 'win32',
+    env: childEnv({ ORCA_HEADLESS_PAIRING_PROFILE_DIR: profileDir }),
+    stdio: ['inherit', 'pipe', 'inherit']
+  })
+  track(child, 'serve')
+
+  const result = { child, pairingUrl: null, webClientUrl: null, endpoint: null, port }
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`serve did not become ready within ${SERVE_READY_TIMEOUT_MS / 1000}s`))
+    }, SERVE_READY_TIMEOUT_MS)
+    const lines = createInterface({ input: child.stdout })
+    lines.on('line', (line) => {
+      process.stdout.write(`[serve] ${line}\n`)
+      const pairing = matchAfter(line, 'Pairing URL:')
+      const web = matchAfter(line, 'Web client URL:')
+      const ready = matchAfter(line, 'Orca server ready:')
+      if (web) {
+        result.webClientUrl = web
+      }
+      if (ready) {
+        result.endpoint = ready
+      }
+      if (pairing) {
+        result.pairingUrl = pairing
+        clearTimeout(timer)
+        resolve(result)
+      }
+    })
+    child.once('exit', (code) => {
+      clearTimeout(timer)
+      if (!result.pairingUrl) {
+        reject(new Error(`serve exited (code ${code ?? 'null'}) before printing a pairing URL`))
+      }
+    })
+  })
+}
+
+function startDesktopArm(profileDir) {
+  mkdirSync(profileDir, { recursive: true })
+  console.error(`[modes] desktop → profile ${profileDir}`)
+  const child = spawn(process.execPath, [runDevScript], {
+    cwd: repoRoot,
+    detached: process.platform !== 'win32',
+    env: childEnv({ ORCA_DEV_USER_DATA_PATH: profileDir }),
+    stdio: 'inherit'
+  })
+  track(child, 'desktop')
+}
+
+function openWebClient(pairing) {
+  if (!pairing?.webClientUrl) {
+    console.error(
+      '[modes] no Web client URL (needs `pnpm build:web` so the server can serve out/web). Pairing URL was printed above.'
+    )
+    return
+  }
+  const opener =
+    process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open'
+  console.error(`[modes] opening web client: ${pairing.webClientUrl}`)
+  const opened = spawnSync(opener, [pairing.webClientUrl], {
+    stdio: 'ignore',
+    shell: process.platform === 'win32'
+  })
+  if (opened.status !== 0) {
+    console.error(
+      `[modes] could not auto-open a browser; open this URL manually:\n  ${pairing.webClientUrl}`
+    )
+  }
+}
+
+/** SSH connect still needs the in-app dialog, but we can make the environment
+ *  ready: build the relay bundle and verify a localhost sshd is reachable. */
+function prepareSshArm() {
+  runPackageScript('build:relay')
+  if (cli.ssh === 'docker') {
+    const hasDocker = spawnSync('docker', ['info'], { stdio: 'ignore' }).status === 0
+    console.error(
+      hasDocker
+        ? '[modes] Docker detected. Use `pnpm test:e2e:ssh-docker-perf` for a throwaway sshd container, or add a host manually.'
+        : '[modes] Docker not running — install/start Docker, or use `--ssh=localhost`.'
+    )
+    return
+  }
+  const reachable =
+    spawnSync('ssh', ['-o', 'BatchMode=yes', '-o', 'ConnectTimeout=4', 'localhost', 'true'], {
+      stdio: 'ignore'
+    }).status === 0
+  if (reachable) {
+    console.error('[modes] localhost sshd reachable with non-interactive auth ✓')
+  } else {
+    console.error(
+      '[modes] localhost SSH not ready. Enable it once:\n' +
+        '  sudo systemsetup -setremotelogin on   # macOS Remote Login\n' +
+        "  ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -N ''   # if you have no key\n" +
+        '  cat ~/.ssh/id_ed25519.pub >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys\n' +
+        '  ssh -o BatchMode=yes localhost true   # must succeed non-interactively'
+    )
+  }
+}
+
+// ── Topology wiring ───────────────────────────────────────────────────────────
+
+/** Writes the runtime server into the desktop profile's saved-server list via the
+ *  supported CLI. Activating it stays a one-click UI step (see printNextSteps). */
+function seedDesktopRuntimeEnvironment(desktopProfile, pairingUrl) {
+  mkdirSync(desktopProfile, { recursive: true })
+  console.error(`[modes] seeding runtime env "${REMOTE_ENV_NAME}" into desktop profile`)
+  const result = spawnSync(
+    process.execPath,
+    [orcaDevScript, 'environment', 'add', '--name', REMOTE_ENV_NAME, '--pairing-code', pairingUrl],
+    { cwd: repoRoot, stdio: 'inherit', env: childEnv({ ORCA_DEV_USER_DATA_PATH: desktopProfile }) }
+  )
+  if (result.status !== 0) {
+    console.error(
+      '[modes] environment add failed; add the server manually via Settings → Runtime Environments.'
+    )
+  }
+}
+
+// ── Build prerequisites ───────────────────────────────────────────────────────
+
+function ensurePrerequisites(arms) {
+  const wantsServe = arms.includes('serve')
+  const wantsDesktop = arms.includes('desktop')
+  // node-pty must load under the Electron ABI for both desktop and serve.
+  if (wantsServe || wantsDesktop) {
+    console.error('[modes] ensuring Electron native runtime (node-pty)…')
+    run(process.execPath, [ensureRuntimeScript, '--runtime=electron'])
+  }
+  // orca-dev CLI (serve launcher + `environment add`).
+  if (wantsServe || arms.includes('web') || mode.seedRemote) {
+    ensureBuilt('build:cli', path.join(repoRoot, 'out', 'cli', 'index.js'))
+  }
+  // serve loads the prebuilt desktop main bundle (electron-vite dev does not).
+  if (wantsServe) {
+    ensureBuilt('build:electron-vite', path.join(repoRoot, 'out', 'main', 'index.js'))
+  }
+  // The runtime only prints a Web client URL when it can serve out/web.
+  if (arms.includes('web')) {
+    ensureBuilt('build:web', path.join(repoRoot, 'out', 'web', 'web-index.html'))
+  }
+  // SSH relay bundle is deployed to the remote host.
+  if (arms.includes('ssh')) {
+    ensureBuilt('build:relay', path.join(repoRoot, 'out', 'relay'))
+  }
+}
+
+function ensureBuilt(script, artifact) {
+  if (existsSync(artifact)) {
+    return
+  }
+  console.error(`[modes] building ${script} (missing ${path.relative(repoRoot, artifact)})…`)
+  runPackageScript(script)
+}
+
+// ── Process helpers ───────────────────────────────────────────────────────────
+
+function childEnv(extra) {
+  const env = { ...process.env, ...extra }
+  if (process.platform === 'darwin') {
+    // Why: launch rebuilds node-pty for the Electron ABI; if a non-Apple c++
+    // (e.g. a corp GCC) is first on PATH it rejects clang's -stdlib=libc++ and the
+    // build fails. Default to Apple clang unless the caller set a compiler.
+    env.CC = env.CC || '/usr/bin/clang'
+    env.CXX = env.CXX || '/usr/bin/clang++'
+  }
+  if (process.platform === 'linux') {
+    // Temp dev profiles have no root-owned chrome-sandbox; local testing only.
+    env.ELECTRON_DISABLE_SANDBOX = env.ELECTRON_DISABLE_SANDBOX || '1'
+  }
+  return env
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, { cwd: repoRoot, stdio: 'inherit', env: childEnv({}) })
+  if (result.status !== 0) {
+    console.error(`[modes] command failed: ${command} ${args.join(' ')}`)
+    cleanup()
+    process.exit(result.status ?? 1)
+  }
+}
+
+function runPackageScript(script) {
+  const pmExec = process.env.npm_execpath
+  if (pmExec) {
+    run(process.execPath, [pmExec, 'run', script])
+    return
+  }
+  const result = spawnSync('pnpm', ['run', script], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    env: childEnv({}),
+    shell: process.platform === 'win32'
+  })
+  if (result.status !== 0) {
+    console.error(`[modes] pnpm run ${script} failed (is pnpm on PATH?).`)
+    cleanup()
+    process.exit(result.status ?? 1)
+  }
+}
+
+function track(child, label) {
+  children.push({ child, label })
+  child.once('exit', (code, signal) => {
+    console.error(`[modes] ${label} exited (code ${code ?? 'null'}${signal ? `, ${signal}` : ''})`)
+  })
+  child.once('error', (error) => {
+    console.error(`[modes] ${label} failed to start: ${error.message}`)
+  })
+}
+
+function installSignalHandlers() {
+  process.on('SIGINT', () => {
+    console.error('\n[modes] stopping…')
+    cleanup()
+    process.exit(0)
+  })
+  process.on('SIGTERM', () => {
+    cleanup()
+    process.exit(0)
+  })
+}
+
+function cleanup() {
+  if (tornDown) {
+    return
+  }
+  tornDown = true
+  for (const { child } of children) {
+    killTree(child)
+  }
+  if (!cli.keep && existsSync(baseDir) && baseDir.includes(path.join('orca-modes', runId))) {
+    try {
+      rmSync(baseDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 })
+      console.error(`[modes] removed ${baseDir}`)
+    } catch (error) {
+      console.error(`[modes] kept ${baseDir} (${error instanceof Error ? error.message : error})`)
+    }
+  } else if (cli.keep) {
+    console.error(`[modes] kept ${baseDir}`)
+  }
+}
+
+function killTree(child) {
+  if (!child || child.killed || child.exitCode !== null) {
+    return
+  }
+  if (process.platform === 'win32' && child.pid) {
+    spawnSync('taskkill', ['/pid', String(child.pid), '/t', '/f'], {
+      stdio: 'ignore',
+      windowsHide: true
+    })
+    return
+  }
+  if (child.pid) {
+    try {
+      // Kill the whole process group (serve/dev own Electron/CLI descendants).
+      process.kill(-child.pid, 'SIGTERM')
+      return
+    } catch {
+      // Group already gone; fall through to a direct kill.
+    }
+  }
+  child.kill('SIGTERM')
+}
+
+// ── Parsing & output ──────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const out = {
+    mode: null,
+    dryRun: false,
+    keep: false,
+    noBuild: false,
+    web: false,
+    ssh: 'localhost',
+    help: false
+  }
+  for (const arg of argv) {
+    if (arg === '-h' || arg === '--help') {
+      out.help = true
+    } else if (arg === '--dry-run') {
+      out.dryRun = true
+    } else if (arg === '--keep') {
+      out.keep = true
+    } else if (arg === '--no-build') {
+      out.noBuild = true
+    } else if (arg === '--web') {
+      out.web = true
+    } else if (arg === '--ssh=docker') {
+      out.ssh = 'docker'
+    } else if (arg === '--ssh=localhost') {
+      out.ssh = 'localhost'
+    } else if (!arg.startsWith('-') && !out.mode) {
+      out.mode = arg
+    } else {
+      console.error(`[modes] ignoring unknown argument: ${arg}`)
+    }
+  }
+  return out
+}
+
+function matchAfter(line, prefix) {
+  const idx = line.indexOf(prefix)
+  if (idx === -1) {
+    return null
+  }
+  const value = line.slice(idx + prefix.length).trim()
+  return value && value !== 'unavailable' ? value : null
+}
+
+function printPlan() {
+  const arms = mode.arms.map((arm) => {
+    if (arm === 'serve') {
+      return `serve → 127.0.0.1:${SERVE_PORT_BASE}, profile ${path.join(baseDir, 'server')}`
+    }
+    if (arm === 'desktop') {
+      return `desktop → profile ${path.join(baseDir, 'desk')}`
+    }
+    if (arm === 'web') {
+      return "web → auto-open the server's Web client URL"
+    }
+    if (arm === 'ssh') {
+      return `ssh (${cli.ssh}) → build relay + reachability check`
+    }
+    return arm
+  })
+  console.error('[modes] DRY RUN — would launch:')
+  for (const line of arms) {
+    console.error(`  • ${line}`)
+  }
+  if (mode.seedRemote) {
+    console.error(`  • seed runtime env "${REMOTE_ENV_NAME}" into the desktop profile`)
+  }
+}
+
+function printNextSteps(pairing) {
+  console.error('\n[modes] ───────────────────────────────────────────────')
+  if (mode.seedRemote) {
+    console.error(
+      `[modes] In the desktop app: Settings → Runtime Environments → connect "${REMOTE_ENV_NAME}"\n` +
+        '[modes] (the remote server is pre-added; one click activates it so repos route to runtime:<env>).'
+    )
+  }
+  if (mode.arms.includes('serve') && pairing?.pairingUrl) {
+    console.error(`[modes] Pairing URL (bearer token — treat as secret):\n  ${pairing.pairingUrl}`)
+  }
+  if (mode.arms.includes('ssh')) {
+    console.error(
+      '[modes] Add the SSH host in the app: sidebar → Add → Remote host (SSH) → host 127.0.0.1, your user, your key.'
+    )
+  }
+  if (children.length > 0) {
+    console.error('[modes] Press Ctrl+C to stop every arm and clean up profiles.')
+  }
+}
+
+function printHelp() {
+  console.log(`Usage: pnpm dev:mode <mode> [flags]
+
+Launch Orca in a local host topology for testing. Modes:
+  local              desktop app only (local host)
+  remote             headless 'orca serve' runtime + auto-paired web client
+  local-remote       desktop app + runtime server (pre-seeded into the app)
+  local-ssh          desktop app + localhost-SSH prep
+  local-remote-ssh   desktop + runtime server + SSH prep
+
+Flags:
+  --dry-run          print the plan (arms/ports/profiles) and exit
+  --keep             keep the temp profiles after exit
+  --no-build         skip auto-building prerequisites (cli/main/web/relay)
+  --ssh=localhost    (default) prepare a localhost SSH host
+  --ssh=docker       check for Docker for a throwaway sshd container
+  -h, --help         show this help
+
+Each host gets an isolated userData profile under a short /tmp path (so the
+macOS daemon UNIX socket stays under the ~104-char limit). See
+docs/local-multi-host-test-modes.md.`)
+}
+
+main().catch((error) => {
+  console.error(`[modes] ${error instanceof Error ? error.message : error}`)
+  cleanup()
+  process.exit(1)
+})

--- a/docs/local-multi-host-test-modes.md
+++ b/docs/local-multi-host-test-modes.md
@@ -1,0 +1,127 @@
+# Local Multi-Host Test Modes
+
+Reproduce Orca's execution-host topologies on a single machine so features can be
+exercised the way users hit them — not just locally. This exists because bugs
+like a runtime-server-only native-chat failure are invisible when you can only
+test the local host.
+
+One orchestrator drives every mode:
+
+```bash
+pnpm dev:mode <mode> [flags]
+```
+
+It composes the existing building blocks (`run-electron-vite-dev.mjs`,
+`serve-headless-fresh-profile-pairing.mjs`, `orca-dev.mjs`); it does not
+reimplement them. Source: [`config/scripts/local-test-modes.mjs`](../config/scripts/local-test-modes.mjs).
+
+## Modes
+
+| Mode | Launches | What it's for |
+|---|---|---|
+| `local` | one desktop app (local host) | Baseline; the default `pnpm dev` experience with an isolated profile. |
+| `remote` | headless `orca serve` runtime + an auto-paired **web** client | Exercise a conversation that lives entirely on a remote Orca Server (execution host `runtime:<env>`). |
+| `local-remote` | desktop app **+** a runtime server, pre-added to the app | Mixed: local repos alongside a remote server in one desktop window. |
+| `local-ssh` | desktop app **+** localhost-SSH prep | Local repos alongside an `ssh:<target>` host. |
+| `local-remote-ssh` | desktop **+** runtime server **+** SSH prep | All three host kinds at once. |
+
+Each host gets its **own isolated `userData` profile** under a short
+`/tmp/orca-modes/<runId>/<arm>` path, so instances never share state and never
+collide. Ports: the desktop app uses the dev default (ws 6769); the runtime
+server uses **6780** (avoiding 6768 packaged / 6769 dev).
+
+## Prerequisites
+
+- `pnpm install` (once). The orchestrator auto-builds anything a mode needs and
+  is missing: `build:cli`, `build:electron-vite` (the `out/main` bundle `orca
+  serve` loads — `electron-vite dev` does **not** produce it), `build:web` (so
+  the server can serve the web client), and `build:relay` (SSH). Pass
+  `--no-build` to skip when you know the artifacts are current.
+- **node-pty / compiler (macOS):** every launch rebuilds `node-pty` for the
+  Electron ABI. If a non-Apple `c++` (e.g. a corporate GCC) is first on `PATH`,
+  the source build fails with `unrecognized command-line option '-stdlib=libc++'`.
+  The harness defaults `CC`/`CXX` to `/usr/bin/clang(++)` on macOS when unset to
+  avoid this. If you still hit it, install the Xcode Command Line Tools
+  (`xcode-select --install`) and make sure `CC`/`CXX` aren't pointed at GCC.
+- **`local-ssh` / `--ssh=localhost`:** a reachable sshd with non-interactive
+  (key or agent) auth. On macOS: `sudo systemsetup -setremotelogin on`, then
+  verify `ssh -o BatchMode=yes localhost true` succeeds.
+- **`--ssh=docker`:** Docker installed and running.
+
+## Runbook
+
+```bash
+# See the plan (arms, ports, profiles) without launching anything:
+pnpm dev:mode local-remote --dry-run
+
+# Local host only:
+pnpm dev:mode local
+
+# Remote Orca Server + auto-paired web client (opens your browser):
+pnpm dev:mode remote
+
+# Local + remote server, pre-added to the desktop app:
+pnpm dev:mode local-remote
+
+# Local + a localhost SSH host (prep only; add the host in-app — see below):
+pnpm dev:mode local-ssh          # or: pnpm dev:mode local-ssh --ssh=docker
+
+# Everything at once:
+pnpm dev:mode local-remote-ssh
+```
+
+`Ctrl+C` stops every arm and removes the temp profiles (pass `--keep` to retain
+them for inspection).
+
+### What's automated vs. one manual step
+
+| Step | Automated? |
+|---|---|
+| Build prerequisites, isolated profiles, process-group teardown | ✅ |
+| `remote`: start server + open the auto-pairing web client | ✅ (the web client pairs from the URL fragment with no paste) |
+| `local-remote`: add the server to the desktop's saved list (`orca environment add`) | ✅ |
+| `local-remote`: **activate** that server in the desktop | ⛱️ one click — **Settings → Runtime Environments → connect "mode-remote"**. There is no CLI/env seam to set the active runtime environment; activating it also fetches the server's repos so they route to `runtime:<env>`. |
+| `local-ssh`: build relay + reachability check | ✅ |
+| `local-ssh`: add/connect the SSH host | ⛱️ in-app — **sidebar → Add → Remote host (SSH)** → host `127.0.0.1`, your user, your key. |
+
+## Troubleshooting
+
+- **Port already in use:** a previous run left a server up. `lsof -ti tcp:6780 |
+  xargs kill`, or the desktop dev port (6769).
+- **macOS `listen EINVAL … daemon-v24.sock`:** the daemon binds
+  `<profile>/daemon/daemon-v24.sock` and macOS caps UNIX socket paths at ~104
+  bytes. The harness anchors profiles at a short `/tmp` path for exactly this
+  reason — don't point profiles at the OS temp dir (`/var/folders/…`), which
+  already overflows the limit and forces non-persistent local PTYs.
+- **Pairing URL is a bearer credential.** The `orca://pair?code=…` the server
+  prints embeds a device token that grants full access — treat server stdout as
+  secret; don't paste it into shared logs.
+- **No "Web client URL":** the server only serves one when `out/web` exists.
+  Re-run without `--no-build`, or `pnpm build:web`.
+
+## Adding a mode / combination
+
+Modes are declarative in `config/scripts/local-test-modes.mjs`:
+
+```js
+const MODES = {
+  'local-remote': { arms: ['serve', 'desktop'], seedRemote: true },
+  // add e.g. a two-server combo:
+  // 'remote-remote': { arms: ['serve', 'serve'], seedRemote: false },
+}
+```
+
+The orchestrator loops arms generically (`desktop` / `serve` / `web` / `ssh`), so
+new combinations are data, not new launch code. Give each additional `serve` arm
+a distinct port.
+
+## Cross-platform notes
+
+- **macOS:** `orca serve` is windowless (no DISPLAY/Xvfb). Dev instances share
+  one bundle id, so notification-click routing across simultaneous desktops is
+  ambiguous — fine for testing.
+- **Linux:** a `serve` arm needs Xvfb + libfuse2 for browser panes (see
+  [`docs/reference/headless-linux-server.md`](./reference/headless-linux-server.md));
+  the harness sets `ELECTRON_DISABLE_SANDBOX=1` for temp dev profiles.
+- **Windows:** SSH modes are POSIX-only; use `local` / `remote`. Teardown uses
+  `taskkill /t /f`. All profile paths use `path.join`.

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "dev": "pnpm run ensure:electron-runtime && node config/scripts/run-electron-vite-dev.mjs",
     "dev-stable-name": "pnpm run ensure:electron-runtime && node config/scripts/run-electron-vite-dev.mjs --stable-name",
     "dev:web": "vite --config vite.web.config.ts --host 127.0.0.1",
+    "dev:mode": "node config/scripts/local-test-modes.mjs",
+    "test:modes": "node config/scripts/local-test-modes.mjs",
     "build:relay": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON config/scripts/build-relay.mjs",
     "build:computer-macos": "node config/scripts/build-computer-macos.mjs",
     "build:keyboard-layout-macos": "node config/scripts/build-keyboard-layout-macos.mjs",


### PR DESCRIPTION
## Summary

Adds a one-command local harness for running Orca in each execution-host topology on a single machine, so bugs that only surface on a **remote** or **SSH** host (e.g. the native-chat-on-a-remote-server bug #9572) can be reproduced without standing up separate infrastructure.

`pnpm dev:mode <mode>` is a single orchestrator ([`config/scripts/local-test-modes.mjs`](https://github.com/stablyai/orca/blob/main/config/scripts/local-test-modes.mjs)) that **composes existing building blocks** (`run-electron-vite-dev.mjs`, `serve-headless-fresh-profile-pairing.mjs`, `orca-dev.mjs`) rather than reimplementing them.

| Mode | Launches |
|---|---|
| `local` | desktop app only (local host) |
| `remote` | headless `orca serve` runtime + auto-paired **web** client (`runtime:<env>`) |
| `local-remote` | desktop **+** runtime server, pre-added to the app |
| `local-ssh` | desktop **+** localhost-SSH prep |
| `local-remote-ssh` | desktop **+** runtime server **+** SSH prep |

Each host gets an isolated `userData` profile; `Ctrl+C` tears every arm down and cleans up. Modes are declarative, so new combinations are data, not code. `--dry-run` prints the plan without launching.

**Two findings baked in (from bringing this up end-to-end):**

- **Short profile path:** macOS caps the daemon's UNIX socket path (`<profile>/daemon/daemon-v24.sock`) at ~104 bytes; the OS temp dir (`/var/folders/…`) already overflows it, which silently downgrades terminals to non-persistent local PTYs. Profiles are anchored under a short `/tmp` path so the socket binds cleanly.
- **Compiler default:** the `node-pty` Electron-ABI rebuild fails when a non-Apple GCC is first on `PATH` (it rejects clang's `-stdlib=libc++`). `CC`/`CXX` default to Apple clang on macOS when unset.

**Automated vs. one manual step (documented honestly):** Fully automated: builds, isolated profiles, teardown, `remote` (server + auto-pairing web client), and seeding the server into the desktop's saved list for `local-remote`. Remaining manual steps (no CLI seam exists): **one click** to activate the runtime env in the desktop (`Settings → Runtime Environments`), and adding the SSH host via the in-app dialog.

Docs: [`docs/local-multi-host-test-modes.md`](https://github.com/stablyai/orca/blob/main/docs/local-multi-host-test-modes.md), linked from `AGENTS.md`.

## Screenshots

No visual change. This PR adds dev tooling (an orchestrator script), docs, and `package.json` scripts only — no renderer/UI source is touched.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Testing notes from the author (dev-tooling script; no automated test suite added):

- `--dry-run` verified for all five modes; `--help` and unknown-mode handling verified.
- **`remote` mode run end-to-end on macOS**: builds `out/web`, starts `orca serve` on the short-path profile (daemon socket binds with **no `EINVAL`**), captures the ready/pairing/web-client URLs, opens the client, and tears down cleanly.
- `oxlint` reported clean; no product source changed (dev tooling + docs only).

## AI Review Report

I reviewed this diff for correctness, edge cases, and cross-platform behavior.

- **Scope / risk:** additive only — a new `.mjs` orchestrator, a docs page, two `package.json` scripts (`dev:mode`, `test:modes`), a `.gitignore` allowlist entry, and an `AGENTS.md` section. No product/runtime source is modified, so the blast radius is limited to local developer tooling.
- **Process lifecycle:** arms are spawned with `detached` on POSIX and torn down via `process.kill(-pid, SIGTERM)` (process group) with a fallback direct kill; Windows uses `taskkill /t /f`. `cleanup()` is guarded by a `tornDown` flag so double-invocation (SIGINT then error path) is safe. The `rmSync` of the profile dir is guarded to only fire when the path contains `orca-modes/<runId>`, which prevents deleting an unexpected directory.
- **Serve readiness:** `startServeArm` resolves on the parsed `Pairing URL:` line with a 180s timeout, and rejects if the child exits before printing one — no indefinite hang. Line parsing via `matchAfter` correctly treats `unavailable` as absent.
- **Edge cases:** web-only `remote` mode with no tracked long-lived child returns cleanly instead of awaiting forever; missing web-client URL degrades to a printed message rather than throwing.
- **Cross-platform compatibility — explicitly checked (macOS / Linux / Windows):** paths use `path.join`/`path.resolve` throughout; the profile base uses `tmpdir()` on Windows and a short `/tmp` anchor on POSIX (deliberate, for the macOS socket-length limit). Browser opener switches `open`/`start`/`xdg-open` and only uses `shell: true` on Windows. Compiler defaults (`CC`/`CXX`) are macOS-only; `ELECTRON_DISABLE_SANDBOX` is Linux-only. Teardown branches per platform. SSH modes are documented as POSIX-only. No keyboard shortcuts or UI labels are touched.

## Security Audit

- **Command execution:** the script spawns child processes (`spawn`/`spawnSync`) for build scripts, `orca serve`, the browser opener, `ssh`, `docker`, and `taskkill`. All arguments are passed as arrays (no shell string interpolation) except the Windows browser-open and `pnpm` fallback, which set `shell: true` but pass fixed/args-arrayed values; the only variable reaching a shell-enabled call is the server-produced web-client URL — low risk in a local dev tool, though worth noting.
- **Secrets:** the pairing URL is a **bearer credential** (`orca://pair?code=…`) that grants full device access. The code and docs correctly flag it as secret and warn against pasting server stdout into shared logs. It is written into the local desktop profile via the supported `orca environment add` CLI and printed to the developer's own terminal — not transmitted elsewhere.
- **Path handling:** temp profile paths are derived from a random `runId` under a fixed base; deletion is guarded (see above).
- **Auth / IPC / dependencies:** no new dependencies, no IPC handlers, no auth logic changed. `ELECTRON_DISABLE_SANDBOX=1` is set for Linux temp dev profiles only and is documented as local-testing-only — not a change to shipped app behavior.

Overall: appropriate for a local developer-tooling script; no shipped-code security surface is affected.

## Notes

- Platform-specific behavior is intentional and documented: macOS short-path/compiler defaults, Linux Xvfb + `ELECTRON_DISABLE_SANDBOX`, Windows `taskkill` teardown and POSIX-only SSH modes.
- Follow-up opportunity noted in the diff itself: activating the runtime environment in the desktop and adding an SSH host still require manual in-app steps because no CLI seam exists yet.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)



## ELI5

pnpm dev:mode starts Orca in local, remote, or SSH-like topologies on one machine. You can reproduce multi-host bugs without spinning up separate servers for each layout.
