### PR TITLE
Flag client/server app-version skew and self-heal stale subscriptions after serve restarts

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3464,6 +3464,9 @@ export class OrcaRuntimeService {
       liveLeafCount: this.leaves.size,
       runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
       minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
+      // Why: read from env (stamped at startup in main/index.ts) so this module
+      // stays importable without Electron in unit tests.
+      appVersion: process.env.ORCA_APP_VERSION ?? null,
       // Why: headless orca serve cannot create/stream BrowserViews, so clients
       // must not treat browser panes as supported just because runtime RPC is up.
       capabilities,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -60,6 +60,7 @@ import { StarNagCard } from './components/StarNagCard'
 import { StarNagAgentValueMomentObserver } from './components/star-nag/StarNagAgentValueMomentObserver'
 import { StarNagToastHost } from './components/star-nag/StarNagToastHost'
 import { SkillFreshnessNudge } from './components/skills/SkillFreshnessNudge'
+import { RuntimeVersionSkewNudge } from './components/sidebar/RuntimeVersionSkewNudge'
 import { SkillFreshnessUpdateDialog } from './components/skills/SkillFreshnessUpdateDialog'
 import { TelemetryFirstLaunchSurface } from './components/TelemetryFirstLaunchSurface'
 import { ZoomOverlay } from './components/ZoomOverlay'
@@ -2594,6 +2595,7 @@ function App(): React.JSX.Element {
       </TooltipProvider>
       <Toaster closeButton toastOptions={{ className: 'font-sans text-sm' }} />
       <SkillFreshnessNudge />
+      <RuntimeVersionSkewNudge />
       <PinnedTabCloseDialog />
       {/* Why: Electron's drag-region hit-test is DOM-order-based (ignores z-index); render last so WindowControls stay clickable. */}
       {hasCustomTitleBar && <WindowControls />}

--- a/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
+++ b/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
@@ -54,6 +54,7 @@ import {
 } from './runtime-environments-search'
 import { unwrapRuntimeRpcResult } from '@/runtime/runtime-rpc-client'
 import { useAppStore } from '@/store'
+import { buildRuntimeEnvironmentStatusEntry } from '@/store/slices/runtime-status'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
 import { getUpdateCheckClickOptions, getUpdateCheckHint } from '@/lib/update-check-click-options'
@@ -347,10 +348,12 @@ export function RuntimeEnvironmentsPane({
             const runtimeStatus = unwrapRuntimeRpcResult<RuntimeStatus>(response)
             // Why: feed the live status into the store so sidebar host pickers
             // reflect manual refreshes, not just the settings pane.
-            useAppStore.getState().setRuntimeEnvironmentStatus(environment.id, {
-              status: runtimeStatus,
-              checkedAt: Date.now()
-            })
+            useAppStore
+              .getState()
+              .setRuntimeEnvironmentStatus(
+                environment.id,
+                await buildRuntimeEnvironmentStatusEntry(runtimeStatus)
+              )
             if (!mountedRef.current) {
               return
             }
@@ -612,10 +615,12 @@ export function RuntimeEnvironmentsPane({
       const compatibility = evaluateHostDetails(runtimeStatus)
       // Why: row Connect is reachability only. The Advanced selector is the
       // explicit default-host control and should be the only active-server path.
-      useAppStore.getState().setRuntimeEnvironmentStatus(environment.id, {
-        status: runtimeStatus,
-        checkedAt: Date.now()
-      })
+      useAppStore
+        .getState()
+        .setRuntimeEnvironmentStatus(
+          environment.id,
+          await buildRuntimeEnvironmentStatusEntry(runtimeStatus)
+        )
       if (mountedRef.current) {
         setDetailsByEnvironmentId((current) => ({
           ...current,

--- a/src/renderer/src/components/sidebar/HostSectionHeaderMenu.tsx
+++ b/src/renderer/src/components/sidebar/HostSectionHeaderMenu.tsx
@@ -31,6 +31,8 @@ import {
   unwrapRuntimeRpcResult
 } from '@/runtime/runtime-rpc-client'
 import type { RuntimeStatus } from '../../../../shared/runtime-types'
+import { buildRuntimeEnvironmentStatusEntry } from '@/store/slices/runtime-status'
+import { describeAppVersionSkew } from '../../../../shared/app-version-skew'
 import type { HostHeaderRow } from './host-section-rows'
 import { buildHostHeaderMenuModel } from './host-header-menu-items'
 import { HostRenameDialog } from './HostRenameDialog'
@@ -86,7 +88,8 @@ export function HostSectionHeaderMenu({ row }: { row: HostHeaderRow }): React.JS
     kind: row.kind,
     health: row.health,
     sshConnected,
-    compatibility: row.compatibility
+    compatibility: row.compatibility,
+    versionSkew: row.versionSkew
   })
   const removalTarget = resolveHostRemoval(row.hostId)
 
@@ -143,10 +146,12 @@ export function HostSectionHeaderMenu({ row }: { row: HostHeaderRow }): React.JS
       const runtimeStatus = unwrapRuntimeRpcResult<RuntimeStatus>(response)
       // Why: feed the probe result into the shared store so the host header and
       // other host pickers reflect this check without a separate fetch.
-      useAppStore.getState().setRuntimeEnvironmentStatus(parsed.environmentId, {
-        status: runtimeStatus,
-        checkedAt: Date.now()
-      })
+      useAppStore
+        .getState()
+        .setRuntimeEnvironmentStatus(
+          parsed.environmentId,
+          await buildRuntimeEnvironmentStatusEntry(runtimeStatus)
+        )
       toast.success(
         translate(
           'auto.components.sidebar.HostSectionHeaderMenu.7f1a2b3c4d',
@@ -225,6 +230,33 @@ export function HostSectionHeaderMenu({ row }: { row: HostHeaderRow }): React.JS
               </TooltipTrigger>
               <TooltipContent side="right" sideOffset={6} className="max-w-72">
                 {row.compatibility ? describeRuntimeCompatBlock(row.compatibility) : null}
+              </TooltipContent>
+            </Tooltip>
+            <DropdownMenuSeparator />
+          </>
+        )}
+        {model.versionSkew && (
+          <>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuItem
+                  className="text-amber-600 focus:text-amber-600 dark:text-amber-400 dark:focus:text-amber-400"
+                  onSelect={() => openManageHost(row)}
+                >
+                  <AlertTriangle className="size-3.5" />
+                  {model.versionSkew.direction === 'server-older'
+                    ? translate(
+                        'auto.components.sidebar.HostSectionHeaderMenu.skewUpdateServer',
+                        'Server update recommended'
+                      )
+                    : translate(
+                        'auto.components.sidebar.HostSectionHeaderMenu.skewUpdateApp',
+                        'App update recommended'
+                      )}
+                </DropdownMenuItem>
+              </TooltipTrigger>
+              <TooltipContent side="right" sideOffset={6} className="max-w-72">
+                {describeAppVersionSkew(model.versionSkew)}
               </TooltipContent>
             </Tooltip>
             <DropdownMenuSeparator />

--- a/src/renderer/src/components/sidebar/RuntimeVersionSkewNudge.tsx
+++ b/src/renderer/src/components/sidebar/RuntimeVersionSkewNudge.tsx
@@ -34,20 +34,33 @@ export function RuntimeVersionSkewNudge(): null {
       const { environmentId, skew } = action
       shownKeys.current.set(environmentId, action.key)
       retractToast(environmentId)
-      const name =
-        environments.find((environment) => environment.id === environmentId)?.name ?? environmentId
+      // Why: the name can lag the first probe (pairing races status refresh) or
+      // be unset; a generic title beats surfacing an opaque environment id.
+      const name = environments
+        .find((environment) => environment.id === environmentId)
+        ?.name?.trim()
       const id = toast.warning(
         skew.direction === 'server-older'
-          ? translate(
-              'auto.components.sidebar.RuntimeVersionSkewNudge.titleServerOlder',
-              'Orca server "{{value0}}" is outdated',
-              { value0: name }
-            )
-          : translate(
-              'auto.components.sidebar.RuntimeVersionSkewNudge.titleServerNewer',
-              'Orca server "{{value0}}" is newer than this app',
-              { value0: name }
-            ),
+          ? name
+            ? translate(
+                'auto.components.sidebar.RuntimeVersionSkewNudge.titleServerOlder',
+                'Orca server "{{value0}}" is outdated',
+                { value0: name }
+              )
+            : translate(
+                'auto.components.sidebar.RuntimeVersionSkewNudge.titleServerOlderUnnamed',
+                'An Orca server is outdated'
+              )
+          : name
+            ? translate(
+                'auto.components.sidebar.RuntimeVersionSkewNudge.titleServerNewer',
+                'Orca server "{{value0}}" is newer than this app',
+                { value0: name }
+              )
+            : translate(
+                'auto.components.sidebar.RuntimeVersionSkewNudge.titleServerNewerUnnamed',
+                'An Orca server is newer than this app'
+              ),
         {
           description: describeAppVersionSkew(skew),
           // Why: skew persists until someone updates a machine; an auto-expiring

--- a/src/renderer/src/components/sidebar/RuntimeVersionSkewNudge.tsx
+++ b/src/renderer/src/components/sidebar/RuntimeVersionSkewNudge.tsx
@@ -14,6 +14,19 @@ export function RuntimeVersionSkewNudge(): null {
   const shownKeys = useRef(new Map<string, string>())
   const activeToasts = useRef(new Map<string, string | number>())
 
+  // Why: infinite-duration toasts outlive this component; without unmount cleanup they linger as undismissable ghosts (and duplicate under StrictMode remounts).
+  useEffect(() => {
+    const toasts = activeToasts.current
+    const keys = shownKeys.current
+    return () => {
+      for (const id of toasts.values()) {
+        toast.dismiss(id)
+      }
+      toasts.clear()
+      keys.clear()
+    }
+  }, [])
+
   useEffect(() => {
     const retractToast = (environmentId: string): void => {
       const activeId = activeToasts.current.get(environmentId)

--- a/src/renderer/src/components/sidebar/RuntimeVersionSkewNudge.tsx
+++ b/src/renderer/src/components/sidebar/RuntimeVersionSkewNudge.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useRef } from 'react'
+import { toast } from 'sonner'
+import { describeAppVersionSkew } from '../../../../shared/app-version-skew'
+import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
+import { planRuntimeVersionSkewNudges } from './runtime-version-skew-nudge-plan'
+
+// Why: proactive counterpart to the sidebar host-header skew warning — that
+// warning only renders in explicit host-filter views, so a user in the default
+// Projects view would first meet version skew as a confusing feature failure.
+export function RuntimeVersionSkewNudge(): null {
+  const statuses = useAppStore((s) => s.runtimeStatusByEnvironmentId)
+  const environments = useAppStore((s) => s.runtimeEnvironments)
+  const shownKeys = useRef(new Map<string, string>())
+  const activeToasts = useRef(new Map<string, string | number>())
+
+  useEffect(() => {
+    const retractToast = (environmentId: string): void => {
+      const activeId = activeToasts.current.get(environmentId)
+      if (activeId !== undefined) {
+        activeToasts.current.delete(environmentId)
+        toast.dismiss(activeId)
+      }
+    }
+    for (const action of planRuntimeVersionSkewNudges({
+      statuses,
+      shownKeyByEnvironmentId: shownKeys.current
+    })) {
+      if (action.kind === 'clear') {
+        shownKeys.current.delete(action.environmentId)
+        retractToast(action.environmentId)
+        continue
+      }
+      const { environmentId, skew } = action
+      shownKeys.current.set(environmentId, action.key)
+      retractToast(environmentId)
+      const name =
+        environments.find((environment) => environment.id === environmentId)?.name ?? environmentId
+      const id = toast.warning(
+        skew.direction === 'server-older'
+          ? translate(
+              'auto.components.sidebar.RuntimeVersionSkewNudge.titleServerOlder',
+              'Orca server "{{value0}}" is outdated',
+              { value0: name }
+            )
+          : translate(
+              'auto.components.sidebar.RuntimeVersionSkewNudge.titleServerNewer',
+              'Orca server "{{value0}}" is newer than this app',
+              { value0: name }
+            ),
+        {
+          description: describeAppVersionSkew(skew),
+          // Why: skew persists until someone updates a machine; an auto-expiring
+          // toast would be missed exactly by the users who need it.
+          duration: Number.POSITIVE_INFINITY,
+          onDismiss: () => {
+            if (activeToasts.current.get(environmentId) === id) {
+              activeToasts.current.delete(environmentId)
+            }
+          },
+          action: {
+            label: translate(
+              'auto.components.sidebar.RuntimeVersionSkewNudge.manageServer',
+              'Manage server'
+            ),
+            onClick: () => {
+              if (activeToasts.current.get(environmentId) === id) {
+                activeToasts.current.delete(environmentId)
+              }
+              const state = useAppStore.getState()
+              state.openSettingsTarget({
+                pane: 'servers',
+                repoId: null,
+                sectionId: environmentId
+              })
+              state.openSettingsPage()
+            }
+          }
+        }
+      )
+      activeToasts.current.set(environmentId, id)
+    }
+  }, [environments, statuses])
+
+  return null
+}

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -760,9 +760,11 @@ function SectionMetricsBadge({ count }: { count: number }): React.JSX.Element {
 }
 
 function HostHeaderHealthIcon({
-  health
+  health,
+  versionSkew
 }: {
   health: HostHeaderRow['health']
+  versionSkew?: HostHeaderRow['versionSkew']
 }): React.JSX.Element | null {
   // Why: only surface states needing attention; healthy is the silent default.
   if (health === 'connecting') {
@@ -771,15 +773,22 @@ function HostHeaderHealthIcon({
   if (health === 'blocked' || health === 'error') {
     return <AlertTriangle className="size-3 shrink-0 text-destructive" />
   }
+  // Why: version skew is non-blocking, so it gets the caution tint rather than
+  // the destructive one reserved for hosts that cannot be used at all.
+  if (versionSkew) {
+    return <AlertTriangle className="size-3 shrink-0 text-amber-500" />
+  }
   return null
 }
 
-function getHostHeaderDetail(row: HostHeaderRow): { text: string; isWarning: boolean } | null {
+function getHostHeaderDetail(
+  row: HostHeaderRow
+): { text: string; tone: 'destructive' | 'caution' | 'muted' } | null {
   // Why: a blocked compatibility verdict earns a compact warning so the host stands out.
   if (row.health === 'blocked') {
     return {
       text: translate('auto.components.sidebar.WorktreeList.7a8b9c0d1e', 'Update required'),
-      isWarning: true
+      tone: 'destructive'
     }
   }
   // Why: auth-failed needs a worded status; the health icon alone doesn't tell the user to re-auth.
@@ -789,18 +798,34 @@ function getHostHeaderDetail(row: HostHeaderRow): { text: string; isWarning: boo
         'auto.components.sidebar.WorktreeList.hostAuthNeeded',
         'Authentication needed'
       ),
-      isWarning: true
+      tone: 'destructive'
     }
   }
   if (row.health === 'disconnected') {
     return {
       text: translate('auto.components.sidebar.WorktreeList.hostDisconnected', 'Disconnected'),
-      isWarning: false
+      tone: 'muted'
     }
+  }
+  // Why: non-blocking app-version skew still works, but warns — a client that
+  // auto-updated ahead of its server hits confusing feature failures otherwise.
+  if (row.versionSkew) {
+    return row.versionSkew.direction === 'server-older'
+      ? {
+          text: translate(
+            'auto.components.sidebar.WorktreeList.hostServerOutdated',
+            'Server outdated'
+          ),
+          tone: 'caution'
+        }
+      : {
+          text: translate('auto.components.sidebar.WorktreeList.hostAppOutdated', 'App outdated'),
+          tone: 'caution'
+        }
   }
   // Why: show the transport detail only for remote hosts; it's noise under the local label.
   if (row.kind !== 'local') {
-    return { text: row.detail, isWarning: false }
+    return { text: row.detail, tone: 'muted' }
   }
   return null
 }
@@ -851,7 +876,7 @@ function HostSectionHeader({
         ) : (
           <Server className="size-3.5 shrink-0 text-muted-foreground" />
         )}
-        <HostHeaderHealthIcon health={row.health} />
+        <HostHeaderHealthIcon health={row.health} versionSkew={row.versionSkew} />
         {/* Why: badge hugs the label (like repo headers) instead of floating by the hover controls. */}
         <div className="flex min-w-0 flex-1 items-baseline gap-1.5">
           <span
@@ -866,7 +891,11 @@ function HostSectionHeader({
             <span
               className={cn(
                 'shrink-0 truncate text-[10px] leading-none',
-                detail.isWarning ? 'text-destructive' : 'text-muted-foreground/70'
+                detail.tone === 'destructive'
+                  ? 'text-destructive'
+                  : detail.tone === 'caution'
+                    ? 'text-amber-600 dark:text-amber-400'
+                    : 'text-muted-foreground/70'
               )}
             >
               {detail.text}

--- a/src/renderer/src/components/sidebar/host-header-menu-items.test.ts
+++ b/src/renderer/src/components/sidebar/host-header-menu-items.test.ts
@@ -89,4 +89,40 @@ describe('buildHostHeaderMenuModel', () => {
     })
     expect(model.blocked).toBeNull()
   })
+
+  it('surfaces non-blocking version skew for a usable runtime host', () => {
+    const model = buildHostHeaderMenuModel({
+      kind: 'runtime',
+      health: 'available',
+      compatibility: { kind: 'ok', clientProtocolVersion: 5, serverProtocolVersion: 5 },
+      versionSkew: {
+        direction: 'server-older',
+        clientAppVersion: '1.4.147',
+        serverAppVersion: '1.4.146'
+      }
+    })
+    expect(model.blocked).toBeNull()
+    expect(model.versionSkew).toMatchObject({ direction: 'server-older' })
+  })
+
+  it('lets a blocking verdict win over version skew', () => {
+    const model = buildHostHeaderMenuModel({
+      kind: 'runtime',
+      health: 'blocked',
+      compatibility: {
+        kind: 'blocked',
+        reason: 'server-too-old',
+        clientProtocolVersion: 5,
+        serverProtocolVersion: 1,
+        requiredServerProtocolVersion: 4
+      },
+      versionSkew: {
+        direction: 'server-older',
+        clientAppVersion: '1.4.147',
+        serverAppVersion: '1.4.146'
+      }
+    })
+    expect(model.blocked).toEqual({ reason: 'server-too-old' })
+    expect(model.versionSkew).toBeNull()
+  })
 })

--- a/src/renderer/src/components/sidebar/host-header-menu-items.ts
+++ b/src/renderer/src/components/sidebar/host-header-menu-items.ts
@@ -1,3 +1,4 @@
+import type { AppVersionSkew } from '../../../../shared/app-version-skew'
 import type { ExecutionHostKind } from '../../../../shared/execution-host'
 import type { ExecutionHostHealth } from '../../../../shared/execution-host-registry'
 import type { RuntimeCompatVerdict } from '../../../../shared/protocol-compat'
@@ -23,6 +24,8 @@ export type HostHeaderMenuModel = {
   blocked: {
     reason: 'client-too-old' | 'server-too-old'
   } | null
+  /** Present when versions skew without blocking; blocked wins when both apply. */
+  versionSkew: AppVersionSkew | null
 }
 
 export type HostHeaderMenuInput = {
@@ -31,6 +34,7 @@ export type HostHeaderMenuInput = {
   /** SSH connection status drives Reconnect vs Disconnect. */
   sshConnected?: boolean
   compatibility?: RuntimeCompatVerdict
+  versionSkew?: AppVersionSkew | null
 }
 
 function sshActions(connected: boolean): HostHeaderMenuAction[] {
@@ -69,5 +73,5 @@ export function buildHostHeaderMenuModel(input: HostHeaderMenuInput): HostHeader
       ? { reason: input.compatibility.reason }
       : null
 
-  return { actions, blocked }
+  return { actions, blocked, versionSkew: blocked ? null : (input.versionSkew ?? null) }
 }

--- a/src/renderer/src/components/sidebar/host-section-rows.ts
+++ b/src/renderer/src/components/sidebar/host-section-rows.ts
@@ -8,6 +8,7 @@ import {
   type ExecutionHostKind,
   type ExecutionHostScope
 } from '../../../../shared/execution-host'
+import type { AppVersionSkew } from '../../../../shared/app-version-skew'
 import type { ExecutionHostHealth } from '../../../../shared/execution-host-registry'
 import type { RuntimeCompatVerdict } from '../../../../shared/protocol-compat'
 import type { SshConnectionStatus } from '../../../../shared/ssh-types'
@@ -25,6 +26,7 @@ export type HostHeaderRow = {
   // Why: blocked-host guidance in the header menu needs the verdict reason so
   // it can deep-link an "Update server/client required" row per skew direction.
   compatibility?: RuntimeCompatVerdict
+  versionSkew?: AppVersionSkew | null
   connectionStatus?: SshConnectionStatus
   collapsed: boolean
   count: number
@@ -39,6 +41,7 @@ export type HostSectionOption = {
   detail: string
   health: ExecutionHostHealth
   compatibility?: RuntimeCompatVerdict
+  versionSkew?: AppVersionSkew | null
   connectionStatus?: SshConnectionStatus
 }
 
@@ -299,6 +302,7 @@ export function addHostSectionRows(args: {
       detail: host.detail,
       health: host.health,
       compatibility: host.compatibility,
+      versionSkew: host.versionSkew,
       connectionStatus: host.connectionStatus,
       collapsed,
       count: countWorktreeRows(hostRows)

--- a/src/renderer/src/components/sidebar/runtime-version-skew-nudge-plan.test.ts
+++ b/src/renderer/src/components/sidebar/runtime-version-skew-nudge-plan.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import type { AppVersionSkew } from '../../../../shared/app-version-skew'
+import type { RuntimeStatus } from '../../../../shared/runtime-types'
+import {
+  planRuntimeVersionSkewNudges,
+  runtimeVersionSkewNudgeKey
+} from './runtime-version-skew-nudge-plan'
+
+const SKEW: AppVersionSkew = {
+  direction: 'server-older',
+  clientAppVersion: '1.4.147',
+  serverAppVersion: '1.4.146'
+}
+
+function reachableStatus(): RuntimeStatus {
+  return {
+    runtimeId: 'runtime-1',
+    rendererGraphEpoch: 1,
+    graphStatus: 'ready',
+    authoritativeWindowId: 1,
+    liveTabCount: 0,
+    liveLeafCount: 0
+  }
+}
+
+describe('planRuntimeVersionSkewNudges', () => {
+  it('shows a nudge for a newly skewed environment', () => {
+    const actions = planRuntimeVersionSkewNudges({
+      statuses: new Map([['env-1', { status: reachableStatus(), versionSkew: SKEW }]]),
+      shownKeyByEnvironmentId: new Map()
+    })
+    expect(actions).toEqual([
+      { kind: 'show', environmentId: 'env-1', key: runtimeVersionSkewNudgeKey(SKEW), skew: SKEW }
+    ])
+  })
+
+  it('does not re-show the same version pair within a session', () => {
+    const actions = planRuntimeVersionSkewNudges({
+      statuses: new Map([['env-1', { status: reachableStatus(), versionSkew: SKEW }]]),
+      shownKeyByEnvironmentId: new Map([['env-1', runtimeVersionSkewNudgeKey(SKEW)]])
+    })
+    expect(actions).toEqual([])
+  })
+
+  it('re-shows when the version pair changes', () => {
+    const nextSkew: AppVersionSkew = { ...SKEW, clientAppVersion: '1.4.148' }
+    const actions = planRuntimeVersionSkewNudges({
+      statuses: new Map([['env-1', { status: reachableStatus(), versionSkew: nextSkew }]]),
+      shownKeyByEnvironmentId: new Map([['env-1', runtimeVersionSkewNudgeKey(SKEW)]])
+    })
+    expect(actions).toEqual([
+      {
+        kind: 'show',
+        environmentId: 'env-1',
+        key: runtimeVersionSkewNudgeKey(nextSkew),
+        skew: nextSkew
+      }
+    ])
+  })
+
+  it('clears only when a reachable probe reports matching versions', () => {
+    const shown = new Map([['env-1', runtimeVersionSkewNudgeKey(SKEW)]])
+    expect(
+      planRuntimeVersionSkewNudges({
+        statuses: new Map([['env-1', { status: reachableStatus(), versionSkew: null }]]),
+        shownKeyByEnvironmentId: shown
+      })
+    ).toEqual([{ kind: 'clear', environmentId: 'env-1' }])
+    // Why: an unreachable blip must not reset the dedupe — that would re-toast
+    // the same skew after every reconnect.
+    expect(
+      planRuntimeVersionSkewNudges({
+        statuses: new Map([['env-1', { status: null }]]),
+        shownKeyByEnvironmentId: shown
+      })
+    ).toEqual([])
+  })
+
+  it('handles multiple environments independently', () => {
+    const otherSkew: AppVersionSkew = { ...SKEW, direction: 'server-newer', serverAppVersion: null }
+    const actions = planRuntimeVersionSkewNudges({
+      statuses: new Map([
+        ['env-shown', { status: reachableStatus(), versionSkew: SKEW }],
+        ['env-new', { status: reachableStatus(), versionSkew: otherSkew }]
+      ]),
+      shownKeyByEnvironmentId: new Map([['env-shown', runtimeVersionSkewNudgeKey(SKEW)]])
+    })
+    expect(actions).toEqual([
+      {
+        kind: 'show',
+        environmentId: 'env-new',
+        key: runtimeVersionSkewNudgeKey(otherSkew),
+        skew: otherSkew
+      }
+    ])
+  })
+})

--- a/src/renderer/src/components/sidebar/runtime-version-skew-nudge-plan.ts
+++ b/src/renderer/src/components/sidebar/runtime-version-skew-nudge-plan.ts
@@ -1,0 +1,45 @@
+import type { AppVersionSkew } from '../../../../shared/app-version-skew'
+import type { RuntimeStatus } from '../../../../shared/runtime-types'
+
+// Why: the sidebar host-header warning only renders in explicit host-filter
+// views, so skew also needs a proactive toast. This planner owns the show/
+// clear decisions as pure data so the nudge cadence is unit-testable.
+export type RuntimeVersionSkewNudgeAction =
+  | { kind: 'show'; environmentId: string; key: string; skew: AppVersionSkew }
+  | { kind: 'clear'; environmentId: string }
+
+export function runtimeVersionSkewNudgeKey(skew: AppVersionSkew): string {
+  return [skew.direction, skew.clientAppVersion, skew.serverAppVersion ?? ''].join('\0')
+}
+
+export function planRuntimeVersionSkewNudges(args: {
+  statuses: ReadonlyMap<
+    string,
+    { status: RuntimeStatus | null; versionSkew?: AppVersionSkew | null }
+  >
+  /** Skew key already toasted this session, per environment. */
+  shownKeyByEnvironmentId: ReadonlyMap<string, string>
+}): RuntimeVersionSkewNudgeAction[] {
+  const actions: RuntimeVersionSkewNudgeAction[] = []
+  for (const [environmentId, entry] of args.statuses) {
+    const skew = entry.versionSkew
+    if (!skew) {
+      // Why: only a reachable, version-matched probe proves the skew resolved.
+      // An unreachable blip (status null) must not reset the session dedupe,
+      // or the same toast would re-fire on every reconnect.
+      if (entry.status && args.shownKeyByEnvironmentId.has(environmentId)) {
+        actions.push({ kind: 'clear', environmentId })
+      }
+      continue
+    }
+    const key = runtimeVersionSkewNudgeKey(skew)
+    // Why: one toast per version pair per session — periodic probes and manual
+    // status refreshes re-record the same skew and must not re-nag. A new
+    // version pair (e.g. the next update race) notifies again.
+    if (args.shownKeyByEnvironmentId.get(environmentId) === key) {
+      continue
+    }
+    actions.push({ kind: 'show', environmentId, key, skew })
+  }
+  return actions
+}

--- a/src/renderer/src/components/sidebar/sidebar-host-options.ts
+++ b/src/renderer/src/components/sidebar/sidebar-host-options.ts
@@ -8,6 +8,7 @@ import {
   buildExecutionHostRegistry,
   type ExecutionHostHealth
 } from '../../../../shared/execution-host-registry'
+import type { AppVersionSkew } from '../../../../shared/app-version-skew'
 import type { RuntimeCompatVerdict } from '../../../../shared/protocol-compat'
 import type { SshConnectionState, SshConnectionStatus } from '../../../../shared/ssh-types'
 import type { RuntimeStatus } from '../../../../shared/runtime-types'
@@ -23,6 +24,7 @@ export type SidebarHostOption = {
   presence: 'local' | 'configured' | 'project' | 'active'
   // Why: surfaced to the sidebar host-header menu so it can warn on version skew.
   compatibility?: RuntimeCompatVerdict
+  versionSkew?: AppVersionSkew | null
   // Why: lets host headers spell out auth-needed SSH states, not just an icon.
   connectionStatus?: SshConnectionStatus
 }
@@ -43,7 +45,11 @@ export function buildSidebarHostOptions(args: {
   // verdicts and blocked health in the sidebar without re-probing servers.
   runtimeStatusByEnvironmentId?: ReadonlyMap<
     string,
-    { status?: RuntimeStatus | null; appVersion?: string | null }
+    {
+      status?: RuntimeStatus | null
+      appVersion?: string | null
+      versionSkew?: AppVersionSkew | null
+    }
   >
   runtimeEnvironments?: readonly Pick<PublicKnownRuntimeEnvironment, 'id' | 'name'>[]
   // Why: per-host display-label overrides rename hosts everywhere the sidebar

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4884,6 +4884,11 @@
           "cancel": "Cancel",
           "forget": "Remove from Orca",
           "reconnectAndDelete": "Reconnect & Delete"
+        },
+        "RuntimeVersionSkewNudge": {
+          "titleServerOlder": "Orca server \"{{value0}}\" is outdated",
+          "titleServerNewer": "Orca server \"{{value0}}\" is newer than this app",
+          "manageServer": "Manage server"
         }
       },
       "shared": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4451,7 +4451,9 @@
           "groupDeleteFailedDesc": "Something went wrong while deleting the group. No projects were removed.",
           "failedNestWorkspace": "Failed to nest workspace",
           "sidebarRowMissing": "Target no longer exists",
-          "failedUnnestWorkspace": "Failed to unnest workspace"
+          "failedUnnestWorkspace": "Failed to unnest workspace",
+          "hostServerOutdated": "Server outdated",
+          "hostAppOutdated": "App outdated"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "Cancel",
@@ -4727,7 +4729,9 @@
           "59b553e2aa": "Disconnect",
           "2d3e4f5a6b": "Check connection",
           "3c4d5e6f7a": "Manage host…",
-          "6e7f8a9b0c": "Remove host…"
+          "6e7f8a9b0c": "Remove host…",
+          "skewUpdateServer": "Server update recommended",
+          "skewUpdateApp": "App update recommended"
         },
         "LinearAgentSkillSetupPrompt": {
           "missingCliAndSkill": "Orca CLI and Linear agent skill are missing.",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4888,7 +4888,9 @@
         "RuntimeVersionSkewNudge": {
           "titleServerOlder": "Orca server \"{{value0}}\" is outdated",
           "titleServerNewer": "Orca server \"{{value0}}\" is newer than this app",
-          "manageServer": "Manage server"
+          "manageServer": "Manage server",
+          "titleServerOlderUnnamed": "An Orca server is outdated",
+          "titleServerNewerUnnamed": "An Orca server is newer than this app"
         }
       },
       "shared": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4861,6 +4861,11 @@
           "cancel": "Cancelar",
           "forget": "Eliminar de Orca",
           "reconnectAndDelete": "Reconectar y eliminar"
+        },
+        "RuntimeVersionSkewNudge": {
+          "titleServerOlder": "Orca server \"{{value0}}\" is outdated",
+          "titleServerNewer": "Orca server \"{{value0}}\" is newer than this app",
+          "manageServer": "Manage server"
         }
       },
       "shared": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4405,7 +4405,9 @@
           "hostDisconnected": "Desconectado",
           "failedNestWorkspace": "No se pudo anidar el espacio de trabajo",
           "sidebarRowMissing": "El destino ya no existe",
-          "failedUnnestWorkspace": "Error al expandir el espacio de trabajo"
+          "failedUnnestWorkspace": "Error al expandir el espacio de trabajo",
+          "hostServerOutdated": "Server outdated",
+          "hostAppOutdated": "App outdated"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "Cancelar",
@@ -4756,7 +4758,9 @@
           "59b553e2aa": "Desconectar",
           "2d3e4f5a6b": "Verificar conexión",
           "3c4d5e6f7a": "Administrar host…",
-          "6e7f8a9b0c": "Quitar host…"
+          "6e7f8a9b0c": "Quitar host…",
+          "skewUpdateServer": "Server update recommended",
+          "skewUpdateApp": "App update recommended"
         },
         "WorkspaceKanbanDrawer": {
           "1975a4e480": "Falló la sincronización del estado de la tarea",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4865,7 +4865,9 @@
         "RuntimeVersionSkewNudge": {
           "titleServerOlder": "Orca server \"{{value0}}\" is outdated",
           "titleServerNewer": "Orca server \"{{value0}}\" is newer than this app",
-          "manageServer": "Manage server"
+          "manageServer": "Manage server",
+          "titleServerOlderUnnamed": "An Orca server is outdated",
+          "titleServerNewerUnnamed": "An Orca server is newer than this app"
         }
       },
       "shared": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4861,6 +4861,11 @@
           "cancel": "キャンセル",
           "forget": "Orcaから削除",
           "reconnectAndDelete": "再接続して削除"
+        },
+        "RuntimeVersionSkewNudge": {
+          "titleServerOlder": "Orca server \"{{value0}}\" is outdated",
+          "titleServerNewer": "Orca server \"{{value0}}\" is newer than this app",
+          "manageServer": "Manage server"
         }
       },
       "shared": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4386,7 +4386,9 @@
           "hostDisconnected": "切断済み",
           "failedNestWorkspace": "ワークスペースをネストできませんでした",
           "sidebarRowMissing": "対象はもう存在しません",
-          "failedUnnestWorkspace": "ワークスペースの展開に失敗しました"
+          "failedUnnestWorkspace": "ワークスペースの展開に失敗しました",
+          "hostServerOutdated": "Server outdated",
+          "hostAppOutdated": "App outdated"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "キャンセル",
@@ -4756,7 +4758,9 @@
           "59b553e2aa": "切断",
           "2d3e4f5a6b": "Check connection",
           "3c4d5e6f7a": "ホストを管理…",
-          "6e7f8a9b0c": "Remove host…"
+          "6e7f8a9b0c": "Remove host…",
+          "skewUpdateServer": "Server update recommended",
+          "skewUpdateApp": "App update recommended"
         },
         "WorkspaceKanbanDrawer": {
           "1975a4e480": "タスクステータスの同期に失敗しました",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4865,7 +4865,9 @@
         "RuntimeVersionSkewNudge": {
           "titleServerOlder": "Orca server \"{{value0}}\" is outdated",
           "titleServerNewer": "Orca server \"{{value0}}\" is newer than this app",
-          "manageServer": "Manage server"
+          "manageServer": "Manage server",
+          "titleServerOlderUnnamed": "An Orca server is outdated",
+          "titleServerNewerUnnamed": "An Orca server is newer than this app"
         }
       },
       "shared": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4386,7 +4386,9 @@
           "hostDisconnected": "연결 끊김",
           "failedNestWorkspace": "워크스페이스를 중첩하지 못했습니다",
           "sidebarRowMissing": "대상이 더 이상 존재하지 않습니다",
-          "failedUnnestWorkspace": "워크트리 펼치기 실패"
+          "failedUnnestWorkspace": "워크트리 펼치기 실패",
+          "hostServerOutdated": "Server outdated",
+          "hostAppOutdated": "App outdated"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "취소",
@@ -4756,7 +4758,9 @@
           "59b553e2aa": "연결 해제",
           "2d3e4f5a6b": "연결 확인",
           "3c4d5e6f7a": "호스트 관리…",
-          "6e7f8a9b0c": "호스트 제거…"
+          "6e7f8a9b0c": "호스트 제거…",
+          "skewUpdateServer": "Server update recommended",
+          "skewUpdateApp": "App update recommended"
         },
         "WorkspaceKanbanDrawer": {
           "1975a4e480": "작업 상태 동기화 실패",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4865,7 +4865,9 @@
         "RuntimeVersionSkewNudge": {
           "titleServerOlder": "Orca server \"{{value0}}\" is outdated",
           "titleServerNewer": "Orca server \"{{value0}}\" is newer than this app",
-          "manageServer": "Manage server"
+          "manageServer": "Manage server",
+          "titleServerOlderUnnamed": "An Orca server is outdated",
+          "titleServerNewerUnnamed": "An Orca server is newer than this app"
         }
       },
       "shared": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4861,6 +4861,11 @@
           "cancel": "취소",
           "forget": "Orca에서 제거",
           "reconnectAndDelete": "재연결 후 삭제"
+        },
+        "RuntimeVersionSkewNudge": {
+          "titleServerOlder": "Orca server \"{{value0}}\" is outdated",
+          "titleServerNewer": "Orca server \"{{value0}}\" is newer than this app",
+          "manageServer": "Manage server"
         }
       },
       "shared": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4861,6 +4861,11 @@
           "cancel": "取消",
           "forget": "从 Orca 中移除",
           "reconnectAndDelete": "重新连接并删除"
+        },
+        "RuntimeVersionSkewNudge": {
+          "titleServerOlder": "Orca server \"{{value0}}\" is outdated",
+          "titleServerNewer": "Orca server \"{{value0}}\" is newer than this app",
+          "manageServer": "Manage server"
         }
       },
       "shared": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4865,7 +4865,9 @@
         "RuntimeVersionSkewNudge": {
           "titleServerOlder": "Orca server \"{{value0}}\" is outdated",
           "titleServerNewer": "Orca server \"{{value0}}\" is newer than this app",
-          "manageServer": "Manage server"
+          "manageServer": "Manage server",
+          "titleServerOlderUnnamed": "An Orca server is outdated",
+          "titleServerNewerUnnamed": "An Orca server is newer than this app"
         }
       },
       "shared": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4386,7 +4386,9 @@
           "hostDisconnected": "已断开连接",
           "failedNestWorkspace": "无法嵌套工作区",
           "sidebarRowMissing": "目标不再存在",
-          "failedUnnestWorkspace": "展开工作区失败"
+          "failedUnnestWorkspace": "展开工作区失败",
+          "hostServerOutdated": "Server outdated",
+          "hostAppOutdated": "App outdated"
         },
         "WorktreeMetaDialog": {
           "3db0a2a593": "取消",
@@ -4756,7 +4758,9 @@
           "59b553e2aa": "断开连接",
           "2d3e4f5a6b": "检查连接",
           "3c4d5e6f7a": "管理主机…",
-          "6e7f8a9b0c": "删除主机..."
+          "6e7f8a9b0c": "删除主机...",
+          "skewUpdateServer": "Server update recommended",
+          "skewUpdateApp": "App update recommended"
         },
         "WorkspaceKanbanDrawer": {
           "1975a4e480": "任务状态同步失败",

--- a/src/renderer/src/runtime/client-app-version.ts
+++ b/src/renderer/src/runtime/client-app-version.ts
@@ -1,0 +1,17 @@
+// Why: version-skew evaluation needs this build's own app version wherever a
+// remote runtime status is ingested. The IPC answer never changes within a
+// session, so cache the promise instead of re-asking per status probe.
+let cachedClientAppVersion: Promise<string | null> | null = null
+
+export function getClientAppVersion(): Promise<string | null> {
+  // Why: resolve inside the chain so a missing preload surface (minimal test
+  // store assemblies) degrades to "unknown version" instead of throwing.
+  cachedClientAppVersion ??= Promise.resolve()
+    .then(() => window.api.updater.getVersion())
+    .catch(() => null)
+  return cachedClientAppVersion
+}
+
+export function resetClientAppVersionForTests(): void {
+  cachedClientAppVersion = null
+}

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -2,6 +2,8 @@ import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import type { PublicKnownRuntimeEnvironment } from '../../../../shared/runtime-environments'
 import type { RuntimeStatus } from '../../../../shared/runtime-types'
+import { evaluateAppVersionSkew, type AppVersionSkew } from '../../../../shared/app-version-skew'
+import { getClientAppVersion } from '@/runtime/client-app-version'
 import {
   clearRecentRuntimeCompatibilityFailure,
   clearRuntimeCompatibilityCache,
@@ -19,8 +21,32 @@ const RUNTIME_STATUS_PROBE_CONCURRENCY = 4
 export type RuntimeEnvironmentStatus = {
   status: RuntimeStatus | null
   appVersion?: string | null
+  /** Non-blocking client/server app-version skew; null when versions match,
+   * the server is unreachable, or this build's version is unknown. */
+  versionSkew?: AppVersionSkew | null
   checkedAt: number
   connectionGeneration?: number
+}
+
+/** Builds a store entry from one probe result, deriving app-version skew
+ * against this build. Shared by the boot/refresh probes and the host menu's
+ * manual "Check connection" so no ingestion path drops the skew verdict. */
+export async function buildRuntimeEnvironmentStatusEntry(
+  status: RuntimeStatus | null
+): Promise<RuntimeEnvironmentStatus> {
+  if (!status) {
+    return { status: null, checkedAt: Date.now() }
+  }
+  const clientAppVersion = await getClientAppVersion()
+  return {
+    status,
+    appVersion: status.appVersion ?? null,
+    versionSkew: evaluateAppVersionSkew({
+      clientAppVersion,
+      serverAppVersion: status.appVersion ?? null
+    }),
+    checkedAt: Date.now()
+  }
 }
 
 export type RuntimeStatusSlice = {
@@ -215,7 +241,10 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
       const status = unwrapRuntimeRpcResult<RuntimeStatus>(response)
       // setRuntimeEnvironmentStatus drops any stale compat failure on a non-null
       // (reachable) status, so a recovered host's reuse-flagged refetches re-probe.
-      get().setRuntimeEnvironmentStatus(environmentId, { status, checkedAt: Date.now() })
+      get().setRuntimeEnvironmentStatus(
+        environmentId,
+        await buildRuntimeEnvironmentStatusEntry(status)
+      )
       return true
     } catch {
       get().setRuntimeEnvironmentStatus(environmentId, {

--- a/src/shared/app-version-skew.test.ts
+++ b/src/shared/app-version-skew.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import { describeAppVersionSkew, evaluateAppVersionSkew, parseAppVersion } from './app-version-skew'
+
+describe('evaluateAppVersionSkew', () => {
+  it('returns null when client and server versions match', () => {
+    expect(
+      evaluateAppVersionSkew({ clientAppVersion: '1.4.147', serverAppVersion: '1.4.147' })
+    ).toBeNull()
+  })
+
+  it('flags a server running behind the client', () => {
+    expect(
+      evaluateAppVersionSkew({ clientAppVersion: '1.4.147', serverAppVersion: '1.4.146' })
+    ).toEqual({
+      direction: 'server-older',
+      clientAppVersion: '1.4.147',
+      serverAppVersion: '1.4.146'
+    })
+  })
+
+  it('flags a server running ahead of the client', () => {
+    expect(
+      evaluateAppVersionSkew({ clientAppVersion: '1.4.147', serverAppVersion: '1.5.0' })
+    ).toEqual({
+      direction: 'server-newer',
+      clientAppVersion: '1.4.147',
+      serverAppVersion: '1.5.0'
+    })
+  })
+
+  it('treats a server that reports no version as older', () => {
+    expect(evaluateAppVersionSkew({ clientAppVersion: '1.4.147', serverAppVersion: null })).toEqual(
+      {
+        direction: 'server-older',
+        clientAppVersion: '1.4.147',
+        serverAppVersion: null
+      }
+    )
+  })
+
+  it('ranks a release above its own release candidates', () => {
+    expect(
+      evaluateAppVersionSkew({ clientAppVersion: '1.4.124', serverAppVersion: '1.4.124-rc.1' })
+    ).toMatchObject({ direction: 'server-older' })
+    expect(
+      evaluateAppVersionSkew({ clientAppVersion: '1.4.124-rc.1', serverAppVersion: '1.4.124' })
+    ).toMatchObject({ direction: 'server-newer' })
+  })
+
+  it('orders release candidates numerically', () => {
+    expect(
+      evaluateAppVersionSkew({
+        clientAppVersion: '1.4.124-rc.10',
+        serverAppVersion: '1.4.124-rc.2'
+      })
+    ).toMatchObject({ direction: 'server-older' })
+  })
+
+  it('stays silent when the client version is unknown or unparseable', () => {
+    expect(
+      evaluateAppVersionSkew({ clientAppVersion: null, serverAppVersion: '1.4.146' })
+    ).toBeNull()
+    expect(
+      evaluateAppVersionSkew({ clientAppVersion: 'dev', serverAppVersion: '1.4.146' })
+    ).toBeNull()
+  })
+
+  it('stays silent when the server version is present but unparseable', () => {
+    expect(
+      evaluateAppVersionSkew({ clientAppVersion: '1.4.147', serverAppVersion: 'weird-build' })
+    ).toBeNull()
+  })
+
+  it('ignores build metadata when comparing', () => {
+    expect(
+      evaluateAppVersionSkew({
+        clientAppVersion: '1.4.147+abc123',
+        serverAppVersion: '1.4.147+def456'
+      })
+    ).toBeNull()
+  })
+})
+
+describe('parseAppVersion', () => {
+  it('parses release and prerelease forms', () => {
+    expect(parseAppVersion('1.4.147')).toEqual({ release: [1, 4, 147], prerelease: null })
+    expect(parseAppVersion('1.4.124-rc.1')).toEqual({
+      release: [1, 4, 124],
+      prerelease: ['rc', '1']
+    })
+  })
+
+  it('rejects malformed versions', () => {
+    expect(parseAppVersion('')).toBeNull()
+    expect(parseAppVersion(undefined)).toBeNull()
+    expect(parseAppVersion('1.4')).toBeNull()
+    expect(parseAppVersion('v1.4.147')).toBeNull()
+  })
+})
+
+describe('describeAppVersionSkew', () => {
+  it('tells the user to update the server when it is older', () => {
+    expect(
+      describeAppVersionSkew({
+        direction: 'server-older',
+        clientAppVersion: '1.4.147',
+        serverAppVersion: '1.4.146'
+      })
+    ).toBe(
+      'This Orca server (1.4.146) is older than your app (1.4.147). Update the server, or some features may fail.'
+    )
+  })
+
+  it('handles servers that predate version reporting', () => {
+    expect(
+      describeAppVersionSkew({
+        direction: 'server-older',
+        clientAppVersion: '1.4.147',
+        serverAppVersion: null
+      })
+    ).toBe(
+      'This Orca server is older than your app (1.4.147). Update the server, or some features may fail.'
+    )
+  })
+
+  it('tells the user to update the app when the server is newer', () => {
+    expect(
+      describeAppVersionSkew({
+        direction: 'server-newer',
+        clientAppVersion: '1.4.146',
+        serverAppVersion: '1.4.147'
+      })
+    ).toBe(
+      'This Orca server (1.4.147) is newer than your app (1.4.146). Update this app, or some features may fail.'
+    )
+  })
+})

--- a/src/shared/app-version-skew.ts
+++ b/src/shared/app-version-skew.ts
@@ -1,0 +1,123 @@
+// Why: protocol-version compat (protocol-compat.ts) only blocks truly
+// incompatible pairs. App-version skew between a desktop client and a remote
+// `orca serve` host is still worth a non-blocking warning: a client that
+// auto-updated ahead of its server can hit missing-RPC failures with
+// misleading downstream errors (e.g. "could not launch claude in a new
+// terminal") when the real fix is updating the server.
+
+export type AppVersionSkewDirection = 'server-older' | 'server-newer'
+
+export type AppVersionSkew = {
+  direction: AppVersionSkewDirection
+  clientAppVersion: string
+  /** null when the server predates app-version reporting in status.get. */
+  serverAppVersion: string | null
+}
+
+type ParsedAppVersion = {
+  release: [number, number, number]
+  prerelease: string[] | null
+}
+
+// Why: hand-rolled instead of the semver package so the evaluator stays
+// dependency-free and safe to mirror in the Expo mobile build.
+export function parseAppVersion(version: string | null | undefined): ParsedAppVersion | null {
+  const trimmed = version?.trim()
+  if (!trimmed) {
+    return null
+  }
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(trimmed)
+  if (!match) {
+    return null
+  }
+  return {
+    release: [Number(match[1]), Number(match[2]), Number(match[3])],
+    prerelease: match[4] ? match[4].split('.') : null
+  }
+}
+
+function comparePrereleaseIds(a: string, b: string): number {
+  const aNumeric = /^\d+$/.test(a)
+  const bNumeric = /^\d+$/.test(b)
+  if (aNumeric && bNumeric) {
+    return Number(a) - Number(b)
+  }
+  // Why: semver rule — numeric identifiers sort below alphanumeric ones.
+  if (aNumeric !== bNumeric) {
+    return aNumeric ? -1 : 1
+  }
+  return a < b ? -1 : a > b ? 1 : 0
+}
+
+export function compareAppVersions(a: ParsedAppVersion, b: ParsedAppVersion): number {
+  for (let i = 0; i < 3; i++) {
+    const diff = a.release[i]! - b.release[i]!
+    if (diff !== 0) {
+      return diff
+    }
+  }
+  // Why: a release (no prerelease) outranks any rc of the same triple.
+  if (!a.prerelease && !b.prerelease) {
+    return 0
+  }
+  if (!a.prerelease || !b.prerelease) {
+    return a.prerelease ? -1 : 1
+  }
+  const length = Math.max(a.prerelease.length, b.prerelease.length)
+  for (let i = 0; i < length; i++) {
+    const aId = a.prerelease[i]
+    const bId = b.prerelease[i]
+    if (aId === undefined || bId === undefined) {
+      return aId === undefined ? -1 : 1
+    }
+    const diff = comparePrereleaseIds(aId, bId)
+    if (diff !== 0) {
+      return diff
+    }
+  }
+  return 0
+}
+
+export function evaluateAppVersionSkew(input: {
+  clientAppVersion: string | null | undefined
+  serverAppVersion: string | null | undefined
+}): AppVersionSkew | null {
+  const client = parseAppVersion(input.clientAppVersion)
+  if (!client) {
+    return null
+  }
+  const reportedServerVersion = input.serverAppVersion?.trim()
+  if (!reportedServerVersion) {
+    // Why: every server that reports a live status but no appVersion predates
+    // this feature, so it is provably older than any client evaluating it.
+    return {
+      direction: 'server-older',
+      clientAppVersion: input.clientAppVersion!.trim(),
+      serverAppVersion: null
+    }
+  }
+  const server = parseAppVersion(reportedServerVersion)
+  if (!server) {
+    // Why: a reported-but-unparseable version (custom build) proves nothing
+    // about age, so stay silent rather than mislabeling it as older.
+    return null
+  }
+  const diff = compareAppVersions(server, client)
+  if (diff === 0) {
+    return null
+  }
+  return {
+    direction: diff < 0 ? 'server-older' : 'server-newer',
+    clientAppVersion: input.clientAppVersion!.trim(),
+    serverAppVersion: input.serverAppVersion!.trim()
+  }
+}
+
+export function describeAppVersionSkew(skew: AppVersionSkew): string {
+  if (skew.direction === 'server-older') {
+    return skew.serverAppVersion
+      ? `This Orca server (${skew.serverAppVersion}) is older than your app (${skew.clientAppVersion}). Update the server, or some features may fail.`
+      : `This Orca server is older than your app (${skew.clientAppVersion}). Update the server, or some features may fail.`
+  }
+  return `This Orca server (${skew.serverAppVersion}) is newer than your app (${skew.clientAppVersion}). Update this app, or some features may fail.`
+}

--- a/src/shared/execution-host-registry.test.ts
+++ b/src/shared/execution-host-registry.test.ts
@@ -143,6 +143,44 @@ describe('execution host registry', () => {
     ])
   })
 
+  it('passes non-blocking version skew through to runtime host entries', () => {
+    const status = {
+      runtimeId: 'runtime-builder',
+      rendererGraphEpoch: 1,
+      graphStatus: 'ready' as const,
+      authoritativeWindowId: 1,
+      liveTabCount: 0,
+      liveLeafCount: 0,
+      runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+      minCompatibleRuntimeClientVersion: 1
+    }
+    const versionSkew = {
+      direction: 'server-older' as const,
+      clientAppVersion: '1.4.147',
+      serverAppVersion: '1.4.146'
+    }
+    const hosts = buildExecutionHostRegistry({
+      repos: [],
+      settings: { activeRuntimeEnvironmentId: null },
+      runtimeEnvironments: [
+        { id: 'builder', name: 'Linux Builder' },
+        { id: 'offline', name: 'Offline' }
+      ],
+      runtimeStatusByEnvironmentId: new Map([
+        ['builder', { status, appVersion: '1.4.146', versionSkew }],
+        // Why: skew must not survive an unreachable probe; a stale verdict on a
+        // disconnected host would warn about a server we can no longer see.
+        ['offline', { status: null, versionSkew }]
+      ])
+    })
+
+    expect(hosts).toMatchObject([
+      { id: 'local', health: 'local' },
+      { id: 'runtime:builder', health: 'available', versionSkew },
+      { id: 'runtime:offline', health: 'disconnected', versionSkew: null }
+    ])
+  })
+
   it('uses shared-control diagnostics to show reconnecting runtime host health', () => {
     const hosts = buildExecutionHostRegistry({
       repos: [],

--- a/src/shared/execution-host-registry.ts
+++ b/src/shared/execution-host-registry.ts
@@ -9,6 +9,7 @@ import {
   type ExecutionHostId,
   type ExecutionHostKind
 } from './execution-host'
+import type { AppVersionSkew } from './app-version-skew'
 import { evaluateRuntimeCompat, type RuntimeCompatVerdict } from './protocol-compat'
 import { MIN_COMPATIBLE_RUNTIME_SERVER_VERSION, RUNTIME_PROTOCOL_VERSION } from './protocol-version'
 import type { RuntimeStatus } from './runtime-types'
@@ -32,6 +33,9 @@ export type ExecutionHostRegistryEntry = {
   health: ExecutionHostHealth
   connectionStatus?: SshConnectionStatus
   compatibility?: RuntimeCompatVerdict
+  // Why: non-blocking app-version skew rides alongside the blocking protocol
+  // verdict so host UI can warn without cutting the connection.
+  versionSkew?: AppVersionSkew | null
   capabilities?: readonly string[]
   appVersion?: string | null
   protocolVersion?: number | null
@@ -50,6 +54,7 @@ type RuntimeEnvironmentSummary = {
 type RuntimeHostStatus = {
   status?: RuntimeStatus | null
   appVersion?: string | null
+  versionSkew?: AppVersionSkew | null
 }
 
 type RuntimeStatusByEnvironmentId = ReadonlyMap<string, RuntimeHostStatus>
@@ -163,6 +168,7 @@ function addRuntimeHost(
     detail: 'Orca server',
     health: controlHealth ?? runtimeHealth(status, compatibility),
     compatibility: compatibility ?? undefined,
+    versionSkew: status ? (runtimeStatus?.versionSkew ?? null) : null,
     capabilities: status?.capabilities,
     appVersion: runtimeStatus?.appVersion ?? status?.appVersion ?? null,
     protocolVersion: status?.runtimeProtocolVersion ?? status?.protocolVersion ?? null,

--- a/src/shared/remote-runtime-shared-control-connection.test.ts
+++ b/src/shared/remote-runtime-shared-control-connection.test.ts
@@ -526,6 +526,73 @@ describe('RemoteRuntimeSharedControlConnection', () => {
     connection.close()
   })
 
+  it('detects a dead E2EE session via the session probe when the relay still answers pings', async () => {
+    // Repro of the serve-restart-behind-a-relay bug: a WS-terminating relay
+    // answers protocol pings itself (autoPong stays enabled), so socket-level
+    // liveness sees inbound traffic — but the server process behind it
+    // restarted, its subscription registry is empty, and encrypted requests go
+    // unanswered. Only the session probe can prove the E2EE session is dead.
+    const server = await createServer({ goSilentOnFirstConnectionAfterFirstStreamingResponse: true })
+    const connection = new RemoteRuntimeSharedControlConnection(server.pairing, {
+      sessionProbeIntervalMs: 40,
+      sessionProbeTimeoutMs: 80
+    })
+    const onClose = vi.fn()
+
+    await connection.subscribe('runtime.clientEvents.subscribe', null, 1000, {
+      onResponse: vi.fn(),
+      onError: vi.fn(),
+      onClose
+    })
+
+    await vi.waitFor(() => expect(server.connectionCount()).toBe(2), { timeout: 5000 })
+    await vi.waitFor(
+      () =>
+        expect(
+          server.requests.filter((request) => request.method === 'runtime.clientEvents.subscribe')
+        ).toHaveLength(2),
+      { timeout: 5000 }
+    )
+    expect(onClose).not.toHaveBeenCalled()
+
+    connection.close()
+  })
+
+  it('keeps a responsive connection on one socket while session probes succeed', async () => {
+    const server = await createServer()
+    const connection = new RemoteRuntimeSharedControlConnection(server.pairing, {
+      sessionProbeIntervalMs: 20,
+      sessionProbeTimeoutMs: 500
+    })
+
+    await connection.subscribe('runtime.clientEvents.subscribe', null, 1000, {
+      onResponse: vi.fn(),
+      onError: vi.fn()
+    })
+
+    await vi.waitFor(() =>
+      expect(server.requests.map((request) => request.method)).toContain('status.get')
+    )
+    expect(server.connectionCount()).toBe(1)
+
+    connection.close()
+  })
+
+  it('does not run session probes when no subscriptions are active', async () => {
+    const server = await createServer()
+    const connection = new RemoteRuntimeSharedControlConnection(server.pairing, {
+      sessionProbeIntervalMs: 10,
+      sessionProbeTimeoutMs: 50
+    })
+
+    await connection.request('worktree.ps', undefined, 1000)
+    await new Promise((resolve) => setTimeout(resolve, 60))
+
+    expect(server.requests.map((request) => request.method)).not.toContain('status.get')
+
+    connection.close()
+  })
+
   it('keeps unrelated pending requests alive when one request times out', async () => {
     const server = await createServer({
       silentMethods: ['worktree.hang'],
@@ -663,6 +730,7 @@ async function createServer(
     disableAutoPong?: boolean
     delayedMethods?: string[]
     silentMethods?: string[]
+    goSilentOnFirstConnectionAfterFirstStreamingResponse?: boolean
   } = {}
 ): Promise<TestServer> {
   const serverKeyPair = generateKeyPair()
@@ -675,6 +743,11 @@ async function createServer(
 
   wss.on('connection', (ws) => {
     connectionCount += 1
+    const isFirstConnection = connectionCount === 1
+    // Zombie mode: record requests but never answer and never close, like a
+    // restarted server process behind a relay that holds the socket open and
+    // keeps answering ws pings itself.
+    let goneSilent = false
     let sharedKey: Uint8Array | null = null
     let authenticated = false
     ws.on('message', (data, isBinary) => {
@@ -706,11 +779,23 @@ async function createServer(
         }
         return
       }
+      const request = JSON.parse(plaintext) as { id: string; method: string; params?: unknown }
+      if (goneSilent) {
+        requests.push(request)
+        return
+      }
+      if (
+        options.goSilentOnFirstConnectionAfterFirstStreamingResponse &&
+        isFirstConnection &&
+        isStreamingMethod(request.method)
+      ) {
+        goneSilent = true
+      }
       handleRequest(
         ws,
         sharedKey,
         requests,
-        JSON.parse(plaintext),
+        request,
         {
           ...options,
           closeAfterStreamingResponse: () => {

--- a/src/shared/remote-runtime-shared-control-connection.ts
+++ b/src/shared/remote-runtime-shared-control-connection.ts
@@ -1,4 +1,4 @@
-import WebSocket from 'ws'
+import type WebSocket from 'ws'
 import type { PairingOffer } from './pairing'
 import type { RuntimeRpcResponse } from './runtime-rpc-envelope'
 import type { RemoteRuntimeClientError } from './remote-runtime-client-error'
@@ -8,20 +8,26 @@ import { handleSharedControlTextFrame } from './remote-runtime-shared-control-fr
 import * as sharedControlProtocol from './remote-runtime-shared-control-protocol'
 import {
   isSharedControlReady,
+  isSharedControlSocketGone,
   waitForSharedControlReadyWithTimeout
 } from './remote-runtime-shared-control-ready'
 import { SharedControlReconnectScheduler } from './remote-runtime-shared-control-reconnect'
 import { requestSharedControl } from './remote-runtime-shared-control-requests'
+import {
+  SHARED_CONTROL_SESSION_PROBE_INTERVAL_MS,
+  SHARED_CONTROL_SESSION_PROBE_TIMEOUT_MS,
+  SharedControlSessionProbe
+} from './remote-runtime-shared-control-session-probe'
 import { SharedControlReadyStableResetTimer } from './remote-runtime-shared-control-stability'
 import * as sharedControlState from './remote-runtime-shared-control-state'
 import * as sharedControlSend from './remote-runtime-shared-control-send'
 import { closeSharedControlSocket } from './remote-runtime-shared-control-socket-close'
-import type { RemoteRuntimeSocketLivenessOptions } from './remote-runtime-socket-liveness'
 import * as sharedControlSubscriptions from './remote-runtime-shared-control-subscriptions'
 import { startSharedControlSubscription } from './remote-runtime-shared-control-subscription-start'
 import { SharedControlSocketGeneration } from './remote-runtime-shared-control-socket-generation'
 import type {
   RemoteRuntimeSharedConnectionDiagnostics,
+  RemoteRuntimeSharedControlConnectionOptions,
   RemoteRuntimeSharedSubscription,
   SharedControlConnectionState,
   SharedControlLogicalSubscription,
@@ -37,6 +43,7 @@ export class RemoteRuntimeSharedControlConnection {
   private socketCleanup: (() => void) | null = null
   private readonly reconnect = new SharedControlReconnectScheduler()
   private readonly readyStableReset: SharedControlReadyStableResetTimer
+  private readonly sessionProbe: SharedControlSessionProbe
   private intentionallyClosed = false
   private lastConnectedAt: number | null = null
   private lastClose: { code: number; reason: string } | null = null
@@ -49,15 +56,24 @@ export class RemoteRuntimeSharedControlConnection {
 
   constructor(
     private readonly pairing: PairingOffer,
-    private readonly options: {
-      environmentId?: string
-      reconnectStableResetMs?: number
-      liveness?: RemoteRuntimeSocketLivenessOptions
-    } = {}
+    private readonly options: RemoteRuntimeSharedControlConnectionOptions = {}
   ) {
     this.readyStableReset = new SharedControlReadyStableResetTimer(
       options.reconnectStableResetMs ?? 30_000
     )
+    this.sessionProbe = new SharedControlSessionProbe({
+      intervalMs: options.sessionProbeIntervalMs ?? SHARED_CONTROL_SESSION_PROBE_INTERVAL_MS,
+      timeoutMs: options.sessionProbeTimeoutMs ?? SHARED_CONTROL_SESSION_PROBE_TIMEOUT_MS,
+      isIntentionallyClosed: () => this.intentionallyClosed,
+      hasSubscriptions: () => this.subscriptions.size > 0,
+      isReady: () =>
+        isSharedControlReady({ state: this.state, ws: this.ws, sharedKey: this.sharedKey }),
+      getSocket: () => this.ws,
+      probe: (timeoutMs) => this.request('status.get', undefined, timeoutMs),
+      // Why: the probe verified it is closing the socket it probed, so it always targets the current generation.
+      forceClose: (error) =>
+        this.handleSocketClosed(error, this.socketGeneration.currentGeneration())
+    })
   }
 
   request<TResult>(
@@ -139,11 +155,7 @@ export class RemoteRuntimeSharedControlConnection {
       readyWaiters: this.readyWaiters,
       timeoutMs,
       open: () => {
-        if (
-          !this.ws ||
-          this.ws.readyState === WebSocket.CLOSED ||
-          this.ws.readyState === WebSocket.CLOSING
-        ) {
+        if (isSharedControlSocketGone(this.ws)) {
           this.open()
         }
       }
@@ -206,6 +218,7 @@ export class RemoteRuntimeSharedControlConnection {
       markReady: () => {
         this.lastConnectedAt = Date.now()
         this.scheduleReconnectAttemptReset()
+        this.sessionProbe.schedule()
       },
       replaySubscriptions: () => this.replaySubscriptions()
     })
@@ -303,6 +316,7 @@ export class RemoteRuntimeSharedControlConnection {
       error,
       clearReadyStableTimer: () => this.readyStableReset.clear()
     })
+    this.sessionProbe.clear()
     this.ws = this.sharedKey = null
     this.socketCleanup = null
     this.state = 'closed'

--- a/src/shared/remote-runtime-shared-control-ready.ts
+++ b/src/shared/remote-runtime-shared-control-ready.ts
@@ -15,6 +15,10 @@ export function isSharedControlReady(args: {
   return args.state === 'ready' && args.ws?.readyState === WebSocket.OPEN && !!args.sharedKey
 }
 
+export function isSharedControlSocketGone(ws: WebSocket | null): boolean {
+  return !ws || ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING
+}
+
 export function waitForSharedControlReadyWithTimeout(args: {
   readyWaiters: SharedControlReadyWaiter[]
   timeoutMs: number

--- a/src/shared/remote-runtime-shared-control-session-probe.ts
+++ b/src/shared/remote-runtime-shared-control-session-probe.ts
@@ -73,7 +73,11 @@ export class SharedControlSessionProbe {
     const probedSocket = this.hooks.getSocket()
     try {
       await this.hooks.probe(this.hooks.timeoutMs)
-      this.schedule()
+      // Why: same stale-socket guard as the failure branch — a reconnect that
+      // replaced the socket mid-probe owns the probe schedule for it.
+      if (this.hooks.getSocket() === probedSocket) {
+        this.schedule()
+      }
     } catch (error) {
       // Why: if the socket already changed, a reconnect handled recovery and
       // scheduled its own probe; force-closing here would kill the new socket.

--- a/src/shared/remote-runtime-shared-control-session-probe.ts
+++ b/src/shared/remote-runtime-shared-control-session-probe.ts
@@ -1,0 +1,85 @@
+import type WebSocket from 'ws'
+import type { RemoteRuntimeClientError } from './remote-runtime-client-error'
+import { toRemoteRuntimeClientError } from './remote-runtime-shared-control-protocol'
+
+// Why: the socket-level liveness monitor (remote-runtime-socket-liveness.ts,
+// #7827) pings at the RFC 6455 control-frame layer, but a WS-terminating
+// relay answers those pings itself — so pongs prove only that the relay is
+// reachable. When `orca serve` restarts behind such a relay, the client's
+// E2EE session and the server's in-memory subscription registry are gone
+// while the socket still looks alive, and worktrees created after the
+// restart never reach the sidebar until an app reload. This probe sends an
+// encrypted RPC on a cadence: only the server holding this connection's
+// session keys can answer, so a failed probe proves the session is dead and
+// routes into the existing close → reconnect → replay machinery.
+export const SHARED_CONTROL_SESSION_PROBE_INTERVAL_MS = 15_000
+export const SHARED_CONTROL_SESSION_PROBE_TIMEOUT_MS = 10_000
+
+export type SharedControlSessionProbeHooks = {
+  intervalMs: number
+  timeoutMs: number
+  isIntentionallyClosed: () => boolean
+  hasSubscriptions: () => boolean
+  isReady: () => boolean
+  getSocket: () => WebSocket | null
+  probe: (timeoutMs: number) => Promise<unknown>
+  // Why: routes through the socket-closed path so probe failure reuses the
+  // existing reconnect + subscription-replay machinery.
+  forceClose: (error: RemoteRuntimeClientError) => void
+}
+
+export class SharedControlSessionProbe {
+  private timer: ReturnType<typeof setTimeout> | null = null
+
+  constructor(private readonly hooks: SharedControlSessionProbeHooks) {}
+
+  schedule(): void {
+    this.clear()
+    const timer = setTimeout(() => {
+      this.timer = null
+      void this.runProbe()
+    }, this.hooks.intervalMs)
+    // Why: mobile typechecks shared code with DOM timer types where unref is absent.
+    const unrefable = timer as unknown as { unref?: () => void }
+    if (typeof unrefable.unref === 'function') {
+      unrefable.unref()
+    }
+    this.timer = timer
+  }
+
+  clear(): void {
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+  }
+
+  private async runProbe(): Promise<void> {
+    if (this.hooks.isIntentionallyClosed()) {
+      return
+    }
+    // Why: every path back to ready runs markReady, which restarts probing;
+    // rescheduling here would keep an idle timer loop alive on a dead socket.
+    if (!this.hooks.isReady()) {
+      return
+    }
+    // Why: only subscriptions need silent-staleness detection; one-shot
+    // requests already surface their own failures. Reconnects gate on
+    // subscriptions the same way.
+    if (!this.hooks.hasSubscriptions()) {
+      this.schedule()
+      return
+    }
+    const probedSocket = this.hooks.getSocket()
+    try {
+      await this.hooks.probe(this.hooks.timeoutMs)
+      this.schedule()
+    } catch (error) {
+      // Why: if the socket already changed, a reconnect handled recovery and
+      // scheduled its own probe; force-closing here would kill the new socket.
+      if (this.hooks.getSocket() === probedSocket && !this.hooks.isIntentionallyClosed()) {
+        this.hooks.forceClose(toRemoteRuntimeClientError(error))
+      }
+    }
+  }
+}

--- a/src/shared/remote-runtime-shared-control-socket-generation.ts
+++ b/src/shared/remote-runtime-shared-control-socket-generation.ts
@@ -8,6 +8,10 @@ export class SharedControlSocketGeneration {
     return generation === this.current
   }
 
+  currentGeneration(): number {
+    return this.current
+  }
+
   begin(): number {
     this.current += 1
     return this.current

--- a/src/shared/remote-runtime-shared-control-types.ts
+++ b/src/shared/remote-runtime-shared-control-types.ts
@@ -1,12 +1,21 @@
 import type { RuntimeRpcResponse } from './runtime-rpc-envelope'
 import type { RemoteRuntimeClientError } from './remote-runtime-client-error'
 import type { RemoteRuntimePreparedRequest } from './remote-runtime-prepared-request-admission'
+import type { RemoteRuntimeSocketLivenessOptions } from './remote-runtime-socket-liveness'
 
 export type SharedControlConnectionState =
   | 'closed'
   | 'awaiting_ready'
   | 'awaiting_authenticated'
   | 'ready'
+
+export type RemoteRuntimeSharedControlConnectionOptions = {
+  environmentId?: string
+  reconnectStableResetMs?: number
+  liveness?: RemoteRuntimeSocketLivenessOptions
+  sessionProbeIntervalMs?: number
+  sessionProbeTimeoutMs?: number
+}
 
 export type SharedControlPendingRequest<TResult> = {
   method: string

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -78,8 +78,10 @@ export type RuntimeStatus = {
   runtimeProtocolVersion?: number
   minCompatibleRuntimeClientVersion?: number
   capabilities?: RuntimeCapability[]
-  // Why: optional fields let updated clients inventory both new and legacy paired servers.
-  appVersion?: string
+  // Why: optional fields let updated clients inventory both new and legacy paired
+  // servers. Absence or null means the server predates version reporting and is
+  // treated as older by the skew evaluator.
+  appVersion?: string | null
   remoteUpdateSupport?: RemoteServerUpdateSupport
   remoteControl?: RemoteRuntimeSharedConnectionDiagnostics | null
   hostPlatform?: NodeJS.Platform


### PR DESCRIPTION
## Summary

Two connection-layer fixes for desktop clients paired with a remote `orca serve` host, both hit in the field on 2026-07-20 with a headless server on v1.4.146 and a desktop client that had auto-updated to v1.4.147:

**1. App-version skew is now detected and surfaced instead of failing downstream with misleading errors.**

The runtime WS connect path exchanged no app version at all: the E2EE handshake (`e2ee_hello`/`e2ee_auth`) carries none, and `status.get` only carried the protocol number, which hard-blocks solely on true protocol incompatibility. A client running ahead of its server (desktop auto-update raced the server's twice-daily update) failed with errors like "could not launch claude in a new terminal", with no hint that the real cause was version skew. Now:

- `status.get` includes the server's `appVersion`, and the client evaluates a non-blocking skew verdict against its own version in the new dependency-free `src/shared/app-version-skew.ts` (semver-style compare including `-rc.N` prereleases; a live server that reports no `appVersion` provably predates this feature and is treated as older; unparseable versions stay silent).
- A proactive bottom-right warning toast (skill-freshness-nudge pattern) announces the skew with a "Manage server" action — one per environment per version pair per session, retracted when a reachable probe reports matching versions. This is the surface that reaches users in the default Projects view, where host section headers don't render.
- The sidebar host header shows an amber "Server outdated" / "App outdated" detail plus a caution icon, and the host menu gets an amber "Server update recommended" / "App update recommended" item whose tooltip spells it out: *"This Orca server (1.4.146) is older than your app (1.4.147). Update the server, or some features may fail."* Both skew directions are flagged.
- The connection is never blocked on app-version skew alone; the existing protocol-incompatibility hard block is unchanged and takes precedence in the UI.

**2. Stale worktree subscriptions after a serve restart behind a WS-terminating relay are now self-healing.**

Same day, second report: the serve process restarted (auto-update) while a client stayed connected via a relay. The client's worktree-graph subscription lives in the server's in-memory registry, which died with the old process; worktrees created after the restart never appeared in the client sidebar until a manual app reload — *even though both builds already contained the #7827 socket-liveness monitor* (merged 2026-07-08, i.e. before this incident). That monitor pings at the RFC 6455 control-frame layer and declares death on inbound silence — but a WS-terminating relay answers protocol pings itself, so pongs prove only that the *relay* is reachable, not that the E2EE session behind it is alive. Fix: a session-level probe on the shared-control connection (`SharedControlSessionProbe`) sends an encrypted `status.get` every 15s while subscriptions are active (10s timeout). Only the server holding the connection's session keys can answer, so a relay can't fake it; a failed probe force-closes the socket and reuses the existing reconnect + replay(+tag) machinery from #7827/#7718 unchanged. This complements — not replaces — the socket-level monitor: that one is cheaper and catches half-open TCP; the session probe catches "transport up, session dead".

The `src/relay/` SSH path is untouched — it already has its own wire-level version handshake (`relay-handshake.ts`).

## Screenshots

In the PR comments: captured end-to-end from a real `orca serve` at app version 1.4.100 paired to a 1.4.147-rc.4 client over the production WS/E2EE path — toast, sidebar host header, and host menu.

## Testing

- [x] `pnpm lint` — passes except two pre-existing `switch-exhaustiveness` errors (`skill-freshness-group.tsx`, `daemon-server.ts`) that reproduce identically on pristine `upstream/main` with no working-tree changes; not introduced by this PR.
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

New/updated tests:
- `src/renderer/src/components/sidebar/runtime-version-skew-nudge-plan.test.ts` — toast cadence: new skew shows, same version pair never re-nags within a session, changed pair re-notifies, resolution clears only on a reachable matching probe (unreachable blips don't reset dedupe), multi-environment independence.
- `src/shared/remote-runtime-shared-control-connection.test.ts` — repro of the field bug: server answers the first subscription, then goes silent **with autoPong still enabled** (relay answering pings), asserting the session probe force-reconnects and replays the subscription with no consumer-visible close. Also: probes keep a healthy connection on one socket; no probing while only one-shot requests are active.
- `src/shared/app-version-skew.test.ts` — match/older/newer, missing server version, rc ordering (`rc.10` > `rc.2`), release-vs-rc, unparseable versions stay silent, build metadata ignored.
- `src/shared/execution-host-registry.test.ts` — skew passes through to runtime host entries; a stale skew verdict is dropped when a probe records the server unreachable.
- `src/renderer/src/components/sidebar/host-header-menu-items.test.ts` — skew surfaces for usable hosts; a blocking verdict wins over skew.

## AI Review Report

Reviewed by Claude Code (agent-driven end to end). Checks performed:

- **Cross-platform (macOS/Linux/Windows):** no platform-specific code paths added; timers use `unref()` guarded for DOM typings (mobile mirrors shared code), no path/shortcut/shell handling touched.
- **SSH/remote vs local:** changes affect only the remote runtime environment path; the SSH relay (`src/relay/`, which has its own version handshake) and local execution are untouched. Skew is only evaluated for reachable remote runtime statuses, never for local/SSH hosts.
- **Rebase-interaction risk (main moves fast):** rebased onto current `upstream/main`; the session probe was deliberately re-layered on top of #7827's socket-liveness + replay-tagging machinery rather than duplicating it, and reuses its close→reconnect→replay path unchanged.
- **Behavioral risks reviewed:** probe-vs-reconnect races (probe failure only force-closes if the socket is unchanged since the probe started); idle-timer leaks (probe never reschedules on a non-ready connection — `markReady` restarts it); old servers (missing `appVersion` treated as older by construction — any server without this code predates it); old clients (ignore the new optional field); noise control (skew warning is non-blocking amber, never toasts, and is dropped when the host is unreachable or blocked).
- **Performance:** one small encrypted RPC per 15s per environment with active subscriptions (server already pings every client at the same cadence); skew evaluation is O(1) at status ingestion; no hot-path work added.
- **UI quality:** amber caution tier per existing sidebar precedent (`text-amber-*`), destructive red reserved for blocking states; tooltips/menu per existing host-header patterns; localization catalog synced for all five locales.
- **Git-provider/agent neutrality:** not applicable — no provider- or agent-specific surfaces touched.

## Security Audit

- **Input handling:** `appVersion` is parsed with a strict anchored regex (`parseAppVersion`); unparseable/hostile strings yield no verdict and are never interpolated into anything but a UI string. No `eval`/dynamic code.
- **Command execution / path handling:** none added.
- **Auth/secrets:** the session probe runs inside the existing authenticated E2EE channel using the already-held device token; no new auth surface, no token logging. The probe cannot be answered by an unauthenticated middlebox — that is its purpose.
- **DoS considerations:** probe cadence is fixed (15s) and gated on active subscriptions; a malicious server ignoring probes only causes the client to close its own socket and back off via the existing bounded reconnect schedule.
- **Dependencies:** none added (version compare is hand-rolled to stay dependency-free, matching `protocol-compat.ts`'s pattern).
- **IPC:** no new IPC channels; renderer reads its own version via the existing `updater:getVersion` handler.

## Notes

- A server predating this change reports no `appVersion`; clients with this change show "Server outdated" for it (correct by construction), with a version-less tooltip message.
- The CLI runtime client has no version source of its own today, so it keeps its protocol-only gate; adding an app-version warning there is a possible follow-up.
- The two `lint:switch-exhaustiveness` failures noted above reproduce byte-identically on pristine `upstream/main` (`skill-freshness-group.tsx:101`, `daemon-server.ts:652`) — pre-existing, and worth a separate fix.
