### PR TITLE
fix(cli): route repo add through SSH hostId, not desktop paths

### DIFF
--- a/src/cli/handlers/repo.ts
+++ b/src/cli/handlers/repo.ts
@@ -1,7 +1,12 @@
 import type { RuntimeRepoList, RuntimeRepoSearchRefs } from '../../shared/runtime-types'
 import type { CommandHandler } from '../dispatch'
 import { formatRepoList, formatRepoRefs, formatRepoShow, printResult } from '../format'
-import { getOptionalPositiveIntegerFlag, getRequiredStringFlag } from '../flags'
+import {
+  getOptionalPositiveIntegerFlag,
+  getOptionalStringFlag,
+  getRequiredStringFlag
+} from '../flags'
+import { isNonLocalRepoAddHost, resolveRepoAddHostId } from '../repo-add-host'
 import { resolveRepoPathArgument } from '../repo-path-arguments'
 
 export const REPO_HANDLERS: Record<string, CommandHandler> = {
@@ -11,8 +16,13 @@ export const REPO_HANDLERS: Record<string, CommandHandler> = {
   },
   'repo add': async ({ flags, client, cwd, json }) => {
     const repoPath = getRequiredStringFlag(flags, 'path')
+    const rawHost = getOptionalStringFlag(flags, 'host')
+    const hostId = rawHost === undefined ? undefined : resolveRepoAddHostId(rawHost)
+    const treatPathAsRemote =
+      client.isRemote || (hostId !== undefined && isNonLocalRepoAddHost(hostId))
     const result = await client.call<{ repo: Record<string, unknown> }>('repo.add', {
-      path: resolveRepoPathArgument(repoPath, cwd, client.isRemote, 'Remote repo add')
+      path: resolveRepoPathArgument(repoPath, cwd, treatPathAsRemote, 'Remote repo add'),
+      ...(hostId !== undefined ? { hostId } : {})
     })
     printResult(result, json, formatRepoShow)
   },

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -233,7 +233,7 @@ Common Commands:
   orca project setup-update --setup <setup-id> [--display-name <name>] [--path <path>] [--worktree-base-path <path>] [--git-username <name>] [--kind git|folder] [--state ready|not-set-up|setting-up|error|unsupported] [--method legacy-repo|imported-existing-folder|cloned|provisioned] [--json]
   orca project setup-delete --setup <setup-id> [--json]
   orca repo list [--json]
-  orca repo add --path <path> [--json]
+  orca repo add --path <path> [--host <host-id>] [--json]
   orca repo show --repo <selector> [--json]
   orca repo set-base-ref --repo <selector> --ref <ref> [--json]
   orca repo search-refs --repo <selector> --query <text> [--limit <n>] [--json]

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -2714,6 +2714,58 @@ describe('orca cli worktree awareness', () => {
     })
   })
 
