### PR TITLE
fix(settings): detect agents on active runtime host

### DIFF
--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -5,7 +5,7 @@ import { useId, useMemo, useState } from 'react'
 import { Check, ChevronDown, ExternalLink, Info, RefreshCw, Terminal } from 'lucide-react'
 import type { GlobalSettings, TuiAgent } from '../../../../shared/types'
 import { getAgentCatalog, AgentIcon } from '@/lib/agent-catalog'
-import { useDetectedAgents } from '@/hooks/useDetectedAgents'
+import { type AgentDetectionTarget, useDetectedAgents } from '@/hooks/useDetectedAgents'
 import { useAppStore } from '@/store'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
@@ -679,7 +679,16 @@ export function AgentsPane({
   wslDistros,
   wslCapabilitiesLoading
 }: AgentsPaneProps): React.JSX.Element {
-  const { detectedIds: detectedList, isRefreshing, refresh } = useDetectedAgents()
+  // Why: Settings → Agents must probe the active runtime host when the user is
+  // working on a remote environment (orca serve / Devbox). Local PATH detection
+  // otherwise hides the remote CLIs even though launches already go remote.
+  const activeRuntimeEnvironmentId = settings.activeRuntimeEnvironmentId?.trim() || null
+  const agentDetectionTarget: AgentDetectionTarget | null = activeRuntimeEnvironmentId
+    ? { kind: 'runtime', environmentId: activeRuntimeEnvironmentId }
+    : null
+  const { detectedIds: detectedList, isRefreshing, refresh } = useDetectedAgents(
+    agentDetectionTarget
+  )
   // Why: refresh re-spawns the user's login shell to re-capture PATH
   // (preflight:refreshAgents on the main side). This handles the
   // "installed a new CLI, Orca doesn't see it yet" case without a restart.

--- a/src/renderer/src/components/settings/OrchestrationSkillAgentCoverage.tsx
+++ b/src/renderer/src/components/settings/OrchestrationSkillAgentCoverage.tsx
@@ -1,7 +1,8 @@
 import type { DiscoveredSkill } from '../../../../shared/skills'
 import type { OrchestrationSkillAgentStatus } from '@/lib/orchestration-skill-coverage'
 import { AgentIcon } from '@/lib/agent-catalog'
-import { useDetectedAgents } from '@/hooks/useDetectedAgents'
+import { type AgentDetectionTarget, useDetectedAgents } from '@/hooks/useDetectedAgents'
+import { useAppStore } from '@/store'
 import { getOrchestrationSkillAgentStatuses } from '@/lib/orchestration-skill-coverage'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
@@ -73,7 +74,16 @@ export function OrchestrationSkillAgentCoverage(props: {
   className?: string
 }): React.JSX.Element {
   const { skills, loading: skillsLoading, embedded = false, className } = props
-  const { detectedIds, isLoading: agentsLoading } = useDetectedAgents()
+  // Why: skill coverage must follow the same host as agent detection/settings.
+  // Without the active runtime target this pane reports laptop PATH while the
+  // user is actually working against a remote orca serve environment.
+  const activeRuntimeEnvironmentId = useAppStore(
+    (s) => s.settings?.activeRuntimeEnvironmentId?.trim() || null
+  )
+  const agentDetectionTarget: AgentDetectionTarget | null = activeRuntimeEnvironmentId
+    ? { kind: 'runtime', environmentId: activeRuntimeEnvironmentId }
+    : null
+  const { detectedIds, isLoading: agentsLoading } = useDetectedAgents(agentDetectionTarget)
   const loading = skillsLoading || agentsLoading || detectedIds === null
   const agentStatuses = getOrchestrationSkillAgentStatuses(skills, detectedIds ?? [])
   const installedCount = agentStatuses.filter((status) => status.installed).length

--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
@@ -102,24 +102,39 @@ function QuickLaunchAgentMenuItemsInner({
   onPromptDelivered
 }: QuickLaunchAgentMenuItemsProps): React.JSX.Element | null {
   // Why: must be a reactive selector (not getConnectionId() which reads a
-  // snapshot via getState()). This ensures the component re-renders when the
-  // SSH / runtime host changes. Prefer explicit SSH connection when present;
-  // otherwise use the worktree's runtime environment (orca serve / Devbox).
-  const agentDetectionTarget = useAppStore((s): AgentDetectionTarget | undefined => {
+  // snapshot via getState()). Prefer SSH when present, otherwise the worktree
+  // runtime environment (orca serve / Devbox). Return a STABLE string key —
+  // a fresh object each render retriggers useDetectedAgents effects (React #185).
+  const agentDetectionTargetKey = useAppStore((s): string | undefined => {
     const connectionId = getConnectionIdFromState(s, worktreeId)
     if (connectionId === undefined) {
       return undefined
     }
     const normalizedConnectionId = connectionId?.trim()
     if (normalizedConnectionId) {
-      return { kind: 'ssh', connectionId: normalizedConnectionId }
+      return `ssh:${normalizedConnectionId}`
     }
     const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(s, worktreeId)?.trim()
     if (runtimeEnvironmentId) {
-      return { kind: 'runtime', environmentId: runtimeEnvironmentId }
+      return `runtime:${runtimeEnvironmentId}`
+    }
+    return 'local'
+  })
+  const agentDetectionTarget = React.useMemo<AgentDetectionTarget | undefined>(() => {
+    if (agentDetectionTargetKey === undefined) {
+      return undefined
+    }
+    if (agentDetectionTargetKey === 'local') {
+      return { kind: 'local' }
+    }
+    if (agentDetectionTargetKey.startsWith('ssh:')) {
+      return { kind: 'ssh', connectionId: agentDetectionTargetKey.slice('ssh:'.length) }
+    }
+    if (agentDetectionTargetKey.startsWith('runtime:')) {
+      return { kind: 'runtime', environmentId: agentDetectionTargetKey.slice('runtime:'.length) }
     }
     return { kind: 'local' }
-  })
+  }, [agentDetectionTargetKey])
   const { detectedIds } = useDetectedAgents(agentDetectionTarget)
   const defaultAgent = useAppStore((s) => s.settings?.defaultTuiAgent)
   const disabledAgents = useAppStore((s) => s.settings?.disabledTuiAgents ?? [])

--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
@@ -5,7 +5,8 @@ import { DropdownMenuItem, DropdownMenuShortcut } from '@/components/ui/dropdown
 import { getAgentCatalog, AgentIcon } from '@/lib/agent-catalog'
 import { useAppStore } from '@/store'
 import { getConnectionIdFromState } from '@/lib/connection-context'
-import { useDetectedAgents } from '@/hooks/useDetectedAgents'
+import { type AgentDetectionTarget, useDetectedAgents } from '@/hooks/useDetectedAgents'
+import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 import { launchAgentInNewTab } from '@/lib/launch-agent-in-new-tab'
 import type { TuiAgent } from '../../../../shared/types'
@@ -102,10 +103,24 @@ function QuickLaunchAgentMenuItemsInner({
 }: QuickLaunchAgentMenuItemsProps): React.JSX.Element | null {
   // Why: must be a reactive selector (not getConnectionId() which reads a
   // snapshot via getState()). This ensures the component re-renders when the
-  // SSH connection state changes. Returns undefined when the worktree isn't
-  // found (store not hydrated), null for local repos, string for remote.
-  const connectionId = useAppStore((s) => getConnectionIdFromState(s, worktreeId))
-  const { detectedIds } = useDetectedAgents(connectionId)
+  // SSH / runtime host changes. Prefer explicit SSH connection when present;
+  // otherwise use the worktree's runtime environment (orca serve / Devbox).
+  const agentDetectionTarget = useAppStore((s): AgentDetectionTarget | undefined => {
+    const connectionId = getConnectionIdFromState(s, worktreeId)
+    if (connectionId === undefined) {
+      return undefined
+    }
+    const normalizedConnectionId = connectionId?.trim()
+    if (normalizedConnectionId) {
+      return { kind: 'ssh', connectionId: normalizedConnectionId }
+    }
+    const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(s, worktreeId)?.trim()
+    if (runtimeEnvironmentId) {
+      return { kind: 'runtime', environmentId: runtimeEnvironmentId }
+    }
+    return { kind: 'local' }
+  })
+  const { detectedIds } = useDetectedAgents(agentDetectionTarget)
   const defaultAgent = useAppStore((s) => s.settings?.defaultTuiAgent)
   const disabledAgents = useAppStore((s) => s.settings?.disabledTuiAgents ?? [])
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)


### PR DESCRIPTION
## Summary
- `AgentsPane` and `OrchestrationSkillAgentCoverage` always called `useDetectedAgents()` with no target, so Settings → Agents probed the **local laptop PATH** even when `activeRuntimeEnvironmentId` pointed at a remote `orca serve` / Devbox host.
- Remote launches already worked; only the detected-agent list was wrong. Mobile/web clients against the same server showed the full remote catalog.
- `QuickLaunchAgentMenuItems` only resolved SSH `connectionId` and missed runtime environments, so the same local-only list could appear in the launch menu for Devbox worktrees.

## Fix
- Pass `{ kind: 'runtime', environmentId }` from `settings.activeRuntimeEnvironmentId` into `useDetectedAgents` in Agents settings + orchestration skill coverage.
- Align Quick Launch with `TabBar`: SSH connection → runtime environment → local.

## Test plan
- [ ] Open Orca desktop with active runtime = remote Devbox / `orca serve`
- [ ] Settings → Agents shows remote-detected CLIs (e.g. Claude, Codex, Cursor, Grok), not only laptop PATH
- [ ] Refresh agents re-probes the runtime host
- [ ] New Agent / Quick Launch menu lists the same remote agents
- [ ] With no active runtime, local PATH detection still works
- [ ] Existing unit mocks for `useDetectedAgents` continue to pass (call-site still compatible)

Closes: remote-only agent list mismatch between desktop settings and mobile/web against the same serve host.


## ELI5

Settings → Agents always scanned your laptop PATH even when the active host was a remote runtime. Agent detection now targets the active runtime host so the list matches what you can actually launch.
