### PR TITLE
fix(ssh): degrade Windows relay node-pty patch on source drift instead of bricking deploy

### DIFF
--- a/config/relay-assets/node-pty-1.1.0-console-list-agent-patch.cjs
+++ b/config/relay-assets/node-pty-1.1.0-console-list-agent-patch.cjs
@@ -15,57 +15,116 @@ catch (_a) {
     consoleProcessList = [shellPid];
 }`
 
-function inspectNodePtyConsoleListAgent(relayDir = process.cwd()) {
-  const nodePtyDir = resolve(relayDir, 'node_modules', 'node-pty')
-  const packageJsonPath = join(nodePtyDir, 'package.json')
-  const agentPath = join(nodePtyDir, 'lib', 'conpty_console_list_agent.js')
-  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
-  if (packageJson.version !== EXPECTED_NODE_PTY_VERSION) {
-    throw new Error(
-      `Refusing to patch node-pty ${packageJson.version}; expected ${EXPECTED_NODE_PTY_VERSION}`
-    )
-  }
-  const source = readFileSync(agentPath, 'utf8')
-  return { agentPath, source }
-}
-
-function assertPatchedNodePtyConsoleListAgent(relayDir = process.cwd()) {
-  const inspected = inspectNodePtyConsoleListAgent(relayDir)
-  if (sourceSha256(inspected.source) !== PATCHED_SOURCE_SHA256) {
-    throw new Error('node-pty ConPTY console-list fallback is not installed')
-  }
-}
-
-function patchNodePtyConsoleListAgent(relayDir = process.cwd()) {
-  const inspected = inspectNodePtyConsoleListAgent(relayDir)
-  const sourceHash = sourceSha256(inspected.source)
-  if (sourceHash === PATCHED_SOURCE_SHA256) {
-    return
-  }
-  if (sourceHash !== ORIGINAL_SOURCE_SHA256) {
-    throw new Error('Refusing to patch unexpected node-pty console-list agent source')
-  }
-  const patchedSource = inspected.source.replace(ORIGINAL_BODY, PATCHED_BODY)
-  const temporaryPath = `${inspected.agentPath}.orca-patch-${process.pid}`
-  // Why: a terminated remote install must leave either known source version recoverable on reconnect.
-  try {
-    writeFileSync(temporaryPath, patchedSource)
-    renameSync(temporaryPath, inspected.agentPath)
-  } finally {
-    rmSync(temporaryPath, { force: true })
-  }
-  assertPatchedNodePtyConsoleListAgent(relayDir)
-}
+// Distinct, catchable outcomes so the deploy path can proceed on drift instead of hard-failing.
+// Fail-OPEN posture (audit follow-up to PR #9638): if the freshly npm-installed source is neither
+// the recognized ORIGINAL nor PATCHED sha, we REFUSE to mutate it (the sha gate stays intact) and
+// run node-pty unpatched. That loses only the Windows ConPTY `AttachConsole`-failure try/catch
+// fallback — a functionality degradation, NOT a security bypass. We never string-replace or mark
+// an unrecognized/foreign source as patched.
+const PATCH_OUTCOME = Object.freeze({
+  PATCHED: 'patched',
+  ALREADY_PATCHED: 'already-patched',
+  UNPATCHED_ORIGINAL: 'unpatched-original',
+  SKIPPED_UNEXPECTED_SOURCE: 'skipped-unexpected-source',
+  SKIPPED_UNEXPECTED_VERSION: 'skipped-unexpected-version'
+})
 
 function sourceSha256(source) {
   return createHash('sha256').update(source).digest('hex')
 }
 
+function readNodePtyConsoleListAgent(relayDir) {
+  const nodePtyDir = resolve(relayDir, 'node_modules', 'node-pty')
+  const packageJsonPath = join(nodePtyDir, 'package.json')
+  const agentPath = join(nodePtyDir, 'lib', 'conpty_console_list_agent.js')
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
+  const source = readFileSync(agentPath, 'utf8')
+  return { agentPath, source, version: packageJson.version }
+}
+
+// Classify the installed console-list agent WITHOUT mutating it and WITHOUT throwing on drift.
+// Throws only if node-pty itself is absent/unreadable — that is a genuine native-deps failure the
+// caller detects via require("node-pty"), not a patch concern.
+function classifyNodePtyConsoleListAgent(relayDir = process.cwd()) {
+  const read = readNodePtyConsoleListAgent(relayDir)
+  const sha256 = sourceSha256(read.source)
+  const base = {
+    agentPath: read.agentPath,
+    source: read.source,
+    version: read.version,
+    sha256,
+    sha256Prefix: sha256.slice(0, 12)
+  }
+  // Version drift can only come from an internal pin edit that forgot to bump this file's
+  // EXPECTED_NODE_PTY_VERSION (external registry drift keeps version 1.1.0 and hits the source path).
+  // Degrade rather than brick; the distinct outcome keeps the pin-drift visible in telemetry.
+  if (read.version !== EXPECTED_NODE_PTY_VERSION) {
+    return { ...base, outcome: PATCH_OUTCOME.SKIPPED_UNEXPECTED_VERSION }
+  }
+  if (sha256 === PATCHED_SOURCE_SHA256) {
+    return { ...base, outcome: PATCH_OUTCOME.ALREADY_PATCHED }
+  }
+  if (sha256 === ORIGINAL_SOURCE_SHA256) {
+    return { ...base, outcome: PATCH_OUTCOME.UNPATCHED_ORIGINAL }
+  }
+  return { ...base, outcome: PATCH_OUTCOME.SKIPPED_UNEXPECTED_SOURCE }
+}
+
+function isPatchSkippedOutcome(outcome) {
+  return (
+    outcome === PATCH_OUTCOME.SKIPPED_UNEXPECTED_SOURCE ||
+    outcome === PATCH_OUTCOME.SKIPPED_UNEXPECTED_VERSION
+  )
+}
+
+function assertPatchedNodePtyConsoleListAgent(relayDir = process.cwd()) {
+  const read = readNodePtyConsoleListAgent(relayDir)
+  if (sourceSha256(read.source) !== PATCHED_SOURCE_SHA256) {
+    throw new Error('node-pty ConPTY console-list fallback is not installed')
+  }
+}
+
+// Returns the outcome instead of throwing on drift so the SSH relay deploy can degrade (run
+// unpatched) rather than brick. Known-original source is still patched via the atomic
+// temp-file+rename write and re-asserted against PATCHED_SOURCE_SHA256 (unchanged happy path).
+function patchNodePtyConsoleListAgent(relayDir = process.cwd()) {
+  const classified = classifyNodePtyConsoleListAgent(relayDir)
+  if (classified.outcome === PATCH_OUTCOME.ALREADY_PATCHED) {
+    return classified
+  }
+  if (isPatchSkippedOutcome(classified.outcome)) {
+    // Fail-OPEN: never mutate source we don't recognize; caller runs node-pty unpatched + reports.
+    return classified
+  }
+  const patchedSource = classified.source.replace(ORIGINAL_BODY, PATCHED_BODY)
+  const temporaryPath = `${classified.agentPath}.orca-patch-${process.pid}`
+  // Why: a terminated remote install must leave either known source version recoverable on reconnect.
+  try {
+    writeFileSync(temporaryPath, patchedSource)
+    renameSync(temporaryPath, classified.agentPath)
+  } finally {
+    rmSync(temporaryPath, { force: true })
+  }
+  assertPatchedNodePtyConsoleListAgent(relayDir)
+  return { ...classified, outcome: PATCH_OUTCOME.PATCHED, sha256: PATCHED_SOURCE_SHA256 }
+}
+
 if (require.main === module) {
-  patchNodePtyConsoleListAgent()
+  // Fail-OPEN on drift: exit 0 so the remote install command does not abort the whole deploy.
+  // The deploy probe re-detects the skip and emits telemetry on the Orca side (no sink here).
+  const result = patchNodePtyConsoleListAgent()
+  if (isPatchSkippedOutcome(result.outcome)) {
+    console.warn(
+      `[orca-relay] node-pty ConPTY console-list patch skipped (${result.outcome}); running unpatched. ` +
+        `sha=${result.sha256Prefix} version=${result.version}`
+    )
+  }
 }
 
 module.exports = {
+  PATCH_OUTCOME,
   assertPatchedNodePtyConsoleListAgent,
+  classifyNodePtyConsoleListAgent,
+  isPatchSkippedOutcome,
   patchNodePtyConsoleListAgent
 }

--- a/config/scripts/node-pty-console-list-agent-patch.test.mjs
+++ b/config/scripts/node-pty-console-list-agent-patch.test.mjs
@@ -5,7 +5,9 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 const require = createRequire(import.meta.url)
 const {
+  PATCH_OUTCOME,
   assertPatchedNodePtyConsoleListAgent,
+  classifyNodePtyConsoleListAgent,
   patchNodePtyConsoleListAgent
 } = require('../relay-assets/node-pty-1.1.0-console-list-agent-patch.cjs')
 const projectDir = resolve(import.meta.dirname, '..', '..')
@@ -18,26 +20,49 @@ afterEach(() => {
 })
 
 describe('Windows SSH relay node-pty console-list patch', () => {
-  it('installs and verifies the fallback idempotently', () => {
+  it('installs and verifies the fallback idempotently (known original -> patched)', () => {
     const fixture = writeNodePtyFixture('1.1.0', publishedAgentSource())
 
-    patchNodePtyConsoleListAgent(fixture.root)
+    expect(classifyNodePtyConsoleListAgent(fixture.root).outcome).toBe(
+      PATCH_OUTCOME.UNPATCHED_ORIGINAL
+    )
+
+    const firstResult = patchNodePtyConsoleListAgent(fixture.root)
+    expect(firstResult.outcome).toBe(PATCH_OUTCOME.PATCHED)
     const once = readFileSync(fixture.agentPath, 'utf8')
     expect(once).toContain('consoleProcessList = [shellPid];')
     expect(existsSync(`${fixture.agentPath}.orca-patch-${process.pid}`)).toBe(false)
     expect(() => assertPatchedNodePtyConsoleListAgent(fixture.root)).not.toThrow()
 
-    patchNodePtyConsoleListAgent(fixture.root)
+    // Already patched -> no-op, source byte-identical.
+    const secondResult = patchNodePtyConsoleListAgent(fixture.root)
+    expect(secondResult.outcome).toBe(PATCH_OUTCOME.ALREADY_PATCHED)
+    expect(classifyNodePtyConsoleListAgent(fixture.root).outcome).toBe(
+      PATCH_OUTCOME.ALREADY_PATCHED
+    )
     expect(readFileSync(fixture.agentPath, 'utf8')).toBe(once)
   })
 
-  it('refuses a different package version or unexpected agent source', () => {
+  it('degrades instead of throwing on unexpected source or version drift (fail-open)', () => {
+    // Unexpected source: neither the recognized original nor patched sha. The sha gate must REFUSE
+    // to mutate it — degrade (skip) and leave the source byte-for-byte unchanged, never patched.
+    const driftedSource = `${publishedAgentSource()}\n// drift`
+    const drifted = writeNodePtyFixture('1.1.0', driftedSource)
+    const driftResult = patchNodePtyConsoleListAgent(drifted.root)
+    expect(driftResult.outcome).toBe(PATCH_OUTCOME.SKIPPED_UNEXPECTED_SOURCE)
+    expect(driftResult.sha256Prefix).toMatch(/^[0-9a-f]{12}$/)
+    expect(readFileSync(drifted.agentPath, 'utf8')).toBe(driftedSource)
+
+    // Unexpected version: the pinned 1.1.0-specific patch cannot apply; degrade with a distinct
+    // outcome so internal pin-drift stays visible in telemetry. Source stays unchanged.
     const wrongVersion = writeNodePtyFixture('1.2.0-beta.11', publishedAgentSource())
