### PR TITLE
fix(pty): report writes to a gone pty as not-written (#9169)

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -741,7 +741,7 @@ describe('registerPtyHandlers', () => {
     const connectionId = 'ssh-1'
     const ptyId = `ssh:${connectionId}@@remote-pty`
     const localProvider = createAgentClaimProvider({})
-    // Why: hasPty=false now blocks writes (#9169); the reconnect assertions need the provider to report this pty live.
+    // Why: the reconnect phase asserts a post-attach provider — the real one marks the pty live in attachForReconnect (#9169).
     const sshProvider = createAgentClaimProvider({ livePtyIds: new Set([ptyId]) })
     setLocalPtyProvider(localProvider as never)
     registerSshPtyProvider(connectionId, sshProvider as never)

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -15490,4 +15490,28 @@ describe('registerPtyHandlers', () => {
       }
     })
   })
+
+  describe('controller.write to a pty with no live process', () => {
+    it('reports failure instead of a silent success (#9169)', () => {
+      const runtime = {
+        setPtyController: vi.fn(),
+        onPtyExit: vi.fn()
+      }
+      handlers.clear()
+      registerPtyHandlers(
+        mainWindow as never,
+        runtime as never,
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      )
+      const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
+        write: (ptyId: string, data: string) => boolean
+      }
+
+      // Why: the provider no-ops on an unknown pty; the controller must report not-written, not a phantom success (#9169).
+      expect(controller.write('never-spawned-pty', 'echo hi\n')).toBe(false)
+    })
+  })
 })

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -741,7 +741,8 @@ describe('registerPtyHandlers', () => {
     const connectionId = 'ssh-1'
     const ptyId = `ssh:${connectionId}@@remote-pty`
     const localProvider = createAgentClaimProvider({})
-    const sshProvider = createAgentClaimProvider({})
+    // Why: hasPty=false now blocks writes (#9169); the reconnect assertions need the provider to report this pty live.
+    const sshProvider = createAgentClaimProvider({ livePtyIds: new Set([ptyId]) })
     setLocalPtyProvider(localProvider as never)
     registerSshPtyProvider(connectionId, sshProvider as never)
     setPtyOwnership(ptyId, connectionId)

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -4026,10 +4026,12 @@ export function registerPtyHandlers(
       }
     },
     write: (ptyId, data) => {
-      const provider = getProviderForPty(ptyId)
       try {
+        // Why: the provider lookup throws for a disconnected SSH pty; resolve inside the try so that write fails closed too.
+        const provider = getProviderForPty(ptyId)
         // Why: provider.write() silently no-ops for a pty it no longer has; report not-written so the send isn't recorded as delivered (#9169).
-        if (provider.hasPty && !provider.hasPty(ptyId)) {
+        // Only an explicit false blocks the write — absent/unknown ownership must not reject a live pty.
+        if (provider.hasPty?.(ptyId) === false) {
           return false
         }
         provider.write(ptyId, data)

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -4026,8 +4026,13 @@ export function registerPtyHandlers(
       }
     },
     write: (ptyId, data) => {
+      const provider = getProviderForPty(ptyId)
       try {
-        getProviderForPty(ptyId).write(ptyId, data)
+        // Why: provider.write() silently no-ops for a pty it no longer has; report not-written so the send isn't recorded as delivered (#9169).
+        if (provider.hasPty && !provider.hasPty(ptyId)) {
+          return false
+        }
+        provider.write(ptyId, data)
         return true
       } catch {
         return false

--- a/src/main/providers/ssh-pty-attach-exit-fence.ts
+++ b/src/main/providers/ssh-pty-attach-exit-fence.ts
@@ -1,0 +1,81 @@
+import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
+import { SSH_SESSION_EXPIRED_ERROR } from './ssh-pty-errors'
+import { parseSshPtyAttachResult, type SshPtyAttachResult } from './ssh-pty-session-reattach'
+import type { SshPtySpawnExitRaceTracker } from './ssh-pty-spawn-exit-race'
+
+export type SshPtyAttachContext = {
+  mux: SshChannelMultiplexer
+  exitRaceTracker: SshPtySpawnExitRaceTracker
+  livePtyIds: Set<string>
+  toRelayPtyId: (id: string) => string
+  toAppPtyId: (id: string) => string
+}
+
+/**
+ * Runs a `pty.attach` request and reports whether a matching `pty.exit` beat it home.
+ *
+ * Why: the relay can deliver the exit inside the attach reply batch, and its handler
+ * removes the id from `livePtyIds` during the await. Marking the PTY live after that
+ * would resurrect one the relay already reported dead — the phantom-live state the
+ * dead-PTY write guard exists to prevent (#9169) — so the exit wins the race.
+ */
+async function fenceAttach(
+  ctx: SshPtyAttachContext,
+  id: string,
+  params: Record<string, unknown>
+): Promise<{ result: SshPtyAttachResult; exited: boolean }> {
+  const operation = ctx.exitRaceTracker.begin()
+  try {
+    const result = parseSshPtyAttachResult(await ctx.mux.request('pty.attach', params))
+    // Why: an absent incarnation on either side matches any exit for this relay id —
+    // the conservative direction, mirroring the spawn fence.
+    const exited = ctx.exitRaceTracker.didMatchingExitArrive(operation, {
+      id: ctx.toRelayPtyId(id),
+      ...(result.incarnationId ? { incarnationId: result.incarnationId } : {})
+    })
+    if (!exited) {
+      ctx.livePtyIds.add(ctx.toAppPtyId(id))
+    }
+    return { result, exited }
+  } finally {
+    ctx.exitRaceTracker.finish(operation)
+  }
+}
+
+/**
+ * Why: a resolved attach is the relay asserting it owns this PTY; without marking it
+ * live a quiet PTY stays absent from `livePtyIds` until its first frame arrives.
+ */
+export async function attachSshPty(ctx: SshPtyAttachContext, id: string): Promise<void> {
+  const relayPtyId = ctx.toRelayPtyId(id)
+  const { exited } = await fenceAttach(ctx, id, { id: relayPtyId })
+  if (exited) {
+    // Why: this path has no outer fence, so a caller that ignores hasPty would keep
+    // writing into a gone PTY; fail the attach rather than resolve on a dead lease.
+    throw new Error(`${SSH_SESSION_EXPIRED_ERROR}: ${relayPtyId}`)
+  }
+}
+
+/**
+ * Why: reconnect owns replay delivery so stale/duplicate attach results can be filtered
+ * before they reach the renderer, and the expected identity lets the relay reject a
+ * cross-generation id collision instead of reattaching this lease to a different pane's
+ * freshly spawned PTY.
+ *
+ * Why: this returns the result even when the PTY exited mid-attach — ssh-relay-session's
+ * pending-exit fence needs the incarnation to retire the pane, and throwing here would
+ * abandon every later PTY in its reattach loop. The fence still withholds liveness.
+ */
+export async function attachSshPtyForReconnect(
+  ctx: SshPtyAttachContext,
+  id: string,
+  expected?: { paneKey?: string; tabId?: string }
+): Promise<SshPtyAttachResult> {
+  const { result } = await fenceAttach(ctx, id, {
+    id: ctx.toRelayPtyId(id),
+    suppressReplayNotification: true,
+    ...(expected?.paneKey ? { expectedPaneKey: expected.paneKey } : {}),
+    ...(expected?.tabId ? { expectedTabId: expected.tabId } : {})
+  })
+  return result
+}

--- a/src/main/providers/ssh-pty-provider-exit-race.test.ts
+++ b/src/main/providers/ssh-pty-provider-exit-race.test.ts
@@ -84,7 +84,9 @@ it('rejects an SSH reattach whose matching exit shares the attach reply batch', 
 // Why: `pty.exit` deletes from livePtyIds during the await, so an unfenced add after
 // it would resurrect a pty the relay already reported dead — the phantom-live state
 // the dead-pty write guard exists to prevent (#9169).
-function createExitDuringAttachMux(incarnationId?: string): ReturnType<typeof createMux> {
+function createExitDuringAttachMux(
+  incarnations: { exitIncarnationId?: string; resultIncarnationId?: string } = {}
+): ReturnType<typeof createMux> {
   const mux = createMux()
   mux.request.mockImplementation(async (method: string) => {
     if (method === 'pty.attach') {
@@ -92,9 +94,11 @@ function createExitDuringAttachMux(incarnationId?: string): ReturnType<typeof cr
       notify?.('pty.exit', {
         id: 'pty-1',
         code: 0,
-        ...(incarnationId ? { incarnationId } : {})
+        ...(incarnations.exitIncarnationId ? { incarnationId: incarnations.exitIncarnationId } : {})
       })
-      return incarnationId ? { incarnationId } : undefined
+      return incarnations.resultIncarnationId
+        ? { incarnationId: incarnations.resultIncarnationId }
+        : undefined
     }
     return undefined
   })
@@ -102,7 +106,10 @@ function createExitDuringAttachMux(incarnationId?: string): ReturnType<typeof cr
 }
 
 it('fails attach() and leaves the pty not live when its exit shares the attach reply batch', async () => {
-  const mux = createExitDuringAttachMux('incarnation-gone')
+  const mux = createExitDuringAttachMux({
+    exitIncarnationId: 'incarnation-gone',
+    resultIncarnationId: 'incarnation-gone'
+  })
   const provider = new SshPtyProvider('conn-1', mux as never)
 
   await expect(provider.attach('ssh:conn-1@@pty-1')).rejects.toThrow('SSH_SESSION_EXPIRED')
@@ -120,7 +127,10 @@ it('fences attach() even when the relay reports no incarnation', async () => {
 })
 
 it('leaves a reconnect-attached pty not live when its exit shares the attach reply batch', async () => {
-  const mux = createExitDuringAttachMux('incarnation-gone')
+  const mux = createExitDuringAttachMux({
+    exitIncarnationId: 'incarnation-gone',
+    resultIncarnationId: 'incarnation-gone'
+  })
   const provider = new SshPtyProvider('conn-1', mux as never)
 
   // Why: ssh-relay-session's pending-exit fence needs the incarnation to retire the
@@ -133,16 +143,11 @@ it('leaves a reconnect-attached pty not live when its exit shares the attach rep
 })
 
 it('still marks an attached pty live when a different incarnation exits mid-attach', async () => {
-  const mux = createMux()
-  const provider = new SshPtyProvider('conn-1', mux as never)
-  mux.request.mockImplementation(async (method: string) => {
-    if (method === 'pty.attach') {
-      const notify = mux.onNotification.mock.calls[0]?.[0]
-      notify?.('pty.exit', { id: 'pty-1', code: 0, incarnationId: 'incarnation-previous' })
-      return { incarnationId: 'incarnation-current' }
-    }
-    return undefined
+  const mux = createExitDuringAttachMux({
+    exitIncarnationId: 'incarnation-previous',
+    resultIncarnationId: 'incarnation-current'
   })
+  const provider = new SshPtyProvider('conn-1', mux as never)
 
   await expect(provider.attachForReconnect('pty-1')).resolves.toEqual({
     incarnationId: 'incarnation-current'

--- a/src/main/providers/ssh-pty-provider-exit-race.test.ts
+++ b/src/main/providers/ssh-pty-provider-exit-race.test.ts
@@ -1,14 +1,24 @@
 import { expect, it, vi } from 'vitest'
 import { SshPtyProvider } from './ssh-pty-provider'
 
-it('rejects a fresh SSH PTY whose exit shares the spawn response batch', async () => {
-  const mux = {
+function createMux(): {
+  request: ReturnType<typeof vi.fn>
+  notify: ReturnType<typeof vi.fn>
+  onNotification: ReturnType<typeof vi.fn>
+  dispose: ReturnType<typeof vi.fn>
+  isDisposed: ReturnType<typeof vi.fn>
+} {
+  return {
     request: vi.fn(),
     notify: vi.fn(),
     onNotification: vi.fn(),
     dispose: vi.fn(),
     isDisposed: vi.fn().mockReturnValue(false)
   }
+}
+
+it('rejects a fresh SSH PTY whose exit shares the spawn response batch', async () => {
+  const mux = createMux()
   const provider = new SshPtyProvider('conn-1', mux as never)
   const exitListener = vi.fn()
   provider.onExit(exitListener)
@@ -42,13 +52,7 @@ it('rejects a fresh SSH PTY whose exit shares the spawn response batch', async (
 })
 
 it('rejects an SSH reattach whose matching exit shares the attach reply batch', async () => {
-  const mux = {
-    request: vi.fn(),
-    notify: vi.fn(),
-    onNotification: vi.fn(),
-    dispose: vi.fn(),
-    isDisposed: vi.fn().mockReturnValue(false)
-  }
+  const mux = createMux()
   const provider = new SshPtyProvider('conn-1', mux as never)
   mux.request.mockImplementation(async (method: string) => {
     if (method === 'pty.attach') {
@@ -75,4 +79,74 @@ it('rejects an SSH reattach whose matching exit shares the attach reply batch', 
     incarnationId: 'incarnation-next',
     isReattach: true
   })
+})
+
+// Why: `pty.exit` deletes from livePtyIds during the await, so an unfenced add after
+// it would resurrect a pty the relay already reported dead — the phantom-live state
+// the dead-pty write guard exists to prevent (#9169).
+function createExitDuringAttachMux(incarnationId?: string): ReturnType<typeof createMux> {
+  const mux = createMux()
+  mux.request.mockImplementation(async (method: string) => {
+    if (method === 'pty.attach') {
+      const notify = mux.onNotification.mock.calls[0]?.[0]
+      notify?.('pty.exit', {
+        id: 'pty-1',
+        code: 0,
+        ...(incarnationId ? { incarnationId } : {})
+      })
+      return incarnationId ? { incarnationId } : undefined
+    }
+    return undefined
+  })
+  return mux
+}
+
+it('fails attach() and leaves the pty not live when its exit shares the attach reply batch', async () => {
+  const mux = createExitDuringAttachMux('incarnation-gone')
+  const provider = new SshPtyProvider('conn-1', mux as never)
+
+  await expect(provider.attach('ssh:conn-1@@pty-1')).rejects.toThrow('SSH_SESSION_EXPIRED')
+
+  expect(provider.hasPty('ssh:conn-1@@pty-1')).toBe(false)
+})
+
+it('fences attach() even when the relay reports no incarnation', async () => {
+  const mux = createExitDuringAttachMux()
+  const provider = new SshPtyProvider('conn-1', mux as never)
+
+  await expect(provider.attach('ssh:conn-1@@pty-1')).rejects.toThrow('SSH_SESSION_EXPIRED')
+
+  expect(provider.hasPty('ssh:conn-1@@pty-1')).toBe(false)
+})
+
+it('leaves a reconnect-attached pty not live when its exit shares the attach reply batch', async () => {
+  const mux = createExitDuringAttachMux('incarnation-gone')
+  const provider = new SshPtyProvider('conn-1', mux as never)
+
+  // Why: ssh-relay-session's pending-exit fence needs the incarnation to retire the
+  // pane, so the exit suppresses the liveness add without failing the reattach loop.
+  await expect(provider.attachForReconnect('pty-1')).resolves.toEqual({
+    incarnationId: 'incarnation-gone'
+  })
+
+  expect(provider.hasPty('ssh:conn-1@@pty-1')).toBe(false)
+})
+
+it('still marks an attached pty live when a different incarnation exits mid-attach', async () => {
+  const mux = createMux()
+  const provider = new SshPtyProvider('conn-1', mux as never)
+  mux.request.mockImplementation(async (method: string) => {
+    if (method === 'pty.attach') {
+      const notify = mux.onNotification.mock.calls[0]?.[0]
+      notify?.('pty.exit', { id: 'pty-1', code: 0, incarnationId: 'incarnation-previous' })
+      return { incarnationId: 'incarnation-current' }
+    }
+    return undefined
+  })
+
+  await expect(provider.attachForReconnect('pty-1')).resolves.toEqual({
+    incarnationId: 'incarnation-current'
+  })
+
+  expect(provider.hasPty('ssh:conn-1@@pty-1')).toBe(true)
 })

--- a/src/main/providers/ssh-pty-provider.test.ts
+++ b/src/main/providers/ssh-pty-provider.test.ts
@@ -706,6 +706,32 @@ describe('SshPtyProvider', () => {
     )
   })
 
+  it('marks a reattached pty live so writes are not reported not-written (#9169)', async () => {
+    // Why: reconnect builds a fresh provider; a silent pty emits no frame to
+    // repopulate livePtyIds, so attach must be what proves liveness.
+    mux.request.mockResolvedValue({ incarnationId: 'incarnation-reconnect' })
+    expect(provider.hasPty(scopedPty1)).toBe(false)
+
+    await provider.attachForReconnect('pty-1')
+
+    expect(provider.hasPty(scopedPty1)).toBe(true)
+  })
+
+  it('marks an attached pty live', async () => {
+    expect(provider.hasPty(scopedPty1)).toBe(false)
+
+    await provider.attach(scopedPty1)
+
+    expect(provider.hasPty(scopedPty1)).toBe(true)
+  })
+
+  it('leaves a failed attach not live', async () => {
+    mux.request.mockRejectedValue(new Error('PTY "pty-1" not found'))
+
+    await expect(provider.attachForReconnect('pty-1')).rejects.toThrow('not found')
+    expect(provider.hasPty(scopedPty1)).toBe(false)
+  })
+
   it('attachForReconnect forwards expected identity when provided', async () => {
     await provider.attachForReconnect(scopedPty1, {
       paneKey: 'tab-a:leaf-a',

--- a/src/main/providers/ssh-pty-provider.ts
+++ b/src/main/providers/ssh-pty-provider.ts
@@ -199,6 +199,9 @@ export class SshPtyProvider implements IPtyProvider {
 
   async attach(id: string): Promise<void> {
     await this.mux.request('pty.attach', { id: this.toRelayPtyId(id) })
+    // Why: a resolved attach is the relay asserting it owns this pty; without it
+    // a quiet pty stays absent from livePtyIds until its first frame arrives.
+    this.livePtyIds.add(this.toAppPtyId(id))
   }
 
   async attachForReconnect(
@@ -209,7 +212,7 @@ export class SshPtyProvider implements IPtyProvider {
     // be filtered before they reach the renderer. The expected identity lets the
     // relay reject a cross-generation id collision instead of reattaching this
     // lease to a different pane's freshly spawned PTY.
-    return parseSshPtyAttachResult(
+    const result = parseSshPtyAttachResult(
       await this.mux.request('pty.attach', {
         id: this.toRelayPtyId(id),
         suppressReplayNotification: true,
@@ -217,6 +220,11 @@ export class SshPtyProvider implements IPtyProvider {
         ...(expected?.tabId ? { expectedTabId: expected.tabId } : {})
       })
     )
+    // Why: reconnect builds a fresh provider with an empty livePtyIds, and a
+    // reattached-but-silent pty emits no frame — mark it live on the attach that
+    // proved it exists, or writes to it report not-written (#9169).
+    this.livePtyIds.add(this.toAppPtyId(id))
+    return result
   }
 
   write(id: string, data: string): void {

--- a/src/main/providers/ssh-pty-provider.ts
+++ b/src/main/providers/ssh-pty-provider.ts
@@ -16,10 +16,14 @@ import {
 } from './ssh-agent-session-create-operation'
 import { mapSshPtyProcessList } from './ssh-agent-session-process-list'
 import {
-  parseSshPtyAttachResult,
   reattachSshPtySessionWithExitFence,
   type SshPtyAttachResult
 } from './ssh-pty-session-reattach'
+import {
+  attachSshPty,
+  attachSshPtyForReconnect,
+  type SshPtyAttachContext
+} from './ssh-pty-attach-exit-fence'
 import { buildSshPtySpawnRequest } from './ssh-pty-spawn-request'
 import { SshPtySpawnExitRaceTracker } from './ssh-pty-spawn-exit-race'
 import { SshAgentSessionCapabilities } from './ssh-agent-session-capabilities'
@@ -197,34 +201,25 @@ export class SshPtyProvider implements IPtyProvider {
     return await this.agentSessionCapabilities.supportsCreateOperations(options)
   }
 
+  private attachContext(): SshPtyAttachContext {
+    return {
+      mux: this.mux,
+      exitRaceTracker: this.spawnExitRaces,
+      livePtyIds: this.livePtyIds,
+      toRelayPtyId: (id) => this.toRelayPtyId(id),
+      toAppPtyId: (id) => this.toAppPtyId(id)
+    }
+  }
+
   async attach(id: string): Promise<void> {
-    await this.mux.request('pty.attach', { id: this.toRelayPtyId(id) })
-    // Why: a resolved attach is the relay asserting it owns this pty; without it
-    // a quiet pty stays absent from livePtyIds until its first frame arrives.
-    this.livePtyIds.add(this.toAppPtyId(id))
+    await attachSshPty(this.attachContext(), id)
   }
 
   async attachForReconnect(
     id: string,
     expected?: { paneKey?: string; tabId?: string }
   ): Promise<SshPtyAttachResult> {
-    // Why: reconnect owns replay delivery so stale/duplicate attach results can
-    // be filtered before they reach the renderer. The expected identity lets the
-    // relay reject a cross-generation id collision instead of reattaching this
-    // lease to a different pane's freshly spawned PTY.
-    const result = parseSshPtyAttachResult(
-      await this.mux.request('pty.attach', {
-        id: this.toRelayPtyId(id),
-        suppressReplayNotification: true,
-        ...(expected?.paneKey ? { expectedPaneKey: expected.paneKey } : {}),
-        ...(expected?.tabId ? { expectedTabId: expected.tabId } : {})
-      })
-    )
-    // Why: reconnect builds a fresh provider with an empty livePtyIds, and a
-    // reattached-but-silent pty emits no frame — mark it live on the attach that
-    // proved it exists, or writes to it report not-written (#9169).
-    this.livePtyIds.add(this.toAppPtyId(id))
-    return result
+    return await attachSshPtyForReconnect(this.attachContext(), id, expected)
   }
 
   write(id: string, data: string): void {


### PR DESCRIPTION
## Summary

`terminal send` reported `accepted: true` for input that reached no shell: the runtime PTY controller's `write()` returned `true` even when the provider no longer owned the PTY, because `provider.write()` silently no-ops in that state. Orchestrating agents then waited forever on output that could never come, with a clean-looking audit trail. The fix guards the controller write on the provider's own `hasPty()` so a gone PTY raises `terminal_not_writable` instead of a phantom success.

Addresses Invariant 1 of #9169. Invariant 2 (`show`/`read` disagreeing on liveness) is left for its own change, so this does not close the issue.

## ELI5

Orca could tell an automated assistant "your message was delivered to the terminal" when the terminal had actually already shut down, so the message went nowhere. The assistant then sat waiting for a reply that was never coming. Now Orca admits the delivery failed, so the caller can retry or start a new terminal instead of hanging.

The first version of this patch had a bug of its own: after an SSH connection dropped and came back, a remote terminal that happened to be sitting quiet was misread as dead, so real typing into a perfectly healthy terminal would have been rejected. That is fixed too.

## Proof of fix

**1. The original bug — a write to a PTY the provider does not have.** Test checked out at the PR head, `src/main/ipc/pty.ts` reverted to the base commit:

```
 FAIL  src/main/ipc/pty.test.ts > registerPtyHandlers > controller.write to a pty
       with no live process > reports failure instead of a silent success (#9169)
AssertionError: expected true to be false // Object.is equality

- Expected
+ Received

- false
+ true

 ❯ src/main/ipc/pty.test.ts:13569:66
    13569|       expect(controller.write('never-spawned-pty', 'echo hi\n')).toBe(false)

 Test Files  1 failed (1)
      Tests  1 failed | 339 skipped (340)
```

With the fix restored:

```
 Test Files  1 passed (1)
      Tests  1 passed | 339 skipped (340)
```

**2. A defect found while reviewing this PR — the guard rejected writes to live SSH PTYs.** `SshPtyProvider` only adds to `livePtyIds` on spawn and on inbound `pty.data`/`pty.replay` frames. A relay reconnect constructs a *fresh* provider whose set is empty, and `attachForReconnect()` did not repopulate it — so a reattached-but-silent remote PTY read as gone and every write to it was refused until its first frame happened to arrive. Without the provider fix:

```
 FAIL  src/main/providers/ssh-pty-provider.test.ts > SshPtyProvider >
       marks a reattached pty live so writes are not reported not-written (#9169)
AssertionError: expected false to be true // Object.is equality

- Expected
+ Received

- true
+ false

 ❯ src/main/providers/ssh-pty-provider.test.ts:717:41
     715|     await provider.attachForReconnect('pty-1')
     717|     expect(provider.hasPty(scopedPty1)).toBe(true)

 Test Files  1 failed (1)
      Tests  1 failed | 54 skipped (55)
```

With it:

```
 Test Files  1 passed (1)
      Tests  55 passed (55)
```

A resolved `pty.attach` is the relay asserting it owns that PTY, so it is the correct point to mark it live. A failed attach leaves it not-live (covered by a third test).

## Proof of no regressions

```
$ npx vitest run --config config/vitest.config.ts \
    src/main/ipc/pty.test.ts src/main/providers/ src/main/ssh/ src/main/daemon/
 Test Files  152 passed | 3 skipped (155)
      Tests  2723 passed | 15 skipped (2738)

$ npx vitest run --config config/vitest.config.ts src/main/runtime/
 Test Files  148 passed | 1 skipped (149)
      Tests  2575 passed | 5 skipped (2580)

$ npx tsc --noEmit -p config/tsconfig.node.json
(exit 0, no output)

$ npx oxlint src/main/ipc/pty.ts src/main/ipc/pty.test.ts \
    src/main/providers/ssh-pty-provider.ts src/main/providers/ssh-pty-provider.test.ts
(no findings)
```

User-visible behavior that changes, all of it intended:

- `terminal.send` / `sendTerminalAgentPrompt` against a PTY whose provider no longer has it now rejects with `terminal_not_writable` instead of resolving `accepted: true`. Callers already handle this code — `active-agent-note-send.ts` maps it to a `not-writable` result and the orchestration coordinator marks the task failed. Neither retries in a loop, so there is no new retry storm.
- Interactive keystrokes are unaffected: the renderer types through the `pty:write` IPC listener, which has its own provider lookup and never calls the controller. No new error toast can fire per keystroke.
- `pty:writeAccepted` already gated on `provider.hasPty()` before this PR, so the two write paths are now consistent rather than divergent.

## Compatibility

- **Platforms:** No platform-specific code — the guard lives in the provider-agnostic controller and calls only the provider's own `hasPty()`. On every OS `LocalPtyProvider.hasPty()` reads the `ptyProcesses` map, and the map entry is deleted synchronously inside node-pty's `onExit` handler (`clearPtyState`), so liveness flips at the same moment on Windows/ConPTY as on unix — it tracks node-pty's exit event, not a POSIX-only signal. Verified by running the suites on macOS; the Windows-specific cases in `pty.test.ts` (which force `process.platform = 'win32'`) pass. Not executed on real Windows or Linux hardware.
- **SSH / remote:** This is the main risk area and the reason for the second commit. Remote writes are fire-and-forget relay notifications, so `hasPty()` is the only liveness signal available on that path — which made the reconnect gap above a real wedge rather than a theoretical one. Providers that don't implement `hasPty` are untouched (`provider.hasPty?.(id) === false` short-circuits only on an explicit `false`, per @coderabbitai's review), so unknown ownership never rejects a live PTY.
- **Performance:** No hot-path change. One `Set`/`Map` lookup per controller write, and controller writes are agent/RPC sends, not per-keystroke traffic.

## Screenshots

No visual change. This is a main-process IPC/PTY correctness fix with no UI surface.

## Testing

- [ ] `pnpm lint` — not run in full. Ran `npx oxlint` on all four changed files: no findings.
- [x] `pnpm typecheck` — `npx tsc --noEmit -p config/tsconfig.node.json`, exit 0.
- [ ] `pnpm test` — not run in full (30+ min). Ran every suite covering the touched surface: `src/main/ipc/pty.test.ts`, `src/main/providers/`, `src/main/ssh/`, `src/main/daemon/` (2723 passed) and `src/main/runtime/` (2575 passed).
- [ ] `pnpm build` — not run.
- [x] Added or updated high-quality tests that would catch regressions — three new tests: the original dead-PTY write (fails on base, passes here), the SSH reattach-liveness defect found during review, and a failed-attach case asserting the PTY stays not-live.

## AI Review Report

Reviewed with Claude Code (Opus 5), then re-reviewed adversarially. Risks checked:

- **Caller blast radius (the main regression risk):** enumerated every consumer of the controller's `write()` return value. `terminal.send` / `sendTerminalAgentPrompt` now reject with `terminal_not_writable`; `active-agent-note-send.ts` maps it to a `not-writable` result and the orchestration coordinator marks the task failed. Neither retries in a loop, so no retry storm. Interactive keystrokes go through the `pty:write` IPC listener, which has its own provider lookup and never touches the controller — so no per-keystroke error toast is possible.
- **SSH / remote:** this is where the review paid for itself. The first version of the guard would have rejected writes to *live* remote PTYs after a relay reconnect, because a fresh `SshPtyProvider` starts with an empty `livePtyIds` and `attachForReconnect()` did not repopulate it. Fixed by marking the PTY live on a resolved `pty.attach` (the relay asserting ownership), with a failed attach leaving it not-live.
- **Feature detection:** `provider.hasPty?.(id) === false` short-circuits only on an explicit `false`, so providers that don't implement `hasPty` keep their existing behavior — unknown ownership never rejects a live PTY. This follows @coderabbitai's review on the PR.
- **Cross-platform (macOS / Linux / Windows):** no platform-specific code. `LocalPtyProvider.hasPty()` reads the `ptyProcesses` map, and the entry is deleted synchronously inside node-pty's `onExit` (`clearPtyState`), so liveness flips identically on Windows/ConPTY and unix — it tracks node-pty's exit event, not a POSIX-only signal. Suites run on macOS; the `process.platform = 'win32'` cases in `pty.test.ts` pass. **Not executed on real Windows or Linux hardware** — stated plainly rather than claimed.
- **Race (check-then-write):** the guard consults the same authoritative map `write()` itself consults, so a `false` means the write would have no-opped anyway; there is no window where a live PTY is rejected.
- **Agent / git-provider neutrality:** the change sits below all agent- and provider-specific layers.

## Security Audit

- **Input handling:** no new parsing. The guard reads provider state before the existing write path.
- **Command execution:** none added or changed. The fix stops input from being falsely reported as delivered; it does not alter what gets executed or where.
- **Path handling:** none.
- **Auth / secrets:** none touched. Note the fix slightly *reduces* a failure mode where an agent prompt (which may contain sensitive context) is reported delivered while actually being discarded.
- **Dependencies:** none added or changed.
- **IPC:** the `terminal_not_writable` error is an existing code on an existing channel; no new IPC surface.

## Notes

- **Scope is deliberately partial.** This addresses Invariant 1 of #9169 (a send to a dead PTY must not report success). It is a plausible mechanism for the "send returns ok, input vanishes" wedge reported there, but that wedge was **not reproduced**, so this does not claim to resolve the incident. Invariant 2 — `show`/`read` disagreeing on liveness — is left for its own change.
- Adjacent in-flight work worth sequencing against: #10504 (Windows PTY input chunk pacing) and #10116 (SSH interrupt inference) touch neighbouring write/status paths.

Closes part of #9169 (Invariant 1 only; Invariant 2 remains open).

Original patch by @tomdebres.
