### PR TITLE
fix(file-explorer): show remote import failure reasons

### DIFF
--- a/src/main/ipc/filesystem-import.test.ts
+++ b/src/main/ipc/filesystem-import.test.ts
@@ -804,4 +804,30 @@ describe('fs:importExternalPaths', () => {
       reason: "Path escaped upload root during staging: 'assets'"
     })
   })
+
+  it('keeps the runtime upload failure label non-empty for a filesystem root', async () => {
+    const sourcePath = path.parse(path.resolve('.')).root
+    lstatMock
+      .mockResolvedValueOnce({
+        isFile: () => false,
+        isDirectory: () => true,
+        isSymbolicLink: () => false
+      })
+      .mockResolvedValueOnce({
+        isFile: () => true,
+        isDirectory: () => false,
+        isSymbolicLink: () => false
+      })
+    realpathMock.mockResolvedValue(sourcePath)
+
+    const result = (await handlers.get('fs:stageExternalPathsForRuntimeUpload')!(null, {
+      sourcePaths: [sourcePath]
+    })) as { sources: { status: string; reason?: string }[] }
+
+    expect(path.basename(sourcePath)).toBe('')
+    expect(result.sources[0]).toMatchObject({
+      status: 'failed',
+      reason: "Unsupported file type in 'root directory'"
+    })
+  })
 })

--- a/src/main/ipc/filesystem-import.test.ts
+++ b/src/main/ipc/filesystem-import.test.ts
@@ -545,7 +545,7 @@ describe('fs:importExternalPaths', () => {
 
     expect(result.sources[0]).toMatchObject({
       status: 'failed',
-      reason: 'File exceeds the 25 MB remote import limit'
+      reason: "'large.bin' exceeds the 25 MB remote import limit"
     })
     expect(openMock).not.toHaveBeenCalled()
   })
@@ -772,7 +772,7 @@ describe('fs:importExternalPaths', () => {
 
     expect(result.sources[0]).toMatchObject({
       status: 'failed',
-      reason: "File changed during upload staging: ''"
+      reason: "File changed during upload staging: 'logo.png'"
     })
     expect(readFileHandleMock).not.toHaveBeenCalled()
   })
@@ -801,7 +801,7 @@ describe('fs:importExternalPaths', () => {
 
     expect(result.sources[0]).toMatchObject({
       status: 'failed',
-      reason: "Path escaped upload root during staging: ''"
+      reason: "Path escaped upload root during staging: 'assets'"
     })
   })
 })

--- a/src/main/ipc/filesystem-import.test.ts
+++ b/src/main/ipc/filesystem-import.test.ts
@@ -522,6 +522,34 @@ describe('fs:importExternalPaths', () => {
     expect(closeMock).toHaveBeenCalled()
   })
 
