### PR TITLE
fix(clipboard): paste copied image files on Windows

### DIFF
--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -18,7 +18,7 @@ const {
   fsWriteFileMock,
   fsStatMock,
   clipboardReadTextMock,
-  clipboardReadMock,
+  clipboardReadBufferMock,
   clipboardWriteTextMock,
   clipboardReadImageMock,
   clipboardWriteImageMock,
@@ -51,7 +51,7 @@ const {
   fsWriteFileMock: vi.fn(),
   fsStatMock: vi.fn(),
   clipboardReadTextMock: vi.fn(),
-  clipboardReadMock: vi.fn(),
+  clipboardReadBufferMock: vi.fn(),
   clipboardWriteTextMock: vi.fn(),
   clipboardReadImageMock: vi.fn(),
   clipboardWriteImageMock: vi.fn(),
@@ -95,7 +95,7 @@ vi.mock('electron', () => ({
   },
   clipboard: {
     readText: clipboardReadTextMock,
-    read: clipboardReadMock,
+    readBuffer: clipboardReadBufferMock,
     writeText: clipboardWriteTextMock,
     readImage: clipboardReadImageMock,
     writeImage: clipboardWriteImageMock,
@@ -195,8 +195,8 @@ describe('registerClipboardHandlers', () => {
     fsStatMock.mockReset()
     fsStatMock.mockResolvedValue({})
     clipboardReadTextMock.mockReset()
-    clipboardReadMock.mockReset()
-    clipboardReadMock.mockReturnValue('')
+    clipboardReadBufferMock.mockReset()
+    clipboardReadBufferMock.mockReturnValue(Buffer.alloc(0))
     clipboardWriteTextMock.mockReset()
     clipboardReadImageMock.mockReset()
     clipboardWriteImageMock.mockReset()
@@ -557,13 +557,13 @@ describe('registerClipboardHandlers', () => {
   it('saves image files copied from Windows Explorer as clipboard images', async () => {
     const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
     const png = Buffer.from([4, 3, 2, 1])
-    const sourcePath = 'C:\\Users\\alice\\Pictures\\copied-image.png'
+    const sourcePath = 'C:\\Users\\alice\\图片\\copied-image.png'
     const expectedPath = join(
       '/tmp',
       'orca-paste-1760000000000-00000000-0000-4000-8000-000000000000.png'
     )
     clipboardReadImageMock.mockReturnValue({ isEmpty: () => true })
-    clipboardReadMock.mockReturnValue(`${sourcePath}\0`)
+    clipboardReadBufferMock.mockReturnValue(Buffer.from(`${sourcePath}\0`, 'utf16le'))
     fsStatMock.mockResolvedValue({ isFile: () => true, size: png.byteLength })
     nativeImageCreateFromPathMock.mockReturnValue({
       getSize: () => ({ height: 1, width: 1 }),
@@ -578,7 +578,7 @@ describe('registerClipboardHandlers', () => {
       await expect(
         handlers.get('clipboard:saveImageAsTempFile')?.(makeClipboardEvent(), undefined)
       ).resolves.toBe(expectedPath)
-      expect(clipboardReadMock).toHaveBeenCalledWith('FileNameW')
+      expect(clipboardReadBufferMock).toHaveBeenCalledWith('FileNameW')
       expect(fsStatMock).toHaveBeenCalledWith(sourcePath)
       expect(nativeImageCreateFromPathMock).toHaveBeenCalledWith(sourcePath)
       expect(fsWriteFileMock).toHaveBeenCalledWith(expectedPath, png)

--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -18,11 +18,13 @@ const {
   fsWriteFileMock,
   fsStatMock,
   clipboardReadTextMock,
+  clipboardReadMock,
   clipboardWriteTextMock,
   clipboardReadImageMock,
   clipboardWriteImageMock,
   clipboardWriteBufferMock,
   nativeImageCreateFromBufferMock,
+  nativeImageCreateFromPathMock,
   randomUUIDMock,
   getSshFilesystemProviderMock,
   callRuntimeEnvironmentMock
@@ -49,11 +51,13 @@ const {
   fsWriteFileMock: vi.fn(),
   fsStatMock: vi.fn(),
   clipboardReadTextMock: vi.fn(),
+  clipboardReadMock: vi.fn(),
   clipboardWriteTextMock: vi.fn(),
   clipboardReadImageMock: vi.fn(),
   clipboardWriteImageMock: vi.fn(),
   clipboardWriteBufferMock: vi.fn(),
   nativeImageCreateFromBufferMock: vi.fn(),
+  nativeImageCreateFromPathMock: vi.fn(),
   randomUUIDMock: vi.fn(() => '00000000-0000-4000-8000-000000000000'),
   getSshFilesystemProviderMock: vi.fn(),
   callRuntimeEnvironmentMock: vi.fn()
@@ -91,6 +95,7 @@ vi.mock('electron', () => ({
   },
   clipboard: {
     readText: clipboardReadTextMock,
+    read: clipboardReadMock,
     writeText: clipboardWriteTextMock,
     readImage: clipboardReadImageMock,
     writeImage: clipboardWriteImageMock,
@@ -101,7 +106,8 @@ vi.mock('electron', () => ({
     handle: handleMock
   },
   nativeImage: {
-    createFromBuffer: nativeImageCreateFromBufferMock
+    createFromBuffer: nativeImageCreateFromBufferMock,
+    createFromPath: nativeImageCreateFromPathMock
   }
 }))
 
@@ -189,11 +195,14 @@ describe('registerClipboardHandlers', () => {
     fsStatMock.mockReset()
     fsStatMock.mockResolvedValue({})
     clipboardReadTextMock.mockReset()
+    clipboardReadMock.mockReset()
+    clipboardReadMock.mockReturnValue('')
     clipboardWriteTextMock.mockReset()
     clipboardReadImageMock.mockReset()
     clipboardWriteImageMock.mockReset()
     clipboardWriteBufferMock.mockReset()
     nativeImageCreateFromBufferMock.mockReset()
+    nativeImageCreateFromPathMock.mockReset()
     randomUUIDMock.mockReset()
     randomUUIDMock.mockReturnValue('00000000-0000-4000-8000-000000000000')
     getSshFilesystemProviderMock.mockReset()
@@ -543,6 +552,39 @@ describe('registerClipboardHandlers', () => {
     ).resolves.toBe(expectedPath)
     expect(fsWriteFileMock).toHaveBeenCalledWith(expectedPath, png)
     expect(getSshFilesystemProviderMock).not.toHaveBeenCalled()
+  })
+
+  it('saves image files copied from Windows Explorer as clipboard images', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const png = Buffer.from([4, 3, 2, 1])
+    const sourcePath = 'C:\\Users\\alice\\Pictures\\copied-image.png'
+    const expectedPath = join(
+      '/tmp',
+      'orca-paste-1760000000000-00000000-0000-4000-8000-000000000000.png'
+    )
+    clipboardReadImageMock.mockReturnValue({ isEmpty: () => true })
+    clipboardReadMock.mockReturnValue(`${sourcePath}\0`)
+    fsStatMock.mockResolvedValue({ isFile: () => true, size: png.byteLength })
+    nativeImageCreateFromPathMock.mockReturnValue({
+      getSize: () => ({ height: 1, width: 1 }),
+      isEmpty: () => false,
+      toPNG: () => png
+    })
+
+    try {
+      registerClipboardHandlers({} as never)
+
+      const handlers = getRegisteredHandlers()
+      await expect(
+        handlers.get('clipboard:saveImageAsTempFile')?.(makeClipboardEvent(), undefined)
+      ).resolves.toBe(expectedPath)
+      expect(clipboardReadMock).toHaveBeenCalledWith('FileNameW')
+      expect(fsStatMock).toHaveBeenCalledWith(sourcePath)
+      expect(nativeImageCreateFromPathMock).toHaveBeenCalledWith(sourcePath)
+      expect(fsWriteFileMock).toHaveBeenCalledWith(expectedPath, png)
+    } finally {
+      platformSpy.mockRestore()
+    }
   })
 
   it('saves clipboard images through the selected remote runtime host', async () => {

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -105,7 +105,7 @@ export function registerClipboardHandlers(store: Store): void {
       if (image.isEmpty()) {
         const copiedFilePng = await readWindowsClipboardImageFileAsPng({
           platform: process.platform,
-          readClipboardFormat: (format) => clipboard.read(format),
+          readClipboardFormatBuffer: (format) => clipboard.readBuffer(format),
           statFile: stat,
           createImageFromPath: (filePath) => nativeImage.createFromPath(filePath)
         })

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -34,6 +34,7 @@ import {
   writeRemoteFileToClipboard
 } from './clipboard-remote-file-copy'
 import { saveClipboardImageBufferInRuntime } from './clipboard-runtime-image-upload'
+import { readWindowsClipboardImageFileAsPng } from './clipboard-windows-image-file'
 
 let trustedClipboardRendererWebContentsId: number | null = null
 
@@ -102,7 +103,13 @@ export function registerClipboardHandlers(store: Store): void {
       assertTrustedClipboardSender(event)
       const image = clipboard.readImage()
       if (image.isEmpty()) {
-        return null
+        const copiedFilePng = await readWindowsClipboardImageFileAsPng({
+          platform: process.platform,
+          readClipboardFormat: (format) => clipboard.read(format),
+          statFile: stat,
+          createImageFromPath: (filePath) => nativeImage.createFromPath(filePath)
+        })
+        return copiedFilePng ? saveClipboardImageBufferForTarget(copiedFilePng, args) : null
       }
       assertClipboardImageDimensionsWithinLimit(image.getSize())
       return saveClipboardImageBufferForTarget(image.toPNG(), args)

--- a/src/main/window/clipboard-windows-image-file.test.ts
+++ b/src/main/window/clipboard-windows-image-file.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest'
+import { CLIPBOARD_IMAGE_MAX_SOURCE_BYTES } from '../../shared/clipboard-image'
+import { readWindowsClipboardImageFileAsPng } from './clipboard-windows-image-file'
+
+function image(png = Buffer.from([1, 2, 3])) {
+  return {
+    getSize: () => ({ height: 10, width: 10 }),
+    isEmpty: () => false,
+    toPNG: () => png
+  }
+}
+
+describe('readWindowsClipboardImageFileAsPng', () => {
+  it('converts a copied Windows image file to bounded PNG bytes', async () => {
+    const filePath = 'C:\\Users\\alice\\Pictures\\shot.PNG'
+    const png = Buffer.from([4, 3, 2, 1])
+    const readClipboardFormat = vi.fn(() => `${filePath}\0`)
+    const statFile = vi.fn(async () => ({ isFile: () => true, size: 1024 }))
+    const createImageFromPath = vi.fn(() => image(png) as never)
+
+    await expect(
+      readWindowsClipboardImageFileAsPng({
+        platform: 'win32',
+        readClipboardFormat,
+        statFile,
+        createImageFromPath
+      })
+    ).resolves.toEqual(png)
+
+    expect(readClipboardFormat).toHaveBeenCalledWith('FileNameW')
+    expect(statFile).toHaveBeenCalledWith(filePath)
+    expect(createImageFromPath).toHaveBeenCalledWith(filePath)
+  })
+
+  it('ignores copied files outside Windows and unsupported file types', async () => {
+    const statFile = vi.fn()
+    const createImageFromPath = vi.fn()
+
+    await expect(
+      readWindowsClipboardImageFileAsPng({
+        platform: 'linux',
+        readClipboardFormat: vi.fn(() => '/tmp/shot.png'),
+        statFile,
+        createImageFromPath
+      })
+    ).resolves.toBeNull()
+    await expect(
+      readWindowsClipboardImageFileAsPng({
+        platform: 'win32',
+        readClipboardFormat: vi.fn(() => 'C:\\Users\\alice\\notes.txt\0'),
+        statFile,
+        createImageFromPath
+      })
+    ).resolves.toBeNull()
+
+    expect(statFile).not.toHaveBeenCalled()
+    expect(createImageFromPath).not.toHaveBeenCalled()
+  })
+
+  it('rejects embedded nulls instead of treating multiple paths as one file', async () => {
+    const statFile = vi.fn()
+
+    await expect(
+      readWindowsClipboardImageFileAsPng({
+        platform: 'win32',
+        readClipboardFormat: vi.fn(() => 'C:\\Users\\alice\\one.png\0C:\\Users\\alice\\two.png\0'),
+        statFile,
+        createImageFromPath: vi.fn()
+      })
+    ).resolves.toBeNull()
+
+    expect(statFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects oversized source files before decoding them', async () => {
+    const createImageFromPath = vi.fn()
+
+    await expect(
+      readWindowsClipboardImageFileAsPng({
+        platform: 'win32',
+        readClipboardFormat: vi.fn(() => 'C:\\Users\\alice\\huge.png\0'),
+        statFile: vi.fn(async () => ({
+          isFile: () => true,
+          size: CLIPBOARD_IMAGE_MAX_SOURCE_BYTES + 1
+        })),
+        createImageFromPath
+      })
+    ).rejects.toThrow('Clipboard image is too large')
+
+    expect(createImageFromPath).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/window/clipboard-windows-image-file.test.ts
+++ b/src/main/window/clipboard-windows-image-file.test.ts
@@ -12,22 +12,22 @@ function image(png = Buffer.from([1, 2, 3])) {
 
 describe('readWindowsClipboardImageFileAsPng', () => {
   it('converts a copied Windows image file to bounded PNG bytes', async () => {
-    const filePath = 'C:\\Users\\alice\\Pictures\\shot.PNG'
+    const filePath = 'C:\\Users\\alice\\图片\\shot.PNG'
     const png = Buffer.from([4, 3, 2, 1])
-    const readClipboardFormat = vi.fn(() => `${filePath}\0`)
+    const readClipboardFormatBuffer = vi.fn(() => Buffer.from(`${filePath}\0`, 'utf16le'))
     const statFile = vi.fn(async () => ({ isFile: () => true, size: 1024 }))
     const createImageFromPath = vi.fn(() => image(png) as never)
 
     await expect(
       readWindowsClipboardImageFileAsPng({
         platform: 'win32',
-        readClipboardFormat,
+        readClipboardFormatBuffer,
         statFile,
         createImageFromPath
       })
     ).resolves.toEqual(png)
 
-    expect(readClipboardFormat).toHaveBeenCalledWith('FileNameW')
+    expect(readClipboardFormatBuffer).toHaveBeenCalledWith('FileNameW')
     expect(statFile).toHaveBeenCalledWith(filePath)
     expect(createImageFromPath).toHaveBeenCalledWith(filePath)
   })
@@ -39,7 +39,7 @@ describe('readWindowsClipboardImageFileAsPng', () => {
     await expect(
       readWindowsClipboardImageFileAsPng({
         platform: 'linux',
-        readClipboardFormat: vi.fn(() => '/tmp/shot.png'),
+        readClipboardFormatBuffer: vi.fn(() => Buffer.from('/tmp/shot.png\0', 'utf16le')),
         statFile,
         createImageFromPath
       })
@@ -47,7 +47,9 @@ describe('readWindowsClipboardImageFileAsPng', () => {
     await expect(
       readWindowsClipboardImageFileAsPng({
         platform: 'win32',
-        readClipboardFormat: vi.fn(() => 'C:\\Users\\alice\\notes.txt\0'),
+        readClipboardFormatBuffer: vi.fn(() =>
+          Buffer.from('C:\\Users\\alice\\notes.txt\0', 'utf16le')
+        ),
         statFile,
         createImageFromPath
       })
@@ -63,7 +65,9 @@ describe('readWindowsClipboardImageFileAsPng', () => {
     await expect(
       readWindowsClipboardImageFileAsPng({
         platform: 'win32',
-        readClipboardFormat: vi.fn(() => 'C:\\Users\\alice\\one.png\0C:\\Users\\alice\\two.png\0'),
+        readClipboardFormatBuffer: vi.fn(() =>
+          Buffer.from('C:\\Users\\alice\\one.png\0C:\\Users\\alice\\two.png\0', 'utf16le')
+        ),
         statFile,
         createImageFromPath: vi.fn()
       })
@@ -78,7 +82,9 @@ describe('readWindowsClipboardImageFileAsPng', () => {
     await expect(
       readWindowsClipboardImageFileAsPng({
         platform: 'win32',
-        readClipboardFormat: vi.fn(() => 'C:\\Users\\alice\\huge.png\0'),
+        readClipboardFormatBuffer: vi.fn(() =>
+          Buffer.from('C:\\Users\\alice\\huge.png\0', 'utf16le')
+        ),
         statFile: vi.fn(async () => ({
           isFile: () => true,
           size: CLIPBOARD_IMAGE_MAX_SOURCE_BYTES + 1
@@ -86,6 +92,25 @@ describe('readWindowsClipboardImageFileAsPng', () => {
         createImageFromPath
       })
     ).rejects.toThrow('Clipboard image is too large')
+
+    expect(createImageFromPath).not.toHaveBeenCalled()
+  })
+
+  it('ignores clipboard files that disappeared before paste', async () => {
+    const createImageFromPath = vi.fn()
+
+    await expect(
+      readWindowsClipboardImageFileAsPng({
+        platform: 'win32',
+        readClipboardFormatBuffer: vi.fn(() =>
+          Buffer.from('C:\\Users\\alice\\missing.png\0', 'utf16le')
+        ),
+        statFile: vi.fn(async () => {
+          throw new Error('ENOENT')
+        }),
+        createImageFromPath
+      })
+    ).resolves.toBeNull()
 
     expect(createImageFromPath).not.toHaveBeenCalled()
   })

--- a/src/main/window/clipboard-windows-image-file.ts
+++ b/src/main/window/clipboard-windows-image-file.ts
@@ -1,0 +1,66 @@
+import { extname, win32 } from 'node:path'
+import type { NativeImage } from 'electron'
+import {
+  assertClipboardImageByteLengthWithinLimit,
+  assertClipboardImageDimensionsWithinLimit
+} from '../../shared/clipboard-image'
+import { IMAGE_FILE_EXTENSIONS } from '../../shared/image-file-extensions'
+
+type ClipboardImageFileStat = {
+  isFile: () => boolean
+  size: number
+}
+
+type ReadWindowsClipboardImageFileDeps = {
+  platform: NodeJS.Platform
+  readClipboardFormat: (format: string) => string
+  statFile: (filePath: string) => Promise<ClipboardImageFileStat>
+  createImageFromPath: (filePath: string) => NativeImage
+}
+
+const IMAGE_FILE_EXTENSION_SET = new Set(IMAGE_FILE_EXTENSIONS)
+
+function decodeWindowsClipboardFileName(value: string): string | null {
+  let end = value.length
+  while (end > 0 && value.charCodeAt(end - 1) === 0) {
+    end -= 1
+  }
+  const filePath = value.slice(0, end)
+  if (!filePath || filePath.includes('\0') || !win32.isAbsolute(filePath)) {
+    return null
+  }
+  return IMAGE_FILE_EXTENSION_SET.has(extname(filePath).toLowerCase()) ? filePath : null
+}
+
+export async function readWindowsClipboardImageFileAsPng({
+  platform,
+  readClipboardFormat,
+  statFile,
+  createImageFromPath
+}: ReadWindowsClipboardImageFileDeps): Promise<Buffer | null> {
+  if (platform !== 'win32') {
+    return null
+  }
+
+  // Why: Explorer copies files as CF_HDROP/FileNameW, not bitmap data, so
+  // clipboard.readImage() cannot see a copied image file.
+  const filePath = decodeWindowsClipboardFileName(readClipboardFormat('FileNameW'))
+  if (!filePath) {
+    return null
+  }
+
+  const file = await statFile(filePath)
+  if (!file.isFile()) {
+    return null
+  }
+  assertClipboardImageByteLengthWithinLimit(file.size)
+
+  const image = createImageFromPath(filePath)
+  if (image.isEmpty()) {
+    return null
+  }
+  assertClipboardImageDimensionsWithinLimit(image.getSize())
+  const png = image.toPNG()
+  assertClipboardImageByteLengthWithinLimit(png.byteLength)
+  return png
+}

--- a/src/main/window/clipboard-windows-image-file.ts
+++ b/src/main/window/clipboard-windows-image-file.ts
@@ -13,19 +13,23 @@ type ClipboardImageFileStat = {
 
 type ReadWindowsClipboardImageFileDeps = {
   platform: NodeJS.Platform
-  readClipboardFormat: (format: string) => string
+  readClipboardFormatBuffer: (format: string) => Buffer
   statFile: (filePath: string) => Promise<ClipboardImageFileStat>
   createImageFromPath: (filePath: string) => NativeImage
 }
 
 const IMAGE_FILE_EXTENSION_SET = new Set(IMAGE_FILE_EXTENSIONS)
 
-function decodeWindowsClipboardFileName(value: string): string | null {
-  let end = value.length
-  while (end > 0 && value.charCodeAt(end - 1) === 0) {
+function decodeWindowsClipboardFileName(value: Buffer): string | null {
+  if (value.byteLength % 2 !== 0) {
+    return null
+  }
+  const decoded = value.toString('utf16le')
+  let end = decoded.length
+  while (end > 0 && decoded.charCodeAt(end - 1) === 0) {
     end -= 1
   }
-  const filePath = value.slice(0, end)
+  const filePath = decoded.slice(0, end)
   if (!filePath || filePath.includes('\0') || !win32.isAbsolute(filePath)) {
     return null
   }
@@ -34,7 +38,7 @@ function decodeWindowsClipboardFileName(value: string): string | null {
 
 export async function readWindowsClipboardImageFileAsPng({
   platform,
-  readClipboardFormat,
+  readClipboardFormatBuffer,
   statFile,
   createImageFromPath
 }: ReadWindowsClipboardImageFileDeps): Promise<Buffer | null> {
@@ -44,12 +48,17 @@ export async function readWindowsClipboardImageFileAsPng({
 
   // Why: Explorer copies files as CF_HDROP/FileNameW, not bitmap data, so
   // clipboard.readImage() cannot see a copied image file.
-  const filePath = decodeWindowsClipboardFileName(readClipboardFormat('FileNameW'))
+  const filePath = decodeWindowsClipboardFileName(readClipboardFormatBuffer('FileNameW'))
   if (!filePath) {
     return null
   }
 
-  const file = await statFile(filePath)
+  let file: ClipboardImageFileStat
+  try {
+    file = await statFile(filePath)
+  } catch {
+    return null
+  }
   if (!file.isFile()) {
     return null
   }


### PR DESCRIPTION
## Summary
- allow Windows users to paste image files copied from Explorer into terminal and native chat composers
- decode the Windows `FileNameW` clipboard path into bounded PNG bytes before using the existing local, SSH, or runtime attachment flow
- preserve the existing bitmap clipboard behavior and non-Windows behavior

## Screenshots

No visual change.

## Testing
- [ ] `pnpm lint` — blocked by pre-existing switch-exhaustiveness failures in `src/main/daemon/daemon-server.ts:652` and `src/renderer/src/components/skills/skill-freshness-group.tsx:101`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — local setup cannot load `windows-native-registry/build/Release/native.node` before Vitest starts
- [x] `pnpm build`
- [x] Added or updated high-quality tests that fail without the change and pass with it
- [x] Targeted Vitest run: 4 files, 51 tests passed
- [x] `pnpm run check:max-lines-ratchet`
- [x] `pnpm run check:reliability-gates`
- [x] Commit hooks: oxlint, React Doctor rules, and oxfmt

## AI Review Report

Reviewed the diff for correctness, error handling, performance, cross-platform behavior, local/SSH/runtime behavior, and supported-agent behavior.

- Cross-platform: the fallback is hard-gated to Windows; macOS and Linux keep the existing `clipboard.readImage()` behavior.
- SSH/runtime: copied files are converted to PNG bytes and passed through the existing target-aware save/upload function.
- Agents: the change is in the shared clipboard IPC path used by terminal and native chat paste flows, rather than a Codex-specific path.
- Performance: file size is checked before image decoding; decoded dimensions and PNG output size use the existing clipboard limits.
- Edge cases: rejects empty, relative, unsupported, multi-path/embedded-NUL, non-file, oversized, and undecodable clipboard entries.

## Security Audit

- The trusted-renderer IPC check remains unchanged.
- No shell execution, authentication, secrets, dependencies, or network behavior were added.
- The Windows clipboard path must be absolute, point to a file, use a supported image extension, and satisfy existing byte and dimension limits.
- The source path is only read in response to the existing paste IPC and is materialized through the established bounded image path.
- No security follow-up is required.

## Notes

- This intentionally handles a single image file copied through Windows Explorer's `FileNameW` clipboard format. Multi-file clipboard payloads remain ignored.
- X handle: not provided.