### PR TITLE
fix(worktrees): prevent session purge on inaccessible repositories

### DIFF
--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -22,6 +22,7 @@ const {
   handleMock,
   removeHandlerMock,
   listWorktreesMock,
+  listWorktreesStrictMock,
   parseWorktreeListMock,
   assertWorktreeCleanForRemovalMock,
   addWorktreeMock,
@@ -61,6 +62,7 @@ const {
   handleMock: vi.fn(),
   removeHandlerMock: vi.fn(),
   listWorktreesMock: vi.fn(),
+  listWorktreesStrictMock: vi.fn(),
   parseWorktreeListMock: vi.fn((output: string) =>
     output
       .trim()
@@ -118,7 +120,7 @@ vi.mock('electron', () => ({
 
 vi.mock('../git/worktree', () => ({
   listWorktrees: listWorktreesMock,
-  listWorktreesStrict: listWorktreesMock,
+  listWorktreesStrict: listWorktreesStrictMock,
   parseWorktreeList: parseWorktreeListMock,
   assertWorktreeCleanForRemoval: assertWorktreeCleanForRemovalMock,
   addWorktree: addWorktreeMock,
@@ -311,6 +313,7 @@ describe('registerWorktreeHandlers', () => {
       handleMock,
       removeHandlerMock,
       listWorktreesMock,
+      listWorktreesStrictMock,
       assertWorktreeCleanForRemovalMock,
       addWorktreeMock,
       addSparseWorktreeMock,
@@ -485,6 +488,7 @@ describe('registerWorktreeHandlers', () => {
     )
     ensurePathWithinWorkspaceMock.mockImplementation((targetPath: string) => targetPath)
     listWorktreesMock.mockResolvedValue([])
+    listWorktreesStrictMock.mockImplementation((...args) => listWorktreesMock(...args))
     forceDeleteLocalBranchMock.mockResolvedValue(undefined)
 
     // Why: minimal stub keeps these tests on create-flow semantics; full fetchRemoteWithCache behavior is covered by fetch-remote-cache.test.ts.
@@ -2413,6 +2417,50 @@ describe('registerWorktreeHandlers', () => {
 
     expect(first).toEqual(second)
     expect(listWorktreesMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats Documents permission failures as non-authoritative and retries the scan', async () => {
+    const permissionError = Object.assign(
+      new Error('Unable to read current working directory: Operation not permitted'),
+      { code: 'EPERM' }
+    )
+    listWorktreesStrictMock.mockRejectedValueOnce(permissionError).mockResolvedValueOnce([
+      {
+        path: '/workspace/repo',
+        head: 'main-head',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+
+    const failed = await handlers['worktrees:listDetected'](null, { repoId: 'repo-1' })
+
+    expect(failed).toEqual({
+      repoId: 'repo-1',
+      authoritative: false,
+      source: 'metadata-fallback',
+      worktrees: []
+    })
+    expect(__getDetectedWorktreeScanCacheStatsForTests()).toEqual({
+      cacheSize: 0,
+      inFlightSize: 0
+    })
+
+    const recovered = await handlers['worktrees:listDetected'](null, { repoId: 'repo-1' })
+
+    expect(recovered).toMatchObject({
+      repoId: 'repo-1',
+      authoritative: true,
+      source: 'git',
+      worktrees: [expect.objectContaining({ path: '/workspace/repo' })]
+    })
+    expect(listWorktreesStrictMock).toHaveBeenCalledTimes(2)
+    expect(listWorktreesMock).not.toHaveBeenCalled()
+    expect(__getDetectedWorktreeScanCacheStatsForTests()).toEqual({
+      cacheSize: 1,
+      inFlightSize: 0
+    })
   })
 
   it('coalesces concurrent authoritative detected worktree scans', async () => {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -554,9 +554,12 @@ async function listDetectedGitWorktrees(
     return { gitWorktrees: await inFlight.promise, fresh: false }
   }
 
+  // Why: authoritative detection must preserve Git/filesystem errors; [] means Git proved no worktrees.
   const scan: DetectedWorktreeScan = {
     invalidated: false,
-    promise: listRepoWorktrees(repo, localWorktreeGitOptions)
+    promise: localWorktreeGitOptions.wslDistro
+      ? listGitWorktreesStrict(repo.path, localWorktreeGitOptions)
+      : listGitWorktreesStrict(repo.path)
   }
   detectedWorktreeScanInFlight.set(cacheKey, scan)
   try {


### PR DESCRIPTION
## Summary

- use the throwing Git scanner for authoritative local worktree detection so filesystem and Git failures reach the existing non-authoritative fallback
- leave failed scans out of the detected-worktree cache so a restored permission grant is retried immediately
- add an EPERM regression covering the macOS Documents/TCC failure and recovery path

## Root cause

A LaunchServices-started Orca without Documents access could make git worktree list fail with EPERM. The ordinary scanner converted that failure to an empty array, worktrees:listDetected labeled it authoritative, and renderer reconciliation treated every local worktree as deleted. Preserving the scan error breaks that deletion chain while keeping genuine successful empty scans authoritative.

## Testing

- pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/worktrees.test.ts src/renderer/src/store/slices/store-session-cascades.test.ts (252 tests passed)
- pnpm run typecheck
- pnpm exec oxlint src/main/ipc/worktrees.ts src/main/ipc/worktrees.test.ts
- pnpm exec oxfmt --check src/main/ipc/worktrees.ts src/main/ipc/worktrees.test.ts
- pnpm run check:reliability-gates
- pnpm run check:max-lines-ratchet

Full pnpm run lint reaches a pre-existing switch-exhaustiveness error in the unchanged src/renderer/src/components/skills/skill-freshness-group.tsx:101.