### PR TITLE
fix(sidebar): keep branch-discovered PR status visible on worktree cards

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.merged-pr-display.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.merged-pr-display.test.tsx
@@ -1,6 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 import type {
   GlobalSettings,
   PRInfo,
@@ -125,6 +126,21 @@ function makePRInfo(overrides: Partial<PRInfo> = {}): PRInfo {
   }
 }
 
+function makeHostedReviewInfo(overrides: Partial<HostedReviewInfo> = {}): HostedReviewInfo {
+  return {
+    provider: 'github',
+    number: 6340,
+    title: 'Merged PR still checked out',
+    state: 'merged',
+    url: 'https://github.com/acme/orca/pull/6340',
+    status: 'success',
+    updatedAt: '2026-05-17T00:00:00.000Z',
+    mergeable: 'MERGEABLE',
+    headSha: 'abc123',
+    ...overrides
+  }
+}
+
 function renderWorktreeCardMarkup(element: ReactNode): string {
   return renderToStaticMarkup(<>{element}</>)
 }
@@ -186,5 +202,54 @@ describe('WorktreeCard merged PR fallback display', () => {
 
     expect(markup).not.toContain('Linked PR #6340')
     expect(markup).not.toContain('Merged PR no longer checked out')
+  })
+
+  it('does not let branch provenance resurrect a merged review after the worktree head moved', async () => {
+    hostedReviewCache = {
+      'local::repo-1::feature/local-branch': {
+        data: makeHostedReviewInfo({ title: 'Stale proven merged PR', headSha: 'old-head' }),
+        fetchedAt: 200,
+        linkedReviewHintKey: 'github:6340',
+        branchLookupGitHubPRNumber: 6340
+      }
+    }
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ linkedPR: null, head: 'new-head' })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expect(markup).not.toContain('Linked PR #6340')
+    expect(markup).not.toContain('Stale proven merged PR')
+  })
+
+  it('keeps proven merged review visible when the worktree head is a confirmed PR commit', async () => {
+    hostedReviewCache = {
+      'local::repo-1::feature/local-branch': {
+        data: makeHostedReviewInfo({
+          title: 'Confirmed proven merged PR',
+          headSha: 'final-head',
+          confirmedContainedHeadOid: 'behind-head'
+        }),
+        fetchedAt: 200,
+        linkedReviewHintKey: 'github:6340',
+        branchLookupGitHubPRNumber: 6340
+      }
+    }
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    const markup = renderWorktreeCardMarkup(
+      <WorktreeCard
+        worktree={makeWorktree({ linkedPR: null, head: 'behind-head' })}
+        repo={makeRepo()}
+        isActive={false}
+      />
+    )
+
+    expect(markup).toContain('Linked PR #6340')
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.pr-display.test.tsx
@@ -265,6 +265,12 @@ describe('WorktreeCard linked PR display', () => {
         linkedReviewHintKey: 'github:456'
       }
     }
+    prCache = {
+      'repo-1::feature/local-branch': {
+        data: makePRInfo({ number: 456, title: 'Stale branch PR' }),
+        fetchedAt: Date.now()
+      }
+    }
     const { default: WorktreeCard } = await import('./WorktreeCard')
 
     const markup = renderWorktreeCardMarkup(
@@ -285,7 +291,14 @@ describe('WorktreeCard linked PR display', () => {
       'local::repo-1::feature/local-branch': {
         data: makeHostedReview({ number: 456, title: 'Branch PR', state: 'open' }),
         fetchedAt: Date.now(),
-        linkedReviewHintKey: ''
+        linkedReviewHintKey: 'github:456',
+        branchLookupGitHubPRNumber: 456
+      }
+    }
+    prCache = {
+      'repo-1::feature/local-branch': {
+        data: makePRInfo({ number: 456, title: 'Branch PR' }),
+        fetchedAt: Date.now()
       }
     }
     const { default: WorktreeCard } = await import('./WorktreeCard')

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -498,7 +498,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
         (useCachedBranchReview || cachedMergedBranchPRMatchesCurrentHead) && !hasLinkedReview
           ? ''
           : hostedReviewEntry?.linkedReviewHintKey,
-      branchLookupGitHubPRNumber: cachedBranchFallbackGitHubPRNumber
+      branchLookupGitHubPRNumber: hostedReviewEntry?.branchLookupGitHubPRNumber
     }
   )
   const issue: IssueInfo | null | undefined = worktree.linkedIssue

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -486,6 +486,13 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const cachedBranchReview = useCachedBranchReview
     ? hostedReviewInfoFromGitHubPRInfo(cachedBranchPR)
     : hostedReview
+  // Why: branch provenance does not supersede the head-ownership gate for merged PRs.
+  const branchLookupGitHubPRNumber =
+    hostedReview?.provider === 'github' &&
+    hostedReview.state === 'merged' &&
+    !isCachedMergedBranchPRCurrentForWorktree(hostedReview, worktree)
+      ? null
+      : hostedReviewEntry?.branchLookupGitHubPRNumber
   const prDisplay = getWorktreeCardPrDisplay(
     cachedBranchReview,
     linkedGitHubPR,
@@ -498,7 +505,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
         (useCachedBranchReview || cachedMergedBranchPRMatchesCurrentHead) && !hasLinkedReview
           ? ''
           : hostedReviewEntry?.linkedReviewHintKey,
-      branchLookupGitHubPRNumber: hostedReviewEntry?.branchLookupGitHubPRNumber
+      branchLookupGitHubPRNumber
     }
   )
   const issue: IssueInfo | null | undefined = worktree.linkedIssue

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -497,7 +497,8 @@ const WorktreeCard = React.memo(function WorktreeCard({
       reviewHintKey:
         (useCachedBranchReview || cachedMergedBranchPRMatchesCurrentHead) && !hasLinkedReview
           ? ''
-          : hostedReviewEntry?.linkedReviewHintKey
+          : hostedReviewEntry?.linkedReviewHintKey,
+      branchLookupGitHubPRNumber: cachedBranchFallbackGitHubPRNumber
     }
   )
   const issue: IssueInfo | null | undefined = worktree.linkedIssue

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.test.ts
@@ -72,6 +72,33 @@ describe('getWorktreeCardPrDisplay', () => {
     ).toBeNull()
   })
 
+  it('keeps an unlinked GitHub PR visible when the branch PR cache names the same PR', () => {
+    expect(
+      getWorktreeCardPrDisplay(pr, null, null, null, null, null, {
+        reviewHintKey: 'github:123',
+        branchLookupGitHubPRNumber: 123
+      })
+    ).toBe(pr)
+  })
+
+  it('still suppresses unlinked linked-lookup details when the branch PR cache names a different PR', () => {
+    expect(
+      getWorktreeCardPrDisplay(pr, null, null, null, null, null, {
+        reviewHintKey: 'github:123',
+        branchLookupGitHubPRNumber: 999
+      })
+    ).toBeNull()
+  })
+
+  it('does not let a GitHub branch PR number corroborate an unlinked GitLab MR', () => {
+    expect(
+      getWorktreeCardPrDisplay(gitLabReview, null, null, null, null, null, {
+        reviewHintKey: 'gitlab:321',
+        branchLookupGitHubPRNumber: 321
+      })
+    ).toBeNull()
+  })
+
   it('shows branch-discovered GitHub PR details when the worktree is unlinked', () => {
     expect(
       getWorktreeCardPrDisplay(pr, null, null, null, null, null, {

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.test.ts
@@ -72,7 +72,7 @@ describe('getWorktreeCardPrDisplay', () => {
     ).toBeNull()
   })
 
-  it('keeps an unlinked GitHub PR visible when the branch PR cache names the same PR', () => {
+  it('keeps an unlinked GitHub PR visible when branch provenance names the same PR', () => {
     expect(
       getWorktreeCardPrDisplay(pr, null, null, null, null, null, {
         reviewHintKey: 'github:123',
@@ -81,7 +81,7 @@ describe('getWorktreeCardPrDisplay', () => {
     ).toBe(pr)
   })
 
-  it('still suppresses unlinked linked-lookup details when the branch PR cache names a different PR', () => {
+  it('still suppresses unlinked linked-lookup details when branch provenance names a different PR', () => {
     expect(
       getWorktreeCardPrDisplay(pr, null, null, null, null, null, {
         reviewHintKey: 'github:123',
@@ -95,6 +95,15 @@ describe('getWorktreeCardPrDisplay', () => {
       getWorktreeCardPrDisplay(gitLabReview, null, null, null, null, null, {
         reviewHintKey: 'gitlab:321',
         branchLookupGitHubPRNumber: 321
+      })
+    ).toBeNull()
+  })
+
+  it('does not let branch provenance override linked non-GitHub review metadata', () => {
+    expect(
+      getWorktreeCardPrDisplay(pr, null, 321, null, null, null, {
+        reviewHintKey: 'gitlab:321',
+        branchLookupGitHubPRNumber: 123
       })
     ).toBeNull()
   })

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
@@ -40,7 +40,7 @@ export type WorktreeCardPrDisplay =
 
 type WorktreeCardPrDisplayOptions = {
   reviewHintKey?: string
-  /** GitHub PR number the branch-keyed PR cache attributes to this branch. */
+  /** GitHub PR number proven by a branch-scoped lookup. */
   branchLookupGitHubPRNumber?: number | null
 }
 
@@ -93,6 +93,12 @@ export function getWorktreeCardPrDisplay(
     linkedAzureDevOpsPR,
     linkedGiteaPR
   }
+  const hasLinkedReview =
+    linkedPR !== null ||
+    linkedGitLabMR !== null ||
+    linkedBitbucketPR !== null ||
+    linkedAzureDevOpsPR !== null ||
+    linkedGiteaPR !== null
   if (review) {
     if (review.provider === 'unsupported') {
       return review
@@ -102,10 +108,9 @@ export function getWorktreeCardPrDisplay(
       if (review.provider !== 'github' && review.provider !== 'gitlab') {
         return review
       }
-      // Why: PR-fetch mirror writes stamp a linked-style hint on branch-discovered
-      // reviews; a branch-keyed PR cache naming the same PR proves it belongs to
-      // this branch, so keep it visible like the checks panel does.
+      // Why: GitHub refreshes retain a linked-style request hint; trust only the separately recorded branch-lookup provenance.
       if (
+        !hasLinkedReview &&
         review.provider === 'github' &&
         options.branchLookupGitHubPRNumber != null &&
         options.branchLookupGitHubPRNumber === review.number

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
@@ -40,6 +40,8 @@ export type WorktreeCardPrDisplay =
 
 type WorktreeCardPrDisplayOptions = {
   reviewHintKey?: string
+  /** GitHub PR number the branch-keyed PR cache attributes to this branch. */
+  branchLookupGitHubPRNumber?: number | null
 }
 
 function getLinkedReviewNumber(
@@ -98,6 +100,16 @@ export function getWorktreeCardPrDisplay(
     const linkedReviewNumber = getLinkedReviewNumber(review.provider, links)
     if (linkedReviewNumber === null) {
       if (review.provider !== 'github' && review.provider !== 'gitlab') {
+        return review
+      }
+      // Why: PR-fetch mirror writes stamp a linked-style hint on branch-discovered
+      // reviews; a branch-keyed PR cache naming the same PR proves it belongs to
+      // this branch, so keep it visible like the checks panel does.
+      if (
+        review.provider === 'github' &&
+        options.branchLookupGitHubPRNumber != null &&
+        options.branchLookupGitHubPRNumber === review.number
+      ) {
         return review
       }
       // Why: GitHub/GitLab linked lookups can outlive the worktree metadata

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
@@ -4,7 +4,7 @@ import type { PRInfo, Worktree } from '../../../../shared/types'
 type LinkedReviewMetadataProvider = Exclude<HostedReviewInfo['provider'], 'unsupported'>
 
 export function isCachedMergedBranchPRCurrentForWorktree(
-  cachedPR: PRInfo | null | undefined,
+  cachedPR: PRInfo | HostedReviewInfo | null | undefined,
   worktree: Pick<Worktree, 'head'>
 ): boolean {
   return (

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -1883,9 +1883,36 @@ describe('createGitHubSlice.fetchPRForBranch', () => {
     await expect(request).resolves.toMatchObject({ title: 'Local request result' })
     expect(store.getState().hostedReviewCache[localHostedReviewCacheKey]).toMatchObject({
       data: expect.objectContaining({ provider: 'github', title: 'Local request result' }),
-      linkedReviewHintKey: 'github:12'
+      linkedReviewHintKey: 'github:12',
+      branchLookupGitHubPRNumber: 12
     })
     expect(store.getState().hostedReviewCache[runtimeHostedReviewCacheKey]).toBeUndefined()
+  })
+
+  it('does not mark an exact linked PR refresh as branch-discovered', async () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-1'
+    const branch = 'feature/exact-linked-provenance'
+    const hostedReviewCacheKey = getHostedReviewCacheKey(repoPath, branch, null, repoId)
+    store.setState({
+      repos: [{ id: repoId, path: repoPath, name: 'repo', kind: 'git' }]
+    } as unknown as Partial<AppState>)
+    mockApi.gh.refreshPRNow.mockResolvedValueOnce({
+      kind: 'found',
+      pr: makePR({ number: 12 }),
+      fetchedAt: 2
+    })
+
+    await store.getState().fetchPRForBranch(repoPath, branch, {
+      force: true,
+      repoId,
+      linkedPRNumber: 12
+    })
+
+    expect(store.getState().hostedReviewCache[hostedReviewCacheKey]).toEqual(
+      expect.not.objectContaining({ branchLookupGitHubPRNumber: expect.anything() })
+    )
   })
 
   it('does not let an older direct PR refresh overwrite a newer hosted-review cache entry', async () => {

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -1910,9 +1910,12 @@ describe('createGitHubSlice.fetchPRForBranch', () => {
       linkedPRNumber: 12
     })
 
-    expect(store.getState().hostedReviewCache[hostedReviewCacheKey]).toEqual(
-      expect.not.objectContaining({ branchLookupGitHubPRNumber: expect.anything() })
-    )
+    const cacheEntry = store.getState().hostedReviewCache[hostedReviewCacheKey]
+    expect(cacheEntry).toMatchObject({
+      data: expect.objectContaining({ provider: 'github', number: 12 }),
+      linkedReviewHintKey: 'github:12'
+    })
+    expect(cacheEntry).not.toHaveProperty('branchLookupGitHubPRNumber')
   })
 
   it('does not let an older direct PR refresh overwrite a newer hosted-review cache entry', async () => {

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -1333,6 +1333,15 @@ function syncHostedReviewCacheFromGitHubPRResult(args: {
   if (!args.pr && !shouldClearHostedReviewForNoGitHubPR(hostedReviewEntry)) {
     return { cache: args.cache, accepted: hostedReviewEntry?.data == null }
   }
+  // Why: hosted-review fallbacks may be stale exact links; inherit branch provenance only when already proven.
+  const branchLookupGitHubPRNumber =
+    args.pr &&
+    args.linkedPRNumber == null &&
+    (args.fallbackPRSource !== 'hosted-review' ||
+      args.pr.number !== args.fallbackPRNumber ||
+      hostedReviewEntry?.branchLookupGitHubPRNumber === args.pr.number)
+      ? args.pr.number
+      : undefined
   return {
     cache: {
       ...args.cache,
@@ -1341,7 +1350,8 @@ function syncHostedReviewCacheFromGitHubPRResult(args: {
         fetchedAt: args.fetchedAt,
         linkedReviewHintKey: args.pr
           ? linkedReviewHintKey({ linkedGitHubPR: args.pr.number })
-          : linkedReviewHintKeyForNoGitHubPR(hostedReviewEntry)
+          : linkedReviewHintKeyForNoGitHubPR(hostedReviewEntry),
+        ...(branchLookupGitHubPRNumber !== undefined ? { branchLookupGitHubPRNumber } : {})
       }
     },
     accepted: true

--- a/src/renderer/src/store/slices/hosted-review.test.ts
+++ b/src/renderer/src/store/slices/hosted-review.test.ts
@@ -64,6 +64,17 @@ const review: HostedReviewInfo = {
   mergeable: 'MERGEABLE'
 }
 
+const githubReview: HostedReviewInfo = {
+  provider: 'github',
+  number: 12,
+  title: 'Branch PR',
+  state: 'open',
+  url: 'https://github.com/acme/orca/pull/12',
+  status: 'success',
+  updatedAt: '2026-05-10T00:00:00.000Z',
+  mergeable: 'MERGEABLE'
+}
+
 describe('hosted review slice', () => {
   beforeEach(() => {
     mockApi.hostedReview.forBranch.mockReset()
@@ -99,6 +110,36 @@ describe('hosted review slice', () => {
       linkedBitbucketPR: null,
       linkedAzureDevOpsPR: null,
       linkedGiteaPR: null
+    })
+  })
+
+  it('records branch provenance separately from a GitHub fallback request hint', async () => {
+    mockApi.hostedReview.forBranch.mockResolvedValueOnce(githubReview)
+    const store = makeStore()
+
+    await store.getState().fetchHostedReviewForBranch('/repo', 'feature/github', {
+      fallbackGitHubPR: 12
+    })
+
+    expect(store.getState().hostedReviewCache['local::repo-1::feature/github']).toMatchObject({
+      data: githubReview,
+      linkedReviewHintKey: 'github:12',
+      branchLookupGitHubPRNumber: 12
+    })
+  })
+
+  it('does not mark an exact linked GitHub lookup as branch-discovered', async () => {
+    mockApi.hostedReview.forBranch.mockResolvedValueOnce(githubReview)
+    const store = makeStore()
+
+    await store.getState().fetchHostedReviewForBranch('/repo', 'feature/github', {
+      linkedGitHubPR: 12
+    })
+
+    expect(store.getState().hostedReviewCache['local::repo-1::feature/github']).toEqual({
+      data: githubReview,
+      fetchedAt: expect.any(Number),
+      linkedReviewHintKey: 'github:12'
     })
   })
 

--- a/src/renderer/src/store/slices/hosted-review.ts
+++ b/src/renderer/src/store/slices/hosted-review.ts
@@ -21,7 +21,12 @@ import { getRepoExecutionHostId, parseExecutionHostId } from '../../../../shared
 
 export { getHostedReviewCacheKey, linkedReviewHintKey } from './hosted-review-cache-identity'
 
-type CacheEntry<T> = { data: T | null; fetchedAt: number; linkedReviewHintKey?: string }
+type CacheEntry<T> = {
+  data: T | null
+  fetchedAt: number
+  linkedReviewHintKey?: string
+  branchLookupGitHubPRNumber?: number
+}
 type FetchOptions = {
   force?: boolean
   repoId?: string
@@ -448,7 +453,16 @@ export const createHostedReviewSlice: StateCreator<AppState, [], [], HostedRevie
                 hostedReviewCache: withHostedReviewCacheEntry(state.hostedReviewCache, cacheKey, {
                   data: review,
                   fetchedAt: Date.now(),
-                  linkedReviewHintKey: hintKey
+                  linkedReviewHintKey: hintKey,
+                  // Why: fallback PR hints come from this branch's PR cache; preserve that provenance separately from request identity.
+                  ...(review?.provider === 'github' &&
+                  options?.linkedGitHubPR == null &&
+                  options?.linkedGitLabMR == null &&
+                  options?.linkedBitbucketPR == null &&
+                  options?.linkedAzureDevOpsPR == null &&
+                  options?.linkedGiteaPR == null
+                    ? { branchLookupGitHubPRNumber: review.number }
+                    : {})
                 })
               }
             })


### PR DESCRIPTION
## Problem

The left sidebar status lane and right checks panel disagree for an unlinked worktree whose branch has an open GitHub PR. The checks panel renders the branch-keyed PR cache, while the sidebar suppresses the mirrored hosted-review entry because GitHub refreshes retain a linked-style request hint.

## Root cause

The request hint serves two roles: request identity/provider scoping and display provenance. A GitHub branch refresh can therefore look like a stale exact-linked lookup even though the PR was discovered for the current branch.

## Fix

Record branch-lookup provenance on the bounded hosted-review cache entry when either the provider-neutral lookup or GitHub refresh proves the PR belongs to the branch. WorktreeCard trusts that provenance only when:

- the cached review is GitHub,
- the provenance number matches the review number, and
- no durable review metadata is linked for any provider.

Exact linked lookups never receive branch provenance. Hosted-review fallbacks inherit it only when the prior entry already proved it, so unlinking cannot resurrect stale PR details. The linked-style request hint remains unchanged, preserving provider-scoped refetch and inflight dedupe behavior.

## Performance

The change adds one optional number to a cache already capped at 500 entries and constant-time comparisons on existing cache write/render paths. It adds no I/O, polling, provider fanout, scans, subscriptions, or timers.

## Review findings

- Reviewed the prior PR-display work and its regression history, including linked/unlinked review behavior, merged-PR head ownership, checks-panel selection, cache refreshes, and provider precedence.
- Found and fixed a stale-status regression: branch provenance could otherwise keep showing a cached merged PR after the worktree advanced beyond that PR's head. Merged reviews now retain the existing exact/confirmed-contained head guard.
- Strengthened the exact-linked refresh test after CodeRabbit correctly noted that the provenance assertion could pass vacuously without proving the cache write occurred.
- Reviewed all CodeRabbit feedback. The actionable thread is resolved, and the latest review has no remaining actionable findings.
- No additional performance-sensitive paths, provider fanout, or render-wide subscriptions were introduced.

## Testing

- 474 focused and adjacent tests pass across sidebar display, merged-PR guards, hosted-review cache races, GitHub refreshes, checks selection, parent review rows, and provider precedence.
- 174 GitHub store tests pass after strengthening the exact-linked cache-write assertion.
- Full GitHub verification passes, including the complete test suite, app build, and packaged CLI smoke test.
- Web typecheck, changed-file oxlint, oxfmt, and max-lines ratchet pass.
- Live-tested with disposable [demo-project PR #28](https://github.com/stablyai/demo-project/pull/28) in an isolated Orca dev profile:
  - an unlinked worktree discovered the open PR by branch;
  - sidebar status matched the Checks pane's failing check state;
  - the state survived an app restart/warm cache;
  - the exact merged PR head retained the merged indicator; and
  - advancing the worktree to a new commit immediately removed the stale merged indicator.
