### PR TITLE
fix(status): gate sleeping worktrees on live PTYs

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -23988,6 +23988,229 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('does not treat a saved tab PTY id as liveness after sleep', async () => {
+    const session = makeWorkspaceSessionWithHeadlessTerminal()
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
+      ...session,
+      terminalLayoutsByTabId: {
+        'host-tab': makeHeadlessTerminalLayout({})
+      }
+    })
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    const { worktrees } = await runtime.getWorktreePs()
+
+    expect(worktrees[0]).toMatchObject({
+      worktreeId: TEST_WORKTREE_ID,
+      hasHostSidebarActivity: false,
+      hasAttachedPty: false,
+      liveTerminalCount: 0,
+      status: 'inactive'
+    })
+  })
+
+  it('does not count a connected provider PTY without current tab or pane ownership', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: vi.fn(() => true),
+      kill: vi.fn(() => true),
+      getForegroundProcess: vi.fn(async () => 'powershell.exe'),
+      listProcesses: vi.fn(async () => [
+        {
+          id: `${TEST_WORKTREE_ID}@@orphan-after-sleep`,
+          cwd: TEST_REPO_PATH,
+          title: 'powershell.exe'
+        }
+      ])
+    })
+
+    const { worktrees } = await runtime.getWorktreePs()
+
+    expect(worktrees[0]).toMatchObject({
+      worktreeId: TEST_WORKTREE_ID,
+      hasHostSidebarActivity: false,
+      hasAttachedPty: false,
+      liveTerminalCount: 0,
+      status: 'inactive'
+    })
+  })
+
+  it('counts a live background PTY with explicit spawn-time pane ownership before persistence', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const ptyId = `${TEST_WORKTREE_ID}@@background-before-reveal`
+    runtime.registerPty(ptyId, TEST_WORKTREE_ID, null, {
+      tabId: 'background-tab',
+      leafId: HEADLESS_LEAF_ID
+    })
+    runtime.setPtyController({
+      write: vi.fn(() => true),
+      kill: vi.fn(() => true),
+      getForegroundProcess: vi.fn(async () => 'agent.exe'),
+      listProcesses: vi.fn(async () => [{ id: ptyId, cwd: TEST_REPO_PATH, title: 'agent' }])
+    })
+
+    const { worktrees } = await runtime.getWorktreePs()
+
+    expect(worktrees[0]).toMatchObject({
+      worktreeId: TEST_WORKTREE_ID,
+      hasHostSidebarActivity: true,
+      hasAttachedPty: true,
+      liveTerminalCount: 1,
+      status: 'active'
+    })
+  })
+
+  it('accepts explicit spawn-time ownership while a saved tab layout is still absent', async () => {
+    const session = makeWorkspaceSessionWithHeadlessTerminal({ terminalLayoutsByTabId: {} })
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(session)
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.registerPty('persisted-pty', TEST_WORKTREE_ID, null, {
+      tabId: 'host-tab',
+      leafId: HEADLESS_LEAF_ID
+    })
+    runtime.setPtyController({
+      write: vi.fn(() => true),
+      kill: vi.fn(() => true),
+      getForegroundProcess: vi.fn(async () => 'agent.exe'),
+      listProcesses: vi.fn(async () => [
+        { id: 'persisted-pty', cwd: TEST_REPO_PATH, title: 'agent' }
+      ])
+    })
+
+    const { worktrees } = await runtime.getWorktreePs()
+
+    expect(worktrees[0]).toMatchObject({
+      hasHostSidebarActivity: true,
+      hasAttachedPty: true,
+      liveTerminalCount: 1,
+      status: 'active'
+    })
+  })
+
+  it('keeps persisted PTY ownership while a reconnect snapshot is missing its tab row', async () => {
+    const session = makeWorkspaceSessionWithHeadlessTerminal({ tabsByWorktree: {} })
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(session)
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.registerPty('persisted-pty', TEST_WORKTREE_ID, 'ssh-reconnect', {
+      tabId: 'host-tab',
+      leafId: HEADLESS_LEAF_ID
+    })
+    runtime.setPtyController({
+      write: vi.fn(() => true),
+      kill: vi.fn(() => true),
+      getForegroundProcess: vi.fn(async () => 'agent.exe'),
+      listProcesses: vi.fn(async () => [
+        { id: 'persisted-pty', cwd: TEST_WORKTREE_PATH, title: 'agent' }
+      ])
+    })
+
+    const { worktrees } = await runtime.getWorktreePs()
+
+    expect(worktrees[0]).toMatchObject({
+      worktreeId: TEST_WORKTREE_ID,
+      hasHostSidebarActivity: true,
+      hasAttachedPty: true,
+      liveTerminalCount: 1,
+      status: 'active'
+    })
+  })
+
+  it('rejects an explicit runtime binding once an empty persisted layout proves sleep', async () => {
+    const session = makeWorkspaceSessionWithHeadlessTerminal()
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
+      ...session,
+      terminalLayoutsByTabId: { 'host-tab': makeHeadlessTerminalLayout({}) }
+    })
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    const ptyId = `${TEST_WORKTREE_ID}@@failed-reattach`
+    runtime.registerPty(ptyId, TEST_WORKTREE_ID, null, {
+      tabId: 'host-tab',
+      leafId: HEADLESS_LEAF_ID
+    })
+    runtime.setPtyController({
+      write: vi.fn(() => true),
+      kill: vi.fn(() => true),
+      getForegroundProcess: vi.fn(async () => 'powershell.exe'),
+      listProcesses: vi.fn(async () => [{ id: ptyId, cwd: TEST_REPO_PATH, title: 'powershell' }])
+    })
+
+    const { worktrees } = await runtime.getWorktreePs()
+
+    expect(worktrees[0]).toMatchObject({
+      hasHostSidebarActivity: false,
+      hasAttachedPty: false,
+      liveTerminalCount: 0,
+      status: 'inactive'
+    })
+  })
+
+  it('updates multi-pane remote liveness immediately across sleep and wake', async () => {
+    const secondLeafId = '44444444-4444-4444-8444-444444444444'
+    const session = makeWorkspaceSessionWithHeadlessTerminal({
+      terminalLayoutsByTabId: {
+        'host-tab': makeHeadlessTerminalLayout({
+          [HEADLESS_LEAF_ID]: 'remote-pty-1',
+          [secondLeafId]: 'remote-pty-2'
+        })
+      }
+    })
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(session)
+    const setWorkspaceSession = runtimeStore.setWorkspaceSession as unknown as (
+      next: WorkspaceSessionState
+    ) => void
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.setPtyController({
+      write: vi.fn(() => true),
+      kill: vi.fn(() => true),
+      getForegroundProcess: vi.fn(async () => 'agent.exe'),
+      listProcesses: vi.fn(async () => [
+        { id: 'remote-pty-1', cwd: '', title: 'agent' },
+        { id: 'remote-pty-2', cwd: '', title: 'agent' }
+      ])
+    })
+
+    await expect(runtime.getWorktreePs()).resolves.toMatchObject({
+      worktrees: [
+        expect.objectContaining({
+          hasHostSidebarActivity: true,
+          hasAttachedPty: true,
+          liveTerminalCount: 2
+        })
+      ]
+    })
+
+    setWorkspaceSession({
+      ...session,
+      terminalLayoutsByTabId: { 'host-tab': makeHeadlessTerminalLayout({}) }
+    })
+    await expect(runtime.getWorktreePs()).resolves.toMatchObject({
+      worktrees: [
+        expect.objectContaining({
+          hasHostSidebarActivity: false,
+          hasAttachedPty: false,
+          liveTerminalCount: 0,
+          status: 'inactive'
+        })
+      ]
+    })
+
+    setWorkspaceSession({
+      ...session,
+      terminalLayoutsByTabId: {
+        'host-tab': makeHeadlessTerminalLayout({ [secondLeafId]: 'remote-pty-2' })
+      }
+    })
+    await expect(runtime.getWorktreePs()).resolves.toMatchObject({
+      worktrees: [
+        expect.objectContaining({
+          hasHostSidebarActivity: true,
+          hasAttachedPty: true,
+          liveTerminalCount: 1
+        })
+      ]
+    })
+  })
+
   it('attributes live legacy PTYs from saved layout bindings when their panes are hidden', async () => {
     const session = makeWorkspaceSessionWithHeadlessTerminal()
     const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
@@ -24052,7 +24275,7 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
-  it('preserves deferred startup activity before restored terminal panes mount', async () => {
+  it('does not treat deferred startup reattach hints as live before a PTY is restored', async () => {
     const session = makeWorkspaceSessionWithHeadlessTerminal({
       activeWorktreeIdsOnShutdown: [TEST_WORKTREE_ID]
     })
@@ -24069,7 +24292,10 @@ describe('OrcaRuntimeService', () => {
 
     expect(worktrees[0]).toMatchObject({
       worktreeId: TEST_WORKTREE_ID,
-      hasHostSidebarActivity: true
+      hasHostSidebarActivity: false,
+      hasAttachedPty: false,
+      liveTerminalCount: 0,
+      status: 'inactive'
     })
   })
 
@@ -24419,7 +24645,9 @@ describe('OrcaRuntimeService', () => {
     ['blocked', 0, true, 'permission'],
     ['waiting', 0, true, 'permission'],
     ['done', 0, false, 'inactive'],
-    ['working', -AGENT_STATUS_STALE_AFTER_MS - 1, false, 'inactive']
+    ['working', -AGENT_STATUS_STALE_AFTER_MS - 1, false, 'inactive'],
+    ['waiting', -AGENT_STATUS_STALE_AFTER_MS - 1, false, 'inactive'],
+    ['done', -AGENT_STATUS_STALE_AFTER_MS - 1, false, 'inactive']
   ] as const)(
     'projects %s agent activity to mobile at freshness offset %s',
     async (state, updatedAtOffset, hasHostSidebarActivity, status) => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -12485,7 +12485,25 @@ export class OrcaRuntimeService {
     )
     const missingRuntimeWorktreeIds = new Set<string>()
     const countedPtyIds = new Set<string>()
+    const session = this.store?.getWorkspaceSession?.()
+    const savedTabOwnerById = new Map<string, { worktreeId: string; title: string }>()
+    for (const [worktreeId, tabs] of Object.entries(session?.tabsByWorktree ?? {})) {
+      for (const tab of tabs) {
+        savedTabOwnerById.set(tab.id, { worktreeId, title: tab.title })
+      }
+    }
+    const savedLayoutTabIdByPtyId = new Map<string, string>()
+    for (const [tabId, layout] of Object.entries(session?.terminalLayoutsByTabId ?? {})) {
+      for (const ptyId of Object.values(layout?.ptyIdsByLeafId ?? {})) {
+        if (ptyId) {
+          savedLayoutTabIdByPtyId.set(ptyId, tabId)
+        }
+      }
+    }
     for (const leaf of this.leaves.values()) {
+      if (!leaf.ptyId || !leaf.connected) {
+        continue
+      }
       const summary = this.getSummaryForRuntimeWorktreeId(
         summaries,
         runtimeWorktreeSummaryPathIndex,
@@ -12495,15 +12513,11 @@ export class OrcaRuntimeService {
       if (!summary) {
         continue
       }
-      if (leaf.ptyId) {
-        countedPtyIds.add(leaf.ptyId)
-      }
-      if (leaf.ptyId && leaf.connected) {
-        summary.hasHostSidebarActivity = true
-      }
+      countedPtyIds.add(leaf.ptyId)
+      summary.hasHostSidebarActivity = true
       const previousLastOutputAt = summary.lastOutputAt
       summary.liveTerminalCount += 1
-      summary.hasAttachedPty = summary.hasAttachedPty || leaf.connected
+      summary.hasAttachedPty = true
       summary.lastOutputAt = maxTimestamp(summary.lastOutputAt, leaf.lastOutputAt)
       summary.status = mergeWorktreeStatus(
         summary.status,
@@ -12521,11 +12535,40 @@ export class OrcaRuntimeService {
       if (!pty.connected || countedPtyIds.has(pty.ptyId)) {
         continue
       }
+      const persistedTabId = savedLayoutTabIdByPtyId.get(pty.ptyId)
+      const persistedOwner = persistedTabId
+        ? (savedTabOwnerById.get(persistedTabId) ??
+          (pty.tabId === persistedTabId
+            ? {
+                worktreeId: pty.worktreeId,
+                title: getLatestPtyTitle(pty) ?? ''
+              }
+            : undefined))
+        : undefined
+      const parsedPaneKey = parsePaneKey(pty.paneKey ?? '')
+      const hasExplicitRuntimeOwner =
+        pty.tabId !== null && parsedPaneKey?.tabId === pty.tabId && parsedPaneKey.leafId.length > 0
+      const savedTabOwner = pty.tabId ? savedTabOwnerById.get(pty.tabId) : undefined
+      const hasSavedLayout =
+        pty.tabId !== null && Object.hasOwn(session?.terminalLayoutsByTabId ?? {}, pty.tabId)
+      const runtimeOwner =
+        hasExplicitRuntimeOwner && !hasSavedLayout
+          ? {
+              worktreeId: savedTabOwner?.worktreeId ?? pty.worktreeId,
+              title: savedTabOwner?.title ?? getLatestPtyTitle(pty) ?? ''
+            }
+          : undefined
+      const owner = persistedOwner ?? runtimeOwner
+      if (!owner) {
+        // Why: provider existence is not ownership; sleep can leave a process
+        // record after a persisted layout has dropped every live pane binding.
+        continue
+      }
       const summary = this.getSummaryForRuntimeWorktreeId(
         summaries,
         runtimeWorktreeSummaryPathIndex,
         missingRuntimeWorktreeIds,
-        pty.worktreeId
+        owner.worktreeId
       )
       if (!summary) {
         continue
@@ -12535,55 +12578,15 @@ export class OrcaRuntimeService {
       summary.hasAttachedPty = true
       summary.hasHostSidebarActivity = true
       summary.lastOutputAt = maxTimestamp(summary.lastOutputAt, pty.lastOutputAt)
-      summary.status = mergeWorktreeStatus(summary.status, 'active')
+      summary.status = mergeWorktreeStatus(
+        summary.status,
+        getSavedTabWorktreeStatus(owner.title, true)
+      )
       if (
         pty.preview &&
         (summary.preview.length === 0 || (pty.lastOutputAt ?? -1) >= (previousLastOutputAt ?? -1))
       ) {
         summary.preview = pty.preview
-      }
-    }
-
-    const session = this.store?.getWorkspaceSession?.()
-    for (const worktreeId of session?.activeWorktreeIdsOnShutdown ?? []) {
-      const summary = this.getSummaryForRuntimeWorktreeId(
-        summaries,
-        runtimeWorktreeSummaryPathIndex,
-        missingRuntimeWorktreeIds,
-        worktreeId
-      )
-      if (summary) {
-        // Why: desktop advertises deferred reattach ids as live before their
-        // panes mount; mobile must preserve the same startup activity view.
-        summary.hasHostSidebarActivity = true
-      }
-    }
-    for (const [worktreeId, tabs] of Object.entries(session?.tabsByWorktree ?? {})) {
-      if (tabs.length === 0) {
-        continue
-      }
-      const summary = this.getSummaryForRuntimeWorktreeId(
-        summaries,
-        runtimeWorktreeSummaryPathIndex,
-        missingRuntimeWorktreeIds,
-        worktreeId
-      )
-      if (!summary) {
-        continue
-      }
-      // Why: desktop can show terminal tabs that are not mounted as renderer
-      // leaves and are not currently visible in the PTY provider list. Mobile
-      // still needs those worktrees to show as terminal-bearing entries.
-      summary.liveTerminalCount = Math.max(summary.liveTerminalCount, tabs.length)
-      summary.hasAttachedPty = summary.hasAttachedPty || tabs.some((tab) => tab.ptyId !== null)
-      if (tabs.some((tab) => tab.ptyId !== null && this.ptysById.get(tab.ptyId)?.connected)) {
-        summary.hasHostSidebarActivity = true
-      }
-      for (const tab of tabs) {
-        summary.status = mergeWorktreeStatus(
-          summary.status,
-          getSavedTabWorktreeStatus(tab.title, tab.ptyId !== null)
-        )
       }
     }
 

--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.test.tsx
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.test.tsx
@@ -345,8 +345,9 @@ describe('useWorktreeActivityStatus', () => {
     expect(renderToStaticMarkup(<StatusProbe worktreeId={firstWorktreeId} />)).toBe(
       '<span>working</span>'
     )
+    // Why: retained completion is scoped here, but no live PTY means the card must agree with Hide sleeping.
     expect(renderToStaticMarkup(<StatusProbe worktreeId={secondWorktreeId} />)).toBe(
-      '<span>done</span>'
+      '<span>inactive</span>'
     )
   })
 })

--- a/src/renderer/src/lib/worktree-status.test.ts
+++ b/src/renderer/src/lib/worktree-status.test.ts
@@ -156,7 +156,7 @@ describe('resolveWorktreeStatus', () => {
     expect(status).toBe('inactive')
   })
 
-  it('promotes to done when a retained done row is visible, even without a live pty', () => {
+  it('keeps a sleeping worktree inactive when only a retained done row survives', () => {
     const status = resolveWorktreeStatus({
       tabs: [{ id: 'tab-1', title: 'bash' }],
       browserTabs: [],
@@ -167,7 +167,55 @@ describe('resolveWorktreeStatus', () => {
       hasRetainedDone: true
     })
 
-    expect(status).toBe('done')
+    expect(status).toBe('inactive')
+  })
+
+  it('keeps a sleeping worktree inactive when a fresh done row outlives its PTY', () => {
+    const status = resolveWorktreeStatus({
+      tabs: [{ id: 'tab-1', title: 'agent [done]' }],
+      browserTabs: [],
+      ptyIdsByTabId: { 'tab-1': [] },
+      hasPermission: false,
+      hasLiveWorking: false,
+      hasLiveDone: true,
+      hasRetainedDone: false
+    })
+
+    expect(status).toBe('inactive')
+  })
+
+  it('keeps an empty remote session snapshot inactive when a retained done row survives', () => {
+    const status = resolveWorktreeStatus({
+      tabs: [],
+      browserTabs: [],
+      ptyIdsByTabId: {},
+      agentStatusPaneIdsByTabId: {
+        'removed-tab': new Set(['removed-pane'])
+      },
+      hasPermission: false,
+      hasLiveWorking: false,
+      hasLiveDone: false,
+      hasRetainedDone: true
+    })
+
+    expect(status).toBe('inactive')
+  })
+
+  it('drops and restores done immediately across sleep and wake without freshness expiry', () => {
+    const args = {
+      tabs: [{ id: 'tab-1', title: 'agent [done]' }],
+      browserTabs: [],
+      hasPermission: false,
+      hasLiveWorking: false,
+      hasLiveDone: true,
+      hasRetainedDone: true
+    }
+
+    expect(resolveWorktreeStatus({ ...args, ptyIdsByTabId: livePtyMap('tab-1') })).toBe('done')
+    expect(resolveWorktreeStatus({ ...args, ptyIdsByTabId: { 'tab-1': [] } })).toBe('inactive')
+    expect(resolveWorktreeStatus({ ...args, ptyIdsByTabId: { 'tab-1': ['reattached-pty'] } })).toBe(
+      'done'
+    )
   })
 
   it('treats pending paired web host terminal mirrors as inactive without a live pty', () => {

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -102,7 +102,8 @@ export function getWorktreeStatusLabel(status: WorktreeStatus): string {
 /**
  * Apply the WorktreeCard priority overlay (permission > working > done >
  * heuristic) on top of the title-heuristic base. Explicit agent rows may
- * promote the dot; sleep cleanup owns removing stale retained rows.
+ * promote the dot while current workspace liveness owns whether completion can
+ * appear on the card.
  *
  * Map args are narrowed to this worktree. `hasPermission`/`hasLiveWorking`/
  * `hasLiveDone` are fresh hook entries ({blocked,waiting} / {working} / {done});
@@ -143,7 +144,9 @@ export function resolveWorktreeStatus(args: {
   if (args.hasLiveWorking || heuristic === 'working') {
     return 'working'
   }
-  if (args.hasLiveDone || args.hasRetainedDone) {
+  // Why: retained/fresh done rows can outlive sleep; the same live PTY/browser
+  // contract that drives Hide sleeping must gate the card's green status.
+  if ((args.hasLiveDone || args.hasRetainedDone) && heuristic !== 'inactive') {
     return 'done'
   }
   return heuristic


### PR DESCRIPTION
## Summary

- fix sleeping worktree cards that stayed green when retained/fresh `done` metadata outlived every live PTY
- make remote `worktree.ps` liveness depend on connected runtime leaves or PTYs with current persisted/explicit pane ownership, not saved wake hints, shutdown hints, or unowned provider records
- keep the sidebar, Hide sleeping, paired desktop clients, and mobile/web runtime projection on the same live-PTY/browser contract

Deterministic reproduction: after sleep, the runtime graph had no connected leaves, the live PTY layout was empty, and retained `done` rows remained. Hide sleeping correctly classified the worktree inactive, while `resolveWorktreeStatus` promoted the retained row to green `done`. Both Windows and paired macOS showed the same wrong dot because they consumed the same runtime-owned state.

## Screenshots

Not included. This removes an incorrect transient/persisted status dot; deterministic store/runtime tests cover the exact state transitions without relying on screenshots.

## Testing

- [x] `pnpm lint` — full CI lint passed
- [x] `pnpm typecheck`
- [x] `pnpm test` — full CI test suite passed
- [x] `pnpm build` — unpacked-app build and packaged CLI smoke passed in CI
- [x] Added or updated high-quality tests that catch the regression

Validation on current `main`:

- 818 focused tests passed across `orca-runtime`, `worktree-status`, and `use-worktree-activity-status`; one unrelated known Windows path fixture was excluded by test name
- changed-file `oxfmt --check` and `oxlint` passed
- all three TypeScript configurations passed
- 44 reliability gates passed
- max-lines ratchet passed with no new bypasses
- `git diff --check` passed

Coverage includes empty versus absent live-PTY layouts, saved PTY/session wake hints, unowned provider records, connected graph leaves, explicit pre-persistence ownership, layout-before-tab reconnect ordering, multi-pane sleep/wake, failed reattach, true live background PTYs, stale done/waiting/working rows, browser activity, and immediate sleep/wake transitions without TTL expiry or sleeps.

## AI Review Report

The requested internal review skill is not installed in this Windows session, so four manual merge-base-anchored adversarial rounds checked:

1. Scope: the final commit changes only five sleeping-status/runtime-liveness files; all Codex finality, Stop handling, spinner, reduced-motion, relay, and unrelated markdown changes were removed.
2. Semantics: compared Hide sleeping, `resolveWorktreeStatus`, StatusIndicator inputs, `worktree.ps`, and the live-PTY invariant from #1603. Retained/fresh completion can no longer promote an otherwise sleeping card.
3. Remote ownership: checked current-main runtime graph/session changes, reconnect ordering, stale provider samples, persisted layouts, explicit spawn-time bindings, multiple panes, browser-only activity, and paired clients consuming the same state.
4. Performance/elegance: verified linear indexing only when `worktree.ps` runs, no per-card timers or render-loop work, clean formatting/types/lint/gates, and no provider-specific behavior.

Cross-platform review covered macOS, Linux, Windows, local, SSH, WSL, paired runtimes, and mobile/web projections. No shortcuts, labels, filesystem paths, shell behavior, or platform-specific Electron behavior changed.

## Security Audit

- no dependencies, auth flows, secrets, IPC methods, shell commands, Git commands, or external process execution were added
- runtime-owned PTY identifiers are only used for in-memory ownership/liveness attribution
- no new untrusted input reaches command execution or filesystem APIs

No security follow-up is required.

## Notes

- This PR intentionally does not change reduced-motion spinner behavior or Codex intermediate-Stop/finality behavior; those can be revisited separately.
- Strict ownership can briefly report inactive for malformed legacy snapshots that have neither a persisted layout binding nor an explicit runtime pane binding. Normal reconnect and pre-persistence orderings have dedicated fallbacks and tests.
- The added `worktree.ps` indexing is O(tabs + layout PTYs + live PTYs). A synthetic Windows run over 1,000 tabs and 4,000 PTYs measured about 0.275 ms per call; it is not a renderer hot path.

