### PR TITLE
fix(mobile): replay terminal creates killed by transport cutover

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -77,10 +77,13 @@ import { SessionDockColumn } from '../../../../src/session/SessionDockColumn'
 import { MobileSessionHeaderIconButton } from '../../../../src/session/MobileSessionHeaderIconButton'
 import { MobileSessionHeaderMoreActionsSheet } from '../../../../src/session/MobileSessionHeaderMoreActionsSheet'
 import { QuickCommandsSheet } from '../../../../src/session/QuickCommandsSheet'
-import { sendSessionTerminalCreateResilient } from '../../../../src/session/session-terminal-create-retry'
+import {
+  sendSessionTerminalCreateResilient,
+  supportsSessionTerminalCreateCutoverRetry
+} from '../../../../src/session/session-terminal-create-retry'
 import {
   buildMobileQuickCommandLaunch,
-  describeQuickCommandLaunchFailure,
+  formatQuickCommandFailure,
   supportsMobileQuickCommands,
   type MobileQuickCommandLaunch
 } from '../../../../src/terminal/quick-commands'
@@ -1054,6 +1057,7 @@ export default function SessionScreen() {
     null
   )
   const [quickCommandsSupported, setQuickCommandsSupported] = useState<boolean | null>(null)
+  const terminalCreateCutoverRetrySupportedRef = useRef(false)
   // Why: stable callbacks (handleFileTap) read the live value via this ref, since
   // the capability probe resolves after the callbacks are created.
   const browserScreencastSupportedRef = useRef(browserScreencastSupported)
