### PR TITLE
fix(codex): auto-trust linked worktrees before launch

### DIFF
--- a/src/main/agent-trust-presets.test.ts
+++ b/src/main/agent-trust-presets.test.ts
@@ -137,7 +137,7 @@ describe('markCopilotFolderTrusted', () => {
 })
 
 describe('markCodexProjectTrusted', () => {
-  it('trusts the main repository root for a linked worktree', () => {
+  it('trusts the main repository root for a linked worktree without reading commondir', () => {
     const fixtureRoot = mkdtempSync(join(tmpdir(), 'orca-codex-linked-ws-'))
     const repository = join(fixtureRoot, 'repo')
     const workspace = join(fixtureRoot, 'worktrees', 'feature')
@@ -146,7 +146,7 @@ describe('markCodexProjectTrusted', () => {
       mkdirSync(worktreeGitDir, { recursive: true })
       mkdirSync(workspace, { recursive: true })
       writeFileSync(join(workspace, '.git'), `gitdir: ${worktreeGitDir}\n`, 'utf-8')
-      writeFileSync(join(worktreeGitDir, 'commondir'), '../..\n', 'utf-8')
+      writeFileSync(join(worktreeGitDir, 'gitdir'), join(workspace, '.git'), 'utf-8')
 
       markCodexProjectTrusted(workspace)
 
@@ -166,6 +166,37 @@ describe('markCodexProjectTrusted', () => {
         expect(written).toContain(`[projects."${escapeTomlBasicString(repositoryRoot)}"]`)
         expect(written).not.toContain(`[projects."${escapeTomlBasicString(workspaceRoot)}"]`)
       }
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('does not broaden trust through arbitrary or adversarial Git metadata', () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), 'orca-codex-untrusted-gitdir-'))
+    const workspace = join(fixtureRoot, 'workspace')
+    const arbitraryGitDir = join(fixtureRoot, 'metadata', 'feature')
+    const unrelatedRoot = join(fixtureRoot, 'unrelated')
+    try {
+      mkdirSync(arbitraryGitDir, { recursive: true })
+      mkdirSync(workspace, { recursive: true })
+      mkdirSync(unrelatedRoot, { recursive: true })
+      writeFileSync(join(workspace, '.git'), `gitdir: ${arbitraryGitDir}\n`, 'utf-8')
+      writeFileSync(join(arbitraryGitDir, 'commondir'), join(unrelatedRoot, '.git'), 'utf-8')
+
+      markCodexProjectTrusted(workspace)
+      const structuredGitDir = join(unrelatedRoot, '.git', 'worktrees', 'feature')
+      mkdirSync(structuredGitDir, { recursive: true })
+      writeFileSync(join(workspace, '.git'), `gitdir: ${structuredGitDir}\n`, 'utf-8')
+      writeFileSync(join(structuredGitDir, 'gitdir'), join(unrelatedRoot, '.git'), 'utf-8')
+      markCodexProjectTrusted(workspace)
+
+      const written = readFileSync(join(testState.fakeHomeDir, '.codex', 'config.toml'), 'utf-8')
+      expect(written).toContain(
+        `[projects."${escapeTomlBasicString(realpathSync.native(workspace))}"]`
+      )
+      expect(written).not.toContain(
+        `[projects."${escapeTomlBasicString(realpathSync.native(unrelatedRoot))}"]`
+      )
     } finally {
       rmSync(fixtureRoot, { recursive: true, force: true })
     }

--- a/src/main/agent-trust-presets.test.ts
+++ b/src/main/agent-trust-presets.test.ts
@@ -137,6 +137,40 @@ describe('markCopilotFolderTrusted', () => {
 })
 
 describe('markCodexProjectTrusted', () => {
+  it('trusts the main repository root for a linked worktree', () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), 'orca-codex-linked-ws-'))
+    const repository = join(fixtureRoot, 'repo')
+    const workspace = join(fixtureRoot, 'worktrees', 'feature')
+    const worktreeGitDir = join(repository, '.git', 'worktrees', 'feature')
+    try {
+      mkdirSync(worktreeGitDir, { recursive: true })
+      mkdirSync(workspace, { recursive: true })
+      writeFileSync(join(workspace, '.git'), `gitdir: ${worktreeGitDir}\n`, 'utf-8')
+      writeFileSync(join(worktreeGitDir, 'commondir'), '../..\n', 'utf-8')
+
+      markCodexProjectTrusted(workspace)
+
+      const repositoryRoot = realpathSync.native(repository)
+      const workspaceRoot = realpathSync.native(workspace)
+      const configPath = join(testState.fakeHomeDir, '.codex', 'config.toml')
+      const runtimeConfigPath = join(
+        testState.userDataDir,
+        'codex-runtime-home',
+        'home',
+        'config.toml'
+      )
+      for (const written of [
+        readFileSync(configPath, 'utf-8'),
+        readFileSync(runtimeConfigPath, 'utf-8')
+      ]) {
+        expect(written).toContain(`[projects."${escapeTomlBasicString(repositoryRoot)}"]`)
+        expect(written).not.toContain(`[projects."${escapeTomlBasicString(workspaceRoot)}"]`)
+      }
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true })
+    }
+  })
+
   it('writes ~/.codex/config.toml with the project marked trusted', () => {
     const workspace = mkdtempSync(join(tmpdir(), 'orca-codex-ws-'))
     try {

--- a/src/main/agent-trust-presets.ts
+++ b/src/main/agent-trust-presets.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, realpathSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { dirname, join, resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 import { writeFileAtomically } from './codex-accounts/fs-utils'
 import { getOrcaManagedCodexHomePath } from './codex/codex-home-paths'
 import { upsertProjectTrustLevel } from './codex/config-toml-trust'
@@ -120,18 +120,34 @@ export function markCodexProjectTrusted(workspacePath: string): void {
 function resolveCodexProjectTrustRoot(workspacePath: string): string {
   const absPath = canonicalize(workspacePath)
   try {
-    const gitDirReference = readFileSync(join(absPath, '.git'), 'utf-8')
-    const gitDirMatch = /^gitdir:\s*(.+?)\s*$/im.exec(gitDirReference)
-    if (!gitDirMatch?.[1]) {
+    const gitDirReference = readFileSync(join(absPath, '.git'), 'utf-8').trim()
+    if (!gitDirReference.startsWith('gitdir:')) {
       return absPath
     }
-    const gitDir = resolve(absPath, gitDirMatch[1])
-    const commonDirReference = readFileSync(join(gitDir, 'commondir'), 'utf-8').trim()
-    if (!commonDirReference) {
+    const gitDirPath = gitDirReference.slice('gitdir:'.length).trim()
+    if (!gitDirPath) {
       return absPath
     }
-    // Why: Codex resolves linked-worktree trust through commondir to the main repo root.
-    return canonicalize(dirname(resolve(gitDir, commonDirReference)))
+    const gitDir = resolve(absPath, gitDirPath)
+    const worktreesDir = dirname(gitDir)
+    if (basename(worktreesDir) !== 'worktrees') {
+      return absPath
+    }
+    // Why: workspace-controlled .git metadata must not broaden trust without Git's reciprocal link.
+    const gitDirBacklink = readFileSync(join(gitDir, 'gitdir'), 'utf-8').trim()
+    if (!gitDirBacklink) {
+      return absPath
+    }
+    const resolvedBacklink = resolve(gitDir, gitDirBacklink)
+    const workspaceGitFile = join(absPath, '.git')
+    if (
+      resolvedBacklink !== workspaceGitFile &&
+      canonicalize(resolvedBacklink) !== canonicalize(workspaceGitFile)
+    ) {
+      return absPath
+    }
+    // Why: mirror Codex's validated .git/worktrees/<name> traversal instead of trusting arbitrary commondir contents.
+    return canonicalize(dirname(dirname(worktreesDir)))
   } catch {
     return absPath
   }

--- a/src/main/agent-trust-presets.ts
+++ b/src/main/agent-trust-presets.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, realpathSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import { writeFileAtomically } from './codex-accounts/fs-utils'
 import { getOrcaManagedCodexHomePath } from './codex/codex-home-paths'
 import { upsertProjectTrustLevel } from './codex/config-toml-trust'
@@ -109,12 +109,32 @@ export function markCopilotFolderTrusted(workspacePath: string): void {
  * codex-rs/core/src/config/config_tests.rs in the Codex CLI source.
  */
 export function markCodexProjectTrusted(workspacePath: string): void {
-  const absPath = canonicalize(workspacePath)
+  const absPath = resolveCodexProjectTrustRoot(workspacePath)
   const configPath = join(homedir(), '.codex', 'config.toml')
   upsertProjectTrustLevel(configPath, absPath, 'trusted')
   // Why: Orca-launched Codex runs with an Orca-owned CODEX_HOME, so the trust
   // preset must also update the runtime config Codex will actually read.
   upsertProjectTrustLevel(join(getOrcaManagedCodexHomePath(), 'config.toml'), absPath, 'trusted')
+}
+
+function resolveCodexProjectTrustRoot(workspacePath: string): string {
+  const absPath = canonicalize(workspacePath)
+  try {
+    const gitDirReference = readFileSync(join(absPath, '.git'), 'utf-8')
+    const gitDirMatch = /^gitdir:\s*(.+?)\s*$/im.exec(gitDirReference)
+    if (!gitDirMatch?.[1]) {
+      return absPath
+    }
+    const gitDir = resolve(absPath, gitDirMatch[1])
+    const commonDirReference = readFileSync(join(gitDir, 'commondir'), 'utf-8').trim()
+    if (!commonDirReference) {
+      return absPath
+    }
+    // Why: Codex resolves linked-worktree trust through commondir to the main repo root.
+    return canonicalize(dirname(resolve(gitDir, commonDirReference)))
+  } catch {
+    return absPath
+  }
 }
 
 function canonicalize(p: string): string {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -53,7 +53,7 @@ import {
   rebuildAppMenu
 } from './menu/register-app-menu'
 import { checkForUpdatesFromMenu, isQuittingForUpdate } from './updater'
-import type { UpdateCheckOptions } from '../shared/types'
+import type { TuiAgent, UpdateCheckOptions } from '../shared/types'
 import { recordUpdaterLifecycle } from './updater-lifecycle-diagnostics'
 import {
   configureElectronNetworkCompatibility,
@@ -129,6 +129,7 @@ import { focusExistingMainWindow } from './window/focus-existing-window'
 import { notifyMainWindowBecameVisible } from './window/main-window-visibility'
 import { CodexAccountService } from './codex-accounts/service'
 import { CodexRuntimeHomeService } from './codex-accounts/runtime-home-service'
+import { markCodexProjectTrusted } from './agent-trust-presets'
 import {
   normalizeCodexRuntimeSelection,
   type CodexAccountSelectionTarget
@@ -695,8 +696,21 @@ function startTerminalRuntimeStartupServices(): Promise<void> {
 
 function prepareCodexRuntimeHomeForLaunch(
   target?: CodexAccountSelectionTarget,
-  launchEnv?: NodeJS.ProcessEnv
+  launchEnv?: NodeJS.ProcessEnv,
+  launchContext?: { workspacePath?: string; launchAgent?: TuiAgent }
 ): string | null {
+  if (
+    target?.runtime !== 'wsl' &&
+    launchContext?.launchAgent === 'codex' &&
+    launchContext.workspacePath
+  ) {
+    try {
+      // Why: renderer quick-launch cannot await trust IPC before its PTY mounts; launch prep runs synchronously before every recognized Codex spawn.
+      markCodexProjectTrusted(launchContext.workspacePath)
+    } catch (error) {
+      console.warn('[codex-project-trust] failed to pre-mark launch workspace:', error)
+    }
+  }
   const ensureRealHomeHooksIfSelected = (): boolean => {
     if (
       target?.runtime === 'wsl' ||

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -743,7 +743,8 @@ describe('registerPtyHandlers', () => {
     processEnvOverrides?: Record<string, string | undefined>,
     getSelectedCodexHomePath?: (
       target?: { runtime?: 'host' | 'wsl'; wslDistro?: string | null },
-      launchEnv?: NodeJS.ProcessEnv
+      launchEnv?: NodeJS.ProcessEnv,
+      launchContext?: { workspacePath?: string; launchAgent?: TuiAgent }
     ) => string | null,
     getSettings?: () => {
       enableGitHubAttribution?: boolean
@@ -753,7 +754,9 @@ describe('registerPtyHandlers', () => {
     },
     // Why: PR #2662 finding 2 — accept an optional `command` so callers can exercise OMP target resolution (was untested).
     command?: string,
-    launchAgent?: TuiAgent
+    launchAgent?: TuiAgent,
+    cwd?: string,
+    worktreeId?: string
   ): Promise<Record<string, string>> {
     const savedEnv: Record<string, string | undefined> = {}
     if (processEnvOverrides) {
@@ -781,7 +784,9 @@ describe('registerPtyHandlers', () => {
         rows: 24,
         ...(argsEnv ? { env: argsEnv } : {}),
         ...(command ? { command } : {}),
-        ...(launchAgent ? { launchAgent } : {})
+        ...(launchAgent ? { launchAgent } : {}),
+        ...(cwd ? { cwd } : {}),
+        ...(worktreeId ? { worktreeId } : {})
       })
       const spawnCall = spawnMock.mock.calls.at(-1)!
       return spawnCall[2].env as Record<string, string>
@@ -924,6 +929,34 @@ describe('registerPtyHandlers', () => {
       const env = await spawnAndGetEnv(undefined, undefined, () => TEST_CODEX_HOME)
       expect(env.CODEX_HOME).toBe(TEST_CODEX_HOME)
       expect(env.ORCA_CODEX_HOME).toBe(TEST_CODEX_HOME)
+    })
+
+    it('prepares Codex launch state for the workspace before spawning an interactive tab', async () => {
+      const workspacePath = '/repo/worktrees/new-feature'
+      const resolveHome = vi.fn(
+        (
+          _target?: { runtime?: 'host' | 'wsl'; wslDistro?: string | null },
+          _launchEnv?: NodeJS.ProcessEnv,
+          _launchContext?: { workspacePath?: string; launchAgent?: TuiAgent }
+        ) => null
+      )
+
+      await spawnAndGetEnv(
+        undefined,
+        undefined,
+        resolveHome,
+        undefined,
+        'codex',
+        'codex',
+        workspacePath,
+        `repo-id::${workspacePath}`
+      )
+
+      expect(resolveHome.mock.calls[0]?.[0]).toEqual({ runtime: 'host' })
+      expect(resolveHome.mock.calls[0]?.[2]).toEqual({ workspacePath, launchAgent: 'codex' })
+      expect(resolveHome.mock.invocationCallOrder[0]).toBeLessThan(
+        spawnMock.mock.invocationCallOrder[0]!
+      )
     })
 
     it('injects the OpenCode hook env into Orca terminal PTYs', async () => {
@@ -1504,7 +1537,11 @@ describe('registerPtyHandlers', () => {
 
       async function daemonSpawnAndGetOptions(
         argsEnv?: Record<string, string>,
-        getSelectedCodexHomePath?: () => string | null,
+        getSelectedCodexHomePath?: (
+          target?: { runtime?: 'host' | 'wsl'; wslDistro?: string | null },
+          launchEnv?: NodeJS.ProcessEnv,
+          launchContext?: { workspacePath?: string; launchAgent?: TuiAgent }
+        ) => string | null,
         getSettings?: () => {
           enableGitHubAttribution?: boolean
           httpProxyUrl?: string
@@ -1517,6 +1554,7 @@ describe('registerPtyHandlers', () => {
           worktreeId?: string
           shellOverride?: string
           command?: string
+          launchAgent?: TuiAgent
           envToDelete?: string[]
         },
         supportsGitCredentialGuardHost = true
@@ -1561,14 +1599,23 @@ describe('registerPtyHandlers', () => {
 
       async function daemonSpawnAndGetEnv(
         argsEnv?: Record<string, string>,
-        getSelectedCodexHomePath?: () => string | null,
+        getSelectedCodexHomePath?: (
+          target?: { runtime?: 'host' | 'wsl'; wslDistro?: string | null },
+          launchEnv?: NodeJS.ProcessEnv,
+          launchContext?: { workspacePath?: string; launchAgent?: TuiAgent }
+        ) => string | null,
         getSettings?: () => {
           enableGitHubAttribution?: boolean
           httpProxyUrl?: string
           httpProxyBypassRules?: string
         },
         processEnvOverrides?: Record<string, string | undefined>,
-        spawnArgs?: { cwd?: string; shellOverride?: string; command?: string },
+        spawnArgs?: {
+          cwd?: string
+          shellOverride?: string
+          command?: string
+          launchAgent?: TuiAgent
+        },
         supportsGitCredentialGuardHost = true
       ): Promise<Record<string, string>> {
         return (
@@ -1680,6 +1727,27 @@ describe('registerPtyHandlers', () => {
         const env = await daemonSpawnAndGetEnv({}, () => TEST_CODEX_HOME)
         expect(env.CODEX_HOME).toBe(TEST_CODEX_HOME)
         expect(env.ORCA_CODEX_HOME).toBe(TEST_CODEX_HOME)
+      })
+
+      it('prepares Codex project trust before a daemon-backed interactive launch', async () => {
+        const workspacePath = '/repo/worktrees/new-feature'
+        const resolveHome = vi.fn(
+          (
+            _target?: { runtime?: 'host' | 'wsl'; wslDistro?: string | null },
+            _launchEnv?: NodeJS.ProcessEnv,
+            _launchContext?: { workspacePath?: string; launchAgent?: TuiAgent }
+          ) => null
+        )
+
+        await daemonSpawnAndGetOptions({}, resolveHome, undefined, undefined, {
+          cwd: workspacePath,
+          worktreeId: `repo-id::${workspacePath}`,
+          command: 'codex',
+          launchAgent: 'codex'
+        })
+
+        expect(resolveHome.mock.calls[0]?.[0]).toEqual({ runtime: 'host' })
+        expect(resolveHome.mock.calls[0]?.[2]).toEqual({ workspacePath, launchAgent: 'codex' })
       })
 
       it('injects explicit proxy settings on the daemon path', async () => {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -621,7 +621,8 @@ function getLocalOrcaCodexHomeEnvKeysToDelete(env: Record<string, string>): stri
 
 type GetSelectedCodexHomePath = (
   target?: CodexAccountSelectionTarget,
-  launchEnv?: NodeJS.ProcessEnv
+  launchEnv?: NodeJS.ProcessEnv,
+  launchContext?: { workspacePath?: string; launchAgent?: TuiAgent }
 ) => string | null
 type PrepareClaudeAuth = (
   target?: ClaudeAccountSelectionTarget
@@ -1452,7 +1453,10 @@ export function registerPtyHandlers(
             : { runtime: 'host' }
         const selectedCodexHomePath = getCompatibleSelectedCodexHomePath(
           codexSelectionTarget,
-          getSelectedCodexHomePath?.(codexSelectionTarget, baseEnv) ?? null
+          getSelectedCodexHomePath?.(codexSelectionTarget, baseEnv, {
+            workspacePath: ctx?.cwd,
+            launchAgent: ctx?.launchAgent
+          }) ?? null
         )
         const skipCodexHomeEnv = ctx?.isWsl === true && !selectedCodexHomePath
         const env = buildPtyHostEnv(id, baseEnv, {
@@ -2794,7 +2798,10 @@ export function registerPtyHandlers(
       const selectedCodexHomePath = isDaemonHostSpawn
         ? getCompatibleSelectedCodexHomePath(
             codexSelectionTarget,
-            getSelectedCodexHomePath?.(codexSelectionTarget, env) ?? null
+            getSelectedCodexHomePath?.(codexSelectionTarget, env, {
+              workspacePath: cwd,
+              launchAgent: isTuiAgent(args.launchAgent) ? args.launchAgent : undefined
+            }) ?? null
           )
         : null
       const skipCodexHomeEnv =
@@ -3682,7 +3689,10 @@ export function registerPtyHandlers(
       const selectedCodexHomePath = isDaemonHostSpawn
         ? getCompatibleSelectedCodexHomePath(
             codexSelectionTarget,
-            getSelectedCodexHomePath?.(codexSelectionTarget, baseEnv) ?? null
+            getSelectedCodexHomePath?.(codexSelectionTarget, baseEnv, {
+              workspacePath: cwd,
+              launchAgent: isTuiAgent(args.launchAgent) ? args.launchAgent : undefined
+            }) ?? null
           )
         : null
       const skipCodexHomeEnv =

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -619,7 +619,7 @@ function getLocalOrcaCodexHomeEnvKeysToDelete(env: Record<string, string>): stri
   return keysToDelete
 }
 
-type GetSelectedCodexHomePath = (
+export type GetSelectedCodexHomePath = (
   target?: CodexAccountSelectionTarget,
   launchEnv?: NodeJS.ProcessEnv,
   launchContext?: { workspacePath?: string; launchAgent?: TuiAgent }

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -471,6 +471,7 @@ export type LocalPtyProviderOptions = {
     ctx?: {
       command?: string
       launchAgent?: PtySpawnOptions['launchAgent']
+      cwd?: string
       shellPath?: string
       isWsl?: boolean
       wslDistro?: string | null
@@ -672,6 +673,7 @@ export class LocalPtyProvider implements IPtyProvider {
       ? this.opts.buildSpawnEnv(id, spawnEnv, {
           command: args.command,
           launchAgent: args.launchAgent,
+          cwd,
           shellPath,
           isWsl: isWslShell,
           wslDistro: launchWslDistro

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -12,7 +12,7 @@ import type {
 import { registerRepoHandlers } from '../ipc/repos'
 import { registerWorktreeHandlers } from '../ipc/worktrees'
 import { registerWorkspaceCleanupHandlers } from '../ipc/workspace-cleanup'
-import { getLocalPtyProvider, registerPtyHandlers } from '../ipc/pty'
+import { getLocalPtyProvider, registerPtyHandlers, type GetSelectedCodexHomePath } from '../ipc/pty'
 import { registerDaemonManagementHandlers } from '../ipc/pty-management'
 import { registerSshHandlers } from '../ipc/ssh'
 import { registerRemoteWorkspaceHandlers } from '../ipc/remote-workspace'
@@ -39,7 +39,6 @@ import type { RuntimeMobileSessionTabMove } from '../../shared/runtime-types'
 import { isNativeFileDropPayload, type NativeFileDropPayload } from '../../shared/native-file-drop'
 import { requestMobileMarkdownFromRenderer } from './mobile-markdown-request-relay'
 import { requestTerminalTabCloseFromRenderer } from './terminal-tab-close-request-relay'
-import type { CodexAccountSelectionTarget } from '../codex-accounts/runtime-selection'
 import type { ClaudeAccountSelectionTarget } from '../claude-accounts/runtime-selection'
 import { runWorktreeChangeInvalidators } from '../ipc/worktree-change-invalidators'
 import {
@@ -66,10 +65,7 @@ export function attachMainWindowServices(
   mainWindow: BrowserWindow,
   store: Store,
   runtime: OrcaRuntimeService,
-  getSelectedCodexHomePath?: (
-    target?: CodexAccountSelectionTarget,
-    launchEnv?: NodeJS.ProcessEnv
-  ) => string | null,
+  getSelectedCodexHomePath?: GetSelectedCodexHomePath,
   prepareClaudeAuth?: (
     target?: ClaudeAccountSelectionTarget
   ) => Promise<ClaudeRuntimeAuthPreparation>,


### PR DESCRIPTION
## Summary

- pre-mark recognized host Codex launch workspaces synchronously in main-process PTY preparation, covering interactive tab launches on local and daemon providers before process spawn
- resolve linked worktrees to the common repository root through the same `.git/worktrees/<name>` shape used by Codex, with a reciprocal `gitdir` backlink check so workspace-controlled metadata cannot broaden trust to an unrelated repository
- preserve host boundaries: WSL skips host trust writes, SSH continues using the remote trust writer, and native host launches use Node path APIs
- retain custom `CODEX_HOME` on the managed lane and seed trust before runtime-home mirroring, so shared and per-account managed homes receive the trust entry selected for launch

## Reliability and security review

- **Invariant:** every recognized host Codex launch seeds the matching project trust entry before the local or daemon PTY provider spawns.
- **Failure source:** fresh linked worktrees could mount Codex before renderer trust IPC completed, allowing the trust prompt to intercept startup input.
- **Oracle:** local-provider invocation ordering, daemon launch-context forwarding, and config assertions for the real and managed Codex homes.
- **Trust scope:** a valid linked worktree trusts only its common repository root, matching Codex lookup semantics. Missing, malformed, arbitrary, or mismatched `.git` metadata falls back to the canonical workspace path.
- **Runtime boundaries:** WSL is excluded from host filesystem writes; SSH keeps its existing remote-side implementation; host system-default, custom-home managed, and per-account managed lanes all prepare trust before their launch-home synchronization.
- **Failure behavior:** trust preparation logs `[codex-project-trust]` and allows Codex to fall back to its own prompt if a bounded filesystem/config operation fails.
- **Performance budget:** no subprocess, Git invocation, polling, directory walk, or provider enumeration was added. A recognized Codex launch performs bounded synchronous reads of the workspace `.git` file and linked-worktree backlink plus existing small TOML upserts; the common reciprocal-link case avoids extra realpath calls, and already-trusted upserts do not rewrite files.
- **Compatibility:** the resolver uses filesystem metadata and Node cross-platform path APIs, adding no Git-version dependency.
- **Residual risk:** no live Windows, WSL, or SSH launch was run locally; deterministic routing tests and required CI cover those unchanged or explicitly excluded paths.

## Validation

- `pnpm tc`
- post-final-rebase focused suite: 8 files, 660 tests passed (trust presets/config mirroring, PTY/provider launch contracts, custom/per-account runtime homes, and remote trust)
- runtime orchestration suites: 2 files, 784 tests passed
- targeted `oxlint` and `oxfmt --check`
- `pnpm check:reliability-gates`
- `pnpm check:max-lines-ratchet`
- PR Checks: lint, reliability/max-lines gates, typecheck, Git compatibility, full test suite, unpacked build, and packaged CLI smoke all passed
- Windows terminal restart regressions passed
- Windows packaged crash-survival E2E passed