### PR TITLE
fix(pi): resolve OMP tab identity from the outer wrapper, not the wrapped pi (#6364)

### DIFF
--- a/src/main/daemon/pty-subprocess-foreground-scan-cadence.test.ts
+++ b/src/main/daemon/pty-subprocess-foreground-scan-cadence.test.ts
@@ -185,4 +185,29 @@ describe('daemon pty foreground scan cadence', () => {
     // Scans at t=0s, 6s, 12s, 18s, 24s, 30s — the cheap `ps` path is unchanged.
     expect(resolveAgentForegroundProcessMock).toHaveBeenCalledTimes(6)
   })
+
+  it.each(['darwin', 'win32'] as const)(
+    'keeps wrapped pi reads on the cached omp owner between bounded %s scans',
+    async (targetPlatform) => {
+      resolveAgentForegroundProcessMock.mockResolvedValue('omp')
+      const { handle } = spawnShellSubprocess('pi', targetPlatform)
+
+      const reads: (string | null)[] = []
+      for (let atMs = 0; atMs <= 3_000; atMs += 250) {
+        reads.push(await readForegroundAt(handle, atMs))
+      }
+
+      // The first synchronous read precedes enrichment; every later read stays on
+      // OMP even when its 1s cache entry expires while the next scan is in flight.
+      expect(reads).toEqual(['pi', ...Array.from({ length: 12 }, () => 'omp')])
+      expect(resolveAgentForegroundProcessMock).toHaveBeenCalledTimes(4)
+
+      await expect(handle.confirmForegroundProcess!()).resolves.toBe('omp')
+      expect(resolveAgentForegroundProcessMock).toHaveBeenLastCalledWith(
+        12345,
+        'pi',
+        expect.objectContaining({ fresh: true })
+      )
+    }
+  )
 })

--- a/src/main/daemon/pty-subprocess-foreground-scan-cadence.test.ts
+++ b/src/main/daemon/pty-subprocess-foreground-scan-cadence.test.ts
@@ -40,10 +40,12 @@ vi.mock('../providers/windows-powershell-executable', () => ({
 }))
 
 vi.mock('../providers/agent-foreground-process', () => ({
-  resolveAgentForegroundProcessWithAvailability: async (...args: unknown[]) => ({
-    available: true,
-    processName: await resolveAgentForegroundProcessMock(...args)
-  })
+  resolveAgentForegroundProcessWithAvailability: async (...args: unknown[]) => {
+    const value = await resolveAgentForegroundProcessMock(...args)
+    return value && typeof value === 'object' && 'available' in value
+      ? value
+      : { available: true, processName: value }
+  }
 }))
 
 import { createPtySubprocess } from './pty-subprocess'
@@ -208,6 +210,32 @@ describe('daemon pty foreground scan cadence', () => {
         'pi',
         expect.objectContaining({ fresh: true })
       )
+    }
+  )
+
+  it.each(['darwin', 'win32'] as const)(
+    'keeps authoritative %s omp reads on the zero-scan path',
+    async (targetPlatform) => {
+      const { handle } = spawnShellSubprocess('omp', targetPlatform)
+
+      for (let atMs = 0; atMs <= 3_000; atMs += 250) {
+        expect(await readForegroundAt(handle, atMs)).toBe('omp')
+      }
+      expect(resolveAgentForegroundProcessMock).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each(['darwin', 'win32'] as const)(
+    'keeps the cached omp owner when a %s wrapper scan is unavailable',
+    async (targetPlatform) => {
+      resolveAgentForegroundProcessMock
+        .mockResolvedValueOnce('omp')
+        .mockResolvedValue({ available: false, processName: 'pi' })
+      const { handle } = spawnShellSubprocess('pi', targetPlatform)
+
+      expect(await readForegroundAt(handle, 0)).toBe('pi')
+      expect(await readForegroundAt(handle, 1_000)).toBe('omp')
+      expect(await readForegroundAt(handle, 2_500)).toBe('omp')
     }
   )
 })

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -53,6 +53,7 @@ import {
   recognizeAgentProcess,
   recognizeAgentProcessFromCommandLine
 } from '../../shared/agent-process-recognition'
