### PR TITLE
fix(codex): migrate legacy shared-home sessions before resume

### DIFF
--- a/mobile/src/agent-history/MobileAgentSessionHistoryPanel.tsx
+++ b/mobile/src/agent-history/MobileAgentSessionHistoryPanel.tsx
@@ -10,6 +10,7 @@ import type { RpcClient } from '../transport/rpc-client'
 import { getWorktreeLabel } from '../session/worktree-label'
 import {
   buildMobileAiVaultResumeLaunch,
+  prepareMobileAiVaultSessionResume,
   createMobileAiVaultResumeMutationRegistry,
   readMobileRuntimeHostPlatform,
   readMobileRuntimeTerminalWindowsShell,
@@ -197,8 +198,9 @@ export function MobileAgentSessionHistoryPanel({
           return
         }
 
+        const preparedSession = await prepareMobileAiVaultSessionResume(client, session)
         const launch = buildMobileAiVaultResumeLaunch({
-          session,
+          session: preparedSession,
           hostPlatform: platform,
           hostTerminalWindowsShell,
           settings

--- a/mobile/src/session/ai-vault-resume-launch.test.ts
+++ b/mobile/src/session/ai-vault-resume-launch.test.ts
@@ -4,6 +4,7 @@ import {
   buildMobileAiVaultResumeLaunch,
   buildMobileAiVaultResumeCommand,
   createMobileAiVaultResumeMutationRegistry,
+  prepareMobileAiVaultSessionResume,
   readMobileRuntimeHostPlatform,
   readMobileRuntimeTerminalWindowsShell,
   resolveMobileAiVaultResumePlatform,
@@ -174,6 +175,59 @@ describe('buildMobileAiVaultResumeLaunch', () => {
     })
     expect(launch.command).toContain("CODEX_HOME='/Users/ada/.orca/codex-runtime-home/home'")
     expect(launch.envToDelete).toBeUndefined()
+  })
+})
+
+describe('prepareMobileAiVaultSessionResume', () => {
+  it('materializes legacy shared-home sessions before building a real-home launch', async () => {
+    const legacy = session({
+      agent: 'codex',
+      filePath:
+        '/Users/ada/Library/Application Support/orca/codex-runtime-home/home/sessions/2026/07/20/rollout-a.jsonl',
+      codexHome: '/Users/ada/Library/Application Support/orca/codex-runtime-home/home'
+    })
+    const sendRequest = vi.fn().mockResolvedValue({
+      ok: true,
+      result: { useRealCodexHome: true }
+    })
+
+    const prepared = await prepareMobileAiVaultSessionResume({ sendRequest }, legacy)
+    const launch = buildMobileAiVaultResumeLaunch({ session: prepared, hostPlatform: 'darwin' })
+
+    expect(sendRequest).toHaveBeenCalledWith(
+      'aiVault.prepareSessionResume',
+      expect.objectContaining({ filePath: legacy.filePath, codexHome: legacy.codexHome }),
+      { timeoutMs: RESUME_RPC_TIMEOUT_MS }
+    )
+    expect(launch.command).not.toContain('CODEX_HOME=')
+    expect(launch.envToDelete).toEqual(['CODEX_HOME', 'ORCA_CODEX_HOME'])
+  })
+
+  it('fails before terminal creation when targeted materialization fails', async () => {
+    const legacy = session({
+      agent: 'codex',
+      codexHome: '/Users/ada/Library/Application Support/orca/codex-runtime-home/home'
+    })
+    const sendRequest = vi.fn().mockResolvedValue({
+      ok: false,
+      error: { message: 'Retry resume after checking session folder permissions.' }
+    })
+
+    await expect(prepareMobileAiVaultSessionResume({ sendRequest }, legacy)).rejects.toThrow(
+      /Retry resume/
+    )
+  })
+
+  it.each([
+    '/Users/ada/.config/codex',
+    '/Users/ada/Library/Application Support/orca/codex-accounts/a/home',
+    '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.codex'
+  ])('preserves a non-legacy Codex home without an RPC: %s', async (codexHome) => {
+    const current = session({ agent: 'codex', codexHome })
+    const sendRequest = vi.fn()
+
+    await expect(prepareMobileAiVaultSessionResume({ sendRequest }, current)).resolves.toBe(current)
+    expect(sendRequest).not.toHaveBeenCalled()
   })
 })
 

--- a/mobile/src/session/ai-vault-resume-launch.ts
+++ b/mobile/src/session/ai-vault-resume-launch.ts
@@ -4,6 +4,7 @@ import {
   buildAiVaultResumeShellCommand,
   realHomeCodexResumeEnvDeletion
 } from '../../../src/shared/ai-vault-types'
+import { isLegacySharedCodexHome } from '../../../src/shared/ai-vault-resume-preparation'
 import { isResumableTuiAgent } from '../../../src/shared/agent-session-resume'
 import type { SleepingAgentLaunchConfig } from '../../../src/shared/agent-session-resume'
 import { buildAgentResumeStartupPlan } from '../../../src/shared/tui-agent-startup'
@@ -150,6 +151,35 @@ function normalizeMobileAiVaultResumeCommandOverrides(
 // Why: without an explicit timeout, a socket drop mid-resume parks the request
 // on the reconnect waiter for the full reconnect budget, pinning the spinner.
 export const RESUME_RPC_TIMEOUT_MS = 30_000
+
+export async function prepareMobileAiVaultSessionResume(
+  client: Pick<RpcClient, 'sendRequest'>,
+  session: AiVaultSession
+): Promise<AiVaultSession> {
+  if (session.agent !== 'codex' || !isLegacySharedCodexHome(session.codexHome)) {
+    return session
+  }
+  const response = await client.sendRequest(
+    'aiVault.prepareSessionResume',
+    {
+      agent: session.agent,
+      filePath: session.filePath,
+      codexHome: session.codexHome,
+      executionHostId: session.executionHostId
+    },
+    { timeoutMs: RESUME_RPC_TIMEOUT_MS }
+  )
+  if (!response.ok) {
+    throw new Error(
+      response.error?.message || 'Could not prepare this legacy Codex session. Retry resume.'
+    )
+  }
+  const result = response.result as { useRealCodexHome?: unknown } | null
+  if (result?.useRealCodexHome !== true) {
+    return session
+  }
+  return { ...session, codexHome: null }
+}
 
 export async function resumeAiVaultSessionInTerminal(
   client: Pick<RpcClient, 'sendRequest'>,

--- a/src/main/ai-vault/runtime-session-scanner.test.ts
+++ b/src/main/ai-vault/runtime-session-scanner.test.ts
@@ -14,8 +14,11 @@ vi.mock('../ipc/runtime-environment-transport-routing', () => ({
   callRuntimeEnvironment: mocks.callRuntimeEnvironment
 }))
 
-const { getSavedRuntimeAiVaultHostInfos, scanRuntimeAiVaultSessions } =
-  await import('./runtime-session-scanner')
+const {
+  getSavedRuntimeAiVaultHostInfos,
+  prepareRuntimeAiVaultSessionResume,
+  scanRuntimeAiVaultSessions
+} = await import('./runtime-session-scanner')
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -107,6 +110,42 @@ describe('runtime AI Vault session scanner', () => {
         executionHostId: 'runtime:env-1'
       })
     ])
+  })
+
+  it('prepares a resume on the transcript-owning runtime', async () => {
+    mocks.callRuntimeEnvironment.mockResolvedValueOnce({
+      ok: true,
+      result: { useRealCodexHome: true }
+    })
+    const args = {
+      agent: 'codex' as const,
+      filePath: '/managed/sessions/2026/07/20/rollout-a.jsonl',
+      codexHome: '/managed',
+      executionHostId: 'runtime:env-1' as const
+    }
+
+    await expect(prepareRuntimeAiVaultSessionResume('/user-data', 'env-1', args)).resolves.toEqual({
+      useRealCodexHome: true
+    })
+    expect(mocks.callRuntimeEnvironment).toHaveBeenCalledWith(
+      '/user-data',
+      'env-1',
+      'aiVault.prepareSessionResume',
+      args
+    )
+  })
+
+  it('fails retryably when runtime preparation returns an invalid result', async () => {
+    mocks.callRuntimeEnvironment.mockResolvedValueOnce({ ok: true, result: {} })
+
+    await expect(
+      prepareRuntimeAiVaultSessionResume('/user-data', 'env-1', {
+        agent: 'codex',
+        filePath: '/managed/sessions/2026/07/20/rollout-a.jsonl',
+        codexHome: '/managed',
+        executionHostId: 'runtime:env-1'
+      })
+    ).rejects.toThrow('Invalid aiVault.prepareSessionResume response')
   })
 })
 

