### PR TITLE
fix(terminal): forward copy shortcuts to mouse-tracking TUIs

### DIFF
--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
@@ -248,9 +248,12 @@ describe('useTerminalKeyboardShortcuts copy selection', () => {
     selection: string
     mouseTrackingMode: 'none' | 'normal' | 'drag' | 'any'
     altKey?: boolean
+    ctrlKey?: boolean
     keybindings?: KeybindingOverrides
+    metaKey?: boolean
     repeat?: boolean
     shiftKey?: boolean
+    userAgent?: string
   }): {
     clearActivePane: ReturnType<typeof vi.fn>
     input: ReturnType<typeof vi.fn>
@@ -284,7 +287,9 @@ describe('useTerminalKeyboardShortcuts copy selection', () => {
       getPanes: vi.fn(() => [pane])
     }
 
-    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Macintosh)' })
+    vi.stubGlobal('navigator', {
+      userAgent: options.userAgent ?? 'Mozilla/5.0 (Macintosh)'
+    })
     vi.stubGlobal('HTMLElement', class HTMLElement {})
     vi.stubGlobal('window', {
       navigator: globalThis.navigator,
@@ -328,8 +333,8 @@ describe('useTerminalKeyboardShortcuts copy selection', () => {
     const event = {
       key: 'c',
       code: 'KeyC',
-      metaKey: true,
-      ctrlKey: false,
+      metaKey: options.metaKey ?? true,
+      ctrlKey: options.ctrlKey ?? false,
       altKey: options.altKey ?? false,
       shiftKey: options.shiftKey ?? false,
       repeat: options.repeat ?? false,
@@ -385,6 +390,30 @@ describe('useTerminalKeyboardShortcuts copy selection', () => {
     expect(harness.event.stopImmediatePropagation).toHaveBeenCalledOnce()
     harness.dispose()
   })
+
+  it.each([
+    ['Linux', 'normal'],
+    ['Windows', 'drag']
+  ] as const)(
+    'forwards the configured copy chord on %s in %s mouse-tracking mode',
+    (platform, mouseTrackingMode) => {
+      const harness = installCopyShortcutHarness({
+        selection: '',
+        mouseTrackingMode,
+        userAgent: `Mozilla/5.0 (${platform})`,
+        metaKey: false,
+        ctrlKey: true,
+        shiftKey: true,
+        keybindings: { 'terminal.copySelection': ['Mod+Shift+C'] }
+      })
+
+      expect(harness.input).toHaveBeenCalledWith('\x03')
+      expect(harness.writeClipboardText).not.toHaveBeenCalled()
+      expect(harness.event.preventDefault).toHaveBeenCalledOnce()
+      expect(harness.event.stopImmediatePropagation).toHaveBeenCalledOnce()
+      harness.dispose()
+    }
+  )
 
   it('ignores repeated macOS Cmd+C from a mouse-capturing TUI selection', () => {
     const harness = installCopyShortcutHarness({

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, it, expect, vi } from 'vitest'
 import { useEffect } from 'react'
 import type * as React from 'react'
 import { FIND_QUERY_MAX_BYTES } from '@/lib/find-query-bounds'
+import type { KeybindingOverrides } from '../../../../shared/keybindings'
 
 const { resetTerminalKeyboardProtocolAfterInterruptMock } = vi.hoisted(() => ({
   resetTerminalKeyboardProtocolAfterInterruptMock: vi.fn()
@@ -247,10 +248,11 @@ describe('useTerminalKeyboardShortcuts copy selection', () => {
     selection: string
     mouseTrackingMode: 'none' | 'normal' | 'drag' | 'any'
     altKey?: boolean
-    keybindings?: { 'terminal.copySelection': string[] }
+    keybindings?: KeybindingOverrides
     repeat?: boolean
     shiftKey?: boolean
   }): {
+    clearActivePane: ReturnType<typeof vi.fn>
     input: ReturnType<typeof vi.fn>
     writeClipboardText: ReturnType<typeof vi.fn>
     event: Pick<
@@ -264,6 +266,7 @@ describe('useTerminalKeyboardShortcuts copy selection', () => {
     dispose: () => void
   } {
     const listeners = new Map<string, EventListener>()
+    const clearActivePane = vi.fn()
     const input = vi.fn()
     const writeClipboardText = vi.fn(() => Promise.resolve())
     const pane = {
@@ -313,7 +316,7 @@ describe('useTerminalKeyboardShortcuts copy selection', () => {
       setSearchOpen: vi.fn(),
       onSearchSelectedText: vi.fn(),
       onRequestClosePane: vi.fn(),
-      onClearPaneScrollback: vi.fn(),
+      onClearPaneScrollback: clearActivePane,
       onSetTitle: vi.fn(),
       onClearPaneTitle: vi.fn(),
       searchOpenRef: { current: false },
@@ -339,6 +342,7 @@ describe('useTerminalKeyboardShortcuts copy selection', () => {
     onKeyDown?.(event as unknown as Event)
 
     return {
+      clearActivePane,
       input,
       writeClipboardText,
       event,
@@ -393,6 +397,38 @@ describe('useTerminalKeyboardShortcuts copy selection', () => {
     expect(harness.writeClipboardText).not.toHaveBeenCalled()
     expect(harness.event.preventDefault).not.toHaveBeenCalled()
     expect(harness.event.stopImmediatePropagation).not.toHaveBeenCalled()
+    harness.dispose()
+  })
+
+  it('ignores a repeated configured copy chord', () => {
+    const harness = installCopyShortcutHarness({
+      selection: '',
+      mouseTrackingMode: 'any',
+      altKey: true,
+      repeat: true,
+      keybindings: { 'terminal.copySelection': ['Mod+Alt+C'] }
+    })
+
+    expect(harness.input).not.toHaveBeenCalled()
+    expect(harness.writeClipboardText).not.toHaveBeenCalled()
+    expect(harness.event.preventDefault).not.toHaveBeenCalled()
+    expect(harness.event.stopImmediatePropagation).not.toHaveBeenCalled()
+    harness.dispose()
+  })
+
+  it('keeps another action rebound to macOS Cmd+C reachable', () => {
+    const harness = installCopyShortcutHarness({
+      selection: 'selected',
+      mouseTrackingMode: 'any',
+      keybindings: {
+        'terminal.copySelection': ['Mod+Shift+C'],
+        'terminal.clear': ['Mod+C']
+      }
+    })
+
+    expect(harness.clearActivePane).toHaveBeenCalledOnce()
+    expect(harness.writeClipboardText).not.toHaveBeenCalled()
+    expect(harness.input).not.toHaveBeenCalled()
     harness.dispose()
   })
 

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
@@ -1,11 +1,19 @@
 // src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
-import { describe, it, expect, vi } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
+import { useEffect } from 'react'
+import type * as React from 'react'
 import { FIND_QUERY_MAX_BYTES } from '@/lib/find-query-bounds'
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof React>()
+  return { ...actual, useEffect: vi.fn() }
+})
 import {
   matchFileSearchShortcut,
   matchSearchNavigate,
   resolveTerminalKeyboardShortcutAction,
-  runTerminalSearchNavigation
+  runTerminalSearchNavigation,
+  useTerminalKeyboardShortcuts
 } from './keyboard-handlers'
 
 function makeKeyEvent(
@@ -219,5 +227,189 @@ describe('matchFileSearchShortcut', () => {
         'sidebar.search.toggle': []
       })
     ).toBe(false)
+  })
+})
+
+describe('useTerminalKeyboardShortcuts copy selection', () => {
+  function CopyShortcutHarness(deps: Parameters<typeof useTerminalKeyboardShortcuts>[0]): null {
+    useTerminalKeyboardShortcuts(deps)
+    return null
+  }
+
+  function installCopyShortcutHarness(options: {
+    selection: string
+    mouseTrackingMode: 'none' | 'normal' | 'drag' | 'any'
+    altKey?: boolean
+    keybindings?: { 'terminal.copySelection': string[] }
+    repeat?: boolean
+    shiftKey?: boolean
+  }): {
+    input: ReturnType<typeof vi.fn>
+    writeClipboardText: ReturnType<typeof vi.fn>
+    event: Pick<
+      KeyboardEvent,
+      'key' | 'code' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey' | 'repeat'
+    > & {
+      target: null
+      preventDefault: ReturnType<typeof vi.fn>
+      stopImmediatePropagation: ReturnType<typeof vi.fn>
+    }
+    dispose: () => void
+  } {
+    const listeners = new Map<string, EventListener>()
+    const input = vi.fn()
+    const writeClipboardText = vi.fn(() => Promise.resolve())
+    const pane = {
+      id: 1,
+      leafId: 'leaf-1',
+      terminal: {
+        getSelection: vi.fn(() => options.selection),
+        clearSelection: vi.fn(),
+        input,
+        modes: { mouseTrackingMode: options.mouseTrackingMode }
+      }
+    }
+    const manager = {
+      getActivePane: vi.fn(() => pane),
+      getPanes: vi.fn(() => [pane])
+    }
+
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Macintosh)' })
+    vi.stubGlobal('HTMLElement', class HTMLElement {})
+    vi.stubGlobal('window', {
+      navigator: globalThis.navigator,
+      api: { ui: { writeTerminalClipboardText: writeClipboardText } },
+      addEventListener: (type: string, listener: EventListener) => listeners.set(type, listener),
+      removeEventListener: (type: string) => listeners.delete(type)
+    })
+
+    let disposeEffect: (() => void) | undefined
+    vi.mocked(useEffect).mockImplementation((effect) => {
+      disposeEffect = effect() as (() => void) | undefined
+    })
+    CopyShortcutHarness({
+      tabId: 'tab-1',
+      worktreeId: 'worktree-1',
+      isActive: true,
+      keyboardScopeRef: { current: null },
+      managerRef: { current: manager } as never,
+      paneTransportsRef: { current: new Map() },
+      panePtyBindingsRef: { current: new Map() },
+      paneCwdRef: { current: new Map() },
+      fallbackCwd: '/workspace',
+      expandedPaneIdRef: { current: null },
+      setExpandedPane: vi.fn(),
+      restoreExpandedLayout: vi.fn(),
+      refreshPaneSizes: vi.fn(),
+      persistLayoutSnapshot: vi.fn(),
+      toggleExpandPane: vi.fn(),
+      setSearchOpen: vi.fn(),
+      onSearchSelectedText: vi.fn(),
+      onRequestClosePane: vi.fn(),
+      onClearPaneScrollback: vi.fn(),
+      onSetTitle: vi.fn(),
+      onClearPaneTitle: vi.fn(),
+      searchOpenRef: { current: false },
+      searchStateRef: { current: { query: '', caseSensitive: false, regex: false } },
+      macOptionAsAltRef: { current: 'false' },
+      keybindings: options.keybindings
+    })
+
+    const event = {
+      key: 'c',
+      code: 'KeyC',
+      metaKey: true,
+      ctrlKey: false,
+      altKey: options.altKey ?? false,
+      shiftKey: options.shiftKey ?? false,
+      repeat: options.repeat ?? false,
+      target: null,
+      preventDefault: vi.fn(),
+      stopImmediatePropagation: vi.fn()
+    }
+    const onKeyDown = listeners.get('keydown')
+    expect(onKeyDown).toBeDefined()
+    onKeyDown?.(event as unknown as Event)
+
+    return {
+      input,
+      writeClipboardText,
+      event,
+      dispose: () => {
+        disposeEffect?.()
+      }
+    }
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('forwards an empty selection from the configured terminal copy chord to a mouse-capturing TUI', () => {
+    const harness = installCopyShortcutHarness({
+      selection: '',
+      mouseTrackingMode: 'any',
+      altKey: true,
+      keybindings: { 'terminal.copySelection': ['Mod+Alt+C'] }
+    })
+
+    expect(harness.input).toHaveBeenCalledWith('\x03')
+    expect(harness.writeClipboardText).not.toHaveBeenCalled()
+    expect(harness.event.preventDefault).toHaveBeenCalledOnce()
+    expect(harness.event.stopImmediatePropagation).toHaveBeenCalledOnce()
+    harness.dispose()
+  })
+
+  it('forwards macOS Cmd+C from an empty mouse-capturing TUI selection', () => {
+    const harness = installCopyShortcutHarness({ selection: '', mouseTrackingMode: 'any' })
+
+    expect(harness.input).toHaveBeenCalledWith('\x03')
+    expect(harness.writeClipboardText).not.toHaveBeenCalled()
+    expect(harness.event.preventDefault).toHaveBeenCalledOnce()
+    expect(harness.event.stopImmediatePropagation).toHaveBeenCalledOnce()
+    harness.dispose()
+  })
+
+  it('ignores repeated macOS Cmd+C from a mouse-capturing TUI selection', () => {
+    const harness = installCopyShortcutHarness({
+      selection: '',
+      mouseTrackingMode: 'any',
+      repeat: true
+    })
+
+    expect(harness.input).not.toHaveBeenCalled()
+    expect(harness.writeClipboardText).not.toHaveBeenCalled()
+    expect(harness.event.preventDefault).not.toHaveBeenCalled()
+    expect(harness.event.stopImmediatePropagation).not.toHaveBeenCalled()
+    harness.dispose()
+  })
+
+  it('copies a non-empty selection without forwarding ETX', () => {
+    const harness = installCopyShortcutHarness({
+      selection: 'selected',
+      mouseTrackingMode: 'any',
+      shiftKey: true
+    })
+
+    expect(harness.writeClipboardText).toHaveBeenCalledWith('selected')
+    expect(harness.input).not.toHaveBeenCalled()
+    expect(harness.event.preventDefault).toHaveBeenCalledOnce()
+    expect(harness.event.stopImmediatePropagation).toHaveBeenCalledOnce()
+    harness.dispose()
+  })
+
+  it('leaves an empty normal-shell selection unhandled', () => {
+    const harness = installCopyShortcutHarness({
+      selection: '',
+      mouseTrackingMode: 'none',
+      shiftKey: true
+    })
+
+    expect(harness.input).not.toHaveBeenCalled()
+    expect(harness.writeClipboardText).not.toHaveBeenCalled()
+    expect(harness.event.preventDefault).not.toHaveBeenCalled()
+    expect(harness.event.stopImmediatePropagation).not.toHaveBeenCalled()
+    harness.dispose()
   })
 })

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
@@ -4,10 +4,17 @@ import { useEffect } from 'react'
 import type * as React from 'react'
 import { FIND_QUERY_MAX_BYTES } from '@/lib/find-query-bounds'
 
+const { resetTerminalKeyboardProtocolAfterInterruptMock } = vi.hoisted(() => ({
+  resetTerminalKeyboardProtocolAfterInterruptMock: vi.fn()
+}))
+
 vi.mock('react', async (importOriginal) => {
   const actual = await importOriginal<typeof React>()
   return { ...actual, useEffect: vi.fn() }
 })
+vi.mock('./use-terminal-pane-lifecycle', () => ({
+  resetTerminalKeyboardProtocolAfterInterrupt: resetTerminalKeyboardProtocolAfterInterruptMock
+}))
 import {
   matchFileSearchShortcut,
   matchSearchNavigate,
@@ -342,6 +349,7 @@ describe('useTerminalKeyboardShortcuts copy selection', () => {
   }
 
   afterEach(() => {
+    resetTerminalKeyboardProtocolAfterInterruptMock.mockClear()
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
   })
@@ -355,6 +363,9 @@ describe('useTerminalKeyboardShortcuts copy selection', () => {
     })
 
     expect(harness.input).toHaveBeenCalledWith('\x03')
+    expect(resetTerminalKeyboardProtocolAfterInterruptMock).toHaveBeenCalledWith(
+      expect.objectContaining({ input: harness.input })
+    )
     expect(harness.writeClipboardText).not.toHaveBeenCalled()
     expect(harness.event.preventDefault).toHaveBeenCalledOnce()
     expect(harness.event.stopImmediatePropagation).toHaveBeenCalledOnce()

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -47,6 +47,7 @@ import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { resolveWindowsShiftEnterEncodingForPane } from './terminal-windows-shift-enter'
 import { resolveTerminalInputHostPlatform } from './terminal-input-host-platform'
 import { TERMINAL_INTERRUPT_INPUT } from './xterm-bypass-policy'
+import { resetTerminalKeyboardProtocolAfterInterrupt } from './use-terminal-pane-lifecycle'
 import {
   markTerminalFollowOutput,
   markTerminalPinnedViewport,
@@ -545,6 +546,7 @@ export function useTerminalKeyboardShortcuts({
         }
         // Why: xterm's input path preserves PTY accounting for TUI-owned copy.
         pane.terminal.input(TERMINAL_INTERRUPT_INPUT)
+        resetTerminalKeyboardProtocolAfterInterrupt(pane.terminal)
         e.preventDefault()
         e.stopImmediatePropagation()
         return

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -46,6 +46,7 @@ import { isLocalWindowsConptyPaneForCtrlArrow } from './terminal-ctrl-arrow-conp
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { resolveWindowsShiftEnterEncodingForPane } from './terminal-windows-shift-enter'
 import { resolveTerminalInputHostPlatform } from './terminal-input-host-platform'
+import { TERMINAL_INTERRUPT_INPUT } from './xterm-bypass-policy'
 import {
   markTerminalFollowOutput,
   markTerminalPinnedViewport,
@@ -512,6 +513,43 @@ export function useTerminalKeyboardShortcuts({
           }
         : e
       const action = resolveShortcutEvent(shortcutEvent)
+
+      const isMacNativeCopy =
+        isMac &&
+        !e.repeat &&
+        e.key.toLowerCase() === 'c' &&
+        e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey &&
+        !e.shiftKey
+
+      // Mouse-capturing TUIs own empty-selection copy; preserve verified clipboard writes.
+      if (action?.type === 'copySelection' || isMacNativeCopy) {
+        const pane = manager.getActivePane() ?? manager.getPanes()[0]
+        if (!pane) {
+          return
+        }
+        if (pane.terminal.getSelection()) {
+          e.preventDefault()
+          e.stopImmediatePropagation()
+          void copyTerminalSelection({
+            terminal: pane.terminal,
+            writeClipboardText: window.api.ui.writeTerminalClipboardText
+          }).catch(() => {
+            /* ignore clipboard write failures */
+          })
+          return
+        }
+        if (pane.terminal.modes.mouseTrackingMode === 'none') {
+          return
+        }
+        // Why: xterm's input path preserves PTY accounting for TUI-owned copy.
+        pane.terminal.input(TERMINAL_INTERRUPT_INPUT)
+        e.preventDefault()
+        e.stopImmediatePropagation()
+        return
+      }
+
       if (!action) {
         return
       }
@@ -547,27 +585,6 @@ export function useTerminalKeyboardShortcuts({
       }
 
       if (e.repeat) {
-        return
-      }
-
-      // Cmd/Ctrl+Shift+C copies terminal selection via Electron clipboard.
-      // This ensures Linux terminal copy works consistently.
-      if (action.type === 'copySelection') {
-        const pane = manager.getActivePane() ?? manager.getPanes()[0]
-        if (!pane) {
-          return
-        }
-        if (!pane.terminal.getSelection()) {
-          return
-        }
-        e.preventDefault()
-        e.stopImmediatePropagation()
-        void copyTerminalSelection({
-          terminal: pane.terminal,
-          writeClipboardText: window.api.ui.writeTerminalClipboardText
-        }).catch(() => {
-          /* ignore clipboard write failures */
-        })
         return
       }
 

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -525,7 +525,7 @@ export function useTerminalKeyboardShortcuts({
         !e.shiftKey
 
       // Mouse-capturing TUIs own empty-selection copy; preserve verified clipboard writes.
-      if (action?.type === 'copySelection' || isMacNativeCopy) {
+      if (action?.type === 'copySelection' || (isMacNativeCopy && !action)) {
         const pane = manager.getActivePane() ?? manager.getPanes()[0]
         if (!pane) {
           return


### PR DESCRIPTION
## Summary

- Preserve normal copy behavior when xterm has a non-empty selection.
- When selection is empty and mouse tracking identifies a TUI, forward ETX (`Ctrl+C`) to the terminal instead of swallowing the shortcut.
- Keep empty-selection shell behavior unchanged and reset kitty keyboard protocol state after forwarding.

Fixes #9727

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused verification passed: 157 terminal-pane keyboard-handler tests, changed-file oxlint/format/max-lines checks, and `pnpm run build:desktop`.

The full `pnpm lint` command is currently blocked by the existing `src/renderer/src/components/skills/skill-freshness-group.ts:101` switch-exhaustiveness error on `origin/main`. The full repository test command was not run; the shortcut state matrix is covered by the focused suite.

## AI Review Report

An independent AI review initially identified a missing kitty keyboard-protocol reset after forwarding the shortcut. A RED regression was added, the reset was implemented, and the final review returned spec-compliance `PASS` and code-quality `APPROVED` with no remaining findings.

The review explicitly checked macOS `Cmd+C`, Linux/Windows `Ctrl+C`, configured copy actions, selection/no-selection behavior, mouse-tracking TUI detection, and kitty-protocol state. No labels, paths, shell construction, or Electron main-process behavior changed.

## Security Audit

Reviewed keyboard-event routing and terminal-input boundaries. The change forwards a fixed ETX byte only after the existing copy action and TUI signal match; it does not interpolate input, execute a shell command, touch paths, alter auth/secrets, add dependencies, or change IPC payload shape.

## Notes

A real macOS Claude Code/OpenCode UI smoke was not run because launching a second development Orca instance while live PTYs exist risks session continuity. The deterministic handler tests cover the affected state matrix; maintainers may still want an interactive smoke before release.



## ELI5

In mouse-tracking TUIs, Ctrl+C with no selection was swallowed and never reached the app. Empty-selection copy now forwards interrupt to the TUI; normal copy with a selection is unchanged.
