### PR TITLE
fix(accounts): follow the runtime for WSL provider account detection (#9537)

### DIFF
--- a/src/main/claude-accounts/runtime-auth-service.test.ts
+++ b/src/main/claude-accounts/runtime-auth-service.test.ts
@@ -3537,6 +3537,72 @@ describe('ClaudeRuntimeAuthService', () => {
     })
   })
 
+  it('uses the global WSL runtime for untargeted Claude preparation under auto', async () => {
+    setPlatform('win32')
+    vi.doMock('../wsl', () => ({
+      getDefaultWslDistro: () => 'Ubuntu',
+      getWslHome: () => null,
+      toWindowsWslPath: (value: string) => value
+    }))
+    const ubuntuAuthPath = createManagedClaudeAuth(
+      testState.userDataDir,
+      'ubuntu-account',
+      createClaudeCredentialsJson('ubuntu@example.com', 'ubuntu-token')
+    )
+    const settings = createSettings({
+      localAccountRuntime: 'auto',
+      localWindowsRuntimeDefault: { kind: 'wsl', distro: 'Ubuntu' },
+      claudeManagedAccounts: [
+        createClaudeAccount('ubuntu-account', ubuntuAuthPath, {
+          managedAuthRuntime: 'wsl',
+          wslDistro: 'Ubuntu',
+          wslLinuxAuthPath: '/home/alice/.local/share/orca/claude-accounts/ubuntu/auth'
+        })
+      ],
+      activeClaudeManagedAccountId: null,
+      activeClaudeManagedAccountIdsByRuntime: {
+        host: null,
+        wsl: { Ubuntu: 'ubuntu-account' }
+      }
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    const preparation = await service.prepareForClaudeLaunch()
+
+    expect(preparation).toMatchObject({
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu',
+      provenance: 'managed:ubuntu-account:wsl:Ubuntu'
+    })
+  })
+
+  it('ignores a persisted WSL account-runtime pin on non-Windows hosts', async () => {
+    setPlatform('darwin')
+    vi.doMock('../wsl', () => ({
+      getDefaultWslDistro: () => 'Ubuntu',
+      getWslHome: () => null,
+      toWindowsWslPath: (value: string) => value
+    }))
+    const settings = createSettings({
+      localAccountRuntime: 'wsl',
+      localAccountWslDistro: 'Ubuntu'
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    const preparation = await service.prepareForClaudeLaunch()
+
+    expect(preparation).toMatchObject({
+      runtime: 'host',
+      wslDistro: null,
+      provenance: 'system',
+      stripAuthEnv: false
+    })
+  })
+
   it('keeps untargeted Claude preparation on host when account runtime is host', async () => {
     setPlatform('win32')
     vi.doMock('../wsl', () => ({

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -684,11 +684,9 @@ export class ClaudeRuntimeAuthService {
   private getDefaultAccountSelectionTarget(
     settings = this.store.getSettings()
   ): ClaudeAccountSelectionTarget {
-    // Why: auth defaults follow the resolved account runtime ('auto' tracks the
-    // global WSL project default), not legacy terminal WSL settings that can
-    // outlive the Terminal UI.
+    // Why: Windows auth follows the resolved account runtime; stale cross-platform WSL pins must stay local-host.
     const resolved = resolveLocalAccountRuntimeTarget(settings)
-    if (resolved.runtime === 'wsl') {
+    if (process.platform === 'win32' && resolved.runtime === 'wsl') {
       return { runtime: 'wsl', wslDistro: resolved.wslDistro }
     }
     return { runtime: 'host' }

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -13,6 +13,7 @@ import {
   writeClaudeManagedAuthFile
 } from './managed-auth-path'
 import { parseWslUncPath } from '../../shared/wsl-paths'
+import { resolveLocalAccountRuntimeTarget } from '../../shared/local-account-runtime'
 import { getDefaultWslDistro, getWslHome, toWindowsWslPath } from '../wsl'
 import { buildEncodedWslBashCommand } from '../wsl-bash-command'
 import { hasLiveClaudePtys } from './live-pty-gate'
@@ -683,9 +684,12 @@ export class ClaudeRuntimeAuthService {
   private getDefaultAccountSelectionTarget(
     settings = this.store.getSettings()
   ): ClaudeAccountSelectionTarget {
-    if (process.platform === 'win32' && settings.localAccountRuntime === 'wsl') {
-      // Why: auth defaults follow account runtime settings, not legacy terminal WSL settings that can outlive the Terminal UI.
-      return { runtime: 'wsl', wslDistro: settings.localAccountWslDistro ?? null }
+    // Why: auth defaults follow the resolved account runtime ('auto' tracks the
+    // global WSL project default), not legacy terminal WSL settings that can
+    // outlive the Terminal UI.
+    const resolved = resolveLocalAccountRuntimeTarget(settings)
+    if (resolved.runtime === 'wsl') {
+      return { runtime: 'wsl', wslDistro: resolved.wslDistro }
     }
     return { runtime: 'host' }
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -113,6 +113,7 @@ import { RateLimitService } from './rate-limits/service'
 import { readMiniMaxSessionCookie } from './minimax/minimax-cookie-store'
 import { getInitialClaudeRateLimitTarget } from './rate-limits/claude-rate-limit-target'
 import { getInitialCodexRateLimitTarget } from './rate-limits/codex-rate-limit-target'
+import { createAccountRuntimeTargetSettingsSync } from './rate-limits/account-runtime-target-sync'
 import {
   attachMainWindowServices,
   ensureAutoUpdaterConfigured
@@ -1710,6 +1711,16 @@ app.whenReady().then(async () => {
   )
   rateLimits.setCodexFetchTarget(getInitialCodexRateLimitTarget(store.getSettings()))
   rateLimits.setClaudeFetchTarget(getInitialClaudeRateLimitTarget(store.getSettings()))
+  const syncAccountRuntimeTargets = createAccountRuntimeTargetSettingsSync(
+    rateLimits,
+    store.getSettings()
+  )
+  store.onSettingsChanged((updates, settings) => {
+    // Why: auto is a live policy; retarget only providers whose settings-derived runtime changed.
+    void syncAccountRuntimeTargets(updates, settings).catch((error) =>
+      console.warn('[rate-limits] Failed to apply account runtime target:', error)
+    )
+  })
   rateLimits.setClaudeAuthPreparationResolver((target) =>
     claudeRuntimeAuth!.prepareForRateLimitFetch(target)
   )

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -618,6 +618,8 @@ describe('Store', () => {
     expect(settings.terminalScrollSensitivity).toBe(1.15)
     expect(settings.terminalFastScrollSensitivity).toBe(5)
     expect(settings.terminalTuiScrollSensitivity).toBe(1)
+    expect(settings.localAccountRuntime).toBe('auto')
+    expect(settings.localAccountRuntimeDefaultedToAutoForAllUsers).toBe(true)
     expect(settings.terminalTuiScrollSensitivityDefaultedToOne).toBe(true)
     expect(settings.terminalUseSeparateLightTheme).toBe(true)
     expect(settings.rightSidebarOpenByDefault).toBe(true)

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -549,6 +549,59 @@ describe('Store', () => {
     })
   })
 
+  it('migrates the legacy host account-runtime default to auto once', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {
+        localAccountRuntime: 'host'
+      }
+    })
+
+    const store = await createStore()
+
+    expect(store.getSettings().localAccountRuntime).toBe('auto')
+    expect(store.getSettings().localAccountRuntimeDefaultedToAutoForAllUsers).toBe(true)
+    store.flush()
+    const persisted = (readDataFile() as PersistedState).settings
+    expect(persisted.localAccountRuntime).toBe('auto')
+    expect(persisted.localAccountRuntimeDefaultedToAutoForAllUsers).toBe(true)
+  })
+
+  it('preserves an explicit WSL account-runtime pin through the migration', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {
+        localAccountRuntime: 'wsl',
+        localAccountWslDistro: 'Ubuntu'
+      }
+    })
+
+    const store = await createStore()
+
+    expect(store.getSettings().localAccountRuntime).toBe('wsl')
+    expect(store.getSettings().localAccountRuntimeDefaultedToAutoForAllUsers).toBe(true)
+  })
+
+  it('does not re-flip an explicit host pin chosen after migration', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {
+        localAccountRuntime: 'host',
+        localAccountRuntimeDefaultedToAutoForAllUsers: true
+      }
+    })
+
+    const store = await createStore()
+
+    expect(store.getSettings().localAccountRuntime).toBe('host')
+  })
+
   it('returns default settings when no data file exists', async () => {
     const store = await createStore()
     const settings = store.getSettings()

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -2959,9 +2959,7 @@ export class Store {
         ) {
           this.loadNeedsSave = true
         }
-        // Why (#9537): the legacy hard 'host' default pinned account detection to
-        // Windows even for WSL projects. Flip the untouched default to 'auto' once
-        // so it follows localWindowsRuntimeDefault; an explicit 'wsl' pin survives.
+        // Why (#9537): migrate the indistinguishable legacy host default once so WSL-default users follow their runtime.
         const localAccountRuntimeAlreadyMigrated =
           parsed.settings?.localAccountRuntimeDefaultedToAutoForAllUsers === true
         const migratedLocalAccountRuntime: GlobalSettings['localAccountRuntime'] =

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -2959,6 +2959,20 @@ export class Store {
         ) {
           this.loadNeedsSave = true
         }
+        // Why (#9537): the legacy hard 'host' default pinned account detection to
+        // Windows even for WSL projects. Flip the untouched default to 'auto' once
+        // so it follows localWindowsRuntimeDefault; an explicit 'wsl' pin survives.
+        const localAccountRuntimeAlreadyMigrated =
+          parsed.settings?.localAccountRuntimeDefaultedToAutoForAllUsers === true
+        const migratedLocalAccountRuntime: GlobalSettings['localAccountRuntime'] =
+          localAccountRuntimeAlreadyMigrated
+            ? (parsed.settings?.localAccountRuntime ?? defaults.settings.localAccountRuntime)
+            : parsed.settings?.localAccountRuntime === 'wsl'
+              ? 'wsl'
+              : 'auto'
+        if (!localAccountRuntimeAlreadyMigrated) {
+          this.loadNeedsSave = true
+        }
         if (!autoRenameBranchFromWorkDefaultedOn) {
           this.loadNeedsSave = true
         }
@@ -3038,6 +3052,8 @@ export class Store {
             terminalMacOptionAsAlt: migratedOptionAsAlt,
             terminalMacOptionAsAltMigrated: true,
             localWindowsRuntimeDefault: migratedWindowsRuntimeDefault,
+            localAccountRuntime: migratedLocalAccountRuntime,
+            localAccountRuntimeDefaultedToAutoForAllUsers: true,
             floatingTerminalEnabled: migratedFloatingTerminalEnabled,
             floatingTerminalDefaultedForAllUsers: true,
             floatingTerminalCwd: migratedFloatingTerminalCwd,

--- a/src/main/rate-limits/account-runtime-target-sync.test.ts
+++ b/src/main/rate-limits/account-runtime-target-sync.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getDefaultSettings } from '../../shared/constants'
+import type { RateLimitState } from '../../shared/rate-limit-types'
+import { createAccountRuntimeTargetSettingsSync } from './account-runtime-target-sync'
+
+function createServiceTargets(
+  claudeTarget: RateLimitState['claudeTarget'],
+  codexTarget: RateLimitState['codexTarget']
+) {
+  const state = { claudeTarget, codexTarget } as RateLimitState
+  return {
+    getState: vi.fn(() => state),
+    refreshClaudeForTarget: vi.fn(async () => state),
+    refreshCodexForTarget: vi.fn(async () => state)
+  }
+}
+
+describe('createAccountRuntimeTargetSettingsSync', () => {
+  it('retargets only Claude and Codex when auto changes to WSL', async () => {
+    const service = createServiceTargets(
+      { runtime: 'host', wslDistro: null },
+      { runtime: 'host', wslDistro: null }
+    )
+    const settings = {
+      ...getDefaultSettings('/tmp'),
+      localAccountRuntime: 'auto' as const,
+      localWindowsRuntimeDefault: { kind: 'wsl' as const, distro: 'Ubuntu' }
+    }
+    const syncSettings = createAccountRuntimeTargetSettingsSync(
+      service,
+      getDefaultSettings('/tmp'),
+      'win32'
+    )
+
+    await syncSettings(
+      { localWindowsRuntimeDefault: settings.localWindowsRuntimeDefault },
+      settings
+    )
+
+    const expectedTarget = { runtime: 'wsl', wslDistro: 'Ubuntu' }
+    expect(service.refreshClaudeForTarget).toHaveBeenCalledOnce()
+    expect(service.refreshClaudeForTarget).toHaveBeenCalledWith(expectedTarget)
+    expect(service.refreshCodexForTarget).toHaveBeenCalledOnce()
+    expect(service.refreshCodexForTarget).toHaveBeenCalledWith(expectedTarget)
+  })
+
+  it('does no work for unrelated settings updates', async () => {
+    const service = createServiceTargets(
+      { runtime: 'host', wslDistro: null },
+      { runtime: 'host', wslDistro: null }
+    )
+    const settings = getDefaultSettings('/tmp')
+    const syncSettings = createAccountRuntimeTargetSettingsSync(service, settings, 'win32')
+
+    await syncSettings({ theme: 'dark' }, settings)
+
+    expect(service.getState).not.toHaveBeenCalled()
+    expect(service.refreshClaudeForTarget).not.toHaveBeenCalled()
+    expect(service.refreshCodexForTarget).not.toHaveBeenCalled()
+  })
+
+  it('preserves a manual runtime when the settings-derived policy does not change', async () => {
+    const service = createServiceTargets(
+      { runtime: 'wsl', wslDistro: 'Ubuntu' },
+      { runtime: 'wsl', wslDistro: 'Ubuntu' }
+    )
+    const initialSettings = {
+      ...getDefaultSettings('/tmp'),
+      localAccountRuntime: 'host' as const
+    }
+    const settings = {
+      ...initialSettings,
+      localWindowsRuntimeDefault: { kind: 'wsl' as const, distro: 'Ubuntu' }
+    }
+    const syncSettings = createAccountRuntimeTargetSettingsSync(service, initialSettings, 'win32')
+
+    await syncSettings(
+      { localWindowsRuntimeDefault: settings.localWindowsRuntimeDefault },
+      settings
+    )
+
+    expect(service.getState).not.toHaveBeenCalled()
+    expect(service.refreshClaudeForTarget).not.toHaveBeenCalled()
+    expect(service.refreshCodexForTarget).not.toHaveBeenCalled()
+  })
+
+  it('refreshes only the provider whose current target differs', async () => {
+    const service = createServiceTargets(
+      { runtime: 'host', wslDistro: null },
+      { runtime: 'wsl', wslDistro: 'Ubuntu' }
+    )
+    const initialSettings = {
+      ...getDefaultSettings('/tmp'),
+      localWindowsRuntimeDefault: { kind: 'wsl' as const, distro: 'Ubuntu' }
+    }
+    const settings = getDefaultSettings('/tmp')
+    const syncSettings = createAccountRuntimeTargetSettingsSync(service, initialSettings, 'win32')
+
+    await syncSettings(
+      { localWindowsRuntimeDefault: settings.localWindowsRuntimeDefault },
+      settings
+    )
+
+    expect(service.refreshClaudeForTarget).not.toHaveBeenCalled()
+    expect(service.refreshCodexForTarget).toHaveBeenCalledOnce()
+    expect(service.refreshCodexForTarget).toHaveBeenCalledWith({ runtime: 'host' })
+  })
+})

--- a/src/main/rate-limits/account-runtime-target-sync.ts
+++ b/src/main/rate-limits/account-runtime-target-sync.ts
@@ -1,0 +1,70 @@
+import type { GlobalSettings } from '../../shared/types'
+import type { RateLimitState } from '../../shared/rate-limit-types'
+import type { RateLimitService } from './service'
+import { getInitialClaudeRateLimitTarget } from './claude-rate-limit-target'
+import { getInitialCodexRateLimitTarget } from './codex-rate-limit-target'
+
+type AccountRuntimeRateLimitService = Pick<
+  RateLimitService,
+  'getState' | 'refreshClaudeForTarget' | 'refreshCodexForTarget'
+>
+
+type RuntimeTarget = {
+  runtime?: 'host' | 'wsl'
+  wslDistro?: string | null
+}
+
+export function createAccountRuntimeTargetSettingsSync(
+  rateLimits: AccountRuntimeRateLimitService,
+  initialSettings: GlobalSettings,
+  platform: NodeJS.Platform = process.platform
+): (updates: Partial<GlobalSettings>, settings: GlobalSettings) => Promise<void> {
+  let settingsTargets = getSettingsTargets(initialSettings, platform)
+
+  return async (updates, settings): Promise<void> => {
+    if (!containsAccountRuntimeTargetUpdate(updates)) {
+      return
+    }
+
+    const nextSettingsTargets = getSettingsTargets(settings, platform)
+    const claudePolicyChanged = !isSameTarget(settingsTargets.claude, nextSettingsTargets.claude)
+    const codexPolicyChanged = !isSameTarget(settingsTargets.codex, nextSettingsTargets.codex)
+    settingsTargets = nextSettingsTargets
+    if (!claudePolicyChanged && !codexPolicyChanged) {
+      return
+    }
+
+    const current = rateLimits.getState()
+    const refreshes: Promise<RateLimitState>[] = []
+    if (claudePolicyChanged && !isSameTarget(current.claudeTarget, nextSettingsTargets.claude)) {
+      refreshes.push(rateLimits.refreshClaudeForTarget(nextSettingsTargets.claude))
+    }
+    if (codexPolicyChanged && !isSameTarget(current.codexTarget, nextSettingsTargets.codex)) {
+      refreshes.push(rateLimits.refreshCodexForTarget(nextSettingsTargets.codex))
+    }
+
+    await Promise.all(refreshes)
+  }
+}
+
+function getSettingsTargets(settings: GlobalSettings, platform: NodeJS.Platform) {
+  return {
+    claude: getInitialClaudeRateLimitTarget(settings, platform),
+    codex: getInitialCodexRateLimitTarget(settings, platform)
+  }
+}
+
+function containsAccountRuntimeTargetUpdate(updates: Partial<GlobalSettings>): boolean {
+  return (
+    'localAccountRuntime' in updates ||
+    'localAccountWslDistro' in updates ||
+    'localWindowsRuntimeDefault' in updates
+  )
+}
+
+function isSameTarget(current: RuntimeTarget, next: RuntimeTarget): boolean {
+  return (
+    (current.runtime ?? 'host') === (next.runtime ?? 'host') &&
+    (current.wslDistro ?? null) === (next.wslDistro ?? null)
+  )
+}

--- a/src/main/rate-limits/claude-rate-limit-target.test.ts
+++ b/src/main/rate-limits/claude-rate-limit-target.test.ts
@@ -163,4 +163,17 @@ describe('getInitialClaudeRateLimitTarget', () => {
       )
     ).toEqual({ runtime: 'host' })
   })
+
+  it('ignores a stale explicit WSL runtime on non-Windows hosts', () => {
+    expect(
+      getInitialClaudeRateLimitTarget(
+        {
+          ...getDefaultSettings('/tmp'),
+          localAccountRuntime: 'wsl',
+          localAccountWslDistro: 'Ubuntu'
+        },
+        'linux'
+      )
+    ).toEqual({ runtime: 'host' })
+  })
 })

--- a/src/main/rate-limits/claude-rate-limit-target.test.ts
+++ b/src/main/rate-limits/claude-rate-limit-target.test.ts
@@ -103,7 +103,7 @@ describe('getInitialClaudeRateLimitTarget', () => {
     ).toEqual({ runtime: 'wsl', wslDistro: 'Ubuntu' })
   })
 
-  it("auto follows the global WSL project runtime default", () => {
+  it('auto follows the global WSL project runtime default', () => {
     expect(
       getInitialClaudeRateLimitTarget(
         {
@@ -123,6 +123,23 @@ describe('getInitialClaudeRateLimitTarget', () => {
           ...getDefaultSettings('/tmp'),
           localAccountRuntime: 'auto',
           localWindowsRuntimeDefault: { kind: 'windows-host' }
+        },
+        'win32'
+      )
+    ).toEqual({ runtime: 'host' })
+  })
+
+  it('does not let a stale WSL-only selection override an auto host target', () => {
+    expect(
+      getInitialClaudeRateLimitTarget(
+        {
+          ...getDefaultSettings('/tmp'),
+          localAccountRuntime: 'auto',
+          localWindowsRuntimeDefault: { kind: 'windows-host' },
+          activeClaudeManagedAccountIdsByRuntime: {
+            host: null,
+            wsl: { Ubuntu: 'wsl-account-1' }
+          }
         },
         'win32'
       )

--- a/src/main/rate-limits/claude-rate-limit-target.test.ts
+++ b/src/main/rate-limits/claude-rate-limit-target.test.ts
@@ -103,6 +103,32 @@ describe('getInitialClaudeRateLimitTarget', () => {
     ).toEqual({ runtime: 'wsl', wslDistro: 'Ubuntu' })
   })
 
+  it("auto follows the global WSL project runtime default", () => {
+    expect(
+      getInitialClaudeRateLimitTarget(
+        {
+          ...getDefaultSettings('/tmp'),
+          localAccountRuntime: 'auto',
+          localWindowsRuntimeDefault: { kind: 'wsl', distro: 'Ubuntu' }
+        },
+        'win32'
+      )
+    ).toEqual({ runtime: 'wsl', wslDistro: 'Ubuntu' })
+  })
+
+  it('auto resolves to host when the global project runtime is windows-host', () => {
+    expect(
+      getInitialClaudeRateLimitTarget(
+        {
+          ...getDefaultSettings('/tmp'),
+          localAccountRuntime: 'auto',
+          localWindowsRuntimeDefault: { kind: 'windows-host' }
+        },
+        'win32'
+      )
+    ).toEqual({ runtime: 'host' })
+  })
+
   it('keeps explicit host runtime on host', () => {
     expect(
       getInitialClaudeRateLimitTarget(

--- a/src/main/rate-limits/claude-rate-limit-target.ts
+++ b/src/main/rate-limits/claude-rate-limit-target.ts
@@ -1,4 +1,5 @@
 import type { GlobalSettings } from '../../shared/types'
+import { resolveLocalAccountRuntimeTarget } from '../../shared/local-account-runtime'
 import {
   getClaudeWslSelectionKey,
   normalizeClaudeRuntimeSelection,
@@ -36,9 +37,14 @@ export function getInitialClaudeRateLimitTarget(
         getSingleSelectedWslDistro(settings)
     }
   }
+  if (settings.localAccountRuntime === 'auto') {
+    const target = resolveLocalAccountRuntimeTarget(settings, platform)
+    return target.runtime === 'wsl'
+      ? { runtime: 'wsl', wslDistro: target.wslDistro }
+      : { runtime: 'host' }
+  }
 
-  // 'auto' (the default) and legacy-unset settings fall through here so account
-  // detection follows the global WSL project runtime instead of pinning host.
+  // Why: pre-setting profiles used account selection as their startup fallback.
   const projectRuntimeTarget = getProjectRuntimeRateLimitTarget(settings, platform)
   if (projectRuntimeTarget) {
     return projectRuntimeTarget

--- a/src/main/rate-limits/claude-rate-limit-target.ts
+++ b/src/main/rate-limits/claude-rate-limit-target.ts
@@ -30,6 +30,9 @@ export function getInitialClaudeRateLimitTarget(
     return { runtime: 'host' }
   }
   if (settings.localAccountRuntime === 'wsl') {
+    if (platform !== 'win32') {
+      return { runtime: 'host' }
+    }
     return {
       runtime: 'wsl',
       wslDistro:

--- a/src/main/rate-limits/claude-rate-limit-target.ts
+++ b/src/main/rate-limits/claude-rate-limit-target.ts
@@ -37,6 +37,8 @@ export function getInitialClaudeRateLimitTarget(
     }
   }
 
+  // 'auto' (the default) and legacy-unset settings fall through here so account
+  // detection follows the global WSL project runtime instead of pinning host.
   const projectRuntimeTarget = getProjectRuntimeRateLimitTarget(settings, platform)
   if (projectRuntimeTarget) {
     return projectRuntimeTarget

--- a/src/main/rate-limits/codex-rate-limit-target.test.ts
+++ b/src/main/rate-limits/codex-rate-limit-target.test.ts
@@ -163,4 +163,17 @@ describe('getInitialCodexRateLimitTarget', () => {
       )
     ).toEqual({ runtime: 'host' })
   })
+
+  it('ignores a stale explicit WSL runtime on non-Windows hosts', () => {
+    expect(
+      getInitialCodexRateLimitTarget(
+        {
+          ...getDefaultSettings('/tmp'),
+          localAccountRuntime: 'wsl',
+          localAccountWslDistro: 'Ubuntu'
+        },
+        'darwin'
+      )
+    ).toEqual({ runtime: 'host' })
+  })
 })

--- a/src/main/rate-limits/codex-rate-limit-target.test.ts
+++ b/src/main/rate-limits/codex-rate-limit-target.test.ts
@@ -129,6 +129,23 @@ describe('getInitialCodexRateLimitTarget', () => {
     ).toEqual({ runtime: 'host' })
   })
 
+  it('does not let a stale WSL-only selection override an auto host target', () => {
+    expect(
+      getInitialCodexRateLimitTarget(
+        {
+          ...getDefaultSettings('/tmp'),
+          localAccountRuntime: 'auto',
+          localWindowsRuntimeDefault: { kind: 'windows-host' },
+          activeCodexManagedAccountIdsByRuntime: {
+            host: null,
+            wsl: { Ubuntu: 'wsl-account-1' }
+          }
+        },
+        'win32'
+      )
+    ).toEqual({ runtime: 'host' })
+  })
+
   it('keeps explicit host runtime on host', () => {
     expect(
       getInitialCodexRateLimitTarget(

--- a/src/main/rate-limits/codex-rate-limit-target.test.ts
+++ b/src/main/rate-limits/codex-rate-limit-target.test.ts
@@ -103,6 +103,32 @@ describe('getInitialCodexRateLimitTarget', () => {
     ).toEqual({ runtime: 'wsl', wslDistro: 'Ubuntu' })
   })
 
+  it('auto follows the global WSL project runtime default', () => {
+    expect(
+      getInitialCodexRateLimitTarget(
+        {
+          ...getDefaultSettings('/tmp'),
+          localAccountRuntime: 'auto',
+          localWindowsRuntimeDefault: { kind: 'wsl', distro: 'Ubuntu' }
+        },
+        'win32'
+      )
+    ).toEqual({ runtime: 'wsl', wslDistro: 'Ubuntu' })
+  })
+
+  it('auto resolves to host when the global project runtime is windows-host', () => {
+    expect(
+      getInitialCodexRateLimitTarget(
+        {
+          ...getDefaultSettings('/tmp'),
+          localAccountRuntime: 'auto',
+          localWindowsRuntimeDefault: { kind: 'windows-host' }
+        },
+        'win32'
+      )
+    ).toEqual({ runtime: 'host' })
+  })
+
   it('keeps explicit host runtime on host', () => {
     expect(
       getInitialCodexRateLimitTarget(

--- a/src/main/rate-limits/codex-rate-limit-target.ts
+++ b/src/main/rate-limits/codex-rate-limit-target.ts
@@ -1,4 +1,5 @@
 import type { GlobalSettings } from '../../shared/types'
+import { resolveLocalAccountRuntimeTarget } from '../../shared/local-account-runtime'
 import {
   getWslSelectionKey,
   normalizeCodexRuntimeSelection,
@@ -36,9 +37,14 @@ export function getInitialCodexRateLimitTarget(
         getSingleSelectedWslDistro(settings)
     }
   }
+  if (settings.localAccountRuntime === 'auto') {
+    const target = resolveLocalAccountRuntimeTarget(settings, platform)
+    return target.runtime === 'wsl'
+      ? { runtime: 'wsl', wslDistro: target.wslDistro }
+      : { runtime: 'host' }
+  }
 
-  // 'auto' (the default) and legacy-unset settings fall through here so account
-  // detection follows the global WSL project runtime instead of pinning host.
+  // Why: pre-setting profiles used account selection as their startup fallback.
   const projectRuntimeTarget = getProjectRuntimeRateLimitTarget(settings, platform)
   if (projectRuntimeTarget) {
     return projectRuntimeTarget

--- a/src/main/rate-limits/codex-rate-limit-target.ts
+++ b/src/main/rate-limits/codex-rate-limit-target.ts
@@ -30,6 +30,9 @@ export function getInitialCodexRateLimitTarget(
     return { runtime: 'host' }
   }
   if (settings.localAccountRuntime === 'wsl') {
+    if (platform !== 'win32') {
+      return { runtime: 'host' }
+    }
     return {
       runtime: 'wsl',
       wslDistro:

--- a/src/main/rate-limits/codex-rate-limit-target.ts
+++ b/src/main/rate-limits/codex-rate-limit-target.ts
@@ -37,6 +37,8 @@ export function getInitialCodexRateLimitTarget(
     }
   }
 
+  // 'auto' (the default) and legacy-unset settings fall through here so account
+  // detection follows the global WSL project runtime instead of pinning host.
   const projectRuntimeTarget = getProjectRuntimeRateLimitTarget(settings, platform)
   if (projectRuntimeTarget) {
     return projectRuntimeTarget

--- a/src/renderer/src/components/settings/AccountsPane.test.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.test.tsx
@@ -51,6 +51,39 @@ describe('AccountsPane', () => {
     expect(markup).toContain('role="radio" aria-checked="true" disabled=""')
   })
 
+  it('selects the WSL account location under auto when the global project runtime is WSL', () => {
+    // Why: navigator.userAgent is a read-only prototype getter, so shadow it with
+    // a configurable own property and remove that shadow afterward to restore it.
+    const originalOwnUserAgent = Object.getOwnPropertyDescriptor(
+      globalThis.navigator,
+      'userAgent'
+    )
+    Object.defineProperty(globalThis.navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+      configurable: true
+    })
+    try {
+      const markup = renderPane(
+        {
+          ...getDefaultSettings('/tmp'),
+          localAccountRuntime: 'auto',
+          localWindowsRuntimeDefault: { kind: 'wsl', distro: 'Ubuntu' }
+        },
+        { wslSupportedPlatform: true, wslCapabilitiesLoading: true }
+      )
+
+      expect(markup).toContain('aria-label="Account location"')
+      // The resolved WSL radio is the checked option (disabled while capabilities load).
+      expect(markup).toContain('role="radio" aria-checked="true" disabled=""')
+    } finally {
+      if (originalOwnUserAgent) {
+        Object.defineProperty(globalThis.navigator, 'userAgent', originalOwnUserAgent)
+      } else {
+        delete (globalThis.navigator as { userAgent?: string }).userAgent
+      }
+    }
+  })
+
   it('keeps the runtime label inside the localized account copy', () => {
     const markup = renderPane(getDefaultSettings('/tmp'))
 

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -10,6 +10,7 @@ import type {
   GlobalSettings
 } from '../../../../shared/types'
 import { resolveLocalAccountRuntimeTarget } from '../../../../shared/local-account-runtime'
+import { getRendererAppPlatform } from '../../lib/renderer-app-platform'
 import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
@@ -267,11 +268,8 @@ function getSelectedAccountRuntime(
   wslDistros: string[],
   wslCapabilitiesLoading: boolean
 ): LocalAccountRuntime {
-  // Why: 'auto' (the default) follows the global WSL project runtime, so resolve
-  // it to a concrete host/wsl position for the toggle instead of only honoring an
-  // explicit 'wsl' pin. The renderer is sandboxed, so derive platform from the UA.
-  const platform = navigator.userAgent.includes('Windows') ? 'win32' : 'linux'
-  const resolvedRuntime = resolveLocalAccountRuntimeTarget(settings, platform)
+  // Why: the two-option control displays the concrete target behind the persisted auto policy.
+  const resolvedRuntime = resolveLocalAccountRuntimeTarget(settings, getRendererAppPlatform())
   if (wslSupportedPlatform && resolvedRuntime.runtime === 'wsl') {
     if (!wslAvailable && !wslCapabilitiesLoading) {
       return {

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -9,6 +9,7 @@ import type {
   CodexRateLimitAccountsState,
   GlobalSettings
 } from '../../../../shared/types'
+import { resolveLocalAccountRuntimeTarget } from '../../../../shared/local-account-runtime'
 import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
@@ -266,14 +267,19 @@ function getSelectedAccountRuntime(
   wslDistros: string[],
   wslCapabilitiesLoading: boolean
 ): LocalAccountRuntime {
-  if (wslSupportedPlatform && settings.localAccountRuntime === 'wsl') {
+  // Why: 'auto' (the default) follows the global WSL project runtime, so resolve
+  // it to a concrete host/wsl position for the toggle instead of only honoring an
+  // explicit 'wsl' pin. The renderer is sandboxed, so derive platform from the UA.
+  const platform = navigator.userAgent.includes('Windows') ? 'win32' : 'linux'
+  const resolvedRuntime = resolveLocalAccountRuntimeTarget(settings, platform)
+  if (wslSupportedPlatform && resolvedRuntime.runtime === 'wsl') {
     if (!wslAvailable && !wslCapabilitiesLoading) {
       return {
         runtime: 'wsl',
         label: translate('auto.components.settings.AccountsPane.8619f9afa9', 'WSL')
       }
     }
-    const configuredDistro = settings.localAccountWslDistro?.trim() || null
+    const configuredDistro = resolvedRuntime.wslDistro?.trim() || null
     const selectedDistro =
       configuredDistro && (wslCapabilitiesLoading || wslDistros.includes(configuredDistro))
         ? configuredDistro

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -46,6 +46,7 @@ import type {
   RateLimitWindow
 } from '../../../../shared/rate-limit-types'
 import { resolveLocalAccountRuntimeTarget } from '../../../../shared/local-account-runtime'
+import { getRendererAppPlatform } from '../../lib/renderer-app-platform'
 import {
   ProviderIcon,
   ProviderPanel,
@@ -196,24 +197,24 @@ function toCodexStatusRuntimeTarget(
 
 export function getStatusBarPreferredWslDistro(
   settings: GlobalSettings | null | undefined,
-  wslDistros: string[]
+  wslDistros: string[],
+  platform: NodeJS.Platform = getRendererAppPlatform()
 ): string | null {
-  const configuredDistro = settings?.localAccountWslDistro?.trim() || null
-  if (configuredDistro) {
-    return configuredDistro
+  if (settings) {
+    const target = resolveLocalAccountRuntimeTarget(settings, platform)
+    if (target.runtime === 'wsl' && target.wslDistro) {
+      return target.wslDistro
+    }
   }
   return wslDistros.length === 1 ? wslDistros[0] : null
 }
 
 function shouldIncludeSettingsWslRuntime(settings: GlobalSettings | null | undefined): boolean {
-  // Why: 'auto' (the default) surfaces the WSL group when the global project
-  // runtime is WSL, matching where account detection now reads from. The renderer
-  // is sandboxed without process.platform, so derive it from the user agent.
   if (!settings) {
     return false
   }
-  const platform = navigator.userAgent.includes('Windows') ? 'win32' : 'linux'
-  return resolveLocalAccountRuntimeTarget(settings, platform).runtime === 'wsl'
+  // Why: the fallback group must match the concrete runtime used for account polling.
+  return resolveLocalAccountRuntimeTarget(settings, getRendererAppPlatform()).runtime === 'wsl'
 }
 
 function getSingleConcreteCodexWslDistro(state: CodexRateLimitAccountsState): string | null {

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -45,6 +45,7 @@ import type {
   RateLimitRuntimeTarget,
   RateLimitWindow
 } from '../../../../shared/rate-limit-types'
+import { resolveLocalAccountRuntimeTarget } from '../../../../shared/local-account-runtime'
 import {
   ProviderIcon,
   ProviderPanel,
@@ -205,7 +206,14 @@ export function getStatusBarPreferredWslDistro(
 }
 
 function shouldIncludeSettingsWslRuntime(settings: GlobalSettings | null | undefined): boolean {
-  return settings?.localAccountRuntime === 'wsl'
+  // Why: 'auto' (the default) surfaces the WSL group when the global project
+  // runtime is WSL, matching where account detection now reads from. The renderer
+  // is sandboxed without process.platform, so derive it from the user agent.
+  if (!settings) {
+    return false
+  }
+  const platform = navigator.userAgent.includes('Windows') ? 'win32' : 'linux'
+  return resolveLocalAccountRuntimeTarget(settings, platform).runtime === 'wsl'
 }
 
 function getSingleConcreteCodexWslDistro(state: CodexRateLimitAccountsState): string | null {

--- a/src/renderer/src/components/status-bar/status-bar-runtime-groups.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-runtime-groups.test.ts
@@ -116,10 +116,12 @@ describe('status bar runtime switch groups', () => {
     expect(
       getStatusBarPreferredWslDistro(
         {
+          localAccountRuntime: 'wsl',
           localAccountWslDistro: null,
           terminalWindowsWslDistro: 'Debian'
         } as GlobalSettings,
-        ['Ubuntu']
+        ['Ubuntu'],
+        'win32'
       )
     ).toBe('Ubuntu')
   })
@@ -128,12 +130,28 @@ describe('status bar runtime switch groups', () => {
     expect(
       getStatusBarPreferredWslDistro(
         {
+          localAccountRuntime: 'wsl',
           localAccountWslDistro: 'Fedora',
           terminalWindowsWslDistro: 'Debian'
         } as GlobalSettings,
-        ['Ubuntu']
+        ['Ubuntu'],
+        'win32'
       )
     ).toBe('Fedora')
+  })
+
+  it('uses the auto runtime distro instead of a stale account-runtime distro', () => {
+    expect(
+      getStatusBarPreferredWslDistro(
+        {
+          localAccountRuntime: 'auto',
+          localAccountWslDistro: 'Fedora',
+          localWindowsRuntimeDefault: { kind: 'wsl', distro: 'Ubuntu' }
+        } as GlobalSettings,
+        ['Fedora', 'Ubuntu'],
+        'win32'
+      )
+    ).toBe('Ubuntu')
   })
 
   it('labels the host account group with the active remote server name', () => {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -228,7 +228,8 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalRightClickToPasteDefaultedForPlatform: true,
     terminalWindowsShell: 'powershell.exe',
     terminalWindowsWslDistro: null,
-    localAccountRuntime: 'host',
+    localAccountRuntime: 'auto',
+    localAccountRuntimeDefaultedToAutoForAllUsers: true,
     localAccountWslDistro: null,
     localWindowsRuntimeDefault: { kind: 'windows-host' },
     // Why: prefer modern PowerShell when installed, falling back to inbox Windows PowerShell.

--- a/src/shared/local-account-runtime.test.ts
+++ b/src/shared/local-account-runtime.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { getDefaultSettings } from './constants'
+import { resolveLocalAccountRuntimeTarget } from './local-account-runtime'
+
+describe('resolveLocalAccountRuntimeTarget', () => {
+  it('honors an explicit host pin', () => {
+    expect(
+      resolveLocalAccountRuntimeTarget(
+        { ...getDefaultSettings('/tmp'), localAccountRuntime: 'host' },
+        'win32'
+      )
+    ).toEqual({ runtime: 'host', wslDistro: null })
+  })
+
+  it('honors an explicit WSL pin and its distro', () => {
+    expect(
+      resolveLocalAccountRuntimeTarget(
+        {
+          ...getDefaultSettings('/tmp'),
+          localAccountRuntime: 'wsl',
+          localAccountWslDistro: 'Ubuntu'
+        },
+        'win32'
+      )
+    ).toEqual({ runtime: 'wsl', wslDistro: 'Ubuntu' })
+  })
+
+  it('auto follows the global WSL project runtime default', () => {
+    expect(
+      resolveLocalAccountRuntimeTarget(
+        {
+          ...getDefaultSettings('/tmp'),
+          localAccountRuntime: 'auto',
+          localWindowsRuntimeDefault: { kind: 'wsl', distro: 'Ubuntu' }
+        },
+        'win32'
+      )
+    ).toEqual({ runtime: 'wsl', wslDistro: 'Ubuntu' })
+  })
+
+  it('auto resolves to host when the global project runtime is windows-host', () => {
+    expect(
+      resolveLocalAccountRuntimeTarget(
+        {
+          ...getDefaultSettings('/tmp'),
+          localAccountRuntime: 'auto',
+          localWindowsRuntimeDefault: { kind: 'windows-host' }
+        },
+        'win32'
+      )
+    ).toEqual({ runtime: 'host', wslDistro: null })
+  })
+
+  it('auto resolves to host on non-Windows platforms even with a WSL default', () => {
+    expect(
+      resolveLocalAccountRuntimeTarget(
+        {
+          ...getDefaultSettings('/tmp'),
+          localAccountRuntime: 'auto',
+          localWindowsRuntimeDefault: { kind: 'wsl', distro: 'Ubuntu' }
+        },
+        'linux'
+      )
+    ).toEqual({ runtime: 'host', wslDistro: null })
+  })
+})

--- a/src/shared/local-account-runtime.ts
+++ b/src/shared/local-account-runtime.ts
@@ -11,13 +11,7 @@ type LocalAccountRuntimeSettings = Pick<
   'localAccountRuntime' | 'localAccountWslDistro' | 'localWindowsRuntimeDefault'
 >
 
-/**
- * Resolves where provider accounts are inspected (Windows host vs a WSL distro).
- *
- * `'host'`/`'wsl'` are explicit pins; `'auto'` (the default) follows the global
- * Windows runtime default so a WSL project surfaces WSL accounts instead of the
- * Windows-host ones. Non-Windows platforms have no WSL, so always resolve host.
- */
+/** Resolves the persisted account policy to a concrete host or WSL target. */
 export function resolveLocalAccountRuntimeTarget(
   settings: LocalAccountRuntimeSettings,
   platform: NodeJS.Platform = process.platform

--- a/src/shared/local-account-runtime.ts
+++ b/src/shared/local-account-runtime.ts
@@ -1,0 +1,46 @@
+import type { GlobalSettings } from './types'
+import { normalizeGlobalWindowsRuntimeDefault } from './project-execution-runtime'
+
+export type LocalAccountRuntimeTarget = {
+  runtime: 'host' | 'wsl'
+  wslDistro: string | null
+}
+
+type LocalAccountRuntimeSettings = Pick<
+  GlobalSettings,
+  'localAccountRuntime' | 'localAccountWslDistro' | 'localWindowsRuntimeDefault'
+>
+
+/**
+ * Resolves where provider accounts are inspected (Windows host vs a WSL distro).
+ *
+ * `'host'`/`'wsl'` are explicit pins; `'auto'` (the default) follows the global
+ * Windows runtime default so a WSL project surfaces WSL accounts instead of the
+ * Windows-host ones. Non-Windows platforms have no WSL, so always resolve host.
+ */
+export function resolveLocalAccountRuntimeTarget(
+  settings: LocalAccountRuntimeSettings,
+  platform: NodeJS.Platform = process.platform
+): LocalAccountRuntimeTarget {
+  if (settings.localAccountRuntime === 'host') {
+    return { runtime: 'host', wslDistro: null }
+  }
+  if (settings.localAccountRuntime === 'wsl') {
+    return { runtime: 'wsl', wslDistro: normalizeDistro(settings.localAccountWslDistro) }
+  }
+
+  // 'auto' (or any unset legacy value): follow the global Windows runtime default.
+  if (platform !== 'win32') {
+    return { runtime: 'host', wslDistro: null }
+  }
+  const runtimeDefault = normalizeGlobalWindowsRuntimeDefault(settings.localWindowsRuntimeDefault)
+  if (runtimeDefault.kind === 'wsl') {
+    return { runtime: 'wsl', wslDistro: runtimeDefault.distro }
+  }
+  return { runtime: 'host', wslDistro: null }
+}
+
+function normalizeDistro(value: string | null | undefined): string | null {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2653,10 +2653,10 @@ export type GlobalSettings = {
   terminalWindowsShell: string
   /** Pins the WSL distro for terminals/agent scans instead of WSL's current global default. */
   terminalWindowsWslDistro?: string | null
-  /** Account/auth location independent from the terminal shell (e.g. WSL terminals but Windows-scoped accounts). 'auto' follows the global Windows runtime default; 'host'/'wsl' pin it explicitly. */
+  /** Account/auth location; auto follows the global Windows runtime while host/wsl pin it. */
   localAccountRuntime: 'auto' | 'host' | 'wsl'
   localAccountWslDistro?: string | null
-  /** One-shot guard: flips the legacy hard 'host' default to 'auto' once so account detection follows the WSL project runtime; preserves explicit 'wsl'. */
+  /** One-shot guard for migrating the legacy host default to auto. */
   localAccountRuntimeDefaultedToAutoForAllUsers?: boolean
   /** Independent from the terminal shell so users can inspect Windows vs WSL agent PATH state without changing it. */
   localAgentRuntime?: 'host' | 'wsl'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2653,9 +2653,11 @@ export type GlobalSettings = {
   terminalWindowsShell: string
   /** Pins the WSL distro for terminals/agent scans instead of WSL's current global default. */
   terminalWindowsWslDistro?: string | null
-  /** Account/auth location independent from the terminal shell (e.g. WSL terminals but Windows-scoped accounts). */
-  localAccountRuntime: 'host' | 'wsl'
+  /** Account/auth location independent from the terminal shell (e.g. WSL terminals but Windows-scoped accounts). 'auto' follows the global Windows runtime default; 'host'/'wsl' pin it explicitly. */
+  localAccountRuntime: 'auto' | 'host' | 'wsl'
   localAccountWslDistro?: string | null
+  /** One-shot guard: flips the legacy hard 'host' default to 'auto' once so account detection follows the WSL project runtime; preserves explicit 'wsl'. */
+  localAccountRuntimeDefaultedToAutoForAllUsers?: boolean
   /** Independent from the terminal shell so users can inspect Windows vs WSL agent PATH state without changing it. */
   localAgentRuntime?: 'host' | 'wsl'
   localAgentWslDistro?: string | null


### PR DESCRIPTION
## Problem

Fixes #9537.

On Windows + WSL, when a user runs their projects in WSL and is signed into Claude/Codex **inside** the WSL distro, Orca still detects/recognizes the **Windows-host** provider accounts and never surfaces the **WSL** account entry in the status-bar account switcher. Account recognition should follow the runtime where the agent actually runs.

## Root cause

Provider-account detection (usage recognition + the status-bar switcher) is driven by a host-vs-WSL "rate-limit fetch target" computed by `getInitialClaudeRateLimitTarget` / `getInitialCodexRateLimitTarget`. Both short-circuit to **host** whenever `settings.localAccountRuntime === 'host'`, and only fall through to the "follow the global Windows runtime default" branch otherwise.

That fall-through branch (and its unit tests) already existed — but `localAccountRuntime` **hard-defaulted to `'host'`** in `constants.ts`, so the short-circuit always fired and the follow-the-runtime branch was dead code for every real user. As a result:

- Usage/account recognition read the Windows `~/.codex` / `~/.claude` instead of the WSL home.
- The status-bar WSL group never appeared (it's gated on the fetch target being WSL or `localAccountRuntime === 'wsl'`).

## Fix

- Add an `'auto'` value to `localAccountRuntime` and make it the default. `'auto'` resolves to the **global Windows runtime default** (host when `windows-host`, the configured distro when `wsl`) via a new shared `resolveLocalAccountRuntimeTarget` helper.
- One-shot, guarded migration flips the untouched legacy `'host'` default to `'auto'` (guard flag `localAccountRuntimeDefaultedToAutoForAllUsers`, mirroring the existing `localWindowsRuntimeDefault` migration). An explicit `'wsl'` pin is preserved, and an explicit `'host'` chosen **after** migration is never re-flipped.
- Wire the shared resolver into the three surfaces that were only honoring a literal `'wsl'`: the managed-account default target (`runtime-auth-service`), the status-bar WSL-group gate (`StatusBar`), and the Accounts settings location toggle (`AccountsPane`).

### Behavior

- **Windows-host default users:** `'auto'` resolves to host — **no change**.
- **WSL default users:** `'auto'` resolves to WSL — WSL accounts are recognized and the WSL switcher group appears. This is the fix.
- The explicit Windows/WSL toggle in Settings › Accounts remains as an override.

### Deliberate scope note

Detection follows the **global** Windows runtime default, not the live active project's runtime (the fetch target is a single global value; "account quota polling has no project id"). Re-targeting on active-project switch is a larger follow-up and intentionally out of scope.

## Tests

- New `src/shared/local-account-runtime.test.ts` (host / wsl / auto×{host,wsl} / non-win32).
- `claude`/`codex-rate-limit-target.test.ts`: `'auto'` + WSL default → WSL; `'auto'` + windows-host → host.
- `persistence.test.ts`: legacy `'host'` migrates to `'auto'`; explicit `'wsl'` preserved; explicit `'host'` set after migration is not re-flipped.
- `AccountsPane.test.tsx`: under `'auto'` + WSL default the WSL location toggle is selected.

## Verification

- `pnpm typecheck` (node/web/cli) — clean.
- Targeted `vitest` suites above — green (two unrelated failures in the full persistence/runtime-auth runs are environmental: a Windows symlink `EPERM` and a 130k-leaf perf test timeout).
- Lint — no new switch-exhaustiveness violations from the new union value.
- Manual (Windows + WSL, out of band): with the global Windows runtime default set to WSL and Claude signed in inside WSL, confirm the WSL account is recognized and the WSL switcher group appears; with a windows-host default, confirm behavior is unchanged.