### PR TITLE
fix(orchestration): let a null-id worker_done complete the sender's own in-flight dispatch

### DIFF
--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -694,6 +694,28 @@ export class OrchestrationDb {
     return this.findActiveDispatchForAssignee(handle)
   }
 
+  // Why: attributing an id-less lifecycle message is only safe when the sender owns
+  // exactly one active dispatch (#7429) — more than one match must not be guessed.
+  getSoleActiveDispatchForSender(
+    assigneeHandle: string,
+    assigneePaneKey?: string | null
+  ): DispatchContextRow | undefined {
+    const matches = (
+      this.db
+        .prepare("SELECT * FROM dispatch_contexts WHERE status IN ('pending', 'dispatched')")
+        .all() as DispatchContextRow[]
+    ).filter(
+      (row) =>
+        row.assignee_handle === assigneeHandle ||
+        Boolean(
+          assigneePaneKey &&
+          row.assignee_pane_key &&
+          isEquivalentPaneKey(row.assignee_pane_key, assigneePaneKey)
+        )
+    )
+    return matches.length === 1 ? matches[0] : undefined
+  }
+
   private findActiveDispatchForAssignee(
     assigneeHandle: string,
     assigneePaneKey?: string

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -61,6 +61,23 @@ function addLifecycleRejectionMarker(payload: string | null, reason: string): st
   })
 }
 
+function stampResolvedLifecycleIds(
+  payload: string | null,
+  taskId: string,
+  dispatchId: string
+): string {
+  let parsed: Record<string, unknown> = {}
+  try {
+    const value: unknown = payload ? JSON.parse(payload) : {}
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      parsed = value as Record<string, unknown>
+    }
+  } catch {
+    // Fallback resolution only reaches this path with object/empty payloads.
+  }
+  return JSON.stringify({ ...parsed, taskId, dispatchId })
+}
+
 const SQLITE_UTC_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)?$/
 
 function exposeUtcTimestamp(timestamp: string | null): string | null {
@@ -383,6 +400,16 @@ export class OrchestrationDb {
       )
       .run(`Rejected ${message.type}: ${message.subject}`, body, payload, messageId)
     return this.getMessageById(messageId)
+  }
+
+  // Why: stamp fallback-resolved ids onto a null-id worker_done so a later re-read takes the stable id path instead of re-resolving against a newer dispatch (#7429).
+  stampResolvedWorkerDoneIds(messageId: string, taskId: string, dispatchId: string): void {
+    const message = this.getMessageById(messageId)
+    if (!message || message.type !== 'worker_done') {
+      return
+    }
+    const payload = stampResolvedLifecycleIds(message.payload, taskId, dispatchId)
+    this.db.prepare('UPDATE messages SET payload = ? WHERE id = ?').run(payload, messageId)
   }
 
   // Why: delivered_at IS NULL filter — push-on-idle delivers each row at most once; read (set only by check) wouldn't prevent replay.

--- a/src/main/runtime/orchestration/lifecycle-reconciliation.test.ts
+++ b/src/main/runtime/orchestration/lifecycle-reconciliation.test.ts
@@ -432,6 +432,41 @@ describe('lifecycle reconciliation', () => {
     expect(db.getDispatchContextById(dispatch.id)?.status).toBe('completed')
   })
 
