### PR TITLE
fix(orchestration): reject incomplete worker_done as semantic completion

### DIFF
--- a/src/main/runtime/orchestration/__snapshots__/preamble.test.ts.snap
+++ b/src/main/runtime/orchestration/__snapshots__/preamble.test.ts.snap
@@ -19,7 +19,12 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
   # payload.reportPath so the coordinator can find it without a file search.
   #
   # RULE: send worker_done exactly once. Failure is still a worker_done
-  # with subject like "Failed: <reason>" — never silently exit.
+  # with subject like "Failed: <reason>" — never silently exit. That
+  # marks the task failed, not completed. Do not send worker_done for
+  # blocked / decision-required / unresolved-escalation / remaining-gate
+  # outcomes unless the durable task spec explicitly defines a
+  # code-complete / activation-gate split; use escalation or status plus
+  # a continuation task (or coordinator reclassification) instead.
   # Include BOTH taskId and dispatchId in the payload so a late completion
   # from a failed retry cannot complete the current dispatch.
   orca orchestration send --to term_COORD --from term_WORKER \\

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -45,7 +45,14 @@ function generateId(prefix: string): string {
   return `${prefix}_${randomBytes(6).toString('hex')}`
 }
 
-function addLifecycleRejectionMarker(payload: string | null, reason: string): string {
+export type LifecycleRejectionCode = 'sender_not_assignee' | 'incomplete_outcome'
+
+function addLifecycleRejectionMarker(
+  payload: string | null,
+  reason: string,
+  code: LifecycleRejectionCode = 'sender_not_assignee',
+  appliedStatus?: 'blocked' | 'failed'
+): string {
   let parsed: Record<string, unknown> = {}
   try {
     const value: unknown = payload ? JSON.parse(payload) : {}
@@ -57,7 +64,11 @@ function addLifecycleRejectionMarker(payload: string | null, reason: string): st
   }
   return JSON.stringify({
     ...parsed,
-    _orcaLifecycleRejection: { code: 'sender_not_assignee', reason }
+    _orcaLifecycleRejection: {
+      code,
+      reason,
+      ...(appliedStatus ? { appliedStatus } : {})
+    }
   })
 }
 
@@ -373,7 +384,12 @@ export class OrchestrationDb {
     )
   }
 
