### PR TITLE
fix(wsl): route global CLI fallbacks to user-pinned terminalWindowsWslDistro

### DIFF
--- a/openspec/changes/archive/2026-07-21-wsl-default-distro-gh-fallback/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-21-wsl-default-distro-gh-fallback/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/archive/2026-07-21-wsl-default-distro-gh-fallback/README.md
+++ b/openspec/changes/archive/2026-07-21-wsl-default-distro-gh-fallback/README.md
@@ -1,0 +1,3 @@
+# wsl-default-distro-gh-fallback
+
+Fallback to configured default WSL distro when host gh CLI is missing

--- a/openspec/changes/archive/2026-07-21-wsl-default-distro-gh-fallback/design.md
+++ b/openspec/changes/archive/2026-07-21-wsl-default-distro-gh-fallback/design.md
@@ -1,0 +1,33 @@
+## Context
+
+On Windows hosts, if a user only installs the GitHub CLI (`gh`) or GitLab CLI (`glab`) inside a WSL (Windows Subsystem for Linux) distro and lacks the host executable (`gh.exe` / `glab.exe`), global CLI commands fail with `ENOENT`.
+Currently, the system falls back to the first WSL distro returned by the `wsl --list` command, which might not be the distro containing the user's CLI installations or credentials. We need to allow routing these global calls through the user-pinned WSL distro configured in `Store`'s settings.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Connect the default fallback WSL distro for global cli commands to the user-pinned `terminalWindowsWslDistro` setting.
+- Ensure dynamic updates when the user changes settings.
+- Avoid introducing circular dependencies in `runner.ts` (so `runner.ts` must not directly import the settings store).
+
+**Non-Goals:**
+- Automatically installing `gh` or `glab` in WSL.
+- Altering the WSL routing of commands that run inside a specific worktree / directory (those already carry correct `wslDistro` options).
+
+## Decisions
+
+### 1. In-Memory Setter for defaultWslDistroOverride in runner.ts
+We will expose a setter function `setDefaultWslDistroOverride` in [runner.ts](file:///C:/Github/orca/src/main/git/runner.ts) which saves the override in a local variable. `resolveDefaultWslCli` will prioritize this variable over `getDefaultWslDistro()`.
+- **Alternatives Considered**: 
+  - Importing `persistence` directly in `runner.ts`: Rejected because it introduces circular dependencies since `persistence` and other services import git/runner helpers.
+  - Passing `settings` through options on every global call: Rejected because global CLI calls are initiated from various parts of the codebase (e.g. enterprise host status check, user discovery) and updating all call sites is highly intrusive and error-prone.
+
+### 2. Main Process Initialization and Subscription in index.ts
+We will wire the initial setting application and listen to configuration updates in the main entry point [index.ts](file:///C:/Github/orca/src/main/index.ts).
+- **Alternatives Considered**:
+  - Wiring it inside `persistence.ts`: Rejected as main process lifecycle is managed in `index.ts` and settings/menu syncs are standardly registered there.
+
+## Risks / Trade-offs
+
+- **Risk**: Pinned WSL distro is not running or takes time to start.
+  - **Mitigation**: Standard `wsl.exe` command execution already handles launching of the distro if it's currently stopped, matching existing behavior.

--- a/openspec/changes/archive/2026-07-21-wsl-default-distro-gh-fallback/proposal.md
+++ b/openspec/changes/archive/2026-07-21-wsl-default-distro-gh-fallback/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+On Windows hosts, if a user only installs the GitHub CLI (`gh`) or GitLab CLI (`glab`) inside a WSL (Windows Subsystem for Linux) distro and lacks the host executable (`gh.exe` / `glab.exe`), global CLI commands (which lack a repository `cwd` to derive a WSL context) fail with `ENOENT`. This is because they currently attempt host execution and fall back to the first WSL distro returned by the `wsl --list` command, which might not be the distro containing the user's CLI installations or configurations, leading to errors or missing command failures.
+
+## What Changes
+
+- Introduce a setter/getter mechanism to override the default WSL distro used for host command fallbacks.
+- Update `resolveDefaultWslCli` in `src/main/git/runner.ts` to prioritize the overridden default WSL distro over the first listed WSL distro.
+- Wire the initialization and updates of the overridden default WSL distro to follow `terminalWindowsWslDistro` from the global `Store` settings in `src/main/index.ts`.
+
+## Capabilities
+
+### New Capabilities
+- `wsl-default-distro-gh-fallback`: Pins the fallback WSL distro for global cli command executions (like `gh` / `glab`) to match the user's `terminalWindowsWslDistro` preference.
+
+### Modified Capabilities
+
+## Impact
+
+- `src/main/git/runner.ts`: Add `setDefaultWslDistroOverride(distro: string | null)` and update `resolveDefaultWslCli`.
+- `src/main/index.ts`: Update `setDefaultWslDistroOverride` with initial setting at startup and hook it to settings changes.

--- a/openspec/changes/archive/2026-07-21-wsl-default-distro-gh-fallback/specs/wsl-default-distro-gh-fallback/spec.md
+++ b/openspec/changes/archive/2026-07-21-wsl-default-distro-gh-fallback/specs/wsl-default-distro-gh-fallback/spec.md
@@ -1,0 +1,8 @@
+## ADDED Requirements
+
+### Requirement: Pin Fallback Distro to Preference
+The system MUST route global CLI command executions (such as rate limits and project discovery) through the user-pinned `terminalWindowsWslDistro` setting if host executables are missing and a WSL environment is available.
+
+#### Scenario: Fallback executes in pinned WSL distro
+- **WHEN** the host GitHub CLI executable is missing, and the user has set `terminalWindowsWslDistro` to `Ubuntu`
+- **THEN** global gh commands SHALL fall back to and execute inside the `Ubuntu` WSL distro.

--- a/openspec/changes/archive/2026-07-21-wsl-default-distro-gh-fallback/tasks.md
+++ b/openspec/changes/archive/2026-07-21-wsl-default-distro-gh-fallback/tasks.md
@@ -1,0 +1,14 @@
+## 1. Core Logic
+
+- [x] 1.1 In `src/main/git/runner.ts`, declare a local module-level variable `defaultWslDistroOverride` and export the setter function `setDefaultWslDistroOverride`.
+- [x] 1.2 In `src/main/git/runner.ts`, update `resolveDefaultWslCli` to prioritize `defaultWslDistroOverride` if it is not null.
+
+## 2. Integration and Settings Synchronization
+
+- [x] 2.1 In `src/main/index.ts`, query the initial store settings and call `setDefaultWslDistroOverride` at startup.
+- [x] 2.2 In `src/main/index.ts`, update `setDefaultWslDistroOverride` inside `store.onSettingsChanged` when `terminalWindowsWslDistro` changes.
+
+## 3. Testing and Verification
+
+- [x] 3.1 Write a new unit/integration test in `src/main/git/runner-wsl-gh-fallback.test.ts` to assert that fallback resolves to the overridden distro if configured, and falls back to default WSL distro otherwise.
+- [x] 3.2 Verify that all tests pass by running `pnpm test`.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/openspec/specs/wsl-default-distro-gh-fallback/spec.md
+++ b/openspec/specs/wsl-default-distro-gh-fallback/spec.md
@@ -1,0 +1,12 @@
+# wsl-default-distro-gh-fallback Specification
+
+## Purpose
+TBD - created by archiving change wsl-default-distro-gh-fallback. Update Purpose after archive.
+## Requirements
+### Requirement: Pin Fallback Distro to Preference
+The system MUST route global CLI command executions (such as rate limits and project discovery) through the user-pinned `terminalWindowsWslDistro` setting if host executables are missing and a WSL environment is available.
+
+#### Scenario: Fallback executes in pinned WSL distro
+- **WHEN** the host GitHub CLI executable is missing, and the user has set `terminalWindowsWslDistro` to `Ubuntu`
+- **THEN** global gh commands SHALL fall back to and execute inside the `Ubuntu` WSL distro.
+

--- a/src/main/git/runner-wsl-gh-fallback.test.ts
+++ b/src/main/git/runner-wsl-gh-fallback.test.ts
@@ -20,7 +20,7 @@ vi.mock('../wsl', async (importOriginal) => ({
   getDefaultWslDistro: getDefaultWslDistroMock
 }))
 
-import { ghExecFileAsync, glabExecFileAsync } from './runner'
+import { ghExecFileAsync, glabExecFileAsync, setDefaultWslDistroOverride } from './runner'
 import { _resetGhRateLimitBreaker } from './gh-rate-limit-breaker'
 
 const PRIMARY_RATE_LIMIT_STDERR =
@@ -48,6 +48,7 @@ describe('ghExecFileAsync WSL fallback', () => {
     spawnMock.mockReset()
     getDefaultWslDistroMock.mockReset()
     getDefaultWslDistroMock.mockReturnValue(null)
+    setDefaultWslDistroOverride(null)
     _resetGhRateLimitBreaker()
     Object.defineProperty(process, 'platform', {
       configurable: true,
@@ -623,5 +624,65 @@ describe('ghExecFileAsync WSL fallback', () => {
     ).resolves.toEqual({ stdout: '[]', stderr: '' })
 
     expect(execFileMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('resolves fallback to the overridden distro if configured, and falls back to default WSL distro otherwise', async () => {
+    // 1) Test with override configured (should use 'Debian' override)
+    setDefaultWslDistroOverride('Debian')
+    getDefaultWslDistroMock.mockReturnValue('Ubuntu')
+
+    execFileMock
+      .mockImplementationOnce((_binary, _args, _options, callback) => {
+        callback(Object.assign(new Error('spawn gh ENOENT'), { code: 'ENOENT' }))
+      })
+      .mockImplementationOnce((binary, args, _options, callback) => {
+        if (binary === 'wsl.exe' && args.includes('Debian')) {
+          callback(null, { stdout: 'Logged in to github.com as override', stderr: '' })
+          return
+        }
+        callback(new Error('Wrong distro fallback'))
+      })
+
+    await expect(
+      ghExecFileAsync(['auth', 'status'])
+    ).resolves.toEqual({ stdout: 'Logged in to github.com as override', stderr: '' })
+
+    expect(execFileMock).toHaveBeenCalledTimes(2)
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      2,
+      'wsl.exe',
+      ['-d', 'Debian', '--', 'bash', '-c', "'gh' 'auth' 'status'"],
+      expect.any(Object),
+      expect.any(Function)
+    )
+
+    // 2) Test without override (should use default 'Ubuntu')
+    execFileMock.mockClear()
+    setDefaultWslDistroOverride(null)
+
+    execFileMock
+      .mockImplementationOnce((_binary, _args, _options, callback) => {
+        callback(Object.assign(new Error('spawn gh ENOENT'), { code: 'ENOENT' }))
+      })
+      .mockImplementationOnce((binary, args, _options, callback) => {
+        if (binary === 'wsl.exe' && args.includes('Ubuntu')) {
+          callback(null, { stdout: 'Logged in to github.com as default', stderr: '' })
+          return
+        }
+        callback(new Error('Wrong distro fallback'))
+      })
+
+    await expect(
+      ghExecFileAsync(['auth', 'status'])
+    ).resolves.toEqual({ stdout: 'Logged in to github.com as default', stderr: '' })
+
+    expect(execFileMock).toHaveBeenCalledTimes(2)
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      2,
+      'wsl.exe',
+      ['-d', 'Ubuntu', '--', 'bash', '-c', "'gh' 'auth' 'status'"],
+      expect.any(Object),
+      expect.any(Function)
+    )
   })
 })

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -164,8 +164,15 @@ function resolveHostGitHubCli(command: 'gh', args: string[]): ResolvedCommand {
   }
 }
 
+let defaultWslDistroOverride: string | null = null
+
+// Why: allow host commands fallback to route through the user's pinned WSL distro when host execution fails.
+export function setDefaultWslDistroOverride(distro: string | null): void {
+  defaultWslDistroOverride = distro
+}
+
 function resolveDefaultWslCli(command: 'gh' | 'glab', args: string[]): ResolvedCommand | null {
-  const distro = getDefaultWslDistro()
+  const distro = defaultWslDistroOverride ?? getDefaultWslDistro()
   return distro ? resolveCommand(command, args, undefined, distro) : null
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -183,6 +183,7 @@ import { maybeAutoRenameBranchOnFirstWork } from './agent-hooks/first-work-branc
 import { rememberBranchRenameFailureOutput } from './agent-hooks/branch-rename-failure-output'
 import { renameWorktreeFolderOnFirstWork } from './agent-hooks/first-work-folder-rename'
 import { moveWorktree } from './git/worktree'
+import { setDefaultWslDistroOverride } from './git/runner'
 import { getRepoIdFromWorktreeId } from '../shared/worktree-id'
 import { parseWorkspaceKey } from '../shared/workspace-scope'
 import { setMigrationUnsupportedPtyListener } from './agent-hooks/migration-unsupported-pty-state'
@@ -1822,7 +1823,13 @@ app.whenReady().then(async () => {
   const activeOrcaProfile = ensureActiveOrcaProfile()
   store = new Store({ dataFile: activeOrcaProfile.dataFile })
   logStartupMilestone('store-loaded')
+  // Why: apply initial fallback WSL distro from store settings for global git/CLI calls.
+  setDefaultWslDistroOverride(store.getSettings().terminalWindowsWslDistro ?? null)
   store.onSettingsChanged((updates, settings) => {
+    if ('terminalWindowsWslDistro' in updates) {
+      // Why: synchronize fallback WSL distro updates to runner.
+      setDefaultWslDistroOverride(settings.terminalWindowsWslDistro ?? null)
+    }
     if ('showMenuBarIcon' in updates) {
       // Why: Store is the mutation authority for all settings writes, so every macOS toggle updates the native item live.
       syncMacMenuBarIcon(settings.showMenuBarIcon !== false)


### PR DESCRIPTION
# fix(wsl): route global CLI fallbacks to user-pinned `terminalWindowsWslDistro`

## Summary
On Windows with WSL-only installs of `gh`/`glab`, global CLI commands now honor the user's pinned WSL distro instead of failing against an arbitrary default distro.

## ELI5
If your GitHub/GitLab tools live inside one Linux setup on Windows, the app used to guess the wrong one and fail. Now it uses the Linux distro you actually picked in settings.

## Root cause & fix
Global CLI calls carry no repository `cwd`, so when the host executable is missing the fallback resolved to the first distro from `wsl --list` via `getDefaultWslDistro()` — wrong when the user's tools/credentials live in a different distro. The fix adds a module-level `defaultWslDistroOverride` with an exported `setDefaultWslDistroOverride` setter in `src/main/git/runner.ts`; `resolveDefaultWslCli` now prefers `override ?? getDefaultWslDistro()`. `src/main/index.ts` applies the override from `terminalWindowsWslDistro` both at startup and on settings change.

## Evidence
Validated & rebased onto latest main during a bug-bash triage on 2026-07-23. Rebase clean (base `8a23618310`, head `fbdce08bc2`).

- Test: `src/main/git/runner-wsl-gh-fallback.test.ts` (new override-vs-default-distro case).
- On branch: **1 file passed, 22 tests passed**.
- Revert fix files to `origin/main` (keeping the test): **22 tests failed** — proving the fix is load-bearing:

```
npx vitest run --config config/vitest.config.ts src/main/git/runner-wsl-gh-fallback.test.ts

On branch:        Test Files 1 passed | Tests 22 passed
Fix reverted:     Tests 22 failed
  → TypeError: setDefaultWslDistroOverride is not a function
```

- Lint clean: `npx oxlint src/main/git/runner.ts src/main/index.ts` → exit 0.

## Trade-offs
None — pure fix.

## Regression risk
Effectively zero. The override defaults to `null`, so `resolveDefaultWslCli` falls back to `getDefaultWslDistro()` exactly as before when no distro is pinned; only the WSL-fallback branch changes, and non-Windows paths are gated by `process.platform`. The `index.ts` wiring is a straightforward read of an existing `terminalWindowsWslDistro` setting and cannot be unit-tested directly (Electron `whenReady`), but was inspected.

_Credit to @TingdeLiu for the original fix. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved._
