### PR TITLE
fix(pty): strip inherited Claude child-session stamps at spawn (silent transcript-persistence loss)

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -1683,6 +1683,28 @@ describe('registerPtyHandlers', () => {
       expect(env.LANG).toBe('fr_FR.UTF-8')
     })
 
+    it('strips inherited Claude child-session stamps from a local spawn env', async () => {
+      // Why: the local provider spreads main's process.env, so a GUI launched from
+      // inside a Claude session would stamp every pane as a nested child and Claude
+      // would silently disable transcript persistence. Not gated on isDaemonHostSpawn.
+      const env = await spawnAndGetEnv(undefined, {
+        CLAUDE_CODE_CHILD_SESSION: '1',
+        CLAUDE_CODE_SESSION_ID: '85935aed-98a7-4094-89a8-85c75e1a5a95',
+        CLAUDE_CODE_BRIDGE_SESSION_ID: 'session_01UCkWN5nDXNyD1V7cfamCxa'
+      })
+      expect(env.CLAUDE_CODE_CHILD_SESSION).toBeUndefined()
+      expect(env.CLAUDE_CODE_SESSION_ID).toBeUndefined()
+      expect(env.CLAUDE_CODE_BRIDGE_SESSION_ID).toBeUndefined()
+    })
+
+    it('keeps an explicitly requested Claude child-session stamp on a local spawn', async () => {
+      const env = await spawnAndGetEnv(
+        { CLAUDE_CODE_CHILD_SESSION: '1' },
+        { CLAUDE_CODE_CHILD_SESSION: '1' }
+      )
+      expect(env.CLAUDE_CODE_CHILD_SESSION).toBe('1')
+    })
+
     it('always sets TERM and COLORTERM regardless of env', async () => {
       const env = await spawnAndGetEnv()
       expect(env.TERM).toBe('xterm-256color')
@@ -3014,6 +3036,84 @@ describe('registerPtyHandlers', () => {
         )
         expect(spawnOptions.env.ORCA_AGENT_HOOK_PORT).toBe('5678')
         expect(spawnOptions.env.ORCA_AGENT_HOOK_TOKEN).toBe('agent-token')
+      })
+
+      it('strips inherited Claude child-session stamps from runtime-created PTYs', async () => {
+        // Why: the runtime controller is the `orca` CLI / automation spawn path and
+        // assembles envToDelete separately from the renderer's pty:spawn handler;
+        // without its own case the two paths can silently drift apart.
+        type RuntimeSpawnController = {
+          spawn(args: {
+            cols: number
+            rows: number
+            worktreeId?: string
+            env?: Record<string, string>
+          }): Promise<{ id: string }>
+        }
+        const daemonSpawn = setupDaemonAdapter()
+        const runtime = {
+          setPtyController: vi.fn(),
+          registerPty: vi.fn(),
+          noteTerminalSpawnCommand: vi.fn(),
+          onPtySpawned: vi.fn(),
+          onPtyExit: vi.fn(),
+          onPtyData: vi.fn()
+        }
+        handlers.clear()
+        registerPtyHandlers(mainWindow as never, runtime as never)
+        const controller = runtime.setPtyController.mock.calls[0]?.[0] as RuntimeSpawnController
+
+        await controller.spawn({ cols: 80, rows: 24, worktreeId: 'wt-runtime', env: {} })
+
+        const spawnOptions = daemonSpawn.mock.calls.at(-1)?.[0] as DaemonSpawnCall
+        expect(spawnOptions.envToDelete).toEqual(
+          expect.arrayContaining([
+            'CLAUDE_CODE_CHILD_SESSION',
+            'CLAUDE_CODE_SESSION_ID',
+            'CLAUDE_CODE_BRIDGE_SESSION_ID'
+          ])
+        )
+      })
+
+      it('strips inherited Claude child-session stamps from a local runtime-created PTY', async () => {
+        // Why: the runtime strip is deliberately not gated on isDaemonHostSpawn, so
+        // the local provider — which spreads main's own process.env — needs its own
+        // case; a daemon-only test would still pass if someone added that gate.
+        type RuntimeSpawnController = {
+          spawn(args: {
+            cols: number
+            rows: number
+            worktreeId?: string
+            env?: Record<string, string>
+          }): Promise<{ id: string }>
+        }
+        const runtime = {
+          setPtyController: vi.fn(),
+          registerPty: vi.fn(),
+          noteTerminalSpawnCommand: vi.fn(),
+          onPtySpawned: vi.fn(),
+          onPtyExit: vi.fn(),
+          onPtyData: vi.fn(),
+          preAllocateHandleForPty: vi.fn(() => 'handle-runtime-local')
+        }
+        const saved = process.env.CLAUDE_CODE_CHILD_SESSION
+        process.env.CLAUDE_CODE_CHILD_SESSION = '1'
+        try {
+          handlers.clear()
+          registerPtyHandlers(mainWindow as never, runtime as never)
+          const controller = runtime.setPtyController.mock.calls[0]?.[0] as RuntimeSpawnController
+
+          await controller.spawn({ cols: 80, rows: 24, env: {} })
+
+          const env = spawnMock.mock.calls.at(-1)![2].env as Record<string, string>
+          expect(env.CLAUDE_CODE_CHILD_SESSION).toBeUndefined()
+        } finally {
+          if (saved === undefined) {
+            delete process.env.CLAUDE_CODE_CHILD_SESSION
+          } else {
+            process.env.CLAUDE_CODE_CHILD_SESSION = saved
+          }
+        }
       })
 
       it('threads the validated pane identity into registerPty for a runtime-created daemon PTY (#7587)', async () => {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -2902,6 +2902,39 @@ describe('registerPtyHandlers', () => {
         expect(spawnOptions.envToDelete ?? []).not.toEqual(expect.arrayContaining(['CODEX_HOME']))
       })
 
+      it('strips inherited Claude child-session stamps from daemon spawns', async () => {
+        // Why: a daemon forked from inside a Claude Code session inherits these
+        // stamps and would mark every terminal as a nested Claude child, which
+        // silently disables transcript persistence for real user sessions.
+        const spawnOptions = await daemonSpawnAndGetOptions(undefined, undefined, undefined, {
+          CLAUDE_CODE_CHILD_SESSION: '1',
+          CLAUDE_CODE_SESSION_ID: '85935aed-98a7-4094-89a8-85c75e1a5a95',
+          CLAUDE_CODE_BRIDGE_SESSION_ID: 'session_01UCkWN5nDXNyD1V7cfamCxa'
+        })
+        expect(spawnOptions.envToDelete).toEqual(
+          expect.arrayContaining([
+            'CLAUDE_CODE_CHILD_SESSION',
+            'CLAUDE_CODE_SESSION_ID',
+            'CLAUDE_CODE_BRIDGE_SESSION_ID'
+          ])
+        )
+      })
+
+      it('preserves an explicitly requested Claude child-session stamp', async () => {
+        // Why: only inherited values are poison; a caller deliberately spawning a
+        // nested Claude child passes the stamp in args.env and must keep it.
+        const spawnOptions = await daemonSpawnAndGetOptions(
+          { CLAUDE_CODE_CHILD_SESSION: '1' },
+          undefined,
+          undefined,
+          { CLAUDE_CODE_CHILD_SESSION: '1' }
+        )
+        expect(spawnOptions.envToDelete ?? []).not.toEqual(
+          expect.arrayContaining(['CLAUDE_CODE_CHILD_SESSION'])
+        )
+        expect(spawnOptions.env.CLAUDE_CODE_CHILD_SESSION).toBe('1')
+      })
+
       it('prepends the bare-orca CLI shim dir to PATH for packaged Linux spawns', async () => {
         const originalPlatform = process.platform
         Object.defineProperty(process, 'platform', {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -238,6 +238,17 @@ const AGENT_HOOK_RUNTIME_ENV_KEYS = [
   'ORCA_CLAUDE_AGENT_STATUS_SETTINGS'
 ] as const
 
+// Why: a pty host launched from inside a Claude Code session inherits Claude's
+// child-session stamps, and the wholesale process.env spread then marks every
+// spawned terminal as a nested Claude child — Claude silently disables
+// transcript persistence for those sessions, so real user sessions lose their
+// on-disk history without any visible error. Orca never sets these itself.
+const CLAUDE_CHILD_SESSION_STAMP_ENV_KEYS = [
+  'CLAUDE_CODE_CHILD_SESSION',
+  'CLAUDE_CODE_SESSION_ID',
+  'CLAUDE_CODE_BRIDGE_SESSION_ID'
+] as const
+
 export function getPtyIdForPaneKey(paneKey: string): string | undefined {
   return paneKeyPtyId.get(paneKey)
 }
@@ -924,6 +935,15 @@ function getInheritedAgentHookEnvKeysToDelete(
   const env = spawnEnv ?? {}
   // Why: providers merge process.env after cleanup; delete stale hook keys without dropping fresh coordinates buildPtyHostEnv set.
   return AGENT_HOOK_RUNTIME_ENV_KEYS.filter((key) => env[key] === undefined)
+}
+
+function getInheritedClaudeSessionStampEnvKeysToDelete(
+  spawnEnv: Record<string, string> | undefined
+): string[] {
+  const env = spawnEnv ?? {}
+  // Why: strip only values inherited from the pty host; a caller that explicitly
+  // provides a stamp (deliberately spawning a nested Claude child) keeps it.
+  return CLAUDE_CHILD_SESSION_STAMP_ENV_KEYS.filter((key) => env[key] === undefined)
 }
 
 // Why: a nested terminal can inherit prior OpenCode/Pi/OMP overlay env; restore the user's recorded source dir, else strip only Orca-owned values.
@@ -3329,7 +3349,12 @@ export function registerPtyHandlers(
       }
       spawnOptions.envToDelete = mergePtyEnvDeletions(
         mergePtyEnvDeletions(authEnvToDelete, args.envToDelete ?? []),
-        isDaemonHostSpawn ? getInheritedAgentHookEnvKeysToDelete(env) : []
+        mergePtyEnvDeletions(
+          isDaemonHostSpawn ? getInheritedAgentHookEnvKeysToDelete(env) : [],
+          // Why: unconditional — both the daemon and the relay host spread their
+          // own (possibly contaminated) process.env into every spawn.
+          getInheritedClaudeSessionStampEnvKeysToDelete(env)
+        )
       )
       if (skipCodexHomeEnv) {
         spawnOptions.envToDelete = mergePtyEnvDeletions(
@@ -4476,10 +4501,13 @@ export function registerPtyHandlers(
         mergePtyEnvDeletions(
           mergePtyEnvDeletions(
             mergePtyEnvDeletions(
-              mergePtyEnvDeletions(envToDelete, args.envToDelete ?? []),
-              agentTeamsEnvToDelete ?? []
+              mergePtyEnvDeletions(
+                mergePtyEnvDeletions(envToDelete, args.envToDelete ?? []),
+                agentTeamsEnvToDelete ?? []
+              ),
+              isDaemonHostSpawn ? getInheritedAgentHookEnvKeysToDelete(spawnEnv) : []
             ),
-            isDaemonHostSpawn ? getInheritedAgentHookEnvKeysToDelete(spawnEnv) : []
+            getInheritedClaudeSessionStampEnvKeysToDelete(spawnEnv)
           ),
           skipCodexHomeEnv ? CODEX_HOME_ENV_KEYS : []
         ),

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -238,11 +238,7 @@ const AGENT_HOOK_RUNTIME_ENV_KEYS = [
   'ORCA_CLAUDE_AGENT_STATUS_SETTINGS'
 ] as const
 
-// Why: a pty host launched from inside a Claude Code session inherits Claude's
-// child-session stamps, and the wholesale process.env spread then marks every
-// spawned terminal as a nested Claude child — Claude silently disables
-// transcript persistence for those sessions, so real user sessions lose their
-// on-disk history without any visible error. Orca never sets these itself.
+// Why: Orca never sets these, so an inherited value means a pty host launched from inside a Claude session — Claude reads it as a nested child and silently stops persisting the transcript.
 const CLAUDE_CHILD_SESSION_STAMP_ENV_KEYS = [
   'CLAUDE_CODE_CHILD_SESSION',
   'CLAUDE_CODE_SESSION_ID',
@@ -913,14 +909,15 @@ function exposePiManagedExtensionEnv(
   }
 }
 
+// Why: variadic because a nested call per source made intermediate `string[] | undefined` collide with the parameter type.
 function mergePtyEnvDeletions(
   existingKeys: string[] | undefined,
-  additionalKeys: readonly string[]
+  ...additionalKeyGroups: readonly (readonly string[])[]
 ): string[] | undefined {
-  if (!existingKeys && additionalKeys.length === 0) {
+  if (!existingKeys && additionalKeyGroups.every((keys) => keys.length === 0)) {
     return undefined
   }
-  return Array.from(new Set([...(existingKeys ?? []), ...additionalKeys]))
+  return Array.from(new Set([...(existingKeys ?? []), ...additionalKeyGroups.flat()]))
 }
 
 function removeCodexHomeDeletionRequests(keys: string[] | undefined): string[] | undefined {
@@ -3348,13 +3345,11 @@ export function registerPtyHandlers(
         args.onPtySpawnCommitted?.()
       }
       spawnOptions.envToDelete = mergePtyEnvDeletions(
-        mergePtyEnvDeletions(authEnvToDelete, args.envToDelete ?? []),
-        mergePtyEnvDeletions(
-          isDaemonHostSpawn ? getInheritedAgentHookEnvKeysToDelete(env) : [],
-          // Why: unconditional — both the daemon and the relay host spread their
-          // own (possibly contaminated) process.env into every spawn.
-          getInheritedClaudeSessionStampEnvKeysToDelete(env)
-        )
+        authEnvToDelete,
+        args.envToDelete ?? [],
+        isDaemonHostSpawn ? getInheritedAgentHookEnvKeysToDelete(env) : [],
+        // Why: ungated, unlike the agent-hook keys — the local provider and the relay host also spread their own process.env into every spawn.
+        getInheritedClaudeSessionStampEnvKeysToDelete(env)
       )
       if (skipCodexHomeEnv) {
         spawnOptions.envToDelete = mergePtyEnvDeletions(
@@ -4498,19 +4493,12 @@ export function registerPtyHandlers(
         ? [...CLAUDE_AUTH_ENV_VARS, 'ANTHROPIC_CUSTOM_HEADERS']
         : undefined
       let combinedEnvToDelete = mergePtyEnvDeletions(
-        mergePtyEnvDeletions(
-          mergePtyEnvDeletions(
-            mergePtyEnvDeletions(
-              mergePtyEnvDeletions(
-                mergePtyEnvDeletions(envToDelete, args.envToDelete ?? []),
-                agentTeamsEnvToDelete ?? []
-              ),
-              isDaemonHostSpawn ? getInheritedAgentHookEnvKeysToDelete(spawnEnv) : []
-            ),
-            getInheritedClaudeSessionStampEnvKeysToDelete(spawnEnv)
-          ),
-          skipCodexHomeEnv ? CODEX_HOME_ENV_KEYS : []
-        ),
+        envToDelete,
+        args.envToDelete ?? [],
+        agentTeamsEnvToDelete ?? [],
+        isDaemonHostSpawn ? getInheritedAgentHookEnvKeysToDelete(spawnEnv) : [],
+        getInheritedClaudeSessionStampEnvKeysToDelete(spawnEnv),
+        skipCodexHomeEnv ? CODEX_HOME_ENV_KEYS : [],
         // Why: the persistent daemon compares its own merged CODEX_HOME pair;
         // main cannot safely decide ownership for a process it may not parent.
         stripInheritedOrcaCodexHome ? ['ORCA_CODEX_HOME'] : []

--- a/src/main/providers/provider-dispatch.test.ts
+++ b/src/main/providers/provider-dispatch.test.ts
@@ -141,19 +141,20 @@ describe('PTY provider dispatch', () => {
     })) as { id: string }
 
     expect(result.id).toBe('ssh-pty-1')
-    expect(mockSshProvider.spawn).toHaveBeenCalledWith({
-      cols: 80,
-      rows: 24,
-      cwd: undefined,
-      env: undefined,
-      // Why: the relay host can be launched from a Claude session too, so the stamps
-      // are stripped on the SSH path as well; pinned exactly so nothing else leaks in.
-      envToDelete: [
+    // Why: the relay host can be launched from a Claude session too, so the stamps are
+    // stripped on the SSH path as well. Compared as a set — envToDelete is consumed by
+    // membership only, so a reordering of the merge sources must not fail this.
+    const sshSpawnArgs = vi.mocked(mockSshProvider.spawn).mock.calls.at(-1)![0]
+    expect([...(sshSpawnArgs.envToDelete ?? [])].sort()).toEqual(
+      [
         'CLAUDE_CODE_CHILD_SESSION',
         'CLAUDE_CODE_SESSION_ID',
         'CLAUDE_CODE_BRIDGE_SESSION_ID'
-      ]
-    })
+      ].sort()
+    )
+    expect(mockSshProvider.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ cols: 80, rows: 24, cwd: undefined, env: undefined })
+    )
 
     unregisterSshPtyProvider('conn-123')
   })

--- a/src/main/providers/provider-dispatch.test.ts
+++ b/src/main/providers/provider-dispatch.test.ts
@@ -145,7 +145,14 @@ describe('PTY provider dispatch', () => {
       cols: 80,
       rows: 24,
       cwd: undefined,
-      env: undefined
+      env: undefined,
+      // Why: the relay host can be launched from a Claude session too, so the stamps
+      // are stripped on the SSH path as well; pinned exactly so nothing else leaks in.
+      envToDelete: [
+        'CLAUDE_CODE_CHILD_SESSION',
+        'CLAUDE_CODE_SESSION_ID',
+        'CLAUDE_CODE_BRIDGE_SESSION_ID'
+      ]
     })
 
     unregisterSshPtyProvider('conn-123')


### PR DESCRIPTION
### Problem

If an Orca GUI (or its daemon) is ever launched from inside a Claude Code session — a terminal where `claude` is running, a shell spawned by it, or an auto-update relaunch chained from such a launch — it inherits three environment variables:

```
CLAUDE_CODE_CHILD_SESSION
CLAUDE_CODE_SESSION_ID
CLAUDE_CODE_BRIDGE_SESSION_ID
```

Both spawn paths start from a wholesale spread of the host's env (the daemon fork env in `daemon-init.ts`, `buildSpawnEnv` in `src/relay/pty-handler.ts`), so every terminal Orca spawns inherits the stamps. Claude Code treats a stamped process as a *nested child session* and **silently disables transcript persistence** — the user's real sessions stop writing their on-disk history, with no visible error and no way to notice until a resume fails.

Two otherwise-good design choices amplify the blast radius: older-protocol daemons are deliberately preserved across upgrades and never respawn, and the auto-updater relaunch inherits the previous app's env. So one contaminated launch propagates through every subsequent auto-update until a fully clean-environment relaunch. Measured on a production machine: a GUI launched once from a Claude session on 07-20 stamped three daemon generations (protocol v23–v25) across two auto-updates; every pane spawned in that window ran with persistence silently off.

### Fix

Orca never sets these variables itself, so on the host they are always inherited poison. This mirrors the existing `AGENT_HOOK_RUNTIME_ENV_KEYS` pattern in `src/main/ipc/pty.ts`:

* a `CLAUDE_CHILD_SESSION_STAMP_ENV_KEYS` deny constant,
* `getInheritedClaudeSessionStampEnvKeysToDelete()` — the same inherited-only filter as the agent-hook helper, so a stamp explicitly passed in `args.env` (a caller deliberately spawning a nested Claude child) is preserved,
* merged into `envToDelete` at both spawn call sites. Unlike the agent-hook keys this is not gated on `isDaemonHostSpawn`, because the relay host's own `process.env` can be contaminated the same way.

### Tests

Two tests in `pty.test.ts` using the existing `daemonSpawnAndGetOptions` helper: a contaminated host env puts all three keys in `envToDelete`; an explicit `args.env` stamp is preserved. The strip test fails against unpatched source (verified); the file suite is 304/304 with the patch. `oxlint`/`oxfmt` clean.

---

*This patch was authored by fable, an AI agent working on @akapug's machine, where the bug was found and measured live; @akapug reviewed and submitted.*



## ELI5

If Orca was started from inside a Claude session, it inherited Claude child-session env vars and silently broke transcript persistence for new sessions. Spawn paths now strip those stamps so each session keeps its own history.
