### PR TITLE
fix(terminal): gate xterm contrast correction by terminal background luminance (#7934)

### DIFF
--- a/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
@@ -8,7 +8,7 @@ import { buildDefaultTerminalOptions } from '@/lib/pane-manager/pane-terminal-op
 import { buildFontFamily } from '@/components/terminal-pane/layout-serialization'
 import { composeActiveTerminalTheme } from '@/components/terminal-pane/terminal-appearance'
 import { clampNumber, resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
-import { isTerminalBackgroundLight } from '@/lib/terminal-title-contrast'
+import { resolveTerminalMinimumContrastRatio } from '@/lib/terminal-contrast-correction'
 import { resolveTerminalFontWeights } from '../../../../shared/terminal-fonts'
 import { resolveTerminalLigaturesEnabled } from '../../../../shared/terminal-ligatures'
 import { normalizeTerminalLineHeight } from '../../../../shared/terminal-line-height-settings'
@@ -196,12 +196,11 @@ export function TerminalSettingsPreview({
       return
     }
     terminal.options.theme = composedTheme
-    // Why: mirror applyTerminalAppearance's background-luminance gating (#7934) so the preview matches live panes.
-    terminal.options.minimumContrastRatio = isTerminalBackgroundLight(composedTheme.background, {
-      appSurface: effectiveMode
-    })
-      ? 4.5
-      : 1
+    // Why: share applyTerminalAppearance's gating helper (#7934) so the preview can't drift from live panes.
+    terminal.options.minimumContrastRatio = resolveTerminalMinimumContrastRatio(
+      composedTheme.background,
+      effectiveMode
+    )
     // Why: xterm renders an alpha-channel background opaque unless allowTransparency is set (matches applyTerminalAppearance).
     terminal.options.allowTransparency =
       settings.terminalBackgroundOpacity !== undefined && settings.terminalBackgroundOpacity < 1

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
@@ -8,6 +8,7 @@ import { buildDefaultTerminalOptions } from '@/lib/pane-manager/pane-terminal-op
 import { buildFontFamily } from '@/components/terminal-pane/layout-serialization'
 import { composeActiveTerminalTheme } from '@/components/terminal-pane/terminal-appearance'
 import { clampNumber, resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
+import { isTerminalBackgroundLight } from '@/lib/terminal-title-contrast'
 import { resolveTerminalFontWeights } from '../../../../shared/terminal-fonts'
 import { resolveTerminalLigaturesEnabled } from '../../../../shared/terminal-ligatures'
 import { normalizeTerminalLineHeight } from '../../../../shared/terminal-line-height-settings'
@@ -195,8 +196,12 @@ export function TerminalSettingsPreview({
       return
     }
     terminal.options.theme = composedTheme
-    // Why: mirror applyTerminalAppearance's mode gating (#7934) so the preview matches live panes on theme flips.
-    terminal.options.minimumContrastRatio = effectiveMode === 'light' ? 4.5 : 1
+    // Why: mirror applyTerminalAppearance's background-luminance gating (#7934) so the preview matches live panes.
+    terminal.options.minimumContrastRatio = isTerminalBackgroundLight(composedTheme.background, {
+      appSurface: effectiveMode
+    })
+      ? 4.5
+      : 1
     // Why: xterm renders an alpha-channel background opaque unless allowTransparency is set (matches applyTerminalAppearance).
     terminal.options.allowTransparency =
       settings.terminalBackgroundOpacity !== undefined && settings.terminalBackgroundOpacity < 1

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
@@ -195,6 +195,8 @@ export function TerminalSettingsPreview({
       return
     }
     terminal.options.theme = composedTheme
+    // Why: mirror applyTerminalAppearance's mode gating (#7934) so the preview matches live panes on theme flips.
+    terminal.options.minimumContrastRatio = effectiveMode === 'light' ? 4.5 : 1
     // Why: xterm renders an alpha-channel background opaque unless allowTransparency is set (matches applyTerminalAppearance).
     terminal.options.allowTransparency =
       settings.terminalBackgroundOpacity !== undefined && settings.terminalBackgroundOpacity < 1
@@ -205,7 +207,7 @@ export function TerminalSettingsPreview({
     // Why reset() not clear(): buffer ends mid-line on the prompt, so clear()+write would duplicate the trailing fragment.
     terminal.reset()
     terminal.write(PREVIEW_BUFFER)
-  }, [composedTheme, settings.terminalBackgroundOpacity])
+  }, [composedTheme, effectiveMode, settings.terminalBackgroundOpacity])
 
   useEffect(() => {
     const terminal = terminalRef.current

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
@@ -455,6 +455,30 @@ describe('applyTerminalAppearance theme assignment', () => {
 
     expect(pane.terminal.options.minimumContrastRatio).toBe(4.5)
   })
+
+  it('skips the minimumContrastRatio write on a no-op re-apply (preserves xterm contrast cache)', () => {
+    const pane = makePane(1)
+    let writes = 0
+    let stored: number | undefined
+    Object.defineProperty(pane.terminal.options, 'minimumContrastRatio', {
+      configurable: true,
+      enumerable: true,
+      get: () => stored,
+      set: (value: number) => {
+        stored = value
+        writes += 1
+      }
+    })
+    const settings = getDefaultSettings('/tmp')
+
+    apply(pane, { ...settings, theme: 'dark' })
+    const writesAfterFirst = writes
+
+    apply(pane, { ...settings, theme: 'dark' })
+
+    // The value-gate must not rewrite an unchanged ratio — each write clears xterm's contrast cache.
+    expect(writes).toBe(writesAfterFirst)
+  })
 })
 
 describe('publishTerminalViewAttributesAtAppStart', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
@@ -406,7 +406,8 @@ describe('applyTerminalAppearance theme assignment', () => {
     expect(pane.terminal.options.theme?.background).toBe('#102030')
   })
 
-  // #7934: contrast correction rescues invisible white text on light backgrounds but over-corrects on dark; gate by mode.
+  // #7934: contrast correction rescues invisible white text on light backgrounds but over-corrects on dark;
+  // gate by the composed theme's background luminance (either theme slot can hold either kind of theme).
   it('keeps xterm contrast correction on light themes', () => {
     const pane = makePane(1)
     const settings = getDefaultSettings('/tmp')
@@ -434,6 +435,25 @@ describe('applyTerminalAppearance theme assignment', () => {
 
     apply(pane, { ...settings, theme: 'dark' })
     expect(pane.terminal.options.minimumContrastRatio).toBe(1)
+  })
+
+  it('disables contrast correction in light mode when the terminal matches dark mode', () => {
+    // terminalUseSeparateLightTheme=false keeps the dark terminal theme in light app mode; the gate must follow the background.
+    const pane = makePane(1)
+    const settings = getDefaultSettings('/tmp')
+
+    apply(pane, { ...settings, theme: 'light', terminalUseSeparateLightTheme: false })
+
+    expect(pane.terminal.options.minimumContrastRatio).toBe(1)
+  })
+
+  it('keeps contrast correction in dark mode when a light theme fills the dark slot', () => {
+    const pane = makePane(1)
+    const settings = getDefaultSettings('/tmp')
+
+    apply(pane, { ...settings, theme: 'dark', terminalThemeDark: 'Builtin Tango Light' })
+
+    expect(pane.terminal.options.minimumContrastRatio).toBe(4.5)
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.test.ts
@@ -405,6 +405,36 @@ describe('applyTerminalAppearance theme assignment', () => {
     expect(pane.terminal.options.theme).not.toBe(firstTheme)
     expect(pane.terminal.options.theme?.background).toBe('#102030')
   })
+
+  // #7934: contrast correction rescues invisible white text on light backgrounds but over-corrects on dark; gate by mode.
+  it('keeps xterm contrast correction on light themes', () => {
+    const pane = makePane(1)
+    const settings = getDefaultSettings('/tmp')
+
+    apply(pane, { ...settings, theme: 'light' })
+
+    expect(pane.terminal.options.minimumContrastRatio).toBe(4.5)
+  })
+
+  it('disables xterm contrast correction on dark themes', () => {
+    const pane = makePane(1)
+    const settings = getDefaultSettings('/tmp')
+
+    apply(pane, { ...settings, theme: 'dark' })
+
+    expect(pane.terminal.options.minimumContrastRatio).toBe(1)
+  })
+
+  it('re-gates contrast correction when the theme flips live', () => {
+    const pane = makePane(1)
+    const settings = getDefaultSettings('/tmp')
+
+    apply(pane, { ...settings, theme: 'light' })
+    expect(pane.terminal.options.minimumContrastRatio).toBe(4.5)
+
+    apply(pane, { ...settings, theme: 'dark' })
+    expect(pane.terminal.options.minimumContrastRatio).toBe(1)
+  })
 })
 
 describe('publishTerminalViewAttributesAtAppStart', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -24,7 +24,7 @@ import type { TerminalViewAttributes } from '../../../../shared/terminal-view-at
 import { publishTerminalViewAttributes } from './terminal-view-attributes-publisher'
 import { normalizeTerminalLineHeight } from '../../../../shared/terminal-line-height-settings'
 import { maybePushMode2031Flip } from './terminal-mode-2031-replies'
-import { isTerminalBackgroundLight } from '@/lib/terminal-title-contrast'
+import { resolveTerminalMinimumContrastRatio } from '@/lib/terminal-contrast-correction'
 
 // Why Pick over a hand-rolled type: stays tied to xterm's canonical signature so upstream tightening surfaces here.
 type Mode2031Parser = Pick<IParser, 'registerCsiHandler'>
@@ -208,15 +208,13 @@ export function applyTerminalAppearance(
     if (theme && !composedTerminalThemesEqual(pane.terminal.options.theme, theme)) {
       pane.terminal.options.theme = theme
     }
-    // Why gate by background luminance, not appearance.mode (#7934): xterm's contrast correction rescues
-    // invisible white/bright-white ANSI text on light backgrounds but over-corrects vibrant ANSI colors on
-    // dark ones — and either theme slot can hold either kind (match-dark-mode, light theme in the dark slot).
+    // Gate off the configured theme background; the live OSC-11 background is deliberately preserved by the
+    // theme write above, so a TUI that repaints its background at runtime won't re-gate (known limitation).
     // Why value-gated: writing minimumContrastRatio clears xterm's contrast cache, so skip on no-op re-applies.
-    const minimumContrastRatio = isTerminalBackgroundLight(theme?.background, {
-      appSurface: appearance.mode
-    })
-      ? 4.5
-      : 1
+    const minimumContrastRatio = resolveTerminalMinimumContrastRatio(
+      theme?.background,
+      appearance.mode
+    )
     if (pane.terminal.options.minimumContrastRatio !== minimumContrastRatio) {
       pane.terminal.options.minimumContrastRatio = minimumContrastRatio
     }

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -24,6 +24,7 @@ import type { TerminalViewAttributes } from '../../../../shared/terminal-view-at
 import { publishTerminalViewAttributes } from './terminal-view-attributes-publisher'
 import { normalizeTerminalLineHeight } from '../../../../shared/terminal-line-height-settings'
 import { maybePushMode2031Flip } from './terminal-mode-2031-replies'
+import { isTerminalBackgroundLight } from '@/lib/terminal-title-contrast'
 
 // Why Pick over a hand-rolled type: stays tied to xterm's canonical signature so upstream tightening surfaces here.
 type Mode2031Parser = Pick<IParser, 'registerCsiHandler'>
@@ -207,10 +208,15 @@ export function applyTerminalAppearance(
     if (theme && !composedTerminalThemesEqual(pane.terminal.options.theme, theme)) {
       pane.terminal.options.theme = theme
     }
-    // Why gate by mode (#7934): xterm's contrast correction rescues invisible white/bright-white ANSI text
-    // on light (white) backgrounds, but over-corrects vibrant ANSI colors on dark themes; disable it there.
+    // Why gate by background luminance, not appearance.mode (#7934): xterm's contrast correction rescues
+    // invisible white/bright-white ANSI text on light backgrounds but over-corrects vibrant ANSI colors on
+    // dark ones — and either theme slot can hold either kind (match-dark-mode, light theme in the dark slot).
     // Why value-gated: writing minimumContrastRatio clears xterm's contrast cache, so skip on no-op re-applies.
-    const minimumContrastRatio = appearance.mode === 'light' ? 4.5 : 1
+    const minimumContrastRatio = isTerminalBackgroundLight(theme?.background, {
+      appSurface: appearance.mode
+    })
+      ? 4.5
+      : 1
     if (pane.terminal.options.minimumContrastRatio !== minimumContrastRatio) {
       pane.terminal.options.minimumContrastRatio = minimumContrastRatio
     }

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -207,6 +207,13 @@ export function applyTerminalAppearance(
     if (theme && !composedTerminalThemesEqual(pane.terminal.options.theme, theme)) {
       pane.terminal.options.theme = theme
     }
+    // Why gate by mode (#7934): xterm's contrast correction rescues invisible white/bright-white ANSI text
+    // on light (white) backgrounds, but over-corrects vibrant ANSI colors on dark themes; disable it there.
+    // Why value-gated: writing minimumContrastRatio clears xterm's contrast cache, so skip on no-op re-applies.
+    const minimumContrastRatio = appearance.mode === 'light' ? 4.5 : 1
+    if (pane.terminal.options.minimumContrastRatio !== minimumContrastRatio) {
+      pane.terminal.options.minimumContrastRatio = minimumContrastRatio
+    }
     // Why clear explicitly: allowTransparency has rendering cost and a stale `true` could bleed in from a prior opacity.
     pane.terminal.options.allowTransparency =
       settings.terminalBackgroundOpacity !== undefined && settings.terminalBackgroundOpacity < 1

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -114,8 +114,7 @@ describe('buildDefaultTerminalOptions', () => {
     expect(normalizeTerminalFastScrollSensitivity(25)).toBe(20)
   })
 
-  it('starts with light-theme contrast correction so first paint never flashes low-contrast text', () => {
-    // Initial value is the light-background setting (4.5); applyTerminalAppearance re-gates it by background luminance (dark bg => 1; #7934).
+  it('defaults minimumContrastRatio to the light-background value (applyTerminalAppearance re-gates it)', () => {
     expect(buildDefaultTerminalOptions().minimumContrastRatio).toBe(4.5)
   })
 

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -115,7 +115,7 @@ describe('buildDefaultTerminalOptions', () => {
   })
 
   it('starts with light-theme contrast correction so first paint never flashes low-contrast text', () => {
-    // Initial value is the light-theme setting (4.5); applyTerminalAppearance re-gates it by mode (dark => 1; #7934).
+    // Initial value is the light-background setting (4.5); applyTerminalAppearance re-gates it by background luminance (dark bg => 1; #7934).
     expect(buildDefaultTerminalOptions().minimumContrastRatio).toBe(4.5)
   })
 

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -114,7 +114,8 @@ describe('buildDefaultTerminalOptions', () => {
     expect(normalizeTerminalFastScrollSensitivity(25)).toBe(20)
   })
 
-  it('enables xterm contrast correction for low-contrast CLI colors', () => {
+  it('starts with light-theme contrast correction so first paint never flashes low-contrast text', () => {
+    // Initial value is the light-theme setting (4.5); applyTerminalAppearance re-gates it by mode (dark => 1; #7934).
     expect(buildDefaultTerminalOptions().minimumContrastRatio).toBe(4.5)
   })
 

--- a/src/renderer/src/lib/pane-manager/pane-terminal-options.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-options.ts
@@ -1,5 +1,6 @@
 import type { ITerminalOptions } from '@xterm/xterm'
 import { DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT } from '../../../../shared/terminal-scrollback-policy'
+import { LIGHT_BG_MIN_CONTRAST } from '@/lib/terminal-contrast-correction'
 
 type TerminalCursorStyle = NonNullable<ITerminalOptions['cursorStyle']>
 type TerminalCursorInactiveStyle = NonNullable<ITerminalOptions['cursorInactiveStyle']>
@@ -47,11 +48,8 @@ export function buildDefaultTerminalOptions(): ITerminalOptions {
     scrollSensitivity: DEFAULT_TERMINAL_SCROLL_SENSITIVITY,
     fastScrollSensitivity: DEFAULT_TERMINAL_FAST_SCROLL_SENSITIVITY,
     allowTransparency: false,
-    // Why 4.5 as the initial value: agent CLIs render body text with ANSI white/bright-white that
-    // vanishes on light (white) backgrounds. applyTerminalAppearance re-gates this by the theme's
-    // background luminance (light bg => 4.5, dark bg => 1; #7934) — start high so the first paint on
-    // a light theme never flashes low-contrast text before appearance-apply runs.
-    minimumContrastRatio: 4.5,
+    // Initial value only; applyTerminalAppearance re-gates by background luminance (#7934) before any content paints.
+    minimumContrastRatio: LIGHT_BG_MIN_CONTRAST,
     // Why: on macOS, non-US layouts rely on Option to compose characters like @ and €.
     macOptionIsMeta: false,
     macOptionClickForcesSelection: true,

--- a/src/renderer/src/lib/pane-manager/pane-terminal-options.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-options.ts
@@ -48,9 +48,9 @@ export function buildDefaultTerminalOptions(): ITerminalOptions {
     fastScrollSensitivity: DEFAULT_TERMINAL_FAST_SCROLL_SENSITIVITY,
     allowTransparency: false,
     // Why 4.5 as the initial value: agent CLIs render body text with ANSI white/bright-white that
-    // vanishes on light (white) backgrounds. applyTerminalAppearance re-gates this by theme mode
-    // (light => 4.5, dark => 1; #7934) — start high so the first paint on a light theme never flashes
-    // low-contrast text before appearance-apply runs.
+    // vanishes on light (white) backgrounds. applyTerminalAppearance re-gates this by the theme's
+    // background luminance (light bg => 4.5, dark bg => 1; #7934) — start high so the first paint on
+    // a light theme never flashes low-contrast text before appearance-apply runs.
     minimumContrastRatio: 4.5,
     // Why: on macOS, non-US layouts rely on Option to compose characters like @ and €.
     macOptionIsMeta: false,

--- a/src/renderer/src/lib/pane-manager/pane-terminal-options.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-options.ts
@@ -47,8 +47,10 @@ export function buildDefaultTerminalOptions(): ITerminalOptions {
     scrollSensitivity: DEFAULT_TERMINAL_SCROLL_SENSITIVITY,
     fastScrollSensitivity: DEFAULT_TERMINAL_FAST_SCROLL_SENSITIVITY,
     allowTransparency: false,
-    // Why: agent CLIs sometimes render body text with ANSI white/bright-white
-    // on light themes; xterm can keep those cells readable across renderers.
+    // Why 4.5 as the initial value: agent CLIs render body text with ANSI white/bright-white that
+    // vanishes on light (white) backgrounds. applyTerminalAppearance re-gates this by theme mode
+    // (light => 4.5, dark => 1; #7934) — start high so the first paint on a light theme never flashes
+    // low-contrast text before appearance-apply runs.
     minimumContrastRatio: 4.5,
     // Why: on macOS, non-US layouts rely on Option to compose characters like @ and €.
     macOptionIsMeta: false,

--- a/src/renderer/src/lib/terminal-contrast-correction.ts
+++ b/src/renderer/src/lib/terminal-contrast-correction.ts
@@ -1,0 +1,18 @@
+import { isTerminalBackgroundLight } from '@/lib/terminal-title-contrast'
+
+// xterm minimumContrastRatio tuning (#7934). Light backgrounds keep WCAG-AA correction so invisible
+// white/bright-white ANSI body text stays readable; dark backgrounds disable it (ratio 1) because
+// correction over-brightens vibrant ANSI colors.
+export const LIGHT_BG_MIN_CONTRAST = 4.5
+export const DARK_BG_MIN_CONTRAST = 1
+
+// Why gate by background luminance, not app mode (#7934): either theme slot can hold either kind of
+// theme (match-dark-mode, or a light theme in the dark slot), so follow the composed background.
+export function resolveTerminalMinimumContrastRatio(
+  background: string | undefined,
+  appSurface: 'dark' | 'light'
+): number {
+  return isTerminalBackgroundLight(background, { appSurface })
+    ? LIGHT_BG_MIN_CONTRAST
+    : DARK_BG_MIN_CONTRAST
+}


### PR DESCRIPTION
## Summary

Fixes #7934. Gates xterm's `minimumContrastRatio` by the terminal's composed background luminance instead of exposing a user setting: **4.5 on light backgrounds, disabled (`1`) on dark backgrounds.**

## Why

`minimumContrastRatio: 4.5` was added in #5986 to rescue invisible white/bright-white ANSI text on light (white) backgrounds. But it was applied globally, so on dark themes it over-corrects — distorting/dulling vibrant ANSI colors that were already perfectly readable. That's the user complaint in #7934.

**Why background luminance, not app theme mode** (the first commit gated by mode; the second switches the signal): either theme slot can hold either kind of theme. With `terminalUseSeparateLightTheme` off ("match dark mode"), light app mode still renders the *dark* terminal theme — mode-gating would keep the over-correction exactly where #7934 complains about it. Conversely, a light theme selected as `terminalThemeDark` would lose the white-text rescue. Gating on `isTerminalBackgroundLight()` over the composed theme background (translucent backgrounds composited against the app surface) resolves both configurations correctly.

`minimumContrastRatio` is a pure render-side setting — it does not change buffer/cell data — so gating it is safe and requires no cross-process/SSH plumbing.

## Visual comparison

Same ANSI output, same theme (Orca's default Ghostty dark), same xterm build — the only variable is `minimumContrastRatio` (4.5 = correction on, 1 = off):

![xterm contrast correction on vs off, dark and light backgrounds](https://gist.githubusercontent.com/AmethystLiang/484d0e0a4ae18df926fb1b3bf4ca77cf/raw/0e5aaf4aad0c604154ff88a761aad3179d170635/contrast-comparison.png)

- **Dark theme, left (old behavior):** xterm force-brightens the theme's dim gray (`brightBlack` `#666666` is only ~2.4:1 against `#282c34`), so dim/secondary TUI text loses its hierarchy and reads like body text; red is washed toward pink; white-on-red/blue badge foregrounds get nudged.
- **Dark theme, right (this PR):** the palette renders exactly as the theme author designed.
- **Light theme, bottom row:** why the correction must stay on for light backgrounds — at `1`, ANSI white/bright-white body text (how agent CLIs print) vanishes into the background; at `4.5` it's rescued to a readable gray. That's the original bug class the setting was added for in #5986.

How dramatic the dark-side difference looks depends on the theme — palettes that already clear 4.5:1 barely change. Dim/secondary text is the case that's visibly wrong on virtually every dark theme.

## In-app validation

The two Terminal settings previews rendering live in the app, confirming the gate resolves per background (unchanged behavior; captured while validating the code path):

**Light Mode Preview** — white background ⇒ `minimumContrastRatio = 4.5` (correction on; ANSI white/bright-white body text stays readable):

![Light Mode Preview in Terminal settings](https://gist.githubusercontent.com/AmethystLiang/267c9fb2c4f2fe7ba3889a03e30b0251/raw/terminal-light-mode-preview.png)

**Dark Mode Preview** — dark background ⇒ `minimumContrastRatio = 1` (correction off; vibrant ANSI palette preserved as the theme author designed):

![Dark Mode Preview in Terminal settings](https://gist.githubusercontent.com/AmethystLiang/267c9fb2c4f2fe7ba3889a03e30b0251/raw/terminal-dark-mode-preview.png)

## Changes (renderer-only)

- **`terminal-appearance.ts`** — `applyTerminalAppearance()` now writes a value-gated `minimumContrastRatio` derived from `isTerminalBackgroundLight(theme?.background, { appSurface: appearance.mode })`, right alongside the existing `options.theme` gating. This path re-runs on every theme flip — including auto/system dark↔light — so live switching is handled for free.
- **`pane-terminal-options.ts`** — `buildDefaultTerminalOptions()` keeps `4.5` as the **initial** value so the first paint on a light background never flashes low-contrast text before appearance-apply runs.
- **`TerminalSettingsPreview.tsx`** — mirrors the same background-luminance gating so the settings preview matches live panes when the preview theme toggle flips.

Deliberately **not** touched: no `GlobalSettings` field, no settings UI, and `src/main/daemon/headless-emulator.ts` is left alone (the headless emulator mirrors options for buffer parity, and `minimumContrastRatio` has no effect on cell data).

## Supersedes #7939

That PR took a "make it configurable" approach we decided against. Background-gating needs no new user-facing knob.

## Trade-off

A poorly-designed **dark** theme with genuinely low-contrast ANSI colors is no longer auto-rescued. That trade is intentional — the reported problem is over-correction on dark backgrounds, where the global rescue was doing more harm than good.

## Tests

- `terminal-appearance.test.ts` — apply-path coverage asserting light ⇒ 4.5, dark ⇒ 1, re-gating on a live flip, plus the two mismatch configs: "match dark mode" (light app + dark terminal theme ⇒ `1`) and a light theme filling the dark slot (⇒ `4.5`).
- `pane-lifecycle.test.ts` — updated the default-options test to document that 4.5 is the light-background initial value.
- Typecheck (`tsconfig.tc.web`), oxlint, and oxfmt all clean.

Made with [Orca](https://github.com/stablyai/orca) 🐋

