### PR TITLE
fix: launch the default agent when opening a workspace without a creation agent

### DIFF
--- a/src/renderer/src/lib/worktree-activation-created-agent.test.ts
+++ b/src/renderer/src/lib/worktree-activation-created-agent.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { getDefaultSettings } from '../../../shared/constants'
+import type { GlobalSettings, Worktree } from '../../../shared/types'
 import { useAppStore } from '@/store'
 import {
   activateAndRevealWorktree,
@@ -113,6 +114,120 @@ describe('activateAndRevealWorktree created agent reopen', () => {
       }
     })
     expect(revealWorktreeInSidebar).toHaveBeenCalledWith(worktree.id)
+  })
+
+  function seedEmptyWorktreeState(
+    worktree: Worktree,
+    settingsOverrides: Partial<GlobalSettings>
+  ): void {
+    useAppStore.setState({
+      repos: [
+        {
+          id: 'repo-1',
+          path: '/workspace/repo',
+          displayName: 'repo',
+          badgeColor: '#000000',
+          addedAt: 0
+        }
+      ],
+      worktreesByRepo: { 'repo-1': [worktree] },
+      activeRepoId: 'repo-1',
+      activeView: 'terminal',
+      tabsByWorktree: {},
+      unifiedTabsByWorktree: {},
+      groupsByWorktree: {},
+      layoutByWorktree: {},
+      activeGroupIdByWorktree: {},
+      openFiles: [],
+      browserTabsByWorktree: {},
+      activeFileIdByWorktree: {},
+      activeBrowserTabIdByWorktree: {},
+      activeTabTypeByWorktree: {},
+      activeTabIdByWorktree: {},
+      tabBarOrderByWorktree: {},
+      pendingStartupByTabId: {},
+      settings: { ...getDefaultSettings('/tmp'), ...settingsOverrides },
+      markWorktreeVisited: vi.fn(),
+      recordWorktreeVisit: vi.fn(),
+      refreshGitHubForWorktreeIfStale: vi.fn(),
+      revealWorktreeInSidebar: vi.fn()
+    })
+  }
+
+  it('seeds the configured default agent when the worktree has no creation agent (issue #9772)', () => {
+    const worktree = { ...makeWorktree(), createdWithAgent: undefined }
+    seedEmptyWorktreeState(worktree, {
+      agentCmdOverrides: {},
+      defaultTuiAgent: 'claude',
+      disabledTuiAgents: [],
+      setupScriptLaunchMode: 'new-tab'
+    })
+
+    activateAndRevealWorktree(worktree.id)
+    const state = useAppStore.getState()
+    const seededTab = state.tabsByWorktree[worktree.id]?.[0]
+
+    expect(seededTab).toBeDefined()
+    const startup = state.pendingStartupByTabId[seededTab!.id]
+    expect(startup?.launchAgent).toBe('claude')
+    expect(startup?.telemetry).toEqual({
+      agent_kind: 'claude-code',
+      launch_source: 'sidebar',
+      request_kind: 'new'
+    })
+  })
+
+  it('keeps a blank initial terminal when the default agent preference is blank', () => {
+    const worktree = { ...makeWorktree(), createdWithAgent: undefined }
+    seedEmptyWorktreeState(worktree, {
+      agentCmdOverrides: {},
+      defaultTuiAgent: 'blank',
+      disabledTuiAgents: [],
+      setupScriptLaunchMode: 'new-tab'
+    })
+
+    activateAndRevealWorktree(worktree.id)
+    const state = useAppStore.getState()
+    const seededTab = state.tabsByWorktree[worktree.id]?.[0]
+
+    expect(seededTab).toBeDefined()
+    expect(state.pendingStartupByTabId[seededTab!.id]).toBeUndefined()
+  })
+
+  it('keeps a blank initial terminal when the default agent is disabled', () => {
+    const worktree = { ...makeWorktree(), createdWithAgent: undefined }
+    seedEmptyWorktreeState(worktree, {
+      agentCmdOverrides: {},
+      defaultTuiAgent: 'claude',
+      disabledTuiAgents: ['claude'],
+      setupScriptLaunchMode: 'new-tab'
+    })
+
+    activateAndRevealWorktree(worktree.id)
+    const state = useAppStore.getState()
+    const seededTab = state.tabsByWorktree[worktree.id]?.[0]
+
+    expect(seededTab).toBeDefined()
+    expect(state.pendingStartupByTabId[seededTab!.id]).toBeUndefined()
+  })
+
+  it('prefers the creation agent over the default agent setting', () => {
+    const worktree = makeWorktree()
+    seedEmptyWorktreeState(worktree, {
+      agentCmdOverrides: {},
+      defaultTuiAgent: 'claude',
+      disabledTuiAgents: [],
+      setupScriptLaunchMode: 'new-tab'
+    })
+
+    activateAndRevealWorktree(worktree.id)
+    const state = useAppStore.getState()
+    const seededTab = state.tabsByWorktree[worktree.id]?.[0]
+
+    expect(seededTab).toBeDefined()
+    const startup = state.pendingStartupByTabId[seededTab!.id]
+    expect(startup?.launchAgent).toBe('codex')
+    expect(startup?.telemetry?.request_kind).toBe('resume')
   })
 
   it('uses WSL launch quoting when reopening a Windows-path WSL project agent', () => {

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -47,6 +47,7 @@ import {
   resolveTuiAgentLaunchEnv
 } from '../../../shared/tui-agent-launch-defaults'
 import { isTuiAgent } from '../../../shared/tui-agent-config'
+import { isTuiAgentEnabled } from '../../../shared/tui-agent-selection'
 import { repoIsRemote } from '../../../shared/agent-launch-remote'
 import { resumeSleepingAgentSessionsForWorktree } from '@/lib/resume-sleeping-agent-session'
 import { queueHookCommandsForFirstWorktreeTab } from '@/lib/hook-command-delayed-delivery'
@@ -228,12 +229,26 @@ export function activateAndRevealFolderWorkspace(
   return { primaryTabId }
 }
 
-function buildCreatedAgentReopenStartup(worktree: Worktree): WorktreeStartupPayload | undefined {
-  const agent = worktree.createdWithAgent
-  if (!isTuiAgent(agent)) {
+function buildInitialTerminalStartup(worktree: Worktree): WorktreeStartupPayload | undefined {
+  const createdAgent = worktree.createdWithAgent
+  if (isTuiAgent(createdAgent)) {
+    return buildAgentLaunchStartup(worktree, createdAgent, 'resume')
+  }
+  // Why: workspaces without a creation agent (main checkouts, externally added
+  // worktrees) must still honor the default-agent setting (issue #9772).
+  const settings = useAppStore.getState().settings
+  const preferred = settings?.defaultTuiAgent
+  if (!isTuiAgent(preferred) || !isTuiAgentEnabled(preferred, settings?.disabledTuiAgents)) {
     return undefined
   }
+  return buildAgentLaunchStartup(worktree, preferred, 'new')
+}
 
+function buildAgentLaunchStartup(
+  worktree: Worktree,
+  agent: TuiAgent,
+  requestKind: 'new' | 'resume'
+): WorktreeStartupPayload | undefined {
   const state = useAppStore.getState()
   const repo = state.repos.find((entry) => entry.id === worktree.repoId)
   const launchPlatform = repo
@@ -273,7 +288,7 @@ function buildCreatedAgentReopenStartup(worktree: Worktree): WorktreeStartupPayl
     telemetry: {
       agent_kind: tuiAgentToAgentKind(agent),
       launch_source: 'sidebar',
-      request_kind: 'resume'
+      request_kind: requestKind
     }
   }
 }
@@ -345,7 +360,7 @@ export function activateAndRevealWorktree(
   const primaryTabId = ensureWorktreeHasInitialTerminal(
     useAppStore.getState(),
     worktreeId,
-    opts?.startup ?? buildCreatedAgentReopenStartup(wt),
+    opts?.startup ?? buildInitialTerminalStartup(wt),
     opts?.setup,
     opts?.issueCommand,
     opts?.defaultTabs


### PR DESCRIPTION
## Summary

Fixes #9772.

Clicking a workspace that has no terminal tab yet always seeded a blank shell, even when a default agent was configured in Settings → Agents. The activation path (`activateAndRevealWorktree` → `ensureWorktreeHasInitialTerminal`) rebuilt its startup payload only from `worktree.createdWithAgent`, so main checkouts and externally added worktrees — which have no creation agent — never consulted the `defaultTuiAgent` setting. Adding a tab manually via `+` worked, which matches the report.

Changes in `src/renderer/src/lib/worktree-activation.ts`:

- Generalized `buildCreatedAgentReopenStartup` into `buildInitialTerminalStartup`:
  - `createdWithAgent` still takes precedence and keeps its resume semantics (telemetry `request_kind: 'resume'`).
  - Otherwise, fall back to the configured `defaultTuiAgent` (telemetry `request_kind: 'new'`, `launch_source: 'sidebar'`).
  - An unset, `'blank'`, or disabled default agent still seeds a plain terminal, preserving the existing opt-out.

## Screenshots

Before: clicking a workspace with no tabs opened a blank zsh despite Claude being the default agent. After: the same click seeds a Claude tab and the agent launches (verified in the running app; sidebar shows the agent session as expected).

## Testing

- [x] `pnpm lint` — oxlint clean on the changed files and full run
- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — activation suites (`worktree-activation*.test.ts`): 49 tests pass, including 4 new cases: default agent seeded when no creation agent (with telemetry shape), `'blank'` preference keeps a blank terminal, disabled default agent keeps a blank terminal, and creation-agent resume precedence over the default setting
- [x] `pnpm build` — electron-vite build passes
- [x] Manual smoke test on macOS dev build: reproduced the bug on `main`, then verified the fix end to end — closed the empty tab, clicked the workspace card, new tab launched with `launchAgent: 'claude'` and a real `claude` process spawned

Note: this machine has npm but not pnpm, so the equivalent npx/npm commands were used.

## AI Review Report

Reviewed with an AI coding agent. Main risks checked:

- Precedence: worktrees created with an agent keep their resume behavior; the fallback only applies when `createdWithAgent` is absent (covered by a test).
- Opt-out: users who chose `'blank'` or disabled the default agent keep getting a plain terminal (covered by tests).
- Scope: only the initial-terminal seeding path changed; explicit `opts?.startup` callers are untouched, and no main-process, IPC, or SSH-path code is affected.

## Security Audit

- No command execution changes: the fallback reuses the existing agent-launch startup builder (same command construction and overrides as the `+` tab flow).
- No new input surfaces, IPC handlers, path handling, or dependency changes.

## Notes

- Telemetry for the fallback reports `request_kind: 'new'` (a fresh launch) rather than `'resume'`, since there is no prior session to resume.



## ELI5

Opening a workspace with no tabs always opened a blank shell even if you set a default agent. Empty workspaces without a creation agent now launch your default TUI agent when one is configured.
