### PR TITLE
fix(agent-status): clear worktree-attributed orphans on relay/daemon teardown (#9030)

### DIFF
--- a/src/renderer/src/store/slices/agent-status-ssh-connection-clear.test.ts
+++ b/src/renderer/src/store/slices/agent-status-ssh-connection-clear.test.ts
@@ -82,6 +82,199 @@ describe('agent status cleanup for a lost SSH connection', () => {
     expect(store.getState().retentionSuppressedPaneKeys[oldA]).toBe(true)
   })
 
+  it('clears worktree-attributed orphans on the connection even when their connectionId stamp is missing', () => {
+    // Why: #9030 — after a relay/daemon restart main drops the rows but renderer entries whose
+    // connectionId never matched (unstamped over SSH) stayed "fresh" 30 min and un-clickable;
+    // the host is proven via the owning worktree's repo so those orphans clear too.
+    vi.useFakeTimers()
+    const store = createTestStore()
+    store.setState({
+      repos: [
+        {
+          id: 'repo-a',
+          path: '/a',
+          displayName: 'A',
+          badgeColor: '#000',
+          addedAt: 0,
+          connectionId: 'ssh-a'
+        },
+        {
+          id: 'repo-b',
+          path: '/b',
+          displayName: 'B',
+          badgeColor: '#000',
+          addedAt: 0,
+          connectionId: 'ssh-b'
+        }
+      ],
+      worktreesByRepo: {
+        'repo-a': [{ id: 'wt-a', repoId: 'repo-a' }],
+        'repo-b': [{ id: 'wt-b', repoId: 'repo-b' }]
+      }
+    } as unknown as Partial<AppState>)
+
+    const orphanA = 'tab-a:11111111-1111-4111-8111-111111111111'
+    const freshOrphanA = 'tab-a2:22222222-2222-4222-8222-222222222222'
+    const otherHostB = 'tab-b:33333333-3333-4333-8333-333333333333'
+    // Orphan on ssh-a's worktree, no connectionId stamp — the #9030 shape.
+    store
+      .getState()
+      .setAgentStatus(
+        orphanA,
+        { state: 'working', prompt: 'orphan', agentType: 'codex' },
+        undefined,
+        { updatedAt: 10 },
+        { worktreeId: 'wt-a' }
+      )
+    // Same host, but updated after the cutoff — a genuinely fresh row must survive.
+    store
+      .getState()
+      .setAgentStatus(
+        freshOrphanA,
+        { state: 'working', prompt: 'fresh', agentType: 'codex' },
+        undefined,
+        { updatedAt: 40 },
+        { worktreeId: 'wt-a' }
+      )
+    // Worktree-attributed row on a different live host must be untouched.
+    store
+      .getState()
+      .setAgentStatus(
+        otherHostB,
+        { state: 'working', prompt: 'other host', agentType: 'codex' },
+        undefined,
+        { updatedAt: 10 },
+        { worktreeId: 'wt-b' }
+      )
+
+    store.getState().clearTransientAgentStatuses('ssh-a', 30)
+
+    expect(store.getState().agentStatusByPaneKey[orphanA]).toBeUndefined()
+    expect(store.getState().agentStatusByPaneKey[freshOrphanA]).toBeDefined()
+    expect(store.getState().agentStatusByPaneKey[otherHostB]).toBeDefined()
+  })
+
+  it('does not clear a live row on another host that shares a repo id', () => {
+    // Why: a repo id can live on multiple hosts and share one worktreesByRepo bucket; scoping by bare
+    // repo id would clear the other host's live rows, so ownership must come from the worktree (#9030).
+    vi.useFakeTimers()
+    const store = createTestStore()
+    store.setState({
+      repos: [
+        {
+          id: 'shared',
+          path: '/a',
+          displayName: 'A',
+          badgeColor: '#000',
+          addedAt: 0,
+          connectionId: 'ssh-a'
+        },
+        {
+          id: 'shared',
+          path: '/b',
+          displayName: 'B',
+          badgeColor: '#000',
+          addedAt: 0,
+          connectionId: 'ssh-b'
+        }
+      ],
+      worktreesByRepo: {
+        shared: [
+          { id: 'wt-a', repoId: 'shared', hostId: 'ssh:ssh-a' },
+          { id: 'wt-b', repoId: 'shared', hostId: 'ssh:ssh-b' }
+        ]
+      }
+    } as unknown as Partial<AppState>)
+
+    const orphanA = 'tab-a:11111111-1111-4111-8111-111111111111'
+    const liveB = 'tab-b:22222222-2222-4222-8222-222222222222'
+    store
+      .getState()
+      .setAgentStatus(
+        orphanA,
+        { state: 'working', prompt: 'orphan', agentType: 'codex' },
+        undefined,
+        { updatedAt: 10 },
+        { worktreeId: 'wt-a' }
+      )
+    store
+      .getState()
+      .setAgentStatus(
+        liveB,
+        { state: 'working', prompt: 'live b', agentType: 'codex' },
+        undefined,
+        { updatedAt: 10 },
+        { worktreeId: 'wt-b' }
+      )
+
+    store.getState().clearTransientAgentStatuses('ssh-a', 30)
+
+    expect(store.getState().agentStatusByPaneKey[orphanA]).toBeUndefined()
+    expect(store.getState().agentStatusByPaneKey[liveB]).toBeDefined()
+  })
+
+  it('does not clear a live row whose worktree id collides across hosts', () => {
+    // Why: worktree id is `${repoId}::${path}` with no host component, so the same project mirrored at
+    // the same path on two hosts shares one id. An explicit stamp for the other host must win, and an
+    // unstamped row on a collided id is ambiguous — left alone rather than hiding a live row (#9030).
+    vi.useFakeTimers()
+    const store = createTestStore()
+    store.setState({
+      repos: [
+        {
+          id: 'shared',
+          path: '/p',
+          displayName: 'A',
+          badgeColor: '#000',
+          addedAt: 0,
+          connectionId: 'ssh-a'
+        },
+        {
+          id: 'shared',
+          path: '/p',
+          displayName: 'B',
+          badgeColor: '#000',
+          addedAt: 0,
+          connectionId: 'ssh-b'
+        }
+      ],
+      worktreesByRepo: {
+        shared: [
+          { id: 'shared::/p', repoId: 'shared', hostId: 'ssh:ssh-a' },
+          { id: 'shared::/p', repoId: 'shared', hostId: 'ssh:ssh-b' }
+        ]
+      }
+    } as unknown as Partial<AppState>)
+
+    const liveOnB = 'tab-b:11111111-1111-4111-8111-111111111111'
+    const collidedOrphan = 'tab-x:22222222-2222-4222-8222-222222222222'
+    // Live agent explicitly on the OTHER host — an old-but-quiet update, before the cutoff.
+    store
+      .getState()
+      .setAgentStatus(
+        liveOnB,
+        { state: 'working', prompt: 'live b', agentType: 'codex' },
+        undefined,
+        { updatedAt: 10 },
+        { connectionId: 'ssh-b', worktreeId: 'shared::/p' }
+      )
+    // Unstamped row on the collided id — host can't be proven, so it must be left alone.
+    store
+      .getState()
+      .setAgentStatus(
+        collidedOrphan,
+        { state: 'working', prompt: 'ambiguous', agentType: 'codex' },
+        undefined,
+        { updatedAt: 10 },
+        { worktreeId: 'shared::/p' }
+      )
+
+    store.getState().clearTransientAgentStatuses('ssh-a', 30)
+
+    expect(store.getState().agentStatusByPaneKey[liveOnB]).toBeDefined()
+    expect(store.getState().agentStatusByPaneKey[collidedOrphan]).toBeDefined()
+  })
+
   it('retains an accepted connection stamp across later unstamped pings', () => {
     const store = createTestStore()
     const paneKey = 'tab-a:11111111-1111-4111-8111-111111111111'

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -27,6 +27,10 @@ import {
 } from '../../../../shared/agent-status-identity'
 import { isCommandCodeNewTurnWhileWorking } from '../../../../shared/command-code-turn-boundary'
 import type { TerminalTab } from '../../../../shared/types'
+import {
+  getRepoExecutionHostId,
+  getWorktreeExecutionHostId
+} from '../../../../shared/execution-host'
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
 import {
   getAgentRowGeneratedTitleText,
@@ -1049,6 +1053,39 @@ function mergeCurrentOrchestrationContext(
   }
   const merged = { ...existing, ...current }
   return orchestrationContextsEqual(existing, merged) ? existing : merged
+}
+
+// Why: relay/daemon teardown drops main's rows, but renderer entries whose connectionId stamp never
+// matched (unstamped over SSH) survive and stay "fresh" 30 min (#9030). Resolve each worktree's host
+// via the canonical hostId-first precedence and keep only ids UNAMBIGUOUSLY on this connection — a
+// worktree id is `${repoId}::${path}` (no host component), so the same project mirrored at the same
+// path on two hosts yields one shared id that must not clear another host's live rows.
+function collectWorktreeIdsForConnection(state: AppState, connectionId: string): Set<string> {
+  const hostIdsOnConnection = new Set(
+    state.repos
+      .filter((repo) => repo.connectionId === connectionId)
+      .map((repo) => getRepoExecutionHostId(repo))
+  )
+  if (hostIdsOnConnection.size === 0) {
+    return new Set()
+  }
+  const repoById = new Map(state.repos.map((repo) => [repo.id, repo] as const))
+  const onConnection = new Set<string>()
+  const onOtherHost = new Set<string>()
+  for (const [repoId, worktrees] of Object.entries(state.worktreesByRepo)) {
+    const repo = repoById.get(repoId)
+    for (const worktree of worktrees) {
+      const bucket = hostIdsOnConnection.has(getWorktreeExecutionHostId(worktree, repo))
+        ? onConnection
+        : onOtherHost
+      bucket.add(worktree.id)
+    }
+  }
+  // A worktree id that also lives on another host is ambiguous — leave it rather than hide a live row.
+  for (const id of onOtherHost) {
+    onConnection.delete(id)
+  }
+  return onConnection
 }
 
 export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusSlice> = (
@@ -2082,10 +2119,21 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
       }
       let removed = false
       set((s) => {
+        const worktreeIdsOnConnection = collectWorktreeIdsForConnection(s, connectionId)
         let next: Record<string, AgentStatusEntry> | null = null
         for (const [paneKey, existing] of Object.entries(s.agentStatusByPaneKey)) {
-          // Why: undefined connectionId is an unstamped legacy/renderer-owned row whose host can't be proven, so leave it to normal pane teardown.
-          if (existing.connectionId !== connectionId || existing.updatedAt > clearedAt) {
+          if (existing.updatedAt > clearedAt) {
+            continue
+          }
+          // Why: clear rows stamped for this connection, plus UNSTAMPED (never-stamped) worktree
+          // rows unambiguously on it (#9030). An explicit stamp — another host's connectionId, or a
+          // local `null` — is authoritative and never overridden by worktree inference.
+          const belongsToConnection =
+            existing.connectionId === connectionId ||
+            (existing.connectionId === undefined &&
+              existing.worktreeId !== undefined &&
+              worktreeIdsOnConnection.has(existing.worktreeId))
+          if (!belongsToConnection) {
             continue
           }
           next ??= { ...s.agentStatusByPaneKey }


### PR DESCRIPTION
Fixes #9030.

## What & why

After an SSH host's relay/daemon restarts (crash or manual kill), agent rows for that host stayed visible in the sidebar but clicking them did nothing for up to 30 minutes.

On teardown, main clears its agent-status rows and broadcasts a transient clear, but the renderer's `clearTransientAgentStatuses` only removed rows whose `connectionId` stamp matched. Orphaned rows on that host have an absent/mis-normalized `connectionId`, so they never matched and lived on as "fresh" for `AGENT_STATUS_STALE_AFTER_MS` (30 min). Their backing tab is gone, so the row's click handler silently no-ops (`WorktreeCardAgents` keeps a live-looking row and returns).

Fix: when clearing a lost connection, also drop rows whose owning **worktree's host** belongs to that connection — resolved via the canonical `getWorktreeExecutionHostId` precedence (worktree `hostId` first, repo fallback). The renderer now converges to main's already-clean state (exactly what a window reload does today), so there's no dead row left to click.

## ELI5

When a remote host's background service restarts, the app is supposed to forget that host's "agent is working" rows. Some rows had a missing host label, so it kept them for 30 minutes — they looked clickable but did nothing. Now we read each row's host from its worktree, so the stale ones clear right away.

## Proof of fix

Unit test: an unstamped orphan row on a torn-down host's worktree is now cleared (it survived before).

## Proof of no regression

This is a clearing path, so the risk is *over*-clearing (hiding **live** rows). Guards:

- **Host-scoped, not repo-scoped.** An adversarial review caught that an earlier repo-id-based version would clear a live row on a *different* host that happens to share a repo id (Orca supports the same repo id on multiple hosts, sharing one `worktreesByRepo` bucket, distinguished by `Worktree.hostId`). Fixed by resolving each worktree's host via `getWorktreeExecutionHostId` — the exact hostId-first precedence every other sidebar host decision uses. **Regression test added** (shared repo id across two hosts → the other host's row survives).
- **Freshness cutoff preserved:** rows updated after the clear watermark survive, so a genuinely live-but-quiet row isn't dropped.
- **Local rows untouched** (`connectionId: null` never matches a real target).
- **Repopulation intact:** a still-live agent's row replays after reconnect (the existing block flag resets on `connected`).
- 14 tests pass across the clear/activation suites, including the existing "keep a live worktree-attributed row visible while its tab is hydrating" contract. `oxlint` + `oxfmt` clean.

Made with [Orca](https://github.com/stablyai/orca) 🐋
