### PR TITLE
fix(github): show current PR check status

### DIFF
--- a/src/main/github/client-pr-checks.test.ts
+++ b/src/main/github/client-pr-checks.test.ts
@@ -134,23 +134,37 @@ function graphQLCheckRun(
     conclusion: string | null
     detailsUrl: string | null
     url: string | null
+    startedAt: string | null
+    completedAt: string | null
     checkSuiteId: number | null
     workflowRunId: number | null
+    workflowName: string | null
+    appSlug: string | null
   }> = {}
 ): Record<string, unknown> {
   const checkSuiteId = overrides.checkSuiteId ?? 1000
-  const workflowRunId = overrides.workflowRunId ?? 1
+  const workflowRunId = overrides.workflowRunId === null ? null : (overrides.workflowRunId ?? 1)
   return {
     __typename: 'CheckRun',
     databaseId: overrides.databaseId ?? 88,
     name: overrides.name ?? 'build',
     status: overrides.status ?? 'COMPLETED',
     conclusion: overrides.conclusion ?? 'SUCCESS',
+    startedAt: overrides.startedAt ?? '2026-07-22T01:00:00Z',
+    completedAt: overrides.completedAt ?? '2026-07-22T01:01:00Z',
     detailsUrl: overrides.detailsUrl ?? 'https://github.com/acme/widgets/actions/runs/1',
     url: overrides.url ?? 'https://github.com/acme/widgets/runs/88',
     checkSuite: {
       databaseId: checkSuiteId,
-      workflowRun: workflowRunId === null ? null : { databaseId: workflowRunId }
+      app: overrides.appSlug === null ? null : { slug: overrides.appSlug ?? 'github-actions' },
+      workflowRun:
+        workflowRunId === null
+          ? null
+          : {
+              databaseId: workflowRunId,
+              workflow:
+                overrides.workflowName === null ? null : { name: overrides.workflowName ?? 'CI' }
+            }
     }
   }
 }
@@ -205,6 +219,8 @@ function expectGraphQLRollupCall(callIndex = 1, noCache = false): void {
   const queryArg = args.find((arg) => arg.startsWith('query='))
   expect(queryArg).toContain('statusCheckRollup')
   expect(queryArg).toContain('checkSuites')
+  expect(queryArg).toContain('startedAt')
+  expect(queryArg).toContain('completedAt')
 }
 
 describe('getPRChecks', () => {
@@ -261,6 +277,33 @@ describe('getPRChecks', () => {
     ])
   })
 
+  it('maps check runs without workflow metadata', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce(
+      graphQLChecksResponse({
+        contexts: [
+          graphQLCheckRun({
+            workflowRunId: null,
+            detailsUrl: 'https://ci.example.com/checks/88',
+            url: null
+          })
+        ]
+      })
+    )
+
+    const checks = await getPRChecks('/repo-root', 42, 'head-oid')
+
+    expect(checks).toEqual([
+      {
+        name: 'build',
+        status: 'completed',
+        conclusion: 'success',
+        url: 'https://ci.example.com/checks/88',
+        checkRunId: 88
+      }
+    ])
+  })
+
   it('merges rollup check-runs with legacy commit status contexts', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock.mockResolvedValueOnce(
@@ -301,6 +344,46 @@ describe('getPRChecks', () => {
         conclusion: 'pending',
         url: 'https://jenkins.example.com/job/merge/1'
       }
+    ])
+  })
+
+  it('keeps only the newest run for a repeated check context', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce(
+      graphQLChecksResponse({
+        contexts: [
+          graphQLCheckRun({
+            databaseId: 87,
+            name: 'merge-label',
+            conclusion: 'FAILURE',
+            startedAt: '2026-07-22T02:08:00Z',
+            completedAt: '2026-07-22T02:09:00Z',
+            checkSuiteId: 999,
+            workflowRunId: 7
+          }),
+          graphQLCheckRun({
+            databaseId: 88,
+            name: 'merge-label',
+            conclusion: 'SUCCESS',
+            startedAt: '2026-07-22T02:21:00Z',
+            completedAt: '2026-07-22T02:22:00Z',
+            checkSuiteId: 1000,
+            workflowRunId: 8
+          })
+        ],
+        checkSuites: [graphQLCheckSuite({ databaseId: 999 })]
+      })
+    )
+
+    const checks = await getPRChecks('/repo-root', 42, 'head-oid')
+
+    expect(checks).toEqual([
+      expect.objectContaining({
+        name: 'merge-label',
+        conclusion: 'success',
+        checkRunId: 88,
+        workflowRunId: 8
+      })
     ])
   })
 

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -109,6 +109,7 @@ import {
   deriveCheckStatus
 } from './mappers'
 import { mapGraphQLReactionGroups, type GitHubGraphQLReactionGroup } from './comment-reactions'