-  convertLifecycleMessageToRejection(messageId: string, reason: string): MessageRow | undefined {
+  convertLifecycleMessageToRejection(
+    messageId: string,
+    reason: string,
+    code: LifecycleRejectionCode = 'sender_not_assignee',
+    appliedStatus?: 'blocked' | 'failed'
+  ): MessageRow | undefined {
     const message = this.getMessageById(messageId)
     if (!message || (message.type !== 'worker_done' && message.type !== 'heartbeat')) {
       return message
@@ -381,7 +397,7 @@ export class OrchestrationDb {
 
     const originalBody = message.body ? `\n\nOriginal body:\n${message.body}` : ''
     const body = `Orca rejected this ${message.type}: ${reason}${originalBody}`
-    const payload = addLifecycleRejectionMarker(message.payload, reason)
+    const payload = addLifecycleRejectionMarker(message.payload, reason, code, appliedStatus)
     // Why: rejected lifecycle signals stay auditable but must not reach read paths as actionable completion/liveness events.
     this.db
       .prepare(
@@ -391,6 +407,23 @@ export class OrchestrationDb {
       )
       .run(`Rejected ${message.type}: ${message.subject}`, body, payload, messageId)
     return this.getMessageById(messageId)
+  }
+
+  // Why: incomplete worker_done must close the in-flight dispatch without
+  // promoting dependents the way updateTaskStatus('completed') does.
+  closeActiveDispatchWithoutCompletion(
+    taskId: string,
+    status: 'blocked' | 'failed',
+    result?: string
+  ): TaskRow | undefined {
+    this.completeActiveDispatchForTask(taskId)
+    const completedAt = status === 'failed' ? new Date().toISOString() : null
+    this.db
+      .prepare(
+        'UPDATE tasks SET status = ?, result = COALESCE(?, result), completed_at = COALESCE(?, completed_at) WHERE id = ?'
+      )
+      .run(status, result ?? null, completedAt, taskId)
+    return this.getTask(taskId)
   }
 
   // Why: delivered_at IS NULL filter — push-on-idle delivers each row at most once; read (set only by check) wouldn't prevent replay.

--- a/src/main/runtime/orchestration/lifecycle-reconciliation.test.ts
+++ b/src/main/runtime/orchestration/lifecycle-reconciliation.test.ts
@@ -409,4 +409,77 @@ describe('lifecycle reconciliation', () => {
     expect(db.getMessageById(lateHeartbeat.id)).toMatchObject({ read: 1 })
     expect(db.getMessageById(lateHeartbeat.id)?.delivered_at).not.toBeNull()
   })
+
+  it('rejects the INC-3 incomplete worker_done instead of completing durable state', () => {
+    db = new OrchestrationDb(':memory:')
+    const task = db.createTask({
+      spec: 'Activate incident producer after owner-gated migration approval.'
+    })
+    const dispatch = db.createDispatchContext(task.id, 'term_worker', `tab_w:${LEAF_A}`)
+    const child = db.createTask({ spec: 'dependent follow-up', deps: [task.id] })
+    const logs: string[] = []
+    const message = db.insertMessage({
+      from: 'term_worker',
+      to: 'term_coordinator',
+      subject: 'INC-3 migration remaining',
+      body:
+        'Attempted activation for INC-3. Migration 0129 failed transactionally. ' +
+        'Remaining reconciliation/activation gates still block deploy and E2E. ' +
+        'No migration/deploy/E2E has occurred.',
+      type: 'worker_done',
+      payload: JSON.stringify({
+        taskId: task.id,
+        dispatchId: dispatch.id,
+        filesModified: []
+      }),
+      senderPaneKey: `tab_w:${LEAF_A}`
+    })
+
+    expect(reconcileLifecycleMessage(db, message, (line) => logs.push(line))).toMatchObject({
+      action: 'rejected',
+      code: 'incomplete_outcome',
+      appliedStatus: 'failed'
+    })
+    expect(db.getTask(task.id)?.status).toBe('failed')
+    expect(db.getDispatchContextById(dispatch.id)?.status).toBe('completed')
+    expect(db.getTask(child.id)?.status).toBe('pending')
+    expect(db.getMessageById(message.id)).toMatchObject({
+      priority: 'high',
+      subject: 'Rejected worker_done: INC-3 migration remaining'
+    })
+    expect(JSON.parse(db.getMessageById(message.id)?.payload ?? '{}')).toMatchObject({
+      _orcaLifecycleRejection: {
+        code: 'incomplete_outcome',
+        appliedStatus: 'failed'
+      }
+    })
+    expect(logs.some((line) => line.includes('worker_done rejected'))).toBe(true)
+  })
+
+  it('allows remaining activation gates only when the durable spec defines the split', () => {
+    db = new OrchestrationDb(':memory:')
+    const task = db.createTask({
+      spec:
+        'Send worker_done when the code/docs change is complete. ' +
+        'The durable task defines a code-complete vs activation split; ' +
+        'owner-gated activation may remain unmet.'
+    })
+    const dispatch = db.createDispatchContext(task.id, 'term_worker', `tab_w:${LEAF_A}`)
+    const message = db.insertMessage({
+      from: 'term_worker',
+      to: 'term_coordinator',
+      subject: 'Code complete; activation pending',
+      body: 'Diff is review-clean. Remaining activation gates are owner-gated.',
+      type: 'worker_done',
+      payload: JSON.stringify({
+        taskId: task.id,
+        dispatchId: dispatch.id,
+        filesModified: ['ORCHESTRATION.md']
+      }),
+      senderPaneKey: `tab_w:${LEAF_A}`
+    })
+
+    expect(reconcileLifecycleMessage(db, message).action).toBe('completed')
+    expect(db.getTask(task.id)?.status).toBe('completed')
+  })
 })

--- a/src/main/runtime/orchestration/lifecycle-reconciliation.test.ts
+++ b/src/main/runtime/orchestration/lifecycle-reconciliation.test.ts
@@ -456,7 +456,7 @@ describe('lifecycle reconciliation', () => {
     expect(logs.some((line) => line.includes('worker_done rejected'))).toBe(true)
   })
 
-  it('allows remaining activation gates only when the durable spec defines the split', () => {
+  it('keeps activation-pending worker_done blocked even with an explicit split', () => {
     db = new OrchestrationDb(':memory:')
     const task = db.createTask({
       spec:
@@ -479,7 +479,11 @@ describe('lifecycle reconciliation', () => {
       senderPaneKey: `tab_w:${LEAF_A}`
     })
 
-    expect(reconcileLifecycleMessage(db, message).action).toBe('completed')
-    expect(db.getTask(task.id)?.status).toBe('completed')
+    expect(reconcileLifecycleMessage(db, message)).toMatchObject({
+      action: 'rejected',
+      code: 'incomplete_outcome',
+      appliedStatus: 'blocked'
+    })
+    expect(db.getTask(task.id)?.status).toBe('blocked')
   })
 })

--- a/src/main/runtime/orchestration/lifecycle-reconciliation.ts
+++ b/src/main/runtime/orchestration/lifecycle-reconciliation.ts
@@ -1,6 +1,7 @@
-import type { OrchestrationDb } from './db'
+import type { LifecycleRejectionCode, OrchestrationDb } from './db'
 import type { MessageRow } from './types'
 import { parsePaneKey } from '../../../shared/stable-pane-id'
+import { evaluateWorkerDoneSemanticCompletion } from './worker-done-semantic-completion'
 
 // Why: the tab half can change on pane break-out, while opaque legacy keys
 // have no safe equivalence beyond exact equality.
@@ -39,8 +40,9 @@ export type LifecycleReconciliationResult =
 
 export type LifecycleRejectionResult = {
   action: 'rejected'
-  code: 'sender_not_assignee'
+  code: LifecycleRejectionCode
   reason: string
+  appliedStatus?: 'blocked' | 'failed'
 }
 
 type LogFn = (msg: string) => void
@@ -65,20 +67,26 @@ function getPersistedLifecycleRejection(
   payload: Record<string, unknown>
 ): LifecycleRejectionResult | undefined {
   const rejection = payload._orcaLifecycleRejection
+  if (!rejection || typeof rejection !== 'object') {
+    return undefined
+  }
+  const code = (rejection as { code?: unknown }).code
   if (
-    !rejection ||
-    typeof rejection !== 'object' ||
-    (rejection as { code?: unknown }).code !== 'sender_not_assignee' ||
+    (code !== 'sender_not_assignee' && code !== 'incomplete_outcome') ||
     typeof (rejection as { reason?: unknown }).reason !== 'string'
   ) {
     return undefined
   }
   // Why: the marker is reserved persistence state; treating it as a rejection
   // also prevents caller-supplied markers from turning lifecycle sends into success.
+  const appliedStatus = (rejection as { appliedStatus?: unknown }).appliedStatus
   return {
     action: 'rejected',
-    code: 'sender_not_assignee',
-    reason: (rejection as { reason: string }).reason
+    code,
+    reason: (rejection as { reason: string }).reason,
+    ...(appliedStatus === 'blocked' || appliedStatus === 'failed'
+      ? { appliedStatus }
+      : {})
   }
 }
 
@@ -226,6 +234,43 @@ function reconcileWorkerDoneMessage(
     payload.filesModified.every((file) => typeof file === 'string')
       ? payload.filesModified
       : []
+
+  // Why: matching taskId+dispatchId is necessary but not sufficient. INC-3
+  // closed as completed on an empty-files worker_done that still declared
+  // transactional migration failure and remaining activation gates.
+  const semantic = evaluateWorkerDoneSemanticCompletion({
+    subject: msg.subject,
+    body: msg.body,
+    filesModified,
+    taskSpec: task.spec
+  })
+  if (!semantic.complete) {
+    const reason = semantic.reason
+    onLog(`Warning: worker_done rejected: ${reason}`)
+    const rejectionPayload = JSON.stringify({
+      taskId,
+      dispatchId,
+      filesModified,
+      closedBy: msg.from_handle,
+      incompleteKind: semantic.kind,
+      appliedStatus: semantic.appliedStatus,
+      closedAt: new Date().toISOString()
+    })
+    db.closeActiveDispatchWithoutCompletion(taskId, semantic.appliedStatus, rejectionPayload)
+    db.convertLifecycleMessageToRejection(
+      msg.id,
+      reason,
+      'incomplete_outcome',
+      semantic.appliedStatus
+    )
+    suppressEarlierHeartbeats(db, msg, dispatchId)
+    return {
+      action: 'rejected',
+      code: 'incomplete_outcome',
+      reason,
+      appliedStatus: semantic.appliedStatus
+    }
+  }
 
   const result = JSON.stringify({
     completedBy: msg.from_handle,

--- a/src/main/runtime/orchestration/preamble.ts
+++ b/src/main/runtime/orchestration/preamble.ts
@@ -71,7 +71,12 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
   # payload.reportPath so the coordinator can find it without a file search.
   #
   # RULE: send worker_done exactly once. Failure is still a worker_done
-  # with subject like "Failed: <reason>" — never silently exit.
+  # with subject like "Failed: <reason>" — never silently exit. That
+  # marks the task failed, not completed. Do not send worker_done for
+  # blocked / decision-required / unresolved-escalation / remaining-gate
+  # outcomes unless the durable task spec explicitly defines a
+  # code-complete / activation-gate split; use escalation or status plus
+  # a continuation task (or coordinator reclassification) instead.
   # Include BOTH taskId and dispatchId in the payload so a late completion
   # from a failed retry cannot complete the current dispatch.
   ${cli} orchestration send --to ${params.coordinatorHandle} --from ${params.workerHandle} \\

--- a/src/main/runtime/orchestration/worker-done-semantic-completion.test.ts
+++ b/src/main/runtime/orchestration/worker-done-semantic-completion.test.ts
@@ -193,4 +193,33 @@ describe('evaluateWorkerDoneSemanticCompletion', () => {
       appliedStatus: 'failed'
     })
   })
+
+  it('still rejects a later current failure after a recovered earlier failure', () => {
+    expect(
+      evaluateWorkerDoneSemanticCompletion({
+        subject: 'Partial recovery',
+        body:
+          'Migration failed, then succeeded after retry; deployment failed; implementation is complete.',
+        filesModified: ['src/main/runtime/orchestration/lifecycle-reconciliation.ts']
+      })
+    ).toMatchObject({
+      complete: false,
+      kind: 'failure',
+      appliedStatus: 'failed'
+    })
+  })
+
+  it('treats pending production deploy approval as an incomplete outcome', () => {
+    expect(
+      evaluateWorkerDoneSemanticCompletion({
+        subject: 'Implementation complete',
+        body: 'Implementation complete. Production deploy is pending owner approval.',
+        filesModified: ['src/main/runtime/orchestration/lifecycle-reconciliation.ts']
+      })
+    ).toMatchObject({
+      complete: false,
+      kind: 'remaining_gates',
+      appliedStatus: 'blocked'
+    })
+  })
 })

--- a/src/main/runtime/orchestration/worker-done-semantic-completion.test.ts
+++ b/src/main/runtime/orchestration/worker-done-semantic-completion.test.ts
@@ -140,4 +140,43 @@ describe('evaluateWorkerDoneSemanticCompletion', () => {
       appliedStatus: 'blocked'
     })
   })
+
+  it('does not reclassify narratively resolved past failures as current failures', () => {
+    expect(
+      evaluateWorkerDoneSemanticCompletion({
+        subject: 'ORCH-R10 complete',
+        body:
+          'Migration failed on the first attempt, then succeeded after retry. ' +
+          'The blocked deployment was resolved. Implementation is complete.',
+        filesModified: ['src/main/runtime/orchestration/lifecycle-reconciliation.ts']
+      })
+    ).toEqual({ complete: true })
+  })
+
+  it('requires an explicit completion claim; filesModified alone is not enough', () => {
+    expect(
+      evaluateWorkerDoneSemanticCompletion({
+        subject: 'Migration update',
+        body: 'I updated the migration, but still need to update the application.',
+        filesModified: ['drizzle/0129_something.sql'],
+        taskSpec: 'Ship the migration and application follow-up.'
+      })
+    ).toMatchObject({
+      complete: false,
+      kind: 'remaining_gates',
+      appliedStatus: 'blocked'
+    })
+
+    expect(
+      evaluateWorkerDoneSemanticCompletion({
+        subject: 'Touched files',
+        body: 'Edited the helper without claiming completion.',
+        filesModified: ['src/main/runtime/orchestration/worker-done-semantic-completion.ts']
+      })
+    ).toMatchObject({
+      complete: false,
+      kind: 'remaining_gates',
+      appliedStatus: 'blocked'
+    })
+  })
 })

