### PR TITLE
fix(rate-limits): add candidate credential discovery paths for Antigravity CLI (#9122)

### DIFF
--- a/src/main/rate-limits/antigravity-auth.ts
+++ b/src/main/rate-limits/antigravity-auth.ts
@@ -123,6 +123,12 @@ export async function readAntigravityCredentialsFromDisk(
       if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
         continue
       }
+      // Why: a corrupt or unreadable candidate must stay distinguishable from
+      // "no credentials on disk" — both otherwise return null from this loop.
+      console.debug('[rate-limits] failed to read/parse Antigravity credential file', {
+        candidatePath,
+        error: err instanceof Error ? err.message : String(err)
+      })
     }
   }
 

--- a/src/main/rate-limits/antigravity-auth.ts
+++ b/src/main/rate-limits/antigravity-auth.ts
@@ -1,0 +1,221 @@
+import { net } from 'electron'
+import { homedir } from 'node:os'
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
+
+const API_TIMEOUT = 10_000
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
+
+// Why: OpenUsage Antigravity shipped client pair used by AGY binary
+export const ANTIGRAVITY_CLIENT_ID =
+  '1071006060591-2n2a9v6u8l1d2m5d6v3v93n9n0c74a00.apps.googleusercontent.com'
+export const ANTIGRAVITY_CLIENT_SECRET = 'GOCSPX-K58h_8z180j_n28h67209n1h670'
+
+export type AntigravityToken = {
+  access_token: string
+  refresh_token?: string
+  expiry_date?: number
+}
+
+type RawTokenData = {
+  token?: {
+    access_token?: string
+    refresh_token?: string
+    expiry_date?: number | string
+    expiry?: number | string
+    expires_in?: number
+  }
+  access_token?: string
+  refresh_token?: string
+  expiry_date?: number | string
+  expiry?: number | string
+  expires_in?: number
+}
+
+// Why: Minimal source-bound cache prevents 15s poll refresh loops & invalidates naturally when refresh token changes
+let cachedRefreshedToken: {
+  sourceRefreshToken: string
+  accessToken: string
+  expiresAt: number
+} | null = null
+
+/**
+ * Clears source-bound auth state so later reads cannot reuse a stale account token.
+ */
+export function clearAntigravityAuthCache(): void {
+  cachedRefreshedToken = null
+}
+
+/**
+ * Normalizes numeric and ISO expiry values used by Antigravity credential stores.
+ *
+ * @param val Candidate expiry value.
+ * @returns Epoch milliseconds when valid; otherwise `undefined`.
+ */
+export function parseExpiryTimestamp(val: unknown): number | undefined {
+  if (typeof val === 'number') {
+    return val
+  }
+  if (typeof val === 'string') {
+    const parsed = Date.parse(val)
+    if (!Number.isNaN(parsed)) {
+      return parsed
+    }
+  }
+  return undefined
+}
+
+/**
+ * Parses both flat and nested Antigravity token payloads into one credential shape.
+ *
+ * @param data Untrusted credential payload.
+ * @returns A normalized token when the payload contains an access token; otherwise `null`.
+ */
+export function parseAntigravityToken(data: unknown): AntigravityToken | null {
+  if (!data || typeof data !== 'object') {
+    return null
+  }
+  const obj = data as RawTokenData
+  const target =
+    obj.token && typeof obj.token === 'object' && typeof obj.token.access_token === 'string'
+      ? obj.token
+      : obj
+  if (typeof target.access_token !== 'string') {
+    return null
+  }
+
+  const expiry =
+    parseExpiryTimestamp(target.expiry) ??
+    parseExpiryTimestamp(target.expiry_date) ??
+    (typeof target.expires_in === 'number' ? Date.now() + target.expires_in * 1000 : undefined)
+
+  return {
+    access_token: target.access_token,
+    refresh_token: typeof target.refresh_token === 'string' ? target.refresh_token : undefined,
+    expiry_date: expiry
+  }
+}
+
+/**
+ * Searches supported native and compatibility paths for the first valid token payload.
+ *
+ * @param baseHomedir Home directory used to resolve credential candidates.
+ * @returns The first valid token found, or `null` when no candidate is usable.
+ */
+export async function readAntigravityCredentialsFromDisk(
+  baseHomedir = homedir()
+): Promise<AntigravityToken | null> {
+  const candidatePaths = [
+    path.join(baseHomedir, '.gemini', 'antigravity-cli', 'antigravity-oauth-token'),
+    path.join(baseHomedir, '.config', 'antigravity', 'antigravity-oauth-token.json'),
+    path.join(baseHomedir, '.gemini', 'antigravity-cli', 'auth.json'),
+    path.join(baseHomedir, '.gemini', 'antigravity-cli', 'settings.json')
+  ]
+
+  for (const candidatePath of candidatePaths) {
+    try {
+      const raw = await readFile(candidatePath, 'utf-8')
+      const token = parseAntigravityToken(JSON.parse(raw))
+      if (token) {
+        return token
+      }
+    } catch (err) {
+      if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+        continue
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Refreshes an Antigravity access token and caches it against its source refresh token.
+ *
+ * @param refreshToken OAuth refresh token from the native credential store.
+ * @returns The refreshed token, or `null` when the refresh request fails.
+ */
+export async function refreshAntigravityToken(
+  refreshToken: string
+): Promise<AntigravityToken | null> {
+  try {
+    const params = new URLSearchParams({
+      refresh_token: refreshToken,
+      grant_type: 'refresh_token',
+      client_id: ANTIGRAVITY_CLIENT_ID,
+      client_secret: ANTIGRAVITY_CLIENT_SECRET
+    })
+    const res = await net.fetch(GOOGLE_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params.toString(),
+      signal: AbortSignal.timeout(API_TIMEOUT)
+    })
+    if (!res.ok) {
+      return null
+    }
+    const data = (await res.json()) as { access_token?: string; expires_in?: number }
+    if (typeof data.access_token === 'string') {
+      const expiresAt = data.expires_in
+        ? Date.now() + data.expires_in * 1000
+        : Date.now() + 3600 * 1000
+      cachedRefreshedToken = {
+        sourceRefreshToken: refreshToken,
+        accessToken: data.access_token,
+        expiresAt
+      }
+      return {
+        access_token: data.access_token,
+        refresh_token: refreshToken,
+        expiry_date: expiresAt
+      }
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Returns a fresh disk or cached token, refreshing only when the current source requires it.
+ *
+ * @param baseHomedir Home directory used to resolve credential candidates.
+ * @returns The best available token, or `null` when no credentials exist.
+ */
+export async function getValidAntigravityToken(
+  baseHomedir = homedir()
+): Promise<AntigravityToken | null> {
+  const diskToken = await readAntigravityCredentialsFromDisk(baseHomedir)
+  if (!diskToken) {
+    return null
+  }
+
+  // 1. If disk access_token is still fresh, use it directly
+  if (diskToken.expiry_date && diskToken.expiry_date > Date.now() + 60_000) {
+    return diskToken
+  }
+
+  // 2. If disk access_token is expired, check if memory cache has valid refreshed token for exact same refresh_token
+  if (
+    diskToken.refresh_token &&
+    cachedRefreshedToken &&
+    cachedRefreshedToken.sourceRefreshToken === diskToken.refresh_token &&
+    cachedRefreshedToken.expiresAt > Date.now() + 60_000
+  ) {
+    return {
+      access_token: cachedRefreshedToken.accessToken,
+      refresh_token: diskToken.refresh_token,
+      expiry_date: cachedRefreshedToken.expiresAt
+    }
+  }
+
+  // 3. Otherwise refresh via OAuth
+  if (diskToken.refresh_token) {
+    const refreshed = await refreshAntigravityToken(diskToken.refresh_token)
+    if (refreshed) {
+      return refreshed
+    }
+  }
+
+  return diskToken
+}

--- a/src/main/rate-limits/antigravity-usage-fetcher.test.ts
+++ b/src/main/rate-limits/antigravity-usage-fetcher.test.ts
@@ -6,7 +6,11 @@ import {
   ANTIGRAVITY_CLIENT_ID,
   ANTIGRAVITY_CLIENT_SECRET
 } from './antigravity-auth'
-import { parseQuotaResponse, fetchAntigravityRateLimits } from './antigravity-usage-fetcher'
+import {
+  parseQuotaResponse,
+  aggregateAntigravityWindows,
+  fetchAntigravityRateLimits
+} from './antigravity-usage-fetcher'
 
 const { readFileMock, netFetchMock } = vi.hoisted(() => ({
   readFileMock: vi.fn(),
@@ -86,6 +90,45 @@ describe('parseQuotaResponse', () => {
       usedPercent: 15,
       windowMinutes: 10080
     })
+  })
+})
+
+describe('aggregateAntigravityWindows', () => {
+  const bucket = (bucketId: string, windowMinutes: number, usedPercent: number) => ({
+    name: bucketId,
+    usedPercent,
+    windowMinutes,
+    resetsAt: 1_700_000_000_000,
+    resetDescription: null,
+    bucketId
+  })
+
+  it('reports no session window when only weekly buckets are present', () => {
+    const { session, weekly } = aggregateAntigravityWindows([
+      bucket('gemini-weekly', 10080, 42),
+      bucket('3p-weekly', 10080, 77)
+    ])
+
+    expect(session).toBeNull()
+    expect(weekly).toMatchObject({ usedPercent: 77, windowMinutes: 10080 })
+  })
+
+  it('picks the worst 5h bucket for session and the worst weekly for weekly', () => {
+    const { session, weekly } = aggregateAntigravityWindows([
+      bucket('gemini-5h', 300, 30),
+      bucket('3p-5h', 300, 65),
+      bucket('gemini-weekly', 10080, 12)
+    ])
+
+    expect(session).toMatchObject({ usedPercent: 65, windowMinutes: 300 })
+    expect(weekly).toMatchObject({ usedPercent: 12, windowMinutes: 10080 })
+  })
+
+  it('reports no weekly window when only session buckets are present', () => {
+    const { session, weekly } = aggregateAntigravityWindows([bucket('gemini-5h', 300, 8)])
+
+    expect(session).toMatchObject({ usedPercent: 8, windowMinutes: 300 })
+    expect(weekly).toBeNull()
   })
 })
 

--- a/src/main/rate-limits/antigravity-usage-fetcher.test.ts
+++ b/src/main/rate-limits/antigravity-usage-fetcher.test.ts
@@ -1,0 +1,257 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearAntigravityAuthCache,
+  parseAntigravityToken,
+  ANTIGRAVITY_CLIENT_ID,
+  ANTIGRAVITY_CLIENT_SECRET
+} from './antigravity-auth'
+import { parseQuotaResponse, fetchAntigravityRateLimits } from './antigravity-usage-fetcher'
+
+const { readFileMock, netFetchMock } = vi.hoisted(() => ({
+  readFileMock: vi.fn(),
+  netFetchMock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  readFile: readFileMock
+}))
+vi.mock('electron', () => ({ net: { fetch: netFetchMock } }))
+
+/**
+ * Builds a JSON response for mocked Electron network requests.
+ * @param data Response body.
+ * @param status HTTP status code.
+ * @returns A JSON response with the requested status.
+ */
+const mockResponse = (data: unknown, status = 200) =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  })
+
+describe('parseAntigravityToken', () => {
+  it('parses number and ISO string token.expiry correctly', () => {
+    const rawNum = { token: { access_token: 't1', expiry: 1700000000000 } }
+    const rawIso = { token: { access_token: 't2', expiry: '2026-04-24T13:00:00.000Z' } }
+    expect(parseAntigravityToken(rawNum)?.expiry_date).toBe(1700000000000)
+    expect(parseAntigravityToken(rawIso)?.expiry_date).toBe(Date.parse('2026-04-24T13:00:00.000Z'))
+  })
+})
+
+describe('parseQuotaResponse', () => {
+  it('parses four exact buckets and ignores unknown bucketId', () => {
+    const raw = {
+      groups: [
+        {
+          name: 'Gemini Models',
+          buckets: [
+            {
+              remainingFraction: 0.9,
+              resetTime: '2026-04-24T13:00:00.000Z',
+              bucketId: 'gemini-5h'
+            },
+            {
+              remainingFraction: 0.95,
+              resetTime: '2026-04-28T13:00:00.000Z',
+              bucketId: 'gemini-weekly'
+            }
+          ]
+        },
+        {
+          name: 'Claude and GPT',
+          buckets: [
+            { remainingFraction: 0.8, resetTime: '2026-04-24T13:00:00.000Z', bucketId: '3p-5h' },
+            {
+              remainingFraction: 0.85,
+              resetTime: '2026-04-28T13:00:00.000Z',
+              bucketId: '3p-weekly'
+            },
+            {
+              remainingFraction: 0.5,
+              resetTime: '2026-04-24T13:00:00.000Z',
+              bucketId: 'unknown-bucket-x'
+            }
+          ]
+        }
+      ]
+    }
+    const parsed = parseQuotaResponse(raw)
+    expect(parsed).toHaveLength(4)
+    expect(parsed[0]).toMatchObject({ name: 'Gemini 5h', usedPercent: 10, windowMinutes: 300 })
+    expect(parsed[1]).toMatchObject({ name: 'Gemini weekly', usedPercent: 5, windowMinutes: 10080 })
+    expect(parsed[2]).toMatchObject({ name: 'Claude/GPT 5h', usedPercent: 20, windowMinutes: 300 })
+    expect(parsed[3]).toMatchObject({
+      name: 'Claude/GPT weekly',
+      usedPercent: 15,
+      windowMinutes: 10080
+    })
+  })
+})
+
+describe('fetchAntigravityRateLimits MVP orchestration', () => {
+  beforeEach(() => {
+    clearAntigravityAuthCache()
+    readFileMock.mockReset()
+    netFetchMock.mockReset()
+    readFileMock.mockRejectedValue({ code: 'ENOENT' })
+  })
+
+  it('renders all four buckets for UI consumers with correct windowMinutes', async () => {
+    readFileMock.mockImplementation(async () =>
+      JSON.stringify({ access_token: 'valid-tok', refresh_token: 'ref-tok' })
+    )
+
+    netFetchMock.mockImplementation((url: string) => {
+      if (url.includes('loadCodeAssist')) {
+        return Promise.resolve(mockResponse({ cloudaicompanionProject: 'proj-123' }))
+      }
+      if (url.includes('retrieveUserQuotaSummary')) {
+        return Promise.resolve(
+          mockResponse({
+            groups: [
+              {
+                buckets: [
+                  {
+                    remainingFraction: 0.9,
+                    resetTime: '2026-04-24T13:00:00.000Z',
+                    bucketId: 'gemini-5h'
+                  },
+                  {
+                    remainingFraction: 0.95,
+                    resetTime: '2026-04-28T13:00:00.000Z',
+                    bucketId: 'gemini-weekly'
+                  },
+                  {
+                    remainingFraction: 0.8,
+                    resetTime: '2026-04-24T13:00:00.000Z',
+                    bucketId: '3p-5h'
+                  },
+                  {
+                    remainingFraction: 0.85,
+                    resetTime: '2026-04-28T13:00:00.000Z',
+                    bucketId: '3p-weekly'
+                  }
+                ]
+              }
+            ]
+          })
+        )
+      }
+      return Promise.resolve(mockResponse({}, 404))
+    })
+
+    const result = await fetchAntigravityRateLimits(true)
+    expect(result.status).toBe('ok')
+    expect(result.buckets).toHaveLength(4)
+    expect(result.session).not.toBeNull()
+    expect(result.weekly).not.toBeNull()
+  })
+
+  it('retries once when loadCodeAssist returns 401, verifying OpenUsage OAuth client/secret', async () => {
+    let loadAttempts = 0
+    readFileMock.mockImplementation(async () =>
+      JSON.stringify({ access_token: 'stale-tok', refresh_token: 'ref-tok-1' })
+    )
+
+    netFetchMock.mockImplementation((url: string) => {
+      if (url.includes('token')) {
+        return Promise.resolve(mockResponse({ access_token: 'new-tok-1', expires_in: 3600 }))
+      }
+      if (url.includes('loadCodeAssist')) {
+        loadAttempts += 1
+        if (loadAttempts === 1) {
+          return Promise.resolve(mockResponse({}, 401))
+        }
+        return Promise.resolve(mockResponse({ cloudaicompanionProject: 'retry-proj' }))
+      }
+      if (url.includes('retrieveUserQuotaSummary')) {
+        return Promise.resolve(mockResponse({ groups: [] }))
+      }
+      return Promise.resolve(mockResponse({}, 404))
+    })
+
+    const result = await fetchAntigravityRateLimits(true)
+    expect(result.status).toBe('ok')
+    expect(loadAttempts).toBe(2)
+    expect(netFetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('token'),
+      expect.objectContaining({
+        body: expect.stringContaining(`client_id=${ANTIGRAVITY_CLIENT_ID}`)
+      })
+    )
+    expect(netFetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('token'),
+      expect.objectContaining({
+        body: expect.stringContaining(`client_secret=${ANTIGRAVITY_CLIENT_SECRET}`)
+      })
+    )
+  })
+
+  it('does not repeat refresh on second poll cycle within expiry', async () => {
+    let refreshCalls = 0
+    readFileMock.mockImplementation(async () =>
+      JSON.stringify({
+        access_token: 'exp-tok',
+        refresh_token: 'ref-tok-2',
+        expiry: Date.now() - 1000
+      })
+    )
+
+    netFetchMock.mockImplementation((url: string) => {
+      if (url.includes('token')) {
+        refreshCalls += 1
+        return Promise.resolve(mockResponse({ access_token: 'refreshed-tok-2', expires_in: 3600 }))
+      }
+      if (url.includes('loadCodeAssist')) {
+        return Promise.resolve(mockResponse({ cloudaicompanionProject: 'proj-2' }))
+      }
+      if (url.includes('retrieveUserQuotaSummary')) {
+        return Promise.resolve(mockResponse({ groups: [] }))
+      }
+      return Promise.resolve(mockResponse({}, 404))
+    })
+
+    await fetchAntigravityRateLimits(true)
+    await fetchAntigravityRateLimits(true)
+    expect(refreshCalls).toBe(1)
+  })
+
+  it('invalidates memory cache when account switches to a different refresh_token', async () => {
+    let refreshCalls = 0
+    readFileMock
+      .mockImplementationOnce(async () =>
+        JSON.stringify({
+          access_token: 'exp-tok-1',
+          refresh_token: 'acc-1-ref',
+          expiry: Date.now() - 1000
+        })
+      )
+      .mockImplementationOnce(async () =>
+        JSON.stringify({
+          access_token: 'exp-tok-2',
+          refresh_token: 'acc-2-ref',
+          expiry: Date.now() - 1000
+        })
+      )
+
+    netFetchMock.mockImplementation((url: string) => {
+      if (url.includes('token')) {
+        refreshCalls += 1
+        return Promise.resolve(
+          mockResponse({ access_token: `refreshed-tok-${refreshCalls}`, expires_in: 3600 })
+        )
+      }
+      if (url.includes('loadCodeAssist')) {
+        return Promise.resolve(mockResponse({ cloudaicompanionProject: 'proj-acc' }))
+      }
+      if (url.includes('retrieveUserQuotaSummary')) {
+        return Promise.resolve(mockResponse({ groups: [] }))
+      }
+      return Promise.resolve(mockResponse({}, 404))
+    })
+
+    await fetchAntigravityRateLimits(true)
+    await fetchAntigravityRateLimits(true)
+    expect(refreshCalls).toBe(2)
+  })
+})

--- a/src/main/rate-limits/antigravity-usage-fetcher.test.ts
+++ b/src/main/rate-limits/antigravity-usage-fetcher.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   clearAntigravityAuthCache,
   parseAntigravityToken,
+  readAntigravityCredentialsFromDisk,
   ANTIGRAVITY_CLIENT_ID,
   ANTIGRAVITY_CLIENT_SECRET
 } from './antigravity-auth'
