### PR TITLE
fix(runtime): scope mirrored-editor close intent to its runtime environment

### DIFF
--- a/src/renderer/src/runtime/close-mirrored-editor-tab.test.ts
+++ b/src/renderer/src/runtime/close-mirrored-editor-tab.test.ts
@@ -46,7 +46,9 @@ describe('notifyHostOfMirroredEditorClose', () => {
     // host snapshot in the dynamic-import gap can't flash the old-path tab back.
     notifyHostOfMirroredEditorClose(buildState(), 'wt-1', 'file-1')
 
-    expect(isWebSessionCloseIntentPending('wt-1', toHostSessionTabId('host-tab-1'), now)).toBe(true)
+    expect(
+      isWebSessionCloseIntentPending('env-1', 'wt-1', toHostSessionTabId('host-tab-1'), now)
+    ).toBe(true)
   })
 
   it('closes the mirrored editor tab on the host using the host tab id', async () => {

--- a/src/renderer/src/runtime/close-mirrored-editor-tab.ts
+++ b/src/renderer/src/runtime/close-mirrored-editor-tab.ts
@@ -40,7 +40,12 @@ export function notifyHostOfMirroredEditorClose(
   }
   // Record the close intent SYNCHRONOUSLY so a host snapshot landing before the dynamic import below resolves can't
   // flash the old-path tab back. closeWebRuntimeSessionTab re-records it idempotently.
-  recordWebSessionCloseIntent(worktreeId, toHostSessionTabId(unifiedTab.id), Date.now())
+  recordWebSessionCloseIntent(
+    runtimeEnvironmentId,
+    worktreeId,
+    toHostSessionTabId(unifiedTab.id),
+    Date.now()
+  )
   // Dynamic import: this helper is imported by the editor slice during store creation, so importing
   // web-runtime-session eagerly imports the store back and trips cyclic init in full-suite import order.
   void import('./web-runtime-session').then(({ closeWebRuntimeSessionTab }) =>


### PR DESCRIPTION
## What

`recordWebSessionCloseIntent` and `isWebSessionCloseIntentPending` gained a leading `environmentId` parameter in #9804, and the `web-runtime-session.ts` callers were updated to the 4-arg form — but the **second** caller, in `close-mirrored-editor-tab.ts`, was missed and still passed 3 args. This breaks the web typecheck on `main`:

```
src/renderer/src/runtime/close-mirrored-editor-tab.ts(43,3): error TS2554: Expected 4 arguments, but got 3.
src/renderer/src/runtime/close-mirrored-editor-tab.test.ts(49,12): error TS2554: Expected 4 arguments, but got 3.
```

Fix: pass the already-validated `runtimeEnvironmentId` (the exact same value handed to `closeWebRuntimeSessionTab({ environmentId })` immediately below) so the close intent is recorded under the correct `closeIntentScopeKey(environmentId, worktreeId)`. Update the test's `isWebSessionCloseIntentPending` assertion to the 4-arg form (`env-1` is what the test's mock resolves the worktree's runtime env to).

## ELI5

When you close a file that's mirrored from a remote host, Orca whispers to the host "I closed this, don't send it back." A recent change started filing those whispers in per-environment folders, but one code path forgot to say *which* environment — so the compiler refused to build, and even if it had built, the whisper would've gone in the wrong folder and the tab could pop back. This puts the environment label back on that one path.

## Proof of zero regression

- `close-mirrored-editor-tab.test.ts`: **4/4 pass** (including the "records the host close intent SYNCHRONOUSLY" test that exercises the fixed call path with `env-1`).
- `pnpm typecheck:web`: **clean** (was failing on `main` before this).
- The passed value is identical to the `environmentId` already used two lines down in `closeWebRuntimeSessionTab`, so the two now agree on scope — this is the behavior #9804 intended.

## Why this is a fix, not just a type patch

Had the code compiled with the missing arg, the intent would have been recorded under `closeIntentScopeKey(undefined, worktreeId)` while `closeWebRuntimeSessionTab` re-records/reads under `closeIntentScopeKey(runtimeEnvironmentId, worktreeId)` — a scope mismatch that reopens the "host snapshot flashes the just-closed mirrored tab back" race #9804 was hardening against.

Made with [Orca](https://github.com/stablyai/orca) 🐋
