### PR TITLE
fix(web): preserve paired runtime ownership

### DIFF
--- a/mobile/src/transport/pairing.test.ts
+++ b/mobile/src/transport/pairing.test.ts
@@ -1,14 +1,15 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { decodePairingUrl, extractPairingCodeFromUrl, parsePairingCode } from './pairing'
+import type { PairingOffer } from './types'
 
-const offer = {
+const offer: PairingOffer = {
   v: 2,
   endpoint: 'ws://100.102.47.57:6768',
   deviceToken: 'token-abc',
   publicKeyB64: 'pubkey-xyz'
-} as const
+}
 
-function encodeOffer(input = offer): string {
+function encodeOffer(input: PairingOffer = offer): string {
   return btoa(JSON.stringify(input)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
 }
 
@@ -60,5 +61,15 @@ describe('pairing deep links', () => {
 
     expect(parsePairingCode(`orca://pair?code=${code}`)).toEqual(offer)
     expect(parsePairingCode(code)).toEqual(offer)
+  })
+
+  it('preserves a TLS reverse-proxy endpoint with an explicit port and path', () => {
+    const proxiedOffer = {
+      ...offer,
+      endpoint: 'wss://proxy.example:443/orca/runtime'
+    }
+    const code = encodeOffer(proxiedOffer)
+
+    expect(parsePairingCode(code)).toEqual(proxiedOffer)
   })
 })

--- a/src/renderer/src/components/ports/WorkspacePortScanner.test.tsx
+++ b/src/renderer/src/components/ports/WorkspacePortScanner.test.tsx
@@ -233,6 +233,41 @@ describe('WorkspacePortScanner', () => {
     })
   })
 
