### PR TITLE
fix(kimi): use native Windows hook launcher

### DIFF
--- a/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
+++ b/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
@@ -254,7 +254,7 @@ describe('Windows managed hook stdin structure', () => {
         (name) => name.endsWith('-hook.cmd') && !name.startsWith('antigravity-')
       )
       mainBatchScripts.push('antigravity-hook.cmd')
-      expect(mainBatchScripts).toHaveLength(10)
+      expect(mainBatchScripts).toHaveLength(11)
       for (const fileName of mainBatchScripts) {
         const script = readFileSync(join(hooksDir, fileName), 'utf8')
         expect(script, `${fileName} port guard`).toContain(
@@ -278,10 +278,6 @@ describe('Windows managed hook stdin structure', () => {
       const copilot = readFileSync(join(hooksDir, 'copilot-hook.ps1'), 'utf8')
       expect(copilot.indexOf('[Console]::In.ReadToEnd()')).toBeLessThan(
         copilot.indexOf('if (-not $env:ORCA_AGENT_HOOK_PORT')
-      )
-      const kimi = readFileSync(join(hooksDir, 'kimi-hook.sh'), 'utf8')
-      expect(kimi.indexOf(`payload=$(${POSIX_HOOK_STDIN_READER})`)).toBeLessThan(
-        kimi.indexOf('exit 0')
       )
     } finally {
       homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())

--- a/src/main/agent-hooks/remote-hook-service-installers.test.ts
+++ b/src/main/agent-hooks/remote-hook-service-installers.test.ts
@@ -176,6 +176,11 @@ describe('remote hook service installers', () => {
         {
           path: '/home/dev/.orca/agent-hooks/droid-hook.sh',
           install: (sftp: SFTPWrapper) => new DroidHookService().installRemote(sftp, '/home/dev')
+        },
+        {
+          // Why: Kimi's local script selection is platform-branched; pin that a Windows host still writes the POSIX remote body.
+          path: '/home/dev/.orca/agent-hooks/kimi-hook.sh',
+          install: (sftp: SFTPWrapper) => new KimiHookService().installRemote(sftp, '/home/dev')
         }
       ]
 

--- a/src/main/kimi/hook-service.test.ts
+++ b/src/main/kimi/hook-service.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -36,7 +36,20 @@ afterEach(() => {
 })
 
 const configPath = (): string => join(home, '.kimi-code', 'config.toml')
-const scriptPath = (): string => join(home, '.orca', 'agent-hooks', 'kimi-hook.sh')
+const scriptPath = (fileName = 'kimi-hook.sh'): string =>
+  join(home, '.orca', 'agent-hooks', fileName)
+
+function withPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform')
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+  try {
+    return run()
+  } finally {
+    if (original) {
+      Object.defineProperty(process, 'platform', original)
+    }
+  }
+}
 
 describe('KimiHookService', () => {
   it('reports not_installed before install', () => {
@@ -62,6 +75,33 @@ describe('KimiHookService', () => {
     expect(script).not.toContain('--data-urlencode "payload=${payload}"')
     // The command Kimi runs points at the managed script via sh.
     expect(config).toContain('agent-hooks/kimi-hook.sh')
+  })
+
+  it('installs a native batch launcher on Windows', () => {
+    const status = withPlatform('win32', () => new KimiHookService().install())
+    expect(status.state).toBe('installed')
+
+    const config = readFileSync(configPath(), 'utf-8')
+    const encodedCommand = config.match(/-EncodedCommand ([A-Za-z0-9+/=]+)/)?.[1]
+    expect(encodedCommand).toBeDefined()
+    const decodedCommand = Buffer.from(encodedCommand!, 'base64').toString('utf16le')
+    expect(decodedCommand).toContain('kimi-hook.cmd')
+
+    const script = readFileSync(scriptPath('kimi-hook.cmd'), 'utf-8')
+    expect(script).toContain('call "%ORCA_AGENT_HOOK_ENDPOINT%"')
+    expect(script).toContain('if "%ORCA_AGENT_HOOK_PORT%"=="" goto :orca_agent_hook_drain_stdin')
+    expect(script).toContain('if "%ORCA_AGENT_HOOK_TOKEN%"=="" goto :orca_agent_hook_drain_stdin')
+    expect(script).toContain('if "%ORCA_PANE_KEY%"=="" goto :orca_agent_hook_drain_stdin')
+    expect(script).toContain('/hook/kimi')
+    expect(script).toContain('--data-urlencode "payload@-"')
+    expect(script).toContain(
+      [
+        ':orca_agent_hook_drain_stdin',
+        '"%SystemRoot%\\System32\\more.com" >nul 2>nul',
+        'exit /b 0'
+      ].join('\r\n')
+    )
+    expect(existsSync(scriptPath())).toBe(false)
   })
 
   it('keeps user config when installing, then restores it on remove', () => {

--- a/src/main/kimi/hook-service.ts
+++ b/src/main/kimi/hook-service.ts
@@ -211,7 +211,9 @@ export class KimiHookService {
     return this.getStatus()
   }
 
-  // Why: SFTP 远端约定为 POSIX，不能让本机 Windows 平台选择污染远端脚本。
+  // Why: SFTP remotes are always POSIX, so force the shared `.sh` body and never
+  // let the local host's Windows platform selection leak into the remote script.
+  // The managed script body is platform-independent (Kimi's remote shell is sh/Git Bash).
   async installRemote(sftp: SFTPWrapper, remoteHome: string): Promise<AgentHookInstallStatus> {
     const remoteConfigPath = pathPosix.join(remoteHome, '.kimi-code', 'config.toml')
     const remoteScriptPath = pathPosix.join(

--- a/src/main/kimi/hook-service.ts
+++ b/src/main/kimi/hook-service.ts
@@ -13,9 +13,11 @@ import { randomUUID } from 'node:crypto'
 import type { SFTPWrapper } from 'ssh2'
 import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared/agent-hook-types'
 import {
+  buildWindowsAgentHookPostCommand,
   createManagedCommandMatcher,
   getSharedManagedScriptPath,
   wrapPosixHookCommand,
+  wrapWindowsHookCommand,
   writeManagedScript
 } from '../agent-hooks/installer-utils'
 import {
@@ -23,7 +25,11 @@ import {
   writeManagedScriptRemote,
   writeTextFileRemoteAtomic
 } from '../agent-hooks/installer-utils-remote'
-import { buildPosixHookPayloadCapture } from '../agent-hooks/hook-stdin-contract'
+import {
+  buildPosixHookPayloadCapture,
+  buildWindowsHookEnvironmentGuardLines,
+  buildWindowsHookStdinDrainEpilogue
+} from '../agent-hooks/hook-stdin-contract'
 import {
   applyManagedKimiHooks,
   KIMI_HOOK_EVENTS,
@@ -42,22 +48,36 @@ function getConfigPath(): string {
   return join(getKimiHome(), 'config.toml')
 }
 
-// Always a POSIX `.sh` script: Kimi runs hook commands through its shell, which
-// is Git Bash even on Windows (see the CLI README / KIMI_SHELL_PATH), so a
-// single curl-based script body works on every platform.
-const MANAGED_SCRIPT_FILE_NAME = 'kimi-hook.sh'
+const REMOTE_MANAGED_SCRIPT_FILE_NAME = 'kimi-hook.sh'
+
+function getManagedScriptFileName(): string {
+  return process.platform === 'win32' ? 'kimi-hook.cmd' : 'kimi-hook.sh'
+}
 
 function getManagedScriptPath(): string {
-  return getSharedManagedScriptPath(MANAGED_SCRIPT_FILE_NAME)
+  return getSharedManagedScriptPath(getManagedScriptFileName())
 }
 
 function getManagedCommand(scriptPath: string): string {
-  // Forward slashes so Kimi's Git Bash shell accepts the path on Windows.
-  const posixPath = process.platform === 'win32' ? scriptPath.replaceAll('\\', '/') : scriptPath
-  return wrapPosixHookCommand(posixPath)
+  return process.platform === 'win32'
+    ? wrapWindowsHookCommand(scriptPath)
+    : wrapPosixHookCommand(scriptPath)
 }
 
-function getManagedScript(): string {
+function getManagedScript(target: 'local' | 'posix' = 'local'): string {
+  if (target === 'local' && process.platform === 'win32') {
+    return [
+      '@echo off',
+      'setlocal',
+      'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
+      ...buildWindowsHookEnvironmentGuardLines(),
+      buildWindowsAgentHookPostCommand('kimi'),
+      'exit /b 0',
+      ...buildWindowsHookStdinDrainEpilogue(),
+      ''
+    ].join('\r\n')
+  }
+
   return [
     '#!/bin/sh',
     ...buildPosixHookPayloadCapture(),
@@ -167,7 +187,7 @@ export class KimiHookService {
         detail: 'Could not read Kimi config.toml'
       }
     }
-    const isManagedCommand = createManagedCommandMatcher(MANAGED_SCRIPT_FILE_NAME)
+    const isManagedCommand = createManagedCommandMatcher(getManagedScriptFileName())
     return buildStatus(readManagedKimiHookEvents(text, isManagedCommand), configPath)
   }
 
@@ -191,23 +211,21 @@ export class KimiHookService {
     return this.getStatus()
   }
 
-  // Why: install Orca's managed Kimi hooks on a remote box over SFTP, mirroring
-  // the local install. POSIX-only by design (Kimi's shell is sh/Git Bash); the
-  // managed script body is already platform-independent.
+  // Why: SFTP 远端约定为 POSIX，不能让本机 Windows 平台选择污染远端脚本。
   async installRemote(sftp: SFTPWrapper, remoteHome: string): Promise<AgentHookInstallStatus> {
     const remoteConfigPath = pathPosix.join(remoteHome, '.kimi-code', 'config.toml')
     const remoteScriptPath = pathPosix.join(
       remoteHome,
       '.orca',
       'agent-hooks',
-      MANAGED_SCRIPT_FILE_NAME
+      REMOTE_MANAGED_SCRIPT_FILE_NAME
     )
     try {
       // null (file absent) → start from an empty config; Kimi creates it lazily.
       const text = (await readTextFileRemote(sftp, remoteConfigPath)) ?? ''
       const command = wrapPosixHookCommand(remoteScriptPath)
       // Write the script first so config.toml never points at a missing script.
-      await writeManagedScriptRemote(sftp, remoteScriptPath, getManagedScript())
+      await writeManagedScriptRemote(sftp, remoteScriptPath, getManagedScript('posix'))
       await writeTextFileRemoteAtomic(sftp, remoteConfigPath, applyManagedKimiHooks(text, command))
       return {
         agent: 'kimi',


### PR DESCRIPTION
## Summary

- Use a native `kimi-hook.cmd` launcher for local Kimi Code hooks on Windows.
- Refresh the current Orca hook endpoint before posting status events, and preserve the shared Windows stdin-drain contract.
- Keep macOS, Linux, WSL, and SFTP remote installs on the existing POSIX `kimi-hook.sh` path.

Closes #9834

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` (blocked by the existing non-exhaustive switch in `src/renderer/src/components/skills/skill-freshness-group.tsx:101`)
- [x] `pnpm typecheck`
- [ ] `pnpm test` (44 targeted tests passed; 1 Windows-only live-process test skipped on macOS)
- [ ] `pnpm build` (`pnpm build:desktop` passed)
- [x] Added or updated high-quality tests that would catch regressions

Targeted coverage includes Kimi local installation, Kimi TOML mutation, remote hook installers, managed-hook timeouts, and managed-hook stdin lifecycle behavior.

## AI Review Report

Reviewed the platform selection, generated TOML command, encoded Windows launcher, managed-command detection, endpoint refresh, and stdin ownership paths. The review verified that local Windows installs generate only `kimi-hook.cmd`, while macOS/Linux and SFTP remote installs retain `kimi-hook.sh`. It also checked that the change introduces no UI shortcut, label, path-separator, or Electron platform behavior changes outside the hook installer.

## Security Audit

No dependencies, IPC messages, protocols, or auth flows were added. The Windows command reuses the existing UTF-16LE PowerShell encoded launcher so user-profile paths are not interpolated into a raw `cmd.exe` command. The batch script continues to use fully qualified Windows system binaries, loopback-only HTTP, the existing hook token header, bounded curl timeouts, and stdin streaming rather than placing payloads on the command line. Remote paths continue to use POSIX path construction and the existing SFTP atomic writer.

## Notes

The Windows live-process lifecycle case remains covered by the existing Windows-only test and is skipped when the suite runs on macOS.
- X handle: N/A



## ELI5

Kimi Code hooks on Windows failed because they used a POSIX shell script. Local Windows installs now use a native kimi-hook.cmd; other platforms keep the existing shell launcher.
