### PR TITLE
fix(terminal): fall back to synchronous pty writes when the libuv threadpool wedges (#8104)

### DIFF
--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -76,7 +76,7 @@ index 8c4fca9022a6d6f015bca87f61625cde2278f428..0a01730616488119aa21ef441cf3c441
  //# sourceMappingURL=conpty_console_list_agent.js.map
 \ No newline at end of file
 diff --git a/lib/unixTerminal.js b/lib/unixTerminal.js
-index 1ec12f796a822c78fba9ad7f6448c3987e325c23..9de09172a606338e816389012c716508cf6fc259 100644
+index 1ec12f796a822c78fba9ad7f6448c3987e325c23..296fc556aa55d6a917abd35a6a9e40908572dc00 100644
 --- a/lib/unixTerminal.js
 +++ b/lib/unixTerminal.js
 @@ -28,8 +28,12 @@ var native = utils_1.loadNativeModule('pty');
@@ -94,7 +94,7 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..9de09172a606338e816389012c716508
  var DEFAULT_FILE = 'sh';
  var DEFAULT_NAME = 'xterm';
  var DESTROY_SOCKET_TIMEOUT_MS = 200;
-@@ -283,10 +287,15 @@ var CustomWriteStream = /** @class */ (function () {
+@@ -283,10 +287,19 @@ var CustomWriteStream = /** @class */ (function () {
          this._fd = _fd;
          this._encoding = _encoding;
          this._writeQueue = [];
@@ -105,12 +105,16 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..9de09172a606338e816389012c716508
          this._writeImmediate = undefined;
 +        clearTimeout(this._callbackWatchdog);
 +        this._callbackWatchdog = undefined;
++        clearTimeout(this._canaryTimer);
++        this._canaryTimer = undefined;
 +        clearTimeout(this._syncRetryTimer);
 +        this._syncRetryTimer = undefined;
++        clearImmediate(this._drainImmediate);
++        this._drainImmediate = undefined;
      };
      CustomWriteStream.prototype.write = function (data) {
          // Writes are put in a queue and processed asynchronously in order to handle
-@@ -296,7 +305,10 @@ var CustomWriteStream = /** @class */ (function () {
+@@ -296,7 +309,10 @@ var CustomWriteStream = /** @class */ (function () {
              : Buffer.from(data);
          if (buffer.byteLength !== 0) {
              this._writeQueue.push({ buffer: buffer, offset: 0 });
@@ -122,7 +126,7 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..9de09172a606338e816389012c716508
                  this._processWriteQueue();
              }
          }
-@@ -308,10 +320,26 @@ var CustomWriteStream = /** @class */ (function () {
+@@ -308,10 +324,28 @@ var CustomWriteStream = /** @class */ (function () {
              return;
          }
          var task = this._writeQueue[0];
@@ -133,16 +137,18 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..9de09172a606338e816389012c716508
 +        // completions stop being delivered — observed in Electron utility
 +        // processes), the callback below never fires, the queue head never
 +        // advances, and every subsequent write is queued forever with no error.
-+        // The watchdog detects a callback that never arrives and switches this
-+        // stream to synchronous writes, which bypass the threadpool.
-+        clearTimeout(this._callbackWatchdog);
-+        this._callbackWatchdog = setTimeout(function () {
-+            _this._callbackWatchdog = undefined;
-+            _this._enterSyncFallback(task);
-+        }, CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS);
++        // The watchdog detects a callback that never arrives; a canary probe
++        // then confirms the pool is actually dead (a paused event loop or a
++        // merely-busy pool completes the canary and no fallback happens) before
++        // switching this stream to synchronous writes, which bypass the pool.
++        this._armWriteWatchdog(task);
          fs.write(this._fd, task.buffer, task.offset, function (err, written) {
 +            clearTimeout(_this._callbackWatchdog);
 +            _this._callbackWatchdog = undefined;
++            // The write completed, so the pool is alive: cancel any in-flight
++            // canary decision that would have abandoned this task.
++            clearTimeout(_this._canaryTimer);
++            _this._canaryTimer = undefined;
 +            if (_this._syncFallback) {
 +                // Late completion of the write the watchdog gave up on. The task
 +                // was abandoned when the fallback engaged; processing it here
@@ -152,31 +158,78 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..9de09172a606338e816389012c716508
              if (err) {
                  if ('code' in err && err.code === 'EAGAIN') {
                      // `setImmediate` is used to yield to the event loop and re-attempt
-@@ -341,6 +369,54 @@ var CustomWriteStream = /** @class */ (function () {
+@@ -341,6 +375,120 @@ var CustomWriteStream = /** @class */ (function () {
              _this._processWriteQueue();
          });
      };
++    CustomWriteStream.prototype._armWriteWatchdog = function (task) {
++        var _this = this;
++        clearTimeout(this._callbackWatchdog);
++        this._callbackWatchdog = setTimeout(function () {
++            _this._callbackWatchdog = undefined;
++            _this._startCanaryProbe(task);
++        }, CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS);
++    };
++    CustomWriteStream.prototype._startCanaryProbe = function (stalledTask) {
++        var _this = this;
++        if (this._syncFallback || this._canaryTimer !== undefined) {
++            return;
++        }
++        // A slow write completion alone cannot distinguish a wedged pool from a
++        // paused event loop (GC, suspend/resume) or a busy-but-alive pool. Probe
++        // with an independent threadpool op: if the probe completes, keep
++        // waiting; only a probe that also never returns confirms the wedge.
++        this._canaryTimer = setTimeout(function () {
++            _this._canaryTimer = undefined;
++            _this._enterSyncFallback(stalledTask);
++        }, CustomWriteStream.CANARY_TIMEOUT_MS);
++        CustomWriteStream.probeThreadpool(function () {
++            if (_this._canaryTimer === undefined) {
++                // Decision already made (fallback engaged, the stalled write
++                // completed, or the stream was disposed).
++                return;
++            }
++            clearTimeout(_this._canaryTimer);
++            _this._canaryTimer = undefined;
++            // Pool alive; if the same write is still pending, watch it again.
++            if (!_this._syncFallback && _this._writeQueue[0] === stalledTask) {
++                _this._armWriteWatchdog(stalledTask);
++            }
++        });
++    };
 +    CustomWriteStream.prototype._enterSyncFallback = function (stalledTask) {
 +        this._syncFallback = true;
 +        // Abandon the stalled task rather than re-writing it synchronously: its
 +        // in-flight fs.write may still land if the threadpool recovers, and
 +        // writing the same bytes twice could, e.g., execute a command twice.
++        var droppedBytes = 0;
 +        if (this._writeQueue[0] === stalledTask) {
++            droppedBytes = stalledTask.buffer.byteLength - stalledTask.offset;
 +            this._writeQueue.shift();
 +        }
 +        console.error('node-pty: pty write completion did not arrive within ' +
 +            CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS +
-+            'ms; assuming a wedged threadpool and falling back to synchronous writes');
++            'ms and a canary threadpool probe also stalled; falling back to ' +
++            'synchronous writes (abandoning ' + droppedBytes + ' undeliverable byte(s))');
 +        this._drainQueueSync();
 +    };
 +    CustomWriteStream.prototype._drainQueueSync = function () {
 +        var _this = this;
-+        if (this._syncRetryTimer !== undefined) {
-+            // An EAGAIN retry is already scheduled; it will drain the queue (and
-+            // anything appended meanwhile) in order.
++        if (this._syncRetryTimer !== undefined || this._drainImmediate !== undefined) {
++            // A retry or continuation is already scheduled; it will drain the
++            // queue (and anything appended meanwhile) in order.
 +            return;
 +        }
++        var bytesThisTurn = 0;
 +        while (this._writeQueue.length > 0) {
++            if (bytesThisTurn >= CustomWriteStream.SYNC_DRAIN_BYTE_BUDGET) {
++                // Yield so a large backlog cannot monopolize the event loop.
++                this._drainImmediate = setImmediate(function () {
++                    _this._drainImmediate = undefined;
++                    _this._drainQueueSync();
++                });
++                return;
++            }
 +            var task = this._writeQueue[0];
 +            var written = void 0;
 +            try {
@@ -184,25 +237,44 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..9de09172a606338e816389012c716508
 +            }
 +            catch (err) {
 +                if (err && err.code === 'EAGAIN') {
-+                    this._syncRetryTimer = setTimeout(function () {
-+                        _this._syncRetryTimer = undefined;
-+                        _this._drainQueueSync();
-+                    }, 5);
++                    this._scheduleSyncRetry();
 +                    return;
 +                }
 +                this._writeQueue.length = 0;
 +                console.error('Unhandled pty write error', err);
 +                return;
 +            }
++            if (written === 0) {
++                // Defensive: treat a zero-byte write like backpressure instead of
++                // spinning on the same task in a tight loop.
++                this._scheduleSyncRetry();
++                return;
++            }
 +            task.offset += written;
++            bytesThisTurn += written;
 +            if (task.offset >= task.buffer.byteLength) {
 +                this._writeQueue.shift();
 +            }
 +        }
 +    };
-+    // How long to wait for an fs.write completion before concluding the
-+    // threadpool is wedged. Static so embedders/tests can tune it.
++    CustomWriteStream.prototype._scheduleSyncRetry = function () {
++        var _this = this;
++        this._syncRetryTimer = setTimeout(function () {
++            _this._syncRetryTimer = undefined;
++            _this._drainQueueSync();
++        }, 5);
++    };
++    // How long to wait for an fs.write completion before probing the
++    // threadpool. Static so embedders/tests can tune them.
 +    CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS = 2000;
++    // How long the canary probe may take before the pool counts as wedged.
++    CustomWriteStream.CANARY_TIMEOUT_MS = 2000;
++    // Max bytes written per event-loop turn once in sync-fallback mode.
++    CustomWriteStream.SYNC_DRAIN_BYTE_BUDGET = 65536;
++    // Independent threadpool liveness probe; injectable for tests.
++    CustomWriteStream.probeThreadpool = function (done) {
++        fs.stat('.', function () { done(); });
++    };
      return CustomWriteStream;
  }());
 +exports.CustomWriteStream = CustomWriteStream;

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -18,7 +18,7 @@ index 1ac5758bedd8cf54f32280dea4e4aeb5afdee30d..e619813759c6f14694838bdfbd0ea5f8
 +++ b/deps/winpty/src/winpty.gyp
 @@ -10,7 +10,7 @@
      #    make -j4 CXX=i686-w64-mingw32-g++ LDFLAGS="-static -static-libgcc -static-libstdc++"
-
+ 
      'variables': {
 -        'WINPTY_COMMIT_HASH%': '<!(cmd /c "cd shared && GetCommitHash.bat")',
 +        'WINPTY_COMMIT_HASH%': '<!(cmd /c "cd shared && .\\GetCommitHash.bat")',
@@ -54,8 +54,29 @@ index 1ac5758bedd8cf54f32280dea4e4aeb5afdee30d..e619813759c6f14694838bdfbd0ea5f8
              'msvs_settings': {
                  # Specify this setting here to override a setting from somewhere
                  # else, such as node's common.gypi.
+diff --git a/lib/conpty_console_list_agent.js b/lib/conpty_console_list_agent.js
+index 8c4fca9022a6d6f015bca87f61625cde2278f428..0a01730616488119aa21ef441cf3c441e02a974c 100644
+--- a/lib/conpty_console_list_agent.js
++++ b/lib/conpty_console_list_agent.js
+@@ -10,7 +10,14 @@ Object.defineProperty(exports, "__esModule", { value: true });
+ var utils_1 = require("./utils");
+ var getConsoleProcessList = utils_1.loadNativeModule('conpty_console_list').module.getConsoleProcessList;
+ var shellPid = parseInt(process.argv[2], 10);
+-var consoleProcessList = getConsoleProcessList(shellPid);
++var consoleProcessList;
++try {
++    consoleProcessList = getConsoleProcessList(shellPid);
++}
++catch (_a) {
++    // Why: AttachConsole can fail after the shell exits; parent already has this fallback.
++    consoleProcessList = [shellPid];
++}
+ process.send({ consoleProcessList: consoleProcessList });
+ process.exit(0);
+ //# sourceMappingURL=conpty_console_list_agent.js.map
+\ No newline at end of file
 diff --git a/lib/unixTerminal.js b/lib/unixTerminal.js
-index 1ec12f796a822c78fba9ad7f6448c3987e325c23..cec8b67aef02f8199e5606a0d257088bf1865877 100644
+index 1ec12f796a822c78fba9ad7f6448c3987e325c23..9de09172a606338e816389012c716508cf6fc259 100644
 --- a/lib/unixTerminal.js
 +++ b/lib/unixTerminal.js
 @@ -28,8 +28,12 @@ var native = utils_1.loadNativeModule('pty');
@@ -73,31 +94,126 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..cec8b67aef02f8199e5606a0d257088b
  var DEFAULT_FILE = 'sh';
  var DEFAULT_NAME = 'xterm';
  var DESTROY_SOCKET_TIMEOUT_MS = 200;
-diff --git a/lib/conpty_console_list_agent.js b/lib/conpty_console_list_agent.js
-index ccc111c9e03a4a661ccfd5d8e8f0ee699571b5dd..f92c6bef7d46dc35c941c87ef186aa46d8ed9c44 100644
---- a/lib/conpty_console_list_agent.js
-+++ b/lib/conpty_console_list_agent.js
-@@ -9,7 +9,14 @@ Object.defineProperty(exports, "__esModule", { value: true });
- var utils_1 = require("./utils");
- var getConsoleProcessList = utils_1.loadNativeModule('conpty_console_list').module.getConsoleProcessList;
- var shellPid = parseInt(process.argv[2], 10);
--var consoleProcessList = getConsoleProcessList(shellPid);
-+var consoleProcessList;
-+try {
-+    consoleProcessList = getConsoleProcessList(shellPid);
-+}
-+catch (_a) {
-+    // Why: AttachConsole can fail after the shell exits; parent already has this fallback.
-+    consoleProcessList = [shellPid];
-+}
- process.send({ consoleProcessList: consoleProcessList });
- process.exit(0);
- //# sourceMappingURL=conpty_console_list_agent.js.map
+@@ -283,10 +287,15 @@ var CustomWriteStream = /** @class */ (function () {
+         this._fd = _fd;
+         this._encoding = _encoding;
+         this._writeQueue = [];
++        this._syncFallback = false;
+     }
+     CustomWriteStream.prototype.dispose = function () {
+         clearImmediate(this._writeImmediate);
+         this._writeImmediate = undefined;
++        clearTimeout(this._callbackWatchdog);
++        this._callbackWatchdog = undefined;
++        clearTimeout(this._syncRetryTimer);
++        this._syncRetryTimer = undefined;
+     };
+     CustomWriteStream.prototype.write = function (data) {
+         // Writes are put in a queue and processed asynchronously in order to handle
+@@ -296,7 +305,10 @@ var CustomWriteStream = /** @class */ (function () {
+             : Buffer.from(data);
+         if (buffer.byteLength !== 0) {
+             this._writeQueue.push({ buffer: buffer, offset: 0 });
+-            if (this._writeQueue.length === 1) {
++            if (this._syncFallback) {
++                this._drainQueueSync();
++            }
++            else if (this._writeQueue.length === 1) {
+                 this._processWriteQueue();
+             }
+         }
+@@ -308,10 +320,26 @@ var CustomWriteStream = /** @class */ (function () {
+             return;
+         }
+         var task = this._writeQueue[0];
+-        // Write to the underlying file descriptor and handle it directly, rather
+-        // than using the `net.Socket`/`tty.WriteStream` wrappers which swallow and
+-        // mask errors like EAGAIN and can cause the thread to block indefinitely.
++        // fs.write completes on the libuv threadpool. If the pool is wedged (all
++        // completions stop being delivered — observed in Electron utility
++        // processes), the callback below never fires, the queue head never
++        // advances, and every subsequent write is queued forever with no error.
++        // The watchdog detects a callback that never arrives and switches this
++        // stream to synchronous writes, which bypass the threadpool.
++        clearTimeout(this._callbackWatchdog);
++        this._callbackWatchdog = setTimeout(function () {
++            _this._callbackWatchdog = undefined;
++            _this._enterSyncFallback(task);
++        }, CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS);
+         fs.write(this._fd, task.buffer, task.offset, function (err, written) {
++            clearTimeout(_this._callbackWatchdog);
++            _this._callbackWatchdog = undefined;
++            if (_this._syncFallback) {
++                // Late completion of the write the watchdog gave up on. The task
++                // was abandoned when the fallback engaged; processing it here
++                // would deliver its bytes twice.
++                return;
++            }
+             if (err) {
+                 if ('code' in err && err.code === 'EAGAIN') {
+                     // `setImmediate` is used to yield to the event loop and re-attempt
+@@ -341,6 +369,54 @@ var CustomWriteStream = /** @class */ (function () {
+             _this._processWriteQueue();
+         });
+     };
++    CustomWriteStream.prototype._enterSyncFallback = function (stalledTask) {
++        this._syncFallback = true;
++        // Abandon the stalled task rather than re-writing it synchronously: its
++        // in-flight fs.write may still land if the threadpool recovers, and
++        // writing the same bytes twice could, e.g., execute a command twice.
++        if (this._writeQueue[0] === stalledTask) {
++            this._writeQueue.shift();
++        }
++        console.error('node-pty: pty write completion did not arrive within ' +
++            CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS +
++            'ms; assuming a wedged threadpool and falling back to synchronous writes');
++        this._drainQueueSync();
++    };
++    CustomWriteStream.prototype._drainQueueSync = function () {
++        var _this = this;
++        if (this._syncRetryTimer !== undefined) {
++            // An EAGAIN retry is already scheduled; it will drain the queue (and
++            // anything appended meanwhile) in order.
++            return;
++        }
++        while (this._writeQueue.length > 0) {
++            var task = this._writeQueue[0];
++            var written = void 0;
++            try {
++                written = fs.writeSync(this._fd, task.buffer, task.offset);
++            }
++            catch (err) {
++                if (err && err.code === 'EAGAIN') {
++                    this._syncRetryTimer = setTimeout(function () {
++                        _this._syncRetryTimer = undefined;
++                        _this._drainQueueSync();
++                    }, 5);
++                    return;
++                }
++                this._writeQueue.length = 0;
++                console.error('Unhandled pty write error', err);
++                return;
++            }
++            task.offset += written;
++            if (task.offset >= task.buffer.byteLength) {
++                this._writeQueue.shift();
++            }
++        }
++    };
++    // How long to wait for an fs.write completion before concluding the
++    // threadpool is wedged. Static so embedders/tests can tune it.
++    CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS = 2000;
+     return CustomWriteStream;
+ }());
++exports.CustomWriteStream = CustomWriteStream;
+ //# sourceMappingURL=unixTerminal.js.map
+\ No newline at end of file
 diff --git a/src/conpty_console_list_agent.ts b/src/conpty_console_list_agent.ts
-index f6a653893e0b9b548c514db29d75599538ee1acb..1d5400489f200ef0161ca687e672e1cc02d29c95 100644
+index 181ccabbbe9c4948a9725fb1db907a68e9de01fc..67f31facf85562b67adbfbd04ce28ddd8eeb4a79 100644
 --- a/src/conpty_console_list_agent.ts
 +++ b/src/conpty_console_list_agent.ts
-@@ -11,5 +11,11 @@ import { loadNativeModule } from './utils';
+@@ -10,6 +10,12 @@ import { loadNativeModule } from './utils';
+ 
  const getConsoleProcessList = loadNativeModule('conpty_console_list').module.getConsoleProcessList;
  const shellPid = parseInt(process.argv[2], 10);
 -const consoleProcessList = getConsoleProcessList(shellPid);
@@ -122,11 +238,11 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
  #include <unistd.h>
 +#include <string>
  #include <thread>
-
+ 
  #include <sys/types.h>
 @@ -237,13 +239,23 @@ pty_getproc(int, char *);
  #endif
-
+ 
  #if defined(__APPLE__) || defined(__OpenBSD__)
 +struct pty_spawn_error {
 +  const char* step;
@@ -147,12 +263,12 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 -                int* err);
 +                pty_spawn_error* err);
  #endif
-
+ 
  struct DelBuf {
 @@ -367,10 +379,11 @@ Napi::Value PtyFork(const Napi::CallbackInfo& info) {
      argv[i + 3] = strdup(arg.c_str());
    }
-
+ 
 -  int err = -1;
 -  pty_posix_spawn(argv, env, term, &winp, &master, &pid, &err);
 -  if (err != 0) {
@@ -167,7 +283,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
      throw Napi::Error::New(napiEnv, "Could not set master fd to nonblocking.");
 @@ -684,15 +697,73 @@ pty_getproc(int fd, char *tty) {
  #endif
-
+ 
  #if defined(__APPLE__)
 +static const char*
 +pty_errno_name(int errnum) {
@@ -238,7 +354,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +  bool acts_initialized = false;
 +  posix_spawnattr_t attrs;
 +  bool attrs_initialized = false;
-
+ 
    for (; count < 3; count++) {
      low_fds[count] = posix_openpt(O_RDWR);
 @@ -706,80 +777,118 @@ pty_posix_spawn(char** argv, char** env,
@@ -255,7 +371,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +    pty_set_spawn_error(err, "grantpt", errno);
 +    goto done;
    }
-
+ 
 -  int res = grantpt(*master) || unlockpt(*master);
 +  res = unlockpt(*master);
    if (res == -1) {
@@ -263,7 +379,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +    pty_set_spawn_error(err, "unlockpt", errno);
 +    goto done;
    }
-
+ 
    // Use TIOCPTYGNAME instead of ptsname() to avoid threading problems.
 -  int slave;
    char slave_pty_name[128];
@@ -273,14 +389,14 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +    pty_set_spawn_error(err, "ioctl_TIOCPTYGNAME", errno);
 +    goto done;
    }
-
+ 
    slave = open(slave_pty_name, O_RDWR | O_NOCTTY);
    if (slave == -1) {
 -    return;
 +    pty_set_spawn_error(err, "open_slave", errno, "slave", slave_pty_name);
 +    goto done;
    }
-
+ 
    if (termp) {
      res = tcsetattr(slave, TCSANOW, termp);
      if (res == -1) {
@@ -289,7 +405,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +      goto done;
      };
    }
-
+ 
    if (winp) {
      res = ioctl(slave, TIOCSWINSZ, winp);
      if (res == -1) {
@@ -298,7 +414,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +      goto done;
      }
    }
-
+ 
 -  posix_spawn_file_actions_t acts;
 -  posix_spawn_file_actions_init(&acts);
 +  res = posix_spawn_file_actions_init(&acts);
@@ -312,7 +428,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
    posix_spawn_file_actions_adddup2(&acts, slave, STDERR_FILENO);
    posix_spawn_file_actions_addclose(&acts, slave);
    posix_spawn_file_actions_addclose(&acts, *master);
-
+ 
 -  posix_spawnattr_t attrs;
 -  posix_spawnattr_init(&attrs);
 -  *err = posix_spawnattr_setflags(&attrs, flags);
@@ -328,7 +444,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +    pty_set_spawn_error(err, "posix_spawnattr_setflags", res);
      goto done;
    }
-
+ 
    sigset_t signal_set;
    /* Reset all signal the child to their default behavior */
    sigfillset(&signal_set);
@@ -339,7 +455,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +    pty_set_spawn_error(err, "posix_spawnattr_setsigdefault", res);
      goto done;
    }
-
+ 
    /* Reset the signal mask for all signals */
    sigemptyset(&signal_set);
 -  *err = posix_spawnattr_setsigmask(&attrs, &signal_set);
@@ -349,7 +465,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +    pty_set_spawn_error(err, "posix_spawnattr_setsigmask", res);
      goto done;
    }
-
+ 
    do
 -    *err = posix_spawn(pid, argv[0], &acts, &attrs, argv, env);
 -  while (*err == EINTR);
@@ -374,7 +490,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..61f39f0cbb91faa2c515f35d2ca85056
 +    close(*master);
 +    *master = -1;
 +  }
-
+ 
 -  for (; count > 0; count--) {
 -    close(low_fds[count]);
 +  for (size_t i = 0; i <= count && i < 3; i++) {

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -76,7 +76,7 @@ index 8c4fca9022a6d6f015bca87f61625cde2278f428..0a01730616488119aa21ef441cf3c441
  //# sourceMappingURL=conpty_console_list_agent.js.map
 \ No newline at end of file
 diff --git a/lib/unixTerminal.js b/lib/unixTerminal.js
-index 1ec12f796a822c78fba9ad7f6448c3987e325c23..296fc556aa55d6a917abd35a6a9e40908572dc00 100644
+index 1ec12f796a822c78fba9ad7f6448c3987e325c23..772684f3380fd99f8e2a31812fbcf0b83d84d28f 100644
 --- a/lib/unixTerminal.js
 +++ b/lib/unixTerminal.js
 @@ -28,8 +28,12 @@ var native = utils_1.loadNativeModule('pty');
@@ -94,7 +94,7 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..296fc556aa55d6a917abd35a6a9e4090
  var DEFAULT_FILE = 'sh';
  var DEFAULT_NAME = 'xterm';
  var DESTROY_SOCKET_TIMEOUT_MS = 200;
-@@ -283,10 +287,19 @@ var CustomWriteStream = /** @class */ (function () {
+@@ -283,10 +287,18 @@ var CustomWriteStream = /** @class */ (function () {
          this._fd = _fd;
          this._encoding = _encoding;
          this._writeQueue = [];
@@ -105,8 +105,7 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..296fc556aa55d6a917abd35a6a9e4090
          this._writeImmediate = undefined;
 +        clearTimeout(this._callbackWatchdog);
 +        this._callbackWatchdog = undefined;
-+        clearTimeout(this._canaryTimer);
-+        this._canaryTimer = undefined;
++        this._cancelCanary();
 +        clearTimeout(this._syncRetryTimer);
 +        this._syncRetryTimer = undefined;
 +        clearImmediate(this._drainImmediate);
@@ -114,7 +113,7 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..296fc556aa55d6a917abd35a6a9e4090
      };
      CustomWriteStream.prototype.write = function (data) {
          // Writes are put in a queue and processed asynchronously in order to handle
-@@ -296,7 +309,10 @@ var CustomWriteStream = /** @class */ (function () {
+@@ -296,7 +308,10 @@ var CustomWriteStream = /** @class */ (function () {
              : Buffer.from(data);
          if (buffer.byteLength !== 0) {
              this._writeQueue.push({ buffer: buffer, offset: 0 });
@@ -126,7 +125,7 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..296fc556aa55d6a917abd35a6a9e4090
                  this._processWriteQueue();
              }
          }
-@@ -308,10 +324,28 @@ var CustomWriteStream = /** @class */ (function () {
+@@ -308,10 +323,28 @@ var CustomWriteStream = /** @class */ (function () {
              return;
          }
          var task = this._writeQueue[0];
@@ -147,8 +146,8 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..296fc556aa55d6a917abd35a6a9e4090
 +            _this._callbackWatchdog = undefined;
 +            // The write completed, so the pool is alive: cancel any in-flight
 +            // canary decision that would have abandoned this task.
-+            clearTimeout(_this._canaryTimer);
-+            _this._canaryTimer = undefined;
++            _this._cancelCanary();
++            _this._canaryProbeCount = 0;
 +            if (_this._syncFallback) {
 +                // Late completion of the write the watchdog gave up on. The task
 +                // was abandoned when the fallback engaged; processing it here
@@ -158,7 +157,7 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..296fc556aa55d6a917abd35a6a9e4090
              if (err) {
                  if ('code' in err && err.code === 'EAGAIN') {
                      // `setImmediate` is used to yield to the event loop and re-attempt
-@@ -341,6 +375,120 @@ var CustomWriteStream = /** @class */ (function () {
+@@ -341,6 +374,165 @@ var CustomWriteStream = /** @class */ (function () {
              _this._processWriteQueue();
          });
      };
@@ -170,6 +169,17 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..296fc556aa55d6a917abd35a6a9e4090
 +            _this._startCanaryProbe(task);
 +        }, CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS);
 +    };
++    CustomWriteStream.prototype._cancelCanary = function () {
++        // Invalidate every outstanding canary artifact: a stale probe
++        // completion or timer from an earlier write must never influence a
++        // later write's decision (it could cancel a live canary and leave the
++        // queue stuck with no watchdog at all).
++        this._canaryGeneration = (this._canaryGeneration || 0) + 1;
++        clearTimeout(this._canaryTimer);
++        this._canaryTimer = undefined;
++        clearImmediate(this._canaryVerdict);
++        this._canaryVerdict = undefined;
++    };
 +    CustomWriteStream.prototype._startCanaryProbe = function (stalledTask) {
 +        var _this = this;
 +        if (this._syncFallback || this._canaryTimer !== undefined) {
@@ -179,20 +189,51 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..296fc556aa55d6a917abd35a6a9e4090
 +        // paused event loop (GC, suspend/resume) or a busy-but-alive pool. Probe
 +        // with an independent threadpool op: if the probe completes, keep
 +        // waiting; only a probe that also never returns confirms the wedge.
++        var gen = (this._canaryGeneration = (this._canaryGeneration || 0) + 1);
++        var armedAt = Date.now();
 +        this._canaryTimer = setTimeout(function () {
-+            _this._canaryTimer = undefined;
-+            _this._enterSyncFallback(stalledTask);
-+        }, CustomWriteStream.CANARY_TIMEOUT_MS);
-+        CustomWriteStream.probeThreadpool(function () {
-+            if (_this._canaryTimer === undefined) {
-+                // Decision already made (fallback engaged, the stalled write
-+                // completed, or the stream was disposed).
++            // Generation first: a stale timer must not null out a newer
++            // timer's reference (dispose could then never cancel it).
++            if (gen !== _this._canaryGeneration) {
 +                return;
 +            }
-+            clearTimeout(_this._canaryTimer);
 +            _this._canaryTimer = undefined;
++            if (_this._syncFallback) {
++                return;
++            }
++            // If this timer fired far past its deadline, the EVENT LOOP was
++            // stalled — the probe may have completed without its callback
++            // running yet. The verdict would be meaningless; probe again.
++            if (Date.now() - armedAt > CustomWriteStream.CANARY_TIMEOUT_MS * 2) {
++                if (_this._writeQueue[0] === stalledTask) {
++                    _this._startCanaryProbe(stalledTask);
++                }
++                return;
++            }
++            // Defer the verdict one check-phase: a probe completion already
++            // sitting in the poll queue still gets to cancel it.
++            _this._canaryVerdict = setImmediate(function () {
++                _this._canaryVerdict = undefined;
++                if (gen !== _this._canaryGeneration || _this._syncFallback) {
++                    return;
++                }
++                _this._enterSyncFallback(stalledTask);
++            });
++        }, CustomWriteStream.CANARY_TIMEOUT_MS);
++        CustomWriteStream.probeThreadpool(function () {
++            if (gen !== _this._canaryGeneration) {
++                // Stale probe from an earlier write; a fresh decision owns the
++                // canary state now.
++                return;
++            }
++            _this._cancelCanary();
 +            // Pool alive; if the same write is still pending, watch it again.
 +            if (!_this._syncFallback && _this._writeQueue[0] === stalledTask) {
++                _this._canaryProbeCount = (_this._canaryProbeCount || 0) + 1;
++                if (_this._canaryProbeCount === 5) {
++                    console.error('node-pty: pty write still undelivered after 5 canary cycles ' +
++                        'with a healthy threadpool; input for this pty may be stalled outside node-pty');
++                }
 +                _this._armWriteWatchdog(stalledTask);
 +            }
 +        });
@@ -210,7 +251,7 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..296fc556aa55d6a917abd35a6a9e4090
 +        console.error('node-pty: pty write completion did not arrive within ' +
 +            CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS +
 +            'ms and a canary threadpool probe also stalled; falling back to ' +
-+            'synchronous writes (abandoning ' + droppedBytes + ' undeliverable byte(s))');
++            'synchronous writes (abandoning ' + droppedBytes + ' byte(s), delivery status unknown)');
 +        this._drainQueueSync();
 +    };
 +    CustomWriteStream.prototype._drainQueueSync = function () {
@@ -232,8 +273,11 @@ index 1ec12f796a822c78fba9ad7f6448c3987e325c23..296fc556aa55d6a917abd35a6a9e4090
 +            }
 +            var task = this._writeQueue[0];
 +            var written = void 0;
++            // Cap the syscall itself at the remaining turn budget so a single
++            // large task cannot bypass the per-turn bound in one write.
++            var lengthCap = Math.min(task.buffer.byteLength - task.offset, CustomWriteStream.SYNC_DRAIN_BYTE_BUDGET - bytesThisTurn);
 +            try {
-+                written = fs.writeSync(this._fd, task.buffer, task.offset);
++                written = fs.writeSync(this._fd, task.buffer, task.offset, lengthCap);
 +            }
 +            catch (err) {
 +                if (err && err.code === 'EAGAIN') {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ patchedDependencies:
     hash: 9c1de9931d86864923ff53bc9d64474a86478085ac81ea4e432648c7e23d702c
     path: config/patches/@xterm__xterm@6.1.0-beta.287.patch
   node-pty@1.1.0:
-    hash: 1d2723d70ee109a078bb2991670f577a721ce8799d902290f806af4d3b6e80a4
+    hash: 5a01221f34cc33a43272fc515bee64724e51abb0813a3d5153495dd27c4c7086
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -63,7 +63,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=1d2723d70ee109a078bb2991670f577a721ce8799d902290f806af4d3b6e80a4)
+        version: 1.1.0(patch_hash=5a01221f34cc33a43272fc515bee64724e51abb0813a3d5153495dd27c4c7086)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12043,7 +12043,7 @@ snapshots:
       undici: 6.27.0
       which: 6.0.1
 
-  node-pty@1.1.0(patch_hash=1d2723d70ee109a078bb2991670f577a721ce8799d902290f806af4d3b6e80a4):
+  node-pty@1.1.0(patch_hash=5a01221f34cc33a43272fc515bee64724e51abb0813a3d5153495dd27c4c7086):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ patchedDependencies:
     hash: 9c1de9931d86864923ff53bc9d64474a86478085ac81ea4e432648c7e23d702c
     path: config/patches/@xterm__xterm@6.1.0-beta.287.patch
   node-pty@1.1.0:
-    hash: 5a01221f34cc33a43272fc515bee64724e51abb0813a3d5153495dd27c4c7086
+    hash: 61de84431c263c126ed3538c0a5f9053605facbe0004fc4b5864edaa96881418
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -63,7 +63,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=5a01221f34cc33a43272fc515bee64724e51abb0813a3d5153495dd27c4c7086)
+        version: 1.1.0(patch_hash=61de84431c263c126ed3538c0a5f9053605facbe0004fc4b5864edaa96881418)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12043,7 +12043,7 @@ snapshots:
       undici: 6.27.0
       which: 6.0.1
 
-  node-pty@1.1.0(patch_hash=5a01221f34cc33a43272fc515bee64724e51abb0813a3d5153495dd27c4c7086):
+  node-pty@1.1.0(patch_hash=61de84431c263c126ed3538c0a5f9053605facbe0004fc4b5864edaa96881418):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ patchedDependencies:
     hash: 9c1de9931d86864923ff53bc9d64474a86478085ac81ea4e432648c7e23d702c
     path: config/patches/@xterm__xterm@6.1.0-beta.287.patch
   node-pty@1.1.0:
-    hash: 407ae07e1e0e2ff2e8b58696449c54c31e51d87535bc6aa4a7a7b0b561407282
+    hash: 1d2723d70ee109a078bb2991670f577a721ce8799d902290f806af4d3b6e80a4
     path: config/patches/node-pty@1.1.0.patch
 
 importers:
@@ -63,7 +63,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=407ae07e1e0e2ff2e8b58696449c54c31e51d87535bc6aa4a7a7b0b561407282)
+        version: 1.1.0(patch_hash=1d2723d70ee109a078bb2991670f577a721ce8799d902290f806af4d3b6e80a4)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12043,7 +12043,7 @@ snapshots:
       undici: 6.27.0
       which: 6.0.1
 
-  node-pty@1.1.0(patch_hash=407ae07e1e0e2ff2e8b58696449c54c31e51d87535bc6aa4a7a7b0b561407282):
+  node-pty@1.1.0(patch_hash=1d2723d70ee109a078bb2991670f577a721ce8799d902290f806af4d3b6e80a4):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/src/main/daemon/node-pty-write-threadpool-stall.test.ts
+++ b/src/main/daemon/node-pty-write-threadpool-stall.test.ts
@@ -1,0 +1,275 @@
+import { execFileSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
+import * as pty from 'node-pty'
+import { afterEach, describe, expect, it } from 'vitest'
+
+// Why: when the daemon's libuv threadpool wedges (#8104-class incidents), the
+// async fs.write completions inside node-pty's CustomWriteStream never arrive
+// and every pty write queues forever with no error. A FIFO reader-open pins a
+// threadpool worker until a writer appears, so opening one per worker
+// reproduces the wedge deterministically.
+const describeOnUnix = process.platform === 'win32' ? describe.skip : describe
+
+const THREADPOOL_SIZE = Number(process.env.UV_THREADPOOL_SIZE || 4)
+
+type CustomWriteStreamClass = {
+  new (
+    fd: number,
+    encoding?: string
+  ): {
+    write: (data: string) => void
+    dispose: () => void
+  }
+  WRITE_CALLBACK_TIMEOUT_MS: number
+}
+
+function loadCustomWriteStream(): CustomWriteStreamClass {
+  const requireFromHere = createRequire(import.meta.url)
+  const unixTerminal = requireFromHere('node-pty/lib/unixTerminal') as {
+    CustomWriteStream: CustomWriteStreamClass
+  }
+  return unixTerminal.CustomWriteStream
+}
+
+type FifoStarvation = {
+  release: () => void
+}
+
+function starveThreadpool(fifoPath: string): FifoStarvation {
+  execFileSync('mkfifo', [fifoPath])
+  const openedFds: number[] = []
+  for (let i = 0; i < THREADPOOL_SIZE + 2; i++) {
+    fs.open(fifoPath, 'r', (err, fd) => {
+      if (!err) {
+        openedFds.push(fd)
+      }
+    })
+  }
+  return {
+    release: () => {
+      // Why: a FIFO writer-open wakes every pending reader-open. Open it from a
+      // background subshell so release itself never blocks.
+      execFileSync('sh', ['-c', `echo > "${fifoPath}" &`])
+      setTimeout(() => {
+        for (const fd of openedFds) {
+          try {
+            fs.closeSync(fd)
+          } catch {
+            // already closed
+          }
+        }
+      }, 500).unref()
+    }
+  }
+}
+
+describeOnUnix('node-pty write threadpool stall fallback', () => {
+  const cleanups: (() => void)[] = []
+
+  afterEach(() => {
+    while (cleanups.length > 0) {
+      cleanups.pop()?.()
+    }
+  })
+
+  it('delivers pty input via sync fallback while the libuv threadpool is stalled', async () => {
+    const dir = fs.mkdtempSync(join(tmpdir(), 'pty-stall-'))
+    cleanups.push(() => fs.rmSync(dir, { recursive: true, force: true }))
+
+    // Shrink the fallback wait so the test runs fast
+    const CustomWriteStream = loadCustomWriteStream()
+    const originalTimeout = CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS
+    CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS = 300
+    cleanups.push(() => {
+      CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS = originalTimeout
+    })
+
+    const proc = pty.spawn('/bin/sh', ['-c', 'read line; echo "GOT:$line"'], {
+      name: 'xterm-256color',
+      cols: 80,
+      rows: 24,
+      cwd: process.cwd(),
+      env: process.env as Record<string, string>
+    })
+    let output = ''
+    proc.onData((data) => {
+      output += data
+    })
+    cleanups.push(() => proc.kill())
+
+    // Let the shell reach its `read` before starving the pool
+    await delay(300)
+    const starvation = starveThreadpool(join(dir, 'stall.fifo'))
+    cleanups.push(() => starvation.release())
+
+    // Sanity: async fs completions must no longer come back
+    let statDone = false
+    fs.stat('/tmp', () => {
+      statDone = true
+    })
+    await delay(300)
+    expect(statDone).toBe(false)
+
+    // The first write is sacrificed to the wedged fs.write (abandoned when the
+    // fallback engages). What matters is that writes after the fallback reach
+    // the shell.
+    proc.write('x')
+    await delay(700)
+    proc.write('hello\n')
+
+    const deadline = Date.now() + 5000
+    while (Date.now() < deadline && !output.includes('GOT:')) {
+      await delay(100)
+    }
+
+    expect(output).toContain('GOT:hello')
+  }, 20000)
+})
+
+describeOnUnix('CustomWriteStream sync fallback', () => {
+  const FAKE_FD = 987654
+
+  type WriteHarness = {
+    stream: InstanceType<CustomWriteStreamClass>
+    syncWrites: string[]
+    pendingCallbacks: ((err: NodeJS.ErrnoException | null, written: number) => void)[]
+    releaseEagain: () => void
+    restore: () => void
+  }
+
+  // Intercepts fs.write/fs.writeSync for FAKE_FD only, so the stream can be
+  // driven without a real pty and without touching vitest's own fs usage.
+  // Patches the CJS fs exports object (what the node-pty lib captured via
+  // require) — the ESM namespace is frozen and cannot be spied.
+  function createHarness(opts?: { eagainSyncWrites?: number }): WriteHarness {
+    const CustomWriteStream = loadCustomWriteStream()
+    const originalTimeout = CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS
+    CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS = 50
+
+    const syncWrites: string[] = []
+    const pendingCallbacks: WriteHarness['pendingCallbacks'] = []
+    let remainingEagain = opts?.eagainSyncWrites ?? 0
+
+    const cjsFs = createRequire(import.meta.url)('fs') as typeof fs
+    const realWrite = cjsFs.write
+    const realWriteSync = cjsFs.writeSync
+
+    cjsFs.write = ((fd: number, ...rest: unknown[]) => {
+      if (fd !== FAKE_FD) {
+        return (realWrite as unknown as (...args: unknown[]) => unknown)(fd, ...rest)
+      }
+      const callback = rest.at(-1) as WriteHarness['pendingCallbacks'][number]
+      pendingCallbacks.push(callback)
+      return undefined
+    }) as typeof fs.write
+
+    cjsFs.writeSync = ((fd: number, buffer: Buffer, offset?: number) => {
+      if (fd !== FAKE_FD) {
+        return (realWriteSync as unknown as (...args: unknown[]) => number)(fd, buffer, offset)
+      }
+      if (remainingEagain > 0) {
+        remainingEagain--
+        const err = new Error('EAGAIN') as NodeJS.ErrnoException
+        err.code = 'EAGAIN'
+        throw err
+      }
+      syncWrites.push(buffer.subarray(offset ?? 0).toString('utf8'))
+      return buffer.byteLength - (offset ?? 0)
+    }) as typeof fs.writeSync
+
+    const stream = new CustomWriteStream(FAKE_FD, 'utf8')
+    return {
+      stream,
+      syncWrites,
+      pendingCallbacks,
+      releaseEagain: () => {
+        remainingEagain = 0
+      },
+      restore: () => {
+        stream.dispose()
+        cjsFs.write = realWrite
+        cjsFs.writeSync = realWriteSync
+        CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS = originalTimeout
+      }
+    }
+  }
+
+  it('abandons the stalled write instead of re-sending it synchronously', async () => {
+    const harness = createHarness()
+    try {
+      harness.stream.write('abc')
+      harness.stream.write('def')
+      await delay(150)
+
+      // Fallback engaged: 'abc' is abandoned (its in-flight fs.write may still
+      // land in the kernel; re-sending it could deliver the bytes twice).
+      // 'def' is delivered synchronously.
+      expect(harness.syncWrites).toEqual(['def'])
+
+      // Later writes keep using the sync path.
+      harness.stream.write('ghi')
+      expect(harness.syncWrites).toEqual(['def', 'ghi'])
+    } finally {
+      harness.restore()
+    }
+  })
+
+  it('ignores the stalled completion arriving while sync writes are queued behind EAGAIN', async () => {
+    const harness = createHarness({ eagainSyncWrites: Number.MAX_SAFE_INTEGER })
+    try {
+      harness.stream.write('abc')
+      harness.stream.write('def')
+      await delay(150)
+
+      // Fallback engaged, but 'def' is still queued: every writeSync hits
+      // EAGAIN and the drain is waiting on its retry timer.
+      expect(harness.syncWrites).toEqual([])
+
+      // The stalled completion finally arrives. Without the guard it would run
+      // the async completion logic and shift the queued 'def' out of the queue,
+      // silently losing it.
+      harness.pendingCallbacks[0]?.(null, 3)
+
+      harness.releaseEagain()
+      await delay(100)
+      expect(harness.syncWrites).toEqual(['def'])
+    } finally {
+      harness.restore()
+    }
+  })
+
+  it('never falls back while async completions arrive normally', async () => {
+    const harness = createHarness()
+    try {
+      harness.stream.write('abc')
+      // Deliver the async completion promptly, like a healthy threadpool.
+      harness.pendingCallbacks.shift()?.(null, 3)
+      await delay(150)
+
+      harness.stream.write('def')
+      harness.pendingCallbacks.shift()?.(null, 3)
+      await delay(50)
+
+      expect(harness.syncWrites).toEqual([])
+    } finally {
+      harness.restore()
+    }
+  })
+
+  it('retries EAGAIN during the sync drain instead of dropping input', async () => {
+    const harness = createHarness({ eagainSyncWrites: 1 })
+    try {
+      harness.stream.write('abc')
+      harness.stream.write('def')
+      await delay(200)
+
+      expect(harness.syncWrites).toEqual(['def'])
+    } finally {
+      harness.restore()
+    }
+  })
+})

--- a/src/main/daemon/node-pty-write-threadpool-stall.test.ts
+++ b/src/main/daemon/node-pty-write-threadpool-stall.test.ts
@@ -25,6 +25,9 @@ type CustomWriteStreamClass = {
     dispose: () => void
   }
   WRITE_CALLBACK_TIMEOUT_MS: number
+  CANARY_TIMEOUT_MS: number
+  SYNC_DRAIN_BYTE_BUDGET: number
+  probeThreadpool: (done: () => void) => void
 }
 
 function loadCustomWriteStream(): CustomWriteStreamClass {
@@ -83,9 +86,12 @@ describeOnUnix('node-pty write threadpool stall fallback', () => {
     // Shrink the fallback wait so the test runs fast
     const CustomWriteStream = loadCustomWriteStream()
     const originalTimeout = CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS
+    const originalCanary = CustomWriteStream.CANARY_TIMEOUT_MS
     CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS = 300
+    CustomWriteStream.CANARY_TIMEOUT_MS = 200
     cleanups.push(() => {
       CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS = originalTimeout
+      CustomWriteStream.CANARY_TIMEOUT_MS = originalCanary
     })
 
     const proc = pty.spawn('/bin/sh', ['-c', 'read line; echo "GOT:$line"'], {
@@ -135,7 +141,9 @@ describeOnUnix('CustomWriteStream sync fallback', () => {
 
   type WriteHarness = {
     stream: InstanceType<CustomWriteStreamClass>
-    syncWrites: string[]
+    syncWrites: { data: string; turn: number }[]
+    syncWriteData: () => string[]
+    zeroReturnTurns: number[]
     pendingCallbacks: ((err: NodeJS.ErrnoException | null, written: number) => void)[]
     releaseEagain: () => void
     restore: () => void
@@ -145,14 +153,42 @@ describeOnUnix('CustomWriteStream sync fallback', () => {
   // driven without a real pty and without touching vitest's own fs usage.
   // Patches the CJS fs exports object (what the node-pty lib captured via
   // require) — the ESM namespace is frozen and cannot be spied.
-  function createHarness(opts?: { eagainSyncWrites?: number }): WriteHarness {
+  function createHarness(opts?: {
+    eagainSyncWrites?: number
+    zeroSyncWrites?: number
+    canary?: 'stalled' | 'alive'
+  }): WriteHarness {
     const CustomWriteStream = loadCustomWriteStream()
     const originalTimeout = CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS
+    const originalCanary = CustomWriteStream.CANARY_TIMEOUT_MS
+    const originalProbe = CustomWriteStream.probeThreadpool
     CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS = 50
+    CustomWriteStream.CANARY_TIMEOUT_MS = 30
+    // Default to a wedged pool: the canary probe never completes. 'alive'
+    // simulates a healthy pool whose one completion is merely late.
+    CustomWriteStream.probeThreadpool = (done: () => void) => {
+      if ((opts?.canary ?? 'stalled') === 'alive') {
+        setTimeout(done, 5)
+      }
+    }
 
-    const syncWrites: string[] = []
+    // Tracks event-loop turns so tests can assert work was split across
+    // setImmediate boundaries (drain budget, zero-write backpressure).
+    let turn = 0
+    let turnTrackerDone = false
+    const tick = (): void => {
+      turn++
+      if (!turnTrackerDone) {
+        setImmediate(tick)
+      }
+    }
+    setImmediate(tick)
+
+    const syncWrites: WriteHarness['syncWrites'] = []
+    const zeroReturnTurns: number[] = []
     const pendingCallbacks: WriteHarness['pendingCallbacks'] = []
     let remainingEagain = opts?.eagainSyncWrites ?? 0
+    let remainingZero = opts?.zeroSyncWrites ?? 0
 
     const cjsFs = createRequire(import.meta.url)('fs') as typeof fs
     const realWrite = cjsFs.write
@@ -177,7 +213,12 @@ describeOnUnix('CustomWriteStream sync fallback', () => {
         err.code = 'EAGAIN'
         throw err
       }
-      syncWrites.push(buffer.subarray(offset ?? 0).toString('utf8'))
+      if (remainingZero > 0) {
+        remainingZero--
+        zeroReturnTurns.push(turn)
+        return 0
+      }
+      syncWrites.push({ data: buffer.subarray(offset ?? 0).toString('utf8'), turn })
       return buffer.byteLength - (offset ?? 0)
     }) as typeof fs.writeSync
 
@@ -185,15 +226,20 @@ describeOnUnix('CustomWriteStream sync fallback', () => {
     return {
       stream,
       syncWrites,
+      syncWriteData: () => syncWrites.map((w) => w.data),
+      zeroReturnTurns,
       pendingCallbacks,
       releaseEagain: () => {
         remainingEagain = 0
       },
       restore: () => {
+        turnTrackerDone = true
         stream.dispose()
         cjsFs.write = realWrite
         cjsFs.writeSync = realWriteSync
         CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS = originalTimeout
+        CustomWriteStream.CANARY_TIMEOUT_MS = originalCanary
+        CustomWriteStream.probeThreadpool = originalProbe
       }
     }
   }
@@ -208,11 +254,11 @@ describeOnUnix('CustomWriteStream sync fallback', () => {
       // Fallback engaged: 'abc' is abandoned (its in-flight fs.write may still
       // land in the kernel; re-sending it could deliver the bytes twice).
       // 'def' is delivered synchronously.
-      expect(harness.syncWrites).toEqual(['def'])
+      expect(harness.syncWriteData()).toEqual(['def'])
 
       // Later writes keep using the sync path.
       harness.stream.write('ghi')
-      expect(harness.syncWrites).toEqual(['def', 'ghi'])
+      expect(harness.syncWriteData()).toEqual(['def', 'ghi'])
     } finally {
       harness.restore()
     }
@@ -227,7 +273,7 @@ describeOnUnix('CustomWriteStream sync fallback', () => {
 
       // Fallback engaged, but 'def' is still queued: every writeSync hits
       // EAGAIN and the drain is waiting on its retry timer.
-      expect(harness.syncWrites).toEqual([])
+      expect(harness.syncWriteData()).toEqual([])
 
       // The stalled completion finally arrives. Without the guard it would run
       // the async completion logic and shift the queued 'def' out of the queue,
@@ -236,7 +282,7 @@ describeOnUnix('CustomWriteStream sync fallback', () => {
 
       harness.releaseEagain()
       await delay(100)
-      expect(harness.syncWrites).toEqual(['def'])
+      expect(harness.syncWriteData()).toEqual(['def'])
     } finally {
       harness.restore()
     }
@@ -254,7 +300,7 @@ describeOnUnix('CustomWriteStream sync fallback', () => {
       harness.pendingCallbacks.shift()?.(null, 3)
       await delay(50)
 
-      expect(harness.syncWrites).toEqual([])
+      expect(harness.syncWriteData()).toEqual([])
     } finally {
       harness.restore()
     }
@@ -267,7 +313,73 @@ describeOnUnix('CustomWriteStream sync fallback', () => {
       harness.stream.write('def')
       await delay(200)
 
-      expect(harness.syncWrites).toEqual(['def'])
+      expect(harness.syncWriteData()).toEqual(['def'])
+    } finally {
+      harness.restore()
+    }
+  })
+
+  it('does not fall back when the pool is alive and a completion is merely late', async () => {
+    const harness = createHarness({ canary: 'alive' })
+    try {
+      harness.stream.write('abc')
+      // Watchdog fires at 50ms, but the canary probe completes (pool alive),
+      // so the stream must keep waiting instead of abandoning the write.
+      await delay(200)
+      expect(harness.syncWriteData()).toEqual([])
+
+      // The late completion finally lands; the async path resumes as normal.
+      harness.pendingCallbacks.shift()?.(null, 3)
+      harness.stream.write('def')
+      await delay(50)
+
+      expect(harness.syncWriteData()).toEqual([])
+      expect(harness.pendingCallbacks.length).toBe(1)
+    } finally {
+      harness.restore()
+    }
+  })
+
+  it('splits a large sync drain across event-loop turns instead of hogging one', async () => {
+    const harness = createHarness()
+    try {
+      const CustomWriteStream = loadCustomWriteStream()
+      const originalBudget = CustomWriteStream.SYNC_DRAIN_BYTE_BUDGET
+      CustomWriteStream.SYNC_DRAIN_BYTE_BUDGET = 4
+      try {
+        harness.stream.write('abc')
+        harness.stream.write('def')
+        harness.stream.write('ghi')
+        harness.stream.write('jkl')
+        await delay(200)
+
+        // All queued input (minus the abandoned head) must still arrive…
+        expect(harness.syncWriteData()).toEqual(['def', 'ghi', 'jkl'])
+        // …but not all inside a single event-loop turn.
+        const turns = new Set(harness.syncWrites.map((w) => w.turn))
+        expect(turns.size).toBeGreaterThan(1)
+      } finally {
+        CustomWriteStream.SYNC_DRAIN_BYTE_BUDGET = originalBudget
+      }
+    } finally {
+      harness.restore()
+    }
+  })
+
+  it('treats a zero-byte writeSync as backpressure and retries later instead of spinning', async () => {
+    const harness = createHarness({ zeroSyncWrites: 1 })
+    try {
+      harness.stream.write('abc')
+      harness.stream.write('def')
+      await delay(200)
+
+      expect(harness.syncWriteData()).toEqual(['def'])
+      // The retry after the zero-byte write must happen in a later turn —
+      // a tight same-turn loop would spin the event loop on backpressure.
+      const firstWrite = harness.syncWrites.at(0)
+      expect(firstWrite).toBeDefined()
+      expect(harness.zeroReturnTurns.length).toBe(1)
+      expect(firstWrite!.turn).toBeGreaterThan(harness.zeroReturnTurns[0]!)
     } finally {
       harness.restore()
     }

--- a/src/main/daemon/node-pty-write-threadpool-stall.test.ts
+++ b/src/main/daemon/node-pty-write-threadpool-stall.test.ts
@@ -145,6 +145,7 @@ describeOnUnix('CustomWriteStream sync fallback', () => {
     syncWriteData: () => string[]
     zeroReturnTurns: number[]
     pendingCallbacks: ((err: NodeJS.ErrnoException | null, written: number) => void)[]
+    probeDones: (() => void)[]
     releaseEagain: () => void
     restore: () => void
   }
@@ -156,7 +157,7 @@ describeOnUnix('CustomWriteStream sync fallback', () => {
   function createHarness(opts?: {
     eagainSyncWrites?: number
     zeroSyncWrites?: number
-    canary?: 'stalled' | 'alive'
+    canary?: 'stalled' | 'alive' | 'manual'
   }): WriteHarness {
     const CustomWriteStream = loadCustomWriteStream()
     const originalTimeout = CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS
@@ -165,10 +166,15 @@ describeOnUnix('CustomWriteStream sync fallback', () => {
     CustomWriteStream.WRITE_CALLBACK_TIMEOUT_MS = 50
     CustomWriteStream.CANARY_TIMEOUT_MS = 30
     // Default to a wedged pool: the canary probe never completes. 'alive'
-    // simulates a healthy pool whose one completion is merely late.
+    // simulates a healthy pool whose one completion is merely late; 'manual'
+    // hands each probe's completion to the test for race orchestration.
+    const probeDones: (() => void)[] = []
     CustomWriteStream.probeThreadpool = (done: () => void) => {
-      if ((opts?.canary ?? 'stalled') === 'alive') {
+      const mode = opts?.canary ?? 'stalled'
+      if (mode === 'alive') {
         setTimeout(done, 5)
+      } else if (mode === 'manual') {
+        probeDones.push(done)
       }
     }
 
@@ -203,9 +209,14 @@ describeOnUnix('CustomWriteStream sync fallback', () => {
       return undefined
     }) as typeof fs.write
 
-    cjsFs.writeSync = ((fd: number, buffer: Buffer, offset?: number) => {
+    cjsFs.writeSync = ((fd: number, buffer: Buffer, offset?: number, length?: number) => {
       if (fd !== FAKE_FD) {
-        return (realWriteSync as unknown as (...args: unknown[]) => number)(fd, buffer, offset)
+        return (realWriteSync as unknown as (...args: unknown[]) => number)(
+          fd,
+          buffer,
+          offset,
+          length
+        )
       }
       if (remainingEagain > 0) {
         remainingEagain--
@@ -218,8 +229,11 @@ describeOnUnix('CustomWriteStream sync fallback', () => {
         zeroReturnTurns.push(turn)
         return 0
       }
-      syncWrites.push({ data: buffer.subarray(offset ?? 0).toString('utf8'), turn })
-      return buffer.byteLength - (offset ?? 0)
+      const start = offset ?? 0
+      const end =
+        length === undefined ? buffer.byteLength : Math.min(start + length, buffer.byteLength)
+      syncWrites.push({ data: buffer.subarray(start, end).toString('utf8'), turn })
+      return end - start
     }) as typeof fs.writeSync
 
     const stream = new CustomWriteStream(FAKE_FD, 'utf8')
@@ -228,6 +242,7 @@ describeOnUnix('CustomWriteStream sync fallback', () => {
       syncWrites,
       syncWriteData: () => syncWrites.map((w) => w.data),
       zeroReturnTurns,
+      probeDones,
       pendingCallbacks,
       releaseEagain: () => {
         remainingEagain = 0
@@ -353,14 +368,104 @@ describeOnUnix('CustomWriteStream sync fallback', () => {
         harness.stream.write('jkl')
         await delay(200)
 
-        // All queued input (minus the abandoned head) must still arrive…
-        expect(harness.syncWriteData()).toEqual(['def', 'ghi', 'jkl'])
+        // All queued input (minus the abandoned head) must still arrive, in
+        // order (tasks may be split by the per-turn byte cap)…
+        expect(harness.syncWriteData().join('')).toBe('defghijkl')
         // …but not all inside a single event-loop turn.
         const turns = new Set(harness.syncWrites.map((w) => w.turn))
         expect(turns.size).toBeGreaterThan(1)
       } finally {
         CustomWriteStream.SYNC_DRAIN_BYTE_BUDGET = originalBudget
       }
+    } finally {
+      harness.restore()
+    }
+  })
+
+  it('ignores a stale canary completion from an earlier write (generation race)', async () => {
+    const harness = createHarness({ canary: 'manual' })
+    try {
+      // Write A stalls long enough for its watchdog to dispatch canary A.
+      harness.stream.write('A')
+      await delay(60)
+      expect(harness.probeDones.length).toBe(1)
+
+      // A's completion arrives before canary A's timer expires; write B then
+      // stalls and dispatches canary B.
+      harness.pendingCallbacks.shift()?.(null, 1)
+      harness.stream.write('B')
+      await delay(60)
+      expect(harness.probeDones.length).toBe(2)
+
+      // The STALE canary-A completion lands while canary B is deciding. It
+      // must not cancel canary B's timer — otherwise write B is stuck forever
+      // with no watchdog and no canary (the exact hang this patch fixes).
+      harness.probeDones[0]?.()
+      await delay(100)
+
+      // Canary B must still have timed out and engaged the fallback: B was
+      // abandoned, and a subsequent write goes through synchronously.
+      harness.stream.write('C')
+      await delay(50)
+      expect(harness.syncWriteData()).toEqual(['C'])
+    } finally {
+      harness.restore()
+    }
+  })
+
+  it('caps each sync writeSync call at the remaining turn budget', async () => {
+    const harness = createHarness()
+    try {
+      const CustomWriteStream = loadCustomWriteStream()
+      const originalBudget = CustomWriteStream.SYNC_DRAIN_BYTE_BUDGET
+      CustomWriteStream.SYNC_DRAIN_BYTE_BUDGET = 4
+      try {
+        harness.stream.write('x')
+        harness.stream.write('abcdefghij')
+        await delay(200)
+
+        // The 10-byte task must arrive in full…
+        expect(harness.syncWriteData().join('')).toBe('abcdefghij')
+        // …but no single event-loop turn may exceed the byte budget — a
+        // single large task must not bypass it in one syscall.
+        const perTurn = new Map<number, number>()
+        for (const w of harness.syncWrites) {
+          perTurn.set(w.turn, (perTurn.get(w.turn) ?? 0) + w.data.length)
+        }
+        for (const bytes of perTurn.values()) {
+          expect(bytes).toBeLessThanOrEqual(4)
+        }
+      } finally {
+        CustomWriteStream.SYNC_DRAIN_BYTE_BUDGET = originalBudget
+      }
+    } finally {
+      harness.restore()
+    }
+  })
+
+  it('defers the wedge verdict when the event loop itself was stalled', async () => {
+    const harness = createHarness()
+    try {
+      harness.stream.write('x')
+      harness.stream.write('y')
+      // Let the watchdog fire and the canary timer arm…
+      await delay(60)
+      // …then stall the event loop synchronously past the canary deadline.
+      // When the loop resumes, the canary timer fires hugely late — that
+      // lateness proves the loop (not necessarily the pool) was stalled, so
+      // the verdict must be deferred to a fresh probe cycle.
+      const blockUntil = Date.now() + 150
+      while (Date.now() < blockUntil) {
+        // busy-wait to stall the loop
+      }
+      // Yield once so the overdue canary timer gets to run its callback.
+      await delay(10)
+      expect(harness.syncWriteData()).toEqual([])
+
+      // The pool really is wedged here (probe never completes), so a fresh
+      // undisturbed probe cycle must still reach the fallback.
+      await delay(300)
+      expect(harness.syncWriteData()).toEqual(['y'])
     } finally {
       harness.restore()
     }


### PR DESCRIPTION
## Summary

Fixes the input-loss issue from #8104 that I reproduced on v1.4.147. Every terminal pane, including newly created tabs, stopped accepting keyboard input while output continued and `orca terminal send` still reported success.

Root cause (confirmed by attaching an inspector to the live pty daemon — full forensics in the #8104 comment): the daemon's libuv threadpool can wedge (async fs completions stop being delivered while the event loop stays healthy). node-pty's `CustomWriteStream` delivers pty input via async `fs.write`, whose completion callback then never fires — the queue head never advances and every subsequent keystroke queues forever, silently. Output, session creation, and sockets are all event-loop paths, which is why only input dies.

This PR adds a two-stage detector to the existing node-pty patch. A per-write watchdog checks the stalled write, then an independent canary confirms that the threadpool is stuck before the stream switches permanently to `fs.writeSync`, which bypasses the threadpool. This avoids triggering on a paused event loop or a busy but functioning pool. The sync path drains at most 64KB per event-loop turn and treats a zero-byte write as backpressure. It abandons the stalled task instead of sending it again, because the in-flight write could still complete if the pool recovers and execute a command twice. The dropped byte count is logged. Applying this fallback via the inspector to my wedged live daemon restored input to every pane instantly, without a restart.

I went with the patch (rather than daemon-side code) because the wedge is unobservable from Orca's code — `proc.write()` returns void with no error or ack — and the repo already tracks node-pty behavior fixes in `config/patches/`. Also filing the same problem upstream: microsoft/node-pty#939.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — every file touched by this PR passes; the full run fails on upstream main itself (pre-existing switch-exhaustiveness error in `skill-freshness-group.tsx`, untouched here)
- [x] `pnpm typecheck`
- [x] `pnpm test` — new file green; the full local suite has ~10 pre-existing env-dependent failures (git/ssh/relay integration) that fail identically on the base commit without this change
- [x] `pnpm build`
- [x] Added regression tests (11): the key test reproduces the wedge deterministically by pinning every libuv worker with FIFO reader-opens, then proves input still reaches a real shell through the fallback. I also verified the individual guards by removing them and checking that the corresponding tests fail. These cover the canary probe, abandoning the stalled task, ignoring late completions, the per-turn drain limit, zero-byte backpressure, EAGAIN retries, and the normal path.

## AI Review Report

Reviewed with Claude Code, plus three adversarial design-review rounds with Codex until it judged the change mergeable. Round 1 found a false-positive fallback when the event loop pauses (a timer can fire before a completed write's callback), an unbounded sync drain monopolizing the event loop, and a zero-byte `writeSync` spin — addressed by the canary probe, the per-turn byte budget, and the backpressure retry. Round 2 found a generation race where a stale canary completion from an earlier write could cancel the next write's live canary (recreating the permanent hang) and a single large task bypassing the byte budget in one syscall — addressed by generation tokens and a per-syscall length cap. Each fix is covered by a mutation-verified test (removing the guard makes its test fail). Also checked: double-delivery of input bytes (late async completion after fallback — guarded), input reordering (abandon semantics lose at most the single confirmed-stalled chunk instead of risking duplicate command execution), EAGAIN in both modes, and timer cleanup on dispose. Cross-platform: the change is inside `unixTerminal.js`, so Windows/ConPTY is untouched; macOS and Linux share the patched path; the new test is skipped on win32. Verified the regenerated patch is content-neutral outside `lib/unixTerminal.js` by diffing the installed package trees old-vs-new.

## Security Audit

No new attack surface: the fallback writes the same user keystrokes to the same pty fd captured at construction; no new process spawning, dynamic code, or inputs. `console.error` logs only timeout constants and a byte count. pnpm patch integrity verified (lockfile hash matches the patch file's sha256). The FIFO/`sh -c` usage is test-only with self-generated tmpdir paths.

## Notes

- Why the threadpool wedges is still unknown (evidence points at an Electron utility-process/libuv issue; timeline correlates with a sleep cycle while the pool was idle). This PR makes input survive it and makes the failure observable (one `console.error` with the dropped byte count) instead of silent.
- Possible follow-ups, outside this PR: expose the degraded state to the renderer instead of only logging it, and replace this fallback upstream with a native nonblocking writer using `uv_poll` so the input path does not depend on the threadpool (proposed in microsoft/node-pty#939).
- The patch targets the compiled `lib/unixTerminal.js`, same as the existing node-pty patch hunks. When an upstream fix ships in a node-pty release, this hunk can be dropped with the version bump.


## ELI5

Terminals could stop accepting keyboard input while still showing output when a background thread pool wedged. Writes fall back to a synchronous path so typing keeps working instead of silently dropping.
