### PR TITLE
fix(skills): pass -y to skill install command so it can't hang on the agent-selection prompt

### DIFF
--- a/src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts
+++ b/src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts
@@ -119,7 +119,7 @@ describe('onboarding feature setup runner', () => {
 
     expect(text).toBe(ALL_SKILL_INSTALL_COMMAND)
     expect(text).toBe(
-      'npx skills add https://github.com/stablyai/orca --skill orca-cli computer-use orchestration orca-linear --global'
+      'npx skills add https://github.com/stablyai/orca --skill orca-cli computer-use orchestration orca-linear --global -y'
     )
   })
 

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx
@@ -7,7 +7,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AgentSkillSetupPanel } from './AgentSkillSetupPanel'
 import { TooltipProvider } from '../ui/tooltip'
 
-const INSTALL_COMMAND = 'npx skills add https://github.com/stablyai/orca --skill orca-cli --global'
+const INSTALL_COMMAND =
+  'npx skills add https://github.com/stablyai/orca --skill orca-cli --global -y'
 const UPDATE_COMMAND = 'npx skills update orca-cli --global'
 
 const mocks = vi.hoisted(() => ({

--- a/src/renderer/src/components/settings/OrchestrationPane.test.tsx
+++ b/src/renderer/src/components/settings/OrchestrationPane.test.tsx
@@ -8,7 +8,7 @@ import { getOrchestrationUsageExamples } from '@/lib/orchestration-usage-example
 import { OrchestrationPane } from './OrchestrationPane'
 
 const INSTALL_COMMAND =
-  'npx skills add https://github.com/stablyai/orca --skill orchestration --global'
+  'npx skills add https://github.com/stablyai/orca --skill orchestration --global -y'
 const UPDATE_COMMAND = INSTALL_COMMAND
 
 const mocks = vi.hoisted(() => ({

--- a/src/renderer/src/components/settings/linear-agent-skill-install-cta.test.tsx
+++ b/src/renderer/src/components/settings/linear-agent-skill-install-cta.test.tsx
@@ -115,7 +115,7 @@ describe('LinearAgentSkillInstallCta', () => {
     expect(rendered.textContent).toContain('Not installed')
     expect(rendered.textContent).toContain('Let your agents read and edit Linear tasks.')
     expect(rendered.textContent).toContain(
-      'npx skills add https://github.com/stablyai/orca --skill orca-linear --global'
+      'npx skills add https://github.com/stablyai/orca --skill orca-linear --global -y'
     )
   })
 
@@ -129,7 +129,7 @@ describe('LinearAgentSkillInstallCta', () => {
     })
 
     expect(mocks.clipboardWrite).toHaveBeenCalledWith(
-      'npx skills add https://github.com/stablyai/orca --skill orca-linear --global'
+      'npx skills add https://github.com/stablyai/orca --skill orca-linear --global -y'
     )
     expect(mocks.toastSuccess).toHaveBeenCalled()
   })

--- a/src/shared/agent-feature-install-commands.ts
+++ b/src/shared/agent-feature-install-commands.ts
@@ -12,7 +12,10 @@ export function buildAgentFeatureSkillInstallCommand(skillNames: readonly string
   if (skillNames.length === 0) {
     throw new Error('At least one skill name is required.')
   }
-  return `npx skills add ${ORCA_SKILLS_REPOSITORY_URL} --skill ${skillNames.join(' ')} --global`
+  // Why: Orca spawns this in a non-driven PTY (ephemeral setup terminal). Without -y the
+  // skills CLI's interactive "Which agents?" prompt blocks until Orca kills it (~50s, exit 1),
+  // so the install silently fails (#9567). -y installs to all detected agents non-interactively.
+  return `npx skills add ${ORCA_SKILLS_REPOSITORY_URL} --skill ${skillNames.join(' ')} --global -y`
 }
 
 export function buildAgentFeatureSkillUpdateCommand(skillName: string): string {


### PR DESCRIPTION
Fixes #9567

## Problem

Clicking **Install** on Settings → Skills (e.g. *Orchestration*, *Computer use*) reports "install complete" in the UI, but the skill is never installed. **Re-check** keeps reporting "Not installed" and every agent shows "missing" coverage. Reproduces reliably when the Orca work area is a WSL2 distro with agents installed inside it.

## Root cause

Orca spawns the install command in a **non-driven ephemeral setup terminal** (a real PTY, so `stdin.isTTY` is true). The spawned command was:

```
npx skills add https://github.com/stablyai/orca --skill <names> --global
```

Note: **no `-y`**. The `skills` CLI runs an interactive `@clack/prompts` selection — *"Which agents do you want to install to?"* — whenever stdin is a TTY. Nothing drives that prompt, so it blocks forever; Orca kills the terminal after ~50s and it exits with code 1. The status never flips to "installed".

Confirmed against the `skills` CLI dist (`skills@1.5.19`): the add command only skips the prompt when `options.yes` (`-y`/`--yes`) is set, taking the non-interactive path `targetAgents = ensureUniversalAgents(installedAgents)` (all detected agents). This matches the CLI's own tip: *"use the --yes (-y) and --global (-g) flags to install without prompts."*

## Fix

Append `-y` to the install command built by `buildAgentFeatureSkillInstallCommand`, so every install surface (Settings panes, onboarding, feature tips, floating-terminal dialog) runs non-interactively and installs to all detected agents. This is the single source of truth for the spawned template, so onboarding/settings/CTA all pick it up.

With install succeeding, **Re-check** reads the real installed state and self-heals — no separate re-run needed.

### Scope

Only the **install** command changed. The **update** commands run in user-facing terminals where the `skills` CLI's upstream-deletion prompt is an intentional interactive choice, so they're deliberately left alone.

## Tests

Updated the exact-match assertions for the install command string across the affected unit tests. All install-command-related suites pass (73 passed, 1 pre-existing skip).