### PR TITLE
perf(linear): lazy-load @linear/sdk off the launch parse path

### DIFF
--- a/src/main/linear/client.test.ts
+++ b/src/main/linear/client.test.ts
@@ -102,9 +102,13 @@ async function loadClientModule(options: SafeStorageMockOptions = {}) {
     return { ...actual, homedir: () => tempHome }
   })
   class AuthenticationLinearError extends Error {}
-  vi.doMock('@linear/sdk', () => ({
-    AuthenticationLinearError,
-    LinearClient: linearClientMock
+  // Why: client.ts loads @linear/sdk lazily via ./linear-sdk (createRequire) to
+  // keep it off the startup parse path; mock the loader, not the raw module.
+  vi.doMock('./linear-sdk', () => ({
+    loadLinearSdk: () => ({
+      AuthenticationLinearError,
+      LinearClient: linearClientMock
+    })
   }))
 
   return import('./client')

--- a/src/main/linear/client.ts
+++ b/src/main/linear/client.ts
@@ -2,10 +2,11 @@
    selection share one module so keychain-safe status reads and token mutation
    stay in one consistency boundary. */
 import { safeStorage } from 'electron'
-import { LinearClient, AuthenticationLinearError } from '@linear/sdk'
+import type { LinearClient } from '@linear/sdk'
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import { loadLinearSdk } from './linear-sdk'
 import {
   CredentialDecryptionError,
   credentialFileHasContent,
@@ -515,7 +516,7 @@ export function getClient(workspaceId?: string | null): LinearClient | null {
   if (!token) {
     return null
   }
-  return new LinearClient({ apiKey: token })
+  return new (loadLinearSdk().LinearClient)({ apiKey: token })
 }
 
 export function getClients(
@@ -546,13 +547,17 @@ export function getClients(
     if (!token) {
       continue
     }
-    clients.push({ workspace, client: new LinearClient({ apiKey: token }), apiKey: token })
+    clients.push({
+      workspace,
+      client: new (loadLinearSdk().LinearClient)({ apiKey: token }),
+      apiKey: token
+    })
   }
   return clients
 }
 
 export function getPublicFileUrlClient(entry: LinearClientForWorkspace): LinearClient {
-  return new LinearClient({
+  return new (loadLinearSdk().LinearClient)({
     apiKey: entry.apiKey,
     headers: {
       'public-file-urls-expire-in': String(LINEAR_PUBLIC_FILE_URL_EXPIRY_SECONDS)
@@ -565,7 +570,7 @@ export function getPublicFileUrlClient(entry: LinearClientForWorkspace): LinearC
 // renderer. All other errors are swallowed with console.warn to match GitHub
 // client's graceful degradation.
 export function isAuthError(error: unknown): boolean {
-  return error instanceof AuthenticationLinearError
+  return error instanceof loadLinearSdk().AuthenticationLinearError
 }
 
 // ── Connect / disconnect / status ────────────────────────────────────
@@ -575,7 +580,7 @@ export async function connect(
   { ok: true; viewer: LinearViewer; workspace: LinearWorkspace } | { ok: false; error: string }
 > {
   try {
-    const client = new LinearClient({ apiKey })
+    const client = new (loadLinearSdk().LinearClient)({ apiKey })
     const me = await client.viewer
     const org = await me.organization
     const workspace = workspaceFromLinearData(me, org)
@@ -670,7 +675,7 @@ export async function testConnection(
   }
 
   try {
-    const client = new LinearClient({ apiKey: token })
+    const client = new (loadLinearSdk().LinearClient)({ apiKey: token })
     const me = await client.viewer
     const org = await me.organization
     const workspace = workspaceFromLinearData(me, org)

--- a/src/main/linear/issues.ts
+++ b/src/main/linear/issues.ts
@@ -9,7 +9,8 @@ import type {
   LinearWorkspaceError,
   LinearWorkspaceSelection
 } from '../../shared/types'
-import { LinearClient } from '@linear/sdk'
+import type { LinearClient } from '@linear/sdk'
+import { loadLinearSdk } from './linear-sdk'
 import {
   LINEAR_ISSUE_API_PAGE_SIZE_MAX,
   clampLinearIssueListLimit
@@ -602,7 +603,9 @@ async function runLinearWrite<T>(
 ): Promise<T> {
   await acquire()
   try {
-    const client = signal ? new LinearClient({ apiKey: entry.apiKey, signal }) : entry.client
+    const client = signal
+      ? new (loadLinearSdk().LinearClient)({ apiKey: entry.apiKey, signal })
+      : entry.client
     return await write(client)
   } catch (error) {
     if (error instanceof LinearWriteFailure) {

--- a/src/main/linear/linear-sdk.ts
+++ b/src/main/linear/linear-sdk.ts
@@ -1,0 +1,32 @@
+import type { LinearClient } from '@linear/sdk'
+import { createRequire } from 'node:module'
+
+// The subset of @linear/sdk that client.ts constructs / type-checks. Declared
+// structurally (not `typeof import('@linear/sdk')`) so this loader never forces
+// an eager module import and satisfies the no-`import()`-type lint rule.
+export type LinearSdkModule = {
+  LinearClient: new (options: {
+    apiKey: string
+    headers?: Record<string, string>
+    signal?: AbortSignal
+  }) => LinearClient
+  AuthenticationLinearError: new (...args: never[]) => Error
+}
+
+// Why: @linear/sdk is a ~2.6MB CJS bundle (~33ms to parse). The Linear client
+// module is imported on the main-process startup path (orca-runtime + ipc), but
+// the SDK itself is only needed once the user actually acts on Linear. Load it
+// lazily via createRequire so launch never parses it for the majority who never
+// connect Linear, and cache it so repeat calls are free. The accessor stays
+// synchronous so the client factories don't have to become async.
+//
+// Kept in its own module (rather than a bare createRequire in client.ts) so
+// tests can mock the loader — a raw createRequire bypasses vitest's module
+// registry, but `vi.doMock('./linear-sdk', …)` on this module works.
+const requireFromMain = createRequire(__filename)
+let cached: LinearSdkModule | null = null
+
+export function loadLinearSdk(): LinearSdkModule {
+  cached ??= requireFromMain('@linear/sdk') as LinearSdkModule
+  return cached
+}


### PR DESCRIPTION
## Description

`@linear/sdk` is a ~2.6 MB CJS bundle (~33 ms to parse). Because `src/main/linear/client.ts` (and `issues.ts`) statically imported it, and those modules are on the main-process startup path (imported by `orca-runtime` and `ipc/linear`), it was emitted as a **hoisted top-level `require("@linear/sdk")` in the eager main index chunk** — parsed at launch for **every** user, including the majority who never connect Linear.

This introduces `src/main/linear/linear-sdk.ts`, a cached **synchronous** lazy loader using `createRequire(__filename)` (the same pattern already shipping in `windows-user-path-registry.ts`), and routes the value-site usages through it: `new (loadLinearSdk().LinearClient)(…)` and `error instanceof loadLinearSdk().AuthenticationLinearError`. `LinearClient` becomes a type-only import. The accessor stays synchronous, so the client factories don't have to become `async`.

Isolating the loader in its own module also keeps it mockable — a raw `createRequire` bypasses vitest's module registry, but `vi.doMock('./linear-sdk', …)` works.

## ELI5

The app was loading and parsing a big 2.6 MB Linear library the instant it started up — for everyone, even people who never use Linear. That's ~33 ms of startup work no one asked for. Now the library is only loaded the first time you actually do something with Linear, and it's remembered after that.

## Evidence

- **Rebuild verification:** after the change, the built `out/main/index.js` contains **zero** top-level `require("@linear/sdk")` (was exactly one); the only occurrence left is `requireFromMain("@linear/sdk")` inside the lazy `loadLinearSdk()` body. → ~33 ms of parse removed from cold launch for all users, and the SDK leaves the eager main chunk.
- `src/main/linear/client.test.ts` updated to mock the loader (`./linear-sdk`) instead of the raw module.

## Proof of zero regression

- Completeness: every value-use of `@linear/sdk` in `src/main` now routes through `loadLinearSdk()`; the only remaining references are `import type` (erased) and the lazy require. No stray `new LinearClient` / `instanceof AuthenticationLinearError` anywhere else.
- Runtime identity preserved: `loadLinearSdk()` returns the **real** module via `require`, so `instanceof` and construction behave exactly as before; the structural `LinearSdkModule` type is compile-time only and covers every call-site option (`apiKey`, `headers?`, `signal?`).
- Packaging: `@linear/sdk` is externalized (stays in `node_modules`) and explicitly listed in `PACKAGED_RUNTIME_PACKAGE_ROOTS`, so the packaged app still ships it — same arrangement `windows-native-registry` already uses.
- Tests: full `src/main/linear` suite (12 files, 87 tests) passes; `tsc -p config/tsconfig.node.json` clean; oxlint clean.

## Adversarial review loop

Reviewed with an adversarial `fable` reviewer instructed to refute completeness, type fidelity, `instanceof` correctness, `createRequire` validity in the bundled CJS main, caching/thread-safety, and test fidelity.

- **Round 1 → VERDICT: CLEAN.** The reviewer grepped the whole `src/` tree (only `import type` + the lazy require remain), checked the built `out/main/index.js` (zero eager require, one lazy), verified the structural type is a strict narrowing of the real `LinearClientOptions` covering every call site, ran an unmocked probe of the real loader under vitest (resolves + caches), confirmed packaging via `PACKAGED_RUNTIME_PACKAGE_ROOTS`, and ran the full suite (87/87). No issues found.

**Final verdict: CLEAN (1 round).**

Made with [Orca](https://github.com/stablyai/orca) 🐋
