### PR TITLE
fix(windows): Grok Native Chat empty when GROK_HOME unset

### DIFF
--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -89,10 +89,14 @@ describe('GrokHookService', () => {
     if (process.platform === 'win32') {
       expect(script).toContain('%SystemRoot%\\System32\\curl.exe')
       expect(script).toContain('set "ORCA_GROK_HOME=%GROK_HOME%"')
+      // Why: empty GROK_HOME must goto-skip substring lines — cmd expands %VAR:~n%
+      // before evaluating a same-line `if`, which is a syntax error.
+      expect(script).toContain('if "%GROK_HOME%"=="" goto :orca_grok_home_ready')
       expect(script).toContain('%GROK_HOME:~4096,1%')
       expect(script).toContain(
         'if "%ORCA_GROK_HOME:~-1%"=="\\" set "ORCA_GROK_HOME=%ORCA_GROK_HOME%."'
       )
+      expect(script).toContain(':orca_grok_home_ready')
       expect(script).toContain('--data-urlencode "grokHome=%ORCA_GROK_HOME%"')
     } else {
       // Why: payload is piped to curl via stdin (`payload@-`) so it never lands
@@ -191,4 +195,38 @@ describe('GrokHookService', () => {
       )
     ).toBe(true)
   })
+
+  // Why: empty/unset GROK_HOME used to trip `%ORCA_GROK_HOME:~-1%` (cmd syntax
+  // error) before curl ran, so Native Chat never received sessionId on Windows.
+  it.skipIf(process.platform !== 'win32')(
+    'windows hook script survives unset GROK_HOME without cmd syntax error',
+    async () => {
+      expect(new GrokHookService().install().state).toBe('installed')
+      const scriptPath = join(homeDir, '.orca', 'agent-hooks', 'grok-hook.cmd')
+      const { spawnSync } = await import('node:child_process')
+      const result = spawnSync('cmd.exe', ['/d', '/c', scriptPath], {
+        encoding: 'utf8',
+        input: JSON.stringify({
+          hook_event_name: 'UserPromptSubmit',
+          sessionId: 'test-session',
+          prompt: 'hi'
+        }),
+        env: {
+          ...process.env,
+          ORCA_AGENT_HOOK_PORT: '1',
+          ORCA_AGENT_HOOK_TOKEN: 'test-token',
+          ORCA_AGENT_HOOK_ENV: 'test',
+          ORCA_AGENT_HOOK_VERSION: '1',
+          ORCA_PANE_KEY:
+            'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+          ORCA_TAB_ID: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          GROK_HOME: ''
+        },
+        windowsHide: true
+      })
+      const combined = `${result.stdout ?? ''}\n${result.stderr ?? ''}`
+      expect(combined).not.toMatch(/语法不正确|The syntax of the command is incorrect/i)
+      expect(result.status).toBe(0)
+    }
+  )
 })

