### PR TITLE
fix(ui): use focusable tooltip menu triggers

### DIFF
--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -877,23 +877,20 @@ export function ActivityThreadOptionsMenu({
     <DropdownMenu>
       <Tooltip>
         <TooltipTrigger asChild>
-          {/* Why: keep Tooltip and Dropdown from composing refs onto the same button (Radix setRef crash loop). */}
-          <span className="inline-flex shrink-0">
-            <DropdownMenuTrigger asChild>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="size-8 shrink-0 border-input bg-transparent p-0 text-muted-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-transparent dark:hover:bg-accent dark:hover:text-accent-foreground"
-                aria-label={translate(
-                  'auto.components.activity.ActivityPrototypePage.db8a1878b5',
-                  'Thread list options'
-                )}
-              >
-                <MoreVertical className="size-3.5" />
-              </Button>
-            </DropdownMenuTrigger>
-          </span>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="size-8 shrink-0 border-input bg-transparent p-0 text-muted-foreground shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-transparent dark:hover:bg-accent dark:hover:text-accent-foreground"
+              aria-label={translate(
+                'auto.components.activity.ActivityPrototypePage.db8a1878b5',
+                'Thread list options'
+              )}
+            >
+              <MoreVertical className="size-3.5" />
+            </Button>
+          </DropdownMenuTrigger>
         </TooltipTrigger>
         <TooltipContent side="bottom">
           {translate('auto.components.activity.ActivityPrototypePage.a472a14700', 'More options')}

--- a/src/renderer/src/components/activity/ActivityThreadOptionsMenu.test.tsx
+++ b/src/renderer/src/components/activity/ActivityThreadOptionsMenu.test.tsx
@@ -44,7 +44,7 @@ describe('ActivityThreadOptionsMenu', () => {
     document.body.replaceChildren()
   })
 
-  it('opens without recursively updating composed Radix trigger refs', async () => {
+  it('opens with direct composed Tooltip and Dropdown triggers', async () => {
     await act(async () => {
       root.render(<Harness />)
     })
@@ -54,7 +54,7 @@ describe('ActivityThreadOptionsMenu', () => {
     )
 
     expect(trigger).not.toBeNull()
-    expect(trigger?.parentElement?.tagName).toBe('SPAN')
+    expect(trigger?.parentElement?.tagName).not.toBe('SPAN')
 
     await act(async () => {
       trigger?.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' }))

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -6710,28 +6710,30 @@ export function CommitArea({
           <DropdownMenu>
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="inline-flex shrink-0">
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="xs"
-                      className={cn(
-                        'rounded-l-none border-l border-border px-1.5 shrink-0',
-                        // Why: mirror the primary's disabled dimming for a unified look, but the chevron stays clickable (its push/fetch/pull stay valid when Commit is disabled).
-                        primaryAction.disabled && 'opacity-50'
-                      )}
-                      aria-label={moreCommitAndRemoteActionsLabel}
-                      title={moreActionsLabel}
-                    >
-                      {showChevronSpinner ? (
-                        <Loader2 className="size-3.5 animate-spin" />
-                      ) : (
-                        <ChevronDown className="size-3.5" />
-                      )}
-                    </Button>
-                  </DropdownMenuTrigger>
-                </span>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="xs"
+                    className={cn(
+                      'rounded-l-none border-l border-border px-1.5 shrink-0',
+                      // Why: mirror the primary's disabled dimming so the split
+                      // button reads as one unit when Commit is unavailable. The
+                      // chevron itself stays clickable — its dropdown exposes
+                      // independently-gated remote actions (push / fetch / pull)
+                      // that are still valid when the primary is disabled.
+                      primaryAction.disabled && 'opacity-50'
+                    )}
+                    aria-label={moreCommitAndRemoteActionsLabel}
+                    title={moreActionsLabel}
+                  >
+                    {showChevronSpinner ? (
+                      <Loader2 className="size-3.5 animate-spin" />
+                    ) : (
+                      <ChevronDown className="size-3.5" />
+                    )}
+                  </Button>
+                </DropdownMenuTrigger>
               </TooltipTrigger>
               <TooltipContent side="top" sideOffset={6}>
                 {moreCommitAndRemoteActionsLabel}

--- a/src/renderer/src/components/right-sidebar/source-control-header-overflow-menu.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control-header-overflow-menu.tsx
@@ -40,22 +40,20 @@ export function SourceControlHeaderOverflowMenu({
     <DropdownMenu>
       <Tooltip>
         <TooltipTrigger asChild>
-          <span className="inline-flex shrink-0">
-            <DropdownMenuTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-xs"
-                className="size-7 text-muted-foreground hover:text-foreground"
-                aria-label={translate(
-                  'auto.components.right.sidebar.SourceControl.f71c4a8d90',
-                  'More source control actions'
-                )}
-              >
-                <MoreHorizontal className="size-3.5" />
-              </Button>
-            </DropdownMenuTrigger>
-          </span>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              className="size-7 text-muted-foreground hover:text-foreground"
+              aria-label={translate(
+                'auto.components.right.sidebar.SourceControl.f71c4a8d90',
+                'More source control actions'
+              )}
+            >
+              <MoreHorizontal className="size-3.5" />
+            </Button>
+          </DropdownMenuTrigger>
         </TooltipTrigger>
         <TooltipContent side="bottom" sideOffset={6}>
           {translate(

--- a/tests/e2e/tooltip-dropdown-trigger-stability.spec.ts
+++ b/tests/e2e/tooltip-dropdown-trigger-stability.spec.ts
@@ -1,0 +1,220 @@
+import type { ConsoleMessage, Locator, Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { openFileExplorer } from './helpers/file-explorer'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+type RendererErrors = {
+  pageErrors: string[]
+  consoleErrors: string[]
+  stop: () => void
+}
+
+function captureRendererErrors(page: Page): RendererErrors {
+  const pageErrors: string[] = []
+  const consoleErrors: string[] = []
+  const onPageError = (error: Error): void => {
+    pageErrors.push(error.message)
+  }
+  const onConsole = (message: ConsoleMessage): void => {
+    if (message.type() === 'error') {
+      consoleErrors.push(message.text())
+    }
+  }
+  page.on('pageerror', onPageError)
+  page.on('console', onConsole)
+  return {
+    pageErrors,
+    consoleErrors,
+    stop: () => {
+      page.off('pageerror', onPageError)
+      page.off('console', onConsole)
+    }
+  }
+}
+
+async function expectTooltipOwnedByButton(
+  page: Page,
+  button: Locator,
+  tooltipText: string
+): Promise<void> {
+  await button.focus()
+  const tooltip = page.getByRole('tooltip').filter({ hasText: tooltipText }).last()
+  await expect(tooltip).toBeVisible({ timeout: 3_000 })
+  await expect
+    .poll(
+      () =>
+        button.evaluate((element) => {
+          const describedBy = element.getAttribute('aria-describedby')?.split(/\s+/) ?? []
+          return describedBy.some((id) => {
+            const description = document.getElementById(id)
+            return (
+              description?.getAttribute('role') === 'tooltip' && description.offsetParent !== null
+            )
+          })
+        }),
+      { timeout: 3_000 }
+    )
+    .toBe(true)
+
+  await page.mouse.move(1, 1)
+  await button.evaluate((element) => (element as HTMLElement).blur())
+  await expectTooltipDismissed(page, tooltipText)
+
+  await button.hover()
+  await expect(tooltip).toBeVisible({ timeout: 3_000 })
+  await page.mouse.move(1, 1)
+  await expectTooltipDismissed(page, tooltipText)
+}
+
+// Why: getByRole('tooltip') hits Radix's aria span that lingers through the throttled
+// exit animation; the content's data-state flips to 'closed' immediately on dismiss.
+async function expectTooltipDismissed(page: Page, tooltipText: string): Promise<void> {
+  const content = page.locator('[data-slot="tooltip-content"]').filter({ hasText: tooltipText })
+  await expect
+    .poll(
+      async () => {
+        // Why: leftover closing tooltips can also match the filter.
+        const states = await content.evaluateAll((elements) =>
+          elements.map((element) => element.getAttribute('data-state'))
+        )
+        return states.every((state) => state === 'closed')
+      },
+      { timeout: 5_000 }
+    )
+    .toBe(true)
+}
+
+async function exerciseTooltipMenuControl(
+  page: Page,
+  button: Locator,
+  tooltipText: string
+): Promise<void> {
+  await expectTooltipOwnedByButton(page, button, tooltipText)
+
+  await button.click()
+  const menu = page.getByRole('menu').last()
+  await expect(menu).toBeVisible()
+  await page.keyboard.press('Escape')
+  await expect(menu).toBeHidden()
+
+  await button.click()
+  await expect(menu).toBeVisible()
+  await page.keyboard.press('Escape')
+  await expect(menu).toBeHidden()
+}
+
+async function closeFileExplorer(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    window.__store?.getState().setRightSidebarTab('source-control')
+  })
+  await expect(page.getByRole('button', { name: 'More Explorer Actions' })).toHaveCount(0)
+}
+
+async function openActivity(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const settings = await window.api.settings.set({ experimentalActivity: true })
+    window.__store?.setState({ settings })
+  })
+  const agents = page.getByRole('button', { name: /^Agents(?:\s+\d+)?$/ }).first()
+  await expect(agents).toBeVisible()
+  await agents.click()
+  await expect(page.getByRole('button', { name: 'Thread list options' })).toBeVisible()
+}
+
+async function closeActivity(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    window.__store?.getState().closeActivityPage()
+  })
+  await expect(page.getByRole('button', { name: 'Thread list options' })).toHaveCount(0)
+}
+
+const SOURCE_CONTROL_TRIGGER_CASES = [
+  ['More source control actions', 'More source control actions'],
+  ['More commit and remote actions', 'More commit and remote actions']
+] as const
+
+async function openSourceControl(page: Page): Promise<void> {
+  const sourceControl = page.getByRole('button', { name: /^Source Control/ }).first()
+  await expect(sourceControl).toBeVisible()
+  await sourceControl.click()
+  for (const [label] of SOURCE_CONTROL_TRIGGER_CASES) {
+    await expect(page.getByRole('button', { name: label })).toBeVisible({ timeout: 10_000 })
+  }
+}
+
+async function closeSourceControl(page: Page): Promise<void> {
+  const explorer = page.getByRole('button', { name: /^Explorer/ }).first()
+  await expect(explorer).toBeVisible()
+  await explorer.click()
+  for (const [label] of SOURCE_CONTROL_TRIGGER_CASES) {
+    await expect(page.getByRole('button', { name: label })).toHaveCount(0)
+  }
+}
+
+function expectNoRendererErrors(errors: RendererErrors): void {
+  expect(errors.pageErrors, `pageerror: ${errors.pageErrors.join('\n')}`).toEqual([])
+  expect(errors.consoleErrors, `console.error: ${errors.consoleErrors.join('\n')}`).toEqual([])
+}
+
+test.describe('Tooltip and menu trigger stability', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+  })
+
+  test('direct File Explorer trigger survives focus, hover, menus, and remounts', async ({
+    orcaPage
+  }) => {
+    const errors = captureRendererErrors(orcaPage)
+    try {
+      for (let cycle = 0; cycle < 2; cycle += 1) {
+        await openFileExplorer(orcaPage)
+        const button = orcaPage.getByRole('button', { name: 'More Explorer Actions' })
+        await expect(button).toBeVisible()
+        await exerciseTooltipMenuControl(orcaPage, button, 'More Explorer Actions')
+        await closeFileExplorer(orcaPage)
+      }
+      expectNoRendererErrors(errors)
+    } finally {
+      errors.stop()
+    }
+  })
+
+  test('Activity trigger keeps tooltip ownership through menu remounts', async ({ orcaPage }) => {
+    const errors = captureRendererErrors(orcaPage)
+    try {
+      for (let cycle = 0; cycle < 2; cycle += 1) {
+        await openActivity(orcaPage)
+        const button = orcaPage.getByRole('button', { name: 'Thread list options' })
+        await exerciseTooltipMenuControl(orcaPage, button, 'More options')
+        await closeActivity(orcaPage)
+      }
+      expectNoRendererErrors(errors)
+    } finally {
+      errors.stop()
+    }
+  })
+
+  test('Source Control compound triggers survive focus, menus, and remounts', async ({
+    orcaPage
+  }) => {
+    const errors = captureRendererErrors(orcaPage)
+    test.setTimeout(240_000)
+    try {
+      for (let cycle = 0; cycle < 2; cycle += 1) {
+        await openSourceControl(orcaPage)
+        for (const [label, tooltip] of SOURCE_CONTROL_TRIGGER_CASES) {
+          await exerciseTooltipMenuControl(
+            orcaPage,
+            orcaPage.getByRole('button', { name: label }),
+            tooltip
+          )
+        }
+        await closeSourceControl(orcaPage)
+      }
+      expectNoRendererErrors(errors)
+    } finally {
+      errors.stop()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #9590.

Several `Tooltip` + `DropdownMenu` trigger compositions (Activity thread options menu, Source Control header overflow menu, the commit-area split button) wrapped the trigger in a `<span>` between `TooltipTrigger` and `DropdownMenuTrigger`, so the tooltip's accessibility props attached to the wrapper instead of the actual button and keyboard focus did not reliably surface the tooltip.

This composes the triggers directly on the button — `TooltipTrigger asChild` → `DropdownMenuTrigger asChild` → `Button` — matching the pattern documented in `docs/STYLEGUIDE.md` (a wrapper is only allowed for natively-disabled controls). Focus/hover now surface the tooltip with correct `aria-describedby` ownership, verified by a new Playwright stability spec that cycles focus, hover, menu open/close, and remounts for each affected control.

No visual design change (behavior/accessibility fix only).

## Screenshots

Keyboard focus on the Source Control overflow trigger surfaces the app tooltip on the actual button:

![Keyboard-focus tooltip on Source Control actions](https://raw.githubusercontent.com/Zuz666/orca/2d67d8516aab0646731bd6d692d57832142b71eb/shots/pr1-focus-tooltip.png)

## Testing

- [x] `pnpm lint` — `oxlint` clean on touched files (repo-wide type-aware switch-exhaustiveness still reports the pre-existing `daemon-server.ts:652` violation that exists on `main`; not CI-enforced)
- [x] `pnpm typecheck`
- [x] `pnpm test` — `ActivityThreadOptionsMenu.test.tsx` passes
- [x] `pnpm build` — app builds and the new e2e spec passes 3/3 under `electron-headless`
- [x] Added or updated high-quality tests that would catch regressions — `tests/e2e/tooltip-dropdown-trigger-stability.spec.ts` covers tooltip ownership (`aria-describedby`), focus/hover open, and dismissal for the File Explorer, Activity, and Source Control compound triggers. The dismissal assertion targets the visual `[data-slot="tooltip-content"]` `data-state`, so it does not race exit-animation timing in hidden headless windows

## AI Review Report

Reviewed with the coding agent for cross-platform compatibility (macOS/Linux/Windows — the composition is platform-neutral Radix usage; no shortcut/label/path changes), SSH/remote/local compatibility (renderer-only), agent/integration compatibility (none), performance (none — one less wrapper element per trigger), UI quality (matches the STYLEGUIDE trigger pattern; e2e proves keyboard-focus tooltips and menu remount stability), and basic security (no new surface). One flag during review — that a hidden-headless-window exit-animation delay could make dismissal assertions flaky — addressed by asserting on the content `data-state` rather than unmount timing.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes. No follow-up.

## Notes

- The Git History panel's overflow menu gets the same composition where it is created (in the follow-up feature PR), so it is not part of this standalone fix.
- X: [@zuz666](https://x.com/zuz666)



## ELI5

Some header menus wrapped buttons so keyboard focus did not show tooltips correctly. Tooltip and menu triggers sit on the real button so focus and accessibility props work as intended.
