### PR TITLE
feat(speech): add Korean streaming zipformer STT model

### DIFF
--- a/src/main/speech/model-catalog.ts
+++ b/src/main/speech/model-catalog.ts
@@ -124,6 +124,28 @@ export const SPEECH_MODEL_CATALOG: SpeechModelManifest[] = [
     modelingUnit: 'cjkchar'
   },
   {
+    id: 'zipformer-streaming-korean',
+    label: 'Zipformer Streaming KO',
+    description: 'Korean only. Low-latency real-time streaming.',
+    type: 'transducer',
+    provider: 'local',
+    language: 'ko',
+    sizeBytes: 418_218_652,
+    downloadUrl:
+      'https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-streaming-zipformer-korean-2024-06-16.tar.bz2',
+    archiveSha256: 'e346a5882a409650472be17326237e24df7bf409db6b4a8a52e1a61422bf2500',
+    archiveFormat: 'tar.bz2',
+    files: [
+      'encoder-epoch-99-avg-1.int8.onnx',
+      'decoder-epoch-99-avg-1.int8.onnx',
+      'joiner-epoch-99-avg-1.int8.onnx',
+      'tokens.txt'
+    ],
+    sampleRate: 16000,
+    streaming: true,
+    modelingUnit: 'bpe'
+  },
+  {
     id: 'whisper-tiny',
     label: 'Whisper Tiny',
     description: '90+ languages. Lower accuracy than Parakeet but broadest language coverage.',


### PR DESCRIPTION
## Summary

Adds a **Korean speech model** to the Voice Dictation catalog: `sherpa-onnx-streaming-zipformer-korean-2024-06-16` from the official k2-fsa sherpa-onnx `asr-models` release. The catalog currently has English, Chinese/English, and multilingual (Whisper Tiny / OpenAI cloud) options, but no dedicated Korean model — Korean users had no good local dictation path.

The model is a **streaming transducer**, so it slots into the existing streaming-transducer worker path with **zero engine changes** — this PR is a single catalog manifest entry, exactly like the existing `zipformer-streaming-zh-14m` pattern:

- int8 ONNX files (encoder/decoder/joiner) for lower memory and faster CPU-only inference
- 16 kHz, real-time streaming partial results, BPE modeling unit
- `sizeBytes` matches the exact upstream asset size (it's the UI size label and the progress denominator), and `archiveSha256` was computed from the downloaded upstream asset

## Screenshots

No visual change beyond one new row in Settings → Voice → Speech models ("Zipformer Streaming KO", 418 MB, download/select like every other local model). The row is rendered entirely by the existing `VoiceSpeechModelSection` list.

## Testing

- [x] `pnpm lint` — oxlint/oxfmt pass on the changed file (pre-commit hook). The repo-wide `lint:switch-exhaustiveness` step fails on two **pre-existing** errors in `src/main/daemon/daemon-server.ts` and `src/renderer/src/components/skills/skill-freshness-group.tsx`, both untouched by this PR.
- [x] `pnpm typecheck` — passes (node + cli + web).
- [x] `pnpm test` — 32,963 passed. Speech suites all green (15 files / 84 tests, including `model-manager.test.ts` which iterates every catalog manifest). The 49 failures across 12 files are **pre-existing** localStorage/toast-timing environment failures also reproducible on a clean `main` checkout; none touch speech, voice settings, or the catalog.
- [x] `pnpm build` (renderer/main bundles via `build:electron-vite`) — passes.
- [x] **Real model smoke test**: downloaded the archive, verified SHA256 + byte size against the GitHub asset, confirmed every `files` entry exists in the archive, then loaded the recognizer in Node with the exact config shape `stt-worker.ts` builds (int8 transducer files, `greedy_search`, endpoint rules) and decoded the four bundled Korean test wavs — all transcribed correctly (e.g. `주민등록증을 보여 주시겠어요?` exact match).
- No new tests added: `model-manager.test.ts` already validates all catalog manifests generically, and this change adds data, not behavior.

## AI Review Report

- **Correctness**: `files` roles resolve via substring match in `stt-worker-model-config.ts` (`encoder`/`decoder`/`joiner` + `tokens.txt`) — verified the int8 filenames resolve unambiguously. `modelingUnit: 'bpe'` matches the bundled `bpe.model`; the archive ships no `.vocab`, so hotwords fall back to `greedy_search` exactly like other catalog models.
- **Cross-platform (macOS / Linux / Windows)**: no platform-specific code; the model runs through the existing sherpa-onnx native addons already shipped for all five platform packages. Download/extract/verify paths are the existing `model-manager` code (uses Node path utilities, has Windows-path tests).
- **SSH / remote / local**: dictation is host-local (mic capture + local inference in the main process); no interaction with SSH worktrees or remote runtimes. The mobile/web RPC dictation path routes through the same catalog.
- **Performance**: int8 variant chosen deliberately (~faster CPU inference, lower memory than fp32); streaming model feeds incrementally, no offline chunking. No hot-path code touched.
- **Provider/integration neutrality**: local model, no new provider; cloud OpenAI path untouched.
- **Security-adjacent**: download URL is the official k2-fsa GitHub release; archive is SHA256-pinned so a moved/tampered asset fails verification rather than installing.

## Security Audit

Data-only change. The one security-relevant surface — downloading and extracting a remote archive — is the existing, tested `model-manager` pipeline (HTTPS GitHub release URL, SHA256 verification before extraction, extraction into the app's models dir). The new entry pins the checksum computed from the real upstream asset. No input handling, command execution, auth, IPC, or dependency changes.

## Notes

- Model card: [k2-fsa streaming zipformer Korean (2024-06-16)](https://k2-fsa.github.io/sherpa/onnx/pretrained_models/online-transducer/zipformer-transducer-models.html) — trained on Korean; punctuation is partially emitted by the model itself.
- Follow-up candidates (out of scope here): SenseVoice (zh/en/ja/ko/yue) would need a new engine branch in `stt-worker.ts`; Korean-native cloud vendors (CLOVA/VITO) would need a new cloud provider surface.
- X/Twitter handle: _(please add yours)_.
