### PR TITLE
fix(runtime): wait for Grok background tasks

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -12957,6 +12957,151 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('does not treat a Grok prompt as idle while a background task is active', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => 'grok'
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      runtime.onPtyData(
+        'pty-bg',
+        [
+          'Tasks 1\n',
+          'Task Background sleep 60 for Orca repro  33s\n',
+          'watching · 1 command\n',
+          ...Array.from({ length: 8 }, (_, index) => `foreground output ${index}\n`),
+          '\x1b]0;Grok ready\x07'
+        ].join(''),
+        Date.now()
+      )
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 5_000
+      })
+      const timeoutAssertion = expect(waitPromise).rejects.toThrow('timeout')
+
+      await vi.advanceTimersByTimeAsync(6_000)
+
+      await timeoutAssertion
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not apply Grok background-task counters to another agent session', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'codex'
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+    runtime.onPtyData('pty-bg', 'Tasks 1\nwatching · 1 command\n\x1b]0;Codex ready\x07', Date.now())
+
+    await expect(
+      runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 1_000 })
+    ).resolves.toMatchObject({ handle, condition: 'tui-idle', status: 'running' })
+  })
+
+  it('reports a blocked prompt while Grok background tasks remain active', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => 'grok'
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      runtime.onPtyData(
+        'pty-bg',
+        [
+          'Tasks 1\n',
+          'Task Background sleep 60 for Orca repro  33s\n',
+          'watching · 1 command\n',
+          '\x1b]0;⠋ - Watching - Grok\x07'
+        ].join(''),
+        Date.now()
+      )
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 10_000
+      })
+      runtime.onPtyData(
+        'pty-bg',
+        'Would you like to grant these permissions?\nPress enter to confirm\n',
+        Date.now()
+      )
+      await vi.advanceTimersByTimeAsync(2_100)
+
+      await expect(waitPromise).resolves.toMatchObject({
+        handle,
+        condition: 'tui-idle',
+        satisfied: false,
+        blockedReason: 'codex-interactive-prompt'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('resolves Grok tui-idle after the active background-task counters clear', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => 'grok'
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      runtime.onPtyData(
+        'pty-bg',
+        [
+          'Tasks 1\n',
+          'Task Background sleep 60 for Orca repro  33s\n',
+          'watching · 1 command\n',
+          '\x1b]0;⠋ - Watching - Grok\x07'
+        ].join(''),
+        Date.now()
+      )
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 10_000
+      })
+      let resolved = false
+      void waitPromise.then(() => {
+        resolved = true
+      })
+
+      runtime.onPtyData('pty-bg', '\x1b]0;Grok ready\x07', Date.now())
+      await vi.advanceTimersByTimeAsync(2_000)
+      expect(resolved).toBe(false)
+
+      runtime.onPtyData('pty-bg', 'Tasks 0\nwatching · 0 commands\n', Date.now())
+      await vi.advanceTimersByTimeAsync(2_000)
+
+      await expect(waitPromise).resolves.toMatchObject({
+        handle,
+        condition: 'tui-idle',
+        status: 'running'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('resolves tui-idle from a Codex ready prompt preview', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -22,6 +22,8 @@ import {
   type TerminalTitleTracker
 } from '../../shared/terminal-output-side-effects'
 import { createCommandCodeOutputStatusDetector } from '../../shared/command-code-output-status'
+import { hasActiveGrokBackgroundTasks } from '../../shared/grok-background-task-status'
+import { resolveExplicitTerminalTitleAgentType } from '../../shared/terminal-title-agent-type'
 import type {
   TerminalSideEffectBatch,
   TerminalSideEffectFact
@@ -1215,6 +1217,48 @@ type RuntimePtyWorktreeRecord = {
   waitBlockedAt: number | null
   // Why: memoized wait scan of the current retained tail (see RuntimeLeafRecord).
   tailWaitState?: TerminalTailWaitState
+}
+
+function isGrokRuntimeTerminal(
+  launchAgent: TuiAgent | null | undefined,
+  foregroundAgent: TuiAgent | null | undefined,
+  titles: readonly (string | null | undefined)[]
+): boolean {
+  return (
+    launchAgent === 'grok' ||
+    foregroundAgent === 'grok' ||
+    titles.some(
+      (title) => !!title && resolveExplicitTerminalTitleAgentType(title.trim()) === 'grok'
+    )
+  )
+}
+
+function ptyHasActiveGrokBackgroundTasks(
+  pty: RuntimePtyWorktreeRecord,
+  terminalText: string
+): boolean {
+  return hasActiveGrokBackgroundTasks(
+    terminalText,
+    isGrokRuntimeTerminal(pty.launchAgent, pty.foregroundAgent, [pty.lastOscTitle, pty.title])
+  )
+}
+
+function leafHasActiveGrokBackgroundTasks(
+  leaf: RuntimeLeafRecord,
+  pty: RuntimePtyWorktreeRecord | undefined,
+  tabTitle: string | null | undefined,
+  terminalText: string
+): boolean {
+  return hasActiveGrokBackgroundTasks(
+    terminalText,
+    isGrokRuntimeTerminal(pty?.launchAgent, pty?.foregroundAgent, [
+      leaf.lastOscTitle,
+      leaf.paneTitle,
+      tabTitle,
+      pty?.lastOscTitle,
+      pty?.title
+    ])
+  )
 }
 
 type TerminalCreateOptions = {
@@ -14561,14 +14605,20 @@ export class OrcaRuntimeService {
         pty.pty.preview
       )
       const ptyBlockedReason = detectTerminalWaitBlockedReason(ptyWaitText)
+      const ptyHasActiveBackgroundTasks = ptyHasActiveGrokBackgroundTasks(pty.pty, ptyWaitText)
       if (condition === 'tui-idle' && ptyBlockedReason) {
         return buildPtyTerminalWaitBlockedResult(handle, condition, pty.pty, ptyBlockedReason)
       }
-      if (condition === 'tui-idle' && pty.pty.lastAgentStatus === 'idle') {
+      if (
+        condition === 'tui-idle' &&
+        !ptyHasActiveBackgroundTasks &&
+        pty.pty.lastAgentStatus === 'idle'
+      ) {
         return buildPtyTerminalWaitResult(handle, condition, pty.pty)
       }
       if (
         condition === 'tui-idle' &&
+        !ptyHasActiveBackgroundTasks &&
         (this.getAdoptedPtyExplicitIdleStatus(pty.pty) === 'idle' ||
           isKnownReadyPromptPreview(ptyWaitText))
       ) {
@@ -14619,16 +14669,21 @@ export class OrcaRuntimeService {
             live.pty.preview
           )
           const blockedReason = detectTerminalWaitBlockedReason(livePtyWaitText)
+          const hasActiveBackgroundTasks = ptyHasActiveGrokBackgroundTasks(
+            live.pty,
+            livePtyWaitText
+          )
           if (blockedReason) {
             this.resolveWaiter(
               waiter,
               buildPtyTerminalWaitBlockedResult(handle, condition, live.pty, blockedReason)
             )
-          } else if (live.pty.lastAgentStatus === 'idle') {
+          } else if (!hasActiveBackgroundTasks && live.pty.lastAgentStatus === 'idle') {
             this.resolveWaiter(waiter, buildPtyTerminalWaitResult(handle, condition, live.pty))
           } else if (
-            this.getAdoptedPtyExplicitIdleStatus(live.pty) === 'idle' ||
-            isKnownReadyPromptPreview(livePtyWaitText)
+            !hasActiveBackgroundTasks &&
+            (this.getAdoptedPtyExplicitIdleStatus(live.pty) === 'idle' ||
+              isKnownReadyPromptPreview(livePtyWaitText))
           ) {
             this.resolveWaiter(waiter, buildPtyTerminalWaitResult(handle, condition, live.pty))
           } else {
@@ -14645,6 +14700,12 @@ export class OrcaRuntimeService {
 
     const leafWaitText = buildTerminalWaitText(leaf.tailBuffer, leaf.tailPartialLine, leaf.preview)
     const leafBlockedReason = detectTerminalWaitBlockedReason(leafWaitText)
+    const leafHasActiveBackgroundTasks = leafHasActiveGrokBackgroundTasks(
+      leaf,
+      leaf.ptyId ? this.ptysById.get(leaf.ptyId) : undefined,
+      this.tabs.get(leaf.tabId)?.title,
+      leafWaitText
+    )
     if (condition === 'tui-idle' && leafBlockedReason) {
       return buildTerminalWaitBlockedResult(handle, condition, leaf, leafBlockedReason)
     }
@@ -14654,14 +14715,19 @@ export class OrcaRuntimeService {
     // detection that powers the renderer's "Task complete" notifications.
     // Why: only 'idle' satisfies tui-idle, not 'permission'. Permission means the
     // agent is blocked on user approval, not finished with its task.
-    if (condition === 'tui-idle' && leaf.lastAgentStatus === 'idle') {
+    if (
+      condition === 'tui-idle' &&
+      !leafHasActiveBackgroundTasks &&
+      leaf.lastAgentStatus === 'idle'
+    ) {
       return buildTerminalWaitResult(handle, condition, leaf)
     }
     if (condition === 'tui-idle') {
       const fastPathTitle = leaf.paneTitle ?? this.tabs.get(leaf.tabId)?.title
       if (
-        (fastPathTitle && detectExplicitIdleStatusFromTitle(fastPathTitle) === 'idle') ||
-        isKnownReadyPromptPreview(leafWaitText)
+        !leafHasActiveBackgroundTasks &&
+        ((fastPathTitle && detectExplicitIdleStatusFromTitle(fastPathTitle) === 'idle') ||
+          isKnownReadyPromptPreview(leafWaitText))
       ) {
         return buildTerminalWaitResult(handle, condition, leaf)
       }
@@ -14721,12 +14787,18 @@ export class OrcaRuntimeService {
             live.leaf.preview
           )
           const blockedReason = detectTerminalWaitBlockedReason(liveLeafWaitText)
+          const hasActiveBackgroundTasks = leafHasActiveGrokBackgroundTasks(
+            live.leaf,
+            live.leaf.ptyId ? this.ptysById.get(live.leaf.ptyId) : undefined,
+            this.tabs.get(live.leaf.tabId)?.title,
+            liveLeafWaitText
+          )
           if (blockedReason) {
             this.resolveWaiter(
               waiter,
               buildTerminalWaitBlockedResult(handle, condition, live.leaf, blockedReason)
             )
-          } else if (live.leaf.lastAgentStatus === 'idle') {
+          } else if (!hasActiveBackgroundTasks && live.leaf.lastAgentStatus === 'idle') {
             // Why: don't clear lastAgentStatus here. It's a factual record of the
             // last detected OSC state, not a one-shot signal. Clearing it causes
             // subsequent tui-idle waiters to hang even though the agent is idle —
@@ -14738,8 +14810,9 @@ export class OrcaRuntimeService {
             // preview/title until the waiter resolves or hits its timeout.
             const fastPathTitle = live.leaf.paneTitle ?? this.tabs.get(live.leaf.tabId)?.title
             if (
-              (fastPathTitle && detectExplicitIdleStatusFromTitle(fastPathTitle) === 'idle') ||
-              isKnownReadyPromptPreview(liveLeafWaitText)
+              !hasActiveBackgroundTasks &&
+              ((fastPathTitle && detectExplicitIdleStatusFromTitle(fastPathTitle) === 'idle') ||
+                isKnownReadyPromptPreview(liveLeafWaitText))
             ) {
               this.resolveWaiter(waiter, buildTerminalWaitResult(handle, condition, live.leaf))
             } else {
@@ -27855,6 +27928,17 @@ export class OrcaRuntimeService {
   }
 
   private resolveTuiIdleWaiters(leaf: RuntimeLeafRecord): void {
+    const waitText = buildTerminalWaitText(leaf.tailBuffer, leaf.tailPartialLine, leaf.preview)
+    if (
+      leafHasActiveGrokBackgroundTasks(
+        leaf,
+        leaf.ptyId ? this.ptysById.get(leaf.ptyId) : undefined,
+        this.tabs.get(leaf.tabId)?.title,
+        waitText
+      )
+    ) {
+      return
+    }
     const handle = this.handleByLeafKey.get(this.getLeafKey(leaf.tabId, leaf.leafId))
     if (!handle) {
       return
@@ -27890,6 +27974,10 @@ export class OrcaRuntimeService {
   }
 
   private resolvePtyTuiIdleWaiters(pty: RuntimePtyWorktreeRecord, ptyId: string): void {
+    const waitText = buildTerminalWaitText(pty.tailBuffer, pty.tailPartialLine, pty.preview)
+    if (ptyHasActiveGrokBackgroundTasks(pty, waitText)) {
+      return
+    }
     const handle = this.handleByPtyId.get(ptyId)
     if (!handle) {
       return
@@ -27914,6 +28002,33 @@ export class OrcaRuntimeService {
       }
       let startedForegroundPoll = false
       try {
+        const leafWaitText = buildTerminalWaitText(
+          leaf.tailBuffer,
+          leaf.tailPartialLine,
+          leaf.preview
+        )
+        const blockedReason = detectTerminalWaitBlockedReason(leafWaitText)
+        if (blockedReason) {
+          if (waiter.pollInterval) {
+            clearInterval(waiter.pollInterval)
+            waiter.pollInterval = null
+          }
+          this.resolveWaiter(
+            waiter,
+            buildTerminalWaitBlockedResult(waiter.handle, 'tui-idle', leaf, blockedReason)
+          )
+          return
+        }
+        if (
+          leafHasActiveGrokBackgroundTasks(
+            leaf,
+            leaf.ptyId ? this.ptysById.get(leaf.ptyId) : undefined,
+            this.tabs.get(leaf.tabId)?.title,
+            leafWaitText
+          )
+        ) {
+          return
+        }
         if (leaf.lastAgentStatus === 'idle') {
           if (waiter.pollInterval) {
             clearInterval(waiter.pollInterval)
@@ -27934,23 +28049,6 @@ export class OrcaRuntimeService {
             this.resolveWaiter(waiter, buildTerminalWaitResult(waiter.handle, 'tui-idle', leaf))
             return
           }
-        }
-        const leafWaitText = buildTerminalWaitText(
-          leaf.tailBuffer,
-          leaf.tailPartialLine,
-          leaf.preview
-        )
-        const blockedReason = detectTerminalWaitBlockedReason(leafWaitText)
-        if (blockedReason) {
-          if (waiter.pollInterval) {
-            clearInterval(waiter.pollInterval)
-            waiter.pollInterval = null
-          }
-          this.resolveWaiter(
-            waiter,
-            buildTerminalWaitBlockedResult(waiter.handle, 'tui-idle', leaf, blockedReason)
-          )
-          return
         }
         if (isKnownReadyPromptPreview(leafWaitText)) {
           if (waiter.pollInterval) {
@@ -27999,14 +28097,6 @@ export class OrcaRuntimeService {
       }
       let startedForegroundPoll = false
       try {
-        if (pty.lastAgentStatus === 'idle') {
-          if (waiter.pollInterval) {
-            clearInterval(waiter.pollInterval)
-            waiter.pollInterval = null
-          }
-          this.resolveWaiter(waiter, buildPtyTerminalWaitResult(waiter.handle, 'tui-idle', pty))
-          return
-        }
         const ptyWaitText = buildTerminalWaitText(pty.tailBuffer, pty.tailPartialLine, pty.preview)
         const blockedReason = detectTerminalWaitBlockedReason(ptyWaitText)
         if (blockedReason) {
@@ -28018,6 +28108,17 @@ export class OrcaRuntimeService {
             waiter,
             buildPtyTerminalWaitBlockedResult(waiter.handle, 'tui-idle', pty, blockedReason)
           )
+          return
+        }
+        if (ptyHasActiveGrokBackgroundTasks(pty, ptyWaitText)) {
+          return
+        }
+        if (pty.lastAgentStatus === 'idle') {
+          if (waiter.pollInterval) {
+            clearInterval(waiter.pollInterval)
+            waiter.pollInterval = null
+          }
+          this.resolveWaiter(waiter, buildPtyTerminalWaitResult(waiter.handle, 'tui-idle', pty))
           return
         }
         // Why: adopted background PTY handles use their live xterm title as the same readiness signal as leaf handles.

--- a/src/shared/grok-background-task-status.test.ts
+++ b/src/shared/grok-background-task-status.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { hasActiveGrokBackgroundTasks } from './grok-background-task-status'
+
+describe('hasActiveGrokBackgroundTasks', () => {
+  it('detects the active background-task status rendered by Grok', () => {
+    expect(
+      hasActiveGrokBackgroundTasks(
+        ['Tasks 1', 'Task Background sleep 60 for Orca repro  33s', 'watching · 1 command'].join(
+          '\n'
+        ),
+        true
+      )
+    ).toBe(true)
+    expect(hasActiveGrokBackgroundTasks('Tasks 3\nwatching · 3 commands', true)).toBe(true)
+  })
+
+  it('uses the latest counts when retained output contains an older active state', () => {
+    expect(
+      hasActiveGrokBackgroundTasks(
+        ['Tasks 1', 'watching · 1 command', 'Tasks 0', 'watching · 0 commands'].join('\n'),
+        true
+      )
+    ).toBe(false)
+  })
+
+  it('ignores matching counters outside a recognized Grok session', () => {
+    expect(hasActiveGrokBackgroundTasks('Tasks 1\nwatching · 1 command', false)).toBe(false)
+  })
+
+  it('requires both Grok status counters to avoid matching ordinary output', () => {
+    expect(hasActiveGrokBackgroundTasks('Tasks 1\nready for input', true)).toBe(false)
+    expect(hasActiveGrokBackgroundTasks('watching · 1 command', true)).toBe(false)
+    expect(hasActiveGrokBackgroundTasks('Tasks 0\nwatching · 0 commands', true)).toBe(false)
+  })
+})

--- a/src/shared/grok-background-task-status.ts
+++ b/src/shared/grok-background-task-status.ts
@@ -1,0 +1,22 @@
+const TASK_COUNT_RE = /\btasks\s+(\d+)\b/gi
+const WATCHING_COUNT_RE = /\bwatching\s*·\s*(\d+)\s+commands?\b/gi
+
+function readLatestCount(text: string, pattern: RegExp): number | null {
+  let count: number | null = null
+  for (const match of text.matchAll(pattern)) {
+    count = Number(match[1])
+  }
+  return count
+}
+
+export function hasActiveGrokBackgroundTasks(
+  terminalText: string,
+  isGrokSession: boolean
+): boolean {
+  if (!isGrokSession) {
+    return false
+  }
+  const taskCount = readLatestCount(terminalText, TASK_COUNT_RE)
+  const watchingCount = readLatestCount(terminalText, WATCHING_COUNT_RE)
+  return taskCount !== null && taskCount > 0 && watchingCount !== null && watchingCount > 0
+}


### PR DESCRIPTION
## Summary

- Keep `tui-idle` pending while a confirmed Grok session still reports active background tasks.
- Read the latest Grok task counters from the bounded retained terminal tail so status is not lost when the short preview scrolls.
- Keep blocked and permission prompts higher priority than the background-task gate across PTY, leaf, daemon, and fallback-poll paths.

Fixes #9905

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
  - Touched-file Oxlint passed.
- [ ] `pnpm typecheck`
  - `pnpm typecheck:node` passed.
- [ ] `pnpm test`
  - Related runtime and shared parser tests passed: 2 files, 859 tests.
- [ ] `pnpm build`
  - Not run; this change does not alter build configuration or bundled assets.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional repository gates passed: touched-file Oxfmt, `git diff --check`, max-lines ratchet, and reliability gates.

## AI Review Report

The review checked the three reported failure modes: counters scrolling outside the 6-line preview, matching similar output from non-Grok CLIs, and blocked or permission prompts being hidden by the background-task gate. The implementation now scans the bounded retained tail only at wait registration, idle transitions, and the 2-second fallback poll; requires Grok identity from launch metadata, foreground-agent detection, or an explicit Grok title; and checks blocked state before the task gate. Regression tests cover each case.

The review also checked PTY and leaf handles, adopted/background PTYs, daemon-hosted terminals, SSH sessions, fallback polling, and repeated counter updates. Cross-platform compatibility was reviewed for macOS, Linux, and Windows. This change does not alter shortcuts, labels, filesystem paths, shell commands, Electron platform branches, or Git-provider behavior.

## Security Audit

This change only parses already-retained terminal text and existing agent metadata. It adds no command execution, path handling, authentication, secrets, dependencies, network access, or IPC surface. The scanned text remains bounded by the existing 256 KiB retained-tail limit, and parser results do not leave the runtime process. No follow-up security work is needed.

## Notes

- Grok background-task detection is deliberately disabled unless the runtime can identify the session as Grok.
- No UI, platform-specific, remote-only, or Git-provider-specific behavior is introduced.
- X/Twitter: N/A (no account)



## ELI5

Waiting for Grok to be "idle" returned too early while background tasks were still running. tui-idle now stays pending until those tasks finish so automation does not inject the next step too soon.
