### PR TITLE
feat(agent-status): question glyph for "needs you" state everywhere

### DIFF
--- a/src/renderer/src/components/AgentStateDot.test.ts
+++ b/src/renderer/src/components/AgentStateDot.test.ts
@@ -51,12 +51,10 @@ describe('AgentStateDot', () => {
     (state) => {
       const markup = renderMarkup(state)
 
-      // Why: the "needs you" states share the dashboard's MessageCircleQuestion
-      // glyph rather than a bare dot. Assert the lucide class hook + amber text
-      // color without coupling to the exact SVG path lucide emits.
-      expect(markup).toContain('lucide-message-circle-question')
+      expect(markup).toContain('lucide-message-circle-question-mark')
       expect(markup).toContain('text-amber-500')
       expect(markup).not.toContain('bg-amber-500')
+      expect(markup).not.toContain('data-agent-spinner')
     }
   )
 

--- a/src/renderer/src/components/AgentStateDot.test.ts
+++ b/src/renderer/src/components/AgentStateDot.test.ts
@@ -47,12 +47,16 @@ describe('AgentStateDot', () => {
   })
 
   it.each(['permission', 'waiting'] satisfies AgentDotState[])(
-    'renders %s as an amber attention dot',
+    'renders %s as an amber question glyph',
     (state) => {
-      const classNames = renderDotClassNames(state)
+      const markup = renderMarkup(state)
 
-      expect(classNames).toContain('bg-amber-500')
-      expect(classNames).not.toContain('bg-red-500')
+      // Why: the "needs you" states share the dashboard's MessageCircleQuestion
+      // glyph rather than a bare dot. Assert the lucide class hook + amber text
+      // color without coupling to the exact SVG path lucide emits.
+      expect(markup).toContain('lucide-message-circle-question')
+      expect(markup).toContain('text-amber-500')
+      expect(markup).not.toContain('bg-amber-500')
     }
   )
 

--- a/src/renderer/src/components/AgentStateDot.tsx
+++ b/src/renderer/src/components/AgentStateDot.tsx
@@ -96,11 +96,6 @@ export const AgentStateDot = React.memo(function AgentStateDot({
   }
 
   if (state === 'permission' || state === 'waiting') {
-    // Why: the "needs you" states (an agent asking a question / awaiting
-    // input) render the same MessageCircleQuestion glyph the dashboard card
-    // uses for its pending-question pill, so "an agent needs you" reads
-    // identically across the board, sidebar rows, and terminal tabs instead
-    // of as an ambiguous amber dot. Amber still carries the attention color.
     return (
       <span
         className={cn('inline-flex shrink-0 items-center justify-center', box, className)}

--- a/src/renderer/src/components/AgentStateDot.tsx
+++ b/src/renderer/src/components/AgentStateDot.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { CircleCheck } from 'lucide-react'
+import { CircleCheck, MessageCircleQuestion } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { AgentWorkingSpinner } from '@/components/AgentWorkingSpinner'
 
@@ -95,6 +95,22 @@ export const AgentStateDot = React.memo(function AgentStateDot({
     )
   }
 
+  if (state === 'permission' || state === 'waiting') {
+    // Why: the "needs you" states (an agent asking a question / awaiting
+    // input) render the same MessageCircleQuestion glyph the dashboard card
+    // uses for its pending-question pill, so "an agent needs you" reads
+    // identically across the board, sidebar rows, and terminal tabs instead
+    // of as an ambiguous amber dot. Amber still carries the attention color.
+    return (
+      <span
+        className={cn('inline-flex shrink-0 items-center justify-center', box, className)}
+        aria-label={agentStateLabel(state)}
+      >
+        <MessageCircleQuestion className={cn('text-amber-500', icon)} aria-hidden="true" />
+      </span>
+    )
+  }
+
   return (
     <span
       className={cn('inline-flex shrink-0 items-center justify-center', box, className)}
@@ -104,11 +120,9 @@ export const AgentStateDot = React.memo(function AgentStateDot({
         className={cn(
           'block rounded-full',
           inner,
-          state === 'permission' || state === 'waiting'
-            ? 'bg-amber-500'
-            : state === 'blocked' || state === 'interrupted' || state === 'failed'
-              ? 'bg-red-500'
-              : 'bg-neutral-500/40'
+          state === 'blocked' || state === 'interrupted' || state === 'failed'
+            ? 'bg-red-500'
+            : 'bg-neutral-500/40'
         )}
       />
     </span>

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.test.tsx
@@ -60,6 +60,30 @@ describe('AgentKanbanCard', () => {
     expect(screen.queryByText(/\d+d/)).not.toBeInTheDocument()
   })
 
+  it('shows the question glyph once when a summary is available', () => {
+    const attentionCard = card({
+      bucket: 'attention',
+      dotState: 'waiting',
+      askSummary: 'Approve deploy?'
+    })
+    const { container, rerender } = render(
+      <AgentKanbanCard card={attentionCard} now={2_000} onOpenTerminal={vi.fn()} />
+    )
+
+    expect(screen.queryByTestId('state-dot')).not.toBeInTheDocument()
+    expect(container.querySelectorAll('.lucide-message-circle-question-mark')).toHaveLength(1)
+
+    rerender(
+      <AgentKanbanCard
+        card={{ ...attentionCard, askSummary: undefined }}
+        now={2_000}
+        onOpenTerminal={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('state-dot')).toBeInTheDocument()
+    expect(container.querySelector('.lucide-message-circle-question-mark')).toBeNull()
+  })
+
   it('skips structured-clone rerenders until visible card data or its age changes', () => {
     const onOpenTerminal = vi.fn()
     const initial = card({ startedAt: 1_000 })

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
@@ -98,9 +98,7 @@ export const AgentKanbanCard = memo(
           >
             {card.worktreeName}
           </span>
-          {/* Why: a pending question already renders the amber
-              MessageCircleQuestion glyph in the summary pill below, so suppress
-              the header state glyph here to avoid showing "needs you" twice. */}
+          {/* The summary pill already carries the attention glyph. */}
           {card.askSummary ? null : <AgentStateDot state={card.dotState} className="ml-auto" />}
         </div>
 

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
@@ -98,7 +98,10 @@ export const AgentKanbanCard = memo(
           >
             {card.worktreeName}
           </span>
-          <AgentStateDot state={card.dotState} className="ml-auto" />
+          {/* Why: a pending question already renders the amber
+              MessageCircleQuestion glyph in the summary pill below, so suppress
+              the header state glyph here to avoid showing "needs you" twice. */}
+          {card.askSummary ? null : <AgentStateDot state={card.dotState} className="ml-auto" />}
         </div>
 
         {card.lastUserMessage || card.lastAgentMessage ? (

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
@@ -252,9 +252,7 @@ describe('DashboardAgentRow', () => {
     const tokens = classTokens(markup)
 
     expect(markup).toContain('aria-label="Waiting for input"')
-    // Why: the "needs you" states render the amber MessageCircleQuestion glyph
-    // rather than a bare amber dot (unified across the board/sidebar).
-    expect(markup).toContain('lucide-message-circle-question')
+    expect(markup).toContain('lucide-message-circle-question-mark')
     expect(tokens).toContain('text-amber-500')
     expect(tokens).not.toContain('bg-red-500')
   })

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
@@ -247,12 +247,15 @@ describe('DashboardAgentRow', () => {
     expect(classes.every((className) => !/\bgroup-hover:/.test(className))).toBe(true)
   })
 
-  it('renders waiting rows with the amber permission color', () => {
+  it('renders waiting rows with the amber question glyph', () => {
     const markup = renderRow(makeAgent({}, { state: 'waiting' }))
     const tokens = classTokens(markup)
 
     expect(markup).toContain('aria-label="Waiting for input"')
-    expect(tokens).toContain('bg-amber-500')
+    // Why: the "needs you" states render the amber MessageCircleQuestion glyph
+    // rather than a bare amber dot (unified across the board/sidebar).
+    expect(markup).toContain('lucide-message-circle-question')
+    expect(tokens).toContain('text-amber-500')
     expect(tokens).not.toContain('bg-red-500')
   })
 

--- a/src/renderer/src/components/sidebar/SidebarNav.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.test.tsx
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   refreshPreflightStatus: vi.fn(),
   checkLinearConnection: vi.fn(),
   hasPairedMobileDevice: false,
+  agentBucketCounts: { attention: 0, working: 0, idle: 0 },
   dismissMobileOnboardingBadge: vi.fn(),
   setSetupGuideSidebarDismissed: vi.fn()
 }))
@@ -37,6 +38,10 @@ vi.mock('@/store/selectors', () => ({
 
 vi.mock('@/components/activity/useActivityUnreadCount', () => ({
   useActivityUnreadCount: () => 0
+}))
+
+vi.mock('@/components/dashboard/useAgentBucketCounts', () => ({
+  useAgentBucketCounts: () => mocks.agentBucketCounts
 }))
 
 vi.mock('@/hooks/useShortcutLabel', () => ({
@@ -203,6 +208,7 @@ describe('SidebarNav', () => {
     vi.clearAllMocks()
     await i18n.changeLanguage('en')
     mocks.hasPairedMobileDevice = false
+    mocks.agentBucketCounts = { attention: 0, working: 0, idle: 0 }
     setSidebarState()
   })
 
@@ -250,6 +256,26 @@ describe('SidebarNav', () => {
     const container = await renderSidebarNav()
 
     expect(queryButtonByText(container, 'Agent Dashboard')).not.toBeNull()
+  })
+
+  it('uses a question glyph only for the Needs You count', async () => {
+    mocks.agentBucketCounts = { attention: 2, working: 3, idle: 4 }
+    setSidebarState({
+      settings: {
+        ...getDefaultSettings('/tmp'),
+        experimentalAgentDashboardPopout: true
+      }
+    })
+    const container = await renderSidebarNav()
+
+    const attention = container.querySelector('[aria-label="Needs You: 2"]')
+    const working = container.querySelector('[aria-label="Working: 3"]')
+    const idle = container.querySelector('[aria-label="Idle: 4"]')
+    expect(attention?.querySelector('.lucide-message-circle-question-mark')).not.toBeNull()
+    expect(working?.querySelector('.rounded-full')).not.toBeNull()
+    expect(idle?.querySelector('.rounded-full')).not.toBeNull()
+    expect(working?.querySelector('svg')).toBeNull()
+    expect(idle?.querySelector('svg')).toBeNull()
   })
 
   it('shows the Mobile entry by default for older settings', () => {

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -52,10 +52,6 @@ export function shouldShowAutomationsButton(
   return settings?.showAutomationsButton !== false
 }
 
-// Per-state markers mirror AgentStateDot so the sidebar counts read the same as
-// the board: 'attention' (needs you) renders the amber MessageCircleQuestion
-// glyph — the same one the board and status dots now use — while the calmer
-// buckets stay dots (yellow = working, neutral = idle).
 const DASHBOARD_BUCKET_DOT_CLASS: Record<'working' | 'idle', string> = {
   working: 'bg-yellow-500',
   idle: 'bg-neutral-500/50'

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -1,5 +1,13 @@
 import React from 'react'
-import { Bell, CalendarClock, EyeOff, LayoutDashboard, Search, Smartphone } from 'lucide-react'
+import {
+  Bell,
+  CalendarClock,
+  EyeOff,
+  LayoutDashboard,
+  MessageCircleQuestion,
+  Search,
+  Smartphone
+} from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
@@ -44,10 +52,11 @@ export function shouldShowAutomationsButton(
   return settings?.showAutomationsButton !== false
 }
 
-// Per-state dot colors mirror AgentStateDot so the sidebar counts read the same
-// as the board (amber = needs you, yellow = working, neutral = idle, emerald = done).
-const DASHBOARD_BUCKET_DOT_CLASS: Record<DashboardBucket, string> = {
-  attention: 'bg-amber-500',
+// Per-state markers mirror AgentStateDot so the sidebar counts read the same as
+// the board: 'attention' (needs you) renders the amber MessageCircleQuestion
+// glyph — the same one the board and status dots now use — while the calmer
+// buckets stay dots (yellow = working, neutral = idle).
+const DASHBOARD_BUCKET_DOT_CLASS: Record<'working' | 'idle', string> = {
   working: 'bg-yellow-500',
   idle: 'bg-neutral-500/50'
 }
@@ -80,7 +89,11 @@ function DashboardBucketCounts({
           aria-label={`${dashboardBucketLabel(bucket)}: ${counts[bucket]}`}
           className="inline-flex items-center gap-1 text-[10px] tabular-nums text-worktree-sidebar-foreground/55"
         >
-          <span className={cn('size-1.5 rounded-full', DASHBOARD_BUCKET_DOT_CLASS[bucket])} />
+          {bucket === 'attention' ? (
+            <MessageCircleQuestion className="size-2.5 text-amber-500" aria-hidden />
+          ) : (
+            <span className={cn('size-1.5 rounded-full', DASHBOARD_BUCKET_DOT_CLASS[bucket])} />
+          )}
           {counts[bucket]}
         </span>
       ))}

--- a/src/renderer/src/components/sidebar/StatusIndicator.test.ts
+++ b/src/renderer/src/components/sidebar/StatusIndicator.test.ts
@@ -35,12 +35,10 @@ describe('StatusIndicator', () => {
   it('renders permission as an amber question glyph', () => {
     const markup = renderMarkup('permission')
 
-    // Why: the "needs permission / needs you" state renders the dashboard's
-    // MessageCircleQuestion glyph rather than a bare amber dot. Assert the
-    // lucide class hook + amber text color without coupling to the SVG path.
-    expect(markup).toContain('lucide-message-circle-question')
+    expect(markup).toContain('lucide-message-circle-question-mark')
     expect(markup).toContain('text-amber-500')
     expect(markup).not.toContain('bg-amber-500')
+    expect(markup).not.toContain('data-agent-spinner')
   })
 
   it('renders active as full emerald dot', () => {

--- a/src/renderer/src/components/sidebar/StatusIndicator.test.ts
+++ b/src/renderer/src/components/sidebar/StatusIndicator.test.ts
@@ -32,11 +32,15 @@ describe('StatusIndicator', () => {
     expect(markup).not.toContain('animation:spin')
   })
 
-  it('renders permission as an amber attention dot', () => {
-    const classNames = renderDotClassNames('permission')
+  it('renders permission as an amber question glyph', () => {
+    const markup = renderMarkup('permission')
 
-    expect(classNames).toContain('bg-amber-500')
-    expect(classNames).not.toContain('bg-red-500')
+    // Why: the "needs permission / needs you" state renders the dashboard's
+    // MessageCircleQuestion glyph rather than a bare amber dot. Assert the
+    // lucide class hook + amber text color without coupling to the SVG path.
+    expect(markup).toContain('lucide-message-circle-question')
+    expect(markup).toContain('text-amber-500')
+    expect(markup).not.toContain('bg-amber-500')
   })
 
   it('renders active as full emerald dot', () => {

--- a/src/renderer/src/components/sidebar/StatusIndicator.tsx
+++ b/src/renderer/src/components/sidebar/StatusIndicator.tsx
@@ -41,10 +41,6 @@ const StatusIndicator = React.memo(function StatusIndicator({
   }
 
   if (status === 'permission') {
-    // Why: the "needs permission / needs you" state renders the same
-    // MessageCircleQuestion glyph the agent dashboard uses, so the sidebar's
-    // worktree-level status matches the board and agent-row indicators
-    // instead of showing a bare amber dot. Amber keeps the attention color.
     return (
       <span
         className={cn('inline-flex h-3 w-3 shrink-0 items-center justify-center', className)}

--- a/src/renderer/src/components/sidebar/StatusIndicator.tsx
+++ b/src/renderer/src/components/sidebar/StatusIndicator.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { MessageCircleQuestion } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { AgentWorkingSpinner } from '@/components/AgentWorkingSpinner'
 import { getWorktreeStatusLabel, type WorktreeStatus } from '@/lib/worktree-status'
@@ -39,6 +40,22 @@ const StatusIndicator = React.memo(function StatusIndicator({
     )
   }
 
+  if (status === 'permission') {
+    // Why: the "needs permission / needs you" state renders the same
+    // MessageCircleQuestion glyph the agent dashboard uses, so the sidebar's
+    // worktree-level status matches the board and agent-row indicators
+    // instead of showing a bare amber dot. Amber keeps the attention color.
+    return (
+      <span
+        className={cn('inline-flex h-3 w-3 shrink-0 items-center justify-center', className)}
+        title={resolvedTitle}
+        {...rest}
+      >
+        <MessageCircleQuestion className="size-3 text-amber-500" aria-hidden="true" />
+      </span>
+    )
+  }
+
   return (
     <span
       className={cn('inline-flex h-3 w-3 shrink-0 items-center justify-center', className)}
@@ -48,14 +65,12 @@ const StatusIndicator = React.memo(function StatusIndicator({
       <span
         className={cn(
           'block size-2 rounded-full',
-          status === 'permission'
-            ? 'bg-amber-500'
-            : status === 'done' || status === 'active'
-              ? // Green dot for both hook-reported 'done' and the heuristic
-                // 'active' (terminal open, quiet). Working uses a yellow
-                // ring above; 'inactive' stays grey.
-                'bg-emerald-500'
-              : 'bg-neutral-500/40'
+          status === 'done' || status === 'active'
+            ? // Green dot for both hook-reported 'done' and the heuristic
+              // 'active' (terminal open, quiet). Working uses a yellow
+              // ring above; 'inactive' stays grey.
+              'bg-emerald-500'
+            : 'bg-neutral-500/40'
         )}
       />
     </span>

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
@@ -126,7 +126,10 @@ describe('WorktreeCardStatusSlot', () => {
     )
 
     expect(markup).toContain('Needs permission · Unread')
-    expect(markup).toContain('bg-amber-500')
+    // Why: the permission status renders the amber MessageCircleQuestion glyph
+    // rather than a bare amber dot.
+    expect(markup).toContain('lucide-message-circle-question')
+    expect(markup).toContain('text-amber-500')
     expect(markup).not.toContain('data-worktree-status-lane-unread=""')
     expect(markup).not.toContain('data-worktree-unread-alert=""')
     expect(markup).not.toContain('aria-label="Mark as read"')
@@ -378,7 +381,8 @@ describe('WorktreeCardStatusSlot', () => {
     )
 
     expect(markup).toContain('Needs permission')
-    expect(markup).toContain('bg-amber-500')
+    expect(markup).toContain('lucide-message-circle-question')
+    expect(markup).toContain('text-amber-500')
     expect(markup).not.toContain('PR checks: Failed')
   })
 

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
@@ -126,9 +126,7 @@ describe('WorktreeCardStatusSlot', () => {
     )
 
     expect(markup).toContain('Needs permission · Unread')
-    // Why: the permission status renders the amber MessageCircleQuestion glyph
-    // rather than a bare amber dot.
-    expect(markup).toContain('lucide-message-circle-question')
+    expect(markup).toContain('lucide-message-circle-question-mark')
     expect(markup).toContain('text-amber-500')
     expect(markup).not.toContain('data-worktree-status-lane-unread=""')
     expect(markup).not.toContain('data-worktree-unread-alert=""')
@@ -381,7 +379,7 @@ describe('WorktreeCardStatusSlot', () => {
     )
 
     expect(markup).toContain('Needs permission')
-    expect(markup).toContain('lucide-message-circle-question')
+    expect(markup).toContain('lucide-message-circle-question-mark')
     expect(markup).toContain('text-amber-500')
     expect(markup).not.toContain('PR checks: Failed')
   })

--- a/src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.test.tsx
+++ b/src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.test.tsx
@@ -40,9 +40,7 @@ describe('TerminalTabLeadingIcon', () => {
     const markup = renderStatus('permission')
 
     expect(markup).toContain('data-agent-activity-status="permission"')
-    // Why: the "needs you" states render the amber MessageCircleQuestion glyph
-    // rather than a bare amber dot (unified across board/sidebar/tabs).
-    expect(markup).toContain('lucide-message-circle-question')
+    expect(markup).toContain('lucide-message-circle-question-mark')
     expect(markup).toContain('text-amber-500')
     expect(markup).not.toContain('bg-red-500')
   })

--- a/src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.test.tsx
+++ b/src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.test.tsx
@@ -36,11 +36,14 @@ describe('TerminalTabLeadingIcon', () => {
     expect(markup).toContain('data-agent-icon="codex"')
   })
 
-  it('shows a needs-input (permission) state as an amber dot', () => {
+  it('shows a needs-input (permission) state as an amber question glyph', () => {
     const markup = renderStatus('permission')
 
     expect(markup).toContain('data-agent-activity-status="permission"')
-    expect(markup).toContain('bg-amber-500')
+    // Why: the "needs you" states render the amber MessageCircleQuestion glyph
+    // rather than a bare amber dot (unified across board/sidebar/tabs).
+    expect(markup).toContain('lucide-message-circle-question')
+    expect(markup).toContain('text-amber-500')
     expect(markup).not.toContain('bg-red-500')
   })
 


### PR DESCRIPTION
## What

Unifies the "needs you / asking a question / waiting" indicator across every surface: it now renders the dashboard's `MessageCircleQuestion` chat glyph (in amber) instead of a bare amber dot.

Previously only the agent-dashboard **card pill** used the chat icon; every other surface showed an amber dot for the same state, and nothing tied them together visually.

### Surfaces updated
- **Agent dashboard cards** (`AgentKanbanCard`) — header state glyph
- **In-app dashboard rows** (`DashboardAgentRow`)
- **Agent Dashboard sidebar quick-indicator** counts (`SidebarNav` — the `attention` / "Needs You" bucket)
- **Worktree-level sidebar status dot** (`StatusIndicator` — `permission`)
- **Shared agent-row + terminal-tab indicators** via the `AgentStateDot` primitive (compact sidebar agent rows, tab leading icon, AI-Vault rows)

### How
- `AgentStateDot`: `waiting`/`permission` now render `MessageCircleQuestion` in `text-amber-500`, mirroring how `done` renders `CircleCheck`. This one change covers most surfaces.
- `StatusIndicator`: `permission` renders the same amber glyph (worktree-level status is not driven by `AgentStateDot`).
- `SidebarNav`: the `attention` bucket count renders the glyph; `working`/`idle` stay colored dots.
- `AgentKanbanCard`: the header glyph is **suppressed when a question summary pill is present**, so the card shows "needs you" once, not twice.

### Out of scope (intentionally untouched)
- `AgentKanbanBoard` "Needs You" **column border** highlight (a column accent, not a status dot).
- Unread badge/bell amber in `WorktreeCardStatusSlot` (unread signal, unrelated state).

## Testing
- Updated `AgentStateDot.test.ts` and `StatusIndicator.test.ts` to assert the `lucide-message-circle-question` + `text-amber-500` glyph.
- Renderer typecheck, oxlint, and affected vitest suites pass.

Screenshots of each surface to follow.