### PR TITLE
fix(browser): prevent invalid grab payloads on Zone.js pages

### DIFF
--- a/src/main/browser/browser-grab-screenshot.ts
+++ b/src/main/browser/browser-grab-screenshot.ts
@@ -1,5 +1,6 @@
 import type { BrowserGrabRect, BrowserGrabScreenshot } from '../../shared/browser-grab-types'
 import { GRAB_BUDGET } from '../../shared/browser-grab-types'
+import { executeBrowserGrabScript } from './browser-grab-script-executor'
 
 const HIDE_BROWSER_GRAB_OVERLAY_SCRIPT = `(function(){
   var g = window.__orcaGrab;
@@ -44,12 +45,12 @@ export async function captureSelectionScreenshot(
     // label don't appear in the screenshot. The overlay is restored after.
     // Wrapped in try/finally so the overlay is always restored even if
     // capturePage() throws (e.g., guest destroyed mid-capture).
-    await guest.executeJavaScript(HIDE_BROWSER_GRAB_OVERLAY_SCRIPT).catch(() => {})
+    await executeBrowserGrabScript(guest, HIDE_BROWSER_GRAB_OVERLAY_SCRIPT).catch(() => {})
     let image: Electron.NativeImage
     try {
       image = await guest.capturePage()
     } finally {
-      await guest.executeJavaScript(RESTORE_BROWSER_GRAB_OVERLAY_SCRIPT).catch(() => {})
+      await executeBrowserGrabScript(guest, RESTORE_BROWSER_GRAB_OVERLAY_SCRIPT).catch(() => {})
     }
     if (image.isEmpty()) {
       return null

--- a/src/main/browser/browser-grab-script-executor.test.ts
+++ b/src/main/browser/browser-grab-script-executor.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest'
+import { BROWSER_GRAB_WORLD_ID, executeBrowserGrabScript } from './browser-grab-script-executor'
+
+describe('executeBrowserGrabScript', () => {
+  it('runs grab scripts in the dedicated isolated world', async () => {
+    const executeJavaScriptInIsolatedWorld = vi.fn().mockResolvedValue({ page: {}, target: {} })
+    const guest = { executeJavaScriptInIsolatedWorld } as unknown as Electron.WebContents
+
+    await executeBrowserGrabScript(
+      guest,
+      'new Promise((resolve) => resolve({ page: {}, target: {} }))'
+    )
+
+    expect(executeJavaScriptInIsolatedWorld).toHaveBeenCalledWith(
+      BROWSER_GRAB_WORLD_ID,
+      [{ code: 'new Promise((resolve) => resolve({ page: {}, target: {} }))' }],
+      false
+    )
+  })
+})

--- a/src/main/browser/browser-grab-script-executor.test.ts
+++ b/src/main/browser/browser-grab-script-executor.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
-import { BROWSER_GRAB_WORLD_ID, executeBrowserGrabScript } from './browser-grab-script-executor'
+import {
+  BROWSER_GRAB_WORLD_ID,
+  executeBrowserGrabPageScript,
+  executeBrowserGrabScript
+} from './browser-grab-script-executor'
 
 describe('executeBrowserGrabScript', () => {
   it('runs grab scripts in the dedicated isolated world', async () => {
@@ -16,5 +20,16 @@ describe('executeBrowserGrabScript', () => {
       [{ code: 'new Promise((resolve) => resolve({ page: {}, target: {} }))' }],
       false
     )
+  })
+})
+
+describe('executeBrowserGrabPageScript', () => {
+  it('executes the script in the guest page world', async () => {
+    const executeJavaScript = vi.fn().mockResolvedValue(true)
+    const guest = { executeJavaScript } as unknown as Electron.WebContents
+
+    await executeBrowserGrabPageScript(guest, 'true')
+
+    expect(executeJavaScript).toHaveBeenCalledWith('true')
   })
 })

--- a/src/main/browser/browser-grab-script-executor.ts
+++ b/src/main/browser/browser-grab-script-executor.ts
@@ -1,0 +1,9 @@
+// Why: keep grab state and Promise resolution away from page-patched globals.
+export const BROWSER_GRAB_WORLD_ID = 1209
+
+export function executeBrowserGrabScript(
+  guest: Electron.WebContents,
+  script: string
+): Promise<unknown> {
+  return guest.executeJavaScriptInIsolatedWorld(BROWSER_GRAB_WORLD_ID, [{ code: script }], false)
+}

--- a/src/main/browser/browser-grab-script-executor.ts
+++ b/src/main/browser/browser-grab-script-executor.ts
@@ -7,3 +7,10 @@ export function executeBrowserGrabScript(
 ): Promise<unknown> {
   return guest.executeJavaScriptInIsolatedWorld(BROWSER_GRAB_WORLD_ID, [{ code: script }], false)
 }
+
+export function executeBrowserGrabPageScript(
+  guest: Electron.WebContents,
+  script: string
+): Promise<unknown> {
+  return guest.executeJavaScript(script)
+}

--- a/src/main/browser/browser-grab-session-controller.ts
+++ b/src/main/browser/browser-grab-session-controller.ts
@@ -1,6 +1,7 @@
 import type { BrowserGrabCancelReason, BrowserGrabResult } from '../../shared/browser-grab-types'
 import { buildGuestOverlayScript } from './grab-guest-script'
 import { clampGrabPayload } from './browser-grab-payload'
+import { executeBrowserGrabScript } from './browser-grab-script-executor'
 
 /** Tracks the lifecycle of a single grab operation on one browser tab. */
 type ActiveGrabOp = {
@@ -123,13 +124,14 @@ export class BrowserGrabSessionController {
         resolve(result)
       }
 
-      // Why: the guest overlay runtime handles the click in-page and calls
-      // __orcaGrabResolve() which is wired by the 'awaitClick' script to
-      // resolve the executeJavaScript Promise with the extracted payload.
-      // Main just needs to run that script and await its result.
+      // Why: the guest overlay runtime handles the click in the isolated world
+      // and resolves the await-click script with the extracted payload.
       const awaitGuestClick = async (): Promise<void> => {
         try {
-          const rawPayload = await guest.executeJavaScript(buildGuestOverlayScript('awaitClick'))
+          const rawPayload = await executeBrowserGrabScript(
+            guest,
+            buildGuestOverlayScript('awaitClick')
+          )
           if (!rawPayload || typeof rawPayload !== 'object') {
             settleOnce({ opId, kind: 'cancelled', reason: 'user' })
             return
@@ -213,7 +215,7 @@ export class BrowserGrabSessionController {
         }
         try {
           if (!guest.isDestroyed()) {
-            void guest.executeJavaScript(buildGuestOverlayScript('teardown'))
+            void executeBrowserGrabScript(guest, buildGuestOverlayScript('teardown'))
           }
         } catch {
           // Best-effort overlay removal

--- a/src/main/browser/browser-grab-session-controller.ts
+++ b/src/main/browser/browser-grab-session-controller.ts
@@ -1,7 +1,10 @@
 import type { BrowserGrabCancelReason, BrowserGrabResult } from '../../shared/browser-grab-types'
-import { buildGuestOverlayScript } from './grab-guest-script'
+import { buildGuestOverlayScript, buildGuestReactMetadataBridgeScript } from './grab-guest-script'
 import { clampGrabPayload } from './browser-grab-payload'
-import { executeBrowserGrabScript } from './browser-grab-script-executor'
+import {
+  executeBrowserGrabPageScript,
+  executeBrowserGrabScript
+} from './browser-grab-script-executor'
 
 /** Tracks the lifecycle of a single grab operation on one browser tab. */
 type ActiveGrabOp = {
@@ -216,6 +219,10 @@ export class BrowserGrabSessionController {
         try {
           if (!guest.isDestroyed()) {
             void executeBrowserGrabScript(guest, buildGuestOverlayScript('teardown'))
+            void executeBrowserGrabPageScript(
+              guest,
+              buildGuestReactMetadataBridgeScript('teardown')
+            )
           }
         } catch {
           // Best-effort overlay removal

--- a/src/main/browser/browser-manager-grab.test.ts
+++ b/src/main/browser/browser-manager-grab.test.ts
@@ -5,6 +5,7 @@ mock setup and make it harder to verify the grab contract holistically. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { GRAB_BUDGET } from '../../shared/browser-grab-types'
 import type { BrowserGrabPayload } from '../../shared/browser-grab-types'
+import { BROWSER_GRAB_WORLD_ID } from './browser-grab-script-executor'
 
 const {
   webContentsFromIdMock,
@@ -177,13 +178,17 @@ describe('browserManager grab operations', () => {
     it('injects overlay when enabling grab mode', async () => {
       const result = await browserManager.setGrabMode('tab-1', true, guest)
       expect(result).toBe(true)
-      expect(guestExecuteJavaScriptMock).toHaveBeenCalledTimes(1)
-      expect(guestExecuteJavaScriptMock.mock.calls[0][0]).toContain('__orca-grab-host')
+      expect(guestExecuteJavaScriptInIsolatedWorldMock).toHaveBeenCalledTimes(1)
+      expect(guestExecuteJavaScriptInIsolatedWorldMock).toHaveBeenCalledWith(
+        BROWSER_GRAB_WORLD_ID,
+        [{ code: expect.stringContaining('__orca-grab-host') }],
+        false
+      )
     })
 
     it('cancels active grab op when disabling', async () => {
       // Start a grab op first
-      guestExecuteJavaScriptMock.mockImplementation(() => new Promise(() => {}))
+      guestExecuteJavaScriptInIsolatedWorldMock.mockImplementation(() => new Promise(() => {}))
       const selectionPromise = browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
 
       // Disable grab mode
@@ -196,7 +201,7 @@ describe('browserManager grab operations', () => {
     })
 
     it('returns false if injection fails', async () => {
-      guestExecuteJavaScriptMock.mockRejectedValue(new Error('Injection failed'))
+      guestExecuteJavaScriptInIsolatedWorldMock.mockRejectedValue(new Error('Injection failed'))
       const result = await browserManager.setGrabMode('tab-1', true, guest)
       expect(result).toBe(false)
     })
@@ -256,7 +261,7 @@ describe('browserManager grab operations', () => {
     })
 
     it('forwards bare s from the guest while a grab op is active', async () => {
-      guestExecuteJavaScriptMock.mockImplementation(() => new Promise(() => {}))
+      guestExecuteJavaScriptInIsolatedWorldMock.mockImplementation(() => new Promise(() => {}))
       void browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
 
       const handler = guestOnMock.mock.calls.find(
@@ -318,7 +323,7 @@ describe('browserManager grab operations', () => {
     })
 
     it('returns true when a grab is active', () => {
-      guestExecuteJavaScriptMock.mockImplementation(() => new Promise(() => {}))
+      guestExecuteJavaScriptInIsolatedWorldMock.mockImplementation(() => new Promise(() => {}))
       void browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
       expect(browserManager.hasActiveGrabOp('tab-1')).toBe(true)
     })
@@ -376,7 +381,7 @@ describe('browserManager grab operations', () => {
       }
 
       // The awaitClick script returns a Promise; simulate it resolving
-      guestExecuteJavaScriptMock.mockResolvedValueOnce(mockPayload)
+      guestExecuteJavaScriptInIsolatedWorldMock.mockResolvedValueOnce(mockPayload)
 
       const result = await browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
       expect(result.kind).toBe('selected')
@@ -387,35 +392,35 @@ describe('browserManager grab operations', () => {
     })
 
     it('resolves with cancelled when guest returns null', async () => {
-      guestExecuteJavaScriptMock.mockResolvedValueOnce(null)
+      guestExecuteJavaScriptInIsolatedWorldMock.mockResolvedValueOnce(null)
 
       const result = await browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
       expect(result.kind).toBe('cancelled')
     })
 
     it('resolves with cancelled when guest returns teardown cancellation marker', async () => {
-      guestExecuteJavaScriptMock.mockResolvedValueOnce({ __orcaCancelled: true })
+      guestExecuteJavaScriptInIsolatedWorldMock.mockResolvedValueOnce({ __orcaCancelled: true })
 
       const result = await browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
       expect(result).toEqual({ opId: 'op-1', kind: 'cancelled', reason: 'user' })
     })
 
     it('resolves with cancelled when guest returns a serialized cancelled error', async () => {
-      guestExecuteJavaScriptMock.mockResolvedValueOnce({ message: 'cancelled' })
+      guestExecuteJavaScriptInIsolatedWorldMock.mockResolvedValueOnce({ message: 'cancelled' })
 
       const result = await browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
       expect(result).toEqual({ opId: 'op-1', kind: 'cancelled', reason: 'user' })
     })
 
     it('resolves with cancelled when executeJavaScript rejects a serialized cancelled error', async () => {
-      guestExecuteJavaScriptMock.mockRejectedValueOnce({ message: 'cancelled' })
+      guestExecuteJavaScriptInIsolatedWorldMock.mockRejectedValueOnce({ message: 'cancelled' })
 
       const result = await browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
       expect(result).toEqual({ opId: 'op-1', kind: 'cancelled', reason: 'user' })
     })
 
     it('does not treat a valid payload message field as cancellation', async () => {
-      guestExecuteJavaScriptMock.mockResolvedValueOnce({
+      guestExecuteJavaScriptInIsolatedWorldMock.mockResolvedValueOnce({
         ...makeValidGrabPayload(),
         message: 'cancelled'
       })
@@ -428,7 +433,7 @@ describe('browserManager grab operations', () => {
     })
 
     it('resolves with error when executeJavaScript throws', async () => {
-      guestExecuteJavaScriptMock.mockRejectedValueOnce(new Error('Script failed'))
+      guestExecuteJavaScriptInIsolatedWorldMock.mockRejectedValueOnce(new Error('Script failed'))
 
       const result = await browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
       expect(result.kind).toBe('error')
@@ -439,7 +444,7 @@ describe('browserManager grab operations', () => {
 
     it('resolves with error when guest returns structurally invalid payload', async () => {
       // Missing required 'target' field
-      guestExecuteJavaScriptMock.mockResolvedValueOnce({ page: { title: 'test' } })
+      guestExecuteJavaScriptInIsolatedWorldMock.mockResolvedValueOnce({ page: { title: 'test' } })
 
       const result = await browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
       expect(result.kind).toBe('error')
@@ -504,7 +509,7 @@ describe('browserManager grab operations', () => {
         screenshot: null
       }
 
-      guestExecuteJavaScriptMock.mockResolvedValueOnce(mockPayload)
+      guestExecuteJavaScriptInIsolatedWorldMock.mockResolvedValueOnce(mockPayload)
       const result = await browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
       expect(result.kind).toBe('selected')
       if (result.kind === 'selected') {
@@ -573,7 +578,7 @@ describe('browserManager grab operations', () => {
         screenshot: null
       }
 
-      guestExecuteJavaScriptMock.mockResolvedValueOnce(mockPayload)
+      guestExecuteJavaScriptInIsolatedWorldMock.mockResolvedValueOnce(mockPayload)
       const result = await browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
       expect(result.kind).toBe('selected')
       if (result.kind === 'selected') {
@@ -583,12 +588,12 @@ describe('browserManager grab operations', () => {
     })
 
     it('cancels previous op when starting a new one on same tab', async () => {
-      guestExecuteJavaScriptMock.mockImplementation(() => new Promise(() => {}))
+      guestExecuteJavaScriptInIsolatedWorldMock.mockImplementation(() => new Promise(() => {}))
 
       const promise1 = browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
 
       // Start a second grab op on same tab
-      guestExecuteJavaScriptMock.mockImplementation(() => new Promise(() => {}))
+      guestExecuteJavaScriptInIsolatedWorldMock.mockImplementation(() => new Promise(() => {}))
       void browserManager.awaitGrabSelection('tab-1', 'op-2', guest)
 
       const result1 = await promise1
@@ -599,31 +604,31 @@ describe('browserManager grab operations', () => {
     it('replacement op skips teardown injection to preserve overlay', async () => {
       // Why: when replacing an op, the old op's cleanup must NOT inject the
       // teardown script because the new op reuses the already-armed overlay.
-      guestExecuteJavaScriptMock.mockImplementation(() => new Promise(() => {}))
+      guestExecuteJavaScriptInIsolatedWorldMock.mockImplementation(() => new Promise(() => {}))
 
       void browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
 
       // Record call count before replacement
-      const callCountBefore = guestExecuteJavaScriptMock.mock.calls.length
+      const callCountBefore = guestExecuteJavaScriptInIsolatedWorldMock.mock.calls.length
 
       // Replace with a new op
-      guestExecuteJavaScriptMock.mockImplementation(() => new Promise(() => {}))
+      guestExecuteJavaScriptInIsolatedWorldMock.mockImplementation(() => new Promise(() => {}))
       void browserManager.awaitGrabSelection('tab-1', 'op-2', guest)
 
       // The only new executeJavaScript call should be the awaitClick for op-2.
       // No teardown should have been injected for op-1's cleanup.
       // Why: distinguish teardown from awaitClick — both contain 'cancelAwait',
       // but only the teardown script contains 'if (!grab) return true;'.
-      const newCalls = guestExecuteJavaScriptMock.mock.calls.slice(callCountBefore)
-      const teardownCalls = newCalls.filter(([script]) =>
-        (script as string).includes('if (!grab) return true;')
+      const newCalls = guestExecuteJavaScriptInIsolatedWorldMock.mock.calls.slice(callCountBefore)
+      const teardownCalls = newCalls.filter(([, scripts]) =>
+        (scripts as { code: string }[])[0]?.code.includes('if (!grab) return true;')
       )
       expect(teardownCalls).toHaveLength(0)
     })
 
     it('times out if the guest never settles the armed selection', async () => {
       vi.useFakeTimers()
-      guestExecuteJavaScriptMock.mockImplementation(() => new Promise(() => {}))
+      guestExecuteJavaScriptInIsolatedWorldMock.mockImplementation(() => new Promise(() => {}))
 
       const resultPromise = browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
       await vi.advanceTimersByTimeAsync(120_000)
@@ -636,7 +641,7 @@ describe('browserManager grab operations', () => {
 
     it('ignores a late guest selection after the op was already cancelled', async () => {
       let resolveGuestSelection!: (value: unknown) => void
-      guestExecuteJavaScriptMock.mockImplementation(
+      guestExecuteJavaScriptInIsolatedWorldMock.mockImplementation(
         () =>
           new Promise<unknown>((resolve) => {
             resolveGuestSelection = resolve
@@ -703,7 +708,7 @@ describe('browserManager grab operations', () => {
 
   describe('cancelGrabOp', () => {
     it('resolves active grab with cancelled reason', async () => {
-      guestExecuteJavaScriptMock.mockImplementation(() => new Promise(() => {}))
+      guestExecuteJavaScriptInIsolatedWorldMock.mockImplementation(() => new Promise(() => {}))
 
       const promise = browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
       browserManager.cancelGrabOp('tab-1', 'user')
@@ -718,7 +723,7 @@ describe('browserManager grab operations', () => {
     })
 
     it('supports different cancellation reasons', async () => {
-      guestExecuteJavaScriptMock.mockImplementation(() => new Promise(() => {}))
+      guestExecuteJavaScriptInIsolatedWorldMock.mockImplementation(() => new Promise(() => {}))
 
       const promise = browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
       browserManager.cancelGrabOp('tab-1', 'navigation')
@@ -733,7 +738,7 @@ describe('browserManager grab operations', () => {
 
   describe('unregisterGuest cancels grab', () => {
     it('cancels active grab on unregister', async () => {
-      guestExecuteJavaScriptMock.mockImplementation(() => new Promise(() => {}))
+      guestExecuteJavaScriptInIsolatedWorldMock.mockImplementation(() => new Promise(() => {}))
 
       const promise = browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
       browserManager.unregisterGuest('tab-1')
@@ -744,7 +749,7 @@ describe('browserManager grab operations', () => {
 
     it('cancels active grab when the same tab is re-registered to a new guest', async () => {
       const replacementGuest = makeGuest(202)
-      guestExecuteJavaScriptMock.mockImplementation(() => new Promise(() => {}))
+      guestExecuteJavaScriptInIsolatedWorldMock.mockImplementation(() => new Promise(() => {}))
 
       const promise = browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
       webContentsFromIdMock.mockImplementation((id: number) => {
@@ -776,7 +781,7 @@ describe('browserManager grab operations', () => {
 
   describe('navigation auto-cancel', () => {
     it('cancels grab when guest navigates in main frame', async () => {
-      guestExecuteJavaScriptMock.mockImplementation(() => new Promise(() => {}))
+      guestExecuteJavaScriptInIsolatedWorldMock.mockImplementation(() => new Promise(() => {}))
 
       const promise = browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
 
@@ -793,7 +798,7 @@ describe('browserManager grab operations', () => {
     })
 
     it('does not cancel grab on subframe navigation', async () => {
-      guestExecuteJavaScriptMock.mockImplementation(() => new Promise(() => {}))
+      guestExecuteJavaScriptInIsolatedWorldMock.mockImplementation(() => new Promise(() => {}))
 
       void browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
 
@@ -812,7 +817,7 @@ describe('browserManager grab operations', () => {
 
   describe('destruction auto-cancel', () => {
     it('cancels grab when guest is destroyed', async () => {
-      guestExecuteJavaScriptMock.mockImplementation(() => new Promise(() => {}))
+      guestExecuteJavaScriptInIsolatedWorldMock.mockImplementation(() => new Promise(() => {}))
 
       const promise = browserManager.awaitGrabSelection('tab-1', 'op-1', guest)
 
@@ -856,15 +861,19 @@ describe('browserManager grab operations', () => {
         width: 100,
         height: 50
       })
-      expect(guestExecuteJavaScriptMock).toHaveBeenNthCalledWith(
+      expect(guestExecuteJavaScriptInIsolatedWorldMock).toHaveBeenNthCalledWith(
         1,
-        expect.stringContaining('__orcaGrab')
+        BROWSER_GRAB_WORLD_ID,
+        [{ code: expect.stringContaining('__orcaGrab') }],
+        false
       )
-      expect(guestExecuteJavaScriptMock).toHaveBeenNthCalledWith(
+      expect(guestExecuteJavaScriptInIsolatedWorldMock).toHaveBeenNthCalledWith(
         2,
-        expect.stringContaining('__orcaGrab')
+        BROWSER_GRAB_WORLD_ID,
+        [{ code: expect.stringContaining('__orcaGrab') }],
+        false
       )
-      expect(guestExecuteJavaScriptMock).toHaveBeenNthCalledWith(3, 'window.innerWidth')
+      expect(guestExecuteJavaScriptMock).toHaveBeenCalledWith('window.innerWidth')
     })
 
     it('omits screenshots that exceed the byte budget', async () => {
@@ -892,7 +901,7 @@ describe('browserManager grab operations', () => {
 
   describe('extractHoverPayload', () => {
     it('returns a clamped payload when the guest reports a hovered element', async () => {
-      guestExecuteJavaScriptMock.mockResolvedValueOnce({
+      guestExecuteJavaScriptInIsolatedWorldMock.mockResolvedValueOnce({
         page: {
           sanitizedUrl: 'https://example.com/path?token=secret#hash',
           title: 'Hover target',
@@ -954,7 +963,9 @@ describe('browserManager grab operations', () => {
     })
 
     it('returns null for structurally invalid guest payloads', async () => {
-      guestExecuteJavaScriptMock.mockResolvedValueOnce({ page: { title: 'missing-target' } })
+      guestExecuteJavaScriptInIsolatedWorldMock.mockResolvedValueOnce({
+        page: { title: 'missing-target' }
+      })
 
       const payload = await browserManager.extractHoverPayload('tab-1', guest)
 

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -23,9 +23,12 @@ import type {
   BrowserGrabResult,
   BrowserGrabScreenshot
 } from '../../shared/browser-grab-types'
-import { buildGuestOverlayScript } from './grab-guest-script'
+import { buildGuestOverlayScript, buildGuestReactMetadataBridgeScript } from './grab-guest-script'
 import { clampGrabPayload } from './browser-grab-payload'
-import { executeBrowserGrabScript } from './browser-grab-script-executor'
+import {
+  executeBrowserGrabPageScript,
+  executeBrowserGrabScript
+} from './browser-grab-script-executor'
 import { captureSelectionScreenshot as captureGrabSelectionScreenshot } from './browser-grab-screenshot'
 import { BrowserGrabSessionController } from './browser-grab-session-controller'
 import { browserDownloadDestinationReservations } from './browser-download-destination'
@@ -1608,11 +1611,19 @@ export class BrowserManager {
     guest: Electron.WebContents
   ): Promise<boolean> {
     if (!enabled) {
+      const hadActiveGrabOp = this.hasActiveGrabOp(browserTabId)
       this.cancelGrabOp(browserTabId, 'user')
+      if (!hadActiveGrabOp && !guest.isDestroyed()) {
+        void executeBrowserGrabPageScript(
+          guest,
+          buildGuestReactMetadataBridgeScript('teardown')
+        ).catch(() => {})
+      }
       return true
     }
     // Why: inject the overlay runtime eagerly on arm so the hover UI appears instantly; re-injection is idempotent/safe.
     try {
+      await executeBrowserGrabPageScript(guest, buildGuestReactMetadataBridgeScript('install'))
       await executeBrowserGrabScript(guest, buildGuestOverlayScript('arm'))
       return true
     } catch {

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -25,6 +25,7 @@ import type {
 } from '../../shared/browser-grab-types'
 import { buildGuestOverlayScript } from './grab-guest-script'
 import { clampGrabPayload } from './browser-grab-payload'
+import { executeBrowserGrabScript } from './browser-grab-script-executor'
 import { captureSelectionScreenshot as captureGrabSelectionScreenshot } from './browser-grab-screenshot'
 import { BrowserGrabSessionController } from './browser-grab-session-controller'
 import { browserDownloadDestinationReservations } from './browser-download-destination'
@@ -1612,7 +1613,7 @@ export class BrowserManager {
     }
     // Why: inject the overlay runtime eagerly on arm so the hover UI appears instantly; re-injection is idempotent/safe.
     try {
-      await guest.executeJavaScript(buildGuestOverlayScript('arm'))
+      await executeBrowserGrabScript(guest, buildGuestOverlayScript('arm'))
       return true
     } catch {
       return false
@@ -1652,7 +1653,10 @@ export class BrowserManager {
     guest: Electron.WebContents
   ): Promise<BrowserGrabPayload | null> {
     try {
-      const rawPayload = await guest.executeJavaScript(buildGuestOverlayScript('extractHover'))
+      const rawPayload = await executeBrowserGrabScript(
+        guest,
+        buildGuestOverlayScript('extractHover')
+      )
       if (!rawPayload || typeof rawPayload !== 'object') {
         return null
       }

--- a/src/main/browser/grab-guest-script.ts
+++ b/src/main/browser/grab-guest-script.ts
@@ -3,6 +3,19 @@
 // Why a string builder not a bundle: guests have no preload/Node; injected code must be plain JS in the page's own world.
 
 type GuestScriptAction = 'arm' | 'awaitClick' | 'finalize' | 'extractHover' | 'teardown'
+type GuestReactMetadataBridgeAction = 'install' | 'teardown'
+
+const REACT_METADATA_REQUEST_EVENT = '__orcaGrabReactMetadataRequest'
+const REACT_METADATA_RESULT_ATTRIBUTE = 'data-orca-grab-react-metadata'
+const REACT_METADATA_BRIDGE_KEY = '__orcaGrabReactMetadataBridge'
+
+export function buildGuestReactMetadataBridgeScript(
+  action: GuestReactMetadataBridgeAction
+): string {
+  return action === 'install'
+    ? INSTALL_REACT_METADATA_BRIDGE_SCRIPT
+    : TEARDOWN_REACT_METADATA_BRIDGE_SCRIPT
+}
 
 /**
  * Build a self-contained JS script for the given grab lifecycle action.
@@ -27,6 +40,145 @@ export function buildGuestOverlayScript(action: GuestScriptAction): string {
       return TEARDOWN_SCRIPT
   }
 }
+
+// Why: isolated-world DOM wrappers cannot see React's page-world fiber expandos.
+// A synchronous event bridge keeps metadata extraction page-local without
+// returning a page-world Promise to Electron.
+const INSTALL_REACT_METADATA_BRIDGE_SCRIPT = `(function() {
+  'use strict';
+  var BRIDGE_KEY = ${JSON.stringify(REACT_METADATA_BRIDGE_KEY)};
+  var REQUEST_EVENT = ${JSON.stringify(REACT_METADATA_REQUEST_EVENT)};
+  var RESULT_ATTRIBUTE = ${JSON.stringify(REACT_METADATA_RESULT_ATTRIBUTE)};
+  if (window[BRIDGE_KEY]) return true;
+
+  var BUDGET = { sourceFileMaxLength: 500, reactComponentsMaxLength: 500 };
+  var SECRET_PATTERNS = [
+    'access_token', 'auth_token', 'api_key', 'apikey', 'client_secret',
+    'oauth_state', 'x-amz-', 'session_id', 'sessionid', 'csrf',
+    'secret', 'password', 'passwd'
+  ];
+
+  function clampStr(s, max) {
+    if (!s || typeof s !== 'string') return '';
+    if (s.length <= max) return s;
+    return s.slice(0, max) + ' (truncated)';
+  }
+
+  function containsSecret(value) {
+    if (!value) return false;
+    var lower = value.toLowerCase();
+    for (var i = 0; i < SECRET_PATTERNS.length; i++) {
+      if (lower.indexOf(SECRET_PATTERNS[i]) !== -1) return true;
+    }
+    return false;
+  }
+
+  function getFiberFromElement(el) {
+    var keys = Object.keys(el);
+    for (var i = 0; i < keys.length; i++) {
+      if (keys[i].indexOf('__reactFiber$') === 0 || keys[i].indexOf('__reactInternalInstance$') === 0) {
+        try {
+          return el[keys[i]] || null;
+        } catch (e) {
+          return null;
+        }
+      }
+    }
+    return null;
+  }
+
+  function getComponentNameFromFiber(fiber) {
+    if (!fiber) return null;
+    var type = fiber.type || fiber.elementType;
+    if (!type || typeof type === 'string') return null;
+    if (type.displayName || type.name) return type.displayName || type.name;
+    if (type.render && (type.render.displayName || type.render.name)) {
+      return type.render.displayName || type.render.name;
+    }
+    if (type.type && (type.type.displayName || type.type.name)) {
+      return type.type.displayName || type.type.name;
+    }
+    return null;
+  }
+
+  function shouldSkipReactName(name) {
+    if (!name || name.length <= 2) return true;
+    return /^(Fragment|Root|Routes|Route|Outlet|Provider|Consumer|Profiler|Suspense)$/.test(name) ||
+      /(?:Boundary|BoundaryHandler|Router|Provider|Consumer|Context|Wrapper)$/.test(name) ||
+      /^(Inner|Outer|Client|Server|RSC|Dev|React|Hot)/.test(name);
+  }
+
+  function cleanSourcePath(path) {
+    if (!path) return '';
+    return String(path)
+      .replace(/[?#].*$/, '')
+      .replace(/^turbopack:\\/\\/\\/\\[project\\]\\//, '')
+      .replace(/^webpack-internal:\\/\\/\\/\\.\\//, '')
+      .replace(/^webpack-internal:\\/\\/\\//, '')
+      .replace(/^webpack:\\/\\/\\/\\.\\//, '')
+      .replace(/^webpack:\\/\\/\\//, '')
+      .replace(/^turbopack:\\/\\/\\//, '')
+      .replace(/^https?:\\/\\/[^/]+\\//, '')
+      .replace(/^file:\\/\\/\\//, '/')
+      .replace(/^\\([^)]+\\)\\/\\.\\//, '')
+      .replace(/^\\.\\//, '');
+  }
+
+  function getReactMetadata(el) {
+    try {
+      var fiber = getFiberFromElement(el);
+      var components = [];
+      var sourceFile = null;
+      var depth = 0;
+      while (fiber && depth < 35) {
+        var name = getComponentNameFromFiber(fiber);
+        if (name && !shouldSkipReactName(name) && components.indexOf(name) === -1 && components.length < 6) {
+          components.push(name);
+        }
+        var source = fiber._debugSource || (fiber._debugOwner && fiber._debugOwner._debugSource);
+        if (!sourceFile && source && source.fileName && source.lineNumber) {
+          sourceFile = cleanSourcePath(source.fileName) + ':' + source.lineNumber +
+            (source.columnNumber !== undefined ? ':' + source.columnNumber : '');
+          if (containsSecret(sourceFile)) sourceFile = null;
+        }
+        fiber = fiber.return;
+        depth++;
+      }
+      return {
+        reactComponents: components.length > 0
+          ? clampStr(components.slice().reverse().map(function(c) { return '<' + c + '>'; }).join(' '), BUDGET.reactComponentsMaxLength)
+          : null,
+        sourceFile: sourceFile ? clampStr(sourceFile, BUDGET.sourceFileMaxLength) : null
+      };
+    } catch (e) {
+      return { reactComponents: null, sourceFile: null };
+    }
+  }
+
+  function onMetadataRequest(event) {
+    var el = event.target;
+    if (!el || el.nodeType !== 1) return;
+    try {
+      el.setAttribute(RESULT_ATTRIBUTE, JSON.stringify(getReactMetadata(el)));
+    } catch (e) {}
+  }
+
+  document.addEventListener(REQUEST_EVENT, onMetadataRequest, true);
+  window[BRIDGE_KEY] = {
+    cleanup: function() {
+      document.removeEventListener(REQUEST_EVENT, onMetadataRequest, true);
+      try { delete window[BRIDGE_KEY]; } catch (e) { window[BRIDGE_KEY] = null; }
+    }
+  };
+  return true;
+})()`
+
+const TEARDOWN_REACT_METADATA_BRIDGE_SCRIPT = `(function() {
+  'use strict';
+  var bridge = window[${JSON.stringify(REACT_METADATA_BRIDGE_KEY)}];
+  if (bridge && typeof bridge.cleanup === 'function') bridge.cleanup();
+  return true;
+})()`
 
 // arm: install the overlay + hover tracking; state lives on window.__orcaGrab so finalize/teardown can reach it.
 const ARM_SCRIPT = `(function() {
@@ -594,6 +746,21 @@ const ARM_SCRIPT = `(function() {
     return null;
   }
 
+  function requestPageWorldReactMetadata(el) {
+    try {
+      el.removeAttribute(${JSON.stringify(REACT_METADATA_RESULT_ATTRIBUTE)});
+      el.dispatchEvent(new CustomEvent(${JSON.stringify(REACT_METADATA_REQUEST_EVENT)}, { bubbles: true }));
+      var raw = el.getAttribute(${JSON.stringify(REACT_METADATA_RESULT_ATTRIBUTE)});
+      el.removeAttribute(${JSON.stringify(REACT_METADATA_RESULT_ATTRIBUTE)});
+      if (!raw) return null;
+      var metadata = JSON.parse(raw);
+      return metadata && typeof metadata === 'object' ? metadata : null;
+    } catch (e) {
+      try { el.removeAttribute(${JSON.stringify(REACT_METADATA_RESULT_ATTRIBUTE)}); } catch (ignored) {}
+      return null;
+    }
+  }
+
   function getComponentNameFromFiber(fiber) {
     if (!fiber) return null;
     var type = fiber.type || fiber.elementType;
@@ -632,6 +799,8 @@ const ARM_SCRIPT = `(function() {
   }
 
   function getReactMetadata(el) {
+    var pageMetadata = requestPageWorldReactMetadata(el);
+    if (pageMetadata) return pageMetadata;
     try {
       var fiber = getFiberFromElement(el);
       var components = [];

--- a/tests/e2e/browser-grab-zonejs.spec.ts
+++ b/tests/e2e/browser-grab-zonejs.spec.ts
@@ -1,27 +1,12 @@
 import { test, expect } from './helpers/orca-app'
 import { BROWSER_GRAB_WORLD_ID } from '../../src/main/browser/browser-grab-script-executor'
-import { buildGuestOverlayScript } from '../../src/main/browser/grab-guest-script'
+import {
+  buildGuestOverlayScript,
+  buildGuestReactMetadataBridgeScript
+} from '../../src/main/browser/grab-guest-script'
 
-function buildAwaitClickProbe(awaitClickScript: string, patchPromise: boolean): string {
-  const promisePatch = patchPromise
-    ? `
-      function ZoneAwarePromise(executor) {
-        const wrapper = {
-          __zone_symbol__state: true,
-          __zone_symbol__value: undefined
-        }
-        executor(
-          (value) => { wrapper.__zone_symbol__value = value },
-          (reason) => { wrapper.__zone_symbol__value = reason }
-        )
-        return wrapper
-      }
-      window.Promise = ZoneAwarePromise
-    `
-    : ''
-
+function buildAwaitClickProbe(awaitClickScript: string): string {
   return `(() => {
-    const nativePromise = window.Promise
     window.__orcaGrab = {
       host: {
         addEventListener(type, listener) {
@@ -40,14 +25,32 @@ function buildAwaitClickProbe(awaitClickScript: string, patchPromise: boolean): 
       cleanup() {},
       freezeHighlight() {}
     }
-    ${promisePatch}
-    try {
-      return eval(${JSON.stringify(awaitClickScript)})
-    } finally {
-      window.Promise = nativePromise
-    }
+    return eval(${JSON.stringify(awaitClickScript)})
   })()`
 }
+
+const INSTALL_ZONE_PROMISE_PATCH_SCRIPT = `(() => {
+  window.__orcaNativePromise = window.Promise
+  function ZoneAwarePromise(executor) {
+    const wrapper = {
+      __zone_symbol__state: true,
+      __zone_symbol__value: undefined
+    }
+    executor(
+      (value) => { wrapper.__zone_symbol__value = value },
+      (reason) => { wrapper.__zone_symbol__value = reason }
+    )
+    return wrapper
+  }
+  window.Promise = ZoneAwarePromise
+  return true
+})()`
+
+const RESTORE_ZONE_PROMISE_PATCH_SCRIPT = `(() => {
+  window.Promise = window.__orcaNativePromise
+  delete window.__orcaNativePromise
+  return true
+})()`
 
 test('browser grab keeps await-click payload shape on Zone.js pages', async ({ electronApp }) => {
   const evidence = await electronApp.evaluate(
@@ -55,33 +58,40 @@ test('browser grab keeps await-click payload shape on Zone.js pages', async ({ e
       const browserWindow = new BrowserWindow({ show: false })
       try {
         await browserWindow.loadURL('data:text/html,<html><body>Grab probe</body></html>')
-        const pageWorldResult = await browserWindow.webContents.executeJavaScript(pageWorldProbe)
-        const isolatedWorldResult =
-          await browserWindow.webContents.executeJavaScriptInIsolatedWorld(
-            worldId,
-            [{ code: isolatedWorldProbe }],
-            false
-          )
-        return {
-          pageWorld: {
-            directKeys: Object.keys(pageWorldResult),
-            wrappedKeys: Object.keys(pageWorldResult.__zone_symbol__value ?? {}),
-            hasDirectPage: Object.prototype.hasOwnProperty.call(pageWorldResult, 'page'),
-            hasDirectTarget: Object.prototype.hasOwnProperty.call(pageWorldResult, 'target')
-          },
-          isolatedWorld: {
-            directKeys: Object.keys(isolatedWorldResult),
-            hasDirectPage: Object.prototype.hasOwnProperty.call(isolatedWorldResult, 'page'),
-            hasDirectTarget: Object.prototype.hasOwnProperty.call(isolatedWorldResult, 'target')
+        await browserWindow.webContents.executeJavaScript(installPromisePatch)
+        try {
+          const pageWorldResult = await browserWindow.webContents.executeJavaScript(pageWorldProbe)
+          const isolatedWorldResult =
+            await browserWindow.webContents.executeJavaScriptInIsolatedWorld(
+              worldId,
+              [{ code: isolatedWorldProbe }],
+              false
+            )
+          return {
+            pageWorld: {
+              directKeys: Object.keys(pageWorldResult),
+              wrappedKeys: Object.keys(pageWorldResult.__zone_symbol__value ?? {}),
+              hasDirectPage: Object.prototype.hasOwnProperty.call(pageWorldResult, 'page'),
+              hasDirectTarget: Object.prototype.hasOwnProperty.call(pageWorldResult, 'target')
+            },
+            isolatedWorld: {
+              directKeys: Object.keys(isolatedWorldResult),
+              hasDirectPage: Object.prototype.hasOwnProperty.call(isolatedWorldResult, 'page'),
+              hasDirectTarget: Object.prototype.hasOwnProperty.call(isolatedWorldResult, 'target')
+            }
           }
+        } finally {
+          await browserWindow.webContents.executeJavaScript(restorePromisePatch)
         }
       } finally {
         browserWindow.destroy()
       }
     },
     {
-      isolatedWorldProbe: buildAwaitClickProbe(buildGuestOverlayScript('awaitClick'), false),
-      pageWorldProbe: buildAwaitClickProbe(buildGuestOverlayScript('awaitClick'), true),
+      isolatedWorldProbe: buildAwaitClickProbe(buildGuestOverlayScript('awaitClick')),
+      pageWorldProbe: buildAwaitClickProbe(buildGuestOverlayScript('awaitClick')),
+      installPromisePatch: INSTALL_ZONE_PROMISE_PATCH_SCRIPT,
+      restorePromisePatch: RESTORE_ZONE_PROMISE_PATCH_SCRIPT,
       worldId: BROWSER_GRAB_WORLD_ID
     }
   )
@@ -96,5 +106,77 @@ test('browser grab keeps await-click payload shape on Zone.js pages', async ({ e
     directKeys: ['page', 'target'],
     hasDirectPage: true,
     hasDirectTarget: true
+  })
+})
+
+test('browser grab preserves React metadata across the isolated-world bridge', async ({
+  electronApp
+}) => {
+  const metadata = await electronApp.evaluate(
+    async (
+      { BrowserWindow },
+      {
+        installBridge,
+        teardownBridge,
+        installPromisePatch,
+        restorePromisePatch,
+        armScript,
+        teardownScript,
+        worldId
+      }
+    ) => {
+      const browserWindow = new BrowserWindow({ show: false })
+      try {
+        await browserWindow.loadURL('data:text/html,<button id="target">Grab me</button>')
+        await browserWindow.webContents.executeJavaScript(`(() => {
+          const target = document.getElementById('target')
+          function SettingsPanel() {}
+          target.__reactFiber$orcaProbe = {
+            type: SettingsPanel,
+            _debugSource: { fileName: 'src/settings-panel.tsx', lineNumber: 24, columnNumber: 7 },
+            return: null
+          }
+          return true
+        })()`)
+        await browserWindow.webContents.executeJavaScript(installPromisePatch)
+        await browserWindow.webContents.executeJavaScript(installBridge)
+        try {
+          await browserWindow.webContents.executeJavaScriptInIsolatedWorld(
+            worldId,
+            [{ code: armScript }],
+            false
+          )
+          return await browserWindow.webContents.executeJavaScriptInIsolatedWorld(
+            worldId,
+            [{ code: `window.__orcaGrab.extractPayload(document.getElementById('target'))` }],
+            false
+          )
+        } finally {
+          await browserWindow.webContents.executeJavaScriptInIsolatedWorld(
+            worldId,
+            [{ code: teardownScript }],
+            false
+          )
+          await browserWindow.webContents.executeJavaScript(teardownBridge)
+          await browserWindow.webContents.executeJavaScript(restorePromisePatch)
+        }
+      } finally {
+        browserWindow.destroy()
+      }
+    },
+    {
+      installBridge: buildGuestReactMetadataBridgeScript('install'),
+      teardownBridge: buildGuestReactMetadataBridgeScript('teardown'),
+      installPromisePatch: INSTALL_ZONE_PROMISE_PATCH_SCRIPT,
+      restorePromisePatch: RESTORE_ZONE_PROMISE_PATCH_SCRIPT,
+      armScript: buildGuestOverlayScript('arm'),
+      teardownScript: buildGuestOverlayScript('teardown'),
+      worldId: BROWSER_GRAB_WORLD_ID
+    }
+  )
+
+  expect(metadata.target).toMatchObject({
+    reactComponents: '<SettingsPanel>',
+    sourceFile: 'src/settings-panel.tsx:24:7'
   })
 })

--- a/tests/e2e/browser-grab-zonejs.spec.ts
+++ b/tests/e2e/browser-grab-zonejs.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from './helpers/orca-app'
+import { BROWSER_GRAB_WORLD_ID } from '../../src/main/browser/browser-grab-script-executor'
+import { buildGuestOverlayScript } from '../../src/main/browser/grab-guest-script'
+
+function buildAwaitClickProbe(awaitClickScript: string, patchPromise: boolean): string {
+  const promisePatch = patchPromise
+    ? `
+      function ZoneAwarePromise(executor) {
+        const wrapper = {
+          __zone_symbol__state: true,
+          __zone_symbol__value: undefined
+        }
+        executor(
+          (value) => { wrapper.__zone_symbol__value = value },
+          (reason) => { wrapper.__zone_symbol__value = reason }
+        )
+        return wrapper
+      }
+      window.Promise = ZoneAwarePromise
+    `
+    : ''
+
+  return `(() => {
+    const nativePromise = window.Promise
+    window.__orcaGrab = {
+      host: {
+        addEventListener(type, listener) {
+          if (type === 'click') {
+            listener({
+              preventDefault() {},
+              stopPropagation() {},
+              stopImmediatePropagation() {}
+            })
+          }
+        },
+        removeEventListener() {}
+      },
+      getCurrentElement: () => ({}),
+      extractPayload: () => ({ page: {}, target: {} }),
+      cleanup() {},
+      freezeHighlight() {}
+    }
+    ${promisePatch}
+    try {
+      return eval(${JSON.stringify(awaitClickScript)})
+    } finally {
+      window.Promise = nativePromise
+    }
+  })()`
+}
+
+test('browser grab keeps await-click payload shape on Zone.js pages', async ({ electronApp }) => {
+  const evidence = await electronApp.evaluate(
+    async ({ BrowserWindow }, { isolatedWorldProbe, pageWorldProbe, worldId }) => {
+      const browserWindow = new BrowserWindow({ show: false })
+      try {
+        await browserWindow.loadURL('data:text/html,<html><body>Grab probe</body></html>')
+        const pageWorldResult = await browserWindow.webContents.executeJavaScript(pageWorldProbe)
+        const isolatedWorldResult =
+          await browserWindow.webContents.executeJavaScriptInIsolatedWorld(
+            worldId,
+            [{ code: isolatedWorldProbe }],
+            false
+          )
+        return {
+          pageWorld: {
+            directKeys: Object.keys(pageWorldResult),
+            wrappedKeys: Object.keys(pageWorldResult.__zone_symbol__value ?? {}),
+            hasDirectPage: Object.prototype.hasOwnProperty.call(pageWorldResult, 'page'),
+            hasDirectTarget: Object.prototype.hasOwnProperty.call(pageWorldResult, 'target')
+          },
+          isolatedWorld: {
+            directKeys: Object.keys(isolatedWorldResult),
+            hasDirectPage: Object.prototype.hasOwnProperty.call(isolatedWorldResult, 'page'),
+            hasDirectTarget: Object.prototype.hasOwnProperty.call(isolatedWorldResult, 'target')
+          }
+        }
+      } finally {
+        browserWindow.destroy()
+      }
+    },
+    {
+      isolatedWorldProbe: buildAwaitClickProbe(buildGuestOverlayScript('awaitClick'), false),
+      pageWorldProbe: buildAwaitClickProbe(buildGuestOverlayScript('awaitClick'), true),
+      worldId: BROWSER_GRAB_WORLD_ID
+    }
+  )
+
+  expect(evidence.pageWorld).toMatchObject({
+    directKeys: ['__zone_symbol__state', '__zone_symbol__value'],
+    wrappedKeys: ['page', 'target'],
+    hasDirectPage: false,
+    hasDirectTarget: false
+  })
+  expect(evidence.isolatedWorld).toMatchObject({
+    directKeys: ['page', 'target'],
+    hasDirectPage: true,
+    hasDirectTarget: true
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #9947 by handling Zone.js `ZoneAwarePromise` wrapping during browser grabs while preserving React component metadata and source-file information.

## Screenshots

No visual changes.

## Testing

- [x] pnpm lint
- [x] pnpm typecheck
- [x] pnpm test
- [x] pnpm build
- [x] Added regression tests for Zone.js Promise wrapping and React metadata preservation.
- [x] Focused Vitest: 63 tests passed.
- [x] Playwright regression tests discovered successfully.

## AI Review Report

Reviewed with GPT-5.6 Luna.

The review verified fixes for:

- Zone.js `ZoneAwarePromise` wrapping during browser grabs.
- React fiber metadata remaining accessible despite isolated-world execution.
- E2E coverage ensuring the page Promise patch remains active.

Cross-platform compatibility was verified on macOS, Linux, and Windows. No shortcut, path, shell, or platform-specific behavior changed.

## Security Audit

- Existing payload validation and secret redaction remain active.
- No new IPC, command execution, filesystem, authentication, or dependency risks.
- Temporary metadata attributes are removed after extraction.

## Notes

No visual changes or platform-specific follow-up required.