### PR TITLE
perf(stats): move the debounced stats write off the main thread

### DIFF
--- a/src/main/stats/collector-async-save.test.ts
+++ b/src/main/stats/collector-async-save.test.ts
@@ -1,0 +1,127 @@
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs'
+import type * as FsPromises from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Why: the debounced stats save must be async (off the main thread), while the
+// shutdown flush() must stay synchronous. These tests pin both behaviors, prove
+// the async path leaves no stray temp files, and — critically — prove an
+// in-flight async write can never clobber the more-complete shutdown flush.
+
+let userDataDir: string
+const statsPath = (): string => join(userDataDir, 'orca-stats.json')
+
+vi.mock('electron', () => ({
+  app: { getPath: () => userDataDir }
+}))
+
+// A controllable gate over node:fs/promises writeFile so a test can hold a
+// debounced async write "in flight" while it drives a synchronous shutdown flush.
+const gate = vi.hoisted(() => ({
+  blocked: false,
+  waiters: [] as (() => void)[],
+  writeFileCalls: 0
+}))
+
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof FsPromises>('node:fs/promises')
+  const writeFile = (async (...args: Parameters<typeof actual.writeFile>) => {
+    gate.writeFileCalls += 1
+    if (gate.blocked) {
+      await new Promise<void>((resolve) => gate.waiters.push(resolve))
+    }
+    return actual.writeFile(...args)
+  }) as typeof actual.writeFile
+  return { ...actual, writeFile }
+})
+
+async function importCollector() {
+  return import('./collector')
+}
+
+describe('StatsCollector async debounced save', () => {
+  beforeEach(() => {
+    userDataDir = mkdtempSync(join(tmpdir(), 'orca-stats-test-'))
+    gate.blocked = false
+    gate.waiters = []
+    gate.writeFileCalls = 0
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    rmSync(userDataDir, { recursive: true, force: true })
+    vi.useRealTimers()
+  })
+
+  it('writes valid JSON via the async fs/promises path on the debounced timer, no stray temp files', async () => {
+    vi.useFakeTimers()
+    const { StatsCollector, initStatsPath } = await importCollector()
+    initStatsPath()
+    const collector = new StatsCollector()
+
+    collector.onAgentStart('pty-1', Date.now(), 'repo-1', 'wt-1')
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    await vi.waitFor(() => {
+      expect(readdirSync(userDataDir)).toContain('orca-stats.json')
+    })
+
+    // Proves the debounced path went through async fs/promises writeFile (a
+    // revert to writeFileSync would leave this at 0).
+    expect(gate.writeFileCalls).toBeGreaterThan(0)
+    // No stray *.tmp files — the rename completed.
+    expect(readdirSync(userDataDir).filter((f) => f.endsWith('.tmp'))).toHaveLength(0)
+
+    const parsed = JSON.parse(readFileSync(statsPath(), 'utf-8'))
+    expect(parsed.aggregates.totalAgentsSpawned).toBe(1)
+    expect(Array.isArray(parsed.events)).toBe(true)
+  })
+
+  it('flush() writes synchronously (no timer, immediately on disk)', async () => {
+    const { StatsCollector, initStatsPath } = await importCollector()
+    initStatsPath()
+    const collector = new StatsCollector()
+
+    collector.onAgentStart('pty-2', Date.now())
+    collector.flush()
+
+    // Synchronous: the file exists immediately with no awaiting.
+    const parsed = JSON.parse(readFileSync(statsPath(), 'utf-8'))
+    expect(parsed.aggregates.totalAgentsSpawned).toBe(1)
+  })
+
+  it('an in-flight async write is vetoed by a shutdown flush (no data-loss clobber)', async () => {
+    const { StatsCollector, initStatsPath } = await importCollector()
+    initStatsPath()
+    const collector = new StatsCollector()
+    // White-box: drive the two writers directly so the race is deterministic
+    // (the debounce path calls writeToDiskAsync; flush() calls writeToDiskSync).
+    const internals = collector as unknown as { writeToDiskAsync: () => Promise<void> }
+
+    collector.onAgentStart('pty-a', 1_000)
+    collector.onAgentStart('pty-b', 1_000)
+
+    // Start the async write; it parks inside the blocked writeFile, before rename.
+    gate.blocked = true
+    const inflight = internals.writeToDiskAsync()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(gate.writeFileCalls).toBeGreaterThan(0)
+
+    // App quits: close out both agents and flush the COMPLETE state synchronously
+    // (newer generation) while the async write is still parked.
+    collector.onAgentStop('pty-a', 5_000)
+    collector.onAgentStop('pty-b', 5_000)
+    collector.flush()
+    expect(JSON.parse(readFileSync(statsPath(), 'utf-8')).aggregates.totalAgentTimeMs).toBe(8_000)
+
+    // Release the parked write; its older generation must be vetoed — the
+    // flushed data must survive and no temp file may leak.
+    gate.blocked = false
+    gate.waiters.splice(0).forEach((resolve) => resolve())
+    await inflight
+
+    expect(JSON.parse(readFileSync(statsPath(), 'utf-8')).aggregates.totalAgentTimeMs).toBe(8_000)
+    expect(readdirSync(userDataDir).filter((f) => f.endsWith('.tmp'))).toHaveLength(0)
+  })
+})

