### PR TITLE
fix(terminal): reap Windows agent trees with Job Objects

### DIFF
--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -1,5 +1,5 @@
 diff --git a/binding.gyp b/binding.gyp
-index 5f63978b07ab50aaf7523219a2170ec737a6b5db..bbd9e06136e8922f40b5779e35d4fc835f1479ab 100644
+index 5f63978b07ab50aaf7523219a2170ec737a6b5db..b3309a07ef99dea7967d7bdd04b9fc3500acacae 100644
 --- a/binding.gyp
 +++ b/binding.gyp
 @@ -5,9 +5,6 @@
@@ -12,28 +12,11 @@ index 5f63978b07ab50aaf7523219a2170ec737a6b5db..bbd9e06136e8922f40b5779e35d4fc83
          'msvs_settings': {
              'VCCLCompilerTool': {
                'AdditionalOptions': [
-@@ -88,6 +85,16 @@
-               'libraries!': [
-                 '-lutil'
-               ]
-+            }],
-+            # Orca: pair with the .symver pins in pty.cc. Force the real
-+            # libutil.so.1/libpthread.so.0 into DT_NEEDED (gcc's default
-+            # --as-needed drops them because the pinned symbols resolve from
-+            # libc's compat aliases at build time) so openpty/forkpty/
-+            # pthread_sigmask still resolve on Ubuntu 20.04 (glibc 2.31).
-+            ['OS=="linux"', {
-+              'ldflags': [
-+                '-Wl,--no-as-needed,-l:libutil.so.1,-l:libpthread.so.0,--as-needed'
-+              ]
-             }]
-           ]
-         }
 diff --git a/deps/winpty/src/winpty.gyp b/deps/winpty/src/winpty.gyp
-index 1ac5758bedd8cf54f32280dea4e4aeb5afdee30d..e619813759c6f14694838bdfbd0ea5f8360130ef 100644
+index 1ac5758bedd8cf54f32280dea4e4aeb5afdee30d..4debd75854 100644
 --- a/deps/winpty/src/winpty.gyp
 +++ b/deps/winpty/src/winpty.gyp
