### PR TITLE
fix(tab-bar): reflect a renamed session's name in its terminal tabs (#9707)

### DIFF
--- a/src/renderer/src/components/tab-bar/TabBar.tsx
+++ b/src/renderer/src/components/tab-bar/TabBar.tsx
@@ -23,6 +23,8 @@ import type {
 import type { ProjectExecutionRuntimeResolution } from '../../../../shared/project-execution-runtime'
 import { resolveTerminalTabTitle } from '../../../../shared/tab-title-resolution'
 import { useAppStore } from '../../store'
+import { useWorktreeById } from '../../store/selectors'
+import { getWorktreeGitIdentityDisplay } from '../../lib/worktree-git-identity-display'
 import { buildStatusMap } from '../right-sidebar/status-display'
 import type { OpenFile } from '../../store/slices/editor'
 import SortableTab from './SortableTab'
@@ -295,6 +297,19 @@ function TabBarInner({
   const pinTab = useAppStore((s) => s.pinTab)
   const unpinTab = useAppStore((s) => s.unpinTab)
   const activeGroupIdForWorktree = useAppStore((s) => s.activeGroupIdByWorktree[worktreeId])
+  // Why: a session the user renamed (Worktree.displayName) should surface on its
+  // tabs too, not just the sidebar; feed it to the title resolver as a fallback.
+  // Pass the branch (same source the sidebar uses) so the resolver can ignore an
+  // auto-default name that still matches the branch.
+  const worktree = useWorktreeById(worktreeId)
+  const worktreeGitIdentity = worktree ? getWorktreeGitIdentityDisplay(worktree) : null
+  const sessionNameFallback = worktree
+    ? {
+        displayName: worktree.displayName,
+        branchName:
+          worktreeGitIdentity?.kind === 'branch' ? worktreeGitIdentity.branchName : null
+      }
+    : undefined
   const defaultWindowsShell = useAppStore(
     (s) => s.settings?.terminalWindowsShell ?? 'powershell.exe'
   )
@@ -1074,7 +1089,8 @@ function TabBarInner({
                   title: resolveTerminalTabTitle(
                     item.data,
                     generatedTabTitlesEnabled,
-                    item.data.title
+                    item.data.title,
+                    sessionNameFallback
                   )
                 }
                 const unifiedTabForItem = unifiedTabByVisibleId.get(item.id)

--- a/src/shared/tab-title-resolution.test.ts
+++ b/src/shared/tab-title-resolution.test.ts
@@ -73,6 +73,47 @@ describe('tab title resolution', () => {
     ).toBe('Manual label')
   })
 
+  it('fills in a renamed session name for tabs without their own title', () => {
+    expect(
+      resolveTerminalTabTitle({ customTitle: null, title: 'zsh' }, false, '', {
+        displayName: 'auth refactor',
+        branchName: 'feature/auth'
+      })
+    ).toBe('auth refactor')
+  })
+
+  it('ignores a session name that is still just the branch default', () => {
+    expect(
+      resolveTerminalTabTitle({ customTitle: null, title: 'zsh' }, false, '', {
+        displayName: 'feature/auth',
+        branchName: 'feature/auth'
+      })
+    ).toBe('zsh')
+  })
+
+  it('keeps per-tab, generated, and meaningful live titles ahead of the session name', () => {
+    const sessionName = { displayName: 'auth refactor', branchName: 'main' }
+    expect(
+      resolveTerminalTabTitle({ customTitle: 'Manual', title: 'zsh' }, false, '', sessionName)
+    ).toBe('Manual')
+    expect(
+      resolveTerminalTabTitle(
+        { customTitle: null, generatedTitle: 'Refactor auth', title: 'zsh' },
+        true,
+        '',
+        sessionName
+      )
+    ).toBe('Refactor auth')
+    expect(
+      resolveTerminalTabTitle(
+        { customTitle: null, title: 'OC | Native Stable Session' },
+        true,
+        '',
+        sessionName
+      )
+    ).toBe('OC | Native Stable Session')
+  })
+
   it('uses the same priority for unified tab labels', () => {
     expect(
       resolveUnifiedTabLabel(

--- a/src/shared/tab-title-resolution.ts
+++ b/src/shared/tab-title-resolution.ts
@@ -1,10 +1,30 @@
 import type { Tab, TerminalTab } from './types'
 import { isMeaningfulOpenCodeTerminalTitle } from './opencode-terminal-title'
 
+/** The owning session's (worktree's) name, used to fill in a tab title when the
+ *  tab has no title of its own. `branchName` lets us tell a name the user
+ *  actually typed from the auto default that still matches the branch. */
+export type TabSessionNameFallback = {
+  displayName?: string | null
+  branchName?: string | null
+}
+
+// Why: only a name the user actually changed should stand in for a tab title; a
+// display name still equal to the branch is the auto default and must not
+// override every tab's own live/generated title.
+function resolveRenamedSessionName(sessionName?: TabSessionNameFallback): string {
+  const displayName = sessionName?.displayName?.trim()
+  if (!displayName) {
+    return ''
+  }
+  return displayName === sessionName?.branchName?.trim() ? '' : displayName
+}
+
 export function resolveTerminalTabTitle(
   tab: Pick<TerminalTab, 'customTitle' | 'quickCommandLabel' | 'generatedTitle' | 'title'>,
   generatedTitlesEnabled: boolean,
-  fallback = ''
+  fallback = '',
+  sessionName?: TabSessionNameFallback
 ): string {
   const liveTitle = tab.title?.trim() ?? ''
   return (
@@ -12,6 +32,7 @@ export function resolveTerminalTabTitle(
     tab.quickCommandLabel?.trim() ||
     (isMeaningfulOpenCodeTerminalTitle(liveTitle) ? liveTitle : '') ||
     (generatedTitlesEnabled ? tab.generatedTitle?.trim() : '') ||
+    resolveRenamedSessionName(sessionName) ||
     liveTitle ||
     fallback
   )


### PR DESCRIPTION
## Summary

Fixes #9707.

Renaming a session via **Edit worktree details → Display name** only updated the sidebar; the renamed name never showed up on the session's terminal tab. The tab-title resolver had no dependency on the worktree's `displayName`, so a session rename had no path to reach the tab.

## Root cause

Two separate naming systems with nothing linking them:

| Action | Writes | Read by |
|---|---|---|
| Session rename (`updateWorktreeMeta`) | `Worktree.displayName` | sidebar card only |
| Terminal tab title | `customTitle ?? title` | tab bar only |

A tab knows its `worktreeId`, but title resolution never consulted the owning session's `displayName`.

## Fix

`resolveTerminalTabTitle` gains an optional session-name fallback, used **only when the user actually renamed the session** — i.e. the display name differs from the branch. An unrenamed session's display name still equals the branch and is ignored, so tabs aren't flooded with the branch name. Priority:

```
customTitle > quickCommandLabel > meaningful live title > generated title > renamed session name > live title > fallback
```

Per-tab custom names, quick-command labels, and meaningful agent/generated titles still win; the session name only fills in for tabs that would otherwise show a generic live title. `TabBar` feeds the name — and the branch, via the same `getWorktreeGitIdentityDisplay` the sidebar uses — into the resolver, so a rename re-renders the tab reactively.

**Scope:** the visible top tab (`TabBar`). The Cmd+J switcher, floating-terminal panel, and the sidebar branch-name edge case are left as follow-ups.

## Testing

- `vitest src/shared/tab-title-resolution.test.ts` — added 3 cases (fallback shows, branch-default ignored, higher-priority titles still win); all green
- `tsc` typecheck — clean
- `oxlint` — clean
- Draft: in-app visual verification still recommended before merge.
