### PR TITLE
fix(ssh): apply node-pty console fallback to Windows relays

### DIFF
--- a/config/relay-assets/node-pty-1.1.0-console-list-agent-patch.cjs
+++ b/config/relay-assets/node-pty-1.1.0-console-list-agent-patch.cjs
@@ -1,0 +1,71 @@
+const { createHash } = require('node:crypto')
+const { readFileSync, renameSync, rmSync, writeFileSync } = require('node:fs')
+const { join, resolve } = require('node:path')
+
+const EXPECTED_NODE_PTY_VERSION = '1.1.0'
+const ORIGINAL_SOURCE_SHA256 = '0d010879bb6680a0253d44363183d53e631f42972594eb6dcb1fb842c8c85e52'
+const PATCHED_SOURCE_SHA256 = '84df20cfe711a88d2bef35078615c58a6ce14f39348a4aef40e852b854dcd857'
+const ORIGINAL_BODY = 'var consoleProcessList = getConsoleProcessList(shellPid);'
+const PATCHED_BODY = `var consoleProcessList;
+try {
+    consoleProcessList = getConsoleProcessList(shellPid);
+}
+catch (_a) {
+    // Why: AttachConsole can fail without a Win32 console; use node-pty's timeout fallback immediately.
+    consoleProcessList = [shellPid];
+}`
+
+function inspectNodePtyConsoleListAgent(relayDir = process.cwd()) {
+  const nodePtyDir = resolve(relayDir, 'node_modules', 'node-pty')
+  const packageJsonPath = join(nodePtyDir, 'package.json')
+  const agentPath = join(nodePtyDir, 'lib', 'conpty_console_list_agent.js')
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
+  if (packageJson.version !== EXPECTED_NODE_PTY_VERSION) {
+    throw new Error(
+      `Refusing to patch node-pty ${packageJson.version}; expected ${EXPECTED_NODE_PTY_VERSION}`
+    )
+  }
+  const source = readFileSync(agentPath, 'utf8')
+  return { agentPath, source }
+}
+
+function assertPatchedNodePtyConsoleListAgent(relayDir = process.cwd()) {
+  const inspected = inspectNodePtyConsoleListAgent(relayDir)
+  if (sourceSha256(inspected.source) !== PATCHED_SOURCE_SHA256) {
+    throw new Error('node-pty ConPTY console-list fallback is not installed')
+  }
+}
+
+function patchNodePtyConsoleListAgent(relayDir = process.cwd()) {
+  const inspected = inspectNodePtyConsoleListAgent(relayDir)
+  const sourceHash = sourceSha256(inspected.source)
+  if (sourceHash === PATCHED_SOURCE_SHA256) {
+    return
+  }
+  if (sourceHash !== ORIGINAL_SOURCE_SHA256) {
+    throw new Error('Refusing to patch unexpected node-pty console-list agent source')
+  }
+  const patchedSource = inspected.source.replace(ORIGINAL_BODY, PATCHED_BODY)
+  const temporaryPath = `${inspected.agentPath}.orca-patch-${process.pid}`
+  // Why: a terminated remote install must leave either known source version recoverable on reconnect.
+  try {
+    writeFileSync(temporaryPath, patchedSource)
+    renameSync(temporaryPath, inspected.agentPath)
+  } finally {
+    rmSync(temporaryPath, { force: true })
+  }
+  assertPatchedNodePtyConsoleListAgent(relayDir)
+}
+
+function sourceSha256(source) {
+  return createHash('sha256').update(source).digest('hex')
+}
+
+if (require.main === module) {
+  patchNodePtyConsoleListAgent()
+}
+
+module.exports = {
+  assertPatchedNodePtyConsoleListAgent,
+  patchNodePtyConsoleListAgent
+}

--- a/config/scripts/build-relay.mjs
+++ b/config/scripts/build-relay.mjs
@@ -10,7 +10,7 @@
  */
 import { build } from 'esbuild'
 import { createHash } from 'node:crypto'
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 const __dirname = import.meta.dirname
@@ -26,6 +26,13 @@ const MANAGED_HOOK_RUNTIME_ENTRY = join(
   'managed-hook-runtime.ts'
 )
 const JSONC_PARSER_ESM_ENTRY = join(ROOT, 'node_modules', 'jsonc-parser', 'lib', 'esm', 'main.js')
