### PR TITLE
fix(terminal): preserve Cursor image paste boundary

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -191,6 +191,7 @@ import {
   getCachedUnifiedTerminalTabForWorktree
 } from './terminal-unified-tab-lookup'
 import { resolveNativeChatLeafTitleAgent } from './native-chat-leaf-title-agent'
+import { isCursorAgentVisibleScreen } from '@/lib/pane-manager/terminal-ime-anchor'
 import { useRepoById } from '@/store/selectors'
 import {
   isXtermHelperTextarea,
@@ -1993,6 +1994,7 @@ export default function TerminalPane({
         saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
         connectionId,
         runtimeEnvironmentId,
+        isCursorAgent: isCursorAgentVisibleScreen(pane.terminal.buffer.active, pane.terminal.rows),
         forceBracketedMultilineTextPaste,
         pasteText: (text, options) =>
           executePanePasteText(pane, source, activeElementAtDispatch, text, options),
@@ -2126,6 +2128,7 @@ export default function TerminalPane({
         saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
         connectionId,
         runtimeEnvironmentId,
+        isCursorAgent: isCursorAgentVisibleScreen(pane.terminal.buffer.active, pane.terminal.rows),
         forceBracketedMultilineTextPaste,
         pasteText: (text, options) =>
           executePanePasteText(pane, 'app-menu', activeElementAtDispatch, text, options),

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
@@ -26,6 +26,24 @@ describe('terminal clipboard paste', () => {
     )
   })
 
+  it('adds a boundary before Cursor image paths adjacent to prompt text', async () => {
+    const pasteText = vi.fn()
+
+    await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue(''),
+      saveClipboardImageAsTempFile: vi
+        .fn()
+        .mockResolvedValue('/tmp/orca-paste-1760000000000-id.png'),
+      pasteText,
+      isCursorAgent: true
+    })
+
+    expect(pasteText).toHaveBeenCalledWith(' /tmp/orca-paste-1760000000000-id.png', {
+      forceBracketedPaste: true,
+      recoverImagePasteWebglAtlas: true
+    })
+  })
+
   it('forces generated image paste onto the native bracketed-paste path after Ctrl+C', async () => {
     const observedIgnoreBracketedPasteMode: boolean[] = []
     const terminal = {
@@ -131,7 +149,7 @@ describe('terminal clipboard paste', () => {
     })
   })
 
-  it('bracket-pastes generated image paths without relying on agent detection', async () => {
+  it('keeps raw generated image paths for non-Cursor agents', async () => {
     const pasteText = vi.fn()
 
     await pasteTerminalClipboard({

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
@@ -21,6 +21,7 @@ type PasteTerminalClipboardDeps = {
   ) => boolean | void | Promise<boolean | void>
   connectionId?: string | null
   runtimeEnvironmentId?: string | null
+  isCursorAgent?: boolean
   forceBracketedMultilineTextPaste?: boolean
   onTextPasteError?: (error: unknown) => void
   onImagePasteError?: (error: unknown) => void
@@ -39,12 +40,21 @@ export type TerminalClipboardPasteResult =
         | 'text-too-large'
     }
 
+function formatCursorImagePath(filePath: string, isCursorAgent: boolean): string {
+  if (!isCursorAgent) {
+    return filePath
+  }
+  // Why: Cursor recognizes pasted image paths only after a whitespace boundary; it keeps the space before the image token.
+  return ` ${filePath}`
+}
+
 export async function pasteTerminalClipboard({
   readClipboardText,
   saveClipboardImageAsTempFile,
   pasteText,
   connectionId,
   runtimeEnvironmentId,
+  isCursorAgent = false,
   forceBracketedMultilineTextPaste = false,
   onTextPasteError,
   onImagePasteError
@@ -80,7 +90,8 @@ export async function pasteTerminalClipboard({
     if (!filePath) {
       return { status: 'skipped', reason: 'empty' }
     }
-    const result = await pasteText(filePath, {
+    const formattedFilePath = formatCursorImagePath(filePath, isCursorAgent)
+    const result = await pasteText(formattedFilePath, {
       // Why: a generated clipboard-image path is terminal image injection, not
       // ordinary one-line text. Keep it off the Ctrl+C stale-text paste path.
       forceBracketedPaste: true,

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -41,6 +41,7 @@ import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 import { copyTerminalHandleForPane } from './terminal-handle-copy'
+import { isCursorAgentVisibleScreen } from '@/lib/pane-manager/terminal-ime-anchor'
 
 const CLOSE_ALL_CONTEXT_MENUS_EVENT = 'orca-close-all-context-menus'
 
@@ -302,6 +303,7 @@ export function useTerminalPaneContextMenu({
       saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
       connectionId,
       runtimeEnvironmentId,
+      isCursorAgent: isCursorAgentVisibleScreen(pane.terminal.buffer.active, pane.terminal.rows),
       forceBracketedMultilineTextPaste,
       pasteText: (text, options) => executeMenuPasteText(pane, source, text, options),
       onTextPasteError: () =>

--- a/src/renderer/src/lib/pane-manager/terminal-ime-anchor.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-anchor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { IBuffer, IBufferCell, IBufferLine } from '@xterm/xterm'
-import { resolveCursorAgentImeAnchor } from './terminal-ime-anchor'
+import { isCursorAgentVisibleScreen, resolveCursorAgentImeAnchor } from './terminal-ime-anchor'
 
 type FakeCell = {
   chars: string
@@ -152,5 +152,28 @@ describe('resolveCursorAgentImeAnchor', () => {
         cursorY: 4
       })
     ).toEqual({ row: 3, column: 8 })
+  })
+})
+
+describe('isCursorAgentVisibleScreen', () => {
+  it('recognizes a live prompt after redraws move the header down', () => {
+    const buffer = makeBuffer([
+      'old',
+      'old',
+      'old',
+      'old',
+      'old',
+      'old',
+      '  Cursor Agent',
+      '  → prompt'
+    ])
+
+    expect(isCursorAgentVisibleScreen(buffer, 8)).toBe(true)
+  })
+
+  it('rejects shell output that only mentions Cursor Agent', () => {
+    const buffer = makeBuffer(['$ grep docs', 'Cursor Agent', 'matching documentation'])
+
+    expect(isCursorAgentVisibleScreen(buffer, 3)).toBe(false)
   })
 })

--- a/src/renderer/src/lib/pane-manager/terminal-ime-anchor.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-ime-anchor.ts
@@ -10,6 +10,30 @@ const CURSOR_AGENT_INPUT_MARKER = '→'
 const CURSOR_AGENT_EMPTY_PROMPT = 'Plan, search, build anything'
 const CURSOR_AGENT_HEADER_SCAN_ROWS = 6
 
+export function isCursorAgentVisibleScreen(buffer: IBuffer, rows: number): boolean {
+  let headerRow = -1
+  for (let row = 0; row < rows; row++) {
+    if (getVisibleLine(buffer, row)?.translateToString(true).trim() === CURSOR_AGENT_HEADER) {
+      headerRow = row
+    }
+  }
+  if (headerRow === -1) {
+    return false
+  }
+  // Why: requiring a later live prompt rejects shell output that merely mentions Cursor Agent.
+  for (let row = headerRow + 1; row < rows; row++) {
+    if (
+      getVisibleLine(buffer, row)
+        ?.translateToString(true)
+        .trim()
+        .startsWith(CURSOR_AGENT_INPUT_MARKER)
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
 export function resolveCursorAgentImeAnchor(args: {
   buffer: IBuffer
   rows: number


### PR DESCRIPTION
## Summary

  - Detect an active Cursor Agent prompt using the visible xterm screen state.
  - Add a whitespace boundary before pasted clipboard-image paths in Cursor Agent, preventing existing prompt text from being joined to the
  path.
  - Apply the behavior consistently to keyboard, application-menu, and terminal context-menu paste paths.
  - Keep paste behavior unchanged for other terminal agents.
  - Add regression coverage for Cursor Agent screen detection and image paths pasted after existing prompt text.

  ## Screenshots

  Before: 

<img width="1119" height="147" alt="image" src="https://github.com/user-attachments/assets/4605b06e-baf5-4a90-9209-ec097431e7a1" />


  After: Cursor recognizes the image attachment while preserving the existing prompt text.

 
<img width="1057" height="98" alt="image" src="https://github.com/user-attachments/assets/11cdf6cc-cce6-4fff-b07c-ed81827d5782" />


  TODO: Attach the before/after screenshots or a short screen recording from the manual dev verification.

  ## Testing

  - [ ] pnpm lint
  - [x] pnpm typecheck
  - [ ] pnpm test
  - [x] pnpm build
  - [x] Added or updated tests for the changed behavior

  Additional verification:

  - Targeted Vitest suite passed: 42 tests.
  - git diff --check passed.
  - Max-lines ratchet check passed.
  - Pre-commit oxlint, React Doctor lint, and formatting checks passed.
  - Manual dev verification passed on macOS:
      - Pasting an image into an empty Cursor prompt still produces an image attachment.
      - Pasting after existing prompt text produces 123 [Image #1].
      - Cursor placement remains correct.

  Known repository-level check results:

  - pnpm lint currently reports an existing error in the unchanged file
    src/renderer/src/components/skills/skill-freshness-group.tsx:101
    (switch-exhaustiveness-check, missing undefined | "current" | "duplicate").

  - The full pnpm test run did not terminate after more than seven minutes and left an idle Vitest worker. The targeted suites covering this
    change completed successfully.

  ## AI Review Report

  The change was reviewed against both the requested behavior and repository standards.

  - Removed all temporary diagnostic logging and retained only the minimal production change.
  - Removed an earlier process-identity approach in favor of detecting Cursor from the existing visible terminal screen.
  - Cross-platform:
      - No platform-specific keyboard handling was introduced.
      - No path separator assumptions were added; the clipboard image path remains opaque.

  - SSH and remote terminals:
      - Detection uses renderer-side xterm screen content rather than local process inspection, so it does not assume the terminal process
        is local.

  - Agent compatibility:
      - The whitespace adjustment is enabled only when the live terminal screen matches Cursor Agent.
      - Other terminal agents retain their existing paste behavior.

  - Performance:
      - Visible terminal rows are inspected only when a paste occurs.
      - No additional work was added to terminal output or keystroke hot paths.

  - UI:
      - No layout, style, color, typography, or component changes were introduced.

  - Integrations and providers:
      - No Git provider, authentication, review integration, or external API behavior changed.

  No unresolved review findings remain.

  ## Security Audit

  - No dependencies were added.
  - No authentication, authorization, credential, or secret-handling code changed.
  - No new command execution or shell interpolation was introduced.
  - Clipboard image paths continue through the existing IPC and terminal paste flow.
  - The new detection result is only used to decide whether a whitespace boundary is required.
  - No new filesystem access or network requests were added.

  ## Notes

  - The behavior was manually verified in the development build on macOS.
  - Linux and Windows were considered in the implementation but were not manually tested.
  - X (Twitter): TODO — add the contributor's X handle before opening the PR.


## ELI5

Pasting an image path into Cursor Agent could glue it to the text already in the prompt. Orca inserts a space boundary for Cursor image pastes so the path stays a separate token.
