### PR TITLE
ci(release-cut): show workflow_dispatch inputs in job summary

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -68,6 +68,10 @@ jobs:
       should_release: ${{ steps.tag.outputs.tag != '' || steps.version.outputs.recovered_tag != '' }}
       latest_published_rc_tag: ${{ steps.publish_drafts.outputs.latest_published_tag }}
     steps:
+      # Surfaces workflow_dispatch inputs as a table in the job summary
+      # (kind, ref, dry_run, version_suffix) so runs are easy to audit.
+      - uses: m-s-abeer/update-gha-summary-with-workflow-inputs@v1
+
       - name: Checkout ref
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- Add `m-s-abeer/update-gha-summary-with-workflow-inputs@v1` as the first step of the Cut Release workflow (same pattern as stablyai/noqa deploy workflows).
- Manual `workflow_dispatch` runs now show a **Workflow Input Parameters** table in the job summary with `kind`, `ref`, `dry_run`, and `version_suffix`.

## Test plan
- [ ] Merge and run **Cut Release** with `dry_run: true`
- [ ] Confirm the job summary includes a parameter table under "Workflow Input Parameters [Branch: …]"