### PR TITLE
fix(ssh): support long-running worktree creation

### DIFF
--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: this suite covers the SSH git provider's one-RPC-per-method contract; splitting it would duplicate the shared mux fixture. */
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { SshGitProvider } from './ssh-git-provider'
+import { SSH_WORKTREE_ADD_TIMEOUT_MS, SshGitProvider } from './ssh-git-provider'
 
 type MockMultiplexer = {
   request: ReturnType<typeof vi.fn>
@@ -1341,18 +1341,25 @@ describe('SshGitProvider', () => {
     expect(result).toEqual(worktrees)
   })
 
-  it('addWorktree sends git.addWorktree request', async () => {
+  it('addWorktree uses the extended git.addWorktree deadline', async () => {
+    const controller = new AbortController()
     await provider.addWorktree('/home/user/repo', 'feature', '/home/user/feat', {
       base: 'main',
-      noCheckout: true
+      noCheckout: true,
+      signal: controller.signal
     })
-    expect(mux.request).toHaveBeenCalledWith('git.addWorktree', {
-      repoPath: '/home/user/repo',
-      branchName: 'feature',
-      targetDir: '/home/user/feat',
-      base: 'main',
-      noCheckout: true
-    })
+    expect(SSH_WORKTREE_ADD_TIMEOUT_MS).toBe(600_000)
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.addWorktree',
+      {
+        repoPath: '/home/user/repo',
+        branchName: 'feature',
+        targetDir: '/home/user/feat',
+        base: 'main',
+        noCheckout: true
+      },
+      { signal: controller.signal, timeoutMs: SSH_WORKTREE_ADD_TIMEOUT_MS }
+    )
   })
 
   it('removeWorktree sends git.removeWorktree request', async () => {

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -40,6 +40,9 @@ type NonInteractiveExecQueueEntry = {
   release: () => void
 }
 
+// Why: 大型 SSH checkout 和 Git LFS 下载可正常超过通用 RPC 的 30 秒时限。
+export const SSH_WORKTREE_ADD_TIMEOUT_MS = 10 * 60_000
+
 function isJsonRpcMethodNotFoundError(error: unknown): boolean {
   if (!error || typeof error !== 'object') {
     return false
@@ -711,15 +714,25 @@ export class SshGitProvider implements IGitProvider {
     repoPath: string,
     branchName: string,
     targetDir: string,
-    options?: { base?: string; checkoutExistingBranch?: boolean; noCheckout?: boolean }
+    options?: {
+      base?: string
+      checkoutExistingBranch?: boolean
+      noCheckout?: boolean
+      signal?: AbortSignal
+    }
   ): Promise<void> {
+    const { signal, ...params } = options ?? {}
     await this.runWithDiffDedupeClear(async () => {
-      await this.mux.request('git.addWorktree', {
-        repoPath,
-        branchName,
-        targetDir,
-        ...options
-      })
+      await this.mux.request(
+        'git.addWorktree',
+        {
+          repoPath,
+          branchName,
+          targetDir,
+          ...params
+        },
+        { signal, timeoutMs: SSH_WORKTREE_ADD_TIMEOUT_MS }
+      )
     })
   }
 

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -351,7 +351,12 @@ export type IGitProvider = {
     repoPath: string,
     branchName: string,
     targetDir: string,
-    options?: { base?: string; checkoutExistingBranch?: boolean; noCheckout?: boolean }
+    options?: {
+      base?: string
+      checkoutExistingBranch?: boolean
+      noCheckout?: boolean
+      signal?: AbortSignal
+    }
   ): Promise<void>
   removeWorktree(
     worktreePath: string,

--- a/src/relay/git-handler-worktree-add-cancellation.test.ts
+++ b/src/relay/git-handler-worktree-add-cancellation.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { GitExec } from './git-handler-ops'
+import { addWorktreeOp } from './git-handler-worktree-ops'
+
+const worktreeParams = {
+  repoPath: '/repo',
+  branchName: 'feature/test',
+  targetDir: '/repo-feature'
+}
+
+function abortError(controller: AbortController, message: string): Error {
+  controller.abort()
+  return Object.assign(new Error(message), { name: 'AbortError' })
+}
+
+describe('addWorktreeOp cancellation', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('stops base-ref fallback when the request is cancelled', async () => {
+    const controller = new AbortController()
+    const git = vi.fn<GitExec>(async () => {
+      throw abortError(controller, 'base probe cancelled')
+    })
+
+    await expect(
+      addWorktreeOp(
+        git,
+        { ...worktreeParams, base: 'origin/main' },
+        {
+          signal: controller.signal
+        }
+      )
+    ).rejects.toMatchObject({ name: 'AbortError', message: 'base probe cancelled' })
+
+    expect(git).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not clean up base metadata after a cancelled persistence write', async () => {
+    const controller = new AbortController()
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'config' && args[2] === '--replace-all') {
+        throw abortError(controller, 'base persistence cancelled')
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      addWorktreeOp(
+        git,
+        { ...worktreeParams, base: 'origin/main' },
+        {
+          signal: controller.signal
+        }
+      )
+    ).rejects.toMatchObject({ name: 'AbortError', message: 'base persistence cancelled' })
+
+    expect(git.mock.calls.map((call) => call[0])).not.toContainEqual([
+      'config',
+      '--local',
+      '--unset-all',
+      'branch.feature/test.base'
+    ])
+  })
+
+  it('rethrows cancellation while clearing stale base metadata', async () => {
+    const controller = new AbortController()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'config' && args[2] === '--replace-all') {
+        throw new Error('config locked')
+      }
+      if (args[0] === 'config' && args[2] === '--unset-all') {
+        throw abortError(controller, 'base cleanup cancelled')
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      addWorktreeOp(
+        git,
+        { ...worktreeParams, base: 'origin/main' },
+        {
+          signal: controller.signal
+        }
+      )
+    ).rejects.toMatchObject({ name: 'AbortError', message: 'base cleanup cancelled' })
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('rethrows cancellation while reading push.autoSetupRemote', async () => {
+    const controller = new AbortController()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'config' && args[1] === '--get') {
+        throw abortError(controller, 'config read cancelled')
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      addWorktreeOp(git, worktreeParams, { signal: controller.signal })
+    ).rejects.toMatchObject({ name: 'AbortError', message: 'config read cancelled' })
+
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('rethrows cancellation while writing push.autoSetupRemote', async () => {
+    const controller = new AbortController()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'config' && args[1] === '--get') {
+        throw Object.assign(new Error('key unset'), { code: 1 })
+      }
+      if (args[0] === 'config' && args[2] === 'push.autoSetupRemote') {
+        throw abortError(controller, 'config write cancelled')
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      addWorktreeOp(git, worktreeParams, { signal: controller.signal })
+    ).rejects.toMatchObject({ name: 'AbortError', message: 'config write cancelled' })
+
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -4,22 +4,31 @@ import type { GitExec } from './git-handler-ops'
 export { removeWorktreeOp } from './git-handler-worktree-remove'
 export { readRelayWorktreeList } from './git-handler-worktree-list'
 
+function rethrowIfRequestAborted(signal: AbortSignal | undefined, error: unknown): void {
+  if (signal?.aborted) {
+    throw error
+  }
+}
+
 async function persistRelayWorktreeCreationBase(
   git: GitExec,
   targetDir: string,
   branchName: string,
-  effectiveBase: string
+  effectiveBase: string,
+  options: { signal?: AbortSignal }
 ): Promise<void> {
   const configKey = `branch.${branchName}.base`
   try {
-    await git(['config', '--local', '--replace-all', configKey, effectiveBase], targetDir)
+    await git(['config', '--local', '--replace-all', configKey, effectiveBase], targetDir, options)
   } catch (error) {
+    rethrowIfRequestAborted(options.signal, error)
     console.warn(`relay addWorktree: failed to set ${configKey} for ${targetDir}`, error)
     try {
       // Why: SSH worktree creation shares branch config by name; clear stale
       // metadata if replacing an old same-name base fails.
-      await git(['config', '--local', '--unset-all', configKey], targetDir)
+      await git(['config', '--local', '--unset-all', configKey], targetDir, options)
     } catch (unsetError) {
+      rethrowIfRequestAborted(options.signal, unsetError)
       console.warn(
         `relay addWorktree: failed to unset stale ${configKey} for ${targetDir}`,
         unsetError
@@ -28,7 +37,11 @@ async function persistRelayWorktreeCreationBase(
   }
 }
 
-export async function addWorktreeOp(git: GitExec, params: Record<string, unknown>): Promise<void> {
+export async function addWorktreeOp(
+  git: GitExec,
+  params: Record<string, unknown>,
+  options: { signal?: AbortSignal } = {}
+): Promise<void> {
   const repoPath = params.repoPath as string
   const branchName = params.branchName as string
   const targetDir = params.targetDir as string
@@ -54,9 +67,14 @@ export async function addWorktreeOp(git: GitExec, params: Record<string, unknown
     base && !checkoutExistingBranch
       ? await resolveWorktreeAddBaseRef(base, async (qualifiedRef) => {
           try {
-            await git(['rev-parse', '--verify', '--quiet', `${qualifiedRef}^{commit}`], repoPath)
+            await git(
+              ['rev-parse', '--verify', '--quiet', `${qualifiedRef}^{commit}`],
+              repoPath,
+              options
+            )
             return true
-          } catch {
+          } catch (error) {
+            rethrowIfRequestAborted(options.signal, error)
             return false
           }
         })
@@ -72,14 +90,14 @@ export async function addWorktreeOp(git: GitExec, params: Record<string, unknown
     args.push(effectiveBase)
   }
 
-  await git(args, repoPath)
+  await git(args, repoPath, options)
 
   if (checkoutExistingBranch) {
     return
   }
 
   if (effectiveBase) {
-    await persistRelayWorktreeCreationBase(git, targetDir, branchName, effectiveBase)
+    await persistRelayWorktreeCreationBase(git, targetDir, branchName, effectiveBase, options)
   }
 
   // Why: best-effort write so a deliberate user value (any scope) is
@@ -91,9 +109,10 @@ export async function addWorktreeOp(git: GitExec, params: Record<string, unknown
   try {
     let alreadySet = false
     try {
-      await git(['config', '--get', 'push.autoSetupRemote'], targetDir)
+      await git(['config', '--get', 'push.autoSetupRemote'], targetDir, options)
       alreadySet = true
     } catch (readError) {
+      rethrowIfRequestAborted(options.signal, readError)
       // Why: `git config --get` exits 1 only when the key is unset at every
       // scope. Any other code is a real read failure (corrupt config,
       // locked file) — surface it via the outer catch instead of falling
@@ -104,9 +123,10 @@ export async function addWorktreeOp(git: GitExec, params: Record<string, unknown
       }
     }
     if (!alreadySet) {
-      await git(['config', '--local', 'push.autoSetupRemote', 'true'], targetDir)
+      await git(['config', '--local', 'push.autoSetupRemote', 'true'], targetDir, options)
     }
   } catch (error) {
+    rethrowIfRequestAborted(options.signal, error)
     console.warn(`relay addWorktree: failed to set push.autoSetupRemote for ${targetDir}`, error)
   }
 }

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -2494,12 +2494,36 @@ describe('GitHandler', () => {
           (
             args: string[],
             cwd: string,
-            opts?: { maxBuffer?: number }
+            opts?: { maxBuffer?: number; signal?: AbortSignal }
           ) => Promise<{ stdout: string; stderr: string }>
         >()
       ;(handler as unknown as { git: typeof gitMock }).git = gitMock
       return { localDispatcher, gitMock }
     }
+
+    it('passes request cancellation to the git worktree add subprocess', async () => {
+      const { localDispatcher, gitMock } = setupMockedHandler(['/relay/repo', '/relay/wt'])
+      const controller = new AbortController()
+      gitMock.mockRejectedValueOnce(new Error('aborted'))
+
+      await expect(
+        localDispatcher.callRequest(
+          'git.addWorktree',
+          {
+            repoPath: '/relay/repo',
+            branchName: 'feature/test',
+            targetDir: '/relay/wt'
+          },
+          { isStale: () => false, signal: controller.signal }
+        )
+      ).rejects.toThrow('aborted')
+
+      expect(gitMock).toHaveBeenCalledWith(
+        ['worktree', 'add', '--no-track', '-b', 'feature/test', '/relay/wt'],
+        '/relay/repo',
+        { signal: controller.signal }
+      )
+    })
 
     it('passes --no-track and writes push.autoSetupRemote when unset', async () => {
       const { localDispatcher, gitMock } = setupMockedHandler(['/relay/repo', '/relay/wt'])

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -246,7 +246,7 @@ export class GitHandler {
     this.dispatcher.onRequest('git.branchDiff', (p, context) => this.branchDiff(p, context))
     this.dispatcher.onRequest('git.commitDiff', (p, context) => this.commitDiff(p, context))
     this.dispatcher.onRequest('git.listWorktrees', (p, context) => this.listWorktrees(p, context))
-    this.dispatcher.onRequest('git.addWorktree', (p) => this.addWorktree(p))
+    this.dispatcher.onRequest('git.addWorktree', (p, context) => this.addWorktree(p, context))
     this.dispatcher.onRequest('git.removeWorktree', (p) => this.removeWorktree(p))
     this.dispatcher.onRequest('git.worktreeIsClean', (p) => this.worktreeIsClean(p))
     this.dispatcher.onRequest('git.refreshLocalBaseRefForWorktreeCreate', (p) =>
@@ -1430,8 +1430,10 @@ export class GitHandler {
       .catch(() => [])
   }
 
-  private async addWorktree(params: Record<string, unknown>) {
-    return this.runWithGitReadCacheClear(() => addWorktreeOp(this.git.bind(this), params))
+  private async addWorktree(params: Record<string, unknown>, context: RequestContext) {
+    return this.runWithGitReadCacheClear(() =>
+      addWorktreeOp(this.git.bind(this), params, { signal: context.signal })
+    )
   }
 
   private async removeWorktree(params: Record<string, unknown>) {


### PR DESCRIPTION
## Summary

- Give SSH `git.addWorktree` requests a 10-minute deadline instead of the generic 30-second RPC timeout.
- Forward the existing relay request cancellation signal into the Git subprocess so timed-out or disconnected requests stop remote work.

Closes #9865

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` (blocked by a pre-existing error on `upstream/main` in `src/renderer/src/components/skills/skill-freshness-group.tsx:101`: `Cases not matched: undefined | "current" | "duplicate"`)
- [x] `pnpm run typecheck`
- [x] Targeted Vitest suites: 241 tests passed
- [x] `pnpm run build:desktop`
- [x] Added regression coverage for the method-specific deadline and relay cancellation propagation
- [x] `pnpm run check:max-lines-ratchet`
- [x] `pnpm run check:reliability-gates`
- [x] Touched-file Oxlint and Oxfmt checks

## AI Review Report

Reviewed timeout scope, relay cancellation flow, old-client/new-relay compatibility, and the existing worktree creation state machine. The 10-minute deadline is limited to `git.addWorktree`; other SSH RPCs retain their current timeout. The wire protocol and Git arguments are unchanged.

Cross-platform compatibility was checked for macOS, Linux, and Windows, including SSH hosts on each platform. The desktop build packaged relay targets for Linux, macOS, Windows, and WSL. This change touches no shortcuts, labels, paths, shell syntax, or Electron-specific platform branches.

## Security Audit

The command execution review confirmed that no user-controlled arguments, new commands, authentication data, secrets, dependencies, or IPC schema changes were introduced. The existing AbortSignal now reaches the relay Git executor, reducing the risk of orphaned remote mutations after a timeout or connection loss. No security follow-up is needed.

## Notes

An older relay still benefits from the longer client deadline but will not terminate a canceled Git subprocess until the updated relay is deployed. The full lint failure is unrelated to this branch; touched-file lint passes.
- X handle: N/A



## ELI5

Creating a worktree over SSH could hit a 30-second timeout on large clones. SSH worktree create gets a 10-minute deadline, and cancel/disconnect stops the remote git work.
