### PR TITLE
feat(settings): make Language setting findable by native-language search terms

### DIFF
--- a/config/localization-coverage-allowlist.json
+++ b/config/localization-coverage-allowlist.json
@@ -5,5 +5,40 @@
     "text": "Terminal 1",
     "dynamic": false,
     "count": 1
+  },
+  {
+    "filePath": "src/renderer/src/components/settings/appearance-search.ts",
+    "kind": "object-property:keywords",
+    "text": "语言",
+    "dynamic": false,
+    "count": 1
+  },
+  {
+    "filePath": "src/renderer/src/components/settings/appearance-search.ts",
+    "kind": "object-property:keywords",
+    "text": "語言",
+    "dynamic": false,
+    "count": 1
+  },
+  {
+    "filePath": "src/renderer/src/components/settings/appearance-search.ts",
+    "kind": "object-property:keywords",
+    "text": "언어",
+    "dynamic": false,
+    "count": 1
+  },
+  {
+    "filePath": "src/renderer/src/components/settings/appearance-search.ts",
+    "kind": "object-property:keywords",
+    "text": "言語",
+    "dynamic": false,
+    "count": 1
+  },
+  {
+    "filePath": "src/renderer/src/components/settings/appearance-search.ts",
+    "kind": "object-property:keywords",
+    "text": "Idioma",
+    "dynamic": false,
+    "count": 1
   }
 ]

--- a/src/renderer/src/components/settings/appearance-search.test.ts
+++ b/src/renderer/src/components/settings/appearance-search.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { i18n } from '@/i18n/i18n'
+import { getLanguageEntries } from './appearance-search'
+import { matchesSettingsSearch } from './settings-search'
+
+// Native word for "language" in each supported UI language. These must be
+// findable no matter which locale the interface is currently rendered in, so a
+// speaker can locate (and switch to) their language from any starting point.
+const NATIVE_LANGUAGE_WORDS = ['语言', '語言', '언어', '言語', 'Idioma']
+
+describe('getLanguageEntries', () => {
+  afterEach(async () => {
+    await i18n.changeLanguage('en')
+  })
+
+  it.each(['en', 'zh', 'ko', 'ja', 'es'])(
+    'indexes every native word for "language" under the %s UI locale',
+    async (locale) => {
+      await i18n.changeLanguage(locale)
+      const entry = getLanguageEntries()[0]
+      for (const word of NATIVE_LANGUAGE_WORDS) {
+        expect(matchesSettingsSearch(word, entry)).toBe(true)
+      }
+    }
+  )
+
+  it('matches the Spanish native language name in English UI', async () => {
+    await i18n.changeLanguage('en')
+    expect(matchesSettingsSearch('Español', getLanguageEntries()[0])).toBe(true)
+  })
+})

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -49,6 +49,15 @@ export const getLanguageEntries = createLocalizedCatalog((): SettingsSearchEntry
       ...translateSearchKeyword('settings.appearance.language.chinese', '中文（简体）'),
       ...translateSearchKeyword('settings.appearance.language.korean', '한국어'),
       ...translateSearchKeyword('settings.appearance.language.japanese', '日本語'),
+      ...translateSearchKeyword('settings.appearance.language.spanish', 'Español'),
+      // Why: the native word for "language" only reaches search via the localized
+      // title in its own UI locale — index each here so speakers can find (and
+      // switch to) their language whatever the current interface locale is.
+      '语言', // Chinese (Simplified)
+      '語言', // Chinese (Traditional)
+      '언어', // Korean
+      '言語', // Japanese
+      'Idioma', // Spanish
       ...translateSearchKeyword(
         'auto.components.settings.appearance.search.language.locale',
         'locale'


### PR DESCRIPTION
## Problem

The **Language** setting was only findable in settings search by its native word (语言 / 언어 / 言語 / Idioma) **when that language was already the active UI locale**. `translateSearchKeyword('settings.appearance.language.title', 'Language')` emits the localized title only in the matching locale — in the default English UI it returns just `['Language']`.

So a Chinese speaker on the default English install who typed **语言** could not find the Language setting to switch away from English — the exact discovery moment where native-word search matters most.

## Fix

In `getLanguageEntries` (`appearance-search.ts`):

1. **Always-index the native word for "language"** in every supported language as keywords, regardless of the active UI locale: `语言`, `語言` (Traditional), `언어`, `言語`, `Idioma`. (English "Language" is already always-indexed as the title fallback.)
2. **Add the previously-omitted Spanish native name** `Español` (chinese/korean/japanese names were already present).

Native words are locale-invariant constants, so they are plain keyword literals with reviewed entries in the localization-coverage allowlist rather than new translation keys.

## Validation

- **Unit** (`appearance-search.test.ts`): asserts every native word matches the Language entry under all five UI locales (en/zh/ko/ja/es), plus `Español`.
- **End-to-end in the Electron app (English UI):** searching `语言` narrows Settings → Appearance to exactly the Language row (screenshot below). Spot-checked `언어`, `言語`, `Idioma`, `語言`, and partial `语` all surface it; a nonsense query does not.

## Notes

- `verify:localization-catalog` is already red on this branch for unrelated pre-existing missing keys (files not touched here); this change adds none.

Made with [Orca](https://github.com/stablyai/orca) 🐋