@@ -85,6 +86,43 @@ describe('parseQuotaResponse', () => {
       usedPercent: 15,
       windowMinutes: 10080
     })
+  })
+})
+
+describe('readAntigravityCredentialsFromDisk error visibility', () => {
+  beforeEach(() => {
+    clearAntigravityAuthCache()
+    readFileMock.mockReset()
+    netFetchMock.mockReset()
+  })
+
+  it('logs non-ENOENT failures and still falls through to a later candidate', async () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    readFileMock
+      .mockRejectedValueOnce(Object.assign(new Error('permission denied'), { code: 'EACCES' }))
+      .mockResolvedValueOnce('{ not valid json')
+      .mockResolvedValueOnce(
+        JSON.stringify({ access_token: 'from-third-candidate', refresh_token: 'ref' })
+      )
+
+    const token = await readAntigravityCredentialsFromDisk('/home/test')
+
+    expect(token?.access_token).toBe('from-third-candidate')
+    expect(debugSpy).toHaveBeenCalledTimes(2)
+    expect(debugSpy.mock.calls[0][0]).toContain('failed to read/parse Antigravity credential file')
+    expect(debugSpy.mock.calls[0][1]).toMatchObject({ error: 'permission denied' })
+    debugSpy.mockRestore()
+  })
+
+  it('stays silent when every candidate is simply absent', async () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    readFileMock.mockRejectedValue({ code: 'ENOENT' })
+
+    const token = await readAntigravityCredentialsFromDisk('/home/test')
+
+    expect(token).toBeNull()
+    expect(debugSpy).not.toHaveBeenCalled()
+    debugSpy.mockRestore()
   })
 })
 

