### PR TITLE
fix: localize Link Routing settings description

### DIFF
--- a/src/renderer/src/components/settings/browser-search.ts
+++ b/src/renderer/src/components/settings/browser-search.ts
@@ -17,7 +17,11 @@ export function getBrowserLinkRoutingShortcutLabel(platform: BrowserShortcutPlat
 }
 
 export function getBrowserLinkRoutingDescription(platform: BrowserShortcutPlatform): string {
-  return `Open http(s) links in Orca's built-in browser — from the terminal, markdown, and the editor. ${getBrowserLinkRoutingShortcutLabel(platform)} always uses your system browser.`
+  return translate(
+    'auto.components.settings.browser.search.d0fdcd86b1',
+    "Open http(s) links in Orca's built-in browser — from the terminal, markdown, and the editor. {{value0}} always uses your system browser.",
+    { value0: getBrowserLinkRoutingShortcutLabel(platform) }
+  )
 }
 
 export function getBrowserPaneSearchEntries(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -7473,6 +7473,7 @@
             "bea27bac4b": "links",
             "44d14df30d": "preview",
             "5cb082b3e3": "Link Routing",
+            "d0fdcd86b1": "Open http(s) links in Orca's built-in browser — from the terminal, markdown, and the editor. {{value0}} always uses your system browser.",
             "95944898e0": "percentage",
             "483a0eb5e0": "new tab",
             "726f2a8556": "page zoom",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -7441,7 +7441,8 @@
             "a942905148": "URL abierta al crear una nueva pestaña del navegador. Déjelo vacío para abrir una pestaña en blanco.",
             "c3903322d2": "Página de inicio predeterminada",
             "19ea5607cf": "Etiquetas de localhost para worktrees",
-            "4e0fdf0a3f": "Abre los puertos del workspace como URL localhost de Orca específicas del worktree para que las pestañas del navegador sean más fáciles de distinguir."
+            "4e0fdf0a3f": "Abre los puertos del workspace como URL localhost de Orca específicas del worktree para que las pestañas del navegador sean más fáciles de distinguir.",
+            "d0fdcd86b1": "Open http(s) links in Orca's built-in browser — from the terminal, markdown, and the editor. {{value0}} always uses your system browser."
           },
           "use": {
             "search": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -7463,7 +7463,8 @@
             "a942905148": "新規ブラウザ タブを作成するときに開かれる URL。空白のタブを開くには、空白のままにします。",
             "c3903322d2": "デフォルトのホームページ",
             "19ea5607cf": "ローカルホストのワークツリーのラベル",
-            "4e0fdf0a3f": "ワークスペース ポートをワークツリー固有の Orca localhost URL として開くと、ブラウザーのタブを区別しやすくなります。"
+            "4e0fdf0a3f": "ワークスペース ポートをワークツリー固有の Orca localhost URL として開くと、ブラウザーのタブを区別しやすくなります。",
+            "d0fdcd86b1": "Open http(s) links in Orca's built-in browser — from the terminal, markdown, and the editor. {{value0}} always uses your system browser."
           },
           "use": {
             "search": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -7426,7 +7426,8 @@
             "a942905148": "새 브라우저 탭을 만들 때 열리는 URL입니다. 빈 탭을 열려면 비워 두세요.",
             "c3903322d2": "기본 홈 페이지",
             "19ea5607cf": "로컬호스트 작업 트리 레이블",
-            "4e0fdf0a3f": "브라우저 탭을 더 쉽게 구분할 수 있도록 작업 트리별 Orca 로컬 호스트 URL로 워크스페이스 포트를 엽니다."
+            "4e0fdf0a3f": "브라우저 탭을 더 쉽게 구분할 수 있도록 작업 트리별 Orca 로컬 호스트 URL로 워크스페이스 포트를 엽니다.",
+            "d0fdcd86b1": "Open http(s) links in Orca's built-in browser — from the terminal, markdown, and the editor. {{value0}} always uses your system browser."
           },
           "use": {
             "search": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -7426,7 +7426,8 @@
             "a942905148": "创建新浏览器选项卡时打开的 URL。留空以打开空白选项卡。",
             "c3903322d2": "默认主页",
             "19ea5607cf": "本地主机工作区标签",
-            "4e0fdf0a3f": "将工作区端口打开为特定于工作区的 Orca localhost URL，便于区分浏览器标签页。"
+            "4e0fdf0a3f": "将工作区端口打开为特定于工作区的 Orca localhost URL，便于区分浏览器标签页。",
+            "d0fdcd86b1": "Open http(s) links in Orca's built-in browser — from the terminal, markdown, and the editor. {{value0}} always uses your system browser."
           },
           "use": {
             "search": {


### PR DESCRIPTION
## Summary
- `getBrowserLinkRoutingDescription()` in `src/renderer/src/components/settings/browser-search.ts` returned a hardcoded template literal instead of going through `translate()`, so the description stayed in English regardless of the selected UI language, even though every other string on the same settings pane (Settings → Workflow → Browser) was translated.
- Wrapped the string in `translate()`, interpolating the platform-specific shortcut label via `{{value0}}` (mirroring the existing pattern used elsewhere, e.g. `App.tsx`'s `Toggle sidebar ({{value0}})`).
- Added the new key to `en.json` and ran `pnpm run sync:localization-catalog` to keep `es.json`/`ja.json`/`ko.json`/`zh.json` in parity (English placeholder copied in, per the documented sync behavior — actual translation happens in a separate machine-translation pass per `config/localization-audit.md`).

Fixes #9652

## Test plan
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/browser-search.test.ts` — 2 passed
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run verify:localization-catalog` — clean
- [x] `pnpm run verify:localization-coverage` — no new unlocalized strings introduced by this change (3 pre-existing unrelated findings in `ai-vault-session-launch-actions.ts`/`AiVaultSessionDropLayer.tsx` confirmed present on unmodified `main` too, out of scope here)
- [x] `oxlint` on the changed file — clean