### PR TITLE
fix(dashboard): align terminal-dialog close X with compact header

### DIFF
--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { SquareArrowOutUpRight } from 'lucide-react'
+import { SquareArrowOutUpRight, XIcon } from 'lucide-react'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
 import { agentStateLabel } from '@/components/AgentStateDot'
@@ -46,6 +46,10 @@ export function AgentTerminalDialog({
           // Why: sm:max-w-lg in DialogContent's base classes would defeat a bare
           // max-w-*, so the full-width override must carry the same breakpoint.
           className="flex w-[calc(100vw-40px)] max-w-none flex-col gap-0 p-0 sm:max-w-none"
+          // Why: the default close X sits at top-4/right-4 (tuned for p-6
+          // dialogs), which misaligns against this p-0 compact header; render
+          // it inside the header row instead so it centers with the title.
+          showCloseButton={false}
           // Why: Esc must reach the agent (interrupt) when typing in the
           // terminal, not dismiss the dialog; xterm has already consumed the
           // keystroke by the time Radix sees it. Click-outside still closes.
@@ -70,6 +74,12 @@ export function AgentTerminalDialog({
             <span className="text-[11px] text-muted-foreground">
               {formatAgentTypeLabel(card.agentType)} · {agentStateLabel(card.dotState)}
             </span>
+            <DialogClose className="ml-auto rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:outline-hidden">
+              <XIcon className="size-4" />
+              <span className="sr-only">
+                {translate('dashboardPopout.terminal.close', 'Close')}
+              </span>
+            </DialogClose>
           </div>
           {card.ptyId ? (
             <AgentTerminalPreview ptyId={card.ptyId} />

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -13636,7 +13636,8 @@
     },
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",
-      "focusWorktree": "Open worktree"
+      "focusWorktree": "Open worktree",
+      "close": "Close"
     }
   },
   "dashboard": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -13613,7 +13613,8 @@
     },
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",
-      "focusWorktree": "Focus worktree"
+      "focusWorktree": "Focus worktree",
+      "close": "Close"
     }
   },
   "dashboard": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -13613,7 +13613,8 @@
     },
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",
-      "focusWorktree": "Focus worktree"
+      "focusWorktree": "Focus worktree",
+      "close": "Close"
     }
   },
   "dashboard": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -13613,7 +13613,8 @@
     },
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",
-      "focusWorktree": "Focus worktree"
+      "focusWorktree": "Focus worktree",
+      "close": "Close"
     }
   },
   "dashboard": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -13613,7 +13613,8 @@
     },
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",
-      "focusWorktree": "Focus worktree"
+      "focusWorktree": "Focus worktree",
+      "close": "Close"
     }
   },
   "dashboard": {


### PR DESCRIPTION
## Problem

In the agent dashboard popout, the terminal dialog's close X is misaligned: it floats below the header row instead of sitting on the title line.

The default `DialogContent` close button is absolutely positioned at `top-4 right-4`, which is tuned for the standard `p-6` dialog. This dialog uses `p-0` with a compact `py-2` header (#9686 switched it from a footer Close button to the corner X), so the default position lands the X below the header's centerline.

## Fix

Suppress the built-in close button (`showCloseButton={false}`) and render the `DialogClose` X inside the header row with `ml-auto`, so it vertically centers with the title and shares the header's horizontal padding. Same visual treatment as the default X (size-4 icon, 70% → 100% opacity on hover, sr-only label).

Adds the `dashboardPopout.terminal.close` locale key (English text in non-en locales, matching the existing keys in that section).

## QA (live Electron, CDP)

Verified in the dev app via the popout QA rig (synthetic snapshot → open dialog):
- X center is exactly on the title's centerline (both measured at the same y), inset to match the header padding.
- Clicking the X still closes the dialog.

![dialog X aligned](https://github.com/stablyai/orca/blob/fix-agent-dashboard-close-screenshots/dialog-x-aligned.png?raw=true)
