### PR TITLE
fix(orchestration): ask keepalive, transition-only preamble heartbeats, CLI stdout drain

### DIFF
--- a/src/main/runtime/orchestration/__snapshots__/preamble.test.ts.snap
+++ b/src/main/runtime/orchestration/__snapshots__/preamble.test.ts.snap
@@ -29,11 +29,12 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
     --files-modified "path/a,path/b" \\
     --report-path "<optional: path to the full artifact>"
 
-  # BEHAVIOR RULE: send a heartbeat every 5 minutes
-  # while actively working on the task. The coordinator uses this to
-  # distinguish "still thinking" from "hung / crashed." Skip heartbeats only
+  # BEHAVIOR RULE: send heartbeat/status only on meaningful phase transitions
+  # (investigating|implementing|reviewing|waiting), not on a timer. A healthy
+  # long wait is silent — do not emit periodic "alive" ticks. Skip heartbeats
   # while blocked inside \`check --wait\` or \`ask\` — those calls are
-  # themselves liveness signals.
+  # themselves liveness signals. Coordinators distinguish hung workers via
+  # lifecycle mail, terminal liveness sweeps, and those blocking waits.
   #
   # Include BOTH taskId and dispatchId in the payload: the coordinator
   # attributes the heartbeat to the specific dispatch context, not just

--- a/src/main/runtime/orchestration/preamble.test.ts
+++ b/src/main/runtime/orchestration/preamble.test.ts
@@ -74,11 +74,13 @@ describe('buildDispatchPreamble', () => {
     }
   )
 
