### PR TITLE
fix(terminal): realign legacy residual output metadata

### DIFF
--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -421,6 +421,17 @@ function stripSnapshotBoundaryQuerySuffixes(
   return output + data.slice(offset)
 }
 
+// 剥离查询字节后，普通残余需按实际数据重对齐，避免被误编码为 OutputSpan。
+function realignResidualOutputMeta(
+  data: string,
+  meta: TerminalOutputMeta | undefined
+): TerminalOutputMeta | undefined {
+  if (!meta || meta.transformed) {
+    return meta
+  }
+  return { ...meta, rawLength: data.length }
+}
+
 function appendAckPendingOutput(
   stream: TerminalMultiplexStream,
   chunk: TerminalOutputFrameChunk
@@ -3119,7 +3130,6 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         if (!initialOutputOverflowed) {
           for (const item of bufferedOutput) {
             let uncoveredData = getOutputAfterSnapshotSeq(item, snapshotOutputSeq)
-            let uncoveredMeta = item.meta
             if (
               uncoveredData &&
               uncoveredData !== item.data &&
@@ -3127,9 +3137,6 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
               typeof item.meta?.seq === 'number' &&
               typeof item.meta.rawLength === 'number'
             ) {
-              if (item.meta.rawLength === item.data.length) {
-                uncoveredMeta = { ...item.meta, rawLength: uncoveredData.length }
-              }
               uncoveredData = stripSnapshotBoundaryQuerySuffixes(
                 uncoveredData,
                 snapshotOutputSeq,
@@ -3138,7 +3145,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
               )
             }
             if (uncoveredData) {
-              outputBatcher.push(uncoveredData, uncoveredMeta)
+              outputBatcher.push(uncoveredData, realignResidualOutputMeta(uncoveredData, item.meta))
             }
           }
         }

--- a/src/main/runtime/rpc/terminal-subscribe-buffer.test.ts
+++ b/src/main/runtime/rpc/terminal-subscribe-buffer.test.ts
@@ -80,7 +80,7 @@ describe('terminal subscribe buffering', () => {
     }
   })
 
