### PR TITLE
fix(terminal): disarm stale TUI modes when a pane confirms return to shell

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -5606,6 +5606,88 @@ describe('connectPanePty', () => {
     expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('alt-enter')
   })
 
+  it('disarms stale TUI modes in the emulator after a confirmed return to shell', async () => {
+    vi.useFakeTimers()
+    const { connectPanePty } = await import('./pty-connection')
+    vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('bash')
+    const dataCallbackRef: { current: ((data: string) => void) | null } = { current: null }
+    const ptyId = 'pty-stale-mode-disarm'
+    const transport = createMockTransport(ptyId)
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      dataCallbackRef.current = callbacks.onData ?? null
+      return { id: ptyId }
+    })
+    transportFactoryQueue.push(transport)
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    const pane = createPane(1)
+    const { writes } = captureCallbackTerminalWrites(pane)
+
+    connectPanePty(
+      pane as never,
+      createManager(1) as never,
+      createDeps({ isVisibleRef: { current: false } }) as never
+    )
+    await vi.advanceTimersByTimeAsync(20)
+    await flushAsyncTicks()
+    mockStoreState.agentLaunchConfigByPaneKey[paneKey] = {
+      launchConfig: { agentArgs: '', agentEnv: {} },
+      identity: { agentType: 'droid' }
+    }
+
+    // A SIGKILLed agent emits no mode teardown; only the shell's next prompt
+    // mark arrives. The bare 133;D must not disarm yet — the foreground read
+    // has not confirmed the agent is gone.
+    dataCallbackRef.current?.('\x1b]133;D;0\x07')
+    expect(writes.some((w) => w.includes(POST_REPLAY_REATTACH_RESET))).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(350)
+    await flushAsyncTicks()
+
+    const disarm = writes.find((w) => w.includes(POST_REPLAY_REATTACH_RESET))
+    expect(disarm).toBeDefined()
+    // The live shell re-arms bracketed paste at its prompt before the disarm
+    // fires; the reset must not strip it.
+    expect(disarm).not.toContain('\x1b[?2004l')
+  })
+
+  it('keeps armed modes while the agent still owns the foreground after a leaked 133;D', async () => {
+    vi.useFakeTimers()
+    const { connectPanePty } = await import('./pty-connection')
+    vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('droid')
+    const dataCallbackRef: { current: ((data: string) => void) | null } = { current: null }
+    const ptyId = 'pty-stale-mode-live-agent'
+    const transport = createMockTransport(ptyId)
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      dataCallbackRef.current = callbacks.onData ?? null
+      return { id: ptyId }
+    })
+    transportFactoryQueue.push(transport)
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    const pane = createPane(1)
+    const { writes } = captureCallbackTerminalWrites(pane)
+
+    connectPanePty(
+      pane as never,
+      createManager(1) as never,
+      createDeps({ isVisibleRef: { current: false } }) as never
+    )
+    await vi.advanceTimersByTimeAsync(20)
+    await flushAsyncTicks()
+    mockStoreState.agentLaunchConfigByPaneKey[paneKey] = {
+      launchConfig: { agentArgs: '', agentEnv: {} },
+      identity: { agentType: 'droid' }
+    }
+
+    // A full-screen agent's nested command shell leaks a 133;D onto the main
+    // PTY; the confirming read republishes the live agent, so its armed
+    // mouse/kitty modes must survive untouched.
+    dataCallbackRef.current?.('\x1b]133;D;0\x07')
+    await vi.advanceTimersByTimeAsync(350 + 1200 + 6000)
+    await flushAsyncTicks()
+
+    expect(writes.some((w) => w.includes(POST_REPLAY_REATTACH_RESET))).toBe(false)
+  })
+
   it('retires stale routing after unavailable command-finish reads without asserting shell', async () => {
     vi.useFakeTimers()
     const { connectPanePty } = await import('./pty-connection')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1990,6 +1990,12 @@ export function connectPanePty(
     hasKnownAgentIdentity: paneHasKnownAgentIdentity,
     onConfirmedShellForeground: (reason) => {
       clearStaleAgentTabTitleOnConfirmedShell()
+      // Why: a hard-killed agent leaves mouse/focus/kitty modes armed, and the
+      // surviving shell then receives pointer moves as typed SGR reports; the
+      // replay guard keeps xterm's auto-replies from leaking to the shell.
+      replayIntoTerminal(pane, deps.replayingPanesRef, POST_REPLAY_REATTACH_RESET, {
+        shouldRefreshViewportSynchronously: shouldRefreshForegroundSynchronously
+      })
       if (reason === 'visible-pty') {
         useAppStore.getState().clearAgentLaunchConfig(cacheKey)
         return


### PR DESCRIPTION
## Problem

When a TUI agent is killed hard (SIGKILL via a process manager, OOM, crash) while its parent shell survives, it never restores the terminal modes it armed. The emulator keeps any-motion mouse tracking (1003/1006), focus reporting (1004), and Kitty keyboard flags on, with two user-visible consequences:

- every pointer movement over the pane lands as typed SGR motion reports at the shell prompt (`35;250;36M35;216;39M…`), filling the input line with garbage that is one Enter away from executing;
- while the doomed TUI is still alive, the same any-motion firehose keeps waking it to parse events — we traced a "fully idle" agent pinned at ~4.5% CPU to exactly this.

Observed in production with Claude Code (arms mouse reporting for scroll support) killed via btop; any mouse-mode TUI reproduces it.

## Why existing resets don't cover it

The codebase already sanitizes stale modes on the *dead-PTY* paths — hibernation kills (`POST_REPLAY_MODE_RESET`) and daemon reattach (`POST_REPLAY_REATTACH_RESET`) — and #9259 filters leaked *focus* reports after Codex history resume. But an agent dying **under a live shell** never crosses any of those paths: the PTY never exits, no replay happens, and the modes stay armed indefinitely.

## Fix

Fire `POST_REPLAY_REATTACH_RESET` (reused — its value is exactly the safe-for-a-live-shell bundle: cursor style/visibility, Kitty flags, all mouse protocols/encodings, focus reporting) at the pane-foreground-agent tracker's **confirmed return-to-shell** transition (`onConfirmedShellForeground`), next to the existing stale-title cleanup — the same residue class, one level down. The write goes through `replayIntoTerminal` so the replay guard keeps xterm's auto-replies from leaking to the shell as input.

Bracketed paste (`?2004l`) is deliberately **not** reset here: the surviving shell re-arms it at its prompt before the confirming read lands, so disabling it would strip paste protection the shell itself requested. (The dead-PTY paths keep the full bundle — there is no live shell to protect.)

The confirmed-shell transition only fires after a foreground process read proves the agent is gone (a leaked nested-shell `133;D` under a live full-screen agent republishes the agent and does not disarm — covered by a test).

## Tests

- `disarms stale TUI modes in the emulator after a confirmed return to shell` — fails on unpatched main, passes with the fix; also asserts no disarm on the bare `133;D` before confirmation, and that the reset excludes `?2004l`.
- `keeps armed modes while the agent still owns the foreground after a leaked 133;D` — negative control.
- Full `terminal-pane` suite green with the change (2,229 tests at v1.4.146, 493 in the touched files on main).

## Verification beyond CI

Dogfooded on a patched v1.4.146 build: the original repro (btop-SIGKILL a claude pane, then mouse over the window) produced a clean prompt on every pane; before the patch it reliably spewed motion reports.

---

This fix was authored, tested, and verified by Claude (Fable 5)


## ELI5

If a TUI agent is killed hard, mouse-tracking and special keyboard modes could stick on and dump garbage at the shell prompt. When the pane is back at a shell, Orca disarms those leftover modes.
