### PR TITLE
perf(mobile): memoize worktree list rows

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -745,14 +745,16 @@ export function HostScreen({
   const toggleCollapsed = useCallback(
     (key: string) => {
       const next = new Set(viewStateRef.current.collapsedGroups)
-      if (next.has(key)) {
-        next.delete(key)
-      } else {
+      if (!next.delete(key)) {
         next.add(key)
       }
       persistViewSettings({ collapsedGroups: [...next] })
     },
     [persistViewSettings]
+  )
+  const toggleWorktreeLineage = useCallback(
+    (item: Worktree) => toggleCollapsed(getMobileWorkspaceLineageGroupKey(item.worktreeId)),
+    [toggleCollapsed]
   )
   const { sections, rawSections, uniqueRepos, uniqueRepoColors } = useWorkspaceSections({
     displayWorktrees,
@@ -1200,9 +1202,7 @@ export function HostScreen({
               hideRepo={groupMode === 'repo'}
               onPress={openWorktreeSession}
               onLongPress={item.workspaceKind === 'folder-workspace' ? undefined : setActionTarget}
-              onToggleLineage={(row) =>
-                toggleCollapsed(getMobileWorkspaceLineageGroupKey(row.worktreeId))
-              }
+              onToggleLineage={toggleWorktreeLineage}
             />
           )}
         />

--- a/mobile/src/components/WorktreeAgentRow.tsx
+++ b/mobile/src/components/WorktreeAgentRow.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import { StyleSheet, Text, View } from 'react-native'
 import type { RuntimeWorktreeAgentRow } from '../../../src/shared/runtime-types'
 import { colors, spacing } from '../theme/mobile-theme'
@@ -18,7 +19,7 @@ type Props = {
 
 // One inline agent row: state dot → identity → last message/prompt → time ago.
 // Mirrors desktop DashboardAgentRow's compact in-card layout.
-export function WorktreeAgentRow({ agent, depth, now, unvisited }: Props) {
+function WorktreeAgentRowComponent({ agent, depth, now, unvisited }: Props) {
   const dotState = agentDotState(agent, now)
   const label = agentDisplayLabel(agent, now)
   const ts = formatTimeAgo(agent.stateStartedAt, now)
@@ -36,6 +37,8 @@ export function WorktreeAgentRow({ agent, depth, now, unvisited }: Props) {
     </View>
   )
 }
+
+export const WorktreeAgentRow = memo(WorktreeAgentRowComponent)
 
 const styles = StyleSheet.create({
   row: {

--- a/mobile/src/components/WorktreeListRow.test.ts
+++ b/mobile/src/components/WorktreeListRow.test.ts
@@ -1,0 +1,212 @@
+import {
+  createElement,
+  Fragment,
+  useCallback,
+  useState,
+  type Dispatch,
+  type SetStateAction
+} from 'react'
+import { Text } from 'react-native'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeWorktreeAgentRow } from '../../../src/shared/runtime-types'
+import { WorktreeAgentRow } from './WorktreeAgentRow'
+import { WorktreeListRow, type WorktreeListRowItem } from './WorktreeListRow'
+
+const { agentSpinnerRender, agentStateDotRender } = vi.hoisted(() => ({
+  agentSpinnerRender: vi.fn(),
+  agentStateDotRender: vi.fn()
+}))
+
+vi.mock('react-native', () => ({
+  Pressable: 'Pressable',
+  StyleSheet: { create: <T>(styles: T) => styles },
+  Text: 'Text',
+  View: 'View'
+}))
+
+vi.mock('lucide-react-native', () => ({
+  Bell: 'Bell',
+  ChevronDown: 'ChevronDown',
+  ChevronRight: 'ChevronRight',
+  GitBranch: 'GitBranch',
+  GitPullRequest: 'GitPullRequest'
+}))
+
+vi.mock('../platform/haptics', () => ({ triggerMediumImpact: vi.fn() }))
+vi.mock('./AgentSpinner', () => ({
+  AgentSpinner: (props: unknown) => {
+    agentSpinnerRender(props)
+    return null
+  }
+}))
+vi.mock('./AgentStateDot', () => ({
+  AgentStateDot: (props: unknown) => {
+    agentStateDotRender(props)
+    return null
+  }
+}))
+vi.mock('./MobileAgentIcon', () => ({ MobileAgentIcon: () => null }))
+vi.mock('./MobileRepoIcon', () => ({ MobileRepoIcon: () => null }))
+vi.mock('./WorktreeAgentList', () => ({ WorktreeAgentList: () => null }))
+vi.mock('./WorktreeMetaGlyphs', () => ({
+  prStateColor: () => '#000000',
+  WorktreeMetaGlyphs: () => null
+}))
+
+type TestItem = WorktreeListRowItem & {
+  status: 'working' | 'active' | 'permission' | 'done' | 'inactive'
+  lastOutputAt: number
+}
+
+const stableRepoIcon = { type: 'emoji', emoji: 'o' } as const
+let updateSibling: Dispatch<SetStateAction<number>> = () => undefined
+
+function ListRowHarness({ item, now }: { item: TestItem; now: number }) {
+  const [sibling, setSibling] = useState(0)
+  updateSibling = setSibling
+  const onPress = useCallback(() => undefined, [])
+  const onLongPress = useCallback(() => undefined, [])
+  const onToggleLineage = useCallback(() => undefined, [])
+
+  // Sibling state changes re-render the harness without changing the row's props,
+  // exercising the row's React.memo bailout.
+  return createElement(
+    Fragment,
+    null,
+    createElement(Text, null, sibling),
+    createElement(WorktreeListRow, {
+      item,
+      isReadOnly: false,
+      now,
+      repoColor: '#000000',
+      repoIcon: stableRepoIcon,
+      hideRepo: false,
+      status: item.status,
+      onPress,
+      onLongPress,
+      onToggleLineage
+    })
+  )
+}
+
+function agent(overrides: Partial<RuntimeWorktreeAgentRow> = {}): RuntimeWorktreeAgentRow {
+  return {
+    paneKey: 'agent-1',
+    parentPaneKey: null,
+    state: 'working',
+    agentType: null,
+    prompt: 'Fix the list',
+    taskTitle: null,
+    displayName: null,
+    lastAssistantMessage: null,
+    toolName: null,
+    toolInput: null,
+    interrupted: false,
+    stateStartedAt: 1_000,
+    updatedAt: 1_000,
+    ...overrides
+  }
+}
+
+const baseItem: TestItem = {
+  worktreeId: 'worktree-1',
+  repo: 'orca',
+  branch: 'feature/mobile-list',
+  displayName: 'mobile-list',
+  liveTerminalCount: 1,
+  preview: 'Waiting',
+  unread: false,
+  linkedPR: null,
+  agents: [agent()],
+  status: 'active',
+  lastOutputAt: 1_000
+}
+
+describe('memoized worktree rows', () => {
+  let renderer: ReactTestRenderer | null = null
+
+  beforeEach(() => {
+    ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    agentSpinnerRender.mockClear()
+    agentStateDotRender.mockClear()
+  })
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+  })
+
+  it('skips an unrelated parent render but updates for live item fields and time', async () => {
+    await act(async () => {
+      renderer = create(createElement(ListRowHarness, { item: baseItem, now: 2_000 }))
+    })
+    expect(agentSpinnerRender).toHaveBeenCalledTimes(1)
+
+    await act(async () => updateSibling((value) => value + 1))
+    expect(agentSpinnerRender).toHaveBeenCalledTimes(1)
+
+    let expectedRenders = 1
+    const liveUpdates: TestItem[] = [
+      { ...baseItem, preview: 'Running tests' },
+      { ...baseItem, unread: true },
+      { ...baseItem, lastOutputAt: 2_000 },
+      { ...baseItem, agents: [agent({ state: 'waiting', updatedAt: 2_000 })] },
+      { ...baseItem, status: 'working' }
+    ]
+    for (const liveUpdate of liveUpdates) {
+      await act(async () =>
+        renderer!.update(createElement(ListRowHarness, { item: liveUpdate, now: 2_000 }))
+      )
+      expect(agentSpinnerRender).toHaveBeenCalledTimes(++expectedRenders)
+      await act(async () =>
+        renderer!.update(createElement(ListRowHarness, { item: baseItem, now: 2_000 }))
+      )
+      expect(agentSpinnerRender).toHaveBeenCalledTimes(++expectedRenders)
+    }
+
+    await act(async () =>
+      renderer!.update(createElement(ListRowHarness, { item: baseItem, now: 32_000 }))
+    )
+    expect(agentSpinnerRender).toHaveBeenCalledTimes(++expectedRenders)
+  })
+
+  it('memoizes agent rows without hiding agent updates', async () => {
+    const firstAgent = agent()
+    await act(async () => {
+      renderer = create(
+        createElement(WorktreeAgentRow, {
+          agent: firstAgent,
+          depth: 0,
+          now: 2_000,
+          unvisited: false
+        })
+      )
+    })
+    expect(agentStateDotRender).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      renderer!.update(
+        createElement(WorktreeAgentRow, {
+          agent: firstAgent,
+          depth: 0,
+          now: 2_000,
+          unvisited: false
+        })
+      )
+    })
+    expect(agentStateDotRender).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      renderer!.update(
+        createElement(WorktreeAgentRow, {
+          agent: agent({ state: 'done', updatedAt: 2_000 }),
+          depth: 0,
+          now: 2_000,
+          unvisited: false
+        })
+      )
+    })
+    expect(agentStateDotRender).toHaveBeenCalledTimes(2)
+  })
+})

--- a/mobile/src/components/WorktreeListRow.tsx
+++ b/mobile/src/components/WorktreeListRow.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import { Bell, ChevronDown, ChevronRight, GitBranch, GitPullRequest } from 'lucide-react-native'
 import { Pressable, StyleSheet, Text, View } from 'react-native'
 import type { RepoIcon } from '../../../src/shared/repo-icon'
@@ -57,7 +58,7 @@ type Props<T extends WorktreeListRowItem> = {
   onToggleLineage?: (item: T) => void
 }
 
-export function WorktreeListRow<T extends WorktreeListRowItem>({
+function WorktreeListRowComponent<T extends WorktreeListRowItem>({
   item,
   isReadOnly,
   now,
@@ -194,6 +195,8 @@ export function WorktreeListRow<T extends WorktreeListRowItem>({
     </Pressable>
   )
 }
+
+export const WorktreeListRow = memo(WorktreeListRowComponent) as typeof WorktreeListRowComponent
 
 const styles = StyleSheet.create({
   worktreeRow: {


### PR DESCRIPTION
## What

The mobile host worktree list rows (`WorktreeListRow`, `WorktreeAgentRow`) were not memoized, so **any** unrelated parent re-render reconciled every visible row — noticeable on large lists / the tablet sidebar. #9857 already preserves the worktree-array identity on equal snapshots, but the rows still re-rendered because the parent did.

Fix: wrap both rows in `React.memo` (default shallow comparison) and stabilize the one prop that defeated it — `onToggleLineage` is now a `useCallback` that reads the worktree id from the row's `item`, instead of an inline per-row closure. The `now` prop stays a real prop so relative timestamps / status aging still update.

## ELI5

Your worktree list re-drew every single row whenever anything on the screen changed. Now each row only re-draws when its own data (status, preview, unread, agents…) actually changes.

## Proof of zero regression

- **Default shallow `memo` comparison** — no custom comparator — so every live field (`preview`, `unread`, `lastOutputAt`, `agents`, `status`, `now`) still invalidates the row. #9857's snapshot equality keeps the `item` reference stable only when nothing changed, so the memo bailout is safe and effective.
- Prop-stability audited: `item` (snapshot-stable), primitives (`now`/`status`/`repoColor`/`hideRepo`/`isReadOnly`), `repoIcon` (state-owned map), `onPress`/`onLongPress` (stable), and the new `useCallback` `onToggleLineage`.
- Tests: a new render-count test (converted to the mobile `.ts` + `createElement` convention) proves an **unrelated sibling render does not re-render the row**, while `preview`/`unread`/`lastOutputAt`/`agents`/`status`/`now` changes **do** — and agent rows skip unchanged props but render for a changed agent. **Full mobile suite 307 files / 2229 pass**; `typecheck` / `oxlint` (index.tsx stays within its max-lines budget) / `oxfmt --check` clean.

## Proof of perf improvement

Cuts row reconciliation on unrelated parent renders (which fire frequently on a live dashboard) — low-medium JS-thread savings that scale with list length, most visible on the tablet sidebar. The test directly asserts the row render count stays flat across an unrelated sibling update.

Made with [Orca](https://github.com/stablyai/orca) 🐋
