### PR TITLE
fix(terminal): stop advertising the unimplemented Bold Text color override

### DIFF
--- a/src/main/ghostty/mapper-extended.test.ts
+++ b/src/main/ghostty/mapper-extended.test.ts
@@ -200,15 +200,15 @@ describe('mapGhosttyToOrca — cursor-text', () => {
 })
 
 describe('mapGhosttyToOrca — bold-color', () => {
-  it('maps valid hex to terminalColorOverrides.bold', () => {
+  // Why: xterm.js ITheme has no bold color slot (xtermjs/xterm.js#6032), so bold-color can never
+  // render; the importer must list it as unsupported rather than claim it was applied (#8595).
+  it('reports valid bold-color as unsupported and does not apply it', () => {
     const result = mapGhosttyToOrca({ 'bold-color': '#ff0000' })
-    expect(result.diff).toEqual({
-      terminalColorOverrides: { bold: '#ff0000' }
-    })
-    expect(result.unsupportedKeys).toEqual([])
+    expect(result.diff).toEqual({})
+    expect(result.unsupportedKeys).toEqual(['bold-color'])
   })
 
-  it('rejects invalid bold-color', () => {
+  it('reports invalid bold-color as unsupported', () => {
     const result = mapGhosttyToOrca({ 'bold-color': 'red' })
     expect(result.diff).toEqual({})
     expect(result.unsupportedKeys).toEqual(['bold-color'])

--- a/src/main/ghostty/mapper.ts
+++ b/src/main/ghostty/mapper.ts
@@ -199,13 +199,6 @@ export function mapGhosttyToOrca(
       return { colorOverrides: { cursorAccent: normalizeHex(v) } }
     },
 
-    'bold-color': (v) => {
-      if (!HEX_COLOR_RE.test(v)) {
-        return null
-      }
-      return { colorOverrides: { bold: normalizeHex(v) } }
-    },
-
     'mouse-hide-while-typing': (v) => {
       if (v !== 'true' && v !== 'false') {
         return null
@@ -285,6 +278,13 @@ export function mapGhosttyToOrca(
     // Passing the same string inverts the semantics, and correctly inverting a
     // character set is non-trivial. Treat as unsupported to avoid silent misbehavior.
     if (key === 'selection-word-chars') {
+      unsupportedKeys.push(key)
+      continue
+    }
+
+    // Why: xterm.js ITheme has no bold color slot (xtermjs/xterm.js#6032), so importing
+    // bold-color would render as a no-op; report it as unsupported instead of silently dropping.
+    if (key === 'bold-color') {
       unsupportedKeys.push(key)
       continue
     }

--- a/src/renderer/src/components/settings/terminal-window-color-groups.tsx
+++ b/src/renderer/src/components/settings/terminal-window-color-groups.tsx
@@ -103,9 +103,11 @@ export const COLOR_OVERRIDE_GROUPS: {
           return translate('auto.components.settings.TerminalWindowSection.862e463f7f', 'Bold Text')
         },
         get description() {
+          // Why: xterm.js ITheme has no bold color slot (xtermjs/xterm.js#6032); the value is
+          // preserved but the terminal renderer does not apply it yet. Keep the copy honest.
           return translate(
-            'auto.components.settings.TerminalWindowSection.fb8c6f1967',
-            'Color for bold text. Falls back to the normal color if not set.'
+            'auto.components.settings.TerminalWindowSection.605a35d600',
+            'Not applied by the terminal renderer yet — xterm.js has no bold color slot. A saved value is preserved.'
           )
         }
       }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -7046,7 +7046,6 @@
           "cf4437a2f7": "ANSI black color",
           "adfdee23cb": "Black",
           "68e9f07de0": "ANSI Normal",
-          "fb8c6f1967": "Color for bold text. Falls back to the normal color if not set.",
           "862e463f7f": "Bold Text",
           "b2c0857c49": "Text color of selected text",
           "8b450b5305": "Selection Foreground",
@@ -7062,7 +7061,8 @@
           "79f6bfb76e": "Foreground",
           "cf37ff69f6": "Base",
           "8abdab9f7c": "Restart now",
-          "907131d741": "Restarting…"
+          "907131d741": "Restarting…",
+          "605a35d600": "Not applied by the terminal renderer yet — xterm.js has no bold color slot. A saved value is preserved."
         },
         "UIZoomControl": {
           "c2c64b24d0": "Reset"

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -6986,7 +6986,6 @@
           "cf4437a2f7": "Color negro ANSI",
           "adfdee23cb": "Negro",
           "68e9f07de0": "ANSI normal",
-          "fb8c6f1967": "Color para texto en negrita. Vuelve al color normal si no se establece.",
           "862e463f7f": "Texto en negrita",
           "b2c0857c49": "Color del texto seleccionado",
           "8b450b5305": "Primer plano de selección",
@@ -7002,7 +7001,8 @@
           "79f6bfb76e": "Primer plano",
           "cf37ff69f6": "Base",
           "8abdab9f7c": "Reiniciar ahora",
-          "907131d741": "Reiniciando…"
+          "907131d741": "Reiniciando…",
+          "605a35d600": "Not applied by the terminal renderer yet — xterm.js has no bold color slot. A saved value is preserved."
         },
         "UIZoomControl": {
           "c2c64b24d0": "Restablecer"

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -7008,7 +7008,6 @@
           "cf4437a2f7": "ANSI黒色",
           "adfdee23cb": "黒",
           "68e9f07de0": "ANSI標準",
-          "fb8c6f1967": "太字のテキストの色。設定されていない場合は、通常の色に戻ります。",
           "862e463f7f": "太字のテキスト",
           "b2c0857c49": "選択したテキストの文字色",
           "8b450b5305": "選択範囲の前景",
@@ -7024,7 +7023,8 @@
           "79f6bfb76e": "前景",
           "cf37ff69f6": "ベース",
           "8abdab9f7c": "今すぐ再起動",
-          "907131d741": "再起動中…"
+          "907131d741": "再起動中…",
+          "605a35d600": "Not applied by the terminal renderer yet — xterm.js has no bold color slot. A saved value is preserved."
         },
         "UIZoomControl": {
           "c2c64b24d0": "リセット"

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -6971,7 +6971,6 @@
           "cf4437a2f7": "ANSI 블랙 컬러",
           "adfdee23cb": "검은색",
           "68e9f07de0": "ANSI 일반",
-          "fb8c6f1967": "굵은 텍스트의 색상입니다. 설정하지 않으면 일반 색상으로 돌아갑니다.",
           "862e463f7f": "굵은 글씨",
           "b2c0857c49": "선택한 텍스트의 텍스트 색상",
           "8b450b5305": "선택 전경",
@@ -6987,7 +6986,8 @@
           "79f6bfb76e": "전경",
           "cf37ff69f6": "베이스",
           "8abdab9f7c": "지금 재시작",
-          "907131d741": "다시 시작하는 중…"
+          "907131d741": "다시 시작하는 중…",
+          "605a35d600": "Not applied by the terminal renderer yet — xterm.js has no bold color slot. A saved value is preserved."
         },
         "UIZoomControl": {
           "c2c64b24d0": "재설정"

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -6971,7 +6971,6 @@
           "cf4437a2f7": "ANSI 黑色",
           "adfdee23cb": "黑色的",
           "68e9f07de0": "ANSI 标准",
-          "fb8c6f1967": "粗体文本的颜色。如果未设置，则返回正常颜色。",
           "862e463f7f": "粗体文字",
           "b2c0857c49": "所选文本的文本颜色",
           "8b450b5305": "选择前景",
@@ -6987,7 +6986,8 @@
           "79f6bfb76e": "前景",
           "cf37ff69f6": "根据",
           "8abdab9f7c": "立即重启",
-          "907131d741": "正在重新启动..."
+          "907131d741": "正在重新启动...",
+          "605a35d600": "Not applied by the terminal renderer yet — xterm.js has no bold color slot. A saved value is preserved."
         },
         "UIZoomControl": {
           "c2c64b24d0": "重置"


### PR DESCRIPTION
## What

Orca's Terminal color settings offered a "Bold Text" color override (described as "Color for bold text. Falls back to the normal color if not set."), and the Ghostty config importer reported `bold-color` as a successfully applied mapping. But setting a bold color never did anything: bold text kept rendering in the normal foreground color. This change makes both surfaces honest — the Settings field now says the value isn't applied by the renderer (though a saved value is preserved), and a Ghostty import that contains `bold-color` now lists that key as unsupported instead of silently claiming success. No terminal rendering behavior changes.

## Why it happened

`composeActiveTerminalTheme` spreads the whole `settings.terminalColorOverrides` object — including `bold` — into the xterm `ITheme` at `src/renderer/src/components/terminal-pane/terminal-appearance.ts:118-120`, and hands it to `terminal.options.theme`. But xterm's `ITheme` has no `bold` slot: `ThemeService._setTheme` enumerates each theme color by name (foreground, background, cursor, ansi[0..15], extendedAnsi) and never reads a `bold` key, so the value is silently dropped (upstream xtermjs/xterm.js#6032). Neither the DOM renderer nor the WebGL addon has a bold-color path either — a bold cell with default fg falls through to `colors.foreground`. Yet the Settings field at `src/renderer/src/components/settings/terminal-window-color-groups.tsx:103-110` and the importer's supported-handler map at `src/main/ghostty/mapper.ts:202-206` both advertised it as applied. The `bold?: string` type is even documented as an xterm-unsupported passthrough at `src/shared/types.ts:2504-2507`.

## ELI5

Orca had a button that said "make bold text this color," but the terminal it talks to has no such knob, so pressing the button did nothing. We weren't allowed to add the knob (it lives in a library Orca doesn't control), so instead we stopped pretending the button works. Now the setting tells you the truth, and importing that option from Ghostty says "not supported" instead of "done!"

## Evidence

Before the fix, the setting appeared to apply but didn't render. Two screenshots capture this (files exist for a human to drag into this PR):

- `/tmp/bb720/shots/8595-setting-applied.png` — the Terminal settings panel with the "Bold Text" color override set to `#ff0000` (bright red), showing the field accepting and persisting the value with its old "Falls back to the normal color if not set." description.
- `/tmp/bb720/shots/8595-terminal.png` — a live terminal pane immediately after, where bold text still renders in the normal white foreground color, not red — proving the override is a no-op in the actual renderer.

The importer test now asserts the honest behavior — valid and invalid `bold-color` are both reported unsupported, and nothing is written to `terminalColorOverrides`:

```
✓ mapGhosttyToOrca — bold-color > reports valid bold-color as unsupported and does not apply it 1ms
✓ mapGhosttyToOrca — bold-color > reports invalid bold-color as unsupported 0ms

 Test Files  1 passed (1)
      Tests  43 passed (43)
```

The importer no longer maps the key into a color override; it pushes it onto `unsupportedKeys` instead:

```ts
// Why: xterm.js ITheme has no bold color slot (xtermjs/xterm.js#6032), so importing
// bold-color would render as a no-op; report it as unsupported instead of silently dropping.
if (key === 'bold-color') {
  unsupportedKeys.push(key)
  continue
}
```

And the Settings description is now truthful:

```ts
'Not applied by the terminal renderer yet — xterm.js has no bold color slot. A saved value is preserved.'
```

## Trade-offs

A user who previously set a Bold Text color keeps that value persisted, but the Settings field now tells them it isn't rendered, and a Ghostty import containing `bold-color` now lists it under "not applied" instead of appearing to succeed. That is the intended correction — replacing a silent no-op with an honest one — not a regression: no terminal rendering changes, so **Zero user-visible regressions** in any terminal pane. The only alternative (patching xterm to add a bold slot) was deferred upstream and would need re-verification against `minimumContrastRatio`.

## Perf

> {"hasRegression":false,"verdict":"no perf regression","notes":"The diff for #8595 is limited to: (1) src/main/ghostty/mapper.ts — moves `bold-color` handling from a color-override mapping to pushing it onto `unsupportedKeys`. This runs only during an explicit one-time Ghostty config import, not on any streaming/render/IPC hot path; it removes work rather than adding it. (2) src/renderer/src/components/settings/terminal-window-color-groups.tsx — swaps a static translated description string in a settings-panel getter (rendered only when the Terminal settings section is open, not in the sidebar/terminal render loop). (3) Locale JSON key rename and a test file update. No new per-keystroke/per-chunk/per-frame allocations, no timers, subprocess spawns, fs watchers, or uncleaned listeners, no new render-created React identities that would break memoization, and no added awaits delaying first paint."}

## Review

Reviewed by an independent agent for 1 round — final verdict: CLEAN.

Closes #8595

Made with [Orca](https://github.com/stablyai/orca) 🐋
