### PR TITLE
feat(editor): seed Find from selected text

### DIFF
--- a/src/renderer/src/components/editor/DiffSectionBody.tsx
+++ b/src/renderer/src/components/editor/DiffSectionBody.tsx
@@ -10,6 +10,7 @@ import type { DiffSection } from './diff-section-types'
 import { translate } from '@/i18n/i18n'
 import { LargeDiffFallback } from './LargeDiffFallback'
 import { buildDiffEditorWordWrapOptions } from './diff-editor-word-wrap-options'
+import { monacoFindOptions } from './monaco-find-options'
 
 const ImageDiffViewer = lazy(() => import('./ImageDiffViewer'))
 
@@ -198,11 +199,7 @@ export function DiffSectionBody({
             renderOverviewRuler: false,
             scrollbar: combinedDiffSectionScrollbarOptions,
             hideUnchangedRegions: { enabled: true },
-            find: {
-              addExtraSpaceOnTop: false,
-              autoFindInSelection: 'never',
-              seedSearchStringFromSelection: 'never'
-            }
+            find: monacoFindOptions
           }}
         />
       )}

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -26,6 +26,7 @@ import type { DiffViewerProps } from './diff-viewer-props'
 import { buildDiffEditorWordWrapOptions } from './diff-editor-word-wrap-options'
 import { useDiffEditorRegistration } from './diff-navigation-context'
 import { preserveDiffViewStateAcrossModelSwaps } from './diff-model-swap-view-state'
+import { monacoFindOptions } from './monaco-find-options'
 
 export default function DiffViewer({
   modelKey,
@@ -429,11 +430,7 @@ export default function DiffViewer({
               renderOverviewRuler: true,
               scrollbar: diffEditorScrollbarOptions,
               padding: { top: 0 },
-              find: {
-                addExtraSpaceOnTop: false,
-                autoFindInSelection: 'never',
-                seedSearchStringFromSelection: 'never'
-              }
+              find: monacoFindOptions
             }}
           />
         )}

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -65,6 +65,7 @@ import {
   isMonacoAutoHeightCapped
 } from './monaco-auto-height'
 import { installMonacoE2EProbe } from './monaco-e2e-probe'
+import { monacoFindOptions } from './monaco-find-options'
 
 type MonacoEditorProps = {
   fileId: string
@@ -848,11 +849,7 @@ export default function MonacoEditor({
           smoothScrolling: true,
           cursorSmoothCaretAnimation: 'off',
           padding: { top: 0 },
-          find: {
-            addExtraSpaceOnTop: false,
-            autoFindInSelection: 'never',
-            seedSearchStringFromSelection: 'never'
-          },
+          find: monacoFindOptions,
           // Why: Monaco owns its rendered line surface, so align its selection-clipboard with the app opt-out (the global DOM hook can't).
           selectionClipboard: settings?.primarySelectionMiddleClickPaste ?? isLinuxUserAgent()
         }}

--- a/src/renderer/src/components/editor/monaco-find-options.test.ts
+++ b/src/renderer/src/components/editor/monaco-find-options.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { monacoFindOptions } from './monaco-find-options'
+
+describe('monacoFindOptions', () => {
+  it('seeds Find only from an explicit selection without changing its layout or scope', () => {
+    expect(monacoFindOptions).toEqual({
+      addExtraSpaceOnTop: false,
+      autoFindInSelection: 'never',
+      seedSearchStringFromSelection: 'selection'
+    })
+  })
+})

--- a/src/renderer/src/components/editor/monaco-find-options.ts
+++ b/src/renderer/src/components/editor/monaco-find-options.ts
@@ -1,0 +1,7 @@
+import type { editor } from 'monaco-editor'
+
+export const monacoFindOptions = {
+  addExtraSpaceOnTop: false,
+  autoFindInSelection: 'never',
+  seedSearchStringFromSelection: 'selection'
+} satisfies editor.IEditorFindOptions


### PR DESCRIPTION
## Summary

- prefill Monaco Find from an explicit non-empty, single-line editor selection
- preserve the previous Find query for empty and multiline selections
- share one typed Find configuration across the file editor and both diff editor implementations

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/monaco-find-options.test.ts src/renderer/src/components/editor/editor-shortcuts.test.ts` (18 tests)
- `pnpm run typecheck:web`
- targeted `oxlint` and `oxfmt --check` on all changed files
- macOS Electron validation on the exact branch instance: source single-line seeding, source selection retention, empty-caret query retention, multiline query retention, and modified diff-pane single-line seeding all passed with zero relevant console errors

Live validation did not repeat empty/multiline cases in the diff pane, exercise the collapsed original diff pane, or cover Linux/Windows/SSH. Those paths share the same Monaco configuration; shortcut matching is covered for macOS, Linux, and Windows by the focused suite.

## Issue

- [STA-2340](https://linear.app/stably/issue/STA-2340/feature-pre-fill-find-widget-with-selected-text-when-pressing-cmdf)
- Closes #9927