### PR TITLE
perf(editor): memoize the markdown preview render pipeline

### DIFF
--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines -- Why: MarkdownPreview keeps rendering, link interception, search, and viewport state together so preview behavior stays coherent. */
 /* oxlint-disable react-doctor/no-adjust-state-on-prop-change -- Why: search match state is synchronized with DOM highlights inserted into the rendered markdown body. */
 import React, {
+  memo,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -30,7 +31,7 @@ import {
   Plus,
   X
 } from 'lucide-react'
-import type { Components } from 'react-markdown'
+import type { Components, Options as ReactMarkdownOptions } from 'react-markdown'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useAppStore } from '@/store'
@@ -327,6 +328,53 @@ const markdownPreviewSanitizeSchema = {
     th: [...(defaultSchema.attributes?.th ?? []), 'align']
   }
 }
+
+// Why: react-markdown's <Markdown> has no internal memoization — it rebuilds the whole
+// unified remark→rehype pipeline and re-parses the document on EVERY render. These plugin
+// lists are fully static, so hoist them to module scope; a fresh array identity per render
+// would otherwise defeat the memoized body below.
+type MarkdownPluginList = NonNullable<ReactMarkdownOptions['remarkPlugins']>
+const MARKDOWN_REMARK_PLUGINS: MarkdownPluginList = [
+  remarkGfm,
+  remarkBreaks,
+  remarkFrontmatter,
+  remarkMath,
+  remarkMarkdownDocLinks
+]
+// Why: sanitize raw HTML before KaTeX/highlight expand it, so their generated markup needn't be whitelisted in the schema.
+const MARKDOWN_REHYPE_PLUGINS: MarkdownPluginList = [
+  rehypeRaw,
+  [rehypeSanitize, markdownPreviewSanitizeSchema],
+  rehypeSlug,
+  rehypeHighlight,
+  rehypeKatex
+]
+
+// Why: render the body through a memoized wrapper so the expensive pipeline only re-runs when
+// the rendered content or the components map changes. Find state (query/match index) and
+// body-unrelated toolbar re-renders touch neither prop, so keystrokes in Find no longer
+// re-parse+re-highlight the whole doc. (Inline-annotation/review state — attentionReviewCommentId,
+// copiedReviewNoteId, activeAnnotationBlockKey — deliberately rebuilds `components`, so those
+// re-renders still re-run the pipeline; that's required to update the live annotation markup.)
+const MarkdownBody = memo(function MarkdownBody({
+  content,
+  components
+}: {
+  content: string
+  components: Components
+}) {
+  return (
+    <Markdown
+      components={components}
+      // Why: react-markdown filters file:// after sanitize; click handlers need the target to authorize and open it.
+      urlTransform={markdownPreviewUrlTransform}
+      remarkPlugins={MARKDOWN_REMARK_PLUGINS}
+      rehypePlugins={MARKDOWN_REHYPE_PLUGINS}
+    >
+      {content}
+    </Markdown>
+  )
+})
 
 function parseLineTarget(hash: string): { line: number; column?: number } | null {
   if (!hash) {
@@ -1947,28 +1995,7 @@ export default function MarkdownPreview({
               </pre>
             </div>
           ) : null}
-          <Markdown
-            components={components}
-            // Why: react-markdown filters file:// after sanitize; click handlers need the target to authorize and open it.
-            urlTransform={markdownPreviewUrlTransform}
-            remarkPlugins={[
-              remarkGfm,
-              remarkBreaks,
-              remarkFrontmatter,
-              remarkMath,
-              remarkMarkdownDocLinks
-            ]}
-            // Why: sanitize raw HTML before KaTeX/highlight expand it, so their generated markup needn't be whitelisted in the schema.
-            rehypePlugins={[
-              rehypeRaw,
-              [rehypeSanitize, markdownPreviewSanitizeSchema],
-              rehypeSlug,
-              rehypeHighlight,
-              rehypeKatex
-            ]}
-          >
-            {renderedContent}
-          </Markdown>
+          <MarkdownBody content={renderedContent} components={components} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What

`react-markdown`'s `<Markdown>` has **no internal memoization**: every render rebuilds the whole `unified` remark→rehype→highlight→katex processor and re-parses the document (react-markdown v10 `lib/index.js` runs `createProcessor` + `parse` + `runSync` per render). `MarkdownPreview` re-renders on internal state that doesn't affect the rendered output — most visibly, **every keystroke in Find** (query / match-index state) — so a large doc with code blocks + math re-ran the full parse + syntax-highlight + KaTeX pass on each keypress, making Find laggy.

This:
- hoists the two fully-static plugin arrays to module scope (a fresh array identity per render would defeat the memo), and
- renders the body through a `React.memo`'d `MarkdownBody` keyed on `content` + `components`.

The pipeline now re-runs only when the rendered content or the `components` map actually changes. The `components` map was already memoized, so its identity is stable across Find/body-unrelated re-renders. (Inline-annotation/review state deliberately rebuilds `components` and thus still re-runs the pipeline — required to keep the live annotation markup correct.)

## ELI5

Every time you typed a letter in the preview's Find box, Orca re-cooked the entire markdown document from scratch — re-parsing it, re-syntax-highlighting every code block, re-rendering every math formula — just to draw a search highlight that doesn't change the document at all. On a big doc that made Find stutter. Now the cooked document is remembered and only re-cooked when the document actually changes, so Find (and other unrelated UI blips) are smooth.

## Proof of zero regression

- Pure memoization + hoisting static arrays; no output change. The `components` memo and its deps are untouched, so inline annotation cards / review-note highlights stay live (they intentionally rebuild `components`).
- `renderedContent` is primitive string state; `Object.is` compares by value, so equal text safely skips and any real content change re-renders — no stale preview.
- `MarkdownBody` adds no host DOM node and stays the same child under the `translate="no"` `bodyRef` container, so the OS-page-translation crash guard (#8678) and the Find CSS-Custom-Highlight painting (which reads `bodyRef`) are unaffected — in fact the body DOM is now *more* stable during search.
- **106 existing MarkdownPreview tests pass.** Independent adversarial review (frontier model) additionally ran the full configured **web typecheck (clean)** and **Vitest suite (33,840 tests pass)** with the change present, and found no regression (only a comment-accuracy nit, now fixed).

## Proof of perf improvement

The triage confirmed by reading `node_modules/react-markdown/lib/index.js` that the sync `Markdown()` has no memoization and rebuilds the processor + re-parses on every render. With the memoized body, Find keystrokes (and review-pulse/store re-renders that don't touch `content`/`components`) no longer trigger that O(document-size) parse + highlight + KaTeX pass — each avoided pass is the full pipeline over the whole document. The win scales with document size and the number of code/math blocks.

Made with [Orca](https://github.com/stablyai/orca) 🐋
