### PR TITLE
fix(rate-limits): unstick Claude "Limited" usage — respect Retry-After and feed live usage from session statuslines

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -13,6 +13,7 @@
     "../src/main/antigravity/hook-service.ts",
     "../src/main/claude/hook-settings.ts",
     "../src/main/claude/hook-service.ts",
+    "../src/main/claude/statusline-script.ts",
     "../src/main/codex/codex-app-server-capability-cache.ts",
     "../src/main/codex/codex-app-server-capability-signal.ts",
     "../src/main/codex/codex-app-server-client.ts",

--- a/src/main/agent-hooks/hook-stdin-contract.ts
+++ b/src/main/agent-hooks/hook-stdin-contract.ts
@@ -13,7 +13,10 @@ export function buildPosixHookPayloadCapture(
 }
 
 export const WINDOWS_HOOK_STDIN_DRAIN_LABEL = 'orca_agent_hook_drain_stdin'
-export const WINDOWS_HOOK_STDIN_DRAIN_COMMAND = '"%SystemRoot%\\System32\\more.com" >nul 2>nul'
+// Why: qualify the stdin reader because Windows searches the worktree for
+// executables before PATH and hook payloads must not reach repo-local code.
+export const WINDOWS_HOOK_STDIN_READER = '"%SystemRoot%\\System32\\more.com"'
+export const WINDOWS_HOOK_STDIN_DRAIN_COMMAND = `${WINDOWS_HOOK_STDIN_READER} >nul 2>nul`
 
 // Why: batch payloads stream directly to curl and cannot be buffered safely in
 // environment variables, so guard failures share one EOF-draining epilogue.
@@ -27,11 +30,5 @@ export function buildWindowsHookEnvironmentGuardLines(): string[] {
 }
 
 export function buildWindowsHookStdinDrainEpilogue(): string[] {
-  return [
-    `:${WINDOWS_HOOK_STDIN_DRAIN_LABEL}`,
-    // Why: qualify the inbox reader because Windows searches the worktree for
-    // executables before PATH and hook payloads must not reach repo-local code.
-    WINDOWS_HOOK_STDIN_DRAIN_COMMAND,
-    'exit /b 0'
-  ]
+  return [`:${WINDOWS_HOOK_STDIN_DRAIN_LABEL}`, WINDOWS_HOOK_STDIN_DRAIN_COMMAND, 'exit /b 0']
 }

--- a/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
+++ b/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
@@ -207,8 +207,11 @@ async function generatePosixScripts(): Promise<Map<string, string>> {
     const generated = [...memory.fs.files.entries()].filter(
       ([path]) => path.includes('/.orca/agent-hooks/') && path.endsWith('.sh')
     )
-    expect(generated, `${entry.agent} generated scripts`).toHaveLength(1)
-    scripts.set(entry.agent, generated[0][1])
+    // Why: Claude ships a second managed script (the statusline usage feed); the stdin lifecycle contract applies to every generated script.
+    expect(generated.length, `${entry.agent} generated scripts`).toBeGreaterThan(0)
+    for (const [path, script] of generated) {
+      scripts.set(`${entry.agent} ${path.split('/').pop()}`, script)
+    }
   }
   return scripts
 }
