### PR TITLE
fix(ssh): pin orchestration to the relay launcher

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -1573,7 +1573,7 @@ describe('registerPtyHandlers', () => {
             env: Record<string, string>
             sessionId?: string
             isNewSession?: boolean
-          }) => ({
+          }): Promise<{ id: string; shellPath?: string; wslDistro?: string | null }> => ({
             id: options.sessionId ?? 'daemon-pty',
             ...(reportedWslDistro !== undefined ? { wslDistro: reportedWslDistro } : {})
           })
@@ -2153,7 +2153,11 @@ describe('registerPtyHandlers', () => {
           }): Promise<{ id: string }>
         }
         const leafId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
-        setupDaemonAdapter()
+        const daemonSpawn = setupDaemonAdapter()
+        daemonSpawn.mockResolvedValueOnce({
+          id: 'daemon-runtime',
+          shellPath: '/bin/actual-remote-shell'
+        })
         const runtime = {
           setPtyController: vi.fn(),
           registerPty: vi.fn(),
@@ -2179,7 +2183,8 @@ describe('registerPtyHandlers', () => {
           'wt-runtime',
           null,
           { tabId: 'tab-1', leafId },
-          false
+          false,
+          '/bin/actual-remote-shell'
         )
       })
 
@@ -2187,6 +2192,7 @@ describe('registerPtyHandlers', () => {
         await withWin32Platform(async () => {
           _setWslCachesForTests({ available: true, distros: ['Ubuntu'] })
           const daemonSpawn = setupDaemonAdapter()
+          daemonSpawn.mockResolvedValueOnce({ id: 'daemon-wsl', shellPath: 'wsl.exe' })
           const runtime = {
             setPtyController: vi.fn(),
             registerPty: vi.fn(),
@@ -2240,7 +2246,8 @@ describe('registerPtyHandlers', () => {
             'repo-1::C:\\repo',
             null,
             undefined,
-            true
+            true,
+            'wsl.exe'
           )
         })
       })
@@ -5285,7 +5292,8 @@ describe('registerPtyHandlers', () => {
       'wt-1',
       null,
       { tabId: 'tab-1', leafId },
-      false
+      false,
+      undefined
     )
   })
 
@@ -5318,7 +5326,8 @@ describe('registerPtyHandlers', () => {
       'wt-1',
       null,
       undefined,
-      false
+      false,
+      undefined
     )
   })
 

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -3147,9 +3147,8 @@ export function registerPtyHandlers(
               metadataLeafId !== null
               ? { tabId: args.tabId, leafId: metadataLeafId }
               : undefined,
-            !args.connectionId
-              ? shouldSkipCodexHomeEnvForWindowsShell(daemonShellOverride, cwd)
-              : undefined
+            shouldSkipCodexHomeEnvForWindowsShell(result.shellPath ?? daemonShellOverride, cwd),
+            result.shellPath
           )
         }
         // Why: arms main's per-PTY Command Code output detector from the launch command (renderer startupCommand parity).
@@ -4188,9 +4187,8 @@ export function registerPtyHandlers(
               metadataLeafId !== null
               ? { tabId: args.tabId, leafId: metadataLeafId }
               : undefined,
-            !args.connectionId
-              ? shouldSkipCodexHomeEnvForWindowsShell(effectiveShellOverride, cwd)
-              : undefined
+            shouldSkipCodexHomeEnvForWindowsShell(result.shellPath ?? effectiveShellOverride, cwd),
+            result.shellPath
           )
         }
         // Why: arm main's per-PTY Command Code output detector from the launch command (startupCommand parity); banner detection covers PTYs without one.

--- a/src/main/providers/pty-orchestration-cli-command.ts
+++ b/src/main/providers/pty-orchestration-cli-command.ts
@@ -1,0 +1,11 @@
+export type PtyOrchestrationCliCommand =
+  | { kind: 'posix-path'; executablePath: string }
+  | { kind: 'powershell-path'; executablePath: string }
+  | { kind: 'posix-env'; variableName: 'ORCA_CLI_COMMAND' }
+  | { kind: 'powershell-env'; variableName: 'ORCA_CLI_COMMAND' }
+  | { kind: 'cmd-env'; variableName: 'ORCA_CLI_COMMAND' }
+
+export type PtyOrchestrationCliCommandResolver = (context: {
+  isWsl: boolean
+  shellPath: string | null
+}) => PtyOrchestrationCliCommand | null

--- a/src/main/providers/pty-process-info.ts
+++ b/src/main/providers/pty-process-info.ts
@@ -1,0 +1,10 @@
+export type PtyProcessInfo = {
+  id: string
+  cwd: string
+  title: string
+  shellPath?: string
+  /** Owning worktree when the provider can report it authoritatively. */
+  worktreeId?: string
+  /** Trusted ORCA_TERMINAL_HANDLE exported into this PTY, when known. */
+  terminalHandle?: string
+}

