### PR TITLE
feat(editor): show selected character and word count

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -3178,6 +3178,27 @@ html.onboarding-tour-start-transition::view-transition-new(root) {
   outline-offset: 1px;
 }
 
+.orca-editor-selection-count {
+  position: absolute;
+  bottom: 6px;
+  right: 16px;
+  z-index: 5;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  padding: 1px 8px;
+  font-size: 11px;
+  line-height: 16px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  user-select: none;
+  color: var(--muted-foreground);
+  background: color-mix(in srgb, var(--popover) 92%, transparent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--foreground) 12%, transparent);
+}
+
 .orca-diff-comment-range-highlight {
   background: rgba(59, 130, 246, 0.14);
 }

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -56,6 +56,7 @@ import {
   getMonacoMarkdownSelectionAnnotationTarget,
   type MonacoMarkdownSelectionAnnotationTarget
 } from './monaco-markdown-selection-annotation'
+import { getMonacoSelectionStats, type MonacoSelectionStats } from './monaco-selection-stats'
 import { translate } from '@/i18n/i18n'
 import { handleMonacoLargeTextPaste } from './monaco-large-text-paste'
 import { buildFileEditorWordWrapOptions } from './file-editor-word-wrap-options'
@@ -184,6 +185,8 @@ export default function MonacoEditor({
   const [commentPopover, setCommentPopover] = useState<MarkdownCommentPopoverState | null>(null)
   const [selectionAnnotationTarget, setSelectionAnnotationTarget] =
     useState<MonacoMarkdownSelectionAnnotationTarget | null>(null)
+  const showSelectionCount = !autoHeight
+  const [selectionStats, setSelectionStats] = useState<MonacoSelectionStats | null>(null)
   // Why: claim drafts synchronously so a same-tick second chord can't remount the composer before React commits state.
   const commentPopoverRef = useRef<MarkdownCommentPopoverState | null>(null)
   useEffect(() => {
@@ -621,6 +624,23 @@ export default function MonacoEditor({
     }
   }, [commentPopover, mountedEditor, shouldShowMarkdownAnnotations])
 
+  useEffect(() => {
+    if (!mountedEditor || !showSelectionCount) {
+      setSelectionStats(null)
+      return
+    }
+    const update = (): void => {
+      setSelectionStats(
+        getMonacoSelectionStats(mountedEditor.getModel(), mountedEditor.getSelections())
+      )
+    }
+    update()
+    const selectionSub = mountedEditor.onDidChangeCursorSelection(update)
+    return () => {
+      selectionSub.dispose()
+    }
+  }, [mountedEditor, showSelectionCount])
+
   const handleSubmitMarkdownComment = async (body: string): Promise<void> => {
     if (!commentPopover || !worktreeId) {
       return
@@ -861,6 +881,16 @@ export default function MonacoEditor({
         saveViewState={false}
         keepCurrentModel
       />
+
+      {showSelectionCount && selectionStats ? (
+        <div className="orca-editor-selection-count" aria-hidden="true">
+          {translate(
+            'auto.components.editor.MonacoEditor.selectionCount',
+            '{{chars}} chars, {{words}} words selected',
+            { chars: selectionStats.chars, words: selectionStats.words }
+          )}
+        </div>
+      ) : null}
 
       {toastNode}
       <MonacoGutterContextMenu

--- a/src/renderer/src/components/editor/monaco-selection-stats.test.ts
+++ b/src/renderer/src/components/editor/monaco-selection-stats.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import type { IRange } from 'monaco-editor'
+import { getMonacoSelectionStats } from './monaco-selection-stats'
+
+function range(
+  startLineNumber: number,
+  startColumn: number,
+  endLineNumber: number,
+  endColumn: number
+): IRange {
+  return { startLineNumber, startColumn, endLineNumber, endColumn }
+}
+
+function modelReturning(textByRange: Map<string, string>): {
+  getValueInRange: (r: IRange) => string
+} {
+  const key = (r: IRange): string =>
+    `${r.startLineNumber}:${r.startColumn}-${r.endLineNumber}:${r.endColumn}`
+  return {
+    getValueInRange: (r) => textByRange.get(key(r)) ?? ''
+  }
+}
+
+describe('getMonacoSelectionStats', () => {
+  it('returns null when there is no model', () => {
+    expect(getMonacoSelectionStats(null, [range(1, 1, 1, 5)])).toBeNull()
+  })
+
+  it('returns null when there are no selections', () => {
+    const model = modelReturning(new Map())
+    expect(getMonacoSelectionStats(model, null)).toBeNull()
+    expect(getMonacoSelectionStats(model, [])).toBeNull()
+  })
+
+  it('returns null for an empty (caret-only) selection', () => {
+    const model = modelReturning(new Map())
+    expect(getMonacoSelectionStats(model, [range(3, 2, 3, 2)])).toBeNull()
+  })
+
+  it('counts characters and whitespace-delimited words for a single selection', () => {
+    const model = modelReturning(new Map([['1:1-1:12', 'hello world!']]))
+    expect(getMonacoSelectionStats(model, [range(1, 1, 1, 12)])).toEqual({
+      chars: 12,
+      words: 2
+    })
+  })
+
+  it('treats runs of whitespace and newlines as single word separators', () => {
+    const model = modelReturning(new Map([['1:1-3:1', 'one   two\n\tthree ']]))
+    const stats = getMonacoSelectionStats(model, [range(1, 1, 3, 1)])
+    expect(stats?.words).toBe(3)
+  })
+
+  it('reports characters but zero words for a whitespace-only selection', () => {
+    const model = modelReturning(new Map([['1:1-1:4', '   ']]))
+    expect(getMonacoSelectionStats(model, [range(1, 1, 1, 4)])).toEqual({
+      chars: 3,
+      words: 0
+    })
+  })
+
+  it('counts an emoji as a single character (code points, not UTF-16 units)', () => {
+    const model = modelReturning(new Map([['1:1-1:3', '👍a']]))
+    const stats = getMonacoSelectionStats(model, [range(1, 1, 1, 3)])
+    expect(stats?.chars).toBe(2)
+  })
+
+  it('sums characters and words across multiple non-empty selections', () => {
+    const model = modelReturning(
+      new Map([
+        ['1:1-1:6', 'alpha'],
+        ['2:1-2:9', 'beta gamma']
+      ])
+    )
+    const stats = getMonacoSelectionStats(model, [range(1, 1, 1, 6), range(2, 1, 2, 9)])
+    expect(stats).toEqual({ chars: 15, words: 3 })
+  })
+
+  it('ignores empty selections when other selections have content', () => {
+    const model = modelReturning(new Map([['1:1-1:5', 'quux']]))
+    const stats = getMonacoSelectionStats(model, [range(3, 1, 3, 1), range(1, 1, 1, 5)])
+    expect(stats).toEqual({ chars: 4, words: 1 })
+  })
+})

--- a/src/renderer/src/components/editor/monaco-selection-stats.ts
+++ b/src/renderer/src/components/editor/monaco-selection-stats.ts
@@ -1,0 +1,51 @@
+import type { IRange } from 'monaco-editor'
+
+export type MonacoSelectionStats = {
+  chars: number
+  words: number
+}
+
+type MonacoSelectionStatsModel = {
+  getValueInRange: (range: IRange) => string
+}
+
+function isEmptyRange(range: IRange): boolean {
+  return range.startLineNumber === range.endLineNumber && range.startColumn === range.endColumn
+}
+
+function countChars(text: string): number {
+  return Array.from(text).length
+}
+
+function countWords(text: string): number {
+  const trimmed = text.trim()
+  if (!trimmed) {
+    return 0
+  }
+  return trimmed.split(/\s+/u).length
+}
+
+export function getMonacoSelectionStats(
+  model: MonacoSelectionStatsModel | null,
+  selections: IRange[] | null
+): MonacoSelectionStats | null {
+  if (!model || !selections || selections.length === 0) {
+    return null
+  }
+  let chars = 0
+  let words = 0
+  let hasContent = false
+  for (const selection of selections) {
+    if (isEmptyRange(selection)) {
+      continue
+    }
+    const text = model.getValueInRange(selection)
+    if (!text) {
+      continue
+    }
+    hasContent = true
+    chars += countChars(text)
+    words += countWords(text)
+  }
+  return hasContent ? { chars, words } : null
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11985,7 +11985,8 @@
         "MonacoEditor": {
           "68cb83f4a7": "Add note on selected text",
           "fd68ae03b3": "Search in Files",
-          "largePasteTooLarge": "Paste is too large."
+          "largePasteTooLarge": "Paste is too large.",
+          "selectionCount": "{{chars}} chars, {{words}} words selected"
         },
         "MonacoGutterContextMenu": {
           "7b57b1b468": "Copy Remote URL",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11962,7 +11962,8 @@
         "MonacoEditor": {
           "68cb83f4a7": "Agregar nota sobre el texto seleccionado",
           "fd68ae03b3": "Buscar en archivos",
-          "largePasteTooLarge": "El contenido pegado es demasiado grande."
+          "largePasteTooLarge": "El contenido pegado es demasiado grande.",
+          "selectionCount": "{{chars}} chars, {{words}} words selected"
         },
         "MonacoGutterContextMenu": {
           "7b57b1b468": "Copiar URL remota",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11962,7 +11962,8 @@
         "MonacoEditor": {
           "68cb83f4a7": "選択したテキストにメモを追加する",
           "fd68ae03b3": "ファイル内を検索",
-          "largePasteTooLarge": "貼り付け内容が大きすぎます。"
+          "largePasteTooLarge": "貼り付け内容が大きすぎます。",
+          "selectionCount": "{{chars}} chars, {{words}} words selected"
         },
         "MonacoGutterContextMenu": {
           "7b57b1b468": "リモート URL をコピー",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11962,7 +11962,8 @@
         "MonacoEditor": {
           "68cb83f4a7": "선택한 텍스트에 메모 추가",
           "fd68ae03b3": "파일에서 검색",
-          "largePasteTooLarge": "붙여넣기 내용이 너무 큽니다."
+          "largePasteTooLarge": "붙여넣기 내용이 너무 큽니다.",
+          "selectionCount": "{{chars}} chars, {{words}} words selected"
         },
         "MonacoGutterContextMenu": {
           "7b57b1b468": "원격 URL 복사",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11962,7 +11962,8 @@
         "MonacoEditor": {
           "68cb83f4a7": "在选定的文本上添加注释",
           "fd68ae03b3": "在文件中搜索",
-          "largePasteTooLarge": "粘贴内容过大。"
+          "largePasteTooLarge": "粘贴内容过大。",
+          "selectionCount": "{{chars}} chars, {{words}} words selected"
         },
         "MonacoGutterContextMenu": {
           "7b57b1b468": "复制远程 URL",


### PR DESCRIPTION
## Summary

Adds a small, unobtrusive readout in the **bottom-right corner of the file editor** that shows the **selected character and word count** whenever text is selected — the same "glance and know how much I've highlighted" affordance VS Code offers. It appears only while there is a non-empty selection and disappears the moment the selection is cleared, so it never adds clutter during normal editing.

Details:
- Character count is Unicode code-point aware (an emoji counts as one character); word count is whitespace-delimited.
- Counts **sum across multi-cursor selections**, matching VS Code's combined count.
- The badge is `pointer-events: none`, so it never intercepts clicks or interferes with the underlying text selection.
- It renders only for the full-height file editor, not the inline auto-height composer editors.

Implements #9737.

### Where it lives / how it's built
- `monaco-selection-stats.ts` — a small pure helper that turns the editor model + selections into `{ chars, words }`, with unit tests.
- `MonacoEditor.tsx` — an always-on `onDidChangeCursorSelection` subscription drives the badge state; the badge is rendered inside the existing positioned editor container.
- `main.css` — `.orca-editor-selection-count` styled with existing design tokens (`--muted-foreground`, `--popover`, `--border`, `--radius-sm`), so it adapts to light/dark automatically.
- The label is localized through the shared catalog (`selectionCount` key, all five locale files kept in parity).

## Screenshots

Selecting text shows the live count in the bottom-right corner:

![Editor selection character and word count badge](https://raw.githubusercontent.com/coredumpdev/orca/pr-assets/selection-count.png)

## Testing

- [ ] `pnpm lint` — my changed files pass `oxlint` and `verify:localization-catalog`. The full `lint` task does not exit clean **locally** due to two pre-existing failures in files this PR does not touch (`skill-freshness-group.tsx` switch-exhaustiveness, `verify:localization-coverage` on `ai-vault-*` strings), both reproduced on a clean `main`. Expected green in CI.
- [x] `pnpm typecheck` — clean
- [ ] `pnpm test` — the new unit tests pass (9/9). The full suite has 9 pre-existing failures across 5 main-process/PTY/GPU test files, all reproduced on a clean `main` (verified by stashing this change) and unrelated to it.
- [x] `pnpm build` — clean
- [x] Added high-quality unit tests — `monaco-selection-stats.test.ts` covers empty/caret-only, single, multi-selection summing, emoji (code points), whitespace-only, and mixed empty+content selections.

## AI Review Report

Reviewed with an AI coding agent for cross-platform, remote, performance, and UI-quality risk:
- **Cross-platform (macOS/Linux/Windows):** No platform-specific code. No new keyboard shortcuts, no path handling, no shell or Electron-main behavior. The feature is pure renderer UI driven by the in-memory Monaco model, so it behaves identically on all three platforms.
- **SSH/remote/local:** No process, file, credential, or network access — the count is computed entirely in the renderer from the already-loaded editor model, so it works the same locally and over SSH.
- **Performance:** The selection subscription only reads the current selection(s) on change; work is proportional to the selected text. It is scoped to the full-height file editor and skipped for inline auto-height editors. It follows the same read pattern already used by the existing markdown-selection annotation code.
- **UI quality:** Styled with existing tokens (light/dark aware), `pointer-events: none` so it can't disrupt selection, and hidden when nothing is selected.

## Security Audit

- The only "input" is the user's own selected editor text, which is **measured only** (character/word counts) — never executed, evaluated, or transmitted anywhere.
- Rendered as a plain React text node with i18next interpolation (auto-escaped); no `dangerouslySetInnerHTML`, no DOM injection.
- No new IPC, no command execution, no path handling, no secrets, no new dependencies.

## Notes

- No behavior change to editing, saving, diffing, or any existing shortcut.
- The screenshot is hosted on a separate `pr-assets` branch of the fork so it stays out of this PR's diff.



## ELI5

When you select text in the file editor, a small character and word count appears in the corner (like VS Code). It only shows while something is selected and hides when you clear the selection.
