### PR TITLE
fix(browser): unstick Ctrl+Tab switcher when opened from a focused browser guest

### DIFF
--- a/src/main/browser/browser-guest-ui.test.ts
+++ b/src/main/browser/browser-guest-ui.test.ts
@@ -498,7 +498,8 @@ describe('setupGuestShortcutForwarding', () => {
       const tabReleasePreventDefault = triggerBeforeInput({ ...ctrlTabInput, type: 'keyUp' })
       const keyUpPreventDefault = triggerBeforeInput(releaseInput)
 
-      expect(keyDownPreventDefault).toHaveBeenCalledTimes(1)
+      // Why: keydown must not preventDefault or Electron drops the commit keyup.
+      expect(keyDownPreventDefault).not.toHaveBeenCalled()
       expect(tabReleasePreventDefault).not.toHaveBeenCalled()
       expect(keyUpPreventDefault).toHaveBeenCalledTimes(1)
       expect(rendererSendMock).toHaveBeenNthCalledWith(1, 'ui:ctrlTabKeyDown', {

--- a/src/main/browser/browser-guest-ui.ts
+++ b/src/main/browser/browser-guest-ui.ts
@@ -446,7 +446,8 @@ export function setupGuestShortcutForwarding(args: {
       input.type === 'keyDown' &&
       matchesRecentTabSwitcherChord(input, process.platform, keybindings)
     ) {
-      event.preventDefault()
+      // Why: held switcher commits on Control keyup; preventDefault on Tab
+      // keydown suppresses that keyup in Electron and strands the overlay.
       ctrlTabSwitching = true
       const renderer = resolveRenderer(browserTabId)
       renderer?.send('ui:ctrlTabKeyDown', { shiftKey: input.shift === true })

--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -2598,7 +2598,8 @@ describe('browserManager', () => {
       }
     )
 
-    expect(keyDownPreventDefault).toHaveBeenCalledTimes(1)
+    // Why: keydown must not preventDefault or Electron drops the commit keyup.
+    expect(keyDownPreventDefault).not.toHaveBeenCalled()
     expect(keyUpPreventDefault).toHaveBeenCalledTimes(1)
     expect(rendererSendMock).toHaveBeenNthCalledWith(1, 'ui:ctrlTabKeyDown', { shiftKey: false })
     expect(rendererSendMock).toHaveBeenNthCalledWith(2, 'ui:ctrlTabKeyUp')


### PR DESCRIPTION
## Summary

Fixes #9937.

Ctrl+Tab from a focused in-app browser opened the MRU Switch Tab overlay but never committed or closed it, because guest `before-input-event` called `preventDefault()` on the Tab keydown and Electron then suppressed the Control keyup that should emit `ui:ctrlTabKeyUp`.

Stop preventDefault-ing that keydown in guest shortcut forwarding (same approach as the main-window path in `createMainWindow.ts`), so the existing IPC commit path can fire on modifier release.

## What changed

**Before:** Guest Ctrl+Tab keydown was `preventDefault()`-ed → guest keyups were dropped → overlay stayed stuck until focus left the browser tab.

**After:** Guest Ctrl+Tab keydown is forwarded without `preventDefault()` → Control keyup reaches the guest handler → `ui:ctrlTabKeyUp` commits/closes the overlay normally.

## Screenshots

No visual change (behavior-only fix for an existing overlay).

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [x] `pnpm test` (targeted: `browser-guest-ui.test.ts`, `browser-manager.test.ts` Ctrl+Tab cases)
- [ ] `pnpm build`
- [x] Updated unit expectations so guest Ctrl+Tab keydown must not call `preventDefault`

## AI Review Report

Root cause matches the documented main-window comment: preventing the held-chord keydown suppresses the modifier keyup and strands the overlay. Alternative approach in #9954 keeps `preventDefault` and blurs the webview so renderer DOM handlers own the rest of the gesture; this PR prefers the smaller change that removes the suppression trigger and stays consistent with `createMainWindow`.

Cross-platform: no new shortcuts/labels/paths; chord matching stays behind `matchesRecentTabSwitcherChord` / keybinding registry. Electron keyup-suppression after preventDefault is platform-independent (reported on Linux, same guest path on macOS/Windows). SSH unaffected (UI keyboard routing only).

## Security Audit

No new IPC channels or guest-supplied data paths. Change only removes `preventDefault` on an already-forwarded app chord; existing main→renderer `ui:ctrlTabKeyDown` / `ui:ctrlTabKeyUp` trust boundary is unchanged. Pages may observe Ctrl+Tab (previously swallowed); most pages ignore it.

## Notes

Related alternative: #9954 (blur webview + focus restore + E2E). This PR is the minimal main-window-aligned fix for the same root cause.


Made with [Cursor](https://cursor.com)