### PR TITLE
fix(worktree): tolerate dead legacy daemon generations during worktree removal (#9569)

### DIFF
--- a/src/main/daemon/daemon-pty-router.test.ts
+++ b/src/main/daemon/daemon-pty-router.test.ts
@@ -265,6 +265,41 @@ describe('DaemonPtyRouter', () => {
     expect(current.hasPty).not.toHaveBeenCalledWith('legacy-session')
   })
 
+  it.each(['connect', 'open'])(
+    'treats a dead legacy daemon ENOENT %s as an already-stopped session',
+    async (syscall) => {
+      const current = createAdapter('current')
+      const legacy = createAdapter('legacy', ['legacy-session'])
+      vi.mocked(legacy.shutdown).mockRejectedValueOnce(
+        Object.assign(new Error(`legacy ${syscall} missing`), { code: 'ENOENT', syscall })
+      )
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const router = new DaemonPtyRouter({ current, legacy: [legacy] })
+      await router.discoverLegacySessions()
+
+      await expect(router.shutdown('legacy-session', { immediate: true })).resolves.toBeUndefined()
+      expect(legacy.shutdown).toHaveBeenCalledWith('legacy-session', { immediate: true })
+      expect(current.shutdown).not.toHaveBeenCalled()
+      expect(warn).toHaveBeenCalledWith(
+        '[daemon] Legacy daemon endpoint disappeared during session shutdown',
+        expect.objectContaining({ code: 'ENOENT', syscall })
+      )
+      warn.mockRestore()
+    }
+  )
+
+  it('still fails shutdown when the current daemon endpoint is missing', async () => {
+    const current = createAdapter('current', ['current-session'])
+    const error = Object.assign(new Error('current socket missing'), {
+      code: 'ENOENT',
+      syscall: 'connect'
+    })
+    vi.mocked(current.shutdown).mockRejectedValueOnce(error)
+    const router = new DaemonPtyRouter({ current, legacy: [] })
+
+    await expect(router.shutdown('current-session', { immediate: true })).rejects.toBe(error)
+  })
+
   it('fails listProcesses closed when any routed adapter cannot list sessions', async () => {
     const current = createAdapter('current', ['current-session'])
     const legacy = createAdapter('legacy', ['legacy-session'])
@@ -272,6 +307,55 @@ describe('DaemonPtyRouter', () => {
     const router = new DaemonPtyRouter({ current, legacy: [legacy] })
 
     await expect(router.listProcesses()).rejects.toThrow('legacy unavailable')
+  })
+
+  it.each(['connect', 'open'])(
+    'ignores a dead legacy daemon with an ENOENT %s failure',
+    async (syscall) => {
+      const current = createAdapter('current', ['current-session'])
+      const legacy = createAdapter('legacy', ['legacy-session'])
+      vi.mocked(legacy.listProcesses).mockRejectedValueOnce(
+        Object.assign(new Error(`legacy ${syscall} missing`), { code: 'ENOENT', syscall })
+      )
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const router = new DaemonPtyRouter({ current, legacy: [legacy] })
+
+      await expect(router.listProcesses()).resolves.toEqual([
+        { id: 'current-session', cwd: '', title: 'current' }
+      ])
+      expect(legacy.listProcesses).toHaveBeenCalledOnce()
+      expect(warn).toHaveBeenCalledWith(
+        '[daemon] Legacy daemon endpoint disappeared during session inventory',
+        expect.objectContaining({ code: 'ENOENT', syscall })
+      )
+      warn.mockRestore()
+    }
+  )
+
+  it('still fails listProcesses when the current daemon endpoint is missing', async () => {
+    const current = createAdapter('current', ['current-session'])
+    const legacy = createAdapter('legacy', ['legacy-session'])
+    const error = Object.assign(new Error('current socket missing'), {
+      code: 'ENOENT',
+      syscall: 'connect'
+    })
+    vi.mocked(current.listProcesses).mockRejectedValueOnce(error)
+    const router = new DaemonPtyRouter({ current, legacy: [legacy] })
+
+    await expect(router.listProcesses()).rejects.toBe(error)
+    expect(legacy.listProcesses).toHaveBeenCalledOnce()
+  })
+
+  it('contacts and includes a live legacy daemon during session inventory', async () => {
+    const current = createAdapter('current', ['current-session'])
+    const legacy = createAdapter('legacy', ['legacy-session'])
+    const router = new DaemonPtyRouter({ current, legacy: [legacy] })
+
+    await expect(router.listProcesses()).resolves.toEqual([
+      { id: 'current-session', cwd: '', title: 'current' },
+      { id: 'legacy-session', cwd: '', title: 'legacy' }
+    ])
+    expect(legacy.listProcesses).toHaveBeenCalledOnce()
   })
 
   it('merges startup reconciliation and updates route mappings', async () => {

--- a/src/main/daemon/daemon-pty-router.ts
+++ b/src/main/daemon/daemon-pty-router.ts
@@ -105,7 +105,17 @@ export class DaemonPtyRouter implements IPtyProvider {
     id: string,
     opts: { immediate?: boolean; keepHistory?: boolean; deadlineMs?: number }
   ): Promise<void> {
-    await this.adapterFor(id).shutdown(id, opts)
+    const adapter = this.adapterFor(id)
+    try {
+      await adapter.shutdown(id, opts)
+    } catch (error) {
+      if (adapter === this.current || !isMissingLegacyDaemonEndpointError(error)) {
+        throw error
+      }
+      console.warn('[daemon] Legacy daemon endpoint disappeared during session shutdown', error)
+      this.sessionAdapters.delete(id)
+      return
+    }
     // Why: sleep passes keepHistory=true and re-spawns against the same
     // sessionId on wake. If we delete the routing entry here, adapterFor()
     // falls back to `this.current` on wake — for a session that originally
@@ -177,11 +187,27 @@ export class DaemonPtyRouter implements IPtyProvider {
   }
 
   async listProcesses(opts?: { deadlineMs?: number }): Promise<PtyProcessInfo[]> {
-    // Why: runtime exact-stop/liveness flows must fail closed if any adapter
-    // cannot provide a trustworthy process list.
-    const results = await Promise.all(
-      this.allAdapters().map((adapter) => adapter.listProcesses(opts))
-    )
+    // Why: runtime exact-stop/liveness flows fail closed for the current daemon
+    // and live legacy daemons. A legacy endpoint whose socket/token disappeared
+    // cannot own a live session, so treating ENOENT as an empty inventory lets
+    // destructive worktree teardown proceed after an upgrade.
+    const results = await Promise.all([
+      this.current.listProcesses(opts),
+      ...this.legacy.map(async (adapter) => {
+        try {
+          return await adapter.listProcesses(opts)
+        } catch (error) {
+          if (!isMissingLegacyDaemonEndpointError(error)) {
+            throw error
+          }
+          console.warn(
+            '[daemon] Legacy daemon endpoint disappeared during session inventory',
+            error
+          )
+          return []
+        }
+      })
+    ])
     return results.flat()
   }
 
@@ -324,4 +350,13 @@ export class DaemonPtyRouter implements IPtyProvider {
   private allAdapters(): DaemonPtyAdapter[] {
     return [this.current, ...this.legacy]
   }
+}
+
+function isMissingLegacyDaemonEndpointError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT' &&
+    ((error as NodeJS.ErrnoException).syscall === 'connect' ||
+      (error as NodeJS.ErrnoException).syscall === 'open')
+  )
 }


### PR DESCRIPTION
## Summary

Fixes #9569 by allowing destructive worktree teardown to continue when a legacy daemon generation has already disappeared.

## Root cause

Terminal records can remain routed to a previous daemon protocol generation after an Orca upgrade. Worktree removal inventories and stops those terminals across every daemon adapter, but `DaemonPtyRouter` previously failed closed when a retired legacy adapter could no longer read its token (`open ENOENT`) or connect to its socket (`connect ENOENT`). That aborted removal even though the missing endpoint proves the legacy daemon and its sessions are already dead.

## Fix

- Treat socket/token ENOENT failures from legacy adapters as an empty process inventory.
- Treat the same failures while shutting down a legacy-routed session as an already-stopped session and clear its stale routing entry.
- Warn when either legacy condition is encountered.
- Preserve fail-closed behavior for the current daemon and for non-ENOENT legacy failures.
- Continue contacting live legacy daemons and include their sessions normally.

## Tests

- `pnpm vitest run --config config/vitest.config.ts src/main/daemon/daemon-pty-router.test.ts src/main/runtime/worktree-teardown.test.ts` (46 passed)
- `pnpm run typecheck:node`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