--- a/src/main/stats/collector.ts
+++ b/src/main/stats/collector.ts
@@ -1,5 +1,6 @@
 import { app } from 'electron'
 import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from 'node:fs'
+import { writeFile, mkdir, rm } from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import type { StatsSummary } from '../../shared/types'
 import type { StatsEvent, StatsAggregates, StatsFile } from './types'
@@ -55,6 +56,10 @@ export class StatsCollector {
   private aggregates: StatsAggregates
   private liveAgents = new Map<string, number>() // ptyId → startTimestamp
   private writeTimer: ReturnType<typeof setTimeout> | null = null
+  // Monotonic id stamped on each prepared payload; the highest committed one
+  // wins so a slow in-flight async write can't clobber a newer sync flush.
+  private writeGeneration = 0
+  private lastCommittedGeneration = 0
   // Why: star-nag lives in its own service but needs to observe the running
   // agent-spawned counter. A lightweight listener avoids cyclic imports and
   // keeps StatsCollector unaware of how the counter is consumed.
@@ -226,11 +231,15 @@ export class StatsCollector {
     }
     this.writeTimer = setTimeout(() => {
       this.writeTimer = null
-      try {
-        this.writeToDiskSync()
-      } catch (err) {
+      // Why: the debounced save is fun-stats telemetry, not crash-critical
+      // state, so it uses the async writer to move the ~900KB tmp-file write
+      // off the main thread (the stringify stays sync — see prepareWritePayload).
+      // A chatty multi-agent session re-arms this every 5s; a fully-sync write
+      // is a recurring main-thread stall. Shutdown flush() stays synchronous;
+      // the generation guard keeps the two paths race-safe.
+      void this.writeToDiskAsync().catch((err) => {
         console.error('[stats] Failed to write stats:', err)
-      }
+      })
     }, DEBOUNCE_MS)
   }
 
@@ -241,12 +250,18 @@ export class StatsCollector {
     }
   }
 
