### PR TITLE
fix(native-chat): add reconciliation to catch missed transcript updates

### DIFF
--- a/src/main/native-chat/transcript-file-version.ts
+++ b/src/main/native-chat/transcript-file-version.ts
@@ -1,0 +1,30 @@
+import { stat } from 'node:fs/promises'
+
+export type TranscriptFileVersion = {
+  identity: string
+  size: number
+  mtimeMs: number
+  ctimeMs: number
+}
+
+export async function readTranscriptFileVersion(filePath: string): Promise<TranscriptFileVersion> {
+  const value = await stat(filePath)
+  return {
+    identity: `${value.dev}:${value.ino}`,
+    size: value.size,
+    mtimeMs: value.mtimeMs,
+    ctimeMs: value.ctimeMs
+  }
+}
+
+export function transcriptFileVersionChanged(
+  current: TranscriptFileVersion,
+  previous: TranscriptFileVersion
+): boolean {
+  return (
+    current.identity !== previous.identity ||
+    current.size !== previous.size ||
+    current.mtimeMs !== previous.mtimeMs ||
+    current.ctimeMs !== previous.ctimeMs
+  )
+}

--- a/src/main/native-chat/transcript-native-watcher.ts
+++ b/src/main/native-chat/transcript-native-watcher.ts
@@ -1,0 +1,80 @@
+import { watch, type FSWatcher } from 'node:fs'
+import { basename, dirname } from 'node:path'
+
+export type TranscriptNativeWatcher = {
+  bind: () => boolean
+  invalidate: () => void
+  needsRebind: () => boolean
+  dispose: () => void
+}
+
+export function createTranscriptNativeWatcher(
+  filePath: string,
+  onEvent: () => void,
+  onError: () => void
+): TranscriptNativeWatcher {
+  const watchedName = basename(filePath)
+  let disposed = false
+  let watcher: FSWatcher | null = null
+  let rebindNeeded = true
+
+  function invalidateCandidate(candidate: FSWatcher): void {
+    if (watcher !== candidate) {
+      return
+    }
+    watcher = null
+    rebindNeeded = true
+    candidate.close()
+  }
+
+  return {
+    bind(): boolean {
+      if (disposed || watcher) {
+        return watcher !== null
+      }
+      let nextWatcher: FSWatcher
+      try {
+        // Why: watching the parent survives target-file replacement on macOS.
+        nextWatcher = watch(dirname(filePath), (event, changedName) => {
+          if (changedName !== null && changedName.toString() !== watchedName) {
+            return
+          }
+          // Why: a parent replacement may emit rename without a watcher error.
+          if (event === 'rename') {
+            invalidateCandidate(nextWatcher)
+          }
+          onEvent()
+        })
+      } catch {
+        rebindNeeded = true
+        return false
+      }
+      // Why: an active tail should not keep a headless runtime alive during shutdown.
+      nextWatcher.unref?.()
+      nextWatcher.on('error', () => {
+        if (disposed || watcher !== nextWatcher) {
+          return
+        }
+        invalidateCandidate(nextWatcher)
+        onError()
+      })
+      watcher = nextWatcher
+      rebindNeeded = false
+      return true
+    },
+    invalidate(): void {
+      if (watcher) {
+        invalidateCandidate(watcher)
+      } else {
+        rebindNeeded = true
+      }
+    },
+    needsRebind: () => rebindNeeded,
+    dispose(): void {
+      disposed = true
+      watcher?.close()
+      watcher = null
+      rebindNeeded = false
+    }
+  }
+}

--- a/src/main/native-chat/transcript-native-watcher.ts
+++ b/src/main/native-chat/transcript-native-watcher.ts
@@ -2,12 +2,19 @@ import { watch, type FSWatcher } from 'node:fs'
 import { basename, dirname } from 'node:path'
 
 export type TranscriptNativeWatcher = {
+  /** Best-effort bind; false keeps the caller in reconciliation-only mode. */
   bind: () => boolean
+  /** Detach from an identity that may no longer represent the watched path. */
   invalidate: () => void
   needsRebind: () => boolean
   dispose: () => void
 }
 
