### PR TITLE
fix(sidebar): use automation icon for Hide automation-created filter

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarFilter.tsx
+++ b/src/renderer/src/components/sidebar/SidebarFilter.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import { Check, FolderPlus, GitBranch, ListFilter, Moon, Server, Workflow } from 'lucide-react'
+import { CalendarClock, Check, FolderPlus, GitBranch, ListFilter, Moon, Server } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
 import {
@@ -200,7 +200,7 @@ const SidebarFilter = React.memo(function SidebarFilter({
           onChange={setHideDefaultBranchWorkspace}
         />
         <FilterToggleRow
-          icon={<Workflow className="size-3.5" />}
+          icon={<CalendarClock className="size-3.5" />}
           label={translate(
             'auto.components.sidebar.SidebarFilter.automationCreated',
             'Hide automation-created'

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceFilterSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { GitBranch, Moon, Workflow } from 'lucide-react'
+import { CalendarClock, GitBranch, Moon } from 'lucide-react'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
@@ -40,7 +40,7 @@ const SidebarWorkspaceFilterSection = React.memo(function SidebarWorkspaceFilter
         onChange={setHideDefaultBranchWorkspace}
       />
       <FilterToggleRow
-        icon={<Workflow className="size-3.5" />}
+        icon={<CalendarClock className="size-3.5" />}
         label={translate(
           'auto.components.sidebar.SidebarWorkspaceFilterSection.automationCreated',
           'Hide automation-created'


### PR DESCRIPTION
## What

The workspace-options **Hide automation-created** filter row used the `Workflow` icon, which doesn't match the **Automations** nav item / page — both of which use `CalendarClock`. This swaps the filter row to `CalendarClock` so the control visibly maps to automation-created workspaces.

Applied in both filter surfaces that render this row:
- `SidebarFilter.tsx` (workspace-options popover)
- `SidebarWorkspaceFilterSection.tsx`

## Screenshot

Filter popover — row now uses the same calendar-clock icon as the Automations nav item:

![orca-automation-icon.png](https://github.com/user-attachments/assets/0ad5103b-df20-495d-b437-e369cb2c0519)

## Testing

- Launched the dev build via `/electron`, opened Workspace options, and confirmed the rendered icon is `lucide-calendar-clock` (verified via DOM), matching the Automations nav.