### PR TITLE
perf(main): park worktree metadata pollers while the window is hidden

### DIFF
--- a/src/main/ipc/worktree-base-directory-poller.test.ts
+++ b/src/main/ipc/worktree-base-directory-poller.test.ts
@@ -3,8 +3,10 @@ import { mkdtemp, mkdir, realpath, rm, stat, utimes, writeFile } from 'node:fs/p
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
+  createWorktreePollerWindowVisibility,
   startWorktreeBaseDirectoryPoller,
-  type WorktreeBasePollEvent
+  type WorktreeBasePollEvent,
+  type WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
 import type {
   WorktreeBaseRepoWatchConfig,
@@ -12,6 +14,37 @@ import type {
 } from './worktree-base-directory-event-filter'
 
 const POLL_MS = 25
+
+type VisibilityHarness = {
+  source: WorktreePollerWindowVisibility
+  hide: () => void
+  show: () => void
+}
+
+function createVisibilityHarness(initiallyVisible = true): VisibilityHarness {
+  let visible = initiallyVisible
+  let listener: (() => void) | null = null
+  return {
+    source: {
+      isWindowVisible: () => visible,
+      onWindowBecameVisible: (nextListener) => {
+        listener = nextListener
+        return () => {
+          if (listener === nextListener) {
+            listener = null
+          }
+        }
+      }
+    },
+    hide: () => {
+      visible = false
+    },
+    show: () => {
+      visible = true
+      listener?.()
+    }
+  }
+}
 
 function makeTarget(
   kind: 'base' | 'git-common',
@@ -169,6 +202,95 @@ describe('worktree base directory poller', () => {
       )
     )
     expect(fullScans.length).toBeGreaterThan(0)
+  })
+
+  it('parks base scans while hidden and losslessly detects changes on resume', async () => {
+    const root = await makeRoot()
+    const visibility = createVisibilityHarness()
+    const received: WorktreeBasePollEvent[][] = []
+    const fullScans: number[] = []
+    const target = makeTarget('base', root)
+    const poller = await startWorktreeBaseDirectoryPoller(
+      target,
+      () => target.repos,
+      (events) => received.push(events),
+      {
+        pollIntervalMs: POLL_MS,
+        visibility: visibility.source,
+        onFullScan: () => fullScans.push(Date.now())
+      }
+    )
+    cleanups.push(() => poller.unsubscribe())
+
+    visibility.hide()
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
+    const worktree = join(root, 'added-while-hidden')
+    await mkdir(worktree)
+    await writeFile(join(worktree, '.git'), 'gitdir: elsewhere')
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
+
+    expect(received.flat()).toHaveLength(0)
+    expect(fullScans).toHaveLength(0)
+
+    visibility.show()
+    expect(fullScans).toHaveLength(1)
+    await waitForEvents(received, (flat) =>
+      flat.some((event) => event.type === 'create' && event.path === join(worktree, '.git'))
+    )
+  })
+
+  it('keeps polling without a main window', async () => {
+    const root = await makeRoot()
+    const received: WorktreeBasePollEvent[][] = []
+    const target = makeTarget('base', root)
+    const visibility = createWorktreePollerWindowVisibility(() => null)
+    const poller = await startWorktreeBaseDirectoryPoller(
+      target,
+      () => target.repos,
+      (events) => received.push(events),
+      { pollIntervalMs: POLL_MS, visibility }
+    )
+    cleanups.push(() => poller.unsubscribe())
+
+    const worktree = join(root, 'headless-add')
+    await mkdir(worktree)
+    await writeFile(join(worktree, '.git'), 'gitdir: elsewhere')
+
+    await waitForEvents(received, (flat) =>
+      flat.some((event) => event.type === 'create' && event.path === join(worktree, '.git'))
+    )
+    expect(visibility.isWindowVisible()).toBe(true)
+  })
+
+  it('treats a destroyed window as absent instead of parking forever', () => {
+    const visibility = createWorktreePollerWindowVisibility(() => ({ isDestroyed: () => true }))
+    expect(visibility.isWindowVisible()).toBe(true)
+  })
+
+  it('keeps polling a live window that has never been shown (E2E headless)', () => {
+    // ORCA_E2E_HEADLESS keeps a live BrowserWindow that is never shown; no show/restore
+    // signal is coming to resume a parked poller, so a never-shown window must keep polling.
+    const visibility = createWorktreePollerWindowVisibility(() => ({
+      isDestroyed: () => false,
+      isVisible: () => false,
+      isMinimized: () => false
+    }))
+    expect(visibility.isWindowVisible()).toBe(true)
+    expect(visibility.isWindowVisible()).toBe(true)
+  })
+
+  it('parks only after the window has been shown at least once', () => {
+    let visible = true
+    const visibility = createWorktreePollerWindowVisibility(() => ({
+      isDestroyed: () => false,
+      isVisible: () => visible,
+      isMinimized: () => false
+    }))
+    // Shown at least once: a later reveal will fire the visibility signal to resume.
+    expect(visibility.isWindowVisible()).toBe(true)
+    // Now hidden — a previously-shown window parks (its show/restore will resume it).
+    visible = false
+    expect(visibility.isWindowVisible()).toBe(false)
   })
 
   it('reports git-common entry creates, allowlisted leaf updates, and removals via polling', async () => {
@@ -333,6 +455,42 @@ describe('worktree base directory poller', () => {
     await waitForEvents(received, (flat) =>
       flat.some((event) => event.type === 'update' && event.path === headFile)
     )
+  })
+
+  it('detects a primary HEAD move immediately after resuming', async () => {
+    const commonDir = await makeRoot()
+    const headFile = join(commonDir, 'HEAD')
+    await writeFile(headFile, 'ref: refs/heads/main')
+    const visibility = createVisibilityHarness()
+    const received: WorktreeBasePollEvent[][] = []
+    const fullScans: number[] = []
+    const target = makeTarget('git-common', commonDir)
+    const poller = await startWorktreeBaseDirectoryPoller(
+      target,
+      () => target.repos,
+      (events) => received.push(events),
+      {
+        pollIntervalMs: POLL_MS,
+        platform: 'linux',
+        visibility: visibility.source,
+        onFullScan: () => fullScans.push(Date.now())
+      }
+    )
+    cleanups.push(() => poller.unsubscribe())
+
+    visibility.hide()
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
+    await writeFile(headFile, 'ref: refs/heads/feature')
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
+
+    expect(received.flat()).toHaveLength(0)
+    expect(fullScans).toHaveLength(0)
+
+    visibility.show()
+    await waitForEvents(received, (flat) =>
+      flat.some((event) => event.type === 'update' && event.path === headFile)
+    )
+    expect(fullScans).toHaveLength(1)
   })
 
   it('emits deletes for all known worktrees when the root vanishes', async () => {

--- a/src/main/ipc/worktree-base-directory-poller.ts
+++ b/src/main/ipc/worktree-base-directory-poller.ts
@@ -1,6 +1,7 @@
 import { readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+import { isMainWindowVisible, onMainWindowBecameVisible } from '../window/main-window-visibility'
 import type {
   WorktreeBaseRepoWatchConfig,
   WorktreeBaseWatchTarget
@@ -11,9 +12,53 @@ export type WorktreeBasePollEvent = { type: 'create' | 'update' | 'delete'; path
 
 export type WorktreeBaseSubscription = { unsubscribe: () => Promise<void> }
 
+export type WorktreePollerWindowVisibility = {
+  isWindowVisible: () => boolean
+  onWindowBecameVisible: (listener: () => void) => () => void
+}
+
+type WorktreePollerWindow = {
+  isDestroyed: () => boolean
+  isVisible?: () => boolean
+  isMinimized?: () => boolean
+}
+
+const alwaysVisible: WorktreePollerWindowVisibility = {
+  isWindowVisible: () => true,
+  onWindowBecameVisible: () => () => {}
+}
+
+export function createWorktreePollerWindowVisibility(
+  getWindow: () => WorktreePollerWindow | null
+): WorktreePollerWindowVisibility {
+  // Why: only park a window that has actually been shown and is now hidden. A window
+  // that has NEVER been shown is either headless (ORCA_E2E_HEADLESS keeps a live but
+  // never-shown BrowserWindow) or still starting up — no show/restore signal is coming
+  // to resume it, so parking it would starve worktree freshness forever. Treat
+  // never-shown as visible and keep polling; only start parking once we've observed the
+  // window visible at least once. null/destroyed (serve/headless, macOS window-recreation
+  // gap) stay always-visible so a torn-down window never permanently parks the poller.
+  let hasBeenVisible = false
+  return {
+    isWindowVisible: () => {
+      const window = getWindow()
+      if (window === null || window.isDestroyed()) {
+        return true
+      }
+      if (isMainWindowVisible(window)) {
+        hasBeenVisible = true
+        return true
+      }
+      return !hasBeenVisible
+    },
+    onWindowBecameVisible: onMainWindowBecameVisible
+  }
+}
+
 export type WorktreeBasePollerOptions = {
   pollIntervalMs?: number
   platform?: NodeJS.Platform
+  visibility?: WorktreePollerWindowVisibility
   /** Test hook: called whenever a full snapshot scan runs (vs. a gated skip). */
   onFullScan?: () => void
 }
@@ -145,6 +190,7 @@ async function startBasePoller(
   getRepos: () => ReadonlyMap<string, WorktreeBaseRepoWatchConfig>,
   onEvents: (events: WorktreeBasePollEvent[]) => void,
   pollIntervalMs: number,
+  visibility: WorktreePollerWindowVisibility,
   onFullScan?: () => void
 ): Promise<WorktreeBaseSubscription> {
   let disposed = false
@@ -152,6 +198,8 @@ async function startBasePoller(
   let tickCount = 0
   let snapshot = await snapshotBase(target.path, getRepos())
   let gateSignatures = await Promise.all(snapshot.gateDirs.map(dirSignature))
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let parkedWhileHidden = false
   // dir → tick when first seen without a `.git` marker
   const pendingMarkers = new Map<string, number>()
   for (const [dir, marker] of snapshot.markers) {
@@ -201,9 +249,9 @@ async function startBasePoller(
     }
   }
 
-  const tick = async (): Promise<void> => {
+  const poll = async (forceFullScan = false): Promise<void> => {
     tickCount++
-    if (tickCount % WORKTREE_BASE_BACKSTOP_TICKS === 0) {
+    if (forceFullScan || tickCount % WORKTREE_BASE_BACKSTOP_TICKS === 0) {
       await fullScan()
       return
     }
@@ -222,25 +270,52 @@ async function startBasePoller(
     }
   }
 
-  const timer = setInterval(() => {
-    if (disposed || ticking) {
+  const tick = async (forceFullScan = false): Promise<void> => {
+    timer = null
+    if (disposed) {
+      return
+    }
+    if (!visibility.isWindowVisible()) {
+      parkedWhileHidden = true
+      return
+    }
+    if (ticking) {
       return
     }
     ticking = true
-    void tick()
-      .catch(() => {
-        // Transient fs error: keep the previous snapshot and retry next tick.
-      })
-      .finally(() => {
-        ticking = false
-      })
-  }, pollIntervalMs)
+    try {
+      await poll(forceFullScan)
+    } catch {
+      // Transient fs error: keep the previous snapshot and retry next tick.
+    } finally {
+      ticking = false
+    }
+    if (!disposed) {
+      timer = setTimeout(() => void tick(), pollIntervalMs)
+      timer.unref?.()
+    }
+  }
+
+  const unsubscribeVisibility = visibility.onWindowBecameVisible(() => {
+    if (disposed || !parkedWhileHidden) {
+      return
+    }
+    parkedWhileHidden = false
+    // Why: the ordinary dir-signature gate can miss same-granule changes made
+    // while hidden; resume must diff a fresh full snapshot against the baseline.
+    void tick(true)
+  })
+
+  timer = setTimeout(() => void tick(), pollIntervalMs)
   timer.unref?.()
 
   return {
     unsubscribe: async () => {
       disposed = true
-      clearInterval(timer)
+      if (timer) {
+        clearTimeout(timer)
+      }
+      unsubscribeVisibility()
     }
   }
 }
@@ -256,8 +331,16 @@ export async function startWorktreeBaseDirectoryPoller(
 ): Promise<WorktreeBaseSubscription> {
   const pollIntervalMs = options.pollIntervalMs ?? WORKTREE_BASE_POLL_INTERVAL_MS
   const platform = options.platform ?? process.platform
+  const visibility = options.visibility ?? alwaysVisible
   if (target.kind === 'git-common') {
-    return startGitCommonWatch(target, onEvents, pollIntervalMs, platform, options.onFullScan)
+    return startGitCommonWatch(
+      target,
+      onEvents,
+      pollIntervalMs,
+      platform,
+      visibility,
+      options.onFullScan
+    )
   }
-  return startBasePoller(target, getRepos, onEvents, pollIntervalMs, options.onFullScan)
+  return startBasePoller(target, getRepos, onEvents, pollIntervalMs, visibility, options.onFullScan)
 }

--- a/src/main/ipc/worktree-base-directory-poller.ts
+++ b/src/main/ipc/worktree-base-directory-poller.ts
@@ -283,6 +283,9 @@ async function startBasePoller(
       return
     }
     ticking = true
+    // Why: measure from tick start so the cadence is start-to-start (like the old setInterval), not
+    // gap-after-completion — otherwise each visible refresh lands a full scan-duration late every tick.
+    const startedAt = Date.now()
     try {
       await poll(forceFullScan)
     } catch {
@@ -291,7 +294,8 @@ async function startBasePoller(
       ticking = false
     }
     if (!disposed) {
-      timer = setTimeout(() => void tick(), pollIntervalMs)
+      const nextDelay = Math.max(0, pollIntervalMs - (Date.now() - startedAt))
+      timer = setTimeout(() => void tick(), nextDelay)
       timer.unref?.()
     }
   }

--- a/src/main/ipc/worktree-base-directory-poller.ts
+++ b/src/main/ipc/worktree-base-directory-poller.ts
@@ -294,7 +294,13 @@ async function startBasePoller(
       ticking = false
     }
     if (!disposed) {
-      const nextDelay = Math.max(0, pollIntervalMs - (Date.now() - startedAt))
+      // Why: clamp to [0, pollIntervalMs]. Date.now() is not monotonic — a backward wall-clock jump (NTP) would
+      // otherwise make elapsed negative and push the next tick out by the adjustment (suppressing refreshes for
+      // minutes); the upper clamp caps the wait at one interval, the lower clamp keeps a long scan from going negative.
+      const nextDelay = Math.max(
+        0,
+        Math.min(pollIntervalMs, pollIntervalMs - (Date.now() - startedAt))
+      )
       timer = setTimeout(() => void tick(), nextDelay)
       timer.unref?.()
     }

--- a/src/main/ipc/worktree-base-directory-watcher.test.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.test.ts
@@ -10,6 +10,10 @@ vi.mock('fs/promises', () => ({
 }))
 
 vi.mock('./worktree-base-directory-poller', () => ({
+  createWorktreePollerWindowVisibility: vi.fn(() => ({
+    isWindowVisible: () => true,
+    onWindowBecameVisible: () => () => {}
+  })),
   startWorktreeBaseDirectoryPoller: vi.fn()
 }))
 

--- a/src/main/ipc/worktree-base-directory-watcher.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.ts
@@ -17,7 +17,10 @@ import {
   buildWorktreeBaseDirectoryWatchTargets,
   clearWorktreeBaseDirectoryWatchTargetWarnings
 } from './worktree-base-directory-watch-targets'
-import { startWorktreeBaseDirectoryPoller } from './worktree-base-directory-poller'
+import {
+  createWorktreePollerWindowVisibility,
+  startWorktreeBaseDirectoryPoller
+} from './worktree-base-directory-poller'
 
 type ActiveWatch = WorktreeBaseWatchTarget & {
   mainWindow: BrowserWindow
@@ -192,10 +195,14 @@ async function subscribeTarget(
     () => (activeWatches.get(target.key) ?? activeWatch)?.repos ?? target.repos,
     (events) => {
       const currentWatch = activeWatches.get(target.key) ?? activeWatch
-      if (!currentWatch || currentWatch.disposed) {
-        return
+      if (currentWatch && !currentWatch.disposed) {
+        handleLocalWatchEvents(currentWatch, null, events)
       }
-      handleLocalWatchEvents(currentWatch, null, events)
+    },
+    {
+      visibility: createWorktreePollerWindowVisibility(
+        () => (activeWatches.get(target.key) ?? activeWatch)?.mainWindow ?? null
+      )
     }
   )
   activeWatch = createActiveWatch(target, mainWindow, subscription)

--- a/src/main/ipc/worktree-base-directory-watcher.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.ts
@@ -61,9 +61,8 @@ function scheduleNotification(watch: ActiveWatch, changes: PendingNotificationIn
   for (const repoId of changes.headIdentityRepoIds ?? []) {
     watch.pendingHeadIdentityRepoIds.add(repoId)
   }
-  if (watch.notifyTimer) {
-    clearTimeout(watch.notifyTimer)
-  }
+  // clearTimeout tolerates null (no-op), so no guard needed before rescheduling.
+  clearTimeout(watch.notifyTimer ?? undefined)
   watch.notifyTimer = setTimeout(() => {
     watch.notifyTimer = null
     if (watch.disposed || watch.mainWindow.isDestroyed()) {
@@ -248,9 +247,7 @@ async function removeWatch(key: string): Promise<void> {
   }
   activeWatches.delete(key)
   watch.disposed = true
-  if (watch.notifyTimer) {
-    clearTimeout(watch.notifyTimer)
-  }
+  clearTimeout(watch.notifyTimer ?? undefined)
   clearPendingRepoIds(watch)
   await watch.subscription.unsubscribe().catch((error) => {
     console.warn(`[worktree-base-watcher] failed to unwatch ${watch.path}:`, error)

--- a/src/main/ipc/worktree-git-common-polling.ts
+++ b/src/main/ipc/worktree-git-common-polling.ts
@@ -2,7 +2,8 @@ import { readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import type {
   WorktreeBasePollEvent,
-  WorktreeBaseSubscription
+  WorktreeBaseSubscription,
+  WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
 
 // Shared with the darwin primary-metadata poll so the platforms cannot drift
@@ -228,6 +229,7 @@ export async function startGitCommonPolling(
   commonDirPath: string,
   onEvents: (events: WorktreeBasePollEvent[]) => void,
   pollIntervalMs: number,
+  visibility: WorktreePollerWindowVisibility,
   onFullScan?: () => void,
   includePrimary = true
 ): Promise<WorktreeBaseSubscription> {
@@ -235,39 +237,71 @@ export async function startGitCommonPolling(
   let ticking = false
   let tickCount = 0
   let snapshot = await snapshotGitCommon(commonDirPath, undefined, includePrimary)
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let parkedWhileHidden = false
 
-  const timer = setInterval(() => {
-    if (disposed || ticking) {
+  const tick = async (forceIndexRead = false): Promise<void> => {
+    timer = null
+    if (disposed) {
+      return
+    }
+    if (!visibility.isWindowVisible()) {
+      parkedWhileHidden = true
+      return
+    }
+    if (ticking) {
       return
     }
     ticking = true
     tickCount++
-    const forceIndexRead = tickCount % INDEX_BACKSTOP_TICKS === 0
+    const shouldForceIndexRead = forceIndexRead || tickCount % INDEX_BACKSTOP_TICKS === 0
     onFullScan?.()
-    void snapshotGitCommon(commonDirPath, snapshot, includePrimary, forceIndexRead)
-      .then((next) => {
-        if (disposed) {
-          return
-        }
-        const events = diffGitCommon(commonDirPath, snapshot, next)
-        snapshot = next
-        if (events.length > 0) {
-          onEvents(events)
-        }
-      })
-      .catch(() => {
-        // Transient fs error: keep the previous snapshot and retry next tick.
-      })
-      .finally(() => {
-        ticking = false
-      })
-  }, pollIntervalMs)
+    try {
+      const next = await snapshotGitCommon(
+        commonDirPath,
+        snapshot,
+        includePrimary,
+        shouldForceIndexRead
+      )
+      if (disposed) {
+        return
+      }
+      const events = diffGitCommon(commonDirPath, snapshot, next)
+      snapshot = next
+      if (events.length > 0) {
+        onEvents(events)
+      }
+    } catch {
+      // Transient fs error: keep the previous snapshot and retry next tick.
+    } finally {
+      ticking = false
+    }
+    if (!disposed) {
+      timer = setTimeout(() => void tick(), pollIntervalMs)
+      timer.unref?.()
+    }
+  }
+
+  const unsubscribeVisibility = visibility.onWindowBecameVisible(() => {
+    if (disposed || !parkedWhileHidden) {
+      return
+    }
+    parkedWhileHidden = false
+    // Why: a linked index can change without its parent dir signature moving;
+    // force the leaf read when diffing the retained pre-hide snapshot.
+    void tick(true)
+  })
+
+  timer = setTimeout(() => void tick(), pollIntervalMs)
   timer.unref?.()
 
   return {
     unsubscribe: async () => {
       disposed = true
-      clearInterval(timer)
+      if (timer) {
+        clearTimeout(timer)
+      }
+      unsubscribeVisibility()
     }
   }
 }

--- a/src/main/ipc/worktree-git-common-polling.ts
+++ b/src/main/ipc/worktree-git-common-polling.ts
@@ -280,7 +280,13 @@ export async function startGitCommonPolling(
       ticking = false
     }
     if (!disposed) {
-      const nextDelay = Math.max(0, pollIntervalMs - (Date.now() - startedAt))
+      // Why: clamp to [0, pollIntervalMs]. Date.now() is not monotonic — a backward wall-clock jump (NTP) would
+      // otherwise make elapsed negative and push the next tick out by the adjustment (suppressing refreshes for
+      // minutes); the upper clamp caps the wait at one interval, the lower clamp keeps a long scan from going negative.
+      const nextDelay = Math.max(
+        0,
+        Math.min(pollIntervalMs, pollIntervalMs - (Date.now() - startedAt))
+      )
       timer = setTimeout(() => void tick(), nextDelay)
       timer.unref?.()
     }

--- a/src/main/ipc/worktree-git-common-polling.ts
+++ b/src/main/ipc/worktree-git-common-polling.ts
@@ -253,6 +253,9 @@ export async function startGitCommonPolling(
       return
     }
     ticking = true
+    // Why: measure from tick start so cadence is start-to-start, not gap-after-completion (which would
+    // land each visible refresh a full scan-duration late every tick).
+    const startedAt = Date.now()
     tickCount++
     const shouldForceIndexRead = forceIndexRead || tickCount % INDEX_BACKSTOP_TICKS === 0
     onFullScan?.()
@@ -277,7 +280,8 @@ export async function startGitCommonPolling(
       ticking = false
     }
     if (!disposed) {
-      timer = setTimeout(() => void tick(), pollIntervalMs)
+      const nextDelay = Math.max(0, pollIntervalMs - (Date.now() - startedAt))
+      timer = setTimeout(() => void tick(), nextDelay)
       timer.unref?.()
     }
   }

--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { mkdtemp, mkdir, realpath, rm } from 'node:fs/promises'
+import { mkdtemp, mkdir, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { subscribeViaWatcherProcess } from './parcel-watcher-process'
@@ -8,7 +8,10 @@ import type {
   WatcherProcessHooks
 } from './parcel-watcher-process-subscription'
 import type { WorktreeBaseWatchTarget } from './worktree-base-directory-event-filter'
-import type { WorktreeBasePollEvent } from './worktree-base-directory-poller'
+import type {
+  WorktreeBasePollEvent,
+  WorktreePollerWindowVisibility
+} from './worktree-base-directory-poller'
 import { startGitCommonWatch } from './worktree-git-common-watch'
 
 vi.mock('./parcel-watcher-process', () => ({
@@ -16,6 +19,40 @@ vi.mock('./parcel-watcher-process', () => ({
 }))
 
 const POLL_MS = 25
+
+const alwaysVisible: WorktreePollerWindowVisibility = {
+  isWindowVisible: () => true,
+  onWindowBecameVisible: () => () => {}
+}
+
+function createVisibilityHarness(): {
+  source: WorktreePollerWindowVisibility
+  hide: () => void
+  show: () => void
+} {
+  let visible = true
+  let listener: (() => void) | null = null
+  return {
+    source: {
+      isWindowVisible: () => visible,
+      onWindowBecameVisible: (nextListener) => {
+        listener = nextListener
+        return () => {
+          if (listener === nextListener) {
+            listener = null
+          }
+        }
+      }
+    },
+    hide: () => {
+      visible = false
+    },
+    show: () => {
+      visible = true
+      listener?.()
+    }
+  }
+}
 
 type ChildSubscription = {
   dir: string
@@ -67,7 +104,8 @@ describe('worktree git-common narrow watch (darwin)', () => {
       makeTarget(commonDir),
       (events) => received.push(events),
       POLL_MS,
-      'darwin'
+      'darwin',
+      alwaysVisible
     )
     cleanups.push(() => watch.unsubscribe())
   }
@@ -167,6 +205,42 @@ describe('worktree git-common narrow watch (darwin)', () => {
     })
   })
 
+  it('keeps the native stream live while the primary poll is parked', async () => {
+    installSubscribeMock()
+    const commonDir = await makeCommonDir(true)
+    const headFile = join(commonDir, 'HEAD')
+    await writeFile(headFile, 'ref: refs/heads/main')
+    const visibility = createVisibilityHarness()
+    const received: WorktreeBasePollEvent[][] = []
+    const fullScans: number[] = []
+    const watch = await startGitCommonWatch(
+      makeTarget(commonDir),
+      (events) => received.push(events),
+      POLL_MS,
+      'darwin',
+      visibility.source,
+      () => fullScans.push(Date.now())
+    )
+    cleanups.push(() => watch.unsubscribe())
+
+    visibility.hide()
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
+    await writeFile(headFile, 'ref: refs/heads/feature')
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
+
+    expect(fullScans).toHaveLength(0)
+    const entryPath = join(commonDir, 'worktrees', 'native-while-hidden')
+    childSubscriptions[0].callback(null, [{ type: 'create', path: entryPath }])
+    expect(received.flat()).toContainEqual({ type: 'create', path: entryPath })
+    expect(childSubscriptions[0].unsubscribe).not.toHaveBeenCalled()
+
+    visibility.show()
+    expect(fullScans).toHaveLength(1)
+    await vi.waitFor(() => {
+      expect(received.flat()).toContainEqual({ type: 'update', path: headFile })
+    })
+  })
+
   it('stops forwarding events and unsubscribes the child on dispose', async () => {
     installSubscribeMock()
     const commonDir = await makeCommonDir(true)
@@ -175,7 +249,8 @@ describe('worktree git-common narrow watch (darwin)', () => {
       makeTarget(commonDir),
       (events) => received.push(events),
       POLL_MS,
-      'darwin'
+      'darwin',
+      alwaysVisible
     )
     await watch.unsubscribe()
     expect(childSubscriptions[0].unsubscribe).toHaveBeenCalledTimes(1)

--- a/src/main/ipc/worktree-git-common-watch.ts
+++ b/src/main/ipc/worktree-git-common-watch.ts
@@ -4,7 +4,8 @@ import { subscribeViaWatcherProcess } from './parcel-watcher-process'
 import type { WorktreeBaseWatchTarget } from './worktree-base-directory-event-filter'
 import type {
   WorktreeBasePollEvent,
-  WorktreeBaseSubscription
+  WorktreeBaseSubscription,
+  WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
 import {
   PRIMARY_CHECKOUT_METADATA_FILES,
@@ -69,42 +70,68 @@ async function startSnapshotDiffPoller(
   takeSnapshot: () => Promise<Map<string, number>>,
   onEvents: (events: WorktreeBasePollEvent[]) => void,
   pollIntervalMs: number,
+  visibility: WorktreePollerWindowVisibility,
   onFullScan?: () => void
 ): Promise<WorktreeBaseSubscription> {
   let disposed = false
   let ticking = false
   let snapshot = await takeSnapshot()
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let parkedWhileHidden = false
 
-  const timer = setInterval(() => {
-    if (disposed || ticking) {
+  const tick = async (): Promise<void> => {
+    timer = null
+    if (disposed) {
+      return
+    }
+    if (!visibility.isWindowVisible()) {
+      parkedWhileHidden = true
+      return
+    }
+    if (ticking) {
       return
     }
     ticking = true
     onFullScan?.()
-    void takeSnapshot()
-      .then((next) => {
-        if (disposed) {
-          return
-        }
-        const events = diffMtimeMap(snapshot, next)
-        snapshot = next
-        if (events.length > 0) {
-          onEvents(events)
-        }
-      })
-      .catch(() => {
-        // Transient fs error: keep the previous snapshot and retry next tick.
-      })
-      .finally(() => {
-        ticking = false
-      })
-  }, pollIntervalMs)
+    try {
+      const next = await takeSnapshot()
+      if (disposed) {
+        return
+      }
+      const events = diffMtimeMap(snapshot, next)
+      snapshot = next
+      if (events.length > 0) {
+        onEvents(events)
+      }
+    } catch {
+      // Transient fs error: keep the previous snapshot and retry next tick.
+    } finally {
+      ticking = false
+    }
+    if (!disposed) {
+      timer = setTimeout(() => void tick(), pollIntervalMs)
+      timer.unref?.()
+    }
+  }
+
+  const unsubscribeVisibility = visibility.onWindowBecameVisible(() => {
+    if (disposed || !parkedWhileHidden) {
+      return
+    }
+    parkedWhileHidden = false
+    void tick()
+  })
+
+  timer = setTimeout(() => void tick(), pollIntervalMs)
   timer.unref?.()
 
   return {
     unsubscribe: async () => {
       disposed = true
-      clearInterval(timer)
+      if (timer) {
+        clearTimeout(timer)
+      }
+      unsubscribeVisibility()
     }
   }
 }
@@ -246,6 +273,7 @@ export async function startGitCommonWatch(
   onEvents: (events: WorktreeBasePollEvent[]) => void,
   pollIntervalMs: number,
   platform: NodeJS.Platform,
+  visibility: WorktreePollerWindowVisibility,
   onFullScan?: () => void
 ): Promise<WorktreeBaseSubscription> {
   if (platform === 'darwin') {
@@ -255,6 +283,7 @@ export async function startGitCommonWatch(
         () => snapshotPrimaryCheckoutMetadata(target.path),
         onEvents,
         pollIntervalMs,
+        visibility,
         onFullScan
       )
     ])
@@ -264,5 +293,5 @@ export async function startGitCommonWatch(
       }
     }
   }
-  return startGitCommonPolling(target.path, onEvents, pollIntervalMs, onFullScan)
+  return startGitCommonPolling(target.path, onEvents, pollIntervalMs, visibility, onFullScan)
 }

--- a/src/main/ipc/worktree-git-common-watch.ts
+++ b/src/main/ipc/worktree-git-common-watch.ts
@@ -112,7 +112,13 @@ async function startSnapshotDiffPoller(
       ticking = false
     }
     if (!disposed) {
-      const nextDelay = Math.max(0, pollIntervalMs - (Date.now() - startedAt))
+      // Why: clamp to [0, pollIntervalMs]. Date.now() is not monotonic — a backward wall-clock jump (NTP) would
+      // otherwise make elapsed negative and push the next tick out by the adjustment (suppressing refreshes for
+      // minutes); the upper clamp caps the wait at one interval, the lower clamp keeps a long scan from going negative.
+      const nextDelay = Math.max(
+        0,
+        Math.min(pollIntervalMs, pollIntervalMs - (Date.now() - startedAt))
+      )
       timer = setTimeout(() => void tick(), nextDelay)
       timer.unref?.()
     }

--- a/src/main/ipc/worktree-git-common-watch.ts
+++ b/src/main/ipc/worktree-git-common-watch.ts
@@ -92,6 +92,9 @@ async function startSnapshotDiffPoller(
       return
     }
     ticking = true
+    // Why: measure from tick start so cadence is start-to-start, not gap-after-completion (which would
+    // land each visible refresh a full scan-duration late every tick).
+    const startedAt = Date.now()
     onFullScan?.()
     try {
       const next = await takeSnapshot()
@@ -109,7 +112,8 @@ async function startSnapshotDiffPoller(
       ticking = false
     }
     if (!disposed) {
-      timer = setTimeout(() => void tick(), pollIntervalMs)
+      const nextDelay = Math.max(0, pollIntervalMs - (Date.now() - startedAt))
+      timer = setTimeout(() => void tick(), nextDelay)
       timer.unref?.()
     }
   }


### PR DESCRIPTION
## What

The per-repo worktree metadata pollers ran 24/7 with **no window-visibility gate**. At ~20 repos on macOS that's ~50 `fs.stat` syscalls/sec continuously, even while the Orca window is hidden/minimized — pure idle-battery drain. This parks the poll **timers** while the window is hidden and resumes **losslessly** when it becomes visible again.

- New injected `WorktreePollerWindowVisibility` (mirrors the shipped `ssh-port-scanner` park/resume pattern). Production adapter follows each `ActiveWatch.mainWindow`; a `null`/destroyed window is treated as **always visible** so headless/`orca serve` and the macOS window-recreation gap never park.
- Converted the three poll loops (base poller, Windows/Linux git-common polling, darwin primary-checkout metadata polling) from `setInterval` to a one-shot `setTimeout` chain that checks visibility **before** the stat fan-out: if hidden, it parks (`parkedWhileHidden = true`, no reschedule) without touching the retained snapshot. `onWindowBecameVisible` resumes with an **immediate** tick that diffs a fresh snapshot against the retained pre-hide snapshot (base forces a full scan; git-common forces the linked-index leaf read), so anything changed while hidden surfaces on reveal.
- The darwin native `worktrees/` fsevents watcher, its teardown/re-arm lifecycle, and the directory-existence poll stay **always-on** (push-based, ~0 idle cost; parking it would risk the #8732 teardown heap-corruption race).

## ELI5

When Orca was hidden, it still poked your disk ~50 times a second per second to notice git changes across all your repos — for windows you couldn't even see, draining battery. Now it stops poking while hidden and, the moment you come back, does one fresh check that catches anything that changed while it was away. The always-on native file watcher (which is basically free) keeps running so nothing is missed on macOS.

## Proof of zero regression

- **Lossless resume**: parking never resets the retained snapshot; resume forces an immediate full/leaf-read diff against it, so a `git worktree add/remove`, commit, or HEAD move made while hidden is detected on reveal (covered by tests).
- **Headless/serve exemption**: `null`/destroyed window ⇒ always visible ⇒ polls normally, so a windowless host is never starved (tested).
- **Native watcher untouched**: only the poll timers are gated; the darwin native subscription and re-arm path are never parked/resubscribed (tested to keep flowing while hidden).
- **Same-granule detection preserved**: git-common resume forces the linked-index read; `logs/HEAD` is still stat'd directly every tick.
- Tests: extended `worktree-base-directory-poller.test.ts`, `worktree-git-common-watch.test.ts`, `worktree-base-directory-watcher.test.ts` — **45/45 pass** (verified in main worktree, not just the author's). New cases: no scans while hidden, hidden add/HEAD-move detected on reveal, null-window & destroyed-window exemptions, native watcher stays subscribed while hidden. `pnpm typecheck:node`: clean. `oxlint` + max-lines ratchet: pass.

## Proof of perf improvement

While the window is hidden/minimized this parks ~50 local `fs.stat`/sec at 20 repos (5 primary-metadata stats per 2s per repo, plus the Windows/Linux readdir + per-linked-worktree structural fan-out). The tests assert the poll body (`onFullScan`/snapshot) does **not** run while hidden — directly proving the syscalls stop — and that a reveal triggers exactly one immediate catch-up scan. Pure background/idle battery win; zero cost while visible, and the always-on native fsevents watch means no missed events on macOS.

Made with [Orca](https://github.com/stablyai/orca) 🐋
