### PR TITLE
fix(source-control): keep commit generation available for custom commands

### DIFF
--- a/src/renderer/src/components/right-sidebar/CommitArea.chevron-spinner.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.chevron-spinner.test.tsx
@@ -39,7 +39,6 @@ function baseProps(overrides: Partial<PrimaryActionInputs> = {}) {
     isFixingCommitFailureWithAI: false,
     isFixingPushFailureWithAI: false,
     sourceControlAiActionsVisible: true,
-    aiEnabled: false,
     aiAgentConfigured: false,
     isGenerating: false,
     generateError: null as string | null,
@@ -61,7 +60,9 @@ function baseProps(overrides: Partial<PrimaryActionInputs> = {}) {
 }
 
 function buttons(markup: string): string[] {
-  return [...markup.matchAll(/<button\b[\s\S]*?<\/button>/g)].map((match) => match[0])
+  return [...markup.matchAll(/<button\b[\s\S]*?<\/button>/g)]
+    .map((match) => match[0])
+    .filter((entry) => !entry.includes('aria-label="Generate commit message with AI"'))
 }
 
 function renderButtons(props: ReturnType<typeof baseProps>): string[] {

--- a/src/renderer/src/components/right-sidebar/CommitArea.generate.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.generate.test.tsx
@@ -9,6 +9,8 @@ import { TooltipProvider } from '@/components/ui/tooltip'
 import { resolvePrimaryAction, type PrimaryActionInputs } from './source-control-primary-action'
 import { resolveDropdownItems, type DropdownActionKind } from './source-control-dropdown-items'
 import { getDefaultSettings } from '../../../../shared/constants'
+import { CUSTOM_AGENT_ID } from '../../../../shared/commit-message-agent-spec'
+import { resolveSourceControlAiForOperation } from '../../../../shared/source-control-ai'
 
 function buildInputs(overrides: Partial<PrimaryActionInputs> = {}): PrimaryActionInputs {
   return {
@@ -40,7 +42,6 @@ function baseProps(overrides: Partial<PrimaryActionInputs> = {}) {
     isFixingPushFailureWithAI: false,
     showComposer: true,
     sourceControlAiActionsVisible: true,
-    aiEnabled: false,
     aiAgentConfigured: false,
     isGenerating: false,
     generateError: null as string | null,
@@ -85,9 +86,12 @@ function hasDisabledAttribute(markup: string): boolean {
 
 describe('CommitArea AI generation', () => {
   it('does not render the AI generate affordance when the feature is disabled', () => {
-    expect(renderCommitArea(baseProps())).not.toContain(
-      'aria-label="Generate commit message with AI"'
-    )
+    expect(
+      renderCommitArea({
+        ...baseProps(),
+        sourceControlAiActionsVisible: false
+      })
+    ).not.toContain('aria-label="Generate commit message with AI"')
   })
 
   it('enables AI generation only when an agent is configured, changes are staged, and the message is empty', () => {
@@ -95,7 +99,6 @@ describe('CommitArea AI generation', () => {
     const markup = renderCommitArea({
       ...props,
       commitMessage: '',
-      aiEnabled: true,
       aiAgentConfigured: true
     })
 
@@ -107,7 +110,6 @@ describe('CommitArea AI generation', () => {
   it('disables AI generation when the textarea already has user text', () => {
     const markup = renderCommitArea({
       ...baseProps(),
-      aiEnabled: true,
       aiAgentConfigured: true
     })
 
@@ -116,17 +118,40 @@ describe('CommitArea AI generation', () => {
     expect(button).toContain('title="Clear the message to regenerate."')
   })
 
-  it('hides AI generation until the configured agent can actually run', () => {
+  it('keeps AI generation discoverable when the configured agent needs attention', () => {
+    const settings = getDefaultSettings('/tmp')
+    const resolved = resolveSourceControlAiForOperation({
+      settings: {
+        ...settings,
+        sourceControlAi: {
+          ...settings.sourceControlAi!,
+          customAgentCommand: '',
+          actions: {
+            ...settings.sourceControlAi!.actions,
+            commitMessage: {
+              agentId: CUSTOM_AGENT_ID
+            }
+          }
+        }
+      },
+      repo: null,
+      operation: 'commitMessage'
+    })
+    expect(resolved).toMatchObject({
+      ok: false,
+      error: 'Custom command is empty. Add one in Settings -> Git -> Source Control AI.'
+    })
+
     const props = baseProps({ hasMessage: false })
     const markup = renderCommitArea({
       ...props,
       commitMessage: '',
-      aiEnabled: true,
-      aiAgentConfigured: false
+      aiAgentConfigured: resolved.ok
     })
 
-    expect(markup).not.toContain('aria-label="Generate commit message with AI"')
-    expect(markup).toContain('Commit')
+    const button = buttonByLabel(markup, 'Generate commit message with AI')
+    expect(hasDisabledAttribute(button)).toBe(false)
+    expect(button).toContain('title="Pick an agent in Settings -&gt; Git -&gt; Source Control AI."')
   })
 
   it('turns the generating icon into a stop affordance', () => {
@@ -134,7 +159,6 @@ describe('CommitArea AI generation', () => {
     const markup = renderCommitArea({
       ...props,
       commitMessage: '',
-      aiEnabled: true,
       aiAgentConfigured: true,
       isGenerating: true
     })
@@ -159,7 +183,6 @@ describe('CommitArea AI generation', () => {
   it('continues to render the split commit button alongside generation controls', () => {
     const markup = renderCommitArea({
       ...baseProps(),
-      aiEnabled: true,
       aiAgentConfigured: true
     })
     expect(markup).toContain('Commit')
@@ -171,7 +194,6 @@ describe('CommitArea AI generation', () => {
     const markup = renderCommitArea({
       ...props,
       commitMessage: '',
-      aiEnabled: true,
       aiAgentConfigured: true
     })
 
@@ -185,7 +207,6 @@ describe('CommitArea AI generation', () => {
     const markup = renderCommitArea({
       ...baseProps({ hasMessage: false, stagedCount: 0 }),
       commitMessage: '',
-      aiEnabled: true,
       aiAgentConfigured: true,
       showComposer: false
     })

--- a/src/renderer/src/components/right-sidebar/CommitArea.primary-icons.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.primary-icons.test.tsx
@@ -39,7 +39,6 @@ function baseProps(overrides: Partial<PrimaryActionInputs> = {}) {
     isFixingCommitFailureWithAI: false,
     isFixingPushFailureWithAI: false,
     sourceControlAiActionsVisible: true,
-    aiEnabled: false,
     aiAgentConfigured: false,
     isGenerating: false,
     generateError: null as string | null,
@@ -66,11 +65,13 @@ function primaryButton(props: ReturnType<typeof baseProps>): string {
       <CommitArea {...props} />
     </TooltipProvider>
   )
-  const match = markup.match(/<button\b[\s\S]*?<\/button>/)
-  if (!match) {
+  const button = [...markup.matchAll(/<button\b[\s\S]*?<\/button>/g)]
+    .map((match) => match[0])
+    .find((entry) => entry.includes('data-slot="button"'))
+  if (!button) {
     throw new Error('primary button not found')
   }
-  return match[0]
+  return button
 }
 
 describe('CommitArea primary action icons', () => {

--- a/src/renderer/src/components/right-sidebar/CommitArea.test.tsx
+++ b/src/renderer/src/components/right-sidebar/CommitArea.test.tsx
@@ -38,7 +38,6 @@ function baseProps(overrides: Partial<PrimaryActionInputs> = {}) {
     isFixingCommitFailureWithAI: false,
     isFixingPushFailureWithAI: false,
     sourceControlAiActionsVisible: true,
-    aiEnabled: false,
     aiAgentConfigured: false,
     isGenerating: false,
     generateError: null as string | null,
@@ -91,11 +90,13 @@ function renderCommitArea(props: Parameters<typeof CommitArea>[0]): string {
 }
 
 function firstButton(markup: string): string {
-  const match = markup.match(/<button\b[\s\S]*?<\/button>/)
-  if (!match) {
+  const button = [...markup.matchAll(/<button\b[\s\S]*?<\/button>/g)]
+    .map((match) => match[0])
+    .find((entry) => entry.includes('data-slot="button"'))
+  if (!button) {
     throw new Error('button not found')
   }
-  return match[0]
+  return button
 }
 
 function buttonContaining(markup: string, label: string): string {
@@ -500,7 +501,6 @@ describe('CommitArea', () => {
   it('hides the composer generate affordance while Create PR intent is in flight', () => {
     const markup = renderCommitArea({
       ...baseProps(),
-      aiEnabled: true,
       aiAgentConfigured: true,
       isGenerating: true,
       isCreatePrIntentInFlight: true,

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -6503,8 +6503,8 @@ export function CommitArea({
     .filter(Boolean)
     .join(' ')
 
-  // Why: 配置错误由生成对话框负责校验，入口可见性只跟随功能开关。
-  // Why: 创建 PR 流程已接管生成状态，避免在输入框中重复显示进度。
+  // Why: config errors are surfaced by the generation dialog, so entry-point visibility only follows the feature toggle.
+  // Why: Create PR intent owns generation, so a second composer spinner would stack on the primary spinner.
   const showGenerate = showComposer && sourceControlAiActionsVisible && !isCreatePrIntentInFlight
   let generateTooltip: string | undefined
   if (isGenerating) {

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -5769,7 +5769,6 @@ function SourceControlInner(): React.JSX.Element {
                 groupId={activeGroupId ?? activeWorktreeId}
                 showComposer={!showGenericEmptyState}
                 sourceControlAiActionsVisible={sourceControlAiActionsVisible}
-                aiEnabled={sourceControlAiActionsVisible && resolvedCommitMessageAi?.ok === true}
                 aiAgentConfigured={resolvedCommitMessageAi?.ok === true}
                 isGenerating={isGenerating}
                 generateError={generateError}
@@ -6382,7 +6381,6 @@ type CommitAreaProps = {
   isCreatePrIntentInFlight?: boolean
   showComposer?: boolean
   sourceControlAiActionsVisible: boolean
-  aiEnabled: boolean
   aiAgentConfigured: boolean
   isGenerating: boolean
   generateError: string | null
@@ -6429,7 +6427,6 @@ export function CommitArea({
   isCreatePrIntentInFlight = false,
   showComposer = true,
   sourceControlAiActionsVisible,
-  aiEnabled,
   aiAgentConfigured,
   isGenerating,
   generateError,
@@ -6506,29 +6503,23 @@ export function CommitArea({
     .filter(Boolean)
     .join(' ')
 
-  // Why: only render Generate when it has a runnable path; else keep the composer focused on Commit.
-  // Why: Create PR intent owns generation, so a second composer spinner would stack on the primary spinner.
-  const showGenerate =
-    showComposer && aiEnabled && !isCreatePrIntentInFlight && (aiAgentConfigured || isGenerating)
-  let generateDisabledReason: string | undefined
+  // Why: 配置错误由生成对话框负责校验，入口可见性只跟随功能开关。
+  // Why: 创建 PR 流程已接管生成状态，避免在输入框中重复显示进度。
+  const showGenerate = showComposer && sourceControlAiActionsVisible && !isCreatePrIntentInFlight
+  let generateTooltip: string | undefined
   if (isGenerating) {
-    generateDisabledReason = 'Generating commit message…'
+    generateTooltip = 'Generating commit message…'
   } else if (isCommitting) {
-    generateDisabledReason = 'Commit in progress…'
-  } else if (!aiAgentConfigured) {
-    generateDisabledReason = 'Pick an agent in Settings -> Git -> Source Control AI.'
+    generateTooltip = 'Commit in progress…'
   } else if (stagedCount === 0) {
-    generateDisabledReason = 'Stage at least one file to generate a message.'
+    generateTooltip = 'Stage at least one file to generate a message.'
   } else if (hasMessage) {
-    generateDisabledReason = 'Clear the message to regenerate.'
+    generateTooltip = 'Clear the message to regenerate.'
+  } else if (!aiAgentConfigured) {
+    generateTooltip = 'Pick an agent in Settings -> Git -> Source Control AI.'
   }
   const isGenerateDisabled =
-    !aiAgentConfigured ||
-    isGenerating ||
-    isCommitting ||
-    stagedCount === 0 ||
-    hasMessage ||
-    hasUnresolvedConflicts
+    isGenerating || isCommitting || stagedCount === 0 || hasMessage || hasUnresolvedConflicts
   const moreCommitAndRemoteActionsLabel = translate(
     'auto.components.right.sidebar.SourceControl.cc199ccc5f',
     'More commit and remote actions'
@@ -6646,7 +6637,7 @@ export function CommitArea({
                       onGenerate()
                     }}
                     title={
-                      generateDisabledReason ??
+                      generateTooltip ??
                       translate(
                         'auto.components.right.sidebar.SourceControl.b16b8f0e4b',
                         'ai commit msg'
@@ -6666,7 +6657,7 @@ export function CommitArea({
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="left" sideOffset={6}>
-                  {generateDisabledReason ??
+                  {generateTooltip ??
                     translate(
                       'auto.components.right.sidebar.SourceControl.b16b8f0e4b',
                       'ai commit msg'


### PR DESCRIPTION
## Summary

- Keep the existing commit-message generation entry point visible whenever Source Control AI actions are enabled, even if the selected Custom command cannot currently resolve.
- Route missing or invalid generation defaults through the existing generation dialog, where users can choose another supported agent and see the actionable configuration error.
- Add a regression test using an empty Custom command configuration and update neighboring component tests to identify the primary action independently of the sparkle button.

Fixes #9691

## Screenshots

Not included: this restores the existing sparkle button in a state where it was previously hidden, without changing its visual treatment.

## Testing

- [ ] `pnpm lint` - the changed files pass `oxlint`, formatting, React Doctor, max-lines, reliability, scrollbar, skill-bundle, and localization-catalog checks. The full command is blocked by pre-existing failures in `skill-freshness-group.tsx:101` and three existing localization-coverage findings in the AI Vault files.
- [x] `pnpm typecheck`
- [ ] `pnpm test` - 33,388 passed and 56 skipped. The full run had three unrelated environment/time-out failures: the Git handler test passed when rerun alone; the zsh path lookup still resolves the local Vite+ shim; and the system SSH fixture times out while installing native dependencies.
- [x] `pnpm build` - verified via its two constituent commands: `pnpm run build:desktop` and `pnpm run build:native`.
- [x] Added or updated high-quality tests that would catch regressions: 64 focused CommitArea tests pass, including the empty Custom command case.

## AI Review Report

The review checked the visibility and click-routing state transitions, disabled states, in-flight generation behavior, and Create PR intent suppression. The main risk was exposing an enabled button that could bypass validation; the existing click handler was verified to generate directly only when defaults are configured and resolve successfully, while unresolved configurations open the generation dialog instead.

Cross-platform review found no platform-specific shortcuts, labels, paths, shell behavior, or Electron APIs in the change. The behavior is shared across macOS, Linux, and Windows. Local, SSH, and remote generation routing is unchanged, as are supported agent and Git-provider paths. The change adds no polling or hot-path work.

## Security Audit

No new input handling, command execution, path handling, authentication, secrets, dependencies, network access, or IPC were introduced. An invalid Custom command is not executed; it only opens the existing validated generation dialog. Existing generation parameter validation and runtime dispatch remain unchanged.

## Notes

- No release or version files were changed.
- X handle: N/A
