### PR TITLE
fix(sidebar): attribute spinner-only pane titles to the launched agent

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -201,6 +201,43 @@ describe('buildTitleDerivedAgentRows', () => {
     }
   })
 
+  it('attributes a spinner-only title to the launched agent when the title has no identity', () => {
+    const launchAgent: TuiAgent = 'codex'
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        // Codex over SSH emits spinner + cwd titles with no agent name (#8711).
+        'tab-1': { 1: '⠼ demo-repo' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-codex-remote'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(
+      rows.map((row) => [row.agentType, row.state, row.entry.prompt, row.entry.terminalTitle])
+    ).toEqual([['codex', 'working', 'Codex', '⠼ demo-repo']])
+  })
+
+  it('keeps explicit title identity over the launched agent', () => {
+    const launchAgent: TuiAgent = 'claude'
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: '⠋ Codex' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-explicit'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state])).toEqual([['codex', 'working']])
+  })
+
   it('does not turn generic Codex-launched task titles into Claude Code rows', () => {
     const launchAgent: TuiAgent = 'codex'
     const rows = buildWorktreeAgentRows({

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -238,6 +238,23 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(rows.map((row) => [row.agentType, row.state])).toEqual([['codex', 'working']])
   })
 
+  it('produces no row for a spinner-only title when the tab has no launch identity', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        // Spinner activity but no identity and no launchAgent to attribute it to.
+        'tab-1': { 1: '⠼ demo-repo' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-anon'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
   it('does not turn generic Codex-launched task titles into Claude Code rows', () => {
     const launchAgent: TuiAgent = 'codex'
     const rows = buildWorktreeAgentRows({

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -145,8 +145,12 @@ function buildTitleDerivedAgentRow(args: {
   const orchestration = args.runtimeAgentOrchestrationByPaneKey?.[paneKey]
   const titleAgentType = isClaudeAgentsTitle ? 'claude' : resolveTitleDerivedAgentType(title, label)
   // Why: a braille spinner proves activity, not identity, so the resolver drops
-  // it. Hook-less agents over SSH (Codex, #8711) surface only spinner+cwd
-  // titles; fall back to the tab's launch identity instead of hiding the pane.
+  // it. Hook-less agents over SSH (Codex, #8711) surface only spinner+cwd titles;
+  // fall back to the tab's launch identity instead of hiding the pane. Gated on
+  // the spinner on purpose — unlike the hook path's unconditional launchAgent
+  // fallback (resolveRowAgentType), this path manufactures agent-ness from a
+  // title alone, so a non-agent title must never become a row. Residual: a split
+  // pane whose own title carries a braille glyph is still attributed to launchAgent.
   const agentType =
     titleAgentType ?? (containsBrailleSpinner(title) ? (args.tab.launchAgent ?? null) : null)
   if (!agentType) {

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -1,5 +1,6 @@
 import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
-import { isClaudeManagementTitle } from '@/lib/agent-status'
+import { formatAgentTypeLabel, isClaudeManagementTitle } from '@/lib/agent-status'
+import { containsBrailleSpinner } from '../../../../shared/agent-title-core'
 import { classifyTitleActivity, resolveTitleActivityLabel } from '@/lib/pane-agent-evidence'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import type {
@@ -142,10 +143,16 @@ function buildTitleDerivedAgentRow(args: {
   }
   const paneKey = makePaneKey(args.tab.id, args.leafId)
   const orchestration = args.runtimeAgentOrchestrationByPaneKey?.[paneKey]
-  const agentType = isClaudeAgentsTitle ? 'claude' : resolveTitleDerivedAgentType(title, label)
+  const titleAgentType = isClaudeAgentsTitle ? 'claude' : resolveTitleDerivedAgentType(title, label)
+  // Why: a braille spinner proves activity, not identity, so the resolver drops
+  // it. Hook-less agents over SSH (Codex, #8711) surface only spinner+cwd
+  // titles; fall back to the tab's launch identity instead of hiding the pane.
+  const agentType =
+    titleAgentType ?? (containsBrailleSpinner(title) ? (args.tab.launchAgent ?? null) : null)
   if (!agentType) {
     return null
   }
+  const rowLabel = titleAgentType ? label : formatAgentTypeLabel(agentType)
   const rowState = titleStatusToRowState(status)
   const secondary =
     status === 'permission' ? 'Needs input' : status === 'working' ? 'Running' : 'Idle'
@@ -153,7 +160,7 @@ function buildTitleDerivedAgentRow(args: {
   const entry: AgentStatusEntry = {
     paneKey,
     state: entryState,
-    prompt: label,
+    prompt: rowLabel,
     updatedAt: args.now,
     stateStartedAt: args.now,
     stateHistory: [],


### PR DESCRIPTION
## Summary

Fixes #9646.

On SSH hosts, a worktree with a working Codex session showed no sidebar agent activity row at all, while Claude worktrees on the same host showed theirs. All three identity signals fail for Codex over SSH: its OSC titles are spinner + cwd with no agent name, its status hooks are dead remotely (#8711), and the foreground-process fallback only scans the local process table.

The title-derived sidebar fallback (`worktree-title-derived-agent-rows.ts`) classified the spinner title as *working* but then dropped the row, because `resolveTitleDerivedAgentType` correctly refuses to attribute a bare braille spinner to Claude (`CLAUDE_AGENT_TOKEN_RE` gate). The tab already knows who it launched — `tab.launchAgent` is stamped by the agent launcher and `worktree create --agent`, and survives the remote path — but this was the one sidebar path that never consulted it.

**Fix:** when the title resolver yields no identity and the title carries a braille spinner, fall back to `tab.launchAgent` for the row's agent type (and label it with `formatAgentTypeLabel`). This mirrors the precedence the hook-row path (`resolveRowAgentType` in `worktree-agent-rows.ts`) already gives launch identity.

Scope guards, all preserved by existing tests:

- Explicit title identity still wins (`⠋ Codex` stays Codex regardless of `launchAgent`).
- A spinner title in a tab **without** launch metadata still produces no row ("does not infer Claude Code from a spinner-only non-agent title").
- Claude-specific prefixes (`✳` / `". "` / `"* "`) contain no braille spinner, so they are not rescued — "does not turn generic Codex-launched task titles into Claude Code rows" stays green.
- Hook rows still take precedence via `seenPaneKeys`; once #8711 lands, the authoritative hook path simply covers these panes first.

## Screenshots

Verified live: dev build connected to an SSH host, workspace created with `worktree create --agent codex`, Codex mid-task. Renderer state at capture time: `tab.launchAgent === 'codex'`, `agentStatusByPaneKey` empty (no hooks, #8711), pane title `⠸ <repo-name>` (no identity token).

![Codex row shown for a hook-less SSH pane](https://raw.githubusercontent.com/choihjin/orca/pr-assets-codex-sidebar-row/codex-sidebar-row.png)

Counter-check observed in the same session: when Codex went idle (title back to the bare repo name, no spinner), the row disappeared — idle panes without identity keep the existing no-row behavior.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added a regression test that fails without the fix

New tests in `worktree-title-derived-agent-rows.test.ts`:

- "attributes a spinner-only title to the launched agent when the title has no identity" — codex-launched tab, live PTY, title `⠼ demo-repo` → exactly one row `['codex', 'working', 'Codex', '⠼ demo-repo']`. Confirmed red before the fix (no row) and green after.
- "keeps explicit title identity over the launched agent" — claude-launched tab with `⠋ Codex` title stays a Codex row (pins the precedence).

Full suite: 30,679 tests pass.

## AI Review Report

Reviewed by Claude (Fable 5, author).

- **Root cause verified live, not guessed**: with a remote Codex mid-task, the renderer store showed `launchAgent: 'codex'` on the tab, an empty `agentStatusByPaneKey`, and a spinner-only pane title — exactly the state the row builder drops today.
- **Blast radius**: the fallback triggers only when (a) the title resolver returned no identity — which happens solely for generic status claims — (b) the title contains a braille spinner, and (c) the tab has launch metadata. All other title shapes and all hook-backed panes are untouched.
- **Known tradeoff**: `launchAgent` is tab-scoped, so a second split pane in an agent-launched tab whose process emits a braille-spinner title would be attributed to the launched agent. This mirrors the existing tab-scoped use of `launchAgent` in the hook-row path; spinner-titled non-agent processes are rare (most CLIs don't set OSC titles).
- **Not covered (documented)**: agents started by manually typing `codex` in a plain terminal have no `launchAgent`; their identity lives in pane-connection-local `commandInferredAgent`, which the sidebar cannot reach today. That belongs to the pane-owner-resolver slice deliberately deferred in `pane-agent-evidence.ts`.
- **Cross-platform (macOS/Linux/Windows)**: pure renderer logic; no platform branches, no Git commands, no provider-specific naming.
- **SSH/remote/local**: verified over SSH (the motivating case); local panes behave identically — locally Codex hooks usually produce authoritative rows first, which keep precedence.

## Security Audit

No new input handling, IPC, auth, command execution, or path handling. The change reads two existing renderer-state fields (`tab.launchAgent`, the already-scraped pane title) to pick a display label and icon. No secrets or logging affected.

## Notes

- #8711 (assigned) remains the root-cause fix for the hooks signal and will bring full status detail (current tool, task text). This change only stops the sidebar from being completely blind in the meantime, and yields to hook rows the moment they exist.
- Possibly explains #8763 (`cannot_repro`): remote panes where the only signal is an anonymous spinner title.