+  it.each([
+    ['a malformed port record', { platform: 'linux', scannedAt: 1, ports: [null] }],
+    [
+      'a malformed workspace owner',
+      {
+        platform: 'linux',
+        scannedAt: 1,
+        ports: [
+          {
+            id: 'tcp:3000',
+            bindHost: '127.0.0.1',
+            connectHost: '127.0.0.1',
+            port: 3000,
+            protocol: 'http',
+            kind: 'workspace',
+            owner: null
+          }
+        ]
+      }
+    ],
+    ['an unsupported platform', { platform: 'plan9', scannedAt: 1, ports: [] }]
+  ])('turns %s into an unavailable result', async (_label, result) => {
+    runtimeEnvironmentCall.mockResolvedValue({ ok: true, result })
+
+    await act(async () => {
+      root?.render(<WorkspacePortScanner />)
+      await flushPromises()
+    })
+
+    expect(useAppStore.getState().workspacePortScansByKey[remoteScanKey]).toMatchObject({
+      ports: [],
+      unavailableReason: 'Workspace port scan returned an invalid response.'
+    })
+  })
+
   it('does not restart remote scans before the background interval when host inputs rerender', async () => {
     await act(async () => {
       root?.render(<WorkspacePortScanner />)

--- a/src/renderer/src/components/ports/WorkspacePortScanner.test.tsx
+++ b/src/renderer/src/components/ports/WorkspacePortScanner.test.tsx
@@ -219,6 +219,20 @@ afterEach(() => {
 })
 
 describe('WorkspacePortScanner', () => {
+  it('turns a missing runtime scan payload into an unavailable result', async () => {
+    runtimeEnvironmentCall.mockResolvedValue({ ok: true, result: undefined })
+
+    await act(async () => {
+      root?.render(<WorkspacePortScanner />)
+      await flushPromises()
+    })
+
+    expect(useAppStore.getState().workspacePortScansByKey[remoteScanKey]).toMatchObject({
+      ports: [],
+      unavailableReason: 'Workspace port scan returned an invalid response.'
+    })
+  })
+
   it('does not restart remote scans before the background interval when host inputs rerender', async () => {
     await act(async () => {
       root?.render(<WorkspacePortScanner />)

--- a/src/renderer/src/lib/workspace-port-actions.ts
+++ b/src/renderer/src/lib/workspace-port-actions.ts
@@ -13,6 +13,7 @@ import type {
   WorkspacePortScanResult
 } from '../../../shared/workspace-ports'
 import type { LocalhostWorktreeLabelRoute } from '../../../shared/localhost-worktree-labels'
+import { runWorkspacePortScanForTarget } from './workspace-port-scan-client'
 import { browserUrlForPort } from './workspace-port-urls'
 
 export { addressForPort } from './workspace-port-urls'
@@ -269,31 +270,6 @@ const inFlightWorkspacePortScans = new Map<string, Promise<WorkspacePortScanResu
 
 function workspacePortScanRequestKey(target: RuntimeClientTarget, repoId?: string): string {
   return JSON.stringify([workspacePortRuntimeTargetKey(target), repoId ?? null])
-}
-
-async function runWorkspacePortScanForTarget(
-  target: RuntimeClientTarget,
-  repoId?: string
-): Promise<WorkspacePortScanResult> {
-  const params = repoId ? { repoId } : {}
-  if (target.kind === 'local') {
-    return window.api.workspacePorts.scan(params)
-  }
-  try {
-    return await callRuntimeRpc<WorkspacePortScanResult>(target, 'workspacePorts.scan', params, {
-      timeoutMs: 15_000
-    })
-  } catch (error) {
-    if (error instanceof RuntimeRpcCallError && error.code === 'method_not_found') {
-      return {
-        platform: 'unknown',
-        scannedAt: Date.now(),
-        ports: [],
-        unavailableReason: 'The connected runtime does not support workspace port management yet.'
-      }
-    }
-    throw error
-  }
 }
 
 export async function scanWorkspacePortsForTarget(

--- a/src/renderer/src/lib/workspace-port-scan-client.ts
+++ b/src/renderer/src/lib/workspace-port-scan-client.ts
@@ -1,0 +1,53 @@
+import {
+  callRuntimeRpc,
+  RuntimeRpcCallError,
+  type RuntimeClientTarget
+} from '@/runtime/runtime-rpc-client'
+import type { WorkspacePortScanResult } from '../../../shared/workspace-ports'
+
+function requireWorkspacePortScanResult(value: unknown): WorkspacePortScanResult {
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    !Array.isArray((value as WorkspacePortScanResult).ports) ||
+    typeof (value as WorkspacePortScanResult).platform !== 'string' ||
+    !Number.isFinite((value as WorkspacePortScanResult).scannedAt) ||
+    ('unavailableReason' in value &&
+      (value as WorkspacePortScanResult).unavailableReason !== undefined &&
+      typeof (value as WorkspacePortScanResult).unavailableReason !== 'string')
+  ) {
+    throw new Error('Workspace port scan returned an invalid response.')
+  }
+  return value as WorkspacePortScanResult
+}
+
+export async function runWorkspacePortScanForTarget(
+  target: RuntimeClientTarget,
+  repoId?: string
+): Promise<WorkspacePortScanResult> {
+  const params = repoId ? { repoId } : {}
+  if (target.kind === 'local') {
+    return requireWorkspacePortScanResult(await window.api.workspacePorts.scan(params))
+  }
+  try {
+    const result = await callRuntimeRpc<WorkspacePortScanResult>(
+      target,
+      'workspacePorts.scan',
+      params,
+      {
+        timeoutMs: 15_000
+      }
+    )
+    return requireWorkspacePortScanResult(result)
+  } catch (error) {
+    if (error instanceof RuntimeRpcCallError && error.code === 'method_not_found') {
+      return {
+        platform: 'unknown',
+        scannedAt: Date.now(),
+        ports: [],
+        unavailableReason: 'The connected runtime does not support workspace port management yet.'
+      }
+    }
+    throw error
+  }
+}

--- a/src/renderer/src/lib/workspace-port-scan-client.ts
+++ b/src/renderer/src/lib/workspace-port-scan-client.ts
@@ -3,22 +3,84 @@ import {
   RuntimeRpcCallError,
   type RuntimeClientTarget
 } from '@/runtime/runtime-rpc-client'
-import type { WorkspacePortScanResult } from '../../../shared/workspace-ports'
+import type { WorkspacePort, WorkspacePortScanResult } from '../../../shared/workspace-ports'
+
+const WORKSPACE_PORT_PLATFORMS = new Set<NodeJS.Platform | 'unknown'>([
+  'aix',
+  'android',
+  'cygwin',
+  'darwin',
+  'freebsd',
+  'haiku',
+  'linux',
+  'netbsd',
+  'openbsd',
+  'sunos',
+  'unknown',
+  'win32'
+])
+const WORKSPACE_PORT_PROTOCOLS = new Set<WorkspacePort['protocol']>(['http', 'https', 'unknown'])
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object'
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === 'string'
+}
+
+function isOptionalFiniteNumber(value: unknown): boolean {
+  return value === undefined || (typeof value === 'number' && Number.isFinite(value))
+}
+
+function isWorkspacePortOwner(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false
+  }
+  return (
+    typeof value.worktreeId === 'string' &&
+    typeof value.repoId === 'string' &&
+    typeof value.displayName === 'string' &&
+    typeof value.path === 'string' &&
+    (value.confidence === 'cwd' || value.confidence === 'command' || value.confidence === 'none')
+  )
+}
+
+function isWorkspacePort(value: unknown): value is WorkspacePort {
+  if (
+    !isRecord(value) ||
+    typeof value.id !== 'string' ||
+    typeof value.bindHost !== 'string' ||
+    typeof value.connectHost !== 'string' ||
+    typeof value.port !== 'number' ||
+    !Number.isFinite(value.port) ||
+    !isOptionalFiniteNumber(value.pid) ||
+    !isOptionalString(value.processName) ||
+    !WORKSPACE_PORT_PROTOCOLS.has(value.protocol as WorkspacePort['protocol'])
+  ) {
+    return false
+  }
+  if (value.kind === 'workspace') {
+    return isWorkspacePortOwner(value.owner) && isOptionalString(value.advertisedUrl)
+  }
+  return value.kind === 'container' || value.kind === 'external'
+}
 
 function requireWorkspacePortScanResult(value: unknown): WorkspacePortScanResult {
   if (
-    !value ||
-    typeof value !== 'object' ||
-    !Array.isArray((value as WorkspacePortScanResult).ports) ||
-    typeof (value as WorkspacePortScanResult).platform !== 'string' ||
-    !Number.isFinite((value as WorkspacePortScanResult).scannedAt) ||
+    !isRecord(value) ||
+    !Array.isArray(value.ports) ||
+    !value.ports.every(isWorkspacePort) ||
+    !WORKSPACE_PORT_PLATFORMS.has(value.platform as NodeJS.Platform | 'unknown') ||
+    typeof value.scannedAt !== 'number' ||
+    !Number.isFinite(value.scannedAt) ||
     ('unavailableReason' in value &&
-      (value as WorkspacePortScanResult).unavailableReason !== undefined &&
-      typeof (value as WorkspacePortScanResult).unavailableReason !== 'string')
+      value.unavailableReason !== undefined &&
+      typeof value.unavailableReason !== 'string')
   ) {
     throw new Error('Workspace port scan returned an invalid response.')
   }
-  return value as WorkspacePortScanResult
+  return value as unknown as WorkspacePortScanResult
 }
 
 export async function runWorkspacePortScanForTarget(

--- a/src/renderer/src/runtime/file-explorer-delete-owner-provenance.test.ts
+++ b/src/renderer/src/runtime/file-explorer-delete-owner-provenance.test.ts
@@ -269,6 +269,39 @@ describe('file explorer deletion owner provenance', () => {
     )
     expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
   })
+
+  it('permanently deletes a paired-server worktree through its stamped runtime', async () => {
+    useAppStore.setState({
+      settings: { activeRuntimeEnvironmentId: 'web-server-b' } as never,
+      repos: [
+        makeRepo({
+          id: LOCAL_REPO_ID,
+          path: '/tmp/project',
+          executionHostId: 'runtime:web-server-a'
+        })
+      ],
+      worktreesByRepo: {
+        [LOCAL_REPO_ID]: [makeWorktree('runtime:web-server-a')]
+      }
+    })
+    const owner = getFileExplorerOperationOwner(LOCAL_WORKTREE_ID)
+    expect(owner).toEqual({ kind: 'runtime', environmentId: 'web-server-a' })
+
+    const { result } = renderDelete(LOCAL_WORKTREE_ID)
+    await requestDelete(result, localNode, owner)
+
+    await vi.waitFor(() =>
+      expect(runtimeEnvironmentCall).toHaveBeenCalledWith(
+        expect.objectContaining({ selector: 'web-server-a', method: 'files.delete' })
+      )
+    )
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: 'This permanently deletes the file on the remote host. This cannot be undone.'
+      })
+    )
+    expect(fsDeletePath).not.toHaveBeenCalled()
+  })
 })
 
 function duplicateHostRepos(): Repo[] {

--- a/src/renderer/src/web/WebConnect.tsx
+++ b/src/renderer/src/web/WebConnect.tsx
@@ -54,7 +54,11 @@ export default function WebConnect({
       return
     }
     setConnecting(true)
-    const environment = createStoredWebRuntimeEnvironment({ name, offer: parsedOffer })
+    const environment = createStoredWebRuntimeEnvironment({
+      name,
+      offer: parsedOffer,
+      previousEnvironment: existingEnvironment
+    })
     const client = new WebRuntimeClient(parsedOffer)
     try {
       const response = await client.call('status.get', undefined, { timeoutMs: 15_000 })

--- a/src/renderer/src/web/main.tsx
+++ b/src/renderer/src/web/main.tsx
@@ -42,7 +42,11 @@ function WebRoot(): React.JSX.Element {
   const [hasEnvironment, setHasEnvironment] = useState(() => {
     if (startupDecision.kind === 'auto-save-runtime-offer') {
       saveStoredWebRuntimeEnvironment(
-        createStoredWebRuntimeEnvironment({ name: 'Orca Server', offer: startupDecision.offer })
+        createStoredWebRuntimeEnvironment({
+          name: 'Orca Server',
+          offer: startupDecision.offer,
+          previousEnvironment: readStoredWebRuntimeEnvironment()
+        })
       )
       return true
     }

--- a/src/renderer/src/web/web-pairing.test.ts
+++ b/src/renderer/src/web/web-pairing.test.ts
@@ -32,6 +32,14 @@ describe('web pairing input', () => {
     })
   })
 
+  it.each([
+    ['wss://proxy.example:443/orca/runtime', 'wss://proxy.example:443/orca/runtime'],
+    ['https://proxy.example/orca/runtime', 'wss://proxy.example/orca/runtime'],
+    ['http://proxy.example:8080/orca/runtime', 'ws://proxy.example:8080/orca/runtime']
+  ])('preserves reverse-proxy endpoint routing for %s', (endpoint, expected) => {
+    expect(parseWebPairingInput(encodeOffer({ endpoint }))).toMatchObject({ endpoint: expected })
+  })
+
   it('treats invalid device scope metadata as unknown', () => {
     expect(parseWebPairingInput(`orca://pair?code=${encodeOffer({ scope: 'admin' })}`)).toEqual(
       offer

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -72,20 +72,20 @@ async function installApi(userAgent?: string): Promise<{
   }
 }
 
-function writeStoredRuntimeEnvironment(storage: Storage): void {
+function writeStoredRuntimeEnvironment(storage: Storage, environmentId = 'web-env-1'): void {
   storage.setItem(
     'orca.web.runtimeEnvironment.v1',
     JSON.stringify({
-      id: 'web-env-1',
+      id: environmentId,
       name: 'Test runtime',
       createdAt: 1,
       updatedAt: 1,
       lastUsedAt: null,
       runtimeId: null,
-      preferredEndpointId: 'ws-web-env-1',
+      preferredEndpointId: `ws-${environmentId}`,
       endpoints: [
         {
-          id: 'ws-web-env-1',
+          id: `ws-${environmentId}`,
           kind: 'websocket',
           label: 'WebSocket',
           endpoint: 'ws://127.0.0.1:1234',
@@ -95,6 +95,19 @@ function writeStoredRuntimeEnvironment(storage: Storage): void {
       ]
     })
   )
+}
+
+function encodePairingCode(overrides: Record<string, unknown> = {}): string {
+  return Buffer.from(
+    JSON.stringify({
+      v: 2,
+      endpoint: 'wss://server.example:443',
+      deviceToken: 'server-token',
+      publicKeyB64: 'server-key',
+      ...overrides
+    }),
+    'utf8'
+  ).toString('base64url')
 }
 
 function trackPromiseSettled(promise: Promise<unknown>): () => boolean {
@@ -171,6 +184,84 @@ describe('web before-unload persistence', () => {
     ).toMatchObject({ activeWorktreeId: 'remote-worktree' })
     expect(JSON.parse(storage.getItem('orca.web.ui.v1') ?? '{}')).toMatchObject({
       activeView: 'settings'
+    })
+  })
+})
+
+describe('web runtime environment identity', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('does not resolve an old server selector through a differently keyed server', async () => {
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage, 'web-server-a')
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    await globals.window.api.runtimeEnvironments.addFromPairingCode({
+      name: 'Server B',
+      pairingCode: encodePairingCode({ publicKeyB64: 'server-b-key' })
+    })
+
+    await expect(
+      globals.window.api.runtimeEnvironments.resolve({ selector: 'web-server-a' })
+    ).rejects.toThrow('Unknown Orca runtime environment: web-server-a')
+  })
+
+  it('keeps old selectors only when re-pairing proves the same server key', async () => {
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage, 'web-server-a')
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    const paired = await globals.window.api.runtimeEnvironments.addFromPairingCode({
+      name: 'Server A again',
+      pairingCode: encodePairingCode({ publicKeyB64: 'public-key' })
+    })
+
+    await expect(
+      globals.window.api.runtimeEnvironments.resolve({ selector: 'web-server-a' })
+    ).resolves.toMatchObject({ id: paired.environment.id, name: 'Server A again' })
+  })
+
+  it('ignores malformed persisted compatibility ids when resolving selectors', async () => {
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage, 'web-server-a')
+    const stored = JSON.parse(
+      globals.storage.getItem('orca.web.runtimeEnvironment.v1') ?? '{}'
+    ) as Record<string, unknown>
+    stored.compatibleEnvironmentIds = { old: 'web-server-old' }
+    globals.storage.setItem('orca.web.runtimeEnvironment.v1', JSON.stringify(stored))
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    await expect(
+      globals.window.api.runtimeEnvironments.resolve({ selector: 'web-server-old' })
+    ).rejects.toThrow('Unknown Orca runtime environment: web-server-old')
+  })
+})
+
+describe('web browser-local port capability', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns an explicit unavailable scan instead of an undefined fallback payload', async () => {
+    const { api } = await installApi('Linux')
+
+    await expect(api.workspacePorts.scan({})).resolves.toMatchObject({
+      platform: 'linux',
+      ports: [],
+      unavailableReason: 'Workspace port scanning is unavailable for browser-local workspaces.'
     })
   })
 })
@@ -1934,6 +2025,99 @@ describe('web repos preload API', () => {
     ).rejects.toThrow('Host-scoped project reordering is unavailable in paired web clients.')
   })
 
+  it('attributes a server-local catalog to the paired runtime that returned it', async () => {
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(): Promise<RuntimeRpcResponse<unknown>> {
+          return Promise.resolve({
+            id: 'repo-list',
+            ok: true,
+            result: {
+              repos: [
+                {
+                  id: 'repo-1',
+                  path: '/srv/repo',
+                  displayName: 'repo',
+                  badgeColor: '#000',
+                  addedAt: 1,
+                  executionHostId: 'local'
+                }
+              ]
+            },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage, 'web-server-a')
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    await expect(globals.window.api.repos.list()).resolves.toMatchObject([
+      { id: 'repo-1', executionHostId: 'runtime:web-server-a' }
+    ])
+  })
+
+  it('does not reassign an in-flight catalog when the browser pairs to another server', async () => {
+    let resolveCatalog!: (response: RuntimeRpcResponse<unknown>) => void
+    const pendingCatalog = new Promise<RuntimeRpcResponse<unknown>>((resolve) => {
+      resolveCatalog = resolve
+    })
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(): Promise<RuntimeRpcResponse<unknown>> {
+          return pendingCatalog
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage, 'web-server-a')
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+    const catalogPromise = globals.window.api.repos.list()
+    const pairingCode = encodePairingCode({
+      endpoint: 'wss://server-b.example:443',
+      deviceToken: 'server-b-token',
+      publicKeyB64: 'server-b-key'
+    })
+    const paired = await globals.window.api.runtimeEnvironments.addFromPairingCode({
+      name: 'Server B',
+      pairingCode
+    })
+
+    resolveCatalog({
+      id: 'repo-list',
+      ok: true,
+      result: {
+        repos: [
+          {
+            id: 'repo-a',
+            path: '/srv/a',
+            displayName: 'A',
+            badgeColor: '#000',
+            addedAt: 1,
+            executionHostId: 'local'
+          }
+        ]
+      },
+      _meta: { runtimeId: 'runtime-a' }
+    })
+
+    await expect(catalogPromise).resolves.toMatchObject([
+      { id: 'repo-a', executionHostId: 'runtime:web-server-a' }
+    ])
+    await expect(globals.window.api.runtimeEnvironments.list()).resolves.toMatchObject([
+      { id: paired.environment.id, name: 'Server B' }
+    ])
+  })
+
   it.each([
     ['/home/alice', '/home/alice/orca/projects'],
     ['/', '/orca/projects'],
@@ -2035,6 +2219,94 @@ describe('web worktree preload API', () => {
     ])
   })
 
+  it.each(['web-server-a', 'web-server-b'])(
+    'attributes server-local worktrees to their own paired runtime %s',
+    async (environmentId) => {
+      vi.doMock('./web-runtime-client', () => ({
+        WebRuntimeClient: class {
+          call(): Promise<RuntimeRpcResponse<unknown>> {
+            return Promise.resolve({
+              id: 'worktree-list',
+              ok: true,
+              result: {
+                worktrees: [
+                  {
+                    id: 'repo-1::/srv/repo',
+                    repoId: 'repo-1',
+                    path: '/srv/repo',
+                    hostId: 'local'
+                  }
+                ]
+              },
+              _meta: { runtimeId: 'runtime-1' }
+            })
+          }
+
+          close(): void {}
+        }
+      }))
+
+      const globals = installBrowserGlobals('Linux')
+      writeStoredRuntimeEnvironment(globals.storage, environmentId)
+      const { installWebPreloadApi } = await import('./web-preload-api')
+      installWebPreloadApi()
+
+      await expect(globals.window.api.worktrees.list({ repoId: 'repo-1' })).resolves.toMatchObject([
+        { id: 'repo-1::/srv/repo', hostId: `runtime:${environmentId}` }
+      ])
+    }
+  )
+
+  it('does not let a stale listAll response repopulate the next server cache', async () => {
+    let resolveServerA: ((response: RuntimeRpcResponse<unknown>) => void) | undefined
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        constructor(private readonly offer: { publicKeyB64: string }) {}
+
+        call(): Promise<RuntimeRpcResponse<unknown>> {
+          if (this.offer.publicKeyB64 === 'public-key') {
+            return new Promise((resolve) => {
+              resolveServerA = resolve
+            })
+          }
+          return Promise.resolve({
+            id: 'server-b-list',
+            ok: true,
+            result: { worktrees: [{ id: 'worktree-b', repoId: 'repo-b', path: '/srv/b' }] },
+            _meta: { runtimeId: 'runtime-b' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage, 'web-server-a')
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    const serverAList = globals.window.api.worktrees.listAll()
+    await vi.waitFor(() => expect(resolveServerA).toBeTypeOf('function'))
+    const paired = await globals.window.api.runtimeEnvironments.addFromPairingCode({
+      name: 'Server B',
+      pairingCode: encodePairingCode({ publicKeyB64: 'server-b-key' })
+    })
+    resolveServerA?.({
+      id: 'server-a-list',
+      ok: true,
+      result: { worktrees: [{ id: 'worktree-a', repoId: 'repo-a', path: '/srv/a' }] },
+      _meta: { runtimeId: 'runtime-a' }
+    })
+
+    await expect(serverAList).rejects.toThrow(
+      'The paired Orca server changed while the request was in progress.'
+    )
+    await expect(globals.window.api.worktrees.listAll()).resolves.toMatchObject([
+      { id: 'worktree-b', hostId: `runtime:${paired.environment.id}` }
+    ])
+  })
+
   it('falls back to legacy worktree.list when detectedList is unavailable', async () => {
     const runtimeCalls: { method: string; params: unknown }[] = []
     const worktree = {
@@ -2097,12 +2369,59 @@ describe('web worktree preload API', () => {
       repoId: 'repo-1',
       authoritative: true,
       source: 'session-fallback',
-      worktrees: [{ id: worktree.id, ownership: 'orca-managed', visible: true }]
+      worktrees: [
+        {
+          id: worktree.id,
+          hostId: 'runtime:web-env-1',
+          ownership: 'orca-managed',
+          visible: true
+        }
+      ]
     })
     expect(runtimeCalls).toEqual([
       { method: 'worktree.detectedList', params: { repo: 'repo-1' } },
       { method: 'worktree.list', params: { repo: 'repo-1', limit: 10_000 } }
     ])
+  })
+
+  it('does not run a legacy detected-worktree fallback against a newly paired server', async () => {
+    const runtimeCalls: string[] = []
+    let resolveDetected: ((response: RuntimeRpcResponse<unknown>) => void) | undefined
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string): Promise<RuntimeRpcResponse<unknown>> {
+          runtimeCalls.push(method)
+          return new Promise((resolve) => {
+            resolveDetected = resolve
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage, 'web-server-a')
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    const detected = globals.window.api.worktrees.listDetected({ repoId: 'repo-1' })
+    await vi.waitFor(() => expect(resolveDetected).toBeTypeOf('function'))
+    await globals.window.api.runtimeEnvironments.addFromPairingCode({
+      name: 'Server B',
+      pairingCode: encodePairingCode({ publicKeyB64: 'server-b-key' })
+    })
+    resolveDetected?.({
+      id: 'detected-list',
+      ok: false,
+      error: { code: 'method_not_found', message: 'Unknown method: worktree.detectedList' },
+      _meta: { runtimeId: 'runtime-a' }
+    })
+
+    await expect(detected).rejects.toThrow(
+      'The paired Orca server changed while the request was in progress.'
+    )
+    expect(runtimeCalls).toEqual(['worktree.detectedList'])
   })
 
   it('forwards review compare-base fields through runtime worktree calls', async () => {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -540,6 +540,22 @@ function createWebPreloadApi(): Partial<PreloadApi> {
         displayServer: null
       })
     },
+    workspacePorts: {
+      // Why: browser-local workspaces have no host process to inspect; return capability state instead of the generic undefined fallback.
+      scan: () =>
+        Promise.resolve({
+          platform: getBrowserPlatform(),
+          scannedAt: Date.now(),
+          ports: [],
+          unavailableReason: 'Workspace port scanning is unavailable for browser-local workspaces.'
+        }),
+      kill: () =>
+        Promise.resolve({
+          ok: false,
+          reason: 'Workspace port management is unavailable for browser-local workspaces.'
+        }),
+      onAdvertisedUrlChanged: () => noopUnsubscribe
+    },
     orcaProfiles: {
       list: () =>
         Promise.resolve({
@@ -1269,8 +1285,9 @@ function createRuntimeEnvironmentsApi(): NonNullable<Partial<PreloadApi>['runtim
       if (!offer) {
         throw new Error('Invalid Orca pairing code.')
       }
+      const previousEnvironment = activeEnvironment
       closeActiveRuntimeClients()
-      activeEnvironment = createStoredWebRuntimeEnvironment({ name, offer })
+      activeEnvironment = createStoredWebRuntimeEnvironment({ name, offer, previousEnvironment })
       saveStoredWebRuntimeEnvironment(activeEnvironment)
       return { environment: redactStoredWebRuntimeEnvironment(activeEnvironment) }
     },
@@ -1349,10 +1366,17 @@ function webAiVaultUnavailableResult(executionHostId: ExecutionHostId): AiVaultL
 
 function createReposApi(): NonNullable<Partial<PreloadApi>['repos']> {
   return {
-    list: async () => (await callRuntimeResult<{ repos: Repo[] }>('repo.list')).repos,
+    list: async () => {
+      const owned = await callRuntimeResultWithOwner<{ repos: Repo[] }>('repo.list')
+      return owned.result.repos.map((repo) => withRuntimeRepoOwner(repo, owned.hostId))
+    },
     add: async ({ path, kind }) => {
       invalidateRuntimeWorktreeCaches()
-      return callRuntimeResult('repo.add', { path, kind })
+      const owned = await callRuntimeResultWithOwner<{ repo: Repo } | { error: string }>(
+        'repo.add',
+        { path, kind }
+      )
+      return withRuntimeRepoMutationOwner(owned.result, owned.hostId)
     },
     remove: async ({ repoId }) => {
       await callRuntimeResult('repo.rm', { repo: repoId })
@@ -1367,16 +1391,24 @@ function createReposApi(): NonNullable<Partial<PreloadApi>['repos']> {
     reorderForHost: async () => {
       throw new Error('Host-scoped project reordering is unavailable in paired web clients.')
     },
-    update: async ({ repoId, updates }) =>
-      (await callRuntimeResult<{ repo: Repo }>('repo.update', { repo: repoId, updates })).repo,
+    update: async ({ repoId, updates }) => {
+      const owned = await callRuntimeResultWithOwner<{ repo: Repo }>('repo.update', {
+        repo: repoId,
+        updates
+      })
+      return withRuntimeRepoOwner(owned.result.repo, owned.hostId)
+    },
     pickFolder: () => Promise.resolve(null),
     pickFolders: () => Promise.resolve([]),
     pickDirectory: () => Promise.resolve(null),
     clone: async ({ url, destination }) => {
       invalidateRuntimeWorktreeCaches()
-      return (
-        await callRuntimeResult<{ repo: Repo }>('repo.clone', { url, destination }, 10 * 60_000)
-      ).repo
+      const owned = await callRuntimeResultWithOwner<{ repo: Repo }>(
+        'repo.clone',
+        { url, destination },
+        10 * 60_000
+      )
+      return withRuntimeRepoOwner(owned.result.repo, owned.hostId)
     },
     cloneRemote: async () => {
       // Why: SSH relay cloning is owned by the desktop main process; paired web clients can't run that local IPC path.
@@ -1389,22 +1421,31 @@ function createReposApi(): NonNullable<Partial<PreloadApi>['repos']> {
     cloneAbort: () => Promise.resolve(),
     addRemote: async ({ remotePath, displayName, kind }) => {
       invalidateRuntimeWorktreeCaches()
-      const result = await callRuntimeResult<{ repo: Repo }>('repo.add', {
+      const owned = await callRuntimeResultWithOwner<{ repo: Repo }>('repo.add', {
         path: remotePath,
         kind
       })
-      return displayName
-        ? {
-            repo: await createReposApi().update({
-              repoId: result.repo.id,
-              updates: { displayName }
-            })
-          }
-        : result
+      const result = {
+        repo: withRuntimeRepoOwner(owned.result.repo, owned.hostId)
+      }
+      if (!displayName) {
+        return result
+      }
+      assertActiveEnvironment(owned.environmentId)
+      return {
+        repo: await createReposApi().update({
+          repoId: result.repo.id,
+          updates: { displayName }
+        })
+      }
     },
     create: async ({ parentPath, name, kind }) => {
       invalidateRuntimeWorktreeCaches()
-      return callRuntimeResult('repo.create', { parentPath, name, kind })
+      const owned = await callRuntimeResultWithOwner<{ repo: Repo } | { error: string }>(
+        'repo.create',
+        { parentPath, name, kind }
+      )
+      return withRuntimeRepoMutationOwner(owned.result, owned.hostId)
     },
     isGitAvailable: async () =>
       (await callRuntimeResult<{ available: boolean }>('repo.gitAvailable')).available,
@@ -1443,18 +1484,20 @@ function createReposApi(): NonNullable<Partial<PreloadApi>['repos']> {
 
 function createWorktreesApi(): NonNullable<Partial<PreloadApi>['worktrees']> {
   return {
-    list: async ({ repoId }) =>
-      (
-        await callRuntimeResult<{ worktrees: Worktree[] }>('worktree.list', {
-          repo: repoId,
-          limit: WEB_RUNTIME_WORKTREE_LIST_LIMIT
-        })
-      ).worktrees,
+    list: async ({ repoId }) => {
+      const owned = await callRuntimeResultWithOwner<{ worktrees: Worktree[] }>('worktree.list', {
+        repo: repoId,
+        limit: WEB_RUNTIME_WORKTREE_LIST_LIMIT
+      })
+      return owned.result.worktrees.map((worktree) =>
+        withRuntimeWorktreeOwner(worktree, owned.hostId)
+      )
+    },
     listDetected: async ({ repoId }) => callRuntimeDetectedWorktrees(repoId),
     listAll: () => listAllRuntimeWorktrees(),
     create: async (args) => {
       invalidateRuntimeWorktreeCaches()
-      return callRuntimeResult('worktree.create', {
+      const owned = await callRuntimeResultWithOwner<{ worktree: Worktree }>('worktree.create', {
         repo: args.repoId,
         name: args.name,
         baseBranch: args.baseBranch,
@@ -1494,6 +1537,10 @@ function createWorktreesApi(): NonNullable<Partial<PreloadApi>['worktrees']> {
         manualOrder: args.manualOrder,
         automationProvenanceRequest: args.automationProvenanceRequest
       })
+      return {
+        ...owned.result,
+        worktree: withRuntimeWorktreeOwner(owned.result.worktree, owned.hostId)
+      }
     },
     // Why: the runtime create path emits no two-phase progress, so the panel falls back to an indeterminate spinner.
     onCreateProgress: () => noopUnsubscribe,
@@ -1543,12 +1590,11 @@ function createWorktreesApi(): NonNullable<Partial<PreloadApi>['worktrees']> {
         updates.pushTarget === undefined
           ? { ...updates, pushTarget: null }
           : updates
-      return (
-        await callRuntimeResult<{ worktree: Worktree }>('worktree.set', {
-          worktree: toRuntimeWorktreeSelector(worktreeId),
-          ...rpcUpdates
-        })
-      ).worktree
+      const owned = await callRuntimeResultWithOwner<{ worktree: Worktree }>('worktree.set', {
+        worktree: toRuntimeWorktreeSelector(worktreeId),
+        ...rpcUpdates
+      })
+      return withRuntimeWorktreeOwner(owned.result.worktree, owned.hostId)
     },
     listLineage: async () =>
       await callRuntimeResult<{
@@ -3077,6 +3123,31 @@ async function callRuntimeResult<TResult>(
   return response.result as TResult
 }
 
+async function callRuntimeResultWithOwner<TResult>(
+  method: string,
+  params?: unknown,
+  timeoutMs?: number
+): Promise<{ result: TResult; hostId: ExecutionHostId; environmentId: string }> {
+  const environmentId = requireActiveEnvironment().id
+  const result = await callRuntimeResult<TResult>(method, params, timeoutMs)
+  return { result, hostId: toRuntimeExecutionHostId(environmentId), environmentId }
+}
+
+function withRuntimeRepoOwner(repo: Repo, hostId: ExecutionHostId): Repo {
+  return { ...repo, executionHostId: hostId }
+}
+
+function withRuntimeRepoMutationOwner(
+  result: { repo: Repo } | { error: string },
+  hostId: ExecutionHostId
+): { repo: Repo } | { error: string } {
+  return 'repo' in result ? { ...result, repo: withRuntimeRepoOwner(result.repo, hostId) } : result
+}
+
+function withRuntimeWorktreeOwner<T extends Worktree>(worktree: T, hostId: ExecutionHostId): T {
+  return { ...worktree, hostId }
+}
+
 async function saveClipboardImageAsTempFileInRuntime(
   contentBase64: string,
   args?: { connectionId?: string | null; runtimeEnvironmentId?: string | null }
@@ -3171,8 +3242,7 @@ function resolveEnvironment(selector: string): StoredWebRuntimeEnvironment {
   if (selector === environment.id || selector === environment.name || selector === 'active') {
     return environment
   }
-  if (selector.startsWith('web-') && environment.id.startsWith('web-')) {
-    // Why: persisted terminal ids can outlive a re-pair, which mints a fresh web-* id for the same active server.
+  if (environment.compatibleEnvironmentIds?.includes(selector)) {
     return environment
   }
   throw new Error(`Unknown Orca runtime environment: ${selector}`)
@@ -3191,10 +3261,19 @@ function requireActiveEnvironmentOrNull(): StoredWebRuntimeEnvironment | null {
   return activeEnvironment
 }
 
+function assertActiveEnvironment(environmentId: string): void {
+  if (requireActiveEnvironment().id !== environmentId) {
+    throw new Error('The paired Orca server changed while the request was in progress.')
+  }
+}
+
 function updateEnvironmentFromResponse(
   environment: StoredWebRuntimeEnvironment,
   response: RuntimeRpcResponse<unknown>
 ): void {
+  if (activeEnvironment?.id !== environment.id) {
+    return
+  }
   const runtimeId = response.ok ? response._meta.runtimeId : (response._meta?.runtimeId ?? null)
   activeEnvironment = updateStoredEnvironmentRuntimeId(environment, runtimeId)
 }
@@ -3547,11 +3626,15 @@ async function listAllRuntimeWorktrees(): Promise<Worktree[]> {
   if (cachedWorktrees && Date.now() - cachedWorktrees.loadedAt < 5_000) {
     return cachedWorktrees.worktrees
   }
-  const result = await callRuntimeResult<{ worktrees: Worktree[] }>('worktree.list', {
+  const owned = await callRuntimeResultWithOwner<{ worktrees: Worktree[] }>('worktree.list', {
     limit: WEB_RUNTIME_WORKTREE_LIST_LIMIT
   })
-  cachedWorktrees = { loadedAt: Date.now(), worktrees: result.worktrees }
-  return result.worktrees
+  const worktrees = owned.result.worktrees.map((worktree) =>
+    withRuntimeWorktreeOwner(worktree, owned.hostId)
+  )
+  assertActiveEnvironment(owned.environmentId)
+  cachedWorktrees = { loadedAt: Date.now(), worktrees }
+  return worktrees
 }
 
 async function listAllRuntimeDetectedWorktrees(): Promise<Worktree[]> {
@@ -3559,34 +3642,49 @@ async function listAllRuntimeDetectedWorktrees(): Promise<Worktree[]> {
     return cachedDetectedWorktrees.worktrees
   }
 
-  const repos = (await callRuntimeResult<{ repos: Repo[] }>('repo.list')).repos
+  const owned = await callRuntimeResultWithOwner<{ repos: Repo[] }>('repo.list')
   const detectedLists = await Promise.all(
-    repos.map((repo) => callRuntimeDetectedWorktrees(repo.id))
+    owned.result.repos.map((repo) => callRuntimeDetectedWorktrees(repo.id, owned.environmentId))
   )
   const worktrees = detectedLists.flatMap((result) => result.worktrees)
+  assertActiveEnvironment(owned.environmentId)
   cachedDetectedWorktrees = { loadedAt: Date.now(), worktrees }
   return worktrees
 }
 
-async function callRuntimeDetectedWorktrees(repoId: string): Promise<DetectedWorktreeListResult> {
+async function callRuntimeDetectedWorktrees(
+  repoId: string,
+  expectedEnvironmentId = requireActiveEnvironment().id
+): Promise<DetectedWorktreeListResult> {
+  assertActiveEnvironment(expectedEnvironmentId)
+  const hostId = toRuntimeExecutionHostId(expectedEnvironmentId)
   const response = await callRuntimeEnvelope<DetectedWorktreeListResult>(
     'worktree.detectedList',
     { repo: repoId },
     15_000
   )
   if (response.ok) {
-    return response.result
+    return {
+      ...response.result,
+      worktrees: response.result.worktrees.map((worktree) =>
+        withRuntimeWorktreeOwner(worktree, hostId)
+      )
+    }
   }
   if (response.error.code !== 'method_not_found') {
     throw new Error(response.error.message)
   }
 
+  assertActiveEnvironment(expectedEnvironmentId)
   const legacy = await callRuntimeResult<{ worktrees: Worktree[] }>(
     'worktree.list',
     { repo: repoId, limit: WEB_RUNTIME_WORKTREE_LIST_LIMIT },
     15_000
   )
-  return toLegacyDetectedWorktreeResult(repoId, legacy.worktrees)
+  return toLegacyDetectedWorktreeResult(
+    repoId,
+    legacy.worktrees.map((worktree) => withRuntimeWorktreeOwner(worktree, hostId))
+  )
 }
 
 function toLegacyDetectedWorktreeResult(

--- a/src/renderer/src/web/web-runtime-direct-proxy-live.integration.test.ts
+++ b/src/renderer/src/web/web-runtime-direct-proxy-live.integration.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { Repo, Worktree } from '../../../shared/types'
+import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
+import type { WorkspacePortScanResult } from '../../../shared/workspace-ports'
+import { parseWebPairingInput, type WebPairingOffer } from './web-pairing'
+import { WebRuntimeClient } from './web-runtime-client'
+
+const pairingInput = process.env.ORCA_REMOTE_ACCESS_PAIRING_INPUT
+const proxyEndpoint = process.env.ORCA_REMOTE_ACCESS_PROXY_ENDPOINT
+const secondPairingInput = process.env.ORCA_REMOTE_ACCESS_SECOND_PAIRING_INPUT
+
+function requireResult<T>(response: RuntimeRpcResponse<unknown>): T {
+  if (!response.ok) {
+    throw new Error(`${response.error.code}: ${response.error.message}`)
+  }
+  return response.result as T
+}
+
+async function openClient(offer: WebPairingOffer): Promise<WebRuntimeClient> {
+  const client = new WebRuntimeClient(offer)
+  requireResult(await client.call('status.get', undefined, { timeoutMs: 15_000 }))
+  return client
+}
+
+async function ensureTestRepo(client: WebRuntimeClient): Promise<Repo> {
+  const listed = requireResult<{ repos: Repo[] }>(await client.call('repo.list'))
+  const existing = listed.repos.find((repo) => repo.path === '/app')
+  if (existing) {
+    return existing
+  }
+  return requireResult<{ repo: Repo }>(await client.call('repo.add', { path: '/app', kind: 'git' }))
+    .repo
+}
+
+async function exerciseCatalogAndFilesystem(client: WebRuntimeClient): Promise<void> {
+  const repo = await ensureTestRepo(client)
+  const listed = requireResult<{ worktrees: Worktree[] }>(
+    await client.call('worktree.list', { repo: repo.id, limit: 10_000 })
+  )
+  expect(listed.worktrees.length).toBeGreaterThan(0)
+  const worktree = listed.worktrees[0]
+  expect(worktree.hostId ?? 'local').toBe('local')
+
+  const preview = requireResult<{ content: string }>(
+    await client.call('files.readPreview', {
+      worktree: `id:${worktree.id}`,
+      relativePath: 'package.json'
+    })
+  )
+  expect(preview.content).toContain('"name": "orca"')
+
+  const ports = requireResult<WorkspacePortScanResult>(await client.call('workspacePorts.scan', {}))
+  expect(Array.isArray(ports.ports)).toBe(true)
+}
+
+describe.runIf(Boolean(pairingInput && proxyEndpoint))(
+  'paired web runtime over direct and reverse-proxy paths',
+  () => {
+    let directOffer: WebPairingOffer
+    const clients: WebRuntimeClient[] = []
+
+    beforeEach(() => {
+      const parsed = parseWebPairingInput(pairingInput ?? '')
+      if (!parsed) {
+        throw new Error('ORCA_REMOTE_ACCESS_PAIRING_INPUT is not a valid pairing input.')
+      }
+      directOffer = parsed
+      Reflect.set(globalThis, 'window', {
+        setTimeout,
+        clearTimeout,
+        setInterval,
+        clearInterval,
+        atob,
+        btoa
+      })
+    })
+
+    afterEach(() => {
+      for (const client of clients) {
+        client.close()
+      }
+      clients.length = 0
+      Reflect.deleteProperty(globalThis, 'window')
+    })
+
+    it('keeps direct and TLS-proxied clients functional across reconnects', async () => {
+      const direct = await openClient(directOffer)
+      clients.push(direct)
+      await exerciseCatalogAndFilesystem(direct)
+
+      const proxy = await openClient({ ...directOffer, endpoint: proxyEndpoint ?? '' })
+      clients.push(proxy)
+      await exerciseCatalogAndFilesystem(proxy)
+
+      direct.close()
+      const reconnected = await openClient(directOffer)
+      clients.push(reconnected)
+      await exerciseCatalogAndFilesystem(reconnected)
+    })
+
+    it('serves independent simultaneous clients over both paths', async () => {
+      const [direct, proxy] = await Promise.all([
+        openClient(directOffer),
+        openClient({ ...directOffer, endpoint: proxyEndpoint ?? '' })
+      ])
+      clients.push(direct, proxy)
+
+      const results = await Promise.all([direct.call('repo.list'), proxy.call('repo.list')])
+      expect(
+        results.map((response) => requireResult<{ repos: Repo[] }>(response).repos.length)
+      ).toEqual([expect.any(Number), expect.any(Number)])
+    })
+
+    it.runIf(Boolean(secondPairingInput))(
+      'keeps simultaneous clients to different servers isolated',
+      async () => {
+        const secondOffer = parseWebPairingInput(secondPairingInput ?? '')
+        if (!secondOffer) {
+          throw new Error('ORCA_REMOTE_ACCESS_SECOND_PAIRING_INPUT is not valid.')
+        }
+        const [first, second] = await Promise.all([
+          openClient(directOffer),
+          openClient(secondOffer)
+        ])
+        clients.push(first, second)
+
+        const statuses = await Promise.all([
+          first.call('status.get', undefined, { timeoutMs: 15_000 }),
+          second.call('status.get', undefined, { timeoutMs: 15_000 })
+        ])
+        expect(new Set(statuses.map((status) => status._meta?.runtimeId)).size).toBe(2)
+        await Promise.all([
+          exerciseCatalogAndFilesystem(first),
+          exerciseCatalogAndFilesystem(second)
+        ])
+      }
+    )
+  }
+)

--- a/src/renderer/src/web/web-runtime-environment.ts
+++ b/src/renderer/src/web/web-runtime-environment.ts
@@ -4,6 +4,7 @@ import { createBrowserUuid } from '@/lib/browser-uuid'
 import { translate } from '@/i18n/i18n'
 
 export type StoredWebRuntimeEnvironment = Omit<PublicKnownRuntimeEnvironment, 'endpoints'> & {
+  compatibleEnvironmentIds?: string[]
   endpoints: {
     id: string
     kind: 'websocket'
@@ -23,10 +24,24 @@ export function readStoredWebRuntimeEnvironment(): StoredWebRuntimeEnvironment |
   }
   try {
     const parsed = JSON.parse(raw) as StoredWebRuntimeEnvironment
-    if (!parsed.id || !parsed.name || parsed.endpoints.length === 0) {
+    if (
+      !parsed.id ||
+      !parsed.name ||
+      !Array.isArray(parsed.endpoints) ||
+      parsed.endpoints.length === 0
+    ) {
       return null
     }
-    return parsed
+    const compatibleEnvironmentIds = Array.isArray(parsed.compatibleEnvironmentIds)
+      ? parsed.compatibleEnvironmentIds.filter(
+          (environmentId): environmentId is string => typeof environmentId === 'string'
+        )
+      : []
+    const { compatibleEnvironmentIds: _unvalidatedIds, ...environment } = parsed
+    return {
+      ...environment,
+      ...(compatibleEnvironmentIds.length > 0 ? { compatibleEnvironmentIds } : {})
+    }
   } catch {
     return null
   }
@@ -43,9 +58,11 @@ export function clearStoredWebRuntimeEnvironment(): void {
 export function createStoredWebRuntimeEnvironment(args: {
   name: string
   offer: WebPairingOffer
+  previousEnvironment?: StoredWebRuntimeEnvironment | null
 }): StoredWebRuntimeEnvironment {
   const id = `web-${createBrowserUuid()}`
   const now = Date.now()
+  const compatibleEnvironmentIds = getCompatibleEnvironmentIds(args.previousEnvironment, args.offer)
   return {
     id,
     name: args.name.trim() || 'Orca Server',
@@ -53,6 +70,7 @@ export function createStoredWebRuntimeEnvironment(args: {
     updatedAt: now,
     lastUsedAt: null,
     runtimeId: null,
+    ...(compatibleEnvironmentIds.length > 0 ? { compatibleEnvironmentIds } : {}),
     preferredEndpointId: `ws-${id}`,
     endpoints: [
       {
@@ -67,11 +85,22 @@ export function createStoredWebRuntimeEnvironment(args: {
   }
 }
 
+function getCompatibleEnvironmentIds(
+  previous: StoredWebRuntimeEnvironment | null | undefined,
+  offer: WebPairingOffer
+): string[] {
+  if (!previous?.endpoints.some((endpoint) => endpoint.publicKeyB64 === offer.publicKeyB64)) {
+    return []
+  }
+  return [...new Set([...(previous.compatibleEnvironmentIds ?? []), previous.id])]
+}
+
 export function redactStoredWebRuntimeEnvironment(
   environment: StoredWebRuntimeEnvironment
 ): PublicKnownRuntimeEnvironment {
+  const { compatibleEnvironmentIds: _compatibleEnvironmentIds, ...publicEnvironment } = environment
   return {
-    ...environment,
+    ...publicEnvironment,
     endpoints: environment.endpoints.map(
       ({ deviceToken: _token, publicKeyB64: _key, ...rest }) => ({
         ...rest

--- a/src/shared/pairing.test.ts
+++ b/src/shared/pairing.test.ts
@@ -27,6 +27,15 @@ describe('pairing offer', () => {
     expect(decodePairingOffer(encodePairingOffer(scopedOffer))).toEqual(scopedOffer)
   })
 
+  it('round-trips a TLS reverse-proxy endpoint with an explicit port and path', () => {
+    const proxiedOffer = {
+      ...offer,
+      endpoint: 'wss://proxy.example:443/orca/runtime'
+    }
+
+    expect(decodePairingOffer(encodePairingOffer(proxiedOffer))).toEqual(proxiedOffer)
+  })
+
   it('encoded URL uses base64url (no +, /, or = characters)', () => {
     const url = encodePairingOffer(offer)
     const code = new URLSearchParams(url.slice(url.indexOf('?') + 1)).get('code')!


### PR DESCRIPTION
## Summary

- stamp paired-web repo and worktree responses with the runtime environment that answered the request, so server-local filesystem and PTY work never falls through to browser-local APIs
- fence late responses, cache writes, legacy fallbacks, and restored selectors across re-pairs; old selectors remain compatible only when the server public key proves the same identity
- model browser-local workspace-port capability explicitly and validate scan payloads at the RPC boundary instead of allowing an undefined result to crash `unavailableReason` handling
- cover reverse-proxy endpoint scheme, port, and path preservation on shared, web, and mobile pairing paths

This addresses the immediate reproducible ownership and renderer-crash portions of #9760 and #9047. It intentionally avoids the global active-runtime fallback proposed in #9090/#9147 because that can route server A's worktree through server B.

## Investigation matrix

| Scope | Result |
| --- | --- |
| Headless server worktrees reported as `local` | Fixed with request-scoped runtime ownership |
| Direct LAN vs reverse proxy | Both validated; no transport-specific routing workaround needed |
| `unavailableReason` crash | Fixed at ownership and capability/RPC lifecycle boundaries |
| Mobile custom endpoint UX | Existing parser retained; TLS port/path behavior covered |
| Cloud relay/product requests | Out of scope; no relay implementation added |

## Verification

- 371 focused renderer/store/destructive-operation tests
- root and mobile TypeScript checks
- max-lines ratchet, focused oxlint, oxfmt, and `git diff --check`
- full mobile suite: 303 files / 2,170 tests passed, 2 skipped
- Docker headless Electron server through direct `ws://` and TLS reverse proxy `wss://.../orca/runtime`
- reconnect, simultaneous direct/proxy clients, two independently keyed servers, filesystem/catalog/port-scan RPCs
- three internal review-until-clean rounds, including elegance and performance audits

## Scope notes

- no cloud-relay work from #8147/#7208/#2471
- no Git provider or Git command behavior changes
- no UI styling changes
