### PR TITLE
feat(tab-bar): add adjustable tab width setting (Hug/Default/Large/X-Large)

### DIFF
--- a/src/renderer/src/components/settings/AppearanceInterfaceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceInterfaceSection.tsx
@@ -19,11 +19,17 @@ import {
   getLanguageEntries,
   getMenuBarIconEntries,
   getSystemTrayEntries,
+  getTabWidthEntries,
   getThemeEntries,
   getTitlebarEntries,
   getTypographyEntries,
   getZoomEntries
 } from './appearance-search'
+import {
+  DEFAULT_TERMINAL_TAB_WIDTH,
+  normalizeTerminalTabWidth,
+  type TerminalTabWidth
+} from '../../../../shared/terminal-tab-width'
 import {
   getUiLanguageChoiceLabel,
   SHOW_UI_LANGUAGE_SETTING,
@@ -66,6 +72,9 @@ export function AppearanceInterfaceSection({
   const titlebarEntry = getTitlebarEntries()[0]
   const typographyEntry = getTypographyEntries()[0]
   const zoomEntry = getZoomEntries()[0]
+  const tabWidthEntry = getTabWidthEntries()[0]
+  const tabWidthLabel = translate('settings.appearance.tabWidth.title', 'Tab Width')
+  const tabWidth = normalizeTerminalTabWidth(settings.terminalTabWidth)
   const advancedEntries = [
     ...(SHOW_UI_LANGUAGE_SETTING ? getLanguageEntries() : []),
     ...getTitlebarEntries(),
@@ -153,6 +162,47 @@ export function AppearanceInterfaceSection({
               onChange={(value) =>
                 updateSettings({ appFontFamily: value.trim() || DEFAULT_APP_FONT_FAMILY })
               }
+            />
+          }
+        />
+      </SearchableSetting>
+
+      <SearchableSetting
+        title={tabWidthLabel}
+        description={tabWidthEntry?.description}
+        keywords={tabWidthEntry?.keywords ?? ['tab', 'width', 'size']}
+        forceVisible={forceVisiblePrimary}
+      >
+        <SettingsRow
+          label={tabWidthLabel}
+          // Why: the presets only shift the flex floor/ceiling; the effect isn't obvious from the labels alone.
+          description={translate(
+            'settings.appearance.tabWidth.description',
+            'Control how wide tabs grow and how narrow they shrink before overflowing.'
+          )}
+          control={
+            <SettingsSegmentedControl
+              ariaLabel={tabWidthLabel}
+              value={tabWidth}
+              onChange={(option: TerminalTabWidth) => updateSettings({ terminalTabWidth: option })}
+              options={[
+                {
+                  value: 'hug',
+                  label: translate('settings.appearance.tabWidth.option.hug', 'Hug')
+                },
+                {
+                  value: DEFAULT_TERMINAL_TAB_WIDTH,
+                  label: translate('settings.appearance.tabWidth.option.default', 'Default')
+                },
+                {
+                  value: 'large',
+                  label: translate('settings.appearance.tabWidth.option.large', 'Large')
+                },
+                {
+                  value: 'x-large',
+                  label: translate('settings.appearance.tabWidth.option.xlarge', 'X-Large')
+                }
+              ]}
             />
           }
         />

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -106,6 +106,23 @@ export const getTypographyEntries = createLocalizedCatalog((): SettingsSearchEnt
   }
 ])
 
+export const getTabWidthEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
+  {
+    title: translate('settings.appearance.tabWidth.title', 'Tab Width'),
+    description: translate(
+      'settings.appearance.tabWidth.description',
+      'Control how wide tabs grow and how narrow they shrink before overflowing.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('settings.appearance.tabWidth.keyword.tab', 'tab'),
+      ...translateSearchKeyword('settings.appearance.tabWidth.keyword.width', 'width'),
+      ...translateSearchKeyword('settings.appearance.tabWidth.keyword.size', 'size'),
+      ...translateSearchKeyword('settings.appearance.tabWidth.keyword.strip', 'tab strip'),
+      ...translateSearchKeyword('settings.appearance.tabWidth.keyword.hug', 'hug')
+    ]
+  }
+])
+
 export const getLayoutEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
   {
     title: translate(
@@ -226,6 +243,7 @@ function buildAppearancePaneSearchEntries(
     ...(SHOW_UI_LANGUAGE_SETTING ? getLanguageEntries() : []),
     ...getTypographyEntries(),
     ...getZoomEntries(),
+    ...getTabWidthEntries(),
     ...getTerminalAppearanceSearchEntries(options),
     ...getLayoutEntries(),
     ...getTitlebarEntries(),

--- a/src/renderer/src/components/tab-bar/BrowserTab.test.tsx
+++ b/src/renderer/src/components/tab-bar/BrowserTab.test.tsx
@@ -132,6 +132,15 @@ vi.mock('../browser-pane/browser-runtime', () => ({
   getLiveBrowserUrl: () => null
 }))
 
+// Why: this shallow harness calls the component as a plain function, so the
+// store-backed width hook can't run; stub it with the default preset's classes.
+vi.mock('./use-tab-container-width', () => ({
+  useTabWidthClasses: () => ({
+    container: 'min-w-[120px] max-w-[280px] flex-[1_1_180px] min-[1280px]:flex-[1_1_220px]',
+    label: 'min-w-0 flex-1 truncate'
+  })
+}))
+
 type ReactElementLike = {
   type: unknown
   props: Record<string, unknown>

--- a/src/renderer/src/components/tab-bar/BrowserTab.tsx
+++ b/src/renderer/src/components/tab-bar/BrowserTab.tsx
@@ -24,7 +24,7 @@ import {
 } from './drop-indicator'
 import { preventMiddleButtonDefault } from './middle-button-default-guard'
 import { translate } from '@/i18n/i18n'
-import { TAB_CONTAINER_WIDTH_CLASSES, TAB_LABEL_WIDTH_CLASSES } from './tab-width-rules'
+import { useTabWidthClasses } from './use-tab-container-width'
 import { TabWorkspaceLayoutMenuSection } from './TabWorkspaceLayoutMenuSection'
 import { useTabStripPointerActivation } from './tab-strip-pointer-activation'
 
@@ -134,6 +134,7 @@ export default function BrowserTab({
     id: tab.id,
     data: dragData
   })
+  const tabWidthClasses = useTabWidthClasses()
   const [menuOpen, setMenuOpen] = useState(false)
   const [menuPoint, setMenuPoint] = useState({ x: 0, y: 0 })
 
@@ -215,7 +216,7 @@ export default function BrowserTab({
           muted-foreground made the icon read as "disabled" in practice. */}
       <BrowserTabFavicon tabId={tab.id} faviconUrl={tab.faviconUrl} />
       {isPinned && <Pin className="mr-1 size-3 shrink-0 text-muted-foreground" aria-hidden />}
-      <span className={`${TAB_LABEL_WIDTH_CLASSES} mr-1`}>{tabLabel}</span>
+      <span className={`${tabWidthClasses.label} mr-1`}>{tabLabel}</span>
       {tab.loading && !tab.loadError && !isBlankBrowserTab(tab) && (
         <span className="mr-1 size-1.5 rounded-full bg-sky-500/80 shrink-0" />
       )}
@@ -241,7 +242,7 @@ export default function BrowserTab({
   return (
     <>
       <div
-        className={TAB_CONTAINER_WIDTH_CLASSES}
+        className={tabWidthClasses.container}
         onContextMenuCapture={(event) => {
           event.preventDefault()
           window.dispatchEvent(new Event(CLOSE_ALL_CONTEXT_MENUS_EVENT))

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -28,7 +28,7 @@ import {
 import { canOpenMarkdownPreview } from '@/components/editor/markdown-preview-controls'
 import { EditorFileTabContextMenu } from './EditorFileTabContextMenu'
 import { translate } from '@/i18n/i18n'
-import { TAB_CONTAINER_WIDTH_CLASSES, TAB_LABEL_WIDTH_CLASSES } from './tab-width-rules'
+import { useTabWidthClasses } from './use-tab-container-width'
 import { EditorFileTabCloseButton } from './EditorFileTabCloseButton'
 import { useTabStripPointerActivation } from './tab-strip-pointer-activation'
 
@@ -97,6 +97,7 @@ export default function EditorFileTab({
     diffSource: file.diffSource
   })
   const openMarkdownPreview = useAppStore((s) => s.openMarkdownPreview)
+  const tabWidthClasses = useTabWidthClasses()
   const [menuOpen, setMenuOpen] = useState(false)
   const [menuPoint, setMenuPoint] = useState({ x: 0, y: 0 })
   const [isRenaming, setIsRenaming] = useState(false)
@@ -315,7 +316,7 @@ export default function EditorFileTab({
           />
         ) : (
           <span
-            className={`${TAB_LABEL_WIDTH_CLASSES}${file.isPreview ? ' italic' : ''}${isMissingFileMutation ? ' line-through' : ''}`}
+            className={`${tabWidthClasses.label}${file.isPreview ? ' italic' : ''}${isMissingFileMutation ? ' line-through' : ''}`}
             style={tabStatusColor ? { color: tabStatusColor } : undefined}
             onDoubleClick={(e) => {
               if (file.isPreview && onMakePermanent) {
@@ -371,7 +372,7 @@ export default function EditorFileTab({
   return (
     <>
       <div
-        className={TAB_CONTAINER_WIDTH_CLASSES}
+        className={tabWidthClasses.container}
         onContextMenuCapture={(event) => {
           event.preventDefault()
           window.dispatchEvent(new Event(CLOSE_ALL_CONTEXT_MENUS_EVENT))

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -20,7 +20,8 @@ import {
 import { preventMiddleButtonDefault } from './middle-button-default-guard'
 import { SortableTabContextMenu } from './SortableTabContextMenu'
 import { translate } from '@/i18n/i18n'
-import { TAB_CONTAINER_WIDTH_CLASSES, TAB_LABEL_WIDTH_CLASSES } from './tab-width-rules'
+import { TAB_EDITING_CONTAINER_WIDTH_CLASSES } from './tab-width-rules'
+import { useTabWidthClasses } from './use-tab-container-width'
 import { useShortcutKeyDetails } from '@/hooks/useShortcutLabel'
 import { useTabStripPointerActivation } from './tab-strip-pointer-activation'
 import { TerminalTabLeadingIcon } from './TerminalTabLeadingIcon'
@@ -103,6 +104,7 @@ export default function SortableTab({
   )
   const renamingTabId = useAppStore((s) => s.renamingTabId)
   const setRenamingTabId = useAppStore((s) => s.setRenamingTabId)
+  const tabWidthClasses = useTabWidthClasses()
 
   // Why: shellOverride is stamped at create time, so changing the default shell later won't repaint existing tabs.
   const shellForIcon = tab.shellOverride
@@ -307,16 +309,16 @@ export default function SortableTab({
           onClick={(event) => event.stopPropagation()}
           onDoubleClick={(event) => event.stopPropagation()}
           onAuxClick={(event) => event.stopPropagation()}
-          // Why: base Input's min-w-0 lets flex shrink it to ~0 in a saturated tab bar; force a usable minimum width.
-          className="mr-1 h-5 min-w-[72px] flex-1 px-1 py-0 text-xs"
+          // Why: base Input's min-w-0 lets flex shrink it to ~0 in a saturated tab bar; force a usable minimum width so the typed title stays visible.
+          className="mr-1 h-5 min-w-[132px] flex-1 px-1 py-0 text-xs"
           spellCheck={false}
         />
       ) : isEditing || menuOpen ? (
-        <span className={`${TAB_LABEL_WIDTH_CLASSES} mr-1`}>{displayTitle}</span>
+        <span className={`${tabWidthClasses.label} mr-1`}>{displayTitle}</span>
       ) : (
         <Tooltip>
           <TooltipTrigger asChild>
-            <span className={`${TAB_LABEL_WIDTH_CLASSES} mr-1`}>{displayTitle}</span>
+            <span className={`${tabWidthClasses.label} mr-1`}>{displayTitle}</span>
           </TooltipTrigger>
           <TooltipContent
             side="bottom"
@@ -401,7 +403,7 @@ export default function SortableTab({
   return (
     <>
       <div
-        className={TAB_CONTAINER_WIDTH_CLASSES}
+        className={isEditing ? TAB_EDITING_CONTAINER_WIDTH_CLASSES : tabWidthClasses.container}
         onContextMenuCapture={(event) => {
           event.preventDefault()
           window.dispatchEvent(new Event(CLOSE_ALL_CONTEXT_MENUS_EVENT))

--- a/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
+++ b/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
@@ -12,6 +12,7 @@ import type { TabDragItemData } from '../tab-group/useTabDragSplit'
 import BrowserTab from './BrowserTab'
 import EditorFileTab from './EditorFileTab'
 import SortableTab from './SortableTab'
+import { getTabContainerWidthClasses } from './tab-width-rules'
 
 let mockTabAgent: TuiAgent | null = null
 
@@ -188,9 +189,10 @@ function textSpanHtml(markup: string, text: string): string {
 
 function expectTabContainerWidth(markup: string, root: string): void {
   const container = firstOpeningTag(markup)
-  const widthClasses = 'min-w-[88px] max-w-[280px] flex-[1_1_180px] min-[1280px]:flex-[1_1_220px]'
+  // Why: derive from source so the default preset's floor/ceiling can change
+  // without this assertion drifting; width lives on the wrapper, never the root.
+  const widthClasses = getTabContainerWidthClasses()
   expect(container).toContain(widthClasses)
-  expect(root).not.toContain('min-w-[88px]')
   expect(root).not.toContain('max-w-[280px]')
   expect(root).not.toContain('flex-[1_1_180px]')
 }

--- a/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
+++ b/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
@@ -193,8 +193,11 @@ function expectTabContainerWidth(markup: string, root: string): void {
   // without this assertion drifting; width lives on the wrapper, never the root.
   const widthClasses = getTabContainerWidthClasses()
   expect(container).toContain(widthClasses)
-  expect(root).not.toContain('max-w-[280px]')
-  expect(root).not.toContain('flex-[1_1_180px]')
+  // Why: assert every width class (incl. min-w) is absent from the root so a
+  // regression that moves any of them off the wrapper can't slip through.
+  for (const widthClass of widthClasses.split(' ')) {
+    expect(root).not.toContain(widthClass)
+  }
 }
 
 function expectTooltipContent(markup: string, text: string): void {

--- a/src/renderer/src/components/tab-bar/tab-width-rules.ts
+++ b/src/renderer/src/components/tab-bar/tab-width-rules.ts
@@ -1,6 +1,38 @@
-// Why: tab strips should reveal as much title as space allows, then shrink to
-// a readable floor before horizontal overflow takes over.
-export const TAB_CONTAINER_WIDTH_CLASSES =
-  'min-w-[88px] max-w-[280px] flex-[1_1_180px] min-[1280px]:flex-[1_1_220px]'
+import {
+  DEFAULT_TERMINAL_TAB_WIDTH,
+  type TerminalTabWidth
+} from '../../../../shared/terminal-tab-width'
 
-export const TAB_LABEL_WIDTH_CLASSES = 'min-w-0 flex-1 truncate'
+// Why: tab strips should reveal as much title as space allows, then shrink to
+// a readable floor before horizontal overflow takes over. The preset controls
+// that floor/ceiling/basis so users trade tab count against readable titles.
+const TAB_CONTAINER_WIDTH_CLASSES_BY_WIDTH: Record<TerminalTabWidth, string> = {
+  // Hug: no grow AND no shrink so the tab sizes to its title and overflows the
+  // strip (scrolls) instead of collapsing; cap so one long title can't dominate.
+  hug: 'min-w-[80px] max-w-[360px] flex-[0_0_auto]',
+  default: 'min-w-[120px] max-w-[280px] flex-[1_1_180px] min-[1280px]:flex-[1_1_220px]',
+  large: 'min-w-[160px] max-w-[340px] flex-[1_1_260px] min-[1280px]:flex-[1_1_300px]',
+  'x-large': 'min-w-[200px] max-w-[420px] flex-[1_1_320px] min-[1280px]:flex-[1_1_380px]'
+}
+
+export function getTabContainerWidthClasses(
+  width: TerminalTabWidth = DEFAULT_TERMINAL_TAB_WIDTH
+): string {
+  return TAB_CONTAINER_WIDTH_CLASSES_BY_WIDTH[width]
+}
+
+// Why: while renaming, the input (and the title being typed) must stay fully visible,
+// so lift the floor well past the normal shrink limit even in a saturated tab strip.
+export const TAB_EDITING_CONTAINER_WIDTH_CLASSES = 'min-w-[180px] max-w-[320px] flex-[1_1_220px]'
+
+// Why: flexible presets give the label basis-0 (flex-1) so it truncates as tabs
+// share the strip. Hug instead lets the label take its natural text width so the
+// tab actually wraps the title — flex-1's basis-0 would collapse it to icons.
+const TAB_LABEL_FLEX_WIDTH_CLASSES = 'min-w-0 flex-1 truncate'
+const TAB_LABEL_HUG_WIDTH_CLASSES = 'min-w-0 max-w-full truncate'
+
+export function getTabLabelWidthClasses(
+  width: TerminalTabWidth = DEFAULT_TERMINAL_TAB_WIDTH
+): string {
+  return width === 'hug' ? TAB_LABEL_HUG_WIDTH_CLASSES : TAB_LABEL_FLEX_WIDTH_CLASSES
+}

--- a/src/renderer/src/components/tab-bar/use-tab-container-width.ts
+++ b/src/renderer/src/components/tab-bar/use-tab-container-width.ts
@@ -1,0 +1,18 @@
+import { useAppStore } from '../../store'
+import { normalizeTerminalTabWidth } from '../../../../shared/terminal-tab-width'
+import { getTabContainerWidthClasses, getTabLabelWidthClasses } from './tab-width-rules'
+
+type TabWidthClasses = {
+  container: string
+  label: string
+}
+
+// Why: single source so every tab surface (terminal, browser, editor) shrinks/grows
+// to the same user-chosen preset; selecting a primitive keeps unrelated tabs from re-rendering.
+export function useTabWidthClasses(): TabWidthClasses {
+  const width = useAppStore((s) => normalizeTerminalTabWidth(s.settings?.terminalTabWidth))
+  return {
+    container: getTabContainerWidthClasses(width),
+    label: getTabLabelWidthClasses(width)
+  }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -58,6 +58,16 @@
       "menuBarIcon": {
         "title": "Show Menu Bar Icon",
         "description": "Keep an Orca shortcut and activity indicator in the macOS menu bar."
+      },
+      "tabWidth": {
+        "title": "Tab Width",
+        "description": "Control how wide tabs grow and how narrow they shrink before overflowing.",
+        "option": {
+          "hug": "Hug",
+          "default": "Default",
+          "large": "Large",
+          "xlarge": "X-Large"
+        }
       }
     }
   },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -35,6 +35,16 @@
       "menuBarIcon": {
         "title": "Mostrar icono en la barra de menús",
         "description": "Mantén un acceso directo de Orca e indicador de actividad en la barra de menús de macOS."
+      },
+      "tabWidth": {
+        "title": "Tab Width",
+        "description": "Control how wide tabs grow and how narrow they shrink before overflowing.",
+        "option": {
+          "hug": "Hug",
+          "default": "Default",
+          "large": "Large",
+          "xlarge": "X-Large"
+        }
       }
     }
   },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -35,6 +35,16 @@
       "menuBarIcon": {
         "title": "メニューバーアイコンを表示",
         "description": "macOS メニューバーに Orca のショートカットとアクティビティインジケーターを表示します。"
+      },
+      "tabWidth": {
+        "title": "Tab Width",
+        "description": "Control how wide tabs grow and how narrow they shrink before overflowing.",
+        "option": {
+          "hug": "Hug",
+          "default": "Default",
+          "large": "Large",
+          "xlarge": "X-Large"
+        }
       }
     }
   },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -35,6 +35,16 @@
       "menuBarIcon": {
         "title": "메뉴 바 아이콘 표시",
         "description": "macOS 메뉴 바에 Orca 바로가기 및 활동 표시기를 유지합니다."
+      },
+      "tabWidth": {
+        "title": "Tab Width",
+        "description": "Control how wide tabs grow and how narrow they shrink before overflowing.",
+        "option": {
+          "hug": "Hug",
+          "default": "Default",
+          "large": "Large",
+          "xlarge": "X-Large"
+        }
       }
     }
   },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -35,6 +35,16 @@
       "menuBarIcon": {
         "title": "显示菜单栏图标",
         "description": "在 macOS 菜单栏中保留 Orca 快捷方式和活动指示器。"
+      },
+      "tabWidth": {
+        "title": "Tab Width",
+        "description": "Control how wide tabs grow and how narrow they shrink before overflowing.",
+        "option": {
+          "hug": "Hug",
+          "default": "Default",
+          "large": "Large",
+          "xlarge": "X-Large"
+        }
       }
     }
   },

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -22,6 +22,7 @@ import {
 import { bumpProviderRuntimeSessionGeneration } from '@/lib/provider-runtime-context'
 import { normalizeUiLanguage } from '../../../../shared/ui-language'
 import { normalizeDesktopTerminalScrollbackRows } from '../../../../shared/terminal-scrollback-policy'
+import { normalizeTerminalTabWidth } from '../../../../shared/terminal-tab-width'
 import { translate } from '@/i18n/i18n'
 
 export type SettingsSlice = SettingsSearchState & {
@@ -134,6 +135,9 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
         sanitizedUpdates.terminalScrollbackRows = normalizeDesktopTerminalScrollbackRows(
           updates.terminalScrollbackRows
         )
+      }
+      if ('terminalTabWidth' in updates) {
+        sanitizedUpdates.terminalTabWidth = normalizeTerminalTabWidth(updates.terminalTabWidth)
       }
       const nextSettings = await window.api.settings.set(sanitizedUpdates)
       set((s) => ({ settings: (nextSettings as GlobalSettings | undefined) ?? s.settings }))

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -24,6 +24,7 @@ import { DEFAULT_BROWSER_PAGE_ZOOM_LEVEL } from './browser-page-zoom'
 import { DEFAULT_DISABLED_TUI_AGENTS } from './tui-agent-selection'
 import { DEFAULT_TUI_AGENT_ARGS, DEFAULT_TUI_AGENT_ENV } from './tui-agent-launch-defaults'
 import { UI_LANGUAGE_SYSTEM } from './ui-language'
+import { DEFAULT_TERMINAL_TAB_WIDTH } from './terminal-tab-width'
 import {
   DEFAULT_LEFT_SIDEBAR_TINT_COLOR,
   DEFAULT_LEFT_SIDEBAR_TINT_OPACITY
@@ -239,6 +240,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalWindowsPowerShellImplementation: 'auto',
     terminalMouseHideWhileTyping: false,
     terminalQuickCommands: getDefaultTerminalQuickCommands(),
+    terminalTabWidth: DEFAULT_TERMINAL_TAB_WIDTH,
     // Why: opt-in only, matching Ghostty's default (upgrades never enable it unexpectedly).
     terminalFocusFollowsMouse: false,
     windowBackgroundBlur: false,

--- a/src/shared/terminal-tab-width.test.ts
+++ b/src/shared/terminal-tab-width.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_TERMINAL_TAB_WIDTH,
+  normalizeTerminalTabWidth,
+  TERMINAL_TAB_WIDTH_VALUES
+} from './terminal-tab-width'
+
+describe('normalizeTerminalTabWidth', () => {
+  it('passes through every known preset', () => {
+    for (const value of TERMINAL_TAB_WIDTH_VALUES) {
+      expect(normalizeTerminalTabWidth(value)).toBe(value)
+    }
+  })
+
+  it('falls back to the default for unknown, legacy, or malformed values', () => {
+    for (const value of [undefined, null, '', 'medium', 'HUG', 42, {}]) {
+      expect(normalizeTerminalTabWidth(value)).toBe(DEFAULT_TERMINAL_TAB_WIDTH)
+    }
+  })
+})

--- a/src/shared/terminal-tab-width.ts
+++ b/src/shared/terminal-tab-width.ts
@@ -1,0 +1,30 @@
+// Why: the tab strip's shrink floor/ceiling is a taste tradeoff — some users want
+// many narrow tabs, others want fewer tabs with readable titles. This enumerates
+// the presets so the renderer's flex rules and the settings UI agree on one source.
+export const TERMINAL_TAB_WIDTH_HUG = 'hug'
+export const TERMINAL_TAB_WIDTH_DEFAULT = 'default'
+export const TERMINAL_TAB_WIDTH_LARGE = 'large'
+export const TERMINAL_TAB_WIDTH_XLARGE = 'x-large'
+
+export type TerminalTabWidth =
+  | typeof TERMINAL_TAB_WIDTH_HUG
+  | typeof TERMINAL_TAB_WIDTH_DEFAULT
+  | typeof TERMINAL_TAB_WIDTH_LARGE
+  | typeof TERMINAL_TAB_WIDTH_XLARGE
+
+export const DEFAULT_TERMINAL_TAB_WIDTH: TerminalTabWidth = TERMINAL_TAB_WIDTH_DEFAULT
+
+export const TERMINAL_TAB_WIDTH_VALUES: readonly TerminalTabWidth[] = [
+  TERMINAL_TAB_WIDTH_HUG,
+  TERMINAL_TAB_WIDTH_DEFAULT,
+  TERMINAL_TAB_WIDTH_LARGE,
+  TERMINAL_TAB_WIDTH_XLARGE
+]
+
+const TERMINAL_TAB_WIDTH_SET = new Set<TerminalTabWidth>(TERMINAL_TAB_WIDTH_VALUES)
+
+export function normalizeTerminalTabWidth(value: unknown): TerminalTabWidth {
+  return TERMINAL_TAB_WIDTH_SET.has(value as TerminalTabWidth)
+    ? (value as TerminalTabWidth)
+    : DEFAULT_TERMINAL_TAB_WIDTH
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -34,6 +34,7 @@ import type { SleepingAgentLaunchConfig, SleepingAgentSessionRecord } from './ag
 import type { ClaudeAgentTeamsMode } from './claude-agent-teams-tmux-compat'
 import type { TerminalCustomTheme } from './terminal-custom-themes'
 import type { UiLanguage } from './ui-language'
+import type { TerminalTabWidth } from './terminal-tab-width'
 import type { ForkSyncMode } from './git-fork-sync'
 import type { GitRemoteIdentity } from './git-remote-identity'
 import type {
@@ -2665,6 +2666,8 @@ export type GlobalSettings = {
   terminalWordSeparator?: string
   terminalCursorOpacity?: number
   terminalQuickCommands?: TerminalQuickCommand[]
+  /** Tab-strip width preset: how narrow tabs may shrink before overflow / how wide they grow. */
+  terminalTabWidth?: TerminalTabWidth
   windowBackgroundBlur?: boolean
   /** Windows-only: close (X) hides to tray instead of quitting; the tray icon is always present regardless. */
   minimizeToTrayOnClose?: boolean


### PR DESCRIPTION
## Summary

Adds an **Appearance → Interface → Tab Width** preset so renamed tab titles stay readable. Closes #9741.

Presets (segmented control, searchable): **Hug · Default · Large · X-Large**. `Default` reproduces today's behavior exactly, so existing users see no change until they opt in. The preset drives the flex floor/ceiling/basis for **terminal, browser, and editor** tabs through one shared hook (`useTabWidthClasses`) so the whole strip stays consistent.

- **Hug** sizes each tab to its own title (`flex-[0_0_auto]`, capped at 360px) and lets the strip scroll, instead of collapsing the label to just the icons.
- **Large / X-Large** raise the min/basis/max so more of the title shows before truncation.
- New shared `TerminalTabWidth` type + `normalizeTerminalTabWidth` guard, added to `GlobalSettings` (defaults to `default`, normalized on update like the other enum settings). Localization keys added to all 5 locale catalogs via `sync:localization-catalog`.

## Screenshots

_Adding a short before/after recording of switching presets — will attach._ <!-- l3aki: drag-drop the Hug/Default screenshots here in the GitHub PR editor -->

## Testing

- [x] `pnpm typecheck` — passes (node, cli, web)
- [x] `pnpm test` — added/updated tests; ran the `tab-bar`, `store/slices/settings`, and new `terminal-tab-width` suites green (203 + settings + normalizer tests). Full suite not run locally; relying on CI.
- [ ] `pnpm lint` — changed files are lint-clean (oxlint + oxfmt via pre-commit). The repo-wide run surfaces one **pre-existing** `switch-exhaustiveness` finding in `skills/skill-freshness-group.tsx` that also exists on `main` and is unrelated to this change.
- [x] `pnpm build` — passes locally (full desktop + native macOS build, exit 0).
- [x] Added/updated tests: unit test for `normalizeTerminalTabWidth`; updated `tab-title-tooltip` + `BrowserTab` tests for the new width source/hook.

## AI Review Report

Reviewed with Claude Code. Focus areas and results:

- **Cross-platform (macOS/Linux/Windows):** no platform-specific code paths, no keyboard shortcuts, no filesystem paths, no shell behavior. The change is Tailwind class selection + a settings enum, so behavior is identical across OSes and inside Electron. Verified nothing touches `metaKey`/`ctrlKey`, path joining, or Electron accelerators.
- **SSH / remote:** the setting is a renderer-side preference persisted through the existing `settings.set` flow; it does not add any filesystem/git/PTY operation, so relay/SSH hosts are unaffected.
- **Consistency:** flagged that terminal, browser, and editor tabs each read the width independently — consolidated them onto one `useTabWidthClasses` hook so a preset can never desync across tab types.
- **Hug regression risk:** original Hug used `flex-1` (basis-0) on the label, which collapsed the tab instead of hugging the title; corrected to natural-width label + `flex-[0_0_auto]` container with a 360px cap so one long title can't dominate the strip (which scrolls).

## Security Audit

- **Input handling:** the only new input is the preset value, which is passed through `normalizeTerminalTabWidth` (allow-list of 4 known strings) before use — an unknown/tampered value falls back to `default`, so no arbitrary string reaches the class list. No class-injection surface.
- **Command execution / paths / secrets:** none introduced.
- **IPC:** no new IPC surface; reuses the existing audited `settings.set` contract. No preload changes.
- **Dependencies:** no new dependencies.

## Notes

- Hug keeps a 360px cap so a single very long title can't take over the strip; happy to make it configurable or unbounded if maintainers prefer.
- Labeled "Tab Width" (applies to every tab type in the strip) rather than terminal-only, to keep the strip visually consistent.



## ELI5

Tab titles can be hard to read when tabs are squeezed. Appearance → Tab Width adds Hug/Default/Large/X-Large presets so terminal, browser, and editor tabs share a readable width you choose.
