### PR TITLE
fix(codex): preserve active account during reauth

### DIFF
--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -970,16 +970,6 @@ describe('CodexAccountService config sync', () => {
     })
     const store = createStore(settings)
     const runtimeHome = createRuntimeHome()
-    runtimeHome.syncForCurrentSelection.mockImplementation(() => {
-      const current = store.getSettings()
-      store.updateSettings({
-        activeCodexManagedAccountId: null,
-        activeCodexManagedAccountIdsByRuntime: {
-          ...current.activeCodexManagedAccountIdsByRuntime!,
-          host: null
-        }
-      })
-    })
     const spawnMock = vi.fn(
       (_command: string, _args: string[], options: { env: NodeJS.ProcessEnv }) => {
         const child = new EventEmitter() as EventEmitter & {
@@ -990,6 +980,14 @@ describe('CodexAccountService config sync', () => {
         child.stdout = new PassThrough()
         child.stderr = new PassThrough()
         child.kill = vi.fn()
+        const current = store.getSettings()
+        store.updateSettings({
+          activeCodexManagedAccountId: null,
+          activeCodexManagedAccountIdsByRuntime: {
+            ...current.activeCodexManagedAccountIdsByRuntime!,
+            host: null
+          }
+        })
         writeFileSync(
           join(options.env.CODEX_HOME!, 'auth.json'),
           createCodexAuthJson('reauthenticated@example.com', 'provider-new', 'refresh-new'),
@@ -1028,6 +1026,9 @@ describe('CodexAccountService config sync', () => {
         wsl: { Ubuntu: null }
       }
     })
+    expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalledTimes(1)
+    // One test-simulated clear plus one atomic account/selection update; reauth must not add a redundant persistence write.
+    expect(store.updateSettings).toHaveBeenCalledTimes(2)
   })
 
   it('does not recreate a missing managed home at a different account path', async () => {

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -14,7 +14,7 @@ import {
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PassThrough } from 'node:stream'
-import type { GlobalSettings } from '../../shared/types'
+import type { CodexRateLimitAccountsState, GlobalSettings } from '../../shared/types'
 import { buildWslCodexAvailabilityArgs, buildWslCodexLoginArgs } from './wsl-codex-command'
 import type { readHookTrustEntries as ReadHookTrustEntries } from '../codex/config-toml-trust'
 
@@ -939,12 +939,38 @@ describe('CodexAccountService config sync', () => {
   })
 
   it.each([
-    ['the active account', 'account-1'],
-    ['a different account', 'account-2']
-  ])('preserves the active selection when reauthenticating %s', async (_label, accountId) => {
+    {
+      label: 'the active account',
+      accountId: 'account-1',
+      outcome: 'success',
+      expectedActiveAccountId: 'account-1',
+      expectedUpdateCount: 2
+    },
+    {
+      label: 'a different account',
+      accountId: 'account-2',
+      outcome: 'success',
+      expectedActiveAccountId: 'account-1',
+      expectedUpdateCount: 2
+    },
+    {
+      label: 'a login that fails',
+      accountId: 'account-1',
+      outcome: 'login-failure',
+      expectedActiveAccountId: null,
+      expectedUpdateCount: 1
+    },
+    {
+      label: 'credentials rejected by runtime validation',
+      accountId: 'account-1',
+      outcome: 'runtime-validation-failure',
+      expectedActiveAccountId: null,
+      expectedUpdateCount: 3
+    }
+  ])('keeps host selection semantics when reauthenticating $label', async (testCase) => {
     vi.resetModules()
 
-    const accounts = ['account-1', 'account-2'].map((id, index) => ({
+    const hostAccounts = ['account-1', 'account-2'].map((id, index) => ({
       id,
       email: `${id}@example.com`,
       managedHomePath: createManagedHome(
@@ -960,12 +986,31 @@ describe('CodexAccountService config sync', () => {
       updatedAt: index + 1,
       lastAuthenticatedAt: index + 1
     }))
+    const wslAccount = {
+      id: 'account-wsl',
+      email: 'account-wsl@example.com',
+      managedHomePath: createManagedHome(
+        testState.userDataDir,
+        'account-wsl',
+        '',
+        createCodexAuthJson('account-wsl@example.com', 'provider-wsl', 'refresh-wsl')
+      ),
+      managedHomeRuntime: 'wsl' as const,
+      wslDistro: 'Ubuntu',
+      wslLinuxHomePath: '/home/test/.local/share/orca/codex-accounts/account-wsl/home',
+      providerAccountId: 'provider-wsl',
+      workspaceLabel: null,
+      workspaceAccountId: 'provider-wsl',
+      createdAt: 3,
+      updatedAt: 3,
+      lastAuthenticatedAt: 3
+    }
     const settings = createSettings({
-      codexManagedAccounts: accounts,
+      codexManagedAccounts: [...hostAccounts, wslAccount],
       activeCodexManagedAccountId: 'account-1',
       activeCodexManagedAccountIdsByRuntime: {
         host: 'account-1',
-        wsl: { Ubuntu: null }
+        wsl: { Ubuntu: 'account-wsl' }
       }
     })
     const store = createStore(settings)
@@ -985,9 +1030,14 @@ describe('CodexAccountService config sync', () => {
           activeCodexManagedAccountId: null,
           activeCodexManagedAccountIdsByRuntime: {
             ...current.activeCodexManagedAccountIdsByRuntime!,
-            host: null
+            host: null,
+            wsl: { Ubuntu: null }
           }
         })
+        if (testCase.outcome === 'login-failure') {
+          queueMicrotask(() => child.emit('close', 1))
+          return child
+        }
         writeFileSync(
           join(options.env.CODEX_HOME!, 'auth.json'),
           createCodexAuthJson('reauthenticated@example.com', 'provider-new', 'refresh-new'),
@@ -1005,30 +1055,60 @@ describe('CodexAccountService config sync', () => {
       resolveCodexCommand: () => 'codex'
     }))
 
+    runtimeHome.syncForCurrentSelection.mockImplementation(() => {
+      if (testCase.outcome !== 'runtime-validation-failure') {
+        return
+      }
+      const current = store.getSettings()
+      store.updateSettings({
+        activeCodexManagedAccountId: null,
+        activeCodexManagedAccountIdsByRuntime: {
+          ...current.activeCodexManagedAccountIdsByRuntime!,
+          host: null
+        }
+      })
+    })
+    const rateLimits = createRateLimits()
     const { CodexAccountService } = await import('./service')
     const service = new CodexAccountService(
       store as never,
-      createRateLimits() as never,
+      rateLimits as never,
       runtimeHome as never
     )
 
-    const result = await service.reauthenticateAccount(accountId)
+    let result: CodexRateLimitAccountsState | null = null
+    if (testCase.outcome === 'login-failure') {
+      await expect(service.reauthenticateAccount(testCase.accountId)).rejects.toThrow(
+        'Codex login exited with code 1.'
+      )
+    } else {
+      result = await service.reauthenticateAccount(testCase.accountId)
+    }
 
-    expect(result.activeAccountId).toBe('account-1')
-    expect(result.activeAccountIdsByRuntime).toEqual({
-      host: 'account-1',
-      wsl: { Ubuntu: null }
-    })
+    expect(result?.activeAccountId ?? null).toBe(testCase.expectedActiveAccountId)
+    if (result) {
+      expect(result.activeAccountIdsByRuntime).toEqual({
+        host: testCase.expectedActiveAccountId,
+        wsl: { Ubuntu: null }
+      })
+    }
     expect(store.getSettings()).toMatchObject({
-      activeCodexManagedAccountId: 'account-1',
+      activeCodexManagedAccountId: testCase.expectedActiveAccountId,
       activeCodexManagedAccountIdsByRuntime: {
-        host: 'account-1',
+        host: testCase.expectedActiveAccountId,
         wsl: { Ubuntu: null }
       }
     })
-    expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalledTimes(1)
-    // One test-simulated clear plus one atomic account/selection update; reauth must not add a redundant persistence write.
-    expect(store.updateSettings).toHaveBeenCalledTimes(2)
+    const completedLogin = testCase.outcome !== 'login-failure'
+    expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalledTimes(completedLogin ? 1 : 0)
+    if (completedLogin) {
+      expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalledWith({ runtime: 'host' })
+      expect(rateLimits.refreshForCodexAccountChange).toHaveBeenCalledWith(undefined, {
+        runtime: 'host'
+      })
+    }
+    expect(rateLimits.refreshForCodexAccountChange).toHaveBeenCalledTimes(completedLogin ? 1 : 0)
+    expect(store.updateSettings).toHaveBeenCalledTimes(testCase.expectedUpdateCount)
   })
 
   it('does not recreate a missing managed home at a different account path', async () => {
@@ -1345,6 +1425,7 @@ describe('CodexAccountService config sync', () => {
       }
       return ''
     })
+    let clearSelectionDuringLogin = (): void => {}
     const spawnMock = vi.fn((command: string, args: string[]) => {
       expect(command).toBe('wsl.exe')
       expect(args).toEqual(buildWslCodexLoginArgs('Ubuntu', wslLinuxHomePath))
@@ -1356,6 +1437,7 @@ describe('CodexAccountService config sync', () => {
       child.stdout = new PassThrough()
       child.stderr = new PassThrough()
       child.kill = vi.fn()
+      clearSelectionDuringLogin()
       writeFileSync(
         join(wslManagedHomePath, 'auth.json'),
         JSON.stringify({
@@ -1400,9 +1482,22 @@ describe('CodexAccountService config sync', () => {
           lastAuthenticatedAt: 1
         }
       ],
-      activeCodexManagedAccountId: 'account-1'
+      activeCodexManagedAccountId: null,
+      activeCodexManagedAccountIdsByRuntime: {
+        host: null,
+        wsl: { Ubuntu: 'account-1' }
+      }
     })
     const store = createStore(settings)
+    clearSelectionDuringLogin = () => {
+      const current = store.getSettings()
+      store.updateSettings({
+        activeCodexManagedAccountIdsByRuntime: {
+          ...current.activeCodexManagedAccountIdsByRuntime!,
+          wsl: { Ubuntu: null }
+        }
+      })
+    }
     const rateLimits = createRateLimits()
     const runtimeHome = createRuntimeHome()
 
@@ -1421,7 +1516,20 @@ describe('CodexAccountService config sync', () => {
         managedHomeRuntime: 'wsl',
         wslDistro: 'Ubuntu'
       })
-      expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalled()
+      expect(result.activeAccountId).toBe(null)
+      expect(result.activeAccountIdsByRuntime).toEqual({
+        host: null,
+        wsl: { Ubuntu: 'account-1' }
+      })
+      expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalledWith({
+        runtime: 'wsl',
+        wslDistro: 'Ubuntu'
+      })
+      expect(rateLimits.refreshForCodexAccountChange).toHaveBeenCalledWith(undefined, {
+        runtime: 'wsl',
+        wslDistro: 'Ubuntu'
+      })
+      expect(store.updateSettings).toHaveBeenCalledTimes(2)
     } finally {
       Object.defineProperty(process, 'platform', {
         configurable: true,

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -938,6 +938,98 @@ describe('CodexAccountService config sync', () => {
     warnSpy.mockRestore()
   })
 
+  it.each([
+    ['the active account', 'account-1'],
+    ['a different account', 'account-2']
+  ])('preserves the active selection when reauthenticating %s', async (_label, accountId) => {
+    vi.resetModules()
+
+    const accounts = ['account-1', 'account-2'].map((id, index) => ({
+      id,
+      email: `${id}@example.com`,
+      managedHomePath: createManagedHome(
+        testState.userDataDir,
+        id,
+        '',
+        createCodexAuthJson(`${id}@example.com`, `provider-${id}`, `refresh-${id}`)
+      ),
+      providerAccountId: `provider-${id}`,
+      workspaceLabel: null,
+      workspaceAccountId: `provider-${id}`,
+      createdAt: index + 1,
+      updatedAt: index + 1,
+      lastAuthenticatedAt: index + 1
+    }))
+    const settings = createSettings({
+      codexManagedAccounts: accounts,
+      activeCodexManagedAccountId: 'account-1',
+      activeCodexManagedAccountIdsByRuntime: {
+        host: 'account-1',
+        wsl: { Ubuntu: null }
+      }
+    })
+    const store = createStore(settings)
+    const runtimeHome = createRuntimeHome()
+    runtimeHome.syncForCurrentSelection.mockImplementation(() => {
+      const current = store.getSettings()
+      store.updateSettings({
+        activeCodexManagedAccountId: null,
+        activeCodexManagedAccountIdsByRuntime: {
+          ...current.activeCodexManagedAccountIdsByRuntime!,
+          host: null
+        }
+      })
+    })
+    const spawnMock = vi.fn(
+      (_command: string, _args: string[], options: { env: NodeJS.ProcessEnv }) => {
+        const child = new EventEmitter() as EventEmitter & {
+          stdout: PassThrough
+          stderr: PassThrough
+          kill: () => void
+        }
+        child.stdout = new PassThrough()
+        child.stderr = new PassThrough()
+        child.kill = vi.fn()
+        writeFileSync(
+          join(options.env.CODEX_HOME!, 'auth.json'),
+          createCodexAuthJson('reauthenticated@example.com', 'provider-new', 'refresh-new'),
+          'utf-8'
+        )
+        queueMicrotask(() => child.emit('close', 0))
+        return child
+      }
+    )
+    vi.doMock('node:child_process', () => ({
+      execFileSync: vi.fn(),
+      spawn: spawnMock
+    }))
+    vi.doMock('../codex-cli/command', () => ({
+      resolveCodexCommand: () => 'codex'
+    }))
+
+    const { CodexAccountService } = await import('./service')
+    const service = new CodexAccountService(
+      store as never,
+      createRateLimits() as never,
+      runtimeHome as never
+    )
+
+    const result = await service.reauthenticateAccount(accountId)
+
+    expect(result.activeAccountId).toBe('account-1')
+    expect(result.activeAccountIdsByRuntime).toEqual({
+      host: 'account-1',
+      wsl: { Ubuntu: null }
+    })
+    expect(store.getSettings()).toMatchObject({
+      activeCodexManagedAccountId: 'account-1',
+      activeCodexManagedAccountIdsByRuntime: {
+        host: 'account-1',
+        wsl: { Ubuntu: null }
+      }
+    })
+  })
+
   it('does not recreate a missing managed home at a different account path', async () => {
     vi.resetModules()
     const managedHomePath = join(testState.userDataDir, 'codex-accounts', 'other-account', 'home')

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -283,6 +283,7 @@ export class CodexAccountService {
         : entry
     )
 
+    // Why: runtime validation can clear selection while login rewrites auth.json; restore it before syncing fresh auth.
     this.store.updateSettings({
       codexManagedAccounts: updatedAccounts,
       activeCodexManagedAccountId: activeSelection.host,
@@ -297,11 +298,6 @@ export class CodexAccountService {
       undefined,
       getCodexSelectionTargetForAccount(account)
     )
-    // Why: runtime-home validation can clear the selection during reauth's credential transition.
-    this.store.updateSettings({
-      activeCodexManagedAccountId: activeSelection.host,
-      activeCodexManagedAccountIdsByRuntime: activeSelection
-    })
     return this.getSnapshot()
   }
 

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -258,6 +258,7 @@ export class CodexAccountService {
   private async doReauthenticateAccount(accountId: string): Promise<CodexRateLimitAccountsState> {
     const account = this.requireAccount(accountId)
     const managedHomePath = this.ensureManagedHomeForReauthentication(account)
+    const activeSelection = normalizeCodexRuntimeSelection(this.store.getSettings())
 
     this.safeSyncCanonicalConfigIntoManagedHome(managedHomePath, undefined, account.id)
     await this.runCodexLogin(managedHomePath)
@@ -283,7 +284,9 @@ export class CodexAccountService {
     )
 
     this.store.updateSettings({
-      codexManagedAccounts: updatedAccounts
+      codexManagedAccounts: updatedAccounts,
+      activeCodexManagedAccountId: activeSelection.host,
+      activeCodexManagedAccountIdsByRuntime: activeSelection
     })
     this.safeSyncCanonicalConfigToManagedHomes()
     this.runtimeHome.clearLastWrittenAuthJson(accountId)
@@ -294,6 +297,11 @@ export class CodexAccountService {
       undefined,
       getCodexSelectionTargetForAccount(account)
     )
+    // Why: runtime-home validation can clear the selection during reauth's credential transition.
+    this.store.updateSettings({
+      activeCodexManagedAccountId: activeSelection.host,
+      activeCodexManagedAccountIdsByRuntime: activeSelection
+    })
     return this.getSnapshot()
   }
 

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -258,7 +258,11 @@ export class CodexAccountService {
   private async doReauthenticateAccount(accountId: string): Promise<CodexRateLimitAccountsState> {
     const account = this.requireAccount(accountId)
     const managedHomePath = this.ensureManagedHomeForReauthentication(account)
-    const activeSelection = normalizeCodexRuntimeSelection(this.store.getSettings())
+    const accountTarget = getCodexSelectionTargetForAccount(account)
+    const selectedAccountId = getSelectedCodexAccountIdForTarget(
+      this.store.getSettings(),
+      accountTarget
+    )
 
     this.safeSyncCanonicalConfigIntoManagedHome(managedHomePath, undefined, account.id)
     await this.runCodexLogin(managedHomePath)
@@ -282,8 +286,13 @@ export class CodexAccountService {
           }
         : entry
     )
+    const activeSelection = setSelectedCodexAccountIdForTarget(
+      normalizeCodexRuntimeSelection(settings),
+      selectedAccountId,
+      accountTarget
+    )
 
-    // Why: runtime validation can clear selection while login rewrites auth.json; restore it before syncing fresh auth.
+    // Why: login can transiently clear this runtime's selection; unrelated runtime validation must remain authoritative.
     this.store.updateSettings({
       codexManagedAccounts: updatedAccounts,
       activeCodexManagedAccountId: activeSelection.host,
@@ -291,13 +300,10 @@ export class CodexAccountService {
     })
     this.safeSyncCanonicalConfigToManagedHomes()
     this.runtimeHome.clearLastWrittenAuthJson(accountId)
-    this.runtimeHome.syncForCurrentSelection(getCodexSelectionTargetForAccount(account))
+    this.runtimeHome.syncForCurrentSelection(accountTarget)
 
     // Why: re-auth can change the underlying Codex identity, so force a fresh read to avoid showing stale quota.
-    await this.rateLimits.refreshForCodexAccountChange(
-      undefined,
-      getCodexSelectionTargetForAccount(account)
-    )
+    await this.rateLimits.refreshForCodexAccountChange(undefined, accountTarget)
     return this.getSnapshot()
   }
 


### PR DESCRIPTION
## Problem

Re-authenticating a managed Codex account could clear the selected account while `codex login` replaced that account's `auth.json`. Settings then showed **System default** as active, and new Codex panes used the system-default lane even though the managed accounts remained signed in.

This affected both re-authenticating the active host account and re-authenticating another host account while the original account was active.

## Root cause

Runtime-home or rate-limit validation can observe the credential transition during the long-running login and clear that runtime's selection. The account service later persisted refreshed identity metadata, but it did not carry forward the valid selection that existed when reauthentication began.

## Fix

- Snapshot the selected account ID for the reauthenticated account's runtime before starting login.
- After a successful login and identity read, merge only that runtime slot into the latest normalized selection as part of the existing account update.
- Keep runtime-home synchronization and rate-limit refresh targeted to that same host/WSL runtime.
- Do not restore after synchronization or rate-limit refresh, so a real missing-home or credential-validation failure remains authoritative.
- Preserve unrelated runtime changes instead of restoring a stale whole-selection snapshot.

## Correctness and performance boundaries

Failed login or identity resolution exits before the restoration write. A downstream runtime validation clear is not overwritten. The success path still performs one account/settings write, one targeted runtime sync, and one targeted rate-limit refresh; the change adds only bounded in-memory selection normalization and no polling, subprocesses, scans, IPC fanout, or extra persistence write.

## Regression coverage

The service tests now cover:

1. Re-authenticating the active host account preserves its selection.
2. Re-authenticating a different host account preserves the original active account.
3. Failed login does not restore a transiently cleared selection.
4. Runtime validation can still clear the selection after successful login.
5. An unrelated WSL selection cleared during host reauth is not resurrected.
6. WSL reauth restores only its WSL slot and keeps the host slot untouched.
7. Runtime sync and rate-limit refresh remain single, target-scoped calls.

## Validation

- `pnpm tc`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/codex-accounts/service.test.ts src/main/codex-accounts/runtime-home-service.test.ts` (146 tests)
- `pnpm exec oxlint src/main/codex-accounts/service.ts src/main/codex-accounts/service.test.ts`
- `pnpm run check:max-lines-ratchet`
- `git diff --check origin/main...HEAD`

The branch was transplanted onto current `origin/main` after #9501 was squash-merged; the PR now contains only this follow-up.
