### PR TITLE
fix(editor): open external SSH file links

### DIFF
--- a/src/renderer/src/components/editor/useEditorPanelContentState.test.tsx
+++ b/src/renderer/src/components/editor/useEditorPanelContentState.test.tsx
@@ -14,7 +14,8 @@ const mocks = vi.hoisted(() => ({
   getConnectionId: vi.fn(),
   getConnectionIdForFile: vi.fn(),
   isWorktreeConnectionResolved: vi.fn(() => true),
-  getState: vi.fn()
+  getState: vi.fn(),
+  authorizeExternalPath: vi.fn()
 }))
 
 vi.mock('@/runtime/runtime-file-client', () => ({
@@ -145,6 +146,12 @@ describe('useEditorPanelContentState', () => {
       openFiles: [],
       setLastKnownDiskSignature: vi.fn()
     })
+    mocks.authorizeExternalPath.mockReset()
+    mocks.authorizeExternalPath.mockResolvedValue(undefined)
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { fs: { authorizeExternalPath: mocks.authorizeExternalPath } }
+    })
   })
 
   afterEach(() => {
@@ -188,6 +195,84 @@ describe('useEditorPanelContentState', () => {
         connectionId: 'ssh-1'
       })
     )
+  })
+
+  it('loads an external SSH path through its resolved remote connection', async () => {
+    const activeFile = createOpenFile({
+      id: '/tmp/orca-repro.txt',
+      filePath: '/tmp/orca-repro.txt',
+      relativePath: '/tmp/orca-repro.txt',
+      worktreeId: 'repo-ssh::/home/user/project'
+    })
+    mocks.getConnectionIdForFile.mockReturnValue('ssh-1')
+    mocks.readRuntimeFileContent.mockResolvedValue({ content: 'remote report', isBinary: false })
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    await act(async () => {
+      root?.render(<HookProbe activeFile={activeFile} openFiles={[activeFile]} />)
+    })
+
+    await vi.waitFor(() => expect(latestFileContents[activeFile.id]?.content).toBe('remote report'))
+    expect(mocks.authorizeExternalPath).not.toHaveBeenCalled()
+    expect(mocks.readRuntimeFileContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: '/tmp/orca-repro.txt',
+        connectionId: 'ssh-1'
+      })
+    )
+  })
+
+  it('reauthorizes an external local path before reading it', async () => {
+    const activeFile = createOpenFile({
+      id: '/tmp/local-report.txt',
+      filePath: '/tmp/local-report.txt',
+      relativePath: '/tmp/local-report.txt'
+    })
+    mocks.readRuntimeFileContent.mockResolvedValue({ content: 'local report', isBinary: false })
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    await act(async () => {
+      root?.render(<HookProbe activeFile={activeFile} openFiles={[activeFile]} />)
+    })
+
+    await vi.waitFor(() => expect(latestFileContents[activeFile.id]?.content).toBe('local report'))
+    expect(mocks.authorizeExternalPath).toHaveBeenCalledWith({
+      targetPath: '/tmp/local-report.txt'
+    })
+    expect(mocks.readRuntimeFileContent).toHaveBeenCalledWith(
+      expect.objectContaining({ filePath: '/tmp/local-report.txt', connectionId: undefined })
+    )
+  })
+
+  it('keeps external paths blocked for remote runtime workspaces', async () => {
+    const activeFile = createOpenFile({
+      id: '/tmp/runtime-report.txt',
+      filePath: '/tmp/runtime-report.txt',
+      relativePath: '/tmp/runtime-report.txt',
+      runtimeEnvironmentId: 'runtime-1'
+    })
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    await act(async () => {
+      root?.render(<HookProbe activeFile={activeFile} openFiles={[activeFile]} />)
+    })
+
+    await vi.waitFor(() =>
+      expect(latestFileContents[activeFile.id]?.loadError).toBe(
+        'External local files are not available for remote workspaces.'
+      )
+    )
+    expect(mocks.authorizeExternalPath).not.toHaveBeenCalled()
+    expect(mocks.readRuntimeFileContent).not.toHaveBeenCalled()
   })
 
   it('loads folder workspace branch diffs through the path-specific SSH connection', async () => {

--- a/src/renderer/src/components/editor/useEditorPanelContentState.ts
+++ b/src/renderer/src/components/editor/useEditorPanelContentState.ts
@@ -149,15 +149,14 @@ export function useEditorPanelContentState({
           throw new Error(WORKTREE_OWNER_NOT_READY_ERROR)
         }
         if (restoredOpenFile?.filePath === filePath && restoredOpenFile.relativePath === filePath) {
-          if (readSettings?.activeRuntimeEnvironmentId?.trim() || connectionId) {
-            // Why: restored external-file tabs contain client-local absolute
-            // paths. Remote runtime and SSH workspaces cannot read those paths
-            // without an explicit upload/import flow.
+          if (readSettings?.activeRuntimeEnvironmentId?.trim()) {
+            // Why: runtime 文件 RPC 受 worktree 限制，不能读取主机绝对路径。
             throw new Error('External local files are not available for remote workspaces.')
           }
-          // Why: restored external-file tabs need their main-process path grant
-          // refreshed because that authorization is only held in memory.
-          await window.api.fs.authorizeExternalPath({ targetPath: filePath })
+          if (!connectionId) {
+            // Why: 本地 external tab 的路径授权只保存在主进程内存中，恢复后必须重建。
+            await window.api.fs.authorizeExternalPath({ targetPath: filePath })
+          }
         }
         const readScope = getRuntimeFileReadScope(readSettings, connectionId)
         const key = inFlightReadKey(readScope, filePath)


### PR DESCRIPTION
## Summary

- Let editor tabs read host-absolute SSH paths through their resolved SSH connection.
- Skip local filesystem authorization only when a concrete SSH `connectionId` owns the path.
- Preserve the existing local external-path authorization and remote runtime worktree boundary.

Closes #9743

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` (blocked by the existing non-exhaustive switch in `src/renderer/src/components/skills/skill-freshness-group.tsx:101`)
- [x] `pnpm typecheck`
- [ ] `pnpm test` (171 related tests passed)
- [ ] `pnpm build` (`pnpm build:desktop` passed)
- [x] Added or updated high-quality tests that would catch regressions

The focused coverage verifies external SSH reads, local external-path authorization, remote runtime rejection, terminal file-link routing, runtime file reads, and connection ownership.

## AI Review Report

Reviewed the terminal-link-to-editor path, owner hydration guard, per-file SSH connection resolution, runtime owner selection, and local authorization flow. The review verified that macOS, Linux, and Windows all use the same provider-aware renderer branch; no keyboard shortcut, label, path separator, or Electron platform behavior changed. It also confirmed that an unresolved SSH owner still fails retryably instead of falling back to a local read.

## Security Audit

No dependencies, IPC messages, protocols, command execution, auth, or secret handling changed. Host-absolute paths bypass local authorization only when `getConnectionIdForFile` has resolved a concrete SSH owner; the read then goes through the existing SSH filesystem provider and connection boundary. Local paths still require `fs:authorizeExternalPath`, and paired runtime paths remain constrained to the owning worktree RPC.

## Notes

This change intentionally does not extend paired runtime file RPCs to host-absolute paths.
- X handle: N/A



## ELI5

Clicking a file link to an absolute path on an SSH host failed local authorization. Editor tabs can open those SSH paths through the owning connection while local path rules stay the same.
