### PR TITLE
perf(worktrees): back off worktree scans for agent-scratch repos

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -56,6 +56,7 @@ import {
   OrcaRuntimeService,
   recentTerminalPathCandidatesIncludePath,
   recentTerminalOutputIncludesPath,
+  resolveWorktreeScanCacheTtlMs,
   type RuntimeTerminalAgentStatusEvent
 } from './orca-runtime'
 import { RecentPtyOutputBuffer } from './recent-pty-output-buffer'
@@ -34977,5 +34978,85 @@ describe('OrcaRuntimeService', () => {
         vi.useRealTimers()
       }
     })
+  })
+})
+
+describe('resolveWorktreeScanCacheTtlMs', () => {
+  const BASE_TTL_MS = 30_000
+  const SCRATCH_TTL_MS = 5 * 60_000
+
+  it('keeps the base TTL for ordinary local repos', () => {
+    expect(
+      resolveWorktreeScanCacheTtlMs({ path: '/Users/dev/projects/app', connectionId: '' })
+    ).toBe(BASE_TTL_MS)
+  })
+
+  it('extends the TTL for agent-scratch repo roots', () => {
+    expect(
+      resolveWorktreeScanCacheTtlMs({
+        path: '/Users/dev/.codex-tmp/foragent-capsule-b1-repo-zP9Az6',
+        connectionId: ''
+      })
+    ).toBe(SCRATCH_TTL_MS)
+    expect(
+      resolveWorktreeScanCacheTtlMs({
+        path: '/Users/dev/.claude/skills/obsidian-second-brain',
+        connectionId: ''
+      })
+    ).toBe(SCRATCH_TTL_MS)
+  })
+
+  it('never extends the TTL for SSH repos', () => {
+    // Why: scratch classification reads local path conventions; a remote path
+    // that merely looks similar must keep normal freshness.
+    expect(
+      resolveWorktreeScanCacheTtlMs({
+        path: '/home/dev/.codex-tmp/capsule',
+        connectionId: 'ssh-1'
+      })
+    ).toBe(BASE_TTL_MS)
+  })
+
+  it('keeps a scratch repo scan cached past the base TTL while normal repos rescan', async () => {
+    // Why: the whole fix lives in the cache-stamp call site; pin the wiring so
+    // a revert to the flat TTL fails CI, not just the pure-function tests.
+    vi.useFakeTimers()
+    // Why: the shared listWorktrees stub keeps call history across this file's
+    // tests; absolute counts need a clean baseline.
+    vi.mocked(listWorktrees).mockClear()
+    try {
+      const scratchPath = '/tmp/.codex-tmp/capsule-a'
+      const runtime = new OrcaRuntimeService({
+        ...store,
+        getRepos: () => [
+          { id: 'repo-1', path: '/tmp/repo', displayName: 'repo', badgeColor: 'blue', addedAt: 1 },
+          {
+            id: 'repo-scratch',
+            path: scratchPath,
+            displayName: 'capsule',
+            badgeColor: 'blue',
+            addedAt: 1
+          }
+        ]
+      } as never)
+      const internals = runtime as unknown as { listResolvedWorktrees: () => Promise<unknown> }
+      const scanCallsFor = (path: string): number =>
+        vi.mocked(listWorktrees).mock.calls.filter((call) => call[0] === path).length
+
+      await internals.listResolvedWorktrees()
+      expect(scanCallsFor('/tmp/repo')).toBe(1)
+      expect(scanCallsFor(scratchPath)).toBe(1)
+
+      vi.advanceTimersByTime(BASE_TTL_MS + 1_000)
+      await internals.listResolvedWorktrees()
+      expect(scanCallsFor('/tmp/repo')).toBe(2)
+      expect(scanCallsFor(scratchPath)).toBe(1)
+
+      vi.advanceTimersByTime(SCRATCH_TTL_MS)
+      await internals.listResolvedWorktrees()
+      expect(scanCallsFor(scratchPath)).toBe(2)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -314,6 +314,7 @@ import {
 } from '../../shared/worktree-ownership'
 import {
   createAgentScratchWorktreePathMatcher,
+  isAgentScratchRepoRootPath,
   type AgentScratchWorktreePathMatcher
 } from '../../shared/agent-scratch-worktrees'
 import {
@@ -23843,7 +23844,7 @@ export class OrcaRuntimeService {
           generation,
           runtimeKey,
           result,
-          expiresAt: Date.now() + WORKTREE_SCAN_CACHE_TTL_MS
+          expiresAt: Date.now() + resolveWorktreeScanCacheTtlMs(repo)
         })
       }
       return result
@@ -29242,7 +29243,17 @@ const DEFAULT_WORKTREE_PS_LIMIT = 200
 const DISCONNECTED_PTY_RECORD_MAX = 128
 const RESOLVED_WORKTREE_CACHE_TTL_MS = 1000
 const WORKTREE_SCAN_CACHE_TTL_MS = 30_000
+// Why: agent-scratch repos don't need 30s freshness — the steady-state scan
+// fan-out was measured at ~128 git execs/min on real installs, mostly against
+// these (crash-cluster diagnostics, 2026-07).
+const WORKTREE_SCAN_AGENT_SCRATCH_TTL_MS = 5 * 60_000
 const RESOLVED_WORKTREE_REPO_TIMEOUT_MS = 5000
+
+export function resolveWorktreeScanCacheTtlMs(repo: Pick<Repo, 'path' | 'connectionId'>): number {
+  return !repo.connectionId && isAgentScratchRepoRootPath(repo.path)
+    ? WORKTREE_SCAN_AGENT_SCRATCH_TTL_MS
+    : WORKTREE_SCAN_CACHE_TTL_MS
+}
 const PTY_CONTROLLER_LIST_TIMEOUT_MS = 3000
 // Why: the renderer waits 15s; leave room for the verified failure response and release the spawn fence before its caller times out.
 const WORKTREE_TERMINAL_SLEEP_TIMEOUT_MS = 12_000

--- a/src/shared/agent-scratch-worktrees.test.ts
+++ b/src/shared/agent-scratch-worktrees.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   createAgentScratchWorktreePathMatcher,
+  isAgentScratchRepoRootPath,
   isAgentScratchWorktreePath
 } from './agent-scratch-worktrees'
 
@@ -99,5 +100,46 @@ describe('isAgentScratchWorktreePath', () => {
       isAgentScratchWorktreePath('/Users/dev/app', '/Users/dev/.superset/worktrees/app/fix-notes')
     ).toBe(false)
     expect(isAgentScratchWorktreePath('/Users/dev/app', '/orca/workspaces/app/feature')).toBe(false)
+  })
+})
+
+describe('isAgentScratchRepoRootPath', () => {
+  it('matches codex scratch capsule repos', () => {
+    expect(
+      isAgentScratchRepoRootPath('/Users/dev/.codex-tmp/foragent-capsule-b1-repo-zP9Az6')
+    ).toBe(true)
+    expect(isAgentScratchRepoRootPath('/Users/dev/.codex-tmp/rc-fwd-qEXuEq')).toBe(true)
+  })
+
+  it('matches codex vendor imports and claude skills containers', () => {
+    expect(isAgentScratchRepoRootPath('/Users/dev/.codex/vendor_imports/skills')).toBe(true)
+    expect(isAgentScratchRepoRootPath('/Users/dev/.claude/skills/obsidian-second-brain')).toBe(true)
+  })
+
+  it('matches a repo registered at the scratch container itself', () => {
+    expect(isAgentScratchRepoRootPath('/Users/dev/.codex-tmp')).toBe(true)
+    expect(isAgentScratchRepoRootPath('/Users/dev/.codex/vendor_imports')).toBe(true)
+  })
+
+  it('matches scratch worktree containers used as repo roots', () => {
+    expect(isAgentScratchRepoRootPath('/Users/dev/app/.claude/worktrees/agent-a04ccaaa')).toBe(true)
+    expect(isAgentScratchRepoRootPath('/Users/dev/app/.gsd-workspaces/phase-1')).toBe(true)
+  })
+
+  it('matches Windows separators and casing', () => {
+    expect(isAgentScratchRepoRootPath('C:\\Users\\Dev\\.codex-tmp\\Capsule-X')).toBe(true)
+    expect(isAgentScratchRepoRootPath('C:\\Users\\Dev\\.Claude\\Skills\\foo')).toBe(true)
+  })
+
+  it('does not match ordinary user repos', () => {
+    expect(isAgentScratchRepoRootPath('/Users/dev/projects/app')).toBe(false)
+    expect(isAgentScratchRepoRootPath('/Users/dev/codex-tmp/app')).toBe(false)
+    expect(isAgentScratchRepoRootPath('/Users/dev/.codex/checkouts/app')).toBe(false)
+    expect(isAgentScratchRepoRootPath('/Users/dev/skills/.claude-app')).toBe(false)
+  })
+
+  it('does not match partial multi-segment markers', () => {
+    expect(isAgentScratchRepoRootPath('/Users/dev/.claude/config')).toBe(false)
+    expect(isAgentScratchRepoRootPath('/Users/dev/vendor_imports/app')).toBe(false)
   })
 })

