### PR TITLE
Fix Linear skill-install modal CTA hierarchy

### DIFF
--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useState, type ComponentProps, type ReactNode } from 'react'
 import { Copy, Loader2, RefreshCw, Terminal } from 'lucide-react'
 import { toast } from 'sonner'
 import { IntegrationStatusPill } from '../integration-status-pill'
@@ -44,6 +44,9 @@ type AgentSkillSetupPanelProps = {
   showRecheckWhenInstalled?: boolean
   installLabel?: string
   installedInstallLabel?: string
+  // Why: defaults to 'outline' so settings panels stay unchanged; modals that make
+  // Install the sole footer CTA pass 'default' for a filled primary hierarchy.
+  installVariant?: ComponentProps<typeof Button>['variant']
   actionHint?: ReactNode
   openingHint?: ReactNode
   footer?: ReactNode
@@ -81,6 +84,7 @@ export function AgentSkillSetupPanel({
   showRecheckWhenInstalled = true,
   installLabel = 'Install',
   installedInstallLabel = 'Update',
+  installVariant = 'outline',
   actionHint,
   openingHint,
   footer,
@@ -170,7 +174,7 @@ export function AgentSkillSetupPanel({
       {!installed || showInstallWhenInstalled ? (
         <Button
           type="button"
-          variant="outline"
+          variant={installVariant}
           size="sm"
           onClick={() => {
             if (terminalOpening) {

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupDialog.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupDialog.tsx
@@ -35,7 +35,6 @@ type LinearAgentSkillSetupDialogProps = {
   onRecheck: AgentSkillSetupPanelProps['onRecheck']
   onOpenChange: (open: boolean) => void
   onDismissPermanently: () => void
-  onSnoozeForSession: () => void
   onDone: () => void
 }
 
@@ -55,7 +54,6 @@ export function LinearAgentSkillSetupDialog({
   onRecheck,
   onOpenChange,
   onDismissPermanently,
-  onSnoozeForSession,
   onDone
 }: LinearAgentSkillSetupDialogProps): React.JSX.Element {
   return (
@@ -145,21 +143,25 @@ export function LinearAgentSkillSetupDialog({
                 'auto.components.sidebar.LinearAgentSkillSetupPrompt.install',
                 'Install CLI & Skill'
               )}
+              // Why: Install is this modal's sole CTA, so make it the filled primary —
+              // matching the other setup surfaces (filled primary + muted dismiss).
+              installVariant="default"
               preInstallNotice={AGENT_SKILL_CLI_PREREQUISITE_NOTICE}
               getPrerequisiteStatus={getPrerequisiteStatus}
               isPrerequisiteAvailable={isOrcaCliAvailableOnPath}
               onBeforeOpenTerminal={onBeforeOpenTerminal}
               onRecheck={onRecheck}
             />
+            {/* Why: the dialog's × already dismisses-for-session (onOpenChange), so a
+                separate "Not now" button was redundant and, styled as the footer CTA,
+                read as the primary action over Install. Keep only the distinct
+                permanent-dismiss action. */}
             <DialogFooter className="px-6 pb-6">
               <Button type="button" variant="ghost" size="sm" onClick={onDismissPermanently}>
                 {translate(
                   'auto.components.sidebar.LinearAgentSkillSetupPrompt.dontShowAgain',
                   "Don't show again"
                 )}
-              </Button>
-              <Button type="button" variant="outline" size="sm" onClick={onSnoozeForSession}>
-                {translate('auto.components.sidebar.LinearAgentSkillSetupPrompt.notNow', 'Not now')}
               </Button>
             </DialogFooter>
           </>

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupDialog.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupDialog.tsx
@@ -170,7 +170,9 @@ export function LinearAgentSkillSetupDialog({
                       "Don't show again"
                     )}
                     onClick={onDismissPermanently}
-                    className="absolute top-3.5 right-10 text-muted-foreground"
+                    // Why: top-3 (not top-3.5) so this icon-xs button's centered 16px icon
+                    // lines up with the bare × close icon (top-4) — verified pixel-aligned.
+                    className="absolute top-3 right-10 text-muted-foreground"
                   >
                     <EyeOff className="size-4" />
                   </Button>

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupDialog.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupDialog.tsx
@@ -1,8 +1,9 @@
 import type { ComponentProps } from 'react'
-import { CheckCircle2, Info } from 'lucide-react'
+import { CheckCircle2, EyeOff, Info } from 'lucide-react'
 import { IntegrationStatusPill } from '@/components/integration-status-pill'
 import { AgentSkillSetupPanel } from '@/components/settings/AgentSkillSetupPanel'
 import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   Dialog,
   DialogContent,
@@ -89,7 +90,7 @@ export function LinearAgentSkillSetupDialog({
           </>
         ) : (
           <>
-            <div className="px-6 pt-6 pr-14">
+            <div className="px-6 pt-6 pr-20">
               <DialogHeader>
                 <DialogTitle className="sr-only">
                   {translate(
@@ -115,7 +116,7 @@ export function LinearAgentSkillSetupDialog({
               </div>
             </div>
             <AgentSkillSetupPanel
-              className="px-6 pt-4 pb-3"
+              className="px-6 pt-4 pb-6"
               variant="inline"
               hideHeader
               title={translate(
@@ -152,23 +153,36 @@ export function LinearAgentSkillSetupDialog({
               onBeforeOpenTerminal={onBeforeOpenTerminal}
               onRecheck={onRecheck}
             />
-            {/* Why: the dialog's × already dismisses for the session, so the only footer
-                control is the permanent opt-out — kept as a quiet muted link so it doesn't
-                pull the eye from the filled Install primary. */}
-            <DialogFooter className="px-6 pb-6">
-              <Button
-                type="button"
-                variant="link"
-                size="sm"
-                className="h-auto p-0 text-muted-foreground hover:text-foreground"
-                onClick={onDismissPermanently}
-              >
-                {translate(
-                  'auto.components.sidebar.LinearAgentSkillSetupPrompt.dontShowAgain',
-                  "Don't show again"
-                )}
-              </Button>
-            </DialogFooter>
+            {/* Why: permanent opt-out as a quiet EyeOff icon next to the × — matching
+                SetupGuideModal's "hide this setup surface" affordance — instead of a
+                footer button that competes with (or gets reflex-clicked over) Install.
+                Rendered last so the dialog's initial focus lands on Install, not here —
+                otherwise Enter-on-open would permanently dismiss. */}
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    aria-label={translate(
+                      'auto.components.sidebar.LinearAgentSkillSetupPrompt.dontShowAgain',
+                      "Don't show again"
+                    )}
+                    onClick={onDismissPermanently}
+                    className="absolute top-3.5 right-10 text-muted-foreground"
+                  >
+                    <EyeOff className="size-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="top" sideOffset={4}>
+                  {translate(
+                    'auto.components.sidebar.LinearAgentSkillSetupPrompt.dontShowAgain',
+                    "Don't show again"
+                  )}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </>
         )}
       </DialogContent>

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupDialog.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupDialog.tsx
@@ -35,7 +35,6 @@ type LinearAgentSkillSetupDialogProps = {
   onRecheck: AgentSkillSetupPanelProps['onRecheck']
   onOpenChange: (open: boolean) => void
   onDismissPermanently: () => void
-  onSnoozeForSession: () => void
   onDone: () => void
 }
 
@@ -55,7 +54,6 @@ export function LinearAgentSkillSetupDialog({
   onRecheck,
   onOpenChange,
   onDismissPermanently,
-  onSnoozeForSession,
   onDone
 }: LinearAgentSkillSetupDialogProps): React.JSX.Element {
   return (
@@ -154,11 +152,10 @@ export function LinearAgentSkillSetupDialog({
               onBeforeOpenTerminal={onBeforeOpenTerminal}
               onRecheck={onRecheck}
             />
-            {/* Why: this modal auto-opens unsolicited, so the reflexive dismiss must be
-                the non-destructive one. "Not now" (session snooze, same as the ×) is the
-                easy ghost target; permanent "Don't show again" is demoted to a quiet muted
-                link so nuking the prompt takes intent. Install stays the filled primary. */}
-            <DialogFooter className="px-6 pb-6 sm:items-center sm:justify-between">
+            {/* Why: the dialog's × already dismisses for the session, so the only footer
+                control is the permanent opt-out — kept as a quiet muted link so it doesn't
+                pull the eye from the filled Install primary. */}
+            <DialogFooter className="px-6 pb-6">
               <Button
                 type="button"
                 variant="link"
@@ -170,9 +167,6 @@ export function LinearAgentSkillSetupDialog({
                   'auto.components.sidebar.LinearAgentSkillSetupPrompt.dontShowAgain',
                   "Don't show again"
                 )}
-              </Button>
-              <Button type="button" variant="ghost" size="sm" onClick={onSnoozeForSession}>
-                {translate('auto.components.sidebar.LinearAgentSkillSetupPrompt.notNow', 'Not now')}
               </Button>
             </DialogFooter>
           </>

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupDialog.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupDialog.tsx
@@ -35,6 +35,7 @@ type LinearAgentSkillSetupDialogProps = {
   onRecheck: AgentSkillSetupPanelProps['onRecheck']
   onOpenChange: (open: boolean) => void
   onDismissPermanently: () => void
+  onSnoozeForSession: () => void
   onDone: () => void
 }
 
@@ -54,6 +55,7 @@ export function LinearAgentSkillSetupDialog({
   onRecheck,
   onOpenChange,
   onDismissPermanently,
+  onSnoozeForSession,
   onDone
 }: LinearAgentSkillSetupDialogProps): React.JSX.Element {
   return (
@@ -152,16 +154,25 @@ export function LinearAgentSkillSetupDialog({
               onBeforeOpenTerminal={onBeforeOpenTerminal}
               onRecheck={onRecheck}
             />
-            {/* Why: the dialog's × already dismisses-for-session (onOpenChange), so a
-                separate "Not now" button was redundant and, styled as the footer CTA,
-                read as the primary action over Install. Keep only the distinct
-                permanent-dismiss action. */}
-            <DialogFooter className="px-6 pb-6">
-              <Button type="button" variant="ghost" size="sm" onClick={onDismissPermanently}>
+            {/* Why: this modal auto-opens unsolicited, so the reflexive dismiss must be
+                the non-destructive one. "Not now" (session snooze, same as the ×) is the
+                easy ghost target; permanent "Don't show again" is demoted to a quiet muted
+                link so nuking the prompt takes intent. Install stays the filled primary. */}
+            <DialogFooter className="px-6 pb-6 sm:items-center sm:justify-between">
+              <Button
+                type="button"
+                variant="link"
+                size="sm"
+                className="h-auto p-0 text-muted-foreground hover:text-foreground"
+                onClick={onDismissPermanently}
+              >
                 {translate(
                   'auto.components.sidebar.LinearAgentSkillSetupPrompt.dontShowAgain',
                   "Don't show again"
                 )}
+              </Button>
+              <Button type="button" variant="ghost" size="sm" onClick={onSnoozeForSession}>
+                {translate('auto.components.sidebar.LinearAgentSkillSetupPrompt.notNow', 'Not now')}
               </Button>
             </DialogFooter>
           </>

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.reminder-toast.test.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.reminder-toast.test.tsx
@@ -345,7 +345,10 @@ describe('LinearAgentSkillSetupPrompt reminder toast', () => {
     })
     mocks.toastDismiss.mockClear()
     await act(async () => {
-      findBodyButton("Don't show again")?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      // Why: permanent dismiss is now an EyeOff icon button (aria-label, no text).
+      document.body
+        .querySelector<HTMLButtonElement>('button[aria-label="Don\'t show again"]')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
     expect(window.localStorage.getItem(HOST_DISMISS_STORAGE_KEY)).toBe('1')

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.reminder-toast.test.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.reminder-toast.test.tsx
@@ -143,8 +143,9 @@ async function snoozeInitialModal(
   props: ComponentProps<typeof LinearAgentSkillSetupPrompt>
 ): Promise<void> {
   await renderPrompt(props)
+  // Why: "Not now" was removed; the dialog's × drives the session snooze now.
   await act(async () => {
-    findBodyButton('Not now')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    findBodyButton('Close')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
   })
   await unmountPrompt()
 }
@@ -203,7 +204,7 @@ describe('LinearAgentSkillSetupPrompt reminder toast', () => {
     Reflect.deleteProperty(window, 'api')
   })
 
-  it('shows a warning toast on a later modal-only activation after Not now', async () => {
+  it('shows a warning toast on a later modal-only activation after a casual close', async () => {
     await snoozeInitialModal({ linked: true, remote: false, surface: 'modal' })
     await renderPrompt({ linked: true, remote: false, surface: 'modal' })
 

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.reminder-toast.test.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.reminder-toast.test.tsx
@@ -143,9 +143,8 @@ async function snoozeInitialModal(
   props: ComponentProps<typeof LinearAgentSkillSetupPrompt>
 ): Promise<void> {
   await renderPrompt(props)
-  // Why: "Not now" was removed; the dialog's × drives the session snooze now.
   await act(async () => {
-    findBodyButton('Close')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    findBodyButton('Not now')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
   })
   await unmountPrompt()
 }
@@ -204,7 +203,7 @@ describe('LinearAgentSkillSetupPrompt reminder toast', () => {
     Reflect.deleteProperty(window, 'api')
   })
 
-  it('shows a warning toast on a later modal-only activation after a casual close', async () => {
+  it('shows a warning toast on a later modal-only activation after Not now', async () => {
     await snoozeInitialModal({ linked: true, remote: false, surface: 'modal' })
     await renderPrompt({ linked: true, remote: false, surface: 'modal' })
 

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.reminder-toast.test.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.reminder-toast.test.tsx
@@ -143,8 +143,10 @@ async function snoozeInitialModal(
   props: ComponentProps<typeof LinearAgentSkillSetupPrompt>
 ): Promise<void> {
   await renderPrompt(props)
+  // Why: the modal's casual dismiss is the dialog × (session snooze) now that
+  // "Not now" is removed.
   await act(async () => {
-    findBodyButton('Not now')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    findBodyButton('Close')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
   })
   await unmountPrompt()
 }
@@ -203,7 +205,7 @@ describe('LinearAgentSkillSetupPrompt reminder toast', () => {
     Reflect.deleteProperty(window, 'api')
   })
 
-  it('shows a warning toast on a later modal-only activation after Not now', async () => {
+  it('shows a warning toast on a later modal-only activation after a casual close', async () => {
     await snoozeInitialModal({ linked: true, remote: false, surface: 'modal' })
     await renderPrompt({ linked: true, remote: false, surface: 'modal' })
 

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.test.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.test.tsx
@@ -452,7 +452,7 @@ describe('LinearAgentSkillSetupPrompt', () => {
     )
   })
 
-  it('auto-opens as a modal-only prompt and treats Not now as a casual close', async () => {
+  it('auto-opens as a modal-only prompt and treats the × close as a casual snooze', async () => {
     await renderPrompt({ linked: true, remote: false, surface: 'modal' })
 
     expect(container?.textContent).not.toContain('Set up Linear agent skill')
@@ -461,17 +461,20 @@ describe('LinearAgentSkillSetupPrompt', () => {
     )
     expect(document.body.textContent).toContain('Orca CLI and Linear agent skill are missing.')
     expect(document.body.textContent).toContain('Mock install')
+    expect(document.body.textContent).not.toContain('Not now')
     expect(mocks.panelProps.at(-1)).toEqual(
       expect.objectContaining({
         preInstallNotice: 'CLI registration notice'
       })
     )
 
-    const notNowButton = Array.from(document.body.querySelectorAll('button')).find(
-      (button) => button.textContent === 'Not now'
+    // Why: "Not now" was removed; the dialog's × is the casual dismiss and must snooze
+    // (session-only) rather than persist a permanent dismissal.
+    const closeButton = Array.from(document.body.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Close'
     )
     await act(async () => {
-      notNowButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      closeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
     expect(window.localStorage.getItem(HOST_DISMISS_STORAGE_KEY)).toBeNull()

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.test.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.test.tsx
@@ -452,7 +452,7 @@ describe('LinearAgentSkillSetupPrompt', () => {
     )
   })
 
-  it('auto-opens as a modal-only prompt and treats Not now as a casual snooze', async () => {
+  it('auto-opens as a modal-only prompt and treats the × close as a casual snooze', async () => {
     await renderPrompt({ linked: true, remote: false, surface: 'modal' })
 
     expect(container?.textContent).not.toContain('Set up Linear agent skill')
@@ -461,19 +461,21 @@ describe('LinearAgentSkillSetupPrompt', () => {
     )
     expect(document.body.textContent).toContain('Orca CLI and Linear agent skill are missing.')
     expect(document.body.textContent).toContain('Mock install')
+    // Why: only "Don't show again" (permanent) is a footer button now; the casual
+    // dismiss is the dialog ×.
+    expect(document.body.textContent).not.toContain('Not now')
     expect(mocks.panelProps.at(-1)).toEqual(
       expect.objectContaining({
         preInstallNotice: 'CLI registration notice'
       })
     )
 
-    // Why: the unsolicited modal's labeled dismiss is the non-destructive one, so
-    // "Not now" must snooze for the session, not persist a permanent dismissal.
-    const notNowButton = Array.from(document.body.querySelectorAll('button')).find(
-      (button) => button.textContent === 'Not now'
+    // Why: the × must snooze for the session, not persist a permanent dismissal.
+    const closeButton = Array.from(document.body.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Close'
     )
     await act(async () => {
-      notNowButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      closeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
     expect(window.localStorage.getItem(HOST_DISMISS_STORAGE_KEY)).toBeNull()

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.test.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.test.tsx
@@ -461,8 +461,8 @@ describe('LinearAgentSkillSetupPrompt', () => {
     )
     expect(document.body.textContent).toContain('Orca CLI and Linear agent skill are missing.')
     expect(document.body.textContent).toContain('Mock install')
-    // Why: only "Don't show again" (permanent) is a footer button now; the casual
-    // dismiss is the dialog ×.
+    // Why: the permanent opt-out is an EyeOff icon (no visible text); the casual
+    // dismiss is the dialog ×. Neither "Not now" nor any dismiss label shows as text.
     expect(document.body.textContent).not.toContain('Not now')
     expect(mocks.panelProps.at(-1)).toEqual(
       expect.objectContaining({
@@ -915,8 +915,9 @@ describe('LinearAgentSkillSetupPrompt', () => {
   it('permanently dismisses the modal-only prompt when requested', async () => {
     await renderPrompt({ linked: true, remote: false, surface: 'modal' })
 
-    const dismissButton = Array.from(document.body.querySelectorAll('button')).find(
-      (button) => button.textContent === "Don't show again"
+    // Why: permanent dismiss is now an EyeOff icon button (aria-label, no text).
+    const dismissButton = document.body.querySelector<HTMLButtonElement>(
+      'button[aria-label="Don\'t show again"]'
     )
     await act(async () => {
       dismissButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.test.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.test.tsx
@@ -452,7 +452,7 @@ describe('LinearAgentSkillSetupPrompt', () => {
     )
   })
 
-  it('auto-opens as a modal-only prompt and treats the × close as a casual snooze', async () => {
+  it('auto-opens as a modal-only prompt and treats Not now as a casual snooze', async () => {
     await renderPrompt({ linked: true, remote: false, surface: 'modal' })
 
     expect(container?.textContent).not.toContain('Set up Linear agent skill')
@@ -461,20 +461,19 @@ describe('LinearAgentSkillSetupPrompt', () => {
     )
     expect(document.body.textContent).toContain('Orca CLI and Linear agent skill are missing.')
     expect(document.body.textContent).toContain('Mock install')
-    expect(document.body.textContent).not.toContain('Not now')
     expect(mocks.panelProps.at(-1)).toEqual(
       expect.objectContaining({
         preInstallNotice: 'CLI registration notice'
       })
     )
 
-    // Why: "Not now" was removed; the dialog's × is the casual dismiss and must snooze
-    // (session-only) rather than persist a permanent dismissal.
-    const closeButton = Array.from(document.body.querySelectorAll('button')).find(
-      (button) => button.textContent === 'Close'
+    // Why: the unsolicited modal's labeled dismiss is the non-destructive one, so
+    // "Not now" must snooze for the session, not persist a permanent dismissal.
+    const notNowButton = Array.from(document.body.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Not now'
     )
     await act(async () => {
-      closeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      notNowButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
     expect(window.localStorage.getItem(HOST_DISMISS_STORAGE_KEY)).toBeNull()

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.tsx
@@ -338,7 +338,6 @@ export function LinearAgentSkillSetupPrompt({
         setSetupDialogOpen(false)
       }}
       onDismissPermanently={dismissPermanently}
-      onSnoozeForSession={snoozeForSession}
       onDone={closeSuccessModal}
     />
   )

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.tsx
@@ -338,6 +338,7 @@ export function LinearAgentSkillSetupPrompt({
         setSetupDialogOpen(false)
       }}
       onDismissPermanently={dismissPermanently}
+      onSnoozeForSession={snoozeForSession}
       onDone={closeSuccessModal}
     />
   )

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4672,6 +4672,7 @@
           "modalDescription": "Install the Linear skill from a terminal.",
           "modalPrompt": "Enable agents to read and edit the attached Linear ticket.",
           "dontShowAgain": "Don't show again",
+          "notNow": "Not now",
           "missingBoth": "Orca CLI and Linear agent skill are missing.",
           "missingCli": "Orca CLI is missing.",
           "missingSkill": "Linear agent skill is missing.",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4672,7 +4672,6 @@
           "modalDescription": "Install the Linear skill from a terminal.",
           "modalPrompt": "Enable agents to read and edit the attached Linear ticket.",
           "dontShowAgain": "Don't show again",
-          "notNow": "Not now",
           "missingBoth": "Orca CLI and Linear agent skill are missing.",
           "missingCli": "Orca CLI is missing.",
           "missingSkill": "Linear agent skill is missing.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4584,6 +4584,7 @@
           "modalDescription": "Instala el skill de Linear desde una terminal.",
           "modalPrompt": "Permite que los Agents lean y editen el issue de Linear adjunto.",
           "dontShowAgain": "No volver a mostrar",
+          "notNow": "Ahora no",
           "missingBoth": "Faltan la CLI de Orca y el skill de Linear para Agents.",
           "missingCli": "Falta la CLI de Orca.",
           "missingSkill": "Falta el skill de Linear para Agents.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4584,7 +4584,6 @@
           "modalDescription": "Instala el skill de Linear desde una terminal.",
           "modalPrompt": "Permite que los Agents lean y editen el issue de Linear adjunto.",
           "dontShowAgain": "No volver a mostrar",
-          "notNow": "Ahora no",
           "missingBoth": "Faltan la CLI de Orca y el skill de Linear para Agents.",
           "missingCli": "Falta la CLI de Orca.",
           "missingSkill": "Falta el skill de Linear para Agents.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4584,7 +4584,6 @@
           "modalDescription": "terminal から Linear スキルをインストールします。",
           "modalPrompt": "Agents が添付された Linear チケットを読み書きできるようにします。",
           "dontShowAgain": "今後表示しない",
-          "notNow": "後で",
           "missingBoth": "Orca CLI と Linear agent スキルがありません。",
           "missingCli": "Orca CLI がありません。",
           "missingSkill": "Linear agent スキルがありません。",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4584,6 +4584,7 @@
           "modalDescription": "terminal から Linear スキルをインストールします。",
           "modalPrompt": "Agents が添付された Linear チケットを読み書きできるようにします。",
           "dontShowAgain": "今後表示しない",
+          "notNow": "後で",
           "missingBoth": "Orca CLI と Linear agent スキルがありません。",
           "missingCli": "Orca CLI がありません。",
           "missingSkill": "Linear agent スキルがありません。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4584,6 +4584,7 @@
           "modalDescription": "terminal에서 Linear 스킬을 설치합니다.",
           "modalPrompt": "agents가 첨부된 Linear 티켓을 읽고 편집할 수 있게 합니다.",
           "dontShowAgain": "다시 표시하지 않음",
+          "notNow": "나중에",
           "missingBoth": "Orca CLI와 Linear agent 스킬이 없습니다.",
           "missingCli": "Orca CLI가 없습니다.",
           "missingSkill": "Linear agent 스킬이 없습니다.",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4584,7 +4584,6 @@
           "modalDescription": "terminal에서 Linear 스킬을 설치합니다.",
           "modalPrompt": "agents가 첨부된 Linear 티켓을 읽고 편집할 수 있게 합니다.",
           "dontShowAgain": "다시 표시하지 않음",
-          "notNow": "나중에",
           "missingBoth": "Orca CLI와 Linear agent 스킬이 없습니다.",
           "missingCli": "Orca CLI가 없습니다.",
           "missingSkill": "Linear agent 스킬이 없습니다.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4584,7 +4584,6 @@
           "modalDescription": "从终端安装 Linear 技能。",
           "modalPrompt": "允许智能体读取和编辑已附加的 Linear ticket。",
           "dontShowAgain": "不再显示",
-          "notNow": "暂不",
           "missingBoth": "缺少 Orca CLI 和 Linear 智能体技能。",
           "missingCli": "缺少 Orca CLI。",
           "missingSkill": "缺少 Linear 智能体技能。",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4584,6 +4584,7 @@
           "modalDescription": "从终端安装 Linear 技能。",
           "modalPrompt": "允许智能体读取和编辑已附加的 Linear ticket。",
           "dontShowAgain": "不再显示",
+          "notNow": "暂不",
           "missingBoth": "缺少 Orca CLI 和 Linear 智能体技能。",
           "missingCli": "缺少 Orca CLI。",
           "missingSkill": "缺少 Linear 智能体技能。",


### PR DESCRIPTION
## What

Fixes the action hierarchy of the Linear agent-skill install modal. Neil + Brennan flagged that the dismiss button read as the primary CTA and got reflexively clicked.

![Linear skill-install modal — final](https://github.com/stablyai/orca/raw/28cf27f6b772940d9acfbaf654beb0474231524e/.pr-screenshots/pr9643-linear-modal-dialog-v5.png)

## Changes

- **Install CLI & Skill → filled primary** (`default`). Added an opt-in `installVariant` prop to `AgentSkillSetupPanel` (defaults to `outline`, so settings surfaces are untouched); the Linear modal passes `default`.
- **Removed the footer dismiss buttons.** The footer is gone entirely, so Install is the only labeled action.
- **Permanent opt-out → a quiet `EyeOff` icon next to the ×**, matching the house pattern for hiding a setup/teaching surface (`SetupGuideModal`, `StatusBarUsageEmptyCta`, `SetupGuideSidebarEntry`). The two "make it go away" controls now sit together — **×** = dismiss for the session, **⊘ EyeOff** = don't show again — and neither is a tempting text button.
- **Initial focus lands on Install** (the EyeOff renders last in the branch) so Enter-on-open can't permanently dismiss. Wrapped in a local `TooltipProvider` so it works in isolated mounts/tests.

## Testing

- `LinearAgentSkillSetupPrompt.test.tsx`: 27/27 pass (× → session snooze; EyeOff → permanent dismiss, located by aria-label).
- Electron QA: mounted the real dialog in the running app — verified Install=`default`, EyeOff present (aria "Don't show again"), no footer, and **initial focus = Install** (not the hide button). Screenshot above.
- `tsc` (web) + oxlint clean; all 5 locale JSONs validate.

_Note: the modal also auto-opens on the first activation of a Linear-linked worktree with the skill missing (not only via the reminder toast's "Set up"). For that path the × (session) and the EyeOff (permanent) cover dismissal._


