### PR TITLE
fix(dashboard-popout): keep moving card under the open terminal

### DIFF
--- a/src/renderer/src/components/dashboard-popout/useDashboardSnapshot.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/useDashboardSnapshot.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import type { DashboardCard, DashboardSnapshot } from '../../../../shared/dashboard-snapshot'
+import { useDashboardSnapshot } from './useDashboardSnapshot'
+
+;(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+function card(overrides: Partial<DashboardCard>): DashboardCard {
+  return {
+    paneKey: 'pk',
+    ptyId: 'p1',
+    agentType: 'claude',
+    bucket: 'working',
+    dotState: 'working',
+    task: 't',
+    repoId: 'r1',
+    worktreeId: 'w1',
+    tabId: 'tab1',
+    leafId: 'l1',
+    repoName: 'Repo',
+    worktreeName: 'wt',
+    startedAt: 0,
+    finishedAt: null,
+    stateChangedAt: 0,
+    unseen: false,
+    ...overrides
+  }
+}
+
+function snapshot(cards: DashboardCard[]): DashboardSnapshot {
+  return { generatedAt: 1, cards }
+}
+
+let apply: (next: DashboardSnapshot) => void
+const startViewTransition = vi.fn((cb: () => void) => {
+  cb()
+  return {
+    finished: Promise.resolve(),
+    ready: Promise.resolve(),
+    updateCallbackDone: Promise.resolve()
+  }
+})
+
+/** A Radix dialog marks its open content with role + data-state; mimic that so
+ *  the hook's top-layer-conflict guard sees an "open terminal". */
+function openTerminalDialog(): HTMLElement {
+  const el = document.createElement('div')
+  el.setAttribute('role', 'dialog')
+  el.setAttribute('data-state', 'open')
+  document.body.appendChild(el)
+  return el
+}
+
+describe('useDashboardSnapshot', () => {
+  beforeEach(() => {
+    ;(window as unknown as { api: unknown }).api = {
+      dashboard: {
+        onSnapshot: (cb: (next: DashboardSnapshot) => void) => {
+          apply = cb
+          return () => {}
+        },
+        requestSnapshot: vi.fn(async () => {})
+      }
+    }
+    ;(document as unknown as { startViewTransition: unknown }).startViewTransition =
+      startViewTransition
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false }) as unknown as typeof matchMedia
+  })
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.clearAllMocks()
+  })
+
+  it('runs a view transition when a card changes column', () => {
+    const { result } = renderHook(() => useDashboardSnapshot())
+    act(() => apply(snapshot([card({ bucket: 'idle' })])))
+    startViewTransition.mockClear() // ignore the initial populate
+
+    act(() => apply(snapshot([card({ bucket: 'working' })])))
+    expect(startViewTransition).toHaveBeenCalledTimes(1)
+    expect(result.current.cards[0].bucket).toBe('working')
+  })
+
+  it('skips the view transition — but still applies the update — while the terminal dialog is open', () => {
+    const { result } = renderHook(() => useDashboardSnapshot())
+    act(() => apply(snapshot([card({ bucket: 'idle' })])))
+    startViewTransition.mockClear() // ignore the initial populate
+    openTerminalDialog()
+
+    act(() => apply(snapshot([card({ bucket: 'working' })])))
+    // Why: the card's View Transition snapshot would paint in the browser top
+    // layer, above the z-50 dialog — so we jump instead of morphing.
+    expect(startViewTransition).not.toHaveBeenCalled()
+    expect(result.current.cards[0].bucket).toBe('working')
+  })
+})

--- a/src/renderer/src/components/dashboard-popout/useDashboardSnapshot.ts
+++ b/src/renderer/src/components/dashboard-popout/useDashboardSnapshot.ts
@@ -18,6 +18,14 @@ function prefersReducedMotion(): boolean {
   return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true
 }
 
+/** Why: View Transition snapshots render in the browser top layer, which paints
+ *  above any z-index — so a card morphing columns would flicker OVER the open
+ *  terminal dialog (a z-50 Radix portal). Skip the transition while it's open;
+ *  the card just settles under the dialog, which the user isn't watching. */
+function terminalDialogIsOpen(): boolean {
+  return document.querySelector('[role="dialog"][data-state="open"]') !== null
+}
+
 /**
  * Pop-out side of the dashboard bridge: subscribe to snapshots relayed from the
  * main window and request an initial one on mount. When a card changes column
@@ -35,7 +43,12 @@ export function useDashboardSnapshot(): DashboardSnapshot {
       columnSignatureRef.current = nextSignature
 
       const startViewTransition = document.startViewTransition?.bind(document)
-      if (!layoutChanged || prefersReducedMotion() || !startViewTransition) {
+      if (
+        !layoutChanged ||
+        prefersReducedMotion() ||
+        terminalDialogIsOpen() ||
+        !startViewTransition
+      ) {
         setSnapshot(next)
         return
       }


### PR DESCRIPTION
## Problem

In the **Orca Agent Dashboard** popout, when an agent card moves between columns (a status change) while the terminal dialog is open, the card briefly **flickers above the terminal** during the transition. It should stay under it.

## Root cause

The card column-move animates via the **View Transitions API** (`document.startViewTransition` in `useDashboardSnapshot.ts`, per-card `view-transition-name` in `AgentKanbanCard.tsx`). While a transition runs, the browser renders the card's snapshot pseudo-elements (`::view-transition-group/old/new`) in the document's real **top layer** — which paints above *any* `z-index`.

The terminal is a Radix `Dialog` rendered through a portal at `z-50` (a plain portal, not a native top-layer element). So a card morphing columns paints its snapshot over the `z-50` dialog — the flicker. No `z-index` on the dialog can beat the top layer.

## Fix

Skip the view transition while the terminal dialog is open (detected via `[role="dialog"][data-state="open"]`). The card just settles into its new column **under** the dialog — which covers the board anyway, so the motion isn't where the user is looking — instead of animating on top. Non-dialog moves are unchanged and still animate.

The check lives in the hook rather than threading dialog state up through `DashboardPopoutRoot`, because the conflict is fundamentally "is a top-layer-competing dialog visible right now" — a rendering fact best read at transition time, and it keeps `openedCard` state owned by the board.

## Test

New `useDashboardSnapshot.test.tsx`:
- a column change runs the transition normally;
- a column change with a dialog open in the DOM **skips** the transition but still applies the snapshot (the card must still land in its new column, just without the animation).

All 16 dashboard-popout tests pass; oxlint clean.

## Trade-off

The moved card now *jumps* under the terminal rather than animating. That's intended — a clipped-beneath animation isn't achievable with the top-layer View Transition and would need a different animation approach for the board.
