### PR TITLE
fix(mobile): keep native chat from resizing the covered terminal PTY

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -1377,7 +1377,10 @@ export default function SessionScreen() {
         {
           terminal: handle,
           client: { id: deviceTokenRef.current!, type: 'mobile' as const },
-          viewport: viewportRef.current ?? undefined,
+          viewport: nativeChatTerminalStream.mobileNativeChatSubscribeViewport(
+            covered,
+            viewportRef.current
+          ),
           capabilities: nativeChatTerminalStream.mobileNativeChatTerminalCapabilities(covered)
         },
         (result) => {
@@ -2455,6 +2458,7 @@ export default function SessionScreen() {
     terminalFrameHeightRef,
     viewportRef,
     viewportMeasuredRef,
+    nativeChatCoveredRef: showNativeChatRef,
     clientRef,
     deviceTokenRef,
     initializedHandlesRef,

--- a/mobile/src/session/mobile-native-chat-terminal-stream.test.ts
+++ b/mobile/src/session/mobile-native-chat-terminal-stream.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   isTerminalCoveredByNativeChat,
+  mobileNativeChatSubscribeViewport,
   mobileNativeChatTerminalCapabilities,
   resolveMobileNativeChatTerminalStreamAction
 } from './mobile-native-chat-terminal-stream'
@@ -32,6 +33,17 @@ describe('mobile native-chat terminal stream lifecycle', () => {
       mobileInputLeaseOnly: 1
     })
     expect(mobileNativeChatTerminalCapabilities(false)).toEqual({ terminalBinaryStream: 1 })
+  })
+
+  it('omits the viewport from a covered lease subscribe so the host keeps desktop dims', () => {
+    // Why: handleMobileSubscribe phone-fits the PTY whenever a viewport is present,
+    // even for a lease-only subscribe — entering chat must not resize the terminal.
+    expect(mobileNativeChatSubscribeViewport(true, { cols: 40, rows: 60 })).toBeUndefined()
+    expect(mobileNativeChatSubscribeViewport(false, { cols: 40, rows: 60 })).toEqual({
+      cols: 40,
+      rows: 60
+    })
+    expect(mobileNativeChatSubscribeViewport(false, null)).toBeUndefined()
   })
 
   it('records a cold-start cover before WebView readiness so return refreshes', () => {

--- a/mobile/src/session/mobile-native-chat-terminal-stream.ts
+++ b/mobile/src/session/mobile-native-chat-terminal-stream.ts
@@ -35,3 +35,11 @@ export function mobileNativeChatTerminalCapabilities(covered: boolean): {
     ? { terminalBinaryStream: 1, mobileInputLeaseOnly: 1 }
     : { terminalBinaryStream: 1 }
 }
+
+// Why: a covered subscribe is only an input lease — carrying phone dims would make the host phone-fit a PTY native chat never renders.
+export function mobileNativeChatSubscribeViewport(
+  covered: boolean,
+  viewport: { cols: number; rows: number } | null
+): { cols: number; rows: number } | undefined {
+  return covered ? undefined : (viewport ?? undefined)
+}

--- a/mobile/src/terminal/terminal-viewport-refit-state.ts
+++ b/mobile/src/terminal/terminal-viewport-refit-state.ts
@@ -7,6 +7,7 @@ export type TerminalViewportRefitTargetState = {
   expectedHandle: string
   currentRef: unknown
   expectedRef: unknown
+  nativeChatCovered: boolean
   disposed: boolean
   runSeq: number
   currentRunSeq: number
@@ -94,6 +95,7 @@ export function isTerminalViewportRefitTargetCurrent(
   state: TerminalViewportRefitTargetState
 ): boolean {
   return (
+    !state.nativeChatCovered &&
     !state.disposed &&
     state.runSeq === state.currentRunSeq &&
     state.activeHandle === state.expectedHandle &&

--- a/mobile/src/terminal/terminal-viewport-refit.test.ts
+++ b/mobile/src/terminal/terminal-viewport-refit.test.ts
@@ -135,6 +135,18 @@ describe('terminal viewport refit', () => {
     expect(timerBody).toContain('if (!decision.shouldRefit)')
   })
 
+  it('suppresses refits while native chat covers the active terminal', () => {
+    // Why: native chat renders the transcript, not the grid — a refit there would
+    // reflow the desktop PTY to phone dims the user never sees.
+    const timerStart = hookSource.indexOf('refitTimerRef.current = setTimeout(')
+    const coveredCheck = hookSource.indexOf('if (nativeChatCoveredRef.current)', timerStart)
+    const measureIndex = hookSource.indexOf('measureFitDimensions', timerStart)
+    expect(timerStart).toBeGreaterThanOrEqual(0)
+    expect(coveredCheck).toBeGreaterThan(timerStart)
+    expect(measureIndex).toBeGreaterThan(coveredCheck)
+    expect(sessionSource).toContain('nativeChatCoveredRef: showNativeChatRef')
+  })
+
   it('is wired into the session screen', () => {
     expect(sessionSource).toContain('useTerminalViewportRefit({')
     expect(sessionSource).toContain('tabStripVisible: terminals.length > 1')

--- a/mobile/src/terminal/terminal-viewport-refit.test.ts
+++ b/mobile/src/terminal/terminal-viewport-refit.test.ts
@@ -313,6 +313,7 @@ describe('terminal viewport refit', () => {
       expectedHandle: 'term-1',
       currentRef: expectedRef,
       expectedRef,
+      nativeChatCovered: false,
       disposed: false,
       runSeq: 2,
       currentRunSeq: 2
@@ -325,5 +326,8 @@ describe('terminal viewport refit', () => {
     ).toBe(false)
     expect(isTerminalViewportRefitTargetCurrent({ ...current, currentRunSeq: 3 })).toBe(false)
     expect(isTerminalViewportRefitTargetCurrent({ ...current, disposed: true })).toBe(false)
+    expect(isTerminalViewportRefitTargetCurrent({ ...current, nativeChatCovered: true })).toBe(
+      false
+    )
   })
 })

--- a/mobile/src/terminal/terminal-viewport-refit.ts
+++ b/mobile/src/terminal/terminal-viewport-refit.ts
@@ -23,6 +23,8 @@ type TerminalViewportRefitOptions = {
   terminalFrameHeightRef: RefObject<number>
   viewportRef: RefObject<TerminalViewportDims | null>
   viewportMeasuredRef: RefObject<boolean>
+  // Why: while native chat covers the active terminal, a refit would push phone dims into a PTY nobody on this device is viewing.
+  nativeChatCoveredRef: RefObject<boolean>
   clientRef: RefObject<RpcClient | null>
   deviceTokenRef: RefObject<string | null>
   initializedHandlesRef: RefObject<Set<string>>
@@ -51,6 +53,7 @@ export function useTerminalViewportRefit(
     terminalFrameHeightRef,
     viewportRef,
     viewportMeasuredRef,
+    nativeChatCoveredRef,
     clientRef,
     deviceTokenRef,
     initializedHandlesRef,
@@ -97,6 +100,10 @@ export function useTerminalViewportRefit(
         refitRunSeqRef.current = runSeq
         const handle = activeHandleRef.current
         if (!handle) {
+          return
+        }
+        // Why: the trigger already marked the viewport stale, and the return-to-terminal resubscribe re-measures — refitting now would resize a covered PTY.
+        if (nativeChatCoveredRef.current) {
           return
         }
         const ref = terminalRefs.current.get(handle)
@@ -171,6 +178,7 @@ export function useTerminalViewportRefit(
       terminalFrameHeightRef,
       viewportRef,
       viewportMeasuredRef,
+      nativeChatCoveredRef,
       clientRef,
       deviceTokenRef,
       initializedHandlesRef,

--- a/mobile/src/terminal/terminal-viewport-refit.ts
+++ b/mobile/src/terminal/terminal-viewport-refit.ts
@@ -116,6 +116,7 @@ export function useTerminalViewportRefit(
             expectedHandle: handle,
             currentRef: terminalRefs.current.get(handle),
             expectedRef: ref,
+            nativeChatCovered: nativeChatCoveredRef.current,
             disposed: disposedRef.current,
             runSeq,
             currentRunSeq: refitRunSeqRef.current

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -2540,7 +2540,8 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           .then(() => runtime.cleanupSubscription(subscriptionId))
           .catch(() => runtime.cleanupSubscription(subscriptionId))
         try {
-          await runtime.handleMobileSubscribe(ptyId, clientId, params.viewport)
+          // Why: a lease-only subscriber has no terminal view, so its cached viewport must never phone-fit the PTY.
+          await runtime.handleMobileSubscribe(ptyId, clientId, undefined)
           if (closed || signal?.aborted) {
             // Why: a disconnect can win the awaited subscribe and resurrect mobile presence after cleanup already released it.
             runtime.handleMobileUnsubscribe(ptyId, clientId)

--- a/src/main/runtime/rpc/terminal-subscribe-lease-only.test.ts
+++ b/src/main/runtime/rpc/terminal-subscribe-lease-only.test.ts
@@ -12,12 +12,13 @@ const request: RpcRequest = {
   params: {
     terminal: 'terminal-1',
     client: { id: 'phone-1', type: 'mobile' },
+    viewport: { cols: 40, rows: 20 },
     capabilities: { terminalBinaryStream: 1, mobileInputLeaseOnly: 1 }
   }
 }
 
 describe('terminal lease-only subscription', () => {
-  it('keeps mobile input ownership without registering output delivery', async () => {
+  it('keeps mobile input ownership without viewport resize or output delivery', async () => {
     const messages: string[] = []
     const cleanups = new Map<string, () => void>()
     const runtime = {


### PR DESCRIPTION
## Summary

Native chat reads the agent transcript and never renders the terminal grid. This change prevents chat-covered mobile sessions from pushing phone dimensions into the host PTY through either the lease-only subscription or viewport-refit paths.

## Problem

Opening a worktree in mobile native chat leaked PTY resizes even though native chat renders the agent transcript, never the terminal grid. The desktop terminal could reflow to phone dimensions while nobody on the phone was looking at it.

Two paths caused the leak:

1. The covered lease-only subscribe carried the cached viewport. `handleMobileSubscribe` phone-fits the PTY whenever a viewport is present, including on an input-lease-only subscribe.
2. The terminal WebView stays mounted beneath the chat overlay, so `useTerminalViewportRefit` still measured it and sent `terminal.updateViewport` on rotation, keyboard show/hide, text-scale change, frame resize, reconnect, and iOS resume.

## Fix

- `mobileNativeChatSubscribeViewport` omits the viewport from covered lease-only subscriptions, preserving compatibility with older hosts.
- The host RPC boundary independently ignores a viewport on every lease-only subscription, so older or regressed clients cannot resize a PTY through that path.
- `useTerminalViewportRefit` skips measurement while native chat covers the active terminal.
- Refit freshness now includes native-chat coverage, so a measurement already in flight is discarded if chat covers the terminal before it resolves.
- Returning to the terminal still re-measures and phone-fits through the existing resubscribe path.

Out of scope and unchanged: after a user has viewed the terminal tab, returning to chat leaves the PTY phone-fit instead of restoring desktop dimensions. Restoring on chat re-entry would require a separate host-side ownership decision.

## Reliability contract

- **Invariant:** `terminal-runtime.mobile-stream-budget` / mobile terminal geometry authority — a native-chat-covered terminal owns only an input lease. It carries no output stream and no viewport capable of phone-fitting the PTY; async refits become stale when coverage begins.
- **Failure source:** the reported path of opening native chat after a terminal viewport had been cached, plus rotation, keyboard, frame, reconnect, or foreground refits while chat covered the terminal.
- **Oracle:** deterministic tests assert that covered client subscriptions omit the viewport, the host discards a supplied viewport for lease-only subscriptions, lease-only setup creates no output delivery, and refit freshness rejects native-chat coverage. The full mobile suite also covers pause/resume and late WebView readiness.
- **Gate:** `terminal-runtime.mobile-stream-budget`, exercised with its three registered runtime stream suites plus `terminal-subscribe-lease-only.test.ts`; the focused mobile stream and viewport-refit suites also passed.
- **Provider/platform coverage:** the client decision and host RPC contract are platform-neutral. The host boundary runs before local, daemon, SSH, or remote PTY resize behavior, so those provider paths receive no viewport from a lease-only request. Local macOS deterministic evidence is complete; live iOS/Android, SSH, WSL, Linux, and Windows device evidence remains uncollected.
- **Performance budget:** covered refits perform zero WebView measurements and zero viewport RPCs. Lease-only subscriptions perform zero viewport resize and zero output-stream registration. No polling, timers, provider scans, subprocesses, stream listeners, or retained buffers were added.
- **Diagnostics:** existing mobile terminal diagnostics retain subscription arm/skip, viewport measurement, and first-stream-event evidence; the host tests expose the exact `handleMobileSubscribe` arguments and output registration counts.
- **Residual gaps:** no physical-device rotation/background artifact is attached. An update RPC already dispatched before chat becomes covered cannot be canceled, but in-flight measurement is now rejected before dispatch and covered lease resubscription cannot introduce another resize.

## Testing

- Mobile format, oxlint, and `tsc --noEmit`: passed.
- Full mobile suite: 306 files passed; 2,235 tests passed and 2 skipped.
- Runtime terminal stream gate plus lease-only contract: 4 files / 49 tests passed.
- Node typecheck: passed.
- Max-lines ratchet and diff checks: passed.
- Latest `origin/main` merge-tree check: clean.

## Screenshots

Not applicable; this is terminal ownership and resize behavior with no visual UI change.

## AI Review Report

Reviewed the complete PR diff, adjacent mobile stream lifecycle, viewport update RPC, mobile presence ownership, stale async refit handling, cleanup paths, reconnect/foreground behavior, current reliability gates, and latest base-branch overlap. Two correctness gaps were found, fixed, and covered by deterministic tests.

## Security Audit

No authentication, authorization, credential, persistence, or new protocol surface was added. The host change narrows accepted lease-only behavior by discarding viewport authority.

## Notes

The change is backward compatible in both directions: the mobile omission protects current clients paired with older hosts, and the host boundary protects current hosts paired with older or regressed clients.
