### PR TITLE
fix(mobile): stop reporting delivered chat messages as "Message not sent"

### DIFF
--- a/mobile/src/session/mobile-native-chat-send.test.ts
+++ b/mobile/src/session/mobile-native-chat-send.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { RpcClient } from '../transport/rpc-client'
-import { sendMobileNativeChatMessage } from './mobile-native-chat-send'
+import { markRpcDeliveryUnknown } from '../transport/rpc-delivery-ambiguity'
+import {
+  sendMobileNativeChatMessage,
+  sendMobileNativeChatMessageWithOutcome
+} from './mobile-native-chat-send'
 
 function clientWithResponse(response: unknown): RpcClient {
   return {
@@ -54,6 +58,54 @@ describe('sendMobileNativeChatMessage', () => {
     await expect(
       sendMobileNativeChatMessage({ client, terminal: 'term', text: 'hello' })
     ).resolves.toBe(false)
+  })
+
+  it('reports a definite rejection when the RPC failed before the frame was written', async () => {
+    const client = {
+      sendRequest: vi.fn().mockRejectedValue(new Error('Connection interrupted'))
+    } as unknown as RpcClient
+
+    await expect(
+      sendMobileNativeChatMessageWithOutcome({ client, terminal: 'term', text: 'hello' })
+    ).resolves.toBe('rejected')
+  })
+
+  it('reports an unknown outcome when the RPC failed after the frame hit the wire', async () => {
+    const client = {
+      sendRequest: vi
+        .fn()
+        .mockRejectedValue(markRpcDeliveryUnknown(new Error('Connection interrupted')))
+    } as unknown as RpcClient
+
+    await expect(
+      sendMobileNativeChatMessageWithOutcome({ client, terminal: 'term', text: 'hello' })
+    ).resolves.toBe('unknown')
+    // The boolean wrapper still treats unknown as not-accepted.
+    await expect(
+      sendMobileNativeChatMessage({ client, terminal: 'term', text: 'hello' })
+    ).resolves.toBe(false)
+  })
+
+  it('reports acceptance and host rejection as definite outcomes', async () => {
+    const accepted = clientWithResponse({
+      id: 'request',
+      ok: true,
+      result: { send: { accepted: true } },
+      _meta: { runtimeId: 'runtime' }
+    })
+    await expect(
+      sendMobileNativeChatMessageWithOutcome({ client: accepted, terminal: 'term', text: 'hi' })
+    ).resolves.toBe('accepted')
+
+    const rejected = clientWithResponse({
+      id: 'request',
+      ok: false,
+      error: { message: 'no pane' },
+      _meta: { runtimeId: 'runtime' }
+    })
+    await expect(
+      sendMobileNativeChatMessageWithOutcome({ client: rejected, terminal: 'term', text: 'hi' })
+    ).resolves.toBe('rejected')
   })
 
   it('sends a single non-submitting Escape for prompt cancellation', async () => {

--- a/mobile/src/session/mobile-native-chat-send.ts
+++ b/mobile/src/session/mobile-native-chat-send.ts
@@ -1,4 +1,5 @@
 import type { RpcClient } from '../transport/rpc-client'
+import { isRpcDeliveryUnknown } from '../transport/rpc-delivery-ambiguity'
 import { isTerminalSendRpcAccepted } from '../terminal/terminal-send-rpc-response'
 
 type MobileTerminalClient = {
@@ -6,13 +7,22 @@ type MobileTerminalClient = {
   type: 'mobile'
 }
 
-export async function sendMobileNativeChatMessage(args: {
+type MobileNativeChatSendArgs = {
   client: RpcClient
   terminal: string
   text: string
   enter?: boolean
   mobileClient?: MobileTerminalClient
-}): Promise<boolean> {
+}
+
+/** 'unknown' = the RPC failed after the request hit the wire (relay drop or
+ *  response timeout) — the desktop may have delivered the text and only the ack
+ *  was lost, so callers must not present it as a definite send failure. */
+export type MobileNativeChatSendOutcome = 'accepted' | 'rejected' | 'unknown'
+
+export async function sendMobileNativeChatMessageWithOutcome(
+  args: MobileNativeChatSendArgs
+): Promise<MobileNativeChatSendOutcome> {
   try {
     const response = await args.client.sendRequest('terminal.send', {
       terminal: args.terminal,
@@ -20,8 +30,14 @@ export async function sendMobileNativeChatMessage(args: {
       enter: args.enter ?? true,
       ...(args.mobileClient ? { client: args.mobileClient } : {})
     })
-    return isTerminalSendRpcAccepted(response)
-  } catch {
-    return false
+    return isTerminalSendRpcAccepted(response) ? 'accepted' : 'rejected'
+  } catch (error) {
+    return isRpcDeliveryUnknown(error) ? 'unknown' : 'rejected'
   }
+}
+
+export async function sendMobileNativeChatMessage(
+  args: MobileNativeChatSendArgs
+): Promise<boolean> {
+  return (await sendMobileNativeChatMessageWithOutcome(args)) === 'accepted'
 }

--- a/mobile/src/session/use-mobile-native-chat-controller.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.ts
@@ -239,7 +239,9 @@ export function useMobileNativeChatController(args: {
       if (outcome === 'unknown') {
         // Why: an ack-lost send usually WAS delivered (issue seen on cellular
         // relay) — verify via the transcript echo instead of a false "not sent".
-        holdUnconfirmedSend(origin, text, () => onSendError('Message not sent'))
+        holdUnconfirmedSend(origin, text, () =>
+          onSendError('Delivery unconfirmed — check chat before retrying')
+        )
         return true
       }
       if (outcome === 'rejected') {

--- a/mobile/src/session/use-mobile-native-chat-controller.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.ts
@@ -17,7 +17,10 @@ import { detectAgentPermission } from './mobile-native-chat-permission'
 import { parseAgentQuestion } from './mobile-native-chat-question'
 import { openMobileNativeChatFile } from './mobile-native-chat-open-file'
 import { useMobileNativeChatPermissionSend } from './mobile-native-chat-permission-send'
-import { sendMobileNativeChatMessage } from './mobile-native-chat-send'
+import {
+  sendMobileNativeChatMessage,
+  sendMobileNativeChatMessageWithOutcome
+} from './mobile-native-chat-send'
 import { useMobileNativeChatAnswerSend } from './use-mobile-native-chat-answer-send'
 import { useMobileNativeChatDrafts } from './use-mobile-native-chat-drafts'
 import { useMobileNativeChatFileSearch } from './use-mobile-native-chat-file-search'
@@ -110,7 +113,8 @@ export function useMobileNativeChatController(args: {
     setComposerText: setChatComposerText,
     pending: chatPending,
     captureSendOrigin,
-    acceptSend
+    acceptSend,
+    holdUnconfirmedSend
   } = useMobileNativeChatDrafts({
     hostId,
     worktreeId,
@@ -224,7 +228,7 @@ export function useMobileNativeChatController(args: {
         onSendError('Message not sent (disconnected)')
         return false
       }
-      const accepted = await sendMobileNativeChatMessage({
+      const outcome = await sendMobileNativeChatMessageWithOutcome({
         client,
         terminal: handle,
         text,
@@ -232,7 +236,13 @@ export function useMobileNativeChatController(args: {
           ? { mobileClient: { id: deviceTokenRef.current, type: 'mobile' } }
           : {})
       })
-      if (!accepted) {
+      if (outcome === 'unknown') {
+        // Why: an ack-lost send usually WAS delivered (issue seen on cellular
+        // relay) — verify via the transcript echo instead of a false "not sent".
+        holdUnconfirmedSend(origin, text, () => onSendError('Message not sent'))
+        return true
+      }
+      if (outcome === 'rejected') {
         onSendError('Message not sent')
         return false
       }
@@ -245,6 +255,7 @@ export function useMobileNativeChatController(args: {
       captureSendOrigin,
       client,
       deviceTokenRef,
+      holdUnconfirmedSend,
       nativeChatInputLeaseReady,
       onSendError
     ]

--- a/mobile/src/session/use-mobile-native-chat-drafts.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts.test.ts
@@ -285,6 +285,93 @@ describe('useMobileNativeChatDrafts', () => {
     }
   })
 
+  it('does not confirm an unconfirmed send when pagination prepends an older identical turn', async () => {
+    vi.useFakeTimers()
+    try {
+      await mount('a')
+      const anchor = assistantTextMessage('anchor', 'working')
+      await act(async () =>
+        renderer?.update(createElement(Harness, { tabId: 'a', messages: [anchor] }))
+      )
+      act(() => state?.setComposerText('ping'))
+      const origin = state?.captureSendOrigin('ping')
+      const onUnconfirmed = vi.fn()
+      act(() => {
+        if (origin) {
+          state?.holdUnconfirmedSend(origin, 'ping', onUnconfirmed)
+        }
+      })
+
+      await act(async () =>
+        renderer?.update(
+          createElement(Harness, {
+            tabId: 'a',
+            messages: [userTextMessage('older', 'ping'), anchor]
+          })
+        )
+      )
+      expect(state?.composerText).toBe('ping')
+
+      act(() => vi.advanceTimersByTime(30_000))
+      expect(onUnconfirmed).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('requires one new transcript echo per repeated unconfirmed send', async () => {
+    vi.useFakeTimers()
+    try {
+      await mount('a')
+      act(() => state?.setComposerText('ping'))
+      const origin = state?.captureSendOrigin('ping')
+      const firstUnconfirmed = vi.fn()
+      const secondUnconfirmed = vi.fn()
+      act(() => {
+        if (origin) {
+          state?.holdUnconfirmedSend(origin, 'ping', firstUnconfirmed)
+          state?.holdUnconfirmedSend(origin, 'ping', secondUnconfirmed)
+        }
+      })
+
+      await act(async () =>
+        renderer?.update(
+          createElement(Harness, { tabId: 'a', messages: [userTextMessage('echo-1', 'ping')] })
+        )
+      )
+      act(() => vi.advanceTimersByTime(30_000))
+
+      expect(firstUnconfirmed).not.toHaveBeenCalled()
+      expect(secondUnconfirmed).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not retain a deadline when an ambiguous send settles after unmount', async () => {
+    vi.useFakeTimers()
+    try {
+      await mount('a')
+      const origin = state?.captureSendOrigin('ping')
+      const holdUnconfirmedSend = state?.holdUnconfirmedSend
+      const onUnconfirmed = vi.fn()
+      act(() => renderer?.unmount())
+      renderer = null
+
+      act(() => {
+        if (origin) {
+          holdUnconfirmedSend?.(origin, 'ping', onUnconfirmed)
+        }
+      })
+
+      expect(vi.getTimerCount()).toBe(0)
+      act(() => vi.advanceTimersByTime(30_000))
+      expect(onUnconfirmed).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('does not erase newer edits when an unconfirmed send lands', async () => {
     await mount('a')
     act(() => state?.setComposerText('submitted'))

--- a/mobile/src/session/use-mobile-native-chat-drafts.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts.test.ts
@@ -179,10 +179,10 @@ describe('useMobileNativeChatDrafts', () => {
       await mount('a')
       act(() => state?.setComposerText('ping'))
       const origin = state?.captureSendOrigin('ping')
-      const onLost = vi.fn()
+      const onUnconfirmed = vi.fn()
       act(() => {
         if (origin) {
-          state?.holdUnconfirmedSend(origin, 'ping', onLost)
+          state?.holdUnconfirmedSend(origin, 'ping', onUnconfirmed)
         }
       })
       expect(state?.composerText).toBe('ping')
@@ -195,27 +195,55 @@ describe('useMobileNativeChatDrafts', () => {
       expect(state?.composerText).toBe('')
 
       act(() => vi.advanceTimersByTime(30_000))
-      expect(onLost).not.toHaveBeenCalled()
+      expect(onUnconfirmed).not.toHaveBeenCalled()
     } finally {
       vi.useRealTimers()
     }
   })
 
-  it('reports a loss and keeps the draft when no echo lands before the deadline', async () => {
+  it('clears immediately when the transcript echo beat the ambiguous RPC rejection', async () => {
     vi.useFakeTimers()
     try {
       await mount('a')
       act(() => state?.setComposerText('ping'))
       const origin = state?.captureSendOrigin('ping')
-      const onLost = vi.fn()
+      const onUnconfirmed = vi.fn()
+
+      await act(async () =>
+        renderer?.update(
+          createElement(Harness, { tabId: 'a', messages: [userTextMessage('m1', 'ping')] })
+        )
+      )
       act(() => {
         if (origin) {
-          state?.holdUnconfirmedSend(origin, 'ping', onLost)
+          state?.holdUnconfirmedSend(origin, 'ping', onUnconfirmed)
+        }
+      })
+
+      expect(state?.composerText).toBe('')
+      expect(vi.getTimerCount()).toBe(0)
+      act(() => vi.advanceTimersByTime(30_000))
+      expect(onUnconfirmed).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('surfaces uncertainty and keeps the draft when no echo lands before the deadline', async () => {
+    vi.useFakeTimers()
+    try {
+      await mount('a')
+      act(() => state?.setComposerText('ping'))
+      const origin = state?.captureSendOrigin('ping')
+      const onUnconfirmed = vi.fn()
+      act(() => {
+        if (origin) {
+          state?.holdUnconfirmedSend(origin, 'ping', onUnconfirmed)
         }
       })
 
       act(() => vi.advanceTimersByTime(30_000))
-      expect(onLost).toHaveBeenCalledTimes(1)
+      expect(onUnconfirmed).toHaveBeenCalledTimes(1)
       expect(state?.composerText).toBe('ping')
     } finally {
       vi.useRealTimers()
@@ -233,10 +261,10 @@ describe('useMobileNativeChatDrafts', () => {
       )
       act(() => state?.setComposerText('ping'))
       const origin = state?.captureSendOrigin('ping')
-      const onLost = vi.fn()
+      const onUnconfirmed = vi.fn()
       act(() => {
         if (origin) {
-          state?.holdUnconfirmedSend(origin, 'ping', onLost)
+          state?.holdUnconfirmedSend(origin, 'ping', onUnconfirmed)
         }
       })
 
@@ -251,7 +279,7 @@ describe('useMobileNativeChatDrafts', () => {
       expect(state?.composerText).toBe('ping')
 
       act(() => vi.advanceTimersByTime(30_000))
-      expect(onLost).toHaveBeenCalledTimes(1)
+      expect(onUnconfirmed).toHaveBeenCalledTimes(1)
     } finally {
       vi.useRealTimers()
     }
@@ -274,6 +302,37 @@ describe('useMobileNativeChatDrafts', () => {
       )
     )
     expect(state?.composerText).toBe('new edit')
+  })
+
+  it('does not confirm an old session send from an identical turn in its replacement', async () => {
+    vi.useFakeTimers()
+    try {
+      await mount('a')
+      act(() => state?.setComposerText('ping'))
+      const origin = state?.captureSendOrigin('ping')
+      const onUnconfirmed = vi.fn()
+      act(() => {
+        if (origin) {
+          state?.holdUnconfirmedSend(origin, 'ping', onUnconfirmed)
+        }
+      })
+
+      await act(async () =>
+        renderer?.update(
+          createElement(Harness, {
+            tabId: 'a',
+            sessionId: 'replacement',
+            messages: [userTextMessage('replacement-message', 'ping')]
+          })
+        )
+      )
+
+      expect(state?.composerText).toBe('ping')
+      act(() => vi.advanceTimersByTime(30_000))
+      expect(onUnconfirmed).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('accepts and clears the first send before a provider session id exists', async () => {

--- a/mobile/src/session/use-mobile-native-chat-drafts.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts.test.ts
@@ -242,7 +242,9 @@ describe('useMobileNativeChatDrafts', () => {
         }
       })
 
-      act(() => vi.advanceTimersByTime(30_000))
+      act(() => vi.advanceTimersByTime(19_999))
+      expect(onUnconfirmed).not.toHaveBeenCalled()
+      act(() => vi.advanceTimersByTime(1))
       expect(onUnconfirmed).toHaveBeenCalledTimes(1)
       expect(state?.composerText).toBe('ping')
     } finally {

--- a/mobile/src/session/use-mobile-native-chat-drafts.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts.test.ts
@@ -173,6 +173,109 @@ describe('useMobileNativeChatDrafts', () => {
     expect(state?.composerText).toBe('new edit')
   })
 
+  it('clears the draft when an unconfirmed send lands in the transcript', async () => {
+    vi.useFakeTimers()
+    try {
+      await mount('a')
+      act(() => state?.setComposerText('ping'))
+      const origin = state?.captureSendOrigin('ping')
+      const onLost = vi.fn()
+      act(() => {
+        if (origin) {
+          state?.holdUnconfirmedSend(origin, 'ping', onLost)
+        }
+      })
+      expect(state?.composerText).toBe('ping')
+
+      await act(async () =>
+        renderer?.update(
+          createElement(Harness, { tabId: 'a', messages: [userTextMessage('m1', 'ping')] })
+        )
+      )
+      expect(state?.composerText).toBe('')
+
+      act(() => vi.advanceTimersByTime(30_000))
+      expect(onLost).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('reports a loss and keeps the draft when no echo lands before the deadline', async () => {
+    vi.useFakeTimers()
+    try {
+      await mount('a')
+      act(() => state?.setComposerText('ping'))
+      const origin = state?.captureSendOrigin('ping')
+      const onLost = vi.fn()
+      act(() => {
+        if (origin) {
+          state?.holdUnconfirmedSend(origin, 'ping', onLost)
+        }
+      })
+
+      act(() => vi.advanceTimersByTime(30_000))
+      expect(onLost).toHaveBeenCalledTimes(1)
+      expect(state?.composerText).toBe('ping')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not confirm an unconfirmed send against an older identical turn', async () => {
+    vi.useFakeTimers()
+    try {
+      await mount('a')
+      await act(async () =>
+        renderer?.update(
+          createElement(Harness, { tabId: 'a', messages: [userTextMessage('old', 'ping')] })
+        )
+      )
+      act(() => state?.setComposerText('ping'))
+      const origin = state?.captureSendOrigin('ping')
+      const onLost = vi.fn()
+      act(() => {
+        if (origin) {
+          state?.holdUnconfirmedSend(origin, 'ping', onLost)
+        }
+      })
+
+      await act(async () =>
+        renderer?.update(
+          createElement(Harness, {
+            tabId: 'a',
+            messages: [userTextMessage('old', 'ping'), assistantTextMessage('other', 'working')]
+          })
+        )
+      )
+      expect(state?.composerText).toBe('ping')
+
+      act(() => vi.advanceTimersByTime(30_000))
+      expect(onLost).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not erase newer edits when an unconfirmed send lands', async () => {
+    await mount('a')
+    act(() => state?.setComposerText('submitted'))
+    const origin = state?.captureSendOrigin('submitted')
+    act(() => {
+      if (origin) {
+        state?.holdUnconfirmedSend(origin, 'submitted', vi.fn())
+      }
+    })
+    act(() => state?.setComposerText('new edit'))
+
+    await act(async () =>
+      renderer?.update(
+        createElement(Harness, { tabId: 'a', messages: [userTextMessage('m1', 'submitted')] })
+      )
+    )
+    expect(state?.composerText).toBe('new edit')
+  })
+
   it('accepts and clears the first send before a provider session id exists', async () => {
     await mount('a')
     await act(async () => renderer?.update(createElement(Harness, { tabId: 'a', sessionId: null })))

--- a/mobile/src/session/use-mobile-native-chat-drafts.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts.ts
@@ -15,6 +15,18 @@ export type MobileNativeChatSendOrigin = {
 
 const NO_PENDING_MESSAGES: MobileNativeChatPendingMessage[] = []
 
+// How long an ack-lost send may wait for its transcript echo before it is
+// reported as a failure. Covers a relay reconnect plus the transcript resync.
+const UNCONFIRMED_SEND_DEADLINE_MS = 20_000
+
+type UnconfirmedSend = {
+  draftKey: string
+  text: string
+  normalizedText: string
+  expectedOccurrence: number
+  deadline: ReturnType<typeof setTimeout>
+}
+
 function normalizedUserText(message: NativeChatMessage): string | null {
   if (message.role !== 'user') {
     return null
@@ -49,6 +61,11 @@ export function useMobileNativeChatDrafts(args: {
   pending: MobileNativeChatPendingMessage[]
   captureSendOrigin: (text: string) => MobileNativeChatSendOrigin | null
   acceptSend: (origin: MobileNativeChatSendOrigin, text: string) => void
+  holdUnconfirmedSend: (
+    origin: MobileNativeChatSendOrigin,
+    text: string,
+    onLost: () => void
+  ) => void
 } {
   const { hostId, worktreeId, tabId, sessionId, messages } = args
   const draftKey = tabId ? `${hostId}\0${worktreeId}\0${tabId}` : null
@@ -122,6 +139,67 @@ export function useMobileNativeChatDrafts(args: {
     })
   }, [])
 
+  // Why: a relay drop mid-send loses only the ack in the common case — the
+  // desktop already delivered the message. Hold the send instead of claiming
+  // failure (which baits a duplicate): clear the draft when the transcript echo
+  // lands, and only report a loss if the deadline passes without one.
+  const unconfirmedRef = useRef<UnconfirmedSend[]>([])
+  const holdUnconfirmedSend = useCallback(
+    (origin: MobileNativeChatSendOrigin, text: string, onLost: () => void) => {
+      const earlierOutstanding = unconfirmedRef.current.filter(
+        (entry) =>
+          entry.draftKey === origin.draftKey &&
+          entry.normalizedText === origin.normalizedText &&
+          entry.expectedOccurrence > origin.baselineOccurrences
+      ).length
+      const entry: UnconfirmedSend = {
+        draftKey: origin.draftKey,
+        text,
+        normalizedText: origin.normalizedText,
+        expectedOccurrence: origin.baselineOccurrences + earlierOutstanding + 1,
+        deadline: setTimeout(() => {
+          unconfirmedRef.current = unconfirmedRef.current.filter((held) => held !== entry)
+          onLost()
+        }, UNCONFIRMED_SEND_DEADLINE_MS)
+      }
+      unconfirmedRef.current = [...unconfirmedRef.current, entry]
+    },
+    []
+  )
+
+  useEffect(() => {
+    if (!draftKey || unconfirmedRef.current.length === 0) {
+      return
+    }
+    const landed = unconfirmedRef.current.filter(
+      (entry) =>
+        entry.draftKey === draftKey &&
+        countUserTextOccurrences(messages, entry.normalizedText) >= entry.expectedOccurrence
+    )
+    if (landed.length === 0) {
+      return
+    }
+    unconfirmedRef.current = unconfirmedRef.current.filter((entry) => !landed.includes(entry))
+    for (const entry of landed) {
+      clearTimeout(entry.deadline)
+      // Same guard as acceptSend: never erase edits typed after the send began.
+      setDrafts((previous) =>
+        (previous[entry.draftKey] ?? '').trim() === entry.text.trim()
+          ? { ...previous, [entry.draftKey]: '' }
+          : previous
+      )
+    }
+  }, [messages, draftKey])
+
+  useEffect(
+    () => () => {
+      for (const entry of unconfirmedRef.current) {
+        clearTimeout(entry.deadline)
+      }
+    },
+    []
+  )
+
   const pending = pendingKey
     ? (pendingBySession[pendingKey] ?? NO_PENDING_MESSAGES)
     : NO_PENDING_MESSAGES
@@ -160,6 +238,7 @@ export function useMobileNativeChatDrafts(args: {
     setComposerText,
     pending,
     captureSendOrigin,
-    acceptSend
+    acceptSend,
+    holdUnconfirmedSend
   }
 }

--- a/mobile/src/session/use-mobile-native-chat-drafts.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts.ts
@@ -11,6 +11,7 @@ export type MobileNativeChatSendOrigin = {
   pendingKey: string | null
   normalizedText: string
   baselineOccurrences: number
+  baselineTailMessageId: string | null
 }
 
 const NO_PENDING_MESSAGES: MobileNativeChatPendingMessage[] = []
@@ -24,8 +25,8 @@ type UnconfirmedSend = {
   pendingKey: string | null
   text: string
   normalizedText: string
-  expectedOccurrence: number
-  deadline: ReturnType<typeof setTimeout>
+  baselineTailMessageId: string | null
+  deadline: ReturnType<typeof setTimeout> | null
 }
 
 function normalizedUserText(message: NativeChatMessage): string | null {
@@ -48,6 +49,43 @@ function countUserTextOccurrences(messages: readonly NativeChatMessage[], text: 
     }
   }
   return count
+}
+
+function findLandedUnconfirmedSends(
+  messages: readonly NativeChatMessage[],
+  entries: readonly UnconfirmedSend[]
+): UnconfirmedSend[] {
+  // Why: pagination prepends old equal text; only unclaimed matches after each captured tail prove new echoes.
+  const messageIndexById = new Map<string, number>()
+  const userMessagesByText = new Map<string, Array<{ id: string; index: number }>>()
+  for (const [index, message] of messages.entries()) {
+    messageIndexById.set(message.id, index)
+    const text = normalizedUserText(message)
+    if (text) {
+      const current = userMessagesByText.get(text) ?? []
+      current.push({ id: message.id, index })
+      userMessagesByText.set(text, current)
+    }
+  }
+
+  const claimedMessageIds = new Set<string>()
+  const landed: UnconfirmedSend[] = []
+  for (const entry of entries) {
+    const tailIndex = entry.baselineTailMessageId
+      ? messageIndexById.get(entry.baselineTailMessageId)
+      : -1
+    if (tailIndex === undefined) {
+      continue
+    }
+    const echo = userMessagesByText
+      .get(entry.normalizedText)
+      ?.find((message) => message.index > tailIndex && !claimedMessageIds.has(message.id))
+    if (echo) {
+      claimedMessageIds.add(echo.id)
+      landed.push(entry)
+    }
+  }
+  return landed
 }
 
 export function useMobileNativeChatDrafts(args: {
@@ -82,6 +120,7 @@ export function useMobileNativeChatDrafts(args: {
   activeDraftKeyRef.current = draftKey
   const activePendingKeyRef = useRef(pendingKey)
   activePendingKeyRef.current = pendingKey
+  const mountedRef = useRef(false)
 
   const setComposerText: Dispatch<SetStateAction<string>> = useCallback(
     (value) => {
@@ -103,11 +142,13 @@ export function useMobileNativeChatDrafts(args: {
         return null
       }
       const normalizedText = text.trim()
+      const currentMessages = messagesRef.current
       return {
         draftKey,
         pendingKey,
         normalizedText,
-        baselineOccurrences: countUserTextOccurrences(messagesRef.current, normalizedText)
+        baselineOccurrences: countUserTextOccurrences(currentMessages, normalizedText),
+        baselineTailMessageId: currentMessages[currentMessages.length - 1]?.id ?? null
       }
     },
     [draftKey, pendingKey]
@@ -151,21 +192,24 @@ export function useMobileNativeChatDrafts(args: {
   const unconfirmedRef = useRef<UnconfirmedSend[]>([])
   const holdUnconfirmedSend = useCallback(
     (origin: MobileNativeChatSendOrigin, text: string, onUnconfirmed: () => void) => {
-      const earlierOutstanding = unconfirmedRef.current.filter(
-        (entry) =>
-          entry.draftKey === origin.draftKey &&
-          entry.pendingKey === origin.pendingKey &&
-          entry.normalizedText === origin.normalizedText &&
-          entry.expectedOccurrence > origin.baselineOccurrences
-      ).length
-      const expectedOccurrence = origin.baselineOccurrences + earlierOutstanding + 1
+      if (!mountedRef.current) {
+        return
+      }
       const isActiveTranscript =
         activeDraftKeyRef.current === origin.draftKey &&
         (origin.pendingKey === null || activePendingKeyRef.current === origin.pendingKey)
+      const entry: UnconfirmedSend = {
+        draftKey: origin.draftKey,
+        pendingKey: origin.pendingKey,
+        text,
+        normalizedText: origin.normalizedText,
+        baselineTailMessageId: origin.baselineTailMessageId,
+        deadline: null
+      }
       // Why: the transcript event can beat the lost RPC acknowledgement.
       if (
         isActiveTranscript &&
-        countUserTextOccurrences(messagesRef.current, origin.normalizedText) >= expectedOccurrence
+        findLandedUnconfirmedSends(messagesRef.current, [entry]).length > 0
       ) {
         setDrafts((previous) =>
           (previous[origin.draftKey] ?? '').trim() === text.trim()
@@ -174,17 +218,10 @@ export function useMobileNativeChatDrafts(args: {
         )
         return
       }
-      const entry: UnconfirmedSend = {
-        draftKey: origin.draftKey,
-        pendingKey: origin.pendingKey,
-        text,
-        normalizedText: origin.normalizedText,
-        expectedOccurrence,
-        deadline: setTimeout(() => {
-          unconfirmedRef.current = unconfirmedRef.current.filter((held) => held !== entry)
-          onUnconfirmed()
-        }, UNCONFIRMED_SEND_DEADLINE_MS)
-      }
+      entry.deadline = setTimeout(() => {
+        unconfirmedRef.current = unconfirmedRef.current.filter((held) => held !== entry)
+        onUnconfirmed()
+      }, UNCONFIRMED_SEND_DEADLINE_MS)
       unconfirmedRef.current = [...unconfirmedRef.current, entry]
     },
     []
@@ -194,18 +231,21 @@ export function useMobileNativeChatDrafts(args: {
     if (!draftKey || unconfirmedRef.current.length === 0) {
       return
     }
-    const landed = unconfirmedRef.current.filter(
+    const relevant = unconfirmedRef.current.filter(
       (entry) =>
         entry.draftKey === draftKey &&
-        (entry.pendingKey === null || entry.pendingKey === pendingKey) &&
-        countUserTextOccurrences(messages, entry.normalizedText) >= entry.expectedOccurrence
+        (entry.pendingKey === null || entry.pendingKey === pendingKey)
     )
+    const landed = findLandedUnconfirmedSends(messages, relevant)
     if (landed.length === 0) {
       return
     }
-    unconfirmedRef.current = unconfirmedRef.current.filter((entry) => !landed.includes(entry))
+    const landedSet = new Set(landed)
+    unconfirmedRef.current = unconfirmedRef.current.filter((entry) => !landedSet.has(entry))
     for (const entry of landed) {
-      clearTimeout(entry.deadline)
+      if (entry.deadline !== null) {
+        clearTimeout(entry.deadline)
+      }
       // Same guard as acceptSend: never erase edits typed after the send began.
       setDrafts((previous) =>
         (previous[entry.draftKey] ?? '').trim() === entry.text.trim()
@@ -215,14 +255,18 @@ export function useMobileNativeChatDrafts(args: {
     }
   }, [messages, draftKey, pendingKey])
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
       for (const entry of unconfirmedRef.current) {
-        clearTimeout(entry.deadline)
+        if (entry.deadline !== null) {
+          clearTimeout(entry.deadline)
+        }
       }
-    },
-    []
-  )
+      unconfirmedRef.current = []
+    }
+  }, [])
 
   const pending = pendingKey
     ? (pendingBySession[pendingKey] ?? NO_PENDING_MESSAGES)

--- a/mobile/src/session/use-mobile-native-chat-drafts.ts
+++ b/mobile/src/session/use-mobile-native-chat-drafts.ts
@@ -15,12 +15,13 @@ export type MobileNativeChatSendOrigin = {
 
 const NO_PENDING_MESSAGES: MobileNativeChatPendingMessage[] = []
 
-// How long an ack-lost send may wait for its transcript echo before it is
-// reported as a failure. Covers a relay reconnect plus the transcript resync.
+// How long an ack-lost send waits for its transcript echo before the UI surfaces
+// that delivery remains unconfirmed.
 const UNCONFIRMED_SEND_DEADLINE_MS = 20_000
 
 type UnconfirmedSend = {
   draftKey: string
+  pendingKey: string | null
   text: string
   normalizedText: string
   expectedOccurrence: number
@@ -64,7 +65,7 @@ export function useMobileNativeChatDrafts(args: {
   holdUnconfirmedSend: (
     origin: MobileNativeChatSendOrigin,
     text: string,
-    onLost: () => void
+    onUnconfirmed: () => void
   ) => void
 } {
   const { hostId, worktreeId, tabId, sessionId, messages } = args
@@ -77,6 +78,10 @@ export function useMobileNativeChatDrafts(args: {
   const pendingCounterRef = useRef(0)
   const messagesRef = useRef(messages)
   messagesRef.current = messages
+  const activeDraftKeyRef = useRef(draftKey)
+  activeDraftKeyRef.current = draftKey
+  const activePendingKeyRef = useRef(pendingKey)
+  activePendingKeyRef.current = pendingKey
 
   const setComposerText: Dispatch<SetStateAction<string>> = useCallback(
     (value) => {
@@ -142,24 +147,42 @@ export function useMobileNativeChatDrafts(args: {
   // Why: a relay drop mid-send loses only the ack in the common case — the
   // desktop already delivered the message. Hold the send instead of claiming
   // failure (which baits a duplicate): clear the draft when the transcript echo
-  // lands, and only report a loss if the deadline passes without one.
+  // lands, and surface the uncertainty if the deadline passes without one.
   const unconfirmedRef = useRef<UnconfirmedSend[]>([])
   const holdUnconfirmedSend = useCallback(
-    (origin: MobileNativeChatSendOrigin, text: string, onLost: () => void) => {
+    (origin: MobileNativeChatSendOrigin, text: string, onUnconfirmed: () => void) => {
       const earlierOutstanding = unconfirmedRef.current.filter(
         (entry) =>
           entry.draftKey === origin.draftKey &&
+          entry.pendingKey === origin.pendingKey &&
           entry.normalizedText === origin.normalizedText &&
           entry.expectedOccurrence > origin.baselineOccurrences
       ).length
+      const expectedOccurrence = origin.baselineOccurrences + earlierOutstanding + 1
+      const isActiveTranscript =
+        activeDraftKeyRef.current === origin.draftKey &&
+        (origin.pendingKey === null || activePendingKeyRef.current === origin.pendingKey)
+      // Why: the transcript event can beat the lost RPC acknowledgement.
+      if (
+        isActiveTranscript &&
+        countUserTextOccurrences(messagesRef.current, origin.normalizedText) >= expectedOccurrence
+      ) {
+        setDrafts((previous) =>
+          (previous[origin.draftKey] ?? '').trim() === text.trim()
+            ? { ...previous, [origin.draftKey]: '' }
+            : previous
+        )
+        return
+      }
       const entry: UnconfirmedSend = {
         draftKey: origin.draftKey,
+        pendingKey: origin.pendingKey,
         text,
         normalizedText: origin.normalizedText,
-        expectedOccurrence: origin.baselineOccurrences + earlierOutstanding + 1,
+        expectedOccurrence,
         deadline: setTimeout(() => {
           unconfirmedRef.current = unconfirmedRef.current.filter((held) => held !== entry)
-          onLost()
+          onUnconfirmed()
         }, UNCONFIRMED_SEND_DEADLINE_MS)
       }
       unconfirmedRef.current = [...unconfirmedRef.current, entry]
@@ -174,6 +197,7 @@ export function useMobileNativeChatDrafts(args: {
     const landed = unconfirmedRef.current.filter(
       (entry) =>
         entry.draftKey === draftKey &&
+        (entry.pendingKey === null || entry.pendingKey === pendingKey) &&
         countUserTextOccurrences(messages, entry.normalizedText) >= entry.expectedOccurrence
     )
     if (landed.length === 0) {
@@ -189,7 +213,7 @@ export function useMobileNativeChatDrafts(args: {
           : previous
       )
     }
-  }, [messages, draftKey])
+  }, [messages, draftKey, pendingKey])
 
   useEffect(
     () => () => {

--- a/mobile/src/transport/rpc-client-delivery-ambiguity.test.ts
+++ b/mobile/src/transport/rpc-client-delivery-ambiguity.test.ts
@@ -31,7 +31,6 @@ class MockWebSocket {
   sent: string[] = []
   close = vi.fn(() => {
     this.readyState = MockWebSocket.CLOSED
-    this.onclose?.()
   })
 
   constructor(readonly endpoint: string) {
@@ -49,6 +48,11 @@ class MockWebSocket {
 
   receive(payload: unknown): void {
     this.onmessage?.({ data: payload })
+  }
+
+  drop(): void {
+    this.close()
+    this.onclose?.()
   }
 }
 
@@ -95,12 +99,28 @@ describe('mobile rpc-client delivery ambiguity marking', () => {
     await Promise.resolve()
     expect(hasSentRequest(socket, 'terminal.send')).toBe(true)
 
-    socket.close()
+    socket.drop()
 
     const error = await requestError
     expect(error).toMatchObject({ message: 'Connection interrupted' })
     expect(isRpcDeliveryUnknown(error)).toBe(true)
     client.close()
+  })
+
+  it('marks an in-flight request when the client closes before its response arrives', async () => {
+    const { client, socket } = connectAuthenticated()
+    const requestError = client.sendRequest('terminal.send', { terminal: 't' }).then(
+      () => null,
+      (error: Error) => error
+    )
+    await Promise.resolve()
+    expect(hasSentRequest(socket, 'terminal.send')).toBe(true)
+
+    client.close()
+
+    const error = await requestError
+    expect(error).toMatchObject({ message: 'Client closed' })
+    expect(isRpcDeliveryUnknown(error)).toBe(true)
   })
 
   it('marks timed-out requests as delivery-unknown', async () => {

--- a/mobile/src/transport/rpc-client-delivery-ambiguity.test.ts
+++ b/mobile/src/transport/rpc-client-delivery-ambiguity.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { connect } from './rpc-client'
+import { isRpcDeliveryUnknown } from './rpc-delivery-ambiguity'
+
+vi.mock('./e2ee', () => ({
+  generateKeyPair: () => ({
+    publicKey: new Uint8Array(32),
+    secretKey: new Uint8Array(32)
+  }),
+  deriveSharedKey: () => new Uint8Array(32),
+  publicKeyFromBase64: () => new Uint8Array(32),
+  publicKeyToBase64: () => 'client-public-key',
+  encrypt: (plaintext: string) => `encrypted:${plaintext}`,
+  decrypt: (raw: string) => raw.replace(/^encrypted:/, ''),
+  decryptBytes: (bytes: Uint8Array) => bytes
+}))
+
+class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSED = 3
+
+  readonly CONNECTING = MockWebSocket.CONNECTING
+  readonly OPEN = MockWebSocket.OPEN
+  readonly CLOSED = MockWebSocket.CLOSED
+
+  readyState = MockWebSocket.CONNECTING
+  onopen: (() => void) | null = null
+  onclose: (() => void) | null = null
+  onmessage: ((event: { data: unknown }) => void) | null = null
+  sent: string[] = []
+  close = vi.fn(() => {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.()
+  })
+
+  constructor(readonly endpoint: string) {
+    mockSockets.push(this)
+  }
+
+  send(payload: string): void {
+    this.sent.push(payload)
+  }
+
+  open(): void {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.()
+  }
+
+  receive(payload: unknown): void {
+    this.onmessage?.({ data: payload })
+  }
+}
+
+const mockSockets: MockWebSocket[] = []
+const originalWebSocket = globalThis.WebSocket
+
+function hasSentRequest(socket: MockWebSocket, method: string): boolean {
+  return socket.sent.some(
+    (payload) =>
+      (JSON.parse(payload.replace(/^encrypted:/, '')) as { method: string }).method === method
+  )
+}
+
+function connectAuthenticated(): { client: ReturnType<typeof connect>; socket: MockWebSocket } {
+  const client = connect('ws://desktop.invalid', 'token', 'server-key')
+  const socket = mockSockets[0]!
+  socket.open()
+  socket.receive(JSON.stringify({ type: 'e2ee_ready' }))
+  socket.receive('encrypted:{"type":"e2ee_authenticated"}')
+  return { client, socket }
+}
+
+// Callers presenting send failures must be able to tell "the host never got the
+// frame" from "the frame was written and only the response is missing" — the
+// latter must not be reported to the user as a definite failure.
+describe('mobile rpc-client delivery ambiguity marking', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mockSockets.length = 0
+    globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    globalThis.WebSocket = originalWebSocket
+  })
+
+  it('marks in-flight requests as delivery-unknown when the socket drops', async () => {
+    const { client, socket } = connectAuthenticated()
+    const requestError = client.sendRequest('terminal.send', { terminal: 't' }).then(
+      () => null,
+      (error: Error) => error
+    )
+    await Promise.resolve()
+    expect(hasSentRequest(socket, 'terminal.send')).toBe(true)
+
+    socket.close()
+
+    const error = await requestError
+    expect(error).toMatchObject({ message: 'Connection interrupted' })
+    expect(isRpcDeliveryUnknown(error)).toBe(true)
+    client.close()
+  })
+
+  it('marks timed-out requests as delivery-unknown', async () => {
+    const { client, socket } = connectAuthenticated()
+    // Short override so the request times out before the activity probe
+    // declares the whole socket dead (which is the drop case above).
+    const requestError = client
+      .sendRequest('terminal.send', { terminal: 't' }, { timeoutMs: 1_000 })
+      .then(
+        () => null,
+        (error: Error) => error
+      )
+    await Promise.resolve()
+    expect(hasSentRequest(socket, 'terminal.send')).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    const error = await requestError
+    expect(error).toMatchObject({ message: 'Request timed out: terminal.send' })
+    expect(isRpcDeliveryUnknown(error)).toBe(true)
+    client.close()
+  })
+
+  it('does not mark requests whose frame never reached the wire', async () => {
+    const { client, socket } = connectAuthenticated()
+    // Simulate RN dropping onclose: the socket is dead but state is still 'connected'.
+    socket.readyState = MockWebSocket.CLOSED
+
+    const error = await client.sendRequest('terminal.send', { terminal: 't' }).then(
+      () => null,
+      (caught: Error) => caught
+    )
+    expect(error).toMatchObject({ message: 'Connection interrupted' })
+    expect(isRpcDeliveryUnknown(error)).toBe(false)
+    client.close()
+  })
+})

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -1150,7 +1150,8 @@ export function connect(
       }
       sharedKey = null
       setState('disconnected')
-      rejectAllPending('Client closed')
+      // Why: closing the client cannot retract request frames already written.
+      rejectAllPending('Client closed', { deliveryUnknown: true })
     }
   }
 }

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -28,6 +28,7 @@ import {
   updateTerminalSubscriptionViewport as updateCachedTerminalSubscriptionViewport
 } from './rpc-client-terminal-subscription'
 import { describeSocketEvent } from './socket-event-debug'
+import { markRpcDeliveryUnknown } from './rpc-delivery-ambiguity'
 import { isRpcResponse } from './rpc-response-shape'
 import { websocketPayloadToUint8 } from './websocket-payload-bytes'
 
@@ -644,7 +645,7 @@ export function connect(
     if (intentionallyClosed) {
       console.log('[net] handleSocketClosed — intentional close')
       setState('disconnected')
-      rejectAllPending('Connection closed')
+      rejectAllPending('Connection closed', { deliveryUnknown: true })
       return
     }
     console.log('[net] handleSocketClosed → reconnect', {
@@ -654,7 +655,7 @@ export function connect(
       attempt: reconnectAttempt
     })
     emitLog('warn', 'WebSocket closed', 'Will attempt to reconnect')
-    rejectAllPending('Connection interrupted')
+    rejectAllPending('Connection interrupted', { deliveryUnknown: true })
     setState('reconnecting')
     scheduleReconnect()
   }
@@ -788,8 +789,12 @@ export function connect(
     }
   }
 
-  function rejectAllPending(reason: string) {
-    const error = new Error(reason)
+  function rejectAllPending(reason: string, options?: { deliveryUnknown?: boolean }) {
+    // Why: pending entries only exist after a successful socket write, so a close
+    // here means the host may have processed them — mark the ambiguity for callers.
+    const error = options?.deliveryUnknown
+      ? markRpcDeliveryUnknown(new Error(reason))
+      : new Error(reason)
     for (const [id, req] of pending) {
       pending.delete(id)
       queueMicrotask(() => req.reject(error))
@@ -985,7 +990,8 @@ export function connect(
             timeoutMs,
             state
           })
-          reject(new Error(`Request timed out: ${method}`))
+          // Why: the frame was written 30s ago — the host may have processed it.
+          reject(markRpcDeliveryUnknown(new Error(`Request timed out: ${method}`)))
         }, timeoutMs)
 
         pending.set(id, {

--- a/mobile/src/transport/rpc-delivery-ambiguity.ts
+++ b/mobile/src/transport/rpc-delivery-ambiguity.ts
@@ -1,0 +1,15 @@
+// Why: RPCs are at-most-once — a socket drop or response timeout after the
+// request frame was written leaves delivery unknown (the host may have processed
+// it and only the ack was lost), unlike a failure before the frame ever left.
+const deliveryUnknownErrors = new WeakSet<Error>()
+
+export function markRpcDeliveryUnknown<T extends Error>(error: T): T {
+  deliveryUnknownErrors.add(error)
+  return error
+}
+
+/** True when the request reached the wire but the RPC failed before a response
+ *  arrived — callers must not present this as a definite send failure. */
+export function isRpcDeliveryUnknown(error: unknown): boolean {
+  return error instanceof Error && deliveryUnknownErrors.has(error)
+}


### PR DESCRIPTION
## Problem

On the mobile relay (seen on cellular), sending a native-chat message sometimes shows **"Message not sent"** and leaves the text in the composer — while the message actually reached the desktop and shows up in the transcript after resync. Tapping send again then delivers the message twice.

## Root cause

`terminal.send` is at-most-once with an ambiguous failure mode. In `rpc-client.ts`, three distinct failures collapsed into one rejection:

1. The frame never reached the wire (`sendEncrypted` fails) — **definitely not sent**
2. The socket drops with the request in flight (`rejectAllPending('Connection interrupted')`) — **possibly delivered; only the ack may be lost**
3. The response times out — the same ambiguity

The chat send path treated all three as definite failure: error toast + inline banner, draft kept, no `acceptSend`.

## Fix

- **Transport:** mark rejections that happen after the request frame was written (in-flight socket drop, explicit client close, or response timeout) as delivery-unknown. The never-written path stays unmarked.
- **Send helper:** return `accepted | rejected | unknown`. The boolean wrapper delegates, so keystroke surfaces (ask answers, permission responses, Escape) keep their existing behavior.
- **Draft reconciliation:** hold an ack-lost send instead of erroring. If its matching provider-session transcript echo already arrived before the RPC rejection, clear the draft synchronously and allocate no deadline timer. Otherwise, clear only when a new occurrence lands in the same transcript. Older identical turns, replacement-session turns, and newer composer edits cannot confirm or be erased by the held send.
- **Deadline semantics:** after 20 seconds without an echo, keep the draft and report **"Delivery unconfirmed — check chat before retrying"**. Elapsed time does not falsely convert an ambiguous outcome into "Message not sent".

No protocol change — this works against every desktop version and adds no mobile/desktop skew risk.

## Reliability contract

- **Invariant (`mobile-native-chat.delivery-ambiguity`):** a request frame written to the relay is never presented as definitely unsent without a host rejection; only a matching echo from the originating provider session may clear its unchanged draft.
- **Failure source:** the reported cellular relay path where `terminal.send` reached desktop but its acknowledgement did not reach mobile.
- **Oracle:** deterministic socket-drop, timeout, explicit-close, never-written, echo-before-rejection, echo-after-rejection, repeated-text, pagination-prepend, one-echo-per-send, replacement-session, deadline, edit-preservation, and post-unmount cleanup tests.
- **Gate:** accepted manifest gap — `config/reliability-gates.jsonc` has no client RPC delivery-ambiguity gate yet. The focused mobile tests are the executable gate for this PR; the repository reliability manifest validator remains green.
- **Provider/platform coverage:** mobile/relay behavior is covered in the shared TypeScript transport and hook tests. Local, daemon, SSH, WSL, and remote-runtime terminal providers are unaffected because the server protocol, routing, PTY ownership, and provider write paths did not change. iOS and Android share this code; no physical-device cellular run is claimed.
- **Performance budget:** the normal transcript path adds only an O(1) empty-held-send check. An outstanding ambiguous send builds one index over the existing capped transcript (maximum 2,000 messages) only on transcript changes and expires after one 20-second timer. An already-landed echo allocates zero timers, asserted with a deterministic timer-count test. No polling, broad session scans, provider fanout, subprocesses, persistence growth, or output-path work was added.
- **Diagnostics:** existing `[net]` close/timeout logs retain request method, pending count, connection state, and reconnect attempt; focused failures distinguish never-written from delivery-unknown outcomes.
- **Residual gaps:** no live physical iOS/Android cellular fault-injection artifact. A client-generated message id echoed by the host remains the durable way to prove delivery and make retries idempotent.

## Verification

- Mobile suite: **304 files / 2,187 passed / 2 skipped**
- Focused delivery/draft tests: **25 passed**
- Terminal/mobile RPC reliability slice: **85 passed**
- Mobile TypeScript, oxlint, and format checks: passed
- Max-lines ratchet and reliability-gate manifest validators: passed

## Follow-up (out of scope)

Add a client-generated message id echoed through `terminal.send` with host-side deduplication (like `clientMutationId` on `worktree.create`). That would make retries safe and allow automatic resend, but requires desktop and protocol changes. Keystroke surfaces still treat ack-lost as failure because they have no transcript echo to reconcile against and need that id-based approach.

