### PR TITLE
Fix mixed-version mobile Codex session resume

### DIFF
--- a/mobile/src/session/ai-vault-resume-launch.test.ts
+++ b/mobile/src/session/ai-vault-resume-launch.test.ts
@@ -4,7 +4,6 @@ import {
   buildMobileAiVaultResumeLaunch,
   buildMobileAiVaultResumeCommand,
   createMobileAiVaultResumeMutationRegistry,
-  prepareMobileAiVaultSessionResume,
   readMobileRuntimeHostPlatform,
   readMobileRuntimeTerminalWindowsShell,
   resolveMobileAiVaultResumePlatform,
@@ -175,59 +174,6 @@ describe('buildMobileAiVaultResumeLaunch', () => {
     })
     expect(launch.command).toContain("CODEX_HOME='/Users/ada/.orca/codex-runtime-home/home'")
     expect(launch.envToDelete).toBeUndefined()
-  })
-})
-
-describe('prepareMobileAiVaultSessionResume', () => {
-  it('materializes legacy shared-home sessions before building a real-home launch', async () => {
-    const legacy = session({
-      agent: 'codex',
-      filePath:
-        '/Users/ada/Library/Application Support/orca/codex-runtime-home/home/sessions/2026/07/20/rollout-a.jsonl',
-      codexHome: '/Users/ada/Library/Application Support/orca/codex-runtime-home/home'
-    })
-    const sendRequest = vi.fn().mockResolvedValue({
-      ok: true,
-      result: { useRealCodexHome: true }
-    })
-
-    const prepared = await prepareMobileAiVaultSessionResume({ sendRequest }, legacy)
-    const launch = buildMobileAiVaultResumeLaunch({ session: prepared, hostPlatform: 'darwin' })
-
-    expect(sendRequest).toHaveBeenCalledWith(
-      'aiVault.prepareSessionResume',
-      expect.objectContaining({ filePath: legacy.filePath, codexHome: legacy.codexHome }),
-      { timeoutMs: RESUME_RPC_TIMEOUT_MS }
-    )
-    expect(launch.command).not.toContain('CODEX_HOME=')
-    expect(launch.envToDelete).toEqual(['CODEX_HOME', 'ORCA_CODEX_HOME'])
-  })
-
-  it('fails before terminal creation when targeted materialization fails', async () => {
-    const legacy = session({
-      agent: 'codex',
-      codexHome: '/Users/ada/Library/Application Support/orca/codex-runtime-home/home'
-    })
-    const sendRequest = vi.fn().mockResolvedValue({
-      ok: false,
-      error: { message: 'Retry resume after checking session folder permissions.' }
-    })
-
-    await expect(prepareMobileAiVaultSessionResume({ sendRequest }, legacy)).rejects.toThrow(
-      /Retry resume/
-    )
-  })
-
-  it.each([
-    '/Users/ada/.config/codex',
-    '/Users/ada/Library/Application Support/orca/codex-accounts/a/home',
-    '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.codex'
-  ])('preserves a non-legacy Codex home without an RPC: %s', async (codexHome) => {
-    const current = session({ agent: 'codex', codexHome })
-    const sendRequest = vi.fn()
-
-    await expect(prepareMobileAiVaultSessionResume({ sendRequest }, current)).resolves.toBe(current)
-    expect(sendRequest).not.toHaveBeenCalled()
   })
 })
 

--- a/mobile/src/session/ai-vault-resume-launch.ts
+++ b/mobile/src/session/ai-vault-resume-launch.ts
@@ -4,7 +4,10 @@ import {
   buildAiVaultResumeShellCommand,
   realHomeCodexResumeEnvDeletion
 } from '../../../src/shared/ai-vault-types'
-import { isLegacySharedCodexHome } from '../../../src/shared/ai-vault-resume-preparation'
+import {
+  isAiVaultPrepareSessionResumeUnavailableError,
+  isLegacySharedCodexHome
+} from '../../../src/shared/ai-vault-resume-preparation'
 import { isResumableTuiAgent } from '../../../src/shared/agent-session-resume'
 import type { SleepingAgentLaunchConfig } from '../../../src/shared/agent-session-resume'
 import { buildAgentResumeStartupPlan } from '../../../src/shared/tui-agent-startup'
