### PR TITLE
fix(gitlab): refresh self-hosted provider detection

### DIFF
--- a/src/main/gitlab/client-mr.test.ts
+++ b/src/main/gitlab/client-mr.test.ts
@@ -65,6 +65,7 @@ import {
   updateMRReviewers
 } from './client'
 import { __resetRepoDefaultBranchCacheForTests } from '../source-control/repo-default-branch'
+import { _resetKnownHostsCache } from './gitlab-known-host-probe'
 
 /** Answer the real default-branch resolver probes (#9171 guard). */
 function primeGitDefaultBranch(defaultRef = 'refs/remotes/origin/main'): void {
@@ -92,6 +93,7 @@ describe('gitlab client — MR operations', () => {
     gitExecFileAsyncMock.mockReset()
     primeGitDefaultBranch()
     __resetRepoDefaultBranchCacheForTests()
+    _resetKnownHostsCache()
     _resetGitLabRateLimitCache()
     getGlabKnownHostsMock.mockResolvedValue(['gitlab.com'])
     resolveIssueSourceMock.mockResolvedValue({
@@ -287,6 +289,39 @@ describe('gitlab client — MR operations', () => {
       expect(glabExecFileAsyncMock).toHaveBeenCalledWith(['auth', 'status'], {
         allowDefaultWslFallback: false
       })
+    })
+
+    it('merges many authenticated hosts with one cache scan', async () => {
+      const hostCount = 256
+      glabExecFileAsyncMock.mockResolvedValueOnce({
+        stdout: Array.from(
+          { length: hostCount },
+          (_, index) => `Logged in to gitlab-${index}.example.test as user`
+        ).join('\n'),
+        stderr: ''
+      })
+      const originalMap = Array.prototype.map
+      let knownHostCacheScans = 0
+      const mapSpy = vi.spyOn(Array.prototype, 'map').mockImplementation(function (
+        this: unknown[],
+        callback: (value: unknown, index: number, array: unknown[]) => unknown,
+        thisArg?: unknown
+      ): unknown[] {
+        if (this[0] === 'gitlab.com' && this.every((value) => typeof value === 'string')) {
+          knownHostCacheScans += 1
+        }
+        return Reflect.apply(originalMap, this, [callback, thisArg])
+      })
+
+      try {
+        await expect(diagnoseAuth()).resolves.toMatchObject({
+          authenticated: true,
+          hosts: expect.any(Array)
+        })
+      } finally {
+        mapSpy.mockRestore()
+      }
+      expect(knownHostCacheScans).toBe(1)
     })
   })
 

--- a/src/main/gitlab/client.ts
+++ b/src/main/gitlab/client.ts
@@ -39,6 +39,7 @@ import {
   type LocalGitExecOptions,
   type ProjectRef
 } from './gl-utils'
+import { rememberGlabKnownHost } from './gitlab-known-host-probe'
 import type { IssueListState } from './issues'
 import {
   hasHostedReviewLocalGitOptions,
@@ -100,6 +101,10 @@ export async function diagnoseAuth(): Promise<GitLabAuthDiagnostic> {
     })
     const output = `${stdout}\n${stderr}`
     const hosts = parseGlabAuthStatusHosts(output)
+    // Why: Settings 刷新认证后要推进 provider cache key，避免继续命中认证前的 null 结果。
+    for (const host of hosts) {
+      rememberGlabKnownHost(host)
+    }
     return {
       glabAvailable: true,
       authenticated:

--- a/src/main/gitlab/client.ts
+++ b/src/main/gitlab/client.ts
@@ -39,7 +39,7 @@ import {
   type LocalGitExecOptions,
   type ProjectRef
 } from './gl-utils'
-import { rememberGlabKnownHost } from './gitlab-known-host-probe'
+import { rememberGlabKnownHosts } from './gitlab-known-host-probe'
 import type { IssueListState } from './issues'
 import {
   hasHostedReviewLocalGitOptions,
@@ -102,9 +102,7 @@ export async function diagnoseAuth(): Promise<GitLabAuthDiagnostic> {
     const output = `${stdout}\n${stderr}`
     const hosts = parseGlabAuthStatusHosts(output)
     // Why: refreshing auth must advance the provider cache key past a stale null result.
-    for (const host of hosts) {
-      rememberGlabKnownHost(host)
-    }
+    rememberGlabKnownHosts(hosts)
     return {
       glabAvailable: true,
       authenticated:

--- a/src/main/gitlab/client.ts
+++ b/src/main/gitlab/client.ts
@@ -101,7 +101,7 @@ export async function diagnoseAuth(): Promise<GitLabAuthDiagnostic> {
     })
     const output = `${stdout}\n${stderr}`
     const hosts = parseGlabAuthStatusHosts(output)
-    // Why: Settings 刷新认证后要推进 provider cache key，避免继续命中认证前的 null 结果。
+    // Why: refreshing auth must advance the provider cache key past a stale null result.
     for (const host of hosts) {
       rememberGlabKnownHost(host)
     }

--- a/src/main/gitlab/gitlab-known-host-probe.ts
+++ b/src/main/gitlab/gitlab-known-host-probe.ts
@@ -34,8 +34,8 @@ export function rememberGlabKnownHost(
 ): void {
   const normalizedHost = normalizeGitLabHost(host)
   const key = knownHostsExecutionKey(connectionId, localGitOptions)
-  const cached = knownHostsCacheByExecutionContext.get(key)
-  if (!cached || cached.map(normalizeGitLabHost).includes(normalizedHost)) {
+  const cached = knownHostsCacheByExecutionContext.get(key) ?? DEFAULT_GITLAB_HOSTS
+  if (cached.map(normalizeGitLabHost).includes(normalizedHost)) {
     return
   }
   knownHostsCacheByExecutionContext.set(key, [...cached, normalizedHost])
@@ -80,12 +80,13 @@ async function probeGlabKnownHosts(
         : {})
     })
     const hosts = parseGlabAuthStatusHosts(`${stdout}\n${stderr}`)
-    const merged = Array.from(new Set([...DEFAULT_GITLAB_HOSTS, ...hosts]))
+    const remembered = knownHostsCacheByExecutionContext.get(key) ?? []
+    const merged = Array.from(new Set([...DEFAULT_GITLAB_HOSTS, ...remembered, ...hosts]))
     knownHostsCacheByExecutionContext.set(key, merged)
     return merged
   } catch {
     // Keep failures uncached so auth or tunnel recovery is discovered later.
-    return [...DEFAULT_GITLAB_HOSTS]
+    return knownHostsCacheByExecutionContext.get(key) ?? [...DEFAULT_GITLAB_HOSTS]
   }
 }
 

--- a/src/main/gitlab/gitlab-known-host-probe.ts
+++ b/src/main/gitlab/gitlab-known-host-probe.ts
@@ -32,13 +32,30 @@ export function rememberGlabKnownHost(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
 ): void {
-  const normalizedHost = normalizeGitLabHost(host)
+  rememberGlabKnownHosts([host], connectionId, localGitOptions)
+}
+
+export function rememberGlabKnownHosts(
+  hosts: readonly string[],
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): void {
   const key = knownHostsExecutionKey(connectionId, localGitOptions)
   const cached = knownHostsCacheByExecutionContext.get(key) ?? DEFAULT_GITLAB_HOSTS
-  if (cached.map(normalizeGitLabHost).includes(normalizedHost)) {
+  const seen = new Set(cached.map(normalizeGitLabHost))
+  const additions: string[] = []
+  for (const host of hosts) {
+    const normalizedHost = normalizeGitLabHost(host)
+    if (seen.has(normalizedHost)) {
+      continue
+    }
+    seen.add(normalizedHost)
+    additions.push(normalizedHost)
+  }
+  if (additions.length === 0) {
     return
   }
-  knownHostsCacheByExecutionContext.set(key, [...cached, normalizedHost])
+  knownHostsCacheByExecutionContext.set(key, [...cached, ...additions])
 }
 
 export async function getGlabKnownHosts(

--- a/src/main/gitlab/gl-utils.test.ts
+++ b/src/main/gitlab/gl-utils.test.ts
@@ -25,7 +25,7 @@ import {
   parseGlabAuthStatusHosts,
   resolveIssueSource
 } from './gl-utils'
-import { rememberGlabKnownHost } from './gitlab-known-host-probe'
+import { rememberGlabKnownHost, rememberGlabKnownHosts } from './gitlab-known-host-probe'
 import { registerSshGitProvider, unregisterSshGitProvider } from '../providers/ssh-git-dispatch'
 
 describe('gitlab project ref resolution', () => {
@@ -561,6 +561,31 @@ describe('getGlabKnownHosts', () => {
       'wsl.test'
     ])
     await expect(getGlabKnownHosts('conn-1')).resolves.toEqual(['gitlab.com', 'ssh.test'])
+  })
+
+  it('batch-normalizes and deduplicates hosts in first-seen order per execution context', async () => {
+    rememberGlabKnownHosts([' Native-B.test ', 'native-a.test', 'NATIVE-B.TEST'])
+    rememberGlabKnownHosts(['WSL-B.test', ' wsl-a.test ', 'wsl-b.test'], undefined, {
+      wslDistro: 'Ubuntu'
+    })
+    rememberGlabKnownHosts(['SSH-B.test', 'ssh-a.test', ' ssh-b.test '], 'conn-batch')
+
+    await expect(getGlabKnownHosts()).resolves.toEqual([
+      'gitlab.com',
+      'native-b.test',
+      'native-a.test'
+    ])
+    await expect(getGlabKnownHosts(undefined, { wslDistro: 'Ubuntu' })).resolves.toEqual([
+      'gitlab.com',
+      'wsl-b.test',
+      'wsl-a.test'
+    ])
+    await expect(getGlabKnownHosts('conn-batch')).resolves.toEqual([
+      'gitlab.com',
+      'ssh-b.test',
+      'ssh-a.test'
+    ])
+    expect(glabExecFileAsyncMock).not.toHaveBeenCalled()
   })
 
   it('recognizes a self-hosted host on a non-default port', async () => {

--- a/src/main/gitlab/gl-utils.test.ts
+++ b/src/main/gitlab/gl-utils.test.ts
@@ -25,6 +25,7 @@ import {
   parseGlabAuthStatusHosts,
   resolveIssueSource
 } from './gl-utils'
+import { rememberGlabKnownHost } from './gitlab-known-host-probe'
 import { registerSshGitProvider, unregisterSshGitProvider } from '../providers/ssh-git-dispatch'
 
 describe('gitlab project ref resolution', () => {
@@ -501,6 +502,65 @@ describe('getGlabKnownHosts', () => {
       timeout: 10_000,
       wslDistro: 'Debian'
     })
+  })
+
+  it('preserves a native auth refresh while an older native probe is in flight', async () => {
+    let resolveProbe!: (value: { stdout: string; stderr: string }) => void
+    glabExecFileAsyncMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveProbe = resolve
+        })
+    )
+
+    const staleProbe = getGlabKnownHosts()
+    rememberGlabKnownHost('gitlab.refreshed.test')
+    resolveProbe({ stdout: 'Logged in to gitlab.com as user\n', stderr: '' })
+
+    await expect(staleProbe).resolves.toEqual(['gitlab.com', 'gitlab.refreshed.test'])
+    await expect(getGlabKnownHosts()).resolves.toEqual(['gitlab.com', 'gitlab.refreshed.test'])
+  })
+
+  it('preserves a native auth refresh when an older native probe fails', async () => {
+    let rejectProbe!: (error: Error) => void
+    glabExecFileAsyncMock.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectProbe = reject
+        })
+    )
+
+    const staleProbe = getGlabKnownHosts()
+    rememberGlabKnownHost('gitlab.refreshed.test')
+    rejectProbe(new Error('stale auth probe failed'))
+
+    await expect(staleProbe).resolves.toEqual(['gitlab.com', 'gitlab.refreshed.test'])
+    await expect(getGlabKnownHosts()).resolves.toEqual(['gitlab.com', 'gitlab.refreshed.test'])
+  })
+
+  it('keeps a remembered native host out of WSL and SSH caches', async () => {
+    glabExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'Logged in to native.test as user\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'Logged in to wsl.test as user\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'Logged in to ssh.test as user\n', stderr: '' })
+
+    await Promise.all([
+      getGlabKnownHosts(),
+      getGlabKnownHosts(undefined, { wslDistro: 'Ubuntu' }),
+      getGlabKnownHosts('conn-1')
+    ])
+    rememberGlabKnownHost('gitlab.refreshed.test')
+
+    await expect(getGlabKnownHosts()).resolves.toEqual([
+      'gitlab.com',
+      'native.test',
+      'gitlab.refreshed.test'
+    ])
+    await expect(getGlabKnownHosts(undefined, { wslDistro: 'Ubuntu' })).resolves.toEqual([
+      'gitlab.com',
+      'wsl.test'
+    ])
+    await expect(getGlabKnownHosts('conn-1')).resolves.toEqual(['gitlab.com', 'ssh.test'])
   })
 
   it('recognizes a self-hosted host on a non-default port', async () => {

--- a/src/main/source-control/hosted-review-creation-gitlab-self-hosted.test.ts
+++ b/src/main/source-control/hosted-review-creation-gitlab-self-hosted.test.ts
@@ -62,6 +62,7 @@ vi.mock('./hosted-review', () => ({
 }))
 
 import { _resetKnownHostsCache, _resetProjectRefCache } from '../gitlab/gl-utils'
+import { diagnoseAuth } from '../gitlab/client'
 import { getHostedReviewCreationEligibility } from './hosted-review-creation'
 
 function resetMocks(): void {
@@ -188,6 +189,66 @@ gitlab.internal
       canCreate: false,
       blockedReason: 'auth_required',
       nextAction: 'authenticate'
+    })
+  })
+
+  it('recovers provider detection after auth diagnostics discover a rejected host', async () => {
+    let selfHostedAuthenticated = false
+    getGiteaRepoSlugMock.mockResolvedValue({
+      host: 'gitlab.example.com',
+      owner: 'team',
+      repo: 'orca',
+      apiBaseUrl: 'https://gitlab.example.com/api/v1',
+      webBaseUrl: 'https://gitlab.example.com'
+    })
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: 'https://gitlab.example.com/team/orca.git\n',
+      stderr: ''
+    })
+    glabExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args.includes('--hostname')) {
+        if (!selfHostedAuthenticated) {
+          throw new Error('authentication required for gitlab.example.com')
+        }
+        return {
+          stdout: '✓ Logged in to gitlab.example.com as user\n',
+          stderr: ''
+        }
+      }
+      return selfHostedAuthenticated
+        ? {
+            stdout: '✓ Logged in to gitlab.example.com as user\n',
+            stderr: ''
+          }
+        : {
+            stdout: '✓ Logged in to gitlab.com as user\n',
+            stderr: ''
+          }
+    })
+
+    const eligibilityInput = {
+      repoPath: '/repo',
+      branch: 'feature/self-hosted-mr',
+      base: 'main',
+      hasUncommittedChanges: false,
+      hasUpstream: true,
+      ahead: 0,
+      behind: 0
+    }
+    await expect(getHostedReviewCreationEligibility(eligibilityInput)).resolves.toMatchObject({
+      provider: 'gitea',
+      blockedReason: 'auth_required'
+    })
+
+    selfHostedAuthenticated = true
+    await expect(diagnoseAuth()).resolves.toMatchObject({
+      authenticated: true,
+      hosts: ['gitlab.example.com']
+    })
+    await expect(getHostedReviewCreationEligibility(eligibilityInput)).resolves.toMatchObject({
+      provider: 'gitlab',
+      canCreate: true,
+      blockedReason: null
     })
   })
 })


