### PR TITLE
fix(ssh): reap orphaned relay PTYs on reconnect before they exhaust the session cap

### DIFF
--- a/src/main/providers/pty-process-info.ts
+++ b/src/main/providers/pty-process-info.ts
@@ -13,4 +13,8 @@ export type PtyProcessInfo = {
   /** Exact WSL owner reported by the PTY provider; null means native Windows. */
   wslDistro?: string | null
   agentSessionOwners?: AgentSessionOwnerBinding[]
+  /** Renderer pane key (ORCA_PANE_KEY) captured at spawn, when the provider tracks it. */
+  paneKey?: string
+  /** Ms since the provider created or revived this PTY, measured on the provider host's clock. */
+  ageMs?: number
 }

--- a/src/main/ssh/ssh-relay-session-orphan-pty-reap.test.ts
+++ b/src/main/ssh/ssh-relay-session-orphan-pty-reap.test.ts
@@ -245,6 +245,37 @@ describe('SshRelaySession orphaned relay PTY reaping', () => {
     })
   })
 
+  it('a known-set build failure skips the sweep instead of reaping with partial knowledge', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const mockShutdown = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(getSshPtyProvider).mockReturnValue({
+      attachForReconnect: vi.fn().mockResolvedValue(undefined),
+      listProcesses: vi.fn().mockResolvedValue([
+        // Would be reaped if the sweep ran with a partial known set.
+        {
+          id: 'ssh:target-1@@pty-9',
+          cwd: '/home/me',
+          title: 'shell',
+          paneKey: 'tab-b:leaf-b',
+          ageMs: 60_000
+        }
+      ]),
+      shutdown: mockShutdown,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    // First call feeds reattachKnownPtys; the sweep's call returns an id owned by a
+    // different connection, which makes toRelaySshPtyId throw mid known-set build.
+    vi.mocked(getPtyIdsForConnection)
+      .mockReturnValueOnce([])
+      .mockReturnValue(['ssh:other-target@@pty-2'])
+
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+    await session.establish(mockConn)
+
+    expect(session.getState()).toBe('ready')
+    expect(mockShutdown).not.toHaveBeenCalled()
+  })
+
   it('sweep failures do not block the session from becoming ready', async () => {
     const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
     vi.mocked(getSshPtyProvider).mockReturnValue({

--- a/src/main/ssh/ssh-relay-session-orphan-pty-reap.test.ts
+++ b/src/main/ssh/ssh-relay-session-orphan-pty-reap.test.ts
@@ -89,7 +89,7 @@ describe('SshRelaySession orphaned relay PTY reaping', () => {
   it('establish reaps orphaned pane-bound relay PTYs the app no longer tracks', async () => {
     const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
     const mockShutdown = vi.fn().mockResolvedValue(undefined)
-    const staleStartedAtMs = Date.now() - 60_000
+    const staleAgeMs = 60_000
     vi.mocked(getSshPtyProvider).mockReturnValue({
       attachForReconnect: vi.fn().mockResolvedValue(undefined),
       listProcesses: vi.fn().mockResolvedValue([
@@ -98,14 +98,14 @@ describe('SshRelaySession orphaned relay PTY reaping', () => {
           cwd: '/home/me',
           title: 'shell',
           paneKey: 'tab-a:leaf-a',
-          startedAtMs: staleStartedAtMs
+          ageMs: staleAgeMs
         },
         {
           id: 'ssh:target-1@@pty-9',
           cwd: '/home/me',
           title: 'shell',
           paneKey: 'tab-b:leaf-b',
-          startedAtMs: staleStartedAtMs
+          ageMs: staleAgeMs
         }
       ]),
       shutdown: mockShutdown,
@@ -127,7 +127,7 @@ describe('SshRelaySession orphaned relay PTY reaping', () => {
   it('spares bare shells, young spawns, missing start times, and leased PTYs', async () => {
     const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
     const mockShutdown = vi.fn().mockResolvedValue(undefined)
-    const staleStartedAtMs = Date.now() - 60_000
+    const staleAgeMs = 60_000
     vi.mocked(getSshPtyProvider).mockReturnValue({
       attachForReconnect: vi.fn().mockResolvedValue(undefined),
       listProcesses: vi.fn().mockResolvedValue([
@@ -136,7 +136,7 @@ describe('SshRelaySession orphaned relay PTY reaping', () => {
           id: 'ssh:target-1@@pty-2',
           cwd: '/home/me',
           title: 'shell',
-          startedAtMs: staleStartedAtMs
+          ageMs: staleAgeMs
         },
         // In-flight spawn racing the sweep: too young to reap.
         {
@@ -144,7 +144,7 @@ describe('SshRelaySession orphaned relay PTY reaping', () => {
           cwd: '/home/me',
           title: 'shell',
           paneKey: 'tab-a:leaf-a',
-          startedAtMs: Date.now()
+          ageMs: 0
         },
         // Durable lease: known, reattached instead of reaped.
         {
@@ -152,9 +152,9 @@ describe('SshRelaySession orphaned relay PTY reaping', () => {
           cwd: '/home/me',
           title: 'shell',
           paneKey: 'tab-b:leaf-b',
-          startedAtMs: staleStartedAtMs
+          ageMs: staleAgeMs
         },
-        // Pre-startedAtMs relay entry: age unknown, never reaped.
+        // Pre-ageMs relay entry: age unknown, never reaped.
         { id: 'ssh:target-1@@pty-5', cwd: '/home/me', title: 'shell', paneKey: 'tab-c:leaf-c' }
       ]),
       shutdown: mockShutdown,
@@ -191,7 +191,7 @@ describe('SshRelaySession orphaned relay PTY reaping', () => {
           cwd: '/home/me',
           title: 'shell',
           paneKey: 'tab-a:leaf-a',
-          startedAtMs: Date.now() - 60_000
+          ageMs: 60_000
         }
       ]),
       shutdown: mockShutdown,
@@ -202,6 +202,44 @@ describe('SshRelaySession orphaned relay PTY reaping', () => {
     await session.reconnect(mockConn)
 
     expect(mockShutdown).toHaveBeenCalledWith('ssh:target-1@@pty-7', {
+      immediate: true,
+      keepHistory: false
+    })
+  })
+
+  it('a foreign-connection entry cannot abort the sweep or the session', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const mockShutdown = vi.fn().mockResolvedValue(undefined)
+    const staleAgeMs = 60_000
+    vi.mocked(getSshPtyProvider).mockReturnValue({
+      attachForReconnect: vi.fn().mockResolvedValue(undefined),
+      listProcesses: vi.fn().mockResolvedValue([
+        // toRelaySshPtyId throws on this id; the sweep must skip it, not die.
+        {
+          id: 'ssh:other-target@@pty-1',
+          cwd: '/home/me',
+          title: 'shell',
+          paneKey: 'tab-x:leaf-x',
+          ageMs: staleAgeMs
+        },
+        {
+          id: 'ssh:target-1@@pty-9',
+          cwd: '/home/me',
+          title: 'shell',
+          paneKey: 'tab-b:leaf-b',
+          ageMs: staleAgeMs
+        }
+      ]),
+      shutdown: mockShutdown,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+    await session.establish(mockConn)
+
+    expect(session.getState()).toBe('ready')
+    expect(mockShutdown).toHaveBeenCalledTimes(1)
+    expect(mockShutdown).toHaveBeenCalledWith('ssh:target-1@@pty-9', {
       immediate: true,
       keepHistory: false
     })

--- a/src/main/ssh/ssh-relay-session-orphan-pty-reap.test.ts
+++ b/src/main/ssh/ssh-relay-session-orphan-pty-reap.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SshRelaySession } from './ssh-relay-session'
+import { createMockDeps, mockDeploySuccess } from './ssh-relay-session-test-fixtures'
+
+vi.mock('./ssh-relay-deploy', () => ({
+  deployAndLaunchRelay: vi.fn()
+}))
+
+vi.mock('./ssh-relay-deploy-helpers', () => ({
+  execCommand: vi.fn().mockResolvedValue('')
+}))
+
+vi.mock('./ssh-channel-multiplexer', () => {
+  return {
+    SshChannelMultiplexer: class MockSshChannelMultiplexer {
+      notify = vi.fn()
+      request = vi.fn().mockResolvedValue([])
+      onNotification = vi.fn().mockReturnValue(() => {})
+      onRequest = vi.fn().mockReturnValue(() => {})
+      onDispose = vi.fn().mockReturnValue(() => {})
+      dispose = vi.fn()
+      isDisposed = vi.fn().mockReturnValue(false)
+    }
+  }
+})
+
+vi.mock('../providers/ssh-pty-provider', () => ({
+  isSshPtyNotFoundError: (err: unknown) =>
+    (err instanceof Error ? err.message : String(err)).includes('not found'),
+  isSshPtyIdentityMismatchError: (err: unknown) =>
+    (err instanceof Error ? err.message : String(err)).includes('identity mismatch'),
+  SshPtyProvider: class MockSshPtyProvider {
+    onData = vi.fn().mockReturnValue(() => {})
+    onReplay = vi.fn().mockReturnValue(() => {})
+    onExit = vi.fn().mockReturnValue(() => {})
+    attach = vi.fn().mockResolvedValue(undefined)
+    attachForReconnect = vi.fn().mockResolvedValue({})
+    dispose = vi.fn()
+  }
+}))
+
+vi.mock('../providers/ssh-filesystem-provider', () => ({
+  SshFilesystemProvider: class MockSshFilesystemProvider {
+    dispose = vi.fn()
+  }
+}))
+
+vi.mock('../providers/ssh-git-provider', () => ({
+  SshGitProvider: class MockSshGitProvider {}
+}))
+
+vi.mock('../ipc/pty', () => ({
+  registerSshPtyProvider: vi.fn(),
+  unregisterSshPtyProvider: vi.fn(),
+  getSshPtyProvider: vi.fn().mockReturnValue({
+    dispose: vi.fn(),
+    attach: vi.fn().mockResolvedValue(undefined),
+    attachForReconnect: vi.fn().mockResolvedValue({}),
+    listProcesses: vi.fn().mockResolvedValue([]),
+    shutdown: vi.fn().mockResolvedValue(undefined)
+  }),
+  getPtyIdsForConnection: vi.fn().mockReturnValue([]),
+  clearPtyOwnershipForConnection: vi.fn(),
+  clearProviderPtyState: vi.fn(),
+  deletePtyOwnership: vi.fn(),
+  setPtyOwnership: vi.fn()
+}))
+
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  registerSshFilesystemProvider: vi.fn(),
+  unregisterSshFilesystemProvider: vi.fn(),
+  getSshFilesystemProvider: vi.fn().mockReturnValue({ dispose: vi.fn() })
+}))
+
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  registerSshGitProvider: vi.fn(),
+  unregisterSshGitProvider: vi.fn()
+}))
+
+const { getSshPtyProvider, getPtyIdsForConnection } = await import('../ipc/pty')
+
+describe('SshRelaySession orphaned relay PTY reaping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDeploySuccess()
+    vi.mocked(getPtyIdsForConnection).mockReturnValue([])
+  })
+
+  it('establish reaps orphaned pane-bound relay PTYs the app no longer tracks', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const mockShutdown = vi.fn().mockResolvedValue(undefined)
+    const staleStartedAtMs = Date.now() - 60_000
+    vi.mocked(getSshPtyProvider).mockReturnValue({
+      attachForReconnect: vi.fn().mockResolvedValue(undefined),
+      listProcesses: vi.fn().mockResolvedValue([
+        {
+          id: 'ssh:target-1@@pty-1',
+          cwd: '/home/me',
+          title: 'shell',
+          paneKey: 'tab-a:leaf-a',
+          startedAtMs: staleStartedAtMs
+        },
+        {
+          id: 'ssh:target-1@@pty-9',
+          cwd: '/home/me',
+          title: 'shell',
+          paneKey: 'tab-b:leaf-b',
+          startedAtMs: staleStartedAtMs
+        }
+      ]),
+      shutdown: mockShutdown,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    vi.mocked(getPtyIdsForConnection).mockReturnValue(['ssh:target-1@@pty-1'])
+
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+    await session.establish(mockConn)
+
+    expect(mockShutdown).toHaveBeenCalledTimes(1)
+    expect(mockShutdown).toHaveBeenCalledWith('ssh:target-1@@pty-9', {
+      immediate: true,
+      keepHistory: false
+    })
+    expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith('target-1', 'pty-9', 'terminated')
+  })
+
+  it('spares bare shells, young spawns, missing start times, and leased PTYs', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const mockShutdown = vi.fn().mockResolvedValue(undefined)
+    const staleStartedAtMs = Date.now() - 60_000
+    vi.mocked(getSshPtyProvider).mockReturnValue({
+      attachForReconnect: vi.fn().mockResolvedValue(undefined),
+      listProcesses: vi.fn().mockResolvedValue([
+        // Bare relay shell (e.g. remote CLI): no paneKey, never reaped.
+        {
+          id: 'ssh:target-1@@pty-2',
+          cwd: '/home/me',
+          title: 'shell',
+          startedAtMs: staleStartedAtMs
+        },
+        // In-flight spawn racing the sweep: too young to reap.
+        {
+          id: 'ssh:target-1@@pty-3',
+          cwd: '/home/me',
+          title: 'shell',
+          paneKey: 'tab-a:leaf-a',
+          startedAtMs: Date.now()
+        },
+        // Durable lease: known, reattached instead of reaped.
+        {
+          id: 'ssh:target-1@@pty-4',
+          cwd: '/home/me',
+          title: 'shell',
+          paneKey: 'tab-b:leaf-b',
+          startedAtMs: staleStartedAtMs
+        },
+        // Pre-startedAtMs relay entry: age unknown, never reaped.
+        { id: 'ssh:target-1@@pty-5', cwd: '/home/me', title: 'shell', paneKey: 'tab-c:leaf-c' }
+      ]),
+      shutdown: mockShutdown,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
+      { targetId: 'target-1', ptyId: 'pty-4', state: 'detached' }
+    ] as ReturnType<typeof mockStore.getSshRemotePtyLeases>)
+
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+    await session.establish(mockConn)
+
+    expect(mockShutdown).not.toHaveBeenCalled()
+    expect(mockStore.markSshRemotePtyLease).not.toHaveBeenCalledWith(
+      'target-1',
+      expect.anything(),
+      'terminated'
+    )
+  })
+
+  it('reconnect reaps orphaned pane-bound relay PTYs', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+    await session.establish(mockConn)
+    vi.clearAllMocks()
+    mockDeploySuccess()
+
+    const mockShutdown = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(getSshPtyProvider).mockReturnValue({
+      attachForReconnect: vi.fn().mockResolvedValue(undefined),
+      listProcesses: vi.fn().mockResolvedValue([
+        {
+          id: 'ssh:target-1@@pty-7',
+          cwd: '/home/me',
+          title: 'shell',
+          paneKey: 'tab-a:leaf-a',
+          startedAtMs: Date.now() - 60_000
+        }
+      ]),
+      shutdown: mockShutdown,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    vi.mocked(getPtyIdsForConnection).mockReturnValue([])
+
+    await session.reconnect(mockConn)
+
+    expect(mockShutdown).toHaveBeenCalledWith('ssh:target-1@@pty-7', {
+      immediate: true,
+      keepHistory: false
+    })
+  })
+
+  it('sweep failures do not block the session from becoming ready', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    vi.mocked(getSshPtyProvider).mockReturnValue({
+      attachForReconnect: vi.fn().mockResolvedValue(undefined),
+      listProcesses: vi.fn().mockRejectedValue(new Error('relay timeout')),
+      shutdown: vi.fn(),
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+
+    await expect(session.establish(mockConn)).resolves.toBeUndefined()
+    expect(session.getState()).toBe('ready')
+  })
+})

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -63,7 +63,9 @@ vi.mock('../ipc/pty', () => ({
   getSshPtyProvider: vi.fn().mockReturnValue({
     dispose: vi.fn(),
     attach: vi.fn().mockResolvedValue(undefined),
-    attachForReconnect: vi.fn().mockResolvedValue({})
+    attachForReconnect: vi.fn().mockResolvedValue({}),
+    listProcesses: vi.fn().mockResolvedValue([]),
+    shutdown: vi.fn().mockResolvedValue(undefined)
   }),
   getPtyIdsForConnection: vi.fn().mockReturnValue([]),
   clearPtyOwnershipForConnection: vi.fn(),

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -119,6 +119,8 @@ export type SshRelayAiVaultHostInfo = {
 
 const RECONNECT_REPLAY_DUPLICATE_WINDOW_MS = 1000
 const REPLAY_FINGERPRINT_EDGE_CHARS = 128
+// Why: a spawn racing the orphan sweep may not have registered ownership yet; age-gate so it can never be reaped.
+const ORPHANED_RELAY_PTY_MIN_AGE_MS = 30_000
 
 function normalizeRelayGracePeriodSeconds(graceTimeSeconds: number | undefined): number {
   const raw = graceTimeSeconds ?? DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS
@@ -299,6 +301,7 @@ export class SshRelaySession {
 
       // Why: explicit disconnect keeps PTY ownership, so a later manual connect must reattach those remote PTYs.
       await this.reattachKnownPtys(ownsAttempt)
+      await this.reapOrphanedRelayPtys(ownsAttempt)
 
       if (!ownsAttempt()) {
         throw new Error('Session disposed during establish')
@@ -411,6 +414,7 @@ export class SshRelaySession {
       }
 
       await this.reattachKnownPtys(ownsAttempt)
+      await this.reapOrphanedRelayPtys(ownsAttempt)
 
       if (!ownsAttempt()) {
         return
@@ -1133,6 +1137,71 @@ export class SshRelaySession {
         if (this.pendingPtyReattaches.get(appPtyId) === pendingReattach) {
           this.pendingPtyReattaches.delete(appPtyId)
         }
+      }
+    }
+  }
+
+  // Why: nothing else reconciles the relay's PTY list with what the app tracks, so
+  // closes that failed or happened while disconnected leak slots until the relay's
+  // session cap blocks new terminals (the relay only self-cleans when all clients
+  // stay away past the grace window). Best-effort: a failed reap waits for the next
+  // reconnect sweep.
+  private async reapOrphanedRelayPtys(shouldContinue: () => boolean): Promise<void> {
+    const ptyProvider = getSshPtyProvider(this.targetId) as SshPtyProvider | undefined
+    if (!ptyProvider) {
+      return
+    }
+    let sessions: Awaited<ReturnType<SshPtyProvider['listProcesses']>>
+    try {
+      sessions = await ptyProvider.listProcesses()
+    } catch (err) {
+      console.warn(
+        `[ssh-relay-session] Orphaned PTY sweep skipped for ${this.targetId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      )
+      return
+    }
+    // Why: build the known set after listing so a spawn that completed mid-sweep counts as known.
+    const knownRelayPtyIds = new Set([
+      ...getPtyIdsForConnection(this.targetId).map((ptyId) =>
+        toRelaySshPtyId(this.targetId, ptyId)
+      ),
+      ...this.store
+        .getSshRemotePtyLeases(this.targetId)
+        .filter((lease) => lease.state !== 'terminated' && lease.state !== 'expired')
+        .map((lease) => lease.ptyId)
+    ])
+    for (const session of sessions) {
+      if (!shouldContinue()) {
+        return
+      }
+      // Why: only pane-bound PTYs are provably desktop-owned; bare relay shells (e.g. remote CLI) are left alone.
+      if (!session.paneKey) {
+        continue
+      }
+      if (
+        typeof session.startedAtMs !== 'number' ||
+        Date.now() - session.startedAtMs < ORPHANED_RELAY_PTY_MIN_AGE_MS
+      ) {
+        continue
+      }
+      const relayPtyId = toRelaySshPtyId(this.targetId, session.id)
+      if (knownRelayPtyIds.has(relayPtyId)) {
+        continue
+      }
+      try {
+        await ptyProvider.shutdown(session.id, { immediate: true, keepHistory: false })
+        this.store.markSshRemotePtyLease(this.targetId, relayPtyId, 'terminated')
+        console.warn(
+          `[ssh-relay-session] Reaped orphaned relay PTY ${relayPtyId} for ${this.targetId} (pane ${session.paneKey})`
+        )
+      } catch (err) {
+        console.warn(
+          `[ssh-relay-session] Failed to reap orphaned relay PTY ${relayPtyId} for ${this.targetId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        )
       }
     }
   }

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -1180,17 +1180,17 @@ export class SshRelaySession {
       if (!session.paneKey) {
         continue
       }
-      if (
-        typeof session.startedAtMs !== 'number' ||
-        Date.now() - session.startedAtMs < ORPHANED_RELAY_PTY_MIN_AGE_MS
-      ) {
+      // Why: ageMs is measured on the relay host's clock, so local/remote clock skew can't defeat the guard.
+      if (typeof session.ageMs !== 'number' || session.ageMs < ORPHANED_RELAY_PTY_MIN_AGE_MS) {
         continue
       }
-      const relayPtyId = toRelaySshPtyId(this.targetId, session.id)
-      if (knownRelayPtyIds.has(relayPtyId)) {
-        continue
-      }
+      // Why: toRelaySshPtyId throws on a foreign connection id; keep it inside the
+      // per-session try so one bad entry can't abort the sweep or the session.
       try {
+        const relayPtyId = toRelaySshPtyId(this.targetId, session.id)
+        if (knownRelayPtyIds.has(relayPtyId)) {
+          continue
+        }
         await ptyProvider.shutdown(session.id, { immediate: true, keepHistory: false })
         this.store.markSshRemotePtyLease(this.targetId, relayPtyId, 'terminated')
         console.warn(
@@ -1198,7 +1198,7 @@ export class SshRelaySession {
         )
       } catch (err) {
         console.warn(
-          `[ssh-relay-session] Failed to reap orphaned relay PTY ${relayPtyId} for ${this.targetId}: ${
+          `[ssh-relay-session] Failed to reap orphaned relay PTY ${session.id} for ${this.targetId}: ${
             err instanceof Error ? err.message : String(err)
           }`
         )

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -1163,15 +1163,27 @@ export class SshRelaySession {
       return
     }
     // Why: build the known set after listing so a spawn that completed mid-sweep counts as known.
-    const knownRelayPtyIds = new Set([
-      ...getPtyIdsForConnection(this.targetId).map((ptyId) =>
-        toRelaySshPtyId(this.targetId, ptyId)
-      ),
-      ...this.store
-        .getSshRemotePtyLeases(this.targetId)
-        .filter((lease) => lease.state !== 'terminated' && lease.state !== 'expired')
-        .map((lease) => lease.ptyId)
-    ])
+    // An incomplete known set could reap a PTY the app still owns, so any failure here must
+    // skip the whole sweep rather than proceed with partial knowledge.
+    let knownRelayPtyIds: Set<string>
+    try {
+      knownRelayPtyIds = new Set([
+        ...getPtyIdsForConnection(this.targetId).map((ptyId) =>
+          toRelaySshPtyId(this.targetId, ptyId)
+        ),
+        ...this.store
+          .getSshRemotePtyLeases(this.targetId)
+          .filter((lease) => lease.state !== 'terminated' && lease.state !== 'expired')
+          .map((lease) => lease.ptyId)
+      ])
+    } catch (err) {
+      console.warn(
+        `[ssh-relay-session] Orphaned PTY sweep skipped for ${this.targetId} (known-set build failed): ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      )
+      return
+    }
     for (const session of sessions) {
       if (!shouldContinue()) {
         return

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -2332,15 +2332,15 @@ describe('PtyHandler', () => {
       const sessions = (await dispatcher.callRequest('pty.listProcesses')) as {
         id: string
         paneKey?: string
-        startedAtMs?: number
+        ageMs?: number
       }[]
 
       const panePty = sessions.find((session) => session.id === 'pty-1')
       const barePty = sessions.find((session) => session.id === 'pty-2')
       expect(panePty?.paneKey).toBe('tab-1:leaf-1')
-      expect(typeof panePty?.startedAtMs).toBe('number')
+      expect(typeof panePty?.ageMs).toBe('number')
       expect(barePty?.paneKey).toBeUndefined()
-      expect(typeof barePty?.startedAtMs).toBe('number')
+      expect(typeof barePty?.ageMs).toBe('number')
     } finally {
       fgSpy.mockRestore()
     }

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -2321,6 +2321,31 @@ describe('PtyHandler', () => {
     expect(callArgs.env.TERM_PROGRAM).toBe('Orca')
   })
 
+  it('lists pane key and start time so clients can reap orphaned pane PTYs', async () => {
+    const fgSpy = vi.spyOn(ptyShellUtils, 'getForegroundProcessName').mockResolvedValue('shell')
+    try {
+      await dispatcher.callRequest('pty.spawn', {
+        env: { ORCA_PANE_KEY: 'tab-1:leaf-1', ORCA_TAB_ID: 'tab-1' }
+      })
+      await dispatcher.callRequest('pty.spawn', {})
+
+      const sessions = (await dispatcher.callRequest('pty.listProcesses')) as {
+        id: string
+        paneKey?: string
+        startedAtMs?: number
+      }[]
+
+      const panePty = sessions.find((session) => session.id === 'pty-1')
+      const barePty = sessions.find((session) => session.id === 'pty-2')
+      expect(panePty?.paneKey).toBe('tab-1:leaf-1')
+      expect(typeof panePty?.startedAtMs).toBe('number')
+      expect(barePty?.paneKey).toBeUndefined()
+      expect(typeof barePty?.startedAtMs).toBe('number')
+    } finally {
+      fgSpy.mockRestore()
+    }
+  })
+
   it('fences both revived worktree identity and cwd with rollback', async () => {
     const finishSiblingAdmission = vi.fn()
     const beginWorktreePtySpawn = vi.fn((operationPath: string) => {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -111,6 +111,8 @@ type ManagedPty = {
   startupIngressIntent?: ReturnType<typeof parsePtyStartupIngressIntent>
   ownerBackend: PtyOwnerBackend
   agentSessionOwners?: AgentSessionOwnerBinding[]
+  /** Epoch ms when this PTY was wired (spawn or revive). */
+  startedAtMs?: number
 }
 
 type RelayAgentSessionCreateResult = {
@@ -245,6 +247,8 @@ type PtyProcessSummary = {
   worktreeId?: string
   terminalHandle?: string
   agentSessionOwners?: AgentSessionOwnerBinding[]
+  paneKey?: string
+  startedAtMs?: number
 }
 
 type SerializedPtyEntry = {
@@ -532,6 +536,8 @@ export class PtyHandler {
 
   /** Wire onData/onExit listeners for a managed PTY and store it. */
   private wireAndStore(managed: ManagedPty): void {
+    // Why: lets clients age-gate orphan reaping so an in-flight spawn is never mistaken for an orphan.
+    managed.startedAtMs ??= Date.now()
     managed.physicalExit = new PhysicalExitTracker()
     this.ptys.set(managed.id, managed)
     const emitIngressData = (emission: PtyIngressEmission): void => {
@@ -1440,7 +1446,9 @@ export class PtyHandler {
         ...(managed.terminalHandle ? { terminalHandle: managed.terminalHandle } : {}),
         ...(this.agentSessionOwners.listForPty(id).length
           ? { agentSessionOwners: this.agentSessionOwners.listForPty(id) }
-          : {})
+          : {}),
+        ...(managed.paneKey ? { paneKey: managed.paneKey } : {}),
+        ...(managed.startedAtMs !== undefined ? { startedAtMs: managed.startedAtMs } : {})
       })
     }
     return results

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -248,7 +248,7 @@ type PtyProcessSummary = {
   terminalHandle?: string
   agentSessionOwners?: AgentSessionOwnerBinding[]
   paneKey?: string
-  startedAtMs?: number
+  ageMs?: number
 }
 
 type SerializedPtyEntry = {
@@ -1448,7 +1448,8 @@ export class PtyHandler {
           ? { agentSessionOwners: this.agentSessionOwners.listForPty(id) }
           : {}),
         ...(managed.paneKey ? { paneKey: managed.paneKey } : {}),
-        ...(managed.startedAtMs !== undefined ? { startedAtMs: managed.startedAtMs } : {})
+        // Why: report age computed on this host's clock so client/remote clock skew can't distort it.
+        ...(managed.startedAtMs !== undefined ? { ageMs: Date.now() - managed.startedAtMs } : {})
       })
     }
     return results


### PR DESCRIPTION
Fixes #9819

## Summary

On SSH remotes, relay PTY slots leak until every new terminal spawn fails with **"Maximum number of PTY sessions reached (50)"**, and closing terminals/worktrees doesn't recover them. The relay daemon survives app restarts (reconnects cancel its grace window), slots are only freed by an explicit `pty.shutdown`, and nothing reconciled the relay's live PTY list with what the app still tracks. Terminals closed while the connection was down (lease tombstoned locally, remote PTY never killed), transient shutdown failures, and worktree teardown (which only sweeps the local provider) all leaked slots permanently. Full analysis in #9819.


**User-visible change:** after this fix, connecting or reconnecting to an SSH remote garbage-collects orphaned relay terminals, so long-running setups no longer hit the 50-session cap. No workflow or UI changes.

### How it works

After `reattachKnownPtys` on both `establish()` and `reconnect()`, the session runs a best-effort orphan sweep:

- lists the relay's PTYs and shuts down (immediate, no history) any entry the app no longer owns or holds a non-terminated/expired lease for
- only reaps **pane-bound** PTYs (`paneKey` captured from `ORCA_PANE_KEY` at spawn) — bare relay shells such as remote-CLI sessions are never touched
- skips entries younger than 30s so a spawn racing the sweep can never be reaped; the age (`ageMs`) is computed on the relay host's clock so local/remote clock skew can't weaken the guard, and the known set is built *after* listing so a spawn that lands mid-sweep counts as known
- skips entries with no `ageMs` (relay predating this change) — age unknown, never reaped
- every per-entry step (including id conversion) is inside a per-session try/catch; any failure logs and moves on, and the session always still reaches `ready`

To support this, the relay's `pty.listProcesses` now reports `paneKey` and `ageMs` (start time stamped in `wireAndStore`, covering both spawn and revive). Both fields are optional and additive; version skew in either direction degrades to "no reaping" rather than misbehavior.

## Screenshots

<img width="554" height="78" alt="image" src="https://github.com/user-attachments/assets/13b31e32-88f3-43c7-9e60-dd953eba7154" />

## Testing

- [x] `pnpm lint` — oxlint clean on every changed file; the full run fails only on a pre-existing `switch-exhaustiveness` error in `src/renderer/src/components/skills/skill-freshness-group.tsx` that reproduces identically on untouched `origin/main` in my environment
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — every suite touching this change passes (`src/main/ssh`, `src/main/providers`, `src/relay/pty-handler.test.ts`); the full run has 48 failures that reproduce identically on untouched `origin/main` in my environment (Node 26 vs the repo's required Node 24), all in files this PR does not touch
- [x] `pnpm build` — clean
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New tests:

- `src/main/ssh/ssh-relay-session-orphan-pty-reap.test.ts`: reaps orphans on establish and reconnect; spares bare shells, young spawns, unknown-age entries, and leased PTYs; a foreign-connection entry cannot abort the sweep or the session; a `listProcesses` failure still reaches `ready`
- `src/relay/pty-handler.test.ts`: `pty.listProcesses` reports `paneKey`/`ageMs`

## AI Review Report

Reviewed with Claude Code (Claude Fable 5), plus the CodeRabbit pass on this PR. Risks checked and outcomes:

- **Cross-platform (macOS/Linux/Windows):** the relay change runs on remote hosts of all three platforms — it adds only `Date.now()` arithmetic and optional metadata fields; no paths, shortcuts, shell behavior, signals, or Electron platform differences are touched. The main-process sweep is platform-neutral. No renderer/UI changes.
- **SSH/remote/local compatibility:** the sweep is SSH-provider-only and cannot touch local or daemon PTYs. Version skew both ways verified: old relay + new app → no `ageMs` → nothing reaped; new relay + old app → extra optional fields ignored.
- **Agent/integration compatibility:** remote-CLI and any non-pane relay shells are exempt (no `paneKey`); agent panes in worktrees are pane-bound and correctly covered. The relay's per-instance socket means the sweep can only ever see PTYs created by this app install.
- **False-positive reaping (main risk):** guarded three ways — pane-key requirement, relay-clock 30s age gate for in-flight spawns, and known-set computed after the relay listing. Flagged during review and fixed: the age gate originally compared a relay timestamp against the local clock (skew could weaken it); it now uses relay-computed `ageMs`.
- **Stability:** CodeRabbit flagged that `toRelaySshPtyId` could throw outside the try/catch and tear down the session on a malformed entry — fixed by moving it inside the per-session try/catch, with a regression test.
- **Performance:** one extra `pty.listProcesses` round-trip per connect/reconnect (not a hot path); shutdowns are sequential and bounded by the 50-session cap.

## Security Audit

- **Input handling:** `session.id`, `paneKey`, and `ageMs` come from the remote relay and are treated as untrusted — ids pass through the existing `toRelaySshPtyId` validation (throws on foreign connection ids, now safely contained per-entry), `ageMs` is type-checked, and `paneKey` is only used as an opaque presence marker and in a local `console.warn`.
- **Command execution:** none added; the sweep only issues existing `pty.shutdown` RPCs back to the same relay the data came from.
- **Path handling / secrets / dependencies:** none touched.
- **IPC:** no new IPC surface; `pty.listProcesses` gains optional response fields only. `markSshRemotePtyLease` no-ops for unknown leases, so a hostile relay can't use the sweep to corrupt lease state beyond marking its own PTYs terminated.
- **Blast radius:** worst case (all guards somehow bypassed) is a terminal the app owns being closed — the sweep can never touch other users' processes or other app installs' relays.

## Notes

- SSH-specific by design; local and WSL PTY providers are unaffected.
- Old relays without `ageMs` are never reaped from — the fix fully activates once the relay redeploys (which happens automatically on version match failure).
- Follow-up candidate (intentionally out of scope): make `kill()`'s close-while-disconnected path record a pending kill instead of tombstoning the lease, so orphans are prevented at the source rather than only GC'd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## ELI5

SSH relay PTY slots leaked across reconnects until new terminals hit the 50-session cap. On reconnect Orca reaps orphaned remote PTYs that the app no longer tracks so slots free up again.