--- a/src/shared/agent-scratch-worktrees.ts
+++ b/src/shared/agent-scratch-worktrees.ts
@@ -37,3 +37,27 @@ export function createAgentScratchWorktreePathMatcher(
 export function isAgentScratchWorktreePath(repoPath: string, worktreePath: string): boolean {
   return createAgentScratchWorktreePathMatcher([repoPath])(worktreePath)
 }
+
+/** Why: agent CLIs also mint whole scratch *repos* under these containers; a
+ *  repo registered at such a root is agent-internal, not a user project (#9388). */
+const AGENT_SCRATCH_REPO_ROOT_SEGMENTS: readonly (readonly string[])[] = [
+  ['.codex-tmp'],
+  ['.codex', 'vendor_imports'],
+  ['.claude', 'skills'],
+  ...AGENT_SCRATCH_PATH_PREFIXES
+]
+
+export function isAgentScratchRepoRootPath(repoPath: string): boolean {
+  const segments = normalizeRuntimePathForComparison(repoPath).split('/')
+  for (const marker of AGENT_SCRATCH_REPO_ROOT_SEGMENTS) {
+    // Why: match the marker anywhere above the repo root (the repo lives at or
+    // under the scratch container), unlike worktree matching which anchors to a
+    // registered checkout path.
+    for (let index = 0; index + marker.length <= segments.length; index += 1) {
+      if (marker.every((segment, offset) => segments[index + offset] === segment)) {
+        return true
+      }
+    }
+  }
+  return false
+}


### PR DESCRIPTION
## What & why

Crash-channel diagnostics from the renderer-OOM cluster surfaced a main-process problem along the way: one production install executed **10,216 git commands in 80 minutes (~128/min, 757s of git busy time — ~16% of wall-clock)**, 92% of them `git worktree list --porcelain`. The resolved-worktree scan (`computeResolvedWorktrees`) fans out over **every** registered repo on a 30-second per-repo cache TTL — and on the affected installs, most registered repos were **agent-CLI scratch repos** (`~/.codex-tmp/foragent-capsule-*`, `~/.codex/vendor_imports`, `~/.claude/skills/*`) that were registered once (nested-repo import) and never need 30-second freshness. #9535 hides agent-scratch rows from the sidebar, but the scan layer still shelled out to all of them every cycle, forever.

**Fix:** classify agent-scratch repo *roots* with the same curated shared-matcher pattern #9535 introduced (`isAgentScratchRepoRootPath`), and stamp their scan-cache entries with a **5-minute TTL** instead of 30 seconds (`resolveWorktreeScanCacheTtlMs`, wired at the single cache-stamp site).

Nothing is skipped or hidden: scratch repos still scan — just 10× less often.

## CLEAR fix evidence

- **Wiring test (fails without the fix):** with fake timers and a two-repo store (normal + `/tmp/.codex-tmp/capsule-a`), advancing 31s re-scans the normal repo but *not* the scratch repo; advancing +5min re-scans the scratch repo. Reverting the one-line cache-stamp wiring makes this test fail (`expected 2 to be 1`) — verified both directions.
- **Quantified impact (perf review):** on the measured install (~59 repos, ~54 scratch): ~118 scans/min → **~21/min, an ~82% reduction** in steady-state git subprocess spawns.
- Matcher: 17/17 tests (POSIX/Windows/WSL paths, negatives). Runtime file: **827/827** full-file, verified across multiple runs. Node typecheck + oxlint/oxfmt clean.

## ELI5

Orca keeps a list of every project folder it has ever been shown, and every 30 seconds it walks the whole list asking git "anything new here?". On some machines, most of that list is temporary scratch folders that coding agents made for themselves — nobody is working in them, but Orca still knocked on every door twice a minute, thousands of times an hour. Now Orca recognizes those agent scratch folders and only checks them every 5 minutes. Real project folders keep the fast checks, and anything you do *inside* Orca still updates instantly.

## Trade-offs

- **One deliberate behavior change, tightly bounded:** a change made *outside* Orca (e.g. a CLI adding a worktree by hand) inside an agent-scratch repo can take up to 5 minutes to appear instead of 30 seconds. Every Orca-driven action (create/remove/repo change) bypasses the TTL via the per-repo generation bump and refreshes instantly — verified in review against all mutation call sites.
- **Fail-safe misclassification:** a legitimately-registered repo under a scratch container (e.g. developing a skill in `~/.claude/skills/x`) only gets slower *passive* pickup — never missing rows, never wrong data.
- Known limits (documented, deliberate): SSH-hosted scratch repos keep the 30s cadence (classification reads local path conventions only), and a case-variant scratch path on macOS keeps the base TTL (safe-fail: missed optimization only).

## Adversarial review & perf

- **Adversarial loop: 3 rounds → CLEAN** (fresh sub-agent each round).
  - Round 1: CLEAN + one actionable minor — the cache-stamp wiring wasn't test-protected. Wiring test added.
  - Round 2: **caught a real blocker in that new test** — it asserted absolute counts against a shared mock whose history accumulates across the 35k-line file, so it passed in isolation but failed deterministically in a full-file (CI-shaped) run. Fixed with a baseline `mockClear()` matching the file's convention.
  - Round 3: verified closure — two full-file runs 827/827, order-independence confirmed, source diff confirmed unchanged since round 1.
- **Perf review (perf skill, sub-agent): CLEAN** — smallest correct fix for the measured waste; 5-min constant validated (bounded blast radius beats a longer TTL); matcher cost trivial (runs only at the stamp site, never on the cache-hit path).

## Follow-ups (ranked by the perf review, not this PR)

1. Focus/visibility gating of the runtime resolution poll (biggest remaining lever; cross-cutting with mobile/SSH startup paths).
2. Apply the same scratch segmentation to the IPC-layer 5s scan cache (UI-request-driven, not the measured steady-state source).
3. Extend classification to SSH once remote scratch conventions are validated.
4. Registration hygiene for repos whose path no longer exists (product decision: auto-deregistration needs buy-in).
