### PR TITLE
fix(sidebar): stabilize workspace drag and lineage drops

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.compact-hover.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.compact-hover.test.tsx
@@ -551,7 +551,7 @@ describe('WorktreeCard compact hover details', () => {
     const surfaceTag = markup.match(/<div[^>]*data-worktree-card-surface="true"[^>]*>/)?.[0]
     expect(surfaceTag).toBeDefined()
     expect(surfaceTag).not.toContain('data-hover-card-trigger=""')
-    expect(markup).not.toContain('data-worktree-lineage-children=""')
+    expect(markup).toContain('data-worktree-lineage-children=""')
     expect(childIndex).toBeGreaterThanOrEqual(0)
   })
 

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -1735,7 +1735,10 @@ const WorktreeCard = React.memo(function WorktreeCard({
         )}
 
         {!newCardStyle && lineageChildren && (
-          <div className="-ml-[1.125rem] mt-1.5 w-[calc(100%+1.125rem)] space-y-1">
+          <div
+            className="-ml-[1.125rem] mt-1.5 w-[calc(100%+1.125rem)] space-y-1"
+            data-worktree-lineage-children=""
+          >
             {lineageChildren}
           </div>
         )}

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -199,6 +199,7 @@ import {
   type WorktreeSidebarDropPreview
 } from './worktree-sidebar-drop-preview'
 import {
+  buildWorktreeLineageInsertionOrderUpdates,
   getReorderedWorktreeIdsToUnnest,
   getWorktreeLineageInsertionGuideY,
   getWorktreeLineageDropTarget
@@ -972,7 +973,10 @@ function areWorktreeDragPreviewOffsetsEqual(
 
 function updateLatestWorktreeStatusDropTarget(
   drag: WorktreePointerDrag,
-  target: WorktreeSidebarStatusDropTarget & { lineageParentId: string | null },
+  target: WorktreeSidebarStatusDropTarget & {
+    lineageParentId: string | null
+    lineageInsertionBeforeChildId?: string | null
+  },
   preview: WorktreeSidebarDropPreview | null
 ): void {
   drag.latestStatusDropTarget =
@@ -998,6 +1002,7 @@ function getPointerDropStatusTarget(args: {
 }): WorktreeSidebarStatusDropTarget & {
   lineageParentId: string | null
   lineageDropIndicatorY: number | null
+  lineageInsertionBeforeChildId?: string | null
 } {
   const target = document.elementFromPoint(args.x, args.y)
   if (!(target instanceof Element) || !args.container.contains(target)) {
@@ -1030,7 +1035,8 @@ function getPointerDropStatusTarget(args: {
         : null,
     isPinDrop: false,
     lineageParentId: lineageTarget?.parentId ?? null,
-    lineageDropIndicatorY: lineageTarget?.dropIndicatorY ?? null
+    lineageDropIndicatorY: lineageTarget?.dropIndicatorY ?? null,
+    lineageInsertionBeforeChildId: lineageTarget?.insertionBeforeChildId
   }
 }
 
@@ -1411,6 +1417,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const setRenamingWorktreeId = useAppStore((s) => s.setRenamingWorktreeId)
   const assignWorktreeParent = useAppStore((s) => s.assignWorktreeParent)
   const updateWorktreeLineage = useAppStore((s) => s.updateWorktreeLineage)
+  const setLineageDragSortBy = useAppStore((s) => s.setSortBy)
+  const updateLineageDragWorktreesMeta = useAppStore((s) => s.updateWorktreesMeta)
   const worktreeDragSessionRef = useRef<WorktreeSidebarDragSession | null>(null)
   const worktreePointerDragRef = useRef<WorktreePointerDrag | null>(null)
   const worktreePointerAutoscrollFrameIdRef = useRef<number | null>(null)
@@ -2723,11 +2731,13 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       target: WorktreeSidebarStatusDropTarget & {
         lineageParentId: string | null
         lineageDropIndicatorY?: number | null
+        lineageInsertionBeforeChildId?: string | null
       },
       draggedIds: readonly string[]
     ): WorktreeSidebarStatusDropTarget & {
       lineageParentId: string | null
       lineageDropIndicatorY?: number | null
+      lineageInsertionBeforeChildId?: string | null
     } => {
       const parentId = target.lineageParentId
       if (!parentId) {
@@ -2748,7 +2758,12 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       })
       return canAssignAll
         ? target
-        : { ...target, lineageParentId: null, lineageDropIndicatorY: null }
+        : {
+            ...target,
+            lineageParentId: null,
+            lineageDropIndicatorY: null,
+            lineageInsertionBeforeChildId: undefined
+          }
     },
     [repoMap, worktreeLineageById, worktreeMap, worktrees]
   )
@@ -2759,9 +2774,15 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       parentId: string
       draggedIds: readonly string[]
       fallbackY: number | null | undefined
+      insertionBeforeChildId?: string | null
     }): number | null => {
       if (args.fallbackY === null || args.fallbackY === undefined) {
         return null
+      }
+      if (args.insertionBeforeChildId !== undefined) {
+        // Why: child-edge hit testing already resolves the exact mounted sibling
+        // in its section; another global row lookup can select a pinned duplicate.
+        return args.fallbackY
       }
       return getWorktreeLineageInsertionGuideY({
         container: args.container,
@@ -2776,7 +2797,11 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   )
 
   const commitWorktreeLineageParentDrop = useCallback(
-    (draggedIds: readonly string[], parentId: string): boolean => {
+    (
+      draggedIds: readonly string[],
+      parentId: string,
+      insertionBeforeChildId?: string | null
+    ): boolean => {
       const target = getEligibleLineageDropTarget(
         { status: null, isPinDrop: false, lineageParentId: parentId },
         draggedIds
@@ -2784,9 +2809,31 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       if (!target.lineageParentId) {
         return false
       }
-      void Promise.all(
-        draggedIds.map((id) => assignWorktreeParent(id, { parentWorktreeId: parentId }))
-      ).catch((err) => {
+      const orderUpdates =
+        insertionBeforeChildId === undefined
+          ? new Map()
+          : buildWorktreeLineageInsertionOrderUpdates({
+              directChildIds: lineageDragOrder.directChildIdsByParentId.get(parentId) ?? [],
+              draggedIds,
+              insertionBeforeChildId,
+              orderIndexById: lineageDragOrder.orderIndexById,
+              rankByWorktreeId: new Map(
+                worktrees.map((worktree) => [
+                  worktree.id,
+                  worktree.manualOrder ?? worktree.sortOrder
+                ])
+              ),
+              now: Date.now()
+            })
+      if (orderUpdates.size > 0) {
+        // Why: a child-edge divider promises an exact sibling slot, which only
+        // persisted manual ranks can preserve across refreshes and sort modes.
+        setLineageDragSortBy('manual')
+      }
+      void Promise.all([
+        ...draggedIds.map((id) => assignWorktreeParent(id, { parentWorktreeId: parentId })),
+        ...(orderUpdates.size > 0 ? [updateLineageDragWorktreesMeta(orderUpdates)] : [])
+      ]).catch((err) => {
         console.error('Failed to nest workspace:', err)
         toast.error(
           translate(
@@ -2797,7 +2844,14 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       })
       return true
     },
-    [assignWorktreeParent, getEligibleLineageDropTarget]
+    [
+      assignWorktreeParent,
+      getEligibleLineageDropTarget,
+      lineageDragOrder,
+      setLineageDragSortBy,
+      updateLineageDragWorktreesMeta,
+      worktrees
+    ]
   )
 
   const clearReorderedWorktreeParents = useCallback(
@@ -2926,7 +2980,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
             container: sidebarContainer,
             parentId: preferredStatusTarget.lineageParentId,
             draggedIds: drag.draggedIds,
-            fallbackY: preferredStatusTarget.lineageDropIndicatorY
+            fallbackY: preferredStatusTarget.lineageDropIndicatorY,
+            insertionBeforeChildId: preferredStatusTarget.lineageInsertionBeforeChildId
           })
         : null
       updateLatestWorktreeStatusDropTarget(drag, preferredStatusTarget, null)
@@ -3317,7 +3372,11 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
           drag.draggedIds
         )
         if (preferredStatusTarget.lineageParentId) {
-          commitWorktreeLineageParentDrop(drag.draggedIds, preferredStatusTarget.lineageParentId)
+          commitWorktreeLineageParentDrop(
+            drag.draggedIds,
+            preferredStatusTarget.lineageParentId,
+            preferredStatusTarget.lineageInsertionBeforeChildId
+          )
           clearWorktreeDrag()
           return
         }
@@ -3385,7 +3444,11 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
             y: event.clientY
           })
           if (target.lineageParentId) {
-            commitWorktreeLineageParentDrop(drag.draggedIds, target.lineageParentId)
+            commitWorktreeLineageParentDrop(
+              drag.draggedIds,
+              target.lineageParentId,
+              target.lineageInsertionBeforeChildId
+            )
           } else if (target.isPinDrop) {
             onPinWorktrees(drag.draggedIds)
           } else if (target.status) {
@@ -3623,7 +3686,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
           container: event.currentTarget,
           parentId: target.lineageParentId,
           draggedIds: session.draggedIds,
-          fallbackY: target.lineageDropIndicatorY
+          fallbackY: target.lineageDropIndicatorY,
+          insertionBeforeChildId: target.lineageInsertionBeforeChildId
         })
         event.preventDefault()
         event.dataTransfer.dropEffect = 'move'
@@ -3739,7 +3803,11 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       if (target.lineageParentId) {
         event.preventDefault()
         event.stopPropagation()
-        commitWorktreeLineageParentDrop(session.draggedIds, target.lineageParentId)
+        commitWorktreeLineageParentDrop(
+          session.draggedIds,
+          target.lineageParentId,
+          target.lineageInsertionBeforeChildId
+        )
         clearWorktreeDrag()
         return
       }
@@ -4001,7 +4069,11 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         if (target.lineageParentId) {
           event.preventDefault()
           event.stopPropagation()
-          commitWorktreeLineageParentDrop(session.draggedIds, target.lineageParentId)
+          commitWorktreeLineageParentDrop(
+            session.draggedIds,
+            target.lineageParentId,
+            target.lineageInsertionBeforeChildId
+          )
           clearWorktreeDrag()
           return
         }
@@ -4905,6 +4977,9 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                   data-worktree-row-key={itemRow.rowKey}
                   data-worktree-section-key={itemRow.sectionKey}
                   data-worktree-drag-id={worktreeDragGroupKey ? itemRow.worktree.id : undefined}
+                  data-worktree-lineage-parent-id={
+                    nested ? worktreeLineageById[itemRow.worktree.id]?.parentWorktreeId : undefined
+                  }
                   data-worktree-drag-group-key={worktreeDragGroupKey}
                   data-worktree-drag-group-index={worktreeDragGroupIndex}
                   className={cn(

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -182,6 +182,7 @@ import {
   setSidebarPointerDragDocumentStyles,
   updateSidebarDragPreviewPosition
 } from './worktree-sidebar-pointer-drag-dom'
+import { shouldStartWorkspaceBoardDragPreview } from './workspace-board-drag-preview-intent'
 import {
   getWorktreeSidebarDragAutoscroll,
   getWorktreeSidebarDragRectsForGroup,
@@ -199,7 +200,8 @@ import {
 } from './worktree-sidebar-drop-preview'
 import {
   getReorderedWorktreeIdsToUnnest,
-  getWorktreeLineageDropTargetId
+  getWorktreeLineageInsertionGuideY,
+  getWorktreeLineageDropTarget
 } from './worktree-lineage-drag-drop'
 import { resolveProjectGroupHeaderColor } from './project-header-color'
 import {
@@ -993,16 +995,29 @@ function getPointerDropStatusTarget(args: {
   container: HTMLElement
   x: number
   y: number
-}): WorktreeSidebarStatusDropTarget & { lineageParentId: string | null } {
+}): WorktreeSidebarStatusDropTarget & {
+  lineageParentId: string | null
+  lineageDropIndicatorY: number | null
+} {
   const target = document.elementFromPoint(args.x, args.y)
   if (!(target instanceof Element) || !args.container.contains(target)) {
-    return { status: null, isPinDrop: false, lineageParentId: null }
+    return {
+      status: null,
+      isPinDrop: false,
+      lineageParentId: null,
+      lineageDropIndicatorY: null
+    }
   }
   const pinTarget = target.closest<HTMLElement>('[data-workspace-pin-drop-target]')
   if (pinTarget && args.container.contains(pinTarget)) {
-    return { status: null, isPinDrop: true, lineageParentId: null }
+    return {
+      status: null,
+      isPinDrop: true,
+      lineageParentId: null,
+      lineageDropIndicatorY: null
+    }
   }
-  const lineageParentId = getWorktreeLineageDropTargetId({
+  const lineageTarget = getWorktreeLineageDropTarget({
     container: args.container,
     target,
     pointerY: args.y
@@ -1014,7 +1029,8 @@ function getPointerDropStatusTarget(args: {
         ? ((statusTarget.dataset.workspaceStatus as WorkspaceStatus | undefined) ?? null)
         : null,
     isPinDrop: false,
-    lineageParentId
+    lineageParentId: lineageTarget?.parentId ?? null,
+    lineageDropIndicatorY: lineageTarget?.dropIndicatorY ?? null
   }
 }
 
@@ -1543,6 +1559,27 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         .map((row) => ({ worktreeId: row.worktree.id, depth: row.depth })),
     [naturalDragWorktreeIds, rows]
   )
+  const lineageDragOrder = useMemo(() => {
+    const orderIndexById = new Map<string, number>()
+    const directChildIdsByParentId = new Map<string, string[]>()
+    worktrees.forEach((worktree, index) => {
+      orderIndexById.set(worktree.id, index)
+      const lineage = worktreeLineageById[worktree.id]
+      const parent = lineage ? worktreeMap.get(lineage.parentWorktreeId) : undefined
+      if (
+        !lineage ||
+        !parent ||
+        lineage.worktreeInstanceId !== worktree.instanceId ||
+        lineage.parentWorktreeInstanceId !== parent.instanceId
+      ) {
+        return
+      }
+      const childIds = directChildIdsByParentId.get(parent.id) ?? []
+      childIds.push(worktree.id)
+      directChildIdsByParentId.set(parent.id, childIds)
+    })
+    return { orderIndexById, directChildIdsByParentId }
+  }, [worktreeLineageById, worktreeMap, worktrees])
   const getReorderDraggedIds = useCallback(
     (draggedIds: readonly string[]) =>
       expandDraggedWorktreeIdsForVisibleLineage(worktreeLineageDragRows, draggedIds),
@@ -2683,9 +2720,15 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
 
   const getEligibleLineageDropTarget = useCallback(
     (
-      target: WorktreeSidebarStatusDropTarget & { lineageParentId: string | null },
+      target: WorktreeSidebarStatusDropTarget & {
+        lineageParentId: string | null
+        lineageDropIndicatorY?: number | null
+      },
       draggedIds: readonly string[]
-    ): WorktreeSidebarStatusDropTarget & { lineageParentId: string | null } => {
+    ): WorktreeSidebarStatusDropTarget & {
+      lineageParentId: string | null
+      lineageDropIndicatorY?: number | null
+    } => {
       const parentId = target.lineageParentId
       if (!parentId) {
         return target
@@ -2703,9 +2746,33 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
           repoMap
         }).some((candidate) => candidate.id === parentId)
       })
-      return canAssignAll ? target : { ...target, lineageParentId: null }
+      return canAssignAll
+        ? target
+        : { ...target, lineageParentId: null, lineageDropIndicatorY: null }
     },
     [repoMap, worktreeLineageById, worktreeMap, worktrees]
+  )
+
+  const resolveLineageDropIndicatorY = useCallback(
+    (args: {
+      container: HTMLElement
+      parentId: string
+      draggedIds: readonly string[]
+      fallbackY: number | null | undefined
+    }): number | null => {
+      if (args.fallbackY === null || args.fallbackY === undefined) {
+        return null
+      }
+      return getWorktreeLineageInsertionGuideY({
+        container: args.container,
+        parentId: args.parentId,
+        directChildIds: lineageDragOrder.directChildIdsByParentId.get(args.parentId) ?? [],
+        draggedIds: args.draggedIds,
+        orderIndexById: lineageDragOrder.orderIndexById,
+        fallbackY: args.fallbackY
+      })
+    },
+    [lineageDragOrder]
   )
 
   const commitWorktreeLineageParentDrop = useCallback(
@@ -2783,14 +2850,26 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       clearWorktreeDrag()
       return
     }
-    // Why: show the board preview as soon as a card drag begins so the drop target is visible up front, not only at the sidebar edge.
+    const previewSidebarContainer = scrollRef.current
     if (
       !drag.workspaceBoardDragPreviewRequested &&
       !workspaceBoardOpen &&
-      !hasWorkspaceKanbanSidebarDropBoard()
+      previewSidebarContainer
     ) {
-      drag.workspaceBoardDragPreviewRequested = true
-      onWorkspaceBoardDragPreviewStart()
+      const sidebarRect = previewSidebarContainer.getBoundingClientRect()
+      // Why: mounting a large companion board during every vertical reorder can
+      // stall the first drag frame; rightward edge movement signals board intent.
+      if (
+        shouldStartWorkspaceBoardDragPreview({
+          pointerX: drag.currentX,
+          startX: drag.startX,
+          sidebarRight: sidebarRect.right
+        }) &&
+        !hasWorkspaceKanbanSidebarDropBoard()
+      ) {
+        drag.workspaceBoardDragPreviewRequested = true
+        onWorkspaceBoardDragPreviewStart()
+      }
     }
     const boardTarget = updateWorkspaceKanbanSidebarDropTargetVisual({
       x: drag.currentX,
@@ -2842,20 +2921,28 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       drag.draggedIds
     )
     if (preferredStatusTarget.lineageParentId) {
+      const lineageDropIndicatorY = sidebarContainer
+        ? resolveLineageDropIndicatorY({
+            container: sidebarContainer,
+            parentId: preferredStatusTarget.lineageParentId,
+            draggedIds: drag.draggedIds,
+            fallbackY: preferredStatusTarget.lineageDropIndicatorY
+          })
+        : null
       updateLatestWorktreeStatusDropTarget(drag, preferredStatusTarget, null)
       clearWorkspaceKanbanSidebarDropTargetVisual()
       setDragOverStatus(null)
       setPinDragOver(false)
       setWorktreeDragState((prev) =>
         prev.dropIndex === null &&
-        prev.dropIndicatorY === null &&
+        prev.dropIndicatorY === lineageDropIndicatorY &&
         prev.pointerY === drag.currentY &&
         prev.previewOffsetsByWorktreeId.size === 0
           ? prev
           : {
               ...prev,
               dropIndex: null,
-              dropIndicatorY: null,
+              dropIndicatorY: lineageDropIndicatorY,
               previewOffsetsByWorktreeId: EMPTY_WORKTREE_DRAG_PREVIEW_OFFSETS,
               pointerY: drag.currentY
             }
@@ -2985,6 +3072,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     onWorkspaceBoardDragPreviewCommit,
     shouldShowWorkspaceBoardDropIndicator,
     getEligibleLineageDropTarget,
+    resolveLineageDropIndicatorY,
     workspaceBoardOpen,
     workspaceStatuses
   ])
@@ -3531,18 +3619,24 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         session.draggedIds
       )
       if (target.lineageParentId) {
+        const lineageDropIndicatorY = resolveLineageDropIndicatorY({
+          container: event.currentTarget,
+          parentId: target.lineageParentId,
+          draggedIds: session.draggedIds,
+          fallbackY: target.lineageDropIndicatorY
+        })
         event.preventDefault()
         event.dataTransfer.dropEffect = 'move'
         setNativeLineageDropTargetId(target.lineageParentId)
         setWorktreeDragState((prev) =>
           prev.dropIndex === null &&
-          prev.dropIndicatorY === null &&
+          prev.dropIndicatorY === lineageDropIndicatorY &&
           prev.previewOffsetsByWorktreeId.size === 0
             ? prev
             : {
                 ...prev,
                 dropIndex: null,
-                dropIndicatorY: null,
+                dropIndicatorY: lineageDropIndicatorY,
                 previewOffsetsByWorktreeId: EMPTY_WORKTREE_DRAG_PREVIEW_OFFSETS,
                 pointerY: event.clientY
               }
@@ -3609,6 +3703,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       computeWorktreeStatusDrop,
       getEligibleLineageDropTarget,
       refreshWorktreeDragSession,
+      resolveLineageDropIndicatorY,
       startWorktreeNativeAutoscroll
     ]
   )

--- a/src/renderer/src/components/sidebar/workspace-board-drag-preview-intent.test.ts
+++ b/src/renderer/src/components/sidebar/workspace-board-drag-preview-intent.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { shouldStartWorkspaceBoardDragPreview } from './workspace-board-drag-preview-intent'
+
+describe('workspace board drag preview intent', () => {
+  it('does not start the expensive board preview for small sidebar reorder drags', () => {
+    expect(
+      shouldStartWorkspaceBoardDragPreview({
+        pointerX: 132,
+        startX: 96,
+        sidebarRight: 285
+      })
+    ).toBe(false)
+  })
+
+  it('starts the board preview after a rightward drag reaches the sidebar edge zone', () => {
+    expect(
+      shouldStartWorkspaceBoardDragPreview({
+        pointerX: 252,
+        startX: 96,
+        sidebarRight: 285
+      })
+    ).toBe(true)
+  })
+
+  it('ignores edge-zone drags that did not move right enough to signal board intent', () => {
+    expect(
+      shouldStartWorkspaceBoardDragPreview({
+        pointerX: 252,
+        startX: 242,
+        sidebarRight: 285
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/sidebar/workspace-board-drag-preview-intent.ts
+++ b/src/renderer/src/components/sidebar/workspace-board-drag-preview-intent.ts
@@ -1,0 +1,13 @@
+const WORKSPACE_BOARD_DRAG_PREVIEW_EDGE_ZONE_PX = 48
+const WORKSPACE_BOARD_DRAG_PREVIEW_MIN_RIGHTWARD_PX = 16
+
+export function shouldStartWorkspaceBoardDragPreview(args: {
+  pointerX: number
+  startX: number
+  sidebarRight: number
+}): boolean {
+  return (
+    args.pointerX >= args.sidebarRight - WORKSPACE_BOARD_DRAG_PREVIEW_EDGE_ZONE_PX &&
+    args.pointerX - args.startX >= WORKSPACE_BOARD_DRAG_PREVIEW_MIN_RIGHTWARD_PX
+  )
+}

--- a/src/renderer/src/components/sidebar/worktree-drag-preview-offsets.ts
+++ b/src/renderer/src/components/sidebar/worktree-drag-preview-offsets.ts
@@ -104,7 +104,15 @@ export function buildWorktreeDragPreviewOffsets(args: {
     const rect = rectById.get(id)
     return rect ? [rect] : []
   })
-  const baseTop = groupRects[0]?.top ?? 0
+  const firstMountedRect = groupRects[0]
+  const firstMountedUnitIndex = firstMountedRect
+    ? args.groupIds.indexOf(firstMountedRect.worktreeId)
+    : 0
+  // Why: virtualization can mount a middle slice of the group. Backfill its
+  // estimated prefix so replay reaches the first measured row at its real top.
+  const baseTop = firstMountedRect
+    ? firstMountedRect.top - Math.max(0, firstMountedUnitIndex) * fallbackStride
+    : 0
   const fallbackHeight = Math.max(0, fallbackStride - fallbackGap)
   const gapAfterById = new Map<string, number>()
   for (let index = 0; index < groupRects.length; index++) {

--- a/src/renderer/src/components/sidebar/worktree-lineage-drag-drop.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-lineage-drag-drop.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildWorktreeLineageInsertionOrderUpdates,
   getReorderedWorktreeIdsToUnnest,
   getWorktreeLineageInsertionBeforeChildId,
   getWorktreeLineageDropTarget,
@@ -76,6 +77,77 @@ describe('getWorktreeLineageDropTargetId', () => {
     })
   })
 
+  it('uses a child upper edge as an exact sibling insertion slot', () => {
+    const { container, target } = makeTarget({
+      worktreeId: 'child-b',
+      lineageParentId: 'parent',
+      directSiblingIds: ['child-a', 'child-b'],
+      top: 200,
+      bottom: 300,
+      containerTop: 20,
+      scrollTop: 400
+    })
+
+    expect(getWorktreeLineageDropTarget({ container, target, pointerY: 215 })).toEqual({
+      parentId: 'parent',
+      insertionBeforeChildId: 'child-b',
+      dropIndicatorY: 577
+    })
+  })
+
+  it('uses a child lower edge to insert before its next sibling', () => {
+    const { container, target } = makeTarget({
+      worktreeId: 'child-a',
+      lineageParentId: 'parent',
+      directSiblingIds: ['child-a', 'child-b'],
+      top: 100,
+      bottom: 200,
+      containerTop: 20,
+      scrollTop: 400
+    })
+
+    expect(getWorktreeLineageDropTarget({ container, target, pointerY: 185 })).toEqual({
+      parentId: 'parent',
+      insertionBeforeChildId: 'child-b',
+      dropIndicatorY: 577
+    })
+  })
+
+  it('uses the last child lower edge as the sibling-list append slot', () => {
+    const { container, target } = makeTarget({
+      worktreeId: 'child-b',
+      lineageParentId: 'parent',
+      directSiblingIds: ['child-a', 'child-b'],
+      top: 200,
+      bottom: 300,
+      containerTop: 20,
+      scrollTop: 400
+    })
+
+    expect(getWorktreeLineageDropTarget({ container, target, pointerY: 285 })).toEqual({
+      parentId: 'parent',
+      insertionBeforeChildId: null,
+      dropIndicatorY: 683
+    })
+  })
+
+  it('keeps the child center available as a deeper nesting target', () => {
+    const { container, target } = makeTarget({
+      worktreeId: 'child-a',
+      lineageParentId: 'parent',
+      directSiblingIds: ['child-a', 'child-b'],
+      top: 100,
+      bottom: 200,
+      containerTop: 20,
+      scrollTop: 400
+    })
+
+    expect(getWorktreeLineageDropTarget({ container, target, pointerY: 150 })).toEqual({
+      parentId: 'child-a',
+      dropIndicatorY: 583
+    })
+  })
+
   it('ignores content targets outside the sidebar container', () => {
     const { container, target } = makeTarget({
       worktreeId: 'parent',
@@ -128,6 +200,47 @@ describe('getWorktreeLineageInsertionBeforeChildId', () => {
   })
 })
 
+describe('buildWorktreeLineageInsertionOrderUpdates', () => {
+  const orderIndexById = new Map([
+    ['root', 0],
+    ['child-a', 1],
+    ['child-b', 2]
+  ])
+  const rankByWorktreeId = new Map([
+    ['root', 4000],
+    ['child-a', 3000],
+    ['child-b', 1000]
+  ])
+
+  it('ranks a root workspace into the pointed-at child gap', () => {
+    expect(
+      Array.from(
+        buildWorktreeLineageInsertionOrderUpdates({
+          directChildIds: ['child-a', 'child-b'],
+          draggedIds: ['root'],
+          insertionBeforeChildId: 'child-b',
+          orderIndexById,
+          rankByWorktreeId,
+          now: 10_000
+        })
+      )
+    ).toEqual([['root', { manualOrder: 2000 }]])
+  })
+
+  it('does not rewrite ranks for a child dropped back into its current gap', () => {
+    expect(
+      buildWorktreeLineageInsertionOrderUpdates({
+        directChildIds: ['child-a', 'child-b'],
+        draggedIds: ['child-a'],
+        insertionBeforeChildId: 'child-b',
+        orderIndexById,
+        rankByWorktreeId,
+        now: 10_000
+      }).size
+    ).toBe(0)
+  })
+})
+
 describe('getReorderedWorktreeIdsToUnnest', () => {
   it('clears parents only for directly dragged nested cards', () => {
     expect(
@@ -160,6 +273,8 @@ function makeTarget(args: {
   worktreeId: string
   top: number
   bottom: number
+  lineageParentId?: string
+  directSiblingIds?: readonly string[]
   lineageChildrenTop?: number
   containerTop?: number
   scrollTop?: number
@@ -168,9 +283,31 @@ function makeTarget(args: {
   container: HTMLElement
   target: Element
 } {
-  const row = {
-    getAttribute: (name: string) => (name === 'data-worktree-drag-id' ? args.worktreeId : null)
-  } as HTMLElement
+  const siblingIds = args.directSiblingIds ?? [args.worktreeId]
+  const currentSiblingIndex = Math.max(0, siblingIds.indexOf(args.worktreeId))
+  const rowHeight = args.bottom - args.top
+  const siblingRows = siblingIds.map(
+    (worktreeId, index) =>
+      ({
+        getAttribute: (name: string) => {
+          if (name === 'data-worktree-drag-id') {
+            return worktreeId
+          }
+          if (name === 'data-worktree-lineage-parent-id') {
+            return args.lineageParentId ?? null
+          }
+          if (name === 'data-worktree-section-key') {
+            return 'section'
+          }
+          return null
+        },
+        getBoundingClientRect: () => {
+          const top = args.top + (index - currentSiblingIndex) * rowHeight
+          return { top, bottom: top + rowHeight }
+        }
+      }) as HTMLElement
+  )
+  const row = siblingRows[currentSiblingIndex]!
   const lineageChildren =
     args.lineageChildrenTop === undefined
       ? null
@@ -182,16 +319,19 @@ function makeTarget(args: {
     querySelector: (selector: string) =>
       selector === '[data-worktree-lineage-children]' ? lineageChildren : null,
     closest: (selector: string) => (selector === '[data-worktree-drag-id]' ? row : null)
-  } as HTMLElement
+  } as unknown as HTMLElement
   const target = {
     closest: (selector: string) =>
       selector === '[data-worktree-card-hover-trigger]' ? content : null
   } as Element
   const contained = args.contained ?? true
   const container = {
-    contains: (element: Element) => contained && (element === content || element === row),
+    contains: (element: Element) =>
+      contained && (element === content || siblingRows.includes(element as HTMLElement)),
+    querySelectorAll: (selector: string) =>
+      selector === '[data-worktree-drag-id]' ? siblingRows : [],
     getBoundingClientRect: () => ({ top: args.containerTop ?? 0 }),
     scrollTop: args.scrollTop ?? 0
-  } as HTMLElement
+  } as unknown as HTMLElement
   return { container, target }
 }

--- a/src/renderer/src/components/sidebar/worktree-lineage-drag-drop.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-lineage-drag-drop.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   getReorderedWorktreeIdsToUnnest,
+  getWorktreeLineageInsertionBeforeChildId,
+  getWorktreeLineageDropTarget,
   getWorktreeLineageDropTargetId,
   isWorktreeLineageDropZoneHit
 } from './worktree-lineage-drag-drop'
@@ -31,6 +33,49 @@ describe('getWorktreeLineageDropTargetId', () => {
     expect(getWorktreeLineageDropTargetId({ container, target, pointerY: 150 })).toBe('parent')
   })
 
+  it('excludes expanded descendants from the parent card drop-zone geometry', () => {
+    const { container, target } = makeTarget({
+      worktreeId: 'parent',
+      top: 100,
+      bottom: 300,
+      lineageChildrenTop: 160
+    })
+
+    expect(getWorktreeLineageDropTargetId({ container, target, pointerY: 130 })).toBe('parent')
+    expect(getWorktreeLineageDropTargetId({ container, target, pointerY: 200 })).toBeNull()
+  })
+
+  it('places the nesting guide between an expanded parent and its children', () => {
+    const { container, target } = makeTarget({
+      worktreeId: 'parent',
+      top: 100,
+      bottom: 300,
+      lineageChildrenTop: 160,
+      containerTop: 20,
+      scrollTop: 400
+    })
+
+    expect(getWorktreeLineageDropTarget({ container, target, pointerY: 130 })).toEqual({
+      parentId: 'parent',
+      dropIndicatorY: 537
+    })
+  })
+
+  it('places the nesting guide below a parent without expanded children', () => {
+    const { container, target } = makeTarget({
+      worktreeId: 'parent',
+      top: 100,
+      bottom: 200,
+      containerTop: 20,
+      scrollTop: 400
+    })
+
+    expect(getWorktreeLineageDropTarget({ container, target, pointerY: 150 })).toEqual({
+      parentId: 'parent',
+      dropIndicatorY: 583
+    })
+  })
+
   it('ignores content targets outside the sidebar container', () => {
     const { container, target } = makeTarget({
       worktreeId: 'parent',
@@ -40,6 +85,46 @@ describe('getWorktreeLineageDropTargetId', () => {
     })
 
     expect(getWorktreeLineageDropTargetId({ container, target, pointerY: 150 })).toBeNull()
+  })
+})
+
+describe('getWorktreeLineageInsertionBeforeChildId', () => {
+  const orderIndexById = new Map([
+    ['above', 0],
+    ['parent', 1],
+    ['child-a', 2],
+    ['child-b', 3],
+    ['below', 4]
+  ])
+
+  it('inserts an earlier workspace before the first child', () => {
+    expect(
+      getWorktreeLineageInsertionBeforeChildId({
+        directChildIds: ['child-a', 'child-b'],
+        draggedIds: ['above'],
+        orderIndexById
+      })
+    ).toBe('child-a')
+  })
+
+  it('appends a later workspace after the existing children', () => {
+    expect(
+      getWorktreeLineageInsertionBeforeChildId({
+        directChildIds: ['child-a', 'child-b'],
+        draggedIds: ['below'],
+        orderIndexById
+      })
+    ).toBeNull()
+  })
+
+  it('ignores a dragged child when resolving its current sibling slot', () => {
+    expect(
+      getWorktreeLineageInsertionBeforeChildId({
+        directChildIds: ['child-a', 'child-b'],
+        draggedIds: ['child-a'],
+        orderIndexById
+      })
+    ).toBe('child-b')
   })
 })
 
@@ -75,6 +160,9 @@ function makeTarget(args: {
   worktreeId: string
   top: number
   bottom: number
+  lineageChildrenTop?: number
+  containerTop?: number
+  scrollTop?: number
   contained?: boolean
 }): {
   container: HTMLElement
@@ -83,8 +171,16 @@ function makeTarget(args: {
   const row = {
     getAttribute: (name: string) => (name === 'data-worktree-drag-id' ? args.worktreeId : null)
   } as HTMLElement
+  const lineageChildren =
+    args.lineageChildrenTop === undefined
+      ? null
+      : ({
+          getBoundingClientRect: () => ({ top: args.lineageChildrenTop })
+        } as HTMLElement)
   const content = {
     getBoundingClientRect: () => ({ top: args.top, bottom: args.bottom }),
+    querySelector: (selector: string) =>
+      selector === '[data-worktree-lineage-children]' ? lineageChildren : null,
     closest: (selector: string) => (selector === '[data-worktree-drag-id]' ? row : null)
   } as HTMLElement
   const target = {
@@ -93,7 +189,9 @@ function makeTarget(args: {
   } as Element
   const contained = args.contained ?? true
   const container = {
-    contains: (element: Element) => contained && (element === content || element === row)
+    contains: (element: Element) => contained && (element === content || element === row),
+    getBoundingClientRect: () => ({ top: args.containerTop ?? 0 }),
+    scrollTop: args.scrollTop ?? 0
   } as HTMLElement
   return { container, target }
 }

--- a/src/renderer/src/components/sidebar/worktree-lineage-drag-drop.ts
+++ b/src/renderer/src/components/sidebar/worktree-lineage-drag-drop.ts
@@ -1,6 +1,12 @@
+import {
+  buildSparseManualOrderUpdates,
+  type WorktreeManualOrderUpdate
+} from './worktree-manual-order-ranks'
+
 const WORKTREE_CARD_CONTENT_TARGET_SELECTOR = '[data-worktree-card-hover-trigger]'
 const WORKTREE_DRAG_ROW_SELECTOR = '[data-worktree-drag-id]'
 const WORKTREE_LINEAGE_CHILDREN_SELECTOR = '[data-worktree-lineage-children]'
+const WORKTREE_LINEAGE_PARENT_ATTRIBUTE = 'data-worktree-lineage-parent-id'
 
 const LINEAGE_DROP_ZONE_RATIO = 0.4
 const LINEAGE_DROP_ZONE_MAX_HEIGHT_PX = 44
@@ -10,6 +16,59 @@ type VerticalRect = Pick<DOMRect, 'top' | 'bottom'>
 export type WorktreeLineageDropTarget = {
   parentId: string
   dropIndicatorY: number
+  insertionBeforeChildId?: string | null
+}
+
+export function buildWorktreeLineageInsertionOrderUpdates(args: {
+  directChildIds: readonly string[]
+  draggedIds: readonly string[]
+  insertionBeforeChildId: string | null
+  orderIndexById: ReadonlyMap<string, number>
+  rankByWorktreeId: ReadonlyMap<string, number>
+  now: number
+}): Map<string, WorktreeManualOrderUpdate> {
+  const draggedIdSet = new Set(args.draggedIds)
+  const orderedDraggedIds = Array.from(draggedIdSet).sort(
+    (left, right) =>
+      (args.orderIndexById.get(left) ?? Number.POSITIVE_INFINITY) -
+      (args.orderIndexById.get(right) ?? Number.POSITIVE_INFINITY)
+  )
+  if (orderedDraggedIds.length === 0) {
+    return new Map()
+  }
+
+  const dropIndex =
+    args.insertionBeforeChildId === null
+      ? args.directChildIds.length
+      : args.directChildIds.indexOf(args.insertionBeforeChildId)
+  if (dropIndex < 0) {
+    return new Map()
+  }
+  let removedBeforeDrop = 0
+  for (let index = 0; index < dropIndex; index++) {
+    if (draggedIdSet.has(args.directChildIds[index]!)) {
+      removedBeforeDrop++
+    }
+  }
+  const remainingIds = args.directChildIds.filter((id) => !draggedIdSet.has(id))
+  const insertAt = Math.max(0, Math.min(remainingIds.length, dropIndex - removedBeforeDrop))
+  const orderedIds = [
+    ...remainingIds.slice(0, insertAt),
+    ...orderedDraggedIds,
+    ...remainingIds.slice(insertAt)
+  ]
+  if (
+    orderedIds.length === args.directChildIds.length &&
+    orderedIds.every((id, index) => id === args.directChildIds[index])
+  ) {
+    return new Map()
+  }
+  return buildSparseManualOrderUpdates({
+    orderedIds,
+    movedIds: orderedDraggedIds,
+    rankByWorktreeId: args.rankByWorktreeId,
+    now: args.now
+  })
 }
 
 export function getWorktreeLineageInsertionBeforeChildId(args: {
@@ -87,8 +146,6 @@ export function getWorktreeLineageDropTarget(args: {
     return null
   }
 
-  // Why: nesting should be deliberate; the top/bottom of a card stays available
-  // for reorder drops instead of treating the whole card as a parent target.
   const contentRect = contentTarget.getBoundingClientRect()
   const lineageChildren = contentTarget.querySelector<HTMLElement>(
     WORKTREE_LINEAGE_CHILDREN_SELECTOR
@@ -101,12 +158,7 @@ export function getWorktreeLineageDropTarget(args: {
         bottom: Math.min(contentRect.bottom, lineageChildren.getBoundingClientRect().top)
       }
     : contentRect
-  if (
-    !isWorktreeLineageDropZoneHit({
-      pointerY: args.pointerY,
-      rect: dropZoneRect
-    })
-  ) {
+  if (args.pointerY < dropZoneRect.top || args.pointerY > dropZoneRect.bottom) {
     return null
   }
 
@@ -118,10 +170,46 @@ export function getWorktreeLineageDropTarget(args: {
   if (!parentId) {
     return null
   }
+  const containerRect = args.container.getBoundingClientRect()
+  if (
+    !isWorktreeLineageDropZoneHit({
+      pointerY: args.pointerY,
+      rect: dropZoneRect
+    })
+  ) {
+    const lineageParentId = rowTarget.getAttribute(WORKTREE_LINEAGE_PARENT_ATTRIBUTE)
+    if (!lineageParentId) {
+      return null
+    }
+    // Why: child-row edges are sibling insertion slots; their center remains
+    // available for deliberately creating a deeper parent-child relationship.
+    const sectionKey = rowTarget.getAttribute('data-worktree-section-key')
+    const directSiblingRows = Array.from(
+      args.container.querySelectorAll<HTMLElement>(WORKTREE_DRAG_ROW_SELECTOR)
+    ).filter(
+      (row) =>
+        row.getAttribute(WORKTREE_LINEAGE_PARENT_ATTRIBUTE) === lineageParentId &&
+        (!sectionKey || row.getAttribute('data-worktree-section-key') === sectionKey)
+    )
+    const siblingIndex = directSiblingRows.indexOf(rowTarget)
+    if (siblingIndex < 0) {
+      return null
+    }
+    const insertBeforeCurrent = args.pointerY < (dropZoneRect.top + dropZoneRect.bottom) / 2
+    const nextSibling = insertBeforeCurrent ? rowTarget : directSiblingRows[siblingIndex + 1]
+    const indicatorViewportY = nextSibling
+      ? nextSibling.getBoundingClientRect().top - 3
+      : rowTarget.getBoundingClientRect().bottom + 3
+    return {
+      parentId: lineageParentId,
+      insertionBeforeChildId: nextSibling?.getAttribute('data-worktree-drag-id') ?? null,
+      dropIndicatorY: Math.max(0, indicatorViewportY - containerRect.top + args.container.scrollTop)
+    }
+  }
+
   const indicatorViewportY = lineageChildren
     ? lineageChildren.getBoundingClientRect().top - 3
     : dropZoneRect.bottom + 3
-  const containerRect = args.container.getBoundingClientRect()
   return {
     parentId,
     // Why: the regular reorder guide is positioned in scroll-content space;

--- a/src/renderer/src/components/sidebar/worktree-lineage-drag-drop.ts
+++ b/src/renderer/src/components/sidebar/worktree-lineage-drag-drop.ts
@@ -1,10 +1,66 @@
 const WORKTREE_CARD_CONTENT_TARGET_SELECTOR = '[data-worktree-card-hover-trigger]'
 const WORKTREE_DRAG_ROW_SELECTOR = '[data-worktree-drag-id]'
+const WORKTREE_LINEAGE_CHILDREN_SELECTOR = '[data-worktree-lineage-children]'
 
 const LINEAGE_DROP_ZONE_RATIO = 0.4
 const LINEAGE_DROP_ZONE_MAX_HEIGHT_PX = 44
 
 type VerticalRect = Pick<DOMRect, 'top' | 'bottom'>
+
+export type WorktreeLineageDropTarget = {
+  parentId: string
+  dropIndicatorY: number
+}
+
+export function getWorktreeLineageInsertionBeforeChildId(args: {
+  directChildIds: readonly string[]
+  draggedIds: readonly string[]
+  orderIndexById: ReadonlyMap<string, number>
+}): string | null {
+  const draggedIdSet = new Set(args.draggedIds)
+  const draggedOrderIndex = args.draggedIds.reduce(
+    (index, id) => Math.min(index, args.orderIndexById.get(id) ?? Number.POSITIVE_INFINITY),
+    Number.POSITIVE_INFINITY
+  )
+  if (!Number.isFinite(draggedOrderIndex)) {
+    return null
+  }
+  return (
+    args.directChildIds.find(
+      (id) =>
+        !draggedIdSet.has(id) &&
+        (args.orderIndexById.get(id) ?? Number.POSITIVE_INFINITY) > draggedOrderIndex
+    ) ?? null
+  )
+}
+
+export function getWorktreeLineageInsertionGuideY(args: {
+  container: HTMLElement
+  parentId: string
+  directChildIds: readonly string[]
+  draggedIds: readonly string[]
+  orderIndexById: ReadonlyMap<string, number>
+  fallbackY: number
+}): number {
+  const rows = Array.from(args.container.querySelectorAll<HTMLElement>(WORKTREE_DRAG_ROW_SELECTOR))
+  const rowById = (id: string): HTMLElement | undefined =>
+    rows.find((row) => row.getAttribute('data-worktree-drag-id') === id)
+  const insertBeforeChildId = getWorktreeLineageInsertionBeforeChildId(args)
+  const insertBeforeRow = insertBeforeChildId ? rowById(insertBeforeChildId) : undefined
+  const parentChildren = rowById(args.parentId)?.querySelector<HTMLElement>(
+    WORKTREE_LINEAGE_CHILDREN_SELECTOR
+  )
+  const indicatorViewportY = insertBeforeRow
+    ? insertBeforeRow.getBoundingClientRect().top - 3
+    : parentChildren
+      ? parentChildren.getBoundingClientRect().bottom + 3
+      : null
+  if (indicatorViewportY === null) {
+    return args.fallbackY
+  }
+  const containerRect = args.container.getBoundingClientRect()
+  return Math.max(0, indicatorViewportY - containerRect.top + args.container.scrollTop)
+}
 
 export function isWorktreeLineageDropZoneHit(args: {
   pointerY: number
@@ -21,11 +77,11 @@ export function isWorktreeLineageDropZoneHit(args: {
   return args.pointerY >= zoneTop && args.pointerY <= zoneBottom
 }
 
-export function getWorktreeLineageDropTargetId(args: {
+export function getWorktreeLineageDropTarget(args: {
   container: HTMLElement
   target: Element
   pointerY: number
-}): string | null {
+}): WorktreeLineageDropTarget | null {
   const contentTarget = args.target.closest<HTMLElement>(WORKTREE_CARD_CONTENT_TARGET_SELECTOR)
   if (!contentTarget || !args.container.contains(contentTarget)) {
     return null
@@ -33,10 +89,22 @@ export function getWorktreeLineageDropTargetId(args: {
 
   // Why: nesting should be deliberate; the top/bottom of a card stays available
   // for reorder drops instead of treating the whole card as a parent target.
+  const contentRect = contentTarget.getBoundingClientRect()
+  const lineageChildren = contentTarget.querySelector<HTMLElement>(
+    WORKTREE_LINEAGE_CHILDREN_SELECTOR
+  )
+  // Why: legacy expanded parent cards include descendants inside their hover
+  // trigger, but only the parent's own surface should be a nesting target.
+  const dropZoneRect = lineageChildren
+    ? {
+        top: contentRect.top,
+        bottom: Math.min(contentRect.bottom, lineageChildren.getBoundingClientRect().top)
+      }
+    : contentRect
   if (
     !isWorktreeLineageDropZoneHit({
       pointerY: args.pointerY,
-      rect: contentTarget.getBoundingClientRect()
+      rect: dropZoneRect
     })
   ) {
     return null
@@ -46,7 +114,28 @@ export function getWorktreeLineageDropTargetId(args: {
   if (!rowTarget || !args.container.contains(rowTarget)) {
     return null
   }
-  return rowTarget.getAttribute('data-worktree-drag-id')
+  const parentId = rowTarget.getAttribute('data-worktree-drag-id')
+  if (!parentId) {
+    return null
+  }
+  const indicatorViewportY = lineageChildren
+    ? lineageChildren.getBoundingClientRect().top - 3
+    : dropZoneRect.bottom + 3
+  const containerRect = args.container.getBoundingClientRect()
+  return {
+    parentId,
+    // Why: the regular reorder guide is positioned in scroll-content space;
+    // lineage targets must use the same coordinates to stay aligned on scroll.
+    dropIndicatorY: Math.max(0, indicatorViewportY - containerRect.top + args.container.scrollTop)
+  }
+}
+
+export function getWorktreeLineageDropTargetId(args: {
+  container: HTMLElement
+  target: Element
+  pointerY: number
+}): string | null {
+  return getWorktreeLineageDropTarget(args)?.parentId ?? null
 }
 
 export function getReorderedWorktreeIdsToUnnest(args: {

--- a/src/renderer/src/components/sidebar/worktree-manual-order.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order.test.ts
@@ -105,6 +105,27 @@ describe('buildWorktreeDragPreviewOffsets', () => {
     ])
   })
 
+  it('keeps a virtualized middle slice anchored while dragging upward', () => {
+    const groupIds = Array.from({ length: 40 }, (_, index) => `worktree-${index}`)
+    const rects = groupIds.slice(25, 36).map((worktreeId, index) => ({
+      worktreeId,
+      groupIndex: index + 25,
+      top: 1500 + index * 56,
+      bottom: 1550 + index * 56
+    }))
+
+    const offsets = buildWorktreeDragPreviewOffsets({
+      groupIds,
+      draggedIds: ['worktree-35'],
+      dropIndex: 25,
+      rects
+    })
+
+    expect(Array.from(offsets)).toEqual(
+      groupIds.slice(25, 35).map((worktreeId) => [worktreeId, 56])
+    )
+  })
+
   it('returns no preview offsets for a no-op hover', () => {
     const offsets = buildWorktreeDragPreviewOffsets({
       groupIds: ['a', 'b'],

--- a/src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.test.ts
@@ -219,7 +219,12 @@ describe('resolveWorktreeSidebarStatusDropCommitTarget', () => {
         currentTarget: { status: null, isPinDrop: false, lineageParentId: null },
         currentPreview: null,
         latestTrackedTarget: {
-          target: { status: null, isPinDrop: false, lineageParentId: 'parent-worktree' },
+          target: {
+            status: null,
+            isPinDrop: false,
+            lineageParentId: 'parent-worktree',
+            lineageInsertionBeforeChildId: 'child-worktree'
+          },
           preview: null,
           x: 100,
           y: 100
@@ -228,7 +233,12 @@ describe('resolveWorktreeSidebarStatusDropCommitTarget', () => {
         y: 101
       })
     ).toEqual({
-      target: { status: null, isPinDrop: false, lineageParentId: 'parent-worktree' },
+      target: {
+        status: null,
+        isPinDrop: false,
+        lineageParentId: 'parent-worktree',
+        lineageInsertionBeforeChildId: 'child-worktree'
+      },
       preview: null
     })
   })

--- a/src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.test.ts
@@ -61,6 +61,58 @@ describe('computeWorktreeSidebarDropPreview', () => {
     expect(Array.from(preview?.previewOffsetsByWorktreeId ?? [])).toEqual([['sibling', -288]])
   })
 
+  it('keeps a partially mounted lineage unit anchored when inserting above it', () => {
+    const preview = computeWorktreeSidebarDropPreview({
+      pointerY: 100,
+      containerTop: 0,
+      scrollTop: 400,
+      rects: [
+        { worktreeId: 'parent', groupIndex: 1, top: 500, bottom: 590 },
+        { worktreeId: 'child-a', groupIndex: 2, top: 596, bottom: 686 },
+        { worktreeId: 'child-b', groupIndex: 3, top: 692, bottom: 782 },
+        { worktreeId: 'sibling', groupIndex: 4, top: 788, bottom: 888 },
+        { worktreeId: 'dragged', groupIndex: 5, top: 894, bottom: 994 }
+      ],
+      groupIds: ['offscreen', 'parent', 'sibling', 'dragged'],
+      draggedIds: ['dragged']
+    })
+
+    expect(preview).toMatchObject({
+      dropIndex: 1,
+      dropIndicatorY: 497
+    })
+    expect(Array.from(preview?.previewOffsetsByWorktreeId ?? [])).toEqual([
+      ['parent', 106],
+      ['sibling', 106]
+    ])
+  })
+
+  it('moves a partially mounted parent and its children as one unit', () => {
+    const preview = computeWorktreeSidebarDropPreview({
+      pointerY: 600,
+      containerTop: 0,
+      scrollTop: 400,
+      rects: [
+        { worktreeId: 'parent', groupIndex: 1, top: 500, bottom: 590 },
+        { worktreeId: 'child-a', groupIndex: 2, top: 596, bottom: 686 },
+        { worktreeId: 'child-b', groupIndex: 3, top: 692, bottom: 782 },
+        { worktreeId: 'sibling', groupIndex: 4, top: 788, bottom: 888 },
+        { worktreeId: 'tail', groupIndex: 5, top: 894, bottom: 994 }
+      ],
+      groupIds: ['offscreen', 'parent', 'sibling', 'tail'],
+      draggedIds: ['parent']
+    })
+
+    expect(preview).toMatchObject({
+      dropIndex: 4,
+      dropIndicatorY: 997
+    })
+    expect(Array.from(preview?.previewOffsetsByWorktreeId ?? [])).toEqual([
+      ['sibling', -288],
+      ['tail', -288]
+    ])
+  })
+
   it('uses one card-height placeholder for multi-select reorder previews', () => {
     const preview = computeWorktreeSidebarDropPreview({
       pointerY: 280,

--- a/src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-drop-preview.ts
@@ -17,7 +17,10 @@ export type WorktreeSidebarStatusDropTarget = {
 }
 
 export type WorktreeSidebarTrackedStatusDropTarget = {
-  target: WorktreeSidebarStatusDropTarget & { lineageParentId: string | null }
+  target: WorktreeSidebarStatusDropTarget & {
+    lineageParentId: string | null
+    lineageInsertionBeforeChildId?: string | null
+  }
   preview: WorktreeSidebarDropPreview | null
   x: number
   y: number
@@ -70,13 +73,19 @@ function hasWorktreeSidebarStatusDropTarget(
 }
 
 export function resolveWorktreeSidebarStatusDropCommitTarget(args: {
-  currentTarget: WorktreeSidebarStatusDropTarget & { lineageParentId?: string | null }
+  currentTarget: WorktreeSidebarStatusDropTarget & {
+    lineageParentId?: string | null
+    lineageInsertionBeforeChildId?: string | null
+  }
   currentPreview: WorktreeSidebarDropPreview | null
   latestTrackedTarget: WorktreeSidebarTrackedStatusDropTarget | null
   x: number
   y: number
 }): {
-  target: WorktreeSidebarStatusDropTarget & { lineageParentId?: string | null }
+  target: WorktreeSidebarStatusDropTarget & {
+    lineageParentId?: string | null
+    lineageInsertionBeforeChildId?: string | null
+  }
   preview: WorktreeSidebarDropPreview | null
 } {
   if (hasWorktreeSidebarStatusDropTarget(args.currentTarget)) {

--- a/tests/e2e/worktree-drag-autoscroll.spec.ts
+++ b/tests/e2e/worktree-drag-autoscroll.spec.ts
@@ -1,0 +1,152 @@
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { worktreeRow } from './worktree-row-locators'
+
+type LongDragScenario = {
+  childId: string
+  parentId: string
+  sourceId: string
+}
+
+async function seedLongDragScenario(page: Page): Promise<LongDragScenario> {
+  return page.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+    const state = store.getState()
+    const repo = state.repos[0]
+    const template = repo ? state.worktreesByRepo[repo.id]?.[0] : undefined
+    if (!repo || !template) {
+      throw new Error('Expected a seeded E2E workspace')
+    }
+
+    state.setActiveView('terminal')
+    state.setSidebarOpen(true)
+    state.setGroupBy('none')
+    state.setSortBy('manual')
+    state.setShowActiveOnly(false)
+    state.setShowSleepingWorkspaces(true)
+    state.setHideDefaultBranchWorkspace(false)
+    state.setFilterRepoIds([])
+
+    const syntheticWorktrees = Array.from({ length: 60 }, (_, index) => {
+      const suffix = String(index).padStart(2, '0')
+      return {
+        ...template,
+        id: `${repo.id}::drag-autoscroll-${suffix}`,
+        instanceId: `drag-autoscroll-${suffix}`,
+        path: `${template.path}-drag-autoscroll-${suffix}`,
+        displayName: `Drag autoscroll ${suffix}`,
+        branch: `drag-autoscroll-${suffix}`,
+        isMainWorktree: false,
+        manualOrder: 60 - index,
+        sortOrder: 60 - index
+      }
+    })
+    // Why: keep the lineage pair in the viewport after the drag has autoscrolled
+    // far enough to exercise virtual row refresh and measurement correction.
+    const parent = syntheticWorktrees[50]!
+    const child = syntheticWorktrees[51]!
+    const source = syntheticWorktrees[59]!
+
+    store.setState((current) => ({
+      worktreesByRepo: {
+        ...current.worktreesByRepo,
+        [repo.id]: [
+          ...(current.worktreesByRepo[repo.id] ?? []).map((worktree, index) => ({
+            ...worktree,
+            manualOrder: 100_000 - index
+          })),
+          ...syntheticWorktrees
+        ]
+      },
+      worktreeLineageById: {
+        ...current.worktreeLineageById,
+        [child.id]: {
+          worktreeId: child.id,
+          worktreeInstanceId: child.instanceId,
+          parentWorktreeId: parent.id,
+          parentWorktreeInstanceId: parent.instanceId,
+          origin: 'manual',
+          capture: { source: 'manual-action', confidence: 'explicit' },
+          createdAt: Date.now()
+        }
+      }
+    }))
+    return { childId: child.id, parentId: parent.id, sourceId: source.id }
+  })
+}
+
+test('keeps virtualized lineage rows populated while dragging upward', async ({ orcaPage }) => {
+  await waitForSessionReady(orcaPage)
+  await waitForActiveWorktree(orcaPage)
+  const scenario = await seedLongDragScenario(orcaPage)
+  const scroller = orcaPage.locator('[data-worktree-sidebar]')
+
+  await expect
+    .poll(() => scroller.evaluate((element) => element.scrollHeight))
+    .toBeGreaterThan(1000)
+  await scroller.evaluate((element) => {
+    element.scrollTop = element.scrollHeight
+  })
+
+  const source = worktreeRow(orcaPage, scenario.sourceId)
+  const parent = worktreeRow(orcaPage, scenario.parentId)
+  const child = worktreeRow(orcaPage, scenario.childId)
+  await expect(source).toBeVisible()
+  await expect(parent).toBeVisible()
+  await expect(child).toBeVisible()
+
+  const initialScrollTop = await scroller.evaluate((element) => element.scrollTop)
+  const sourceBox = await source.boundingBox()
+  const scrollerBox = await scroller.boundingBox()
+  if (!sourceBox || !scrollerBox) {
+    throw new Error('Expected sidebar drag geometry')
+  }
+  const initialLineageGap = await child.evaluate((element, parentId) => {
+    const parent = [...document.querySelectorAll<HTMLElement>('[data-worktree-id]')].find(
+      (candidate) => candidate.dataset.worktreeId === parentId
+    )
+    if (!parent) {
+      throw new Error('Expected mounted lineage parent')
+    }
+    return element.getBoundingClientRect().top - parent.getBoundingClientRect().top
+  }, scenario.parentId)
+
+  await orcaPage.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2)
+  await orcaPage.mouse.down()
+  try {
+    await orcaPage.mouse.move(sourceBox.x + sourceBox.width / 2, scrollerBox.y + 8, { steps: 12 })
+    await expect
+      .poll(() => scroller.evaluate((element) => element.scrollTop))
+      .toBeLessThan(initialScrollTop - 200)
+
+    const draggedGeometry = await orcaPage.evaluate(({ childId, parentId }) => {
+      const scroller = document.querySelector<HTMLElement>('[data-worktree-sidebar]')
+      const rowFor = (worktreeId: string) =>
+        [...document.querySelectorAll<HTMLElement>('[data-worktree-id]')].find(
+          (candidate) => candidate.dataset.worktreeId === worktreeId
+        )
+      const parent = rowFor(parentId)
+      const child = rowFor(childId)
+      if (!scroller || !parent || !child) {
+        return null
+      }
+      const scrollerRect = scroller.getBoundingClientRect()
+      const parentRect = parent.getBoundingClientRect()
+      const childRect = child.getBoundingClientRect()
+      return {
+        lineageGap: childRect.top - parentRect.top,
+        parentIntersectsViewport:
+          parentRect.bottom > scrollerRect.top && parentRect.top < scrollerRect.bottom
+      }
+    }, scenario)
+    expect(draggedGeometry).not.toBeNull()
+    expect(draggedGeometry!.parentIntersectsViewport).toBe(true)
+    expect(draggedGeometry!.lineageGap).toBeCloseTo(initialLineageGap, 0)
+  } finally {
+    await orcaPage.mouse.up()
+  }
+})


### PR DESCRIPTION
## Summary

- keep long workspace-list drags populated while autoscrolling upward
- support reliable parent/child nesting, unnesting, and reordering with visible insertion guides
- defer Workspace Board mounting until deliberate rightward drag intent

## Performance

- ordinary drag start: no long tasks across five measured runs; next frame at or below 16.6 ms
- lineage guide lookup: at or below 0.3 ms per frame, including three-level nesting
- upward autoscroll moved about 900 px in two seconds while keeping rows populated
- Workspace Board mount remains gated behind rightward intent

## Testing

- 108 focused Vitest tests across 9 files
- pnpm run typecheck
- targeted oxlint and oxfmt checks
- pnpm run check:max-lines-ratchet
- headless worktree drag autoscroll E2E