### PR TITLE
fix(runtime): keep lastAssistantMessage on demoted remote agent status

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -17814,6 +17814,86 @@ describe('OrcaRuntimeService', () => {
     expect(suppressed?.type === 'terminal' && suppressed.agentStatus?.terminalTitle).toBeUndefined()
   })
 
+  // Why (#9914): paired clients mirror this projection (not local hook IPC). Dropping
+  // lastAssistantMessage when demoting stale "working" left remote workspace cards
+  // without the completion subtitle that local cards still show from the hook row.
+  it('keeps lastAssistantMessage when demoting stale working status under a neutral title', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'claude working',
+          activeLeafId: leafId,
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          leafId,
+          paneRuntimeId: 1,
+          ptyId: 'pty-1',
+          paneTitle: 'bash'
+        }
+      ],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'epoch-1',
+          snapshotVersion: 1,
+          activeGroupId: null,
+          activeTabId: `tab-1::${leafId}`,
+          activeTabType: 'terminal',
+          tabs: [
+            {
+              type: 'terminal',
+              id: `tab-1::${leafId}`,
+              parentTabId: 'tab-1',
+              leafId,
+              title: 'bash',
+              agentStatus: {
+                state: 'working',
+                prompt: 'stale task',
+                updatedAt: 1_700_000_000_000,
+                stateStartedAt: 1_699_999_999_000,
+                agentType: 'claude',
+                paneKey: `tab-1:${leafId}`,
+                terminalTitle: 'claude working',
+                lastAssistantMessage: '좌→우 가로 파이프라인으로 다시 그렸습니다',
+                interrupted: false,
+                stateHistory: []
+              },
+              isActive: true
+            }
+          ]
+        }
+      ]
+    })
+
+    const result = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    const tab = result.tabs[0]
+    expect(tab?.type).toBe('terminal')
+    if (tab?.type !== 'terminal') {
+      return
+    }
+    expect(tab.agentStatus).toEqual(
+      expect.objectContaining({
+        state: 'done',
+        agentType: 'claude',
+        lastAssistantMessage: '좌→우 가로 파이프라인으로 다시 그렸습니다',
+        interrupted: false
+      })
+    )
+    // Still demote the working spinner / stale prompt / title ownership fields.
+    expect(tab.agentStatus?.prompt).toBe('')
+    expect(tab.agentStatus?.terminalTitle).toBeUndefined()
+  })
+
   it('suppresses saved mobile agent status when the current terminal title is neutral', async () => {
     const runtime = new OrcaRuntimeService(store)
     const leafId = '11111111-1111-4111-8111-111111111111'

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -27535,6 +27535,86 @@ describe('OrcaRuntimeService', () => {
     expect(suppressed?.type === 'terminal' && suppressed.agentStatus?.terminalTitle).toBeUndefined()
   })
 
+  // Why (#9914): paired clients mirror this projection (not local hook IPC). Dropping
+  // lastAssistantMessage when demoting stale "working" left remote workspace cards
+  // without the completion subtitle that local cards still show from the hook row.
+  it('keeps lastAssistantMessage when demoting stale working status under a neutral title', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'claude working',
+          activeLeafId: leafId,
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: TEST_WORKTREE_ID,
+          leafId,
+          paneRuntimeId: 1,
+          ptyId: 'pty-1',
+          paneTitle: 'bash'
+        }
+      ],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'epoch-1',
+          snapshotVersion: 1,
+          activeGroupId: null,
+          activeTabId: `tab-1::${leafId}`,
+          activeTabType: 'terminal',
+          tabs: [
+            {
+              type: 'terminal',
+              id: `tab-1::${leafId}`,
+              parentTabId: 'tab-1',
+              leafId,
+              title: 'bash',
+              agentStatus: {
+                state: 'working',
+                prompt: 'stale task',
+                updatedAt: 1_700_000_000_000,
+                stateStartedAt: 1_699_999_999_000,
+                agentType: 'claude',
+                paneKey: `tab-1:${leafId}`,
+                terminalTitle: 'claude working',
+                lastAssistantMessage: '좌→우 가로 파이프라인으로 다시 그렸습니다',
+                interrupted: false,
+                stateHistory: []
+              },
+              isActive: true
+            }
+          ]
+        }
+      ]
+    })
+
+    const result = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    const tab = result.tabs[0]
+    expect(tab?.type).toBe('terminal')
+    if (tab?.type !== 'terminal') {
+      return
+    }
+    expect(tab.agentStatus).toEqual(
+      expect.objectContaining({
+        state: 'done',
+        agentType: 'claude',
+        lastAssistantMessage: '좌→우 가로 파이프라인으로 다시 그렸습니다',
+        interrupted: false
+      })
+    )
+    // Still demote the working spinner / stale prompt / title ownership fields.
+    expect(tab.agentStatus?.prompt).toBe('')
+    expect(tab.agentStatus?.terminalTitle).toBeUndefined()
+  })
+
   it('suppresses saved mobile agent status when the current terminal title is neutral', async () => {
     const runtime = new OrcaRuntimeService(store)
     const leafId = '11111111-1111-4111-8111-111111111111'

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -25017,6 +25017,7 @@ export class OrcaRuntimeService {
       const agentStatus = keepFullAgentStatus
         ? { agentStatus: normalizedTabAgentStatus }
         : // Why: idle live title → drop stale "working" (no spinner) but keep agent identity so native chat can still address the transcript.
+          // Why: also keep lastAssistantMessage / interrupted so paired clients and mobile can still show the completion subtitle (#9914). Local desktop already has the full hook row in-process; remote mirrors only this projection.
           normalizedTabAgentStatus?.agentType != null
           ? {
               agentStatus: {
@@ -25027,6 +25028,12 @@ export class OrcaRuntimeService {
                 paneKey: normalizedTabAgentStatus.paneKey,
                 stateHistory: [],
                 agentType: normalizedTabAgentStatus.agentType,
+                ...(normalizedTabAgentStatus.lastAssistantMessage
+                  ? { lastAssistantMessage: normalizedTabAgentStatus.lastAssistantMessage }
+                  : {}),
+                ...(normalizedTabAgentStatus.interrupted != null
+                  ? { interrupted: normalizedTabAgentStatus.interrupted }
+                  : {}),
                 ...(normalizedTabAgentStatus.providerSession
                   ? { providerSession: normalizedTabAgentStatus.providerSession }
                   : {})

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -36417,6 +36417,7 @@ export class OrcaRuntimeService {
       const agentStatus = keepFullAgentStatus
         ? { agentStatus: normalizedTabAgentStatus }
         : // Why: idle live title → drop stale "working" (no spinner) but keep agent identity so native chat can still address the transcript.
+          // Why: also keep lastAssistantMessage / interrupted so paired clients and mobile can still show the completion subtitle (#9914). Local desktop already has the full hook row in-process; remote mirrors only this projection.
           normalizedTabAgentStatus?.agentType != null
           ? {
               agentStatus: {
@@ -36429,6 +36430,12 @@ export class OrcaRuntimeService {
                 paneKey: normalizedTabAgentStatus.paneKey,
                 stateHistory: [],
                 agentType: normalizedTabAgentStatus.agentType,
+                ...(normalizedTabAgentStatus.lastAssistantMessage
+                  ? { lastAssistantMessage: normalizedTabAgentStatus.lastAssistantMessage }
+                  : {}),
+                ...(normalizedTabAgentStatus.interrupted != null
+                  ? { interrupted: normalizedTabAgentStatus.interrupted }
+                  : {}),
                 ...(normalizedTabAgentStatus.providerSession
                   ? { providerSession: normalizedTabAgentStatus.providerSession }
                   : {})


### PR DESCRIPTION
## 🧑‍🤝‍🧑 Impact & ELI5

**1) What's broken today (ELI5).**  
When your laptop is **paired to a remote Orca runtime** (headless `orca serve` on a Linux box, etc.), the workspace list on the laptop shows each remote workspace’s name but **not the last agent message** under it — the little completion/subtitle line that tells you what Claude/Codex/… just said.

On **local** workspaces on the same laptop, that subtitle works. On **remote/paired** ones, it’s empty.

This is not a data-loss bug on the remote host. `orca worktree ps --json` on the node still returns populated `agents[].lastAssistantMessage`. The remote runtime has the text; the **paired client UI never receives it** on the path it uses for workspace cards.

**2) What this PR does (ELI5).**  
When the runtime publishes terminal surfaces for remote/mobile clients, an agent that is no longer “spinning” gets a slimmed-down status (so we don’t show a fake “working” spinner). That slimmed-down row used to **throw away the last assistant message**. We now **keep the last message (and interrupt flag)** while still demoting the spinner/prompt.

Local behavior is unchanged. Remote/paired cards can finally show the same completion subtitle local cards already show.

**3) Tradeoffs / regressions — honest answer.**

| Concern | Assessment |
|--------|------------|
| Local desktop | **No change.** Local still uses the full in-process hook row via IPC, not this demoted projection. |
| Stale “working” spinners | **Still suppressed.** We still force `state: 'done'`, clear `prompt`, drop terminal-title ownership fields when live evidence is neutral/non-agent. |
| Payload size | Slightly larger demoted status when a completion message exists (up to the existing lastAssistantMessage cap). Acceptable; this is the intentional preview field. |
| Platforms / SSH / pairing | Single publication path in main runtime; paired clients, web, and mobile that mirror session tabs all benefit. |
| API surface | No new RPC/CLI flags. |

---

## Summary

**Bug:** Remote (paired) workspace cards omit the last agent message subtitle; local cards show it.  
**Root cause:** In `listMobileSessionTabs` / session-tab publication (`orca-runtime.ts`), when `keepFullAgentStatus` is false (neutral / non-agent live title without live tool/prompt signal), full hook status is demoted to:

```ts
{ state: 'done', prompt: '', agentType, /* … */ }
```

…and **`lastAssistantMessage` was omitted**.

- **Local desktop:** renderer already has the full `agentStatusByPaneKey` entry from hook IPC → subtitle works.  
- **Paired client:** only mirrors this published projection → subtitle empty, even though `worktree ps` still has the message (different code path that already preserved `lastAssistantMessage`).

**Fix:** When demoting, preserve:

- `lastAssistantMessage` (completion subtitle for WorktreeCardAgents / compact rows)
- `interrupted` (same secondary-line path)

Still demote spinner/working/prompt/title ownership exactly as before.

Fixes #9914

---

## Evidence

### Automated

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/main/runtime/orca-runtime.test.ts \
  -t "keeps lastAssistantMessage when demoting|suppresses saved mobile agent status when live evidence|suppresses saved mobile agent status when the current terminal title"
```

**3/3 passed**, including new:

| Test | Asserts |
|------|---------|
| `keeps lastAssistantMessage when demoting stale working status under a neutral title` | Neutral `bash` title + saved working status with Korean completion text → `state: 'done'`, **message retained**, prompt cleared, terminalTitle undefined |
| Existing suppress tests | Still demote spinner / keep agentType (no regression) |

### Manual (reporter path)

1. Remote `orca serve` with agent activity that produced a last message.  
2. Pair laptop UI.  
3. **Before:** workspace card secondary/subtitle empty for remote workspaces.  
4. **After:** same card shows last assistant text; spinner still not falsely “working” under a neutral shell title.

(I did not re-run a live pair in this environment; the regression fixture matches the demotion publication path paired clients consume.)

### Code map

| Location | Change |
|----------|--------|
| `src/main/runtime/orca-runtime.ts` | Demoted `agentStatus` keeps `lastAssistantMessage` + `interrupted` |
| `src/main/runtime/orca-runtime.test.ts` | Regression for #9914 |

---

## ELI5

Remote Orca was “summarizing” agent status for the laptop and accidentally left out the last thing the agent said. Local Orca never used that summary, so it looked fine. We put the last message back into the summary without bringing back the fake “still working” spinner.

---

## User-regression-tradeoffs

- **Intended:** paired/remote/mobile consumers of demoted agent status can show completion text again.  
- **Unchanged:** demotion still clears stale working/prompt under neutral titles (native-chat identity retention behavior preserved).  
- **Risk:** none material; if anything, more correct UI for remote setups.

---

## Checklist notes (CONTRIBUTING / AGENTS)

| Area | Notes |
|------|--------|
| **Cross-platform** | Runtime publication only; no OS-specific code. |
| **SSH / remote / pairing** | **Primary target.** Fixes the paired-client mirror path. |
| **Agents** | Provider-agnostic; any agentType that carried lastAssistantMessage benefits. |
| **Git / providers** | N/A |
| **Performance** | Copies an already-capped string field onto an object we already build. |
| **UI** | No new components; existing compact secondary line can finally receive data for remote. |
| **Security** | Same message already present in hook status / worktree ps; no new trust boundary. |
| **Tests** | Regression + existing demotion cases green. |

---

## Test plan

- [x] New demotion test retains lastAssistantMessage + interrupted  
- [x] Existing “Claude agents screen” / neutral-title suppress tests still pass  
- [ ] Optional live pair smoke by reviewer/reporter

---

## Out of scope

- Feeding `worktree ps` agents into the desktop sidebar as a second source of truth (not needed once projection keeps the field)  
- Changing when demotion triggers (`keepFullAgentStatus` heuristics)

---

## AI code-review summary

1. **Cross-platform** — OK  
2. **SSH/remote** — intentional fix for paired mirror path  
3. **Agents** — preserves generic lastAssistantMessage; no agent-specific logic  
4. **Performance** — trivial  
5. **UI** — data-only; STYLEGUIDE N/A  
6. **Security** — no new IPC surface  
7. **Correctness** — demotion still clears working spinner; only completion/interrupt fields retained  

---

Made for remote pairing parity 🐋