--- a/src/main/ai-vault/runtime-session-scanner.ts
+++ b/src/main/ai-vault/runtime-session-scanner.ts
@@ -9,6 +9,10 @@ import {
 import { normalizeExecutionHostId, toRuntimeExecutionHostId } from '../../shared/execution-host'
 import { listEnvironments } from '../../shared/runtime-environment-store'
 import { callRuntimeEnvironment } from '../ipc/runtime-environment-transport-routing'
+import type {
+  AiVaultPrepareSessionResumeArgs,
+  AiVaultPrepareSessionResumeResult
+} from '../../shared/ai-vault-resume-preparation'
 
 export type RuntimeAiVaultHostInfo = {
   environmentId: string
@@ -99,6 +103,8 @@ const aiVaultListResultSchema = z.object({
   scannedAt: z.string()
 })
 
+const aiVaultPrepareSessionResumeResultSchema = z.object({ useRealCodexHome: z.boolean() })
+
 export function getSavedRuntimeAiVaultHostInfos(
   userDataPath: string
 ): readonly RuntimeAiVaultHostInfo[] {
@@ -149,6 +155,29 @@ export async function scanRuntimeAiVaultSessions(
     environmentId,
     message: response.error.message
   })
+}
+
+export async function prepareRuntimeAiVaultSessionResume(
+  userDataPath: string,
+  environmentId: string,
+  args: AiVaultPrepareSessionResumeArgs
+): Promise<AiVaultPrepareSessionResumeResult> {
+  const response = await callRuntimeEnvironment(
+    userDataPath,
+    environmentId,
+    'aiVault.prepareSessionResume',
+    args
+  )
+  if (response.ok !== true) {
+    throw new Error(response.error.message)
+  }
+  const parsed = aiVaultPrepareSessionResumeResultSchema.safeParse(response.result)
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid aiVault.prepareSessionResume response: ${parsed.error.issues[0]?.message ?? 'unexpected result shape'}`
+    )
+  }
+  return parsed.data
 }
 
 function withRuntimeExecutionHost(

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -1756,12 +1756,14 @@ describe('CodexAccountService config sync', () => {
     const store = createStore(settings)
     const rateLimits = createRateLimits()
     const runtimeHome = createRuntimeHome()
+    const onHostSystemDefaultSelected = vi.fn()
 
     const { CodexAccountService } = await import('./service')
     const service = new CodexAccountService(
       store as never,
       rateLimits as never,
-      runtimeHome as never
+      runtimeHome as never,
+      { onHostSystemDefaultSelected }
     )
 
     const result = await service.selectAccount(null)
@@ -1769,6 +1771,7 @@ describe('CodexAccountService config sync', () => {
     expect(result.activeAccountId).toBe(null)
     expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalled()
     expect(rateLimits.refreshForCodexAccountChange).toHaveBeenCalled()
+    expect(onHostSystemDefaultSelected).toHaveBeenCalledOnce()
   })
 
   it('selectAccount immediately rewrites the shared runtime auth for existing terminals', async () => {

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -79,6 +79,10 @@ export type CodexAccountAddTarget = {
   wslDistro?: string | null
 }
 
+export type CodexAccountServiceLifecycle = {
+  onHostSystemDefaultSelected?: () => void
+}
+
 type ManagedHomeLocation = {
   managedHomePath: string
   managedHomeRuntime: 'host' | 'wsl'
@@ -158,7 +162,8 @@ export class CodexAccountService {
   constructor(
     private readonly store: Store,
     private readonly rateLimits: RateLimitService,
-    private readonly runtimeHome: CodexRuntimeHomeService
+    private readonly runtimeHome: CodexRuntimeHomeService,
+    private readonly lifecycle: CodexAccountServiceLifecycle = {}
   ) {
     this.safeSyncCanonicalConfigToManagedHomes()
   }
@@ -324,6 +329,9 @@ export class CodexAccountService {
       activeCodexManagedAccountIdsByRuntime: nextSelection
     })
     this.runtimeHome.syncForCurrentSelection()
+    if (account.managedHomeRuntime === 'host' && nextSelection.host === null) {
+      this.lifecycle.onHostSystemDefaultSelected?.()
+    }
 
     this.safeRemoveManagedHome(account.managedHomePath, account.id)
     // Why: a removed account can no longer appear in the switcher dropdown,
@@ -371,6 +379,12 @@ export class CodexAccountService {
     })
     this.safeSyncCanonicalConfigToManagedHomes()
     this.runtimeHome.syncForCurrentSelection(effectiveTarget)
+    if (
+      accountId === null &&
+      normalizeCodexAccountSelectionTarget(effectiveTarget).runtime === 'host'
+    ) {
+      this.lifecycle.onHostSystemDefaultSelected?.()
+    }
 
     await this.rateLimits.refreshForCodexAccountChange(outgoingAccountId, effectiveTarget)
     return this.getSnapshot()
@@ -520,6 +534,9 @@ export class CodexAccountService {
         activeCodexManagedAccountId: nextSelection.host,
         activeCodexManagedAccountIdsByRuntime: nextSelection
       })
+      if (selection.host !== null && nextSelection.host === null) {
+        this.lifecycle.onHostSystemDefaultSelected?.()
+      }
     }
   }
 

--- a/src/main/codex/codex-legacy-session-resume.test.ts
+++ b/src/main/codex/codex-legacy-session-resume.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { prepareLegacySharedCodexSessionResume } from './codex-legacy-session-resume'
+
+describe('prepareLegacySharedCodexSessionResume', () => {
+  let root: string
+  let legacyHome: string
+  let systemHome: string
+  let rolloutPath: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'orca-legacy-codex-resume-'))
+    legacyHome = join(root, 'codex-runtime-home', 'home')
+    systemHome = join(root, 'real-codex-home')
+    rolloutPath = join(
+      legacyHome,
+      'sessions',
+      '2026',
+      '07',
+      '20',
+      'rollout-2026-07-20T12-00-00-session.jsonl'
+    )
+    mkdirSync(join(rolloutPath, '..'), { recursive: true })
+    writeFileSync(rolloutPath, '{"type":"session_meta"}\n', 'utf-8')
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('materializes an immediate legacy resume into the real home', async () => {
+    const result = await prepare()
+    const targetPath = targetRolloutPath()
+
+    expect(result).toEqual({ useRealCodexHome: true })
+    expect(readFileSync(targetPath, 'utf-8')).toBe('{"type":"session_meta"}\n')
+    expect(statSync(targetPath).ino).toBe(statSync(rolloutPath).ino)
+  })
+
+  it('coalesces concurrent resumes of the same legacy rollout', async () => {
+    const [first, second] = await Promise.all([prepare(), prepare()])
+
+    expect(first.useRealCodexHome).toBe(true)
+    expect(second.useRealCodexHome).toBe(true)
+    expect(readFileSync(targetRolloutPath(), 'utf-8')).toContain('session_meta')
+  })
+
+  it('fails clearly and retryably instead of approving a missing rollout', async () => {
+    rmSync(rolloutPath)
+
+    await expect(prepare()).rejects.toThrow(/Retry resume/)
+    expect(existsSync(targetRolloutPath())).toBe(false)
+  })
+
+  it('fails closed when a different rollout already owns the target path', async () => {
+    mkdirSync(join(targetRolloutPath(), '..'), { recursive: true })
+    writeFileSync(targetRolloutPath(), '{"different":true}\n', 'utf-8')
+
+    await expect(prepare()).rejects.toThrow(/Retry resume/)
+    expect(readFileSync(targetRolloutPath(), 'utf-8')).toBe('{"different":true}\n')
+  })
+
+  it.each([
+    ['per-account home', join(rootPlaceholder(), 'codex-accounts', 'account-1', 'home'), 'local'],
+    ['custom home', join(rootPlaceholder(), 'custom-codex-home'), 'local'],
+    ['WSL home', '\\\\wsl.localhost\\Ubuntu\\home\\me\\.codex', 'local'],
+    ['SSH session', rootPlaceholder(), 'ssh:server-1']
+  ])(
+    'preserves %s without materializing it',
+    async (_label, codexHomeTemplate, executionHostId) => {
+      const codexHome = codexHomeTemplate.replace(rootPlaceholder(), root)
+      const result = await prepareLegacySharedCodexSessionResume(
+        {
+          agent: 'codex',
+          filePath: rolloutPath,
+          codexHome,
+          executionHostId: executionHostId as 'local'
+        },
+        options()
+      )
+
+      expect(result).toEqual({ useRealCodexHome: false })
+      expect(existsSync(targetRolloutPath())).toBe(false)
+    }
+  )
+
+  it.each(['managed account', 'custom CODEX_HOME'])(
+    'preserves the legacy home while the %s lane is selected',
+    async () => {
+      const result = await prepareLegacySharedCodexSessionResume(legacyArgs(), {
+        ...options(),
+        isHostSystemDefaultRealHome: () => false
+      })
+
+      expect(result).toEqual({ useRealCodexHome: false })
+      expect(existsSync(targetRolloutPath())).toBe(false)
+    }
+  )
+
+  function prepare() {
+    return prepareLegacySharedCodexSessionResume(legacyArgs(), options())
+  }
+
+  function legacyArgs() {
+    return {
+      agent: 'codex' as const,
+      filePath: rolloutPath,
+      codexHome: legacyHome,
+      executionHostId: 'local' as const
+    }
+  }
+
+  function options() {
+    return {
+      isHostSystemDefaultRealHome: () => true,
+      legacyCodexHomePath: legacyHome,
+      systemCodexHomePath: systemHome
+    }
+  }
+
+  function targetRolloutPath(): string {
+    return join(
+      systemHome,
+      'sessions',
+      '2026',
+      '07',
+      '20',
+      'rollout-2026-07-20T12-00-00-session.jsonl'
+    )
+  }
+})
+
+function rootPlaceholder(): string {
+  return '__ROOT__'
+}

--- a/src/main/codex/codex-legacy-session-resume.ts
+++ b/src/main/codex/codex-legacy-session-resume.ts
@@ -1,0 +1,175 @@
+import { createHash } from 'node:crypto'
+import { createReadStream } from 'node:fs'
+import { link, lstat, mkdir } from 'node:fs/promises'
+import { dirname, join, relative, resolve, sep } from 'node:path'
+import type {
+  AiVaultPrepareSessionResumeArgs,
+  AiVaultPrepareSessionResumeResult
+} from '../../shared/ai-vault-resume-preparation'
+import { LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
+import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+import {
+  appendCodexSessionHealAuditRecord,
+  createCodexSessionBackfillAuditWriter
+} from './codex-session-backfill-audit'
+import {
+  copySessionFileWithoutOverwrite,
+  isAtomicNoReplaceUnsupportedError
+} from './codex-session-backfill-copy'
+import { resolveCodexSessionBackfillPaths } from './codex-session-backfill'
+
+const RETRYABLE_RESUME_ERROR =
+  'Orca could not safely move this legacy Codex session into your system Codex home. Retry resume; if it still fails, check that both Codex session folders are readable and writable.'
+
+const materializations = new Map<string, Promise<void>>()
+
+export async function prepareLegacySharedCodexSessionResume(
+  args: AiVaultPrepareSessionResumeArgs,
+  options: {
+    isHostSystemDefaultRealHome: () => boolean
+    legacyCodexHomePath?: string
+    systemCodexHomePath?: string
+  }
+): Promise<AiVaultPrepareSessionResumeResult> {
+  const paths = resolveCodexSessionBackfillPaths(options.systemCodexHomePath)
+  const legacyCodexHomePath = options.legacyCodexHomePath ?? dirname(paths.managedSessionsRoot)
+  const managedSessionsRoot = join(legacyCodexHomePath, 'sessions')
+  if (
+    args.agent !== 'codex' ||
+    args.executionHostId !== LOCAL_EXECUTION_HOST_ID ||
+    !args.codexHome ||
+    !sameRuntimePath(args.codexHome, legacyCodexHomePath) ||
+    !options.isHostSystemDefaultRealHome()
+  ) {
+    return { useRealCodexHome: false }
+  }
+
+  const sourcePath = resolve(args.filePath)
+  const relativePath = relative(resolve(managedSessionsRoot), sourcePath)
+  if (!isLegacyRolloutRelativePath(relativePath)) {
+    throw new Error(RETRYABLE_RESUME_ERROR)
+  }
+  const targetPath = join(paths.systemSessionsRoot, relativePath)
+  const key = `${normalizeRuntimePathForComparison(sourcePath)}\0${normalizeRuntimePathForComparison(targetPath)}`
+  let task = materializations.get(key)
+  if (!task) {
+    task = materializeLegacyRollout(sourcePath, targetPath, paths.auditLogPath)
+    materializations.set(key, task)
+    void task.then(
+      () => {
+        if (materializations.get(key) === task) {
+          materializations.delete(key)
+        }
+      },
+      () => {
+        if (materializations.get(key) === task) {
+          materializations.delete(key)
+        }
+      }
+    )
+  }
+
+  try {
+    await task
+  } catch (error) {
+    console.warn('[codex-legacy-session-resume] Targeted session migration failed:', error)
+    throw new Error(RETRYABLE_RESUME_ERROR, { cause: error })
+  }
+  return { useRealCodexHome: true }
+}
+
+async function materializeLegacyRollout(
+  sourcePath: string,
+  targetPath: string,
+  auditLogPath: string
+): Promise<void> {
+  const sourceStat = await lstat(sourcePath)
+  if (!sourceStat.isFile() || sourceStat.isSymbolicLink()) {
+    throw new Error('Legacy rollout source is not a regular file.')
+  }
+  await mkdir(dirname(targetPath), { recursive: true })
+  try {
+    await link(sourcePath, targetPath)
+  } catch (linkError) {
+    if (isExistsError(linkError)) {
+      await assertMatchingExistingTarget(sourcePath, targetPath)
+    } else {
+      try {
+        await copySessionFileWithoutOverwrite(sourcePath, targetPath)
+      } catch (copyError) {
+        if (isExistsError(copyError)) {
+          await assertMatchingExistingTarget(sourcePath, targetPath)
+        } else {
+          if (isAtomicNoReplaceUnsupportedError(copyError)) {
+            throw new Error('The target filesystem cannot safely install this rollout.', {
+              cause: copyError
+            })
+          }
+          throw copyError
+        }
+      }
+    }
+  }
+
+  const summary = {
+    stopped: false,
+    scannedFiles: 1,
+    linkedFiles: 0,
+    copiedFiles: 0,
+    skippedExistingFiles: 0,
+    skippedUnexpectedFiles: 0,
+    skippedSymlinkFiles: 0,
+    skippedUnsupportedFilesystemFiles: 0,
+    failedDirectories: 0,
+    failedFiles: 0,
+    failedHealAuditRecords: 0
+  }
+  await appendCodexSessionHealAuditRecord(
+    createCodexSessionBackfillAuditWriter(auditLogPath),
+    summary,
+    { action: 'targeted-resume', source: sourcePath, target: targetPath }
+  )
+}
+
+async function assertMatchingExistingTarget(sourcePath: string, targetPath: string): Promise<void> {
+  const [sourceStat, targetStat] = await Promise.all([lstat(sourcePath), lstat(targetPath)])
+  if (
+    !targetStat.isFile() ||
+    targetStat.isSymbolicLink() ||
+    sourceStat.size !== targetStat.size ||
+    ((sourceStat.dev !== targetStat.dev || sourceStat.ino !== targetStat.ino) &&
+      (await fileDigest(sourcePath)) !== (await fileDigest(targetPath)))
+  ) {
+    throw new Error('A different rollout already occupies the real-home target path.')
+  }
+}
+
+async function fileDigest(filePath: string): Promise<string> {
+  const hash = createHash('sha256')
+  for await (const chunk of createReadStream(filePath)) {
+    hash.update(chunk as Buffer)
+  }
+  return hash.digest('hex')
+}
+
+function isLegacyRolloutRelativePath(relativePath: string): boolean {
+  if (!relativePath || relativePath.startsWith('..') || resolve(relativePath) === relativePath) {
+    return false
+  }
+  const parts = relativePath.split(sep)
+  return (
+    parts.length === 4 &&
+    /^\d{4}$/.test(parts[0] ?? '') &&
+    /^\d{2}$/.test(parts[1] ?? '') &&
+    /^\d{2}$/.test(parts[2] ?? '') &&
+    /^rollout-.+\.jsonl$/.test(parts[3] ?? '')
+  )
+}
+
+function sameRuntimePath(left: string, right: string): boolean {
+  return normalizeRuntimePathForComparison(left) === normalizeRuntimePathForComparison(right)
+}
+
+function isExistsError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | null)?.code === 'EEXIST'
+}

--- a/src/main/codex/codex-session-migration-scheduler.test.ts
+++ b/src/main/codex/codex-session-migration-scheduler.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createCodexSessionMigrationScheduler } from './codex-session-migration-scheduler'
+
+describe('createCodexSessionMigrationScheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  it('runs after a managed-account startup switches to host system default', async () => {
+    let eligible = false
+    const startBackfill = vi.fn().mockResolvedValue(null)
+    const startIndexHeal = vi.fn().mockResolvedValue(null)
+    const scheduler = createCodexSessionMigrationScheduler({
+      isEligible: () => eligible,
+      isQuitting: () => false,
+      resolveSystemCodexHomePathOverride: () => undefined,
+      startBackfill,
+      startIndexHeal
+    })
+
+    scheduler.scheduleInitialRun()
+    await vi.advanceTimersByTimeAsync(15_000)
+    expect(startBackfill).not.toHaveBeenCalled()
+
+    eligible = true
+    scheduler.requestRun()
+    await vi.waitFor(() => expect(startIndexHeal).toHaveBeenCalledOnce())
+    expect(startBackfill).toHaveBeenCalledOnce()
+  })
+
+  it('coalesces concurrent run requests and stops before index heal after opt-out', async () => {
+    let eligible = true
+    let releaseBackfill: (() => void) | undefined
+    const startBackfill = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseBackfill = resolve
+        })
+    )
+    const startIndexHeal = vi.fn().mockResolvedValue(null)
+    const scheduler = createCodexSessionMigrationScheduler({
+      isEligible: () => eligible,
+      isQuitting: () => false,
+      resolveSystemCodexHomePathOverride: () => '/custom/history',
+      startBackfill,
+      startIndexHeal
+    })
+
+    scheduler.requestRun()
+    scheduler.requestRun()
+    expect(startBackfill).toHaveBeenCalledOnce()
+    expect(startBackfill).toHaveBeenCalledWith(expect.any(Object), '/custom/history')
+
+    eligible = false
+    releaseBackfill?.()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(startIndexHeal).not.toHaveBeenCalled()
+  })
+
+  it('reruns after a stopping migration becomes eligible again', async () => {
+    let eligible = true
+    let releaseFirstBackfill: ((result: { stopped: boolean }) => void) | undefined
+    const startBackfill = vi
+      .fn()
+      .mockImplementationOnce(
+        (_options) =>
+          new Promise<{ stopped: boolean }>((resolve) => {
+            releaseFirstBackfill = resolve
+          })
+      )
+      .mockResolvedValueOnce({ stopped: false })
+    const startIndexHeal = vi.fn().mockResolvedValue(null)
+    const scheduler = createCodexSessionMigrationScheduler({
+      isEligible: () => eligible,
+      isQuitting: () => false,
+      resolveSystemCodexHomePathOverride: () => undefined,
+      startBackfill,
+      startIndexHeal
+    })
+
+    scheduler.requestRun()
+    const firstRunOptions = startBackfill.mock.calls[0]?.[0]
+    eligible = false
+    expect(firstRunOptions?.shouldStop()).toBe(true)
+    eligible = true
+    scheduler.requestRun()
+    releaseFirstBackfill?.({ stopped: true })
+
+    await vi.waitFor(() => expect(startBackfill).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(startIndexHeal).toHaveBeenCalledOnce())
+  })
+})

--- a/src/main/codex/codex-session-migration-scheduler.ts
+++ b/src/main/codex/codex-session-migration-scheduler.ts
@@ -1,0 +1,87 @@
+import type { CodexSessionBackfillOptions } from './codex-session-backfill-types'
+
+type MigrationRun = (
+  options: CodexSessionBackfillOptions,
+  systemCodexHomePathOverride?: string
+) => Promise<unknown>
+
+export type CodexSessionMigrationScheduler = {
+  scheduleInitialRun(): void
+  requestRun(): void
+}
+
+export function createCodexSessionMigrationScheduler(args: {
+  isEligible: () => boolean
+  isQuitting: () => boolean
+  resolveSystemCodexHomePathOverride: () => string | undefined
+  startBackfill: MigrationRun
+  startIndexHeal: MigrationRun
+  initialDelayMs?: number
+}): CodexSessionMigrationScheduler {
+  let initialTimer: ReturnType<typeof setTimeout> | null = null
+  let migrationTask: Promise<void> | null = null
+  let activeRunStopObserved = false
+  let rerunRequested = false
+
+  const requestRun = (): void => {
+    if (args.isQuitting() || !args.isEligible()) {
+      return
+    }
+    if (migrationTask) {
+      // Why: an account transition can re-enable migration while the prior run is still stopping.
+      rerunRequested ||= activeRunStopObserved
+      return
+    }
+    activeRunStopObserved = false
+    rerunRequested = false
+    const shouldStop = (): boolean => {
+      const stopped = args.isQuitting() || !args.isEligible()
+      activeRunStopObserved ||= stopped
+      return stopped
+    }
+    const systemCodexHomePathOverride = args.resolveSystemCodexHomePathOverride()
+    let stoppedBackfill = false
+    const task = args
+      .startBackfill({ shouldStop }, systemCodexHomePathOverride)
+      .then((result) => {
+        stoppedBackfill = isStoppedMigrationResult(result)
+        if (stoppedBackfill || shouldStop()) {
+          return
+        }
+        return args.startIndexHeal({ shouldStop }, systemCodexHomePathOverride)
+      })
+      .catch((error: unknown) => {
+        console.warn('[codex-session-migration] Background session migration failed:', error)
+      })
+      .then(() => undefined)
+    migrationTask = task
+    void task.finally(() => {
+      if (migrationTask === task) {
+        migrationTask = null
+        const shouldRerun = rerunRequested || stoppedBackfill
+        rerunRequested = false
+        activeRunStopObserved = false
+        if (shouldRerun) {
+          requestRun()
+        }
+      }
+    })
+  }
+
+  return {
+    scheduleInitialRun(): void {
+      if (initialTimer) {
+        return
+      }
+      initialTimer = setTimeout(() => {
+        initialTimer = null
+        requestRun()
+      }, args.initialDelayMs ?? 15_000)
+    },
+    requestRun
+  }
+}
+
+function isStoppedMigrationResult(result: unknown): boolean {
+  return Boolean(result && typeof result === 'object' && 'stopped' in result && result.stopped)
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -143,6 +143,8 @@ import {
 import { setCodexTrustGrantTelemetry } from './codex/codex-hook-trust-grant'
 import { startCodexSessionBackfillInBackground } from './codex/codex-session-backfill'
 import { startCodexSessionIndexHealInBackground } from './codex/codex-session-index-heal'
+import { createCodexSessionMigrationScheduler } from './codex/codex-session-migration-scheduler'
+import { prepareLegacySharedCodexSessionResume } from './codex/codex-legacy-session-resume'
 import { resolveHostCodexSessionSourceHome } from './codex/codex-session-source-home'
 import { getDefaultWslDistro } from './wsl'
 import { ClaudeAccountService } from './claude-accounts/service'
@@ -1023,6 +1025,12 @@ function openMainWindow(): BrowserWindow {
     {
       getAdditionalAiVaultCodexHomePaths: () =>
         codexRuntimeHome ? codexRuntimeHome.getHostCodexHomePathsForSessionDiscovery() : [],
+      prepareAiVaultSessionResume: (args) =>
+        prepareLegacySharedCodexSessionResume(args, {
+          isHostSystemDefaultRealHome: () =>
+            codexRuntimeHome?.isHostSystemDefaultRealHome() === true,
+          systemCodexHomePath: resolveHostCodexSessionSourceHome(store!.getSettings())
+        }),
       onBeforeRelaunch: async () => {
         isQuitting = true
         desktopRelayService?.fenceAndCloseNow()
@@ -1789,41 +1797,22 @@ app.whenReady().then(async () => {
       codexRuntimeHome.isHostSystemDefaultRealHome() &&
       isAgentStatusHooksEnabled(store?.getSettings())
   )
-  codexAccounts = new CodexAccountService(store, rateLimits, codexRuntimeHome)
+  const codexSessionMigration = createCodexSessionMigrationScheduler({
+    isEligible: () => codexRuntimeHome?.isHostSystemDefaultRealHome() === true,
+    isQuitting: () => isQuitting,
+    resolveSystemCodexHomePathOverride: () =>
+      resolveHostCodexSessionSourceHome(store!.getSettings()),
+    startBackfill: startCodexSessionBackfillInBackground,
+    startIndexHeal: startCodexSessionIndexHealInBackground
+  })
+  codexAccounts = new CodexAccountService(store, rateLimits, codexRuntimeHome, {
+    onHostSystemDefaultSelected: codexSessionMigration.requestRun
+  })
   // Why: one-time per-host backfill makes historical Orca-managed Codex
   // sessions visible to the user's own resume picker and app history (#4444,
   // #8612). Deferred so startup and first PTY spawns never compete with the
   // sessions tree walk.
-  setTimeout(() => {
-    // Why: reverse-backfilling into the user's Codex home belongs exclusively
-    // to the real-home lane; flag-off, managed-account, and custom-CODEX_HOME
-    // launch lanes must remain byte-identical and leave that history untouched.
-    if (!codexRuntimeHome?.isHostSystemDefaultRealHome()) {
-      return
-    }
-    const systemCodexHomePathOverride = resolveHostCodexSessionSourceHome(store!.getSettings())
-    const shouldStopSessionMigration = (): boolean =>
-      isQuitting || codexRuntimeHome?.isHostSystemDefaultRealHome() !== true
-    // Why: the heal pass chains after the backfill settles so thread/read only
-    // runs once the audit ledger covers this startup's newly linked rollouts;
-    // it also drains sessions left pending by an interrupted earlier pass.
-    void startCodexSessionBackfillInBackground(
-      { shouldStop: shouldStopSessionMigration },
-      systemCodexHomePathOverride
-    ).then(() => {
-      // Why: flag-OFF, managed-account, and custom-home lanes must never spawn
-      // an app-server against the user's real sqlite index.
-      if (!codexRuntimeHome?.isHostSystemDefaultRealHome()) {
-        return
-      }
-      return startCodexSessionIndexHealInBackground(
-        {
-          shouldStop: shouldStopSessionMigration
-        },
-        systemCodexHomePathOverride
-      )
-    })
-  }, 15_000)
+  codexSessionMigration.scheduleInitialRun()
   claudeRuntimeAuth = new ClaudeRuntimeAuthService(store)
   claudeAccounts = new ClaudeAccountService(store, rateLimits, claudeRuntimeAuth)
   rateLimits.setCodexHomePathResolver((target) =>
@@ -1914,6 +1903,11 @@ app.whenReady().then(async () => {
     // Why: source codex-home here (runs in window AND serve) so aiVault.listSessions includes managed-Codex sessions; registerCoreHandlers is window-only.
     getAdditionalAiVaultCodexHomePaths: () =>
       codexRuntimeHome ? codexRuntimeHome.getHostCodexHomePathsForSessionDiscovery() : [],
+    prepareAiVaultSessionResume: (args) =>
+      prepareLegacySharedCodexSessionResume(args, {
+        isHostSystemDefaultRealHome: () => codexRuntimeHome?.isHostSystemDefaultRealHome() === true,
+        systemCodexHomePath: resolveHostCodexSessionSourceHome(store!.getSettings())
+      }),
     buildAgentHookPtyEnv: () =>
       isAgentStatusHooksEnabled(store?.getSettings()) ? agentHookServer.buildPtyEnv() : {}
   })

--- a/src/main/ipc/ai-vault-resume.ts
+++ b/src/main/ipc/ai-vault-resume.ts
@@ -1,0 +1,39 @@
+import { ipcMain } from 'electron'
+import type {
+  AiVaultPrepareSessionResumeArgs,
+  AiVaultPrepareSessionResumeResult,
+  AiVaultSessionResumePreparation
+} from '../../shared/ai-vault-resume-preparation'
+import { parseExecutionHostId } from '../../shared/execution-host'
+
+export type AiVaultResumeHandlerOptions = {
+  prepareSessionResume?: AiVaultSessionResumePreparation
+  prepareRuntimeSessionResume?: (
+    environmentId: string,
+    args: AiVaultPrepareSessionResumeArgs
+  ) => Promise<AiVaultPrepareSessionResumeResult>
+}
+
+export function registerAiVaultResumeHandler(options: AiVaultResumeHandlerOptions): void {
+  ipcMain.handle('aiVault:prepareSessionResume', (_event, args: AiVaultPrepareSessionResumeArgs) =>
+    prepareAiVaultSessionResume(args, options)
+  )
+}
+
+export async function prepareAiVaultSessionResume(
+  args: AiVaultPrepareSessionResumeArgs,
+  options: AiVaultResumeHandlerOptions
+): Promise<AiVaultPrepareSessionResumeResult> {
+  const executionHost = parseExecutionHostId(args.executionHostId)
+  if (executionHost?.kind === 'runtime') {
+    if (!options.prepareRuntimeSessionResume) {
+      throw new Error('The session host is unavailable. Reconnect it and retry resume.')
+    }
+    return options.prepareRuntimeSessionResume(executionHost.environmentId, args)
+  }
+  // Why: the desktop process must never materialize transcript paths owned by an SSH host.
+  if (executionHost?.kind === 'ssh') {
+    return { useRealCodexHome: false }
+  }
+  return options.prepareSessionResume?.(args) ?? { useRealCodexHome: false }
+}

--- a/src/main/ipc/ai-vault.test.ts
+++ b/src/main/ipc/ai-vault.test.ts
@@ -13,12 +13,13 @@ const mocks = vi.hoisted(() => ({
   getAiVaultWslHomeDirs: vi.fn(),
   getSshFilesystemProvider: vi.fn(),
   getActiveSshAiVaultHostInfo: vi.fn(),
-  getActiveSshAiVaultHostInfos: vi.fn()
+  getActiveSshAiVaultHostInfos: vi.fn(),
+  ipcHandle: vi.fn()
 }))
 
 vi.mock('electron', () => ({
   app: { on: vi.fn() },
-  ipcMain: { handle: vi.fn() }
+  ipcMain: { handle: mocks.ipcHandle }
 }))
 
 vi.mock('../ai-vault/session-scanner', () => ({
@@ -205,6 +206,79 @@ describe('listAiVaultSessions host routing', () => {
     expect(mocks.scanRemoteAiVaultSessions).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('prepareSessionResume IPC', () => {
+  it('awaits the host-local targeted resume preparation', async () => {
+    const prepareSessionResume = vi.fn().mockResolvedValue({ useRealCodexHome: true })
+    registerAiVaultHandlers({ prepareSessionResume })
+    const registration = mocks.ipcHandle.mock.calls.find(
+      ([channel]) => channel === 'aiVault:prepareSessionResume'
+    )
+    const handler = registration?.[1] as
+      | ((_event: unknown, args: unknown) => Promise<unknown>)
+      | undefined
+    const args = {
+      agent: 'codex',
+      filePath: '/managed/sessions/2026/07/20/rollout-a.jsonl',
+      codexHome: '/managed',
+      executionHostId: 'local'
+    }
+
+    await expect(handler?.({}, args)).resolves.toEqual({ useRealCodexHome: true })
+    expect(prepareSessionResume).toHaveBeenCalledWith(args)
+  })
+
+  it('prepares saved-runtime sessions on the transcript-owning runtime', async () => {
+    const prepareSessionResume = vi.fn()
+    const prepareRuntimeSessionResume = vi.fn().mockResolvedValue({ useRealCodexHome: true })
+    registerAiVaultHandlers({ prepareSessionResume, prepareRuntimeSessionResume })
+    const args = {
+      agent: 'codex' as const,
+      filePath: '/managed/sessions/2026/07/20/rollout-a.jsonl',
+      codexHome: '/managed',
+      executionHostId: 'runtime:env-123' as const
+    }
+
+    await expect(getPrepareSessionResumeHandler()({}, args)).resolves.toEqual({
+      useRealCodexHome: true
+    })
+    expect(prepareRuntimeSessionResume).toHaveBeenCalledWith('env-123', args)
+    expect(prepareSessionResume).not.toHaveBeenCalled()
+  })
+
+  it('preserves SSH session homes without reading their paths locally', async () => {
+    const prepareSessionResume = vi.fn()
+    const prepareRuntimeSessionResume = vi.fn()
+    registerAiVaultHandlers({ prepareSessionResume, prepareRuntimeSessionResume })
+
+    await expect(
+      getPrepareSessionResumeHandler()(
+        {},
+        {
+          agent: 'codex',
+          filePath: '/managed/sessions/2026/07/20/rollout-a.jsonl',
+          codexHome: '/managed',
+          executionHostId: 'ssh:dev-box'
+        }
+      )
+    ).resolves.toEqual({ useRealCodexHome: false })
+    expect(prepareSessionResume).not.toHaveBeenCalled()
+    expect(prepareRuntimeSessionResume).not.toHaveBeenCalled()
+  })
+})
+
+function getPrepareSessionResumeHandler(): (
+  event: unknown,
+  args: unknown
+) => Promise<{ useRealCodexHome: boolean }> {
+  const registration = mocks.ipcHandle.mock.calls.find(
+    ([channel]) => channel === 'aiVault:prepareSessionResume'
+  )
+  if (!registration) {
+    throw new Error('aiVault:prepareSessionResume was not registered')
+  }
+  return registration[1]
+}
 
 describe('listAiVaultSubagentSessions gating', () => {
   const claudeRoot = join(homedir(), '.claude', 'projects')

--- a/src/main/ipc/ai-vault.ts
+++ b/src/main/ipc/ai-vault.ts
@@ -18,6 +18,7 @@ import type {
   AiVaultSubagentListArgs,
   AiVaultSubagentListResult
 } from '../../shared/ai-vault-types'
+import { registerAiVaultResumeHandler, type AiVaultResumeHandlerOptions } from './ai-vault-resume'
 import {
   LOCAL_EXECUTION_HOST_ID,
   normalizeExecutionHostScope,
@@ -35,14 +36,15 @@ import { getActiveSshAiVaultHostInfo, getActiveSshAiVaultHostInfos } from './ssh
 const AI_VAULT_CACHE_TTL_MS = 15_000
 const AI_VAULT_ALL_HOST_RUNTIME_TIMEOUT_MS = 3_000
 
-type AiVaultHandlerOptions = AiVaultSessionSources & {
-  getActiveRuntimeAiVaultHostInfos?: () => readonly RuntimeAiVaultHostInfo[]
-  scanRuntimeAiVaultSessions?: (
-    environmentId: string,
-    args: AiVaultListArgs,
-    options?: RuntimeAiVaultScanOptions
-  ) => Promise<AiVaultListResult>
-}
+type AiVaultHandlerOptions = AiVaultSessionSources &
+  AiVaultResumeHandlerOptions & {
+    getActiveRuntimeAiVaultHostInfos?: () => readonly RuntimeAiVaultHostInfo[]
+    scanRuntimeAiVaultSessions?: (
+      environmentId: string,
+      args: AiVaultListArgs,
+      options?: RuntimeAiVaultScanOptions
+    ) => Promise<AiVaultListResult>
+  }
 
 type RuntimeAiVaultScanOptions = {
   timeoutMs?: number
@@ -281,6 +283,7 @@ export function registerAiVaultHandlers(options: AiVaultHandlerOptions = {}): vo
   ipcMain.handle('aiVault:listSessions', (_event, args?: AiVaultListArgs) =>
     listAiVaultSessions(args)
   )
+  registerAiVaultResumeHandler(options)
   ipcMain.handle(
     'aiVault:listSubagentSessions',
     (_event, args?: AiVaultSubagentListArgs): Promise<AiVaultSubagentListResult> =>

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -512,7 +512,8 @@ describe('registerCoreHandlers', () => {
       expect.objectContaining({
         getAdditionalCodexHomePaths: getAdditionalAiVaultCodexHomePaths,
         getActiveRuntimeAiVaultHostInfos: expect.any(Function),
-        scanRuntimeAiVaultSessions: expect.any(Function)
+        scanRuntimeAiVaultSessions: expect.any(Function),
+        prepareRuntimeSessionResume: expect.any(Function)
       })
     )
     expect(aiVaultOptions.getActiveRuntimeAiVaultHostInfos()).toEqual([])
@@ -561,6 +562,26 @@ describe('registerCoreHandlers', () => {
         executionHostId: 'runtime:env-123'
       },
       3000
+    )
+
+    callRuntimeEnvironmentMock.mockResolvedValueOnce({
+      ok: true,
+      result: { useRealCodexHome: true }
+    })
+    const prepareArgs = {
+      agent: 'codex',
+      filePath: '/managed/sessions/2026/07/20/rollout-a.jsonl',
+      codexHome: '/managed',
+      executionHostId: 'runtime:env-123'
+    }
+    await expect(
+      aiVaultOptions.prepareRuntimeSessionResume('env-123', prepareArgs)
+    ).resolves.toEqual({ useRealCodexHome: true })
+    expect(callRuntimeEnvironmentMock).toHaveBeenLastCalledWith(
+      '/test/user-data',
+      'env-123',
+      'aiVault.prepareSessionResume',
+      prepareArgs
     )
   })
 

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -74,8 +74,13 @@ import type { AutomationService } from '../automations/service'
 import type { AgentAwakeService } from '../agent-awake-service'
 import type { CrashReportStore } from '../crash-reporting/crash-report-store'
 import type { KeybindingService } from '../keybindings/keybinding-service'
+import type {
+  AiVaultPrepareSessionResumeArgs,
+  AiVaultPrepareSessionResumeResult
+} from '../../shared/ai-vault-resume-preparation'
 import {
   getSavedRuntimeAiVaultHostInfos,
+  prepareRuntimeAiVaultSessionResume,
   scanRuntimeAiVaultSessions
 } from '../ai-vault/runtime-session-scanner'
 
@@ -86,6 +91,9 @@ type CoreHandlerLifecycleOptions = {
   onOrcaProfileAuthMutation?: () => void
   onBeforeOrcaProfileSignOut?: () => void
   getAdditionalAiVaultCodexHomePaths?: () => readonly string[]
+  prepareAiVaultSessionResume?: (
+    args: AiVaultPrepareSessionResumeArgs
+  ) => Promise<AiVaultPrepareSessionResumeResult>
 }
 
 export function registerCoreHandlers(
@@ -190,10 +198,13 @@ export function registerCoreHandlers(
   registerEphemeralVmHandlers(store)
   registerAiVaultHandlers({
     getAdditionalCodexHomePaths: lifecycleOptions.getAdditionalAiVaultCodexHomePaths,
+    prepareSessionResume: lifecycleOptions.prepareAiVaultSessionResume,
     getActiveRuntimeAiVaultHostInfos: () =>
       getSavedRuntimeAiVaultHostInfos(app.getPath('userData')),
     scanRuntimeAiVaultSessions: async (environmentId, args, options) =>
-      scanRuntimeAiVaultSessions(app.getPath('userData'), environmentId, args, options)
+      scanRuntimeAiVaultSessions(app.getPath('userData'), environmentId, args, options),
+    prepareRuntimeSessionResume: async (environmentId, args) =>
+      prepareRuntimeAiVaultSessionResume(app.getPath('userData'), environmentId, args)
   })
   registerNativeChatHandlers()
   registerClipboardHandlers(store)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -288,6 +288,10 @@ import {
 } from '../ai-vault/cached-session-list'
 import type { AiVaultListArgs, AiVaultListResult } from '../../shared/ai-vault-types'
 import type {
+  AiVaultPrepareSessionResumeArgs,
+  AiVaultPrepareSessionResumeResult
+} from '../../shared/ai-vault-resume-preparation'
+import type {
   WorkspacePortKillRequest,
   WorkspacePortKillResult,
   WorkspacePortProbe,
@@ -2661,6 +2665,9 @@ export class OrcaRuntimeService {
   private readonly getAgentStatusSnapshotFn: (() => AgentStatusIpcPayload[]) | null
   private readonly buildAgentHookPtyEnv: (() => Record<string, string>) | null
   private readonly getDesktopWindowStatusFn: () => RuntimeDesktopWindowStatus
+  private readonly prepareAiVaultSessionResumeFn:
+    | ((args: AiVaultPrepareSessionResumeArgs) => Promise<AiVaultPrepareSessionResumeResult>)
+    | null
   private accountServices: RuntimeAccountServices | null = null
   private commitMessageAgentEnv: CommitMessageAgentEnvironmentResolvers | null = null
   private automationService: AutomationService | null = null
@@ -2694,6 +2701,9 @@ export class OrcaRuntimeService {
       // runs under `orca serve`, so remote/SSH hosts would silently drop
       // managed-Codex sessions. The runtime ctor runs in BOTH window and serve.
       getAdditionalAiVaultCodexHomePaths?: () => readonly string[]
+      prepareAiVaultSessionResume?: (
+        args: AiVaultPrepareSessionResumeArgs
+      ) => Promise<AiVaultPrepareSessionResumeResult>
       buildAgentHookPtyEnv?: () => Record<string, string>
       getDesktopWindowStatus?: () => RuntimeDesktopWindowStatus
     }
@@ -2724,6 +2734,7 @@ export class OrcaRuntimeService {
     this.onTerminalAgentStatus = deps?.onTerminalAgentStatus ?? null
     this.buildAgentHookPtyEnv = deps?.buildAgentHookPtyEnv ?? null
     this.getDesktopWindowStatusFn = deps?.getDesktopWindowStatus ?? (() => 'openable')
+    this.prepareAiVaultSessionResumeFn = deps?.prepareAiVaultSessionResume ?? null
     this.onTerminalSideEffects = deps?.onTerminalSideEffects ?? null
     // Why: the ConPTY spawn mark can land after daemon stream data already
     // created this PTY's emulator; the mark retrofits the DA1 override here
@@ -3204,6 +3215,14 @@ export class OrcaRuntimeService {
   // cache so the desktop panel and the mobile screen never double-scan.
   listAiVaultSessions(args?: AiVaultListArgs): Promise<AiVaultListResult> {
     return listAiVaultSessions(args)
+  }
+
+  prepareAiVaultSessionResume(
+    args: AiVaultPrepareSessionResumeArgs
+  ): Promise<AiVaultPrepareSessionResumeResult> {
+    return (
+      this.prepareAiVaultSessionResumeFn?.(args) ?? Promise.resolve({ useRealCodexHome: false })
+    )
   }
 
   setPtyController(controller: RuntimePtyController | null): void {

--- a/src/main/runtime/rpc/methods/ai-vault.test.ts
+++ b/src/main/runtime/rpc/methods/ai-vault.test.ts
@@ -13,7 +13,11 @@ vi.mock('../../../ai-vault/session-scanner', () => ({
   scanAiVaultSessions
 }))
 
-import { AI_VAULT_METHODS, AiVaultListSessionsParams } from './ai-vault'
+import {
+  AI_VAULT_METHODS,
+  AiVaultListSessionsParams,
+  AiVaultPrepareSessionResumeParams
+} from './ai-vault'
 import {
   configureAiVaultSessionSources,
   listAiVaultSessions,
@@ -103,6 +107,41 @@ describe('aiVault.listSessions params schema', () => {
     expect(AiVaultListSessionsParams.safeParse({ executionHostId: 'ssh:dev-box' }).success).toBe(
       false
     )
+  })
+})
+
+describe('aiVault.prepareSessionResume', () => {
+  it('validates bounded paths and executes against the receiving host identity', async () => {
+    expect(
+      AiVaultPrepareSessionResumeParams.safeParse({
+        agent: 'codex',
+        filePath: '/managed/sessions/rollout-a.jsonl',
+        codexHome: '/managed'
+      }).success
+    ).toBe(true)
+    const prepareAiVaultSessionResume = vi.fn().mockResolvedValue({ useRealCodexHome: true })
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      prepareAiVaultSessionResume
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: AI_VAULT_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('aiVault.prepareSessionResume', {
+        agent: 'codex',
+        filePath: '/managed/sessions/rollout-a.jsonl',
+        codexHome: '/managed',
+        executionHostId: 'ssh:spoofed'
+      })
+    )
+
+    expect(response).toMatchObject({ ok: true, result: { useRealCodexHome: true } })
+    expect(prepareAiVaultSessionResume).toHaveBeenCalledWith({
+      agent: 'codex',
+      filePath: '/managed/sessions/rollout-a.jsonl',
+      codexHome: '/managed',
+      executionHostId: 'local'
+    })
   })
 })
 

--- a/src/main/runtime/rpc/methods/ai-vault.ts
+++ b/src/main/runtime/rpc/methods/ai-vault.ts
@@ -2,7 +2,8 @@ import { z } from 'zod'
 import { defineMethod, type RpcMethod } from '../core'
 import { OptionalBoolean } from '../schemas'
 import { restampAiVaultListResult } from '../../../ai-vault/session-list-results'
-import { AI_VAULT_SCOPE_PATHS_MAX_COUNT } from '../../../../shared/ai-vault-types'
+import { AI_VAULT_AGENTS, AI_VAULT_SCOPE_PATHS_MAX_COUNT } from '../../../../shared/ai-vault-types'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
 import { parseExecutionHostId } from '../../../../shared/execution-host'
 
 // Why: bound limit + scopePaths so a client cannot force an unbounded scan.
@@ -45,6 +46,13 @@ export const AiVaultListSessionsParams = z.object({
   executionHostId: executionHostIdSchema.optional()
 })
 
+export const AiVaultPrepareSessionResumeParams = z.object({
+  agent: z.enum(AI_VAULT_AGENTS),
+  filePath: z.string().min(1).max(AI_VAULT_SCOPE_PATH_MAX_LENGTH),
+  codexHome: z.string().min(1).max(AI_VAULT_SCOPE_PATH_MAX_LENGTH).nullable(),
+  executionHostId: z.string().optional()
+})
+
 export const AI_VAULT_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'aiVault.listSessions',
@@ -61,5 +69,18 @@ export const AI_VAULT_METHODS: RpcMethod[] = [
         ? restampAiVaultListResult(result, params.executionHostId)
         : result
     }
+  }),
+  defineMethod({
+    name: 'aiVault.prepareSessionResume',
+    params: AiVaultPrepareSessionResumeParams,
+    handler: (params, { runtime }) =>
+      runtime.prepareAiVaultSessionResume({
+        agent: params.agent,
+        filePath: params.filePath,
+        codexHome: params.codexHome,
+        // Why: the RPC executes on the transcript-owning host; never let a
+        // client-provided runtime/SSH stamp escape that host boundary.
+        executionHostId: LOCAL_EXECUTION_HOST_ID
+      })
   })
 ]

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -146,6 +146,7 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'accounts.subscribe',
   'accounts.unsubscribe',
   'aiVault.listSessions',
+  'aiVault.prepareSessionResume',
   'browser.back',
   'browser.dialogAccept',
   'browser.dialogDismiss',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -434,6 +434,10 @@ import type {
   AiVaultSubagentListResult
 } from '../shared/ai-vault-types'
 import type {
+  AiVaultPrepareSessionResumeArgs,
+  AiVaultPrepareSessionResumeResult
+} from '../shared/ai-vault-resume-preparation'
+import type {
   AgentType,
   NativeChatMessage,
   NativeChatTurnLifecycle
@@ -822,6 +826,9 @@ export type OpenCodeUsageApi = {
 
 export type AiVaultApi = {
   listSessions: (args?: AiVaultListArgs) => Promise<AiVaultListResult>
+  prepareSessionResume: (
+    args: AiVaultPrepareSessionResumeArgs
+  ) => Promise<AiVaultPrepareSessionResumeResult>
   /** Lists the Task subagent transcripts of one session, on demand. */
   listSubagentSessions: (args: AiVaultSubagentListArgs) => Promise<AiVaultSubagentListResult>
   /** Fires when any app window regains OS focus; returns an unsubscribe. */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -176,6 +176,7 @@ import type {
 } from '../shared/automations-types'
 import type { KeybindingActionId, KeybindingFileSnapshot } from '../shared/keybindings'
 import type { AiVaultListArgs, AiVaultSubagentListArgs } from '../shared/ai-vault-types'
+import type { AiVaultPrepareSessionResumeArgs } from '../shared/ai-vault-resume-preparation'
 import type { AgentType } from '../shared/native-chat-types'
 import type {
   NativeChatAppendedPayload,
@@ -3824,6 +3825,8 @@ const api = {
   aiVault: {
     listSessions: (args?: AiVaultListArgs): Promise<unknown> =>
       ipcRenderer.invoke('aiVault:listSessions', args),
+    prepareSessionResume: (args: AiVaultPrepareSessionResumeArgs): Promise<unknown> =>
+      ipcRenderer.invoke('aiVault:prepareSessionResume', args),
     listSubagentSessions: (args: AiVaultSubagentListArgs): Promise<unknown> =>
       ipcRenderer.invoke('aiVault:listSubagentSessions', args),
     onWindowFocused: (callback: () => void): (() => void) => {

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionRow.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionRow.tsx
@@ -31,6 +31,7 @@ export function VaultSessionRow({
   session,
   liveState,
   resumeStartup,
+  realHomeResumeStartup,
   worktreeInfo,
   vaultScope,
   detailsExpanded,
@@ -54,6 +55,7 @@ export function VaultSessionRow({
   session: AiVaultSession
   liveState: AgentStatusState | null
   resumeStartup: AiVaultResumeStartup
+  realHomeResumeStartup: AiVaultResumeStartup
   worktreeInfo: AiVaultSessionWorktreeInfo | null
   vaultScope: AiVaultScope
   detailsExpanded: boolean
@@ -99,13 +101,15 @@ export function VaultSessionRow({
         command: resumeStartup.command,
         sessionFilePath: session.filePath,
         sessionExecutionHostId: session.executionHostId,
+        codexHome: session.codexHome,
         ...(resumeStartup.env ? { env: resumeStartup.env } : {}),
         ...(resumeStartup.envToDelete ? { envToDelete: resumeStartup.envToDelete } : {}),
-        ...(resumeStartup.launchConfig ? { launchConfig: resumeStartup.launchConfig } : {})
+        ...(resumeStartup.launchConfig ? { launchConfig: resumeStartup.launchConfig } : {}),
+        realHomeStartup: realHomeResumeStartup
       })
       window.dispatchEvent(new Event(AI_VAULT_SESSION_DRAG_START_EVENT))
     },
-    [resumeDisabled, session, resumeStartup]
+    [realHomeResumeStartup, resumeDisabled, session, resumeStartup]
   )
 
   return (

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionVirtualList.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionVirtualList.tsx
@@ -327,6 +327,10 @@ function AiVaultVirtualRow({
           session={row.session}
           liveState={getSessionLiveState(row.session)}
           resumeStartup={buildResumeStartup(row.session, resumeState?.worktreeId)}
+          realHomeResumeStartup={buildResumeStartup(
+            { ...row.session, codexHome: null },
+            resumeState?.worktreeId
+          )}
           worktreeInfo={worktreeInfo}
           vaultScope={vaultScope}
           detailsExpanded={expandedSessionIds.has(row.session.id)}

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.ts
@@ -17,6 +17,7 @@ import {
   getAiVaultResumeWorkspaceTargetStatus
 } from '@/lib/ai-vault-resume-target'
 import type { AiVaultAgent, AiVaultSession } from '../../../../shared/ai-vault-types'
+import { prepareAiVaultSessionForResume } from '@/lib/ai-vault-session-resume-preparation'
 import type { Worktree } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
 import { agentLabel } from './ai-vault-session-filters'
@@ -65,13 +66,20 @@ export function useAiVaultSessionLaunchActions({
 
   const copyResumeCommand = useCallback(
     async (session: AiVaultSession, worktreeId?: string | null): Promise<void> => {
-      await window.api.ui.writeClipboardText(buildResumeCommand(session, worktreeId))
-      toast.success(
-        translate(
-          'auto.components.right.sidebar.AiVaultPanel.resumeCommandCopied',
-          'Resume command copied'
+      try {
+        const preparedSession = await prepareAiVaultSessionForResume(session)
+        await window.api.ui.writeClipboardText(buildResumeCommand(preparedSession, worktreeId))
+        toast.success(
+          translate(
+            'auto.components.right.sidebar.AiVaultPanel.resumeCommandCopied',
+            'Resume command copied'
+          )
         )
-      )
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : 'Could not prepare this session for resume.'
+        )
+      }
     },
     [buildResumeCommand]
   )
@@ -100,11 +108,6 @@ export function useAiVaultSessionLaunchActions({
         return
       }
 
-      const launchResult = launchAiVaultSessionInNewTab({
-        agent: session.agent,
-        worktreeId: targetId.worktreeId,
-        ...buildResumeStartup(session, targetId.worktreeId)
-      })
       const showQueuedToast = (): void => {
         toast.success(
           translate(
@@ -114,26 +117,39 @@ export function useAiVaultSessionLaunchActions({
           )
         )
       }
-      if (launchResult.tabId === null) {
-        void launchResult.runtimeLaunch.then((created) => {
-          if (!created) {
-            toast.error(
-              translate(
-                'auto.lib.launch.agent.in.new.tab.11cce5cc77',
-                'Could not launch {{value0}} in a new terminal.',
-                { value0: agentLabel(session.agent) }
-              )
-            )
+      void prepareAiVaultSessionForResume(session)
+        .then((preparedSession) => {
+          const launchResult = launchAiVaultSessionInNewTab({
+            agent: session.agent,
+            worktreeId: targetId.worktreeId,
+            ...buildResumeStartup(preparedSession, targetId.worktreeId)
+          })
+          if (launchResult.tabId === null) {
+            void launchResult.runtimeLaunch.then((created) => {
+              if (!created) {
+                toast.error(
+                  translate(
+                    'auto.lib.launch.agent.in.new.tab.11cce5cc77',
+                    'Could not launch {{value0}} in a new terminal.',
+                    { value0: agentLabel(session.agent) }
+                  )
+                )
+                return
+              }
+              showQueuedToast()
+            })
             return
+          }
+          if (useAppStore.getState().activeWorktreeId !== targetId.worktreeId) {
+            activateAiVaultResumeWorkspace(targetId.worktreeId)
           }
           showQueuedToast()
         })
-        return
-      }
-      if (useAppStore.getState().activeWorktreeId !== targetId.worktreeId) {
-        activateAiVaultResumeWorkspace(targetId.worktreeId)
-      }
-      showQueuedToast()
+        .catch((error: unknown) => {
+          toast.error(
+            error instanceof Error ? error.message : 'Could not prepare this session for resume.'
+          )
+        })
     },
     [activeWorktree?.id, activeWorktreeId, buildResumeStartup, targetState]
   )

--- a/src/renderer/src/components/tab-group/AiVaultSessionDropLayer.tsx
+++ b/src/renderer/src/components/tab-group/AiVaultSessionDropLayer.tsx
@@ -17,6 +17,7 @@ import { useAppStore } from '@/store'
 import { resolveDropZone } from './tab-drop-zone'
 import type { TabDropZone } from './useTabDragSplit'
 import { translate } from '@/i18n/i18n'
+import { isLegacySharedCodexHome } from '../../../../shared/ai-vault-resume-preparation'
 
 type PaneDropTarget = {
   groupId: string
@@ -199,16 +200,6 @@ export default function AiVaultSessionDropLayer({
         return true
       }
 
-      const launchResult = launchAiVaultSessionInNewTab({
-        agent: payload.agent,
-        worktreeId,
-        command: payload.command,
-        ...(payload.env ? { env: payload.env } : {}),
-        ...(payload.envToDelete ? { envToDelete: payload.envToDelete } : {}),
-        ...(payload.launchConfig ? { launchConfig: payload.launchConfig } : {}),
-        targetGroupId: dropTarget.groupId,
-        splitDirection: dropTarget.zone === 'center' ? undefined : dropTarget.zone
-      })
       const showQueuedToast = (): void => {
         toast.success(
           translate(
@@ -217,23 +208,58 @@ export default function AiVaultSessionDropLayer({
           )
         )
       }
-      if (launchResult.tabId === null) {
-        void launchResult.runtimeLaunch.then((created) => {
-          if (!created) {
-            toast.error(
-              translate(
-                'auto.lib.launch.agent.in.new.tab.11cce5cc77',
-                'Could not launch {{value0}} in a new terminal.',
-                { value0: payload.agent }
-              )
-            )
+      const preparation =
+        payload.agent === 'codex' &&
+        isLegacySharedCodexHome(payload.codexHome ?? null) &&
+        payload.sessionFilePath &&
+        payload.sessionExecutionHostId &&
+        payload.codexHome !== undefined
+          ? window.api.aiVault.prepareSessionResume({
+              agent: payload.agent,
+              filePath: payload.sessionFilePath,
+              executionHostId: payload.sessionExecutionHostId,
+              codexHome: payload.codexHome
+            })
+          : Promise.resolve({ useRealCodexHome: false })
+      void preparation
+        .then((result) => {
+          const startup = result.useRealCodexHome ? payload.realHomeStartup : payload
+          if (!startup) {
+            throw new Error('Orca could not prepare this legacy Codex session. Retry resume.')
+          }
+          const launchResult = launchAiVaultSessionInNewTab({
+            agent: payload.agent,
+            worktreeId,
+            command: startup.command,
+            ...(startup.env ? { env: startup.env } : {}),
+            ...(startup.envToDelete ? { envToDelete: startup.envToDelete } : {}),
+            ...(startup.launchConfig ? { launchConfig: startup.launchConfig } : {}),
+            targetGroupId: dropTarget.groupId,
+            splitDirection: dropTarget.zone === 'center' ? undefined : dropTarget.zone
+          })
+          if (launchResult.tabId === null) {
+            void launchResult.runtimeLaunch.then((created) => {
+              if (!created) {
+                toast.error(
+                  translate(
+                    'auto.lib.launch.agent.in.new.tab.11cce5cc77',
+                    'Could not launch {{value0}} in a new terminal.',
+                    { value0: payload.agent }
+                  )
+                )
+                return
+              }
+              showQueuedToast()
+            })
             return
           }
           showQueuedToast()
         })
-        return true
-      }
-      showQueuedToast()
+        .catch((error: unknown) => {
+          toast.error(
+            error instanceof Error ? error.message : 'Could not prepare this session for resume.'
+          )
+        })
       return true
     },
     [clearDragState, target, updateTarget, worktreeId]

--- a/src/renderer/src/lib/ai-vault-resume-command.test.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.test.ts
@@ -232,6 +232,88 @@ describe('ai vault resume command runtime', () => {
     ).toBe("Set-Location -LiteralPath 'C:\\Users\\alice\\repo'; claude '--resume' 'session one'")
   })
 
+  it('copies a real-home Codex command that clears inherited homes in PowerShell', () => {
+    const state = makeState({ worktreePath: 'C:\\Users\\alice\\repo' })
+
+    expect(
+      buildAiVaultResumeCopyCommandForWorktree({
+        state,
+        session: {
+          agent: 'codex',
+          sessionId: 'session one',
+          cwd: 'C:\\Users\\alice\\repo',
+          codexHome: null
+        }
+      })
+    ).toBe(
+      "Remove-Item Env:CODEX_HOME -ErrorAction SilentlyContinue; Remove-Item Env:ORCA_CODEX_HOME -ErrorAction SilentlyContinue; Set-Location -LiteralPath 'C:\\Users\\alice\\repo'; codex 'resume' 'session one'"
+    )
+  })
+
+  it('copies a real-home Codex command that clears inherited homes in cmd', () => {
+    const state = makeState({
+      worktreePath: 'C:\\Users\\alice\\repo',
+      terminalWindowsShell: 'cmd.exe'
+    })
+
+    expect(
+      buildAiVaultResumeCopyCommandForWorktree({
+        state,
+        session: {
+          agent: 'codex',
+          sessionId: 'session one',
+          cwd: 'C:\\Users\\alice\\repo',
+          codexHome: null
+        }
+      })
+    ).toBe(
+      'set "CODEX_HOME=" & set "ORCA_CODEX_HOME=" & cd /d "C:\\Users\\alice\\repo" && codex "resume" "session one"'
+    )
+  })
+
+  it('copies a real-home Codex command that clears inherited homes in POSIX shells', () => {
+    const state = makeState({
+      worktreePath: '/home/alice/repo',
+      localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+    })
+
+    expect(
+      buildAiVaultResumeCopyCommandForWorktree({
+        state,
+        session: {
+          agent: 'codex',
+          sessionId: 'session one',
+          cwd: '/home/alice/repo',
+          codexHome: null
+        }
+      })
+    ).toBe(
+      "unset CODEX_HOME; unset ORCA_CODEX_HOME; cd '/home/alice/repo' && codex 'resume' 'session one'"
+    )
+  })
+
+  it('keeps copied custom-home Codex commands pinned to that home', () => {
+    const state = makeState({
+      worktreePath: '/home/alice/repo',
+      localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' }
+    })
+
+    const command = buildAiVaultResumeCopyCommandForWorktree({
+      state,
+      session: {
+        agent: 'codex',
+        sessionId: 'session one',
+        cwd: '/home/alice/repo',
+        codexHome: '/home/alice/custom-codex'
+      }
+    })
+
+    expect(command).toBe(
+      "cd '/home/alice/repo' && CODEX_HOME='/home/alice/custom-codex' codex 'resume' 'session one'"
+    )
+    expect(command).not.toContain('unset CODEX_HOME')
+  })
+
   it('uses configured agent defaults for resumable session history entries', () => {
     const state = makeState({
       worktreePath: 'C:\\Users\\alice\\repo',
@@ -410,7 +492,7 @@ describe('ai vault resume command runtime', () => {
     })
   })
 
-  it('returns the remote resume command verbatim for non-local host sessions', () => {
+  it('rebuilds remote real-home Codex commands without a stored home assignment', () => {
     const state = makeState({ worktreePath: '/home/alice/repo' })
     state.repos = [{ id: 'repo-1', path: '/home/alice/repo', connectionId: 'ssh-1' }] as never
 
@@ -427,13 +509,13 @@ describe('ai vault resume command runtime', () => {
           resumeCommand: "CODEX_HOME='/root/.codex' codex resume 'session one'"
         }
       })
-    ).toEqual({
-      command: "CODEX_HOME='/root/.codex' codex resume 'session one'",
+    ).toMatchObject({
+      command: "cd '/home/alice/repo' && codex 'resume' 'session one'",
       envToDelete: ['CODEX_HOME', 'ORCA_CODEX_HOME']
     })
   })
 
-  it('bypasses the resume pipeline even when the command override is blank', () => {
+  it('rebuilds remote real-home Codex commands when the override is blank', () => {
     const state = makeState({ worktreePath: '/home/alice/repo' })
     state.repos = [{ id: 'repo-1', path: '/home/alice/repo', connectionId: 'ssh-1' }] as never
 
@@ -451,7 +533,31 @@ describe('ai vault resume command runtime', () => {
           resumeCommand: "CODEX_HOME='/root/.codex' codex resume 'session one'"
         }
       })
-    ).toBe("CODEX_HOME='/root/.codex' codex resume 'session one'")
+    ).toBe("cd '/home/alice/repo' && codex 'resume' 'session one'")
+  })
+
+  it('copies remote real-home Codex commands with explicit environment cleanup', () => {
+    const state = makeState({ worktreePath: '/home/alice/repo' })
+    state.repos = [{ id: 'repo-1', path: '/home/alice/repo', connectionId: 'ssh-1' }] as never
+
+    const command = buildAiVaultResumeCopyCommandForWorktree({
+      state,
+      worktreeId: 'repo-1::worktree-1',
+      session: {
+        agent: 'codex',
+        sessionId: 'session one',
+        cwd: '/home/alice/repo',
+        codexHome: null,
+        executionHostId: 'runtime:env-1',
+        executionHostPlatform: 'linux',
+        resumeCommand: "CODEX_HOME='/retired/shared-home' codex resume 'session one'"
+      }
+    })
+
+    expect(command).toBe(
+      "unset CODEX_HOME; unset ORCA_CODEX_HOME; cd '/home/alice/repo' && codex 'resume' 'session one'"
+    )
+    expect(command).not.toContain('/retired/shared-home')
   })
 
   it('rebuilds the command when a non-blank override is supplied for a remote session', () => {

--- a/src/renderer/src/lib/ai-vault-resume-command.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.ts
@@ -15,6 +15,11 @@ import {
 import { parseWslUncPath } from '../../../shared/wsl-paths'
 import { resolveWindowsShellStartupFamily } from '../../../shared/windows-terminal-shell'
 import type { AgentStartupShell } from '../../../shared/tui-agent-startup-shell'
+import {
+  clearEnvCommand,
+  commandSeparator,
+  resolveStartupShell
+} from '../../../shared/tui-agent-startup-shell'
 import type { AppState } from '@/store/types'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import { CLIENT_PLATFORM } from '@/lib/new-workspace'
@@ -56,7 +61,16 @@ type AiVaultResumeWorktreeArgs = {
 }
 
 export function buildAiVaultResumeCopyCommandForWorktree(args: AiVaultResumeWorktreeArgs): string {
-  return buildAiVaultResumeForWorktree(args).command
+  const command = buildAiVaultResumeForWorktree(args).command
+  if (args.session.agent !== 'codex' || args.session.codexHome !== null) {
+    return command
+  }
+  const shell = resolveAiVaultResumeShell(args)
+  const separator = commandSeparator(shell)
+  const clearHomes = ['CODEX_HOME', 'ORCA_CODEX_HOME']
+    .map((name) => clearEnvCommand(name, shell))
+    .join(separator)
+  return `${clearHomes}${separator}${command}`
 }
 
 export function buildAiVaultResumeStartupForWorktree(
@@ -70,6 +84,7 @@ function buildAiVaultResumeForWorktree(args: AiVaultResumeWorktreeArgs): AiVault
     args.session.executionHostId &&
     args.session.executionHostId !== LOCAL_EXECUTION_HOST_ID &&
     args.session.resumeCommand &&
+    !(args.session.agent === 'codex' && args.session.codexHome === null) &&
     !args.commandOverride?.trim()
   ) {
     return {
@@ -144,6 +159,22 @@ function buildAiVaultResumeForWorktree(args: AiVaultResumeWorktreeArgs): AiVault
     }),
     ...realHomeCodexResumeEnvDeletion(args.session)
   }
+}
+
+function resolveAiVaultResumeShell(args: AiVaultResumeWorktreeArgs): AgentStartupShell {
+  const platform =
+    args.session.executionHostId &&
+    args.session.executionHostId !== LOCAL_EXECUTION_HOST_ID &&
+    args.session.executionHostPlatform
+      ? args.session.executionHostPlatform
+      : getAiVaultResumePlatform(args.state, args.worktreeId)
+  const isLocalSession =
+    !args.session.executionHostId || args.session.executionHostId === LOCAL_EXECUTION_HOST_ID
+  const shell =
+    platform === 'win32' && isLocalSession
+      ? resolveWindowsShellStartupFamily(args.state.settings?.terminalWindowsShell)
+      : undefined
+  return resolveStartupShell(platform, shell)
 }
 
 function getAiVaultResumeCodexHome(

--- a/src/renderer/src/lib/ai-vault-session-drag.test.ts
+++ b/src/renderer/src/lib/ai-vault-session-drag.test.ts
@@ -49,12 +49,17 @@ describe('Session History session drag data', () => {
       title: 'Fix terminal split',
       command: "cd '/repo' && claude --resume session-1",
       sessionFilePath: '/Users/ada/.claude/projects/-repo/session-1.jsonl',
+      codexHome: '/Users/ada/Library/Application Support/orca/codex-runtime-home/home',
       env: { ANTHROPIC_BASE_URL: 'https://claude.example.test' },
       envToDelete: ['CODEX_HOME', 'ORCA_CODEX_HOME'],
       launchConfig: {
         agentCommand: 'claude --dangerously-skip-permissions',
         agentArgs: '--dangerously-skip-permissions',
         agentEnv: { ANTHROPIC_BASE_URL: 'https://claude.example.test' }
+      },
+      realHomeStartup: {
+        command: "cd '/repo' && claude --resume session-1",
+        envToDelete: ['CODEX_HOME', 'ORCA_CODEX_HOME']
       }
     }
 

--- a/src/renderer/src/lib/ai-vault-session-drag.ts
+++ b/src/renderer/src/lib/ai-vault-session-drag.ts
@@ -17,10 +17,17 @@ export type AiVaultSessionDragPayload = {
   // WSL) to reject SSH panes that cannot reach it.
   sessionFilePath?: string
   sessionExecutionHostId?: ExecutionHostId
+  codexHome?: string | null
   // Why: drag/drop resume must preserve planned env mutations/default args, not just the command.
   env?: Record<string, string>
   envToDelete?: string[]
   launchConfig?: SleepingAgentLaunchConfig
+  realHomeStartup?: {
+    command: string
+    env?: Record<string, string>
+    envToDelete?: string[]
+    launchConfig?: SleepingAgentLaunchConfig
+  }
 }
 
 let activeAiVaultSessionDragPayload: AiVaultSessionDragPayload | null = null
@@ -80,9 +87,28 @@ function isSerializedPayload(value: unknown): value is SerializedAiVaultSessionD
     (payload.sessionFilePath === undefined || isNonEmptyString(payload.sessionFilePath)) &&
     (payload.sessionExecutionHostId === undefined ||
       Boolean(normalizeExecutionHostId(payload.sessionExecutionHostId))) &&
+    (payload.codexHome === undefined ||
+      payload.codexHome === null ||
+      isNonEmptyString(payload.codexHome)) &&
     (payload.env === undefined || isStringRecord(payload.env)) &&
     (payload.envToDelete === undefined || isEnvDeletionList(payload.envToDelete)) &&
-    (payload.launchConfig === undefined || isLaunchConfig(payload.launchConfig))
+    (payload.launchConfig === undefined || isLaunchConfig(payload.launchConfig)) &&
+    (payload.realHomeStartup === undefined || isResumeStartup(payload.realHomeStartup))
+  )
+}
+
+function isResumeStartup(
+  value: unknown
+): value is NonNullable<AiVaultSessionDragPayload['realHomeStartup']> {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+  const startup = value as NonNullable<AiVaultSessionDragPayload['realHomeStartup']>
+  return (
+    isNonEmptyString(startup.command) &&
+    (startup.env === undefined || isStringRecord(startup.env)) &&
+    (startup.envToDelete === undefined || isEnvDeletionList(startup.envToDelete)) &&
+    (startup.launchConfig === undefined || isLaunchConfig(startup.launchConfig))
   )
 }
 
@@ -135,9 +161,11 @@ export function readAiVaultSessionDragData(
       command,
       sessionFilePath,
       sessionExecutionHostId,
+      codexHome,
       env,
       envToDelete,
-      launchConfig
+      launchConfig,
+      realHomeStartup
     } = parsed
     return {
       agent,
@@ -146,9 +174,11 @@ export function readAiVaultSessionDragData(
       command,
       ...(sessionFilePath ? { sessionFilePath } : {}),
       ...(sessionExecutionHostId ? { sessionExecutionHostId } : {}),
+      ...(codexHome !== undefined ? { codexHome } : {}),
       ...(env ? { env } : {}),
       ...(envToDelete ? { envToDelete } : {}),
-      ...(launchConfig ? { launchConfig } : {})
+      ...(launchConfig ? { launchConfig } : {}),
+      ...(realHomeStartup ? { realHomeStartup } : {})
     }
   } catch {
     return null

--- a/src/renderer/src/lib/ai-vault-session-resume-preparation.test.ts
+++ b/src/renderer/src/lib/ai-vault-session-resume-preparation.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AiVaultSession } from '../../../shared/ai-vault-types'
+import { prepareAiVaultSessionForResume } from './ai-vault-session-resume-preparation'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('prepareAiVaultSessionForResume', () => {
+  it('returns a real-home launch identity only after targeted materialization succeeds', async () => {
+    const prepareSessionResume = vi.fn().mockResolvedValue({ useRealCodexHome: true })
+    stubPreparation(prepareSessionResume)
+    const legacy = session({
+      codexHome: '/Users/ada/Library/Application Support/orca/codex-runtime-home/home'
+    })
+
+    const prepared = await prepareAiVaultSessionForResume(legacy)
+
+    expect(prepared.codexHome).toBeNull()
+    expect(prepareSessionResume).toHaveBeenCalledWith({
+      agent: 'codex',
+      filePath: legacy.filePath,
+      codexHome: legacy.codexHome,
+      executionHostId: 'local'
+    })
+  })
+
+  it('rejects without changing the launch identity when materialization fails', async () => {
+    stubPreparation(vi.fn().mockRejectedValue(new Error('Retry resume.')))
+
+    await expect(
+      prepareAiVaultSessionForResume(session({ codexHome: '/tmp/orca/codex-runtime-home/home' }))
+    ).rejects.toThrow('Retry resume.')
+  })
+
+  it.each(['/custom/codex', '/tmp/orca/codex-accounts/account-1/home'])(
+    'preserves a non-legacy home without materialization: %s',
+    async (codexHome) => {
+      const prepareSessionResume = vi.fn()
+      stubPreparation(prepareSessionResume)
+      const current = session({ codexHome })
+
+      await expect(prepareAiVaultSessionForResume(current)).resolves.toBe(current)
+      expect(prepareSessionResume).not.toHaveBeenCalled()
+    }
+  )
+})
+
+function stubPreparation(prepareSessionResume: ReturnType<typeof vi.fn>): void {
+  vi.stubGlobal('window', { api: { aiVault: { prepareSessionResume } } })
+}
+
+function session(overrides: Partial<AiVaultSession> = {}): AiVaultSession {
+  return {
+    id: 'local:codex:session-1:/tmp/rollout.jsonl',
+    executionHostId: 'local',
+    agent: 'codex',
+    sessionId: 'session-1',
+    title: 'Legacy session',
+    cwd: '/repo',
+    branch: null,
+    model: null,
+    filePath: '/tmp/rollout.jsonl',
+    codexHome: null,
+    createdAt: null,
+    updatedAt: null,
+    modifiedAt: '2026-07-20T00:00:00.000Z',
+    messageCount: 1,
+    totalTokens: 0,
+    previewMessages: [],
+    queuedMessageCount: 0,
+    subagentTranscriptCount: 0,
+    resumeCommand: "codex resume 'session-1'",
+    subagent: null,
+    ...overrides
+  }
+}

--- a/src/renderer/src/lib/ai-vault-session-resume-preparation.ts
+++ b/src/renderer/src/lib/ai-vault-session-resume-preparation.ts
@@ -1,0 +1,17 @@
+import type { AiVaultSession } from '../../../shared/ai-vault-types'
+import { isLegacySharedCodexHome } from '../../../shared/ai-vault-resume-preparation'
+
+export async function prepareAiVaultSessionForResume(
+  session: AiVaultSession
+): Promise<AiVaultSession> {
+  if (session.agent !== 'codex' || !isLegacySharedCodexHome(session.codexHome)) {
+    return session
+  }
+  const result = await window.api.aiVault.prepareSessionResume({
+    agent: session.agent,
+    filePath: session.filePath,
+    codexHome: session.codexHome,
+    executionHostId: session.executionHostId
+  })
+  return result.useRealCodexHome ? { ...session, codexHome: null } : session
+}

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -8,6 +8,10 @@ import type {
 } from '../../../preload/api-types'
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
 import type { AiVaultListArgs, AiVaultListResult } from '../../../shared/ai-vault-types'
+import type {
+  AiVaultPrepareSessionResumeArgs,
+  AiVaultPrepareSessionResumeResult
+} from '../../../shared/ai-vault-resume-preparation'
 import { buildNativeChatUnsubscribe } from '../../../shared/native-chat-stream-unsubscribe'
 import type {
   ComputerUsePermissionSetupResult,
@@ -1316,6 +1320,8 @@ function createAiVaultApi(): NonNullable<Partial<PreloadApi>['aiVault']> {
         executionHostId
       })
     },
+    prepareSessionResume: (args: AiVaultPrepareSessionResumeArgs) =>
+      callRuntimeResult<AiVaultPrepareSessionResumeResult>('aiVault.prepareSessionResume', args),
     // Why: no server-side RPC for subagent transcript listing yet, so report an empty (not erroring) result.
     listSubagentSessions: () => Promise.resolve({ sessions: [], issues: [] }),
     onWindowFocused: () => noopUnsubscribe

--- a/src/shared/ai-vault-resume-preparation.ts
+++ b/src/shared/ai-vault-resume-preparation.ts
@@ -1,0 +1,22 @@
+import type { AiVaultSession } from './ai-vault-types'
+
+export type AiVaultPrepareSessionResumeArgs = Pick<
+  AiVaultSession,
+  'agent' | 'filePath' | 'codexHome' | 'executionHostId'
+>
+
+export type AiVaultPrepareSessionResumeResult = {
+  useRealCodexHome: boolean
+}
+
+export type AiVaultSessionResumePreparation = (
+  args: AiVaultPrepareSessionResumeArgs
+) => Promise<AiVaultPrepareSessionResumeResult>
+
+export function isLegacySharedCodexHome(codexHome: string | null): boolean {
+  if (!codexHome) {
+    return false
+  }
+  const segments = codexHome.split(/[\\/]/).filter(Boolean)
+  return segments.at(-2) === 'codex-runtime-home' && segments.at(-1) === 'home'
+}


### PR DESCRIPTION
## Summary

- make the delayed legacy Codex session backfill restart when startup begins on a managed account and the user later switches the host to system default, including the stopping/in-flight transition race
- before resuming a rollout from the retired shared `codex-runtime-home/home`, safely hardlink or no-overwrite-copy that exact rollout into the real system Codex sessions tree, coalesce concurrent resumes, and fail with a retryable error on missing, conflicting, or unsafe materialization
- resume successfully materialized sessions with `CODEX_HOME` and `ORCA_CODEX_HOME` removed; copied resume commands explicitly clear both variables for POSIX, PowerShell, and cmd shells
- route saved-runtime preparation to the transcript-owning Orca runtime, while preserving SSH/WSL boundaries, self-contained per-account homes, user custom homes, and the selected managed-account lane

## Real upgrade path

Validation of the production profile found 1,846 rollout files only under `Library/Application Support/orca/codex-runtime-home/home/sessions`, 15 under the real `~/.codex/sessions`, zero same-relative-path overlap, and no `codex-session-backfill` state files. On an upgrade that starts with a managed account selected, the previous one-shot 15-second callback returned and was never scheduled again. The scanner correctly classified the remaining rollouts as managed-only, but that froze their resume commands to the retired shared `CODEX_HOME`, whose refresh token could already be revoked even while real `~/.codex` auth was healthy.

The observed process-boundary evidence matches that diagnosis: Codex worked immediately in a newly opened terminal, while an already-running terminal still failed with the revoked refresh-token/login error. The old shell retained the retired `CODEX_HOME`/`ORCA_CODEX_HOME`; opening a new shell removed that inherited state.

## Why #9501 did not cover this

#9501 established real-home routing and the bulk migration, but its background work was gated by a single delayed eligibility check. It did not restart after a managed-to-system-default selection change, and resume remained dependent on that background timing. It also did not preflight an individual legacy rollout or sanitize copied commands, so an immediate resume could still launch against the retired shared credentials.

This change makes resume correctness independent of bulk timing for the system-default real-home lane: the requested rollout must be safely present in the real sessions tree before launch, the launch environment deletes both Orca-owned home variables, and copied commands clear both variables in the receiving shell. If safe materialization cannot be proven, Orca does not launch and asks the user to retry. Managed-account and custom-home selections remain pinned to their existing homes and are not silently switched to system credentials.

## Verification

- 237 focused desktop/main tests across migration scheduling, targeted materialization, Codex account/runtime-home transitions, IPC/runtime routing, resume command construction, preparation, and drag payloads
- root TypeScript checks (`pnpm run typecheck`)
- changed-file `oxfmt --check` and `oxlint`
- max-lines ratchet and `git diff --check`
- mobile full suite: 2,130 passed, 2 skipped
- mobile TypeScript check
- rebased onto `bf7fbdd57` (#9621)

## Residual limitation

Already-running Codex processes and shells cannot have their inherited environment rewritten by an application upgrade. New Orca-created resume launches are sanitized, and copied real-home commands explicitly clear both variables when run; an older live shell must be replaced with a new terminal or have `CODEX_HOME` and `ORCA_CODEX_HOME` manually unset before continuing.
