### PR TITLE
feat(status-bar): tooltips for Detailed vs Compact usage modes

### DIFF
--- a/resources/skills/current-manifest.json
+++ b/resources/skills/current-manifest.json
@@ -40,7 +40,7 @@
     {
       "name": "orca-cli",
       "sourcePath": "skills/orca-cli",
-      "releaseRevision": 33,
+      "releaseRevision": 35,
       "packageDigest": "72f63dcaad3dea8bea54838835fe46c689c37b63cd96a9ef2f2537f0c2f6b8c8",
       "gitTreeSha": "97f6596bb43a56c6e81246f077c35144c9025343",
       "files": [

--- a/resources/skills/release-mapping.json
+++ b/resources/skills/release-mapping.json
@@ -509,6 +509,45 @@
         "orca-per-workspace-env": 2,
         "orchestration": 25
       }
+    },
+    {
+      "appVersion": "1.4.148-rc.1",
+      "skills": {
+        "computer-use": 5,
+        "linear-tickets": 4,
+        "orca-cli": 33,
+        "orca-emulator": 4,
+        "orca-emulator-android": 2,
+        "orca-linear": 2,
+        "orca-per-workspace-env": 2,
+        "orchestration": 25
+      }
+    },
+    {
+      "appVersion": "1.4.148",
+      "skills": {
+        "computer-use": 5,
+        "linear-tickets": 4,
+        "orca-cli": 34,
+        "orca-emulator": 4,
+        "orca-emulator-android": 2,
+        "orca-linear": 2,
+        "orca-per-workspace-env": 2,
+        "orchestration": 25
+      }
+    },
+    {
+      "appVersion": "1.4.149-rc.0",
+      "skills": {
+        "computer-use": 5,
+        "linear-tickets": 4,
+        "orca-cli": 35,
+        "orca-emulator": 4,
+        "orca-emulator-android": 2,
+        "orca-linear": 2,
+        "orca-per-workspace-env": 2,
+        "orchestration": 25
+      }
     }
   ]
 }

--- a/resources/skills/snapshot-registry.json
+++ b/resources/skills/snapshot-registry.json
@@ -529,6 +529,38 @@
             "identitySha256": "90228630bc4daab4ccf67b691153976d1f28ec064d7069a4c170621ed2ea99b5"
           }
         ]
