### PR TITLE
fix(editor): reconcile multi-byte markdown saves without byte-offset crash (#9492)

### DIFF
--- a/src/renderer/src/components/editor/rich-markdown-source-reconcile.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-source-reconcile.test.ts
@@ -348,7 +348,7 @@ describe('reconcileSerializedMarkdown', () => {
     // previously threw; every such edit must reconcile and stay render-equal to `edited`.
     const lines: string[] = []
     for (let i = 0; i < 20; i++) {
-      lines.push(`_强调${i}_ 这是一段包含很多中文字符的文本内容用来测试多字节偏移问题`)
+      lines.push(`_强调${i}_ 😀 café 这是一段包含很多中文字符的文本内容用来测试多字节偏移问题`)
     }
     const originalSource = `# 标题\n\n${lines.join('\n')}\n`
     const baseCanonical = fakeCanonicalize(originalSource)
@@ -356,11 +356,13 @@ describe('reconcileSerializedMarkdown', () => {
     // Sweep insert positions so we exercise the offsets that used to overshoot the byte target.
     const chars = [...baseCanonical]
     for (let pos = 5; pos < chars.length - 5; pos += 3) {
-      const edited = `${chars.slice(0, pos).join('')}插${chars.slice(pos).join('')}`
+      const inserted = ['插', '😀', 'é'][Math.floor(pos / 3) % 3]
+      const edited = `${chars.slice(0, pos).join('')}${inserted}${chars.slice(pos).join('')}`
 
       const reconciled = reconcileWithFake(originalSource, edited)
 
-      // Never throws, and the reconciled bytes render exactly to `edited`.
+      // Never throws or falls back to a whole-document canonical rewrite.
+      expect(reconciled).not.toBe(edited)
       expect(fakeCanonicalize(reconciled).trimEnd()).toBe(edited.trimEnd())
     }
   })

--- a/src/renderer/src/components/editor/rich-markdown-source-reconcile.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-source-reconcile.test.ts
@@ -366,6 +366,21 @@ describe('reconcileSerializedMarkdown', () => {
       expect(fakeCanonicalize(reconciled).trimEnd()).toBe(edited.trimEnd())
     }
   })
+
+  it('keeps later multi-hunk seeds in the rolling application coordinate space', () => {
+    const lines = Array.from({ length: 8 }, (_, i) => `_强调${i}_ ascii segment ${i} 中文 tail`)
+    const originalSource = `# 标题\n\n${lines.join('\n')}\n`
+    const baseCanonical = fakeCanonicalize(originalSource)
+    // Why: the first hunk changes the UTF-8/code-unit delta before the second seed is decoded.
+    const edited = baseCanonical
+      .replace('segment 1', 'segment 1 🚀🚀')
+      .replace('segment 6', 'segment 6 XYZ')
+
+    const reconciled = reconcileWithFake(originalSource, edited)
+
+    expect(reconciled).not.toBe(edited)
+    expect(fakeCanonicalize(reconciled)).toBe(edited)
+  })
 })
 
 describe('serializeRichMarkdownForReconcile (real editor pipeline)', () => {

--- a/src/renderer/src/components/editor/rich-markdown-source-reconcile.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-source-reconcile.test.ts
@@ -341,6 +341,29 @@ describe('reconcileSerializedMarkdown', () => {
       reconciled.includes('_alpha edited_') && reconciled.split('_beta_').length === 3
     expect(landedInStyle || reconciled === edited).toBe(true)
   })
+
+  it('reconciles a multi-byte edit without throwing "Failed to determine byte offset" (#9492)', () => {
+    // Regression: dmp's byte/char index mixup crashes when the patch seed lands mid multi-byte run.
+    // Build a mostly-Chinese doc with non-canonical `_`/`*` markers and edit a position that
+    // previously threw; every such edit must reconcile and stay render-equal to `edited`.
+    const lines: string[] = []
+    for (let i = 0; i < 20; i++) {
+      lines.push(`_强调${i}_ 这是一段包含很多中文字符的文本内容用来测试多字节偏移问题`)
+    }
+    const originalSource = `# 标题\n\n${lines.join('\n')}\n`
+    const baseCanonical = fakeCanonicalize(originalSource)
+
+    // Sweep insert positions so we exercise the offsets that used to overshoot the byte target.
+    const chars = [...baseCanonical]
+    for (let pos = 5; pos < chars.length - 5; pos += 3) {
+      const edited = `${chars.slice(0, pos).join('')}插${chars.slice(pos).join('')}`
+
+      const reconciled = reconcileWithFake(originalSource, edited)
+
+      // Never throws, and the reconciled bytes render exactly to `edited`.
+      expect(fakeCanonicalize(reconciled).trimEnd()).toBe(edited.trimEnd())
+    }
+  })
 })
 
 describe('serializeRichMarkdownForReconcile (real editor pipeline)', () => {

--- a/src/renderer/src/components/editor/rich-markdown-source-reconcile.ts
+++ b/src/renderer/src/components/editor/rich-markdown-source-reconcile.ts
@@ -80,7 +80,13 @@ export function reconcileSerializedMarkdown({
     diffs = cleanupEfficiency(diffs)
   }
   const patches = makePatches(baseLf, diffs)
-  const [reconciledLf, results] = applyPatches(patches, originalSourceLf)
+  // Why: dmp's adjustIndiciesToUcs2 treats patch.start1 (a char index) as a UTF-8 byte offset, so on multi-byte
+  // text (Chinese/emoji/accented) its byte counter overshoots the target and throws "Failed to determine byte
+  // offset" (#9492). allowExceedingIndices returns the nearest index instead; the fuzzy match relocates the hunk
+  // and branch 6's round-trip proof rejects any misplacement, so the seed offset need not be exact.
+  const [reconciledLf, results] = applyPatches(patches, originalSourceLf, {
+    allowExceedingIndices: true
+  })
 
   // Branch 5: a hunk failed to locate in the non-canonical source → unreliable fuzzy match, fall back to canonical.
   if (results.some((applied) => !applied)) {

--- a/src/renderer/src/components/editor/rich-markdown-source-reconcile.ts
+++ b/src/renderer/src/components/editor/rich-markdown-source-reconcile.ts
@@ -80,13 +80,16 @@ export function reconcileSerializedMarkdown({
     diffs = cleanupEfficiency(diffs)
   }
   const patches = makePatches(baseLf, diffs)
-  // Why: dmp's adjustIndiciesToUcs2 treats patch.start1 (a char index) as a UTF-8 byte offset, so on multi-byte
-  // text (Chinese/emoji/accented) its byte counter overshoots the target and throws "Failed to determine byte
-  // offset" (#9492). allowExceedingIndices returns the nearest index instead; the fuzzy match relocates the hunk
-  // and branch 6's round-trip proof rejects any misplacement, so the seed offset need not be exact.
-  const [reconciledLf, results] = applyPatches(patches, originalSourceLf, {
-    allowExceedingIndices: true
-  })
+  // Why: applyPatches decodes starts as UTF-8 offsets even though makePatches returns UTF-16 indices; encode against the divergent text being patched so decoding preserves the fuzzy-match seed.
+  const utf8Offsets = getUtf8OffsetsAtCodeUnitIndices(
+    originalSourceLf,
+    patches.flatMap((patch) => [patch.start1, patch.start2])
+  )
+  for (const patch of patches) {
+    patch.start1 = utf8Offsets.get(patch.start1) ?? 0
+    patch.start2 = utf8Offsets.get(patch.start2) ?? 0
+  }
+  const [reconciledLf, results] = applyPatches(patches, originalSourceLf)
 
   // Branch 5: a hunk failed to locate in the non-canonical source → unreliable fuzzy match, fall back to canonical.
   if (results.some((applied) => !applied)) {
@@ -126,6 +129,42 @@ function restoreEol(lfText: string, eol: '\n' | '\r\n'): string {
 function normalizeForSafety(text: string): string {
   // Why: compare exactly (only CRLF-normalized) — a trailing `\n\n` empty paragraph is semantic, so a lenient trimEnd would mask the trailing-block drift branch 6 must catch.
   return text.replace(/\r\n/g, '\n')
+}
+
+function getUtf8OffsetsAtCodeUnitIndices(
+  text: string,
+  codeUnitIndices: number[]
+): Map<number, number> {
+  const targets = [...new Set(codeUnitIndices)].sort((a, b) => a - b)
+  const offsets = new Map<number, number>()
+  let codeUnitIndex = 0
+  let byteOffset = 0
+  for (const target of targets) {
+    const boundedTarget = Math.max(0, Math.min(target, text.length))
+    while (codeUnitIndex < boundedTarget) {
+      const codePoint = text.codePointAt(codeUnitIndex)
+      if (codePoint === undefined) {
+        break
+      }
+      byteOffset += utf8CodePointLength(codePoint)
+      codeUnitIndex += codePoint > 0xffff ? 2 : 1
+    }
+    offsets.set(target, byteOffset)
+  }
+  return offsets
+}
+
+function utf8CodePointLength(codePoint: number): number {
+  if (codePoint <= 0x7f) {
+    return 1
+  }
+  if (codePoint <= 0x7ff) {
+    return 2
+  }
+  if (codePoint <= 0xffff) {
+    return 3
+  }
+  return 4
 }
 
 function hasRepeatedHalfMatchSeed(textA: string, textB: string): boolean {


### PR DESCRIPTION
## Problem

Saving a mostly multi-byte markdown document (Chinese, emoji, accented Latin) via `Ctrl`/`Cmd`+`S` can throw:

```
Uncaught Error: Failed to determine byte offset
    at advanceTo (@sanity_diff-match-patch)
    at adjustIndiciesToUcs2 (@sanity_diff-match-patch)
    at apply (@sanity_diff-match-patch)
    at reconcileSerializedMarkdown (rich-markdown-source-reconcile.ts)
```

Fixes #9492 (P1). Regression introduced by #8862.

## Root cause

`@sanity/diff-match-patch` `makePatches` stores `patch.start1` and `patch.start2` as UTF-16 code-unit indices, but `applyPatches` passes them through a converter that interprets them as UTF-8 byte offsets. ASCII hides the mismatch. In multi-byte text, the byte counter can skip over the requested value and throw.

The first version of this PR used `allowExceedingIndices` to suppress the exception. Review measurement found that this was safe for content but caused most multi-byte edits to miss the source-preserving path and rewrite the document canonically (28/282 positions preserved original style).

## Fix

Before applying patches, translate their UTF-16 seeds into valid UTF-8 offsets against the actual non-canonical source. The dependency then decodes them back to the intended fuzzy-match locations without relaxing its strict offset check.

The conversion scans the bounded document once plus sorting patch targets: O(document length + patch count log patch count). Existing hunk-result and round-trip checks still reject failed or misplaced patches and fall back to canonical output.

In the same 282-position mixed-Unicode sweep, the corrected seeds preserved source style in 282/282 cases and reduced aggregate patch-application time from about 29.8 ms to 19.3 ms.

## Tests

- Position sweep over Chinese, emoji, and accented Latin content with 2-, 3-, and 4-byte insertions.
- Asserts every edit avoids the exception, remains render-equivalent, and does not fall back to a whole-document canonical rewrite.
- Focused reconciliation and serialization commit suites: 34/34 passing, including rolling multi-hunk Unicode seeds.
- Web typecheck, changed-file lint/format, diff check, and max-lines ratchet pass.
- 10,000-case mixed-Unicode fuzz check: zero offset exceptions with strict dependency defaults.