### PR TITLE
fix(worktree): don't let a WSL selector_not_found abort worktree deletion (#9197)

### DIFF
--- a/src/main/runtime/worktree-teardown.test.ts
+++ b/src/main/runtime/worktree-teardown.test.ts
@@ -581,6 +581,36 @@ describe('killAllProcessesForWorktree', () => {
     ).rejects.toThrow('runtime sweep failed')
   })
 
+  it('does not abort a destructive delete when the runtime cannot resolve the worktree (WSL selector_not_found, #9197)', async () => {
+    // On a WSL project the removal target's UNC form (\\wsl.localhost) can differ
+    // from the runtime's resolved id (\\wsl$), so resolveWorktreeSelector's
+    // exact-string branch throws selector_not_found before any PTY is touched.
+    // That means "no renderer-graph terminals to stop" — it must not fail-close
+    // the delete, while the provider sweep still tears down real PTYs.
+    const worktreeId = 'repo-1::\\\\wsl.localhost\\Ubuntu\\root\\orca\\workspaces\\wt'
+    const stopTerminalsForWorktree = vi.fn().mockRejectedValue(new Error('selector_not_found'))
+    const runtime = {
+      stopTerminalsForWorktree
+    } as unknown as Parameters<typeof killAllProcessesForWorktree>[1]['runtime']
+    const localProvider = createProviderStub(async () => [
+      { id: `${worktreeId}@@live-1`, cwd: '/wsl/wt', title: 'shell' }
+    ])
+    listRegisteredPtysMock.mockReturnValue([])
+
+    const result = await killAllProcessesForWorktree(worktreeId, {
+      runtime,
+      localProvider,
+      requirePhysicalStop: true
+    })
+
+    expect(result.runtimeStopped).toBe(0)
+    expect(result.providerStopped).toBe(1)
+    expect(localProvider.shutdown).toHaveBeenCalledWith(
+      `${worktreeId}@@live-1`,
+      expect.objectContaining({ immediate: true })
+    )
+  })
+
   it('bounds the entire process sweep when a provider never settles', async () => {
     vi.useFakeTimers()
     try {

--- a/src/main/runtime/worktree-teardown.test.ts
+++ b/src/main/runtime/worktree-teardown.test.ts
@@ -611,6 +611,29 @@ describe('killAllProcessesForWorktree', () => {
     )
   })
 
+  it('still fails the destructive delete closed when a provider PTY refuses to stop, even though the runtime cannot resolve the worktree (#9197)', async () => {
+    // Guard the invariant the #9197 fix depends on: swallowing selector_not_found
+    // relaxes only the renderer-graph sweep. A real provider-visible PTY that
+    // cannot be physically stopped must still block filesystem removal.
+    const worktreeId = 'repo-1::\\\\wsl.localhost\\Ubuntu\\root\\orca\\workspaces\\wt'
+    const runtime = {
+      stopTerminalsForWorktree: vi.fn().mockRejectedValue(new Error('selector_not_found'))
+    } as unknown as Parameters<typeof killAllProcessesForWorktree>[1]['runtime']
+    const localProvider = createProviderStub(async () => [
+      { id: `${worktreeId}@@live-1`, cwd: '/wsl/wt', title: 'shell' }
+    ])
+    localProvider.shutdown = vi.fn().mockRejectedValue(new Error('daemon refused kill'))
+    listRegisteredPtysMock.mockReturnValue([])
+
+    await expect(
+      killAllProcessesForWorktree(worktreeId, {
+        runtime,
+        localProvider,
+        requirePhysicalStop: true
+      })
+    ).rejects.toThrow('Failed to physically stop every PTY')
+  })
+
   it('bounds the entire process sweep when a provider never settles', async () => {
     vi.useFakeTimers()
     try {

--- a/src/main/runtime/worktree-teardown.ts
+++ b/src/main/runtime/worktree-teardown.ts
@@ -9,6 +9,19 @@ import { mapWithConcurrency } from '../../shared/map-with-concurrency'
 // or pathological inventory cannot fan out unbounded provider/RPC shutdowns.
 const WORKTREE_TEARDOWN_CONCURRENCY = 32
 
+// Why: the runtime sweep only stops renderer-graph terminals. If the runtime
+// can't resolve the worktree at all — headless/reloading (runtime_unavailable)
+// or a WSL UNC-alias id mismatch that misses resolveWorktreeSelector's
+// exact-string branch (selector_not_found, #9197) — there are no such terminals
+// to stop, so it must never fail-close a destructive delete. The provider and
+// registry sweeps remain the physical-stop proof for any PTY that truly exists.
+function isBenignRuntimeSweepError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message === 'runtime_unavailable' || error.message === 'selector_not_found')
+  )
+}
+
 export type WorktreeTeardownDeps = {
   runtime?: OrcaRuntimeService
   localProvider: IPtyProvider
@@ -101,7 +114,7 @@ export async function killAllProcessesForWorktree(
         { stopped: 0 },
         deadline,
         deps.requirePhysicalStop ? deadlineError : undefined,
-        (error) => !(error instanceof Error && error.message === 'runtime_unavailable')
+        (error) => !isBenignRuntimeSweepError(error)
       )
     : Promise.resolve({ stopped: 0 })
   const providerSweep = settleBeforeDeadline(


### PR DESCRIPTION
## Problem — Fixes #9197

Deleting a worktree in a **WSL-runtime** project fails with
`Error invoking remote method 'worktrees:remove': Error: selector_not_found`
and leaves the worktree **half-deleted**. Triggers when the project lives at
`\wsl.localhost\Ubuntu\...` with worktrees under `\wsl.localhost\Ubuntu\root\orca\workspaces`.

## Root cause (code-verified)

Destructive removal runs `stopPtysForDestructiveWorktreeRemoval` →
`killAllProcessesForWorktree(worktreeId)` → the runtime sweep
`runtime.stopTerminalsForWorktree(worktreeId)` →
`resolveWorktreeSelector(worktreeId)`, which resolves the selector **before**
touching any PTY.

- `killAllProcessesForWorktree` passes the **raw composite id** (`repoId::path`, no
  `id:`/`path:` prefix), so `resolveWorktreeSelector` falls to the exact-string
  else-branch (`worktree.id === selector`, `orca-runtime.ts`).
- Every *other* comparator in the removal path is normalization-tolerant (it folds
  the `\wsl.localhost` ↔ `\wsl$` UNC aliases + distro casing), so the removal
  **preflight matches and the delete begins** — then the exact id-match **misses**
  and `resolveWorktreeSelector` throws `selector_not_found`.
- The teardown **fail-closes on every error except `runtime_unavailable`**
  (`worktree-teardown.ts`), so that throw propagates and **aborts the whole delete**.

A slow WSL `git worktree list` exceeding `RESOLVED_WORKTREE_REPO_TIMEOUT_MS`
(degrades to an empty list) reproduces the same asymmetry. Distinct from `#9045`,
which fails later at the PTY-kill gate.

## Fix

The runtime sweep only stops **renderer-graph** terminals. If the runtime can't
resolve the worktree at all, there are simply **no such terminals to stop** — that
must never fail-close a destructive delete. So `selector_not_found` is treated as
benign there, exactly like `runtime_unavailable` (matching existing precedent that
already swallows `selector_not_found` elsewhere in `orca-runtime.ts`).

Safety is preserved: the **independent provider sweep** (which also matches PTYs by
cwd-inside-worktree, tolerant of the UNC aliasing) and **registry sweep**, plus the
`requirePhysicalStop` gate, remain the proof that any PTY that truly exists was
physically stopped. The invariant ("nothing to stop must never abort a delete")
holds on native/SSH too, so **those paths are untouched** — a generic runtime-sweep
error still fails closed.

```diff
-        (error) => !(error instanceof Error && error.message === 'runtime_unavailable')
+        (error) => !isBenignRuntimeSweepError(error)   // runtime_unavailable OR selector_not_found
```

## Reproduction & verification

A live slow-WSL Electron host is impractical to drive deterministically, so — as the
issue's own repro note allows — this uses a **focused unit reproduction** that forces
the exact failure mode: the runtime sweep rejects with `selector_not_found` under
`requirePhysicalStop`, using a `\wsl.localhost` composite id.

- **Red (before):** the new test throws `Error: selector_not_found` — the destructive
  teardown aborts (reproduces #9197).
- **Green (after):** the delete completes, `runtimeStopped: 0`, and the provider sweep
  still tears down the live PTY (`providerStopped: 1`).
- Full `worktree-teardown.test.ts` suite: **22/22 pass**. `oxlint` clean;
  `tsc -p config/tsconfig.node.json` clean.

## Trade-offs / user-visible changes

None beyond the fix: WSL worktree deletion now completes instead of aborting with
`selector_not_found`. No behavior change for native or SSH removal. A live WSL
Electron end-to-end pass is still worth a maintainer's confirmation before merge.