+import { deriveGitHubCheckSummary, selectLatestGitHubCheckContexts } from './github-check-rollup'
 import {
   getRateLimit,
   noteRepositoryRateLimitSpend,
@@ -643,57 +644,6 @@ function isAutoMergeEnabled(value: unknown): boolean {
   return typeof value === 'object' && value !== null
 }
 
-function checkRollupEntries(value: unknown): unknown[] {
-  if (Array.isArray(value)) {
-    return value
-  }
-  if (typeof value !== 'object' || value === null) {
-    return []
-  }
-  const raw = value as Record<string, unknown>
-  const nodes = (raw.contexts as { nodes?: unknown } | undefined)?.nodes
-  return Array.isArray(nodes) ? nodes : []
-}
-
-function deriveWorkItemCheckSummary(value: unknown): GitHubWorkItem['checksSummary'] {
-  const entries = checkRollupEntries(value)
-  if (entries.length === 0) {
-    return { state: 'none', total: 0, passed: 0, failed: 0, pending: 0 }
-  }
-  let passed = 0
-  let failed = 0
-  let pending = 0
-  for (const entry of entries) {
-    if (typeof entry !== 'object' || entry === null) {
-      pending += 1
-      continue
-    }
-    const raw = entry as Record<string, unknown>
-    const conclusion = String(raw.conclusion ?? raw.state ?? '').toUpperCase()
-    const status = String(raw.status ?? '').toUpperCase()
-    if (['SUCCESS', 'NEUTRAL', 'SKIPPED'].includes(conclusion)) {
-      passed += 1
-    } else if (
-      ['FAILURE', 'ERROR', 'TIMED_OUT', 'CANCELLED', 'ACTION_REQUIRED', 'STARTUP_FAILURE'].includes(
-        conclusion
-      )
-    ) {
-      failed += 1
-    } else if (status === 'COMPLETED' && conclusion) {
-      failed += 1
-    } else {
-      pending += 1
-    }
-  }
-  return {
-    state: failed > 0 ? 'failure' : pending > 0 ? 'pending' : 'success',
-    total: entries.length,
-    passed,
-    failed,
-    pending
-  }
-}
-
 function mapPullRequestWorkItem(
   item: Record<string, unknown>,
   baseOwnerRepo: OwnerRepo | null = null
@@ -779,7 +729,7 @@ function mapPullRequestWorkItem(
       : {}),
     ...(item.assignees !== undefined ? { assignees: usersFromUnknown(item.assignees) } : {}),
     ...(item.statusCheckRollup !== undefined
-      ? { checksSummary: deriveWorkItemCheckSummary(item.statusCheckRollup) }
+      ? { checksSummary: deriveGitHubCheckSummary(item.statusCheckRollup) }
       : {}),
     ...(mergeable ? { mergeable } : {}),
     ...('autoMergeRequest' in item
@@ -3244,18 +3194,27 @@ query($owner: String!, $repo: String!, $pr: Int!) {
                     name
                     status
                     conclusion
+                    startedAt
+                    completedAt
                     detailsUrl
                     url
                     checkSuite {
                       databaseId
+                      app {
+                        slug
+                      }
                       workflowRun {
                         databaseId
+                        workflow {
+                          name
+                        }
                       }
                     }
                   }
                   ... on StatusContext {
                     context
                     state
+                    createdAt
                     targetUrl
                   }
                 }
@@ -3311,11 +3270,17 @@ type GraphQLCheckRunContext = {
   name?: string | null
   status?: string | null
   conclusion?: string | null
+  startedAt?: string | null
+  completedAt?: string | null
   detailsUrl?: string | null
   url?: string | null
   checkSuite?: {
     databaseId?: number | null
-    workflowRun?: { databaseId?: number | null } | null
+    app?: { slug?: string | null } | null
+    workflowRun?: {
+      databaseId?: number | null
+      workflow?: { name?: string | null } | null
+    } | null
   } | null
 }
 
@@ -3323,6 +3288,7 @@ type GraphQLStatusContext = {
   __typename: 'StatusContext'
   context?: string | null
   state?: string | null
+  createdAt?: string | null
   targetUrl?: string | null
 }
 
@@ -3465,14 +3431,17 @@ function mapGraphQLPRChecksResponse(
     return []
   }
 
-  const contexts = commit.statusCheckRollup?.contexts?.nodes ?? []
+  const allContexts = commit.statusCheckRollup?.contexts?.nodes ?? []
+  const contexts = selectLatestGitHubCheckContexts(allContexts)
   const checkRunContexts = contexts.filter(isGraphQLCheckRunContext)
   const checkRuns = checkRunContexts
     .map(mapGraphQLCheckRunContext)
     .filter((check): check is PRCheckDetail => check !== null)
   const checkRunNames = new Set(checkRuns.map((check) => check.name))
+  // 原因：被新运行替代的旧 CheckRun 仍证明检查套件已启动，不能再生成 action_required 占位项。
   const checkSuiteIdsWithRuns = new Set(
-    checkRunContexts
+    allContexts
+      .filter(isGraphQLCheckRunContext)
       .map((context) => nullableNumber(context.checkSuite?.databaseId))
       .filter((id): id is number => id !== null)
   )

--- a/src/main/github/github-check-rollup.test.ts
+++ b/src/main/github/github-check-rollup.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import { deriveGitHubCheckSummary, selectLatestGitHubCheckContexts } from './github-check-rollup'
+
+function checkRun(
+  name: string,
+  conclusion: string,
+  startedAt?: string,
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    __typename: 'CheckRun',
+    name,
+    status: 'COMPLETED',
+    conclusion,
+    startedAt,
+    workflowName: 'CI',
+    ...overrides
+  }
+}
+
+describe('selectLatestGitHubCheckContexts', () => {
+  it('keeps the newest check run for each stable context', () => {
+    const oldFailure = checkRun('merge-label', 'FAILURE', '2026-07-22T02:08:00Z')
+    const latestSuccess = checkRun('merge-label', 'SUCCESS', '2026-07-22T02:21:00Z')
+
+    expect(selectLatestGitHubCheckContexts([latestSuccess, oldFailure])).toEqual([latestSuccess])
+  })
+
+  it('uses the later input when timestamps are absent or equal', () => {
+    const noTimeFailure = checkRun('build', 'FAILURE')
+    const noTimeSuccess = checkRun('build', 'SUCCESS')
+    const equalTimeFailure = checkRun('lint', 'FAILURE', '2026-07-22T03:00:00Z')
+    const equalTimeSuccess = checkRun('lint', 'SUCCESS', '2026-07-22T03:00:00Z')
+
+    expect(
+      selectLatestGitHubCheckContexts([
+        noTimeFailure,
+        noTimeSuccess,
+        equalTimeFailure,
+        equalTimeSuccess
+      ])
+    ).toEqual([noTimeSuccess, equalTimeSuccess])
+  })
+
+  it('keeps check runs from different apps separate', () => {
+    const actionsBuild = checkRun('build', 'SUCCESS', '2026-07-22T03:00:00Z', {
+      workflowName: 'CI',
+      checkSuite: { app: { slug: 'github-actions' } }
+    })
+    const externalBuild = checkRun('build', 'SUCCESS', '2026-07-22T03:02:00Z', {
+      workflowName: 'CI',
+      checkSuite: { app: { slug: 'external-ci' } }
+    })
+
+    expect(selectLatestGitHubCheckContexts([actionsBuild, externalBuild])).toEqual([
+      actionsBuild,
+      externalBuild
+    ])
+  })
+
+  it('uses the workflow as the provider fallback when app metadata is unavailable', () => {
+    const ciBuild = checkRun('build', 'SUCCESS', '2026-07-22T03:00:00Z')
+    const releaseBuild = checkRun('build', 'SUCCESS', '2026-07-22T03:01:00Z', {
+      workflowName: 'Release'
+    })
+
+    expect(selectLatestGitHubCheckContexts([ciBuild, releaseBuild])).toEqual([
+      ciBuild,
+      releaseBuild
+    ])
+  })
+
+  it('does not merge legacy statuses with check runs sharing a display name', () => {
+    const run = checkRun('build', 'SUCCESS', '2026-07-22T03:00:00Z')
+    const status = {
+      __typename: 'StatusContext',
+      context: 'build',
+      state: 'FAILURE',
+      createdAt: '2026-07-22T03:01:00Z'
+    }
+
+    expect(selectLatestGitHubCheckContexts([run, status])).toEqual([run, status])
+  })
+
+  it('keeps unrecognized entries instead of dropping their pending signal', () => {
+    expect(selectLatestGitHubCheckContexts([null, { status: 'QUEUED' }, 'unknown'])).toEqual([
+      null,
+      { status: 'QUEUED' },
+      'unknown'
+    ])
+  })
+})
+
+describe('deriveGitHubCheckSummary', () => {
+  it('counts only the latest result after repeated fail and pass cycles', () => {
+    const summary = deriveGitHubCheckSummary([
+      checkRun('merge-label', 'FAILURE', '2026-07-22T02:08:00Z'),
+      checkRun('merge-label', 'SUCCESS', '2026-07-22T02:21:00Z'),
+      checkRun('merge-label', 'FAILURE', '2026-07-22T02:30:00Z'),
+      checkRun('merge-label', 'SUCCESS', '2026-07-22T02:42:00Z'),
+      checkRun('lint', 'SUCCESS', '2026-07-22T02:10:00Z')
+    ])
+
+    expect(summary).toEqual({ state: 'success', total: 2, passed: 2, failed: 0, pending: 0 })
+  })
+
+  it('accepts the GraphQL rollup wrapper and deduplicates legacy statuses', () => {
+    const summary = deriveGitHubCheckSummary({
+      contexts: {
+        nodes: [
+          {
+            __typename: 'StatusContext',
+            context: 'jenkins',
+            state: 'FAILURE',
+            createdAt: '2026-07-22T02:08:00Z'
+          },
+          {
+            __typename: 'StatusContext',
+            context: 'jenkins',
+            state: 'SUCCESS',
+            createdAt: '2026-07-22T02:21:00Z'
+          }
+        ]
+      }
+    })
+
+    expect(summary).toEqual({ state: 'success', total: 1, passed: 1, failed: 0, pending: 0 })
+  })
+})

--- a/src/main/github/github-check-rollup.test.ts
+++ b/src/main/github/github-check-rollup.test.ts
@@ -42,6 +42,21 @@ describe('selectLatestGitHubCheckContexts', () => {
     ).toEqual([noTimeSuccess, equalTimeSuccess])
   })
 