-  it('captures live queries before awaiting mobile fit and delivers them after the snapshot', async () => {
+  it('replays boundary-spanning queries without corrupting residual output metadata', async () => {
     const binaryFrames: Uint8Array<ArrayBufferLike>[] = []
     const cleanups = new Map<string, () => void>()
     let dataListener:
@@ -105,7 +105,7 @@ describe('terminal subscribe buffering', () => {
       readTerminal: vi.fn().mockResolvedValue({ tail: [], truncated: false }),
       serializeTerminalBuffer: vi
         .fn()
-        .mockResolvedValue({ data: 'snapshot', cols: 80, rows: 24, seq: 4 }),
+        .mockResolvedValue({ data: 'snapshot', cols: 80, rows: 24, seq: 2 }),
       getTerminalSize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
       getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
       getLayout: vi.fn().mockReturnValue({ seq: 1 }),
@@ -142,7 +142,7 @@ describe('terminal subscribe buffering', () => {
     await vi.waitFor(() => expect(runtime.handleMobileSubscribe).toHaveBeenCalled())
     expect(dataListener).toBeDefined()
     expect(registerRemoteTerminalViewSubscriber).toHaveBeenCalledWith('pty-1')
-    dataListener?.('\x1b[6n', { seq: 4, rawLength: 4 })
+    dataListener?.('\x1b[6nafter', { seq: 9, rawLength: 9 })
     resolveMobileSubscribe()
 
     await vi.waitFor(() =>
@@ -151,7 +151,7 @@ describe('terminal subscribe buffering', () => {
           const frame = decodeTerminalStreamFrame(bytes)
           return (
             frame?.opcode === TerminalStreamOpcode.Output &&
-            decodeTerminalStreamText(frame.payload) === '\x1b[6n'
+            decodeTerminalStreamText(frame.payload) === '\x1b[6nafter'
           )
         })
       ).toBe(true)
@@ -160,7 +160,7 @@ describe('terminal subscribe buffering', () => {
       const frame = decodeTerminalStreamFrame(bytes)
       return (
         frame?.opcode === TerminalStreamOpcode.Output &&
-        decodeTerminalStreamText(frame.payload) === '\x1b[6n'
+        decodeTerminalStreamText(frame.payload) === '\x1b[6nafter'
       )
     })
     expect(queryOutputFrames).toHaveLength(1)

--- a/src/main/runtime/rpc/terminal-subscribe-transformed-residual.test.ts
+++ b/src/main/runtime/rpc/terminal-subscribe-transformed-residual.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RuntimeTerminalWait } from '../../../shared/runtime-types'
+import {
+  TerminalStreamOpcode,
+  decodeTerminalStreamFrame,
+  decodeTerminalStreamJson
+} from '../../../shared/terminal-stream-protocol'
+import type { OrcaRuntimeService } from '../orca-runtime'
+import type { RpcRequest } from './core'
+import { RpcDispatcher } from './dispatcher'
+import { TERMINAL_METHODS } from './methods/terminal'
+
+const makeRequest = (method: string, params?: unknown): RpcRequest => ({
+  id: 'req-1',
+  authToken: 'tok',
+  method,
+  params
+})
+
+describe('terminal transformed residual replay', () => {
+  it('preserves sparse output metadata after snapshot boundary trimming', async () => {
+    const binaryFrames: Uint8Array<ArrayBufferLike>[] = []
+    const cleanups = new Map<string, () => void>()
+    let dataListener:
+      | ((data: string, meta?: { seq?: number; rawLength?: number; transformed?: boolean }) => void)
+      | undefined
+    let resolveMobileSubscribe: () => void = () => {}
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      resolveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+      handleMobileSubscribe: vi.fn(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolveMobileSubscribe = () => resolve(true)
+          })
+      ),
+      handleMobileUnsubscribe: vi.fn(),
+      subscribeToTerminalData: vi.fn((_ptyId, listener) => {
+        dataListener = listener
+        return vi.fn()
+      }),
+      registerRemoteTerminalViewSubscriber: vi.fn(() => vi.fn()),
+      requestRendererTerminalTabMount: vi.fn().mockReturnValue(false),
+      readTerminal: vi.fn().mockResolvedValue({ tail: [], truncated: false }),
+      serializeTerminalBuffer: vi
+        .fn()
+        .mockResolvedValue({ data: 'snapshot', cols: 80, rows: 24, seq: 4 }),
+      getTerminalSize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
+      getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
+      getLayout: vi.fn().mockReturnValue({ seq: 1 }),
+      isTerminalAlternateScreen: vi.fn().mockReturnValue(false),
+      subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
+      subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+      registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
+        cleanups.set(id, cleanup)
+      }),
+      cleanupSubscription: vi.fn((id: string) => {
+        cleanups.get(id)?.()
+        cleanups.delete(id)
+      }),
+      waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {}))
+      // 为什么：此用例只实现 terminal.subscribe 触及的 runtime 表面，避免构造无关方法。
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+
+    const dispatchPromise = dispatcher.dispatchStreaming(
+      makeRequest('terminal.subscribe', {
+        terminal: 'terminal-1',
+        client: { id: 'phone-1', type: 'mobile' },
+        capabilities: { terminalBinaryStream: 1 }
+      }),
+      vi.fn(),
+      {
+        connectionId: 'conn-phone',
+        sendBinary: (bytes) => {
+          binaryFrames.push(bytes)
+        },
+        registerBinaryStreamHandler: vi.fn(() => vi.fn())
+      }
+    )
+
+    await vi.waitFor(() => expect(runtime.handleMobileSubscribe).toHaveBeenCalled())
+    expect(dataListener).toBeDefined()
+    dataListener?.('abcdef', { seq: 11, rawLength: 9, transformed: true })
+    resolveMobileSubscribe()
+
+    await vi.waitFor(() =>
+      expect(
+        binaryFrames.some(
+          (bytes) => decodeTerminalStreamFrame(bytes)?.opcode === TerminalStreamOpcode.OutputSpan
+        )
+      ).toBe(true)
+    )
+    const outputSpan = binaryFrames
+      .map((bytes) => decodeTerminalStreamFrame(bytes))
+      .find((frame) => frame?.opcode === TerminalStreamOpcode.OutputSpan)
+
+    expect(outputSpan?.seq).toBe(11)
+    expect(outputSpan && decodeTerminalStreamJson(outputSpan.payload)).toEqual({
+      data: 'cdef',
+      rawLength: 9,
+      transformed: true
+    })
+
+    runtime.cleanupSubscription('terminal-1:phone-1')
+    await dispatchPromise
+  })
+})


### PR DESCRIPTION
## Summary

- Realign plain buffered residual metadata after snapshot-boundary query suffix stripping.
- Preserve metadata for genuinely transformed spans.
- Prevent mobile and legacy clients from receiving plain residual text as `OutputSpan` and triggering a redundant resync.

Fixes #9682

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` - scoped oxlint and the max-lines ratchet pass; the full command is blocked by a pre-existing non-exhaustive switch in `skill-freshness-group.tsx:101`.
- [x] `pnpm typecheck`
- [ ] `pnpm test` - 33,490 passed and 56 skipped; 7 environment-dependent failures remain in unrelated submodule, zsh path lookup, and system SSH tests. The two directly affected replay suites pass 11/11.
- [x] `pnpm run build:desktop`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Reviewed the post-strip ordering, `rawLength` and sequence semantics, preservation of genuinely transformed spans, output batching behavior, and regression coverage. The initial review strengthened the existing query replay harness with zero net line growth. Follow-up coverage for sparse transformed output lives in a dedicated test file because the existing buffering suite is at its effective line limit, without adding a max-lines bypass. Cross-platform compatibility was checked for macOS, Linux, and Windows: this change is platform-neutral protocol metadata logic and touches no shortcuts, labels, paths, shell behavior, or Electron platform branches. The same behavior applies to local, SSH, and remote terminal streams.

## Security Audit

Reviewed terminal data handling and frame metadata boundaries. The change only realigns an existing string-length field after existing query removal and does not execute or reinterpret terminal bytes. It adds no command execution, path handling, authentication, secrets, dependencies, permissions, or new IPC surface.

## Notes

This is the mobile and legacy sibling of the multiplex residual metadata handling described in #8255.

X handle: N/A


## ELI5

Legacy clients could get residual terminal text as the wrong span type and force a redundant full resync. Metadata is realigned after suffix stripping so plain residual output does not look like a structured span.
