### PR TITLE
feat(dashboard): open-worktree dialog control + finished-time parity

### DIFF
--- a/src/main/ipc/dashboard-payload-validation.test.ts
+++ b/src/main/ipc/dashboard-payload-validation.test.ts
@@ -21,6 +21,7 @@ const SNAPSHOT = {
       repoName: 'Orca',
       worktreeName: 'Dashboard',
       startedAt: 1_699_999_000_000,
+      finishedAt: null,
       stateChangedAt: 1_699_999_500_000,
       unseen: true,
       askSummary: '{"question":"Proceed?"}'

--- a/src/main/ipc/dashboard-payload-validation.ts
+++ b/src/main/ipc/dashboard-payload-validation.ts
@@ -77,6 +77,7 @@ function isDashboardCard(value: unknown): boolean {
     isBoundedString(card.repoName, MAX_LABEL_LENGTH, true) &&
     isBoundedString(card.worktreeName, MAX_LABEL_LENGTH, true) &&
     isFiniteNumber(card.startedAt) &&
+    (card.finishedAt === null || isFiniteNumber(card.finishedAt)) &&
     isFiniteNumber(card.stateChangedAt) &&
     typeof card.unseen === 'boolean' &&
     isOptionalBoundedString(card.askSummary, AGENT_STATUS_INTERACTIVE_PROMPT_MAX_LENGTH)

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanBoard.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanBoard.test.tsx
@@ -60,6 +60,7 @@ function card(overrides: Partial<DashboardCard>): DashboardCard {
     repoName: 'Repo',
     worktreeName: 'wt',
     startedAt: 0,
+    finishedAt: null,
     stateChangedAt: 0,
     unseen: false,
     ...overrides

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.test.tsx
@@ -35,6 +35,7 @@ function card(overrides: Partial<DashboardCard> = {}): DashboardCard {
     repoName: 'Orca',
     worktreeName: 'dashboard-review',
     startedAt: 1_000,
+    finishedAt: null,
     stateChangedAt: 1_000,
     unseen: false,
     ...overrides

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
@@ -26,6 +26,12 @@ function formatStartedAgo(startedAt: number, now: number): string {
   })
 }
 
+/** The timestamp the card's time column counts from: since it finished when the
+ *  agent has completed, else since it started — parity with the worktree sidebar. */
+function displayTimestamp(card: DashboardCard): number {
+  return card.finishedAt ?? card.startedAt
+}
+
 function sameCard(a: DashboardCard, b: DashboardCard): boolean {
   return (
     a.paneKey === b.paneKey &&
@@ -43,6 +49,7 @@ function sameCard(a: DashboardCard, b: DashboardCard): boolean {
     a.repoName === b.repoName &&
     a.worktreeName === b.worktreeName &&
     a.startedAt === b.startedAt &&
+    a.finishedAt === b.finishedAt &&
     a.stateChangedAt === b.stateChangedAt &&
     a.unseen === b.unseen &&
     a.askSummary === b.askSummary
@@ -125,9 +132,9 @@ export const AgentKanbanCard = memo(
 
         <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
           <span className="truncate font-mono">{card.repoName}</span>
-          {card.startedAt > 0 ? (
+          {displayTimestamp(card) > 0 ? (
             <span className="ml-auto shrink-0 tabular-nums">
-              {formatStartedAgo(card.startedAt, now)}
+              {formatStartedAgo(displayTimestamp(card), now)}
             </span>
           ) : null}
         </div>
@@ -137,7 +144,7 @@ export const AgentKanbanCard = memo(
   (previous, next) =>
     previous.onOpenTerminal === next.onOpenTerminal &&
     sameCard(previous.card, next.card) &&
-    (previous.card.startedAt <= 0 ||
-      formatStartedAgo(previous.card.startedAt, previous.now) ===
-        formatStartedAgo(next.card.startedAt, next.now))
+    (displayTimestamp(previous.card) <= 0 ||
+      formatStartedAgo(displayTimestamp(previous.card), previous.now) ===
+        formatStartedAgo(displayTimestamp(next.card), next.now))
 )

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { MessageCircleQuestion } from 'lucide-react'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
 import { AgentStateDot } from '@/components/AgentStateDot'
@@ -125,7 +126,7 @@ export const AgentKanbanCard = memo(
 
         {card.askSummary ? (
           <div className="flex items-start gap-1 rounded-md bg-amber-500/10 px-1.5 py-1 text-[11px] text-amber-600 dark:text-amber-400">
-            <span aria-hidden>✋</span>
+            <MessageCircleQuestion className="mt-px size-3 shrink-0" aria-hidden />
             <span className="line-clamp-2">{card.askSummary}</span>
           </div>
         ) : null}

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react'
+import { SquareArrowOutUpRight } from 'lucide-react'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
 import { agentStateLabel } from '@/components/AgentStateDot'
@@ -41,7 +42,6 @@ export function AgentTerminalDialog({
     <Dialog open={card !== null} onOpenChange={onOpenChange}>
       {card ? (
         <DialogContent
-          showCloseButton={false}
           aria-describedby={undefined}
           // Why: sm:max-w-lg in DialogContent's base classes would defeat a bare
           // max-w-*, so the full-width override must carry the same breakpoint.
@@ -81,15 +81,11 @@ export function AgentTerminalDialog({
               )}
             </div>
           )}
-          <div className="flex items-center justify-end gap-2 px-2.5 py-1.5">
-            <DialogClose asChild>
-              <Button type="button" variant="outline" size="xs">
-                {translate('dashboardPopout.terminal.close', 'Close')}
-              </Button>
-            </DialogClose>
+          <div className="flex items-center justify-end px-2.5 py-1.5">
             <DialogClose asChild>
               <Button type="button" variant="outline" size="xs" onClick={reveal}>
-                {translate('dashboardPopout.terminal.focusWorktree', 'Focus worktree')}
+                <SquareArrowOutUpRight className="size-3" />
+                {translate('dashboardPopout.terminal.focusWorktree', 'Open worktree')}
               </Button>
             </DialogClose>
           </div>

--- a/src/renderer/src/components/dashboard/agent-finished-timestamp.ts
+++ b/src/renderer/src/components/dashboard/agent-finished-timestamp.ts
@@ -1,0 +1,27 @@
+import type { DashboardAgentRow } from './useDashboardData'
+
+/**
+ * The moment an agent last entered `done`, or null if it never finished (still
+ * working / idle without a prior completion). Shared by the left worktree
+ * sidebar and the pop-out dashboard so both time from the SAME event: a finished
+ * agent reads "N since it finished", an active one falls through to its start.
+ */
+export function lastEnteredDoneAt(
+  agent: Pick<DashboardAgentRow, 'rowSource' | 'state' | 'entry'>
+): number | null {
+  // Why: idle subagent child rows are alive-but-idle (teammates persist
+  // between turns), not finished — fall through to the started-at timestamp.
+  if (agent.rowSource === 'subagent' && agent.state === 'idle') {
+    return null
+  }
+  const entry = agent.entry
+  if (entry.state === 'done') {
+    return entry.stateStartedAt
+  }
+  for (let i = (entry.stateHistory?.length ?? 0) - 1; i >= 0; i--) {
+    if (entry.stateHistory[i].state === 'done') {
+      return entry.stateHistory[i].startedAt
+    }
+  }
+  return null
+}

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
@@ -8,6 +8,7 @@ import type {
 import { parsePaneKey } from '../../../../shared/stable-pane-id'
 import { migrationUnsupportedToAgentStatusEntry } from '@/lib/migration-unsupported-agent-entry'
 import { applyAgentRowLineage } from './agent-row-lineage'
+import { lastEnteredDoneAt } from './agent-finished-timestamp'
 import type { DashboardAgentRow } from './useDashboardData'
 import { buildWorktreeAgentRows } from '../sidebar/worktree-agent-rows'
 import {
@@ -155,6 +156,7 @@ export function buildDashboardSnapshot(
           lastUserMessage: isTitleDerived ? undefined : nonEmpty(row.entry.prompt),
           lastAgentMessage: isTitleDerived ? undefined : nonEmpty(row.entry.lastAssistantMessage),
           startedAt: row.startedAt,
+          finishedAt: lastEnteredDoneAt(row),
           stateChangedAt: row.entry.stateStartedAt || row.startedAt,
           // Same derivation as WorktreeCardAgents' unvisitedByPaneKey, so the
           // board and the sidebar bold/mute the same agents at the same time.

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
@@ -8,6 +8,7 @@ import { cn } from '@/lib/utils'
 import { getAgentDotState } from './worktree-card-agent-summary'
 import { translate } from '@/i18n/i18n'
 import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
+import { lastEnteredDoneAt } from '@/components/dashboard/agent-finished-timestamp'
 import CacheTimer, { usePromptCacheCountdownForPane } from './CacheTimer'
 
 function formatShortTimeAgo(ts: number, now: number): string {
@@ -24,24 +25,6 @@ function formatShortTimeAgo(ts: number, now: number): string {
     return `${hours}h`
   }
   return `${Math.floor(hours / 24)}d`
-}
-
-function lastEnteredDoneAt(agent: DashboardAgentRowData): number | null {
-  // Why: idle subagent child rows are alive-but-idle (teammates persist
-  // between turns), not finished — fall through to the started-at timestamp.
-  if (agent.rowSource === 'subagent' && agent.state === 'idle') {
-    return null
-  }
-  const entry = agent.entry
-  if (entry.state === 'done') {
-    return entry.stateStartedAt
-  }
-  for (let i = (entry.stateHistory?.length ?? 0) - 1; i >= 0; i--) {
-    if (entry.stateHistory[i].state === 'done') {
-      return entry.stateHistory[i].startedAt
-    }
-  }
-  return null
 }
 
 function getCompactAgentPrimary(agent: DashboardAgentRowData): string {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -13608,8 +13608,7 @@
     },
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",
-      "close": "Close",
-      "focusWorktree": "Focus worktree"
+      "focusWorktree": "Open worktree"
     }
   },
   "dashboard": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -13585,7 +13585,6 @@
     },
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",
-      "close": "Close",
       "focusWorktree": "Focus worktree"
     }
   },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -13585,7 +13585,6 @@
     },
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",
-      "close": "Close",
       "focusWorktree": "Focus worktree"
     }
   },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -13585,7 +13585,6 @@
     },
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",
-      "close": "Close",
       "focusWorktree": "Focus worktree"
     }
   },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -13585,7 +13585,6 @@
     },
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",
-      "close": "Close",
       "focusWorktree": "Focus worktree"
     }
   },