+  it('uses the check-run id when a queued rerun has no timestamps and arrives first', () => {
+    const queued = checkRun('build', '', undefined, {
+      databaseId: 102,
+      status: 'QUEUED',
+      conclusion: null,
+      startedAt: null,
+      completedAt: null
+    })
+    const completed = checkRun('build', 'SUCCESS', '2026-07-22T03:00:00Z', {
+      databaseId: 101
+    })
+
+    expect(selectLatestGitHubCheckContexts([queued, completed])).toEqual([queued])
+  })
+
   it('keeps check runs from different apps separate', () => {
     const actionsBuild = checkRun('build', 'SUCCESS', '2026-07-22T03:00:00Z', {
       workflowName: 'CI',
@@ -62,6 +77,22 @@ describe('selectLatestGitHubCheckContexts', () => {
     const ciBuild = checkRun('build', 'SUCCESS', '2026-07-22T03:00:00Z')
     const releaseBuild = checkRun('build', 'SUCCESS', '2026-07-22T03:01:00Z', {
       workflowName: 'Release'
+    })
+
+    expect(selectLatestGitHubCheckContexts([ciBuild, releaseBuild])).toEqual([
+      ciBuild,
+      releaseBuild
+    ])
+  })
+
+  it('keeps same-name jobs from different workflows in the same app separate', () => {
+    const ciBuild = checkRun('build', 'SUCCESS', '2026-07-22T03:00:00Z', {
+      workflowName: 'CI',
+      checkSuite: { app: { slug: 'github-actions' } }
+    })
+    const releaseBuild = checkRun('build', 'SUCCESS', '2026-07-22T03:01:00Z', {
+      workflowName: 'Release',
+      checkSuite: { app: { slug: 'github-actions' } }
     })
 
     expect(selectLatestGitHubCheckContexts([ciBuild, releaseBuild])).toEqual([
@@ -92,6 +123,24 @@ describe('selectLatestGitHubCheckContexts', () => {
 })
 
 describe('deriveGitHubCheckSummary', () => {
+  it('reports a newer queued rerun when GitHub omits its timestamps', () => {
+    const completed = checkRun('build', 'SUCCESS', '2026-07-22T03:00:00Z')
+    const queued = checkRun('build', '', undefined, {
+      status: 'QUEUED',
+      conclusion: null,
+      startedAt: null,
+      completedAt: null
+    })
+
+    expect(deriveGitHubCheckSummary([completed, queued])).toEqual({
+      state: 'pending',
+      total: 1,
+      passed: 0,
+      failed: 0,
+      pending: 1
+    })
+  })
+
   it('counts only the latest result after repeated fail and pass cycles', () => {
     const summary = deriveGitHubCheckSummary([
       checkRun('merge-label', 'FAILURE', '2026-07-22T02:08:00Z'),

--- a/src/main/github/github-check-rollup.ts
+++ b/src/main/github/github-check-rollup.ts
@@ -1,0 +1,180 @@
+import type { GitHubPRCheckSummary } from '../../shared/types'
+
+type CheckContextKind = 'CheckRun' | 'StatusContext'
+
+type SelectedContext<T> = {
+  entry: T
+  index: number
+  timestamp: number | null
+}
+
+function recordFromUnknown(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null
+}
+
+function stringFromUnknown(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+function nestedRecord(
+  value: Record<string, unknown> | null,
+  key: string
+): Record<string, unknown> | null {
+  return recordFromUnknown(value?.[key])
+}
+
+function checkContextKind(entry: Record<string, unknown>): CheckContextKind | null {
+  if (entry.__typename === 'CheckRun') {
+    return 'CheckRun'
+  }
+  if (entry.__typename === 'StatusContext') {
+    return 'StatusContext'
+  }
+  if (stringFromUnknown(entry.name)) {
+    return 'CheckRun'
+  }
+  if (stringFromUnknown(entry.context)) {
+    return 'StatusContext'
+  }
+  return null
+}
+
+function checkRunIdentity(entry: Record<string, unknown>): string | null {
+  const name = stringFromUnknown(entry.name)
+  if (!name) {
+    return null
+  }
+  const checkSuite = nestedRecord(entry, 'checkSuite')
+  const workflowRun = nestedRecord(checkSuite, 'workflowRun')
+  const app = nestedRecord(checkSuite, 'app') ?? nestedRecord(entry, 'app')
+  const workflow = nestedRecord(workflowRun, 'workflow')
+  const appSlug = stringFromUnknown(app?.slug)
+  const workflowName = stringFromUnknown(entry.workflowName) ?? stringFromUnknown(workflow?.name)
+  const provider = appSlug ? `app:${appSlug}` : workflowName ? `workflow:${workflowName}` : null
+  return JSON.stringify(['CheckRun', name, provider])
+}
+
+function checkContextIdentity(entry: Record<string, unknown>): string | null {
+  const kind = checkContextKind(entry)
+  if (kind === 'CheckRun') {
+    return checkRunIdentity(entry)
+  }
+  if (kind === 'StatusContext') {
+    const context = stringFromUnknown(entry.context)
+    return context ? JSON.stringify(['StatusContext', context]) : null
+  }
+  return null
+}
+
+function timestampFromUnknown(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+  if (typeof value !== 'string') {
+    return null
+  }
+  const timestamp = Date.parse(value)
+  return Number.isFinite(timestamp) ? timestamp : null
+}
+
+function checkContextTimestamp(entry: Record<string, unknown>): number | null {
+  const kind = checkContextKind(entry)
+  // 原因：运行开始时间能区分同名重跑且不受完成时刻变化影响；旧式状态则以创建时间排序。
+  const candidates =
+    kind === 'CheckRun'
+      ? [entry.startedAt, entry.createdAt, entry.completedAt]
+      : [entry.createdAt, entry.startedAt, entry.updatedAt]
+  for (const candidate of candidates) {
+    const timestamp = timestampFromUnknown(candidate)
+    if (timestamp !== null) {
+      return timestamp
+    }
+  }
+  return null
+}
+
+function shouldReplace<T>(current: SelectedContext<T>, candidate: SelectedContext<T>): boolean {
+  // 原因：GitHub 会省略或复用时间戳；并列时以后返回的条目为准，避免保留旧失败结果。
+  if (candidate.timestamp === null) {
+    return current.timestamp === null
+  }
+  return current.timestamp === null || candidate.timestamp >= current.timestamp
+}
+
+export function selectLatestGitHubCheckContexts<T>(entries: readonly T[]): T[] {
+  const selectedByIdentity = new Map<string, SelectedContext<T>>()
+  const ungrouped: SelectedContext<T>[] = []
+
+  entries.forEach((entry, index) => {
+    const record = recordFromUnknown(entry)
+    const identity = record ? checkContextIdentity(record) : null
+    const candidate = {
+      entry,
+      index,
+      timestamp: record ? checkContextTimestamp(record) : null
+    }
+    if (!identity) {
+      ungrouped.push(candidate)
+      return
+    }
+    const current = selectedByIdentity.get(identity)
+    if (!current || shouldReplace(current, candidate)) {
+      selectedByIdentity.set(identity, candidate)
+    }
+  })
+
+  return [...ungrouped, ...selectedByIdentity.values()]
+    .sort((left, right) => left.index - right.index)
+    .map(({ entry }) => entry)
+}
+
+function checkRollupEntries(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value
+  }
+  const raw = recordFromUnknown(value)
+  const nodes = nestedRecord(raw, 'contexts')?.nodes
+  return Array.isArray(nodes) ? nodes : []
+}
+
+export function deriveGitHubCheckSummary(value: unknown): GitHubPRCheckSummary {
+  const entries = selectLatestGitHubCheckContexts(checkRollupEntries(value))
+  if (entries.length === 0) {
+    return { state: 'none', total: 0, passed: 0, failed: 0, pending: 0 }
+  }
+
+  let passed = 0
+  let failed = 0
+  let pending = 0
+  for (const entry of entries) {
+    const raw = recordFromUnknown(entry)
+    if (!raw) {
+      pending += 1
+      continue
+    }
+    const conclusion = String(raw.conclusion ?? raw.state ?? '').toUpperCase()
+    const status = String(raw.status ?? '').toUpperCase()
+    if (['SUCCESS', 'NEUTRAL', 'SKIPPED'].includes(conclusion)) {
+      passed += 1
+    } else if (
+      ['FAILURE', 'ERROR', 'TIMED_OUT', 'CANCELLED', 'ACTION_REQUIRED', 'STARTUP_FAILURE'].includes(
+        conclusion
+      )
+    ) {
+      failed += 1
+    } else if (status === 'COMPLETED' && conclusion) {
+      // 原因：GitHub 新增的完成结论不能被误报为成功或仍在运行，未知值保守按失败展示。
+      failed += 1
+    } else {
+      pending += 1
+    }
+  }
+
+  return {
+    state: failed > 0 ? 'failure' : pending > 0 ? 'pending' : 'success',
+    total: entries.length,
+    passed,
+    failed,
+    pending
+  }
+}

--- a/src/main/github/github-check-rollup.ts
+++ b/src/main/github/github-check-rollup.ts
@@ -6,6 +6,7 @@ type SelectedContext<T> = {
   entry: T
   index: number
   timestamp: number | null
+  databaseId: number | null
 }
 
 function recordFromUnknown(value: unknown): Record<string, unknown> | null {
@@ -14,6 +15,10 @@ function recordFromUnknown(value: unknown): Record<string, unknown> | null {
 
 function stringFromUnknown(value: unknown): string | null {
   return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+function numberFromUnknown(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
 }
 
 function nestedRecord(
@@ -50,8 +55,7 @@ function checkRunIdentity(entry: Record<string, unknown>): string | null {
   const workflow = nestedRecord(workflowRun, 'workflow')
   const appSlug = stringFromUnknown(app?.slug)
   const workflowName = stringFromUnknown(entry.workflowName) ?? stringFromUnknown(workflow?.name)
-  const provider = appSlug ? `app:${appSlug}` : workflowName ? `workflow:${workflowName}` : null
-  return JSON.stringify(['CheckRun', name, provider])
+  return JSON.stringify(['CheckRun', name, appSlug, workflowName])
 }
 
 function checkContextIdentity(entry: Record<string, unknown>): string | null {
@@ -79,7 +83,7 @@ function timestampFromUnknown(value: unknown): number | null {
 
 function checkContextTimestamp(entry: Record<string, unknown>): number | null {
   const kind = checkContextKind(entry)
-  // 原因：运行开始时间能区分同名重跑且不受完成时刻变化影响；旧式状态则以创建时间排序。
+  // Start time identifies reruns without changing at completion; legacy statuses use creation time.
   const candidates =
     kind === 'CheckRun'
       ? [entry.startedAt, entry.createdAt, entry.completedAt]
@@ -94,11 +98,22 @@ function checkContextTimestamp(entry: Record<string, unknown>): number | null {
 }
 
 function shouldReplace<T>(current: SelectedContext<T>, candidate: SelectedContext<T>): boolean {
-  // 原因：GitHub 会省略或复用时间戳；并列时以后返回的条目为准，避免保留旧失败结果。
-  if (candidate.timestamp === null) {
-    return current.timestamp === null
+  if (
+    candidate.timestamp !== null &&
+    current.timestamp !== null &&
+    candidate.timestamp !== current.timestamp
+  ) {
+    return candidate.timestamp > current.timestamp
   }
-  return current.timestamp === null || candidate.timestamp >= current.timestamp
+  // 为什么：queued run 可能没有时间戳，databaseId 仍可在乱序响应中判断新旧。
+  if (
+    candidate.databaseId !== null &&
+    current.databaseId !== null &&
+    candidate.databaseId !== current.databaseId
+  ) {
+    return candidate.databaseId > current.databaseId
+  }
+  return true
 }
 
 export function selectLatestGitHubCheckContexts<T>(entries: readonly T[]): T[] {
@@ -111,7 +126,8 @@ export function selectLatestGitHubCheckContexts<T>(entries: readonly T[]): T[] {
     const candidate = {
       entry,
       index,
-      timestamp: record ? checkContextTimestamp(record) : null
+      timestamp: record ? checkContextTimestamp(record) : null,
+      databaseId: record ? numberFromUnknown(record.databaseId) : null
     }
     if (!identity) {
       ungrouped.push(candidate)
@@ -163,7 +179,7 @@ export function deriveGitHubCheckSummary(value: unknown): GitHubPRCheckSummary {
     ) {
       failed += 1
     } else if (status === 'COMPLETED' && conclusion) {
-      // 原因：GitHub 新增的完成结论不能被误报为成功或仍在运行，未知值保守按失败展示。
+      // Unknown completed conclusions must not be reported as successful or still running.
       failed += 1
     } else {
       pending += 1


### PR DESCRIPTION
## Summary

- Deduplicate GitHub check rollup entries by check type, name, and provider, keeping the newest run.
- Apply the same normalization to PR list badges and check details while preserving pending approval suites.
- Add regression coverage for repeated fail/pass cycles, missing timestamps, provider collisions, legacy statuses, and historical suites.

Closes #9864

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/github/github-check-rollup.test.ts src/main/github/client-pr-checks.test.ts src/main/github/client.test.ts` (147 tests)
- [x] `pnpm run build:desktop`
- [x] Targeted oxlint, formatting, max-lines ratchet, and reliability gate checks

## AI Review Report

Reviewed check identity, timestamp precedence, missing metadata, provider collisions, CheckRun versus StatusContext collisions, and pending approval behavior. The review caught that suite coverage must use the full unfiltered rollup so a historical suite with a run cannot reappear as pending; the implementation and regression test cover that case.

Cross-platform compatibility was checked for macOS, Linux, and Windows. This change is limited to GitHub provider response mapping and adds no shortcuts, labels, paths, shell behavior, or Electron-specific platform behavior. SSH and remote use the same provider result normalization.

## Security Audit

No command execution, file path handling, authentication, secrets, dependencies, or IPC contracts were added or changed. The additional GraphQL fields are non-sensitive timestamps and provider metadata. Unknown API values remain defensively validated before normalization. No follow-up is required.

## Notes

- `pnpm lint` is currently blocked by the existing non-exhaustive switch at `src/renderer/src/components/skills/skill-freshness-group.tsx:101`; all touched files pass oxlint.
- The full `pnpm test` suite was not run; 147 related GitHub tests passed.
- `pnpm build` was not run because it includes platform-native artifacts; `pnpm run build:desktop` passed.
- X handle: N/A



## ELI5

PR check badges could show an old failed run after a newer pass because duplicates were not collapsed by name. Orca keeps the newest run per check so the status matches GitHub today.
