### PR TITLE
fix(tasks): prefer upstream for PR list when source preference is auto (#9851)

### DIFF
--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -1110,7 +1110,7 @@ async function resolvePrWorkItemSource(
     getGitHubApiRepositoryForRemote(repoPath, 'upstream', connectionId, localGitOptions)
   ])
   const source =
-    preference === 'upstream' ? (upstreamCandidate ?? originCandidate) : originCandidate
+    preference === 'origin' ? originCandidate : (upstreamCandidate ?? originCandidate)
   return { source, originCandidate, upstreamCandidate }
 }
 


### PR DESCRIPTION
# fix(tasks): prefer upstream for PR list when source preference is auto

## Summary

Fixes fork workflows where open upstream PRs never appeared in the Tasks list until the user manually clicked the "U" source selector.

## ELI5

When your project is a fork, its open pull requests live on the original ("upstream") repo. The Tasks list used to only look at your fork, so those PRs stayed hidden until you switched the source by hand. Now they show up automatically.

## Root cause & fix

`resolvePrWorkItemSource` in `src/main/github/client.ts` used only `originCandidate` for the `auto` and `undefined` preferences, so in a fork with an `upstream` remote — where open PRs actually live — no upstream PRs were ever queried. The one-line ternary was flipped so that only an explicit `origin` preference returns origin; every other case now resolves `upstreamCandidate ?? originCandidate`. This aligns the PR side with the existing issue-side semantics (`getIssueGitHubApiRepository`, "upstream first, then origin"). For non-fork repos the upstream probe returns `null`, so the fallback to origin keeps behavior unchanged.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23. Clean rebase onto `origin/main` (base `8a23618310`, head `cc8961051c`); single changed file, one-line change.

- Branch (fix present) — `client-issue-source.test.ts`:

```
npx vitest run --config config/vitest.config.ts src/main/github/client-issue-source.test.ts
-> Test Files 1 passed, Tests 28 passed
```

- Regression guard: `client-work-items.test.ts`, `client-work-items-query-paging.test.ts`, `client.test.ts` -> Test Files 3 passed, Tests 146 passed.
- Honesty note: the existing suite still passes with the fix reverted, so no automated test captures this specific bug. The fix is confirmed by code inspection, not by a failing-on-revert assertion. proven=false.
- Lint clean: `npx oxlint src/main/github/client.ts` -> no diagnostics.

## Trade-offs

None — pure fix. No new I/O; the same two parallel remote probes run as before.

## Regression risk

Low. Only the `auto`/`undefined` branch changes; the explicit `origin` and `upstream` branches are byte-identical in behavior. Non-fork repos have no upstream candidate (probe returns `null`), so they fall through to origin exactly as before. GitLab uses its own `resolveMergeRequestSource` and is untouched. Residual: no test asserts the corrected upstream path, so the guard against future regression is code review rather than CI.

_Original fix by @fsdwen. Validated, rebased, and reviewed via automated bug-bash triage; original one-line fix design preserved with no changes added._
