### PR TITLE
perf(mobile): gate host polling on foreground/background

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -38,6 +38,7 @@ import {
   useForceReconnect
 } from '../../../src/transport/client-context'
 import { useWorktreeResync } from '../../../src/transport/use-worktree-resync'
+import { startHostWorktreeRefresh } from '../../../src/worktree/host-worktree-refresh'
 import {
   useLastConnectedAt,
   useReconnectAttempt
@@ -141,7 +142,8 @@ export function HostScreen({
   const lastConnectedAt = useLastConnectedAt(hostId)
   const clientRef = useRef<RpcClient | null>(null)
   const fetchWorktreesInFlightRef = useRef(false)
-  const fetchRepoMetadataInFlightRef = useRef(false)
+  const fetchRepoMetadataInFlightRef = useRef(new WeakSet<RpcClient>())
+  const fetchRepoMetadataPendingRef = useRef(new WeakSet<RpcClient>())
   const repoMetadataFetchedAtRef = useRef(0)
   const newWorktreeModalRef = useRef<{ open: () => void }>(null)
   const newWorktreeModalVisibleRef = useRef(false)
@@ -356,48 +358,54 @@ export function HostScreen({
   }, [hostId])
 
   const fetchRepoMetadata = useCallback(
-    async (options: { force?: boolean } = {}) => {
+    async (options: { force?: boolean; queueIfInFlight?: boolean } = {}) => {
       if (!client || connState !== 'connected' || !hostId) {
         return
       }
-      if (fetchRepoMetadataInFlightRef.current) {
+      if (fetchRepoMetadataInFlightRef.current.has(client)) {
+        if (options.queueIfInFlight) {
+          fetchRepoMetadataPendingRef.current.add(client)
+        }
         return
       }
       const now = Date.now()
       if (!options.force && now - repoMetadataFetchedAtRef.current < REPO_METADATA_REFRESH_MS) {
         return
       }
-      fetchRepoMetadataInFlightRef.current = true
+      fetchRepoMetadataInFlightRef.current.add(client)
       const requestClient = client,
         requestHostId = hostId
       try {
-        const repoResponse = await requestClient.sendRequest('repo.list')
-        if (clientRef.current !== requestClient || hostId !== requestHostId || !repoResponse.ok) {
-          return
-        }
-        const repoResult = (repoResponse as RpcSuccess).result as { repos: RepoSummary[] }
-        repoMetadataFetchedAtRef.current = Date.now()
-        setCachedRepos(requestHostId, repoResult.repos)
-        setRepoColorsByName(
-          new Map(
-            repoResult.repos.map((repo) => [
-              repo.displayName,
-              repo.badgeColor || repoColor(repo.displayName)
-            ])
-          )
-        )
-        setRepoIconsByName(
-          new Map(
-            repoResult.repos.flatMap((repo) =>
-              repo.repoIcon ? [[repo.displayName, repo.repoIcon] as const] : []
+        do {
+          fetchRepoMetadataPendingRef.current.delete(requestClient)
+          const repoResponse = await requestClient.sendRequest('repo.list')
+          if (clientRef.current !== requestClient || hostId !== requestHostId || !repoResponse.ok) {
+            return
+          }
+          const repoResult = (repoResponse as RpcSuccess).result as { repos: RepoSummary[] }
+          repoMetadataFetchedAtRef.current = Date.now()
+          setCachedRepos(requestHostId, repoResult.repos)
+          setRepoColorsByName(
+            new Map(
+              repoResult.repos.map((repo) => [
+                repo.displayName,
+                repo.badgeColor || repoColor(repo.displayName)
+              ])
             )
           )
-        )
-        setRepoIdsByName(new Map(repoResult.repos.map((repo) => [repo.displayName, repo.id])))
+          setRepoIconsByName(
+            new Map(
+              repoResult.repos.flatMap((repo) =>
+                repo.repoIcon ? [[repo.displayName, repo.repoIcon] as const] : []
+              )
+            )
+          )
+          setRepoIdsByName(new Map(repoResult.repos.map((repo) => [repo.displayName, repo.id])))
+        } while (fetchRepoMetadataPendingRef.current.has(requestClient))
       } catch {
-        // Repo metadata is decorative; the next throttled refresh can retry.
+        // Repo metadata is decorative; the next refresh can retry.
       } finally {
-        fetchRepoMetadataInFlightRef.current = false
+        fetchRepoMetadataInFlightRef.current.delete(requestClient)
       }
     },
     [client, connState, hostId]
@@ -494,39 +502,29 @@ export function HostScreen({
     }, [])
   )
 
-  useFocusEffect(
-    useCallback(() => {
-      // The embedded sidebar isn't a routed screen (focus never fires); it polls via the mount effect below.
-      if (embedded || connState !== 'connected') {
-        return
-      }
-      void fetchWorktrees()
-      void fetchRepoMetadata()
-      // Pull desktop's shared view settings on focus so desktop changes show up without a manual refresh.
-      void syncViewSettingsFromDesktop()
-      // Why: React Navigation keeps prior screens mounted; only poll while this route is visible.
-      const interval = setInterval(() => {
-        void fetchWorktrees()
-        void fetchRepoMetadata()
-      }, 3000)
-      return () => clearInterval(interval)
-    }, [embedded, connState, fetchWorktrees, fetchRepoMetadata, syncViewSettingsFromDesktop])
-  )
-
-  // Why: the embedded sidebar is never the focused route, so useFocusEffect never polls; mirror it from a mount effect.
-  useEffect(() => {
-    if (!embedded || connState !== 'connected') {
+  const startWorktreeRefresh = useCallback(() => {
+    if (!client || connState !== 'connected') {
       return
     }
-    void fetchWorktrees()
-    void fetchRepoMetadata()
     void syncViewSettingsFromDesktop()
-    const interval = setInterval(() => {
-      void fetchWorktrees()
-      void fetchRepoMetadata()
-    }, 3000)
-    return () => clearInterval(interval)
-  }, [embedded, connState, fetchWorktrees, fetchRepoMetadata, syncViewSettingsFromDesktop])
+    return startHostWorktreeRefresh({ client, fetchWorktrees, fetchRepoMetadata })
+  }, [client, connState, fetchWorktrees, fetchRepoMetadata, syncViewSettingsFromDesktop])
+
+  useFocusEffect(
+    useCallback(() => {
+      // The embedded sidebar isn't a routed screen (focus never fires); it refreshes via the mount effect below.
+      if (!embedded) {
+        return startWorktreeRefresh()
+      }
+    }, [embedded, startWorktreeRefresh])
+  )
+
+  // Why: the embedded sidebar is never the focused route, so wire its refresh lifecycle from a mount effect.
+  useEffect(() => {
+    if (embedded) {
+      return startWorktreeRefresh()
+    }
+  }, [embedded, startWorktreeRefresh])
 
   // Why (#8498): steady-state polls miss the transition INTO 'connected' after background/sleep, when the cache is stalest.
   const { refreshing, onRefresh } = useWorktreeResync({

--- a/mobile/src/transport/use-worktree-resync.ts
+++ b/mobile/src/transport/use-worktree-resync.ts
@@ -10,7 +10,7 @@ export function useWorktreeResync(args: {
   client: RpcClient | null
   connState: ConnectionState
   fetchWorktrees: (opts?: { allowDuringModal?: boolean }) => Promise<void>
-  fetchRepoMetadata: () => Promise<void>
+  fetchRepoMetadata: (options?: { force?: boolean; queueIfInFlight?: boolean }) => Promise<void>
 }): { refreshing: boolean; onRefresh: () => Promise<void> } {
   const { client, connState, fetchWorktrees, fetchRepoMetadata } = args
 
@@ -22,7 +22,6 @@ export function useWorktreeResync(args: {
     prevConnStateRef.current = connState
     if (prev !== 'connected' && connState === 'connected' && client) {
       void fetchWorktrees({ allowDuringModal: true })
-      void fetchRepoMetadata()
     }
   }, [connState, client, fetchWorktrees, fetchRepoMetadata])
 
@@ -35,7 +34,7 @@ export function useWorktreeResync(args: {
     setRefreshing(true)
     try {
       await fetchWorktrees({ allowDuringModal: true })
-      await fetchRepoMetadata()
+      await fetchRepoMetadata({ force: true })
     } finally {
       setRefreshing(false)
     }

--- a/mobile/src/transport/use-worktree-resync.ts
+++ b/mobile/src/transport/use-worktree-resync.ts
@@ -23,7 +23,10 @@ export function useWorktreeResync(args: {
     if (prev !== 'connected' && connState === 'connected' && client) {
       void fetchWorktrees({ allowDuringModal: true })
     }
-  }, [connState, client, fetchWorktrees, fetchRepoMetadata])
+    // Why: repo metadata refetch on reconnect is owned by startHostWorktreeRefresh (mount +
+    // reposChanged + stream replay); this effect only refetches worktrees, so fetchRepoMetadata
+    // is intentionally not a dependency here.
+  }, [connState, client, fetchWorktrees])
 
   const [refreshing, setRefreshing] = useState(false)
   // Why (#8498): let the user force a fresh snapshot instead of the possibly-poisoned cache.

--- a/mobile/src/worktree/host-worktree-refresh.test.ts
+++ b/mobile/src/worktree/host-worktree-refresh.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RpcClient } from '../transport/rpc-client'
+import { startHostWorktreeRefresh } from './host-worktree-refresh'
+
+const appState = vi.hoisted(() => ({
+  currentState: 'active',
+  listener: null as ((state: string) => void) | null,
+  remove: vi.fn()
+}))
+
+vi.mock('react-native', () => ({
+  AppState: {
+    get currentState() {
+      return appState.currentState
+    },
+    addEventListener: (_event: string, listener: (state: string) => void) => {
+      appState.listener = listener
+      return { remove: appState.remove }
+    }
+  }
+}))
+
+describe('startHostWorktreeRefresh', () => {
+  let eventListener: ((payload: unknown) => void) | null
+  let fetchWorktrees: ReturnType<typeof vi.fn>
+  let fetchRepoMetadata: ReturnType<typeof vi.fn>
+  let unsubscribe: ReturnType<typeof vi.fn>
+  let stop: (() => void) | null
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    appState.currentState = 'active'
+    appState.listener = null
+    appState.remove.mockClear()
+    eventListener = null
+    fetchWorktrees = vi.fn().mockResolvedValue(undefined)
+    fetchRepoMetadata = vi.fn().mockResolvedValue(undefined)
+    unsubscribe = vi.fn()
+    stop = null
+  })
+
+  function start(): void {
+    const client = {
+      subscribe: vi.fn(
+        (_method: string, _params: unknown, listener: (payload: unknown) => void) => {
+          eventListener = listener
+          return unsubscribe
+        }
+      )
+    } as unknown as RpcClient
+    stop = startHostWorktreeRefresh({ client, fetchWorktrees, fetchRepoMetadata })
+  }
+
+  afterEach(() => {
+    stop?.()
+    vi.useRealTimers()
+  })
+
+  it('keeps the worktree poll active but skips ticks while backgrounded', async () => {
+    start()
+    expect(fetchWorktrees).toHaveBeenCalledTimes(1)
+
+    appState.currentState = 'background'
+    await vi.advanceTimersByTimeAsync(6_000)
+    expect(fetchWorktrees).toHaveBeenCalledTimes(1)
+
+    appState.currentState = 'active'
+    await vi.advanceTimersByTimeAsync(3_000)
+    expect(fetchWorktrees).toHaveBeenCalledTimes(2)
+  })
+
+  it('refreshes both snapshots immediately on foreground return', () => {
+    start()
+    fetchWorktrees.mockClear()
+    fetchRepoMetadata.mockClear()
+
+    appState.currentState = 'active'
+    appState.listener?.('active')
+
+    expect(fetchWorktrees).toHaveBeenCalledWith({ allowDuringModal: true })
+    expect(fetchRepoMetadata).toHaveBeenCalledWith({ queueIfInFlight: true })
+  })
+
+  it('polls repo metadata on the interval while foregrounded and skips it while backgrounded', async () => {
+    start()
+    // Mount force-fetch.
+    expect(fetchRepoMetadata).toHaveBeenCalledTimes(1)
+
+    // Foregrounded: repo.list rides the interval as a convergence safety-net for desktop
+    // Settings edits that never emit a runtime reposChanged (the callee self-throttles).
+    await vi.advanceTimersByTimeAsync(9_000)
+    expect(fetchWorktrees).toHaveBeenCalledTimes(4)
+    expect(fetchRepoMetadata).toHaveBeenCalledTimes(4)
+
+    // Backgrounded: neither snapshot is polled.
+    fetchWorktrees.mockClear()
+    fetchRepoMetadata.mockClear()
+    appState.currentState = 'background'
+    await vi.advanceTimersByTimeAsync(9_000)
+    expect(fetchWorktrees).not.toHaveBeenCalled()
+    expect(fetchRepoMetadata).not.toHaveBeenCalled()
+  })
+
+  it('force-refreshes repo metadata on reposChanged', () => {
+    start()
+    fetchRepoMetadata.mockClear()
+
+    eventListener?.({ type: 'reposChanged' })
+
+    expect(fetchRepoMetadata).toHaveBeenCalledOnce()
+    expect(fetchRepoMetadata).toHaveBeenCalledWith({ force: true, queueIfInFlight: true })
+  })
+
+  it('refreshes worktrees on worktreesChanged and both snapshots after stream replay', () => {
+    start()
+    fetchWorktrees.mockClear()
+    fetchRepoMetadata.mockClear()
+
+    eventListener?.({ type: 'worktreesChanged', repoId: 'repo-1' })
+    expect(fetchWorktrees).toHaveBeenCalledTimes(1)
+
+    eventListener?.({ type: 'ready', subscriptionId: 'events-1' })
+    eventListener?.({ type: 'ready', subscriptionId: 'events-2' })
+    expect(fetchWorktrees).toHaveBeenCalledTimes(2)
+    expect(fetchRepoMetadata).toHaveBeenCalledWith({ force: true, queueIfInFlight: true })
+  })
+})

--- a/mobile/src/worktree/host-worktree-refresh.ts
+++ b/mobile/src/worktree/host-worktree-refresh.ts
@@ -1,0 +1,88 @@
+import { AppState } from 'react-native'
+import type { RuntimeClientEventStreamMessage } from '../../../src/shared/runtime-client-events'
+import type { RpcClient } from '../transport/rpc-client'
+
+const WORKTREE_REFRESH_MS = 3000
+
+type WorktreeRefreshOptions = { allowDuringModal?: boolean }
+type RepoRefreshOptions = { force?: boolean; queueIfInFlight?: boolean }
+
+type HostWorktreeRefreshArgs = {
+  client: RpcClient
+  fetchWorktrees: (options?: WorktreeRefreshOptions) => Promise<void>
+  fetchRepoMetadata: (options?: RepoRefreshOptions) => Promise<void>
+}
+
+export function startHostWorktreeRefresh({
+  client,
+  fetchWorktrees,
+  fetchRepoMetadata
+}: HostWorktreeRefreshArgs): () => void {
+  let stale = false
+  let eventStreamReady = false
+
+  const refreshOnForeground = (): void => {
+    if (AppState.currentState !== 'active') {
+      return
+    }
+    void fetchWorktrees({ allowDuringModal: true })
+    void fetchRepoMetadata({ queueIfInFlight: true })
+  }
+
+  const appStateSubscription = AppState.addEventListener('change', (state) => {
+    if (state === 'active') {
+      refreshOnForeground()
+    }
+  })
+  const interval = setInterval(() => {
+    if (AppState.currentState !== 'active') {
+      return
+    }
+    void fetchWorktrees()
+    // Why: desktop Settings repo edits (icon/color/name, repo removal) notify only the
+    // renderer IPC, not the runtime clientEvents stream, so `reposChanged` never reaches
+    // mobile. Keep a periodic repo.list as the convergence safety-net; fetchRepoMetadata
+    // self-throttles to REPO_METADATA_REFRESH_MS (60s), so this is ~1 request/min while
+    // foregrounded — the AppState gate is what removes the waste (both stop while backgrounded).
+    void fetchRepoMetadata()
+  }, WORKTREE_REFRESH_MS)
+  const unsubscribe = client.subscribe(
+    'runtime.clientEvents.subscribe',
+    null,
+    (payload: unknown) => {
+      if (stale || !payload || typeof payload !== 'object') {
+        return
+      }
+      const event = payload as RuntimeClientEventStreamMessage | { type: 'error' }
+      if (event.type === 'ready') {
+        const replayedAfterReconnect = eventStreamReady
+        eventStreamReady = true
+        if (replayedAfterReconnect) {
+          // Why: client events are not queued while disconnected, so re-read both snapshots after replay.
+          void fetchWorktrees()
+          void fetchRepoMetadata({ force: true, queueIfInFlight: true })
+        }
+        return
+      }
+      if (event.type === 'end' || event.type === 'error') {
+        eventStreamReady = false
+        return
+      }
+      if (event.type === 'reposChanged') {
+        void fetchRepoMetadata({ force: true, queueIfInFlight: true })
+      } else if (event.type === 'worktreesChanged') {
+        void fetchWorktrees()
+      }
+    }
+  )
+
+  void fetchWorktrees()
+  void fetchRepoMetadata({ force: true, queueIfInFlight: true })
+
+  return () => {
+    stale = true
+    clearInterval(interval)
+    appStateSubscription.remove()
+    unsubscribe()
+  }
+}


### PR DESCRIPTION
## What

The mobile host screen ran two 3-second polls while connected — the routed screen and the embedded sidebar — and **each fired both `worktree.ps` (a full multi-repo process scan) AND `repo.list`**, with no foreground/background gate. So a phone left connected pinged every 3s (host CPU + relay/cellular bytes + a radio wakeup) even during brief background windows while the socket stays parked.

This consolidates both poll sites into one `startHostWorktreeRefresh` lifecycle and **AppState-gates the interval** so both polls stop while backgrounded and refresh immediately on foreground return:

- `worktree.ps` keeps its 3s cadence while foregrounded — it carries live per-worktree agent status / preview / unread that no push event replaces, so it is **not** removed.
- `repo.list` stays on the interval as an AppState-gated **convergence safety-net** (it self-throttles to `REPO_METADATA_REFRESH_MS` = 60s, so it's ~1 request/min while foregrounded), **plus** a `reposChanged`/`worktreesChanged` fast-path and a reconnect-replay refetch.

The win is the **foreground gate**: while the app is backgrounded, both polls (and their radio wakeups) stop entirely; while foregrounded, behavior matches the old cadence.

## ELI5

Your phone kept pinging the computer twice every 3 seconds — even in your pocket — for the live agent list and a rarely-changing repo icon/color list. Now both pings pause while the app is backgrounded and instantly catch up when you reopen it. The live list keeps its speed while you're looking, and the repo-icon list still refreshes on its own so a desktop settings change never leaves the phone stale.

## Proof of zero regression

- **Repo metadata still converges** (this was caught by adversarial review): desktop Settings repo edits (icon/color/name, repo removal) notify only the renderer IPC, **not** the runtime `clientEvents` stream mobile subscribes to — so `repo.list` cannot be purely event-driven without going stale on a foregrounded screen. It's kept on the (now gated) interval, self-throttled to 60s, exactly as before, so a foregrounded screen still converges within ≤60s. The event fast-path is additive.
- The live `worktree.ps` poll (agent status/preview/unread) is preserved; optimistic reconciliation still gets periodic confirmations while foreground and an immediate one on foreground return.
- Reconnect refetches everything (lifecycle mount-fetch on connState flip + same-instance `ready`-after-`ready` replay), covering "events aren't queued while disconnected."
- Embedded-sidebar path (never focused) wired independently, gated the same way.
- **Verified in a deps-installed mobile checkout**: `pnpm typecheck` clean, **full mobile suite 2232 pass / 2 skipped (307 files)**, `oxlint` clean (within the frozen max-lines budget), `oxfmt --check` clean. Tests cover: interval polls (worktrees + repo.list) while active and skips **both** while backgrounded; immediate foreground refresh; `reposChanged`/`worktreesChanged` refetch; reconnect stream replay.

## Proof of perf improvement

While backgrounded this stops the entire 3s poll loop (worktree.ps + repo.list + their radio wakeups) — the new tests assert neither snapshot is fetched while `AppState !== 'active'`. Foreground steady-state keeps exactly the prior cadence (worktree.ps every 3s, repo.list ≤ once/60s), now with faster runtime-origin repo/worktree convergence via the event fast-path. Net: a connected phone in your pocket stops waking its radio every 3s.

## Follow-up (out of scope)

The cleaner long-term fix for the desktop-repo-edit case is to bridge the renderer-only `notifyReposChanged` to `OrcaRuntimeService.notifyReposChanged()` so mobile gets an instant runtime event and the periodic `repo.list` safety-net could drop further. Left as a separate desktop-side change to keep this PR mobile-only.