-@@ -10,7 +10,7 @@
+@@ -10,9 +10,10 @@
      #    make -j4 CXX=i686-w64-mingw32-g++ LDFLAGS="-static -static-libgcc -static-libstdc++"
 
      'variables': {
@@ -41,8 +24,11 @@ index 1ac5758bedd8cf54f32280dea4e4aeb5afdee30d..e619813759c6f14694838bdfbd0ea5f8
 +        'WINPTY_COMMIT_HASH%': '<!(cmd /c "cd shared && .\\GetCommitHash.bat")',
      },
      'target_defaults' : {
++        # Why: target-level opt-outs below override node-gyp's addon defaults for these non-Node binaries.
          'defines' : [
-@@ -22,7 +22,7 @@
+             'UNICODE',
+             '_UNICODE',
+@@ -22,12 +23,13 @@
          'include_dirs': [
              # Add the 'src/gen' directory to the include path and force gyp to
              # run the script (re)generating the version header.
@@ -51,7 +37,13 @@ index 1ac5758bedd8cf54f32280dea4e4aeb5afdee30d..e619813759c6f14694838bdfbd0ea5f8
          ]
      },
      'targets' : [
-@@ -40,9 +40,6 @@
+         {
+             'target_name' : 'winpty-agent',
++            'win_delay_load_hook' : 'false',
+             'type' : 'executable',
+             'include_dirs' : [
+                 'include',
+@@ -40,9 +42,6 @@
                  '-lshell32',
                  '-luser32',
              ],
@@ -61,7 +53,15 @@ index 1ac5758bedd8cf54f32280dea4e4aeb5afdee30d..e619813759c6f14694838bdfbd0ea5f8
              'msvs_settings': {
                  # Specify this setting here to override a setting from somewhere
                  # else, such as node's common.gypi.
-@@ -142,9 +139,6 @@
+@@ -131,6 +130,7 @@
+         },
+         {
+             'target_name' : 'winpty',
++            'win_delay_load_hook' : 'false',
+             'type' : 'shared_library',
+             'include_dirs' : [
+                 'include',
+@@ -142,9 +142,6 @@
                  '-ladvapi32',
                  '-luser32',
              ],
@@ -71,27 +71,14 @@ index 1ac5758bedd8cf54f32280dea4e4aeb5afdee30d..e619813759c6f14694838bdfbd0ea5f8
              'msvs_settings': {
                  # Specify this setting here to override a setting from somewhere
                  # else, such as node's common.gypi.
-diff --git a/lib/conpty_console_list_agent.js b/lib/conpty_console_list_agent.js
-index 8c4fca9022a6d6f015bca87f61625cde2278f428..0a01730616488119aa21ef441cf3c441e02a974c 100644
---- a/lib/conpty_console_list_agent.js
-+++ b/lib/conpty_console_list_agent.js
-@@ -10,7 +10,14 @@ Object.defineProperty(exports, "__esModule", { value: true });
- var utils_1 = require("./utils");
- var getConsoleProcessList = utils_1.loadNativeModule('conpty_console_list').module.getConsoleProcessList;
- var shellPid = parseInt(process.argv[2], 10);
--var consoleProcessList = getConsoleProcessList(shellPid);
-+var consoleProcessList;
-+try {
-+    consoleProcessList = getConsoleProcessList(shellPid);
-+}
-+catch (_a) {
-+    // Why: AttachConsole can fail after the shell exits; parent already has this fallback.
-+    consoleProcessList = [shellPid];
-+}
- process.send({ consoleProcessList: consoleProcessList });
- process.exit(0);
- //# sourceMappingURL=conpty_console_list_agent.js.map
-\ No newline at end of file
+@@ -198,6 +195,7 @@
+         },
+         {
+             'target_name' : 'winpty-debugserver',
++            'win_delay_load_hook' : 'false',
+             'type' : 'executable',
+             'msvs_settings': {
+                 # Specify this setting here to override a setting from somewhere
 diff --git a/lib/unixTerminal.js b/lib/unixTerminal.js
 index 1ec12f796a822c78fba9ad7f6448c3987e325c23..cec8b67aef02f8199e5606a0d257088bf1865877 100644
 --- a/lib/unixTerminal.js
@@ -111,12 +98,31 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..cec8b67aef02f8199e5606a0d257088b
  var DEFAULT_FILE = 'sh';
  var DEFAULT_NAME = 'xterm';
  var DESTROY_SOCKET_TIMEOUT_MS = 200;
+diff --git a/lib/conpty_console_list_agent.js b/lib/conpty_console_list_agent.js
+index ccc111c9e03a4a661ccfd5d8e8f0ee699571b5dd..f92c6bef7d46dc35c941c87ef186aa46d8ed9c44 100644
+--- a/lib/conpty_console_list_agent.js
++++ b/lib/conpty_console_list_agent.js
+@@ -9,7 +9,14 @@ Object.defineProperty(exports, "__esModule", { value: true });
+ var utils_1 = require("./utils");
+ var getConsoleProcessList = utils_1.loadNativeModule('conpty_console_list').module.getConsoleProcessList;
+ var shellPid = parseInt(process.argv[2], 10);
+-var consoleProcessList = getConsoleProcessList(shellPid);
++var consoleProcessList;
++try {
++    consoleProcessList = getConsoleProcessList(shellPid);
++}
++catch (_a) {
++    // Why: AttachConsole can fail after the shell exits; parent already has this fallback.
++    consoleProcessList = [shellPid];
++}
+ process.send({ consoleProcessList: consoleProcessList });
+ process.exit(0);
+ //# sourceMappingURL=conpty_console_list_agent.js.map
 diff --git a/src/conpty_console_list_agent.ts b/src/conpty_console_list_agent.ts
-index 181ccabbbe9c4948a9725fb1db907a68e9de01fc..67f31facf85562b67adbfbd04ce28ddd8eeb4a79 100644
+index f6a653893e0b9b548c514db29d75599538ee1acb..1d5400489f200ef0161ca687e672e1cc02d29c95 100644
 --- a/src/conpty_console_list_agent.ts
 +++ b/src/conpty_console_list_agent.ts
-@@ -10,6 +10,12 @@ import { loadNativeModule } from './utils';
-
+@@ -11,5 +11,11 @@ import { loadNativeModule } from './utils';
  const getConsoleProcessList = loadNativeModule('conpty_console_list').module.getConsoleProcessList;
  const shellPid = parseInt(process.argv[2], 10);
 -const consoleProcessList = getConsoleProcessList(shellPid);
@@ -130,7 +136,7 @@ index 181ccabbbe9c4948a9725fb1db907a68e9de01fc..67f31facf85562b67adbfbd04ce28ddd
  process.send!({ consoleProcessList });
  process.exit(0);
 diff --git a/src/unix/pty.cc b/src/unix/pty.cc
-index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d15c4dd44 100644
+index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca850564e6368d9 100644
 --- a/src/unix/pty.cc
 +++ b/src/unix/pty.cc
 @@ -23,7 +23,9 @@
@@ -143,33 +149,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
  #include <thread>
 
  #include <sys/types.h>
-@@ -47,6 +49,25 @@
- #include <termios.h>
- #endif
-
-+/* Orca: glibc 2.32-2.34 relocated pthread_sigmask/openpty/forkpty into libc
-+ * under new symbol versions, so building on a newer glibc produces references
-+ * (GLIBC_2.32/2.34) absent on Ubuntu 20.04 (glibc 2.31) and the app fails to
-+ * launch. Pin these to the pre-merge version glibc still ships as a compat
-+ * alias; the binding.gyp ldflags force libutil/libpthread into DT_NEEDED so
-+ * those aliases are actually loaded on the target. */
-+#if defined(__linux__)
-+#  if defined(__x86_64__)
-+#    define ORCA_GLIBC_COMPAT_VERSION "GLIBC_2.2.5"
-+#  elif defined(__aarch64__)
-+#    define ORCA_GLIBC_COMPAT_VERSION "GLIBC_2.17"
-+#  endif
-+#  ifdef ORCA_GLIBC_COMPAT_VERSION
-+__asm__(".symver openpty,openpty@" ORCA_GLIBC_COMPAT_VERSION);
-+__asm__(".symver forkpty,forkpty@" ORCA_GLIBC_COMPAT_VERSION);
-+__asm__(".symver pthread_sigmask,pthread_sigmask@" ORCA_GLIBC_COMPAT_VERSION);
-+#  endif
-+#endif
-+
- /* Some platforms name VWERASE and VDISCARD differently */
- #if !defined(VWERASE) && defined(VWERSE)
- #define VWERASE	VWERSE
-@@ -237,13 +258,23 @@ pty_getproc(int, char *);
+@@ -237,13 +239,23 @@ pty_getproc(int, char *);
  #endif
 
  #if defined(__APPLE__) || defined(__OpenBSD__)
@@ -194,7 +174,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
  #endif
 
  struct DelBuf {
-@@ -367,10 +398,11 @@ Napi::Value PtyFork(const Napi::CallbackInfo& info) {
+@@ -367,10 +379,11 @@ Napi::Value PtyFork(const Napi::CallbackInfo& info) {
      argv[i + 3] = strdup(arg.c_str());
    }
 
@@ -210,7 +190,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
    }
    if (pty_nonblock(master) == -1) {
      throw Napi::Error::New(napiEnv, "Could not set master fd to nonblocking.");
-@@ -684,15 +716,73 @@ pty_getproc(int fd, char *tty) {
+@@ -684,15 +697,73 @@ pty_getproc(int fd, char *tty) {
  #endif
 
  #if defined(__APPLE__)
@@ -286,25 +266,25 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
 
    for (; count < 3; count++) {
      low_fds[count] = posix_openpt(O_RDWR);
-@@ -706,80 +796,118 @@ pty_posix_spawn(char** argv, char** env,
+@@ -706,80 +777,118 @@ pty_posix_spawn(char** argv, char** env,
                POSIX_SPAWN_SETSID;
    *master = posix_openpt(O_RDWR);
    if (*master == -1) {
 -    return;
 +    pty_set_spawn_error(err, "posix_openpt", errno);
 +    goto done;
++  }
++
++  res = grantpt(*master);
++  if (res == -1) {
++    pty_set_spawn_error(err, "grantpt", errno);
++    goto done;
    }
 
 -  int res = grantpt(*master) || unlockpt(*master);
-+  res = grantpt(*master);
++  res = unlockpt(*master);
    if (res == -1) {
 -    return;
-+    pty_set_spawn_error(err, "grantpt", errno);
-+    goto done;
-+  }
-+
-+  res = unlockpt(*master);
-+  if (res == -1) {
 +    pty_set_spawn_error(err, "unlockpt", errno);
 +    goto done;
    }

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -537,9 +537,9 @@ index 7b286d3d64..7434bcc994 100644
 +}
 +
 +static void close_job_handle(const std::shared_ptr<pty_baton>& baton) {
-+  HANDLE hJob = take_job_handle(baton);
-+  if (hJob != nullptr) {
-+    CloseHandle(hJob);
++  const HANDLE closedJobHandle = take_job_handle(baton);
++  if (closedJobHandle != nullptr) {
++    CloseHandle(closedJobHandle);
 +  }
 +}
 +
@@ -643,20 +643,20 @@ index 7b286d3d64..7434bcc994 100644
 +  }
 +  bool jobAssigned = false;
 +  if (useConptyJobObject) {
-+    HANDLE hJob = CreateJobObjectW(nullptr, nullptr);
-+    if (hJob != nullptr) {
++    const HANDLE createdJobHandle = CreateJobObjectW(nullptr, nullptr);
++    if (createdJobHandle != nullptr) {
 +      JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobInfo{};
 +      jobInfo.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
 +      if (SetInformationJobObject(
-+            hJob,
++            createdJobHandle,
 +            JobObjectExtendedLimitInformation,
 +            &jobInfo,
 +            sizeof(jobInfo)) &&
-+          AssignProcessToJobObject(hJob, piClient.hProcess)) {
-+        handle->hJob.store(hJob);
++          AssignProcessToJobObject(createdJobHandle, piClient.hProcess)) {
++        handle->hJob.store(createdJobHandle);
 +        jobAssigned = true;
 +      } else {
-+        CloseHandle(hJob);
++        CloseHandle(createdJobHandle);
 +      }
 +    }
 +
@@ -665,10 +665,10 @@ index 7b286d3d64..7434bcc994 100644
 +
 +    if (ResumeThread(piClient.hThread) == static_cast<DWORD>(-1)) {
 +      const DWORD resumeError = GetLastError();
-+      HANDLE hJob = take_job_handle(handle);
-+      if (hJob != nullptr) {
-+        TerminateJobObject(hJob, 1);
-+        CloseHandle(hJob);
++      const HANDLE resumeJobHandle = take_job_handle(handle);
++      if (resumeJobHandle != nullptr) {
++        TerminateJobObject(resumeJobHandle, 1);
++        CloseHandle(resumeJobHandle);
 +      } else {
 +        terminate_shell_process(handle);
 +      }
@@ -693,20 +693,21 @@ index 7b286d3d64..7434bcc994 100644
 @@ -516 +624 @@ static Napi::Value PtyClear(const Napi::CallbackInfo& info) {
 -  const pty_baton* handle = get_pty_baton(id);
 +  const std::shared_ptr<pty_baton> handle = get_pty_baton(id);
-@@ -547,3 +655,8 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+@@ -547,3 +655,9 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
 -  const pty_baton* handle = get_pty_baton(id);
 +  const std::shared_ptr<pty_baton> handle = get_pty_baton(id);
 
    if (handle != nullptr) {
-+    HANDLE hJob = take_job_handle(handle);
-+    if (hJob != nullptr) {
-+      TerminateJobObject(hJob, 1);
-+      CloseHandle(hJob);
++    const HANDLE killJobHandle = take_job_handle(handle);
++    const bool hadJobHandle = killJobHandle != nullptr;
++    if (hadJobHandle) {
++      TerminateJobObject(killJobHandle, 1);
++      CloseHandle(killJobHandle);
 +    }
-@@ -562,2 +675,4 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+@@ -562,2 +676,4 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
 -    if (useConptyDll) {
 -      TerminateProcess(handle->hShell, 1);
-+    if (hJob == nullptr &&
++    if (!hadJobHandle &&
 +        !handle->jobObjectAssigned &&
 +        (useConptyDll || handle->jobObjectSetupFailed)) {
 +      terminate_shell_process(handle);

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -1,5 +1,5 @@
 diff --git a/binding.gyp b/binding.gyp
-index 5f63978b07ab50aaf7523219a2170ec737a6b5db..b3309a07ef99dea7967d7bdd04b9fc3500acacae 100644
+index 5f63978..b3309a0 100644
 --- a/binding.gyp
 +++ b/binding.gyp
 @@ -5,9 +5,6 @@
@@ -13,12 +13,12 @@ index 5f63978b07ab50aaf7523219a2170ec737a6b5db..b3309a07ef99dea7967d7bdd04b9fc35
              'VCCLCompilerTool': {
                'AdditionalOptions': [
 diff --git a/deps/winpty/src/winpty.gyp b/deps/winpty/src/winpty.gyp
-index 1ac5758bedd8cf54f32280dea4e4aeb5afdee30d..4debd75854 100644
+index 1ac5758..4debd75 100644
 --- a/deps/winpty/src/winpty.gyp
 +++ b/deps/winpty/src/winpty.gyp
 @@ -10,9 +10,10 @@
      #    make -j4 CXX=i686-w64-mingw32-g++ LDFLAGS="-static -static-libgcc -static-libstdc++"
-
+ 
      'variables': {
 -        'WINPTY_COMMIT_HASH%': '<!(cmd /c "cd shared && GetCommitHash.bat")',
 +        'WINPTY_COMMIT_HASH%': '<!(cmd /c "cd shared && .\\GetCommitHash.bat")',
@@ -80,7 +80,7 @@ index 1ac5758bedd8cf54f32280dea4e4aeb5afdee30d..4debd75854 100644
              'msvs_settings': {
                  # Specify this setting here to override a setting from somewhere
 diff --git a/lib/unixTerminal.js b/lib/unixTerminal.js
-index 1ec12f796a822c78fba9ad7f6448c3987e325c23..cec8b67aef02f8199e5606a0d257088bf1865877 100644
+index 1ec12f7..cec8b67 100644
 --- a/lib/unixTerminal.js
 +++ b/lib/unixTerminal.js
 @@ -28,8 +28,12 @@ var native = utils_1.loadNativeModule('pty');
@@ -99,10 +99,10 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..cec8b67aef02f8199e5606a0d257088b
  var DEFAULT_NAME = 'xterm';
  var DESTROY_SOCKET_TIMEOUT_MS = 200;
 diff --git a/lib/conpty_console_list_agent.js b/lib/conpty_console_list_agent.js
-index ccc111c9e03a4a661ccfd5d8e8f0ee699571b5dd..f92c6bef7d46dc35c941c87ef186aa46d8ed9c44 100644
+index 8c4fca9..0a01730 100644
 --- a/lib/conpty_console_list_agent.js
 +++ b/lib/conpty_console_list_agent.js
-@@ -9,7 +9,14 @@ Object.defineProperty(exports, "__esModule", { value: true });
+@@ -10,7 +10,14 @@ Object.defineProperty(exports, "__esModule", { value: true });
  var utils_1 = require("./utils");
  var getConsoleProcessList = utils_1.loadNativeModule('conpty_console_list').module.getConsoleProcessList;
  var shellPid = parseInt(process.argv[2], 10);
@@ -118,11 +118,13 @@ index ccc111c9e03a4a661ccfd5d8e8f0ee699571b5dd..f92c6bef7d46dc35c941c87ef186aa46
  process.send({ consoleProcessList: consoleProcessList });
  process.exit(0);
  //# sourceMappingURL=conpty_console_list_agent.js.map
+\ No newline at end of file
 diff --git a/src/conpty_console_list_agent.ts b/src/conpty_console_list_agent.ts
-index f6a653893e0b9b548c514db29d75599538ee1acb..1d5400489f200ef0161ca687e672e1cc02d29c95 100644
+index 181ccab..67f31fa 100644
 --- a/src/conpty_console_list_agent.ts
 +++ b/src/conpty_console_list_agent.ts
-@@ -11,5 +11,11 @@ import { loadNativeModule } from './utils';
+@@ -10,6 +10,12 @@ import { loadNativeModule } from './utils';
+ 
  const getConsoleProcessList = loadNativeModule('conpty_console_list').module.getConsoleProcessList;
  const shellPid = parseInt(process.argv[2], 10);
 -const consoleProcessList = getConsoleProcessList(shellPid);
@@ -136,7 +138,7 @@ index f6a653893e0b9b548c514db29d75599538ee1acb..1d5400489f200ef0161ca687e672e1cc
  process.send!({ consoleProcessList });
  process.exit(0);
 diff --git a/src/unix/pty.cc b/src/unix/pty.cc
-index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca850564e6368d9 100644
+index 7b4b9e1..8edd6f5 100644
 --- a/src/unix/pty.cc
 +++ b/src/unix/pty.cc
 @@ -23,7 +23,9 @@
@@ -147,11 +149,11 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
  #include <unistd.h>
 +#include <string>
  #include <thread>
-
+ 
  #include <sys/types.h>
 @@ -237,13 +239,23 @@ pty_getproc(int, char *);
  #endif
-
+ 
  #if defined(__APPLE__) || defined(__OpenBSD__)
 +struct pty_spawn_error {
 +  const char* step;
@@ -172,12 +174,12 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 -                int* err);
 +                pty_spawn_error* err);
  #endif
-
+ 
  struct DelBuf {
 @@ -367,10 +379,11 @@ Napi::Value PtyFork(const Napi::CallbackInfo& info) {
      argv[i + 3] = strdup(arg.c_str());
    }
-
+ 
 -  int err = -1;
 -  pty_posix_spawn(argv, env, term, &winp, &master, &pid, &err);
 -  if (err != 0) {
@@ -190,10 +192,12 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
    }
    if (pty_nonblock(master) == -1) {
      throw Napi::Error::New(napiEnv, "Could not set master fd to nonblocking.");
-@@ -684,15 +697,73 @@ pty_getproc(int fd, char *tty) {
+@@ -683,6 +696,61 @@ pty_getproc(int fd, char *tty) {
+ 
  #endif
-
- #if defined(__APPLE__)
+ 
++#if defined(__APPLE__) || defined(__OpenBSD__)
++// Why: call sites are Apple/OpenBSD-only; keep helpers out of Linux builds (-Werror unused).
 +static const char*
 +pty_errno_name(int errnum) {
 +  switch (errnum) {
@@ -245,10 +249,12 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +
 +  return message;
 +}
++#endif
 +
+ #if defined(__APPLE__)
  static void
  pty_posix_spawn(char** argv, char** env,
-                 const struct termios *termp,
+@@ -690,9 +758,15 @@ pty_posix_spawn(char** argv, char** env,
                  const struct winsize *winp,
                  int* master,
                  pid_t* pid,
@@ -263,10 +269,10 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +  bool acts_initialized = false;
 +  posix_spawnattr_t attrs;
 +  bool attrs_initialized = false;
-
+ 
    for (; count < 3; count++) {
      low_fds[count] = posix_openpt(O_RDWR);
-@@ -706,80 +777,118 @@ pty_posix_spawn(char** argv, char** env,
+@@ -706,80 +780,118 @@ pty_posix_spawn(char** argv, char** env,
                POSIX_SPAWN_SETSID;
    *master = posix_openpt(O_RDWR);
    if (*master == -1) {
@@ -280,7 +286,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +    pty_set_spawn_error(err, "grantpt", errno);
 +    goto done;
    }
-
+ 
 -  int res = grantpt(*master) || unlockpt(*master);
 +  res = unlockpt(*master);
    if (res == -1) {
@@ -288,7 +294,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +    pty_set_spawn_error(err, "unlockpt", errno);
 +    goto done;
    }
-
+ 
    // Use TIOCPTYGNAME instead of ptsname() to avoid threading problems.
 -  int slave;
    char slave_pty_name[128];
@@ -298,14 +304,14 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +    pty_set_spawn_error(err, "ioctl_TIOCPTYGNAME", errno);
 +    goto done;
    }
-
+ 
    slave = open(slave_pty_name, O_RDWR | O_NOCTTY);
    if (slave == -1) {
 -    return;
 +    pty_set_spawn_error(err, "open_slave", errno, "slave", slave_pty_name);
 +    goto done;
    }
-
+ 
    if (termp) {
      res = tcsetattr(slave, TCSANOW, termp);
      if (res == -1) {
@@ -314,7 +320,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +      goto done;
      };
    }
-
+ 
    if (winp) {
      res = ioctl(slave, TIOCSWINSZ, winp);
      if (res == -1) {
@@ -323,7 +329,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +      goto done;
      }
    }
-
+ 
 -  posix_spawn_file_actions_t acts;
 -  posix_spawn_file_actions_init(&acts);
 +  res = posix_spawn_file_actions_init(&acts);
@@ -337,7 +343,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
    posix_spawn_file_actions_adddup2(&acts, slave, STDERR_FILENO);
    posix_spawn_file_actions_addclose(&acts, slave);
    posix_spawn_file_actions_addclose(&acts, *master);
-
+ 
 -  posix_spawnattr_t attrs;
 -  posix_spawnattr_init(&attrs);
 -  *err = posix_spawnattr_setflags(&attrs, flags);
@@ -353,7 +359,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +    pty_set_spawn_error(err, "posix_spawnattr_setflags", res);
      goto done;
    }
-
+ 
    sigset_t signal_set;
    /* Reset all signal the child to their default behavior */
    sigfillset(&signal_set);
@@ -364,7 +370,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +    pty_set_spawn_error(err, "posix_spawnattr_setsigdefault", res);
      goto done;
    }
-
+ 
    /* Reset the signal mask for all signals */
    sigemptyset(&signal_set);
 -  *err = posix_spawnattr_setsigmask(&attrs, &signal_set);
@@ -374,7 +380,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +    pty_set_spawn_error(err, "posix_spawnattr_setsigmask", res);
      goto done;
    }
-
+ 
    do
 -    *err = posix_spawn(pid, argv[0], &acts, &attrs, argv, env);
 -  while (*err == EINTR);
@@ -399,7 +405,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +    close(*master);
 +    *master = -1;
 +  }
-
+ 
 -  for (; count > 0; count--) {
 -    close(low_fds[count]);
 +  for (size_t i = 0; i <= count && i < 3; i++) {
@@ -410,20 +416,37 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
  }
  #endif
 diff --git a/lib/windowsPtyAgent.js b/lib/windowsPtyAgent.js
-index a358ffb177..8722bcd166 100644
+index a358ffb..246364a 100644
 --- a/lib/windowsPtyAgent.js
 +++ b/lib/windowsPtyAgent.js
-@@ -29 +29 @@ var WindowsPtyAgent = /** @class */ (function () {
+@@ -26,11 +26,13 @@ var FLUSH_DATA_INTERVAL = 1000;
+  * and winpty.
+  */
+ var WindowsPtyAgent = /** @class */ (function () {
 -    function WindowsPtyAgent(file, args, env, cwd, cols, rows, debug, _useConpty, _useConptyDll, conptyInheritCursor) {
 +    function WindowsPtyAgent(file, args, env, cwd, cols, rows, debug, _useConpty, _useConptyDll, _useConptyJobObject, conptyInheritCursor) {
-@@ -31,0 +32 @@ var WindowsPtyAgent = /** @class */ (function () {
+         var _this = this;
 +        if (_useConptyJobObject === void 0) { _useConptyJobObject = false; }
-@@ -34,0 +36 @@ var WindowsPtyAgent = /** @class */ (function () {
+         if (_useConptyDll === void 0) { _useConptyDll = false; }
+         if (conptyInheritCursor === void 0) { conptyInheritCursor = false; }
+         this._useConpty = _useConpty;
 +        this._useConptyJobObject = _useConptyJobObject;
-@@ -89 +91 @@ var WindowsPtyAgent = /** @class */ (function () {
+         this._useConptyDll = _useConptyDll;
+         this._pid = 0;
+         this._innerPid = 0;
+@@ -86,7 +88,7 @@ var WindowsPtyAgent = /** @class */ (function () {
+         });
+         this._inSocket.setEncoding('utf8');
+         if (this._useConpty) {
 -            var connect = this._ptyNative.connect(this._pty, commandLine, cwd, env, this._useConptyDll, function (c) { return _this._$onProcessExit(c); });
 +            var connect = this._ptyNative.connect(this._pty, commandLine, cwd, env, this._useConptyDll, this._useConptyJobObject, function (c) { return _this._$onProcessExit(c); });
-@@ -137 +139,14 @@ var WindowsPtyAgent = /** @class */ (function () {
+             this._innerPid = connect.pid;
+         }
+     }
+@@ -134,7 +136,20 @@ var WindowsPtyAgent = /** @class */ (function () {
+         var _this = this;
+         // Tell the agent to kill the pty, this releases handles to the process
+         if (this._useConpty) {
 -            if (!this._useConptyDll) {
 +            if (this._useConptyJobObject || this._useConptyDll) {
 +                // Close the input write handle to signal the end of session.
@@ -439,7 +462,13 @@ index a358ffb177..8722bcd166 100644
 +                }
 +            }
 +            else {
-@@ -153,8 +167,0 @@ var WindowsPtyAgent = /** @class */ (function () {
+                 this._inSocket.readable = false;
+                 this._outSocket.readable = false;
+                 this._getConsoleProcessList().then(function (consoleProcessList) {
+@@ -150,14 +165,6 @@ var WindowsPtyAgent = /** @class */ (function () {
+                 this._ptyNative.kill(this._pty, this._useConptyDll);
+                 this._conoutSocketWorker.dispose();
+             }
 -            else {
 -                // Close the input write handle to signal the end of session.
 -                this._inSocket.destroy();
@@ -448,61 +477,93 @@ index a358ffb177..8722bcd166 100644
 -                    _this._conoutSocketWorker.dispose();
 -                });
 -            }
-@@ -320 +327 @@ function xOr(arg1, arg2) {
--//# sourceMappingURL=windowsPtyAgent.js.map
-\ No newline at end of file
-+//# sourceMappingURL=windowsPtyAgent.js.map
+         }
+         else {
+             // Because pty.kill closes the handle, it will kill most processes by itself.
 diff --git a/lib/windowsTerminal.js b/lib/windowsTerminal.js
-index 3c38f89d14..2de1d0c7db 100644
+index 3c38f89..c1aef17 100644
 --- a/lib/windowsTerminal.js
 +++ b/lib/windowsTerminal.js
-@@ -51 +51 @@ var WindowsTerminal = /** @class */ (function (_super) {
+@@ -48,7 +48,7 @@ var WindowsTerminal = /** @class */ (function (_super) {
+         // Functions that need to run after `ready` event is emitted.
+         _this._deferreds = [];
+         // Create new termal.
 -        _this._agent = new windowsPtyAgent_1.WindowsPtyAgent(file, args, parsedEnv, cwd, _this._cols, _this._rows, false, opt.useConpty, opt.useConptyDll, opt.conptyInheritCursor);
 +        _this._agent = new windowsPtyAgent_1.WindowsPtyAgent(file, args, parsedEnv, cwd, _this._cols, _this._rows, false, opt.useConpty, opt.useConptyDll, opt.useConptyJobObject, opt.conptyInheritCursor);
-@@ -199 +199 @@ exports.WindowsTerminal = WindowsTerminal;
--//# sourceMappingURL=windowsTerminal.js.map
-\ No newline at end of file
-+//# sourceMappingURL=windowsTerminal.js.map
+         _this._socket = _this._agent.outSocket;
+         // Not available until `ready` event emitted.
+         _this._pid = _this._agent.innerPid;
 diff --git a/src/interfaces.ts b/src/interfaces.ts
-index a269e77bd2..8b45c785a0 100644
+index a269e77..992be6c 100644
 --- a/src/interfaces.ts
 +++ b/src/interfaces.ts
-@@ -122,0 +123 @@ export interface IWindowsPtyForkOptions extends IBasePtyForkOptions {
+@@ -119,6 +119,7 @@ export interface IPtyForkOptions extends IBasePtyForkOptions {
+ 
+ export interface IWindowsPtyForkOptions extends IBasePtyForkOptions {
+   useConpty?: boolean;
 +  useConptyJobObject?: boolean;
+   useConptyDll?: boolean;
+   conptyInheritCursor?: boolean;
+ }
 diff --git a/src/native.d.ts b/src/native.d.ts
-index c53e086b49..71f493040d 100644
+index c53e086..71f4930 100644
 --- a/src/native.d.ts
 +++ b/src/native.d.ts
-@@ -7 +7 @@ interface IConptyNative {
+@@ -4,7 +4,7 @@
+ 
+ interface IConptyNative {
+   startProcess(file: string, cols: number, rows: number, debug: boolean, pipeName: string, conptyInheritCursor: boolean, useConptyDll: boolean): IConptyProcess;
 -  connect(ptyId: number, commandLine: string, cwd: string, env: string[], useConptyDll: boolean, onExitCallback: (exitCode: number) => void): { pid: number };
 +  connect(ptyId: number, commandLine: string, cwd: string, env: string[], useConptyDll: boolean, useConptyJobObject: boolean, onExitCallback: (exitCode: number) => void): { pid: number; jobAssigned: boolean };
+   resize(ptyId: number, cols: number, rows: number, useConptyDll: boolean): void;
+   clear(ptyId: number, useConptyDll: boolean): void;
+   kill(ptyId: number, useConptyDll: boolean): void;
 diff --git a/src/win/conpty.cc b/src/win/conpty.cc
-index 7b286d3d64..7434bcc994 100644
+index 7b286d3..1bb7c74 100644
 --- a/src/win/conpty.cc
 +++ b/src/win/conpty.cc
-@@ -16,0 +17,3 @@
+@@ -13,6 +13,9 @@
+ #define NODE_ADDON_API_DISABLE_DEPRECATED
+ #include <node_api.h>
+ #include <assert.h>
 +#include <atomic>
 +#include <memory>
 +#include <mutex>
-@@ -47 +50,5 @@ struct pty_baton {
+ #include <Shlwapi.h> // PathCombine, PathIsRelative
+ #include <sstream>
+ #include <iostream>
+@@ -44,40 +47,89 @@ struct pty_baton {
+   HANDLE hOut;
+   HPCON hpc;
+ 
 -  HANDLE hShell;
 +  std::mutex hShellMutex;
 +  HANDLE hShell = nullptr;
 +  std::atomic<HANDLE> hJob{nullptr};
 +  bool jobObjectAssigned = false;
 +  bool jobObjectSetupFailed = false;
-@@ -52 +59,2 @@ struct pty_baton {
+ 
+   pty_baton(int _id, HANDLE _hIn, HANDLE _hOut, HPCON _hpc) : id(_id), hIn(_hIn), hOut(_hOut), hpc(_hpc) {};
+ };
+ 
 -static std::vector<std::unique_ptr<pty_baton>> ptyHandles;
 +static std::vector<std::shared_ptr<pty_baton>> ptyHandles;
 +static std::mutex ptyHandlesMutex;
-@@ -55 +63,2 @@ static volatile LONG ptyCounter;
+ static volatile LONG ptyCounter;
+ 
 -static pty_baton* get_pty_baton(int id) {
 +static std::shared_ptr<pty_baton> get_pty_baton(int id) {
 +  std::lock_guard<std::mutex> lock(ptyHandlesMutex);
-@@ -60 +69 @@ static pty_baton* get_pty_baton(int id) {
+   auto it = std::find_if(ptyHandles.begin(), ptyHandles.end(), [id](const auto& ptyHandle) {
+     return ptyHandle->id == id;
+   });
+   if (it != ptyHandles.end()) {
 -    return it->get();
 +    return *it;
-@@ -65,6 +75,7 @@ static bool remove_pty_baton(int id) {
+   }
+   return nullptr;
+ }
+ 
  static bool remove_pty_baton(int id) {
 +  std::lock_guard<std::mutex> lock(ptyHandlesMutex);
    auto it = std::remove_if(ptyHandles.begin(), ptyHandles.end(), [id](const auto& ptyHandle) {
@@ -511,7 +572,10 @@ index 7b286d3d64..7434bcc994 100644
    if (it != ptyHandles.end()) {
 -    ptyHandles.erase(it);
 +    ptyHandles.erase(it, ptyHandles.end());
-@@ -75,0 +86,42 @@ static bool remove_pty_baton(int id) {
+     return true;
+   }
+   return false;
+ }
 +static HANDLE take_job_handle(const std::shared_ptr<pty_baton>& baton) {
 +  return baton->hJob.exchange(nullptr);
 +}
@@ -554,13 +618,21 @@ index 7b286d3d64..7434bcc994 100644
 +  }
 +}
 +
-@@ -77 +129 @@ struct ExitEvent {
+ 
+ struct ExitEvent {
 -  int exit_code = 0;
 +  DWORD exit_code = 0;
-@@ -80 +132 @@ struct ExitEvent {
+ };
+ 
 -void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
 +void SetupExitCallback(Napi::Env env, Napi::Function cb, std::shared_ptr<pty_baton> baton) {
-@@ -101,6 +153,10 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
+   std::thread *th = new std::thread;
+   // Don't use Napi::AsyncWorker which is limited by UV_THREADPOOL_SIZE.
+   auto tsfn = Napi::ThreadSafeFunction::New(
+@@ -98,12 +150,16 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
+ 
+     ExitEvent *exit_event = new ExitEvent;
+     // Wait for process to complete.
 -    WaitForSingleObject(baton->hShell, INFINITE);
 -    // Get process exit code.
 -    GetExitCodeProcess(baton->hShell, (LPDWORD)(&exit_event->exit_code));
@@ -577,18 +649,32 @@ index 7b286d3d64..7434bcc994 100644
 +    const bool removed = remove_pty_baton(baton->id);
 +    assert(removed);
 +    (void)removed;
-@@ -128 +184 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
+ 
+     auto status = tsfn.BlockingCall(exit_event, callback); // In main thread
+     switch (status) {
+@@ -125,12 +181,16 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
+   });
+ }
+ 
 -Napi::Error errorWithCode(const Napi::CallbackInfo& info, const char* text) {
 +Napi::Error errorWithCode(const Napi::CallbackInfo& info, const char* text, DWORD errorCode) {
-@@ -131 +187 @@ Napi::Error errorWithCode(const Napi::CallbackInfo& info, const char* text) {
+   std::stringstream errorText;
+   errorText << text;
 -  errorText << ", error code: " << GetLastError();
 +  errorText << ", error code: " << errorCode;
-@@ -134,0 +191,4 @@ Napi::Error errorWithCode(const Napi::CallbackInfo& info, const char* text) {
+   return Napi::Error::New(info.Env(), errorText.str());
+ }
 +Napi::Error errorWithCode(const Napi::CallbackInfo& info, const char* text) {
 +  return errorWithCode(info, text, GetLastError());
 +}
 +
-@@ -304,2 +364,5 @@ static Napi::Value PtyStartProcess(const Napi::CallbackInfo& info) {
+ 
+ // Returns a new server named pipe.  It has not yet been connected.
+ bool createDataServerPipe(bool write,
+@@ -301,8 +361,11 @@ static Napi::Value PtyStartProcess(const Napi::CallbackInfo& info) {
+     // We were able to instantiate a conpty
+     const int ptyId = InterlockedIncrement(&ptyCounter);
+     marshal.Set("pty", Napi::Number::New(env, ptyId));
 -    ptyHandles.emplace_back(
 -        std::make_unique<pty_baton>(ptyId, hIn, hOut, hpc));
 +    {
@@ -596,27 +682,56 @@ index 7b286d3d64..7434bcc994 100644
 +      ptyHandles.emplace_back(
 +          std::make_shared<pty_baton>(ptyId, hIn, hOut, hpc));
 +    }
-@@ -336 +399 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+   } else {
+     throw Napi::Error::New(env, "Cannot launch conpty");
+   }
+@@ -333,14 +396,15 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+   std::stringstream errorText;
+   BOOL fSuccess = FALSE;
+ 
 -  if (info.Length() != 6 ||
 +  if (info.Length() != 7 ||
-@@ -342,2 +405,3 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+       !info[0].IsNumber() ||
+       !info[1].IsString() ||
+       !info[2].IsString() ||
+       !info[3].IsArray() ||
+       !info[4].IsBoolean() ||
 -      !info[5].IsFunction()) {
 -    throw Napi::Error::New(env, "Usage: pty.connect(id, cmdline, cwd, env, useConptyDll, exitCallback)");
 +      !info[5].IsBoolean() ||
 +      !info[6].IsFunction()) {
 +    throw Napi::Error::New(env, "Usage: pty.connect(id, cmdline, cwd, env, useConptyDll, useConptyJobObject, exitCallback)");
-@@ -351 +415,2 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+   }
+ 
+   const int id = info[0].As<Napi::Number>().Int32Value();
+@@ -348,10 +412,11 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+   const std::wstring cwd(path_util::to_wstring(info[2].As<Napi::String>()));
+   const Napi::Array envValues = info[3].As<Napi::Array>();
+   const bool useConptyDll = info[4].As<Napi::Boolean>().Value();
 -  Napi::Function exitCallback = info[5].As<Napi::Function>();
 +  const bool useConptyJobObject = info[5].As<Napi::Boolean>().Value();
 +  Napi::Function exitCallback = info[6].As<Napi::Function>();
-@@ -354 +419 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+ 
+   // Fetch pty handle from ID and start process
 -  pty_baton* handle = get_pty_baton(id);
 +  std::shared_ptr<pty_baton> handle = get_pty_baton(id);
-@@ -419 +484,2 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+   if (!handle) {
+     throw Napi::Error::New(env, "Invalid pty handle");
+   }
+@@ -416,7 +481,8 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+       nullptr,                      // lpProcessAttributes
+       nullptr,                      // lpThreadAttributes
+       false,                        // bInheritHandles VERY IMPORTANT that this is false
 -      EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT, // dwCreationFlags
 +      EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT |
 +        (useConptyJobObject ? CREATE_SUSPENDED : 0), // dwCreationFlags
-@@ -428,0 +495,44 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+       envArg,                       // lpEnvironment
+       mutableCwd.get(),             // lpCurrentDirectory
+       &siEx.StartupInfo,            // lpStartupInfo
+@@ -425,6 +491,51 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+   if (!fSuccess) {
+     throw errorWithCode(info, "Cannot create process");
+   }
 +  {
 +    std::lock_guard<std::mutex> lock(handle->hShellMutex);
 +    handle->hShell = piClient.hProcess;
@@ -662,22 +777,52 @@ index 7b286d3d64..7434bcc994 100644
 +    CloseHandle(piClient.hThread);
 +  }
 +
-@@ -441,3 +550,0 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+ 
+   HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
+   bool fLoadedDll = hLibrary != nullptr;
+@@ -438,9 +549,6 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+     }
+   }
+ 
 -  // Update handle
 -  handle->hShell = piClient.hProcess;
 -
-@@ -454,0 +562 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+   // Close the thread handle to avoid resource leak
+   CloseHandle(piClient.hThread);
+   // Close the input read and output write handle of the pseudoconsole
+@@ -451,6 +559,7 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+ 
+   // Return
+   auto marshal = Napi::Object::New(env);
 +  marshal.Set("jobAssigned", Napi::Boolean::New(env, jobAssigned));
-@@ -475 +583 @@ static Napi::Value PtyResize(const Napi::CallbackInfo& info) {
+   marshal.Set("pid", Napi::Number::New(env, piClient.dwProcessId));
+   return marshal;
+ }
+@@ -472,7 +581,7 @@ static Napi::Value PtyResize(const Napi::CallbackInfo& info) {
+   SHORT rows = static_cast<SHORT>(info[2].As<Napi::Number>().Uint32Value());
+   const bool useConptyDll = info[3].As<Napi::Boolean>().Value();
+ 
 -  const pty_baton* handle = get_pty_baton(id);
 +  const std::shared_ptr<pty_baton> handle = get_pty_baton(id);
-@@ -516 +624 @@ static Napi::Value PtyClear(const Napi::CallbackInfo& info) {
+ 
+   if (handle != nullptr) {
+     HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
+@@ -513,7 +622,7 @@ static Napi::Value PtyClear(const Napi::CallbackInfo& info) {
+     return env.Undefined();
+   }
+ 
 -  const pty_baton* handle = get_pty_baton(id);
 +  const std::shared_ptr<pty_baton> handle = get_pty_baton(id);
-@@ -547,3 +655,9 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+ 
+   if (handle != nullptr) {
+     HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
+@@ -544,9 +653,15 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+   int id = info[0].As<Napi::Number>().Int32Value();
+   const bool useConptyDll = info[1].As<Napi::Boolean>().Value();
+ 
 -  const pty_baton* handle = get_pty_baton(id);
 +  const std::shared_ptr<pty_baton> handle = get_pty_baton(id);
-
+ 
    if (handle != nullptr) {
 +    const HANDLE killJobHandle = take_job_handle(handle);
 +    const bool hadJobHandle = killJobHandle != nullptr;
@@ -685,23 +830,47 @@ index 7b286d3d64..7434bcc994 100644
 +      TerminateJobObject(killJobHandle, 1);
 +      CloseHandle(killJobHandle);
 +    }
-@@ -562,2 +676,4 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+     HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
+     bool fLoadedDll = hLibrary != nullptr;
+     if (fLoadedDll)
+@@ -559,8 +674,10 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+         pfnClosePseudoConsole(handle->hpc);
+       }
+     }
 -    if (useConptyDll) {
 -      TerminateProcess(handle->hShell, 1);
 +    if (!hadJobHandle &&
 +        !handle->jobObjectAssigned &&
 +        (useConptyDll || handle->jobObjectSetupFailed)) {
 +      terminate_shell_process(handle);
+     }
+   }
+ 
 diff --git a/src/windowsPtyAgent.ts b/src/windowsPtyAgent.ts
-index d705444951..0d4fbdd5e5 100644
+index d705444..592a976 100644
 --- a/src/windowsPtyAgent.ts
 +++ b/src/windowsPtyAgent.ts
-@@ -58,0 +59 @@ export class WindowsPtyAgent {
+@@ -55,6 +55,7 @@ export class WindowsPtyAgent {
+     rows: number,
+     debug: boolean,
+     private _useConpty: boolean | undefined,
 +    private _useConptyJobObject: boolean = false,
-@@ -119 +120 @@ export class WindowsPtyAgent {
+     private _useConptyDll: boolean = false,
+     conptyInheritCursor: boolean = false
+   ) {
+@@ -116,7 +117,7 @@ export class WindowsPtyAgent {
+     this._inSocket.setEncoding('utf8');
+ 
+     if (this._useConpty) {
 -      const connect = (this._ptyNative as IConptyNative).connect(this._pty, commandLine, cwd, env, this._useConptyDll, c => this._$onProcessExit(c));
 +      const connect = (this._ptyNative as IConptyNative).connect(this._pty, commandLine, cwd, env, this._useConptyDll, this._useConptyJobObject, c => this._$onProcessExit(c));
-@@ -144 +145,12 @@ export class WindowsPtyAgent {
+       this._innerPid = connect.pid;
+     }
+   }
+@@ -141,7 +142,18 @@ export class WindowsPtyAgent {
+   public kill(): void {
+     // Tell the agent to kill the pty, this releases handles to the process
+     if (this._useConpty) {
 -      if (!this._useConptyDll) {
 +      if (this._useConptyJobObject || this._useConptyDll) {
 +        // Close the input write handle to signal the end of session.
@@ -715,7 +884,13 @@ index d705444951..0d4fbdd5e5 100644
 +          this._conoutSocketWorker.dispose();
 +        }
 +      } else {
-@@ -158,7 +169,0 @@ export class WindowsPtyAgent {
+         this._inSocket.readable = false;
+         this._outSocket.readable = false;
+         this._getConsoleProcessList().then(consoleProcessList => {
+@@ -155,13 +167,6 @@ export class WindowsPtyAgent {
+         });
+         (this._ptyNative as IConptyNative).kill(this._pty, this._useConptyDll);
+         this._conoutSocketWorker.dispose();
 -      } else {
 -        // Close the input write handle to signal the end of session.
 -        this._inSocket.destroy();
@@ -723,18 +898,30 @@ index d705444951..0d4fbdd5e5 100644
 -        this._outSocket.on('data', () => {
 -          this._conoutSocketWorker.dispose();
 -        });
+       }
+     } else {
+       // Because pty.kill closes the handle, it will kill most processes by itself.
 diff --git a/src/windowsTerminal.ts b/src/windowsTerminal.ts
-index 13f6c6dbb3..03c2f3421f 100644
+index 13f6c6d..03c2f34 100644
 --- a/src/windowsTerminal.ts
 +++ b/src/windowsTerminal.ts
-@@ -51 +51 @@ export class WindowsTerminal extends Terminal {
+@@ -48,7 +48,7 @@ export class WindowsTerminal extends Terminal {
+     this._deferreds = [];
+ 
+     // Create new termal.
 -    this._agent = new WindowsPtyAgent(file, args, parsedEnv, cwd, this._cols, this._rows, false, opt.useConpty, opt.useConptyDll, opt.conptyInheritCursor);
 +    this._agent = new WindowsPtyAgent(file, args, parsedEnv, cwd, this._cols, this._rows, false, opt.useConpty, opt.useConptyDll, opt.useConptyJobObject, opt.conptyInheritCursor);
+     this._socket = this._agent.outSocket;
+ 
+     // Not available until `ready` event emitted.
 diff --git a/typings/node-pty.d.ts b/typings/node-pty.d.ts
-index 6f050ff1d9..0b28e5a667 100644
+index 6f050ff..5cdd497 100644
 --- a/typings/node-pty.d.ts
 +++ b/typings/node-pty.d.ts
-@@ -105,0 +106,8 @@ declare module 'node-pty' {
+@@ -102,6 +102,14 @@ declare module 'node-pty' {
+      * Windows. Defaults to false.
+      */
+     useConptyDll?: boolean;
 +    /**
 +     * (EXPERIMENTAL)
 +     *
@@ -743,3 +930,6 @@ index 6f050ff1d9..0b28e5a667 100644
 +     */
 +    useConptyJobObject?: boolean;
 +
+ 
+     /**
+      * Whether to use PSEUDOCONSOLE_INHERIT_CURSOR in conpty.

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -429,3 +429,330 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..383df0c9c48355547c65e6c9bbba593d
    }
  }
  #endif
+diff --git a/lib/windowsPtyAgent.js b/lib/windowsPtyAgent.js
+index a358ffb177..8722bcd166 100644
+--- a/lib/windowsPtyAgent.js
++++ b/lib/windowsPtyAgent.js
+@@ -29 +29 @@ var WindowsPtyAgent = /** @class */ (function () {
+-    function WindowsPtyAgent(file, args, env, cwd, cols, rows, debug, _useConpty, _useConptyDll, conptyInheritCursor) {
++    function WindowsPtyAgent(file, args, env, cwd, cols, rows, debug, _useConpty, _useConptyDll, _useConptyJobObject, conptyInheritCursor) {
+@@ -31,0 +32 @@ var WindowsPtyAgent = /** @class */ (function () {
++        if (_useConptyJobObject === void 0) { _useConptyJobObject = false; }
+@@ -34,0 +36 @@ var WindowsPtyAgent = /** @class */ (function () {
++        this._useConptyJobObject = _useConptyJobObject;
+@@ -89 +91 @@ var WindowsPtyAgent = /** @class */ (function () {
+-            var connect = this._ptyNative.connect(this._pty, commandLine, cwd, env, this._useConptyDll, function (c) { return _this._$onProcessExit(c); });
++            var connect = this._ptyNative.connect(this._pty, commandLine, cwd, env, this._useConptyDll, this._useConptyJobObject, function (c) { return _this._$onProcessExit(c); });
+@@ -137 +139,14 @@ var WindowsPtyAgent = /** @class */ (function () {
+-            if (!this._useConptyDll) {
++            if (this._useConptyJobObject || this._useConptyDll) {
++                // Close the input write handle to signal the end of session.
++                this._inSocket.destroy();
++                this._ptyNative.kill(this._pty, this._useConptyDll);
++                if (this._useConptyDll) {
++                    this._outSocket.on('data', function () {
++                        _this._conoutSocketWorker.dispose();
++                    });
++                }
++                else {
++                    this._conoutSocketWorker.dispose();
++                }
++            }
++            else {
+@@ -153,8 +167,0 @@ var WindowsPtyAgent = /** @class */ (function () {
+-            else {
+-                // Close the input write handle to signal the end of session.
+-                this._inSocket.destroy();
+-                this._ptyNative.kill(this._pty, this._useConptyDll);
+-                this._outSocket.on('data', function () {
+-                    _this._conoutSocketWorker.dispose();
+-                });
+-            }
+@@ -320 +327 @@ function xOr(arg1, arg2) {
+-//# sourceMappingURL=windowsPtyAgent.js.map
+\ No newline at end of file
++//# sourceMappingURL=windowsPtyAgent.js.map
+diff --git a/lib/windowsTerminal.js b/lib/windowsTerminal.js
+index 3c38f89d14..2de1d0c7db 100644
+--- a/lib/windowsTerminal.js
++++ b/lib/windowsTerminal.js
+@@ -51 +51 @@ var WindowsTerminal = /** @class */ (function (_super) {
+-        _this._agent = new windowsPtyAgent_1.WindowsPtyAgent(file, args, parsedEnv, cwd, _this._cols, _this._rows, false, opt.useConpty, opt.useConptyDll, opt.conptyInheritCursor);
++        _this._agent = new windowsPtyAgent_1.WindowsPtyAgent(file, args, parsedEnv, cwd, _this._cols, _this._rows, false, opt.useConpty, opt.useConptyDll, opt.useConptyJobObject, opt.conptyInheritCursor);
+@@ -199 +199 @@ exports.WindowsTerminal = WindowsTerminal;
+-//# sourceMappingURL=windowsTerminal.js.map
+\ No newline at end of file
++//# sourceMappingURL=windowsTerminal.js.map
+diff --git a/src/interfaces.ts b/src/interfaces.ts
+index a269e77bd2..8b45c785a0 100644
+--- a/src/interfaces.ts
++++ b/src/interfaces.ts
+@@ -122,0 +123 @@ export interface IWindowsPtyForkOptions extends IBasePtyForkOptions {
++  useConptyJobObject?: boolean;
+diff --git a/src/native.d.ts b/src/native.d.ts
+index c53e086b49..71f493040d 100644
+--- a/src/native.d.ts
++++ b/src/native.d.ts
+@@ -7 +7 @@ interface IConptyNative {
+-  connect(ptyId: number, commandLine: string, cwd: string, env: string[], useConptyDll: boolean, onExitCallback: (exitCode: number) => void): { pid: number };
++  connect(ptyId: number, commandLine: string, cwd: string, env: string[], useConptyDll: boolean, useConptyJobObject: boolean, onExitCallback: (exitCode: number) => void): { pid: number; jobAssigned: boolean };
+diff --git a/src/win/conpty.cc b/src/win/conpty.cc
+index 7b286d3d64..7434bcc994 100644
+--- a/src/win/conpty.cc
++++ b/src/win/conpty.cc
+@@ -16,0 +17,3 @@
++#include <atomic>
++#include <memory>
++#include <mutex>
+@@ -47 +50,5 @@ struct pty_baton {
+-  HANDLE hShell;
++  std::mutex hShellMutex;
++  HANDLE hShell = nullptr;
++  std::atomic<HANDLE> hJob{nullptr};
++  bool jobObjectAssigned = false;
++  bool jobObjectSetupFailed = false;
+@@ -52 +59,2 @@ struct pty_baton {
+-static std::vector<std::unique_ptr<pty_baton>> ptyHandles;
++static std::vector<std::shared_ptr<pty_baton>> ptyHandles;
++static std::mutex ptyHandlesMutex;
+@@ -55 +63,2 @@ static volatile LONG ptyCounter;
+-static pty_baton* get_pty_baton(int id) {
++static std::shared_ptr<pty_baton> get_pty_baton(int id) {
++  std::lock_guard<std::mutex> lock(ptyHandlesMutex);
+@@ -60 +69 @@ static pty_baton* get_pty_baton(int id) {
+-    return it->get();
++    return *it;
+@@ -65,0 +75 @@ static bool remove_pty_baton(int id) {
++  std::lock_guard<std::mutex> lock(ptyHandlesMutex);
+@@ -70 +80 @@ static bool remove_pty_baton(int id) {
+-    ptyHandles.erase(it);
++    ptyHandles.erase(it, ptyHandles.end());
+@@ -75,0 +86,42 @@ static bool remove_pty_baton(int id) {
++static HANDLE take_job_handle(const std::shared_ptr<pty_baton>& baton) {
++  return baton->hJob.exchange(nullptr);
++}
++
++static void close_job_handle(const std::shared_ptr<pty_baton>& baton) {
++  HANDLE hJob = take_job_handle(baton);
++  if (hJob != nullptr) {
++    CloseHandle(hJob);
++  }
++}
++
++static HANDLE get_shell_handle(const std::shared_ptr<pty_baton>& baton) {
++  std::lock_guard<std::mutex> lock(baton->hShellMutex);
++  return baton->hShell;
++}
++
++static void terminate_shell_process(const std::shared_ptr<pty_baton>& baton) {
++  std::lock_guard<std::mutex> lock(baton->hShellMutex);
++  if (baton->hShell != nullptr) {
++    TerminateProcess(baton->hShell, 1);
++  }
++}
++
++static void close_shell_handle(const std::shared_ptr<pty_baton>& baton) {
++  std::lock_guard<std::mutex> lock(baton->hShellMutex);
++  if (baton->hShell != nullptr) {
++    CloseHandle(baton->hShell);
++    baton->hShell = nullptr;
++  }
++}
++
++static void read_exit_code_and_close_shell_handle(
++    const std::shared_ptr<pty_baton>& baton,
++    DWORD* exitCode) {
++  std::lock_guard<std::mutex> lock(baton->hShellMutex);
++  if (baton->hShell != nullptr) {
++    GetExitCodeProcess(baton->hShell, exitCode);
++    CloseHandle(baton->hShell);
++    baton->hShell = nullptr;
++  }
++}
++
+@@ -77 +129 @@ struct ExitEvent {
+-  int exit_code = 0;
++  DWORD exit_code = 0;
+@@ -80 +132 @@ struct ExitEvent {
+-void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
++void SetupExitCallback(Napi::Env env, Napi::Function cb, std::shared_ptr<pty_baton> baton) {
+@@ -101,6 +153,10 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
+-    WaitForSingleObject(baton->hShell, INFINITE);
+-    // Get process exit code.
+-    GetExitCodeProcess(baton->hShell, (LPDWORD)(&exit_event->exit_code));
+-    // Clean up handles
+-    CloseHandle(baton->hShell);
+-    assert(remove_pty_baton(baton->id));
++    HANDLE hShell = get_shell_handle(baton);
++    if (hShell != nullptr) {
++      WaitForSingleObject(hShell, INFINITE);
++    }
++    // Closing the last kill-on-close Job Object handle also reaps surviving descendants.
++    close_job_handle(baton);
++    read_exit_code_and_close_shell_handle(baton, &exit_event->exit_code);
++    const bool removed = remove_pty_baton(baton->id);
++    assert(removed);
++    (void)removed;
+@@ -128 +184 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
+-Napi::Error errorWithCode(const Napi::CallbackInfo& info, const char* text) {
++Napi::Error errorWithCode(const Napi::CallbackInfo& info, const char* text, DWORD errorCode) {
+@@ -131 +187 @@ Napi::Error errorWithCode(const Napi::CallbackInfo& info, const char* text) {
+-  errorText << ", error code: " << GetLastError();
++  errorText << ", error code: " << errorCode;
+@@ -134,0 +191,4 @@ Napi::Error errorWithCode(const Napi::CallbackInfo& info, const char* text) {
++Napi::Error errorWithCode(const Napi::CallbackInfo& info, const char* text) {
++  return errorWithCode(info, text, GetLastError());
++}
++
+@@ -304,2 +364,5 @@ static Napi::Value PtyStartProcess(const Napi::CallbackInfo& info) {
+-    ptyHandles.emplace_back(
+-        std::make_unique<pty_baton>(ptyId, hIn, hOut, hpc));
++    {
++      std::lock_guard<std::mutex> lock(ptyHandlesMutex);
++      ptyHandles.emplace_back(
++          std::make_shared<pty_baton>(ptyId, hIn, hOut, hpc));
++    }
+@@ -336 +399 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+-  if (info.Length() != 6 ||
++  if (info.Length() != 7 ||
+@@ -342,2 +405,3 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+-      !info[5].IsFunction()) {
+-    throw Napi::Error::New(env, "Usage: pty.connect(id, cmdline, cwd, env, useConptyDll, exitCallback)");
++      !info[5].IsBoolean() ||
++      !info[6].IsFunction()) {
++    throw Napi::Error::New(env, "Usage: pty.connect(id, cmdline, cwd, env, useConptyDll, useConptyJobObject, exitCallback)");
+@@ -351 +415,2 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+-  Napi::Function exitCallback = info[5].As<Napi::Function>();
++  const bool useConptyJobObject = info[5].As<Napi::Boolean>().Value();
++  Napi::Function exitCallback = info[6].As<Napi::Function>();
+@@ -354 +419 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+-  pty_baton* handle = get_pty_baton(id);
++  std::shared_ptr<pty_baton> handle = get_pty_baton(id);
+@@ -419 +484,2 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+-      EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT, // dwCreationFlags
++      EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT |
++        (useConptyJobObject ? CREATE_SUSPENDED : 0), // dwCreationFlags
+@@ -428,0 +495,44 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
++  {
++    std::lock_guard<std::mutex> lock(handle->hShellMutex);
++    handle->hShell = piClient.hProcess;
++  }
++  bool jobAssigned = false;
++  if (useConptyJobObject) {
++    HANDLE hJob = CreateJobObjectW(nullptr, nullptr);
++    if (hJob != nullptr) {
++      JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobInfo{};
++      jobInfo.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
++      if (SetInformationJobObject(
++            hJob,
++            JobObjectExtendedLimitInformation,
++            &jobInfo,
++            sizeof(jobInfo)) &&
++          AssignProcessToJobObject(hJob, piClient.hProcess)) {
++        handle->hJob.store(hJob);
++        jobAssigned = true;
++      } else {
++        CloseHandle(hJob);
++      }
++    }
++
++    handle->jobObjectAssigned = jobAssigned;
++    handle->jobObjectSetupFailed = !jobAssigned;
++
++    if (ResumeThread(piClient.hThread) == static_cast<DWORD>(-1)) {
++      const DWORD resumeError = GetLastError();
++      HANDLE hJob = take_job_handle(handle);
++      if (hJob != nullptr) {
++        TerminateJobObject(hJob, 1);
++        CloseHandle(hJob);
++      } else {
++        terminate_shell_process(handle);
++      }
++      CloseHandle(piClient.hThread);
++      close_shell_handle(handle);
++      const bool removed = remove_pty_baton(handle->id);
++      assert(removed);
++      (void)removed;
++      throw errorWithCode(info, "Cannot resume process", resumeError);
++    }
++  }
++
+@@ -441,3 +550,0 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+-  // Update handle
+-  handle->hShell = piClient.hProcess;
+-
+@@ -454,0 +562 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
++  marshal.Set("jobAssigned", Napi::Boolean::New(env, jobAssigned));
+@@ -475 +583 @@ static Napi::Value PtyResize(const Napi::CallbackInfo& info) {
+-  const pty_baton* handle = get_pty_baton(id);
++  const std::shared_ptr<pty_baton> handle = get_pty_baton(id);
+@@ -516 +624 @@ static Napi::Value PtyClear(const Napi::CallbackInfo& info) {
+-  const pty_baton* handle = get_pty_baton(id);
++  const std::shared_ptr<pty_baton> handle = get_pty_baton(id);
+@@ -547 +655 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+-  const pty_baton* handle = get_pty_baton(id);
++  const std::shared_ptr<pty_baton> handle = get_pty_baton(id);
+@@ -549,0 +658,5 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
++    HANDLE hJob = take_job_handle(handle);
++    if (hJob != nullptr) {
++      TerminateJobObject(hJob, 1);
++      CloseHandle(hJob);
++    }
+@@ -562,2 +675,4 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+-    if (useConptyDll) {
+-      TerminateProcess(handle->hShell, 1);
++    if (hJob == nullptr &&
++        !handle->jobObjectAssigned &&
++        (useConptyDll || handle->jobObjectSetupFailed)) {
++      terminate_shell_process(handle);
+diff --git a/src/windowsPtyAgent.ts b/src/windowsPtyAgent.ts
+index d705444951..0d4fbdd5e5 100644
+--- a/src/windowsPtyAgent.ts
++++ b/src/windowsPtyAgent.ts
+@@ -58,0 +59 @@ export class WindowsPtyAgent {
++    private _useConptyJobObject: boolean = false,
+@@ -119 +120 @@ export class WindowsPtyAgent {
+-      const connect = (this._ptyNative as IConptyNative).connect(this._pty, commandLine, cwd, env, this._useConptyDll, c => this._$onProcessExit(c));
++      const connect = (this._ptyNative as IConptyNative).connect(this._pty, commandLine, cwd, env, this._useConptyDll, this._useConptyJobObject, c => this._$onProcessExit(c));
+@@ -144 +145,12 @@ export class WindowsPtyAgent {
+-      if (!this._useConptyDll) {
++      if (this._useConptyJobObject || this._useConptyDll) {
++        // Close the input write handle to signal the end of session.
++        this._inSocket.destroy();
++        (this._ptyNative as IConptyNative).kill(this._pty, this._useConptyDll);
++        if (this._useConptyDll) {
++          this._outSocket.on('data', () => {
++            this._conoutSocketWorker.dispose();
++          });
++        } else {
++          this._conoutSocketWorker.dispose();
++        }
++      } else {
+@@ -158,7 +169,0 @@ export class WindowsPtyAgent {
+-      } else {
+-        // Close the input write handle to signal the end of session.
+-        this._inSocket.destroy();
+-        (this._ptyNative as IConptyNative).kill(this._pty, this._useConptyDll);
+-        this._outSocket.on('data', () => {
+-          this._conoutSocketWorker.dispose();
+-        });
+diff --git a/src/windowsTerminal.ts b/src/windowsTerminal.ts
+index 13f6c6dbb3..03c2f3421f 100644
+--- a/src/windowsTerminal.ts
++++ b/src/windowsTerminal.ts
+@@ -51 +51 @@ export class WindowsTerminal extends Terminal {
+-    this._agent = new WindowsPtyAgent(file, args, parsedEnv, cwd, this._cols, this._rows, false, opt.useConpty, opt.useConptyDll, opt.conptyInheritCursor);
++    this._agent = new WindowsPtyAgent(file, args, parsedEnv, cwd, this._cols, this._rows, false, opt.useConpty, opt.useConptyDll, opt.useConptyJobObject, opt.conptyInheritCursor);
+diff --git a/typings/node-pty.d.ts b/typings/node-pty.d.ts
+index 6f050ff1d9..0b28e5a667 100644
+--- a/typings/node-pty.d.ts
++++ b/typings/node-pty.d.ts
+@@ -105,0 +106,8 @@ declare module 'node-pty' {
++    /**
++     * (EXPERIMENTAL)
++     *
++     * Whether to assign the suspended ConPTY child to a kill-on-close Windows Job Object before it runs.
++     * If Job Object setup is unavailable, kill falls back to terminating only the direct child.
++     */
++    useConptyJobObject?: boolean;
++

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -522,9 +522,13 @@ index 7b286d3d64..7434bcc994 100644
 @@ -60 +69 @@ static pty_baton* get_pty_baton(int id) {
 -    return it->get();
 +    return *it;
-@@ -65,0 +75 @@ static bool remove_pty_baton(int id) {
+@@ -65,6 +75,7 @@ static bool remove_pty_baton(int id) {
+ static bool remove_pty_baton(int id) {
 +  std::lock_guard<std::mutex> lock(ptyHandlesMutex);
-@@ -70 +80 @@ static bool remove_pty_baton(int id) {
+   auto it = std::remove_if(ptyHandles.begin(), ptyHandles.end(), [id](const auto& ptyHandle) {
+     return ptyHandle->id == id;
+   });
+   if (it != ptyHandles.end()) {
 -    ptyHandles.erase(it);
 +    ptyHandles.erase(it, ptyHandles.end());
 @@ -75,0 +86,42 @@ static bool remove_pty_baton(int id) {
@@ -689,10 +693,11 @@ index 7b286d3d64..7434bcc994 100644
 @@ -516 +624 @@ static Napi::Value PtyClear(const Napi::CallbackInfo& info) {
 -  const pty_baton* handle = get_pty_baton(id);
 +  const std::shared_ptr<pty_baton> handle = get_pty_baton(id);
-@@ -547 +655 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+@@ -547,3 +655,8 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
 -  const pty_baton* handle = get_pty_baton(id);
 +  const std::shared_ptr<pty_baton> handle = get_pty_baton(id);
-@@ -549,0 +658,5 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+
+   if (handle != nullptr) {
 +    HANDLE hJob = take_job_handle(handle);
 +    if (hJob != nullptr) {
 +      TerminateJobObject(hJob, 1);

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -659,6 +659,7 @@ index 7b286d3d64..7434bcc994 100644
 +      (void)removed;
 +      throw errorWithCode(info, "Cannot resume process", resumeError);
 +    }
++    CloseHandle(piClient.hThread);
 +  }
 +
 @@ -441,3 +550,0 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {

--- a/config/scripts/ensure-native-runtime.mjs
+++ b/config/scripts/ensure-native-runtime.mjs
@@ -64,7 +64,7 @@ function ensureNodeRuntime() {
     if (!initial.ok) {
       printCheckError(initial)
     }
-    runPnpm(['rebuild', 'node-pty'])
+    runPnpm(['rebuild', 'node-pty'], { buildFromSource: true })
     verifyNodeRuntimeAfterRebuild()
     return
   }
@@ -300,10 +300,11 @@ function getPatchedNodePtyRebuildReason() {
     return null
   }
 
-  // Why: a loadable upstream node-pty prebuild is not enough; Orca's Unix
-  // patch only lands in the source-built build/Release artifacts.
+  // Why: a loadable upstream node-pty prebuild is not enough; Orca's native
+  // patch only lands in source-built build/Release artifacts.
   const nodePtyDir = resolve(projectDir, 'node_modules', 'node-pty')
-  const artifactPaths = [resolve(nodePtyDir, 'build', 'Release', 'pty.node')]
+  const nativeArtifact = process.platform === 'win32' ? 'conpty.node' : 'pty.node'
+  const artifactPaths = [resolve(nodePtyDir, 'build', 'Release', nativeArtifact)]
   // Why: node-pty only builds spawn-helper on macOS; Linux builds only pty.node.
   if (process.platform === 'darwin') {
     artifactPaths.push(resolve(nodePtyDir, 'build', 'Release', 'spawn-helper'))
@@ -318,10 +319,6 @@ function getPatchedNodePtyRebuildReason() {
 }
 
 function requiresPatchedNodePtySourceBuild() {
-  if (process.platform === 'win32') {
-    return false
-  }
-
   const nodePtyPatchPath = resolve(projectDir, 'config', 'patches', 'node-pty@1.1.0.patch')
   if (!existsSync(nodePtyPatchPath)) {
     return false
@@ -339,10 +336,14 @@ function getWindowsBuildNumber() {
   return match && match.length === 4 ? Number.parseInt(match[3], 10) : 0
 }
 
-function runPnpm(args) {
+function runPnpm(args, options = {}) {
   const command = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
   const result = spawnSync(command, args, {
     cwd: projectDir,
+    env: {
+      ...process.env,
+      ...(options.buildFromSource ? { npm_config_build_from_source: 'true' } : {})
+    },
     stdio: 'inherit',
     shell: process.platform === 'win32'
   })

--- a/config/scripts/node-pty-windows-job-object-contract.test.mjs
+++ b/config/scripts/node-pty-windows-job-object-contract.test.mjs
@@ -75,19 +75,25 @@ describe('patched node-pty Windows Job Object contract', () => {
       'const std::shared_ptr<pty_baton> handle = get_pty_baton(id)'
     )
     const handleGuard = native.indexOf('if (handle != nullptr)', killHandle)
-    const takeJob = native.indexOf('HANDLE hJob = take_job_handle(handle)', killHandle)
+    const takeJob = native.indexOf(
+      'const HANDLE killJobHandle = take_job_handle(handle);\n    const bool hadJobHandle = killJobHandle != nullptr',
+      killHandle
+    )
     expect(handleGuard).toBeGreaterThan(killHandle)
     expect(takeJob).toBeGreaterThan(handleGuard)
     expect(native).toContain('std::shared_ptr<pty_baton>')
     expect(native).toContain('std::atomic<HANDLE> hJob')
     expect(native).toContain('hJob.exchange(nullptr)')
-    expect(native).toContain('TerminateJobObject(')
-    expect(native).toContain('CloseHandle(hJob)')
+    expect(native).toContain('const HANDLE createdJobHandle = CreateJobObjectW(')
+    expect(native).toContain('const HANDLE resumeJobHandle = take_job_handle(handle)')
+    expect(native).toContain('TerminateJobObject(killJobHandle, 1)')
+    expect(native).toContain('CloseHandle(killJobHandle)')
+    expect(native).not.toContain('const HANDLE jobHandle =')
     expect(native).toContain('bool jobObjectAssigned = false')
     expect(native).toContain('bool jobObjectSetupFailed = false')
     expect(native).toContain('std::mutex hShellMutex')
     expect(native).toMatch(
-      /if \(hJob == nullptr &&\s*!handle->jobObjectAssigned &&\s*\(useConptyDll \|\| handle->jobObjectSetupFailed\)\)/
+      /if \(!hadJobHandle &&\s*!handle->jobObjectAssigned &&\s*\(useConptyDll \|\| handle->jobObjectSetupFailed\)\)/
     )
     expect(native).toContain('terminate_shell_process(handle)')
     expect(native).not.toContain('TerminateProcess(handle->hShell')

--- a/config/scripts/node-pty-windows-job-object-contract.test.mjs
+++ b/config/scripts/node-pty-windows-job-object-contract.test.mjs
@@ -65,6 +65,22 @@ describe('patched node-pty Windows Job Object contract', () => {
     expect(resume).toBeGreaterThan(assignJob)
   })
 
+  it('closes the suspended-thread handle after a successful resume', () => {
+    const native = patchedLines(patchSection('src/win/conpty.cc'))
+    const resume = native.indexOf('if (ResumeThread(piClient.hThread) == static_cast<DWORD>(-1))')
+    const failedResumeClose = native.indexOf('CloseHandle(piClient.hThread);', resume)
+    const failedResumeEnd = native.indexOf('\n    }\n', failedResumeClose)
+    const successfulResumeClose = native.indexOf(
+      '    CloseHandle(piClient.hThread);',
+      failedResumeEnd
+    )
+
+    expect(resume).toBeGreaterThanOrEqual(0)
+    expect(failedResumeClose).toBeGreaterThan(resume)
+    expect(failedResumeEnd).toBeGreaterThan(failedResumeClose)
+    expect(successfulResumeClose).toBeGreaterThan(failedResumeEnd)
+  })
+
   it('keeps Job Object cleanup race-safe and falls back to direct-root termination', () => {
     const native = patchedLines(patchSection('src/win/conpty.cc'))
 

--- a/config/scripts/node-pty-windows-job-object-contract.test.mjs
+++ b/config/scripts/node-pty-windows-job-object-contract.test.mjs
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const projectDir = join(import.meta.dirname, '../..')
+const patchSource = readFileSync(join(projectDir, 'config/patches/node-pty@1.1.0.patch'), 'utf8')
+
+function patchSection(path) {
+  const marker = `diff --git a/${path} b/${path}`
+  const start = patchSource.indexOf(marker)
+  expect(start, `missing patch section for ${path}`).toBeGreaterThanOrEqual(0)
+  const next = patchSource.indexOf('\ndiff --git ', start + marker.length)
+  return patchSource.slice(start, next === -1 ? undefined : next)
+}
+
+function addedLines(section) {
+  return section
+    .split('\n')
+    .filter((line) => line.startsWith('+') && !line.startsWith('+++'))
+    .map((line) => line.slice(1))
+    .join('\n')
+}
+
+function patchedLines(section) {
+  return section
+    .split('\n')
+    .filter(
+      (line) =>
+        (line.startsWith('+') && !line.startsWith('+++')) ||
+        (line.startsWith(' ') && !line.startsWith(' diff --git'))
+    )
+    .map((line) => line.slice(1))
+    .join('\n')
+}
+
+describe('patched node-pty Windows Job Object contract', () => {
+  it('suspends ConPTY children until kill-on-close ownership is configured', () => {
+    const native = patchedLines(patchSection('src/win/conpty.cc'))
+    const createFlags = native.indexOf(
+      'EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT |'
+    )
+    const suspended = native.indexOf('CREATE_SUSPENDED')
+    const createJob = native.indexOf('CreateJobObjectW(')
+    const killOnClose = native.indexOf('JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE')
+    const configureJob = native.indexOf('SetInformationJobObject(')
+    const assignJob = native.indexOf('AssignProcessToJobObject(')
+    const resume = native.indexOf('ResumeThread(')
+
+    for (const index of [
+      createFlags,
+      suspended,
+      createJob,
+      killOnClose,
+      configureJob,
+      assignJob,
+      resume
+    ]) {
+      expect(index).toBeGreaterThanOrEqual(0)
+    }
+    expect(suspended).toBeGreaterThan(createFlags)
+    expect(createJob).toBeGreaterThan(suspended)
+    expect(killOnClose).toBeGreaterThan(createJob)
+    expect(configureJob).toBeGreaterThan(killOnClose)
+    expect(assignJob).toBeGreaterThan(configureJob)
+    expect(resume).toBeGreaterThan(assignJob)
+  })
+
+  it('keeps Job Object cleanup race-safe and falls back to direct-root termination', () => {
+    const native = patchedLines(patchSection('src/win/conpty.cc'))
+
+    expect(native).toContain('std::shared_ptr<pty_baton>')
+    expect(native).toContain('std::atomic<HANDLE> hJob')
+    expect(native).toContain('hJob.exchange(nullptr)')
+    expect(native).toContain('TerminateJobObject(')
+    expect(native).toContain('CloseHandle(hJob)')
+    expect(native).toContain('bool jobObjectAssigned = false')
+    expect(native).toContain('bool jobObjectSetupFailed = false')
+    expect(native).toContain('std::mutex hShellMutex')
+    expect(native).toMatch(
+      /if \(hJob == nullptr &&\s*!handle->jobObjectAssigned &&\s*\(useConptyDll \|\| handle->jobObjectSetupFailed\)\)/
+    )
+    expect(native).toContain('terminate_shell_process(handle)')
+    expect(native).not.toContain('TerminateProcess(handle->hShell')
+  })
+
+  it('serializes shell-handle close with fallback termination and preserves resume errors', () => {
+    const native = patchedLines(patchSection('src/win/conpty.cc'))
+    const closeHelper = native.indexOf('read_exit_code_and_close_shell_handle(')
+    const closeLock = native.indexOf(
+      'std::lock_guard<std::mutex> lock(baton->hShellMutex)',
+      closeHelper
+    )
+    const getExitCode = native.indexOf('GetExitCodeProcess(', closeLock)
+    const closeHandle = native.indexOf('CloseHandle(baton->hShell)', getExitCode)
+    const clearHandle = native.indexOf('baton->hShell = nullptr', closeHandle)
+
+    expect(closeHelper).toBeGreaterThanOrEqual(0)
+    expect(closeLock).toBeGreaterThan(closeHelper)
+    expect(getExitCode).toBeGreaterThan(closeLock)
+    expect(closeHandle).toBeGreaterThan(getExitCode)
+    expect(clearHandle).toBeGreaterThan(closeHandle)
+
+    const resume = native.indexOf('ResumeThread(')
+    const saveError = native.indexOf('const DWORD resumeError = GetLastError()', resume)
+    const removeBaton = native.indexOf('remove_pty_baton(handle->id)', saveError)
+    const throwSavedError = native.indexOf(
+      'errorWithCode(info, "Cannot resume process", resumeError)',
+      removeBaton
+    )
+
+    expect(resume).toBeGreaterThanOrEqual(0)
+    expect(saveError).toBeGreaterThan(resume)
+    expect(removeBaton).toBeGreaterThan(saveError)
+    expect(throwSavedError).toBeGreaterThan(removeBaton)
+
+    expect(native).not.toContain('assert(remove_pty_baton(')
+    expect(native.match(/const bool removed = remove_pty_baton\(/g)).toHaveLength(2)
+    expect(native.match(/assert\(removed\);\s*\(void\)removed;/g)).toHaveLength(2)
+  })
+
+  it('threads the opt-in through source, compiled JS, native typings, and public typings', () => {
+    for (const path of [
+      'src/interfaces.ts',
+      'src/native.d.ts',
+      'src/windowsTerminal.ts',
+      'src/windowsPtyAgent.ts',
+      'lib/windowsTerminal.js',
+      'lib/windowsPtyAgent.js',
+      'typings/node-pty.d.ts'
+    ]) {
+      expect(addedLines(patchSection(path))).toContain('useConptyJobObject')
+    }
+
+    const agent = addedLines(patchSection('src/windowsPtyAgent.ts'))
+    expect(agent).toContain('if (this._useConptyJobObject || this._useConptyDll)')
+    expect(agent).not.toContain('process.kill(this._innerPid)')
+  })
+
+  it('forces patched Windows node-pty installs to use build/Release conpty.node', () => {
+    for (const scriptName of ['ensure-native-runtime.mjs', 'rebuild-native-deps.mjs']) {
+      const source = readFileSync(join(projectDir, 'config/scripts', scriptName), 'utf8')
+      expect(source).toContain("process.platform === 'win32' ? 'conpty.node' : 'pty.node'")
+      expect(source).not.toMatch(
+        /if \((?:process\.platform|rebuildPlatform) === 'win32'\) \{\s*return false\s*\}/
+      )
+    }
+  })
+})

--- a/config/scripts/node-pty-windows-job-object-contract.test.mjs
+++ b/config/scripts/node-pty-windows-job-object-contract.test.mjs
@@ -68,6 +68,16 @@ describe('patched node-pty Windows Job Object contract', () => {
   it('keeps Job Object cleanup race-safe and falls back to direct-root termination', () => {
     const native = patchedLines(patchSection('src/win/conpty.cc'))
 
+    expect(native).toContain(
+      'static bool remove_pty_baton(int id) {\n  std::lock_guard<std::mutex> lock(ptyHandlesMutex)'
+    )
+    const killHandle = native.lastIndexOf(
+      'const std::shared_ptr<pty_baton> handle = get_pty_baton(id)'
+    )
+    const handleGuard = native.indexOf('if (handle != nullptr)', killHandle)
+    const takeJob = native.indexOf('HANDLE hJob = take_job_handle(handle)', killHandle)
+    expect(handleGuard).toBeGreaterThan(killHandle)
+    expect(takeJob).toBeGreaterThan(handleGuard)
     expect(native).toContain('std::shared_ptr<pty_baton>')
     expect(native).toContain('std::atomic<HANDLE> hJob')
     expect(native).toContain('hJob.exchange(nullptr)')

--- a/config/scripts/node-pty-windows-job-object-contract.test.mjs
+++ b/config/scripts/node-pty-windows-job-object-contract.test.mjs
@@ -161,4 +161,19 @@ describe('patched node-pty Windows Job Object contract', () => {
       )
     }
   })
+
+  it('disables the node-gyp delay-load hook only for non-Node winpty targets', () => {
+    const winpty = patchedLines(patchSection('deps/winpty/src/winpty.gyp'))
+    const optOut = "'win_delay_load_hook' : 'false'"
+
+    expect(winpty.match(new RegExp(optOut, 'g')) ?? []).toHaveLength(3)
+    for (const target of ['winpty-agent', 'winpty', 'winpty-debugserver']) {
+      const targetStart = winpty.indexOf(`'target_name' : '${target}'`)
+      const nextTarget = winpty.indexOf("'target_name' :", targetStart + 1)
+      const targetSource = winpty.slice(targetStart, nextTarget === -1 ? undefined : nextTarget)
+
+      expect(targetStart).toBeGreaterThanOrEqual(0)
+      expect(targetSource).toContain(optOut)
+    }
+  })
 })

--- a/config/scripts/rebuild-native-deps.mjs
+++ b/config/scripts/rebuild-native-deps.mjs
@@ -399,10 +399,11 @@ function getPatchedNodePtyRebuildReason() {
     return null
   }
 
-  // Why: Orca patches node-pty's native Unix spawn path; upstream prebuilds can
-  // load successfully in Electron while missing the patched fd/error handling.
+  // Why: upstream prebuilds can load successfully while omitting Orca's native
+  // Unix error handling or Windows Job Object ownership.
   const nodePtyDir = resolve(projectDir, 'node_modules', 'node-pty')
-  const artifactPaths = [resolve(nodePtyDir, 'build', 'Release', 'pty.node')]
+  const nativeArtifact = process.platform === 'win32' ? 'conpty.node' : 'pty.node'
+  const artifactPaths = [resolve(nodePtyDir, 'build', 'Release', nativeArtifact)]
   // Why: node-pty only builds spawn-helper on macOS; Linux builds only pty.node.
   if (process.platform === 'darwin') {
     artifactPaths.push(resolve(nodePtyDir, 'build', 'Release', 'spawn-helper'))
@@ -418,9 +419,6 @@ function getPatchedNodePtyRebuildReason() {
 
 function requiresPatchedNodePtySourceBuild() {
   if (!onlyModules.includes('node-pty')) {
-    return false
-  }
-  if (rebuildPlatform === 'win32') {
     return false
   }
   if (rebuildPlatform !== osPlatform() || rebuildArch !== process.arch) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ patchedDependencies:
     hash: 037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8
     path: config/patches/@xterm__xterm@6.1.0-beta.287.patch
   node-pty@1.1.0:
-    hash: 327a3852f901288bae18dd4184ac4755a08de2af9bc0b8a19db12d5d8871933d
+    hash: bb522ed52638f9aca92f38a3fe4e8f52b7960c32af518aa16c92d1cc070e2fd1
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -64,7 +64,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=327a3852f901288bae18dd4184ac4755a08de2af9bc0b8a19db12d5d8871933d)
+        version: 1.1.0(patch_hash=bb522ed52638f9aca92f38a3fe4e8f52b7960c32af518aa16c92d1cc070e2fd1)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12013,7 +12013,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=327a3852f901288bae18dd4184ac4755a08de2af9bc0b8a19db12d5d8871933d):
+  node-pty@1.1.0(patch_hash=bb522ed52638f9aca92f38a3fe4e8f52b7960c32af518aa16c92d1cc070e2fd1):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ patchedDependencies:
     hash: 037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8
     path: config/patches/@xterm__xterm@6.1.0-beta.287.patch
   node-pty@1.1.0:
-    hash: c425d5dca21f0d4a28403231a50f80aec4f994050b539846bc1564bb983faff7
+    hash: 29b2cdcc6660a50c29461623eaaa0a4f8995b4b11eed8c670101bb60d873f2b4
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -64,7 +64,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=c425d5dca21f0d4a28403231a50f80aec4f994050b539846bc1564bb983faff7)
+        version: 1.1.0(patch_hash=29b2cdcc6660a50c29461623eaaa0a4f8995b4b11eed8c670101bb60d873f2b4)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12013,7 +12013,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=c425d5dca21f0d4a28403231a50f80aec4f994050b539846bc1564bb983faff7):
+  node-pty@1.1.0(patch_hash=29b2cdcc6660a50c29461623eaaa0a4f8995b4b11eed8c670101bb60d873f2b4):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ patchedDependencies:
     hash: 037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8
     path: config/patches/@xterm__xterm@6.1.0-beta.287.patch
   node-pty@1.1.0:
-    hash: 8fc49f17011b6611a5b8c00e83a6f12e14e75aada2b0ef26dc5393f8376d20e8
+    hash: 327a3852f901288bae18dd4184ac4755a08de2af9bc0b8a19db12d5d8871933d
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -64,7 +64,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=8fc49f17011b6611a5b8c00e83a6f12e14e75aada2b0ef26dc5393f8376d20e8)
+        version: 1.1.0(patch_hash=327a3852f901288bae18dd4184ac4755a08de2af9bc0b8a19db12d5d8871933d)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12013,7 +12013,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=8fc49f17011b6611a5b8c00e83a6f12e14e75aada2b0ef26dc5393f8376d20e8):
+  node-pty@1.1.0(patch_hash=327a3852f901288bae18dd4184ac4755a08de2af9bc0b8a19db12d5d8871933d):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ patchedDependencies:
     hash: 037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8
     path: config/patches/@xterm__xterm@6.1.0-beta.287.patch
   node-pty@1.1.0:
-    hash: bb522ed52638f9aca92f38a3fe4e8f52b7960c32af518aa16c92d1cc070e2fd1
+    hash: c425d5dca21f0d4a28403231a50f80aec4f994050b539846bc1564bb983faff7
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -64,7 +64,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=bb522ed52638f9aca92f38a3fe4e8f52b7960c32af518aa16c92d1cc070e2fd1)
+        version: 1.1.0(patch_hash=c425d5dca21f0d4a28403231a50f80aec4f994050b539846bc1564bb983faff7)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12013,7 +12013,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=bb522ed52638f9aca92f38a3fe4e8f52b7960c32af518aa16c92d1cc070e2fd1):
+  node-pty@1.1.0(patch_hash=c425d5dca21f0d4a28403231a50f80aec4f994050b539846bc1564bb983faff7):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -508,6 +508,74 @@ describe('createPtySubprocess', () => {
     )
   })
 
+  it('opts only recognized native Windows agent PTYs into ConPTY Job Object ownership', () => {
+    spawnMock.mockReturnValue(mockPtyProcess())
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    try {
+      createPtySubprocess({
+        sessionId: 'agent',
+        cols: 80,
+        rows: 24,
+        cwd: 'C:\\repo',
+        env: { COMSPEC: CMD_ABS },
+        command: 'claude'
+      })
+      expect(spawnMock.mock.calls.at(-1)?.[2]).toMatchObject({
+        useConptyDll: true,
+        useConptyJobObject: true
+      })
+
+      createPtySubprocess({
+        sessionId: 'terminal',
+        cols: 80,
+        rows: 24,
+        cwd: 'C:\\repo',
+        env: { COMSPEC: CMD_ABS }
+      })
+      expect(spawnMock.mock.calls.at(-1)?.[2]).not.toHaveProperty('useConptyJobObject')
+
+      createPtySubprocess({
+        sessionId: 'wsl-agent-no-extension',
+        cols: 80,
+        rows: 24,
+        cwd: 'C:\\repo',
+        env: { COMSPEC: CMD_ABS },
+        command: 'codex',
+        shellOverride: 'wsl'
+      })
+      expect(spawnMock.mock.calls.at(-1)?.[2]).not.toHaveProperty('useConptyJobObject')
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+  })
+
+  it('does not apply the native Windows Job Object option to WSL agent PTYs', () => {
+    spawnMock.mockReturnValue(mockPtyProcess())
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    try {
+      createPtySubprocess({
+        sessionId: 'wsl-agent',
+        cols: 80,
+        rows: 24,
+        cwd: 'C:\\repo',
+        env: { COMSPEC: CMD_ABS },
+        command: 'codex',
+        shellOverride: 'wsl.exe'
+      })
+      expect(spawnMock.mock.calls.at(-1)?.[2]).not.toHaveProperty('useConptyJobObject')
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+  })
+
   it('suppresses the first-run Powerlevel10k wizard for daemon terminals', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -71,6 +71,7 @@ import {
   expandWindowsPathEnvironmentVariables
 } from '../../shared/windows-environment-expansion'
 import { forceKillPosixPtyProcessGroups } from '../pty/posix-pty-process-groups'
+import { isWslShellName } from '../../shared/local-windows-terminal-runtime'
 import { readPtySlavePath } from '../../shared/pty-slave-line-discipline-echo'
 
 const PANE_IDENTITY_ENV_KEYS = [
@@ -543,6 +544,7 @@ function spawnDaemonPtyWithWindowsFallback(args: {
   cols: number
   rows: number
   windowsFallbackAttempts: WindowsShellSpawnAttempt[]
+  useConptyJobObject: boolean
 }): {
   process: pty.IPty
   shellPath: string
@@ -558,7 +560,14 @@ function spawnDaemonPtyWithWindowsFallback(args: {
       cwd,
       env: args.env,
       // Why: legacy system ConPTY can corrupt full-width TUI rows in scrollback; bundled ConPTY has the wrap-marker behavior xterm expects.
-      ...(process.platform === 'win32' ? { useConptyDll: true } : {})
+      ...(process.platform === 'win32'
+        ? {
+            useConptyDll: true,
+            ...(args.useConptyJobObject && !isWslShellName(shellPath)
+              ? { useConptyJobObject: true }
+              : {})
+          }
+        : {})
     })
   }
 
@@ -633,6 +642,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   let startupCommandDeliveredInShellArgs = false
   let windowsFallbackAttempts: WindowsShellSpawnAttempt[] = []
   const startupAgentRecognition = recognizeAgentProcessFromCommandLine(opts.command)
+  const isAgentPty = Boolean(opts.launchAgent || startupAgentRecognition)
   const isCodexStartupCommand = startupAgentRecognition?.agent === 'codex'
   // Why: gate on the effective cwd, not raw opts.cwd — an omitted cwd becomes a safe
   // default (mirrors LocalPtyProvider). Guarding first treated undefined as root-like (#9578).
@@ -837,7 +847,8 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       env,
       cols: size.cols,
       rows: size.rows,
-      windowsFallbackAttempts
+      windowsFallbackAttempts,
+      useConptyJobObject: process.platform === 'win32' && isAgentPty
     })
     proc = spawned.process
     // Why: a Windows fallback (e.g. cmd.exe) carries its own argv-embedded startup command; adopt the winning shell's identity + delivery flag.

--- a/src/main/daemon/terminal-session-teardown.test.ts
+++ b/src/main/daemon/terminal-session-teardown.test.ts
@@ -117,3 +117,35 @@ describe('TerminalSessionTeardown plain-shell teardown', () => {
     expect(session.kill).toHaveBeenCalled()
   })
 })
+
+describe('TerminalSessionTeardown agent teardown', () => {
+  beforeEach(() => {
+    killWithDescendantSweepMock.mockReset()
+  })
+
+  it('keeps agent teardown rooted in the owned native PTY handle', async () => {
+    const session = {
+      beginTermination: vi.fn(() => true),
+      forceKillAndWaitForExit: vi.fn(() => Promise.resolve()),
+      isAlive: true,
+      launchAgent: 'claude',
+      pid: 42,
+      scheduleForceDisposeFallback: vi.fn(),
+      signalTerminationRoot: vi.fn()
+    } as unknown as Session
+    const sessions = new Map([['agent-session', session]])
+    const teardown = new TerminalSessionTeardown(sessions)
+
+    const operation = teardown.killSession('agent-session', session, true)
+
+    expect(killWithDescendantSweepMock).toHaveBeenCalledWith(
+      session.pid,
+      expect.any(Function),
+      expect.objectContaining({ ownsRoot: expect.any(Function) })
+    )
+    const killRoot = killWithDescendantSweepMock.mock.calls[0][1] as () => void
+    killRoot()
+    await operation
+    expect(session.forceKillAndWaitForExit).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -224,6 +224,43 @@ describe('LocalPtyProvider', () => {
       expect(typeof result.id).toBe('string')
     })
 
+    it('opts only recognized native Windows agent PTYs into ConPTY Job Object ownership', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+
+      await provider.spawn({ cols: 80, rows: 24, cwd: 'C:\\repo', command: 'claude' })
+      expect(spawnMock.mock.calls.at(-1)?.[2]).toMatchObject({
+        useConptyDll: true,
+        useConptyJobObject: true
+      })
+
+      await provider.spawn({ cols: 80, rows: 24, cwd: 'C:\\repo' })
+      expect(spawnMock.mock.calls.at(-1)?.[2]).not.toHaveProperty('useConptyJobObject')
+    })
+
+    it('does not apply the native Windows Job Object option to WSL agent PTYs', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+
+      await provider.spawn({
+        cols: 80,
+        rows: 24,
+        cwd: 'C:\\repo',
+        command: 'codex',
+        shellOverride: 'wsl.exe'
+      })
+
+      expect(spawnMock.mock.calls.at(-1)?.[2]).not.toHaveProperty('useConptyJobObject')
+
+      await provider.spawn({
+        cols: 80,
+        rows: 24,
+        cwd: 'C:\\repo',
+        command: 'codex',
+        shellOverride: 'wsl'
+      })
+      expect(spawnMock.mock.calls.at(-1)?.[2]).not.toHaveProperty('useConptyJobObject')
+    })
+
+
     it('expands variables in PATH before spawning a Windows shell', async () => {
       Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
 
@@ -1331,6 +1368,55 @@ describe('LocalPtyProvider', () => {
       await provider.shutdown(id, { immediate: true })
       expect(killSpy).toHaveBeenCalled()
     })
+
+    it('coalesces Windows agent shutdown around one native Job Object kill and physical exit', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      const killSpy = vi.fn()
+      mockProc.kill = killSpy
+      const { id } = await provider.spawn({
+        cols: 80,
+        rows: 24,
+        launchAgent: 'claude'
+      })
+      expect(spawnMock.mock.calls.at(-1)?.[2]).toMatchObject({ useConptyJobObject: true })
+
+      const graceful = provider.shutdown(id, { immediate: false })
+      const immediate = provider.shutdown(id, { immediate: true })
+      let settled = false
+      void immediate.then(() => {
+        settled = true
+      })
+      await Promise.resolve()
+      const settledBeforeExit = settled
+      exitCb?.({ exitCode: 137 })
+      await Promise.all([graceful, immediate])
+
+      expect(settledBeforeExit).toBe(false)
+      expect(killSpy).toHaveBeenCalledOnce()
+      // Why: Job Object owns the agent tree — no taskkill /T via killWithDescendantSweep.
+      expect(killWithDescendantSweepMock).not.toHaveBeenCalled()
+      expect(provider.hasPty(id)).toBe(false)
+    })
+
+    it('sweeps WSL agent descendants when no Windows Job Object owns the tree', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      const { id } = await provider.spawn({
+        cols: 80,
+        rows: 24,
+        launchAgent: 'claude',
+        shellOverride: 'wsl'
+      })
+      expect(spawnMock.mock.calls.at(-1)?.[2]).not.toHaveProperty('useConptyJobObject')
+
+      await provider.shutdown(id, { immediate: true })
+
+      expect(killWithDescendantSweepMock).toHaveBeenCalledWith(
+        mockProc.pid,
+        expect.any(Function),
+        expect.objectContaining({ ownsRoot: expect.any(Function) })
+      )
+    })
+
 
     it('invokes onExit callback via the node-pty exit handler', async () => {
       const onExit = vi.fn()

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -87,7 +87,7 @@ const ptyProcesses = new Map<string, pty.IPty>()
 const ptyIncarnations = new Map<string, string>()
 // Why: agent sessions always sweep descendant trees; plain terminals preserve nohup children except on immediate win32 shutdown.
 const ptyAgentSessionIds = new Set<string>()
-// Why: descendant capture is async, so reattach/duplicate shutdown must wait for the original owner, not return a dying PTY.
+// Why: descendant teardown is async, so reattach/duplicate shutdown must wait for the original owner, not return a dying PTY.
 type PtyShutdownOperation = {
   promise: Promise<void>
   immediate: boolean
@@ -856,6 +856,7 @@ export class LocalPtyProvider implements IPtyProvider {
       onBeforeFallbackSpawn: historyResult?.histFile
         ? (env, fallbackShell) => updateHistFileForFallback(env, fallbackShell)
         : undefined,
+      useConptyJobObject: process.platform === 'win32' && isAgentPty,
       windowsFallbackAttempts
     })
     args.onPtySpawnCommitted?.()
@@ -1145,9 +1146,9 @@ export class LocalPtyProvider implements IPtyProvider {
     operation: PtyShutdownOperation
   ): Promise<void> {
     const physicalExit = ptyPhysicalExits.get(id)
-    const signalRoot = (): void => {
-      // Why: natural exit can race the sweep — never signal after this PTY loses ownership.
-      if (ptyProcesses.get(id) !== proc) {
+    const ownsRoot = (): boolean => ptyProcesses.get(id) === proc
+    const killRoot = (): void => {
+      if (!ownsRoot()) {
         return
       }
       // Cancel startup delivery now, but keep the exit listener and ownership maps until node-pty reports physical exit.
@@ -1155,23 +1156,22 @@ export class LocalPtyProvider implements IPtyProvider {
       operation.rootSignalled = true
       this.requestTrackedPtyShutdown(id, proc, operation.immediate)
     }
-    if (ptyAgentSessionIds.has(id)) {
-      // Why: POSIX needs a pre-kill descendant snapshot; Windows tree-kills only when the
-      // identity probe returns `own` so agent/MCP orphans cannot hold the worktree cwd
-      // (#10004). `unknown`/`foreign`/`absent` skip taskkill and rely on root close alone.
-      await killWithDescendantSweep(proc.pid, signalRoot, {
-        ownsRoot: () => ptyProcesses.get(id) === proc
-      })
+    if (ptyAgentSessionIds.has(id) && process.platform === 'win32') {
+      // Why: Windows agent trees are owned by node-pty Job Objects (useConptyJobObject);
+      // killRoot closing the job reaps descendants — taskkill /T is redundant.
+      killRoot()
+    } else if (ptyAgentSessionIds.has(id)) {
+      // Why: POSIX needs a pre-kill descendant snapshot so agent/MCP orphans cannot
+      // hold the worktree cwd after shell stop (#10004).
+      await killWithDescendantSweep(proc.pid, killRoot, { ownsRoot })
     } else if (process.platform === 'win32' && operation.immediate) {
       // Why: a plain shell's ConPTY teardown doesn't reap orphaned children (useConptyDll
       // skips the console reap), so a live `pnpm i`/`node` keeps the ConPTY console alive and
-      // holds the worktree cwd. Tree kill runs only when the OS identity probe returns `own`;
-      // otherwise root close alone, and detached children may block physical stop (#10004).
-      await killWithDescendantSweep(proc.pid, signalRoot, {
-        ownsRoot: () => ptyProcesses.get(id) === proc
-      })
+      // holds the worktree cwd, failing destructive removal. taskkill /T /F clears the tree so
+      // physical stop is verifiable. POSIX shells reach their child pgroup on forceKill (#10004).
+      await killWithDescendantSweep(proc.pid, killRoot, { ownsRoot })
     } else {
-      signalRoot()
+      killRoot()
     }
     await waitForPtyPhysicalExit(id, physicalExit)
   }

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -66,6 +66,7 @@ import { PhysicalExitTracker } from '../../shared/physical-exit-tracker'
 import { mergeGitConfigEnvProtocol } from '../../shared/git-credential-prompt-env'
 import { PtyStartupIngress, type PtyIngressEmission } from '../../shared/pty-startup-ingress'
 import { resolvePtyOwnerBackend } from '../../shared/pty-owner-backend'
+import { isWslShellName } from '../../shared/local-windows-terminal-runtime'
 import {
   createPtySlaveEchoProbe,
   readPtySlavePath
@@ -87,6 +88,8 @@ const ptyProcesses = new Map<string, pty.IPty>()
 const ptyIncarnations = new Map<string, string>()
 // Why: agent sessions always sweep descendant trees; plain terminals preserve nohup children except on immediate win32 shutdown.
 const ptyAgentSessionIds = new Set<string>()
+// Why: only native ConPTY agent sessions receive kill-on-close Job Object ownership.
+const ptyWindowsJobObjectSessionIds = new Set<string>()
 // Why: descendant teardown is async, so reattach/duplicate shutdown must wait for the original owner, not return a dying PTY.
 type PtyShutdownOperation = {
   promise: Promise<void>
@@ -251,6 +254,7 @@ function clearPtyState(id: string): void {
   ptyProcesses.delete(id)
   ptyIncarnations.delete(id)
   ptyAgentSessionIds.delete(id)
+  ptyWindowsJobObjectSessionIds.delete(id)
   ptyShellName.delete(id)
   ptyAgentForegroundContextPaths.delete(id)
   ptyLastRecognizedForeground.delete(id)
@@ -893,6 +897,9 @@ export class LocalPtyProvider implements IPtyProvider {
     if (args.launchAgent || startupAgentRecognition) {
       ptyAgentSessionIds.add(id)
     }
+    if (process.platform === 'win32' && isAgentPty && !isWslShellName(shellPath)) {
+      ptyWindowsJobObjectSessionIds.add(id)
+    }
     ptyShellName.set(id, getSpawnedShellName(shellPath))
     if (finalEnv.ORCA_TERMINAL_HANDLE) {
       ptyTerminalHandle.set(id, finalEnv.ORCA_TERMINAL_HANDLE)
@@ -1158,7 +1165,7 @@ export class LocalPtyProvider implements IPtyProvider {
       operation.rootSignalled = true
       this.requestTrackedPtyShutdown(id, proc, operation.immediate)
     }
-    if (ptyAgentSessionIds.has(id) && process.platform === 'win32') {
+    if (ptyWindowsJobObjectSessionIds.has(id)) {
       // Why: Windows agent trees are owned by node-pty Job Objects (useConptyJobObject);
       // killRoot closing the job reaps descendants — taskkill /T is redundant.
       killRoot()

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -842,6 +842,8 @@ export class LocalPtyProvider implements IPtyProvider {
     if (concurrentWinner) {
       return concurrentWinner
     }
+    // Why: agent PTYs opt into Windows Job Object tree ownership; plain shells skip it.
+    const isAgentPty = Boolean(args.launchAgent || startupAgentRecognition)
     const spawnResult = spawnShellWithFallback({
       shellPath,
       shellArgs,

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -1166,18 +1166,20 @@ export class LocalPtyProvider implements IPtyProvider {
       this.requestTrackedPtyShutdown(id, proc, operation.immediate)
     }
     if (ptyWindowsJobObjectSessionIds.has(id)) {
-      // Why: Windows agent trees are owned by node-pty Job Objects (useConptyJobObject);
-      // killRoot closing the job reaps descendants — taskkill /T is redundant.
+      // Why: Job Object is the primary reaper for native Windows agent trees
+      // (useConptyJobObject); killRoot closes the job and kernel-reaps descendants.
       killRoot()
     } else if (ptyAgentSessionIds.has(id)) {
-      // Why: POSIX needs a pre-kill descendant snapshot so agent/MCP orphans cannot
-      // hold the worktree cwd after shell stop (#10004).
+      // Why: POSIX needs a pre-kill descendant snapshot; non-Job Windows (e.g. WSL)
+      // tree-kills only when the identity probe returns `own` so agent/MCP orphans
+      // cannot hold the worktree cwd (#10004). `unknown`/`foreign`/`absent` skip
+      // taskkill and rely on root close alone (fail-closed, #10484/#10674).
       await killWithDescendantSweep(proc.pid, killRoot, { ownsRoot })
     } else if (process.platform === 'win32' && operation.immediate) {
       // Why: a plain shell's ConPTY teardown doesn't reap orphaned children (useConptyDll
       // skips the console reap), so a live `pnpm i`/`node` keeps the ConPTY console alive and
-      // holds the worktree cwd, failing destructive removal. taskkill /T /F clears the tree so
-      // physical stop is verifiable. POSIX shells reach their child pgroup on forceKill (#10004).
+      // holds the worktree cwd. taskkill is the fallback reaper and runs only when the OS
+      // identity probe returns `own`; otherwise root close alone (#10004/#10484/#10674).
       await killWithDescendantSweep(proc.pid, killRoot, { ownsRoot })
     } else {
       killRoot()

--- a/src/main/providers/local-pty-utils-windows-fallback.test.ts
+++ b/src/main/providers/local-pty-utils-windows-fallback.test.ts
@@ -121,6 +121,80 @@ describe('spawnShellWithFallback on Windows', () => {
     expect(result.startupCommandDeliveredInShellArgs).toBe(true)
   })
 
+  it('preserves requested ConPTY Job Object ownership across Windows fallback attempts', () => {
+    restorePlatform = setPlatform('win32')
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const attempts = [makeAttempt(PWSH7), makeAttempt(WINDOWS_POWERSHELL)]
+    const ptySpawn = vi.fn((shellPath: string) => {
+      if (shellPath === PWSH7) {
+        throw new Error(ACCESS_DENIED_5)
+      }
+      return makeFakePty()
+    }) as unknown as typeof pty.spawn
+
+    spawnShellWithFallback({
+      shellPath: PWSH7,
+      shellArgs: attempts[0].shellArgs,
+      cols: 80,
+      rows: 24,
+      cwd: 'C:\\repo',
+      env: {},
+      ptySpawn,
+      useConptyJobObject: true,
+      windowsFallbackAttempts: attempts
+    })
+
+    expect(ptySpawn).toHaveBeenNthCalledWith(
+      1,
+      PWSH7,
+      attempts[0].shellArgs,
+      expect.objectContaining({ useConptyJobObject: true })
+    )
+    expect(ptySpawn).toHaveBeenNthCalledWith(
+      2,
+      WINDOWS_POWERSHELL,
+      attempts[1].shellArgs,
+      expect.objectContaining({ useConptyJobObject: true })
+    )
+  })
+
+  it('does not carry requested Job Object ownership into a WSL fallback', () => {
+    restorePlatform = setPlatform('win32')
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const attempts = [makeAttempt(PWSH7), makeAttempt('wsl')]
+    const ptySpawn = vi.fn((shellPath: string) => {
+      if (shellPath === PWSH7) {
+        throw new Error(ACCESS_DENIED_5)
+      }
+      return makeFakePty()
+    }) as unknown as typeof pty.spawn
+
+    spawnShellWithFallback({
+      shellPath: PWSH7,
+      shellArgs: attempts[0].shellArgs,
+      cols: 80,
+      rows: 24,
+      cwd: 'C:\\repo',
+      env: {},
+      ptySpawn,
+      useConptyJobObject: true,
+      windowsFallbackAttempts: attempts
+    })
+
+    expect(ptySpawn).toHaveBeenNthCalledWith(
+      1,
+      PWSH7,
+      attempts[0].shellArgs,
+      expect.objectContaining({ useConptyJobObject: true })
+    )
+    expect(ptySpawn).toHaveBeenNthCalledWith(
+      2,
+      'wsl',
+      attempts[1].shellArgs,
+      expect.not.objectContaining({ useConptyJobObject: true })
+    )
+  })
+
   it('throws a descriptive error when every Windows fallback fails', () => {
     restorePlatform = setPlatform('win32')
     vi.spyOn(console, 'warn').mockImplementation(() => {})

--- a/src/main/providers/local-pty-utils.ts
+++ b/src/main/providers/local-pty-utils.ts
@@ -1,6 +1,7 @@
 import { basename, isAbsolute, join } from 'node:path'
 import { existsSync, accessSync, statSync, chmodSync, constants as fsConstants } from 'node:fs'
 import type * as pty from 'node-pty'
+import { isWslShellName } from '../../shared/local-windows-terminal-runtime'
 import { isWslUncPath } from '../../shared/wsl-paths'
 import { wslUncDirectoryExists } from '../wsl'
 import { wrapShellSpawnForMacosTccAttribution } from './macos-tcc-login-shell'
@@ -163,6 +164,8 @@ export type ShellSpawnParams = {
    *  fails to spawn, the next real absolute executable is tried with its own
    *  recomputed args/cwd. */
   windowsFallbackAttempts?: WindowsShellSpawnAttempt[]
+  /** Native Windows agent PTYs opt into pre-resume Job Object ownership. */
+  useConptyJobObject?: boolean
 }
 
 export type ShellSpawnResult = {
@@ -186,8 +189,18 @@ export type ShellSpawnResult = {
 // has the modern wrap-marker behavior xterm expects; legacy system ConPTY can
 // corrupt full-width TUI rows in scrollback. Without this, degraded-mode and
 // fresh-local spawns silently behave differently from daemon terminals.
-function windowsConptyDllOptions(): { useConptyDll: true } | Record<string, never> {
-  return process.platform === 'win32' ? { useConptyDll: true } : {}
+function windowsConptyOptions(
+  shellPath: string,
+  useConptyJobObject: boolean | undefined
+): { useConptyDll: true; useConptyJobObject?: true } | Record<string, never> {
+  return process.platform === 'win32'
+    ? {
+        useConptyDll: true,
+        ...(useConptyJobObject === true && !isWslShellName(shellPath)
+          ? { useConptyJobObject: true }
+          : {})
+      }
+    : {}
 }
 
 function spawnWindowsFallbackChain(
@@ -205,7 +218,7 @@ function spawnWindowsFallbackChain(
         rows,
         cwd: attempt.effectiveCwd,
         env,
-        ...windowsConptyDllOptions()
+        ...windowsConptyOptions(attempt.shellPath, params.useConptyJobObject)
       })
       console.warn(
         `[pty] Primary shell "${params.shellPath}" failed (${primaryError}), fell back to "${attempt.shellPath}"`
@@ -255,7 +268,7 @@ export function spawnShellWithFallback(params: ShellSpawnParams): ShellSpawnResu
           rows,
           cwd,
           env,
-          ...windowsConptyDllOptions()
+          ...windowsConptyOptions(shellPath, params.useConptyJobObject)
         }),
         shellPath
       }


### PR DESCRIPTION
## Summary

- Opt agent-owned Windows ConPTY roots into a kill-on-close Job Object before their primary thread is resumed.
- Reap descendants on explicit kill and on natural root exit without a PID snapshot or PowerShell/taskkill sweep.
- Keep plain terminals, WSL, Unix, and the current SSH relay path on their existing behavior.
- Force patched Windows `node-pty` installs to build the matching native addon from source.

Fixes #9704

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused verification passed: 10 files / 350 tests, changed-file oxlint and oxfmt, max-lines, patch-hash, lockfile, and diff checks. `pnpm run build:desktop` also passed.

On Windows 11 `10.0.22631` with Node `24.10.0` and VS2019 Build Tools, the final package patch installed cleanly and Orca's product path, `npm_config_build_from_source=true pnpm rebuild node-pty`, produced `winpty-agent.exe`, `winpty.dll`, `conpty.node`, `conpty_console_list.node`, and `pty.node` (`gyp info ok`). A native ConPTY smoke verified that explicit kill and natural root exit both reaped parent/child/grandchild processes, while the plain-terminal control left detached descendants alive until harness cleanup.

The full `pnpm lint` command is currently blocked by the existing `src/renderer/src/components/skills/skill-freshness-group.ts:101` switch-exhaustiveness error on `origin/main`. The full repository test command and the exact template command `pnpm build` were not run; focused tests plus `pnpm run build:desktop` and the Windows native build/smoke were used instead.

## AI Review Report

Independent AI reviews checked Job Object ownership, suspend/assign/resume ordering, handle races, natural-exit cleanup, resume failure, direct-root fallback, daemon/local ownership, plain-terminal and WSL exclusion, patch integrity, and cross-platform routing. Earlier review findings about cleanup lock placement and native warning-prone handle reuse were corrected and covered by contract tests; the final review returned spec-compliance `PASS` and code-quality `APPROVED`.

The cross-platform review explicitly covered macOS, Linux, Windows, WSL, daemon/local providers, Electron native rebuild selection, shell behavior, and SSH relay scope. No shortcut, label, or UI behavior changed.

## Security Audit

Reviewed process-termination scope, native handle lifetime, failure cleanup, command execution, path handling, IPC/API threading, dependencies, and secrets. Job Object ownership is opt-in only for recognized agent PTYs; ordinary terminals are excluded. The implementation removes the proposed PowerShell/PID sweep, introduces no user-derived shell command, adds no dependency or secret handling, and falls back only to terminating the known root when Job setup fails.

## Notes

Windows local and daemon-owned agent PTYs are covered, including the remote-server daemon path. Windows SSH relay remains unchanged because it installs vanilla `node-pty`; shipping the patched native addon through that boundary is tracked separately by TODO #1693.

The issue also discusses why kill requests may be initiated, transient `EAGAIN`, and stale registry entries. This PR fixes descendant cleanup once the agent PTY is killed; it does not claim to change those separate initiators or diagnostics.



## ELI5

On Windows, killing an agent terminal could leave child processes behind. Agent ConPTY sessions join a kill-on-close Job Object so the whole tree dies with the root without sweeping every PID by hand.