+const NODE_PTY_CONSOLE_LIST_PATCH_FILENAME = 'node-pty-1.1.0-console-list-agent-patch.cjs'
+const NODE_PTY_CONSOLE_LIST_PATCH_SOURCE = join(
+  ROOT,
+  'config',
+  'relay-assets',
+  NODE_PTY_CONSOLE_LIST_PATCH_FILENAME
+)
 
 const PLATFORMS = [
   'linux-x64',
@@ -58,6 +65,13 @@ for (const platform of PLATFORMS) {
       'process.env.NODE_ENV': '"production"'
     }
   })
+
+  if (platform.startsWith('win32-')) {
+    copyFileSync(
+      NODE_PTY_CONSOLE_LIST_PATCH_SOURCE,
+      join(outDir, NODE_PTY_CONSOLE_LIST_PATCH_FILENAME)
+    )
+  }
 
   await build({
     entryPoints: [WATCHER_ENTRY],
@@ -101,9 +115,12 @@ for (const platform of PLATFORMS) {
     .update(relayContent)
     .update(watcherContent)
     .update(managedHookRuntimeContent)
-    .digest('hex')
-    .slice(0, 12)
-  writeFileSync(join(outDir, '.version'), `${RELAY_VERSION}+${hash}`)
+  // Why: changing the remote node-pty patch must select a fresh immutable Windows relay directory.
+  if (platform.startsWith('win32-')) {
+    hash.update(readFileSync(join(outDir, NODE_PTY_CONSOLE_LIST_PATCH_FILENAME)))
+  }
+  const contentHash = hash.digest('hex').slice(0, 12)
+  writeFileSync(join(outDir, '.version'), `${RELAY_VERSION}+${contentHash}`)
 
   console.log(`Built relay for ${platform} → ${outDir}/relay.js`)
 }

--- a/config/scripts/node-pty-console-list-agent-patch.test.mjs
+++ b/config/scripts/node-pty-console-list-agent-patch.test.mjs
@@ -1,0 +1,79 @@
+import { createRequire } from 'node:module'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const {
+  assertPatchedNodePtyConsoleListAgent,
+  patchNodePtyConsoleListAgent
+} = require('../relay-assets/node-pty-1.1.0-console-list-agent-patch.cjs')
+const projectDir = resolve(import.meta.dirname, '..', '..')
+const cleanupDirs = []
+
+afterEach(() => {
+  for (const dir of cleanupDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('Windows SSH relay node-pty console-list patch', () => {
+  it('installs and verifies the fallback idempotently', () => {
+    const fixture = writeNodePtyFixture('1.1.0', publishedAgentSource())
+
+    patchNodePtyConsoleListAgent(fixture.root)
+    const once = readFileSync(fixture.agentPath, 'utf8')
+    expect(once).toContain('consoleProcessList = [shellPid];')
+    expect(existsSync(`${fixture.agentPath}.orca-patch-${process.pid}`)).toBe(false)
+    expect(() => assertPatchedNodePtyConsoleListAgent(fixture.root)).not.toThrow()
+
+    patchNodePtyConsoleListAgent(fixture.root)
+    expect(readFileSync(fixture.agentPath, 'utf8')).toBe(once)
+  })
+
+  it('refuses a different package version or unexpected agent source', () => {
+    const wrongVersion = writeNodePtyFixture('1.2.0-beta.11', publishedAgentSource())
+    expect(() => patchNodePtyConsoleListAgent(wrongVersion.root)).toThrow('expected 1.1.0')
+
+    const drifted = writeNodePtyFixture('1.1.0', `${publishedAgentSource()}\n// drift`)
+    expect(() => patchNodePtyConsoleListAgent(drifted.root)).toThrow('unexpected node-pty')
+
+    const tamperedPatch = writeNodePtyFixture('1.1.0', publishedAgentSource())
+    patchNodePtyConsoleListAgent(tamperedPatch.root)
+    writeFileSync(tamperedPatch.agentPath, `${readFileSync(tamperedPatch.agentPath)}\n// drift`)
+    expect(() => assertPatchedNodePtyConsoleListAgent(tamperedPatch.root)).toThrow('not installed')
+  })
+})
+
+function writeNodePtyFixture(version, agentSource) {
+  const root = mkdtempSync(join(projectDir, '.node-pty-console-list-patch-test-'))
+  cleanupDirs.push(root)
+  const nodePtyDir = join(root, 'node_modules', 'node-pty')
+  const libDir = join(nodePtyDir, 'lib')
+  const agentPath = join(libDir, 'conpty_console_list_agent.js')
+  mkdirSync(libDir, { recursive: true })
+  writeFileSync(join(nodePtyDir, 'package.json'), JSON.stringify({ version }))
+  writeFileSync(agentPath, agentSource)
+  return { root, agentPath }
+}
+
+function publishedAgentSource() {
+  return [
+    '"use strict";',
+    '/**',
+    ' * Copyright (c) 2019, Microsoft Corporation (MIT License).',
+    ' *',
+    ' * This module fetches the console process list for a particular PID. It must be',
+    ' * called from a different process (child_process.fork) as there can only be a',
+    ' * single console attached to a process.',
+    ' */',
+    'Object.defineProperty(exports, "__esModule", { value: true });',
+    'var utils_1 = require("./utils");',
+    "var getConsoleProcessList = utils_1.loadNativeModule('conpty_console_list').module.getConsoleProcessList;",
+    'var shellPid = parseInt(process.argv[2], 10);',
+    'var consoleProcessList = getConsoleProcessList(shellPid);',
+    'process.send({ consoleProcessList: consoleProcessList });',
+    'process.exit(0);',
+    '//# sourceMappingURL=conpty_console_list_agent.js.map'
+  ].join('\n')
+}

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -217,6 +217,23 @@ describe('Electron runtime package contract', () => {
     )
   })
 
+  it('packages and verifies the Windows SSH node-pty console-list fallback', () => {
+    const relayBuild = readFileSync(join(projectDir, 'config/scripts/build-relay.mjs'), 'utf8')
+    const relayDeploy = readFileSync(join(projectDir, 'src/main/ssh/ssh-relay-deploy.ts'), 'utf8')
+    const patchAsset = readFileSync(
+      join(projectDir, 'config/relay-assets/node-pty-1.1.0-console-list-agent-patch.cjs'),
+      'utf8'
+    )
+
+    expect(relayBuild).toContain('copyFileSync(')
+    expect(relayBuild).toContain('hash.update(readFileSync')
+    expect(relayBuild).toContain('node-pty-1.1.0-console-list-agent-patch.cjs')
+    expect(relayDeploy).toContain('assertPatchedNodePtyConsoleListAgent')
+    expect(relayDeploy.match(/\$\{windowsNodePtyPatchCommand\(nodePath\)\}/g)).toHaveLength(2)
+    expect(patchAsset).toContain('consoleProcessList = [shellPid];')
+    expect(patchAsset).toContain('packageJson.version !== EXPECTED_NODE_PTY_VERSION')
+  })
+
   it('pins the Windows release builder to the VS 2022 runner image', () => {
     const releaseWorkflow = parse(
       readFileSync(join(projectDir, '.github/workflows/release-cut.yml'), 'utf8')

--- a/config/scripts/windows-ssh-attach-console-repro.mjs
+++ b/config/scripts/windows-ssh-attach-console-repro.mjs
@@ -1,0 +1,435 @@
+import { spawn, spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { copyFileSync, cpSync, existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { createConnection } from 'node:net'
+import { join, resolve } from 'node:path'
+
+const projectDir = resolve(import.meta.dirname, '..', '..')
+const relayBuildDir = join(projectDir, 'out', 'relay', 'win32-x64')
+const SENTINEL = Buffer.from('ORCA-RELAY v0.1.0 READY\n')
+const HEADER_LENGTH = 13
+const REGRESSION_TIMEOUT_MS = 15_000
+const NODE_PTY_PATCH_FILENAME = 'node-pty-1.1.0-console-list-agent-patch.cjs'
+
+if (process.platform !== 'win32') {
+  console.log('SKIP: Windows ConPTY regression only runs on Windows.')
+  process.exit(0)
+}
+
+const options = parseArgs(process.argv.slice(2))
+const nodePath = resolve(options.node ?? process.execPath)
+const nodePtyDir = resolve(options.nodePty ?? join(projectDir, 'node_modules', 'node-pty'))
+const expectFailure = options.expect === 'attach-console-failure'
+
+for (const required of [
+  nodePath,
+  nodePtyDir,
+  join(relayBuildDir, 'relay.js'),
+  join(relayBuildDir, '.version')
+]) {
+  if (!existsSync(required)) {
+    throw new Error(`Required regression input is missing: ${required}`)
+  }
+}
+
+const runDir = mkdtempSync(join(projectDir, '.issue-9586-relay-repro-'))
+const relayPath = join(runDir, 'relay.js')
+const stdoutLog = join(runDir, 'relay.log')
+const stderrLog = join(runDir, 'relay.err.log')
+const socketPath = `\\\\.\\pipe\\orca-issue-9586-${process.pid}-${Date.now()}`
+let relayPid
+
+try {
+  prepareRelayTree(runDir, nodePtyDir)
+  if (!options.skipRelayPatch) {
+    applyPackagedNodePtyPatch(nodePath, runDir)
+  }
+  relayPid = launchRelayWithoutConsole({
+    nodePath,
+    relayPath,
+    runDir,
+    socketPath,
+    stdoutLog,
+    stderrLog
+  })
+  await waitForPipe(socketPath, 5_000)
+  const observation = await exerciseRelayClient({
+    nodePath,
+    relayPath,
+    runDir,
+    socketPath,
+    shell: options.shell
+  })
+  await waitForExit(relayPid, 8_000)
+
+  const relayStdout = readIfPresent(stdoutLog)
+  const relayStderr = readIfPresent(stderrLog)
+  const attachConsoleFailed = relayStderr.includes('Error: AttachConsole failed')
+  const installedNodePtyDir = join(runDir, 'node_modules', 'node-pty')
+  const agentPath = join(installedNodePtyDir, 'lib', 'conpty_console_list_agent.js')
+  const nativeBindingPath = join(
+    installedNodePtyDir,
+    'prebuilds',
+    `${process.platform}-${process.arch}`,
+    'conpty.node'
+  )
+  const summary = {
+    node: observation.nodeVersion,
+    nodePty: JSON.parse(readFileSync(join(nodePtyDir, 'package.json'), 'utf8')).version,
+    shell: options.shell,
+    relayPid,
+    handshake: observation.handshake,
+    ptySpawn: observation.ptySpawn,
+    ptyShutdown: observation.ptyShutdown,
+    relayAliveAfterPtyShutdown: observation.relayAliveAfterPtyShutdown,
+    bridgeExit: observation.bridgeExit,
+    relayPatchApplied: !options.skipRelayPatch,
+    agentSha256: fileSha256(agentPath),
+    nativeBindingPresent: existsSync(nativeBindingPath),
+    attachConsoleFailed,
+    relayExitedAfterClientDisconnect: !isProcessAlive(relayPid)
+  }
+  console.log(JSON.stringify(summary, null, 2))
+
+  if (expectFailure !== attachConsoleFailed) {
+    throw new Error(
+      expectFailure
+        ? `Expected the real console-list agent to fail AttachConsole. stderr:\n${relayStderr}`
+        : `The real console-list agent failed AttachConsole. stderr:\n${relayStderr}`
+    )
+  }
+  if (
+    !observation.handshake ||
+    !observation.ptySpawn ||
+    !observation.ptyShutdown ||
+    !observation.relayAliveAfterPtyShutdown
+  ) {
+    throw new Error(
+      `Relay lifecycle did not complete. stdout:\n${relayStdout}\nstderr:\n${relayStderr}`
+    )
+  }
+} finally {
+  if (relayPid && isProcessAlive(relayPid)) {
+    stopExactProcess(relayPid, relayPath)
+  }
+  rmSync(runDir, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 })
+}
+
+function parseArgs(args) {
+  const parsed = { expect: 'clean', shell: 'cmd.exe', skipRelayPatch: false }
+  for (let index = 0; index < args.length; index++) {
+    const flag = args[index]
+    if (flag === '--skip-relay-patch') {
+      parsed.skipRelayPatch = true
+      continue
+    }
+    const value = args[index + 1]
+    if (!value || !['--node', '--node-pty', '--expect', '--shell'].includes(flag)) {
+      throw new Error(
+        'Usage: node windows-ssh-attach-console-repro.mjs [--node PATH] [--node-pty DIR] [--shell PATH] [--skip-relay-patch] [--expect clean|attach-console-failure]'
+      )
+    }
+    if (flag === '--node') {
+      parsed.node = value
+    }
+    if (flag === '--node-pty') {
+      parsed.nodePty = value
+    }
+    if (flag === '--expect') {
+      parsed.expect = value
+    }
+    if (flag === '--shell') {
+      parsed.shell = value
+    }
+    index++
+  }
+  if (!['clean', 'attach-console-failure'].includes(parsed.expect)) {
+    throw new Error(`Unsupported expectation: ${parsed.expect}`)
+  }
+  return parsed
+}
+
+function prepareRelayTree(runDir, nodePtyDir) {
+  for (const filename of [
+    'relay.js',
+    'relay-watcher.js',
+    'managed-hook-runtime.js',
+    NODE_PTY_PATCH_FILENAME,
+    '.version'
+  ]) {
+    copyFileSync(join(relayBuildDir, filename), join(runDir, filename))
+  }
+  cpSync(nodePtyDir, join(runDir, 'node_modules', 'node-pty'), { recursive: true })
+}
+
+function applyPackagedNodePtyPatch(nodePath, runDir) {
+  const result = spawnSync(nodePath, [join(runDir, NODE_PTY_PATCH_FILENAME)], {
+    cwd: runDir,
+    encoding: 'utf8',
+    windowsHide: true
+  })
+  if (result.status !== 0) {
+    throw new Error(`Packaged node-pty patch failed: ${result.stderr || result.stdout}`)
+  }
+}
+
+function launchRelayWithoutConsole({
+  nodePath,
+  relayPath,
+  runDir,
+  socketPath,
+  stdoutLog,
+  stderrLog
+}) {
+  const relayArgs = [
+    quoteWindowsArg(nodePath),
+    quoteWindowsArg(relayPath),
+    '--detached',
+    '--grace-time',
+    '5',
+    '--sock-path',
+    quoteWindowsArg(socketPath),
+    '--endpoint-dir',
+    quoteWindowsArg(join(runDir, 'endpoint')),
+    '--log-file',
+    quoteWindowsArg(stdoutLog),
+    `1>${quoteWindowsArg(stdoutLog)}`,
+    `2>${quoteWindowsArg(stderrLog)}`
+  ].join(' ')
+  const commandLine = `cmd.exe /d /s /c "${relayArgs}"`
+  const script = [
+    `$result = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{ CommandLine = ${powerShellLiteral(commandLine)}; CurrentDirectory = ${powerShellLiteral(runDir)} }`,
+    `if ($result.ReturnValue -ne 0) { throw "Win32_Process.Create failed with $($result.ReturnValue)" }`,
+    '$result.ProcessId'
+  ].join('; ')
+  const launched = runPowerShell(script)
+  const pid = Number(launched.stdout.trim())
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new Error(`Could not parse detached relay pid from: ${launched.stdout}`)
+  }
+  return pid
+}
+
+function exerciseRelayClient({ nodePath, relayPath, runDir, socketPath, shell }) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const bridge = spawn(nodePath, [relayPath, '--connect', '--sock-path', socketPath], {
+      cwd: runDir,
+      windowsHide: true,
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+    const observation = {
+      nodeVersion: readNodeVersion(nodePath),
+      handshake: false,
+      ptySpawn: false,
+      ptyShutdown: false,
+      relayAliveAfterPtyShutdown: false,
+      bridgeExit: null
+    }
+    let stderr = ''
+    let buffer = Buffer.alloc(0)
+    let sentinelRead = false
+    let outgoingSequence = 1
+    let settled = false
+    const timeout = setTimeout(
+      () => finish(new Error(`Timed out waiting for relay client lifecycle. stderr:\n${stderr}`)),
+      REGRESSION_TIMEOUT_MS
+    )
+
+    bridge.stderr.on('data', (data) => {
+      stderr += data.toString()
+    })
+    bridge.on('error', finish)
+    bridge.on('close', (code, signal) => {
+      observation.bridgeExit = { code, signal }
+      if (!settled && observation.relayAliveAfterPtyShutdown) {
+        finish()
+      } else if (!settled) {
+        finish(new Error(`Relay bridge closed before lifecycle completed. stderr:\n${stderr}`))
+      }
+    })
+    bridge.stdout.on('data', (data) => {
+      try {
+        buffer = Buffer.concat([buffer, data])
+        if (!sentinelRead) {
+          const sentinelIndex = buffer.indexOf(SENTINEL)
+          if (sentinelIndex === -1) {
+            return
+          }
+          buffer = buffer.subarray(sentinelIndex + SENTINEL.length)
+          sentinelRead = true
+          observation.handshake = true
+          request(1, 'pty.spawn', {
+            shellOverride: shell,
+            cwd: projectDir,
+            cols: 80,
+            rows: 24,
+            env: {}
+          })
+        }
+        for (const message of drainMessages()) {
+          if (message.id === 1) {
+            throwResponseError(message)
+            observation.ptySpawn = true
+            request(2, 'pty.shutdown', { id: message.result.id, immediate: true })
+          } else if (message.id === 2) {
+            throwResponseError(message)
+            observation.ptyShutdown = true
+            request(3, 'relay.status', {})
+          } else if (message.id === 3) {
+            throwResponseError(message)
+            observation.relayAliveAfterPtyShutdown = message.result.ptys.active === 0
+            bridge.stdin.end()
+          }
+        }
+      } catch (error) {
+        finish(error)
+      }
+    })
+
+    function request(id, method, params) {
+      bridge.stdin.write(encodeRequestFrame({ id, method, params }, outgoingSequence++))
+    }
+
+    function drainMessages() {
+      const messages = []
+      while (buffer.length >= HEADER_LENGTH) {
+        const type = buffer[0]
+        const payloadLength = buffer.readUInt32BE(9)
+        if (buffer.length < HEADER_LENGTH + payloadLength) {
+          break
+        }
+        const payload = buffer.subarray(HEADER_LENGTH, HEADER_LENGTH + payloadLength)
+        buffer = buffer.subarray(HEADER_LENGTH + payloadLength)
+        if (type === 1) {
+          messages.push(JSON.parse(payload.toString('utf8')))
+        }
+      }
+      return messages
+    }
+
+    function finish(error) {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      if (error) {
+        bridge.kill()
+        rejectPromise(error)
+      } else {
+        resolvePromise(observation)
+      }
+    }
+  })
+}
+
+function waitForPipe(socketPath, timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+  return new Promise((resolvePromise, rejectPromise) => {
+    const attempt = () => {
+      const socket = createConnection(socketPath)
+      let settled = false
+      const retry = () => {
+        if (settled) {
+          return
+        }
+        settled = true
+        socket.destroy()
+        if (Date.now() >= deadline) {
+          rejectPromise(new Error(`Detached relay did not listen on ${socketPath}`))
+        } else {
+          setTimeout(attempt, 50)
+        }
+      }
+      socket.once('connect', () => {
+        if (settled) {
+          return
+        }
+        settled = true
+        socket.destroy()
+        resolvePromise()
+      })
+      socket.once('error', retry)
+      socket.setTimeout(250, retry)
+    }
+    attempt()
+  })
+}
+
+function encodeRequestFrame({ id, method, params }, sequence) {
+  const payload = Buffer.from(JSON.stringify({ jsonrpc: '2.0', id, method, params }))
+  const header = Buffer.alloc(HEADER_LENGTH)
+  header[0] = 1
+  header.writeUInt32BE(sequence, 1)
+  header.writeUInt32BE(0, 5)
+  header.writeUInt32BE(payload.length, 9)
+  return Buffer.concat([header, payload])
+}
+
+function throwResponseError(message) {
+  if (message.error) {
+    throw new Error(`Relay RPC failed: ${message.error.message}`)
+  }
+}
+
+function readNodeVersion(nodePath) {
+  return spawnSync(nodePath, ['--version'], { encoding: 'utf8' }).stdout.trim()
+}
+
+function waitForExit(pid, timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+  return new Promise((resolvePromise) => {
+    const poll = () => {
+      if (!isProcessAlive(pid) || Date.now() >= deadline) {
+        resolvePromise()
+        return
+      }
+      setTimeout(poll, 50)
+    }
+    poll()
+  })
+}
+
+function isProcessAlive(pid) {
+  const result = runPowerShell(
+    `if (Get-Process -Id ${pid} -ErrorAction SilentlyContinue) { 'ALIVE' }`
+  )
+  return result.stdout.includes('ALIVE')
+}
+
+function stopExactProcess(pid, relayPath) {
+  const script = [
+    `$process = Get-CimInstance Win32_Process -Filter ${powerShellLiteral(`ProcessId = ${pid}`)}`,
+    `if ($process -and $process.CommandLine -like ${powerShellLiteral(`*${relayPath}*`)}) { Stop-Process -Id ${pid} -Force }`
+  ].join('; ')
+  runPowerShell(script)
+}
+
+function runPowerShell(script) {
+  const encoded = Buffer.from(script, 'utf16le').toString('base64')
+  const result = spawnSync(
+    'powershell.exe',
+    ['-NoLogo', '-NoProfile', '-NonInteractive', '-EncodedCommand', encoded],
+    { encoding: 'utf8' }
+  )
+  if (result.status !== 0) {
+    throw new Error(`PowerShell failed (${result.status}): ${result.stderr || result.stdout}`)
+  }
+  return result
+}
+
+function quoteWindowsArg(value) {
+  return `"${value.replaceAll('"', '\\"')}"`
+}
+
+function powerShellLiteral(value) {
+  return `'${value.replaceAll("'", "''")}'`
+}
+
+function readIfPresent(path) {
+  return existsSync(path) ? readFileSync(path, 'utf8') : ''
+}
+
+function fileSha256(path) {
+  return createHash('sha256').update(readFileSync(path)).digest('hex')
+}

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -503,8 +503,10 @@ async function writeRemoteFile(
   }
 }
 
+const NODE_PTY_VERSION = '1.1.0'
+const NODE_PTY_CONSOLE_LIST_PATCH_FILENAME = 'node-pty-1.1.0-console-list-agent-patch.cjs'
 const RELAY_NATIVE_DEPS = {
-  'node-pty': '1.1.0',
+  'node-pty': NODE_PTY_VERSION,
   '@parcel/watcher': '2.5.6'
 } as const
 
@@ -520,7 +522,8 @@ const RELAY_NATIVE_DEP_SCRIPT_ALLOWLIST = Object.fromEntries(
 function nativeDepsProbeJs(successToken: string): string {
   // Why: node-pty's Windows wrapper defers conpty.node until first spawn, so require("node-pty") alone can't prove the binding is healthy.
   const loadNodePty =
-    'require("node-pty"); require("node-pty/lib/utils").loadNativeModule(process.platform==="win32"&&Number(require("os").release().split(".")[2])>=18309?"conpty":"pty")'
+    'require("node-pty"); require("node-pty/lib/utils").loadNativeModule(process.platform==="win32"&&Number(require("os").release().split(".")[2])>=18309?"conpty":"pty");' +
+    `if(process.platform==="win32"){require("./${NODE_PTY_CONSOLE_LIST_PATCH_FILENAME}").assertPatchedNodePtyConsoleListAgent(process.cwd())}`
   return `(()=>{const missing=[];try{${loadNodePty}}catch{missing.push("node-pty")}try{require("@parcel/watcher")}catch{missing.push("@parcel/watcher")}if(missing.length){console.log("${NATIVE_DEPS_MISSING_PREFIX}"+missing.join(","));process.exitCode=1}else{console.log(${JSON.stringify(successToken)})}})()`
 }
 
@@ -723,7 +726,9 @@ async function installNativeDeps(
             RELAY_NATIVE_DEPS
           )
             .map(([dep, version]) => powerShellLiteral(`${dep}@${version}`))
-            .join(' ')}; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }`
+            .join(
+              ' '
+            )}; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }; ${windowsNodePtyPatchCommand(nodePath)}`
         )
       : commandWithNodePath(
           hostPlatform,
@@ -840,7 +845,7 @@ async function rebuildNativeDeps(
         hostPlatform,
         nodePath,
         remoteDir,
-        `npm rebuild --ignore-scripts=false ${depNames.map(powerShellLiteral).join(' ')}; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }`
+        `npm rebuild --ignore-scripts=false ${depNames.map(powerShellLiteral).join(' ')}; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }; ${windowsNodePtyPatchCommand(nodePath)}`
       )
     : commandWithNodePath(
         hostPlatform,
@@ -852,6 +857,11 @@ async function rebuildNativeDeps(
     timeoutMs: NATIVE_DEPS_COMMAND_TIMEOUT_MS,
     signal
   })
+}
+
+function windowsNodePtyPatchCommand(nodePath: string): string {
+  // Why: pnpm patches do not cross the SSH boundary; apply the version-checked fallback to the remote npm package.
+  return `& ${powerShellLiteral(nodePath)} ${powerShellLiteral(NODE_PTY_CONSOLE_LIST_PATCH_FILENAME)}; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }`
 }
 
 async function makeNodePtySpawnHelperExecutable(


### PR DESCRIPTION
## Summary

- Apply Orca's existing `node-pty@1.1.0` console-list fallback to the independently installed Windows SSH relay dependency.
- Ship a strict, atomic patch asset, include it in Windows relay version hashes, and verify it during native-dependency health probes.
- Preserve the `[shellPid]` cleanup fallback without upgrading to a broad node-pty beta or adding a process-wide exception handler.
- Add a deterministic Node 22 Windows relay/ConPTY regression harness plus package and source-drift coverage.

Closes #9586.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — targeted lint passes; the full command reaches two unchanged switch-exhaustiveness failures in `daemon-server.ts` and `skill-freshness-group.tsx`.
- [ ] `pnpm typecheck` — `pnpm run typecheck:node` passes; web/CLI projects were not changed.
- [ ] `pnpm test` — focused suites pass; the full suite was not run.
- [ ] `pnpm build` — `pnpm run build:relay` passes for all relay targets; the full desktop/native build was not run.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused results:

- Node 22.22.0 + pristine npm `node-pty@1.1.0`, detached through `Win32_Process.Create`: real ConPTY spawn/shutdown succeeds and deterministically emits `AttachConsole failed` from helper SHA-256 `0d010879...c85e52`.
- Loopback SSH E2E (`ssh2.Server` on `127.0.0.1`, real `SshConnection`/SFTP): Node 22 detection, upload, native install, patch, detached WMI launch, named-pipe bridge/handshake, and cmd + Windows PowerShell ConPTY spawn/shutdown all pass; relay status returns zero active PTYs and both relay logs contain no `AttachConsole failed` (1/1 passed, 15.49s). The host had no `sshd`, so no service, firewall, account, or credential configuration was changed.
- The same packaged relay with the patch: cmd and Windows PowerShell both handshake, spawn, shut down, report zero active PTYs, close the bridge, and exit after grace with no AttachConsole error; helper SHA-256 is `84df20cf...dcd857` and the native binding is present.
- `pnpm exec vitest run --config config/vitest.config.ts config/scripts/node-pty-console-list-agent-patch.test.mjs src/main/ssh/ssh-relay-native-deps-install.test.ts config/scripts/package-electron-runtime-contract.test.mjs` — 53 passed.
- Electron builder contract — 20 passed, 1 skipped.
- `pnpm run typecheck:node`, targeted oxlint, oxfmt check, 44 reliability gates, and max-lines ratchet pass.
- Independent artifact verification confirms only win32-x64/win32-arm64 outputs contain the exact patch asset and every relay `.version` matches its recomputed content hash.

## AI Review Report

Three merge-base-anchored adversarial rounds reviewed the complete diff and the real Windows evidence. Review covered dependency ownership, exact upstream release contents, old-Windows/WinPTY behavior, cmd/PowerShell shells, ARM64/x64 packaging, process-tree cleanup, Node/Electron ABI stability, reconnect/install recovery, source drift, macOS/Linux no-op behavior, and packaging contents.

The first rounds flagged two hardening opportunities that were implemented: validate the entire published helper by exact hashes, and replace it atomically so an interrupted remote install remains recoverable. The final round found no remaining in-scope issues. There is no terminal hot-path change; reconnect adds only an ~800-byte helper hash inside the existing native-dependency probe.

A `node-pty` beta bump was rejected because beta.11 spans 108 commits/222 files, removes the WinPTY fallback, weakens this failure fallback to `[]`, and predates later ConPTY lifecycle/leak fixes. Forcing bundled ConPTY was also rejected because it changes backend and process-tree cleanup semantics.

Cross-platform review confirmed the patch/install command is Windows-gated, the asset is shipped only in Windows relay outputs, local terminals are unchanged, and macOS/Linux relay dependency installation remains unchanged.

## Security Audit

- The remote patch is restricted to exact `node-pty@1.1.0` original/patched source hashes and fails closed on version or source drift.
- Replacement is atomic and idempotent; health probes verify the installed bytes on reconnect.
- Node and asset paths continue through existing PowerShell literal escaping, with no new user-controlled shell fragments.
- No dependency or lockfile changes, new credentials, auth behavior, IPC surface, or broad `uncaughtException` handler.
- The fallback catches only the native console-list call and retains the known shell PID for cleanup.

## Notes

The reproduction corrects part of the issue report's causal chain: the console-list helper is forked during PTY kill, and its failure does not itself crash the relay/socket. The baseline relay remained alive and the bridge exited successfully. This PR fixes the verified missing relay patch and AttachConsole error; it does not claim that this helper exception independently explains every reported client startup failure.
