### PR TITLE
fix(sidebar): preserve workspace shortcut order when sidebar panel is hidden

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -5964,8 +5964,6 @@ const WorktreeList = React.memo(function WorktreeList({
   // Why layout effect: the Cmd/Ctrl+1–9 handler can fire right after commit; publishing after paint would leave the shortcut cache stale.
   useLayoutEffect(() => {
     setVisibleWorktreeIds(renderedWorktreeIds)
-    // Why: unmounting the list clears the rendered-order cache so shortcuts fall back to the live store snapshot.
-    return () => setVisibleWorktreeIds([])
   }, [renderedWorktreeIds])
 
   const handleCreateForRepo = useCallback(

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import {
   computeClearFilterActions,
   computeVisibleWorktreeIds,
@@ -689,11 +689,14 @@ describe('computeClearFilterActions', () => {
 })
 
 describe('getVisibleWorktreeIds caching', () => {
+  afterEach(() => {
+    // Why: guarantee cleanup after each test so failures do not leak cached state.
+    setVisibleWorktreeIds([])
+  })
+
   it('preserves cached rendered order when setVisibleWorktreeIds is populated', () => {
     setVisibleWorktreeIds(['wt-2', 'wt-1', 'wt-3'])
-    // Why: cached IDs override live store fallback to maintain rendered sidebar card order even when panel is hidden.
     expect(getVisibleWorktreeIds().slice(0, 3)).toEqual(['wt-2', 'wt-1', 'wt-3'])
-    setVisibleWorktreeIds([])
   })
 })
 

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest'
 import {
   computeClearFilterActions,
   computeVisibleWorktreeIds,
+  getVisibleWorktreeIds,
   isDefaultBranchWorkspace,
+  setVisibleWorktreeIds,
   sidebarHasActiveFilters
 } from './visible-worktrees'
 import type { Repo, TerminalTab, Worktree, WorktreeLineage } from '../../../../shared/types'
@@ -685,3 +687,13 @@ describe('computeClearFilterActions', () => {
     })
   })
 })
+
+describe('getVisibleWorktreeIds caching', () => {
+  it('preserves cached rendered order when setVisibleWorktreeIds is populated', () => {
+    setVisibleWorktreeIds(['wt-2', 'wt-1', 'wt-3'])
+    // Why: cached IDs override live store fallback to maintain rendered sidebar card order even when panel is hidden.
+    expect(getVisibleWorktreeIds().slice(0, 3)).toEqual(['wt-2', 'wt-1', 'wt-3'])
+    setVisibleWorktreeIds([])
+  })
+})
+

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { useAppStore } from '@/store'
 import {
   computeClearFilterActions,
   computeVisibleWorktreeIds,
@@ -689,14 +690,53 @@ describe('computeClearFilterActions', () => {
 })
 
 describe('getVisibleWorktreeIds caching', () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState(), true)
+  })
+
   afterEach(() => {
-    // Why: guarantee cleanup after each test so failures do not leak cached state.
     setVisibleWorktreeIds([])
+    useAppStore.setState(useAppStore.getInitialState(), true)
   })
 
   it('preserves cached rendered order when setVisibleWorktreeIds is populated', () => {
+    const worktrees = [makeWorktree('wt-1'), makeWorktree('wt-2'), makeWorktree('wt-3')]
+    useAppStore.setState({
+      repos: [makeRepo('repo1', 'Repo 1', '#000')],
+      worktreesByRepo: { repo1: worktrees },
+      sortBy: 'name'
+    })
     setVisibleWorktreeIds(['wt-2', 'wt-1', 'wt-3'])
-    expect(getVisibleWorktreeIds().slice(0, 3)).toEqual(['wt-2', 'wt-1', 'wt-3'])
+    expect(getVisibleWorktreeIds()).toEqual(['wt-2', 'wt-1', 'wt-3'])
+  })
+
+  it('drops stale cached IDs and appends newly visible worktrees in live order', () => {
+    const archived = makeWorktree('wt-3')
+    archived.isArchived = true
+    useAppStore.setState({
+      repos: [makeRepo('repo1', 'Repo 1', '#000')],
+      worktreesByRepo: {
+        repo1: [makeWorktree('wt-1'), makeWorktree('wt-2'), archived, makeWorktree('wt-4')]
+      },
+      sortBy: 'name'
+    })
+    setVisibleWorktreeIds(['wt-2', 'wt-3', 'deleted', 'wt-1'])
+
+    expect(getVisibleWorktreeIds()).toEqual(['wt-2', 'wt-1', 'wt-4'])
+  })
+
+  it('revalidates cached IDs against current visibility filters', () => {
+    useAppStore.setState({
+      repos: [makeRepo('repo1', 'Repo 1', '#000'), makeRepo('repo2', 'Repo 2', '#111')],
+      worktreesByRepo: {
+        repo1: [makeWorktree('wt-1', 'repo1')],
+        repo2: [makeWorktree('wt-2', 'repo2')]
+      },
+      sortBy: 'name'
+    })
+    setVisibleWorktreeIds(['wt-1', 'wt-2'])
+    useAppStore.setState({ filterRepoIds: ['repo2'] })
+
+    expect(getVisibleWorktreeIds()).toEqual(['wt-2'])
   })
 })