+  it('does not let a re-read of a fallback-resolved worker_done complete a later dispatch to the same pane', () => {
+    db = new OrchestrationDb(':memory:')
+    const taskA = db.createTask({ spec: 'work A' })
+    const dispatchA = db.createDispatchContext(taskA.id, 'term_worker', `tab_w:${LEAF_A}`)
+    const done = db.insertMessage({
+      from: 'term_worker',
+      to: 'term_coordinator',
+      subject: 'Done',
+      type: 'worker_done',
+      payload: JSON.stringify({}),
+      senderPaneKey: `tab_w:${LEAF_A}`
+    })
+
+    // First reconcile completes A via the sole-active-dispatch fallback.
+    expect(reconcileLifecycleMessage(db, done)).toMatchObject({
+      action: 'completed',
+      taskId: taskA.id,
+      dispatchId: dispatchA.id
+    })
+
+    // The same pane now owns a fresh dispatch B.
+    const taskB = db.createTask({ spec: 'work B' })
+    const dispatchB = db.createDispatchContext(taskB.id, 'term_worker', `tab_w:${LEAF_A}`)
+
+    // Re-reading the ORIGINAL message (as the coordinator does) must re-target A, not B.
+    const reread = db.getMessageById(done.id)
+    expect(reread && reconcileLifecycleMessage(db, reread)).toMatchObject({
+      action: 'completed',
+      taskId: taskA.id,
+      dispatchId: dispatchA.id
+    })
+    expect(db.getTask(taskB.id)?.status).toBe('dispatched')
+    expect(db.getDispatchContextById(dispatchB.id)?.status).toBe('dispatched')
+  })
+
   it('ignores a null-id worker_done sent from a foreign pane and handle', () => {
     db = new OrchestrationDb(':memory:')
     const task = db.createTask({ spec: 'work' })

--- a/src/main/runtime/orchestration/lifecycle-reconciliation.test.ts
+++ b/src/main/runtime/orchestration/lifecycle-reconciliation.test.ts
@@ -409,4 +409,87 @@ describe('lifecycle reconciliation', () => {
     expect(db.getMessageById(lateHeartbeat.id)).toMatchObject({ read: 1 })
     expect(db.getMessageById(lateHeartbeat.id)?.delivered_at).not.toBeNull()
   })
+
+  it('completes a null-id worker_done sent from the pane that owns the sole dispatch', () => {
+    db = new OrchestrationDb(':memory:')
+    const task = db.createTask({ spec: 'work' })
+    const dispatch = db.createDispatchContext(task.id, 'term_worker', `tab_w:${LEAF_A}`)
+    const done = db.insertMessage({
+      from: 'term_worker',
+      to: 'term_coordinator',
+      subject: 'Done',
+      type: 'worker_done',
+      payload: JSON.stringify({}),
+      senderPaneKey: `tab_w:${LEAF_A}`
+    })
+
+    expect(reconcileLifecycleMessage(db, done)).toEqual({
+      action: 'completed',
+      taskId: task.id,
+      dispatchId: dispatch.id
+    })
+    expect(db.getTask(task.id)?.status).toBe('completed')
+    expect(db.getDispatchContextById(dispatch.id)?.status).toBe('completed')
+  })
+
+  it('ignores a null-id worker_done sent from a foreign pane and handle', () => {
+    db = new OrchestrationDb(':memory:')
+    const task = db.createTask({ spec: 'work' })
+    const dispatch = db.createDispatchContext(task.id, 'term_owner', `tab_w:${LEAF_A}`)
+    const logs: string[] = []
+    const done = db.insertMessage({
+      from: 'term_stranger',
+      to: 'term_coordinator',
+      subject: 'Done',
+      type: 'worker_done',
+      payload: JSON.stringify({}),
+      senderPaneKey: `tab_w:${LEAF_B}`
+    })
+
+    expect(reconcileLifecycleMessage(db, done, (line) => logs.push(line))).toEqual({
+      action: 'ignored'
+    })
+    expect(db.getTask(task.id)?.status).toBe('dispatched')
+    expect(db.getDispatchContextById(dispatch.id)?.status).toBe('dispatched')
+    expect(logs.some((line) => line.includes('without taskId'))).toBe(true)
+  })
+
+  it('ignores a null-id worker_done when the sender has no active dispatch', () => {
+    db = new OrchestrationDb(':memory:')
+    const task = db.createTask({ spec: 'work' })
+    const dispatch = db.createDispatchContext(task.id, 'term_worker', `tab_w:${LEAF_A}`)
+    db.updateTaskStatus(task.id, 'completed')
+    const done = db.insertMessage({
+      from: 'term_worker',
+      to: 'term_coordinator',
+      subject: 'Done again',
+      type: 'worker_done',
+      payload: JSON.stringify({}),
+      senderPaneKey: `tab_w:${LEAF_A}`
+    })
+
+    expect(reconcileLifecycleMessage(db, done)).toEqual({ action: 'ignored' })
+    expect(db.getDispatchContextById(dispatch.id)?.status).toBe('completed')
+  })
+
+  it('ignores a null-id worker_done when the sender matches two active dispatches', () => {
+    db = new OrchestrationDb(':memory:')
+    const ownTask = db.createTask({ spec: 'work' })
+    const ownDispatch = db.createDispatchContext(ownTask.id, 'term_worker', `tab_w:${LEAF_A}`)
+    const paneTask = db.createTask({ spec: 'other work' })
+    const paneDispatch = db.createDispatchContext(paneTask.id, 'term_other', `tab_w:${LEAF_B}`)
+    // Sender matches one dispatch by handle and another by pane, so neither can be attributed.
+    const done = db.insertMessage({
+      from: 'term_worker',
+      to: 'term_coordinator',
+      subject: 'Done',
+      type: 'worker_done',
+      payload: JSON.stringify({}),
+      senderPaneKey: `tab_w:${LEAF_B}`
+    })
+
+    expect(reconcileLifecycleMessage(db, done)).toEqual({ action: 'ignored' })
+    expect(db.getDispatchContextById(ownDispatch.id)?.status).toBe('dispatched')
+    expect(db.getDispatchContextById(paneDispatch.id)?.status).toBe('dispatched')
+  })
 })

