### PR TITLE
fix(browser): unstick Ctrl+Tab switcher when opened from a focused browser guest

### DIFF
--- a/src/main/browser/browser-guest-ui.test.ts
+++ b/src/main/browser/browser-guest-ui.test.ts
@@ -498,7 +498,8 @@ describe('setupGuestShortcutForwarding', () => {
       const tabReleasePreventDefault = triggerBeforeInput({ ...ctrlTabInput, type: 'keyUp' })
       const keyUpPreventDefault = triggerBeforeInput(releaseInput)
 
-      expect(keyDownPreventDefault).toHaveBeenCalledTimes(1)
+      // Why: keydown must not preventDefault or Electron drops the commit keyup.
+      expect(keyDownPreventDefault).not.toHaveBeenCalled()
       expect(tabReleasePreventDefault).not.toHaveBeenCalled()
       expect(keyUpPreventDefault).toHaveBeenCalledTimes(1)
       expect(rendererSendMock).toHaveBeenNthCalledWith(1, 'ui:ctrlTabKeyDown', {

--- a/src/main/browser/browser-guest-ui.ts
+++ b/src/main/browser/browser-guest-ui.ts
@@ -446,7 +446,8 @@ export function setupGuestShortcutForwarding(args: {
       input.type === 'keyDown' &&
       matchesRecentTabSwitcherChord(input, process.platform, keybindings)
     ) {
-      event.preventDefault()
+      // Why: held switcher commits on Control keyup; preventDefault on Tab
+      // keydown suppresses that keyup in Electron and strands the overlay.
       ctrlTabSwitching = true
       const renderer = resolveRenderer(browserTabId)
       renderer?.send('ui:ctrlTabKeyDown', { shiftKey: input.shift === true })

--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -2598,7 +2598,8 @@ describe('browserManager', () => {
       }
     )
 
-    expect(keyDownPreventDefault).toHaveBeenCalledTimes(1)
+    // Why: keydown must not preventDefault or Electron drops the commit keyup.
+    expect(keyDownPreventDefault).not.toHaveBeenCalled()
     expect(keyUpPreventDefault).toHaveBeenCalledTimes(1)
     expect(rendererSendMock).toHaveBeenNthCalledWith(1, 'ui:ctrlTabKeyDown', { shiftKey: false })
     expect(rendererSendMock).toHaveBeenNthCalledWith(2, 'ui:ctrlTabKeyUp')


### PR DESCRIPTION
## Summary

Fixes the in-app browser's Ctrl+Tab tab switcher, which opened the MRU overlay but never committed or closed it, leaving it stranded on screen.

## ELI5

When you pressed Ctrl+Tab inside the built-in browser, the "switch tab" popup would appear and then get stuck open. Now it closes and switches tabs the way it should.

## Root cause & fix

In `setupGuestShortcutForwarding` (`src/main/browser/browser-guest-ui.ts`), the recent-tab-switcher chord handler called `event.preventDefault()` on the Ctrl+Tab keydown. In Electron, calling `preventDefault()` on the Tab keydown suppresses the subsequent Control keyup, so the overlay never received its commit keyup and stayed open. The fix removes `preventDefault()` from the keydown path (the commit keyup path still calls it), matching the existing main-window behavior in `createMainWindow.ts`.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- Test files: `src/main/browser/browser-guest-ui.test.ts`, `src/main/browser/browser-manager.test.ts`
- On branch (fix present): 2 files passed, 79 tests passed.
- Fix reverted (test kept): 2 tests fail at `browser-guest-ui.test.ts:502` and `browser-manager.test.ts:2602`, both asserting `expect(keyDownPreventDefault).not.toHaveBeenCalled()`.
- Lint clean: `npx oxlint src/main/browser/browser-guest-ui.ts` reports no findings.

```
On branch (fix present):
  Test Files  2 passed (2)
  Tests  79 passed (79)

Fix reverted, tests kept:
  Test Files  2 failed (2)
  Tests  2 failed | 77 passed (79)
  - browser-guest-ui.test.ts:502  expect(keyDownPreventDefault).not.toHaveBeenCalled()
      -> expected not to be called, but called 1 time
  - browser-manager.test.ts:2602  expect(keyDownPreventDefault).not.toHaveBeenCalled()
      -> expected not to be called, but called 1 time
```

## Trade-offs

None — pure fix.

## Regression risk

Zero-regression: only the guest Ctrl+Tab keydown branch changes by dropping one `preventDefault()` call; the commit keyup path and all other input forwarding remain byte-identical, and the two updated unit tests prove both the fixed behavior and its absence when reverted.

_Credit to original author @Fazalkadivar21. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved._
