### PR TITLE
perf(status-bar): guard usage-notice anchor against equal-geometry re-render churn

### DIFF
--- a/src/renderer/src/components/status-bar/UsagePercentageDisplayChangeNotice.test.tsx
+++ b/src/renderer/src/components/status-bar/UsagePercentageDisplayChangeNotice.test.tsx
@@ -1,10 +1,23 @@
 // @vitest-environment happy-dom
 
-import { act } from 'react'
+import { act, Profiler } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { UsagePercentageDisplayChangeNotice } from './UsagePercentageDisplayChangeNotice'
 import { USAGE_PERCENTAGE_DISPLAY_SETTING_ID } from '../settings/appearance-usage-percentage-search'
+
+// Controllable ResizeObserver so tests can drive reflow deliveries by hand.
+type ResizeObserverStub = { cb: ResizeObserverCallback; targets: Element[] }
+const resizeObservers: ResizeObserverStub[] = []
+
+function fireResizeObservers(): void {
+  for (const observer of resizeObservers) {
+    if (observer.targets.length === 0) {
+      continue
+    }
+    observer.cb([] as unknown as ResizeObserverEntry[], observer as unknown as ResizeObserver)
+  }
+}
 
 const storeState = {
   persistedUIReady: true,
@@ -31,6 +44,22 @@ describe('UsagePercentageDisplayChangeNotice', () => {
 
   beforeEach(() => {
     vi.useFakeTimers()
+    resizeObservers.length = 0
+    ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+      cb: ResizeObserverCallback
+      targets: Element[] = []
+      constructor(cb: ResizeObserverCallback) {
+        this.cb = cb
+        resizeObservers.push({ cb, targets: this.targets })
+      }
+      observe(el: Element): void {
+        this.targets.push(el)
+      }
+      unobserve(): void {}
+      disconnect(): void {
+        this.targets.length = 0
+      }
+    }
     storeState.persistedUIReady = true
     storeState.usagePercentageDisplayChangeNoticeDismissed = false
     storeState.statusBarVisible = true
@@ -207,6 +236,40 @@ describe('UsagePercentageDisplayChangeNotice', () => {
       window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
     })
     expect(storeState.dismissUsagePercentageDisplayChangeNotice).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not re-render on ResizeObserver deliveries with unchanged geometry', () => {
+    let commits = 0
+    act(() => {
+      root.render(
+        <Profiler
+          id="notice"
+          onRender={() => {
+            commits++
+          }}
+        >
+          <UsagePercentageDisplayChangeNotice hasVisibleUsageMeters>
+            <span>usage-meters</span>
+          </UsagePercentageDisplayChangeNotice>
+        </Profiler>
+      )
+    })
+    act(() => {
+      vi.advanceTimersByTime(1_800)
+    })
+    expect(document.querySelector('.status-bar-change-notice-card')).not.toBeNull()
+    const commitsAfterOpen = commits
+
+    for (let i = 0; i < 20; i++) {
+      act(() => {
+        fireResizeObservers()
+      })
+    }
+    // Why: without the equality guard every identical-geometry delivery churns a
+    // fresh AnchorPosition object → one re-render each (measured 20). The guard
+    // returns the same reference so React bails on all but the first settling
+    // commit → ≤1 (measured 1). This is the churn the fix removes.
+    expect(commits - commitsAfterOpen).toBeLessThanOrEqual(1)
   })
 
   function openNotice(): void {

--- a/src/renderer/src/components/status-bar/UsagePercentageDisplayChangeNotice.tsx
+++ b/src/renderer/src/components/status-bar/UsagePercentageDisplayChangeNotice.tsx
@@ -100,7 +100,13 @@ export function UsagePercentageDisplayChangeNotice({
     }
 
     const update = (): void => {
-      setAnchorPosition(measureAnchorPosition(anchor))
+      const next = measureAnchorPosition(anchor)
+      // Why: ResizeObserver/resize fire on every reflow, but measureAnchorPosition
+      // returns a fresh object each time; bail on unchanged geometry so equal
+      // deliveries don't churn re-renders (avoids feeding a layout-effect loop).
+      setAnchorPosition((prev) =>
+        prev && prev.bottom === next.bottom && prev.left === next.left ? prev : next
+      )
     }
     update()
 


### PR DESCRIPTION
## What & why

The status-bar **"Usage now shows % used"** callout (`UsagePercentageDisplayChangeNotice`) positions a `position: fixed` card above the usage meters. It re-measures its anchor on **every** `ResizeObserver` / window-`resize` delivery and calls `setAnchorPosition(measureAnchorPosition(anchor))` — a **new object every time**. Because the object identity changes, React re-rendered on every delivery **even when the geometry was identical** (the common case: meters reflow, agent-status ticks, background repaints).

This PR guards `setAnchorPosition` with a functional updater that returns the **previous reference** when `bottom`/`left` are unchanged, so React short-circuits before commit.

> ⚠️ **Scope honesty:** this is defensive **robustness/perf hardening**, *not* a proven crash fix. It surfaced while investigating crash **`f75ed81b`** (React #185 "Maximum update depth exceeded" in `overlay.status-bar`, still occurring *after* the react/radix bump in #8679). We reproduced enough to prove the notice component is **not** the root cause — the actual #185 loop lives inside **radix Popper's** layout effect and does **not** reproduce under unit/happy-dom. This PR removes one re-render-churn source feeding that subtree; it does not claim to close `f75ed81b`.

## CLEAR, undeniable fix evidence

Unit test counts commits (React `Profiler.onRender`) across **20 identical-geometry `ResizeObserver` deliveries**:

| | extra commits over 20 deliveries |
|---|---|
| **Without** the guard | **20** (one re-render per delivery) |
| **With** the guard | **1** (single post-open settling commit; deliveries 2–20 all bail) |

- Reverting only the source guard makes the new test **fail** (`expected 20 to be less than or equal to 1`); with the guard it **passes**. Verified independently by a second reviewer via `git stash`.
- Full file suite: **9/9 passing**. `oxlint` + `oxfmt` clean (pre-commit).

```
$ npx vitest run --config config/vitest.config.ts .../UsagePercentageDisplayChangeNotice.test.tsx
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

## ELI5

A little pop-up above your usage bars asks the window "where are you?" many times a second so it can float in the right spot. Every time it asked, it wrote down a **brand-new sticky note** with the answer — and React treats a new sticky note as "something changed!" and repaints, **even when the answer was the exact same spot**. Now the pop-up checks first: "same spot as last time? then keep the old sticky note" — so React stops repainting for no reason. 20 needless repaints → 1.

## Trade-offs / regressions

- **None user-facing.** Pure referential-equality optimization. When geometry genuinely changes, the returned value is identical to the old code path, so the card still repositions on window resize, status-bar compact toggle, and anchor moves (verified: `bottom` folds `window.innerHeight`, `left` folds `window.innerWidth`; any real move changes one and returns the fresh value). Initial placement is unchanged (`prev` is `null` → returns the new value).
- Tiny per-delivery closure allocation, which **buys** an avoided re-render — net win. Perf review confirmed `useLayoutEffect` is the correct home (fixed positioning must measure synchronously pre-paint; rAF would flicker).

## Adversarial review + perf

- **Adversarial review loop: 2 loops → CLEAN.** Each loop a fresh sub-agent.
  - *Loop 1* returned "CLEAN" but asserted the guard yields "exactly 0" extra commits. Empirically that was **wrong** (it's exactly 1). Caught it, corrected the test assertion to the honest `≤1` bound and the comment to "measured 20 → measured 1".
  - *Loop 2* independently verified via `git stash` (20 without / 1 with), confirmed no stale-position risk (compared fields are an exact superset of render inputs), no leftover debug code, AGENTS.md-compliant → **CLEAN**.
- **Perf review (`/perf` skill, sub-agent): PASS.** Smallest behavior-preserving fix; correct measurement (Profiler commit count); no remaining waste worth acting on; no new perf risk.
