### PR TITLE
fix: paired-client terminal panes read local SSH state for remote-runtime worktrees

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -175,6 +175,20 @@ type StoreState = {
   >
   deferredSshReconnectTargets: string[]
   deferredSshSessionIdsByTabId: Record<string, string>
+  sshTargetLabels?: Map<string, string>
+  sshStateByEnvironment?: Map<
+    string,
+    {
+      targetLabels: Map<string, string>
+      removedTargetLabels: Map<string, string>
+      connectionStates: Map<
+        string,
+        { targetId: string; status: string; error: string | null; reconnectAttempt: number }
+      >
+      targetsHydrated: boolean
+    }
+  >
+  runtimeStatusByEnvironmentId?: Map<string, { status: unknown }>
   removeDeferredSshReconnectTarget: ReturnType<typeof vi.fn>
   removeDeferredSshSessionId: ReturnType<typeof vi.fn>
   consumePendingColdRestore: ReturnType<typeof vi.fn>
@@ -348,6 +362,15 @@ vi.mock('./remote-runtime-pty-transport', () => ({
       return nextTransport
     }
   )
+}))
+
+const { waitForRuntimeEnvironmentSshConnectionMock } = vi.hoisted(() => ({
+  waitForRuntimeEnvironmentSshConnectionMock: vi.fn()
+}))
+
+vi.mock('@/runtime/runtime-environment-ssh-state', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  waitForRuntimeEnvironmentSshConnection: waitForRuntimeEnvironmentSshConnectionMock
 }))
 
 // Why: stub only getEagerPtyBufferHandle so tests can simulate a live eager buffer (adopt path) without standing up the real IPC dispatcher.
