### PR TITLE
fix(skills): make skippedReason switch exhaustive

### DIFF
--- a/src/renderer/src/components/skills/skill-freshness-group.tsx
+++ b/src/renderer/src/components/skills/skill-freshness-group.tsx
@@ -134,7 +134,11 @@ function skippedReason(locations: readonly SkillLocationRow[]): string {
         'auto.components.skills.SkillFreshnessRow.skippedReasonBrokenLink',
         'This copy is a shortcut to something that no longer exists, so Orca left it out — you can safely delete it.'
       )
-    default:
+    // Why: 'current'/'duplicate' are non-blocking chips, and an empty priority
+    // list is possible; all fall through to the generic skipped message.
+    case 'current':
+    case 'duplicate':
+    case undefined:
       return translate(
         'auto.components.skills.SkillFreshnessRow.cantUpdateReason',
         'Orca left this skill out of the update command.'


### PR DESCRIPTION
## Summary

Fixes #9589.

Adds explicit `'current'`, `'duplicate'`, and `undefined` cases to the `skippedReason` switch in `skill-freshness-group.tsx`. The type-aware `switch-exhaustiveness` lint rule (`pnpm run lint:switch-exhaustiveness`) requires them; all three fall through to the existing generic skipped message, so behavior is unchanged.

No visual change.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — passes for the changed file; the repo-wide type-aware run now reports only the pre-existing `daemon-server.ts:652` violation that also exists on `main` (untouched here). CI's lint step (non-type-aware `oxlint`) is green.
- [x] `pnpm typecheck`
- [x] `pnpm test` — not run in full; change is a no-op branch through the same `default` path, covered by existing lint/typecheck
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed — not needed: behavior is unchanged; the compiler/lint now verifies exhaustiveness of this switch

## AI Review Report

Reviewed the change with the coding agent for cross-platform compatibility (macOS/Linux/Windows — pure TS switch, no platform surface), SSH/remote/local compatibility (renderer-only), agent/integration compatibility (none), performance (none — same code path, explicit cases fall through identically), UI quality (no visual change), and basic security (no input handling changes). No flags; nothing to change as a result.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC surface touched. No follow-up.

## Notes

- `main` currently has one more pre-existing violation of the same rule in `src/main/daemon/daemon-server.ts:652` (`closeStartupQueryAuthority`). Left alone deliberately — unrelated to this fix and the rule is not CI-enforced.
- X: [@zuz666](https://x.com/zuz666)