-

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -266,9 +266,17 @@ export function setVisibleWorktreeIds(ids: string[]): void {
  * only before WorktreeList's first render (e.g. app startup).
  */
 export function getVisibleWorktreeIds(): string[] {
-  // Prefer the cached IDs that mirror the rendered sidebar order.
+  // Why: reuse cached sidebar order while filtering out archived or deleted worktrees.
   if (_cachedVisibleIds.length > 0) {
-    return _cachedVisibleIds
+    const state = useAppStore.getState()
+    const allWorktrees = getAllWorktreesFromState(state).filter((w) => !w.isArchived)
+    const validIds = new Set(allWorktrees.map((w) => w.id))
+    const validCached = _cachedVisibleIds.filter((id) => validIds.has(id))
+    if (validCached.length > 0) {
+      const cachedSet = new Set(validCached)
+      const missing = allWorktrees.filter((w) => !cachedSet.has(w.id)).map((w) => w.id)
+      return [...validCached, ...missing]
+    }
   }
 
   // Fallback: live recomputation for the window before WorktreeList renders.

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -266,24 +266,8 @@ export function setVisibleWorktreeIds(ids: string[]): void {
  * only before WorktreeList's first render (e.g. app startup).
  */
 export function getVisibleWorktreeIds(): string[] {
-  // Why: reuse cached sidebar order while filtering out archived or deleted worktrees.
-  if (_cachedVisibleIds.length > 0) {
-    const state = useAppStore.getState()
-    const allWorktrees = getAllWorktreesFromState(state).filter((w) => !w.isArchived)
-    const validIds = new Set(allWorktrees.map((w) => w.id))
-    const validCached = _cachedVisibleIds.filter((id) => validIds.has(id))
-    if (validCached.length > 0) {
-      const cachedSet = new Set(validCached)
-      const missing = allWorktrees.filter((w) => !cachedSet.has(w.id)).map((w) => w.id)
-      return [...validCached, ...missing]
-    }
-  }
-
-  // Fallback: live recomputation for the window before WorktreeList renders.
   const state = useAppStore.getState()
   const allWorktrees = getAllWorktreesFromState(state).filter((w) => !w.isArchived)
-
-  // Hoist repoMap so it's built once and reused across all branches below.
   const repoMap = getRepoMapFromState(state)
 
   let sortedIds: string[]
@@ -308,7 +292,7 @@ export function getVisibleWorktreeIds(): string[] {
     sortedIds = sorted.map((w) => w.id)
   }
 
-  return computeVisibleWorktreeIds(state.worktreesByRepo, sortedIds, {
+  const liveVisibleIds = computeVisibleWorktreeIds(state.worktreesByRepo, sortedIds, {
     filterRepoIds: state.filterRepoIds,
     showSleepingWorkspaces: state.showSleepingWorkspaces,
     tabsByWorktree: state.tabsByWorktree,
@@ -327,4 +311,17 @@ export function getVisibleWorktreeIds(): string[] {
     defaultHostId: getSettingsFocusedExecutionHostId(state.settings),
     worktreeLineageById: state.worktreeLineageById
   })
+
+  // Why: preserve cached sidebar order for items matching active filters, appending new visible items.
+  if (_cachedVisibleIds.length > 0) {
+    const liveSet = new Set(liveVisibleIds)
+    const validCached = _cachedVisibleIds.filter((id) => liveSet.has(id))
+    if (validCached.length > 0) {
+      const cachedSet = new Set(validCached)
+      const missing = liveVisibleIds.filter((id) => !cachedSet.has(id))
+      return [...validCached, ...missing]
+    }
+  }
+
+  return liveVisibleIds
 }

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -244,7 +244,8 @@ function addVisibleLineageAncestors(
  * recomputes sort order from a live Zustand snapshot, the Cmd+1–9 shortcut
  * could target a different worktree than what's rendered at that sidebar
  * position. By caching the IDs that WorktreeList actually rendered, the
- * shortcut numbering always matches the sidebar card order.
+ * shortcut numbering preserves the last sidebar card order while the panel
+ * is hidden.
  */
 let _cachedVisibleIds: string[] = []
 
@@ -261,9 +262,9 @@ export function setVisibleWorktreeIds(ids: string[]): void {
  * state. Called by the App-level Cmd+1–9 handler (not a React hook — reads
  * store snapshot at call time).
  *
- * If WorktreeList has rendered at least once, returns the cached IDs so the
- * shortcut numbering matches the sidebar. Falls back to a live recomputation
- * only before WorktreeList's first render (e.g. app startup).
+ * If WorktreeList has rendered at least once, preserves the cached relative
+ * order for IDs that remain visible, then appends newly visible IDs in live
+ * sort order. Falls back to the live order before WorktreeList's first render.
  */
 export function getVisibleWorktreeIds(): string[] {
   const state = useAppStore.getState()


### PR DESCRIPTION
## Summary

Preserves workspace shortcut order when the left sidebar panel is hidden. Previously, unmounting `WorktreeList` cleared the rendered-order cache, so `Cmd/Ctrl + 1–9` fell back to a flat live-store sort that could differ from the sidebar's project grouping, pinned positions, and section hierarchy.

## Fix

1. Retain the last rendered worktree ID order when `WorktreeList` unmounts.
2. Revalidate cached IDs against the current visible worktrees, preserve the cached relative order for IDs that remain visible, and append newly visible worktrees in live sort order.
3. Add regression coverage for cached ordering, archived and deleted IDs, newly visible worktrees, filter changes, and test-state cleanup.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — left unchecked only because of a failure outside this PR's scope. `oxlint` passes for every file this PR changes; the full command reaches the type-aware exhaustiveness check and then fails on the pre-existing, unmodified `src/renderer/src/components/skills/skill-freshness-group.tsx:101`.
- [x] `pnpm typecheck`
- [x] `pnpm test` — the full suite passed on rerun. The first run had two environment-related timeouts while native/Electron dependencies were warming; both tests passed in isolation before the successful full rerun.
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions.
- [x] Targeted `visible-worktrees.test.ts` suite passed all 41 tests.
- [x] `git diff --check`

All commands above were run with Node 24 and pnpm 10.24.0.

## AI Review Report

Reviewed the branch diff against `main`, the rendered sidebar-order publication path, the workspace-index shortcut handler, and the live visibility computation.

The review found that the initial cache regression test did not seed the live Zustand store. Because the production code revalidates cached IDs against live visibility, that test would have returned an empty list. The test now seeds real worktrees and verifies:

- cached relative order is preserved;
- archived and deleted cached IDs are discarded;
- newly visible worktrees are appended in live sort order;
- active repository filters revalidate the cache.

Compatibility and risk review:

- **macOS, Linux, and Windows:** No platform-specific shortcut, label, path, shell, or Electron behavior was added. The change remains downstream of the existing centralized shortcut policy, which already resolves platform modifiers before sending the same workspace index through the existing IPC path.
- **Local, remote, and SSH worktrees:** The change operates only on host-neutral worktree IDs and existing renderer store state. It adds no local filesystem, process, credential, shell, or network assumptions.
- **CLI agents and integrations:** No agent protocol, agent-specific branch, integration API, or live-agent detection behavior changed. Existing agent activity only contributes to the shared live visibility set.
- **Git providers:** No Git command or provider-specific behavior changed; GitHub, GitLab, and other providers remain unaffected.
- **Performance:** The live visibility and sort snapshot is recomputed only when a workspace-index shortcut is pressed so stale or filtered IDs can be rejected. No render loop, polling path, or background work was added. No benchmark was run.
- **UI quality:** No layout, color, typography, component, light/dark theme, or shortcut-label output changed. The behavioral result is that hidden-sidebar navigation remains consistent with the last rendered sidebar order.

## Security Audit

No new user input, IPC channel, command execution, filesystem path handling, authentication, secrets, or dependencies were introduced. The changed code reads existing in-memory store state and rejects cached IDs that are no longer present in the current visible-ID set. No security follow-up was identified.

## Notes

- The remaining full-lint failure is outside this PR's changed files.
- No platform-specific behavior, migration, remote/SSH follow-up, agent/integration follow-up, or Git-provider follow-up is required.
- X (Twitter): [@kunsanglee](https://x.com/kunsanglee)




## ELI5

Hiding the left sidebar used to scramble Cmd/Ctrl+1–9 workspace order. Orca keeps the last rendered order so shortcuts still match the project grouping you saw when the panel was open.
