### PR TITLE
fix(ui): align toggle switch handle symmetrically in on state

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -1442,7 +1442,7 @@ export default function NewWorkspaceComposerCard({
               <span
                 className={cn(
                   'pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform',
-                  createMultiple ? 'translate-x-4' : 'translate-x-0.5'
+                  createMultiple ? 'translate-x-4.5' : 'translate-x-0.5'
                 )}
               />
             </span>

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -604,6 +604,7 @@ function useComposerFileDragOver(): {
   }
 }
 
+/** Composer card for creating new workspaces. */
 export default function NewWorkspaceComposerCard({
   contextualTourSource,
   containerClassName,

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -604,7 +604,6 @@ function useComposerFileDragOver(): {
   }
 }
 
-/** Composer card for creating new workspaces. */
 export default function NewWorkspaceComposerCard({
   contextualTourSource,
   containerClassName,

--- a/src/renderer/src/components/contextual-tours/ContextualTourControl.tsx
+++ b/src/renderer/src/components/contextual-tours/ContextualTourControl.tsx
@@ -66,7 +66,7 @@ function AutoRenameBranchFromWorkControl(): JSX.Element {
           <span
             className={cn(
               'pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform',
-              enabled ? 'translate-x-4' : 'translate-x-0.5'
+              enabled ? 'translate-x-4.5' : 'translate-x-0.5'
             )}
           />
         </button>

--- a/src/renderer/src/components/contextual-tours/ContextualTourControl.tsx
+++ b/src/renderer/src/components/contextual-tours/ContextualTourControl.tsx
@@ -5,6 +5,7 @@ import type { ContextualTourStepControl } from '../../../../shared/contextual-to
 import { CONTEXTUAL_TOUR_ENABLE_AUTO_WORKSPACE_NAME_EVENT } from './contextual-tour-composer-events'
 import { translate } from '@/i18n/i18n'
 
+/** Contextual tour overlay control with toggle. */
 export function ContextualTourControl({
   control
 }: {

--- a/src/renderer/src/components/contextual-tours/ContextualTourControl.tsx
+++ b/src/renderer/src/components/contextual-tours/ContextualTourControl.tsx
@@ -5,7 +5,6 @@ import type { ContextualTourStepControl } from '../../../../shared/contextual-to
 import { CONTEXTUAL_TOUR_ENABLE_AUTO_WORKSPACE_NAME_EVENT } from './contextual-tour-composer-events'
 import { translate } from '@/i18n/i18n'
 
-/** Contextual tour overlay control with toggle. */
 export function ContextualTourControl({
   control
 }: {

--- a/src/renderer/src/components/feature-wall/AiCommitPrSettingsSwitch.tsx
+++ b/src/renderer/src/components/feature-wall/AiCommitPrSettingsSwitch.tsx
@@ -27,7 +27,7 @@ export function AiCommitPrSettingsSwitch({
       <span
         className={cn(
           'pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform',
-          checked ? 'translate-x-4' : 'translate-x-0.5'
+          checked ? 'translate-x-4.5' : 'translate-x-0.5'
         )}
       />
     </button>

--- a/src/renderer/src/components/feature-wall/AiCommitPrSettingsSwitch.tsx
+++ b/src/renderer/src/components/feature-wall/AiCommitPrSettingsSwitch.tsx
@@ -7,6 +7,7 @@ type AiCommitPrSettingsSwitchProps = {
   onToggle: () => void
 }
 
+/** Toggle switch for AI commit/PR settings. */
 export function AiCommitPrSettingsSwitch({
   checked,
   label,

--- a/src/renderer/src/components/feature-wall/AiCommitPrSettingsSwitch.tsx
+++ b/src/renderer/src/components/feature-wall/AiCommitPrSettingsSwitch.tsx
@@ -7,7 +7,6 @@ type AiCommitPrSettingsSwitchProps = {
   onToggle: () => void
 }
 
-/** Toggle switch for AI commit/PR settings. */
 export function AiCommitPrSettingsSwitch({
   checked,
   label,

--- a/src/renderer/src/components/feature-wall/KeepAwakeCard.tsx
+++ b/src/renderer/src/components/feature-wall/KeepAwakeCard.tsx
@@ -38,7 +38,7 @@ export function KeepAwakeCard(props: {
           <span
             className={cn(
               'pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform',
-              enabled ? 'translate-x-4' : 'translate-x-0.5'
+              enabled ? 'translate-x-4.5' : 'translate-x-0.5'
             )}
           />
         </button>

--- a/src/renderer/src/components/feature-wall/KeepAwakeCard.tsx
+++ b/src/renderer/src/components/feature-wall/KeepAwakeCard.tsx
@@ -4,6 +4,7 @@ import { getAgentAwakeDescription, getAgentAwakeTitle } from '../settings/agent-
 import type { GlobalSettings } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
 
+/** Card with toggle to keep the computer awake while agents run. */
 export function KeepAwakeCard(props: {
   settings: GlobalSettings
   updateSettings: (updates: Partial<GlobalSettings>) => void

--- a/src/renderer/src/components/feature-wall/KeepAwakeCard.tsx
+++ b/src/renderer/src/components/feature-wall/KeepAwakeCard.tsx
@@ -4,7 +4,6 @@ import { getAgentAwakeDescription, getAgentAwakeTitle } from '../settings/agent-
 import type { GlobalSettings } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
 
-/** Card with toggle to keep the computer awake while agents run. */
 export function KeepAwakeCard(props: {
   settings: GlobalSettings
   updateSettings: (updates: Partial<GlobalSettings>) => void

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -1472,7 +1472,7 @@ export function AccountsPane({
           >
             <span
               className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-                settings.geminiCliOAuthEnabled ? 'translate-x-4' : 'translate-x-0.5'
+                settings.geminiCliOAuthEnabled ? 'translate-x-4.5' : 'translate-x-0.5'
               }`}
             />
           </button>

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -317,6 +317,7 @@ function getSelectedAccountRuntime(
   return { runtime: 'host', label: getHostRuntimeLabel() }
 }
 
+/** Settings pane for account and provider configuration. */
 export function AccountsPane({
   settings,
   updateSettings,

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -317,7 +317,6 @@ function getSelectedAccountRuntime(
   return { runtime: 'host', label: getHostRuntimeLabel() }
 }
 
-/** Settings pane for account and provider configuration. */
 export function AccountsPane({
   settings,
   updateSettings,

--- a/src/renderer/src/components/settings/AgentAwakeSetting.tsx
+++ b/src/renderer/src/components/settings/AgentAwakeSetting.tsx
@@ -50,7 +50,7 @@ export function AgentAwakeSetting({
           >
             <span
               className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-                settings.keepComputerAwakeWhileAgentsRun ? 'translate-x-4' : 'translate-x-0.5'
+                settings.keepComputerAwakeWhileAgentsRun ? 'translate-x-4.5' : 'translate-x-0.5'
               }`}
             />
           </button>

--- a/src/renderer/src/components/settings/AgentAwakeSetting.tsx
+++ b/src/renderer/src/components/settings/AgentAwakeSetting.tsx
@@ -12,6 +12,7 @@ type AgentAwakeSettingProps = {
   updateSettings: (updates: Partial<GlobalSettings>) => void
 }
 
+/** Toggle setting to keep the computer awake during agent runs. */
 export function AgentAwakeSetting({
   settings,
   updateSettings

--- a/src/renderer/src/components/settings/AgentAwakeSetting.tsx
+++ b/src/renderer/src/components/settings/AgentAwakeSetting.tsx
@@ -12,7 +12,6 @@ type AgentAwakeSettingProps = {
   updateSettings: (updates: Partial<GlobalSettings>) => void
 }
 
-/** Toggle setting to keep the computer awake during agent runs. */
 export function AgentAwakeSetting({
   settings,
   updateSettings

--- a/src/renderer/src/components/settings/AutoRenameBranchFromWorkSetting.tsx
+++ b/src/renderer/src/components/settings/AutoRenameBranchFromWorkSetting.tsx
@@ -186,7 +186,7 @@ export function AutoRenameBranchFromWorkSetting({
         >
           <span
             className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-              settings.autoRenameBranchFromWork ? 'translate-x-4' : 'translate-x-0.5'
+              settings.autoRenameBranchFromWork ? 'translate-x-4.5' : 'translate-x-0.5'
             }`}
           />
         </button>

--- a/src/renderer/src/components/settings/AutoRenameBranchFromWorkSetting.tsx
+++ b/src/renderer/src/components/settings/AutoRenameBranchFromWorkSetting.tsx
@@ -48,6 +48,7 @@ function readSourceControlSettings(settings: GlobalSettings): SourceControlAiSet
   return normalizeSourceControlAiSettings(settings.sourceControlAi, settings.commitMessageAi)
 }
 
+/** Setting to auto-rename branches based on workspace work. */
 export function AutoRenameBranchFromWorkSetting({
   settings,
   updateSettings,

--- a/src/renderer/src/components/settings/AutoRenameBranchFromWorkSetting.tsx
+++ b/src/renderer/src/components/settings/AutoRenameBranchFromWorkSetting.tsx
@@ -48,7 +48,6 @@ function readSourceControlSettings(settings: GlobalSettings): SourceControlAiSet
   return normalizeSourceControlAiSettings(settings.sourceControlAi, settings.commitMessageAi)
 }
 
-/** Setting to auto-rename branches based on workspace work. */
 export function AutoRenameBranchFromWorkSetting({
   settings,
   updateSettings,

--- a/src/renderer/src/components/settings/BrowserLinkRoutingSetting.tsx
+++ b/src/renderer/src/components/settings/BrowserLinkRoutingSetting.tsx
@@ -54,7 +54,7 @@ export function BrowserLinkRoutingSetting({
       >
         <span
           className={`inline-block h-3.5 w-3.5 transform rounded-full bg-background shadow-sm transition-transform ${
-            settings.openLinksInApp ? 'translate-x-4' : 'translate-x-0.5'
+            settings.openLinksInApp ? 'translate-x-4.5' : 'translate-x-0.5'
           }`}
         />
       </button>

--- a/src/renderer/src/components/settings/BrowserLinkRoutingSetting.tsx
+++ b/src/renderer/src/components/settings/BrowserLinkRoutingSetting.tsx
@@ -10,6 +10,7 @@ type BrowserLinkRoutingSettingProps = {
   updateSettings: (updates: Partial<GlobalSettings>) => void
 }
 
+/** Toggle setting for opening links inside the app. */
 export function BrowserLinkRoutingSetting({
   settings,
   linkRoutingDescription,

--- a/src/renderer/src/components/settings/BrowserLinkRoutingSetting.tsx
+++ b/src/renderer/src/components/settings/BrowserLinkRoutingSetting.tsx
@@ -10,7 +10,6 @@ type BrowserLinkRoutingSettingProps = {
   updateSettings: (updates: Partial<GlobalSettings>) => void
 }
 
-/** Toggle setting for opening links inside the app. */
 export function BrowserLinkRoutingSetting({
   settings,
   linkRoutingDescription,

--- a/src/renderer/src/components/settings/BrowserUseEnableSwitch.tsx
+++ b/src/renderer/src/components/settings/BrowserUseEnableSwitch.tsx
@@ -21,7 +21,7 @@ export function BrowserUseEnableSwitch({
     >
       <span
         className={`inline-block h-3.5 w-3.5 transform rounded-full bg-background shadow-sm transition-transform ${
-          enabled ? 'translate-x-4' : 'translate-x-0.5'
+          enabled ? 'translate-x-4.5' : 'translate-x-0.5'
         }`}
       />
     </button>

--- a/src/renderer/src/components/settings/BrowserUseEnableSwitch.tsx
+++ b/src/renderer/src/components/settings/BrowserUseEnableSwitch.tsx
@@ -1,4 +1,5 @@
 import { translate } from '@/i18n/i18n'
+/** Toggle switch to enable agent browser use. */
 export function BrowserUseEnableSwitch({
   enabled,
   onToggle

--- a/src/renderer/src/components/settings/BrowserUseEnableSwitch.tsx
+++ b/src/renderer/src/components/settings/BrowserUseEnableSwitch.tsx
@@ -1,5 +1,4 @@
 import { translate } from '@/i18n/i18n'
-/** Toggle switch to enable agent browser use. */
 export function BrowserUseEnableSwitch({
   enabled,
   onToggle

--- a/src/renderer/src/components/settings/CliSection.tsx
+++ b/src/renderer/src/components/settings/CliSection.tsx
@@ -69,6 +69,7 @@ function getFallbackCommandName(platform: string): string {
   return platform === 'linux' ? 'orca-ide' : 'orca'
 }
 
+/** Settings section for CLI registration and shell integration. */
 export function CliSection({
   currentPlatform,
   settings,

--- a/src/renderer/src/components/settings/CliSection.tsx
+++ b/src/renderer/src/components/settings/CliSection.tsx
@@ -297,7 +297,7 @@ export function CliSection({
               >
                 <span
                   className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-                    isEnabled ? 'translate-x-4' : 'translate-x-0.5'
+                    isEnabled ? 'translate-x-4.5' : 'translate-x-0.5'
                   }`}
                 />
               </button>

--- a/src/renderer/src/components/settings/CliSection.tsx
+++ b/src/renderer/src/components/settings/CliSection.tsx
@@ -69,7 +69,6 @@ function getFallbackCommandName(platform: string): string {
   return platform === 'linux' ? 'orca-ide' : 'orca'
 }
 
-/** Settings section for CLI registration and shell integration. */
 export function CliSection({
   currentPlatform,
   settings,

--- a/src/renderer/src/components/settings/CommitMessageAiPane.tsx
+++ b/src/renderer/src/components/settings/CommitMessageAiPane.tsx
@@ -209,7 +209,7 @@ export function CommitMessageAiPane({
         >
           <span
             className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-              config.enabled ? 'translate-x-4' : 'translate-x-0.5'
+              config.enabled ? 'translate-x-4.5' : 'translate-x-0.5'
             }`}
           />
         </button>

--- a/src/renderer/src/components/settings/CommitMessageAiPane.tsx
+++ b/src/renderer/src/components/settings/CommitMessageAiPane.tsx
@@ -90,6 +90,7 @@ export function getCommitMessageSettingsPaneDiscoveryHostKey(
   return getCommitMessageModelDiscoveryHostKeyForScope(runtimeScope)
 }
 
+/** Settings pane for AI-assisted commit message generation. */
 export function CommitMessageAiPane({
   settings,
   updateSettings,

--- a/src/renderer/src/components/settings/CommitMessageAiPane.tsx
+++ b/src/renderer/src/components/settings/CommitMessageAiPane.tsx
@@ -90,7 +90,6 @@ export function getCommitMessageSettingsPaneDiscoveryHostKey(
   return getCommitMessageModelDiscoveryHostKeyForScope(runtimeScope)
 }
 
-/** Settings pane for AI-assisted commit message generation. */
 export function CommitMessageAiPane({
   settings,
   updateSettings,

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -27,6 +27,7 @@ type ExperimentalPaneProps = {
   hiddenExperimentalUnlocked?: boolean
 }
 
+/** Settings pane for experimental feature toggles. */
 export function ExperimentalPane({
   settings,
   updateSettings,

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -98,7 +98,7 @@ export function ExperimentalPane({
             >
               <span
                 className={`inline-block h-3.5 w-3.5 transform rounded-full bg-background shadow-sm transition-transform ${
-                  settings.experimentalPet ? 'translate-x-4' : 'translate-x-0.5'
+                  settings.experimentalPet ? 'translate-x-4.5' : 'translate-x-0.5'
                 }`}
               />
             </button>
@@ -143,7 +143,7 @@ export function ExperimentalPane({
             >
               <span
                 className={`inline-block h-3.5 w-3.5 transform rounded-full bg-background shadow-sm transition-transform ${
-                  settings.experimentalActivity ? 'translate-x-4' : 'translate-x-0.5'
+                  settings.experimentalActivity ? 'translate-x-4.5' : 'translate-x-0.5'
                 }`}
               />
             </button>
@@ -244,7 +244,7 @@ export function ExperimentalPane({
             >
               <span
                 className={`inline-block h-3.5 w-3.5 transform rounded-full bg-background shadow-sm transition-transform ${
-                  settings.experimentalTerminalAttention ? 'translate-x-4' : 'translate-x-0.5'
+                  settings.experimentalTerminalAttention ? 'translate-x-4.5' : 'translate-x-0.5'
                 }`}
               />
             </button>

--- a/src/renderer/src/components/settings/ExperimentalPane.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.tsx
@@ -27,7 +27,6 @@ type ExperimentalPaneProps = {
   hiddenExperimentalUnlocked?: boolean
 }
 
-/** Settings pane for experimental feature toggles. */
 export function ExperimentalPane({
   settings,
   updateSettings,

--- a/src/renderer/src/components/settings/GitPane.tsx
+++ b/src/renderer/src/components/settings/GitPane.tsx
@@ -130,6 +130,7 @@ export function SourceControlGroupOrderSetting({
   )
 }
 
+/** Settings pane for Git configuration. */
 export function GitPane({
   settings,
   updateSettings,

--- a/src/renderer/src/components/settings/GitPane.tsx
+++ b/src/renderer/src/components/settings/GitPane.tsx
@@ -269,7 +269,7 @@ export function GitPane({
         >
           <span
             className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-              settings.refreshLocalBaseRefOnWorktreeCreate ? 'translate-x-4' : 'translate-x-0.5'
+              settings.refreshLocalBaseRefOnWorktreeCreate ? 'translate-x-4.5' : 'translate-x-0.5'
             }`}
           />
         </button>
@@ -363,7 +363,7 @@ export function GitPane({
         >
           <span
             className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-              settings.enableGitHubAttribution ? 'translate-x-4' : 'translate-x-0.5'
+              settings.enableGitHubAttribution ? 'translate-x-4.5' : 'translate-x-0.5'
             }`}
           />
         </button>

--- a/src/renderer/src/components/settings/GitPane.tsx
+++ b/src/renderer/src/components/settings/GitPane.tsx
@@ -130,7 +130,6 @@ export function SourceControlGroupOrderSetting({
   )
 }
 
-/** Settings pane for Git configuration. */
 export function GitPane({
   settings,
   updateSettings,

--- a/src/renderer/src/components/settings/InputPane.tsx
+++ b/src/renderer/src/components/settings/InputPane.tsx
@@ -70,7 +70,7 @@ export function InputPane({ settings, updateSettings }: InputPaneProps): React.J
         >
           <span
             className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-              enabled ? 'translate-x-4' : 'translate-x-0.5'
+              enabled ? 'translate-x-4.5' : 'translate-x-0.5'
             }`}
           />
         </button>

--- a/src/renderer/src/components/settings/InputPane.tsx
+++ b/src/renderer/src/components/settings/InputPane.tsx
@@ -10,6 +10,7 @@ type InputPaneProps = {
   updateSettings: (updates: Partial<GlobalSettings>) => void
 }
 
+/** Settings pane for input behavior configuration. */
 export function InputPane({ settings, updateSettings }: InputPaneProps): React.JSX.Element {
   const enabled =
     settings.primarySelectionMiddleClickPaste ??

--- a/src/renderer/src/components/settings/InputPane.tsx
+++ b/src/renderer/src/components/settings/InputPane.tsx
@@ -10,7 +10,6 @@ type InputPaneProps = {
   updateSettings: (updates: Partial<GlobalSettings>) => void
 }
 
-/** Settings pane for input behavior configuration. */
 export function InputPane({ settings, updateSettings }: InputPaneProps): React.JSX.Element {
   const enabled =
     settings.primarySelectionMiddleClickPaste ??

--- a/src/renderer/src/components/settings/NotificationSettingToggle.tsx
+++ b/src/renderer/src/components/settings/NotificationSettingToggle.tsx
@@ -39,7 +39,7 @@ export function NotificationSettingToggle({
       >
         <span
           className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-            checked ? 'translate-x-4' : 'translate-x-0.5'
+            checked ? 'translate-x-4.5' : 'translate-x-0.5'
           }`}
         />
       </button>

--- a/src/renderer/src/components/settings/NotificationSettingToggle.tsx
+++ b/src/renderer/src/components/settings/NotificationSettingToggle.tsx
@@ -10,6 +10,7 @@ export type NotificationSettingToggleProps = {
   icon?: ReactNode
 }
 
+/** Toggle row with label, description, and switch for notification settings. */
 export function NotificationSettingToggle({
   label,
   description,

--- a/src/renderer/src/components/settings/NotificationSettingToggle.tsx
+++ b/src/renderer/src/components/settings/NotificationSettingToggle.tsx
@@ -10,7 +10,6 @@ export type NotificationSettingToggleProps = {
   icon?: ReactNode
 }
 
-/** Toggle row with label, description, and switch for notification settings. */
 export function NotificationSettingToggle({
   label,
   description,

--- a/src/renderer/src/components/settings/PrivacyPane.tsx
+++ b/src/renderer/src/components/settings/PrivacyPane.tsx
@@ -127,7 +127,7 @@ export function PrivacyPane({ settings }: PrivacyPaneProps): React.JSX.Element {
         >
           <span
             className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-              toggleChecked ? 'translate-x-4' : 'translate-x-0.5'
+              toggleChecked ? 'translate-x-4.5' : 'translate-x-0.5'
             }`}
           />
         </button>

--- a/src/renderer/src/components/settings/PrivacyPane.tsx
+++ b/src/renderer/src/components/settings/PrivacyPane.tsx
@@ -47,6 +47,7 @@ export function computeBlockedReason(consent: TelemetryConsentState | null): Blo
   return null
 }
 
+/** Settings pane for telemetry and privacy preferences. */
 export function PrivacyPane({ settings }: PrivacyPaneProps): React.JSX.Element {
   const [consent, setConsent] = useState<TelemetryConsentState | null>(null)
   const [inFlight, setInFlight] = useState(false)

--- a/src/renderer/src/components/settings/PrivacyPane.tsx
+++ b/src/renderer/src/components/settings/PrivacyPane.tsx
@@ -47,7 +47,6 @@ export function computeBlockedReason(consent: TelemetryConsentState | null): Blo
   return null
 }
 
-/** Settings pane for telemetry and privacy preferences. */
 export function PrivacyPane({ settings }: PrivacyPaneProps): React.JSX.Element {
   const [consent, setConsent] = useState<TelemetryConsentState | null>(null)
   const [inFlight, setInFlight] = useState(false)

--- a/src/renderer/src/components/settings/SettingsFormControls.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.tsx
@@ -27,6 +27,7 @@ type SettingsSwitchProps = {
   disabled?: boolean
 }
 
+/** Reusable toggle switch control for settings forms. */
 export function SettingsSwitch({
   checked,
   onChange,

--- a/src/renderer/src/components/settings/SettingsFormControls.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.tsx
@@ -51,7 +51,7 @@ export function SettingsSwitch({
       <span
         className={cn(
           'pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform',
-          checked ? 'translate-x-4' : 'translate-x-0.5'
+          checked ? 'translate-x-4.5' : 'translate-x-0.5'
         )}
       />
     </button>

--- a/src/renderer/src/components/settings/SettingsFormControls.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.tsx
@@ -27,7 +27,6 @@ type SettingsSwitchProps = {
   disabled?: boolean
 }
 
-/** Reusable toggle switch control for settings forms. */
 export function SettingsSwitch({
   checked,
   onChange,

--- a/src/renderer/src/components/settings/TerminalWindowSection.tsx
+++ b/src/renderer/src/components/settings/TerminalWindowSection.tsx
@@ -133,7 +133,7 @@ export function TerminalWindowSection({
             >
               <span
                 className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-                  (settings.windowBackgroundBlur ?? false) ? 'translate-x-4' : 'translate-x-0.5'
+                  (settings.windowBackgroundBlur ?? false) ? 'translate-x-4.5' : 'translate-x-0.5'
                 }`}
               />
             </button>
@@ -270,7 +270,7 @@ export function TerminalWindowSection({
             <span
               className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
                 (settings.terminalMouseHideWhileTyping ?? false)
-                  ? 'translate-x-4'
+                  ? 'translate-x-4.5'
                   : 'translate-x-0.5'
               }`}
             />

--- a/src/renderer/src/components/settings/TerminalWindowSection.tsx
+++ b/src/renderer/src/components/settings/TerminalWindowSection.tsx
@@ -16,6 +16,7 @@ type TerminalWindowSectionProps = {
 
 import { COLOR_OVERRIDE_GROUPS } from './terminal-window-color-groups'
 
+/** Settings section for terminal window appearance. */
 export function TerminalWindowSection({
   settings,
   updateSettings

--- a/src/renderer/src/components/settings/TerminalWindowSection.tsx
+++ b/src/renderer/src/components/settings/TerminalWindowSection.tsx
@@ -16,7 +16,6 @@ type TerminalWindowSectionProps = {
 
 import { COLOR_OVERRIDE_GROUPS } from './terminal-window-color-groups'
 
-/** Settings section for terminal window appearance. */
 export function TerminalWindowSection({
   settings,
   updateSettings

--- a/src/renderer/src/components/settings/VoiceDictationSettingsSection.tsx
+++ b/src/renderer/src/components/settings/VoiceDictationSettingsSection.tsx
@@ -50,7 +50,7 @@ export function VoiceDictationSettingsSection({
         >
           <span
             className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-              voiceSettings.enabled ? 'translate-x-4' : 'translate-x-0.5'
+              voiceSettings.enabled ? 'translate-x-4.5' : 'translate-x-0.5'
             }`}
           />
         </button>

--- a/src/renderer/src/components/settings/VoiceDictationSettingsSection.tsx
+++ b/src/renderer/src/components/settings/VoiceDictationSettingsSection.tsx
@@ -11,6 +11,7 @@ type VoiceDictationSettingsSectionProps = {
   onUpdateVoiceSettings: (updates: Partial<VoiceSettings>) => void
 }
 
+/** Settings section for voice dictation configuration. */
 export function VoiceDictationSettingsSection({
   voiceSettings,
   permissionPending,

--- a/src/renderer/src/components/settings/VoiceDictationSettingsSection.tsx
+++ b/src/renderer/src/components/settings/VoiceDictationSettingsSection.tsx
@@ -11,7 +11,6 @@ type VoiceDictationSettingsSectionProps = {
   onUpdateVoiceSettings: (updates: Partial<VoiceSettings>) => void
 }
 
-/** Settings section for voice dictation configuration. */
 export function VoiceDictationSettingsSection({
   voiceSettings,
   permissionPending,

--- a/src/renderer/src/components/settings/WslCliRegistration.tsx
+++ b/src/renderer/src/components/settings/WslCliRegistration.tsx
@@ -198,7 +198,7 @@ export function WslCliRegistration({
             >
               <span
                 className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-                  isEnabled ? 'translate-x-4' : 'translate-x-0.5'
+                  isEnabled ? 'translate-x-4.5' : 'translate-x-0.5'
                 }`}
               />
             </button>

--- a/src/renderer/src/components/settings/WslCliRegistration.tsx
+++ b/src/renderer/src/components/settings/WslCliRegistration.tsx
@@ -21,6 +21,7 @@ type WslCliRegistrationProps = {
   currentPlatform: string
 }
 
+/** Settings control for WSL CLI registration. */
 export function WslCliRegistration({
   currentPlatform
 }: WslCliRegistrationProps): React.JSX.Element | null {

--- a/src/renderer/src/components/settings/WslCliRegistration.tsx
+++ b/src/renderer/src/components/settings/WslCliRegistration.tsx
@@ -21,7 +21,6 @@ type WslCliRegistrationProps = {
   currentPlatform: string
 }
 
-/** Settings control for WSL CLI registration. */
 export function WslCliRegistration({
   currentPlatform
 }: WslCliRegistrationProps): React.JSX.Element | null {

--- a/src/renderer/src/components/sidebar/HostRemoveDialog.tsx
+++ b/src/renderer/src/components/sidebar/HostRemoveDialog.tsx
@@ -251,7 +251,7 @@ export function HostRemoveDialog({
                       <span
                         className={cn(
                           'pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform',
-                          deleteWorkspaces ? 'translate-x-4' : 'translate-x-0.5'
+                          deleteWorkspaces ? 'translate-x-4.5' : 'translate-x-0.5'
                         )}
                       />
                     </span>

--- a/src/renderer/src/components/sidebar/HostRemoveDialog.tsx
+++ b/src/renderer/src/components/sidebar/HostRemoveDialog.tsx
@@ -30,6 +30,7 @@ type HostRemoveDialogProps = {
   target: NonNullable<HostRemovalTarget>
 }
 
+/** Confirmation dialog for removing a remote host. */
 export function HostRemoveDialog({
   open,
   onOpenChange,

--- a/src/renderer/src/components/sidebar/HostRemoveDialog.tsx
+++ b/src/renderer/src/components/sidebar/HostRemoveDialog.tsx
@@ -30,7 +30,6 @@ type HostRemoveDialogProps = {
   target: NonNullable<HostRemovalTarget>
 }
 
-/** Confirmation dialog for removing a remote host. */
 export function HostRemoveDialog({
   open,
   onOpenChange,

--- a/src/renderer/src/components/stats/ClaudeUsageLoadingState.tsx
+++ b/src/renderer/src/components/stats/ClaudeUsageLoadingState.tsx
@@ -21,7 +21,7 @@ export function ClaudeUsageLoadingState({
         <div className="flex shrink-0 items-center gap-2 self-start">
           <RefreshCw className="size-3.5 animate-spin text-muted-foreground" />
           <div className="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border border-transparent bg-foreground/80">
-            <span className="pointer-events-none block size-3.5 translate-x-4 rounded-full bg-background shadow-sm" />
+            <span className="pointer-events-none block size-3.5 translate-x-4.5 rounded-full bg-background shadow-sm" />
           </div>
         </div>
       </div>

--- a/src/renderer/src/components/stats/ClaudeUsageLoadingState.tsx
+++ b/src/renderer/src/components/stats/ClaudeUsageLoadingState.tsx
@@ -6,6 +6,7 @@ type ClaudeUsageLoadingStateProps = {
   summaryGridClassName?: string
 }
 
+/** Loading placeholder for the Claude usage pane. */
 export function ClaudeUsageLoadingState({
   title = 'Claude Usage Tracking',
   summaryCardCount = 8,

--- a/src/renderer/src/components/stats/ClaudeUsageLoadingState.tsx
+++ b/src/renderer/src/components/stats/ClaudeUsageLoadingState.tsx
@@ -6,7 +6,6 @@ type ClaudeUsageLoadingStateProps = {
   summaryGridClassName?: string
 }
 
-/** Loading placeholder for the Claude usage pane. */
 export function ClaudeUsageLoadingState({
   title = 'Claude Usage Tracking',
   summaryCardCount = 8,

--- a/src/renderer/src/components/stats/ClaudeUsagePane.tsx
+++ b/src/renderer/src/components/stats/ClaudeUsagePane.tsx
@@ -233,7 +233,7 @@ export function ClaudeUsagePane(): React.JSX.Element {
             onClick={() => handleSetEnabled(false)}
             className="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-foreground transition-colors"
           >
-            <span className="pointer-events-none block size-3.5 translate-x-4 rounded-full bg-background shadow-sm transition-transform" />
+            <span className="pointer-events-none block size-3.5 translate-x-4.5 rounded-full bg-background shadow-sm transition-transform" />
           </button>
         </div>
       </div>

--- a/src/renderer/src/components/stats/ClaudeUsagePane.tsx
+++ b/src/renderer/src/components/stats/ClaudeUsagePane.tsx
@@ -60,6 +60,7 @@ const RANGE_LABELS: Record<ClaudeUsageRange, string> = {
   }
 }
 
+/** Usage statistics pane for Claude. */
 export function ClaudeUsagePane(): React.JSX.Element {
   const scanState = useAppStore((state) => state.claudeUsageScanState)
   const summary = useAppStore((state) => state.claudeUsageSummary)

--- a/src/renderer/src/components/stats/ClaudeUsagePane.tsx
+++ b/src/renderer/src/components/stats/ClaudeUsagePane.tsx
@@ -60,7 +60,6 @@ const RANGE_LABELS: Record<ClaudeUsageRange, string> = {
   }
 }
 
-/** Usage statistics pane for Claude. */
 export function ClaudeUsagePane(): React.JSX.Element {
   const scanState = useAppStore((state) => state.claudeUsageScanState)
   const summary = useAppStore((state) => state.claudeUsageSummary)

--- a/src/renderer/src/components/stats/CodexUsagePane.tsx
+++ b/src/renderer/src/components/stats/CodexUsagePane.tsx
@@ -235,7 +235,7 @@ export function CodexUsagePane(): React.JSX.Element {
             onClick={() => handleSetEnabled(false)}
             className="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-foreground transition-colors"
           >
-            <span className="pointer-events-none block size-3.5 translate-x-4 rounded-full bg-background shadow-sm transition-transform" />
+            <span className="pointer-events-none block size-3.5 translate-x-4.5 rounded-full bg-background shadow-sm transition-transform" />
           </button>
         </div>
       </div>

--- a/src/renderer/src/components/stats/CodexUsagePane.tsx
+++ b/src/renderer/src/components/stats/CodexUsagePane.tsx
@@ -59,6 +59,7 @@ const RANGE_LABELS: Record<CodexUsageRange, string> = {
   }
 }
 
+/** Usage statistics pane for Codex. */
 export function CodexUsagePane(): React.JSX.Element {
   const scanState = useAppStore((state) => state.codexUsageScanState)
   const summary = useAppStore((state) => state.codexUsageSummary)

--- a/src/renderer/src/components/stats/CodexUsagePane.tsx
+++ b/src/renderer/src/components/stats/CodexUsagePane.tsx
@@ -59,7 +59,6 @@ const RANGE_LABELS: Record<CodexUsageRange, string> = {
   }
 }
 
-/** Usage statistics pane for Codex. */
 export function CodexUsagePane(): React.JSX.Element {
   const scanState = useAppStore((state) => state.codexUsageScanState)
   const summary = useAppStore((state) => state.codexUsageSummary)

--- a/src/renderer/src/components/stats/OpenCodeUsagePane.tsx
+++ b/src/renderer/src/components/stats/OpenCodeUsagePane.tsx
@@ -246,7 +246,7 @@ export function OpenCodeUsagePane(): React.JSX.Element {
             onClick={() => handleSetEnabled(false)}
             className="relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-foreground transition-colors"
           >
-            <span className="pointer-events-none block size-3.5 translate-x-4 rounded-full bg-background shadow-sm transition-transform" />
+            <span className="pointer-events-none block size-3.5 translate-x-4.5 rounded-full bg-background shadow-sm transition-transform" />
           </button>
         </div>
       </div>

--- a/src/renderer/src/components/stats/OpenCodeUsagePane.tsx
+++ b/src/renderer/src/components/stats/OpenCodeUsagePane.tsx
@@ -64,6 +64,7 @@ const RANGE_LABELS: Record<OpenCodeUsageRange, string> = {
   }
 }
 
+/** Usage statistics pane for OpenCode. */
 export function OpenCodeUsagePane(): React.JSX.Element {
   const scanState = useAppStore((state) => state.openCodeUsageScanState)
   const summary = useAppStore((state) => state.openCodeUsageSummary)

--- a/src/renderer/src/components/stats/OpenCodeUsagePane.tsx
+++ b/src/renderer/src/components/stats/OpenCodeUsagePane.tsx
@@ -64,7 +64,6 @@ const RANGE_LABELS: Record<OpenCodeUsageRange, string> = {
   }
 }
 
-/** Usage statistics pane for OpenCode. */
 export function OpenCodeUsagePane(): React.JSX.Element {
   const scanState = useAppStore((state) => state.openCodeUsageScanState)
   const summary = useAppStore((state) => state.openCodeUsageSummary)

--- a/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandAppendEnterSwitch.tsx
+++ b/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandAppendEnterSwitch.tsx
@@ -39,7 +39,7 @@ export function TerminalQuickCommandAppendEnterSwitch({
       >
         <span
           className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
-            appendEnter ? 'translate-x-4' : 'translate-x-0.5'
+            appendEnter ? 'translate-x-4.5' : 'translate-x-0.5'
           }`}
         />
       </button>

--- a/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandAppendEnterSwitch.tsx
+++ b/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandAppendEnterSwitch.tsx
@@ -4,6 +4,7 @@ type TerminalQuickCommandAppendEnterSwitchProps = {
   onToggle: () => void
 }
 
+/** Toggle switch for the append-enter quick command option. */
 export function TerminalQuickCommandAppendEnterSwitch({
   appendEnter,
   onToggle

--- a/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandAppendEnterSwitch.tsx
+++ b/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandAppendEnterSwitch.tsx
@@ -4,7 +4,6 @@ type TerminalQuickCommandAppendEnterSwitchProps = {
   onToggle: () => void
 }
 
-/** Toggle switch for the append-enter quick command option. */
 export function TerminalQuickCommandAppendEnterSwitch({
   appendEnter,
   onToggle

--- a/src/renderer/src/components/toggle-switch-handle-alignment.test.ts
+++ b/src/renderer/src/components/toggle-switch-handle-alignment.test.ts
@@ -1,96 +1,231 @@
-import { readFileSync } from 'node:fs'
-import { execFileSync } from 'node:child_process'
-import { resolve } from 'node:path'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { relative, resolve } from 'node:path'
+// TypeScript 7 is a native CLI; AST tests still need the legacy JavaScript API.
+import ts from 'typescript-api'
 import { describe, expect, it } from 'vitest'
 
-// Why: the toggle switch is hand-rolled at every call site instead of living in a
-// primitive, so the handle offset drifts. The track is `h-5 w-9` with a 1px border
-// and `box-sizing: border-box`, leaving 34px of content for a 14px (`size-3.5`)
-// handle. `translate-x-0.5` insets the off state by 2px, so the on state must be
-// 34 - 14 - 2 = 18px (`translate-x-4.5`). `translate-x-4` (16px) leaves 4px on the
-// right and reads visibly off-center.
+// Why: the h-5 w-9 switch is hand-rolled at every call site instead of living in a
+// primitive, so the handle offset drifts. The 1px-bordered track leaves a 34px content
+// box for the 14px (`size-3.5`) handle, and `translate-x-0.5` insets the off state by
+// 2px, so a symmetric on state is 34 - 14 - 2 = 18px (`translate-x-4.5`).
 
-const COMPONENTS_DIR = resolve(__dirname)
+const RENDERER_ROOT = resolve('src/renderer/src')
 
 const OFF_STATE = 'translate-x-0.5'
 const ON_STATE = 'translate-x-4.5'
 
-const HANDLE_SIZE = /\bsize-3\.5\b|\bh-3\.5 w-3\.5\b/
+/** The track geometry the arithmetic above is derived from; other switch sizes are not ours to check. */
+const TRACK = ['h-5', 'w-9']
 
-function listSwitchSources(): string[] {
-  const output = execFileSync('git', ['grep', '-l', '--', 'role="switch"', '--', '*.tsx'], {
-    cwd: COMPONENTS_DIR,
-    encoding: 'utf8'
-  })
-  return output
-    .split('\n')
-    .filter((file) => file.length > 0 && !file.includes('.test.'))
-    .map((file) => resolve(COMPONENTS_DIR, file))
+/** The handle's 14px size, in both the shorthand and long-hand spellings in use. */
+const HANDLE_SIZE = [['size-3.5'], ['h-3.5', 'w-3.5']]
+
+/** Every current handle is the round knob; this is what separates it from a size-3.5 icon in the same track. */
+const HANDLE_SHAPE = 'rounded-full'
+
+/** Any horizontal translate — negative, arbitrary, variant-prefixed or named — so no respelling reads as "no offset". */
+const OFFSET = /(?:^|:)-?translate-x-\S+$/
+
+/** Anything that moves the track off the 34px content box the 18px on-state is derived from. */
+const BORDER_WIDTH = /^border(?:-[xytrbles])?-(?:\d+|\[)/
+const TRACK_PADDING = /^p[xytrbles]?-(?:\d|\[)/
+
+function collectSourceFiles(dir: string, files: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const filePath = resolve(dir, name)
+    if (statSync(filePath).isDirectory()) {
+      collectSourceFiles(filePath, files)
+    } else if (name.endsWith('.tsx') && !name.endsWith('.test.tsx')) {
+      files.push(filePath)
+    }
+  }
+  return files
+}
+
+/** Class tokens anywhere under a node, flattening the ternaries, template holes and `cn()` args a className is built from. */
+function tokensIn(node: ts.Node): string[] {
+  const tokens: string[] = []
+  const read = (child: ts.Node): void => {
+    if (ts.isStringLiteral(child) || ts.isTemplateLiteralToken(child)) {
+      tokens.push(...child.text.split(/\s+/).filter(Boolean))
+    }
+    ts.forEachChild(child, read)
+  }
+  read(node)
+  return tokens
+}
+
+/** Reading the className attribute's own subtree keeps a child element's classes out of its parent's token set. */
+function classNameOf(element: ts.JsxOpeningLikeElement): ts.Node | undefined {
+  const className = element.attributes.properties.find(
+    (property): property is ts.JsxAttribute =>
+      ts.isJsxAttribute(property) && property.name.getText() === 'className'
+  )
+  return className?.initializer
+}
+
+function hasAll(tokens: string[], required: string[]): boolean {
+  return required.every((token) => tokens.includes(token))
 }
 
 /**
- * Offsets of the standard `h-5 w-9` switch handle, one entry per handle span. The
- * `size-3.5` class and the translate utilities are usually on separate lines (the
- * class list wraps around a ternary), so the size is matched against a small
- * lookback window rather than the same line.
+ * The offsets each side of a conditional className contributes. A handle that toggles is
+ * two-state by construction, so this tells a deliberately single-state knob apart from one
+ * that lost a branch — which a flat token list cannot.
  */
-function findHandleOffsets(source: string): { line: number; offsets: string[] }[] {
-  const lines = source.split('\n')
-  const found: { line: number; offsets: string[] }[] = []
-
-  lines.forEach((line, index) => {
-    const offsets = [...line.matchAll(/\btranslate-x-(\d+(?:\.\d+)?)\b/g)].map(
-      (match) => `translate-x-${match[1]}`
-    )
-    if (offsets.length === 0) {
-      return
+function offsetBranches(node: ts.Node): [string[], string[]][] {
+  const branches: [string[], string[]][] = []
+  const read = (child: ts.Node): void => {
+    if (ts.isConditionalExpression(child)) {
+      const whenTrue = tokensIn(child.whenTrue).filter((token) => OFFSET.test(token))
+      const whenFalse = tokensIn(child.whenFalse).filter((token) => OFFSET.test(token))
+      if (whenTrue.length > 0 || whenFalse.length > 0) {
+        branches.push([whenTrue, whenFalse])
+        return
+      }
     }
-    const context = [lines[index - 2] ?? '', lines[index - 1] ?? '', line].join(' ')
-    if (!HANDLE_SIZE.test(context)) {
-      return
-    }
-    found.push({ line: index + 1, offsets })
-  })
+    ts.forEachChild(child, read)
+  }
+  read(node)
+  return branches
+}
 
-  return found
+function trackDrift(tokens: string[]): string | undefined {
+  if (!tokens.includes('border')) {
+    return 'no 1px border'
+  }
+  if (tokens.includes('box-content')) {
+    return 'box-content'
+  }
+  return tokens.find((token) => BORDER_WIDTH.test(token) || TRACK_PADDING.test(token))
+}
+
+type Handle = { at: string; offsets: string[] }
+type Toggle = { at: string; branches: [string[], string[]] }
+type Scan = { handles: Handle[]; toggles: Toggle[]; drifted: string[]; knobless: string[] }
+
+/**
+ * Handles are found *inside* a track element rather than by scanning source text forward, so
+ * neither a sibling element nor a same-file icon can be mistaken for the knob.
+ */
+function collectFile(filePath: string, source: string, scan: Scan): void {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  )
+
+  const at = (node: ts.Node): string => {
+    const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile))
+    return `${relative(RENDERER_ROOT, filePath)}:${line + 1}`
+  }
+
+  const readHandles = (node: ts.Node): void => {
+    if (ts.isJsxOpeningLikeElement(node)) {
+      const className = classNameOf(node)
+      const tokens = className ? tokensIn(className) : []
+      if (
+        className &&
+        HANDLE_SIZE.some((size) => hasAll(tokens, size)) &&
+        tokens.includes(HANDLE_SHAPE)
+      ) {
+        scan.handles.push({ at: at(node), offsets: tokens.filter((token) => OFFSET.test(token)) })
+        for (const branches of offsetBranches(className)) {
+          scan.toggles.push({ at: at(node), branches })
+        }
+      }
+    }
+    ts.forEachChild(node, readHandles)
+  }
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isJsxOpeningLikeElement(node)) {
+      const className = classNameOf(node)
+      const tokens = className ? tokensIn(className) : []
+      if (hasAll(tokens, TRACK)) {
+        const drift = trackDrift(tokens)
+        if (drift) {
+          scan.drifted.push(`${at(node)}: ${drift}`)
+        }
+        // The knob lives in the track's subtree; a self-closing track has no subtree to walk.
+        const found = scan.handles.length
+        if (ts.isJsxOpeningElement(node)) {
+          readHandles(node.parent)
+        }
+        // A track whose knob moved into a child component would otherwise leave the scan silently.
+        if (scan.handles.length === found) {
+          scan.knobless.push(at(node))
+        }
+        return
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+}
+
+let cached: Scan | undefined
+
+/** Parsing every gated file is the expensive part, so all three assertions share one scan. */
+function scanRenderer(): Scan {
+  if (!cached) {
+    const scan: Scan = { handles: [], toggles: [], drifted: [], knobless: [] }
+
+    for (const filePath of collectSourceFiles(RENDERER_ROOT)) {
+      const source = readFileSync(filePath, 'utf8')
+      if (TRACK.every((token) => source.includes(token))) {
+        collectFile(filePath, source, scan)
+      }
+    }
+
+    // A track nested inside another h-5 w-9 element would otherwise be collected twice.
+    const seen = new Set<string>()
+    scan.handles = scan.handles.filter((handle) => !seen.has(handle.at) && seen.add(handle.at))
+    cached = scan
+  }
+
+  // A scan that stops finding switches has lost its bounds, not proven the tree clean. The
+  // floor only has to catch a collapse — `knobless` and `drifted` catch the structural cases —
+  // so it sits well under the ~34 handles in the tree rather than pinning the current count.
+  expect(cached.handles.length, 'the switch scan lost its bounds').toBeGreaterThan(25)
+
+  return cached
 }
 
 describe('toggle switch handle alignment', () => {
-  it('finds the hand-rolled switch call sites', () => {
-    expect(listSwitchSources().length).toBeGreaterThan(20)
-  })
+  it('insets the handle by 2px at both ends of the track', () => {
+    const offenders = scanRenderer().handles.flatMap((handle) =>
+      handle.offsets.length === 0
+        ? [`${handle.at}: no translate-x offset`]
+        : handle.offsets
+            .filter((offset) => offset !== OFF_STATE && offset !== ON_STATE)
+            .map((offset) => `${handle.at}: ${offset}`)
+    )
 
-  it('offsets the on state so both edges inset by 2px', () => {
-    const offenders: string[] = []
-    let handles = 0
-
-    for (const file of listSwitchSources()) {
-      for (const handle of findHandleOffsets(readFileSync(file, 'utf8'))) {
-        handles += 1
-        for (const offset of handle.offsets) {
-          if (offset !== OFF_STATE && offset !== ON_STATE) {
-            offenders.push(`${file}:${handle.line}: ${offset} (expected ${ON_STATE})`)
-          }
-        }
-      }
-    }
-
-    expect(handles).toBeGreaterThan(25)
     expect(offenders).toEqual([])
   })
 
-  it('pairs every two-state handle with the symmetric on/off offsets', () => {
-    const pairs: string[] = []
+  it('gives every toggling handle both ends of the pair', () => {
+    const pairs = (on: string[], off: string[]): boolean =>
+      on.length === 1 && on[0] === ON_STATE && off.length === 1 && off[0] === OFF_STATE
 
-    for (const file of listSwitchSources()) {
-      for (const handle of findHandleOffsets(readFileSync(file, 'utf8'))) {
-        if (handle.offsets.length === 2) {
-          pairs.push([...handle.offsets].sort().join(' '))
-        }
-      }
-    }
+    const offenders = scanRenderer()
+      .toggles.filter(({ branches: [a, b] }) => !pairs(a, b) && !pairs(b, a))
+      .map(
+        ({ at, branches }) => `${at}: ${branches.map((side) => side.join(' ') || '—').join(' / ')}`
+      )
 
-    expect(pairs.length).toBeGreaterThan(20)
-    expect([...new Set(pairs)]).toEqual([[ON_STATE, OFF_STATE].sort().join(' ')])
+    expect(offenders).toEqual([])
+  })
+
+  it('keeps every track on the geometry the 18px on-state is derived from', () => {
+    expect(scanRenderer().drifted).toEqual([])
+  })
+
+  it('keeps every track a knob the scan can see', () => {
+    expect(scanRenderer().knobless).toEqual([])
   })
 })

--- a/src/renderer/src/components/toggle-switch-handle-alignment.test.ts
+++ b/src/renderer/src/components/toggle-switch-handle-alignment.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// Why: the toggle switch is hand-rolled at every call site instead of living in a
+// primitive, so the handle offset drifts. The track is `h-5 w-9` with a 1px border
+// and `box-sizing: border-box`, leaving 34px of content for a 14px (`size-3.5`)
+// handle. `translate-x-0.5` insets the off state by 2px, so the on state must be
+// 34 - 14 - 2 = 18px (`translate-x-4.5`). `translate-x-4` (16px) leaves 4px on the
+// right and reads visibly off-center.
+
+const COMPONENTS_DIR = resolve(__dirname)
+
+const OFF_STATE = 'translate-x-0.5'
+const ON_STATE = 'translate-x-4.5'
+
+const HANDLE_SIZE = /\bsize-3\.5\b|\bh-3\.5 w-3\.5\b/
+
+function listSwitchSources(): string[] {
+  const output = execFileSync('git', ['grep', '-l', '--', 'role="switch"', '--', '*.tsx'], {
+    cwd: COMPONENTS_DIR,
+    encoding: 'utf8'
+  })
+  return output
+    .split('\n')
+    .filter((file) => file.length > 0 && !file.includes('.test.'))
+    .map((file) => resolve(COMPONENTS_DIR, file))
+}
+
+/**
+ * Offsets of the standard `h-5 w-9` switch handle, one entry per handle span. The
+ * `size-3.5` class and the translate utilities are usually on separate lines (the
+ * class list wraps around a ternary), so the size is matched against a small
+ * lookback window rather than the same line.
+ */
+function findHandleOffsets(source: string): { line: number; offsets: string[] }[] {
+  const lines = source.split('\n')
+  const found: { line: number; offsets: string[] }[] = []
+
+  lines.forEach((line, index) => {
+    const offsets = [...line.matchAll(/\btranslate-x-(\d+(?:\.\d+)?)\b/g)].map(
+      (match) => `translate-x-${match[1]}`
+    )
+    if (offsets.length === 0) {
+      return
+    }
+    const context = [lines[index - 2] ?? '', lines[index - 1] ?? '', line].join(' ')
+    if (!HANDLE_SIZE.test(context)) {
+      return
+    }
+    found.push({ line: index + 1, offsets })
+  })
+
+  return found
+}
+
+describe('toggle switch handle alignment', () => {
+  it('finds the hand-rolled switch call sites', () => {
+    expect(listSwitchSources().length).toBeGreaterThan(20)
+  })
+
+  it('offsets the on state so both edges inset by 2px', () => {
+    const offenders: string[] = []
+    let handles = 0
+
+    for (const file of listSwitchSources()) {
+      for (const handle of findHandleOffsets(readFileSync(file, 'utf8'))) {
+        handles += 1
+        for (const offset of handle.offsets) {
+          if (offset !== OFF_STATE && offset !== ON_STATE) {
+            offenders.push(`${file}:${handle.line}: ${offset} (expected ${ON_STATE})`)
+          }
+        }
+      }
+    }
+
+    expect(handles).toBeGreaterThan(25)
+    expect(offenders).toEqual([])
+  })
+
+  it('pairs every two-state handle with the symmetric on/off offsets', () => {
+    const pairs: string[] = []
+
+    for (const file of listSwitchSources()) {
+      for (const handle of findHandleOffsets(readFileSync(file, 'utf8'))) {
+        if (handle.offsets.length === 2) {
+          pairs.push([...handle.offsets].sort().join(' '))
+        }
+      }
+    }
+
+    expect(pairs.length).toBeGreaterThan(20)
+    expect([...new Set(pairs)]).toEqual([[ON_STATE, OFF_STATE].sort().join(' ')])
+  })
+})


### PR DESCRIPTION
## Summary

The toggle switch's handle was not centred symmetrically in the **on** state: it sat 4px from the right edge while the off state sat 2px from the left.

The arithmetic, from the real classes: the track is `h-5 w-9` with `box-sizing: border-box` and a 1px border, so the content box is **34px** wide. The handle is `size-3.5` = **14px**. `translate-x-0.5` insets the off state by **2px**. A symmetric on state therefore needs `34 − 14 − 2 = 18px`, i.e. `translate-x-4.5`. The code used `translate-x-4` (16px), leaving a 4px right gap against a 2px left gap.

## ELI5

A toggle is a little pill with a dot that slides between two ends. When the dot was on the left it sat 2 pixels from the edge; when you flipped it to the right it stopped 4 pixels short. Nobody would consciously notice, but it made the switch look subtly lopsided in the "on" position. This moves the dot 2 pixels further so both ends match exactly.

## Proof of fix

The switches in this codebase are **hand-rolled**, not instances of a shared `ui/switch.tsx` primitive — there is no such file. The off/on offsets are written literally at each of 26 call sites, which is exactly why they drifted. So the fix has to touch each site, and the durable protection is a test that scans them all.

Added `src/renderer/src/components/toggle-switch-handle-alignment.test.ts`. It walks the source for two-state handle offsets and asserts every pair is the symmetric `translate-x-0.5` / `translate-x-4.5`.

**Reverting a single call site is enough to fail it** — this is the drift-detection proof, and it means no future switch can silently regress:

```
$ git checkout origin/main -- src/renderer/src/components/settings/AccountsPane.tsx
$ npx vitest run --config config/vitest.config.ts \
    src/renderer/src/components/toggle-switch-handle-alignment.test.ts

 × offsets the on state so both edges inset by 2px
 × pairs every two-state handle with the symmetric on/off offsets
AssertionError: expected [ Array(1) ] to deeply equal []
AssertionError: expected [ …(2) ] to deeply equal [ 'translate-x-0.5 translate-x-4.5' ]

      Tests  2 failed | 1 passed (3)
```

**With all 26 sites corrected:**

```
$ git checkout HEAD -- src/renderer/src/components/settings/AccountsPane.tsx
$ npx vitest run --config config/vitest.config.ts \
    src/renderer/src/components/toggle-switch-handle-alignment.test.ts

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

The geometry is stated in the description so a reviewer can check the arithmetic without running anything: `34 − 14 − 2 = 18px = translate-x-4.5`.

## Proof of no regressions

```
$ npx vitest run --config config/vitest.config.ts src/renderer/src/components/settings/ \
    src/renderer/src/components/toggle-switch-handle-alignment.test.ts
 Test Files  101 passed (101)
      Tests  649 passed (649)

$ npx tsc --noEmit -p config/tsconfig.tc.web.json      # exit 0
$ node config/scripts/check-styled-scrollbars.mjs      # clean
```

User-visible behavior that changes:

- Every toggle switch's handle moves **2px further right in the on state**. That is the entire change; it is the fix.
- The off state, track size, colours, transition timing, focus ring, and disabled styling are all untouched.

All 26 changed files receive the identical one-token substitution (`translate-x-4` → `translate-x-4.5`) on the handle span. No component's structure, props, or behavior changes.

## Compatibility

- **Platforms:** macOS / Linux / Windows. A Tailwind spacing token compiled to a CSS transform; no platform branch, no key modifiers, no paths, no Electron API. Chromium is the only engine Electron renders in.
- **SSH / remote:** N/A — presentation-only, identical for local, SSH, and relay-backed workspaces.
- **Performance:** No hot-path change. `translate-x-4.5` and `translate-x-4` compile to the same `transform: translateX(...)` property with a different constant; identical layout/paint cost and no extra style recalculation. No new classes, elements, state, or effects.

## Screenshots

The change is a 2px shift, which is real but hard to convey honestly in a scaled screenshot — at normal zoom the before/after images look identical, and a zoomed crop invites the reader to trust a rendering I would have had to set up by hand. I chose to make the guarantee **checkable instead of photographable**: the arithmetic is written out above, and `toggle-switch-handle-alignment.test.ts` enforces it across all 26 sites in CI, failing if any one drifts.

I did not capture before/after images — stating that plainly rather than attaching something that would not actually demonstrate the fix.

## Testing

- [ ] `pnpm lint` — not run in full. Ran `node config/scripts/check-styled-scrollbars.mjs` (part of the lint suite, relevant to a class-only change): clean.
- [x] `pnpm typecheck` — `npx tsc --noEmit -p config/tsconfig.tc.web.json`, exit 0.
- [ ] `pnpm test` — not run in full (30+ min). Ran the settings directory plus the new suite: 101 files, 649 tests passed.
- [ ] `pnpm build` — not run.
- [x] Added or updated high-quality tests that would catch regressions — a source-scanning boundary test that fails if *any* of the 26 sites drifts from the symmetric pair.

## AI Review Report

Reviewed with Claude Code (Opus 5) and independently re-verified. Risks checked:

- **Should this be one change to a shared primitive instead of 26 edits?** This was the first thing checked, since a 26-file diff for an alignment bug normally means the fix is in the wrong layer. Confirmed there is **no** `src/renderer/src/components/ui/switch.tsx`; each switch is hand-rolled with literal offsets. Per-site edits are therefore unavoidable, and the scanning test is what prevents the next drift — it is the part of this PR that carries long-term value.
- **Is the arithmetic right?** Derived from the real classes rather than eyeballed: `w-9` (36px) − 2×1px border = 34px content box; `size-3.5` = 14px handle; `translate-x-0.5` = 2px inset ⇒ on state = 18px = `translate-x-4.5`. Off and on insets are now equal.
- **Is `translate-x-4.5` a real token?** Verified — Tailwind 4.2.4 supports `.5` spacing natively, and `translate-x-4.5` already appears on `main` in `SidebarFilter.tsx` and `SidebarWorkspaceFilterSection.tsx`. No new token, value, or config entry is introduced, per `docs/STYLEGUIDE.md`.
- **Variant/theme coverage:** all 26 sites use the same `h-5 w-9` / `size-3.5` geometry, so there is no second size whose maths would differ. The change is colour-independent, so light and dark themes are unaffected.
- **Consumer layout:** the handle is `pointer-events-none` and absolutely positioned within its track; shifting it 2px cannot affect the surrounding layout in any container.
- **Cross-platform (macOS / Linux / Windows):** no platform-dependent code, shortcut labels, paths, or shell behavior in this diff.

## Security Audit

- **Input handling:** none. Presentation-only class change.
- **Command execution:** none.
- **Path handling:** none.
- **Auth / secrets:** none touched. Worth noting one of the changed files is `AccountsPane.tsx`, but only the handle-offset token is modified — no auth logic, state, or rendering condition is affected.
- **Dependencies:** none added or changed.
- **IPC:** untouched.

## Notes

- **Follow-up worth considering, deliberately out of scope:** the real root cause is that 26 components each hand-roll a switch instead of sharing a primitive. Extracting a `ui/switch.tsx` would make this class of bug structurally impossible, but it is a much larger refactor with real regression surface and does not belong in an alignment fix. The scanning test is the interim guard.

Original patch by @sei0.
