### PR TITLE
Revert "Confirm before merging a PR/MR from the sidebar strategy dropdown (#8911)"

### DIFF
--- a/src/renderer/src/components/right-sidebar/use-hosted-review-actions.test.tsx
+++ b/src/renderer/src/components/right-sidebar/use-hosted-review-actions.test.tsx
@@ -46,25 +46,14 @@ function makeRepo(overrides: Partial<Repo> = {}): Repo {
   } as Repo
 }
 
-type ProviderOverrides = {
-  review?: HostedReviewActionInfo
-  isGitLab?: boolean
-  shortLabel?: string
-  reviewLabel?: string
-}
-
-function HookProbe(props: {
-  repo: Repo
-  onRefreshReview: () => Promise<void>
-  overrides?: ProviderOverrides
-}): null {
+function HookProbe(props: { repo: Repo; onRefreshReview: () => Promise<void> }): null {
   latest = useHostedReviewActions({
-    review: props.overrides?.review ?? review,
+    review,
     githubPR,
     repo: props.repo,
-    isGitLab: props.overrides?.isGitLab ?? false,
-    shortLabel: props.overrides?.shortLabel ?? 'PR',
-    reviewLabel: props.overrides?.reviewLabel ?? 'pull request',
+    isGitLab: false,
+    shortLabel: 'PR',
+    reviewLabel: 'pull request',
     defaultMergeMethod: 'squash',
     autoMergeAction: null,
     onRefreshReview: props.onRefreshReview
@@ -72,16 +61,12 @@ function HookProbe(props: {
   return null
 }
 
-async function renderHook(
-  repo: Repo,
-  onRefreshReview = vi.fn().mockResolvedValue(undefined),
-  overrides?: ProviderOverrides
-) {
+async function renderHook(repo: Repo, onRefreshReview = vi.fn().mockResolvedValue(undefined)) {
   const container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
   await act(async () => {
-    root?.render(createElement(HookProbe, { repo, onRefreshReview, overrides }))
+    root?.render(createElement(HookProbe, { repo, onRefreshReview }))
   })
   return { onRefreshReview }
 }
@@ -154,63 +139,5 @@ describe('useHostedReviewActions', () => {
     })
     expect(runtimeRpcMocks.callRuntimeRpc).not.toHaveBeenCalled()
     expect(onRefreshReview).toHaveBeenCalledTimes(1)
-  })
-
-  it('confirms before merging with the selected strategy label (#7943)', async () => {
-    await renderHook(makeRepo())
-
-    await act(async () => {
-      await latest?.handleMerge('merge')
-    })
-
-    expect(confirmationMocks.confirm).toHaveBeenCalledWith(
-      expect.objectContaining({
-        title: 'Create merge commit PR #1015?',
-        confirmLabel: 'Create merge commit'
-      })
-    )
-  })
-
-  it('does not merge when the confirmation is cancelled (#7943)', async () => {
-    confirmationMocks.confirm.mockResolvedValue(false)
-    const { onRefreshReview } = await renderHook(makeRepo())
-
-    await act(async () => {
-      await latest?.handleMerge('squash')
-    })
-
-    expect(confirmationMocks.confirm).toHaveBeenCalledTimes(1)
-    expect(window.api.gh.mergePR).not.toHaveBeenCalled()
-    expect(runtimeRpcMocks.callRuntimeRpc).not.toHaveBeenCalled()
-    expect(onRefreshReview).not.toHaveBeenCalled()
-  })
-
-  it('confirms GitLab MR merges with provider-aware copy (#7943)', async () => {
-    await renderHook(makeRepo(), undefined, {
-      review: {
-        provider: 'gitlab',
-        number: 42,
-        state: 'open',
-        status: 'success',
-        mergeable: 'MERGEABLE'
-      },
-      isGitLab: true,
-      shortLabel: 'MR',
-      reviewLabel: 'merge request'
-    })
-
-    await act(async () => {
-      await latest?.handleMerge('squash')
-    })
-
-    expect(confirmationMocks.confirm).toHaveBeenCalledWith(
-      expect.objectContaining({ title: 'Squash and merge MR !42?' })
-    )
-    expect(window.api.gl.mergeMR).toHaveBeenCalledWith({
-      repoPath: '/repo',
-      repoId: 'repo-1',
-      iid: 42,
-      method: 'squash'
-    })
   })
 })

--- a/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
+++ b/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
@@ -5,7 +5,6 @@ import type { GitHubPRAutoMergeAction } from '@/components/github-pr-merge-state
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 import type { PRInfo, Repo } from '../../../../shared/types'
 import type { GitHubPRMergeMethod } from '../../../../shared/types'
-import { GITHUB_PR_MERGE_METHOD_LABELS } from '../../../../shared/github-pr-merge-methods'
 import {
   mergeGitHubHostedReview,
   setGitHubHostedReviewAutoMerge,
@@ -64,21 +63,6 @@ export function useHostedReviewActions({
 
   const handleMerge = useCallback(
     async (method: GitHubPRMergeMethod = defaultMergeMethod) => {
-      // Why: choosing a strategy from the merge dropdown must not merge on its
-      // own — confirm first, matching every other PR/MR merge surface (#7943).
-      const label = GITHUB_PR_MERGE_METHOD_LABELS[method]
-      const confirmed = await confirm({
-        title: `${label} ${shortLabel} ${isGitLab ? '!' : '#'}${review.number}?`,
-        description: translate(
-          'auto.components.right.sidebar.use.hosted.review.actions.e475c29b17',
-          'This will merge the {{value0}}.',
-          { value0: reviewLabel }
-        ),
-        confirmLabel: label
-      })
-      if (!confirmed) {
-        return
-      }
       setMerging(true)
       setActionError(null)
       try {
@@ -106,17 +90,7 @@ export function useHostedReviewActions({
         setMerging(false)
       }
     },
-    [
-      confirm,
-      githubPR?.prRepo,
-      isGitLab,
-      shortLabel,
-      reviewLabel,
-      defaultMergeMethod,
-      onRefreshReview,
-      repo,
-      review.number
-    ]
+    [githubPR?.prRepo, isGitLab, defaultMergeMethod, onRefreshReview, repo, review.number]
   )
 
   const handleAutoMerge = useCallback(async () => {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10271,13 +10271,6 @@
                   "cfafa92509": "No unresolved conflicts to send."
                 }
               }
-            },
-            "hosted": {
-              "review": {
-                "actions": {
-                  "e475c29b17": "This will merge the {{value0}}."
-                }
-              }
             }
           },
           "fileExplorerOperationOwner": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -10248,13 +10248,6 @@
                   "cfafa92509": "No hay conflictos sin resolver para enviar."
                 }
               }
-            },
-            "hosted": {
-              "review": {
-                "actions": {
-                  "e475c29b17": "This will merge the {{value0}}."
-                }
-              }
             }
           },
           "fileExplorerOperationOwner": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -10248,13 +10248,6 @@
                   "cfafa92509": "送信する未解決の競合はありません。"
                 }
               }
