### PR TITLE
fix(task-page): hide local-only repos from the task source picker

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -179,7 +179,6 @@ import {
   readLinearBoardIssueDragData,
   writeLinearBoardIssueDragData
 } from '@/lib/linear-board-drag-payload'
-import { isGitRepoKind } from '../../../shared/repo-kind'
 import { getRepoExecutionHostId } from '../../../shared/execution-host'
 import { projectHostSetupProjectionFromRepos } from '../../../shared/project-host-setup-projection'
 import { TASK_SOURCE_CONTEXT_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
@@ -239,6 +238,7 @@ import { getRepoBackedTaskEmptyState } from '@/components/task-page-empty-state'
 import {
   getDefaultTaskRepoSelection,
   getTaskProjectPickerGroups,
+  getTaskSourceEligibleRepos,
   normalizeTaskRepoSelection
 } from '@/components/task-page-default-repo-selection'
 import {
@@ -3141,7 +3141,7 @@ export default function TaskPage(): React.JSX.Element {
   const linearConnected = linearStatusCurrent && linearStatus.connected
   const jiraConnected = jiraStatusCurrent && jiraStatus.connected
   const submitShortcutLabel = getScreenSubmitShortcutLabel()
-  const eligibleRepos = useMemo(() => repos.filter((repo) => isGitRepoKind(repo)), [repos])
+  const eligibleRepos = useMemo(() => getTaskSourceEligibleRepos(repos), [repos])
 
   // Why: initial selection precedence — explicit preselection > persisted defaultRepoSelection > all eligible; preselection wins so "open tasks for this repo" lands single-repo.
   const resolvedInitialSelection = useMemo<ReadonlySet<string>>(() => {

--- a/src/renderer/src/components/task-page-default-repo-selection.test.ts
+++ b/src/renderer/src/components/task-page-default-repo-selection.test.ts
@@ -4,6 +4,7 @@ import {
   getDefaultTaskRepoSelection,
   getTaskProjectPickerGroups,
   getTaskProjectPickerRepos,
+  getTaskSourceEligibleRepos,
   normalizeTaskRepoSelection
 } from './task-page-default-repo-selection'
 
@@ -17,6 +18,28 @@ function repo(overrides: Partial<Repo> & Pick<Repo, 'id'>): Repo {
     ...overrides
   }
 }
+
+describe('getTaskSourceEligibleRepos', () => {
+  it('excludes local-only git repos with no resolvable remote identity', () => {
+    // Why: a repo with no remote has no provider to fetch tasks from (#9844);
+    // it otherwise appears as its own "project" via the repo:${id} fallback.
+    const eligible = getTaskSourceEligibleRepos([
+      repo({ id: 'github', upstream: { owner: 'stablyai', repo: 'orca' } }),
+      repo({
+        id: 'gitlab',
+        gitRemoteIdentity: {
+          canonicalKey: 'gitlab.com/team/app',
+          remoteName: 'origin',
+          remoteUrl: 'https://gitlab.com/team/app.git'
+        }
+      }),
+      repo({ id: 'local-only' }),
+      repo({ id: 'folder', kind: 'folder' })
+    ])
+
+    expect(eligible.map((r) => r.id).sort()).toEqual(['github', 'gitlab'])
+  })
+})
 
 describe('getDefaultTaskRepoSelection', () => {
   it('selects one source per logical GitHub project', () => {

--- a/src/renderer/src/components/task-page-default-repo-selection.ts
+++ b/src/renderer/src/components/task-page-default-repo-selection.ts
@@ -1,11 +1,23 @@
 import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../../shared/execution-host'
-import { getProjectIdentityKey } from '../../../shared/project-host-setup-projection'
+import {
+  getProjectIdentityKey,
+  hasResolvableProjectRemoteIdentity
+} from '../../../shared/project-host-setup-projection'
+import { isGitRepoKind } from '../../../shared/repo-kind'
 import type { Repo } from '../../../shared/types'
 
 export type TaskProjectPickerGroup = {
   projectKey: string
   repo: Repo
   sources: Repo[]
+}
+
+/** Repos usable as task/issue sources: git repos (not folders) that resolve to
+ *  a remote provider. Excludes local-only repos with no remote, which have no
+ *  provider to fetch tasks from and otherwise surface as their own project via
+ *  the repo:${id} identity fallback (#9844). */
+export function getTaskSourceEligibleRepos(repos: readonly Repo[]): Repo[] {
+  return repos.filter((repo) => isGitRepoKind(repo) && hasResolvableProjectRemoteIdentity(repo))
 }
 
 export function getDefaultTaskRepoSelection(repos: readonly Repo[]): Set<string> {

--- a/src/shared/project-host-setup-projection.test.ts
+++ b/src/shared/project-host-setup-projection.test.ts
@@ -3,6 +3,7 @@ import {
   projectHostSetupProjectionFromRepos,
   getProjectHostSetupsForProject,
   getProjectHostSetupWorktreeMeta,
+  hasResolvableProjectRemoteIdentity,
   isGitHubBackedRepo
 } from './project-host-setup-projection'
 import type { Repo } from './types'
@@ -506,5 +507,43 @@ describe('isGitHubBackedRepo', () => {
 
   it('is false for a plain local repo with no provider signal', () => {
     expect(isGitHubBackedRepo(repo({ id: 'r', path: '/r', displayName: 'r' }))).toBe(false)
+  })
+})
+
+describe('hasResolvableProjectRemoteIdentity', () => {
+  it('is true for a GitHub upstream repo', () => {
+    expect(
+      hasResolvableProjectRemoteIdentity(
+        repo({
+          id: 'r',
+          path: '/r',
+          displayName: 'r',
+          upstream: { owner: 'stablyai', repo: 'orca' }
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('is true for a non-GitHub remote resolved through gitRemoteIdentity', () => {
+    expect(
+      hasResolvableProjectRemoteIdentity(
+        repo({
+          id: 'r',
+          path: '/r',
+          displayName: 'r',
+          gitRemoteIdentity: {
+            canonicalKey: 'gitlab.com/team/app',
+            remoteName: 'origin',
+            remoteUrl: 'https://gitlab.com/team/app.git'
+          }
+        })
+      )
+    ).toBe(true)
+  })
+
+  it('is false for a local-only git repo with no remote', () => {
+    expect(
+      hasResolvableProjectRemoteIdentity(repo({ id: 'r', path: '/r', displayName: 'r' }))
+    ).toBe(false)
   })
 })

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -80,6 +80,16 @@ export function isGitHubBackedRepo(
   return getProjectProviderIdentity(repo) !== null
 }
 
+/** True when the repo has a remote identity Orca can resolve to a task/issue
+ *  provider (an explicit provider identity or any git remote). This is exactly
+ *  the negation of the `repo:${id}` fallback in getProjectIdentityKey — a
+ *  local-only repo with no remote has no provider to fetch tasks from. */
+export function hasResolvableProjectRemoteIdentity(
+  repo: Pick<Repo, 'upstream' | 'repoIcon' | 'gitRemoteIdentity'>
+): boolean {
+  return getProjectProviderIdentity(repo) !== null || getProjectGitRemoteIdentity(repo) !== null
+}
+
 export function getProjectIdentityKey(
   repo: Pick<Repo, 'id' | 'upstream' | 'repoIcon' | 'gitRemoteIdentity'>
 ): string {


### PR DESCRIPTION
## Summary

Fixes #9844.

A git repo with **no remote** (e.g. a local `git init` with no upstream) has no provider to fetch issues/PRs from, yet it appeared in the task page's project-source picker as its own selectable project. `getProjectIdentityKey` falls back to `repo:${repo.id}` when a repo has no resolvable remote identity, so each local-only repo minted a distinct "project" entry. The task page's `eligibleRepos` only filtered out folder repos (`isGitRepoKind`), so these remoteless git repos passed straight through.

**Fix:** add `hasResolvableProjectRemoteIdentity(repo)` — the exact negation of the `repo:${id}` fallback (a resolvable provider identity **or** any git remote) — and a `getTaskSourceEligibleRepos(repos)` helper that requires both `isGitRepoKind` and a resolvable remote identity. `eligibleRepos` now uses it.

Scope notes:
- Repos with a **non-GitHub** remote (GitLab/Gitea, resolved through `gitRemoteIdentity`) keep their `git:` identity key and remain eligible — they *can* fetch tasks, so they stay. Only truly remoteless repos drop out.
- This changes **only** the task-source list. The general project/worktree rail is untouched — a local-only repo is still a first-class project everywhere else, it just isn't offered as a task source it can't serve.

## Screenshots

No new UI. Behavioral: a local-only repo no longer appears in the task page project-source picker.

Verified live (dev build): added a local `git init` repo with no remote alongside a GitHub-backed repo. The task-source picker ("All projects" dropdown) listed only the remote-backed repo; the local-only repo was absent, while it still appeared normally in the left project rail. A GitLab-style repo (remote via `gitRemoteIdentity`) stays eligible.

## Testing

- [x] `pnpm lint` (my files clean; one pre-existing unrelated `skill-freshness-group.tsx` switch-exhaustiveness error is present on `main` too)
- [x] `pnpm typecheck`
- [x] `pnpm test` (the 5 changed-area test files pass; the remaining full-suite failures are pre-existing environment-sensitive packaging/PTY/relay/IME tests that fail identically on clean `main` in this Node 22 sandbox)
- [x] `pnpm build`
- [x] Added regression tests that fail without the fix

New tests:
- `project-host-setup-projection.test.ts` — `hasResolvableProjectRemoteIdentity`: true for a GitHub upstream repo, true for a non-GitHub remote via `gitRemoteIdentity`, false for a local-only repo.
- `task-page-default-repo-selection.test.ts` — `getTaskSourceEligibleRepos` excludes local-only and folder repos, keeps GitHub and GitLab-style repos.

Both were confirmed red before the fix (function missing / repo included) and green after.

## AI Review Report

Reviewed by Claude (Opus 4.8, author).

- **Root cause verified in source**, not guessed: `getProjectIdentityKey` (`project-host-setup-projection.ts`) returns `repo:${id}` exactly when `getProjectProviderIdentity` and `getProjectGitRemoteIdentity` are both null; `eligibleRepos` (`TaskPage.tsx`) filtered only folders via `isGitRepoKind`. Confirmed live: a no-remote repo's store record has `upstream` absent, no GitHub `repoIcon`, and `gitRemoteIdentity: null`.
- **Blast radius**: the new predicate is the strict complement of the existing identity fallback, so it can only exclude repos that would otherwise group under `repo:${id}`. The filter is applied at the single `eligibleRepos` derivation that feeds the picker, default selection, and fetch — keeping them consistent (a hidden repo can't be selected or fetched). No other consumer of the repo list changes.
- **Non-GitHub providers preserved**: GitLab/Gitea repos resolve through `gitRemoteIdentity` to a `git:` key, so `hasResolvableProjectRemoteIdentity` returns true and they remain eligible — the fix is not GitHub-only.
- **Cross-platform / SSH**: pure renderer selection logic; no platform branches, no Git invocation, no transport code. Remote (SSH) repos carry the same identity fields and behave identically.
- **Edge**: a repo whose remote metadata hasn't resolved yet would be transiently excluded until `gitRemoteIdentity` populates — strictly better than showing an unfetchable source, and self-corrects.

## Security Audit

No new input handling, IPC, auth, command execution, or path handling. The change reads existing repo-identity fields already present in renderer state to decide list membership. No secrets or logging affected.
