### PR TITLE
fix(preflight): preserve WSL agent detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ prod-release-scan-*.md
 # Temp
 tmp/
 .tmp/
+graphify-out/
 design-docs/
 .context/
 .atl/

--- a/src/renderer/src/lib/local-preflight-context-cache.ts
+++ b/src/renderer/src/lib/local-preflight-context-cache.ts
@@ -54,9 +54,10 @@ export function getWslPreflightContext(wslDistro: string): NonNullable<LocalPref
 }
 
 export function getProjectRuntimePreflightContext(
-  resolution: ProjectExecutionRuntimeResolution
+  resolution: ProjectExecutionRuntimeResolution,
+  runtimeContextKey?: string
 ): NonNullable<LocalPreflightContext> {
-  const cacheKey = getProjectRuntimeContextObjectCacheKey(resolution)
+  const cacheKey = getProjectRuntimeContextObjectCacheKey(resolution, runtimeContextKey)
   const cached = projectRuntimePreflightContextsByKey.get(cacheKey)
   if (cached) {
     return cached
@@ -70,6 +71,7 @@ export function getProjectRuntimePreflightContext(
   // adding projectRuntime does not reintroduce useSyncExternalStore churn.
   const context = Object.freeze({
     ...(wslDistro ? { wslDistro } : {}),
+    ...(runtimeContextKey ? { runtimeContextKey } : {}),
     projectRuntime: resolution
   })
   storeCacheEntry(
@@ -82,8 +84,12 @@ export function getProjectRuntimePreflightContext(
 }
 
 function getProjectRuntimeContextObjectCacheKey(
-  resolution: ProjectExecutionRuntimeResolution
+  resolution: ProjectExecutionRuntimeResolution,
+  runtimeContextKey?: string
 ): string {
+  if (runtimeContextKey) {
+    return `${runtimeContextKey}:override`
+  }
   if (resolution.status === 'resolved') {
     return `${resolution.runtime.cacheKey}:${resolution.runtime.reason}`
   }

--- a/src/renderer/src/lib/local-preflight-context-key.ts
+++ b/src/renderer/src/lib/local-preflight-context-key.ts
@@ -10,13 +10,13 @@ type LocalPreflightContextKeyInput =
   | undefined
 
 export function localPreflightContextKey(context: LocalPreflightContextKeyInput): string {
+  if (context?.runtimeContextKey) {
+    return context.runtimeContextKey
+  }
   if (context?.projectRuntime) {
     return context.projectRuntime.status === 'resolved'
       ? context.projectRuntime.runtime.cacheKey
       : context.projectRuntime.repair.cacheKey
-  }
-  if (context?.runtimeContextKey) {
-    return context.runtimeContextKey
   }
   if (context?.wslDistro) {
     return `wsl:${context.wslDistro}`

--- a/src/renderer/src/lib/local-preflight-context.test.ts
+++ b/src/renderer/src/lib/local-preflight-context.test.ts
@@ -290,6 +290,7 @@ describe('local preflight context', () => {
 
     expect(context).toEqual({
       wslDistro: 'Ubuntu',
+      runtimeContextKey: 'repo-1:wsl:Ubuntu:wsl-capability-unknown',
       projectRuntime: {
         status: 'resolved',
         runtime: {
@@ -302,6 +303,7 @@ describe('local preflight context', () => {
         }
       }
     })
+    expect(localPreflightContextKey(context)).toBe('repo-1:wsl:Ubuntu:wsl-capability-unknown')
   })
 
   it('ignores stale terminal WSL settings when no Windows project runtime is available', () => {

--- a/src/renderer/src/lib/local-preflight-context.test.ts
+++ b/src/renderer/src/lib/local-preflight-context.test.ts
@@ -274,6 +274,36 @@ describe('local preflight context', () => {
     expect(localPreflightContextKey(context)).toBe('repo-1:wsl:Ubuntu')
   })
 
+  it('keeps WSL agent detection probeable when capability loading failed', () => {
+    const state = {
+      ...makeState({ repoPath: 'C:\\Users\\alice\\repo' }),
+      settings: {
+        localAgentRuntime: 'wsl',
+        localAgentWslDistro: 'Ubuntu'
+      }
+    } as AppState
+
+    const context = getLocalAgentPreflightContext(state, 'win32', {
+      wslAvailable: false,
+      availableWslDistros: []
+    })
+
+    expect(context).toEqual({
+      wslDistro: 'Ubuntu',
+      projectRuntime: {
+        status: 'resolved',
+        runtime: {
+          kind: 'wsl',
+          hostPlatform: 'wsl',
+          projectId: 'repo-1',
+          distro: 'Ubuntu',
+          reason: 'global-default',
+          cacheKey: 'repo-1:wsl:Ubuntu'
+        }
+      }
+    })
+  })
+
   it('ignores stale terminal WSL settings when no Windows project runtime is available', () => {
     const state = {
       ...makeState({ repoPath: 'C:\\Users\\alice\\repo' }),

--- a/src/renderer/src/lib/local-preflight-context.ts
+++ b/src/renderer/src/lib/local-preflight-context.ts
@@ -139,7 +139,8 @@ export function getLocalAgentPreflightContext(
 ): LocalPreflightContext {
   // Why: a failed capability read reports unavailable, but WSL agent detection
   // can still verify the selected distro directly through wsl.exe.
-  const agentDetectionWslContext = wslContext.wslAvailable === false ? {} : wslContext
+  const wslCapabilityUnknown = wslContext.wslAvailable === false
+  const agentDetectionWslContext = wslCapabilityUnknown ? {} : wslContext
   const projectRuntime = getLocalProjectExecutionRuntimeContext(
     state,
     undefined,
@@ -147,7 +148,7 @@ export function getLocalAgentPreflightContext(
     agentDetectionWslContext
   )
   if (projectRuntime) {
-    return getProjectRuntimePreflightContext(projectRuntime)
+    return getAgentDetectionRuntimeContext(projectRuntime, wslCapabilityUnknown)
   }
 
   if (
@@ -158,20 +159,21 @@ export function getLocalAgentPreflightContext(
   ) {
     // Why: Settings -> Agents is global and can mount before any project is
     // active; still respect the Windows/WSL runtime default for PATH detection.
-    return getProjectRuntimePreflightContext(
+    return getAgentDetectionRuntimeContext(
       resolveProjectExecutionRuntime({
         appPlatform: 'win32',
         projectId: getLocalPreflightProjectId(state),
         projectRuntimePreference: { kind: 'inherit-global' },
         globalWindowsRuntimeDefault: state.settings.localWindowsRuntimeDefault,
         ...agentDetectionWslContext
-      })
+      }),
+      wslCapabilityUnknown
     )
   }
 
   const explicitAgentRuntime = appPlatform === 'win32' ? state.settings?.localAgentRuntime : null
   if (explicitAgentRuntime === 'host') {
-    return getProjectRuntimePreflightContext(
+    return getAgentDetectionRuntimeContext(
       resolveProjectExecutionRuntime({
         appPlatform: 'win32',
         projectId: getLocalPreflightProjectId(state),
@@ -179,13 +181,14 @@ export function getLocalAgentPreflightContext(
         globalWindowsRuntimeDefault: deriveGlobalWindowsRuntimeDefaultFromLegacySettings(
           state.settings
         ).defaultRuntime
-      })
+      }),
+      wslCapabilityUnknown
     )
   }
   if (explicitAgentRuntime === 'wsl') {
     const explicitDistro = state.settings?.localAgentWslDistro?.trim()
     if (explicitDistro) {
-      return getProjectRuntimePreflightContext(
+      return getAgentDetectionRuntimeContext(
         resolveProjectExecutionRuntime({
           appPlatform: 'win32',
           projectId: getLocalPreflightProjectId(state),
@@ -193,10 +196,11 @@ export function getLocalAgentPreflightContext(
           globalWindowsRuntimeDefault: deriveGlobalWindowsRuntimeDefaultFromLegacySettings(
             state.settings
           ).defaultRuntime
-        })
+        }),
+        wslCapabilityUnknown
       )
     }
-    return getProjectRuntimePreflightContext(
+    return getAgentDetectionRuntimeContext(
       resolveProjectExecutionRuntime({
         appPlatform: 'win32',
         projectId: getLocalPreflightProjectId(state),
@@ -204,7 +208,8 @@ export function getLocalAgentPreflightContext(
         globalWindowsRuntimeDefault: deriveGlobalWindowsRuntimeDefaultFromLegacySettings(
           state.settings
         ).defaultRuntime
-      })
+      }),
+      wslCapabilityUnknown
     )
   }
 
@@ -213,6 +218,18 @@ export function getLocalAgentPreflightContext(
     return getWslPreflightContext(wslDistro)
   }
   return undefined
+}
+
+function getAgentDetectionRuntimeContext(
+  resolution: ProjectExecutionRuntimeResolution,
+  wslCapabilityUnknown: boolean
+): NonNullable<LocalPreflightContext> {
+  // Why: capability recovery must invalidate an empty detection snapshot.
+  const runtimeContextKey =
+    wslCapabilityUnknown && resolution.status === 'resolved' && resolution.runtime.kind === 'wsl'
+      ? `${resolution.runtime.cacheKey}:wsl-capability-unknown`
+      : undefined
+  return getProjectRuntimePreflightContext(resolution, runtimeContextKey)
 }
 
 function getCachedLocalProjectRuntimeWslContext(): LocalProjectRuntimeWslContext {

--- a/src/renderer/src/lib/local-preflight-context.ts
+++ b/src/renderer/src/lib/local-preflight-context.ts
@@ -137,11 +137,14 @@ export function getLocalAgentPreflightContext(
   appPlatform: NodeJS.Platform = getRendererAppPlatform(),
   wslContext: LocalProjectRuntimeWslContext = getCachedLocalProjectRuntimeWslContext()
 ): LocalPreflightContext {
+  // Why: a failed capability read reports unavailable, but WSL agent detection
+  // can still verify the selected distro directly through wsl.exe.
+  const agentDetectionWslContext = wslContext.wslAvailable === false ? {} : wslContext
   const projectRuntime = getLocalProjectExecutionRuntimeContext(
     state,
     undefined,
     appPlatform,
-    wslContext
+    agentDetectionWslContext
   )
   if (projectRuntime) {
     return getProjectRuntimePreflightContext(projectRuntime)
@@ -161,7 +164,7 @@ export function getLocalAgentPreflightContext(
         projectId: getLocalPreflightProjectId(state),
         projectRuntimePreference: { kind: 'inherit-global' },
         globalWindowsRuntimeDefault: state.settings.localWindowsRuntimeDefault,
-        ...wslContext
+        ...agentDetectionWslContext
       })
     )
   }

--- a/src/renderer/src/store/slices/detected-agents.test.ts
+++ b/src/renderer/src/store/slices/detected-agents.test.ts
@@ -13,6 +13,17 @@ import {
 } from '../../../../shared/protocol-version'
 import { clearRuntimeCompatibilityCacheForTests } from '@/runtime/runtime-rpc-client'
 
+const { hasCachedWindowsTerminalCapabilitiesMock, getCachedWindowsTerminalCapabilitiesMock } =
+  vi.hoisted(() => ({
+    hasCachedWindowsTerminalCapabilitiesMock: vi.fn(() => false),
+    getCachedWindowsTerminalCapabilitiesMock: vi.fn()
+  }))
+
+vi.mock('@/lib/windows-terminal-capabilities', () => ({
+  hasCachedWindowsTerminalCapabilities: hasCachedWindowsTerminalCapabilitiesMock,
+  getCachedWindowsTerminalCapabilities: getCachedWindowsTerminalCapabilitiesMock
+}))
+
 const detectAgents = vi.fn()
 const refreshAgents = vi.fn()
 const detectRemoteAgents = vi.fn()
@@ -87,6 +98,8 @@ function makeWorktree(
 describe('createDetectedAgentsSlice WSL context', () => {
   beforeEach(() => {
     clearRuntimeCompatibilityCacheForTests()
+    hasCachedWindowsTerminalCapabilitiesMock.mockReset().mockReturnValue(false)
+    getCachedWindowsTerminalCapabilitiesMock.mockReset()
     detectAgents.mockReset().mockResolvedValue(['claude'])
     refreshAgents.mockReset().mockResolvedValue({
       agents: ['codex'],
@@ -287,6 +300,34 @@ describe('createDetectedAgentsSlice WSL context', () => {
         }
       }
     })
+  })
+
+  it('retries an empty WSL result after capability loading recovers', async () => {
+    hasCachedWindowsTerminalCapabilitiesMock.mockReturnValue(true)
+    getCachedWindowsTerminalCapabilitiesMock.mockReturnValue({
+      wslAvailable: false,
+      wslDistros: []
+    })
+    detectAgents.mockReset().mockResolvedValueOnce([]).mockResolvedValueOnce(['codex'])
+    const store = createTestStore({
+      settings: {
+        localAgentRuntime: 'wsl',
+        localAgentWslDistro: 'Ubuntu'
+      } as AppState['settings'],
+      repos: [makeRepo({ id: 'repo-1', path: 'C:\\repo' })],
+      activeRepoId: 'repo-1',
+      activeWorktreeId: null
+    })
+
+    await expect(store.getState().ensureDetectedAgents()).resolves.toEqual([])
+
+    getCachedWindowsTerminalCapabilitiesMock.mockReturnValue({
+      wslAvailable: true,
+      wslDistros: ['Ubuntu']
+    })
+
+    await expect(store.getState().ensureDetectedAgents()).resolves.toEqual(['codex'])
+    expect(detectAgents).toHaveBeenCalledTimes(2)
   })
 
   it('detects agents in the global WSL runtime when no project is active', async () => {


### PR DESCRIPTION
## Summary

Fixes WSL agent detection on Windows when capability probing fails or returns stale data.

- Treats failed WSL capability reads as unknown during agent detection.
- Allows `wsl.exe` to verify the configured distro directly.
- Adds regression coverage.
- Ignores local `graphify-out/` output.

## Screenshots

No visual changes.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Focused Vitest tests: 34 passed.
- [x] Renderer typecheck passed.
- [x] Oxlint and React Doctor checks passed.
- [x] Regression test failed before the fix and passed afterward.

## AI Review Report

Reviewed the WSL preflight flow, renderer context selection, IPC boundary, and direct `wsl.exe` probing.

- Verified that capability-read failures no longer block agent detection.
- Checked Windows, macOS, Linux, WSL, and shell behavior.
- Confirmed no shortcut, label, path, Electron, or unrelated provider behavior was changed.
- Preserved existing direct WSL validation and added focused regression coverage.

## Security Audit

- Reviewed WSL command execution and distro input handling.
- No new dependencies, authentication flows, secrets, IPC methods, or filesystem mutations were added.
- Existing shell quoting and command boundaries remain unchanged.
- No follow-up security work required.

## Notes

The fix is specific to Windows WSL agent detection. If capability detection is unavailable, Orca now falls back to direct WSL probing instead of incorrectly reporting the configured distro as unavailable. Closses #9725.


## ELI5

WSL agent detection on Windows failed when capability probes were wrong or stale. Failed probes are treated as unknown and wsl.exe can verify the distro directly so agents still show up.
