### PR TITLE
feat(editor): add an opt-in editor font family (default: follow terminal font)

### DIFF
--- a/src/renderer/src/components/editor/DiffSectionBody.tsx
+++ b/src/renderer/src/components/editor/DiffSectionBody.tsx
@@ -36,7 +36,7 @@ type DiffSectionBodyProps = {
   isEditable: boolean
   diffEditorFontSize: number
   diffWordWrap?: boolean
-  terminalFontFamily?: string
+  editorFontFamily?: string
   onCancelComment: () => void
   onSubmitComment: (body: string) => Promise<void>
   onRetrySection: (index: number) => void
@@ -61,7 +61,7 @@ export function DiffSectionBody({
   isEditable,
   diffEditorFontSize,
   diffWordWrap,
-  terminalFontFamily,
+  editorFontFamily,
   onCancelComment,
   onSubmitComment,
   onRetrySection,
@@ -191,7 +191,7 @@ export function DiffSectionBody({
             minimap: { enabled: false },
             scrollBeyondLastLine: false,
             fontSize: diffEditorFontSize,
-            fontFamily: terminalFontFamily || 'monospace',
+            fontFamily: editorFontFamily || 'monospace',
             lineNumbers: 'on',
             ...buildDiffEditorWordWrapOptions(diffWordWrap),
             automaticLayout: true,

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -12,7 +12,7 @@ import type { editor as monacoEditor } from 'monaco-editor'
 import { monaco } from '@/lib/monaco-setup'
 import { detectLanguage } from '@/lib/language-detect'
 import { useAppStore } from '@/store'
-import { computeDiffEditorFontSize } from '@/lib/editor-font-zoom'
+import { computeDiffEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
 import { selectWorktreeDiffComments } from '@/store/worktree-diff-comments-selector'
 import {
   useDiffCommentDecorator,
@@ -431,7 +431,7 @@ export function DiffSectionItem({
           isEditable={isEditable}
           diffEditorFontSize={diffEditorFontSize}
           diffWordWrap={settings?.diffWordWrap}
-          terminalFontFamily={settings?.terminalFontFamily}
+          editorFontFamily={resolveEditorFontFamily(settings)}
           onCancelComment={() => setPopover(null)}
           onSubmitComment={handleSubmitComment}
           onRetrySection={retrySection}

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -4,7 +4,7 @@ import type { editor } from 'monaco-editor'
 import { useAppStore } from '@/store'
 import { diffViewStateCache, setWithLRU } from '@/lib/scroll-cache'
 import { monaco } from '@/lib/monaco-setup'
-import { computeDiffEditorFontSize } from '@/lib/editor-font-zoom'
+import { computeDiffEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
 import { useContextualCopySetup } from './useContextualCopySetup'
 import { selectWorktreeDiffComments } from '@/store/worktree-diff-comments-selector'
 import { useDiffCommentDecorator } from '../diff-comments/useDiffCommentDecorator'
@@ -422,7 +422,7 @@ export default function DiffViewer({
               minimap: { enabled: false },
               scrollBeyondLastLine: false,
               fontSize: diffEditorFontSize,
-              fontFamily: settings?.terminalFontFamily || 'monospace',
+              fontFamily: resolveEditorFontFamily(settings),
               lineNumbers: 'on',
               ...buildDiffEditorWordWrapOptions(settings?.diffWordWrap),
               automaticLayout: true,

--- a/src/renderer/src/components/editor/IpynbViewer.tsx
+++ b/src/renderer/src/components/editor/IpynbViewer.tsx
@@ -32,7 +32,11 @@ import {
   Trash2
 } from 'lucide-react'
 import { monaco } from '@/lib/monaco-setup'
-import { computeEditorFontSize } from '@/lib/editor-font-zoom'
+import {
+  computeEditorFontSize,
+  resolveEditorFontFamily,
+  resolveEditorFontFamilyOrInherit
+} from '@/lib/editor-font-zoom'
 import { getConnectionId } from '@/lib/connection-context'
 import { resolveDocumentTheme } from '@/lib/document-theme'
 import { useAppStore } from '@/store'
@@ -409,7 +413,7 @@ function CodeCell({
         onChange={(value) => onChange(value ?? '')}
         options={{
           automaticLayout: true,
-          fontFamily: settings?.terminalFontFamily || 'monospace',
+          fontFamily: resolveEditorFontFamily(settings),
           fontSize,
           glyphMargin: false,
           lineNumbersMinChars: 3,
@@ -874,7 +878,7 @@ export default function IpynbViewer({
     <div
       ref={setRootRef}
       className="h-full min-h-0 overflow-auto bg-editor-surface scrollbar-editor"
-      style={{ fontSize, fontFamily: settings?.terminalFontFamily || undefined }}
+      style={{ fontSize, fontFamily: resolveEditorFontFamilyOrInherit(settings) }}
       onKeyDownCapture={handleNotebookKeyDownCapture}
       onPointerDownCapture={handleNotebookPointerDownCapture}
     >

--- a/src/renderer/src/components/editor/MonacoCodeExcerpt.tsx
+++ b/src/renderer/src/components/editor/MonacoCodeExcerpt.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { monaco } from '@/lib/monaco-setup'
-import { computeEditorFontSize } from '@/lib/editor-font-zoom'
+import { computeEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
 import { resolveDocumentTheme } from '@/lib/document-theme'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
@@ -51,7 +51,7 @@ export default function MonacoCodeExcerpt({
     settings?.terminalFontSize ?? 13,
     editorFontZoomLevel
   )
-  const fontFamily = settings?.terminalFontFamily || 'monospace'
+  const fontFamily = resolveEditorFontFamily(settings)
   const isDark = resolveDocumentTheme(settings?.theme ?? 'system')
   const code = useMemo(() => lines.join('\n'), [lines])
   const [htmlLines, setHtmlLines] = useState<string[]>(() => lines.map(() => ''))

--- a/src/renderer/src/components/editor/MonacoEditor.font-family.test.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.font-family.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const editorProps = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }))
+const storeState = vi.hoisted(() => ({
+  current: {
+    theme: 'dark',
+    terminalFontSize: 13,
+    terminalFontFamily: 'D2Coding Nerd Font Mono',
+    editorFontFamily: ''
+  } as Record<string, unknown>
+}))
+
+vi.mock('@monaco-editor/react', () => ({
+  default: (props: Record<string, unknown>) => {
+    editorProps.current = props
+    return null
+  },
+  loader: { config: vi.fn() }
+}))
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      settings: storeState.current,
+      editorFontZoomLevel: 0,
+      setPendingEditorReveal: vi.fn(),
+      setEditorCursorLine: vi.fn(),
+      addDiffComment: vi.fn(),
+      deleteDiffComment: vi.fn(),
+      updateDiffComment: vi.fn(),
+      scrollToDiffCommentId: null,
+      setScrollToDiffCommentId: vi.fn(),
+      worktreeDiffComments: {}
+    })
+}))
+vi.mock('../diff-comments/useDiffCommentDecorator', () => ({
+  useDiffCommentDecorator: vi.fn()
+}))
+vi.mock('./useContextualCopySetup', () => ({
+  useContextualCopySetup: () => ({ setupCopy: vi.fn(), toastNode: null })
+}))
+
+import MonacoEditor from './MonacoEditor'
+
+function renderEditor(): void {
+  render(
+    <MonacoEditor
+      fileId="file"
+      filePath="/repo/file.py"
+      viewStateKey="pane:file"
+      relativePath="file.py"
+      content="# 한글 주석"
+      language="python"
+      onContentChange={vi.fn()}
+      onSave={vi.fn()}
+      readOnly
+    />
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  editorProps.current = null
+})
+
+describe('MonacoEditor font family', () => {
+  it('follows the terminal font when no editor font override is set', () => {
+    storeState.current = {
+      theme: 'dark',
+      terminalFontSize: 13,
+      terminalFontFamily: 'D2Coding Nerd Font Mono',
+      editorFontFamily: ''
+    }
+    renderEditor()
+    const options = editorProps.current?.options as Record<string, unknown> | undefined
+    expect(options?.fontFamily).toBe('D2Coding Nerd Font Mono')
+  })
+
+  it('uses the opt-in editor font override instead of the terminal font', () => {
+    storeState.current = {
+      theme: 'dark',
+      terminalFontSize: 13,
+      terminalFontFamily: 'D2Coding Nerd Font Mono',
+      editorFontFamily: 'D2Coding Nerd Font'
+    }
+    renderEditor()
+    const options = editorProps.current?.options as Record<string, unknown> | undefined
+    expect(options?.fontFamily).toBe('D2Coding Nerd Font')
+  })
+})

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -8,7 +8,7 @@ import type { MarkdownDocument } from '../../../../shared/types'
 import { useAppStore } from '@/store'
 import { scrollTopCache, cursorPositionCache, setWithLRU } from '@/lib/scroll-cache'
 import '@/lib/monaco-setup'
-import { computeEditorFontSize } from '@/lib/editor-font-zoom'
+import { computeEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
 import { registerFileSearchSelectedTextProvider } from '@/lib/file-search-selection'
 
 import { useContextualCopySetup } from './useContextualCopySetup'
@@ -152,7 +152,7 @@ export default function MonacoEditor({
     settings?.terminalFontSize ?? 13,
     editorFontZoomLevel
   )
-  const editorFontFamily = settings?.terminalFontFamily || 'monospace'
+  const editorFontFamily = resolveEditorFontFamily(settings)
   const editorWordWrap = settings?.editorWordWrap
   const estimatedAutoHeight = useMemo(() => {
     if (!autoHeight) {

--- a/src/renderer/src/components/settings/EditorFontFamilySetting.tsx
+++ b/src/renderer/src/components/settings/EditorFontFamilySetting.tsx
@@ -1,0 +1,56 @@
+import type React from 'react'
+import type { GlobalSettings } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+import { SearchableSetting } from './SearchableSetting'
+import { FontAutocomplete, SettingsRow } from './SettingsFormControls'
+
+type EditorFontFamilySettingProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+  fontSuggestions: string[]
+  onRequestFontSuggestions?: () => void
+}
+
+export function EditorFontFamilySetting({
+  settings,
+  updateSettings,
+  fontSuggestions,
+  onRequestFontSuggestions
+}: EditorFontFamilySettingProps): React.JSX.Element {
+  return (
+    <SearchableSetting
+      title={translate(
+        'auto.components.settings.EditorFontFamilySetting.title',
+        'Editor Font Family'
+      )}
+      description={translate(
+        'auto.components.settings.EditorFontFamilySetting.description',
+        'Font used by file editors and diff views. Leave empty to follow the terminal font.'
+      )}
+      keywords={['editor', 'font', 'typography', 'family', 'code', 'cjk']}
+    >
+      <SettingsRow
+        label={translate(
+          'auto.components.settings.EditorFontFamilySetting.title',
+          'Editor Font Family'
+        )}
+        description={translate(
+          'auto.components.settings.EditorFontFamilySetting.description',
+          'Font used by file editors and diff views. Leave empty to follow the terminal font.'
+        )}
+        control={
+          <FontAutocomplete
+            value={settings.editorFontFamily ?? ''}
+            suggestions={fontSuggestions}
+            onRequestSuggestions={onRequestFontSuggestions}
+            placeholder={translate(
+              'auto.components.settings.EditorFontFamilySetting.placeholder',
+              'Same as terminal font'
+            )}
+            onChange={(value) => updateSettings({ editorFontFamily: value })}
+          />
+        }
+      />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
@@ -18,51 +18,25 @@ import {
 import { translate } from '@/i18n/i18n'
 import { RichMarkdownSpellcheckSetting } from './RichMarkdownSpellcheckSetting'
 import { EditorWordWrapSetting } from './EditorWordWrapSetting'
-
-export type AutoSaveDelayDraftState = {
-  sourceDelayMs: number
-  draft: string
-}
-
-export function createAutoSaveDelayDraftState(
-  editorAutoSaveDelayMs: number
-): AutoSaveDelayDraftState {
-  return {
-    sourceDelayMs: editorAutoSaveDelayMs,
-    draft: String(editorAutoSaveDelayMs)
-  }
-}
-
-function resolveAutoSaveDelayDraftState(
-  state: AutoSaveDelayDraftState,
-  editorAutoSaveDelayMs: number
-): AutoSaveDelayDraftState {
-  return state.sourceDelayMs === editorAutoSaveDelayMs
-    ? state
-    : createAutoSaveDelayDraftState(editorAutoSaveDelayMs)
-}
-
-export function updateAutoSaveDelayDraftState(
-  state: AutoSaveDelayDraftState,
-  editorAutoSaveDelayMs: number,
-  draft: string
-): AutoSaveDelayDraftState {
-  return {
-    // Why: settings persistence is async, so a committed draft must stay tied
-    // to the current source until the persisted value reloads.
-    ...resolveAutoSaveDelayDraftState(state, editorAutoSaveDelayMs),
-    draft
-  }
-}
+import { EditorFontFamilySetting } from './EditorFontFamilySetting'
+import {
+  createAutoSaveDelayDraftState,
+  resolveAutoSaveDelayDraftState,
+  updateAutoSaveDelayDraftState
+} from './auto-save-delay-draft'
 
 type GeneralEditorSettingsSectionProps = {
   settings: GlobalSettings
   updateSettings: (updates: Partial<GlobalSettings>) => void
+  fontSuggestions: string[]
+  onRequestFontSuggestions?: () => void
 }
 
 export function GeneralEditorSettingsSection({
   settings,
-  updateSettings
+  updateSettings,
+  fontSuggestions,
+  onRequestFontSuggestions
 }: GeneralEditorSettingsSectionProps): React.JSX.Element {
   const [autoSaveDelayDraftState, setAutoSaveDelayDraftState] = useState(() =>
     createAutoSaveDelayDraftState(settings.editorAutoSaveDelayMs)
@@ -248,6 +222,13 @@ export function GeneralEditorSettingsSection({
           ]}
         />
       </SearchableSetting>
+
+      <EditorFontFamilySetting
+        settings={settings}
+        updateSettings={updateSettings}
+        fontSuggestions={fontSuggestions}
+        onRequestFontSuggestions={onRequestFontSuggestions}
+      />
 
       <EditorWordWrapSetting settings={settings} updateSettings={updateSettings} />
 

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -28,7 +28,7 @@ export {
   createAutoSaveDelayDraftState,
   updateAutoSaveDelayDraftState,
   type AutoSaveDelayDraftState
-} from './GeneralEditorSettingsSection'
+} from './auto-save-delay-draft'
 export { shouldCommitOpenInApplicationsDraft } from './OpenInMenuSetting'
 
 type GeneralSearchEntry = ReturnType<typeof getGeneralNavigationSearchEntries>[number]
@@ -79,6 +79,8 @@ const EMPTY_WSL_DISTROS: string[] = []
 type GeneralPaneProps = {
   settings: GlobalSettings
   updateSettings: (updates: Partial<GlobalSettings>) => void
+  fontSuggestions: string[]
+  onRequestFontSuggestions?: () => void
   wslSupportedPlatform?: boolean
   wslAvailable?: boolean
   wslDistros?: string[]
@@ -88,6 +90,8 @@ type GeneralPaneProps = {
 export function GeneralPane({
   settings,
   updateSettings,
+  fontSuggestions,
+  onRequestFontSuggestions,
   wslSupportedPlatform,
   wslAvailable,
   wslDistros = EMPTY_WSL_DISTROS,
@@ -177,6 +181,8 @@ export function GeneralPane({
         key="editor"
         settings={settings}
         updateSettings={updateSettings}
+        fontSuggestions={fontSuggestions}
+        onRequestFontSuggestions={onRequestFontSuggestions}
       />
     ) : null,
     matchesSettingsSearch(searchQuery, getGeneralCliSearchEntries()) ? (

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -1290,6 +1290,8 @@ function Settings(): React.JSX.Element {
                     <GeneralPane
                       settings={settings}
                       updateSettings={updateSettings}
+                      fontSuggestions={terminalFontSuggestions}
+                      onRequestFontSuggestions={requestFontSuggestions}
                       wslSupportedPlatform={wslSupportedPlatform}
                       wslAvailable={windowsTerminalCapabilities.wslAvailable}
                       wslDistros={windowsTerminalCapabilities.wslDistros}

--- a/src/renderer/src/components/settings/auto-save-delay-draft.ts
+++ b/src/renderer/src/components/settings/auto-save-delay-draft.ts
@@ -1,0 +1,35 @@
+export type AutoSaveDelayDraftState = {
+  sourceDelayMs: number
+  draft: string
+}
+
+export function createAutoSaveDelayDraftState(
+  editorAutoSaveDelayMs: number
+): AutoSaveDelayDraftState {
+  return {
+    sourceDelayMs: editorAutoSaveDelayMs,
+    draft: String(editorAutoSaveDelayMs)
+  }
+}
+
+export function resolveAutoSaveDelayDraftState(
+  state: AutoSaveDelayDraftState,
+  editorAutoSaveDelayMs: number
+): AutoSaveDelayDraftState {
+  return state.sourceDelayMs === editorAutoSaveDelayMs
+    ? state
+    : createAutoSaveDelayDraftState(editorAutoSaveDelayMs)
+}
+
+export function updateAutoSaveDelayDraftState(
+  state: AutoSaveDelayDraftState,
+  editorAutoSaveDelayMs: number,
+  draft: string
+): AutoSaveDelayDraftState {
+  return {
+    // Why: settings persistence is async, so a committed draft must stay tied
+    // to the current source until the persisted value reloads.
+    ...resolveAutoSaveDelayDraftState(state, editorAutoSaveDelayMs),
+    draft
+  }
+}

--- a/src/renderer/src/components/settings/general-editor-search.ts
+++ b/src/renderer/src/components/settings/general-editor-search.ts
@@ -30,6 +30,21 @@ export const getGeneralEditorSearchEntries = createLocalizedCatalog(() => [
     ]
   },
   {
+    title: translate(
+      'auto.components.settings.general.search.editorFontFamily',
+      'Editor Font Family'
+    ),
+    description: translate(
+      'auto.components.settings.general.search.editorFontFamilyDesc',
+      'Font used by file editors and diff views. Leave empty to follow the terminal font.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.general.search.e1ee631696', 'editor'),
+      ...translateSearchKeyword('auto.components.settings.general.search.editorFontKw', 'font'),
+      ...translateSearchKeyword('auto.components.settings.general.search.3ca5ab78a5', 'code')
+    ]
+  },
+  {
     title: translate('auto.components.settings.general.search.e61157e926', 'Editor Word Wrap'),
     description: translate(
       'auto.components.settings.general.search.005be5c699',

--- a/src/renderer/src/components/settings/setting-labels.ts
+++ b/src/renderer/src/components/settings/setting-labels.ts
@@ -3,6 +3,7 @@ import type { GlobalSettings } from '../../../../shared/types'
 export const SETTING_LABELS: Partial<Record<keyof GlobalSettings, string>> = {
   terminalFontSize: 'Font Size',
   terminalFontFamily: 'Font Family',
+  editorFontFamily: 'Editor Font Family',
   terminalFontWeight: 'Font Weight',
   terminalLineHeight: 'Line Height',
   terminalScrollSensitivity: 'Normal Scroll Speed',

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -7879,7 +7879,9 @@
             "d2d2d929c0": "Rich Markdown Spellcheck",
             "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown.",
             "e61157e926": "Editor Word Wrap",
-            "005be5c699": "Wrap long lines in file editors instead of requiring horizontal scrolling."
+            "005be5c699": "Wrap long lines in file editors instead of requiring horizontal scrolling.",
+            "editorFontFamily": "Editor Font Family",
+            "editorFontFamilyDesc": "Font used by file editors and diff views. Leave empty to follow the terminal font."
           }
         },
         "git": {
@@ -9271,6 +9273,11 @@
         },
         "MobileRelayBetaNotice": {
           "notice": "Orca Relay is in beta."
+        },
+        "EditorFontFamilySetting": {
+          "title": "Editor Font Family",
+          "description": "Font used by file editors and diff views. Leave empty to follow the terminal font.",
+          "placeholder": "Same as terminal font"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -7819,7 +7819,9 @@
             "d2d2d929c0": "Corrector ortográfico de Rich Markdown",
             "4497e2e2bb": "Muestra subrayados y sugerencias ortográficas del navegador al editar Rich Markdown.",
             "e61157e926": "Ajuste de línea en el editor",
-            "005be5c699": "Ajusta las líneas largas en editores de archivos en lugar de requerir desplazamiento horizontal."
+            "005be5c699": "Ajusta las líneas largas en editores de archivos en lugar de requerir desplazamiento horizontal.",
+            "editorFontFamily": "Editor Font Family",
+            "editorFontFamilyDesc": "Font used by file editors and diff views. Leave empty to follow the terminal font."
           }
         },
         "git": {
@@ -9248,6 +9250,11 @@
         },
         "MobileRelayBetaNotice": {
           "notice": "Orca Relay is in beta."
+        },
+        "EditorFontFamilySetting": {
+          "title": "Editor Font Family",
+          "description": "Font used by file editors and diff views. Leave empty to follow the terminal font.",
+          "placeholder": "Same as terminal font"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -7841,7 +7841,9 @@
             "d2d2d929c0": "Rich Markdown Spellcheck",
             "4497e2e2bb": "Show browser spelling underlines and suggestions while editing rich Markdown.",
             "e61157e926": "エディターのワードラップ",
-            "005be5c699": "水平スクロールを使わずに、ファイルエディターで長い行を折り返します。"
+            "005be5c699": "水平スクロールを使わずに、ファイルエディターで長い行を折り返します。",
+            "editorFontFamily": "Editor Font Family",
+            "editorFontFamilyDesc": "Font used by file editors and diff views. Leave empty to follow the terminal font."
           }
         },
         "git": {
@@ -9248,6 +9250,11 @@
         },
         "MobileRelayBetaNotice": {
           "notice": "Orca Relay is in beta."
+        },
+        "EditorFontFamilySetting": {
+          "title": "Editor Font Family",
+          "description": "Font used by file editors and diff views. Leave empty to follow the terminal font.",
+          "placeholder": "Same as terminal font"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -7804,7 +7804,9 @@
             "d2d2d929c0": "리치 Markdown 맞춤법 검사",
             "4497e2e2bb": "리치 Markdown을 편집하는 동안 브라우저 맞춤법 밑줄과 제안을 표시합니다.",
             "e61157e926": "편집기 자동 줄 바꿈",
-            "005be5c699": "가로 스크롤 대신 파일 편집기에서 긴 줄을 자동으로 줄 바꿈합니다."
+            "005be5c699": "가로 스크롤 대신 파일 편집기에서 긴 줄을 자동으로 줄 바꿈합니다.",
+            "editorFontFamily": "Editor Font Family",
+            "editorFontFamilyDesc": "Font used by file editors and diff views. Leave empty to follow the terminal font."
           }
         },
         "git": {
@@ -9248,6 +9250,11 @@
         },
         "MobileRelayBetaNotice": {
           "notice": "Orca Relay is in beta."
+        },
+        "EditorFontFamilySetting": {
+          "title": "Editor Font Family",
+          "description": "Font used by file editors and diff views. Leave empty to follow the terminal font.",
+          "placeholder": "Same as terminal font"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -7804,7 +7804,9 @@
             "d2d2d929c0": "Rich Markdown Spellcheck",
             "4497e2e2bb": "在编辑富 Markdown 时显示浏览器拼写下划线和建议。",
             "e61157e926": "编辑器自动换行",
-            "005be5c699": "在文件编辑器中自动换行长行，而无需水平滚动。"
+            "005be5c699": "在文件编辑器中自动换行长行，而无需水平滚动。",
+            "editorFontFamily": "Editor Font Family",
+            "editorFontFamilyDesc": "Font used by file editors and diff views. Leave empty to follow the terminal font."
           }
         },
         "git": {
@@ -9248,6 +9250,11 @@
         },
         "MobileRelayBetaNotice": {
           "notice": "Orca Relay is in beta."
+        },
+        "EditorFontFamilySetting": {
+          "title": "Editor Font Family",
+          "description": "Font used by file editors and diff views. Leave empty to follow the terminal font.",
+          "placeholder": "Same as terminal font"
         }
       },
       "right": {

--- a/src/renderer/src/lib/editor-font-zoom.test.ts
+++ b/src/renderer/src/lib/editor-font-zoom.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { computeDiffEditorFontSize, computeEditorFontSize } from './editor-font-zoom'
+import {
+  computeDiffEditorFontSize,
+  computeEditorFontSize,
+  resolveEditorFontFamily,
+  resolveEditorFontFamilyOrInherit
+} from './editor-font-zoom'
 
 describe('editor font zoom', () => {
   it('keeps diff editors smaller than regular editor surfaces', () => {
@@ -11,5 +16,53 @@ describe('editor font zoom', () => {
   it('keeps diff editor font size within the editor safety bounds', () => {
     expect(computeDiffEditorFontSize(10, -6)).toBe(8)
     expect(computeDiffEditorFontSize(24, 18)).toBe(32)
+  })
+})
+
+describe('resolveEditorFontFamily', () => {
+  it('follows the terminal font when no editor font is set (byte-identical to legacy behavior)', () => {
+    expect(resolveEditorFontFamily({ terminalFontFamily: 'D2Coding Nerd Font Mono' })).toBe(
+      'D2Coding Nerd Font Mono'
+    )
+  })
+
+  it('treats an empty/whitespace editor font as unset and follows the terminal font', () => {
+    expect(resolveEditorFontFamily({ editorFontFamily: '', terminalFontFamily: 'Menlo' })).toBe(
+      'Menlo'
+    )
+    expect(resolveEditorFontFamily({ editorFontFamily: '   ', terminalFontFamily: 'Menlo' })).toBe(
+      'Menlo'
+    )
+  })
+
+  it('uses the editor font override when the user opts in', () => {
+    expect(
+      resolveEditorFontFamily({ editorFontFamily: 'JetBrains Mono', terminalFontFamily: 'Menlo' })
+    ).toBe('JetBrains Mono')
+  })
+
+  it('falls back to monospace when neither font is set', () => {
+    expect(resolveEditorFontFamily(undefined)).toBe('monospace')
+    expect(resolveEditorFontFamily({})).toBe('monospace')
+  })
+})
+
+describe('resolveEditorFontFamilyOrInherit', () => {
+  it('returns undefined (inherit UI font) when neither font is set', () => {
+    expect(resolveEditorFontFamilyOrInherit({})).toBeUndefined()
+    expect(resolveEditorFontFamilyOrInherit(undefined)).toBeUndefined()
+  })
+
+  it('follows the terminal font when no editor override is set', () => {
+    expect(resolveEditorFontFamilyOrInherit({ terminalFontFamily: 'Menlo' })).toBe('Menlo')
+  })
+
+  it('uses the editor font override when set', () => {
+    expect(
+      resolveEditorFontFamilyOrInherit({
+        editorFontFamily: 'Fira Code',
+        terminalFontFamily: 'Menlo'
+      })
+    ).toBe('Fira Code')
   })
 })

--- a/src/renderer/src/lib/editor-font-zoom.ts
+++ b/src/renderer/src/lib/editor-font-zoom.ts
@@ -30,3 +30,23 @@ export function computeDiffEditorFontSize(baseFontSize: number, zoomLevel: numbe
   // terminal font size makes review views feel oversized relative to app chrome.
   return computeEditorFontSize(baseFontSize - 0.5, zoomLevel)
 }
+
+export type EditorFontFamilySettings = {
+  editorFontFamily?: string
+  terminalFontFamily?: string
+}
+
+/**
+ * Why: the editor font is opt-in and defaults to empty, so an unset value must
+ * keep falling back to the terminal font exactly as before the setting existed.
+ */
+export function resolveEditorFontFamily(settings?: EditorFontFamilySettings | null): string {
+  return settings?.editorFontFamily?.trim() || settings?.terminalFontFamily || 'monospace'
+}
+
+/** Same resolution, but keeps the notebook shell's "no font set → inherit UI font" fallback. */
+export function resolveEditorFontFamilyOrInherit(
+  settings?: EditorFontFamilySettings | null
+): string | undefined {
+  return settings?.editorFontFamily?.trim() || settings?.terminalFontFamily || undefined
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -191,6 +191,8 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     editorAutoSave: false,
     editorAutoSaveDelayMs: DEFAULT_EDITOR_AUTO_SAVE_DELAY_MS,
     editorMinimapEnabled: false,
+    // Why empty: the editor keeps following the terminal font unless the user opts in.
+    editorFontFamily: '',
     editorWordWrap: true,
     richMarkdownSpellcheckEnabled: true,
     markdownReviewToolsEnabled: true,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2598,6 +2598,8 @@ export type GlobalSettings = {
   editorAutoSave: boolean
   editorAutoSaveDelayMs: number
   editorMinimapEnabled: boolean
+  /** Opt-in code-editor font; empty (the default) keeps following `terminalFontFamily`. */
+  editorFontFamily?: string
   /** Defaults on for profiles saved before file-editor wrapping became configurable. */
   editorWordWrap?: boolean
   /** Persisted opt-out for browser spellcheck noise in rich Markdown editing surfaces. */


### PR DESCRIPTION
## What
On Monaco-based editor surfaces (file editor, diffs, notebook cells, code excerpts) the font was hard-wired to the **terminal** font. Users who set their terminal font to a Nerd Font "Mono" variant saw CJK/Hangul text overlap in the editor: the `--mono` patch clamps every glyph advance to a single cell, so wide glyphs (ink ~2 cells) advance only 1 cell and pile up on top of each other. The terminal itself stayed correct because it sizes cells from Unicode tables, not font advances. There was no way to give the editor its own font.

## Why it happened
`MonacoEditor.tsx:155` did `const editorFontFamily = settings?.terminalFontFamily || 'monospace'` and fed it straight into Monaco (`updateOptions` at `:718`, options at `:836`). The same terminal-font reuse existed in `DiffViewer.tsx:425`, `IpynbViewer.tsx:412`/`:877`, `MonacoCodeExcerpt.tsx:54`, and `DiffSectionBody.tsx:194` (from `DiffSectionItem.tsx:434`). No `editorFontFamily` setting existed anywhere — `types.ts:2597-2618` and `constants.ts:190-203` declared only `appFontFamily` and `terminalFontFamily` — so the editor could not be given a different font.

## ELI5
The code editor was borrowing the font you picked for your terminal. Some of those fonts are specially squished so every character takes exactly one column — which looks fine in a terminal but makes Chinese, Japanese, and Korean letters crash into each other in the editor. This adds a separate "editor font" setting; leave it blank and nothing changes, or set it to a normal font to fix the overlap.

## Evidence
Independent metric check of the Nerd-Fonts "Mono" patch (fontTools 4.61.1, upm=1950) confirms the advance-clamping that causes the overlap:

```
FiraCodeNerdFont-Regular      U+F08C6  advance 1200  xMax 1790  (ink overflows one cell)
FiraCodeNerdFontMono-Regular  U+F08C6  advance 1200  xMax 1200  (clamped to one cell)
```

The editor and terminal are on different rendering paths — the terminal never uses font advances:

```
$ grep -rn "editorFontFamily" src   # before: only the local const in MonacoEditor.tsx
$ grep -n fontFamily src/renderer/src/components/editor/MarkdownPreview.tsx   # no hits — Markdown view is immune
```

The fix introduces a pure resolver and a new opt-in setting (default empty), plus tests. New `MonacoEditor.font-family.test.tsx` (91 lines) and expanded `editor-font-zoom.test.ts` assert that with `editorFontFamily` unset the resolver returns the byte-identical terminal-font string, and that a set value is honoured:

```
$ git diff origin/main...HEAD --stat
 23 files changed, 361 insertions(+), 58 deletions(-)
 ... MonacoEditor.font-family.test.tsx | 91 +++++++++++++
 ... lib/editor-font-zoom.ts           | 20 +++++
 ... settings/EditorFontFamilySetting.tsx | 56 +++++++++
```

The notebook shell's inherit-UI-font branch (`IpynbViewer.tsx:877`, previously falling back to `undefined` rather than `monospace`) is preserved via a dedicated `resolveEditorFontFamilyOrInherit`.

## Trade-offs
**Zero user-visible regressions.** The new `editorFontFamily` setting defaults to empty, and `resolveEditorFontFamily(settings)` returns `editorFontFamily?.trim() || terminalFontFamily || 'monospace'` — the identical string as before for anyone who does not set it. Per the repro's risk notes, the fix deliberately does **not** route the editor through `buildFontFamily()` (which would append the Nerd-Font/PUA fallback chain and change glyph rendering for every existing user), and preserves the notebook inherit-font branch.

## Perf
> {"hasRegression":false,"verdict":"0 perf regressions: pure-function font resolver swapped into existing Monaco option objects","notes":"The diff adds an opt-in `editorFontFamily` setting. Hot-path touch points (DiffViewer, DiffSectionBody/Item, IpynbViewer CodeCell, MonacoCodeExcerpt, MonacoEditor) only replace `settings?.terminalFontFamily || 'monospace'` with `resolveEditorFontFamily(settings)` — a trivial pure function (`editorFontFamily?.trim() || terminalFontFamily || 'monospace'`) returning a string primitive. It's placed inside Monaco options objects that were already reconstructed every render, so no new object/array/function identity is introduced that would break downstream memo bail-out; the returned value is a stable string. The only per-render allocation is `.trim()` on a short string, and only when the font is set (negligible, and Monaco option-object construction dominates anyway). No changes to onPtyData, xterm render loop, IPC fanout, polling, or fs watchers. No new intervals/listeners/subprocesses/sync-I-O, so no cleanup concerns. New settings-pane files (EditorFontFamilySetting.tsx, auto-save-delay-draft.ts, general-editor-search.ts) run only on the settings screen, a cold path. constants.ts/types.ts add a default-empty field. No added awaits on the startup/first-paint path."}

## Review
Reviewed by an independent agent for 1 round — final verdict: CLEAN.

Closes #9628

Made with [Orca](https://github.com/stablyai/orca) 🐋
