### PR TITLE
fix(mobile): restore notification opt-in route compatibility

### DIFF
--- a/mobile/app/notification-opt-in.tsx
+++ b/mobile/app/notification-opt-in.tsx
@@ -1,0 +1,12 @@
+import { Redirect, useLocalSearchParams } from 'expo-router'
+import {
+  legacyNotificationOptInDestination,
+  type LegacyNotificationOptInParams
+} from '../src/onboarding/legacy-notification-opt-in-destination'
+
+export default function NotificationOptInRedirect() {
+  const params = useLocalSearchParams<LegacyNotificationOptInParams>()
+
+  // Why: restored stacks may contain this retired route; replacement keeps Back from reopening it.
+  return <Redirect href={legacyNotificationOptInDestination(params)} />
+}

--- a/mobile/src/onboarding/legacy-notification-opt-in-destination.ts
+++ b/mobile/src/onboarding/legacy-notification-opt-in-destination.ts
@@ -1,0 +1,19 @@
+export type LegacyNotificationOptInParams = {
+  hostId?: string | string[]
+}
+
+export type LegacyNotificationOptInDestination = {
+  pathname: '/mobile-onboarding'
+  params: { steps: 'notifications'; hostId?: string }
+}
+
+/** Maps restored navigation and old deep links onto the canonical notifications step. */
+export function legacyNotificationOptInDestination(
+  params: LegacyNotificationOptInParams
+): LegacyNotificationOptInDestination {
+  const hostId = Array.isArray(params.hostId) ? params.hostId[0] : params.hostId
+  return {
+    pathname: '/mobile-onboarding',
+    params: { steps: 'notifications', ...(hostId ? { hostId } : {}) }
+  }
+}

--- a/mobile/src/onboarding/legacy-notification-opt-in-route.test.ts
+++ b/mobile/src/onboarding/legacy-notification-opt-in-route.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+import NotificationOptInRedirect from '../../app/notification-opt-in'
+import { legacyNotificationOptInDestination } from './legacy-notification-opt-in-destination'
+
+const mocks = vi.hoisted(() => ({
+  params: {} as Record<string, string | string[] | undefined>,
+  ensureNotificationPermissions: vi.fn()
+}))
+
+vi.mock('expo-router', () => ({
+  Redirect: 'Redirect',
+  useLocalSearchParams: () => mocks.params
+}))
+
+vi.mock('../notifications/mobile-notifications', () => ({
+  ensureNotificationPermissions: mocks.ensureNotificationPermissions
+}))
+
+describe('legacy notification opt-in destination', () => {
+  it('selects only notifications and preserves a scalar hostId', () => {
+    expect(legacyNotificationOptInDestination({ hostId: 'paired-host' })).toEqual({
+      pathname: '/mobile-onboarding',
+      params: { steps: 'notifications', hostId: 'paired-host' }
+    })
+  })
+
+  it.each([
+    [['first-host', 'second-host'], 'first-host'],
+    [[], undefined],
+    [undefined, undefined]
+  ] as const)('normalizes hostId %j to %s', (hostId, expectedHostId) => {
+    expect(legacyNotificationOptInDestination({ hostId })).toEqual({
+      pathname: '/mobile-onboarding',
+      params: {
+        steps: 'notifications',
+        ...(expectedHostId ? { hostId: expectedHostId } : {})
+      }
+    })
+  })
+
+  it('ignores unrelated legacy parameters', () => {
+    const legacyParams = {
+      hostId: 'paired-host',
+      steps: 'session-view',
+      returnTo: '/settings'
+    }
+
+    expect(legacyNotificationOptInDestination(legacyParams)).toEqual({
+      pathname: '/mobile-onboarding',
+      params: { steps: 'notifications', hostId: 'paired-host' }
+    })
+  })
+})
+
+describe('/notification-opt-in compatibility route', () => {
+  it('is present and synchronously returns a replace-style redirect to the canonical route', () => {
+    mocks.params = {
+      hostId: ['paired-host', 'ignored-host'],
+      steps: 'session-view',
+      unrelated: 'ignored'
+    }
+
+    expect(NotificationOptInRedirect()).toMatchObject({
+      type: 'Redirect',
+      props: {
+        href: {
+          pathname: '/mobile-onboarding',
+          params: { steps: 'notifications', hostId: 'paired-host' }
+        }
+      }
+    })
+    expect(mocks.ensureNotificationPermissions).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- restore `/notification-opt-in` as a thin compatibility route after PR #9478 removed the file-backed screen
- redirect directly to `/mobile-onboarding` with `steps=notifications`, preserving only a normalized scalar `hostId`
- add a pure destination mapper and deterministic coverage for scalar, array, missing, and unrelated route params

## Upgrade and deep-link compatibility

Existing installations can restore a persisted navigation stack containing `/notification-opt-in`, and previously shared deep links can still target that path after upgrading. The compatibility route returns Expo Router `Redirect`, whose implementation uses `router.replace`, so the retired entry is removed instead of remaining beneath the canonical modal and creating a Back loop.

The redirect always selects only the notifications onboarding step. It forwards the first scalar `hostId` value when Expo Router supplies an array, omits missing or empty values, and drops every unrelated parameter. It does not duplicate onboarding UI, evaluate onboarding gates, or request native notification permissions; the canonical `/mobile-onboarding` screen continues to own that behavior.

## Tests

- `pnpm --dir mobile test src/onboarding/legacy-notification-opt-in-route.test.ts src/onboarding/mobile-onboarding-plan.test.ts src/onboarding/mobile-onboarding-screen.test.ts src/onboarding/MobileOnboardingPage.test.ts` — 4 files passed, 26 tests passed
- `pnpm --dir mobile test` — 299 files passed, 2,151 tests passed, 2 skipped
- `pnpm --dir mobile typecheck` — passed
- `pnpm --dir mobile lint` — passed
- `pnpm --dir mobile format:check` — passed
- `git diff --check origin/main...HEAD` — passed