@@ -170,6 +173,10 @@ export async function prepareMobileAiVaultSessionResume(
     { timeoutMs: RESUME_RPC_TIMEOUT_MS }
   )
   if (!response.ok) {
+    if (isAiVaultPrepareSessionResumeUnavailableError(response.error)) {
+      // Why: older hosts cannot prepare, but their shared home still supports the legacy resume path.
+      return session
+    }
     throw new Error(
       response.error?.message || 'Could not prepare this legacy Codex session. Retry resume.'
     )

--- a/mobile/src/session/ai-vault-resume-preparation.test.ts
+++ b/mobile/src/session/ai-vault-resume-preparation.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AiVaultSession } from '../../../src/shared/ai-vault-types'
+import {
+  buildMobileAiVaultResumeLaunch,
+  prepareMobileAiVaultSessionResume,
+  resumeAiVaultSessionInTerminal,
+  RESUME_RPC_TIMEOUT_MS
+} from './ai-vault-resume-launch'
+
+const LEGACY_CODEX_HOME = '/Users/ada/Library/Application Support/orca/codex-runtime-home/home'
+
+function legacySession(overrides: Partial<AiVaultSession> = {}): AiVaultSession {
+  return {
+    id: 'codex:legacy-1',
+    executionHostId: 'local',
+    agent: 'codex',
+    sessionId: 'legacy-1',
+    title: 'Resume me',
+    cwd: '/Users/ada/repo',
+    branch: 'main',
+    model: null,
+    filePath: `${LEGACY_CODEX_HOME}/sessions/2026/07/20/rollout-a.jsonl`,
+    codexHome: LEGACY_CODEX_HOME,
+    createdAt: null,
+    updatedAt: null,
+    modifiedAt: '2026-07-20T00:00:00.000Z',
+    messageCount: 2,
+    totalTokens: 10,
+    previewMessages: [],
+    queuedMessageCount: 0,
+    subagentTranscriptCount: 0,
+    resumeCommand: '',
+    subagent: null,
+    ...overrides
+  }
+}
+
+describe('prepareMobileAiVaultSessionResume', () => {
+  it.each([
+    {
+      code: 'forbidden',
+      message: "Method 'aiVault.prepareSessionResume' is not available to mobile clients"
+    },
+    {
+      code: 'method_not_found',
+      message: 'Unknown method: aiVault.prepareSessionResume'
+    }
+  ])('uses the legacy command and environment on old-host $code', async (error) => {
+    const legacy = legacySession()
+    const sendRequest = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, error })
+      .mockResolvedValueOnce({
+        ok: true,
+        result: { tab: { type: 'terminal', id: 'tab-1', terminal: 'pty-1', title: 'Terminal' } }
+      })
+      .mockResolvedValueOnce({ ok: true, result: { send: { accepted: true } } })
+
+    const prepared = await prepareMobileAiVaultSessionResume({ sendRequest }, legacy)
+    const launch = buildMobileAiVaultResumeLaunch({ session: prepared, hostPlatform: 'darwin' })
+    await resumeAiVaultSessionInTerminal({ sendRequest }, 'worktree-1', launch)
+
+    expect(prepared).toBe(legacy)
+    expect(sendRequest.mock.calls[1]?.[1]).not.toHaveProperty('envToDelete')
+    expect(sendRequest).toHaveBeenNthCalledWith(
+      3,
+      'terminal.send',
+      {
+        terminal: 'pty-1',
+        text: `cd '/Users/ada/repo' && CODEX_HOME='${LEGACY_CODEX_HOME}' codex '--dangerously-bypass-approvals-and-sandbox' 'resume' 'legacy-1'`,
+        enter: true
+      },
+      { timeoutMs: RESUME_RPC_TIMEOUT_MS }
+    )
+  })
+
+  it('uses the real Codex home when a supported desktop requests it', async () => {
+    const legacy = legacySession()
+    const sendRequest = vi.fn().mockResolvedValue({
+      ok: true,
+      result: { useRealCodexHome: true }
+    })
+
+    const prepared = await prepareMobileAiVaultSessionResume({ sendRequest }, legacy)
+    const launch = buildMobileAiVaultResumeLaunch({ session: prepared, hostPlatform: 'darwin' })
+
+    expect(sendRequest).toHaveBeenCalledWith(
+      'aiVault.prepareSessionResume',
+      {
+        agent: 'codex',
+        filePath: legacy.filePath,
+        codexHome: LEGACY_CODEX_HOME,
+        executionHostId: 'local'
+      },
+      { timeoutMs: RESUME_RPC_TIMEOUT_MS }
+    )
+    expect(prepared).toEqual({ ...legacy, codexHome: null })
+    expect(launch.command).toBe(
+      "cd '/Users/ada/repo' && codex '--dangerously-bypass-approvals-and-sandbox' 'resume' 'legacy-1'"
+    )
+    expect(launch.envToDelete).toEqual(['CODEX_HOME', 'ORCA_CODEX_HOME'])
+  })
+
+  it('preserves the legacy resume path when a supported desktop declines real-home use', async () => {
+    const legacy = legacySession()
+    const sendRequest = vi.fn().mockResolvedValue({
+      ok: true,
+      result: { useRealCodexHome: false }
+    })
+
+    const prepared = await prepareMobileAiVaultSessionResume({ sendRequest }, legacy)
+    const launch = buildMobileAiVaultResumeLaunch({ session: prepared, hostPlatform: 'darwin' })
+
+    expect(prepared).toBe(legacy)
+    expect(launch.command).toContain(`CODEX_HOME='${LEGACY_CODEX_HOME}'`)
+    expect(launch.envToDelete).toBeUndefined()
+  })
+
+  it.each([
+    { agent: 'claude' as const, codexHome: null },
+    { agent: 'codex' as const, codexHome: '/Users/ada/.config/codex' },
+    {
+      agent: 'codex' as const,
+      codexHome: '/Users/ada/Library/Application Support/orca/codex-accounts/a/home'
+    },
+    { agent: 'codex' as const, codexHome: '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.codex' }
+  ])('does not prepare non-legacy session $agent at $codexHome', async (overrides) => {
+    const current = legacySession(overrides)
+    const sendRequest = vi.fn()
+
+    await expect(prepareMobileAiVaultSessionResume({ sendRequest }, current)).resolves.toBe(current)
+    expect(sendRequest).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {
+      code: 'internal_error',
+      message: 'Retry resume after checking session folder permissions.'
+    },
+    {
+      code: 'forbidden',
+      message: 'Session resume is forbidden'
+    }
+  ])('keeps genuine server error visible: $code', async (error) => {
+    const sendRequest = vi.fn().mockResolvedValue({ ok: false, error })
+
+    await expect(
+      prepareMobileAiVaultSessionResume({ sendRequest }, legacySession())
+    ).rejects.toThrow(error.message)
+  })
+
+  it.each(['Request timed out: aiVault.prepareSessionResume', 'Connection interrupted'])(
+    'keeps transport failure visible: %s',
+    async (message) => {
+      const failure = new Error(message)
+      const sendRequest = vi.fn().mockRejectedValue(failure)
+
+      await expect(
+        prepareMobileAiVaultSessionResume({ sendRequest }, legacySession())
+      ).rejects.toBe(failure)
+    }
+  )
+})