--- a/src/main/runtime/orchestration/worker-done-semantic-completion.test.ts
+++ b/src/main/runtime/orchestration/worker-done-semantic-completion.test.ts
@@ -104,4 +104,19 @@ describe('evaluateWorkerDoneSemanticCompletion', () => {
       })
     ).toEqual({ complete: true })
   })
+
+  it('fails closed for pending activation wording without a durable split', () => {
+    expect(
+      evaluateWorkerDoneSemanticCompletion({
+        subject: 'Activation pending',
+        body: 'Waiting for owner approval before the migration can run.',
+        filesModified: [],
+        taskSpec: 'Activate after migration.'
+      })
+    ).toMatchObject({
+      complete: false,
+      kind: 'remaining_gates',
+      appliedStatus: 'blocked'
+    })
+  })
 })

--- a/src/main/runtime/orchestration/worker-done-semantic-completion.test.ts
+++ b/src/main/runtime/orchestration/worker-done-semantic-completion.test.ts
@@ -222,4 +222,19 @@ describe('evaluateWorkerDoneSemanticCompletion', () => {
       appliedStatus: 'blocked'
     })
   })
+
+  it('does not treat an unrelated resolved item as clearing a blocked state', () => {
+    expect(
+      evaluateWorkerDoneSemanticCompletion({
+        subject: 'Still blocked',
+        body:
+          'The task is blocked by owner approval; the documentation issue was resolved. Implementation complete.',
+        filesModified: ['src/main/runtime/orchestration/lifecycle-reconciliation.ts']
+      })
+    ).toMatchObject({
+      complete: false,
+      kind: 'blocked',
+      appliedStatus: 'blocked'
+    })
+  })
 })

--- a/src/main/runtime/orchestration/worker-done-semantic-completion.test.ts
+++ b/src/main/runtime/orchestration/worker-done-semantic-completion.test.ts
@@ -179,4 +179,18 @@ describe('evaluateWorkerDoneSemanticCompletion', () => {
       appliedStatus: 'blocked'
     })
   })
+
+  it('rejects plain test-suite failure wording before completion language', () => {
+    expect(
+      evaluateWorkerDoneSemanticCompletion({
+        subject: 'Tests failed; implementation complete.',
+        body: 'The test suite failed after the last push.',
+        filesModified: ['src/main/runtime/orchestration/worker-done-semantic-completion.ts']
+      })
+    ).toMatchObject({
+      complete: false,
+      kind: 'failure',
+      appliedStatus: 'failed'
+    })
+  })
 })

--- a/src/main/runtime/orchestration/worker-done-semantic-completion.test.ts
+++ b/src/main/runtime/orchestration/worker-done-semantic-completion.test.ts
@@ -102,7 +102,11 @@ describe('evaluateWorkerDoneSemanticCompletion', () => {
         filesModified: ['ORCHESTRATION.md'],
         taskSpec: spec
       })
-    ).toEqual({ complete: true })
+    ).toMatchObject({
+      complete: false,
+      kind: 'remaining_gates',
+      appliedStatus: 'blocked'
+    })
   })
 
   it('fails closed for pending activation wording without a durable split', () => {

--- a/src/main/runtime/orchestration/worker-done-semantic-completion.test.ts
+++ b/src/main/runtime/orchestration/worker-done-semantic-completion.test.ts
@@ -119,4 +119,21 @@ describe('evaluateWorkerDoneSemanticCompletion', () => {
       appliedStatus: 'blocked'
     })
   })
+
+  it('still requires completion evidence when an activation split is present', () => {
+    expect(
+      evaluateWorkerDoneSemanticCompletion({
+        subject: 'Activation pending',
+        body: 'Waiting for owner approval before the migration can run.',
+        filesModified: [],
+        taskSpec:
+          'Send worker_done when the code/docs change is complete. ' +
+          'The durable task defines a code-complete vs activation split.'
+      })
+    ).toMatchObject({
+      complete: false,
+      kind: 'remaining_gates',
+      appliedStatus: 'blocked'
+    })
+  })
 })