+      },
+      {
+        "releaseRevision": 34,
+        "packageDigest": "51740ff13f379ac5743d3fd28a14b17168dcef40f7048c20182dce166098c45f",
+        "gitTreeSha": "ded93000a5f654e2b4f324501282459bd56afe19",
+        "files": [
+          {
+            "path": "SKILL.md",
+            "size": 21557,
+            "executable": false,
+            "classification": "text",
+            "exactSha256": "b4c36e19fc158fc8c286bdfdf05a537985cb2159a596c93862968c5417bf15be",
+            "textNormalizedSha256": "b4c36e19fc158fc8c286bdfdf05a537985cb2159a596c93862968c5417bf15be",
+            "identitySha256": "b4c36e19fc158fc8c286bdfdf05a537985cb2159a596c93862968c5417bf15be"
+          }
+        ]
+      },
+      {
+        "releaseRevision": 35,
+        "packageDigest": "72f63dcaad3dea8bea54838835fe46c689c37b63cd96a9ef2f2537f0c2f6b8c8",
+        "gitTreeSha": "97f6596bb43a56c6e81246f077c35144c9025343",
+        "files": [
+          {
+            "path": "SKILL.md",
+            "size": 3835,
+            "executable": false,
+            "classification": "text",
+            "exactSha256": "90228630bc4daab4ccf67b691153976d1f28ec064d7069a4c170621ed2ea99b5",
+            "textNormalizedSha256": "90228630bc4daab4ccf67b691153976d1f28ec064d7069a4c170621ed2ea99b5",
+            "identitySha256": "90228630bc4daab4ccf67b691153976d1f28ec064d7069a4c170621ed2ea99b5"
+          }
+        ]
       }
     ],
     "orchestration": [

--- a/src/renderer/src/components/settings/SettingsFormControls.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.tsx
@@ -7,6 +7,7 @@ import { ScrollArea } from '../ui/scroll-area'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { Popover, PopoverAnchor, PopoverContent } from '../ui/popover'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { Check, ChevronsUpDown, CircleX } from 'lucide-react'
 import { normalizeColor, type TerminalThemeOption } from '@/lib/terminal-theme'
 import { MAX_THEME_RESULTS } from './SettingsConstants'
@@ -138,6 +139,8 @@ type SegmentedOption<T extends string | number> = {
   label: React.ReactNode
   disabled?: boolean
   ariaLabel?: string
+  /** Optional hover label describing what the option does. */
+  tooltip?: React.ReactNode
 }
 
 type SettingsSegmentedControlProps<T extends string | number> = {
@@ -169,7 +172,7 @@ export function SettingsSegmentedControl<T extends string | number>({
     >
       {options.map((opt) => {
         const active = opt.value === value
-        return (
+        const button = (
           <button
             key={String(opt.value)}
             type="button"
@@ -195,6 +198,15 @@ export function SettingsSegmentedControl<T extends string | number>({
           >
             {opt.label}
           </button>
+        )
+        if (opt.tooltip == null) {
+          return button
+        }
+        return (
+          <Tooltip key={String(opt.value)}>
+            <TooltipTrigger asChild>{button}</TooltipTrigger>
+            <TooltipContent>{opt.tooltip}</TooltipContent>
+          </Tooltip>
         )
       })}
     </div>

--- a/src/renderer/src/components/status-bar/UsageRosterPanel.test.tsx
+++ b/src/renderer/src/components/status-bar/UsageRosterPanel.test.tsx
@@ -28,6 +28,7 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
   }: React.PropsWithChildren<{ onSelect?: () => void }>) => <div {...props}>{children}</div>
 }))
 
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { UsageRosterPanel, UsageRow } from './UsageRosterPanel'
 
 const signedOutCodex: ProviderRateLimits = {
@@ -90,37 +91,39 @@ describe('UsageRow', () => {
     const sessionReset = mocks.now + 2 * 60_000
     const weeklyReset = mocks.now + 7 * 24 * 60 * 60_000
     const markup = renderToStaticMarkup(
-      <UsageRosterPanel
-        providers={[
-          {
-            ...signedOutCodex,
-            session: {
-              usedPercent: 25,
-              windowMinutes: 300,
-              resetsAt: sessionReset,
-              resetDescription: null
-            },
-            weekly: {
-              usedPercent: 10,
-              windowMinutes: 10_080,
-              resetsAt: weeklyReset,
-              resetDescription: null
-            },
-            status: 'ok',
-            error: null
-          }
-        ]}
-        display="used"
-        statusBarUsageMode="verbose"
-        onStatusBarUsageModeChange={() => {}}
-        isRefreshing={false}
-        onRefresh={() => {}}
-        onOpenProvider={() => {}}
-        onSignIn={() => {}}
-        canSignIn={() => true}
-        onManageAccounts={() => {}}
-        onUsageDetails={() => {}}
-      />
+      <TooltipProvider>
+        <UsageRosterPanel
+          providers={[
+            {
+              ...signedOutCodex,
+              session: {
+                usedPercent: 25,
+                windowMinutes: 300,
+                resetsAt: sessionReset,
+                resetDescription: null
+              },
+              weekly: {
+                usedPercent: 10,
+                windowMinutes: 10_080,
+                resetsAt: weeklyReset,
+                resetDescription: null
+              },
+              status: 'ok',
+              error: null
+            }
+          ]}
+          display="used"
+          statusBarUsageMode="verbose"
+          onStatusBarUsageModeChange={() => {}}
+          isRefreshing={false}
+          onRefresh={() => {}}
+          onOpenProvider={() => {}}
+          onSignIn={() => {}}
+          canSignIn={() => true}
+          onManageAccounts={() => {}}
+          onUsageDetails={() => {}}
+        />
+      </TooltipProvider>
     )
 
     expect(mocks.useResetCountdownClock).toHaveBeenCalledOnce()
@@ -153,19 +156,21 @@ describe('UsageRosterPanel density picker', () => {
   ): void {
     act(() => {
       root.render(
-        <UsageRosterPanel
-          providers={[]}
-          display="used"
-          statusBarUsageMode={statusBarUsageMode}
-          onStatusBarUsageModeChange={onStatusBarUsageModeChange}
-          isRefreshing={false}
-          onRefresh={() => {}}
-          onOpenProvider={() => {}}
-          onSignIn={() => {}}
-          canSignIn={() => true}
-          onManageAccounts={() => {}}
-          onUsageDetails={() => {}}
-        />
+        <TooltipProvider>
+          <UsageRosterPanel
+            providers={[]}
+            display="used"
+            statusBarUsageMode={statusBarUsageMode}
+            onStatusBarUsageModeChange={onStatusBarUsageModeChange}
+            isRefreshing={false}
+            onRefresh={() => {}}
+            onOpenProvider={() => {}}
+            onSignIn={() => {}}
+            canSignIn={() => true}
+            onManageAccounts={() => {}}
+            onUsageDetails={() => {}}
+          />
+        </TooltipProvider>
       )
     })
   }

--- a/src/renderer/src/components/status-bar/UsageRosterPanel.tsx
+++ b/src/renderer/src/components/status-bar/UsageRosterPanel.tsx
@@ -239,7 +239,7 @@ export function UsageRosterPanel({
               label: translate('auto.components.status.bar.UsageRosterPanel.detailed', 'Detailed'),
               tooltip: translate(
                 'auto.components.status.bar.UsageRosterPanel.detailedTooltip',
-                'Full usage with bars, labels, and percentages in the status bar'
+                'Full usage with bars, labels, and percentages'
               )
             },
             {
@@ -247,7 +247,7 @@ export function UsageRosterPanel({
               label: translate('auto.components.status.bar.UsageRosterPanel.compact', 'Compact'),
               tooltip: translate(
                 'auto.components.status.bar.UsageRosterPanel.compactTooltip',
-                'Condensed usage — just the tightest window'
+                'Condensed usage: only the tightest window'
               )
             }
           ]}

--- a/src/renderer/src/components/status-bar/UsageRosterPanel.tsx
+++ b/src/renderer/src/components/status-bar/UsageRosterPanel.tsx
@@ -236,11 +236,19 @@ export function UsageRosterPanel({
           options={[
             {
               value: 'verbose',
-              label: translate('auto.components.status.bar.UsageRosterPanel.detailed', 'Detailed')
+              label: translate('auto.components.status.bar.UsageRosterPanel.detailed', 'Detailed'),
+              tooltip: translate(
+                'auto.components.status.bar.UsageRosterPanel.detailedTooltip',
+                'Full usage with bars, labels, and percentages in the status bar'
+              )
             },
             {
               value: 'compact',
-              label: translate('auto.components.status.bar.UsageRosterPanel.compact', 'Compact')
+              label: translate('auto.components.status.bar.UsageRosterPanel.compact', 'Compact'),
+              tooltip: translate(
+                'auto.components.status.bar.UsageRosterPanel.compactTooltip',
+                'Condensed usage — just the tightest window'
+              )
             }
           ]}
         />

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3310,8 +3310,8 @@
             "noUsageData": "No usage data",
             "detailed": "Detailed",
             "compact": "Compact",
-            "detailedTooltip": "Full usage with bars, labels, and percentages in the status bar",
-            "compactTooltip": "Condensed usage — just the tightest window",
+            "detailedTooltip": "Full usage with bars, labels, and percentages",
+            "compactTooltip": "Condensed usage: only the tightest window",
             "footerDetailAria": "Usage footer detail"
           }
         }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3310,6 +3310,8 @@
             "noUsageData": "No usage data",
             "detailed": "Detailed",
             "compact": "Compact",
+            "detailedTooltip": "Full usage with bars, labels, and percentages in the status bar",
+            "compactTooltip": "Condensed usage — just the tightest window",
             "footerDetailAria": "Usage footer detail"
           }
         }

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3287,7 +3287,9 @@
             "noUsageData": "No usage data",
             "detailed": "Detailed",
             "compact": "Compact",
-            "footerDetailAria": "Usage footer detail"
+            "footerDetailAria": "Usage footer detail",
+            "detailedTooltip": "Uso completo con barras, etiquetas y porcentajes.",
+            "compactTooltip": "Uso condensado: sólo la ventana más estrecha"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3288,7 +3288,7 @@
             "detailed": "Detailed",
             "compact": "Compact",
             "footerDetailAria": "Usage footer detail",
-            "detailedTooltip": "Uso completo con barras, etiquetas y porcentajes.",
+            "detailedTooltip": "Uso completo con barras, etiquetas y porcentajes",
             "compactTooltip": "Uso condensado: sólo la ventana más estrecha"
           }
         }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3288,8 +3288,8 @@
             "detailed": "Detailed",
             "compact": "Compact",
             "footerDetailAria": "Usage footer detail",
-            "detailedTooltip": "バー、ラベル、パーセントを完全に使用",
-            "compactTooltip": "凝縮された使用法: 最も狭いウィンドウのみ"
+            "detailedTooltip": "バー・ラベル・パーセントを含む完全な使用状況",
+            "compactTooltip": "凝縮された使用状況: 最も狭いウィンドウのみ"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3287,7 +3287,9 @@
             "noUsageData": "No usage data",
             "detailed": "Detailed",
             "compact": "Compact",
-            "footerDetailAria": "Usage footer detail"
+            "footerDetailAria": "Usage footer detail",
+            "detailedTooltip": "バー、ラベル、パーセントを完全に使用",
+            "compactTooltip": "凝縮された使用法: 最も狭いウィンドウのみ"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3287,7 +3287,9 @@
             "noUsageData": "No usage data",
             "detailed": "Detailed",
             "compact": "Compact",
-            "footerDetailAria": "Usage footer detail"
+            "footerDetailAria": "Usage footer detail",
+            "detailedTooltip": "막대, 레이블, 백분율을 포함한 전체 사용량",
+            "compactTooltip": "압축된 사용: 가장 좁은 창만 사용"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3289,7 +3289,7 @@
             "compact": "Compact",
             "footerDetailAria": "Usage footer detail",
             "detailedTooltip": "完整使用情况，包含条形图、标签和百分比",
-            "compactTooltip": "压缩使用：只使用最紧的窗口"
+            "compactTooltip": "精简使用情况：仅显示最吃紧的窗口"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3287,7 +3287,9 @@
             "noUsageData": "No usage data",
             "detailed": "Detailed",
             "compact": "Compact",
-            "footerDetailAria": "Usage footer detail"
+            "footerDetailAria": "Usage footer detail",
+            "detailedTooltip": "充分利用条形图、标签和百分比",
+            "compactTooltip": "压缩使用：只使用最紧的窗口"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3288,7 +3288,7 @@
             "detailed": "Detailed",
             "compact": "Compact",
             "footerDetailAria": "Usage footer detail",
-            "detailedTooltip": "充分利用条形图、标签和百分比",
+            "detailedTooltip": "完整使用情况，包含条形图、标签和百分比",
             "compactTooltip": "压缩使用：只使用最紧的窗口"
           }
         }


### PR DESCRIPTION
## What

The **Detailed** / **Compact** density picker in the status-bar usage popover named both modes but didn't say what they change. This adds hover tooltips so the difference is discoverable:

| Mode | Tooltip |
|---|---|
| **Detailed** | `Full usage with bars, labels, and percentages` |
| **Compact** | `Condensed usage: only the tightest window` |

Copy is translated into all locales (zh/ko/ja/es) via the repo's translate+repair policy.

## How

- `SettingsSegmentedControl` renders its buttons internally, so segments can't be wrapped from the outside. Added an optional `tooltip?: React.ReactNode` field to `SegmentedOption`; when present, the segment is wrapped in the app's `Tooltip` primitives. No behavior change for the other ~dozen segmented controls that don't set it. Relies on the global `TooltipProvider` already mounted at App root.
- Wired the copy into the Detailed/Compact options in `UsageRosterPanel` via new i18n keys (`detailedTooltip` / `compactTooltip`).

## Verification

Ran the real dev build via Electron/CDP, opened the usage popover, and hovered each segment. Both tooltips render above the control.

> **Note:** the screenshots below were captured before the final reword — they show the earlier copy (`…percentages in the status bar` / `… — just the tightest window`). Placement/behavior are identical; only the wording changed.

**Detailed**

![Detailed tooltip](https://github.com/stablyai/orca/raw/brennanb2025/tooltip-usage-screenshots/.pr-screenshots/tooltip-detailed.png)

**Compact**

![Compact tooltip](https://github.com/stablyai/orca/raw/brennanb2025/tooltip-usage-screenshots/.pr-screenshots/tooltip-compact.png)

_(Screenshots live on `brennanb2025/tooltip-usage-screenshots`, not this branch.)_
