### PR TITLE
fix(terminal): forward Ctrl+M as kitty CSI-u for Grok multiline toggle

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-ctrl-m.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-ctrl-m.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveTerminalShortcutAction,
+  type TerminalShortcutEvent
+} from './terminal-shortcut-policy'
+
+function event(overrides: Partial<TerminalShortcutEvent>): TerminalShortcutEvent {
+  return {
+    key: '',
+    code: '',
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    repeat: false,
+    ...overrides
+  }
+}
+
+describe('resolveTerminalShortcutAction Ctrl+M', () => {
+  it('forwards Ctrl+M as the kitty CSI-u chord so Grok can toggle multiline', () => {
+    // Why: Ctrl+M is historically CR (same as Enter). xterm collapses it to bare
+    // CR, so Grok Build never sees a distinct toggle-multiline chord (#9736).
+    expect(
+      resolveTerminalShortcutAction(event({ key: 'm', code: 'KeyM', ctrlKey: true }), true)
+    ).toEqual({ type: 'sendInput', data: '\x1b[109;5u' })
+    expect(
+      resolveTerminalShortcutAction(event({ key: 'M', code: 'KeyM', ctrlKey: true }), false)
+    ).toEqual({ type: 'sendInput', data: '\x1b[109;5u' })
+    // Physical KeyM with a layout-remapped event.key still routes as Ctrl+M.
+    expect(
+      resolveTerminalShortcutAction(event({ key: 'Dead', code: 'KeyM', ctrlKey: true }), true)
+    ).toEqual({ type: 'sendInput', data: '\x1b[109;5u' })
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'm', code: 'KeyM', ctrlKey: true }),
+        false,
+        'false',
+        0,
+        true
+      )
+    ).toEqual({ type: 'sendInput', data: '\x1b[109;5u' })
+  })
+
+  it('does not claim non-plain Ctrl+M chords', () => {
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'm', code: 'KeyM', ctrlKey: true, shiftKey: true }),
+        true
+      )
+    ).toBeNull()
+    expect(
+      resolveTerminalShortcutAction(
+        event({ key: 'm', code: 'KeyM', ctrlKey: true, metaKey: true }),
+        true
+      )
+    ).toBeNull()
+    expect(
+      resolveTerminalShortcutAction(event({ key: 'm', code: 'KeyM', ctrlKey: false }), true)
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -172,6 +172,19 @@ export function resolveTerminalShortcutAction(
     !event.metaKey &&
     !event.altKey &&
     !event.shiftKey &&
+    (event.key === 'm' || event.key === 'M' || event.code === 'KeyM')
+  ) {
+    // Why: Ctrl+M is historically CR (same byte as Enter). xterm collapses it to
+    // bare CR, so Grok Build's multiline toggle never sees a distinct chord (#9736).
+    // Forward kitty CSI-u (codepoint 109 = 'm', modifier 5 = Ctrl) like Ctrl+Enter.
+    return { type: 'sendInput', data: '\x1b[109;5u' }
+  }
+
+  if (
+    event.ctrlKey &&
+    !event.metaKey &&
+    !event.altKey &&
+    !event.shiftKey &&
     event.key === 'Backspace'
   ) {
     return { type: 'sendInput', data: '\x17' }


### PR DESCRIPTION
## 🧑‍🤝‍🧑 Impact & ELI5

**1) What's broken today (ELI5).**  
In Grok Build inside an Orca terminal, **Ctrl+M is supposed to toggle multiline input**. It does not work (behaves like Enter / does nothing useful). Users cannot switch multiline mode with the chord Grok documents.

**2) What this PR does (ELI5).**  
Orca now sends Ctrl+M the same special way it already sends **Ctrl+Enter**: as a **kitty CSI-u** sequence that keeps Ctrl+M **different from Enter**. Grok can finally see the toggle chord.

**3) Tradeoffs / regressions — honest answer.**

