### PR TITLE
fix(startup): recover Win11 renderer STATUS_BREAKPOINT launch crashes via build-scoped sandbox fallback (#9891)

### DIFF
--- a/src/main/app-relaunch.ts
+++ b/src/main/app-relaunch.ts
@@ -8,6 +8,7 @@ export type AppRelaunchReason =
   | 'profile-switch'
   | 'profile-transfer'
   | 'renderer-request'
+  | 'renderer-sandbox-fallback'
 
 export function relaunchApp(reason: AppRelaunchReason, data?: CrashReportBreadcrumbData): void {
   // Why: the current process can exit immediately after app.relaunch(), so

--- a/src/main/crash-reporting/renderer-sandbox-crash-decision.test.ts
+++ b/src/main/crash-reporting/renderer-sandbox-crash-decision.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_RENDERER_SANDBOX_FALLBACK_THRESHOLD,
+  DEFAULT_RENDERER_SANDBOX_FALLBACK_WINDOW_MS,
+  RendererSandboxCrashFallbackTracker,
+  STATUS_BREAKPOINT_EXIT_CODE,
+  isRendererSandboxFallbackCrashCandidate
+} from './renderer-sandbox-crash-decision'
+
+function makeTracker(overrides: { windowMs?: number; threshold?: number } = {}) {
+  return new RendererSandboxCrashFallbackTracker({
+    windowMs: overrides.windowMs ?? DEFAULT_RENDERER_SANDBOX_FALLBACK_WINDOW_MS,
+    threshold: overrides.threshold ?? DEFAULT_RENDERER_SANDBOX_FALLBACK_THRESHOLD
+  })
+}
+
+describe('RendererSandboxCrashFallbackTracker', () => {
+  it('engages once the threshold of in-window crashes is reached', () => {
+    const tracker = makeTracker({ threshold: 3 })
+    expect(tracker.recordRendererCrash(1_000)).toEqual({
+      shouldEngageFallback: false,
+      crashesInWindow: 1
+    })
+    expect(tracker.recordRendererCrash(3_000)).toEqual({
+      shouldEngageFallback: false,
+      crashesInWindow: 2
+    })
+    expect(tracker.recordRendererCrash(6_000)).toEqual({
+      shouldEngageFallback: true,
+      crashesInWindow: 3
+    })
+    expect(tracker.hasEngaged()).toBe(true)
+  })
+
+  it('ignores crashes outside the post-launch window', () => {
+    const tracker = makeTracker({ windowMs: 30_000, threshold: 2 })
+    expect(tracker.recordRendererCrash(30_001)).toEqual({
+      shouldEngageFallback: false,
+      crashesInWindow: 0
+    })
+    expect(tracker.recordRendererCrash(-1)).toEqual({
+      shouldEngageFallback: false,
+      crashesInWindow: 0
+    })
+    expect(tracker.recordRendererCrash(Number.NaN)).toEqual({
+      shouldEngageFallback: false,
+      crashesInWindow: 0
+    })
+    // A crash exactly on the window boundary still counts.
+    expect(tracker.recordRendererCrash(30_000).crashesInWindow).toBe(1)
+  })
+
+  it('engages at most once and stops counting afterwards', () => {
+    const tracker = makeTracker({ threshold: 2 })
+    tracker.recordRendererCrash(500)
+    expect(tracker.recordRendererCrash(1_000).shouldEngageFallback).toBe(true)
+    // Further crashes never re-engage, so the caller relaunches only once.
+    expect(tracker.recordRendererCrash(1_500)).toEqual({
+      shouldEngageFallback: false,
+      crashesInWindow: 2
+    })
+  })
+})
+
+describe('isRendererSandboxFallbackCrashCandidate', () => {
+  it('matches only a win32 renderer STATUS_BREAKPOINT exit', () => {
+    expect(
+      isRendererSandboxFallbackCrashCandidate({
+        platform: 'win32',
+        source: 'renderer',
+        exitCode: STATUS_BREAKPOINT_EXIT_CODE
+      })
+    ).toBe(true)
+  })
+
+  it('rejects renderer OOM (#9872) and other renderer exit codes', () => {
+    expect(
+      isRendererSandboxFallbackCrashCandidate({
+        platform: 'win32',
+        source: 'renderer',
+        exitCode: -36861
+      })
+    ).toBe(false)
+    expect(
+      isRendererSandboxFallbackCrashCandidate({
+        platform: 'win32',
+        source: 'renderer',
+        exitCode: 5
+      })
+    ).toBe(false)
+    expect(
+      isRendererSandboxFallbackCrashCandidate({
+        platform: 'win32',
+        source: 'renderer',
+        exitCode: null
+      })
+    ).toBe(false)
+  })
+
+  it('rejects GPU/child STATUS_BREAKPOINT and non-win32 platforms', () => {
+    expect(
+      isRendererSandboxFallbackCrashCandidate({
+        platform: 'win32',
+        source: 'child',
+        exitCode: STATUS_BREAKPOINT_EXIT_CODE
+      })
+    ).toBe(false)
+    expect(
+      isRendererSandboxFallbackCrashCandidate({
+        platform: 'darwin',
+        source: 'renderer',
+        exitCode: STATUS_BREAKPOINT_EXIT_CODE
+      })
+    ).toBe(false)
+    expect(
+      isRendererSandboxFallbackCrashCandidate({
+        platform: 'linux',
+        source: 'renderer',
+        exitCode: STATUS_BREAKPOINT_EXIT_CODE
+      })
+    ).toBe(false)
+  })
+})

--- a/src/main/crash-reporting/renderer-sandbox-crash-decision.ts
+++ b/src/main/crash-reporting/renderer-sandbox-crash-decision.ts
@@ -1,0 +1,93 @@
+export type RendererSandboxCrashFallbackOptions = {
+  /** Window after launch in which clustered renderer breakpoints indicate a sandbox-incompatible build. */
+  windowMs: number
+  /** Launch-window STATUS_BREAKPOINT renderer crashes that trigger the unsandboxed-renderer fallback. */
+  threshold: number
+}
+
+// Why: on Win11 build 26200 the sandboxed renderer breakpoints during startup
+// (STATUS_BREAKPOINT / 0x80000003) within ~2s, repeatedly, on nearly every
+// launch (#9891). Disabling hardware acceleration does not help - the renderer
+// sandbox itself is unusable on this build - so a burst right after launch is
+// the signal to relaunch with the top-level renderer unsandboxed.
+// Why 60s (vs the GPU tracker's 30s): GPU child processes die pre-window, but
+// the renderer breakpoints ~2s AFTER the window loads, so the launch burst can
+// land later on a slow cold start. Matching the renderer-recovery breaker's 60s
+// window means any breakpoint loop the breaker would react to is preempted by
+// this fallback first, instead of dead-ending at the "keeps failing to load" dialog.
+export const DEFAULT_RENDERER_SANDBOX_FALLBACK_WINDOW_MS = 60_000
+export const DEFAULT_RENDERER_SANDBOX_FALLBACK_THRESHOLD = 3
+
+// Windows STATUS_BREAKPOINT (0x80000003) as a signed 32-bit exit code. This is
+// Chromium's generic CHECK/IMMEDIATE_CRASH code on Windows, not a sandbox-unique
+// signature, so the fallback is best-effort and degrades safely if ineffective.
+export const STATUS_BREAKPOINT_EXIT_CODE = -2147483645
+
+/**
+ * Tracks launch-time renderer STATUS_BREAKPOINT crashes and decides when to
+ * relaunch this build with the top-level renderer unsandboxed. Pure and
+ * deterministic: callers pass `msSinceLaunch` so behavior is testable without
+ * timers, mirroring {@link GpuCrashFallbackTracker}.
+ *
+ * Only crashes inside the post-launch window count: a renderer that dies hours
+ * into a session is not a launch-time sandbox incompatibility.
+ */
+export class RendererSandboxCrashFallbackTracker {
+  private readonly windowMs: number
+  private readonly threshold: number
+  private crashesInWindow = 0
+  private engaged = false
+
+  constructor(options: RendererSandboxCrashFallbackOptions) {
+    this.windowMs = options.windowMs
+    this.threshold = options.threshold
+  }
+
+  /**
+   * Records a renderer breakpoint at `msSinceLaunch` and reports whether this
+   * crash just pushed the count over the threshold (i.e. fallback should engage
+   * now). Returns false for crashes outside the window or after fallback already
+   * engaged, so the caller relaunches at most once.
+   */
+  recordRendererCrash(msSinceLaunch: number): {
+    shouldEngageFallback: boolean
+    crashesInWindow: number
+  } {
+    if (
+      this.engaged ||
+      !Number.isFinite(msSinceLaunch) ||
+      msSinceLaunch < 0 ||
+      msSinceLaunch > this.windowMs
+    ) {
+      return { shouldEngageFallback: false, crashesInWindow: this.crashesInWindow }
+    }
+    this.crashesInWindow += 1
+    if (this.crashesInWindow >= this.threshold) {
+      this.engaged = true
+      return { shouldEngageFallback: true, crashesInWindow: this.crashesInWindow }
+    }
+    return { shouldEngageFallback: false, crashesInWindow: this.crashesInWindow }
+  }
+
+  hasEngaged(): boolean {
+    return this.engaged
+  }
+}
+
+/**
+ * True for the renderer crashes that should feed the sandbox-fallback tracker:
+ * a win32 top-level renderer that exited with STATUS_BREAKPOINT. Deliberately
+ * narrow so renderer OOM (#9872, exit -36861) and non-Windows crashes never trip
+ * the sandbox downgrade.
+ */
+export function isRendererSandboxFallbackCrashCandidate({
+  platform,
+  source,
+  exitCode
+}: {
+  platform: NodeJS.Platform
+  source: 'renderer' | 'child'
+  exitCode: number | null
+}): boolean {
+  return platform === 'win32' && source === 'renderer' && exitCode === STATUS_BREAKPOINT_EXIT_CODE
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -91,6 +91,21 @@ import {
   isGpuFallbackCrashCandidate
 } from './crash-reporting/gpu-crash-fallback-decision'
 import {
+  readActiveRendererSandboxFallbackMarker,
+  writeRendererSandboxFallbackMarker
+} from './startup/renderer-sandbox-fallback-marker'
+import {
+  DEFAULT_RENDERER_SANDBOX_FALLBACK_THRESHOLD,
+  DEFAULT_RENDERER_SANDBOX_FALLBACK_WINDOW_MS,
+  RendererSandboxCrashFallbackTracker,
+  STATUS_BREAKPOINT_EXIT_CODE,
+  isRendererSandboxFallbackCrashCandidate
+} from './crash-reporting/renderer-sandbox-crash-decision'
+import {
+  isRendererSandboxFallbackActive,
+  setRendererSandboxFallbackActive
+} from './window/renderer-sandbox-fallback-state'
+import {
   shouldSuppressDevEducation,
   suppressDevEducationForStore
 } from './startup/dev-education-suppression'
@@ -275,13 +290,18 @@ let managedWslCliReconciliationReady: Promise<void> = Promise.resolve()
 let managedWslCliStartupBarrierReady: Promise<void> = Promise.resolve()
 // Why: the serve barrier fails open, so this state tells headless clients a WSL PTY launch may still race an un-migrated registration ('settled' = off-Windows no-op).
 let managedWslCliReconciliationStatus: 'pending' | 'settled' | 'failed' = 'settled'
-// Why: GPU child crashes clustered right after launch indicate a broken driver; track them to switch this build to software rendering.
-const gpuLaunchTimeMs = Date.now()
+// Why: GPU child crashes and renderer STATUS_BREAKPOINT crashes clustered right after launch indicate a broken driver or sandbox; both trackers measure from this shared launch time.
+const appLaunchTimeMs = Date.now()
 const gpuCrashFallbackTracker = new GpuCrashFallbackTracker({
   windowMs: DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS,
   threshold: DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD
 })
 let gpuFallbackActiveThisLaunch = false
+// Why: on Win11 build 26200 the sandboxed renderer breakpoints on launch (#9891); a burst means this build must run its top-level renderer unsandboxed.
+const rendererSandboxCrashFallbackTracker = new RendererSandboxCrashFallbackTracker({
+  windowMs: DEFAULT_RENDERER_SANDBOX_FALLBACK_WINDOW_MS,
+  threshold: DEFAULT_RENDERER_SANDBOX_FALLBACK_THRESHOLD
+})
 let localPtyStartupReady: Promise<void> = Promise.resolve()
 let localPtyProviderStartupReady: Promise<void> = Promise.resolve()
 const AGENT_STATE_CRASH_BREADCRUMB_MIN_INTERVAL_MS = 30_000
@@ -640,6 +660,7 @@ if (hasSingleInstanceLock) {
   configureElectronNetworkCompatibility()
   enableRendererHeapHeadroom()
   maybeApplyGpuFallbackForThisLaunch()
+  maybeApplyRendererSandboxFallbackForThisLaunch()
   if (!gpuFallbackActiveThisLaunch) {
     enableMainProcessGpuFeatures()
   }
@@ -1026,6 +1047,17 @@ function openMainWindow(): BrowserWindow {
         },
         webContentsId
       )
+      // Why: a launch-time renderer STATUS_BREAKPOINT burst means this build's renderer can't run sandboxed (#9891); engage the build-scoped unsandboxed-renderer fallback before the recovery breaker dead-ends at the "keeps failing to load" dialog. Only genuine (teardown 'none') main-window crashes count.
+      if (
+        isRendererSandboxFallbackCrashCandidate({
+          platform: process.platform,
+          source: 'renderer',
+          exitCode: details.exitCode ?? null
+        }) &&
+        getExpectedTeardownScope(webContentsId) === 'none'
+      ) {
+        handleRendererSandboxCrash(details.exitCode ?? null, details.reason)
+      }
     },
     shouldRecoverRenderer: (details, webContentsId) =>
       shouldRecoverRendererAfterProcessGone({
@@ -1041,6 +1073,7 @@ function openMainWindow(): BrowserWindow {
       void presentRendererRecoveryPrompt(recentRecoveryCount)
     },
     deferLoad: true,
+    disableRendererSandbox: isRendererSandboxFallbackActive(),
     title: devInstanceIdentity.name,
     getKeybindings: () => keybindings?.getOverrides(),
     onBeforeReload: ({ ignoreCache, webContentsId }) => {
@@ -1368,7 +1401,7 @@ function handleGpuChildCrash(reason: string, exitCode: number | null): void {
   if (gpuFallbackActiveThisLaunch || isQuitting || isServeMode) {
     return
   }
-  const result = gpuCrashFallbackTracker.recordGpuCrash(Date.now() - gpuLaunchTimeMs)
+  const result = gpuCrashFallbackTracker.recordGpuCrash(Date.now() - appLaunchTimeMs)
   if (!result.shouldEngageFallback) {
     return
   }
@@ -1397,6 +1430,75 @@ function handleGpuChildCrash(reason: string, exitCode: number | null): void {
   }
   isQuitting = true
   relaunchApp('gpu-fallback', {
+    processReason: reason,
+    exitCode,
+    crashesInWindow: result.crashesInWindow
+  })
+  app.exit(0)
+}
+
+// Why: read the renderer-sandbox-fallback marker before app.whenReady() so the first BrowserWindow is created unsandboxed. Windows desktop only; sets no command-line switch — the effect is applied per-window in createMainWindow.
+function maybeApplyRendererSandboxFallbackForThisLaunch(): void {
+  if (isServeMode || process.platform !== 'win32') {
+    return
+  }
+  const marker = readActiveRendererSandboxFallbackMarker(
+    app.getPath('userData'),
+    getGpuFallbackEnvironment()
+  )
+  if (!marker) {
+    return
+  }
+  setRendererSandboxFallbackActive(true)
+  recordCrashBreadcrumb('renderer_sandbox_fallback_applied', {
+    crashesInWindow: marker.crashesInWindow,
+    exitCode: marker.exitCode
+  })
+  // Why: per-window sandbox:false is silently ignored if the sandbox is forced globally (app.enableSandbox()/--enable-sandbox), which would send #9891 machines back into the crash loop. Surface that so it's diagnosable instead of invisible.
+  if (app.commandLine.hasSwitch('enable-sandbox')) {
+    recordDurableCrashBreadcrumb('renderer_sandbox_fallback_neutralized', {
+      crashesInWindow: marker.crashesInWindow
+    })
+  }
+}
+
+// Why: a burst of launch-time renderer STATUS_BREAKPOINT crashes means the sandboxed renderer is unusable on this build (#9891) — persist a build-scoped marker and relaunch with the top-level renderer unsandboxed, preempting the recovery breaker's dead-end dialog.
+function handleRendererSandboxCrash(exitCode: number | null, reason: string): void {
+  // Already unsandboxed this launch, or shutting down: nothing more to do. If sandbox:false still crashes it degrades to the recovery-breaker dialog, never an infinite relaunch loop.
+  if (isRendererSandboxFallbackActive() || isQuitting || isServeMode) {
+    return
+  }
+  const result = rendererSandboxCrashFallbackTracker.recordRendererCrash(
+    Date.now() - appLaunchTimeMs
+  )
+  if (!result.shouldEngageFallback) {
+    return
+  }
+  const environment = getWindowsGpuFallbackEnvironment()
+  if (!environment) {
+    return
+  }
+  recordCrashBreadcrumb('renderer_sandbox_fallback_engaged', {
+    reason,
+    exitCode,
+    crashesInWindow: result.crashesInWindow
+  })
+  try {
+    writeRendererSandboxFallbackMarker(
+      app.getPath('userData'),
+      {
+        engagedAt: Date.now(),
+        crashesInWindow: result.crashesInWindow,
+        exitCode: exitCode ?? STATUS_BREAKPOINT_EXIT_CODE
+      },
+      environment
+    )
+  } catch (error) {
+    console.warn('[renderer-sandbox-fallback] failed to persist marker:', error)
+    return
+  }
+  isQuitting = true
+  relaunchApp('renderer-sandbox-fallback', {
     processReason: reason,
     exitCode,
     crashesInWindow: result.crashesInWindow

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -302,6 +302,12 @@ const rendererSandboxCrashFallbackTracker = new RendererSandboxCrashFallbackTrac
   windowMs: DEFAULT_RENDERER_SANDBOX_FALLBACK_WINDOW_MS,
   threshold: DEFAULT_RENDERER_SANDBOX_FALLBACK_THRESHOLD
 })
+// Why: a launch-time STATUS_BREAKPOINT burst detected this launch (#9891) carries the context for the user-consent prompt shown when the recovery breaker gives up. Never acted on without explicit consent.
+let rendererSandboxBurst: {
+  reason: string
+  exitCode: number | null
+  crashesInWindow: number
+} | null = null
 let localPtyStartupReady: Promise<void> = Promise.resolve()
 let localPtyProviderStartupReady: Promise<void> = Promise.resolve()
 const AGENT_STATE_CRASH_BREADCRUMB_MIN_INTERVAL_MS = 30_000
@@ -1070,7 +1076,16 @@ function openMainWindow(): BrowserWindow {
         exitCode: details.exitCode ?? null,
         recentRecoveryCount
       })
-      void presentRendererRecoveryPrompt(recentRecoveryCount)
+      // Why: if the crash loop is the win32 renderer-sandbox signature (#9891), OFFER the user the unsandboxed-restart workaround instead of the generic dead-end dialog. Never auto-applied.
+      if (
+        rendererSandboxBurst &&
+        !isRendererSandboxFallbackActive() &&
+        process.platform === 'win32'
+      ) {
+        void presentRendererSandboxConsentPrompt()
+      } else {
+        void presentRendererRecoveryPrompt(recentRecoveryCount)
+      }
     },
     deferLoad: true,
     disableRendererSandbox: isRendererSandboxFallbackActive(),
@@ -1462,9 +1477,8 @@ function maybeApplyRendererSandboxFallbackForThisLaunch(): void {
   }
 }
 
-// Why: a burst of launch-time renderer STATUS_BREAKPOINT crashes means the sandboxed renderer is unusable on this build (#9891) — persist a build-scoped marker and relaunch with the top-level renderer unsandboxed, preempting the recovery breaker's dead-end dialog.
+// Why: detection only — a burst of launch-time renderer STATUS_BREAKPOINT crashes is the sandbox-incompatibility signature (#9891). Orca NEVER drops the sandbox automatically; it just remembers the burst so the recovery-exhausted handler can offer the workaround to the user.
 function handleRendererSandboxCrash(exitCode: number | null, reason: string): void {
-  // Already unsandboxed this launch, or shutting down: nothing more to do. If sandbox:false still crashes it degrades to the recovery-breaker dialog, never an infinite relaunch loop.
   if (isRendererSandboxFallbackActive() || isQuitting || isServeMode) {
     return
   }
@@ -1474,22 +1488,74 @@ function handleRendererSandboxCrash(exitCode: number | null, reason: string): vo
   if (!result.shouldEngageFallback) {
     return
   }
+  rendererSandboxBurst = { reason, exitCode, crashesInWindow: result.crashesInWindow }
+  recordDurableCrashBreadcrumb('renderer_sandbox_crash_burst_detected', {
+    reason,
+    exitCode,
+    crashesInWindow: result.crashesInWindow
+  })
+}
+
+// Why: the renderer cannot launch sandboxed on this build (#9891). Never auto-drop the sandbox — ASK the user whether to restart with it off. Shown when the recovery breaker gives up, replacing the generic "keeps failing to load" dialog for this signature.
+async function presentRendererSandboxConsentPrompt(): Promise<void> {
+  const burst = rendererSandboxBurst
+  if (!burst || isQuitting || isServeMode) {
+    return
+  }
+  const parent = mainWindow && !mainWindow.isDestroyed() ? mainWindow : undefined
+  const options = {
+    type: 'warning' as const,
+    buttons: ['Disable the sandbox and restart', 'Quit'],
+    defaultId: 0,
+    cancelId: 1,
+    title: 'Orca keeps crashing on startup',
+    message:
+      'Orca’s window crashed repeatedly right after launch, which looks like a security-sandbox incompatibility with this version of Windows.',
+    detail:
+      'Orca can restart with the renderer security sandbox turned off to work around it. This lowers one process-hardening layer for the app window only — your workspaces and data stay isolated, and Orca automatically tries the sandbox again after its next update. Nothing changes unless you choose to disable it.'
+  }
+  const { response } = parent
+    ? await dialog.showMessageBox(parent, options)
+    : await dialog.showMessageBox(options)
+  if (response === 0) {
+    recordDurableCrashBreadcrumb('renderer_sandbox_fallback_user_accepted', {
+      crashesInWindow: burst.crashesInWindow
+    })
+    engageRendererSandboxFallback(burst)
+  } else {
+    recordDurableCrashBreadcrumb('renderer_sandbox_fallback_user_declined', {
+      crashesInWindow: burst.crashesInWindow
+    })
+    isQuitting = true
+    app.quit()
+  }
+}
+
+// Why: only invoked AFTER explicit user consent — persist a build-scoped marker and relaunch with the top-level renderer unsandboxed for this build.
+function engageRendererSandboxFallback(burst: {
+  reason: string
+  exitCode: number | null
+  crashesInWindow: number
+}): void {
+  if (isRendererSandboxFallbackActive() || isServeMode) {
+    return
+  }
   const environment = getWindowsGpuFallbackEnvironment()
   if (!environment) {
     return
   }
   recordCrashBreadcrumb('renderer_sandbox_fallback_engaged', {
-    reason,
-    exitCode,
-    crashesInWindow: result.crashesInWindow
+    reason: burst.reason,
+    exitCode: burst.exitCode,
+    crashesInWindow: burst.crashesInWindow
   })
   try {
     writeRendererSandboxFallbackMarker(
       app.getPath('userData'),
       {
         engagedAt: Date.now(),
-        crashesInWindow: result.crashesInWindow,
-        exitCode: exitCode ?? STATUS_BREAKPOINT_EXIT_CODE
+        crashesInWindow: burst.crashesInWindow,
+        exitCode: burst.exitCode ?? STATUS_BREAKPOINT_EXIT_CODE
       },
       environment
     )
@@ -1499,9 +1565,9 @@ function handleRendererSandboxCrash(exitCode: number | null, reason: string): vo
   }
   isQuitting = true
   relaunchApp('renderer-sandbox-fallback', {
-    processReason: reason,
-    exitCode,
-    crashesInWindow: result.crashesInWindow
+    processReason: burst.reason,
+    exitCode: burst.exitCode,
+    crashesInWindow: burst.crashesInWindow
   })
   app.exit(0)
 }

--- a/src/main/startup/renderer-sandbox-fallback-marker.test.ts
+++ b/src/main/startup/renderer-sandbox-fallback-marker.test.ts
@@ -1,0 +1,147 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  RENDERER_SANDBOX_FALLBACK_MARKER_FILE,
+  clearRendererSandboxFallbackMarker,
+  readActiveRendererSandboxFallbackMarker,
+  readRendererSandboxFallbackMarker,
+  writeRendererSandboxFallbackMarker
+} from './renderer-sandbox-fallback-marker'
+
+describe('renderer-sandbox-fallback-marker', () => {
+  let userDataPath: string
+  const environment = {
+    appVersion: '1.4.150',
+    electronVersion: '43.1.0',
+    platform: 'win32' as const
+  }
+
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(os.tmpdir(), 'orca-renderer-sandbox-fallback-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(userDataPath, { recursive: true, force: true })
+  })
+
+  it('round-trips a written marker', () => {
+    writeRendererSandboxFallbackMarker(
+      userDataPath,
+      { engagedAt: 123, crashesInWindow: 3, exitCode: -2147483645 },
+      environment
+    )
+    expect(readRendererSandboxFallbackMarker(userDataPath)).toEqual({
+      schemeVersion: 1,
+      engagedAt: 123,
+      crashesInWindow: 3,
+      exitCode: -2147483645,
+      appVersion: '1.4.150',
+      electronVersion: '43.1.0',
+      platform: 'win32'
+    })
+  })
+
+  it('returns null when no marker exists', () => {
+    expect(readRendererSandboxFallbackMarker(userDataPath)).toBeNull()
+    expect(readActiveRendererSandboxFallbackMarker(userDataPath, environment)).toBeNull()
+  })
+
+  it('keeps an active marker for repeated launches on the same build', () => {
+    writeRendererSandboxFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 3, exitCode: -2147483645 },
+      environment
+    )
+    expect(existsSync(join(userDataPath, RENDERER_SANDBOX_FALLBACK_MARKER_FILE))).toBe(true)
+
+    expect(
+      readActiveRendererSandboxFallbackMarker(userDataPath, environment)?.crashesInWindow
+    ).toBe(3)
+    expect(existsSync(join(userDataPath, RENDERER_SANDBOX_FALLBACK_MARKER_FILE))).toBe(true)
+    expect(readActiveRendererSandboxFallbackMarker(userDataPath, environment)?.exitCode).toBe(
+      -2147483645
+    )
+  })
+
+  it('clears an active marker when the app or Electron build changes', () => {
+    writeRendererSandboxFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 3, exitCode: -2147483645 },
+      environment
+    )
+    expect(
+      readActiveRendererSandboxFallbackMarker(userDataPath, {
+        ...environment,
+        appVersion: '1.4.151'
+      })
+    ).toBeNull()
+    expect(existsSync(join(userDataPath, RENDERER_SANDBOX_FALLBACK_MARKER_FILE))).toBe(false)
+
+    writeRendererSandboxFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 3, exitCode: -2147483645 },
+      environment
+    )
+    expect(
+      readActiveRendererSandboxFallbackMarker(userDataPath, {
+        ...environment,
+        electronVersion: '44.0.0'
+      })
+    ).toBeNull()
+    expect(existsSync(join(userDataPath, RENDERER_SANDBOX_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
+  it('clears an active marker outside Windows', () => {
+    writeRendererSandboxFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 3, exitCode: -2147483645 },
+      environment
+    )
+    expect(
+      readActiveRendererSandboxFallbackMarker(userDataPath, { ...environment, platform: 'linux' })
+    ).toBeNull()
+    expect(existsSync(join(userDataPath, RENDERER_SANDBOX_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
+  it('clears a corrupt or wrong-version marker', () => {
+    writeFileSync(join(userDataPath, RENDERER_SANDBOX_FALLBACK_MARKER_FILE), '{ not json')
+    expect(readRendererSandboxFallbackMarker(userDataPath)).toBeNull()
+    expect(readActiveRendererSandboxFallbackMarker(userDataPath, environment)).toBeNull()
+    expect(existsSync(join(userDataPath, RENDERER_SANDBOX_FALLBACK_MARKER_FILE))).toBe(false)
+
+    writeFileSync(
+      join(userDataPath, RENDERER_SANDBOX_FALLBACK_MARKER_FILE),
+      JSON.stringify({ schemeVersion: 999, engagedAt: 1, crashesInWindow: 1, exitCode: -1 })
+    )
+    expect(readRendererSandboxFallbackMarker(userDataPath)).toBeNull()
+    expect(readActiveRendererSandboxFallbackMarker(userDataPath, environment)).toBeNull()
+    expect(existsSync(join(userDataPath, RENDERER_SANDBOX_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
+  it('rejects a marker missing the exitCode field', () => {
+    writeFileSync(
+      join(userDataPath, RENDERER_SANDBOX_FALLBACK_MARKER_FILE),
+      JSON.stringify({
+        schemeVersion: 1,
+        engagedAt: 1,
+        crashesInWindow: 3,
+        appVersion: '1.4.150',
+        electronVersion: '43.1.0',
+        platform: 'win32'
+      })
+    )
+    expect(readRendererSandboxFallbackMarker(userDataPath)).toBeNull()
+  })
+
+  it('can explicitly clear the marker', () => {
+    writeRendererSandboxFallbackMarker(
+      userDataPath,
+      { engagedAt: 1, crashesInWindow: 3, exitCode: -2147483645 },
+      environment
+    )
+    clearRendererSandboxFallbackMarker(userDataPath)
+    expect(readRendererSandboxFallbackMarker(userDataPath)).toBeNull()
+  })
+})

--- a/src/main/startup/renderer-sandbox-fallback-marker.ts
+++ b/src/main/startup/renderer-sandbox-fallback-marker.ts
@@ -1,0 +1,126 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Persisted "run this build's top-level renderer unsandboxed" marker.
+ *
+ * Why a standalone file (not the Store): createMainWindow must pick
+ * webPreferences.sandbox for the first window, which happens before the settings
+ * Store is constructed inside whenReady. A tiny JSON marker in userData reads
+ * synchronously during early startup, mirroring gpu-fallback-marker.ts.
+ */
+
+export const RENDERER_SANDBOX_FALLBACK_MARKER_FILE = 'renderer-sandbox-fallback.json'
+export const RENDERER_SANDBOX_FALLBACK_SCHEME_VERSION = 1
+
+export type RendererSandboxFallbackEnvironment = {
+  appVersion: string
+  electronVersion: string
+  platform: NodeJS.Platform
+}
+
+export type WindowsRendererSandboxFallbackEnvironment = RendererSandboxFallbackEnvironment & {
+  platform: 'win32'
+}
+
+export type RendererSandboxFallbackMarker = {
+  schemeVersion: number
+  engagedAt: number
+  crashesInWindow: number
+  exitCode: number
+  appVersion: string
+  electronVersion: string
+  platform: 'win32'
+}
+
+function markerPath(userDataPath: string): string {
+  return join(userDataPath, RENDERER_SANDBOX_FALLBACK_MARKER_FILE)
+}
+
+export function readRendererSandboxFallbackMarker(
+  userDataPath: string
+): RendererSandboxFallbackMarker | null {
+  try {
+    const parsed = JSON.parse(readFileSync(markerPath(userDataPath), 'utf-8')) as Partial<
+      Record<keyof RendererSandboxFallbackMarker, unknown>
+    >
+    if (parsed.schemeVersion !== RENDERER_SANDBOX_FALLBACK_SCHEME_VERSION) {
+      return null
+    }
+    if (
+      typeof parsed.engagedAt !== 'number' ||
+      !Number.isFinite(parsed.engagedAt) ||
+      typeof parsed.crashesInWindow !== 'number' ||
+      !Number.isFinite(parsed.crashesInWindow) ||
+      typeof parsed.exitCode !== 'number' ||
+      !Number.isFinite(parsed.exitCode) ||
+      typeof parsed.appVersion !== 'string' ||
+      typeof parsed.electronVersion !== 'string' ||
+      parsed.platform !== 'win32'
+    ) {
+      return null
+    }
+    return {
+      schemeVersion: RENDERER_SANDBOX_FALLBACK_SCHEME_VERSION,
+      engagedAt: parsed.engagedAt,
+      crashesInWindow: parsed.crashesInWindow,
+      exitCode: parsed.exitCode,
+      appVersion: parsed.appVersion,
+      electronVersion: parsed.electronVersion,
+      platform: parsed.platform
+    }
+  } catch {
+    // missing or corrupt means no fallback requested
+  }
+  return null
+}
+
+export function writeRendererSandboxFallbackMarker(
+  userDataPath: string,
+  info: { engagedAt: number; crashesInWindow: number; exitCode: number },
+  environment: WindowsRendererSandboxFallbackEnvironment
+): void {
+  const marker: RendererSandboxFallbackMarker = {
+    schemeVersion: RENDERER_SANDBOX_FALLBACK_SCHEME_VERSION,
+    engagedAt: info.engagedAt,
+    crashesInWindow: info.crashesInWindow,
+    exitCode: info.exitCode,
+    appVersion: environment.appVersion,
+    electronVersion: environment.electronVersion,
+    platform: 'win32'
+  }
+  writeFileSync(markerPath(userDataPath), JSON.stringify(marker))
+}
+
+export function clearRendererSandboxFallbackMarker(userDataPath: string): void {
+  try {
+    rmSync(markerPath(userDataPath), { force: true })
+  } catch {
+    // best effort; a stale marker is revalidated on the next launch
+  }
+}
+
+export function readActiveRendererSandboxFallbackMarker(
+  userDataPath: string,
+  environment: RendererSandboxFallbackEnvironment
+): RendererSandboxFallbackMarker | null {
+  const marker = readRendererSandboxFallbackMarker(userDataPath)
+  if (!marker) {
+    if (existsSync(markerPath(userDataPath))) {
+      clearRendererSandboxFallbackMarker(userDataPath)
+    }
+    return null
+  }
+  if (
+    environment.platform !== 'win32' ||
+    marker.platform !== environment.platform ||
+    marker.appVersion !== environment.appVersion ||
+    marker.electronVersion !== environment.electronVersion
+  ) {
+    // Why: the marker is sticky only for the build that observed the crash
+    // burst; updates get one fresh sandboxed attempt automatically.
+    clearRendererSandboxFallbackMarker(userDataPath)
+    return null
+  }
+  return marker
+}

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -133,6 +133,50 @@ describe('createMainWindow', () => {
     expect(browserWindowInstance.loadURL).not.toHaveBeenCalled()
   })
 
+  it('unsandboxes the renderer only when the #9891 sandbox fallback is engaged', () => {
+    const webContents = {
+      on: vi.fn(),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn(),
+      isDevToolsOpened: vi.fn(),
+      openDevTools: vi.fn(),
+      closeDevTools: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => false),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    createMainWindow(null, { deferLoad: true, disableRendererSandbox: true })
+    expect(browserWindowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        webPreferences: expect.objectContaining({ sandbox: false })
+      })
+    )
+
+    browserWindowMock.mockClear()
+    createMainWindow(null, { deferLoad: true, disableRendererSandbox: false })
+    expect(browserWindowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        webPreferences: expect.objectContaining({ sandbox: true })
+      })
+    )
+  })
+
   it('enables renderer sandboxing and opens external links safely', () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -157,6 +157,8 @@ type CreateMainWindowOptions = {
   onBeforeReload?: (options: { ignoreCache: boolean; webContentsId: number }) => void
   /** Marks the in-place recovery reload so did-finish-load's PTY orphan sweep spares live sessions until restore re-attaches (#5787). */
   onBeforeRecoveryReload?: (webContentsId: number) => void
+  /** Run this window's top-level renderer unsandboxed (build-scoped #9891 fallback after repeated launch-time renderer STATUS_BREAKPOINT crashes); webview guests stay sandbox:true via will-attach-webview. */
+  disableRendererSandbox?: boolean
 }
 
 export function loadMainWindow(mainWindow: BrowserWindow): void {
@@ -247,7 +249,9 @@ export function createMainWindow(
     ...platformBlurOptions,
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
-      sandbox: true,
+      // Why: keep the renderer sandboxed by default; only the build-scoped #9891 fallback unsandboxes this one window after repeated launch-time STATUS_BREAKPOINT crashes. Webview guests stay sandbox:true via will-attach-webview.
+      // NOTE: this per-window opt-out only works because Orca never calls app.enableSandbox() (global enforcement ignores per-window sandbox:false). See renderer-sandbox-fallback-state.ts before adding it.
+      sandbox: opts?.disableRendererSandbox !== true,
       webviewTag: true
     }
   })

--- a/src/main/window/dashboard-popout-window.test.ts
+++ b/src/main/window/dashboard-popout-window.test.ts
@@ -140,6 +140,7 @@ import {
   isDashboardPopoutRenderer,
   zoomDashboardPopoutIfFocused
 } from './dashboard-popout-window'
+import { setRendererSandboxFallbackActive } from './renderer-sandbox-fallback-state'
 
 type FakeWindow = InstanceType<typeof BrowserWindowMock>
 
@@ -174,6 +175,8 @@ describe('createOrFocusDashboardPopout', () => {
   beforeEach(() => {
     instances.length = 0
     isMock.dev = false
+    // Reset the shared #9891 launch flag so window-sandbox assertions are isolated.
+    setRendererSandboxFallbackActive(false)
     vi.stubEnv('ELECTRON_RENDERER_URL', '')
     getAllDisplaysMock.mockReturnValue([{ workArea: { x: 0, y: 0, width: 1920, height: 1080 } }])
   })
@@ -183,6 +186,12 @@ describe('createOrFocusDashboardPopout', () => {
     closeDashboardPopout()
     vi.unstubAllEnvs()
     vi.clearAllMocks()
+  })
+
+  it('unsandboxes the pop-out renderer when the #9891 sandbox fallback is active', () => {
+    setRendererSandboxFallbackActive(true)
+    createOrFocusDashboardPopout(makeStore() as never)
+    expect(instances[0].options.webPreferences?.sandbox).toBe(false)
   })
 
   it('creates a native-frame window with the shared preload and no webview surface', () => {

--- a/src/main/window/dashboard-popout-window.ts
+++ b/src/main/window/dashboard-popout-window.ts
@@ -5,6 +5,7 @@ import type { Store } from '../persistence'
 import { rectHasVisibleAreaOnAnyDisplay } from './window-bounds-validation'
 import { sendToTrustedUIRenderer } from '../ipc/ui'
 import { installPrivilegedWindowNavigationPolicy } from './privileged-window-navigation'
+import { isRendererSandboxFallbackActive } from './renderer-sandbox-fallback-state'
 import { stepUIZoomLevel, type UIZoomDirection } from '../../shared/ui-zoom-level'
 import { nativeZoomCommandMatchesKeybindings } from '../../shared/window-shortcut-policy'
 import {
@@ -168,7 +169,8 @@ export function createOrFocusDashboardPopout(
     // no such chrome yet, so a native frame is the correct default here.
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
-      sandbox: true,
+      // Why: keep the pop-out renderer sandboxed by default; honor the same build-scoped #9891 fallback as the main window so this companion renderer doesn't STATUS_BREAKPOINT on a sandbox-incompatible Windows build.
+      sandbox: !isRendererSandboxFallbackActive(),
       // Why: Chromium shares zoom by origin; a separate in-memory session keeps pop-out zoom window-local.
       partition: DASHBOARD_POPOUT_PARTITION,
       // Why: the dashboard is plain DOM — no <webview> guests — so keep the

--- a/src/main/window/renderer-sandbox-fallback-state.test.ts
+++ b/src/main/window/renderer-sandbox-fallback-state.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  isRendererSandboxFallbackActive,
+  setRendererSandboxFallbackActive
+} from './renderer-sandbox-fallback-state'
+
+afterEach(() => {
+  setRendererSandboxFallbackActive(false)
+})
+
+describe('renderer-sandbox-fallback-state', () => {
+  it('defaults to inactive', () => {
+    expect(isRendererSandboxFallbackActive()).toBe(false)
+  })
+
+  it('reflects the last set value', () => {
+    setRendererSandboxFallbackActive(true)
+    expect(isRendererSandboxFallbackActive()).toBe(true)
+    setRendererSandboxFallbackActive(false)
+    expect(isRendererSandboxFallbackActive()).toBe(false)
+  })
+})

--- a/src/main/window/renderer-sandbox-fallback-state.ts
+++ b/src/main/window/renderer-sandbox-fallback-state.ts
@@ -1,0 +1,24 @@
+// Why: the build-scoped #9891 fallback decision — run this launch's renderers
+// unsandboxed after repeated launch-time STATUS_BREAKPOINT crashes — is resolved
+// once before app.whenReady() and then read when creating each window. A shared
+// flag lets every window creator (main window and the dashboard pop-out, which
+// is spawned deep in an IPC handler) honor it without threading an option
+// through every call site.
+//
+// IMPORTANT (security-relevant): the fallback works by creating those windows
+// with webPreferences.sandbox:false, which Electron only honors PER-WINDOW when
+// the app does NOT call app.enableSandbox(). Orca deliberately relies on
+// per-window sandbox config so the default stays sandboxed and only the affected
+// build's main/pop-out renderers opt out - webview guests and every other window
+// remain sandboxed. Adding a global app.enableSandbox() would ignore the
+// per-window opt-out entirely and silently neutralize this fallback (#9891
+// machines would crash-loop again); don't, without a replacement.
+let rendererSandboxFallbackActive = false
+
+export function setRendererSandboxFallbackActive(value: boolean): void {
+  rendererSandboxFallbackActive = value
+}
+
+export function isRendererSandboxFallbackActive(): boolean {
+  return rendererSandboxFallbackActive
+}


### PR DESCRIPTION
Fixes #9891

## Description

On **Windows 11 build 26200** (Intel Iris Xe), Orca's **renderer process** breakpoints
~2s after launch with `STATUS_BREAKPOINT` — `0x80000003`, reported by Electron as
`render-process-gone { reason: 'crashed', exitCode: -2147483645 }` — on nearly every start.
The reporter established that `--in-process-gpu` removes the GPU-child crash but the renderer
**still** crashes, and only `--no-sandbox` fully fixes it: a renderer‑*sandbox* incompatibility
with this Windows build.

Two existing mechanisms are the wrong tool for this:

- **GPU‑child‑crash fallback** only disables hardware acceleration — software rendering doesn't
  touch the renderer sandbox, so the renderer keeps breakpointing (the reporter's breadcrumb trail
  `gpu_fallback_applied → main_window_created → renderer crashed` confirms this).
- **Renderer recovery circuit breaker** just reloads the *same sandboxed renderer*, which
  breakpoints again, 3× → then dead-ends at the **"Orca keeps failing to load"** dialog.

This PR adds a **build‑scoped renderer sandbox fallback** that mirrors the existing GPU‑fallback
marker system — but **Orca never disables the sandbox on the user's behalf**. After **3
launch‑window renderer `STATUS_BREAKPOINT` crashes on win32**, the crash is *remembered* but nothing
is done; when the renderer‑recovery breaker gives up, Orca shows a **consent dialog** offering
*Disable the sandbox and restart* or *Quit*. **Only on consent** does it persist a marker and
relaunch with the top‑level renderer **unsandboxed** (`webPreferences.sandbox: false`) — the
surgical, **per‑window** equivalent of the confirmed `--no-sandbox`, while **GPU / utility /
network** child processes and **webview guests** stay sandboxed. The marker is scoped to
`appVersion + electronVersion` and **auto‑clears on any update**, so a fixed Electron build
automatically regains the sandbox (and a still‑broken build re‑asks).

Key safety properties:
- **Distinct from renderer OOM (#9872, exit `-36861`)** — detection keys strictly on exit code
  `-2147483645`, so OOM and other crashes can never trigger the downgrade.
- **No infinite loop** — a `hasEngaged` / active‑this‑launch guard means it engages at most once;
  if `sandbox:false` still crashes it degrades to *today's* behavior (the dialog), never a relaunch
  loop. Independent of the GPU marker (both can coexist; the app converges to a stable state).
- **User consent, never automatic** — when the recovery breaker gives up, the consent dialog
  *replaces* the generic "keeps failing to load" prompt for this signature (single dialog, no
  stacking). The marker is written only if the user chooses to disable the sandbox; declining
  persists nothing, so the next launch is sandboxed again.
- The **dashboard pop‑out** honors the same (consented) flag, so the companion window doesn't breakpoint either.

## Transparency & hardening

- **User consent, not silent action.** Orca never disables the sandbox on the user's behalf. When
  the crash loop is this signature and the recovery breaker gives up, a native dialog ("Orca keeps
  crashing on startup") offers **Disable the sandbox and restart** or **Quit**, explaining that it
  lowers one hardening layer for the app window only, that workspaces/data stay isolated, and that
  the sandbox is retried automatically after the next update. `sandbox:false` is persisted **only**
  on consent; declining persists nothing. Re‑asked per build (the marker clears on update).
- **Webview guests are never unsandboxed** — they host untrusted web content and stay `sandbox:true`
  via `will-attach-webview`. `contextIsolation` stays on and the page has no Node access, so the
  reduction is limited to the top‑level first‑party renderer process only.
- **Invariant guarded.** The per‑window opt‑out only works because Orca never calls global
  `app.enableSandbox()`; this is documented at the source and a durable
  `renderer_sandbox_fallback_neutralized` breadcrumb fires if the sandbox is ever forced globally,
  so a regressed machine is diagnosable rather than silently crash‑looping.

## ELI5

Imagine Orca's window is a worker who has to put on a heavy safety suit (the "sandbox") before
starting. On these specific Windows 11 machines, that one suit is defective — the moment the worker
zips it up, they trip and fall (crash). Orca keeps handing them the same broken suit and telling
them to try again; they fall three times and Orca gives up with "keeps failing to load."

This change teaches Orca: *"if the worker trips putting on this exact suit over and over at the
start, **ask them** whether they'd like to work without that one suit — and take it off only if they
say yes."* Everyone else in the building keeps theirs on. It remembers their choice only for the
current app version (so a future fixed suit is tried again automatically), and it only offers this
for the very specific "tripped on the suit" fall, not for other kinds of falls (like running out of
memory).

## Proof of fix

**Reproduction (verified by code‑path trace on the affected build, Win11 10.0.26200):**

```
render-process-gone { reason:'crashed', exitCode:-2147483645 }
  → shouldRecordProcessGoneCrash → records it
  → shouldRecoverRendererAfterProcessGone → true → createMainWindow auto-reloads
  → reloaded renderer breakpoints again ~2s later  … ×3
  → RendererRecoveryCircuitBreaker opens → "Orca keeps failing to load"   ❌ dead end
```

Because auto‑recovery reloads mark only `recoveryReloadInFlight` (orphan‑sweep), **not**
`expectedRendererReload`, `getExpectedTeardownScope` returns `'none'` for every crash in the loop —
so each launch‑window `STATUS_BREAKPOINT` is a countable, "unexpected" event.

**After this change:**

```
crash #1..#3 (~2s each) → STATUS_BREAKPOINT burst remembered (no action)
  → crash #4 → recovery breaker opens → CONSENT DIALOG "Disable the sandbox and restart?"
  → [consent]  writeRendererSandboxFallbackMarker + relaunchApp('renderer-sandbox-fallback') + app.exit(0)
             → next launch: readActiveRendererSandboxFallbackMarker → window sandbox:false → renderer launches ✅
  → [decline]  nothing persisted → next launch is sandboxed again
```

**New tests proving the behavior (all green):**
- `renderer-sandbox-crash-decision.test.ts` — tracker window/threshold/engage‑once semantics; the
  predicate matrix asserts **only** `{win32, renderer, -2147483645}` is a candidate and that OOM
  `-36861`, other exit codes, `child` source, and non‑win32 are all rejected.
- `renderer-sandbox-fallback-marker.test.ts` — round‑trip, build‑change/non‑win32/corrupt/missing‑field
  clearing (mirrors `gpu-fallback-marker.test.ts`).
- `createMainWindow.test.ts` — `webPreferences.sandbox === false` iff `disableRendererSandbox: true`,
  `true` by default.
- `dashboard-popout-window.test.ts` + `renderer-sandbox-fallback-state.test.ts` — pop‑out honors the
  shared launch flag; default stays sandboxed.

```
✓ New + directly-affected unit suites pass   (typecheck ✓  oxlint ✓)
```

## Screenshots

The new consent decision, and — for contrast — the generic dead‑end it replaces
for this crash signature.

**Before** — a launch‑time renderer `STATUS_BREAKPOINT` loop dead‑ended here, and
*Reload* just re‑crashes the same sandboxed renderer:

![Generic "Orca keeps failing to load" recovery dialog with Reload / Quit](https://raw.githubusercontent.com/stablyai/orca/pr-9891-screenshots/recovery-deadend.png)

**After** — when the loop is the win32 sandbox signature, Orca instead asks the
user to choose (nothing is disabled unless they pick the first button):

![Consent dialog "Orca keeps crashing on startup" offering "Disable the sandbox and restart" or "Quit"](https://raw.githubusercontent.com/stablyai/orca/pr-9891-screenshots/consent-dialog.png)

> Captured on Windows 11 by invoking the **exact** `dialog.showMessageBox`
> options from `presentRendererRecoveryPrompt` / `presentRendererSandboxConsentPrompt`
> — verbatim title, copy, icons, and buttons. These are the real native Electron
> dialogs, not mockups. The end‑to‑end crash loop can't be reproduced on
> non‑affected hardware, so the dialogs are shown by driving their configuration
> directly; the detection/marker/relaunch wiring behind them is covered by the
> unit suites above.

## Proof of no other regressions

- **`tsc --noEmit -p config/tsconfig.node.json`** → clean (exit 0).
- **`oxlint`** on all changed files → clean (exit 0).
- **Full baseline diff** across `src/main/{window,crash-reporting,startup,ipc}` + `app-relaunch`
  (2,486 tests): with my changes **stashed**, the failing‑file set is byte‑for‑byte **identical** to
  the working tree —

  ```
  diff <(working-tree failures) <(baseline failures)  →  IDENTICAL: 0 regressions
  ```

  All 9 pre‑existing failures are unrelated to this change: 6 are Windows‑environment tests
  (`spawn /bin/sh ENOENT`, symlinks, native fs watchers, clipboard) and 2 are brittle
  `index.ts` source‑string‑ordering tests already out of sync with the file on `main`.

## Review process

Reproduced (opus) on the affected build → design doc adversarially reviewed by a fable panel
(sandbox‑semantics / loop‑safety / detection / security / code‑fit) until no major issue →
implemented → **adversarial fable review of the diff** (0 critical, 0 major; 2 actionable minors
applied: window widened 30s→60s to match the recovery breaker + slow cold starts; pop‑out coverage)
→ **performance review** (clean, 0 findings). A third minor — gating on `reason==='crashed'` or
"never reached did‑finish‑load" — was **rejected**: the latter would exclude the *actual* #9891
crash, which fires ~2s *after* the window loads.

_Design notes kept as a local planning doc per the repo's `docs/**` convention (not checked in)._
