### PR TITLE
Remove host-blind lookups in SSH snapshot scoping, runtime events, and setup resolution

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
@@ -523,4 +523,41 @@ describe('NewWorkspaceComposerCard folder task source mode', () => {
     expect(hostChanges).toEqual(['setup-builder'])
     expect(recipeChanges).toEqual([null])
   })
+
+  it('distinguishes legacy setup ids that collide across hosts', () => {
+    const hostChanges: [string, string][] = []
+    current = renderCard({
+      projectHostSetupOptions: [
+        {
+          kind: 'ready',
+          id: 'same-repo',
+          hostId: 'runtime:env-1',
+          label: 'Builder One',
+          path: '/workspace/one'
+        },
+        {
+          kind: 'ready',
+          id: 'same-repo',
+          hostId: 'runtime:env-2',
+          label: 'Builder Two',
+          path: '/workspace/two'
+        }
+      ] as never,
+      selectedProjectHostSetupId: 'same-repo',
+      selectedProjectHostId: 'runtime:env-2',
+      onProjectHostSetupChange: (setupId, hostId) => hostChanges.push([setupId, hostId])
+    })
+
+    const runTargetButton =
+      current.container.querySelector<HTMLButtonElement>('button[role="combobox"]')
+    expect(runTargetButton?.textContent).toContain('Builder Two')
+    act(() => runTargetButton?.click())
+
+    const builderOneItem = [...document.body.querySelectorAll<HTMLElement>('[cmdk-item]')].find(
+      (item) => item.textContent?.includes('Builder One')
+    )
+    act(() => builderOneItem?.click())
+
+    expect(hostChanges).toEqual([['same-repo', 'runtime:env-1']])
+  })
 })

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -61,6 +61,7 @@ import type {
 import type { WorkspaceCreateErrorDisplay } from '@/lib/workspace-create-error-format'
 import type { SshConnectionStatus } from '../../../shared/ssh-types'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
+import type { ExecutionHostId } from '../../../shared/execution-host'
 import { translate } from '@/i18n/i18n'
 
 type RepoOption = React.ComponentProps<typeof RepoCombobox>['repos'][number]
@@ -86,7 +87,8 @@ type NewWorkspaceComposerCardProps = {
   onProjectChange: (value: string) => void
   projectHostSetupOptions?: ProjectHostSetupOption[]
   selectedProjectHostSetupId?: string | null
-  onProjectHostSetupChange?: (setupId: string) => void
+  selectedProjectHostId?: ExecutionHostId | null
+  onProjectHostSetupChange?: (setupId: string, hostId: ExecutionHostId) => void
   ephemeralVmRecipes?: EphemeralVmRecipeOption[]
   selectedEphemeralVmRecipeId?: string | null
   onEphemeralVmRecipeChange?: (recipeId: string | null) => void
@@ -225,10 +227,15 @@ function getRecipeDestroyLabel(recipe: EphemeralVmRecipeOption): string {
 type WorkspaceRunTargetComboboxProps = {
   hostOptions: readonly ReadyProjectHostSetupOption[]
   hostValue: string | null
-  onHostChange?: (setupId: string) => void
+  hostId: ExecutionHostId | null
+  onHostChange?: (setupId: string, hostId: ExecutionHostId) => void
   recipes: EphemeralVmRecipeOption[]
   recipeValue: string | null
   onRecipeChange?: (recipeId: string | null) => void
+}
+
+function getHostOptionValue(option: ReadyProjectHostSetupOption): string {
+  return JSON.stringify([option.hostId, option.id])
 }
 
 type HostPathTooltipPosition = {
@@ -314,6 +321,7 @@ function HostPathTooltip({ path }: { path: string }): React.JSX.Element {
 function WorkspaceRunTargetCombobox({
   hostOptions,
   hostValue,
+  hostId,
   onHostChange,
   recipes,
   recipeValue,
@@ -322,12 +330,16 @@ function WorkspaceRunTargetCombobox({
   const [open, setOpen] = React.useState(false)
   const [vmRecipesOpen, setVmRecipesOpen] = React.useState(false)
   const selectedHost =
-    hostOptions.find((option) => option.id === hostValue) ?? hostOptions[0] ?? null
+    hostOptions.find(
+      (option) => option.id === hostValue && (hostId === null || option.hostId === hostId)
+    ) ??
+    hostOptions[0] ??
+    null
   const selectedRecipe = recipes.find((recipe) => recipe.id === recipeValue) ?? null
   const selectedValue = selectedRecipe
     ? `recipe:${selectedRecipe.id}`
     : selectedHost
-      ? `host:${selectedHost.id}`
+      ? `host:${getHostOptionValue(selectedHost)}`
       : ''
   const ephemeralVmLabel = translate(
     'auto.components.NewWorkspaceComposerCard.ephemeralVm',
@@ -335,11 +347,12 @@ function WorkspaceRunTargetCombobox({
   )
 
   const handleHostSelect = React.useCallback(
-    (setupId: string): void => {
-      if (!hostOptions.some((candidate) => candidate.id === setupId)) {
+    (optionValue: string): void => {
+      const option = hostOptions.find((candidate) => getHostOptionValue(candidate) === optionValue)
+      if (!option) {
         return
       }
-      onHostChange?.(setupId)
+      onHostChange?.(option.id, option.hostId)
       onRecipeChange?.(null)
       setOpen(false)
     },
@@ -405,9 +418,9 @@ function WorkspaceRunTargetCombobox({
             </CommandEmpty>
             {hostOptions.map((option) => (
               <CommandItem
-                key={option.id}
-                value={`host:${option.id}`}
-                onSelect={() => handleHostSelect(option.id)}
+                key={getHostOptionValue(option)}
+                value={`host:${getHostOptionValue(option)}`}
+                onSelect={() => handleHostSelect(getHostOptionValue(option))}
                 className="items-center gap-2 px-3 py-2"
               >
                 <Check
@@ -621,6 +634,7 @@ export default function NewWorkspaceComposerCard({
   onProjectChange,
   projectHostSetupOptions = EMPTY_PROJECT_HOST_SETUP_OPTIONS,
   selectedProjectHostSetupId = null,
+  selectedProjectHostId = null,
   onProjectHostSetupChange,
   ephemeralVmRecipes = EMPTY_EPHEMERAL_VM_RECIPES,
   selectedEphemeralVmRecipeId = null,
@@ -839,8 +853,8 @@ export default function NewWorkspaceComposerCard({
     [projectHostSetupOptions]
   )
   const handleProjectHostSetupChange = React.useCallback(
-    (setupId: string): void => {
-      onProjectHostSetupChange?.(setupId)
+    (setupId: string, hostId: ExecutionHostId): void => {
+      onProjectHostSetupChange?.(setupId, hostId)
     },
     [onProjectHostSetupChange]
   )
@@ -933,6 +947,7 @@ export default function NewWorkspaceComposerCard({
               <WorkspaceRunTargetCombobox
                 hostOptions={readyProjectHostSetupOptions}
                 hostValue={selectedProjectHostSetupId ?? null}
+                hostId={selectedProjectHostId}
                 onHostChange={handleProjectHostSetupChange}
                 recipes={ephemeralVmRecipes}
                 recipeValue={selectedEphemeralVmRecipeId}

--- a/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
+++ b/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
@@ -272,6 +272,25 @@ describe('useComposerState host-context boundaries', () => {
     expect(section).toContain('projectHostSetupId: initialRunSeed.projectHostSetupId')
   })
 
+  it('keeps the selected setup host after reducing composer state to a repo id', () => {
+    const targetSection = sourceBetween(
+      HOOK_SOURCE,
+      'const selectedWorkspaceTarget = useMemo',
+      'const selectedRepoIsGit'
+    )
+    expect(targetSection).toContain('selectedWorkspaceTargetIdentity?.repoId === repoId')
+    expect(targetSection).toContain('hostId: pinnedTarget?.hostId')
+    expect(targetSection).toContain('projectHostSetupId: pinnedTarget?.projectHostSetupId')
+
+    const changeSection = sourceBetween(
+      HOOK_SOURCE,
+      'const handleProjectHostSetupChange = useCallback',
+      'const handleProjectChange = useCallback'
+    )
+    expect(changeSection).toContain('candidate.id === setupId && candidate.hostId === hostId')
+    expect(changeSection).toContain('workspaceTargetIdentity:')
+  })
+
   it('resolves typed GitHub issue/PR input through the selected repo source context', () => {
     expect(HOOK_SOURCE).toContain('const selectedRepoGitHubSourceContext = useMemo')
 
@@ -444,9 +463,8 @@ describe('useComposerState host-context boundaries', () => {
       'const handleProjectChange = useCallback',
       'const handleSmartGitHubItemSelect'
     )
-    expect(handleProjectChange).toContain(
-      'handleRepoChange(nextRepoId, { forceResetStartFrom: isProjectGroupTarget })'
-    )
+    expect(handleProjectChange).toContain('handleRepoChange(nextTarget.target.repoId, {')
+    expect(handleProjectChange).toContain('forceResetStartFrom: isProjectGroupTarget')
   })
 
   it('keeps a Linear branch override when its workspace-scoped issue survives a repo change', () => {

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -113,8 +113,8 @@ import {
   resolveComposerActiveRepoId
 } from '@/lib/new-workspace-composer-repo'
 import {
-  resolveWorkspaceCreationRepoId,
-  resolveWorkspaceCreationTarget
+  resolveWorkspaceCreationTarget,
+  type WorkspaceCreationTarget
 } from '@/lib/project-host-workspace-target'
 import {
   buildProjectHostSetupOptions,
@@ -243,7 +243,8 @@ export type ComposerCardProps = {
   onProjectChange: (value: string) => void
   projectHostSetupOptions: ProjectHostSetupOption[]
   selectedProjectHostSetupId: string | null
-  onProjectHostSetupChange: (setupId: string) => void
+  selectedProjectHostId: ExecutionHostId | null
+  onProjectHostSetupChange: (setupId: string, hostId: ExecutionHostId) => void
   ephemeralVmRecipes: NonNullable<OrcaHooks['environmentRecipes']>
   selectedEphemeralVmRecipeId: string | null
   onEphemeralVmRecipeChange: (recipeId: string | null) => void
@@ -380,6 +381,16 @@ export type InitialWorkspaceRunSeedInput = {
     TaskSourceContext,
     'projectId' | 'hostId' | 'projectHostSetupId'
   > | null
+}
+
+type WorkspaceTargetIdentity = Pick<
+  WorkspaceCreationTarget,
+  'projectId' | 'hostId' | 'projectHostSetupId' | 'repoId'
+>
+
+function getWorkspaceTargetIdentity(target: WorkspaceCreationTarget): WorkspaceTargetIdentity {
+  const { projectId, hostId, projectHostSetupId, repoId } = target
+  return { projectId, hostId, projectHostSetupId, repoId }
 }
 
 function getRepoSetupAgentStartupPolicy(repo?: {
@@ -613,7 +624,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     [initialWorkspaceStatus, workspaceStatuses]
   )
 
-  const resolvedInitialRepoId = resolveWorkspaceCreationRepoId({
+  const resolvedInitialWorkspaceTarget = resolveWorkspaceCreationTarget({
     eligibleRepos,
     projects,
     projectHostSetups,
@@ -625,8 +636,18 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     projectHostSetupId: initialRunSeed.projectHostSetupId,
     focusedHostScope: workspaceHostScope
   })
+  const resolvedInitialRepoId =
+    resolvedInitialWorkspaceTarget.status === 'ready'
+      ? resolvedInitialWorkspaceTarget.target.repoId
+      : ''
 
   const [internalRepoId, setInternalRepoId] = useState<string>(resolvedInitialRepoId)
+  const [selectedWorkspaceTargetIdentity, setSelectedWorkspaceTargetIdentity] =
+    useState<WorkspaceTargetIdentity | null>(() =>
+      resolvedInitialWorkspaceTarget.status === 'ready'
+        ? getWorkspaceTargetIdentity(resolvedInitialWorkspaceTarget.target)
+        : null
+    )
   const initialFolderProjectGroupId = initialProjectGroupId ?? draftProjectGroupId
   const initialFolderProjectGroup = projectGroups.find(
     (group) => group.id === initialFolderProjectGroupId && Boolean(group.parentPath?.trim())
@@ -708,18 +729,31 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     () => (folderDetectedIds ? new Set(folderDetectedIds) : null),
     [folderDetectedIds]
   )
-  const selectedWorkspaceTarget = useMemo(
-    () =>
-      resolveWorkspaceCreationTarget({
-        eligibleRepos,
-        projects,
-        projectHostSetups,
-        draftRepoId: repoId,
-        focusedHostScope: workspaceHostScope
-      }),
-    [eligibleRepos, projectHostSetups, projects, repoId, workspaceHostScope]
-  )
-  const selectedRepo = eligibleRepos.find((repo) => repo.id === repoId)
+  const selectedWorkspaceTarget = useMemo(() => {
+    const pinnedTarget =
+      selectedWorkspaceTargetIdentity?.repoId === repoId ? selectedWorkspaceTargetIdentity : null
+    return resolveWorkspaceCreationTarget({
+      eligibleRepos,
+      projects,
+      projectHostSetups,
+      draftRepoId: repoId,
+      projectId: pinnedTarget?.projectId,
+      hostId: pinnedTarget?.hostId,
+      projectHostSetupId: pinnedTarget?.projectHostSetupId,
+      focusedHostScope: workspaceHostScope
+    })
+  }, [
+    eligibleRepos,
+    projectHostSetups,
+    projects,
+    repoId,
+    selectedWorkspaceTargetIdentity,
+    workspaceHostScope
+  ])
+  const selectedRepo =
+    selectedWorkspaceTarget.status === 'ready'
+      ? selectedWorkspaceTarget.target.repo
+      : eligibleRepos.find((repo) => repo.id === repoId)
   const selectedRepoIsGit = selectedRepo ? isGitRepoKind(selectedRepo) : false
   const [ephemeralVmRecipes, setEphemeralVmRecipes] = useState<
     NonNullable<OrcaHooks['environmentRecipes']>
@@ -763,6 +797,10 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   const selectedProjectHostSetupId =
     !selectedProjectGroup && selectedWorkspaceTarget.status === 'ready'
       ? selectedWorkspaceTarget.target.projectHostSetupId
+      : null
+  const selectedProjectHostId =
+    !selectedProjectGroup && selectedWorkspaceTarget.status === 'ready'
+      ? selectedWorkspaceTarget.target.hostId
       : null
   const hostOptions = useMemo(
     () =>
@@ -891,6 +929,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   repoIdRef.current = repoId
   const setRepoId = useCallback(
     (value: string) => {
+      setSelectedWorkspaceTargetIdentity(null)
       if (onRepoIdOverrideChange) {
         onRepoIdOverrideChange(value)
       } else {
@@ -2498,11 +2537,16 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   const handleRepoChange = useCallback(
     (
       value: string,
-      options: { preserveStartFrom?: boolean; forceResetStartFrom?: boolean } = {}
+      options: {
+        preserveStartFrom?: boolean
+        forceResetStartFrom?: boolean
+        workspaceTargetIdentity?: WorkspaceTargetIdentity
+      } = {}
     ): void => {
       setProjectError(null)
       if (value === repoId && !options.forceResetStartFrom) {
         setRepoId(value)
+        setSelectedWorkspaceTargetIdentity(options.workspaceTargetIdentity ?? null)
         return
       }
       // Why: capture a descriptor of the prior Start-from selection so the field can show an inline reset (e.g. "was PR #8778") after it's wiped.
@@ -2522,6 +2566,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         ? getLinearLinkedWorkItemBranchName(linkedWorkItem)
         : undefined
       setRepoId(value)
+      setSelectedWorkspaceTargetIdentity(options.workspaceTargetIdentity ?? null)
       if (!options.preserveStartFrom) {
         smartGitHubPrStartPointSelectionRef.current = null
         setLinkedIssue('')
@@ -2575,13 +2620,23 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     [folderSourceRepos, setRepoId]
   )
   const handleProjectHostSetupChange = useCallback(
-    (setupId: string): void => {
-      const option = projectHostSetupOptions.find((candidate) => candidate.id === setupId)
+    (setupId: string, hostId: ExecutionHostId): void => {
+      const option = projectHostSetupOptions.find(
+        (candidate) => candidate.id === setupId && candidate.hostId === hostId
+      )
       if (!option || option.kind !== 'ready') {
         return
       }
       // Why: switching run host for the same project must not erase the task/PR source the user is starting from.
-      handleRepoChange(option.repoId, { preserveStartFrom: true })
+      handleRepoChange(option.repoId, {
+        preserveStartFrom: true,
+        workspaceTargetIdentity: {
+          projectId: option.projectId,
+          hostId: option.hostId,
+          projectHostSetupId: option.id,
+          repoId: option.repoId
+        }
+      })
     },
     [handleRepoChange, projectHostSetupOptions]
   )
@@ -2633,17 +2688,20 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       const preferredHostId =
         selectedWorkspaceTarget.status === 'ready' ? selectedWorkspaceTarget.target.hostId : null
       // Why: pass the current host as a preference (focusedHostScope), not a hard hostId — pinning made selecting a project set up only on another host a silent no-op.
-      const nextRepoId = resolveWorkspaceCreationRepoId({
+      const nextTarget = resolveWorkspaceCreationTarget({
         eligibleRepos,
         projects,
         projectHostSetups,
         projectId,
         focusedHostScope: preferredHostId ?? workspaceHostScope
       })
-      if (!nextRepoId) {
+      if (nextTarget.status !== 'ready') {
         return
       }
-      handleRepoChange(nextRepoId, { forceResetStartFrom: isProjectGroupTarget })
+      handleRepoChange(nextTarget.target.repoId, {
+        forceResetStartFrom: isProjectGroupTarget,
+        workspaceTargetIdentity: getWorkspaceTargetIdentity(nextTarget.target)
+      })
     },
     [
       eligibleRepos,
@@ -4121,6 +4179,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     onProjectChange: handleProjectChange,
     projectHostSetupOptions: isProjectGroupTarget ? [] : projectHostSetupOptions,
     selectedProjectHostSetupId: isProjectGroupTarget ? null : selectedProjectHostSetupId,
+    selectedProjectHostId: isProjectGroupTarget ? null : selectedProjectHostId,
     onProjectHostSetupChange: handleProjectHostSetupChange,
     ephemeralVmRecipes: isProjectGroupTarget || !ephemeralVmsEnabled ? [] : ephemeralVmRecipes,
     selectedEphemeralVmRecipeId:

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -4,16 +4,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   buildRuntimeClientEventEnvironmentKey,
   buildNewWorkspaceShortcutModalData,
+  collectSshTargetWorktreeIds,
   getNewlyConnectedRuntimeEnvironmentIds,
   getNewlyDisconnectedRuntimeEnvironmentIds,
   getRuntimeProjectRefreshEnvironmentIds,
+  isRuntimeEventRepoKnown,
   openNewWorkspaceFromShortcut,
   resolveBrowserSessionTabTarget,
   resolveZoomTarget
 } from './useIpcEvents'
 import type { SleepingAgentLaunchConfig } from '../../../shared/agent-session-resume'
 import type { AgentStatusClearIpcPayload } from '../../../shared/agent-status-types'
-import type { TuiAgent } from '../../../shared/types'
+import type { Repo, TuiAgent, Worktree } from '../../../shared/types'
 import { makePaneKey } from '../../../shared/stable-pane-id'
 import { YOLO_TUI_AGENT_ARGS } from '../../../shared/tui-agent-permissions'
 
@@ -89,6 +91,64 @@ describe('getRuntimeProjectRefreshEnvironmentIds', () => {
         nextReachable: ['env-a']
       })
     ).toEqual(['env-a'])
+  })
+})
+
+function makeHostRepo(id: string, overrides: Partial<Repo> = {}): Repo {
+  return { id, path: `/repos/${id}`, displayName: id, badgeColor: '#000', addedAt: 0, ...overrides }
+}
+
+function makeHostWorktree(id: string, repoId: string, hostId?: Worktree['hostId']): Worktree {
+  return { id, repoId, path: `/repos/${repoId}/${id}`, hostId } as Worktree
+}
+
+describe('collectSshTargetWorktreeIds', () => {
+  const sshRepo = makeHostRepo('repo-1', { connectionId: 'ssh-target-1' })
+
+  it('includes host-stamped and legacy hostless rows of the target repos', () => {
+    const ids = collectSshTargetWorktreeIds(
+      [sshRepo, makeHostRepo('repo-2')],
+      {
+        'repo-1': [
+          makeHostWorktree('wt-ssh', 'repo-1', 'ssh:ssh-target-1'),
+          makeHostWorktree('wt-legacy', 'repo-1')
+        ],
+        'repo-2': [makeHostWorktree('wt-other-repo', 'repo-2')]
+      },
+      'ssh-target-1'
+    )
+    expect(ids).toEqual(new Set(['wt-ssh', 'wt-legacy']))
+  })
+
+  it('excludes sibling-host rows that share the repo id', () => {
+    const ids = collectSshTargetWorktreeIds(
+      [sshRepo, makeHostRepo('repo-1', { executionHostId: 'runtime:env-1' })],
+      {
+        'repo-1': [
+          makeHostWorktree('wt-ssh', 'repo-1', 'ssh:ssh-target-1'),
+          makeHostWorktree('wt-runtime', 'repo-1', 'runtime:env-1'),
+          makeHostWorktree('wt-local', 'repo-1', 'local')
+        ]
+      },
+      'ssh-target-1'
+    )
+    expect(ids).toEqual(new Set(['wt-ssh']))
+  })
+})
+
+describe('isRuntimeEventRepoKnown', () => {
+  it('recognizes a repo fetched from the event environment', () => {
+    const repos = [makeHostRepo('repo-1', { executionHostId: 'runtime:env-1' })]
+    expect(isRuntimeEventRepoKnown(repos, 'env-1', 'repo-1')).toBe(true)
+  })
+
+  it('does not let a same-id repo on another host suppress the environment fetch', () => {
+    const repos = [
+      makeHostRepo('repo-1'),
+      makeHostRepo('repo-1', { executionHostId: 'runtime:env-2' })
+    ]
+    expect(isRuntimeEventRepoKnown(repos, 'env-1', 'repo-1')).toBe(false)
+    expect(isRuntimeEventRepoKnown(undefined, 'env-1', 'repo-1')).toBe(false)
   })
 })
 

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -127,7 +127,22 @@ describe('collectSshTargetWorktreeIds', () => {
         'repo-1': [
           makeHostWorktree('wt-ssh', 'repo-1', 'ssh:ssh-target-1'),
           makeHostWorktree('wt-runtime', 'repo-1', 'runtime:env-1'),
-          makeHostWorktree('wt-local', 'repo-1', 'local')
+          makeHostWorktree('wt-local', 'repo-1', 'local'),
+          makeHostWorktree('wt-ambiguous-legacy', 'repo-1')
+        ]
+      },
+      'ssh-target-1'
+    )
+    expect(ids).toEqual(new Set(['wt-ssh']))
+  })
+
+  it('excludes hostless rows when duplicate repo records share the target host', () => {
+    const ids = collectSshTargetWorktreeIds(
+      [sshRepo, makeHostRepo('repo-1', { connectionId: 'ssh-target-1' })],
+      {
+        'repo-1': [
+          makeHostWorktree('wt-ssh', 'repo-1', 'ssh:ssh-target-1'),
+          makeHostWorktree('wt-ambiguous-legacy', 'repo-1')
         ]
       },
       'ssh-target-1'
@@ -4404,7 +4419,7 @@ describe('useIpcEvents CLI-created worktree activation', () => {
           fetchProjectGroups: vi.fn(),
           fetchWorktrees,
           fetchWorktreeLineage,
-          repos: [{ id: 'repo-1' }],
+          repos: [{ id: 'repo-1' }, { id: 'repo-1', executionHostId: 'runtime:env-1' }],
           detectedWorktreesByRepo: {
             'repo-1': {
               repoId: 'repo-1',
@@ -4594,7 +4609,7 @@ describe('useIpcEvents CLI-created worktree activation', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
     await new Promise((resolve) => setTimeout(resolve, 0))
 
-    expect(fetchWorktrees).toHaveBeenCalledWith('repo-1')
+    expect(fetchWorktrees).toHaveBeenCalledWith('repo-1', { ownerHostId: 'runtime:env-1' })
     expect(fetchWorktreeLineage).toHaveBeenCalledTimes(1)
   })
 })
@@ -7034,6 +7049,150 @@ describe('useIpcEvents agent status snapshot integration', () => {
     expect(hydrateTabsSession).not.toHaveBeenCalled()
     expect(hydrateEditorSession).not.toHaveBeenCalled()
     expect(hydrateBrowserSession).not.toHaveBeenCalled()
+  })
+
+  it('fetches and applies SSH workspace snapshots only for the target host', async () => {
+    const hydrateWorkspaceSession = vi.fn()
+    const hydrateTabsSession = vi.fn()
+    const hydrateEditorSession = vi.fn()
+    const hydrateBrowserSession = vi.fn()
+    const setRemoteWorkspaceSyncStatus = vi.fn()
+    const onChangedListenerRef: {
+      current:
+        | ((event: {
+            targetId: string
+            sourceClientId?: string
+            snapshot: Record<string, unknown>
+          }) => void)
+        | null
+    } = { current: null }
+    const storeState: StoreLike = buildStoreState({
+      workspaceSessionReady: true,
+      repos: [
+        { id: 'same-repo', executionHostId: 'local' },
+        { id: 'same-repo', connectionId: 'conn-1', executionHostId: 'ssh:conn-1' }
+      ],
+      worktreesByRepo: {
+        'same-repo': [
+          { id: 'same-repo::/local', repoId: 'same-repo', hostId: 'local' },
+          { id: 'same-repo::/remote', repoId: 'same-repo', hostId: 'ssh:conn-1' }
+        ]
+      },
+      tabsByWorktree: {
+        'same-repo::/local': [
+          { id: 'local-tab', ptyId: 'local-pty', worktreeId: 'same-repo::/local', title: 'Local' }
+        ],
+        'same-repo::/remote': [
+          { id: 'old-remote-tab', ptyId: null, worktreeId: 'same-repo::/remote', title: 'Old' }
+        ]
+      },
+      activeRepoId: 'same-repo',
+      activeWorkspaceKey: null,
+      activeWorktreeId: 'same-repo::/local',
+      activeTabId: 'local-tab',
+      ptyIdsByTabId: {},
+      lastKnownRelayPtyIdByTabId: {},
+      activeTabIdByWorktree: { 'same-repo::/local': 'local-tab' },
+      openFiles: [],
+      editorDrafts: {},
+      markdownFrontmatterVisible: {},
+      activeFileIdByWorktree: {},
+      activeTabTypeByWorktree: {},
+      browserTabsByWorktree: {},
+      browserPagesByWorkspace: {},
+      activeBrowserTabIdByWorktree: {},
+      browserUrlHistory: [],
+      groupsByWorktree: {},
+      layoutByWorktree: {},
+      activeGroupIdByWorktree: {},
+      sshConnectionStates: new Map(),
+      lastVisitedAtByWorktreeId: {},
+      defaultTerminalTabsAppliedByWorktreeId: {},
+      fetchWorktrees: vi.fn(() => Promise.resolve(true)),
+      fetchWorktreeLineage: vi.fn(() => Promise.resolve()),
+      hydrateWorkspaceSession,
+      hydrateTabsSession,
+      hydrateEditorSession,
+      hydrateBrowserSession,
+      markRemoteWorkspaceHydrated: vi.fn(),
+      setRemoteWorkspaceSyncStatus,
+      reconnectPersistedTerminals: vi.fn(() => Promise.resolve())
+    })
+
+    vi.doUnmock('@/lib/workspace-session')
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => storeState
+      }
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: () => () => {},
+        remoteWorkspace: {
+          clientId: () => Promise.resolve('client-local'),
+          onChanged: (cb: typeof onChangedListenerRef.current) => {
+            onChangedListenerRef.current = cb
+            return () => {}
+          }
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    onChangedListenerRef.current?.({
+      targetId: 'conn-1',
+      sourceClientId: 'client-remote',
+      snapshot: {
+        revision: 2,
+        updatedAt: Date.now(),
+        session: {
+          activeWorktreePath: '/remote',
+          activeTabId: 'remote-tab',
+          tabsByWorktreePath: {
+            '/remote': [
+              {
+                id: 'remote-tab',
+                ptyId: null,
+                worktreePath: '/remote',
+                title: 'Remote',
+                customTitle: null,
+                color: null,
+                sortOrder: 1,
+                createdAt: 1
+              }
+            ]
+          },
+          terminalLayoutsByTabId: {}
+        }
+      }
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(storeState.fetchWorktrees).toHaveBeenCalledWith('same-repo', {
+      ownerHostId: 'ssh:conn-1'
+    })
+    expect(setRemoteWorkspaceSyncStatus).toHaveBeenCalledWith(
+      'conn-1',
+      expect.objectContaining({ phase: 'synced' })
+    )
+    const hydrated = hydrateTabsSession.mock.calls[0]?.[0] as {
+      tabsByWorktree: Record<string, { id: string }[]>
+    }
+    expect(hydrated.tabsByWorktree['same-repo::/local']).toEqual([
+      expect.objectContaining({ id: 'local-tab' })
+    ])
+    expect(hydrated.tabsByWorktree['same-repo::/remote']).toEqual([
+      expect.objectContaining({ id: 'remote-tab' })
+    ])
   })
 
   it('silently discards snapshot entries whose tabs are still unknown', async () => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -31,7 +31,8 @@ import type {
 import {
   getRepoExecutionHostId,
   toRuntimeExecutionHostId,
-  toSshExecutionHostId
+  toSshExecutionHostId,
+  type ExecutionHostId
 } from '../../../shared/execution-host'
 import type {
   RemoteWorkspacePatchResult,
@@ -439,7 +440,13 @@ async function prepareRemoteWorkspaceTarget(targetId: string): Promise<boolean> 
     await store.fetchRepos()
     repos = useAppStore.getState().repos.filter((repo) => repo.connectionId === targetId)
   }
-  await Promise.all(repos.map((repo) => useAppStore.getState().fetchWorktrees(repo.id)))
+  await Promise.all(
+    repos.map((repo) =>
+      useAppStore.getState().fetchWorktrees(repo.id, {
+        ownerHostId: getRepoExecutionHostId(repo)
+      })
+    )
+  )
   await useAppStore.getState().fetchWorktreeLineage()
   return true
 }
@@ -453,15 +460,27 @@ export function collectSshTargetWorktreeIds(
     repos.filter((repo) => repo.connectionId === targetId).map((repo) => repo.id)
   )
   const sshHostId = toSshExecutionHostId(targetId)
+  const repoOwnerById = new Map<string, { count: number; onlyHostId?: ExecutionHostId }>()
+  for (const repo of repos) {
+    const current = repoOwnerById.get(repo.id)
+    repoOwnerById.set(
+      repo.id,
+      current
+        ? { count: current.count + 1 }
+        : { count: 1, onlyHostId: getRepoExecutionHostId(repo) }
+    )
+  }
   return new Set(
     Object.values(worktreesByRepo)
       .flat()
       .filter(
         (worktree) =>
           repoIds.has(worktree.repoId) &&
-          // Why: same-id repos can exist on several hosts (#9783); only rows owned by
-          // this SSH host (or legacy hostless rows) may be claimed by its snapshot.
-          (worktree.hostId == null || worktree.hostId === sshHostId)
+          (worktree.hostId === sshHostId ||
+            // Why: a hostless legacy row belongs to a remote host only when that repo has one unambiguous owner.
+            (worktree.hostId == null &&
+              repoOwnerById.get(worktree.repoId)?.count === 1 &&
+              repoOwnerById.get(worktree.repoId)?.onlyHostId === sshHostId))
       )
       .map((worktree) => worktree.id)
   )
@@ -818,7 +837,7 @@ export function getRuntimeProjectRefreshEnvironmentIds(args: {
   ]
 }
 
-async function refreshRuntimeProjectWorktrees(repos: readonly { id: string }[]): Promise<void> {
+async function refreshRuntimeProjectWorktrees(repos: readonly Repo[]): Promise<void> {
   let nextIndex = 0
   const failures: { repoId: string; error: unknown }[] = []
   const workerCount = Math.min(RUNTIME_PROJECT_REFRESH_CONCURRENCY, repos.length)
@@ -829,9 +848,12 @@ async function refreshRuntimeProjectWorktrees(repos: readonly { id: string }[]):
       while (nextIndex < repos.length) {
         const index = nextIndex
         nextIndex += 1
-        const repoId = repos[index].id
+        const repo = repos[index]
+        const repoId = repo.id
         try {
-          await useAppStore.getState().fetchWorktrees(repoId)
+          await useAppStore.getState().fetchWorktrees(repoId, {
+            ownerHostId: getRepoExecutionHostId(repo)
+          })
         } catch (error) {
           failures.push({ repoId, error })
         }
@@ -873,6 +895,7 @@ export function useIpcEvents(): void {
 
     const handleWorktreesChanged = async (
       repoId: string,
+      ownerHostId?: ExecutionHostId,
       renamed?: { oldWorktreeId: string; newWorktreeId: string }
     ): Promise<void> => {
       // Why: capture active-ness before migration moves the pointer; re-key maps before the diff so a rename isn't a deletion.
@@ -890,7 +913,9 @@ export function useIpcEvents(): void {
       const before =
         getAuthoritativeDetectedWorktreeIds(state, repoId) ??
         getVisibleWorktreeIdsForRepo(state, repoId)
-      await state.fetchWorktrees(repoId)
+      await (ownerHostId
+        ? state.fetchWorktrees(repoId, { ownerHostId })
+        : state.fetchWorktrees(repoId))
       await useAppStore.getState().fetchWorktreeLineage()
       // Why: an id change unmounts the active pane; re-activate so the tab reconciles, else it vanishes until re-select.
       if (renamedWasActive && renamed) {
@@ -939,7 +964,7 @@ export function useIpcEvents(): void {
         startup,
         defaultTabs
       }: Extract<RuntimeClientEvent, { type: 'activateWorktree' }>,
-      options: { allowRuntimeEnvironment: boolean }
+      options: { allowRuntimeEnvironment: boolean; ownerHostId?: ExecutionHostId }
     ): Promise<void> => {
       if (!options.allowRuntimeEnvironment && isRuntimeEnvironmentActive()) {
         // Why: local CLI worktree events carry local ids; runtime activation comes via the remote stream, allowed separately.
@@ -947,7 +972,10 @@ export function useIpcEvents(): void {
       }
       const existedBeforeFetch = Boolean(useAppStore.getState().getKnownWorktreeById(worktreeId))
       // Why: fetch first so activation can resolve the CLI-created worktree; it arrived from main, not yet in renderer state.
-      await useAppStore.getState().fetchWorktrees(repoId)
+      const store = useAppStore.getState()
+      await (options.ownerHostId
+        ? store.fetchWorktrees(repoId, { ownerHostId: options.ownerHostId })
+        : store.fetchWorktrees(repoId))
       const existsAfterFetch = Boolean(useAppStore.getState().getKnownWorktreeById(worktreeId))
       // Why: use the canonical activation path so the CLI switch records a back/forward visit, or the nav buttons ignore it.
       activateAndRevealWorktree(worktreeId, {
@@ -1005,7 +1033,10 @@ export function useIpcEvents(): void {
       }
       if (event.type === 'worktreesChanged') {
         void ensureRuntimeEventRepoKnown(environmentId, event.repoId).then(() =>
-          worktreeChangeRefreshQueue.enqueue({ repoId: event.repoId })
+          worktreeChangeRefreshQueue.enqueue({
+            repoId: event.repoId,
+            ownerHostId: toRuntimeExecutionHostId(environmentId)
+          })
         )
         return
       }
@@ -1019,7 +1050,12 @@ export function useIpcEvents(): void {
         return
       }
       void ensureRuntimeEventRepoKnown(environmentId, event.repoId)
-        .then(() => activateNotifiedWorktree(event, { allowRuntimeEnvironment: true }))
+        .then(() =>
+          activateNotifiedWorktree(event, {
+            allowRuntimeEnvironment: true,
+            ownerHostId: toRuntimeExecutionHostId(environmentId)
+          })
+        )
         .catch((error) => {
           console.error('Failed to activate runtime-created worktree:', error)
         })
@@ -2689,7 +2725,11 @@ export function useIpcEvents(): void {
       }
 
       if (state.status === 'connected') {
-        void Promise.all(remoteRepos.map((r) => store.fetchWorktrees(r.id))).then(async () => {
+        void Promise.all(
+          remoteRepos.map((repo) =>
+            store.fetchWorktrees(repo.id, { ownerHostId: getRepoExecutionHostId(repo) })
+          )
+        ).then(async () => {
           await useAppStore.getState().fetchWorktreeLineage()
           // Why: panes that never spawned (no PTY provider at cold start) or whose deferred reattach never ran sit inert.
           // Bumping generation remounts TerminalPane so the deferred-connect gate reattaches or spawns fresh now that the provider exists.

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -21,11 +21,18 @@ import { getVisibleWorktreeIds } from '@/components/sidebar/visible-worktrees'
 import { activateTabNumberShortcut } from '@/lib/tab-number-shortcuts'
 import { nextEditorFontZoomLevel, computeEditorFontSize } from '@/lib/editor-font-zoom'
 import type {
+  Repo,
   TerminalLayoutSnapshot,
   TerminalPaneLayoutNode,
   UpdateStatus,
-  WorkspaceSessionState
+  WorkspaceSessionState,
+  Worktree
 } from '../../../shared/types'
+import {
+  getRepoExecutionHostId,
+  toRuntimeExecutionHostId,
+  toSshExecutionHostId
+} from '../../../shared/execution-host'
 import type {
   RemoteWorkspacePatchResult,
   RemoteWorkspaceSnapshot
@@ -437,23 +444,43 @@ async function prepareRemoteWorkspaceTarget(targetId: string): Promise<boolean> 
   return true
 }
 
-function targetRepoIds(targetId: string): Set<string> {
+export function collectSshTargetWorktreeIds(
+  repos: readonly Repo[],
+  worktreesByRepo: Record<string, Worktree[]>,
+  targetId: string
+): Set<string> {
+  const repoIds = new Set(
+    repos.filter((repo) => repo.connectionId === targetId).map((repo) => repo.id)
+  )
+  const sshHostId = toSshExecutionHostId(targetId)
   return new Set(
-    useAppStore
-      .getState()
-      .repos.filter((repo) => repo.connectionId === targetId)
-      .map((repo) => repo.id)
+    Object.values(worktreesByRepo)
+      .flat()
+      .filter(
+        (worktree) =>
+          repoIds.has(worktree.repoId) &&
+          // Why: same-id repos can exist on several hosts (#9783); only rows owned by
+          // this SSH host (or legacy hostless rows) may be claimed by its snapshot.
+          (worktree.hostId == null || worktree.hostId === sshHostId)
+      )
+      .map((worktree) => worktree.id)
   )
 }
 
 function targetWorktreeIds(targetId: string): Set<string> {
-  const repoIds = targetRepoIds(targetId)
-  return new Set(
-    Object.values(useAppStore.getState().worktreesByRepo)
-      .flat()
-      .filter((worktree) => repoIds.has(worktree.repoId))
-      .map((worktree) => worktree.id)
-  )
+  const state = useAppStore.getState()
+  return collectSshTargetWorktreeIds(state.repos, state.worktreesByRepo, targetId)
+}
+
+export function isRuntimeEventRepoKnown(
+  repos: readonly Repo[] | undefined,
+  environmentId: string,
+  repoId: string
+): boolean {
+  const hostId = toRuntimeExecutionHostId(environmentId)
+  // Why: same-id repos can exist on several hosts (#9783); a row known only on
+  // another host must still trigger the environment repo fetch.
+  return (repos ?? []).some((repo) => repo.id === repoId && getRepoExecutionHostId(repo) === hostId)
 }
 
 function mergeRemoteWorkspaceSession(
@@ -937,7 +964,7 @@ export function useIpcEvents(): void {
       environmentId: string,
       repoId: string
     ): Promise<void> => {
-      if ((useAppStore.getState().repos ?? []).some((repo) => repo.id === repoId)) {
+      if (isRuntimeEventRepoKnown(useAppStore.getState().repos, environmentId, repoId)) {
         return
       }
       await useAppStore.getState().fetchRuntimeEnvironmentRepos(environmentId)
@@ -2646,11 +2673,10 @@ export function useIpcEvents(): void {
         store.setDetectedPorts(targetId, [])
 
         // Why: SSH teardown fires no per-PTY exit events; clear stale PTY ids so reconnect remounts rather than reattach a dead PTY.
-        const remoteWorktreeIds = new Set(
-          Object.values(store.worktreesByRepo)
-            .flat()
-            .filter((w) => remoteRepos.some((r) => r.id === w.repoId))
-            .map((w) => w.id)
+        const remoteWorktreeIds = collectSshTargetWorktreeIds(
+          store.repos,
+          store.worktreesByRepo,
+          targetId
         )
         for (const worktreeId of remoteWorktreeIds) {
           const tabs = useAppStore.getState().tabsByWorktree[worktreeId] ?? []
@@ -2668,11 +2694,11 @@ export function useIpcEvents(): void {
           // Why: panes that never spawned (no PTY provider at cold start) or whose deferred reattach never ran sit inert.
           // Bumping generation remounts TerminalPane so the deferred-connect gate reattaches or spawns fresh now that the provider exists.
           const freshStore = useAppStore.getState()
-          const remoteRepoIds = new Set(remoteRepos.map((r) => r.id))
-          const worktreeIds = Object.values(freshStore.worktreesByRepo)
-            .flat()
-            .filter((w) => remoteRepoIds.has(w.repoId))
-            .map((w) => w.id)
+          const worktreeIds = collectSshTargetWorktreeIds(
+            freshStore.repos,
+            freshStore.worktreesByRepo,
+            targetId
+          )
 
           for (const worktreeId of worktreeIds) {
             const tabs = freshStore.tabsByWorktree[worktreeId] ?? []

--- a/src/renderer/src/hooks/worktree-change-refresh-queue.test.ts
+++ b/src/renderer/src/hooks/worktree-change-refresh-queue.test.ts
@@ -28,13 +28,13 @@ describe('createWorktreeChangeRefreshQueue', () => {
     queue.enqueue({ repoId: 'repo-1' })
 
     expect(handler).toHaveBeenCalledTimes(1)
-    expect(handler).toHaveBeenCalledWith('repo-1', undefined)
+    expect(handler).toHaveBeenCalledWith('repo-1', undefined, undefined)
 
     firstRefresh.resolve()
     await flushPromises()
 
     expect(handler).toHaveBeenCalledTimes(2)
-    expect(handler).toHaveBeenNthCalledWith(2, 'repo-1', undefined)
+    expect(handler).toHaveBeenNthCalledWith(2, 'repo-1', undefined, undefined)
   })
 
   it('does not overlap refreshes for the same repo', async () => {
@@ -73,10 +73,28 @@ describe('createWorktreeChangeRefreshQueue', () => {
     queue.enqueue({ repoId: 'repo-2' })
 
     expect(handler).toHaveBeenCalledTimes(2)
-    expect(handler).toHaveBeenNthCalledWith(1, 'repo-1', undefined)
-    expect(handler).toHaveBeenNthCalledWith(2, 'repo-2', undefined)
+    expect(handler).toHaveBeenNthCalledWith(1, 'repo-1', undefined, undefined)
+    expect(handler).toHaveBeenNthCalledWith(2, 'repo-2', undefined, undefined)
 
     repoOneRefresh.resolve()
+    await flushPromises()
+  })
+
+  it('runs same-id repos on different hosts independently', async () => {
+    const firstHostRefresh = deferred()
+    const handler = vi.fn((_repoId: string, ownerHostId?: string) =>
+      ownerHostId === 'runtime:env-1' ? firstHostRefresh.promise : Promise.resolve()
+    )
+    const queue = createWorktreeChangeRefreshQueue(handler)
+
+    queue.enqueue({ repoId: 'repo-1', ownerHostId: 'runtime:env-1' })
+    queue.enqueue({ repoId: 'repo-1', ownerHostId: 'runtime:env-2' })
+
+    expect(handler).toHaveBeenCalledTimes(2)
+    expect(handler).toHaveBeenNthCalledWith(1, 'repo-1', 'runtime:env-1', undefined)
+    expect(handler).toHaveBeenNthCalledWith(2, 'repo-1', 'runtime:env-2', undefined)
+
+    firstHostRefresh.resolve()
     await flushPromises()
   })
 
@@ -100,8 +118,8 @@ describe('createWorktreeChangeRefreshQueue', () => {
       await flushPromises()
 
       expect(handler).toHaveBeenCalledTimes(3)
-      expect(handler).toHaveBeenNthCalledWith(2, 'repo-1', renamed)
-      expect(handler).toHaveBeenNthCalledWith(3, 'repo-1', undefined)
+      expect(handler).toHaveBeenNthCalledWith(2, 'repo-1', undefined, renamed)
+      expect(handler).toHaveBeenNthCalledWith(3, 'repo-1', undefined, undefined)
     } finally {
       consoleError.mockRestore()
     }
@@ -116,8 +134,8 @@ describe('createWorktreeChangeRefreshQueue', () => {
     queue.enqueue({ repoId: 'repo-1', renamed })
     await flushPromises()
 
-    expect(handler).toHaveBeenNthCalledWith(1, 'repo-1', undefined)
-    expect(handler).toHaveBeenNthCalledWith(2, 'repo-1', renamed)
+    expect(handler).toHaveBeenNthCalledWith(1, 'repo-1', undefined, undefined)
+    expect(handler).toHaveBeenNthCalledWith(2, 'repo-1', undefined, renamed)
   })
 
   it('keeps a plain refresh queued after a rename', async () => {
@@ -136,8 +154,8 @@ describe('createWorktreeChangeRefreshQueue', () => {
     await flushPromises()
 
     expect(handler).toHaveBeenCalledTimes(3)
-    expect(handler).toHaveBeenNthCalledWith(2, 'repo-1', renamed)
-    expect(handler).toHaveBeenNthCalledWith(3, 'repo-1', undefined)
+    expect(handler).toHaveBeenNthCalledWith(2, 'repo-1', undefined, renamed)
+    expect(handler).toHaveBeenNthCalledWith(3, 'repo-1', undefined, undefined)
   })
 
   it('drops queued trailing refreshes after disposal', async () => {

--- a/src/renderer/src/hooks/worktree-change-refresh-queue.ts
+++ b/src/renderer/src/hooks/worktree-change-refresh-queue.ts
@@ -1,3 +1,5 @@
+import type { ExecutionHostId } from '../../../shared/execution-host'
+
 type WorktreeRename = {
   oldWorktreeId: string
   newWorktreeId: string
@@ -5,16 +7,23 @@ type WorktreeRename = {
 
 type WorktreeChangeEvent = {
   repoId: string
+  ownerHostId?: ExecutionHostId
   renamed?: WorktreeRename
 }
 
-type WorktreeChangeRefreshHandler = (repoId: string, renamed?: WorktreeRename) => Promise<void>
+type WorktreeChangeRefreshHandler = (
+  repoId: string,
+  ownerHostId?: ExecutionHostId,
+  renamed?: WorktreeRename
+) => Promise<void>
 
 type QueuedWorktreeChange = {
   renamed?: WorktreeRename
 }
 
 type RepoRefreshState = {
+  repoId: string
+  ownerHostId?: ExecutionHostId
   running: boolean
   queue: QueuedWorktreeChange[]
 }
@@ -30,13 +39,16 @@ export function createWorktreeChangeRefreshQueue(
   const states = new Map<string, RepoRefreshState>()
   let disposed = false
 
-  const drain = async (repoId: string, state: RepoRefreshState): Promise<void> => {
+  const getRefreshKey = (event: Pick<WorktreeChangeEvent, 'repoId' | 'ownerHostId'>): string =>
+    `${event.ownerHostId ?? 'focused'}\0${event.repoId}`
+
+  const drain = async (key: string, state: RepoRefreshState): Promise<void> => {
     state.running = true
     try {
       while (!disposed && state.queue.length > 0) {
         const next = state.queue.shift()
         try {
-          await handler(repoId, next?.renamed)
+          await handler(state.repoId, state.ownerHostId, next?.renamed)
         } catch (error) {
           console.error('Failed to refresh changed worktrees:', error)
         }
@@ -44,9 +56,9 @@ export function createWorktreeChangeRefreshQueue(
     } finally {
       state.running = false
       if (disposed || state.queue.length === 0) {
-        states.delete(repoId)
+        states.delete(key)
       } else {
-        void drain(repoId, state)
+        void drain(key, state)
       }
     }
   }
@@ -61,10 +73,11 @@ export function createWorktreeChangeRefreshQueue(
       if (disposed) {
         return
       }
-      let state = states.get(event.repoId)
+      const key = getRefreshKey(event)
+      let state = states.get(key)
       if (!state) {
-        state = { running: false, queue: [] }
-        states.set(event.repoId, state)
+        state = { repoId: event.repoId, ownerHostId: event.ownerHostId, running: false, queue: [] }
+        states.set(key, state)
       }
 
       if (event.renamed) {
@@ -79,7 +92,7 @@ export function createWorktreeChangeRefreshQueue(
       }
 
       if (!state.running) {
-        void drain(event.repoId, state)
+        void drain(key, state)
       }
     }
   }

--- a/src/renderer/src/lib/project-host-setup-options.test.ts
+++ b/src/renderer/src/lib/project-host-setup-options.test.ts
@@ -15,13 +15,14 @@ const FULL_HOST_MODEL_RUNTIME_CAPABILITIES = [
 
 const LOCAL_HOST_LABEL = getExecutionHostLabel('local')
 
-function repo(id: string): Repo {
+function repo(id: string, overrides: Partial<Repo> = {}): Repo {
   return {
     id,
     path: `/repos/${id}`,
     displayName: id,
     badgeColor: '#000000',
-    addedAt: 1
+    addedAt: 1,
+    ...overrides
   }
 }
 
@@ -65,7 +66,7 @@ describe('buildProjectHostSetupOptions', () => {
   it('returns ready setup choices for one project sorted with local first', () => {
     const options = buildProjectHostSetupOptions({
       projectId: 'project-1',
-      eligibleRepos: [repo('local-repo'), repo('remote-repo')],
+      eligibleRepos: [repo('local-repo'), repo('remote-repo', { executionHostId: 'ssh:builder' })],
       projectHostSetups: [
         setup('remote', 'project-1', 'ssh:builder', 'remote-repo'),
         setup('local', 'project-1', 'local', 'local-repo')
@@ -80,7 +81,11 @@ describe('buildProjectHostSetupOptions', () => {
   it('uses saved host labels for ready runtime setup choices', () => {
     const options = buildProjectHostSetupOptions({
       projectId: 'project-1',
-      eligibleRepos: [repo('runtime-repo')],
+      eligibleRepos: [
+        repo('runtime-repo', {
+          executionHostId: 'runtime:03ef704c-b180-4b10-998d-e28fbd5de9a3'
+        })
+      ],
       hosts: [
         host('runtime:03ef704c-b180-4b10-998d-e28fbd5de9a3', {
           label: 'dev box',
@@ -104,6 +109,32 @@ describe('buildProjectHostSetupOptions', () => {
         label: 'dev box',
         repoId: 'runtime-repo'
       })
+    ])
+  })
+
+  it('does not expose a setup backed only by a same-id repo on another host', () => {
+    const options = buildProjectHostSetupOptions({
+      projectId: 'project-1',
+      eligibleRepos: [repo('same-repo')],
+      projectHostSetups: [setup('remote', 'project-1', 'runtime:env-1', 'same-repo')]
+    })
+
+    expect(options).toEqual([])
+  })
+
+  it('keeps colliding legacy setup ids available on each owning host', () => {
+    const options = buildProjectHostSetupOptions({
+      projectId: 'project-1',
+      eligibleRepos: [repo('same-repo'), repo('same-repo', { executionHostId: 'runtime:env-1' })],
+      projectHostSetups: [
+        setup('same-repo', 'project-1', 'local', 'same-repo'),
+        setup('same-repo', 'project-1', 'runtime:env-1', 'same-repo')
+      ]
+    })
+
+    expect(options).toEqual([
+      expect.objectContaining({ id: 'same-repo', hostId: 'local' }),
+      expect.objectContaining({ id: 'same-repo', hostId: 'runtime:env-1' })
     ])
   })
 

--- a/src/renderer/src/lib/project-host-setup-options.ts
+++ b/src/renderer/src/lib/project-host-setup-options.ts
@@ -1,5 +1,6 @@
 import {
   getExecutionHostLabel,
+  getRepoExecutionHostId,
   isRuntimeOwnedSshTargetId,
   LOCAL_EXECUTION_HOST_ID,
   parseExecutionHostId,
@@ -109,7 +110,9 @@ function buildReadySetupOptions({
   eligibleRepos,
   hosts
 }: BuildReadySetupOptionsInput): ReadyProjectHostSetupOption[] {
-  const eligibleRepoIds = new Set(eligibleRepos.map((repo) => repo.id))
+  const eligibleRepoHosts = new Set(
+    eligibleRepos.map((repo) => `${getRepoExecutionHostId(repo)}\0${repo.id}`)
+  )
   const hostById = new Map(hosts.map((host) => [host.id, host]))
   return projectHostSetups
     .filter((setup) => {
@@ -117,7 +120,7 @@ function buildReadySetupOptions({
       return (
         setup.projectId === projectId &&
         setup.setupState === 'ready' &&
-        eligibleRepoIds.has(setup.repoId) &&
+        eligibleRepoHosts.has(`${setup.hostId}\0${setup.repoId}`) &&
         !isEphemeralVmProjectHost(host) &&
         !isRuntimeOwnedSshSetupHost(setup.hostId)
       )

--- a/src/renderer/src/lib/project-host-workspace-target.test.ts
+++ b/src/renderer/src/lib/project-host-workspace-target.test.ts
@@ -201,6 +201,26 @@ describe('project-host workspace target resolution', () => {
     })
   })
 
+  it('pins an explicit setup id to the requested host when setup ids collide across hosts', () => {
+    // Legacy projected setups reuse the repo id, so the same setup id exists on
+    // both hosts when a repo id is checked out locally and on a runtime host.
+    const result = resolveWorkspaceCreationTarget({
+      eligibleRepos: [
+        makeRepo('orca', { executionHostId: 'local' }),
+        makeRepo('orca', { executionHostId: 'runtime:env-1' })
+      ],
+      projectHostSetups: [
+        makeSetup('orca', 'github:stablyai/orca', 'local', 'orca'),
+        makeSetup('orca', 'github:stablyai/orca', 'runtime:env-1', 'orca')
+      ],
+      projectHostSetupId: 'orca',
+      hostId: 'runtime:env-1'
+    })
+
+    expect(result.status).toBe('ready')
+    expect(result.status === 'ready' && result.target.setup.hostId).toBe('runtime:env-1')
+  })
+
   // Regression: selecting a project in the new-workspace dropdown must not be
   // pinned to the host of the currently-active workspace. Each project below is
   // set up on exactly one (different) host; picking the other project while the

--- a/src/renderer/src/lib/project-host-workspace-target.test.ts
+++ b/src/renderer/src/lib/project-host-workspace-target.test.ts
@@ -206,19 +206,95 @@ describe('project-host workspace target resolution', () => {
     // both hosts when a repo id is checked out locally and on a runtime host.
     const result = resolveWorkspaceCreationTarget({
       eligibleRepos: [
-        makeRepo('orca', { executionHostId: 'local' }),
-        makeRepo('orca', { executionHostId: 'runtime:env-1' })
+        makeRepo('orca', { executionHostId: 'local', path: '/repos/local-orca' }),
+        makeRepo('orca', { executionHostId: 'runtime:env-1', path: '/repos/runtime-orca' })
       ],
       projectHostSetups: [
         makeSetup('orca', 'github:stablyai/orca', 'local', 'orca'),
         makeSetup('orca', 'github:stablyai/orca', 'runtime:env-1', 'orca')
       ],
       projectHostSetupId: 'orca',
-      hostId: 'runtime:env-1'
+      hostId: 'local'
     })
 
     expect(result.status).toBe('ready')
-    expect(result.status === 'ready' && result.target.setup.hostId).toBe('runtime:env-1')
+    expect(result.status === 'ready' && result.target).toMatchObject({
+      hostId: 'local',
+      repo: { path: '/repos/local-orca' }
+    })
+  })
+
+  it('uses focused host when an explicit setup id collides without a requested host', () => {
+    const result = resolveWorkspaceCreationTarget({
+      eligibleRepos: [
+        makeRepo('orca', { path: '/repos/local-orca' }),
+        makeRepo('orca', { executionHostId: 'runtime:env-1', path: '/repos/runtime-orca' })
+      ],
+      projectHostSetups: [
+        makeSetup('orca', 'github:stablyai/orca', 'local', 'orca'),
+        makeSetup('orca', 'github:stablyai/orca', 'runtime:env-1', 'orca')
+      ],
+      projectHostSetupId: 'orca',
+      focusedHostScope: 'runtime:env-1'
+    })
+
+    expect(result).toMatchObject({
+      status: 'ready',
+      target: { hostId: 'runtime:env-1', repo: { path: '/repos/runtime-orca' } }
+    })
+  })
+
+  it('keeps a globally unique explicit setup when focus is on another host', () => {
+    const result = resolveWorkspaceCreationTarget({
+      eligibleRepos: [makeRepo('orca', { executionHostId: 'runtime:env-1' })],
+      projectHostSetups: [
+        makeSetup('setup-runtime', 'github:stablyai/orca', 'runtime:env-1', 'orca')
+      ],
+      projectHostSetupId: 'setup-runtime',
+      focusedHostScope: 'local'
+    })
+
+    expect(result).toMatchObject({
+      status: 'ready',
+      target: { hostId: 'runtime:env-1', projectHostSetupId: 'setup-runtime' }
+    })
+  })
+
+  it('does not guess an explicit setup owner when host focus is ambiguous', () => {
+    expect(
+      resolveWorkspaceCreationTarget({
+        eligibleRepos: [makeRepo('orca'), makeRepo('orca', { executionHostId: 'runtime:env-1' })],
+        projectHostSetups: [
+          makeSetup('orca', 'github:stablyai/orca', 'local', 'orca'),
+          makeSetup('orca', 'github:stablyai/orca', 'runtime:env-1', 'orca')
+        ],
+        projectHostSetupId: 'orca'
+      })
+    ).toEqual({ status: 'unavailable', reason: 'setup-not-found' })
+  })
+
+  it('keeps the legacy repo fallback on the focused host when repo ids collide', () => {
+    const result = resolveWorkspaceCreationTarget({
+      eligibleRepos: [
+        makeRepo('orca', { path: '/repos/local-orca' }),
+        makeRepo('orca', { executionHostId: 'runtime:env-1', path: '/repos/runtime-orca' })
+      ],
+      projectHostSetups: [
+        makeSetup('runtime-setup', 'github:stablyai/orca', 'runtime:env-1', 'orca'),
+        makeSetup('local-setup', 'github:stablyai/orca', 'local', 'orca')
+      ],
+      activeRepoId: 'orca',
+      focusedHostScope: 'local'
+    })
+
+    expect(result).toMatchObject({
+      status: 'ready',
+      target: {
+        hostId: 'local',
+        projectHostSetupId: 'local-setup',
+        repo: { path: '/repos/local-orca' }
+      }
+    })
   })
 
   // Regression: selecting a project in the new-workspace dropdown must not be

--- a/src/renderer/src/lib/project-host-workspace-target.ts
+++ b/src/renderer/src/lib/project-host-workspace-target.ts
@@ -1,7 +1,8 @@
 import {
   ALL_EXECUTION_HOSTS_SCOPE,
   type ExecutionHostId,
-  type ExecutionHostScope
+  type ExecutionHostScope,
+  getRepoExecutionHostId
 } from '../../../shared/execution-host'
 import { projectHostSetupProjectionFromRepos } from '../../../shared/project-host-setup-projection'
 import type { Project, ProjectHostSetup, Repo } from '../../../shared/types'
@@ -75,11 +76,21 @@ function isReadySetup(setup: ProjectHostSetup): boolean {
   return setup.setupState === 'ready'
 }
 
+function getRepoSetupHostKey(repoId: string, hostId: ExecutionHostId): string {
+  return `${hostId}\0${repoId}`
+}
+
+function createRepoBySetupHost(repos: readonly Repo[]): ReadonlyMap<string, Repo> {
+  return new Map(
+    repos.map((repo) => [getRepoSetupHostKey(repo.id, getRepoExecutionHostId(repo)), repo])
+  )
+}
+
 function createTarget(
   setup: ProjectHostSetup,
-  repoById: ReadonlyMap<string, Repo>
+  repoBySetupHost: ReadonlyMap<string, Repo>
 ): WorkspaceCreationTarget | null {
-  const repo = repoById.get(setup.repoId)
+  const repo = repoBySetupHost.get(getRepoSetupHostKey(setup.repoId, setup.hostId))
   if (!repo) {
     return null
   }
@@ -95,19 +106,32 @@ function createTarget(
 
 function findReadySetupTarget(
   setups: readonly ProjectHostSetup[],
-  repoById: ReadonlyMap<string, Repo>,
+  repoBySetupHost: ReadonlyMap<string, Repo>,
   predicate: (setup: ProjectHostSetup) => boolean
 ): WorkspaceCreationTarget | null {
   for (const setup of setups) {
     if (!isReadySetup(setup) || !predicate(setup)) {
       continue
     }
-    const target = createTarget(setup, repoById)
+    const target = createTarget(setup, repoBySetupHost)
     if (target) {
       return target
     }
   }
   return null
+}
+
+function findLegacyFallbackRepo(
+  repos: readonly Repo[],
+  repoId: string,
+  focusedHostScope?: ExecutionHostScope | null
+): Repo | undefined {
+  const matches = repos.filter((repo) => repo.id === repoId)
+  const focusedHostId =
+    focusedHostScope && focusedHostScope !== ALL_EXECUTION_HOSTS_SCOPE ? focusedHostScope : null
+  return focusedHostId
+    ? (matches.find((repo) => getRepoExecutionHostId(repo) === focusedHostId) ?? matches[0])
+    : matches[0]
 }
 
 export function resolveWorkspaceCreationTarget(
@@ -119,22 +143,30 @@ export function resolveWorkspaceCreationTarget(
   }
 
   const model = getProjectSetupModel(input)
-  const repoById = new Map(eligibleRepos.map((repo) => [repo.id, repo]))
+  const repoBySetupHost = createRepoBySetupHost(eligibleRepos)
   const setups = model?.setups ?? []
 
   if (projectHostSetupId) {
-    // Why: legacy projected setups reuse repo ids, so one setup id can exist on
-    // several hosts (#9783); an explicit hostId must pin the lookup to that host.
-    const setup = setups.find(
+    const matchingSetups = setups.filter(
       (entry) => entry.id === projectHostSetupId && (!hostId || entry.hostId === hostId)
     )
+    const focusedHostId =
+      focusedHostScope && focusedHostScope !== ALL_EXECUTION_HOSTS_SCOPE ? focusedHostScope : null
+    // Why: legacy projected setup ids collide across hosts; never let array order choose an owner.
+    const setup = hostId
+      ? matchingSetups[0]
+      : matchingSetups.length === 1
+        ? matchingSetups[0]
+        : focusedHostId
+          ? matchingSetups.find((entry) => entry.hostId === focusedHostId)
+          : undefined
     if (!setup) {
       return { status: 'unavailable', reason: 'setup-not-found' }
     }
     if (!isReadySetup(setup)) {
       return { status: 'unavailable', reason: 'setup-not-ready' }
     }
-    const target = createTarget(setup, repoById)
+    const target = createTarget(setup, repoBySetupHost)
     if (target) {
       return { status: 'ready', target }
     }
@@ -154,7 +186,7 @@ export function resolveWorkspaceCreationTarget(
     }
     const target = findReadySetupTarget(
       setups,
-      repoById,
+      repoBySetupHost,
       (setup) => setup.projectId === projectId && setup.hostId === hostId
     )
     if (target) {
@@ -169,14 +201,18 @@ export function resolveWorkspaceCreationTarget(
     const focusedTarget = focusedHostId
       ? findReadySetupTarget(
           setups,
-          repoById,
+          repoBySetupHost,
           (setup) => setup.projectId === projectId && setup.hostId === focusedHostId
         )
       : null
     if (focusedTarget) {
       return { status: 'ready', target: focusedTarget }
     }
-    const target = findReadySetupTarget(setups, repoById, (setup) => setup.projectId === projectId)
+    const target = findReadySetupTarget(
+      setups,
+      repoBySetupHost,
+      (setup) => setup.projectId === projectId
+    )
     if (target) {
       return { status: 'ready', target }
     }
@@ -184,22 +220,25 @@ export function resolveWorkspaceCreationTarget(
   }
 
   if (hostId) {
-    const target = findReadySetupTarget(setups, repoById, (setup) => setup.hostId === hostId)
+    const target = findReadySetupTarget(setups, repoBySetupHost, (setup) => setup.hostId === hostId)
     if (target) {
       return { status: 'ready', target }
     }
   }
 
   const repoId = resolveComposerRepoId(input)
-  const legacyRepo = repoId ? repoById.get(repoId) : null
+  const legacyRepo = repoId ? findLegacyFallbackRepo(eligibleRepos, repoId, focusedHostScope) : null
   if (!legacyRepo) {
     return { status: 'unavailable', reason: 'no-eligible-repo' }
   }
 
+  const legacyRepoHostId = getRepoExecutionHostId(legacyRepo)
   const legacySetup =
-    setups.find((setup) => setup.repoId === legacyRepo.id && isReadySetup(setup)) ??
-    projectHostSetupProjectionFromRepos([legacyRepo]).setups[0]
-  const legacyTarget = legacySetup ? createTarget(legacySetup, repoById) : null
+    setups.find(
+      (setup) =>
+        setup.repoId === legacyRepo.id && setup.hostId === legacyRepoHostId && isReadySetup(setup)
+    ) ?? projectHostSetupProjectionFromRepos([legacyRepo]).setups[0]
+  const legacyTarget = legacySetup ? createTarget(legacySetup, repoBySetupHost) : null
   if (!legacyTarget) {
     return { status: 'unavailable', reason: 'setup-not-found' }
   }

--- a/src/renderer/src/lib/project-host-workspace-target.ts
+++ b/src/renderer/src/lib/project-host-workspace-target.ts
@@ -123,7 +123,11 @@ export function resolveWorkspaceCreationTarget(
   const setups = model?.setups ?? []
 
   if (projectHostSetupId) {
-    const setup = setups.find((entry) => entry.id === projectHostSetupId)
+    // Why: legacy projected setups reuse repo ids, so one setup id can exist on
+    // several hosts (#9783); an explicit hostId must pin the lookup to that host.
+    const setup = setups.find(
+      (entry) => entry.id === projectHostSetupId && (!hostId || entry.hostId === hostId)
+    )
     if (!setup) {
       return { status: 'unavailable', reason: 'setup-not-found' }
     }

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -20,6 +20,7 @@ import type {
   WorktreeMeta,
   WorkspaceKey
 } from '../../../../shared/types'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
 import type { WorktreeForceDeleteReason } from '../../../../shared/worktree-removal'
 import type { TerminalGitHubPRLink } from '../../../../shared/terminal-github-pr-link-detector'
 import type {
@@ -117,7 +118,10 @@ export type WorktreeSlice = {
    */
   hasHydratedWorktreePurge: boolean
   fetchDetectedWorktrees: (repoId: string) => Promise<DetectedWorktreeListResult | null>
-  fetchWorktrees: (repoId: string, options?: { requireAuthoritative?: boolean }) => Promise<boolean>
+  fetchWorktrees: (
+    repoId: string,
+    options?: { requireAuthoritative?: boolean; ownerHostId?: ExecutionHostId }
+  ) => Promise<boolean>
   fetchAllWorktrees: (options?: { hydrationPurge?: 'allow' | 'defer' }) => Promise<void>
   fetchWorktreeLineage: () => Promise<void>
   updateWorktreeLineage: (

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -6005,6 +6005,83 @@ describe('fetchAllWorktrees hydration-time purge (design §4.4)', () => {
     })
   })
 
+  it('refreshes the requested owner when duplicate repo ids span focused hosts', async () => {
+    const store = createTestStore()
+    const remoteWorktree = makeWorktree({
+      id: 'same-repo::/remote/wt',
+      repoId: 'same-repo',
+      path: '/remote/wt',
+      hostId: 'local'
+    })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-owner-qualified-refresh',
+      ok: true,
+      result: makeDetectedResult('same-repo', [remoteWorktree]),
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: null } as never,
+      repos: [
+        {
+          id: 'same-repo',
+          path: '/repos/local',
+          displayName: 'Local',
+          badgeColor: '#000',
+          addedAt: 0
+        },
+        {
+          id: 'same-repo',
+          path: '/repos/remote',
+          displayName: 'Remote',
+          badgeColor: '#111',
+          addedAt: 1,
+          executionHostId: 'runtime:env-1'
+        }
+      ]
+    } as Partial<AppState>)
+
+    await store.getState().fetchWorktrees('same-repo', { ownerHostId: 'runtime:env-1' })
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'worktree.detectedList',
+      params: { repo: 'same-repo' },
+      timeoutMs: 15_000
+    })
+    expect(mockApi.worktrees.listDetected).not.toHaveBeenCalled()
+    expect(store.getState().worktreesByRepo['same-repo']).toEqual([
+      { ...remoteWorktree, hostId: 'runtime:env-1' }
+    ])
+  })
+
+  it('does not fall back to local when the requested owner disappears before refresh', async () => {
+    const store = createTestStore()
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-owner-removed',
+      ok: true,
+      result: makeDetectedResult('same-repo', []),
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    store.setState({
+      repos: [
+        {
+          id: 'same-repo',
+          path: '/repos/local',
+          displayName: 'Local',
+          badgeColor: '#000',
+          addedAt: 0
+        }
+      ]
+    } as Partial<AppState>)
+
+    await store.getState().fetchWorktrees('same-repo', { ownerHostId: 'runtime:env-1' })
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith(
+      expect.objectContaining({ selector: 'env-1', method: 'worktree.detectedList' })
+    )
+    expect(mockApi.worktrees.listDetected).not.toHaveBeenCalled()
+  })
+
   it('bounds concurrent repo scans during hydration-time refresh', async () => {
     const store = createTestStore()
     const repos = Array.from({ length: WORKTREE_REFRESH_CONCURRENCY + 2 }, (_, index) => ({

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -359,7 +359,10 @@ function repoHostId(
   repoId: string,
   hostId?: ExecutionHostId | null
 ): ExecutionHostId {
-  const repo = findRepoForHost(state.repos, repoId, { hostId, settings: state.settings })
+  if (hostId) {
+    return hostId
+  }
+  const repo = findRepoForHost(state.repos, repoId, { settings: state.settings })
   return repo ? getRepoExecutionHostId(repo) : LOCAL_EXECUTION_HOST_ID
 }
 
@@ -2282,10 +2285,12 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     try {
       const ownerState = get()
       const requestStartedWorktrees = ownerState.worktreesByRepo[repoId]
-      const hostId = repoHostId(ownerState, repoId)
+      const hostId = repoHostId(ownerState, repoId, options?.ownerHostId)
       const ownerWasMissingAtStart = !ownerState.repos.some((repo) => repo.id === repoId)
       const setup = getProjectHostSetupForRepoHost(ownerState, repoId, hostId)
-      const settings = settingsForRepoOwner(ownerState, repoId, hostId)
+      const settings = options?.ownerHostId
+        ? settingsForExecutionHostOwner(ownerState.settings, hostId)
+        : settingsForRepoOwner(ownerState, repoId, hostId)
       const detected = await listDetectedWorktreesForRepoCoalesced(settings, repoId, {
         executionHostId: hostId,
         requireAuthoritative: options?.requireAuthoritative


### PR DESCRIPTION
## Context

Part of #9783 (follow-up from the #6030/#6031 supersession review; core multi-host state model landed in #6136). Same-id repos can legitimately exist on several execution hosts, and legacy projected setups reuse repo ids. Bare `repoId` or `setupId` lookups can therefore refresh, merge, or create on the wrong host.

This PR covers the renderer-side gaps (2–4). Gap 1 (`projectHostSetup` update/delete routing) still needs client/server host-perspective work and remains separate.

## Changed

- **Host-qualified refreshes:** `fetchWorktrees` accepts an explicit owner host and preserves it through runtime project refreshes, runtime change/activation events, SSH snapshot preparation, and SSH reconnects. Explicit owners remain authoritative if the repo catalog changes during an in-flight refresh.
- **Cross-host event isolation:** the worktree refresh queue keys by host and repo, so same-id events from two runtimes neither coalesce nor block each other.
- **SSH snapshot scoping:** snapshot merge, disconnect cleanup, and reconnect retry include only rows owned by the target SSH host. Legacy hostless rows are accepted only when the repo has one unambiguous owner.
- **Workspace creation:** target resolution pairs setups with repos by host plus repo id, preserves the resolved setup identity through composer state, and makes colliding legacy setup ids independently selectable in the Run on picker.
- **Option integrity:** host setup options require a matching repo on the same host; a same-id sibling repo can no longer make a stale setup appear runnable.
- **Performance:** refresh concurrency and per-host request coalescing remain bounded. Added host qualification is linear over already-enumerated repo/setup collections and constant-time on event queue operations.

## Review fixes added

The deeper review caught cases the first commit did not cover:

- runtime events fetched the correct repo catalog but then refreshed whichever host was focused;
- same-id runtime events were deduplicated across hosts;
- SSH snapshot preparation and reconnect refreshes were still host-blind;
- workspace resolution selected the correct setup but paired it with the wrong repo object;
- the composer discarded host identity after reducing the selection to a bare repo id;
- duplicate legacy setup ids produced duplicate UI keys/values and could not select the second host;
- explicit owner refreshes could fall back to local after an owner disappeared.

## Validation

Post-merge with current `main`:

- 7 affected Vitest files, **380/380 tests passing**
- `pnpm run typecheck:web`
- Oxlint on all 15 changed files
- `pnpm run check:max-lines-ratchet`
- `git diff --check`

A full-suite run during review completed 33,495 passing tests; its failures were unrelated local Node 26 / optional-native-package environment failures. The repository targets Node 24.

Credit: this lookup class was identified by @prateek in the #6030/#6031 stack.