--- a/src/main/rate-limits/antigravity-usage-fetcher.ts
+++ b/src/main/rate-limits/antigravity-usage-fetcher.ts
@@ -1,0 +1,298 @@
+import { net } from 'electron'
+import { homedir } from 'node:os'
+import type {
+  ProviderRateLimits,
+  RateLimitBucket,
+  RateLimitWindow
+} from '../../shared/rate-limit-types'
+import { getValidAntigravityToken, refreshAntigravityToken } from './antigravity-auth'
+
+const API_TIMEOUT = 10_000
+const RETRIEVE_QUOTA_SUMMARY_URL =
+  'https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuotaSummary'
+const RETRIEVE_QUOTA_URL = 'https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota'
+const LOAD_CODE_ASSIST_URL = 'https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist'
+
+type RawQuotaBucket = {
+  bucketId?: string
+  modelId?: string
+  remainingFraction?: number
+  resetTime?: string
+}
+
+type QuotaGroup = {
+  name?: string
+  buckets?: RawQuotaBucket[]
+}
+
+const EXACT_BUCKET_MAP: Record<string, { name: string; windowMinutes: number }> = {
+  'gemini-5h': { name: 'Gemini 5h', windowMinutes: 300 },
+  'gemini-weekly': { name: 'Gemini weekly', windowMinutes: 10080 },
+  '3p-5h': { name: 'Claude/GPT 5h', windowMinutes: 300 },
+  '3p-weekly': { name: 'Claude/GPT weekly', windowMinutes: 10080 }
+}
+
+/**
+ * Normalizes supported quota payloads while excluding unknown Antigravity bucket IDs.
+ * @param data Untrusted quota response payload.
+ * @returns Recognized quota buckets with their source bucket IDs.
+ */
+export function parseQuotaResponse(data: unknown): (RateLimitBucket & { bucketId: string })[] {
+  let rawBuckets: RawQuotaBucket[] = []
+  if (Array.isArray(data)) {
+    rawBuckets = data as RawQuotaBucket[]
+  } else if (data && typeof data === 'object') {
+    const obj = data as { groups?: QuotaGroup[]; buckets?: RawQuotaBucket[] }
+    if (Array.isArray(obj.groups)) {
+      for (const g of obj.groups) {
+        if (g && Array.isArray(g.buckets)) {
+          rawBuckets.push(...g.buckets)
+        }
+      }
+    } else if (Array.isArray(obj.buckets)) {
+      rawBuckets = obj.buckets
+    }
+  }
+
+  const result: (RateLimitBucket & { bucketId: string })[] = []
+  for (const b of rawBuckets) {
+    if (
+      typeof b.remainingFraction === 'number' &&
+      Number.isFinite(b.remainingFraction) &&
+      typeof b.resetTime === 'string'
+    ) {
+      const bucketId = b.bucketId || b.modelId || ''
+      const config = EXACT_BUCKET_MAP[bucketId]
+      // Why: Skip unknown bucket IDs per OpenUsage exact allowlist to avoid polluting quota pools
+      if (!config) {
+        continue
+      }
+      const usedPercent = Math.min(100, Math.max(0, Math.round((1 - b.remainingFraction) * 100)))
+      const resetsAt = new Date(b.resetTime).getTime()
+      result.push({
+        name: config.name,
+        usedPercent,
+        windowMinutes: config.windowMinutes,
+        resetsAt: !Number.isNaN(resetsAt) ? resetsAt : null,
+        resetDescription: null,
+        bucketId
+      })
+    }
+  }
+  return result
+}
+
+/**
+ * Selects the most-used five-hour and weekly buckets for legacy summary consumers.
+ * @param buckets Normalized Antigravity quota buckets.
+ * @returns Session and weekly summary windows.
+ */
+export function aggregateAntigravityWindows(buckets: (RateLimitBucket & { bucketId: string })[]): {
+  session: RateLimitWindow | null
+  weekly: RateLimitWindow | null
+} {
+  if (buckets.length === 0) {
+    return { session: null, weekly: null }
+  }
+
+  const sessionBuckets = buckets.filter((b) => b.windowMinutes === 300)
+  const targetSession = (sessionBuckets.length > 0 ? sessionBuckets : buckets).reduce((worst, b) =>
+    b.usedPercent > worst.usedPercent ? b : worst
+  )
+
+  const weeklyBuckets = buckets.filter((b) => b.windowMinutes === 10080)
+  const targetWeekly =
+    weeklyBuckets.length > 0
+      ? weeklyBuckets.reduce((worst, b) => (b.usedPercent > worst.usedPercent ? b : worst))
+      : null
+
+  const session: RateLimitWindow = {
+    usedPercent: targetSession.usedPercent,
+    windowMinutes: targetSession.windowMinutes,
+    resetsAt: targetSession.resetsAt,
+    resetDescription: targetSession.resetDescription
+  }
+
+  const weekly: RateLimitWindow | null = targetWeekly
+    ? {
+        usedPercent: targetWeekly.usedPercent,
+        windowMinutes: targetWeekly.windowMinutes,
+        resetsAt: targetWeekly.resetsAt,
+        resetDescription: targetWeekly.resetDescription
+      }
+    : null
+
+  return { session, weekly }
+}
+
+/**
+ * Resolves the Cloud Code project associated with an Antigravity access token.
+ * @param accessToken OAuth access token used for project discovery.
+ * @returns The associated Cloud AI companion project ID.
+ */
+async function loadAntigravityProjectId(accessToken: string): Promise<string> {
+  const res = await net.fetch(LOAD_CODE_ASSIST_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
+    body: JSON.stringify({ metadata: { ideType: 'ANTIGRAVITY', pluginType: 'GEMINI' } }),
+    signal: AbortSignal.timeout(API_TIMEOUT)
+  })
+  if (!res.ok) {
+    const err = new Error(`Failed to load Antigravity project ID (HTTP ${res.status})`)
+    Object.assign(err, { status: res.status })
+    throw err
+  }
+  const data = (await res.json()) as { cloudaicompanionProject?: string }
+  if (typeof data.cloudaicompanionProject !== 'string') {
+    throw new Error('Antigravity project ID not found in API response')
+  }
+  return data.cloudaicompanionProject
+}
+
+/**
+ * Queries the quota-summary endpoint with a legacy endpoint fallback.
+ * @param accessToken OAuth access token used for quota requests.
+ * @param projectId Cloud AI companion project ID.
+ * @returns A normalized HTTP result and parsed response payload when successful.
+ */
+async function queryQuotaEndpoint(
+  accessToken: string,
+  projectId: string
+): Promise<{ ok: boolean; status: number; data?: unknown }> {
+  try {
+    let res = await net.fetch(RETRIEVE_QUOTA_SUMMARY_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
+      body: JSON.stringify({ project: projectId }),
+      signal: AbortSignal.timeout(API_TIMEOUT)
+    })
+    if (!res.ok) {
+      res = await net.fetch(RETRIEVE_QUOTA_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
+        body: JSON.stringify({ project: projectId }),
+        signal: AbortSignal.timeout(API_TIMEOUT)
+      })
+    }
+    if (!res.ok) {
+      return { ok: false, status: res.status }
+    }
+    return { ok: true, status: 200, data: await res.json() }
+  } catch {
+    return { ok: false, status: 500 }
+  }
+}
+
+/**
+ * Fetches independent Antigravity usage and retries the authenticated flow once on rejection.
+ * @param antigravityEnabled Whether the provider is enabled.
+ * @param baseHomedir Home directory used for credential discovery.
+ * @returns The current Antigravity rate-limit state.
+ */
+export async function fetchAntigravityRateLimits(
+  antigravityEnabled = true,
+  baseHomedir = homedir()
+): Promise<ProviderRateLimits> {
+  if (!antigravityEnabled) {
+    return {
+      provider: 'antigravity',
+      session: null,
+      weekly: null,
+      updatedAt: Date.now(),
+      error: 'Antigravity OAuth is disabled in settings',
+      status: 'unavailable'
+    }
+  }
+
+  try {
+    let token = await getValidAntigravityToken(baseHomedir)
+    if (!token) {
+      return {
+        provider: 'antigravity',
+        session: null,
+        weekly: null,
+        updatedAt: Date.now(),
+        error: 'AGY credentials missing',
+        status: 'unavailable'
+      }
+    }
+
+    let isUnauthorized = false
+    let projectId = ''
+    try {
+      projectId = await loadAntigravityProjectId(token.access_token)
+    } catch (err) {
+      if (
+        err &&
+        typeof err === 'object' &&
+        'status' in err &&
+        (err.status === 401 || err.status === 403)
+      ) {
+        isUnauthorized = true
+      } else {
+        return {
+          provider: 'antigravity',
+          session: null,
+          weekly: null,
+          updatedAt: Date.now(),
+          error: 'AGY project ID not found',
+          status: 'error'
+        }
+      }
+    }
+
+    let quotaRes = !isUnauthorized
+      ? await queryQuotaEndpoint(token.access_token, projectId)
+      : { ok: false, status: 401 }
+
+    // Why: Unified 401/403 retry policy refreshes token and retries the full flow once if any authenticated call is rejected
+    if (
+      !quotaRes.ok &&
+      (quotaRes.status === 401 || quotaRes.status === 403) &&
+      token.refresh_token
+    ) {
+      const refreshed = await refreshAntigravityToken(token.refresh_token)
+      if (refreshed) {
+        token = refreshed
+        projectId = await loadAntigravityProjectId(token.access_token).catch(() => '')
+        if (projectId) {
+          quotaRes = await queryQuotaEndpoint(token.access_token, projectId)
+        }
+      }
+    }
+
+    if (!quotaRes.ok || !quotaRes.data) {
+      return {
+        provider: 'antigravity',
+        session: null,
+        weekly: null,
+        updatedAt: Date.now(),
+        error: `AGY quota fetch failed (${quotaRes.status})`,
+        status: 'error'
+      }
+    }
+
+    const rawParsed = parseQuotaResponse(quotaRes.data)
+    const { session, weekly } = aggregateAntigravityWindows(rawParsed)
+    const buckets = rawParsed.map(({ bucketId: _b, ...rest }) => rest)
+
+    return {
+      provider: 'antigravity',
+      session,
+      weekly,
+      buckets,
+      updatedAt: Date.now(),
+      error: null,
+      status: 'ok'
+    }
+  } catch (err) {
+    return {
+      provider: 'antigravity',
+      session: null,
+      weekly: null,
+      updatedAt: Date.now(),
+      error: err instanceof Error ? err.message : 'Unknown error',
+      status: 'error'
+    }
+  }
+}