--- a/src/shared/ai-vault-resume-preparation.test.ts
+++ b/src/shared/ai-vault-resume-preparation.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { isAiVaultPrepareSessionResumeUnavailableError } from './ai-vault-resume-preparation'
+
+describe('isAiVaultPrepareSessionResumeUnavailableError', () => {
+  it('recognizes deterministic old-host responses', () => {
+    expect(
+      isAiVaultPrepareSessionResumeUnavailableError({
+        code: 'forbidden',
+        message: "Method 'aiVault.prepareSessionResume' is not available to mobile clients"
+      })
+    ).toBe(true)
+    expect(
+      isAiVaultPrepareSessionResumeUnavailableError({
+        code: 'method_not_found',
+        message: 'Unknown method: aiVault.prepareSessionResume'
+      })
+    ).toBe(true)
+  })
+
+  it.each([
+    {
+      code: 'forbidden',
+      message: "Method 'aiVault.listSessions' is not available to mobile clients"
+    },
+    { code: 'forbidden', message: 'Session resume is forbidden' },
+    { code: 'internal_error', message: 'Method not found while preparing session' }
+  ])('rejects a non-capability error: $code / $message', (error) => {
+    expect(isAiVaultPrepareSessionResumeUnavailableError(error)).toBe(false)
+  })
+})

