### PR TITLE
fix(terminal): restore clickable link hover after returning to the Orca window

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
@@ -28,9 +28,11 @@ vi.mock('./terminal-webgl-atlas-recovery', () => ({
   scheduleTabRevealWebglAtlasRecovery: () => scheduleTabRevealWebglAtlasRecovery()
 }))
 const resetTerminalLinkifierHoverState = vi.fn()
+const isTerminalLinkifierHoverActive = vi.fn((_terminal: unknown) => false)
 vi.mock('@/lib/pane-manager/terminal-linkifier-hover-reset', () => ({
   resetTerminalLinkifierHoverState: (terminal: unknown) =>
-    resetTerminalLinkifierHoverState(terminal)
+    resetTerminalLinkifierHoverState(terminal),
+  isTerminalLinkifierHoverActive: (terminal: unknown) => isTerminalLinkifierHoverActive(terminal)
 }))
 
 type FakeManager = {
@@ -113,6 +115,37 @@ describe('resumeTerminalVisibility reveal repaint', () => {
     resumeTerminalVisibility(resumeArgs(manager, false))
 
     expect(order).toEqual(['resume-rendering', 'reveal-repaint'])
+  })
+
+  it('resets each pane linkifier hover cache on window wake recovery so links recover without a scroll', () => {
+    const first = { name: 'pane-a' }
+    const second = { name: 'pane-b' }
+    const manager = createManager()
+    manager.getPanes.mockReturnValue([{ terminal: first }, { terminal: second }])
+
+    recoverVisibleTerminalWindowWake({
+      manager: manager as never as PaneManager,
+      isActive: true,
+      clearGlyphAtlases: false
+    })
+
+    expect(resetTerminalLinkifierHoverState).toHaveBeenCalledWith(first)
+    expect(resetTerminalLinkifierHoverState).toHaveBeenCalledWith(second)
+  })
+
+  it('keeps a genuinely-hovered link intact on window wake recovery', () => {
+    const hovered = { name: 'hovered-pane' }
+    const manager = createManager()
+    manager.getPanes.mockReturnValue([{ terminal: hovered }])
+    isTerminalLinkifierHoverActive.mockReturnValueOnce(true)
+
+    recoverVisibleTerminalWindowWake({
+      manager: manager as never as PaneManager,
+      isActive: true,
+      clearGlyphAtlases: false
+    })
+
+    expect(resetTerminalLinkifierHoverState).not.toHaveBeenCalled()
   })
 
   it('schedules the atlas-clearing repaint on genuine wake recovery', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -9,7 +9,10 @@ import {
   enforceTerminalCurrentScrollIntent,
   syncTerminalScrollIntentFromViewport
 } from '@/lib/pane-manager/terminal-scroll-intent'
-import { resetTerminalLinkifierHoverState } from '@/lib/pane-manager/terminal-linkifier-hover-reset'
+import {
+  isTerminalLinkifierHoverActive,
+  resetTerminalLinkifierHoverState
+} from '@/lib/pane-manager/terminal-linkifier-hover-reset'
 import { fitAndFocusPanes, fitPanes, focusActivePane } from './pane-helpers'
 import { scheduleTabRevealWebglAtlasRecovery } from './terminal-webgl-atlas-recovery'
 
@@ -143,6 +146,13 @@ export function recoverVisibleTerminalWindowWake({
   for (const pane of manager.getPanes()) {
     requestTerminalBacklogRecovery(pane.terminal)
     flushTerminalOutput(pane.terminal, { maxChars: WINDOW_WAKE_FLUSH_CHARS })
+    // Why: window blur fires mouseleave, clearing xterm's current link but not
+    // its hover cell cache; on refocus the stationary pointer sits on the same
+    // cell, so the link stays dead until a scroll. Skip while a link is hovered
+    // to avoid flickering its underline (same guard as the on-write reset).
+    if (!isTerminalLinkifierHoverActive(pane.terminal)) {
+      resetTerminalLinkifierHoverState(pane.terminal)
+    }
   }
   syncTerminalViewportIntents(manager)
   manager.resumeRendering()


### PR DESCRIPTION
## What

When you Cmd+click a link in an Orca terminal, the browser window opens on top of Orca. On returning to Orca — without moving the mouse — the link under the pointer went dead: it lost its underline and pointer cursor and rendered as plain text, and hover-dependent links (OSC‑8 hyperlinks with a label, file-path links, `term_*` handles) stopped activating on click. It stayed broken until you scrolled the buffer or dragged the pointer into a different cell. This restores the clickable-link hover affordance the instant you refocus the Orca window.

## Why it happened

xterm's `Linkifier` only re-runs link providers on `mousemove` when the hovered cell differs from its cached `_lastBufferCell` (`node_modules/@xterm/xterm/src/browser/Linkifier.ts:83-86`). On window blur, macOS fires `mouseleave`, which clears `_currentLink` but leaves that cell cache intact (`Linkifier.ts:51-54`). Orca already invalidates that cache on tab/worktree reveal (PR #9061) and on streamed output (PR #9320), but the window-blur/refocus path — `recoverVisibleTerminalWindowWake` in `src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts:146`, driven by the `focus`/`visibilitychange` listeners in `use-terminal-window-wake-recovery.ts:85-100` — never did. So on return with a stationary pointer, the same cell short-circuits, `_currentLink` stays null, and the link is dead until a scroll.

## ELI5

The terminal only re-checks "is my mouse on a link?" when the mouse moves to a new spot. When a link opens a browser window and you click back to Orca without moving the mouse, the terminal thinks nothing changed and forgets the link is there. This nudge tells the terminal to re-check the moment you come back.

## Evidence

The one-line fix, inside the existing per-pane loop of `recoverVisibleTerminalWindowWake`:

```ts
// Why: window blur fires mouseleave, clearing xterm's current link but not
// its hover cell cache; on refocus the stationary pointer sits on the same
// cell, so the link stays dead until a scroll. Skip while a link is hovered
// to avoid flickering its underline (same guard as the on-write reset).
if (!isTerminalLinkifierHoverActive(pane.terminal)) {
  resetTerminalLinkifierHoverState(pane.terminal)
}
```

`grep` proves the asymmetry that caused the bug — before this change, `resetTerminalLinkifierHoverState` had exactly two non-test call sites: the reveal path (`terminal-visibility-resume.ts:62`) and the streamed-output path (`terminal-linkifier-hover-reset-on-write.ts:49`); nothing in the focus path.

New tests assert both the fix and its guard, alongside the pre-existing reveal coverage:

```
✓ ... resets each pane linkifier hover cache on window wake recovery so links recover without a scroll 7ms
✓ ... keeps a genuinely-hovered link intact on window wake recovery 0ms

 Test Files  1 passed (1)
      Tests  9 passed (9)
```

## Trade-offs

**Zero user-visible regressions.** The reset only writes `_lastBufferCell = undefined` / `_activeLine = -1` — it never clears `_currentLink`, so nothing changes on screen until the user's next mousemove re-queries providers; and the `isTerminalLinkifierHoverActive` guard skips the reset while a link is genuinely hovered, so a real underline/tooltip never flickers.

## Perf

> {"hasRegression":false,"verdict":"no regression","notes":"The diff adds a hover-active guard + linkifier hover-cache reset per pane inside recoverVisibleTerminalWindowWake (src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts). This function runs only on window/display wake and refocus, not on any hot path (onPtyData, xterm render loop, list-row render, IPC fanout, timers, fs watchers). Both isTerminalLinkifierHoverActive and resetTerminalLinkifierHoverState are constant-time reads/writes of xterm _core.linkifier internal fields with no allocations, no I/O, no subprocess, no new listeners/intervals, and no added awaits. Pane counts are small and the loop already does heavier work (backlog recovery, output flush). No React render-identity concerns (plain module functions). Negligible cost."}

## Review

Reviewed by an independent agent for 2 round(s) — final verdict: CLEAN.

Closes #9116

Made with [Orca](https://github.com/stablyai/orca) 🐋
