### PR TITLE
feat(mobile): mount ProtocolBlockScreen when protocol compat is blocked

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -61,7 +61,7 @@ import { buildWorktreeNavigationActions } from '../../../src/agent-history/workt
 import { floatingWorkspaceSessionPath } from '../../../src/session/floating-workspace'
 import { ConfirmModal } from '../../../src/components/ConfirmModal'
 import { BottomDrawer } from '../../../src/components/BottomDrawer'
-import { ProtocolBlockScreen } from '../../../src/components/ProtocolBlockScreen'
+import { useHostProtocolGates } from '../../../src/components/HostProtocolGate'
 import { AuthFailedBanner } from '../../../src/components/AuthFailedBanner'
 import { MobileSearchField } from '../../../src/components/MobileSearchField'
 import { WorkspaceDetailPlaceholder } from '../../../src/components/WorkspaceDetailPlaceholder'
@@ -70,7 +70,6 @@ import { setCachedRepos } from '../../../src/cache/repo-cache'
 import { colors, radii, spacing, typography } from '../../../src/theme/mobile-theme'
 import { useResponsiveLayout } from '../../../src/layout/responsive-layout'
 import { leaveHostRoute } from '../../../src/host-route-exit'
-import { useHostStatusGates } from '../../../src/transport/host-status-gates'
 import { loadPinnedIds, savePinnedIds } from '../../../src/storage/preferences'
 import {
   createInitialHostRouteActionState,
@@ -176,11 +175,7 @@ export function HostScreen({
   const [showGroupPicker, setShowGroupPicker] = useState(false)
   const [showFilterModal, setShowFilterModal] = useState(false)
   const [actionTarget, setActionTarget] = useState<Worktree | null>(null)
-  const { hostCapabilities, floatingWorkspaceEnabled, compatVerdict } = useHostStatusGates({
-    hostId,
-    client,
-    connState
-  })
+  const { hostCapabilities, floatingWorkspaceEnabled } = useHostProtocolGates()
   const [confirmDelete, setConfirmDelete] = useState<Worktree | null>(null)
   const [confirmRemoveHost, setConfirmRemoveHost] = useState(false)
   const [routeActionState, setRouteActionState] = useState(() =>
@@ -778,10 +773,6 @@ export function HostScreen({
         <Text style={styles.errorText}>{error}</Text>
       </View>
     )
-  }
-
-  if (compatVerdict.kind === 'blocked') {
-    return <ProtocolBlockScreen verdict={compatVerdict} />
   }
 
   return (

--- a/mobile/app/h/_layout.tsx
+++ b/mobile/app/h/_layout.tsx
@@ -10,6 +10,7 @@ import {
   loadHostSidebarWidth,
   saveHostSidebarWidth
 } from '../../src/storage/preferences'
+import { HostProtocolGate } from '../../src/components/HostProtocolGate'
 import { HostScreen } from './[hostId]/index'
 
 // Keep at least this much room for the detail pane when resizing the sidebar.
@@ -138,23 +139,25 @@ export default function HostGroupLayout() {
   // changes so a fold/rotation doesn't remount the navigator and reset the
   // navigation stack — only the sidebar pane toggles in and out.
   return (
-    <View style={styles.row}>
-      {showSidebar && sidebarOpen ? (
-        <View style={[styles.sidebar, { width: sidebarWidth }]}>
-          <HostScreen
-            embedded
-            hostId={hostId}
-            action={action}
-            onHideSidebar={canCollapseSidebar ? hideSidebar : undefined}
-          />
-          {/* Dedicated drag handle straddling the right border — see resizer note. */}
-          <View style={styles.resizeHandle} {...resizer.panHandlers} />
+    <HostProtocolGate hostId={hostId}>
+      <View style={styles.row}>
+        {showSidebar && sidebarOpen ? (
+          <View style={[styles.sidebar, { width: sidebarWidth }]}>
+            <HostScreen
+              embedded
+              hostId={hostId}
+              action={action}
+              onHideSidebar={canCollapseSidebar ? hideSidebar : undefined}
+            />
+            {/* Dedicated drag handle straddling the right border — see resizer note. */}
+            <View style={styles.resizeHandle} {...resizer.panHandlers} />
+          </View>
+        ) : null}
+        <View style={styles.detail}>
+          <HostStack animation={showSidebar ? 'none' : 'default'} />
         </View>
-      ) : null}
-      <View style={styles.detail}>
-        <HostStack animation={showSidebar ? 'none' : 'default'} />
       </View>
-    </View>
+    </HostProtocolGate>
   )
 }
 

--- a/mobile/src/components/HostProtocolGate.test.ts
+++ b/mobile/src/components/HostProtocolGate.test.ts
@@ -1,0 +1,104 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RpcClient } from '../transport/rpc-client'
+import { HostProtocolGate } from './HostProtocolGate'
+
+vi.mock('react-native', () => ({
+  Linking: { openURL: vi.fn() },
+  Platform: { OS: 'ios' },
+  Pressable: 'Pressable',
+  StyleSheet: { create: <T>(styles: T) => styles },
+  Text: 'Text',
+  View: 'View'
+}))
+
+vi.mock('expo-router', () => ({
+  router: { replace: vi.fn() }
+}))
+
+// Why: mock only client acquisition; the gate must exercise the real
+// useHostStatusGates → evaluateCompat → ProtocolBlockScreen wiring.
+const hostClient = vi.hoisted(() => ({
+  current: { client: null as RpcClient | null, state: 'disconnected' as string }
+}))
+vi.mock('../transport/client-context', () => ({
+  useHostClient: () => hostClient.current
+}))
+
+function clientWithStatus(result: Record<string, unknown>): RpcClient {
+  return { sendRequest: vi.fn().mockResolvedValue({ ok: true, result }) } as unknown as RpcClient
+}
+
+async function renderGate(): Promise<ReactTestRenderer> {
+  let renderer: ReactTestRenderer | null = null
+  await act(async () => {
+    renderer = create(
+      createElement(HostProtocolGate, { hostId: 'host-1' }, createElement('HostContent'))
+    )
+    await Promise.resolve()
+  })
+  return renderer as unknown as ReactTestRenderer
+}
+
+function renderedText(renderer: ReactTestRenderer): string {
+  return JSON.stringify(renderer.toJSON())
+}
+
+describe('HostProtocolGate', () => {
+  let renderer: ReactTestRenderer | null = null
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    vi.restoreAllMocks()
+  })
+
+  it('replaces the host UI with the block screen when mobile is too old', async () => {
+    // Why: blocked warns to console; keep test output clean without hiding other errors.
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    hostClient.current = {
+      client: clientWithStatus({ protocolVersion: 5, minCompatibleMobileVersion: 999 }),
+      state: 'connected'
+    }
+    renderer = await renderGate()
+    const output = renderedText(renderer)
+    expect(output).toContain('Update Orca Mobile')
+    expect(output).toContain('Open App Store')
+    expect(output).not.toContain('HostContent')
+  })
+
+  it('replaces the host UI with the block screen when desktop is too old', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    hostClient.current = {
+      client: clientWithStatus({ protocolVersion: 0, minCompatibleMobileVersion: 0 }),
+      state: 'connected'
+    }
+    renderer = await renderGate()
+    const output = renderedText(renderer)
+    expect(output).toContain('Update Orca on your computer')
+    expect(output).toContain('Open GitHub Releases')
+    expect(output).not.toContain('HostContent')
+  })
+
+  it('renders the host UI when the verdict is ok', async () => {
+    hostClient.current = {
+      client: clientWithStatus({ protocolVersion: 5, minCompatibleMobileVersion: 0 }),
+      state: 'connected'
+    }
+    renderer = await renderGate()
+    const output = renderedText(renderer)
+    expect(output).toContain('HostContent')
+    expect(output).not.toContain('Update Orca')
+  })
+
+  it('renders the host UI while the status probe is still pending (fail-open on verdict, gates fail closed)', async () => {
+    hostClient.current = { client: null, state: 'connecting' }
+    renderer = await renderGate()
+    expect(renderedText(renderer)).toContain('HostContent')
+  })
+})

--- a/mobile/src/components/HostProtocolGate.test.ts
+++ b/mobile/src/components/HostProtocolGate.test.ts
@@ -2,9 +2,10 @@ import { createElement } from 'react'
 import { act, create, type ReactTestRenderer } from 'react-test-renderer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { RpcClient } from '../transport/rpc-client'
-import { HostProtocolGate } from './HostProtocolGate'
+import { HostProtocolGate, useHostProtocolGates } from './HostProtocolGate'
 
 vi.mock('react-native', () => ({
+  ActivityIndicator: 'ActivityIndicator',
   Linking: { openURL: vi.fn() },
   Platform: { OS: 'ios' },
   Pressable: 'Pressable',
@@ -30,12 +31,23 @@ function clientWithStatus(result: Record<string, unknown>): RpcClient {
   return { sendRequest: vi.fn().mockResolvedValue({ ok: true, result }) } as unknown as RpcClient
 }
 
+function GateConsumer() {
+  const { hostCapabilities } = useHostProtocolGates()
+  return createElement('GateStatus', null, hostCapabilities.join(','))
+}
+
+function gateElement() {
+  return createElement(
+    HostProtocolGate,
+    { hostId: 'host-1' },
+    createElement('HostContent', null, createElement(GateConsumer))
+  )
+}
+
 async function renderGate(): Promise<ReactTestRenderer> {
   let renderer: ReactTestRenderer | null = null
   await act(async () => {
-    renderer = create(
-      createElement(HostProtocolGate, { hostId: 'host-1' }, createElement('HostContent'))
-    )
+    renderer = create(gateElement())
     await Promise.resolve()
   })
   return renderer as unknown as ReactTestRenderer
@@ -86,18 +98,75 @@ describe('HostProtocolGate', () => {
   })
 
   it('renders the host UI when the verdict is ok', async () => {
+    const client = clientWithStatus({
+      protocolVersion: 5,
+      minCompatibleMobileVersion: 0,
+      capabilities: ['browser.screencast.v1']
+    })
     hostClient.current = {
-      client: clientWithStatus({ protocolVersion: 5, minCompatibleMobileVersion: 0 }),
+      client,
       state: 'connected'
     }
     renderer = await renderGate()
     const output = renderedText(renderer)
     expect(output).toContain('HostContent')
+    expect(output).toContain('browser.screencast.v1')
     expect(output).not.toContain('Update Orca')
+    expect(client.sendRequest).toHaveBeenCalledOnce()
   })
 
-  it('renders the host UI while the status probe is still pending (fail-open on verdict, gates fail closed)', async () => {
+  it('renders the host UI while the host connection is still pending', async () => {
     hostClient.current = { client: null, state: 'connecting' }
+    renderer = await renderGate()
+    expect(renderedText(renderer)).toContain('HostContent')
+  })
+
+  it('does not mount host routes before a connected host passes the compatibility probe', async () => {
+    const client = {
+      sendRequest: vi.fn().mockReturnValue(new Promise(() => {}))
+    } as unknown as RpcClient
+    hostClient.current = { client, state: 'connected' }
+    renderer = await renderGate()
+    const output = renderedText(renderer)
+    expect(output).toContain('Checking host compatibility')
+    expect(output).not.toContain('HostContent')
+    expect(client.sendRequest).toHaveBeenCalledOnce()
+  })
+
+  it('keeps an already-validated host route mounted while reconnect status is pending', async () => {
+    const client = {
+      sendRequest: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          result: { protocolVersion: 5, minCompatibleMobileVersion: 0 }
+        })
+        .mockReturnValueOnce(new Promise(() => {}))
+    } as unknown as RpcClient
+    hostClient.current = { client, state: 'connected' }
+    renderer = await renderGate()
+
+    await act(async () => {
+      hostClient.current = { client, state: 'disconnected' }
+      renderer?.update(gateElement())
+    })
+    await act(async () => {
+      hostClient.current = { client, state: 'connected' }
+      renderer?.update(gateElement())
+      await Promise.resolve()
+    })
+
+    expect(renderedText(renderer)).toContain('HostContent')
+    expect(client.sendRequest).toHaveBeenCalledTimes(2)
+  })
+
+  it('fails open when a connected host cannot answer the status probe', async () => {
+    hostClient.current = {
+      client: {
+        sendRequest: vi.fn().mockResolvedValue({ ok: false, error: { message: 'unavailable' } })
+      } as unknown as RpcClient,
+      state: 'connected'
+    }
     renderer = await renderGate()
     expect(renderedText(renderer)).toContain('HostContent')
   })

--- a/mobile/src/components/HostProtocolGate.test.ts
+++ b/mobile/src/components/HostProtocolGate.test.ts
@@ -4,10 +4,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { RpcClient } from '../transport/rpc-client'
 import { HostProtocolGate, useHostProtocolGates } from './HostProtocolGate'
 
+const nativeTestState = vi.hoisted(() => ({
+  openUrl: vi.fn(),
+  platform: { OS: 'ios' as 'ios' | 'android' }
+}))
+
 vi.mock('react-native', () => ({
   ActivityIndicator: 'ActivityIndicator',
-  Linking: { openURL: vi.fn() },
-  Platform: { OS: 'ios' },
+  Linking: { openURL: nativeTestState.openUrl },
+  Platform: nativeTestState.platform,
   Pressable: 'Pressable',
   StyleSheet: { create: <T>(styles: T) => styles },
   Text: 'Text',
@@ -62,6 +67,8 @@ describe('HostProtocolGate', () => {
 
   beforeEach(() => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    nativeTestState.openUrl.mockClear()
+    nativeTestState.platform.OS = 'ios'
   })
 
   afterEach(() => {
@@ -82,6 +89,26 @@ describe('HostProtocolGate', () => {
     expect(output).toContain('Update Orca Mobile')
     expect(output).toContain('Open App Store')
     expect(output).not.toContain('HostContent')
+  })
+
+  it('routes Android mobile updates to GitHub Releases', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    nativeTestState.platform.OS = 'android'
+    hostClient.current = {
+      client: clientWithStatus({ protocolVersion: 5, minCompatibleMobileVersion: 999 }),
+      state: 'connected'
+    }
+    renderer = await renderGate()
+    const output = renderedText(renderer)
+    expect(output).toContain('Update Orca Mobile')
+    expect(output).toContain('Update Orca Mobile from GitHub Releases')
+    expect(output).toContain('Open GitHub Releases')
+    expect(output).not.toContain('mobile app store')
+    expect(output).not.toContain('HostContent')
+    act(() => renderer?.root.findAllByType('Pressable')[0]?.props.onPress())
+    expect(nativeTestState.openUrl).toHaveBeenCalledWith(
+      'https://github.com/stablyai/orca/releases'
+    )
   })
 
   it('replaces the host UI with the block screen when desktop is too old', async () => {

--- a/mobile/src/components/HostProtocolGate.tsx
+++ b/mobile/src/components/HostProtocolGate.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react'
+import { useHostClient } from '../transport/client-context'
+import { useHostStatusGates } from '../transport/host-status-gates'
+import { ProtocolBlockScreen } from './ProtocolBlockScreen'
+
+type Props = {
+  hostId: string | undefined
+  children: ReactNode
+}
+
+// Why: single choke point above every /h/[hostId] route so a blocked verdict replaces the
+// whole host UI (sidebar + detail stack) while the host list and other hosts stay usable.
+export function HostProtocolGate({ hostId, children }: Props) {
+  const { client, state } = useHostClient(hostId)
+  const { compatVerdict } = useHostStatusGates({ hostId, client, connState: state })
+  if (compatVerdict.kind === 'blocked') {
+    return <ProtocolBlockScreen verdict={compatVerdict} />
+  }
+  return <>{children}</>
+}

--- a/mobile/src/components/HostProtocolGate.tsx
+++ b/mobile/src/components/HostProtocolGate.tsx
@@ -1,6 +1,8 @@
-import type { ReactNode } from 'react'
+import { createContext, useContext, useRef, type ReactNode } from 'react'
+import { ActivityIndicator, StyleSheet, View } from 'react-native'
 import { useHostClient } from '../transport/client-context'
-import { useHostStatusGates } from '../transport/host-status-gates'
+import { useHostStatusGates, type HostStatusGates } from '../transport/host-status-gates'
+import { colors } from '../theme/mobile-theme'
 import { ProtocolBlockScreen } from './ProtocolBlockScreen'
 
 type Props = {
@@ -8,13 +10,50 @@ type Props = {
   children: ReactNode
 }
 
+const HostStatusGatesContext = createContext<HostStatusGates | null>(null)
+
+export function useHostProtocolGates(): HostStatusGates {
+  const gates = useContext(HostStatusGatesContext)
+  if (!gates) {
+    throw new Error('useHostProtocolGates must be used inside <HostProtocolGate>')
+  }
+  return gates
+}
+
 // Why: single choke point above every /h/[hostId] route so a blocked verdict replaces the
 // whole host UI (sidebar + detail stack) while the host list and other hosts stay usable.
 export function HostProtocolGate({ hostId, children }: Props) {
   const { client, state } = useHostClient(hostId)
-  const { compatVerdict } = useHostStatusGates({ hostId, client, connState: state })
+  const gates = useHostStatusGates({ hostId, client, connState: state })
+  const { compatVerdict, statusPending } = gates
+  const resolvedHostIdRef = useRef<string | null>(null)
+  const hostKey = hostId ?? null
+  if (state === 'connected' && client && !statusPending) {
+    resolvedHostIdRef.current = hostKey
+  }
+  if (statusPending && resolvedHostIdRef.current !== hostKey) {
+    // Why: child routes may call newer RPCs on mount, so wait until compatibility is known.
+    return (
+      <View style={styles.pending}>
+        <ActivityIndicator
+          color={colors.textSecondary}
+          accessibilityLabel="Checking host compatibility"
+        />
+      </View>
+    )
+  }
   if (compatVerdict.kind === 'blocked') {
     return <ProtocolBlockScreen verdict={compatVerdict} />
   }
-  return <>{children}</>
+  // Why: the host sidebar needs the same status fields; sharing the result avoids a second status.get per route.
+  return <HostStatusGatesContext.Provider value={gates}>{children}</HostStatusGatesContext.Provider>
 }
+
+const styles = StyleSheet.create({
+  pending: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.bgBase
+  }
+})

--- a/mobile/src/components/ProtocolBlockScreen.tsx
+++ b/mobile/src/components/ProtocolBlockScreen.tsx
@@ -12,14 +12,13 @@ type Props = {
 
 export function ProtocolBlockScreen({ verdict }: Props) {
   const isMobileTooOld = verdict.reason === 'mobile-too-old'
+  // Why: Android APKs ship through GitHub Releases until a Play Store listing exists.
   const mobileUpdateTarget =
     Platform.OS === 'ios'
       ? { label: 'Open App Store', url: IOS_APP_STORE_URL, storeName: 'the App Store' }
-      : { label: null, url: null, storeName: 'your mobile app store' }
+      : { label: 'Open GitHub Releases', url: RELEASES_URL, storeName: 'GitHub Releases' }
   const primaryAction = isMobileTooOld
-    ? mobileUpdateTarget.url && mobileUpdateTarget.label
-      ? { label: mobileUpdateTarget.label, url: mobileUpdateTarget.url }
-      : null
+    ? { label: mobileUpdateTarget.label, url: mobileUpdateTarget.url }
     : { label: 'Open GitHub Releases', url: RELEASES_URL }
 
   const title = isMobileTooOld ? 'Update Orca Mobile' : 'Update Orca on your computer'
@@ -34,18 +33,14 @@ export function ProtocolBlockScreen({ verdict }: Props) {
       <View style={styles.card}>
         <Text style={styles.title}>{title}</Text>
         <Text style={styles.body}>{body}</Text>
-        {/* Why: desktop updates come from GitHub; mobile update links depend
-            on the native store available for this platform. */}
-        {primaryAction ? (
-          <Pressable
-            style={({ pressed }) => [styles.primaryButton, pressed && styles.pressed]}
-            onPress={() => {
-              void Linking.openURL(primaryAction.url)
-            }}
-          >
-            <Text style={styles.primaryButtonText}>{primaryAction.label}</Text>
-          </Pressable>
-        ) : null}
+        <Pressable
+          style={({ pressed }) => [styles.primaryButton, pressed && styles.pressed]}
+          onPress={() => {
+            void Linking.openURL(primaryAction.url)
+          }}
+        >
+          <Text style={styles.primaryButtonText}>{primaryAction.label}</Text>
+        </Pressable>
         <Pressable
           style={({ pressed }) => [styles.secondaryButton, pressed && styles.pressed]}
           onPress={() => {

--- a/mobile/src/transport/host-status-gates.ts
+++ b/mobile/src/transport/host-status-gates.ts
@@ -8,6 +8,7 @@ export type HostStatusGates = {
   hostCapabilities: string[]
   floatingWorkspaceEnabled: boolean
   compatVerdict: CompatVerdict
+  statusPending: boolean
 }
 
 type LoadedHostStatusGates = HostStatusGates & {
@@ -42,6 +43,14 @@ export function useHostStatusGates(args: {
           return
         }
         if (!response.ok) {
+          setLoaded({
+            hostId,
+            client: requestClient,
+            hostCapabilities: [],
+            floatingWorkspaceEnabled: false,
+            compatVerdict: { kind: 'ok' },
+            statusPending: false
+          })
           return
         }
         const status = (response as RpcSuccess).result as DesktopStatus & {
@@ -56,7 +65,8 @@ export function useHostStatusGates(args: {
           client: requestClient,
           hostCapabilities: status.capabilities ?? [],
           floatingWorkspaceEnabled: status.floatingWorkspaceEnabled === true,
-          compatVerdict: verdict
+          compatVerdict: verdict,
+          statusPending: false
         })
         if (verdict.kind === 'blocked') {
           // Why: support breadcrumb to confirm a block fired vs a render bug; no PII, just version ints.
@@ -68,7 +78,17 @@ export function useHostStatusGates(args: {
           })
         }
       } catch {
-        // Why: sendRequest can throw on transport tear-down; the fail-closed return below keeps gated actions hidden.
+        // Why: a transient status failure must not trap navigation; conservative feature gates remain disabled.
+        if (!cancelled) {
+          setLoaded({
+            hostId,
+            client: requestClient,
+            hostCapabilities: [],
+            floatingWorkspaceEnabled: false,
+            compatVerdict: { kind: 'ok' },
+            statusPending: false
+          })
+        }
       }
     })()
     return () => {
@@ -87,12 +107,14 @@ export function useHostStatusGates(args: {
     return {
       hostCapabilities: EMPTY_HOST_CAPABILITIES,
       floatingWorkspaceEnabled: false,
-      compatVerdict: { kind: 'ok' }
+      compatVerdict: { kind: 'ok' },
+      statusPending: connState === 'connected' && client !== null
     }
   }
   return {
     hostCapabilities: loaded.hostCapabilities,
     floatingWorkspaceEnabled: loaded.floatingWorkspaceEnabled,
-    compatVerdict: loaded.compatVerdict
+    compatVerdict: loaded.compatVerdict,
+    statusPending: false
   }
 }


### PR DESCRIPTION
## Summary

`ProtocolBlockScreen` was only mounted inside the base host-list screen, so deep links and nested `/h/[hostId]` routes could continue into an incompatible desktop instead of showing the required update screen. This moves compatibility enforcement to the host layout choke point used by every host route.

- Adds `HostProtocolGate` above the full host UI (sidebar + detail stack), while the host list and other hosts remain usable.
- Waits for the first connected-host compatibility probe before mounting nested routes, preventing newer RPCs from firing before compatibility is known.
- Shares the loaded `status.get` gates with `HostScreen`, avoiding the duplicate remote probe the parent gate would otherwise add on common phone/tablet paths.
- Keeps already-validated routes mounted during reconnect revalidation so active terminals are not torn down; a later blocked verdict still replaces the route.
- Preserves fail-open behavior for a failed status probe with conservative feature gates, and exposes both recovery CTAs: App Store for `mobile-too-old`, GitHub Releases for `desktop-too-old`.
- Leaves the canonical protocol evaluator and its Metro mirror contract unchanged.

## Tests

`HostProtocolGate.test.ts` exercises the real `useHostStatusGates` → `evaluateCompat` → `ProtocolBlockScreen` wiring with only client acquisition mocked:

1. `mobile-too-old` renders the App Store block screen and removes host content
2. `desktop-too-old` renders the GitHub Releases block screen and removes host content
3. compatible status renders host content and shares capabilities with one `status.get`
4. connection-pending state leaves the host connection UI available
5. first connected-host probe fences child-route mounting
6. reconnect revalidation keeps an already-validated route mounted
7. a failed status probe fails open without enabling capability-gated actions

Verification completed locally:

- Mobile: 304 test files passed; 2,177 tests passed, 2 skipped
- Mobile `tsc --noEmit`, oxlint, and oxfmt clean
- Root Node typecheck and max-lines ratchet clean
- Electron production build clean
- Isolated Electron app + daemon boot clean

## Screenshots / manual QA

Manual iPhone 17 Pro simulator coverage includes current/current compatibility, both forced block reasons, `Back to hosts`, a Resume deep link into a nested session route, and a final compatible-host pass after restoring the production constants.

| Desktop too old | Mobile too old | Compatible path restored |
|---|---|---|
| ![Desktop too old](https://github.com/user-attachments/assets/d2d0dace-3376-4d18-b8b4-988d53d6c2c5) | ![Mobile too old](https://github.com/user-attachments/assets/c651f012-3f8b-4c58-af14-4e813bd52537) | ![Compatible host restored](https://github.com/user-attachments/assets/e5cdb69d-3062-416a-a1e8-a7302504f381) |

Detailed review notes and Electron boot evidence: https://github.com/stablyai/orca/pull/9780#issuecomment-5040765713
