### PR TITLE
perf(editor): don't slice the markdown suffix per-character in the rich-editor preprocessor

### DIFF
--- a/src/renderer/src/components/editor/raw-markdown-html.ts
+++ b/src/renderer/src/components/editor/raw-markdown-html.ts
@@ -67,9 +67,11 @@ export function encodeRawMarkdownHtmlForRichEditor(
   let result = ''
 
   while (index < normalizedContent.length) {
-    const lineRest = normalizedContent.slice(index)
-
     if (isLineStart) {
+      // Why: only line starts inspect the rest of the line, so slicing the suffix on every
+      // character (one throwaway string per char) is pure waste — compute it here. On a large
+      // doc this drops O(n) suffix allocations from the rich-editor open path (#7056).
+      const lineRest = normalizedContent.slice(index)
       const fenceMatch = lineRest.match(/^\s*(`{3,}|~{3,})/)
       if (fenceMatch) {
         const fenceChar = fenceMatch[1][0] as '`' | '~'


### PR DESCRIPTION
## What

`encodeRawMarkdownHtmlForRichEditor` — the preprocessor on the **rich Markdown editor open path** — computed `normalizedContent.slice(index)` on **every character** of the document, but that suffix string is only read at line starts (the fenced-code-block detection `match`). Move the slice inside the `if (isLineStart)` branch.

Byte-identical output; **O(lines)** suffix allocations instead of **O(chars)**.

## ELI5

To notice where code fences start, the editor was making a fresh copy of "the rest of the document from here" for every single character — but it only looks at that copy at the start of each line. Now it only makes the copy at line starts.

## Proof of zero regression

- `lineRest` is used **only** inside the `if (isLineStart)` block (the fence `match`), so the value computed is identical — pure behavior-preserving.
- Tests: the codec's round-trip + HTML-superscript + link-shortcut + programmatic-sync suites **62/62 pass** (incl. `markdown-round-trip.test.ts`, the byte-fidelity test). `typecheck:web` clean.

## Proof of perf improvement

Isolated micro-benchmark on a 2,000-line (~150 KB) doc: **76× fewer suffix allocations** (152,889 → 2,000), and the isolated slice loop drops from ~0.66 ms to ~0.29 ms/run.

## Honest scope

Surfaced while investigating **#7056** (rich editor slow to open long docs). This removes obvious per-character allocation waste, but it is a **small** contribution — the dominant cost of #7056's 3–5s open is the full TipTap/ProseMirror document construction, which is a separate, larger change (being coordinated with the issue's assignee). Shipping this independently as a clean, free win.

Made with [Orca](https://github.com/stablyai/orca) 🐋