+  it('routes repo.add --host ssh through hostId without resolving against the desktop cwd', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_repo_add', {
+        repo: {
+          id: 'repo-ssh-1',
+          path: '/home/minhun/dev/orca-r11-reconnect',
+          displayName: 'orca-r11-reconnect',
+          connectionId: 'ssh-1784350275544-cv3c0t'
+        }
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      [
+        'repo',
+        'add',
+        '--path',
+        '/home/minhun/dev/orca-r11-reconnect',
+        '--host',
+        'ssh-1784350275544-cv3c0t',
+        '--json'
+      ],
+      process.platform === 'win32' ? 'C:\\Users\\me' : '/tmp/desktop-cwd'
+    )
+
+    expect(callMock).toHaveBeenCalledWith('repo.add', {
+      path: '/home/minhun/dev/orca-r11-reconnect',
+      hostId: 'ssh:ssh-1784350275544-cv3c0t'
+    })
+  })
+
+  it('rejects invalid repo.add --host values with an --environment hint', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(
+      ['repo', 'add', '--path', '/home/me/orca', '--host', 'env:not-a-host', '--json'],
+      '/tmp/repo'
+    )
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect([...logSpy.mock.calls, ...errSpy.mock.calls].flat().join('\n')).toContain(
+      '--environment selects a paired Orca server'
+    )
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
   it.each(['C:\\repo', 'C:/repo', '\\\\server\\share\\repo', '//server/share/repo'])(
     'sends remote repo.add server absolute path %s unchanged',
     async (serverPath) => {

--- a/src/cli/repo-add-host.test.ts
+++ b/src/cli/repo-add-host.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { resolveRepoAddHostId } from './repo-add-host'
+import { RuntimeClientError } from './runtime-client'
+
+describe('resolveRepoAddHostId', () => {
+  it('accepts canonical execution host ids', () => {
+    expect(resolveRepoAddHostId('local')).toBe('local')
+    expect(resolveRepoAddHostId('ssh:ssh-1784350275544-cv3c0t')).toBe(
+      'ssh:ssh-1784350275544-cv3c0t'
+    )
+    expect(resolveRepoAddHostId('runtime:gpu')).toBe('runtime:gpu')
+  })
+
+  it('accepts bare SSH connectionIds from repo list output', () => {
+    expect(resolveRepoAddHostId('ssh-1784350275544-cv3c0t')).toBe('ssh:ssh-1784350275544-cv3c0t')
+  })
+
+  it('rejects unknown host selectors with an --environment hint', () => {
+    expect(() => resolveRepoAddHostId('env:something')).toThrow(RuntimeClientError)
+    try {
+      resolveRepoAddHostId('env:something')
+    } catch (error) {
+      expect(error).toBeInstanceOf(RuntimeClientError)
+      expect((error as RuntimeClientError).message).toContain('--environment')
+      expect((error as RuntimeClientError).message).toContain('ssh:<connectionId>')
+    }
+  })
+})

--- a/src/cli/repo-add-host.ts
+++ b/src/cli/repo-add-host.ts
@@ -1,0 +1,34 @@
+import {
+  normalizeExecutionHostId,
+  toSshExecutionHostId,
+  type ExecutionHostId
+} from '../shared/execution-host'
+import { RuntimeClientError } from './runtime-client'
+
+/**
+ * Resolve `orca repo add --host` to an ExecutionHostId.
+ * Accepts canonical ids (`local`, `ssh:…`, `runtime:…`) and bare SSH connectionIds
+ * (as shown on existing repos) by prefixing `ssh:`.
+ */
+export function resolveRepoAddHostId(rawHost: string): ExecutionHostId {
+  const trimmed = rawHost.trim()
+  const normalized = normalizeExecutionHostId(trimmed)
+  if (normalized) {
+    return normalized
+  }
+  // Why: repo list / connectionId fields omit the ssh: prefix; agents often paste that bare id.
+  if (trimmed.length > 0 && !trimmed.includes(':')) {
+    const asSsh = toSshExecutionHostId(trimmed)
+    if (normalizeExecutionHostId(asSsh)) {
+      return asSsh
+    }
+  }
+  throw new RuntimeClientError(
+    'invalid_argument',
+    `Invalid --host ${trimmed}. Use local, ssh:<connectionId>, or runtime:<environmentId>. Note: --environment selects a paired Orca server, not an SSH connectionId.`
+  )
+}
+
+export function isNonLocalRepoAddHost(hostId: ExecutionHostId): boolean {
+  return hostId !== 'local'
+}

--- a/src/cli/repo-path-arguments.test.ts
+++ b/src/cli/repo-path-arguments.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { resolveRepoPathArgument } from './repo-path-arguments'
+import { RuntimeClientError } from './runtime-client'
+
+describe('resolveRepoPathArgument', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('resolves local relative paths against cwd', () => {
+    expect(resolveRepoPathArgument('apps/web', '/tmp/repo', false)).toBe('/tmp/repo/apps/web')
+  })
+
+  it('keeps remote absolute POSIX paths unchanged', () => {
+    expect(resolveRepoPathArgument('/home/me/orca', '/tmp/client', true)).toBe('/home/me/orca')
+  })
+
+  it('rejects remote relative paths', () => {
+    expect(() =>
+      resolveRepoPathArgument('./apps/web', '/tmp/client', true, 'Remote repo add')
+    ).toThrow(/absolute path on the remote server/)
+  })
+
+  it('rejects Windows-desktop POSIX absolute paths that would become C:\\home\\...', () => {
+    vi.stubGlobal('process', { ...process, platform: 'win32' })
+    expect(() =>
+      resolveRepoPathArgument(
+        '/home/minhun/dev/orca-r11-reconnect',
+        'C:\\Users\\me',
+        false,
+        'Remote repo add'
+      )
+    ).toThrow(RuntimeClientError)
+    try {
+      resolveRepoPathArgument(
+        '/home/minhun/dev/orca-r11-reconnect',
+        'C:\\Users\\me',
+        false,
+        'Remote repo add'
+      )
+    } catch (error) {
+      expect((error as RuntimeClientError).message).toContain('--host ssh:<connectionId>')
+      expect((error as RuntimeClientError).message).toContain('not --environment')
+    }
+  })
+
+  it('preserves remote absolute paths when --host routes off the desktop', () => {
+    vi.stubGlobal('process', { ...process, platform: 'win32' })
+    expect(
+      resolveRepoPathArgument('/home/minhun/dev/orca-r11-reconnect', 'C:\\Users\\me', true)
+    ).toBe('/home/minhun/dev/orca-r11-reconnect')
+  })
+})

--- a/src/cli/repo-path-arguments.ts
+++ b/src/cli/repo-path-arguments.ts
@@ -1,4 +1,5 @@
 import { resolve as resolvePath } from 'node:path'
+import { isWindowsAbsolutePathLike } from '../shared/cross-platform-path'
 import { RuntimeClientError } from './runtime-client'
 
 function isAbsoluteServerPath(value: string): boolean {
@@ -6,7 +7,9 @@ function isAbsoluteServerPath(value: string): boolean {
     value.startsWith('/') ||
     /^[A-Za-z]:[\\/]/.test(value) ||
     value.startsWith('\\\\') ||
-    value.startsWith('//')
+    value.startsWith('//') ||
+    value === '~' ||
+    value.startsWith('~/')
   )
 }
 
@@ -17,6 +20,18 @@ export function resolveRepoPathArgument(
   remotePathSubject = 'Remote repo path'
 ): string {
   if (!isRemote) {
+    // Why: win32 path.resolve turns `/home/foo` into `C:\home\foo`, which is never the
+    // intended local path and hides SSH/remote-host imports behind a bogus desktop probe.
+    if (
+      process.platform === 'win32' &&
+      inputPath.startsWith('/') &&
+      !isWindowsAbsolutePathLike(inputPath)
+    ) {
+      throw new RuntimeClientError(
+        'invalid_argument',
+        `${remotePathSubject} looks like a remote POSIX path on the Windows desktop. Pass --host ssh:<connectionId> (not --environment) so Orca validates it on that SSH host.`
+      )
+    }
     return resolvePath(cwd, inputPath)
   }
   // Why: the local CLI cwd is unrelated to a paired runtime's filesystem.

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -39,8 +39,17 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
   {
     path: ['repo', 'add'],
     summary: 'Add a project to Orca by filesystem path',
-    usage: 'orca repo add --path <path> [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'path']
+    usage: 'orca repo add --path <path> [--host <host-id>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'path', 'host'],
+    notes: [
+      'Use --host ssh:<connectionId> (or the bare connectionId) to import a path on a connected SSH host.',
+      'Do not use --environment for SSH connectionIds; --environment selects a paired Orca server.'
+    ],
+    examples: [
+      'orca repo add --path ~/src/orca --json',
+      'orca repo add --path /home/me/orca --host ssh:ssh-123 --json',
+      'orca repo add --path /home/me/orca --host ssh-123 --json'
+    ]
   },
   {
     path: ['repo', 'show'],

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -100,6 +100,7 @@ import {
 import { getGitCloneFailureMessage } from '../../shared/git-clone-failure-message'
 import { prepareLocalWorktreeRootForRepo } from '../worktree-root-preparation'
 import { runWithGitReadCacheInvalidation } from '../git/status'
+import { addRemoteRepoFromPath, resolveRemoteHomePath } from '../repos/add-remote-repo-from-path'
 
 // Why: `method` is the IPC entry point the user took, not what they added (never path/URL/name); repos:create → 'folder_picker'.
 // Why: `isGitRepo` is a non-identifying git-vs-folder signal from the caller's detection; pass undefined when unknown, never default false.
@@ -217,116 +218,6 @@ async function addLocalRepoFromPath(
   store.addRepo(repo)
   await prepareLocalWorktreeRootForRepo(store, repo)
   return { repo, alreadyExisted: false }
-}
-
-async function addRemoteRepoFromPath(
-  store: Store,
-  args: {
-    connectionId: string
-    remotePath: string
-    displayName?: string
-    kind?: 'git' | 'folder'
-    setupMethod?: Repo['projectHostSetupMethod']
-  }
-): Promise<{ repo: Repo; alreadyExisted: boolean } | { error: string }> {
-  const gitProvider = getSshGitProvider(args.connectionId)
-  if (!gitProvider) {
-    return { error: `SSH connection "${args.connectionId}" not found or not connected` }
-  }
-
-  let repoKind: 'git' | 'folder' = args.kind ?? 'git'
-  let resolvedPath = await resolveRemoteHomePath(args.connectionId, args.remotePath)
-
-  const existing = store
-    .getRepos()
-    .find(
-      (repo) =>
-        repo.connectionId === args.connectionId &&
-        normalizeRuntimePathForComparison(repo.path) ===
-          normalizeRuntimePathForComparison(resolvedPath)
-    )
-  if (existing) {
-    return { repo: existing, alreadyExisted: true }
-  }
-
-  if (args.kind !== 'folder') {
-    try {
-      const check = await gitProvider.isGitRepoAsync(resolvedPath)
-      if (check.isRepo) {
-        repoKind = 'git'
-        if (check.rootPath) {
-          resolvedPath = check.rootPath
-        }
-      } else {
-        return { error: `Not a valid git repository: ${args.remotePath}` }
-      }
-    } catch (err) {
-      if (err instanceof Error && err.message.includes('Not a valid git repository')) {
-        return { error: err.message }
-      }
-      return { error: `Not a valid git repository: ${args.remotePath}` }
-    }
-  }
-
-  const existingAfterRootResolve = store
-    .getRepos()
-    .find(
-      (repo) =>
-        repo.connectionId === args.connectionId &&
-        normalizeRuntimePathForComparison(repo.path) ===
-          normalizeRuntimePathForComparison(resolvedPath)
-    )
-  if (existingAfterRootResolve) {
-    return { repo: existingAfterRootResolve, alreadyExisted: true }
-  }
-
-  const folderName = getRemoteRepoFolderName(resolvedPath)
-  let displayName = args.displayName || folderName
-  if (!args.displayName && (args.remotePath === '~' || args.remotePath === '~/')) {
-    const sshTarget = store.getSshTarget(args.connectionId)
-    if (sshTarget) {
-      displayName = sshTarget.label
-    }
-  }
-
-  const detected = await detectRepoIconAndUpstream({
-    repoPath: resolvedPath,
-    kind: repoKind,
-    connectionId: args.connectionId
-  })
-  const repo: Repo = {
-    id: randomUUID(),
-    path: resolvedPath,
-    displayName,
-    badgeColor: DEFAULT_REPO_BADGE_COLOR,
-    ...detected,
-    addedAt: Date.now(),
-    kind: repoKind,
-    connectionId: args.connectionId,
-    ...(repoKind === 'git'
-      ? {
-          externalWorktreeVisibility: 'hide' as const,
-          externalWorktreeVisibilityLegacy: false,
-          projectHostSetupMethod: args.setupMethod ?? ('imported-existing-folder' as const)
-        }
-      : {})
-  }
-
-  store.addRepo(repo)
-  const mux = getActiveMultiplexer(args.connectionId)
-  if (mux) {
-    mux.notify('session.registerRoot', { rootPath: resolvedPath })
-  }
-
-  return { repo, alreadyExisted: false }
-}
-
-function getRemoteRepoFolderName(remotePath: string): string {
-  const trimmed = remotePath.replace(/[\\/]+$/, '')
-  if (!trimmed) {
-    return remotePath
-  }
-  return trimmed.split(/[\\/]/).at(-1) || remotePath
 }
 
 async function cloneRemoteRepo(
@@ -578,23 +469,6 @@ async function createRemoteRepo(
   }
   emitRepoAdded('folder_picker', result.alreadyExisted)
   return { repo: result.repo }
-}
-
-async function resolveRemoteHomePath(connectionId: string, path: string): Promise<string> {
-  if (path !== '~' && path !== '~/' && !path.startsWith('~/')) {
-    return path
-  }
-  const mux = getActiveMultiplexer(connectionId)
-  if (!mux) {
-    return path
-  }
-  try {
-    const result = (await mux.request('session.resolveHome', { path })) as { resolvedPath: string }
-    return result.resolvedPath
-  } catch {
-    // Why: older relays may not support this; return the original path so callers surface their own validation error.
-    return path
-  }
 }
 
 type ActiveCloneMetadata = {

--- a/src/main/repos/add-remote-repo-from-path.ts
+++ b/src/main/repos/add-remote-repo-from-path.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from 'node:crypto'
+import { DEFAULT_REPO_BADGE_COLOR } from '../../shared/constants'
+import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+import type { Repo } from '../../shared/types'
+import { detectRepoIconAndUpstream } from '../repo-icon-autodetect'
+import type { Store } from '../persistence'
+import { getSshGitProvider } from '../providers/ssh-git-dispatch'
+import { getActiveMultiplexer } from '../ipc/ssh'
+
+export type AddRemoteRepoFromPathArgs = {
+  connectionId: string
+  remotePath: string
+  displayName?: string
+  kind?: 'git' | 'folder'
+  setupMethod?: Repo['projectHostSetupMethod']
+}
+
+export async function addRemoteRepoFromPath(
+  store: Store,
+  args: AddRemoteRepoFromPathArgs
+): Promise<{ repo: Repo; alreadyExisted: boolean } | { error: string }> {
+  const gitProvider = getSshGitProvider(args.connectionId)
+  if (!gitProvider) {
+    return { error: `SSH connection "${args.connectionId}" not found or not connected` }
+  }
+
+  let repoKind: 'git' | 'folder' = args.kind ?? 'git'
+  let resolvedPath = await resolveRemoteHomePath(args.connectionId, args.remotePath)
+
+  const existing = store
+    .getRepos()
+    .find(
+      (repo) =>
+        repo.connectionId === args.connectionId &&
+        normalizeRuntimePathForComparison(repo.path) ===
+          normalizeRuntimePathForComparison(resolvedPath)
+    )
+  if (existing) {
+    return { repo: existing, alreadyExisted: true }
+  }
+
+  if (args.kind !== 'folder') {
+    try {
+      const check = await gitProvider.isGitRepoAsync(resolvedPath)
+      if (check.isRepo) {
+        repoKind = 'git'
+        if (check.rootPath) {
+          resolvedPath = check.rootPath
+        }
+      } else {
+        return { error: `Not a valid git repository: ${args.remotePath}` }
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('Not a valid git repository')) {
+        return { error: err.message }
+      }
+      return { error: `Not a valid git repository: ${args.remotePath}` }
+    }
+  }
+
+  const existingAfterRootResolve = store
+    .getRepos()
+    .find(
+      (repo) =>
+        repo.connectionId === args.connectionId &&
+        normalizeRuntimePathForComparison(repo.path) ===
+          normalizeRuntimePathForComparison(resolvedPath)
+    )
+  if (existingAfterRootResolve) {
+    return { repo: existingAfterRootResolve, alreadyExisted: true }
+  }
+
+  const folderName = getRemoteRepoFolderName(resolvedPath)
+  let displayName = args.displayName || folderName
+  if (!args.displayName && (args.remotePath === '~' || args.remotePath === '~/')) {
+    const sshTarget = store.getSshTarget(args.connectionId)
+    if (sshTarget) {
+      displayName = sshTarget.label
+    }
+  }
+
+  const detected = await detectRepoIconAndUpstream({
+    repoPath: resolvedPath,
+    kind: repoKind,
+    connectionId: args.connectionId
+  })
+  const repo: Repo = {
+    id: randomUUID(),
+    path: resolvedPath,
+    displayName,
+    badgeColor: DEFAULT_REPO_BADGE_COLOR,
+    ...detected,
+    addedAt: Date.now(),
+    kind: repoKind,
+    connectionId: args.connectionId,
+    ...(repoKind === 'git'
+      ? {
+          externalWorktreeVisibility: 'hide' as const,
+          externalWorktreeVisibilityLegacy: false,
+          projectHostSetupMethod: args.setupMethod ?? ('imported-existing-folder' as const)
+        }
+      : {})
+  }
+
+  store.addRepo(repo)
+  const mux = getActiveMultiplexer(args.connectionId)
+  if (mux) {
+    mux.notify('session.registerRoot', { rootPath: resolvedPath })
+  }
+
+  return { repo, alreadyExisted: false }
+}
+
+export async function resolveRemoteHomePath(connectionId: string, path: string): Promise<string> {
+  if (path !== '~' && path !== '~/' && !path.startsWith('~/')) {
+    return path
+  }
+  const mux = getActiveMultiplexer(connectionId)
+  if (!mux) {
+    return path
+  }
+  try {
+    const result = (await mux.request('session.resolveHome', { path })) as { resolvedPath: string }
+    return result.resolvedPath
+  } catch {
+    // Why: older relays may not support this; return the original path so callers surface their own validation error.
+    return path
+  }
+}
+
+function getRemoteRepoFolderName(remotePath: string): string {
+  const trimmed = remotePath.replace(/[\\/]+$/, '')
+  if (!trimmed) {
+    return remotePath
+  }
+  return trimmed.split(/[\\/]/).at(-1) || remotePath
+}

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -6611,44 +6611,83 @@ describe('OrcaRuntimeService', () => {
     expect(repos[0]).not.toHaveProperty('executionHostId')
   })
 
-  it('only a runtime host adopts an unstamped repo; local/ssh imports never stamp it', async () => {
-    // Local and legacy runtime repos both have null executionHostId/connectionId, so only a runtime host may backfill; local/ssh imports leave it untouched.
-    for (const importHostId of ['local', 'ssh:ssh-target-9'] as const) {
-      const repos: Record<string, unknown>[] = [
-        {
-          id: 'repo-local-1',
-          path: '/workspace',
-          displayName: 'workspace',
-          badgeColor: 'blue',
-          addedAt: 1,
-          kind: 'folder'
-        }
-      ]
-      const runtimeStore = {
-        ...store,
-        getRepos: () => [...repos] as never,
-        addRepo: (repo: Record<string, unknown>) => {
-          repos.push(repo)
-        },
-        getRepo: (id: string) => repos.find((repo) => repo.id === id) as never,
-        updateRepo: (id: string, updates: Record<string, unknown>) => {
-          const index = repos.findIndex((repo) => repo.id === id)
-          if (index === -1) {
-            return null
-          }
-          repos[index] = { ...repos[index], ...updates }
-          return repos[index] as never
-        }
+  it('only a runtime host adopts an unstamped repo; local imports never stamp it', async () => {
+    // Local and legacy runtime repos both have null executionHostId/connectionId, so only a runtime host may backfill; local imports leave it untouched.
+    const repos: Record<string, unknown>[] = [
+      {
+        id: 'repo-local-1',
+        path: '/workspace',
+        displayName: 'workspace',
+        badgeColor: 'blue',
+        addedAt: 1,
+        kind: 'folder'
       }
-      const runtime = new OrcaRuntimeService(runtimeStore as never)
-
-      const repo = await runtime.addRepo('/workspace', 'folder', importHostId)
-
-      // The matched repo is returned unchanged — no new repo, no executionHostId stamped.
-      expect(repos).toHaveLength(1)
-      expect(repo.id).toBe('repo-local-1')
-      expect(repos[0]).not.toHaveProperty('executionHostId')
+    ]
+    const runtimeStore = {
+      ...store,
+      getRepos: () => [...repos] as never,
+      addRepo: (repo: Record<string, unknown>) => {
+        repos.push(repo)
+      },
+      getRepo: (id: string) => repos.find((repo) => repo.id === id) as never,
+      updateRepo: (id: string, updates: Record<string, unknown>) => {
+        const index = repos.findIndex((repo) => repo.id === id)
+        if (index === -1) {
+          return null
+        }
+        repos[index] = { ...repos[index], ...updates }
+        return repos[index] as never
+      }
     }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    const repo = await runtime.addRepo('/workspace', 'folder', 'local')
+
+    // The matched repo is returned unchanged — no new repo, no executionHostId stamped.
+    expect(repos).toHaveLength(1)
+    expect(repo.id).toBe('repo-local-1')
+    expect(repos[0]).not.toHaveProperty('executionHostId')
+  })
+
+  it('routes SSH hostId repo.add through the remote connection path without desktop path probing', async () => {
+    const isGitRepoAsync = vi.fn().mockResolvedValue({
+      isRepo: true,
+      rootPath: '/home/minhun/dev/orca-r11-reconnect'
+    })
+    sshGitProviders.set('ssh-1784350275544-cv3c0t', { isGitRepoAsync })
+    const repos: Record<string, unknown>[] = []
+    const runtimeStore = {
+      ...store,
+      getRepos: () => [...repos] as never,
+      addRepo: (repo: Record<string, unknown>) => {
+        repos.push(repo)
+      },
+      getRepo: (id: string) => repos.find((repo) => repo.id === id) as never,
+      getSshTarget: vi.fn().mockReturnValue({ label: 'relay-host' })
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    const repo = await runtime.addRepo(
+      '/home/minhun/dev/orca-r11-reconnect',
+      'git',
+      'ssh:ssh-1784350275544-cv3c0t'
+    )
+
+    expect(isGitRepoAsync).toHaveBeenCalledWith('/home/minhun/dev/orca-r11-reconnect')
+    expect(repo).toMatchObject({
+      path: '/home/minhun/dev/orca-r11-reconnect',
+      connectionId: 'ssh-1784350275544-cv3c0t',
+      kind: 'git'
+    })
+    expect(repos).toHaveLength(1)
+    expect(repos[0]).not.toHaveProperty('executionHostId')
+  })
+
+  it('rejects disconnected SSH hostIds instead of probing the desktop filesystem', async () => {
+    const runtime = new OrcaRuntimeService(store as never)
+    await expect(
+      runtime.addRepo('/home/minhun/dev/orca-r11-reconnect', 'git', 'ssh:ssh-missing')
+    ).rejects.toThrow('SSH connection "ssh-missing" not found or not connected')
   })
 
   it('keeps project clone setup on the cloned host-qualified repo', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -854,6 +854,7 @@ import {
   getSshGitProviderGeneration,
   requireSshGitProvider
 } from '../providers/ssh-git-dispatch'
+import { addRemoteRepoFromPath } from '../repos/add-remote-repo-from-path'
 import { detectRepoIconAndUpstream } from '../repo-icon-autodetect'
 import { enrichMissingRepoGitRemoteIdentities } from '../repo-git-remote-identity-enrichment'
 import { githubAvatarIcon } from '../../shared/repo-icon'
@@ -14420,6 +14421,32 @@ export class OrcaRuntimeService {
   ): Promise<Repo> {
     if (!this.store) {
       throw new Error('runtime_unavailable')
+    }
+    const parsedHost = parseExecutionHostId(executionHostId ?? null)
+    if (parsedHost?.kind === 'ssh') {
+      const result = await addRemoteRepoFromPath(this.store, {
+        connectionId: parsedHost.targetId,
+        remotePath: path,
+        kind
+      })
+      if ('error' in result) {
+        throw new Error(result.error)
+      }
+      this.invalidateResolvedWorktreeCache()
+      this.invalidateWorktreeScanCacheForRepo(result.repo.id)
+      this.notifyReposChanged()
+      return this.store.getRepo(result.repo.id) ?? result.repo
+    }
+    // Why: Windows path.resolve / local probes turn `/home/...` into `C:\home\...` and hide SSH imports.
+    if (
+      process.platform === 'win32' &&
+      !parsedHost &&
+      path.startsWith('/') &&
+      !path.startsWith('//')
+    ) {
+      throw new Error(
+        `Path looks like a remote POSIX path (${path}). Pass hostId ssh:<connectionId> to import it on an SSH host.`
+      )
     }
     if (!isAbsolute(path)) {
       // Why: remote clients may run in a different cwd than the server. Require

--- a/src/main/runtime/rpc/methods/repo.ts
+++ b/src/main/runtime/rpc/methods/repo.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { normalizeExecutionHostId } from '../../../../shared/execution-host'
 import { defineMethod, type RpcMethod } from '../core'
 import { OptionalFiniteNumber, OptionalString, requiredString } from '../schemas'
 import { PROJECT_RUNTIME_METHODS } from './project-runtime-rpc-methods'
@@ -11,7 +12,29 @@ const RepoSelector = z.object({
 
 const RepoPath = z.object({
   path: requiredString('Missing repo path'),
-  kind: z.enum(['git', 'folder']).optional()
+  kind: z.enum(['git', 'folder']).optional(),
+  hostId: z
+    .unknown()
+    .transform((value, ctx) => {
+      if (value === undefined || value === null || value === '') {
+        return undefined
+      }
+      if (typeof value !== 'string') {
+        ctx.addIssue({ code: 'custom', message: 'Invalid host ID' })
+        return z.NEVER
+      }
+      const hostId = normalizeExecutionHostId(value)
+      if (!hostId) {
+        ctx.addIssue({
+          code: 'custom',
+          message:
+            'Invalid host ID. Use local, ssh:<connectionId>, or runtime:<environmentId>. --environment selects a paired Orca server, not an SSH connectionId.'
+        })
+        return z.NEVER
+      }
+      return hostId
+    })
+    .optional()
 })
 
 const RepoCreate = z.object({
@@ -178,7 +201,7 @@ export const REPO_METHODS: RpcMethod[] = [
     name: 'repo.add',
     params: RepoPath,
     handler: async (params, { runtime }) => ({
-      repo: await runtime.addRepo(params.path, params.kind)
+      repo: await runtime.addRepo(params.path, params.kind, params.hostId)
     })
   }),
   defineMethod({


### PR DESCRIPTION
## Summary
- `orca repo add` now accepts `--host ssh:<connectionId>` (or a bare connectionId from `repo list`) and validates/imports the path on that SSH host instead of the Windows desktop filesystem.
- Preserves remote POSIX absolute paths (no more `C:\home\...` mangling) and clarifies that `--environment` is for paired Orca servers, not SSH connectionIds.
- Extracts shared `addRemoteRepoFromPath` for runtime RPC + IPC, with deterministic CLI/runtime regression coverage for the Linux-relay / Windows-desktop ORCH-R12 repro.

## Test plan
- [x] `npx vitest run src/cli/repo-add-host.test.ts src/cli/repo-path-arguments.test.ts src/cli/index.test.ts src/main/runtime/orca-runtime.test.ts src/main/ipc/repos-remote.test.ts` (1087 passed)
- [ ] Manual: from a Linux relay with an SSH host connected, run `orca repo add --path /absolute/remote/repo --host <connectionId> --json` and confirm the repo registers with that `connectionId`
- [ ] Manual: on Windows desktop without `--host`, confirm a POSIX `/home/...` path errors with the `--host ssh:<connectionId>` hint instead of probing `C:\home\...`
- [ ] Manual: confirm `--environment <connectionId>` still fails as unknown environment (expected), while `--host <connectionId>` succeeds


Made with [Cursor](https://cursor.com)


## ELI5

orca repo add with an SSH host used to resolve paths on your desktop filesystem and mangle Linux paths. It now validates and imports on the SSH host itself, keeping remote absolute paths intact.