@@ -377,14 +380,13 @@ describe.skipIf(process.platform === 'win32')('managed hook stdin lifecycle', ()
   it('accepts a large payload without Orca environment or a broken writer', async () => {
     const scripts = await generatePosixScripts()
     for (const [agent, script] of scripts) {
-      const extraEnv =
-        agent === 'command-code'
-          ? {
-              ORCA_AGENT_HOOK_PORT: '1',
-              ORCA_AGENT_HOOK_TOKEN: 'test-token',
-              ORCA_PANE_KEY: 'test-pane'
-            }
-          : {}
+      const extraEnv = agent.startsWith('command-code')
+        ? {
+            ORCA_AGENT_HOOK_PORT: '1',
+            ORCA_AGENT_HOOK_TOKEN: 'test-token',
+            ORCA_PANE_KEY: 'test-pane'
+          }
+        : {}
       const result = await runPosixHook(script, extraEnv)
       expect(result.exitCode, `${agent} exit code`).toBe(0)
       expect(result.stdinErrors, `${agent} stdin errors`).toHaveLength(0)
@@ -392,7 +394,7 @@ describe.skipIf(process.platform === 'win32')('managed hook stdin lifecycle', ()
   })
 
   it('drains before Claude skips hooks imported by Devin', async () => {
-    const script = (await generatePosixScripts()).get('claude')
+    const script = (await generatePosixScripts()).get('claude claude-hook.sh')
     expect(script).toBeDefined()
     const result = await runPosixHook(script!, { DEVIN_PROJECT_DIR: '/tmp/devin-project' })
     expect(result.exitCode).toBe(0)

--- a/src/main/agent-hooks/managed-hook-timeout.test.ts
+++ b/src/main/agent-hooks/managed-hook-timeout.test.ts
@@ -112,6 +112,8 @@ const JSON_INSTALLERS = [
 ] as const
 
 const MANAGED_HOOKS_DIR_NEEDLE = '/.orca/agent-hooks/'
+// Why: statusLine is not a hook — Claude's schema has no timeout field (type/command/padding/refreshInterval), and a slow statusline can't block agent turns.
+const STATUSLINE_SCRIPT_NEEDLE = '-statusline.'
 
 // Walk the parsed config and assert every Orca-managed command carrier (a node
 // with a `command`/`bash`/`powershell` string pointing at the managed script
@@ -121,8 +123,13 @@ const MANAGED_HOOKS_DIR_NEEDLE = '/.orca/agent-hooks/'
 function countManagedCarriersWithTimeout(
   node: unknown,
   expectedTimeout: number,
-  isManagedCarrier = (value: string): boolean =>
-    value.replaceAll('\\', '/').includes(MANAGED_HOOKS_DIR_NEEDLE)
+  isManagedCarrier = (value: string): boolean => {
+    const normalized = value.replaceAll('\\', '/')
+    return (
+      normalized.includes(MANAGED_HOOKS_DIR_NEEDLE) &&
+      !normalized.includes(STATUSLINE_SCRIPT_NEEDLE)
+    )
+  }
 ): number {
   if (Array.isArray(node)) {
     return node.reduce<number>(

--- a/src/main/agent-hooks/server-claude-statusline.test.ts
+++ b/src/main/agent-hooks/server-claude-statusline.test.ts
@@ -1,0 +1,77 @@
+// Why: locks the /statusline/claude loopback contract — form-encoded posts from the
+// managed statusline script must reach the listener, and junk must fail open (204).
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { AgentHookServer } from './server'
+import type { ClaudeStatusLineRateLimits } from '../../shared/claude-statusline-rate-limits'
+
+describe('AgentHookServer /statusline/claude', () => {
+  let server: AgentHookServer
+
+  beforeEach(async () => {
+    server = new AgentHookServer()
+    await server.start({ env: 'production' })
+  })
+
+  afterEach(() => {
+    server.stop()
+  })
+
+  function post(body: string, token?: string): Promise<Response> {
+    const env = server.buildPtyEnv()
+    return fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/statusline/claude`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'X-Orca-Agent-Hook-Token': token ?? env.ORCA_AGENT_HOOK_TOKEN
+      },
+      body
+    })
+  }
+
+  it('forwards parsed rate limits to the statusline listener', async () => {
+    const events: ClaudeStatusLineRateLimits[] = []
+    server.setClaudeStatusLineListener((event) => {
+      events.push(event)
+    })
+
+    const payload = JSON.stringify({
+      rate_limits: {
+        five_hour: { used_percentage: 12.5, resets_at: 1738425600 },
+        seven_day: { used_percentage: 40, resets_at: 1712059200 }
+      }
+    })
+    const body = new URLSearchParams({
+      paneKey: 'pane-1',
+      configDir: '/home/dev/managed',
+      payload
+    }).toString()
+
+    await expect(post(body)).resolves.toMatchObject({ status: 204 })
+    expect(events).toEqual([
+      {
+        configDir: '/home/dev/managed',
+        fiveHour: { used_percentage: 12.5, resets_at: 1738425600 },
+        sevenDay: { used_percentage: 40, resets_at: 1712059200 }
+      }
+    ])
+  })
+
+  it('rejects posts with a bad token and ignores payloads without rate limits', async () => {
+    const events: ClaudeStatusLineRateLimits[] = []
+    server.setClaudeStatusLineListener((event) => {
+      events.push(event)
+    })
+
+    await expect(post('payload={}', 'wrong-token')).resolves.toMatchObject({ status: 403 })
+
+    const noLimits = new URLSearchParams({
+      paneKey: 'pane-1',
+      payload: JSON.stringify({ context_window: { used_percentage: 8 } })
+    }).toString()
+    await expect(post(noLimits)).resolves.toMatchObject({ status: 204 })
+
+    await expect(post('payload=not-json')).resolves.toMatchObject({ status: 204 })
+
+    expect(events).toEqual([])
+  })
+})

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -33,6 +33,11 @@ import {
 } from '../../shared/agent-hook-listener'
 import type { AgentHookSource } from '../../shared/agent-hook-relay'
 import {
+  CLAUDE_STATUSLINE_PATHNAME,
+  parseClaudeStatusLineBody,
+  type ClaudeStatusLineRateLimits
+} from '../../shared/claude-statusline-rate-limits'
+import {
   AGENT_STATUS_STALE_AFTER_MS,
   type AgentStatusClearIpcPayload,
   type AgentStatusIpcPayload,
@@ -445,6 +450,7 @@ export class AgentHookServer {
   // Why: identifies this Orca instance so the server can detect dev vs. prod cross-talk; set at start() from packaged-build knowledge.
   private env = 'production'
   private onAgentStatus: ((payload: EnrichedAgentHookEventPayload) => void) | null = null
+  private onClaudeStatusLine: ((event: ClaudeStatusLineRateLimits) => void) | null = null
   private onPaneStatusCleared: PaneStatusClearListener | null = null
   private statusChangeListeners = new Set<StatusChangeListener>()
   // Why: set via start()'s userDataPath so the class has no direct Electron dependency (mockable in vitest node env).
@@ -484,6 +490,13 @@ export class AgentHookServer {
         console.error('[agent-hooks] replay listener threw', err)
       }
     }
+  }
+
+  // Why: statusline posts carry live Claude usage windows, not agent status; they feed RateLimitService directly.
+  setClaudeStatusLineListener(
+    listener: ((event: ClaudeStatusLineRateLimits) => void) | null
+  ): void {
+    this.onClaudeStatusLine = listener
   }
 
   subscribeStatusChanges(listener: StatusChangeListener): () => void {
@@ -1472,6 +1485,15 @@ export class AgentHookServer {
       try {
         const body = await readRequestBody(req)
         const pathname = new URL(req.url ?? '/', 'http://127.0.0.1').pathname
+        if (pathname === CLAUDE_STATUSLINE_PATHNAME) {
+          const statusLineEvent = parseClaudeStatusLineBody(body)
+          if (statusLineEvent) {
+            this.onClaudeStatusLine?.(statusLineEvent)
+          }
+          res.writeHead(204)
+          res.end()
+          return
+        }
         const source = resolveHookSource(pathname)
         if (!source) {
           res.writeHead(404)

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -201,10 +201,13 @@ describe('ClaudeHookService.install', () => {
         'utf-8'
       )
       expect(script).toContain('/statusline/claude')
-      expect(script).toContain('--data-urlencode "payload@-"')
-      if (process.platform !== 'win32') {
-        // Why: non-subscriber sessions never carry rate_limits; the script must exit before spawning curl.
+      // Why: non-subscriber sessions never carry rate_limits; both branches must guard before spawning curl.
+      if (process.platform === 'win32') {
+        expect(script).toContain('findstr.exe" /c:\\"rate_limits\\"')
+        expect(script).toContain('--data-urlencode "payload@%ORCA_STATUSLINE_PAYLOAD_FILE%"')
+      } else {
         expect(script).toContain('"rate_limits"')
+        expect(script).toContain('--data-urlencode "payload@-"')
       }
     } finally {
       vi.unstubAllEnvs()
@@ -254,6 +257,50 @@ describe('ClaudeHookService.install', () => {
       new ClaudeHookService().remove()
       const settings = JSON.parse(readFileSync(join(tmpHome, '.claude', 'settings.json'), 'utf-8'))
       expect(settings.statusLine).toBeUndefined()
+    } finally {
+      vi.unstubAllEnvs()
+      rmSync(tmpHome, { recursive: true, force: true })
+    }
+  })
+
+  it('does not re-install a managed statusLine the user deleted, until remove() resets the opt-out', () => {
+    const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-statusline-optout-'))
+    vi.stubEnv('HOME', tmpHome)
+    vi.stubEnv('USERPROFILE', tmpHome)
+    try {
+      const settingsPath = join(tmpHome, '.claude', 'settings.json')
+      new ClaudeHookService().install()
+      expect(JSON.parse(readFileSync(settingsPath, 'utf-8')).statusLine).toBeTruthy()
+
+      // The user deletes the managed statusLine from settings.json (e.g. via /statusline or an editor).
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+      delete settings.statusLine
+      writeFileSync(settingsPath, JSON.stringify(settings))
+
+      // A later install (app restart) must respect the deletion — statusLine is opportunistic, not required.
+      new ClaudeHookService().install()
+      expect(JSON.parse(readFileSync(settingsPath, 'utf-8')).statusLine).toBeUndefined()
+
+      // An Orca-level remove() resets the opt-out memory, so a fresh install re-adds it.
+      new ClaudeHookService().remove()
+      new ClaudeHookService().install()
+      expect(JSON.parse(readFileSync(settingsPath, 'utf-8')).statusLine).toBeTruthy()
+    } finally {
+      vi.unstubAllEnvs()
+      rmSync(tmpHome, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps refreshing a still-managed statusLine across installs', () => {
+    const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-statusline-refresh-'))
+    vi.stubEnv('HOME', tmpHome)
+    vi.stubEnv('USERPROFILE', tmpHome)
+    try {
+      const settingsPath = join(tmpHome, '.claude', 'settings.json')
+      new ClaudeHookService().install()
+      new ClaudeHookService().install()
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+      expect(settings.statusLine?.command).toContain('claude-statusline')
     } finally {
       vi.unstubAllEnvs()
       rmSync(tmpHome, { recursive: true, force: true })
@@ -358,12 +405,10 @@ describe('ClaudeHookService.installRemote', () => {
     expect(script).toContain('--data-urlencode "payload@-"')
     expect(script).not.toContain('--data-urlencode "payload=${payload}"')
     expect(fs.modes.get('/home/dev/.orca/agent-hooks/claude-hook.sh')).toBe(0o755)
-    // Managed statusLine (POSIX on remotes regardless of the local OS)
-    expect(parsed.statusLine.type).toBe('command')
-    expect(parsed.statusLine.command).toContain('/home/dev/.orca/agent-hooks/claude-statusline.sh')
-    const statusLineScript = fs.files.get('/home/dev/.orca/agent-hooks/claude-statusline.sh')
-    expect(statusLineScript).toContain('/statusline/claude')
-    expect(statusLineScript).toContain('"rate_limits"')
+    // Why: no remote statusLine — this path serves SSH remotes and WSL guests, whose relay
+    // listener doesn't route /statusline/claude and whose accounts aren't attributable locally.
+    expect(parsed.statusLine).toBeUndefined()
+    expect(fs.files.get('/home/dev/.orca/agent-hooks/claude-statusline.sh')).toBeUndefined()
   })
 
   it('reports parse error when remote settings.json cannot be parsed', async () => {

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -20,6 +20,8 @@ import { ClaudeHookService } from './hook-service'
 import { OPENCLAUDE_HOOK_SETTINGS } from './hook-settings'
 
 const CLAUDE_SCRIPT_FILE_NAME = process.platform === 'win32' ? 'claude-hook.cmd' : 'claude-hook.sh'
+const STATUSLINE_SCRIPT_FILE_NAME =
+  process.platform === 'win32' ? 'claude-statusline.cmd' : 'claude-statusline.sh'
 const OPENCLAUDE_SCRIPT_FILE_NAME =
   process.platform === 'win32' ? 'openclaude-hook.cmd' : 'openclaude-hook.sh'
 const WINDOWS_POWERSHELL_LAUNCHER =
@@ -181,6 +183,83 @@ describe('ClaudeHookService.install', () => {
     }
   })
 
+  it('installs the managed statusLine command and forwards rate_limits posts', () => {
+    const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-statusline-'))
+    vi.stubEnv('HOME', tmpHome)
+    vi.stubEnv('USERPROFILE', tmpHome)
+    try {
+      expect(new ClaudeHookService().install().state).toBe('installed')
+
+      const settings = JSON.parse(
+        readFileSync(join(tmpHome, '.claude', 'settings.json'), 'utf-8')
+      ) as { statusLine?: { type: string; command: string } }
+      expect(settings.statusLine?.type).toBe('command')
+      expect(settings.statusLine?.command).toContain('claude-statusline')
+
+      const script = readFileSync(
+        join(tmpHome, '.orca', 'agent-hooks', STATUSLINE_SCRIPT_FILE_NAME),
+        'utf-8'
+      )
+      expect(script).toContain('/statusline/claude')
+      expect(script).toContain('--data-urlencode "payload@-"')
+      if (process.platform !== 'win32') {
+        // Why: non-subscriber sessions never carry rate_limits; the script must exit before spawning curl.
+        expect(script).toContain('"rate_limits"')
+      }
+    } finally {
+      vi.unstubAllEnvs()
+      rmSync(tmpHome, { recursive: true, force: true })
+    }
+  })
+
+  it('never overwrites a user-owned statusLine command', () => {
+    const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-user-statusline-'))
+    vi.stubEnv('HOME', tmpHome)
+    vi.stubEnv('USERPROFILE', tmpHome)
+    try {
+      const settingsPath = join(tmpHome, '.claude', 'settings.json')
+      mkdirSync(join(tmpHome, '.claude'), { recursive: true })
+      writeFileSync(
+        settingsPath,
+        JSON.stringify({ statusLine: { type: 'command', command: '/usr/local/bin/my-statusline' } })
+      )
+
+      expect(new ClaudeHookService().install().state).toBe('installed')
+
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+      expect(settings.statusLine).toEqual({
+        type: 'command',
+        command: '/usr/local/bin/my-statusline'
+      })
+
+      // remove() must also leave the user's statusLine untouched.
+      new ClaudeHookService().remove()
+      const afterRemove = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+      expect(afterRemove.statusLine).toEqual({
+        type: 'command',
+        command: '/usr/local/bin/my-statusline'
+      })
+    } finally {
+      vi.unstubAllEnvs()
+      rmSync(tmpHome, { recursive: true, force: true })
+    }
+  })
+
+  it('removes the managed statusLine on remove()', () => {
+    const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-statusline-remove-'))
+    vi.stubEnv('HOME', tmpHome)
+    vi.stubEnv('USERPROFILE', tmpHome)
+    try {
+      new ClaudeHookService().install()
+      new ClaudeHookService().remove()
+      const settings = JSON.parse(readFileSync(join(tmpHome, '.claude', 'settings.json'), 'utf-8'))
+      expect(settings.statusLine).toBeUndefined()
+    } finally {
+      vi.unstubAllEnvs()
+      rmSync(tmpHome, { recursive: true, force: true })
+    }
+  })
+
   // Why: #6078 — Claude Code runs hooks through Git Bash, and an unquoted path
   // with a space (e.g. `C:/Users/Jane Doe`) splits at the space. The managed
   // command must use an encoded launcher so Git Bash/cmd.exe never splits or
@@ -279,6 +358,12 @@ describe('ClaudeHookService.installRemote', () => {
     expect(script).toContain('--data-urlencode "payload@-"')
     expect(script).not.toContain('--data-urlencode "payload=${payload}"')
     expect(fs.modes.get('/home/dev/.orca/agent-hooks/claude-hook.sh')).toBe(0o755)
+    // Managed statusLine (POSIX on remotes regardless of the local OS)
+    expect(parsed.statusLine.type).toBe('command')
+    expect(parsed.statusLine.command).toContain('/home/dev/.orca/agent-hooks/claude-statusline.sh')
+    const statusLineScript = fs.files.get('/home/dev/.orca/agent-hooks/claude-statusline.sh')
+    expect(statusLineScript).toContain('/statusline/claude')
+    expect(statusLineScript).toContain('"rate_limits"')
   })
 
   it('reports parse error when remote settings.json cannot be parsed', async () => {
@@ -364,6 +449,8 @@ describe('OpenClaudeHookService-compatible install', () => {
       expect(
         readFileSync(join(tmpHome, '.orca', 'agent-hooks', OPENCLAUDE_SCRIPT_FILE_NAME), 'utf-8')
       ).not.toContain('DEVIN_PROJECT_DIR')
+      // Why: the statusline usage feed is Claude-only; OpenClaude installs must not set statusLine.
+      expect(parsed.statusLine).toBeUndefined()
       expect(existsSync(join(tmpHome, '.claude', 'settings.json'))).toBe(false)
     } finally {
       vi.unstubAllEnvs()

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -1,10 +1,12 @@
+import { existsSync, rmSync, writeFileSync } from 'node:fs'
 import type { SFTPWrapper } from 'ssh2'
 import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared/agent-hook-types'
 import {
   buildWindowsAgentHookCurlPostCommand,
   readHooksJson,
   writeHooksJson,
-  writeManagedScript
+  writeManagedScript,
+  type HooksConfig
 } from '../agent-hooks/installer-utils'
 import {
   readHooksJsonRemote,
@@ -28,11 +30,12 @@ import {
   getManagedCommand,
   getManagedScriptPath,
   getPosixManagedScriptFileName,
-  getPosixStatusLineScriptFileName,
   getRemoteConfigPath,
   getRemoteManagedCommand,
+  getStatusLineInstallMarkerPath,
   getStatusLineScriptFileName,
   getStatusLineScriptPath,
+  getStatusLineSlotState,
   removeManagedHooks,
   removeManagedStatusLine,
   type ClaudeCompatibleHookSettings
@@ -192,16 +195,34 @@ export class ClaudeHookService {
     )
     // Why: the statusline usage feed is Claude-only — OpenClaude data would be misattributed to the Claude provider.
     if (this.options.agent === 'claude') {
-      const statusLineScriptPath = getStatusLineScriptPath(this.options.settings)
-      writeManagedScript(statusLineScriptPath, getManagedStatusLineScript('local'))
-      nextConfig = applyManagedStatusLine(
-        nextConfig,
-        getManagedCommand(statusLineScriptPath),
-        getStatusLineScriptFileName(this.options.settings)
-      )
+      nextConfig = this.installManagedStatusLine(nextConfig)
     }
     writeHooksJson(configPath, nextConfig)
     return this.getStatus()
+  }
+
+  // Why: the statusline feed is opportunistic (usage display, not agent status); a user who deleted the
+  // managed entry has opted out, and the marker distinguishes that deletion from a first install.
+  private installManagedStatusLine(config: HooksConfig): HooksConfig {
+    const scriptFileName = getStatusLineScriptFileName(this.options.settings)
+    const markerPath = getStatusLineInstallMarkerPath(this.options.settings)
+    const slot = getStatusLineSlotState(config, scriptFileName)
+    if (slot === 'user' || (slot === 'empty' && existsSync(markerPath))) {
+      return config
+    }
+    const statusLineScriptPath = getStatusLineScriptPath(this.options.settings)
+    writeManagedScript(statusLineScriptPath, getManagedStatusLineScript('local'))
+    const next = applyManagedStatusLine(
+      config,
+      getManagedCommand(statusLineScriptPath),
+      scriptFileName
+    )
+    try {
+      writeFileSync(markerPath, '')
+    } catch {
+      // Best-effort: a missing marker only means one future user deletion gets re-installed once.
+    }
+    return next
   }
 
   // Why: install the Claude hook on the remote box (via SFTP); POSIX-only by design (Windows-remote deferred).
@@ -225,7 +246,7 @@ export class ClaudeHookService {
 
       // Why: the POSIX wrapper is identical regardless of where the script lands; only the path differs.
       const command = getRemoteManagedCommand(remoteScriptPath)
-      let nextConfig = applyManagedHooks(config, command, remoteScriptFileName)
+      const nextConfig = applyManagedHooks(config, command, remoteScriptFileName)
 
       // Why: write script before settings — a mid-install failure then leaves a harmless orphan script, not settings.json pointing at a missing one.
       // Why: SSH remotes use POSIX `.sh` paths even when Orca runs on Windows; never derive remote script syntax from the local OS.
@@ -234,21 +255,9 @@ export class ClaudeHookService {
         remoteScriptPath,
         getManagedScript('posix', { skipWhenDevinImportsClaude: this.options.agent === 'claude' })
       )
-      // Why: the statusline usage feed is Claude-only — OpenClaude data would be misattributed to the Claude provider.
-      if (this.options.agent === 'claude') {
-        const remoteStatusLineFileName = getPosixStatusLineScriptFileName(this.options.settings)
-        const remoteStatusLinePath = `${remoteHome.replace(/\/$/, '')}/.orca/agent-hooks/${remoteStatusLineFileName}`
-        await writeManagedScriptRemote(
-          sftp,
-          remoteStatusLinePath,
-          getManagedStatusLineScript('posix')
-        )
-        nextConfig = applyManagedStatusLine(
-          nextConfig,
-          getRemoteManagedCommand(remoteStatusLinePath),
-          remoteStatusLineFileName
-        )
-      }
+      // Why: no statusline install here — this path serves SSH remotes and WSL guests, whose relay hook
+      // listener doesn't route /statusline/claude, and an SSH box's Claude login can be a different
+      // account than the locally selected one, so its usage must not feed the local bar (live feed is host-local only).
       await writeHooksJsonRemote(sftp, remoteConfigPath, nextConfig)
 
       return {
@@ -291,6 +300,14 @@ export class ClaudeHookService {
     )
     if (hooksChanged || statusLineChanged) {
       writeHooksJson(configPath, nextConfig)
+    }
+    if (this.options.agent === 'claude') {
+      try {
+        // Why: an Orca-level uninstall resets the opt-out memory so a later re-enable installs the statusline again.
+        rmSync(getStatusLineInstallMarkerPath(this.options.settings), { force: true })
+      } catch {
+        // ignore — marker cleanup is best-effort
+      }
     }
     return this.getStatus()
   }

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -17,8 +17,10 @@ import {
   buildWindowsHookStdinDrainEpilogue,
   WINDOWS_HOOK_STDIN_DRAIN_LABEL
 } from '../agent-hooks/hook-stdin-contract'
+import { getManagedStatusLineScript } from './statusline-script'
 import {
   applyManagedHooks,
+  applyManagedStatusLine,
   CLAUDE_EVENTS,
   CLAUDE_HOOK_SETTINGS,
   getManagedScriptFileName,
@@ -26,9 +28,13 @@ import {
   getManagedCommand,
   getManagedScriptPath,
   getPosixManagedScriptFileName,
+  getPosixStatusLineScriptFileName,
   getRemoteConfigPath,
   getRemoteManagedCommand,
+  getStatusLineScriptFileName,
+  getStatusLineScriptPath,
   removeManagedHooks,
+  removeManagedStatusLine,
   type ClaudeCompatibleHookSettings
 } from './hook-settings'
 
@@ -175,7 +181,7 @@ export class ClaudeHookService {
     }
 
     const command = getManagedCommand(scriptPath)
-    const nextConfig = applyManagedHooks(
+    let nextConfig = applyManagedHooks(
       config,
       command,
       getManagedScriptFileName(this.options.settings)
@@ -184,6 +190,16 @@ export class ClaudeHookService {
       scriptPath,
       getManagedScript('local', { skipWhenDevinImportsClaude: this.options.agent === 'claude' })
     )
+    // Why: the statusline usage feed is Claude-only — OpenClaude data would be misattributed to the Claude provider.
+    if (this.options.agent === 'claude') {
+      const statusLineScriptPath = getStatusLineScriptPath(this.options.settings)
+      writeManagedScript(statusLineScriptPath, getManagedStatusLineScript('local'))
+      nextConfig = applyManagedStatusLine(
+        nextConfig,
+        getManagedCommand(statusLineScriptPath),
+        getStatusLineScriptFileName(this.options.settings)
+      )
+    }
     writeHooksJson(configPath, nextConfig)
     return this.getStatus()
   }
@@ -209,7 +225,7 @@ export class ClaudeHookService {
 
       // Why: the POSIX wrapper is identical regardless of where the script lands; only the path differs.
       const command = getRemoteManagedCommand(remoteScriptPath)
-      const nextConfig = applyManagedHooks(config, command, remoteScriptFileName)
+      let nextConfig = applyManagedHooks(config, command, remoteScriptFileName)
 
       // Why: write script before settings — a mid-install failure then leaves a harmless orphan script, not settings.json pointing at a missing one.
       // Why: SSH remotes use POSIX `.sh` paths even when Orca runs on Windows; never derive remote script syntax from the local OS.
@@ -218,6 +234,21 @@ export class ClaudeHookService {
         remoteScriptPath,
         getManagedScript('posix', { skipWhenDevinImportsClaude: this.options.agent === 'claude' })
       )
+      // Why: the statusline usage feed is Claude-only — OpenClaude data would be misattributed to the Claude provider.
+      if (this.options.agent === 'claude') {
+        const remoteStatusLineFileName = getPosixStatusLineScriptFileName(this.options.settings)
+        const remoteStatusLinePath = `${remoteHome.replace(/\/$/, '')}/.orca/agent-hooks/${remoteStatusLineFileName}`
+        await writeManagedScriptRemote(
+          sftp,
+          remoteStatusLinePath,
+          getManagedStatusLineScript('posix')
+        )
+        nextConfig = applyManagedStatusLine(
+          nextConfig,
+          getRemoteManagedCommand(remoteStatusLinePath),
+          remoteStatusLineFileName
+        )
+      }
       await writeHooksJsonRemote(sftp, remoteConfigPath, nextConfig)
 
       return {
@@ -250,11 +281,15 @@ export class ClaudeHookService {
         detail: `Could not parse ${this.options.displayName} settings.json`
       }
     }
-    const { config: nextConfig, changed } = removeManagedHooks(
+    const { config: hooksRemoved, changed: hooksChanged } = removeManagedHooks(
       config,
       getManagedScriptFileName(this.options.settings)
     )
-    if (changed) {
+    const { config: nextConfig, changed: statusLineChanged } = removeManagedStatusLine(
+      hooksRemoved,
+      getStatusLineScriptFileName(this.options.settings)
+    )
+    if (hooksChanged || statusLineChanged) {
       writeHooksJson(configPath, nextConfig)
     }
     return this.getStatus()

--- a/src/main/claude/hook-settings.ts
+++ b/src/main/claude/hook-settings.ts
@@ -4,6 +4,7 @@ import {
   buildManagedCommandHook,
   createManagedCommandMatcher,
   getSharedManagedScriptPath,
+  isPlainObject,
   removeManagedCommands,
   wrapPosixHookCommand,
   wrapWindowsGitBashHookCommand,
@@ -64,6 +65,24 @@ export function getConfigPath(settings = CLAUDE_HOOK_SETTINGS): string {
   return join(homedir(), settings.configDirName, 'settings.json')
 }
 
+export function getStatusLineScriptBaseName(settings = CLAUDE_HOOK_SETTINGS): string {
+  return settings.scriptBaseName.replace(/-hook$/, '-statusline')
+}
+
+export function getStatusLineScriptFileName(settings = CLAUDE_HOOK_SETTINGS): string {
+  return process.platform === 'win32'
+    ? `${getStatusLineScriptBaseName(settings)}.cmd`
+    : getPosixStatusLineScriptFileName(settings)
+}
+
+export function getPosixStatusLineScriptFileName(settings = CLAUDE_HOOK_SETTINGS): string {
+  return `${getStatusLineScriptBaseName(settings)}.sh`
+}
+
+export function getStatusLineScriptPath(settings = CLAUDE_HOOK_SETTINGS): string {
+  return getSharedManagedScriptPath(getStatusLineScriptFileName(settings))
+}
+
 export function getManagedScriptFileName(settings = CLAUDE_HOOK_SETTINGS): string {
   return process.platform === 'win32'
     ? `${settings.scriptBaseName}.cmd`
@@ -111,6 +130,39 @@ export function applyManagedHooks(
   }
 
   return { ...config, hooks: nextHooks }
+}
+
+// Why: statusLine is a single settings slot, not a hooks array — never overwrite a
+// user-owned status line; the usage feed then simply falls back to the OAuth poll.
+export function applyManagedStatusLine(
+  config: HooksConfig,
+  command: string,
+  scriptFileName = getStatusLineScriptFileName()
+): HooksConfig {
+  const isManagedCommand = createManagedCommandMatcher(scriptFileName)
+  const current = config.statusLine
+  const currentCommand =
+    isPlainObject(current) && typeof current.command === 'string' ? current.command : null
+  if (currentCommand && !isManagedCommand(currentCommand)) {
+    return config
+  }
+  return { ...config, statusLine: { type: 'command', command } }
+}
+
+export function removeManagedStatusLine(
+  config: HooksConfig,
+  scriptFileName = getStatusLineScriptFileName()
+): { config: HooksConfig; changed: boolean } {
+  const isManagedCommand = createManagedCommandMatcher(scriptFileName)
+  const current = config.statusLine
+  const currentCommand =
+    isPlainObject(current) && typeof current.command === 'string' ? current.command : null
+  if (!currentCommand || !isManagedCommand(currentCommand)) {
+    return { config, changed: false }
+  }
+  const next = { ...config }
+  delete next.statusLine
+  return { config: next, changed: true }
 }
 
 export function removeManagedHooks(

--- a/src/main/claude/hook-settings.ts
+++ b/src/main/claude/hook-settings.ts
@@ -132,6 +132,29 @@ export function applyManagedHooks(
   return { ...config, hooks: nextHooks }
 }
 
+export type StatusLineSlotState = 'managed' | 'user' | 'empty'
+
+// Why: install policy needs "user owns the slot" vs "slot is empty" vs "ours" — an empty slot
+// after a prior install means the user deleted the managed entry, which install must respect.
+export function getStatusLineSlotState(
+  config: HooksConfig,
+  scriptFileName = getStatusLineScriptFileName()
+): StatusLineSlotState {
+  const isManagedCommand = createManagedCommandMatcher(scriptFileName)
+  const current = config.statusLine
+  const currentCommand =
+    isPlainObject(current) && typeof current.command === 'string' ? current.command : null
+  if (!currentCommand) {
+    return 'empty'
+  }
+  return isManagedCommand(currentCommand) ? 'managed' : 'user'
+}
+
+// Why: records that the managed statusline was installed once, so a later empty slot reads as user opt-out.
+export function getStatusLineInstallMarkerPath(settings = CLAUDE_HOOK_SETTINGS): string {
+  return getSharedManagedScriptPath(`${getStatusLineScriptBaseName(settings)}.installed`)
+}
+
 // Why: statusLine is a single settings slot, not a hooks array — never overwrite a
 // user-owned status line; the usage feed then simply falls back to the OAuth poll.
 export function applyManagedStatusLine(
@@ -139,11 +162,7 @@ export function applyManagedStatusLine(
   command: string,
   scriptFileName = getStatusLineScriptFileName()
 ): HooksConfig {
-  const isManagedCommand = createManagedCommandMatcher(scriptFileName)
-  const current = config.statusLine
-  const currentCommand =
-    isPlainObject(current) && typeof current.command === 'string' ? current.command : null
-  if (currentCommand && !isManagedCommand(currentCommand)) {
+  if (getStatusLineSlotState(config, scriptFileName) === 'user') {
     return config
   }
   return { ...config, statusLine: { type: 'command', command } }

--- a/src/main/claude/statusline-script.test.ts
+++ b/src/main/claude/statusline-script.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { getManagedStatusLineScript } from './statusline-script'
+
+const ORIGINAL_PLATFORM = process.platform
+
+function stubPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+}
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', { configurable: true, value: ORIGINAL_PLATFORM })
+})
+
+describe('getManagedStatusLineScript (posix)', () => {
+  it('guards on rate_limits before sourcing the endpoint or spawning curl', () => {
+    stubPlatform('darwin')
+    const script = getManagedStatusLineScript('local')
+    expect(script).toBe(getManagedStatusLineScript('posix'))
+    const guardIndex = script.indexOf('*\'"rate_limits"\'*')
+    const endpointIndex = script.indexOf('ORCA_AGENT_HOOK_ENDPOINT')
+    const curlIndex = script.indexOf('curl -sS')
+    expect(guardIndex).toBeGreaterThan(-1)
+    expect(guardIndex).toBeLessThan(endpointIndex)
+    expect(endpointIndex).toBeLessThan(curlIndex)
+    expect(script).toContain('/statusline/claude')
+    expect(script).toContain('--data-urlencode "payload@-"')
+  })
+
+  it('returns the posix script even on win32 when targeting a remote', () => {
+    stubPlatform('win32')
+    const script = getManagedStatusLineScript('posix')
+    expect(script).toContain('#!/bin/sh')
+    expect(script).not.toContain('curl.exe')
+  })
+})
+
+describe('getManagedStatusLineScript (win32 local)', () => {
+  it('guards on rate_limits via findstr before the endpoint call and curl spawn', () => {
+    stubPlatform('win32')
+    const script = getManagedStatusLineScript('local')
+    const captureIndex = script.indexOf('more.com')
+    // Why: the \"-escaped needle makes findstr match the quoted JSON key, not any path containing rate_limits.
+    const guardIndex = script.indexOf('findstr.exe" /c:\\"rate_limits\\"')
+    const endpointIndex = script.indexOf('call "%ORCA_AGENT_HOOK_ENDPOINT%"')
+    const curlIndex = script.indexOf('curl.exe')
+    expect(captureIndex).toBeGreaterThan(-1)
+    expect(guardIndex).toBeGreaterThan(captureIndex)
+    expect(guardIndex).toBeLessThan(endpointIndex)
+    expect(endpointIndex).toBeLessThan(curlIndex)
+    expect(script).toContain('if errorlevel 1 goto :orca_statusline_cleanup')
+  })
+
+  it('posts the buffered payload file and deletes it afterwards', () => {
+    stubPlatform('win32')
+    const script = getManagedStatusLineScript('local')
+    // Why: the temp file is per-pane (pane key with ":" mapped to "_") because %RANDOM%
+    // collides across cmd instances spawned in the same second.
+    expect(script).toContain(
+      'set "ORCA_STATUSLINE_PAYLOAD_FILE=%TEMP%\\orca-claude-statusline-%ORCA_PANE_KEY::=_%.tmp"'
+    )
+    expect(script).toContain('--data-urlencode "payload@%ORCA_STATUSLINE_PAYLOAD_FILE%"')
+    expect(script).not.toContain('payload@-')
+    const curlIndex = script.indexOf('curl.exe')
+    const delIndex = script.indexOf('del "%ORCA_STATUSLINE_PAYLOAD_FILE%"')
+    expect(delIndex).toBeGreaterThan(curlIndex)
+  })
+
+  it('never posts a literal %CLAUDE_CONFIG_DIR% token when the var is unset', () => {
+    stubPlatform('win32')
+    const script = getManagedStatusLineScript('local')
+    // Why: the posted field comes from an always-defined variable so an unset
+    // CLAUDE_CONFIG_DIR yields "configDir=" (matching POSIX + the null snapshot).
+    expect(script).toContain('set "ORCA_STATUSLINE_CONFIG_DIR_FIELD=configDir="')
+    expect(script).toContain(
+      'if defined CLAUDE_CONFIG_DIR set "ORCA_STATUSLINE_CONFIG_DIR_FIELD=configDir=%CLAUDE_CONFIG_DIR%"'
+    )
+    expect(script).toContain('--data-urlencode "%ORCA_STATUSLINE_CONFIG_DIR_FIELD%"')
+    expect(script).not.toContain('"configDir=%CLAUDE_CONFIG_DIR%"')
+  })
+
+  it('drains stdin before exiting when the pane key is missing', () => {
+    stubPlatform('win32')
+    const script = getManagedStatusLineScript('local')
+    const paneGuardIndex = script.indexOf(
+      'if "%ORCA_PANE_KEY%"=="" goto :orca_agent_hook_drain_stdin'
+    )
+    const captureIndex = script.indexOf('more.com')
+    expect(paneGuardIndex).toBeGreaterThan(-1)
+    expect(paneGuardIndex).toBeLessThan(captureIndex)
+    expect(script).toContain(':orca_agent_hook_drain_stdin')
+  })
+})

--- a/src/main/claude/statusline-script.ts
+++ b/src/main/claude/statusline-script.ts
@@ -1,9 +1,12 @@
 import {
   buildPosixHookPayloadCapture,
-  buildWindowsHookEnvironmentGuardLines,
-  buildWindowsHookStdinDrainEpilogue
+  buildWindowsHookStdinDrainEpilogue,
+  WINDOWS_HOOK_STDIN_DRAIN_LABEL,
+  WINDOWS_HOOK_STDIN_READER
 } from '../agent-hooks/hook-stdin-contract'
 import { CLAUDE_STATUSLINE_PATHNAME } from '../../shared/claude-statusline-rate-limits'
+
+const STATUSLINE_CLEANUP_LABEL = 'orca_statusline_cleanup'
 
 // Why: Claude Code pipes `rate_limits` to the statusLine command on every turn; forwarding
 // it gives Orca live usage without spending the OAuth usage endpoint's tight budget.
@@ -13,9 +16,25 @@ export function getManagedStatusLineScript(target: 'local' | 'posix' = 'local'):
     return [
       '@echo off',
       'setlocal',
+      // Why: pane key is static PTY env (the endpoint file never sets it), so it can gate before stdin is consumed.
+      `if "%ORCA_PANE_KEY%"=="" goto :${WINDOWS_HOOK_STDIN_DRAIN_LABEL}`,
+      // Why: cmd has no builtin stdin capture, so buffer the payload in a per-pane temp file
+      // (%RANDOM% collides across same-second cmd spawns) to guard before any curl spawn.
+      'set "ORCA_STATUSLINE_PAYLOAD_FILE=%TEMP%\\orca-claude-statusline-%ORCA_PANE_KEY::=_%.tmp"',
+      `${WINDOWS_HOOK_STDIN_READER} >"%ORCA_STATUSLINE_PAYLOAD_FILE%" 2>nul`,
+      // Why: rate_limits appears only for Claude.ai-subscriber sessions after the first API response; the
+      // statusline ticks ~3x/sec during streaming, so skip the endpoint call and curl spawn otherwise.
+      // Why: \" is the MSVC argv escape — findstr sees the quoted JSON key, so a cwd containing rate_limits can't false-match (POSIX guard parity).
+      '"%SystemRoot%\\System32\\findstr.exe" /c:\\"rate_limits\\" "%ORCA_STATUSLINE_PAYLOAD_FILE%" >nul 2>nul',
+      `if errorlevel 1 goto :${STATUSLINE_CLEANUP_LABEL}`,
       // Why: call the endpoint file to refresh port/token — a PTY that survived an Orca restart carries stale env; falls through to PTY env if missing.
       'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
-      ...buildWindowsHookEnvironmentGuardLines(),
+      `if "%ORCA_AGENT_HOOK_PORT%"=="" goto :${STATUSLINE_CLEANUP_LABEL}`,
+      `if "%ORCA_AGENT_HOOK_TOKEN%"=="" goto :${STATUSLINE_CLEANUP_LABEL}`,
+      // Why: pre-build the field from an always-defined variable so an unset CLAUDE_CONFIG_DIR posts
+      // empty (matching POSIX and the null attribution snapshot), never a literal %VAR% token.
+      'set "ORCA_STATUSLINE_CONFIG_DIR_FIELD=configDir="',
+      'if defined CLAUDE_CONFIG_DIR set "ORCA_STATUSLINE_CONFIG_DIR_FIELD=configDir=%CLAUDE_CONFIG_DIR%"',
       [
         '"%SystemRoot%\\System32\\curl.exe" -sS -X POST',
         `"http://127.0.0.1:%ORCA_AGENT_HOOK_PORT%${CLAUDE_STATUSLINE_PATHNAME}"`,
@@ -23,12 +42,14 @@ export function getManagedStatusLineScript(target: 'local' | 'posix' = 'local'):
         '-H "Content-Type: application/x-www-form-urlencoded"',
         '-H "X-Orca-Agent-Hook-Token: %ORCA_AGENT_HOOK_TOKEN%"',
         '--data-urlencode "paneKey=%ORCA_PANE_KEY%"',
-        '--data-urlencode "configDir=%CLAUDE_CONFIG_DIR%"',
+        '--data-urlencode "%ORCA_STATUSLINE_CONFIG_DIR_FIELD%"',
         '--data-urlencode "env=%ORCA_AGENT_HOOK_ENV%"',
         '--data-urlencode "version=%ORCA_AGENT_HOOK_VERSION%"',
-        '--data-urlencode "payload@-"',
+        '--data-urlencode "payload@%ORCA_STATUSLINE_PAYLOAD_FILE%"',
         '>nul 2>&1'
       ].join(' '),
+      `:${STATUSLINE_CLEANUP_LABEL}`,
+      'del "%ORCA_STATUSLINE_PAYLOAD_FILE%" >nul 2>nul',
       'exit /b 0',
       ...buildWindowsHookStdinDrainEpilogue(),
       ''

--- a/src/main/claude/statusline-script.ts
+++ b/src/main/claude/statusline-script.ts
@@ -1,0 +1,64 @@
+import {
+  buildPosixHookPayloadCapture,
+  buildWindowsHookEnvironmentGuardLines,
+  buildWindowsHookStdinDrainEpilogue
+} from '../agent-hooks/hook-stdin-contract'
+import { CLAUDE_STATUSLINE_PATHNAME } from '../../shared/claude-statusline-rate-limits'
+
+// Why: Claude Code pipes `rate_limits` to the statusLine command on every turn; forwarding
+// it gives Orca live usage without spending the OAuth usage endpoint's tight budget.
+// Emits no stdout so the in-terminal status line stays visually unchanged.
+export function getManagedStatusLineScript(target: 'local' | 'posix' = 'local'): string {
+  if (target === 'local' && process.platform === 'win32') {
+    return [
+      '@echo off',
+      'setlocal',
+      // Why: call the endpoint file to refresh port/token — a PTY that survived an Orca restart carries stale env; falls through to PTY env if missing.
+      'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
+      ...buildWindowsHookEnvironmentGuardLines(),
+      [
+        '"%SystemRoot%\\System32\\curl.exe" -sS -X POST',
+        `"http://127.0.0.1:%ORCA_AGENT_HOOK_PORT%${CLAUDE_STATUSLINE_PATHNAME}"`,
+        '--connect-timeout 0.5 --max-time 1.5',
+        '-H "Content-Type: application/x-www-form-urlencoded"',
+        '-H "X-Orca-Agent-Hook-Token: %ORCA_AGENT_HOOK_TOKEN%"',
+        '--data-urlencode "paneKey=%ORCA_PANE_KEY%"',
+        '--data-urlencode "configDir=%CLAUDE_CONFIG_DIR%"',
+        '--data-urlencode "env=%ORCA_AGENT_HOOK_ENV%"',
+        '--data-urlencode "version=%ORCA_AGENT_HOOK_VERSION%"',
+        '--data-urlencode "payload@-"',
+        '>nul 2>&1'
+      ].join(' '),
+      'exit /b 0',
+      ...buildWindowsHookStdinDrainEpilogue(),
+      ''
+    ].join('\r\n')
+  }
+
+  return [
+    '#!/bin/sh',
+    ...buildPosixHookPayloadCapture(),
+    // Why: rate_limits appears only for Claude.ai-subscriber sessions after the first API response; skip the post (and its curl spawn) otherwise.
+    'case "$payload" in',
+    '  *\'"rate_limits"\'*) ;;',
+    '  *) exit 0 ;;',
+    'esac',
+    'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',
+    '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
+    'fi',
+    'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
+    '  exit 0',
+    'fi',
+    `printf '%s' "$payload" | curl -sS -X POST "http://127.0.0.1:\${ORCA_AGENT_HOOK_PORT}${CLAUDE_STATUSLINE_PATHNAME}" \\`,
+    '  --connect-timeout 0.5 --max-time 1.5 \\',
+    '  -H "Content-Type: application/x-www-form-urlencoded" \\',
+    '  -H "X-Orca-Agent-Hook-Token: ${ORCA_AGENT_HOOK_TOKEN}" \\',
+    '  --data-urlencode "paneKey=${ORCA_PANE_KEY}" \\',
+    '  --data-urlencode "configDir=${CLAUDE_CONFIG_DIR}" \\',
+    '  --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
+    '  --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
+    '  --data-urlencode "payload@-" >/dev/null 2>&1 || true',
+    'exit 0',
+    ''
+  ].join('\n')
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1820,6 +1820,10 @@ app.whenReady().then(async () => {
   rateLimits.setClaudeAuthPreparationResolver((target) =>
     claudeRuntimeAuth!.prepareForRateLimitFetch(target)
   )
+  // Why: live Claude sessions stream usage windows through their statusLine command; feeding them here avoids OAuth usage-endpoint polling (and its 429s).
+  agentHookServer.setClaudeStatusLineListener((event) => {
+    rateLimits?.ingestLiveClaudeRateLimits(event)
+  })
   rateLimits.setOpenCodeGoConfigResolver(() => {
     const settings = store!.getSettings()
     return {

--- a/src/main/rate-limits/claude-fetcher.test.ts
+++ b/src/main/rate-limits/claude-fetcher.test.ts
@@ -856,15 +856,20 @@ describe('fetchClaudeRateLimits', () => {
             message: 'Rate limited. Please try again later.'
           }
         }),
-        { status: 429 }
+        { status: 429, headers: { 'retry-after': '3000' } }
       )
     )
 
-    await expect(fetchClaudeRateLimits({ authPreparation })).resolves.toMatchObject({
+    const before = Date.now()
+    const result = await fetchClaudeRateLimits({ authPreparation })
+    expect(result).toMatchObject({
       provider: 'claude',
       status: 'error',
-      error: 'Claude usage is rate limited right now.'
+      error: 'Claude usage is rate limited right now.',
+      usageMetadata: expect.objectContaining({ failureKind: 'rate-limited' })
     })
+    expect(result.usageMetadata?.retryAtMs).toBeGreaterThanOrEqual(before + 3000 * 1000)
+    expect(result.usageMetadata?.retryAtMs).toBeLessThanOrEqual(Date.now() + 3000 * 1000)
 
     expect(netFetchMock).toHaveBeenCalledWith(
       'https://api.anthropic.com/api/oauth/usage',
@@ -874,6 +879,41 @@ describe('fetchClaudeRateLimits', () => {
         })
       })
     )
+    expect(fetchViaPty).not.toHaveBeenCalled()
+  })
+
+  it('omits retryAtMs when a 429 has no Retry-After header', async () => {
+    const configDir = '/Users/test/.claude'
+    const authPreparation: ClaudeRuntimeAuthPreparation = {
+      configDir,
+      envPatch: { CLAUDE_CONFIG_DIR: configDir },
+      stripAuthEnv: false,
+      provenance: 'system'
+    }
+    vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockResolvedValueOnce(
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'expired-oauth-token',
+          refreshToken: 'refresh-token',
+          expiresAt: Date.now() - 60_000
+        }
+      })
+    )
+    netFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            type: 'rate_limit_error',
+            message: 'Rate limited. Please try again later.'
+          }
+        }),
+        { status: 429 }
+      )
+    )
+
+    const result = await fetchClaudeRateLimits({ authPreparation })
+    expect(result.status).toBe('error')
+    expect(result.usageMetadata?.retryAtMs).toBeUndefined()
     expect(fetchViaPty).not.toHaveBeenCalled()
   })
 

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -33,6 +33,7 @@ import {
   refreshClaudeOauthCredentials
 } from '../claude-accounts/oauth-refresh'
 import { createOAuthUsageError, OAuthUsageError } from './claude-oauth-usage-error'
+import { mapClaudeUsageWindow, type ClaudeUsageWindowInput } from './claude-usage-window'
 import { withMacTailscaleDnsHint } from '../network/macos-tailscale-dns-diagnostic'
 import { ensureElectronProxyFromEnvironment } from '../network/proxy-settings'
 import { resolveClaudeUsageRefreshPlan } from './claude-usage-refresh-plan'
@@ -278,11 +279,7 @@ function warnClaudeUsageFetchFailure(
 // OAuth API fetch
 // ---------------------------------------------------------------------------
 
-type OAuthUsageWindow = {
-  utilization?: number
-  used_percentage?: number
-  resets_at?: string | number
-}
+type OAuthUsageWindow = ClaudeUsageWindowInput
 
 type OAuthUsageLimit = {
   kind?: string
@@ -316,73 +313,6 @@ function abortedClaudeRateLimitResult(): ProviderRateLimits {
   }
 }
 
-function parseResetTimestamp(value: string | number | undefined): number | null {
-  if (typeof value === 'number') {
-    if (!Number.isFinite(value)) {
-      return null
-    }
-    return value > 10_000_000_000 ? value : value * 1000
-  }
-
-  if (!value) {
-    return null
-  }
-
-  const numericValue = Number(value)
-  if (Number.isFinite(numericValue) && value.trim() !== '') {
-    return numericValue > 10_000_000_000 ? numericValue : numericValue * 1000
-  }
-
-  const parsed = new Date(value).getTime()
-  return Number.isNaN(parsed) ? null : parsed
-}
-
-function parseResetDescription(resetValue: string | number | undefined): string | null {
-  const resetTimestamp = parseResetTimestamp(resetValue)
-  if (resetTimestamp === null) {
-    return null
-  }
-  try {
-    const date = new Date(resetTimestamp)
-    const now = new Date()
-    const isToday = date.toDateString() === now.toDateString()
-    if (isToday) {
-      return date.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
-    }
-    return date.toLocaleDateString(undefined, {
-      weekday: 'short',
-      hour: 'numeric',
-      minute: '2-digit'
-    })
-  } catch {
-    return null
-  }
-}
-
-function mapWindow(
-  raw: OAuthUsageWindow | undefined,
-  windowMinutes: number
-): RateLimitWindow | null {
-  if (!raw) {
-    return null
-  }
-  const usedPercent =
-    typeof raw.utilization === 'number'
-      ? raw.utilization
-      : typeof raw.used_percentage === 'number'
-        ? raw.used_percentage
-        : null
-  if (usedPercent === null) {
-    return null
-  }
-  return {
-    usedPercent: Math.min(100, Math.max(0, usedPercent)),
-    windowMinutes,
-    resetsAt: parseResetTimestamp(raw.resets_at),
-    resetDescription: parseResetDescription(raw.resets_at)
-  }
-}
-
 function mapFableWeeklyWindow(data: OAuthUsageResponse): RateLimitWindow | null {
   // Why: model quotas moved to structured scoped limits; prefer them but keep legacy weekly fields for older responses.
   const scoped = Array.isArray(data.limits)
@@ -396,13 +326,13 @@ function mapFableWeeklyWindow(data: OAuthUsageResponse): RateLimitWindow | null 
       )
     : undefined
   return (
-    mapWindow(
+    mapClaudeUsageWindow(
       scoped ? { used_percentage: scoped.percent, resets_at: scoped.resets_at } : undefined,
       10080
     ) ??
-    mapWindow(data.fable_weekly, 10080) ??
-    mapWindow(data.fable_seven_day, 10080) ??
-    mapWindow(data.seven_day_fable, 10080)
+    mapClaudeUsageWindow(data.fable_weekly, 10080) ??
+    mapClaudeUsageWindow(data.fable_seven_day, 10080) ??
+    mapClaudeUsageWindow(data.seven_day_fable, 10080)
   )
 }
 
@@ -443,8 +373,8 @@ async function fetchViaOAuth(token: string, signal?: AbortSignal): Promise<Provi
 
     return {
       provider: 'claude',
-      session: mapWindow(data.five_hour, 300),
-      weekly: mapWindow(data.seven_day, 10080),
+      session: mapClaudeUsageWindow(data.five_hour, 300),
+      weekly: mapClaudeUsageWindow(data.seven_day, 10080),
       fableWeekly: mapFableWeeklyWindow(data),
       updatedAt: Date.now(),
       error: null,
@@ -505,6 +435,7 @@ function metadataForAttempt(input: {
   source?: UsageRateLimitSource
   failureKind?: UsageRateLimitFailureKind
   deferredByLiveClaudeSession?: boolean
+  retryAtMs?: number
 }): UsageRateLimitMetadata {
   return {
     source: input.source,
@@ -512,7 +443,8 @@ function metadataForAttempt(input: {
     failureKind: input.failureKind,
     credentialSource: input.oauthCredentials.source,
     authProvenance: input.authPreparation?.provenance ?? 'system',
-    deferredByLiveClaudeSession: input.deferredByLiveClaudeSession
+    deferredByLiveClaudeSession: input.deferredByLiveClaudeSession,
+    retryAtMs: input.retryAtMs
   }
 }
 
@@ -727,12 +659,15 @@ function errorResultForClassification(input: {
 }): ProviderRateLimits {
   const message =
     input.error instanceof Error ? input.error.message : String(input.error || 'Unknown error')
+  // Why: refetching before Retry-After expires wastes the endpoint's tight budget and keeps usage stuck on "Limited"; let the service wait it out.
+  const retryAfterMs = input.error instanceof OAuthUsageError ? input.error.retryAfterMs : null
   return makeClaudeUsageResult('error', withMacTailscaleDnsHint(message), {
     ...metadataForAttempt({
       attemptedSources: input.attempts.attemptedSources,
       oauthCredentials: input.oauthCredentials,
       authPreparation: input.authPreparation,
-      failureKind: input.classification.failureKind
+      failureKind: input.classification.failureKind,
+      retryAtMs: retryAfterMs ? Date.now() + retryAfterMs : undefined
     })
   })
 }

--- a/src/main/rate-limits/claude-oauth-usage-error.test.ts
+++ b/src/main/rate-limits/claude-oauth-usage-error.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { createOAuthUsageError } from './claude-oauth-usage-error'
+
+function rateLimitedResponse(headers?: Record<string, string>): Response {
+  return new Response('{"error":{"type":"rate_limit_error"}}', { status: 429, headers })
+}
+
+describe('createOAuthUsageError', () => {
+  it('captures a numeric Retry-After on 429', async () => {
+    const error = await createOAuthUsageError(rateLimitedResponse({ 'retry-after': '3037' }))
+    expect(error.status).toBe(429)
+    expect(error.skipPtyFallback).toBe(true)
+    expect(error.retryAfterMs).toBe(3037 * 1000)
+    expect(error.message).toBe('Claude usage is rate limited right now.')
+  })
+
+  it('captures an HTTP-date Retry-After on 429', async () => {
+    const error = await createOAuthUsageError(
+      rateLimitedResponse({ 'retry-after': new Date(Date.now() + 90_000).toUTCString() })
+    )
+    expect(error.retryAfterMs).toBeGreaterThan(0)
+    expect(error.retryAfterMs).toBeLessThanOrEqual(90_000)
+  })
+
+  it('caps Retry-After at 24 hours', async () => {
+    const error = await createOAuthUsageError(
+      rateLimitedResponse({ 'retry-after': String(48 * 60 * 60) })
+    )
+    expect(error.retryAfterMs).toBe(24 * 60 * 60 * 1000)
+  })
+
+  it('ignores missing, invalid, and non-positive Retry-After values', async () => {
+    for (const headers of [
+      undefined,
+      { 'retry-after': 'soon' },
+      { 'retry-after': '0' },
+      { 'retry-after': '-5' }
+    ]) {
+      const error = await createOAuthUsageError(rateLimitedResponse(headers))
+      expect(error.retryAfterMs).toBeNull()
+    }
+  })
+
+  it('does not capture Retry-After for non-429 responses', async () => {
+    const error = await createOAuthUsageError(
+      new Response('{"error":{"message":"Invalid token"}}', {
+        status: 401,
+        headers: { 'retry-after': '60' }
+      })
+    )
+    expect(error.status).toBe(401)
+    expect(error.retryAfterMs).toBeNull()
+  })
+})

--- a/src/main/rate-limits/claude-oauth-usage-error.ts
+++ b/src/main/rate-limits/claude-oauth-usage-error.ts
@@ -1,8 +1,12 @@
+// Why: a corrupt/hostile Retry-After must not gate usage refreshes for days.
+const MAX_RETRY_AFTER_MS = 24 * 60 * 60 * 1000
+
 export class OAuthUsageError extends Error {
   constructor(
     message: string,
     readonly status: number,
-    readonly skipPtyFallback: boolean
+    readonly skipPtyFallback: boolean,
+    readonly retryAfterMs: number | null = null
   ) {
     super(message)
   }
@@ -14,8 +18,26 @@ export async function createOAuthUsageError(res: Response): Promise<OAuthUsageEr
     res.status,
     // Why: auth/rate-limit responses are already the user-visible usage API
     // answer. Falling through to /usage can spawn Claude Code needlessly.
-    res.status === 401 || res.status === 403 || res.status === 429
+    res.status === 401 || res.status === 403 || res.status === 429,
+    res.status === 429 ? parseRetryAfterMs(res.headers.get('retry-after')) : null
   )
+}
+
+function parseRetryAfterMs(header: string | null): number | null {
+  if (!header) {
+    return null
+  }
+  const seconds = Number(header)
+  if (Number.isFinite(seconds)) {
+    return seconds > 0 ? Math.min(seconds * 1000, MAX_RETRY_AFTER_MS) : null
+  }
+  // Why: Retry-After may also be an HTTP-date (RFC 9110).
+  const dateMs = Date.parse(header)
+  if (!Number.isFinite(dateMs)) {
+    return null
+  }
+  const delta = dateMs - Date.now()
+  return delta > 0 ? Math.min(delta, MAX_RETRY_AFTER_MS) : null
 }
 
 async function describeOAuthUsageError(res: Response): Promise<string> {

--- a/src/main/rate-limits/claude-usage-window.ts
+++ b/src/main/rate-limits/claude-usage-window.ts
@@ -7,6 +7,7 @@ export type ClaudeUsageWindowInput = {
   resets_at?: string | number
 }
 
+// Why: 1e10 sits between any plausible seconds epoch (<2286) and any millisecond epoch (>2001), so it distinguishes the two units without extra metadata.
 export function parseClaudeUsageResetTimestamp(value: string | number | undefined): number | null {
   if (typeof value === 'number') {
     if (!Number.isFinite(value)) {

--- a/src/main/rate-limits/claude-usage-window.ts
+++ b/src/main/rate-limits/claude-usage-window.ts
@@ -12,6 +12,7 @@ export function parseClaudeUsageResetTimestamp(value: string | number | undefine
     if (!Number.isFinite(value)) {
       return null
     }
+    // Why: 1e10 splits epoch seconds from epoch ms — seconds stay below it until year 2286, ms passed it in 1970.
     return value > 10_000_000_000 ? value : value * 1000
   }
 

--- a/src/main/rate-limits/claude-usage-window.ts
+++ b/src/main/rate-limits/claude-usage-window.ts
@@ -1,0 +1,75 @@
+import type { RateLimitWindow } from '../../shared/rate-limit-types'
+
+// Why: shared by the OAuth usage fetcher and the statusline live feed, whose window payloads share this shape.
+export type ClaudeUsageWindowInput = {
+  utilization?: number
+  used_percentage?: number
+  resets_at?: string | number
+}
+
+export function parseClaudeUsageResetTimestamp(value: string | number | undefined): number | null {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return null
+    }
+    return value > 10_000_000_000 ? value : value * 1000
+  }
+
+  if (!value) {
+    return null
+  }
+
+  const numericValue = Number(value)
+  if (Number.isFinite(numericValue) && value.trim() !== '') {
+    return numericValue > 10_000_000_000 ? numericValue : numericValue * 1000
+  }
+
+  const parsed = new Date(value).getTime()
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+function parseClaudeUsageResetDescription(resetValue: string | number | undefined): string | null {
+  const resetTimestamp = parseClaudeUsageResetTimestamp(resetValue)
+  if (resetTimestamp === null) {
+    return null
+  }
+  try {
+    const date = new Date(resetTimestamp)
+    const now = new Date()
+    const isToday = date.toDateString() === now.toDateString()
+    if (isToday) {
+      return date.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+    }
+    return date.toLocaleDateString(undefined, {
+      weekday: 'short',
+      hour: 'numeric',
+      minute: '2-digit'
+    })
+  } catch {
+    return null
+  }
+}
+
+export function mapClaudeUsageWindow(
+  raw: ClaudeUsageWindowInput | undefined,
+  windowMinutes: number
+): RateLimitWindow | null {
+  if (!raw) {
+    return null
+  }
+  const usedPercent =
+    typeof raw.utilization === 'number'
+      ? raw.utilization
+      : typeof raw.used_percentage === 'number'
+        ? raw.used_percentage
+        : null
+  if (usedPercent === null) {
+    return null
+  }
+  return {
+    usedPercent: Math.min(100, Math.max(0, usedPercent)),
+    windowMinutes,
+    resetsAt: parseClaudeUsageResetTimestamp(raw.resets_at),
+    resetDescription: parseClaudeUsageResetDescription(raw.resets_at)
+  }
+}

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -779,6 +779,140 @@ describe('RateLimitService', () => {
     }
   })
 
+  it('does not roll back a live-session snapshot that arrived while a claude fetch was in flight', async () => {
+    vi.useFakeTimers()
+    try {
+      const parkedClaudeFetch = deferred<ProviderRateLimits>()
+      vi.mocked(fetchClaudeRateLimits)
+        .mockImplementationOnce(async () => okProvider('claude', 18))
+        .mockImplementationOnce(() => parkedClaudeFetch.promise)
+      mockFreshBackgroundProviderFetches()
+
+      const service = new RateLimitService()
+      await service.refresh()
+
+      const secondRefresh = service.refresh()
+      await flushMicrotasks()
+
+      // A live statusline post lands while the second fetch is parked in flight.
+      service.ingestLiveClaudeRateLimits({
+        configDir: null,
+        fiveHour: { used_percentage: 41 },
+        sevenDay: null
+      })
+      expect(service.getState().claude?.session?.usedPercent).toBe(41)
+
+      parkedClaudeFetch.resolve({
+        provider: 'claude',
+        session: null,
+        weekly: null,
+        updatedAt: Date.now(),
+        error: 'boom',
+        status: 'error'
+      })
+      await secondRefresh
+
+      // The failed fetch must not roll the bar back to the pre-cycle snapshot or flip it to error.
+      const claude = service.getState().claude
+      expect(claude?.status).toBe('ok')
+      expect(claude?.session?.usedPercent).toBe(41)
+      expect(claude?.usageMetadata?.source).toBe('live-session')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps a populated weekly bar when a live post carries only the five-hour window', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.mocked(fetchClaudeRateLimits).mockResolvedValue({
+        ...okProvider('claude', 18),
+        weekly: { usedPercent: 62, windowMinutes: 10080, resetsAt: null, resetDescription: null }
+      })
+      mockFreshBackgroundProviderFetches()
+
+      const service = new RateLimitService()
+      await service.refresh()
+      expect(service.getState().claude?.weekly?.usedPercent).toBe(62)
+
+      service.ingestLiveClaudeRateLimits({
+        configDir: null,
+        fiveHour: { used_percentage: 23.5 },
+        sevenDay: null
+      })
+
+      const claude = service.getState().claude
+      expect(claude?.session?.usedPercent).toBe(23.5)
+      expect(claude?.weekly?.usedPercent).toBe(62)
+      expect(claude?.usageMetadata?.source).toBe('live-session')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not restore the outgoing account auth snapshot when the account switches mid-resolve', async () => {
+    vi.useFakeTimers()
+    try {
+      const staleClaudeFetch = deferred<ProviderRateLimits>()
+      vi.mocked(fetchClaudeRateLimits)
+        .mockImplementationOnce(() => staleClaudeFetch.promise)
+        .mockImplementation(async () => okProvider('claude', 18))
+      mockFreshBackgroundProviderFetches()
+
+      const authGate = deferred<void>()
+      let resolverCalls = 0
+      const service = new RateLimitService()
+      service.setClaudeAuthPreparationResolver(async () => {
+        resolverCalls += 1
+        const outgoing = resolverCalls === 1
+        if (outgoing) {
+          await authGate.promise
+        }
+        return {
+          configDir: outgoing ? '/outgoing/.claude' : '/incoming/.claude',
+          runtime: 'host',
+          wslDistro: null,
+          wslLinuxConfigDir: null,
+          envPatch: {
+            CLAUDE_CONFIG_DIR: outgoing ? '/outgoing/.claude' : '/incoming/.claude'
+          },
+          stripAuthEnv: false,
+          provenance: outgoing ? 'managed:outgoing' : 'managed:incoming'
+        }
+      })
+
+      // The first cycle is parked inside the outgoing account's resolver await when the switch lands.
+      const firstRefresh = service.refresh()
+      await flushMicrotasks()
+      const switchPromise = service.refreshForClaudeAccountChange('outgoing-account')
+      await flushMicrotasks()
+      authGate.resolve()
+      await flushMicrotasks(8)
+
+      // The stale cycle resumed after the switch; while its Claude fetch is still in flight,
+      // a live post from the outgoing session must not land on the incoming account's bar.
+      service.ingestLiveClaudeRateLimits({
+        configDir: '/outgoing/.claude',
+        fiveHour: { used_percentage: 99 },
+        sevenDay: null
+      })
+      expect(service.getState().claude?.session?.usedPercent).not.toBe(99)
+
+      staleClaudeFetch.resolve(okProvider('claude', 18))
+      await Promise.all([firstRefresh, switchPromise])
+
+      // The incoming account's own sessions still attribute correctly.
+      service.ingestLiveClaudeRateLimits({
+        configDir: '/incoming/.claude',
+        fiveHour: { used_percentage: 55 },
+        sevenDay: null
+      })
+      expect(service.getState().claude?.session?.usedPercent).toBe(55)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('keeps a settled error chip settled during background refetches instead of flashing fetching', async () => {
     vi.useFakeTimers()
     try {

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -922,12 +922,13 @@ describe('RateLimitService', () => {
 
       // The stale cycle resumed after the switch; while its Claude fetch is still in flight,
       // a live post from the outgoing session must not land on the incoming account's bar.
+      const beforeOutgoingPost = service.getState().claude?.session?.usedPercent
       service.ingestLiveClaudeRateLimits({
         configDir: '/outgoing/.claude',
         fiveHour: { used_percentage: 99 },
         sevenDay: null
       })
-      expect(service.getState().claude?.session?.usedPercent).not.toBe(99)
+      expect(service.getState().claude?.session?.usedPercent).toBe(beforeOutgoingPost)
 
       staleClaudeFetch.resolve(okProvider('claude', 18))
       await Promise.all([firstRefresh, switchPromise])

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -747,6 +747,37 @@ describe('RateLimitService', () => {
     }
   })
 
+  it('keeps the other window when a statusline post carries only one', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 18))
+      mockFreshBackgroundProviderFetches()
+
+      const service = new RateLimitService()
+      await service.refresh()
+
+      service.ingestLiveClaudeRateLimits({
+        configDir: null,
+        fiveHour: { used_percentage: 20 },
+        sevenDay: { used_percentage: 41 }
+      })
+      expect(service.getState().claude?.weekly?.usedPercent).toBe(41)
+
+      // A later post reporting only the 5h window must not wipe the weekly bar.
+      await vi.advanceTimersByTimeAsync(1000)
+      service.ingestLiveClaudeRateLimits({
+        configDir: null,
+        fiveHour: { used_percentage: 25 },
+        sevenDay: null
+      })
+      const claude = service.getState().claude
+      expect(claude?.session?.usedPercent).toBe(25)
+      expect(claude?.weekly?.usedPercent).toBe(41)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('dedupes identical statusline posts within the throttle window', async () => {
     vi.useFakeTimers()
     try {

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -561,6 +561,224 @@ describe('RateLimitService', () => {
     }
   })
 
+  it('waits out Retry-After before automated Claude refetches, then recovers', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.mocked(fetchClaudeRateLimits)
+        .mockImplementationOnce(async () => ({
+          ...errorProvider('claude', 'Claude usage is rate limited right now.'),
+          usageMetadata: { failureKind: 'rate-limited', retryAtMs: Date.now() + 40 * 60 * 1000 }
+        }))
+        .mockImplementation(async () => okProvider('claude', 18))
+      mockFreshBackgroundProviderFetches()
+
+      const service = new RateLimitService()
+      const window = new FakeRateLimitWindow()
+      service.attach(asRateLimitWindow(window))
+      service.start({ fetchImmediately: false })
+
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(fetchClaudeRateLimits).toHaveBeenCalledTimes(1)
+
+      // Activations that would normally retry immediately must respect the server's Retry-After.
+      window.emit('focus')
+      await vi.advanceTimersByTimeAsync(0)
+      expect(fetchClaudeRateLimits).toHaveBeenCalledTimes(1)
+
+      // The 15- and 30-minute poll cycles land inside the 40-minute window: other providers refresh, Claude is skipped.
+      await vi.advanceTimersByTimeAsync(15 * 60 * 1000)
+      expect(vi.mocked(fetchCodexRateLimits).mock.calls.length).toBeGreaterThan(1)
+      expect(fetchClaudeRateLimits).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(15 * 60 * 1000)
+      expect(fetchClaudeRateLimits).toHaveBeenCalledTimes(1)
+
+      // The 45-minute poll cycle is past the window and refetches Claude.
+      await vi.advanceTimersByTimeAsync(15 * 60 * 1000)
+      expect(fetchClaudeRateLimits).toHaveBeenCalledTimes(2)
+      expect(service.getState().claude?.status).toBe('ok')
+
+      service.stop()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('lets a user-directed refresh bypass the Claude Retry-After gate', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.mocked(fetchClaudeRateLimits)
+        .mockImplementationOnce(async () => ({
+          ...errorProvider('claude', 'Claude usage is rate limited right now.'),
+          usageMetadata: { failureKind: 'rate-limited', retryAtMs: Date.now() + 40 * 60 * 1000 }
+        }))
+        .mockImplementation(async () => okProvider('claude', 18))
+      mockFreshBackgroundProviderFetches()
+
+      const service = new RateLimitService()
+
+      await service.refresh()
+      expect(fetchClaudeRateLimits).toHaveBeenCalledTimes(1)
+      expect(service.getState().claude?.status).toBe('error')
+
+      await service.refresh()
+      expect(fetchClaudeRateLimits).toHaveBeenCalledTimes(2)
+      expect(service.getState().claude?.status).toBe('ok')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps last-known usage through a rate-limited window past the generic stale threshold', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.mocked(fetchClaudeRateLimits)
+        .mockImplementationOnce(async () => okProvider('claude', 18))
+        .mockImplementation(async () => ({
+          ...errorProvider('claude', 'Claude usage is rate limited right now.'),
+          usageMetadata: { failureKind: 'rate-limited' }
+        }))
+      mockFreshBackgroundProviderFetches()
+
+      const service = new RateLimitService()
+
+      await service.refresh()
+      expect(service.getState().claude?.status).toBe('ok')
+
+      // 31 minutes later the generic 30-minute stale policy would drop the snapshot; rate-limited failures keep it.
+      await vi.advanceTimersByTimeAsync(31 * 60 * 1000)
+      await service.refresh()
+
+      const claude = service.getState().claude
+      expect(claude?.status).toBe('error')
+      expect(claude?.error).toBe('Claude usage is rate limited right now.')
+      expect(claude?.session?.usedPercent).toBe(18)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ingests statusline usage, clears errors, and skips OAuth polls while the live feed is fresh', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.mocked(fetchClaudeRateLimits).mockImplementation(async () => ({
+        ...errorProvider('claude', 'Claude usage is rate limited right now.'),
+        usageMetadata: { failureKind: 'rate-limited' }
+      }))
+      mockFreshBackgroundProviderFetches()
+
+      const service = new RateLimitService()
+      const window = new FakeRateLimitWindow()
+      service.attach(asRateLimitWindow(window))
+      service.start({ fetchImmediately: false })
+
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(fetchClaudeRateLimits).toHaveBeenCalledTimes(1)
+      expect(service.getState().claude?.status).toBe('error')
+
+      // A live session reports usage 12 minutes in; the error state clears without any OAuth call.
+      await vi.advanceTimersByTimeAsync(12 * 60 * 1000 - 1000)
+      service.ingestLiveClaudeRateLimits({
+        configDir: null,
+        fiveHour: { used_percentage: 23.5, resets_at: Math.floor(Date.now() / 1000) + 3600 },
+        sevenDay: { used_percentage: 41.2 }
+      })
+
+      const claude = service.getState().claude
+      expect(claude?.status).toBe('ok')
+      expect(claude?.error).toBeNull()
+      expect(claude?.session?.usedPercent).toBe(23.5)
+      expect(claude?.weekly?.usedPercent).toBe(41.2)
+      expect(claude?.usageMetadata?.source).toBe('live-session')
+
+      // The 15-minute poll cycle lands inside the live-feed freshness window: other providers refresh, Claude's OAuth fetch is skipped.
+      const codexCallsBeforePoll = vi.mocked(fetchCodexRateLimits).mock.calls.length
+      await vi.advanceTimersByTimeAsync(3 * 60 * 1000)
+      expect(vi.mocked(fetchCodexRateLimits).mock.calls.length).toBeGreaterThan(
+        codexCallsBeforePoll
+      )
+      expect(fetchClaudeRateLimits).toHaveBeenCalledTimes(1)
+
+      // Once the live feed goes stale, automated refetches resume.
+      await vi.advanceTimersByTimeAsync(15 * 60 * 1000)
+      expect(vi.mocked(fetchClaudeRateLimits).mock.calls.length).toBeGreaterThan(1)
+
+      service.stop()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('drops statusline posts before attribution is known or from a mismatched config dir', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 18))
+      mockFreshBackgroundProviderFetches()
+
+      const service = new RateLimitService()
+
+      // No fetch cycle has captured the selected account's config dir yet.
+      service.ingestLiveClaudeRateLimits({
+        configDir: null,
+        fiveHour: { used_percentage: 50 },
+        sevenDay: null
+      })
+      expect(service.getState().claude).toBeNull()
+
+      await service.refresh()
+      expect(service.getState().claude?.session?.usedPercent).toBe(18)
+
+      // A managed-account session must not overwrite the system-default bar.
+      service.ingestLiveClaudeRateLimits({
+        configDir: '/some/managed/dir',
+        fiveHour: { used_percentage: 99 },
+        sevenDay: null
+      })
+      expect(service.getState().claude?.session?.usedPercent).toBe(18)
+
+      service.ingestLiveClaudeRateLimits({
+        configDir: null,
+        fiveHour: { used_percentage: 33 },
+        sevenDay: null
+      })
+      expect(service.getState().claude?.session?.usedPercent).toBe(33)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('dedupes identical statusline posts within the throttle window', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 18))
+      mockFreshBackgroundProviderFetches()
+
+      const service = new RateLimitService()
+      await service.refresh()
+
+      const event = {
+        configDir: null,
+        fiveHour: { used_percentage: 20, resets_at: 1738425600 },
+        sevenDay: null
+      }
+      service.ingestLiveClaudeRateLimits(event)
+      const firstUpdatedAt = service.getState().claude?.updatedAt
+
+      await vi.advanceTimersByTimeAsync(1000)
+      service.ingestLiveClaudeRateLimits(event)
+      expect(service.getState().claude?.updatedAt).toBe(firstUpdatedAt)
+
+      // A changed window updates immediately despite the throttle.
+      service.ingestLiveClaudeRateLimits({
+        ...event,
+        fiveHour: { used_percentage: 21, resets_at: 1738425600 }
+      })
+      expect(service.getState().claude?.session?.usedPercent).toBe(21)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('keeps a settled error chip settled during background refetches instead of flashing fetching', async () => {
     vi.useFakeTimers()
     try {

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -9,6 +9,8 @@ import type {
 } from '../../shared/rate-limit-types'
 import { fetchClaudeRateLimits, fetchManagedAccountUsage } from './claude-fetcher'
 import type { InactiveClaudeAccountInfo } from './claude-fetcher'
+import { mapClaudeUsageWindow } from './claude-usage-window'
+import type { ClaudeStatusLineRateLimits } from '../../shared/claude-statusline-rate-limits'
 import { consumeCodexRateLimitResetCredit, fetchCodexRateLimits } from './codex-fetcher'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
 import type { NetworkProxySettings } from '../../shared/network-proxy'
@@ -83,6 +85,10 @@ const INDIVIDUALLY_REFRESHABLE_PROVIDERS: ReadonlySet<ActiveRateLimitProvider> =
   'grok'
 ])
 const STALE_THRESHOLD_MS = 30 * 60 * 1000 // 30 minutes — after this, stale data is dropped
+// Why: usage-endpoint 429 windows can outlast the generic threshold (Retry-After ~1h); quota is informational, so a stale snapshot beats a bare "Limited".
+const RATE_LIMITED_STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000
+// Why: statusline posts arrive on every turn; skip renderer pushes for identical windows so streaming sessions don't spam state updates.
+const LIVE_CLAUDE_INGEST_DEDUPE_MS = 30 * 1000
 const INACTIVE_FETCH_DEBOUNCE_MS = 60 * 1000 // 60 seconds — debounce fetch-on-open
 const DEFERRED_STARTUP_ACTIVE_REFRESH_MS = 1000
 
@@ -118,6 +124,21 @@ function isSystemDefaultClaudeAuth(
 
 function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
+}
+
+function normalizeClaudeConfigDir(dir: string | null | undefined): string | null {
+  const trimmed = dir?.trim().replace(/[/\\]+$/, '')
+  return trimmed || null
+}
+
+function isSameUsageWindow(
+  a: ProviderRateLimits['session'],
+  b: ProviderRateLimits['session']
+): boolean {
+  if (!a || !b) {
+    return a === b
+  }
+  return a.usedPercent === b.usedPercent && a.resetsAt === b.resetsAt
 }
 
 export class RateLimitService {
@@ -168,6 +189,8 @@ export class RateLimitService {
   private fetchIdleResolvers: (() => void)[] = []
   private codexFetchGeneration = 0
   private claudeFetchGeneration = 0
+  // Why: statusline ingest must attribute live windows to the selected account without re-running the side-effectful auth sync per post.
+  private lastClaudeAuthSnapshot: { configDir: string | null; provenance: string } | null = null
   private opencodeFetchGeneration = 0
   private minimaxFetchGeneration = 0
   private lastOpencodeConfigHash = ''
@@ -433,6 +456,8 @@ export class RateLimitService {
     this.claudeFetchGeneration += 1
     // Why: a new account/target starts with a clean retry schedule.
     this.activeFailureStreakByProvider.claude = 0
+    // Why: statusline posts from the outgoing account's sessions must not land on the incoming account's bar mid-switch.
+    this.lastClaudeAuthSnapshot = null
     this.lastInactiveClaudeFetchAt = 0
     this.updateState({
       ...this.state,
@@ -448,6 +473,10 @@ export class RateLimitService {
     this.claudeFetchTarget = nextTarget
     this.claudeFetchGeneration += 1
     this.activeFailureStreakByProvider.claude = 0
+    if (targetChanged) {
+      // Why: statusline posts from the outgoing target's sessions must not land on the incoming target's bar mid-switch.
+      this.lastClaudeAuthSnapshot = null
+    }
     this.updateState({
       ...this.state,
       claude: this.withFetchingStatus(targetChanged ? null : this.state.claude, 'claude')
@@ -758,6 +787,10 @@ export class RateLimitService {
       }
       // Why: a failed startup read is not fresh data; keep it eligible for activation recovery, throttled per provider.
       if (limits.status === 'error') {
+        // Why: the server told us when to come back (Retry-After); retrying earlier burns the endpoint's budget and keeps the 429 alive.
+        if (this.isRetryAfterActive(limits)) {
+          continue
+        }
         const lastRetryAt = this.lastActiveFailureRetryAtByProvider[provider]
         const throttleMs = INDIVIDUALLY_REFRESHABLE_PROVIDERS.has(provider)
           ? Math.min(
@@ -847,11 +880,14 @@ export class RateLimitService {
 
     try {
       let shouldContinue = true
+      // Why: only user-directed (force) fetches may bypass a provider's Retry-After gate; queued reruns inherit force because only forced calls queue them.
+      let cycleForce = options?.force ?? false
       while (shouldContinue) {
         const signal = await this.runWithFetchAbortSignal((fetchSignal) =>
-          this.runFetchAllCycle(fetchSignal)
+          this.runFetchAllCycle(fetchSignal, { force: cycleForce })
         )
         shouldContinue = false
+        cycleForce = true
         if (signal.aborted) {
           break
         }
@@ -872,7 +908,7 @@ export class RateLimitService {
         if (this.claudeOnlyFetchQueued) {
           this.claudeOnlyFetchQueued = false
           const claudeSignal = await this.runWithFetchAbortSignal((fetchSignal) =>
-            this.runFetchClaudeOnlyCycle(fetchSignal)
+            this.runFetchClaudeOnlyCycle(fetchSignal, { force: true })
           )
           if (claudeSignal.aborted) {
             break
@@ -917,7 +953,7 @@ export class RateLimitService {
         if (this.fullFetchQueued) {
           this.fullFetchQueued = false
           const fullSignal = await this.runWithFetchAbortSignal((fetchSignal) =>
-            this.runFetchAllCycle(fetchSignal)
+            this.runFetchAllCycle(fetchSignal, { force: true })
           )
           if (fullSignal.aborted) {
             break
@@ -931,7 +967,7 @@ export class RateLimitService {
         if (this.claudeOnlyFetchQueued) {
           this.claudeOnlyFetchQueued = false
           const claudeSignal = await this.runWithFetchAbortSignal((fetchSignal) =>
-            this.runFetchClaudeOnlyCycle(fetchSignal)
+            this.runFetchClaudeOnlyCycle(fetchSignal, { force: true })
           )
           if (claudeSignal.aborted) {
             break
@@ -965,18 +1001,21 @@ export class RateLimitService {
 
     try {
       let shouldContinue = true
+      // Why: only user-directed (force) fetches may bypass a provider's Retry-After gate; queued reruns inherit force because only forced calls queue them.
+      let cycleForce = options?.force ?? false
       while (shouldContinue) {
         const signal = await this.runWithFetchAbortSignal((fetchSignal) =>
-          this.runFetchClaudeOnlyCycle(fetchSignal)
+          this.runFetchClaudeOnlyCycle(fetchSignal, { force: cycleForce })
         )
         shouldContinue = false
+        cycleForce = true
         if (signal.aborted) {
           break
         }
         if (this.fullFetchQueued) {
           this.fullFetchQueued = false
           const fullSignal = await this.runWithFetchAbortSignal((fetchSignal) =>
-            this.runFetchAllCycle(fetchSignal)
+            this.runFetchAllCycle(fetchSignal, { force: true })
           )
           if (fullSignal.aborted) {
             break
@@ -1035,7 +1074,7 @@ export class RateLimitService {
         if (this.fullFetchQueued) {
           this.fullFetchQueued = false
           const fullSignal = await this.runWithFetchAbortSignal((fetchSignal) =>
-            this.runFetchAllCycle(fetchSignal)
+            this.runFetchAllCycle(fetchSignal, { force: true })
           )
           if (fullSignal.aborted) {
             break
@@ -1058,7 +1097,7 @@ export class RateLimitService {
         if (this.claudeOnlyFetchQueued) {
           this.claudeOnlyFetchQueued = false
           const claudeSignal = await this.runWithFetchAbortSignal((fetchSignal) =>
-            this.runFetchClaudeOnlyCycle(fetchSignal)
+            this.runFetchClaudeOnlyCycle(fetchSignal, { force: true })
           )
           if (claudeSignal.aborted) {
             break
@@ -1242,6 +1281,85 @@ export class RateLimitService {
     }
   }
 
+  // Why: hitting a usage endpoint before its Retry-After expires burns the budget for nothing and keeps the 429 window alive.
+  private isRetryAfterActive(limits: ProviderRateLimits | null): boolean {
+    return Boolean(
+      limits?.status === 'error' &&
+      limits.usageMetadata?.retryAtMs &&
+      limits.usageMetadata.retryAtMs > Date.now()
+    )
+  }
+
+  // Why: a live Claude session already streams fresh usage windows; spending the OAuth usage endpoint's tight budget on the same data invites 429s.
+  private isLiveClaudeUsageFresh(limits: ProviderRateLimits | null): boolean {
+    return Boolean(
+      limits?.status === 'ok' &&
+      limits.usageMetadata?.source === 'live-session' &&
+      Date.now() - limits.updatedAt < MIN_REFETCH_MS
+    )
+  }
+
+  private shouldSkipAutomatedClaudeFetch(limits: ProviderRateLimits | null): boolean {
+    return this.isRetryAfterActive(limits) || this.isLiveClaudeUsageFresh(limits)
+  }
+
+  private rememberClaudeAuthSnapshot(
+    authPreparation: ClaudeRuntimeAuthPreparation | undefined
+  ): void {
+    this.lastClaudeAuthSnapshot = {
+      configDir: normalizeClaudeConfigDir(authPreparation?.envPatch.CLAUDE_CONFIG_DIR),
+      provenance: authPreparation?.provenance ?? 'system'
+    }
+  }
+
+  /** Live usage windows forwarded from a Claude session's statusLine command. */
+  ingestLiveClaudeRateLimits(event: ClaudeStatusLineRateLimits): void {
+    // Why: attribution needs the selected account's config dir; until a fetch cycle captures it, drop posts rather than guess the account.
+    const snapshot = this.lastClaudeAuthSnapshot
+    if (!snapshot) {
+      return
+    }
+    // Why: sessions of other accounts (or other runtimes) report their own quota; mixing them into the active account's bar would lie.
+    if (normalizeClaudeConfigDir(event.configDir) !== snapshot.configDir) {
+      return
+    }
+    const session = mapClaudeUsageWindow(event.fiveHour ?? undefined, 300)
+    const weekly = mapClaudeUsageWindow(event.sevenDay ?? undefined, 10080)
+    if (!session && !weekly) {
+      return
+    }
+    const previous = this.state.claude
+    if (
+      previous?.status === 'ok' &&
+      previous.usageMetadata?.source === 'live-session' &&
+      Date.now() - previous.updatedAt < LIVE_CLAUDE_INGEST_DEDUPE_MS &&
+      isSameUsageWindow(previous.session, session) &&
+      isSameUsageWindow(previous.weekly, weekly)
+    ) {
+      return
+    }
+    this.activeFailureStreakByProvider.claude = 0
+    this.updateState({
+      ...this.state,
+      claude: {
+        provider: 'claude',
+        session,
+        weekly,
+        // Why: the statusline payload has no Fable scoped window; keep the last OAuth-provided one visible.
+        fableWeekly: previous?.fableWeekly ?? null,
+        updatedAt: Date.now(),
+        error: null,
+        status: 'ok',
+        usageMetadata: {
+          source: 'live-session',
+          lastSuccessfulSource: 'live-session',
+          credentialSource: previous?.usageMetadata?.credentialSource,
+          authProvenance: snapshot.provenance
+        }
+      }
+    })
+  }
+
   private trackActiveFailureStreak(
     provider: ActiveRateLimitProvider,
     fresh: ProviderRateLimits
@@ -1287,7 +1405,10 @@ export class RateLimitService {
     return { ...current, status: 'fetching' }
   }
 
-  private async runFetchAllCycle(signal: AbortSignal): Promise<void> {
+  private async runFetchAllCycle(
+    signal: AbortSignal,
+    options?: { force?: boolean }
+  ): Promise<void> {
     if (signal.aborted) {
       return
     }
@@ -1296,6 +1417,7 @@ export class RateLimitService {
     if (signal.aborted) {
       return
     }
+    this.rememberClaudeAuthSnapshot(claudeAuthPreparation)
     const claudeProvenance = claudeAuthPreparation?.provenance ?? 'system'
     const claudeGeneration = this.claudeFetchGeneration
     const codexTarget = this.codexFetchTarget
@@ -1360,15 +1482,21 @@ export class RateLimitService {
       (reason) => ({ status: 'rejected', reason }) as const
     )
 
+    // Why: skip automated Claude fetches while a Retry-After window is open or a live session feed is fresher than the OAuth poll would be.
+    const claudeFetchGated =
+      !options?.force && this.shouldSkipAutomatedClaudeFetch(previousState.claude)
+
     const [claudeResult, codexResult, geminiResult, opencodeGoResult, kimiResult, miniMaxResult] =
       await Promise.allSettled([
-        fetchClaudeRateLimits({
-          authPreparation: claudeAuthPreparation,
-          allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation),
-          allowUsagePanelSupplement: this.shouldAllowClaudeUsagePanelSupplement(),
-          networkProxySettings: this.networkProxySettingsResolver?.(),
-          signal
-        }),
+        claudeFetchGated
+          ? Promise.resolve(previousState.claude as ProviderRateLimits)
+          : fetchClaudeRateLimits({
+              authPreparation: claudeAuthPreparation,
+              allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation),
+              allowUsagePanelSupplement: this.shouldAllowClaudeUsagePanelSupplement(),
+              networkProxySettings: this.networkProxySettingsResolver?.(),
+              signal
+            }),
         missingWslCodexHome ??
           fetchCodexRateLimits({
             codexHomePath,
@@ -1488,7 +1616,9 @@ export class RateLimitService {
     const latestCodexProvenance = this.getCodexProvenance(codexTarget, latestCodexHomePath)
     const shouldApplyCodex =
       codexGeneration === this.codexFetchGeneration && codexProvenance === latestCodexProvenance
+    // Why: a gated cycle made no Claude attempt; applying its passthrough result would grow the failure streak and reset stale-policy clocks for free.
     const shouldApplyClaude =
+      !claudeFetchGated &&
       claudeGeneration === this.claudeFetchGeneration &&
       claudeProvenance === latestClaudeProvenance &&
       this.isSameClaudeTarget(claudeTarget, this.claudeFetchTarget)
@@ -1612,8 +1742,15 @@ export class RateLimitService {
     })
   }
 
-  private async runFetchClaudeOnlyCycle(signal: AbortSignal): Promise<void> {
+  private async runFetchClaudeOnlyCycle(
+    signal: AbortSignal,
+    options?: { force?: boolean }
+  ): Promise<void> {
     if (signal.aborted) {
+      return
+    }
+    // Why: skip automated Claude fetches while a Retry-After window is open or a live session feed is fresher than the OAuth poll would be.
+    if (!options?.force && this.shouldSkipAutomatedClaudeFetch(this.state.claude)) {
       return
     }
     const claudeTarget = this.claudeFetchTarget
@@ -1621,6 +1758,7 @@ export class RateLimitService {
     if (signal.aborted) {
       return
     }
+    this.rememberClaudeAuthSnapshot(claudeAuthPreparation)
     const claudeProvenance = claudeAuthPreparation?.provenance ?? 'system'
     const claudeGeneration = this.claudeFetchGeneration
     const previousState = this.state
@@ -1745,7 +1883,11 @@ export class RateLimitService {
     }
 
     // Previous data is too old — don't show stale data
-    if (Date.now() - previous.updatedAt > STALE_THRESHOLD_MS) {
+    const staleThresholdMs =
+      fresh.usageMetadata?.failureKind === 'rate-limited'
+        ? RATE_LIMITED_STALE_THRESHOLD_MS
+        : STALE_THRESHOLD_MS
+    if (Date.now() - previous.updatedAt > staleThresholdMs) {
       return fresh
     }
 

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -127,7 +127,8 @@ function toErrorMessage(error: unknown): string {
 }
 
 function normalizeClaudeConfigDir(dir: string | null | undefined): string | null {
-  const trimmed = dir?.trim().replace(/[/\\]+$/, '')
+  // Why: the same dir can arrive with mixed separators (Windows env vs statusline JSON); unify them so attribution compares paths, not spellings. Case is left alone — Linux paths are case-sensitive.
+  const trimmed = dir?.trim().replace(/\\/g, '/').replace(/\/+$/, '')
   return trimmed || null
 }
 
@@ -1303,9 +1304,31 @@ export class RateLimitService {
     return this.isRetryAfterActive(limits) || this.isLiveClaudeUsageFresh(limits)
   }
 
+  private resolveClaudeFetchApply(
+    fresh: ProviderRateLimits,
+    previous: ProviderRateLimits | null
+  ): ProviderRateLimits {
+    // Why: a live statusline post can land while an OAuth cycle is in flight; a failed fetch must not
+    // roll the bar back to the pre-cycle snapshot or flip the just-refreshed live data to error.
+    const current = this.state.claude
+    if (fresh.status !== 'ok' && current && this.isLiveClaudeUsageFresh(current)) {
+      return current
+    }
+    return this.applyStalePolicy(fresh, previous)
+  }
+
   private rememberClaudeAuthSnapshot(
-    authPreparation: ClaudeRuntimeAuthPreparation | undefined
+    authPreparation: ClaudeRuntimeAuthPreparation | undefined,
+    claudeGeneration: number,
+    claudeTarget: NormalizedClaudeAccountSelectionTarget
   ): void {
+    // Why: an account switch during the resolver await already cleared the snapshot; restoring the outgoing account's configDir here would cross-attribute its live posts to the new bar.
+    if (
+      claudeGeneration !== this.claudeFetchGeneration ||
+      !this.isSameClaudeTarget(claudeTarget, this.claudeFetchTarget)
+    ) {
+      return
+    }
     this.lastClaudeAuthSnapshot = {
       configDir: normalizeClaudeConfigDir(authPreparation?.envPatch.CLAUDE_CONFIG_DIR),
       provenance: authPreparation?.provenance ?? 'system'
@@ -1317,18 +1340,29 @@ export class RateLimitService {
     // Why: attribution needs the selected account's config dir; until a fetch cycle captures it, drop posts rather than guess the account.
     const snapshot = this.lastClaudeAuthSnapshot
     if (!snapshot) {
+      // Why: breadcrumbs make a silently dark live feed diagnosable — dropped posts are otherwise invisible.
+      console.debug('[rate-limits] dropped live Claude usage: no auth snapshot yet', {
+        eventConfigDir: event.configDir
+      })
       return
     }
     // Why: sessions of other accounts (or other runtimes) report their own quota; mixing them into the active account's bar would lie.
     if (normalizeClaudeConfigDir(event.configDir) !== snapshot.configDir) {
+      console.debug('[rate-limits] dropped live Claude usage: configDir mismatch', {
+        eventConfigDir: event.configDir,
+        snapshotConfigDir: snapshot.configDir
+      })
       return
     }
-    const session = mapClaudeUsageWindow(event.fiveHour ?? undefined, 300)
-    const weekly = mapClaudeUsageWindow(event.sevenDay ?? undefined, 10080)
-    if (!session && !weekly) {
+    const freshSession = mapClaudeUsageWindow(event.fiveHour ?? undefined, 300)
+    const freshWeekly = mapClaudeUsageWindow(event.sevenDay ?? undefined, 10080)
+    if (!freshSession && !freshWeekly) {
       return
     }
     const previous = this.state.claude
+    // Why: statusline payloads can carry a single window; an absent one means "no update", not "cleared" — keep the other bar populated.
+    const session = freshSession ?? previous?.session ?? null
+    const weekly = freshWeekly ?? previous?.weekly ?? null
     if (
       previous?.status === 'ok' &&
       previous.usageMetadata?.source === 'live-session' &&
@@ -1346,6 +1380,7 @@ export class RateLimitService {
         session,
         weekly,
         // Why: the statusline payload has no Fable scoped window; keep the last OAuth-provided one visible.
+        // Tradeoff: while live posts keep the OAuth poll gated, fableWeekly stays frozen until the session idles past the freshness window.
         fableWeekly: previous?.fableWeekly ?? null,
         updatedAt: Date.now(),
         error: null,
@@ -1413,13 +1448,14 @@ export class RateLimitService {
       return
     }
     const claudeTarget = this.claudeFetchTarget
+    // Why: capture before the resolver await so an account switch during it invalidates both the snapshot and the state apply.
+    const claudeGeneration = this.claudeFetchGeneration
     const claudeAuthPreparation = await this.claudeAuthPreparationResolver?.(claudeTarget)
     if (signal.aborted) {
       return
     }
-    this.rememberClaudeAuthSnapshot(claudeAuthPreparation)
+    this.rememberClaudeAuthSnapshot(claudeAuthPreparation, claudeGeneration, claudeTarget)
     const claudeProvenance = claudeAuthPreparation?.provenance ?? 'system'
-    const claudeGeneration = this.claudeFetchGeneration
     const codexTarget = this.codexFetchTarget
     const codexHomePath = this.codexHomePathResolver?.(codexTarget) ?? null
     const codexProvenance = this.getCodexProvenance(codexTarget, codexHomePath)
@@ -1645,7 +1681,7 @@ export class RateLimitService {
     this.updateState({
       ...this.state,
       claude: shouldApplyClaude
-        ? this.applyStalePolicy(claude, previousState.claude)
+        ? this.resolveClaudeFetchApply(claude, previousState.claude)
         : this.state.claude,
       codex: shouldApplyCodex
         ? this.applyStalePolicy(codex, previousState.codex)
@@ -1754,13 +1790,14 @@ export class RateLimitService {
       return
     }
     const claudeTarget = this.claudeFetchTarget
+    // Why: capture before the resolver await so an account switch during it invalidates both the snapshot and the state apply.
+    const claudeGeneration = this.claudeFetchGeneration
     const claudeAuthPreparation = await this.claudeAuthPreparationResolver?.(claudeTarget)
     if (signal.aborted) {
       return
     }
-    this.rememberClaudeAuthSnapshot(claudeAuthPreparation)
+    this.rememberClaudeAuthSnapshot(claudeAuthPreparation, claudeGeneration, claudeTarget)
     const claudeProvenance = claudeAuthPreparation?.provenance ?? 'system'
-    const claudeGeneration = this.claudeFetchGeneration
     const previousState = this.state
 
     this.updateState({
@@ -1805,7 +1842,7 @@ export class RateLimitService {
     this.updateState({
       ...this.state,
       claude: shouldApplyClaude
-        ? this.applyStalePolicy(claude, previousState.claude)
+        ? this.resolveClaudeFetchApply(claude, previousState.claude)
         : this.state.claude
     })
   }

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -1323,12 +1323,15 @@ export class RateLimitService {
     if (normalizeClaudeConfigDir(event.configDir) !== snapshot.configDir) {
       return
     }
-    const session = mapClaudeUsageWindow(event.fiveHour ?? undefined, 300)
-    const weekly = mapClaudeUsageWindow(event.sevenDay ?? undefined, 10080)
+    const previous = this.state.claude
+    // Why: statusline posts may carry only one window; fall back to the last-known value instead of wiping the other bar to null.
+    const session =
+      mapClaudeUsageWindow(event.fiveHour ?? undefined, 300) ?? previous?.session ?? null
+    const weekly =
+      mapClaudeUsageWindow(event.sevenDay ?? undefined, 10080) ?? previous?.weekly ?? null
     if (!session && !weekly) {
       return
     }
-    const previous = this.state.claude
     if (
       previous?.status === 'ok' &&
       previous.usageMetadata?.source === 'live-session' &&

--- a/src/shared/claude-statusline-rate-limits.test.ts
+++ b/src/shared/claude-statusline-rate-limits.test.ts
@@ -37,6 +37,33 @@ describe('parseClaudeStatusLineBody', () => {
     expect(parsed?.sevenDay).toBeNull()
   })
 
+  it('passes through a string resets_at so schema drift degrades gracefully', () => {
+    const parsed = parseClaudeStatusLineBody(
+      formBody({
+        rate_limits: {
+          five_hour: { used_percentage: 12, resets_at: '2026-07-20T10:00:00Z' },
+          seven_day: { used_percentage: 3, resets_at: '   ' }
+        }
+      })
+    )
+    expect(parsed?.fiveHour).toEqual({ used_percentage: 12, resets_at: '2026-07-20T10:00:00Z' })
+    expect(parsed?.sevenDay).toEqual({ used_percentage: 3, resets_at: undefined })
+  })
+
+  it('falls back to the OAuth-shaped utilization field so schema drift degrades gracefully', () => {
+    const parsed = parseClaudeStatusLineBody(
+      formBody({
+        rate_limits: {
+          five_hour: { utilization: 37, resets_at: 1_750_000_000 },
+          seven_day: { used_percentage: 8, utilization: 99 }
+        }
+      })
+    )
+    expect(parsed?.fiveHour).toEqual({ utilization: 37, resets_at: 1_750_000_000 })
+    // used_percentage wins when both are present — it is the documented statusline field.
+    expect(parsed?.sevenDay).toEqual({ used_percentage: 8, resets_at: undefined })
+  })
+
   it('returns null when rate_limits is absent or empty', () => {
     expect(
       parseClaudeStatusLineBody(formBody({ context_window: { used_percentage: 8 } }))

--- a/src/shared/claude-statusline-rate-limits.test.ts
+++ b/src/shared/claude-statusline-rate-limits.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { parseClaudeStatusLineBody } from './claude-statusline-rate-limits'
+
+function formBody(payload: unknown, configDir?: string): Record<string, string> {
+  return {
+    payload: JSON.stringify(payload),
+    ...(configDir !== undefined ? { configDir } : {})
+  }
+}
+
+describe('parseClaudeStatusLineBody', () => {
+  it('extracts both windows and the session config dir', () => {
+    const parsed = parseClaudeStatusLineBody(
+      formBody(
+        {
+          rate_limits: {
+            five_hour: { used_percentage: 23.5, resets_at: 1738425600 },
+            seven_day: { used_percentage: 41.2, resets_at: 1712059200 }
+          }
+        },
+        '/home/dev/.config/managed-claude'
+      )
+    )
+    expect(parsed).toEqual({
+      configDir: '/home/dev/.config/managed-claude',
+      fiveHour: { used_percentage: 23.5, resets_at: 1738425600 },
+      sevenDay: { used_percentage: 41.2, resets_at: 1712059200 }
+    })
+  })
+
+  it('treats a missing/empty configDir as a system-default session', () => {
+    const parsed = parseClaudeStatusLineBody(
+      formBody({ rate_limits: { five_hour: { used_percentage: 5 } } }, '')
+    )
+    expect(parsed?.configDir).toBeNull()
+    expect(parsed?.fiveHour).toEqual({ used_percentage: 5, resets_at: undefined })
+    expect(parsed?.sevenDay).toBeNull()
+  })
+
+  it('returns null when rate_limits is absent or empty', () => {
+    expect(
+      parseClaudeStatusLineBody(formBody({ context_window: { used_percentage: 8 } }))
+    ).toBeNull()
+    expect(parseClaudeStatusLineBody(formBody({ rate_limits: {} }))).toBeNull()
+    expect(parseClaudeStatusLineBody(formBody({ rate_limits: null }))).toBeNull()
+  })
+
+  it('rejects malformed bodies without throwing', () => {
+    expect(parseClaudeStatusLineBody(null)).toBeNull()
+    expect(parseClaudeStatusLineBody('raw string')).toBeNull()
+    expect(parseClaudeStatusLineBody({ payload: 'not json' })).toBeNull()
+    expect(parseClaudeStatusLineBody({ payload: '"just a string"' })).toBeNull()
+    expect(
+      parseClaudeStatusLineBody(
+        formBody({ rate_limits: { five_hour: { used_percentage: 'NaN' } } })
+      )
+    ).toBeNull()
+  })
+})

--- a/src/shared/claude-statusline-rate-limits.ts
+++ b/src/shared/claude-statusline-rate-limits.ts
@@ -1,0 +1,69 @@
+// Why: Claude Code (>=2.1.80) pipes `rate_limits` to the statusLine command on every
+// turn — piggybacked on Messages API responses, so reading it costs no usage-endpoint
+// budget (the endpoint 429s under Orca's polling; see rate-limits/service.ts).
+
+export const CLAUDE_STATUSLINE_PATHNAME = '/statusline/claude'
+
+export type ClaudeStatusLineWindow = {
+  used_percentage: number
+  /** Unix epoch seconds when the window resets, if known. */
+  resets_at?: number
+}
+
+export type ClaudeStatusLineRateLimits = {
+  /** CLAUDE_CONFIG_DIR of the reporting session; null for system-default sessions. */
+  configDir: string | null
+  fiveHour: ClaudeStatusLineWindow | null
+  sevenDay: ClaudeStatusLineWindow | null
+}
+
+function parseWindow(value: unknown): ClaudeStatusLineWindow | null {
+  if (typeof value !== 'object' || value === null) {
+    return null
+  }
+  const raw = value as { used_percentage?: unknown; resets_at?: unknown }
+  if (typeof raw.used_percentage !== 'number' || !Number.isFinite(raw.used_percentage)) {
+    return null
+  }
+  return {
+    used_percentage: raw.used_percentage,
+    resets_at:
+      typeof raw.resets_at === 'number' && Number.isFinite(raw.resets_at)
+        ? raw.resets_at
+        : undefined
+  }
+}
+
+/**
+ * Parses the form-encoded body posted by the managed Claude statusline script.
+ * Returns null when the payload carries no usable rate-limit windows.
+ */
+export function parseClaudeStatusLineBody(body: unknown): ClaudeStatusLineRateLimits | null {
+  if (typeof body !== 'object' || body === null) {
+    return null
+  }
+  const fields = body as { payload?: unknown; configDir?: unknown }
+  if (typeof fields.payload !== 'string' || !fields.payload) {
+    return null
+  }
+  let payload: unknown
+  try {
+    payload = JSON.parse(fields.payload)
+  } catch {
+    return null
+  }
+  if (typeof payload !== 'object' || payload === null) {
+    return null
+  }
+  const rateLimits = (payload as { rate_limits?: unknown }).rate_limits
+  if (typeof rateLimits !== 'object' || rateLimits === null) {
+    return null
+  }
+  const fiveHour = parseWindow((rateLimits as { five_hour?: unknown }).five_hour)
+  const sevenDay = parseWindow((rateLimits as { seven_day?: unknown }).seven_day)
+  if (!fiveHour && !sevenDay) {
+    return null
+  }
+  const configDir = typeof fields.configDir === 'string' ? fields.configDir.trim() : ''
+  return { configDir: configDir || null, fiveHour, sevenDay }
+}

--- a/src/shared/claude-statusline-rate-limits.ts
+++ b/src/shared/claude-statusline-rate-limits.ts
@@ -5,9 +5,11 @@
 export const CLAUDE_STATUSLINE_PATHNAME = '/statusline/claude'
 
 export type ClaudeStatusLineWindow = {
-  used_percentage: number
-  /** Unix epoch seconds when the window resets, if known. */
-  resets_at?: number
+  used_percentage?: number
+  /** OAuth-usage-shaped sibling field (0-100); accepted so a CLI schema drift degrades instead of going dark. */
+  utilization?: number
+  /** Unix epoch seconds when the window resets, if known; tolerates an ISO/date string if the schema drifts. */
+  resets_at?: number | string
 }
 
 export type ClaudeStatusLineRateLimits = {
@@ -17,20 +19,32 @@ export type ClaudeStatusLineRateLimits = {
   sevenDay: ClaudeStatusLineWindow | null
 }
 
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
 function parseWindow(value: unknown): ClaudeStatusLineWindow | null {
   if (typeof value !== 'object' || value === null) {
     return null
   }
-  const raw = value as { used_percentage?: unknown; resets_at?: unknown }
-  if (typeof raw.used_percentage !== 'number' || !Number.isFinite(raw.used_percentage)) {
+  const raw = value as { used_percentage?: unknown; utilization?: unknown; resets_at?: unknown }
+  const usedPercentage = finiteNumber(raw.used_percentage)
+  // Why: mirror mapClaudeUsageWindow's OAuth-shape tolerance (utilization, 0-100) so a statusline field rename degrades instead of silently darkening the feed.
+  const utilization = usedPercentage === undefined ? finiteNumber(raw.utilization) : undefined
+  if (usedPercentage === undefined && utilization === undefined) {
     return null
   }
-  return {
-    used_percentage: raw.used_percentage,
-    resets_at:
-      typeof raw.resets_at === 'number' && Number.isFinite(raw.resets_at)
+  // Why: resets_at is epoch seconds today, but pass a string/ISO value through so schema drift degrades to a parseable timestamp (see parseClaudeUsageResetTimestamp) instead of silently dropping it.
+  const resetsAt =
+    typeof raw.resets_at === 'number' && Number.isFinite(raw.resets_at)
+      ? raw.resets_at
+      : typeof raw.resets_at === 'string' && raw.resets_at.trim()
         ? raw.resets_at
         : undefined
+  return {
+    ...(usedPercentage !== undefined ? { used_percentage: usedPercentage } : {}),
+    ...(utilization !== undefined ? { utilization } : {}),
+    resets_at: resetsAt
   }
 }
 

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -15,7 +15,7 @@ export type RateLimitBucket = RateLimitWindow & {
   name: string
 }
 
-export type UsageRateLimitSource = 'oauth' | 'cli' | 'web'
+export type UsageRateLimitSource = 'oauth' | 'cli' | 'web' | 'live-session'
 
 export type UsageRateLimitFailureKind =
   | 'missing-credentials'
@@ -41,6 +41,8 @@ export type UsageRateLimitMetadata = {
   authProvenance?: string
   deferredByLiveClaudeSession?: boolean
   lastSuccessfulSource?: UsageRateLimitSource
+  /** Unix ms timestamp before which usage refetches should not be attempted (from HTTP Retry-After). */
+  retryAtMs?: number
 }
 
 export type ProviderRateLimits = {


### PR DESCRIPTION
## Summary

Fixes #9616

Claude usage in the status bar could get stuck on a bare **"Limited — Claude usage is rate limited right now."** indefinitely while Claude Code itself worked fine in every terminal. Root cause (confirmed with a live probe): the OAuth usage endpoint returns `429` with `retry-after: ~3000s`, Orca discards that header, and the 30s→15min automated retry lanes keep landing inside the throttle window — a self-sustaining 429 loop. On top of that, the generic 30-minute stale policy drops the last good snapshot before the ~50-minute throttle can clear, leaving no usage bars at all.

This PR fixes the loop and adds a zero-cost live usage source:

- **Respect `Retry-After` on 429** (`claude-oauth-usage-error.ts`): parsed (seconds or HTTP-date, capped at 24h) and carried through `usageMetadata.retryAtMs`. Automated refetches — the activation-retry lane in `getActiveWindowRefreshPlan` and both fetch cycles — now wait it out; the status-bar refresh button still forces a real attempt.
- **Keep last-known usage through rate-limited windows**: `applyStalePolicy` retains the previous snapshot for up to 24h when the fresh failure is `rate-limited` (quota display is informational; a stale bar beats a bare "Limited"). The existing renderer already shows stale windows + the error note, so no UI changes were needed.
- **Live usage from session statuslines**: Claude Code ≥ 2.1.80 pipes `rate_limits` (5h/7d `used_percentage` + `resets_at`) to the `statusLine` command on every turn, piggybacked on Messages API responses. A new managed statusline script (installed alongside the existing managed hooks, locally and on SSH remotes) forwards it to a new `/statusline/claude` loopback route → `RateLimitService.ingestLiveClaudeRateLimits()`. Live posts clear stuck error states, are attributed to the selected account by comparing the session's `CLAUDE_CONFIG_DIR` against a snapshot captured during fetch cycles (no per-post auth sync), and are deduped (30s) so streaming sessions don't spam renderer pushes. While the live feed is fresh (<5 min), automated OAuth polling is skipped entirely — which also removes the polling pressure that caused the 429s in the first place. **A user-owned `statusLine` command is never overwritten** (single settings slot; managed-command matcher, same sweep semantics as hooks), and the managed script emits no stdout so the in-terminal status line stays visually unchanged.

## Screenshots

Before — status bar and popover stuck on "Limited" with no usage data, while Claude's own in-terminal statusline showed correct 5h/weekly usage the whole time:

<img width="301" alt="Claude usage popover stuck on Limited with no usage bars" src="https://gist.githubusercontent.com/dbachko/6da65a30003f71bb24dbef327b8989ba/raw/56075c1031de5469d2f976d5c872bc1379813897/claude-usage-limited-before.png" />

After: no new UI surfaces — the existing status-bar states just behave correctly: usage bars stay visible (with the stale-warning icon + "Limited" note) through a 429 window, and live sessions update the bars on every turn.

## Testing

- [x] `pnpm lint` — passes except 2 pre-existing `switch-exhaustiveness-check` errors in `src/renderer/src/components/skills/skill-freshness-group.tsx` and `src/main/daemon/daemon-server.ts`; both files are untouched by this PR and byte-identical to `origin/main`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 32,871 passed; the only failures are in files byte-identical to `origin/main` (`src/main/ipc/pty.test.ts` shell-ready-marker timing — the same pre-existing set noted in #7598 — plus environment-flaky relay/daemon/ssh suites that pass or fail nondeterministically across runs in this environment); every suite touched by this PR passes
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions:
  - `claude-oauth-usage-error.test.ts` (new): Retry-After parsing — numeric, HTTP-date, 24h cap, invalid/non-positive, non-429
  - `claude-fetcher.test.ts`: 429 results carry `retryAtMs`; absent header ⇒ no gate
  - `service.test.ts`: automated refetches wait out Retry-After then recover; manual refresh bypasses; rate-limited windows keep last-known usage past the 30-min threshold; statusline ingest clears errors and pauses OAuth polling while fresh; posts dropped before attribution is known or on config-dir mismatch; identical-post dedupe
  - `claude-statusline-rate-limits.test.ts` (new): payload parser incl. malformed bodies
  - `server-claude-statusline.test.ts` (new): real HTTP round-trip — token rejection, fail-open on junk, listener dispatch
  - `hook-service.test.ts`: managed statusLine install (local + remote script/settings shape), user-owned statusLine preserved on install *and* remove, managed statusLine removed on remove, OpenClaude excluded
  - Updated contract suites: stdin-lifecycle now executes the statusline script too; timeout contract exempts `statusLine` (schema has no `timeout` field)
- [x] Manual: reproduced the live 429 (`retry-after: 3037`) with the exact headers Orca sends before writing the fix

## AI Review Report

Reviewed the full diff against the repo checklist:

- **Cross-platform (macOS/Linux/Windows):** statusline script ships both variants — POSIX `.sh` and Windows `.cmd` (fully-qualified `%SystemRoot%\System32\curl.exe`, shared stdin-drain epilogue, endpoint-file refresh) — and settings commands use the existing `wrapWindowsGitBashHookCommand`/`wrapPosixHookCommand` wrappers. The `.cmd` variant skips the client-side `rate_limits` pre-check (payload substring checks are impractical in batch); the server validates payloads regardless. No shortcuts, labels, or path joins added outside existing helpers.
- **SSH/remote/local:** `installRemote` ships the POSIX statusline script + settings to SSH remotes. Flagged: relay-hosted hook receivers (SSH relay, WSL guest relay) do not forward `/statusline/claude` yet — those posts 404 fail-open and remote sessions simply keep the OAuth path (now Retry-After-gated). Local sessions on all three OSes get the live feed. Follow-up noted below.
- **Agent/integration neutrality:** Claude-only by design; OpenClaude is explicitly excluded from the statusLine install so its sessions can't misattribute usage to the Claude provider. Other providers' retry lanes are unaffected (`retryAtMs` is only ever set by the Claude OAuth path; the plan-level gate is a safe no-op for providers that never set it).
- **Performance:** statusline invocations run ≤ every 300ms during streaming — the POSIX script exits before spawning curl when the payload has no `rate_limits`; ingest uses a cached auth snapshot (no per-post keychain/auth sync, which is serialized and side-effectful) and dedupes identical windows within 30s so `updateState`/renderer pushes don't churn. Gated cycles skip the Claude network fetch entirely, reducing total API traffic versus main.
- **Behavior risks checked:** gated full cycles don't grow the failure streak or reset stale-policy clocks (`shouldApplyClaude` excludes gated passthroughs); account/target switches clear the attribution snapshot so mid-switch posts from the outgoing account are dropped; the deferred-by-live-session and CLI-fallback paths are unchanged.

## Security Audit

- **Endpoint exposure:** `/statusline/claude` rides the existing loopback-only (`127.0.0.1`) hook server behind the per-instance random-UUID token header, checked before any body parsing; slowloris timeout and body-size cap come from the shared `readRequestBody`. Malformed input fails open with 204 and no state change.
- **Input handling:** the payload is `JSON.parse`d inside try/catch with strict shape validation (`typeof`/`Number.isFinite` on every consumed field); `configDir` is only compared for equality against Orca's own captured value — never used as a path, command, or interpolated string. `Retry-After` is clamped to 24h so a hostile/corrupt header can't disable usage refresh for days.
- **Command execution:** the managed scripts reuse the audited hook-script patterns — payload piped to curl via stdin (`payload@-`, never argv), token via env, `curl.exe` fully qualified on Windows to prevent repo-local binary hijack.
- **Settings writes:** atomic temp-file + rename via the existing `writeHooksJson`; only the managed statusLine slot (matched by the managed-script needle) is ever created/removed — user statusLine commands are preserved on install and remove, covered by tests.
- **Secrets/deps:** no new dependencies; no secrets logged or persisted (the hook token already lived in the endpoint file; unchanged).

## Notes

- The statusline feed requires managed agent status hooks to be enabled (it installs alongside them) and Claude Code ≥ 2.1.80 with a Claude.ai subscriber session; anything older/API-key simply never posts and the OAuth path (now Retry-After-aware) covers it. No version gating needed — the `statusLine` setting itself is long-supported and older CLIs just omit `rate_limits`.
- The Fable scoped weekly window is not present in statusline payloads; the last OAuth-provided value is carried through live updates and refreshes on manual refresh or once the live feed goes idle.
- Follow-up: forward `/statusline/claude` through the SSH/WSL relay envelope so remote sessions also feed live usage (currently they fail open to OAuth polling); consider the same Retry-After plumbing for other providers if their endpoints start throttling.
- Related open issues in the same "stuck usage state" class that this does *not* fully close but should improve (live posts now clear stale Claude error states): #9324, #8974.

X: [@dbachko](https://x.com/dbachko)

Generated with [Devin](https://devin.ai)
