### PR TITLE
fix(browser): stop failing goto when a redirect or download aborts the load

### DIFF
--- a/src/main/browser/agent-browser-bridge.test.ts
+++ b/src/main/browser/agent-browser-bridge.test.ts
@@ -98,6 +98,9 @@ function mockWebContents(id: number, url = 'https://example.com', title = 'Examp
     loadURL: vi.fn(async (nextUrl: string) => {
       currentUrl = nextUrl
     }),
+    isLoading: vi.fn(() => false),
+    on: vi.fn(),
+    removeListener: vi.fn(),
     isDestroyed: () => false,
     invalidate: vi.fn(),
     focus: vi.fn(),
@@ -1667,19 +1670,37 @@ describe('AgentBrowserBridge', () => {
     }
   })
 
-  it('reports the landed page when a client-side redirect aborts direct navigation', async () => {
+  it('waits for a superseding navigation to land after direct navigation aborts', async () => {
     const wc = mockWebContents(100, 'https://example.com/current', 'Example')
-    wc.loadURL.mockImplementation(async () => {
-      // Mimic Electron: the target commits, a JS/meta redirect supersedes the load, loadURL rejects.
-      wc.getURL = () => 'https://example.com/login'
-      throw Object.assign(new Error('ERR_ABORTED (-3)'), { code: 'ERR_ABORTED', errno: -3 })
+    let currentUrl = 'https://example.com/current'
+    let loading = true
+    const listeners = new Map<string, () => void>()
+    wc.getURL = () => currentUrl
+    wc.isLoading.mockImplementation(() => loading)
+    wc.on.mockImplementation((event: string, listener: () => void) => {
+      listeners.set(event, listener)
     })
+    wc.loadURL.mockRejectedValue(
+      Object.assign(new Error('ERR_ABORTED (-3)'), { code: 'ERR_ABORTED', errno: -3 })
+    )
     webContentsFromIdMock.mockReturnValue(wc)
 
-    await expect(bridge.goto('https://example.com/sso')).resolves.toEqual({
+    const navigation = bridge.goto('https://example.com/sso')
+    await vi.waitFor(() => expect(listeners.get('did-stop-loading')).toBeDefined())
+
+    currentUrl = 'https://example.com/login'
+    loading = false
+    listeners.get('did-stop-loading')!()
+
+    await expect(navigation).resolves.toEqual({
       url: 'https://example.com/login',
       title: 'Example'
     })
+    expect(wc.removeListener).toHaveBeenCalledWith(
+      'did-stop-loading',
+      listeners.get('did-stop-loading')
+    )
+    expect(wc.removeListener).toHaveBeenCalledWith('destroyed', listeners.get('destroyed'))
     expect(execFileMock).not.toHaveBeenCalled()
   })
 
@@ -1693,6 +1714,82 @@ describe('AgentBrowserBridge', () => {
       title: 'Example'
     })
     expect(execFileMock).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when the page prevents direct navigation', async () => {
+    const wc = mockWebContents(100, 'https://example.com/unsaved', 'Unsaved changes')
+    wc.loadURL.mockImplementation(async () => {
+      const preventUnload = wc.on.mock.calls.find(
+        ([event]) => event === 'will-prevent-unload'
+      )?.[1] as ((event: { defaultPrevented: boolean }) => void) | undefined
+      preventUnload!({ defaultPrevented: false })
+      throw Object.assign(new Error('ERR_ABORTED (-3)'), { code: 'ERR_ABORTED', errno: -3 })
+    })
+    webContentsFromIdMock.mockReturnValue(wc)
+
+    await expect(bridge.goto('https://example.com/next')).rejects.toMatchObject({
+      code: 'browser_error',
+      message: 'Failed to navigate browser page tab-1: ERR_ABORTED (-3)'
+    })
+    const preventUnload = wc.on.mock.calls.find(([event]) => event === 'will-prevent-unload')?.[1]
+    expect(wc.removeListener).toHaveBeenCalledWith('will-prevent-unload', preventUnload)
+    expect(execFileMock).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when the navigation superseding an abort fails', async () => {
+    const wc = mockWebContents(100, 'https://example.com/current', 'Example')
+    wc.loadURL.mockRejectedValue(
+      Object.assign(new Error('ERR_ABORTED (-3)'), { code: 'ERR_ABORTED', errno: -3 })
+    )
+    webContentsFromIdMock.mockReturnValue(wc)
+    const getBrowserPageLoadError = vi.fn(() => ({
+      code: -105,
+      description: 'Name not resolved',
+      validatedUrl: 'https://nxdomain.example/'
+    }))
+    const b = new AgentBrowserBridge(
+      mockBrowserManager(new Map([['tab-1', 100]]), undefined, {
+        getBrowserPageLoadError
+      })
+    )
+    b.setActiveTab(100)
+
+    await expect(b.goto('https://example.com/redirect')).rejects.toMatchObject({
+      code: 'browser_error',
+      message: 'Failed to navigate browser page tab-1: Name not resolved (-105)'
+    })
+    expect(execFileMock).not.toHaveBeenCalled()
+  })
+
+  it('bounds and cleans up a superseding navigation that never settles', async () => {
+    vi.useFakeTimers()
+    try {
+      const wc = mockWebContents(100, 'https://example.com/current', 'Example')
+      wc.isLoading.mockReturnValue(true)
+      wc.loadURL.mockRejectedValue(
+        Object.assign(new Error('ERR_ABORTED (-3)'), { code: 'ERR_ABORTED', errno: -3 })
+      )
+      webContentsFromIdMock.mockReturnValue(wc)
+
+      const navigation = bridge.goto('https://example.com/redirect')
+      const rejection = expect(navigation).rejects.toMatchObject({
+        code: 'browser_error',
+        message: 'Failed to navigate browser page tab-1: Browser navigation timed out after 30000ms'
+      })
+      await vi.advanceTimersByTimeAsync(30_000)
+
+      await rejection
+      const stopLoading = wc.on.mock.calls.find(([event]) => event === 'did-stop-loading')?.[1]
+      const destroyed = wc.on.mock.calls.find(([event]) => event === 'destroyed')?.[1]
+      expect(wc.removeListener).toHaveBeenCalledWith('did-stop-loading', stopLoading)
+      expect(wc.removeListener).toHaveBeenCalledWith('destroyed', destroyed)
+      expect(vi.getTimerCount()).toBe(0)
+      expect(
+        (bridge as unknown as { commandQueues: Map<string, unknown[]> }).commandQueues.size
+      ).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('fails closed when direct navigation fails for a non-abort reason', async () => {

--- a/src/main/browser/agent-browser-bridge.test.ts
+++ b/src/main/browser/agent-browser-bridge.test.ts
@@ -1667,16 +1667,47 @@ describe('AgentBrowserBridge', () => {
     }
   })
 
-  it('fails closed when direct navigation is aborted', async () => {
-    const wc = mockWebContents(100, 'https://example.com/current', 'Current')
+  it('reports the landed page when a client-side redirect aborts direct navigation', async () => {
+    const wc = mockWebContents(100, 'https://example.com/current', 'Example')
+    wc.loadURL.mockImplementation(async () => {
+      // Mimic Electron: the target commits, a JS/meta redirect supersedes the load, loadURL rejects.
+      wc.getURL = () => 'https://example.com/login'
+      throw Object.assign(new Error('ERR_ABORTED (-3)'), { code: 'ERR_ABORTED', errno: -3 })
+    })
+    webContentsFromIdMock.mockReturnValue(wc)
+
+    await expect(bridge.goto('https://example.com/sso')).resolves.toEqual({
+      url: 'https://example.com/login',
+      title: 'Example'
+    })
+    expect(execFileMock).not.toHaveBeenCalled()
+  })
+
+  it('resolves with the unchanged page when a download-triggered load aborts', async () => {
+    const wc = mockWebContents(100, 'https://example.com/current', 'Example')
+    wc.loadURL.mockRejectedValue(Object.assign(new Error('ERR_ABORTED (-3)'), { errno: -3 }))
+    webContentsFromIdMock.mockReturnValue(wc)
+
+    await expect(bridge.goto('https://example.com/download')).resolves.toEqual({
+      url: 'https://example.com/current',
+      title: 'Example'
+    })
+    expect(execFileMock).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when direct navigation fails for a non-abort reason', async () => {
+    const wc = mockWebContents(100, 'https://example.com/current', 'Example')
     wc.loadURL.mockRejectedValue(
-      Object.assign(new Error('ERR_ABORTED (-3)'), { code: 'ERR_ABORTED' })
+      Object.assign(new Error('ERR_NAME_NOT_RESOLVED (-105)'), {
+        code: 'ERR_NAME_NOT_RESOLVED',
+        errno: -105
+      })
     )
     webContentsFromIdMock.mockReturnValue(wc)
 
-    await expect(bridge.goto('https://example.com/download')).rejects.toMatchObject({
+    await expect(bridge.goto('https://nxdomain.example')).rejects.toMatchObject({
       code: 'browser_error',
-      message: 'Failed to navigate browser page tab-1: ERR_ABORTED (-3)'
+      message: 'Failed to navigate browser page tab-1: ERR_NAME_NOT_RESOLVED (-105)'
     })
     expect(execFileMock).not.toHaveBeenCalled()
   })

--- a/src/main/browser/agent-browser-bridge.test.ts
+++ b/src/main/browser/agent-browser-bridge.test.ts
@@ -1620,6 +1620,7 @@ describe('AgentBrowserBridge', () => {
     })
 
     expect(wc.loadURL).toHaveBeenCalledWith('https://example.com/next')
+    expect(wc.isLoading).not.toHaveBeenCalled()
     expect(execFileMock).not.toHaveBeenCalled()
   })
 
@@ -1713,6 +1714,8 @@ describe('AgentBrowserBridge', () => {
       url: 'https://example.com/current',
       title: 'Example'
     })
+    expect(wc.isLoading).toHaveBeenCalledTimes(1)
+    expect(wc.on).not.toHaveBeenCalledWith('did-stop-loading', expect.any(Function))
     expect(execFileMock).not.toHaveBeenCalled()
   })
 
@@ -1783,6 +1786,39 @@ describe('AgentBrowserBridge', () => {
       const destroyed = wc.on.mock.calls.find(([event]) => event === 'destroyed')?.[1]
       expect(wc.removeListener).toHaveBeenCalledWith('did-stop-loading', stopLoading)
       expect(wc.removeListener).toHaveBeenCalledWith('destroyed', destroyed)
+      expect(vi.getTimerCount()).toBe(0)
+      expect(
+        (bridge as unknown as { commandQueues: Map<string, unknown[]> }).commandQueues.size
+      ).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('cleans up when the guest is destroyed while attaching the replacement wait', async () => {
+    vi.useFakeTimers()
+    try {
+      const wc = mockWebContents(100, 'https://example.com/current', 'Example')
+      let destroyed = false
+      wc.isDestroyed = () => destroyed
+      wc.isLoading.mockReturnValueOnce(true).mockImplementationOnce(() => {
+        destroyed = true
+        throw new Error('Object has been destroyed')
+      })
+      wc.loadURL.mockRejectedValue(
+        Object.assign(new Error('ERR_ABORTED (-3)'), { code: 'ERR_ABORTED', errno: -3 })
+      )
+      webContentsFromIdMock.mockReturnValue(wc)
+
+      await expect(bridge.goto('https://example.com/redirect')).rejects.toMatchObject({
+        code: 'browser_tab_not_found',
+        message: 'Browser page tab-1 is no longer available'
+      })
+
+      const stopLoading = wc.on.mock.calls.find(([event]) => event === 'did-stop-loading')?.[1]
+      const destroyedListener = wc.on.mock.calls.find(([event]) => event === 'destroyed')?.[1]
+      expect(wc.removeListener).toHaveBeenCalledWith('did-stop-loading', stopLoading)
+      expect(wc.removeListener).toHaveBeenCalledWith('destroyed', destroyedListener)
       expect(vi.getTimerCount()).toBe(0)
       expect(
         (bridge as unknown as { commandQueues: Map<string, unknown[]> }).commandQueues.size

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -272,17 +272,21 @@ function isAbortedNavigationError(error: unknown): boolean {
   return code === 'ERR_ABORTED' || errno === -3
 }
 
+function isWebContentsLoading(wc: WebContents): boolean {
+  try {
+    return wc.isLoading()
+  } catch {
+    // Why: destruction races are resolved against the authoritative page registration after the wait.
+    return false
+  }
+}
+
 function waitForAbortedNavigationReplacement(
   wc: WebContents,
   browserPageId: string,
   timeoutMs: number
 ): Promise<void> {
-  try {
-    if (!wc.isLoading()) {
-      return Promise.resolve()
-    }
-  } catch {
-    // A destroyed guest is resolved against the authoritative page registration below.
+  if (!isWebContentsLoading(wc)) {
     return Promise.resolve()
   }
 
@@ -323,7 +327,7 @@ function waitForAbortedNavigationReplacement(
     timeout.unref?.()
 
     // Why: the replacement can finish between loadURL rejecting and listener attachment.
-    if (!wc.isLoading()) {
+    if (!isWebContentsLoading(wc)) {
       finish()
     }
   })

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -264,6 +264,14 @@ function classifyErrorCode(message: string): string {
   return 'browser_error'
 }
 
+function isAbortedNavigationError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+  const { code, errno } = error as { code?: unknown; errno?: unknown }
+  return code === 'ERR_ABORTED' || errno === -3
+}
+
 function isTabClosedTransportError(message: string): boolean {
   return /session destroyed while command|session destroyed while commands|connection refused|cdp discovery methods failed|websocket connect failed/i.test(
     message
@@ -798,10 +806,13 @@ export class AgentBrowserBridge {
           if (!this.getWebContents(target.webContentsId)) {
             throw this.createPageUnavailableError(`orca-tab-${target.browserPageId}`)
           }
-          throw new BrowserError(
-            'browser_error',
-            `Failed to navigate browser page ${target.browserPageId}: ${error instanceof Error ? error.message : String(error)}`
-          )
+          // Why: loadURL rejects ERR_ABORTED (-3) on redirects/SPA navigations and downloads; the page is still usable (see offscreen-browser-backend), so report where it landed instead of failing.
+          if (!isAbortedNavigationError(error)) {
+            throw new BrowserError(
+              'browser_error',
+              `Failed to navigate browser page ${target.browserPageId}: ${error instanceof Error ? error.message : String(error)}`
+            )
+          }
         } finally {
           if (navigationTimeout) {
             clearTimeout(navigationTimeout)

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -272,6 +272,63 @@ function isAbortedNavigationError(error: unknown): boolean {
   return code === 'ERR_ABORTED' || errno === -3
 }
 
+function waitForAbortedNavigationReplacement(
+  wc: WebContents,
+  browserPageId: string,
+  timeoutMs: number
+): Promise<void> {
+  try {
+    if (!wc.isLoading()) {
+      return Promise.resolve()
+    }
+  } catch {
+    // A destroyed guest is resolved against the authoritative page registration below.
+    return Promise.resolve()
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false
+    let timeout: ReturnType<typeof setTimeout> | null = null
+    const finish = (error?: BrowserError): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      wc.removeListener('did-stop-loading', onDidStopLoading)
+      wc.removeListener('destroyed', onDestroyed)
+      if (timeout) {
+        clearTimeout(timeout)
+      }
+      if (error) {
+        reject(error)
+      } else {
+        resolve()
+      }
+    }
+    const onDidStopLoading = (): void => finish()
+    const onDestroyed = (): void => finish()
+
+    wc.on('did-stop-loading', onDidStopLoading)
+    wc.on('destroyed', onDestroyed)
+    timeout = setTimeout(
+      () =>
+        finish(
+          new BrowserError(
+            'browser_error',
+            `Failed to navigate browser page ${browserPageId}: Browser navigation timed out after ${EMBEDDED_NAVIGATION_TIMEOUT_MS}ms`
+          )
+        ),
+      timeoutMs
+    )
+    timeout.unref?.()
+
+    // Why: the replacement can finish between loadURL rejecting and listener attachment.
+    if (!wc.isLoading()) {
+      finish()
+    }
+  })
+}
+
 function isTabClosedTransportError(message: string): boolean {
   return /session destroyed while command|session destroyed while commands|connection refused|cdp discovery methods failed|websocket connect failed/i.test(
     message
@@ -785,6 +842,15 @@ export class AgentBrowserBridge {
         if (!navigationUrl) {
           throw new BrowserError('invalid_argument', `Unsupported browser URL: ${url}`)
         }
+        const navigationState: { preventUnloadEvent: Electron.Event | null } = {
+          preventUnloadEvent: null
+        }
+        const onWillPreventUnload = (event: Electron.Event): void => {
+          navigationState.preventUnloadEvent = event
+        }
+        wc.on('will-prevent-unload', onWillPreventUnload)
+        let navigationAborted = false
+        const navigationDeadline = Date.now() + EMBEDDED_NAVIGATION_TIMEOUT_MS
         let navigationTimeout: ReturnType<typeof setTimeout> | null = null
         try {
           await Promise.race([
@@ -803,17 +869,33 @@ export class AgentBrowserBridge {
             })
           ])
         } catch (error) {
+          if (navigationTimeout) {
+            clearTimeout(navigationTimeout)
+            navigationTimeout = null
+          }
           if (!this.getWebContents(target.webContentsId)) {
             throw this.createPageUnavailableError(`orca-tab-${target.browserPageId}`)
           }
-          // Why: loadURL rejects ERR_ABORTED (-3) on redirects/SPA navigations and downloads; the page is still usable (see offscreen-browser-backend), so report where it landed instead of failing.
-          if (!isAbortedNavigationError(error)) {
+          // Why: ERR_ABORTED also covers a page vetoing unload; that navigation did not succeed.
+          if (
+            !isAbortedNavigationError(error) ||
+            (navigationState.preventUnloadEvent !== null &&
+              !navigationState.preventUnloadEvent.defaultPrevented)
+          ) {
             throw new BrowserError(
               'browser_error',
               `Failed to navigate browser page ${target.browserPageId}: ${error instanceof Error ? error.message : String(error)}`
             )
           }
+          navigationAborted = true
+          // Why: a superseding navigation rejects the first load before its replacement has landed.
+          await waitForAbortedNavigationReplacement(
+            wc,
+            target.browserPageId,
+            Math.max(0, navigationDeadline - Date.now())
+          )
         } finally {
+          wc.removeListener('will-prevent-unload', onWillPreventUnload)
           if (navigationTimeout) {
             clearTimeout(navigationTimeout)
           }
@@ -822,6 +904,15 @@ export class AgentBrowserBridge {
         // Why: cross-process navigation can replace the guest while retaining the same authoritative page id.
         const navigatedTarget = this.resolveCommandTarget(worktreeId, target.browserPageId)
         const navigatedWebContents = this.requireTargetWebContents(navigatedTarget)
+        const loadError = navigationAborted
+          ? this.browserManager.getBrowserPageLoadError(target.browserPageId)
+          : null
+        if (loadError) {
+          throw new BrowserError(
+            'browser_error',
+            `Failed to navigate browser page ${target.browserPageId}: ${loadError.description} (${loadError.code})`
+          )
+        }
         return { url: navigatedWebContents.getURL(), title: navigatedWebContents.getTitle() }
       },
       { ensureSession: false }


### PR DESCRIPTION
## What

Embedded-browser `goto` no longer reports a spurious failure when Electron `loadURL` rejects with `ERR_ABORTED (-3)` for a superseded or download-triggered load.

The abort path now distinguishes three outcomes:

- If another navigation is already loading, wait for it to stop and return its actual URL/title.
- If no replacement is loading, return the still-usable current page (the download-triggered case).
- If the page vetoed unload, the replacement failed, or the bounded wait timed out, fail closed.

Every non-abort `loadURL` error remains unchanged.

## Why

#9633 moved embedded `goto` from the daemon helper to direct `WebContents.loadURL`. Electron rejects with `ERR_ABORTED` when that load is superseded, even though the browser can continue to a usable replacement page. Surfacing that rejection directly caused successful SSO/login flows to report `Failed to navigate browser page ...: ERR_ABORTED (-3)`.

Testing against the pinned Electron 43.1.0 runtime also showed why a bare catch-and-ignore is unsafe:

- the rejected promise can settle before the replacement navigation lands, so immediately reading `getURL()` returns the old page;
- a page that blocks navigation in `beforeunload` also produces `ERR_ABORTED`, but the requested navigation did not happen.

The bridge therefore waits only when an aborted load has an in-flight replacement, uses `did-stop-loading` rather than polling, keeps the existing 30-second total budget, cleans up its timer/listeners on success, timeout, and destruction, and re-checks BrowserManager load state before reporting success.

## Tests

Added coverage for:

- superseding navigation abort → waits and returns the landed URL/title;
- download-triggered abort → returns the unchanged usable page;
- `beforeunload` veto → fails closed;
- failed replacement navigation → fails closed;
- replacement that never settles → times out, removes listeners/timer, and releases the command queue;
- ordinary non-abort navigation failure → still fails closed.

Verification:

- `agent-browser-bridge.test.ts`: 103/103
- related browser-manager/offscreen/runtime RPC suites: 83/83
- all TypeScript projects
- repository-wide oxlint (0 errors)
- oxfmt and `git diff --check`
- max-lines ratchet

A full local suite under unsupported Node 26 completed 33,665 passing tests; its unrelated failures were Node-24/environment-sensitive localStorage, inherited Git environment, and timeout tests. PR CI runs the supported Node version.