### PR TITLE
fix(tab-bar): unstick Ctrl+Tab switcher opened from a focused browser guest

### DIFF
--- a/src/main/browser/browser-guest-ui.test.ts
+++ b/src/main/browser/browser-guest-ui.test.ts
@@ -508,6 +508,30 @@ describe('setupGuestShortcutForwarding', () => {
     }
   })
 
+  it('clears held Ctrl+Tab state when the guest blurs mid-gesture', () => {
+    setupGuestShortcutForwarding({
+      browserTabId,
+      guest: makeGuest(),
+      resolveRenderer: () => makeRenderer()
+    })
+
+    triggerBeforeInput({ code: 'Tab', key: 'Tab', control: true, meta: false })
+    expect(rendererSendMock).toHaveBeenCalledWith('ui:ctrlTabKeyDown', { shiftKey: false })
+    rendererSendMock.mockClear()
+
+    // Why: the renderer steals focus from the guest to run the held gesture;
+    // a later stray keyup must not emit a phantom commit from stale state.
+    triggerGuestBlur()
+    triggerBeforeInput({
+      type: 'keyUp',
+      code: 'ControlLeft',
+      key: 'Control',
+      control: false,
+      meta: false
+    })
+    expect(rendererSendMock).not.toHaveBeenCalled()
+  })
+
   it('forwards browser page zoom shortcuts from focused guest pages', () => {
     setupGuestShortcutForwarding({
       browserTabId,

--- a/src/main/browser/browser-guest-ui.ts
+++ b/src/main/browser/browser-guest-ui.ts
@@ -272,7 +272,13 @@ export function setupGuestShortcutForwarding(args: {
   } = args
   let ctrlTabSwitching = false
   const doubleTapDetector = new ModifierDoubleTapDetector()
-  const resetDoubleTapDetector = (): void => doubleTapDetector.reset()
+  // Why: the renderer pulls focus out of the guest mid-Ctrl+Tab gesture (a
+  // prevented keydown suppresses guest keyups), so clear held-key state on blur
+  // rather than letting a stale flag emit a phantom commit on a later keyup.
+  const resetHeldKeyState = (): void => {
+    ctrlTabSwitching = false
+    doubleTapDetector.reset()
+  }
   type GuestShortcutInput = WindowShortcutInput & { isAutoRepeat?: boolean }
 
   const forwardBrowserPageZoom = (
@@ -516,12 +522,12 @@ export function setupGuestShortcutForwarding(args: {
 
   guest.on('before-input-event', handler)
   guest.on('zoom-changed', zoomCommandHandler)
-  guest.on('blur', resetDoubleTapDetector)
+  guest.on('blur', resetHeldKeyState)
   return () => {
     try {
       guest.off('before-input-event', handler)
       guest.off('zoom-changed', zoomCommandHandler)
-      guest.off('blur', resetDoubleTapDetector)
+      guest.off('blur', resetHeldKeyState)
     } catch {
       // Why: best-effort — guest may already be destroyed during teardown.
     }

--- a/src/renderer/src/components/tab-bar/RecentTabSwitcher.test.tsx
+++ b/src/renderer/src/components/tab-bar/RecentTabSwitcher.test.tsx
@@ -88,6 +88,17 @@ function makeStore(): AppState {
   } as unknown as AppState
 }
 
+function makeBrowserGuestStore(): AppState {
+  const store = makeStore() as unknown as Record<string, unknown>
+  store.activeTabType = 'browser'
+  store.activeBrowserTabId = 'browser-tab-1'
+  // Why: focus requests target the browser *page* id, resolved from the tab.
+  store.browserTabsByWorktree = {
+    [WORKTREE_ID]: [{ id: 'browser-tab-1', activePageId: 'page-1' }]
+  }
+  return store as unknown as AppState
+}
+
 function installWindowApi(): void {
   Object.defineProperty(window, 'api', {
     configurable: true,
@@ -181,6 +192,67 @@ describe('RecentTabSwitcher', () => {
     expect(terminal.keyUp).not.toHaveBeenCalled()
     expectCommittedToTabB()
 
+    await act(async () => {
+      root.unmount()
+    })
+  })
+
+  it('pulls DOM focus out of a webview guest when the switcher opens via IPC', async () => {
+    // Why: a prevented guest keydown suppresses guest keyups (see #9937), so
+    // the gesture must transfer to the renderer window by blurring the webview.
+    const store = makeBrowserGuestStore()
+    getStateMock.mockReturnValue(store)
+
+    const { root } = await renderSwitcher()
+    const webview = document.createElement('webview')
+    const blur = vi.fn()
+    webview.blur = blur
+    const activeElementSpy = vi
+      .spyOn(document, 'activeElement', 'get')
+      .mockReturnValue(webview as unknown as Element)
+
+    await act(async () => {
+      ctrlTabKeyDownCallback?.({ shiftKey: false })
+    })
+
+    expect(document.body.querySelector('[role="listbox"]')).not.toBeNull()
+    expect(blur).toHaveBeenCalledTimes(1)
+
+    activeElementSpy.mockRestore()
+    await act(async () => {
+      root.unmount()
+    })
+  })
+
+  it('returns focus to the source browser page when the gesture is cancelled', async () => {
+    const store = makeBrowserGuestStore()
+    getStateMock.mockReturnValue(store)
+
+    const { root } = await renderSwitcher()
+    const webview = document.createElement('webview')
+    webview.blur = vi.fn()
+    const activeElementSpy = vi
+      .spyOn(document, 'activeElement', 'get')
+      .mockReturnValue(webview as unknown as Element)
+
+    await act(async () => {
+      ctrlTabKeyDownCallback?.({ shiftKey: false })
+    })
+    activeElementSpy.mockRestore()
+
+    const focusRequests: { pageId: string; target: string }[] = []
+    const onFocusRequest = (event: Event): void => {
+      focusRequests.push((event as CustomEvent<{ pageId: string; target: string }>).detail)
+    }
+    window.addEventListener('orca:browser-focus-request', onFocusRequest)
+
+    await dispatchKeyboard(document.body, 'keydown', { key: 'Escape', code: 'Escape' })
+
+    expect(document.body.querySelector('[role="listbox"]')).toBeNull()
+    expect(focusRequests).toEqual([{ pageId: 'page-1', target: 'webview' }])
+    expect(activateCyclableTabMock).not.toHaveBeenCalled()
+
+    window.removeEventListener('orca:browser-focus-request', onFocusRequest)
     await act(async () => {
       root.unmount()
     })

--- a/src/renderer/src/components/tab-bar/RecentTabSwitcher.tsx
+++ b/src/renderer/src/components/tab-bar/RecentTabSwitcher.tsx
@@ -14,6 +14,10 @@ import {
   normalizeCtrlTabOrderMode,
   type RecentTabSwitcherItem
 } from './recent-tab-switching'
+import {
+  ORCA_BROWSER_FOCUS_REQUEST_EVENT,
+  queueBrowserFocusRequest
+} from '../browser-pane/browser-focus'
 import { translate } from '@/i18n/i18n'
 
 type SwitcherState = {
@@ -24,6 +28,21 @@ type SwitcherState = {
 function consumeKeyboardEvent(event: KeyboardEvent): void {
   event.preventDefault()
   event.stopPropagation()
+}
+
+// Why: focus requests are keyed by browser *page* id (what BrowserPane mounts),
+// while switcher items and activeBrowserTabId carry the browser *tab* id.
+function resolveActiveBrowserPageId(
+  state: ReturnType<typeof useAppStore.getState>,
+  browserTabId: string
+): string | null {
+  for (const tabs of Object.values(state.browserTabsByWorktree)) {
+    const tab = tabs.find((candidate) => candidate.id === browserTabId)
+    if (tab) {
+      return tab.activePageId ?? null
+    }
+  }
+  return null
 }
 
 function TabIcon({ item }: { item: RecentTabSwitcherItem }): React.JSX.Element {
@@ -47,10 +66,40 @@ function TabIcon({ item }: { item: RecentTabSwitcherItem }): React.JSX.Element {
 export default function RecentTabSwitcher(): React.JSX.Element | null {
   const [switcher, setSwitcher] = useState<SwitcherState | null>(null)
   const switcherRef = useRef<SwitcherState | null>(null)
+  // Why: set only when the gesture started inside a browser guest, so commit/
+  // cancel know to hand focus back to a webview instead of leaving it on body.
+  const guestSourcePageIdRef = useRef<string | null>(null)
 
   const setSwitcherState = useCallback((next: SwitcherState | null): void => {
     switcherRef.current = next
     setSwitcher(next)
+  }, [])
+
+  const requestGuestPageFocus = useCallback((pageId: string): void => {
+    const detail = { pageId, target: 'webview' as const }
+    queueBrowserFocusRequest(detail)
+    window.dispatchEvent(new CustomEvent(ORCA_BROWSER_FOCUS_REQUEST_EVENT, { detail }))
+  }, [])
+
+  const releaseGuestFocusForHeldGesture = useCallback((): void => {
+    if (!switcherRef.current) {
+      return
+    }
+    const active = document.activeElement
+    if (!(active instanceof HTMLElement) || active.tagName !== 'WEBVIEW') {
+      return
+    }
+    const store = useAppStore.getState()
+    guestSourcePageIdRef.current =
+      store.activeTabType === 'browser' && store.activeBrowserTabId
+        ? resolveActiveBrowserPageId(store, store.activeBrowserTabId)
+        : null
+    // Why: main preventDefault-ed the guest's Ctrl+Tab keydown, and Chromium
+    // then suppresses every guest keyup until the next keydown — the
+    // modifier-release commit can never arrive over IPC (#9937). Move DOM focus
+    // out of the webview so the rest of the held gesture (advance, release,
+    // Escape) flows through this window's key handlers instead.
+    active.blur()
   }, [])
 
   const openOrAdvance = useCallback(
@@ -88,27 +137,43 @@ export default function RecentTabSwitcher(): React.JSX.Element | null {
   const commit = useCallback((): void => {
     const current = switcherRef.current
     setSwitcherState(null)
+    const guestSourcePageId = guestSourcePageIdRef.current
+    guestSourcePageIdRef.current = null
     const selected = current?.items[current.selectedIndex]
     if (!selected) {
       return
     }
     activateCyclableTab(useAppStore.getState(), selected)
-  }, [setSwitcherState])
+    // Why: the held gesture pulled focus out of the source webview; when it
+    // commits to a browser tab, hand focus to that page like a click would.
+    if (guestSourcePageId !== null && selected.type === 'browser') {
+      const pageId = resolveActiveBrowserPageId(useAppStore.getState(), selected.id)
+      if (pageId !== null) {
+        requestGuestPageFocus(pageId)
+      }
+    }
+  }, [requestGuestPageFocus, setSwitcherState])
 
   const cancel = useCallback((): void => {
     setSwitcherState(null)
-  }, [setSwitcherState])
+    const guestSourcePageId = guestSourcePageIdRef.current
+    guestSourcePageIdRef.current = null
+    if (guestSourcePageId !== null) {
+      requestGuestPageFocus(guestSourcePageId)
+    }
+  }, [requestGuestPageFocus, setSwitcherState])
 
   useEffect(() => {
     const unsubscribeKeyDown = window.api.ui.onCtrlTabKeyDown(({ shiftKey }) => {
       openOrAdvance(shiftKey ? -1 : 1)
+      releaseGuestFocusForHeldGesture()
     })
     const unsubscribeKeyUp = window.api.ui.onCtrlTabKeyUp(commit)
     return () => {
       unsubscribeKeyDown()
       unsubscribeKeyUp()
     }
-  }, [commit, openOrAdvance])
+  }, [commit, openOrAdvance, releaseGuestFocusForHeldGesture])
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent): void => {

--- a/tests/e2e/browser-ctrl-tab-switcher.spec.ts
+++ b/tests/e2e/browser-ctrl-tab-switcher.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * E2E regression for issue #9937: Ctrl+Tab MRU switcher got stuck open when the
+ * gesture started inside a focused in-app browser (webview guest).
+ *
+ * Root cause: the guest's before-input-event handler preventDefault-s the
+ * Ctrl+Tab keydown, and Chromium then suppresses every guest keyup until the
+ * next keydown — so the modifier-release commit could never arrive over IPC.
+ * The fix hands the rest of the held gesture to the renderer window: opening
+ * the switcher from a guest pulls DOM focus out of the webview, so release/
+ * advance/Escape flow through the renderer's key handlers.
+ */
+
+import { test, expect } from './helpers/orca-app'
+import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import {
+  waitForSessionReady,
+  waitForActiveWorktree,
+  getActiveWorktreeId,
+  getActiveTabType,
+  ensureTerminalVisible
+} from './helpers/store'
+
+type OrcaPage = Parameters<typeof getActiveWorktreeId>[0]
+
+async function startFocusablePageServer(): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+    response.end(
+      '<!doctype html><html><head><title>Guest page</title></head><body><input id="q" autofocus /></body></html>'
+    )
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const port = (server.address() as AddressInfo).port
+  return {
+    url: `http://127.0.0.1:${port}/`,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((error: Error | undefined) => (error ? reject(error) : resolve()))
+      )
+  }
+}
+
+async function createBrowserTab(
+  page: OrcaPage,
+  worktreeId: string,
+  url: string
+): Promise<string | null> {
+  return page.evaluate(
+    ({ targetWorktreeId, targetUrl }) => {
+      const store = window.__store
+      if (!store) {
+        return null
+      }
+      const tab = store
+        .getState()
+        .createBrowserTab(targetWorktreeId, targetUrl, { title: 'Guest page', activate: true })
+      return tab.id
+    },
+    { targetWorktreeId: worktreeId, targetUrl: url }
+  )
+}
+
+async function focusGuestPage(page: OrcaPage, browserTabId: string): Promise<void> {
+  await page.evaluate(async (targetBrowserTabId) => {
+    const slot = [...document.querySelectorAll('[data-browser-overlay-tab-id]')].find(
+      (candidate) => candidate.getAttribute('data-browser-overlay-tab-id') === targetBrowserTabId
+    )
+    const webview = slot?.querySelector('webview') as Electron.WebviewTag | null
+    if (!webview) {
+      throw new Error(`Missing webview for browser tab ${targetBrowserTabId}`)
+    }
+    webview.focus()
+    await webview.executeJavaScript('document.querySelector("#q")?.focus()')
+  }, browserTabId)
+}
+
+async function sendGuestCtrlTabKeyDown(page: OrcaPage, browserTabId: string): Promise<void> {
+  await page.evaluate(
+    async ({ targetBrowserTabId }) => {
+      const slot = [...document.querySelectorAll('[data-browser-overlay-tab-id]')].find(
+        (candidate) => candidate.getAttribute('data-browser-overlay-tab-id') === targetBrowserTabId
+      )
+      const webview = slot?.querySelector('webview') as Electron.WebviewTag | null
+      if (!webview) {
+        throw new Error(`Missing webview for browser tab ${targetBrowserTabId}`)
+      }
+      await webview.sendInputEvent({ type: 'keyDown', keyCode: 'Tab', modifiers: ['control'] })
+    },
+    { targetBrowserTabId: browserTabId }
+  )
+}
+
+async function getRendererActiveElementTag(page: OrcaPage): Promise<string | null> {
+  return page.evaluate(() => document.activeElement?.tagName ?? null)
+}
+
+async function getSelectedSwitcherLabel(page: OrcaPage): Promise<string | null> {
+  const selected = page.locator('[role="listbox"] [role="option"][aria-selected="true"]')
+  return (await selected.count()) === 1 ? selected.textContent() : null
+}
+
+test.describe('Ctrl+Tab switcher from focused browser guest', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+  })
+
+  test('opens from the guest and commits on modifier release', async ({ orcaPage }) => {
+    const pageServer = await startFocusablePageServer()
+    try {
+      const worktreeId = (await getActiveWorktreeId(orcaPage))!
+      const browserTabId = await createBrowserTab(orcaPage, worktreeId, pageServer.url)
+      expect(browserTabId).toBeTruthy()
+      await expect.poll(async () => getActiveTabType(orcaPage), { timeout: 5_000 }).toBe('browser')
+      await focusGuestPage(orcaPage, browserTabId!)
+
+      const overlay = orcaPage.locator('[role="listbox"][aria-label="Switch tabs"]')
+      await sendGuestCtrlTabKeyDown(orcaPage, browserTabId!)
+      await expect(overlay).toBeVisible({ timeout: 5_000 })
+
+      // The renderer must own the rest of the held gesture: a prevented guest
+      // keydown suppresses guest keyups, so focus has to leave the webview.
+      await expect
+        .poll(async () => getRendererActiveElementTag(orcaPage), { timeout: 5_000 })
+        .not.toBe('WEBVIEW')
+
+      // Modifier release now reaches the renderer window and commits.
+      await orcaPage.keyboard.down('Control')
+      await orcaPage.keyboard.up('Control')
+      await expect(overlay).toBeHidden({ timeout: 5_000 })
+      await expect.poll(async () => getActiveTabType(orcaPage), { timeout: 5_000 }).toBe('terminal')
+    } finally {
+      await pageServer.close()
+    }
+  })
+
+  test('advances while held and returns focus to the committed browser page', async ({
+    orcaPage
+  }) => {
+    const pageServer = await startFocusablePageServer()
+    try {
+      const worktreeId = (await getActiveWorktreeId(orcaPage))!
+      const browserTabId = await createBrowserTab(orcaPage, worktreeId, pageServer.url)
+      expect(browserTabId).toBeTruthy()
+      await expect.poll(async () => getActiveTabType(orcaPage), { timeout: 5_000 }).toBe('browser')
+      await focusGuestPage(orcaPage, browserTabId!)
+
+      const overlay = orcaPage.locator('[role="listbox"][aria-label="Switch tabs"]')
+      await sendGuestCtrlTabKeyDown(orcaPage, browserTabId!)
+      await expect(overlay).toBeVisible({ timeout: 5_000 })
+
+      // Keep tapping Tab (Ctrl held) until the browser tab is selected again,
+      // then release: the switcher must commit back to it and hand focus to
+      // the guest page rather than leaving it stranded on the renderer body.
+      await orcaPage.keyboard.down('Control')
+      const itemCount = await overlay.locator('[role="option"]').count()
+      for (let step = 0; step < itemCount; step += 1) {
+        if ((await getSelectedSwitcherLabel(orcaPage))?.includes('Guest page')) {
+          break
+        }
+        await orcaPage.keyboard.press('Tab')
+      }
+      expect(await getSelectedSwitcherLabel(orcaPage)).toContain('Guest page')
+      await orcaPage.keyboard.up('Control')
+
+      await expect(overlay).toBeHidden({ timeout: 5_000 })
+      await expect.poll(async () => getActiveTabType(orcaPage), { timeout: 5_000 }).toBe('browser')
+      await expect
+        .poll(async () => getRendererActiveElementTag(orcaPage), { timeout: 5_000 })
+        .toBe('WEBVIEW')
+    } finally {
+      await pageServer.close()
+    }
+  })
+})


### PR DESCRIPTION

## Summary

Fixes #9937.

Fixed issue where the Ctrl+Tab tab switching overlay gets stuck when activated from within a browser window. 

https://github.com/user-attachments/assets/e317b63e-673f-43bc-ac4e-da099ea48b8d


## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added regression tests:
    - New E2E spec `tests/e2e/browser-ctrl-tab-switcher.spec.ts` — reproduced the stuck overlay pre-fix (drives the real guest `before-input-event` path via `webview.sendInputEvent`), green post-fix: (1) opens from the guest and commits on modifier release; (2) advances while held, commits back to the browser tab, and returns focus to the guest page.
    - Unit: `RecentTabSwitcher.test.tsx` (webview blur on IPC open; focus-request restore on cancel), `browser-guest-ui.test.ts` (guest blur clears held-chord state).


## AI Review Report

Reviewed with Claude Code. The root cause was established empirically before writing the fix: an instrumented E2E run showed guest keydowns reaching `before-input-event` while every keyup after the prevented Ctrl+Tab keydown was suppressed, ruling out IPC wiring and renderer-listener explanations.

Risks checked:
- **Gesture correctness** — repeat keydowns, Shift-reversed direction, Tab-release-while-Ctrl-held (must not commit), Escape cancel, and window blur cancel all flow through the existing renderer handlers after the webview blur; no chord logic changed.
- **Focus lifecycle** — blur only fires when the switcher actually opened (guard on `switcherRef`) and the active element is a `<webview>`; restore targets the browser *page* id resolved from the tab (`activePageId`), matching what `BrowserPane` consumes. An earlier draft passed the tab id — the E2E focus-restore test caught it.
- **Stale state** — guest `blur` now clears `ctrlTabSwitching` so a later unrelated keyup can't emit a phantom `ui:ctrlTabKeyUp`; a phantom commit is additionally a no-op in the renderer (null switcher guard).
- **Non-browser guests** — simulator/emulator webviews still get the blur (commit works); source-restore is intentionally skipped when `activeTabType !== 'browser'`.

Cross-platform: explicitly checked for macOS, Linux, and Windows. No new chords or labels; matching stays behind `matchesRecentTabSwitcherChord`/the keybinding registry (`Ctrl+Tab` default on all platforms), the Chromium keyup-suppression behavior is platform-independent (bug reported on Linux, reproduced on macOS), and the change touches no paths, shell behavior, or platform-conditional Electron APIs. SSH use case unaffected — UI keyboard routing only.

## Security Audit

- **IPC**: no new channels; the fix consumes the existing main→renderer `ui:ctrlTabKeyDown`/`ui:ctrlTabKeyUp` events, which originate only from the main process's guest shortcut forwarding — guest page content cannot forge them and no guest-supplied data flows into the new code paths.
- **Input handling**: the renderer acts only on trusted store state (tab/page ids) plus `document.activeElement` tag checks; the guest keydown remains `preventDefault()`-ed, so pages still never observe the Ctrl+Tab chord.
- **Focus requests**: reuse the existing TTL-bounded `queueBrowserFocusRequest` path already used by the palette; ids come from the renderer store, not from guest content.






## ELI5

Ctrl+Tab from inside a browser tab could leave the tab switcher stuck on screen. Input is handled so the overlay closes when you release the keys, even when focus was in the browser guest.