--- a/src/main/runtime/orchestration/worker-done-semantic-completion.test.ts
+++ b/src/main/runtime/orchestration/worker-done-semantic-completion.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import {
+  evaluateWorkerDoneSemanticCompletion,
+  taskSpecDefinesCodeCompleteActivationSplit
+} from './worker-done-semantic-completion'
+
+describe('evaluateWorkerDoneSemanticCompletion', () => {
+  it('accepts an ordinary successful worker_done', () => {
+    expect(
+      evaluateWorkerDoneSemanticCompletion({
+        subject: 'ORCH-R10 complete',
+        body: 'Implemented the guard, verified tests, and opened the PR.',
+        filesModified: ['src/main/runtime/orchestration/lifecycle-reconciliation.ts']
+      })
+    ).toEqual({ complete: true })
+  })
+
+  it('rejects the exact INC-3 incomplete shape as failed', () => {
+    // Observed 2026-07-22: task_c51afc88a23d / ctx_750a6815bc9f completed on an
+    // empty-files worker_done while migration 0129 failed transactionally and
+    // remaining reconciliation/activation gates were still reported.
+    const verdict = evaluateWorkerDoneSemanticCompletion({
+      subject: 'INC-3 migration remaining',
+      body:
+        'Attempted activation for INC-3. Migration 0129 failed transactionally. ' +
+        'Remaining reconciliation/activation gates still block deploy and E2E. ' +
+        'No migration/deploy/E2E has occurred.',
+      filesModified: [],
+      taskSpec: 'Activate incident producer after owner-gated migration approval.'
+    })
+    expect(verdict).toMatchObject({
+      complete: false,
+      kind: 'failure',
+      appliedStatus: 'failed'
+    })
+  })
+
+  it('rejects Failed: subjects without completing', () => {
+    expect(
+      evaluateWorkerDoneSemanticCompletion({
+        subject: 'Failed: review gate red',
+        body: 'Could not finish the required checks.'
+      })
+    ).toMatchObject({ complete: false, kind: 'failure', appliedStatus: 'failed' })
+  })
+
+  it('rejects blocked and decision-required worker_done', () => {
+    expect(
+      evaluateWorkerDoneSemanticCompletion({
+        subject: 'Blocked: waiting on queue binding',
+        body: 'PR remains open and blocked on the activation dependency.'
+      })
+    ).toMatchObject({ complete: false, kind: 'blocked', appliedStatus: 'blocked' })
+
+    expect(
+      evaluateWorkerDoneSemanticCompletion({
+        subject: 'Need direction',
+        body: 'Decision-required: choose whether to keep the binding or re-scope.'
+      })
+    ).toMatchObject({
+      complete: false,
+      kind: 'decision_required',
+      appliedStatus: 'blocked'
+    })
+  })
+
+  it('rejects unresolved escalation and remaining gates without an explicit split', () => {
+    expect(
+      evaluateWorkerDoneSemanticCompletion({
+        subject: 'Done for now',
+        body: 'There is still an unresolved escalation on the coordinator inbox.'
+      })
+    ).toMatchObject({
+      complete: false,
+      kind: 'unresolved_escalation',
+      appliedStatus: 'blocked'
+    })
+
+    expect(
+      evaluateWorkerDoneSemanticCompletion({
+        subject: 'Code pushed',
+        body: 'What\'s left: remaining activation gates before deploy.',
+        taskSpec: 'Ship the docs-only change and open a PR.'
+      })
+    ).toMatchObject({
+      complete: false,
+      kind: 'remaining_gates',
+      appliedStatus: 'blocked'
+    })
+  })
+
+  it('preserves an explicit durable code-complete/activation-gate split', () => {
+    const spec =
+      'Send worker_done when the code/docs change is complete. ' +
+      'The durable task defines a code-complete vs activation split; ' +
+      'owner-gated activation may remain unmet.'
+    expect(taskSpecDefinesCodeCompleteActivationSplit(spec)).toBe(true)
+    expect(
+      evaluateWorkerDoneSemanticCompletion({
+        subject: 'Code complete; activation pending',
+        body: 'Diff is review-clean. Remaining activation gates are owner-gated.',
+        filesModified: ['ORCHESTRATION.md'],
+        taskSpec: spec
+      })
+    ).toEqual({ complete: true })
+  })
+})