### PR DESCRIPTION
## Summary

- Refresh native GitLab known-host state when the integration auth diagnostic discovers authenticated hosts.
- Let provider detection move past a cached pre-authentication miss without clearing unrelated repository caches.
- Preserve separate native, WSL, and SSH provider-cache scopes and the existing GitLab/GitHub/Bitbucket/Azure DevOps/Gitea detection order.

Closes #9656

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` (blocked by the existing non-exhaustive switch in `src/renderer/src/components/skills/skill-freshness-group.tsx:101`)
- [x] `pnpm typecheck`
- [ ] `pnpm test` (119 related tests passed)
- [ ] `pnpm build` (`pnpm build:desktop` passed)
- [x] Added or updated high-quality tests that would catch regressions

The regression test first caches a self-managed GitLab remote as Gitea while its GitLab host is unauthenticated, then verifies that a successful integration auth diagnostic restores GitLab MR eligibility without restarting Orca.

## AI Review Report

Reviewed self-managed GitLab remote parsing, `glab auth status` host extraction, negative project-ref cache keys, native/WSL/SSH execution scopes, forge provider ordering, and the final creation auth gate. The review confirmed that the change updates only the native cache used by the native diagnostic, does not use hostname heuristics, and leaves GitHub Enterprise and genuine Gitea detection intact. No UI shortcut, label, path, or Electron platform behavior changed.

## Security Audit

No dependencies, IPC messages, protocols, command execution, tokens, or credential storage changed. The cache accepts hosts only from the existing `glab auth status` parser; it does not expose token output or bypass the provider-specific authentication check before MR creation. WSL and SSH authentication state remains isolated from the native process cache.

## Notes

The change advances the project-ref cache key by updating known hosts instead of flushing all cached repository identities.
- X handle: N/A



## ELI5

Self-hosted GitLab could stay "unknown" after you authenticated because detection cached a pre-login miss. Successful auth now refreshes known hosts so provider detection moves on without wiping unrelated caches.