--- a/src/main/rate-limits/antigravity-usage-fetcher.ts
+++ b/src/main/rate-limits/antigravity-usage-fetcher.ts
@@ -96,9 +96,12 @@ export function aggregateAntigravityWindows(buckets: (RateLimitBucket & { bucket
   }
 
   const sessionBuckets = buckets.filter((b) => b.windowMinutes === 300)
-  const targetSession = (sessionBuckets.length > 0 ? sessionBuckets : buckets).reduce((worst, b) =>
-    b.usedPercent > worst.usedPercent ? b : worst
-  )
+  // Why: falling back to every bucket would surface a weekly (10080-minute)
+  // reading under the session window, so report nothing when no 5h bucket exists.
+  const targetSession =
+    sessionBuckets.length > 0
+      ? sessionBuckets.reduce((worst, b) => (b.usedPercent > worst.usedPercent ? b : worst))
+      : null
 
   const weeklyBuckets = buckets.filter((b) => b.windowMinutes === 10080)
   const targetWeekly =
@@ -106,12 +109,14 @@ export function aggregateAntigravityWindows(buckets: (RateLimitBucket & { bucket
       ? weeklyBuckets.reduce((worst, b) => (b.usedPercent > worst.usedPercent ? b : worst))
       : null
 
-  const session: RateLimitWindow = {
-    usedPercent: targetSession.usedPercent,
-    windowMinutes: targetSession.windowMinutes,
-    resetsAt: targetSession.resetsAt,
-    resetDescription: targetSession.resetDescription
-  }
+  const session: RateLimitWindow | null = targetSession
+    ? {
+        usedPercent: targetSession.usedPercent,
+        windowMinutes: targetSession.windowMinutes,
+        resetsAt: targetSession.resetsAt,
+        resetDescription: targetSession.resetDescription
+      }
+    : null
 
   const weekly: RateLimitWindow | null = targetWeekly
     ? {

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -9,6 +9,7 @@ import { RateLimitService } from './service'
 import { fetchClaudeRateLimits, fetchManagedAccountUsage } from './claude-fetcher'
 import { consumeCodexRateLimitResetCredit, fetchCodexRateLimits } from './codex-fetcher'
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
+import { fetchAntigravityRateLimits } from './antigravity-usage-fetcher'
 import { fetchKimiRateLimits } from './kimi-fetcher'
 import { fetchMiniMaxRateLimits } from './minimax-fetcher'
 import { fetchGrokRateLimits } from './grok-fetcher'
@@ -28,6 +29,10 @@ vi.mock('./codex-fetcher', () => ({
 
 vi.mock('./gemini-usage-fetcher', () => ({
   fetchGeminiRateLimits: vi.fn()
+}))
+
+vi.mock('./antigravity-usage-fetcher', () => ({
+  fetchAntigravityRateLimits: vi.fn()
 }))
 
 vi.mock('./kimi-fetcher', () => ({
@@ -128,6 +133,7 @@ function unavailableProvider(
 function mockFreshBackgroundProviderFetches(): void {
   vi.mocked(fetchCodexRateLimits).mockImplementation(async () => okProvider('codex', 24))
   vi.mocked(fetchGeminiRateLimits).mockImplementation(async () => okProvider('gemini', 0))
+  vi.mocked(fetchAntigravityRateLimits).mockImplementation(async () => okProvider('antigravity', 0))
   vi.mocked(fetchOpenCodeGoRateLimits).mockImplementation(async () => okProvider('opencode-go', 0))
   vi.mocked(fetchKimiRateLimits).mockImplementation(async () => okProvider('kimi', 0))
   vi.mocked(fetchMiniMaxRateLimits).mockImplementation(async () => okProvider('minimax', 0))
@@ -174,6 +180,9 @@ describe('RateLimitService', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(fetchGeminiRateLimits).mockResolvedValue(okProvider('gemini', 0, Date.now()))
+    vi.mocked(fetchAntigravityRateLimits).mockResolvedValue(
+      okProvider('antigravity', 0, Date.now())
+    )
     vi.mocked(fetchOpenCodeGoRateLimits).mockResolvedValue(okProvider('opencode-go', 0, Date.now()))
     vi.mocked(fetchKimiRateLimits).mockResolvedValue(okProvider('kimi', 0, Date.now()))
     vi.mocked(fetchMiniMaxRateLimits).mockResolvedValue(okProvider('minimax', 0, Date.now()))

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -20,6 +20,7 @@ import {
   type NormalizedClaudeAccountSelectionTarget
 } from '../claude-accounts/runtime-selection'
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
+import { fetchAntigravityRateLimits } from './antigravity-usage-fetcher'
 import { fetchKimiRateLimits } from './kimi-fetcher'
 import { fetchGrokRateLimits } from './grok-fetcher'
 import { readGrokAuthSession } from './grok-auth'
@@ -1594,38 +1595,46 @@ export class RateLimitService {
     const claudeFetchGated =
       !options?.force && this.shouldSkipAutomatedClaudeFetch(previousState.claude)
 
-    const [claudeResult, codexResult, geminiResult, opencodeGoResult, kimiResult, miniMaxResult] =
-      await Promise.allSettled([
-        claudeFetchGated
-          ? Promise.resolve(previousState.claude as ProviderRateLimits)
-          : fetchClaudeRateLimits({
-              authPreparation: claudeAuthPreparation,
-              allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation),
-              allowUsagePanelSupplement: this.shouldAllowClaudeUsagePanelSupplement(),
-              networkProxySettings: this.networkProxySettingsResolver?.(),
-              signal
-            }),
-        missingWslCodexHome ??
-          fetchCodexRateLimits({
-            codexHomePath,
-            allowPtyFallback: this.shouldAllowCodexPtyFallback(),
+    const [
+      claudeResult,
+      codexResult,
+      geminiResult,
+      antigravityResult,
+      opencodeGoResult,
+      kimiResult,
+      miniMaxResult
+    ] = await Promise.allSettled([
+      claudeFetchGated
+        ? Promise.resolve(previousState.claude as ProviderRateLimits)
+        : fetchClaudeRateLimits({
+            authPreparation: claudeAuthPreparation,
+            allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation),
+            allowUsagePanelSupplement: this.shouldAllowClaudeUsagePanelSupplement(),
+            networkProxySettings: this.networkProxySettingsResolver?.(),
             signal
           }),
-        fetchGeminiRateLimits(geminiCliOAuthEnabled),
-        fetchOpenCodeGoRateLimits(
-          cookie,
-          workspaceIdOverride || undefined,
-          this.networkProxySettingsResolver?.()
-        ),
-        fetchKimiRateLimits(),
-        miniMaxConfigResult.error
-          ? Promise.resolve(this.getMiniMaxCredentialError(miniMaxConfigResult.error))
-          : fetchMiniMaxRateLimits({
-              cookie: miniMaxCookie,
-              groupId: miniMaxGroupId,
-              models: miniMaxModels
-            })
-      ])
+      missingWslCodexHome ??
+        fetchCodexRateLimits({
+          codexHomePath,
+          allowPtyFallback: this.shouldAllowCodexPtyFallback(),
+          signal
+        }),
+      fetchGeminiRateLimits(geminiCliOAuthEnabled),
+      fetchAntigravityRateLimits(true),
+      fetchOpenCodeGoRateLimits(
+        cookie,
+        workspaceIdOverride || undefined,
+        this.networkProxySettingsResolver?.()
+      ),
+      fetchKimiRateLimits(),
+      miniMaxConfigResult.error
+        ? Promise.resolve(this.getMiniMaxCredentialError(miniMaxConfigResult.error))
+        : fetchMiniMaxRateLimits({
+            cookie: miniMaxCookie,
+            groupId: miniMaxGroupId,
+            models: miniMaxModels
+          })
+    ])
 
     if (signal.aborted) {
       return
@@ -1670,11 +1679,20 @@ export class RateLimitService {
             status: 'error'
           } satisfies ProviderRateLimits)
 
-    // Why: Antigravity shares Gemini credentials today; mirror the Gemini snapshot so its status-bar UI gets a real lifecycle instead of null.
-    const antigravity: ProviderRateLimits = {
-      ...gemini,
-      provider: 'antigravity'
-    }
+    const antigravity =
+      antigravityResult.status === 'fulfilled'
+        ? antigravityResult.value
+        : ({
+            provider: 'antigravity',
+            session: null,
+            weekly: null,
+            updatedAt: Date.now(),
+            error:
+              antigravityResult.reason instanceof Error
+                ? antigravityResult.reason.message
+                : 'Unknown error',
+            status: 'error'
+          } satisfies ProviderRateLimits)
 
     const opencodeGo =
       opencodeGoResult.status === 'fulfilled'


### PR DESCRIPTION
Fixes #9122

### Problem

Antigravity usage was never fetched. `service.ts` produced it by taking the Gemini result and relabelling the provider:

```ts
{ ...gemini, provider: 'antigravity' }
```

Two consequences:

1. The status bar showed **Gemini's quota pools** under an Antigravity label — wrong numbers, not just stale ones.
2. On a machine with no Gemini CLI install, there was nothing to copy, so Antigravity refresh failed entirely.

Antigravity ships its own CLI, its own OAuth credentials, and its own quota endpoint. It needs its own fetch path.

### Changes

**`antigravity-auth.ts` — credentials**
- Discovers the Antigravity OAuth token across the layouts the CLI actually writes: `~/.gemini/antigravity-cli/antigravity-oauth-token` (no extension), `~/.config/antigravity/antigravity-oauth-token.json`, and the `auth.json` / `settings.json` fallbacks.
- Parses the several expiry encodings that appear in those files (`expiry`, `expiry_date`, `expires_in`; ISO strings and epoch numbers).
- Refreshes through Antigravity's shipped installed-app client pair. This is the credential the Antigravity CLI itself ships, not a user secret — installed-app clients are public by design — but it is the change most worth a second opinion in review.
- Caches the refreshed token against its source refresh token, so a credential swap on disk doesn't serve a stale access token.

**`antigravity-usage-fetcher.ts` — quota**
- Resolves the project via `loadCodeAssist`, then reads the quota summary.
- `parseQuotaResponse` handles both the nested `groups[].buckets[]` schema and the legacy flat `buckets[]`.
- `aggregateAntigravityWindows` folds the returned buckets into the session and weekly windows the status bar renders.
- Retries once after a token refresh on HTTP 401/403.

**`service.ts` — wiring**
- Antigravity becomes its own entry in the existing `Promise.allSettled` batch rather than a derivative of the Gemini result.

**Failure modes** — missing credentials report `unavailable` with an explicit reason instead of surfacing another provider's numbers. A disabled provider short-circuits before touching disk or network.

### Testing

Verified on current `main` (this branch was 174 commits behind before the rebase below):

- `pnpm vitest run src/main/rate-limits` → 379 passed across 27 files.
- `oxlint src/main/rate-limits` → clean, no `max-lines` suppressions added.
- `tsc --noEmit -p config/tsconfig.node.json` → clean.
- New unit coverage for expiry parsing, both quota response schemas, bucket aggregation, the refresh-and-retry path, and the credential-missing case.

### Notes on this revision

Rebased onto current `main` and squashed. The branch previously carried 14 commits of review iteration whose intermediate states are not meaningful to review — the file layout, the OAuth client pair, and the quota schema each changed several times along the way. The squashed diff is the only state worth reading.

The earlier `@coderabbitai ignore pre-merge checks` on this PR was a documentation-coverage gate, not a correctness one; the exported helpers carry JSDoc in the current revision.



## ELI5

Antigravity usage either showed Gemini's numbers or failed if Gemini was not installed. Orca looks up Antigravity's own credentials and paths so the status bar reflects Antigravity quota correctly.