| Concern | Assessment |
|--------|------------|
| Shell users who rely on Ctrl+M = Enter (CR) | Ctrl+M will now send CSI-u `\x1b[109;5u` instead of bare CR. **Enter still submits.** Same design choice as Ctrl+Enter (#2418): prefer TUI disambiguation over historical control-char collapse. |
| Other TUIs that bind Ctrl+M via CSI-u | **Benefit.** |
| Cmd+M on macOS | Untouched (window minimize). Only **Ctrl+M**. |
| Platforms | Same policy on macOS / Linux / Windows. |

No settings, menus, or agent-config changes.

---

## Summary

**Bug:** Grok Build Ctrl+M (toggle multiline) does not work in Orca’s terminal (#9736).

**Root cause:** In terminal encoding, **Ctrl+M is historically CR (`0x0d`)**, the same byte as Enter. xterm.js collapses Ctrl+M to bare CR, so the TUI cannot distinguish “toggle multiline” from “submit”.

This is the same class of problem already fixed for **Ctrl+Enter** in `terminal-shortcut-policy.ts` (#2418):

```ts
// Ctrl+Enter → \x1b[13;5u  (Enter codepoint 13, Ctrl modifier 5)
```

Grok’s multiline toggle needs the analogous encoding for **M**:

```ts
// Ctrl+M → \x1b[109;5u  (codepoint 109 = 'm', Ctrl modifier 5)
```

**Fix:** In `resolveTerminalShortcutAction`, intercept plain Ctrl+M (`key` m/M or `code` KeyM) and `sendInput` the kitty CSI-u chord.

Fixes #9736

---

## Evidence

### Automated

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/components/terminal-pane/terminal-shortcut-ctrl-m.test.ts \
  src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts
```

**39/39 passed**

| File | Asserts |
|------|---------|
| `terminal-shortcut-ctrl-m.test.ts` (new) | Ctrl+M / layout-Dead+KeyM → `\x1b[109;5u`; shift/meta/no-ctrl stay `null` |
| `terminal-shortcut-policy.test.ts` | Existing suite still green (including Ctrl+Enter) |

Why a separate test file: the main policy test file is already at the repo max-lines ratchet; AGENTS.md forbids `max-lines` disables.

### Manual (expected after this PR)

1. Open Grok Build in an Orca terminal (macOS).  
2. Focus the composer.  
3. Press **Ctrl+M**.  
4. **Before:** acts like Enter / no multiline toggle.  
5. **After:** multiline mode toggles as outside Orca.

### Code map

| Location | Change |
|----------|--------|
| `terminal-shortcut-policy.ts` | Ctrl+M → `\x1b[109;5u` |
| `terminal-shortcut-ctrl-m.test.ts` | New focused regression tests |

---

## ELI5

Ctrl+M and Enter used to look identical to the terminal (both “carriage return”). Grok needs them to look different so Ctrl+M can mean “multiline,” not “send.” We label Ctrl+M with a special code, like we already did for Ctrl+Enter.

---

## User-regression-tradeoffs

- **Intended:** Ctrl+M reaches agent TUIs (Grok) as a distinct chord.  
- **Shell Ctrl+M-as-Enter:** may stop inserting CR; use **Enter** instead (same as Ctrl+Enter tradeoff).  
- **Cmd+M (macOS):** unchanged.

---

## Checklist notes (CONTRIBUTING / AGENTS)

| Area | Notes |
|------|--------|
| **Cross-platform** | Uses `ctrlKey` (not meta). Cmd+M not remapped. |
| **SSH / remote** | PTY input bytes; encoding independent of remote OS. |
| **Agents** | Helps Grok multiline (and any TUI binding Ctrl+M via CSI-u). No agent-config change. |
| **Git / providers** | N/A |
| **Performance** | One extra predicate on the shortcut path. |
| **UI** | No visual change. |
| **Security** | No new IPC. |
| **Tests** | Focused new file + full policy suite green. No max-lines disable. |

---

## Test plan

- [x] Unit: Ctrl+M → `\x1b[109;5u`  
- [x] Unit: non-plain chords still passthrough  
- [x] Full policy suite green  
- [ ] Optional live Grok smoke on macOS

---

## Out of scope

- Other historical Ctrl+letter collapses (Ctrl+J = LF, etc.) without a concrete TUI need  
- Changing Grok launch / kitty enablement

---

## AI code-review summary

1. **Cross-platform** — Ctrl not Cmd; OK  
2. **SSH/remote** — PTY bytes; OK  
3. **Agents** — encoding only  
4. **Performance** — trivial  
5. **UI** — N/A  
6. **Security** — N/A  
7. **Correctness** — mirrors proven Ctrl+Enter pattern; tests lock encoding; no max-lines disable  

---

Made so Grok multiline works in Orca 🐋