-            },
-            "hosted": {
-              "review": {
-                "actions": {
-                  "e475c29b17": "This will merge the {{value0}}."
-                }
-              }
             }
           },
           "fileExplorerOperationOwner": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10248,13 +10248,6 @@
                   "cfafa92509": "보낼 해결되지 않은 충돌이 없습니다."
                 }
               }
-            },
-            "hosted": {
-              "review": {
-                "actions": {
-                  "e475c29b17": "This will merge the {{value0}}."
-                }
-              }
             }
           },
           "fileExplorerOperationOwner": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -10248,13 +10248,6 @@
                   "cfafa92509": "没有未解决的冲突需要发送。"
                 }
               }
-            },
-            "hosted": {
-              "review": {
-                "actions": {
-                  "e475c29b17": "This will merge the {{value0}}."
-                }
-              }
             }
           },
           "fileExplorerOperationOwner": {


### PR DESCRIPTION
## Summary
- Reverts #8911, which added a confirmation dialog when choosing a merge strategy from the hosted-review sidebar dropdown.
- Restores the previous behavior: selecting a strategy from the dropdown merges immediately (no extra confirm gate in `handleMerge`).

## Why
The confirmation dialog added friction that we do not want on this path. Reverting returns the sidebar merge control to its pre-#8911 behavior.

## Test plan
- [ ] Open a PR/MR in the right-sidebar Checks/hosted-review panel
- [ ] Click the merge split-button primary action → merges without a confirmation dialog
- [ ] Pick an alternate strategy from the dropdown (e.g. Squash / Merge / Rebase) → merges with that strategy without a confirmation dialog
- [ ] Confirm close/reopen and other PR actions that still use confirmation still work