### PR TITLE
fix(runtime): republish runtime metadata on second-instance signal (CLI stale_bootstrap)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -486,6 +486,9 @@ function focusExistingWindow(): void {
 
 function requestDesktopActivation(): void {
   desktopActivationGate.requestActivation()
+  // Why: the losing instance may have clobbered orca-runtime.json on its way
+  // out; republish so the CLI keeps resolving to this live runtime.
+  runtimeRpc?.republishMetadata()
 }
 
 function getDesktopWindowStatus(): RuntimeDesktopWindowStatus {

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Why: this integration-style RPC test keeps the request/response contract together so regressions in the external CLI surface are easier to spot. */
-import { existsSync, mkdtempSync } from 'node:fs'
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createConnection, type Socket } from 'node:net'
@@ -11,6 +11,7 @@ import { OrcaRuntimeService } from './orca-runtime'
 import { OrchestrationDb } from './orchestration/db'
 import * as runtimeMetadataModule from './runtime-metadata'
 import { readRuntimeMetadata } from './runtime-metadata'
+import { getRuntimeMetadataPath } from '../../shared/runtime-bootstrap'
 import { createRuntimeTransportMetadata, OrcaRuntimeRpcServer } from './runtime-rpc'
 import { parsePairingCode } from '../../shared/pairing'
 import { subscribeRemoteRuntimeRequest } from '../../shared/remote-runtime-client'
@@ -337,6 +338,49 @@ describe('OrcaRuntimeRpcServer', () => {
     expect(readRuntimeMetadata(userDataPath)).toMatchObject({
       runtimeId: runtime.getRuntimeId()
     })
+  })
+
+  it('republishes runtime metadata after a losing second instance clobbers it', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const runtime = new OrcaRuntimeService()
+    const server = new OrcaRuntimeRpcServer({ runtime, userDataPath })
+
+    await server.start()
+
+    // Why: a second launch that loses the single-instance lock writes its own
+    // metadata before exiting, leaving the file pointing at a dead pid — the
+    // CLI then reads stale_bootstrap forever while this instance runs on.
+    writeFileSync(
+      getRuntimeMetadataPath(userDataPath),
+      JSON.stringify({
+        runtimeId: 'dead-loser',
+        pid: 99999999,
+        transports: [{ kind: 'unix', endpoint: '/tmp/never.sock' }],
+        authToken: 'stale',
+        startedAt: 0
+      })
+    )
+
+    server.republishMetadata()
+
+    const metadata = readRuntimeMetadata(userDataPath)
+    expect(metadata?.runtimeId).toBe(runtime.getRuntimeId())
+    expect(metadata?.pid).toBe(process.pid)
+    expect(metadata?.transports).toEqual(server['transports'])
+
+    await server.stop()
+  })
+
+  it('republishMetadata is a no-op before transports exist', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const runtime = new OrcaRuntimeService()
+    const server = new OrcaRuntimeRpcServer({ runtime, userDataPath })
+
+    // Why: an unstarted server has no endpoint to advertise; publishing a
+    // transportless record would replace a possibly-valid file with garbage.
+    server.republishMetadata()
+
+    expect(readRuntimeMetadata(userDataPath)).toBeNull()
   })
 
   it('creates a pairing offer for the active WebSocket transport', async () => {

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -1170,6 +1170,23 @@ export class OrcaRuntimeRpcServer {
     return errorResponse(id, { runtimeId: this.runtime.getRuntimeId() }, code, message)
   }
 
+  // Why: the metadata file is written once at transport startup, and a LOSING
+  // second instance (dock click, CLI `open`, updater relaunch) can overwrite it
+  // with its own short-lived record as it exits — leaving the CLI pointed at a
+  // dead pid while this instance runs on, permanently unreachable. The
+  // second-instance signal fires in the winner at exactly the moment that race
+  // has just happened, so re-publishing there heals the file.
+  republishMetadata(): void {
+    if (this.transports.length === 0) {
+      return
+    }
+    try {
+      this.writeMetadata()
+    } catch {
+      // Why: a failed heal must never break second-instance activation.
+    }
+  }
+
   private writeMetadata(): void {
     const metadata: RuntimeMetadata = {
       runtimeId: this.runtime.getRuntimeId(),


### PR DESCRIPTION
### Problem

`orca-runtime.json` (the CLI's bootstrap file) is written exactly once, at transport startup. A second launch that loses the single-instance lock — a dock click while Orca is already running, `orca open` from a shell, an updater relaunch — writes its **own** metadata during its brief startup and then exits, leaving the file pointing at a dead pid.

From that moment the CLI reads `stale_bootstrap` forever: `orca status` reports `appRunning: false / runtimeReachable: false` while a perfectly healthy GUI runs on, and every `orca terminal` / `orca worktree` verb is blind until the winning instance happens to be restarted. Nothing in the running app ever rewrites the file.

Reproduced twice in one day on a production machine — once via a dock click, once via `orca open` — each time leaving automation that drives the CLI unable to reach the running GUI.

### Fix

The `second-instance` signal fires in the *winning* instance at exactly the moment the race has just happened, so `requestDesktopActivation` now also asks the RPC server to republish its metadata.

`republishMetadata()`:
* is a no-op before transports exist — an unstarted server has no endpoint to advertise, and a transportless record would replace a possibly-valid file with garbage;
* swallows write failures — a failed heal must never break second-instance activation.

### Tests

Two tests in `runtime-rpc.test.ts` following the existing start-server-on-tmpdir pattern: a started server whose metadata file has been overwritten with a dead record restores `runtimeId`/`pid`/`transports` on `republishMetadata()`; an unstarted server's call leaves no file. File suite 49/49. `oxlint`/`oxfmt` clean.

---

*This patch was authored by fable, an AI agent working on @akapug's machine, where the bug was found and reproduced live; @akapug reviewed and submitted.*



## ELI5

A second Orca launch (dock click, orca open) could overwrite the CLI bootstrap file with a dead process id. The running app now republishes live metadata when it gets that signal so orca status stays accurate.
