### PR TITLE
feat(linear): resolve issue URLs in smart workspace picker

### DIFF
--- a/mobile/src/components/SmartCrossRepoSourcePrompt.tsx
+++ b/mobile/src/components/SmartCrossRepoSourcePrompt.tsx
@@ -1,0 +1,74 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import type { SmartCrossRepoPrompt } from '../tasks/use-smart-workspace-source'
+import { colors, radii, spacing } from '../theme/mobile-theme'
+
+export function SmartCrossRepoSourcePrompt({
+  prompt,
+  onDismiss,
+  onAccept
+}: {
+  prompt: SmartCrossRepoPrompt
+  onDismiss: () => void
+  onAccept: () => void
+}) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>
+        This item lives in {prompt.link.slug.owner}/{prompt.link.slug.repo}.
+      </Text>
+      <View style={styles.actions}>
+        <Pressable style={styles.dismiss} onPress={onDismiss}>
+          <Text style={styles.dismissText}>Cancel</Text>
+        </Pressable>
+        <Pressable style={styles.accept} onPress={onAccept}>
+          <Text style={styles.acceptText}>Switch to {prompt.matchingRepo.displayName}</Text>
+        </Pressable>
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.bgRaised,
+    borderRadius: radii.input,
+    borderWidth: 1,
+    borderColor: colors.borderSubtle,
+    padding: spacing.md,
+    marginBottom: spacing.sm,
+    gap: spacing.sm
+  },
+  text: {
+    fontSize: 13,
+    color: colors.textSecondary
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: spacing.sm
+  },
+  dismiss: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs + 2,
+    borderRadius: radii.button,
+    borderWidth: 1,
+    borderColor: colors.borderSubtle
+  },
+  dismissText: {
+    fontSize: 13,
+    color: colors.textSecondary
+  },
+  accept: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs + 2,
+    borderRadius: radii.button,
+    backgroundColor: colors.bgPanel,
+    borderWidth: 1,
+    borderColor: colors.textSecondary
+  },
+  acceptText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.textPrimary
+  }
+})

--- a/mobile/src/components/SmartLinearLinkResolutionStatus.tsx
+++ b/mobile/src/components/SmartLinearLinkResolutionStatus.tsx
@@ -1,0 +1,59 @@
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native'
+import type { SmartLinearLinkResolution } from '../tasks/use-smart-workspace-source'
+import { colors, spacing } from '../theme/mobile-theme'
+
+export function SmartLinearLinkResolutionStatus({
+  resolution,
+  hasSourceResults
+}: {
+  resolution: SmartLinearLinkResolution
+  hasSourceResults: boolean
+}) {
+  if (resolution.status === 'idle') {
+    return null
+  }
+  if (resolution.status === 'resolved') {
+    return (
+      <Text accessible accessibilityLiveRegion="polite" style={styles.accessibilityAnnouncement}>
+        Linear issue {resolution.identifier} resolved.
+      </Text>
+    )
+  }
+  if (resolution.status === 'resolving') {
+    return (
+      <View accessible accessibilityLiveRegion="polite" style={styles.resolution}>
+        <ActivityIndicator size="small" color={colors.textSecondary} />
+        <Text style={styles.text}>Resolving Linear link…</Text>
+      </View>
+    )
+  }
+  return (
+    <Text accessibilityLiveRegion="polite" style={styles.text}>
+      {hasSourceResults
+        ? 'No exact match for this Linear link.'
+        : 'Linear issue not found in your connected workspaces.'}
+    </Text>
+  )
+}
+
+const styles = StyleSheet.create({
+  accessibilityAnnouncement: {
+    position: 'absolute',
+    width: 1,
+    height: 1,
+    opacity: 0
+  },
+  resolution: {
+    minHeight: 36,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md
+  },
+  text: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    color: colors.textMuted,
+    fontSize: 12
+  }
+})

--- a/mobile/src/components/SmartWorkspaceSourceDrawer.tsx
+++ b/mobile/src/components/SmartWorkspaceSourceDrawer.tsx
@@ -27,7 +27,9 @@ import { useSmartWorkspaceSource } from '../tasks/use-smart-workspace-source'
 import type { MobileComposerSource } from '../tasks/use-mobile-composer-source'
 import { colors, radii, spacing, typography } from '../theme/mobile-theme'
 import { BottomDrawer, BOTTOM_DRAWER_HIDE_DURATION_MS } from './BottomDrawer'
+import { SmartCrossRepoSourcePrompt } from './SmartCrossRepoSourcePrompt'
 import { SmartSourceModeIcon } from './SmartSourceModeIcon'
