### PR TITLE
fix(mobile): pop to home when leaving a host so the back chevron animates backward

### DIFF
--- a/mobile/src/host-route-exit.test.ts
+++ b/mobile/src/host-route-exit.test.ts
@@ -4,16 +4,18 @@ import { leaveHostRoute } from './host-route-exit'
 
 function makeRouter() {
   return {
-    replace: vi.fn()
+    dismissTo: vi.fn()
   }
 }
 
 describe('leaveHostRoute', () => {
-  it('returns to home instead of depending on route history', () => {
+  // Why: dismissTo (not replace) is what makes the chevron animate back like swipe-back, so the
+  // call shape is the behavior under test, not an implementation detail.
+  it('dismisses to home instead of depending on route history', () => {
     const router = makeRouter()
 
     leaveHostRoute(router)
 
-    expect(router.replace).toHaveBeenCalledWith('/')
+    expect(router.dismissTo).toHaveBeenCalledWith('/')
   })
 })

--- a/mobile/src/host-route-exit.ts
+++ b/mobile/src/host-route-exit.ts
@@ -1,9 +1,10 @@
 type HostRouteExitRouter = {
-  replace: (href: '/') => void
+  dismissTo: (href: '/') => void
 }
 
 export function leaveHostRoute(router: HostRouteExitRouter): void {
-  // Why: direct pairing can open /h/:hostId as the root route, and split-view
-  // detail history is not the host/home screen the header is meant to exit to.
-  router.replace('/')
+  // Why: direct pairing can open /h/:hostId as the root route, and split-view detail history is
+  // not the host/home screen the header is meant to exit to. dismissTo pops to home when it is on
+  // the stack, so the chevron animates back like swipe-back, and replaces when it is not.
+  router.dismissTo('/')
 }


### PR DESCRIPTION
## Summary

On the host screen (the worktree list grouped by repo), the back chevron in the header animated in the wrong direction: it slid **forward** — home entering from the right — while swipe-back on the same screen slid **backward**. The two ways of leaving a host disagreed.

Cause: `leaveHostRoute` called `router.replace('/')`, and native-stack animates a replace as a push by default. Swipe-back, by contrast, performs a real stack pop, which is why only the button looked wrong.

Fix: use `router.dismissTo('/')`. It pops to home when home is on the stack, so the chevron performs the *same stack pop* the gesture does — not merely a similar-looking animation — and it still falls back to replacing when direct pairing opened `/h/:hostId` as the root route, which is the case the original `replace` existed to cover.

Notably this is **not** fixed with a screen-level animation override. Animation direction belongs to the navigation action, not the destination screen: both `/` and `/h/:hostId` are replace targets of forward flows too (pairing completion, onboarding completion via `mobileOnboardingDestination`), so any fixed per-screen animation would be wrong for one side or the other.

## Screenshots

Behavior change is an animation direction, so a still frame can't show it. Verified by screen-recording the transition on an iPhone 17 Pro simulator and extracting frames at 30fps:

| | before (`replace`) | after (`dismissTo`) |
|---|---|---|
| back chevron | home enters from the **right**, host page slides left (push) | host page slides out **right**, home enters from the **left** (pop) |
| swipe-back | host page slides out right, home enters from left (pop) | unchanged (pop) |

After the fix both paths produce the same pop, and the button transition spans noticeably more frames than the previous replace — consistent with a real stack pop rather than a replace with an animation flag applied.

A screen recording of the post-fix transition is available and can be attached on request.
<img width="300" height="652" alt="back-slowmo" src="https://github.com/user-attachments/assets/4342c9b2-4df2-4918-9be3-3f8b45fe88e4" />


## Testing

- [x] `pnpm lint` — run in `mobile/`, exit 0
- [x] `pnpm typecheck` — run in `mobile/`, 0 errors
- [x] `pnpm test` — run in `mobile/`, 301 files / 2159 tests passed
- [ ] `pnpm build` — **not applicable**: `mobile/` has no `build` script, and `.github/workflows/mobile.yml` runs only typecheck / test / lint for `mobile/**` changes. The change touches no desktop code, so the root Electron build is unaffected.
- [x] Updated the existing test

On tests: `host-route-exit.test.ts` previously asserted `router.replace` was called with `'/'`; it now asserts `router.dismissTo` is called with `'/'`. The call shape *is* the behavior here — reverting the implementation to `replace` fails the test, which is exactly the regression this PR fixes.

I deliberately did not add a test asserting the animation itself. `mobile/vitest.config.ts` restricts `include` to `src/**/*.test.ts` under a `node` environment, so screen transitions are not reachable from the suite; a test asserting an animation constant would pass while the real wiring was broken. The direction was verified on-device instead (see Screenshots).

Two pre-existing unhandled errors appear in the mobile suite on `main` and are unrelated to this change: `happy-dom` is not declared in `mobile/package.json`, so `src/terminal/terminal-webview-init-surface.test.ts` and `terminal-webview-tap-routing.test.ts` fail to start their workers. Worth a separate fix.

## AI Review Report

Reviewed with Claude Code, including a dedicated review pass over the diff.

**An earlier version of this fix was rejected by that review.** It added `animationTypeForReplace: 'pop'` to the root `index` screen in `app/_layout.tsx`. The review flagged that this attaches a fixed direction to a *destination screen* that is also the target of forward navigations — specifically `mobile-onboarding.tsx:73` `continueToApp`, reached from `app/index.tsx` with no `hostId`, which would then have animated the onboarding-completion step backward. The same conflict blocks the equivalent option on `[hostId]/index`, since pairing and onboarding completion both replace onto it. That finding is what motivated moving to `dismissTo`, which removes the screen-level override entirely and leaves every forward flow at its original behavior.

The review also raised, and I withdrew as a false positive, a claim that `leaveSession` in `session/[worktreeId].tsx` had the same defect. It does not: it guards with `router.canGoBack()` and only replaces when there is no history at all — a state in which swipe-back cannot fire either, so there is no inconsistency and nothing to pop to.

Risks checked:

- **Call-site tracing** — enumerated every `router.replace` landing on `/` (`pair.tsx:13` goHome, `pair-confirm.tsx:54` cancel, `ProtocolBlockScreen.tsx:54`) and on `/h/:hostId`. All remaining ones are untouched by this PR.
- **Behavior preservation** — `dismissTo`'s documented fallback ("if the href is not found, it will instead replace the current screen") preserves the direct-pairing / split-view invariant recorded in the original comment.
- **Pop-to-route scope** — `dismissTo` pops *to* a route rather than one level, so it is correct for the host screen (home is the intended exit) but would be wrong for the session screen, where back should land on an intermediate screen such as tasks. That is a second reason `leaveSession` was left alone.
- **Performance** — one imperative navigation call replaced by another; no hot-path, startup, or retained-closure impact.
- **Cross-platform** — see below.
- **UI quality** — verified on-device; no styling, token, or layout changes, so `docs/STYLEGUIDE.md` is not engaged.

**Cross-platform (macOS / Linux / Windows):** this PR touches only `mobile/`, contains no keyboard shortcuts, no shortcut labels, and no filesystem paths, so the desktop platform rules do not apply to it — no desktop code is modified. For the mobile platforms it does affect: `router.dismissTo` is platform-agnostic expo-router API with no iOS/Android branch. **I verified the animation on an iOS simulator only; I have not run it on Android.** Android should behave correctly — native-stack performs a real pop there too, and Android hardware back on this screen already went through React Navigation's default pop rather than `leaveHostRoute` — but an Android confirmation would be worth having before merge.

**SSH / remote / local:** no transport, host-connection, or git-provider code is touched. The verification ran against an unreachable host (stuck at "Connecting…") and the navigation behaved identically, since the transition does not depend on connection state.

## Security Audit

Low risk. The change swaps one imperative navigation call for another within the same module and updates its unit test.

- **Input handling** — none. The route is the hardcoded literal `'/'`; no user or network input reaches it.
- **Command execution / path handling** — none.
- **Auth / secrets** — none. Host credentials and the pairing token are untouched; `dismissTo` does not affect `host-store` or SecureStore.
- **IPC** — none.
- **Dependencies** — no dependency change. `router.dismissTo` is existing API in the pinned `expo-router` (`^55.0.14`, present in `imperative-api.d.ts`).

No follow-up needed.

## Notes

- Mobile-only; no desktop, SSH, agent, integration, or git-provider behavior changes.
- Android animation not yet confirmed on-device (see AI Review Report).
- Unrelated pre-existing issue worth a separate PR: `happy-dom` missing from `mobile/package.json` breaks two `src/terminal/` test files on `main`.

X: [@ye4241](https://x.com/ye4241)