+  it('reports the per-file remote import limit before reading an oversized file', async () => {
+    const sourcePath = '/tmp/dropped/large.bin'
+    const resolvedPath = path.resolve(sourcePath)
+    lstatMock.mockImplementation(async (p: string) => {
+      if (p === resolvedPath) {
+        return {
+          size: 80 * 1024 * 1024,
+          ino: 1,
+          dev: 1,
+          isFile: () => true,
+          isDirectory: () => false,
+          isSymbolicLink: () => false
+        }
+      }
+      throw enoent()
+    })
+
+    const result = (await handlers.get('fs:stageExternalPathsForRuntimeUpload')!(null, {
+      sourcePaths: [sourcePath]
+    })) as { sources: { status: string; reason?: string }[] }
+
+    expect(result.sources[0]).toMatchObject({
+      status: 'failed',
+      reason: 'File exceeds the 25 MB remote import limit'
+    })
+    expect(openMock).not.toHaveBeenCalled()
+  })
+
   it('stages runtime upload directories whose child names start with dotdot characters', async () => {
     const sourcePath = '/tmp/dropped/project'
     const resolvedPath = path.resolve(sourcePath)
@@ -704,7 +732,7 @@ describe('fs:importExternalPaths', () => {
 
     expect(result.sources[0]).toMatchObject({
       status: 'failed',
-      reason: 'Remote import is too large'
+      reason: 'Remote import exceeds the 100 MB total limit'
     })
     expect(readFileMock).toHaveBeenCalledTimes(4)
     expect(openMock).not.toHaveBeenCalledWith(filePaths.at(-1), expect.anything())

--- a/src/main/ipc/filesystem-mutations.ts
+++ b/src/main/ipc/filesystem-mutations.ts
@@ -503,7 +503,12 @@ async function stageOneSourceForRuntimeUpload(
   try {
     const entries = sourceStat.isDirectory()
       ? await stageDirectoryEntries(resolvedSource)
-      : [(await stageFileEntry(resolvedSource, '')).entry]
+      : // Why: a top-level file's staged relativePath must stay '', so its
+        // name reaches error messages via a display-only option.
+        [
+          (await stageFileEntry(resolvedSource, '', { displayName: basename(resolvedSource) }))
+            .entry
+        ]
     return {
       sourcePath,
       status: 'staged',
@@ -529,22 +534,18 @@ async function stageDirectoryEntries(rootPath: string): Promise<StagedExternalIm
   const rootRealPath = await realpath(rootPath)
 
   async function visit(dirPath: string): Promise<void> {
+    // Why: the root itself has no relative path; fall back to its name so
+    // failure reasons never render an empty '' label.
+    const dirDisplayPath =
+      normalizeRelativeUploadPath(relative(rootPath, dirPath)) || basename(rootPath)
     const dirStat = await lstat(dirPath)
     if (dirStat.isSymbolicLink()) {
-      throw new RuntimeUploadSymlinkError(
-        `Symlink not allowed in '${normalizeRelativeUploadPath(relative(rootPath, dirPath))}'`
-      )
+      throw new RuntimeUploadSymlinkError(`Symlink not allowed in '${dirDisplayPath}'`)
     }
     if (!dirStat.isDirectory()) {
-      throw new Error(
-        `Unsupported file type in '${normalizeRelativeUploadPath(relative(rootPath, dirPath))}'`
-      )
+      throw new Error(`Unsupported file type in '${dirDisplayPath}'`)
     }
-    await assertRealPathInsideRoot(
-      rootRealPath,
-      dirPath,
-      normalizeRelativeUploadPath(relative(rootPath, dirPath))
-    )
+    await assertRealPathInsideRoot(rootRealPath, dirPath, dirDisplayPath)
     const dirEntries = await readdir(dirPath, { withFileTypes: true })
     for (const entry of dirEntries) {
       const childPath = join(dirPath, entry.name)
@@ -576,10 +577,13 @@ async function stageDirectoryEntries(rootPath: string): Promise<StagedExternalIm
 async function stageFileEntry(
   filePath: string,
   relativePath: string,
-  options?: { rootRealPath?: string; totalBytesBefore?: number }
+  options?: { rootRealPath?: string; totalBytesBefore?: number; displayName?: string }
 ): Promise<{ entry: StagedExternalImportEntry; byteLength: number }> {
   const statResult = await lstat(filePath)
-  const displayPath = normalizeRelativeUploadPath(relativePath)
+  const entryRelativePath = normalizeRelativeUploadPath(relativePath)
+  // Why: the staged entry must keep the top-level '' relativePath; only
+  // user-facing failure reasons get the display-name fallback.
+  const displayPath = entryRelativePath || options?.displayName || ''
   if (statResult.isSymbolicLink()) {
     throw new RuntimeUploadSymlinkError(`Symlink not allowed in '${displayPath}'`)
   }
@@ -593,7 +597,7 @@ async function stageFileEntry(
     options?.totalBytesBefore === undefined
       ? statResult.size
       : options.totalBytesBefore + statResult.size
-  assertRemoteUploadBudget(relativePath, statResult.size, initialTotalBytes)
+  assertRemoteUploadBudget(displayPath, statResult.size, initialTotalBytes)
   const fileHandle = await open(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0))
   try {
     const openedStat = await fileHandle.stat()
@@ -611,7 +615,7 @@ async function stageFileEntry(
       options?.totalBytesBefore === undefined
         ? openedStat.size
         : options.totalBytesBefore + openedStat.size
-    assertRemoteUploadBudget(relativePath, openedStat.size, totalBytes)
+    assertRemoteUploadBudget(displayPath, openedStat.size, totalBytes)
     const buffer = await fileHandle.readFile()
     const afterReadStat = await fileHandle.stat()
     if (afterReadStat.size !== openedStat.size) {
@@ -619,7 +623,7 @@ async function stageFileEntry(
     }
     return {
       entry: {
-        relativePath: displayPath,
+        relativePath: entryRelativePath,
         kind: 'file',
         contentBase64: buffer.toString('base64')
       },
@@ -647,12 +651,12 @@ async function assertRealPathInsideRoot(
 }
 
 function assertRemoteUploadBudget(
-  relativePath: string,
+  displayPath: string,
   fileBytes: number,
   totalBytes: number
 ): void {
   if (fileBytes > REMOTE_IMPORT_MAX_FILE_BYTES) {
-    const fileLabel = relativePath ? `'${relativePath}'` : 'File'
+    const fileLabel = displayPath ? `'${displayPath}'` : 'File'
     throw new Error(`${fileLabel} exceeds the ${REMOTE_IMPORT_MAX_FILE_MB} MB remote import limit`)
   }
   if (totalBytes > REMOTE_IMPORT_MAX_TOTAL_BYTES) {

--- a/src/main/ipc/filesystem-mutations.ts
+++ b/src/main/ipc/filesystem-mutations.ts
@@ -534,10 +534,12 @@ async function stageDirectoryEntries(rootPath: string): Promise<StagedExternalIm
   const rootRealPath = await realpath(rootPath)
 
   async function visit(dirPath: string): Promise<void> {
-    // Why: the root itself has no relative path; fall back to its name so
-    // failure reasons never render an empty '' label.
+    // Why: the root itself has no relative path, and filesystem roots also
+    // have no basename; keep their failure labels actionable and non-empty.
     const dirDisplayPath =
-      normalizeRelativeUploadPath(relative(rootPath, dirPath)) || basename(rootPath)
+      normalizeRelativeUploadPath(relative(rootPath, dirPath)) ||
+      basename(rootPath) ||
+      'root directory'
     const dirStat = await lstat(dirPath)
     if (dirStat.isSymbolicLink()) {
       throw new RuntimeUploadSymlinkError(`Symlink not allowed in '${dirDisplayPath}'`)

--- a/src/main/ipc/filesystem-mutations.ts
+++ b/src/main/ipc/filesystem-mutations.ts
@@ -362,8 +362,10 @@ export type StagedExternalImportEntry =
   | { relativePath: string; kind: 'directory' }
   | { relativePath: string; kind: 'file'; contentBase64: string }
 
-const REMOTE_IMPORT_MAX_FILE_BYTES = 25 * 1024 * 1024
-const REMOTE_IMPORT_MAX_TOTAL_BYTES = 100 * 1024 * 1024
+const REMOTE_IMPORT_MAX_FILE_MB = 25
+const REMOTE_IMPORT_MAX_TOTAL_MB = 100
+const REMOTE_IMPORT_MAX_FILE_BYTES = REMOTE_IMPORT_MAX_FILE_MB * 1024 * 1024
+const REMOTE_IMPORT_MAX_TOTAL_BYTES = REMOTE_IMPORT_MAX_TOTAL_MB * 1024 * 1024
 
 class RuntimeUploadSymlinkError extends Error {}
 
@@ -650,10 +652,11 @@ function assertRemoteUploadBudget(
   totalBytes: number
 ): void {
   if (fileBytes > REMOTE_IMPORT_MAX_FILE_BYTES) {
-    throw new Error(`'${relativePath}' is too large for remote import`)
+    const fileLabel = relativePath ? `'${relativePath}'` : 'File'
+    throw new Error(`${fileLabel} exceeds the ${REMOTE_IMPORT_MAX_FILE_MB} MB remote import limit`)
   }
   if (totalBytes > REMOTE_IMPORT_MAX_TOTAL_BYTES) {
-    throw new Error('Remote import is too large')
+    throw new Error(`Remote import exceeds the ${REMOTE_IMPORT_MAX_TOTAL_MB} MB total limit`)
   }
 }
 

--- a/src/renderer/src/components/right-sidebar/file-explorer-import-feedback.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-import-feedback.test.ts
@@ -4,10 +4,24 @@ import { getFileExplorerImportFailureToast } from './file-explorer-import-feedba
 describe('getFileExplorerImportFailureToast', () => {
   it('shows the actionable reason for a single failed import', () => {
     expect(
-      getFileExplorerImportFailureToast([{ reason: 'File exceeds the 25 MB remote import limit' }])
+      getFileExplorerImportFailureToast([
+        { reason: "'large.bin' exceeds the 25 MB remote import limit" }
+      ])
     ).toEqual({
       title: 'Failed to import 1 file.',
-      description: 'File exceeds the 25 MB remote import limit'
+      description: "'large.bin' exceeds the 25 MB remote import limit"
+    })
+  })
+
+  it('collapses newlines inside a reason to keep one line per reason', () => {
+    expect(
+      getFileExplorerImportFailureToast([
+        { reason: "'a\nfake status line.bin' exceeds the 25 MB remote import limit" },
+        { reason: "'a fake status line.bin' exceeds the 25 MB remote import limit" }
+      ])
+    ).toEqual({
+      title: 'Failed to import 2 files.',
+      description: "'a fake status line.bin' exceeds the 25 MB remote import limit"
     })
   })
 
@@ -41,5 +55,16 @@ describe('getFileExplorerImportFailureToast', () => {
       failed.slice(0, 5).map((f) => f.reason)
     )
     expect(toast.description?.endsWith('\n…')).toBe(true)
+  })
+
+  it('never truncates when the ellipsis would not save a line', () => {
+    const reasonsOf = (count: number) =>
+      getFileExplorerImportFailureToast(
+        Array.from({ length: count }, (_, i) => ({ reason: `r-${i}` }))
+      ).description?.split('\n')
+    expect(reasonsOf(5)).toHaveLength(5)
+    expect(reasonsOf(5)).not.toContain('…')
+    expect(reasonsOf(6)).toHaveLength(6)
+    expect(reasonsOf(6)).not.toContain('…')
   })
 })

--- a/src/renderer/src/components/right-sidebar/file-explorer-import-feedback.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-import-feedback.test.ts
@@ -29,4 +29,17 @@ describe('getFileExplorerImportFailureToast', () => {
       title: 'Failed to import 1 file.'
     })
   })
+
+  it('caps distinct reasons and marks the truncation', () => {
+    const failed = Array.from({ length: 7 }, (_, i) => ({
+      reason: `EACCES: permission denied, open '/dest/file-${i}.txt'`
+    }))
+    const toast = getFileExplorerImportFailureToast(failed)
+    expect(toast.title).toBe('Failed to import 7 files.')
+    expect(toast.description?.split('\n')).toHaveLength(6)
+    expect(toast.description?.split('\n').slice(0, 5)).toEqual(
+      failed.slice(0, 5).map((f) => f.reason)
+    )
+    expect(toast.description?.endsWith('\n…')).toBe(true)
+  })
 })

--- a/src/renderer/src/components/right-sidebar/file-explorer-import-feedback.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-import-feedback.test.ts
@@ -39,8 +39,16 @@ describe('getFileExplorerImportFailureToast', () => {
   })
 
   it('omits an empty description while preserving the failure count', () => {
-    expect(getFileExplorerImportFailureToast([{ reason: '  ' }])).toEqual({
+    expect(getFileExplorerImportFailureToast([{ reason: '  ' }])).toStrictEqual({
       title: 'Failed to import 1 file.'
+    })
+  })
+
+  it('dedupes before applying the cap', () => {
+    const failed = Array.from({ length: 7 }, (_, i) => ({ reason: `r-${i % 3}` }))
+    expect(getFileExplorerImportFailureToast(failed)).toStrictEqual({
+      title: 'Failed to import 7 files.',
+      description: 'r-0\nr-1\nr-2'
     })
   })
 

--- a/src/renderer/src/components/right-sidebar/file-explorer-import-feedback.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-import-feedback.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { getFileExplorerImportFailureToast } from './file-explorer-import-feedback'
+
+describe('getFileExplorerImportFailureToast', () => {
+  it('shows the actionable reason for a single failed import', () => {
+    expect(
+      getFileExplorerImportFailureToast([{ reason: 'File exceeds the 25 MB remote import limit' }])
+    ).toEqual({
+      title: 'Failed to import 1 file.',
+      description: 'File exceeds the 25 MB remote import limit'
+    })
+  })
+
+  it('deduplicates repeated reasons for a multi-file failure', () => {
+    expect(
+      getFileExplorerImportFailureToast([
+        { reason: 'Permission denied' },
+        { reason: ' Permission denied ' },
+        { reason: 'Disk full' }
+      ])
+    ).toEqual({
+      title: 'Failed to import 3 files.',
+      description: 'Permission denied\nDisk full'
+    })
+  })
+
+  it('omits an empty description while preserving the failure count', () => {
+    expect(getFileExplorerImportFailureToast([{ reason: '  ' }])).toEqual({
+      title: 'Failed to import 1 file.'
+    })
+  })
+})

--- a/src/renderer/src/components/right-sidebar/file-explorer-import-feedback.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-import-feedback.ts
@@ -9,13 +9,21 @@ export type FileExplorerImportFailureToast = {
   description?: string
 }
 
+// Why: path-bearing reasons (e.g. per-file EACCES) defeat dedup, so a large
+// drop could otherwise fill the screen with one toast.
+const MAX_DESCRIPTION_REASONS = 5
+
 export function getFileExplorerImportFailureToast(
   failed: readonly FailedFileExplorerImport[]
 ): FileExplorerImportFailureToast {
   const noun = failed.length === 1 ? 'file' : 'files'
-  const reasons = [
+  const uniqueReasons = [
     ...new Set(failed.map((result) => result.reason.trim()).filter((reason) => reason.length > 0))
   ]
+  const reasons =
+    uniqueReasons.length > MAX_DESCRIPTION_REASONS
+      ? [...uniqueReasons.slice(0, MAX_DESCRIPTION_REASONS), '…']
+      : uniqueReasons
 
   return {
     title: translate(

--- a/src/renderer/src/components/right-sidebar/file-explorer-import-feedback.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-import-feedback.ts
@@ -18,10 +18,18 @@ export function getFileExplorerImportFailureToast(
 ): FileExplorerImportFailureToast {
   const noun = failed.length === 1 ? 'file' : 'files'
   const uniqueReasons = [
-    ...new Set(failed.map((result) => result.reason.trim()).filter((reason) => reason.length > 0))
+    ...new Set(
+      failed
+        // Why: reasons can embed filenames, and a newline-bearing filename would
+        // both defeat the line cap and forge an extra toast line.
+        .map((result) => result.reason.replace(/\s+/g, ' ').trim())
+        .filter((reason) => reason.length > 0)
+    )
   ]
+  // Why: truncate only when it hides more than one reason — five reasons plus
+  // an ellipsis line costs the same height as six plain lines.
   const reasons =
-    uniqueReasons.length > MAX_DESCRIPTION_REASONS
+    uniqueReasons.length > MAX_DESCRIPTION_REASONS + 1
       ? [...uniqueReasons.slice(0, MAX_DESCRIPTION_REASONS), '…']
       : uniqueReasons
 

--- a/src/renderer/src/components/right-sidebar/file-explorer-import-feedback.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-import-feedback.ts
@@ -1,0 +1,30 @@
+import { translate } from '@/i18n/i18n'
+
+type FailedFileExplorerImport = {
+  reason: string
+}
+
+export type FileExplorerImportFailureToast = {
+  title: string
+  description?: string
+}
+
+export function getFileExplorerImportFailureToast(
+  failed: readonly FailedFileExplorerImport[]
+): FileExplorerImportFailureToast {
+  const noun = failed.length === 1 ? 'file' : 'files'
+  const reasons = [
+    ...new Set(failed.map((result) => result.reason.trim()).filter((reason) => reason.length > 0))
+  ]
+
+  return {
+    title: translate(
+      'auto.components.right.sidebar.useFileExplorerImport.132fd0e1e9',
+      'Failed to import {{value0}} {{value1}}.',
+      { value0: failed.length, value1: noun }
+    ),
+    // Why: import failures already carry the actionable server/staging reason;
+    // hiding it behind a count makes size, permission, and SSH errors indistinguishable.
+    ...(reasons.length > 0 ? { description: reasons.join('\n') } : {})
+  }
+}

--- a/src/renderer/src/components/right-sidebar/useFileExplorerImport.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerImport.ts
@@ -100,7 +100,12 @@ export function useFileExplorerImport({
 
           if (failed.length > 0) {
             const message = getFileExplorerImportFailureToast(failed)
-            toast.error(message.title, { description: message.description })
+            // Why: sonner renders string descriptions with collapsed whitespace;
+            // pre-line keeps the one-reason-per-line format.
+            toast.error(message.title, {
+              description: message.description,
+              descriptionClassName: 'whitespace-pre-line'
+            })
           } else if (skipped.length > 0 && imported.length === 0) {
             const noun = skipped.length === 1 ? 'file' : 'files'
             toast.error(

--- a/src/renderer/src/components/right-sidebar/useFileExplorerImport.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerImport.ts
@@ -101,10 +101,12 @@ export function useFileExplorerImport({
           if (failed.length > 0) {
             const message = getFileExplorerImportFailureToast(failed)
             // Why: sonner renders string descriptions with collapsed whitespace;
-            // pre-line keeps the one-reason-per-line format.
+            // pre-line keeps the one-reason-per-line format. Multi-line reasons
+            // need more than sonner's 4s default to read and act on.
             toast.error(message.title, {
               description: message.description,
-              descriptionClassName: 'whitespace-pre-line'
+              descriptionClassName: 'whitespace-pre-line',
+              duration: 60_000
             })
           } else if (skipped.length > 0 && imported.length === 0) {
             const noun = skipped.length === 1 ? 'file' : 'files'

--- a/src/renderer/src/components/right-sidebar/useFileExplorerImport.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerImport.ts
@@ -5,6 +5,7 @@ import { importExternalPathsToRuntime } from '@/runtime/runtime-file-client'
 import { translate } from '@/i18n/i18n'
 import type { FileExplorerOperationOwner } from './file-explorer-types'
 import { captureFileExplorerOperationGuard } from './file-explorer-operation-owner'
+import { getFileExplorerImportFailureToast } from './file-explorer-import-feedback'
 
 type UseFileExplorerImportParams = {
   worktreePath: string | null
@@ -98,14 +99,8 @@ export function useFileExplorerImport({
           }
 
           if (failed.length > 0) {
-            const noun = failed.length === 1 ? 'file' : 'files'
-            toast.error(
-              translate(
-                'auto.components.right.sidebar.useFileExplorerImport.132fd0e1e9',
-                'Failed to import {{value0}} {{value1}}.',
-                { value0: failed.length, value1: noun }
-              )
-            )
+            const message = getFileExplorerImportFailureToast(failed)
+            toast.error(message.title, { description: message.description })
           } else if (skipped.length > 0 && imported.length === 0) {
             const noun = skipped.length === 1 ? 'file' : 'files'
             toast.error(


### PR DESCRIPTION
## Summary

Fixes #9896.

- Show the unique failure reasons already returned by file Explorer imports in the existing error toast.
- Make runtime upload failures state the 25 MB per-file and 100 MB aggregate limits.
- Avoid the empty file label previously produced when a top-level dropped file exceeds the per-file limit.
- Add regression coverage for an 80 MB file and for renderer failure-message formatting.

## Screenshots

No screenshot attached. This is a text-only extension of the existing error toast: its title is unchanged and its description now contains the actionable backend reason. No user data or local paths are included in this PR.

## Testing

- [ ] `pnpm lint` — full lint reaches pre-existing failures on current `main`: a non-exhaustive switch in `skill-freshness-group.tsx` and missing localization keys in unrelated files. Changed-file oxlint, type-aware oxlint, reliability gates, max-lines, localization coverage, styled-scrollbar, bundled-guide, and skill-manifest checks pass.
- [x] `pnpm typecheck`
- [x] `pnpm test` — 3,218 files passed; 34,127 tests passed; 7 files and 58 tests skipped
- [x] `pnpm build`
- [x] Added high-quality tests that would catch regressions

## AI Review Report

Reviewed the native desktop drop path, local import path, paired-runtime staging path, and SSH-backed import path. The actionable reason was already preserved through the main-process and authenticated runtime results but was discarded at the final renderer feedback seam. The change therefore leaves routing, ownership, destination planning, and the runtime RPC protocol unchanged.

The review checked repeated failures, empty reasons, an oversized top-level file, aggregate-size failures, and whether the file body is opened before rejecting an oversized file. Repeated reasons are deduplicated so a multi-file failure does not flood the toast, while distinct reasons remain visible.

Cross-platform review covered macOS, Linux, and Windows. No shortcut, shell command, platform path separator, native API, or Electron platform behavior changes. Local, paired-runtime, and SSH-backed imports continue to use their existing implementations.

## Security Audit

Reviewed error provenance, input handling, paths, authentication, IPC, secrets, dependencies, and command execution.

- The UI only displays reasons returned by the existing import operation to the user who initiated it.
- Paired-runtime reasons continue to cross the existing authenticated runtime boundary.
- No new IPC or RPC method, filesystem authority, network request, dependency, command execution, logging, telemetry, or credential storage was added.
- Limit checks still happen before opening an oversized file, and the regression test verifies this.
- Error details are shown locally in a transient toast and are not persisted or sent to a new destination.

No follow-up security work was identified.

## Notes

- The 25 MB per-file and 100 MB aggregate limits are unchanged; this PR only names them and surfaces their failures.
- The full-lint failures described above are reproducible on the upstream base and do not touch files changed by this PR.
- X/Twitter handle: N/A


## ELI5

Failed remote file imports showed a vague toast with little detail. The error message now includes the real reasons (including size limits) so you know why the drop or upload failed.