--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -89,14 +89,10 @@ describe('GrokHookService', () => {
     if (process.platform === 'win32') {
       expect(script).toContain('%SystemRoot%\\System32\\curl.exe')
       expect(script).toContain('set "ORCA_GROK_HOME=%GROK_HOME%"')
-      // Why: empty GROK_HOME must goto-skip substring lines — cmd expands %VAR:~n%
-      // before evaluating a same-line `if`, which is a syntax error.
-      expect(script).toContain('if "%GROK_HOME%"=="" goto :orca_grok_home_ready')
       expect(script).toContain('%GROK_HOME:~4096,1%')
       expect(script).toContain(
         'if "%ORCA_GROK_HOME:~-1%"=="\\" set "ORCA_GROK_HOME=%ORCA_GROK_HOME%."'
       )
-      expect(script).toContain(':orca_grok_home_ready')
       expect(script).toContain('--data-urlencode "grokHome=%ORCA_GROK_HOME%"')
     } else {
       // Why: payload is piped to curl via stdin (`payload@-`) so it never lands
@@ -196,22 +192,65 @@ describe('GrokHookService', () => {
     ).toBe(true)
   })
 
-  // Why: empty/unset GROK_HOME used to trip `%ORCA_GROK_HOME:~-1%` (cmd syntax
-  // error) before curl ran, so Native Chat never received sessionId on Windows.
+  // Why: GROK_HOME is unset for most users, and cmd leaves `%VAR:~-1%` literal
+  // when VAR is undefined — the trailing-backslash line then collapses to
+  // `if "~-1ORCA_GROK_HOME."` and aborts before curl, so Native Chat never got
+  // a sessionId. Runs off-Windows too; the win32 branch is a pure string build.
+  it('guards the Windows trailing-backslash line against an undefined GROK_HOME', () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    try {
+      expect(new GrokHookService().install().state).toBe('installed')
+      const script = readFileSync(
+        join(homeDir, '.orca', 'agent-hooks', 'grok-hook.cmd'),
+        'utf8'
+      ).split('\r\n')
+
+      const guardIndex = script.indexOf('if not defined ORCA_GROK_HOME goto :orca_grok_home_ready')
+      const substringIndex = script.indexOf(
+        'if "%ORCA_GROK_HOME:~-1%"=="\\" set "ORCA_GROK_HOME=%ORCA_GROK_HOME%."'
+      )
+      const labelIndex = script.indexOf(':orca_grok_home_ready')
+
+      expect(guardIndex).toBeGreaterThanOrEqual(0)
+      // Why: the guard is only useful ahead of the substring it protects, and
+      // the jump target must sit after it or the line still runs.
+      expect(guardIndex).toBeLessThan(substringIndex)
+      expect(labelIndex).toBeGreaterThan(substringIndex)
+      // Why: truncation clears ORCA_GROK_HOME, so the guard must follow it to
+      // cover an oversize GROK_HOME emptying the copy.
+      expect(script.indexOf('if not "%GROK_HOME:~4096,1%"=="" set "ORCA_GROK_HOME="')).toBeLessThan(
+        guardIndex
+      )
+      // Why: comparing the raw value breaks on a quote inside GROK_HOME; the
+      // `if defined` form never embeds it.
+      expect(script).not.toContain('if "%GROK_HOME%"=="" goto :orca_grok_home_ready')
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
+  // Why: the guard above is a string assertion; only real cmd.exe proves the
+  // script still reaches curl with GROK_HOME unset, empty, or oversize.
   it.skipIf(process.platform !== 'win32')(
-    'windows hook script survives unset GROK_HOME without cmd syntax error',
+    'windows hook script reaches curl for every GROK_HOME shape',
     async () => {
       expect(new GrokHookService().install().state).toBe('installed')
       const scriptPath = join(homeDir, '.orca', 'agent-hooks', 'grok-hook.cmd')
       const { spawnSync } = await import('node:child_process')
-      const result = spawnSync('cmd.exe', ['/d', '/c', scriptPath], {
-        encoding: 'utf8',
-        input: JSON.stringify({
-          hook_event_name: 'UserPromptSubmit',
-          sessionId: 'test-session',
-          prompt: 'hi'
-        }),
-        env: {
+
+      for (const grokHome of [
+        undefined,
+        '',
+        '   ',
+        'C:\\Users\\dev\\.grok',
+        'C:\\Users\\dev\\.grok\\',
+        'C:\\a"b\\.grok',
+        `C:\\${'a'.repeat(5000)}`
+      ]) {
+        const env: NodeJS.ProcessEnv = {
           ...process.env,
           ORCA_AGENT_HOOK_PORT: '1',
           ORCA_AGENT_HOOK_TOKEN: 'test-token',
@@ -219,14 +258,30 @@ describe('GrokHookService', () => {
           ORCA_AGENT_HOOK_VERSION: '1',
           ORCA_PANE_KEY:
             'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
-          ORCA_TAB_ID: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
-          GROK_HOME: ''
-        },
-        windowsHide: true
-      })
-      const combined = `${result.stdout ?? ''}\n${result.stderr ?? ''}`
-      expect(combined).not.toMatch(/语法不正确|The syntax of the command is incorrect/i)
-      expect(result.status).toBe(0)
+          ORCA_TAB_ID: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+        }
+        delete env.GROK_HOME
+        if (grokHome !== undefined) {
+          env.GROK_HOME = grokHome
+        }
+
+        const result = spawnSync('cmd.exe', ['/d', '/c', scriptPath], {
+          encoding: 'utf8',
+          input: JSON.stringify({
+            hook_event_name: 'UserPromptSubmit',
+            sessionId: 'test-session',
+            prompt: 'hi'
+          }),
+          env,
+          windowsHide: true
+        })
+
+        const combined = `${result.stdout ?? ''}\n${result.stderr ?? ''}`
+        expect(combined).not.toMatch(/语法不正确|The syntax of the command is incorrect/i)
+        // Why: the hook is best-effort — the listener is absent here, so only a
+        // cmd-level abort (non-zero) signals the parse bug.
+        expect(result.status).toBe(0)
+      }
     }
   )
 })

--- a/src/main/grok/hook-service.ts
+++ b/src/main/grok/hook-service.ts
@@ -122,10 +122,14 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
       'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
       ...buildWindowsHookEnvironmentGuardLines(),
       'set "ORCA_GROK_HOME=%GROK_HOME%"',
-      `if not "%GROK_HOME:~${GROK_HOME_ENVELOPE_MAX_LENGTH},1%"=="" set "ORCA_GROK_HOME="`,
+      // Why: cmd expands %VAR:~n% on the whole line before evaluating `if`, so an
+      // empty GROK_HOME still syntax-errors unless we skip those lines entirely.
+      'if "%GROK_HOME%"=="" goto :orca_grok_home_ready',
+      `if not "%GROK_HOME:~${GROK_HOME_ENVELOPE_MAX_LENGTH},1%"=="" set "ORCA_GROK_HOME=" & goto :orca_grok_home_ready`,
       // Why: a trailing backslash escapes curl's closing argv quote on Windows,
       // merging the payload option into grokHome and dropping the hook body.
       'if "%ORCA_GROK_HOME:~-1%"=="\\" set "ORCA_GROK_HOME=%ORCA_GROK_HOME%."',
+      ':orca_grok_home_ready',
       WINDOWS_GROK_HOOK_POST_COMMAND,
       'exit /b 0',
       ...buildWindowsHookStdinDrainEpilogue(),

--- a/src/main/grok/hook-service.ts
+++ b/src/main/grok/hook-service.ts
@@ -89,10 +89,7 @@ function getRemoteGrokHome(remoteHome: string, remoteGrokHome?: string): string 
 }
 
 function hasControlCharacter(value: string): boolean {
-  return Array.from(value).some((character) => {
-    const code = character.charCodeAt(0)
-    return code <= 0x1f || code === 0x7f
-  })
+  return Array.from(value, (c) => c.charCodeAt(0)).some((code) => code <= 0x1f || code === 0x7f)
 }
 
 const WINDOWS_GROK_HOOK_POST_COMMAND = buildWindowsAgentHookPostCommand('grok').replace(
@@ -122,10 +119,11 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
       'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
       ...buildWindowsHookEnvironmentGuardLines(),
       'set "ORCA_GROK_HOME=%GROK_HOME%"',
-      // Why: cmd expands %VAR:~n% on the whole line before evaluating `if`, so an
-      // empty GROK_HOME still syntax-errors unless we skip those lines entirely.
-      'if "%GROK_HOME%"=="" goto :orca_grok_home_ready',
-      `if not "%GROK_HOME:~${GROK_HOME_ENVELOPE_MAX_LENGTH},1%"=="" set "ORCA_GROK_HOME=" & goto :orca_grok_home_ready`,
+      `if not "%GROK_HOME:~${GROK_HOME_ENVELOPE_MAX_LENGTH},1%"=="" set "ORCA_GROK_HOME="`,
+      // Why: cmd leaves %VAR:~-1% literal when VAR is undefined, so the next
+      // line collapses to `if "~-1ORCA_GROK_HOME."` and aborts the script before
+      // curl posts. Unset GROK_HOME is the common case, so skip it entirely.
+      'if not defined ORCA_GROK_HOME goto :orca_grok_home_ready',
       // Why: a trailing backslash escapes curl's closing argv quote on Windows,
       // merging the payload option into grokHome and dropping the hook body.
       'if "%ORCA_GROK_HOME:~-1%"=="\\" set "ORCA_GROK_HOME=%ORCA_GROK_HOME%."',


### PR DESCRIPTION
## Summary

On Windows, the managed `grok-hook.cmd` never posted a single hook event when `GROK_HOME` was unset — the default for most users. `last-status.json` stayed empty and Grok Native Chat never received a `sessionId`, so the pane stayed blank even though the Grok CLI itself worked fine.

The cause is a cmd.exe parsing rule: when a variable is **undefined**, cmd leaves `%VAR:~-1%` in the line *literally* instead of expanding it. The trailing-backslash sanitizer

```bat
if "%ORCA_GROK_HOME:~-1%"=="\" set "ORCA_GROK_HOME=%ORCA_GROK_HOME%."
```

therefore degenerates to `if "~-1ORCA_GROK_HOME."` — a syntax error that aborts the **entire script** before curl runs (`The syntax of the command is incorrect`, exit 255, reproduced on a real Windows 11 box below).

Note `set "ORCA_GROK_HOME=%GROK_HOME%"` with an empty value leaves the variable **undefined**, not empty — so unset and empty-string `GROK_HOME` fail identically. An oversize `GROK_HOME` (>4096) hit the same abort, because the truncation guard clears the copy.

The fix skips that line when there is nothing to sanitize:

```bat
if not defined ORCA_GROK_HOME goto :orca_grok_home_ready
```

Closes the Native Chat binding gap on Windows. macOS/Linux use the POSIX `grok-hook.sh` branch and are untouched.

## ELI5

Grok tells Orca what it's doing by running a tiny Windows script after each step. That script had a line that only made sense if you had set a special folder setting — and almost nobody sets it. Without it, Windows choked on that line and quit the whole script early, so Orca never heard anything back and the chat panel stayed empty. Now the script skips that line when there's nothing to check, so the messages get through.

## Proof of fix

New test `guards the Windows trailing-backslash line against an undefined GROK_HOME`. It stubs `process.platform = 'win32'`, so it runs on **every** CI platform rather than only Windows runners.

Against `origin/main`'s `hook-service.ts` — **FAILS**:

```
$ git checkout origin/main -- src/main/grok/hook-service.ts
$ npx vitest run --config config/vitest.config.ts src/main/grok/

 ❯ src/main/grok/hook-service.test.ts (6 tests | 1 failed | 2 skipped) 12ms
     × guards the Windows trailing-backslash line against an undefined GROK_HOME 3ms

 FAIL  src/main/grok/hook-service.test.ts > GrokHookService > guards the Windows trailing-backslash line against an undefined GROK_HOME
AssertionError: expected -1 to be greater than or equal to 0
 ❯ src/main/grok/hook-service.test.ts:215:26
    215|       expect(guardIndex).toBeGreaterThanOrEqual(0)

 Test Files  1 failed (1)
      Tests  1 failed | 3 passed | 2 skipped (6)
```

With this PR — **PASSES**:

```
$ git checkout HEAD -- src/main/grok/hook-service.ts
$ npx vitest run --config config/vitest.config.ts src/main/grok/

 Test Files  1 passed (1)
      Tests  4 passed | 2 skipped (6)
```

### End-to-end on real Windows 11 (win32 x64, Node v24.18.0)

The real generated `grok-hook.cmd` from `origin/main` and from this PR (emitted by `getManagedScript()` itself, not hand-copied) were run by actual `cmd.exe` against a **live HTTP listener**, asserting the hook POST arrives. Captured output:

```
homedir=C:\Users\neil
USERPROFILE=C:\Users\neil
APPDATA=C:\Users\neil\AppData\Roaming
LOCALAPPDATA=C:\Users\neil\AppData\Local
grok-dir-exists=true
[MAIN][unset] rc=255 syntaxErr=true posted=false stderr=[The syntax of the command is incorrect.]
[MAIN][empty] rc=255 syntaxErr=true posted=false stderr=[The syntax of the command is incorrect.]
[MAIN][normal] rc=0 syntaxErr=false posted=true grokHome=[C:\Users\neil\.grok]
[PR][unset] rc=0 syntaxErr=false posted=true grokHome=[]
[PR][empty] rc=0 syntaxErr=false posted=true grokHome=[]
[PR][spaces] rc=0 syntaxErr=false posted=true grokHome=[   ]
[PR][normal] rc=0 syntaxErr=false posted=true grokHome=[C:\Users\neil\.grok]
[PR][trailslash] rc=0 syntaxErr=false posted=true grokHome=[C:\Users\neil\.grok\.]
[PR][quote] rc=0 syntaxErr=false posted=true grokHome=[C:\ab\.grok ^]
[PR][oversize] rc=0 syntaxErr=false posted=true grokHome=[]
PROBE_DONE
```

`unset`, `empty` and `oversize` go from **no hook event at all** (cmd abort, exit 255) to a delivered POST — exactly the Native Chat symptom. `normal` and `trailslash` post the same `grokHome` as before (trailing-backslash sanitization preserved: `...\.grok\` arrives as `...\.grok\.`).

The environment probe above also confirms the unset-`GROK_HOME` default on this box and that Grok stores its data under `%USERPROFILE%\.grok` (not `%APPDATA%`/`%LOCALAPPDATA%`), matching the existing `resolveGrokHomeDir()` fallback (`join(homedir(), '.grok')`) — so no path change was needed.

## Proof of no regressions

```
$ npx vitest run --config config/vitest.config.ts src/main/grok/ src/main/agent-hooks/ \
    src/shared/grok-session-paths.test.ts src/shared/agent-hook-listener.test.ts src/main/native-chat/

 Test Files  37 passed (37)
      Tests  685 passed | 5 skipped (690)

$ npx oxlint src/main/grok/hook-service.ts src/main/grok/hook-service.test.ts
(clean)

$ npx oxfmt --check src/main/grok/hook-service.ts src/main/grok/hook-service.test.ts
All matched files use the correct format.

$ node config/scripts/check-max-lines-ratchet.mjs
max-lines ratchet OK — 354 grandfathered suppression(s), no new bypasses.
```

`npx tsc --noEmit -p config/tsconfig.node.json` reports 8 errors, all in `src/main/ipc/worktree-common-git-directory.ts` and `src/main/skills/skill-installation-topology.ts`. These are **pre-existing** on pristine `main` in files this diff does not touch; none are in `src/main/grok/`.

No user-visible behavior changes beyond the fix. For every `GROK_HOME` value that worked before, the script behaves identically: the new `if not defined` guard is a no-op whenever the variable holds a value, and the real-Windows matrix above shows the same `grokHome` payload for `normal` and `trailing-backslash` inputs on main and on this PR.

## Compatibility

- **Platforms:** **Windows** — verified by execution on a real Windows 11 box (win32 x64, Node v24.18.0, cmd.exe) across 7 `GROK_HOME` shapes against a live HTTP listener (output above). **macOS** — covering suites run locally on darwin; the changed emission sits behind `process.platform === 'win32'`, and the POSIX branch is byte-for-byte unchanged. **Linux** — same POSIX branch as macOS, unchanged; guarded by the platform-stubbed test that runs on all CI platforms. No hardcoded path separators: the cmd script is Windows-only by construction, and TS path building goes through `path.join`.
- **SSH / remote:** No impact. `installRemote()` always emits the POSIX `grok-hook.sh` via `getManagedScript('posix')`, which this PR does not touch; the remote Grok home continues to resolve on the guest through `getRemoteGrokHome()` / the relay probe, never from the local host's `GROK_HOME`.
- **Performance:** No hot-path change. The script is generated once per install, and the added line is a single `if not defined` test per hook invocation — no new process spawn, no I/O.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — ran `npx oxlint` on both changed files plus the `check-max-lines-ratchet` gate; both clean.
- [ ] `pnpm typecheck` — ran the covering project only: `npx tsc --noEmit -p config/tsconfig.node.json`. 8 errors, all pre-existing on pristine `main` in unrelated files (see above); none in `src/main/grok/`.
- [ ] `pnpm test` — ran the covering suites only (37 files, 685 tests, all passing), not the full 30+ minute suite.
- [ ] `pnpm build` — not run.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Reviewed adversarially, with each hypothesis checked by execution on real Windows rather than reasoning alone. Two defects were found in the original patch and fixed:

1. **Quote-containing `GROK_HOME` regression.** The original guard `if "%GROK_HOME%"=="" goto ...` embeds the raw value in the comparison, so a `"` inside `GROK_HOME` unbalances the line — a path that *worked on `main`* and broke under the original patch. Switching to `if not defined ORCA_GROK_HOME` never embeds the value; the `[PR][quote]` row above posts with exit 0. The new test pins the `if defined` form and rejects the value-embedding form.
2. **CI lint failure.** `hook-service.ts` on `main` sits at exactly the 300-line `max-lines` cap, so the original patch's added lines failed oxlint. `AGENTS.md` forbids adding a `max-lines` disable, and the ratchet gate blocks new suppressions. Reclaimed the lines by collapsing the local `hasControlCharacter` helper into an equivalent one-liner — verified behaviorally identical over 18 targeted cases (including lone surrogates) plus 300k random fuzz strings.

Two hypotheses were **disproved** by running them, recorded so the next reader doesn't re-raise them:

- `set "X=" & goto :label` on an `if` line — suspected the `goto` would run unconditionally. It does not; cmd binds `&` inside the `if` body.
- Collapsing the guard into one chained `if defined X if "%X:~-1%"...` line (which would have avoided the lint pressure) — **fails**, because cmd substitutes `%X:~-1%` across the whole line before the first `if` is evaluated. The `goto`-based structure the original author chose is genuinely required.

Cross-platform compatibility was explicitly checked for macOS, Linux and Windows: path handling (no hardcoded separators), shell quoting/escaping (`"`, `&`, `^`, spaces), and `windowsHide` on every test spawn. No shortcuts, labels or UI are touched. The original win32-only string assertion was replaced with a platform-stubbed test so the regression is caught on macOS/Linux CI too, and the real-`cmd.exe` execution test was kept and broadened to 7 `GROK_HOME` shapes.

## Security Audit

- **Command execution / injection:** The change reduces attack surface slightly — `if not defined` no longer interpolates `GROK_HOME`'s value into a parsed command line, whereas the original patch's `if "%GROK_HOME%"==""` did. The value still reaches curl as a quoted `--data-urlencode` argument, unchanged from `main`.
- **Path handling:** No path is constructed or resolved by this change. `resolveGrokHomeDir()` and the 4096-char envelope cap are untouched, as is server-side validation in `readGrokHomeEnvelope()` (absolute-path check, control-character rejection, length bound).
- **Input handling:** Hook payload flow is unchanged — still piped to curl's stdin via `payload@-`, so large tool output never lands on the command line.
- **Auth / secrets / IPC / dependencies:** Not touched. No new dependency, no IPC surface change, no change to the hook token check (`ORCA_AGENT_HOOK_TOKEN` guard still precedes the post).
- **Follow-up:** none required.

## Notes

- A `GROK_HOME` **ending in a double quote** (`C:\a\.grok"`) still aborts the script. This is **unchanged from `main`** — a pre-existing edge case, not a regression from this PR; fixing it properly needs delayed expansion (`setlocal EnableDelayedExpansion`), a larger change to the shared hook-script contract. Left out deliberately to keep this fix minimal.
- A `GROK_HOME` containing an embedded `"` posts but with a mangled `grokHome` value (`C:\ab\.grok ^` above) — also unchanged in kind from cmd's quoting rules and bounded server-side by `readGrokHomeEnvelope()` validation.
- `hasControlCharacter` is duplicated in four files (`src/main/grok/hook-service.ts`, `src/shared/agent-hook-listener.ts`, `src/main/agent-hooks/managed-hook-runtime.ts`, `src/main/integration-credential-file.ts`). Consolidating it into one shared module is a reasonable follow-up, out of scope here.
- The Windows-only execution test remains `skipIf(process.platform !== 'win32')`, so it only runs on Windows; the platform-stubbed test is what guards the regression everywhere else.

Original patch by @yuhoudeqingchun.