--- a/src/main/providers/pty-spawn-result.ts
+++ b/src/main/providers/pty-spawn-result.ts
@@ -5,6 +5,8 @@ export type PtySpawnResult = {
   /** App-facing PTY id. Remote providers must return globally routable ids,
    *  not relay-local handles, because renderer/runtime IPC routes by this key. */
   id: string
+  /** Actual shell selected by the provider, used for shell-specific lifecycle commands. */
+  shellPath?: string
   /** OS-level pid of the shell process, when available at spawn time.
    *  Why: the memory collector needs this to walk each PTY's process
    *  subtree. Daemon-backed providers return it from the RPC result;

--- a/src/main/providers/ssh-pty-provider.test.ts
+++ b/src/main/providers/ssh-pty-provider.test.ts
@@ -35,6 +35,89 @@ describe('SshPtyProvider', () => {
     expect(provider.getConnectionId()).toBe('conn-1')
   })
 
+  describe('orchestration CLI command', () => {
+    it('uses an absolute launcher path on POSIX hosts regardless of shell startup', () => {
+      provider = new SshPtyProvider('conn-1', mux as never, {
+        binDir: '/home/user/.orca-relay/bin',
+        relayDir: '/relay',
+        nodePath: '/node',
+        sockPath: '/socket',
+        orchestrationLauncherPath: '/home/user/.orca-relay/bin/orca-relay'
+      })
+
+      expect(provider.getOrchestrationCliCommand({ isWsl: false, shellPath: '/bin/zsh' })).toEqual({
+        kind: 'posix-path',
+        executablePath: '/home/user/.orca-relay/bin/orca-relay'
+      })
+    })
+
+    it('uses PowerShell invocation syntax for pwsh on a POSIX SSH host', () => {
+      provider = new SshPtyProvider('conn-1', mux as never, {
+        binDir: '/home/user/.orca-relay/bin',
+        relayDir: '/relay',
+        nodePath: '/node',
+        sockPath: '/socket',
+        orchestrationLauncherPath: "/home/user's/.orca-relay/bin/orca-relay"
+      })
+
+      expect(
+        provider.getOrchestrationCliCommand({ isWsl: false, shellPath: '/opt/microsoft/pwsh' })
+      ).toEqual({
+        kind: 'powershell-path',
+        executablePath: "/home/user's/.orca-relay/bin/orca-relay"
+      })
+    })
+
+    it.each([
+      ['WSL', true, 'C:/Windows/System32/wsl.exe', 'posix-env'],
+      ['PowerShell 5', false, 'powershell.exe', 'powershell-env'],
+      ['PowerShell 7', false, 'C:/Program Files/PowerShell/7/pwsh.exe', 'powershell-env'],
+      ['cmd', false, 'C:/Windows/System32/cmd.exe', 'cmd-env'],
+      ['Git Bash', false, 'C:/Program Files/Git/bin/bash.exe', 'posix-env']
+    ])('selects %s invocation syntax on Windows SSH hosts', (_name, isWsl, shellPath, kind) => {
+      provider = new SshPtyProvider('conn-1', mux as never, {
+        binDir: 'C:/Users/me/.orca-relay/bin',
+        relayDir: 'C:/Users/me/.orca-remote/relay-v1',
+        nodePath: 'C:/Program Files/nodejs/node.exe',
+        sockPath: '\\\\.\\pipe\\orca-relay-123',
+        orchestrationLauncherPath: 'C:/Users/me/.orca-relay/bin/orca-relay.exe',
+        pathDelimiter: ';'
+      })
+
+      expect(provider.getOrchestrationCliCommand({ isWsl, shellPath })).toEqual({
+        kind,
+        variableName: 'ORCA_CLI_COMMAND'
+      })
+    })
+
+    it('withholds capability after install failure or for an unknown Windows shell', () => {
+      const missingInstall = new SshPtyProvider('conn-1', mux as never, {
+        binDir: '/home/user/.orca-relay/bin',
+        relayDir: '/relay',
+        nodePath: '/node',
+        sockPath: '/socket'
+      })
+      const unknownWindowsShell = new SshPtyProvider('conn-1', mux as never, {
+        binDir: 'C:/Users/me/.orca-relay/bin',
+        relayDir: 'C:/relay',
+        nodePath: 'C:/node.exe',
+        sockPath: '\\\\.\\pipe\\orca',
+        orchestrationLauncherPath: 'C:/Users/me/.orca-relay/bin/orca-relay.exe',
+        pathDelimiter: ';'
+      })
+
+      expect(
+        missingInstall.getOrchestrationCliCommand({ isWsl: false, shellPath: '/bin/bash' })
+      ).toBeNull()
+      expect(
+        unknownWindowsShell.getOrchestrationCliCommand({
+          isWsl: false,
+          shellPath: 'C:/tools/nu.exe'
+        })
+      ).toBeNull()
+    })
+  })
+
   describe('spawn', () => {
     it('sends pty.spawn request through multiplexer', async () => {
       mux.request.mockResolvedValue({ id: 'pty-1' })
@@ -239,7 +322,8 @@ describe('SshPtyProvider', () => {
         binDir: '/home/user/.orca-relay/bin',
         relayDir: '/home/user/.orca-relay/relay-v1',
         nodePath: '/usr/bin/node',
-        sockPath: '/home/user/.orca-relay/relay.sock'
+        sockPath: '/home/user/.orca-relay/relay.sock',
+        orchestrationLauncherPath: '/home/user/.orca-relay/bin/orca-relay'
       })
 
       await provider.spawn({
@@ -256,6 +340,7 @@ describe('SshPtyProvider', () => {
           PATH: '/home/user/.orca-relay/bin:/usr/bin',
           ORCA_TERMINAL_HANDLE: 'term_ssh',
           [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'true',
+          ORCA_CLI_COMMAND: '/home/user/.orca-relay/bin/orca-relay',
           ORCA_REMOTE_CLI_BIN_DIR: '/home/user/.orca-relay/bin',
           ORCA_RELAY_DIR: '/home/user/.orca-relay/relay-v1',
           ORCA_RELAY_NODE_PATH: '/usr/bin/node',
@@ -270,7 +355,8 @@ describe('SshPtyProvider', () => {
         binDir: '/home/user/.orca-relay/bin',
         relayDir: '/home/user/.orca-relay/relay-v1',
         nodePath: '/usr/bin/node',
-        sockPath: '/home/user/.orca-relay/relay.sock'
+        sockPath: '/home/user/.orca-relay/relay.sock',
+        orchestrationLauncherPath: '/home/user/.orca-relay/bin/orca-relay'
       })
 
       await provider.spawn({
@@ -286,6 +372,7 @@ describe('SshPtyProvider', () => {
         env: {
           ORCA_TERMINAL_HANDLE: 'term_ssh',
           [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'true',
+          ORCA_CLI_COMMAND: '/home/user/.orca-relay/bin/orca-relay',
           ORCA_REMOTE_CLI_BIN_DIR: '/home/user/.orca-relay/bin',
           ORCA_RELAY_DIR: '/home/user/.orca-relay/relay-v1',
           ORCA_RELAY_NODE_PATH: '/usr/bin/node',
@@ -301,6 +388,7 @@ describe('SshPtyProvider', () => {
         relayDir: 'C:/Users/me/.orca-remote/relay-v1',
         nodePath: 'C:/Program Files/nodejs/node.exe',
         sockPath: '\\\\.\\pipe\\orca-relay-123',
+        orchestrationLauncherPath: 'C:/Users/me/.orca-relay/bin/orca-relay.exe',
         pathDelimiter: ';'
       })
 
@@ -317,6 +405,7 @@ describe('SshPtyProvider', () => {
         env: {
           Path: 'C:/Users/me/.orca-relay/bin;C:/Windows/System32;C:/Tools',
           [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'true',
+          ORCA_CLI_COMMAND: 'C:/Users/me/.orca-relay/bin/orca-relay.exe',
           ORCA_REMOTE_CLI_BIN_DIR: 'C:/Users/me/.orca-relay/bin',
           ORCA_RELAY_DIR: 'C:/Users/me/.orca-remote/relay-v1',
           ORCA_RELAY_NODE_PATH: 'C:/Program Files/nodejs/node.exe',
@@ -325,8 +414,70 @@ describe('SshPtyProvider', () => {
       })
     })
 
+    it.each([
+      {
+        name: 'buried POSIX entry',
+        binDir: '/home/user/.orca-relay/bin',
+        pathDelimiter: ':' as const,
+        pathKey: 'PATH',
+        input: '/host/bin:/home/user/.orca-relay/bin:/usr/bin',
+        expected: '/home/user/.orca-relay/bin:/host/bin:/usr/bin'
+      },
+      {
+        name: 'duplicate POSIX entries',
+        binDir: '/home/user/.orca-relay/bin',
+        pathDelimiter: ':' as const,
+        pathKey: 'PATH',
+        input: '/home/user/.orca-relay/bin:/usr/bin:/home/user/.orca-relay/bin:',
+        expected: '/home/user/.orca-relay/bin:/usr/bin:'
+      },
+      {
+        name: 'POSIX prefix lookalike and empty entries',
+        binDir: '/relay/[bin]*',
+        pathDelimiter: ':' as const,
+        pathKey: 'PATH',
+        input: ':/relay/[bin]*-old:/relay/[bin]*::/usr/bin',
+        expected: '/relay/[bin]*::/relay/[bin]*-old::/usr/bin'
+      },
+      {
+        name: 'case-insensitive Windows entries',
+        binDir: 'C:/Users/me/.orca-relay/bin',
+        pathDelimiter: ';' as const,
+        pathKey: 'Path',
+        input: 'C:/Tools;c:/users/ME/.ORCA-RELAY/BIN;C:/Windows',
+        expected: 'C:/Users/me/.orca-relay/bin;C:/Tools;C:/Windows'
+      }
+    ])('moves the relay bin first for $name', async (testCase) => {
+      mux.request.mockResolvedValue({ id: 'pty-path' })
+      provider = new SshPtyProvider('conn-1', mux as never, {
+        binDir: testCase.binDir,
+        relayDir: '/relay',
+        nodePath: '/node',
+        sockPath: '/socket',
+        orchestrationLauncherPath:
+          testCase.pathDelimiter === ';'
+            ? `${testCase.binDir}/orca-relay.exe`
+            : `${testCase.binDir}/orca-relay`,
+        pathDelimiter: testCase.pathDelimiter
+      })
+
+      await provider.spawn({
+        cols: 80,
+        rows: 24,
+        env: { [testCase.pathKey]: testCase.input }
+      })
+
+      expect(mux.request.mock.calls[0]?.[1]?.env).toMatchObject({
+        [testCase.pathKey]: testCase.expected,
+        ORCA_CLI_COMMAND:
+          testCase.pathDelimiter === ';'
+            ? `${testCase.binDir}/orca-relay.exe`
+            : `${testCase.binDir}/orca-relay`
+      })
+    })
+
     it('reattaches an existing session and returns attach replay separately from snapshot', async () => {
-      mux.request.mockResolvedValue({ replay: 'buffered-output' })
+      mux.request.mockResolvedValue({ replay: 'buffered-output', shellPath: '/bin/zsh' })
 
       const result = await provider.spawn({ cols: 80, rows: 24, sessionId: 'pty-old' })
 
@@ -339,7 +490,8 @@ describe('SshPtyProvider', () => {
       expect(result).toEqual({
         id: 'ssh:conn-1@@pty-old',
         isReattach: true,
-        replay: 'buffered-output'
+        replay: 'buffered-output',
+        shellPath: '/bin/zsh'
       })
     })
 
@@ -439,11 +591,11 @@ describe('SshPtyProvider', () => {
   })
 
   it('attachForReconnect returns replay without relay notification', async () => {
-    mux.request.mockResolvedValue({ replay: 'restored output' })
+    mux.request.mockResolvedValue({ replay: 'restored output', shellPath: '/bin/zsh' })
 
     const result = await provider.attachForReconnect(scopedPty1)
 
-    expect(result).toEqual({ replay: 'restored output' })
+    expect(result).toEqual({ replay: 'restored output', shellPath: '/bin/zsh' })
     expect(mux.request).toHaveBeenCalledWith('pty.attach', {
       id: 'pty-1',
       suppressReplayNotification: true

--- a/src/main/providers/ssh-pty-provider.ts
+++ b/src/main/providers/ssh-pty-provider.ts
@@ -1,5 +1,10 @@
 import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
 import type { IPtyProvider, PtyProcessInfo, PtySpawnOptions, PtySpawnResult } from './types'
+import {
+  mergeSshRemoteCliBridgeEnv,
+  resolveSshOrchestrationCliCommand,
+  type SshRemoteCliBridgeEnv
+} from './ssh-remote-cli-resolution'
 import { toAppSshPtyId, toRelaySshPtyId } from './ssh-pty-id'
 import { seedPowerlevel10kWizardEnv } from '../pty/powerlevel10k-wizard-env'
 import { PTY_STARTUP_INGRESS_VERSION } from '../../shared/pty-startup-ingress'
@@ -14,13 +19,6 @@ type DataCallback = (payload: {
 }) => void
 type ReplayCallback = (payload: { id: string; data: string }) => void
 type ExitCallback = (payload: { id: string; code: number }) => void
-type RemoteCliBridgeEnv = {
-  binDir: string
-  relayDir: string
-  nodePath: string
-  sockPath: string
-  pathDelimiter?: ':' | ';'
-}
 
 export const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
 export const SSH_PTY_IDENTITY_MISMATCH_ERROR = 'SSH_PTY_IDENTITY_MISMATCH'
@@ -62,7 +60,7 @@ export class SshPtyProvider implements IPtyProvider {
   constructor(
     connectionId: string,
     mux: SshChannelMultiplexer,
-    private readonly remoteCliBridgeEnv?: RemoteCliBridgeEnv
+    private readonly remoteCliBridgeEnv?: SshRemoteCliBridgeEnv
   ) {
     this.connectionId = connectionId
     this.mux = mux
@@ -114,6 +112,14 @@ export class SshPtyProvider implements IPtyProvider {
     return this.connectionId
   }
 
+  getOrchestrationCliCommand(context: { isWsl: boolean; shellPath: string | null }) {
+    return resolveSshOrchestrationCliCommand({
+      launcherPath: this.remoteCliBridgeEnv?.orchestrationLauncherPath,
+      pathDelimiter: this.remoteCliBridgeEnv?.pathDelimiter ?? ':',
+      ...context
+    })
+  }
+
   private toRelayPtyId(id: string): string {
     return toRelaySshPtyId(this.connectionId, id)
   }
@@ -145,14 +151,15 @@ export class SshPtyProvider implements IPtyProvider {
           suppressReplayNotification: true,
           ...(expectedPaneKey ? { expectedPaneKey } : {}),
           ...(expectedTabId ? { expectedTabId } : {})
-        })) as { replay?: string }
+        })) as { replay?: string; shellPath?: string }
         console.warn(
           `[ssh-pty] pty.attach succeeded for ${opts.sessionId}, replay=${!!attachResult.replay}`
         )
         return {
           id: this.toAppPtyId(relaySessionId),
           isReattach: true,
-          ...(attachResult.replay ? { replay: attachResult.replay } : {})
+          ...(attachResult.replay ? { replay: attachResult.replay } : {}),
+          ...(attachResult.shellPath ? { shellPath: attachResult.shellPath } : {})
         }
       } catch (err) {
         // Why: pty.attach fails when the relay grace window has elapsed.
@@ -211,23 +218,7 @@ export class SshPtyProvider implements IPtyProvider {
     env: Record<string, string> | undefined,
     envToDelete?: readonly string[]
   ): Record<string, string> {
-    const merged = { ...env }
-    if (this.remoteCliBridgeEnv) {
-      const pathDelimiter = this.remoteCliBridgeEnv.pathDelimiter ?? ':'
-      const pathKey = merged.PATH !== undefined ? 'PATH' : merged.Path !== undefined ? 'Path' : null
-      if (pathKey) {
-        const pathValue = merged[pathKey] ?? ''
-        merged[pathKey] = pathValue.split(pathDelimiter).includes(this.remoteCliBridgeEnv.binDir)
-          ? pathValue
-          : pathValue
-            ? `${this.remoteCliBridgeEnv.binDir}${pathDelimiter}${pathValue}`
-            : this.remoteCliBridgeEnv.binDir
-      }
-      merged.ORCA_REMOTE_CLI_BIN_DIR = this.remoteCliBridgeEnv.binDir
-      merged.ORCA_RELAY_DIR = this.remoteCliBridgeEnv.relayDir
-      merged.ORCA_RELAY_NODE_PATH = this.remoteCliBridgeEnv.nodePath
-      merged.ORCA_RELAY_SOCKET_PATH = this.remoteCliBridgeEnv.sockPath
-    }
+    const merged = mergeSshRemoteCliBridgeEnv(env, this.remoteCliBridgeEnv)
     // Why: match local/daemon precedence—managed defaults and augmentations
     // cannot resurrect values the caller explicitly removed.
     for (const key of envToDelete ?? []) {
@@ -244,7 +235,7 @@ export class SshPtyProvider implements IPtyProvider {
   async attachForReconnect(
     id: string,
     expected?: { paneKey?: string; tabId?: string }
-  ): Promise<{ replay?: string }> {
+  ): Promise<{ replay?: string; shellPath?: string }> {
     // Why: reconnect owns replay delivery so stale/duplicate attach results can
     // be filtered before they reach the renderer. The expected identity lets the
     // relay reject a cross-generation id collision instead of reattaching this
@@ -254,7 +245,7 @@ export class SshPtyProvider implements IPtyProvider {
       suppressReplayNotification: true,
       ...(expected?.paneKey ? { expectedPaneKey: expected.paneKey } : {}),
       ...(expected?.tabId ? { expectedTabId: expected.tabId } : {})
-    })) as { replay?: string } | undefined
+    })) as { replay?: string; shellPath?: string } | undefined
     return result ?? {}
   }
 

--- a/src/main/providers/ssh-remote-cli-resolution.ts
+++ b/src/main/providers/ssh-remote-cli-resolution.ts
@@ -1,0 +1,87 @@
+import type { PtyOrchestrationCliCommand } from './pty-orchestration-cli-command'
+
+export type SshRemoteCliBridgeEnv = {
+  binDir: string
+  relayDir: string
+  nodePath: string
+  sockPath: string
+  orchestrationLauncherPath?: string
+  pathDelimiter?: ':' | ';'
+}
+
+export function prependSshRemoteCliBin(
+  pathValue: string,
+  binDir: string,
+  delimiter: ':' | ';'
+): string {
+  const normalize =
+    delimiter === ';' ? (value: string) => value.toLowerCase() : (value: string) => value
+  const normalizedBinDir = normalize(binDir)
+  const remaining = pathValue
+    .split(delimiter)
+    .filter((entry) => normalize(entry) !== normalizedBinDir)
+  return [binDir, ...remaining].join(delimiter)
+}
+
+export function mergeSshRemoteCliBridgeEnv(
+  env: Record<string, string> | undefined,
+  bridge: SshRemoteCliBridgeEnv | undefined
+): Record<string, string> {
+  const merged = { ...env }
+  if (!bridge) {
+    return merged
+  }
+  const pathDelimiter = bridge.pathDelimiter ?? ':'
+  const pathKey = merged.PATH !== undefined ? 'PATH' : merged.Path !== undefined ? 'Path' : null
+  if (pathKey) {
+    const pathValue = merged[pathKey] ?? ''
+    merged[pathKey] = pathValue
+      ? prependSshRemoteCliBin(pathValue, bridge.binDir, pathDelimiter)
+      : bridge.binDir
+  }
+  if (bridge.orchestrationLauncherPath) {
+    merged.ORCA_CLI_COMMAND = bridge.orchestrationLauncherPath
+  }
+  merged.ORCA_REMOTE_CLI_BIN_DIR = bridge.binDir
+  merged.ORCA_RELAY_DIR = bridge.relayDir
+  merged.ORCA_RELAY_NODE_PATH = bridge.nodePath
+  merged.ORCA_RELAY_SOCKET_PATH = bridge.sockPath
+  return merged
+}
+
+export function resolveSshOrchestrationCliCommand(args: {
+  launcherPath?: string
+  pathDelimiter: ':' | ';'
+  isWsl: boolean
+  shellPath: string | null
+}): PtyOrchestrationCliCommand | null {
+  if (!args.launcherPath) {
+    return null
+  }
+  const shellName = args.shellPath?.replaceAll('\\', '/').split('/').pop()?.toLowerCase()
+  const isPowerShell =
+    shellName === 'powershell.exe' ||
+    shellName === 'powershell' ||
+    shellName === 'pwsh.exe' ||
+    shellName === 'pwsh'
+  if (args.pathDelimiter === ':') {
+    return isPowerShell
+      ? { kind: 'powershell-path', executablePath: args.launcherPath }
+      : { kind: 'posix-path', executablePath: args.launcherPath }
+  }
+  if (args.isWsl || shellName === 'wsl.exe' || shellName === 'wsl') {
+    return { kind: 'posix-env', variableName: 'ORCA_CLI_COMMAND' }
+  }
+  if (isPowerShell) {
+    return { kind: 'powershell-env', variableName: 'ORCA_CLI_COMMAND' }
+  }
+  if (shellName === 'cmd.exe' || shellName === 'cmd') {
+    return { kind: 'cmd-env', variableName: 'ORCA_CLI_COMMAND' }
+  }
+  if (shellName?.includes('bash') || shellName?.includes('sh')) {
+    return { kind: 'posix-env', variableName: 'ORCA_CLI_COMMAND' }
+  }
+  // Why: unknown Windows shells have unknown invocation syntax. A bare-name
+  // fallback would recreate the host-CLI collision this bridge prevents.
+  return null
+}

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -26,12 +26,15 @@ import type { TerminalOscLinkRange } from '../../shared/terminal-osc-link-ranges
 import type { GitProviderStatusOptions } from './git-provider-status-options'
 import type { PtyBackgroundStreamEvent, PtyDataEvent } from './pty-provider-events'
 import type { PtySpawnResult } from './pty-spawn-result'
+import type { PtyOrchestrationCliCommandResolver } from './pty-orchestration-cli-command'
+import type { PtyProcessInfo } from './pty-process-info'
 
 export type {
   PtyBackgroundStreamEvent,
   PtyDataEvent,
   PtyTransientFact
 } from './pty-provider-events'
+export type { PtyProcessInfo } from './pty-process-info'
 
 // ─── PTY Provider ───────────────────────────────────────────────────
 
@@ -100,18 +103,9 @@ export type PtySpawnOptions = {
 
 export type { PtySpawnResult }
 
-export type PtyProcessInfo = {
-  id: string
-  cwd: string
-  title: string
-  /** Owning worktree when the provider can report it authoritatively. */
-  worktreeId?: string
-  /** Trusted ORCA_TERMINAL_HANDLE exported into this PTY, when known. */
-  terminalHandle?: string
-}
-
 export type IPtyProvider = {
   spawn(opts: PtySpawnOptions): Promise<PtySpawnResult>
+  getOrchestrationCliCommand?: PtyOrchestrationCliCommandResolver
   /** Whether this spawn target can append the Git guard after its final env merge. */
   supportsGitCredentialGuardHost?: (sessionId?: string) => boolean
   attach(id: string): Promise<void>

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -522,7 +522,10 @@ import {
 } from '../project-runtime-git-options'
 import { resolveLocalProjectRuntimeForWorktreeId } from '../local-project-runtime-resolution'
 import type { ProjectExecutionRuntimeResolution } from '../../shared/project-execution-runtime'
-import { resolveTerminalOrchestrationCliCommand } from './orchestration/cli-command'
+import {
+  resolveTerminalOrchestrationCliCommand,
+  type OrchestrationCliCommand
+} from './orchestration/cli-command'
 import {
   getLocalWorktreePathAccess,
   removeLocalWorktreePath,
@@ -1062,6 +1065,7 @@ type RuntimePtyWorktreeRecord = {
   // selection must follow the pane that executes it, not process.platform.
   isWsl: boolean | null
   wslDistro: string | null
+  shellPath: string | null
   // Why: background CLI PTYs can outlive a failed renderer reveal. Preserve the
   // spawn-time tab/pane identity so later reveals can adopt under the env key.
   tabId: string | null
@@ -6430,12 +6434,20 @@ export class OrcaRuntimeService {
     }
   }
 
+  recordPtyShellPath(ptyId: string, shellPath: string): void {
+    const pty = this.ptysById.get(ptyId)
+    if (pty) {
+      pty.shellPath = shellPath
+    }
+  }
+
   registerPty(
     ptyId: string,
     worktreeId: string,
     connectionId: string | null = null,
     binding?: { tabId: string; leafId: string },
-    isWsl?: boolean
+    isWsl?: boolean,
+    shellPath?: string
   ): void {
     // Why: record the renderer pane identity at spawn time so a stalled graph
     // sync can't hide that a live PTY already backs a pending mobile create.
@@ -6447,6 +6459,7 @@ export class OrcaRuntimeService {
       connected: true,
       connectionId,
       ...(isWsl !== undefined ? { isWsl } : {}),
+      ...(shellPath !== undefined ? { shellPath } : {}),
       ...(binding && paneKey ? { tabId: binding.tabId, paneKey } : {})
     })
     // Why: the renderer's own PTY spawn is the reliable signal that the pending
@@ -8797,7 +8810,7 @@ export class OrcaRuntimeService {
       : undefined
   }
 
-  getTerminalOrchestrationCliCommand(handle: string): 'orca' | 'orca-ide' {
+  getTerminalOrchestrationCliCommand(handle: string): OrchestrationCliCommand {
     let pty: RuntimePtyWorktreeRecord | null = null
     try {
       const ptyId = this.resolveLeafForHandle(handle)?.ptyId
@@ -8808,10 +8821,17 @@ export class OrcaRuntimeService {
     if (!pty) {
       return 'orca'
     }
+    const sshCliCommand = pty.connectionId
+      ? (this.getSshProviderFn?.(pty.connectionId)?.getOrchestrationCliCommand?.({
+          isWsl: pty.isWsl === true,
+          shellPath: pty.shellPath
+        }) ?? null)
+      : undefined
     return resolveTerminalOrchestrationCliCommand({
       connectionId: pty.connectionId,
       isWsl: pty.isWsl,
       worktreeId: pty.worktreeId,
+      sshCliCommand,
       projectRuntime: this.store
         ? resolveLocalProjectRuntimeForWorktreeId(this.requireStore(), pty.worktreeId)
         : undefined
@@ -22404,6 +22424,7 @@ export class OrcaRuntimeService {
         | 'connectionId'
         | 'isWsl'
         | 'wslDistro'
+        | 'shellPath'
       >
     > = {}
   ): RuntimePtyWorktreeRecord {
@@ -22426,6 +22447,7 @@ export class OrcaRuntimeService {
         connectionId,
         isWsl: state.isWsl ?? null,
         wslDistro,
+        shellPath: state.shellPath ?? null,
         tabId: state.tabId ?? null,
         paneKey: state.paneKey ?? null,
         launchConfig: null,
@@ -22487,6 +22509,9 @@ export class OrcaRuntimeService {
       } else {
         this.wslDistroByPtyId.delete(ptyId)
       }
+    }
+    if (state.shellPath !== undefined) {
+      pty.shellPath = state.shellPath
     }
     if (state.tabId !== undefined) {
       pty.tabId = state.tabId
@@ -22575,7 +22600,8 @@ export class OrcaRuntimeService {
       }
       if (worktreeId) {
         this.recordPtyWorktree(session.id, worktreeId, {
-          connected: true
+          connected: true,
+          ...(session.shellPath ? { shellPath: session.shellPath } : {})
         })
       }
       // Why: fire-and-forget so this listing hot path doesn't serialize a relay round-trip per session and a throw can't abort the sweep below.

--- a/src/main/runtime/orchestration/cli-command.test.ts
+++ b/src/main/runtime/orchestration/cli-command.test.ts
@@ -40,7 +40,7 @@ describe('resolveTerminalOrchestrationCliCommand', () => {
     ).toBe('orca-ide')
   })
 
-  it('preserves native and SSH bare-orca commands', () => {
+  it('preserves native bare-orca and isolates SSH orchestration from host collisions', () => {
     expect(
       resolveTerminalOrchestrationCliCommand({
         connectionId: null,
@@ -52,8 +52,26 @@ describe('resolveTerminalOrchestrationCliCommand', () => {
       resolveTerminalOrchestrationCliCommand({
         connectionId: 'ssh-1',
         isWsl: null,
-        worktreeId: 'repo::\\\\wsl.localhost\\Ubuntu\\home\\alice\\repo'
+        worktreeId: 'repo::\\\\wsl.localhost\\Ubuntu\\home\\alice\\repo',
+        sshCliCommand: {
+          kind: 'posix-path',
+          executablePath: '/home/alice/.orca-relay/bin/orca-relay'
+        }
       })
-    ).toBe('orca')
+    ).toEqual({
+      kind: 'posix-path',
+      executablePath: '/home/alice/.orca-relay/bin/orca-relay'
+    })
+  })
+
+  it('fails before dispatch when an SSH launcher was not proven', () => {
+    expect(() =>
+      resolveTerminalOrchestrationCliCommand({
+        connectionId: 'ssh-1',
+        isWsl: false,
+        worktreeId: 'repo::/home/alice/repo',
+        sshCliCommand: null
+      })
+    ).toThrow(/remote CLI launcher was not installed/)
   })
 })

--- a/src/main/runtime/orchestration/cli-command.ts
+++ b/src/main/runtime/orchestration/cli-command.ts
@@ -1,17 +1,24 @@
 import type { ProjectExecutionRuntimeResolution } from '../../../shared/project-execution-runtime'
 import { isWslUncPath } from '../../../shared/wsl-paths'
 import { splitWorktreeIdForFilesystem } from '../../../shared/worktree-id'
+import type { PtyOrchestrationCliCommand } from '../../providers/pty-orchestration-cli-command'
 
-export type OrchestrationCliCommand = 'orca' | 'orca-ide'
+export type OrchestrationCliCommand = 'orca' | 'orca-ide' | PtyOrchestrationCliCommand
 
 export function resolveTerminalOrchestrationCliCommand(args: {
   connectionId: string | null
   isWsl: boolean | null | undefined
   worktreeId: string
+  sshCliCommand?: PtyOrchestrationCliCommand | null
   projectRuntime?: ProjectExecutionRuntimeResolution
 }): OrchestrationCliCommand {
   if (args.connectionId) {
-    return 'orca'
+    if (!args.sshCliCommand) {
+      throw new Error(
+        'SSH orchestration is unavailable because the remote CLI launcher was not installed. Reconnect the SSH target and retry.'
+      )
+    }
+    return args.sshCliCommand
   }
   if (args.isWsl !== null && args.isWsl !== undefined) {
     return args.isWsl ? 'orca-ide' : 'orca'

--- a/src/main/runtime/orchestration/coordinator.test.ts
+++ b/src/main/runtime/orchestration/coordinator.test.ts
@@ -7,6 +7,7 @@ import {
   parseAllowStaleBaseFromSpec,
   type CoordinatorRuntime
 } from './coordinator'
+import type { OrchestrationCliCommand } from './cli-command'
 
 type DriftResult = {
   base: string
@@ -21,7 +22,7 @@ function createMockRuntime(): CoordinatorRuntime & {
   createdTerminalOptions: { title?: string }[]
   probeDriftCalls: string[]
   probeDriftResult: DriftResult
-  cliCommand: 'orca' | 'orca-ide'
+  cliCommand: OrchestrationCliCommand
   setProbeDrift(result: DriftResult): void
   throwProbeDrift: Error | null
 } {
@@ -37,7 +38,7 @@ function createMockRuntime(): CoordinatorRuntime & {
     createdTerminalOptions: [] as { title?: string }[],
     probeDriftCalls: [] as string[],
     probeDriftResult: null as DriftResult,
-    cliCommand: 'orca' as 'orca' | 'orca-ide',
+    cliCommand: 'orca' as OrchestrationCliCommand,
     throwProbeDrift: null as Error | null,
     setProbeDrift(result: DriftResult): void {
       mock.probeDriftResult = result
@@ -154,6 +155,33 @@ describe('Coordinator', () => {
     expect(result.completedTasks).toContain(task.id)
     expect(runtime.sentMessages.length).toBeGreaterThan(0)
     expect(runtime.sentMessages[0].text).toContain('orca-ide orchestration send')
+  })
+
+  it('leaves a ready task untouched when SSH orchestration capability is unavailable', async () => {
+    db = new OrchestrationDb(':memory:')
+    const runtime = createMockRuntime()
+    runtime.terminals = [{ handle: 'term_ssh', worktreeId: 'wt1', connected: true, writable: true }]
+    runtime.getTerminalOrchestrationCliCommand = () => {
+      throw new Error('SSH remote CLI launcher was not installed')
+    }
+    const task = db.createTask({ spec: 'implement feature' })
+    const coordinator = new Coordinator(db, runtime, {
+      spec: 'build it',
+      coordinatorHandle: 'coord'
+    })
+
+    const dispatchTask = (
+      coordinator as unknown as {
+        dispatchTask(taskRow: typeof task, targetHandle: string): Promise<void>
+      }
+    ).dispatchTask.bind(coordinator)
+    await expect(dispatchTask(task, 'term_ssh')).rejects.toThrow(
+      'remote CLI launcher was not installed'
+    )
+
+    expect(db.getTask(task.id)?.status).toBe('ready')
+    expect(db.getDispatchContext(task.id)).toBeUndefined()
+    expect(runtime.sentMessages).toEqual([])
   })
 
   it('records the assignee pane key when the runtime can resolve one', async () => {

--- a/src/main/runtime/orchestration/coordinator.ts
+++ b/src/main/runtime/orchestration/coordinator.ts
@@ -3,6 +3,7 @@ import type { OrchestrationDb } from './db'
 import type { MessageRow, TaskRow, CoordinatorStatus } from './types'
 import { buildDispatchPreamble } from './preamble'
 import { reconcileLifecycleMessage } from './lifecycle-reconciliation'
+import type { OrchestrationCliCommand } from './cli-command'
 
 export type CoordinatorRuntime = {
   sendTerminalAgentPrompt(handle: string, prompt: string): Promise<unknown>
@@ -28,8 +29,8 @@ export type CoordinatorRuntime = {
   } | null>
   // Why: optional so lightweight runtime fakes keep compiling; when present, dispatch records the assignee's remint-stable pane identity.
   getTerminalPaneKey?(handle: string): string | null
-  // Why: Windows can host native and WSL workers at once, so the worker pane (not the coordinator) picks the packaged CLI name.
-  getTerminalOrchestrationCliCommand?(handle: string): 'orca' | 'orca-ide'
+  // Why: native, WSL, and SSH workers require the command owned by their pane.
+  getTerminalOrchestrationCliCommand?(handle: string): OrchestrationCliCommand
 }
 
 // Why (§3.1): 20 lets normal monorepo day-velocity pass but trips the 168-commit harm from ORCHESTRATOR_FEEDBACK.md (chosen in msg_eff3a646110d).
@@ -414,6 +415,9 @@ export class Coordinator {
       }
     }
 
+    // Why: prove the remote lifecycle-command route before mutating task state;
+    // a failed SSH launcher install must leave the ready task retryable.
+    const cliCommand = this.runtime.getTerminalOrchestrationCliCommand?.(targetHandle)
     const dispatch = this.db.createDispatchContext(
       task.id,
       targetHandle,
@@ -429,10 +433,8 @@ export class Coordinator {
       coordinatorHandle: this.opts.coordinatorHandle,
       workerHandle: targetHandle,
       devMode: process.env.ORCA_USER_DATA_PATH?.includes('orca-dev'),
-      ...(this.runtime.getTerminalOrchestrationCliCommand
-        ? { cliCommand: this.runtime.getTerminalOrchestrationCliCommand(targetHandle) }
-        : {}),
-      // Why (§3.2): pass baseDrift unconditionally — the preamble builder itself gates the drift section on behind > 0.
+      ...(cliCommand ? { cliCommand } : {}),
+      // Why (§3.2): the preamble builder itself gates the drift section on behind > 0.
       ...(baseDrift ? { baseDrift } : {})
     })
 

--- a/src/main/runtime/orchestration/preamble.test.ts
+++ b/src/main/runtime/orchestration/preamble.test.ts
@@ -2,6 +2,11 @@ import { spawnSync } from 'node:child_process'
 import { describe, expect, it } from 'vitest'
 import { buildDispatchPreamble } from './preamble'
 
+const itWithPwsh =
+  spawnSync('pwsh', ['-NoProfile', '-Command', '$PSVersionTable.PSVersion']).status === 0
+    ? it
+    : it.skip
+
 function baseParams(overrides: Partial<Parameters<typeof buildDispatchPreamble>[0]> = {}) {
   return {
     taskId: 'task_abc123',
@@ -182,6 +187,79 @@ describe('buildDispatchPreamble', () => {
     expect(result).toContain('orca-ide orchestration check')
     expect(result).toContain('orca-ide orchestration ask')
     expect(result).not.toMatch(/(^|\s)orca orchestration/m)
+  })
+
+  it('uses the SSH relay command even when the desktop runtime is a dev build', () => {
+    const result = buildDispatchPreamble(
+      baseParams({
+        devMode: true,
+        cliCommand: {
+          kind: 'posix-path',
+          executablePath: "/home/me user/.orca-relay/bin/orca-relay's"
+        }
+      })
+    )
+
+    expect(result).toContain("'/home/me user/.orca-relay/bin/orca-relay'\\''s' orchestration send")
+    expect(result).toContain("'/home/me user/.orca-relay/bin/orca-relay'\\''s' orchestration check")
+    expect(result).toContain("'/home/me user/.orca-relay/bin/orca-relay'\\''s' orchestration ask")
+    expect(result).not.toContain('orca-dev orchestration')
+    expect(result).not.toMatch(/(^|\s)orca orchestration/m)
+  })
+
+  it.each([
+    [
+      'WSL or Git Bash',
+      { kind: 'posix-env' as const, variableName: 'ORCA_CLI_COMMAND' as const },
+      '"$ORCA_CLI_COMMAND" orchestration send',
+      '\\'
+    ],
+    [
+      'PowerShell on POSIX',
+      { kind: 'powershell-path' as const, executablePath: "/home/me user's/orca-relay" },
+      "& '/home/me user''s/orca-relay' orchestration send",
+      '`'
+    ],
+    [
+      'PowerShell',
+      { kind: 'powershell-env' as const, variableName: 'ORCA_CLI_COMMAND' as const },
+      '& $env:ORCA_CLI_COMMAND orchestration send',
+      '`'
+    ],
+    [
+      'cmd',
+      { kind: 'cmd-env' as const, variableName: 'ORCA_CLI_COMMAND' as const },
+      '"%ORCA_CLI_COMMAND%" orchestration send',
+      '^'
+    ]
+  ])('renders the exact %s launcher syntax', (_name, cliCommand, expected, continuation) => {
+    const result = buildDispatchPreamble(baseParams({ cliCommand }))
+
+    expect(result).toContain(expected)
+    expect(result).toContain(`${expected} --to term_coord --from term_worker ${continuation}\n`)
+    expect(result).not.toMatch(/(^|\s)orca orchestration/m)
+    expect(result).not.toContain('orca-relay orchestration')
+  })
+
+  itWithPwsh('executes the rendered absolute launcher command in POSIX-hosted PowerShell', () => {
+    const result = buildDispatchPreamble(
+      baseParams({ cliCommand: { kind: 'powershell-path', executablePath: '/bin/echo' } })
+    )
+    const checkCommand = result
+      .split('\n')
+      .find((line) => line.trim() === "& '/bin/echo' orchestration check --terminal term_worker")
+    expect(checkCommand).toBeTruthy()
+
+    const executed = spawnSync(
+      'pwsh',
+      ['-NoProfile', '-NonInteractive', '-Command', checkCommand!],
+      {
+        encoding: 'utf8'
+      }
+    )
+
+    expect(executed.status, executed.stderr).toBe(0)
+    expect(executed.stdout.trim()).toBe('orchestration check --terminal term_worker')
   })
 
   it('appends a BASE DRIFT section when baseDrift.behind > 0', () => {

--- a/src/main/runtime/orchestration/preamble.ts
+++ b/src/main/runtime/orchestration/preamble.ts
@@ -1,5 +1,44 @@
 import type { OrchestrationCliCommand } from './cli-command'
 
+function quotePosix(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`
+}
+
+function quotePowerShell(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`
+}
+
+function renderCliCommand(command: OrchestrationCliCommand): string {
+  if (typeof command === 'string') {
+    return command
+  }
+  switch (command.kind) {
+    case 'posix-path':
+      return quotePosix(command.executablePath)
+    case 'powershell-path':
+      return `& ${quotePowerShell(command.executablePath)}`
+    case 'posix-env':
+      return `"$${command.variableName}"`
+    case 'powershell-env':
+      return `& $env:${command.variableName}`
+    case 'cmd-env':
+      return `"%${command.variableName}%"`
+  }
+}
+
+function renderLineContinuation(command: OrchestrationCliCommand | undefined): string {
+  if (
+    typeof command === 'object' &&
+    (command.kind === 'powershell-env' || command.kind === 'powershell-path')
+  ) {
+    return '`'
+  }
+  if (typeof command === 'object' && command.kind === 'cmd-env') {
+    return '^'
+  }
+  return '\\'
+}
+
 export type PreambleParams = {
   taskId: string
   // Why: completion and heartbeat payloads attribute activity to a specific
@@ -12,8 +51,8 @@ export type PreambleParams = {
   coordinatorHandle: string
   workerHandle: string
   devMode?: boolean
-  // Why: packaged WSL panes install the scoped launcher as `orca-ide`;
-  // other execution hosts keep their existing bare `orca` bridge.
+  // Why: WSL and SSH panes use host-scoped launchers that cannot be inferred
+  // safely from the desktop process platform.
   cliCommand?: OrchestrationCliCommand
   // Why: populated by the coordinator's dispatch pre-flight (§3.1) only
   // when the target worktree is behind its tracking remote. When absent
@@ -47,7 +86,15 @@ export function buildDispatchPreamble(params: PreambleParams): string {
   // Why: in dev mode, agents must use orca-dev to connect to the dev runtime's
   // socket. Without this, agents inside the dev Electron app would call the
   // production CLI and talk to the wrong Orca instance (Section 6.4).
-  const cli = params.devMode ? 'orca-dev' : (params.cliCommand ?? 'orca')
+  // Why: SSH lifecycle traffic must cross the relay even when the desktop is
+  // a dev build; `orca-dev` exists on the desktop, not the remote host.
+  const cli =
+    params.cliCommand && typeof params.cliCommand !== 'string'
+      ? renderCliCommand(params.cliCommand)
+      : params.devMode
+        ? 'orca-dev'
+        : renderCliCommand(params.cliCommand ?? 'orca')
+  const continuation = renderLineContinuation(params.cliCommand)
   const postDoneInstructions = buildPostWorkerDoneInstructions({
     cli,
     workerKind: params.workerKind ?? 'prompt-returning-agent'
@@ -74,11 +121,11 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
   # with subject like "Failed: <reason>" — never silently exit.
   # Include BOTH taskId and dispatchId in the payload so a late completion
   # from a failed retry cannot complete the current dispatch.
-  ${cli} orchestration send --to ${params.coordinatorHandle} --from ${params.workerHandle} \\
-    --type worker_done --subject "<short status>" \\
-    --body "<3-sentence summary: what you did, what you found, what's left>" \\
-    --task-id ${params.taskId} --dispatch-id ${params.dispatchId} \\
-    --files-modified "path/a,path/b" \\
+  ${cli} orchestration send --to ${params.coordinatorHandle} --from ${params.workerHandle} ${continuation}
+    --type worker_done --subject "<short status>" ${continuation}
+    --body "<3-sentence summary: what you did, what you found, what's left>" ${continuation}
+    --task-id ${params.taskId} --dispatch-id ${params.dispatchId} ${continuation}
+    --files-modified "path/a,path/b" ${continuation}
     --report-path "<optional: path to the full artifact>"
 
   # BEHAVIOR RULE: send a heartbeat every ${HEARTBEAT_INTERVAL_MIN} minutes
@@ -91,9 +138,9 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
   # attributes the heartbeat to the specific dispatch context, not just
   # the task, so a straggler heartbeat from a previously-failed dispatch
   # cannot mask a hung retry.
-  ${cli} orchestration send --to ${params.coordinatorHandle} --from ${params.workerHandle} \\
-    --type heartbeat --subject "alive" \\
-    --task-id ${params.taskId} --dispatch-id ${params.dispatchId} \\
+  ${cli} orchestration send --to ${params.coordinatorHandle} --from ${params.workerHandle} ${continuation}
+    --type heartbeat --subject "alive" ${continuation}
+    --task-id ${params.taskId} --dispatch-id ${params.dispatchId} ${continuation}
     --phase "<short: investigating|implementing|reviewing|waiting>"
 
   # Ask the coordinator a question and block until it answers.
@@ -108,16 +155,16 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
   # blocks on \`check --wait\` until the coordinator replies, then prints the
   # reply body. Use it anywhere you would otherwise have reached for
   # AskUserQuestion.
-  ${cli} orchestration ask --to ${params.coordinatorHandle} --from ${params.workerHandle} \\
-    --question "<your question>" \\
-    --options "<optional,comma,separated>" \\
+  ${cli} orchestration ask --to ${params.coordinatorHandle} --from ${params.workerHandle} ${continuation}
+    --question "<your question>" ${continuation}
+    --options "<optional,comma,separated>" ${continuation}
     --timeout-ms 600000
 
   # Escalate a blocker or failure (pre-completion, when you need the
   # coordinator to do something before you can continue):
-  ${cli} orchestration send --to ${params.coordinatorHandle} --from ${params.workerHandle} \\
-    --type escalation --subject "Blocked: <reason>" \\
-    --body "<details>" \\
+  ${cli} orchestration send --to ${params.coordinatorHandle} --from ${params.workerHandle} ${continuation}
+    --type escalation --subject "Blocked: <reason>" ${continuation}
+    --body "<details>" ${continuation}
     --task-id ${params.taskId}
 
   # Check for messages from the coordinator:

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -1346,6 +1346,21 @@ describe('orchestration RPC methods', () => {
       expect(db.getActiveDispatchForTerminal('term_a')).toBeUndefined()
     })
 
+    it('does not create a dispatch when SSH orchestration capability is unavailable', async () => {
+      setup()
+      const task = db.createTask({ spec: 'work' })
+      vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockImplementation(() => {
+        throw new Error('SSH remote CLI launcher was not installed')
+      })
+
+      await expect(
+        call('orchestration.dispatch', { task: task.id, to: 'term_ssh' })
+      ).rejects.toThrow('remote CLI launcher was not installed')
+
+      expect(db.getTask(task.id)?.status).toBe('ready')
+      expect(db.getDispatchContext(task.id)).toBeUndefined()
+    })
+
     it('uses caller-provided dev mode for injected preamble', async () => {
       setup()
       const task = db.createTask({ spec: 'work' })

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -484,6 +484,9 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         }
       }
 
+      // Why: prove the remote lifecycle-command route before mutating task
+      // state, so launcher-install failures leave the task ready to retry.
+      const cliCommand = runtime.getTerminalOrchestrationCliCommand(to)
       const ctx = db.createDispatchContext(
         params.task,
         to,
@@ -498,7 +501,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         coordinatorHandle: params.from ?? 'coordinator',
         workerHandle: to,
         devMode: params.devMode,
-        cliCommand: runtime.getTerminalOrchestrationCliCommand(to)
+        cliCommand
       })
 
       let injected = false

--- a/src/main/ssh/ssh-orchestration-cli-command.ts
+++ b/src/main/ssh/ssh-orchestration-cli-command.ts
@@ -1,0 +1,2 @@
+// Why: a distinct name cannot resolve to a host tool named `orca` after user profiles reorder PATH.
+export const SSH_ORCHESTRATION_CLI_COMMAND = 'orca-relay' as const

--- a/src/main/ssh/ssh-relay-session-cli-launcher.test.ts
+++ b/src/main/ssh/ssh-relay-session-cli-launcher.test.ts
@@ -1,0 +1,261 @@
+import { Buffer } from 'node:buffer'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SshConnection } from './ssh-connection'
+import { createMockDeps } from './ssh-relay-session-test-fixtures'
+import { getRemoteHostPlatform } from './ssh-remote-platform'
+
+const { muxRequestMock, registerSshPtyProviderMock, deployAndLaunchRelayMock } = vi.hoisted(() => ({
+  muxRequestMock: vi.fn(),
+  registerSshPtyProviderMock: vi.fn(),
+  deployAndLaunchRelayMock: vi.fn()
+}))
+
+vi.mock('./ssh-relay-deploy', () => ({ deployAndLaunchRelay: deployAndLaunchRelayMock }))
+vi.mock('./ssh-channel-multiplexer', () => ({
+  SshChannelMultiplexer: class MockSshChannelMultiplexer {
+    request = muxRequestMock
+    notify = vi.fn()
+    onNotification = vi.fn().mockReturnValue(() => {})
+    onRequest = vi.fn().mockReturnValue(() => {})
+    onDispose = vi.fn().mockReturnValue(() => {})
+    dispose = vi.fn()
+    isDisposed = vi.fn().mockReturnValue(false)
+  }
+}))
+vi.mock('../providers/ssh-pty-provider', () => ({
+  isSshPtyNotFoundError: () => false,
+  isSshPtyIdentityMismatchError: () => false,
+  SshPtyProvider: class MockSshPtyProvider {
+    constructor(
+      readonly connectionId: string,
+      readonly mux: unknown,
+      readonly remoteCliBridgeEnv?: Record<string, unknown>
+    ) {}
+    onData = vi.fn().mockReturnValue(() => {})
+    onReplay = vi.fn().mockReturnValue(() => {})
+    onExit = vi.fn().mockReturnValue(() => {})
+    dispose = vi.fn()
+  }
+}))
+vi.mock('../providers/ssh-filesystem-provider', () => ({
+  SshFilesystemProvider: class MockSshFilesystemProvider {
+    dispose = vi.fn()
+  }
+}))
+vi.mock('../providers/ssh-git-provider', () => ({ SshGitProvider: class MockSshGitProvider {} }))
+vi.mock('../ipc/pty', () => ({
+  registerSshPtyProvider: registerSshPtyProviderMock,
+  unregisterSshPtyProvider: vi.fn(),
+  getSshPtyProvider: vi.fn(),
+  getPtyIdsForConnection: vi.fn().mockReturnValue([]),
+  clearPtyOwnershipForConnection: vi.fn(),
+  clearProviderPtyState: vi.fn(),
+  deletePtyOwnership: vi.fn(),
+  setPtyOwnership: vi.fn(),
+  answerStartupTerminalColorQueriesForPty: vi.fn((_id: string, data: string) => data)
+}))
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  registerSshFilesystemProvider: vi.fn(),
+  unregisterSshFilesystemProvider: vi.fn(),
+  getSshFilesystemProvider: vi.fn()
+}))
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  registerSshGitProvider: vi.fn(),
+  unregisterSshGitProvider: vi.fn()
+}))
+vi.mock('../agent-hooks/remote-managed-hook-installers', () => ({
+  installRemoteManagedAgentHooks: vi.fn()
+}))
+
+const { SshRelaySession } = await import('./ssh-relay-session')
+
+describe('SSH relay CLI launcher registration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.ORCA_FEATURE_REMOTE_AGENT_HOOKS = '0'
+    deployAndLaunchRelayMock.mockResolvedValue({
+      transport: { write: vi.fn(), onData: vi.fn(), onClose: vi.fn() },
+      platform: 'linux-x64',
+      hostPlatform: getRemoteHostPlatform('linux-x64'),
+      remoteHome: '/home/orca',
+      remoteRelayDir: '/home/orca/.orca-remote/relay-v1',
+      nodePath: '/usr/bin/node',
+      sockPath: '/home/orca/.orca-remote/relay-v1/relay.sock'
+    })
+  })
+
+  it('installs and proves the launcher through the existing relay mux', async () => {
+    muxRequestMock.mockImplementation(async (method: string) =>
+      method === 'agent.execNonInteractive'
+        ? {
+            exitCode: 0,
+            timedOut: false,
+            stdout: '{"app":{"running":true},"runtime":{"reachable":true}}'
+          }
+        : { resolvedPath: '/home/orca' }
+    )
+    const rawWriteFile = vi.fn()
+    const rawSftp = vi.fn()
+    const { mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const connection = { writeFile: rawWriteFile, sftp: rawSftp } as unknown as SshConnection
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+
+    await session.establish(connection)
+
+    expect(muxRequestMock).toHaveBeenCalledWith('fs.createDir', {
+      dirPath: '/home/orca/.orca-relay/bin'
+    })
+    expect(muxRequestMock.mock.calls.filter(([method]) => method === 'fs.writeFile')).toHaveLength(
+      2
+    )
+    const steps = muxRequestMock.mock.calls.filter(
+      ([method, params]) =>
+        method === 'agent.execNonInteractive' && params.operation === 'ssh-cli-launcher-install'
+    )
+    expect(steps.map(([, params]) => params.binary)).toEqual(['chmod', 'mv', 'mv'])
+    expect(muxRequestMock).toHaveBeenCalledWith('agent.execNonInteractive', {
+      binary: '/home/orca/.orca-relay/bin/orca-relay',
+      args: ['status', '--json'],
+      env: {
+        ORCA_RELAY_NODE_PATH: '/usr/bin/node',
+        ORCA_RELAY_DIR: '/home/orca/.orca-remote/relay-v1',
+        ORCA_RELAY_SOCKET_PATH: '/home/orca/.orca-remote/relay-v1/relay.sock'
+      },
+      operation: 'ssh-cli-launcher-probe',
+      timeoutMs: 30_000
+    })
+    expect(rawWriteFile).not.toHaveBeenCalled()
+    expect(rawSftp).not.toHaveBeenCalled()
+    const provider = registerSshPtyProviderMock.mock.calls[0]?.[1] as {
+      remoteCliBridgeEnv?: Record<string, unknown>
+    }
+    expect(provider.remoteCliBridgeEnv?.orchestrationLauncherPath).toBe(
+      '/home/orca/.orca-relay/bin/orca-relay'
+    )
+  })
+
+  it('keeps terminal access but withholds capability when launcher install fails', async () => {
+    muxRequestMock.mockImplementation(async (method: string) =>
+      method === 'agent.execNonInteractive'
+        ? { exitCode: 126, timedOut: false, stderr: 'chmod denied' }
+        : { resolvedPath: '/home/orca' }
+    )
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+
+    await session.establish(mockConn)
+
+    expect(session.getState()).toBe('ready')
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('chmod denied'))
+    const provider = registerSshPtyProviderMock.mock.calls[0]?.[1] as {
+      remoteCliBridgeEnv?: Record<string, unknown>
+    }
+    expect(provider.remoteCliBridgeEnv?.orchestrationLauncherPath).toBeUndefined()
+    warn.mockRestore()
+  })
+
+  it('reuses an existing launcher when a reconnect-time reinstall fails', async () => {
+    muxRequestMock.mockImplementation(async (method: string, params: Record<string, unknown>) => {
+      if (method !== 'agent.execNonInteractive') {
+        return { resolvedPath: '/home/orca' }
+      }
+      return params.operation === 'ssh-cli-launcher-probe'
+        ? {
+            exitCode: 0,
+            timedOut: false,
+            stdout: '{"ok":true,"result":{"app":{"running":true},"runtime":{"reachable":true}}}'
+          }
+        : { exitCode: 1, timedOut: false, stderr: 'transient install failure' }
+    })
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+
+    await session.establish(mockConn)
+
+    const provider = registerSshPtyProviderMock.mock.calls[0]?.[1] as {
+      remoteCliBridgeEnv?: Record<string, unknown>
+    }
+    expect(provider.remoteCliBridgeEnv?.orchestrationLauncherPath).toBe(
+      '/home/orca/.orca-relay/bin/orca-relay'
+    )
+    expect(muxRequestMock.mock.calls.filter(([method]) => method === 'fs.deletePath')).toHaveLength(
+      2
+    )
+  })
+
+  it('withholds capability when an executable does not reach the Orca runtime', async () => {
+    muxRequestMock.mockImplementation(async (method: string, params: Record<string, unknown>) => {
+      if (method !== 'agent.execNonInteractive') {
+        return { resolvedPath: '/home/orca' }
+      }
+      return params.operation === 'ssh-cli-launcher-probe'
+        ? { exitCode: 0, timedOut: false, stdout: '' }
+        : { exitCode: 0, timedOut: false }
+    })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+
+    await session.establish(mockConn)
+
+    const provider = registerSshPtyProviderMock.mock.calls[0]?.[1] as {
+      remoteCliBridgeEnv?: Record<string, unknown>
+    }
+    expect(provider.remoteCliBridgeEnv?.orchestrationLauncherPath).toBeUndefined()
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('invalid Orca status response'))
+    warn.mockRestore()
+  })
+
+  it('compiles the Windows launcher through the relay without a cmd.exe shim', async () => {
+    deployAndLaunchRelayMock.mockResolvedValueOnce({
+      transport: { write: vi.fn(), onData: vi.fn(), onClose: vi.fn() },
+      platform: 'win32-x64',
+      hostPlatform: getRemoteHostPlatform('win32-x64'),
+      remoteHome: 'C:/Users/me',
+      remoteRelayDir: 'C:/Users/me/.orca-remote/relay-v1',
+      nodePath: 'C:/Program Files/nodejs/node.exe',
+      sockPath: '\\\\.\\pipe\\orca-relay-123'
+    })
+    muxRequestMock.mockImplementation(async (method: string) =>
+      method === 'agent.execNonInteractive'
+        ? {
+            exitCode: 0,
+            timedOut: false,
+            stdout: '{"app":{"running":true},"runtime":{"reachable":true}}'
+          }
+        : { resolvedPath: 'C:/Users/me' }
+    )
+    const { mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const rawWriteFile = vi.fn()
+    const connection = { writeFile: rawWriteFile } as unknown as SshConnection
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+
+    await session.establish(connection)
+
+    expect(rawWriteFile).not.toHaveBeenCalled()
+    const writes = muxRequestMock.mock.calls.filter(([method]) => method === 'fs.writeFile')
+    expect(writes).toHaveLength(1)
+    expect(writes[0]?.[1]?.filePath).toMatch(
+      /^C:\/Users\/me\/\.orca-relay\/bin\/orca-launcher-[a-f0-9]+\.cs$/
+    )
+    const launcherSource = writes[0]?.[1]?.content as string
+    expect(launcherSource).toContain('ORCA_RELAY_SOCKET_PATH')
+    expect(launcherSource).not.toContain('cmd.exe')
+    expect(launcherSource).not.toContain('%*')
+    const install = muxRequestMock.mock.calls.find(
+      ([method, params]) =>
+        method === 'agent.execNonInteractive' && params.operation === 'ssh-cli-launcher-install'
+    )
+    expect(install?.[1]).toMatchObject({
+      binary: 'powershell.exe',
+      operation: 'ssh-cli-launcher-install'
+    })
+    const args = install?.[1]?.args as string[]
+    const encoded = args[args.indexOf('-EncodedCommand') + 1]
+    const script = Buffer.from(encoded!, 'base64').toString('utf16le')
+    expect(script).toContain('csc.exe')
+    expect(script).toContain("-Destination 'C:/Users/me/.orca-relay/bin/orca-relay.exe'")
+    expect(script).not.toContain('cmd.exe')
+  })
+})

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -14,10 +14,6 @@ vi.mock('./ssh-relay-deploy', () => ({
   deployAndLaunchRelay: vi.fn()
 }))
 
-vi.mock('./ssh-relay-deploy-helpers', () => ({
-  execCommand: vi.fn().mockResolvedValue('')
-}))
-
 vi.mock('./ssh-channel-multiplexer', () => {
   return {
     SshChannelMultiplexer: class MockSshChannelMultiplexer {
@@ -38,6 +34,11 @@ vi.mock('../providers/ssh-pty-provider', () => ({
   isSshPtyIdentityMismatchError: (err: unknown) =>
     (err instanceof Error ? err.message : String(err)).includes('identity mismatch'),
   SshPtyProvider: class MockSshPtyProvider {
+    constructor(
+      readonly connectionId: string,
+      readonly mux: unknown,
+      readonly remoteCliBridgeEnv?: Record<string, unknown>
+    ) {}
     onData = vi.fn().mockReturnValue(() => {})
     onReplay = vi.fn().mockReturnValue(() => {})
     onExit = vi.fn().mockReturnValue(() => {})
@@ -90,7 +91,6 @@ const { markHiddenRendererPty, setRendererPtyDeliveryInterest } =
   await import('../ipc/pty-hidden-delivery-gate')
 const { _resetHiddenRendererPtyDeliveryGateForTest } =
   await import('../ipc/pty-hidden-delivery-gate')
-const { execCommand } = await import('./ssh-relay-deploy-helpers')
 const { getRemoteHostPlatform } = await import('./ssh-remote-platform')
 const {
   registerSshPtyProvider,
@@ -409,48 +409,6 @@ describe('SshRelaySession', () => {
     expect(unregisterSshFilesystemProvider).toHaveBeenCalledWith('target-1')
     expect(unregisterSshGitProvider).toHaveBeenCalledWith('target-1')
     expect(registerSshPtyProvider).toHaveBeenCalledWith('target-1', expect.anything())
-  })
-
-  it('compiles a native Windows Orca CLI bridge without a cmd.exe shim', async () => {
-    const { mockStore, mockPortForward, getMainWindow } = createMockDeps()
-    const mockConn = {
-      writeFile: vi.fn().mockResolvedValue(undefined)
-    } as unknown as SshConnection
-    vi.mocked(deployAndLaunchRelay).mockResolvedValueOnce({
-      transport: {
-        write: vi.fn(),
-        onData: vi.fn(),
-        onClose: vi.fn()
-      },
-      platform: 'win32-x64',
-      hostPlatform: getRemoteHostPlatform('win32-x64'),
-      remoteHome: 'C:/Users/me',
-      remoteRelayDir: 'C:/Users/me/.orca-remote/relay-v1',
-      nodePath: 'C:/Program Files/nodejs/node.exe',
-      sockPath: '\\\\.\\pipe\\orca-relay-123'
-    })
-
-    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
-
-    await session.establish(mockConn)
-
-    expect(execCommand).toHaveBeenCalledTimes(2)
-    expect(vi.mocked(execCommand).mock.calls[0]?.[1]).toContain('powershell.exe')
-    expect(vi.mocked(execCommand).mock.calls[0]?.[2]).toEqual({ wrapCommand: false })
-    expect(mockConn.writeFile).toHaveBeenCalledWith(
-      'C:/Users/me/.orca-relay/bin/orca-launcher.cs',
-      expect.stringContaining('ProcessStartInfo'),
-      { hostPlatform: getRemoteHostPlatform('win32-x64') }
-    )
-    const launcherSource = vi.mocked(mockConn.writeFile).mock.calls[0]?.[1] as string
-    expect(launcherSource).toContain('ORCA_RELAY_SOCKET_PATH')
-    expect(launcherSource).not.toContain('cmd.exe')
-    expect(launcherSource).not.toContain('%*')
-    expect(vi.mocked(execCommand).mock.calls[1]?.[1]).toContain('powershell.exe')
-    expect(vi.mocked(execCommand).mock.calls[1]?.[2]).toEqual({ wrapCommand: false })
-    expect(vi.mocked(execCommand).mock.calls.some(([, command]) => command.includes('chmod'))).toBe(
-      false
-    )
   })
 
   it('reconnect re-attaches live PTYs', async () => {

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -3,7 +3,6 @@
 
 import type { BrowserWindow } from 'electron'
 import { deployAndLaunchRelay } from './ssh-relay-deploy'
-import { execCommand } from './ssh-relay-deploy-helpers'
 import { isRelayVersionMismatchError } from './ssh-relay-version-mismatch-error'
 import type { RelayVersionMismatchError } from './ssh-relay-version-mismatch-error'
 import { SshChannelMultiplexer } from './ssh-channel-multiplexer'
@@ -52,8 +51,7 @@ import { PortScanner } from './ssh-port-scanner'
 import { isMainWindowVisible, onMainWindowBecameVisible } from '../window/main-window-visibility'
 import type { SshPortForwardManager } from './ssh-port-forward'
 import type { SshConnection } from './ssh-connection'
-import { joinRemotePath, isWindowsRemoteHost, type RemoteHostPlatform } from './ssh-remote-platform'
-import { makeRemoteDirectoryCommand } from './ssh-remote-commands'
+import { isWindowsRemoteHost, joinRemotePath, type RemoteHostPlatform } from './ssh-remote-platform'
 import { createRemoteCliInstallPlan } from './ssh-remote-cli-launcher'
 import {
   DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS,
@@ -78,6 +76,7 @@ type RemoteCliBridgeEnv = {
   nodePath: string
   sockPath: string
   hostPlatform: RemoteHostPlatform
+  orchestrationLauncherPath?: string
   pathDelimiter?: ':' | ';'
 }
 
@@ -512,10 +511,16 @@ export class SshRelaySession {
       return false
     }
 
+    // Why: the install probe enters through the remote launcher and comes back
+    // over `orca.cli`, so register that bidirectional route before probing.
+    this.wireUpRemoteOrcaCli(mux)
     try {
-      await this.installRemoteOrcaCliLauncher()
+      const orchestrationLauncherPath = await this.installRemoteOrcaCliLauncher(mux)
+      if (this.remoteCliBridgeEnv) {
+        this.remoteCliBridgeEnv.orchestrationLauncherPath = orchestrationLauncherPath
+      }
     } catch (error) {
-      // Why: on MaxSessions=1 remotes the relay holds the only slot, so this raw-connection install can fail — don't fail the whole connection.
+      // Why: keep terminal access, but withhold orchestration until the launcher is proven.
       console.warn(
         `[ssh-relay-session] remote orca CLI launcher install failed for ${this.targetId}: ${
           error instanceof Error ? error.message : String(error)
@@ -525,8 +530,6 @@ export class SshRelaySession {
     if (shouldContinue && !shouldContinue()) {
       return false
     }
-
-    this.wireUpRemoteOrcaCli(mux)
 
     const ptyProvider = new SshPtyProvider(this.targetId, mux, this.remoteCliBridgeEnv ?? undefined)
     registerSshPtyProvider(this.targetId, ptyProvider)
@@ -628,39 +631,96 @@ export class SshRelaySession {
     }
   }
 
-  private async installRemoteOrcaCliLauncher(): Promise<void> {
+  private async installRemoteOrcaCliLauncher(mux: SshChannelMultiplexer): Promise<string> {
     if (!this.remoteCliBridgeEnv) {
-      return
+      throw new Error('Remote CLI bridge environment is unavailable')
     }
-    const { binDir, hostPlatform } = this.remoteCliBridgeEnv
+    const { binDir } = this.remoteCliBridgeEnv
     const plan = createRemoteCliInstallPlan(this.remoteCliBridgeEnv)
-    const conn = this.requireReadyConnection()
-    await execCommand(conn, makeRemoteDirectoryCommand(hostPlatform, binDir), {
-      wrapCommand: !isWindowsRemoteHost(hostPlatform)
-    })
-    if (typeof conn.writeFile === 'function') {
+    let installError: unknown = null
+    try {
+      await mux.request('fs.createDir', { dirPath: binDir })
       for (const file of plan.files) {
-        await conn.writeFile(file.path, file.contents, { hostPlatform })
+        await mux.request('fs.writeFile', { filePath: file.path, content: file.contents })
       }
-    } else {
-      const sftp = await conn.sftp()
-      try {
-        for (const file of plan.files) {
-          await new Promise<void>((resolve, reject) => {
-            const ws = sftp.createWriteStream(file.path)
-            sftp.once('error', reject)
-            ws.once('close', resolve)
-            ws.once('error', reject)
-            ws.end(file.contents)
-          })
+      for (const step of plan.postWriteSteps) {
+        const result = (await mux.request('agent.execNonInteractive', {
+          binary: step.binary,
+          args: step.args,
+          ...(step.cwd ? { cwd: step.cwd } : {}),
+          operation: 'ssh-cli-launcher-install',
+          timeoutMs: 30_000
+        })) as {
+          exitCode: number | null
+          timedOut: boolean
+          spawnError?: string
+          stderr?: string
         }
-      } finally {
-        sftp.end()
+        if (result.spawnError || result.timedOut || result.exitCode !== 0) {
+          throw new Error(
+            result.spawnError || result.stderr || `launcher install exited ${result.exitCode}`
+          )
+        }
       }
+    } catch (error) {
+      // Why: compiler/chmod failures can recur on every reconnect; random
+      // staging names must not accumulate indefinitely on the remote host.
+      await Promise.allSettled(
+        plan.cleanupPaths.map((targetPath) =>
+          mux.request('fs.deletePath', { targetPath, recursive: false })
+        )
+      )
+      installError = error
     }
-    for (const command of plan.postWriteCommands) {
-      await execCommand(conn, command, { wrapCommand: !isWindowsRemoteHost(hostPlatform) })
+
+    const probe = (await mux.request('agent.execNonInteractive', {
+      binary: plan.orchestrationLauncherPath,
+      args: ['status', '--json'],
+      env: {
+        ORCA_RELAY_NODE_PATH: this.remoteCliBridgeEnv.nodePath,
+        ORCA_RELAY_DIR: this.remoteCliBridgeEnv.relayDir,
+        ORCA_RELAY_SOCKET_PATH: this.remoteCliBridgeEnv.sockPath
+      },
+      operation: 'ssh-cli-launcher-probe',
+      timeoutMs: 30_000
+    })) as {
+      exitCode: number | null
+      timedOut: boolean
+      spawnError?: string
+      stderr?: string
+      stdout?: string
     }
+    let parsedProbe: unknown
+    try {
+      parsedProbe = JSON.parse(probe.stdout ?? '')
+    } catch {
+      parsedProbe = null
+    }
+    const probeRecord = parsedProbe as {
+      app?: { running?: unknown }
+      runtime?: { reachable?: unknown }
+      result?: unknown
+    } | null
+    const status = (probeRecord?.result ?? probeRecord) as {
+      app?: { running?: unknown }
+      runtime?: { reachable?: unknown }
+    } | null
+    const hasExpectedStatus = status?.app?.running === true && status.runtime?.reachable === true
+    if (probe.spawnError || probe.timedOut || probe.exitCode !== 0 || !hasExpectedStatus) {
+      const probeMessage =
+        probe.spawnError ||
+        probe.stderr ||
+        (probe.exitCode !== 0
+          ? `launcher probe exited ${probe.exitCode}`
+          : 'launcher probe returned an invalid Orca status response')
+      if (installError) {
+        const installMessage =
+          installError instanceof Error ? installError.message : String(installError)
+        throw new Error(`${installMessage}; existing launcher probe failed: ${probeMessage}`)
+      }
+      throw new Error(probeMessage)
+    }
+    return plan.orchestrationLauncherPath
   }
 
   private wireUpRemoteOrcaCli(mux: SshChannelMultiplexer): void {
@@ -1039,6 +1099,9 @@ export class SshRelaySession {
         }
         const appPtyId = toAppSshPtyId(this.targetId, ptyId)
         setPtyOwnership(appPtyId, this.targetId)
+        if (attachResult.shellPath) {
+          this.runtime?.recordPtyShellPath(appPtyId, attachResult.shellPath)
+        }
         this.store.markSshRemotePtyLease(this.targetId, ptyId, 'attached')
         this.forwardReattachReplay(appPtyId, attachResult.replay ?? '')
       } catch (err) {

--- a/src/main/ssh/ssh-remote-cli-launcher.test.ts
+++ b/src/main/ssh/ssh-remote-cli-launcher.test.ts
@@ -14,10 +14,11 @@ function itWindows(name: string, test: () => void): void {
   runner(name, { timeout: 15_000 }, test)
 }
 
-function decodePowerShellCommand(command: string): string {
-  const encoded = command.match(/-EncodedCommand\s+([A-Za-z0-9+/=]+)/)?.[1]
+function decodePowerShellStep(step: { binary: string; args: string[] }): string {
+  expect(step.binary).toBe('powershell.exe')
+  const encoded = step.args[step.args.indexOf('-EncodedCommand') + 1]
   if (!encoded) {
-    throw new Error(`Expected an encoded PowerShell command: ${command}`)
+    throw new Error(`Expected an encoded PowerShell step: ${JSON.stringify(step)}`)
   }
   return Buffer.from(encoded, 'base64').toString('utf16le')
 }
@@ -37,8 +38,11 @@ describe('SSH remote Orca CLI launcher', () => {
     const plan = windowsInstallPlan()
 
     expect(plan.launcherPath).toBe('C:/Users/me user/.orca-relay/bin/orca.exe')
+    expect(plan.orchestrationLauncherPath).toBe('C:/Users/me user/.orca-relay/bin/orca-relay.exe')
     expect(plan.files).toHaveLength(1)
-    expect(plan.files[0]?.path).toBe('C:/Users/me user/.orca-relay/bin/orca-launcher.cs')
+    expect(plan.files[0]?.path).toMatch(
+      /^C:\/Users\/me user\/\.orca-relay\/bin\/orca-launcher-[a-f0-9]+\.cs$/
+    )
     expect(plan.files[0]?.contents).toContain('ProcessStartInfo')
     expect(plan.files[0]?.contents).toContain('"--orca-cli"')
     expect(plan.files[0]?.contents).toContain("value[index] == '\"'")
@@ -46,35 +50,48 @@ describe('SSH remote Orca CLI launcher', () => {
     expect(plan.files[0]?.contents).not.toContain('cmd.exe')
     expect(plan.files[0]?.contents).not.toContain('%*')
 
-    expect(plan.postWriteCommands).toHaveLength(1)
-    const compileScript = decodePowerShellCommand(plan.postWriteCommands[0] ?? '')
+    expect(plan.postWriteSteps).toHaveLength(1)
+    const compileScript = decodePowerShellStep(plan.postWriteSteps[0]!)
     expect(compileScript).toContain('v4.0.30319\\csc.exe')
     // Why: legacy csc.exe is invoked from the bin directory with bare, space-free
     // file names so PowerShell 5.1 never mangles a space-bearing absolute path.
     expect(compileScript).toContain(
       "Set-Location -ErrorAction Stop -LiteralPath 'C:/Users/me user/.orca-relay/bin'"
     )
-    expect(compileScript).toContain('/out:orca.exe')
-    expect(compileScript).toContain('C:/Users/me user/.orca-relay/bin/orca-launcher.cs')
+    expect(compileScript).toMatch(/\/out:orca-launcher-[a-f0-9]+\.exe/)
+    expect(compileScript).toContain(
+      "-Destination 'C:/Users/me user/.orca-relay/bin/orca-relay.exe'"
+    )
+    expect(compileScript).toContain(plan.files[0]!.path)
     expect(compileScript).toContain('C:/Users/me user/.orca-relay/bin/orca.cmd')
   })
 
   it('removes the legacy orca.cmd only after every compile guard has passed', () => {
-    const script = decodePowerShellCommand(windowsInstallPlan().postWriteCommands[0] ?? '')
+    const script = decodePowerShellStep(windowsInstallPlan().postWriteSteps[0]!)
     const legacyShimRemoval =
       "Remove-Item -LiteralPath 'C:/Users/me user/.orca-relay/bin/orca.cmd' -Force -ErrorAction SilentlyContinue"
+    const compiledPath = script.match(
+      /if \(-not \(Test-Path -LiteralPath '([^']+orca-launcher-[a-f0-9]+\.exe)' -PathType Leaf\)\)/
+    )?.[1]
+    expect(compiledPath).toBeTruthy()
     // Why: a host missing csc.exe or failing the compile must keep its existing
     // CLI, so every fail-closed guard precedes the legacy %* shim removal.
     const guards = [
       "if (-not $compiler) { Write-Error 'Unable to find the .NET Framework C# compiler required for the Orca SSH CLI launcher.'; exit 1 }",
       'if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }',
-      "if (-not (Test-Path -LiteralPath 'C:/Users/me user/.orca-relay/bin/orca.exe' -PathType Leaf))"
+      `if (-not (Test-Path -LiteralPath '${compiledPath}' -PathType Leaf))`
     ]
     expect(script).toContain(legacyShimRemoval)
     for (const guard of guards) {
       expect(script).toContain(guard)
       expect(script.indexOf(guard)).toBeLessThan(script.indexOf(legacyShimRemoval))
     }
+    expect(
+      script.indexOf("-Destination 'C:/Users/me user/.orca-relay/bin/orca-relay.exe'")
+    ).toBeLessThan(script.indexOf("-Destination 'C:/Users/me user/.orca-relay/bin/orca.exe'"))
+    expect(script.indexOf("-Destination 'C:/Users/me user/.orca-relay/bin/orca.exe'")).toBeLessThan(
+      script.indexOf(legacyShimRemoval)
+    )
   })
 
   itWindows('preserves a multiline argument through the compiled remote launcher', () => {
@@ -95,20 +112,8 @@ describe('SSH remote Orca CLI launcher', () => {
         writeFileSync(file.path, file.contents, 'utf8')
       }
 
-      const encoded = plan.postWriteCommands[0]?.match(/-EncodedCommand\s+(\S+)/)?.[1]
-      expect(encoded).toBeTruthy()
-      const compile = spawnSync(
-        'powershell.exe',
-        [
-          '-NoProfile',
-          '-NonInteractive',
-          '-ExecutionPolicy',
-          'Bypass',
-          '-EncodedCommand',
-          encoded!
-        ],
-        { encoding: 'utf8' }
-      )
+      const step = plan.postWriteSteps[0]!
+      const compile = spawnSync(step.binary, step.args, { encoding: 'utf8' })
       expect(compile.status, `${compile.stdout}\n${compile.stderr}`).toBe(0)
 
       mkdirSync(relayDir, { recursive: true })
@@ -143,6 +148,7 @@ describe('SSH remote Orca CLI launcher', () => {
         body,
         '--json'
       ])
+      expect(existsSync(join(binDir, 'orca-relay.exe'))).toBe(true)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
@@ -168,21 +174,12 @@ describe('SSH remote Orca CLI launcher', () => {
         writeFileSync(file.path, file.contents, 'utf8')
       }
 
-      const encoded = plan.postWriteCommands[0]?.match(/-EncodedCommand\s+(\S+)/)?.[1]
-      expect(encoded).toBeTruthy()
+      const step = plan.postWriteSteps[0]!
       // Point WINDIR at a directory with no csc.exe so compiler discovery fails.
-      const compile = spawnSync(
-        'powershell.exe',
-        [
-          '-NoProfile',
-          '-NonInteractive',
-          '-ExecutionPolicy',
-          'Bypass',
-          '-EncodedCommand',
-          encoded!
-        ],
-        { encoding: 'utf8', env: { ...process.env, WINDIR: root, SystemRoot: root } }
-      )
+      const compile = spawnSync(step.binary, step.args, {
+        encoding: 'utf8',
+        env: { ...process.env, WINDIR: root, SystemRoot: root }
+      })
 
       expect(compile.status).not.toBe(0)
       expect(existsSync(legacyShimPath), 'existing orca.cmd must survive a failed install').toBe(
@@ -203,10 +200,24 @@ describe('SSH remote Orca CLI launcher', () => {
     })
 
     expect(plan.launcherPath).toBe('/home/me/.orca-relay/bin/orca')
+    expect(plan.files[0]?.contents.startsWith('#!/bin/sh\n')).toBe(true)
     expect(plan.files).toEqual([
       expect.objectContaining({
-        path: '/home/me/.orca-relay/bin/orca',
+        path: expect.stringMatching(/^\/home\/me\/\.orca-relay\/bin\/orca\.[a-f0-9]+\.tmp$/),
         contents: expect.stringContaining('--orca-cli "$@"')
+      }),
+      expect.objectContaining({
+        path: expect.stringMatching(/^\/home\/me\/\.orca-relay\/bin\/orca-relay\.[a-f0-9]+\.tmp$/),
+        contents: expect.stringContaining('--orca-cli "$@"')
+      })
+    ])
+    expect(plan.orchestrationLauncherPath).toBe('/home/me/.orca-relay/bin/orca-relay')
+    expect(plan.postWriteSteps).toEqual([
+      expect.objectContaining({ binary: 'chmod' }),
+      expect.objectContaining({ binary: 'mv', args: expect.arrayContaining([plan.launcherPath]) }),
+      expect.objectContaining({
+        binary: 'mv',
+        args: expect.arrayContaining([plan.orchestrationLauncherPath])
       })
     ])
   })

--- a/src/main/ssh/ssh-remote-cli-launcher.ts
+++ b/src/main/ssh/ssh-remote-cli-launcher.ts
@@ -1,6 +1,12 @@
+import { randomBytes } from 'node:crypto'
 import type { RemoteHostPlatform } from './ssh-remote-platform'
 import { isWindowsRemoteHost, joinRemotePath } from './ssh-remote-platform'
-import { powerShellCommand, powerShellLiteral, powerShellNativeArg } from './ssh-remote-powershell'
+import { SSH_ORCHESTRATION_CLI_COMMAND } from './ssh-orchestration-cli-command'
+import {
+  powerShellArguments,
+  powerShellLiteral,
+  powerShellNativeArg
+} from './ssh-remote-powershell'
 
 type RemoteCliInstallEnv = {
   binDir: string
@@ -17,8 +23,10 @@ type RemoteCliInstallFile = {
 
 export type RemoteCliInstallPlan = {
   launcherPath: string
+  orchestrationLauncherPath: string
   files: RemoteCliInstallFile[]
-  postWriteCommands: string[]
+  postWriteSteps: { binary: string; args: string[]; cwd?: string }[]
+  cleanupPaths: string[]
 }
 
 const WINDOWS_REMOTE_CLI_LAUNCHER_SOURCE = String.raw`using System;
@@ -146,14 +154,17 @@ function quoteSh(value: string): string {
   return `'${value.replaceAll("'", `'\\''`)}'`
 }
 
-function createWindowsLauncherCompileCommand(
+function createWindowsLauncherCompileStep(
   binDir: string,
   sourceFileName: string,
-  launcherFileName: string,
-  launcherPath: string,
+  compiledFileName: string,
   sourcePath: string,
+  compiledPath: string,
+  launcherPath: string,
+  orchestrationTempPath: string,
+  orchestrationLauncherPath: string,
   legacyShimPath: string
-): string {
+): { binary: string; args: string[] } {
   // Why: legacy csc.exe mis-parses space-bearing absolute paths handed to it by
   // Windows PowerShell 5.1's native-argument quoting, so compile from the bin
   // directory and pass only the bare, space-free launcher file names.
@@ -162,49 +173,65 @@ function createWindowsLauncherCompileCommand(
     '/target:exe',
     '/optimize+',
     '/warnaserror+',
-    `/out:${launcherFileName}`,
+    `/out:${compiledFileName}`,
     sourceFileName
   ]
     .map(powerShellNativeArg)
     .join(' ')
-  return powerShellCommand(
-    [
-      `Set-Location -ErrorAction Stop -LiteralPath ${powerShellLiteral(binDir)}`,
-      '$windowsDirectory = if ($env:WINDIR) { $env:WINDIR } else { $env:SystemRoot }',
-      `$compilerCandidates = @((Join-Path $windowsDirectory 'Microsoft.NET\\Framework64\\v4.0.30319\\csc.exe'), (Join-Path $windowsDirectory 'Microsoft.NET\\Framework\\v4.0.30319\\csc.exe'))`,
-      '$compiler = $compilerCandidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } | Select-Object -First 1',
-      "if (-not $compiler) { Write-Error 'Unable to find the .NET Framework C# compiler required for the Orca SSH CLI launcher.'; exit 1 }",
-      `& $compiler ${compilerArgs}`,
-      'if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }',
-      `if (-not (Test-Path -LiteralPath ${powerShellLiteral(launcherPath)} -PathType Leaf)) { Write-Error 'The Orca SSH CLI launcher compiler produced no executable.'; exit 1 }`,
-      // Why: remove the legacy %* bridge only after a successful compile, so a
-      // host missing csc.exe keeps its existing CLI (orca.exe shadows orca.cmd).
-      `Remove-Item -LiteralPath ${powerShellLiteral(legacyShimPath)} -Force -ErrorAction SilentlyContinue`,
-      `Remove-Item -LiteralPath ${powerShellLiteral(sourcePath)} -Force`
-    ].join('; ')
-  )
+  const script = [
+    `Set-Location -ErrorAction Stop -LiteralPath ${powerShellLiteral(binDir)}`,
+    '$windowsDirectory = if ($env:WINDIR) { $env:WINDIR } else { $env:SystemRoot }',
+    `$compilerCandidates = @((Join-Path $windowsDirectory 'Microsoft.NET\\Framework64\\v4.0.30319\\csc.exe'), (Join-Path $windowsDirectory 'Microsoft.NET\\Framework\\v4.0.30319\\csc.exe'))`,
+    '$compiler = $compilerCandidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } | Select-Object -First 1',
+    "if (-not $compiler) { Write-Error 'Unable to find the .NET Framework C# compiler required for the Orca SSH CLI launcher.'; exit 1 }",
+    `& $compiler ${compilerArgs}`,
+    'if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }',
+    `if (-not (Test-Path -LiteralPath ${powerShellLiteral(compiledPath)} -PathType Leaf)) { Write-Error 'The Orca SSH CLI launcher compiler produced no executable.'; exit 1 }`,
+    `Copy-Item -LiteralPath ${powerShellLiteral(compiledPath)} -Destination ${powerShellLiteral(orchestrationTempPath)} -Force -ErrorAction Stop`,
+    `Move-Item -LiteralPath ${powerShellLiteral(orchestrationTempPath)} -Destination ${powerShellLiteral(orchestrationLauncherPath)} -Force -ErrorAction Stop`,
+    `Move-Item -LiteralPath ${powerShellLiteral(compiledPath)} -Destination ${powerShellLiteral(launcherPath)} -Force -ErrorAction Stop`,
+    // Why: remove the legacy %* bridge only after a successful compile, so a
+    // host missing csc.exe keeps its existing CLI (orca.exe shadows orca.cmd).
+    `Remove-Item -LiteralPath ${powerShellLiteral(legacyShimPath)} -Force -ErrorAction SilentlyContinue`,
+    `Remove-Item -LiteralPath ${powerShellLiteral(sourcePath)} -Force`
+  ].join('; ')
+  return { binary: 'powershell.exe', args: powerShellArguments(script) }
 }
 
 export function createRemoteCliInstallPlan(env: RemoteCliInstallEnv): RemoteCliInstallPlan {
+  const installId = randomBytes(8).toString('hex')
   if (isWindowsRemoteHost(env.hostPlatform)) {
     const launcherFileName = 'orca.exe'
-    const sourceFileName = 'orca-launcher.cs'
+    const sourceFileName = `orca-launcher-${installId}.cs`
     const launcherPath = joinRemotePath(env.hostPlatform, env.binDir, launcherFileName)
     const sourcePath = joinRemotePath(env.hostPlatform, env.binDir, sourceFileName)
+    const compiledFileName = `orca-launcher-${installId}.exe`
+    const compiledPath = joinRemotePath(env.hostPlatform, env.binDir, compiledFileName)
     const legacyShimPath = joinRemotePath(env.hostPlatform, env.binDir, 'orca.cmd')
+    const orchestrationLauncherPath = joinRemotePath(
+      env.hostPlatform,
+      env.binDir,
+      `${SSH_ORCHESTRATION_CLI_COMMAND}.exe`
+    )
+    const orchestrationTempPath = `${orchestrationLauncherPath}.${installId}.tmp`
     const binDir = joinRemotePath(env.hostPlatform, env.binDir)
     return {
       launcherPath,
+      orchestrationLauncherPath,
       files: [{ path: sourcePath, contents: WINDOWS_REMOTE_CLI_LAUNCHER_SOURCE }],
+      cleanupPaths: [sourcePath, compiledPath, orchestrationTempPath],
       // Why: compiling on the Windows target avoids shipping an unsigned
       // cross-host binary while ensuring argv never crosses cmd.exe's parser.
-      postWriteCommands: [
-        createWindowsLauncherCompileCommand(
+      postWriteSteps: [
+        createWindowsLauncherCompileStep(
           binDir,
           sourceFileName,
-          launcherFileName,
-          launcherPath,
+          compiledFileName,
           sourcePath,
+          compiledPath,
+          launcherPath,
+          orchestrationTempPath,
+          orchestrationLauncherPath,
           legacyShimPath
         )
       ]
@@ -212,27 +239,43 @@ export function createRemoteCliInstallPlan(env: RemoteCliInstallEnv): RemoteCliI
   }
 
   const launcherPath = joinRemotePath(env.hostPlatform, env.binDir, 'orca')
+  const orchestrationLauncherPath = joinRemotePath(
+    env.hostPlatform,
+    env.binDir,
+    SSH_ORCHESTRATION_CLI_COMMAND
+  )
+  const launcherTempPath = `${launcherPath}.${installId}.tmp`
+  const orchestrationTempPath = `${orchestrationLauncherPath}.${installId}.tmp`
+  const launcherContents = [
+    // Why: profiles may replace PATH with only a competing CLI directory;
+    // `/usr/bin/env sh` would then fail before the absolute bridge can run.
+    '#!/bin/sh',
+    'set -eu',
+    `ORCA_RELAY_NODE_PATH=\${ORCA_RELAY_NODE_PATH:-${quoteSh(env.nodePath)}}`,
+    `ORCA_RELAY_DIR=\${ORCA_RELAY_DIR:-${quoteSh(env.relayDir)}}`,
+    `ORCA_RELAY_SOCKET_PATH=\${ORCA_RELAY_SOCKET_PATH:-${quoteSh(env.sockPath)}}`,
+    'if [ ! -S "$ORCA_RELAY_SOCKET_PATH" ]; then',
+    '  echo "Orca SSH CLI bridge cannot find the relay socket: $ORCA_RELAY_SOCKET_PATH" >&2',
+    '  exit 1',
+    'fi',
+    'exec "$ORCA_RELAY_NODE_PATH" "$ORCA_RELAY_DIR/relay.js" --sock-path "$ORCA_RELAY_SOCKET_PATH" --orca-cli "$@"',
+    ''
+  ].join('\n')
   return {
     launcherPath,
+    orchestrationLauncherPath,
     files: [
       {
-        path: launcherPath,
-        contents: [
-          '#!/usr/bin/env sh',
-          'set -eu',
-          `ORCA_RELAY_NODE_PATH=\${ORCA_RELAY_NODE_PATH:-${quoteSh(env.nodePath)}}`,
-          `ORCA_RELAY_DIR=\${ORCA_RELAY_DIR:-${quoteSh(env.relayDir)}}`,
-          `ORCA_RELAY_SOCKET_PATH=\${ORCA_RELAY_SOCKET_PATH:-${quoteSh(env.sockPath)}}`,
-          'if [ ! -S "$ORCA_RELAY_SOCKET_PATH" ]; then',
-          '  echo "Orca SSH CLI bridge cannot find the relay socket: $ORCA_RELAY_SOCKET_PATH" >&2',
-          '  exit 1',
-          'fi',
-          'exec "$ORCA_RELAY_NODE_PATH" "$ORCA_RELAY_DIR/relay.js" --sock-path "$ORCA_RELAY_SOCKET_PATH" --orca-cli "$@"',
-          ''
-        ].join('\n')
-      }
+        path: launcherTempPath,
+        contents: launcherContents
+      },
+      { path: orchestrationTempPath, contents: launcherContents }
     ],
-    // Surface chmod failures: a non-executable launcher must fail install loudly, not silently.
-    postWriteCommands: [`chmod +x ${quoteSh(launcherPath)}`]
+    cleanupPaths: [launcherTempPath, orchestrationTempPath],
+    postWriteSteps: [
+      { binary: 'chmod', args: ['+x', launcherTempPath, orchestrationTempPath] },
+      { binary: 'mv', args: ['-f', launcherTempPath, launcherPath] },
+      { binary: 'mv', args: ['-f', orchestrationTempPath, orchestrationLauncherPath] }
+    ]
   }
 }

--- a/src/main/ssh/ssh-remote-powershell.ts
+++ b/src/main/ssh/ssh-remote-powershell.ts
@@ -5,5 +5,16 @@ export {
 } from '../../shared/powershell-native-argument'
 
 export function powerShellCommand(script: string): string {
-  return `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ${encodePowerShellCommand(script)}`
+  return `powershell.exe ${powerShellArguments(script).join(' ')}`
+}
+
+export function powerShellArguments(script: string): string[] {
+  return [
+    '-NoProfile',
+    '-NonInteractive',
+    '-ExecutionPolicy',
+    'Bypass',
+    '-EncodedCommand',
+    encodePowerShellCommand(script)
+  ]
 }

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -177,7 +177,7 @@ describe('PtyHandler', () => {
 
   it('spawns a PTY and returns an id', async () => {
     const result = await dispatcher.callRequest('pty.spawn', { cols: 80, rows: 24 })
-    expect(result).toEqual({ id: 'pty-1' })
+    expect(result).toEqual({ id: 'pty-1', shellPath: expect.any(String) })
     expect(mockPtySpawn).toHaveBeenCalled()
     expect(handler.activePtyCount).toBe(1)
   })
@@ -379,16 +379,22 @@ describe('PtyHandler', () => {
       .spyOn(ptyShellUtils, 'resolveDefaultShell')
       .mockReturnValue('/default-shell')
     try {
-      await dispatcher.callRequest('pty.spawn', {
+      const result = await dispatcher.callRequest('pty.spawn', {
         cols: 80,
         rows: 24,
         shellOverride: 'powershell.exe'
       })
+      expect(result).toEqual({ id: 'pty-1', shellPath: 'powershell.exe' })
       expect(mockPtySpawn).toHaveBeenCalledWith(
         'powershell.exe',
         expect.any(Array),
         expect.any(Object)
       )
+      expect(await dispatcher.callRequest('pty.listProcesses')).toEqual([
+        expect.objectContaining({ id: 'pty-1', shellPath: 'powershell.exe' })
+      ])
+      const state = (await dispatcher.callRequest('pty.serialize', { ids: ['pty-1'] })) as string
+      expect(JSON.parse(state)[0]?.shellPath).toBe('powershell.exe')
 
       mockPtySpawn.mockClear()
 
@@ -502,7 +508,14 @@ describe('PtyHandler', () => {
         cols: 80,
         rows: 24,
         shellOverride: 'wsl.exe',
-        terminalWindowsWslDistro: 'Ubuntu-24.04'
+        terminalWindowsWslDistro: 'Ubuntu-24.04',
+        env: {
+          WSLENV: 'KEEP_ME:ORCA_CLI_COMMAND/u',
+          ORCA_CLI_COMMAND: 'C:/Users/me/.orca-relay/bin/orca-relay.exe',
+          ORCA_RELAY_NODE_PATH: 'C:/Program Files/nodejs/node.exe',
+          ORCA_RELAY_DIR: 'C:/Users/me/.orca-remote/relay-v1',
+          ORCA_RELAY_SOCKET_PATH: '\\\\.\\pipe\\orca-relay-123'
+        }
       })
 
       expect(mockPtySpawn).toHaveBeenCalledWith(
@@ -510,6 +523,14 @@ describe('PtyHandler', () => {
         ['-d', 'Ubuntu-24.04'],
         expect.any(Object)
       )
+      const spawnEnv = mockPtySpawn.mock.calls[0]?.[2]?.env as Record<string, string>
+      expect(spawnEnv.WSLENV.split(':')).toEqual([
+        'KEEP_ME',
+        'ORCA_CLI_COMMAND/p',
+        'ORCA_RELAY_DIR/p',
+        'ORCA_RELAY_NODE_PATH/p',
+        'ORCA_RELAY_SOCKET_PATH'
+      ])
     } finally {
       Object.defineProperty(process, 'platform', {
         configurable: true,
@@ -803,7 +824,10 @@ describe('PtyHandler', () => {
         id: 'pty-1',
         suppressReplayNotification: true
       })
-      expect(result).toEqual({ replay: '\x1b]777;orca-shell-ready' })
+      expect(result).toMatchObject({
+        replay: '\x1b]777;orca-shell-ready',
+        shellPath: expect.any(String)
+      })
     }
   )
 
@@ -894,7 +918,7 @@ describe('PtyHandler', () => {
         id: 'pty-1',
         suppressReplayNotification: true
       })
-      expect(result).toEqual({ replay: 'prompt$ ' })
+      expect(result).toMatchObject({ replay: 'prompt$ ', shellPath: expect.any(String) })
     } finally {
       aliveSpy.mockRestore()
     }
@@ -1048,7 +1072,7 @@ describe('PtyHandler', () => {
         id: 'pty-1',
         suppressReplayNotification: true
       })
-    ).resolves.toEqual({ replay: 'prompt' })
+    ).resolves.toEqual({ replay: 'prompt', shellPath: '/bin/zsh' })
   })
 
   it('leaves startup queries untouched for an unsupported relay capability version', async () => {
@@ -1272,7 +1296,7 @@ describe('PtyHandler', () => {
       suppressReplayNotification: true
     })
 
-    expect(result).toEqual({ replay: 'buffered output' })
+    expect(result).toMatchObject({ replay: 'buffered output', shellPath: expect.any(String) })
     expect(dispatcher.notify).not.toHaveBeenCalledWith('pty.replay', expect.anything())
     vi.advanceTimersByTime(8)
     expect(dispatcher.notify).not.toHaveBeenCalledWith('pty.data', expect.anything())
@@ -1294,7 +1318,7 @@ describe('PtyHandler', () => {
 
     const result = await dispatcher.callRequest('pty.attach', { id: 'pty-1' })
 
-    expect(result).toEqual({})
+    expect(result).toEqual({ shellPath: expect.any(String) })
     expect(dispatcher.notify).toHaveBeenCalledWith('pty.replay', {
       id: 'pty-1',
       data: 'buffered output'
@@ -1345,7 +1369,7 @@ describe('PtyHandler', () => {
         expectedPaneKey: 'tab-a:leaf-a',
         expectedTabId: 'tab-a'
       })
-    ).resolves.toEqual({})
+    ).resolves.toEqual({ shellPath: expect.any(String) })
   })
 
   it('notifies on PTY exit and removes from map', async () => {
@@ -1777,7 +1801,7 @@ describe('PtyHandler', () => {
       id: 'pty-1',
       suppressReplayNotification: true
     })
-    expect(r1).toEqual({ replay: 'initial output' })
+    expect(r1).toMatchObject({ replay: 'initial output', shellPath: expect.any(String) })
 
     dataCallback!(' more')
 
@@ -1785,7 +1809,7 @@ describe('PtyHandler', () => {
       id: 'pty-1',
       suppressReplayNotification: true
     })
-    expect(r2).toEqual({ replay: 'initial output more' })
+    expect(r2).toMatchObject({ replay: 'initial output more', shellPath: expect.any(String) })
   })
 
   it('second app restart still replays full buffer', async () => {
@@ -1822,7 +1846,8 @@ describe('PtyHandler', () => {
       suppressReplayNotification: true
     })
     expect(result).toEqual({
-      replay: '$ while true; do date; done\r\nMon Apr 28\r\nTue Apr 29\r\nWed Apr 30\r\n'
+      replay: '$ while true; do date; done\r\nMon Apr 28\r\nTue Apr 29\r\nWed Apr 30\r\n',
+      shellPath: expect.any(String)
     })
   })
 

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -16,6 +16,7 @@ import {
   listShellProfiles
 } from './pty-shell-utils'
 import { getRelayShellLaunchConfig } from './pty-shell-launch'
+import { addSshRelayWslEnv, isWindowsWslShell } from './ssh-relay-wsl-env'
 import { DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS } from '../shared/ssh-types'
 import { shouldUseShellReadyStartupDelivery } from '../shared/codex-startup-delivery'
 import { buildStartupCommandSubmission } from '../shared/startup-command-submission'
@@ -58,6 +59,7 @@ function isMissingNodePtyNativeBinding(error: unknown): boolean {
 type ManagedPty = {
   id: string
   pty: IPty
+  shellPath: string
   initialCwd: string
   buffered: string
   /** Timer for SIGKILL fallback after a graceful SIGTERM shutdown. */
@@ -202,6 +204,7 @@ type PtyProcessSummary = {
   id: string
   cwd: string
   title: string
+  shellPath: string
   worktreeId?: string
   terminalHandle?: string
 }
@@ -212,6 +215,7 @@ type SerializedPtyEntry = {
   cols: number
   rows: number
   cwd: string
+  shellPath?: string
   paneKey?: string
   tabId?: string
   attachIdentity?: PtyIdentity
@@ -800,7 +804,7 @@ export class PtyHandler {
   private async spawn(
     params: Record<string, unknown>,
     context?: RequestContext
-  ): Promise<{ id: string }> {
+  ): Promise<{ id: string; shellPath: string }> {
     const env = params.env as Record<string, string> | undefined
     const worktreeId = env?.ORCA_WORKTREE_ID
     const worktreePath = worktreeId ? splitWorktreeId(worktreeId)?.worktreePath : undefined
@@ -816,7 +820,7 @@ export class PtyHandler {
   private async spawnAfterAdmission(
     params: Record<string, unknown>,
     context?: RequestContext
-  ): Promise<{ id: string }> {
+  ): Promise<{ id: string; shellPath: string }> {
     const pty = await this.loadPty()
     if (!pty) {
       throw new Error('node-pty is not available on this remote host')
@@ -855,6 +859,9 @@ export class PtyHandler {
     const commandDelivery = params.commandDelivery === 'provider' ? 'provider' : 'renderer'
     const shouldProviderDeliverCommand = commandDelivery === 'provider' && command !== undefined
     const spawnEnv = this.buildSpawnEnv(env, { id, paneKey, shell, command }, envToDelete)
+    if (process.platform === 'win32' && isWindowsWslShell(shell)) {
+      addSshRelayWslEnv(spawnEnv)
+    }
     const launchCommandHint = resolveSetupAgentSequenceLaunchCommand(spawnEnv, command)
     // Why: SSH PTYs bypass main's host-env builder, so apply the guard after the relay merges its authoritative env.
     const gitCredentialPromptGuarded = applyTerminalGitCredentialPromptGuard(spawnEnv, {
@@ -910,6 +917,7 @@ export class PtyHandler {
     const managed: ManagedPty = {
       id,
       pty: term,
+      shellPath: shell,
       initialCwd: cwd,
       buffered: '',
       paneKey,
@@ -954,10 +962,13 @@ export class PtyHandler {
           : STARTUP_COMMAND_WRITE_DELAY_MS
       )
     }
-    return { id }
+    return { id, shellPath: shell }
   }
 
-  private async attach(params: Record<string, unknown>): Promise<{ replay?: string }> {
+  private async attach(params: Record<string, unknown>): Promise<{
+    replay?: string
+    shellPath: string
+  }> {
     const id = params.id as string
     const managed = this.ptys.get(id)
     // Why: after dispose, pty.kill is a POSIX no-op; treat disposed as not-found so failures aren't silent.
@@ -998,11 +1009,11 @@ export class PtyHandler {
       this.pendingOutputByPty.delete(id)
       this.clearOutputFlushTimerIfIdle()
       if (params.suppressReplayNotification) {
-        return { replay: managed.buffered }
+        return { replay: managed.buffered, shellPath: managed.shellPath }
       }
       this.dispatcher.notify('pty.replay', { id, data: managed.buffered })
     }
-    return {}
+    return { shellPath: managed.shellPath }
   }
 
   private writeData(params: Record<string, unknown>): void {
@@ -1208,6 +1219,7 @@ export class PtyHandler {
         id,
         cwd: managed.initialCwd,
         title,
+        shellPath: managed.shellPath,
         ...(managed.worktreeId ? { worktreeId: managed.worktreeId } : {}),
         ...(managed.terminalHandle ? { terminalHandle: managed.terminalHandle } : {})
       })
@@ -1230,6 +1242,7 @@ export class PtyHandler {
         cols,
         rows,
         cwd: managed.initialCwd,
+        shellPath: managed.shellPath,
         paneKey: managed.paneKey,
         tabId: managed.tabId,
         attachIdentity: managed.attachIdentity,
@@ -1322,6 +1335,7 @@ export class PtyHandler {
     this.wireAndStore({
       id: entry.id,
       pty: term,
+      shellPath: shell,
       initialCwd: entry.cwd,
       buffered: '',
       paneKey: entry.paneKey,

--- a/src/relay/pty-shell-launch.test.ts
+++ b/src/relay/pty-shell-launch.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -7,6 +7,37 @@ import { getRelayShellLaunchConfig } from './pty-shell-launch'
 
 const hasBash = process.platform !== 'win32' && spawnSync('bash', ['--version']).status === 0
 const itWithBash = hasBash ? it : it.skip
+const hasZsh = process.platform !== 'win32' && spawnSync('zsh', ['--version']).status === 0
+const itWithZsh = hasZsh ? it : it.skip
+
+function quotePosix(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`
+}
+
+function writeMarkerCommand(directory: string, command: string, marker: string): void {
+  mkdirSync(directory, { recursive: true })
+  const commandPath = join(directory, command)
+  writeFileSync(commandPath, `#!/bin/sh\nprintf '%s\\n' ${quotePosix(marker)}\n`, 'utf8')
+  chmodSync(commandPath, 0o755)
+}
+
+function parseOutputFields(output: string): Map<string, string> {
+  return new Map(
+    output
+      .split('\n')
+      .map((line) => line.match(/(initial-(?:orca|relay|path)|nested-(?:orca|relay))=(.*)$/))
+      .filter((match): match is RegExpMatchArray => match !== null)
+      .map((match) => [match[1] ?? '', match[2] ?? ''])
+  )
+}
+
+const PATH_COLLISION_PROBE = [
+  'printf \'initial-orca=%s\\n\' "$(orca)"',
+  'printf \'initial-relay=%s\\n\' "$(orca-relay)"',
+  'printf \'nested-orca=%s\\n\' "$("$SHELL" -lc orca)"',
+  'printf \'nested-relay=%s\\n\' "$("$SHELL" -lc orca-relay)"',
+  'printf \'initial-path=%s\\n\' "$PATH"'
+].join('; ')
 
 function runInteractiveBashRcfile(rcfile: string, homeDir: string): string {
   const result = spawnSync(
@@ -250,5 +281,97 @@ describe('getRelayShellLaunchConfig', () => {
     expect(output).not.toContain('syntax error')
     expect(output).toContain('PROMPT_SEP')
     expectBashOsc133Lifecycle(output)
+  })
+
+  itWithBash('keeps SSH lifecycle commands on the relay across nested bash login startup', () => {
+    const relayBin = join(homeDir, 'relay [bin]*')
+    const hostBin = join(homeDir, 'host bin')
+    writeMarkerCommand(relayBin, 'orca', 'RELAY')
+    writeMarkerCommand(relayBin, 'orca-relay', 'RELAY')
+    writeMarkerCommand(hostBin, 'orca', 'HOST')
+    writeFileSync(
+      join(homeDir, '.bash_profile'),
+      `export PATH=${quotePosix(hostBin)}:"$PATH"\n`,
+      'utf8'
+    )
+    const inheritedPath = `${relayBin}:${hostBin}:${relayBin}:${process.env.PATH ?? '/usr/bin'}`
+    const config = getRelayShellLaunchConfig('/bin/bash', {
+      HOME: homeDir,
+      PATH: inheritedPath,
+      ORCA_REMOTE_CLI_BIN_DIR: relayBin
+    })
+    const result = spawnSync(
+      '/bin/bash',
+      ['--noprofile', '--rcfile', config.args[1] as string, '-ic', PATH_COLLISION_PROBE],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ...config.env,
+          HOME: homeDir,
+          SHELL: '/bin/bash',
+          PATH: inheritedPath,
+          ORCA_REMOTE_CLI_BIN_DIR: relayBin
+        }
+      }
+    )
+
+    expect(result.status, result.stderr).toBe(0)
+    const fields = parseOutputFields(result.stdout)
+    expect(fields.get('initial-orca')).toBe('RELAY')
+    expect(fields.get('initial-relay')).toBe('RELAY')
+    expect(fields.get('nested-orca')).toBe('HOST')
+    expect(fields.get('nested-relay')).toBe('RELAY')
+    expect(fields.get('initial-path')?.split(':')[0]).toBe(relayBin)
+    expect(
+      fields
+        .get('initial-path')
+        ?.split(':')
+        .filter((entry) => entry === relayBin)
+    ).toHaveLength(1)
+  })
+
+  itWithZsh('keeps SSH lifecycle commands on the relay across nested zsh login startup', () => {
+    const relayBin = join(homeDir, 'relay [bin]*')
+    const hostBin = join(homeDir, 'host bin')
+    writeMarkerCommand(relayBin, 'orca', 'RELAY')
+    writeMarkerCommand(relayBin, 'orca-relay', 'RELAY')
+    writeMarkerCommand(hostBin, 'orca', 'HOST')
+    writeFileSync(
+      join(homeDir, '.zprofile'),
+      `export PATH=${quotePosix(hostBin)}:"$PATH"\n`,
+      'utf8'
+    )
+    const inheritedPath = `${relayBin}:${hostBin}:${relayBin}:${process.env.PATH ?? '/usr/bin'}`
+    const config = getRelayShellLaunchConfig('/bin/zsh', {
+      HOME: homeDir,
+      PATH: inheritedPath,
+      ORCA_REMOTE_CLI_BIN_DIR: relayBin
+    })
+    const result = spawnSync('/bin/zsh', [...config.args, '-c', PATH_COLLISION_PROBE], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ...config.env,
+        HOME: homeDir,
+        SHELL: '/bin/zsh',
+        PATH: inheritedPath,
+        ORCA_REMOTE_CLI_BIN_DIR: relayBin
+      }
+    })
+
+    expect(result.status, result.stderr).toBe(0)
+    const fields = parseOutputFields(result.stdout)
+    expect(fields.get('initial-orca')).toBe('RELAY')
+    expect(fields.get('initial-relay')).toBe('RELAY')
+    expect(fields.get('nested-orca')).toBe('HOST')
+    expect(fields.get('nested-relay')).toBe('RELAY')
+    expect(fields.get('initial-path')?.split(':')[0]).toBe(relayBin)
+    expect(
+      fields
+        .get('initial-path')
+        ?.split(':')
+        .filter((entry) => entry === relayBin)
+    ).toHaveLength(1)
   })
 })

--- a/src/relay/pty-shell-launch.ts
+++ b/src/relay/pty-shell-launch.ts
@@ -7,6 +7,7 @@ import {
   getZshShellReadyMarkerRegistrationBlock,
   getZshStartupFileSourceBlock
 } from '../main/shell-templates'
+import { getRemoteCliPathRestoreBlock } from './remote-cli-path-restore'
 
 const RELAY_SHELL_READY_DIR = '.orca-relay/shell-ready'
 const POSIX_LOGIN_ARGS = ['-l']
@@ -111,7 +112,7 @@ if [[ ! -o login ]]; then
   # Why: remote startup files can re-export user defaults after relay spawn.
   [[ -n "\${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="\${ORCA_OPENCODE_CONFIG_DIR}"
   [[ -n "\${ORCA_MIMOCODE_HOME:-}" ]] && export MIMOCODE_HOME="\${ORCA_MIMOCODE_HOME}"
-  [[ -n "\${ORCA_REMOTE_CLI_BIN_DIR:-}" ]] && case ":$PATH:" in *:"\${ORCA_REMOTE_CLI_BIN_DIR}":*) ;; *) export PATH="\${ORCA_REMOTE_CLI_BIN_DIR}:$PATH" ;; esac
+  ${getRemoteCliPathRestoreBlock()}
   ${getPosixOmpShellWrapper()}
 fi
 if [[ ! -o login ]]; then
@@ -127,7 +128,7 @@ ${getZshStartupFileSourceBlock({
 # Why: .zlogin is the final zsh login startup file before the prompt.
 [[ -n "\${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="\${ORCA_OPENCODE_CONFIG_DIR}"
 [[ -n "\${ORCA_MIMOCODE_HOME:-}" ]] && export MIMOCODE_HOME="\${ORCA_MIMOCODE_HOME}"
-[[ -n "\${ORCA_REMOTE_CLI_BIN_DIR:-}" ]] && case ":$PATH:" in *:"\${ORCA_REMOTE_CLI_BIN_DIR}":*) ;; *) export PATH="\${ORCA_REMOTE_CLI_BIN_DIR}:$PATH" ;; esac
+${getRemoteCliPathRestoreBlock()}
 ${getPosixOmpShellWrapper()}
 ${getZshFinalZdotdirRestoreBlock('"${ORCA_USER_ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"')}
 ${getZshShellReadyMarkerRegistrationBlock(SHELL_READY_MARKER_ESCAPED)}
@@ -149,7 +150,7 @@ fi
 # Why: remote startup files can re-export user defaults after relay spawn.
 [[ -n "\${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="\${ORCA_OPENCODE_CONFIG_DIR}"
 [[ -n "\${ORCA_MIMOCODE_HOME:-}" ]] && export MIMOCODE_HOME="\${ORCA_MIMOCODE_HOME}"
-[[ -n "\${ORCA_REMOTE_CLI_BIN_DIR:-}" ]] && case ":$PATH:" in *:"\${ORCA_REMOTE_CLI_BIN_DIR}":*) ;; *) export PATH="\${ORCA_REMOTE_CLI_BIN_DIR}:$PATH" ;; esac
+${getRemoteCliPathRestoreBlock()}
 ${getPosixOmpShellWrapper()}
 # Why: SSH bash sessions need the same command lifecycle markers as local
 # bash so agent rows stop showing "working" when the foreground command exits.

--- a/src/relay/remote-cli-path-restore.ts
+++ b/src/relay/remote-cli-path-restore.ts
@@ -1,0 +1,34 @@
+export function getRemoteCliPathRestoreBlock(): string {
+  return `# Why: user startup files can move a competing host CLI ahead of the relay bridge.
+if [[ -n "\${ORCA_REMOTE_CLI_BIN_DIR:-}" ]]; then
+  __orca_path_remaining="\${PATH-}"
+  __orca_path_without_remote=""
+  __orca_path_has_entry=0
+  while :; do
+    if [[ "$__orca_path_remaining" == *:* ]]; then
+      __orca_path_entry="\${__orca_path_remaining%%:*}"
+      __orca_path_remaining="\${__orca_path_remaining#*:}"
+      __orca_path_last=0
+    else
+      __orca_path_entry="$__orca_path_remaining"
+      __orca_path_last=1
+    fi
+    if [[ "$__orca_path_entry" != "$ORCA_REMOTE_CLI_BIN_DIR" ]]; then
+      if (( __orca_path_has_entry )); then
+        __orca_path_without_remote="$__orca_path_without_remote:$__orca_path_entry"
+      else
+        __orca_path_without_remote="$__orca_path_entry"
+        __orca_path_has_entry=1
+      fi
+    fi
+    (( __orca_path_last )) && break
+  done
+  if (( __orca_path_has_entry )); then
+    export PATH="$ORCA_REMOTE_CLI_BIN_DIR:$__orca_path_without_remote"
+  else
+    export PATH="$ORCA_REMOTE_CLI_BIN_DIR"
+  fi
+  unset __orca_path_remaining __orca_path_without_remote __orca_path_has_entry
+  unset __orca_path_entry __orca_path_last
+fi`
+}

--- a/src/relay/ssh-relay-wsl-env.test.ts
+++ b/src/relay/ssh-relay-wsl-env.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { addSshRelayWslEnv, isWindowsWslShell } from './ssh-relay-wsl-env'
+
+describe('SSH relay WSL environment', () => {
+  it.each(['wsl.exe', 'WSL', 'C:\\Windows\\System32\\wsl.exe'])(
+    'recognizes %s as WSL',
+    (shellPath) => {
+      expect(isWindowsWslShell(shellPath)).toBe(true)
+    }
+  )
+
+  it('passes launcher paths bidirectionally and preserves the named pipe verbatim', () => {
+    const env: Record<string, string> = {
+      ORCA_CLI_COMMAND: 'C:/Users/me/.orca-relay/bin/orca-relay.exe',
+      ORCA_REMOTE_CLI_BIN_DIR: 'C:/Users/me/.orca-relay/bin',
+      ORCA_RELAY_DIR: 'C:/Users/me/.orca-remote/relay-v1',
+      ORCA_RELAY_NODE_PATH: 'C:/Program Files/nodejs/node.exe',
+      ORCA_RELAY_SOCKET_PATH: '\\\\.\\pipe\\orca-relay-123'
+    }
+
+    addSshRelayWslEnv(env)
+
+    expect(env.WSLENV?.split(':')).toEqual([
+      'ORCA_CLI_COMMAND/p',
+      'ORCA_REMOTE_CLI_BIN_DIR/p',
+      'ORCA_RELAY_DIR/p',
+      'ORCA_RELAY_NODE_PATH/p',
+      'ORCA_RELAY_SOCKET_PATH'
+    ])
+  })
+
+  it('deduplicates managed entries while preserving unrelated WSLENV entries', () => {
+    const env = {
+      WSLENV: 'KEEP_ME:ORCA_CLI_COMMAND/u:ORCA_RELAY_SOCKET_PATH/up:KEEP_PATH/p',
+      ORCA_CLI_COMMAND: 'C:/relay/orca-relay.exe',
+      ORCA_RELAY_SOCKET_PATH: '\\\\.\\pipe\\orca'
+    }
+
+    addSshRelayWslEnv(env)
+
+    expect(env.WSLENV.split(':')).toEqual([
+      'KEEP_ME',
+      'ORCA_CLI_COMMAND/p',
+      'ORCA_RELAY_SOCKET_PATH',
+      'KEEP_PATH/p'
+    ])
+  })
+
+  it('does not advertise absent bridge variables', () => {
+    const env = { WSLENV: 'KEEP_ME' }
+
+    addSshRelayWslEnv(env)
+
+    expect(env.WSLENV).toBe('KEEP_ME')
+  })
+})

--- a/src/relay/ssh-relay-wsl-env.ts
+++ b/src/relay/ssh-relay-wsl-env.ts
@@ -1,0 +1,36 @@
+function upsertWslenvEntry(entries: string[], entry: string): void {
+  const variableName = entry.split('/')[0]
+  const index = entries.findIndex((value) => value.split('/')[0] === variableName)
+  if (index === -1) {
+    entries.push(entry)
+  } else {
+    entries[index] = entry
+  }
+}
+
+export function isWindowsWslShell(shellPath: string): boolean {
+  const shellName = shellPath.replaceAll('\\', '/').split('/').pop()?.toLowerCase()
+  return shellName === 'wsl.exe' || shellName === 'wsl'
+}
+
+export function addSshRelayWslEnv(env: Record<string, string>): void {
+  const entries = env.WSLENV?.split(':').filter(Boolean) ?? []
+  // Why: wsl.exe imports only allowlisted variables; path flags translate the
+  // Windows relay installation into the selected distro's mount layout.
+  const passthrough = [
+    'ORCA_CLI_COMMAND/p',
+    'ORCA_REMOTE_CLI_BIN_DIR/p',
+    'ORCA_RELAY_DIR/p',
+    'ORCA_RELAY_NODE_PATH/p',
+    // Why: the Windows launcher invoked through WSL interop needs the named
+    // pipe value on the return trip too; `/u` would make it one-way into WSL.
+    'ORCA_RELAY_SOCKET_PATH'
+  ]
+  for (const entry of passthrough) {
+    const variableName = entry.split('/')[0] ?? ''
+    if (env[variableName]) {
+      upsertWslenvEntry(entries, entry)
+    }
+  }
+  env.WSLENV = entries.join(':')
+}


### PR DESCRIPTION
Fixes #8608
Supersedes #8710

## ELI5

An SSH worker can have two commands named `orca`: Orca's relay command and a different Orca installed on the remote host. Shell startup files can reshuffle `PATH`, so a nested shell may silently pick the host command and report task completion to the wrong Orca instance.

This change gives relay lifecycle traffic its own name (`orca-relay`) and injects the exact launcher for the worker's actual shell. `PATH` promotion remains as convenience and defense in depth, but orchestration correctness no longer depends on `PATH` order.

## Root cause

The relay bin was promoted only when Orca created the PTY and after the initial bash/zsh startup files. A later `bash -lc` or `zsh -lc` re-runs user profiles and can put a competing host `orca` first again. The injected worker lifecycle preamble used bare `orca`, so `worker_done`, heartbeat, ask, and escalation commands could reach the wrong runtime without an error visible to the coordinator.

## Fix

- Install a distinct `orca-relay` / `orca-relay.exe` launcher atomically through the existing relay multiplexer, including on SSH servers limited to one session.
- Probe the installed launcher end to end with `status --json`; expose orchestration capability only when the launcher reaches the expected Orca runtime. Reuse a previously working launcher when a reconnect-time reinstall fails, and clean randomized staging files after failures.
- Render shell-specific lifecycle commands: quoted absolute paths for POSIX shells, PowerShell invocation syntax for POSIX `pwsh`, and environment-based PowerShell, cmd, Git Bash, and WSL forms on Windows. Unknown Windows shells fail closed instead of falling back to bare `orca`.
- Propagate the actual remote shell through spawn, attach, reconnect, process listing, serialization, and runtime records so the preamble uses the correct syntax.
- Keep relay PATH promotion idempotent and duplicate-free after bash/zsh startup as defense in depth.
- Resolve launcher capability before creating a dispatch context, so an unavailable bridge leaves the task ready to retry.

## Evidence

Real SSH reproduction used a disposable Ubuntu 24.04.4 LTS aarch64 host with bash 5.2.21, zsh 5.9, a competing `/usr/local/bin/orca`, and a relay path containing spaces and glob characters.

- With both PATH-prepending and PATH-replacing profiles, bare `orca` in nested bash/zsh login shells resolved to `HOST`.
- The exact `orca-relay` launcher resolved to `RELAY` in every nested-shell case.
- Exact launching also succeeded with a host-only PATH.
- The wrapper restored the relay directory to PATH position 1, removed duplicates, and preserved empty PATH entries.
- The disposable SSH container was removed after the run.

## Validation

- Typecheck: passed.
- Focused regression suite: 12 files, 720 passed, 2 skipped.
- POSIX-hosted PowerShell execution regression: passed with real `pwsh`.
- Full Node 24 suite: 33,801 passed, 82 skipped. An unrelated sidebar import timeout passed alone; two environment-contaminated agent-exec assertions passed with inherited Git config removed. Two pre-existing macOS relay-socket timing tests remain red both in the full run and alone.
- Formatter and changed-file lint: passed.
- Repository lint reaches an unrelated current-main switch-exhaustiveness error in `skill-freshness-group.tsx`, which this branch does not modify.
- Fresh independent review against current main: CLEAN.

## Cross-platform behavior and risk

The changed command rendering is covered for macOS/Linux POSIX shells, POSIX `pwsh`, Windows PowerShell, cmd, Git Bash, and WSL. Native Windows launcher compilation remains platform-conditional and is covered by plan/argument tests; no native Windows host was available in this run. Unknown Windows shells intentionally lose orchestration capability rather than risk misrouting lifecycle messages. Ordinary terminal use remains available if launcher installation or probing fails.

The main compatibility cost is a larger SSH integration change than #8710. That is intentional: PATH-only promotion cannot protect nested or custom shell startup, while an exact proven launcher makes the control path deterministic.

## Relationship to #8710

#8710 correctly identified PATH ordering and its PATH promotion is retained here. It does not cover nested login shells that reorder PATH after Orca's initial wrapper, so this PR replaces it with a deterministic launcher while preserving the useful defense-in-depth behavior.
