### PR TITLE
Fix folder workspace parent race during background creation

### DIFF
--- a/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
+++ b/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
@@ -383,6 +383,18 @@ describe('useComposerState host-context boundaries', () => {
     expect(quickCreate).toBeGreaterThan(quickPolicySave)
   })
 
+  it('captures the folder parent before quick-create preflight can change focus', () => {
+    const quickSubmit = sourceBetween(HOOK_SOURCE, 'const submitQuick = useCallback', 'return {')
+    const captureParent = quickSubmit.indexOf('const parentWorkspace =')
+    const firstPreflightAwait = quickSubmit.indexOf('await resolvePendingSmartGitHubSubmit()')
+    const request = quickSubmit.indexOf('const request: WorktreeCreationRequest = {')
+
+    expect(captureParent).toBeGreaterThanOrEqual(0)
+    expect(captureParent).toBeLessThan(firstPreflightAwait)
+    expect(request).toBeGreaterThan(firstPreflightAwait)
+    expect(quickSubmit.slice(request)).toContain('parentWorkspace,')
+  })
+
   it('resolves submit-time GitHub smart input when folder child repos exist', () => {
     expect(
       canResolveFolderSmartGitHubSubmit({

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -21,6 +21,7 @@ import { filterEnabledTuiAgents, isTuiAgentEnabled } from '../../../shared/tui-a
 import { repoIsRemote } from '../../../shared/agent-launch-remote'
 import { resolveLocalWindowsAgentStartupShell } from '../../../shared/windows-terminal-shell'
 import { resolveNativeChatSessionOptionDefaults } from '../../../shared/native-chat-session-option-defaults'
+import { folderWorkspaceKey, parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { seedNativeChatAppliedSessionOptions } from '@/components/native-chat/native-chat-session-option-cache'
 import {
   resolveTuiAgentLaunchArgs,
@@ -3691,6 +3692,13 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         return
       }
 
+      const activeWorkspaceScope = parseWorkspaceKey(
+        useAppStore.getState().activeWorkspaceKey ?? ''
+      )
+      const parentWorkspace =
+        activeWorkspaceScope?.type === 'folder'
+          ? folderWorkspaceKey(activeWorkspaceScope.folderWorkspaceId)
+          : null
       setCreateError(null)
       setCreating(true)
       try {
@@ -3959,6 +3967,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
 
         const request: WorktreeCreationRequest = {
           repoId,
+          parentWorkspace,
           ...(ephemeralVmRecipe ? { ephemeralVmRecipe } : {}),
           worktreeCreateProgressMode:
             activeEphemeralVmRecipeId ||

--- a/src/renderer/src/lib/pending-worktree-creation.ts
+++ b/src/renderer/src/lib/pending-worktree-creation.ts
@@ -4,6 +4,7 @@ import type {
   SetupDecision,
   TuiAgent,
   WorkspaceCreateTelemetrySource,
+  WorkspaceKey,
   WorkspaceStatus,
   WorktreeStartupLaunch
 } from '../../../shared/types'
@@ -29,6 +30,9 @@ export type WorktreeCreationProgressMode = 'stepped' | 'indeterminate'
  */
 export type WorktreeCreationRequest = {
   repoId: string
+  /** Folder workspace captured when the request was submitted. `null` freezes
+   *  an intentionally unparented create; `undefined` preserves legacy fallback. */
+  parentWorkspace?: WorkspaceKey | null
   /** Source host/account that produced the linked task. Kept separate from the
    *  run context so Retry does not infer provider ownership from the run host. */
   taskSourceContext?: TaskSourceContext | null

--- a/src/renderer/src/lib/worktree-creation-flow.test.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.test.ts
@@ -199,6 +199,30 @@ describe('runBackgroundWorktreeCreation', () => {
     )
   })
 
+  it('preserves the folder parent captured before background creation starts', async () => {
+    store.createWorktree.mockResolvedValue({
+      worktree: { id: 'repo-1::/workspace/feature', repoId: 'repo-1' }
+    })
+
+    runBackgroundWorktreeCreation(makeRequest({ parentWorkspace: 'folder:folder-1' }))
+
+    await vi.waitFor(() => expect(store.createWorktree).toHaveBeenCalled())
+    const createCall = store.createWorktree.mock.calls[0] as unknown[]
+    expect(createCall[25]).toEqual({ parentWorkspace: 'folder:folder-1' })
+  })
+
+  it('preserves an intentionally unparented background creation', async () => {
+    store.createWorktree.mockResolvedValue({
+      worktree: { id: 'repo-1::/workspace/feature', repoId: 'repo-1' }
+    })
+
+    runBackgroundWorktreeCreation(makeRequest({ parentWorkspace: null }))
+
+    await vi.waitFor(() => expect(store.createWorktree).toHaveBeenCalled())
+    const createCall = store.createWorktree.mock.calls[0] as unknown[]
+    expect(createCall[25]).toEqual({ parentWorkspace: null })
+  })
+
   it('shows a VM provisioning phase and creates the worktree on the prepared runtime repo', async () => {
     store.repos = [
       {

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -165,7 +165,10 @@ async function executeWorktreeCreation(
         preparedRequest.linkedBitbucketPR,
         preparedRequest.linkedAzureDevOpsPR,
         preparedRequest.linkedGiteaPR,
-        preparedRequest.compareBaseRef
+        preparedRequest.compareBaseRef,
+        preparedRequest.parentWorkspace !== undefined
+          ? { parentWorkspace: preparedRequest.parentWorkspace }
+          : undefined
       )
   } catch (error) {
     // Why: a missing entry means the user cancelled mid-flight — abandon

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -156,9 +156,12 @@ export type WorktreeSlice = {
     linkedAzureDevOpsPR?: number | null,
     linkedGiteaPR?: number | null,
     compareBaseRef?: string,
-    // Why: reserved for automation-dispatch flows so host-side provenance can
-    // be minted securely; regular create callers should omit this.
-    options?: { automationProvenanceRequest?: CreateWorktreeArgs['automationProvenanceRequest'] }
+    // Why: optional context travels separately from the legacy positional API.
+    options?: {
+      automationProvenanceRequest?: CreateWorktreeArgs['automationProvenanceRequest']
+      /** Captured submit-time parent. `null` explicitly prevents active-workspace fallback. */
+      parentWorkspace?: WorkspaceKey | null
+    }
   ) => Promise<CreateWorktreeResult>
   /** Register an in-flight background creation and make it the active surface. */
   beginPendingWorktreeCreation: (entry: PendingWorktreeCreation) => void

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -3023,6 +3023,47 @@ describe('createWorktree base status merge', () => {
     })
   })
 
+  it('uses a captured folder parent after the active workspace changes', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      instanceId: 'child-instance'
+    })
+    store.setState({
+      activeWorkspaceKey: worktreeWorkspaceKey('repo1::/path/other')
+    } as Partial<AppState>)
+    mockApi.worktrees.create.mockResolvedValue({ worktree: wt })
+
+    const createWorktree = store.getState().createWorktree
+    const createArgs: Parameters<typeof createWorktree> = ['repo1', 'feature', 'origin/main']
+    createArgs[25] = { parentWorkspace: folderWorkspaceKey('folder-1') }
+
+    await createWorktree(...createArgs)
+
+    expect(mockApi.worktrees.create).toHaveBeenCalledWith(
+      expect.objectContaining({ parentWorkspace: folderWorkspaceKey('folder-1') })
+    )
+  })
+
+  it('does not infer a parent when the submitted request captured none', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })
+    store.setState({ activeWorkspaceKey: folderWorkspaceKey('folder-1') } as Partial<AppState>)
+    mockApi.worktrees.create.mockResolvedValue({ worktree: wt })
+
+    const createWorktree = store.getState().createWorktree
+    const createArgs: Parameters<typeof createWorktree> = ['repo1', 'feature', 'origin/main']
+    createArgs[25] = { parentWorkspace: null }
+
+    await createWorktree(...createArgs)
+
+    expect(mockApi.worktrees.create).toHaveBeenCalledWith(
+      expect.not.objectContaining({ parentWorkspace: expect.anything() })
+    )
+  })
+
   it('merges create result metadata into a worktree inserted by the watcher race', async () => {
     const store = createTestStore()
     const watcherWorktree = makeWorktree({

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -2920,6 +2920,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     options
   ) => {
     const automationProvenanceRequest = options?.automationProvenanceRequest
+    const hasCapturedParentWorkspace =
+      options != null && Object.prototype.hasOwnProperty.call(options, 'parentWorkspace')
     try {
       for (let attempt = 0; attempt < CLIENT_WORKTREE_CREATE_MAX_ATTEMPTS; attempt += 1) {
         const candidateName = getClientWorktreeCreateCandidate(name, attempt)
@@ -2931,8 +2933,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           // Why: manual sort is user-authored order; stamp new workspaces at the top rather than relying on sortOrder fallback.
           const manualOrder = get().sortBy === 'manual' ? Date.now() : undefined
           const activeScope = parseWorkspaceKey(get().activeWorkspaceKey ?? '')
-          const parentWorkspace =
-            activeScope?.type === 'folder'
+          const parentWorkspace = hasCapturedParentWorkspace
+            ? (options.parentWorkspace ?? undefined)
+            : activeScope?.type === 'folder'
               ? folderWorkspaceKey(activeScope.folderWorkspaceId)
               : undefined
           const createArgs = {


### PR DESCRIPTION
## Summary

- capture the active folder workspace when quick worktree creation is submitted
- carry that captured parent through pending/retry state and background creation
- preserve the existing active-workspace fallback for legacy and synchronous callers
- add regression coverage for changed focus and explicitly unparented requests

## Root cause

Quick creates close the composer and continue in the background. The store previously resolved `parentWorkspace` only when each background job reached `createWorktree`. If an earlier job completed first, activation changed `activeWorkspaceKey` from the folder workspace to the new worktree. Later jobs then omitted the folder parent and appeared as unattached worktrees.

## Impact

Users can queue worktrees for several repositories in one folder workspace without waiting for each previous task to complete. Every queued worktree remains attached to the folder workspace that was active when Create was clicked.

## Validation

- `vitest` targeted suites: 261 tests passed
- `pnpm run typecheck:web`
- `oxlint` on all changed files
- `oxfmt` on all changed files



## ELI5

Quick worktree create under a folder workspace could attach to the wrong parent if you switched focus while creation ran in the background. The parent is captured at submit so the new tree stays under the folder you meant.
