### PR TITLE
feat(settings): make automatic terminal creation optional

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1134,7 +1134,9 @@ function Terminal(): React.JSX.Element | null {
 
     // Why: give a newly activated worktree a focusable surface when nothing renders, without recreating one after the user closes the last visible tab.
     const { renderableTabCount } = reconcileWorktreeTabModel(activeWorktreeId)
-    if (!shouldAutoCreateInitialTerminal(renderableTabCount)) {
+    const automaticCreationEnabled =
+      useAppStore.getState().settings?.autoCreateTerminalOnWorkspaceActivation !== false
+    if (!shouldAutoCreateInitialTerminal(renderableTabCount, automaticCreationEnabled)) {
       return
     }
     // Why: tag this never-visited-worktree tab so its PTY spawn doesn't count as activity and reshuffle the sidebar (explicit New Tab still bumps).

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -24,6 +24,9 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
+import { FileText, Globe, TerminalSquare } from 'lucide-react'
+import { useShortcutKeyDetails } from '@/hooks/useShortcutLabel'
 import TabBar from './tab-bar/TabBar'
 import TerminalPane from './terminal-pane/TerminalPane'
 import {
@@ -267,6 +270,9 @@ function Terminal(): React.JSX.Element | null {
   const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
   const pendingStartupByTabId = useAppStore((s) => s.pendingStartupByTabId)
   const terminalParkingEnabled = useAppStore((s) => s.settings?.terminalHiddenViewParking !== false)
+  const autoCreateTerminalOnWorkspaceActivation = useAppStore(
+    (s) => s.settings?.autoCreateTerminalOnWorkspaceActivation !== false
+  )
   const terminalTitleSnapshotAuthorityEnabled = useAppStore((s) =>
     isMainTerminalSideEffectAuthorityForPty({
       settings: s.settings,
@@ -2112,6 +2118,17 @@ function Terminal(): React.JSX.Element | null {
         <>
           {/* Why: render only one surface model — legacy panes mounted alongside split-group panes race two React trees over one PTY/webview; gate on !anyMountedWorktreeHasLayout too so shutdown-from-focused doesn't respawn PTYs and re-light the sidebar dot. */}
           {/* Terminal panes container - hidden when editor tab active */}
+          {renderedActiveWorktreeId !== null &&
+            tabs.length === 0 &&
+            worktreeFiles.length === 0 &&
+            worktreeBrowserTabs.length === 0 &&
+            autoCreateTerminalOnWorkspaceActivation === false && (
+              <WorkspaceEmptyState
+                onNewTerminal={handleNewTab}
+                onNewBrowser={handleNewBrowserTab}
+                onNewMarkdown={handleNewFile}
+              />
+            )}
           <div
             className={`relative flex-1 min-h-0 overflow-hidden ${
               // Why: only hide the terminal when another tab type has content; else a stale activeTabType (e.g. 'editor' with no files after restore) blanks the screen.
@@ -2421,5 +2438,80 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
     </div>
   )
 })
+
+function WorkspaceEmptyState({
+  onNewTerminal,
+  onNewBrowser,
+  onNewMarkdown
+}: {
+  onNewTerminal: () => void
+  onNewBrowser: () => void
+  onNewMarkdown: () => void
+}): React.JSX.Element {
+  const newTerminalShortcut = useShortcutKeyDetails('tab.newTerminal')
+  const newBrowserShortcut = useShortcutKeyDetails('tab.newBrowser')
+  const newMarkdownShortcut = useShortcutKeyDetails('tab.newMarkdown')
+
+  return (
+    <div className="absolute inset-0 flex items-center justify-center">
+      <div className="flex w-[360px] flex-col items-center gap-1.5">
+        <Button
+          type="button"
+          variant="ghost"
+          className="grid h-8 w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2.5 rounded-md px-3 py-0 text-sm font-normal text-foreground hover:bg-muted/40 hover:text-foreground"
+          onClick={onNewTerminal}
+        >
+          <TerminalSquare className="size-3.5 opacity-90" />
+          <span className="truncate text-left leading-none">
+            {translate('auto.components.Terminal.workspaceEmptyState.newTerminal', 'New Terminal')}
+          </span>
+          {newTerminalShortcut.keys.length > 0 ? (
+            <ShortcutKeyCombo
+              keys={newTerminalShortcut.keys}
+              doubleTap={newTerminalShortcut.doubleTap}
+            />
+          ) : null}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          className="grid h-8 w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2.5 rounded-md px-3 py-0 text-sm font-normal text-foreground hover:bg-muted/40 hover:text-foreground"
+          onClick={onNewMarkdown}
+        >
+          <FileText className="size-3.5 opacity-90" />
+          <span className="truncate text-left leading-none">
+            {translate(
+              'auto.components.Terminal.workspaceEmptyState.newMarkdown',
+              'New Markdown Note'
+            )}
+          </span>
+          {newMarkdownShortcut.keys.length > 0 ? (
+            <ShortcutKeyCombo
+              keys={newMarkdownShortcut.keys}
+              doubleTap={newMarkdownShortcut.doubleTap}
+            />
+          ) : null}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          className="grid h-8 w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2.5 rounded-md px-3 py-0 text-sm font-normal text-foreground hover:bg-muted/40 hover:text-foreground"
+          onClick={onNewBrowser}
+        >
+          <Globe className="size-3.5 opacity-90" />
+          <span className="truncate text-left leading-none">
+            {translate('auto.components.Terminal.workspaceEmptyState.newBrowser', 'New Browser')}
+          </span>
+          {newBrowserShortcut.keys.length > 0 ? (
+            <ShortcutKeyCombo
+              keys={newBrowserShortcut.keys}
+              doubleTap={newBrowserShortcut.doubleTap}
+            />
+          ) : null}
+        </Button>
+      </div>
+    </div>
+  )
+}
 
 export default React.memo(Terminal)

--- a/src/renderer/src/components/settings/GeneralPane.test.ts
+++ b/src/renderer/src/components/settings/GeneralPane.test.ts
@@ -109,6 +109,14 @@ describe('GeneralPane search entries', () => {
     expect(matchesSettingsSearch('red underline', entries)).toBe(true)
   })
 
+  it('includes automatic terminal creation keywords', () => {
+    const entries = getGeneralPaneSearchEntries()
+
+    expect(matchesSettingsSearch('create terminal on workspace selection', entries)).toBe(true)
+    expect(matchesSettingsSearch('click', entries)).toBe(true)
+    expect(matchesSettingsSearch('worktree', entries)).toBe(true)
+  })
+
   it('omits the default project runtime setting when Windows runtimes are unsupported', () => {
     const entries = getGeneralPaneSearchEntries({ includeProjectRuntime: false })
 

--- a/src/renderer/src/components/settings/GeneralWorkspaceSettingsSection.test.tsx
+++ b/src/renderer/src/components/settings/GeneralWorkspaceSettingsSection.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment happy-dom
+
+import type React from 'react'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultSettings } from '../../../../shared/constants'
+import type { GlobalSettings } from '../../../../shared/types'
+import { GeneralWorkspaceSettingsSection } from './GeneralWorkspaceSettingsSection'
+
+vi.mock('./WorkspaceDirectorySetting', () => ({
+  WorkspaceDirectorySetting: () => null
+}))
+
+vi.mock('./OpenInMenuSetting', () => ({
+  OpenInMenuSetting: () => null
+}))
+
+vi.mock('./SearchableSetting', () => ({
+  SearchableSetting: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  container.remove()
+})
+
+function renderSection(
+  settings: GlobalSettings,
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+): void {
+  act(() => {
+    root.render(
+      <GeneralWorkspaceSettingsSection settings={settings} updateSettings={updateSettings} />
+    )
+  })
+}
+
+function getAutoCreateTerminalSwitch(): HTMLButtonElement {
+  const switchControl = container.querySelector<HTMLButtonElement>(
+    'button[role="switch"][aria-label="Create Terminal on Workspace Selection"]'
+  )
+  if (!switchControl) {
+    throw new Error('auto-create terminal switch was not rendered')
+  }
+  return switchControl
+}
+
+function clickAutoCreateTerminalSwitch(): void {
+  act(() => {
+    getAutoCreateTerminalSwitch().dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+describe('GeneralWorkspaceSettingsSection', () => {
+  it('treats a missing legacy preference as enabled and lets users disable it', () => {
+    const updateSettings = vi.fn()
+    renderSection(
+      {
+        ...getDefaultSettings('/tmp'),
+        autoCreateTerminalOnWorkspaceActivation: undefined
+      },
+      updateSettings
+    )
+
+    expect(getAutoCreateTerminalSwitch().getAttribute('aria-checked')).toBe('true')
+    clickAutoCreateTerminalSwitch()
+
+    expect(updateSettings).toHaveBeenCalledWith({
+      autoCreateTerminalOnWorkspaceActivation: false
+    })
+  })
+
+  it('lets users re-enable automatic terminal creation', () => {
+    const updateSettings = vi.fn()
+    renderSection(
+      {
+        ...getDefaultSettings('/tmp'),
+        autoCreateTerminalOnWorkspaceActivation: false
+      },
+      updateSettings
+    )
+
+    expect(getAutoCreateTerminalSwitch().getAttribute('aria-checked')).toBe('false')
+    clickAutoCreateTerminalSwitch()
+
+    expect(updateSettings).toHaveBeenCalledWith({
+      autoCreateTerminalOnWorkspaceActivation: true
+    })
+  })
+})

--- a/src/renderer/src/components/settings/GeneralWorkspaceSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralWorkspaceSettingsSection.tsx
@@ -55,6 +55,36 @@ export function GeneralWorkspaceSettingsSection({
         />
       </SearchableSetting>
 
+      <SearchableSetting
+        title={translate(
+          'auto.components.settings.GeneralWorkspaceSettingsSection.autoCreateTerminalOnWorkspaceActivation',
+          'Create Terminal on Workspace Selection'
+        )}
+        description={translate(
+          'auto.components.settings.GeneralWorkspaceSettingsSection.autoCreateTerminalOnWorkspaceActivationDescription',
+          'Automatically create the first terminal when selecting a workspace with no open tabs.'
+        )}
+        keywords={['terminal', 'automatic', 'select', 'click', 'workspace', 'worktree']}
+      >
+        <SettingsSwitchRow
+          label={translate(
+            'auto.components.settings.GeneralWorkspaceSettingsSection.autoCreateTerminalOnWorkspaceActivation',
+            'Create Terminal on Workspace Selection'
+          )}
+          description={translate(
+            'auto.components.settings.GeneralWorkspaceSettingsSection.autoCreateTerminalOnWorkspaceActivationDescription',
+            'Automatically create the first terminal when selecting a workspace with no open tabs.'
+          )}
+          checked={settings.autoCreateTerminalOnWorkspaceActivation !== false}
+          onChange={() =>
+            updateSettings({
+              autoCreateTerminalOnWorkspaceActivation:
+                settings.autoCreateTerminalOnWorkspaceActivation === false
+            })
+          }
+        />
+      </SearchableSetting>
+
       {/* Why: the "Don't ask again" toast in the delete-worktree dialog
           deep-links here, so the wrapper id must stay stable. Renaming it
           breaks that toast action even though this pane still renders fine. */}

--- a/src/renderer/src/components/settings/general-search.ts
+++ b/src/renderer/src/components/settings/general-search.ts
@@ -37,6 +37,35 @@ export const getGeneralWorkspaceSearchEntries = createLocalizedCatalog(() => [
   },
   {
     title: translate(
+      'auto.components.settings.general.search.autoCreateTerminalOnWorkspaceActivation',
+      'Create Terminal on Workspace Selection'
+    ),
+    description: translate(
+      'auto.components.settings.general.search.autoCreateTerminalOnWorkspaceActivationDescription',
+      'Automatically create the first terminal when selecting a workspace with no open tabs.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.autoCreateTerminalOnWorkspaceActivationTerminal',
+        'terminal'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.autoCreateTerminalOnWorkspaceActivationAutomatic',
+        'automatic'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.autoCreateTerminalOnWorkspaceActivationSelect',
+        'select'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.general.search.autoCreateTerminalOnWorkspaceActivationClick',
+        'click'
+      ),
+      ...translateSearchKeyword('auto.components.settings.general.search.df10666259', 'worktree')
+    ]
+  },
+  {
+    title: translate(
       'auto.components.settings.general.search.913242091d',
       'Ask Before Deleting Workspaces'
     ),

--- a/src/renderer/src/components/tab-group/TabGroupEmptyState.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupEmptyState.tsx
@@ -1,0 +1,77 @@
+import { memo } from 'react'
+import { FileText, Globe, TerminalSquare } from 'lucide-react'
+import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
+import { Button } from '@/components/ui/button'
+import { useShortcutKeyDetails } from '@/hooks/useShortcutLabel'
+import { translate } from '@/i18n/i18n'
+
+const ACTION_CLASS_NAME =
+  'grid h-8 w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2.5 rounded-md px-3 py-0 text-sm font-normal text-foreground hover:bg-muted/40 hover:text-foreground'
+
+type TabGroupEmptyStateProps = {
+  onNewTerminal: () => void
+  onNewMarkdown: () => void
+  onNewBrowser: () => void
+}
+
+export const TabGroupEmptyState = memo(function TabGroupEmptyState({
+  onNewTerminal,
+  onNewMarkdown,
+  onNewBrowser
+}: TabGroupEmptyStateProps): React.JSX.Element {
+  const newTerminalShortcut = useShortcutKeyDetails('tab.newTerminal')
+  const newBrowserShortcut = useShortcutKeyDetails('tab.newBrowser')
+  const newMarkdownShortcut = useShortcutKeyDetails('tab.newMarkdown')
+
+  return (
+    <div className="absolute inset-0 flex items-center justify-center">
+      <div className="flex w-[360px] flex-col items-center gap-1.5">
+        <Button type="button" variant="ghost" className={ACTION_CLASS_NAME} onClick={onNewTerminal}>
+          <TerminalSquare className="size-3.5 opacity-90" />
+          <span className="truncate text-left leading-none">
+            {translate(
+              'auto.components.tab.group.TabGroupPanel.emptyState.newTerminal',
+              'New Terminal'
+            )}
+          </span>
+          {newTerminalShortcut.keys.length > 0 ? (
+            <ShortcutKeyCombo
+              keys={newTerminalShortcut.keys}
+              doubleTap={newTerminalShortcut.doubleTap}
+            />
+          ) : null}
+        </Button>
+        <Button type="button" variant="ghost" className={ACTION_CLASS_NAME} onClick={onNewMarkdown}>
+          <FileText className="size-3.5 opacity-90" />
+          <span className="truncate text-left leading-none">
+            {translate(
+              'auto.components.tab.group.TabGroupPanel.emptyState.newMarkdown',
+              'New Markdown Note'
+            )}
+          </span>
+          {newMarkdownShortcut.keys.length > 0 ? (
+            <ShortcutKeyCombo
+              keys={newMarkdownShortcut.keys}
+              doubleTap={newMarkdownShortcut.doubleTap}
+            />
+          ) : null}
+        </Button>
+        <Button type="button" variant="ghost" className={ACTION_CLASS_NAME} onClick={onNewBrowser}>
+          <Globe className="size-3.5 opacity-90" />
+          <span className="truncate text-left leading-none">
+            {translate(
+              'auto.components.tab.group.TabGroupPanel.emptyState.newBrowser',
+              'New Browser'
+            )}
+          </span>
+          {newBrowserShortcut.keys.length > 0 ? (
+            <ShortcutKeyCombo
+              keys={newBrowserShortcut.keys}
+              doubleTap={newBrowserShortcut.doubleTap}
+            />
+          ) : null}
+        </Button>
+      </div>
+    </div>
+  )
+})

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -1,7 +1,7 @@
-import { Suspense, useMemo } from 'react'
+import { memo, Suspense, useMemo } from 'react'
 import { lazyWithRetry as lazy } from '@/lib/lazy-with-retry'
 import { useDroppable } from '@dnd-kit/core'
-import { Ellipsis, X } from 'lucide-react'
+import { Ellipsis, FileText, Globe, TerminalSquare, X } from 'lucide-react'
 import { useAppStore } from '../../store'
 import {
   DropdownMenu,
@@ -10,6 +10,9 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { Button } from '@/components/ui/button'
+import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
+import { useShortcutKeyDetails } from '@/hooks/useShortcutLabel'
 import TabBar from '../tab-bar/TabBar'
 
 import { TabBarQuickCommandsButton } from '../tab-bar/TabBarQuickCommandsButton'
@@ -21,6 +24,86 @@ import { tabGroupBodyAnchorName } from './tab-group-body-anchor'
 import { translate } from '@/i18n/i18n'
 
 const EditorPanel = lazy(() => import('../editor/EditorPanel'))
+
+const TabGroupEmptyState = memo(function TabGroupEmptyState({
+  worktreeId,
+  groupId
+}: {
+  worktreeId: string
+  groupId: string
+}): React.JSX.Element {
+  const newTerminalShortcut = useShortcutKeyDetails('tab.newTerminal')
+  const newBrowserShortcut = useShortcutKeyDetails('tab.newBrowser')
+  const newMarkdownShortcut = useShortcutKeyDetails('tab.newMarkdown')
+  const commands = useTabGroupWorkspaceModel({ groupId, worktreeId }).commands
+
+  return (
+    <div className="absolute inset-0 flex items-center justify-center">
+      <div className="flex w-[360px] flex-col items-center gap-1.5">
+        <Button
+          type="button"
+          variant="ghost"
+          className="grid h-8 w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2.5 rounded-md px-3 py-0 text-sm font-normal text-foreground hover:bg-muted/40 hover:text-foreground"
+          onClick={commands.newTerminalTab}
+        >
+          <TerminalSquare className="size-3.5 opacity-90" />
+          <span className="truncate text-left leading-none">
+            {translate(
+              'auto.components.tab.group.TabGroupPanel.emptyState.newTerminal',
+              'New Terminal'
+            )}
+          </span>
+          {newTerminalShortcut.keys.length > 0 ? (
+            <ShortcutKeyCombo
+              keys={newTerminalShortcut.keys}
+              doubleTap={newTerminalShortcut.doubleTap}
+            />
+          ) : null}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          className="grid h-8 w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2.5 rounded-md px-3 py-0 text-sm font-normal text-foreground hover:bg-muted/40 hover:text-foreground"
+          onClick={commands.newFileTab}
+        >
+          <FileText className="size-3.5 opacity-90" />
+          <span className="truncate text-left leading-none">
+            {translate(
+              'auto.components.tab.group.TabGroupPanel.emptyState.newMarkdown',
+              'New Markdown Note'
+            )}
+          </span>
+          {newMarkdownShortcut.keys.length > 0 ? (
+            <ShortcutKeyCombo
+              keys={newMarkdownShortcut.keys}
+              doubleTap={newMarkdownShortcut.doubleTap}
+            />
+          ) : null}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          className="grid h-8 w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2.5 rounded-md px-3 py-0 text-sm font-normal text-foreground hover:bg-muted/40 hover:text-foreground"
+          onClick={commands.newBrowserTab}
+        >
+          <Globe className="size-3.5 opacity-90" />
+          <span className="truncate text-left leading-none">
+            {translate(
+              'auto.components.tab.group.TabGroupPanel.emptyState.newBrowser',
+              'New Browser'
+            )}
+          </span>
+          {newBrowserShortcut.keys.length > 0 ? (
+            <ShortcutKeyCombo
+              keys={newBrowserShortcut.keys}
+              doubleTap={newBrowserShortcut.doubleTap}
+            />
+          ) : null}
+        </Button>
+      </div>
+    </div>
+  )
+})
 
 export default function TabGroupPanel({
   groupId,
@@ -55,6 +138,9 @@ export default function TabGroupPanel({
 }): React.JSX.Element {
   const rightSidebarOpen = useAppStore((state) => state.rightSidebarOpen)
   const sidebarOpen = useAppStore((state) => state.sidebarOpen)
+  const autoCreateTerminalOnWorkspaceActivation = useAppStore(
+    (state) => state.settings?.autoCreateTerminalOnWorkspaceActivation !== false
+  )
 
   const model = useTabGroupWorkspaceModel({ groupId, worktreeId })
   const { activeTab, browserItems, commands, editorItems, tabBarOrder, terminalTabs } = model
@@ -324,6 +410,13 @@ export default function TabGroupPanel({
           )}
 
         {/* Why: terminal/browser/simulator panes render at the worktree level (overlay layers); per-group rendering remounted xterm/webview/simulator on split moves. */}
+        {activeTab === null &&
+          terminalTabs.length === 0 &&
+          editorItems.length === 0 &&
+          browserItems.length === 0 &&
+          !autoCreateTerminalOnWorkspaceActivation && (
+            <TabGroupEmptyState worktreeId={worktreeId} groupId={groupId} />
+          )}
       </div>
     </div>
   )

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -1,7 +1,7 @@
-import { memo, Suspense, useMemo } from 'react'
+import { Suspense, useMemo } from 'react'
 import { lazyWithRetry as lazy } from '@/lib/lazy-with-retry'
 import { useDroppable } from '@dnd-kit/core'
-import { Ellipsis, FileText, Globe, TerminalSquare, X } from 'lucide-react'
+import { Ellipsis, X } from 'lucide-react'
 import { useAppStore } from '../../store'
 import {
   DropdownMenu,
@@ -10,9 +10,6 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { Button } from '@/components/ui/button'
-import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
-import { useShortcutKeyDetails } from '@/hooks/useShortcutLabel'
 import TabBar from '../tab-bar/TabBar'
 
 import { TabBarQuickCommandsButton } from '../tab-bar/TabBarQuickCommandsButton'
@@ -22,88 +19,9 @@ import { resolveGroupTabFromVisibleId } from './tab-group-visible-id'
 import { getTabPaneBodyDroppableId, type HoveredTabInsertion } from './useTabDragSplit'
 import { tabGroupBodyAnchorName } from './tab-group-body-anchor'
 import { translate } from '@/i18n/i18n'
+import { TabGroupEmptyState } from './TabGroupEmptyState'
 
 const EditorPanel = lazy(() => import('../editor/EditorPanel'))
-
-const TabGroupEmptyState = memo(function TabGroupEmptyState({
-  worktreeId,
-  groupId
-}: {
-  worktreeId: string
-  groupId: string
-}): React.JSX.Element {
-  const newTerminalShortcut = useShortcutKeyDetails('tab.newTerminal')
-  const newBrowserShortcut = useShortcutKeyDetails('tab.newBrowser')
-  const newMarkdownShortcut = useShortcutKeyDetails('tab.newMarkdown')
-  const commands = useTabGroupWorkspaceModel({ groupId, worktreeId }).commands
-
-  return (
-    <div className="absolute inset-0 flex items-center justify-center">
-      <div className="flex w-[360px] flex-col items-center gap-1.5">
-        <Button
-          type="button"
-          variant="ghost"
-          className="grid h-8 w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2.5 rounded-md px-3 py-0 text-sm font-normal text-foreground hover:bg-muted/40 hover:text-foreground"
-          onClick={commands.newTerminalTab}
-        >
-          <TerminalSquare className="size-3.5 opacity-90" />
-          <span className="truncate text-left leading-none">
-            {translate(
-              'auto.components.tab.group.TabGroupPanel.emptyState.newTerminal',
-              'New Terminal'
-            )}
-          </span>
-          {newTerminalShortcut.keys.length > 0 ? (
-            <ShortcutKeyCombo
-              keys={newTerminalShortcut.keys}
-              doubleTap={newTerminalShortcut.doubleTap}
-            />
-          ) : null}
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          className="grid h-8 w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2.5 rounded-md px-3 py-0 text-sm font-normal text-foreground hover:bg-muted/40 hover:text-foreground"
-          onClick={commands.newFileTab}
-        >
-          <FileText className="size-3.5 opacity-90" />
-          <span className="truncate text-left leading-none">
-            {translate(
-              'auto.components.tab.group.TabGroupPanel.emptyState.newMarkdown',
-              'New Markdown Note'
-            )}
-          </span>
-          {newMarkdownShortcut.keys.length > 0 ? (
-            <ShortcutKeyCombo
-              keys={newMarkdownShortcut.keys}
-              doubleTap={newMarkdownShortcut.doubleTap}
-            />
-          ) : null}
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          className="grid h-8 w-full grid-cols-[1rem_minmax(0,1fr)_auto] items-center gap-2.5 rounded-md px-3 py-0 text-sm font-normal text-foreground hover:bg-muted/40 hover:text-foreground"
-          onClick={commands.newBrowserTab}
-        >
-          <Globe className="size-3.5 opacity-90" />
-          <span className="truncate text-left leading-none">
-            {translate(
-              'auto.components.tab.group.TabGroupPanel.emptyState.newBrowser',
-              'New Browser'
-            )}
-          </span>
-          {newBrowserShortcut.keys.length > 0 ? (
-            <ShortcutKeyCombo
-              keys={newBrowserShortcut.keys}
-              doubleTap={newBrowserShortcut.doubleTap}
-            />
-          ) : null}
-        </Button>
-      </div>
-    </div>
-  )
-})
 
 export default function TabGroupPanel({
   groupId,
@@ -415,7 +333,11 @@ export default function TabGroupPanel({
           editorItems.length === 0 &&
           browserItems.length === 0 &&
           !autoCreateTerminalOnWorkspaceActivation && (
-            <TabGroupEmptyState worktreeId={worktreeId} groupId={groupId} />
+            <TabGroupEmptyState
+              onNewTerminal={commands.newTerminalTab}
+              onNewMarkdown={commands.newFileTab}
+              onNewBrowser={commands.newBrowserTab}
+            />
           )}
       </div>
     </div>

--- a/src/renderer/src/components/terminal/initial-terminal.test.ts
+++ b/src/renderer/src/components/terminal/initial-terminal.test.ts
@@ -10,4 +10,8 @@ describe('shouldAutoCreateInitialTerminal', () => {
     expect(shouldAutoCreateInitialTerminal(1)).toBe(false)
     expect(shouldAutoCreateInitialTerminal(2)).toBe(false)
   })
+
+  it('leaves an empty workspace terminal-free when automatic creation is disabled', () => {
+    expect(shouldAutoCreateInitialTerminal(0, false)).toBe(false)
+  })
 })

--- a/src/renderer/src/components/terminal/initial-terminal.ts
+++ b/src/renderer/src/components/terminal/initial-terminal.ts
@@ -1,7 +1,8 @@
-export function shouldAutoCreateInitialTerminal(renderableTabCount: number): boolean {
-  // Why: the tab-group model is now the source of truth for visible worktree
-  // content. If it has no renderable tabs, the workspace must synthesize a
-  // terminal instead of deferring to legacy editor/browser restore state,
-  // which can otherwise leave an empty split group with nothing mounted.
-  return renderableTabCount === 0
+export function shouldAutoCreateInitialTerminal(
+  renderableTabCount: number,
+  automaticCreationEnabled = true
+): boolean {
+  // Why: the tab-group model is the source of truth; the preference only gates
+  // the empty-workspace fallback, never explicit terminal creation.
+  return automaticCreationEnabled && renderableTabCount === 0
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1842,7 +1842,12 @@
         "61ed600d29": "\"{{value0}}\" has unsaved changes. Do you want to save before closing?",
         "cdc9ac4b2d": "editor",
         "e57db40c11": "Could not build launch command for {{value0}}.",
-        "5b2c1a9e44": "No agent CLI detected — install one or pick a default agent in Settings."
+        "5b2c1a9e44": "No agent CLI detected — install one or pick a default agent in Settings.",
+        "workspaceEmptyState": {
+          "newTerminal": "New Terminal",
+          "newMarkdown": "New Markdown Note",
+          "newBrowser": "New Browser"
+        }
       },
       "TerminalSearch": {
         "db234b7519": "Close",
@@ -2777,7 +2782,12 @@
             "1ff1c77616": "browser",
             "586d2ac445": "terminal",
             "addSplitPane": "Add split pane",
-            "closePaneColumn": "Close split pane"
+            "closePaneColumn": "Close split pane",
+            "emptyState": {
+              "newTerminal": "New Terminal",
+              "newMarkdown": "New Markdown Note",
+              "newBrowser": "New Browser"
+            }
           },
           "AiVaultSessionDropLayer": {
             "dropOntoTerminalPane": "Drop onto a terminal pane to resume this session.",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5701,7 +5701,9 @@
           "5567191a6e": "Browse",
           "0e9fc0eadc": "Workspace Directory",
           "e2955d9ccb": "Configure where new workspaces are created.",
-          "7511097c5d": "Workspace"
+          "7511097c5d": "Workspace",
+          "autoCreateTerminalOnWorkspaceActivation": "Create Terminal on Workspace Selection",
+          "autoCreateTerminalOnWorkspaceActivationDescription": "Automatically create the first terminal when selecting a workspace with no open tabs."
         },
         "GhosttyImportModal": {
           "9d3e56ca36": "Apply Changes",
@@ -7958,7 +7960,13 @@
             "e61157e926": "Editor Word Wrap",
             "005be5c699": "Wrap long lines in file editors instead of requiring horizontal scrolling.",
             "editorFontFamily": "Editor Font Family",
-            "editorFontFamilyDesc": "Font used by file editors and diff views. Leave empty to follow the terminal font."
+            "editorFontFamilyDesc": "Font used by file editors and diff views. Leave empty to follow the terminal font.",
+            "autoCreateTerminalOnWorkspaceActivation": "Create Terminal on Workspace Selection",
+            "autoCreateTerminalOnWorkspaceActivationDescription": "Automatically create the first terminal when selecting a workspace with no open tabs.",
+            "autoCreateTerminalOnWorkspaceActivationTerminal": "terminal",
+            "autoCreateTerminalOnWorkspaceActivationAutomatic": "automatic",
+            "autoCreateTerminalOnWorkspaceActivationSelect": "select",
+            "autoCreateTerminalOnWorkspaceActivationClick": "click"
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1819,7 +1819,12 @@
         "61ed600d29": "\"{{value0}}\" tiene cambios no guardados. ¿Quieres guardar antes de cerrar?",
         "cdc9ac4b2d": "editor",
         "e57db40c11": "No se pudo generar el comando de inicio para {{value0}}.",
-        "5b2c1a9e44": "No se detectó ninguna CLI de agente; instala una o elige un agente predeterminado en Ajustes."
+        "5b2c1a9e44": "No se detectó ninguna CLI de agente; instala una o elige un agente predeterminado en Ajustes.",
+        "workspaceEmptyState": {
+          "newTerminal": "Nueva terminal",
+          "newMarkdown": "Nueva nota Markdown",
+          "newBrowser": "Nuevo navegador"
+        }
       },
       "TerminalSearch": {
         "db234b7519": "Cerrar",
@@ -2754,7 +2759,12 @@
             "1ff1c77616": "navegador",
             "586d2ac445": "terminal",
             "addSplitPane": "Agregar panel dividido",
-            "closePaneColumn": "Cerrar panel dividido"
+            "closePaneColumn": "Cerrar panel dividido",
+            "emptyState": {
+              "newTerminal": "Nueva terminal",
+              "newMarkdown": "Nueva nota Markdown",
+              "newBrowser": "Nuevo navegador"
+            }
           },
           "AiVaultSessionDropLayer": {
             "dropOntoTerminalPane": "Suelta sobre un panel de terminal para reanudar esta sesión.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5678,7 +5678,9 @@
           "5567191a6e": "Examinar",
           "0e9fc0eadc": "Directorio de espacio de trabajo",
           "e2955d9ccb": "Configura dónde se crean nuevos espacios de trabajo.",
-          "7511097c5d": "Espacio de trabajo"
+          "7511097c5d": "Espacio de trabajo",
+          "autoCreateTerminalOnWorkspaceActivation": "Crear terminal al seleccionar un espacio de trabajo",
+          "autoCreateTerminalOnWorkspaceActivationDescription": "Crea automáticamente el primer terminal al seleccionar un espacio de trabajo sin pestañas abiertas."
         },
         "GhosttyImportModal": {
           "9d3e56ca36": "Aplicar cambios",
@@ -7898,7 +7900,13 @@
             "e61157e926": "Ajuste de línea en el editor",
             "005be5c699": "Ajusta las líneas largas en editores de archivos en lugar de requerir desplazamiento horizontal.",
             "editorFontFamily": "Editor Font Family",
-            "editorFontFamilyDesc": "Font used by file editors and diff views. Leave empty to follow the terminal font."
+            "editorFontFamilyDesc": "Font used by file editors and diff views. Leave empty to follow the terminal font.",
+            "autoCreateTerminalOnWorkspaceActivation": "Crear terminal al seleccionar un espacio de trabajo",
+            "autoCreateTerminalOnWorkspaceActivationDescription": "Crea automáticamente el primer terminal al seleccionar un espacio de trabajo sin pestañas abiertas.",
+            "autoCreateTerminalOnWorkspaceActivationTerminal": "terminal",
+            "autoCreateTerminalOnWorkspaceActivationAutomatic": "automático",
+            "autoCreateTerminalOnWorkspaceActivationSelect": "seleccionar",
+            "autoCreateTerminalOnWorkspaceActivationClick": "clic"
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5663,7 +5663,9 @@
           "5567191a6e": "ブラウズ",
           "0e9fc0eadc": "ワークスペースディレクトリ",
           "e2955d9ccb": "新規ワークスペースを作成する場所を構成します。",
-          "7511097c5d": "ワークスペース"
+          "7511097c5d": "ワークスペース",
+          "autoCreateTerminalOnWorkspaceActivation": "ワークスペース選択時にターミナルを作成",
+          "autoCreateTerminalOnWorkspaceActivationDescription": "開いているタブがないワークスペースを選択したときに、最初のターミナルを自動的に作成します。"
         },
         "GhosttyImportModal": {
           "9d3e56ca36": "変更を適用する",
@@ -7920,7 +7922,13 @@
             "e61157e926": "エディターのワードラップ",
             "005be5c699": "水平スクロールを使わずに、ファイルエディターで長い行を折り返します。",
             "editorFontFamily": "Editor Font Family",
-            "editorFontFamilyDesc": "Font used by file editors and diff views. Leave empty to follow the terminal font."
+            "editorFontFamilyDesc": "Font used by file editors and diff views. Leave empty to follow the terminal font.",
+            "autoCreateTerminalOnWorkspaceActivation": "ワークスペース選択時にターミナルを作成",
+            "autoCreateTerminalOnWorkspaceActivationDescription": "開いているタブがないワークスペースを選択したときに、最初のターミナルを自動的に作成します。",
+            "autoCreateTerminalOnWorkspaceActivationTerminal": "ターミナル",
+            "autoCreateTerminalOnWorkspaceActivationAutomatic": "自動",
+            "autoCreateTerminalOnWorkspaceActivationSelect": "選択",
+            "autoCreateTerminalOnWorkspaceActivationClick": "クリック"
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1819,7 +1819,12 @@
         "61ed600d29": "「{{value0}}」には未保存の変更があります。閉じる前に保存しますか?",
         "cdc9ac4b2d": "エディタ",
         "e57db40c11": "{{value0}} の起動コマンドを作成できませんでした。",
-        "5b2c1a9e44": "エージェント CLI が検出されません。インストールするか、設定で既定のエージェントを選択してください。"
+        "5b2c1a9e44": "エージェント CLI が検出されません。インストールするか、設定で既定のエージェントを選択してください。",
+        "workspaceEmptyState": {
+          "newTerminal": "新規ターミナル",
+          "newMarkdown": "新規 Markdown ノート",
+          "newBrowser": "新規ブラウザ"
+        }
       },
       "TerminalSearch": {
         "db234b7519": "閉じる",
@@ -2754,7 +2759,12 @@
             "1ff1c77616": "ブラウザ",
             "586d2ac445": "ターミナル",
             "addSplitPane": "分割ペインを追加",
-            "closePaneColumn": "分割ペインを閉じる"
+            "closePaneColumn": "分割ペインを閉じる",
+            "emptyState": {
+              "newTerminal": "新規ターミナル",
+              "newMarkdown": "新規 Markdown ノート",
+              "newBrowser": "新規ブラウザ"
+            }
           },
           "AiVaultSessionDropLayer": {
             "dropOntoTerminalPane": "このセッションを再開するにはターミナルペインにドロップしてください。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5663,7 +5663,9 @@
           "5567191a6e": "찾아보기",
           "0e9fc0eadc": "워크스페이스 디렉토리",
           "e2955d9ccb": "새 워크스페이스가 생성되는 위치를 구성합니다.",
-          "7511097c5d": "워크스페이스"
+          "7511097c5d": "워크스페이스",
+          "autoCreateTerminalOnWorkspaceActivation": "워크스페이스 선택 시 터미널 생성",
+          "autoCreateTerminalOnWorkspaceActivationDescription": "열린 탭이 없는 워크스페이스를 선택하면 첫 번째 터미널을 자동으로 생성합니다."
         },
         "GhosttyImportModal": {
           "9d3e56ca36": "변경 사항 적용",
@@ -7883,7 +7885,13 @@
             "e61157e926": "편집기 자동 줄 바꿈",
             "005be5c699": "가로 스크롤 대신 파일 편집기에서 긴 줄을 자동으로 줄 바꿈합니다.",
             "editorFontFamily": "Editor Font Family",
-            "editorFontFamilyDesc": "Font used by file editors and diff views. Leave empty to follow the terminal font."
+            "editorFontFamilyDesc": "Font used by file editors and diff views. Leave empty to follow the terminal font.",
+            "autoCreateTerminalOnWorkspaceActivation": "워크스페이스 선택 시 터미널 생성",
+            "autoCreateTerminalOnWorkspaceActivationDescription": "열린 탭이 없는 워크스페이스를 선택하면 첫 번째 터미널을 자동으로 생성합니다.",
+            "autoCreateTerminalOnWorkspaceActivationTerminal": "터미널",
+            "autoCreateTerminalOnWorkspaceActivationAutomatic": "자동",
+            "autoCreateTerminalOnWorkspaceActivationSelect": "선택",
+            "autoCreateTerminalOnWorkspaceActivationClick": "클릭"
           }
         },
         "git": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1819,7 +1819,12 @@
         "61ed600d29": "'{{value0}}'에 저장되지 않은 변경사항이 있습니다. 닫기 전에 저장하시겠습니까?",
         "cdc9ac4b2d": "편집기",
         "e57db40c11": "{{value0}} 실행 명령을 만들 수 없습니다.",
-        "5b2c1a9e44": "agent CLI를 찾지 못했습니다. 하나를 설치하거나 설정에서 기본 agent를 선택하세요."
+        "5b2c1a9e44": "agent CLI를 찾지 못했습니다. 하나를 설치하거나 설정에서 기본 agent를 선택하세요.",
+        "workspaceEmptyState": {
+          "newTerminal": "새 터미널",
+          "newMarkdown": "새 Markdown 노트",
+          "newBrowser": "새 브라우저"
+        }
       },
       "TerminalSearch": {
         "db234b7519": "닫기",
@@ -2754,7 +2759,12 @@
             "1ff1c77616": "브라우저",
             "586d2ac445": "터미널",
             "addSplitPane": "분할 창 추가",
-            "closePaneColumn": "분할 창 닫기"
+            "closePaneColumn": "분할 창 닫기",
+            "emptyState": {
+              "newTerminal": "새 터미널",
+              "newMarkdown": "새 Markdown 노트",
+              "newBrowser": "새 브라우저"
+            }
           },
           "AiVaultSessionDropLayer": {
             "dropOntoTerminalPane": "이 세션을 재개하려면 terminal 창에 놓으세요.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1819,7 +1819,12 @@
         "61ed600d29": "“{{value0}}”有未保存的更改。您想在关闭前保存吗？",
         "cdc9ac4b2d": "编辑",
         "e57db40c11": "无法为 {{value0}} 构建启动命令。",
-        "5b2c1a9e44": "未检测到智能体 CLI，请安装一个，或在设置中选择默认智能体。"
+        "5b2c1a9e44": "未检测到智能体 CLI，请安装一个，或在设置中选择默认智能体。",
+        "workspaceEmptyState": {
+          "newTerminal": "新建终端",
+          "newMarkdown": "新建 Markdown 笔记",
+          "newBrowser": "新建浏览器"
+        }
       },
       "TerminalSearch": {
         "db234b7519": "关闭",
@@ -2754,7 +2759,12 @@
             "1ff1c77616": "浏览器",
             "586d2ac445": "终端",
             "addSplitPane": "添加拆分窗格",
-            "closePaneColumn": "关闭拆分窗格"
+            "closePaneColumn": "关闭拆分窗格",
+            "emptyState": {
+              "newTerminal": "新建终端",
+              "newMarkdown": "新建 Markdown 笔记",
+              "newBrowser": "新建浏览器"
+            }
           },
           "AiVaultSessionDropLayer": {
             "dropOntoTerminalPane": "拖放到终端面板以恢复此会话。",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5663,7 +5663,9 @@
           "5567191a6e": "浏览",
           "0e9fc0eadc": "工作区目录",
           "e2955d9ccb": "配置创建新工作区的位置。",
-          "7511097c5d": "工作区"
+          "7511097c5d": "工作区",
+          "autoCreateTerminalOnWorkspaceActivation": "选择工作区时创建终端",
+          "autoCreateTerminalOnWorkspaceActivationDescription": "选择没有打开标签页的工作区时，自动创建第一个终端。"
         },
         "GhosttyImportModal": {
           "9d3e56ca36": "应用更改",
@@ -7883,7 +7885,13 @@
             "e61157e926": "编辑器自动换行",
             "005be5c699": "在文件编辑器中自动换行长行，而无需水平滚动。",
             "editorFontFamily": "Editor Font Family",
-            "editorFontFamilyDesc": "Font used by file editors and diff views. Leave empty to follow the terminal font."
+            "editorFontFamilyDesc": "Font used by file editors and diff views. Leave empty to follow the terminal font.",
+            "autoCreateTerminalOnWorkspaceActivation": "选择工作区时创建终端",
+            "autoCreateTerminalOnWorkspaceActivationDescription": "选择没有打开标签页的工作区时，自动创建第一个终端。",
+            "autoCreateTerminalOnWorkspaceActivationTerminal": "终端",
+            "autoCreateTerminalOnWorkspaceActivationAutomatic": "自动",
+            "autoCreateTerminalOnWorkspaceActivationSelect": "选择",
+            "autoCreateTerminalOnWorkspaceActivationClick": "点击"
           }
         },
         "git": {

--- a/src/renderer/src/lib/worktree-activation-created-agent.test.ts
+++ b/src/renderer/src/lib/worktree-activation-created-agent.test.ts
@@ -123,6 +123,56 @@ describe('activateAndRevealWorktree created agent reopen', () => {
     expect(revealWorktreeInSidebar).toHaveBeenCalledWith(worktree.id)
   })
 
+  it('leaves an empty worktree terminal-free when automatic creation is disabled', () => {
+    const worktree = makeWorktree()
+    const revealWorktreeInSidebar = vi.fn()
+
+    useAppStore.setState({
+      repos: [
+        {
+          id: 'repo-1',
+          path: '/workspace/repo',
+          displayName: 'repo',
+          badgeColor: '#000000',
+          addedAt: 0
+        }
+      ],
+      worktreesByRepo: { 'repo-1': [worktree] },
+      activeRepoId: 'repo-1',
+      activeWorktreeId: null,
+      activeView: 'terminal',
+      tabsByWorktree: {},
+      unifiedTabsByWorktree: {},
+      groupsByWorktree: {},
+      layoutByWorktree: {},
+      activeGroupIdByWorktree: {},
+      openFiles: [],
+      browserTabsByWorktree: {},
+      activeFileIdByWorktree: {},
+      activeBrowserTabIdByWorktree: {},
+      activeTabTypeByWorktree: {},
+      activeTabIdByWorktree: {},
+      tabBarOrderByWorktree: {},
+      pendingStartupByTabId: {},
+      settings: {
+        ...getDefaultSettings('/tmp'),
+        autoCreateTerminalOnWorkspaceActivation: false
+      },
+      markWorktreeVisited: vi.fn(),
+      recordWorktreeVisit: vi.fn(),
+      refreshGitHubForWorktreeIfStale: vi.fn(),
+      revealWorktreeInSidebar
+    })
+
+    const result = activateAndRevealWorktree(worktree.id)
+    const state = useAppStore.getState()
+
+    expect(result).toEqual({ primaryTabId: null })
+    expect(state.tabsByWorktree[worktree.id]).toBeUndefined()
+    expect(state.pendingStartupByTabId).toEqual({})
+    expect(revealWorktreeInSidebar).toHaveBeenCalledWith(worktree.id)
+  })
+
   it('uses WSL launch quoting when reopening a Windows-path WSL project agent', () => {
     const worktree = {
       ...makeWorktree(),
@@ -661,7 +711,9 @@ describe('activateAndRevealWorktree created agent reopen', () => {
       }))
     })
 
-    ensureWebRuntimeWorktreeTerminalAfterWake(worktree.id)
+    ensureWebRuntimeWorktreeTerminalAfterWake(worktree.id, {
+      automaticCreationEnabled: false
+    })
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(callRuntimeEnvironment).toHaveBeenCalledWith(

--- a/src/renderer/src/lib/worktree-activation-empty-remote.test.ts
+++ b/src/renderer/src/lib/worktree-activation-empty-remote.test.ts
@@ -116,4 +116,48 @@ describe('empty remote worktree activation', () => {
       })
     )
   })
+
+  it('does not create a first host terminal when automatic creation is disabled', () => {
+    const worktree = makeWorktree()
+    const callRuntimeEnvironment = vi.fn()
+    ;(globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
+    vi.stubGlobal('window', {
+      api: {
+        runtimeEnvironments: {
+          call: callRuntimeEnvironment,
+          subscribe: vi.fn()
+        }
+      }
+    })
+
+    useAppStore.setState({
+      repos: [
+        {
+          id: 'repo-1',
+          path: REPO_PATH,
+          displayName: 'repo',
+          badgeColor: '#000000',
+          addedAt: 0
+        }
+      ],
+      worktreesByRepo: { 'repo-1': [worktree] },
+      tabsByWorktree: {},
+      ptyIdsByTabId: {},
+      settings: {
+        ...getDefaultSettings(ORCA_WORKSPACES_PATH),
+        activeRuntimeEnvironmentId: 'web-runtime-1',
+        autoCreateTerminalOnWorkspaceActivation: false
+      },
+      reconcileWorktreeTabModel: vi.fn(() => ({
+        renderableTabCount: 0,
+        activeRenderableTabId: null
+      }))
+    })
+
+    ensureWebRuntimeWorktreeTerminalAfterWake(worktree.id, {
+      automaticCreationEnabled: false
+    })
+
+    expect(callRuntimeEnvironment).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/lib/worktree-activation-folder-workspace.test.ts
+++ b/src/renderer/src/lib/worktree-activation-folder-workspace.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultSettings } from '../../../shared/constants'
+import type { FolderWorkspace } from '../../../shared/types'
+import { folderWorkspaceKey } from '../../../shared/workspace-scope'
+import { useAppStore } from '@/store'
+import { activateAndRevealFolderWorkspace } from './worktree-activation'
+
+const initialAppStoreState = useAppStore.getState()
+
+afterEach(() => {
+  useAppStore.setState(initialAppStoreState, true)
+})
+
+function makeFolderWorkspace(): FolderWorkspace {
+  return {
+    id: 'folder-1',
+    projectGroupId: 'group-1',
+    name: 'Platform',
+    folderPath: '/workspace/platform',
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    createdAt: 0,
+    updatedAt: 0
+  }
+}
+
+function seedFolderWorkspace(): {
+  folderWorkspace: FolderWorkspace
+  revealWorktreeInSidebar: ReturnType<typeof vi.fn>
+} {
+  const folderWorkspace = makeFolderWorkspace()
+  const revealWorktreeInSidebar = vi.fn()
+
+  useAppStore.setState({
+    folderWorkspaces: [folderWorkspace],
+    projectGroups: [],
+    activeRepoId: null,
+    activeWorktreeId: null,
+    activeView: 'terminal',
+    tabsByWorktree: {},
+    unifiedTabsByWorktree: {},
+    groupsByWorktree: {},
+    layoutByWorktree: {},
+    activeGroupIdByWorktree: {},
+    openFiles: [],
+    browserTabsByWorktree: {},
+    activeFileIdByWorktree: {},
+    activeBrowserTabIdByWorktree: {},
+    activeTabTypeByWorktree: {},
+    activeTabIdByWorktree: {},
+    tabBarOrderByWorktree: {},
+    pendingStartupByTabId: {},
+    settings: {
+      ...getDefaultSettings('/tmp'),
+      autoCreateTerminalOnWorkspaceActivation: false
+    },
+    getFreshFolderWorkspacePathStatus: vi.fn(() => null),
+    markWorktreeVisited: vi.fn(),
+    recordWorktreeVisit: vi.fn(),
+    revealWorktreeInSidebar
+  })
+
+  return { folderWorkspace, revealWorktreeInSidebar }
+}
+
+describe('activateAndRevealFolderWorkspace', () => {
+  it('leaves an empty folder workspace terminal-free when automatic creation is disabled', () => {
+    const { folderWorkspace, revealWorktreeInSidebar } = seedFolderWorkspace()
+    const workspaceKey = folderWorkspaceKey(folderWorkspace.id)
+
+    const result = activateAndRevealFolderWorkspace(folderWorkspace.id, {
+      runtimeEnvironmentId: null
+    })
+
+    expect(result).toEqual({ primaryTabId: null })
+    expect(useAppStore.getState().tabsByWorktree[workspaceKey]).toBeUndefined()
+    expect(revealWorktreeInSidebar).toHaveBeenCalledWith(workspaceKey)
+  })
+
+  it('still creates a terminal for an explicit startup request', () => {
+    const { folderWorkspace } = seedFolderWorkspace()
+
+    const result = activateAndRevealFolderWorkspace(folderWorkspace.id, {
+      runtimeEnvironmentId: null,
+      startup: { command: 'echo ready' }
+    })
+
+    if (result === false || !result.primaryTabId) {
+      throw new Error('explicit folder workspace startup did not create a terminal')
+    }
+    expect(useAppStore.getState().pendingStartupByTabId[result.primaryTabId]).toMatchObject({
+      command: 'echo ready'
+    })
+  })
+})

--- a/src/renderer/src/lib/worktree-activation.test.ts
+++ b/src/renderer/src/lib/worktree-activation.test.ts
@@ -101,6 +101,23 @@ describe('ensureWorktreeHasInitialTerminal', () => {
     expect(store.queueTabSetupSplit).not.toHaveBeenCalled()
   })
 
+  it('does not create a tab when automatic creation is disabled', () => {
+    const store = createMockStore()
+
+    const result = ensureWorktreeHasInitialTerminal(
+      store,
+      'wt-1',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { automaticCreationEnabled: false }
+    )
+
+    expect(result).toBeNull()
+    expect(store.createTab).not.toHaveBeenCalled()
+  })
+
   it('creates configured default tabs once with title, color, and opted-in commands', () => {
     let createdIndex = 0
     const createTab = vi.fn(() => ({ id: `tab-${++createdIndex}` }))

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -141,7 +141,12 @@ type WorktreeActivationStore = Partial<WorktreeRuntimeOwnerState> & {
     startup: { command: string; env?: Record<string, string> }
   ) => void
   queueTabInitialCwd: (tabId: string, cwd: string) => void
-  settings?: Pick<GlobalSettings, 'experimentalNativeChat' | 'openAgentTabsInChatByDefault'> | null
+  settings?: Pick<
+    GlobalSettings,
+    | 'autoCreateTerminalOnWorkspaceActivation'
+    | 'experimentalNativeChat'
+    | 'openAgentTabsInChatByDefault'
+  > | null
 }
 
 /**
@@ -157,7 +162,8 @@ export type ActivateAndRevealResult = {
 
 function ensureFolderWorkspaceInitialTerminal(
   folderWorkspace: FolderWorkspace,
-  startup?: WorktreeStartupPayload
+  startup?: WorktreeStartupPayload,
+  automaticCreationEnabled = true
 ): string | null {
   const state = useAppStore.getState()
   const workspaceKey = folderWorkspaceKey(folderWorkspace.id)
@@ -167,7 +173,8 @@ function ensureFolderWorkspaceInitialTerminal(
     startup,
     undefined,
     undefined,
-    undefined
+    undefined,
+    { automaticCreationEnabled }
   )
   return primaryTabId
 }
@@ -217,7 +224,13 @@ export function activateAndRevealFolderWorkspace(
     state.recordWorktreeVisit(workspaceKey)
   }
   resumeSleepingAgentSessionsForWorktree(workspaceKey)
-  const primaryTabId = ensureFolderWorkspaceInitialTerminal(folderWorkspace, opts?.startup)
+  const automaticCreationEnabled =
+    Boolean(opts?.startup) || state.settings?.autoCreateTerminalOnWorkspaceActivation !== false
+  const primaryTabId = ensureFolderWorkspaceInitialTerminal(
+    folderWorkspace,
+    opts?.startup,
+    automaticCreationEnabled
+  )
 
   if (opts?.sidebarRevealBehavior) {
     state.revealWorktreeInSidebar(workspaceKey, { behavior: opts.sidebarRevealBehavior })
@@ -299,6 +312,9 @@ export function activateAndRevealWorktree(
   const hasActivationWork = Boolean(
     opts?.startup || opts?.setup || opts?.defaultTabs || opts?.issueCommand
   )
+  const hasTerminalLaunchWork = Boolean(hasActivationWork || opts?.initialCwd)
+  const automaticCreationEnabled =
+    hasTerminalLaunchWork || state.settings?.autoCreateTerminalOnWorkspaceActivation !== false
   // Why: a plain reselect should still reveal the sidebar row but must not restamp focus recency or wake persistence.
   const isPlainAlreadyActiveTerminal =
     !hasActivationWork &&
@@ -345,10 +361,11 @@ export function activateAndRevealWorktree(
   const primaryTabId = ensureWorktreeHasInitialTerminal(
     useAppStore.getState(),
     worktreeId,
-    opts?.startup ?? buildCreatedAgentReopenStartup(wt),
+    opts?.startup ?? (automaticCreationEnabled ? buildCreatedAgentReopenStartup(wt) : undefined),
     opts?.setup,
     opts?.issueCommand,
-    opts?.defaultTabs
+    opts?.defaultTabs,
+    { automaticCreationEnabled }
   )
   if (primaryTabId && opts?.initialCwd) {
     useAppStore.getState().queueTabInitialCwd(primaryTabId, opts.initialCwd)
@@ -375,13 +392,16 @@ export function activateAndRevealWorktree(
   }
 
   if (opts?.notifyHostRuntime !== false) {
-    ensureWebRuntimeWorktreeTerminalAfterWake(worktreeId)
+    ensureWebRuntimeWorktreeTerminalAfterWake(worktreeId, { automaticCreationEnabled })
   }
 
   return { primaryTabId }
 }
 
-export function ensureWebRuntimeWorktreeTerminalAfterWake(worktreeId: string): void {
+export function ensureWebRuntimeWorktreeTerminalAfterWake(
+  worktreeId: string,
+  opts?: { automaticCreationEnabled?: boolean }
+): void {
   const state = useAppStore.getState()
   const worktree = state.getKnownWorktreeById(worktreeId)
   if (!worktree) {
@@ -405,6 +425,11 @@ export function ensureWebRuntimeWorktreeTerminalAfterWake(worktreeId: string): v
   }
 
   if (getLastKnownHostTerminalTabCount(runtimeEnvironmentId, worktreeId) > 0) {
+    return
+  }
+
+  // Why: the preference suppresses only a first terminal, not restoration of preserved dead tabs.
+  if (tabs.length === 0 && opts?.automaticCreationEnabled === false) {
     return
   }
 
@@ -435,7 +460,7 @@ export function ensureWorktreeHasInitialTerminal(
   setup?: WorktreeSetupLaunch,
   issueCommand?: IssueCommandLaunch,
   defaultTabs?: WorktreeDefaultTabsLaunch,
-  opts?: { activateCreatedTabs?: boolean }
+  opts?: { activateCreatedTabs?: boolean; automaticCreationEnabled?: boolean }
 ): string | null {
   const { renderableTabCount } = store.reconcileWorktreeTabModel(worktreeId)
   // Why: creating a terminal just because the legacy terminal slice is empty gives editor/browser-only worktrees an unexpected extra tab.
@@ -498,7 +523,9 @@ export function ensureWorktreeHasInitialTerminal(
     return null
   }
 
-  if (!shouldAutoCreateInitialTerminal(renderableTabCount)) {
+  if (
+    !shouldAutoCreateInitialTerminal(renderableTabCount, opts?.automaticCreationEnabled !== false)
+  ) {
     const existingTerminalTabId = store.tabsByWorktree[worktreeId]?.[0]?.id
     if (existingTerminalTabId && (setup || issueCommand)) {
       // Why: main may have adopted the startup tab but failed to spawn setup; renderer must still launch the returned fallback setup.

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -173,6 +173,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
   return {
     workspaceDir: getDefaultWorkspaceDir(homedir),
     nestWorkspaces: true,
+    autoCreateTerminalOnWorkspaceActivation: true,
     workspaceDirHistory: [],
     refreshLocalBaseRefOnWorktreeCreate: false,
     localBaseRefSuggestionDismissed: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2600,6 +2600,8 @@ export type GlobalSettings = {
    *  host-varying setting is `host override ?? client default`. */
   hostSettingOverrides?: Partial<Record<ExecutionHostId, HostSettingOverrides>>
   nestWorkspaces: boolean
+  /** Defaults on; when false, selecting an empty workspace leaves terminal creation explicit. */
+  autoCreateTerminalOnWorkspaceActivation?: boolean
   workspaceDirHistory?: OrcaWorkspaceLayout[]
   refreshLocalBaseRefOnWorktreeCreate: boolean
   /** Set once the user dismisses the "local main is behind" suggestion toast, so


### PR DESCRIPTION
## Summary
- Add a setting to keep empty workspace selection from automatically creating the first terminal.
- Preserve explicit terminal creation for startup/setup/default-tab/issue-command flows.
- Show localized empty-state actions when automatic creation is disabled, so users can explicitly open a terminal, Markdown note, or browser.

## Testing
- pnpm run typecheck
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal/initial-terminal.test.ts src/renderer/src/components/settings/GeneralWorkspaceSettingsSection.test.tsx src/renderer/src/lib/worktree-activation.test.ts src/renderer/src/lib/worktree-activation-created-agent.test.ts src/renderer/src/lib/worktree-activation-empty-remote.test.ts src/renderer/src/lib/worktree-activation-folder-workspace.test.ts
- pnpm run verify:localization-catalog
- pnpm run verify:localization-coverage
- pnpm run check:max-lines-ratchet


## ELI5

You can turn off automatic first-terminal creation when selecting an empty workspace. Empty workspaces show actions to open a terminal, note, or browser yourself instead of always spawning a shell.
