### PR TITLE
feat(settings): link Linear capabilities pane to Integrations settings

### DIFF
--- a/src/renderer/src/components/settings/LinearAgentSkillPane.tsx
+++ b/src/renderer/src/components/settings/LinearAgentSkillPane.tsx
@@ -1,12 +1,5 @@
 import { useMemo } from 'react'
-import {
-  ArrowRightCircle,
-  BookOpen,
-  Blocks,
-  Link2,
-  ListTodo,
-  MessageSquarePlus
-} from 'lucide-react'
+import { ArrowRightCircle, BookOpen, Link2, ListTodo, MessageSquarePlus } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { LinearIcon } from '@/components/icons/LinearIcon'
 import { Button } from '@/components/ui/button'
@@ -181,10 +174,9 @@ export function LinearAgentSkillPane(): React.JSX.Element {
           type="button"
           variant="link"
           size="sm"
-          className="h-auto gap-1 p-0 text-xs align-baseline"
+          className="h-auto p-0 text-xs align-baseline"
           onClick={openIntegrationSettings}
         >
-          <Blocks className="size-3" />
           {translate(
             'auto.components.settings.LinearAgentSkillPane.manageConnectionLink',
             'Integrations settings'

--- a/src/renderer/src/components/settings/LinearAgentSkillPane.tsx
+++ b/src/renderer/src/components/settings/LinearAgentSkillPane.tsx
@@ -111,26 +111,6 @@ export function LinearAgentSkillPane(): React.JSX.Element {
       keywords={getLinearAgentSkillPaneSearchEntries()[0].keywords}
       className="space-y-5 py-2"
     >
-      <p className="text-xs text-muted-foreground">
-        {translate(
-          'auto.components.settings.LinearAgentSkillPane.manageConnectionHint',
-          'Review connected Linear workspaces and API keys in'
-        )}{' '}
-        <Button
-          type="button"
-          variant="link"
-          size="sm"
-          className="h-auto gap-1 p-0 text-xs align-baseline"
-          onClick={openIntegrationSettings}
-        >
-          <Blocks className="size-3" />
-          {translate(
-            'auto.components.settings.LinearAgentSkillPane.manageConnectionLink',
-            'Integrations settings'
-          )}
-        </Button>
-      </p>
-
       <AgentSkillSetupPanel
         title={translate(
           'auto.components.settings.LinearAgentSkillPane.skillTitle',
@@ -191,6 +171,26 @@ export function LinearAgentSkillPane(): React.JSX.Element {
         resolveIcon={resolveLinearExampleIcon}
         slashCommand={`/${ORCA_LINEAR_SKILL_NAME}`}
       />
+
+      <p className="text-xs text-muted-foreground">
+        {translate(
+          'auto.components.settings.LinearAgentSkillPane.manageConnectionHint',
+          'Review connected Linear workspaces and API keys in'
+        )}{' '}
+        <Button
+          type="button"
+          variant="link"
+          size="sm"
+          className="h-auto gap-1 p-0 text-xs align-baseline"
+          onClick={openIntegrationSettings}
+        >
+          <Blocks className="size-3" />
+          {translate(
+            'auto.components.settings.LinearAgentSkillPane.manageConnectionLink',
+            'Integrations settings'
+          )}
+        </Button>
+      </p>
     </SearchableSetting>
   )
 }

--- a/src/renderer/src/components/settings/LinearAgentSkillPane.tsx
+++ b/src/renderer/src/components/settings/LinearAgentSkillPane.tsx
@@ -1,7 +1,16 @@
 import { useMemo } from 'react'
-import { ArrowRightCircle, BookOpen, Link2, ListTodo, MessageSquarePlus } from 'lucide-react'
+import {
+  ArrowRightCircle,
+  BookOpen,
+  Blocks,
+  Link2,
+  ListTodo,
+  MessageSquarePlus
+} from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { LinearIcon } from '@/components/icons/LinearIcon'
+import { Button } from '@/components/ui/button'
+import { useAppStore } from '@/store'
 import {
   LINEAR_AGENT_SKILL_NAMES,
   ORCA_LINEAR_SKILL_INSTALL_COMMAND,
@@ -48,6 +57,14 @@ function resolveLinearExampleIcon(example: SkillUsageExample): LucideIcon {
 // connection that makes it useful.
 export function LinearAgentSkillPane(): React.JSX.Element {
   const activeSkillRuntime = useActiveProjectSkillRuntime()
+  const openSettingsPage = useAppStore((state) => state.openSettingsPage)
+  const openSettingsTarget = useAppStore((state) => state.openSettingsTarget)
+
+  const openIntegrationSettings = (): void => {
+    openSettingsPage()
+    openSettingsTarget({ pane: 'integrations', repoId: null })
+  }
+
   const {
     installed: linearSkillInstalled,
     loading: linearSkillLoading,
@@ -94,6 +111,26 @@ export function LinearAgentSkillPane(): React.JSX.Element {
       keywords={getLinearAgentSkillPaneSearchEntries()[0].keywords}
       className="space-y-5 py-2"
     >
+      <p className="text-xs text-muted-foreground">
+        {translate(
+          'auto.components.settings.LinearAgentSkillPane.manageConnectionHint',
+          'Review connected Linear workspaces and API keys in'
+        )}{' '}
+        <Button
+          type="button"
+          variant="link"
+          size="sm"
+          className="h-auto gap-1 p-0 text-xs align-baseline"
+          onClick={openIntegrationSettings}
+        >
+          <Blocks className="size-3" />
+          {translate(
+            'auto.components.settings.LinearAgentSkillPane.manageConnectionLink',
+            'Integrations settings'
+          )}
+        </Button>
+      </p>
+
       <AgentSkillSetupPanel
         title={translate(
           'auto.components.settings.LinearAgentSkillPane.skillTitle',

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9270,7 +9270,9 @@
           "howToUse": "How to use it",
           "howToUseDescription": "Ask an agent working a Linear-linked worktree to read context, post updates, move the ticket, or attach the PR.",
           "terminalTitle": "Linear skill setup",
-          "terminalAriaLabel": "Linear skill install terminal"
+          "terminalAriaLabel": "Linear skill install terminal",
+          "manageConnectionHint": "Review connected Linear workspaces and API keys in",
+          "manageConnectionLink": "Integrations settings"
         },
         "MobileRelayBetaNotice": {
           "notice": "Orca Relay is in beta."

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9247,7 +9247,9 @@
           "howToUse": "How to use it",
           "howToUseDescription": "Ask an agent working a Linear-linked worktree to read context, post updates, move the ticket, or attach the PR.",
           "terminalTitle": "Linear skill setup",
-          "terminalAriaLabel": "Linear skill install terminal"
+          "terminalAriaLabel": "Linear skill install terminal",
+          "manageConnectionHint": "Review connected Linear workspaces and API keys in",
+          "manageConnectionLink": "Integrations settings"
         },
         "MobileRelayBetaNotice": {
           "notice": "Orca Relay is in beta."

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9247,7 +9247,9 @@
           "howToUse": "How to use it",
           "howToUseDescription": "Ask an agent working a Linear-linked worktree to read context, post updates, move the ticket, or attach the PR.",
           "terminalTitle": "Linear skill setup",
-          "terminalAriaLabel": "Linear skill install terminal"
+          "terminalAriaLabel": "Linear skill install terminal",
+          "manageConnectionHint": "Review connected Linear workspaces and API keys in",
+          "manageConnectionLink": "Integrations settings"
         },
         "MobileRelayBetaNotice": {
           "notice": "Orca Relay is in beta."

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9247,7 +9247,9 @@
           "howToUse": "How to use it",
           "howToUseDescription": "Ask an agent working a Linear-linked worktree to read context, post updates, move the ticket, or attach the PR.",
           "terminalTitle": "Linear skill setup",
-          "terminalAriaLabel": "Linear skill install terminal"
+          "terminalAriaLabel": "Linear skill install terminal",
+          "manageConnectionHint": "Review connected Linear workspaces and API keys in",
+          "manageConnectionLink": "Integrations settings"
         },
         "MobileRelayBetaNotice": {
           "notice": "Orca Relay is in beta."

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9247,7 +9247,9 @@
           "howToUse": "How to use it",
           "howToUseDescription": "Ask an agent working a Linear-linked worktree to read context, post updates, move the ticket, or attach the PR.",
           "terminalTitle": "Linear skill setup",
-          "terminalAriaLabel": "Linear skill install terminal"
+          "terminalAriaLabel": "Linear skill install terminal",
+          "manageConnectionHint": "Review connected Linear workspaces and API keys in",
+          "manageConnectionLink": "Integrations settings"
         },
         "MobileRelayBetaNotice": {
           "notice": "Orca Relay is in beta."


### PR DESCRIPTION
## What

Settings → Agent capabilities → **Linear** now includes a text link, at
the **very bottom of the card**, to the **Integrations settings** pane —
the place where connected Linear workspaces and API keys are managed.

Previously this pane only offered the `orca-linear` skill install/update
UI, with no pointer to where the underlying Linear connection lives. The
new inline link jumps straight to Settings → Integrations.

## How

- `LinearAgentSkillPane` reads `openSettingsPage` / `openSettingsTarget`
  from the store and navigates to `{ pane: 'integrations' }` — the same
  in-app navigation convention used by `ProviderHostScopeControl`.
- Rendered as a plain `variant="link"` button (no icon), matching the
  settings link idiom.
- Two new localized strings (`manageConnectionHint` / `manageConnectionLink`)
  added to `en.json` and synced across all locale catalogs.

## Screenshot

**The link at the bottom of Settings → Agent capabilities → Linear** (below the "How to use it" examples):

![Linear capabilities pane with Integrations settings link at the bottom](https://github.com/stablyai/orca/blob/a381bca650d31aa29ebd1d2fc710906c168bc053/linear-capabilities-pane-link.png?raw=true)

**Clicking it lands on Settings → Integrations** (where connected Linear workspaces live):

![Integrations settings destination](https://github.com/stablyai/orca/blob/a381bca650d31aa29ebd1d2fc710906c168bc053/linear-integrations-destination.png?raw=true)

## Validation

- Typecheck (`typecheck:tsc:web`), `oxlint`, and `verify:localization-catalog` pass.
- Verified live in the running Electron app via CDP: the link renders at
  the bottom of the Linear pane (no icon) and clicking it navigates to
  the Integrations pane (both screenshots above are real app captures).

## Notes

- The pane is only mounted when Linear is connected, so the link always
  points somewhere meaningful.
