### PR TITLE
fix(mobile-quick-commands): replay sheet load killed by connection migration

### DIFF
--- a/mobile/src/session/use-quick-commands.test.ts
+++ b/mobile/src/session/use-quick-commands.test.ts
@@ -3,6 +3,7 @@ import { act, create, type ReactTestRenderer } from 'react-test-renderer'
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest'
 import type { TerminalQuickCommand } from '../../../src/shared/types'
 import type { RpcClient } from '../transport/rpc-client'
+import { LogicalClientCutoverError } from '../transport/stable-logical-rpc-client'
 import type { RpcResponse } from '../transport/types'
 import { useQuickCommands } from './use-quick-commands'
 
@@ -86,6 +87,79 @@ describe('useQuickCommands', () => {
 
     expect(client.sendRequest).not.toHaveBeenCalled()
     expect(state?.ready).toBe(false)
+  })
+
+  it('replays the load after a connection-migration cutover', async () => {
+    const client = {
+      sendRequest: vi
+        .fn()
+        .mockRejectedValueOnce(new LogicalClientCutoverError())
+        .mockResolvedValueOnce(success([FIRST]))
+    } as unknown as RpcClient
+
+    await mount(client)
+
+    expect(client.sendRequest).toHaveBeenCalledTimes(2)
+    expect(state?.commands).toEqual([FIRST])
+    expect(state?.ready).toBe(true)
+    expect(state?.error).toBeNull()
+  })
+
+  it('surfaces the cutover error once replays are exhausted', async () => {
+    const client = {
+      sendRequest: vi.fn(() => Promise.reject(new LogicalClientCutoverError()))
+    } as unknown as RpcClient
+
+    await mount(client)
+
+    // Initial attempt + 5 replays, then give up rather than loop forever.
+    expect(client.sendRequest).toHaveBeenCalledTimes(6)
+    expect(state?.ready).toBe(false)
+    expect(state?.error).toBe('RPC interrupted by connection migration')
+  })
+
+  it('does not replay non-cutover load failures', async () => {
+    const client = {
+      sendRequest: vi.fn(() => Promise.reject(new Error('boom')))
+    } as unknown as RpcClient
+
+    await mount(client)
+
+    expect(client.sendRequest).toHaveBeenCalledTimes(1)
+    expect(state?.ready).toBe(false)
+    expect(state?.error).toBe('boom')
+  })
+
+  it('stops replaying a cutover-interrupted load after the sheet closes', async () => {
+    let rejectLoad: (error: Error) => void = () => {}
+    const client = {
+      sendRequest: vi.fn(
+        () =>
+          new Promise<RpcResponse>((_resolve, reject) => {
+            rejectLoad = reject
+          })
+      )
+    } as unknown as RpcClient
+
+    function Harness({ enabled }: { enabled: boolean }): null {
+      state = useQuickCommands({ client, enabled })
+      return null
+    }
+    await act(async () => {
+      renderer = create(createElement(Harness, { enabled: true }))
+      await Promise.resolve()
+    })
+    await act(async () => {
+      renderer!.update(createElement(Harness, { enabled: false }))
+      await Promise.resolve()
+    })
+    await act(async () => {
+      rejectLoad(new LogicalClientCutoverError())
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(client.sendRequest).toHaveBeenCalledTimes(1)
   })
 
   it('keeps mutations disabled when the remote list could not be loaded', async () => {

--- a/mobile/src/session/use-quick-commands.ts
+++ b/mobile/src/session/use-quick-commands.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { RpcClient } from '../transport/rpc-client'
-import type { RpcFailure, RpcSuccess } from '../transport/types'
+import { isLogicalClientCutoverError } from '../transport/stable-logical-rpc-client'
+import type { RpcFailure, RpcResponse, RpcSuccess } from '../transport/types'
 import type { TerminalQuickCommand } from '../../../src/shared/types'
 import {
   applyTerminalQuickCommandMutation,
@@ -41,6 +42,30 @@ type MutationContext = {
 function readQuickCommands(result: unknown): TerminalQuickCommand[] | null {
   const list = (result as { terminalQuickCommands?: unknown } | null)?.terminalQuickCommands
   return parseNormalizedTerminalQuickCommands(list)
+}
+
+const LOAD_CUTOVER_MAX_RETRIES = 5
+
+// Why: opening the sheet right after connecting over relay races the relay→direct
+// cutover, which rejects in-flight one-shots while connState stays 'connected';
+// the read is side-effect-free, so replay it instead of stranding an empty sheet.
+async function loadQuickCommandsWithCutoverRetry(
+  client: RpcClient,
+  cancelled: () => boolean
+): Promise<RpcResponse> {
+  for (let migrationRetry = 0; ; migrationRetry += 1) {
+    try {
+      return await client.sendRequest('settings.getTerminalQuickCommands')
+    } catch (error) {
+      if (
+        cancelled() ||
+        !isLogicalClientCutoverError(error) ||
+        migrationRetry >= LOAD_CUTOVER_MAX_RETRIES
+      ) {
+        throw error
+      }
+    }
+  }
 }
 
 export function useQuickCommands({ client, enabled }: Args): QuickCommandsState {
@@ -90,7 +115,13 @@ export function useQuickCommands({ client, enabled }: Args): QuickCommandsState 
         ) {
           return
         }
-        const response = await client.sendRequest('settings.getTerminalQuickCommands')
+        const response = await loadQuickCommandsWithCutoverRetry(
+          client,
+          () =>
+            stale ||
+            operationId !== operationIdRef.current ||
+            mutationContextRef.current !== mutationContext
+        )
         if (
           stale ||
           operationId !== operationIdRef.current ||

--- a/mobile/src/transport/stable-logical-rpc-client.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.ts
@@ -9,6 +9,15 @@ export class LogicalClientCutoverError extends Error {
   }
 }
 
+// Why: cutover errors can cross module boundaries as plain Errors (re-thrown or
+// serialized), so callers match on the message as well as the instance.
+export function isLogicalClientCutoverError(error: unknown): boolean {
+  return (
+    error instanceof LogicalClientCutoverError ||
+    (error instanceof Error && error.message === 'RPC interrupted by connection migration')
+  )
+}
+
 type SubscriptionRecord = {
   method: string
   params: unknown


### PR DESCRIPTION
## Problem

Opening the Quick Commands sheet within a few seconds of connecting over relay races the relay→direct cutover. The cutover (`migrateTo` in `stable-logical-rpc-client.ts`) rejects the sheet's in-flight one-shot `settings.getTerminalQuickCommands` with `LogicalClientCutoverError` while `connState` stays `'connected'`, so nothing re-triggers the fetch. The sheet strands on a red **"RPC interrupted by connection migration"** error with a misleading empty "No quick commands yet" list until closed and reopened.

Hit live on 2026-07-21 (screenshot on file). Third surface of the same cutover-kill mechanism as #9794 (capability probe → button vanishes) and #9796 (terminal create → "Couldn't run …" toast); neither of those touches this fetch.

## Fix

- `use-quick-commands.ts`: wrap the load in `loadQuickCommandsWithCutoverRetry` — the read is side-effect-free, so it replays immediately on cutover (the replacement session is already authenticated), capped at 5 replays, and aborts if the sheet closes / the operation is superseded / the client is replaced. Mirrors the on-main pattern in `worktree-create-capability.ts`.
- `stable-logical-rpc-client.ts`: export `isLogicalClientCutoverError`. **Byte-identical to the export added in #9794 and #9796** — whichever lands second/third gets a trivial same-code conflict; keep either side.

Non-cutover failures (timeouts, `ok:false`) still surface immediately — unchanged behavior, kept out of scope.

## Verification

- 4 new tests: replay-then-succeed, exhaustion after 6 attempts surfaces the error, non-cutover errors not replayed, no replay after the sheet closes.
- Mobile `src/session` + `src/transport` suites: 134 files, 867 passed / 2 skipped.
- `tsc --noEmit`, `oxlint`, `oxfmt --check` all clean.