### PR TITLE
fix(terminal): make Ctrl+V / Cmd+V paste work in the HTTP web client

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -153,6 +153,14 @@ import {
 } from '@/components/terminal-quick-commands/TerminalQuickCommandDialog'
 import { keybindingMatchesAction } from '../../../../shared/keybindings'
 import { pasteTerminalClipboard } from './terminal-clipboard-paste'
+import {
+  getClipboardEventText,
+  isClipboardEventPasteRequired
+} from './terminal-clipboard-event-paste'
+import {
+  assertClipboardTextWithinLimitWithYield,
+  type ReadClipboardTextOptions
+} from '../../../../shared/clipboard-text'
 import { scheduleImagePasteWebglAtlasRecovery } from './terminal-webgl-atlas-recovery'
 import { restoreTerminalFitToDesktop, restoreTerminalFitsToDesktop } from './terminal-fit-restore'
 import { useVisibleTerminalTabClaim } from './use-visible-terminal-tab-claim'
@@ -2001,7 +2009,9 @@ export default function TerminalPane({
 
     const pasteFromClipboard = (
       pane: ManagedPane,
-      source: Extract<TerminalPasteSource, 'keyboard' | 'paste-event'>
+      source: Extract<TerminalPasteSource, 'keyboard' | 'paste-event'>,
+      readClipboardText: (options?: ReadClipboardTextOptions) => Promise<string> = window.api.ui
+        .readClipboardText
     ): void => {
       const connectionId = getConnectionId(worktreeId) ?? null
       const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(
@@ -2010,7 +2020,7 @@ export default function TerminalPane({
       )
       const activeElementAtDispatch = document.activeElement
       void pasteTerminalClipboard({
-        readClipboardText: window.api.ui.readClipboardText,
+        readClipboardText,
         saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
         connectionId,
         runtimeEnvironmentId,
@@ -2064,6 +2074,11 @@ export default function TerminalPane({
         }
         return
       }
+      if (isClipboardEventPasteRequired()) {
+        // Why: without navigator.clipboard the chord's native paste event is the
+        // only clipboard access — let its default fire and handle it in onPaste.
+        return
+      }
       e.preventDefault()
       e.stopPropagation()
       const manager = managerRef.current
@@ -2112,6 +2127,13 @@ export default function TerminalPane({
       }
       const pane = manager.getActivePane() ?? manager.getPanes()[0]
       if (!pane) {
+        return
+      }
+      if (isClipboardEventPasteRequired()) {
+        const eventText = getClipboardEventText(e)
+        pasteFromClipboard(pane, 'paste-event', (options) =>
+          assertClipboardTextWithinLimitWithYield(eventText, options)
+        )
         return
       }
       pasteFromClipboard(pane, 'paste-event')

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -154,6 +154,7 @@ import {
 import { keybindingMatchesAction } from '../../../../shared/keybindings'
 import { pasteTerminalClipboard } from './terminal-clipboard-paste'
 import {
+  firesNativePasteEvent,
   getClipboardEventText,
   isClipboardEventPasteRequired
 } from './terminal-clipboard-event-paste'
@@ -2074,9 +2075,11 @@ export default function TerminalPane({
         }
         return
       }
-      if (isClipboardEventPasteRequired()) {
+      if (isClipboardEventPasteRequired() && firesNativePasteEvent(e, isMac)) {
         // Why: without navigator.clipboard the chord's native paste event is the
         // only clipboard access — let its default fire and handle it in onPaste.
+        // A remapped chord (e.g. Ctrl+Y) fires no paste event, so keep consuming it
+        // below instead of letting xterm encode it to the PTY as a raw control char.
         return
       }
       e.preventDefault()

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-event-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-event-paste.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getClipboardEventText,
+  shouldUseClipboardEventPaste
+} from './terminal-clipboard-event-paste'
+
+function makeClipboardEvent(text: string | null): ClipboardEvent {
+  return {
+    clipboardData:
+      text === null
+        ? null
+        : {
+            getData: (type: string) => (type === 'text/plain' ? text : '')
+          }
+  } as unknown as ClipboardEvent
+}
+
+describe('shouldUseClipboardEventPaste', () => {
+  it('requires the fallback for web clients without navigator.clipboard.readText', () => {
+    expect(
+      shouldUseClipboardEventPaste({ isWebClient: true, clipboardReadTextAvailable: false })
+    ).toBe(true)
+  })
+
+  it('keeps async clipboard reads for secure-context web clients', () => {
+    expect(
+      shouldUseClipboardEventPaste({ isWebClient: true, clipboardReadTextAvailable: true })
+    ).toBe(false)
+  })
+
+  it('never applies to the Electron renderer, which reads the clipboard over IPC', () => {
+    expect(
+      shouldUseClipboardEventPaste({ isWebClient: false, clipboardReadTextAvailable: false })
+    ).toBe(false)
+    expect(
+      shouldUseClipboardEventPaste({ isWebClient: false, clipboardReadTextAvailable: true })
+    ).toBe(false)
+  })
+})
+
+describe('getClipboardEventText', () => {
+  it('reads text/plain from the event clipboardData', () => {
+    expect(getClipboardEventText(makeClipboardEvent('echo hi'))).toBe('echo hi')
+  })
+
+  it('returns empty text when clipboardData is missing', () => {
+    expect(getClipboardEventText(makeClipboardEvent(null))).toBe('')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-event-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-event-paste.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import {
+  firesNativePasteEvent,
   getClipboardEventText,
   shouldUseClipboardEventPaste
 } from './terminal-clipboard-event-paste'
+
+function makeKeyEvent(
+  overrides: Partial<Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>>
+): Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'> {
+  return { key: '', metaKey: false, ctrlKey: false, altKey: false, shiftKey: false, ...overrides }
+}
 
 function makeClipboardEvent(text: string | null): ClipboardEvent {
   return {
@@ -45,5 +52,33 @@ describe('getClipboardEventText', () => {
 
   it('returns empty text when clipboardData is missing', () => {
     expect(getClipboardEventText(makeClipboardEvent(null))).toBe('')
+  })
+})
+
+describe('firesNativePasteEvent', () => {
+  it('recognizes the default native paste chords on macOS', () => {
+    expect(firesNativePasteEvent(makeKeyEvent({ key: 'v', metaKey: true }), true)).toBe(true)
+  })
+
+  it('recognizes the default native paste chords on Windows/Linux', () => {
+    expect(firesNativePasteEvent(makeKeyEvent({ key: 'v', ctrlKey: true }), false)).toBe(true)
+    // Ctrl+Shift+V is the default terminal paste and still dispatches a native event.
+    expect(
+      firesNativePasteEvent(makeKeyEvent({ key: 'v', ctrlKey: true, shiftKey: true }), false)
+    ).toBe(true)
+    expect(
+      firesNativePasteEvent(makeKeyEvent({ key: 'Insert', shiftKey: true }), false)
+    ).toBe(true)
+  })
+
+  it('does not treat a remapped non-clipboard chord as a native paste event', () => {
+    // A custom terminal.paste binding like Ctrl+Y fires no native paste event and
+    // must stay consumed so it is not encoded to the PTY as a control char.
+    expect(firesNativePasteEvent(makeKeyEvent({ key: 'y', ctrlKey: true }), false)).toBe(false)
+    expect(firesNativePasteEvent(makeKeyEvent({ key: 'd', ctrlKey: true }), false)).toBe(false)
+    // Cmd+V does not fire a native paste event on Windows/Linux.
+    expect(firesNativePasteEvent(makeKeyEvent({ key: 'v', metaKey: true }), false)).toBe(false)
+    // Ctrl+V does not fire a native paste event on macOS (readline quote-insert).
+    expect(firesNativePasteEvent(makeKeyEvent({ key: 'v', ctrlKey: true }), true)).toBe(false)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-event-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-event-paste.ts
@@ -20,3 +20,27 @@ export function isClipboardEventPasteRequired(): boolean {
 export function getClipboardEventText(event: ClipboardEvent): string {
   return event.clipboardData?.getData('text/plain') ?? ''
 }
+
+type PasteChordEvent = Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>
+
+// Why: only these chords make the browser dispatch a native `paste` ClipboardEvent,
+// the sole clipboard path on insecure web. A remapped terminal.paste chord (e.g. Ctrl+Y)
+// fires no paste event, so it must still be consumed rather than encoded to the PTY as
+// raw control chars.
+export function firesNativePasteEvent(event: PasteChordEvent, isMac: boolean): boolean {
+  const key = event.key.toLowerCase()
+  if (isMac) {
+    return key === 'v' && event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey
+  }
+  // Ctrl+V and Ctrl+Shift+V both dispatch a native paste event on Windows/Linux.
+  if (key === 'v' && event.ctrlKey && !event.metaKey && !event.altKey) {
+    return true
+  }
+  return (
+    event.key === 'Insert' &&
+    event.shiftKey &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.altKey
+  )
+}

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-event-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-event-paste.ts
@@ -1,0 +1,22 @@
+import { isWebClientLocation } from '@/lib/web-client-location'
+
+// Why: navigator.clipboard only exists in secure contexts. The web client served
+// over plain HTTP (e.g. a LAN address) can reach the clipboard only through the
+// chord's native ClipboardEvent, so Ctrl/Cmd+V must not be preventDefault-ed there.
+export function shouldUseClipboardEventPaste(args: {
+  isWebClient: boolean
+  clipboardReadTextAvailable: boolean
+}): boolean {
+  return args.isWebClient && !args.clipboardReadTextAvailable
+}
+
+export function isClipboardEventPasteRequired(): boolean {
+  return shouldUseClipboardEventPaste({
+    isWebClient: isWebClientLocation(),
+    clipboardReadTextAvailable: typeof navigator.clipboard?.readText === 'function'
+  })
+}
+
+export function getClipboardEventText(event: ClipboardEvent): string {
+  return event.clipboardData?.getData('text/plain') ?? ''
+}


### PR DESCRIPTION
## Summary

Restores terminal paste on insecure-context (plain-HTTP) web clients so Ctrl+V / Cmd+V pastes text instead of silently failing — without letting custom-remapped paste chords leak raw control characters into the shell.

## ELI5

When you open Orca in a browser over plain `http://`, pasting into the terminal did nothing. This makes paste work again, and also makes sure a custom paste shortcut doesn't accidentally type stray control keys into your shell.

## Root cause & fix

`navigator.clipboard` only exists in secure contexts, so on insecure-origin web clients the async clipboard read returned empty while the keydown handler had already suppressed the browser's native paste — the one clipboard access that works there. The original PR fell back to the native `paste` event, but its early return (`if (isClipboardEventPasteRequired()) return`) ran *before* `preventDefault()`/`stopPropagation()`; a remapped chord (e.g. Ctrl+Y, Ctrl+D) fires no native paste event, so paste silently failed **and** the un-suppressed keydown reached xterm, which encoded it to the PTY (Ctrl+Y yank, Ctrl+D EOF). The fix gates that early return behind a new `firesNativePasteEvent(event, isMac)` predicate (mac: Cmd+V; non-mac: Ctrl+V, Ctrl+Shift+V, Shift+Insert), so only true native-paste chords skip suppression; any other matched chord keeps the existing preventDefault/stopPropagation path — a harmless no-op matching main.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- Test file `terminal-clipboard-event-paste.test.ts` — 8/8 tests pass on branch. New `firesNativePasteEvent` cases confirm default chords match and remapped Ctrl+Y / Ctrl+D (and cross-platform Cmd+V on non-mac, Ctrl+V on mac) do NOT match — the assertion that fails if the fix is reverted.
- Lint clean: `oxlint` on the 3 changed source files exits 0, no `max-lines` disable.

```
npx vitest run --config config/vitest.config.ts \
  src/renderer/src/components/terminal-pane/terminal-clipboard-event-paste.test.ts
=> Test Files  1 passed (1) | Tests  8 passed (8)
```

## Trade-offs

None — pure fix. (Pre-existing limitation unchanged: image paste and context-menu Paste still need a secure context.)

## Regression risk

Zero-regression by construction: only the buggy branch — the new early return — is narrowed by an added predicate. Standard clipboard chords (Cmd+V / Ctrl+V / Ctrl+Shift+V / Shift+Insert) still take the native-paste path; every other chord reverts to main's preventDefault/stopPropagation no-op. Electron and secure-context HTTPS clients are untouched. Proven by the passing predicate tests.

*Credit to @kespineira for the original fix. Validated, rebased, and hardened via automated bug-bash review; original fix design preserved. This session added `firesNativePasteEvent` plus tests to stop remapped paste chords from injecting control characters (Ctrl+Y/Ctrl+D) into the PTY.*
