### PR TITLE
fix(terminal): stop leaking Orca's own NODE_ENV into spawned terminals

### DIFF
--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -1218,6 +1218,55 @@ describe('createPtySubprocess', () => {
     expect(env.ELECTRON_RUN_AS_NODE).toBeUndefined()
   })
 
+  it('does not inherit NODE_ENV from the daemon process env', () => {
+    // Why: a dev-mode Orca forks the daemon with NODE_ENV=development; leaking
+    // Orca's build mode into user shells breaks `next build` and Vitest.
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const previous = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
+
+    try {
+      createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    } finally {
+      if (previous === undefined) {
+        delete process.env.NODE_ENV
+      } else {
+        process.env.NODE_ENV = previous
+      }
+    }
+
+    const env = spawnMock.mock.calls.at(-1)?.[2].env
+    expect(env.NODE_ENV).toBeUndefined()
+    expect(env.PATH).toBe(process.env.PATH)
+  })
+
+  it('keeps an explicitly requested NODE_ENV for daemon PTY shells', () => {
+    // Why: only the ambient value is stripped; a caller-supplied NODE_ENV still wins.
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const previous = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
+
+    try {
+      createPtySubprocess({
+        sessionId: 'test',
+        cols: 80,
+        rows: 24,
+        env: { NODE_ENV: 'production' }
+      })
+    } finally {
+      if (previous === undefined) {
+        delete process.env.NODE_ENV
+      } else {
+        process.env.NODE_ENV = previous
+      }
+    }
+
+    const env = spawnMock.mock.calls.at(-1)?.[2].env
+    expect(env.NODE_ENV).toBe('production')
+  })
+
   it('does not inherit AppImage runtime env into daemon PTY shells', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -31,6 +31,7 @@ import { isPwshAvailable } from '../pwsh'
 import { isHostCodexHomeForWsl, isWslCodexHomeForHost } from '../pty/codex-home-wsl-env'
 import { removeInheritedNoColor } from '../pty/terminal-color-env'
 import { removeAppImageRuntimeEnv } from '../pty/appimage-terminal-env'
+import { stripInheritedBuildModeEnv } from '../pty/build-mode-env'
 import { parseWslPath } from '../wsl'
 import { addWslEnvKeys } from '../wsl-env'
 import {
@@ -559,7 +560,7 @@ function spawnDaemonPtyWithWindowsFallback(args: {
 export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandle {
   const size = normalizePtySize(opts.cols, opts.rows)
   const env: Record<string, string> = {
-    ...mergeGitConfigEnvProtocol(process.env, opts.env),
+    ...mergeGitConfigEnvProtocol(stripInheritedBuildModeEnv(process.env), opts.env),
     TERM: 'xterm-256color',
     COLORTERM: 'truecolor',
     TERM_PROGRAM: 'Orca',

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -441,6 +441,44 @@ describe('LocalPtyProvider', () => {
       expect(spawnCall[2].env.CUSTOM_VAR).toBe('custom-value')
     })
 
+    it('does not inherit NODE_ENV from the Orca process env', async () => {
+      // Why: NODE_ENV in Orca's process is Orca's build mode (electron-vite sets
+      // `development` in dev runs); leaking it breaks `next build` and Vitest.
+      const previous = process.env.NODE_ENV
+      process.env.NODE_ENV = 'development'
+      try {
+        await provider.spawn({ cols: 80, rows: 24 })
+      } finally {
+        if (previous === undefined) {
+          delete process.env.NODE_ENV
+        } else {
+          process.env.NODE_ENV = previous
+        }
+      }
+
+      const spawnCall = spawnMock.mock.calls.at(-1)!
+      expect(spawnCall[2].env.NODE_ENV).toBeUndefined()
+      expect(spawnCall[2].env.PATH).toBe(process.env.PATH)
+    })
+
+    it('keeps an explicitly requested NODE_ENV for spawned terminals', async () => {
+      // Why: only the ambient value is stripped; a caller-supplied NODE_ENV still wins.
+      const previous = process.env.NODE_ENV
+      process.env.NODE_ENV = 'development'
+      try {
+        await provider.spawn({ cols: 80, rows: 24, env: { NODE_ENV: 'production' } })
+      } finally {
+        if (previous === undefined) {
+          delete process.env.NODE_ENV
+        } else {
+          process.env.NODE_ENV = previous
+        }
+      }
+
+      const spawnCall = spawnMock.mock.calls.at(-1)!
+      expect(spawnCall[2].env.NODE_ENV).toBe('production')
+    })
+
     it('suppresses the first-run Powerlevel10k wizard for spawned terminals', async () => {
       await provider.spawn({ cols: 80, rows: 24 })
 

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -37,6 +37,7 @@ import {
 import type { ShellReadySignal } from './local-pty-shell-ready'
 import { removeInheritedNoColor } from '../pty/terminal-color-env'
 import { removeAppImageRuntimeEnv } from '../pty/appimage-terminal-env'
+import { stripInheritedBuildModeEnv } from '../pty/build-mode-env'
 import { isHostCodexHomeForWsl, isWslCodexHomeForHost } from '../pty/codex-home-wsl-env'
 import { addWslEnvKeys } from '../wsl-env'
 import {
@@ -635,7 +636,7 @@ export class LocalPtyProvider implements IPtyProvider {
     validateWorkingDirectory(validationCwd)
 
     const spawnEnv: Record<string, string> = {
-      ...mergeGitConfigEnvProtocol(process.env, args.env),
+      ...mergeGitConfigEnvProtocol(stripInheritedBuildModeEnv(process.env), args.env),
       TERM: 'xterm-256color',
       COLORTERM: 'truecolor',
       TERM_PROGRAM: 'Orca',

--- a/src/main/pty/build-mode-env.test.ts
+++ b/src/main/pty/build-mode-env.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { stripInheritedBuildModeEnv } from './build-mode-env'
+
+describe('stripInheritedBuildModeEnv', () => {
+  it('drops NODE_ENV while keeping every other inherited variable', () => {
+    const env = { NODE_ENV: 'development', PATH: '/usr/bin', HOME: '/home/tester' }
+
+    expect(stripInheritedBuildModeEnv(env)).toEqual({ PATH: '/usr/bin', HOME: '/home/tester' })
+  })
+
+  it('does not mutate the source env', () => {
+    const env = { NODE_ENV: 'development' }
+
+    stripInheritedBuildModeEnv(env)
+
+    expect(env.NODE_ENV).toBe('development')
+  })
+
+  it('is a no-op when NODE_ENV is unset', () => {
+    expect(stripInheritedBuildModeEnv({ PATH: '/usr/bin' })).toEqual({ PATH: '/usr/bin' })
+  })
+})

--- a/src/main/pty/build-mode-env.ts
+++ b/src/main/pty/build-mode-env.ts
@@ -1,0 +1,9 @@
+/** Return a copy of an inherited environment without Orca's own build-mode flag. */
+export function stripInheritedBuildModeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  // Why: NODE_ENV in Orca's process is Orca's build mode (electron-vite sets
+  // `development` in dev runs), not the user's; leaking it makes `next build`
+  // and Vitest take the wrong branch. Caller/renderer env and shell rc still win.
+  const next = { ...env }
+  delete next.NODE_ENV
+  return next
+}

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -182,6 +182,48 @@ describe('PtyHandler', () => {
     expect(handler.activePtyCount).toBe(1)
   })
 
+  it("does not forward Orca's own NODE_ENV into the spawned shell", async () => {
+    // Why: NODE_ENV in the relay host process is a build-mode flag, not the
+    // user's; leaking it breaks `next build` and Vitest in the terminal.
+    const previous = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
+    try {
+      await dispatcher.callRequest('pty.spawn', { cols: 80, rows: 24 })
+    } finally {
+      if (previous === undefined) {
+        delete process.env.NODE_ENV
+      } else {
+        process.env.NODE_ENV = previous
+      }
+    }
+
+    const spawnOptions = mockPtySpawn.mock.calls[0][2] as { env: Record<string, string> }
+    expect(spawnOptions.env.NODE_ENV).toBeUndefined()
+    expect(spawnOptions.env.PATH).toBe(process.env.PATH)
+  })
+
+  it('keeps a renderer-supplied NODE_ENV for the spawned shell', async () => {
+    // Why: only the ambient value is stripped; an explicit request still wins.
+    const previous = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
+    try {
+      await dispatcher.callRequest('pty.spawn', {
+        cols: 80,
+        rows: 24,
+        env: { NODE_ENV: 'production' }
+      })
+    } finally {
+      if (previous === undefined) {
+        delete process.env.NODE_ENV
+      } else {
+        process.env.NODE_ENV = previous
+      }
+    }
+
+    const spawnOptions = mockPtySpawn.mock.calls[0][2] as { env: Record<string, string> }
+    expect(spawnOptions.env.NODE_ENV).toBe('production')
+  })
+
   it('normalizes a missing native binding as degraded node-pty availability', async () => {
     mockPtySpawn.mockImplementationOnce(() => {
       throw new Error(

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -39,6 +39,7 @@ import {
 } from '../shared/git-credential-prompt-env'
 import { isTuiAgent } from '../shared/tui-agent-config'
 import { forceKillPosixPtyProcessGroups } from '../main/pty/posix-pty-process-groups'
+import { stripInheritedBuildModeEnv } from '../main/pty/build-mode-env'
 import {
   PTY_STARTUP_INGRESS_VERSION,
   PtyStartupIngress,
@@ -387,7 +388,7 @@ export class PtyHandler {
   ): Record<string, string> {
     const baseEnv = mergeGitConfigEnvProtocol(
       {
-        ...process.env,
+        ...stripInheritedBuildModeEnv(process.env),
         TERM: 'xterm-256color',
         COLORTERM: 'truecolor',
         TERM_PROGRAM: 'Orca',


### PR DESCRIPTION
## What
When Orca was run from source (a dev build), every integrated terminal it spawned inherited Orca's own `NODE_ENV=development`. A user who opened a terminal and ran `echo $NODE_ENV` saw `development`, and any tool that branches on it — `next build`, Vitest, countless build scripts — silently took the wrong (dev) code path inside a terminal the user considered a clean shell. The value came from Orca's build tooling, not from anything the user set.

## Why it happened
electron-vite sets `process.env.NODE_ENV = 'development'` in the Electron main process during a dev run, and every PTY env-assembly site spread the whole process env into the child with no scrub for it: `src/main/daemon/pty-subprocess.ts:562`, `src/main/providers/local-pty-provider.ts:638`, and `src/relay/pty-handler.ts:390`. Those sites already strip other inherited leak vars (`ELECTRON_RUN_AS_NODE`, AppImage runtime vars, `NO_COLOR`, pane-identity vars) — `NODE_ENV` was simply missing from that list, so it rode straight through the daemon fork into node-pty.

## ELI5
When you start Orca from its source code, Orca quietly wears a "development" name tag. Every terminal window you opened inside Orca was copying that name tag onto itself, so programs in your terminal thought they were in "development mode" when they weren't. This change tears that one name tag off the copy before handing the terminal its environment — everything else on the tag is left exactly as-is.

## Evidence
Root cause is a real inherited leak. The final hop was reproduced at runtime against this repo's node-pty (parent exporting `NODE_ENV=development`, replicating `pty-subprocess.ts:562`):

```
CHILD SAW: NODE_ENV=[development]
```

The fix adds a single-purpose stripper wired into all three spawn-env builders:

```ts
/** Return a copy of an inherited environment without Orca's own build-mode flag. */
export function stripInheritedBuildModeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
  const next = { ...env }
  delete next.NODE_ENV
  return next
}
```

New and existing tests pass, covering the strip, non-mutation of the source env, the no-op-when-unset case, and precedence at each spawn site:

```
 ✓ build-mode-env.test.ts > drops NODE_ENV while keeping every other inherited variable
 ✓ build-mode-env.test.ts > does not mutate the source env
 ✓ build-mode-env.test.ts > is a no-op when NODE_ENV is unset

 Test Files  4 passed (4)
      Tests  298 passed (298)
```

(4 files: `build-mode-env.test.ts`, `pty-subprocess.test.ts`, `local-pty-provider.test.ts`, `pty-handler.test.ts`.)

## Trade-offs
One deliberate, user-facing behavior change: if you export `NODE_ENV` in the shell you launch Orca from (e.g. `NODE_ENV=production orca .`), integrated terminals will no longer inherit that value from the launch environment. This is exactly what the issue asks for, and the blast radius is small — login-shell rc files (`zsh -l`) still set `NODE_ENV`, and renderer-supplied env, `envAugmenters`, and startup plans that set it explicitly are unaffected because the strip targets only the inherited process env (which precedes those overrides). On packaged macOS GUI launches nothing changes (`NODE_ENV` is already unset there). Unlike PR #9058, which patched only the relay host, this lands on the daemon side so stale dev-mode daemons stop leaking too.

## Perf
Perf audit verdict:

```
{"hasRegression":false,"verdict":"0 perf regressions: one extra shallow env copy + delete on the cold PTY-spawn path","notes":"Diff adds stripInheritedBuildModeEnv (shallow-copies process.env and deletes NODE_ENV) and wires it into three spawn-env builders: src/main/daemon/pty-subprocess.ts createPtySubprocess, src/main/providers/local-pty-provider.ts LocalPtyProvider spawn (spawnEnv), and src/relay/pty-handler.ts buildSpawnEnv. All three are PTY spawn-time (once per terminal creation), not per-keystroke/per-chunk/per-frame. Each site already spreads process.env and mutates the env repeatedly, so one additional {...env}+delete is negligible relative to existing spawn work. No new timers, listeners, watchers, subprocesses, sync I/O, or React render allocations. No startup await added. Not a hot path; no regression."}
```

## Review
Reviewed by an independent agent for 1 round — final verdict: CLEAN.

Closes #9057

Made with [Orca](https://github.com/stablyai/orca) 🐋
