### PR TITLE
fix(terminal): reap Windows agent PTY process trees on worktree teardown (#9045)

### DIFF
--- a/src/main/pty-descendant-termination.test.ts
+++ b/src/main/pty-descendant-termination.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const execFileMock = vi.hoisted(() => vi.fn())
-vi.mock('node:child_process', () => ({ execFile: execFileMock }))
+const execFileSyncMock = vi.hoisted(() => vi.fn())
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+  execFileSync: execFileSyncMock
+}))
 
 import {
   captureDescendantSnapshot,
@@ -12,6 +16,7 @@ import {
   killWithDescendantSweep,
   parseProcessTable,
   terminateDescendantSnapshot,
+  WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS,
   type ProcessTableCapture,
   type ProcessTableRow
 } from './pty-descendant-termination'
@@ -24,6 +29,8 @@ beforeEach(() => {
     const callback = args.at(-1) as (error: Error | null, stdout: string) => void
     callback(null, '10 1 10 Mon Jul 13 12:54:47 2026')
   })
+  execFileSyncMock.mockReset()
+  execFileSyncMock.mockReturnValue(Buffer.from(''))
 })
 
 function row(
@@ -115,10 +122,23 @@ describe('captureDescendantSnapshot', () => {
     expect(vi.getTimerCount()).toBe(0)
   })
 
-  it('is a null no-op on Windows', async () => {
+  it('carries the root PID as a Windows tree-kill snapshot without a ps walk (#9045)', async () => {
     const readTable = vi.fn()
-    expect(await captureDescendantSnapshot(10, { readTable, platform: 'win32' })).toBeNull()
+    const result = await captureDescendantSnapshot(4321, { readTable, platform: 'win32' })
+    // Why: Windows reaps via taskkill /T at kill time, so the snapshot needs only
+    // the root PID — no ppid table read (which reparenting would invalidate anyway).
+    expect(result).toEqual({
+      rootPgid: null,
+      descendants: [],
+      capturedAtMs: expect.any(Number),
+      windowsRootPid: 4321
+    })
     expect(readTable).not.toHaveBeenCalled()
+  })
+
+  it('returns null on Windows for an invalid root PID', async () => {
+    expect(await captureDescendantSnapshot(0, { platform: 'win32' })).toBeNull()
+    expect(await captureDescendantSnapshot(-1, { platform: 'win32' })).toBeNull()
   })
 
   it('degrades to null when ps fails', async () => {
@@ -267,6 +287,53 @@ describe('terminateDescendantSnapshot', () => {
     expect(sendSignal).not.toHaveBeenCalled()
     expect(vi.getTimerCount()).toBe(0)
   })
+
+  it('force-kills the whole Windows tree via taskkill and skips POSIX escalation (#9045)', () => {
+    const killWindowsProcessTree = vi.fn()
+    const sendSignal = vi.fn()
+    terminateDescendantSnapshot(
+      { rootPgid: null, descendants: [], capturedAtMs: CAPTURED_AT_MS, windowsRootPid: 4321 },
+      { killWindowsProcessTree, sendSignal }
+    )
+    // Why: taskkill /T reaps the tree in one shot — no per-descendant SIGTERM and
+    // no grace-window SIGKILL timer that the POSIX path arms.
+    expect(killWindowsProcessTree).toHaveBeenCalledWith(4321)
+    expect(sendSignal).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('runs a bounded, hidden taskkill /pid <root> /t /f by default (#9045)', () => {
+    terminateDescendantSnapshot({
+      rootPgid: null,
+      descendants: [],
+      capturedAtMs: CAPTURED_AT_MS,
+      windowsRootPid: 4321
+    })
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      'taskkill',
+      ['/pid', '4321', '/t', '/f'],
+      expect.objectContaining({
+        timeout: WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS,
+        windowsHide: true,
+        stdio: 'ignore'
+      })
+    )
+  })
+
+  it('swallows an already-gone taskkill failure instead of throwing (#9045)', () => {
+    execFileSyncMock.mockImplementation(() => {
+      // Why: taskkill exits non-zero (execFileSync throws) when the tree is already dead.
+      throw new Error('ERROR: The process "4321" not found.')
+    })
+    expect(() =>
+      terminateDescendantSnapshot({
+        rootPgid: null,
+        descendants: [],
+        capturedAtMs: CAPTURED_AT_MS,
+        windowsRootPid: 4321
+      })
+    ).not.toThrow()
+  })
 })
 
 describe('createProcessTableSnapshotReader', () => {
@@ -378,6 +445,37 @@ describe('killWithDescendantSweep', () => {
 
     expect(ownsRoot).toHaveBeenCalledOnce()
     expect(sendSignal).not.toHaveBeenCalled()
+    expect(killRoot).toHaveBeenCalledOnce()
+  })
+
+  it('taskkills the Windows tree BEFORE closing the ConPTY root (#9045)', async () => {
+    const events: string[] = []
+    // Why: this ordering is the whole fix — killing the root (ConPTY close) first
+    // would break the child links and orphan the claude/node/cmd grandchildren.
+    const killWindowsProcessTree = vi.fn(() => events.push('tree-kill'))
+    const killRoot = vi.fn(() => events.push('root-kill'))
+
+    await killWithDescendantSweep(4321, killRoot, {
+      platform: 'win32',
+      killWindowsProcessTree
+    })
+
+    expect(killWindowsProcessTree).toHaveBeenCalledWith(4321)
+    expect(killRoot).toHaveBeenCalledOnce()
+    expect(events).toEqual(['tree-kill', 'root-kill'])
+  })
+
+  it('still closes the Windows root when it no longer owns the tree (#9045)', async () => {
+    const killWindowsProcessTree = vi.fn()
+    const killRoot = vi.fn()
+
+    await killWithDescendantSweep(4321, killRoot, {
+      platform: 'win32',
+      killWindowsProcessTree,
+      ownsRoot: () => false
+    })
+
+    expect(killWindowsProcessTree).not.toHaveBeenCalled()
     expect(killRoot).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/pty-descendant-termination.ts
+++ b/src/main/pty-descendant-termination.ts
@@ -1,7 +1,10 @@
-import { execFile } from 'node:child_process'
+import { execFile, execFileSync } from 'node:child_process'
 
 export const DESCENDANT_KILL_GRACE_MS = 2_000
 export const DESCENDANT_SNAPSHOT_TIMEOUT_MS = 1_000
+// Why: taskkill reaping a live tree is quick, but the sync call must stay bounded
+// so a wedged taskkill can never outlast the worktree physical-stop deadline.
+export const WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS = 2_000
 // Why: a full process table on a busy host can exceed execFile's 1MB default;
 // truncation would silently drop descendants from the snapshot.
 const PS_MAX_BUFFER_BYTES = 32 * 1024 * 1024
@@ -21,6 +24,9 @@ export type DescendantSnapshot = {
   /** Wall-clock boundary for deciding whether ps's second-resolution lstart
    *  can safely distinguish this process from a later PID reuse. */
   capturedAtMs: number
+  /** Windows-only: the PTY root PID. Windows has no ppid pre-snapshot — taskkill /T
+   *  enumerates the live child tree at kill time — so the root alone is sufficient. */
+  windowsRootPid?: number
 }
 
 export type ProcessTableCapture = {
@@ -190,8 +196,9 @@ type SnapshotDeps = {
 /**
  * Snapshots a PTY root's live descendant tree. Must run BEFORE the root is
  * signalled: once the root dies, surviving descendants reparent to pid 1 and
- * can no longer be found by a ppid walk. Resolves null (never rejects) on
- * Windows, ps failure, or timeout — callers then degrade to today's
+ * can no longer be found by a ppid walk. On Windows there is no ppid walk —
+ * the snapshot just carries the root PID for a taskkill /T tree kill. Resolves
+ * null (never rejects) on ps failure or timeout — callers then degrade to a
  * shell-only kill.
  */
 export async function captureDescendantSnapshot(
@@ -199,8 +206,16 @@ export async function captureDescendantSnapshot(
   deps: SnapshotDeps = {}
 ): Promise<DescendantSnapshot | null> {
   const platform = deps.platform ?? process.platform
-  if (platform === 'win32' || !Number.isInteger(rootPid) || rootPid <= 0) {
+  if (!Number.isInteger(rootPid) || rootPid <= 0) {
     return null
+  }
+  if (platform === 'win32') {
+    // Why: a ConPTY close reaps only the direct shell, so agent grandchildren
+    // (claude→node/cmd) survive, keep the conout pipe open — node-pty's exit then
+    // never fires — and hold handles into the worktree dir (#9045). taskkill /T
+    // enumerates the live tree at kill time, so we carry only the root PID; a ppid
+    // pre-snapshot would be invalidated the moment the shell is signalled anyway.
+    return { rootPgid: null, descendants: [], capturedAtMs: Date.now(), windowsRootPid: rootPid }
   }
   const readTable = deps.readTable ?? readProcessTable
   const timeoutMs = deps.timeoutMs ?? DESCENDANT_SNAPSHOT_TIMEOUT_MS
@@ -249,6 +264,29 @@ type TerminateDeps = {
   sendSignal?: SignalSender
   graceMs?: number
   timeoutMs?: number
+  killWindowsProcessTree?: (rootPid: number) => void
+}
+
+/**
+ * Force-kills a Windows PTY root and its whole descendant tree with `taskkill /T /F`.
+ * Synchronous on purpose: it must reap the tree BEFORE the caller closes the ConPTY —
+ * once the shell dies the child links break and taskkill can no longer reach the
+ * grandchildren, exactly the reparent hazard the POSIX snapshot-first path avoids.
+ */
+function killWindowsProcessTree(rootPid: number): void {
+  if (!Number.isInteger(rootPid) || rootPid <= 0) {
+    return
+  }
+  try {
+    execFileSync('taskkill', ['/pid', String(rootPid), '/t', '/f'], {
+      timeout: WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS,
+      windowsHide: true,
+      stdio: 'ignore'
+    })
+  } catch {
+    // Why: taskkill exits non-zero when the tree is already gone (the Windows
+    // analogue of ESRCH); a failure must never block the caller's root kill.
+  }
 }
 
 function hasUnambiguousStartIdentity(row: ProcessTableRow, capturedAtMs: number): boolean {
@@ -271,6 +309,12 @@ export function terminateDescendantSnapshot(
   snapshot: DescendantSnapshot,
   deps: TerminateDeps = {}
 ): void {
+  if (snapshot.windowsRootPid !== undefined) {
+    // Why: Windows has no captured descendant list — taskkill /T reaps the tree from
+    // the root in one shot (no grace/SIGKILL escalation, which is a POSIX-signal notion).
+    ;(deps.killWindowsProcessTree ?? killWindowsProcessTree)(snapshot.windowsRootPid)
+    return
+  }
   const sendSignal = deps.sendSignal ?? defaultSendSignal
   const readTable = deps.readTable ?? readProcessTable
   for (const row of snapshot.descendants) {

--- a/src/main/runtime/repro-9045-windows-pty-tree-kill-gap.test.ts
+++ b/src/main/runtime/repro-9045-windows-pty-tree-kill-gap.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const execFileSyncMock = vi.hoisted(() => vi.fn())
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+  execFileSync: execFileSyncMock
+}))
+
+import { killWithDescendantSweep } from '../pty-descendant-termination'
+
+/**
+ * Reproduction for issue #9045 — on Windows, deleting a worktree fails with
+ * "Failed to physically stop every PTY for worktree" and leaves orphaned
+ * claude.exe / node.exe / cmd.exe processes holding handles into the worktree dir.
+ *
+ * Mechanism (single root cause):
+ *   Windows PTY teardown reduces to a ConPTY close of the *direct shell*. The agent's
+ *   grandchildren (claude → node/cmd) are never reaped, so they keep the ConPTY conout
+ *   pipe open. node-pty's `onExit` — the physical-exit proof the destructive delete gate
+ *   (`killAllProcessesForWorktree`, requirePhysicalStop) waits on — only fires once the
+ *   conout pipe is free, i.e. once every console-attached descendant is gone. So both
+ *   symptoms fall out of one missing tree kill: the gate times out AND the grandchildren
+ *   linger as orphans.
+ *
+ * These tests model that conout dependency at the exact seam that used to be a Windows
+ * no-op — `captureDescendantSnapshot` returned null on win32, so `killWithDescendantSweep`
+ * never reaped the tree. The fix carries the root PID as a Windows snapshot and reaps the
+ * tree with `taskkill /pid <root> /t /f` before the ConPTY close.
+ */
+describe('repro #9045: Windows agent worktree teardown leaves orphaned process trees', () => {
+  /**
+   * Models a Windows agent PTY: a shell root whose orphan-prone grandchildren keep the
+   * ConPTY conout pipe open. The root's physical exit (node-pty onExit) is proven only if
+   * the grandchild tree is already reaped when the ConPTY is closed.
+   */
+  function simulateWindowsAgentTeardown(config: {
+    killWindowsProcessTree?: (rootPid: number) => void
+  }): Promise<{ orphans: Set<string>; rootPhysicalExitProven: boolean }> {
+    const SHELL_PID = 4321
+    const orphans = new Set(['claude.exe', 'node.exe', 'cmd.exe'])
+    let rootPhysicalExitProven = false
+
+    const killRoot = (): void => {
+      // ConPTY close reaps only the direct shell; onExit fires only when no grandchild
+      // is still holding the conout pipe open (the real Windows ConPTY behavior).
+      if (orphans.size === 0) {
+        rootPhysicalExitProven = true
+      }
+    }
+
+    return killWithDescendantSweep(SHELL_PID, killRoot, {
+      platform: 'win32',
+      ...(config.killWindowsProcessTree
+        ? { killWindowsProcessTree: config.killWindowsProcessTree }
+        : {})
+    }).then(() => ({ orphans, rootPhysicalExitProven }))
+  }
+
+  it('BUG (pre-fix win32 no-op): grandchildren survive and the physical-stop gate is never satisfied', async () => {
+    // Pre-#9045, win32 produced no descendant snapshot, so no tree kill ran — modeled here
+    // as a killWindowsProcessTree that does nothing (the old shell-only kill).
+    const { orphans, rootPhysicalExitProven } = await simulateWindowsAgentTeardown({
+      killWindowsProcessTree: () => {}
+    })
+
+    // Both reported symptoms: orphaned claude/node/cmd, and an unproven physical exit that
+    // makes `killAllProcessesForWorktree` throw "Failed to physically stop every PTY".
+    expect([...orphans]).toEqual(['claude.exe', 'node.exe', 'cmd.exe'])
+    expect(rootPhysicalExitProven).toBe(false)
+  })
+
+  it('FIX: taskkill /t /f reaps the whole tree, the conout frees, and physical exit is proven', async () => {
+    // Exercise the REAL default helper: killWithDescendantSweep → captureDescendantSnapshot
+    // (win32) → terminateDescendantSnapshot → killWindowsProcessTree → execFileSync taskkill.
+    const orphansRef = { current: new Set<string>() }
+    execFileSyncMock.mockReset()
+    execFileSyncMock.mockImplementation((command: string, args: string[]) => {
+      if (command === 'taskkill' && args.includes('/t') && args.includes('/f')) {
+        // taskkill /T /F reaps the shell root and every descendant in one shot.
+        orphansRef.current.clear()
+      }
+      return Buffer.from('')
+    })
+
+    const SHELL_PID = 4321
+    const orphans = new Set(['claude.exe', 'node.exe', 'cmd.exe'])
+    orphansRef.current = orphans
+    let rootPhysicalExitProven = false
+    const killRoot = (): void => {
+      if (orphans.size === 0) {
+        rootPhysicalExitProven = true
+      }
+    }
+
+    await killWithDescendantSweep(SHELL_PID, killRoot, { platform: 'win32' })
+
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      'taskkill',
+      ['/pid', String(SHELL_PID), '/t', '/f'],
+      expect.objectContaining({ windowsHide: true, stdio: 'ignore' })
+    )
+    expect([...orphans]).toEqual([])
+    expect(rootPhysicalExitProven).toBe(true)
+  })
+})


### PR DESCRIPTION
Fixes #9045

## Problem
On Windows, deleting a worktree fails with `Failed to physically stop every PTY for worktree` (or `Timed out waiting for physical PTY teardown` on Force Delete) and leaves orphaned `claude.exe` / `node.exe` / `cmd.exe` processes holding handles into the worktree directory.

## Root cause (single)
Windows PTY teardown reduces to a ConPTY close of the **direct shell**. The descendant-snapshot module (`src/main/pty-descendant-termination.ts`) was a **deliberate win32 no-op** (`captureDescendantSnapshot` hard-returned `null`), so an agent's grandchildren (`claude -> node/cmd`) were never reaped. Those grandchildren:

1. keep the ConPTY **conout pipe open**, so node-pty's `exit` — the physical-exit proof the destructive delete gate (`killAllProcessesForWorktree`, `requirePhysicalStop`) waits on — never fires, and
2. keep **handles into the worktree dir**.

Both reported symptoms fall out of that one missing tree kill: the delete gate throws AND the processes orphan. This is distinct from #9197 (already fixed in #9601), which failed earlier at selector resolution.

## Fix
Minimal, Windows-scoped, inside the descendant module both providers already route agent teardown through:

- `captureDescendantSnapshot` now carries the **root PID** as a Windows snapshot (`windowsRootPid`) instead of returning `null`. Windows needs no ppid pre-snapshot because `taskkill /T` enumerates the live tree at kill time.
- `terminateDescendantSnapshot` reaps the tree with a **synchronous** `taskkill /pid <root> /t /f` — synchronous on purpose, so the tree is enumerated and killed **before** the caller closes the ConPTY (once the shell dies the child links break and taskkill can no longer reach the grandchildren, exactly the reparent hazard the POSIX snapshot-first path avoids). Failures are swallowed (the Windows analogue of ESRCH) so they never block the root kill, and the call is bounded so it can't outlast the physical-stop deadline.

Both the **daemon** (`terminal-session-teardown.ts` -> `killWithDescendantSweep`) and **local** (`local-pty-provider.ts` -> `shutdownTrackedPty`) providers get the fix through their existing **agent-scoped** calls. Non-agent terminals, POSIX, and remote hosts are untouched (the platform check runs on whichever host owns the PTY, so SSH/WSL remain correct). `taskkill /t /f` matches existing repo idiom (e.g. `claude-accounts/service.ts`).

## Tests
- New repro `src/main/runtime/repro-9045-windows-pty-tree-kill-gap.test.ts` models the ConPTY conout dependency and contrasts the pre-fix no-op (grandchildren survive, physical exit never proven) with the fix (tree reaped via real `taskkill`, conout frees, physical exit proven).
- Regression tests in `pty-descendant-termination.test.ts`: Windows snapshot shape, `taskkill /pid <root> /t /f` args + bounded/hidden opts, already-gone error swallowed, and the critical **ordering** assertion that the tree kill runs before the ConPTY root close.

Affected suites pass (`pty-descendant-termination`, `repro-9045`, `worktree-teardown`, daemon `session`/`terminal-session-teardown`/`pty-subprocess`, `local-pty-provider`): 301 passed. `npm run typecheck` and `oxlint` clean.

## Note on live repro
A fresh live Electron repro was impractical in this environment (dev CLI build incomplete); the deterministic gate-mechanism test above is used per the issue's allowance, and the issue already carries live `Get-CimInstance` evidence of the `powershell -> claude -> pwsh/node` tree shape on Windows.