@@ -2309,6 +2313,7 @@ export default function SessionScreen() {
   const hostQueryReplyInputSupportedRef = useRef(false)
 
   useEffect(() => {
+    terminalCreateCutoverRetrySupportedRef.current = false
     if (!client || connState !== 'connected') {
       setBrowserScreencastSupported(null)
       setAgentSessionHistorySupported(null)
@@ -2336,6 +2341,9 @@ export default function SessionScreen() {
           status.capabilities?.includes(MOBILE_AI_VAULT_CAPABILITY) === true
         )
         setQuickCommandsSupported(supportsMobileQuickCommands(status.capabilities))
+        terminalCreateCutoverRetrySupportedRef.current = supportsSessionTerminalCreateCutoverRetry(
+          status.capabilities
+        )
         // Why: hosts without this capability strip inputKind from terminal.send,
         // so a forwarded xterm reply would become floor-stealing shell input.
         hostQueryReplyInputSupportedRef.current =
@@ -3759,9 +3767,7 @@ export default function SessionScreen() {
           select: true,
           navigation: 'caller'
         },
-        // Why: quick-commands support implies the createTerminal mutation-id
-        // dedupe (it shipped earlier), so a cutover replay cannot double-create.
-        { hostDedupesTerminalCreates: quickCommandsSupported === true }
+        { supportsIdempotentCutoverRetry: terminalCreateCutoverRetrySupportedRef.current }
       )
       if (response.ok) {
         const result = (response as RpcSuccess).result as TerminalCreateResult
@@ -3854,10 +3860,7 @@ export default function SessionScreen() {
         }
         scheduleDelayedAction(() => void fetchSessionTabs(), 500)
       } else {
-        const message = describeQuickCommandLaunchFailure(
-          options?.errorToast,
-          (response as RpcFailure).error.message
-        )
+        const message = formatQuickCommandFailure(options?.errorToast, response.error.message)
         setCreateError(message)
         if (options?.errorToast) {
           triggerError()
@@ -3865,7 +3868,7 @@ export default function SessionScreen() {
         }
       }
     } catch (err) {
-      const message = describeQuickCommandLaunchFailure(options?.errorToast, err)
+      const message = formatQuickCommandFailure(options?.errorToast, err)
       setCreateError(message)
       if (options?.errorToast) {
         triggerError()
@@ -3882,7 +3885,6 @@ export default function SessionScreen() {
   // use the host's shell-ready startup path; insert-only commands stay drafts.
   function launchQuickCommand(command: TerminalQuickCommand): boolean {
     if (!client || connState !== 'connected') {
-      // Why: a dead tap here reads as "quick commands are broken"; name the real blocker.
       triggerError()
       showToast('Not connected to desktop — try again in a moment', 1800)
       return false

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -77,8 +77,10 @@ import { SessionDockColumn } from '../../../../src/session/SessionDockColumn'
 import { MobileSessionHeaderIconButton } from '../../../../src/session/MobileSessionHeaderIconButton'
 import { MobileSessionHeaderMoreActionsSheet } from '../../../../src/session/MobileSessionHeaderMoreActionsSheet'
 import { QuickCommandsSheet } from '../../../../src/session/QuickCommandsSheet'
+import { sendSessionTerminalCreateResilient } from '../../../../src/session/session-terminal-create-retry'
 import {
   buildMobileQuickCommandLaunch,
+  describeQuickCommandLaunchFailure,
   supportsMobileQuickCommands,
   type MobileQuickCommandLaunch
 } from '../../../../src/terminal/quick-commands'
@@ -3741,20 +3743,26 @@ export default function SessionScreen() {
       .slice(2, 10)}`
 
     try {
-      const response = await client.sendRequest('session.tabs.createTerminal', {
-        worktree: `id:${worktreeId}`,
-        afterTabId: activeSessionTabId ?? undefined,
-        clientMutationId,
-        ...(options?.startupCommand ? { command: options.startupCommand } : {}),
-        ...(options?.startupCommandDelivery
-          ? { startupCommandDelivery: options.startupCommandDelivery }
-          : {}),
-        ...(options?.agentPrompt ? { agentPrompt: options.agentPrompt } : {}),
-        ...(agent ? { agent } : {}),
-        activate: false,
-        select: true,
-        navigation: 'caller'
-      })
+      const response = await sendSessionTerminalCreateResilient(
+        client,
+        {
+          worktree: `id:${worktreeId}`,
+          afterTabId: activeSessionTabId ?? undefined,
+          clientMutationId,
+          ...(options?.startupCommand ? { command: options.startupCommand } : {}),
+          ...(options?.startupCommandDelivery
+            ? { startupCommandDelivery: options.startupCommandDelivery }
+            : {}),
+          ...(options?.agentPrompt ? { agentPrompt: options.agentPrompt } : {}),
+          ...(agent ? { agent } : {}),
+          activate: false,
+          select: true,
+          navigation: 'caller'
+        },
+        // Why: quick-commands support implies the createTerminal mutation-id
+        // dedupe (it shipped earlier), so a cutover replay cannot double-create.
+        { hostDedupesTerminalCreates: quickCommandsSupported === true }
+      )
       if (response.ok) {
         const result = (response as RpcSuccess).result as TerminalCreateResult
         const created = result.tab
@@ -3846,19 +3854,22 @@ export default function SessionScreen() {
         }
         scheduleDelayedAction(() => void fetchSessionTabs(), 500)
       } else {
-        const message = options?.errorToast ?? 'Failed to create terminal'
+        const message = describeQuickCommandLaunchFailure(
+          options?.errorToast,
+          (response as RpcFailure).error.message
+        )
         setCreateError(message)
         if (options?.errorToast) {
           triggerError()
-          showToast(message, 1800)
+          showToast(message, 2600)
         }
       }
-    } catch {
-      const message = options?.errorToast ?? 'Failed to create terminal'
+    } catch (err) {
+      const message = describeQuickCommandLaunchFailure(options?.errorToast, err)
       setCreateError(message)
       if (options?.errorToast) {
         triggerError()
-        showToast(message, 1800)
+        showToast(message, 2600)
       }
     } finally {
       creatingTerminalRef.current = false
@@ -3870,13 +3881,13 @@ export default function SessionScreen() {
   // run-quick-command-in-new-tab: agent prompts and runnable terminal commands
   // use the host's shell-ready startup path; insert-only commands stay drafts.
   function launchQuickCommand(command: TerminalQuickCommand): boolean {
-    if (
-      !client ||
-      connState !== 'connected' ||
-      creatingTerminalRef.current ||
-      creatingBrowser ||
-      creatingMarkdown
-    ) {
+    if (!client || connState !== 'connected') {
+      // Why: a dead tap here reads as "quick commands are broken"; name the real blocker.
+      triggerError()
+      showToast('Not connected to desktop — try again in a moment', 1800)
+      return false
+    }
+    if (creatingTerminalRef.current || creatingBrowser || creatingMarkdown) {
       return false
     }
     const launch = buildMobileQuickCommandLaunch(command)

--- a/mobile/src/session/session-terminal-create-retry.test.ts
+++ b/mobile/src/session/session-terminal-create-retry.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import type { RpcClient } from '../transport/rpc-client'
+import { LogicalClientCutoverError } from '../transport/stable-logical-rpc-client'
+import { sendSessionTerminalCreateResilient } from './session-terminal-create-retry'
+
+type Attempt = { method: string; params: Record<string, unknown> }
+
+// A client whose per-call outcome is scripted: resolve with a tab or throw
+// (transport-level rejection, e.g. a connection-migration cutover). Records
+// every call so tests can assert the replay reuses the same clientMutationId.
+function scriptedClient(
+  outcomes: Array<{ tabId: string } | { throws: unknown }>,
+  attempts: Attempt[]
+): RpcClient {
+  let call = 0
+  return {
+    sendRequest: async (method: string, params?: unknown) => {
+      attempts.push({ method, params: (params ?? {}) as Record<string, unknown> })
+      const outcome = outcomes[Math.min(call, outcomes.length - 1)]!
+      call += 1
+      if ('throws' in outcome) {
+        throw outcome.throws
+      }
+      return {
+        id: '1',
+        ok: true,
+        result: { tab: { id: outcome.tabId } },
+        _meta: { runtimeId: 'r' }
+      }
+    }
+  } as unknown as RpcClient
+}
+
+const params = { worktree: 'id:w', clientMutationId: 'mobile-create:key', agent: 'codex' }
+
+describe('sendSessionTerminalCreateResilient', () => {
+  it('replays the same params after a connection-migration cutover', async () => {
+    const attempts: Attempt[] = []
+    const client = scriptedClient(
+      [{ throws: new LogicalClientCutoverError() }, { tabId: 'tab-1' }],
+      attempts
+    )
+
+    const response = await sendSessionTerminalCreateResilient(client, params, {
+      hostDedupesTerminalCreates: true
+    })
+
+    expect(response.ok).toBe(true)
+    expect(attempts).toHaveLength(2)
+    expect(attempts.every((attempt) => attempt.method === 'session.tabs.createTerminal')).toBe(true)
+    // The replay must reuse the SAME mutation id so the host dedupes it.
+    expect(attempts[1]!.params.clientMutationId).toBe('mobile-create:key')
+  })
+
+  it('matches cutover errors rethrown as plain Errors', async () => {
+    const attempts: Attempt[] = []
+    const client = scriptedClient(
+      [{ throws: new Error('RPC interrupted by connection migration') }, { tabId: 'tab-1' }],
+      attempts
+    )
+
+    const response = await sendSessionTerminalCreateResilient(client, params, {
+      hostDedupesTerminalCreates: true
+    })
+
+    expect(response.ok).toBe(true)
+    expect(attempts).toHaveLength(2)
+  })
+
+  it('does not replay against hosts without the mutation-id dedupe', async () => {
+    const attempts: Attempt[] = []
+    const client = scriptedClient(
+      [{ throws: new LogicalClientCutoverError() }, { tabId: 'tab-1' }],
+      attempts
+    )
+
+    await expect(
+      sendSessionTerminalCreateResilient(client, params, { hostDedupesTerminalCreates: false })
+    ).rejects.toThrow('RPC interrupted by connection migration')
+    expect(attempts).toHaveLength(1)
+  })
+
+  it('propagates non-cutover transport errors without replaying', async () => {
+    const attempts: Attempt[] = []
+    const client = scriptedClient(
+      [{ throws: new Error('relay RPC timed out: session.tabs.createTerminal') }],
+      attempts
+    )
+
+    await expect(
+      sendSessionTerminalCreateResilient(client, params, { hostDedupesTerminalCreates: true })
+    ).rejects.toThrow('relay RPC timed out')
+    expect(attempts).toHaveLength(1)
+  })
+
+  it('gives up after the bounded replay budget instead of looping forever', async () => {
+    const attempts: Attempt[] = []
+    const client = scriptedClient([{ throws: new LogicalClientCutoverError() }], attempts)
+
+    await expect(
+      sendSessionTerminalCreateResilient(client, params, { hostDedupesTerminalCreates: true })
+    ).rejects.toThrow('RPC interrupted by connection migration')
+    // 1 initial attempt + 5 replays.
+    expect(attempts).toHaveLength(6)
+  })
+})

--- a/mobile/src/session/session-terminal-create-retry.test.ts
+++ b/mobile/src/session/session-terminal-create-retry.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { RpcClient } from '../transport/rpc-client'
 import { LogicalClientCutoverError } from '../transport/stable-logical-rpc-client'
-import { sendSessionTerminalCreateResilient } from './session-terminal-create-retry'
+import {
+  sendSessionTerminalCreateResilient,
+  supportsSessionTerminalCreateCutoverRetry
+} from './session-terminal-create-retry'
 
 type Attempt = { method: string; params: Record<string, unknown> }
 
@@ -34,6 +37,14 @@ function scriptedClient(
 const params = { worktree: 'id:w', clientMutationId: 'mobile-create:key', agent: 'codex' }
 
 describe('sendSessionTerminalCreateResilient', () => {
+  it('requires the explicit disconnect-safe idempotency capability', () => {
+    expect(supportsSessionTerminalCreateCutoverRetry(undefined)).toBe(false)
+    expect(supportsSessionTerminalCreateCutoverRetry(['terminal.quick-commands.v1'])).toBe(false)
+    expect(
+      supportsSessionTerminalCreateCutoverRetry(['session.tabs.create-terminal-idempotency.v1'])
+    ).toBe(true)
+  })
+
   it('replays the same params after a connection-migration cutover', async () => {
     const attempts: Attempt[] = []
     const client = scriptedClient(
@@ -42,7 +53,7 @@ describe('sendSessionTerminalCreateResilient', () => {
     )
 
     const response = await sendSessionTerminalCreateResilient(client, params, {
-      hostDedupesTerminalCreates: true
+      supportsIdempotentCutoverRetry: true
     })
 
     expect(response.ok).toBe(true)
@@ -60,7 +71,7 @@ describe('sendSessionTerminalCreateResilient', () => {
     )
 
     const response = await sendSessionTerminalCreateResilient(client, params, {
-      hostDedupesTerminalCreates: true
+      supportsIdempotentCutoverRetry: true
     })
 
     expect(response.ok).toBe(true)
@@ -75,7 +86,9 @@ describe('sendSessionTerminalCreateResilient', () => {
     )
 
     await expect(
-      sendSessionTerminalCreateResilient(client, params, { hostDedupesTerminalCreates: false })
+      sendSessionTerminalCreateResilient(client, params, {
+        supportsIdempotentCutoverRetry: false
+      })
     ).rejects.toThrow('RPC interrupted by connection migration')
     expect(attempts).toHaveLength(1)
   })
@@ -88,7 +101,9 @@ describe('sendSessionTerminalCreateResilient', () => {
     )
 
     await expect(
-      sendSessionTerminalCreateResilient(client, params, { hostDedupesTerminalCreates: true })
+      sendSessionTerminalCreateResilient(client, params, {
+        supportsIdempotentCutoverRetry: true
+      })
     ).rejects.toThrow('relay RPC timed out')
     expect(attempts).toHaveLength(1)
   })
@@ -98,7 +113,9 @@ describe('sendSessionTerminalCreateResilient', () => {
     const client = scriptedClient([{ throws: new LogicalClientCutoverError() }], attempts)
 
     await expect(
-      sendSessionTerminalCreateResilient(client, params, { hostDedupesTerminalCreates: true })
+      sendSessionTerminalCreateResilient(client, params, {
+        supportsIdempotentCutoverRetry: true
+      })
     ).rejects.toThrow('RPC interrupted by connection migration')
     // 1 initial attempt + 5 replays.
     expect(attempts).toHaveLength(6)

--- a/mobile/src/session/session-terminal-create-retry.ts
+++ b/mobile/src/session/session-terminal-create-retry.ts
@@ -1,27 +1,35 @@
 import type { RpcClient } from '../transport/rpc-client'
 import type { RpcResponse } from '../transport/types'
 import { isLogicalClientCutoverError } from '../transport/stable-logical-rpc-client'
+import { SESSION_TABS_CREATE_TERMINAL_IDEMPOTENCY_RUNTIME_CAPABILITY } from '../../../src/shared/protocol-version'
+
+export function supportsSessionTerminalCreateCutoverRetry(
+  capabilities: readonly string[] | undefined
+): boolean {
+  return (
+    capabilities?.includes(SESSION_TABS_CREATE_TERMINAL_IDEMPOTENCY_RUNTIME_CAPABILITY) === true
+  )
+}
 
 // Why: a create in flight when the mobile transport migrates (relay→direct
 // hand-off on cellular) rejects client-side with a cutover error even though the
 // host may still complete it — the desktop never logs a trace, the user just
-// sees "Couldn't run <quick command>". The host has deduped
-// session.tabs.createTerminal by clientMutationId since before it advertised
-// terminal.quick-commands.v1, so replaying the same params on the fresh session
-// is idempotent. Mirrors sendWorktreeCreateResilient in tasks/worktree-create-retry.ts.
+// sees "Couldn't run <quick command>". A capability-gated replay of the same
+// mutation joins the host-owned create. Mirrors sendWorktreeCreateResilient in
+// tasks/worktree-create-retry.ts.
 const SESSION_TERMINAL_CREATE_CUTOVER_MAX_RETRIES = 5
 
 export async function sendSessionTerminalCreateResilient(
   client: RpcClient,
   params: Record<string, unknown>,
-  opts: { hostDedupesTerminalCreates: boolean }
+  opts: { supportsIdempotentCutoverRetry: boolean }
 ): Promise<RpcResponse> {
   for (let migrationRetry = 0; ; migrationRetry += 1) {
     try {
       return await client.sendRequest('session.tabs.createTerminal', params)
     } catch (error) {
       if (
-        !opts.hostDedupesTerminalCreates ||
+        !opts.supportsIdempotentCutoverRetry ||
         !isLogicalClientCutoverError(error) ||
         migrationRetry >= SESSION_TERMINAL_CREATE_CUTOVER_MAX_RETRIES
       ) {

--- a/mobile/src/session/session-terminal-create-retry.ts
+++ b/mobile/src/session/session-terminal-create-retry.ts
@@ -1,0 +1,34 @@
+import type { RpcClient } from '../transport/rpc-client'
+import type { RpcResponse } from '../transport/types'
+import { isLogicalClientCutoverError } from '../transport/stable-logical-rpc-client'
+
+// Why: a create in flight when the mobile transport migrates (relay→direct
+// hand-off on cellular) rejects client-side with a cutover error even though the
+// host may still complete it — the desktop never logs a trace, the user just
+// sees "Couldn't run <quick command>". The host has deduped
+// session.tabs.createTerminal by clientMutationId since before it advertised
+// terminal.quick-commands.v1, so replaying the same params on the fresh session
+// is idempotent. Mirrors sendWorktreeCreateResilient in tasks/worktree-create-retry.ts.
+const SESSION_TERMINAL_CREATE_CUTOVER_MAX_RETRIES = 5
+
+export async function sendSessionTerminalCreateResilient(
+  client: RpcClient,
+  params: Record<string, unknown>,
+  opts: { hostDedupesTerminalCreates: boolean }
+): Promise<RpcResponse> {
+  for (let migrationRetry = 0; ; migrationRetry += 1) {
+    try {
+      return await client.sendRequest('session.tabs.createTerminal', params)
+    } catch (error) {
+      if (
+        !opts.hostDedupesTerminalCreates ||
+        !isLogicalClientCutoverError(error) ||
+        migrationRetry >= SESSION_TERMINAL_CREATE_CUTOVER_MAX_RETRIES
+      ) {
+        throw error
+      }
+      // Why: LogicalClientCutoverError is raised only after migrateTo installs an
+      // authenticated replacement session, so retry immediately instead of backing off.
+    }
+  }
+}

--- a/mobile/src/session/session-terminal-create-retry.ts
+++ b/mobile/src/session/session-terminal-create-retry.ts
@@ -21,7 +21,7 @@ const SESSION_TERMINAL_CREATE_CUTOVER_MAX_RETRIES = 5
 
 export async function sendSessionTerminalCreateResilient(
   client: RpcClient,
-  params: Record<string, unknown>,
+  params: Record<string, unknown> & { clientMutationId: string },
   opts: { supportsIdempotentCutoverRetry: boolean }
 ): Promise<RpcResponse> {
   for (let migrationRetry = 0; ; migrationRetry += 1) {

--- a/mobile/src/terminal/quick-commands.test.ts
+++ b/mobile/src/terminal/quick-commands.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { TerminalQuickCommand } from '../../../src/shared/types'
 import {
   buildMobileQuickCommandLaunch,
-  describeQuickCommandLaunchFailure,
+  formatQuickCommandFailure,
   getQuickCommandDisplayPreview,
   getQuickCommandPreview,
   supportsMobileQuickCommands
@@ -89,25 +89,21 @@ describe('mobile quick-command launch', () => {
   })
 
   it('surfaces the underlying failure reason in the launch error message', () => {
+    expect(formatQuickCommandFailure("Couldn't run codex review", 'after_tab_not_found')).toBe(
+      "Couldn't run codex review — after_tab_not_found"
+    )
     expect(
-      describeQuickCommandLaunchFailure("Couldn't run codex review", 'after_tab_not_found')
-    ).toBe("Couldn't run codex review — after_tab_not_found")
-    expect(
-      describeQuickCommandLaunchFailure(
+      formatQuickCommandFailure(
         "Couldn't run codex review",
         new Error('relay RPC timed out: session.tabs.createTerminal')
       )
     ).toBe("Couldn't run codex review — relay RPC timed out: session.tabs.createTerminal")
     // No detail (or a detail equal to the label) keeps the plain label.
-    expect(describeQuickCommandLaunchFailure("Couldn't run codex review", undefined)).toBe(
+    expect(formatQuickCommandFailure("Couldn't run codex review", undefined)).toBe(
       "Couldn't run codex review"
     )
-    expect(describeQuickCommandLaunchFailure("Couldn't run x", "Couldn't run x")).toBe(
-      "Couldn't run x"
-    )
-    expect(describeQuickCommandLaunchFailure(undefined, '  ')).toBe('Failed to create terminal')
-    expect(describeQuickCommandLaunchFailure(undefined, 'boom')).toBe(
-      'Failed to create terminal — boom'
-    )
+    expect(formatQuickCommandFailure("Couldn't run x", "Couldn't run x")).toBe("Couldn't run x")
+    expect(formatQuickCommandFailure(undefined, '  ')).toBe('Failed to create terminal')
+    expect(formatQuickCommandFailure(undefined, 'boom')).toBe('Failed to create terminal — boom')
   })
 })

--- a/mobile/src/terminal/quick-commands.test.ts
+++ b/mobile/src/terminal/quick-commands.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { TerminalQuickCommand } from '../../../src/shared/types'
 import {
   buildMobileQuickCommandLaunch,
+  describeQuickCommandLaunchFailure,
   getQuickCommandDisplayPreview,
   getQuickCommandPreview,
   supportsMobileQuickCommands
@@ -85,5 +86,28 @@ describe('mobile quick-command launch', () => {
       agent: 'codex',
       options: { agentPrompt: longPrompt }
     })
+  })
+
+  it('surfaces the underlying failure reason in the launch error message', () => {
+    expect(
+      describeQuickCommandLaunchFailure("Couldn't run codex review", 'after_tab_not_found')
+    ).toBe("Couldn't run codex review — after_tab_not_found")
+    expect(
+      describeQuickCommandLaunchFailure(
+        "Couldn't run codex review",
+        new Error('relay RPC timed out: session.tabs.createTerminal')
+      )
+    ).toBe("Couldn't run codex review — relay RPC timed out: session.tabs.createTerminal")
+    // No detail (or a detail equal to the label) keeps the plain label.
+    expect(describeQuickCommandLaunchFailure("Couldn't run codex review", undefined)).toBe(
+      "Couldn't run codex review"
+    )
+    expect(describeQuickCommandLaunchFailure("Couldn't run x", "Couldn't run x")).toBe(
+      "Couldn't run x"
+    )
+    expect(describeQuickCommandLaunchFailure(undefined, '  ')).toBe('Failed to create terminal')
+    expect(describeQuickCommandLaunchFailure(undefined, 'boom')).toBe(
+      'Failed to create terminal — boom'
+    )
   })
 })

--- a/mobile/src/terminal/quick-commands.ts
+++ b/mobile/src/terminal/quick-commands.ts
@@ -81,6 +81,18 @@ export function buildMobileQuickCommandLaunch(
       }
 }
 
+// Why: the failure toast used to show only "Couldn't run <label>", masking the
+// real RPC/transport reason and making mobile launch failures undiagnosable.
+export function describeQuickCommandLaunchFailure(
+  fallback: string | undefined,
+  detail: unknown
+): string {
+  const base = fallback?.trim() || 'Failed to create terminal'
+  const raw = typeof detail === 'string' ? detail : detail instanceof Error ? detail.message : ''
+  const reason = raw.trim()
+  return reason && reason !== base ? `${base} — ${reason}` : base
+}
+
 export function getQuickCommandAgentLabel(agent: TuiAgent): string {
   return MOBILE_TUI_AGENT_LABELS[agent] ?? agent
 }

--- a/mobile/src/terminal/quick-commands.ts
+++ b/mobile/src/terminal/quick-commands.ts
@@ -83,10 +83,7 @@ export function buildMobileQuickCommandLaunch(
 
 // Why: the failure toast used to show only "Couldn't run <label>", masking the
 // real RPC/transport reason and making mobile launch failures undiagnosable.
-export function describeQuickCommandLaunchFailure(
-  fallback: string | undefined,
-  detail: unknown
-): string {
+export function formatQuickCommandFailure(fallback: string | undefined, detail: unknown): string {
   const base = fallback?.trim() || 'Failed to create terminal'
   const raw = typeof detail === 'string' ? detail : detail instanceof Error ? detail.message : ''
   const reason = raw.trim()

--- a/mobile/src/transport/stable-logical-rpc-client.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.ts
@@ -9,6 +9,15 @@ export class LogicalClientCutoverError extends Error {
   }
 }
 
+// Why: cutover errors can cross module boundaries as plain Errors (re-thrown or
+// serialized), so callers match on the message as well as the instance.
+export function isLogicalClientCutoverError(error: unknown): boolean {
+  return (
+    error instanceof LogicalClientCutoverError ||
+    (error instanceof Error && error.message === 'RPC interrupted by connection migration')
+  )
+}
+
 type SubscriptionRecord = {
   method: string
   params: unknown

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1695,6 +1695,7 @@ describe('OrcaRuntimeService', () => {
     expect(status.capabilities).toContain('workspace-ports.v1')
     expect(status.capabilities).toContain('mobile.tasks.v1')
     expect(status.capabilities).toContain('terminal.quick-commands.v1')
+    expect(status.capabilities).toContain('session.tabs.create-terminal-idempotency.v1')
     expect(status.capabilities).toContain('worktree.create-idempotency.v1')
     expect(status.capabilities).toContain('project-host-setup.v1')
     expect(status.capabilities).toContain('linear.issue-attribute-filter.v1')
@@ -22627,6 +22628,70 @@ describe('OrcaRuntimeService', () => {
     expect(createRequests).toHaveLength(1)
     expect(second).toBe(first)
     expect(first.tab).toMatchObject({ parentTabId: 'tab-renderer' })
+  })
+
+  it('keeps mutation-keyed creates host-owned across client disconnects', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setNotifier(createMobileCreateTestNotifier(vi.fn()))
+    const abort = new AbortController()
+    const webContents = { send: vi.fn() }
+    let requestId: string | null = null
+    const send = vi.fn((_channel: string, payload: { requestId: string }) => {
+      requestId = payload.requestId
+    })
+    webContents.send = send
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+    electronMocks.BrowserWindow.fromId.mockReturnValue({
+      isDestroyed: () => false,
+      webContents
+    })
+
+    let firstSettled = false
+    const first = runtime.createMobileSessionTerminal(`id:${TEST_WORKTREE_ID}`, {
+      activate: false,
+      clientMutationId: 'mutation-cutover',
+      signal: abort.signal
+    })
+    const observedFirst = first.then(
+      (value) => {
+        firstSettled = true
+        return { ok: true as const, value }
+      },
+      (error: unknown) => {
+        firstSettled = true
+        return { ok: false as const, error }
+      }
+    )
+    await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
+
+    abort.abort()
+    await Promise.resolve()
+    expect(firstSettled).toBe(false)
+
+    const replay = runtime.createMobileSessionTerminal(`id:${TEST_WORKTREE_ID}`, {
+      activate: false,
+      clientMutationId: 'mutation-cutover'
+    })
+    expect(send).toHaveBeenCalledTimes(1)
+
+    const leafId = '77777777-7777-4777-8777-777777777777'
+    runtime.registerPty('pty-cutover', TEST_WORKTREE_ID, null, {
+      tabId: 'tab-cutover',
+      leafId
+    })
+    ipcMain.emit(
+      'terminal:tabCreateReply',
+      { sender: webContents },
+      { requestId, tabId: 'tab-cutover', title: 'Terminal' }
+    )
+
+    const [firstOutcome, replayed] = await Promise.all([observedFirst, replay])
+    expect(firstOutcome.ok).toBe(true)
+    if (firstOutcome.ok) {
+      expect(replayed).toBe(firstOutcome.value)
+    }
+    expect(send).toHaveBeenCalledTimes(1)
   })
 
   it('returns the settled success for a retried clientMutationId whose response was lost', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -19986,11 +19986,14 @@ export class OrcaRuntimeService {
   ): Promise<RuntimeMobileSessionCreateTerminalResult> {
     const navigation = opts.navigation ?? 'all'
     const select = opts.select ?? opts.activate !== false
+    const mutationId = opts.clientMutationId
     const runOpts = {
       ...opts,
-      activate: select && navigationTargetsHost(navigation)
+      activate: select && navigationTargetsHost(navigation),
+      // Why: host-owned idempotent work must survive the old socket closing so
+      // a same-key cutover replay joins it instead of creating a second tab.
+      signal: mutationId ? undefined : opts.signal
     }
-    const mutationId = opts.clientMutationId
     let result: RuntimeMobileSessionCreateTerminalResult
     if (!mutationId) {
       result = await this.runCreateMobileSessionTerminal(worktreeSelector, runOpts)

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -47,6 +47,10 @@ export const TERMINAL_QUERY_REPLY_INPUT_RUNTIME_CAPABILITY =
 // Why: older hosts lack the targeted settings RPCs and strip agentPrompt from
 // terminal creation, so mobile must hide Quick Commands unless both are present.
 export const TERMINAL_QUICK_COMMANDS_RUNTIME_CAPABILITY = 'terminal.quick-commands.v1' as const
+// Why: clients may replay an interrupted session-tab create only when its
+// mutation-owned operation survives the original connection closing.
+export const SESSION_TABS_CREATE_TERMINAL_IDEMPOTENCY_RUNTIME_CAPABILITY =
+  'session.tabs.create-terminal-idempotency.v1' as const
 // Why: older hosts strip worktree.create's clientMutationId, so mobile must only
 // replay ambiguous cutovers when the host advertises idempotent create support.
 export const WORKTREE_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY =
@@ -72,6 +76,7 @@ export const RUNTIME_CAPABILITIES = [
   AI_VAULT_RUNTIME_CAPABILITY,
   TERMINAL_QUERY_REPLY_INPUT_RUNTIME_CAPABILITY,
   TERMINAL_QUICK_COMMANDS_RUNTIME_CAPABILITY,
+  SESSION_TABS_CREATE_TERMINAL_IDEMPOTENCY_RUNTIME_CAPABILITY,
   WORKTREE_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY,
   TERMINAL_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY
 ] as const


### PR DESCRIPTION
## Problem

Tapping a quick command on mobile shortly after opening a session over relay could fail with a bare **"Couldn't run codex review"** toast. Desktop-side there was zero trace — no PTY, no tab, nothing in the daemon log: the request never arrived.

Root cause: the relay→direct cutover (`migrateTo` in `stable-logical-rpc-client.ts`) rejects all in-flight requests with `LogicalClientCutoverError` while `connState` stays `'connected'`. The cutover fires seconds after connecting over relay — exactly when a quick command gets tapped after opening a session. Same mechanism as the capability-probe loss addressed in #9794.

## Fix

- Replay `session.tabs.createTerminal` with the **same** `clientMutationId` when a cutover kills it, bounded to five authenticated cutovers.
- Keep mutation-keyed creates host-owned when the original socket closes, so a replay joins the in-flight create instead of starting a second terminal. Non-idempotent creates retain their existing disconnect cancellation.
- Advertise `session.tabs.create-terminal-idempotency.v1` only with that disconnect-safe behavior, and require this exact capability before mobile replays. Hosts that only advertise Quick Commands fail closed rather than risking a duplicate terminal.
- Surface the underlying RPC/transport reason in the launch error and report a disconnected tap explicitly.

Timeout-shaped losses that are not identified as cutovers are intentionally not replayed.

## Reliability contract

- **Invariant:** `terminal-session.create-cutover-idempotency` — one mutation creates at most one terminal across relay/direct connection migration.
- **Failure source:** an authenticated transport replacement rejects a client request while the old host request may be absent, in flight, or already committed.
- **Oracle:** fault-injected tests abort the original request, replay the same mutation, and require exactly one renderer `terminal:requestTabCreate`; client tests require the same key, explicit capability, non-cutover propagation, and a six-attempt hard ceiling.
- **Gate:** accepted manifest gap; no exact `config/reliability-gates.jsonc` entry exists yet. Deterministic mobile and host unit contracts cover this PR.
- **Provider/platform coverage:** the ownership/dedupe logic is provider- and platform-neutral and runs before local, daemon, SSH, or WSL terminal realization. Mobile/relay cutover is covered deterministically; no filesystem, path, shell, or desktop-only assumption was added.
- **Performance budget:** ordinary launches remain one RPC. Only explicit authenticated cutovers can add work, capped at five replays; the host emits one renderer create for a shared mutation. No polling, sleeps, scans, subprocesses, provider fanout, or persistent listeners were added.
- **Diagnostics:** failure toasts retain the action label and append the transport/RPC reason.
- **Residual gap:** no packaged-device live relay→direct cutover artifact is attached; old hosts without the new capability retain the original fail-safe error rather than replaying.

## Verification

- Mobile: 304 files, 2,178 tests passed.
- Host/runtime: 3 focused files, 819 tests passed, including the full `orca-runtime.test.ts`.
- Mobile and Node TypeScript checks passed.
- Full mobile lint and changed-file host lint passed.
- Reliability manifest and max-lines ratchet checks passed.
