### PR TITLE
feat(shortcuts): Cmd/Ctrl+Shift+N creates a child workspace of the active workspace

### DIFF
--- a/src/main/ipc/worktree-create-lineage.test.ts
+++ b/src/main/ipc/worktree-create-lineage.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+import { recordWorktreeLineageForCreatedWorktree } from './worktree-create-lineage'
+import { folderWorkspaceKey, worktreeWorkspaceKey } from '../../shared/workspace-scope'
+import type { WorktreeLineage } from '../../shared/types'
+
+function makeStore(metaById: Record<string, { instanceId?: string }>) {
+  return {
+    getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+    setWorktreeLineage: vi.fn((_worktreeId: string, lineage: WorktreeLineage) => lineage)
+  }
+}
+
+const CHILD = { id: 'repo::child', instanceId: 'child-instance' }
+
+describe('recordWorktreeLineageForCreatedWorktree', () => {
+  it('records worktree lineage for a worktree-type parent workspace', () => {
+    const store = makeStore({ 'repo::parent': { instanceId: 'parent-instance' } })
+
+    const lineage = recordWorktreeLineageForCreatedWorktree(
+      store,
+      worktreeWorkspaceKey('repo::parent'),
+      CHILD,
+      1234
+    )
+
+    expect(lineage).toEqual({
+      worktreeId: 'repo::child',
+      worktreeInstanceId: 'child-instance',
+      parentWorktreeId: 'repo::parent',
+      parentWorktreeInstanceId: 'parent-instance',
+      origin: 'manual',
+      capture: { source: 'active-workspace', confidence: 'explicit' },
+      createdAt: 1234
+    })
+    expect(store.setWorktreeLineage).toHaveBeenCalledWith('repo::child', lineage)
+  })
+
+  it('records nothing for folder-workspace parents', () => {
+    const store = makeStore({})
+
+    expect(
+      recordWorktreeLineageForCreatedWorktree(store, folderWorkspaceKey('folder-1'), CHILD, 1)
+    ).toBeNull()
+    expect(store.setWorktreeLineage).not.toHaveBeenCalled()
+  })
+
+  it('records nothing without a parent workspace or instance identity', () => {
+    const store = makeStore({ 'repo::parent': {} })
+
+    expect(recordWorktreeLineageForCreatedWorktree(store, undefined, CHILD, 1)).toBeNull()
+    expect(
+      recordWorktreeLineageForCreatedWorktree(
+        store,
+        worktreeWorkspaceKey('repo::parent'),
+        { id: 'repo::child', instanceId: undefined } as never,
+        1
+      )
+    ).toBeNull()
+    // Parent meta exists but has no instance id.
+    expect(
+      recordWorktreeLineageForCreatedWorktree(store, worktreeWorkspaceKey('repo::parent'), CHILD, 1)
+    ).toBeNull()
+    expect(store.setWorktreeLineage).not.toHaveBeenCalled()
+  })
+
+  it('refuses to attach a worktree to itself', () => {
+    const store = makeStore({ 'repo::child': { instanceId: 'child-instance' } })
+
+    expect(
+      recordWorktreeLineageForCreatedWorktree(store, worktreeWorkspaceKey('repo::child'), CHILD, 1)
+    ).toBeNull()
+    expect(store.setWorktreeLineage).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/worktree-create-lineage.ts
+++ b/src/main/ipc/worktree-create-lineage.ts
@@ -1,0 +1,38 @@
+import { parseWorkspaceKey } from '../../shared/workspace-scope'
+import type { CreateWorktreeArgs, Worktree, WorktreeLineage } from '../../shared/types'
+
+type WorktreeLineageStore = {
+  getWorktreeMeta(worktreeId: string): { instanceId?: string } | undefined
+  setWorktreeLineage(worktreeId: string, lineage: WorktreeLineage): WorktreeLineage
+}
+
+// Why: mirrors the runtime create path (recordCreatedWorktreeLineage) for in-app
+// creates — sidebar nesting reads only worktree lineage, so a worktree-type
+// parentWorkspace must land there, not just in workspace lineage.
+export function recordWorktreeLineageForCreatedWorktree(
+  store: WorktreeLineageStore,
+  parentWorkspace: CreateWorktreeArgs['parentWorkspace'],
+  worktree: Pick<Worktree, 'id' | 'instanceId'>,
+  createdAt: number
+): WorktreeLineage | null {
+  if (!parentWorkspace || !worktree.instanceId) {
+    return null
+  }
+  const parentScope = parseWorkspaceKey(parentWorkspace)
+  if (parentScope?.type !== 'worktree' || parentScope.worktreeId === worktree.id) {
+    return null
+  }
+  const parentInstanceId = store.getWorktreeMeta(parentScope.worktreeId)?.instanceId
+  if (!parentInstanceId) {
+    return null
+  }
+  return store.setWorktreeLineage(worktree.id, {
+    worktreeId: worktree.id,
+    worktreeInstanceId: worktree.instanceId,
+    parentWorktreeId: parentScope.worktreeId,
+    parentWorktreeInstanceId: parentInstanceId,
+    origin: 'manual',
+    capture: { source: 'active-workspace', confidence: 'explicit' },
+    createdAt
+  })
+}

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -40,6 +40,7 @@ import { parseGitHubOwnerRepo } from '../github/gh-utils'
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
 import type { RemoteFetchResult, RemoteTrackingBase } from '../runtime/orca-runtime'
 import { getProjectHostSetupWorktreeMeta } from '../../shared/project-host-setup-projection'
+import { recordWorktreeLineageForCreatedWorktree } from './worktree-create-lineage'
 import {
   buildPosixRunnerScript,
   buildWindowsRunnerScript,
@@ -1863,6 +1864,12 @@ export async function createRemoteWorktree(
     return { worktree: mergeWorktree(repo.id, created, meta) }
   })
   const workspaceLineage = recordWorkspaceLineageForCreatedWorktree(store, args, worktree, now)
+  const lineage = recordWorktreeLineageForCreatedWorktree(
+    store,
+    args.parentWorkspace,
+    worktree,
+    now
+  )
 
   // Why: shared/symlink paths are local-only; remote (SSH) support needs a new relay method + auth surface, so configured symlinkPaths are ignored here.
 
@@ -1909,7 +1916,8 @@ export async function createRemoteWorktree(
 
   notifyWorktreesChanged(mainWindow, repo.id)
   return {
-    worktree: { ...worktree, workspaceLineage },
+    worktree: { ...worktree, ...(lineage ? { lineage } : {}), workspaceLineage },
+    ...(lineage ? { lineage } : {}),
     ...(workspaceLineage ? { workspaceLineage } : {}),
     ...(setup ? { setup } : {}),
     ...(defaultTabs ? { defaultTabs } : {}),
@@ -2444,6 +2452,12 @@ export async function createLocalWorktree(
     return { worktree: mergeWorktree(repo.id, created, meta) }
   })
   const workspaceLineage = recordWorkspaceLineageForCreatedWorktree(store, args, worktree, now)
+  const lineage = recordWorktreeLineageForCreatedWorktree(
+    store,
+    args.parentWorkspace,
+    worktree,
+    now
+  )
   // Why: reuse the roots creation already paid for via `git worktree list` so later IPC doesn't lazily rescan and trip macOS privacy prompts.
   registerWorktreeRootsForRepo(store, repo.id, [
     repo.path,
@@ -2513,7 +2527,8 @@ export async function createLocalWorktree(
 
   notifyWorktreesChanged(mainWindow, repo.id)
   return {
-    worktree: { ...worktree, workspaceLineage },
+    worktree: { ...worktree, ...(lineage ? { lineage } : {}), workspaceLineage },
+    ...(lineage ? { lineage } : {}),
     ...(workspaceLineage ? { workspaceLineage } : {}),
     ...(stagedStartup.activationSetup
       ? { setup: stagedStartup.activationSetup }

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -621,6 +621,9 @@ export function createMainWindow(
       case 'openNewWorkspace':
         mainWindow.webContents.send('ui:openNewWorkspace')
         return
+      case 'openNewChildWorkspace':
+        mainWindow.webContents.send('ui:openNewChildWorkspace')
+        return
       case 'deleteCurrentWorkspace':
         mainWindow.webContents.send('ui:deleteCurrentWorkspace')
         return

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2813,6 +2813,7 @@ export type PreloadApi = {
     onOpenQuickOpen: (callback: () => void) => () => void
     onToggleQuickCommandsMenu: (callback: () => void) => () => void
     onOpenNewWorkspace: (callback: () => void) => () => void
+    onOpenNewChildWorkspace: (callback: () => void) => () => void
     onDeleteCurrentWorkspace: (callback: () => void) => () => void
     onOpenWorkspaceBoard: (callback: () => void) => () => void
     onOpenTasks: (callback: () => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3243,6 +3243,11 @@ const api = {
       ipcRenderer.on('ui:openNewWorkspace', listener)
       return () => ipcRenderer.removeListener('ui:openNewWorkspace', listener)
     },
+    onOpenNewChildWorkspace: (callback: () => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent) => callback()
+      ipcRenderer.on('ui:openNewChildWorkspace', listener)
+      return () => ipcRenderer.removeListener('ui:openNewChildWorkspace', listener)
+    },
     onDeleteCurrentWorkspace: (callback: () => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent) => callback()
       ipcRenderer.on('ui:deleteCurrentWorkspace', listener)

--- a/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
@@ -197,6 +197,32 @@ function changeInputValue(input: HTMLInputElement, value: string): void {
 
 let current: { container: HTMLDivElement; root: Root } | null = null
 
+describe('NewWorkspaceComposerCard child workspace parent hint', () => {
+  afterEach(() => {
+    act(() => current?.root.unmount())
+    current?.container.remove()
+    current = null
+  })
+
+  it('shows the parent lineage hint when composing a child workspace', () => {
+    current = renderCard({
+      childWorkspaceParent: { displayName: 'Payments API' }
+    })
+
+    const hint = current.container.querySelector('[data-testid="child-workspace-parent-hint"]')
+    expect(hint).not.toBeNull()
+    expect(hint?.textContent).toContain('Payments API')
+  })
+
+  it('renders no hint without a parent context', () => {
+    current = renderCard()
+
+    expect(
+      current.container.querySelector('[data-testid="child-workspace-parent-hint"]')
+    ).toBeNull()
+  })
+})
+
 describe('NewWorkspaceComposerCard folder task source mode', () => {
   afterEach(() => {
     act(() => current?.root.unmount())

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -12,6 +12,7 @@ import {
   Cloud,
   CornerDownLeft,
   FolderPlus,
+  FolderTree,
   LoaderCircle,
   PlugZap,
   Settings2,
@@ -122,6 +123,8 @@ type NewWorkspaceComposerCardProps = {
   smartNameGitHubSourceContext?: TaskSourceContext | null
   /** Advisory shown under the name field when a fork PR can't accept maintainer pushes. */
   forkPushWarning: string | null
+  /** Parent context when composing a child workspace from the sidebar. */
+  childWorkspaceParent?: { displayName: string } | null
   detectedAgentIds: Set<TuiAgent> | null
   onOpenAgentSettings: () => void
   advancedOpen: boolean
@@ -654,6 +657,7 @@ export default function NewWorkspaceComposerCard({
   onCreateMultipleChange,
   smartNameGitHubSourceContext,
   forkPushWarning,
+  childWorkspaceParent,
   detectedAgentIds,
   onOpenAgentSettings,
   advancedOpen,
@@ -1037,6 +1041,21 @@ export default function NewWorkspaceComposerCard({
             <p className="flex items-start gap-1.5 text-[11px] text-yellow-600 dark:text-yellow-500">
               <AlertTriangle className="mt-0.5 size-3 shrink-0" aria-hidden="true" />
               <span>{forkPushWarning}</span>
+            </p>
+          ) : null}
+          {childWorkspaceParent ? (
+            <p
+              className="flex items-start gap-1.5 text-[11px] text-muted-foreground"
+              data-testid="child-workspace-parent-hint"
+            >
+              <FolderTree className="mt-0.5 size-3 shrink-0" aria-hidden="true" />
+              <span>
+                {translate(
+                  'auto.components.NewWorkspaceComposerCard.childWorkspaceParentHint',
+                  'Created as a child workspace of "{{parent}}".',
+                  { parent: childWorkspaceParent.displayName }
+                )}
+              </span>
             </p>
           ) : null}
           {/* Why (#5181): sits under the branch selection (not Name, which can differ) so reusing the picked branch is an explicit choice. */}

--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -43,6 +43,10 @@ type ComposerModalData = {
   linkedWorkItem?: LinkedWorkItemSummary | null
   taskSourceContext?: TaskSourceContext | null
   initialBaseBranch?: string
+  /** Worktree the created workspace should nest under as a lineage child; its
+   *  branch is the default base when no Start-from source is picked. Set by the
+   *  sidebar's "New Child Workspace" context-menu action. */
+  parentWorktreeId?: string
   initialWorkspaceStatus?: WorkspaceStatus
   /** Telemetry surface that opened the composer. Set by each
    *  `openModal('new-workspace-composer', ...)` site so
@@ -142,6 +146,7 @@ function QuickTabBody({
     initialProjectGroupId: modalData.initialProjectGroupId,
     initialWorkspaceStatus: modalData.initialWorkspaceStatus,
     ...(modalData.initialBaseBranch ? { initialBaseBranch: modalData.initialBaseBranch } : {}),
+    ...(modalData.parentWorktreeId ? { parentWorktreeId: modalData.parentWorktreeId } : {}),
     persistDraft: false,
     onCreated: onClose,
     ...(modalData.telemetrySource ? { telemetrySource: modalData.telemetrySource } : {}),

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
 import {
-  canCreateChildWorkspaceFromContextMenu,
   hasSleepableWorkspaceActivity,
   isContextWorktreeDeletable,
   shouldUseNativeContextMenu,
@@ -169,60 +168,6 @@ describe('parent picker context menu affordance', () => {
     } as HTMLElement
 
     expect(getWorktreeParentPickerAnchor(scope, 'child')).toBe(scope)
-  })
-})
-
-describe('new child workspace context menu affordance', () => {
-  it('offers child creation for git-backed rows with a branch', () => {
-    expect(
-      canCreateChildWorkspaceFromContextMenu({
-        repo: { kind: 'git' },
-        branch: 'feature/api',
-        isFolderWorkspace: false
-      })
-    ).toBe(true)
-    // Legacy repos persisted without a kind are git repos.
-    expect(
-      canCreateChildWorkspaceFromContextMenu({
-        repo: {},
-        branch: 'main',
-        isFolderWorkspace: false
-      })
-    ).toBe(true)
-  })
-
-  it('hides child creation when there is no branch to base the child on', () => {
-    expect(
-      canCreateChildWorkspaceFromContextMenu({
-        repo: { kind: 'git' },
-        branch: '',
-        isFolderWorkspace: false
-      })
-    ).toBe(false)
-  })
-
-  it('hides child creation for folder workspaces and missing projects', () => {
-    expect(
-      canCreateChildWorkspaceFromContextMenu({
-        repo: { kind: 'folder' },
-        branch: 'feature/api',
-        isFolderWorkspace: false
-      })
-    ).toBe(false)
-    expect(
-      canCreateChildWorkspaceFromContextMenu({
-        repo: { kind: 'git' },
-        branch: 'feature/api',
-        isFolderWorkspace: true
-      })
-    ).toBe(false)
-    expect(
-      canCreateChildWorkspaceFromContextMenu({
-        repo: null,
-        branch: 'feature/api',
-        isFolderWorkspace: false
-      })
-    ).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  canCreateChildWorkspaceFromContextMenu,
   hasSleepableWorkspaceActivity,
   isContextWorktreeDeletable,
   shouldUseNativeContextMenu,
@@ -168,6 +169,60 @@ describe('parent picker context menu affordance', () => {
     } as HTMLElement
 
     expect(getWorktreeParentPickerAnchor(scope, 'child')).toBe(scope)
+  })
+})
+
+describe('new child workspace context menu affordance', () => {
+  it('offers child creation for git-backed rows with a branch', () => {
+    expect(
+      canCreateChildWorkspaceFromContextMenu({
+        repo: { kind: 'git' },
+        branch: 'feature/api',
+        isFolderWorkspace: false
+      })
+    ).toBe(true)
+    // Legacy repos persisted without a kind are git repos.
+    expect(
+      canCreateChildWorkspaceFromContextMenu({
+        repo: {},
+        branch: 'main',
+        isFolderWorkspace: false
+      })
+    ).toBe(true)
+  })
+
+  it('hides child creation when there is no branch to base the child on', () => {
+    expect(
+      canCreateChildWorkspaceFromContextMenu({
+        repo: { kind: 'git' },
+        branch: '',
+        isFolderWorkspace: false
+      })
+    ).toBe(false)
+  })
+
+  it('hides child creation for folder workspaces and missing projects', () => {
+    expect(
+      canCreateChildWorkspaceFromContextMenu({
+        repo: { kind: 'folder' },
+        branch: 'feature/api',
+        isFolderWorkspace: false
+      })
+    ).toBe(false)
+    expect(
+      canCreateChildWorkspaceFromContextMenu({
+        repo: { kind: 'git' },
+        branch: 'feature/api',
+        isFolderWorkspace: true
+      })
+    ).toBe(false)
+    expect(
+      canCreateChildWorkspaceFromContextMenu({
+        repo: null,
+        branch: 'feature/api',
+        isFolderWorkspace: false
+      })
+    ).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -23,6 +23,7 @@ import {
   Pencil,
   Pin,
   PinOff,
+  GitBranchPlus,
   Kanban,
   Trash2,
   Unlink,
@@ -48,6 +49,7 @@ import { ProjectGroupNameDialog } from './ProjectGroupNameDialog'
 import { WorktreeParentPickerPopover } from './WorktreeParentPickerPopover'
 import { getEligibleWorktreeParents } from './worktree-parent-candidates'
 import { isEventTargetInsideCurrentTarget } from './worktree-card-dom-events'
+import { isGitRepoKind } from '../../../../shared/repo-kind'
 import { translate } from '@/i18n/i18n'
 import {
   folderWorkspaceKey,
@@ -144,6 +146,18 @@ function isWorktreeParentPickerDisabled(args: {
   eligibleParentCount: number
 }): boolean {
   return args.isDeleting || args.eligibleParentCount === 0
+}
+
+function canCreateChildWorkspaceFromContextMenu(args: {
+  repo: Pick<Repo, 'kind'> | null | undefined
+  branch: Worktree['branch']
+  isFolderWorkspace: boolean
+}): boolean {
+  // Why: a child branches from this worktree's branch, so detached/branchless
+  // rows and non-git (folder) workspaces have nothing to base the child on.
+  return (
+    args.repo != null && isGitRepoKind(args.repo) && !args.isFolderWorkspace && args.branch !== ''
+  )
 }
 
 function getWorktreeParentPickerAnchor(
@@ -601,6 +615,16 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
     )
   }, [activeContextWorktrees, updateWorktreeLineage])
 
+  // Why: no initialBaseBranch — seeding it would occupy the Start-from slot and
+  // block name/issue sources. The parent's branch becomes the base at create time.
+  const handleCreateChildWorkspace = useCallback(() => {
+    openModal('new-workspace-composer', {
+      initialRepoId: worktree.repoId,
+      parentWorktreeId: worktree.id,
+      telemetrySource: 'sidebar'
+    })
+  }, [openModal, worktree.id, worktree.repoId])
+
   const suppressOpeningPointerEvent = useCallback((event: React.SyntheticEvent) => {
     const contextMenuOpenedAt = contextMenuOpenedAtRef.current
     if (
@@ -807,6 +831,19 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
                 </>
               ) : null}
               <DropdownMenuSeparator />
+              {canCreateChildWorkspaceFromContextMenu({
+                repo,
+                branch: worktree.branch,
+                isFolderWorkspace: folderWorkspaceId !== null
+              }) && (
+                <DropdownMenuItem onSelect={handleCreateChildWorkspace} disabled={isDeleting}>
+                  <GitBranchPlus className="size-3.5" />
+                  {translate(
+                    'auto.components.sidebar.WorktreeContextMenu.newChildWorkspace',
+                    'New Child Workspace...'
+                  )}
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem
                 onSelect={handleOpenParentPicker}
                 disabled={isWorktreeParentPickerDisabled({ isDeleting, eligibleParentCount })}
@@ -972,6 +1009,7 @@ export {
   CLOSE_ALL_CONTEXT_MENUS_EVENT,
   WORKTREE_CONTEXT_MENU_SCOPE_ATTR,
   WORKTREE_NATIVE_CONTEXT_MENU_ATTR,
+  canCreateChildWorkspaceFromContextMenu,
   hasSleepableWorkspaceActivity,
   isContextWorktreeDeletable,
   getWorktreeParentPickerAnchor,

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -49,7 +49,7 @@ import { ProjectGroupNameDialog } from './ProjectGroupNameDialog'
 import { WorktreeParentPickerPopover } from './WorktreeParentPickerPopover'
 import { getEligibleWorktreeParents } from './worktree-parent-candidates'
 import { isEventTargetInsideCurrentTarget } from './worktree-card-dom-events'
-import { isGitRepoKind } from '../../../../shared/repo-kind'
+import { canCreateChildWorkspace } from '@/lib/worktree-create-parent'
 import { translate } from '@/i18n/i18n'
 import {
   folderWorkspaceKey,
@@ -146,18 +146,6 @@ function isWorktreeParentPickerDisabled(args: {
   eligibleParentCount: number
 }): boolean {
   return args.isDeleting || args.eligibleParentCount === 0
-}
-
-function canCreateChildWorkspaceFromContextMenu(args: {
-  repo: Pick<Repo, 'kind'> | null | undefined
-  branch: Worktree['branch']
-  isFolderWorkspace: boolean
-}): boolean {
-  // Why: a child branches from this worktree's branch, so detached/branchless
-  // rows and non-git (folder) workspaces have nothing to base the child on.
-  return (
-    args.repo != null && isGitRepoKind(args.repo) && !args.isFolderWorkspace && args.branch !== ''
-  )
 }
 
 function getWorktreeParentPickerAnchor(
@@ -831,7 +819,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
                 </>
               ) : null}
               <DropdownMenuSeparator />
-              {canCreateChildWorkspaceFromContextMenu({
+              {canCreateChildWorkspace({
                 repo,
                 branch: worktree.branch,
                 isFolderWorkspace: folderWorkspaceId !== null
@@ -1009,7 +997,6 @@ export {
   CLOSE_ALL_CONTEXT_MENUS_EVENT,
   WORKTREE_CONTEXT_MENU_SCOPE_ATTR,
   WORKTREE_NATIVE_CONTEXT_MENU_ATTR,
-  canCreateChildWorkspaceFromContextMenu,
   hasSleepableWorkspaceActivity,
   isContextWorktreeDeletable,
   getWorktreeParentPickerAnchor,

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -30,6 +30,8 @@ import { tuiAgentToAgentKind } from '@/lib/telemetry'
 import { isGitRepoKind } from '../../../shared/repo-kind'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { resolveWorktreeCreateBaseBranch } from '@/runtime/worktree-create-base'
+import { resolveWorktreeCreateParent } from '@/lib/worktree-create-parent'
+import { branchDisplayName } from '@/components/sidebar/WorktreeCardHelpers'
 import {
   buildTaskSourceContextFromRepo,
   type TaskSourceContext
@@ -219,6 +221,8 @@ export type UseComposerStateOptions = {
   initialWorkspaceStatus?: WorkspaceStatus
   /** Seeds the Start-from selection on open; the Create-from → Quick fallback uses it so a PR pick lands with the resolved PR head as base. */
   initialBaseBranch?: string
+  /** Worktree recorded as the lineage parent of the created workspace (quick submit). Paired with initialBaseBranch by "New Child Workspace". */
+  parentWorktreeId?: string
   /** The full-page composer persists drafts across navigation; the transient quick-composer modal must not clobber that draft. */
   persistDraft: boolean
   /** Invoked after a successful createWorktree; the caller usually closes its surface (palette modal, full page, etc.). */
@@ -314,6 +318,8 @@ export type ComposerCardProps = {
   onNoteChange: (value: string) => void
   baseBranch: string | undefined
   onBaseBranchChange: (next: string | undefined) => void
+  /** Parent context when composing a child workspace from the sidebar; renders the lineage hint under the name field. */
+  childWorkspaceParent?: { displayName: string } | null
   /** Called when a PR is selected in the Start-from picker; updates baseBranch and linkedWorkItem/linkedPR in one pass. */
   onBaseBranchPrSelect: (
     baseBranch: string,
@@ -525,6 +531,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     initialTaskSourceContext = null,
     initialWorkspaceStatus,
     initialBaseBranch,
+    parentWorktreeId,
     persistDraft,
     onCreated,
     repoIdOverride,
@@ -721,6 +728,13 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
   )
   const selectedRepo = eligibleRepos.find((repo) => repo.id === repoId)
   const selectedRepoIsGit = selectedRepo ? isGitRepoKind(selectedRepo) : false
+  // Why: resolved live from the store so a parent deleted (or a repo switch)
+  // hides the child-workspace hint and drops the link without extra state.
+  const createParentWorktree = useAppStore((s) =>
+    parentWorktreeId && selectedRepoIsGit
+      ? resolveWorktreeCreateParent(s, parentWorktreeId, repoId)
+      : null
+  )
   const [ephemeralVmRecipes, setEphemeralVmRecipes] = useState<
     NonNullable<OrcaHooks['environmentRecipes']>
   >([])
@@ -3975,6 +3989,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
           ...(selectedRepoIsGit && submitCompareBaseRef
             ? { compareBaseRef: submitCompareBaseRef }
             : {}),
+          ...(selectedRepoIsGit && parentWorktreeId ? { parentWorktreeId } : {}),
           setupDecision: effectiveSetupDecision,
           ...(selectedRepoIsGit && sparseEnabled
             ? {
@@ -4050,6 +4065,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
       normalizedSparseDirectories,
       note,
       onCreated,
+      parentWorktreeId,
       parsedLinkedIssueNumber,
       persistSetupAgentStartupPolicy,
       persistDraft,
@@ -4185,6 +4201,14 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     onCreate: () => void submit(),
     baseBranch: isProjectGroupTarget ? undefined : baseBranch,
     onBaseBranchChange: isProjectGroupTarget ? () => {} : handleBaseBranchChange,
+    childWorkspaceParent:
+      !isProjectGroupTarget && createParentWorktree
+        ? {
+            // Why: displayName is typed non-optional but can arrive undefined at runtime (crash 99657ab1).
+            displayName:
+              createParentWorktree.displayName || branchDisplayName(createParentWorktree.branch)
+          }
+        : null,
     onBaseBranchPrSelect: isProjectGroupTarget ? () => {} : handleBaseBranchPrSelect,
     onBaseBranchMrSelect: isProjectGroupTarget ? () => {} : handleBaseBranchMrSelect,
     baseBranchLinkedPrNumber:

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -7,6 +7,7 @@ import {
   getNewlyConnectedRuntimeEnvironmentIds,
   getNewlyDisconnectedRuntimeEnvironmentIds,
   getRuntimeProjectRefreshEnvironmentIds,
+  openNewChildWorkspaceFromShortcut,
   openNewWorkspaceFromShortcut,
   resolveBrowserSessionTabTarget,
   resolveZoomTarget
@@ -812,6 +813,69 @@ describe('openNewWorkspaceFromShortcut', () => {
       activeModal: 'new-workspace-composer',
       activeView: 'terminal',
       taskPageData: {},
+      openModal
+    } as never)
+
+    expect(openModal).not.toHaveBeenCalled()
+  })
+})
+
+describe('openNewChildWorkspaceFromShortcut', () => {
+  const eligibleState = {
+    activeModal: 'none',
+    activeView: 'terminal',
+    taskPageData: {},
+    activeWorktreeId: 'wt-1',
+    worktreesByRepo: { 'repo-1': [{ id: 'wt-1', repoId: 'repo-1', branch: 'refs/heads/feat/x' }] },
+    repos: [{ id: 'repo-1', connectionId: null }]
+  }
+
+  it('opens the composer seeded with the active worktree as parent', () => {
+    const openModal = vi.fn()
+
+    openNewChildWorkspaceFromShortcut({ ...eligibleState, openModal } as never)
+
+    expect(openModal).toHaveBeenCalledWith('new-workspace-composer', {
+      initialRepoId: 'repo-1',
+      parentWorktreeId: 'wt-1',
+      telemetrySource: 'shortcut'
+    })
+  })
+
+  it('falls back to the plain composer without an eligible active workspace', () => {
+    const openModal = vi.fn()
+
+    openNewChildWorkspaceFromShortcut({
+      ...eligibleState,
+      activeWorktreeId: null,
+      openModal
+    } as never)
+
+    expect(openModal).toHaveBeenCalledWith('new-workspace-composer', {
+      telemetrySource: 'shortcut'
+    })
+  })
+
+  it('falls back for branchless and folder-workspace rows', () => {
+    const openModal = vi.fn()
+
+    openNewChildWorkspaceFromShortcut({
+      ...eligibleState,
+      worktreesByRepo: { 'repo-1': [{ id: 'wt-1', repoId: 'repo-1', branch: '' }] },
+      openModal
+    } as never)
+
+    expect(openModal).toHaveBeenCalledWith('new-workspace-composer', {
+      telemetrySource: 'shortcut'
+    })
+  })
+
+  it('does not reopen the composer when it is already active', () => {
+    const openModal = vi.fn()
+
+    openNewChildWorkspaceFromShortcut({
+      ...eligibleState,
+      activeModal: 'new-workspace-composer',
       openModal
     } as never)
 

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -8,6 +8,8 @@ import { getWorktreeMapFromState, getRepoMapFromState } from '@/store/selectors'
 import { applyUIZoom } from '@/lib/ui-zoom'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { buildLinearIssueLinkedWorkItem } from '@/lib/linear-linked-work-item'
+import { canCreateChildWorkspace } from '@/lib/worktree-create-parent'
+import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { runWorktreeDelete } from '@/components/sidebar/delete-worktree-flow'
 import { runSleepWorktree } from '@/components/sidebar/sleep-worktree-flow'
 import { createBackgroundSleepingAgentWakeDispatcher } from '@/lib/wake-sleeping-agents-in-background'
@@ -701,6 +703,46 @@ export function openNewWorkspaceFromShortcut(
   state.openModal('new-workspace-composer', buildNewWorkspaceShortcutModalData(state))
 }
 
+export function openNewChildWorkspaceFromShortcut(
+  state: Pick<
+    AppState,
+    | 'activeModal'
+    | 'activeView'
+    | 'taskPageData'
+    | 'openModal'
+    | 'activeWorktreeId'
+    | 'worktreesByRepo'
+    | 'repos'
+  >
+): void {
+  if (state.activeModal === 'new-workspace-composer') {
+    return
+  }
+  const worktree = state.activeWorktreeId
+    ? getWorktreeMapFromState(state).get(state.activeWorktreeId)
+    : undefined
+  const eligibleParent =
+    worktree &&
+    canCreateChildWorkspace({
+      repo: getRepoMapFromState(state).get(worktree.repoId),
+      branch: worktree.branch,
+      isFolderWorkspace: parseWorkspaceKey(worktree.id)?.type === 'folder'
+    })
+      ? worktree
+      : null
+  if (!eligibleParent) {
+    // Why: Mod+Shift+N used to alias workspace.create; without an eligible
+    // active workspace it still opens the plain composer instead of dying.
+    state.openModal('new-workspace-composer', buildNewWorkspaceShortcutModalData(state))
+    return
+  }
+  state.openModal('new-workspace-composer', {
+    initialRepoId: eligibleParent.repoId,
+    parentWorktreeId: eligibleParent.id,
+    telemetrySource: 'shortcut'
+  })
+}
+
 export function resolveBrowserSessionTabTarget(
   state: Pick<AppState, 'browserTabsByWorktree' | 'unifiedTabsByWorktree'>,
   worktreeId: string,
@@ -1279,6 +1321,15 @@ export function useIpcEvents(): void {
         openNewWorkspaceFromShortcut(store)
       })
     )
+
+    if (window.api.ui.onOpenNewChildWorkspace) {
+      unsubs.push(
+        window.api.ui.onOpenNewChildWorkspace(() => {
+          const store = useAppStore.getState()
+          openNewChildWorkspaceFromShortcut(store)
+        })
+      )
+    }
 
     if (window.api.ui.onDeleteCurrentWorkspace) {
       unsubs.push(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1269,7 +1269,8 @@
         "noRunTargets": "No run targets are ready for this project.",
         "perWorkspaceEnvHint": "Provision an on-demand environment from a recipe",
         "branchName": "Branch name",
-        "branchNamePlaceholder": "feature/my-branch"
+        "branchNamePlaceholder": "feature/my-branch",
+        "childWorkspaceParentHint": "Created as a child workspace of \"{{parent}}\"."
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "Create worktree",
@@ -4375,6 +4376,7 @@
           "697d0f6e1b": "Unpin",
           "250de158fd": "Remove Workspace",
           "changeParentWorkspace": "Change Parent Worktree...",
+          "newChildWorkspace": "New Child Workspace...",
           "setParentWorkspace": "Set Parent Worktree...",
           "workspaceSection": "Workspace",
           "primaryDeleteDisabled": "Primary worktree — can't be deleted. Remove the project instead.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1246,7 +1246,8 @@
         "noRunTargets": "No hay destinos de ejecución listos para este proyecto.",
         "perWorkspaceEnvHint": "Provisiona un entorno bajo demanda a partir de una receta",
         "branchName": "Nombre de rama",
-        "branchNamePlaceholder": "feature/my-branch"
+        "branchNamePlaceholder": "feature/my-branch",
+        "childWorkspaceParentHint": "Se creará como espacio de trabajo hijo de «{{parent}}»."
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "Crear worktree",
@@ -4329,6 +4330,7 @@
           "697d0f6e1b": "Desanclar",
           "250de158fd": "Eliminar espacio de trabajo",
           "changeParentWorkspace": "Cambiar worktree padre...",
+          "newChildWorkspace": "Nuevo espacio de trabajo hijo...",
           "setParentWorkspace": "Establecer worktree padre...",
           "workspaceSection": "Espacio de trabajo",
           "primaryDeleteDisabled": "El worktree principal no se puede eliminar. Quita el proyecto en su lugar.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1246,7 +1246,8 @@
         "noRunTargets": "このプロジェクトには実行ターゲットが準備されていません。",
         "perWorkspaceEnvHint": "レシピからオンデマンド環境をプロビジョニングする",
         "branchName": "ブランチ名",
-        "branchNamePlaceholder": "feature/my-branch"
+        "branchNamePlaceholder": "feature/my-branch",
+        "childWorkspaceParentHint": "「{{parent}}」の子ワークスペースとして作成されます。"
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "ワークツリーを作成する",
@@ -4310,6 +4311,7 @@
           "697d0f6e1b": "固定を解除する",
           "250de158fd": "ワークスペースを削除",
           "changeParentWorkspace": "親ワークツリーを変更...",
+          "newChildWorkspace": "新しい子ワークスペース...",
           "setParentWorkspace": "親ワークツリーを設定...",
           "workspaceSection": "ワークスペース",
           "primaryDeleteDisabled": "プライマリワークツリーは削除できません。代わりにプロジェクトを削除してください。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1246,7 +1246,8 @@
         "noRunTargets": "이 프로젝트에는 실행 대상이 준비되어 있지 않습니다.",
         "perWorkspaceEnvHint": "레시피에서 온디맨드 환경 프로비저닝",
         "branchName": "브랜치 이름",
-        "branchNamePlaceholder": "feature/my-branch"
+        "branchNamePlaceholder": "feature/my-branch",
+        "childWorkspaceParentHint": "\"{{parent}}\"의 하위 워크스페이스로 생성됩니다."
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "작업 트리 만들기",
@@ -4310,6 +4311,7 @@
           "697d0f6e1b": "고정 해제",
           "250de158fd": "워크스페이스 제거",
           "changeParentWorkspace": "상위 워크트리 변경...",
+          "newChildWorkspace": "새 하위 워크스페이스...",
           "setParentWorkspace": "상위 워크트리 설정...",
           "workspaceSection": "워크스페이스",
           "primaryDeleteDisabled": "기본 작업 트리는 삭제할 수 없습니다. 대신 프로젝트를 제거하세요.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1246,7 +1246,8 @@
         "noRunTargets": "此项目还没有可用的运行目标。",
         "perWorkspaceEnvHint": "通过环境模板按需创建环境",
         "branchName": "分支名称",
-        "branchNamePlaceholder": "feature/my-branch"
+        "branchNamePlaceholder": "feature/my-branch",
+        "childWorkspaceParentHint": "将创建为“{{parent}}”的子工作区。"
       },
       "NewWorkspaceComposerModal": {
         "createWorktree": "创建工作树",
@@ -4310,6 +4311,7 @@
           "697d0f6e1b": "取消固定",
           "250de158fd": "移除工作区",
           "changeParentWorkspace": "更改父工作树...",
+          "newChildWorkspace": "新建子工作区...",
           "setParentWorkspace": "设置父工作树...",
           "workspaceSection": "工作区",
           "primaryDeleteDisabled": "主工作树不能删除。请改为移除项目。",

--- a/src/renderer/src/lib/pending-worktree-creation.ts
+++ b/src/renderer/src/lib/pending-worktree-creation.ts
@@ -67,6 +67,10 @@ export type WorktreeCreationRequest = {
   linkedLinearIssueWorkspaceId?: string | null
   linkedLinearIssueOrganizationUrlKey?: string | null
   branchNameOverride?: string
+  /** Worktree recorded as the lineage parent at create time; its branch is the
+   *  default base when no explicit baseBranch was picked. Dropped if the parent
+   *  stops qualifying (deleted, other repo/host) by submit. */
+  parentWorktreeId?: string
   workspaceStatus?: WorkspaceStatus
   linkedGitLabMR?: number
   linkedGitLabIssue?: number

--- a/src/renderer/src/lib/worktree-create-parent.test.ts
+++ b/src/renderer/src/lib/worktree-create-parent.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWorktreeCreateParent } from './worktree-create-parent'
+import type { AppState } from '@/store/types'
+
+type StateFixture = Pick<AppState, 'worktreesByRepo' | 'repos'>
+
+function makeState(args: {
+  worktreesByRepo: Record<string, object[]>
+  repos?: object[]
+}): StateFixture {
+  return {
+    worktreesByRepo: args.worktreesByRepo,
+    repos: args.repos ?? [{ id: 'repo-1', connectionId: null }]
+  } as unknown as StateFixture
+}
+
+describe('resolveWorktreeCreateParent', () => {
+  it('resolves an eligible same-repo parent', () => {
+    const state = makeState({
+      worktreesByRepo: { 'repo-1': [{ id: 'parent-1', repoId: 'repo-1', branch: 'feat/api' }] }
+    })
+
+    expect(resolveWorktreeCreateParent(state, 'parent-1', 'repo-1')?.id).toBe('parent-1')
+  })
+
+  it('returns null when the parent no longer exists', () => {
+    const state = makeState({ worktreesByRepo: { 'repo-1': [] } })
+
+    expect(resolveWorktreeCreateParent(state, 'parent-1', 'repo-1')).toBeNull()
+  })
+
+  it('returns null when the create targets another repo', () => {
+    const state = makeState({
+      worktreesByRepo: { 'repo-2': [{ id: 'parent-2', repoId: 'repo-2' }] },
+      repos: [
+        { id: 'repo-1', connectionId: null },
+        { id: 'repo-2', connectionId: null }
+      ]
+    })
+
+    expect(resolveWorktreeCreateParent(state, 'parent-2', 'repo-1')).toBeNull()
+  })
+
+  it('returns null for archived parents', () => {
+    const state = makeState({
+      worktreesByRepo: { 'repo-1': [{ id: 'parent-1', repoId: 'repo-1', isArchived: true }] }
+    })
+
+    expect(resolveWorktreeCreateParent(state, 'parent-1', 'repo-1')).toBeNull()
+  })
+
+  it('returns null when the parent lives on another execution host', () => {
+    const state = makeState({
+      worktreesByRepo: {
+        'repo-1': [{ id: 'parent-1', repoId: 'repo-1', hostId: 'ssh:remote-box' }]
+      }
+    })
+
+    expect(resolveWorktreeCreateParent(state, 'parent-1', 'repo-1')).toBeNull()
+  })
+})

--- a/src/renderer/src/lib/worktree-create-parent.test.ts
+++ b/src/renderer/src/lib/worktree-create-parent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolveWorktreeCreateParent } from './worktree-create-parent'
+import { canCreateChildWorkspace, resolveWorktreeCreateParent } from './worktree-create-parent'
 import type { AppState } from '@/store/types'
 
 type StateFixture = Pick<AppState, 'worktreesByRepo' | 'repos'>
@@ -13,6 +13,48 @@ function makeState(args: {
     repos: args.repos ?? [{ id: 'repo-1', connectionId: null }]
   } as unknown as StateFixture
 }
+
+describe('canCreateChildWorkspace', () => {
+  it('offers child creation for git-backed rows with a branch', () => {
+    expect(
+      canCreateChildWorkspace({
+        repo: { kind: 'git' },
+        branch: 'feature/api',
+        isFolderWorkspace: false
+      })
+    ).toBe(true)
+    // Legacy repos persisted without a kind are git repos.
+    expect(canCreateChildWorkspace({ repo: {}, branch: 'main', isFolderWorkspace: false })).toBe(
+      true
+    )
+  })
+
+  it('hides child creation when there is no branch to base the child on', () => {
+    expect(
+      canCreateChildWorkspace({ repo: { kind: 'git' }, branch: '', isFolderWorkspace: false })
+    ).toBe(false)
+  })
+
+  it('hides child creation for folder workspaces and missing projects', () => {
+    expect(
+      canCreateChildWorkspace({
+        repo: { kind: 'folder' },
+        branch: 'feature/api',
+        isFolderWorkspace: false
+      })
+    ).toBe(false)
+    expect(
+      canCreateChildWorkspace({
+        repo: { kind: 'git' },
+        branch: 'feature/api',
+        isFolderWorkspace: true
+      })
+    ).toBe(false)
+    expect(
+      canCreateChildWorkspace({ repo: null, branch: 'feature/api', isFolderWorkspace: false })
+    ).toBe(false)
+  })
+})
 
 describe('resolveWorktreeCreateParent', () => {
   it('resolves an eligible same-repo parent', () => {

--- a/src/renderer/src/lib/worktree-create-parent.ts
+++ b/src/renderer/src/lib/worktree-create-parent.ts
@@ -1,0 +1,23 @@
+import { getIndexedRepoMap, getIndexedWorktreeById } from '@/store/worktree-repo-index'
+import type { AppState } from '@/store/types'
+import { getRepoExecutionHostId, getWorktreeExecutionHostId } from '../../../shared/execution-host'
+import type { Worktree } from '../../../shared/types'
+
+// Why: re-validated at submit with the parent picker's rules — the parent can be
+// deleted (or the composer switched to another repo/host) while the composer was
+// open, and a stale parent must drop the link, not fail or mislink the create.
+export function resolveWorktreeCreateParent(
+  state: Pick<AppState, 'worktreesByRepo' | 'repos'>,
+  parentWorktreeId: string,
+  repoId: string
+): Worktree | null {
+  const parent = getIndexedWorktreeById(state.worktreesByRepo, parentWorktreeId)
+  if (!parent || parent.repoId !== repoId || parent.isArchived) {
+    return null
+  }
+  const repo = getIndexedRepoMap(state.repos).get(repoId)
+  if (!repo || getWorktreeExecutionHostId(parent, repo) !== getRepoExecutionHostId(repo)) {
+    return null
+  }
+  return parent
+}

--- a/src/renderer/src/lib/worktree-create-parent.ts
+++ b/src/renderer/src/lib/worktree-create-parent.ts
@@ -1,7 +1,20 @@
 import { getIndexedRepoMap, getIndexedWorktreeById } from '@/store/worktree-repo-index'
 import type { AppState } from '@/store/types'
 import { getRepoExecutionHostId, getWorktreeExecutionHostId } from '../../../shared/execution-host'
-import type { Worktree } from '../../../shared/types'
+import { isGitRepoKind } from '../../../shared/repo-kind'
+import type { Repo, Worktree } from '../../../shared/types'
+
+export function canCreateChildWorkspace(args: {
+  repo: Pick<Repo, 'kind'> | null | undefined
+  branch: Worktree['branch']
+  isFolderWorkspace: boolean
+}): boolean {
+  // Why: a child branches from this worktree's branch, so detached/branchless
+  // rows and non-git (folder) workspaces have nothing to base the child on.
+  return (
+    args.repo != null && isGitRepoKind(args.repo) && !args.isFolderWorkspace && args.branch !== ''
+  )
+}
 
 // Why: re-validated at submit with the parent picker's rules — the parent can be
 // deleted (or the composer switched to another repo/host) while the composer was

--- a/src/renderer/src/lib/worktree-creation-flow.test.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.test.ts
@@ -17,6 +17,7 @@ const store = {
   activeView: 'terminal' as TestActiveView,
   activePendingCreationId: 'creation-1' as string | null,
   repos: [{ id: 'repo-runtime', connectionId: null }],
+  worktreesByRepo: {} as Record<string, { id: string; repoId: string; branch?: string }[]>,
   pendingWorktreeCreations: {} as Record<string, PendingWorktreeCreation>,
   beginPendingWorktreeCreation: vi.fn((entry: PendingWorktreeCreation) => {
     store.pendingWorktreeCreations[entry.creationId] = entry
@@ -95,6 +96,7 @@ beforeEach(() => {
   store.activeView = 'terminal'
   store.activePendingCreationId = 'creation-1'
   store.repos = []
+  store.worktreesByRepo = {}
   store.pendingWorktreeCreations = { 'creation-1': makePendingCreation(makeRequest()) }
   store.createWorktree.mockImplementation(() => new Promise(() => {}))
   vi.mocked(ensureWorktreeHasInitialTerminal).mockReturnValue('tab-1')
@@ -644,6 +646,82 @@ describe('staged background worktree creation', () => {
       })
     )
     expect(toast.error).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('child workspace parent at create time', () => {
+  const CREATE_OPTIONS_ARG = 25
+
+  beforeEach(() => {
+    store.activeView = 'tasks'
+    store.repos = [{ id: 'repo-1', connectionId: null }]
+    store.worktreesByRepo = {
+      'repo-1': [{ id: 'parent-1', repoId: 'repo-1', branch: 'feat/parent' }]
+    }
+    store.createWorktree.mockResolvedValueOnce({ worktree: { id: 'wt-1', repoId: 'repo-1' } })
+  })
+
+  it('threads the parent branch and lineage option into the create call', async () => {
+    const started = continueBackgroundWorktreeCreation(
+      'creation-1',
+      makeRequest({ parentWorktreeId: 'parent-1' }),
+      { revealCreationSurface: false }
+    )
+
+    expect(started).toBe(true)
+    await vi.waitFor(() => expect(store.createWorktree).toHaveBeenCalledTimes(1))
+    const createCall = store.createWorktree.mock.calls[0] as unknown[]
+    expect(createCall[2]).toBe('feat/parent')
+    expect(createCall[CREATE_OPTIONS_ARG]).toEqual({ parentWorktreeId: 'parent-1' })
+  })
+
+  it('lets an explicit Start-from base win over the parent branch', async () => {
+    continueBackgroundWorktreeCreation(
+      'creation-1',
+      makeRequest({ parentWorktreeId: 'parent-1', baseBranch: 'release/1.0' }),
+      { revealCreationSurface: false }
+    )
+
+    await vi.waitFor(() => expect(store.createWorktree).toHaveBeenCalledTimes(1))
+    const createCall = store.createWorktree.mock.calls[0] as unknown[]
+    expect(createCall[2]).toBe('release/1.0')
+    expect(createCall[CREATE_OPTIONS_ARG]).toEqual({ parentWorktreeId: 'parent-1' })
+  })
+
+  it('drops the parent when it was deleted before submit', async () => {
+    store.worktreesByRepo = { 'repo-1': [] }
+
+    continueBackgroundWorktreeCreation(
+      'creation-1',
+      makeRequest({ parentWorktreeId: 'parent-1' }),
+      { revealCreationSurface: false }
+    )
+
+    await vi.waitFor(() => expect(store.createWorktree).toHaveBeenCalledTimes(1))
+    const createCall = store.createWorktree.mock.calls[0] as unknown[]
+    expect(createCall[2]).toBeUndefined()
+    expect(createCall[CREATE_OPTIONS_ARG]).toBeUndefined()
+  })
+
+  it('drops the parent when the composer switched to another repo', async () => {
+    store.repos = [
+      { id: 'repo-1', connectionId: null },
+      { id: 'repo-2', connectionId: null }
+    ]
+    store.worktreesByRepo = {
+      'repo-2': [{ id: 'parent-2', repoId: 'repo-2', branch: 'feat/other' }]
+    }
+
+    continueBackgroundWorktreeCreation(
+      'creation-1',
+      makeRequest({ parentWorktreeId: 'parent-2' }),
+      { revealCreationSurface: false }
+    )
+
+    await vi.waitFor(() => expect(store.createWorktree).toHaveBeenCalledTimes(1))
+    const createCall = store.createWorktree.mock.calls[0] as unknown[]
+    expect(createCall[2]).toBeUndefined()
+    expect(createCall[CREATE_OPTIONS_ARG]).toBeUndefined()
   })
 })
 

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -19,6 +19,7 @@ import {
   formatWorkspaceCreateError,
   getWorkspaceCreateErrorToastMessage
 } from '@/lib/workspace-create-error-format'
+import { resolveWorktreeCreateParent } from '@/lib/worktree-create-parent'
 import type { CreateWorktreeResult } from '../../../shared/types'
 import type {
   WorktreeCreationPhase,
@@ -136,6 +137,17 @@ async function executeWorktreeCreation(
     return
   }
 
+  // Why: the parent is re-resolved at create time (not menu-open time) so the
+  // child bases on the branch the parent points at now, and a parent that was
+  // deleted or left behind by a repo switch drops the link instead of failing.
+  const createParent = preparedRequest.parentWorktreeId
+    ? resolveWorktreeCreateParent(
+        useAppStore.getState(),
+        preparedRequest.parentWorktreeId,
+        preparedRequest.repoId
+      )
+    : null
+
   let result: CreateWorktreeResult
   try {
     result = await useAppStore
@@ -143,7 +155,7 @@ async function executeWorktreeCreation(
       .createWorktree(
         preparedRequest.repoId,
         preparedRequest.name,
-        preparedRequest.baseBranch,
+        preparedRequest.baseBranch ?? (createParent?.branch || undefined),
         preparedRequest.setupDecision,
         preparedRequest.sparseCheckout,
         preparedRequest.telemetrySource,
@@ -165,7 +177,8 @@ async function executeWorktreeCreation(
         preparedRequest.linkedBitbucketPR,
         preparedRequest.linkedAzureDevOpsPR,
         preparedRequest.linkedGiteaPR,
-        preparedRequest.compareBaseRef
+        preparedRequest.compareBaseRef,
+        createParent ? { parentWorktreeId: createParent.id } : undefined
       )
   } catch (error) {
     // Why: a missing entry means the user cancelled mid-flight — abandon

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -158,7 +158,12 @@ export type WorktreeSlice = {
     compareBaseRef?: string,
     // Why: reserved for automation-dispatch flows so host-side provenance can
     // be minted securely; regular create callers should omit this.
-    options?: { automationProvenanceRequest?: CreateWorktreeArgs['automationProvenanceRequest'] }
+    options?: {
+      automationProvenanceRequest?: CreateWorktreeArgs['automationProvenanceRequest']
+      /** Records the created worktree as a lineage child of this worktree.
+       *  Overrides the folder-scope parent derived from the active workspace. */
+      parentWorktreeId?: string
+    }
   ) => Promise<CreateWorktreeResult>
   /** Register an in-flight background creation and make it the active surface. */
   beginPendingWorktreeCreation: (entry: PendingWorktreeCreation) => void

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -2931,8 +2931,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           // Why: manual sort is user-authored order; stamp new workspaces at the top rather than relying on sortOrder fallback.
           const manualOrder = get().sortBy === 'manual' ? Date.now() : undefined
           const activeScope = parseWorkspaceKey(get().activeWorkspaceKey ?? '')
-          const parentWorkspace =
-            activeScope?.type === 'folder'
+          const parentWorkspace = options?.parentWorktreeId
+            ? worktreeWorkspaceKey(options.parentWorktreeId)
+            : activeScope?.type === 'folder'
               ? folderWorkspaceKey(activeScope.folderWorkspaceId)
               : undefined
           const createArgs = {
@@ -3051,6 +3052,14 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
                 ...s.worktreesByRepo,
                 [repoId]: nextWorktrees
               },
+              ...(result.lineage
+                ? {
+                    worktreeLineageById: {
+                      ...s.worktreeLineageById,
+                      [result.worktree.id]: result.lineage
+                    }
+                  }
+                : {}),
               ...(result.workspaceLineage
                 ? {
                     workspaceLineageByChildKey: {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2531,6 +2531,7 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
     onToggleQuickCommandsMenu: () => noopUnsubscribe,
     onOpenTasks: () => noopUnsubscribe,
     onOpenNewWorkspace: () => noopUnsubscribe,
+    onOpenNewChildWorkspace: () => noopUnsubscribe,
     onDeleteCurrentWorkspace: () => noopUnsubscribe,
     onOpenWorkspaceBoard: () => noopUnsubscribe,
     onJumpToWorktreeIndex: () => noopUnsubscribe,

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -33,6 +33,7 @@ export type KeybindingActionId =
   | 'app.settings'
   | 'app.forceReload'
   | 'workspace.create'
+  | 'workspace.createChild'
   | 'workspace.rename'
   | 'workspace.delete'
   | 'workspace.openBoard'
@@ -255,7 +256,15 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     group: 'Global',
     scope: 'global',
     searchKeywords: ['shortcut', 'global', 'worktree', 'create', 'new workspace'],
-    defaultBindings: platformBindings(['Mod+N', 'Mod+Shift+N'])
+    defaultBindings: platformBindings(['Mod+N'])
+  },
+  {
+    id: 'workspace.createChild',
+    title: 'Create child worktree of active workspace',
+    group: 'Global',
+    scope: 'global',
+    searchKeywords: ['shortcut', 'global', 'worktree', 'create', 'child', 'stacked', 'lineage'],
+    defaultBindings: platformBindings(['Mod+Shift+N'])
   },
   {
     id: 'workspace.rename',

--- a/src/shared/window-shortcut-policy.test.ts
+++ b/src/shared/window-shortcut-policy.test.ts
@@ -768,22 +768,20 @@ describe('resolveWindowShortcutAction', () => {
     ).toBeNull()
   })
 
-  it('routes Cmd/Ctrl+Shift+N to the unified new-workspace composer', () => {
-    // Why: keep the former Create-from shortcut accepted so muscle memory
-    // still opens the composer; source switching now lives in the smart name field.
+  it('routes Cmd/Ctrl+Shift+N to the child-workspace composer', () => {
     expect(
       resolveWindowShortcutAction(
         { code: 'KeyN', key: 'n', meta: true, control: false, alt: false, shift: true },
         'darwin'
       )
-    ).toEqual({ type: 'openNewWorkspace' })
+    ).toEqual({ type: 'openNewChildWorkspace' })
 
     expect(
       resolveWindowShortcutAction(
         { code: 'KeyN', key: 'n', meta: false, control: true, alt: false, shift: true },
         'linux'
       )
-    ).toEqual({ type: 'openNewWorkspace' })
+    ).toEqual({ type: 'openNewChildWorkspace' })
 
     // Alt must still be rejected — the allowlist is alt-free for Cmd/Ctrl+N
     // so future chords like Cmd+Alt+Shift+N remain available.

--- a/src/shared/window-shortcut-policy.ts
+++ b/src/shared/window-shortcut-policy.ts
@@ -38,6 +38,7 @@ export type WindowShortcutAction =
   | { type: 'openQuickOpen' }
   | { type: 'toggleQuickCommandsMenu' }
   | { type: 'openNewWorkspace' }
+  | { type: 'openNewChildWorkspace' }
   | { type: 'deleteCurrentWorkspace' }
   | { type: 'openWorkspaceBoard' }
   | { type: 'openTasks' }
@@ -229,10 +230,12 @@ export function resolveWindowShortcutAction(
   // main process so it reaches the renderer even when focus lives inside
   // a contentEditable surface (markdown rich editor) or a browser guest
   // webContents, both of which bypass the renderer's window-level keydown.
-  // Shift is accepted for compatibility with the former Create-from shortcut;
-  // the unified composer now exposes source switching inside the name field.
   if (actionMatches('workspace.create', input, platform, keybindings, options)) {
     return { type: 'openNewWorkspace' }
+  }
+
+  if (actionMatches('workspace.createChild', input, platform, keybindings, options)) {
+    return { type: 'openNewChildWorkspace' }
   }
 
   if (actionMatches('workspace.delete', input, platform, keybindings, options)) {
@@ -318,6 +321,8 @@ export function getWindowShortcutActionId(action: WindowShortcutAction): Keybind
       return 'tab.openQuickCommandsMenu'
     case 'openNewWorkspace':
       return 'workspace.create'
+    case 'openNewChildWorkspace':
+      return 'workspace.createChild'
     case 'deleteCurrentWorkspace':
       return 'workspace.delete'
     case 'openWorkspaceBoard':


### PR DESCRIPTION
> **Stacked on #9859** — this branch is based on `feat/new-child-workspace-from-context-menu`, so the diff includes that PR's commit until it merges. Only the top commit (`feat(shortcuts): …`) is new here. GitHub does not allow a fork branch as the base of an upstream PR, hence `main` as the nominal base.

## Summary

- Adds a **Cmd/Ctrl+Shift+N** shortcut (`workspace.createChild`) that opens the New Workspace composer seeded with the **currently active workspace as lineage parent** — the keyboard counterpart of #9859's "New Child Workspace..." context-menu action. Cmd/Ctrl+N (`workspace.create`) keeps opening the plain composer.
- `Mod+Shift+N` was previously a secondary alias of `workspace.create` (kept for muscle-memory compatibility with the old Create-from shortcut). It is reassigned to the new action; when there is **no eligible active workspace** (nothing active, folder workspace, branchless checkout), the shortcut **falls back to the plain composer**, so users who relied on the alias see unchanged behavior exactly in the situations where a child create is impossible.
- Routed through the main-process window-shortcut policy like Cmd/Ctrl+N, so it fires even when focus is inside a browser guest or contentEditable surface.
- The command appears automatically in **Settings → Shortcuts** ("Create child worktree of active workspace", Global group) via the keybinding registry, with normal user rebinding support.
- The child-eligibility gate (`canCreateChildWorkspace`) moves from the context menu into `worktree-create-parent.ts` so both entry points share one rule.

## Screenshots

No new visual surface: the shortcut opens the same composer-with-lineage-hint shown in #9859's screenshots, and the Settings → Shortcuts row is auto-generated from the keybinding registry like every other command.

## Testing

- [x] `pnpm lint` — oxlint passes; same single pre-existing `lint:switch-exhaustiveness` failure as current `main` (untouched file).
- [x] `pnpm typecheck` — all three projects pass.
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions:
  - `window-shortcut-policy.test.ts`: `Mod+Shift+N` now resolves to `openNewChildWorkspace` on darwin and linux; the alt-chord rejection guard stays.
  - `useIpcEvents.test.ts`: the handler seeds `initialRepoId`/`parentWorktreeId` from the active worktree; falls back to the plain composer when nothing is active or the row is branchless/folder; no-ops while the composer is already open.
  - `worktree-create-parent.test.ts`: gating tests moved here alongside the shared `canCreateChildWorkspace`.
- [ ] Manual verification pending: ⌘⇧N happy path + fallback, ⌘N unchanged, new row in Settings → Shortcuts. (#9859's underlying flow was already manually verified on macOS.)

## AI Review Report

- **Cross-platform (macOS/Linux/Windows)**: no hand-rolled `metaKey`/`ctrlKey` branches — the binding is declared as `Mod+Shift+N` in the keybinding registry, which resolves Mod per platform in both the main-process resolver and the renderer matcher; layout-aware key matching comes with the existing infrastructure.
- **Behavior change audit**: the only regression surface is users pressing Mod+Shift+N expecting a plain create; the fallback covers every case where a child create is impossible, and when a parent IS eligible the composer still allows exactly the same inputs (name, Create-From sources) with one extra hint line, so no workflow is lost. User keybinding overrides are unaffected (new action id, existing ids keep their meaning).
- **SSH/remote**: the handler only reads renderer store state and opens the composer; parent eligibility and lineage recording reuse #9859's submit-time validation (repo/host checks), so remote workspaces behave identically to the context-menu path.
- **Dead-key/IME/browser-guest routing**: reuses the `before-input-event` allowlist path that `workspace.create` already exercises; no new event listeners in the renderer besides the IPC subscription (guarded for older preloads, mirroring `onDeleteCurrentWorkspace`).
- **Settings UI**: no manual list to update — `ShortcutsPane` renders from `KEYBINDING_DEFINITIONS`.

## Security Audit

- No new IPC surface beyond a one-way, argument-less `ui:openNewChildWorkspace` notification from main to renderer, matching the existing `ui:openNewWorkspace` channel pattern; the renderer resolves everything from its own store state.
- No shell, path, auth, or dependency changes.

## Notes

- Depends on #9859 for `parentWorktreeId` composer support and create-time lineage recording; merge that first, then rebase this to drop the shared commit.
- X handle: none — feel free to credit the GitHub handle instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