--- a/src/shared/ai-vault-resume-preparation.ts
+++ b/src/shared/ai-vault-resume-preparation.ts
@@ -13,6 +13,19 @@ export type AiVaultSessionResumePreparation = (
   args: AiVaultPrepareSessionResumeArgs
 ) => Promise<AiVaultPrepareSessionResumeResult>
 
+const LEGACY_MOBILE_PREPARATION_FORBIDDEN_MESSAGE =
+  "Method 'aiVault.prepareSessionResume' is not available to mobile clients"
+
+export function isAiVaultPrepareSessionResumeUnavailableError(error: {
+  code: string
+  message: string
+}): boolean {
+  return (
+    error.code === 'method_not_found' ||
+    (error.code === 'forbidden' && error.message === LEGACY_MOBILE_PREPARATION_FORBIDDEN_MESSAGE)
+  )
+}
+
 export function isLegacySharedCodexHome(codexHome: string | null): boolean {
   if (!codexHome) {
     return false


### PR DESCRIPTION
## Summary

- restore legacy Codex shared-home resume when a newer mobile client talks to a desktop that predates `aiVault.prepareSessionResume`
- classify only the two deterministic old-host responses: v1.4.147's exact mobile-allowlist `forbidden` response and the runtime dispatcher's `method_not_found` response
- preserve fail-closed behavior for genuine preparation failures, permission errors, timeouts, and transport failures
- split preparation coverage into focused shared and mobile suites, including the terminal command and environment sent across mixed versions

## Compatibility matrix

| Desktop response / session | Resume behavior |
| --- | --- |
| v1.4.147 mobile allowlist: exact `forbidden` response | Keep the original legacy shared home; send inline `CODEX_HOME`; do not delete Codex home env vars |
| Older/direct runtime: `method_not_found` | Same legacy fallback |
| Supported: `useRealCodexHome: true` | Resume from the real home; omit inline `CODEX_HOME`; delete inherited `CODEX_HOME` and `ORCA_CODEX_HOME` |
| Supported: `useRealCodexHome: false` | Keep the original session/home and legacy command/env behavior |
| Non-legacy or non-Codex session | Skip preparation entirely |
| Any other server error | Surface the server error and stop before terminal creation |
| Timeout or transport rejection | Preserve the rejection and stop before terminal creation |

## Validation

- `cd mobile && pnpm exec vitest run src/session/ai-vault-resume-preparation.test.ts src/session/ai-vault-resume-launch.test.ts` — 2 files, 30 tests passed
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/ai-vault-resume-preparation.test.ts` — 1 file, 4 tests passed
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/ai-vault-resume-preparation.test.ts src/main/codex/codex-legacy-session-resume.test.ts src/main/ai-vault/runtime-session-scanner.test.ts src/main/runtime/rpc/methods/ai-vault.test.ts` — 4 files, 33 tests passed
- `cd mobile && pnpm test` — 299 files passed; 2,152 tests passed, 2 skipped
- `cd mobile && pnpm typecheck` — passed
- `cd mobile && pnpm lint` — passed
- `pnpm typecheck` — passed
- touched-file `oxlint` and `oxfmt --check` — passed
- `pnpm run check:max-lines-ratchet` — passed

`pnpm lint` completes the main `oxlint` phase, then stops in `lint:switch-exhaustiveness` on two existing `origin/main` errors in `src/renderer/src/components/skills/skill-freshness-group.tsx` and `src/main/daemon/daemon-server.ts`. This branch does not modify either file; the touched-file lint passes.