-  private writeToDiskSync(): void {
+  // Serialize the current state and pick a unique temp path. Trimming mutates
+  // in-memory state and JSON.stringify must see a consistent snapshot, so both
+  // writers call this synchronously before any await to avoid a torn snapshot.
+  // The monotonic generation lets a later write veto an earlier, still-in-flight
+  // one so a stale rename can never win (see writeToDiskAsync).
+  private prepareWritePayload(): {
+    statsFile: string
+    tmpFile: string
+    json: string
+    generation: number
+  } {
     const statsFile = getStatsFile()
-    const dir = dirname(statsFile)
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true })
-    }
 
     // Trim events to bounded size before writing
     if (this.events.length > MAX_EVENTS) {
@@ -259,10 +274,44 @@ export class StatsCollector {
       aggregates: this.aggregates
     }
 
-    // Why unique temp file: same race-safe pattern as persistence.ts:120 —
-    // synchronous flushes can race the debounced writer during shutdown.
+    const generation = ++this.writeGeneration
+    // Unique temp file so the async debounced writer and the sync shutdown
+    // flush never write the same temp path (same pattern as persistence.ts).
     const tmpFile = `${statsFile}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
-    writeFileSync(tmpFile, JSON.stringify(data), 'utf-8')
+    return { statsFile, tmpFile, json: JSON.stringify(data), generation }
+  }
+
+  private writeToDiskSync(): void {
+    const dir = dirname(getStatsFile())
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true })
+    }
+    const { statsFile, tmpFile, json, generation } = this.prepareWritePayload()
+    writeFileSync(tmpFile, json, 'utf-8')
     renameSync(tmpFile, statsFile)
+    this.lastCommittedGeneration = Math.max(this.lastCommittedGeneration, generation)
+  }
+
+  private async writeToDiskAsync(): Promise<void> {
+    const dir = dirname(getStatsFile())
+    if (!existsSync(dir)) {
+      await mkdir(dir, { recursive: true })
+    }
+    const { statsFile, tmpFile, json, generation } = this.prepareWritePayload()
+    // Only the ~900KB tmp write moves off the main thread; stringify stayed sync
+    // above (torn-snapshot constraint). The rename is a trivial metadata op done
+    // SYNCHRONOUSLY so it stays ordered with the shutdown flush's renameSync —
+    // an async rename could land after flush and clobber the more-complete
+    // shutdown data. The generation guard vetoes this write if a newer one (a
+    // later debounce OR the shutdown flush) already committed while we were
+    // writing; the check + rename run with no await between them, so the sync
+    // flush cannot interleave.
+    await writeFile(tmpFile, json, 'utf-8')
+    if (this.lastCommittedGeneration >= generation) {
+      await rm(tmpFile, { force: true }).catch(() => {})
+      return
+    }
+    renameSync(tmpFile, statsFile)
+    this.lastCommittedGeneration = generation
   }
 }


### PR DESCRIPTION
## Description

The fun-stats collector (`StatsCollector`) debounces a save 5 s after activity and, on fire, did a **synchronous** `JSON.stringify` + `writeFileSync` + `renameSync` of the stats file (up to ~900 KB) on the Electron **main** thread. A chatty multi-agent session re-arms that debounce continuously (agents cycling working↔idle), so it's a recurring main-thread stall for data that is explicitly non-durable ("fun stats", not billing).

This makes the **debounced** save async: the tmp-file write moves to `node:fs/promises` `writeFile` (off the main thread). The `stringify` stays synchronous — it must serialize a consistent snapshot before any `await` — and the **rename stays synchronous** so it remains ordered with the shutdown flush. The **shutdown `flush()`** (before-quit) remains fully synchronous.

A monotonic write generation guards against a stale write winning: each prepared payload gets `++writeGeneration`; a write only renames if no newer generation has committed. So a later debounce **or** the synchronous shutdown flush vetoes an older, still-in-flight async write.

## ELI5

Every 5 seconds the app wrote its "lifetime stats" file, and it froze the main thread for that whole write. Now it does the slow part (writing the file) in the background. The tricky bit: when you quit, the app writes the *final* complete stats synchronously — we had to make sure a slow background write already in progress can't finish *afterwards* and overwrite that final file with older data. A little version counter guarantees the newest write always wins.

## Evidence

`src/main/stats/collector-async-save.test.ts`:

- **async path**: the debounced save goes through the mocked `fs/promises` `writeFile` (a revert to `writeFileSync` would leave the call count at 0), writes valid JSON, and leaves no stray `.tmp` files.
- **sync shutdown**: `flush()` produces the file synchronously (read immediately after, no `await`).
- **race / data-loss guard**: an async write is deterministically held in-flight (mocked `writeFile` blocked) while a synchronous `flush()` writes the complete state (newer generation); on release, the in-flight write is vetoed — the flushed data survives and no `.tmp` leaks.

## Proof of zero regression

- The data-loss race that a synchronous-only original could not have (`rename` landing after shutdown flush) is closed by the generation guard: the check + `renameSync` run with no `await` between them, so the sync flush can't interleave, and any in-flight write with an older generation `rm`s its temp instead of renaming.
- Overlapping debounced writes commit newest-last (same guard).
- Torn-snapshot safe: `prepareWritePayload` trims + stringifies with no `await`, so a concurrent `record()` can't corrupt an already-serialized payload.
- Tests: 20 pass (3 files); `tsc -p config/tsconfig.node.json` clean; oxlint clean.

**Caveat:** only the file write moved off-thread; the `JSON.stringify` stays synchronous (snapshot-atomicity constraint), so the main-thread win is the I/O portion, not the full stall. A hard process kill mid-write can orphan one `.tmp` in `userData` — pre-existing behavior of the unique-temp-name pattern (matches `persistence.ts`).

## Adversarial review loop

Reviewed with an adversarial `fable` reviewer across two rounds.

- **Round 1 → VERDICT: ISSUES.** Found a **MAJOR** data-loss race: an in-flight async `rename` from the debounce could land *after* the synchronous shutdown `flush()` and clobber the more-complete shutdown data (a regression vs. the all-sync original, since `will-quit` defers via `preventDefault()` and keeps the loop alive). Also flagged: overlapping-write ordering, an over-claiming comment ("stringify+write off the main thread"), and a first test that didn't actually pin asynchrony.
- **Fixes applied:** monotonic generation guard + synchronous `renameSync` in the async path; corrected comments (stringify stays sync); rewrote the test to prove the async `writeFile` path **and** to deterministically exercise the shutdown-race veto.
- **Round 2 → VERDICT: CLEAN.** The reviewer walked both interleavings, confirmed the race is closed (no `await` between the generation check and `renameSync`), verified newest-write-wins for overlapping writes, confirmed no new bugs from moving to `renameSync`, and confirmed the deferred-quit case holds. Ran the suite (3/3), typecheck, oxlint — all clean.

**Final verdict: CLEAN (2 rounds).**

Made with [Orca](https://github.com/stablyai/orca) 🐋