-  it('includes heartbeat CLI block with taskId and dispatchId and 5-minute cadence', () => {
+  it('includes heartbeat CLI block with taskId and dispatchId and transition-only policy', () => {
     const result = buildDispatchPreamble(baseParams())
     expect(result).toContain('--type heartbeat')
     expect(result).toContain('--subject "alive"')
-    expect(result).toMatch(/5 minutes/)
+    expect(result).toMatch(/meaningful phase transitions/)
+    expect(result).toMatch(/not on a timer/)
+    expect(result).not.toMatch(/heartbeat every \d+ minutes/)
     // Both taskId and dispatchId are rendered as structured payload flags
     // (regression guard for §5.3.4 attribution — dispatchId attribution
     // prevents the zombie-heartbeat-masks-hung-retry race).

--- a/src/main/runtime/orchestration/preamble.ts
+++ b/src/main/runtime/orchestration/preamble.ts
@@ -32,17 +32,14 @@ export type PreambleParams = {
   workerKind?: 'prompt-returning-agent' | 'bare-shell'
 }
 
-// Why: 5 minutes is frequent enough that the coordinator's stale-heartbeat
-// check (threshold 10 min) catches a hung worker within one tick, and
-// infrequent enough to avoid inbox spam on long tasks. One constant so
-// cadence tuning is a single-line change (Q1 in DESIGN_DOC_PREAMBLE_FIX.md).
-const HEARTBEAT_INTERVAL_MIN = 5
-
 // Why: the dispatch preamble teaches agents about Orca's CLI commands for
-// structured communication. Behavioral rules (body summary, heartbeat cadence,
+// structured communication. Behavioral rules (body summary, heartbeat policy,
 // no-AskUserQuestion) live as inline comments above the relevant CLI example,
 // not as a separate prose block — LLM readers anchor on examples and skim
 // trailing prose, so rules must land at the point of use.
+// Heartbeat policy is transition-only / silent supervision: timer ticks spam
+// the coordinator inbox and conflict with check --wait / ask liveness. Phase
+// changes remain the only required heartbeat/status surface.
 export function buildDispatchPreamble(params: PreambleParams): string {
   // Why: in dev mode, agents must use orca-dev to connect to the dev runtime's
   // socket. Without this, agents inside the dev Electron app would call the
@@ -81,11 +78,12 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
     --files-modified "path/a,path/b" \\
     --report-path "<optional: path to the full artifact>"
 
-  # BEHAVIOR RULE: send a heartbeat every ${HEARTBEAT_INTERVAL_MIN} minutes
-  # while actively working on the task. The coordinator uses this to
-  # distinguish "still thinking" from "hung / crashed." Skip heartbeats only
+  # BEHAVIOR RULE: send heartbeat/status only on meaningful phase transitions
+  # (investigating|implementing|reviewing|waiting), not on a timer. A healthy
+  # long wait is silent — do not emit periodic "alive" ticks. Skip heartbeats
   # while blocked inside \`check --wait\` or \`ask\` — those calls are
-  # themselves liveness signals.
+  # themselves liveness signals. Coordinators distinguish hung workers via
+  # lifecycle mail, terminal liveness sweeps, and those blocking waits.
   #
   # Include BOTH taskId and dispatchId in the payload: the coordinator
   # attributes the heartbeat to the specific dispatch context, not just

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -3896,6 +3896,50 @@ describe('OrcaRuntimeRpcServer', () => {
       }
     })
 
+    it('emits keepalive frames while orchestration.ask blocks', async () => {
+      const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+      const runtime = new OrcaRuntimeService()
+      const db = new OrchestrationDb(':memory:')
+      runtime.setOrchestrationDb(db)
+      const server = new OrcaRuntimeRpcServer({
+        runtime,
+        userDataPath,
+        keepaliveIntervalMs: 50
+      })
+      await server.start()
+
+      try {
+        const metadata = readRuntimeMetadata(userDataPath)
+        const session = openFramedSession(metadata!.transports[0]!.endpoint, {
+          id: 'req_ask',
+          authToken: metadata!.authToken,
+          method: 'orchestration.ask',
+          params: {
+            to: 'term_coord',
+            from: 'term_worker',
+            question: 'keepalive coverage?',
+            timeoutMs: 300
+          }
+        })
+        await session.done
+
+        const keepalives = session.frames.filter((f) => f._keepalive === true)
+        const terminals = session.frames.filter((f) => f.ok !== undefined)
+        expect(terminals).toHaveLength(1)
+        expect(terminals[0]).toMatchObject({ id: 'req_ask', ok: true })
+        expect(terminals[0]?.result).toMatchObject({ timedOut: true })
+        expect(keepalives.length).toBeGreaterThanOrEqual(3)
+        // Why: ask inserts the gate before waiting; one gate must remain even
+        // when the wait times out — the duplicate-gate failure mode starts
+        // when a closed socket makes the worker retry ask.
+        const gates = db.getInbox(20).filter((m) => m.type === 'decision_gate')
+        expect(gates).toHaveLength(1)
+      } finally {
+        db.close()
+        await server.stop()
+      }
+    })
+
     it('emits keepalive frames while terminal.wait blocks and returns its structured timeout', async () => {
       const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
       const runtime = new OrcaRuntimeService()

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -390,8 +390,13 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
 ])
 
 // Why: single classifier for long-poll requests (handlers that block on an external event), shared by counter/abort/keepalive. See §3.1.
+// orchestration.ask must be included: it inserts a decision_gate then blocks on
+// waitForMessage for up to timeoutMs (default 10 min). Without keepalive, the
+// unix-socket idle timer (30s) destroys the connection, the CLI surfaces
+// "closed the connection before responding", and a worker retry creates a
+// duplicate decision_gate while the runtime/terminal stay healthy.
 function isLongPollRequest(request: RpcRequest): boolean {
-  if (request.method === 'terminal.wait') {
+  if (request.method === 'terminal.wait' || request.method === 'orchestration.ask') {
     return true
   }
   if (request.method === 'orchestration.check') {

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -11,7 +11,7 @@
 import { createServer, createConnection, type Socket, type Server } from 'node:net'
 import { homedir } from 'node:os'
 import { resolve, join } from 'node:path'
-import { unlinkSync, existsSync, statSync } from 'node:fs'
+import { unlinkSync, existsSync, statSync, writeSync } from 'node:fs'
 import {
   RELAY_SENTINEL,
   FrameDecoder,
@@ -241,14 +241,19 @@ async function runOrcaCliMode(sockPath: string, argv: string[]): Promise<void> {
       stderr?: unknown
       exitCode?: unknown
     }
+    // Why: process.exit() after async stdout.write truncates at the OS pipe
+    // buffer (~64KiB) when the consumer is a pipe/coproc that has not drained
+    // yet — large --json payloads (e.g. agent-context) arrive as incomplete
+    // JSON. writeSync flushes before exit; file redirects often masked this.
+    const exitCode = typeof result.exitCode === 'number' ? result.exitCode : 0
     if (typeof result.stdout === 'string' && result.stdout.length > 0) {
-      process.stdout.write(result.stdout)
+      writeSync(process.stdout.fd, result.stdout)
     }
     if (typeof result.stderr === 'string' && result.stderr.length > 0) {
-      process.stderr.write(result.stderr)
+      writeSync(process.stderr.fd, result.stderr)
     }
     sock.destroy()
-    process.exit(typeof result.exitCode === 'number' ? result.exitCode : 0)
+    process.exit(exitCode)
   })
 
   const connectTimeout = setTimeout(() => {


### PR DESCRIPTION
## Summary
- Classify `orchestration.ask` as a long-poll in `isLongPollRequest` so unix-socket keepalives arm during the wait. Without this, the 30s idle timer destroys the socket while the decision_gate is already inserted, the CLI reports `The Orca runtime closed the connection before responding`, and worker retries create duplicate gates (runtime/terminal remain healthy).
- Rewrite the injected dispatch preamble heartbeat rule from a 5-minute timer to transition-only / silent supervision (phase changes only), matching the current global coordinator policy.
- In remote `runOrcaCliMode`, `writeSync` stdout/stderr before `process.exit` so large `--json` payloads are not truncated at the ~64KiB OS pipe buffer for pipe/coproc readers (product bug, not shell-integration framing).

## Provenance (repro host)
- Installed relay: `0.1.0+46db28a33c24` (`~/.orca-remote/relay-0.1.0+46db28a33c24`)
- Upstream HEAD at patch time: `586cf781c`
- Authoritative surfaces: `src/main/runtime/runtime-rpc.ts`, `src/main/runtime/orchestration/preamble.ts`, `src/relay/relay.ts`, `src/cli/runtime/transport.ts` (error string)

## Test plan
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orchestration/preamble.test.ts`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/runtime-rpc.test.ts -t 'orchestration.ask blocks'`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/runtime-rpc.test.ts -t 'keepalive frames while a check'`
- [ ] Manual: `orca orchestration ask` held >30s without answer still receives keepalives / does not emit connection-closed; only one decision_gate row
- [ ] Manual: `orca agent-context --json` piped to a slow/coproc reader yields complete JSON (length >65536)

## Notes
- Do not patch installed `~/.orca-remote` bundles; this PR is the durable upstream repair.
- Until release: workers should `gate-list` / inbox-check before re-asking after a connection-closed error; treat preamble timer heartbeats as superseded by transition-only policy when the coordinator playbook says so.


Made with [Cursor](https://cursor.com)


## ELI5

Long orchestration.ask waits could drop the socket after 30s idle, so the CLI saw a closed connection and workers made duplicate decision gates. Ask is treated as a long-poll with keepalives, and heartbeat rules are quieter.