--- a/src/main/runtime/orchestration/lifecycle-reconciliation.ts
+++ b/src/main/runtime/orchestration/lifecycle-reconciliation.ts
@@ -170,17 +170,11 @@ function reconcileWorkerDoneMessage(
     return persistedRejection
   }
 
-  const taskId = payload.taskId
-  if (typeof taskId !== 'string' || taskId.length === 0) {
-    onLog(`Warning: worker_done without taskId from ${msg.from_handle}`)
+  const target = resolveWorkerDoneTarget(db, msg, payload, onLog)
+  if (!target) {
     return { action: 'ignored' }
   }
-
-  const dispatchId = payload.dispatchId
-  if (typeof dispatchId !== 'string' || dispatchId.length === 0) {
-    onLog(`Warning: worker_done without dispatchId from ${msg.from_handle}`)
-    return { action: 'ignored' }
-  }
+  const { taskId, dispatchId } = target
 
   const task = db.getTask(taskId)
   if (!task) {
@@ -237,6 +231,36 @@ function reconcileWorkerDoneMessage(
 
   onLog(`Task ${taskId} completed`)
   return { action: 'completed', taskId, dispatchId }
+}
+
+// Why: a worker_done from the pane that owns the sole in-flight dispatch is still
+// authoritative (#7429); the payload ids are a convenience, not the authority.
+function resolveWorkerDoneTarget(
+  db: OrchestrationDb,
+  msg: MessageRow,
+  payload: Record<string, unknown>,
+  onLog: LogFn
+): { taskId: string; dispatchId: string } | undefined {
+  const payloadTaskId = payload.taskId
+  const payloadDispatchId = payload.dispatchId
+  const taskId = typeof payloadTaskId === 'string' && payloadTaskId.length > 0 ? payloadTaskId : ''
+  const dispatchId =
+    typeof payloadDispatchId === 'string' && payloadDispatchId.length > 0 ? payloadDispatchId : ''
+  if (taskId && dispatchId) {
+    return { taskId, dispatchId }
+  }
+
+  const fallback = db.getSoleActiveDispatchForSender(msg.from_handle, msg.sender_pane_key)
+  if (fallback && hasLifecycleAuthority(fallback, msg)) {
+    return { taskId: taskId || fallback.task_id, dispatchId: dispatchId || fallback.id }
+  }
+
+  onLog(
+    taskId
+      ? `Warning: worker_done without dispatchId from ${msg.from_handle}`
+      : `Warning: worker_done without taskId from ${msg.from_handle}`
+  )
+  return undefined
 }
 
 function buildLifecycleAuthorityRejectionReason(

--- a/src/main/runtime/orchestration/lifecycle-reconciliation.ts
+++ b/src/main/runtime/orchestration/lifecycle-reconciliation.ts
@@ -252,7 +252,10 @@ function resolveWorkerDoneTarget(
 
   const fallback = db.getSoleActiveDispatchForSender(msg.from_handle, msg.sender_pane_key)
   if (fallback && hasLifecycleAuthority(fallback, msg)) {
-    return { taskId: taskId || fallback.task_id, dispatchId: dispatchId || fallback.id }
+    const resolved = { taskId: taskId || fallback.task_id, dispatchId: dispatchId || fallback.id }
+    // Why: persist before completion so a re-read of this same message uses the recorded ids; else the sole-dispatch fallback would re-resolve onto a later dispatch B and wrongly complete it (#7429).
+    db.stampResolvedWorkerDoneIds(msg.id, resolved.taskId, resolved.dispatchId)
+    return resolved
   }
 
   onLog(

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -748,11 +748,26 @@ describe('orchestration RPC methods', () => {
       expect(db.getUnreadMessages('term_coord', ['worker_done'])).toHaveLength(1)
     })
 
-    it('does not complete worker_done missing taskId or dispatchId', async () => {
+    it('completes worker_done missing taskId or dispatchId from the assigned terminal', async () => {
       setup()
       const { task, dispatch } = createDispatchedTask()
       insertWorkerDone({ dispatchId: dispatch.id })
-      insertWorkerDone({ taskId: task.id })
+
+      const result = (await call('orchestration.check', {
+        terminal: 'term_coord',
+        types: 'worker_done'
+      })) as { count: number }
+
+      expect(result.count).toBe(1)
+      expect(db.getTask(task.id)?.status).toBe('completed')
+      expect(db.getDispatchContextById(dispatch.id)?.status).toBe('completed')
+    })
+
+    it('does not complete worker_done missing taskId or dispatchId from another terminal', async () => {
+      setup()
+      const { task, dispatch } = createDispatchedTask()
+      insertWorkerDone({ from: 'term_other', dispatchId: dispatch.id })
+      insertWorkerDone({ from: 'term_other', taskId: task.id })
 
       const result = (await call('orchestration.check', {
         terminal: 'term_coord',


### PR DESCRIPTION
## What

A `worker_done` lifecycle message that arrives without a payload `taskId`/`dispatchId` was dropped with only a warning, so a worker running a custom harness (rather than the stock preamble that injects those ids) could report completion from the very pane that owns the sole in-flight dispatch and have it silently ignored. The CLI still printed `Sent msg_…` and exited `0`, while the task stayed `dispatched` forever — a task that will never advance and gives the sender no signal that anything went wrong.

## Why it happened

`reconcileWorkerDoneMessage` (`src/main/runtime/orchestration/lifecycle-reconciliation.ts:173-183`) treated payload `taskId`/`dispatchId` as the *only* key for locating the dispatch: if either was missing or empty it logged `Warning: worker_done without taskId …` and returned `{ action: 'ignored' }` **before** ever reaching the pane/handle ownership check (`hasLifecycleAuthority`, line 203). The DB already had an authoritative handle/pane-key lookup for exactly this case (`getActiveDispatchForTerminal` / `findActiveDispatchForAssignee`, `db.ts:693-726`) that was never consulted. On the send path, `src/main/runtime/rpc/methods/orchestration.ts:218-232` only propagates `lifecycle` for `rejected`/`suppressed` results, so an `ignored` reconcile returns a bare `{ message }` and `src/cli/handlers/orchestration.ts:368` leaves `process.exitCode` at 0 — the drop is invisible.

## ELI5

A worker finishes its job and says "I'm done." The coordinator normally recognizes it by a ticket number stapled to the message. If the worker forgets to staple the ticket, the coordinator used to throw the whole "I'm done" note in the trash — even though it already knew, from which desk the note came from, exactly which job it was about. Now it checks the desk: if that desk has exactly one open job, it marks that job done. If the desk is ambiguous or belongs to someone else, it still ignores the note, just like before.

## Evidence

Real-DB repro against pre-fix HEAD (`0e7b0ac220`) — a null-id `worker_done` from the owning pane was dropped and the task stayed stuck:

```
Test 1 — null-id worker_done from the owning pane (handle term_worker, pane tab_w:<leafA>):
  RESULT {"action":"ignored"}
  LOGS  ["Worker done: term_worker — Done","Warning: worker_done without taskId from term_worker"]
  TASK STATUS      dispatched
  DISPATCH STATUS  dispatched
  ACTIVE DISPATCH FOR TERMINAL {"id":"ctx_56051c31d7dc","task_id":"task_8d832b696ba8",
     "assignee_handle":"term_worker","assignee_pane_key":"tab_w:1111…","status":"dispatched"}
  -> the fallback data the fix needs (db.getActiveDispatchForTerminal('term_worker')) is present
     and unambiguous, but unused.

Test 2 — byte-identical message WITH {taskId, dispatchId} -> action:'completed', task 'completed'.
```

The fix adds `getSoleActiveDispatchForSender` and gates adoption on `hasLifecycleAuthority`, then pins the behavior with four new reconciliation cases plus an RPC-level case. Full run of both affected suites on this branch:

```
$ npx vitest run --config config/vitest.config.ts \
    src/main/runtime/orchestration/lifecycle-reconciliation.test.ts \
    src/main/runtime/rpc/methods/orchestration.test.ts

 Test Files  2 passed (2)
      Tests  134 passed (134)
   Duration  4.22s
```

New tests cover: completes a null-id `worker_done` from the pane owning the sole dispatch; ignores one from a foreign pane+handle; ignores one when the sender has no active dispatch; ignores one when the sender matches two active dispatches (one by handle, one by pane). The RPC test that previously asserted "does not complete worker_done missing taskId or dispatchId" was split into an assigned-terminal (now completes) and another-terminal (still ignored) case.

## Trade-offs

The change is strictly additive for the previously-working path: every message that completes a task today still completes it. Messages that were `ignored` today either now complete the sender's own sole in-flight dispatch (the intended fix) or stay `ignored` — foreign panes, absent dispatches, and ambiguous multi-dispatch senders are unchanged, and no new `rejected` results or non-zero CLI exits are introduced.

The one honest semantic change: a worker that sends a bare informational `worker_done` while holding exactly one unrelated live dispatch will now auto-complete that dispatch. This is arguably the correct interpretation of "done" from a pane that owns a single job, but it is a behavior change for a worker that used a bare `worker_done` as a non-terminal status ping. Ambiguity is deliberately not guessed: `getSoleActiveDispatchForSender` returns a target only when exactly one active dispatch matches (`matches.length === 1`), so the multi-dispatch race noted during review cannot silently pick an arbitrary row. Legacy dispatch rows with no `assignee_pane_key` still fall back to exact handle equality, so a reminted handle won't resolve — unchanged from today.

## Perf

```json
{"hasRegression":false,"verdict":"0 perf regressions: cold-path orchestration lifecycle-message reconciliation, not a streaming/render path","notes":"The diff only touches orchestration worker_done lifecycle reconciliation (lifecycle-reconciliation.ts + a new db.ts query getSoleActiveDispatchForSender). This code runs in Coordinator.handleLifecycleMessage / RPC reconcile paths, invoked once per agent task-completion message — a very low-frequency coordination event, not a hot path. It is nowhere near onPtyData, the xterm render loop, React list-row render, IPC fanout, polling timers, or FS watchers.\n\nThe one added cost is a new SQL query (SELECT * FROM dispatch_contexts WHERE status IN ('pending','dispatched') then a JS .filter). This query only executes in the fallback branch, i.e. when a worker_done arrives WITHOUT payload taskId/dispatchId — the normal case (both ids present) returns early before any query. Even when it runs, it's a single indexed-status query over the small active-dispatch set, allocating one array of rows per such message. No per-keystroke/per-chunk/per-frame allocations.\n\nNo new intervals, listeners, subprocesses, filesystem watchers, or synchronous startup awaits are introduced; nothing added to first-paint. No React render code touched, so no memo-bailout identity concerns. Net: no arguable perf/battery regression."}
```

## Review

Reviewed by an independent agent for 1 round — final verdict: not-clean (max rounds reached). The principal residual concern raised in review — arbitrary attribution when a sender matches more than one active dispatch — is addressed by `getSoleActiveDispatchForSender` returning `undefined` unless exactly one active dispatch matches; that ambiguous case is covered by a dedicated test.

Closes #7429

Made with [Orca](https://github.com/stablyai/orca) 🐋
