### PR TITLE
fix(editor): make Cmd+Shift+O (Open Markdown) work in the main window

### DIFF
--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -36,12 +36,14 @@ type RegisterAppHandlersOptions = {
   onBeforeRelaunch?: () => void | Promise<void>
 }
 
-async function pickFloatingMarkdownDocument(
-  event: IpcMainInvokeEvent
+// Why: the dialog runs on the LOCAL machine; callers must only pass a rootPath for LOCAL worktrees (remote/SSH roots would mis-root the result). See issue #8532.
+async function pickMarkdownDocument(
+  event: IpcMainInvokeEvent,
+  rootPath?: string
 ): Promise<MarkdownDocument | null> {
-  const cwd = await ensureDefaultFloatingWorkspacePath()
+  const root = rootPath?.trim() ? rootPath : await ensureDefaultFloatingWorkspacePath()
   const options = {
-    defaultPath: cwd,
+    defaultPath: root,
     properties: ['openFile'],
     filters: [{ name: 'Markdown', extensions: ['md', 'mdx', 'markdown'] }]
   } satisfies Electron.OpenDialogOptions
@@ -57,7 +59,7 @@ async function pickFloatingMarkdownDocument(
     throw new Error('Selected file is not a markdown document.')
   }
   authorizeExternalPath(filePath)
-  return markdownDocumentFromFilePath(cwd, filePath, { outsideRootRelativePath: 'basename' })
+  return markdownDocumentFromFilePath(root, filePath, { outsideRootRelativePath: 'basename' })
 }
 
 async function pickFloatingWorkspaceDirectory(
@@ -309,7 +311,12 @@ export function registerAppHandlers(store: Store, options: RegisterAppHandlersOp
 
   ipcMain.handle('app:getFloatingMarkdownDirectory', () => ensureDefaultFloatingWorkspacePath())
 
-  ipcMain.handle('app:pickFloatingMarkdownDocument', (event) => pickFloatingMarkdownDocument(event))
+  ipcMain.handle('app:pickMarkdownDocument', (event, rootPath?: string) =>
+    pickMarkdownDocument(event, rootPath)
+  )
+
+  // Why: kept as an alias so the Floating Terminal picker keeps working unchanged.
+  ipcMain.handle('app:pickFloatingMarkdownDocument', (event) => pickMarkdownDocument(event))
 
   ipcMain.handle('app:pickFloatingWorkspaceDirectory', (event) =>
     pickFloatingWorkspaceDirectory(event, store)

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -942,6 +942,10 @@ export type AppApi = {
   /** Resolves Orca's app-owned directory for auto-created Floating Workspace
    *  markdown notes. */
   getFloatingMarkdownDirectory: () => Promise<string>
+  /** Opens a native picker for markdown documents rooted at `rootPath` (a LOCAL
+   *  worktree root; omit for the floating workspace) and authorizes the selected
+   *  file for editor reads/writes. */
+  pickMarkdownDocument: (rootPath?: string) => Promise<MarkdownDocument | null>
   /** Opens a native picker for markdown documents, rooted in the floating
    *  workspace, and authorizes the selected file for editor reads/writes. */
   pickFloatingMarkdownDocument: () => Promise<MarkdownDocument | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -458,6 +458,8 @@ const api = {
       ipcRenderer.invoke('app:getFloatingTerminalCwd', args),
     getFloatingMarkdownDirectory: (): Promise<string> =>
       ipcRenderer.invoke('app:getFloatingMarkdownDirectory'),
+    pickMarkdownDocument: (rootPath?: string): Promise<MarkdownDocument | null> =>
+      ipcRenderer.invoke('app:pickMarkdownDocument', rootPath),
     pickFloatingMarkdownDocument: (): Promise<MarkdownDocument | null> =>
       ipcRenderer.invoke('app:pickFloatingMarkdownDocument'),
     pickFloatingWorkspaceDirectory: (): Promise<string | null> =>

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -133,7 +133,11 @@ import { useContextualTour } from './contextual-tours/use-contextual-tour'
 import { openTabBarEntry, type TabCreateEntryArgs } from './tab-bar/tab-create-entry-action'
 import { closeTerminalTab } from './terminal/terminal-tab-actions'
 import { translate } from '@/i18n/i18n'
-import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import {
+  getExecutionHostIdForWorktree,
+  getRuntimeEnvironmentIdForWorktree
+} from '@/lib/worktree-runtime-owner'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../shared/execution-host'
 import { getResolvedExecutionHostIdForWorktree } from '@/lib/resolved-worktree-execution-host'
 import { browserWorkspaceHasRemoteOwner } from '@/runtime/remote-browser-tab-ownership'
 
@@ -305,6 +309,11 @@ function Terminal(): React.JSX.Element | null {
     (s) => s.openNewBrowserTabInActiveWorkspace
   )
   const openNewMarkdownInActiveWorkspace = useAppStore((s) => s.openNewMarkdownInActiveWorkspace)
+  const openMarkdownFileInActiveWorkspace = useAppStore((s) => s.openMarkdownFileInActiveWorkspace)
+  // Why: the native open picker runs locally, so the "Open Markdown" action is only offered for LOCAL worktrees (issue #8532).
+  const activeWorktreeIsLocal = useAppStore(
+    (s) => getExecutionHostIdForWorktree(s, s.activeWorktreeId) === LOCAL_EXECUTION_HOST_ID
+  )
   const openNewTerminalTabInActiveWorkspace = useAppStore(
     (s) => s.openNewTerminalTabInActiveWorkspace
   )
@@ -1329,6 +1338,20 @@ function Terminal(): React.JSX.Element | null {
     await openNewMarkdownInActiveWorkspace(targetGroupId)
   }, [activeWorktreeId, openNewMarkdownInActiveWorkspace])
 
+  const handleOpenFile = useCallback(async () => {
+    if (!activeWorktreeId) {
+      return
+    }
+    const targetGroupId =
+      useAppStore.getState().activeGroupIdByWorktree[activeWorktreeId] ??
+      useAppStore.getState().groupsByWorktree[activeWorktreeId]?.[0]?.id
+    if (!targetGroupId) {
+      return
+    }
+    // Why: the store action re-checks locality, so a rebound shortcut on a remote worktree safely no-ops.
+    await openMarkdownFileInActiveWorkspace(targetGroupId)
+  }, [activeWorktreeId, openMarkdownFileInActiveWorkspace])
+
   const handleCloseTab = useCallback((tabId: string) => {
     closeTerminalTab(tabId)
   }, [])
@@ -1767,6 +1790,21 @@ function Terminal(): React.JSX.Element | null {
         return
       }
 
+      // Cmd/Ctrl+Shift+O - open an existing markdown file (issue #8532).
+      // Why: the floating panel's own handler calls stopImmediatePropagation, so this window
+      // listener can't double-fire when the floating panel owns focus; guard anyway.
+      // Why: gate on locality so we don't swallow/notify the key on remote worktrees where the
+      // native picker no-ops — keeps the shortcut consistent with the (also local-only) menu item.
+      if (!e.repeat && activeWorktreeIsLocal && matchShortcut('tab.openMarkdown')) {
+        e.preventDefault()
+        notifyTerminalCapture('tab.openMarkdown')
+        if (floatingWorkspaceFocused) {
+          return
+        }
+        void handleOpenFile()
+        return
+      }
+
       if (handleEmptyFloatingWorkspacePanelCloseShortcut(e, shortcutPlatform, keybindings)) {
         return
       }
@@ -1875,9 +1913,11 @@ function Terminal(): React.JSX.Element | null {
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
   }, [
     activeWorktreeId,
+    activeWorktreeIsLocal,
     handleNewBrowserTab,
     handleNewSimulatorTab,
     handleNewFile,
+    handleOpenFile,
     handleNewTab,
     handleNewAgentTab,
     handleCloseTab,
@@ -2019,6 +2059,7 @@ function Terminal(): React.JSX.Element | null {
             onNewSimulatorTab={mobileEmulatorEnabled ? handleNewSimulatorTab : undefined}
             onOpenEntry={handleOpenEntry}
             onNewFileTab={handleNewFile}
+            onOpenFileTab={activeWorktreeIsLocal ? handleOpenFile : undefined}
             onSetCustomTitle={setTabCustomTitle}
             onSetTabColor={setTabColor}
             expandedPaneByTabId={expandedPaneByTabId}

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -111,6 +111,7 @@ export default function TabGroupPanel({
       onNewSimulatorTab={commands.newSimulatorTab}
       onOpenEntry={commands.openEntry}
       onNewFileTab={commands.newFileTab}
+      onOpenFileTab={commands.openFileTab}
       onSetCustomTitle={commands.setTabCustomTitle}
       onSetTabColor={commands.setTabColor}
       onTogglePaneExpand={commands.toggleTerminalPaneExpand}

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -26,7 +26,11 @@ import { openTabBarEntry, type TabCreateEntryArgs } from '../tab-bar/tab-create-
 import { openMobileEmulatorTab } from '@/lib/open-mobile-emulator-tab'
 import { ensureSimulatorTab, getSimulatorTabForWorktree } from '@/lib/ensure-simulator-tab'
 import { buildDuplicatedBrowserTabOptions } from '@/lib/duplicate-browser-tab-options'
-import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import {
+  getExecutionHostIdForWorktree,
+  getRuntimeEnvironmentIdForWorktree
+} from '@/lib/worktree-runtime-owner'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
 import { browserWorkspaceHasRemoteOwner } from '@/runtime/remote-browser-tab-ownership'
 
 export function recordTerminalTabGroupSplit(createdTerminal: TerminalTab | null | undefined): void {
@@ -86,6 +90,13 @@ export function useTabGroupWorkspaceModel({
   )
   const openNewMarkdownInActiveWorkspace = useAppStore(
     (state) => state.openNewMarkdownInActiveWorkspace
+  )
+  const openMarkdownFileInActiveWorkspace = useAppStore(
+    (state) => state.openMarkdownFileInActiveWorkspace
+  )
+  // Why: the native open picker runs locally, so "Open Markdown" is only offered for LOCAL worktrees (issue #8532).
+  const worktreeIsLocal = useAppStore(
+    (state) => getExecutionHostIdForWorktree(state, worktreeId) === LOCAL_EXECUTION_HOST_ID
   )
   const openNewTerminalTabInActiveWorkspace = useAppStore(
     (state) => state.openNewTerminalTabInActiveWorkspace
@@ -609,6 +620,12 @@ export function useTabGroupWorkspaceModel({
       newFileTab: async () => {
         await openNewMarkdownInActiveWorkspace(groupId)
       },
+      // Why: undefined for remote worktrees hides the "Open Markdown" menu item (local-only native picker, issue #8532).
+      openFileTab: worktreeIsLocal
+        ? async () => {
+            await openMarkdownFileInActiveWorkspace(groupId)
+          }
+        : undefined,
       newTerminalTab: () => {
         void openNewTerminalTabInActiveWorkspace(groupId)
       },

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -4870,3 +4870,75 @@ describe('read-only editor tabs (AI Vault View Log)', () => {
     expect(store.getState().editorDrafts[LOG_PATH]).toBeUndefined()
   })
 })
+
+describe('openMarkdownFileInActiveWorkspace — main-window open markdown (issue #8532)', () => {
+  const pickMarkdownDocumentMock = vi.fn()
+
+  function createOpenMarkdownStore(options?: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    repos?: any[]
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    worktreesByRepo?: Record<string, any[]>
+  }): StoreApi<AppState> {
+    const repos = options?.repos ?? [{ id: 'repo-1', path: '/repo' }]
+    const worktreesByRepo = options?.worktreesByRepo ?? {
+      'repo-1': [{ id: 'wt-1', repoId: 'repo-1', path: '/repo' }]
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return createStore<any>()((...args: any[]) => ({
+      activeWorktreeId: 'wt-1',
+      repos,
+      worktreesByRepo,
+      folderWorkspaces: [],
+      projectGroups: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getKnownWorktreeById: (id: string) =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        Object.values(worktreesByRepo)
+          .flat()
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .find((wt: any) => wt.id === id) ?? null,
+      recordFeatureInteraction: vi.fn(),
+      ...createEditorSlice(...(args as Parameters<typeof createEditorSlice>))
+    })) as unknown as StoreApi<AppState>
+  }
+
+  beforeEach(() => {
+    pickMarkdownDocumentMock.mockReset()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(globalThis as any).window = (globalThis as any).window ?? {}
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(globalThis as any).window.api = { app: { pickMarkdownDocument: pickMarkdownDocumentMock } }
+  })
+
+  it('opens a picked markdown file into the active LOCAL worktree, rooted at the worktree path', async () => {
+    const store = createOpenMarkdownStore()
+    pickMarkdownDocumentMock.mockResolvedValue({
+      filePath: '/repo/docs/notes.md',
+      relativePath: 'docs/notes.md',
+      basename: 'notes.md',
+      name: 'notes'
+    })
+
+    await store.getState().openMarkdownFileInActiveWorkspace('wt-1:group')
+
+    // Native picker must be rooted at the worktree path, not the floating workspace.
+    expect(pickMarkdownDocumentMock).toHaveBeenCalledWith('/repo')
+    const opened = store.getState().openFiles.find((f) => f.filePath === '/repo/docs/notes.md')
+    expect(opened).toBeDefined()
+    expect(opened?.worktreeId).toBe('wt-1')
+    expect(opened?.mode).toBe('edit')
+  })
+
+  it('no-ops for a remote/SSH worktree without invoking the local picker', async () => {
+    const store = createOpenMarkdownStore({
+      repos: [{ id: 'repo-1', path: '/repo', connectionId: 'ssh-host-1' }],
+      worktreesByRepo: { 'repo-1': [{ id: 'wt-1', repoId: 'repo-1', path: '/remote/repo' }] }
+    })
+
+    await store.getState().openMarkdownFileInActiveWorkspace('wt-1:group')
+
+    expect(pickMarkdownDocumentMock).not.toHaveBeenCalled()
+    expect(store.getState().openFiles).toHaveLength(0)
+  })
+})

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -64,7 +64,11 @@ import {
 import { settingsForRuntimeOwner } from '@/runtime/runtime-rpc-client'
 import { notifyHostOfMirroredEditorClose } from '@/runtime/close-mirrored-editor-tab'
 import { findWorktreeById, getRepoIdFromWorktreeId } from './worktree-helpers'
-import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import {
+  getExecutionHostIdForWorktree,
+  getExplicitRuntimeEnvironmentIdForWorktree
+} from '@/lib/worktree-runtime-owner'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
 import {
   addAdditionalValidWorkspaceKeys,
   type WorkspaceSessionHydrationOptions
@@ -431,6 +435,9 @@ export type EditorSlice = {
     }
   ) => void
   openNewMarkdownInActiveWorkspace: (groupId: string) => Promise<void>
+  /** Opens a markdown file via the native picker into the active worktree.
+   *  No-ops for remote/SSH/runtime worktrees (the local dialog can't reach them). */
+  openMarkdownFileInActiveWorkspace: (groupId: string) => Promise<void>
   // Why: sequences openFile/setMarkdownViewMode/reveal around an async Monaco remount. See docs/markdown-internal-link-opening-design.md.
   activateMarkdownLink: (
     rawHref: string | undefined,
@@ -1775,6 +1782,41 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       get().recordFeatureInteraction('markdown-file-created')
     } catch (err) {
       toast.error(extractIpcErrorMessage(err, 'Failed to create untitled markdown file.'))
+    }
+  },
+
+  openMarkdownFileInActiveWorkspace: async (groupId) => {
+    const state = get()
+    const worktreeId = state.activeWorktreeId
+    if (!worktreeId) {
+      return
+    }
+    // Why: the native open dialog runs on the LOCAL machine, so a remote/SSH/runtime worktree must not receive a local file path (issue #8532).
+    if (getExecutionHostIdForWorktree(state, worktreeId) !== LOCAL_EXECUTION_HOST_ID) {
+      return
+    }
+    const worktree = state.getKnownWorktreeById(worktreeId)
+    if (!worktree) {
+      return
+    }
+    try {
+      const document = await window.api.app.pickMarkdownDocument(worktree.path)
+      if (!document) {
+        return
+      }
+      get().openFile(
+        {
+          filePath: document.filePath,
+          relativePath: document.relativePath,
+          worktreeId,
+          language: detectLanguage(document.relativePath),
+          mode: 'edit',
+          runtimeEnvironmentId: null
+        },
+        { preview: false, targetGroupId: groupId }
+      )
+    } catch (err) {
+      toast.error(extractIpcErrorMessage(err, 'Failed to open markdown file.'))
     }
   },
 

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -511,6 +511,7 @@ function createWebPreloadApi(): Partial<PreloadApi> {
       setUnreadDockBadgeCount: () => Promise.resolve(),
       getFloatingTerminalCwd: () => Promise.resolve(''),
       getFloatingMarkdownDirectory: () => Promise.resolve(''),
+      pickMarkdownDocument: () => Promise.resolve(null),
       pickFloatingMarkdownDocument: () => Promise.resolve(null),
       pickFloatingWorkspaceDirectory: () => Promise.resolve(null),
       // Browser fallback has no app-owned userData dir; reject so the sentinel can't claim sensitive evidence was persisted.


### PR DESCRIPTION
## What

In the main window, pressing `Cmd+Shift+O` (macOS) / `Ctrl+Shift+O` (Linux/Windows) — the shortcut labeled "Open Markdown..." in Settings → Shortcuts — did nothing. The action was declared globally and shown in the shortcuts list, but only the Floating Terminal panel actually handled it, so from a normal worktree the key was a no-op and there was no menu entry to trigger it either. This PR wires the action into the main window: the shortcut and the "+" tab menu now open a native file picker (rooted at the active worktree) and load the chosen markdown file into the current tab group. To match the picker's local-only nature, the action is offered only for LOCAL worktrees.

## Why it happened

`tab.openMarkdown` is declared globally (`src/shared/keybindings.ts:575`) and listed unconditionally in Settings via `settings/shortcut-groups.ts:23`, but its only consumer was the Floating Terminal panel's React `onKeyDown` handler (`FloatingTerminalPanel.tsx:1021`). The main-window window-level keydown handler in `Terminal.tsx` handled siblings like `tab.newMarkdown` (`Terminal.tsx:1750`) but had **no** `tab.openMarkdown` branch, `App.tsx` had none, and the main-process `before-input-event` path never mapped it. The UI had the same gap: the only provider of `onOpenFileTab` was `FloatingTerminalPanel.tsx:1516`, so the main-window tab strips never rendered the "Open Markdown..." item. That asymmetry is exactly why `Cmd+Shift+M` (new markdown) worked in the main window and `Cmd+Shift+O` did not.

## ELI5

There was a menu button and a keyboard shortcut for "open a markdown file," but in the main window nobody was listening, so nothing happened when you used them. They only worked in the small floating terminal window. This change makes the main window listen too, and pop up the normal "choose a file" box.

## Evidence

New tests exercise the store action for both the local (works) and remote (safely no-ops) paths:

```
✓ editor.test.ts > openMarkdownFileInActiveWorkspace — main-window open markdown (issue #8532) > opens a picked markdown file into the active LOCAL worktree, rooted at the worktree path 3ms
✓ editor.test.ts > openMarkdownFileInActiveWorkspace — main-window open markdown (issue #8532) > no-ops for a remote/SSH worktree without invoking the local picker 1ms

Test Files  1 passed (1)
     Tests  184 passed (184)
```

The window keydown handler now has the missing branch, gated on worktree locality (`Terminal.tsx`):

```ts
// Cmd/Ctrl+Shift+O - open an existing markdown file (issue #8532).
if (!e.repeat && activeWorktreeIsLocal && matchShortcut('tab.openMarkdown')) {
  e.preventDefault()
  notifyTerminalCapture('tab.openMarkdown')
  if (floatingWorkspaceFocused) {
    return
  }
  void handleOpenFile()
  return
}
```

The store action re-checks locality before ever invoking the local dialog, so a rebound shortcut on a remote worktree can't leak a local path onto a remote host (`editor.ts`):

```ts
// Why: the native open dialog runs on the LOCAL machine, so a remote/SSH/runtime worktree must not receive a local file path (issue #8532).
if (getExecutionHostIdForWorktree(state, worktreeId) !== LOCAL_EXECUTION_HOST_ID) {
  return
}
```

The IPC handler is generalized to accept a root path and rooted at the worktree, with the floating handler kept as an alias so its behavior is unchanged (`src/main/ipc/app.ts`):

```ts
ipcMain.handle('app:pickMarkdownDocument', (event, rootPath?: string) =>
  pickMarkdownDocument(event, rootPath)
)
// Why: kept as an alias so the Floating Terminal picker keeps working unchanged.
ipcMain.handle('app:pickFloatingMarkdownDocument', (event) => pickMarkdownDocument(event))
```

## Trade-offs

Honest, user-visible behavior changes (all intended consequences of making a listed-but-dead shortcut live):

- Anyone who rebound `Cmd+Shift+O` in a terminal-first workflow now sees a native file dialog where nothing happened before; the existing `notifyTerminalCapture('tab.openMarkdown')` path shows the usual shortcut-capture toast.
- The main-window "+" tab menu gains an "Open Markdown..." row (only on LOCAL worktrees), shifting menu-item positions slightly.
- Opened files may live outside the worktree via `authorizeExternalPath` — the same trust model the floating picker already uses, now reachable from local worktrees.

The main regression risk of a naive fix — a local file silently opening into a remote/SSH worktree tab and saving to the wrong host — is prevented: both the keydown gate (`activeWorktreeIsLocal`) and the store action re-check locality, and the "Open Markdown..." menu item is only wired when the active worktree is LOCAL.

## Perf

{"hasRegression":false,"verdict":"no perf/battery regression","notes":"The diff adds an \"Open existing markdown file\" action (native picker rooted at a LOCAL worktree). Perf-relevant surface:\n\n- Two new zustand selectors (Terminal.tsx:~312, useTabGroupWorkspaceModel.ts:~99) compute `getExecutionHostIdForWorktree(state, id) === LOCAL_EXECUTION_HOST_ID`. They return a boolean primitive, so default Object.is equality prevents extra re-renders and no render-time identity is created that would break downstream memo. The function does a few Map/array lookups (findWorktreeRecord/findRepoRecord); this runs on store notifications but is consistent with the already-present getResolvedExecutionHostIdForWorktree / browserWorkspaceHasRemoteOwner selectors in the same components — marginal, not a new hot-path cost.\n- The keydown capture listener gains one branch (Terminal.tsx:~1795) but it short-circuits on `!e.repeat && activeWorktreeIsLocal` before evaluating matchShortcut, so it's cheaper than neighboring checks. Effect deps add activeWorktreeIsLocal/handleOpenFile, causing a re-subscribe only when worktree locality flips (rare).\n- No onPtyData / xterm render-loop / IPC-fanout changes. New IPC handler (app:pickMarkdownDocument) and store action openMarkdownFileInActiveWorkspace are user-triggered (dialog open), not per-keystroke/per-chunk/per-frame. No new timers, intervals, fs watchers, subprocess spawns, or uncleaned listeners. No awaits added to first-paint path.\n\nConclusion: no real, arguable perf/battery cost."}

## Review

Reviewed by an independent agent for 3 round(s) — final verdict: CLEAN.

Closes #8532

Made with [Orca](https://github.com/stablyai/orca) 🐋
