### PR TITLE
fix(runtime): do not treat Grok background tasks as tui-idle

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -12311,6 +12311,67 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  // Why (#9905): Grok Build keeps an idle OSC title + ready composer while
+  // background tasks still run. tui-idle must not treat that as task-complete.
+  it('does not resolve tui-idle while Grok background tasks are still active', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      runtime.onPtyData(
+        'pty-bg',
+        [
+          '\x1b]0;grok\x07',
+          'Tasks 1\n',
+          'Task Background sleep 60 for Orca repro  33s\n',
+          'watching · 1 command\n',
+          '> '
+        ].join(''),
+        Date.now()
+      )
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 5_000
+      })
+      const timeoutAssertion = expect(waitPromise).rejects.toThrow('timeout')
+      await vi.advanceTimersByTimeAsync(5_000)
+      await timeoutAssertion
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('resolves tui-idle for Grok once background tasks clear', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+    runtime.onPtyData(
+      'pty-bg',
+      ['\x1b]0;grok\x07', 'Tasks 0\n', 'No background tasks\n', '> '].join(''),
+      Date.now()
+    )
+
+    await expect(
+      runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 1_000 })
+    ).resolves.toMatchObject({
+      handle,
+      condition: 'tui-idle',
+      status: 'running'
+    })
+  })
+
   it('resolves tui-idle from an Antigravity ready prompt preview', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -12372,6 +12372,60 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  // Why (#9905): live OSC idle transition is the primary waiter path and must
+  // not bypass the background-work veto (immediate/poll paths alone are not enough).
+  it('does not resolve tui-idle on idle OSC title while Grok background tasks remain', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      runtime.onPtyData(
+        'pty-bg',
+        [
+          '\x1b]0;\u280b Grok\x07',
+          'Tasks 1\n',
+          'Task Background sleep 60 for Orca repro  33s\n',
+          'watching · 1 command\n',
+          '> '
+        ].join(''),
+        Date.now()
+      )
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 5_000
+      })
+      let settled: 'resolved' | 'rejected' | null = null
+      void waitPromise.then(
+        () => {
+          settled = 'resolved'
+        },
+        () => {
+          settled = 'rejected'
+        }
+      )
+
+      // Non-idle → idle title transition while HUD still shows Tasks 1
+      runtime.onPtyData('pty-bg', '\x1b]0;Grok\x07', Date.now())
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(settled).toBeNull()
+
+      const timeoutAssertion = expect(waitPromise).rejects.toThrow('timeout')
+      await vi.advanceTimersByTimeAsync(5_000)
+      await timeoutAssertion
+      expect(settled).toBe('rejected')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('resolves tui-idle from an Antigravity ready prompt preview', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -12357,15 +12357,19 @@ describe('OrcaRuntimeService', () => {
       getForegroundProcess: async () => null
     })
     const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+    // Why: seed active background work, then clear — proves Tasks 1 → Tasks 0 releases waiters.
+    runtime.onPtyData('pty-bg', 'Tasks 1\nwatching · 1 command\n> ', Date.now())
+    const waitPromise = runtime.waitForTerminal(handle, {
+      condition: 'tui-idle',
+      timeoutMs: 1_000
+    })
     runtime.onPtyData(
       'pty-bg',
       ['\x1b]0;grok\x07', 'Tasks 0\n', 'No background tasks\n', '> '].join(''),
       Date.now()
     )
 
-    await expect(
-      runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 1_000 })
-    ).resolves.toMatchObject({
+    await expect(waitPromise).resolves.toMatchObject({
       handle,
       condition: 'tui-idle',
       status: 'running'

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -13243,11 +13243,16 @@ export class OrcaRuntimeService {
       if (condition === 'tui-idle' && ptyBlockedReason) {
         return buildPtyTerminalWaitBlockedResult(handle, condition, pty.pty, ptyBlockedReason)
       }
-      if (condition === 'tui-idle' && pty.pty.lastAgentStatus === 'idle') {
+      if (
+        condition === 'tui-idle' &&
+        !hasActiveAgentBackgroundWork(ptyWaitText) &&
+        pty.pty.lastAgentStatus === 'idle'
+      ) {
         return buildPtyTerminalWaitResult(handle, condition, pty.pty)
       }
       if (
         condition === 'tui-idle' &&
+        !hasActiveAgentBackgroundWork(ptyWaitText) &&
         (this.getAdoptedPtyExplicitIdleStatus(pty.pty) === 'idle' ||
           isKnownReadyPromptPreview(ptyWaitText))
       ) {
@@ -13303,11 +13308,15 @@ export class OrcaRuntimeService {
               waiter,
               buildPtyTerminalWaitBlockedResult(handle, condition, live.pty, blockedReason)
             )
-          } else if (live.pty.lastAgentStatus === 'idle') {
+          } else if (
+            !hasActiveAgentBackgroundWork(livePtyWaitText) &&
+            live.pty.lastAgentStatus === 'idle'
+          ) {
             this.resolveWaiter(waiter, buildPtyTerminalWaitResult(handle, condition, live.pty))
           } else if (
-            this.getAdoptedPtyExplicitIdleStatus(live.pty) === 'idle' ||
-            isKnownReadyPromptPreview(livePtyWaitText)
+            !hasActiveAgentBackgroundWork(livePtyWaitText) &&
+            (this.getAdoptedPtyExplicitIdleStatus(live.pty) === 'idle' ||
+              isKnownReadyPromptPreview(livePtyWaitText))
           ) {
             this.resolveWaiter(waiter, buildPtyTerminalWaitResult(handle, condition, live.pty))
           } else {
@@ -13333,10 +13342,15 @@ export class OrcaRuntimeService {
     // detection that powers the renderer's "Task complete" notifications.
     // Why: only 'idle' satisfies tui-idle, not 'permission'. Permission means the
     // agent is blocked on user approval, not finished with its task.
-    if (condition === 'tui-idle' && leaf.lastAgentStatus === 'idle') {
+    // Why: also refuse idle while Grok-style background tasks are still active (#9905).
+    if (
+      condition === 'tui-idle' &&
+      !hasActiveAgentBackgroundWork(leafWaitText) &&
+      leaf.lastAgentStatus === 'idle'
+    ) {
       return buildTerminalWaitResult(handle, condition, leaf)
     }
-    if (condition === 'tui-idle') {
+    if (condition === 'tui-idle' && !hasActiveAgentBackgroundWork(leafWaitText)) {
       const fastPathTitle = leaf.paneTitle ?? this.tabs.get(leaf.tabId)?.title
       if (
         (fastPathTitle && detectExplicitIdleStatusFromTitle(fastPathTitle) === 'idle') ||
@@ -13405,7 +13419,10 @@ export class OrcaRuntimeService {
               waiter,
               buildTerminalWaitBlockedResult(handle, condition, live.leaf, blockedReason)
             )
-          } else if (live.leaf.lastAgentStatus === 'idle') {
+          } else if (
+            !hasActiveAgentBackgroundWork(liveLeafWaitText) &&
+            live.leaf.lastAgentStatus === 'idle'
+          ) {
             // Why: don't clear lastAgentStatus here. It's a factual record of the
             // last detected OSC state, not a one-shot signal. Clearing it causes
             // subsequent tui-idle waiters to hang even though the agent is idle —
@@ -13415,10 +13432,12 @@ export class OrcaRuntimeService {
             // Why: renderer-synced previews can show a known ready prompt even
             // while the last OSC title is still "working"; keep polling the
             // preview/title until the waiter resolves or hits its timeout.
+            // Why: suppress while Grok-style background tasks are still active (#9905).
             const fastPathTitle = live.leaf.paneTitle ?? this.tabs.get(live.leaf.tabId)?.title
             if (
-              (fastPathTitle && detectExplicitIdleStatusFromTitle(fastPathTitle) === 'idle') ||
-              isKnownReadyPromptPreview(liveLeafWaitText)
+              !hasActiveAgentBackgroundWork(liveLeafWaitText) &&
+              ((fastPathTitle && detectExplicitIdleStatusFromTitle(fastPathTitle) === 'idle') ||
+                isKnownReadyPromptPreview(liveLeafWaitText))
             ) {
               this.resolveWaiter(waiter, buildTerminalWaitResult(handle, condition, live.leaf))
             } else {
@@ -26065,7 +26084,14 @@ export class OrcaRuntimeService {
       }
       let startedForegroundPoll = false
       try {
-        if (leaf.lastAgentStatus === 'idle') {
+        const leafWaitText = buildTerminalWaitText(
+          leaf.tailBuffer,
+          leaf.tailPartialLine,
+          leaf.preview
+        )
+        // Why: Grok can stay OSC-idle while background tasks still run (#9905).
+        const backgroundWorkActive = hasActiveAgentBackgroundWork(leafWaitText)
+        if (leaf.lastAgentStatus === 'idle' && !backgroundWorkActive) {
           if (waiter.pollInterval) {
             clearInterval(waiter.pollInterval)
             waiter.pollInterval = null
@@ -26075,7 +26101,7 @@ export class OrcaRuntimeService {
         }
         // Why: the renderer-synced title is the only path where OSC titles are visible for daemon-hosted terminals.
         const pollTitle = leaf.paneTitle ?? this.tabs.get(leaf.tabId)?.title
-        if (pollTitle) {
+        if (pollTitle && !backgroundWorkActive) {
           const titleStatus = detectExplicitIdleStatusFromTitle(pollTitle)
           if (titleStatus === 'idle') {
             if (waiter.pollInterval) {
@@ -26086,11 +26112,6 @@ export class OrcaRuntimeService {
             return
           }
         }
-        const leafWaitText = buildTerminalWaitText(
-          leaf.tailBuffer,
-          leaf.tailPartialLine,
-          leaf.preview
-        )
         const blockedReason = detectTerminalWaitBlockedReason(leafWaitText)
         if (blockedReason) {
           if (waiter.pollInterval) {
@@ -26150,7 +26171,10 @@ export class OrcaRuntimeService {
       }
       let startedForegroundPoll = false
       try {
-        if (pty.lastAgentStatus === 'idle') {
+        const ptyWaitText = buildTerminalWaitText(pty.tailBuffer, pty.tailPartialLine, pty.preview)
+        // Why: Grok can stay OSC-idle while background tasks still run (#9905).
+        const backgroundWorkActive = hasActiveAgentBackgroundWork(ptyWaitText)
+        if (pty.lastAgentStatus === 'idle' && !backgroundWorkActive) {
           if (waiter.pollInterval) {
             clearInterval(waiter.pollInterval)
             waiter.pollInterval = null
@@ -26158,7 +26182,6 @@ export class OrcaRuntimeService {
           this.resolveWaiter(waiter, buildPtyTerminalWaitResult(waiter.handle, 'tui-idle', pty))
           return
         }
-        const ptyWaitText = buildTerminalWaitText(pty.tailBuffer, pty.tailPartialLine, pty.preview)
         const blockedReason = detectTerminalWaitBlockedReason(ptyWaitText)
         if (blockedReason) {
           if (waiter.pollInterval) {
@@ -26173,8 +26196,9 @@ export class OrcaRuntimeService {
         }
         // Why: adopted background PTY handles use their live xterm title as the same readiness signal as leaf handles.
         if (
-          this.getAdoptedPtyExplicitIdleStatus(pty) === 'idle' ||
-          isKnownReadyPromptPreview(ptyWaitText)
+          !backgroundWorkActive &&
+          (this.getAdoptedPtyExplicitIdleStatus(pty) === 'idle' ||
+            isKnownReadyPromptPreview(ptyWaitText))
         ) {
           if (waiter.pollInterval) {
             clearInterval(waiter.pollInterval)
@@ -30696,6 +30720,11 @@ function detectExplicitIdleStatusFromTitle(title: string): AgentStatus | null {
 
 function isKnownReadyPromptPreview(preview: string): boolean {
   const normalized = preview.toLowerCase()
+  // Why: Grok (and similar) can expose a ready composer while background tasks
+  // still run — that is input-ready, not task-complete (#9905).
+  if (hasActiveAgentBackgroundWork(normalized)) {
+    return false
+  }
   const readyIndex = findKnownReadyPromptIndex(normalized)
   if (readyIndex === null) {
     return false
@@ -30705,6 +30734,22 @@ function isKnownReadyPromptPreview(preview: string): boolean {
     return false
   }
   return true
+}
+
+// Why: tui-idle is used as task-complete evidence by coordinators. Grok Build
+// keeps the input prompt (and often an idle OSC title) while background tasks
+// are still live ("Tasks 1", "watching · 1 command"); treat that as not idle.
+function hasActiveAgentBackgroundWork(preview: string): boolean {
+  const normalized = preview.toLowerCase()
+  // "watching · 1 command" / "watching • 2 commands" — Grok task HUD chrome
+  if (/\bwatching\s*[·.•]\s*[1-9]\d*\s+commands?\b/.test(normalized)) {
+    return true
+  }
+  // "Tasks 1" with at least one task row still listed
+  if (/\btasks\s+[1-9]\d*\b/.test(normalized) && /\btask\b/.test(normalized)) {
+    return true
+  }
+  return false
 }
 
 function detectTerminalWaitBlockedReason(preview: string): RuntimeTerminalWaitBlockedReason | null {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -26033,8 +26033,13 @@ export class OrcaRuntimeService {
     if (!waiters || waiters.size === 0) {
       return
     }
+    // Why: OSC idle can fire while Grok background tasks still run (#9905).
+    // Skip here; the fallback poll re-checks and resolves once work clears.
+    const backgroundWorkActive = hasActiveAgentBackgroundWork(
+      buildTerminalWaitText(leaf.tailBuffer, leaf.tailPartialLine, leaf.preview)
+    )
     for (const waiter of [...waiters]) {
-      if (waiter.condition === 'tui-idle') {
+      if (waiter.condition === 'tui-idle' && !backgroundWorkActive) {
         this.resolveWaiter(waiter, buildTerminalWaitResult(handle, 'tui-idle', leaf))
       }
     }
@@ -26068,8 +26073,13 @@ export class OrcaRuntimeService {
     if (!waiters || waiters.size === 0) {
       return
     }
+    // Why: title-transition path is the primary live trigger; gate it the same
+    // as immediate/poll checks so Grok background HUD still blocks tui-idle.
+    const backgroundWorkActive = hasActiveAgentBackgroundWork(
+      buildTerminalWaitText(pty.tailBuffer, pty.tailPartialLine, pty.preview)
+    )
     for (const waiter of [...waiters]) {
-      if (waiter.condition === 'tui-idle') {
+      if (waiter.condition === 'tui-idle' && !backgroundWorkActive) {
         this.resolveWaiter(waiter, buildPtyTerminalWaitResult(handle, 'tui-idle', pty))
       }
     }


### PR DESCRIPTION
## 🧑‍🤝‍🧑 Impact & ELI5

**1) What's broken today (ELI5).**  
Orca lets you script AI coding agents: “wait until the agent is done, then do the next thing.” The command for that is:

```bash
orca terminal wait --terminal <handle> --for tui-idle --timeout-ms …
```

With **Grok Build**, that check can answer **“yes, done!” almost immediately even while Grok is still running background work** (for example a long `sleep` or an external command that Grok is still *watching*). The terminal still shows chrome like:

```text
Tasks 1
Task Background sleep 60 for Orca repro  33s
watching · 1 command
```

…and often still has a ready-looking input prompt. Automation that treats `tui-idle` as **task complete** then synthesizes a result, dispatches the next step, or stops monitoring **before the background work finishes**.

This is narrower than the older “busy TUI looked idle from a weak title” class of bugs (#6011 / #6555): **foreground** busy work is already handled correctly on the same terminal. The false positive is specific to **Grok’s live background-task state** while the composer still looks idle.

**2) What this PR does (ELI5).**  
It teaches `tui-idle` a simple extra rule:

> If the terminal wait-text still shows Grok-style **active background-task HUD chrome**, do **not** treat the TUI as idle — even if the OSC title says idle and the composer looks ready.

Once that chrome goes away (task finished / no more “watching N commands”), normal idle resolution works again.

**3) Tradeoffs / regressions — honest answer.**

| Concern | Assessment |
|--------|------------|
| Latency when truly idle | **None** for the common path: no HUD chrome → same immediate resolution as before |
| Latency while Grok background tasks run | Wait correctly continues / times out instead of false-success — **this is the fix** |
| Other agents (Codex, Claude, Antigravity, …) | Unaffected unless their wait-text literally matches the same HUD patterns (unlikely) |
| False positives | Possible if user/agent *text* happens to contain `Tasks 3` + `task` or `watching · 2 commands`. Patterns are deliberately tight (`N ≥ 1`, optional middle-dot, “command(s)”). Happy to tighten further if live Grok copy differs |
| API surface | **No new flags / conditions.** `tui-idle` stays the single condition; we keep its intended “task complete / quiescent” semantics rather than splitting input-ready vs task-complete in this PR |
| Platforms | Text-level wait-path only — macOS / Linux / Windows / SSH / remote runtime all share the same code |

No settings, UI, Git-provider, or agent-launch changes.

---

## Summary

`orca terminal wait --for tui-idle` can return `satisfied: true` in ~100ms while **Grok Build still has active background tasks**.

**Root cause**

`waitForTerminal(..., { condition: 'tui-idle' })` has several *immediate success* paths:

1. `lastAgentStatus === 'idle'` (from OSC title classification)
2. Explicit idle title markers
3. Known body-level ready prompts (`isKnownReadyPromptPreview`)

Grok Build can:

- set an **idle** OSC title (e.g. bare `grok`) and/or show a ready composer, **while**
- still rendering active background-task HUD: `Tasks 1`, `Task …`, `watching · 1 command`

So the waiter resolves as soon as idle evidence appears, without checking whether background work is still live. That matches the reporter’s control case: **foreground** `sleep` correctly stays non-idle (timeout), **background** `sleep` false-succeeds.

This is the gap left after #6555’s intentional design: body-level ready prompts remain a fast path. When Grok exposes a ready prompt *and* background tasks, that fast path (or the idle OSC path) is still wrong for “task complete.”

**Fix**

Add `hasActiveAgentBackgroundWork(waitText)` and use it as a **hard veto** on every tui-idle success path (immediate + fallback poll, leaf + PTY):

```ts
// Patterns derived from #9905’s reported Grok Build HUD
/\bwatching\s*[·.•]\s*[1-9]\d*\s+commands?\b/
/\btasks\s+[1-9]\d*\b/  &&  /\btask\b/   // count ≥ 1 plus a task row
```

When the veto fires, the waiter keeps polling / eventually times out instead of returning early success. When the HUD clears, normal idle resolution resumes.

**Why not a new wait condition?**  
Issue #9905 discusses optionally splitting input-ready vs task-complete. That would be a larger API change for CLI/skills/orchestration docs. This PR keeps `tui-idle` meaning “safe to treat the agent turn as quiescent for orchestration,” which is how docs and skills already use it, and only plugs the Grok background false positive.

Fixes #9905

---

## Evidence

### Automated tests

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/main/runtime/orca-runtime.test.ts -t "tui-idle"
```

**Result: 18/18 passed** (including two new cases)

| New test | Asserts |
|----------|---------|
| `does not resolve tui-idle while Grok background tasks are still active` | Idle OSC (`grok`) + `Tasks 1` / `watching · 1 command` → **timeout** (no false success) |
| `resolves tui-idle for Grok once background tasks clear` | Idle OSC + `Tasks 0` / no watching line → **satisfied** |

Existing tui-idle cases still green (Codex ready prompt, Antigravity, coalesced titles, adopted PTY, launch-title rejection, etc.).

### Manual repro (from #9905) — expected after this PR

```bash
# While Grok is watching a background sleep / command:
orca terminal read --terminal <handle> --json
# still shows: Tasks 1, watching · N command

orca terminal wait --terminal <handle> --for tui-idle --timeout-ms 5000 --json
# BEFORE: satisfied true in ~0.1s
# AFTER:  timeout (or wait until background HUD clears, then satisfied)
```

I did not re-run against a live Grok Build binary in this environment; the regression fixture matches the issue’s reported HUD text byte-for-byte for the critical lines. If production Grok chrome differs (wording / glyphs), we can extend the detector without changing the architecture.

### Code map

| Location | Change |
|----------|--------|
| `hasActiveAgentBackgroundWork()` | New detector (Grok HUD chrome) |
| `isKnownReadyPromptPreview()` | Veto ready-prompt fast path when background work active |
| `waitForTerminal` (PTY + leaf) | Veto `lastAgentStatus === 'idle'`, explicit title idle, and ready-prompt immediate resolve |
| `startTuiIdleFallbackPoll` / `startPtyTuiIdleFallbackPoll` | Same veto so the 2s poll cannot re-introduce the false success |
| `orca-runtime.test.ts` | Regression + “cleared” control case |

---

## ELI5

Grok can look “ready for input” while it is still babysitting a background command. Orca used to treat “ready for input” as “done with the job.” Now Orca also looks for Grok’s “I’m still watching N commands” status and refuses to say “done” until that goes away.

---

## User-regression-tradeoffs

- **Intended behavior change:** `tui-idle` no longer returns success while Grok background-task HUD is visible. Callers that wanted “composer is typeable” while background work continues may now wait longer / hit timeout. That is correct for the documented orchestration use of `tui-idle` as a completion/liveness checkpoint.
- **If someone needs input-ready specifically:** that remains a possible follow-up API (`tui-input-ready` vs `tui-idle`); not introduced here to keep the PR focused and backward-compatible for the common “wait until agent finished” meaning.
- **False positive risk:** low for normal agent output; patterns require count ≥ 1 and Grok-like phrasing. Worst case of a false positive: wait times out and coordinator re-checks via `terminal read` — safer than early success.
- **No change** for agents that don’t emit this HUD while “idle.”

---

## Checklist notes (CONTRIBUTING / AGENTS)

| Area | Notes |
|------|--------|
| **Cross-platform** | Pure wait-text classification in main runtime; no platform branches. macOS/Linux/Windows share the path. |
| **SSH / remote** | Uses the same `tailBuffer` / `preview` wait-text already used for remote/daemon-hosted terminals and fallback polls. No local-only assumption. |
| **Agents / integrations** | Targeted at Grok Build background HUD; other agents only affected if wait-text matches the same strings. No agent-launch / hook changes. |
| **Git / providers** | N/A |
| **Performance** | One extra pair of regexes over wait-text that is already built for every tui-idle check. No hot-path allocations beyond existing string lowercasing. |
| **UI** | No visual change. |
| **Security** | No new IPC, no secrets, no elevated privileges. |
| **Tests** | Regression tests for active vs cleared background HUD; full `tui-idle` suite green. |

---

## Test plan

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "tui-idle"` → 18/18
- [x] New timeout case: idle OSC + `Tasks 1` + `watching · 1 command`
- [x] New success case: idle OSC + `Tasks 0` / no watching chrome
- [ ] Optional live smoke (reviewer / reporter): Grok background `sleep 60` + `terminal wait --for tui-idle --timeout-ms 5000` should **not** succeed early; after task ends, wait should succeed

---

## Out of scope (follow-ups welcome)

- New public wait condition for “input-ready but not quiescent”
- Structured agent status from Grok hooks (more durable than HUD scraping)
- Broadening detectors if live Grok Build chrome differs from the issue fixture

---

## AI code-review summary

Self-review against project rules:

1. **Cross-platform** — text-only runtime wait path; no `metaKey`/path separators/menu accelerators.
2. **SSH/remote** — uses existing wait-text sources used for daemon/remote PTYs; no host-local-only APIs.
3. **Agents** — Grok-specific HUD patterns; no change to spawn/hook config.
4. **Performance** — constant-time regexes on already-constructed wait-text; no extra IPC.
5. **UI** — none.
6. **Security** — none.
7. **Correctness risk** — string heuristics can drift with upstream Grok UI; mitigated by tight patterns + tests + easy extension point (`hasActiveAgentBackgroundWork`).

---

Made with care for orchestration reliability 🐋