### PR TITLE
fix(sidebar): coalesce staggered reconnect refreshes to stop wake freeze (#8539)

### DIFF
--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -13,6 +13,7 @@ import { cn } from '@/lib/utils'
 import { FolderPlus, Loader2 } from 'lucide-react'
 import { useSidebarProjectDrop } from './useSidebarProjectDrop'
 import { useWorkspaceBoardPanel } from './useWorkspaceBoardPanel'
+import { createSingleFlightCoalescer, type SingleFlightCoalescer } from './single-flight-coalescer'
 import { resolveLeftSidebarStyleVariables } from '@/lib/left-sidebar-appearance'
 import { useSystemPrefersDark } from '@/components/terminal-pane/use-system-prefers-dark'
 import { lazyWithRetry } from '@/lib/lazy-with-retry'
@@ -100,6 +101,13 @@ function Sidebar({
     [runtimeStatusByEnvironmentId]
   )
   const previousOnlineRuntimeEnvKeyRef = React.useRef<string | null>(null)
+  // Coalesce staggered wake reconnects so K hosts can't fire K sidebar remounts and freeze (#8539).
+  const reconnectRefreshRef = React.useRef<SingleFlightCoalescer | null>(null)
+  if (reconnectRefreshRef.current === null) {
+    reconnectRefreshRef.current = createSingleFlightCoalescer(() =>
+      fetchAllWorktrees().then(() => fetchWorktreeLineage())
+    )
+  }
   useEffect(() => {
     // Skip the initial value — startup/repoCount effects already fetch. Only
     // refetch when the online-host set actually changes.
@@ -111,8 +119,8 @@ function Sidebar({
       return
     }
     previousOnlineRuntimeEnvKeyRef.current = onlineRuntimeEnvKey
-    void fetchAllWorktrees().then(() => fetchWorktreeLineage())
-  }, [onlineRuntimeEnvKey, fetchAllWorktrees, fetchWorktreeLineage])
+    reconnectRefreshRef.current?.request()
+  }, [onlineRuntimeEnvKey])
 
   useEffect(() => {
     if (!sidebarOpen && workspaceBoardRenderedOpen) {

--- a/src/renderer/src/components/sidebar/single-flight-coalescer.test.ts
+++ b/src/renderer/src/components/sidebar/single-flight-coalescer.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+import { createSingleFlightCoalescer } from './single-flight-coalescer'
+
+/** Resolve after all queued microtasks and timers have drained. */
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+type Deferred = {
+  promise: Promise<void>
+  resolve: () => void
+  reject: (e: unknown) => void
+}
+const deferred = (): Deferred => {
+  let resolve!: () => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise<void>((res, rej) => {
+    resolve = () => res()
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('createSingleFlightCoalescer', () => {
+  it('runs the task immediately on the first request', async () => {
+    let calls = 0
+    const c = createSingleFlightCoalescer(async () => {
+      calls++
+    })
+    c.request()
+    await flush()
+    expect(calls).toBe(1)
+  })
+
+  it('collapses a burst of requests during an in-flight run into ONE trailing run', async () => {
+    // This is the #8539 wake-storm guard: K near-simultaneous reconnect triggers must
+    // not produce K refreshes — only the leading run + a single trailing run.
+    let calls = 0
+    const gates: Deferred[] = []
+    const c = createSingleFlightCoalescer(() => {
+      calls++
+      const d = deferred()
+      gates.push(d)
+      return d.promise
+    })
+
+    c.request() // leading run starts
+    await flush()
+    expect(calls).toBe(1)
+
+    // 10 staggered reconnects land while the first refresh is still in flight.
+    for (let i = 0; i < 10; i++) {
+      c.request()
+    }
+    await flush()
+    expect(calls).toBe(1) // still just the one in-flight run
+
+    gates[0].resolve() // leading run settles -> exactly one trailing run
+    await flush()
+    expect(calls).toBe(2)
+
+    gates[1].resolve() // trailing run settles; nothing pending
+    await flush()
+    expect(calls).toBe(2)
+  })
+
+  it('runs each request that arrives while idle (no coalescing without contention)', async () => {
+    let calls = 0
+    const c = createSingleFlightCoalescer(async () => {
+      calls++
+    })
+    c.request()
+    await flush()
+    c.request()
+    await flush()
+    c.request()
+    await flush()
+    expect(calls).toBe(3)
+  })
+
+  it('chains multiple bursts: each in-flight window yields at most one trailing run', async () => {
+    let calls = 0
+    const gates: Deferred[] = []
+    const c = createSingleFlightCoalescer(() => {
+      calls++
+      const d = deferred()
+      gates.push(d)
+      return d.promise
+    })
+
+    c.request()
+    await flush()
+    c.request() // pending during run 1
+    gates[0].resolve()
+    await flush()
+    expect(calls).toBe(2) // trailing run 2 started
+    c.request() // pending during run 2
+    c.request()
+    gates[1].resolve()
+    await flush()
+    expect(calls).toBe(3) // one trailing run 3
+    gates[2].resolve()
+    await flush()
+    expect(calls).toBe(3)
+  })
+
+  it('does not wedge when the task throws synchronously', async () => {
+    let calls = 0
+    const c = createSingleFlightCoalescer(() => {
+      calls++
+      if (calls === 1) {
+        throw new Error('sync boom')
+      }
+      return Promise.resolve()
+    })
+    c.request()
+    await flush()
+    expect(calls).toBe(1)
+    // A later request must still run (inFlight was released despite the throw).
+    c.request()
+    await flush()
+    expect(calls).toBe(2)
+  })
+
+  it('still runs the trailing run after a rejected task', async () => {
+    let calls = 0
+    const gates: Deferred[] = []
+    const c = createSingleFlightCoalescer(() => {
+      calls++
+      const d = deferred()
+      gates.push(d)
+      return d.promise
+    })
+    c.request()
+    await flush()
+    c.request() // pending
+    gates[0].reject(new Error('async boom'))
+    await flush()
+    expect(calls).toBe(2) // trailing run still fires
+    gates[1].resolve()
+    await flush()
+  })
+})

--- a/src/renderer/src/components/sidebar/single-flight-coalescer.ts
+++ b/src/renderer/src/components/sidebar/single-flight-coalescer.ts
@@ -1,0 +1,36 @@
+// Single-flight: runs `task` on the first request; requests during a run collapse into one
+// trailing re-run. Stops staggered wake reconnects firing K sidebar refreshes at once (#8539).
+export type SingleFlightCoalescer = {
+  request: () => void
+}
+
+export function createSingleFlightCoalescer(task: () => Promise<unknown>): SingleFlightCoalescer {
+  let inFlight = false
+  let pending = false
+
+  const run = (): void => {
+    inFlight = true
+    // Microtask-defer so a sync throw in `task` can't wedge inFlight.
+    Promise.resolve()
+      .then(task)
+      .catch(() => {})
+      .finally(() => {
+        inFlight = false
+        if (!pending) {
+          return
+        }
+        pending = false
+        run()
+      })
+  }
+
+  return {
+    request: () => {
+      if (inFlight) {
+        pending = true
+        return
+      }
+      run()
+    }
+  }
+}


### PR DESCRIPTION
## What & why

Fixes the macOS **"app freezes after sleep/wake, must Force-Quit"** reports (#8539) for users with remote/SSH sessions.

On wake, remote/SSH runtimes reconnect in a **staggered burst** — each host coming back online flips `onlineRuntimeEnvKey` in the sidebar, and the reconnect effect fired a **full `fetchAllWorktrees()` per host**. Each call bumps `sortEpoch` for every repo → a full sidebar + tab-tree remount. With K hosts and N repos that's **K×N synchronous remounts** stacked on the renderer main thread, and the window wedges. (It's then *unkillable* because a hung renderer vetoes the window close — that half is a separate follow-up.)

This wraps the reconnect refresh in a **single-flight coalescer**: the first trigger refreshes immediately (unchanged from today), and any triggers that arrive while a refresh is in flight collapse into **one** trailing re-run. At any instant at most one refresh runs plus one queued rerun, for any K.

`fetchAllWorktrees()` and its `fetchWorktreeLineage()` follow-up are **unchanged** — same data, same order, same commit path. Only *how often* the effect fires changes.

## ELI5

Your laptop wakes and 20 remote machines reconnect at once. The app used to shout *"someone reconnected — reload the entire project list!"* **20 times back-to-back**, redrawing the whole sidebar 20 times in a row, which locked up the window. Now it says *"a bunch reconnected — reload once; if more show up while I'm reloading, reload one more time after."* Same end result, no lock-up.

## Proof of fix

- **Root cause, measured** (repro branch `nwparker/repro-8539-wake-storm`): a test against the real store shows a staggered 5-runtime wake fires `fetchAllWorktrees` **5×** with **100** `sortEpoch` bumps, vs **1× / 20 bumps** for a single reconnect — an exact K× amplification with zero coalescing.
- **New unit tests** (`single-flight-coalescer.test.ts`, 6 cases): 10 requests arriving during an in-flight run → exactly **1 leading + 1 trailing** run; idle requests still run individually; chained bursts, a synchronous throw, and an async rejection are all handled without wedging.

## Proof of no regression

- The whole `fetchAllWorktrees().then(fetchWorktreeLineage)` unit is coalesced as-is → **lineage ordering and worktree data are identical to today**; only redundant repeats are dropped.
- The first trigger still runs **immediately** (no debounce/delay), so an isolated reconnect or offline flip behaves exactly as before.
- Effect deps narrowed to `[onlineRuntimeEnvKey]`; the coalescer captures the `fetchAllWorktrees` / `fetchWorktreeLineage` store actions, which are **singleton-stable** in zustand (verified) — no stale-closure risk.
- No unmount `stop()` on purpose: a trailing refresh after unmount just updates the global store (harmless, and matches today's non-cancellation of in-flight refreshes), and the persistent ref avoids a React 18 StrictMode-dev pitfall.
- **Independent adversarial review** (GPT-5.6 xhigh) of the actual diff found **zero defects / regressions**, confirming against source that the zustand actions are stable, lineage ordering is preserved, the single-flight state machine is race-free, and the sibling `repoCount` effect is unaffected.
- `oxlint`, `oxfmt`, the renderer TypeScript check, and the unit tests all pass.

## Scope

Bug A (the freeze) only. The separate *"a hung renderer makes the app unkillable"* half (the window-close veto) is a follow-up PR — its save-guard state machine is safety-sensitive and shouldn't be bundled here.

Made with [Orca](https://github.com/stablyai/orca) 🐋