--- a/src/main/runtime/orchestration/worker-done-semantic-completion.ts
+++ b/src/main/runtime/orchestration/worker-done-semantic-completion.ts
@@ -108,16 +108,16 @@ export function evaluateWorkerDoneSemanticCompletion(
   }
 
   if (REMAINING_GATES_RE.test(text) || PENDING_WORK_RE.test(text)) {
-    if (splitAllowed) {
-      return { complete: true }
+    if (!splitAllowed) {
+      return {
+        complete: false,
+        kind: 'remaining_gates',
+        appliedStatus: 'blocked',
+        reason:
+          'worker_done reports required remaining or pending work without an explicit durable code-complete/activation-gate split'
+      }
     }
-    return {
-      complete: false,
-      kind: 'remaining_gates',
-      appliedStatus: 'blocked',
-      reason:
-        'worker_done reports required remaining or pending work without an explicit durable code-complete/activation-gate split'
-    }
+    // Explicit split may leave activation pending, but still requires code-complete evidence.
   }
 
   const hasPositiveCompletionEvidence =

--- a/src/main/runtime/orchestration/worker-done-semantic-completion.ts
+++ b/src/main/runtime/orchestration/worker-done-semantic-completion.ts
@@ -35,7 +35,7 @@ export interface WorkerDoneSemanticCompletionInput {
 
 const FAILURE_SUBJECT_RE = /^\s*failed\s*:/i
 const FAILURE_BODY_RE =
-  /\b(failed\s+transactionally|migration(?:\s+\S+)?\s+failed|transaction(?:al)?(?:ly)?\s+failed|deploy(?:ment)?\s+failed|e2e\s+failed|(?:npm(?:\s+run)?\s+)?(?:lint|format:check|typecheck|test|build(?::cloudflare)?|smoke(?::cloudflare-worker-startup)?)\s+failed|required\s+(?:check|gate)s?\s+failed)\b/i
+  /\b(failed\s+transactionally|migration(?:\s+\S+)?\s+failed|transaction(?:al)?(?:ly)?\s+failed|deploy(?:ment)?\s+failed|e2e\s+failed|tests?\s+failed|test[- ]suite\s+failed|(?:npm(?:\s+run)?\s+)?(?:lint|format:check|typecheck|test|build(?::cloudflare)?|smoke(?::cloudflare-worker-startup)?)\s+failed|required\s+(?:check|gate)s?\s+failed)\b/i
 /** Past/transient failure wording that is narratively resolved — not a current terminal failure. */
 const RESOLVED_FAILURE_NARRATIVE_RE =
   /\b(?:failed|failure)\b[\s\S]{0,160}\b(?:then\s+succeeded|succeeded\s+after(?:\s+(?:a\s+)?retry)?|after\s+(?:a\s+)?retr(?:y|ies)|later\s+succeeded|was\s+(?:then\s+)?(?:fixed|resolved)|retr(?:y|ied|ies)[\s\S]{0,60}succeed(?:ed|s)?)\b/i

--- a/src/main/runtime/orchestration/worker-done-semantic-completion.ts
+++ b/src/main/runtime/orchestration/worker-done-semantic-completion.ts
@@ -44,6 +44,10 @@ const UNRESOLVED_ESCALATION_RE =
   /\b(unresolved\s+escalation|escalation\s+(?:still\s+)?(?:open|unresolved|pending)|open\s+escalation)\b/i
 const REMAINING_GATES_RE =
   /\b(remaining(?:\s+(?:required)?)?\s+(?:reconciliation|activation|owner[- ]gated|deploy(?:ment)?|migration)?\s*gates?|activation\s+gates?\s+remain(?:ing|s)?|reconciliation(?:\/activation)?\s+gates?\s+remain|what'?s\s+left\b.{0,80}\b(?:activation|reconciliation|migration|deploy|gate))/i
+const PENDING_WORK_RE =
+  /\b(activation\s+pending|waiting\s+for\s+owner(?:\s+approval)?|before\s+the\s+migration\s+can\s+run|owner\s+approval\s+before|not\s+yet\s+(?:migrated|deployed|activated)|still\s+need(?:s|ed)?\s+to\s+(?:migrate|deploy|activate)|unfinished\s+required\s+(?:work|outcome))\b/i
+const POSITIVE_COMPLETION_RE =
+  /\b(complete(?:d)?|done|shipped|landed|merged|review-clean|implementation\s+finished)\b/i
 
 const CODE_COMPLETE_ACTIVATION_SPLIT_RE =
   /\b(code[- ]complete(?:\s+vs\.?|\s+versus|\s*\/\s*|\s+from\s+)?\s*activation|activation[- ]gate\s+split|explicit(?:ly)?\s+(?:defines?|allow(?:s|ed)?)\s+(?:a\s+)?(?:code[- ]complete|activation[- ]gate)\s+split|owner[- ]gated\s+activation(?:\s+dependency)?\s+(?:may|can|should)\s+remain|send\s+worker_done\s+when\s+(?:the\s+)?code(?:\/docs)?(?:\s+change)?\s+is\s+complete)\b/i
@@ -59,6 +63,9 @@ export function evaluateWorkerDoneSemanticCompletion(
   const body = input.body ?? ''
   const text = `${subject}\n${body}`
   const splitAllowed = taskSpecDefinesCodeCompleteActivationSplit(input.taskSpec)
+  const filesModified = Array.isArray(input.filesModified)
+    ? input.filesModified.filter((file) => typeof file === 'string' && file.trim().length > 0)
+    : []
 
   if (FAILURE_SUBJECT_RE.test(subject) || FAILURE_BODY_RE.test(text)) {
     return {
@@ -100,7 +107,7 @@ export function evaluateWorkerDoneSemanticCompletion(
     }
   }
 
-  if (REMAINING_GATES_RE.test(text)) {
+  if (REMAINING_GATES_RE.test(text) || PENDING_WORK_RE.test(text)) {
     if (splitAllowed) {
       return { complete: true }
     }
@@ -109,7 +116,19 @@ export function evaluateWorkerDoneSemanticCompletion(
       kind: 'remaining_gates',
       appliedStatus: 'blocked',
       reason:
-        'worker_done reports required remaining gates without an explicit durable code-complete/activation-gate split'
+        'worker_done reports required remaining or pending work without an explicit durable code-complete/activation-gate split'
+    }
+  }
+
+  const hasPositiveCompletionEvidence =
+    POSITIVE_COMPLETION_RE.test(text) || filesModified.length > 0
+  if (!hasPositiveCompletionEvidence) {
+    return {
+      complete: false,
+      kind: 'remaining_gates',
+      appliedStatus: 'blocked',
+      reason:
+        'worker_done lacks positive completion evidence (completion language or filesModified) and cannot fail open'
     }
   }
 

--- a/src/main/runtime/orchestration/worker-done-semantic-completion.ts
+++ b/src/main/runtime/orchestration/worker-done-semantic-completion.ts
@@ -108,27 +108,29 @@ export function evaluateWorkerDoneSemanticCompletion(
   }
 
   if (REMAINING_GATES_RE.test(text) || PENDING_WORK_RE.test(text)) {
-    if (!splitAllowed) {
-      return {
-        complete: false,
-        kind: 'remaining_gates',
-        appliedStatus: 'blocked',
-        reason:
-          'worker_done reports required remaining or pending work without an explicit durable code-complete/activation-gate split'
-      }
+    return {
+      complete: false,
+      kind: 'remaining_gates',
+      appliedStatus: 'blocked',
+      reason: splitAllowed
+        ? 'worker_done reports unmet activation/remaining gates; durable task stays blocked despite an explicit code-complete/activation-gate split'
+        : 'worker_done reports required remaining or pending work without an explicit durable code-complete/activation-gate split'
     }
-    // Explicit split may leave activation pending, but still requires code-complete evidence.
   }
 
-  const hasPositiveCompletionEvidence =
-    POSITIVE_COMPLETION_RE.test(text) || filesModified.length > 0
-  if (!hasPositiveCompletionEvidence) {
+  const negated =
+    /\b(?:not|never|no(?:t)?\s+yet|hasn'?t|haven'?t|didn'?t|doesn'?t|isn'?t|aren'?t|wasn'?t|weren'?t|cannot|can'?t)\b[\s\w-]{0,40}\b(?:complete(?:d)?|done|shipped|merged|landed)\b/i.test(
+      text
+    )
+  const hasAffirmativeCompletionEvidence =
+    !negated && (POSITIVE_COMPLETION_RE.test(text) || filesModified.length > 0)
+  if (!hasAffirmativeCompletionEvidence) {
     return {
       complete: false,
       kind: 'remaining_gates',
       appliedStatus: 'blocked',
       reason:
-        'worker_done lacks positive completion evidence (completion language or filesModified) and cannot fail open'
+        'worker_done lacks affirmative completion evidence (non-negated completion language or filesModified) and cannot fail open'
     }
   }
 

--- a/src/main/runtime/orchestration/worker-done-semantic-completion.ts
+++ b/src/main/runtime/orchestration/worker-done-semantic-completion.ts
@@ -36,15 +36,14 @@ export interface WorkerDoneSemanticCompletionInput {
 const FAILURE_SUBJECT_RE = /^\s*failed\s*:/i
 const FAILURE_BODY_RE =
   /\b(failed\s+transactionally|migration(?:\s+\S+)?\s+failed|transaction(?:al)?(?:ly)?\s+failed|deploy(?:ment)?\s+failed|e2e\s+failed|tests?\s+failed|test[- ]suite\s+failed|(?:npm(?:\s+run)?\s+)?(?:lint|format:check|typecheck|test|build(?::cloudflare)?|smoke(?::cloudflare-worker-startup)?)\s+failed|required\s+(?:check|gate)s?\s+failed)\b/i
-/** Past/transient failure wording that is narratively resolved — not a current terminal failure. */
-const RESOLVED_FAILURE_NARRATIVE_RE =
-  /\b(?:failed|failure)\b[\s\S]{0,160}\b(?:then\s+succeeded|succeeded\s+after(?:\s+(?:a\s+)?retry)?|after\s+(?:a\s+)?retr(?:y|ies)|later\s+succeeded|was\s+(?:then\s+)?(?:fixed|resolved)|retr(?:y|ied|ies)[\s\S]{0,60}succeed(?:ed|s)?)\b/i
+/** Local resolution window after a failure match — does not suppress later failures. */
+const LOCAL_FAILURE_RESOLUTION_RE =
+  /\b(?:then\s+succeeded|succeeded\s+after(?:\s+(?:a\s+)?retry)?|after\s+(?:a\s+)?retr(?:y|ies)|later\s+succeeded|was\s+(?:then\s+)?(?:fixed|resolved)|retr(?:y|ied|ies)[\s\S]{0,60}succeed(?:ed|s)?)\b/i
 const BLOCKED_SUBJECT_RE = /^\s*blocked\s*:/i
 const BLOCKED_BODY_RE =
   /\b(blocked(?:\s+on|\s+by)?|status\s*[:=]\s*blocked|persist(?:ed|ing)?\s+blocked|leave(?:s|ing)?\s+(?:the\s+)?(?:task|pr)\s+blocked)\b/i
-/** Past blocked wording that is narratively resolved — not a current blocked outcome. */
-const RESOLVED_BLOCKED_NARRATIVE_RE =
-  /\bblocked\b[\s\S]{0,100}\b(?:was\s+resolved|resolved|unblocked|cleared|lifted)\b/i
+const LOCAL_BLOCKED_RESOLUTION_RE =
+  /\b(?:was\s+resolved|resolved|unblocked|cleared|lifted)\b/i
 const DECISION_REQUIRED_RE =
   /\b(decision[- ]required|awaiting\s+(?:owner\s+)?decision|needs?\s+(?:a\s+)?(?:coordinator|owner)\s+decision|pending\s+decision\s+gate)\b/i
 const UNRESOLVED_ESCALATION_RE =
@@ -52,7 +51,7 @@ const UNRESOLVED_ESCALATION_RE =
 const REMAINING_GATES_RE =
   /\b(remaining(?:\s+(?:required)?)?\s+(?:reconciliation|activation|owner[- ]gated|deploy(?:ment)?|migration)?\s*gates?|activation\s+gates?\s+remain(?:ing|s)?|reconciliation(?:\/activation)?\s+gates?\s+remain|what'?s\s+left\b.{0,80}\b(?:activation|reconciliation|migration|deploy|gate))/i
 const PENDING_WORK_RE =
-  /\b(activation\s+pending|waiting\s+for\s+owner(?:\s+approval)?|before\s+the\s+migration\s+can\s+run|owner\s+approval\s+before|not\s+yet\s+(?:migrated|deployed|activated)|still\s+need(?:s|ed)?\s+to\b|unfinished\s+required\s+(?:work|outcome))\b/i
+  /\b(activation\s+pending|waiting\s+for\s+owner(?:\s+approval)?|before\s+the\s+migration\s+can\s+run|owner\s+approval\s+before|not\s+yet\s+(?:migrated|deployed|activated)|still\s+need(?:s|ed)?\s+to\b|unfinished\s+required\s+(?:work|outcome)|(?:production\s+)?deploy(?:ment)?\s+(?:is\s+)?pending(?:\s+owner\s+approval)?|(?:migration|deploy(?:ment)?)\s+pending|pending\s+owner\s+approval)\b/i
 const POSITIVE_COMPLETION_RE =
   /(?:^|[\s.,;:!?(])((?:is|are|was|were|has been|have been|mark(?:ed)?|now)\s+)?(complete(?:d)?|done|shipped|landed|merged|review-clean|implementation\s+finished)\b/i
 const NEGATED_COMPLETION_RE =
@@ -65,6 +64,28 @@ export function taskSpecDefinesCodeCompleteActivationSplit(taskSpec: string | nu
   return typeof taskSpec === 'string' && CODE_COMPLETE_ACTIVATION_SPLIT_RE.test(taskSpec)
 }
 
+function hasUnresolvedFailureDeclaration(subject: string, text: string): boolean {
+  if (FAILURE_SUBJECT_RE.test(subject)) return true
+  const matcher = new RegExp(FAILURE_BODY_RE.source, 'gi')
+  let match: RegExpExecArray | null
+  while ((match = matcher.exec(text)) !== null) {
+    const window = text.slice(match.index, match.index + match[0].length + 180)
+    if (!LOCAL_FAILURE_RESOLUTION_RE.test(window)) return true
+  }
+  return false
+}
+
+function hasUnresolvedBlockedDeclaration(subject: string, text: string): boolean {
+  if (BLOCKED_SUBJECT_RE.test(subject)) return true
+  const matcher = new RegExp(BLOCKED_BODY_RE.source, 'gi')
+  let match: RegExpExecArray | null
+  while ((match = matcher.exec(text)) !== null) {
+    const window = text.slice(match.index, match.index + match[0].length + 120)
+    if (!LOCAL_BLOCKED_RESOLUTION_RE.test(window)) return true
+  }
+  return false
+}
+
 export function evaluateWorkerDoneSemanticCompletion(
   input: WorkerDoneSemanticCompletionInput
 ): WorkerDoneSemanticCompletion {
@@ -75,10 +96,7 @@ export function evaluateWorkerDoneSemanticCompletion(
   // filesModified proves activity only; never treat it as a completion claim.
   void input.filesModified
 
-  const failedSubject = FAILURE_SUBJECT_RE.test(subject)
-  const failedBody = FAILURE_BODY_RE.test(text)
-  const resolvedFailureNarrative = RESOLVED_FAILURE_NARRATIVE_RE.test(text)
-  if (failedSubject || (failedBody && !resolvedFailureNarrative)) {
+  if (hasUnresolvedFailureDeclaration(subject, text)) {
     return {
       complete: false,
       kind: 'failure',
@@ -88,10 +106,7 @@ export function evaluateWorkerDoneSemanticCompletion(
     }
   }
 
-  const blockedSubject = BLOCKED_SUBJECT_RE.test(subject)
-  const blockedBody = BLOCKED_BODY_RE.test(text)
-  const resolvedBlockedNarrative = RESOLVED_BLOCKED_NARRATIVE_RE.test(text)
-  if (blockedSubject || (blockedBody && !resolvedBlockedNarrative)) {
+  if (hasUnresolvedBlockedDeclaration(subject, text)) {
     return {
       complete: false,
       kind: 'blocked',

--- a/src/main/runtime/orchestration/worker-done-semantic-completion.ts
+++ b/src/main/runtime/orchestration/worker-done-semantic-completion.ts
@@ -5,8 +5,9 @@
  * declares failure, blocked/decision-required state, unresolved escalation, or
  * required remaining gates must not flip durable task/dispatch state to
  * completed. A durable task spec may explicitly authorize a code-complete /
- * activation-gate split; only then may remaining activation/reconciliation
- * gates alone still complete.
+ * activation-gate split; unmet activation/remaining gates still keep the
+ * durable task blocked (the split authorizes code-complete mail, not
+ * durable `completed`).
  */
 
 export type WorkerDoneIncompleteKind =
@@ -34,10 +35,16 @@ export interface WorkerDoneSemanticCompletionInput {
 
 const FAILURE_SUBJECT_RE = /^\s*failed\s*:/i
 const FAILURE_BODY_RE =
-  /\b(failed\s+transactionally|migration\s+\S+\s+failed|transaction(?:al)?(?:ly)?\s+failed|deploy(?:ment)?\s+failed|e2e\s+failed)\b/i
+  /\b(failed\s+transactionally|migration(?:\s+\S+)?\s+failed|transaction(?:al)?(?:ly)?\s+failed|deploy(?:ment)?\s+failed|e2e\s+failed|(?:npm(?:\s+run)?\s+)?(?:lint|format:check|typecheck|test|build(?::cloudflare)?|smoke(?::cloudflare-worker-startup)?)\s+failed|required\s+(?:check|gate)s?\s+failed)\b/i
+/** Past/transient failure wording that is narratively resolved — not a current terminal failure. */
+const RESOLVED_FAILURE_NARRATIVE_RE =
+  /\b(?:failed|failure)\b[\s\S]{0,160}\b(?:then\s+succeeded|succeeded\s+after(?:\s+(?:a\s+)?retry)?|after\s+(?:a\s+)?retr(?:y|ies)|later\s+succeeded|was\s+(?:then\s+)?(?:fixed|resolved)|retr(?:y|ied|ies)[\s\S]{0,60}succeed(?:ed|s)?)\b/i
 const BLOCKED_SUBJECT_RE = /^\s*blocked\s*:/i
 const BLOCKED_BODY_RE =
   /\b(blocked(?:\s+on|\s+by)?|status\s*[:=]\s*blocked|persist(?:ed|ing)?\s+blocked|leave(?:s|ing)?\s+(?:the\s+)?(?:task|pr)\s+blocked)\b/i
+/** Past blocked wording that is narratively resolved — not a current blocked outcome. */
+const RESOLVED_BLOCKED_NARRATIVE_RE =
+  /\bblocked\b[\s\S]{0,100}\b(?:was\s+resolved|resolved|unblocked|cleared|lifted)\b/i
 const DECISION_REQUIRED_RE =
   /\b(decision[- ]required|awaiting\s+(?:owner\s+)?decision|needs?\s+(?:a\s+)?(?:coordinator|owner)\s+decision|pending\s+decision\s+gate)\b/i
 const UNRESOLVED_ESCALATION_RE =
@@ -45,9 +52,11 @@ const UNRESOLVED_ESCALATION_RE =
 const REMAINING_GATES_RE =
   /\b(remaining(?:\s+(?:required)?)?\s+(?:reconciliation|activation|owner[- ]gated|deploy(?:ment)?|migration)?\s*gates?|activation\s+gates?\s+remain(?:ing|s)?|reconciliation(?:\/activation)?\s+gates?\s+remain|what'?s\s+left\b.{0,80}\b(?:activation|reconciliation|migration|deploy|gate))/i
 const PENDING_WORK_RE =
-  /\b(activation\s+pending|waiting\s+for\s+owner(?:\s+approval)?|before\s+the\s+migration\s+can\s+run|owner\s+approval\s+before|not\s+yet\s+(?:migrated|deployed|activated)|still\s+need(?:s|ed)?\s+to\s+(?:migrate|deploy|activate)|unfinished\s+required\s+(?:work|outcome))\b/i
+  /\b(activation\s+pending|waiting\s+for\s+owner(?:\s+approval)?|before\s+the\s+migration\s+can\s+run|owner\s+approval\s+before|not\s+yet\s+(?:migrated|deployed|activated)|still\s+need(?:s|ed)?\s+to\b|unfinished\s+required\s+(?:work|outcome))\b/i
 const POSITIVE_COMPLETION_RE =
-  /\b(complete(?:d)?|done|shipped|landed|merged|review-clean|implementation\s+finished)\b/i
+  /(?:^|[\s.,;:!?(])((?:is|are|was|were|has been|have been|mark(?:ed)?|now)\s+)?(complete(?:d)?|done|shipped|landed|merged|review-clean|implementation\s+finished)\b/i
+const NEGATED_COMPLETION_RE =
+  /\b(?:not|never|no(?:t)?\s+yet|hasn'?t|haven'?t|didn'?t|doesn'?t|isn'?t|aren'?t|wasn'?t|weren'?t|cannot|can'?t)\b[\s\w-]{0,40}\b(?:complete(?:d)?|done|shipped|merged|landed)\b/i
 
 const CODE_COMPLETE_ACTIVATION_SPLIT_RE =
   /\b(code[- ]complete(?:\s+vs\.?|\s+versus|\s*\/\s*|\s+from\s+)?\s*activation|activation[- ]gate\s+split|explicit(?:ly)?\s+(?:defines?|allow(?:s|ed)?)\s+(?:a\s+)?(?:code[- ]complete|activation[- ]gate)\s+split|owner[- ]gated\s+activation(?:\s+dependency)?\s+(?:may|can|should)\s+remain|send\s+worker_done\s+when\s+(?:the\s+)?code(?:\/docs)?(?:\s+change)?\s+is\s+complete)\b/i
@@ -63,11 +72,13 @@ export function evaluateWorkerDoneSemanticCompletion(
   const body = input.body ?? ''
   const text = `${subject}\n${body}`
   const splitAllowed = taskSpecDefinesCodeCompleteActivationSplit(input.taskSpec)
-  const filesModified = Array.isArray(input.filesModified)
-    ? input.filesModified.filter((file) => typeof file === 'string' && file.trim().length > 0)
-    : []
+  // filesModified proves activity only; never treat it as a completion claim.
+  void input.filesModified
 
-  if (FAILURE_SUBJECT_RE.test(subject) || FAILURE_BODY_RE.test(text)) {
+  const failedSubject = FAILURE_SUBJECT_RE.test(subject)
+  const failedBody = FAILURE_BODY_RE.test(text)
+  const resolvedFailureNarrative = RESOLVED_FAILURE_NARRATIVE_RE.test(text)
+  if (failedSubject || (failedBody && !resolvedFailureNarrative)) {
     return {
       complete: false,
       kind: 'failure',
@@ -77,7 +88,10 @@ export function evaluateWorkerDoneSemanticCompletion(
     }
   }
 
-  if (BLOCKED_SUBJECT_RE.test(subject) || BLOCKED_BODY_RE.test(text)) {
+  const blockedSubject = BLOCKED_SUBJECT_RE.test(subject)
+  const blockedBody = BLOCKED_BODY_RE.test(text)
+  const resolvedBlockedNarrative = RESOLVED_BLOCKED_NARRATIVE_RE.test(text)
+  if (blockedSubject || (blockedBody && !resolvedBlockedNarrative)) {
     return {
       complete: false,
       kind: 'blocked',
@@ -118,19 +132,15 @@ export function evaluateWorkerDoneSemanticCompletion(
     }
   }
 
-  const negated =
-    /\b(?:not|never|no(?:t)?\s+yet|hasn'?t|haven'?t|didn'?t|doesn'?t|isn'?t|aren'?t|wasn'?t|weren'?t|cannot|can'?t)\b[\s\w-]{0,40}\b(?:complete(?:d)?|done|shipped|merged|landed)\b/i.test(
-      text
-    )
   const hasAffirmativeCompletionEvidence =
-    !negated && (POSITIVE_COMPLETION_RE.test(text) || filesModified.length > 0)
+    !NEGATED_COMPLETION_RE.test(text) && POSITIVE_COMPLETION_RE.test(text)
   if (!hasAffirmativeCompletionEvidence) {
     return {
       complete: false,
       kind: 'remaining_gates',
       appliedStatus: 'blocked',
       reason:
-        'worker_done lacks affirmative completion evidence (non-negated completion language or filesModified) and cannot fail open'
+        'worker_done lacks an explicit non-negated completion claim and cannot fail open on filesModified alone'
     }
   }
 

--- a/src/main/runtime/orchestration/worker-done-semantic-completion.ts
+++ b/src/main/runtime/orchestration/worker-done-semantic-completion.ts
@@ -1,0 +1,117 @@
+/**
+ * Fail-closed semantic completion for worker_done.
+ *
+ * Matching taskId + dispatchId is necessary but not sufficient: a payload that
+ * declares failure, blocked/decision-required state, unresolved escalation, or
+ * required remaining gates must not flip durable task/dispatch state to
+ * completed. A durable task spec may explicitly authorize a code-complete /
+ * activation-gate split; only then may remaining activation/reconciliation
+ * gates alone still complete.
+ */
+
+export type WorkerDoneIncompleteKind =
+  | 'failure'
+  | 'blocked'
+  | 'decision_required'
+  | 'unresolved_escalation'
+  | 'remaining_gates'
+
+export type WorkerDoneSemanticCompletion =
+  | { complete: true }
+  | {
+      complete: false
+      kind: WorkerDoneIncompleteKind
+      reason: string
+      appliedStatus: 'failed' | 'blocked'
+    }
+
+export interface WorkerDoneSemanticCompletionInput {
+  subject: string
+  body?: string | null
+  filesModified?: readonly string[] | null
+  taskSpec?: string | null
+}
+
+const FAILURE_SUBJECT_RE = /^\s*failed\s*:/i
+const FAILURE_BODY_RE =
+  /\b(failed\s+transactionally|migration\s+\S+\s+failed|transaction(?:al)?(?:ly)?\s+failed|deploy(?:ment)?\s+failed|e2e\s+failed)\b/i
+const BLOCKED_SUBJECT_RE = /^\s*blocked\s*:/i
+const BLOCKED_BODY_RE =
+  /\b(blocked(?:\s+on|\s+by)?|status\s*[:=]\s*blocked|persist(?:ed|ing)?\s+blocked|leave(?:s|ing)?\s+(?:the\s+)?(?:task|pr)\s+blocked)\b/i
+const DECISION_REQUIRED_RE =
+  /\b(decision[- ]required|awaiting\s+(?:owner\s+)?decision|needs?\s+(?:a\s+)?(?:coordinator|owner)\s+decision|pending\s+decision\s+gate)\b/i
+const UNRESOLVED_ESCALATION_RE =
+  /\b(unresolved\s+escalation|escalation\s+(?:still\s+)?(?:open|unresolved|pending)|open\s+escalation)\b/i
+const REMAINING_GATES_RE =
+  /\b(remaining(?:\s+(?:required)?)?\s+(?:reconciliation|activation|owner[- ]gated|deploy(?:ment)?|migration)?\s*gates?|activation\s+gates?\s+remain(?:ing|s)?|reconciliation(?:\/activation)?\s+gates?\s+remain|what'?s\s+left\b.{0,80}\b(?:activation|reconciliation|migration|deploy|gate))/i
+
+const CODE_COMPLETE_ACTIVATION_SPLIT_RE =
+  /\b(code[- ]complete(?:\s+vs\.?|\s+versus|\s*\/\s*|\s+from\s+)?\s*activation|activation[- ]gate\s+split|explicit(?:ly)?\s+(?:defines?|allow(?:s|ed)?)\s+(?:a\s+)?(?:code[- ]complete|activation[- ]gate)\s+split|owner[- ]gated\s+activation(?:\s+dependency)?\s+(?:may|can|should)\s+remain|send\s+worker_done\s+when\s+(?:the\s+)?code(?:\/docs)?(?:\s+change)?\s+is\s+complete)\b/i
+
+export function taskSpecDefinesCodeCompleteActivationSplit(taskSpec: string | null | undefined): boolean {
+  return typeof taskSpec === 'string' && CODE_COMPLETE_ACTIVATION_SPLIT_RE.test(taskSpec)
+}
+
+export function evaluateWorkerDoneSemanticCompletion(
+  input: WorkerDoneSemanticCompletionInput
+): WorkerDoneSemanticCompletion {
+  const subject = input.subject ?? ''
+  const body = input.body ?? ''
+  const text = `${subject}\n${body}`
+  const splitAllowed = taskSpecDefinesCodeCompleteActivationSplit(input.taskSpec)
+
+  if (FAILURE_SUBJECT_RE.test(subject) || FAILURE_BODY_RE.test(text)) {
+    return {
+      complete: false,
+      kind: 'failure',
+      appliedStatus: 'failed',
+      reason:
+        'worker_done declares failure and cannot be accepted as semantic completion'
+    }
+  }
+
+  if (BLOCKED_SUBJECT_RE.test(subject) || BLOCKED_BODY_RE.test(text)) {
+    return {
+      complete: false,
+      kind: 'blocked',
+      appliedStatus: 'blocked',
+      reason:
+        'worker_done declares a blocked state; use escalation/status and coordinator reclassification'
+    }
+  }
+
+  if (DECISION_REQUIRED_RE.test(text)) {
+    return {
+      complete: false,
+      kind: 'decision_required',
+      appliedStatus: 'blocked',
+      reason:
+        'worker_done declares a decision-required state; resolve the gate or escalate instead of completing'
+    }
+  }
+
+  if (UNRESOLVED_ESCALATION_RE.test(text)) {
+    return {
+      complete: false,
+      kind: 'unresolved_escalation',
+      appliedStatus: 'blocked',
+      reason:
+        'worker_done reports an unresolved escalation and cannot close durable completion'
+    }
+  }
+
+  if (REMAINING_GATES_RE.test(text)) {
+    if (splitAllowed) {
+      return { complete: true }
+    }
+    return {
+      complete: false,
+      kind: 'remaining_gates',
+      appliedStatus: 'blocked',
+      reason:
+        'worker_done reports required remaining gates without an explicit durable code-complete/activation-gate split'
+    }
+  }
+
+  return { complete: true }
+}

--- a/src/main/runtime/orchestration/worker-done-semantic-completion.ts
+++ b/src/main/runtime/orchestration/worker-done-semantic-completion.ts
@@ -43,7 +43,7 @@ const BLOCKED_SUBJECT_RE = /^\s*blocked\s*:/i
 const BLOCKED_BODY_RE =
   /\b(blocked(?:\s+on|\s+by)?|status\s*[:=]\s*blocked|persist(?:ed|ing)?\s+blocked|leave(?:s|ing)?\s+(?:the\s+)?(?:task|pr)\s+blocked)\b/i
 const LOCAL_BLOCKED_RESOLUTION_RE =
-  /\b(?:was\s+resolved|resolved|unblocked|cleared|lifted)\b/i
+  /\bblocked(?:\s+[\w-]+){0,6}\s+(?:was\s+)?(?:resolved|unblocked|cleared|lifted)\b|\bunblocked\b/i
 const DECISION_REQUIRED_RE =
   /\b(decision[- ]required|awaiting\s+(?:owner\s+)?decision|needs?\s+(?:a\s+)?(?:coordinator|owner)\s+decision|pending\s+decision\s+gate)\b/i
 const UNRESOLVED_ESCALATION_RE =


### PR DESCRIPTION
## Summary
- Matching `taskId` + `dispatchId` is necessary but not sufficient for durable completion. `reconcileWorkerDoneMessage` now runs a fail-closed semantic guard before `updateTaskStatus(..., 'completed')`.
- A `worker_done` that declares failure, blocked/decision-required state, unresolved escalation, or required remaining gates is rejected (`incomplete_outcome`), closes the active dispatch without promoting dependents, and persists the task as `failed` or `blocked`.
- Preserve a legitimate code-complete / activation-gate split only when the durable task spec explicitly defines that split; otherwise remaining gates require escalation/status + continuation or coordinator reclassification.
- Injected preamble documents the Failed→failed (not completed) rule and the incomplete-outcome prohibition.
- Regression coverage for the INC-3 shape (`task_c51afc88a23d` / `ctx_750a6815bc9f`): empty-files `worker_done` with transactional migration failure + remaining reconciliation/activation gates must not complete.

## Authoritative surface
- Auto-close path: `src/main/runtime/orchestration/lifecycle-reconciliation.ts` → `reconcileWorkerDoneMessage` → `OrchestrationDb.updateTaskStatus(..., 'completed')` (which also `completeActiveDispatchForTask` + `promoteReadyTasks`)
- New evaluator: `src/main/runtime/orchestration/worker-done-semantic-completion.ts`
- New durable close helper: `OrchestrationDb.closeActiveDispatchWithoutCompletion`

## Test plan
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orchestration/worker-done-semantic-completion.test.ts`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orchestration/lifecycle-reconciliation.test.ts`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orchestration/preamble.test.ts`
- [ ] Manual: send a Failed: worker_done with matching IDs → task `failed`, dependents not promoted, CLI lifecycle rejection
- [ ] Manual: remaining activation gates without split in spec → task `blocked`; with explicit split wording → completed

## Notes
- Do not patch installed `~/.orca-remote` bundles; this PR is the durable upstream repair.
- AimStrings local supervisor/runbook mitigation mirrors the evaluator until this ships.


Made with [Cursor](https://cursor.com)


## ELI5

A worker could report "done" while still failed, blocked, or waiting on gates, and the task was marked completed. Incomplete worker_done outcomes are rejected and the task is failed or blocked instead of promoting dependents.
