### PR TITLE
fix(branch-name): back off after Claude session limits

### DIFF
--- a/src/main/agent-hooks/first-work-branch-rename.test.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.test.ts
@@ -313,6 +313,76 @@ describe('maybeAutoRenameBranchOnFirstWork', () => {
     expect(setRenameError).toHaveBeenLastCalledWith(WORKTREE_ID, null)
   })
 
+  it('defers Claude session-limit failures until the reported reset', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-07-21T09:00:00Z'))
+      const resetAt = Date.now() + 2 * 60 * 60_000
+      generateBranchNameMock.mockResolvedValueOnce({
+        success: false,
+        error: 'Claude CLI exited with code 1.',
+        failureOutput: {
+          label: 'Claude',
+          exitCode: 1,
+          stdout: "You've hit your session limit\nResets in 2h",
+          stderr: ''
+        }
+      })
+      const { deps, onRenamed } = makeDeps()
+
+      await maybeAutoRenameBranchOnFirstWork(workingEvent(), deps)
+      await maybeAutoRenameBranchOnFirstWork(workingEvent(), deps)
+      vi.setSystemTime(resetAt - 1)
+      await maybeAutoRenameBranchOnFirstWork(workingEvent(), deps)
+
+      expect(generateBranchNameMock).toHaveBeenCalledTimes(1)
+      expect(onRenamed).not.toHaveBeenCalled()
+
+      vi.setSystemTime(resetAt)
+      await maybeAutoRenameBranchOnFirstWork(workingEvent(), deps)
+
+      expect(generateBranchNameMock).toHaveBeenCalledTimes(2)
+      expect(onRenamed).toHaveBeenCalledWith(REPO_ID)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('defers folder workspace title generation after a Claude session limit', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-07-21T09:00:00Z'))
+      generateBranchNameMock.mockResolvedValueOnce({
+        success: false,
+        error: 'Claude CLI exited with code 1.',
+        failureOutput: {
+          label: 'Claude',
+          exitCode: 1,
+          stdout: "You've hit your session limit\nResets in 2h",
+          stderr: ''
+        }
+      })
+      const { deps, onRenamed } = makeDeps({
+        resolveWorktreeIdForTab: () => FOLDER_WORKTREE_ID,
+        getFolderWorkspacePath: () => '/workspace/platform',
+        isPendingFirstAgentMessageRename: () => true
+      })
+
+      await maybeAutoRenameBranchOnFirstWork(workingEvent(), deps)
+      await maybeAutoRenameBranchOnFirstWork(workingEvent(), deps)
+
+      expect(generateBranchNameMock).toHaveBeenCalledTimes(1)
+
+      vi.advanceTimersByTime(2 * 60 * 60_000)
+      await maybeAutoRenameBranchOnFirstWork(workingEvent(), deps)
+
+      expect(generateBranchNameMock).toHaveBeenCalledTimes(2)
+      expect(onRenamed).toHaveBeenCalledWith(FOLDER_WORKTREE_ID)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('records a user-facing error and the full CLI output when generation fails', async () => {
     const failureOutput = { label: 'Pi', exitCode: 1, stdout: '', stderr: 'No API key found.' }
     generateBranchNameMock.mockResolvedValueOnce({

--- a/src/main/agent-hooks/first-work-branch-rename.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.ts
@@ -25,6 +25,7 @@ import {
 } from '../text-generation/commit-message-text-generation'
 import type { CommitMessageAgentEnvironmentResolvers } from '../text-generation/commit-message-agent-environment'
 import type { AgentGenerationFailureOutput } from '../text-generation/agent-failure-output'
+import { getFirstWorkGenerationSessionLimitRetryAt } from './first-work-generation-session-limit'
 import { resolveGenerationTarget } from './first-work-generation-target'
 import { runFolderWorkspaceTitleAutoRename } from './first-work-workspace-title-rename'
 
@@ -70,12 +71,15 @@ export type FirstWorkBranchRenameDeps = {
 // inFlight blocks concurrent generation; settled caches definitive verdicts (transient bails stay unsettled to retry later).
 const inFlightWorktreeIds = new Set<string>()
 const settledWorktreeIds = new Set<string>()
+// 会话限额按工作区隔离，并复用 settled 上限避免长进程中冷却记录无限增长。
+const sessionLimitRetryAtByWorktreeId = new Map<string, number>()
 export const FIRST_WORK_BRANCH_RENAME_SETTLED_CACHE_LIMIT = 500
 
 /** Test seam: clear the per-process dedupe sets. */
 export function resetFirstWorkBranchRenameState(): void {
   inFlightWorktreeIds.clear()
   settledWorktreeIds.clear()
+  sessionLimitRetryAtByWorktreeId.clear()
 }
 
 function rememberSettledWorktreeId(worktreeId: string): void {
@@ -89,6 +93,30 @@ function rememberSettledWorktreeId(worktreeId: string): void {
     }
     settledWorktreeIds.delete(oldest)
   }
+}
+
+function rememberSessionLimitRetryAt(worktreeId: string, retryAt: number): void {
+  sessionLimitRetryAtByWorktreeId.delete(worktreeId)
+  sessionLimitRetryAtByWorktreeId.set(worktreeId, retryAt)
+  while (sessionLimitRetryAtByWorktreeId.size > FIRST_WORK_BRANCH_RENAME_SETTLED_CACHE_LIMIT) {
+    const oldest = sessionLimitRetryAtByWorktreeId.keys().next().value
+    if (typeof oldest !== 'string') {
+      return
+    }
+    sessionLimitRetryAtByWorktreeId.delete(oldest)
+  }
+}
+
+function isSessionLimitRetryDeferred(worktreeId: string): boolean {
+  const retryAt = sessionLimitRetryAtByWorktreeId.get(worktreeId)
+  if (retryAt === undefined) {
+    return false
+  }
+  if (Date.now() >= retryAt) {
+    sessionLimitRetryAtByWorktreeId.delete(worktreeId)
+    return false
+  }
+  return true
 }
 
 export async function maybeAutoRenameBranchOnFirstWork(
@@ -109,7 +137,11 @@ export async function maybeAutoRenameBranchOnFirstWork(
     return
   }
   // Short-circuit settled/in-flight worktrees before any logging or work.
-  if (settledWorktreeIds.has(worktreeId) || inFlightWorktreeIds.has(worktreeId)) {
+  if (
+    settledWorktreeIds.has(worktreeId) ||
+    inFlightWorktreeIds.has(worktreeId) ||
+    isSessionLimitRetryDeferred(worktreeId)
+  ) {
     return
   }
   const prompt = event.prompt?.trim()
@@ -121,6 +153,7 @@ export async function maybeAutoRenameBranchOnFirstWork(
     // settled = definitive verdict (renamed/ineligible); false = transient bail to retry later.
     const settled = await runAutoRename(worktreeId, prompt, event.assistantMessage, deps)
     if (settled) {
+      sessionLimitRetryAtByWorktreeId.delete(worktreeId)
       rememberSettledWorktreeId(worktreeId)
     }
   } catch (error) {
@@ -146,7 +179,14 @@ async function runAutoRename(
     console.info(`[auto-branch-rename] skip (${reason}) for ${worktreeId}`)
     return true
   }
-  const retry = (reason: string): false => {
+  const retry = (reason: string, retryAt: number | null = null): false => {
+    if (retryAt !== null && retryAt > Date.now()) {
+      rememberSessionLimitRetryAt(worktreeId, retryAt)
+      console.info(
+        `[auto-branch-rename] retry-after (${reason}) until ${new Date(retryAt).toISOString()} for ${worktreeId}`
+      )
+      return false
+    }
     console.info(`[auto-branch-rename] retry-later (${reason}) for ${worktreeId}`)
     return false
   }
@@ -232,7 +272,10 @@ async function runAutoRename(
     if (!generated.canceled) {
       deps.setRenameError(worktreeId, generated.error, generated.failureOutput ?? null)
     }
-    return retry(`generation failed: ${generated.error}`)
+    return retry(
+      `generation failed: ${generated.error}`,
+      getFirstWorkGenerationSessionLimitRetryAt(generated)
+    )
   }
 
   // Re-validate after generation (takes seconds): bail if the branch changed or was published meanwhile.

--- a/src/main/agent-hooks/first-work-generation-session-limit.test.ts
+++ b/src/main/agent-hooks/first-work-generation-session-limit.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getFirstWorkGenerationSessionLimitRetryAt } from './first-work-generation-session-limit'
+
+describe('getFirstWorkGenerationSessionLimitRetryAt', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('uses the reset carried by a Claude session-limit response', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-21T09:00:00Z'))
+
+    expect(
+      getFirstWorkGenerationSessionLimitRetryAt({
+        error: 'Claude CLI exited with code 1.',
+        failureOutput: {
+          label: 'Claude',
+          exitCode: 1,
+          stdout: "You've hit your session limit\nResets in 2h",
+          stderr: ''
+        }
+      })
+    ).toBe(Date.now() + 2 * 60 * 60_000)
+  })
+
+  it('recognizes the time-only response reported in issue 9705', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-21T10:00:00.000Z'))
+
+    const retryAt = getFirstWorkGenerationSessionLimitRetryAt({
+      error: 'Claude CLI exited with code 1.',
+      failureOutput: {
+        label: 'Claude',
+        exitCode: 1,
+        stdout: 'hit your session limit · resets 2pm (Europe/Madrid)',
+        stderr: ''
+      }
+    })
+
+    expect(retryAt).toBe(Date.parse('2026-07-21T12:00:00.000Z'))
+  })
+
+  it('falls back to a bounded cooldown when the reset is missing', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-21T09:00:00Z'))
+
+    expect(
+      getFirstWorkGenerationSessionLimitRetryAt({
+        error: 'You have hit your session limit.',
+        failureOutput: undefined
+      })
+    ).toBe(Date.now() + 15 * 60_000)
+  })
+
+  it('leaves ordinary generation failures on the immediate retry path', () => {
+    expect(
+      getFirstWorkGenerationSessionLimitRetryAt({
+        error: 'Claude CLI is temporarily unavailable.',
+        failureOutput: undefined
+      })
+    ).toBeNull()
+  })
+})

--- a/src/main/agent-hooks/first-work-generation-session-limit.ts
+++ b/src/main/agent-hooks/first-work-generation-session-limit.ts
@@ -1,0 +1,35 @@
+import { stripAnsiControlSequences } from '../../shared/commit-message-agent-output'
+import { extractClaudePtyResetMetadata } from '../rate-limits/claude-pty-reset-parser'
+import type { GenerateBranchNameResult } from '../text-generation/commit-message-text-generation'
+
+const SESSION_LIMIT_RE =
+  /\b(?:(?:you(?:'ve| have)\s+)?hit\s+(?:your\s+)?session\s+limit|session\s+limit\s+(?:has\s+been\s+)?(?:reached|exceeded))\b/i
+const UNPARSED_SESSION_LIMIT_COOLDOWN_MS = 15 * 60_000
+
+type BranchNameGenerationFailure = Extract<GenerateBranchNameResult, { success: false }>
+
+export function getFirstWorkGenerationSessionLimitRetryAt(
+  failure: Pick<BranchNameGenerationFailure, 'error' | 'failureOutput'>
+): number | null {
+  const output = stripAnsiControlSequences(
+    [failure.error, failure.failureOutput?.stderr, failure.failureOutput?.stdout]
+      .filter((value): value is string => Boolean(value))
+      .join('\n')
+  )
+  const lines = output.split(/\r?\n/)
+  if (!lines.some((line) => SESSION_LIMIT_RE.test(line))) {
+    return null
+  }
+
+  const reset = extractClaudePtyResetMetadata(
+    lines,
+    (line) => SESSION_LIMIT_RE.test(line),
+    () => false
+  )
+  const now = Date.now()
+  if (reset.resetsAt !== null && reset.resetsAt > now) {
+    return reset.resetsAt
+  }
+  // 无法解析供应商文案时仍需限流，避免每个 working 事件都启动新会话。
+  return now + UNPARSED_SESSION_LIMIT_COOLDOWN_MS
+}

--- a/src/main/agent-hooks/first-work-workspace-title-rename.ts
+++ b/src/main/agent-hooks/first-work-workspace-title-rename.ts
@@ -3,6 +3,7 @@ import {
   generateBranchNameFromContext,
   resolveTextGenerationParams
 } from '../text-generation/commit-message-text-generation'
+import { getFirstWorkGenerationSessionLimitRetryAt } from './first-work-generation-session-limit'
 import { resolveGenerationTarget } from './first-work-generation-target'
 import type { FirstWorkBranchRenameDeps } from './first-work-branch-rename'
 
@@ -17,7 +18,7 @@ export async function runFolderWorkspaceTitleAutoRename(
   assistantMessage: string | undefined,
   deps: FirstWorkBranchRenameDeps,
   stop: (reason: string, clearError?: boolean) => true,
-  retry: (reason: string) => false
+  retry: (reason: string, retryAt?: number | null) => false
 ): Promise<boolean> {
   if (deps.isPendingFirstAgentMessageRename?.(worktreeId) !== true) {
     return stop('folder workspace is not pending title rename', true)
@@ -53,7 +54,10 @@ export async function runFolderWorkspaceTitleAutoRename(
     if (!generated.canceled) {
       deps.setRenameError(worktreeId, generated.error, generated.failureOutput ?? null)
     }
-    return retry(`generation failed: ${generated.error}`)
+    return retry(
+      `generation failed: ${generated.error}`,
+      getFirstWorkGenerationSessionLimitRetryAt(generated)
+    )
   }
 
   const newDisplayName = humanizeBranchSlug(generated.slug)

--- a/src/main/rate-limits/claude-pty-reset-parser.ts
+++ b/src/main/rate-limits/claude-pty-reset-parser.ts
@@ -1,5 +1,5 @@
 import type { RateLimitWindow } from '../../shared/rate-limit-types'
-import { buildWallClockTimestamp } from './time-zone-wall-clock'
+import { buildWallClockTimestamp, getTimeZoneDateParts } from './time-zone-wall-clock'
 
 const RESET_LINE_RE = /resets?\s+(?:at\s+|in\s+)?(.+)/i
 const MONTH_PATTERN =
@@ -262,6 +262,30 @@ function parseTimeOnlyResetTimestamp(resetDescription: string): number | null {
   const minute = Number(match[2] ?? 0)
   if (!isValidClockTime(hour, minute)) {
     return null
+  }
+
+  const timeZone = extractResetTimeZone(resetDescription)
+  if (timeZone) {
+    const now = Date.now()
+    const dateParts = getTimeZoneDateParts(now, timeZone)
+    if (!dateParts) {
+      return null
+    }
+    let timestamp = buildWallClockTimestamp({ ...dateParts, hour, minute }, timeZone)
+    if (timestamp !== null && timestamp <= now) {
+      const nextDate = new Date(Date.UTC(dateParts.year, dateParts.monthIndex, dateParts.day + 1))
+      timestamp = buildWallClockTimestamp(
+        {
+          year: nextDate.getUTCFullYear(),
+          monthIndex: nextDate.getUTCMonth(),
+          day: nextDate.getUTCDate(),
+          hour,
+          minute
+        },
+        timeZone
+      )
+    }
+    return timestamp
   }
 
   const candidate = new Date()

--- a/src/main/rate-limits/time-zone-wall-clock.ts
+++ b/src/main/rate-limits/time-zone-wall-clock.ts
@@ -42,7 +42,10 @@ function getTimeZoneOffsetMs(timestamp: number, timeZone: string): number | null
   return Date.UTC(parts.year, parts.monthIndex, parts.day, parts.hour, parts.minute) - timestamp
 }
 
-function getTimeZoneDateParts(timestamp: number, timeZone: string): WallClockDateParts | null {
+export function getTimeZoneDateParts(
+  timestamp: number,
+  timeZone: string
+): WallClockDateParts | null {
   const formatter = new Intl.DateTimeFormat('en-US', {
     timeZone,
     hourCycle: 'h23',


### PR DESCRIPTION
## Summary

- Detect explicit Claude session-limit responses during first-work branch-name generation and defer the next attempt until the reported reset.
- Parse time-only reset messages using their reported IANA time zone, with a bounded 15-minute fallback when the reset cannot be parsed.
- Apply the same retry behavior to Git worktree branch names and folder workspace titles while preserving immediate retries for ordinary transient failures.

Fixes #9705

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` (blocked by pre-existing switch-exhaustiveness and localization coverage failures in unchanged renderer files)
- [x] `pnpm typecheck`
- [ ] `pnpm test` (33,499 passed; three unrelated failures passed when rerun in isolation, while one unchanged Vite+ path-resolution test remains environment-dependent)
- [ ] `pnpm build` (`pnpm run build:electron-vite` passed; native/release builds were not run)
- [x] Added or updated high-quality tests that would catch regressions

Additional checks:

- 61 first-work and Claude PTY tests
- Targeted `oxlint`
- `oxfmt --check`
- Reliability, max-lines, skill bundle, and localization catalog gates

## AI Review Report

Reviewed the retry lifecycle, reset boundary behavior, cache bounds, ordinary-failure behavior, and shared Git/folder workspace paths. The review flagged that time-only resets such as `2pm (Europe/Madrid)` were being interpreted in the machine's local time zone; the parser and regression test now honor the supplied IANA zone.

Cross-platform review covered macOS, Linux, and Windows. The change uses platform-neutral `Date`/`Intl` APIs and does not alter shortcuts, labels, paths, shell commands, or Electron platform branches. Local and SSH generation paths feed the same result handling, and no Git-provider-specific behavior was introduced.

## Security Audit

Reviewed untrusted CLI output parsing, logging, memory growth, command execution, paths, auth, secrets, dependencies, and IPC. ANSI/control sequences are stripped before bounded pattern matching, IANA zones are validated through `Intl`, and the per-worktree cooldown cache is capped at 500 entries. No new commands, filesystem access, network calls, dependencies, auth handling, secrets, or IPC surfaces were added. No follow-up security work is required.

## Notes

- X handle: N/A
- The remaining full-lint/full-test failures are in files unchanged by this branch and are documented above.



## ELI5

Auto branch naming kept hammering Claude after a session limit and burned more quota. When Claude says you are rate-limited, naming backs off until the reported reset instead of retrying immediately.
