### PR TITLE
feat(right-sidebar): add expand toggle to widen the panel

### DIFF
--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -1,6 +1,15 @@
 /* eslint-disable max-lines -- Why: the right sidebar owns activity-bar visibility, routing, and resize behavior as one interaction surface; splitting the tab table away would make hidden-tab fallbacks harder to audit. */
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { Plug, Files, GitBranch, ListChecks, PanelRight, Workflow } from 'lucide-react'
+import {
+  Plug,
+  Files,
+  GitBranch,
+  ListChecks,
+  Maximize2,
+  Minimize2,
+  PanelRight,
+  Workflow
+} from 'lucide-react'
 import { useAppStore } from '@/store'
 import type { ActiveRightSidebarTab } from '@/store/slices/editor'
 import { useRepoById } from '@/store/selectors'
@@ -35,6 +44,7 @@ import {
 import {
   RIGHT_SIDEBAR_MIN_WIDTH,
   clampRightSidebarPanelWidth,
+  computeExpandedRightSidebarPanelWidth,
   computeMaxRightSidebarPanelWidth
 } from './right-sidebar-width'
 import { translate } from '@/i18n/i18n'
@@ -69,6 +79,8 @@ function RightSidebarInner(): React.JSX.Element {
   const setRightSidebarTab = useAppStore((s) => s.setRightSidebarTab)
   const showRightSidebarFiles = useAppStore((s) => s.showRightSidebarFiles)
   const toggleRightSidebar = useAppStore((s) => s.toggleRightSidebar)
+  const rightSidebarExpanded = useAppStore((s) => s.rightSidebarExpanded)
+  const toggleRightSidebarExpanded = useAppStore((s) => s.toggleRightSidebarExpanded)
   const checksStatus = useAppStore((s) => (s.rightSidebarOpen ? getActiveChecksStatus(s) : null))
   const activityBarPosition = useAppStore((s) => s.activityBarPosition)
   const setActivityBarPosition = useAppStore((s) => s.setActivityBarPosition)
@@ -199,11 +211,12 @@ function RightSidebarInner(): React.JSX.Element {
   const activityBarSideWidth = activityBarPosition === 'side' ? ACTIVITY_BAR_SIDE_WIDTH : 0
   const windowWidth = useWindowWidth()
   const maxWidth = computeMaxRightSidebarPanelWidth(windowWidth, activityBarSideWidth)
-  const renderedRightSidebarWidth = clampRightSidebarPanelWidth(
-    rightSidebarWidth,
-    windowWidth,
-    activityBarSideWidth
-  )
+  // Why: expanded mode renders at the expand target (a fraction of the window)
+  // without mutating the stored width, so toggling off restores the user's
+  // chosen (and persisted) width.
+  const renderedRightSidebarWidth = rightSidebarExpanded
+    ? computeExpandedRightSidebarPanelWidth(windowWidth, activityBarSideWidth)
+    : clampRightSidebarPanelWidth(rightSidebarWidth, windowWidth, activityBarSideWidth)
   const { containerRef, onResizeStart } = useSidebarResize<HTMLDivElement>({
     isOpen: rightSidebarOpen,
     width: renderedRightSidebarWidth,
@@ -247,6 +260,42 @@ function RightSidebarInner(): React.JSX.Element {
       statusIndicator={item.id === 'checks' ? checksStatus : null}
     />
   ))
+
+  const expandButton = rightSidebarOpen ? (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className="sidebar-toggle mr-1"
+          onClick={toggleRightSidebarExpanded}
+          aria-label={
+            rightSidebarExpanded
+              ? translate(
+                  'auto.components.right.sidebar.index.collapseRightSidebar',
+                  'Collapse right sidebar'
+                )
+              : translate(
+                  'auto.components.right.sidebar.index.expandRightSidebar',
+                  'Expand right sidebar'
+                )
+          }
+        >
+          {rightSidebarExpanded ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={6}>
+        {rightSidebarExpanded
+          ? translate(
+              'auto.components.right.sidebar.index.collapseRightSidebar',
+              'Collapse right sidebar'
+            )
+          : translate(
+              'auto.components.right.sidebar.index.expandRightSidebar',
+              'Expand right sidebar'
+            )}
+      </TooltipContent>
+    </Tooltip>
+  ) : null
 
   const closeButton = rightSidebarOpen ? (
     <Tooltip>
@@ -343,6 +392,7 @@ function RightSidebarInner(): React.JSX.Element {
                       RIGHT_SIDEBAR_HEADER_NO_DRAG_CLASS_NAME
                     )}
                   >
+                    {expandButton}
                     {closeButton}
                   </div>
                 </TooltipProvider>
@@ -355,6 +405,7 @@ function RightSidebarInner(): React.JSX.Element {
                       RIGHT_SIDEBAR_HEADER_NO_DRAG_CLASS_NAME
                     )}
                   >
+                    {expandButton}
                     {closeButton}
                   </div>
                 </TooltipProvider>
@@ -413,7 +464,10 @@ function RightSidebarInner(): React.JSX.Element {
               {visibleItems.find((item) => item.id === effectiveTab)?.title ?? ''}
             </span>
             <TooltipProvider delayDuration={400}>
-              <div className="flex items-center">{closeButton}</div>
+              <div className="flex items-center">
+                {expandButton}
+                {closeButton}
+              </div>
             </TooltipProvider>
           </div>
         )}

--- a/src/renderer/src/components/right-sidebar/right-sidebar-titlebar-drag-regions.render.test.tsx
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-titlebar-drag-regions.render.test.tsx
@@ -68,6 +68,8 @@ vi.mock('@/store', async () => {
     const selected = selector({
       rightSidebarOpen: mockAppState.rightSidebarOpen,
       rightSidebarWidth: 350,
+      rightSidebarExpanded: false,
+      toggleRightSidebarExpanded: vi.fn(),
       setRightSidebarWidth: vi.fn(),
       rightSidebarTab: mockAppState.rightSidebarTab,
       rightSidebarExplorerView: 'files',

--- a/src/renderer/src/components/right-sidebar/right-sidebar-width.test.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-width.test.ts
@@ -3,6 +3,7 @@ import {
   RIGHT_SIDEBAR_ABSOLUTE_FALLBACK_MAX_WIDTH,
   RIGHT_SIDEBAR_MIN_WIDTH,
   clampRightSidebarPanelWidth,
+  computeExpandedRightSidebarPanelWidth,
   computeMaxRightSidebarPanelWidth
 } from './right-sidebar-width'
 
@@ -22,6 +23,30 @@ describe('right sidebar rendered width', () => {
 
   it('uses the fallback max outside DOM environments', () => {
     expect(computeMaxRightSidebarPanelWidth(null, 40)).toBe(
+      RIGHT_SIDEBAR_ABSOLUTE_FALLBACK_MAX_WIDTH
+    )
+  })
+})
+
+describe('right sidebar expand target', () => {
+  it('targets the configured fraction of the window width', () => {
+    // 70% of 1440 = 1008.
+    expect(computeExpandedRightSidebarPanelWidth(1440, 0)).toBe(1008)
+  })
+
+  it('never crowds the reserved non-sidebar area on wide windows', () => {
+    // 1008 still leaves 432 for the editor, above the 320 floor.
+    expect(computeExpandedRightSidebarPanelWidth(1440, 0)).toBeLessThanOrEqual(
+      computeMaxRightSidebarPanelWidth(1440, 0)
+    )
+  })
+
+  it('clamps to the minimum sidebar width on narrow windows', () => {
+    expect(computeExpandedRightSidebarPanelWidth(400, 0)).toBe(RIGHT_SIDEBAR_MIN_WIDTH)
+  })
+
+  it('falls back to the max target outside DOM environments', () => {
+    expect(computeExpandedRightSidebarPanelWidth(null, 40)).toBe(
       RIGHT_SIDEBAR_ABSOLUTE_FALLBACK_MAX_WIDTH
     )
   })

--- a/src/renderer/src/components/right-sidebar/right-sidebar-width.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-width.ts
@@ -1,6 +1,9 @@
 export const RIGHT_SIDEBAR_MIN_WIDTH = 220
 export const RIGHT_SIDEBAR_MIN_NON_SIDEBAR_AREA = 320
 export const RIGHT_SIDEBAR_ABSOLUTE_FALLBACK_MAX_WIDTH = 2000
+// The "expand" toggle targets this fraction of the window rather than the full
+// max, so the editor/terminal keeps a usable strip instead of the 320px floor.
+export const RIGHT_SIDEBAR_EXPANDED_WINDOW_FRACTION = 0.7
 
 export function computeMaxRightSidebarPanelWidth(
   windowWidth: number | null | undefined,
@@ -24,5 +27,20 @@ export function clampRightSidebarPanelWidth(
   return Math.min(
     computeMaxRightSidebarPanelWidth(windowWidth, renderedExtraWidth),
     Math.max(RIGHT_SIDEBAR_MIN_WIDTH, width)
+  )
+}
+
+export function computeExpandedRightSidebarPanelWidth(
+  windowWidth: number | null | undefined,
+  renderedExtraWidth: number
+): number {
+  if (typeof windowWidth !== 'number' || !Number.isFinite(windowWidth)) {
+    return computeMaxRightSidebarPanelWidth(windowWidth, renderedExtraWidth)
+  }
+
+  return clampRightSidebarPanelWidth(
+    Math.round(windowWidth * RIGHT_SIDEBAR_EXPANDED_WINDOW_FRACTION),
+    windowWidth,
+    renderedExtraWidth
   )
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10118,7 +10118,9 @@
             "fc3095d2ed": "explorer",
             "aiVaultSessionHistory": "Agents",
             "folderWorkspaces": "Attached worktrees",
-            "parentPrChecks": "PR Checks"
+            "parentPrChecks": "PR Checks",
+            "expandRightSidebar": "Expand right sidebar",
+            "collapseRightSidebar": "Collapse right sidebar"
           },
           "right": {
             "panel": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -10095,7 +10095,9 @@
             "fc3095d2ed": "explorador",
             "aiVaultSessionHistory": "Agentes",
             "folderWorkspaces": "Worktrees adjuntos",
-            "parentPrChecks": "Checks de PR"
+            "parentPrChecks": "Checks de PR",
+            "expandRightSidebar": "Expandir barra lateral derecha",
+            "collapseRightSidebar": "Contraer barra lateral derecha"
           },
           "right": {
             "panel": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -10095,7 +10095,9 @@
             "fc3095d2ed": "エクスプローラ",
             "aiVaultSessionHistory": "エージェント",
             "folderWorkspaces": "添付ワークツリー",
-            "parentPrChecks": "PR チェック"
+            "parentPrChecks": "PR チェック",
+            "expandRightSidebar": "右サイドバーを展開",
+            "collapseRightSidebar": "右サイドバーを折りたたむ"
           },
           "right": {
             "panel": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10095,7 +10095,9 @@
             "fc3095d2ed": "탐색기",
             "aiVaultSessionHistory": "에이전트",
             "folderWorkspaces": "연결된 워크트리",
-            "parentPrChecks": "PR 검사"
+            "parentPrChecks": "PR 검사",
+            "expandRightSidebar": "오른쪽 사이드바 확장",
+            "collapseRightSidebar": "오른쪽 사이드바 축소"
           },
           "right": {
             "panel": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -10095,7 +10095,9 @@
             "fc3095d2ed": "资源管理器",
             "aiVaultSessionHistory": "智能体",
             "folderWorkspaces": "已附加的工作树",
-            "parentPrChecks": "PR 检查"
+            "parentPrChecks": "PR 检查",
+            "expandRightSidebar": "展开右侧边栏",
+            "collapseRightSidebar": "收起右侧边栏"
           },
           "right": {
             "panel": {

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -381,6 +381,9 @@ export type EditorSlice = {
   // Right sidebar
   rightSidebarOpen: boolean
   rightSidebarWidth: number
+  // Session-only: when true the panel renders at max width without overwriting
+  // rightSidebarWidth, so toggling off restores the user's chosen width.
+  rightSidebarExpanded: boolean
   rightSidebarTab: ActiveRightSidebarTab
   rightSidebarExplorerView: RightSidebarExplorerView
   rightSidebarRouteRequestId: number
@@ -388,6 +391,7 @@ export type EditorSlice = {
   rightSidebarExplorerViewByWorktree: Record<string, RightSidebarExplorerView>
   activityBarPosition: ActivityBarPosition
   toggleRightSidebar: () => void
+  toggleRightSidebarExpanded: () => void
   setRightSidebarOpen: (open: boolean) => void
   setRightSidebarWidth: (width: number) => void
   setRightSidebarTab: (tab: ActiveRightSidebarTab) => void
@@ -1359,6 +1363,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
   // Right sidebar
   rightSidebarOpen: false,
   rightSidebarWidth: 280,
+  rightSidebarExpanded: false,
   rightSidebarTab: 'explorer',
   rightSidebarExplorerView: 'files',
   rightSidebarRouteRequestId: 0,
@@ -1366,8 +1371,11 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
   rightSidebarExplorerViewByWorktree: {},
   activityBarPosition: 'top',
   toggleRightSidebar: () => set((s) => ({ rightSidebarOpen: !s.rightSidebarOpen })),
+  toggleRightSidebarExpanded: () => set((s) => ({ rightSidebarExpanded: !s.rightSidebarExpanded })),
   setRightSidebarOpen: (open) => set({ rightSidebarOpen: open }),
-  setRightSidebarWidth: (width) => set({ rightSidebarWidth: width }),
+  // Why: an explicit width change (e.g. dragging the resize handle) means the
+  // user picked a concrete width, so leave the auto-expanded mode.
+  setRightSidebarWidth: (width) => set({ rightSidebarWidth: width, rightSidebarExpanded: false }),
   setRightSidebarTab: (tab) =>
     set((s) => ({
       rightSidebarTab: tab,


### PR DESCRIPTION
## Summary

Adds an **expand toggle** to the right sidebar header. Clicking it widens the panel to 70% of the window width; clicking again restores the width the user had before. Dragging the resize handle while expanded exits expanded mode (the dragged width becomes the new baseline).

Expanded mode is **session-only** and never mutates the stored/persisted `rightSidebarWidth`: it only changes the *rendered* width. So toggling off — or restarting the app — restores the user's chosen width. The expand target is clamped to the same min/max bounds a manual drag respects, so the editor/terminal always keeps its reserved area and narrow windows fall back to the minimum sidebar width.

The new button sits next to the existing close button in both header layouts (top and side activity bar), reusing the existing `Tooltip` + `.sidebar-toggle` + `lucide-react` icon pattern. It shows `Maximize2` when collapsed and `Minimize2` when expanded.

## Screenshots

Right sidebar header, collapsed vs. expanded:

```
 collapsed:  [ Explorer  Agents  … ]           [ ⤢ ] [ ⇥ ]
 expanded :  [ Explorer  Agents  … ]           [ ⤡ ] [ ⇥ ]   ← panel now 70% of window
```

I could not capture a live screenshot in this environment (Electron desktop app). A short screen recording of the toggle/restore/drag-to-exit flow should be attached before merge.

## Testing

- [ ] `pnpm lint` — fails only on **pre-existing** `switch-exhaustiveness` errors in `src/main/daemon/daemon-server.ts` and `src/renderer/src/components/skills/skill-freshness-group.tsx` (untouched by this PR). oxlint/oxfmt on the changed files pass via the pre-commit hook, and the localization catalog verifier passes.
- [x] `pnpm typecheck` — passes (node + cli + web).
- [x] `pnpm test` — 32,975 passed. The 41 failures (7 files: `use-markup-draw-hint`, `pr-comment-presentation`, `pr-comments-list-selection`, `use-persisted-ai-vault-view-options`, `LinearAgentSkillSetupPrompt.reminder-toast`, …) are **pre-existing** localStorage/toast-timing environment failures reproducible on a clean checkout; **none** are in files this PR touches.
- [x] `pnpm build` (renderer bundle via `build:electron-vite`) — passes.
- [x] Added unit tests for the new `computeExpandedRightSidebarPanelWidth` helper (fraction target, wide/narrow-window clamping, non-DOM fallback) and updated the right-sidebar render-test store mock.

## AI Review Report

Reviewed the change end to end with the following focus:

- **Correctness / state**: Expanded mode is a single session-only boolean (`rightSidebarExpanded`); it derives the rendered width instead of writing it, so restore is lossless. `setRightSidebarWidth` resets the flag, which is the only setter used by the resize hook — verified there are no other callers that would leave the flag inconsistent. Fixed a sub-pixel floating-point result (`1440 * 0.7 = 1007.999…`) by rounding the target.
- **Cross-platform (macOS / Linux / Windows)**: No platform-specific code. The button reuses existing icon/tooltip primitives; no keyboard shortcut, accelerator, label, or path handling was added. Both header layouts (top and custom-desktop-chrome) get the button, and the `RIGHT_SIDEBAR_HEADER_NO_DRAG_CLASS_NAME` is applied so it stays clickable inside the draggable titlebar region on all platforms.
- **SSH / remote / local**: Purely renderer-side layout state; no process, file, credential, or network assumptions.
- **Performance**: Width is computed from existing memo-friendly inputs; no new subscriptions in hot paths. Expanded rendering reuses the existing clamp/`useWindowWidth` machinery, so window-resize handling is unchanged.
- **UI quality**: Follows `docs/STYLEGUIDE.md` — no new tokens, sizes, or colors; icon size and button class match the sibling close button.
- **i18n**: New `expandRightSidebar` / `collapseRightSidebar` keys added to all five locale catalogs (en, ko, ja, zh, es) with real translations; catalog parity verifier passes.

## Security Audit

No security-relevant surface touched. The change adds a client-side layout toggle only: no input handling, no command execution, no path handling, no auth/secret access, and no IPC changes. Persistence rides the existing debounced UI-state writer with no new fields (`rightSidebarExpanded` is intentionally not persisted). No new dependencies.

## Notes

- Expand target fraction is `RIGHT_SIDEBAR_EXPANDED_WINDOW_FRACTION = 0.7` in `right-sidebar-width.ts`, easy to tune.
- No git-provider-, agent-, or integration-specific behavior.
- X/Twitter handle: _(please add yours — I don't have it)_.



## ELI5

The right sidebar gets an expand toggle that temporarily widens it to most of the window. Toggle off or restart and your saved width comes back; dragging while expanded exits expand mode.
