### PR TITLE
fix(skills): record latest Linear release history

### DIFF
--- a/resources/skills/current-manifest.json
+++ b/resources/skills/current-manifest.json
@@ -22,7 +22,7 @@
     {
       "name": "linear-tickets",
       "sourcePath": "skills/linear-tickets",
-      "releaseRevision": 6,
+      "releaseRevision": 7,
       "packageDigest": "ff9f085631f753f059c631d874177ddd4fa847c5eca85a420dc85fb2bece6ff6",
       "gitTreeSha": "e35ac3c0c583661983d3fc1352ff3aec74e67e8c",
       "files": [
@@ -94,7 +94,7 @@
     {
       "name": "orca-linear",
       "sourcePath": "skills/orca-linear",
-      "releaseRevision": 4,
+      "releaseRevision": 5,
       "packageDigest": "5e9622bd3883c0f53e6bd349758096deafceebd2fa260d3e90d677e64d06416d",
       "gitTreeSha": "f3727995a4719fd522119eca6d1b57542cb5fe23",
       "files": [

--- a/resources/skills/release-mapping.json
+++ b/resources/skills/release-mapping.json
@@ -561,6 +561,19 @@
         "orca-per-workspace-env": 2,
         "orchestration": 25
       }
+    },
+    {
+      "appVersion": "1.4.149-rc.2",
+      "skills": {
+        "computer-use": 5,
+        "linear-tickets": 6,
+        "orca-cli": 35,
+        "orca-emulator": 4,
+        "orca-emulator-android": 2,
+        "orca-linear": 4,
+        "orca-per-workspace-env": 2,
+        "orchestration": 25
+      }
     }
   ]
 }

--- a/resources/skills/snapshot-registry.json
+++ b/resources/skills/snapshot-registry.json
@@ -1214,6 +1214,22 @@
       },
       {
         "releaseRevision": 6,
+        "packageDigest": "f198d7b22e5ee1673dac403f9cca0553b124e0a90e4fdd05d2c23b7344e32d2b",
+        "gitTreeSha": "de9fc106bbb4e313a90ff9a9513a720909bbd176",
+        "files": [
+          {
+            "path": "SKILL.md",
+            "size": 10596,
+            "executable": false,
+            "classification": "text",
+            "exactSha256": "0c3077c93328b9965430cd6951f1a35889b8c0775037870ea3a8bcf303d9d2c5",
+            "textNormalizedSha256": "0c3077c93328b9965430cd6951f1a35889b8c0775037870ea3a8bcf303d9d2c5",
+            "identitySha256": "0c3077c93328b9965430cd6951f1a35889b8c0775037870ea3a8bcf303d9d2c5"
+          }
+        ]
+      },
+      {
+        "releaseRevision": 7,
         "packageDigest": "ff9f085631f753f059c631d874177ddd4fa847c5eca85a420dc85fb2bece6ff6",
         "gitTreeSha": "e35ac3c0c583661983d3fc1352ff3aec74e67e8c",
         "files": [
@@ -1280,6 +1296,22 @@
       },
       {
         "releaseRevision": 4,
+        "packageDigest": "d44d09e6ecb6a64da177083aad26a95f031cd1cf26ba059fdc888c2628aef64f",
+        "gitTreeSha": "c34f42030f43e5a85737996fa375bbd79cb5bea8",
+        "files": [
+          {
+            "path": "SKILL.md",
+            "size": 10320,
+            "executable": false,
+            "classification": "text",
+            "exactSha256": "48ded55ec3842ce65105e6db7adf9bc9ed263ece08555cec056e68e90321c3d5",
+            "textNormalizedSha256": "48ded55ec3842ce65105e6db7adf9bc9ed263ece08555cec056e68e90321c3d5",
+            "identitySha256": "48ded55ec3842ce65105e6db7adf9bc9ed263ece08555cec056e68e90321c3d5"
+          }
+        ]
+      },
+      {
+        "releaseRevision": 5,
         "packageDigest": "5e9622bd3883c0f53e6bd349758096deafceebd2fa260d3e90d677e64d06416d",
         "gitTreeSha": "f3727995a4719fd522119eca6d1b57542cb5fe23",
         "files": [


### PR DESCRIPTION
## Summary

- record `v1.4.149-rc.2` in the generated skill release mapping
- preserve the tag-owned rollback snapshots as `linear-tickets` revision 6 and `orca-linear` revision 4
- assign the current combined Linear guidance fresh candidate revisions 7 and 5

## Cause

`v1.4.149-rc.2` was published at 20:48 UTC after #9775 passed skill freshness but before it merged at 20:50 UTC. The tag contains older Linear skill bytes, so the generated append-only history changed during the CI-to-merge window.

## Validation

- `pnpm run verify:bundled-skill-guides`
- `pnpm run verify:skill-bundle-manifest`
- `pnpm exec vitest run config/scripts/generate-skill-bundle-manifest.test.mjs` (10 passed, 1 skipped)

Immediately before merging, tags will be fetched again and skill freshness re-run to prevent the same landing race.