### PR TITLE
fix(terminal): harden macOS login-preflight spawn path (#9301 follow-ups)

### DIFF
--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -82,6 +82,18 @@ async function main(): Promise<void> {
   daemonLog.log('startup', { protocolVersion: PROTOCOL_VERSION, socketPath })
   void warmPwshAvailabilityCache()
 
+  // Why: detached daemons destroy stderr, so the preflight's console.warn is lost;
+  // surface a degraded TCC attribution here where it's diagnosable (F2).
+  const runMacosLoginPreflight = async (): Promise<void> => {
+    const outcome = await prepareMacosTccLoginShell()
+    if (outcome && !outcome.ok) {
+      daemonLog.log('macos-login-preflight', { ok: outcome.ok, reason: outcome.reason })
+    }
+  }
+  // Why: warm the PAM probe at idle startup so the first terminal spawn doesn't
+  // pay it under load — shrinking the window where a slow probe degrades (F1/F7).
+  void runMacosLoginPreflight()
+
   // Why: node-pty can throw a C++ Napi::Error that escapes all JS try/catch
   // blocks (e.g. writing to a PTY whose fd was closed between the native
   // exit signal and the JS onExit callback). Without this handler, Node's
@@ -152,7 +164,7 @@ async function main(): Promise<void> {
     ...(launchNonce ? { launchNonce } : {}),
     ...(pidPath ? { startedAtMs } : {}),
     log: daemonLog,
-    preparePtySpawn: prepareMacosTccLoginShell,
+    preparePtySpawn: runMacosLoginPreflight,
     spawnSubprocess: (opts) => createPtySubprocess(opts),
     onIdleShutdown: () => {
       shuttingDown = true

--- a/src/main/daemon/daemon-preflight-client-replacement.test.ts
+++ b/src/main/daemon/daemon-preflight-client-replacement.test.ts
@@ -1,27 +1,34 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { connect, type Socket } from 'node:net'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { DaemonClient } from './client'
 import { DaemonServer } from './daemon-server'
+import { encodeNdjson } from './ndjson'
+import { PROTOCOL_VERSION } from './types'
 import type { SubprocessHandle } from './session'
 
 type DaemonServerPrivate = {
   pendingPtySpawnPreparations: Map<string, Set<unknown>>
+  clients: Map<string, { streamSocket: Socket | null }>
 }
 
 function createMockSubprocess(): SubprocessHandle {
+  let onExitCb: ((code: number) => void) | null = null
   return {
     pid: 55555,
     getForegroundProcess: vi.fn(() => null),
     confirmForegroundProcess: vi.fn(async () => null),
     write: vi.fn(),
     resize: vi.fn(),
-    kill: vi.fn(),
-    forceKill: vi.fn(),
+    kill: vi.fn(() => setTimeout(() => onExitCb?.(0), 0)),
+    forceKill: vi.fn(() => onExitCb?.(137)),
     signal: vi.fn(),
     onData: vi.fn(),
-    onExit: vi.fn(),
+    onExit: vi.fn((cb: (code: number) => void) => {
+      onExitCb = cb
+    }),
     dispose: vi.fn()
   }
 }
@@ -38,6 +45,24 @@ describe('daemon preflight client replacement', () => {
     await server?.shutdown()
     rmSync(dir, { recursive: true, force: true })
   })
+
+  async function connectDaemonSocketPair(
+    socketPath: string,
+    tokenPath: string,
+    clientId: string
+  ): Promise<{ control: Socket; stream: Socket }> {
+    const token = readFileSync(tokenPath, 'utf-8').trim()
+    const connectRole = async (role: 'control' | 'stream'): Promise<Socket> => {
+      const socket = connect(socketPath)
+      await new Promise<void>((resolve) => socket.once('connect', resolve))
+      socket.write(
+        encodeNdjson({ type: 'hello', version: PROTOCOL_VERSION, token, clientId, role })
+      )
+      await new Promise<void>((resolve) => socket.once('data', () => resolve()))
+      return socket
+    }
+    return { control: await connectRole('control'), stream: await connectRole('stream') }
+  }
 
   it('cancels preparation when a reconnect replaces the owning control socket', async () => {
     let finishPreparation!: () => void
@@ -76,5 +101,54 @@ describe('daemon preflight client replacement', () => {
 
     replacement.disconnect()
     original.disconnect()
+  })
+
+  it('cancels only the preparation whose client loses its stream socket', async () => {
+    let finishPreparation!: () => void
+    const preparation = new Promise<void>((resolve) => {
+      finishPreparation = resolve
+    })
+    const preparePtySpawn = vi.fn(() => preparation)
+    const spawnSubprocess = vi.fn(() => createMockSubprocess())
+    const socketPath = join(dir, 'daemon.sock')
+    const tokenPath = join(dir, 'daemon.token')
+    server = new DaemonServer({ socketPath, tokenPath, preparePtySpawn, spawnSubprocess })
+    await server.start()
+
+    const disconnectedClientId = 'stream-loss-client'
+    const survivingClientId = 'stream-survivor-client'
+    const disconnected = await connectDaemonSocketPair(socketPath, tokenPath, disconnectedClientId)
+    const survivor = await connectDaemonSocketPair(socketPath, tokenPath, survivingClientId)
+    disconnected.control.write(
+      encodeNdjson({
+        id: 'req-stream-loss',
+        type: 'createOrAttach',
+        payload: { sessionId: 'stream-loss-pending', cols: 80, rows: 24 }
+      })
+    )
+    survivor.control.write(
+      encodeNdjson({
+        id: 'req-stream-survivor',
+        type: 'createOrAttach',
+        payload: { sessionId: 'stream-survivor-pending', cols: 80, rows: 24 }
+      })
+    )
+    await vi.waitFor(() => expect(preparePtySpawn).toHaveBeenCalledTimes(2))
+
+    disconnected.stream.destroy()
+    await vi.waitFor(() =>
+      expect(
+        (server as unknown as DaemonServerPrivate).clients.get(disconnectedClientId)?.streamSocket
+      ).toBeNull()
+    )
+    finishPreparation()
+    await vi.waitFor(() =>
+      expect((server as unknown as DaemonServerPrivate).pendingPtySpawnPreparations.size).toBe(0)
+    )
+    expect(spawnSubprocess).toHaveBeenCalledOnce()
+
+    disconnected.control.destroy()
+    survivor.control.destroy()
+    survivor.stream.destroy()
   })
 })

--- a/src/main/daemon/daemon-preflight-client-replacement.test.ts
+++ b/src/main/daemon/daemon-preflight-client-replacement.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { DaemonClient } from './client'
+import { DaemonServer } from './daemon-server'
+import type { SubprocessHandle } from './session'
+
+type DaemonServerPrivate = {
+  pendingPtySpawnPreparations: Map<string, Set<unknown>>
+}
+
+function createMockSubprocess(): SubprocessHandle {
+  return {
+    pid: 55555,
+    getForegroundProcess: vi.fn(() => null),
+    confirmForegroundProcess: vi.fn(async () => null),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    forceKill: vi.fn(),
+    signal: vi.fn(),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    dispose: vi.fn()
+  }
+}
+
+describe('daemon preflight client replacement', () => {
+  let dir: string
+  let server: DaemonServer
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'daemon-preflight-replacement-'))
+  })
+
+  afterEach(async () => {
+    await server?.shutdown()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('cancels preparation when a reconnect replaces the owning control socket', async () => {
+    let finishPreparation!: () => void
+    const preparation = new Promise<void>((resolve) => {
+      finishPreparation = resolve
+    })
+    const preparePtySpawn = vi.fn(() => preparation)
+    const spawnSubprocess = vi.fn(() => createMockSubprocess())
+    const socketPath = join(dir, 'daemon.sock')
+    const tokenPath = join(dir, 'daemon.token')
+    server = new DaemonServer({ socketPath, tokenPath, preparePtySpawn, spawnSubprocess })
+    await server.start()
+
+    const original = new DaemonClient({ socketPath, tokenPath })
+    const replacement = new DaemonClient({ socketPath, tokenPath })
+    ;(original as unknown as { clientId: string }).clientId = 'reused-client-id'
+    ;(replacement as unknown as { clientId: string }).clientId = 'reused-client-id'
+    await original.ensureConnected()
+    original
+      .request('createOrAttach', {
+        sessionId: 'replacement-pending',
+        cols: 80,
+        rows: 24
+      })
+      .catch(() => {
+        /* replacement disconnects the original request */
+      })
+    await vi.waitFor(() => expect(preparePtySpawn).toHaveBeenCalledOnce())
+
+    await replacement.ensureConnected()
+    finishPreparation()
+    await vi.waitFor(() =>
+      expect((server as unknown as DaemonServerPrivate).pendingPtySpawnPreparations.size).toBe(0)
+    )
+    expect(spawnSubprocess).not.toHaveBeenCalled()
+
+    replacement.disconnect()
+    original.disconnect()
+  })
+})

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -313,6 +313,56 @@ describe('DaemonServer', () => {
       expect(spawnSubprocess).not.toHaveBeenCalled()
     })
 
+    it('cancels a disconnecting client’s pending preparation to avoid an orphan PTY (F4)', async () => {
+      let finishPreparation!: () => void
+      const preparation = new Promise<void>((resolve) => {
+        finishPreparation = resolve
+      })
+      const preparePtySpawn = vi.fn(() => preparation)
+      const spawnSubprocess = vi.fn(() => createMockSubprocess())
+      server = new DaemonServer({
+        socketPath,
+        tokenPath,
+        preparePtySpawn,
+        spawnSubprocess
+      })
+      await server.start()
+      const c = await connectClient()
+
+      // Hangs in preflight; the control-socket close must abort it before spawn.
+      c.request('createOrAttach', {
+        sessionId: 'disconnect-pending',
+        cols: 80,
+        rows: 24
+      }).catch(() => {
+        /* the disconnect rejects the in-flight request; that's expected */
+      })
+      await vi.waitFor(() => expect(preparePtySpawn).toHaveBeenCalledOnce())
+
+      c.disconnect()
+      // Wait for the server to process the close (and cancel the prep) before
+      // releasing the preflight, else the resumed spawn races ahead of cancellation.
+      await vi.waitFor(() =>
+        expect((server as unknown as DaemonServerPrivate).clients.size).toBe(0)
+      )
+      finishPreparation()
+      await vi.waitFor(() => expect(preparePtySpawn).toHaveBeenCalledOnce())
+      // Give the resumed preparation a beat to (not) spawn.
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      expect(spawnSubprocess).not.toHaveBeenCalled()
+    })
+
+    it('kill with no pending preparation still surfaces SessionNotFoundError (F7)', async () => {
+      await startServer()
+      const c = await connectClient()
+
+      // No preparation was canceled, so the host's not-found verdict must propagate
+      // rather than be swallowed by the pending-spawn kill reconciliation.
+      await expect(
+        c.request('kill', { sessionId: 'never-created', immediate: true })
+      ).rejects.toThrow('Session not found: never-created')
+    })
+
     it('persists only an allowlisted launch identity across reattach', async () => {
       await startServer()
       const c = await connectClient()

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -49,6 +49,7 @@ function createMockSubprocess(): SubprocessHandle & {
 
 type DaemonServerPrivate = {
   server: Server | null
+  pendingPtySpawnPreparations: Map<string, Set<unknown>>
   host: {
     kill: (sessionId: string, opts?: { immediate?: boolean }) => void | Promise<void>
   }
@@ -346,9 +347,9 @@ describe('DaemonServer', () => {
         expect((server as unknown as DaemonServerPrivate).clients.size).toBe(0)
       )
       finishPreparation()
-      await vi.waitFor(() => expect(preparePtySpawn).toHaveBeenCalledOnce())
-      // Give the resumed preparation a beat to (not) spawn.
-      await new Promise((resolve) => setTimeout(resolve, 20))
+      await vi.waitFor(() =>
+        expect((server as unknown as DaemonServerPrivate).pendingPtySpawnPreparations.size).toBe(0)
+      )
       expect(spawnSubprocess).not.toHaveBeenCalled()
     })
 

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -541,6 +541,8 @@ export class DaemonServer {
       if (this.clients.get(client.clientId) !== client || client.streamSocket !== socket) {
         return
       }
+      // Why: a preflight that outlives its output channel would create an unattached daemon PTY.
+      this.cancelPendingPtySpawnPreparationsForClient(client.clientId)
       this.streamDataBatcher.clear(client.clientId)
       client.streamSocket = null
     }

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -462,6 +462,8 @@ export class DaemonServer {
       this.clients.set(hello.clientId, client)
       this.setupControlSocket(socket, hello.clientId)
       if (previous) {
+        // Why: reconnect reuses clientId before stale close fires; cancel the old owner's preflight at handoff.
+        this.cancelPendingPtySpawnPreparationsForClient(hello.clientId)
         this.recordFullyAuthenticatedDisconnect(previous.authenticatedPairEstablished)
         // Why: tear down the old sockets after installing the new owner so a stale close can't delete the replacement.
         previous.streamSocket?.destroy()

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -75,6 +75,9 @@ type ConnectedClient = {
 
 type PendingPtySpawnPreparation = {
   canceled: boolean
+  // Why: preparations are keyed by sessionId, but a control-socket close must
+  // cancel only the disconnecting client's preps, not another client's (F4).
+  clientId: string
 }
 
 type PendingShutdownReply = {
@@ -497,6 +500,9 @@ export class DaemonServer {
       if (client?.controlSocket !== socket) {
         return
       }
+      // Why: a client that disconnects mid-preflight would otherwise still create
+      // its daemon PTY, orphaning a durable, unattached session — cancel its preps (F4).
+      this.cancelPendingPtySpawnPreparationsForClient(clientId)
       const wasFullyAuthenticated = client.authenticatedPairEstablished
       this.streamDataBatcher.clear(clientId)
       client.streamSocket?.destroy()
@@ -610,8 +616,8 @@ export class DaemonServer {
     this.pendingShutdownReplies.set(key, { start })
   }
 
-  private async preparePtySpawnUnlessCanceled(sessionId: string): Promise<void> {
-    const preparation: PendingPtySpawnPreparation = { canceled: false }
+  private async preparePtySpawnUnlessCanceled(sessionId: string, clientId: string): Promise<void> {
+    const preparation: PendingPtySpawnPreparation = { canceled: false, clientId }
     const pending = this.pendingPtySpawnPreparations.get(sessionId) ?? new Set()
     pending.add(preparation)
     this.pendingPtySpawnPreparations.set(sessionId, pending)
@@ -646,6 +652,16 @@ export class DaemonServer {
     }
   }
 
+  private cancelPendingPtySpawnPreparationsForClient(clientId: string): void {
+    for (const pending of this.pendingPtySpawnPreparations.values()) {
+      for (const preparation of pending) {
+        if (preparation.clientId === clientId) {
+          preparation.canceled = true
+        }
+      }
+    }
+  }
+
   private async routeRequest(clientId: string, request: DaemonRequest): Promise<unknown> {
     const client = this.clients.get(clientId)
 
@@ -662,7 +678,7 @@ export class DaemonServer {
         const p = request.payload
         let result: Awaited<ReturnType<TerminalHost['createOrAttach']>>
         try {
-          await this.preparePtySpawnUnlessCanceled(p.sessionId)
+          await this.preparePtySpawnUnlessCanceled(p.sessionId, clientId)
           result = await this.host.createOrAttach({
             sessionId: p.sessionId,
             cols: p.cols,

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -327,6 +327,39 @@ describe('LocalPtyProvider', () => {
       expect(spawnMock).toHaveBeenCalledOnce()
     })
 
+    it('coalesces a concurrent same-session-id spawn onto the winner instead of orphaning it (F3)', async () => {
+      spawnMock.mockClear()
+      // Distinct procs so we can prove the redundant shell is torn down, not tracked.
+      const procA = { ...mockProc, pid: 1001 }
+      // Hold the kill spy separately: destroyPtyProcess neutralizes proc.kill after
+      // calling it, so the reference on procB is swapped out post-teardown.
+      const killB = vi.fn()
+      const procB = { ...mockProc, pid: 2002, kill: killB }
+      spawnMock.mockReturnValueOnce(procA).mockReturnValueOnce(procB)
+
+      // Hold both spawns past the existence check and inside the preflight so they
+      // race to register the same id; release only after both are parked.
+      let releasePreflight!: () => void
+      prepareMacosTccLoginShellMock.mockReturnValue(
+        new Promise<void>((resolve) => {
+          releasePreflight = resolve
+        })
+      )
+
+      const spawnA = provider.spawn({ cols: 80, rows: 24, sessionId: 'race-session' })
+      const spawnB = provider.spawn({ cols: 80, rows: 24, sessionId: 'race-session' })
+      await vi.waitFor(() => expect(prepareMacosTccLoginShellMock).toHaveBeenCalledTimes(2))
+      releasePreflight()
+
+      const [a, b] = await Promise.all([spawnA, spawnB])
+      // The winner owns the tracked PTY; the loser attaches to it, not a second one.
+      expect(a.isReattach).toBeUndefined()
+      expect(b.isReattach).toBe(true)
+      expect(b.pid).toBe(procA.pid)
+      expect(provider.getPtyProcess('race-session')).toBe(procA)
+      expect(killB).toHaveBeenCalledOnce()
+    })
+
     it('calls node-pty spawn with correct args', async () => {
       await provider.spawn({ cols: 120, rows: 40, cwd: '/tmp' })
       expect(spawnMock).toHaveBeenCalledWith(

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -327,15 +327,10 @@ describe('LocalPtyProvider', () => {
       expect(spawnMock).toHaveBeenCalledOnce()
     })
 
-    it('coalesces a concurrent same-session-id spawn onto the winner instead of orphaning it (F3)', async () => {
+    it('coalesces a concurrent same-session-id spawn before launching a redundant shell (F3)', async () => {
       spawnMock.mockClear()
-      // Distinct procs so we can prove the redundant shell is torn down, not tracked.
       const procA = { ...mockProc, pid: 1001 }
-      // Hold the kill spy separately: destroyPtyProcess neutralizes proc.kill after
-      // calling it, so the reference on procB is swapped out post-teardown.
-      const killB = vi.fn()
-      const procB = { ...mockProc, pid: 2002, kill: killB }
-      spawnMock.mockReturnValueOnce(procA).mockReturnValueOnce(procB)
+      spawnMock.mockReturnValueOnce(procA)
 
       // Hold both spawns past the existence check and inside the preflight so they
       // race to register the same id; release only after both are parked.
@@ -347,7 +342,7 @@ describe('LocalPtyProvider', () => {
       )
 
       const spawnA = provider.spawn({ cols: 80, rows: 24, sessionId: 'race-session' })
-      const spawnB = provider.spawn({ cols: 80, rows: 24, sessionId: 'race-session' })
+      const spawnB = provider.spawn({ cols: 132, rows: 44, sessionId: 'race-session' })
       await vi.waitFor(() => expect(prepareMacosTccLoginShellMock).toHaveBeenCalledTimes(2))
       releasePreflight()
 
@@ -357,7 +352,8 @@ describe('LocalPtyProvider', () => {
       expect(b.isReattach).toBe(true)
       expect(b.pid).toBe(procA.pid)
       expect(provider.getPtyProcess('race-session')).toBe(procA)
-      expect(killB).toHaveBeenCalledOnce()
+      expect(spawnMock).toHaveBeenCalledOnce()
+      expect(procA.resize).toHaveBeenCalledWith(132, 44)
     })
 
     it('calls node-pty spawn with correct args', async () => {

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -365,6 +365,24 @@ function normalizeLocalCallerSessionId(sessionId: string | undefined): string | 
   return requested
 }
 
+function reattachLocalPty(id: string, cols: number, rows: number): PtySpawnResult | null {
+  const existing = ptyProcesses.get(id)
+  if (!existing) {
+    return null
+  }
+  try {
+    existing.resize(cols, rows)
+  } catch {
+    /* Existing PTY may reject resize during teardown; still return the live handle. */
+  }
+  return {
+    id,
+    pid: existing.pid,
+    ...(ptyWslDistroById.has(id) ? { wslDistro: ptyWslDistroById.get(id) ?? null } : {}),
+    isReattach: true
+  }
+}
+
 /**
  * Normalizes node-pty foreground process strings to executable basenames.
  */
@@ -499,20 +517,9 @@ export class LocalPtyProvider implements IPtyProvider {
       if (pendingShutdown) {
         await pendingShutdown.promise
       }
-      const existing = ptyProcesses.get(reattachId)
+      const existing = reattachLocalPty(reattachId, args.cols, args.rows)
       if (existing) {
-        const existingWslDistro = ptyWslDistroById.get(reattachId)
-        try {
-          existing.resize(args.cols, args.rows)
-        } catch {
-          /* Existing PTY may reject resize during teardown; still return the live handle. */
-        }
-        return {
-          id: reattachId,
-          pid: existing.pid,
-          ...(ptyWslDistroById.has(reattachId) ? { wslDistro: existingWslDistro ?? null } : {}),
-          isReattach: true
-        }
+        return existing
       }
     }
     const id = allocatePtyId(reattachId ?? undefined)
@@ -787,6 +794,11 @@ export class LocalPtyProvider implements IPtyProvider {
     }
 
     await prepareLocalPtySpawn(id)
+    // Why: another same-id request can win while this one awaits preflight; attach before launching a redundant shell.
+    const concurrentWinner = reattachId ? reattachLocalPty(id, args.cols, args.rows) : null
+    if (concurrentWinner) {
+      return concurrentWinner
+    }
     const spawnResult = spawnShellWithFallback({
       shellPath,
       shellArgs,
@@ -820,25 +832,6 @@ export class LocalPtyProvider implements IPtyProvider {
     const spawnedShellIsWsl =
       process.platform === 'win32' && pathWin32.basename(shellPath).toLowerCase() === 'wsl.exe'
     const spawnedWslDistro = spawnedShellIsWsl ? (launchWslDistro ?? undefined) : null
-    // Why: a concurrent spawn for the same stable session id can register while we
-    // await the preflight; the tracking write below is synchronous from that await,
-    // so a live id here means we lost the race. Tear down this redundant shell and
-    // attach to the winner instead of orphaning an untracked, unkillable PTY (F3).
-    if (reattachId && ptyProcesses.has(id)) {
-      const winner = ptyProcesses.get(id)
-      try {
-        proc.kill()
-      } catch {
-        /* the redundant shell may already be gone */
-      }
-      destroyPtyProcess(proc, { alreadyKilled: true })
-      return {
-        id,
-        pid: winner?.pid ?? proc.pid,
-        ...(ptyWslDistroById.has(id) ? { wslDistro: ptyWslDistroById.get(id) ?? null } : {}),
-        isReattach: true
-      }
-    }
     createPtyPhysicalExit(id)
     ptyProcesses.set(id, proc)
     ptyInitialCwd.set(id, cwd)

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -820,6 +820,25 @@ export class LocalPtyProvider implements IPtyProvider {
     const spawnedShellIsWsl =
       process.platform === 'win32' && pathWin32.basename(shellPath).toLowerCase() === 'wsl.exe'
     const spawnedWslDistro = spawnedShellIsWsl ? (launchWslDistro ?? undefined) : null
+    // Why: a concurrent spawn for the same stable session id can register while we
+    // await the preflight; the tracking write below is synchronous from that await,
+    // so a live id here means we lost the race. Tear down this redundant shell and
+    // attach to the winner instead of orphaning an untracked, unkillable PTY (F3).
+    if (reattachId && ptyProcesses.has(id)) {
+      const winner = ptyProcesses.get(id)
+      try {
+        proc.kill()
+      } catch {
+        /* the redundant shell may already be gone */
+      }
+      destroyPtyProcess(proc, { alreadyKilled: true })
+      return {
+        id,
+        pid: winner?.pid ?? proc.pid,
+        ...(ptyWslDistroById.has(id) ? { wslDistro: ptyWslDistroById.get(id) ?? null } : {}),
+        isReattach: true
+      }
+    }
     createPtyPhysicalExit(id)
     ptyProcesses.set(id, proc)
     ptyInitialCwd.set(id, cwd)

--- a/src/main/providers/macos-tcc-login-shell.test.ts
+++ b/src/main/providers/macos-tcc-login-shell.test.ts
@@ -51,6 +51,7 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     } else {
       process.env.ORCA_DISABLE_MACOS_LOGIN_SHELL = origDisable
     }
+    vi.restoreAllMocks()
     vi.clearAllMocks()
   })
 
@@ -115,8 +116,10 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     expect(console.warn).toHaveBeenCalledTimes(1)
   })
 
-  it('re-probes after a transient timeout instead of caching the degrade (F1)', async () => {
+  it('backs off repeated transient timeouts instead of delaying every terminal spawn (F1)', async () => {
     setPlatform('darwin')
+    let now = 1_000
+    vi.spyOn(Date, 'now').mockImplementation(() => now)
     // A probe our own SIGKILL cap killed proves nothing about PAM; it must retry.
     execFileMock.mockImplementation(
       (_file: string, _args: string[], _options: unknown, callback: ExecFileCallback) => {
@@ -131,13 +134,27 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     // Degraded probe fails open to a direct shell for this spawn...
     expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l']).file).toBe('/bin/zsh')
 
-    // ...but a later spawn re-runs the probe rather than reusing the timeout.
+    // ...without making every subsequent terminal pay the same 500 ms timeout.
+    await prepareMacosTccLoginShell()
+    expect(execFileMock).toHaveBeenCalledOnce()
+
+    now += 5_000
     await prepareMacosTccLoginShell()
     expect(execFileMock).toHaveBeenCalledTimes(2)
+
+    // Repeated failures back off further rather than spawning login(1) every 5 seconds.
+    now += 5_000
+    await prepareMacosTccLoginShell()
+    expect(execFileMock).toHaveBeenCalledTimes(2)
+    now += 5_000
+    await prepareMacosTccLoginShell()
+    expect(execFileMock).toHaveBeenCalledTimes(3)
   })
 
   it('self-heals to the login wrapper once a re-probe succeeds (F1)', async () => {
     setPlatform('darwin')
+    let now = 1_000
+    vi.spyOn(Date, 'now').mockImplementation(() => now)
     let attempt = 0
     execFileMock.mockImplementation(
       (_file: string, _args: string[], _options: unknown, callback: ExecFileCallback) => {
@@ -154,6 +171,10 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
 
     await prepareMacosTccLoginShell()
     await prepareMacosTccLoginShell()
+    expect(execFileMock).toHaveBeenCalledOnce()
+    now += 5_000
+    await prepareMacosTccLoginShell()
+    expect(execFileMock).toHaveBeenCalledTimes(2)
     expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l']).file).toBe('/usr/bin/login')
   })
 

--- a/src/main/providers/macos-tcc-login-shell.test.ts
+++ b/src/main/providers/macos-tcc-login-shell.test.ts
@@ -96,11 +96,12 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     )
   })
 
-  it('caches a failed login preflight for later terminal spawns', async () => {
+  it('caches a conclusive PAM rejection for later terminal spawns', async () => {
     setPlatform('darwin')
     execFileMock.mockImplementation(
       (_file: string, _args: string[], _options: unknown, callback: ExecFileCallback) => {
-        callback(new Error('timed out'), '', '')
+        // login(1) exiting non-zero on its own is a deterministic PAM verdict.
+        callback(Object.assign(new Error('login incorrect'), { code: 1 }), '', '')
         return { stdin: { end: stdinEndMock } }
       }
     )
@@ -112,6 +113,64 @@ describe('wrapShellSpawnForMacosTccAttribution', () => {
     expect(wrapShellSpawnForMacosTccAttribution('/bin/bash', ['-l']).file).toBe('/bin/bash')
     expect(execFileMock).toHaveBeenCalledTimes(1)
     expect(console.warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-probes after a transient timeout instead of caching the degrade (F1)', async () => {
+    setPlatform('darwin')
+    // A probe our own SIGKILL cap killed proves nothing about PAM; it must retry.
+    execFileMock.mockImplementation(
+      (_file: string, _args: string[], _options: unknown, callback: ExecFileCallback) => {
+        callback(Object.assign(new Error('timed out'), { killed: true }), '', '')
+        return { stdin: { end: stdinEndMock } }
+      }
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const first = await prepareMacosTccLoginShell()
+    expect(first).toEqual({ ok: false, conclusive: false, reason: 'timeout' })
+    // Degraded probe fails open to a direct shell for this spawn...
+    expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l']).file).toBe('/bin/zsh')
+
+    // ...but a later spawn re-runs the probe rather than reusing the timeout.
+    await prepareMacosTccLoginShell()
+    expect(execFileMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('self-heals to the login wrapper once a re-probe succeeds (F1)', async () => {
+    setPlatform('darwin')
+    let attempt = 0
+    execFileMock.mockImplementation(
+      (_file: string, _args: string[], _options: unknown, callback: ExecFileCallback) => {
+        attempt += 1
+        if (attempt === 1) {
+          callback(Object.assign(new Error('timed out'), { killed: true }), '', '')
+        } else {
+          callback(null, 'ORCA_LOGIN_PREFLIGHT_OK', '')
+        }
+        return { stdin: { end: stdinEndMock } }
+      }
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await prepareMacosTccLoginShell()
+    await prepareMacosTccLoginShell()
+    expect(wrapShellSpawnForMacosTccAttribution('/bin/zsh', ['-l']).file).toBe('/usr/bin/login')
+  })
+
+  it('returns a conclusive outcome the daemon can log structurally (F2)', async () => {
+    setPlatform('darwin')
+    execFileMock.mockImplementation(
+      (_file: string, _args: string[], _options: unknown, callback: ExecFileCallback) => {
+        callback(null, 'Login incorrect\nlogin: ', '')
+        return { stdin: { end: stdinEndMock } }
+      }
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const outcome = await prepareMacosTccLoginShell()
+    expect(outcome).toEqual({ ok: false, conclusive: true, reason: 'rejected' })
+    // A second call is short-circuited by the cache, so nothing new to log.
+    expect(await prepareMacosTccLoginShell()).toBeNull()
   })
 
   it('rejects a marker emitted by a preflight that does not exit cleanly', async () => {

--- a/src/main/providers/macos-tcc-login-shell.ts
+++ b/src/main/providers/macos-tcc-login-shell.ts
@@ -8,6 +8,8 @@ const MACOS_PRINTF_PATH = '/usr/bin/printf'
 const LOGIN_PREFLIGHT_TIMEOUT_MS = 500
 const LOGIN_PREFLIGHT_MARKER = 'ORCA_LOGIN_PREFLIGHT_OK'
 const LOGIN_PREFLIGHT_MAX_BUFFER_BYTES = 1024
+const LOGIN_PREFLIGHT_RETRY_BASE_MS = 5_000
+const LOGIN_PREFLIGHT_RETRY_MAX_MS = 5 * 60_000
 
 /**
  * Env escape hatch to force the plain (unwrapped) spawn. Set to `1`/`true` if a
@@ -29,10 +31,18 @@ export type LoginPreflightOutcome = {
 
 let cachedLoginPreflightResult: boolean | null = null
 let loginPreflightInFlight: Promise<LoginPreflightOutcome> | null = null
+let transientLoginPreflightFailure: { failureCount: number; retryAtMs: number } | null = null
 
 function isDisabledByEnv(): boolean {
   const value = process.env[DISABLE_ENV_VAR]
   return value === '1' || value === 'true'
+}
+
+function loginPreflightRetryDelayMs(failureCount: number): number {
+  return Math.min(
+    LOGIN_PREFLIGHT_RETRY_MAX_MS,
+    LOGIN_PREFLIGHT_RETRY_BASE_MS * 2 ** Math.max(0, failureCount - 1)
+  )
 }
 
 function classifyPreflightError(error: ExecFileException): LoginPreflightOutcome {
@@ -118,6 +128,13 @@ function loginPreflightSucceeds(
       // environmental and must be retried next spawn, not stuck forever (F1).
       if (outcome.conclusive) {
         cachedLoginPreflightResult = outcome.ok
+        transientLoginPreflightFailure = null
+      } else {
+        const failureCount = (transientLoginPreflightFailure?.failureCount ?? 0) + 1
+        transientLoginPreflightFailure = {
+          failureCount,
+          retryAtMs: Date.now() + loginPreflightRetryDelayMs(failureCount)
+        }
       }
       if (!outcome.ok) {
         console.warn('[pty] macOS login(1) preflight failed; spawning shells directly')
@@ -148,6 +165,10 @@ export async function prepareMacosTccLoginShell(): Promise<LoginPreflightOutcome
   if (cachedLoginPreflightResult !== null) {
     return null
   }
+  // Why: a persistently hung probe must not add 500 ms and a subprocess to every terminal spawn.
+  if (transientLoginPreflightFailure && Date.now() < transientLoginPreflightFailure.retryAtMs) {
+    return null
+  }
   if (!existsSync(MACOS_LOGIN_PATH)) {
     return null
   }
@@ -170,6 +191,7 @@ export async function prepareMacosTccLoginShell(): Promise<LoginPreflightOutcome
 export function resetMacosLoginShellPreflightForTests(): void {
   cachedLoginPreflightResult = null
   loginPreflightInFlight = null
+  transientLoginPreflightFailure = null
 }
 
 /**

--- a/src/main/providers/macos-tcc-login-shell.ts
+++ b/src/main/providers/macos-tcc-login-shell.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'node:child_process'
+import { execFile, type ExecFileException } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { userInfo } from 'node:os'
 
@@ -16,15 +16,44 @@ const LOGIN_PREFLIGHT_MAX_BUFFER_BYTES = 1024
  */
 const DISABLE_ENV_VAR = 'ORCA_DISABLE_MACOS_LOGIN_SHELL'
 
+/**
+ * Result of one PAM probe. `conclusive` marks a real PAM verdict (accept or
+ * reject) that may be cached; an inconclusive probe (our own timeout/SIGKILL,
+ * maxBuffer, or spawn error) proves nothing about PAM and must not stick.
+ */
+export type LoginPreflightOutcome = {
+  ok: boolean
+  conclusive: boolean
+  reason: 'accepted' | 'rejected' | 'timeout' | 'error'
+}
+
 let cachedLoginPreflightResult: boolean | null = null
-let loginPreflightInFlight: Promise<boolean> | null = null
+let loginPreflightInFlight: Promise<LoginPreflightOutcome> | null = null
 
 function isDisabledByEnv(): boolean {
   const value = process.env[DISABLE_ENV_VAR]
   return value === '1' || value === 'true'
 }
 
-function runLoginPreflight(username: string, accountHome: string): Promise<boolean> {
+function classifyPreflightError(error: ExecFileException): LoginPreflightOutcome {
+  // Why: our SIGKILL timeout cap (and maxBuffer, which also kills) is an
+  // environmental slow-path, not a PAM verdict — retry, don't cache (F1).
+  if (error.killed || error.code === 'ETIMEDOUT') {
+    return { ok: false, conclusive: false, reason: 'timeout' }
+  }
+  // A numeric exit code means login(1) ran to completion and rejected the user
+  // (it exits immediately on EOF-driven rejection); that verdict is cacheable.
+  if (typeof error.code === 'number') {
+    return { ok: false, conclusive: true, reason: 'rejected' }
+  }
+  // Spawn/EOF/other failure: inconclusive, fail open for this spawn but retry.
+  return { ok: false, conclusive: false, reason: 'error' }
+}
+
+// Fidelity limit: the probe runs over pipes while production shells run under a
+// real PTY, so a tty-sensitive PAM stack could diverge. It fails safe — a probe
+// pass with a prod failure only degrades to today's direct spawn (no wrapper).
+function runLoginPreflight(username: string, accountHome: string): Promise<LoginPreflightOutcome> {
   return new Promise((resolve) => {
     try {
       const child = execFile(
@@ -42,33 +71,61 @@ function runLoginPreflight(username: string, accountHome: string): Promise<boole
           timeout: LOGIN_PREFLIGHT_TIMEOUT_MS
         },
         (error, stdout) => {
-          // login(1) can return zero after an EOF-driven failed prompt, so only the
-          // requested child program's output plus a clean exit proves PAM accepted it.
-          resolve(error === null && stdout === LOGIN_PREFLIGHT_MARKER)
+          if (error === null) {
+            // login(1) can return zero after an EOF-driven failed prompt, so only the
+            // requested child program's output plus a clean exit proves PAM accepted it.
+            resolve(
+              stdout === LOGIN_PREFLIGHT_MARKER
+                ? { ok: true, conclusive: true, reason: 'accepted' }
+                : { ok: false, conclusive: true, reason: 'rejected' }
+            )
+            return
+          }
+          resolve(classifyPreflightError(error))
         }
       )
       // Why: login(1) must see immediate EOF, not an interactive pipe, so a PAM
       // rejection exits instead of waiting at `login:` until the timeout.
       child.stdin?.end()
     } catch {
-      resolve(false)
+      resolve({ ok: false, conclusive: false, reason: 'error' })
     }
   })
 }
 
-function loginPreflightSucceeds(username: string, accountHome: string): Promise<boolean> {
-  if (cachedLoginPreflightResult !== null) {
-    return Promise.resolve(cachedLoginPreflightResult)
+function cachedOutcome(): LoginPreflightOutcome | null {
+  if (cachedLoginPreflightResult === null) {
+    return null
+  }
+  return cachedLoginPreflightResult
+    ? { ok: true, conclusive: true, reason: 'accepted' }
+    : { ok: false, conclusive: true, reason: 'rejected' }
+}
+
+function loginPreflightSucceeds(
+  username: string,
+  accountHome: string
+): Promise<LoginPreflightOutcome> {
+  const cached = cachedOutcome()
+  if (cached) {
+    return Promise.resolve(cached)
   }
   if (!loginPreflightInFlight) {
     // Why: simultaneous pane restores share one PAM child instead of multiplying
     // subprocesses at exactly the point terminal startup is already busiest.
-    loginPreflightInFlight = runLoginPreflight(username, accountHome).then((result) => {
-      cachedLoginPreflightResult = result
-      if (!result) {
+    loginPreflightInFlight = runLoginPreflight(username, accountHome).then((outcome) => {
+      // Why: cache only a conclusive PAM verdict; a killed/timed-out probe is
+      // environmental and must be retried next spawn, not stuck forever (F1).
+      if (outcome.conclusive) {
+        cachedLoginPreflightResult = outcome.ok
+      }
+      if (!outcome.ok) {
         console.warn('[pty] macOS login(1) preflight failed; spawning shells directly')
       }
-      return result
+      // Why: release the in-flight slot so an inconclusive probe can re-run on the
+      // next spawn instead of pinning every terminal to the degraded outcome.
+      loginPreflightInFlight = null
+      return outcome
     })
   }
   return loginPreflightInFlight
@@ -78,16 +135,21 @@ function loginPreflightSucceeds(username: string, accountHome: string): Promise<
  * Resolves the one-time PAM capability check before a fresh PTY is spawned.
  * Callers await this at their async request boundary so existing terminals and
  * the Electron main thread remain responsive while login(1) runs.
+ *
+ * Returns the probe outcome when a probe actually ran this call, or `null` when
+ * short-circuited (non-macOS, disabled, already cached, no login binary). The
+ * daemon uses the return to emit a structured degrade record, since detached
+ * daemons destroy stderr and never surface the console.warn above (F2).
  */
-export async function prepareMacosTccLoginShell(): Promise<void> {
+export async function prepareMacosTccLoginShell(): Promise<LoginPreflightOutcome | null> {
   if (process.platform !== 'darwin' || isDisabledByEnv()) {
-    return
+    return null
   }
   if (cachedLoginPreflightResult !== null) {
-    return
+    return null
   }
   if (!existsSync(MACOS_LOGIN_PATH)) {
-    return
+    return null
   }
 
   let username: string
@@ -97,12 +159,12 @@ export async function prepareMacosTccLoginShell(): Promise<void> {
     username = account.username
     accountHome = account.homedir
   } catch {
-    return
+    return null
   }
   if (!username || !accountHome) {
-    return
+    return null
   }
-  await loginPreflightSucceeds(username, accountHome)
+  return loginPreflightSucceeds(username, accountHome)
 }
 
 export function resetMacosLoginShellPreflightForTests(): void {


### PR DESCRIPTION
Follow-ups to the two-pass review on #9301 (`fix(terminal): bypass rejected macOS login sessions`). I re-derived each finding's severity from the code rather than trusting the review labels. None are release blockers; these are low-likelihood robustness, observability, and bounded-work fixes.

## What's fixed

**F1 — transient probe failures recover without taxing every spawn** (`macos-tcc-login-shell.ts`)
The probe returns `{ok, conclusive, reason}`. Only a conclusive PAM verdict caches permanently. A probe killed by our SIGKILL timeout / `ETIMEDOUT` / maxBuffer is inconclusive: it fails open to a direct shell, then retries with 5-second exponential backoff capped at 5 minutes. This preserves self-healing without adding a 500 ms wait and a `login(1)` subprocess to every terminal spawn when the environmental failure persists.

**F2 — degrade is diagnosable** (`daemon-entry.ts`)
`prepareMacosTccLoginShell()` returns the outcome; the daemon emits a structured `macos-login-preflight {ok, reason}` log on degrade, since detached daemons destroy stderr and lose the `console.warn`.

**F3 — concurrent same-session-id spawn is coalesced before process launch** (`local-pty-provider.ts`)
After the only async preparation boundary, the loser re-checks the stable session ID and attaches to the winner before calling node-pty. This avoids both an orphan and the prior follow-up's redundant spawn-then-kill subprocess. The winning PTY receives the later request's resize and retains its native/WSL metadata.

**F4 — pending daemon preparation follows connection ownership** (`daemon-server.ts`)
Preparations carry their `clientId`; control- or stream-socket loss cancels only that client's pending work. Reconnect handoff also cancels the old owner's preparation synchronously, covering the same-ID socket-replacement path where the stale close handler intentionally does nothing. Other clients' preparations are unaffected.

**F7**
Warm the PAM probe at daemon startup (mirrors `warmPwshAvailabilityCache`); document the pipe-vs-PTY probe fidelity limit; preserve `SessionNotFoundError` when `kill` has no pending preparation.

## Deliberately not fixed

- **F5** (orphan sweep misses in-flight spawns): self-limits to the next reload, and a complete fix needs generation ownership for in-flight local work.
- **F6** (hibernated v22 wake bypasses v23 preflight): inherent to legacy attach; self-heals once daemons are v23.
- F7 error-name unification: cosmetic cross-layer churn.

## Reliability and performance contract

- **Invariant:** a fresh terminal reaches the configured shell; a rejected/hung PAM probe never strands the PTY at `login:`. One stable local session ID owns at most one native PTY, and a disconnected/replaced daemon client cannot create a later orphan.
- **Failure sources:** transient or persistent PAM timeout, concurrent same-ID local spawn, control- or stream-socket loss during preparation, and same-client-ID reconnect before the stale close event.
- **Oracle:** deterministic tests count `execFile`, node-pty spawn, resize, and daemon subprocess calls. Persistent failures attempt at t=0, 5s, and 15s rather than every spawn; two concurrent local requests produce one native spawn; a lost owner's control or stream socket and reconnect replacement produce zero subprocesses after ownership cancellation, while unrelated clients continue.
- **Gate:** focused provider/daemon unit coverage is the deterministic gate. The existing real macOS Electron run covers the healthy spawn/reattach path; live PAM-timeout and socket-replacement fault injection remain accepted gaps.
- **Provider/platform coverage:** macOS local and daemon paths are covered. The stable-ID coalescing path is platform-neutral and retains Windows/WSL metadata semantics. SSH/remote and mobile/relay do not execute this local/daemon preflight path and are unaffected.
- **Diagnostics:** detached-daemon degradation is recorded as structured metadata without PAM output or account details.
- **Performance budget:** no polling, timers, global session inventories, or provider fanout were added. Retry state is O(1), probes remain in-flight deduplicated, retry frequency is exponentially bounded, and concurrent same-ID requests now launch one native process instead of two.

## Tests

- 139/139 focused tests across macOS preflight, local PTY, daemon server, and client ownership suites.
- 11 adjacent terminal/daemon/provider suites passed, including session teardown, terminal host, daemon adapter respawn/reattach, subprocess, entry/main, and IPC.
- `pnpm run typecheck:node` passed.
- Changed-file oxlint, React Doctor lint, oxfmt, and `git diff --check` passed.
- Existing Electron dev-build macOS happy-path evidence is attached below.