+/**
+ * Optional fs.watch acceleration for transcript reconciliation. Native watches
+ * can fail on otherwise-readable remote filesystems, so binding is retryable
+ * and never owns transcript liveness; the caller's polling loop does.
+ */
 export function createTranscriptNativeWatcher(
   filePath: string,
   onEvent: () => void,

--- a/src/main/native-chat/transcript-watch-contract.ts
+++ b/src/main/native-chat/transcript-watch-contract.ts
@@ -28,6 +28,8 @@ export type SubscribeNativeChatTranscriptArgs = ResolveSessionFileOptions & {
   debounceMs?: number
   /** Test-only override for the production resolve-poll backoff. */
   resolvePollIntervalMs?: number
+  /** Test-only override for the host-side watcher reconciliation interval. */
+  reconciliationIntervalMs?: number
 }
 
 export type NativeChatTranscriptSubscription = {

--- a/src/main/native-chat/transcript-watch-engine.ts
+++ b/src/main/native-chat/transcript-watch-engine.ts
@@ -1,6 +1,4 @@
-import { watch, type FSWatcher } from 'node:fs'
 import { open, stat } from 'node:fs/promises'
-import { basename, dirname } from 'node:path'
 import type { NativeChatMessage, NativeChatTurnLifecycle } from '../../shared/native-chat-types'
 import {
   readTranscriptFileVersion,
@@ -12,6 +10,7 @@ import {
   resetIncrementalTranscriptState,
   type IncrementalTranscriptState
 } from './transcript-incremental-reader'
+import { createTranscriptNativeWatcher } from './transcript-native-watcher'
 import { readNativeChatTranscriptTailFile } from './transcript-tail-reader'
 import { nativeChatTurnLifecycleDecoderForAgent } from './transcript-turn-lifecycle'
 import type {
@@ -45,12 +44,9 @@ async function boundaryFingerprint(filePath: string, offset: number): Promise<st
 
 /**
  * Install the live-tail engine on an already-resolved file path. Returns null
- * (rather than throwing) when the file doesn't exist yet or `watch()` fails —
- * e.g. an explicit transcriptPath whose first JSONL line hasn't flushed, or a
- * file that vanished between resolve and install — so the caller falls back to
- * the resolve-poll below instead of surfacing a hard error (#8401). The
- * existence gate matters because the engine watches the parent directory (see
- * bindWatcher), which succeeds even when the file itself is missing.
+ * when the file doesn't exist yet, so the caller falls back to resolve-polling.
+ * A failed native watch still installs a reconciliation-only subscription: some
+ * remote filesystems allow stat/read while rejecting fs.watch entirely.
  */
 export async function installTranscriptWatcher(
   filePath: string,
@@ -82,8 +78,6 @@ export async function installTranscriptWatcher(
   let reading = false
   let pendingReadRequested = false
   let rotationRetryCount = 0
-  let watcher: FSWatcher | null = null
-  let watcherNeedsRebind = false
 
   function scheduleRotationRetry(): void {
     if (closed) {
@@ -119,24 +113,50 @@ export async function installTranscriptWatcher(
     }
   }
 
+  async function finishSuccessfulDrain(startVersion: TranscriptFileVersion): Promise<void> {
+    watchedBoundary = await boundaryFingerprint(filePath, state.offset)
+    const completedVersion = await readTranscriptFileVersion(filePath)
+    if (transcriptFileVersionChanged(completedVersion, startVersion)) {
+      // Why: a write racing this drain needs another pass even when the reader
+      // happened to reach its new EOF; timestamp-only rewrites may need replace.
+      watchedVersion = startVersion
+      pendingReadRequested = true
+    } else {
+      watchedVersion = completedVersion
+    }
+    if (closed) {
+      return
+    }
+    if (!nativeWatcher.needsRebind() || nativeWatcher.bind()) {
+      rotationRetryCount = 0
+      return
+    }
+    scheduleRotationRetry()
+  }
+
   async function drainOnce(): Promise<void> {
     const current = await readTranscriptFileVersion(filePath)
     const currentBoundary = await boundaryFingerprint(filePath, state.offset)
     if (closed) {
       return
     }
-    if (watcherNeedsRebind) {
-      bindWatcher()
-    }
     const identityChanged = watchedVersion !== null && current.identity !== watchedVersion.identity
+    const sameSizeVersionChanged =
+      watchedVersion !== null &&
+      current.identity === watchedVersion.identity &&
+      current.size === watchedVersion.size &&
+      transcriptFileVersionChanged(current, watchedVersion)
     const contentReplaced =
       identityChanged ||
+      sameSizeVersionChanged ||
       current.size < state.offset ||
       (state.offset > 0 && watchedBoundary !== currentBoundary)
+    if (identityChanged) {
+      nativeWatcher.invalidate()
+    }
     if (contentReplaced) {
       resetIncrementalTranscriptState(state)
     }
-    watchedVersion = current
 
     const replacementSnapshot =
       // Why: 0 is a valid window — an explicit undefined check keeps an empty
@@ -164,8 +184,7 @@ export async function installTranscriptWatcher(
         replacementSnapshot.lifecycle
       )
       await readAndEmitAppends()
-      watchedBoundary = await boundaryFingerprint(filePath, state.offset)
-      rotationRetryCount = 0
+      await finishSuccessfulDrain(current)
       return
     }
 
@@ -208,14 +227,16 @@ export async function installTranscriptWatcher(
             lifecycle = nextLifecycle
           }
         )
+        if (closed) {
+          return
+        }
         onInitialSnapshot(messages, false, 0, undefined, lifecycle)
       }
     } else {
       initialDrain = false
       await readAndEmitAppends()
     }
-    watchedBoundary = await boundaryFingerprint(filePath, state.offset)
-    rotationRetryCount = 0
+    await finishSuccessfulDrain(current)
   }
 
   async function drain(): Promise<void> {
@@ -238,7 +259,7 @@ export async function installTranscriptWatcher(
           // A still-pending initial drain also surfaces one error snapshot so a
           // watching client isn't stranded at 'loading' when the read keeps
           // throwing; initialDrain stays true so a recovered read can still win.
-          if (initialDrain && onInitialSnapshot && !initialErrorEmitted) {
+          if (!closed && initialDrain && onInitialSnapshot && !initialErrorEmitted) {
             initialErrorEmitted = true
             onInitialSnapshot([], false, 0, 'Transcript unavailable')
           }
@@ -262,7 +283,7 @@ export async function installTranscriptWatcher(
       }
       const versionChanged =
         watchedVersion === null || transcriptFileVersionChanged(current, watchedVersion)
-      if (versionChanged || current.size !== state.offset || watcherNeedsRebind) {
+      if (versionChanged || current.size !== state.offset || nativeWatcher.needsRebind()) {
         await drain()
       }
     } catch {
@@ -278,39 +299,13 @@ export async function installTranscriptWatcher(
     drain: () => void drain(),
     reconcile
   })
+  const nativeWatcher = createTranscriptNativeWatcher(
+    filePath,
+    () => scheduler.scheduleEventDrain(),
+    scheduleRotationRetry
+  )
 
-  function bindWatcher(): void {
-    const watchedName = basename(filePath)
-    // Why: file watchers stay bound to an unlinked inode on macOS. Watching
-    // the parent keeps observing a successor even after a long recreate gap.
-    const nextWatcher = watch(dirname(filePath), (_event, changedName) => {
-      if (changedName === null || changedName.toString() === watchedName) {
-        scheduler.scheduleEventDrain()
-      }
-    })
-    // Why: an active tail should not keep a headless runtime alive during shutdown.
-    nextWatcher.unref?.()
-    nextWatcher.on('error', () => {
-      // Why: Windows can emit EPERM when a watched directory disappears. An
-      // error listener prevents a process crash and retries against its successor.
-      if (closed || watcher !== nextWatcher) {
-        return
-      }
-      watcherNeedsRebind = true
-      nextWatcher.close()
-      watcher = null
-      scheduleRotationRetry()
-    })
-    watcher = nextWatcher
-    watcherNeedsRebind = false
-  }
-
-  try {
-    bindWatcher()
-  } catch {
-    // File vanished between resolve and watch.
-    return null
-  }
+  nativeWatcher.bind()
   activeWatcherCount++
   scheduler.startReconciliation()
   scheduler.scheduleEventDrain()
@@ -323,8 +318,7 @@ export async function installTranscriptWatcher(
       }
       closed = true
       scheduler.dispose()
-      watcher?.close()
-      watcher = null
+      nativeWatcher.dispose()
       activeWatcherCount--
     }
   }

--- a/src/main/native-chat/transcript-watch-engine.ts
+++ b/src/main/native-chat/transcript-watch-engine.ts
@@ -3,6 +3,11 @@ import { open, stat } from 'node:fs/promises'
 import { basename, dirname } from 'node:path'
 import type { NativeChatMessage, NativeChatTurnLifecycle } from '../../shared/native-chat-types'
 import {
+  readTranscriptFileVersion,
+  transcriptFileVersionChanged,
+  type TranscriptFileVersion
+} from './transcript-file-version'
+import {
   readIncrementalTranscriptMessages,
   resetIncrementalTranscriptState,
   type IncrementalTranscriptState
@@ -13,19 +18,14 @@ import type {
   NativeChatTranscriptSubscription,
   SubscribeNativeChatTranscriptArgs
 } from './transcript-watch-contract'
+import { createTranscriptWatchScheduler } from './transcript-watch-scheduler'
 
-const DEFAULT_DEBOUNCE_MS = 40
 const ROTATION_RETRY_MS = 25
 const MAX_ROTATION_RETRY_MS = 2_000
 let activeWatcherCount = 0
 
 export function getActiveNativeChatWatcherCount(): number {
   return activeWatcherCount
-}
-
-async function fileVersion(filePath: string): Promise<{ identity: string; size: number }> {
-  const value = await stat(filePath)
-  return { identity: `${value.dev}:${value.ino}`, size: value.size }
 }
 
 async function boundaryFingerprint(filePath: string, offset: number): Promise<string> {
@@ -62,7 +62,7 @@ export async function installTranscriptWatcher(
   } catch {
     return null
   }
-  const { onAppend, onInitialSnapshot, onReplace, initialLimit, debounceMs } = args
+  const { onAppend, onInitialSnapshot, onReplace, initialLimit } = args
   const decodeLifecycle = nativeChatTurnLifecycleDecoderForAgent(args.agent)
 
   const state: IncrementalTranscriptState = {
@@ -72,7 +72,7 @@ export async function installTranscriptWatcher(
     pendingBytes: 0,
     droppingOversizedRecord: false
   }
-  let watchedIdentity: string | null = null
+  let watchedVersion: TranscriptFileVersion | null = null
   let watchedBoundary = ''
   let initialDrain = true
   // Guards the one-time error snapshot emitted when the initial drain throws, so
@@ -82,36 +82,20 @@ export async function installTranscriptWatcher(
   let reading = false
   let pendingReadRequested = false
   let rotationRetryCount = 0
-  let debounceTimer: ReturnType<typeof setTimeout> | null = null
   let watcher: FSWatcher | null = null
   let watcherNeedsRebind = false
 
-  function scheduleDrain(): void {
-    if (closed) {
-      return
-    }
-    if (debounceTimer) {
-      clearTimeout(debounceTimer)
-    }
-    debounceTimer = setTimeout(() => {
-      debounceTimer = null
-      void drain()
-    }, debounceMs ?? DEFAULT_DEBOUNCE_MS)
-  }
-
   function scheduleRotationRetry(): void {
-    if (closed || debounceTimer) {
+    if (closed) {
       return
     }
     const retryDelay = Math.min(
       ROTATION_RETRY_MS * 2 ** Math.min(rotationRetryCount, 7),
       MAX_ROTATION_RETRY_MS
     )
-    rotationRetryCount += 1
-    debounceTimer = setTimeout(() => {
-      debounceTimer = null
-      void drain()
-    }, retryDelay)
+    if (scheduler.scheduleRetry(retryDelay)) {
+      rotationRetryCount += 1
+    }
   }
 
   async function readAndEmitAppends(): Promise<void> {
@@ -136,7 +120,7 @@ export async function installTranscriptWatcher(
   }
 
   async function drainOnce(): Promise<void> {
-    const current = await fileVersion(filePath)
+    const current = await readTranscriptFileVersion(filePath)
     const currentBoundary = await boundaryFingerprint(filePath, state.offset)
     if (closed) {
       return
@@ -144,7 +128,7 @@ export async function installTranscriptWatcher(
     if (watcherNeedsRebind) {
       bindWatcher()
     }
-    const identityChanged = watchedIdentity !== null && current.identity !== watchedIdentity
+    const identityChanged = watchedVersion !== null && current.identity !== watchedVersion.identity
     const contentReplaced =
       identityChanged ||
       current.size < state.offset ||
@@ -152,7 +136,7 @@ export async function installTranscriptWatcher(
     if (contentReplaced) {
       resetIncrementalTranscriptState(state)
     }
-    watchedIdentity = current.identity
+    watchedVersion = current
 
     const replacementSnapshot =
       // Why: 0 is a valid window — an explicit undefined check keeps an empty
@@ -267,15 +251,45 @@ export async function installTranscriptWatcher(
     }
   }
 
+  async function reconcile(): Promise<void> {
+    if (closed) {
+      return
+    }
+    try {
+      const current = await readTranscriptFileVersion(filePath)
+      if (closed) {
+        return
+      }
+      const versionChanged =
+        watchedVersion === null || transcriptFileVersionChanged(current, watchedVersion)
+      if (versionChanged || current.size !== state.offset || watcherNeedsRebind) {
+        await drain()
+      }
+    } catch {
+      // Why: a missing/replaced path needs the existing capped rotation retry,
+      // even when fs.watch stayed silent about the transition.
+      await drain()
+    }
+  }
+
+  const scheduler = createTranscriptWatchScheduler({
+    debounceMs: args.debounceMs,
+    reconciliationIntervalMs: args.reconciliationIntervalMs,
+    drain: () => void drain(),
+    reconcile
+  })
+
   function bindWatcher(): void {
     const watchedName = basename(filePath)
     // Why: file watchers stay bound to an unlinked inode on macOS. Watching
     // the parent keeps observing a successor even after a long recreate gap.
     const nextWatcher = watch(dirname(filePath), (_event, changedName) => {
       if (changedName === null || changedName.toString() === watchedName) {
-        scheduleDrain()
+        scheduler.scheduleEventDrain()
       }
     })
+    // Why: an active tail should not keep a headless runtime alive during shutdown.
+    nextWatcher.unref?.()
     nextWatcher.on('error', () => {
       // Why: Windows can emit EPERM when a watched directory disappears. An
       // error listener prevents a process crash and retries against its successor.
@@ -298,7 +312,8 @@ export async function installTranscriptWatcher(
     return null
   }
   activeWatcherCount++
-  scheduleDrain()
+  scheduler.startReconciliation()
+  scheduler.scheduleEventDrain()
 
   return {
     watching: true,
@@ -307,10 +322,7 @@ export async function installTranscriptWatcher(
         return
       }
       closed = true
-      if (debounceTimer) {
-        clearTimeout(debounceTimer)
-        debounceTimer = null
-      }
+      scheduler.dispose()
       watcher?.close()
       watcher = null
       activeWatcherCount--

--- a/src/main/native-chat/transcript-watch-liveness.test.ts
+++ b/src/main/native-chat/transcript-watch-liveness.test.ts
@@ -1,23 +1,27 @@
 import { EventEmitter } from 'node:events'
 import type { FSWatcher } from 'node:fs'
 import type * as NodeFs from 'node:fs'
-import { appendFile, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { appendFile, mkdir, mkdtemp, rename, rm, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-const { watchers, watchCallbacks, watchMock } = vi.hoisted(() => ({
+const { watchers, watchCallbacks, watchMock, watchState } = vi.hoisted(() => ({
   watchers: [] as (EventEmitter & {
     close: ReturnType<typeof vi.fn>
     unref: ReturnType<typeof vi.fn>
   })[],
   watchCallbacks: [] as ((event: string, filename: string | Buffer | null) => void)[],
-  watchMock: vi.fn()
+  watchMock: vi.fn(),
+  watchState: { error: null as Error | null }
 }))
 
 vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof NodeFs>('node:fs')
   watchMock.mockImplementation((_path, callback) => {
+    if (watchState.error) {
+      throw watchState.error
+    }
     const watcher = Object.assign(new EventEmitter(), { close: vi.fn(), unref: vi.fn() })
     watchers.push(watcher)
     watchCallbacks.push(callback)
@@ -35,6 +39,7 @@ afterEach(async () => {
   watchers.length = 0
   watchCallbacks.length = 0
   watchMock.mockClear()
+  watchState.error = null
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
@@ -66,6 +71,60 @@ async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<voi
 }
 
 describe('native chat transcript watcher liveness', () => {
+  it('reconciles without a native watcher when fs.watch cannot bind', async () => {
+    watchState.error = new Error('ENOSYS')
+    const filePath = await tempFile(claudeLine('seed', 'user', 'hello'))
+    const snapshots = vi.fn()
+    const appends = vi.fn()
+    const subscription = await subscribeNativeChatTranscript({
+      agent: 'claude',
+      sessionId: 'session',
+      filePath,
+      onInitialSnapshot: snapshots,
+      onAppend: appends,
+      debounceMs: 0,
+      reconciliationIntervalMs: 20
+    })
+    await waitFor(() => snapshots.mock.calls.length === 1)
+
+    await appendFile(filePath, claudeLine('poll-only', 'assistant', 'recovered'))
+    await waitFor(() => appends.mock.calls.flat(2).some((message) => message.id === 'poll-only'))
+
+    subscription.unsubscribe()
+    expect(subscription.watching).toBe(true)
+    expect(watchers).toHaveLength(0)
+    expect(watchMock.mock.calls.length).toBeGreaterThan(1)
+  })
+
+  it('keeps polling readable transcripts while native watcher rebind fails', async () => {
+    const filePath = await tempFile(claudeLine('seed', 'user', 'hello'))
+    const snapshots = vi.fn()
+    const appends = vi.fn()
+    const subscription = await subscribeNativeChatTranscript({
+      agent: 'claude',
+      sessionId: 'session',
+      filePath,
+      onInitialSnapshot: snapshots,
+      onAppend: appends,
+      debounceMs: 0,
+      reconciliationIntervalMs: 20
+    })
+    await waitFor(() => snapshots.mock.calls.length === 1)
+
+    watchState.error = new Error('EPERM')
+    watchers[0]!.emit('error', watchState.error)
+    await appendFile(filePath, claudeLine('failed-rebind', 'assistant', 'still tailed'))
+    await waitFor(
+      () =>
+        appends.mock.calls.flat(2).some((message) => message.id === 'failed-rebind') &&
+        watchMock.mock.calls.length > 1
+    )
+
+    subscription.unsubscribe()
+    expect(watchers[0]!.close).toHaveBeenCalledOnce()
+    expect(watchMock.mock.calls.length).toBeGreaterThan(1)
+  })
+
   it('reconciles an append when fs.watch omits the callback', async () => {
     const filePath = await tempFile(claudeLine('seed', 'user', 'hello'))
     const snapshots = vi.fn()
@@ -88,6 +147,72 @@ describe('native chat transcript watcher liveness', () => {
 
     subscription.unsubscribe()
     expect(watchCallbacks).toHaveLength(1)
+  })
+
+  it('replaces a same-size prefix rewrite with an unchanged trailing boundary', async () => {
+    const prefixBefore = claudeLine('prefix-old', 'user', 'before')
+    const prefixAfter = claudeLine('prefix-new', 'user', 'after!')
+    const stableTail = claudeLine('stable-tail', 'assistant', 'x'.repeat(200))
+    expect(Buffer.byteLength(prefixAfter)).toBe(Buffer.byteLength(prefixBefore))
+    const filePath = await tempFile(prefixBefore + stableTail)
+    const snapshots = vi.fn()
+    const replacements = vi.fn()
+    const subscription = await subscribeNativeChatTranscript({
+      agent: 'claude',
+      sessionId: 'session',
+      filePath,
+      initialLimit: 40,
+      onInitialSnapshot: snapshots,
+      onReplace: replacements,
+      onAppend: () => {},
+      debounceMs: 0,
+      reconciliationIntervalMs: 20
+    })
+    await waitFor(() => snapshots.mock.calls.length === 1)
+
+    await writeFile(filePath, prefixAfter + stableTail)
+    const future = new Date(Date.now() + 10_000)
+    await utimes(filePath, future, future)
+    await waitFor(() =>
+      replacements.mock.calls.flat(2).some((message) => message.id === 'prefix-new')
+    )
+
+    subscription.unsubscribe()
+    expect(replacements).toHaveBeenCalledOnce()
+  })
+
+  it('rebinds the native watcher after silent parent-directory replacement', async () => {
+    const filePath = await tempFile(claudeLine('old-file', 'user', 'before'))
+    const root = dirname(filePath)
+    const oldRoot = `${root}.old`
+    roots.push(oldRoot)
+    const snapshots = vi.fn()
+    const replacements = vi.fn()
+    const appends = vi.fn()
+    const subscription = await subscribeNativeChatTranscript({
+      agent: 'claude',
+      sessionId: 'session',
+      filePath,
+      initialLimit: 40,
+      onInitialSnapshot: snapshots,
+      onReplace: replacements,
+      onAppend: appends,
+      debounceMs: 0,
+      reconciliationIntervalMs: 20
+    })
+    await waitFor(() => snapshots.mock.calls.length === 1)
+
+    await rename(root, oldRoot)
+    await mkdir(root)
+    await writeFile(filePath, claudeLine('new-file', 'user', 'after'))
+    await waitFor(() => replacements.mock.calls.length === 1 && watchers.length === 2)
+    await appendFile(filePath, claudeLine('new-followup', 'assistant', 'event-driven'))
+    watchCallbacks[1]!('change', 'transcript.jsonl')
+    await waitFor(() => appends.mock.calls.flat(2).some((message) => message.id === 'new-followup'))
+
+    subscription.unsubscribe()
+    expect(watchers[0]!.close).toHaveBeenCalledOnce()
+    expect(watchers[1]!.close).toHaveBeenCalledOnce()
   })
 
   it('drains within the max wait while matching events remain sustained', async () => {

--- a/src/main/native-chat/transcript-watch-liveness.test.ts
+++ b/src/main/native-chat/transcript-watch-liveness.test.ts
@@ -1,0 +1,148 @@
+import { EventEmitter } from 'node:events'
+import type { FSWatcher } from 'node:fs'
+import type * as NodeFs from 'node:fs'
+import { appendFile, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { watchers, watchCallbacks, watchMock } = vi.hoisted(() => ({
+  watchers: [] as (EventEmitter & {
+    close: ReturnType<typeof vi.fn>
+    unref: ReturnType<typeof vi.fn>
+  })[],
+  watchCallbacks: [] as ((event: string, filename: string | Buffer | null) => void)[],
+  watchMock: vi.fn()
+}))
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof NodeFs>('node:fs')
+  watchMock.mockImplementation((_path, callback) => {
+    const watcher = Object.assign(new EventEmitter(), { close: vi.fn(), unref: vi.fn() })
+    watchers.push(watcher)
+    watchCallbacks.push(callback)
+    return watcher as unknown as FSWatcher
+  })
+  return { ...actual, watch: watchMock }
+})
+
+import { subscribeNativeChatTranscript } from './transcript-watch'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  vi.useRealTimers()
+  watchers.length = 0
+  watchCallbacks.length = 0
+  watchMock.mockClear()
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+async function tempFile(initial: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-native-chat-watch-liveness-'))
+  roots.push(root)
+  const filePath = join(root, 'transcript.jsonl')
+  await writeFile(filePath, initial)
+  return filePath
+}
+
+function claudeLine(uuid: string, role: 'user' | 'assistant', text: string): string {
+  return `${JSON.stringify({
+    type: role,
+    uuid,
+    timestamp: '2026-06-01T10:00:00.000Z',
+    message: { role, content: role === 'user' ? text : [{ type: 'text', text }] }
+  })}\n`
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const start = Date.now()
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('timed out waiting for condition')
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}
+
+describe('native chat transcript watcher liveness', () => {
+  it('reconciles an append when fs.watch omits the callback', async () => {
+    const filePath = await tempFile(claudeLine('seed', 'user', 'hello'))
+    const snapshots = vi.fn()
+    const appends = vi.fn()
+    const subscription = await subscribeNativeChatTranscript({
+      agent: 'claude',
+      sessionId: 'session',
+      filePath,
+      onInitialSnapshot: snapshots,
+      onAppend: appends,
+      debounceMs: 0,
+      reconciliationIntervalMs: 20
+    })
+    await waitFor(() => snapshots.mock.calls.length === 1)
+
+    await appendFile(filePath, claudeLine('missed-event', 'assistant', 'recovered'))
+    // The mocked watcher never invokes watchCallbacks[0], reproducing a silent
+    // missed/coalesced host event while the file itself remains valid.
+    await waitFor(() => appends.mock.calls.flat(2).some((message) => message.id === 'missed-event'))
+
+    subscription.unsubscribe()
+    expect(watchCallbacks).toHaveLength(1)
+  })
+
+  it('drains within the max wait while matching events remain sustained', async () => {
+    const filePath = await tempFile(claudeLine('seed', 'user', 'hello'))
+    const snapshots = vi.fn()
+    const appends = vi.fn()
+    const subscription = await subscribeNativeChatTranscript({
+      agent: 'claude',
+      sessionId: 'session',
+      filePath,
+      onInitialSnapshot: snapshots,
+      onAppend: appends,
+      debounceMs: 40,
+      reconciliationIntervalMs: 10_000
+    })
+    await waitFor(() => snapshots.mock.calls.length === 1)
+    await appendFile(filePath, claudeLine('sustained-events', 'assistant', 'bounded'))
+
+    for (let index = 0; index < 20; index += 1) {
+      watchCallbacks[0]!('change', 'transcript.jsonl')
+      await new Promise((resolve) => setTimeout(resolve, 20))
+    }
+
+    expect(appends.mock.calls.flat(2).some((message) => message.id === 'sustained-events')).toBe(
+      true
+    )
+    subscription.unsubscribe()
+  })
+
+  it('clears every timer and cannot rebind after unsubscribe', async () => {
+    vi.useFakeTimers()
+    const filePath = await tempFile('')
+    const snapshots = vi.fn()
+    const appends = vi.fn()
+    const subscription = await subscribeNativeChatTranscript({
+      agent: 'claude',
+      sessionId: 'session',
+      filePath,
+      onInitialSnapshot: snapshots,
+      onAppend: appends,
+      reconciliationIntervalMs: 20
+    })
+
+    subscription.unsubscribe()
+    expect(watchers[0]!.unref).toHaveBeenCalledOnce()
+    expect(watchers[0]!.close).toHaveBeenCalledOnce()
+    expect(vi.getTimerCount()).toBe(0)
+
+    watchCallbacks[0]!('change', 'transcript.jsonl')
+    watchers[0]!.emit('error', new Error('late watcher error'))
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    expect(watchMock).toHaveBeenCalledOnce()
+    expect(snapshots).not.toHaveBeenCalled()
+    expect(appends).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/main/native-chat/transcript-watch-scheduler.ts
+++ b/src/main/native-chat/transcript-watch-scheduler.ts
@@ -1,0 +1,101 @@
+const DEFAULT_DEBOUNCE_MS = 40
+const EVENT_DRAIN_MAX_WAIT_MS = 250
+const DEFAULT_RECONCILIATION_MS = 1_000
+
+type TranscriptWatchSchedulerOptions = {
+  debounceMs?: number
+  reconciliationIntervalMs?: number
+  drain: () => void
+  reconcile: () => Promise<void>
+}
+
+export type TranscriptWatchScheduler = {
+  scheduleEventDrain: () => void
+  scheduleRetry: (delayMs: number) => boolean
+  startReconciliation: () => void
+  dispose: () => void
+}
+
+function unrefTimer(timer: ReturnType<typeof setTimeout>): void {
+  timer.unref?.()
+}
+
+export function createTranscriptWatchScheduler(
+  options: TranscriptWatchSchedulerOptions
+): TranscriptWatchScheduler {
+  const debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS
+  const maxEventWaitMs = Math.max(debounceMs, EVENT_DRAIN_MAX_WAIT_MS)
+  const reconciliationIntervalMs = options.reconciliationIntervalMs ?? DEFAULT_RECONCILIATION_MS
+  let disposed = false
+  let drainTimer: ReturnType<typeof setTimeout> | null = null
+  let firstEventAt: number | null = null
+  let reconciliationTimer: ReturnType<typeof setTimeout> | null = null
+
+  function clearDrainTimer(): void {
+    if (!drainTimer) {
+      return
+    }
+    clearTimeout(drainTimer)
+    drainTimer = null
+  }
+
+  function fireDrain(): void {
+    clearDrainTimer()
+    firstEventAt = null
+    options.drain()
+  }
+
+  function armDrain(delayMs: number): void {
+    drainTimer = setTimeout(fireDrain, delayMs)
+    unrefTimer(drainTimer)
+  }
+
+  function armReconciliation(): void {
+    if (disposed || reconciliationTimer) {
+      return
+    }
+    reconciliationTimer = setTimeout(() => {
+      reconciliationTimer = null
+      // Why: wait for the host-side stat/drain check before rearming so a slow
+      // remote filesystem cannot accumulate overlapping reconciliation work.
+      void options.reconcile().then(armReconciliation, armReconciliation)
+    }, reconciliationIntervalMs)
+    unrefTimer(reconciliationTimer)
+  }
+
+  return {
+    scheduleEventDrain(): void {
+      if (disposed) {
+        return
+      }
+      const now = Date.now()
+      firstEventAt ??= now
+      const remainingMaxWait = Math.max(0, maxEventWaitMs - (now - firstEventAt))
+      clearDrainTimer()
+      armDrain(Math.min(debounceMs, remainingMaxWait))
+    },
+    scheduleRetry(delayMs: number): boolean {
+      if (disposed || drainTimer) {
+        return false
+      }
+      firstEventAt = null
+      armDrain(delayMs)
+      return true
+    },
+    startReconciliation(): void {
+      armReconciliation()
+    },
+    dispose(): void {
+      if (disposed) {
+        return
+      }
+      disposed = true
+      clearDrainTimer()
+      if (reconciliationTimer) {
+        clearTimeout(reconciliationTimer)
+        reconciliationTimer = null
+      }
+      firstEventAt = null
+    }
+  }
+}

--- a/src/main/native-chat/transcript-watch-unsubscribe-race.test.ts
+++ b/src/main/native-chat/transcript-watch-unsubscribe-race.test.ts
@@ -1,0 +1,68 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type * as TranscriptTailReader from './transcript-tail-reader'
+
+const { tailRead, tailReadStarted, rejectTailRead } = vi.hoisted(() => {
+  let markStarted = (): void => {}
+  let reject = (_error: Error): void => {}
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve
+  })
+  const read = new Promise<never>((_resolve, rejectPromise) => {
+    reject = rejectPromise
+  })
+  return {
+    tailRead: vi.fn(() => {
+      markStarted()
+      return read
+    }),
+    tailReadStarted: started,
+    rejectTailRead: reject
+  }
+})
+
+vi.mock('./transcript-tail-reader', async () => {
+  const actual = await vi.importActual<typeof TranscriptTailReader>('./transcript-tail-reader')
+  return { ...actual, readNativeChatTranscriptTailFile: tailRead }
+})
+
+import { getActiveNativeChatWatcherCount, subscribeNativeChatTranscript } from './transcript-watch'
+
+let root: string | null = null
+
+afterEach(async () => {
+  if (root) {
+    await rm(root, { recursive: true, force: true })
+    root = null
+  }
+})
+
+describe('native chat transcript watcher unsubscribe race', () => {
+  it('does not emit an initial read error after unsubscribe', async () => {
+    root = await mkdtemp(join(tmpdir(), 'orca-native-chat-unsubscribe-race-'))
+    const filePath = join(root, 'transcript.jsonl')
+    await writeFile(filePath, '{}\n')
+    const snapshots = vi.fn()
+    const activeBefore = getActiveNativeChatWatcherCount()
+    const subscription = await subscribeNativeChatTranscript({
+      agent: 'claude',
+      sessionId: 'session',
+      filePath,
+      initialLimit: 40,
+      onInitialSnapshot: snapshots,
+      onAppend: () => {},
+      debounceMs: 0,
+      reconciliationIntervalMs: 10_000
+    })
+    await tailReadStarted
+
+    subscription.unsubscribe()
+    rejectTailRead(new Error('late read failure'))
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(snapshots).not.toHaveBeenCalled()
+    expect(getActiveNativeChatWatcherCount()).toBe(activeBefore)
+  })
+})

--- a/src/main/native-chat/transcript-watch.ts
+++ b/src/main/native-chat/transcript-watch.ts
@@ -15,9 +15,8 @@ export type {
   SubscribeNativeChatTranscriptArgs
 } from './transcript-watch-contract'
 
-/** One resolve+install attempt. Returns null when the file isn't resolvable
- *  yet, or vanished between resolve and `watch()` — either case is retried by
- *  the resolve-poll rather than treated as a hard failure. */
+/** One resolve+install attempt. Returns null while the transcript file itself
+ *  is unresolved; native-watch failure degrades to reconciliation-only mode. */
 async function attemptInstall(
   args: SubscribeNativeChatTranscriptArgs,
   decode: (line: string, fallbackId: string) => NativeChatMessage | null


### PR DESCRIPTION
## Summary

Add periodic reconciliation to the native chat transcript watcher to catch file updates missed by `fs.watch`. Some filesystems or host configurations can silently drop watcher events; this change adds a background reconciliation interval that proactively stat-checks the file and triggers a drain if its version has changed.

## Changes

- **`transcript-file-version.ts`** (new): Utilities to track file identity, size, and timestamps for detecting changes.
- **`transcript-watch-scheduler.ts`** (new): Centralized scheduler for event-driven drains, reconciliation intervals, and rotation retries. Enforces bounded wait times (max 250ms) to guarantee responsiveness even under sustained events.
- **`transcript-watch-engine.ts`**: Refactored to use the new scheduler. Reconciliation runs at a configurable interval (default 1s, test-overridable) to catch missed appends. File watchers are now unreferenced so they don't block shutdown.
- **`transcript-watch-contract.ts`**: Added `reconciliationIntervalMs` test override option.
- **`transcript-watch-liveness.test.ts`** (new): Tests that reconciliation catches appends when the watcher callback is skipped, and validates timer cleanup on unsubscribe.

## Testing

- Added comprehensive test coverage in `transcript-watch-liveness.test.ts` that:
  - Reproduces the silent-miss scenario by mocking fs.watch
  - Validates reconciliation detects and recovers the missed update
  - Confirms event-driven drain completes within bounded wait time
  - Verifies all timers and watcher state are cleaned up after unsubscribe

## Notes

- Reconciliation interval is configurable and test-overridable to keep CI fast while providing production safety.
- Bounded event-drain wait time (250ms) ensures responsiveness even under sustained filesystem events.
- No visual or behavioral changes to the user-facing native chat feature; this is a reliability improvement for the underlying watch mechanism.