### PR TITLE
fix(native-chat): buffer composer side effects during IME composition (#9738)

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatComposer.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.tsx
@@ -1,4 +1,12 @@
-import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react'
+import {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 import { useAppStore } from '../../store'
 import { sendRuntimePtyInput } from '@/runtime/runtime-terminal-inspection'
 import { getSettingsForAgentTabRuntimeOwner } from '@/lib/agent-paste-draft'
@@ -82,14 +90,17 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
     // Why: local, SSH, and runtime reconnects can replace or temporarily clear
     // the PTY id. Pane identity is the stable ownership key for unsent input.
     const draftScopeKey = paneKey
-    const { draft, setDraft } = useNativeChatDraft(draftScopeKey)
+    const isComposingRef = useRef(false)
+    // Why: compositionend is followed by one more change with the committed text, so the next draft update must skip duplicate side effects.
+    const skipNextChangeRef = useRef<string | null>(null)
+    const { draft, setDraft, setDraftWithoutPersist, persistDraft } =
+      useNativeChatDraft(draftScopeKey)
     const [caret, setCaret] = useState(draft.length)
     const [history, setHistory] = useState<HistoryState>(EMPTY_HISTORY)
     const [activeSuggestion, setActiveSuggestion] = useState(0)
     const [notice, setNotice] = useState<string | null>(null)
     const [dictationPressed, setDictationPressed] = useState(false)
     const textareaRef = useRef<HTMLTextAreaElement>(null)
-    const isComposingRef = useRef(false)
     const { cancelPendingSends, trackPendingSend } = useNativeChatSendLifecycle(
       terminalTabId,
       targetPtyId,
@@ -113,6 +124,10 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
       lastDraftScopeKey.current = draftScopeKey
       setCaret(readNativeChatDraftCache(draftScopeKey).length)
     }
+    useLayoutEffect(() => {
+      isComposingRef.current = false
+      skipNextChangeRef.current = null
+    }, [draftScopeKey])
 
     const agentCommands = useMemo(() => getVerifiedNativeChatCommands(agent), [agent])
     const picker = useNativeChatPickerState({
@@ -366,6 +381,18 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
         isDictating={isDictating}
         isDictationHoldMode={isDictationHoldMode}
         onDraftChange={(value, element) => {
+          if (isComposingRef.current) {
+            setDraftWithoutPersist(value)
+            syncCaret(element)
+            return
+          }
+          if (skipNextChangeRef.current === value) {
+            skipNextChangeRef.current = null
+            setDraftWithoutPersist(value)
+            syncCaret(element)
+            return
+          }
+          skipNextChangeRef.current = null
           setDraft(value)
           setHistory((prev) => ({ entries: prev.entries, index: null }))
           syncCaret(element)
@@ -380,9 +407,19 @@ export const NativeChatComposer = forwardRef<NativeChatComposerHandle, NativeCha
         onKeyDown={handleKeyDown}
         onCompositionStart={() => {
           isComposingRef.current = true
+          skipNextChangeRef.current = null
         }}
-        onCompositionEnd={() => {
+        onCompositionEnd={(event) => {
           isComposingRef.current = false
+          const element = event.currentTarget
+          const value = element.value
+          setDraftWithoutPersist(value)
+          persistDraft(value)
+          setHistory((prev) => ({ entries: prev.entries, index: null }))
+          syncCaret(element)
+          handleDraftOrCaretChange(value, element.selectionStart ?? value.length)
+          setActiveSuggestion(0)
+          skipNextChangeRef.current = value
         }}
         onPaste={handlePaste}
         pickerListboxId={picker.listboxId}

--- a/src/renderer/src/components/native-chat/native-chat-composer-composition.test.tsx
+++ b/src/renderer/src/components/native-chat/native-chat-composer-composition.test.tsx
@@ -1,0 +1,240 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  draft: '',
+  setDraft: vi.fn(),
+  setDraftWithoutPersist: vi.fn(),
+  persistDraft: vi.fn(),
+  fieldProps: null as ComposerFieldProps | null,
+  pickerChange: vi.fn(),
+  send: vi.fn()
+}))
+
+type CompositionEvent = { currentTarget: HTMLTextAreaElement }
+type KeyEvent = {
+  key: string
+  shiftKey: boolean
+  keyCode: number
+  nativeEvent: { isComposing: boolean }
+  preventDefault: () => void
+}
+type ComposerFieldProps = {
+  onDraftChange: (value: string, element: HTMLTextAreaElement) => void
+  onCompositionStart: () => void
+  onCompositionEnd: (event: CompositionEvent) => void
+  onKeyDown: (event: KeyEvent) => void
+}
+
+vi.mock('../../store', () => ({
+  useAppStore: (
+    selector: (value: {
+      dictationState: string
+      settings: { voice: { enabled: boolean } }
+    }) => unknown
+  ) => selector({ dictationState: 'idle', settings: { voice: { enabled: false } } })
+}))
+vi.mock('@/runtime/runtime-terminal-inspection', () => ({
+  sendRuntimePtyInput: vi.fn(),
+  isRemoteRuntimePtyId: () => false
+}))
+vi.mock('@/lib/agent-paste-draft', () => ({ getSettingsForAgentTabRuntimeOwner: () => ({}) }))
+vi.mock('./native-chat-runtime-send', () => ({
+  sendNativeChatMessage: (...args: unknown[]) => mocks.send(...args),
+  sendNativeChatMessageWithImageAttachments: vi.fn(),
+  submitNativeChatPrompt: vi.fn()
+}))
+vi.mock('../../../../shared/native-chat-agent-profiles', () => ({
+  getVerifiedNativeChatCommands: () => []
+}))
+vi.mock('@/lib/native-chat-telemetry', () => ({ emitNativeChatMessageSent: vi.fn() }))
+vi.mock('./use-native-chat-draft', () => ({
+  useNativeChatDraft: () => ({
+    draft: mocks.draft,
+    setDraft: mocks.setDraft,
+    setDraftWithoutPersist: mocks.setDraftWithoutPersist,
+    persistDraft: mocks.persistDraft
+  })
+}))
+vi.mock('./native-chat-draft-cache', () => ({ readNativeChatDraftCache: () => '' }))
+vi.mock('./NativeChatComposerField', () => ({
+  NativeChatComposerField: (props: ComposerFieldProps) => {
+    mocks.fieldProps = props
+    return null
+  }
+}))
+vi.mock('./use-native-chat-composer-attachments', () => ({
+  useNativeChatComposerAttachments: () => ({
+    imageAttachments: [],
+    attachResolvedPaths: vi.fn(),
+    clearImageAttachments: vi.fn(),
+    removeImageAttachment: vi.fn()
+  })
+}))
+vi.mock('./use-native-chat-composer-paste', () => ({
+  useNativeChatComposerPaste: () => ({ handlePaste: vi.fn(), pasteFromClipboard: vi.fn() })
+}))
+vi.mock('./use-native-chat-external-attachments', () => ({
+  useNativeChatExternalAttachments: () => ({
+    attachExternalPaths: vi.fn(),
+    resolveAttachmentOwner: vi.fn()
+  })
+}))
+vi.mock('./use-native-chat-send-lifecycle', () => ({
+  useNativeChatSendLifecycle: () => ({ cancelPendingSends: vi.fn(), trackPendingSend: vi.fn() })
+}))
+vi.mock('./use-native-chat-session-options', () => ({
+  useNativeChatSessionOptions: () => ({ surface: null, snapshot: [] })
+}))
+vi.mock('./use-native-chat-file-attachment-actions', () => ({
+  useNativeChatFileAttachmentActions: () => ({ pickAttachment: vi.fn() })
+}))
+vi.mock('./use-native-chat-dictation-actions', () => ({
+  useNativeChatDictationActions: () => ({
+    toggleDictation: vi.fn(),
+    startHoldDictation: vi.fn(),
+    stopHoldDictation: vi.fn()
+  })
+}))
+vi.mock('./use-native-chat-session-option-command', () => ({
+  useNativeChatSessionOptionCommand: () => ({ dispatch: vi.fn(), isDispatching: false })
+}))
+vi.mock('./use-native-chat-picker-state', () => ({
+  useNativeChatPickerState: () => ({
+    autocomplete: { mode: 'none', items: [], query: '', triggerKey: '' },
+    classifySend: () => 'chat',
+    clearSkillOrigin: vi.fn(),
+    completeItem: vi.fn(),
+    dismiss: vi.fn(),
+    handleDraftOrCaretChange: mocks.pickerChange,
+    listboxId: 'picker',
+    retrySkills: vi.fn()
+  })
+}))
+vi.mock('./use-native-chat-picker-command-dispatch', () => ({
+  useNativeChatPickerCommandDispatch: () => vi.fn()
+}))
+vi.mock('./use-native-chat-typed-insertion', () => ({
+  useNativeChatTypedInsertion: () => ({
+    insertTypedText: vi.fn(),
+    focus: vi.fn()
+  })
+}))
+
+import { NativeChatComposer } from './NativeChatComposer'
+
+const element = (value: string): HTMLTextAreaElement =>
+  ({ value, selectionStart: value.length }) as HTMLTextAreaElement
+
+describe('NativeChatComposer IME composition', () => {
+  let rerenderComposer: ReturnType<typeof render>['rerender']
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.fieldProps = null
+    mocks.draft = ''
+    rerenderComposer = render(
+      <NativeChatComposer
+        terminalTabId="tab-1"
+        paneKey="tab-1:leaf-1"
+        targetPtyId="pty-1"
+        agent="codex"
+      />
+    ).rerender
+  })
+
+  afterEach(() => cleanup())
+
+  it('defers side effects until composition end', () => {
+    act(() => mocks.fieldProps?.onCompositionStart())
+    act(() => mocks.fieldProps?.onDraftChange('ㅎ', element('ㅎ')))
+    act(() => mocks.fieldProps?.onDraftChange('한', element('한')))
+
+    expect(mocks.setDraftWithoutPersist).toHaveBeenCalledTimes(2)
+    expect(mocks.persistDraft).not.toHaveBeenCalled()
+    expect(mocks.pickerChange).not.toHaveBeenCalled()
+  })
+
+  it('flushes confirmed text once on composition end', () => {
+    const textarea = element('한')
+    act(() => mocks.fieldProps?.onCompositionStart())
+    act(() => mocks.fieldProps?.onDraftChange('ㅎ', element('ㅎ')))
+    act(() => mocks.fieldProps?.onCompositionEnd({ currentTarget: textarea }))
+    act(() => mocks.fieldProps?.onDraftChange('한', textarea))
+
+    expect(mocks.persistDraft).toHaveBeenCalledOnce()
+    expect(mocks.persistDraft).toHaveBeenCalledWith('한')
+    expect(mocks.pickerChange).toHaveBeenCalledOnce()
+  })
+
+  it('keeps non-composition typing behavior unchanged', () => {
+    act(() => mocks.fieldProps?.onDraftChange('a', element('a')))
+
+    expect(mocks.setDraft).toHaveBeenCalledWith('a')
+    expect(mocks.pickerChange).toHaveBeenCalledWith('a', 1)
+  })
+
+  it('resets composition state when switching panes', () => {
+    act(() => mocks.fieldProps?.onCompositionStart())
+    act(() => mocks.fieldProps?.onDraftChange('ㅎ', element('ㅎ')))
+
+    act(() =>
+      rerenderComposer(
+        <NativeChatComposer
+          terminalTabId="tab-1"
+          paneKey="tab-1:leaf-2"
+          targetPtyId="pty-2"
+          agent="codex"
+        />
+      )
+    )
+    act(() => mocks.fieldProps?.onDraftChange('b', element('b')))
+
+    expect(mocks.setDraft).toHaveBeenCalledWith('b')
+    expect(mocks.pickerChange).toHaveBeenCalledWith('b', 1)
+  })
+
+  it('keeps enter submit and shift-enter newline unchanged', () => {
+    mocks.draft = 'hello'
+    act(() =>
+      rerenderComposer(
+        <NativeChatComposer
+          terminalTabId="tab-1"
+          paneKey="tab-1:leaf-1"
+          targetPtyId="pty-1"
+          agent="codex"
+        />
+      )
+    )
+
+    const preventDefault = vi.fn()
+    act(() =>
+      mocks.fieldProps?.onKeyDown({
+        key: 'Enter',
+        shiftKey: false,
+        keyCode: 13,
+        nativeEvent: { isComposing: false },
+        preventDefault
+      })
+    )
+    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(mocks.send).toHaveBeenCalledOnce()
+    expect(mocks.send).toHaveBeenCalledWith({}, 'pty-1', 'hello')
+
+    mocks.send.mockClear()
+    preventDefault.mockClear()
+    act(() =>
+      mocks.fieldProps?.onKeyDown({
+        key: 'Enter',
+        shiftKey: true,
+        keyCode: 13,
+        nativeEvent: { isComposing: false },
+        preventDefault
+      })
+    )
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(mocks.send).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/native-chat/use-native-chat-draft.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-draft.ts
@@ -1,6 +1,8 @@
 import { useCallback, useRef, useState } from 'react'
 import { readNativeChatDraftCache, writeNativeChatDraftCache } from './native-chat-draft-cache'
 
+type DraftUpdate = string | ((previous: string) => string)
+
 /**
  * Composer draft state backed by the scope cache so a typed-but-unsent message
  * survives the composer unmounting on a TUI/GUI toggle. `scopeKey` is the stable
@@ -9,7 +11,9 @@ import { readNativeChatDraftCache, writeNativeChatDraftCache } from './native-ch
  */
 export function useNativeChatDraft(scopeKey: string): {
   draft: string
-  setDraft: (next: string | ((previous: string) => string)) => void
+  setDraft: (next: DraftUpdate) => void
+  setDraftWithoutPersist: (next: DraftUpdate) => void
+  persistDraft: (text: string) => void
 } {
   const [draft, setDraftState] = useState(() => readNativeChatDraftCache(scopeKey))
 
@@ -22,18 +26,30 @@ export function useNativeChatDraft(scopeKey: string): {
     setDraftState(readNativeChatDraftCache(scopeKey))
   }
 
-  // Persist every mutation through the cache. Accepts the same value/updater
-  // forms as a useState setter so call sites are drop-in.
-  const setDraft = useCallback(
-    (next: string | ((previous: string) => string)) => {
+  const updateDraft = useCallback(
+    (next: DraftUpdate, persist: boolean) => {
       setDraftState((previous) => {
         const resolved = typeof next === 'function' ? next(previous) : next
-        writeNativeChatDraftCache(scopeKey, resolved)
+        if (persist) {
+          writeNativeChatDraftCache(scopeKey, resolved)
+        }
         return resolved
       })
     },
     [scopeKey]
   )
 
-  return { draft, setDraft }
+  // Persist every normal mutation through the cache. Composition updates use
+  // the non-persisting setter until compositionend confirms the text.
+  const setDraft = useCallback((next: DraftUpdate) => updateDraft(next, true), [updateDraft])
+  const setDraftWithoutPersist = useCallback(
+    (next: DraftUpdate) => updateDraft(next, false),
+    [updateDraft]
+  )
+  const persistDraft = useCallback(
+    (text: string) => writeNativeChatDraftCache(scopeKey, text),
+    [scopeKey]
+  )
+
+  return { draft, setDraft, setDraftWithoutPersist, persistDraft }
 }


### PR DESCRIPTION
## Summary

Fixes the native-chat composer dropping Korean (and other IME) characters because every intermediate composition update ran the full draft/picker/suggestion/cache pipeline before the IME confirmed the text.

## ELI5

When you type in a language like Korean that assembles characters as you go, the chat box was reacting to each half-finished keystroke and losing letters. Now it waits until the character is finished before doing anything.

## Root cause & fix

Each in-progress IME composition change triggered draft persistence and picker/history/caret side effects while the text was still unconfirmed, corrupting or dropping characters. The fix mirrors Orca's existing settings-input composition pattern: while `isComposingRef` is true, per-change updates route through a non-persisting setter (`setDraftWithoutPersist`); on `compositionend` the committed text is persisted once and side effects run. A `skipNextChangeRef` de-dupes the trailing change event some browsers emit after `compositionend`, and a `useLayoutEffect` resets composition refs on pane (`draftScopeKey`) change so state can't leak across panes.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23. Clean rebase onto `origin/main`.

- Test file `native-chat-composer-composition.test.tsx` (new): 5/5 passed on branch.
- Reverting ONLY the two fix files to `origin/main` (keeping the test) reproduces the bug: 2 failed, 3 passed.
- Lint clean (`oxlint`); PR also reports `typecheck:web` and `oxfmt --check` passing.

```
On branch:        Test Files 1 passed (1); Tests 5 passed (5)
Fix reverted:     Test Files 1 failed (1); Tests 2 failed | 3 passed (5)
  - "defers side effects until composition end": expected setDraftWithoutPersist called 2 times, got 0
  - "flushes confirmed text once on composition end": expected persistDraft called once, got 0
```

## Trade-offs

None — pure fix. It only narrows *when* draft cache persistence occurs during composition.

## Regression risk

Zero-regression by construction: only the active-composition branch changes. Non-composition typing, Enter submit, and Shift+Enter newline paths are untouched and remain covered by dedicated passing tests; the textarea stays controlled. No new IPC, network, or file-path surface. Residual risk is limited to IME edge cases, which the change-before/change-after `compositionend` ordering tests exercise.

---

*Original fix by @rodboev (closes #9738). Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved.*
