### PR TITLE
fix(terminal): keep Pi Shift+Enter on CSI-u

### DIFF
--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -429,9 +429,9 @@ export function useTerminalKeyboardShortcuts({
             // Why: this direct shortcut write does not pass through PTY onData,
             // so no-OSC shells need an explicit post-write confirmation ladder.
             const binding = panePtyBindingsRef.current.get(pane.id) as
-              | (IDisposable & { requestDroidReconfirmation?: () => void })
+              | (IDisposable & { requestWindowsCsiUReconfirmation?: () => void })
               | undefined
-            binding?.requestDroidReconfirmation?.()
+            binding?.requestWindowsCsiUReconfirmation?.()
           }
         }
         return

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -6893,44 +6893,48 @@ describe('connectPanePty', () => {
     expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('csi-u')
   })
 
-  it('confirms an Orca-launched Droid fresh spawn in a no-OSC shell (Git Bash)', async () => {
-    // Why: no-OSC shells (Git Bash/cmd) emit no command boundary, so without a fresh-spawn sample the pane never earns routing trust and Shift+Enter regresses to Esc+CR (#7620).
-    vi.useFakeTimers()
-    const { connectPanePty } = await import('./pty-connection')
-    vi.mocked(window.api.pty.getForegroundProcess).mockResolvedValue('droid')
-    vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('droid')
-    const pane = createPane(1)
-    const ptyId = 'pty-launched-droid-no-osc'
-    const tabId = 'tab-launched-droid-no-osc'
-    const paneKey = makePaneKey(tabId, LEAF_1)
-    transportFactoryQueue.push(createMockTransport(ptyId))
+  it.each(['droid', 'pi'] as const)(
+    'confirms an Orca-launched %s fresh spawn in a no-OSC shell (Git Bash)',
+    async (agent) => {
+      // Why: Git Bash/cmd 没有 OSC 命令边界，启动后的前台进程采样是获得可信 CSI-u 路由的唯一入口。
+      vi.useFakeTimers()
+      const { connectPanePty } = await import('./pty-connection')
+      vi.mocked(window.api.pty.getForegroundProcess).mockResolvedValue(agent)
+      vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue(agent)
+      const pane = createPane(1)
+      const ptyId = `pty-launched-${agent}-no-osc`
+      const tabId = `tab-launched-${agent}-no-osc`
+      const paneKey = makePaneKey(tabId, LEAF_1)
+      transportFactoryQueue.push(createMockTransport(ptyId))
 
-    connectPanePty(
-      pane as never,
-      createManager(1) as never,
-      createDeps({
-        tabId,
-        startup: { command: 'droid', launchAgent: 'droid' }
-      }) as never
-    )
-    await vi.advanceTimersByTimeAsync(20)
-    await flushAsyncTicks()
-    // The transport reports the fresh spawn; no OSC 133, no typed inference.
-    const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as ((id: string) => void) | undefined
-    expect(onPtySpawn).toBeTypeOf('function')
-    onPtySpawn?.(ptyId)
-    // Span the bounded confirmation retry ladder while Droid boots.
-    await vi.advanceTimersByTimeAsync(350 + 1200 + 6000)
-    await flushAsyncTicks()
+      connectPanePty(
+        pane as never,
+        createManager(1) as never,
+        createDeps({
+          tabId,
+          startup: { command: agent, launchAgent: agent }
+        }) as never
+      )
+      await vi.advanceTimersByTimeAsync(20)
+      await flushAsyncTicks()
+      const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
+        | ((id: string) => void)
+        | undefined
+      expect(onPtySpawn).toBeTypeOf('function')
+      onPtySpawn?.(ptyId)
+      // Why: 有界重试阶梯需要覆盖 agent 尚未成为前台进程的启动窗口。
+      await vi.advanceTimersByTimeAsync(350 + 1200 + 6000)
+      await flushAsyncTicks()
 
-    expect(window.api.pty.confirmForegroundProcess).toHaveBeenCalledWith(ptyId)
-    expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
-      agent: 'droid',
-      routingTrusted: true,
-      shellForeground: false
-    })
-    expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('csi-u')
-  })
+      expect(window.api.pty.confirmForegroundProcess).toHaveBeenCalledWith(ptyId)
+      expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+        agent,
+        routingTrusted: true,
+        shellForeground: false
+      })
+      expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('csi-u')
+    }
+  )
 
   it('trusts a launched Droid whose no-OSC boot only becomes foreground after retries', async () => {
     // Why: the confirmation ladder must span Droid's boot — the shell is still foreground on the first read(s) before Droid takes over.
@@ -7012,42 +7016,45 @@ describe('connectPanePty', () => {
     expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('csi-u')
   })
 
-  it('revokes trusted Droid after accepted no-OSC exit input until shell confirmation', async () => {
-    vi.useFakeTimers()
-    const { connectPanePty } = await import('./pty-connection')
-    vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('cmd.exe')
-    const pane = createPane(1)
-    const ptyId = 'pty-droid-exit-no-osc'
-    const tabId = 'tab-droid-exit-no-osc'
-    const paneKey = makePaneKey(tabId, LEAF_1)
-    transportFactoryQueue.push(createMockTransport(ptyId))
+  it.each(['droid', 'pi'] as const)(
+    'revokes trusted %s after accepted no-OSC exit input until shell confirmation',
+    async (agent) => {
+      vi.useFakeTimers()
+      const { connectPanePty } = await import('./pty-connection')
+      vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('cmd.exe')
+      const pane = createPane(1)
+      const ptyId = `pty-${agent}-exit-no-osc`
+      const tabId = `tab-${agent}-exit-no-osc`
+      const paneKey = makePaneKey(tabId, LEAF_1)
+      transportFactoryQueue.push(createMockTransport(ptyId))
 
-    connectPanePty(pane as never, createManager(1) as never, createDeps({ tabId }) as never)
-    await vi.advanceTimersByTimeAsync(20)
-    await flushAsyncTicks()
-    mockStoreState.paneForegroundAgentByPaneKey[paneKey] = {
-      agent: 'droid',
-      routingTrusted: true,
-      shellForeground: false
+      connectPanePty(pane as never, createManager(1) as never, createDeps({ tabId }) as never)
+      await vi.advanceTimersByTimeAsync(20)
+      await flushAsyncTicks()
+      mockStoreState.paneForegroundAgentByPaneKey[paneKey] = {
+        agent,
+        routingTrusted: true,
+        shellForeground: false
+      }
+
+      sendTerminalInputThroughPane(pane, '\x03')
+      await flushAsyncTicks()
+
+      expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+        agent,
+        shellForeground: false
+      })
+      expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('alt-enter')
+
+      await vi.advanceTimersByTimeAsync(350 + 1200 + 6000)
+
+      expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+        agent: null,
+        shellForeground: true
+      })
+      expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('alt-enter')
     }
-
-    sendTerminalInputThroughPane(pane, '\x03')
-    await flushAsyncTicks()
-
-    expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
-      agent: 'droid',
-      shellForeground: false
-    })
-    expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('alt-enter')
-
-    await vi.advanceTimersByTimeAsync(350 + 1200 + 6000)
-
-    expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
-      agent: null,
-      shellForeground: true
-    })
-    expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('alt-enter')
-  })
+  )
 
   it('never promotes typed Droid text when foreground enrichment is unavailable', async () => {
     vi.useFakeTimers()
@@ -22165,7 +22172,7 @@ describe('connectPanePty', () => {
       binding: {
         noteVisibilityResume: () => void
         sampleForegroundAgentOnFocus: () => void
-        requestDroidReconfirmation: () => void
+        requestWindowsCsiUReconfirmation: () => void
       }
       deps: ReturnType<typeof createDeps>
       transport: MockTransport
@@ -22202,7 +22209,7 @@ describe('connectPanePty', () => {
       ) as unknown as {
         noteVisibilityResume: () => void
         sampleForegroundAgentOnFocus: () => void
-        requestDroidReconfirmation: () => void
+        requestWindowsCsiUReconfirmation: () => void
       }
       await vi.advanceTimersByTimeAsync(20)
       await flushAsyncTicks(20)
@@ -22318,60 +22325,63 @@ describe('connectPanePty', () => {
       }
     })
 
-    it('keeps trusted Droid routing through a rapid Shift+Enter burst', async () => {
-      vi.useFakeTimers()
-      const ptyId = 'pty-droid-shift-enter-burst'
-      const tabId = `tab-${ptyId}`
-      const { binding, cacheKey } = await connectRestoredPaneForForegroundSampling({
-        ptyId,
-        tabId
-      })
-      mockStoreState.paneForegroundAgentByPaneKey[cacheKey] = {
-        agent: 'droid',
-        routingTrusted: true,
-        shellForeground: false
+    it.each(['droid', 'pi'] as const)(
+      'keeps trusted %s routing through a rapid Shift+Enter burst',
+      async (agent) => {
+        vi.useFakeTimers()
+        const ptyId = `pty-${agent}-shift-enter-burst`
+        const tabId = `tab-${ptyId}`
+        const { binding, cacheKey } = await connectRestoredPaneForForegroundSampling({
+          ptyId,
+          tabId
+        })
+        mockStoreState.paneForegroundAgentByPaneKey[cacheKey] = {
+          agent,
+          routingTrusted: true,
+          shellForeground: false
+        }
+        mockStoreState.agentStatusByPaneKey[cacheKey] = {
+          state: 'working',
+          agentType: agent
+        }
+        vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue(agent)
+
+        binding.requestWindowsCsiUReconfirmation()
+        await vi.advanceTimersByTimeAsync(200)
+        binding.requestWindowsCsiUReconfirmation()
+        await vi.advanceTimersByTimeAsync(349)
+
+        expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+          agent,
+          routingTrusted: true,
+          shellForeground: false
+        })
+
+        await vi.advanceTimersByTimeAsync(1)
+        expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+          agent,
+          shellForeground: false
+        })
+
+        await vi.advanceTimersByTimeAsync(350)
+        await flushAsyncTicks()
+        expect(window.api.pty.confirmForegroundProcess).toHaveBeenCalledWith(ptyId)
+        expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+          agent,
+          routingTrusted: true,
+          shellForeground: false
+        })
+
+        binding.requestWindowsCsiUReconfirmation()
+        await vi.advanceTimersByTimeAsync(700)
+        await flushAsyncTicks()
+        expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+          agent,
+          routingTrusted: true,
+          shellForeground: false
+        })
       }