@@ -20348,6 +20371,137 @@ describe('connectPanePty', () => {
       expect(getSize).toHaveBeenCalledTimes(1)
       resolveSize({ cols: 120, rows: 40 })
       await flushAsyncTicks()
+    })
+  })
+
+  // Regression (#9276): a hub-owned SSH worktree opened on a paired desktop
+  // client mirrors its target only into the owner environment's SSH bucket;
+  // reading the LOCAL ssh maps made the pane silently bail before any spawn.
+  describe('remote-runtime-owned SSH panes', () => {
+    function hubBucket(overrides?: {
+      status?: string
+      targetLabels?: Map<string, string>
+      removedTargetLabels?: Map<string, string>
+      targetsHydrated?: boolean
+    }) {
+      return {
+        targetLabels: overrides?.targetLabels ?? new Map([['conn-1', 'Hub box']]),
+        removedTargetLabels: overrides?.removedTargetLabels ?? new Map<string, string>(),
+        connectionStates: new Map([
+          [
+            'conn-1',
+            {
+              targetId: 'conn-1',
+              status: overrides?.status ?? 'connected',
+              error: null,
+              reconnectAttempt: 0
+            }
+          ]
+        ]),
+        targetsHydrated: overrides?.targetsHydrated ?? true
+      }
+    }
+
+    function seedRemoteSshWorktree(bucket: ReturnType<typeof hubBucket> | null): void {
+      mockStoreState = {
+        ...mockStoreState,
+        tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+        repos: [
+          {
+            id: 'repo1',
+            connectionId: 'conn-1',
+            executionHostId: 'runtime:env-1',
+            displayName: 'orca'
+          }
+        ],
+        // Why: a paired client's local maps are hydrated but never contain hub targets — the exact #9276 shape.
+        sshTargetLabels: new Map<string, string>(),
+        sshConnectionStates: new Map(),
+        sshStateByEnvironment: bucket ? new Map([['env-1', bucket]]) : new Map(),
+        runtimeStatusByEnvironmentId: new Map([['env-1', { status: { runtimeId: 'r1' } }]])
+      }
+    }
+
+    it('spawns through the owner environment when the hub reports the target connected', async () => {
+      const { connectPanePty } = await import('./pty-connection')
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      const transport = createMockTransport()
+      transportFactoryQueue.push(transport)
+      seedRemoteSshWorktree(hubBucket())
+
+      connectPanePty(createPane(1) as never, createManager(1) as never, createDeps() as never)
+      await flushAsyncTicks(20)
+
+      expect(vi.mocked(createRemoteRuntimePtyTransport)).toHaveBeenCalledWith(
+        'env-1',
+        expect.anything()
+      )
+      expect(transport.connect).toHaveBeenCalled()
+      const api = (
+        globalThis as unknown as { window: { api: { ssh: { connect: ReturnType<typeof vi.fn> } } } }
+      ).window.api
+      expect(api.ssh.connect).not.toHaveBeenCalled()
+      expect(waitForRuntimeEnvironmentSshConnectionMock).not.toHaveBeenCalled()
+    })
+
+    it('asks the owner environment to reconnect (never the local ssh api) when the hub reports a disconnect', async () => {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      transportFactoryQueue.push(transport)
+      seedRemoteSshWorktree(hubBucket({ status: 'disconnected' }))
+      waitForRuntimeEnvironmentSshConnectionMock.mockResolvedValue({ connected: true })
+
+      connectPanePty(createPane(1) as never, createManager(1) as never, createDeps() as never)
+      await flushAsyncTicks(20)
+
+      expect(waitForRuntimeEnvironmentSshConnectionMock).toHaveBeenCalledWith('env-1', 'conn-1')
+      expect(transport.connect).toHaveBeenCalled()
+      const api = (
+        globalThis as unknown as {
+          window: {
+            api: {
+              ssh: {
+                connect: ReturnType<typeof vi.fn>
+                needsPassphrasePrompt: ReturnType<typeof vi.fn>
+              }
+            }
+          }
+        }
+      ).window.api
+      expect(api.ssh.connect).not.toHaveBeenCalled()
+      expect(api.ssh.needsPassphrasePrompt).not.toHaveBeenCalled()
+    })
+
+    it('still proceeds while the owner bucket has not hydrated instead of stranding the pane', async () => {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      transportFactoryQueue.push(transport)
+      seedRemoteSshWorktree(hubBucket({ targetsHydrated: false }))
+      waitForRuntimeEnvironmentSshConnectionMock.mockResolvedValue({ connected: true })
+
+      connectPanePty(createPane(1) as never, createManager(1) as never, createDeps() as never)
+      await flushAsyncTicks(20)
+
+      expect(waitForRuntimeEnvironmentSshConnectionMock).toHaveBeenCalledWith('env-1', 'conn-1')
+      expect(transport.connect).toHaveBeenCalled()
+    })
+
+    it('skips the pane when the owner has removed the target (remote ghost workspace)', async () => {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      transportFactoryQueue.push(transport)
+      seedRemoteSshWorktree(
+        hubBucket({
+          targetLabels: new Map<string, string>(),
+          removedTargetLabels: new Map([['conn-1', 'Hub box']])
+        })
+      )
+
+      connectPanePty(createPane(1) as never, createManager(1) as never, createDeps() as never)
+      await flushAsyncTicks(20)
+
+      expect(transport.connect).not.toHaveBeenCalled()
+      expect(waitForRuntimeEnvironmentSshConnectionMock).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -11,7 +11,6 @@ import { useAppStore } from '@/store'
 import { getWorktreeMapFromState } from '@/store/selectors'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import { TerminalKittyKeyboardModeTracker } from '../../../../shared/terminal-kitty-keyboard-mode-tracker'
-import { isRuntimeOwnedSshTargetId } from '../../../../shared/execution-host'
 import { createTerminalZeroDimensionsMessage } from '../../../../shared/terminal-zero-dimensions-diagnostic'
 import { parseTerminalOscColorQuery } from '../../../../shared/terminal-osc-color-reply'
 import {
@@ -157,7 +156,9 @@ import {
 import { createTerminalCommandLifecycle } from './terminal-command-lifecycle'
 import { createPaneForegroundAgentTracker } from './pane-foreground-agent-tracker'
 import { parseAppSshPtyId } from '../../../../shared/ssh-pty-id'
-import { resolveSshPaneConnectGate } from './ssh-pane-connect-gate'
+import { resolveSshPaneConnectGate, resolveSshPaneTargetPresence } from './ssh-pane-connect-gate'
+import { selectRuntimeAwareSshStatus } from '@/store/slices/runtime-environment-ssh'
+import { waitForRuntimeEnvironmentSshConnection } from '@/runtime/runtime-environment-ssh-state'
 import { dispatchTerminalCommandFinishedEvent } from '@/hooks/terminal-command-finished-event'
 import { e2eConfig } from '@/lib/e2e-config'
 import {
@@ -7435,13 +7436,17 @@ export function connectPanePty(
     // Must run before session-id resolution: the SSH provider isn't registered until connect succeeds.
     if (connectionId) {
       const storeState = useAppStore.getState()
-      // Why: a removed SSH target (ghost workspace) would fail reattach with a spurious "file an issue" banner for an expected action, so skip it (runtime-owned targets exempt).
-      // A present map missing this id = target removed; an absent map = not yet hydrated (test stubs), so don't treat it as gone.
-      if (
-        !isRuntimeOwnedSshTargetId(connectionId) &&
-        storeState.sshTargetLabels instanceof Map &&
-        !storeState.sshTargetLabels.has(connectionId)
-      ) {
+      // Why: a removed SSH target (ghost workspace) would fail reattach with a spurious "file an issue" banner for an expected action, so skip it.
+      // The target's catalog lives on whichever machine owns it: a remote runtime environment's bucket, or this machine's local maps (#9276 — hub targets never appear locally).
+      const targetPresence = resolveSshPaneTargetPresence({
+        connectionId,
+        environmentId: runtimeEnvironmentId,
+        localTargetLabels: storeState.sshTargetLabels,
+        environmentBucket: runtimeEnvironmentId
+          ? storeState.sshStateByEnvironment.get(runtimeEnvironmentId)
+          : null
+      })
+      if (targetPresence === 'removed') {
         return
       }
       const restoredLeafSessionId =
@@ -7450,7 +7455,11 @@ export function connectPanePty(
           : null
       const gate = resolveSshPaneConnectGate({
         connectionId,
-        sshStatus: storeState.sshConnectionStates.get(connectionId)?.status,
+        // Why: for a remote-runtime worktree the OWNER's connection health decides spawn readiness; the local maps never track hub targets.
+        sshStatus: runtimeEnvironmentId
+          ? (selectRuntimeAwareSshStatus(storeState, runtimeEnvironmentId, connectionId) ??
+            undefined)
+          : storeState.sshConnectionStates.get(connectionId)?.status,
         isDeferredTarget: storeState.deferredSshReconnectTargets.includes(connectionId),
         restoredLeafSessionId,
         deferredTabSessionId: storeState.deferredSshSessionIdsByTabId[deps.tabId],
@@ -7468,14 +7477,17 @@ export function connectPanePty(
         void (async () => {
           // Why: for a passphrase target with no cached credential, don't auto-fire ssh.connect — a prompt popping just from focusing a tab / Cmd+J would surprise the user.
           // Wait for a user-initiated connect first; no-passphrase targets return false here and auto-connect as before.
+          // Remote-runtime targets skip the probe: credentials live on the owner, and the local ssh api doesn't know the target.
           let needsPrompt = false
-          try {
-            needsPrompt = await window.api.ssh.needsPassphrasePrompt({
-              targetId: connectionId
-            })
-          } catch (err) {
-            console.warn('[pty-connection] needsPassphrasePrompt probe failed:', err)
-            // Why: on probe failure fall through to auto-connect rather than stranding the tab — a stuck tab is worse than a surprising prompt.
+          if (!runtimeEnvironmentId) {
+            try {
+              needsPrompt = await window.api.ssh.needsPassphrasePrompt({
+                targetId: connectionId
+              })
+            } catch (err) {
+              console.warn('[pty-connection] needsPassphrasePrompt probe failed:', err)
+              // Why: on probe failure fall through to auto-connect rather than stranding the tab — a stuck tab is worse than a surprising prompt.
+            }
           }
           if (disposed) {
             return
@@ -7556,7 +7568,10 @@ export function connectPanePty(
           }
 
           // Why: wait for the shared SSH connection (multiple panes/tabs may need it) before PTY reattach, rather than returning early when it's in-flight.
-          const connectResult = await waitForSshConnection(connectionId)
+          // A remote-runtime worktree asks the OWNING environment to connect; the client never dials the hub's target itself.
+          const connectResult = runtimeEnvironmentId
+            ? await waitForRuntimeEnvironmentSshConnection(runtimeEnvironmentId, connectionId)
+            : await waitForSshConnection(connectionId)
           if (!connectResult.connected) {
             reportError(`SSH connection failed: ${connectResult.error}`)
             return

--- a/src/renderer/src/components/terminal-pane/ssh-pane-connect-gate.test.ts
+++ b/src/renderer/src/components/terminal-pane/ssh-pane-connect-gate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolveSshPaneConnectGate } from './ssh-pane-connect-gate'
+import { resolveSshPaneConnectGate, resolveSshPaneTargetPresence } from './ssh-pane-connect-gate'
 
 const BASE = {
   connectionId: 'conn-1',
@@ -83,5 +83,119 @@ describe('resolveSshPaneConnectGate', () => {
       connectionId: 'runtime-ssh-env-1'
     })
     expect(gate.enterDeferredFlow).toBe(false)
+  })
+})
+
+describe('resolveSshPaneTargetPresence', () => {
+  const bucket = (overrides?: {
+    targetLabels?: Map<string, string>
+    removedTargetLabels?: Map<string, string>
+    targetsHydrated?: boolean
+  }) => ({
+    targetLabels: overrides?.targetLabels ?? new Map<string, string>(),
+    removedTargetLabels: overrides?.removedTargetLabels ?? new Map<string, string>(),
+    targetsHydrated: overrides?.targetsHydrated ?? true
+  })
+
+  it('reports a locally known target as present', () => {
+    expect(
+      resolveSshPaneTargetPresence({
+        connectionId: 'conn-1',
+        environmentId: null,
+        localTargetLabels: new Map([['conn-1', 'Box']]),
+        environmentBucket: null
+      })
+    ).toBe('present')
+  })
+
+  it('reports a target missing from the hydrated local map as removed', () => {
+    expect(
+      resolveSshPaneTargetPresence({
+        connectionId: 'conn-1',
+        environmentId: null,
+        localTargetLabels: new Map(),
+        environmentBucket: null
+      })
+    ).toBe('removed')
+  })
+
+  it('reports unknown while the local map is not hydrated', () => {
+    expect(
+      resolveSshPaneTargetPresence({
+        connectionId: 'conn-1',
+        environmentId: null,
+        localTargetLabels: undefined,
+        environmentBucket: null
+      })
+    ).toBe('unknown')
+  })
+
+  it('always treats runtime-owned targets as present', () => {
+    expect(
+      resolveSshPaneTargetPresence({
+        connectionId: 'runtime-ssh-env-1',
+        environmentId: 'env-1',
+        localTargetLabels: new Map(),
+        environmentBucket: null
+      })
+    ).toBe('present')
+  })
+
+  // Regression (#9276): a hub-owned SSH target lives only in the owner
+  // environment's bucket; reading the local map marked it removed and the
+  // pane silently never spawned.
+  it('reports a hub-owned target in the owner bucket as present despite empty local maps', () => {
+    expect(
+      resolveSshPaneTargetPresence({
+        connectionId: 'conn-1',
+        environmentId: 'env-1',
+        localTargetLabels: new Map(),
+        environmentBucket: bucket({ targetLabels: new Map([['conn-1', 'Hub box']]) })
+      })
+    ).toBe('present')
+  })
+
+  it('reports a hub-side tombstoned target as removed', () => {
+    expect(
+      resolveSshPaneTargetPresence({
+        connectionId: 'conn-1',
+        environmentId: 'env-1',
+        localTargetLabels: new Map([['conn-1', 'Local twin']]),
+        environmentBucket: bucket({ removedTargetLabels: new Map([['conn-1', 'Hub box']]) })
+      })
+    ).toBe('removed')
+  })
+
+  it('reports a target absent from a hydrated owner bucket as removed', () => {
+    expect(
+      resolveSshPaneTargetPresence({
+        connectionId: 'conn-1',
+        environmentId: 'env-1',
+        localTargetLabels: new Map([['conn-1', 'Local twin']]),
+        environmentBucket: bucket()
+      })
+    ).toBe('removed')
+  })
+
+  it('reports unknown while the owner bucket is missing', () => {
+    expect(
+      resolveSshPaneTargetPresence({
+        connectionId: 'conn-1',
+        environmentId: 'env-1',
+        localTargetLabels: new Map(),
+        environmentBucket: null
+      })
+    ).toBe('unknown')
+  })
+
+  it('reports unknown while the owner bucket is not hydrated', () => {
+    expect(
+      resolveSshPaneTargetPresence({
+        connectionId: 'conn-1',
+        environmentId: 'env-1',
+        localTargetLabels: new Map(),
+        environmentBucket: bucket({ targetsHydrated: false })
+      })
+    ).toBe('unknown')
   })
 })

--- a/src/renderer/src/components/terminal-pane/ssh-pane-connect-gate.ts
+++ b/src/renderer/src/components/terminal-pane/ssh-pane-connect-gate.ts
@@ -1,6 +1,47 @@
 import { parseAppSshPtyId } from '../../../../shared/ssh-pty-id'
 import { isRuntimeOwnedSshTargetId } from '../../../../shared/execution-host'
 
+export type SshPaneTargetPresence = 'present' | 'removed' | 'unknown'
+
+/**
+ * Whether the pane's SSH target still exists on the machine that owns it.
+ * `environmentId` names the remote Orca server owning the target (null = this
+ * machine). Only 'removed' should skip the pane; 'unknown' means the owner's
+ * catalog has not hydrated yet and the pane must proceed rather than strand.
+ */
+export function resolveSshPaneTargetPresence(input: {
+  connectionId: string
+  environmentId: string | null
+  localTargetLabels: unknown
+  environmentBucket:
+    | {
+        targetLabels: ReadonlyMap<string, string>
+        removedTargetLabels: ReadonlyMap<string, string>
+        targetsHydrated: boolean
+      }
+    | null
+    | undefined
+}): SshPaneTargetPresence {
+  // Why: runtime-owned targets are internal relay plumbing without catalog entries; treating them as removed would strand ephemeral-VM panes.
+  if (isRuntimeOwnedSshTargetId(input.connectionId)) {
+    return 'present'
+  }
+  if (input.environmentId === null) {
+    if (!(input.localTargetLabels instanceof Map)) {
+      return 'unknown'
+    }
+    return input.localTargetLabels.has(input.connectionId) ? 'present' : 'removed'
+  }
+  const bucket = input.environmentBucket
+  if (!bucket?.targetsHydrated) {
+    return 'unknown'
+  }
+  if (bucket.removedTargetLabels.has(input.connectionId)) {
+    return 'removed'
+  }
+  return bucket.targetLabels.has(input.connectionId) ? 'present' : 'removed'
+}
+
 export type SshPaneConnectGate = {
   /** Session the pane should reattach after connecting (null → fresh spawn). */
   pendingSessionId: string | null

--- a/src/renderer/src/runtime/runtime-environment-ssh-state.test.ts
+++ b/src/renderer/src/runtime/runtime-environment-ssh-state.test.ts
@@ -5,7 +5,8 @@ import {
   applyRuntimeEnvironmentSshStateChanged,
   connectRuntimeEnvironmentSshTarget,
   hydrateRuntimeEnvironmentSshState,
-  resyncRuntimeEnvironmentSshTargets
+  resyncRuntimeEnvironmentSshTargets,
+  waitForRuntimeEnvironmentSshConnection
 } from './runtime-environment-ssh-state'
 import { callRuntimeRpc } from './runtime-rpc-client'
 
@@ -235,6 +236,86 @@ describe('connectRuntimeEnvironmentSshTarget', () => {
       'SSH target not found'
     )
     expect(useAppStore.getState().sshStateByEnvironment.has(envId)).toBe(false)
+  })
+})
+
+describe('waitForRuntimeEnvironmentSshConnection', () => {
+  function seedReachableEnv(envId: string, status: SshConnectionState['status']): void {
+    useAppStore
+      .getState()
+      .setRuntimeEnvironmentStatus(envId, { status: { runtimeId: 'r1' } } as never)
+    useAppStore
+      .getState()
+      .setEnvironmentSshTargetsMetadata(envId, [{ id: 'ssh-1', label: 'hub box' }])
+    useAppStore
+      .getState()
+      .setEnvironmentSshConnectionState(envId, 'ssh-1', connState('ssh-1', status))
+  }
+
+  it('resolves immediately without RPC when the owner already reports connected', async () => {
+    const envId = nextEnvId()
+    seedReachableEnv(envId, 'connected')
+
+    const result = await waitForRuntimeEnvironmentSshConnection(envId, 'ssh-1')
+
+    expect(result).toEqual({ connected: true })
+    expect(callRuntimeRpcMock).not.toHaveBeenCalled()
+  })
+
+  it('asks the owning environment to connect when the target is not connected', async () => {
+    const envId = nextEnvId()
+    seedReachableEnv(envId, 'disconnected')
+    callRuntimeRpcMock.mockResolvedValue({ state: connState('ssh-1', 'connected') } as never)
+
+    const result = await waitForRuntimeEnvironmentSshConnection(envId, 'ssh-1')
+
+    expect(result).toEqual({ connected: true })
+    expect(callRuntimeRpcMock).toHaveBeenCalledWith(
+      { kind: 'environment', environmentId: envId },
+      'ssh.connect',
+      { targetId: 'ssh-1' },
+      expect.anything()
+    )
+  })
+
+  it('reports failure with the hub error when the hub-side connect does not succeed', async () => {
+    const envId = nextEnvId()
+    seedReachableEnv(envId, 'disconnected')
+    callRuntimeRpcMock.mockResolvedValue({
+      state: { targetId: 'ssh-1', status: 'auth-failed', error: 'bad key', reconnectAttempt: 1 }
+    } as never)
+
+    const result = await waitForRuntimeEnvironmentSshConnection(envId, 'ssh-1')
+
+    expect(result.connected).toBe(false)
+    expect(result.error).toContain('bad key')
+  })
+
+  it('reports failure when the runtime RPC itself rejects', async () => {
+    const envId = nextEnvId()
+    callRuntimeRpcMock.mockRejectedValue(new Error('runtime unavailable'))
+
+    const result = await waitForRuntimeEnvironmentSshConnection(envId, 'ssh-1')
+
+    expect(result.connected).toBe(false)
+    expect(result.error).toContain('runtime unavailable')
+  })
+
+  it('coalesces concurrent waits for the same target into one connect RPC', async () => {
+    const envId = nextEnvId()
+    seedReachableEnv(envId, 'disconnected')
+    let resolveRpc: (value: never) => void = () => {}
+    callRuntimeRpcMock.mockImplementation(
+      () => new Promise((resolve) => (resolveRpc = resolve as never))
+    )
+
+    const first = waitForRuntimeEnvironmentSshConnection(envId, 'ssh-1')
+    const second = waitForRuntimeEnvironmentSshConnection(envId, 'ssh-1')
+    resolveRpc({ state: connState('ssh-1', 'connected') } as never)
+
+    expect(await first).toEqual({ connected: true })
+    expect(await second).toEqual({ connected: true })
+    expect(callRuntimeRpcMock).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/renderer/src/runtime/runtime-environment-ssh-state.ts
+++ b/src/renderer/src/runtime/runtime-environment-ssh-state.ts
@@ -1,4 +1,5 @@
 import { useAppStore } from '@/store'
+import { selectRuntimeAwareSshStatus } from '@/store/slices/runtime-environment-ssh'
 import type { SshConnectionState, SshTarget } from '../../../shared/ssh-types'
 import { callRuntimeRpc } from './runtime-rpc-client'
 
@@ -162,4 +163,47 @@ export async function connectRuntimeEnvironmentSshTarget(
  * stale overlay converges to the ghost/re-adopted state (STA-1468). */
 export async function resyncRuntimeEnvironmentSshTargets(environmentId: string): Promise<void> {
   await syncEnvironmentSshTargetMetadata(environmentId)
+}
+
+const environmentSshConnectWaits = new Map<
+  string,
+  Promise<{ connected: boolean; error?: string }>
+>()
+
+/**
+ * Remote analog of the pane's deferred local SSH connect: ensure the OWNING
+ * environment's connection to `targetId` is up before the pane spawns/reattaches.
+ * The client never dials the target itself — it asks the owner to connect.
+ */
+export async function waitForRuntimeEnvironmentSshConnection(
+  environmentId: string,
+  targetId: string
+): Promise<{ connected: boolean; error?: string }> {
+  const state = useAppStore.getState()
+  if (selectRuntimeAwareSshStatus(state, environmentId, targetId) === 'connected') {
+    return { connected: true }
+  }
+  const waitKey = `${environmentId}::${targetId}`
+  const existing = environmentSshConnectWaits.get(waitKey)
+  if (existing) {
+    return existing
+  }
+  const wait = (async (): Promise<{ connected: boolean; error?: string }> => {
+    try {
+      const connectionState = await connectRuntimeEnvironmentSshTarget(environmentId, targetId)
+      if (connectionState?.status === 'connected') {
+        return { connected: true }
+      }
+      return {
+        connected: false,
+        error: connectionState?.error ?? connectionState?.status ?? 'not connected'
+      }
+    } catch (err) {
+      return { connected: false, error: err instanceof Error ? err.message : String(err) }
+    } finally {
+      environmentSshConnectWaits.delete(waitKey)
+    }
+  })()
+  environmentSshConnectWaits.set(waitKey, wait)
+  return wait
 }


### PR DESCRIPTION
Completes #9276 together with #9955 — #9955 fixed the false "SSH disconnected" chip on the sidebar card; this PR fixes the other half of the report: on a paired desktop client, terminals for the hub's SSH-hosted worktrees never opened or streamed ("the cards come through the shared graph, but their terminals won't open").

## User-visible change

On a paired desktop client connected to a hub running the Orca runtime, clicking a worktree hosted on one of the **hub's SSH targets** produced a permanently blank terminal pane — no spawn, no stream, no error. The hub's own web UI streamed those same terminals fine, and the hub's local worktrees streamed to the client fine; only the SSH-hosted ones broke. After this fix the pane spawns through the owning environment, and a genuine hub-side disconnect asks the hub (not the client) to reconnect the target.

## Root cause

Verified live on a real hub + paired-client topology with temporary instrumentation: the pane died **client-side, before any RPC left the machine**.

`connectPanePty`'s ghost-target guard read the flat **local** `sshTargetLabels` map to decide whether the pane's SSH target still exists. On a paired client, hub-owned targets are mirrored only into the per-environment bucket `sshStateByEnvironment` (STA-1468) and never into the local maps — so every hub SSH target looked "removed" and the guard silently `return`ed before any spawn. Past that guard, two more local reads were wrong for hub-owned panes: the connect gate's status came from local `sshConnectionStates` (always `undefined` → deferred flow), and the deferred flow dialed `window.api.ssh.connect` / `needsPassphrasePrompt` for a target only the hub owns.

This is the same store-contract violation class as #9955, in the terminal pane's spawn gating instead of the card's status display. It explains all three observations in the report: the hub's own desktop has those targets in its local maps (works), paired *web* clients deliberately mirror through the local maps (works), paired desktop clients use buckets (silently dead).

## Changes

- **`ssh-pane-connect-gate.ts`**: new pure `resolveSshPaneTargetPresence` — routes the ghost-target check to whichever machine owns the target: the owner environment's bucket (tombstoned or missing-from-hydrated-catalog → `removed`; unhydrated/missing bucket → `unknown`, proceed) or the local maps (`environmentId === null`, byte-for-byte the old semantics including the runtime-owned-target exemption and the not-yet-hydrated pass-through).
- **`runtime-environment-ssh-state.ts`**: new `waitForRuntimeEnvironmentSshConnection` — the remote analog of the pane's deferred local connect: short-circuits when the owner already reports `connected`, otherwise asks the **owning environment** to `ssh.connect` (existing runtime RPC), deduped per `environment::target`.
- **`pty-connection.ts`** (wiring only): the guard uses the presence resolver with the pane's `runtimeEnvironmentId`; the connect gate's status comes from `selectRuntimeAwareSshStatus` for environment-owned panes; the deferred flow skips the local passphrase probe and uses the environment connect wait. The transport decision and all three gate paths key off the same `runtimeEnvironmentId`, so transport and gating can never disagree about ownership. Local panes (`runtimeEnvironmentId === null`) keep identical behavior.

## Tests

Written red→green; every regression case was watched failing before the fix code existed.

**Wiring-level (`pty-connection.test.ts`, 4 new cases driving the real `connectPanePty`)** — the exact #9276 shape: repo with `connectionId` + `executionHostId: runtime:<env>`, hydrated local maps that do NOT contain the hub target, owner bucket in `sshStateByEnvironment`:

- owner reports `connected` → pane spawns through `createRemoteRuntimePtyTransport('env-1', …)`, no local `ssh.connect`, no connect wait (fails on main: silent early return, no spawn)
- owner reports `disconnected` → pane asks the owner to connect (`waitForRuntimeEnvironmentSshConnection('env-1','conn-1')`), never the local ssh api or passphrase probe (fails on main)
- owner bucket not yet hydrated → pane proceeds instead of stranding (fails on main)
- owner tombstoned the target → pane skips (remote ghost-workspace semantics preserved)

Red proof for the wiring: `git stash push -- pty-connection.ts` (fix reverted, pure modules kept) → the first three fail; popped → all four pass.

**Unit-level**: 9 new cases for `resolveSshPaneTargetPresence` (local parity across all edge shapes, bucket present/tombstoned/absent/unhydrated, runtime-owned exemption) and 5 for `waitForRuntimeEnvironmentSshConnection` (short-circuit without RPC, owner-routed connect, hub-error and RPC-failure reporting, concurrent-wait coalescing).

## AI code-review summary

Co-developed with Claude (Claude Code, Fable 5) under human direction and review: I scoped the fix, reviewed the diff, and verified the result live on my real hub + paired-client setup (fresh terminal spawn, owner-routed connect, and the stale-lease edge case below). On the AI side, root cause was confirmed empirically before any code was written: client-side instrumentation on a live paired client showed the ghost-target guard firing (`localLabelPresent: false` with the owner bucket present) for every hub SSH pane, with no RPC reaching the hub. An adversarial review pass then attacked the diff and refuted each risk:

- **Cross-platform (macOS/Linux/Windows)**: renderer-only; no paths, shells, or platform APIs. Verified live with a Windows client against a macOS hub.
- **SSH/remote/local compatibility**: the point of the fix. Local SSH panes are provably byte-for-byte equivalent (unit-tested across every guard shape). A local SSH repo can never reach the environment path: with `connectionId` set, `getRuntimeEnvironmentIdForWorktree` never falls back to the focused environment — it returns an environment only for an explicit `runtime:<env>` owner. Paired web clients resolve the same environment path and gain the fix too (their empty local maps stranded them identically). Runtime-owned (`runtime-ssh-*`) ephemeral-VM targets keep their exemption.
- **Agent/integration neutrality**: no agent-, integration-, or git-provider-specific behavior.
- **Performance**: no new IPC or subscriptions on the render path; the presence/status reads are O(1) map lookups in the existing spawn routine. The owner-connect RPC fires only for a pane whose owner reports the target not connected — a case that previously produced a permanently dead pane.
- **UI quality**: no visual changes; only whether the pane actually connects. A real hub-side disconnect now surfaces the existing reconnect overlay/error path instead of silence.
- **Security**: no new data flows; the hub-side `ssh.connect` RPC and per-environment mirroring already existed (STA-1468) — the pane now consults them instead of local state.

Acknowledged non-blocking follow-ups from the adversarial pass (left out of this single-topic diff): register a dispose teardown so an in-flight owner-connect RPC is abandoned before its 60s timeout (parity with the passphrase-wait teardown); align `resolveSshPaneTargetPresence` with `selectRuntimeAwareSshTargetRemoved`'s reachability gate (currently benign — a bucket is only hydrated when the environment was reachable); add an unreachable-environment gate test.

One more surfaced during live verification: `remote-runtime-pty-transport.ts` has no `SSH_SESSION_EXPIRED` handling. A pre-existing mirrored hub terminal whose backing SSH relay session died (e.g. the target's relay restarted while the pane was unreachable) becomes a zombie: every attach re-emits `SSH_SESSION_EXPIRED: <relay-id>` from the hub, and `handleRemoteTerminalError` surfaces it as a red toast instead of retiring the terminal (the way `isRemoteTerminalGoneMessage` does) or converting it to the `sessionExpired: true` rebind-and-respawn the local IPC transport performs. Closing the tab and opening a new one recovers (fresh spawns work — that's this PR). This state was unreachable before the fix because those panes died client-side without ever contacting the hub. Follow-up: treat `SSH_SESSION_EXPIRED` in the remote transport as terminal-gone/session-expired so stale mirrored tabs recover in place.

## Screenshots

Paired Windows desktop client, hub (macOS, Orca 1.4.147). `TL/Fusion` is a hub SSH-hosted repo (the #9276 topology); `TL/fusion-mcp` is hub-local. The sidebar shots below are from the same live verification session in which the fixed build's terminal panes spawned and streamed for these worktrees (they were permanently blank before).

| Before | After |
| --- | --- |
| <img src="https://gist.githubusercontent.com/VictorCano/294b4840586da90690fb1790157ebda3/raw/orca-9955-before.png" alt="Before: hub SSH-hosted worktrees show a false disconnected state on the paired client" width="260"> | <img src="https://gist.githubusercontent.com/VictorCano/294b4840586da90690fb1790157ebda3/raw/orca-9955-after.png" alt="After: the same worktrees render healthy" width="260"> |

## Notes

- Pre-existing failures on `main` (untouched, reproduced on a clean checkout in the same environment, same set as noted in #9955): `pnpm lint` fails in `lint:switch-exhaustiveness` on `src/renderer/src/components/skills/skill-freshness-group.tsx:101`; `pnpm test` has 3 failures in `src/main/startup/configure-process.test.ts` (GPU feature flags) and `src/main/agent-hooks/managed-hook-timeout.test.ts` (timing) — all outside the renderer. The other 34,161 tests pass, including the 18 new ones (the total differs from #9955 because `main` advanced between the two branches).
- `pnpm typecheck` and `pnpm build` pass; changed files are lint-clean.
- No version bumps.



## ELI5

On a paired laptop connected to a hub, terminals for the hub's SSH worktrees never opened. The client now reads the right local SSH state so those remote terminals stream like they should.
