### PR TITLE
fix(claude-auth): keep refresh failures from clobbering fresh login

### DIFF
--- a/src/main/claude-accounts/runtime-auth-service.test.ts
+++ b/src/main/claude-accounts/runtime-auth-service.test.ts
@@ -18,6 +18,8 @@ import { getDefaultSettings } from '../../shared/constants'
 import type { ClaudeManagedAccount, GlobalSettings } from '../../shared/types'
 import { isOauthTokenExpiring, refreshClaudeOauthCredentials } from './oauth-refresh'
 
+type IsOauthTokenExpiringFn = typeof isOauthTokenExpiring
+
 const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
 const hostPlatform = process.platform
 const testState = {
@@ -1084,7 +1086,12 @@ describe('ClaudeRuntimeAuthService', () => {
   it('rematerializes managed credentials over a wiped runtime blob while a Claude terminal is live', async () => {
     setPlatform('win32')
     const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
-    const originalCredentials = createClaudeCredentialsJson('user@example.com', 'original', 'org-a')
+    const originalCredentials = createClaudeCredentialsJson(
+      'user@example.com',
+      'original',
+      'org-a',
+      1_000
+    )
     // Why: Claude CLI wipes tokens in place (keeps identity fields) after an
     // invalid_grant refresh — the exact blob shape this regression guards.
     const parsedOriginal = JSON.parse(originalCredentials) as {
@@ -1107,24 +1114,31 @@ describe('ClaudeRuntimeAuthService', () => {
       claudeManagedAccounts: [
         createClaudeAccount('account-1', managedAuthPath, { organizationUuid: 'org-a' })
       ],
-      activeClaudeManagedAccountId: 'account-1'
+      activeClaudeManagedAccountId: null
     })
     const store = createStore(settings)
 
     const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
     const { markClaudePtyExited, markClaudePtySpawned } = await import('./live-pty-gate')
+    const actualOauthRefresh = await vi.importActual<{
+      isOauthTokenExpiring: IsOauthTokenExpiringFn
+    }>('./oauth-refresh')
     const service = new ClaudeRuntimeAuthService(store as never)
     await service.syncForCurrentSelection()
 
+    vi.mocked(isOauthTokenExpiring).mockImplementation(actualOauthRefresh.isOauthTokenExpiring)
     markClaudePtySpawned('live-claude-pty')
     try {
       writeFileSync(runtimeCredentialsPath, wipedCredentials, 'utf-8')
+      store.updateSettings({ activeClaudeManagedAccountId: 'account-1' })
       await service.syncForCurrentSelection()
 
+      expect(refreshClaudeOauthCredentials).not.toHaveBeenCalled()
       expect(readManagedCredentialsForTest('account-1', managedAuthPath)).toBe(originalCredentials)
       expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(originalCredentials)
     } finally {
       markClaudePtyExited('live-claude-pty')
+      vi.mocked(isOauthTokenExpiring).mockReturnValue(false)
     }
   })
 
@@ -3821,7 +3835,260 @@ describe('ClaudeRuntimeAuthService', () => {
     expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(account1Refreshed)
   })
 
-  it('refreshes the active account with an expired token when no Claude PTY is live', async () => {
+  it('does not materialize an expired managed credential after refresh failure', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const freshRuntimeCredentials = createClaudeCredentialsJson(
+      'one@example.com',
+      'fresh-runtime',
+      null,
+      9_999_999_999_999
+    )
+    const expiredManagedCredentials = createClaudeCredentialsJson(
+      'one@example.com',
+      'one-expired',
+      null,
+      1_000
+    )
+    writeFileSync(runtimeCredentialsPath, freshRuntimeCredentials, 'utf-8')
+    testState.scopedKeychainCredentials = freshRuntimeCredentials
+    testState.legacyKeychainCredentials = freshRuntimeCredentials
+    const managedAuthPath1 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      expiredManagedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath1, { email: 'one@example.com' })
+      ],
+      activeClaudeManagedAccountId: null
+    })
+    const store = createStore(settings)
+
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.syncForCurrentSelection()
+
+    vi.mocked(isOauthTokenExpiring).mockReturnValue(true)
+    try {
+      vi.mocked(refreshClaudeOauthCredentials).mockResolvedValue(null)
+      store.updateSettings({ activeClaudeManagedAccountId: 'account-1' })
+      await service.syncForCurrentSelection()
+
+      expect(refreshClaudeOauthCredentials).toHaveBeenCalled()
+      expect.soft(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(freshRuntimeCredentials)
+      expect.soft(testState.runtimeWriteConfigDir).toBeNull()
+      expect.soft(testState.scopedKeychainCredentials).toBe(freshRuntimeCredentials)
+    } finally {
+      vi.mocked(isOauthTokenExpiring).mockReturnValue(false)
+    }
+  })
+
+  it('does not materialize a managed credential with non-numeric expiresAt after refresh failure', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const freshRuntimeCredentials = createClaudeCredentialsJson(
+      'one@example.com',
+      'fresh-runtime',
+      null,
+      9_999_999_999_999
+    )
+    const parsedManagedCredentials = JSON.parse(
+      createClaudeCredentialsJson('one@example.com', 'one-expired', null, 1_000)
+    ) as { claudeAiOauth: Record<string, unknown> }
+    const malformedManagedCredentials = JSON.stringify({
+      ...parsedManagedCredentials,
+      claudeAiOauth: {
+        ...parsedManagedCredentials.claudeAiOauth,
+        expiresAt: 'not-a-number'
+      }
+    })
+    writeFileSync(runtimeCredentialsPath, freshRuntimeCredentials, 'utf-8')
+    testState.scopedKeychainCredentials = freshRuntimeCredentials
+    testState.legacyKeychainCredentials = freshRuntimeCredentials
+    const managedAuthPath1 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      malformedManagedCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath1, { email: 'one@example.com' })
+      ],
+      activeClaudeManagedAccountId: null
+    })
+    const store = createStore(settings)
+
+    const actualOauthRefresh = await vi.importActual<{
+      isOauthTokenExpiring: IsOauthTokenExpiringFn
+    }>('./oauth-refresh')
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+    await service.syncForCurrentSelection()
+
+    vi.mocked(isOauthTokenExpiring).mockImplementation(actualOauthRefresh.isOauthTokenExpiring)
+    try {
+      vi.mocked(refreshClaudeOauthCredentials).mockResolvedValue(null)
+      store.updateSettings({ activeClaudeManagedAccountId: 'account-1' })
+      await service.syncForCurrentSelection()
+
+      expect(refreshClaudeOauthCredentials).toHaveBeenCalledWith(malformedManagedCredentials)
+      expect.soft(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(freshRuntimeCredentials)
+      expect.soft(testState.runtimeWriteConfigDir).toBeNull()
+      expect.soft(testState.scopedKeychainCredentials).toBe(freshRuntimeCredentials)
+    } finally {
+      vi.mocked(isOauthTokenExpiring).mockReturnValue(false)
+    }
+  })
+
+  it('restores the system-default runtime snapshot when switching into an expired account whose refresh fails', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const systemDefaultCredentials = createClaudeCredentialsJson(
+      'system@example.com',
+      'system-default',
+      null,
+      9_999_999_999_999
+    )
+    const currentAccountCredentials = createClaudeCredentialsJson(
+      'one@example.com',
+      'one-current',
+      null,
+      9_999_999_999_999
+    )
+    const expiredTargetCredentials = createClaudeCredentialsJson(
+      'two@example.com',
+      'two-expired',
+      null,
+      1_000
+    )
+    writeFileSync(runtimeCredentialsPath, systemDefaultCredentials, 'utf-8')
+    const managedAuthPath1 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      currentAccountCredentials
+    )
+    const managedAuthPath2 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-2',
+      expiredTargetCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath1, { email: 'one@example.com' }),
+        createClaudeAccount('account-2', managedAuthPath2, { email: 'two@example.com' })
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const actualOauthRefresh = await vi.importActual<{
+      isOauthTokenExpiring: IsOauthTokenExpiringFn
+    }>('./oauth-refresh')
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+
+    vi.mocked(isOauthTokenExpiring).mockImplementation(actualOauthRefresh.isOauthTokenExpiring)
+    try {
+      await service.syncForCurrentSelection()
+      expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(currentAccountCredentials)
+
+      vi.mocked(refreshClaudeOauthCredentials).mockResolvedValue(null)
+      store.updateSettings({ activeClaudeManagedAccountId: 'account-2' })
+      await service.syncForCurrentSelection()
+
+      expect(refreshClaudeOauthCredentials).toHaveBeenCalledWith(expiredTargetCredentials)
+      const runtimeAfterSwitch = existsSync(runtimeCredentialsPath)
+        ? readFileSync(runtimeCredentialsPath, 'utf-8')
+        : null
+      expect(runtimeAfterSwitch).not.toBe(currentAccountCredentials)
+      expect([systemDefaultCredentials, null]).toContain(runtimeAfterSwitch)
+      expect(readManagedCredentialsForTest('account-1', managedAuthPath1)).toBe(
+        currentAccountCredentials
+      )
+      expect(readManagedCredentialsForTest('account-2', managedAuthPath2)).toBe(
+        expiredTargetCredentials
+      )
+    } finally {
+      vi.mocked(isOauthTokenExpiring).mockReturnValue(false)
+      vi.mocked(refreshClaudeOauthCredentials).mockResolvedValue(null)
+    }
+  })
+
+  it('restores the previous runtime footprint when the last synced account was removed before an expired switch fails', async () => {
+    const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
+    const systemDefaultCredentials = createClaudeCredentialsJson(
+      'system@example.com',
+      'system-default',
+      null,
+      9_999_999_999_999
+    )
+    const removedAccountCredentials = createClaudeCredentialsJson(
+      'one@example.com',
+      'one-current',
+      null,
+      9_999_999_999_999
+    )
+    const expiredTargetCredentials = createClaudeCredentialsJson(
+      'two@example.com',
+      'two-expired',
+      null,
+      1_000
+    )
+    writeFileSync(runtimeCredentialsPath, systemDefaultCredentials, 'utf-8')
+    const managedAuthPath1 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-1',
+      removedAccountCredentials
+    )
+    const managedAuthPath2 = createManagedClaudeAuth(
+      testState.userDataDir,
+      'account-2',
+      expiredTargetCredentials
+    )
+    const settings = createSettings({
+      claudeManagedAccounts: [
+        createClaudeAccount('account-1', managedAuthPath1, { email: 'one@example.com' }),
+        createClaudeAccount('account-2', managedAuthPath2, { email: 'two@example.com' })
+      ],
+      activeClaudeManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+
+    const actualOauthRefresh = await vi.importActual<{
+      isOauthTokenExpiring: IsOauthTokenExpiringFn
+    }>('./oauth-refresh')
+    const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
+    const service = new ClaudeRuntimeAuthService(store as never)
+
+    vi.mocked(isOauthTokenExpiring).mockImplementation(actualOauthRefresh.isOauthTokenExpiring)
+    try {
+      await service.syncForCurrentSelection()
+      expect(readFileSync(runtimeCredentialsPath, 'utf-8')).toBe(removedAccountCredentials)
+
+      store.updateSettings({
+        claudeManagedAccounts: [
+          createClaudeAccount('account-2', managedAuthPath2, { email: 'two@example.com' })
+        ],
+        activeClaudeManagedAccountId: 'account-2'
+      })
+      vi.mocked(refreshClaudeOauthCredentials).mockResolvedValue(null)
+      await service.syncForCurrentSelection()
+
+      const runtimeAfterSwitch = existsSync(runtimeCredentialsPath)
+        ? readFileSync(runtimeCredentialsPath, 'utf-8')
+        : null
+      expect(refreshClaudeOauthCredentials).toHaveBeenCalledWith(expiredTargetCredentials)
+      expect(runtimeAfterSwitch).not.toBe(removedAccountCredentials)
+      expect([systemDefaultCredentials, null]).toContain(runtimeAfterSwitch)
+      expect(readManagedCredentialsForTest('account-2', managedAuthPath2)).toBe(
+        expiredTargetCredentials
+      )
+    } finally {
+      vi.mocked(isOauthTokenExpiring).mockReturnValue(false)
+      vi.mocked(refreshClaudeOauthCredentials).mockResolvedValue(null)
+    }
+  })
+
+  it('materializes refreshed managed credentials after refresh success', async () => {
     const runtimeCredentialsPath = join(testState.fakeHomeDir, '.claude', '.credentials.json')
     const expired = createClaudeCredentialsJson('one@example.com', 'one-expired', null, 1_000)
     const refreshedCreds = createClaudeCredentialsJson(
@@ -3841,8 +4108,8 @@ describe('ClaudeRuntimeAuthService', () => {
     })
     const store = createStore(settings)
 
-    vi.mocked(isOauthTokenExpiring).mockReturnValue(true)
-    vi.mocked(refreshClaudeOauthCredentials).mockResolvedValue(refreshedCreds)
+    vi.mocked(isOauthTokenExpiring).mockReturnValueOnce(true)
+    vi.mocked(refreshClaudeOauthCredentials).mockResolvedValueOnce(refreshedCreds)
 
     const { ClaudeRuntimeAuthService } = await import('./runtime-auth-service')
     const service = new ClaudeRuntimeAuthService(store as never)

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -417,6 +417,23 @@ export class ClaudeRuntimeAuthService {
         credentialsJson = refreshed
       }
     }
+    // Why: a live Claude PTY can still own and later refresh a wiped runtime
+    // blob, so only the non-live path fails closed on an expired snapshot.
+    if (!liveClaudePtys && isOauthTokenExpiring(credentialsJson)) {
+      console.warn(
+        '[claude-runtime-auth] Skipping runtime materialization for expired managed credentials after refresh failure'
+      )
+      if (previousAccount && previousAccount.id !== activeAccount.id) {
+        await this.restoreSystemDefaultSnapshotForMissingManagedCredentials(
+          previousAccount,
+          previousManagedOauthAccount
+        )
+      } else if (!previousAccount && this.hasMaterializedRuntimeAuth) {
+        await this.restoreSystemDefaultSnapshot(this.lastWrittenCredentialsJson, undefined)
+      }
+      this.lastSyncedAccountId = activeAccount.id
+      return
+    }
 
     const paths = this.pathResolver.getRuntimePaths()
     this.writeRuntimeCredentials(credentialsJson)


### PR DESCRIPTION
## Summary

- Stop `ClaudeRuntimeAuthService` from rewriting shared Claude runtime auth with an already-expired managed snapshot after a failed proactive refresh.
- Keep a failed switch into another expired managed account from leaving the previous runtime footprint active in shared Claude auth.
- Keep the successful-refresh materialization path and the live-PTY defer/read-back path unchanged. Caller policy stays in `ClaudeRuntimeAuthService`; `ClaudeAccountService` and `index.ts` still route through `syncForCurrentSelection()` and `prepareForRateLimitFetch()` without a new bypass.
- Scope stays limited to the local stale-materialization invariant behind issue https://github.com/stablyai/orca/issues/9582. The broader token-family revocation and multi-writer race remain out of scope.

Refs #9582.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/claude-accounts/runtime-auth-service.test.ts` - pass, `Tests 100 passed (100)`
- `pnpm run typecheck:node` - pass, `tsc --noEmit -p config/tsconfig.node.json`
- `pnpm exec oxlint src/main/claude-accounts/runtime-auth-service.ts src/main/claude-accounts/runtime-auth-service.test.ts` - pass, no diagnostics emitted
- `pnpm exec oxfmt --check src/main/claude-accounts/runtime-auth-service.ts src/main/claude-accounts/runtime-auth-service.test.ts` - pass, `All matched files use the correct format.`

## AI Review Report

Reviewed surface is limited to the Claude managed-account runtime sync in main-process auth code. The change keeps Linux and Windows runtime-file behavior intact for valid credentials, prevents darwin keychain writes only when the selected managed credential is still expired after refresh, leaves renderer, SSH, remote-runtime, and provider-routing logic untouched, and adds no UI or performance claims.

## Security Audit

The change stays inside the existing runtime-auth service, adds no new commands, IPC, or path inputs, and fails closed by refusing to promote an expired managed credential after refresh failure. No new secret surfaces, subprocesses, or trust-boundary crossings are introduced beyond the existing runtime credential and keychain materialization path.

## Notes

Attribution: the current-tree reproduction and implementation sketch came from https://github.com/stablyai/orca/issues/9582#issuecomment-5029408794.

Scope boundary: this PR does not claim to fix the broader token-family revocation or cross-process multi-writer race described in the upstream issue.

Proof points:

- The refresh-failure repro failed on `origin/main`, where the stale managed credential overwrote the fresher runtime login, and passed on this branch.
- A second refresh-failure repro with non-numeric `expiresAt` metadata also failed on `origin/main` and preserved the fresher runtime login on this branch.
- The same repro showed the darwin runtime keychain write on `origin/main` and no write on this branch.
- The successful-refresh materialization path still passed on this branch.
- Switching from one managed account to another no longer leaves the previous runtime footprint active when the incoming expired account fails refresh.
- The same failed-switch cleanup still restores or clears the previous runtime footprint when the last synced account disappeared from settings before the incoming expired account failed refresh.
- The live-PTY wiped-runtime boundary still passed on this branch with an expiring managed credential, so deferred refresh does not suppress rematerialization.
- The live-PTY deferred-refresh boundary still passed on this branch.



## ELI5

A failed Claude token refresh could overwrite a good login with an expired snapshot and log you out. Failed refreshes no longer clobber fresh shared auth; successful refresh paths stay the same.