-      mockStoreState.agentStatusByPaneKey[cacheKey] = {
-        state: 'working',
-        agentType: 'droid'
-      }
-      vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('droid')
-
-      binding.requestDroidReconfirmation()
-      await vi.advanceTimersByTimeAsync(200)
-      binding.requestDroidReconfirmation()
-      await vi.advanceTimersByTimeAsync(349)
-
-      expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
-        agent: 'droid',
-        routingTrusted: true,
-        shellForeground: false
-      })
-
-      await vi.advanceTimersByTimeAsync(1)
-      expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
-        agent: 'droid',
-        shellForeground: false
-      })
-
-      await vi.advanceTimersByTimeAsync(350)
-      await flushAsyncTicks()
-      expect(window.api.pty.confirmForegroundProcess).toHaveBeenCalledWith(ptyId)
-      expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
-        agent: 'droid',
-        routingTrusted: true,
-        shellForeground: false
-      })
-
-      binding.requestDroidReconfirmation()
-      await vi.advanceTimersByTimeAsync(700)
-      await flushAsyncTicks()
-      expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
-        agent: 'droid',
-        routingTrusted: true,
-        shellForeground: false
-      })
-    })
+    )
 
     it('samples once when an identityless hidden pane resumes visible', async () => {
       vi.useFakeTimers()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -684,7 +684,7 @@ type PanePtyBinding = IDisposable & {
    *  agent pane has no OSC boundary left to correct it. */
   sampleForegroundAgentOnFocus: () => void
   /** Reconfirm after direct shortcut input, which bypasses PTY onData. */
-  requestDroidReconfirmation: () => void
+  requestWindowsCsiUReconfirmation: () => void
   reconcileIfSessionDead: (liveSessionIds: Set<string>, snapshotRequestedAt?: number) => void
   reconcileIfSessionMissing: (hasPty: HasPty, livenessRequestedAt?: number) => void
 }
@@ -1303,7 +1303,7 @@ export function connectPanePty(
   let commandInferredPaneAgentGeneration = 0
   let shellCommandInferenceSuspendedUntilCommandEnd = false
   let startAcceptedInferredCommand = (_agent: TuiAgent): void => {}
-  let requestKnownDroidReconfirmation = (): void => {}
+  let requestWindowsCsiUAgentReconfirmation = (): void => {}
   const resetPendingShellCommandLine = (): void => {
     pendingShellCommandLine = ''
     pendingShellCommandCursor = 0
@@ -1551,9 +1551,8 @@ export function connectPanePty(
       data.includes('\x03') ||
       data.includes('\x04')
     ) {
-      // Why: shells without OSC 133 give no command/exit boundary. An accepted
-      // submit or interrupt revokes only stale Droid routing and confirms once.
-      requestKnownDroidReconfirmation()
+      // Why: 无 OSC 133 的 shell 没有命令/退出边界；提交或中断后先撤销旧的 CSI-u 路由再确认。
+      requestWindowsCsiUAgentReconfirmation()
     }
     if (commandInferredPaneAgent) {
       return
@@ -2130,25 +2129,24 @@ export function connectPanePty(
   startAcceptedInferredCommand = (agent) => {
     paneForegroundAgentTracker.onCommandStarted(agent)
   }
-  requestKnownDroidReconfirmation = () => {
+  requestWindowsCsiUAgentReconfirmation = () => {
     const foreground = useAppStore.getState().paneForegroundAgentByPaneKey[cacheKey]
-    // Why: daemon reattach/launch metadata is display-only until a live
-    // provider read confirms it. Submit/interrupt/title-exit evidence must
-    // revoke that launch-only hint too, otherwise Shift+Enter can route bytes
-    // to a Droid that already exited before confirmation ever ran.
-    if (foreground?.agent !== 'droid') {
+    const foregroundAgent = foreground?.agent
+    // Why: 只撤销声明了 Windows CSI-u 的 agent，普通 agent 无需为输入字节触发额外进程扫描。
+    if (
+      !foregroundAgent ||
+      TUI_AGENT_CONFIG[foregroundAgent].windowsShiftEnterEncoding !== 'csi-u'
+    ) {
       return
     }
-    // Why: cmd.exe and Git Bash have no OSC command boundaries. Keep the icon
-    // as a hint, but revoke bytes until one current provider confirmation lands.
+    // Why: cmd.exe 与 Git Bash 没有 OSC 命令边界；保留图标提示，但在当前进程确认前撤销字节路由权限。
     useAppStore.getState().setPaneForegroundAgent(cacheKey, {
-      agent: 'droid',
+      agent: foregroundAgent,
       shellForeground: false
     })
     visibleForegroundSamplePending = false
     visibleForegroundSampleSettled = false
-    // Why: hook rows can suppress display-only sampling, but cannot restore
-    // byte authority after this function explicitly revoked routing trust.
+    // Why: hook 状态只能提供展示身份，不能在这里显式撤销信任后恢复字节路由权限。
     sampleVisiblePaneForegroundAgent(true)
   }
   const commandLifecycle = createTerminalCommandLifecycle({
@@ -3228,7 +3226,7 @@ export function connectPanePty(
     deps.onAgentExitedRef.current(pane.leafId)
     clearSuppressedTitleSideEffects()
     clearCommandInferredPaneAgent()
-    requestKnownDroidReconfirmation()
+    requestWindowsCsiUAgentReconfirmation()
     // Why: when the terminal title reverts to a plain shell (e.g., "bash", "zsh"),
     // the agent has exited. Clear any running cache timer so the sidebar doesn't
     // show a stale countdown for a tab that no longer has an active Claude session.
@@ -8616,7 +8614,7 @@ export function connectPanePty(
     noteVisibilityResume() {
       ptySizeReassertion.request({ fit: false })
       consumeHibernatedAgentWake()
-      requestKnownDroidReconfirmation()
+      requestWindowsCsiUAgentReconfirmation()
       sampleVisiblePaneForegroundAgent()
     },
     reassertPtySizeAfterWindowWake() {
@@ -8661,17 +8659,17 @@ export function connectPanePty(
       return null
     },
     sampleForegroundAgentOnFocus() {
-      requestKnownDroidReconfirmation()
+      requestWindowsCsiUAgentReconfirmation()
       sampleVisiblePaneForegroundAgent()
     },
-    requestDroidReconfirmation() {
+    requestWindowsCsiUReconfirmation() {
       if (shiftEnterReconfirmTimer !== null) {
         clearTimeout(shiftEnterReconfirmTimer)
       }
-      // Why: confirm the Droid composer only after the Shift+Enter burst goes idle, to preserve rapid multiline input.
+      // Why: 等连续 Shift+Enter 输入停止后再确认前台进程，避免快速多行输入期间反复撤销路由。
       shiftEnterReconfirmTimer = setTimeout(() => {
         shiftEnterReconfirmTimer = null
-        requestKnownDroidReconfirmation()
+        requestWindowsCsiUAgentReconfirmation()
         sampleVisiblePaneForegroundAgent()
       }, SHIFT_ENTER_RECONFIRM_IDLE_MS)
     },

--- a/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts
@@ -5,13 +5,13 @@ import {
 } from './terminal-windows-shift-enter'
 
 describe('resolveWindowsShiftEnterEncoding', () => {
-  it('uses CSI-u only for trusted Droid process evidence', () => {
+  it.each(['droid', 'pi'] as const)('uses CSI-u only for trusted %s process evidence', (agent) => {
     expect(
       resolveWindowsShiftEnterEncoding({
-        foreground: { agent: 'droid', routingTrusted: true, shellForeground: false }
+        foreground: { agent, routingTrusted: true, shellForeground: false }
       })
     ).toBe('csi-u')
-    expect(resolveWindowsShiftEnterEncoding({ launchAgentType: 'droid' })).toBe('alt-enter')
+    expect(resolveWindowsShiftEnterEncoding({ launchAgentType: agent })).toBe('alt-enter')
   })
 
   it('does not let hook or OSC-derived status forge Droid input routing', () => {

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -130,7 +130,9 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     expectedProcess: 'pi',
     promptInjectionMode: 'argv',
     // Why: pi has no `--prefill` and paste-after-ready races its long startup; the orca-prefill extension seeds this env var instead.
-    draftPromptEnvVar: 'ORCA_PI_PREFILL'
+    draftPromptEnvVar: 'ORCA_PI_PREFILL',
+    // Why: Pi 在 Windows 上解码 CSI-u；Esc+CR 会被当成普通 Enter 并直接提交。
+    windowsShiftEnterEncoding: 'csi-u'
   },
   omp: {
     detectCmd: 'omp',


### PR DESCRIPTION
## Summary

- Keep Pi Shift+Enter mapped to CSI-u on Windows, avoiding the ESC ambiguity delay and preserving newline behavior after tool subprocess churn.
- Reuse the existing trusted foreground-process gate; launch metadata and hook status still cannot authorize input bytes.
- Generalize post-input reconfirmation from Droid to every agent that explicitly declares the Windows CSI-u capability, so Git Bash and cmd panes revoke stale routing when an agent exits.

Fixes #9703.
Fixes #10203.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` - 35,488 passed and 59 skipped. Sixteen local failures remained outside the changed surface in Windows PTY mocks, worktree/runtime, SSH, Git, and zsh path lookup tests; all focused terminal suites passed.
- [x] `pnpm build`
- [x] Added regression coverage for trusted Pi routing, no-OSC fresh launch, rapid multiline input, and exit-to-shell trust revocation. The four focused terminal suites pass with 541 tests.

The exact patch was reapplied and revalidated against current `upstream/main` (`1bd36ce04`) before this update.

## AI Review Report

The review focused on the terminal byte-authority boundary, Kitty protocol resets, no-OSC shell lifecycle, and stale foreground identity. It verified that only adding the Pi capability would leave shortcut, focus, submit, interrupt, and title-exit reconfirmation hard-coded to Droid, which could preserve stale Pi routing after the process exits. Reconfirmation is therefore generalized only to agents that explicitly declare Windows CSI-u support, while preserving the provider-owned foreground-process confirmation requirement.

Cross-platform review covered macOS, Linux, and Windows terminal hosts. The override is consulted only for a Windows PTY host; macOS and Linux remain gated by live Kitty negotiation, while SSH, WSL, and remote panes retain their existing conservative process-evidence behavior. No shortcut labels, paths, shell commands, or Electron APIs changed.

## Security Audit

This change adds no IPC, filesystem, network, authentication, secret, dependency, or command-execution surface. The relevant risk is sending an application control sequence to a shell after the agent exits. Launch metadata, hook status, and terminal output remain insufficient to authorize the bytes: CSI-u requires current trusted process evidence, and accepted direct input revokes that authority until the bounded provider confirmation succeeds again. Tests cover both continued Pi ownership and confirmed return to cmd.

## Notes

- X handle: N/A
- A physical Windows and Pi session was not available in this macOS worktree; the Windows host, Git Bash no-OSC, process-confirmation, and byte-routing paths are covered with focused integration-style mocks.



## ELI5

Pi on Windows lost reliable Shift+Enter newlines after tool churn because of ESC ambiguity. Shift+Enter stays on CSI-u for Pi, and stale Windows routing is cleared when an agent exits.
