### PR TITLE
fix: sidebar worktree card reads local SSH state for remote-runtime worktrees

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.ssh-reconnect-prompt.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.ssh-reconnect-prompt.test.tsx
@@ -2,6 +2,8 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import type { ReactNode } from 'react'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Repo, Worktree, WorktreeCardProperty } from '../../../../shared/types'
+import { toRuntimeExecutionHostId } from '../../../../shared/execution-host'
+import type { RuntimeEnvironmentSshBucket } from '@/store/slices/runtime-environment-ssh'
 import type WorktreeCardComponent from './WorktreeCard'
 
 const fetchHostedReviewForBranch = vi.fn()
@@ -14,6 +16,8 @@ let WorktreeCard: typeof WorktreeCardComponent
 let sshConnectionStates = new Map<string, { status: string }>()
 let sshTargetLabels = new Map<string, string>()
 let runtimeStatusByEnvironmentId = new Map<string, { status?: unknown }>()
+let sshStateByEnvironment = new Map<string, RuntimeEnvironmentSshBucket>()
+let worktreesByRepo: Record<string, Worktree[]> = {}
 let worktreeCardProperties: WorktreeCardProperty[] = ['status']
 
 vi.mock('@/store', () => ({
@@ -32,10 +36,14 @@ vi.mock('@/store', () => ({
       remoteBranchConflictByWorktreeId: {},
       runtimeStatusByEnvironmentId,
       settings: null,
+      removedSshTargetLabels: new Map(),
       sshConnectionStates,
+      sshStateByEnvironment,
       sshTargetLabels,
+      sshTargetsHydrated: false,
       updateWorktreeMeta,
-      worktreeCardProperties
+      worktreeCardProperties,
+      worktreesByRepo
     })
 }))
 
@@ -130,6 +138,8 @@ describe('WorktreeCard SSH reconnect prompt', () => {
     sshConnectionStates = new Map()
     sshTargetLabels = new Map()
     runtimeStatusByEnvironmentId = new Map()
+    sshStateByEnvironment = new Map()
+    worktreesByRepo = {}
     worktreeCardProperties = ['status']
   })
 
@@ -159,6 +169,80 @@ describe('WorktreeCard SSH reconnect prompt', () => {
       <WorktreeCard worktree={makeWorktree()} repo={runtimeRepo} isActive={false} />
     )
     expect(markup).toContain('Server disconnected')
+  })
+
+  // Regression (#9276): paired clients mirror hub SSH state only into
+  // sshStateByEnvironment; reading the local maps marked every healthy hub
+  // worktree disconnected and armed the blocking reconnect dialog.
+  it('does not mark a hub-owned SSH worktree disconnected when the hub reports it connected', () => {
+    runtimeStatusByEnvironmentId.set('env-1', { status: { runtimeId: 'r1' } })
+    sshStateByEnvironment.set('env-1', {
+      connectionStates: new Map([
+        [
+          'ssh-target-1',
+          { targetId: 'ssh-target-1', status: 'connected', error: null, reconnectAttempt: 0 }
+        ]
+      ]),
+      targetLabels: new Map([['ssh-target-1', 'Hub target']]),
+      removedTargetLabels: new Map(),
+      targetsHydrated: true
+    })
+    const hubWorktree: Worktree = {
+      ...makeWorktree(),
+      hostId: toRuntimeExecutionHostId('env-1')
+    }
+    worktreesByRepo = { 'repo-1': [hubWorktree] }
+
+    const markup = renderToStaticMarkup(
+      <WorktreeCard worktree={hubWorktree} repo={makeRepo()} isActive={false} />
+    )
+
+    expect(markup).not.toContain('SSH disconnected')
+    expect(markup).toContain('data-ssh-status="connected"')
+    expect(markup).toContain('data-ssh-target-label="Hub target"')
+  })
+
+  it('still shows the disconnected chip when the hub itself reports the target disconnected', () => {
+    runtimeStatusByEnvironmentId.set('env-1', { status: { runtimeId: 'r1' } })
+    sshStateByEnvironment.set('env-1', {
+      connectionStates: new Map([
+        [
+          'ssh-target-1',
+          { targetId: 'ssh-target-1', status: 'disconnected', error: null, reconnectAttempt: 0 }
+        ]
+      ]),
+      targetLabels: new Map([['ssh-target-1', 'Hub target']]),
+      removedTargetLabels: new Map(),
+      targetsHydrated: true
+    })
+    const hubWorktree: Worktree = {
+      ...makeWorktree(),
+      hostId: toRuntimeExecutionHostId('env-1')
+    }
+    worktreesByRepo = { 'repo-1': [hubWorktree] }
+
+    const markup = renderToStaticMarkup(
+      <WorktreeCard worktree={hubWorktree} repo={makeRepo()} isActive={false} />
+    )
+
+    expect(markup).toContain('SSH disconnected')
+    expect(markup).toContain('data-ssh-target-label="Hub target"')
+  })
+
+  it('shows nothing for a hub-owned SSH worktree while the hub bucket is not hydrated', () => {
+    runtimeStatusByEnvironmentId.set('env-1', { status: { runtimeId: 'r1' } })
+    const hubWorktree: Worktree = {
+      ...makeWorktree(),
+      hostId: toRuntimeExecutionHostId('env-1')
+    }
+    worktreesByRepo = { 'repo-1': [hubWorktree] }
+
+    const markup = renderToStaticMarkup(
+      <WorktreeCard worktree={hubWorktree} repo={makeRepo()} isActive={false} />
+    )
+
+    // Unknown owner state must render no chip instead of a false disconnect.
+    expect(markup).not.toContain('SSH disconnected')
   })
 
   it('shows a runtime-host worktree as connected when its environment has a status', () => {

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -81,8 +81,14 @@ import {
 import { translate } from '@/i18n/i18n'
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-diagnostics'
 import { folderWorkspaceKey, parseWorkspaceKey } from '../../../../shared/workspace-scope'
-import { isRuntimeOwnedSshTargetId, parseExecutionHostId } from '../../../../shared/execution-host'
+import { parseExecutionHostId } from '../../../../shared/execution-host'
 import { DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE } from '../../../../shared/constants'
+import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { isPairedWebClientWindow } from '@/lib/desktop-window-chrome'
+import {
+  selectWorktreeCardSshStatus,
+  selectWorktreeCardSshTargetLabel
+} from './worktree-card-ssh-status'
 
 type WorktreeRenameRequest = {
   worktreeId: string
@@ -331,14 +337,16 @@ const WorktreeCard = React.memo(function WorktreeCard({
   )
 
   // SSH disconnected state
-  const sshStatus = useAppStore((s) => {
-    // Why: runtime-owned SSH targets suppress their ssh:state-changed broadcasts, so don't show a false "disconnected" chip for them.
-    if (!repo?.connectionId || isRuntimeOwnedSshTargetId(repo.connectionId)) {
-      return null
-    }
-    const state = s.sshConnectionStates.get(repo.connectionId)
-    return state?.status ?? 'disconnected'
-  })
+  // Which machine's SSH store owns this card's target: a remote server's per-environment bucket, or null for this machine's local SSH maps.
+  // Why: paired web clients force null — they mirror their one host through the local maps, not an explicit environment bucket.
+  const sshEnvironmentId = useAppStore((s) =>
+    repo?.connectionId && !isPairedWebClientWindow()
+      ? getExplicitRuntimeEnvironmentIdForWorktree(s, worktree.id)
+      : null
+  )
+  const sshStatus = useAppStore((s) =>
+    selectWorktreeCardSshStatus(s, sshEnvironmentId, repo?.connectionId)
+  )
   const isSshDisconnected = sshStatus != null && sshStatus !== 'connected'
   // Why: terminal views have their own reconnect overlay; reserve the blocking dialog for non-terminal views (default to terminal when ambiguous).
   const activeViewIsTerminal = useAppStore(
@@ -359,7 +367,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   const [showRenameErrorDialog, setShowRenameErrorDialog] = useState(false)
   // Why: read the target label from the store (hydrated in useIpcEvents.ts) instead of a listTargets IPC per card.
   const sshTargetLabel = useAppStore((s) =>
-    repo?.connectionId ? (s.sshTargetLabels.get(repo.connectionId) ?? '') : ''
+    selectWorktreeCardSshTargetLabel(s, sshEnvironmentId, repo?.connectionId)
   )
 
   const gitIdentityDisplay = getWorktreeGitIdentityDisplay(worktree)

--- a/src/renderer/src/components/sidebar/worktree-card-ssh-status.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-ssh-status.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+import type { SshConnectionState } from '../../../../shared/ssh-types'
+import type { RuntimeStatus } from '../../../../shared/runtime-types'
+import { toRuntimeExecutionHostId } from '../../../../shared/execution-host'
+import {
+  createTestStore,
+  makeWorktree,
+  seedStore,
+  TEST_REPO
+} from '@/store/slices/store-test-helpers'
+import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import {
+  selectWorktreeCardSshStatus,
+  selectWorktreeCardSshTargetLabel
+} from './worktree-card-ssh-status'
+
+const ENV_HUB = 'env-hub'
+const TARGET = 'ssh-hub-box'
+
+function connState(status: SshConnectionState['status'] = 'connected'): SshConnectionState {
+  return { targetId: TARGET, status, error: null, reconnectAttempt: 0 }
+}
+
+function markReachable(store: ReturnType<typeof createTestStore>, environmentId: string): void {
+  store.getState().setRuntimeEnvironmentStatus(environmentId, {
+    status: { runtimeId: environmentId } as RuntimeStatus,
+    checkedAt: Date.now()
+  })
+}
+
+function seedHubBucket(
+  store: ReturnType<typeof createTestStore>,
+  status: SshConnectionState['status'] = 'connected'
+): void {
+  markReachable(store, ENV_HUB)
+  store.getState().setEnvironmentSshTargetsMetadata(ENV_HUB, [{ id: TARGET, label: 'hub-box' }])
+  store.getState().setEnvironmentSshConnectionState(ENV_HUB, TARGET, connState(status))
+}
+
+describe('selectWorktreeCardSshStatus', () => {
+  // Regression: paired clients mirror hub SSH state only into sshStateByEnvironment,
+  // so a local-map read made every healthy hub worktree render "disconnected".
+  it('reads the owning environment bucket, not the local maps, for hub-owned targets', () => {
+    const store = createTestStore()
+    seedHubBucket(store)
+    expect(store.getState().sshConnectionStates.size).toBe(0)
+
+    expect(selectWorktreeCardSshStatus(store.getState(), ENV_HUB, TARGET)).toBe('connected')
+  })
+
+  it('still surfaces a real disconnect reported by the hub', () => {
+    const store = createTestStore()
+    seedHubBucket(store, 'disconnected')
+
+    expect(selectWorktreeCardSshStatus(store.getState(), ENV_HUB, TARGET)).toBe('disconnected')
+  })
+
+  it('reports unknown (null), not disconnected, while the hub bucket is unhydrated', () => {
+    const store = createTestStore()
+    markReachable(store, ENV_HUB)
+
+    expect(selectWorktreeCardSshStatus(store.getState(), ENV_HUB, TARGET)).toBeNull()
+  })
+
+  it('reports unknown (null) when the owning environment is unreachable', () => {
+    const store = createTestStore()
+    store.getState().setEnvironmentSshTargetsMetadata(ENV_HUB, [{ id: TARGET, label: 'hub-box' }])
+    store.getState().setEnvironmentSshConnectionState(ENV_HUB, TARGET, connState())
+
+    expect(selectWorktreeCardSshStatus(store.getState(), ENV_HUB, TARGET)).toBeNull()
+  })
+
+  it('keeps local-map semantics for local worktrees (environmentId null)', () => {
+    const store = createTestStore()
+    store.setState({ sshConnectionStates: new Map([[TARGET, connState()]]) })
+
+    expect(selectWorktreeCardSshStatus(store.getState(), null, TARGET)).toBe('connected')
+    // Absent local state must keep today's pessimistic fallback.
+    expect(selectWorktreeCardSshStatus(store.getState(), null, 'ssh-unknown')).toBe('disconnected')
+  })
+
+  it('returns null for runtime-owned target ids and missing connection ids', () => {
+    const store = createTestStore()
+    seedHubBucket(store)
+
+    expect(selectWorktreeCardSshStatus(store.getState(), null, 'runtime-ssh-vm1')).toBeNull()
+    expect(selectWorktreeCardSshStatus(store.getState(), ENV_HUB, 'runtime-ssh-vm1')).toBeNull()
+    expect(selectWorktreeCardSshStatus(store.getState(), null, undefined)).toBeNull()
+  })
+})
+
+describe('selectWorktreeCardSshTargetLabel', () => {
+  it('reads the owning environment bucket label for hub-owned targets', () => {
+    const store = createTestStore()
+    seedHubBucket(store)
+    expect(store.getState().sshTargetLabels.size).toBe(0)
+
+    expect(selectWorktreeCardSshTargetLabel(store.getState(), ENV_HUB, TARGET)).toBe('hub-box')
+  })
+
+  it('keeps local-map semantics for local worktrees (environmentId null)', () => {
+    const store = createTestStore()
+    store.setState({ sshTargetLabels: new Map([[TARGET, 'my-box']]) })
+
+    expect(selectWorktreeCardSshTargetLabel(store.getState(), null, TARGET)).toBe('my-box')
+    // Absent local label must keep today's '' fallback (card falls back to repo.displayName).
+    expect(selectWorktreeCardSshTargetLabel(store.getState(), null, 'ssh-unknown')).toBe('')
+  })
+
+  it('returns "" instead of the raw target id when the hub bucket has no label', () => {
+    const store = createTestStore()
+    markReachable(store, ENV_HUB)
+    store.getState().setEnvironmentSshConnectionState(ENV_HUB, TARGET, connState())
+
+    expect(selectWorktreeCardSshTargetLabel(store.getState(), ENV_HUB, TARGET)).toBe('')
+  })
+
+  it('falls back to the hub tombstone label for a target removed on the hub', () => {
+    const store = createTestStore()
+    markReachable(store, ENV_HUB)
+    store.getState().setEnvironmentRemovedSshTargetLabels(ENV_HUB, { [TARGET]: 'old hub box' })
+
+    expect(selectWorktreeCardSshTargetLabel(store.getState(), ENV_HUB, TARGET)).toBe('old hub box')
+  })
+
+  it('returns "" when there is no connection id', () => {
+    const store = createTestStore()
+
+    expect(selectWorktreeCardSshTargetLabel(store.getState(), null, undefined)).toBe('')
+  })
+})
+
+describe('worktree card SSH status wiring', () => {
+  it('resolves a runtime-hosted worktree to its hub environment whose bucket answers the card', () => {
+    const store = createTestStore()
+    seedStore(store, {
+      worktreesByRepo: {
+        [TEST_REPO.id]: [
+          makeWorktree({
+            id: 'wt-hub',
+            repoId: TEST_REPO.id,
+            hostId: toRuntimeExecutionHostId(ENV_HUB)
+          })
+        ]
+      }
+    })
+    seedHubBucket(store)
+
+    const environmentId = getExplicitRuntimeEnvironmentIdForWorktree(store.getState(), 'wt-hub')
+    expect(environmentId).toBe(ENV_HUB)
+    expect(selectWorktreeCardSshStatus(store.getState(), environmentId, TARGET)).toBe('connected')
+    expect(selectWorktreeCardSshTargetLabel(store.getState(), environmentId, TARGET)).toBe(
+      'hub-box'
+    )
+  })
+
+  it('resolves a plain local worktree to no environment, keeping local-map reads', () => {
+    const store = createTestStore()
+    seedStore(store, {
+      worktreesByRepo: {
+        [TEST_REPO.id]: [makeWorktree({ id: 'wt-local', repoId: TEST_REPO.id })]
+      }
+    })
+
+    expect(getExplicitRuntimeEnvironmentIdForWorktree(store.getState(), 'wt-local')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-card-ssh-status.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-ssh-status.ts
@@ -1,0 +1,41 @@
+import type { SshConnectionStatus } from '../../../../shared/ssh-types'
+import { isRuntimeOwnedSshTargetId } from '../../../../shared/execution-host'
+import {
+  selectRuntimeAwareSshStatus,
+  selectRuntimeAwareSshTargetLabel,
+  type RuntimeAwareSshReadState
+} from '@/store/slices/runtime-environment-ssh'
+
+/**
+ * SSH status behind the card's "SSH disconnected" chip and blocking dialog.
+ * `environmentId` is the remote Orca server owning the target (null = this
+ * machine); null status means unknown/no target — show nothing.
+ */
+export function selectWorktreeCardSshStatus(
+  state: RuntimeAwareSshReadState,
+  environmentId: string | null,
+  connectionId: string | null | undefined
+): SshConnectionStatus | null {
+  // Why: runtime-owned SSH targets suppress their ssh:state-changed broadcasts, so don't show a false "disconnected" chip for them.
+  if (!connectionId || isRuntimeOwnedSshTargetId(connectionId)) {
+    return null
+  }
+  return selectRuntimeAwareSshStatus(state, environmentId, connectionId)
+}
+
+export function selectWorktreeCardSshTargetLabel(
+  state: RuntimeAwareSshReadState,
+  environmentId: string | null,
+  connectionId: string | null | undefined
+): string {
+  if (!connectionId) {
+    return ''
+  }
+  if (environmentId === null) {
+    // Why: keep the card's historical '' fallback for local targets so the dialog falls back to repo.displayName.
+    return state.sshTargetLabels.get(connectionId) ?? ''
+  }
+  const label = selectRuntimeAwareSshTargetLabel(state, environmentId, connectionId)
+  // Why: the runtime-aware fallback is the raw target id, meaningless in the dialog; '' defers to repo.displayName instead.
+  return label === connectionId ? '' : label
+}

--- a/src/renderer/src/store/slices/runtime-environment-ssh.ts
+++ b/src/renderer/src/store/slices/runtime-environment-ssh.ts
@@ -173,7 +173,7 @@ export const createRuntimeEnvironmentSshSlice: StateCreator<
     })
 })
 
-type RuntimeAwareSshReadState = Pick<
+export type RuntimeAwareSshReadState = Pick<
   AppState,
   | 'sshConnectionStates'
   | 'sshTargetLabels'


### PR DESCRIPTION
Partially addresses #9276 — this fixes the misleading "SSH disconnected" chip and the spurious blocking reconnect dialog on paired clients. The other half of the issue — terminals for hub SSH-hosted worktrees never opening — turned out to be a client-side bug of the same class and is fixed separately in #9987 (single-topic PRs).

## User-visible change

On a paired desktop client connected to a hub machine running the Orca runtime, every one of the hub's SSH-hosted worktrees showed a red "SSH disconnected" chip in the sidebar, and clicking one popped the blocking `SshDisconnectedDialog` — even while the hub's SSH connections were perfectly healthy. After this fix, the sidebar card reports the hub's actual SSH state (chip only on a real disconnect, correct target label in the dialog), and shows nothing while the owner's state is unknown instead of defaulting to a false "disconnected".

## Root cause

`WorktreeCard.tsx` still read the flat **local-machine** SSH maps directly (`s.sshConnectionStates.get(repo.connectionId) ?? 'disconnected'`, and `s.sshTargetLabels` for the dialog label). On a paired client, the hub's SSH connections never exist in those local maps — they are mirrored into the per-environment bucket `sshStateByEnvironment`, whose slice explicitly documents "Do NOT read this map directly from components — use the `selectRuntimeAwareSsh*` selectors". So the lookup was always `undefined` → `'disconnected'` for every hub SSH worktree. This was a missed migration to the runtime-aware SSH selectors that `TerminalPane.tsx` already uses; the card now mirrors TerminalPane's exact pattern (`getExplicitRuntimeEnvironmentIdForWorktree` + `selectRuntimeAwareSshStatus`/`selectRuntimeAwareSshTargetLabel`, including the paired-web-client force-local guard).

## Changes

- **New `worktree-card-ssh-status.ts`** (sidebar sibling module, following `worktree-card-pr-display.ts` naming): lifts the card's inline SSH status/label derivation into pure, unit-testable selectors that route between local maps (`environmentId === null`) and the owning environment's bucket. Local-worktree values are byte-for-byte identical to before (including the `'' → repo.displayName` label fallback).
- **`WorktreeCard.tsx`**: replaces the direct map reads with the new selectors; derives the owning environment id exactly like TerminalPane. The blocking-dialog gating (`isSshDisconnected` in the click handler and the dialog `open` prop) is fixed transitively since it derives from the corrected status.
- **`runtime-environment-ssh.ts`**: export-only change (`RuntimeAwareSshReadState` type) so the new module can share the selectors' state contract. No behavior change.

## Tests

Written red→green: every regression case below was run against today's `main` behavior first and observed failing, then observed passing with the fix.

**Component-level (`WorktreeCard.ssh-reconnect-prompt.test.tsx`, 3 new cases)** — drives the exact #9276 topology through the real card (runtime-hosted worktree + `repo.connectionId` + hydrated environment bucket + empty local maps):

- hub reports `connected` → no "SSH disconnected" chip, dialog receives `connected` + the hub's target label (fails on main)
- hub reports `disconnected` → chip still shows, with the hub's label (label fails on main)
- hub bucket not yet hydrated → no chip instead of a false disconnect (fails on main)

**Selector-level (`worktree-card-ssh-status.test.ts`, 13 cases)**:

- hub-owned target `connected` in `sshStateByEnvironment` but absent from local `sshConnectionStates` → reports `connected` + the hub's target label (fails on main: reported `disconnected` + empty label)
- unreachable environment / unhydrated bucket → `null` (show nothing), not a false `disconnected`
- a real hub-side disconnect still surfaces
- local SSH worktrees keep local-map semantics unchanged (status fallback `'disconnected'`, label fallback `''`)
- runtime-owned (`runtime-ssh-*`) targets and missing connection ids stay suppressed
- end-to-end wiring: a worktree with a `runtime:<env>` host id resolves to its environment via `getExplicitRuntimeEnvironmentIdForWorktree` and reads that bucket; a plain local worktree resolves to no environment

## AI code-review summary

Co-developed with Claude (Claude Code, Fable 5) under human direction and review: I scoped the fix, reviewed the diff, and verified the result live on my real hub + paired-client setup (screenshots above). On the AI side it was reviewed by the implementing agent plus an adversarial multi-model review pass (3 independent reviewer lenses, each finding verified by a separate refutation agent). The one confirmed finding — the end-to-end #9276 topology was not driven through the real component, so a wiring revert would have kept the suite green — was addressed by adding the component-level tests above (verified red against the reverted wiring):

- **Cross-platform (macOS/Linux/Windows)**: renderer-only store/selector logic; no paths, shells, key handling, or platform APIs touched.
- **SSH/remote/local compatibility**: the point of the fix. Local worktrees keep byte-for-byte identical behavior (unit-tested); hub-owned worktrees read the owning environment bucket; paired web clients keep forcing local maps (same guard as TerminalPane); runtime-owned ephemeral-VM targets stay suppressed; unknown owner state renders nothing rather than a false disconnect.
- **Agent/integration neutrality**: no agent-, integration-, or git-provider-specific behavior involved.
- **Performance (sidebar render hot path)**: no new IPC and no new subscriptions; the only added work per store update is the environment-id resolution (`getExplicitRuntimeEnvironmentIdForWorktree`, in-memory map/array lookups) plus two O(1) bucket lookups — the same per-selector cost TerminalPane already pays, and the added selectors return scalars so re-render behavior is unchanged. Bucket hydration continues to happen centrally in `useIpcEvents` on runtime (re)connect; cards trigger none.
- **UI quality**: chip/dialog visuals untouched; only when they appear changes. Dialog label now prefers the owning host's label and still falls back to `repo.displayName` (never a raw `ssh-<ts>-<rand>` id).
- **Security**: no new data flows; reads already-mirrored renderer store state only.

An additional OpenAI Codex native review of the final diff surfaced two P2 observations, both acknowledged and intentionally left out of this single-topic PR as follow-ups:

1. **Reconnect routing**: `SshDisconnectedDialog`'s Reconnect button calls the local `window.api.ssh.connect({ targetId })` path, which cannot reconnect a hub-owned target (it would need the runtime RPC path the terminal overlay uses). This is pre-existing behavior — before this fix that dead-end dialog was reachable constantly via the false chip; now it is reachable only on a genuine hub-side disconnect.
2. **Offline-hub visibility**: when the owning environment is unreachable, the card intentionally shows nothing (`null` = unknown, mirroring TerminalPane's semantics) rather than a possibly-false "SSH disconnected" chip; for an SSH repo whose worktree is hub-hosted this means no chip while the hub itself is offline. Whether that shape should get a "Server disconnected" fallback keyed off the worktree's `hostId` is left as a follow-up.

## Screenshots

Paired Windows desktop client, hub (macOS, Orca 1.4.147) with healthy SSH connections. `TL/Fusion` is a hub SSH-hosted repo; `TL/fusion-mcp` is hub-local.

| Before | After |
| --- | --- |
| <img src="https://gist.githubusercontent.com/VictorCano/294b4840586da90690fb1790157ebda3/raw/orca-9955-before.png" alt="Before: every TL/Fusion worktree shows a red SSH-disconnected icon despite the hub's SSH connection being healthy" width="260"> | <img src="https://gist.githubusercontent.com/VictorCano/294b4840586da90690fb1790157ebda3/raw/orca-9955-after.png" alt="After: TL/Fusion worktrees render normally with no false disconnected state" width="260"> |

## Notes

- Pre-existing failures on `main` (untouched — each reproduced on a clean `main` checkout in the same environment):
  - `pnpm lint` fails in `lint:switch-exhaustiveness` on `src/renderer/src/components/skills/skill-freshness-group.tsx:101` (switch not exhaustive). The files in this PR are lint-clean.
  - `pnpm test`: 3 failures in `src/main/startup/configure-process.test.ts` (GPU feature flags) and `src/main/agent-hooks/managed-hook-timeout.test.ts` (transport-budget timing), all outside the renderer; the other 33,783 tests pass, including the 16 new ones.
- `pnpm typecheck` and `pnpm build` pass.
- No version bumps.



## ELI5

Paired clients showed hub SSH worktrees as "SSH disconnected" even when the hub was fine. The sidebar now uses the correct local SSH state for remote-runtime worktrees so the chip and reconnect dialog stop lying.
