### PR TITLE
fix(terminal): keep agent resume records durable across restarts

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -240,6 +240,8 @@ type StoreState = {
   getAgentLaunchConfigForStatusEntry: ReturnType<typeof vi.fn>
   getAgentLaunchConfigForStatusMetadata: ReturnType<typeof vi.fn>
   clearSleepingAgentSession: ReturnType<typeof vi.fn>
+  automaticAgentResumeClaimsByTabId: Record<string, unknown>
+  claimAutomaticAgentResume: ReturnType<typeof vi.fn>
   registerAgentLaunchConfig: ReturnType<typeof vi.fn>
   clearAgentLaunchConfig: ReturnType<typeof vi.fn>
   markWorktreeUnread: ReturnType<typeof vi.fn>
@@ -949,6 +951,8 @@ describe('connectPanePty', () => {
       clearSleepingAgentSession: vi.fn((paneKey: string) => {
         delete mockStoreState.sleepingAgentSessionsByPaneKey[paneKey]
       }),
+      automaticAgentResumeClaimsByTabId: {},
+      claimAutomaticAgentResume: vi.fn(),
       registerAgentLaunchConfig: vi.fn(),
       clearAgentLaunchConfig: vi.fn(),
       markWorktreeUnread: vi.fn(),
@@ -3449,7 +3453,17 @@ describe('connectPanePty', () => {
 
     deferredSpawn.resolve('pty-resumed')
     await flushAsyncTicks()
-    expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledWith(paneKey)
+    // Why: the hibernated record must survive the in-place wake spawn too — it
+    // shares applyColdRestoreAgentResumeStartup/clearSleepingRecordAfterColdRestoreSpawn
+    // with disk-backed cold restore, so a failed wake must not lose the
+    // session; an automatic-resume claim is registered instead (Task 2).
+    expect(mockStoreState.clearSleepingAgentSession).not.toHaveBeenCalledWith(paneKey)
+    expect(mockStoreState.sleepingAgentSessionsByPaneKey[paneKey]).toBeDefined()
+    expect(mockStoreState.claimAutomaticAgentResume).toHaveBeenCalledWith('tab-1', {
+      worktreeId: 'wt-1',
+      launchAgent: 'claude',
+      providerSession: { key: 'session_id', id: 'sess-hibernated-inflight' }
+    })
   })
 
   it('re-arms the exact hibernation target after a replacement spawn fails', async () => {
@@ -18136,7 +18150,15 @@ describe('connectPanePty', () => {
     expect(deps.updateTabPtyId).toHaveBeenCalledWith('tab-1', freshPtyId)
     expect(window.api.pty.reportRendererSerializerReady).toHaveBeenCalledWith(freshPtyId)
     expect(transport.sendInput).not.toHaveBeenCalled()
-    expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledWith(paneKey)
+    // Why: the record must survive the spawn — it is only replaced once the
+    // resumed agent's hook event confirms the session (Task 1's path).
+    expect(mockStoreState.clearSleepingAgentSession).not.toHaveBeenCalledWith(paneKey)
+    expect(mockStoreState.sleepingAgentSessionsByPaneKey[paneKey]).toBeDefined()
+    expect(mockStoreState.claimAutomaticAgentResume).toHaveBeenCalledWith('tab-1', {
+      worktreeId: 'wt-1',
+      launchAgent: 'codex',
+      providerSession: { key: 'session_id', id: 'codex-session-1' }
+    })
   })
 
   it('does not let a restored encoded PTY override the current worktree owner', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -8343,7 +8343,12 @@ describe('connectPanePty', () => {
       expect(deps.clearTabPtyId).toHaveBeenCalledWith('tab-1', 'restored-session')
       expect(deps.syncPanePtyLayoutBinding).not.toHaveBeenCalledWith(2, 'restored-session')
       expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(2, 'fresh-resume-pty')
-      expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledWith(paneKey)
+      expect(mockStoreState.clearSleepingAgentSession).not.toHaveBeenCalledWith(paneKey)
+      expect(mockStoreState.claimAutomaticAgentResume).toHaveBeenCalledWith('tab-1', {
+        worktreeId: 'wt-1',
+        launchAgent: 'codex',
+        providerSession: { key: 'session_id', id: 'codex-session-1' }
+      })
       expect(window.api.pty.clearPendingPaneSerializer).toHaveBeenCalledWith(paneKey, 1)
     } finally {
       globalThis.setTimeout = originalSetTimeout
@@ -10015,8 +10020,12 @@ describe('connectPanePty', () => {
         })
       })
     )
-    // Why: consuming the record prevents a later worktree activation from launching a duplicate resume tab.
-    expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledWith(paneKey)
+    expect(mockStoreState.clearSleepingAgentSession).not.toHaveBeenCalledWith(paneKey)
+    expect(mockStoreState.claimAutomaticAgentResume).toHaveBeenCalledWith('tab-1', {
+      worktreeId: 'wt-1',
+      launchAgent: 'codex',
+      providerSession: { key: 'session_id', id: 'codex-session-1', transcriptPath }
+    })
   })
 
   it('marks the pane as freshly started when main declined an unverifiable resume', async () => {
@@ -10822,7 +10831,12 @@ describe('connectPanePty', () => {
     )
     expect(deps.onShowSessionRestoredBanner).toHaveBeenCalledTimes(1)
     expect(deps.onShowSessionRestoredBanner).toHaveBeenCalledWith(2, 'restored')
-    expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledWith(paneKey)
+    expect(mockStoreState.clearSleepingAgentSession).not.toHaveBeenCalledWith(paneKey)
+    expect(mockStoreState.claimAutomaticAgentResume).toHaveBeenCalledWith('tab-1', {
+      worktreeId: 'wt-1',
+      launchAgent: 'codex',
+      providerSession: { key: 'session_id', id: 'codex-session-1' }
+    })
   })
 
   it('resumes a local sleeping pane in place when the restored PTY hint is missing', async () => {
@@ -10925,7 +10939,12 @@ describe('connectPanePty', () => {
 
     expect(deps.onShowSessionRestoredBanner).toHaveBeenCalledTimes(1)
     expect(deps.onShowSessionRestoredBanner).toHaveBeenCalledWith(2, 'restored')
-    expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledWith(paneKey)
+    expect(mockStoreState.clearSleepingAgentSession).not.toHaveBeenCalledWith(paneKey)
+    expect(mockStoreState.claimAutomaticAgentResume).toHaveBeenCalledWith('tab-1', {
+      worktreeId: 'wt-1',
+      launchAgent: 'codex',
+      providerSession: { key: 'session_id', id: 'codex-session-1' }
+    })
   })
 
   it('says the fresh-spawn resume started fresh when main declined it', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -5026,8 +5026,8 @@ export function connectPanePty(
         leafId: pane.leafId
       })
       if (!startup.useLiveEntry && startup.sleepingRecordEntry) {
-        // Why: the record now survives this spawn, so a claim is what blocks
-        // worktree-activation from double-launching the same provider session.
+        // Why: claims are keyed per tab, so a split tab's second pane overwrites
+        // the first's; resumeSleepingAgentSessionsForWorktree's pane-owned check backstops split-tab safety.
         state.claimAutomaticAgentResume(deps.tabId, {
           worktreeId: deps.worktreeId,
           launchAgent: startup.agent,

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1221,12 +1221,19 @@ export function connectPanePty(
     'legacy-orchestration-worker'
   const clearSleepingRecordProviderDuplicates = (
     state: ReturnType<typeof useAppStore.getState>,
-    consumed: { paneKey: string; record: SleepingAgentSessionRecord }
+    consumed: { paneKey: string; record: SleepingAgentSessionRecord },
+    // Why: a failed cold-restore spawn must not lose the session, so the
+    // resuming pane's own key is excluded from the clear (legacy aliases lack
+    // this protection — they never receive the resumed agent's hook event).
+    excludePaneKey?: string
   ): void => {
-    state.clearSleepingAgentSession(consumed.paneKey)
+    if (consumed.paneKey !== excludePaneKey) {
+      state.clearSleepingAgentSession(consumed.paneKey)
+    }
     for (const [paneKey, record] of Object.entries(state.sleepingAgentSessionsByPaneKey)) {
       if (
         paneKey !== consumed.paneKey &&
+        paneKey !== excludePaneKey &&
         record.worktreeId === consumed.record.worktreeId &&
         record.agent === consumed.record.agent &&
         agentProviderSessionsEqual(
@@ -5018,13 +5025,28 @@ export function connectPanePty(
         tabId: deps.tabId,
         leafId: pane.leafId
       })
+      if (!startup.useLiveEntry && startup.sleepingRecordEntry) {
+        // Why: the record now survives this spawn, so a claim is what blocks
+        // worktree-activation from double-launching the same provider session.
+        state.claimAutomaticAgentResume(deps.tabId, {
+          worktreeId: deps.worktreeId,
+          launchAgent: startup.agent,
+          providerSession: startup.sleepingRecordEntry.record.providerSession
+        })
+      }
       return true
     }
     const clearSleepingRecordAfterColdRestoreSpawn = (
       startup: ColdRestoreAgentResumeStartup | null
     ): void => {
       if (startup && !startup.useLiveEntry && startup.sleepingRecordEntry) {
-        clearSleepingRecordProviderDuplicates(useAppStore.getState(), startup.sleepingRecordEntry)
+        // Why: only clear duplicate aliases here — the spawning pane's own
+        // record survives until the resumed agent's hook event confirms it.
+        clearSleepingRecordProviderDuplicates(
+          useAppStore.getState(),
+          startup.sleepingRecordEntry,
+          cacheKey
+        )
       }
     }
     const mergeStartupEnvWithPaneIdentity = (

--- a/src/renderer/src/lib/agent-hibernation-planner.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.ts
@@ -7,7 +7,6 @@ import {
 } from '../../../shared/agent-session-resume'
 import { parsePaneKey } from '../../../shared/stable-pane-id'
 import { lastInputBlocksHibernation } from './agent-hibernation-input-guard'
-import { isCompletedPiCompatibleAgentWithLiveRecoveryRecord } from './pi-compatible-live-recovery-record'
 import type { GlobalSettings, TerminalLayoutSnapshot, TerminalTab } from '../../../shared/types'
 import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
 
@@ -140,16 +139,16 @@ function getEligiblePane(args: {
     mobileLockedPtyIds
   } = args
   const sleepingRecord = sleepingAgentSessionsByPaneKey[entry.paneKey]
-  // Why: a Pi-compatible done hook ends a turn, not its TUI. Its live
+  // Why: a resumable done hook ends a turn, not its TUI. Its live
   // recovery checkpoint must not make the pane look already hibernated.
-  const hasOnlyLivePiCompatibleRecoveryIdentity =
-    isCompletedPiCompatibleAgentWithLiveRecoveryRecord(entry, sleepingRecord, tab.worktreeId)
   if (
     entry.state !== 'done' ||
     entry.interrupted === true ||
     Boolean(entry.subagents?.length) ||
     hasUnsettledOrUnknownDispatch(entry) ||
-    (sleepingRecord && !hasOnlyLivePiCompatibleRecoveryIdentity)
+    (sleepingRecord &&
+      (!isCompletedAgentWithLiveRecoveryRecord(entry, sleepingRecord) ||
+        sleepingRecord.worktreeId !== tab.worktreeId))
   ) {
     return null
   }

--- a/src/renderer/src/lib/agent-hibernation-planner.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.ts
@@ -1,6 +1,7 @@
 import type { AgentStatusEntry } from '../../../shared/agent-status-types'
 import {
   getAgentResumeArgv,
+  isCompletedAgentWithLiveRecoveryRecord,
   isResumableTuiAgent,
   type SleepingAgentSessionRecord
 } from '../../../shared/agent-session-resume'

--- a/src/renderer/src/lib/pi-live-session-no-duplicate-tab.test.ts
+++ b/src/renderer/src/lib/pi-live-session-no-duplicate-tab.test.ts
@@ -13,6 +13,7 @@ afterEach(() => {
 
 describe('Pi live session does not spawn a duplicate resume tab', () => {
   it('keeps a done-but-alive Pi pane instead of forking a new tab', () => {
+    const capturedAt = Date.now()
     const providerSession = {
       key: 'session_id' as const,
       id: 'pi-1',
@@ -26,8 +27,8 @@ describe('Pi live session does not spawn a duplicate resume tab', () => {
       providerSession,
       prompt: '',
       state: 'working',
-      capturedAt: 1,
-      updatedAt: 1,
+      capturedAt,
+      updatedAt: capturedAt,
       origin: 'live'
     }
     useAppStore.setState({

--- a/src/renderer/src/lib/pi-session-resume-wake.test.ts
+++ b/src/renderer/src/lib/pi-session-resume-wake.test.ts
@@ -28,8 +28,10 @@ describe('Pi session wake', () => {
       providerSession,
       prompt: '',
       state: 'working',
-      capturedAt: 1,
-      updatedAt: 1,
+      // Why: the activation gate rejects records older than the absolute
+      // max age, so fixtures must use current timestamps.
+      capturedAt: Date.now(),
+      updatedAt: Date.now(),
       origin: 'worktree-sleep'
     }
     const tab: TerminalTab = {

--- a/src/renderer/src/lib/resume-sleeping-agent-session-activation-gate.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-activation-gate.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import { isInvalidWorktreeActivationRecord } from './resume-sleeping-agent-session'
+
+describe('isInvalidWorktreeActivationRecord age policy', () => {
+  const baseRecord = {
+    paneKey: 'tab-1:leaf-1',
+    tabId: 'tab-1',
+    worktreeId: 'wt-1',
+    agent: 'claude',
+    providerSession: { key: 'session_id', id: 's1' },
+    prompt: '',
+    state: 'waiting',
+    origin: 'quit'
+  } as const
+
+  it('accepts a record that idled hours before quit', () => {
+    const now = Date.now()
+    // capturedAt at quit, updatedAt 3 hours earlier — previously rejected.
+    const record = { ...baseRecord, capturedAt: now, updatedAt: now - 3 * 60 * 60 * 1000 }
+    expect(isInvalidWorktreeActivationRecord(record as SleepingAgentSessionRecord)).toBe(false)
+  })
+
+  it('rejects a record older than 14 days', () => {
+    const now = Date.now()
+    const capturedAt = now - 15 * 24 * 60 * 60 * 1000
+    const record = { ...baseRecord, capturedAt, updatedAt: capturedAt }
+    expect(isInvalidWorktreeActivationRecord(record as SleepingAgentSessionRecord)).toBe(true)
+  })
+})

--- a/src/renderer/src/lib/resume-sleeping-agent-session-provider-claim.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-provider-claim.test.ts
@@ -16,6 +16,7 @@ function makeRecord(
   paneKey: string,
   origin: SleepingAgentSessionRecord['origin'] = 'quit'
 ): SleepingAgentSessionRecord {
+  const capturedAt = Date.now()
   return {
     paneKey,
     tabId: 'tab-1',
@@ -24,8 +25,8 @@ function makeRecord(
     providerSession: { key: 'session_id', id: 'sess-1' },
     prompt: 'finish the task',
     state: 'working',
-    capturedAt: 1,
-    updatedAt: 1,
+    capturedAt,
+    updatedAt: capturedAt,
     origin,
     launchConfig: {
       agentCommand: 'omp',

--- a/src/renderer/src/lib/resume-sleeping-agent-session-remote-compat.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-remote-compat.test.ts
@@ -6,6 +6,7 @@ import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-
 const initialState = useAppStore.getState()
 
 function record(origin: 'live' | 'quit'): SleepingAgentSessionRecord {
+  const now = Date.now()
   return {
     paneKey: 'tab-1:leaf-1',
     tabId: 'tab-1',
@@ -14,8 +15,8 @@ function record(origin: 'live' | 'quit'): SleepingAgentSessionRecord {
     providerSession: { key: 'session_id', id: 'sess-1' },
     prompt: 'finish the task',
     state: 'working',
-    capturedAt: 1,
-    updatedAt: 1,
+    capturedAt: now,
+    updatedAt: now,
     origin
   }
 }

--- a/src/renderer/src/lib/resume-sleeping-agent-session-replay.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-replay.test.ts
@@ -14,6 +14,9 @@ afterEach(() => {
 function makeRecord(
   overrides: Partial<SleepingAgentSessionRecord> = {}
 ): SleepingAgentSessionRecord {
+  // Why: the activation gate rejects records by absolute age from Date.now()
+  // (Task 3), so fixtures need a recent timestamp, not an epoch-adjacent one.
+  const now = Date.now()
   return {
     paneKey: 'old-tab:leaf-1',
     tabId: 'old-tab',
@@ -22,8 +25,8 @@ function makeRecord(
     providerSession: { key: 'session_id', id: 'sess-1' },
     prompt: 'continue',
     state: 'working',
-    capturedAt: 1,
-    updatedAt: 1,
+    capturedAt: now,
+    updatedAt: now,
     origin: 'live',
     ...overrides
   }
@@ -52,6 +55,33 @@ describe('resumeSleepingAgentSessionsForWorktree replay protection', () => {
       launchAgent: record.agent,
       providerSession: record.providerSession
     })
+  })
+
+  it('does not clear its own record when a same-tab cold-restore claim covers the session', () => {
+    // Why: pty-connection.ts's cold-restore spawn registers a claim for its
+    // own tab before the resumed agent's first hook event lands (Task 2).
+    // Ordinary startup calls resumeSleepingAgentSessionsForWorktree right
+    // after that claim is registered — it must not treat the pane's own
+    // claim as evidence the record is a stale duplicate and clear it.
+    const record = makeRecord()
+    useAppStore.setState({
+      tabsByWorktree: { 'wt-1': [makeTerminalTab(record.tabId!)] },
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record },
+      automaticAgentResumeClaimsByTabId: {
+        [record.tabId!]: {
+          worktreeId: record.worktreeId,
+          launchAgent: record.agent,
+          providerSession: record.providerSession
+        }
+      }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    expect(launched).toBe(0)
+    const state = useAppStore.getState()
+    expect(state.sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
+    expect(state.tabsByWorktree['wt-1']).toHaveLength(1)
   })
 
   it('does not fork a provider session that is already queued', () => {

--- a/src/renderer/src/lib/resume-sleeping-agent-session-slept-pane-recovery.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-slept-pane-recovery.test.ts
@@ -16,6 +16,7 @@ afterEach(() => {
 function makeRecord(
   overrides: Partial<SleepingAgentSessionRecord> = {}
 ): SleepingAgentSessionRecord {
+  const capturedAt = Date.now()
   return {
     paneKey: makePaneKey('tab-1', LEAF_ID),
     tabId: 'tab-1',
@@ -24,8 +25,8 @@ function makeRecord(
     providerSession: { key: 'session_id', id: 'sess-1' },
     prompt: 'finish the task',
     state: 'working',
-    capturedAt: 1,
-    updatedAt: 1,
+    capturedAt,
+    updatedAt: capturedAt,
     origin: 'worktree-sleep',
     ...overrides
   }

--- a/src/renderer/src/lib/resume-sleeping-agent-session-suppress-navigation.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-suppress-navigation.test.ts
@@ -14,6 +14,9 @@ afterEach(() => {
 function makeRecord(
   overrides: Partial<SleepingAgentSessionRecord> = {}
 ): SleepingAgentSessionRecord {
+  // Why: the activation gate rejects records by absolute age from Date.now()
+  // (Task 3), so fixtures need a recent timestamp, not an epoch-adjacent one.
+  const now = Date.now()
   return {
     paneKey: 'tab-1:leaf-1',
     tabId: 'tab-1',
@@ -22,8 +25,8 @@ function makeRecord(
     providerSession: { key: 'session_id', id: 'sess-1' },
     prompt: 'finish the task',
     state: 'working',
-    capturedAt: 1,
-    updatedAt: 1,
+    capturedAt: now,
+    updatedAt: now,
     ...overrides
   }
 }

--- a/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.test.ts
@@ -17,6 +17,7 @@ afterEach(() => {
 function makeRecord(
   overrides: Partial<SleepingAgentSessionRecord> = {}
 ): SleepingAgentSessionRecord {
+  const now = Date.now()
   return {
     paneKey: 'tab-1:leaf-1',
     tabId: 'tab-1',
@@ -25,8 +26,8 @@ function makeRecord(
     providerSession: { key: 'session_id', id: 'sess-1' },
     prompt: 'finish the task',
     state: 'working',
-    capturedAt: 1,
-    updatedAt: 1,
+    capturedAt: now,
+    updatedAt: now,
     ...overrides
   }
 }
@@ -225,6 +226,7 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
   })
 
   it('rechecks pane ownership after an earlier fresh resume activates a new terminal', () => {
+    const now = Date.now()
     const initiallyUnownedPaneKey = makePaneKey('missing-tab', OTHER_LEAF_ID)
     const initiallyOwnedPaneKey = makePaneKey('tab-active', LEAF_ID)
     const initiallyUnowned = makeRecord({
@@ -232,16 +234,16 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
       tabId: 'missing-tab',
       origin: 'worktree-sleep',
       providerSession: { key: 'session_id', id: 'sess-first' },
-      capturedAt: 1,
-      updatedAt: 1
+      capturedAt: now,
+      updatedAt: now
     })
     const initiallyOwned = makeRecord({
       paneKey: initiallyOwnedPaneKey,
       tabId: 'tab-active',
       origin: 'worktree-sleep',
       providerSession: { key: 'session_id', id: 'sess-second' },
-      capturedAt: 2,
-      updatedAt: 2
+      capturedAt: now + 1,
+      updatedAt: now + 1
     })
     useAppStore.setState({
       ...makeActiveTerminalState('tab-active'),
@@ -472,9 +474,7 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
     const second = makeRecord({
       paneKey: 'tab-1:1',
       origin: 'worktree-sleep',
-      providerSession: { key: 'session_id', id: 'sess-2' },
-      capturedAt: 2,
-      updatedAt: 2
+      providerSession: { key: 'session_id', id: 'sess-2' }
     })
     useAppStore.setState({
       tabsByWorktree: {
@@ -549,16 +549,17 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
   })
 
   it('launches once and clears skipped duplicates for the same provider session', () => {
+    const now = Date.now()
     const first = makeRecord({
       paneKey: 'tab-1:leaf-1',
-      capturedAt: 1,
-      updatedAt: 1,
+      capturedAt: now,
+      updatedAt: now,
       launchConfig: { agentArgs: '--older', agentEnv: {} }
     })
     const duplicate = makeRecord({
       paneKey: 'tab-2:leaf-1',
-      capturedAt: 2,
-      updatedAt: 2,
+      capturedAt: now + 1,
+      updatedAt: now + 1,
       launchConfig: { agentArgs: '--newer', agentEnv: {} }
     })
     useAppStore.setState({
@@ -589,9 +590,7 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
     const stale = makeRecord({
       paneKey: stalePaneKey,
       tabId: 'missing-tab',
-      origin: 'worktree-sleep',
-      capturedAt: 2,
-      updatedAt: 2
+      origin: 'worktree-sleep'
     })
     useAppStore.setState({
       ...makeActiveTerminalState('tab-1'),
@@ -619,9 +618,7 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
     const stale = makeRecord({
       paneKey: stalePaneKey,
       tabId: 'missing-tab',
-      origin: 'worktree-sleep',
-      capturedAt: 2,
-      updatedAt: 2
+      origin: 'worktree-sleep'
     })
     useAppStore.setState({
       ...makeActiveTerminalState('tab-1'),
@@ -658,8 +655,6 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
       paneKey: activePaneKey,
       tabId: 'tab-active',
       origin: 'worktree-sleep',
-      capturedAt: 2,
-      updatedAt: 2,
       launchConfig: { agentArgs: '--active', agentEnv: {} }
     })
     useAppStore.setState({
@@ -693,20 +688,19 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
   })
 
   it('does not let invalid pane-owned records block a valid duplicate resume', () => {
+    const now = Date.now()
     const invalidPaneKey = makePaneKey('tab-1', LEAF_ID)
     const validPaneKey = makePaneKey('missing-tab', OTHER_LEAF_ID)
     const invalid = makeRecord({
       paneKey: invalidPaneKey,
       origin: 'live',
-      capturedAt: 3_000_000,
-      updatedAt: 1
+      capturedAt: now - 15 * 24 * 60 * 60 * 1000,
+      updatedAt: now - 15 * 24 * 60 * 60 * 1000
     })
     const valid = makeRecord({
       paneKey: validPaneKey,
       tabId: 'missing-tab',
-      origin: 'worktree-sleep',
-      capturedAt: 3_000_001,
-      updatedAt: 3_000_001
+      origin: 'worktree-sleep'
     })
     useAppStore.setState({
       tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-1', 'wt-1')] },
@@ -769,14 +763,16 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
   })
 
   it('clears stale manual records without launching a tab', () => {
-    const record = makeRecord({ capturedAt: 3_000_000, updatedAt: 1 })
+    const now = Date.now()
+    const record = makeRecord({
+      capturedAt: now - 15 * 24 * 60 * 60 * 1000,
+      updatedAt: now - 15 * 24 * 60 * 60 * 1000
+    })
     useAppStore.setState({
       tabsByWorktree: { 'wt-1': [] },
       sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
     } as never)
-
     const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
-
     expect(launched).toBe(0)
     expect(useAppStore.getState().tabsByWorktree['wt-1']).toEqual([])
     expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
@@ -788,7 +784,6 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
       tabsByWorktree: { 'wt-1': [] },
       sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
     } as never)
-
     const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
 
     const state = useAppStore.getState()
@@ -821,9 +816,7 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
       tabsByWorktree: { 'wt-1': [] },
       sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
     } as never)
-
     const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
-
     expect(launched).toBe(0)
     expect(useAppStore.getState().tabsByWorktree['wt-1']).toEqual([])
     expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
@@ -835,9 +828,7 @@ describe('resumeSleepingAgentSessionsForWorktree', () => {
       tabsByWorktree: { 'wt-1': [] },
       sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
     } as never)
-
     const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
-
     expect(launched).toBe(0)
     expect(useAppStore.getState().tabsByWorktree['wt-1']).toEqual([])
     expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()

--- a/src/renderer/src/lib/resume-sleeping-agent-session.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.ts
@@ -3,7 +3,7 @@ import {
   agentProviderSessionsEqual,
   type SleepingAgentSessionRecord
 } from '../../../shared/agent-session-resume'
-import { AGENT_STATUS_STALE_AFTER_MS } from '../../../shared/agent-status-types'
+import { SLEEPING_AGENT_RECORD_MAX_AGE_MS } from '../../../shared/agent-session-resume'
 import {
   getProviderSessionClaimKey,
   isPassiveCompletedHibernationEvidence,
@@ -79,6 +79,22 @@ function getAgentStatusTabId(entry: {
   return separatorIndex === -1 ? null : entry.paneKey.slice(0, separatorIndex)
 }
 
+// Why: a pane's own cold-restore claim covers its still-present record until
+// a hook event replaces it (Task 2) — it must not read as a stale duplicate.
+function ownTabResumeClaimMatchesProviderSession(
+  record: SleepingAgentSessionRecord,
+  state: ReturnType<typeof useAppStore.getState>
+): boolean {
+  const tabId = getAgentStatusTabId(record)
+  const claim = tabId ? state.automaticAgentResumeClaimsByTabId[tabId] : undefined
+  return Boolean(
+    claim &&
+    claim.worktreeId === record.worktreeId &&
+    claim.launchAgent === record.agent &&
+    agentProviderSessionsEqual(record.agent, claim.providerSession, record.providerSession)
+  )
+}
+
 function activeOrQueuedResumeClaimsProviderSession(
   record: SleepingAgentSessionRecord,
   state: ReturnType<typeof useAppStore.getState>,
@@ -117,8 +133,12 @@ function activeOrQueuedResumeClaimsProviderSession(
     }
   }
 
+  // Why: the record's own tab is handled by ownTabResumeClaimMatchesProviderSession
+  // instead — excluded here so its claim never triggers the clear-as-duplicate path.
+  const recordTabId = getAgentStatusTabId(record)
   for (const [tabId, claim] of Object.entries(state.automaticAgentResumeClaimsByTabId)) {
     if (
+      tabId !== recordTabId &&
       worktreeTabIds.has(tabId) &&
       claim.worktreeId === record.worktreeId &&
       claim.launchAgent === record.agent &&
@@ -137,7 +157,7 @@ function isInvalidWorktreeActivationRecord(record: SleepingAgentSessionRecord): 
     return true
   }
   return (
-    record.state !== 'done' && record.capturedAt - record.updatedAt > AGENT_STATUS_STALE_AFTER_MS
+    record.state !== 'done' && Date.now() - record.capturedAt > SLEEPING_AGENT_RECORD_MAX_AGE_MS
   )
 }
 

--- a/src/renderer/src/lib/resume-sleeping-agent-session.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.ts
@@ -1,9 +1,9 @@
 import { useAppStore } from '@/store'
 import {
   agentProviderSessionsEqual,
+  SLEEPING_AGENT_RECORD_MAX_AGE_MS,
   type SleepingAgentSessionRecord
 } from '../../../shared/agent-session-resume'
-import { SLEEPING_AGENT_RECORD_MAX_AGE_MS } from '../../../shared/agent-session-resume'
 import {
   getProviderSessionClaimKey,
   isPassiveCompletedHibernationEvidence,

--- a/src/renderer/src/lib/resume-sleeping-agent-session.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.ts
@@ -152,7 +152,7 @@ function activeOrQueuedResumeClaimsProviderSession(
 
 // Why: an interrupted turn is still resumable — `claude --resume` reopens the transcript at the
 // prompt — so discarding those records only stranded the session across wake and restart.
-function isInvalidWorktreeActivationRecord(record: SleepingAgentSessionRecord): boolean {
+export function isInvalidWorktreeActivationRecord(record: SleepingAgentSessionRecord): boolean {
   if (!record.origin && record.state === 'done') {
     return true
   }
@@ -206,6 +206,9 @@ export function resumeSleepingAgentSessionsForWorktree(
       if (!isPaneOwned || activeClaimKeys.has(claimKey)) {
         state.clearSleepingAgentSession(record.paneKey)
       }
+      continue
+    }
+    if (ownTabResumeClaimMatchesProviderSession(record, currentState)) {
       continue
     }
     if (activeOrQueuedResumeClaimsProviderSession(record, currentState, isPaneOwned)) {

--- a/src/renderer/src/lib/serve-desktop-promotion-session-continuity.test.ts
+++ b/src/renderer/src/lib/serve-desktop-promotion-session-continuity.test.ts
@@ -151,6 +151,7 @@ function makeTerminalTab(id: string): Record<string, unknown> {
 
 function makeSurvivingAgentRecord(index: number): SleepingAgentSessionRecord {
   const pane = AGENT_PANES[index]
+  const capturedAt = Date.now()
   return {
     paneKey: makePaneKey(pane.tabId, pane.leafId),
     tabId: pane.tabId,
@@ -159,8 +160,8 @@ function makeSurvivingAgentRecord(index: number): SleepingAgentSessionRecord {
     providerSession: { key: 'session_id', id: `provider-session-${index + 1}` },
     prompt: 'keep working',
     state: 'working',
-    capturedAt: 1,
-    updatedAt: 1,
+    capturedAt,
+    updatedAt: capturedAt,
     // Why: Cmd+Q captures live agents as quit-origin records — the exact input
     // the promoted renderer replays.
     origin: 'quit'

--- a/src/renderer/src/lib/worktree-activation-created-agent.test.ts
+++ b/src/renderer/src/lib/worktree-activation-created-agent.test.ts
@@ -181,6 +181,9 @@ describe('activateAndRevealWorktree', () => {
       tabBarOrderByWorktree: {},
       pendingStartupByTabId: {},
       sleepingAgentSessionsByPaneKey: {
+        // Why: the activation gate rejects records by absolute age from
+        // Date.now() (Task 3), so this needs a recent timestamp, not an
+        // epoch-adjacent one.
         'slept-tab:0': {
           paneKey: 'slept-tab:0',
           tabId: 'slept-tab',
@@ -189,8 +192,8 @@ describe('activateAndRevealWorktree', () => {
           providerSession: { key: 'session_id', id: 'codex-session-1' },
           prompt: 'resume prior task',
           state: 'working',
-          capturedAt: 1000,
-          updatedAt: 1000,
+          capturedAt: Date.now(),
+          updatedAt: Date.now(),
           terminalTitle: 'Codex'
         }
       },

--- a/src/renderer/src/lib/worktree-reactivation-preserved-pane-replacement.test.ts
+++ b/src/renderer/src/lib/worktree-reactivation-preserved-pane-replacement.test.ts
@@ -98,6 +98,7 @@ function seedHuskTab(
 
 function seedSleepingRecord(worktreeId: string, sessionId: string): void {
   const paneKey = makePaneKey(HUSK_TAB_ID, LEAF_ID)
+  const capturedAt = Date.now()
   useAppStore.setState((s) => ({
     sleepingAgentSessionsByPaneKey: {
       ...s.sleepingAgentSessionsByPaneKey,
@@ -110,8 +111,8 @@ function seedSleepingRecord(worktreeId: string, sessionId: string): void {
         prompt: 'resume prior task',
         state: 'working' as const,
         origin: 'quit' as const,
-        capturedAt: 1000,
-        updatedAt: 1000,
+        capturedAt,
+        updatedAt: capturedAt,
         terminalTitle: 'Codex'
       }
     }
@@ -282,6 +283,7 @@ describe('preserved-pane replacement contract on workspace activation', () => {
     }
     useAppStore.setState(state)
     const paneKey = makePaneKey(webTabId, LEAF_ID)
+    const capturedAt = Date.now()
     useAppStore.setState((s) => ({
       sleepingAgentSessionsByPaneKey: {
         ...s.sleepingAgentSessionsByPaneKey,
@@ -294,8 +296,8 @@ describe('preserved-pane replacement contract on workspace activation', () => {
           prompt: 'resume prior task',
           state: 'working' as const,
           origin: 'quit' as const,
-          capturedAt: 1000,
-          updatedAt: 1000,
+          capturedAt,
+          updatedAt: capturedAt,
           terminalTitle: 'Codex'
         }
       }

--- a/src/renderer/src/lib/worktree-reactivation-tab-forkbomb.test.ts
+++ b/src/renderer/src/lib/worktree-reactivation-tab-forkbomb.test.ts
@@ -60,6 +60,7 @@ describe('STA-1111 worktree reopen does not fork-bomb tabs', () => {
 
     for (let reopen = 0; reopen < 4; reopen++) {
       const paneKey = `slept-pane-${reopen}:0`
+      const capturedAt = Date.now() + reopen
       useAppStore.setState((s) => ({
         sleepingAgentSessionsByPaneKey: {
           ...s.sleepingAgentSessionsByPaneKey,
@@ -72,8 +73,8 @@ describe('STA-1111 worktree reopen does not fork-bomb tabs', () => {
             prompt: 'resume prior task',
             state: 'working',
             origin: 'live',
-            capturedAt: 1000 + reopen,
-            updatedAt: 1000 + reopen,
+            capturedAt,
+            updatedAt: capturedAt,
             terminalTitle: 'Codex'
           }
         }

--- a/src/renderer/src/store/slices/agent-status-provider-session.test.ts
+++ b/src/renderer/src/store/slices/agent-status-provider-session.test.ts
@@ -121,6 +121,55 @@ describe('recordAgentProviderSession', () => {
     expect(store.getState().agentStatusByPaneKey['tab-1:leaf-1']?.providerSession).toBeUndefined()
   })
 
+  it('inherits omitted connection ownership but preserves an explicit local null', () => {
+    const store = createTestStore()
+    const providerSession = { key: 'session_id' as const, id: 'codex-session-1' }
+    store.setState({
+      tabsByWorktree: { 'wt-1': [makeTab({ id: 'tab-1', worktreeId: 'wt-1' })] },
+      sleepingAgentSessionsByPaneKey: {
+        'tab-1:leaf-1': {
+          paneKey: 'tab-1:leaf-1',
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          connectionId: 'ssh-old',
+          agent: 'codex',
+          providerSession,
+          prompt: 'first task',
+          state: 'working',
+          capturedAt: 10,
+          updatedAt: 10,
+          origin: 'live'
+        }
+      }
+    } as Partial<AppState>)
+
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:leaf-1',
+        { state: 'done', prompt: 'first task', agentType: 'codex' },
+        'Codex',
+        { updatedAt: 20, stateStartedAt: 10 },
+        { tabId: 'tab-1', worktreeId: 'wt-1' },
+        { providerSession }
+      )
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']?.connectionId).toBe(
+      'ssh-old'
+    )
+
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:leaf-1',
+        { state: 'done', prompt: 'first task', agentType: 'codex' },
+        'Codex',
+        { updatedAt: 30, stateStartedAt: 10 },
+        { tabId: 'tab-1', worktreeId: 'wt-1', connectionId: null },
+        { providerSession }
+      )
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']?.connectionId).toBeNull()
+  })
+
   it('uses the session file as part of Pi resume ownership only', () => {
     const base = {
       paneKey: 'tab-1:leaf-1',

--- a/src/renderer/src/store/slices/agent-status-quit-capture.test.ts
+++ b/src/renderer/src/store/slices/agent-status-quit-capture.test.ts
@@ -729,7 +729,7 @@ describe('captureAllSleepingAgentSessions', () => {
     }
   )
 
-  it('does not reuse launch config from a completed same-pane agent', () => {
+  it('reuses recovery identity and launch config for the next turn in the same Codex TUI', () => {
     const store = createTestStore()
     store.setState({
       tabsByWorktree: {
@@ -776,11 +776,11 @@ describe('captureAllSleepingAgentSessions', () => {
       )
 
     const entry = store.getState().agentStatusByPaneKey['tab-1:leaf-1']
-    expect(entry?.providerSession).toBeUndefined()
-    expect(entry).not.toHaveProperty('launchConfig')
-    expect(
-      store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']?.launchConfig
-    ).toBeUndefined()
+    expect(entry?.providerSession).toEqual({ key: 'session_id', id: 'codex-session-1' })
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']?.launchConfig).toEqual({
+      agentArgs: '--model gpt-5',
+      agentEnv: { CODEX_PROFILE: 'captured' }
+    })
   })
 
   it('captures resumable agents across every worktree, not just one', () => {
@@ -823,7 +823,7 @@ describe('captureAllSleepingAgentSessions', () => {
     })
   })
 
-  it('skips done agents — there is no turn left to resume', () => {
+  it('skips done agents that have no live recovery checkpoint', () => {
     const store = createTestStore()
     const entry = makeAgentEntry({
       paneKey: 'tab-1:leaf-1',

--- a/src/renderer/src/store/slices/agent-status.test.ts
+++ b/src/renderer/src/store/slices/agent-status.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- Why: this file is the umbrella suite for the agent-status slice (freshness, tool/assistant fields, stateStartedAt, retention + prefix sweep). Splitting by sub-area would scatter shared helpers (createTestStore, fake timers); narrower edge-cases live in sibling agent-status-*.test.ts files already. */
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { SleepingAgentSessionRecord } from '../../../../shared/agent-session-resume'
 import {
   AGENT_STATUS_STALE_AFTER_MS,
   type AgentStatusEntry

--- a/src/renderer/src/store/slices/agent-status.test.ts
+++ b/src/renderer/src/store/slices/agent-status.test.ts
@@ -1500,3 +1500,79 @@ describe('session-boundary done semantics (STA-3386)', () => {
     expect(store.getState().agentStatusByPaneKey[PANE].sessionBoundary).toBeUndefined()
   })
 })
+
+describe('automatic-resume claim release on session replacement (Task 2)', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function seedClaimedRecord(store: ReturnType<typeof createTestStore>): void {
+    const record: SleepingAgentSessionRecord = {
+      paneKey: 'tab-1:leaf-1',
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: 'persisted-session' },
+      prompt: 'earlier prompt',
+      state: 'waiting',
+      capturedAt: 1000,
+      updatedAt: 1000,
+      origin: 'live'
+    }
+    store.setState({
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as Partial<AppState>)
+    // Why: mirrors the claim pty-connection.ts registers at cold-restore
+    // spawn time, before the resumed agent's own hook event has landed.
+    store.getState().claimAutomaticAgentResume('tab-1', {
+      worktreeId: 'wt-1',
+      launchAgent: 'claude',
+      providerSession: { key: 'session_id', id: 'persisted-session' }
+    })
+  }
+
+  it('releases the claim once a hook event reports a different provider session', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    seedClaimedRecord(store)
+
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:leaf-1',
+        { state: 'working', prompt: 'continuing', agentType: 'claude' },
+        'Claude',
+        undefined,
+        { worktreeId: 'wt-1', tabId: 'tab-1' },
+        { providerSession: { key: 'session_id', id: 'fresh-session' } }
+      )
+
+    expect(
+      store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']?.providerSession.id
+    ).toBe('fresh-session')
+    expect(store.getState().automaticAgentResumeClaimsByTabId['tab-1']).toBeUndefined()
+  })
+
+  it('keeps the claim when the hook event confirms the same provider session', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    seedClaimedRecord(store)
+
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:leaf-1',
+        { state: 'working', prompt: 'continuing', agentType: 'claude' },
+        'Claude',
+        undefined,
+        { worktreeId: 'wt-1', tabId: 'tab-1' },
+        { providerSession: { key: 'session_id', id: 'persisted-session' } }
+      )
+
+    expect(store.getState().automaticAgentResumeClaimsByTabId['tab-1']).toEqual({
+      worktreeId: 'wt-1',
+      launchAgent: 'claude',
+      providerSession: { key: 'session_id', id: 'persisted-session' }
+    })
+  })
+})

--- a/src/renderer/src/store/slices/agent-status.test.ts
+++ b/src/renderer/src/store/slices/agent-status.test.ts
@@ -1575,4 +1575,49 @@ describe('automatic-resume claim release on session replacement (Task 2)', () =>
       providerSession: { key: 'session_id', id: 'persisted-session' }
     })
   })
+
+  it('does not release a split-pane sibling claim owned by a different session', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    // Pane A's own sleeping record — the one whose hook event is about to fire.
+    const paneARecord: SleepingAgentSessionRecord = {
+      paneKey: 'tab-1:leaf-a',
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: 'pane-a-old' },
+      prompt: 'earlier prompt',
+      state: 'waiting',
+      capturedAt: 1000,
+      updatedAt: 1000,
+      origin: 'live'
+    }
+    store.setState({
+      sleepingAgentSessionsByPaneKey: { [paneARecord.paneKey]: paneARecord }
+    } as Partial<AppState>)
+    // Split tab: the tab-keyed claim currently belongs to pane B, not pane A
+    // (claimAutomaticAgentResume is last-write-wins per tab — see pty-connection.ts).
+    store.getState().claimAutomaticAgentResume('tab-1', {
+      worktreeId: 'wt-1',
+      launchAgent: 'claude',
+      providerSession: { key: 'session_id', id: 'pane-b-session' }
+    })
+
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:leaf-a',
+        { state: 'working', prompt: 'continuing', agentType: 'claude' },
+        'Claude',
+        undefined,
+        { worktreeId: 'wt-1', tabId: 'tab-1' },
+        { providerSession: { key: 'session_id', id: 'pane-a-new' } }
+      )
+
+    expect(store.getState().automaticAgentResumeClaimsByTabId['tab-1']).toEqual({
+      worktreeId: 'wt-1',
+      launchAgent: 'claude',
+      providerSession: { key: 'session_id', id: 'pane-b-session' }
+    })
+  })
 })

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -15,6 +15,7 @@ import {
 import {
   agentProviderSessionsEqual,
   getAgentResumeArgv,
+  isCompletedAgentWithLiveRecoveryRecord,
   isResumableTuiAgent,
   type AgentProviderSessionMetadata,
   type ResumableTuiAgent,
@@ -551,6 +552,7 @@ function sleepingRecordFromEntry(args: {
     state: args.entry.state,
     capturedAt: args.capturedAt,
     updatedAt: args.entry.updatedAt,
+    ...(args.entry.connectionId !== undefined ? { connectionId: args.entry.connectionId } : {}),
     ...((args.entry.terminalTitle ?? tab?.title)
       ? { terminalTitle: (args.entry.terminalTitle ?? tab?.title)! }
       : {}),
@@ -681,8 +683,7 @@ export function collectSleepingAgentSessionRecordsForWorktree(
       ) {
         continue
       }
-      // Why: Pi identity is resumable with no turn row and while idle after done, so manual
-      // sleep must promote both instead of deleting the checkpoint.
+      // Why: completed resumable TUIs keep recovery identity without a pending turn row.
       records[existing.paneKey] = {
         ...existing,
         state: 'working',
@@ -2080,7 +2081,10 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         }
         let nextAutomaticAgentResumeClaimsByTabId = s.automaticAgentResumeClaimsByTabId
         if (liveRecoveryRecord) {
-          if (!recoveryRecordMatches(existingSleepingRecord, liveRecoveryRecord)) {
+          if (
+            retainsCompletedRecoveryIdentity ||
+            !recoveryRecordMatches(existingSleepingRecord, liveRecoveryRecord)
+          ) {
             nextSleepingAgentSessions = {
               ...s.sleepingAgentSessionsByPaneKey,
               [paneKey]: liveRecoveryRecord

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -15,7 +15,6 @@ import {
 import {
   agentProviderSessionsEqual,
   getAgentResumeArgv,
-  isCompletedAgentWithLiveRecoveryRecord,
   isResumableTuiAgent,
   type AgentProviderSessionMetadata,
   type ResumableTuiAgent,
@@ -1845,6 +1844,15 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         const canReuseExistingProviderSession =
           existing?.agentType === identity.agentType &&
           (existing.state !== 'done' || payload.state === 'done')
+        const existingSleepingRecord = s.sleepingAgentSessionsByPaneKey[paneKey]
+        // Why: the first warm-reattach status can omit provider metadata while
+        // the persisted nonterminal record still owns the same pane and agent.
+        const rehydratedProviderSession =
+          existingSleepingRecord?.agent === identity.agentType &&
+          existingSleepingRecord.state !== 'done' &&
+          payload.state !== 'done'
+            ? existingSleepingRecord.providerSession
+            : undefined
         const providerSession =
           metadata?.providerSession ??
           (canReuseExistingProviderSession ? existing.providerSession : undefined) ??
@@ -1876,7 +1884,6 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         })
           ? registryEntry?.launchConfig
           : undefined
-        const existingSleepingRecord = s.sleepingAgentSessionsByPaneKey[paneKey]
         // Why: a completed turn leaves the TUI session alive and resumable at its prompt for any
         // resumable agent (Claude/Codex/Pi/…), not just Pi — so keep its persisted recovery anchor
         // even when done. Else a cold restore after an abrupt app death (macOS logout, #9454) drops
@@ -2033,13 +2040,24 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           entry.state === 'done' && !retainsResumableRecoveryIdentity
             ? null
             : (entry.worktreeId ?? findAgentPaneWorktreeId(s, entry.paneKey))
+        // Why: omitted routing metadata inherits the persisted owner, while an
+        // explicit local null must replace an older remote connection id.
+        const recoveryEntry =
+          entry.connectionId !== undefined || existingSleepingRecord?.connectionId === undefined
+            ? entry
+            : { ...entry, connectionId: existingSleepingRecord.connectionId }
         const liveRecoveryRecord = liveRecoveryWorktreeId
           ? sleepingRecordFromEntry({
               state: s,
               // Why: a completed resumable-agent turn leaves the TUI session alive — keep resume identity active without representing done as pending work.
               entry: retainsResumableRecoveryIdentity
-                ? { ...entry, state: 'working', prompt: '', lastAssistantMessage: undefined }
-                : entry,
+                ? {
+                    ...recoveryEntry,
+                    state: 'working',
+                    prompt: '',
+                    lastAssistantMessage: undefined
+                  }
+                : recoveryEntry,
               worktreeId: liveRecoveryWorktreeId,
               capturedAt: updatedAt,
               launchConfig: launchConfigSource,
@@ -2082,7 +2100,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         let nextAutomaticAgentResumeClaimsByTabId = s.automaticAgentResumeClaimsByTabId
         if (liveRecoveryRecord) {
           if (
-            retainsCompletedRecoveryIdentity ||
+            retainsResumableRecoveryIdentity ||
             !recoveryRecordMatches(existingSleepingRecord, liveRecoveryRecord)
           ) {
             nextSleepingAgentSessions = {

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -2078,11 +2078,27 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           nextLaunchConfigs = { ...s.agentLaunchConfigByPaneKey }
           delete nextLaunchConfigs[paneKey]
         }
+        let nextAutomaticAgentResumeClaimsByTabId = s.automaticAgentResumeClaimsByTabId
         if (liveRecoveryRecord) {
           if (!recoveryRecordMatches(existingSleepingRecord, liveRecoveryRecord)) {
             nextSleepingAgentSessions = {
               ...s.sleepingAgentSessionsByPaneKey,
               [paneKey]: liveRecoveryRecord
+            }
+            // Why: a hook-confirmed session change fulfills the cold-restore
+            // claim (pty-connection.ts); release it so a later sleeping
+            // session on this tab is not blocked by a stale claim.
+            if (
+              statusTabId &&
+              existingSleepingRecord &&
+              !providerSessionsEqual(
+                existingSleepingRecord.providerSession,
+                liveRecoveryRecord.providerSession
+              ) &&
+              statusTabId in s.automaticAgentResumeClaimsByTabId
+            ) {
+              nextAutomaticAgentResumeClaimsByTabId = { ...s.automaticAgentResumeClaimsByTabId }
+              delete nextAutomaticAgentResumeClaimsByTabId[statusTabId]
             }
           }
         } else if (existingSleepingRecord) {
@@ -2110,6 +2126,9 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           agentLaunchConfigByPaneKey: nextLaunchConfigs,
           migrationUnsupportedByPtyId: migrationUnsupported.next,
           retentionSuppressedPaneKeys: nextRetentionSuppressedPaneKeys,
+          ...(nextAutomaticAgentResumeClaimsByTabId !== s.automaticAgentResumeClaimsByTabId
+            ? { automaticAgentResumeClaimsByTabId: nextAutomaticAgentResumeClaimsByTabId }
+            : {}),
           agentStatusEpoch:
             retentionRelevantChange || migrationUnsupported.changed || evictedOrphans
               ? s.agentStatusEpoch + 1

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -2088,14 +2088,27 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
             // Why: a hook-confirmed session change fulfills the cold-restore
             // claim (pty-connection.ts); release it so a later sleeping
             // session on this tab is not blocked by a stale claim.
+            const tabClaim = statusTabId
+              ? s.automaticAgentResumeClaimsByTabId[statusTabId]
+              : undefined
+            // Why: split panes share one tab-keyed claim slot, so only release it
+            // when it still belongs to the record actually being replaced here.
             if (
               statusTabId &&
               existingSleepingRecord &&
-              !providerSessionsEqual(
+              tabClaim &&
+              tabClaim.worktreeId === existingSleepingRecord.worktreeId &&
+              tabClaim.launchAgent === existingSleepingRecord.agent &&
+              agentProviderSessionsEqual(
+                existingSleepingRecord.agent,
+                tabClaim.providerSession,
+                existingSleepingRecord.providerSession
+              ) &&
+              !agentProviderSessionsEqual(
+                existingSleepingRecord.agent,
                 existingSleepingRecord.providerSession,
                 liveRecoveryRecord.providerSession
-              ) &&
-              statusTabId in s.automaticAgentResumeClaimsByTabId
+              )
             ) {
               nextAutomaticAgentResumeClaimsByTabId = { ...s.automaticAgentResumeClaimsByTabId }
               delete nextAutomaticAgentResumeClaimsByTabId[statusTabId]

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -1846,7 +1846,8 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           (existing.state !== 'done' || payload.state === 'done')
         const providerSession =
           metadata?.providerSession ??
-          (canReuseExistingProviderSession ? existing.providerSession : undefined)
+          (canReuseExistingProviderSession ? existing.providerSession : undefined) ??
+          rehydratedProviderSession
         const existingProviderSession = canReuseExistingProviderSession
           ? existing.providerSession
           : undefined

--- a/src/renderer/src/store/slices/terminals.test.ts
+++ b/src/renderer/src/store/slices/terminals.test.ts
@@ -11,8 +11,8 @@ describe('claimAutomaticAgentResume', () => {
   // Why: Task 2 (pty-connection.ts cold-restore spawn) relies on this exact
   // claim shape to block a duplicate worktree-activation resume while the
   // spawning pane's sleeping record is deliberately left in place. See
-  // resume-sleeping-agent-session.ts:118-127 for the reader that matches on
-  // worktreeId/launchAgent/providerSession.
+  // activeOrQueuedResumeClaimsProviderSession in resume-sleeping-agent-session.ts
+  // for the reader that matches on worktreeId/launchAgent/providerSession.
   it('cold-restore claim blocks duplicate activation resume for the same session', () => {
     useAppStore.getState().claimAutomaticAgentResume('tab-1', {
       worktreeId: 'wt-1',

--- a/src/renderer/src/store/slices/terminals.test.ts
+++ b/src/renderer/src/store/slices/terminals.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { useAppStore } from '@/store'
+
+const initialAppStoreState = useAppStore.getState()
+
+afterEach(() => {
+  useAppStore.setState(initialAppStoreState, true)
+})
+
+describe('claimAutomaticAgentResume', () => {
+  // Why: Task 2 (pty-connection.ts cold-restore spawn) relies on this exact
+  // claim shape to block a duplicate worktree-activation resume while the
+  // spawning pane's sleeping record is deliberately left in place. See
+  // resume-sleeping-agent-session.ts:118-127 for the reader that matches on
+  // worktreeId/launchAgent/providerSession.
+  it('cold-restore claim blocks duplicate activation resume for the same session', () => {
+    useAppStore.getState().claimAutomaticAgentResume('tab-1', {
+      worktreeId: 'wt-1',
+      launchAgent: 'claude',
+      providerSession: { key: 'session_id', id: 'persisted-session' }
+    })
+    expect(
+      useAppStore.getState().automaticAgentResumeClaimsByTabId['tab-1']?.providerSession?.id
+    ).toBe('persisted-session')
+  })
+})

--- a/src/shared/agent-session-resume.test.ts
+++ b/src/shared/agent-session-resume.test.ts
@@ -3,6 +3,7 @@ import {
   agentProviderSessionsEqual,
   extractAgentProviderSession,
   getAgentResumeArgv,
+  isCompletedAgentWithLiveRecoveryRecord,
   isResumableTuiAgent,
   normalizeAgentProviderSession
 } from './agent-session-resume'
@@ -87,6 +88,47 @@ describe('agent session resume metadata', () => {
     expect(agentProviderSessionsEqual('pi', first, second)).toBe(false)
     expect(agentProviderSessionsEqual('claude', first, second)).toBe(true)
   })
+
+  it.each([
+    ['codex', { key: 'session_id' as const, id: 'codex-session' }],
+    [
+      'pi',
+      {
+        key: 'session_id' as const,
+        id: 'pi-session',
+        transcriptPath: '/tmp/pi-session.jsonl'
+      }
+    ]
+  ] as const)(
+    'recognizes completed %s sessions with live recovery records',
+    (agentType, providerSession) => {
+      const record = {
+        paneKey: 'tab-1:leaf-1',
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        agent: agentType,
+        providerSession,
+        prompt: '',
+        state: 'working' as const,
+        capturedAt: 10,
+        updatedAt: 10,
+        origin: 'live' as const
+      }
+
+      expect(
+        isCompletedAgentWithLiveRecoveryRecord(
+          { state: 'done', agentType, providerSession, worktreeId: 'wt-1' },
+          record
+        )
+      ).toBe(true)
+      expect(
+        isCompletedAgentWithLiveRecoveryRecord(
+          { state: 'done', agentType, providerSession, worktreeId: 'wt-1' },
+          { ...record, origin: 'quit' }
+        )
+      ).toBe(false)
+    }
+  )
 
   it('rejects devin resume when provider session key is not session_id', () => {
     expect(getAgentResumeArgv('devin', { key: 'conversation_id', id: 'x' })).toBeNull()

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -277,3 +277,27 @@ export function getAgentResumeArgv(
         : null
   }
 }
+
+/** Matches a completed visible row to its still-resumable live TUI checkpoint. */
+export function isCompletedAgentWithLiveRecoveryRecord(
+  entry:
+    | {
+        state: AgentStatusState
+        agentType?: string
+        providerSession?: AgentProviderSessionMetadata
+        worktreeId?: string
+      }
+    | undefined,
+  record: SleepingAgentSessionRecord | undefined
+): record is SleepingAgentSessionRecord {
+  return Boolean(
+    entry?.state === 'done' &&
+    isResumableTuiAgent(entry.agentType) &&
+    entry.providerSession &&
+    record?.agent === entry.agentType &&
+    record.origin === 'live' &&
+    (!entry.worktreeId || entry.worktreeId === record.worktreeId) &&
+    agentProviderSessionsEqual(entry.agentType, entry.providerSession, record.providerSession) &&
+    getAgentResumeArgv(record.agent, record.providerSession)
+  )
+}

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -16,6 +16,11 @@ export const RESUMABLE_TUI_AGENTS = [
   'omp'
 ] as const satisfies readonly TuiAgent[]
 
+/** Why: resume records are pane state, not activity signals — a rebooted
+ * machine should restore agents no matter how long they idled before the
+ * quit. The absolute cap is defense in depth against zombie records. */
+export const SLEEPING_AGENT_RECORD_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000
+
 export type ResumableTuiAgent = (typeof RESUMABLE_TUI_AGENTS)[number]
 
 export type AgentProviderSessionKey = 'session_id' | 'conversation_id'

--- a/tests/e2e/agent-session-live-force-exit-resume.spec.ts
+++ b/tests/e2e/agent-session-live-force-exit-resume.spec.ts
@@ -15,8 +15,8 @@ import {
 } from './helpers/terminal'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 import { attachRepoAndOpenTerminal, createRestartSession } from './helpers/orca-restart'
-import { PROTOCOL_VERSION } from '../../src/main/daemon/types'
 import { DEFAULT_LOCAL_ORCA_PROFILE_ID } from '../../src/shared/orca-profiles'
+import { readOrcaDaemonPid } from './helpers/agent-session-persistence'
 
 const PROVIDER_SESSION_ID = 'e2e-live-force-exit-session'
 
@@ -52,19 +52,6 @@ function readPersistedData(userDataDir: string): PersistedData {
 
 function writePersistedData(userDataDir: string, data: PersistedData): void {
   writeFileSync(dataFilePath(userDataDir), `${JSON.stringify(data, null, 2)}\n`, 'utf8')
-}
-
-function daemonPidPath(userDataDir: string): string {
-  return path.join(userDataDir, 'daemon', `daemon-v${PROTOCOL_VERSION}.pid`)
-}
-
-function readDaemonPid(userDataDir: string): number {
-  const raw = readFileSync(daemonPidPath(userDataDir), 'utf8')
-  const parsed = JSON.parse(raw) as { pid?: unknown }
-  if (typeof parsed.pid !== 'number') {
-    throw new Error(`Daemon pid file did not contain a numeric pid: ${raw}`)
-  }
-  return parsed.pid
 }
 
 function hasExited(proc: ChildProcess): boolean {
@@ -244,7 +231,7 @@ test('resumes a live agent record after force-exit restart when pane PTY ownersh
       )
     }
 
-    const daemonPid = readDaemonPid(session.userDataDir)
+    const daemonPid = readOrcaDaemonPid(session.userDataDir)
     await forceKillElectronApp(firstApp)
     firstApp = null
     killPid(daemonPid)

--- a/tests/e2e/agent-session-quit-resume.spec.ts
+++ b/tests/e2e/agent-session-quit-resume.spec.ts
@@ -1,5 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
-import path from 'node:path'
+import { existsSync, readFileSync } from 'node:fs'
 import type { ElectronApplication } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
 import { TEST_REPO_PATH_FILE } from './global-setup'
@@ -13,54 +12,12 @@ import {
 } from './helpers/terminal'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 import { attachRepoAndOpenTerminal, createRestartSession } from './helpers/orca-restart'
-import { PROTOCOL_VERSION } from '../../src/main/daemon/types'
-import { DEFAULT_LOCAL_ORCA_PROFILE_ID } from '../../src/shared/orca-profiles'
+import {
+  overridePersistedAgentResumeCommand,
+  readOrcaDaemonPid
+} from './helpers/agent-session-persistence'
 
 const PROVIDER_SESSION_ID = 'e2e-quit-resume-session'
-
-function stubPersistedResumeCommand(userDataDir: string): void {
-  const dataPath = path.join(
-    userDataDir,
-    'profiles',
-    DEFAULT_LOCAL_ORCA_PROFILE_ID,
-    'orca-data.json'
-  )
-  const data = JSON.parse(readFileSync(dataPath, 'utf8')) as {
-    workspaceSession?: {
-      sleepingAgentSessionsByPaneKey?: Record<
-        string,
-        {
-          providerSession?: { id?: unknown }
-          launchConfig?: {
-            agentCommand?: string
-            agentArgs?: string
-            agentEnv?: Record<string, string>
-          }
-        }
-      >
-    }
-  }
-  const record = Object.values(data.workspaceSession?.sleepingAgentSessionsByPaneKey ?? {}).find(
-    (candidate) => candidate.providerSession?.id === PROVIDER_SESSION_ID
-  )
-  if (!record) {
-    throw new Error('Expected a persisted resumable agent session')
-  }
-  record.launchConfig = { agentCommand: 'echo', agentArgs: '', agentEnv: {} }
-  writeFileSync(dataPath, `${JSON.stringify(data, null, 2)}\n`, 'utf8')
-}
-
-function readDaemonPid(userDataDir: string): number {
-  const raw = readFileSync(
-    path.join(userDataDir, 'daemon', `daemon-v${PROTOCOL_VERSION}.pid`),
-    'utf8'
-  )
-  const parsed = JSON.parse(raw) as { pid?: unknown }
-  if (typeof parsed.pid !== 'number') {
-    throw new Error(`Daemon pid file did not contain a numeric pid: ${raw}`)
-  }
-  return parsed.pid
-}
 
 test.describe.configure({ mode: 'serial' })
 
@@ -122,11 +79,11 @@ test('resumes an agent session after quit when its daemon PTY died while the app
       }
     )
 
-    const daemonPid = readDaemonPid(session.userDataDir)
+    const daemonPid = readOrcaDaemonPid(session.userDataDir)
 
     await session.close(firstApp)
     firstApp = null
-    stubPersistedResumeCommand(session.userDataDir)
+    overridePersistedAgentResumeCommand(session.userDataDir, PROVIDER_SESSION_ID)
 
     // Why: simulates the daemon (and the agent CLI inside it) dying while the
     // app is closed — reboot, crash, or update kill. SIGKILL leaves history

--- a/tests/e2e/agent-session-quit-resume.spec.ts
+++ b/tests/e2e/agent-session-quit-resume.spec.ts
@@ -71,7 +71,6 @@ test('resumes an agent session after quit when its daemon PTY died while the app
     test.skip(true, 'Global setup did not produce a seeded test repo')
     return
   }
-  test.skip(process.platform === 'win32', 'Uses POSIX SIGKILL to simulate daemon death')
 
   const session = createRestartSession(testInfo)
   let firstApp: ElectronApplication | null = null
@@ -131,8 +130,12 @@ test('resumes an agent session after quit when its daemon PTY died while the app
 
     // Why: simulates the daemon (and the agent CLI inside it) dying while the
     // app is closed — reboot, crash, or update kill. SIGKILL leaves history
-    // checkpoints unclean so the relaunch takes the cold-restore path.
+    // checkpoints unclean so the relaunch takes the cold-restore path. On
+    // Windows, Node maps SIGKILL to TerminateProcess, giving the same abrupt
+    // "no clean shutdown" semantics as POSIX SIGKILL.
     process.kill(daemonPid, 'SIGKILL')
+
+    overrideResumeLaunchCommand(session.userDataDir, PROVIDER_SESSION_ID)
 
     const secondLaunch = await session.launch()
     secondApp = secondLaunch.app

--- a/tests/e2e/agent-session-quit-resume.spec.ts
+++ b/tests/e2e/agent-session-quit-resume.spec.ts
@@ -92,7 +92,7 @@ test('resumes an agent session after quit when its daemon PTY died while the app
     // "no clean shutdown" semantics as POSIX SIGKILL.
     process.kill(daemonPid, 'SIGKILL')
 
-    overrideResumeLaunchCommand(session.userDataDir, PROVIDER_SESSION_ID)
+    overridePersistedAgentResumeCommand(session.userDataDir, PROVIDER_SESSION_ID)
 
     const secondLaunch = await session.launch()
     secondApp = secondLaunch.app

--- a/tests/e2e/agent-session-warm-restart-reboot-resume.spec.ts
+++ b/tests/e2e/agent-session-warm-restart-reboot-resume.spec.ts
@@ -1,0 +1,233 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import type { ElectronApplication } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { TEST_REPO_PATH_FILE } from './global-setup'
+import {
+  execInTerminal,
+  waitForActivePaneHookDescriptor,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager,
+  waitForPaneCount,
+  waitForTerminalOutput
+} from './helpers/terminal'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { attachRepoAndOpenTerminal, createRestartSession } from './helpers/orca-restart'
+import { PROTOCOL_VERSION } from '../../src/main/daemon/types'
+import { DEFAULT_LOCAL_ORCA_PROFILE_ID } from '../../src/shared/orca-profiles'
+
+const PROVIDER_SESSION_ID = 'e2e-warm-then-reboot-session'
+
+type PersistedWorkspaceSession = {
+  sleepingAgentSessionsByPaneKey?: Record<
+    string,
+    {
+      providerSession?: { id?: unknown }
+      launchConfig?: {
+        agentCommand?: string
+        agentArgs?: string
+        agentEnv?: Record<string, string>
+      }
+    }
+  >
+}
+
+type PersistedData = {
+  workspaceSession?: PersistedWorkspaceSession
+}
+
+function dataFilePath(userDataDir: string): string {
+  // Fresh sessions migrate the seeded legacy file, then persist only here.
+  return path.join(userDataDir, 'profiles', DEFAULT_LOCAL_ORCA_PROFILE_ID, 'orca-data.json')
+}
+
+function readPersistedData(userDataDir: string): PersistedData {
+  return JSON.parse(readFileSync(dataFilePath(userDataDir), 'utf8')) as PersistedData
+}
+
+function writePersistedData(userDataDir: string, data: PersistedData): void {
+  writeFileSync(dataFilePath(userDataDir), `${JSON.stringify(data, null, 2)}\n`, 'utf8')
+}
+
+// Why: the e2e proof should verify Orca launches the resumed command, not
+// depend on a developer machine having a real Codex CLI installed (mirrors
+// agent-session-live-force-exit-resume.spec.ts's stripPersistedPtyOwnership).
+function overrideResumeLaunchCommand(userDataDir: string, providerSessionId: string): void {
+  const data = readPersistedData(userDataDir)
+  const records = data.workspaceSession?.sleepingAgentSessionsByPaneKey
+  if (!records) {
+    throw new Error('Expected a persisted sleeping agent session record after quit')
+  }
+  let found = false
+  for (const record of Object.values(records)) {
+    if (record.providerSession?.id === providerSessionId) {
+      record.launchConfig = { agentCommand: 'echo', agentArgs: '', agentEnv: {} }
+      found = true
+    }
+  }
+  if (!found) {
+    throw new Error(
+      `No persisted sleeping agent record found for provider session ${providerSessionId}`
+    )
+  }
+  writePersistedData(userDataDir, data)
+}
+
+function readDaemonPid(userDataDir: string): number {
+  const raw = readFileSync(
+    path.join(userDataDir, 'daemon', `daemon-v${PROTOCOL_VERSION}.pid`),
+    'utf8'
+  )
+  const parsed = JSON.parse(raw) as { pid?: unknown }
+  if (typeof parsed.pid !== 'number') {
+    throw new Error(`Daemon pid file did not contain a numeric pid: ${raw}`)
+  }
+  return parsed.pid
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test('resumes an agent session after a warm restart followed by daemon death', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
+{}, testInfo) => {
+  const repoPath = readFileSync(TEST_REPO_PATH_FILE, 'utf-8').trim()
+  if (!repoPath || !existsSync(repoPath)) {
+    test.skip(true, 'Global setup did not produce a seeded test repo')
+    return
+  }
+
+  const session = createRestartSession(testInfo)
+  let firstApp: ElectronApplication | null = null
+  let secondApp: ElectronApplication | null = null
+  let thirdApp: ElectronApplication | null = null
+
+  try {
+    // --- Run 1: create the pane, seed a live provider session, quit cleanly. ---
+    const firstLaunch = await session.launch()
+    firstApp = firstLaunch.app
+    const page = firstLaunch.page
+    const worktreeId = await attachRepoAndOpenTerminal(page, repoPath)
+    await waitForSessionReady(page)
+    await waitForActiveWorktree(page)
+    await ensureTerminalVisible(page)
+    await waitForActiveTerminalManager(page, 30_000)
+    await waitForPaneCount(page, 1, 30_000)
+
+    const marker = `AGENT_WARM_REBOOT_${Date.now()}`
+    const descriptor = await waitForActivePaneHookDescriptor(page)
+    const firstPtyId = await waitForActivePanePtyId(page)
+    await execInTerminal(page, firstPtyId, `echo ${marker}`)
+    await waitForTerminalOutput(page, marker)
+
+    // Why: a real agent run reports its provider session id over the hook
+    // server; seeding the same store entry keeps this test hermetic (no agent
+    // CLI install or auth) while exercising the identical persistence path.
+    await page.evaluate(
+      ({ paneKey, worktreeId: wtId, providerSessionId }) => {
+        window.__store
+          ?.getState()
+          .setAgentStatus(
+            paneKey,
+            { state: 'working', prompt: 'finish the task', agentType: 'codex' },
+            'Codex',
+            undefined,
+            { worktreeId: wtId },
+            { providerSession: { key: 'session_id', id: providerSessionId } }
+          )
+      },
+      {
+        paneKey: descriptor.paneKey,
+        worktreeId: descriptor.worktreeId,
+        providerSessionId: PROVIDER_SESSION_ID
+      }
+    )
+
+    // Why: the daemon must survive the whole warm cycle below — read its pid
+    // now, before either app quit, so run 3 kills the same process that owned
+    // the PTY the warm-reattached pane in run 2 bound to.
+    const daemonPid = readDaemonPid(session.userDataDir)
+
+    await session.close(firstApp)
+    firstApp = null
+
+    // --- Run 2 (warm): daemon is still alive, app relaunches and reattaches
+    // to the same PTY. No hook/status traffic must be emitted here — this
+    // reproduces the pre-fix bug where the first title-derived status event
+    // on a warm-reattached pane (no providerSession) deleted the persisted
+    // sleeping-agent record. ---
+    const secondLaunch = await session.launch()
+    secondApp = secondLaunch.app
+    await waitForSessionReady(secondLaunch.page)
+    await expect
+      .poll(
+        async () => secondLaunch.page.evaluate(() => window.__store?.getState().activeWorktreeId),
+        { timeout: 15_000 }
+      )
+      .toBe(worktreeId)
+    await ensureTerminalVisible(secondLaunch.page)
+    await waitForActiveTerminalManager(secondLaunch.page, 30_000)
+    await waitForPaneCount(secondLaunch.page, 1, 30_000)
+
+    // Confirm this was a true warm reattach (same daemon PTY), not a cold
+    // restore of a fresh shell.
+    const secondPtyId = await waitForActivePanePtyId(secondLaunch.page)
+    expect(secondPtyId).toBe(firstPtyId)
+
+    // NOTE: verifies the persisted record survives a close/reopen round-trip
+    // with a live daemon; the title-event deletion path is separately guarded
+    // by the 'adopts the persisted record session...' test in agent-status.test.ts.
+    const recordId = await secondLaunch.page.evaluate(
+      (paneKey) =>
+        window.__store?.getState().sleepingAgentSessionsByPaneKey[paneKey]?.providerSession?.id,
+      descriptor.paneKey
+    )
+    expect(recordId).toBe(PROVIDER_SESSION_ID)
+
+    await session.close(secondApp)
+    secondApp = null
+
+    // --- Kill the daemon: simulates a reboot/crash/update kill while the app
+    // is closed. SIGKILL leaves history checkpoints unclean so the relaunch
+    // takes the cold-restore path. On Windows, Node maps SIGKILL to
+    // TerminateProcess, giving the same abrupt "no clean shutdown" semantics
+    // as POSIX SIGKILL. ---
+    process.kill(daemonPid, 'SIGKILL')
+
+    overrideResumeLaunchCommand(session.userDataDir, PROVIDER_SESSION_ID)
+
+    // --- Run 3: cold restore. The provider session id captured in run 1 must
+    // still drive a resume command into the freshly spawned pane. ---
+    const thirdLaunch = await session.launch()
+    thirdApp = thirdLaunch.app
+    await waitForSessionReady(thirdLaunch.page)
+    await expect
+      .poll(
+        async () => thirdLaunch.page.evaluate(() => window.__store?.getState().activeWorktreeId),
+        { timeout: 15_000 }
+      )
+      .toBe(worktreeId)
+    await ensureTerminalVisible(thirdLaunch.page)
+    await waitForActiveTerminalManager(thirdLaunch.page, 30_000)
+    await waitForPaneCount(thirdLaunch.page, 1, 30_000)
+
+    await waitForTerminalOutput(thirdLaunch.page, PROVIDER_SESSION_ID, 30_000)
+
+    // No duplicate resume tab: the run-1-origin record must not be consumed
+    // twice across the warm reattach and the later cold restore.
+    const terminalTabCount = await thirdLaunch.page.evaluate(
+      (wtId) => (window.__store?.getState().tabsByWorktree[wtId] ?? []).length,
+      worktreeId
+    )
+    expect(terminalTabCount).toBe(1)
+  } finally {
+    if (thirdApp) {
+      await session.close(thirdApp)
+    }
+    if (secondApp) {
+      await session.close(secondApp)
+    }
+    if (firstApp) {
+      await session.close(firstApp)
+    }
+    await session.dispose()
+  }
+})

--- a/tests/e2e/agent-session-warm-restart-reboot-resume.spec.ts
+++ b/tests/e2e/agent-session-warm-restart-reboot-resume.spec.ts
@@ -1,5 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
-import path from 'node:path'
+import { existsSync, readFileSync } from 'node:fs'
 import type { ElectronApplication } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
 import { TEST_REPO_PATH_FILE } from './global-setup'
@@ -13,77 +12,12 @@ import {
 } from './helpers/terminal'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 import { attachRepoAndOpenTerminal, createRestartSession } from './helpers/orca-restart'
-import { PROTOCOL_VERSION } from '../../src/main/daemon/types'
-import { DEFAULT_LOCAL_ORCA_PROFILE_ID } from '../../src/shared/orca-profiles'
+import {
+  overridePersistedAgentResumeCommand,
+  readOrcaDaemonPid
+} from './helpers/agent-session-persistence'
 
 const PROVIDER_SESSION_ID = 'e2e-warm-then-reboot-session'
-
-type PersistedWorkspaceSession = {
-  sleepingAgentSessionsByPaneKey?: Record<
-    string,
-    {
-      providerSession?: { id?: unknown }
-      launchConfig?: {
-        agentCommand?: string
-        agentArgs?: string
-        agentEnv?: Record<string, string>
-      }
-    }
-  >
-}
-
-type PersistedData = {
-  workspaceSession?: PersistedWorkspaceSession
-}
-
-function dataFilePath(userDataDir: string): string {
-  // Fresh sessions migrate the seeded legacy file, then persist only here.
-  return path.join(userDataDir, 'profiles', DEFAULT_LOCAL_ORCA_PROFILE_ID, 'orca-data.json')
-}
-
-function readPersistedData(userDataDir: string): PersistedData {
-  return JSON.parse(readFileSync(dataFilePath(userDataDir), 'utf8')) as PersistedData
-}
-
-function writePersistedData(userDataDir: string, data: PersistedData): void {
-  writeFileSync(dataFilePath(userDataDir), `${JSON.stringify(data, null, 2)}\n`, 'utf8')
-}
-
-// Why: the e2e proof should verify Orca launches the resumed command, not
-// depend on a developer machine having a real Codex CLI installed (mirrors
-// agent-session-live-force-exit-resume.spec.ts's stripPersistedPtyOwnership).
-function overrideResumeLaunchCommand(userDataDir: string, providerSessionId: string): void {
-  const data = readPersistedData(userDataDir)
-  const records = data.workspaceSession?.sleepingAgentSessionsByPaneKey
-  if (!records) {
-    throw new Error('Expected a persisted sleeping agent session record after quit')
-  }
-  let found = false
-  for (const record of Object.values(records)) {
-    if (record.providerSession?.id === providerSessionId) {
-      record.launchConfig = { agentCommand: 'echo', agentArgs: '', agentEnv: {} }
-      found = true
-    }
-  }
-  if (!found) {
-    throw new Error(
-      `No persisted sleeping agent record found for provider session ${providerSessionId}`
-    )
-  }
-  writePersistedData(userDataDir, data)
-}
-
-function readDaemonPid(userDataDir: string): number {
-  const raw = readFileSync(
-    path.join(userDataDir, 'daemon', `daemon-v${PROTOCOL_VERSION}.pid`),
-    'utf8'
-  )
-  const parsed = JSON.parse(raw) as { pid?: unknown }
-  if (typeof parsed.pid !== 'number') {
-    throw new Error(`Daemon pid file did not contain a numeric pid: ${raw}`)
-  }
-  return parsed.pid
-}
 
 test.describe.configure({ mode: 'serial' })
 
@@ -155,7 +89,7 @@ test('resumes a completed agent session after a warm restart followed by daemon 
     // Why: the daemon must survive the whole warm cycle below — read its pid
     // now, before either app quit, so run 3 kills the same process that owned
     // the PTY the warm-reattached pane in run 2 bound to.
-    const daemonPid = readDaemonPid(session.userDataDir)
+    const daemonPid = readOrcaDaemonPid(session.userDataDir)
 
     await session.close(firstApp)
     firstApp = null
@@ -203,7 +137,7 @@ test('resumes a completed agent session after a warm restart followed by daemon 
     // as POSIX SIGKILL. ---
     process.kill(daemonPid, 'SIGKILL')
 
-    overrideResumeLaunchCommand(session.userDataDir, PROVIDER_SESSION_ID)
+    overridePersistedAgentResumeCommand(session.userDataDir, PROVIDER_SESSION_ID)
 
     // --- Run 3: cold restore. The provider session id captured in run 1 must
     // still drive a resume command into the freshly spawned pane. ---

--- a/tests/e2e/agent-session-warm-restart-reboot-resume.spec.ts
+++ b/tests/e2e/agent-session-warm-restart-reboot-resume.spec.ts
@@ -87,7 +87,7 @@ function readDaemonPid(userDataDir: string): number {
 
 test.describe.configure({ mode: 'serial' })
 
-test('resumes an agent session after a warm restart followed by daemon death', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
+test('resumes a completed agent session after a warm restart followed by daemon death', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
 {}, testInfo) => {
   const repoPath = readFileSync(TEST_REPO_PATH_FILE, 'utf-8').trim()
   if (!repoPath || !existsSync(repoPath)) {
@@ -123,6 +123,7 @@ test('resumes an agent session after a warm restart followed by daemon death', a
     // CLI install or auth) while exercising the identical persistence path.
     await page.evaluate(
       ({ paneKey, worktreeId: wtId, providerSessionId }) => {
+        const providerSession = { key: 'session_id' as const, id: providerSessionId }
         window.__store
           ?.getState()
           .setAgentStatus(
@@ -131,7 +132,17 @@ test('resumes an agent session after a warm restart followed by daemon death', a
             'Codex',
             undefined,
             { worktreeId: wtId },
-            { providerSession: { key: 'session_id', id: providerSessionId } }
+            { providerSession }
+          )
+        window.__store
+          ?.getState()
+          .setAgentStatus(
+            paneKey,
+            { state: 'done', prompt: 'finish the task', agentType: 'codex' },
+            'Codex',
+            undefined,
+            { worktreeId: wtId },
+            { providerSession }
           )
       },
       {

--- a/tests/e2e/helpers/agent-session-persistence.ts
+++ b/tests/e2e/helpers/agent-session-persistence.ts
@@ -1,0 +1,52 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { PROTOCOL_VERSION } from '../../../src/main/daemon/types'
+import { DEFAULT_LOCAL_ORCA_PROFILE_ID } from '../../../src/shared/orca-profiles'
+
+type PersistedAgentSessionData = {
+  workspaceSession?: {
+    sleepingAgentSessionsByPaneKey?: Record<
+      string,
+      {
+        providerSession?: { id?: unknown }
+        launchConfig?: {
+          agentCommand?: string
+          agentArgs?: string
+          agentEnv?: Record<string, string>
+        }
+      }
+    >
+  }
+}
+
+function dataFilePath(userDataDir: string): string {
+  return path.join(userDataDir, 'profiles', DEFAULT_LOCAL_ORCA_PROFILE_ID, 'orca-data.json')
+}
+
+export function overridePersistedAgentResumeCommand(
+  userDataDir: string,
+  providerSessionId: string
+): void {
+  const dataPath = dataFilePath(userDataDir)
+  const data = JSON.parse(readFileSync(dataPath, 'utf8')) as PersistedAgentSessionData
+  const record = Object.values(data.workspaceSession?.sleepingAgentSessionsByPaneKey ?? {}).find(
+    (candidate) => candidate.providerSession?.id === providerSessionId
+  )
+  if (!record) {
+    throw new Error(`Expected persisted resumable agent session ${providerSessionId}`)
+  }
+  record.launchConfig = { agentCommand: 'echo', agentArgs: '', agentEnv: {} }
+  writeFileSync(dataPath, `${JSON.stringify(data, null, 2)}\n`, 'utf8')
+}
+
+export function readOrcaDaemonPid(userDataDir: string): number {
+  const raw = readFileSync(
+    path.join(userDataDir, 'daemon', `daemon-v${PROTOCOL_VERSION}.pid`),
+    'utf8'
+  )
+  const parsed = JSON.parse(raw) as { pid?: unknown }
+  if (typeof parsed.pid !== 'number') {
+    throw new Error(`Daemon pid file did not contain a numeric pid: ${raw}`)
+  }
+  return parsed.pid
+}


### PR DESCRIPTION
## Summary

Ports the durable agent-resume work from #9306 onto current `main`, preserving Lee Coder (`@KR-JasonLane`) as the author of the original implementation.

- keep provider-session identity across warm restarts and machine reboots
- retain recovery records until the relaunched agent confirms its matching session
- use per-tab claims to prevent duplicate automatic resumes
- retain a neutral recovery checkpoint for completed resumable TUIs without presenting completed work as pending
- preserve authoritative local `connectionId: null` and current remote/session ownership rules

## Current-main integration

The recut preserves connection-scoped clearing, remote terminal recovery, host-authoritative agent sessions, Codex account-home resume handling, and deferred worktree shutdown. Recovery matches pane, worktree, agent, provider session, origin, connection identity, and supported resume argv. Completed prompt/assistant text is removed from the private checkpoint.

## Screenshots

No visual change.

## Testing

Exact published head: `4140f681779d20b3947ae71abce7d9425cd21fd3` on base `f71373953baa1d384b75bbdf4845fda17a847da5`.

- focused current-head resume tests: 18/18
- corrected six stale retention-window fixture timestamps
- corrected the E2E call to use the imported `overridePersistedAgentResumeCommand`
- previous equivalent stack passed 648 focused tests, all three TypeScript projects, desktop/web production builds, and Electron restart/daemon-death resume E2E
- combined stable integration passed lint, all three TypeScript projects, and 3,563 focused desktop tests before the final #10046-only delta
- current installed integration `e13fa51f38102e1c3bf972e206e68fd323927406` preserved all five terminal handles/incarnations and two live Hermes TUIs across desktop restart; the daemon intentionally stayed alive, so this is continuity acceptance rather than a fresh manual daemon-death proof

## AI Review Report

The review covered duplicate-launch claims, completed-session retention, explicit local-vs-remote connection identity, imported E2E helpers, retention windows, warm restart, daemon death, and folder-workspace compatibility. Resume command construction remains provider-specific and argument-array based.

## Security Audit

No new dependency, credential path, network request, privileged IPC, or shell interpolation is introduced. Persisted records contain the minimum provider/session and launch identity required for recovery; completed prompt and assistant content is stripped from the neutral checkpoint.

## Notes

- The installed desktop continuity check deliberately did not restart daemon PID `5115`, because it owns active user PTYs.
- Deterministic E2E remains the evidence for daemon-death automatic resume.
- X handle: not provided.

## ELI5

Orca keeps the resume ticket until the restarted agent proves it has reclaimed the same session, so sessions survive restarts without double-launching.
