### PR TITLE
fix(runtime): report local PTY inventory readiness (#9229)

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -4476,6 +4476,82 @@ describe('registerPtyHandlers', () => {
     })
   })
 
+  it('marks local inventory stale after ipc pty spawn', async () => {
+    let listCall = 0
+    let resolveRefresh!: (sessions: { id: string; cwd: string; title: string }[]) => void
+    const pendingRefresh = new Promise<{ id: string; cwd: string; title: string }[]>((resolve) => {
+      resolveRefresh = resolve
+    })
+    const runtime = {
+      setPtyController: vi.fn(),
+      createPreAllocatedTerminalHandle: vi.fn(() => 'handle-1'),
+      registerPreAllocatedHandleForPty: vi.fn(),
+      preparePtyExecutionContext: vi.fn(),
+      getPtyOutputSequence: vi.fn(() => 0),
+      synchronizePtyOutputSequenceFromProvider: vi.fn(),
+      noteTerminalSpawnCommand: vi.fn()
+    }
+
+    setLocalPtyProvider({
+      spawn: vi.fn(async () => ({ id: 'daemon-local-pty', pid: 321 })),
+      write: vi.fn(),
+      resize: vi.fn(),
+      shutdown: vi.fn(),
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => {
+        listCall += 1
+        if (listCall === 1) {
+          return []
+        }
+        return pendingRefresh
+      }),
+      attach: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+    registerPtyHandlers(mainWindow as never, runtime as never)
+    const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
+      refreshLocalProcessInventory: () => Promise<void>
+      getLocalProcessInventorySnapshot: () => {
+        state: 'pending' | 'ready' | 'stale'
+        processes?: { id: string; cwd: string; title: string }[]
+      }
+    }
+
+    await controller.refreshLocalProcessInventory()
+    expect(controller.getLocalProcessInventorySnapshot()).toEqual({
+      state: 'ready',
+      processes: []
+    })
+
+    await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24, env: {} })
+
+    expect(controller.getLocalProcessInventorySnapshot()).toEqual({
+      state: 'stale',
+      processes: []
+    })
+    expect(listCall).toBe(2)
+
+    resolveRefresh([{ id: 'daemon-local-pty', cwd: '/local', title: 'shell' }])
+    await vi.waitFor(() =>
+      expect(controller.getLocalProcessInventorySnapshot()).toEqual({
+        state: 'ready',
+        processes: [{ id: 'daemon-local-pty', cwd: '/local', title: 'shell' }]
+      })
+    )
+  })
+
   it('removes an exited PTY before the next status read', async () => {
     let exitListener = (_payload: { id: string; code: number }) => {
       throw new Error('missing exit listener')

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -4435,6 +4435,191 @@ describe('registerPtyHandlers', () => {
     })
   })
 
+  it('updates local inventory readiness through pty:listSessions', async () => {
+    const runtime = { setPtyController: vi.fn() }
+    const localSessions = [{ id: 'local-pty', cwd: '/local', title: 'local-shell' }]
+    setLocalPtyProvider({
+      spawn: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      shutdown: vi.fn(),
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => localSessions),
+      attach: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+    registerPtyHandlers(mainWindow as never, runtime as never)
+    const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
+      getLocalProcessInventorySnapshot: () => {
+        state: 'pending' | 'ready' | 'stale'
+        processes?: { id: string; cwd: string; title: string }[]
+      }
+    }
+
+    expect(controller.getLocalProcessInventorySnapshot()).toEqual({ state: 'pending' })
+    await expect(handlers.get('pty:listSessions')!(null, undefined)).resolves.toEqual(localSessions)
+    expect(controller.getLocalProcessInventorySnapshot()).toEqual({
+      state: 'ready',
+      processes: localSessions
+    })
+  })
+
+  it('removes an exited PTY before the next status read', async () => {
+    let exitListener = (_payload: { id: string; code: number }) => {
+      throw new Error('missing exit listener')
+    }
+    let shouldBlockRefresh = false
+    const refreshBarrier = makeDeferred()
+    const listProcesses = vi.fn(async () => {
+      if (!shouldBlockRefresh) {
+        return [{ id: 'local-pty', cwd: '/local', title: 'shell' }]
+      }
+      await refreshBarrier.promise
+      return []
+    })
+    const runtime = { setPtyController: vi.fn(), onPtyExit: vi.fn() }
+
+    setLocalPtyProvider({
+      spawn: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      shutdown: vi.fn(),
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn((callback) => {
+        exitListener = callback
+        return () => {}
+      }),
+      listProcesses,
+      attach: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+    registerPtyHandlers(mainWindow as never, runtime as never)
+    const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
+      refreshLocalProcessInventory: () => Promise<void>
+      getLocalProcessInventorySnapshot: () => {
+        state: 'pending' | 'ready' | 'stale'
+        processes?: { id: string; cwd: string; title: string }[]
+      }
+    }
+
+    await controller.refreshLocalProcessInventory()
+    expect(controller.getLocalProcessInventorySnapshot()).toEqual({
+      state: 'ready',
+      processes: [{ id: 'local-pty', cwd: '/local', title: 'shell' }]
+    })
+
+    shouldBlockRefresh = true
+    exitListener({ id: 'local-pty', code: 0 })
+
+    expect(runtime.onPtyExit).toHaveBeenCalledWith('local-pty', 0)
+    expect(controller.getLocalProcessInventorySnapshot()).toEqual({
+      state: 'stale',
+      processes: []
+    })
+
+    shouldBlockRefresh = false
+    refreshBarrier.resolve()
+  })
+
+  it('discards local inventory that resolves after PTY exit', async () => {
+    let exitListener = (_payload: { id: string; code: number }) => {
+      throw new Error('missing exit listener')
+    }
+    let mode: 'idle' | 'two-stage' | 'done' = 'idle'
+    let pendingRefreshCall = 0
+    let resolveFirst!: (sessions: { id: string; cwd: string; title: string }[]) => void
+    let resolveSecond!: (sessions: { id: string; cwd: string; title: string }[]) => void
+    const firstList = new Promise<{ id: string; cwd: string; title: string }[]>((resolve) => {
+      resolveFirst = resolve
+    })
+    const secondList = new Promise<{ id: string; cwd: string; title: string }[]>((resolve) => {
+      resolveSecond = resolve
+    })
+    const listProcesses = vi.fn(async () => {
+      if (mode !== 'two-stage') {
+        return []
+      }
+      pendingRefreshCall += 1
+      return pendingRefreshCall === 1 ? firstList : secondList
+    })
+    const runtime = { setPtyController: vi.fn(), onPtyExit: vi.fn() }
+
+    setLocalPtyProvider({
+      spawn: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      shutdown: vi.fn(),
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn((callback) => {
+        exitListener = callback
+        return () => {}
+      }),
+      listProcesses,
+      attach: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+    registerPtyHandlers(mainWindow as never, runtime as never)
+    const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
+      refreshLocalProcessInventory: () => Promise<void>
+      getLocalProcessInventorySnapshot: () => {
+        state: 'pending' | 'ready' | 'stale'
+        processes?: { id: string; cwd: string; title: string }[]
+      }
+    }
+
+    mode = 'two-stage'
+    const firstRefresh = controller.refreshLocalProcessInventory()
+    exitListener({ id: 'local-pty', code: 0 })
+    resolveFirst([{ id: 'local-pty', cwd: '/local', title: 'shell' }])
+    await firstRefresh
+
+    expect(runtime.onPtyExit).toHaveBeenCalledWith('local-pty', 0)
+    expect(controller.getLocalProcessInventorySnapshot()).toEqual({ state: 'pending' })
+
+    mode = 'done'
+    resolveSecond([])
+    await vi.waitFor(() =>
+      expect(controller.getLocalProcessInventorySnapshot()).toEqual({
+        state: 'ready',
+        processes: []
+      })
+    )
+  })
+
   it('reports authoritative snapshot capability with the owning provider context', () => {
     const capabilityProvider = {
       authoritativeIds: new Set(['current-pty']),

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -56,7 +56,12 @@ import { piTitlebarExtensionService } from '../pi/titlebar-extension-service'
 import { detectPiAgentKindFromCommand, type PiAgentKind } from '../../shared/pi-agent-kind'
 import { isPwshAvailable } from '../pwsh'
 import { LocalPtyProvider } from '../providers/local-pty-provider'
-import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers/types'
+import type {
+  IPtyProvider,
+  PtyProcessInfo,
+  PtySpawnOptions,
+  PtySpawnResult
+} from '../providers/types'
 import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery'
 import {
   SSH_SESSION_EXPIRED_ERROR,
@@ -1084,6 +1089,7 @@ export function getLocalPtyProvider(): IPtyProvider {
  *  Call before registerPtyHandlers so the IPC layer routes through the daemon. */
 export function setLocalPtyProvider(provider: IPtyProvider): void {
   localProvider = provider
+  refreshLocalProcessInventoryAfterProviderChange()
 }
 
 /** Get all PTY IDs owned by a given connectionId (for reconnection reattach). */
@@ -1199,9 +1205,11 @@ let rendererDidStartLoadingHandler: (() => void) | null = null
 
 // Why: Restart daemon must re-bind provider→renderer listeners after replaceDaemonProvider swaps localProvider, else subscribers stay bound to the disposed adapter and new PTY data silently drops.
 let rebindProviderListeners: (() => void) | null = null
+let refreshLocalProcessInventoryAfterProviderChange: () => void = () => {}
 
 export function rebindLocalProviderListeners(): void {
   rebindProviderListeners?.()
+  refreshLocalProcessInventoryAfterProviderChange()
 }
 
 export type PtyRendererDeliveryDebugSnapshot = {
@@ -1426,6 +1434,129 @@ export function registerPtyHandlers(
     return options?.awaitLocalPtyProviderStartup?.() ?? options?.awaitLocalPtyStartup?.()
   }
 
+  type LocalProcessInventorySnapshot =
+    | {
+        state: 'pending'
+      }
+    | {
+        state: 'ready'
+        processes: PtyProcessInfo[]
+      }
+    | {
+        state: 'stale'
+        processes?: PtyProcessInfo[]
+      }
+
+  let localProcessInventorySnapshot: LocalProcessInventorySnapshot = { state: 'pending' }
+  let localProcessInventoryEpoch = 0
+  let localProcessInventoryRequestSeq = 0
+  let localProcessInventoryRefreshEpoch: number | null = null
+  let localProcessInventoryRefreshPromise: Promise<PtyProcessInfo[]> | null = null
+
+  const getRetainedLocalProcessInventory = (): PtyProcessInfo[] | undefined =>
+    'processes' in localProcessInventorySnapshot
+      ? localProcessInventorySnapshot.processes
+      : undefined
+
+  const cloneProcessInventory = (processes: readonly PtyProcessInfo[]): PtyProcessInfo[] =>
+    processes.map((process) => ({ ...process }))
+
+  const updateLocalProcessInventoryForEpoch = (opts: { removePtyId?: string } = {}): void => {
+    const retained = getRetainedLocalProcessInventory()
+    if (retained !== undefined) {
+      localProcessInventorySnapshot = {
+        state: 'stale',
+        processes: retained.filter((process) => process.id !== opts.removePtyId)
+      }
+      return
+    }
+    localProcessInventorySnapshot =
+      localProcessInventorySnapshot.state === 'pending' ? { state: 'pending' } : { state: 'stale' }
+  }
+
+  const requestLocalProcessInventory = async (
+    opts: { coalesce?: boolean } = {}
+  ): Promise<PtyProcessInfo[]> => {
+    const epoch = localProcessInventoryEpoch
+    if (
+      opts.coalesce === true &&
+      localProcessInventoryRefreshEpoch === epoch &&
+      localProcessInventoryRefreshPromise
+    ) {
+      return await localProcessInventoryRefreshPromise
+    }
+    const requestSeq = ++localProcessInventoryRequestSeq
+    let request!: Promise<PtyProcessInfo[]>
+    request = (async (): Promise<PtyProcessInfo[]> => {
+      try {
+        const processes = cloneProcessInventory(await localProvider.listProcesses())
+        if (
+          requestSeq === localProcessInventoryRequestSeq &&
+          epoch === localProcessInventoryEpoch
+        ) {
+          localProcessInventorySnapshot = { state: 'ready', processes }
+        }
+        return processes
+      } catch (error) {
+        if (
+          requestSeq === localProcessInventoryRequestSeq &&
+          epoch === localProcessInventoryEpoch
+        ) {
+          const retained = getRetainedLocalProcessInventory()
+          localProcessInventorySnapshot =
+            retained !== undefined ? { state: 'stale', processes: retained } : { state: 'stale' }
+        }
+        throw error
+      } finally {
+        if (localProcessInventoryRefreshPromise === request) {
+          localProcessInventoryRefreshPromise = null
+          localProcessInventoryRefreshEpoch = null
+        }
+      }
+    })()
+    if (opts.coalesce === true) {
+      localProcessInventoryRefreshEpoch = epoch
+      localProcessInventoryRefreshPromise = request
+    }
+    return await request
+  }
+
+  const refreshLocalProcessInventory = async (): Promise<void> => {
+    await requestLocalProcessInventory({ coalesce: true })
+  }
+
+  const invalidateLocalProcessInventory = (
+    opts: { removePtyId?: string; refresh?: boolean } = {}
+  ): void => {
+    localProcessInventoryEpoch += 1
+    updateLocalProcessInventoryForEpoch(opts)
+    if (opts.refresh !== false) {
+      void refreshLocalProcessInventory().catch(() => undefined)
+    }
+  }
+
+  const noteLocalProcessInventoryChange = (connectionId?: string | null): void => {
+    if (connectionId) {
+      return
+    }
+    invalidateLocalProcessInventory()
+  }
+
+  const forwardRuntimePtyExit = (
+    ptyId: string,
+    code: number,
+    opts: { connectionId?: string | null } = {}
+  ): void => {
+    if (opts.connectionId == null) {
+      invalidateLocalProcessInventory({ removePtyId: ptyId })
+    }
+    runtime?.onPtyExit(ptyId, code)
+  }
+
+  refreshLocalProcessInventoryAfterProviderChange = () => {
+    invalidateLocalProcessInventory()
+  }
+
   // Remove prior handlers so re-registration (e.g. macOS re-activate creating a new window) doesn't double-register.
   ipcMain.removeHandler('pty:spawn')
   ipcMain.removeHandler('pty:kill')
@@ -1515,12 +1646,15 @@ export function registerPtyHandlers(
         }
         return env
       },
-      onSpawned: (id) => runtime?.onPtySpawned(id),
+      onSpawned: (id) => {
+        noteLocalProcessInventoryChange(null)
+        runtime?.onPtySpawned(id)
+      },
       onExit: (id, code) => {
         clearProviderPtyState(id)
         ptyOwnership.delete(id)
         markClaudePtyExited(id)
-        runtime?.onPtyExit(id, code)
+        forwardRuntimePtyExit(id, code)
       },
       onData: (id, data, timestamp, sequenceChars, transformed) =>
         runtime?.onPtyData(id, data, timestamp, sequenceChars ?? data.length, transformed)
@@ -2539,7 +2673,7 @@ export function registerPtyHandlers(
         clearProviderPtyState(payload.id)
         ptyOwnership.delete(payload.id)
         markClaudePtyExited(payload.id)
-        runtime?.onPtyExit(payload.id, payload.code)
+        forwardRuntimePtyExit(payload.id, payload.code)
       }
       sendPtyExitToRenderer(payload)
     })
@@ -3193,6 +3327,7 @@ export function registerPtyHandlers(
                 : null
           })
         }
+        noteLocalProcessInventoryChange(args.connectionId)
         const response = { id: result.id }
         return resolvePaneSpawnReservation(materializedPaneKey, paneSpawnReservation, response)
       } catch (err) {
@@ -3224,7 +3359,7 @@ export function registerPtyHandlers(
           if (connectionId) {
             // Why: runtime/CLI close can target a detached SSH PTY after its provider was unregistered; tombstone the lease so reconnect can't revive it.
             finishPtyShutdown(ptyId, connectionId, store)
-            runtime?.onPtyExit(ptyId, -1)
+            forwardRuntimePtyExit(ptyId, -1, { connectionId })
             rememberSyntheticKillExit(ptyId)
             sendPtyExitToRenderer({ id: ptyId, code: -1 })
             return true
@@ -3236,7 +3371,7 @@ export function registerPtyHandlers(
           .then((providerExitObserved) => {
             finishPtyShutdown(ptyId, connectionId, store)
             if (!providerExitObserved) {
-              runtime?.onPtyExit(ptyId, -1)
+              forwardRuntimePtyExit(ptyId, -1, { connectionId })
               rememberSyntheticKillExit(ptyId)
               sendPtyExitToRenderer({ id: ptyId, code: -1 })
             }
@@ -3244,7 +3379,7 @@ export function registerPtyHandlers(
           .catch((err) => {
             if (isPtyAlreadyGoneError(err)) {
               finishPtyShutdown(ptyId, connectionId, store)
-              runtime?.onPtyExit(ptyId, -1)
+              forwardRuntimePtyExit(ptyId, -1, { connectionId })
               rememberSyntheticKillExit(ptyId)
               sendPtyExitToRenderer({ id: ptyId, code: -1 })
               return
@@ -3253,7 +3388,7 @@ export function registerPtyHandlers(
               `[pty] Failed to stop PTY ${ptyId}: ${err instanceof Error ? err.message : String(err)}`
             )
             // Why: close runtime tails but keep provider ownership so a retry can still target a PTY that survived the failed shutdown.
-            runtime?.onPtyExit(ptyId, -1)
+            forwardRuntimePtyExit(ptyId, -1, { connectionId })
           })
         return true
       }
@@ -3264,7 +3399,7 @@ export function registerPtyHandlers(
           console.warn(
             `[pty] Failed to stop PTY ${ptyId}: ${err instanceof Error ? err.message : String(err)}`
           )
-          runtime?.onPtyExit(ptyId, -1)
+          forwardRuntimePtyExit(ptyId, -1, { connectionId })
         })
         return true
       }
@@ -3308,7 +3443,7 @@ export function registerPtyHandlers(
         if (connectionId) {
           // Why: an absent SSH provider means no live target to await, but the relay lease must still be tombstoned.
           finishPtyShutdown(ptyId, connectionId, store)
-          runtime?.onPtyExit(ptyId, -1)
+          forwardRuntimePtyExit(ptyId, -1, { connectionId })
           rememberSyntheticKillExit(ptyId)
           sendPtyExitToRenderer({ id: ptyId, code: -1 })
           return true
@@ -3344,7 +3479,7 @@ export function registerPtyHandlers(
       }
       finishPtyShutdown(ptyId, connectionId, store)
       if (!providerExitObserved) {
-        runtime?.onPtyExit(ptyId, -1)
+        forwardRuntimePtyExit(ptyId, -1, { connectionId })
         rememberSyntheticKillExit(ptyId)
         sendPtyExitToRenderer({ id: ptyId, code: -1 })
       }
@@ -3398,11 +3533,27 @@ export function registerPtyHandlers(
       }
     },
     listProcesses: async () => {
+      const localProcesses = await requestLocalProcessInventory()
       const providerSessions = await Promise.all([
-        localProvider.listProcesses(),
+        Promise.resolve(localProcesses),
         ...Array.from(sshProviders.values(), (provider) => provider.listProcesses())
       ])
       return providerSessions.flat()
+    },
+    getLocalProcessInventorySnapshot: () => {
+      if (localProcessInventorySnapshot.state === 'pending') {
+        return { state: 'pending' }
+      }
+      if (localProcessInventorySnapshot.processes === undefined) {
+        return { state: 'stale' }
+      }
+      return {
+        state: localProcessInventorySnapshot.state,
+        processes: cloneProcessInventory(localProcessInventorySnapshot.processes)
+      }
+    },
+    refreshLocalProcessInventory: async () => {
+      await refreshLocalProcessInventory()
     },
     serializeBuffer: (ptyId, opts) => {
       // Why: mobile xterm must start from the desktop's exact screen state/dimensions before live TUI chunks render correctly.
@@ -4755,7 +4906,7 @@ export function registerPtyHandlers(
     if (!provider && connectionId) {
       // Why: detached SSH PTYs keep ownership after provider unregister, and hydrated app-scoped ids may arrive pre-ownership; tombstone instead of falling back local.
       finishPtyShutdown(args.id, connectionId, store)
-      runtime?.onPtyExit(args.id, -1)
+      forwardRuntimePtyExit(args.id, -1, { connectionId })
       rememberSyntheticKillExit(args.id)
       sendPtyExitToRenderer({ id: args.id, code: -1 })
       return
@@ -4777,7 +4928,7 @@ export function registerPtyHandlers(
     // Why: some shutdown paths don't emit onExit via the provider listener; this cleanup is idempotent and covers already-dead PTYs.
     finishPtyShutdown(args.id, connectionId, store)
     if (!providerExitObserved) {
-      runtime?.onPtyExit(args.id, -1)
+      forwardRuntimePtyExit(args.id, -1, { connectionId })
       rememberSyntheticKillExit(args.id)
       sendPtyExitToRenderer({ id: args.id, code: -1 })
     }
@@ -4789,7 +4940,7 @@ export function registerPtyHandlers(
       const providerSessions = await Promise.all([
         Promise.resolve({
           connectionId: null as string | null,
-          sessions: await localProvider.listProcesses()
+          sessions: await requestLocalProcessInventory()
         }),
         ...Array.from(sshProviders.entries(), async ([connectionId, provider]) => ({
           connectionId,

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -4396,6 +4396,7 @@ export function registerPtyHandlers(
                 ? spawnedPid
                 : null
           })
+          noteLocalProcessInventoryChange(args.connectionId)
         }
         // Why: telemetry-plan.md§Agent launch semantics — fire agent_started only after spawn resolved; safeParse each field so a spoofed IPC payload can't poison the event (missing required field skips it).
         if (args.telemetry) {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1705,6 +1705,90 @@ describe('OrcaRuntimeService', () => {
     expect(status.minCompatibleMobileVersion).toBeGreaterThanOrEqual(0)
   })
 
+  it('classifies surviving sessions and exposes the cached status summary', async () => {
+    const activePtyId = `${TEST_WORKTREE_ID}@@active`
+    const restorablePtyId = `${TEST_WORKTREE_ID}@@restorable`
+    const ambiguousPtyId = 'repo-1::/removed@@ambiguous'
+    const restorablePaneKey = makePaneKey('tab-1', HEADLESS_SECOND_LEAF_ID)
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getWorkspaceSession: () => ({
+        ...getDefaultWorkspaceSession(),
+        sleepingAgentSessionsByPaneKey: {
+          [restorablePaneKey]: {
+            paneKey: restorablePaneKey,
+            tabId: 'tab-1',
+            worktreeId: TEST_WORKTREE_ID,
+            agent: 'codex',
+            providerSession: { key: 'session_id', id: 'session-1' },
+            prompt: 'resume',
+            state: 'done',
+            capturedAt: 1,
+            updatedAt: 1,
+            origin: 'worktree-sleep'
+          }
+        }
+      })
+    } as never)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => [
+        { id: activePtyId, cwd: TEST_WORKTREE_PATH, title: '' },
+        { id: restorablePtyId, cwd: TEST_WORKTREE_PATH, title: '' },
+        { id: ambiguousPtyId, cwd: '/tmp/removed', title: '' }
+      ]
+    })
+    runtime.attachWindow(TEST_WINDOW_ID)
+    runtime.syncWindowGraph(TEST_WINDOW_ID, {
+      tabs: [],
+      leaves: [
+        {
+          tabId: 'tab-active',
+          worktreeId: TEST_WORKTREE_ID,
+          leafId: HEADLESS_LEAF_ID,
+          paneRuntimeId: 1,
+          ptyId: activePtyId
+        }
+      ],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'headless:test',
+          snapshotVersion: 1,
+          activeGroupId: null,
+          activeTabId: 'tab-1',
+          activeTabType: 'terminal',
+          tabs: [
+            {
+              type: 'terminal',
+              id: 'tab-1',
+              title: 'sleeping agent',
+              parentTabId: 'tab-1',
+              leafId: HEADLESS_SECOND_LEAF_ID,
+              ptyId: restorablePtyId,
+              isActive: true
+            }
+          ]
+        }
+      ]
+    })
+
+    await expect(runtime.classifySurvivingSessionsAgainstGeneration()).resolves.toEqual({
+      active: 1,
+      restorable: 1,
+      ambiguous: 1,
+      provenOrphan: 0
+    })
+    expect(runtime.getStatus().survivingSessionReconciliation).toEqual({
+      active: 1,
+      restorable: 1,
+      ambiguous: 1,
+      provenOrphan: 0
+    })
+  })
+
   it('reports the configured Windows terminal shell on status', () => {
     const runtime = new OrcaRuntimeService({
       ...store,

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1705,7 +1705,7 @@ describe('OrcaRuntimeService', () => {
     expect(status.minCompatibleMobileVersion).toBeGreaterThanOrEqual(0)
   })
 
-  it('classifies surviving sessions and exposes the cached status summary', async () => {
+  const buildSurvivingSessionReconciliationHarness = () => {
     const activePtyId = `${TEST_WORKTREE_ID}@@active`
     const restorablePtyId = `${TEST_WORKTREE_ID}@@restorable`
     const ambiguousPtyId = 'repo-1::/removed@@ambiguous'
@@ -1774,17 +1774,49 @@ describe('OrcaRuntimeService', () => {
         }
       ]
     })
+    runtime.onPtySpawned(activePtyId)
+    runtime.onPtySpawned(restorablePtyId)
+    runtime.onPtySpawned(ambiguousPtyId)
 
-    await expect(runtime.classifySurvivingSessionsAgainstGeneration()).resolves.toEqual({
+    const expected = {
       active: 1,
       restorable: 1,
       ambiguous: 1,
       provenOrphan: 0
-    })
-    expect(runtime.getStatus().survivingSessionReconciliation).toEqual({
+    } as const
+
+    return {
+      runtime,
+      expected
+    }
+  }
+
+  it('classifies surviving daemon PTYs against the active runtime generation', async () => {
+    const { runtime, expected } = buildSurvivingSessionReconciliationHarness()
+
+    await expect(runtime.classifySurvivingSessionsAgainstGeneration()).resolves.toEqual(expected)
+  })
+
+  it('surfaces surviving session reconciliation on runtime status', () => {
+    const { runtime, expected } = buildSurvivingSessionReconciliationHarness()
+
+    expect(runtime.getStatus().survivingSessionReconciliation).toEqual(expected)
+  })
+
+  it('keeps live current-generation PTYs out of ambiguous reconciliation', () => {
+    const { runtime } = buildSurvivingSessionReconciliationHarness()
+
+    expect(runtime.getStatus().survivingSessionReconciliation).toMatchObject({
       active: 1,
+      ambiguous: 1
+    })
+  })
+
+  it('keeps sleeping or serve-owned PTYs restorable', () => {
+    const { runtime } = buildSurvivingSessionReconciliationHarness()
+
+    expect(runtime.getStatus().survivingSessionReconciliation).toMatchObject({
       restorable: 1,
-      ambiguous: 1,
       provenOrphan: 0
     })
   })

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1973,6 +1973,66 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('treats legacy mobile pane ids as restorable during reconciliation', async () => {
+    const controllerHarness = createSurvivingSessionControllerHarness()
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getWorkspaceSession: () => ({
+        ...getDefaultWorkspaceSession(),
+        sleepingAgentSessionsByPaneKey: {
+          'tab-legacy:2': {
+            paneKey: 'tab-legacy:2',
+            tabId: 'tab-legacy',
+            worktreeId: TEST_WORKTREE_ID,
+            agent: 'codex',
+            providerSession: { key: 'session_id', id: 'session-legacy' },
+            prompt: 'resume',
+            state: 'done',
+            capturedAt: 1,
+            updatedAt: 1,
+            origin: 'worktree-sleep'
+          }
+        }
+      })
+    } as never)
+
+    runtime.setPtyController(controllerHarness.controller)
+    await controllerHarness.resolveRefresh([
+      { id: `${TEST_WORKTREE_ID}@@legacy-restorable`, cwd: TEST_WORKTREE_PATH, title: '' }
+    ])
+    runtime.attachWindow(TEST_WINDOW_ID)
+    runtime.syncWindowGraph(TEST_WINDOW_ID, {
+      tabs: [],
+      leaves: [],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'legacy-pane:test',
+          snapshotVersion: 1,
+          activeGroupId: null,
+          activeTabId: 'tab-legacy',
+          activeTabType: 'terminal',
+          tabs: [
+            {
+              type: 'terminal',
+              id: 'tab-legacy',
+              title: 'sleeping agent',
+              parentTabId: 'tab-legacy',
+              leafId: 'pane:2',
+              ptyId: `${TEST_WORKTREE_ID}@@legacy-restorable`,
+              isActive: true
+            }
+          ]
+        }
+      ]
+    })
+
+    expect(runtime.getStatus().survivingSessionReconciliation).toEqual({
+      state: 'ready',
+      summary: { active: 0, restorable: 1, ambiguous: 0 }
+    })
+  })
+
   it('reports the configured Windows terminal shell on status', () => {
     const runtime = new OrcaRuntimeService({
       ...store,
@@ -2838,6 +2898,48 @@ describe('OrcaRuntimeService', () => {
     })
     const split = internals.getMobileSessionTabsForWorktree(TEST_WORKTREE_ID)
     expect(split.tabs.filter((tab) => tab.type === 'terminal')).toHaveLength(2)
+  })
+
+  it('finds legacy mobile pane ids when snapshot PTY ids are absent', () => {
+    const runtime = createRuntime()
+    const internals = runtime as unknown as {
+      recordPtyWorktree: (
+        ptyId: string,
+        worktreeId: string,
+        state?: Record<string, unknown>
+      ) => { worktreeId: string; tabId: string | null; paneKey: string | null }
+      findPtyForMobileTerminalTab: (
+        worktreeId: string,
+        tab: {
+          type: 'terminal'
+          id: string
+          parentTabId: string
+          leafId: string
+          title: string
+          isActive: boolean
+        }
+      ) => { worktreeId: string; tabId: string | null; paneKey: string | null } | null
+    }
+    internals.recordPtyWorktree('pty-legacy-pane', TEST_WORKTREE_ID, {
+      connected: true,
+      tabId: 'tab-legacy',
+      paneKey: 'tab-legacy:2'
+    })
+
+    const match = internals.findPtyForMobileTerminalTab(TEST_WORKTREE_ID, {
+      type: 'terminal',
+      id: 'tab-legacy',
+      parentTabId: 'tab-legacy',
+      leafId: 'pane:2',
+      title: 'legacy',
+      isActive: true
+    })
+
+    expect(match).toMatchObject({
+      worktreeId: TEST_WORKTREE_ID,
+      tabId: 'tab-legacy',
+      paneKey: 'tab-legacy:2'
+    })
   })
 
   it('keeps targeted terminal lists from adopting controller PTYs for other worktrees', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -102,6 +102,7 @@ import {
   _resetTerminalViewAttributesForTest,
   setTerminalViewAttributes
 } from './terminal-view-attribute-store'
+import type { PtyProcessInfo } from '../providers/types'
 
 const ORIGINAL_PLATFORM = process.platform
 const ORIGINAL_PLATFORM_DESCRIPTOR = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -1705,11 +1706,89 @@ describe('OrcaRuntimeService', () => {
     expect(status.minCompatibleMobileVersion).toBeGreaterThanOrEqual(0)
   })
 
-  const buildSurvivingSessionReconciliationHarness = () => {
+  const createSurvivingSessionControllerHarness = () => {
+    type Snapshot =
+      | { state: 'pending' }
+      | { state: 'ready'; processes: PtyProcessInfo[] }
+      | { state: 'stale'; processes?: PtyProcessInfo[] }
+
+    let snapshot: Snapshot = { state: 'pending' }
+    let refreshStarts = 0
+    let pending: {
+      promise: Promise<void>
+      resolve: (processes: PtyProcessInfo[]) => void
+      reject: (error?: Error) => void
+    } | null = null
+
+    const refreshLocalProcessInventory = vi.fn(() => {
+      if (pending) {
+        return pending.promise
+      }
+      refreshStarts += 1
+      let settle = () => {}
+      let fail = (_error: Error) => {}
+      const promise = new Promise<void>((resolve, reject) => {
+        settle = resolve
+        fail = reject
+      })
+      pending = {
+        promise,
+        resolve: (processes) => {
+          snapshot = { state: 'ready', processes }
+          pending = null
+          settle()
+        },
+        reject: (error = new Error('refresh failed')) => {
+          const retained = 'processes' in snapshot ? snapshot.processes : undefined
+          snapshot = retained ? { state: 'stale', processes: retained } : { state: 'stale' }
+          pending = null
+          fail(error)
+        }
+      }
+      return promise
+    })
+
+    return {
+      controller: {
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null,
+        getLocalProcessInventorySnapshot: () => snapshot,
+        refreshLocalProcessInventory
+      },
+      refreshLocalProcessInventory,
+      getRefreshStarts() {
+        return refreshStarts
+      },
+      setReady(processes: PtyProcessInfo[]) {
+        snapshot = { state: 'ready', processes }
+      },
+      invalidate() {
+        const retained = 'processes' in snapshot ? snapshot.processes : undefined
+        snapshot =
+          retained !== undefined
+            ? { state: 'stale', processes: retained }
+            : snapshot.state === 'pending'
+              ? { state: 'pending' }
+              : { state: 'stale' }
+      },
+      async resolveRefresh(processes: PtyProcessInfo[]) {
+        pending?.resolve(processes)
+        await Promise.resolve()
+      },
+      async rejectRefresh(error?: Error) {
+        pending?.reject(error)
+        await Promise.resolve()
+      }
+    }
+  }
+
+  const buildSurvivingSessionReconciliationHarness = async () => {
     const activePtyId = `${TEST_WORKTREE_ID}@@active`
     const restorablePtyId = `${TEST_WORKTREE_ID}@@restorable`
     const ambiguousPtyId = 'repo-1::/removed@@ambiguous'
     const restorablePaneKey = makePaneKey('tab-1', HEADLESS_SECOND_LEAF_ID)
+    const controllerHarness = createSurvivingSessionControllerHarness()
     const runtime = new OrcaRuntimeService({
       ...store,
       getWorkspaceSession: () => ({
@@ -1730,16 +1809,12 @@ describe('OrcaRuntimeService', () => {
         }
       })
     } as never)
-    runtime.setPtyController({
-      write: () => true,
-      kill: () => true,
-      getForegroundProcess: async () => null,
-      listProcesses: async () => [
-        { id: activePtyId, cwd: TEST_WORKTREE_PATH, title: '' },
-        { id: restorablePtyId, cwd: TEST_WORKTREE_PATH, title: '' },
-        { id: ambiguousPtyId, cwd: '/tmp/removed', title: '' }
-      ]
-    })
+    runtime.setPtyController(controllerHarness.controller)
+    await controllerHarness.resolveRefresh([
+      { id: activePtyId, cwd: TEST_WORKTREE_PATH, title: '' },
+      { id: restorablePtyId, cwd: TEST_WORKTREE_PATH, title: '' },
+      { id: ambiguousPtyId, cwd: '/tmp/removed', title: '' }
+    ])
     runtime.attachWindow(TEST_WINDOW_ID)
     runtime.syncWindowGraph(TEST_WINDOW_ID, {
       tabs: [],
@@ -1774,50 +1849,127 @@ describe('OrcaRuntimeService', () => {
         }
       ]
     })
-    runtime.onPtySpawned(activePtyId)
-    runtime.onPtySpawned(restorablePtyId)
-    runtime.onPtySpawned(ambiguousPtyId)
-
-    const expected = {
-      active: 1,
-      restorable: 1,
-      ambiguous: 1,
-      provenOrphan: 0
-    } as const
 
     return {
       runtime,
-      expected
+      controllerHarness,
+      activePtyId,
+      ambiguousPtyId
     }
   }
 
-  it('classifies surviving daemon PTYs against the active runtime generation', async () => {
-    const { runtime, expected } = buildSurvivingSessionReconciliationHarness()
+  it('loads pre-existing local PTYs before any spawn callback', async () => {
+    const controllerHarness = createSurvivingSessionControllerHarness()
+    const runtime = createRuntime()
 
-    await expect(runtime.classifySurvivingSessionsAgainstGeneration()).resolves.toEqual(expected)
-  })
+    runtime.setPtyController(controllerHarness.controller)
 
-  it('surfaces surviving session reconciliation on runtime status', () => {
-    const { runtime, expected } = buildSurvivingSessionReconciliationHarness()
+    expect(runtime.getStatus().survivingSessionReconciliation).toEqual({ state: 'pending' })
 
-    expect(runtime.getStatus().survivingSessionReconciliation).toEqual(expected)
-  })
+    await controllerHarness.resolveRefresh([
+      { id: `${TEST_WORKTREE_ID}@@preexisting`, cwd: TEST_WORKTREE_PATH, title: 'shell' }
+    ])
 
-  it('keeps live current-generation PTYs out of ambiguous reconciliation', () => {
-    const { runtime } = buildSurvivingSessionReconciliationHarness()
-
-    expect(runtime.getStatus().survivingSessionReconciliation).toMatchObject({
-      active: 1,
-      ambiguous: 1
+    expect(runtime.getStatus().survivingSessionReconciliation).toEqual({
+      state: 'ready',
+      summary: { active: 0, restorable: 0, ambiguous: 1 }
     })
   })
 
-  it('keeps sleeping or serve-owned PTYs restorable', () => {
-    const { runtime } = buildSurvivingSessionReconciliationHarness()
+  it('reports pending until local PTY inventory is ready', async () => {
+    const controllerHarness = createSurvivingSessionControllerHarness()
+    const runtime = createRuntime()
 
-    expect(runtime.getStatus().survivingSessionReconciliation).toMatchObject({
-      restorable: 1,
-      provenOrphan: 0
+    runtime.setPtyController(controllerHarness.controller)
+
+    expect(runtime.getStatus().survivingSessionReconciliation).toEqual({ state: 'pending' })
+    expect(runtime.getStatus().survivingSessionReconciliation).toEqual({ state: 'pending' })
+    expect(controllerHarness.getRefreshStarts()).toBe(1)
+
+    await controllerHarness.resolveRefresh([])
+
+    expect(runtime.getStatus().survivingSessionReconciliation).toEqual({
+      state: 'ready',
+      summary: { active: 0, restorable: 0, ambiguous: 0 }
+    })
+  })
+
+  it('labels failed and invalidated local PTY inventory stale', async () => {
+    const controllerHarness = createSurvivingSessionControllerHarness()
+    const runtime = createRuntime()
+
+    runtime.setPtyController(controllerHarness.controller)
+    await controllerHarness.resolveRefresh([
+      { id: `${TEST_WORKTREE_ID}@@stale`, cwd: TEST_WORKTREE_PATH, title: 'shell' }
+    ])
+    controllerHarness.invalidate()
+
+    expect(runtime.getStatus().survivingSessionReconciliation).toEqual({
+      state: 'stale',
+      summary: { active: 0, restorable: 0, ambiguous: 1 }
+    })
+    expect(controllerHarness.refreshLocalProcessInventory).toHaveBeenCalledTimes(2)
+
+    await controllerHarness.rejectRefresh()
+    expect(runtime.getStatus().survivingSessionReconciliation).toEqual({
+      state: 'stale',
+      summary: { active: 0, restorable: 0, ambiguous: 1 }
+    })
+
+    await controllerHarness.resolveRefresh([])
+    expect(runtime.getStatus().survivingSessionReconciliation).toEqual({
+      state: 'ready',
+      summary: { active: 0, restorable: 0, ambiguous: 0 }
+    })
+  })
+
+  it('reclassifies ready local inventory from current runtime bindings on every status read', async () => {
+    const controllerHarness = createSurvivingSessionControllerHarness()
+    const runtime = createRuntime()
+    const ptyId = `${TEST_WORKTREE_ID}@@reclassify`
+
+    runtime.setPtyController(controllerHarness.controller)
+    await controllerHarness.resolveRefresh([{ id: ptyId, cwd: TEST_WORKTREE_PATH, title: 'shell' }])
+
+    expect(runtime.getStatus().survivingSessionReconciliation).toEqual({
+      state: 'ready',
+      summary: { active: 0, restorable: 0, ambiguous: 1 }
+    })
+
+    runtime.attachWindow(TEST_WINDOW_ID)
+    runtime.syncWindowGraph(TEST_WINDOW_ID, {
+      tabs: [
+        {
+          tabId: 'tab-active',
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'Claude',
+          activeLeafId: HEADLESS_LEAF_ID,
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-active',
+          worktreeId: TEST_WORKTREE_ID,
+          leafId: HEADLESS_LEAF_ID,
+          paneRuntimeId: 1,
+          ptyId
+        }
+      ]
+    })
+
+    expect(runtime.getStatus().survivingSessionReconciliation).toEqual({
+      state: 'ready',
+      summary: { active: 1, restorable: 0, ambiguous: 0 }
+    })
+  })
+
+  it('surfaces surviving session reconciliation on runtime status', async () => {
+    const { runtime } = await buildSurvivingSessionReconciliationHarness()
+
+    expect(runtime.getStatus().survivingSessionReconciliation).toEqual({
+      state: 'ready',
+      summary: { active: 1, restorable: 1, ambiguous: 1 }
     })
   })
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -225,7 +225,6 @@ import {
   SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV
 } from '../../shared/setup-agent-sequencing'
 import { TASK_PROVIDERS } from '../../shared/task-providers'
-import { FIRST_PANE_ID } from '../../shared/pane-key'
 import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../shared/stable-pane-id'
 import { parseAppSshPtyId } from '../../shared/ssh-pty-id'
 import { isValidHostTerminalTabId, isValidTerminalTabId } from '../../shared/terminal-tab-id'
@@ -21243,7 +21242,12 @@ export class OrcaRuntimeService {
       }
 
       const tabs = terminalTabsByPtyId.get(session.id) ?? []
-      const paneKeys = new Set(tabs.map((tab) => `${tab.parentTabId}:${tab.leafId}`))
+      const paneKeys = new Set(
+        tabs.flatMap((tab) => [
+          this.getMobileTerminalPaneKey(tab),
+          `${tab.parentTabId}:${tab.leafId}`
+        ])
+      )
       const worktreeId = session.worktreeId ?? parsePtySessionId(session.id).worktreeId
       const restorable =
         tabs.some((tab) => this.hasServeOrSshOwnedBinding(tab)) ||
@@ -23768,10 +23772,10 @@ export class OrcaRuntimeService {
       }
       return null
     }
-    const paneKeys = new Set([`${tab.parentTabId}:${tab.leafId}`])
-    if (tab.leafId === `pane:${FIRST_PANE_ID}`) {
-      paneKeys.add(`${tab.parentTabId}:${FIRST_PANE_ID}`)
-    }
+    const paneKeys = new Set([
+      this.getMobileTerminalPaneKey(tab),
+      `${tab.parentTabId}:${tab.leafId}`
+    ])
     for (const pty of this.ptysById.values()) {
       if (pty.tabId === tab.parentTabId && pty.paneKey && paneKeys.has(pty.paneKey)) {
         return pty

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1095,6 +1095,20 @@ type RuntimePtyWorktreeRecord = {
   tailWaitState?: TerminalTailWaitState
 }
 
+type SurvivingSessionReconciliation = {
+  active: number
+  restorable: number
+  ambiguous: number
+  provenOrphan: number
+}
+
+const EMPTY_SURVIVING_SESSION_RECONCILIATION: SurvivingSessionReconciliation = {
+  active: 0,
+  restorable: 0,
+  ambiguous: 0,
+  provenOrphan: 0
+}
+
 type TerminalCreateOptions = {
   command?: string
   claudeAgentTeamsSourceCommand?: string
@@ -2338,6 +2352,7 @@ export class OrcaRuntimeService {
   private graphSyncCallbacks: (() => void)[] = []
   private waitersByHandle = new Map<string, Set<TerminalWaiter>>()
   private ptyController: RuntimePtyController | null = null
+  private survivingSessionReconciliation = EMPTY_SURVIVING_SESSION_RECONCILIATION
   private notifier: RuntimeNotifier | null = null
   private clientEventListeners = new Set<(event: RuntimeClientEvent) => void>()
   private forkBackfillStarted = false
@@ -3255,6 +3270,7 @@ export class OrcaRuntimeService {
       desktopWindowStatus: hasRenderer ? 'available' : this.getDesktopWindowStatusFn(),
       liveTabCount: this.tabs.size,
       liveLeafCount: this.leaves.size,
+      survivingSessionReconciliation: this.survivingSessionReconciliation,
       runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
       minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
       // Why: headless orca serve cannot create/stream BrowserViews, so clients
@@ -3645,7 +3661,6 @@ export class OrcaRuntimeService {
     for (const leaf of this.leaves.values()) {
       this.adoptPreAllocatedHandle(leaf)
     }
-
     // Why: createTerminal waits for the renderer's graph sync to populate the
     // new leaf so it can return a handle. Drain callbacks after leaves update.
     for (const cb of [...this.graphSyncCallbacks]) {
@@ -21134,6 +21149,79 @@ export class OrcaRuntimeService {
     return { stopped }
   }
 
+  async classifySurvivingSessionsAgainstGeneration(
+    inventory?: PtyProcessInfo[]
+  ): Promise<SurvivingSessionReconciliation> {
+    const sessions = inventory ?? (await this.ptyController?.listProcesses?.()) ?? []
+    const terminalTabsByPtyId = new Map<string, RuntimeMobileSessionTerminalTab[]>()
+    for (const snapshot of this.mobileSessionTabsByWorktree.values()) {
+      for (const tab of snapshot.tabs) {
+        if (tab.type !== 'terminal' || !tab.ptyId) {
+          continue
+        }
+        const tabs = terminalTabsByPtyId.get(tab.ptyId) ?? []
+        tabs.push(tab)
+        terminalTabsByPtyId.set(tab.ptyId, tabs)
+      }
+    }
+
+    const sleepingPaneKeysByWorktree = new Map<string, Set<string>>()
+    const sessionHosts = new Set<string>()
+    for (const repo of this.store?.getRepos?.() ?? []) {
+      sessionHosts.add(getRepoExecutionHostId(repo))
+    }
+    if (sessionHosts.size === 0) {
+      sessionHosts.add('local')
+    }
+    for (const host of sessionHosts) {
+      const records = this.store?.getWorkspaceSession?.(host).sleepingAgentSessionsByPaneKey
+      if (!records) {
+        continue
+      }
+      for (const record of Object.values(records)) {
+        const keys = sleepingPaneKeysByWorktree.get(record.worktreeId) ?? new Set<string>()
+        keys.add(record.paneKey)
+        sleepingPaneKeysByWorktree.set(record.worktreeId, keys)
+      }
+    }
+
+    const result: SurvivingSessionReconciliation = { ...EMPTY_SURVIVING_SESSION_RECONCILIATION }
+    for (const session of sessions) {
+      const record = this.ptysById.get(session.id)
+      const currentHandle =
+        this.handleByPtyId.get(session.id) ?? this.findHandleForPtyRecord(session.id)
+      const active = Boolean(
+        record?.connected ||
+        this.leafExistsForPty(session.id) ||
+        (currentHandle && this.handles.get(currentHandle)?.runtimeId === this.runtimeId)
+      )
+      if (active) {
+        result.active += 1
+        continue
+      }
+
+      const tabs = terminalTabsByPtyId.get(session.id) ?? []
+      const paneKeys = new Set(tabs.map((tab) => `${tab.parentTabId}:${tab.leafId}`))
+      const worktreeId = session.worktreeId ?? parsePtySessionId(session.id).worktreeId
+      const restorable =
+        tabs.some((tab) => this.hasServeOrSshOwnedBinding(tab)) ||
+        (worktreeId !== null &&
+          [...paneKeys].some((paneKey) => sleepingPaneKeysByWorktree.get(worktreeId)?.has(paneKey)))
+      if (restorable) {
+        result.restorable += 1
+        continue
+      }
+
+      // PtyProcessInfo has no owner PID, and runtime metadata identifies only
+      // the current runtime. Without positive external liveness proof, keep
+      // removed-worktree sessions ambiguous instead of claiming an orphan.
+      result.ambiguous += 1
+    }
+
+    this.survivingSessionReconciliation = result
+    return result
+  }
+
   async stopExactTerminalsForWorktree(
     worktreeSelector: string,
     expectedPtyIds: readonly string[],
@@ -22588,6 +22676,7 @@ export class OrcaRuntimeService {
       }
     }
     this.pruneDisconnectedPtyRecords()
+    void this.classifySurvivingSessionsAgainstGeneration(sessions).catch(() => undefined)
     return livePtyIds
   }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3621,6 +3621,7 @@ export class OrcaRuntimeService {
 
     this.leaves = nextLeaves
     this.rebuildLeafPtyIndex()
+    this.refreshKnownSurvivingSessionReconciliation()
     // Why: the emitted client payload is a function of the stored snapshot AND
     // the tab/leaf graph (handles/titles/connected resolve from leaf state), so
     // a graph-only change — e.g. a restored leaf binding its ptyId while the
@@ -6443,6 +6444,7 @@ export class OrcaRuntimeService {
       leaf.writable = this.graphStatus === 'ready'
       this.adoptPreAllocatedHandle(leaf)
     }
+    this.refreshKnownSurvivingSessionReconciliation()
   }
 
   registerPty(
@@ -21153,6 +21155,65 @@ export class OrcaRuntimeService {
     inventory?: PtyProcessInfo[]
   ): Promise<SurvivingSessionReconciliation> {
     const sessions = inventory ?? (await this.ptyController?.listProcesses?.()) ?? []
+    const result = this.classifySurvivingSessionInventory(sessions)
+    this.survivingSessionReconciliation = result
+    return result
+  }
+
+  private refreshKnownSurvivingSessionReconciliation(): void {
+    if (
+      this.ptysById.size === 0 &&
+      this.leaves.size === 0 &&
+      this.mobileSessionTabsByWorktree.size === 0
+    ) {
+      this.survivingSessionReconciliation = EMPTY_SURVIVING_SESSION_RECONCILIATION
+      return
+    }
+    this.survivingSessionReconciliation = this.classifySurvivingSessionInventory(
+      this.collectKnownSurvivingSessionInventory()
+    )
+  }
+
+  private collectKnownSurvivingSessionInventory(): PtyProcessInfo[] {
+    const sessionsById = new Map<string, PtyProcessInfo>()
+    for (const pty of this.ptysById.values()) {
+      sessionsById.set(pty.ptyId, {
+        id: pty.ptyId,
+        cwd: '',
+        title: pty.title ?? '',
+        worktreeId: pty.worktreeId
+      })
+    }
+    for (const leaf of this.leaves.values()) {
+      if (!leaf.ptyId || sessionsById.has(leaf.ptyId)) {
+        continue
+      }
+      sessionsById.set(leaf.ptyId, {
+        id: leaf.ptyId,
+        cwd: '',
+        title: '',
+        worktreeId: leaf.worktreeId
+      })
+    }
+    for (const [worktreeId, snapshot] of this.mobileSessionTabsByWorktree) {
+      for (const tab of snapshot.tabs) {
+        if (tab.type !== 'terminal' || !tab.ptyId || sessionsById.has(tab.ptyId)) {
+          continue
+        }
+        sessionsById.set(tab.ptyId, {
+          id: tab.ptyId,
+          cwd: '',
+          title: '',
+          worktreeId
+        })
+      }
+    }
+    return [...sessionsById.values()]
+  }
+
+  private classifySurvivingSessionInventory(
+    sessions: readonly Pick<PtyProcessInfo, 'id' | 'worktreeId'>[]
+  ): SurvivingSessionReconciliation {
     const terminalTabsByPtyId = new Map<string, RuntimeMobileSessionTerminalTab[]>()
     for (const snapshot of this.mobileSessionTabsByWorktree.values()) {
       for (const tab of snapshot.tabs) {
@@ -21187,11 +21248,9 @@ export class OrcaRuntimeService {
 
     const result: SurvivingSessionReconciliation = { ...EMPTY_SURVIVING_SESSION_RECONCILIATION }
     for (const session of sessions) {
-      const record = this.ptysById.get(session.id)
       const currentHandle =
         this.handleByPtyId.get(session.id) ?? this.findHandleForPtyRecord(session.id)
       const active = Boolean(
-        record?.connected ||
         this.leafExistsForPty(session.id) ||
         (currentHandle && this.handles.get(currentHandle)?.runtimeId === this.runtimeId)
       )
@@ -21217,8 +21276,6 @@ export class OrcaRuntimeService {
       // removed-worktree sessions ambiguous instead of claiming an orphan.
       result.ambiguous += 1
     }
-
-    this.survivingSessionReconciliation = result
     return result
   }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -334,6 +334,8 @@ import type {
   RuntimeTerminalResolvePane,
   RuntimeTerminalState,
   RuntimeStatus,
+  RuntimeSurvivingSessionReconciliation,
+  RuntimeSurvivingSessionReconciliationSummary,
   RuntimeSyncWindowGraphResult,
   RuntimeTerminalWait,
   RuntimeTerminalWaitBlockedReason,
@@ -1095,18 +1097,32 @@ type RuntimePtyWorktreeRecord = {
   tailWaitState?: TerminalTailWaitState
 }
 
-type SurvivingSessionReconciliation = {
-  active: number
-  restorable: number
-  ambiguous: number
-  provenOrphan: number
-}
+type RuntimeLocalProcessInventorySnapshot =
+  | {
+      state: 'pending'
+    }
+  | {
+      state: 'ready'
+      processes: PtyProcessInfo[]
+    }
+  | {
+      state: 'stale'
+      processes?: PtyProcessInfo[]
+    }
 
-const EMPTY_SURVIVING_SESSION_RECONCILIATION: SurvivingSessionReconciliation = {
-  active: 0,
-  restorable: 0,
-  ambiguous: 0,
-  provenOrphan: 0
+const EMPTY_SURVIVING_SESSION_RECONCILIATION_SUMMARY: RuntimeSurvivingSessionReconciliationSummary =
+  {
+    active: 0,
+    restorable: 0,
+    ambiguous: 0
+  }
+
+function hasProcessInventoryBaseline(
+  snapshot: RuntimeLocalProcessInventorySnapshot
+): snapshot is Extract<RuntimeLocalProcessInventorySnapshot, { processes?: PtyProcessInfo[] }> & {
+  processes: PtyProcessInfo[]
+} {
+  return 'processes' in snapshot && snapshot.processes !== undefined
 }
 
 type TerminalCreateOptions = {
@@ -1338,6 +1354,8 @@ type RuntimePtyController = {
   // Why: exact-id mobile polls should not enumerate every local and SSH PTY.
   hasPty?(ptyId: string): boolean | null
   listProcesses?(): Promise<PtyProcessInfo[]>
+  getLocalProcessInventorySnapshot?(): RuntimeLocalProcessInventorySnapshot
+  refreshLocalProcessInventory?(): Promise<void>
   serializeBuffer?(
     ptyId: string,
     opts?: { scrollbackRows?: number; altScreenForcesZeroRows?: boolean }
@@ -2352,7 +2370,6 @@ export class OrcaRuntimeService {
   private graphSyncCallbacks: (() => void)[] = []
   private waitersByHandle = new Map<string, Set<TerminalWaiter>>()
   private ptyController: RuntimePtyController | null = null
-  private survivingSessionReconciliation = EMPTY_SURVIVING_SESSION_RECONCILIATION
   private notifier: RuntimeNotifier | null = null
   private clientEventListeners = new Set<(event: RuntimeClientEvent) => void>()
   private forkBackfillStarted = false
@@ -3262,6 +3279,7 @@ export class OrcaRuntimeService {
     if (canBrowse) {
       capabilities.push(BROWSER_CERTIFICATE_TRUST_RUNTIME_CAPABILITY)
     }
+    const survivingSessionReconciliation = this.getSurvivingSessionReconciliationStatus()
     return {
       runtimeId: this.runtimeId,
       rendererGraphEpoch: this.rendererGraphEpoch,
@@ -3270,7 +3288,7 @@ export class OrcaRuntimeService {
       desktopWindowStatus: hasRenderer ? 'available' : this.getDesktopWindowStatusFn(),
       liveTabCount: this.tabs.size,
       liveLeafCount: this.leaves.size,
-      survivingSessionReconciliation: this.survivingSessionReconciliation,
+      survivingSessionReconciliation,
       runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
       minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
       // Why: headless orca serve cannot create/stream BrowserViews, so clients
@@ -3304,6 +3322,7 @@ export class OrcaRuntimeService {
     // instead of tunneling back through renderer IPC, or live handles could
     // drift from the process they are supposed to control during reloads.
     this.ptyController = controller
+    void controller?.refreshLocalProcessInventory?.().catch(() => undefined)
   }
 
   setNotifier(notifier: RuntimeNotifier | null): void {
@@ -3621,7 +3640,6 @@ export class OrcaRuntimeService {
 
     this.leaves = nextLeaves
     this.rebuildLeafPtyIndex()
-    this.refreshKnownSurvivingSessionReconciliation()
     // Why: the emitted client payload is a function of the stored snapshot AND
     // the tab/leaf graph (handles/titles/connected resolve from leaf state), so
     // a graph-only change — e.g. a restored leaf binding its ptyId while the
@@ -6444,7 +6462,6 @@ export class OrcaRuntimeService {
       leaf.writable = this.graphStatus === 'ready'
       this.adoptPreAllocatedHandle(leaf)
     }
-    this.refreshKnownSurvivingSessionReconciliation()
   }
 
   registerPty(
@@ -21151,69 +21168,29 @@ export class OrcaRuntimeService {
     return { stopped }
   }
 
-  async classifySurvivingSessionsAgainstGeneration(
-    inventory?: PtyProcessInfo[]
-  ): Promise<SurvivingSessionReconciliation> {
-    const sessions = inventory ?? (await this.ptyController?.listProcesses?.()) ?? []
-    const result = this.classifySurvivingSessionInventory(sessions)
-    this.survivingSessionReconciliation = result
-    return result
-  }
-
-  private refreshKnownSurvivingSessionReconciliation(): void {
-    if (
-      this.ptysById.size === 0 &&
-      this.leaves.size === 0 &&
-      this.mobileSessionTabsByWorktree.size === 0
-    ) {
-      this.survivingSessionReconciliation = EMPTY_SURVIVING_SESSION_RECONCILIATION
-      return
+  private getSurvivingSessionReconciliationStatus():
+    | RuntimeSurvivingSessionReconciliation
+    | undefined {
+    const snapshot = this.ptyController?.getLocalProcessInventorySnapshot?.()
+    if (!snapshot) {
+      return undefined
     }
-    this.survivingSessionReconciliation = this.classifySurvivingSessionInventory(
-      this.collectKnownSurvivingSessionInventory()
-    )
-  }
-
-  private collectKnownSurvivingSessionInventory(): PtyProcessInfo[] {
-    const sessionsById = new Map<string, PtyProcessInfo>()
-    for (const pty of this.ptysById.values()) {
-      sessionsById.set(pty.ptyId, {
-        id: pty.ptyId,
-        cwd: '',
-        title: pty.title ?? '',
-        worktreeId: pty.worktreeId
-      })
+    if (snapshot.state !== 'ready') {
+      void this.ptyController?.refreshLocalProcessInventory?.().catch(() => undefined)
     }
-    for (const leaf of this.leaves.values()) {
-      if (!leaf.ptyId || sessionsById.has(leaf.ptyId)) {
-        continue
-      }
-      sessionsById.set(leaf.ptyId, {
-        id: leaf.ptyId,
-        cwd: '',
-        title: '',
-        worktreeId: leaf.worktreeId
-      })
+    if (snapshot.state === 'pending') {
+      return { state: 'pending' }
     }
-    for (const [worktreeId, snapshot] of this.mobileSessionTabsByWorktree) {
-      for (const tab of snapshot.tabs) {
-        if (tab.type !== 'terminal' || !tab.ptyId || sessionsById.has(tab.ptyId)) {
-          continue
-        }
-        sessionsById.set(tab.ptyId, {
-          id: tab.ptyId,
-          cwd: '',
-          title: '',
-          worktreeId
-        })
-      }
+    if (!hasProcessInventoryBaseline(snapshot)) {
+      return { state: 'stale' }
     }
-    return [...sessionsById.values()]
+    const summary = this.classifySurvivingSessionInventory(snapshot.processes)
+    return snapshot.state === 'ready' ? { state: 'ready', summary } : { state: 'stale', summary }
   }
 
   private classifySurvivingSessionInventory(
     sessions: readonly Pick<PtyProcessInfo, 'id' | 'worktreeId'>[]
-  ): SurvivingSessionReconciliation {
+  ): RuntimeSurvivingSessionReconciliationSummary {
     const terminalTabsByPtyId = new Map<string, RuntimeMobileSessionTerminalTab[]>()
     for (const snapshot of this.mobileSessionTabsByWorktree.values()) {
       for (const tab of snapshot.tabs) {
@@ -21246,7 +21223,13 @@ export class OrcaRuntimeService {
       }
     }
 
-    const result: SurvivingSessionReconciliation = { ...EMPTY_SURVIVING_SESSION_RECONCILIATION }
+    if (sessions.length === 0) {
+      return EMPTY_SURVIVING_SESSION_RECONCILIATION_SUMMARY
+    }
+
+    const result: RuntimeSurvivingSessionReconciliationSummary = {
+      ...EMPTY_SURVIVING_SESSION_RECONCILIATION_SUMMARY
+    }
     for (const session of sessions) {
       const currentHandle =
         this.handleByPtyId.get(session.id) ?? this.findHandleForPtyRecord(session.id)
@@ -21271,9 +21254,6 @@ export class OrcaRuntimeService {
         continue
       }
 
-      // PtyProcessInfo has no owner PID, and runtime metadata identifies only
-      // the current runtime. Without positive external liveness proof, keep
-      // removed-worktree sessions ambiguous instead of claiming an orphan.
       result.ambiguous += 1
     }
     return result
@@ -22733,7 +22713,6 @@ export class OrcaRuntimeService {
       }
     }
     this.pruneDisconnectedPtyRecords()
-    void this.classifySurvivingSessionsAgainstGeneration(sessions).catch(() => undefined)
     return livePtyIds
   }
 

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -61,6 +61,25 @@ export type RuntimeTerminalDriverState =
 
 export type RuntimeBrowserDriverState = RuntimeTerminalDriverState
 
+export type RuntimeSurvivingSessionReconciliationSummary = {
+  active: number
+  restorable: number
+  ambiguous: number
+}
+
+export type RuntimeSurvivingSessionReconciliation =
+  | {
+      state: 'pending'
+    }
+  | {
+      state: 'ready'
+      summary: RuntimeSurvivingSessionReconciliationSummary
+    }
+  | {
+      state: 'stale'
+      summary?: RuntimeSurvivingSessionReconciliationSummary
+    }
+
 export type RuntimeStatus = {
   runtimeId: string
   rendererGraphEpoch: number
@@ -69,12 +88,7 @@ export type RuntimeStatus = {
   desktopWindowStatus?: RuntimeDesktopWindowStatus
   liveTabCount: number
   liveLeafCount: number
-  survivingSessionReconciliation?: {
-    active: number
-    restorable: number
-    ambiguous: number
-    provenOrphan: number
-  }
+  survivingSessionReconciliation?: RuntimeSurvivingSessionReconciliation
   // Why: optional so clients can read both new and pre-contract runtimes.
   // Absence is treated as protocol 0 by the compat evaluator.
   runtimeProtocolVersion?: number

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -69,6 +69,12 @@ export type RuntimeStatus = {
   desktopWindowStatus?: RuntimeDesktopWindowStatus
   liveTabCount: number
   liveLeafCount: number
+  survivingSessionReconciliation?: {
+    active: number
+    restorable: number
+    ambiguous: number
+    provenOrphan: number
+  }
   // Why: optional so clients can read both new and pre-contract runtimes.
   // Absence is treated as protocol 0 by the compat evaluator.
   runtimeProtocolVersion?: number


### PR DESCRIPTION
## Summary

- Report whether the local PTY inventory is pending, ready, or stale instead of presenting an uninitialized or outdated summary as current, and invalidate that snapshot after renderer-facing local `pty:spawn` succeeds.
- Derive active, restorable, and ambiguous counts from the controller's raw inventory and current runtime bindings on every status read, including mobile sleeping sessions keyed with legacy `pane:N` ids.
- Refresh on startup and lifecycle invalidation; remove an exited PTY before the next status read and reject late refresh results that could reinsert it.

Refs #9229.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- [x] Startup inventory includes PTYs that predate controller installation without an `onPtySpawned()` callback.
- [x] Renderer-facing local `pty:spawn` marks the local inventory snapshot stale and refreshes it through the same controller-owned path as desktop daemon spawns.
- [x] Pending, ready, stale, failed-refresh, exit-removal, and late-result transitions pass focused Vitest coverage.
- [x] Legacy mobile `pane:N` tabs still match canonical sleeping-session and PTY pane keys during reconciliation and fallback PTY lookup.
- [x] Existing exact-stop tests still require fresh controller inventory.
- [x] Node and web typechecks pass.
- [x] Changed-file lint, format, and `git diff --check` pass.

## AI Review Report

- [x] Confirm the controller owns raw local inventory freshness across both controller and renderer-facing local spawn paths, and runtime status owns read-time classification.
- [x] Confirm every startup, spawn, exit, provider replacement, and refresh-failure transition preserves the `pending | ready | stale` contract.
- [x] Confirm legacy mobile `pane:N` identifiers normalize to the same pane key the persisted sleeping-session and PTY records use.
- [x] Confirm a late inventory result cannot overwrite a newer epoch or reinsert an exited PTY.
- [x] Confirm desktop and headless registration share the contract; SSH inventory output and fresh-list consumers retain their existing behavior.

## Security Audit

- [x] Confirm stale inventory never authorizes stop, kill, shutdown, retirement, or cleanup.
- [x] Confirm status exposes counts and freshness only, with no session IDs, paths, commands, credentials, or terminal output.
- [x] Confirm the change adds no process-control capability, daemon wire field, or cleanup path.

## Notes

- This is a non-closing read-only slice. `PtyProcessInfo` does not identify current versus legacy daemon generation and does not describe descendants, so generation attribution, proven-orphan classification, reconciliation commands, and cleanup remain outside this PR.
- The issue and scope comment remain the upstream source for the broader Linux/headless recovery work: https://github.com/stablyai/orca/issues/9229 and https://github.com/stablyai/orca/issues/9229#issuecomment-5017080191
- Open PR https://github.com/stablyai/orca/pull/9804 covers destructive reconnect safety and explicitly leaves generation handoff to #9138/#9229.



## ELI5

Local PTY inventory could look "current" when it was still loading or stale. Status now reports pending/ready/stale and refreshes after spawns so tools do not act on an outdated terminal list.
