### PR TITLE
fix(settings): stop mislabeling a WSL default shell as PowerShell

### DIFF
--- a/src/renderer/src/components/settings/TerminalPane.pwsh.test.ts
+++ b/src/renderer/src/components/settings/TerminalPane.pwsh.test.ts
@@ -362,7 +362,7 @@ describe('TerminalPane PowerShell version setting', () => {
     expect(collectText(element)).not.toContain('WSL')
   })
 
-  it('does not show WSL distro choices for a persisted legacy WSL shell', () => {
+  it('shows a persisted WSL default without PowerShell or distro sub-settings', () => {
     const element = TerminalPane({
       settings: {
         terminalScrollbackRows: 5_000,
@@ -383,6 +383,9 @@ describe('TerminalPane PowerShell version setting', () => {
     const text = collectText(element)
     expect(text).toContain('PowerShell')
     expect(text).toContain('Command Prompt')
+    expect(text).toContain('WSL')
+    expect(hasShellIconFor(element, 'wsl.exe')).toBe(true)
+    expect(text).not.toContain('PowerShell Version')
     expect(text).not.toContain('Choose which WSL distribution')
     expect(text).not.toContain('Windows default')
     expect(text).not.toContain('Ubuntu')

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -56,8 +56,7 @@ export function TerminalPane({
   const isWindows = isWindowsUserAgent()
   const showWindowsHostSettings = isWindowsTerminalHost ?? isWindows
   const isMac = isMacUserAgent()
-  const rawWindowsShell = settings.terminalWindowsShell ?? 'powershell.exe'
-  const windowsShell = rawWindowsShell === 'wsl.exe' ? 'powershell.exe' : rawWindowsShell
+  const windowsShell = settings.terminalWindowsShell ?? 'powershell.exe'
   const showWindowsPowerShellImplementation =
     showWindowsHostSettings && windowsShell === 'powershell.exe'
 

--- a/src/renderer/src/components/settings/TerminalWindowsShellSection.tsx
+++ b/src/renderer/src/components/settings/TerminalWindowsShellSection.tsx
@@ -30,6 +30,10 @@ export function TerminalWindowsShellSection({
   gitBashAvailable
 }: TerminalWindowsShellSectionProps): React.JSX.Element {
   const showGitBashOption = gitBashAvailable || windowsShell === WINDOWS_GIT_BASH_SHELL
+  // Why: WSL can't be *selected* here (it needs a companion distro chosen in
+  // onboarding), but surface it disabled when it's the active default so the
+  // control reflects the real shell instead of mislabeling WSL as PowerShell.
+  const showWslOption = windowsShell === 'wsl.exe'
 
   return (
     <section key="windows-shell" className="space-y-3">
@@ -116,6 +120,22 @@ export function TerminalWindowsShellSection({
                             'Git Bash'
                           ),
                           disabled: !gitBashAvailable
+                        }
+                      ]
+                    : []),
+                  ...(showWslOption
+                    ? [
+                        {
+                          value: 'wsl.exe',
+                          label: windowsShellLabel(
+                            'wsl.exe',
+                            translate('auto.components.settings.TerminalPane.b637dd57a7', 'WSL')
+                          ),
+                          ariaLabel: translate(
+                            'auto.components.settings.TerminalPane.b637dd57a7',
+                            'WSL'
+                          ),
+                          disabled: true
                         }
                       ]
                     : [])

--- a/src/renderer/src/components/settings/TerminalWindowsShellSection.tsx
+++ b/src/renderer/src/components/settings/TerminalWindowsShellSection.tsx
@@ -30,9 +30,7 @@ export function TerminalWindowsShellSection({
   gitBashAvailable
 }: TerminalWindowsShellSectionProps): React.JSX.Element {
   const showGitBashOption = gitBashAvailable || windowsShell === WINDOWS_GIT_BASH_SHELL
-  // Why: WSL can't be *selected* here (it needs a companion distro chosen in
-  // onboarding), but surface it disabled when it's the active default so the
-  // control reflects the real shell instead of mislabeling WSL as PowerShell.
+  // Why: selecting WSL here would omit its required distro, but an existing WSL default must stay visible.
   const showWslOption = windowsShell === 'wsl.exe'
 
   return (


### PR DESCRIPTION
## Problem

On Windows, the **Settings → Terminal → Default Shell** toggle silently misrepresented a WSL default. If a user picked **WSL** during onboarding (`terminalWindowsShell = 'wsl.exe'`), the Settings page:

1. **Showed "PowerShell" selected** — because it coerced `wsl.exe → powershell.exe` for display (`TerminalPane.tsx:60`), and
2. **Surfaced irrelevant PowerShell-version sub-settings** ("PowerShell 7 vs Windows PowerShell"), since the coerced value made `showWindowsPowerShellImplementation` true.

So the setting the user actually chose was invisible here, and the page claimed a shell they weren't using.

## Fix

- **`TerminalPane.tsx`** — remove the `wsl.exe → powershell.exe` coercion. The page now passes the real shell through, which both fixes the mislabel and correctly hides the PowerShell-version options for WSL users.
- **`TerminalWindowsShellSection.tsx`** — surface WSL as a **disabled, already-selected** segment when it's the active default (mirroring the existing Git Bash `disabled` pattern). The segmented control renders a disabled+active option with the selected styling, so the toggle now tells the truth. Users can still switch away to PowerShell/cmd.

Reuses the existing `b637dd57a7: "WSL"` i18n key (already translated in all 5 locales) — no new string.

## Deliberately out of scope

WSL is **not** made selectable from this toggle. Choosing WSL requires a companion distro (`terminalWindowsWslDistro`) that only the onboarding step configures, and WSL was intentionally modeled as a per-project runtime + onboarding concept in #5519. Wiring a full WSL picker (with distro selection) into Settings needs a design pass to reconcile the global-default / project-runtime / onboarding surfaces — tracked separately, not patched here.

## Verification

- `oxlint` clean on both files
- `tsc --noEmit` (web project) passes
- `verify:localization-catalog` passes (key parity across en/es/ja/ko/zh)