### PR TITLE
perf(checks-panel): gate the terminal-cwd poll on window visibility

### DIFF
--- a/src/renderer/src/components/right-sidebar/use-checks-panel-terminal-worktree.test.ts
+++ b/src/renderer/src/components/right-sidebar/use-checks-panel-terminal-worktree.test.ts
@@ -129,6 +129,36 @@ describe('useChecksPanelTerminalWorktree', () => {
     expect(latest?.worktree).toBe(parentWorktree)
   })
 
+  it('does not spawn getCwd while the window is hidden, then refreshes on becoming visible', async () => {
+    getCwdMock.mockResolvedValue(`${CHILD_PATH}/src`)
+    const setVisibility = (state: 'visible' | 'hidden'): void => {
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => state
+      })
+    }
+    setVisibility('hidden')
+    try {
+      await renderHook(parentWorktree)
+      await flushMicrotasks()
+      // Hidden window: no lsof-backed cwd probe at all.
+      expect(getCwdMock).not.toHaveBeenCalled()
+      expect(latest?.worktree).toBe(parentWorktree)
+
+      setVisibility('visible')
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'))
+      })
+      await flushMicrotasks()
+      // Becoming visible runs an immediate refresh (a `cd` made while hidden
+      // is picked up promptly on return).
+      expect(getCwdMock).toHaveBeenCalledWith('pty-1')
+      expect(latest?.worktree).toBe(childWorktree)
+    } finally {
+      setVisibility('visible')
+    }
+  })
+
   it('keeps the default worktree when the cwd is outside every worktree', async () => {
     getCwdMock.mockResolvedValue('/tmp/scratch')
 

--- a/src/renderer/src/components/right-sidebar/use-checks-panel-terminal-worktree.ts
+++ b/src/renderer/src/components/right-sidebar/use-checks-panel-terminal-worktree.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '@/store'
+import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
 import { useAllWorktrees, useRepoMap } from '@/store/selectors'
 import { isRemoteRuntimePtyId } from '@/runtime/runtime-terminal-inspection'
 import { parseAppSshPtyId } from '../../../../shared/ssh-pty-id'
@@ -31,7 +32,8 @@ type ChecksPanelTerminalWorktree = {
  * the *remote* shell's OSC 7 path, which must not resolve a local worktree.
  * getCwd reads the local shell pid, so it is correct for that case. Remote
  * runtime PTYs are skipped (their cwd lives on the relay host). Polling is
- * gated on panel visibility, so a hidden panel does no background work and the
+ * gated on both panel visibility and window visibility, so a hidden panel or a
+ * hidden/minimized window does no background work (no `lsof` spawns) and the
  * caller's fallback worktree is used.
  *
  * Resolution is scoped to locally-executing worktrees: the cwd comes from a
@@ -123,11 +125,18 @@ export function useChecksPanelTerminalWorktree(args: {
       }
     }
 
-    void refresh()
-    const interval = window.setInterval(refresh, TERMINAL_CWD_POLL_MS)
+    // Why: getCwd shells out to `lsof` on macOS every tick (poll cadence >
+    // the 1.5s per-pid cache TTL, so each tick is a guaranteed miss). Gate on
+    // window visibility so a hidden/minimized window spawns no subprocesses;
+    // the helper runs an immediate refresh on becoming visible so a `cd` made
+    // while hidden is picked up promptly on return.
+    const stopInterval = installWindowVisibilityInterval({
+      run: () => void refresh(),
+      intervalMs: TERMINAL_CWD_POLL_MS
+    })
     return () => {
       disposed = true
-      window.clearInterval(interval)
+      stopInterval()
     }
   }, [activeTerminalPtyId, shouldPollCwd])
 


### PR DESCRIPTION
## Description

`useChecksPanelTerminalWorktree` polls `window.api.pty.getCwd(activeTerminalPtyId)` every 4 s to follow the active terminal's working directory so the Checks panel can track a `cd` across a stack of worktrees. The poll was gated only on **panel** visibility (`isPanelVisible`), not **window** visibility — so when the Checks tab is the active right-sidebar tab on a local PTY, a hidden or minimized window kept polling. On macOS `getCwd` shells out to `lsof` on a cache miss, and because the 4 s cadence exceeds the main-side 1.5 s per-pid cache TTL, **every tick is a guaranteed miss → a fresh `lsof` subprocess**, ~15/min, purely in the background.

The fix swaps the raw `window.setInterval` for `installWindowVisibilityInterval` — the shared helper ~14 other timers already use (git-status polling, rate-limit displays, port scanner…). It pauses while the window is hidden and runs an immediate refresh on becoming visible.

## ELI5

The panel keeps peeking at which folder your terminal is in, and on a Mac that peek launches a little helper program every 4 seconds. It kept doing this even when the whole app window was hidden or minimized — spawning background processes nobody could see the result of. Now it stops peeking while the window is hidden, and takes one fresh peek the moment you come back.

## Evidence

`src/renderer/src/components/right-sidebar/use-checks-panel-terminal-worktree.test.ts` adds a case that:

- mounts with polling eligible but the window **hidden** → `getCwd` is never called (no `lsof`);
- dispatches `visibilitychange` to **visible** → an immediate refresh fires and resolves the worktree.

Subprocess elimination while hidden: **~15 `lsof` spawns/min → 0** whenever the Checks tab is active on a local PTY and the window is hidden.

## Proof of zero regression

- The in-flight `getCwd` promise is still guarded by the effect's `disposed` flag (the cleanup sets `disposed = true` before `stopInterval()`), so no `setState`-after-unmount.
- Visible behavior is unchanged: exactly one immediate refresh on install, then every 4 s; a visible-but-unfocused window on a second monitor still polls (`installWindowVisibilityInterval` keys on `document.visibilityState`, which is visibility, not focus).
- No leaked interval or `visibilitychange` listener across deps changes (`[activeTerminalPtyId, shouldPollCwd]`): each install owns its own timer + listener and the prior cleanup tears them down.
- Tests: full file 12/12 pass; typecheck (web) clean; oxlint clean.

## Adversarial review loop

Reviewed with an adversarial `fable` reviewer instructed to refute cleanup correctness, immediate-run equivalence, hidden→visible resume, over-gating (second-monitor case), and test quality.

- **Round 1 → VERDICT: CLEAN.** The reviewer confirmed the `disposed` guard still protects the late promise, verified no double immediate-refresh, confirmed a visible-but-unfocused window keeps polling (matching the helper's own tests), and ran the file (12/12). It attempted StrictMode double-invoke, rapid hide/show toggling, and a visibilitychange racing cleanup — none held up.

**Final verdict: CLEAN (1 round).**

Made with [Orca](https://github.com/stablyai/orca) 🐋