+import { SmartLinearLinkResolutionStatus } from './SmartLinearLinkResolutionStatus'
 import { SmartWorkspaceSourceRow } from './SmartWorkspaceSourceRow'
 
 type Props = {
@@ -85,7 +87,8 @@ export function SmartWorkspaceSourceDrawer({
     needsGitHubRemote,
     emptyHint,
     crossRepoPrompt,
-    dismissCrossRepoPrompt
+    dismissCrossRepoPrompt,
+    linearLinkResolution
   } = useSmartWorkspaceSource({
     client,
     enabled: searchEnabled,
@@ -220,21 +223,11 @@ export function SmartWorkspaceSourceDrawer({
       ) : null}
 
       {crossRepoPrompt ? (
-        <View style={styles.crossRepo}>
-          <Text style={styles.crossRepoText}>
-            This item lives in {crossRepoPrompt.link.slug.owner}/{crossRepoPrompt.link.slug.repo}.
-          </Text>
-          <View style={styles.crossRepoActions}>
-            <Pressable style={styles.crossRepoDismiss} onPress={dismissCrossRepoPrompt}>
-              <Text style={styles.crossRepoDismissText}>Cancel</Text>
-            </Pressable>
-            <Pressable style={styles.crossRepoSwitch} onPress={() => void handleAcceptCrossRepo()}>
-              <Text style={styles.crossRepoSwitchText}>
-                Switch to {crossRepoPrompt.matchingRepo.displayName}
-              </Text>
-            </Pressable>
-          </View>
-        </View>
+        <SmartCrossRepoSourcePrompt
+          prompt={crossRepoPrompt}
+          onDismiss={dismissCrossRepoPrompt}
+          onAccept={() => void handleAcceptCrossRepo()}
+        />
       ) : null}
 
       {!sshReady && effectiveMode !== 'text' && effectiveMode !== 'linear' ? (
@@ -253,8 +246,16 @@ export function SmartWorkspaceSourceDrawer({
         style={styles.list}
         keyboardShouldPersistTaps="handled"
         nestedScrollEnabled
+        ListHeaderComponent={
+          <SmartLinearLinkResolutionStatus
+            resolution={linearLinkResolution}
+            hasSourceResults={rows.some(
+              (row) => row.kind !== 'use-name' && row.kind !== 'create-branch'
+            )}
+          />
+        }
         ListFooterComponent={
-          loading ? (
+          loading && linearLinkResolution.status !== 'resolving' ? (
             <View style={styles.loading}>
               <ActivityIndicator size="small" color={colors.textSecondary} />
             </View>
@@ -350,48 +351,6 @@ const styles = StyleSheet.create({
   chipTextSelected: {
     color: colors.textPrimary,
     fontWeight: '600'
-  },
-  crossRepo: {
-    backgroundColor: colors.bgRaised,
-    borderRadius: radii.input,
-    borderWidth: 1,
-    borderColor: colors.borderSubtle,
-    padding: spacing.md,
-    marginBottom: spacing.sm,
-    gap: spacing.sm
-  },
-  crossRepoText: {
-    fontSize: 13,
-    color: colors.textSecondary
-  },
-  crossRepoActions: {
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-    gap: spacing.sm
-  },
-  crossRepoDismiss: {
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.xs + 2,
-    borderRadius: radii.button,
-    borderWidth: 1,
-    borderColor: colors.borderSubtle
-  },
-  crossRepoDismissText: {
-    fontSize: 13,
-    color: colors.textSecondary
-  },
-  crossRepoSwitch: {
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.xs + 2,
-    borderRadius: radii.button,
-    backgroundColor: colors.bgPanel,
-    borderWidth: 1,
-    borderColor: colors.textSecondary
-  },
-  crossRepoSwitchText: {
-    fontSize: 13,
-    fontWeight: '600',
-    color: colors.textPrimary
   },
   notice: {
     fontSize: 12,

--- a/mobile/src/tasks/smart-source-fan-out.test.ts
+++ b/mobile/src/tasks/smart-source-fan-out.test.ts
@@ -109,4 +109,20 @@ describe('fanOutSmartSearch', () => {
       branches: []
     })
   })
+
+  it('uses a normalized Linear query without changing other provider searches', async () => {
+    const calls: Call[] = []
+    const client = fakeClient({}, calls)
+    await fanOutSmartSearch({
+      ...smartArgs,
+      query: 'raw-linear-url',
+      linearQuery: 'ENG-42',
+      client
+    })
+
+    const linearCall = calls.find((call) => call.method === 'linear.searchIssues')
+    const githubCall = calls.find((call) => call.method === 'github.listWorkItems')
+    expect(linearCall?.params.query).toBe('ENG-42')
+    expect(githubCall?.params.query).toBe('raw-linear-url')
+  })
 })

--- a/mobile/src/tasks/smart-source-fan-out.ts
+++ b/mobile/src/tasks/smart-source-fan-out.ts
@@ -60,6 +60,7 @@ type FanOutArgs = {
   linearAvailable: boolean
   mrStateFilter: MrStateFilter
   linearWorkspaceId: string | null | undefined
+  linearQuery?: string
 }
 
 // Runs every provider search the active mode needs, concurrently. Smart mode is
@@ -93,7 +94,7 @@ export async function fanOutSmartSearch(args: FanOutArgs): Promise<SmartFanOutRe
         ? searchGitLabItems(client, repoId, query, mrStateFilter)
         : null,
     linear: shouldSearchLinear(mode, linearAvailable)
-      ? searchLinearIssues(client, query, args.linearWorkspaceId)
+      ? searchLinearIssues(client, args.linearQuery ?? query, args.linearWorkspaceId)
       : null,
     branches:
       shouldSearchBranches(mode, query) && repoId ? searchBranches(client, repoId, query) : null

--- a/mobile/src/tasks/smart-source-paste-intent.test.ts
+++ b/mobile/src/tasks/smart-source-paste-intent.test.ts
@@ -28,6 +28,21 @@ describe('resolvePasteIntent', () => {
     }
   })
 
+  it('classifies a Linear issue URL with its normalized reference', () => {
+    expect(resolvePasteIntent('https://linear.app/Acme/issue/eng-42/fix-auth')).toEqual({
+      kind: 'linear-link',
+      reference: { identifier: 'ENG-42', organizationUrlKey: 'Acme' }
+    })
+  })
+
+  it('keeps bare Linear identifiers on the search-only path', () => {
+    expect(resolvePasteIntent('ENG-42')).toBeNull()
+  })
+
+  it('rejects non-issue Linear URLs', () => {
+    expect(resolvePasteIntent('https://linear.app/acme/settings/api')).toBeNull()
+  })
+
   it('returns null for plain search text', () => {
     expect(resolvePasteIntent('login bug')).toBeNull()
   })

--- a/mobile/src/tasks/smart-source-paste-intent.ts
+++ b/mobile/src/tasks/smart-source-paste-intent.ts
@@ -6,6 +6,10 @@ import {
   type RepoSlug
 } from '../../../src/shared/new-workspace/github-links'
 import { parseGitLabIssueOrMRLink } from '../../../src/shared/new-workspace/gitlab-links'
+import {
+  parseLinearIssueInput,
+  type ParsedLinearIssueInput
+} from '../../../src/shared/linear-links'
 import { isSmartWorkspaceSourceQueryWithinLimit } from '../../../src/shared/new-workspace/smart-workspace-source-results'
 import type { RpcClient } from '../transport/rpc-client'
 import type { RpcSuccess } from '../transport/types'
@@ -27,11 +31,13 @@ export type GitLabPasteIntent = {
   link: NonNullable<ReturnType<typeof parseGitLabIssueOrMRLink>>
 }
 
-export type PasteIntent = GitHubPasteIntent | GitLabPasteIntent | null
+export type LinearPasteIntent = {
+  kind: 'linear-link'
+  reference: ParsedLinearIssueInput & { organizationUrlKey: string }
+}
 
-// Pure: classify pasted text into a work-item lookup intent. A slug-bearing
-// GitHub URL becomes 'github-link'; a bare "#123"/number becomes 'github-number';
-// a GitLab issue/MR URL becomes 'gitlab-link'.
+export type PasteIntent = GitHubPasteIntent | GitLabPasteIntent | LinearPasteIntent | null
+
 export function resolvePasteIntent(query: string): PasteIntent {
   if (!isSmartWorkspaceSourceQueryWithinLimit(query)) {
     return null
@@ -51,6 +57,18 @@ export function resolvePasteIntent(query: string): PasteIntent {
   const glLink = parseGitLabIssueOrMRLink(trimmed)
   if (glLink) {
     return { kind: 'gitlab-link', link: glLink }
+  }
+  const linearReference = parseLinearIssueInput(trimmed)
+  // Why: bare identifiers remain ordinary search text; only URLs are precise
+  // enough to trigger the all-workspace exact lookup and not-found cue.
+  if (linearReference?.organizationUrlKey) {
+    return {
+      kind: 'linear-link',
+      reference: {
+        ...linearReference,
+        organizationUrlKey: linearReference.organizationUrlKey
+      }
+    }
   }
   return null
 }

--- a/mobile/src/tasks/smart-source-search-requests.test.ts
+++ b/mobile/src/tasks/smart-source-search-requests.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { RpcClient } from '../transport/rpc-client'
-import { scopeGitHubQuery, searchLinearIssues } from './smart-source-search-requests'
+import {
+  getLinearIssuesByIdentifier,
+  scopeGitHubQuery,
+  searchLinearIssues
+} from './smart-source-search-requests'
 
 type Call = { method: string; params: Record<string, unknown> }
 
@@ -41,5 +45,31 @@ describe('searchLinearIssues', () => {
     await searchLinearIssues(client, 'bug', 'ws-1')
     expect(calls[0]!.method).toBe('linear.searchIssues')
     expect(calls[0]!.params).toMatchObject({ query: 'bug', workspaceId: 'ws-1' })
+  })
+
+  it('gets identifier hits from all Linear workspaces with the error envelope', async () => {
+    const calls: Call[] = []
+    const client = fakeClient(
+      {
+        items: [
+          {
+            id: 'issue-1',
+            identifier: 'ENG-42',
+            url: 'https://linear.app/acme/issue/ENG-42'
+          }
+        ],
+        errors: [{ workspaceId: 'workspace-2', type: 'network', message: 'timeout' }]
+      },
+      calls
+    )
+
+    await expect(getLinearIssuesByIdentifier(client, 'ENG-42')).resolves.toMatchObject({
+      items: [{ identifier: 'ENG-42' }],
+      errors: [{ workspaceId: 'workspace-2', type: 'network' }]
+    })
+    expect(calls[0]).toEqual({
+      method: 'linear.getIssuesByIdentifier',
+      params: { identifier: 'ENG-42', workspaceId: 'all' }
+    })
   })
 })

--- a/mobile/src/tasks/smart-source-search-requests.ts
+++ b/mobile/src/tasks/smart-source-search-requests.ts
@@ -2,6 +2,7 @@ import type {
   BaseRefSearchResult,
   GitHubWorkItem,
   GitLabWorkItem,
+  LinearCollectionResult,
   LinearIssue
 } from '../../../src/shared/types'
 import type { RpcClient } from '../transport/rpc-client'
@@ -93,6 +94,26 @@ export async function searchLinearIssues(
   // extractLinearIssueReadItems yields the mobile issue-read shape; the fields the
   // row builder/create flow read (id/identifier/title/url/state/team) are a subset.
   return extractLinearIssueReadItems((response as RpcSuccess).result) as unknown as LinearIssue[]
+}
+
+export async function getLinearIssuesByIdentifier(
+  client: RpcClient,
+  identifier: string
+): Promise<LinearCollectionResult<LinearIssue>> {
+  const response = await client.sendRequest('linear.getIssuesByIdentifier', {
+    identifier,
+    workspaceId: 'all'
+  })
+  if (!response.ok) {
+    throw new Error(response.error.message)
+  }
+  const result = (response as RpcSuccess).result
+  const items = extractLinearIssueReadItems(result) as unknown as LinearIssue[]
+  const errors =
+    result && typeof result === 'object' && Array.isArray((result as { errors?: unknown }).errors)
+      ? ((result as LinearCollectionResult<LinearIssue>).errors ?? [])
+      : []
+  return { items, errors }
 }
 
 export async function searchBranches(

--- a/mobile/src/tasks/use-smart-workspace-source.test.ts
+++ b/mobile/src/tasks/use-smart-workspace-source.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import type { LinearIssue } from '../../../src/shared/types'
+import type { RpcClient } from '../transport/rpc-client'
+import { runSmartSearch } from './use-smart-workspace-source'
+
+function issue(organizationUrlKey: string): LinearIssue {
+  return {
+    id: `issue-${organizationUrlKey}`,
+    workspaceId: `workspace-${organizationUrlKey}`,
+    identifier: 'ENG-42',
+    title: 'Fix auth',
+    url: `https://linear.app/${organizationUrlKey}/issue/ENG-42/fix-auth`,
+    state: { name: 'Todo', type: 'unstarted', color: '#888888' },
+    team: { id: 'team-1', name: 'Engineering', key: 'ENG' },
+    labels: [],
+    labelIds: [],
+    priority: 0,
+    updatedAt: '2026-01-01T00:00:00.000Z'
+  }
+}
+
+function clientFor(
+  searchItems: LinearIssue[],
+  lookupResult: { items: LinearIssue[]; errors?: unknown[] },
+  calls: Array<{ method: string; params: unknown }>
+): RpcClient {
+  return {
+    sendRequest: async (method: string, params?: unknown) => {
+      calls.push({ method, params })
+      const result = method === 'linear.searchIssues' ? searchItems : lookupResult
+      return { id: '1', ok: true, result, _meta: { runtimeId: 'runtime-1' } }
+    }
+  } as unknown as RpcClient
+}
+
+function runArgs(client: RpcClient) {
+  return {
+    client,
+    mode: 'linear' as const,
+    query: 'https://linear.app/acme/issue/eng-42/fix-auth',
+    repoId: null,
+    githubAvailable: false,
+    gitlabAvailable: false,
+    linearAvailable: true,
+    mrStateFilter: 'opened' as const,
+    linearWorkspaceId: 'workspace-other',
+    repos: [],
+    dismissedPasteRef: { current: '' },
+    repoSlugCache: new Map<string, { owner: string; repo: string } | null>()
+  }
+}
+
+describe('runSmartSearch Linear URL resolution', () => {
+  it('normalizes search and pins the all-workspace organization match', async () => {
+    const calls: Array<{ method: string; params: unknown }> = []
+    const wrongOrg = issue('other')
+    const exact = issue('acme')
+
+    const result = await runSmartSearch(
+      runArgs(clientFor([wrongOrg], { items: [wrongOrg, exact], errors: [] }, calls))
+    )
+
+    expect(result.paste.linear).toBe(exact)
+    expect(result.fan.linearIssues).toEqual([wrongOrg])
+    expect(result.linearLinkResolution).toEqual({ status: 'resolved', identifier: 'ENG-42' })
+    expect(calls).toEqual([
+      {
+        method: 'linear.searchIssues',
+        params: { query: 'ENG-42', limit: 50, workspaceId: 'workspace-other' }
+      },
+      {
+        method: 'linear.getIssuesByIdentifier',
+        params: { identifier: 'ENG-42', workspaceId: 'all' }
+      }
+    ])
+  })
+
+  it('shows an authoritative miss but keeps a colliding search result ordinary', async () => {
+    const wrongOrg = issue('other')
+    const result = await runSmartSearch(
+      runArgs(clientFor([wrongOrg], { items: [wrongOrg], errors: [] }, []))
+    )
+
+    expect(result.paste.linear).toBeNull()
+    expect(result.fan.linearIssues).toEqual([wrongOrg])
+    expect(result.linearLinkResolution).toEqual({ status: 'not-found' })
+  })
+
+  it('keeps transient lookup failures silent and non-authoritative', async () => {
+    const result = await runSmartSearch(
+      runArgs(
+        clientFor(
+          [],
+          {
+            items: [],
+            errors: [{ workspaceId: 'workspace-acme', type: 'network', message: 'timeout' }]
+          },
+          []
+        )
+      )
+    )
+
+    expect(result.fan.error).toBe('')
+    expect(result.linearLinkResolution).toEqual({ status: 'idle' })
+  })
+
+  it('does not resolve Linear links when Linear is unavailable', async () => {
+    const calls: Array<{ method: string; params: unknown }> = []
+    const args = runArgs(clientFor([], { items: [], errors: [] }, calls))
+
+    const result = await runSmartSearch({ ...args, linearAvailable: false })
+
+    expect(calls).toEqual([])
+    expect(result.linearLinkResolution).toEqual({ status: 'idle' })
+  })
+})

--- a/mobile/src/tasks/use-smart-workspace-source.ts
+++ b/mobile/src/tasks/use-smart-workspace-source.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { GitHubWorkItem, GitLabWorkItem } from '../../../src/shared/types'
+import type { GitHubWorkItem, GitLabWorkItem, LinearIssue } from '../../../src/shared/types'
+import { findLinearIssueExactReferenceMatch } from '../../../src/shared/linear-links'
 import {
   buildSmartWorkspaceSourceRows,
   getSmartWorkspaceEmptyHint,
@@ -17,6 +18,7 @@ import {
   resolvePasteIntent,
   type PasteRepoCandidate
 } from './smart-source-paste-intent'
+import { getLinearIssuesByIdentifier } from './smart-source-search-requests'
 
 const DEBOUNCE_MS = 200
 const RESULT_LIMIT = 36
@@ -49,7 +51,19 @@ const EMPTY_FAN: SmartFanOutResult = {
   error: ''
 }
 
-type PasteResolved = { github: GitHubWorkItem | null; gitlab: GitLabWorkItem | null }
+type PasteResolved = {
+  github: GitHubWorkItem | null
+  gitlab: GitLabWorkItem | null
+  linear: LinearIssue | null
+}
+
+export type SmartLinearLinkResolution =
+  | { status: 'idle' }
+  | { status: 'resolving' }
+  | { status: 'resolved'; identifier: string }
+  | { status: 'not-found' }
+
+const IDLE_LINEAR_LINK_RESOLUTION: SmartLinearLinkResolution = { status: 'idle' }
 
 export function useSmartWorkspaceSource(args: UseSmartWorkspaceSourceArgs) {
   const {
@@ -66,7 +80,10 @@ export function useSmartWorkspaceSource(args: UseSmartWorkspaceSourceArgs) {
     repos
   } = args
   const [fan, setFan] = useState<SmartFanOutResult>(EMPTY_FAN)
-  const [paste, setPaste] = useState<PasteResolved>({ github: null, gitlab: null })
+  const [paste, setPaste] = useState<PasteResolved>({ github: null, gitlab: null, linear: null })
+  const [linearLinkResolution, setLinearLinkResolution] = useState<SmartLinearLinkResolution>(
+    IDLE_LINEAR_LINK_RESOLUTION
+  )
   const [loading, setLoading] = useState(false)
   const [crossRepoPrompt, setCrossRepoPrompt] = useState<SmartCrossRepoPrompt | null>(null)
   // Why: preserve results across keystrokes (debounce) but drop them the moment
@@ -78,7 +95,8 @@ export function useSmartWorkspaceSource(args: UseSmartWorkspaceSourceArgs) {
   useEffect(() => {
     if (!client || !enabled || mode === 'text') {
       setFan(EMPTY_FAN)
-      setPaste({ github: null, gitlab: null })
+      setPaste({ github: null, gitlab: null, linear: null })
+      setLinearLinkResolution(IDLE_LINEAR_LINK_RESOLUTION)
       setLoading(false)
       setCrossRepoPrompt(null)
       return
@@ -88,9 +106,16 @@ export function useSmartWorkspaceSource(args: UseSmartWorkspaceSourceArgs) {
     scopeRef.current = scope
     if (scopeChanged) {
       setFan(EMPTY_FAN)
-      setPaste({ github: null, gitlab: null })
+      setPaste({ github: null, gitlab: null, linear: null })
       setCrossRepoPrompt(null)
     }
+    const pendingIntent = mode === 'branches' ? null : resolvePasteIntent(query)
+    const shouldResolveLinearLink = linearAvailable && (mode === 'smart' || mode === 'linear')
+    setLinearLinkResolution(
+      pendingIntent?.kind === 'linear-link' && shouldResolveLinearLink
+        ? { status: 'resolving' }
+        : IDLE_LINEAR_LINK_RESOLUTION
+    )
     setLoading(true)
     let stale = false
     const timer = setTimeout(() => {
@@ -114,11 +139,13 @@ export function useSmartWorkspaceSource(args: UseSmartWorkspaceSourceArgs) {
           }
           setFan(result.fan)
           setPaste(result.paste)
+          setLinearLinkResolution(result.linearLinkResolution)
           setCrossRepoPrompt(result.crossRepoPrompt)
           setLoading(false)
         })
         .catch(() => {
           if (!stale) {
+            setLinearLinkResolution(IDLE_LINEAR_LINK_RESOLUTION)
             setLoading(false)
           }
         })
@@ -149,7 +176,15 @@ export function useSmartWorkspaceSource(args: UseSmartWorkspaceSourceArgs) {
         gitlabAvailable,
         gitlabItems: paste.gitlab ? [paste.gitlab] : fan.gitlabItems,
         linearAvailable,
-        linearIssues: fan.linearIssues,
+        linearIssues: paste.linear
+          ? [
+              paste.linear,
+              ...fan.linearIssues.filter(
+                (issue) =>
+                  issue.id !== paste.linear?.id || issue.workspaceId !== paste.linear.workspaceId
+              )
+            ]
+          : fan.linearIssues,
         mode,
         resultLimit: RESULT_LIMIT,
         value: query
@@ -169,11 +204,12 @@ export function useSmartWorkspaceSource(args: UseSmartWorkspaceSourceArgs) {
     needsGitHubRemote: fan.needsGitHubRemote,
     emptyHint: getSmartWorkspaceEmptyHint(mode),
     crossRepoPrompt,
-    dismissCrossRepoPrompt
+    dismissCrossRepoPrompt,
+    linearLinkResolution
   }
 }
 
-async function runSmartSearch(args: {
+export async function runSmartSearch(args: {
   client: RpcClient
   mode: SmartNameMode
   query: string
@@ -190,44 +226,90 @@ async function runSmartSearch(args: {
   fan: SmartFanOutResult
   paste: PasteResolved
   crossRepoPrompt: SmartCrossRepoPrompt | null
+  linearLinkResolution: SmartLinearLinkResolution
 }> {
   const { client, mode, query, repoId, repos, dismissedPasteRef, repoSlugCache } = args
-  const fan = await fanOutSmartSearch(args)
-  const paste: PasteResolved = { github: null, gitlab: null }
-  let crossRepoPrompt: SmartCrossRepoPrompt | null = null
-
   const intent =
     mode === 'branches' || dismissedPasteRef.current === query.trim()
       ? null
       : resolvePasteIntent(query)
-  if (intent && repoId) {
+  const effectiveIntent =
+    intent?.kind === 'linear-link' &&
+    (!args.linearAvailable || (mode !== 'smart' && mode !== 'linear'))
+      ? null
+      : intent
+  const fan = await fanOutSmartSearch({
+    ...args,
+    ...(effectiveIntent?.kind === 'linear-link'
+      ? { linearQuery: effectiveIntent.reference.identifier }
+      : {})
+  })
+  const paste: PasteResolved = { github: null, gitlab: null, linear: null }
+  let crossRepoPrompt: SmartCrossRepoPrompt | null = null
+  let linearLinkResolution: SmartLinearLinkResolution = IDLE_LINEAR_LINK_RESOLUTION
+
+  if (effectiveIntent?.kind === 'linear-link') {
+    const searchExactIssue = findLinearIssueExactReferenceMatch(
+      fan.linearIssues,
+      effectiveIntent.reference
+    )
+    if (searchExactIssue) {
+      paste.linear = searchExactIssue
+      linearLinkResolution = {
+        status: 'resolved',
+        identifier: searchExactIssue.identifier
+      }
+    } else {
+      try {
+        const result = await getLinearIssuesByIdentifier(
+          client,
+          effectiveIntent.reference.identifier
+        )
+        const exactIssue = findLinearIssueExactReferenceMatch(
+          result.items,
+          effectiveIntent.reference
+        )
+        if (exactIssue) {
+          paste.linear = exactIssue
+          linearLinkResolution = { status: 'resolved', identifier: exactIssue.identifier }
+        } else if ((result.errors?.length ?? 0) === 0) {
+          linearLinkResolution = { status: 'not-found' }
+        }
+      } catch {
+        // Best-effort exact lookup: an RPC failure is transient, not a miss.
+      }
+    }
+    // Why: URL resolution failures fall through silently even in Linear-only
+    // mode; the exact lookup envelope decides whether a not-found cue is safe.
+    fan.error = ''
+  } else if (effectiveIntent && repoId) {
     try {
-      if (intent.kind === 'github-number') {
-        paste.github = await lookupGitHubItemByNumber(client, repoId, intent.number)
-      } else if (intent.kind === 'github-link') {
+      if (effectiveIntent.kind === 'github-number') {
+        paste.github = await lookupGitHubItemByNumber(client, repoId, effectiveIntent.number)
+      } else if (effectiveIntent.kind === 'github-link') {
         const matchingRepo = await findRepoMatchingSlugForPaste(
           client,
           repos,
-          intent.link.slug,
+          effectiveIntent.link.slug,
           repoSlugCache
         )
         if (matchingRepo && matchingRepo.id !== repoId) {
-          crossRepoPrompt = { link: intent.link, matchingRepo }
+          crossRepoPrompt = { link: effectiveIntent.link, matchingRepo }
         } else {
           paste.github = await lookupGitHubItemByOwnerRepo(
             client,
             repoId,
-            intent.link.slug,
-            intent.link.number,
-            intent.link.type
+            effectiveIntent.link.slug,
+            effectiveIntent.link.number,
+            effectiveIntent.link.type
           )
         }
-      } else if (intent.kind === 'gitlab-link') {
-        paste.gitlab = await lookupGitLabItemByPath(client, repoId, intent.link)
+      } else if (effectiveIntent.kind === 'gitlab-link') {
+        paste.gitlab = await lookupGitLabItemByPath(client, repoId, effectiveIntent.link)
       }
     } catch {
       // Best-effort paste resolution; fall back to the fan-out results.
     }
   }
-  return { fan, paste, crossRepoPrompt }
+  return { fan, paste, crossRepoPrompt, linearLinkResolution }
 }

--- a/src/main/ipc/linear.ts
+++ b/src/main/ipc/linear.ts
@@ -5,6 +5,7 @@ import { connect, disconnect, getStatus, selectWorkspace, testConnection } from 
 import { _resetPreflightCache } from './preflight'
 import {
   getIssue,
+  getIssuesByIdentifier,
   searchIssues,
   listIssues,
   createIssue,
@@ -214,6 +215,19 @@ export function registerLinearHandlers(): void {
     }
     return getIssue(args.id.trim(), normalizeWorkspaceId(args.workspaceId))
   })
+
+  ipcMain.handle(
+    'linear:getIssuesByIdentifier',
+    async (_event, args: { identifier: string; workspaceId?: LinearWorkspaceSelection }) => {
+      if (typeof args?.identifier !== 'string' || !args.identifier.trim()) {
+        return { items: [], errors: [] }
+      }
+      return getIssuesByIdentifier(
+        args.identifier.trim(),
+        normalizeWorkspaceSelection(args.workspaceId) ?? 'all'
+      )
+    }
+  )
 
   ipcMain.handle(
     'linear:updateIssue',

--- a/src/main/linear/issues-by-identifier.test.ts
+++ b/src/main/linear/issues-by-identifier.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LinearClientForWorkspace } from './client'
+
+const getClients = vi.fn()
+const clearToken = vi.fn()
+const isAuthError = vi.fn()
+
+vi.mock('./client', () => ({
+  acquire: vi.fn().mockResolvedValue(undefined),
+  release: vi.fn(),
+  getClients: (...args: unknown[]) => getClients(...args),
+  isAuthError: (...args: unknown[]) => isAuthError(...args),
+  clearToken: (...args: unknown[]) => clearToken(...args)
+}))
+
+function sdkIssue(identifier: string, organizationUrlKey: string) {
+  return {
+    id: `${organizationUrlKey}-${identifier}`,
+    identifier,
+    title: identifier,
+    description: 'Description',
+    url: `https://linear.app/${organizationUrlKey}/issue/${identifier}`,
+    estimate: 3,
+    priority: 2,
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    state: Promise.resolve({ name: 'Todo', type: 'unstarted', color: '#888888' }),
+    team: Promise.resolve({ id: 'team-1', name: 'Team', key: 'TM' }),
+    assignee: Promise.resolve(undefined),
+    labels: async () => ({ nodes: [] })
+  }
+}
+
+function makeEntry(
+  workspaceId: string,
+  issue: (id: string) => Promise<unknown>
+): LinearClientForWorkspace {
+  return {
+    workspace: {
+      id: workspaceId,
+      organizationId: workspaceId,
+      organizationName: workspaceId,
+      displayName: 'Ada',
+      email: 'ada@example.com'
+    },
+    client: { issue }
+  } as unknown as LinearClientForWorkspace
+}
+
+describe('Linear issue identifier fan-out', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isAuthError.mockReturnValue(false)
+  })
+
+  it('gets every workspace hit for an issue identifier', async () => {
+    getClients.mockReturnValue([
+      makeEntry('workspace-acme', vi.fn().mockResolvedValue(sdkIssue('ENG-42', 'acme'))),
+      makeEntry('workspace-other', vi.fn().mockResolvedValue(sdkIssue('ENG-42', 'other')))
+    ])
+    const { getIssuesByIdentifier } = await import('./issues')
+
+    await expect(getIssuesByIdentifier('ENG-42')).resolves.toMatchObject({
+      items: [
+        { identifier: 'ENG-42', workspaceId: 'workspace-acme' },
+        { identifier: 'ENG-42', workspaceId: 'workspace-other' }
+      ],
+      errors: []
+    })
+    expect(getClients).toHaveBeenCalledWith('all')
+  })
+
+  it('treats identifier lookup misses as authoritative empty results', async () => {
+    getClients.mockReturnValue([
+      makeEntry(
+        'workspace-1',
+        vi
+          .fn()
+          .mockRejectedValue(new Error('Entity not found: Issue - Could not find referenced issue'))
+      )
+    ])
+    const { getIssuesByIdentifier } = await import('./issues')
+
+    await expect(getIssuesByIdentifier('ENG-404')).resolves.toEqual({ items: [], errors: [] })
+  })
+
+  it('returns transient failures in the workspace error envelope', async () => {
+    getClients.mockReturnValue([
+      makeEntry('workspace-1', vi.fn().mockRejectedValue(new Error('network timeout'))),
+      makeEntry(
+        'workspace-2',
+        vi.fn().mockRejectedValue(new Error('Issue not found for identifier ENG-404'))
+      )
+    ])
+    const { getIssuesByIdentifier } = await import('./issues')
+
+    await expect(getIssuesByIdentifier('ENG-404')).resolves.toMatchObject({
+      items: [],
+      errors: [{ workspaceId: 'workspace-1', type: 'network', message: 'network timeout' }]
+    })
+  })
+
+  it('contains all-workspace authentication failures without collapsing healthy lookups', async () => {
+    const authError = new Error('Unauthorized')
+    isAuthError.mockImplementation((error) => error === authError)
+    getClients.mockReturnValue([
+      makeEntry('workspace-auth', vi.fn().mockRejectedValue(authError)),
+      makeEntry('workspace-acme', vi.fn().mockResolvedValue(sdkIssue('ENG-42', 'acme')))
+    ])
+    const { getIssuesByIdentifier } = await import('./issues')
+
+    await expect(getIssuesByIdentifier('ENG-42')).resolves.toMatchObject({
+      items: [{ identifier: 'ENG-42', workspaceId: 'workspace-acme' }],
+      errors: [{ workspaceId: 'workspace-auth', type: 'auth' }]
+    })
+    expect(clearToken).toHaveBeenCalledWith('workspace-auth')
+  })
+
+  it('returns an empty envelope with no connected workspaces', async () => {
+    getClients.mockReturnValue([])
+    const { getIssuesByIdentifier } = await import('./issues')
+
+    await expect(getIssuesByIdentifier('ENG-404')).resolves.toEqual({ items: [], errors: [] })
+  })
+})

--- a/src/main/linear/issues.ts
+++ b/src/main/linear/issues.ts
@@ -646,6 +646,16 @@ function isLinearLookupMiss(error: unknown): boolean {
   return message.includes('Entity not found:') && message.includes('Could not find referenced')
 }
 
+function isLinearIssueIdentifierLookupMiss(error: unknown): boolean {
+  if (isLinearLookupMiss(error)) {
+    return true
+  }
+  const message = error instanceof Error ? error.message : String(error)
+  // Why: SDK issue(identifier) errors have changed wording across releases;
+  // keep only issue-specific not-found shapes authoritative for the URL cue.
+  return /(?:issue[^\n]*not found|could not find[^\n]*issue)/i.test(message)
+}
+
 async function confirmLinearWrite<T>(message: string, readback: () => Promise<T>): Promise<T> {
   try {
     return await readback()
@@ -735,6 +745,48 @@ export async function getIssue(
     }
   }
   return null
+}
+
+export async function getIssuesByIdentifier(
+  identifier: string,
+  workspaceId: LinearWorkspaceSelection | null | undefined = 'all'
+): Promise<LinearCollectionResult<LinearIssue>> {
+  const entries = getClients(workspaceId ?? 'all')
+  if (entries.length === 0) {
+    return { items: [], errors: [] }
+  }
+
+  const results = await Promise.all(
+    entries.map(async (entry) => {
+      await acquire()
+      try {
+        const issue = await entry.client.issue(identifier)
+        return {
+          item: await mapIssueForWorkspace(entry, issue)
+        }
+      } catch (error) {
+        if (isLinearIssueIdentifierLookupMiss(error)) {
+          return {}
+        }
+        if (isAuthError(error)) {
+          clearToken(entry.workspace.id)
+          if (shouldThrowAuthError(workspaceId ?? 'all')) {
+            throw error
+          }
+        } else {
+          console.warn('[linear] getIssuesByIdentifier failed:', error)
+        }
+        return { error: linearWorkspaceError(entry, error) }
+      } finally {
+        release()
+      }
+    })
+  )
+
+  return {
+    items: results.flatMap((result) => (result.item ? [result.item] : [])),
+    errors: results.flatMap((result) => (result.error ? [result.error] : []))
+  }
 }
 
 export async function getIssueByUuidForAgent(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -508,6 +508,7 @@ import {
   getAttachmentByUuidForAgent as getLinearAttachmentByUuidForAgent,
   getCommentByUuidForAgent as getLinearCommentByUuidForAgent,
   getIssue as getLinearIssue,
+  getIssuesByIdentifier as getLinearIssuesByIdentifier,
   getIssueByUuidForAgent as getLinearIssueByUuidForAgent,
   getIssueCommentThreadRoot as getLinearIssueCommentThreadRoot,
   getIssueComments as getLinearIssueComments,
@@ -24074,6 +24075,13 @@ export class OrcaRuntimeService {
 
   linearGetIssue(id: string, workspaceId?: string): ReturnType<typeof getLinearIssue> {
     return getLinearIssue(id, workspaceId)
+  }
+
+  linearGetIssuesByIdentifier(
+    identifier: string,
+    workspaceId?: LinearWorkspaceSelection
+  ): ReturnType<typeof getLinearIssuesByIdentifier> {
+    return getLinearIssuesByIdentifier(identifier, workspaceId ?? 'all')
   }
 
   linearUpdateIssue(

--- a/src/main/runtime/rpc/methods/linear.test.ts
+++ b/src/main/runtime/rpc/methods/linear.test.ts
@@ -39,6 +39,7 @@ describe('linear RPC methods', () => {
       linearSearchIssues: vi.fn().mockResolvedValue([{ id: 'issue-1' }]),
       linearListIssues: vi.fn().mockResolvedValue({ items: [{ id: 'issue-2' }], hasMore: true }),
       linearGetIssue: vi.fn().mockResolvedValue({ id: 'issue-3' }),
+      linearGetIssuesByIdentifier: vi.fn().mockResolvedValue({ items: [{ id: 'issue-3' }] }),
       linearCreateIssue: vi.fn().mockResolvedValue({ ok: true, id: 'issue-4' }),
       linearUpdateIssue: vi.fn().mockResolvedValue({ ok: true }),
       linearAddIssueComment: vi.fn().mockResolvedValue({ ok: true, id: 'comment-1' }),
@@ -58,6 +59,12 @@ describe('linear RPC methods', () => {
     )
     await dispatcher.dispatch(
       makeRequest('linear.getIssue', { id: 'issue-3', workspaceId: 'workspace-1' })
+    )
+    await dispatcher.dispatch(
+      makeRequest('linear.getIssuesByIdentifier', {
+        identifier: 'ENG-3',
+        workspaceId: 'all'
+      })
     )
     await dispatcher.dispatch(
       makeRequest('linear.createIssue', {
@@ -106,6 +113,7 @@ describe('linear RPC methods', () => {
       attributeFilter: undefined
     })
     expect(runtime.linearGetIssue).toHaveBeenCalledWith('issue-3', 'workspace-1')
+    expect(runtime.linearGetIssuesByIdentifier).toHaveBeenCalledWith('ENG-3', 'all')
     expect(runtime.linearCreateIssue).toHaveBeenCalledWith(
       'team-1',
       'Fix bug',

--- a/src/main/runtime/rpc/methods/linear.ts
+++ b/src/main/runtime/rpc/methods/linear.ts
@@ -62,6 +62,11 @@ const IssueId = z.object({
   workspaceId: OptionalString
 })
 
+const IssuesByIdentifier = z.object({
+  identifier: requiredString('Issue identifier is required'),
+  workspaceId: OptionalString
+})
+
 const IssueComment = z.object({
   issueId: requiredString('Issue ID is required'),
   body: requiredString('Comment body is required'),
@@ -195,6 +200,12 @@ export const LINEAR_METHODS: RpcMethod[] = [
     params: IssueId,
     handler: async (params, { runtime }) =>
       runtime.linearGetIssue(params.id.trim(), params.workspaceId)
+  }),
+  defineMethod({
+    name: 'linear.getIssuesByIdentifier',
+    params: IssuesByIdentifier,
+    handler: async (params, { runtime }) =>
+      runtime.linearGetIssuesByIdentifier(params.identifier.trim(), params.workspaceId)
   }),
   defineMethod({
     name: 'linear.updateIssue',

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -304,6 +304,7 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'hostedReview.getCreationEligibility',
   'linear.getCustomView',
   'linear.getIssue',
+  'linear.getIssuesByIdentifier',
   'linear.getProject',
   'linear.agentSearchIssues',
   'linear.issueContext',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1980,6 +1980,10 @@ export type PreloadApi = {
       | { ok: false; error: string }
     >
     getIssue: (args: { id: string; workspaceId?: string }) => Promise<LinearIssue | null>
+    getIssuesByIdentifier: (args: {
+      identifier: string
+      workspaceId?: LinearWorkspaceSelection
+    }) => Promise<LinearCollectionResult<LinearIssue>>
     updateIssue: (args: {
       id: string
       updates: LinearIssueUpdate

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1654,6 +1654,9 @@ const api = {
     getIssue: (args: { id: string; workspaceId?: string }): Promise<unknown> =>
       ipcRenderer.invoke('linear:getIssue', args),
 
+    getIssuesByIdentifier: (args: { identifier: string; workspaceId?: string }): Promise<unknown> =>
+      ipcRenderer.invoke('linear:getIssuesByIdentifier', args),
+
     updateIssue: (args: {
       id: string
       updates: unknown

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField-source-boundaries.test.ts
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField-source-boundaries.test.ts
@@ -98,4 +98,23 @@ describe('SmartWorkspaceNameField repo-backed source boundaries', () => {
     expect(FIELD_SOURCE).toContain('onPointerDown={() => {')
     expect(FIELD_SOURCE).toContain('markSourcePopoverUserEngaged()')
   })
+
+  it('normalizes and verifies Linear link resolution before showing an exact result', () => {
+    const linearLookupSection = sourceBetween(
+      FIELD_SOURCE,
+      'useEffect(() => {\n    if (disabled || !shouldQueryLinear || !linearStatus.connected)',
+      '// Why: GitLab paste-URL flow.'
+    )
+
+    expect(linearLookupSection).toContain(
+      'const query = parsedLinearReference?.identifier ?? trimmed'
+    )
+    expect(linearLookupSection).toContain('findLinearIssueExactReferenceMatch')
+    expect(linearLookupSection).toContain('getLinearIssuesByIdentifier')
+    expect(linearLookupSection).toContain("status: 'not-found'")
+    expect(linearLookupSection).toContain("status: 'idle'")
+    expect(FIELD_SOURCE).toContain('No exact match for this Linear link.')
+    expect(FIELD_SOURCE).toContain('Linear issue not found in your connected workspaces.')
+    expect(FIELD_SOURCE).toContain('parseLinearIssueInput(trimmed) !== null')
+  })
 })

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -82,6 +82,10 @@ import {
   type TaskSourceContext
 } from '../../../../shared/task-source-context'
 import { parseExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
+import {
+  findLinearIssueExactReferenceMatch,
+  parseLinearIssueInput
+} from '../../../../shared/linear-links'
 
 type RepoOption = ReturnType<typeof useAppStore.getState>['repos'][number]
 const EMPTY_REPO_SEARCH_REPOS: readonly RepoOption[] = []
@@ -141,6 +145,12 @@ export function canUseGitLabSmartSource({
 
 type RowEntry = SmartWorkspaceSourceRow
 
+type LinearReferenceResolution =
+  | { status: 'idle'; query: string }
+  | { status: 'resolving'; query: string }
+  | { status: 'resolved'; query: string; identifier: string }
+  | { status: 'not-found'; query: string }
+
 const ROW_ITEM_CLASS_NAME = 'gap-2 px-3 py-2 text-xs'
 
 function isTypedTextSourceRow(row: RowEntry): boolean {
@@ -152,6 +162,15 @@ function getRowItemClassName(row: RowEntry, options?: { pinnedAction?: boolean }
     ROW_ITEM_CLASS_NAME,
     options?.pinnedAction && isTypedTextSourceRow(row) && 'bg-muted/35'
   )
+}
+
+function pinLinearIssue(exactIssue: LinearIssue, issues: LinearIssue[]): LinearIssue[] {
+  return [
+    exactIssue,
+    ...issues.filter(
+      (issue) => issue.id !== exactIssue.id || issue.workspaceId !== exactIssue.workspaceId
+    )
+  ]
 }
 
 export default function SmartWorkspaceNameField({
@@ -187,6 +206,7 @@ export default function SmartWorkspaceNameField({
     checkLinearConnection,
     fetchWorkItems,
     fetchWorkItemsAcrossRepos,
+    getLinearIssuesByIdentifier,
     getCachedWorkItems,
     linearStatus,
     linearStatusChecked,
@@ -204,6 +224,7 @@ export default function SmartWorkspaceNameField({
       checkLinearConnection: s.checkLinearConnection,
       fetchWorkItems: s.fetchWorkItems,
       fetchWorkItemsAcrossRepos: s.fetchWorkItemsAcrossRepos,
+      getLinearIssuesByIdentifier: s.getLinearIssuesByIdentifier,
       getCachedWorkItems: s.getCachedWorkItems,
       linearStatus: s.linearStatus,
       linearStatusChecked: s.linearStatusChecked,
@@ -299,6 +320,8 @@ export default function SmartWorkspaceNameField({
     query: string
   } | null>(null)
   const [linearIssues, setLinearIssues] = useState<LinearIssue[]>([])
+  const [linearReferenceResolution, setLinearReferenceResolution] =
+    useState<LinearReferenceResolution>({ status: 'idle', query: '' })
   const [githubLoading, setGithubLoading] = useState(false)
   const [gitlabLoading, setGitlabLoading] = useState(false)
   const [branchesLoading, setBranchesLoading] = useState(false)
@@ -487,6 +510,7 @@ export default function SmartWorkspaceNameField({
     setMode('smart')
     setGitlabItems([])
     setLinearIssues([])
+    setLinearReferenceResolution({ status: 'idle', query: '' })
     setGitlabLoading(false)
     setLinearLoading(false)
     setCommandValue('')
@@ -525,6 +549,10 @@ export default function SmartWorkspaceNameField({
   )
   const parsedGhLink = useMemo(
     () => (sourceQueryWithinLimit ? parseGitHubIssueOrPRLink(debouncedQuery) : null),
+    [debouncedQuery, sourceQueryWithinLimit]
+  )
+  const parsedLinearReference = useMemo(
+    () => (sourceQueryWithinLimit ? parseLinearIssueInput(debouncedQuery) : null),
     [debouncedQuery, sourceQueryWithinLimit]
   )
   const shouldQueryGithub =
@@ -845,27 +873,77 @@ export default function SmartWorkspaceNameField({
   useEffect(() => {
     if (disabled || !shouldQueryLinear || !linearStatus.connected) {
       setLinearIssues([])
+      setLinearReferenceResolution({ status: 'idle', query: '' })
       setLinearLoading(false)
       return
     }
     let stale = false
     setLinearLoading(true)
     const trimmed = debouncedQuery.trim()
-    const request = trimmed
-      ? searchLinearIssues(trimmed, RESULT_LIMIT, { sourceContext: linearSourceContext })
+    const query = parsedLinearReference?.identifier ?? trimmed
+    const isUrlReference = parsedLinearReference?.organizationUrlKey !== undefined
+    setLinearReferenceResolution({
+      status: isUrlReference ? 'resolving' : 'idle',
+      query: trimmed
+    })
+    const request = query
+      ? searchLinearIssues(query, RESULT_LIMIT, { sourceContext: linearSourceContext })
       : listLinearIssues(
           { kind: 'list', filter: 'assigned', limit: RESULT_LIMIT },
           { sourceContext: linearSourceContext }
         ).then((result) => result.items)
-    void request
-      .then((issues) => {
-        if (!stale) {
-          setLinearIssues(issues)
+    void (async () => {
+      const issues = await request
+      if (stale) {
+        return
+      }
+      const searchExactIssue = parsedLinearReference
+        ? findLinearIssueExactReferenceMatch(issues, parsedLinearReference)
+        : null
+      if (searchExactIssue) {
+        setLinearIssues(pinLinearIssue(searchExactIssue, issues))
+        setLinearReferenceResolution({
+          status: 'resolved',
+          query: trimmed,
+          identifier: searchExactIssue.identifier
+        })
+        return
+      }
+      setLinearIssues(issues)
+      if (!isUrlReference || !parsedLinearReference) {
+        return
+      }
+
+      try {
+        const result = await getLinearIssuesByIdentifier(parsedLinearReference.identifier, {
+          sourceContext: linearSourceContext
+        })
+        if (stale) {
+          return
         }
-      })
+        const exactIssue = findLinearIssueExactReferenceMatch(result.items, parsedLinearReference)
+        if (exactIssue) {
+          setLinearIssues(pinLinearIssue(exactIssue, issues))
+          setLinearReferenceResolution({
+            status: 'resolved',
+            query: trimmed,
+            identifier: exactIssue.identifier
+          })
+        } else if ((result.errors?.length ?? 0) === 0) {
+          setLinearReferenceResolution({ status: 'not-found', query: trimmed })
+        } else {
+          setLinearReferenceResolution({ status: 'idle', query: trimmed })
+        }
+      } catch {
+        if (!stale) {
+          setLinearReferenceResolution({ status: 'idle', query: trimmed })
+        }
+      }
+    })()
       .catch(() => {
         if (!stale) {
           setLinearIssues([])
+          setLinearReferenceResolution({ status: 'idle', query: trimmed })
         }
       })
       .finally(() => {
@@ -876,10 +954,17 @@ export default function SmartWorkspaceNameField({
     return () => {
       stale = true
     }
-    // Why: list/search actions are stable store methods; depending on them
+    // Why: Linear read actions are stable store methods; depending on them
     // would refetch on unrelated store writes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedQuery, disabled, linearSourceContext, linearStatus.connected, shouldQueryLinear])
+  }, [
+    debouncedQuery,
+    disabled,
+    linearSourceContext,
+    linearStatus.connected,
+    parsedLinearReference,
+    shouldQueryLinear
+  ])
 
   // Why: GitLab paste-URL flow. Watches the debounced query for a GitLab
   // issue/MR URL (parseGitLabIssueOrMRLink already filters non-GitLab URLs
@@ -1106,7 +1191,7 @@ export default function SmartWorkspaceNameField({
     if (parseGitLabIssueOrMRLink(trimmed) !== null) {
       return 'gitlab'
     }
-    if (linearAvailable && /^[A-Za-z][A-Za-z0-9_]*-\d+$/.test(trimmed)) {
+    if (linearAvailable && parseLinearIssueInput(trimmed) !== null) {
       return 'linear'
     }
     return null
@@ -1120,6 +1205,21 @@ export default function SmartWorkspaceNameField({
   })
 
   const loading = githubLoading || gitlabLoading || branchesLoading || linearLoading
+  const currentLinearReferenceResolution =
+    linearReferenceResolution.query === trimmedValue ? linearReferenceResolution : null
+  const linearUrlResolving = currentLinearReferenceResolution?.status === 'resolving'
+  const linearNotFound = currentLinearReferenceResolution?.status === 'not-found'
+  const linearNotFoundCue = linearNotFound
+    ? searchResultRows.length > 0
+      ? translate(
+          'auto.components.new.workspace.SmartWorkspaceNameField.c24d9b8ef1',
+          'No exact match for this Linear link.'
+        )
+      : translate(
+          'auto.components.new.workspace.SmartWorkspaceNameField.51f5a8c927',
+          'Linear issue not found in your connected workspaces.'
+        )
+    : null
   const ActiveInputIcon = mode === 'text' ? CaseSensitive : loading ? LoaderCircle : Search
 
   const handleSelect = useCallback(
@@ -1585,11 +1685,25 @@ export default function SmartWorkspaceNameField({
               </div>
             ) : null}
             <CommandList className="!max-h-none min-h-0 flex-1 scrollbar-sleek">
+              {currentLinearReferenceResolution?.status === 'resolved' ? (
+                <div className="sr-only" aria-live="polite">
+                  {translate(
+                    'auto.components.new.workspace.SmartWorkspaceNameField.2e128194c4',
+                    'Linear issue {{identifier}} resolved.',
+                    { identifier: currentLinearReferenceResolution.identifier }
+                  )}
+                </div>
+              ) : null}
               {typedTextActionRow ? (
                 <div
                   className="sticky top-0 z-10 border-b border-border/40 bg-popover p-1"
                   onMouseDown={(event) => event.preventDefault()}
                 >
+                  {linearNotFoundCue ? (
+                    <div aria-live="polite" className="px-2 py-1 text-xs text-muted-foreground">
+                      {linearNotFoundCue}
+                    </div>
+                  ) : null}
                   <CommandItem
                     key={typedTextActionRow.value}
                     value={typedTextActionRow.value}
@@ -1601,7 +1715,24 @@ export default function SmartWorkspaceNameField({
                   </CommandItem>
                 </div>
               ) : null}
-              {loading && searchResultRows.length === 0 ? (
+              {linearNotFoundCue && !typedTextActionRow ? (
+                <div aria-live="polite" className="px-3 py-2 text-xs text-muted-foreground">
+                  {linearNotFoundCue}
+                </div>
+              ) : null}
+              {linearUrlResolving ? (
+                <div
+                  role="status"
+                  aria-live="polite"
+                  className="flex h-8 items-center gap-2 px-3 text-xs text-muted-foreground"
+                >
+                  <LoaderCircle className="size-3.5 animate-spin" />
+                  {translate(
+                    'auto.components.new.workspace.SmartWorkspaceNameField.8dc291159e',
+                    'Resolving Linear link…'
+                  )}
+                </div>
+              ) : loading && searchResultRows.length === 0 ? (
                 <div className="space-y-1 p-1">
                   {[0, 1, 2].map((index) => (
                     <div key={index} className="h-8 animate-pulse rounded bg-muted/40" />

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10693,7 +10693,11 @@
             "searchGitLab": "Search GitLab MRs and issues",
             "searchBranches": "Search branches",
             "searchLinear": "Search Linear issues",
-            "workspaceName": "Workspace name"
+            "workspaceName": "Workspace name",
+            "c24d9b8ef1": "No exact match for this Linear link.",
+            "51f5a8c927": "Linear issue not found in your connected workspaces.",
+            "2e128194c4": "Linear issue {{identifier}} resolved.",
+            "8dc291159e": "Resolving Linear link…"
           },
           "ProjectHostSetupCombobox": {
             "empty": "No hosts are ready for this project.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -10670,7 +10670,11 @@
             "searchGitLab": "Buscar MRs e issues de GitLab",
             "searchBranches": "Buscar ramas",
             "searchLinear": "Buscar issues de Linear",
-            "workspaceName": "Nombre del espacio de trabajo"
+            "workspaceName": "Nombre del espacio de trabajo",
+            "c24d9b8ef1": "No exact match for this Linear link.",
+            "51f5a8c927": "Linear issue not found in your connected workspaces.",
+            "2e128194c4": "Linear issue {{identifier}} resolved.",
+            "8dc291159e": "Resolving Linear link…"
           },
           "ProjectHostSetupCombobox": {
             "empty": "No hay hosts listos para este proyecto.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -10670,7 +10670,11 @@
             "searchGitLab": "GitLab MR と Issue を検索",
             "searchBranches": "ブランチを検索",
             "searchLinear": "Linear Issue を検索",
-            "workspaceName": "ワークスペース名"
+            "workspaceName": "ワークスペース名",
+            "c24d9b8ef1": "No exact match for this Linear link.",
+            "51f5a8c927": "Linear issue not found in your connected workspaces.",
+            "2e128194c4": "Linear issue {{identifier}} resolved.",
+            "8dc291159e": "Resolving Linear link…"
           },
           "ProjectHostSetupCombobox": {
             "empty": "No hosts are ready for this project.",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10670,7 +10670,11 @@
             "searchGitLab": "GitLab MR 및 이슈 검색",
             "searchBranches": "브랜치 검색",
             "searchLinear": "Linear 이슈 검색",
-            "workspaceName": "워크스페이스 이름"
+            "workspaceName": "워크스페이스 이름",
+            "c24d9b8ef1": "No exact match for this Linear link.",
+            "51f5a8c927": "Linear issue not found in your connected workspaces.",
+            "2e128194c4": "Linear issue {{identifier}} resolved.",
+            "8dc291159e": "Resolving Linear link…"
           },
           "ProjectHostSetupCombobox": {
             "empty": "이 프로젝트에 준비된 호스트가 없습니다.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -10670,7 +10670,11 @@
             "searchGitLab": "搜索 GitLab MR 和议题",
             "searchBranches": "搜索分支",
             "searchLinear": "搜索 Linear 议题",
-            "workspaceName": "工作区名称"
+            "workspaceName": "工作区名称",
+            "c24d9b8ef1": "No exact match for this Linear link.",
+            "51f5a8c927": "Linear issue not found in your connected workspaces.",
+            "2e128194c4": "Linear issue {{identifier}} resolved.",
+            "8dc291159e": "Resolving Linear link…"
           },
           "ProjectHostSetupCombobox": {
             "empty": "此项目没有已就绪的主机。",

--- a/src/renderer/src/runtime/runtime-linear-client.test.ts
+++ b/src/renderer/src/runtime/runtime-linear-client.test.ts
@@ -4,6 +4,7 @@ import {
   linearCreateProject,
   linearCreateSubIssue,
   linearGetCustomView,
+  linearGetIssuesByIdentifier,
   linearGetProject,
   linearListCustomViewIssues,
   linearListCustomViewProjects,
@@ -28,6 +29,7 @@ const runtimeEnvironmentCall = vi.fn()
 const runtimeEnvironmentTransportCall = vi.fn()
 const linearStatusLocal = vi.fn()
 const linearSearchIssuesLocal = vi.fn()
+const linearGetIssuesByIdentifierLocal = vi.fn()
 const linearListIssuesLocal = vi.fn()
 const linearCreateIssueLocal = vi.fn()
 const linearCreateProjectLocal = vi.fn()
@@ -48,6 +50,7 @@ beforeEach(() => {
   runtimeEnvironmentTransportCall.mockReset()
   linearStatusLocal.mockReset()
   linearSearchIssuesLocal.mockReset()
+  linearGetIssuesByIdentifierLocal.mockReset()
   linearListIssuesLocal.mockReset()
   linearCreateIssueLocal.mockReset()
   linearCreateProjectLocal.mockReset()
@@ -70,6 +73,7 @@ beforeEach(() => {
       linear: {
         status: linearStatusLocal,
         searchIssues: linearSearchIssuesLocal,
+        getIssuesByIdentifier: linearGetIssuesByIdentifierLocal,
         listIssues: linearListIssuesLocal,
         createIssue: linearCreateIssueLocal,
         createProject: linearCreateProjectLocal,
@@ -92,6 +96,7 @@ describe('runtime linear client', () => {
   it('uses local Linear IPC when no runtime environment is active', async () => {
     linearStatusLocal.mockResolvedValue({ connected: false, viewer: null })
     linearSearchIssuesLocal.mockResolvedValue([{ id: 'issue-1' }])
+    linearGetIssuesByIdentifierLocal.mockResolvedValue({ items: [{ id: 'issue-42' }], errors: [] })
     linearListIssuesLocal.mockResolvedValue({ items: [{ id: 'issue-2' }], hasMore: true })
     linearCreateIssueLocal.mockResolvedValue({
       ok: true,
@@ -110,6 +115,9 @@ describe('runtime linear client', () => {
       linearSearchIssues({ activeRuntimeEnvironmentId: null }, 'bug', 10)
     ).resolves.toEqual([{ id: 'issue-1' }])
     await expect(
+      linearGetIssuesByIdentifier({ activeRuntimeEnvironmentId: null }, 'ENG-42')
+    ).resolves.toEqual({ items: [{ id: 'issue-42' }], errors: [] })
+    await expect(
       linearListIssues({ activeRuntimeEnvironmentId: null }, 'all', 72, 'workspace-1')
     ).resolves.toEqual({ items: [{ id: 'issue-2' }], hasMore: true })
     await linearCreateSubIssue(
@@ -126,6 +134,10 @@ describe('runtime linear client', () => {
       query: 'bug',
       limit: 10,
       workspaceId: undefined
+    })
+    expect(linearGetIssuesByIdentifierLocal).toHaveBeenCalledWith({
+      identifier: 'ENG-42',
+      workspaceId: 'all'
     })
     expect(linearListIssuesLocal).toHaveBeenCalledWith({
       filter: 'all',

--- a/src/renderer/src/runtime/runtime-linear-client.ts
+++ b/src/renderer/src/runtime/runtime-linear-client.ts
@@ -304,6 +304,24 @@ export async function linearGetIssue(
     : window.api.linear.getIssue({ id, workspaceId: workspaceId ?? undefined })
 }
 
+export async function linearGetIssuesByIdentifier(
+  settings: RuntimeLinearSettings,
+  identifier: string,
+  workspaceId: LinearWorkspaceSelection = 'all'
+): Promise<LinearCollectionResult<LinearIssue>> {
+  const target = getLinearRuntimeTarget(settings)
+  const result =
+    target.kind === 'environment'
+      ? await callRuntimeRpc<unknown>(
+          target,
+          'linear.getIssuesByIdentifier',
+          { identifier, workspaceId },
+          { timeoutMs: 30_000 }
+        )
+      : await window.api.linear.getIssuesByIdentifier({ identifier, workspaceId })
+  return normalizeLinearIssueCollectionResult(result)
+}
+
 export async function linearUpdateIssue(
   settings: RuntimeLinearSettings,
   id: string,

--- a/src/renderer/src/store/slices/linear-invalidation.test.ts
+++ b/src/renderer/src/store/slices/linear-invalidation.test.ts
@@ -10,12 +10,14 @@ const linearListIssues = vi.fn()
 const linearSearchIssues = vi.fn()
 const linearListTeams = vi.fn()
 const linearGetIssue = vi.fn()
+const linearGetIssuesByIdentifier = vi.fn()
 
 vi.mock('@/runtime/runtime-linear-client', () => ({
   linearConnect: (...args: unknown[]) => linearConnect(...args),
   linearDisconnect: vi.fn(),
   linearDisconnectWorkspace: vi.fn(),
   linearGetIssue: (...args: unknown[]) => linearGetIssue(...args),
+  linearGetIssuesByIdentifier: (...args: unknown[]) => linearGetIssuesByIdentifier(...args),
   isLinearIssueAttributeFilterUnsupportedError: () => false,
   linearListIssues: (...args: unknown[]) => linearListIssues(...args),
   linearListTeams: (...args: unknown[]) => linearListTeams(...args),

--- a/src/renderer/src/store/slices/linear.test.ts
+++ b/src/renderer/src/store/slices/linear.test.ts
@@ -27,6 +27,7 @@ const linearListIssues = vi.fn()
 const linearSearchIssues = vi.fn()
 const linearListTeams = vi.fn()
 const linearGetIssue = vi.fn()
+const linearGetIssuesByIdentifier = vi.fn()
 const linearListProjects = vi.fn()
 const linearGetCustomView = vi.fn()
 const linearGetProject = vi.fn()
@@ -46,6 +47,7 @@ vi.mock('@/runtime/runtime-linear-client', async (importOriginal) => {
     linearGetCustomView: (...args: unknown[]) => linearGetCustomView(...args),
     linearGetProject: (...args: unknown[]) => linearGetProject(...args),
     linearGetIssue: (...args: unknown[]) => linearGetIssue(...args),
+    linearGetIssuesByIdentifier: (...args: unknown[]) => linearGetIssuesByIdentifier(...args),
     linearListCustomViewIssues: (...args: unknown[]) => linearListCustomViewIssues(...args),
     linearListCustomViewProjects: (...args: unknown[]) => linearListCustomViewProjects(...args),
     linearListCustomViews: (...args: unknown[]) => linearListCustomViews(...args),
@@ -150,6 +152,22 @@ describe('createLinearSlice caching', () => {
     ).resolves.toMatchObject({ items: [{ id: 'LIN-2' }] })
 
     expect(linearListIssues).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not cache all-workspace identifier verification lookups', async () => {
+    const store = createTestStore()
+    linearGetIssuesByIdentifier
+      .mockResolvedValueOnce({
+        items: [],
+        errors: [{ workspaceId: 'workspace-1', type: 'network', message: 'timeout' }]
+      })
+      .mockResolvedValueOnce({ items: [issue('ENG-42')], errors: [] })
+
+    await store.getState().getLinearIssuesByIdentifier('ENG-42')
+    await store.getState().getLinearIssuesByIdentifier('ENG-42')
+
+    expect(linearGetIssuesByIdentifier).toHaveBeenCalledTimes(2)
+    expect(linearGetIssuesByIdentifier).toHaveBeenLastCalledWith(null, 'ENG-42', 'all')
   })
 
   it('isolates list cache entries by attribute filter signature', async () => {
@@ -1093,6 +1111,7 @@ describe('createLinearSlice', () => {
     linearSearchIssues.mockReset()
     linearListTeams.mockReset()
     linearGetIssue.mockReset()
+    linearGetIssuesByIdentifier.mockReset()
     linearTestConnection.mockReset()
   })
 

--- a/src/renderer/src/store/slices/linear.ts
+++ b/src/renderer/src/store/slices/linear.ts
@@ -29,6 +29,7 @@ import {
   linearGetCustomView,
   linearGetProject,
   linearGetIssue,
+  linearGetIssuesByIdentifier,
   linearListCustomViewIssues,
   linearListCustomViewProjects,
   linearListCustomViews,
@@ -492,6 +493,10 @@ export type LinearSlice = {
     workspaceId?: string | null,
     options?: LinearFetchOptions
   ) => Promise<LinearIssue | null>
+  getLinearIssuesByIdentifier: (
+    identifier: string,
+    options?: Pick<LinearFetchOptions, 'sourceContext'>
+  ) => Promise<LinearCollectionResult<LinearIssue>>
   refreshLinearIssue: (
     id: string,
     workspaceId?: string | null,
@@ -893,6 +898,13 @@ export const createLinearSlice: StateCreator<AppState, [], [], LinearSlice> = (s
       linearStatusChecked: true,
       linearStatusContextKey: contextKey
     })
+  },
+
+  getLinearIssuesByIdentifier: async (identifier, options) => {
+    const scope = getLinearReadScope(get().settings, options?.sourceContext)
+    // Why: URL verification must fan out on every attempt; caching a transient
+    // miss would prevent retyping the link from retrying a recovered workspace.
+    return linearGetIssuesByIdentifier(scope.settings, identifier, 'all')
   },
 
   fetchLinearIssue: async (

--- a/src/shared/linear-links.test.ts
+++ b/src/shared/linear-links.test.ts
@@ -4,7 +4,9 @@ import {
   buildLinearPersonalApiKeySettingsUrl,
   buildLinearTeamUrl,
   buildLinearWorkspaceApiSettingsUrl,
+  findLinearIssueExactReferenceMatch,
   getLinearOrganizationUrlKeyFromIssueUrl,
+  isLinearIssueExactReferenceMatch,
   parseLinearIssueInput
 } from './linear-links'
 
@@ -59,7 +61,52 @@ describe('linear links', () => {
   })
 
   it('rejects non-Linear issue input', () => {
+    expect(parseLinearIssueInput('https://linear.app/acme/settings/api')).toBeNull()
+    expect(parseLinearIssueInput('https://linear.app/acme/team/ENG/all')).toBeNull()
+    expect(parseLinearIssueInput('https://linear.app/acme/settings/issue/ENG-123')).toBeNull()
     expect(parseLinearIssueInput('https://example.com/acme/issue/ENG-123')).toBeNull()
+    expect(parseLinearIssueInput('https://linear.app/acme/issue/not-an-identifier')).toBeNull()
     expect(parseLinearIssueInput('not an issue')).toBeNull()
+  })
+
+  it('matches exact issue references with strict organization verification', () => {
+    const issue = {
+      identifier: 'ENG-123',
+      url: 'https://linear.app/AcMe/issue/ENG-123/fix-auth'
+    }
+
+    expect(
+      isLinearIssueExactReferenceMatch(issue, {
+        identifier: 'eng-123',
+        organizationUrlKey: 'acme'
+      })
+    ).toBe(true)
+    expect(
+      isLinearIssueExactReferenceMatch(issue, {
+        identifier: 'ENG-123',
+        organizationUrlKey: 'other'
+      })
+    ).toBe(false)
+    expect(isLinearIssueExactReferenceMatch(issue, { identifier: 'ENG-123' })).toBe(true)
+    expect(
+      isLinearIssueExactReferenceMatch(
+        { identifier: 'ENG-123', url: 'https://example.com/acme/issue/ENG-123' },
+        { identifier: 'ENG-123', organizationUrlKey: 'acme' }
+      )
+    ).toBe(false)
+  })
+
+  it('selects the organization-matching issue when identifiers collide', () => {
+    const issues = [
+      { identifier: 'ENG-42', url: 'https://linear.app/wrong/issue/ENG-42' },
+      { identifier: 'ENG-42', url: 'https://linear.app/acme/issue/ENG-42' }
+    ]
+
+    expect(
+      findLinearIssueExactReferenceMatch(issues, {
+        identifier: 'ENG-42',
+        organizationUrlKey: 'ACME'
+      })
+    ).toBe(issues[1])
   })
 })

--- a/src/shared/linear-links.ts
+++ b/src/shared/linear-links.ts
@@ -1,3 +1,5 @@
+import type { LinearIssue } from './types'
+
 export function buildLinearTeamUrl(args: {
   organizationUrlKey?: string | null
   teamKey?: string | null
@@ -44,6 +46,29 @@ export type ParsedLinearIssueInput = {
   organizationUrlKey?: string
 }
 
+export function isLinearIssueExactReferenceMatch(
+  issue: Pick<LinearIssue, 'identifier' | 'url'>,
+  reference: ParsedLinearIssueInput
+): boolean {
+  if (issue.identifier.toUpperCase() !== reference.identifier.toUpperCase()) {
+    return false
+  }
+  if (!reference.organizationUrlKey) {
+    return true
+  }
+  const issueOrganizationUrlKey = getLinearOrganizationUrlKeyFromIssueUrl(issue.url)
+  return (
+    issueOrganizationUrlKey !== null &&
+    issueOrganizationUrlKey.toLowerCase() === reference.organizationUrlKey.toLowerCase()
+  )
+}
+
+export function findLinearIssueExactReferenceMatch<
+  T extends Pick<LinearIssue, 'identifier' | 'url'>
+>(issues: readonly T[], reference: ParsedLinearIssueInput): T | null {
+  return issues.find((issue) => isLinearIssueExactReferenceMatch(issue, reference)) ?? null
+}
+
 const LINEAR_IDENTIFIER_PATTERN = /^[A-Za-z][A-Za-z0-9_]*-\d+$/
 
 export function parseLinearIssueInput(input: string): ParsedLinearIssueInput | null {
@@ -62,9 +87,8 @@ export function parseLinearIssueInput(input: string): ParsedLinearIssueInput | n
       return null
     }
     const parts = parsed.pathname.split('/').filter(Boolean)
-    const issueIndex = parts.indexOf('issue')
     const organizationUrlKey = parts[0]
-    const rawIdentifier = issueIndex >= 0 ? parts[issueIndex + 1] : undefined
+    const rawIdentifier = parts[1] === 'issue' ? parts[2] : undefined
     if (!organizationUrlKey || !rawIdentifier) {
       return null
     }


### PR DESCRIPTION
## Summary

- recognize Linear issue URLs in the desktop and mobile smart workspace pickers
- normalize links to issue identifiers and verify exact matches against the canonical Linear organization key
- add an all-workspace get-by-identifier fallback with transient-error reporting
- wire the fallback through Electron IPC, preload, runtime RPC, SSH/remote routing, renderer state, and mobile
- show resolving and authoritative not-found status while retaining fuzzy neighborhood results

## Validation

- Node, web, CLI, and mobile typechecks passed
- mobile suite: 2,055 passed, 2 skipped
- desktop suite: 31,914 passed; one unrelated remote-runtime test flaked and passed in isolation
- changed-file lint, pre-commit lint, formatting, and relevant gates passed
- repository-wide lint remains blocked by the pre-existing exhaustiveness error in src/renderer/src/components/skills/skill-freshness-group.tsx

## Draft status / known blockers

This is intentionally not merge-ready:

- The supplied STA-2067 Linear URL already resolves on main because Linear search returns the issue even when given the raw URL. The original problem statement is not reproduced.
- A URL with the wrong organization can leave the matching issue highlighted as a normal fuzzy result. Pressing Enter can therefore select an organization-mismatched issue.
- A missing issue URL can show the no-exact-match cue while an unrelated fuzzy result is highlighted. Pressing Enter can select that unrelated issue.
- The branch was opened as a discussion/reference draft and should either be abandoned or revised from a confirmed failing reproduction with selection gated on a verified exact match.
