### PR TITLE
feat(mobile): group workspaces by project group, synced with desktop

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -73,7 +73,7 @@ import {
 } from '../../../src/host-route-action-state'
 import {
   applyDesktopViewSettings,
-  groupModeToDesktop,
+  toDesktopViewSettingsPayload,
   type MobileGroupMode,
   type MobileSortMode,
   type MobileViewState,
@@ -83,6 +83,7 @@ import {
   getWorktreeStatus,
   isWorktreePinned,
   type FilterState,
+  type ProjectGroupBucket,
   type Worktree
 } from '../../../src/worktree/workspace-list-sections'
 import { useWorkspaceSections } from '../../../src/worktree/use-workspace-sections'
@@ -93,8 +94,10 @@ import { HostWorkspaceListStates } from '../../../src/worktree/host-workspace-li
 import { repoColor } from '../../../src/worktree/repo-color'
 import {
   WORKSPACE_GROUP_OPTIONS as GROUP_OPTIONS,
-  WORKSPACE_SORT_OPTIONS as SORT_OPTIONS
+  WORKSPACE_SORT_OPTIONS as SORT_OPTIONS,
+  groupModeToolbarLabel
 } from '../../../src/worktree/workspace-list-picker-options'
+import { buildProjectGroupByRepoId } from '../../../src/worktree/project-group-membership'
 import type { RepoSummary } from '../../../src/worktree/host-worktree-rpc-types'
 import type { WorkspaceStatusDefinition } from '../../../../src/shared/types'
 import { DEFAULT_MOBILE_WORKSPACE_STATUSES } from '../../../src/worktree/mobile-workspace-statuses'
@@ -179,6 +182,11 @@ export function HostScreen({
   )
   // displayName → repo id: filters key on repo id, but section headers/rows key on displayName, so bridge the two.
   const [repoIdsByName, setRepoIdsByName] = useState<Map<string, string>>(new Map())
+  // repoId -> resolved top-level project group (null when ungrouped/unknown),
+  // powering the 'projectGroup' mode. Built from repo.list + projectGroup.list.
+  const [projectGroupByRepoId, setProjectGroupByRepoId] = useState<
+    Map<string, ProjectGroupBucket | null>
+  >(new Map())
   const [showSortPicker, setShowSortPicker] = useState(false)
   const [showGroupPicker, setShowGroupPicker] = useState(false)
   const [showFilterModal, setShowFilterModal] = useState(false)
@@ -244,18 +252,7 @@ export function HostScreen({
       if (!client) {
         return
       }
-      // alwaysShowDefaultBranchWorkspace is deliberately absent: mobile reads it
-      // but has no toggle, so echoing its local default would silently revert a
-      // desktop opt-out on the first filter tap before ui.get lands (#8873).
-      const payload: WorkspaceViewSettings = {
-        groupBy: groupModeToDesktop(next.groupMode),
-        sortBy: next.sortMode,
-        hideSleepingWorkspaces: next.hideSleeping,
-        hideDefaultBranchWorkspace: next.hideDefaultBranch,
-        filterRepoIds: next.filterRepoIds,
-        collapsedGroups: next.collapsedGroups
-      }
-      void client.sendRequest('ui.set', payload).catch(() => {
+void client.sendRequest('ui.set', toDesktopViewSettingsPayload(next, patch)).catch(() => {
         // Best-effort: view settings are a convenience preference.
       })
     },
@@ -331,6 +328,7 @@ export function HostScreen({
     setError('')
     setRepoColorsByName(new Map())
     setRepoIconsByName(new Map())
+    setProjectGroupByRepoId(new Map())
     repoMetadataFetchedAtRef.current = 0
     // Why: useState initializer runs only on first mount, so re-seed the cache when Expo Router reuses this screen for a new hostId.
     const freshCache = hostId ? (getCachedWorktrees(hostId) as Worktree[] | null) : null
@@ -386,13 +384,19 @@ export function HostScreen({
       try {
         do {
           fetchRepoMetadataPendingRef.current.delete(requestClient)
-          const repoResponse = await requestClient.sendRequest('repo.list')
+          const [repoResponse, groupResponse] = await Promise.all([
+            requestClient.sendRequest('repo.list'),
+            requestClient.sendRequest('projectGroup.list')
+          ])
           if (clientRef.current !== requestClient || hostId !== requestHostId || !repoResponse.ok) {
             return
           }
           const repoResult = (repoResponse as RpcSuccess).result as { repos: RepoSummary[] }
           repoMetadataFetchedAtRef.current = Date.now()
           setCachedRepos(requestHostId, repoResult.repos)
+          // Why: project groups are decorative for the list; degrade to "all
+          // ungrouped" if the call fails rather than blocking repo metadata.
+          setProjectGroupByRepoId(buildProjectGroupByRepoId(repoResult.repos, groupResponse))
           setRepoColorsByName(
             new Map(
               repoResult.repos.map((repo) => [
@@ -784,7 +788,8 @@ export function HostScreen({
     repoIdsByName,
     repoColorsByName,
     collapsedGroups,
-    workspaceStatuses
+    workspaceStatuses,
+    projectGroupByRepoId
   })
   const existingWorktreePaths = useMemo(() => worktrees.map((w) => w.path), [worktrees])
 
@@ -929,13 +934,7 @@ export function HostScreen({
               >
                 <Layers size={14} color={colors.textSecondary} />
                 <Text style={styles.sortLabel} numberOfLines={1}>
-                  {groupMode === 'none'
-                    ? 'Group'
-                    : groupMode === 'workspaceStatus'
-                      ? 'Status'
-                      : groupMode === 'repo'
-                        ? 'Repo'
-                        : 'PR'}
+                  {groupModeToolbarLabel(groupMode)}
                 </Text>
               </Pressable>
             </View>
@@ -1051,13 +1050,7 @@ export function HostScreen({
             <Pressable style={styles.modeButton} onPress={() => setShowGroupPicker(true)}>
               <Layers size={14} color={colors.textSecondary} />
               <Text style={styles.sortLabel} numberOfLines={1}>
-                {groupMode === 'none'
-                  ? 'Group'
-                  : groupMode === 'workspaceStatus'
-                    ? 'Status'
-                    : groupMode === 'repo'
-                      ? 'Repo'
-                      : 'PR'}
+                {groupModeToolbarLabel(groupMode)}
               </Text>
             </Pressable>
 

--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -93,9 +93,9 @@ import { WorktreeCatalogSnapshotClient } from '../../../src/worktree/worktree-ca
 import { HostWorkspaceListStates } from '../../../src/worktree/host-workspace-list-states'
 import { repoColor } from '../../../src/worktree/repo-color'
 import {
-  WORKSPACE_GROUP_OPTIONS as GROUP_OPTIONS,
   WORKSPACE_SORT_OPTIONS as SORT_OPTIONS,
-  groupModeToolbarLabel
+  groupModeToolbarLabel,
+  workspaceGroupOptionsForCapabilities
 } from '../../../src/worktree/workspace-list-picker-options'
 import {
   buildProjectGroupByRepoId,
@@ -736,6 +736,10 @@ void client.sendRequest('ui.set', toDesktopViewSettingsPayload(next, patch)).cat
   }, [filters])
   const selectedSortLabel =
     SORT_OPTIONS.find((option) => option.value === sortMode)?.label ?? 'Recent'
+  const groupOptions = useMemo(
+    () => workspaceGroupOptionsForCapabilities(hostCapabilities),
+    [hostCapabilities]
+  )
 
   const handleGroupChange = useCallback(
     (value: MobileGroupMode) => {
@@ -1228,7 +1232,7 @@ void client.sendRequest('ui.set', toDesktopViewSettingsPayload(next, patch)).cat
       <PickerModal
         visible={showGroupPicker}
         title="Group By"
-        options={GROUP_OPTIONS}
+        options={groupOptions}
         selected={groupMode}
         onSelect={handleGroupChange}
         onClose={() => setShowGroupPicker(false)}

--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -97,7 +97,10 @@ import {
   WORKSPACE_SORT_OPTIONS as SORT_OPTIONS,
   groupModeToolbarLabel
 } from '../../../src/worktree/workspace-list-picker-options'
-import { buildProjectGroupByRepoId } from '../../../src/worktree/project-group-membership'
+import {
+  buildProjectGroupByRepoId,
+  loadRepoProjectGroupResponses
+} from '../../../src/worktree/project-group-membership'
 import type { RepoSummary } from '../../../src/worktree/host-worktree-rpc-types'
 import type { WorkspaceStatusDefinition } from '../../../../src/shared/types'
 import { DEFAULT_MOBILE_WORKSPACE_STATUSES } from '../../../src/worktree/mobile-workspace-statuses'
@@ -384,10 +387,7 @@ void client.sendRequest('ui.set', toDesktopViewSettingsPayload(next, patch)).cat
       try {
         do {
           fetchRepoMetadataPendingRef.current.delete(requestClient)
-          const [repoResponse, groupResponse] = await Promise.all([
-            requestClient.sendRequest('repo.list'),
-            requestClient.sendRequest('projectGroup.list')
-          ])
+          const [repoResponse, groupResponse] = await loadRepoProjectGroupResponses(requestClient)
           if (clientRef.current !== requestClient || hostId !== requestHostId || !repoResponse.ok) {
             return
           }

--- a/mobile/src/worktree/host-worktree-rpc-types.ts
+++ b/mobile/src/worktree/host-worktree-rpc-types.ts
@@ -17,4 +17,6 @@ export type RepoSummary = {
   executionHostId?: ExecutionHostId | null
   badgeColor?: string
   repoIcon?: RepoIcon | null
+  // Membership used by the 'projectGroup' grouping mode; already on the repo.list wire.
+  projectGroupId?: string | null
 }

--- a/mobile/src/worktree/project-group-membership.test.ts
+++ b/mobile/src/worktree/project-group-membership.test.ts
@@ -80,7 +80,7 @@ describe('loadRepoProjectGroupResponses', () => {
     expect(warn).not.toHaveBeenCalled()
   })
 
-  it('preserves resolved project-group RPC failures', async () => {
+  it('reports and preserves resolved project-group RPC failures', async () => {
     const repoResponse = {
       id: 'repo-list',
       ok: true as const,
@@ -93,6 +93,7 @@ describe('loadRepoProjectGroupResponses', () => {
       error: { code: 'unsupported', message: 'old host' },
       _meta: { runtimeId: 'runtime' }
     }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const client: Pick<RpcClient, 'sendRequest'> = {
       sendRequest: vi.fn(async (method: string) =>
         method === 'repo.list' ? repoResponse : groupResponse
@@ -103,6 +104,10 @@ describe('loadRepoProjectGroupResponses', () => {
       repoResponse,
       groupResponse
     ])
+    expect(warn).toHaveBeenCalledWith(
+      '[mobile workspaces] projectGroup.list failed',
+      groupResponse.error
+    )
   })
 })
 
@@ -126,6 +131,15 @@ describe('buildProjectGroupByRepoId', () => {
 
     expect(map.get('ungrouped')).toBeNull()
     expect(map.get('stale')).toBeNull()
+  })
+
+  it('degrades to all-ungrouped on a malformed success payload instead of throwing', () => {
+    const map = buildProjectGroupByRepoId([repo('r', 'child')], {
+      ok: true,
+      result: { groups: 'not-an-array' }
+    })
+
+    expect(map.get('r')).toBeNull()
   })
 
   it('degrades to all-ungrouped when the projectGroup.list call failed', () => {

--- a/mobile/src/worktree/project-group-membership.test.ts
+++ b/mobile/src/worktree/project-group-membership.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   buildProjectGroupByRepoId,
   loadRepoProjectGroupResponses
@@ -28,6 +28,10 @@ function repo(id: string, projectGroupId?: string | null): RepoSummary {
   return { id, displayName: id, projectGroupId }
 }
 
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
 describe('loadRepoProjectGroupResponses', () => {
   it('keeps repo metadata when the project-group request rejects', async () => {
     const repoResponse = {
@@ -36,12 +40,14 @@ describe('loadRepoProjectGroupResponses', () => {
       result: { repos: [repo('r', 'child')] },
       _meta: { runtimeId: 'runtime' }
     }
+    const groupError = new Error('Request timed out: projectGroup.list')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const client: Pick<RpcClient, 'sendRequest'> = {
       sendRequest: vi.fn(async (method: string) => {
         if (method === 'repo.list') {
           return repoResponse
         }
-        throw new Error('Request timed out: projectGroup.list')
+        throw groupError
       })
     }
 
@@ -50,6 +56,53 @@ describe('loadRepoProjectGroupResponses', () => {
       { ok: false }
     ])
     expect(client.sendRequest).toHaveBeenCalledTimes(2)
+    expect(warn).toHaveBeenCalledWith('[mobile workspaces] projectGroup.list failed', groupError)
+  })
+
+  it('keeps repo-list transport failures fatal', async () => {
+    const repoError = new Error('Request timed out: repo.list')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const client: Pick<RpcClient, 'sendRequest'> = {
+      sendRequest: vi.fn(async (method: string) => {
+        if (method === 'repo.list') {
+          throw repoError
+        }
+        return {
+          id: 'project-group-list',
+          ok: true,
+          result: { groups: [] },
+          _meta: { runtimeId: 'runtime' }
+        }
+      })
+    }
+
+    await expect(loadRepoProjectGroupResponses(client)).rejects.toBe(repoError)
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('preserves resolved project-group RPC failures', async () => {
+    const repoResponse = {
+      id: 'repo-list',
+      ok: true as const,
+      result: { repos: [] },
+      _meta: { runtimeId: 'runtime' }
+    }
+    const groupResponse = {
+      id: 'project-group-list',
+      ok: false as const,
+      error: { code: 'unsupported', message: 'old host' },
+      _meta: { runtimeId: 'runtime' }
+    }
+    const client: Pick<RpcClient, 'sendRequest'> = {
+      sendRequest: vi.fn(async (method: string) =>
+        method === 'repo.list' ? repoResponse : groupResponse
+      )
+    }
+
+    await expect(loadRepoProjectGroupResponses(client)).resolves.toEqual([
+      repoResponse,
+      groupResponse
+    ])
   })
 })
 

--- a/mobile/src/worktree/project-group-membership.test.ts
+++ b/mobile/src/worktree/project-group-membership.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from 'vitest'
-import { buildProjectGroupByRepoId } from './project-group-membership'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  buildProjectGroupByRepoId,
+  loadRepoProjectGroupResponses
+} from './project-group-membership'
 import { folderWorkspaceRepoId } from '../../../src/shared/folder-workspace-worktree'
 import type { RepoSummary } from './host-worktree-rpc-types'
 import type { ProjectGroup } from '../../../src/shared/types'
+import type { RpcClient } from '../transport/rpc-client'
 
 function group(overrides: Partial<ProjectGroup> & { id: string }): ProjectGroup {
   return {
@@ -23,6 +27,31 @@ function group(overrides: Partial<ProjectGroup> & { id: string }): ProjectGroup 
 function repo(id: string, projectGroupId?: string | null): RepoSummary {
   return { id, displayName: id, projectGroupId }
 }
+
+describe('loadRepoProjectGroupResponses', () => {
+  it('keeps repo metadata when the project-group request rejects', async () => {
+    const repoResponse = {
+      id: 'repo-list',
+      ok: true as const,
+      result: { repos: [repo('r', 'child')] },
+      _meta: { runtimeId: 'runtime' }
+    }
+    const client: Pick<RpcClient, 'sendRequest'> = {
+      sendRequest: vi.fn(async (method: string) => {
+        if (method === 'repo.list') {
+          return repoResponse
+        }
+        throw new Error('Request timed out: projectGroup.list')
+      })
+    }
+
+    await expect(loadRepoProjectGroupResponses(client)).resolves.toEqual([
+      repoResponse,
+      { ok: false }
+    ])
+    expect(client.sendRequest).toHaveBeenCalledTimes(2)
+  })
+})
 
 describe('buildProjectGroupByRepoId', () => {
   it('maps a repo to its top-level project group, collapsing nested subgroups', () => {

--- a/mobile/src/worktree/project-group-membership.test.ts
+++ b/mobile/src/worktree/project-group-membership.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { buildProjectGroupByRepoId } from './project-group-membership'
+import { folderWorkspaceRepoId } from '../../../src/shared/folder-workspace-worktree'
+import type { RepoSummary } from './host-worktree-rpc-types'
+import type { ProjectGroup } from '../../../src/shared/types'
+
+function group(overrides: Partial<ProjectGroup> & { id: string }): ProjectGroup {
+  return {
+    name: overrides.id,
+    parentPath: null,
+    connectionId: null,
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides
+  }
+}
+
+function repo(id: string, projectGroupId?: string | null): RepoSummary {
+  return { id, displayName: id, projectGroupId }
+}
+
+describe('buildProjectGroupByRepoId', () => {
+  it('maps a repo to its top-level project group, collapsing nested subgroups', () => {
+    const groups = [
+      group({ id: 'root', name: 'Backend', tabOrder: 2 }),
+      group({ id: 'child', parentGroupId: 'root' })
+    ]
+
+    const map = buildProjectGroupByRepoId([repo('r', 'child')], { ok: true, result: { groups } })
+
+    expect(map.get('r')).toEqual({ groupId: 'root', groupName: 'Backend', tabOrder: 2 })
+  })
+
+  it('marks ungrouped repos and unknown memberships as null', () => {
+    const map = buildProjectGroupByRepoId([repo('ungrouped', null), repo('stale', 'gone')], {
+      ok: true,
+      result: { groups: [] }
+    })
+
+    expect(map.get('ungrouped')).toBeNull()
+    expect(map.get('stale')).toBeNull()
+  })
+
+  it('degrades to all-ungrouped when the projectGroup.list call failed', () => {
+    const map = buildProjectGroupByRepoId([repo('r', 'child')], { ok: false })
+
+    expect(map.get('r')).toBeNull()
+  })
+
+  it('maps folder-workspace synthetic repoIds to their top-level group', () => {
+    const groups = [
+      group({ id: 'root', name: 'Backend', tabOrder: 4 }),
+      group({ id: 'child', parentGroupId: 'root' })
+    ]
+
+    const map = buildProjectGroupByRepoId([], { ok: true, result: { groups } })
+
+    // A folder workspace directly in the root group and one in a nested subgroup
+    // both resolve to the root bucket (folder-workspace-worktree.ts repoId scheme).
+    expect(map.get(folderWorkspaceRepoId('root'))).toEqual({
+      groupId: 'root',
+      groupName: 'Backend',
+      tabOrder: 4
+    })
+    expect(map.get(folderWorkspaceRepoId('child'))).toEqual({
+      groupId: 'root',
+      groupName: 'Backend',
+      tabOrder: 4
+    })
+  })
+})

--- a/mobile/src/worktree/project-group-membership.ts
+++ b/mobile/src/worktree/project-group-membership.ts
@@ -14,7 +14,10 @@ export async function loadRepoProjectGroupResponses(
   // Why: group labels are decorative; transport failure must not discard successful repo metadata.
   return Promise.all([
     client.sendRequest('repo.list'),
-    client.sendRequest('projectGroup.list').catch(() => ({ ok: false as const }))
+    client.sendRequest('projectGroup.list').catch((error: unknown) => {
+      console.warn('[mobile workspaces] projectGroup.list failed', error)
+      return { ok: false as const }
+    })
   ])
 }
 

--- a/mobile/src/worktree/project-group-membership.ts
+++ b/mobile/src/worktree/project-group-membership.ts
@@ -6,27 +6,40 @@ import type { RpcResponse } from '../transport/types'
 import type { RepoSummary } from './host-worktree-rpc-types'
 import type { ProjectGroupBucket } from './workspace-list-sections'
 
-type ProjectGroupResponse = { ok: boolean; result?: unknown }
+type ProjectGroupResponse = { ok: boolean; result?: unknown; error?: unknown }
+
+async function loadProjectGroupResponse(
+  client: Pick<RpcClient, 'sendRequest'>
+): Promise<ProjectGroupResponse> {
+  try {
+    const response = await client.sendRequest('projectGroup.list')
+    if (!response.ok) {
+      console.warn('[mobile workspaces] projectGroup.list failed', response.error)
+    }
+    return response
+  } catch (error) {
+    console.warn('[mobile workspaces] projectGroup.list failed', error)
+    return { ok: false }
+  }
+}
 
 export async function loadRepoProjectGroupResponses(
   client: Pick<RpcClient, 'sendRequest'>
 ): Promise<[RpcResponse, ProjectGroupResponse]> {
   // Why: group labels are decorative; transport failure must not discard successful repo metadata.
-  return Promise.all([
-    client.sendRequest('repo.list'),
-    client.sendRequest('projectGroup.list').catch((error: unknown) => {
-      console.warn('[mobile workspaces] projectGroup.list failed', error)
-      return { ok: false as const }
-    })
-  ])
+  return Promise.all([client.sendRequest('repo.list'), loadProjectGroupResponse(client)])
 }
 
 // Extract the ProjectGroup list from a projectGroup.list RPC response, degrading
 // to empty when the call failed so the list falls back to "all ungrouped".
 function parseProjectGroupsResponse(response: ProjectGroupResponse): ProjectGroup[] {
-  return response.ok
-    ? ((response.result as { groups?: ProjectGroup[] } | undefined)?.groups ?? [])
-    : []
+  if (!response.ok) {
+    return []
+  }
+  // Why: a malformed success payload must degrade to ungrouped, not throw and
+  // discard the repo metadata resolved alongside it.
+  const groups = (response.result as { groups?: unknown } | undefined)?.groups
+  return Array.isArray(groups) ? (groups as ProjectGroup[]) : []
 }
 
 // Map each repo to its resolved top-level project group (or null when ungrouped

--- a/mobile/src/worktree/project-group-membership.ts
+++ b/mobile/src/worktree/project-group-membership.ts
@@ -1,12 +1,26 @@
 import { resolveTopLevelProjectGroupId } from '../../../src/shared/project-groups'
 import { folderWorkspaceRepoId } from '../../../src/shared/folder-workspace-worktree'
 import type { ProjectGroup } from '../../../src/shared/types'
+import type { RpcClient } from '../transport/rpc-client'
+import type { RpcResponse } from '../transport/types'
 import type { RepoSummary } from './host-worktree-rpc-types'
 import type { ProjectGroupBucket } from './workspace-list-sections'
 
+type ProjectGroupResponse = { ok: boolean; result?: unknown }
+
+export async function loadRepoProjectGroupResponses(
+  client: Pick<RpcClient, 'sendRequest'>
+): Promise<[RpcResponse, ProjectGroupResponse]> {
+  // Why: group labels are decorative; transport failure must not discard successful repo metadata.
+  return Promise.all([
+    client.sendRequest('repo.list'),
+    client.sendRequest('projectGroup.list').catch(() => ({ ok: false as const }))
+  ])
+}
+
 // Extract the ProjectGroup list from a projectGroup.list RPC response, degrading
 // to empty when the call failed so the list falls back to "all ungrouped".
-function parseProjectGroupsResponse(response: { ok: boolean; result?: unknown }): ProjectGroup[] {
+function parseProjectGroupsResponse(response: ProjectGroupResponse): ProjectGroup[] {
   return response.ok
     ? ((response.result as { groups?: ProjectGroup[] } | undefined)?.groups ?? [])
     : []
@@ -17,7 +31,7 @@ function parseProjectGroupsResponse(response: { ok: boolean; result?: unknown })
 // mode. Nested subgroups collapse to their root so a repo renders under one folder.
 export function buildProjectGroupByRepoId(
   repos: readonly RepoSummary[],
-  groupResponse: { ok: boolean; result?: unknown }
+  groupResponse: ProjectGroupResponse
 ): Map<string, ProjectGroupBucket | null> {
   const groups = parseProjectGroupsResponse(groupResponse)
   const groupsById = new Map(groups.map((group) => [group.id, group]))

--- a/mobile/src/worktree/project-group-membership.ts
+++ b/mobile/src/worktree/project-group-membership.ts
@@ -1,0 +1,51 @@
+import { resolveTopLevelProjectGroupId } from '../../../src/shared/project-groups'
+import { folderWorkspaceRepoId } from '../../../src/shared/folder-workspace-worktree'
+import type { ProjectGroup } from '../../../src/shared/types'
+import type { RepoSummary } from './host-worktree-rpc-types'
+import type { ProjectGroupBucket } from './workspace-list-sections'
+
+// Extract the ProjectGroup list from a projectGroup.list RPC response, degrading
+// to empty when the call failed so the list falls back to "all ungrouped".
+function parseProjectGroupsResponse(response: { ok: boolean; result?: unknown }): ProjectGroup[] {
+  return response.ok
+    ? ((response.result as { groups?: ProjectGroup[] } | undefined)?.groups ?? [])
+    : []
+}
+
+// Map each repo to its resolved top-level project group (or null when ungrouped
+// or the membership points at an unknown group), for the 'projectGroup' grouping
+// mode. Nested subgroups collapse to their root so a repo renders under one folder.
+export function buildProjectGroupByRepoId(
+  repos: readonly RepoSummary[],
+  groupResponse: { ok: boolean; result?: unknown }
+): Map<string, ProjectGroupBucket | null> {
+  const groups = parseProjectGroupsResponse(groupResponse)
+  const groupsById = new Map(groups.map((group) => [group.id, group]))
+  // Memoized so a repeated groupId (many repos in one group, or the group's own
+  // folder-workspace key) doesn't re-walk the parent chain each time.
+  const bucketCache = new Map<string, ProjectGroupBucket | null>()
+  const bucketFor = (groupId: string | null | undefined): ProjectGroupBucket | null => {
+    if (!groupId) {
+      return null
+    }
+    const cached = bucketCache.get(groupId)
+    if (cached !== undefined) {
+      return cached
+    }
+    const top = groupsById.get(resolveTopLevelProjectGroupId(groupsById, groupId))
+    const bucket = top ? { groupId: top.id, groupName: top.name, tabOrder: top.tabOrder } : null
+    bucketCache.set(groupId, bucket)
+    return bucket
+  }
+  const byRepoId = new Map<string, ProjectGroupBucket | null>()
+  for (const repo of repos) {
+    byRepoId.set(repo.id, bucketFor(repo.projectGroupId))
+  }
+  // Why: folder-workspace worktrees carry a synthetic repoId encoding their owning
+  // group (folderWorkspaceRepoId), so map each group's synthetic key too — else they
+  // always fall into "Ungrouped" despite belonging to a folder.
+  for (const group of groups) {
+    byRepoId.set(folderWorkspaceRepoId(group.id), bucketFor(group.id))
+  }
+  return byRepoId
+}

--- a/mobile/src/worktree/use-workspace-sections.ts
+++ b/mobile/src/worktree/use-workspace-sections.ts
@@ -4,6 +4,7 @@ import type { MobileGroupMode, MobileSortMode } from './workspace-view-settings'
 import {
   buildSections,
   type FilterState,
+  type ProjectGroupBucket,
   type Section,
   type Worktree
 } from './workspace-list-sections'
@@ -26,6 +27,7 @@ export function useWorkspaceSections(args: {
   repoColorsByName: Map<string, string>
   collapsedGroups: Set<string>
   workspaceStatuses: readonly WorkspaceStatusDefinition[]
+  projectGroupByRepoId: ReadonlyMap<string, ProjectGroupBucket | null>
 }): {
   sections: Section[]
   rawSections: Section[]
@@ -42,7 +44,8 @@ export function useWorkspaceSections(args: {
     repoIdsByName,
     repoColorsByName,
     collapsedGroups,
-    workspaceStatuses
+    workspaceStatuses,
+    projectGroupByRepoId
   } = args
 
   const uniqueRepos = useMemo(() => {
@@ -74,7 +77,8 @@ export function useWorkspaceSections(args: {
         pinnedIds,
         repoIdsByName,
         workspaceStatuses,
-        collapsedGroups
+        collapsedGroups,
+        projectGroupByRepoId
       ),
     [
       displayWorktrees,
@@ -85,7 +89,8 @@ export function useWorkspaceSections(args: {
       pinnedIds,
       repoIdsByName,
       workspaceStatuses,
-      collapsedGroups
+      collapsedGroups,
+      projectGroupByRepoId
     ]
   )
 

--- a/mobile/src/worktree/workspace-list-picker-options.test.ts
+++ b/mobile/src/worktree/workspace-list-picker-options.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { WORKSPACE_SORT_OPTIONS } from './workspace-list-picker-options'
+import { WORKSPACE_GROUP_OPTIONS, WORKSPACE_SORT_OPTIONS } from './workspace-list-picker-options'
 
 describe('WORKSPACE_SORT_OPTIONS', () => {
   it('keeps the persisted sort values stable for desktop compatibility', () => {
@@ -17,6 +17,25 @@ describe('WORKSPACE_SORT_OPTIONS', () => {
       value: 'smart',
       label: 'Agent activity',
       subtitle: 'Agents that need attention, then recent activity'
+    })
+  })
+})
+
+describe('WORKSPACE_GROUP_OPTIONS', () => {
+  it('keeps the persisted group values stable for desktop compatibility', () => {
+    expect(WORKSPACE_GROUP_OPTIONS.map((option) => option.value)).toEqual([
+      'none',
+      'workspaceStatus',
+      'repo',
+      'prStatus',
+      'projectGroup'
+    ])
+  })
+
+  it('labels the project-group mode', () => {
+    expect(WORKSPACE_GROUP_OPTIONS.find((option) => option.value === 'projectGroup')).toEqual({
+      value: 'projectGroup',
+      label: 'Project Group'
     })
   })
 })

--- a/mobile/src/worktree/workspace-list-picker-options.test.ts
+++ b/mobile/src/worktree/workspace-list-picker-options.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import { WORKSPACE_GROUP_OPTIONS, WORKSPACE_SORT_OPTIONS } from './workspace-list-picker-options'
+import {
+  MOBILE_PROJECT_GROUP_SYNC_RUNTIME_CAPABILITY,
+  RUNTIME_CAPABILITIES
+} from '../../../src/shared/protocol-version'
+import {
+  WORKSPACE_GROUP_OPTIONS,
+  WORKSPACE_SORT_OPTIONS,
+  workspaceGroupOptionsForCapabilities
+} from './workspace-list-picker-options'
 
 describe('WORKSPACE_SORT_OPTIONS', () => {
   it('keeps the persisted sort values stable for desktop compatibility', () => {
@@ -37,5 +45,20 @@ describe('WORKSPACE_GROUP_OPTIONS', () => {
       value: 'projectGroup',
       label: 'Project Group'
     })
+  })
+
+  it('does not offer project-group until the host can persist the new enum', () => {
+    expect(workspaceGroupOptionsForCapabilities([]).map((option) => option.value)).not.toContain(
+      'projectGroup'
+    )
+    expect(
+      workspaceGroupOptionsForCapabilities([MOBILE_PROJECT_GROUP_SYNC_RUNTIME_CAPABILITY]).map(
+        (option) => option.value
+      )
+    ).toContain('projectGroup')
+  })
+
+  it('advertises the project-group sync contract from current hosts', () => {
+    expect(RUNTIME_CAPABILITIES).toContain(MOBILE_PROJECT_GROUP_SYNC_RUNTIME_CAPABILITY)
   })
 })

--- a/mobile/src/worktree/workspace-list-picker-options.ts
+++ b/mobile/src/worktree/workspace-list-picker-options.ts
@@ -1,4 +1,5 @@
 import type { PickerOption } from '../components/PickerModal'
+import { MOBILE_PROJECT_GROUP_SYNC_RUNTIME_CAPABILITY } from '../../../src/shared/protocol-version'
 import type { MobileGroupMode, MobileSortMode } from './workspace-view-settings'
 
 export const WORKSPACE_SORT_OPTIONS: PickerOption<MobileSortMode>[] = [
@@ -21,6 +22,19 @@ export const WORKSPACE_GROUP_OPTIONS: PickerOption<MobileGroupMode>[] = [
   { value: 'prStatus', label: 'PR Status' },
   { value: 'projectGroup', label: 'Project Group' }
 ]
+
+const WORKSPACE_GROUP_OPTIONS_WITHOUT_PROJECT_GROUP = WORKSPACE_GROUP_OPTIONS.filter(
+  (option) => option.value !== 'projectGroup'
+)
+
+// Why: older hosts reject this enum; hiding it avoids a selection that later reverts on ui.get.
+export function workspaceGroupOptionsForCapabilities(
+  capabilities: readonly string[]
+): PickerOption<MobileGroupMode>[] {
+  return capabilities.includes(MOBILE_PROJECT_GROUP_SYNC_RUNTIME_CAPABILITY)
+    ? WORKSPACE_GROUP_OPTIONS
+    : WORKSPACE_GROUP_OPTIONS_WITHOUT_PROJECT_GROUP
+}
 
 // Compact label for the group-mode chip in the list toolbar (distinct from the
 // fuller picker labels above).

--- a/mobile/src/worktree/workspace-list-picker-options.ts
+++ b/mobile/src/worktree/workspace-list-picker-options.ts
@@ -18,5 +18,20 @@ export const WORKSPACE_GROUP_OPTIONS: PickerOption<MobileGroupMode>[] = [
   { value: 'none', label: 'No Grouping' },
   { value: 'workspaceStatus', label: 'Status' },
   { value: 'repo', label: 'Repository' },
-  { value: 'prStatus', label: 'PR Status' }
+  { value: 'prStatus', label: 'PR Status' },
+  { value: 'projectGroup', label: 'Project Group' }
 ]
+
+// Compact label for the group-mode chip in the list toolbar (distinct from the
+// fuller picker labels above).
+const GROUP_TOOLBAR_LABELS: Record<MobileGroupMode, string> = {
+  none: 'Group',
+  workspaceStatus: 'Status',
+  repo: 'Repo',
+  prStatus: 'PR',
+  projectGroup: 'Groups'
+}
+
+export function groupModeToolbarLabel(mode: MobileGroupMode): string {
+  return GROUP_TOOLBAR_LABELS[mode]
+}

--- a/mobile/src/worktree/workspace-list-sections.test.ts
+++ b/mobile/src/worktree/workspace-list-sections.test.ts
@@ -9,6 +9,14 @@ import {
   sortWorktrees
 } from './workspace-list-sections'
 import { DEFAULT_MOBILE_WORKSPACE_STATUSES } from './mobile-workspace-statuses'
+import { UNGROUPED_PROJECT_GROUP_KEY } from '../../../src/shared/project-groups'
+import { folderWorkspaceRepoId } from '../../../src/shared/folder-workspace-worktree'
+
+const NO_FILTERS = {
+  filterRepoIds: new Set<string>(),
+  hideSleeping: false,
+  hideDefaultBranch: false
+}
 
 function worktree(overrides: Partial<Worktree> = {}): Worktree {
   const worktreePath = join('/tmp', 'orca', 'worktrees', 'feature')
@@ -316,6 +324,109 @@ describe('buildSections', () => {
       'desktop-first',
       'mobile-fallback-first'
     ])
+  })
+
+  it('groups by top-level project group ordered by tabOrder, ungrouped last', () => {
+    const platform = worktree({
+      worktreeId: 'w-platform',
+      repoId: 'repo-platform',
+      repo: 'platform'
+    })
+    const web = worktree({ worktreeId: 'w-web', repoId: 'repo-web', repo: 'web' })
+    const loose = worktree({ worktreeId: 'w-loose', repoId: 'repo-loose', repo: 'loose' })
+    const projectGroupByRepoId = new Map([
+      ['repo-platform', { groupId: 'g-backend', groupName: 'Backend', tabOrder: 1 }],
+      ['repo-web', { groupId: 'g-frontend', groupName: 'Frontend', tabOrder: 0 }],
+      ['repo-loose', null]
+    ])
+
+    const sections = buildSections(
+      [platform, web, loose],
+      'name',
+      NO_FILTERS,
+      '',
+      'projectGroup',
+      new Set(),
+      new Map(),
+      DEFAULT_MOBILE_WORKSPACE_STATUSES,
+      new Set(),
+      projectGroupByRepoId
+    )
+
+    expect(sections.map((section) => [section.key, section.title])).toEqual([
+      ['project-group:g-frontend', 'Frontend'],
+      ['project-group:g-backend', 'Backend'],
+      [UNGROUPED_PROJECT_GROUP_KEY, 'Ungrouped']
+    ])
+    // Every worktree stays visible exactly once.
+    expect(sections.flatMap((section) => section.data.map((item) => item.worktreeId))).toEqual([
+      'w-web',
+      'w-platform',
+      'w-loose'
+    ])
+  })
+
+  it('merges repos sharing a top-level project group into one section', () => {
+    const api = worktree({ worktreeId: 'w-api', repoId: 'repo-api', repo: 'api' })
+    const workerA = worktree({ worktreeId: 'w-worker', repoId: 'repo-worker', repo: 'worker' })
+    const bucket = { groupId: 'g-backend', groupName: 'Backend', tabOrder: 0 }
+    // repo-orphan has no map entry at all -> treated as Ungrouped via `?? null`.
+    const orphan = worktree({ worktreeId: 'w-orphan', repoId: 'repo-orphan', repo: 'orphan' })
+
+    const sections = buildSections(
+      [api, workerA, orphan],
+      'name',
+      NO_FILTERS,
+      '',
+      'projectGroup',
+      new Set(),
+      new Map(),
+      DEFAULT_MOBILE_WORKSPACE_STATUSES,
+      new Set(),
+      new Map([
+        ['repo-api', bucket],
+        ['repo-worker', bucket]
+      ])
+    )
+
+    expect(sections.map((section) => section.key)).toEqual([
+      'project-group:g-backend',
+      UNGROUPED_PROJECT_GROUP_KEY
+    ])
+    expect(sections[0]?.data.map((item) => item.worktreeId).sort()).toEqual(['w-api', 'w-worker'])
+    expect(sections[1]?.data.map((item) => item.worktreeId)).toEqual(['w-orphan'])
+  })
+
+  it('groups folder-workspace worktrees under their owning project group', () => {
+    const folder = worktree({
+      worktreeId: 'w-folder',
+      workspaceKind: 'folder-workspace',
+      repoId: folderWorkspaceRepoId('g-backend'),
+      repo: 'context',
+      branch: ''
+    })
+    const projectGroupByRepoId = new Map([
+      [
+        folderWorkspaceRepoId('g-backend'),
+        { groupId: 'g-backend', groupName: 'Backend', tabOrder: 0 }
+      ]
+    ])
+
+    const sections = buildSections(
+      [folder],
+      'name',
+      NO_FILTERS,
+      '',
+      'projectGroup',
+      new Set(),
+      new Map(),
+      DEFAULT_MOBILE_WORKSPACE_STATUSES,
+      new Set(),
+      projectGroupByRepoId
+    )
+
+    expect(sections.map((section) => section.key)).toEqual(['project-group:g-backend'])
+    expect(sections[0]?.data.map((item) => item.worktreeId)).toEqual(['w-folder'])
   })
 
   it('uses desktop display-name tie-breaks for equal persisted smart ranks', () => {

--- a/mobile/src/worktree/workspace-list-sections.test.ts
+++ b/mobile/src/worktree/workspace-list-sections.test.ts
@@ -429,6 +429,38 @@ describe('buildSections', () => {
     expect(sections[0]?.data.map((item) => item.worktreeId)).toEqual(['w-folder'])
   })
 
+  it('keeps empty project group headers when filters remove their worktrees', () => {
+    const sleeping = worktree({
+      worktreeId: 'w-sleeping',
+      repoId: 'repo-platform',
+      repo: 'platform',
+      hasHostSidebarActivity: false
+    })
+    const platform = { groupId: 'g-platform', groupName: 'Platform', tabOrder: 0 }
+    const empty = { groupId: 'g-empty', groupName: 'Empty', tabOrder: 1 }
+
+    const sections = buildSections(
+      [sleeping],
+      'manual',
+      { ...NO_FILTERS, hideSleeping: true },
+      '',
+      'projectGroup',
+      new Set(),
+      new Map(),
+      DEFAULT_MOBILE_WORKSPACE_STATUSES,
+      new Set(),
+      new Map([
+        ['repo-platform', platform],
+        [folderWorkspaceRepoId('g-empty'), empty]
+      ])
+    )
+
+    expect(withoutSectionListKeys(sections)).toEqual([
+      { key: 'project-group:g-platform', title: 'Platform', data: [] },
+      { key: 'project-group:g-empty', title: 'Empty', data: [] }
+    ])
+  })
+
   it('uses desktop display-name tie-breaks for equal persisted smart ranks', () => {
     const zed = worktree({ worktreeId: 'zed', displayName: 'Zed', sortOrder: 20, unread: true })
     const alpha = worktree({

--- a/mobile/src/worktree/workspace-list-sections.ts
+++ b/mobile/src/worktree/workspace-list-sections.ts
@@ -241,6 +241,15 @@ export function buildSections(
     // Why: mirror desktop's sidebar folders — one section per top-level project
     // group (nested subgroups collapse into their root), ungrouped repos last.
     const byGroup = new Map<string, { name: string; tabOrder: number; items: Worktree[] }>()
+    for (const bucket of projectGroupByRepoId.values()) {
+      if (bucket && !byGroup.has(`project-group:${bucket.groupId}`)) {
+        byGroup.set(`project-group:${bucket.groupId}`, {
+          name: bucket.groupName,
+          tabOrder: bucket.tabOrder,
+          items: []
+        })
+      }
+    }
     for (const w of canonicalGroupWorktrees) {
       const bucket = projectGroupByRepoId.get(w.repoId) ?? null
       const key = bucket ? `project-group:${bucket.groupId}` : UNGROUPED_PROJECT_GROUP_KEY

--- a/mobile/src/worktree/workspace-list-sections.ts
+++ b/mobile/src/worktree/workspace-list-sections.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceStatusDefinition } from '../../../src/shared/types'
+import { UNGROUPED_PROJECT_GROUP_KEY } from '../../../src/shared/project-groups'
 import {
   DEFAULT_MOBILE_WORKSPACE_STATUSES,
   coerceMobileWorkspaceStatuses,
@@ -13,6 +14,10 @@ import { sortWorktrees } from './workspace-list-ordering'
 
 export type { FilterState, Section, Worktree } from './workspace-list-types'
 export { CREATE_GRACE_MS, getWorktreeStatus, sortWorktrees } from './workspace-list-ordering'
+
+// Resolved top-level project group a repo belongs to, for groupMode 'projectGroup'.
+// Built in the screen from repo.list (projectGroupId) + projectGroup.list (name/tabOrder).
+export type ProjectGroupBucket = { groupId: string; groupName: string; tabOrder: number }
 
 function makeSection(
   key: string,
@@ -128,7 +133,8 @@ export function buildSections(
   pinnedIds: Set<string>,
   repoIdsByName: ReadonlyMap<string, string> = new Map(),
   workspaceStatuses: readonly WorkspaceStatusDefinition[] = DEFAULT_MOBILE_WORKSPACE_STATUSES,
-  collapsedGroups: ReadonlySet<string> = new Set()
+  collapsedGroups: ReadonlySet<string> = new Set(),
+  projectGroupByRepoId: ReadonlyMap<string, ProjectGroupBucket | null> = new Map()
 ): Section[] {
   const filtered = filterWorktrees(worktrees, filters, search)
   const sorted = sortWorktrees(filtered, sortMode)
@@ -230,6 +236,39 @@ export function buildSections(
           )
         )
       }
+    }
+  } else if (groupMode === 'projectGroup') {
+    // Why: mirror desktop's sidebar folders — one section per top-level project
+    // group (nested subgroups collapse into their root), ungrouped repos last.
+    const byGroup = new Map<string, { name: string; tabOrder: number; items: Worktree[] }>()
+    for (const w of canonicalGroupWorktrees) {
+      const bucket = projectGroupByRepoId.get(w.repoId) ?? null
+      const key = bucket ? `project-group:${bucket.groupId}` : UNGROUPED_PROJECT_GROUP_KEY
+      const existing = byGroup.get(key)
+      if (existing) {
+        existing.items.push(w)
+      } else {
+        byGroup.set(key, {
+          name: bucket ? bucket.groupName : 'Ungrouped',
+          // Ungrouped sorts last; groups keep their desktop tabOrder.
+          tabOrder: bucket ? bucket.tabOrder : Number.POSITIVE_INFINITY,
+          items: [w]
+        })
+      }
+    }
+    const ordered = [...byGroup.entries()].sort(
+      ([, a], [, b]) => a.tabOrder - b.tabOrder || a.name.localeCompare(b.name)
+    )
+    for (const [key, group] of ordered) {
+      sections.push(
+        makeSection(
+          key,
+          group.name,
+          orderMainWorktreeFirst(group.items),
+          undefined,
+          collapsedGroups
+        )
+      )
     }
   }
 

--- a/mobile/src/worktree/workspace-view-settings.test.ts
+++ b/mobile/src/worktree/workspace-view-settings.test.ts
@@ -5,6 +5,7 @@ import {
   groupModeFromDesktop,
   groupModeToDesktop,
   sortModeFromDesktop,
+  toDesktopViewSettingsPayload,
   type MobileViewState,
   type WorkspaceViewSettings
 } from './workspace-view-settings'
@@ -21,7 +22,7 @@ const base: MobileViewState = {
 
 describe('group mode mapping', () => {
   it('round-trips every mobile group mode through the desktop value', () => {
-    for (const mode of ['none', 'workspaceStatus', 'repo', 'prStatus'] as const) {
+    for (const mode of ['none', 'workspaceStatus', 'repo', 'prStatus', 'projectGroup'] as const) {
       expect(groupModeFromDesktop(groupModeToDesktop(mode))).toBe(mode)
     }
   })
@@ -29,6 +30,7 @@ describe('group mode mapping', () => {
   it('maps the desktop kebab-case values back to mobile', () => {
     expect(groupModeFromDesktop('workspace-status')).toBe('workspaceStatus')
     expect(groupModeFromDesktop('pr-status')).toBe('prStatus')
+    expect(groupModeFromDesktop('project-group')).toBe('projectGroup')
     expect(groupModeFromDesktop(undefined)).toBeNull()
   })
 })
@@ -81,5 +83,32 @@ describe('applyDesktopViewSettings', () => {
   it('ignores an unrecognized groupBy rather than blanking the mode', () => {
     const next = applyDesktopViewSettings(base, { groupBy: 'mystery' as never })
     expect(next.groupMode).toBe('repo')
+  })
+
+  it('applies a desktop project-group grouping onto the mobile mode', () => {
+    const next = applyDesktopViewSettings(base, { groupBy: 'project-group' })
+    expect(next.groupMode).toBe('projectGroup')
+  })
+})
+
+describe('toDesktopViewSettingsPayload', () => {
+  it('includes groupBy when the grouping mode changed', () => {
+    const next: MobileViewState = { ...base, groupMode: 'projectGroup' }
+
+    const payload = toDesktopViewSettingsPayload(next, { groupMode: 'projectGroup' })
+
+    expect(payload.groupBy).toBe('project-group')
+    expect(payload.sortBy).toBe('recent')
+  })
+
+  it('omits groupBy when the change did not touch the grouping mode', () => {
+    const next: MobileViewState = { ...base, groupMode: 'projectGroup', sortMode: 'name' }
+
+    const payload = toDesktopViewSettingsPayload(next, { sortMode: 'name' })
+
+    // Why: keeps a held 'project-group' out of unrelated ui.set calls so an old
+    // desktop rejecting it doesn't also drop these other settings.
+    expect('groupBy' in payload).toBe(false)
+    expect(payload.sortBy).toBe('name')
   })
 })

--- a/mobile/src/worktree/workspace-view-settings.ts
+++ b/mobile/src/worktree/workspace-view-settings.ts
@@ -27,10 +27,7 @@ const GROUP_TO_DESKTOP: Record<MobileGroupMode, NonNullable<WorkspaceViewSetting
   workspaceStatus: 'workspace-status',
   repo: 'repo',
   prStatus: 'pr-status',
-  // Mixed-version caveat: a desktop predating 'project-group' rejects this value on
-  // ui.set (strict enum), so the mode won't persist there. toDesktopViewSettingsPayload
-  // only sends groupBy when the mode itself changes, so only that one call fails —
-  // unrelated settings still sync. Self-heals on desktop update.
+  // Why: the picker capability-gates this strict enum so older hosts cannot reject a user selection.
   projectGroup: 'project-group'
 }
 
@@ -101,9 +98,8 @@ export function applyDesktopViewSettings(
 }
 
 // Build the ui.set payload for a mobile view-settings change. groupBy is included
-// ONLY when the grouping mode actually changed (patch carries groupMode), so a
-// desktop that rejects a newer value (strict enum, e.g. 'project-group') fails only
-// the grouping change itself instead of dropping every other bundled setting too.
+// only when the grouping mode changed, so a stale retained value cannot make an
+// older desktop drop unrelated setting updates.
 export function toDesktopViewSettingsPayload(
   next: MobileViewState,
   patch: Partial<MobileViewState>

--- a/mobile/src/worktree/workspace-view-settings.ts
+++ b/mobile/src/worktree/workspace-view-settings.ts
@@ -6,13 +6,13 @@
 import type { WorkspaceStatusDefinition } from '../../../src/shared/types'
 import { coerceMobileWorkspaceStatuses } from './mobile-workspace-statuses'
 
-export type MobileGroupMode = 'none' | 'workspaceStatus' | 'repo' | 'prStatus'
+export type MobileGroupMode = 'none' | 'workspaceStatus' | 'repo' | 'prStatus' | 'projectGroup'
 // Desktop sort adds 'manual'; mobile renders it but sorts by server order.
 export type MobileSortMode = 'smart' | 'name' | 'recent' | 'repo' | 'manual'
 
 // Desktop PersistedUIState fields this screen syncs (a structural subset).
 export type WorkspaceViewSettings = {
-  groupBy?: 'none' | 'workspace-status' | 'repo' | 'pr-status'
+  groupBy?: 'none' | 'workspace-status' | 'repo' | 'pr-status' | 'project-group'
   sortBy?: 'name' | 'smart' | 'recent' | 'repo' | 'manual'
   hideSleepingWorkspaces?: boolean
   hideDefaultBranchWorkspace?: boolean
@@ -26,14 +26,20 @@ const GROUP_TO_DESKTOP: Record<MobileGroupMode, NonNullable<WorkspaceViewSetting
   none: 'none',
   workspaceStatus: 'workspace-status',
   repo: 'repo',
-  prStatus: 'pr-status'
+  prStatus: 'pr-status',
+  // Mixed-version caveat: a desktop predating 'project-group' rejects this value on
+  // ui.set (strict enum), so the mode won't persist there. toDesktopViewSettingsPayload
+  // only sends groupBy when the mode itself changes, so only that one call fails —
+  // unrelated settings still sync. Self-heals on desktop update.
+  projectGroup: 'project-group'
 }
 
 const GROUP_FROM_DESKTOP: Record<NonNullable<WorkspaceViewSettings['groupBy']>, MobileGroupMode> = {
   none: 'none',
   'workspace-status': 'workspaceStatus',
   repo: 'repo',
-  'pr-status': 'prStatus'
+  'pr-status': 'prStatus',
+  'project-group': 'projectGroup'
 }
 
 const SORT_VALUES: readonly MobileSortMode[] = ['smart', 'name', 'recent', 'repo', 'manual']
@@ -92,4 +98,22 @@ export function applyDesktopViewSettings(
     workspaceStatuses
   }
   return next
+}
+
+// Build the ui.set payload for a mobile view-settings change. groupBy is included
+// ONLY when the grouping mode actually changed (patch carries groupMode), so a
+// desktop that rejects a newer value (strict enum, e.g. 'project-group') fails only
+// the grouping change itself instead of dropping every other bundled setting too.
+export function toDesktopViewSettingsPayload(
+  next: MobileViewState,
+  patch: Partial<MobileViewState>
+): WorkspaceViewSettings {
+  return {
+    ...('groupMode' in patch ? { groupBy: groupModeToDesktop(next.groupMode) } : {}),
+    sortBy: next.sortMode,
+    hideSleepingWorkspaces: next.hideSleeping,
+    hideDefaultBranchWorkspace: next.hideDefaultBranch,
+    filterRepoIds: next.filterRepoIds,
+    collapsedGroups: next.collapsedGroups
+  }
 }

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -1320,6 +1320,15 @@ describe('Store', () => {
     expect(store.getUI().groupBy).toBe('workspace-status')
   })
 
+  it('preserves project-group grouping so a phone selection survives sync', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      ui: { groupBy: 'project-group' }
+    })
+    const store = await createStore()
+    expect(store.getUI().groupBy).toBe('project-group')
+  })
+
   it('defaults projectOrderBy to manual when absent, even with recent sortBy', async () => {
     writeDataFile({
       schemaVersion: 1,

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -766,7 +766,8 @@ function normalizeGroupBy(groupBy: unknown): PersistedState['ui']['groupBy'] {
     groupBy === 'none' ||
     groupBy === 'workspace-status' ||
     groupBy === 'repo' ||
-    groupBy === 'pr-status'
+    groupBy === 'pr-status' ||
+    groupBy === 'project-group'
   ) {
     return groupBy
   }

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -201,7 +201,7 @@ const UiUpdateFields = z
     rightSidebarWidth: z.number().finite().optional(),
     markdownTocPanelWidth: z.number().finite().optional(),
     combinedDiffFileTreeWidth: z.number().finite().optional(),
-    groupBy: z.enum(['none', 'workspace-status', 'repo', 'pr-status']).optional(),
+    groupBy: z.enum(['none', 'workspace-status', 'repo', 'pr-status', 'project-group']).optional(),
     showWorkspaceLineage: z.boolean().optional(),
     sortBy: z.enum(['name', 'smart', 'recent', 'repo', 'manual']).optional(),
     projectOrderBy: z.enum(['manual', 'recent']).optional(),

--- a/src/main/runtime/rpc/methods/client-ui.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui.test.ts
@@ -657,6 +657,20 @@ describe('client UI RPC methods', () => {
     expect(runtime.updateUIState).not.toHaveBeenCalled()
   })
 
+  it('accepts the project-group grouping value so mobile can sync it', async () => {
+    const updated: PersistedUIState = { ...getDefaultUIState(), groupBy: 'project-group' }
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      updateUIState: vi.fn(() => updated)
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: CLIENT_UI_METHODS })
+
+    const response = await dispatcher.dispatch(makeRequest('ui.set', { groupBy: 'project-group' }))
+
+    expect(runtime.updateUIState).toHaveBeenCalledWith({ groupBy: 'project-group' })
+    expect(response).toMatchObject({ ok: true, result: { ui: updated } })
+  })
+
   // Why the contract flipped: an unknown VALUE used to fail the whole batch, so
   // one drifted enum member took sidebar widths, filters and agent acks down
   // with it. Unknown KEYS still reject — the parity assertions catch those.
@@ -664,7 +678,8 @@ describe('client UI RPC methods', () => {
     ['worktree card property', { worktreeCardProperties: ['status', 'pr-status'] }],
     ['feature interaction id', { featureInteractions: { unknown: { firstInteractedAt: 100 } } }],
     ['feature tip id', { featureTipsSeenIds: ['voice-dictation', 'unknown-tip'] }],
-    ['right sidebar tab', { rightSidebarTab: 'not-a-tab' }]
+    ['right sidebar tab', { rightSidebarTab: 'not-a-tab' }],
+    ['grouping value', { groupBy: 'folders' }]
   ])('drops an unknown %s instead of rejecting the batch around it', async (_label, drifted) => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -4,6 +4,7 @@ import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import SidebarWorkspaceOptionsMenu from './SidebarWorkspaceOptionsMenu'
+import { effectiveGroupByForRender } from './worktree-list-groups'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import { openWorkspaceCreationComposerWithTourHandoff } from '../contextual-tours/workspace-creation-tour-handoff'
 import { translate } from '@/i18n/i18n'
@@ -17,7 +18,8 @@ const SidebarHeader = React.memo(function SidebarHeader({
 }: SidebarHeaderProps) {
   const openModal = useAppStore((s) => s.openModal)
   const newWorktreeShortcutLabel = useShortcutLabel('workspace.create')
-  const groupBy = useAppStore((s) => s.groupBy)
+  // Why: 'project-group' is the Project view on desktop (see effectiveGroupByForRender).
+  const groupBy = useAppStore((s) => effectiveGroupByForRender(s.groupBy))
   const canCreateWorkspace = useAppStore((s) => s.repos.length > 0)
   const sidebarTitle = groupBy === 'repo' ? 'Projects' : 'Workspaces'
 

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
@@ -26,6 +26,7 @@ import { PROJECT_ORDER_OPTIONS, SORT_OPTIONS } from './sidebar-workspace-option-
 import { WorktreeCardDisplayMenuSection } from './WorktreeCardDisplayMenuSection'
 import { translate } from '@/i18n/i18n'
 import { SidebarGroupByToggle } from './SidebarGroupByToggle'
+import { effectiveGroupByForRender } from './worktree-list-groups'
 
 type SidebarWorkspaceOptionsMenuProps = {
   preserveWorkspaceBoardOpen?: boolean
@@ -50,7 +51,9 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
   const setVisibleWorkspaceHostIds = useAppStore((s) => s.setVisibleWorkspaceHostIds)
   const sortBy = useAppStore((s) => s.sortBy)
   const setSortBy = useAppStore((s) => s.setSortBy)
-  const groupBy = useAppStore((s) => s.groupBy)
+  // Why: 'project-group' shows as the Project (repo) grouping on desktop, so the
+  // toggle highlights Project and the project-order controls stay available.
+  const groupBy = useAppStore((s) => effectiveGroupByForRender(s.groupBy))
   const setGroupBy = useAppStore((s) => s.setGroupBy)
   const projectOrderBy = useAppStore((s) => s.projectOrderBy)
   const setProjectOrderBy = useAppStore((s) => s.setProjectOrderBy)

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -88,6 +88,7 @@ import {
   ALL_GROUP_KEY,
   PINNED_GROUP_KEY,
   buildRows,
+  effectiveGroupByForRender,
   getProjectGroupHeaderKey,
   getGroupKeysForWorktree,
   getLineageGroupKey,
@@ -5211,7 +5212,9 @@ const WorktreeList = React.memo(function WorktreeList({
     () => getActiveSidebarWorkspaceId(activeWorkspaceKey, activeWorktreeId),
     [activeWorkspaceKey, activeWorktreeId]
   )
-  const groupBy = useAppStore((s) => s.groupBy)
+  // Why: 'project-group' has no distinct desktop layout; render it as 'repo'
+  // (Project) grouping. The raw value is still persisted by App.tsx's writer.
+  const groupBy = useAppStore((s) => effectiveGroupByForRender(s.groupBy))
   const setGroupBy = useAppStore((s) => s.setGroupBy)
   const workspaceHostScope = useAppStore((s) => s.workspaceHostScope)
   const visibleWorkspaceHostIds = useAppStore((s) => s.visibleWorkspaceHostIds)

--- a/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.test.ts
+++ b/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.test.ts
@@ -170,6 +170,16 @@ describe('closed-sidebar Cmd+1-9 ordering (#9497)', () => {
     expect(getVisibleWorktreeIds()).toEqual([])
   })
 
+  it("renders 'project-group' as the Project view, never the PR grouping branch", () => {
+    // Why: buildRows' fall-through branch groups by PR status; a raw 'project-group'
+    // value landed there and reordered by prCache instead of by repo.
+    const main = makeMainWorktree('wt-main', { sortOrder: 0 })
+    const feature = makeWorktree('wt-feature', { sortOrder: 1 })
+    seedStore([feature, main], { groupBy: 'project-group' })
+
+    expect(getVisibleWorktreeIds()).toEqual(['wt-main', 'wt-feature'])
+  })
+
   it('numbers folder workspaces, which the flat fallback omitted entirely', () => {
     const group = makeProjectGroup('group-1')
     const folderWorkspace = makeFolderWorkspace('fw-1', group.id)

--- a/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.ts
+++ b/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.ts
@@ -7,7 +7,11 @@ import {
 } from '../../../../shared/execution-host'
 import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
 import { getProjectHostSetupProjectionFromState } from '@/store/project-host-setup-selector'
-import { buildRows, getPinnedWorktreeDisplayPolicy } from './worktree-list-groups'
+import {
+  buildRows,
+  effectiveGroupByForRender,
+  getPinnedWorktreeDisplayPolicy
+} from './worktree-list-groups'
 import { addHostSectionRows } from './host-section-rows'
 import { orderHostSectionOptions } from './host-section-order'
 import { buildSidebarHostOptions } from './sidebar-host-options'
@@ -52,8 +56,10 @@ export function computeRenderedSidebarWorktreeOrder(
     state.worktreeCardProperties
   )
 
+  // Why: 'project-group' renders as the Project view on desktop; without this
+  // the unmounted-sidebar order falls into buildRows' PR-grouping branch.
   const rows = buildRows(
-    state.groupBy,
+    effectiveGroupByForRender(state.groupBy),
     [...visibleWorktrees],
     getRepoMapFromState(state),
     prCache,

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -7,6 +7,7 @@ import { projectHostSetupProjectionFromRepos } from '../../../../shared/project-
 import {
   ALL_GROUP_META,
   buildRows,
+  effectiveGroupByForRender,
   getGroupKeyForWorktree,
   getGroupKeysForWorktree,
   getLineageGroupKey,
@@ -132,6 +133,20 @@ function makeDetectedWorktree(overrides: Partial<DetectedWorktree> = {}): Detect
     ...overrides
   }
 }
+
+describe('effectiveGroupByForRender', () => {
+  it('renders project-group as the repo (Project) view', () => {
+    // Why: desktop has no distinct project-group layout; rendering it as 'repo'
+    // avoids buildRows' bare-else fall-through to pr-status grouping.
+    expect(effectiveGroupByForRender('project-group')).toBe('repo')
+  })
+
+  it('passes the other grouping values through unchanged', () => {
+    for (const value of ['none', 'workspace-status', 'repo', 'pr-status'] as const) {
+      expect(effectiveGroupByForRender(value)).toBe(value)
+    }
+  })
+})
 
 describe('getPRGroupKey', () => {
   it('puts merged PRs in the done group', () => {

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -56,13 +56,23 @@ export { getLineageRenderInfo } from './worktree-lineage-projection'
 
 export { branchName }
 
-export type WorktreeGroupBy = 'none' | 'workspace-status' | 'repo' | 'pr-status'
+export type WorktreeGroupBy = 'none' | 'workspace-status' | 'repo' | 'pr-status' | 'project-group'
 export type PinnedWorktreeDisplayPolicy = 'single-location' | 'duplicate-in-groups'
 
 export function getPinnedWorktreeDisplayPolicy(
   settings?: { showPinnedWorktreesInGroups?: boolean } | null
 ): PinnedWorktreeDisplayPolicy {
   return settings?.showPinnedWorktreesInGroups === true ? 'duplicate-in-groups' : 'single-location'
+}
+
+// Why: desktop has no distinct 'project-group' layout — its 'repo' (Project) view
+// already nests project groups. Render 'project-group' as 'repo' while keeping the
+// persisted value intact so a phone's choice survives the ui.get/ui.set round-trip.
+// Persistence/write-back paths (App.tsx debounced ui.set) must NOT use this.
+export function effectiveGroupByForRender(
+  groupBy: WorktreeGroupBy
+): Exclude<WorktreeGroupBy, 'project-group'> {
+  return groupBy === 'project-group' ? 'repo' : groupBy
 }
 
 export type GroupHeaderRow = {

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -1138,6 +1138,19 @@ describe('createUISlice hydratePersistedUI', () => {
     expect(setUI).toHaveBeenCalledWith({ groupBy: 'none', collapsedGroups: [] })
   })
 
+  it('persists the raw project-group value, never the desktop render alias', () => {
+    // Why: 'project-group' renders as 'repo' via effectiveGroupByForRender, but the
+    // write path must store the raw value so a phone's choice survives the round-trip.
+    const setUI = vi.fn(() => Promise.resolve())
+    vi.stubGlobal('window', { api: { ui: { set: setUI } } })
+    const store = createUIStore()
+
+    store.getState().setGroupBy('project-group')
+
+    expect(store.getState().groupBy).toBe('project-group')
+    expect(setUI).toHaveBeenCalledWith({ groupBy: 'project-group', collapsedGroups: [] })
+  })
+
   it('hydrates persisted per-worktree dotfile visibility', () => {
     const store = createUIStore()
 

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -872,7 +872,7 @@ export type UISlice = {
   dismissUsagePercentageDisplayChangeNotice: () => void
   usageEmptyStateDismissed: boolean
   dismissUsageEmptyState: () => void
-  groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status'
+  groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status' | 'project-group'
   setGroupBy: (g: UISlice['groupBy']) => void
   sortBy: 'name' | 'smart' | 'recent' | 'repo' | 'manual'
   setSortBy: (s: UISlice['sortBy']) => void

--- a/src/shared/folder-workspace-worktree.ts
+++ b/src/shared/folder-workspace-worktree.ts
@@ -3,6 +3,12 @@ import { folderWorkspaceKey } from './workspace-scope'
 import { parseExecutionHostId, toSshExecutionHostId } from './execution-host'
 import { normalizeWorkspaceCreatorProvenance } from './workspace-creator-provenance'
 
+// Synthetic repoId a folder workspace carries in place of a real git repo id.
+// Encodes its owning project group so consumers can recover group membership.
+export function folderWorkspaceRepoId(projectGroupId: string): string {
+  return `folder-workspace:${projectGroupId}`
+}
+
 export function folderWorkspaceToWorktree(folderWorkspace: FolderWorkspace): Worktree {
   const linkedTask = folderWorkspace.linkedTask
   const creatorProvenance = normalizeWorkspaceCreatorProvenance(folderWorkspace.creatorProvenance)
@@ -12,7 +18,7 @@ export function folderWorkspaceToWorktree(folderWorkspace: FolderWorkspace): Wor
   const parsedHost = parseExecutionHostId(hostId)
   return {
     id: folderWorkspaceKey(folderWorkspace.id),
-    repoId: `folder-workspace:${folderWorkspace.projectGroupId}`,
+    repoId: folderWorkspaceRepoId(folderWorkspace.projectGroupId),
     ...(creatorProvenance ? { creatorProvenance } : {}),
     displayName: folderWorkspace.name,
     comment: folderWorkspace.comment,

--- a/src/shared/project-groups.test.ts
+++ b/src/shared/project-groups.test.ts
@@ -6,9 +6,10 @@ import {
   getNextProjectGroupOrder,
   getProjectGroupSubtreeIds,
   normalizeProjectGroupName,
-  normalizeProjectGroups
+  normalizeProjectGroups,
+  resolveTopLevelProjectGroupId
 } from './project-groups'
-import type { Repo } from './types'
+import type { ProjectGroup, Repo } from './types'
 
 function repo(overrides: Partial<Repo>): Repo {
   return {
@@ -138,6 +139,37 @@ describe('project-groups', () => {
         )
       ].sort()
     ).toEqual(['child', 'grandchild', 'root'])
+  })
+
+  it('resolves the top-level ancestor by walking parentGroupId upward', () => {
+    const groupsById = new Map<string, Pick<ProjectGroup, 'id' | 'parentGroupId'>>([
+      ['root', { id: 'root', parentGroupId: null }],
+      ['child', { id: 'child', parentGroupId: 'root' }],
+      ['grandchild', { id: 'grandchild', parentGroupId: 'child' }]
+    ])
+
+    expect(resolveTopLevelProjectGroupId(groupsById, 'grandchild')).toBe('root')
+    expect(resolveTopLevelProjectGroupId(groupsById, 'root')).toBe('root')
+  })
+
+  it('returns the input id when the group is missing or the chain breaks', () => {
+    const groupsById = new Map<string, Pick<ProjectGroup, 'id' | 'parentGroupId'>>([
+      ['child', { id: 'child', parentGroupId: 'gone' }]
+    ])
+
+    expect(resolveTopLevelProjectGroupId(groupsById, 'unknown')).toBe('unknown')
+    // Parent id points outside the map: stop at the last resolvable node.
+    expect(resolveTopLevelProjectGroupId(groupsById, 'child')).toBe('child')
+  })
+
+  it('guards cycles instead of looping forever', () => {
+    const groupsById = new Map<string, Pick<ProjectGroup, 'id' | 'parentGroupId'>>([
+      ['a', { id: 'a', parentGroupId: 'b' }],
+      ['b', { id: 'b', parentGroupId: 'a' }]
+    ])
+
+    // Terminates once a node is revisited rather than spinning forever.
+    expect(resolveTopLevelProjectGroupId(groupsById, 'a')).toBe('a')
   })
 
   it('collects wide descendant groups without overflowing argument limits', () => {

--- a/src/shared/project-groups.ts
+++ b/src/shared/project-groups.ts
@@ -139,6 +139,30 @@ export function getProjectGroupSubtreeIds(
   return subtreeIds
 }
 
+/** Resolve the top-level (root) ancestor of a project group by walking
+ *  `parentGroupId` upward. Used to collapse a repo in any nested subgroup into a
+ *  single displayed folder section (mobile v1 flat grouping). Returns the input
+ *  id if the group is missing or already a root; a visited-set guards cycles. */
+export function resolveTopLevelProjectGroupId(
+  groupsById: ReadonlyMap<string, Pick<ProjectGroup, 'id' | 'parentGroupId'>>,
+  groupId: string
+): string {
+  let current = groupsById.get(groupId)
+  if (!current) {
+    return groupId
+  }
+  const visited = new Set<string>()
+  while (current.parentGroupId && !visited.has(current.id)) {
+    visited.add(current.id)
+    const parent = groupsById.get(current.parentGroupId)
+    if (!parent) {
+      break
+    }
+    current = parent
+  }
+  return current.id
+}
+
 /** Manual rank for a project inside a group bucket. Explicit
  *  `projectGroupOrder` wins; otherwise fall back to global repo order so drag
  *  midpoint math and sidebar sorting stay aligned. */

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -63,6 +63,8 @@ export const TERMINAL_PAIRED_PARKING_RUNTIME_CAPABILITY = 'terminal.paired-parki
 // Why: older hosts lack the targeted settings RPCs and strip agentPrompt from
 // terminal creation, so mobile must hide Quick Commands unless both are present.
 export const TERMINAL_QUICK_COMMANDS_RUNTIME_CAPABILITY = 'terminal.quick-commands.v1' as const
+// Why: older hosts reject the project-group ui.set enum, so mobile must gate that picker value.
+export const MOBILE_PROJECT_GROUP_SYNC_RUNTIME_CAPABILITY = 'mobile.project-group-sync.v1' as const
 // Why: older hosts strip worktree.create's clientMutationId, so mobile must only
 // replay ambiguous cutovers when the host advertises idempotent create support.
 export const WORKTREE_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY =
@@ -109,6 +111,7 @@ export const RUNTIME_CAPABILITIES = [
   TERMINAL_QUERY_REPLY_INPUT_RUNTIME_CAPABILITY,
   TERMINAL_PAIRED_PARKING_RUNTIME_CAPABILITY,
   TERMINAL_QUICK_COMMANDS_RUNTIME_CAPABILITY,
+  MOBILE_PROJECT_GROUP_SYNC_RUNTIME_CAPABILITY,
   WORKTREE_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY,
   TERMINAL_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY,
   SESSION_TAB_CLOSE_INTENT_RUNTIME_CAPABILITY,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3439,7 +3439,8 @@ export type PersistedUIState = {
   rightSidebarWidth: number
   markdownTocPanelWidth?: number
   combinedDiffFileTreeWidth?: number
-  groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status'
+  /** Preserves mobile project-group selection while desktop renders the existing project view. */
+  groupBy: 'none' | 'workspace-status' | 'repo' | 'pr-status' | 'project-group'
   sortBy: 'name' | 'smart' | 'recent' | 'repo' | 'manual'
   /** Project header ordering in `groupBy: 'repo'`, independent of `sortBy`: 'manual' uses persisted order + header drag, 'recent' by latest visible activity. */
   projectOrderBy: ProjectOrderBy


### PR DESCRIPTION
## Summary

Adds a **"Project Group"** grouping mode to the mobile worktree list, bidirectionally synced with desktop via a new persisted `PersistedUIState.groupBy` value `'project-group'`. Workspaces (git worktrees **and** folder workspaces) group under their repo's top-level project group folder.

## Design

- **preserve-value, render-alias**: `'project-group'` is a distinct persisted value that survives the `ui.get`/`ui.set` round-trip. Desktop has no separate layout, so it renders as the existing `'repo'` (Project) nested view via `effectiveGroupByForRender()` while the raw value stays persisted (App.tsx's debounced writer keeps it) — so a phone's choice isn't lost.
- Two validation gates learn the value (the `ui.set` zod enum + `normalizeGroupBy`).
- Mobile only offers the mode when the connected host advertises `mobile.project-group-sync.v1`, so mixed-version clients cannot send a value an older host rejects.
- `toDesktopViewSettingsPayload` only sends `groupBy` when the grouping mode itself changed, so a rejected grouping update cannot also drop other bundled view settings in the same `ui.set`.
- Folder-workspace worktrees resolve to their owning group via `folderWorkspaceRepoId()`; nested subgroups collapse to their top-level folder.
- Project-group metadata failures are reported while the independently successful repo list remains usable.

## Testing

- Node/CLI/web + mobile TypeScript checks: clean
- Focused root vitest: 6 files / 677 tests green
- Mobile worktree vitest: 14 files / 105 tests green
- Root/mobile oxlint, changed-file type-aware lint, formatting, max-lines ratchet, and `git diff --check`: clean
- Independent post-rebase spec/code-quality gate: PASS / APPROVED

## Coordination

**#6903** (decouple groups from Group by) is open and unmerged as of 2026-08-06. It adds a separate `showGroups` boolean and leaves the `groupBy` union itself untouched, so `'project-group'` needs no re-modelling whichever way the order falls. The two do overlap textually — both edit `PersistedUIState` in `src/shared/types.ts` on adjacent lines, and both touch `persistence.ts`, `worktree-list-groups.ts`, `store/slices/ui.ts`, `WorktreeList.tsx` and `SidebarWorkspaceOptionsMenu.tsx` — so whichever lands second takes a small merge rather than a redesign.

## ELI5

Mobile can group workspaces by Project Group, matching the folders you set on desktop. The choice syncs both ways so phone and desktop show the same project-group layout.