--- a/src/shared/dashboard-snapshot.ts
+++ b/src/shared/dashboard-snapshot.ts
@@ -45,6 +45,10 @@ export type DashboardCard = {
   worktreeName: string
   /** "Started … ago" display. */
   startedAt: number
+  /** When the agent last entered `done`, or null if it never finished. Drives
+   *  the card's time column: finished cards read time-since-finish (parity with
+   *  the left worktree sidebar), active cards fall back to startedAt. */
+  finishedAt: number | null
   /** When the agent entered its current state — column ordering key (cards
    *  that moved into a bucket most recently sort first). 0 when unknown. */
   stateChangedAt: number


### PR DESCRIPTION
## What

Polish for the pop-out agent dashboard (experimental):

**1. Terminal dialog controls**
- Replaced the footer **Close** button with the standard top-right **✕**.
- Renamed the primary action **Focus worktree → Open worktree**.
- Added an open-in-window icon before the label.

**2. Card time column — finished-time parity with the left sidebar**
- Finished agents now read **time since they finished** instead of time since they started, matching the left worktree sidebar exactly (same `4m` / `8h` bare format).
- Extracted the sidebar's finished-timestamp logic into a shared helper (`agent-finished-timestamp.ts`) so the two surfaces can't drift, and threaded `finishedAt` through the `DashboardCard` snapshot contract (+ relay validator).

**3. Pending-question chip icon**
- Replaced the raw ✋ emoji (rendered per-OS, off the design system) on the amber "needs you" question chip with the lucide `MessageCircleQuestion` (chat bubble + question mark).

## Screenshots

Board — the amber chip now uses the chat-question icon, and the two **Idle** cards read `33m` / `7h` since they *finished*, not since they started (which would be 3h / 9h):

![board](https://github.com/stablyai/orca/blob/brennanb2025/agent-canvas-focus-worktree-screenshots/board.png?raw=true)

Terminal dialog — corner ✕, "Open worktree" with the open-in-window icon, footer Close removed:

![dialog](https://github.com/stablyai/orca/blob/brennanb2025/agent-canvas-focus-worktree-screenshots/dialog.png?raw=true)

## Testing

- `AgentKanbanCard`, `build-dashboard-snapshot`, `dashboard-payload-validation`, and sidebar activity-summary unit tests pass.
- Full CI `verify` (lint + typecheck + test + packaged-CLI smoke) green.
- Localized string catalog re-synced (dropped the now-unused `terminal.close` key across locales).
- Verified live in a dev Electron build via CDP: opened the real pop-out window, published a representative snapshot through the real main→popout relay, and confirmed the rendered board + dialog above. **Note:** the dashboard data in the screenshots is seeded (the test profile has no live agents); the components, styling, relay path, and behavior are the real app.