-    expect(() => patchNodePtyConsoleListAgent(wrongVersion.root)).toThrow('expected 1.1.0')
+    const versionResult = patchNodePtyConsoleListAgent(wrongVersion.root)
+    expect(versionResult.outcome).toBe(PATCH_OUTCOME.SKIPPED_UNEXPECTED_VERSION)
+    expect(versionResult.version).toBe('1.2.0-beta.11')
+    expect(readFileSync(wrongVersion.agentPath, 'utf8')).toBe(publishedAgentSource())
+  })
 
-    const drifted = writeNodePtyFixture('1.1.0', `${publishedAgentSource()}\n// drift`)
-    expect(() => patchNodePtyConsoleListAgent(drifted.root)).toThrow('unexpected node-pty')
-
+  it('still reports the patched fallback as not installed after tampering', () => {
     const tamperedPatch = writeNodePtyFixture('1.1.0', publishedAgentSource())
     patchNodePtyConsoleListAgent(tamperedPatch.root)
     writeFileSync(tamperedPatch.agentPath, `${readFileSync(tamperedPatch.agentPath)}\n// drift`)

--- a/src/main/ssh/ssh-relay-deploy-native-deps-probe.test.ts
+++ b/src/main/ssh/ssh-relay-deploy-native-deps-probe.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Why: ssh-relay-deploy imports `electron` (app) and the telemetry client at module load; mock both
+// so the pure probe helpers can be exercised without an Electron runtime or a live posthog client.
+vi.mock('electron', () => ({
+  app: { getAppPath: () => '/mock/app' }
+}))
+
+vi.mock('../telemetry/client', () => ({
+  track: vi.fn()
+}))
+
+import { __nativeDepsProbeTestables } from './ssh-relay-deploy'
+import { track } from '../telemetry/client'
+import type { RemoteHostPlatform } from './ssh-remote-platform'
+
+const {
+  NATIVE_DEPS_MISSING_PREFIX,
+  NODE_PTY_PATCH_SKIPPED_PREFIX,
+  nativeDepsProbeJs,
+  missingNativeDepsFromProbe,
+  parseNodePtyPatchSkipSignal,
+  reportNodePtyPatchSkipFromProbe
+} = __nativeDepsProbeTestables
+
+const OK_TOKEN = 'ORCA-NATIVE-DEPS-OK'
+const win32HostPlatform = { relayPlatform: 'win32-x64' } as unknown as RemoteHostPlatform
+
+describe('native-deps probe: node-pty console-list patch drift (issue #9638)', () => {
+  beforeEach(() => {
+    vi.mocked(track).mockClear()
+  })
+
+  it('classifies the patch separately so an UNEXPECTED source degrades, not fails, node-pty', () => {
+    const probeJs = nativeDepsProbeJs(OK_TOKEN)
+    expect(probeJs).toContain('classifyNodePtyConsoleListAgent(process.cwd())')
+    // Only a recognized-but-unpatched original re-marks node-pty missing (repair re-applies).
+    expect(probeJs).toContain('c.outcome==="unpatched-original"')
+    expect(probeJs).toContain(NODE_PTY_PATCH_SKIPPED_PREFIX)
+    // The classification only runs once node-pty itself loaded.
+    expect(probeJs).toContain('if(nptyOk&&process.platform==="win32")')
+  })
+
+  it('(c) UNEXPECTED source: node-pty stays available and a skip signal is present', () => {
+    const output = `${NODE_PTY_PATCH_SKIPPED_PREFIX}skipped-unexpected-source:0d010879bb66:1.1.0\n${OK_TOKEN}`
+
+    // Degraded, not missing: the probe still emits the OK token, so the deploy proceeds and no dep
+    // is flagged missing — the skip token never suppresses the success signal.
+    expect(output.includes(OK_TOKEN)).toBe(true)
+    expect(output.includes(NATIVE_DEPS_MISSING_PREFIX)).toBe(false)
+
+    expect(parseNodePtyPatchSkipSignal(output)).toEqual({
+      reason: 'unexpected_source',
+      sha256Prefix: '0d010879bb66',
+      version: '1.1.0'
+    })
+
+    reportNodePtyPatchSkipFromProbe(win32HostPlatform, output)
+    expect(track).toHaveBeenCalledWith('relay_node_pty_patch_skipped', {
+      reason: 'unexpected_source',
+      node_pty_version: '1.1.0',
+      source_sha_prefix: '0d010879bb66',
+      relay_platform: 'win32-x64'
+    })
+  })
+
+  it('(c) UNEXPECTED version reports a distinct telemetry reason', () => {
+    const output = `${NODE_PTY_PATCH_SKIPPED_PREFIX}skipped-unexpected-version:abcdef012345:1.2.0-beta.11\n${OK_TOKEN}`
+    expect(parseNodePtyPatchSkipSignal(output)?.reason).toBe('unexpected_version')
+
+    reportNodePtyPatchSkipFromProbe(win32HostPlatform, output)
+    expect(track).toHaveBeenCalledWith(
+      'relay_node_pty_patch_skipped',
+      expect.objectContaining({ reason: 'unexpected_version', node_pty_version: '1.2.0-beta.11' })
+    )
+  })
+
+  it('(d) node-pty missing entirely is still reported as missing (deploy stays fatal)', () => {
+    const output = `${NATIVE_DEPS_MISSING_PREFIX}node-pty`
+    expect(missingNativeDepsFromProbe(output)).toEqual(['node-pty'])
+    // A genuine node-pty failure carries no patch-skip signal, so no degrade telemetry fires.
+    expect(parseNodePtyPatchSkipSignal(output)).toBeNull()
+    reportNodePtyPatchSkipFromProbe(win32HostPlatform, output)
+    expect(track).not.toHaveBeenCalled()
+  })
+
+  it('healthy output emits no drift telemetry', () => {
+    reportNodePtyPatchSkipFromProbe(win32HostPlatform, OK_TOKEN)
+    expect(track).not.toHaveBeenCalled()
+    expect(parseNodePtyPatchSkipSignal(OK_TOKEN)).toBeNull()
+  })
+})

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -28,6 +28,7 @@ import {
   waitForRelayGcClaimRelease
 } from './ssh-relay-gc-claim'
 import { NATIVE_DEPS_COMMAND_TIMEOUT_MS, RELAY_DEPLOY_TIMEOUT_MS } from './ssh-relay-deploy-timing'
+import { track } from '../telemetry/client'
 import { createSshOperationAbortError, shellEscape } from './ssh-connection-utils'
 import {
   probeBuildToolchain,
@@ -513,18 +514,101 @@ const RELAY_NATIVE_DEPS = {
 type RelayNativeDepName = keyof typeof RELAY_NATIVE_DEPS
 const RELAY_NATIVE_DEP_NAMES = Object.keys(RELAY_NATIVE_DEPS) as RelayNativeDepName[]
 const NATIVE_DEPS_MISSING_PREFIX = 'ORCA-NATIVE-DEPS-MISSING:'
+// Why: the probe runs inside a remote node one-liner with no telemetry sink; it prints this token so
+// the local (Orca) side that parses the probe output can emit `relay_node_pty_patch_skipped`.
+// Mirrors NATIVE_DEPS_MISSING_PREFIX. Payload: `<prefix><outcome>:<sha12>:<node-pty version>`.
+const NODE_PTY_PATCH_SKIPPED_PREFIX = 'ORCA-NODE-PTY-PATCH-SKIPPED:'
 
 // Why: npm 12 blocks dependency lifecycle scripts unless each exact package version is approved, even with ignore-scripts disabled.
 const RELAY_NATIVE_DEP_SCRIPT_ALLOWLIST = Object.fromEntries(
   Object.entries(RELAY_NATIVE_DEPS).map(([name, version]) => [`${name}@${version}`, true])
 )
 
+// Test surface: the probe one-liner and its output parsers are pure and covered directly.
+export const __nativeDepsProbeTestables = {
+  get NATIVE_DEPS_MISSING_PREFIX(): string {
+    return NATIVE_DEPS_MISSING_PREFIX
+  },
+  get NODE_PTY_PATCH_SKIPPED_PREFIX(): string {
+    return NODE_PTY_PATCH_SKIPPED_PREFIX
+  },
+  nativeDepsProbeJs: (successToken: string): string => nativeDepsProbeJs(successToken),
+  missingNativeDepsFromProbe: (output: string): RelayNativeDepName[] =>
+    missingNativeDepsFromProbe(output),
+  parseNodePtyPatchSkipSignal: (output: string): NodePtyPatchSkipSignal | null =>
+    parseNodePtyPatchSkipSignal(output),
+  reportNodePtyPatchSkipFromProbe: (hostPlatform: RemoteHostPlatform, output: string): void =>
+    reportNodePtyPatchSkipFromProbe(hostPlatform, output)
+}
+
 function nativeDepsProbeJs(successToken: string): string {
   // Why: node-pty's Windows wrapper defers conpty.node until first spawn, so require("node-pty") alone can't prove the binding is healthy.
   const loadNodePty =
-    'require("node-pty"); require("node-pty/lib/utils").loadNativeModule(process.platform==="win32"&&Number(require("os").release().split(".")[2])>=18309?"conpty":"pty");' +
-    `if(process.platform==="win32"){require("./${NODE_PTY_CONSOLE_LIST_PATCH_FILENAME}").assertPatchedNodePtyConsoleListAgent(process.cwd())}`
-  return `(()=>{const missing=[];try{${loadNodePty}}catch{missing.push("node-pty")}try{require("@parcel/watcher")}catch{missing.push("@parcel/watcher")}if(missing.length){console.log("${NATIVE_DEPS_MISSING_PREFIX}"+missing.join(","));process.exitCode=1}else{console.log(${JSON.stringify(successToken)})}})()`
+    'require("node-pty");require("node-pty/lib/utils").loadNativeModule(process.platform==="win32"&&Number(require("os").release().split(".")[2])>=18309?"conpty":"pty");'
+  // Why: classify the ConPTY console-list patch SEPARATELY from the node-pty load so source/version
+  // drift does not fail an otherwise-healthy node-pty. A recognized-but-unpatched original still
+  // counts as node-pty-missing so the repair path re-applies the patch (unchanged behavior); an
+  // UNEXPECTED source/version degrades — node-pty stays available and we print a skip token the
+  // local side turns into telemetry (never a hard failure).
+  const classifyPatch =
+    `try{var c=require("./${NODE_PTY_CONSOLE_LIST_PATCH_FILENAME}").classifyNodePtyConsoleListAgent(process.cwd());` +
+    `if(c.outcome==="unpatched-original"){missing.push("node-pty")}` +
+    `else if(c.outcome!=="patched"&&c.outcome!=="already-patched"){` +
+    `console.log(${JSON.stringify(NODE_PTY_PATCH_SKIPPED_PREFIX)}+c.outcome+":"+c.sha256Prefix+":"+c.version)}}` +
+    `catch{missing.push("node-pty")}`
+  return `(()=>{const missing=[];let nptyOk=false;try{${loadNodePty}nptyOk=true}catch{missing.push("node-pty")}if(nptyOk&&process.platform==="win32"){${classifyPatch}}try{require("@parcel/watcher")}catch{missing.push("@parcel/watcher")}if(missing.length){console.log("${NATIVE_DEPS_MISSING_PREFIX}"+missing.join(","));process.exitCode=1}else{console.log(${JSON.stringify(successToken)})}})()`
+}
+
+type NodePtyPatchSkipSignal = {
+  reason: 'unexpected_source' | 'unexpected_version'
+  sha256Prefix: string
+  version: string
+}
+
+// Parse the skip token the remote probe prints when it degrades to unpatched node-pty. Returns null
+// when no drift was observed (the healthy path). Robust to trailing output on the same line.
+function parseNodePtyPatchSkipSignal(output: string): NodePtyPatchSkipSignal | null {
+  const line = output
+    .split(/\r?\n/)
+    .find((entry) => entry.trim().startsWith(NODE_PTY_PATCH_SKIPPED_PREFIX))
+  if (!line) {
+    return null
+  }
+  const [outcome, sha256Prefix, ...versionParts] = line
+    .trim()
+    .slice(NODE_PTY_PATCH_SKIPPED_PREFIX.length)
+    .split(':')
+  const version = versionParts.join(':')
+  if (!sha256Prefix || !version) {
+    return null
+  }
+  const reason =
+    outcome === 'skipped-unexpected-version' ? 'unexpected_version' : 'unexpected_source'
+  return { reason, sha256Prefix, version }
+}
+
+// Emit `relay_node_pty_patch_skipped` on the local side when the remote probe reported drift. The
+// deploy still succeeds (node-pty runs unpatched); this only makes the degradation observable.
+function reportNodePtyPatchSkipFromProbe(hostPlatform: RemoteHostPlatform, output: string): void {
+  const signal = parseNodePtyPatchSkipSignal(output)
+  if (!signal) {
+    return
+  }
+  const relayPlatform = hostPlatform.relayPlatform
+  console.warn(
+    `[ssh-relay] node-pty ConPTY console-list patch skipped (${signal.reason}) on ${relayPlatform}; ` +
+      `running unpatched. sha=${signal.sha256Prefix} node-pty=${signal.version}`
+  )
+  // Why: the skip token only prints on win32; guard the enum so a malformed value drops cleanly.
+  if (relayPlatform !== 'win32-x64' && relayPlatform !== 'win32-arm64') {
+    return
+  }
+  track('relay_node_pty_patch_skipped', {
+    reason: signal.reason,
+    node_pty_version: signal.version.slice(0, 64),
+    source_sha_prefix: signal.sha256Prefix.slice(0, 32),
+    relay_platform: relayPlatform
+  })
 }
 
 function missingNativeDepsFromProbe(output: string): RelayNativeDepName[] {
@@ -562,6 +646,7 @@ async function probeRequiredNativeDeps(
           `(${escapedNode} -e ${shellEscape(probeJs)} 2>/dev/null || echo MISSING)`
         )
     const probe = await execHostCommand(conn, hostPlatform, command, { signal })
+    reportNodePtyPatchSkipFromProbe(hostPlatform, probe)
     const available = probe.includes('ORCA-NATIVE-DEPS-OK')
     return { available, missing: available ? [] : missingNativeDepsFromProbe(probe) }
   } catch {
@@ -913,6 +998,7 @@ async function probeInstalledNativeDeps(
         `(${shellEscape(nodePath)} -e ${shellEscape(probeJs)} ${shellEscape(PROBE_OK)} 2>${escapedStderr} || echo MISSING)`
       )
   const probeOutput = await execHostCommand(conn, hostPlatform, probeCommand, { signal })
+  reportNodePtyPatchSkipFromProbe(hostPlatform, probeOutput)
   const remoteStderr =
     probeOutput.includes(PROBE_OK) || isWindowsRemoteHost(hostPlatform)
       ? ''

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -364,6 +364,20 @@ const agentErrorSchema = z
 // Why: daemon start-failure signal (fleet-wide outage like v1.4.129-rc.1); enum-only so raw stderr never reaches the wire.
 const daemonStartFailedSchema = z.object({ error_class: errorClassSchema }).strict()
 
+// Why: surfaces Windows SSH relay node-pty source/version drift (audit follow-up to PR #9638).
+// When the freshly-installed node-pty console-list agent is neither the recognized original nor
+// patched sha, the deploy now skips the ConPTY `AttachConsole` fallback patch and runs unpatched
+// instead of hard-failing every Windows relay deploy. This event makes that otherwise-silent
+// degradation observable. `source_sha_prefix` is a 12-char hex prefix — never the full source.
+const relayNodePtyPatchSkippedSchema = z
+  .object({
+    reason: z.enum(['unexpected_source', 'unexpected_version']),
+    node_pty_version: z.string().max(64),
+    source_sha_prefix: z.string().max(32),
+    relay_platform: z.enum(['win32-x64', 'win32-arm64'])
+  })
+  .strict()
+
 // Rollout signal for granting Codex hook trust via codex app-server RPCs
 // instead of Orca's self-computed trusted_hash. `fallback`/`verify_failed`
 // spikes mean the RPC lane is not taking; steady-state ledger skips are not
@@ -1283,6 +1297,7 @@ export const eventSchemas = {
   agent_hook_unattributed: agentHookUnattributedSchema,
 
   daemon_start_failed: daemonStartFailedSchema,
+  relay_node_pty_patch_skipped: relayNodePtyPatchSkippedSchema,
 
   codex_trust_grant: codexTrustGrantSchema,
 


### PR DESCRIPTION
## Summary

Audit follow-up to **PR #9638** (shipped in **v1.4.150**). The Windows SSH relay patches node-pty's `conpty_console_list_agent.js` (`config/relay-assets/node-pty-1.1.0-console-list-agent-patch.cjs`) to wrap `getConsoleProcessList` in an `AttachConsole`-failure `try/catch` fallback.

That patch was strictly **fail-CLOSED** on source drift:

- `patchNodePtyConsoleListAgent()` **threw** `"Refusing to patch unexpected node-pty console-list agent source"` during install if the freshly npm-installed source SHA matched neither the pinned original nor patched hash → the remote install command exited non-zero → the fresh Windows relay deploy hard-failed.
- The deploy probe (`assertPatchedNodePtyConsoleListAgent`) mapped any non-patched source to "node-pty missing".

**Blast radius:** if node-pty ever shipped a byte-different 1.1.0 build (registry mirror, alternate registry, republish), **every** Windows SSH relay deploy would hard-fail with no fallback. Zero user impact today (the pinned SHA matches); low-probability, total-outage.

## What changed

On an **unexpected source/version**, the deploy now **degrades** instead of bricking: it **skips the patch**, runs node-pty **unpatched**, and **emits telemetry** so the drift is visible.

- `patchNodePtyConsoleListAgent()` / new `classifyNodePtyConsoleListAgent()` return a **typed outcome** (`patched` / `already-patched` / `unpatched-original` / `skipped-unexpected-source` / `skipped-unexpected-version`) rather than throwing on drift.
- The remote probe one-liner runs on the relay host and has **no telemetry sink**, so it prints an `ORCA-NODE-PTY-PATCH-SKIPPED:<outcome>:<sha12>:<version>` token (mirroring `NATIVE_DEPS_MISSING_PREFIX`). The **local Orca side** parses it where the probe result is interpreted and emits the new `relay_node_pty_patch_skipped` event.
- New telemetry event `relay_node_pty_patch_skipped` in `src/shared/telemetry-events.ts` (validated by the existing `src/main/telemetry/validator.ts`): `{ reason, node_pty_version, source_sha_prefix (12-char), relay_platform }`. SHA prefix only — never full source.

## ⚠️ Security tradeoff (please scrutinize)

Degrading to **unpatched node-pty is a FUNCTIONALITY loss, not a security bypass.** The patch only adds a Windows ConPTY `AttachConsole`-failure `try/catch` fallback; running without it just loses that fallback.

The SHA verification is **not weakened**:

- The SHA gate stays intact — we still **refuse to mutate source we don't recognize**. No blind string-replace, and an unknown/foreign source is **never** marked "patched". Degradation is "skip + run unpatched + report", never "apply the patch anyway".
- The **known-original happy path is unchanged**: atomic temp-file+rename write + post-write `PATCHED_SHA` re-assert.
- The probe **still fails the deploy on genuinely broken native deps** (node-pty won't load at all). Patch classification runs on a branch **separate** from the node-pty load; a recognized-but-**unpatched original** still re-marks node-pty missing so the repair path re-applies the patch (unchanged behavior). Only the "patch legitimately skipped due to source drift" case becomes non-fatal.

## Design decision (version mismatch)

A node-pty **version** mismatch (npm installed a version != pinned `1.1.0`) also **degrades**, with a **distinct** telemetry reason (`unexpected_version` vs `unexpected_source`). External registry drift keeps `version=1.1.0` and hits the source path; `version != 1.1.0` only happens from an internal pin edit that forgot to bump the patch's `EXPECTED_NODE_PTY_VERSION`. Degrading keeps a single fail-open posture while the distinct telemetry reason keeps that internal pin-drift visible without bricking user deploys. Happy to switch version back to fail-closed if review prefers.

## Cross-platform / SSH

All new behavior is Windows-relay-only and stays behind the existing `isWindowsRemoteHost` / `process.platform === "win32"` runtime checks. The skip token only prints on win32, and the telemetry enum guards the `relay_platform` value.

## Tests

- `config/scripts/node-pty-console-list-agent-patch.test.mjs`: (a) known original → patched (happy path unchanged), (b) already-patched → no-op, (c) unexpected source **and** unexpected version → skip with no throw and **source left byte-for-byte unchanged**, tamper → still reports "not installed".
- `src/main/ssh/ssh-relay-deploy-native-deps-probe.test.ts` (new): probe classifies the patch on a separate branch; (c) unexpected source/version → node-pty stays available + skip signal parsed + `relay_node_pty_patch_skipped` emitted with the right props; (d) node-pty missing entirely → still flagged missing (deploy stays fatal) and no drift telemetry; healthy output emits nothing.

`pnpm run tc` passes; touched vitest + node test files green (126 tests); oxlint clean.