+import { shouldInspectOuterWrapperForegroundProcess } from '../../shared/foreground-wrapper-agent'
 import {
   shouldUseShellReadyStartupDelivery,
   type StartupCommandDelivery
@@ -81,6 +82,11 @@ const PTY_SPAWN_HEALTH_TIMEOUT_MS = 4_000
 // Why: retry once so a transient slow spawn doesn't route every terminal to the local fallback, losing daemon persistence.
 const PTY_SPAWN_HEALTH_RETRY_ATTEMPTS = 2
 const PENDING_PRE_LISTENER_DATA_MAX_CHARS = 512 * 1024
+
+function shouldInspectOuterWrapperFallback(processName: string | null): boolean {
+  const recognized = recognizeAgentProcess(processName)
+  return recognized !== null && shouldInspectOuterWrapperForegroundProcess(recognized)
+}
 
 function composeGuardedDaemonGitConfigEnv(
   env: Record<string, string>,
@@ -867,6 +873,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
     fallbackProcess !== null &&
     (isShellProcess(fallbackProcess) ||
       isAgentForegroundWrapperProcess(fallbackProcess) ||
+      shouldInspectOuterWrapperFallback(fallbackProcess) ||
       // Why: agent-spawned helpers can become the PTY foreground child, but the Unix process tree still identifies the parent agent.
       process.platform !== 'win32')
   const scheduleAgentForegroundRefresh = (fallbackProcess: string | null): void => {
@@ -874,9 +881,11 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       return
     }
     const fallbackIsShell = fallbackProcess !== null && isShellProcess(fallbackProcess)
+    const fallbackRecognition = recognizeAgentProcess(fallbackProcess)
     if (
       !fallbackProcess ||
-      recognizeAgentProcess(fallbackProcess) ||
+      (fallbackRecognition !== null &&
+        !shouldInspectOuterWrapperForegroundProcess(fallbackRecognition)) ||
       !shouldInspectFallbackForegroundProcess(fallbackProcess)
     ) {
       return
@@ -974,7 +983,11 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       }
       try {
         const fallbackProcess = getFallbackForegroundProcess()
-        if (fallbackProcess && recognizeAgentProcess(fallbackProcess)) {
+        const fallbackRecognition = recognizeAgentProcess(fallbackProcess)
+        const inspectOuterWrapper =
+          fallbackRecognition !== null &&
+          shouldInspectOuterWrapperForegroundProcess(fallbackRecognition)
+        if (fallbackProcess && fallbackRecognition && !inspectOuterWrapper) {
           cachedAgentForeground = { processName: fallbackProcess, refreshedAt: Date.now() }
           startupAgentForeground = null
           return fallbackProcess
@@ -993,6 +1006,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
           cachedAgentForeground &&
           fallbackProcess !== null &&
           (isAgentForegroundWrapperProcess(fallbackProcess) ||
+            inspectOuterWrapper ||
             (process.platform === 'win32' && isShellProcess(fallbackProcess)))
         ) {
           return cachedAgentForeground.processName
@@ -1012,9 +1026,12 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       }
       try {
         const fallbackProcess = getFallbackForegroundProcess()
+        const fallbackRecognition = recognizeAgentProcess(fallbackProcess)
         if (
           !fallbackProcess ||
-          (recognizeAgentProcess(fallbackProcess) && process.platform !== 'win32') ||
+          (fallbackRecognition !== null &&
+            process.platform !== 'win32' &&
+            !shouldInspectOuterWrapperForegroundProcess(fallbackRecognition)) ||
           (process.platform !== 'win32' && !shouldInspectFallbackForegroundProcess(fallbackProcess))
         ) {
           return fallbackProcess

--- a/src/main/providers/agent-foreground-process.test.ts
+++ b/src/main/providers/agent-foreground-process.test.ts
@@ -109,6 +109,29 @@ describe('resolveAgentForegroundProcess', () => {
     await expect(resolveAgentForegroundProcess(100, 'node')).resolves.toBe('codex')
   })
 
+  // #6364 / STA-944: OMP runs as shell→omp→pi and both are recognized agents.
+  // The deepest-foreground scan must not surface the wrapped `pi` engine — the
+  // user launched `omp`, so the outer wrapper is the identity.
+  it('reports the outer omp wrapper, not the wrapped pi child', async () => {
+    mockPs(['101 100 S+   omp', '102 101 S+   pi'].join('\n'))
+
+    await expect(resolveAgentForegroundProcess(100, 'omp')).resolves.toBe('omp')
+  })
+
+  it('reports omp even when the wrapped pi child holds the foreground alone', async () => {
+    // Why: across command boundaries only the deeper `pi` carries `+`; the
+    // wrapper identity must stay omp regardless of which frame we sampled.
+    mockPs(['101 100 S    omp', '102 101 S+   pi'].join('\n'))
+
+    await expect(resolveAgentForegroundProcess(100, 'omp')).resolves.toBe('omp')
+  })
+
+  it('reports bare pi when no omp wrapper is present', async () => {
+    mockPs(['101 100 S+   pi'].join('\n'))
+
+    await expect(resolveAgentForegroundProcess(100, 'pi')).resolves.toBe('pi')
+  })
+
   it('treats a fresh POSIX snapshot missing the PTY root as unavailable', async () => {
     mockPs('101 999 S+ node /Users/dev/.nvm/versions/node/bin/codex')
 

--- a/src/main/providers/agent-foreground-process.test.ts
+++ b/src/main/providers/agent-foreground-process.test.ts
@@ -208,7 +208,7 @@ describe('resolveAgentForegroundProcess', () => {
     ).resolves.toEqual({ available: false, processName: 'zsh' })
   })
 
-  it('treats a failed fresh POSIX scan as unavailable', async () => {
+  it('treats failed POSIX scans as unavailable', async () => {
     execFileMock.mockImplementation(
       (_cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
         const callback = cb as (err: unknown, result: { stdout: string; stderr: string }) => void
@@ -219,6 +219,10 @@ describe('resolveAgentForegroundProcess', () => {
     await expect(
       resolveAgentForegroundProcessWithAvailability(100, 'zsh', { fresh: true })
     ).resolves.toEqual({ available: false, processName: 'zsh' })
+    await expect(resolveAgentForegroundProcessWithAvailability(100, 'zsh')).resolves.toEqual({
+      available: false,
+      processName: 'zsh'
+    })
     await expect(resolveAgentForegroundProcess(100, 'zsh')).resolves.toBe('zsh')
   })
 

--- a/src/main/providers/agent-foreground-process.test.ts
+++ b/src/main/providers/agent-foreground-process.test.ts
@@ -109,9 +109,7 @@ describe('resolveAgentForegroundProcess', () => {
     await expect(resolveAgentForegroundProcess(100, 'node')).resolves.toBe('codex')
   })
 
-  // #6364 / STA-944: OMP runs as shell→omp→pi and both are recognized agents.
-  // The deepest-foreground scan must not surface the wrapped `pi` engine — the
-  // user launched `omp`, so the outer wrapper is the identity.
+  // Why: OMP embeds Pi, but the outer process is the user-visible identity (#6364).
   it('reports the outer omp wrapper, not the wrapped pi child', async () => {
     mockPs(['101 100 S+   omp', '102 101 S+   pi'].join('\n'))
 
@@ -130,6 +128,76 @@ describe('resolveAgentForegroundProcess', () => {
     mockPs(['101 100 S+   pi'].join('\n'))
 
     await expect(resolveAgentForegroundProcess(100, 'pi')).resolves.toBe('pi')
+  })
+
+  it('reports the outer omp wrapper on Windows', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
+        const callback = cb as (err: unknown, result: { stdout: string; stderr: string }) => void
+        callback(null, {
+          stdout: windowsProcessJsonRows([
+            {
+              CommandLine: 'powershell.exe',
+              Name: 'powershell.exe',
+              ParentProcessId: 99,
+              ProcessId: 100
+            },
+            {
+              CommandLine: 'omp.exe',
+              Name: 'omp.exe',
+              ParentProcessId: 100,
+              ProcessId: 101
+            },
+            {
+              CommandLine: 'pi.exe',
+              Name: 'pi.exe',
+              ParentProcessId: 101,
+              ProcessId: 102
+            }
+          ]),
+          stderr: ''
+        })
+      }
+    )
+
+    await expect(resolveAgentForegroundProcess(100, 'pi.exe')).resolves.toBe('omp')
+  })
+
+  it('keeps the Windows omp ancestor when context selects one of multiple pi descendants', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    mockPs(
+      windowsProcessJsonRows([
+        {
+          CommandLine: 'powershell.exe',
+          Name: 'powershell.exe',
+          ParentProcessId: 99,
+          ProcessId: 100
+        },
+        {
+          CommandLine: 'omp.exe',
+          Name: 'omp.exe',
+          ParentProcessId: 100,
+          ProcessId: 101
+        },
+        {
+          CommandLine: 'pi.exe --cwd C:\\repo\\orca',
+          Name: 'pi.exe',
+          ParentProcessId: 101,
+          ProcessId: 102
+        },
+        {
+          CommandLine: 'pi.exe --cwd C:\\repo\\other',
+          Name: 'pi.exe',
+          ParentProcessId: 100,
+          ProcessId: 103
+        }
+      ])
+    )
+
+    await expect(
+      resolveAgentForegroundProcess(100, 'pi.exe', { contextPaths: ['C:\\repo\\orca'] })
+    ).resolves.toBe('omp')
   })
 
   it('treats a fresh POSIX snapshot missing the PTY root as unavailable', async () => {

--- a/src/main/providers/agent-foreground-process.ts
+++ b/src/main/providers/agent-foreground-process.ts
@@ -1,4 +1,5 @@
 import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process-recognition'
+import { resolveOuterWrapperForegroundProcess } from '../../shared/foreground-wrapper-agent'
 import {
   getFreshProcessTableSnapshot,
   getProcessTableSnapshot,
@@ -125,7 +126,9 @@ function resolveAgentForegroundProcessFromPs(
     }
     const recognized = recognizeAgentProcessFromCommandLine(candidate.command)
     if (recognized) {
-      return recognized.processName
+      // Why: return the outer wrapper (omp) rather than the deeper wrapped child
+      // (pi) of a shell→omp→pi tree — see resolveOuterWrapperForegroundProcess.
+      return resolveOuterWrapperForegroundProcess(recognized, candidate.depth, candidates)
     }
   }
   return null

--- a/src/main/providers/agent-foreground-process.ts
+++ b/src/main/providers/agent-foreground-process.ts
@@ -128,7 +128,7 @@ function resolveAgentForegroundProcessFromPs(
     if (recognized) {
       // Why: return the outer wrapper (omp) rather than the deeper wrapped child
       // (pi) of a shell→omp→pi tree — see resolveOuterWrapperForegroundProcess.
-      return resolveOuterWrapperForegroundProcess(recognized, candidate.depth, candidates)
+      return resolveOuterWrapperForegroundProcess(recognized, candidate, candidates)
     }
   }
   return null

--- a/src/main/providers/agent-foreground-process.ts
+++ b/src/main/providers/agent-foreground-process.ts
@@ -102,7 +102,8 @@ export async function resolveAgentForegroundProcessWithAvailability(
       processName: resolveAgentForegroundProcessFromPs(rows, shellPid) ?? fallbackProcess
     }
   } catch {
-    return { available: !options.fresh, processName: fallbackProcess }
+    // Why: a failed scan cannot prove fallback ownership; callers retain the last recognized agent.
+    return { available: false, processName: fallbackProcess }
   }
 }
 

--- a/src/main/providers/windows-agent-foreground-process.ts
+++ b/src/main/providers/windows-agent-foreground-process.ts
@@ -1,8 +1,14 @@
 import {
   isAgentForegroundWrapperProcess,
   isExpectedAgentProcess,
-  recognizeAgentProcessFromCommandLine
+  recognizeAgentProcess,
+  recognizeAgentProcessFromCommandLine,
+  type RecognizedAgentProcess
 } from '../../shared/agent-process-recognition'
+import {
+  resolveOuterWrapperForegroundProcess,
+  shouldInspectOuterWrapperForegroundProcess
+} from '../../shared/foreground-wrapper-agent'
 import { isShellProcess } from '../../shared/shell-process-detection'
 import {
   queryWindowsProcessDescendants,
@@ -26,7 +32,12 @@ export type WindowsAgentForegroundResolution = {
 }
 
 export function shouldInspectWindowsAgentForeground(fallbackProcess: string): boolean {
-  return isAgentForegroundWrapperProcess(fallbackProcess) || isShellProcess(fallbackProcess)
+  const recognized = recognizeAgentProcess(fallbackProcess)
+  return (
+    isAgentForegroundWrapperProcess(fallbackProcess) ||
+    isShellProcess(fallbackProcess) ||
+    (recognized !== null && shouldInspectOuterWrapperForegroundProcess(recognized))
+  )
 }
 
 export async function resolveWindowsAgentForegroundProcess(
@@ -106,14 +117,18 @@ function resolveWindowsProcessName(
     windowsCandidateMatchesFallbackWrapper(candidate, fallbackProcess)
   )
   if (wrapperCandidates.length !== 1) {
-    return resolveWrapperForegroundProcessFromWindowsCandidates(wrapperCandidates, contextPaths)
+    return resolveWrapperForegroundProcessFromWindowsCandidates(
+      wrapperCandidates,
+      candidates,
+      contextPaths
+    )
   }
   const [candidate] = wrapperCandidates
   const recognized =
     recognizeAgentProcessFromCommandLine(candidate.command) ??
     recognizeAgentProcessFromCommandLine(candidate.name)
   if (recognized) {
-    return recognized.processName
+    return resolveOuterWrapperForegroundProcess(recognized, candidate, candidates)
   }
   return null
 }
@@ -132,6 +147,7 @@ function resolveShellForegroundProcessFromWindowsCandidates(
 
 function resolveWrapperForegroundProcessFromWindowsCandidates(
   candidates: readonly WindowsProcessCandidate[],
+  allCandidates: readonly WindowsProcessCandidate[],
   contextPaths: readonly string[] | undefined
 ): string | null {
   const contextCandidates = createRecognizedWindowsProcessCandidates(
@@ -139,7 +155,7 @@ function resolveWrapperForegroundProcessFromWindowsCandidates(
     contextPaths
   ).filter((candidate) => candidate.contextMatch)
   return contextCandidates.length > 0
-    ? resolveRecognizedWindowsProcessCandidates(contextCandidates, candidates)
+    ? resolveRecognizedWindowsProcessCandidates(contextCandidates, allCandidates)
     : null
 }
 
@@ -147,6 +163,7 @@ type RecognizedWindowsProcessCandidate = WindowsProcessRow & {
   contextMatch: boolean
   depth: number
   processName: string
+  recognized: RecognizedAgentProcess
 }
 
 function createRecognizedWindowsProcessCandidates(
@@ -163,7 +180,8 @@ function createRecognizedWindowsProcessCandidates(
       {
         ...candidate,
         contextMatch: candidateMatchesContextPath(candidate, normalizedContextPaths),
-        processName: recognized
+        processName: recognized.processName,
+        recognized
       }
     ]
   })
@@ -176,13 +194,6 @@ function resolveRecognizedWindowsProcessCandidates(
   if (recognizedCandidates.length === 0) {
     return null
   }
-  const recognizedProcessNames = new Set(
-    recognizedCandidates.map((candidate) => candidate.processName)
-  )
-  if (recognizedProcessNames.size === 1) {
-    return [...recognizedProcessNames][0]
-  }
-
   const candidatesByPid = new Map(allCandidates.map((candidate) => [candidate.pid, candidate]))
   const leafCandidates = recognizedCandidates.filter(
     (candidate) =>
@@ -192,7 +203,11 @@ function resolveRecognizedWindowsProcessCandidates(
           windowsCandidateIsAncestor(candidate, other, candidatesByPid)
       )
   )
-  const leafProcessNames = new Set(leafCandidates.map((candidate) => candidate.processName))
+  const leafProcessNames = new Set(
+    leafCandidates.map((candidate) =>
+      resolveOuterWrapperForegroundProcess(candidate.recognized, candidate, allCandidates)
+    )
+  )
   // Why: Windows lacks a cheap PTY foreground marker like POSIX '+'. A single
   // recognized lineage leaf is strong enough; sibling agent leaves are not.
   return leafProcessNames.size === 1 ? [...leafProcessNames][0] : null
@@ -267,11 +282,13 @@ function commandLineContainsPath(haystack: string, contextPath: string): boolean
   return false
 }
 
-function recognizeWindowsProcessCandidate(candidate: WindowsProcessRow): string | null {
-  const recognized =
+function recognizeWindowsProcessCandidate(
+  candidate: WindowsProcessRow
+): RecognizedAgentProcess | null {
+  return (
     recognizeAgentProcessFromCommandLine(candidate.command) ??
     recognizeAgentProcessFromCommandLine(candidate.name)
-  return recognized?.processName ?? null
+  )
 }
 
 function windowsCandidateMatchesFallbackWrapper(

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -14611,6 +14611,55 @@ describe('OrcaRuntimeService', () => {
     unsubscribe()
   })
 
+  // STA-944 / #6364: OMP runs as shell→omp→pi, and its status extension posts
+  // /hook/omp so the hook durably carries `omp`. On a restored/mirrored pane the
+  // omp launchAgent is dropped, and the foreground reader returns the deeper `pi`
+  // child. The host must keep publishing `omp` from the hook, not normalize it
+  // onto the (oscillating) pi foreground — otherwise the mirrored tab flips OMP↔Pi.
+  it('keeps an OMP hook labeled OMP when the wrapped pi child owns the foreground', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'omp-flicker-pty' })
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      // Why: the remote relay reads the deeper `pi` child of the omp process tree.
+      getForegroundProcess: async () => 'pi'
+    })
+    const events: RuntimeMobileSessionTabsResult[] = []
+    const unsubscribe = runtime.onMobileSessionTabsChanged((snapshot) => events.push(snapshot))
+
+    await runtime.createTerminal(`id:${TEST_WORKTREE_ID}`, {
+      tabId: 'omp-tab',
+      leafId: HEADLESS_LEAF_ID
+    })
+    // Restored/mirrored pane: no launchAgent, only the pi foreground read remains.
+    const pty = (
+      runtime as unknown as {
+        ptysById: Map<string, { launchAgent: string | null; foregroundAgent: string | null }>
+      }
+    ).ptysById.get('omp-flicker-pty')!
+    pty.launchAgent = null
+    pty.foregroundAgent = 'pi'
+    events.length = 0
+
+    runtime.onPtyData(
+      'omp-flicker-pty',
+      '\x1b]9999;{"state":"working","prompt":"fix the bug","agentType":"omp"}\x07',
+      100
+    )
+
+    await waitForMobileSessionTabsEvents(events, 1)
+    expect(events[0]?.tabs[0]).toEqual(
+      expect.objectContaining({
+        type: 'terminal',
+        agentStatus: expect.objectContaining({ state: 'working', agentType: 'omp' })
+      })
+    )
+
+    unsubscribe()
+  })
+
   it('does not republish mobile session tabs for repeated identical OSC 9999 payloads', async () => {
     const spawn = vi.fn().mockResolvedValue({ id: 'hook-ping-pty' })
     const runtime = new OrcaRuntimeService(store)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -14611,11 +14611,7 @@ describe('OrcaRuntimeService', () => {
     unsubscribe()
   })
 
-  // STA-944 / #6364: OMP runs as shell→omp→pi, and its status extension posts
-  // /hook/omp so the hook durably carries `omp`. On a restored/mirrored pane the
-  // omp launchAgent is dropped, and the foreground reader returns the deeper `pi`
-  // child. The host must keep publishing `omp` from the hook, not normalize it
-  // onto the (oscillating) pi foreground — otherwise the mirrored tab flips OMP↔Pi.
+  // Why: restored OMP panes can retain the hook while the wrapped Pi owns foreground (#6364).
   it('keeps an OMP hook labeled OMP when the wrapped pi child owns the foreground', async () => {
     const spawn = vi.fn().mockResolvedValue({ id: 'omp-flicker-pty' })
     const runtime = new OrcaRuntimeService(store)
@@ -14645,7 +14641,8 @@ describe('OrcaRuntimeService', () => {
 
     runtime.onPtyData(
       'omp-flicker-pty',
-      '\x1b]9999;{"state":"working","prompt":"fix the bug","agentType":"omp"}\x07',
+      '\x1b]0;⠋ Pi\x07' +
+        '\x1b]9999;{"state":"working","prompt":"fix the bug","agentType":"omp"}\x07',
       100
     )
 
@@ -14653,7 +14650,12 @@ describe('OrcaRuntimeService', () => {
     expect(events[0]?.tabs[0]).toEqual(
       expect.objectContaining({
         type: 'terminal',
-        agentStatus: expect.objectContaining({ state: 'working', agentType: 'omp' })
+        title: '⠋ OMP',
+        agentStatus: expect.objectContaining({
+          state: 'working',
+          agentType: 'omp',
+          terminalTitle: '⠋ OMP'
+        })
       })
     )
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -22412,6 +22412,12 @@ export class OrcaRuntimeService {
       const paneKey = isTerminalLeafId(tab.leafId)
         ? makePaneKey(tab.parentTabId, tab.leafId)
         : `${tab.parentTabId}:${legacyPaneId ?? tab.leafId}`
+      const mobileStatusPty = livePty ?? pty
+      // Why: headless hooks live only in main's retained rows; reuse this lookup
+      // for both title ownership and status publication so the two cannot diverge.
+      const retainedAgentStatus = tab.agentStatus
+        ? null
+        : this.getFreshRetainedAgentStatusForMobileTab(paneKey, liveLeafPty ?? mobileStatusPty, tab)
       const leafTitle = leaf
         ? getLatestAgentCandidateTitle(
             { title: leaf.paneTitle, updatedAt: leaf.paneTitleUpdatedAt },
@@ -22425,13 +22431,12 @@ export class OrcaRuntimeService {
           )
         : null
       const launchAgent = tab.launchAgent ?? liveLeafPty?.launchAgent ?? pty?.launchAgent ?? null
-      // Why: rank the pane's own hook identity above foregroundAgent. OMP's hook
-      // posts /hook/omp (runtime exec detection) so it durably carries `omp`, while
-      // foregroundAgent reads the deeper wrapped `pi` of a shell→omp→pi tree and
-      // oscillates — normalizing the hook onto it flipped OMP tabs to Pi once
-      // launchAgent was dropped (restored/mirrored pane). Unify on the shared owner.
+      // Why: a retained OMP hook stays stable while wrapper foreground reads can report Pi.
       const ownerAgent =
-        resolvePaneAgentOwner({ launchAgent, hookAgent: tab.agentStatus?.agentType ?? null }) ??
+        resolvePaneAgentOwner({
+          launchAgent,
+          hookAgent: tab.agentStatus?.agentType ?? retainedAgentStatus?.payload.agentType ?? null
+        }) ??
         liveLeafPty?.foregroundAgent ??
         pty?.foregroundAgent ??
         null
@@ -22493,7 +22498,13 @@ export class OrcaRuntimeService {
         ...(tab.ptyId ? { ptyId: tab.ptyId } : {}),
         ...(tab.terminalTheme ? { terminalTheme: tab.terminalTheme } : {}),
         ...(launchAgent ? { launchAgent } : {}),
-        ...(agentStatus ?? this.buildPtyMobileAgentStatus(livePty ?? pty, tab, terminalHandle)),
+        ...(agentStatus ??
+          this.buildPtyMobileAgentStatus(
+            mobileStatusPty,
+            tab,
+            terminalHandle,
+            retainedAgentStatus
+          )),
         ...(tab.parentLayout ? { parentLayout: tab.parentLayout } : {}),
         ...(tab.startupCwd ? { startupCwd: tab.startupCwd } : {}),
         ...(tab.color != null ? { color: tab.color } : {}),
@@ -22548,10 +22559,10 @@ export class OrcaRuntimeService {
   private buildPtyMobileAgentStatus(
     pty: RuntimePtyWorktreeRecord | null,
     tab: RuntimeMobileSessionTerminalTab,
-    terminalHandle: string | null
+    terminalHandle: string | null,
+    retained: RuntimeAgentRowSnapshot | null
   ): { agentStatus: AgentStatusEntry } | Record<string, never> {
     const paneKey = this.getMobileTerminalPaneKey(tab)
-    const retained = this.getFreshRetainedAgentStatusForMobileTab(paneKey, pty, tab)
     if (!pty?.lastAgentStatus && !retained) {
       return {}
     }
@@ -22576,9 +22587,7 @@ export class OrcaRuntimeService {
         return {}
       }
     }
-    // Why: the retained hook identity outranks foregroundAgent — OMP's hook posts
-    // /hook/omp so it durably carries `omp`, while foregroundAgent reads the wrapped
-    // `pi` of a shell→omp→pi tree and oscillates. See buildMobileSessionSnapshot.
+    // Why: a retained OMP hook stays stable while wrapper foreground reads can report Pi.
     const ownerAgent =
       resolvePaneAgentOwner({
         launchAgent: tab.launchAgent ?? pty?.launchAgent ?? null,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -39,6 +39,7 @@ import {
   normalizeCompatibleAgentStatusEntryForOwner,
   normalizeCompatibleAgentTitleForOwner
 } from '../../shared/agent-title-owner'
+import { resolvePaneAgentOwner } from '../../shared/pane-agent-owner'
 import {
   createAgentStatusOscProcessor,
   type ProcessedAgentStatusChunk
@@ -22424,7 +22425,16 @@ export class OrcaRuntimeService {
           )
         : null
       const launchAgent = tab.launchAgent ?? liveLeafPty?.launchAgent ?? pty?.launchAgent ?? null
-      const ownerAgent = launchAgent ?? liveLeafPty?.foregroundAgent ?? pty?.foregroundAgent ?? null
+      // Why: rank the pane's own hook identity above foregroundAgent. OMP's hook
+      // posts /hook/omp (runtime exec detection) so it durably carries `omp`, while
+      // foregroundAgent reads the deeper wrapped `pi` of a shell→omp→pi tree and
+      // oscillates — normalizing the hook onto it flipped OMP tabs to Pi once
+      // launchAgent was dropped (restored/mirrored pane). Unify on the shared owner.
+      const ownerAgent =
+        resolvePaneAgentOwner({ launchAgent, hookAgent: tab.agentStatus?.agentType ?? null }) ??
+        liveLeafPty?.foregroundAgent ??
+        pty?.foregroundAgent ??
+        null
       const title = normalizeCompatibleAgentTitleForOwner(
         leafTitle ?? ptyTitle ?? syncedTab?.title ?? tab.title,
         ownerAgent
@@ -22566,7 +22576,16 @@ export class OrcaRuntimeService {
         return {}
       }
     }
-    const ownerAgent = tab.launchAgent ?? pty?.launchAgent ?? pty?.foregroundAgent ?? null
+    // Why: the retained hook identity outranks foregroundAgent — OMP's hook posts
+    // /hook/omp so it durably carries `omp`, while foregroundAgent reads the wrapped
+    // `pi` of a shell→omp→pi tree and oscillates. See buildMobileSessionSnapshot.
+    const ownerAgent =
+      resolvePaneAgentOwner({
+        launchAgent: tab.launchAgent ?? pty?.launchAgent ?? null,
+        hookAgent: retained?.payload.agentType ?? null
+      }) ??
+      pty?.foregroundAgent ??
+      null
     const terminalTitle = normalizeCompatibleAgentTitleForOwner(
       (pty ? getLatestPtyTitle(pty) : null) ?? tab.title,
       ownerAgent

--- a/src/relay/pty-shell-utils.test.ts
+++ b/src/relay/pty-shell-utils.test.ts
@@ -8,6 +8,7 @@ vi.mock('child_process', () => ({
   execFile: execFileMock
 }))
 
+import { resetWindowsProcessRowsSnapshotForTests } from '../main/providers/windows-foreground-process-rows'
 import { resetProcessTableSnapshotForTests } from '../shared/process-table-snapshot'
 import {
   getForegroundProcessName,
@@ -50,6 +51,7 @@ async function withProcessPlatform<T>(
 beforeEach(() => {
   execFileMock.mockReset()
   resetProcessTableSnapshotForTests()
+  resetWindowsProcessRowsSnapshotForTests()
 })
 
 describe('isProcessAlive', () => {
@@ -269,8 +271,7 @@ describe('getForegroundProcessName', () => {
     })
   })
 
-  // #6364 / STA-944: OMP runs as shell→omp→pi. The relay scan must report the
-  // outer `omp` wrapper the user launched, not the deeper wrapped `pi` engine.
+  // Why: OMP embeds Pi, but the outer process is the user-visible identity (#6364).
   it('reports the outer omp wrapper over the wrapped pi child from a shell fallback', async () => {
     await withProcessPlatform('linux', async () => {
       mockExecFile((_command, args) => {
@@ -292,6 +293,50 @@ describe('getForegroundProcessName', () => {
         if (args[0] === '-axo') {
           return {
             stdout: ['100 99 Ss   bash -l', '101 100 S+   omp', '102 101 S+   pi'].join('\n')
+          }
+        }
+        return new Error('unexpected command')
+      })
+
+      await expect(getForegroundProcessName(100, 'pi')).resolves.toBe('omp')
+    })
+  })
+
+  it('returns an outer omp fallback without a process-table scan', async () => {
+    mockExecFile(() => new Error('unexpected process-table scan'))
+
+    await expect(getForegroundProcessName(100, 'omp')).resolves.toBe('omp')
+    expect(execFileMock).not.toHaveBeenCalled()
+  })
+
+  it('rescans a Windows pi fallback for its outer omp wrapper', async () => {
+    await withProcessPlatform('win32', async () => {
+      mockExecFile((command) => {
+        if (command === 'powershell.exe') {
+          return {
+            stdout: JSON.stringify([
+              {
+                CommandLine: 'powershell.exe',
+                ExecutablePath: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+                Name: 'powershell.exe',
+                ParentProcessId: 99,
+                ProcessId: 100
+              },
+              {
+                CommandLine: 'omp.exe',
+                ExecutablePath: 'C:\\Tools\\omp.exe',
+                Name: 'omp.exe',
+                ParentProcessId: 100,
+                ProcessId: 101
+              },
+              {
+                CommandLine: 'pi.exe',
+                ExecutablePath: 'C:\\Tools\\pi.exe',
+                Name: 'pi.exe',
+                ParentProcessId: 101,
+                ProcessId: 102
+              }
+            ])
           }
         }
         return new Error('unexpected command')

--- a/src/relay/pty-shell-utils.test.ts
+++ b/src/relay/pty-shell-utils.test.ts
@@ -269,6 +269,51 @@ describe('getForegroundProcessName', () => {
     })
   })
 
+  // #6364 / STA-944: OMP runs as shell→omp→pi. The relay scan must report the
+  // outer `omp` wrapper the user launched, not the deeper wrapped `pi` engine.
+  it('reports the outer omp wrapper over the wrapped pi child from a shell fallback', async () => {
+    await withProcessPlatform('linux', async () => {
+      mockExecFile((_command, args) => {
+        if (args[0] === '-axo') {
+          return {
+            stdout: ['100 99 Ss   bash -l', '101 100 S+   omp', '102 101 S+   pi'].join('\n')
+          }
+        }
+        return new Error('unexpected command')
+      })
+
+      await expect(getForegroundProcessName(100, 'bash')).resolves.toBe('omp')
+    })
+  })
+
+  it('rescans for the omp wrapper when node-pty reports the wrapped pi as foreground', async () => {
+    await withProcessPlatform('linux', async () => {
+      mockExecFile((_command, args) => {
+        if (args[0] === '-axo') {
+          return {
+            stdout: ['100 99 Ss   bash -l', '101 100 S+   omp', '102 101 S+   pi'].join('\n')
+          }
+        }
+        return new Error('unexpected command')
+      })
+
+      await expect(getForegroundProcessName(100, 'pi')).resolves.toBe('omp')
+    })
+  })
+
+  it('keeps a pi fallback as pi when no omp wrapper is in the tree', async () => {
+    await withProcessPlatform('linux', async () => {
+      mockExecFile((_command, args) => {
+        if (args[0] === '-axo') {
+          return { stdout: ['100 99 Ss   bash -l', '101 100 S+   pi'].join('\n') }
+        }
+        return new Error('unexpected command')
+      })
+
+      await expect(getForegroundProcessName(100, 'pi')).resolves.toBe('pi')
+    })
+  })
+
   it('falls back to the root process command when descendant inspection fails', async () => {
     mockExecFile((_command, args) => {
       if (args[0] === '-axo') {

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -11,8 +11,10 @@ import {
 } from '../shared/agent-process-recognition'
 import { getFirstCommandToken } from '../shared/command-token-scanner'
 import { getProcessTableSnapshot, type ProcessTableRow } from '../shared/process-table-snapshot'
-import { resolveOuterWrapperForegroundProcess } from '../shared/foreground-wrapper-agent'
-import { getSyntheticAgentTitleProfile } from '../shared/synthetic-agent-title'
+import {
+  resolveOuterWrapperForegroundProcess,
+  shouldInspectOuterWrapperForegroundProcess
+} from '../shared/foreground-wrapper-agent'
 import { isShellProcess } from '../shared/shell-process-detection'
 import {
   resolveWindowsAgentForegroundProcess,
@@ -236,7 +238,7 @@ async function getRecognizedForegroundDescendant(
       if (recognized) {
         // Why: return the outer wrapper (omp) rather than the deeper wrapped child
         // (pi) of a shell→omp→pi tree — see resolveOuterWrapperForegroundProcess.
-        return resolveOuterWrapperForegroundProcess(recognized, candidate.depth, candidates)
+        return resolveOuterWrapperForegroundProcess(recognized, candidate, candidates)
       }
     }
   } catch {
@@ -255,10 +257,15 @@ export async function getForegroundProcessName(
   if (fallbackProcess) {
     const fallbackRecognition = recognizeAgentProcess(fallbackProcess)
     if (fallbackRecognition) {
-      // Why: node-pty may report the wrapped `pi` of a shell→omp→pi tree as the
-      // foreground. A pi-compatible fallback still needs the descendant scan to
-      // surface the outer `omp` wrapper; never downgrade below the fallback.
-      if (getSyntheticAgentTitleProfile(fallbackRecognition.agent)?.titleIdentityGroup) {
+      // Why: node-pty can report OMP's wrapped Pi; enrich only that ambiguous
+      // fallback so authoritative OMP reads keep the zero-subprocess fast path.
+      if (shouldInspectOuterWrapperForegroundProcess(fallbackRecognition)) {
+        if (process.platform === 'win32') {
+          return (
+            (await resolveWindowsAgentForegroundProcess(pid, fallbackProcess, {})) ??
+            fallbackRecognition.processName
+          )
+        }
         return (
           (await getRecognizedForegroundDescendant(pid, fallbackProcess)) ??
           fallbackRecognition.processName

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -11,6 +11,8 @@ import {
 } from '../shared/agent-process-recognition'
 import { getFirstCommandToken } from '../shared/command-token-scanner'
 import { getProcessTableSnapshot, type ProcessTableRow } from '../shared/process-table-snapshot'
+import { resolveOuterWrapperForegroundProcess } from '../shared/foreground-wrapper-agent'
+import { getSyntheticAgentTitleProfile } from '../shared/synthetic-agent-title'
 import { isShellProcess } from '../shared/shell-process-detection'
 import {
   resolveWindowsAgentForegroundProcess,
@@ -232,7 +234,9 @@ async function getRecognizedForegroundDescendant(
     for (const candidate of inspectionCandidates) {
       const recognized = recognizeAgentProcessFromCommandLine(candidate.command)
       if (recognized) {
-        return recognized.processName
+        // Why: return the outer wrapper (omp) rather than the deeper wrapped child
+        // (pi) of a shell→omp→pi tree — see resolveOuterWrapperForegroundProcess.
+        return resolveOuterWrapperForegroundProcess(recognized, candidate.depth, candidates)
       }
     }
   } catch {
@@ -251,6 +255,15 @@ export async function getForegroundProcessName(
   if (fallbackProcess) {
     const fallbackRecognition = recognizeAgentProcess(fallbackProcess)
     if (fallbackRecognition) {
+      // Why: node-pty may report the wrapped `pi` of a shell→omp→pi tree as the
+      // foreground. A pi-compatible fallback still needs the descendant scan to
+      // surface the outer `omp` wrapper; never downgrade below the fallback.
+      if (getSyntheticAgentTitleProfile(fallbackRecognition.agent)?.titleIdentityGroup) {
+        return (
+          (await getRecognizedForegroundDescendant(pid, fallbackProcess)) ??
+          fallbackRecognition.processName
+        )
+      }
       return fallbackRecognition.processName
     }
     if (process.platform === 'win32') {

--- a/src/shared/foreground-wrapper-agent.test.ts
+++ b/src/shared/foreground-wrapper-agent.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { resolveOuterWrapperForegroundProcess } from './foreground-wrapper-agent'
+
+describe('resolveOuterWrapperForegroundProcess', () => {
+  const omp = { agent: 'omp' as const, processName: 'omp' }
+  const pi = { agent: 'pi' as const, processName: 'pi' }
+
+  it('collapses a wrapped pi read onto the shallower omp wrapper', () => {
+    // Winner is the deeper pi (depth 2); omp is its wrapper at depth 1.
+    expect(
+      resolveOuterWrapperForegroundProcess(pi, 2, [
+        { command: 'pi', depth: 2 },
+        { command: 'omp', depth: 1 }
+      ])
+    ).toBe('omp')
+  })
+
+  it('keeps bare pi when no same-group wrapper is present', () => {
+    expect(resolveOuterWrapperForegroundProcess(pi, 1, [{ command: 'pi', depth: 1 }])).toBe('pi')
+  })
+
+  it('leaves a cross-group agent (codex) untouched even under a deeper same-name child', () => {
+    const codex = { agent: 'codex' as const, processName: 'codex' }
+    expect(
+      resolveOuterWrapperForegroundProcess(codex, 2, [
+        { command: 'node /usr/bin/codex', depth: 2 },
+        { command: 'bash -l', depth: 1 }
+      ])
+    ).toBe('codex')
+  })
+
+  it('does not promote a deeper pi over an already-outer omp winner', () => {
+    expect(
+      resolveOuterWrapperForegroundProcess(omp, 1, [
+        { command: 'omp', depth: 1 },
+        { command: 'pi', depth: 2 }
+      ])
+    ).toBe('omp')
+  })
+})

--- a/src/shared/foreground-wrapper-agent.test.ts
+++ b/src/shared/foreground-wrapper-agent.test.ts
@@ -8,33 +8,48 @@ describe('resolveOuterWrapperForegroundProcess', () => {
   it('collapses a wrapped pi read onto the shallower omp wrapper', () => {
     // Winner is the deeper pi (depth 2); omp is its wrapper at depth 1.
     expect(
-      resolveOuterWrapperForegroundProcess(pi, 2, [
-        { command: 'pi', depth: 2 },
-        { command: 'omp', depth: 1 }
+      resolveOuterWrapperForegroundProcess(pi, { pid: 102, ppid: 101, command: 'pi' }, [
+        { pid: 102, ppid: 101, command: 'pi' },
+        { pid: 101, ppid: 100, command: 'omp' }
       ])
     ).toBe('omp')
   })
 
   it('keeps bare pi when no same-group wrapper is present', () => {
-    expect(resolveOuterWrapperForegroundProcess(pi, 1, [{ command: 'pi', depth: 1 }])).toBe('pi')
+    const barePi = { pid: 101, ppid: 100, command: 'pi' }
+    expect(resolveOuterWrapperForegroundProcess(pi, barePi, [barePi])).toBe('pi')
   })
 
   it('leaves a cross-group agent (codex) untouched even under a deeper same-name child', () => {
     const codex = { agent: 'codex' as const, processName: 'codex' }
     expect(
-      resolveOuterWrapperForegroundProcess(codex, 2, [
-        { command: 'node /usr/bin/codex', depth: 2 },
-        { command: 'bash -l', depth: 1 }
-      ])
+      resolveOuterWrapperForegroundProcess(
+        codex,
+        { pid: 102, ppid: 101, command: 'node /usr/bin/codex' },
+        [
+          { pid: 102, ppid: 101, command: 'node /usr/bin/codex' },
+          { pid: 101, ppid: 100, command: 'bash -l' }
+        ]
+      )
     ).toBe('codex')
   })
 
   it('does not promote a deeper pi over an already-outer omp winner', () => {
     expect(
-      resolveOuterWrapperForegroundProcess(omp, 1, [
-        { command: 'omp', depth: 1 },
-        { command: 'pi', depth: 2 }
+      resolveOuterWrapperForegroundProcess(omp, { pid: 101, ppid: 100, command: 'omp' }, [
+        { pid: 101, ppid: 100, command: 'omp' },
+        { pid: 102, ppid: 101, command: 'pi' }
       ])
     ).toBe('omp')
+  })
+
+  it('does not treat an unrelated shallower omp sibling as the pi wrapper', () => {
+    expect(
+      resolveOuterWrapperForegroundProcess(pi, { pid: 103, ppid: 102, command: 'pi' }, [
+        { pid: 101, ppid: 100, command: 'omp' },
+        { pid: 102, ppid: 100, command: 'node server.js' },
+        { pid: 103, ppid: 102, command: 'pi' }
+      ])
+    ).toBe('pi')
   })
 })

--- a/src/shared/foreground-wrapper-agent.ts
+++ b/src/shared/foreground-wrapper-agent.ts
@@ -1,0 +1,45 @@
+import {
+  recognizeAgentProcessFromCommandLine,
+  type RecognizedAgentProcess
+} from './agent-process-recognition'
+import { getSyntheticAgentTitleProfile } from './synthetic-agent-title'
+
+export type ForegroundAgentCandidate = { command: string; depth: number }
+
+/**
+ * Collapse a foreground read onto the OUTER wrapper when one agent embeds
+ * another of the same title-identity group. OMP runs as `shell → omp → pi` and
+ * both are recognized agents, so the deepest-foreground scan otherwise returns
+ * the wrapped `pi` child — but `omp` is the agent the user launched and sees.
+ * Given the reader's recognized winner plus every descendant, return the
+ * shallowest same-group agent (the wrapper). Un-nested or cross-group reads
+ * (bare Pi, Codex, etc.) are returned unchanged, and the result is stable
+ * regardless of which of omp/pi holds the terminal foreground at the sampled
+ * instant — which is what stops the OMP↔Pi tab-icon flicker at its source.
+ */
+export function resolveOuterWrapperForegroundProcess(
+  winner: RecognizedAgentProcess,
+  winnerDepth: number,
+  descendants: readonly ForegroundAgentCandidate[]
+): string {
+  const winnerGroup = getSyntheticAgentTitleProfile(winner.agent)?.titleIdentityGroup
+  if (!winnerGroup) {
+    return winner.processName
+  }
+  let outerProcessName = winner.processName
+  let outerDepth = winnerDepth
+  for (const candidate of descendants) {
+    if (candidate.depth >= outerDepth) {
+      continue
+    }
+    const recognized = recognizeAgentProcessFromCommandLine(candidate.command)
+    if (!recognized) {
+      continue
+    }
+    if (getSyntheticAgentTitleProfile(recognized.agent)?.titleIdentityGroup === winnerGroup) {
+      outerProcessName = recognized.processName
+      outerDepth = candidate.depth
+    }
+  }
+  return outerProcessName
+}

--- a/src/shared/foreground-wrapper-agent.ts
+++ b/src/shared/foreground-wrapper-agent.ts
@@ -4,42 +4,53 @@ import {
 } from './agent-process-recognition'
 import { getSyntheticAgentTitleProfile } from './synthetic-agent-title'
 
-export type ForegroundAgentCandidate = { command: string; depth: number }
+export type ForegroundAgentCandidate = {
+  pid: number
+  ppid: number
+  command: string
+  name?: string
+}
+
+export function shouldInspectOuterWrapperForegroundProcess(
+  process: RecognizedAgentProcess
+): boolean {
+  // Why: only Pi is currently embedded by a same-group wrapper; scanning OMP would add a subprocess to every relay poll.
+  return process.agent === 'pi'
+}
 
 /**
- * Collapse a foreground read onto the OUTER wrapper when one agent embeds
- * another of the same title-identity group. OMP runs as `shell → omp → pi` and
- * both are recognized agents, so the deepest-foreground scan otherwise returns
- * the wrapped `pi` child — but `omp` is the agent the user launched and sees.
- * Given the reader's recognized winner plus every descendant, return the
- * shallowest same-group agent (the wrapper). Un-nested or cross-group reads
- * (bare Pi, Codex, etc.) are returned unchanged, and the result is stable
- * regardless of which of omp/pi holds the terminal foreground at the sampled
- * instant — which is what stops the OMP↔Pi tab-icon flicker at its source.
+ * Collapse a foreground read onto its outermost same-title-group ancestor.
+ * Why: OMP embeds Pi, while depth alone cannot distinguish wrappers from sibling jobs.
  */
 export function resolveOuterWrapperForegroundProcess(
   winner: RecognizedAgentProcess,
-  winnerDepth: number,
+  winnerCandidate: ForegroundAgentCandidate,
   descendants: readonly ForegroundAgentCandidate[]
 ): string {
   const winnerGroup = getSyntheticAgentTitleProfile(winner.agent)?.titleIdentityGroup
   if (!winnerGroup) {
     return winner.processName
   }
+  const candidatesByPid = new Map(descendants.map((candidate) => [candidate.pid, candidate]))
+  const seen = new Set<number>([winnerCandidate.pid])
   let outerProcessName = winner.processName
-  let outerDepth = winnerDepth
-  for (const candidate of descendants) {
-    if (candidate.depth >= outerDepth) {
-      continue
+  let parentPid = winnerCandidate.ppid
+  while (!seen.has(parentPid)) {
+    seen.add(parentPid)
+    const candidate = candidatesByPid.get(parentPid)
+    if (!candidate) {
+      break
     }
-    const recognized = recognizeAgentProcessFromCommandLine(candidate.command)
-    if (!recognized) {
-      continue
-    }
-    if (getSyntheticAgentTitleProfile(recognized.agent)?.titleIdentityGroup === winnerGroup) {
+    const recognized =
+      recognizeAgentProcessFromCommandLine(candidate.command) ??
+      recognizeAgentProcessFromCommandLine(candidate.name)
+    if (
+      recognized &&
+      getSyntheticAgentTitleProfile(recognized.agent)?.titleIdentityGroup === winnerGroup
+    ) {
       outerProcessName = recognized.processName
-      outerDepth = candidate.depth
     }
+    parentPid = candidate.ppid
   }
   return outerProcessName
 }


### PR DESCRIPTION
## Summary

Fixes the **OMP → Pi tab-icon/label flicker** reported in #6364 (STA-944). The Remote Host beta report saw an OMP pane alternate OMP↔Pi while the agent was working because Orca exposed OMP's wrapped Pi engine as the pane owner.

## Root cause

OMP runs as `shell → omp → pi`, and Orca recognizes both `omp` and `pi` as agents. Foreground readers could select the wrapped Pi child. Restored or mirrored remote panes often have no `launchAgent`, so that unstable foreground identity reached the tab directly.

The first implementation also selected any shallower same-group process. That did not prove ownership: an unrelated/background OMP sibling could claim a foreground bare-Pi lineage.

## Fix

- `resolveOuterWrapperForegroundProcess` now walks the selected process's real `ppid` ancestry and returns only an outer same-title-group ancestor. Sibling jobs cannot claim ownership, and malformed process-table cycles terminate safely.
- Local POSIX, daemon-backed PTYs, SSH relay, and Windows CIM/WMIC readers use the same ancestry rule. Windows context filtering retains the full candidate tree so it cannot discard OMP before resolving a selected Pi descendant.
- Recognized OMP fallbacks keep their zero-subprocess fast path. Only the ambiguous Pi fallback is enriched, using the existing globally deduplicated 500 ms process-table snapshot; daemon reads retain the resolved owner across its bounded 1 s refresh cadence.
- Host mobile snapshots use a fresh retained hook identity for both the published tab title and `agentStatus`, so an OMP hook cannot publish an OMP status beside a Pi title. The retained-row lookup is shared rather than duplicated.

## Prior fixes and why this one closes the remaining gap

The earlier fixes were valid for the signal path each one covered, but OMP identity was still being decided independently at several layers:

- #6689 preserved an already-known OMP launch owner through Remote Host/mobile snapshots, live PTY metadata, mirrored tabs, and sidebar title/status normalization.
- #6954 covered agents typed into a blank terminal by inferring ephemeral ownership and using foreground identity as a host fallback when `launchAgent` was absent.
- #7633 covered Orca-created worktree panes that did have `launchAgent: 'omp'`, preventing later Pi-compatible renderer title/hook/status frames from overriding that owner.
- #9077 fixed tab-icon flicker from the renderer's raw `processAgent` signal by re-owning it to a durable launch/hook owner. Its documented residual was a restored pane with no `launchAgent`, live/completed hook, or hibernated session: with no owner anchor, a raw foreground `pi` read could still win.

This PR closes that exact residual at the source instead of asking another renderer rule to reinterpret an already-wrong value. When the host selects the wrapped `pi`, it follows that process's real parent chain and resolves the outer `omp`; the same rule now feeds local, daemon, relay, and Windows readers. The daemon retains that resolved owner across bounded refresh/degraded scans, and Remote Host publishes title and status from one retained owner. Therefore a launchless/hookless restored pane can recover OMP ownership from `shell → omp → pi` itself, while bare Pi and unrelated sibling jobs remain Pi.

The regression coverage combines every previously protected OMP case with the formerly unprotected case: a restored/launchless Remote Host pane receiving Pi foreground evidence from a real OMP ancestor chain. This is why #9600 closes the escape hatch left by the earlier PRs rather than moving the same ambiguity to another identity layer.

## Reliability contract

- **Invariant:** foreground identity belongs to the selected process lineage; a same-group ancestor may own it, but a sibling may not.
- **Failure source:** #6364 / STA-944, especially restored Remote Host panes without `launchAgent`.
- **Oracle:** POSIX, daemon-cadence, relay, Windows, sibling-lineage, context-filtering, zero-scan, and retained-hook title/status regression tests.
- **Performance budget:** authoritative OMP reads perform no new subprocess work; ambiguous Pi reads reuse the bounded process-table cache; retained hook lookup runs once and is reused.
- **Residual gap:** no live Remote Host repro binary/E2E was available, so the remote process tree and host publication path are covered deterministically.

## Testing

- 1,039/1,039 focused and adjacent tests pass across the shared resolver, process-table cache, local/Windows provider, daemon PTY, SSH relay, and host runtime.
- 456/456 renderer PTY connection tests pass; the one failure seen only in a larger suite-order run was not reproducible alone or in its full file and touches no changed module.
- Typecheck passes for node, CLI, and web projects.
- Oxlint, commit-time React lint, formatting, reliability-gate manifest, max-lines ratchet, and `git diff --check` pass.
- Full `pnpm run lint` is currently blocked by pre-existing switch-exhaustiveness errors in untouched `src/main/daemon/daemon-server.ts` and `src/renderer/src/components/skills/skill-freshness-group.tsx`.
