### PR TITLE
feat(emulator): guide mobile toolchain setup

### DIFF
--- a/src/main/emulator/android/android-sdk-discovery.test.ts
+++ b/src/main/emulator/android/android-sdk-discovery.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { discoverAndroidSdk } from './android-sdk-discovery'
+import { discoverAndroidSdk, discoverAndroidSdkAtPath } from './android-sdk-discovery'
 import type { DiscoverAndroidSdkOptions } from './android-sdk-discovery'
 
 // Fake `exists` predicate: only paths placed in the set are reported present.
@@ -137,5 +137,16 @@ describe('discoverAndroidSdk', () => {
     })
 
     expect(result).toBeNull()
+  })
+
+  it('does not fall back when an app-configured SDK path is incomplete', () => {
+    const defaultRoot = '/Users/erik/Library/Android/sdk'
+    expect(
+      discoverAndroidSdkAtPath(
+        '/custom/incomplete',
+        'darwin',
+        existsIn(sdkToolsFor(defaultRoot, false))
+      )
+    ).toBeNull()
   })
 })

--- a/src/main/emulator/android/android-sdk-discovery.ts
+++ b/src/main/emulator/android/android-sdk-discovery.ts
@@ -32,6 +32,15 @@ export function discoverAndroidSdk(options: DiscoverAndroidSdkOptions): AndroidS
   return null
 }
 
+export function discoverAndroidSdkAtPath(
+  sdkRoot: string,
+  platform: NodeJS.Platform,
+  exists: (path: string) => boolean
+): AndroidSdkPaths | null {
+  const paths = resolveToolPaths(sdkRoot, platform === 'win32')
+  return exists(paths.adb) && exists(paths.emulator) ? paths : null
+}
+
 function candidateSdkRoots(
   env: NodeJS.ProcessEnv,
   platform: NodeJS.Platform,

--- a/src/main/emulator/android/android-sdk-host-discovery.ts
+++ b/src/main/emulator/android/android-sdk-host-discovery.ts
@@ -1,12 +1,20 @@
 import { homedir, platform } from 'node:os'
 import { existsSync } from 'node:fs'
-import { discoverAndroidSdk, type AndroidSdkPaths } from './android-sdk-discovery'
+import {
+  discoverAndroidSdk,
+  discoverAndroidSdkAtPath,
+  type AndroidSdkPaths
+} from './android-sdk-discovery'
 
 let configuredSdkPath: string | null = null
 
+export function getConfiguredAndroidSdkPath(): string | null {
+  return configuredSdkPath
+}
+
 // Lets the user point Orca at an Android SDK in a non-standard location (saved in
-// settings). Applied as the highest-priority candidate; an invalid path falls
-// back to ANDROID_HOME / ANDROID_SDK_ROOT / the default install location.
+// settings). An explicit invalid path stays invalid so the setup UI can explain
+// the saved configuration instead of silently running a different SDK.
 export function setConfiguredAndroidSdkPath(path: string | null): void {
   const trimmed = path?.trim()
   configuredSdkPath = trimmed ? trimmed : null
@@ -16,9 +24,17 @@ export function setConfiguredAndroidSdkPath(path: string | null): void {
 // returning null on any failure so the backend degrades to "unsupported". The
 // pure resolver lives in android-sdk-discovery; this wires it to the real host.
 export function discoverAndroidSdkFromHost(): AndroidSdkPaths | null {
-  const env = configuredSdkPath ? { ...process.env, ANDROID_HOME: configuredSdkPath } : process.env
   try {
-    return discoverAndroidSdk({ env, platform: platform(), homedir: homedir(), exists: existsSync })
+    const currentPlatform = platform()
+    if (configuredSdkPath) {
+      return discoverAndroidSdkAtPath(configuredSdkPath, currentPlatform, existsSync)
+    }
+    return discoverAndroidSdk({
+      env: process.env,
+      platform: currentPlatform,
+      homedir: homedir(),
+      exists: existsSync
+    })
   } catch {
     return null
   }

--- a/src/main/emulator/android/android-setup-probe.test.ts
+++ b/src/main/emulator/android/android-setup-probe.test.ts
@@ -1,0 +1,114 @@
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { inspectAndroidSetup, type AndroidSetupProbeOptions } from './android-setup-probe'
+
+function probe(overrides: Partial<AndroidSetupProbeOptions> & { paths?: string[] } = {}) {
+  const paths = new Set(overrides.paths ?? [])
+  return inspectAndroidSetup({
+    env: {},
+    platform: 'darwin',
+    homedir: '/Users/tester',
+    exists: (path) => paths.has(path),
+    hasInstalledSystemImage: (path) => paths.has(`${path}/package.xml`),
+    backendAvailable: false,
+    ...overrides
+  })
+}
+
+function completeSdk(root: string, platform: NodeJS.Platform = 'darwin'): string[] {
+  const suffix = platform === 'win32' ? '.exe' : ''
+  return [
+    root,
+    join(root, 'platform-tools', `adb${suffix}`),
+    join(root, 'emulator', `emulator${suffix}`),
+    `${join(root, 'system-images')}/package.xml`
+  ]
+}
+
+describe('inspectAndroidSetup', () => {
+  it('distinguishes Android Studio missing from an SDK missing after Studio install', () => {
+    expect(probe().message).toMatch(/Android Studio and the Android SDK/)
+    expect(probe({ paths: ['/Applications/Android Studio.app'] })).toMatchObject({
+      state: 'sdk-missing',
+      studioInstalled: true,
+      message: expect.stringContaining('SDK has not been installed')
+    })
+  })
+
+  it('detects the standard macOS SDK path without ANDROID_HOME', () => {
+    const root = '/Users/tester/Library/Android/sdk'
+    expect(probe({ paths: completeSdk(root), backendAvailable: true })).toMatchObject({
+      state: 'ready',
+      sdkPath: root,
+      configuredPath: false
+    })
+  })
+
+  it('uses an app-configured custom SDK without mutating environment variables', () => {
+    const root = '/Volumes/Tools/android-sdk'
+    const env = { ANDROID_HOME: '/broken/environment/path' }
+    expect(
+      probe({ configuredPath: root, env, paths: completeSdk(root), backendAvailable: true })
+    ).toMatchObject({ state: 'ready', sdkPath: root, configuredPath: true })
+    expect(env.ANDROID_HOME).toBe('/broken/environment/path')
+  })
+
+  it('falls through a stale environment path to a complete standard SDK', () => {
+    const root = '/Users/tester/Library/Android/sdk'
+    expect(
+      probe({
+        env: { ANDROID_HOME: '/stale/sdk' },
+        paths: ['/stale/sdk', ...completeSdk(root)],
+        backendAvailable: true
+      }).sdkPath
+    ).toBe(root)
+  })
+
+  it('reports an invalid configured SDK instead of silently using another path', () => {
+    expect(probe({ configuredPath: '/not-an-sdk' })).toMatchObject({
+      state: 'sdk-invalid',
+      sdkPath: '/not-an-sdk'
+    })
+  })
+
+  it('identifies each incomplete SDK component and missing virtual device', () => {
+    const root = '/Users/tester/Library/Android/sdk'
+    expect(probe({ paths: [root] }).state).toBe('platform-tools-missing')
+    expect(probe({ paths: [root, join(root, 'platform-tools', 'adb')] }).state).toBe(
+      'emulator-missing'
+    )
+    expect(
+      probe({
+        paths: [root, join(root, 'platform-tools', 'adb'), join(root, 'emulator', 'emulator')]
+      }).state
+    ).toBe('system-image-missing')
+    expect(probe({ paths: completeSdk(root) }).state).toBe('device-missing')
+  })
+
+  it('surfaces tool failures instead of mislabeling them as a missing device', () => {
+    const root = '/Users/tester/Library/Android/sdk'
+    expect(
+      probe({
+        paths: completeSdk(root),
+        backendMessage: 'adb server failed to start'
+      }).state
+    ).toBe('error')
+  })
+
+  it.each([
+    ['linux', '/home/tester/Android/Sdk'],
+    ['win32', join('C:\\Users\\tester', 'AppData', 'Local', 'Android', 'Sdk')]
+  ] as const)('uses the standard %s SDK location', (platform, root) => {
+    const env =
+      platform === 'win32' ? { LOCALAPPDATA: join('C:\\Users\\tester', 'AppData', 'Local') } : {}
+    expect(
+      probe({
+        platform,
+        homedir: platform === 'win32' ? 'C:\\Users\\tester' : '/home/tester',
+        env,
+        paths: completeSdk(root, platform),
+        backendAvailable: true
+      }).sdkPath
+    ).toBe(root)
+  })
+})

--- a/src/main/emulator/android/android-setup-probe.ts
+++ b/src/main/emulator/android/android-setup-probe.ts
@@ -1,0 +1,150 @@
+import { join } from 'node:path'
+import type { AndroidSetupStatus } from '../../../shared/emulator-setup-types'
+
+export type AndroidSetupProbeOptions = {
+  env: NodeJS.ProcessEnv
+  platform: NodeJS.Platform
+  homedir: string
+  configuredPath?: string | null
+  exists: (path: string) => boolean
+  hasInstalledSystemImage: (path: string) => boolean
+  backendAvailable: boolean
+  backendMessage?: string
+}
+
+type Candidate = { path: string; configured: boolean }
+
+function defaultSdkPath(options: AndroidSetupProbeOptions): string {
+  if (options.platform === 'win32') {
+    return join(
+      options.env.LOCALAPPDATA ?? join(options.homedir, 'AppData', 'Local'),
+      'Android',
+      'Sdk'
+    )
+  }
+  if (options.platform === 'darwin') {
+    return join(options.homedir, 'Library', 'Android', 'sdk')
+  }
+  return join(options.homedir, 'Android', 'Sdk')
+}
+
+function sdkCandidates(options: AndroidSetupProbeOptions): Candidate[] {
+  const candidates: Candidate[] = []
+  const add = (path: string | null | undefined, configured: boolean): void => {
+    const trimmed = path?.trim()
+    if (trimmed && !candidates.some((candidate) => candidate.path === trimmed)) {
+      candidates.push({ path: trimmed, configured })
+    }
+  }
+  add(options.configuredPath, true)
+  add(options.env.ANDROID_HOME, false)
+  add(options.env.ANDROID_SDK_ROOT, false)
+  add(defaultSdkPath(options), false)
+  return candidates
+}
+
+function androidStudioCandidates(options: AndroidSetupProbeOptions): string[] {
+  if (options.platform === 'darwin') {
+    return [
+      '/Applications/Android Studio.app',
+      join(options.homedir, 'Applications', 'Android Studio.app')
+    ]
+  }
+  if (options.platform === 'win32') {
+    return [
+      join(
+        options.env.ProgramFiles ?? 'C:\\Program Files',
+        'Android',
+        'Android Studio',
+        'bin',
+        'studio64.exe'
+      ),
+      join(
+        options.env.LOCALAPPDATA ?? join(options.homedir, 'AppData', 'Local'),
+        'Programs',
+        'Android Studio',
+        'bin',
+        'studio64.exe'
+      )
+    ]
+  }
+  return [
+    '/opt/android-studio/bin/studio.sh',
+    join(options.homedir, 'android-studio', 'bin', 'studio.sh')
+  ]
+}
+
+export function inspectAndroidSetup(options: AndroidSetupProbeOptions): AndroidSetupStatus {
+  const studioPath = androidStudioCandidates(options).find(options.exists)
+  const candidates = sdkCandidates(options)
+  const configured = candidates.find((candidate) => candidate.configured)
+  const automatic = candidates.filter((candidate) => !candidate.configured)
+  const executableSuffix = options.platform === 'win32' ? '.exe' : ''
+  const hasCoreTools = (candidate: Candidate): boolean =>
+    options.exists(join(candidate.path, 'platform-tools', `adb${executableSuffix}`)) &&
+    options.exists(join(candidate.path, 'emulator', `emulator${executableSuffix}`))
+  const selected =
+    configured ??
+    automatic.find((candidate) => options.exists(candidate.path) && hasCoreTools(candidate)) ??
+    automatic.find((candidate) => options.exists(candidate.path))
+
+  if (!selected || !options.exists(selected.path)) {
+    return {
+      state: configured ? 'sdk-invalid' : 'sdk-missing',
+      message: configured
+        ? 'The selected folder is not a complete Android SDK.'
+        : studioPath
+          ? 'Android Studio is installed, but its SDK has not been installed yet.'
+          : 'Android Studio and the Android SDK were not found.',
+      sdkPath: configured?.path,
+      configuredPath: Boolean(configured),
+      studioInstalled: Boolean(studioPath),
+      studioPath,
+      components: { platformTools: false, emulator: false, systemImages: false }
+    }
+  }
+
+  const platformTools = options.exists(
+    join(selected.path, 'platform-tools', `adb${executableSuffix}`)
+  )
+  const emulator = options.exists(join(selected.path, 'emulator', `emulator${executableSuffix}`))
+  const systemImages = options.hasInstalledSystemImage(join(selected.path, 'system-images'))
+  const base = {
+    sdkPath: selected.path,
+    configuredPath: selected.configured,
+    studioInstalled: Boolean(studioPath),
+    studioPath,
+    components: { platformTools, emulator, systemImages }
+  }
+
+  if (!platformTools) {
+    return {
+      ...base,
+      state: 'platform-tools-missing',
+      message: 'Install Android SDK Platform-Tools in Android Studio.'
+    }
+  }
+  if (!emulator) {
+    return {
+      ...base,
+      state: 'emulator-missing',
+      message: 'Install Android Emulator in Android Studio.'
+    }
+  }
+  if (!systemImages) {
+    return {
+      ...base,
+      state: 'system-image-missing',
+      message: 'Install an Android system image in Android Studio, then create a virtual device.'
+    }
+  }
+  if (!options.backendAvailable) {
+    const deviceMissing = /no android devices|no avds found/i.test(options.backendMessage ?? '')
+    return {
+      ...base,
+      state: deviceMissing || !options.backendMessage ? 'device-missing' : 'error',
+      message: options.backendMessage || 'Create an Android Virtual Device in Android Studio.'
+    }
+  }
+  return { ...base, state: 'ready', message: 'Ready' }
+}

--- a/src/main/emulator/emulator-availability.test.ts
+++ b/src/main/emulator/emulator-availability.test.ts
@@ -3,6 +3,7 @@ import { inspectEmulatorAvailability } from './emulator-availability'
 import type { EmulatorBridge } from './emulator-bridge'
 import type { SimulatorDevice } from './simctl-simulator-devices'
 import type { BackendAvailability } from './backends/emulator-backend'
+import type { AndroidSetupStatus, IosSetupStatus } from '../../shared/emulator-setup-types'
 
 type FakeBridgeOverrides = {
   supported?: boolean
@@ -43,16 +44,50 @@ const DEVICE: SimulatorDevice = {
   runtime: 'com.apple.CoreSimulator.SimRuntime.iOS-18-0'
 }
 
+const IOS_READY: IosSetupStatus = {
+  state: 'ready',
+  message: 'Ready',
+  installedXcodes: [],
+  devices: [DEVICE]
+}
+
+const IOS_MISSING: IosSetupStatus = {
+  state: 'xcode-missing',
+  message: 'Full Xcode is not installed.',
+  installedXcodes: [],
+  devices: []
+}
+
+const ANDROID_MISSING: AndroidSetupStatus = {
+  state: 'sdk-missing',
+  message: NO_ANDROID.message,
+  configuredPath: false,
+  studioInstalled: false,
+  components: { platformTools: false, emulator: false, systemImages: false }
+}
+
+function inspect(bridge: EmulatorBridge, ios: IosSetupStatus = IOS_READY) {
+  return inspectEmulatorAvailability(bridge, {
+    inspectIos: async () => ios,
+    inspectAndroid: (backend) => ({
+      ...ANDROID_MISSING,
+      state: backend.available ? 'ready' : 'sdk-missing',
+      message: backend.message,
+      sdkPath: backend.sdkPath
+    })
+  })
+}
+
 describe('inspectEmulatorAvailability', () => {
   it('falls back to the Android setup message when no backend is available', async () => {
-    const result = await inspectEmulatorAvailability(fakeBridge({ supported: false }))
+    const result = await inspect(fakeBridge({ supported: false }), IOS_MISSING)
     expect(result.available).toBe(false)
     expect(result.message).toMatch(/Android SDK/)
     expect(result.devices).toEqual([])
   })
 
   it('reports ready when iOS simulators exist and serve-sim is available', async () => {
-    const result = await inspectEmulatorAvailability(
+    const result = await inspect(
       fakeBridge({ supported: true, listSimulators: async () => [DEVICE] })
     )
     expect(result.available).toBe(true)
@@ -61,7 +96,7 @@ describe('inspectEmulatorAvailability', () => {
   })
 
   it('reports ready with Android devices when the iOS backend is unsupported', async () => {
-    const result = await inspectEmulatorAvailability(
+    const result = await inspect(
       fakeBridge({
         supported: false,
         android: {
@@ -92,17 +127,54 @@ describe('inspectEmulatorAvailability', () => {
     ])
   })
 
-  it('flags simctl when no simulators are installed', async () => {
+  it('does not report Android ready until the setup probe verifies every component', async () => {
     const result = await inspectEmulatorAvailability(
-      fakeBridge({ supported: true, listSimulators: async () => [] })
+      fakeBridge({
+        supported: false,
+        android: {
+          available: true,
+          message: 'Ready',
+          sdkPath: '/sdk',
+          devices: [
+            {
+              backend: 'android',
+              id: 'emulator-5554',
+              name: 'Pixel_7',
+              state: 'booted',
+              isAvailable: true
+            }
+          ]
+        }
+      }),
+      {
+        inspectIos: async () => IOS_MISSING,
+        inspectAndroid: () => ({
+          ...ANDROID_MISSING,
+          state: 'system-image-missing',
+          message: 'Install an Android system image.',
+          sdkPath: '/sdk'
+        })
+      }
     )
     expect(result.available).toBe(false)
+    expect(result.devices).toEqual([])
+    expect(result.android.state).toBe('system-image-missing')
+  })
+
+  it('flags simctl when no simulators are installed', async () => {
+    const result = await inspect(fakeBridge({ supported: true }), {
+      ...IOS_READY,
+      state: 'simulator-runtime-missing',
+      message: 'No compatible iOS Simulator runtime is installed.',
+      devices: []
+    })
+    expect(result.available).toBe(false)
     expect(result.simctl.ok).toBe(false)
-    expect(result.simctl.message).toMatch(/No iOS simulators/)
+    expect(result.simctl.message).toMatch(/No compatible iOS Simulator runtime/)
   })
 
   it('flags serve-sim when its check throws', async () => {
-    const result = await inspectEmulatorAvailability(
+    const result = await inspect(
       fakeBridge({
         supported: true,
         listSimulators: async () => [DEVICE],
@@ -117,14 +189,12 @@ describe('inspectEmulatorAvailability', () => {
   })
 
   it('flags simctl when listing simulators throws', async () => {
-    const result = await inspectEmulatorAvailability(
-      fakeBridge({
-        supported: true,
-        listSimulators: async () => {
-          throw new Error('xcrun exploded')
-        }
-      })
-    )
+    const result = await inspect(fakeBridge({ supported: true }), {
+      ...IOS_READY,
+      state: 'error',
+      message: 'xcrun exploded',
+      devices: []
+    })
     expect(result.available).toBe(false)
     expect(result.simctl.ok).toBe(false)
     expect(result.simctl.message).toBe('xcrun exploded')

--- a/src/main/emulator/emulator-availability.ts
+++ b/src/main/emulator/emulator-availability.ts
@@ -2,14 +2,17 @@ import { platform } from 'node:os'
 import type { EmulatorBridge } from './emulator-bridge'
 import type { SimulatorDevice } from './simctl-simulator-devices'
 import type { BackendAvailability, EmulatorDevice } from './backends/emulator-backend'
+import type { AndroidSetupStatus, IosSetupStatus } from '../../shared/emulator-setup-types'
+import { inspectAndroidSetupFromHost, inspectIosSetupFromHost } from './emulator-setup-host-probe'
 
 export type EmulatorAvailability = {
   platform: NodeJS.Platform
   available: boolean
   devices: SimulatorDevice[]
+  ios: IosSetupStatus
   simctl: { ok: boolean; message?: string }
   serveSim: { ok: boolean; message?: string }
-  android: { sdkFound: boolean; sdkPath?: string; message: string }
+  android: AndroidSetupStatus & { sdkFound: boolean }
   message: string
 }
 
@@ -32,38 +35,36 @@ type IosAvailability = {
   devices: SimulatorDevice[]
   simctl: { ok: boolean; message?: string }
   serveSim: { ok: boolean; message?: string }
+  setup: IosSetupStatus
 }
 
-async function inspectIosAvailability(bridge: EmulatorBridge): Promise<IosAvailability> {
-  let devices: SimulatorDevice[] = []
-  let simctl: IosAvailability['simctl'] = { ok: true }
+async function inspectIosAvailability(
+  bridge: EmulatorBridge,
+  setup: IosSetupStatus
+): Promise<IosAvailability> {
+  const devices = setup.devices
+  const simctl: IosAvailability['simctl'] =
+    setup.state === 'ready' ? { ok: true } : { ok: false, message: setup.message }
   let serveSim: IosAvailability['serveSim'] = { ok: true }
 
-  try {
-    devices = await bridge.listSimulators()
-    if (devices.length === 0) {
-      simctl = {
+  if (setup.state === 'ready') {
+    try {
+      await bridge.checkServeSimAvailable()
+    } catch (error) {
+      serveSim = {
         ok: false,
-        message: 'No iOS simulators found. Add one in Xcode Settings > Platforms.'
+        message: error instanceof Error ? error.message : 'serve-sim is unavailable.'
       }
     }
-  } catch (error) {
-    simctl = {
-      ok: false,
-      message: error instanceof Error ? error.message : 'xcrun simctl is unavailable.'
-    }
   }
 
-  try {
-    await bridge.checkServeSimAvailable()
-  } catch (error) {
-    serveSim = {
-      ok: false,
-      message: error instanceof Error ? error.message : 'serve-sim is unavailable.'
-    }
+  return {
+    available: simctl.ok && serveSim.ok && devices.length > 0,
+    devices,
+    simctl,
+    serveSim,
+    setup
   }
-
-  return { available: simctl.ok && serveSim.ok && devices.length > 0, devices, simctl, serveSim }
 }
 
 // Android devices are surfaced through the same SimulatorDevice-shaped list the
@@ -81,44 +82,59 @@ function toSimulatorRow(device: EmulatorDevice): SimulatorDevice {
 // Aggregates availability across backends so the Mobile Emulator pane works on
 // every desktop platform: iOS (macOS only) plus Android (any host with the SDK).
 export async function inspectEmulatorAvailability(
-  bridge: EmulatorBridge
+  bridge: EmulatorBridge,
+  probes: {
+    inspectIos?: () => Promise<IosSetupStatus>
+    inspectAndroid?: (backend: BackendAvailability) => AndroidSetupStatus
+  } = {}
 ): Promise<EmulatorAvailability> {
   const currentPlatform = platform()
   const backends = bridge.listBackends()
   const iosBackend = backends.find((backend) => backend.kind === 'ios')
   const androidBackend = backends.find((backend) => backend.kind === 'android')
+  const iosSupported = Boolean(iosBackend?.isSupportedOnHost())
 
-  const ios: IosAvailability = iosBackend?.isSupportedOnHost()
-    ? await inspectIosAvailability(bridge)
-    : { available: false, devices: [], simctl: { ok: false }, serveSim: { ok: false } }
+  const [android, iosSetup] = await Promise.all([
+    androidBackend
+      ? androidBackend.checkAvailability()
+      : Promise.resolve({ available: false, devices: [], message: '' }),
+    (probes.inspectIos ?? inspectIosSetupFromHost)()
+  ])
+  const ios: IosAvailability = iosSupported
+    ? await inspectIosAvailability(bridge, iosSetup)
+    : {
+        available: false,
+        devices: [],
+        simctl: { ok: false, message: iosSetup.message },
+        serveSim: { ok: false },
+        setup: iosSetup
+      }
+  const androidSetup = (probes.inspectAndroid ?? inspectAndroidSetupFromHost)(android)
 
-  const android: BackendAvailability = androidBackend
-    ? await androidBackend.checkAvailability()
-    : { available: false, devices: [], message: '' }
-
-  const devices = [...ios.devices, ...android.devices.map(toSimulatorRow)]
-  const available = ios.available || android.available
+  const androidReady = androidSetup.state === 'ready'
+  const devices = [...ios.devices, ...(androidReady ? android.devices.map(toSimulatorRow) : [])]
+  const available = ios.available || androidReady
   // Why: on non-macOS hosts the iOS messages are irrelevant, so surface the
   // Android setup message instead of "requires macOS".
   const message = available
     ? 'Ready'
-    : currentPlatform === 'darwin'
+    : currentPlatform === 'darwin' && iosSupported
       ? ios.simctl.message ||
         ios.serveSim.message ||
-        android.message ||
+        androidSetup.message ||
         'Mobile Emulator is not available.'
-      : android.message || 'Mobile Emulator is not available.'
+      : androidSetup.message || 'Mobile Emulator is not available.'
 
   return {
     platform: currentPlatform,
     available,
     devices,
+    ios: ios.setup,
     simctl: ios.simctl,
     serveSim: ios.serveSim,
     android: {
-      sdkFound: Boolean(android.sdkPath),
-      sdkPath: android.sdkPath,
-      message: android.message || ''
+      ...androidSetup,
+      sdkFound: Boolean(androidSetup.sdkPath && androidSetup.state !== 'sdk-invalid')
     },
     message
   }

--- a/src/main/emulator/emulator-setup-host-probe.e2e.test.ts
+++ b/src/main/emulator/emulator-setup-host-probe.e2e.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { inspectAndroidSetupFromHost, inspectIosSetupFromHost } from './emulator-setup-host-probe'
+
+const runHostProbe = process.env.ORCA_EMULATOR_SETUP_E2E === '1' ? describe : describe.skip
+
+runHostProbe('mobile emulator host setup probe', () => {
+  it('classifies the real host without claiming unusable iOS tooling is ready', async () => {
+    const ios = await inspectIosSetupFromHost()
+    console.info(`iOS setup state: ${ios.state} (${ios.message})`)
+    expect(ios.state).toMatch(
+      /^(unsupported|xcode-missing|xcode-selection-required|xcode-first-launch-required|simulator-runtime-missing|simulator-device-missing|ready|error)$/
+    )
+    if (ios.state === 'ready') {
+      expect(ios.devices.length).toBeGreaterThan(0)
+    }
+    if (ios.state === 'xcode-selection-required') {
+      expect(ios.recommendedXcode?.developerDir).toMatch(/\.app\/Contents\/Developer$/)
+    }
+  })
+
+  it('classifies the real Android SDK component boundary', () => {
+    const android = inspectAndroidSetupFromHost({
+      available: false,
+      devices: [],
+      message: 'No Android devices or AVDs found.'
+    })
+    console.info(`Android setup state: ${android.state} (${android.message})`)
+    expect(android.state).toMatch(
+      /^(sdk-missing|sdk-invalid|platform-tools-missing|emulator-missing|system-image-missing|device-missing|ready|error)$/
+    )
+    if (android.state === 'ready') {
+      expect(android.components).toEqual({
+        platformTools: true,
+        emulator: true,
+        systemImages: true
+      })
+    }
+  })
+})

--- a/src/main/emulator/emulator-setup-host-probe.ts
+++ b/src/main/emulator/emulator-setup-host-probe.ts
@@ -1,0 +1,82 @@
+import { execFile } from 'node:child_process'
+import { existsSync, readdirSync } from 'node:fs'
+import { homedir, platform } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import type { BackendAvailability } from './backends/emulator-backend'
+import { inspectAndroidSetup } from './android/android-setup-probe'
+import { getConfiguredAndroidSdkPath } from './android/android-sdk-host-discovery'
+import { inspectIosSetup } from './ios-setup-probe'
+
+const execFileAsync = promisify(execFile)
+
+function listDirectory(path: string): string[] {
+  try {
+    return readdirSync(path)
+  } catch {
+    return []
+  }
+}
+
+function hasInstalledSystemImage(path: string, remainingDepth = 4): boolean {
+  if (remainingDepth < 0) {
+    return false
+  }
+  try {
+    for (const entry of readdirSync(path, { withFileTypes: true })) {
+      if (entry.isFile() && entry.name === 'package.xml') {
+        return true
+      }
+      if (
+        entry.isDirectory() &&
+        hasInstalledSystemImage(join(path, entry.name), remainingDepth - 1)
+      ) {
+        return true
+      }
+    }
+  } catch {
+    return false
+  }
+  return false
+}
+
+async function runCommand(
+  file: string,
+  args: string[],
+  env?: NodeJS.ProcessEnv
+): Promise<{ ok: boolean; stdout: string; stderr: string }> {
+  try {
+    const result = await execFileAsync(file, args, { env, timeout: 20_000 })
+    return { ok: true, stdout: result.stdout, stderr: result.stderr }
+  } catch (error) {
+    const failure = error as Error & { stdout?: string; stderr?: string }
+    return {
+      ok: false,
+      stdout: failure.stdout ?? '',
+      stderr: failure.stderr ?? failure.message
+    }
+  }
+}
+
+export function inspectIosSetupFromHost() {
+  return inspectIosSetup({
+    platform: platform(),
+    homedir: homedir(),
+    exists: existsSync,
+    listDirectory,
+    run: runCommand
+  })
+}
+
+export function inspectAndroidSetupFromHost(backend: BackendAvailability) {
+  return inspectAndroidSetup({
+    env: process.env,
+    platform: platform(),
+    homedir: homedir(),
+    configuredPath: getConfiguredAndroidSdkPath(),
+    exists: existsSync,
+    hasInstalledSystemImage,
+    backendAvailable: backend.available,
+    backendMessage: backend.message
+  })
+}

--- a/src/main/emulator/ios-setup-probe.test.ts
+++ b/src/main/emulator/ios-setup-probe.test.ts
@@ -1,0 +1,210 @@
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { inspectIosSetup, type IosSetupProbeOptions } from './ios-setup-probe'
+
+const DEFAULT_APP = '/Applications/Xcode.app'
+const DEFAULT_DEVELOPER_DIR = join(DEFAULT_APP, 'Contents', 'Developer')
+const IOS_DEVICE_JSON = JSON.stringify({
+  devices: {
+    'com.apple.CoreSimulator.SimRuntime.iOS-18-0': [
+      { name: 'iPhone 16', udid: 'device-1', state: 'Shutdown', isAvailable: true }
+    ]
+  }
+})
+const IOS_RUNTIME_JSON = JSON.stringify({
+  runtimes: [{ identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-18-0', isAvailable: true }]
+})
+
+type ProbeScenario = {
+  platform?: NodeJS.Platform
+  selected?: string
+  apps?: string[]
+  firstLaunch?: { ok: boolean; stderr?: string }
+  devices?: { ok: boolean; stdout?: string; stderr?: string }
+  runtimes?: { ok: boolean; stdout?: string }
+  spotlight?: string[]
+}
+
+function scenarioOptions(scenario: ProbeScenario): IosSetupProbeOptions {
+  const apps = scenario.apps ?? []
+  const toolPaths = new Set(
+    apps.map((app) => join(app, 'Contents', 'Developer', 'usr', 'bin', 'xcodebuild'))
+  )
+  return {
+    platform: scenario.platform ?? 'darwin',
+    homedir: '/Users/tester',
+    exists: (path) => toolPaths.has(path),
+    listDirectory: (path) =>
+      path === '/Applications'
+        ? apps
+            .filter((app) => app.startsWith('/Applications/'))
+            .map((app) => app.slice('/Applications/'.length))
+        : [],
+    run: async (file, args) => {
+      if (file === '/usr/bin/xcode-select') {
+        return {
+          ok: true,
+          stdout: `${scenario.selected ?? '/Library/Developer/CommandLineTools'}\n`,
+          stderr: ''
+        }
+      }
+      if (file === '/usr/bin/mdfind') {
+        return { ok: true, stdout: (scenario.spotlight ?? []).join('\n'), stderr: '' }
+      }
+      if (args[0] === '-checkFirstLaunchStatus') {
+        return {
+          ok: scenario.firstLaunch?.ok ?? true,
+          stdout: '',
+          stderr: scenario.firstLaunch?.stderr ?? ''
+        }
+      }
+      if (args.includes('devices')) {
+        return {
+          ok: scenario.devices?.ok ?? true,
+          stdout: scenario.devices?.stdout ?? IOS_DEVICE_JSON,
+          stderr: scenario.devices?.stderr ?? ''
+        }
+      }
+      return {
+        ok: scenario.runtimes?.ok ?? true,
+        stdout: scenario.runtimes?.stdout ?? IOS_RUNTIME_JSON,
+        stderr: ''
+      }
+    }
+  }
+}
+
+describe('inspectIosSetup', () => {
+  it('reports Xcode missing', async () => {
+    expect((await inspectIosSetup(scenarioOptions({ apps: [] }))).state).toBe('xcode-missing')
+  })
+
+  it('detects full Xcode while standalone Command Line Tools remain selected', async () => {
+    const result = await inspectIosSetup(scenarioOptions({ apps: [DEFAULT_APP] }))
+    expect(result).toMatchObject({
+      state: 'xcode-selection-required',
+      selectedDeveloperDir: '/Library/Developer/CommandLineTools',
+      recommendedXcode: { appPath: DEFAULT_APP, developerDir: DEFAULT_DEVELOPER_DIR }
+    })
+  })
+
+  it('separates pending license and first-launch components', async () => {
+    const result = await inspectIosSetup(
+      scenarioOptions({
+        apps: [DEFAULT_APP],
+        selected: DEFAULT_DEVELOPER_DIR,
+        firstLaunch: { ok: false, stderr: 'license not accepted' }
+      })
+    )
+    expect(result.state).toBe('xcode-first-launch-required')
+  })
+
+  it('reports a missing simulator runtime after simctl becomes usable', async () => {
+    const result = await inspectIosSetup(
+      scenarioOptions({
+        apps: [DEFAULT_APP],
+        selected: DEFAULT_DEVELOPER_DIR,
+        devices: { ok: true, stdout: '{"devices":{}}' },
+        runtimes: { ok: true, stdout: '{"runtimes":[]}' }
+      })
+    )
+    expect(result.state).toBe('simulator-runtime-missing')
+  })
+
+  it('requires a compatible simulator device even when an iOS runtime exists', async () => {
+    const result = await inspectIosSetup(
+      scenarioOptions({
+        apps: [DEFAULT_APP],
+        selected: DEFAULT_DEVELOPER_DIR,
+        devices: { ok: true, stdout: '{"devices":{}}' }
+      })
+    )
+    expect(result.state).toBe('simulator-device-missing')
+  })
+
+  it('reports ready only after simctl lists a compatible iOS device', async () => {
+    const result = await inspectIosSetup(
+      scenarioOptions({ apps: [DEFAULT_APP], selected: DEFAULT_DEVELOPER_DIR })
+    )
+    expect(result.state).toBe('ready')
+    expect(result.devices).toEqual([
+      expect.objectContaining({ name: 'iPhone 16', runtime: expect.stringContaining('iOS-18-0') })
+    ])
+  })
+
+  it('does not claim ready for an unavailable device returned by simctl', async () => {
+    const result = await inspectIosSetup(
+      scenarioOptions({
+        apps: [DEFAULT_APP],
+        selected: DEFAULT_DEVELOPER_DIR,
+        devices: {
+          ok: true,
+          stdout: JSON.stringify({
+            devices: {
+              'com.apple.CoreSimulator.SimRuntime.iOS-18-0': [
+                { name: 'iPhone 16', udid: 'device-1', isAvailable: false }
+              ]
+            }
+          })
+        }
+      })
+    )
+    expect(result.state).toBe('simulator-device-missing')
+  })
+
+  it('reports malformed simctl output as an error instead of a missing runtime', async () => {
+    const result = await inspectIosSetup(
+      scenarioOptions({
+        apps: [DEFAULT_APP],
+        selected: DEFAULT_DEVELOPER_DIR,
+        devices: { ok: true, stdout: 'not-json' }
+      })
+    )
+    expect(result.state).toBe('error')
+    expect(result.message).toMatch(/unreadable/)
+  })
+
+  it('reports a failed runtime query as an error instead of a missing runtime', async () => {
+    const result = await inspectIosSetup(
+      scenarioOptions({
+        apps: [DEFAULT_APP],
+        selected: DEFAULT_DEVELOPER_DIR,
+        devices: { ok: true, stdout: '{"devices":{}}' },
+        runtimes: { ok: false, stdout: '' }
+      })
+    )
+    expect(result.state).toBe('error')
+  })
+
+  it('does not turn an unknown xcodebuild failure into a privileged setup action', async () => {
+    const result = await inspectIosSetup(
+      scenarioOptions({
+        apps: [DEFAULT_APP],
+        selected: DEFAULT_DEVELOPER_DIR,
+        firstLaunch: { ok: false, stderr: 'xcodebuild crashed' }
+      })
+    )
+    expect(result.state).toBe('error')
+  })
+
+  it('discovers Xcode installed at a non-default path through Spotlight', async () => {
+    const appPath = '/Developer/Xcode-16.4.app'
+    const result = await inspectIosSetup(scenarioOptions({ apps: [appPath], spotlight: [appPath] }))
+    expect(result.recommendedXcode?.appPath).toBe(appPath)
+    expect(result.state).toBe('xcode-selection-required')
+  })
+
+  it('re-probes stale selection state into ready after setup', async () => {
+    const before = await inspectIosSetup(scenarioOptions({ apps: [DEFAULT_APP] }))
+    const after = await inspectIosSetup(
+      scenarioOptions({ apps: [DEFAULT_APP], selected: DEFAULT_DEVELOPER_DIR })
+    )
+    expect([before.state, after.state]).toEqual(['xcode-selection-required', 'ready'])
+  })
+
+  it.each(['linux', 'win32'] as const)('does not offer local iOS setup on %s', async (platform) => {
+    const result = await inspectIosSetup(scenarioOptions({ platform, apps: [DEFAULT_APP] }))
+    expect(result.state).toBe('unsupported')
+    expect(result.recommendedXcode).toBeUndefined()
+  })
+})

--- a/src/main/emulator/ios-setup-probe.ts
+++ b/src/main/emulator/ios-setup-probe.ts
@@ -1,0 +1,257 @@
+import { basename, dirname, join } from 'node:path'
+import type { IosSetupStatus, XcodeApplication } from '../../shared/emulator-setup-types'
+
+type CommandResult = { ok: boolean; stdout: string; stderr: string }
+
+export type IosSetupProbeOptions = {
+  platform: NodeJS.Platform
+  homedir: string
+  exists: (path: string) => boolean
+  listDirectory: (path: string) => string[]
+  run: (file: string, args: string[], env?: NodeJS.ProcessEnv) => Promise<CommandResult>
+}
+
+function xcodeFromDeveloperDir(developerDir: string): XcodeApplication | null {
+  if (!developerDir.endsWith('.app/Contents/Developer')) {
+    return null
+  }
+  const appPath = dirname(dirname(developerDir))
+  return { appPath, developerDir, name: basename(appPath, '.app') }
+}
+
+function addXcode(
+  applications: Map<string, XcodeApplication>,
+  appPath: string,
+  exists: (path: string) => boolean
+): void {
+  const developerDir = join(appPath, 'Contents', 'Developer')
+  if (!appPath.endsWith('.app') || !exists(join(developerDir, 'usr', 'bin', 'xcodebuild'))) {
+    return
+  }
+  applications.set(appPath, { appPath, developerDir, name: basename(appPath, '.app') })
+}
+
+async function discoverXcodes(
+  options: IosSetupProbeOptions,
+  selectedDeveloperDir?: string
+): Promise<XcodeApplication[]> {
+  const applications = new Map<string, XcodeApplication>()
+  for (const root of ['/Applications', join(options.homedir, 'Applications')]) {
+    for (const name of options.listDirectory(root)) {
+      if (/^Xcode.*\.app$/i.test(name)) {
+        addXcode(applications, join(root, name), options.exists)
+      }
+    }
+  }
+  if (selectedDeveloperDir) {
+    const selected = xcodeFromDeveloperDir(selectedDeveloperDir)
+    if (selected) {
+      addXcode(applications, selected.appPath, options.exists)
+    }
+  }
+  const spotlight = await options.run('/usr/bin/mdfind', [
+    "kMDItemCFBundleIdentifier == 'com.apple.dt.Xcode'"
+  ])
+  if (spotlight.ok) {
+    for (const appPath of spotlight.stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)) {
+      addXcode(applications, appPath, options.exists)
+    }
+  }
+  return [...applications.values()].sort((left, right) => {
+    if (left.appPath === '/Applications/Xcode.app') {
+      return -1
+    }
+    if (right.appPath === '/Applications/Xcode.app') {
+      return 1
+    }
+    return left.name.localeCompare(right.name)
+  })
+}
+
+function commandMessage(result: CommandResult): string {
+  return `${result.stderr}\n${result.stdout}`.trim()
+}
+
+function hasPendingXcodeSetup(result: CommandResult): boolean {
+  const detail = commandMessage(result).toLowerCase()
+  return (
+    detail.includes('license') ||
+    detail.includes('first launch') ||
+    detail.includes('runfirstlaunch') ||
+    detail.includes('additional components')
+  )
+}
+
+function parseIosDevices(stdout: string): IosSetupStatus['devices'] | null {
+  try {
+    const groups = (
+      JSON.parse(stdout || '{}') as {
+        devices?: Record<
+          string,
+          { name?: string; udid?: string; state?: string; isAvailable?: boolean }[]
+        >
+      }
+    ).devices
+    return Object.entries(groups ?? {}).flatMap(([runtime, rows]) =>
+      runtime.includes('SimRuntime.iOS-')
+        ? rows.flatMap((device) =>
+            device.udid && device.isAvailable !== false
+              ? [
+                  {
+                    name: device.name ?? device.udid,
+                    udid: device.udid,
+                    state: device.state ?? 'Unknown',
+                    runtime,
+                    isAvailable: device.isAvailable
+                  }
+                ]
+              : []
+          )
+        : []
+    )
+  } catch {
+    return null
+  }
+}
+
+function hasIosRuntime(stdout: string): boolean | null {
+  try {
+    const runtimes = (
+      JSON.parse(stdout || '{}') as {
+        runtimes?: { identifier?: string; isAvailable?: boolean }[]
+      }
+    ).runtimes
+    return Boolean(
+      runtimes?.some(
+        (runtime) =>
+          runtime.identifier?.includes('SimRuntime.iOS-') && runtime.isAvailable !== false
+      )
+    )
+  } catch {
+    return null
+  }
+}
+
+export async function inspectIosSetup(options: IosSetupProbeOptions): Promise<IosSetupStatus> {
+  if (options.platform !== 'darwin') {
+    return {
+      state: 'unsupported',
+      message: 'iOS Simulator is available only on a local Mac.',
+      installedXcodes: [],
+      devices: []
+    }
+  }
+  const selection = await options.run('/usr/bin/xcode-select', ['-p'])
+  const selectedDeveloperDir = selection.ok ? selection.stdout.trim() : undefined
+  const installedXcodes = await discoverXcodes(options, selectedDeveloperDir)
+  const recommendedXcode = installedXcodes[0]
+  if (!recommendedXcode) {
+    return {
+      state: 'xcode-missing',
+      message: 'Full Xcode is not installed.',
+      selectedDeveloperDir,
+      installedXcodes,
+      devices: []
+    }
+  }
+  const selectedXcode = installedXcodes.find((xcode) => xcode.developerDir === selectedDeveloperDir)
+  if (!selectedXcode) {
+    return {
+      state: 'xcode-selection-required',
+      message: `${recommendedXcode.name} is installed, but macOS is still using the smaller Command Line Tools package. Use Installed Xcode will ask for administrator approval before changing it.`,
+      selectedDeveloperDir,
+      recommendedXcode,
+      installedXcodes,
+      devices: []
+    }
+  }
+
+  const env = { ...process.env, DEVELOPER_DIR: selectedXcode.developerDir }
+  const firstLaunch = await options.run(
+    join(selectedXcode.developerDir, 'usr', 'bin', 'xcodebuild'),
+    ['-checkFirstLaunchStatus'],
+    env
+  )
+  if (!firstLaunch.ok) {
+    const pendingSetup = hasPendingXcodeSetup(firstLaunch)
+    return {
+      state: pendingSetup ? 'xcode-first-launch-required' : 'error',
+      message: pendingSetup
+        ? 'Xcode needs its license accepted and required components installed. Finish Xcode Setup will ask for administrator approval.'
+        : 'Xcode could not check its setup status. Open Xcode, resolve any setup message, then refresh.',
+      selectedDeveloperDir,
+      recommendedXcode: selectedXcode,
+      installedXcodes,
+      devices: []
+    }
+  }
+  const devices = await options.run(
+    '/usr/bin/xcrun',
+    ['simctl', 'list', 'devices', 'available', '-j'],
+    env
+  )
+  if (!devices.ok) {
+    return {
+      state: hasPendingXcodeSetup(devices) ? 'xcode-first-launch-required' : 'error',
+      message: hasPendingXcodeSetup(devices)
+        ? 'Xcode needs its license accepted and required components installed. Finish Xcode Setup will ask for administrator approval.'
+        : 'Xcode could not list Simulator devices. Open Xcode, resolve any setup message, then refresh.',
+      selectedDeveloperDir,
+      recommendedXcode: selectedXcode,
+      installedXcodes,
+      devices: []
+    }
+  }
+  const parsedDevices = parseIosDevices(devices.stdout)
+  if (!parsedDevices) {
+    return {
+      state: 'error',
+      message: 'Xcode returned an unreadable Simulator device list. Open Xcode, then refresh.',
+      selectedDeveloperDir,
+      recommendedXcode: selectedXcode,
+      installedXcodes,
+      devices: []
+    }
+  }
+  if (parsedDevices.length > 0) {
+    return {
+      state: 'ready',
+      message: 'Ready',
+      selectedDeveloperDir,
+      recommendedXcode: selectedXcode,
+      installedXcodes,
+      devices: parsedDevices
+    }
+  }
+  const runtimes = await options.run(
+    '/usr/bin/xcrun',
+    ['simctl', 'list', 'runtimes', 'available', '-j'],
+    env
+  )
+  const runtimeAvailable = runtimes.ok ? hasIosRuntime(runtimes.stdout) : null
+  if (runtimeAvailable === null) {
+    return {
+      state: 'error',
+      message: 'Xcode could not read installed Simulator runtimes. Open Xcode, then refresh.',
+      selectedDeveloperDir,
+      recommendedXcode: selectedXcode,
+      installedXcodes,
+      devices: []
+    }
+  }
+  const state = runtimeAvailable ? 'simulator-device-missing' : 'simulator-runtime-missing'
+  return {
+    state,
+    message:
+      state === 'simulator-device-missing'
+        ? 'An iOS runtime is installed, but no compatible device exists. Create one in Xcode > Window > Devices and Simulators.'
+        : 'No compatible iOS Simulator runtime is installed. Install one in Xcode > Settings > Components (Platforms on older Xcode versions).',
+    selectedDeveloperDir,
+    recommendedXcode: selectedXcode,
+    installedXcodes,
+    devices: []
+  }
+}

--- a/src/main/emulator/simctl-simulator-devices.test.ts
+++ b/src/main/emulator/simctl-simulator-devices.test.ts
@@ -88,10 +88,28 @@ describe('listSimulatorDevices', () => {
 
     expect(error).toMatchObject({
       code: 'emulator_simctl_unavailable',
-      message: expect.stringContaining('Xcode Simulator tools are unavailable')
+      message: expect.stringContaining('Open Settings > Mobile Emulator')
     })
     expect(error).toBeInstanceOf(Error)
     expect((error as Error).message).not.toContain('Command failed')
+  })
+
+  it('routes pending Xcode license errors to the guided setup page', async () => {
+    execFileMock.mockImplementationOnce((_file, _args, _options, callback) => {
+      callback(
+        Object.assign(new Error('You have not agreed to the Xcode license agreements.'), {
+          code: 69
+        }),
+        '',
+        'Run xcodebuild -license'
+      )
+      return {} as never
+    })
+
+    await expect(listSimulatorDevices()).rejects.toMatchObject({
+      code: 'emulator_simctl_unavailable',
+      message: expect.stringContaining('Open Settings > Mobile Emulator')
+    })
   })
 })
 

--- a/src/main/emulator/simctl-simulator-devices.ts
+++ b/src/main/emulator/simctl-simulator-devices.ts
@@ -25,7 +25,7 @@ type SimctlDeviceList = {
 
 const UDID_RE = /^[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}$/i
 const SIMCTL_UNAVAILABLE_MESSAGE =
-  'Xcode Simulator tools are unavailable. Install full Xcode, open it once, then select it with `sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer`.'
+  'iOS Simulator is not set up for Orca. Open Settings > Mobile Emulator to select Xcode and finish setup.'
 
 function parseSimctlDevices(stdout: string): SimulatorDevice[] {
   const data = JSON.parse(stdout || '{}') as SimctlDeviceList
@@ -53,7 +53,11 @@ function mapSimctlError(error: ExecFileException, stderr?: string | Buffer): Emu
   if (
     error.code === 'ENOENT' ||
     (lower.includes('unable to find utility') && lower.includes('simctl')) ||
-    lower.includes('not a developer tool')
+    lower.includes('not a developer tool') ||
+    lower.includes('license') ||
+    lower.includes('runfirstlaunch') ||
+    lower.includes('first launch') ||
+    lower.includes('active developer path')
   ) {
     // Why: xcrun exposes setup problems as raw execFile text; UI and CLI need
     // the actionable Xcode fix instead of "Command failed: xcrun ...".

--- a/src/main/emulator/xcode-setup-actions.test.ts
+++ b/src/main/emulator/xcode-setup-actions.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createXcodeSetupActions } from './xcode-setup-actions'
+
+const DEVELOPER_DIR = '/Applications/Xcode.app/Contents/Developer'
+
+function dependencies(overrides: Record<string, unknown> = {}) {
+  return {
+    platform: 'darwin' as NodeJS.Platform,
+    realpath: vi.fn(async (path: string) => path),
+    exists: vi.fn(() => true),
+    inspect: vi.fn(async () => ({
+      state: 'xcode-selection-required' as const,
+      message: 'Select Xcode',
+      installedXcodes: [
+        { appPath: '/Applications/Xcode.app', developerDir: DEVELOPER_DIR, name: 'Xcode' }
+      ],
+      devices: []
+    })),
+    verifyXcode: vi.fn(async () => {}),
+    runPrivileged: vi.fn(async () => {}),
+    ...overrides
+  }
+}
+
+describe('createXcodeSetupActions', () => {
+  it('runs selection and first-launch only after the explicit guided action', async () => {
+    const deps = dependencies()
+    const actions = createXcodeSetupActions(deps)
+    expect(deps.runPrivileged).not.toHaveBeenCalled()
+    await expect(actions.useInstalledXcode(DEVELOPER_DIR)).resolves.toEqual({ ok: true })
+    expect(deps.runPrivileged).toHaveBeenCalledWith(
+      expect.stringContaining('xcode-select --switch')
+    )
+    expect(deps.runPrivileged).toHaveBeenCalledWith(expect.stringContaining('-runFirstLaunch'))
+    expect(deps.runPrivileged).toHaveBeenCalledWith(expect.stringContaining('codesign --verify'))
+  })
+
+  it('rejects untrusted paths before requesting administrator privileges', async () => {
+    const deps = dependencies()
+    const result = await createXcodeSetupActions(deps).useInstalledXcode('/tmp/toolchain')
+    expect(result).toMatchObject({ ok: false, message: expect.stringContaining('invalid') })
+    expect(deps.runPrivileged).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unsigned Xcode lookalike before requesting administrator privileges', async () => {
+    const deps = dependencies({
+      verifyXcode: vi.fn(async () => {
+        throw new Error('code object is not signed at all')
+      })
+    })
+    const result = await createXcodeSetupActions(deps).useInstalledXcode(DEVELOPER_DIR)
+    expect(result).toMatchObject({ ok: false, message: expect.stringContaining('not signed') })
+    expect(deps.runPrivileged).not.toHaveBeenCalled()
+  })
+
+  it('does not expose a macOS action on Linux, Windows, or remote host implementations', async () => {
+    for (const targetPlatform of ['linux', 'win32'] as const) {
+      const deps = dependencies({ platform: targetPlatform })
+      const result = await createXcodeSetupActions(deps).useInstalledXcode(DEVELOPER_DIR)
+      expect(result.ok).toBe(false)
+      expect(deps.runPrivileged).not.toHaveBeenCalled()
+    }
+  })
+
+  it('surfaces canceled authorization without claiming setup succeeded', async () => {
+    const deps = dependencies({
+      runPrivileged: vi.fn(async () => {
+        throw new Error('execution error: User canceled. (-128)')
+      })
+    })
+    await expect(createXcodeSetupActions(deps).finishXcodeSetup(DEVELOPER_DIR)).resolves.toEqual({
+      ok: false,
+      canceled: true,
+      message: 'Administrator authorization was canceled.'
+    })
+  })
+})

--- a/src/main/emulator/xcode-setup-actions.ts
+++ b/src/main/emulator/xcode-setup-actions.ts
@@ -1,0 +1,133 @@
+import { execFile } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { realpath } from 'node:fs/promises'
+import { platform } from 'node:os'
+import { dirname, join, normalize } from 'node:path'
+import { promisify } from 'node:util'
+import type { EmulatorSetupActionResult } from '../../shared/emulator-setup-types'
+import { inspectIosSetupFromHost } from './emulator-setup-host-probe'
+
+const execFileAsync = promisify(execFile)
+
+function quoteShell(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`
+}
+
+function quoteAppleScript(value: string): string {
+  return `"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`
+}
+
+function xcodeSignatureCheck(xcodebuild: string): string {
+  const requirement = '-R=anchor apple and identifier "com.apple.dt.xcodebuild"'
+  return `/usr/bin/codesign --verify --strict ${quoteShell(requirement)} ${quoteShell(xcodebuild)}`
+}
+
+async function runPrivilegedCommand(command: string): Promise<void> {
+  await execFileAsync('/usr/bin/osascript', [
+    '-e',
+    `do shell script ${quoteAppleScript(command)} with administrator privileges`
+  ])
+}
+
+type XcodeSetupActionDependencies = {
+  platform: NodeJS.Platform
+  realpath: (path: string) => Promise<string>
+  exists: (path: string) => boolean
+  inspect: typeof inspectIosSetupFromHost
+  verifyXcode: (appPath: string) => Promise<void>
+  runPrivileged: (command: string) => Promise<void>
+}
+
+async function verifyAppleXcode(appPath: string): Promise<void> {
+  try {
+    await execFileAsync('/usr/bin/codesign', [
+      '--verify',
+      '--strict',
+      '-R=anchor apple and identifier "com.apple.dt.xcodebuild"',
+      join(appPath, 'Contents', 'Developer', 'usr', 'bin', 'xcodebuild')
+    ])
+  } catch {
+    throw new Error('Orca could not verify this copy of Xcode. Reinstall Xcode and try again.')
+  }
+}
+
+const defaultDependencies: XcodeSetupActionDependencies = {
+  platform: platform(),
+  realpath,
+  exists: existsSync,
+  inspect: inspectIosSetupFromHost,
+  verifyXcode: verifyAppleXcode,
+  runPrivileged: runPrivilegedCommand
+}
+
+async function validateDeveloperDir(
+  developerDir: string,
+  dependencies: XcodeSetupActionDependencies
+): Promise<string> {
+  if (dependencies.platform !== 'darwin') {
+    throw new Error('Xcode setup is available only on macOS.')
+  }
+  const normalized = normalize(developerDir)
+  if (!normalized.endsWith('.app/Contents/Developer')) {
+    throw new Error('The selected Xcode developer folder is invalid.')
+  }
+  const canonical = await dependencies.realpath(normalized)
+  if (!dependencies.exists(join(canonical, 'usr', 'bin', 'xcodebuild'))) {
+    throw new Error('The selected app does not contain the full Xcode toolchain.')
+  }
+  await dependencies.verifyXcode(dirname(dirname(canonical)))
+  const status = await dependencies.inspect()
+  if (!status.installedXcodes.some((xcode) => xcode.developerDir === normalized)) {
+    throw new Error('Xcode is no longer installed at the detected location. Refresh and try again.')
+  }
+  return canonical
+}
+
+function actionFailure(error: unknown): EmulatorSetupActionResult {
+  const message = error instanceof Error ? error.message : 'Xcode setup failed.'
+  const canceled = /-128|user canceled|user cancelled/i.test(message)
+  return {
+    ok: false,
+    canceled,
+    message: canceled ? 'Administrator authorization was canceled.' : message
+  }
+}
+
+export function createXcodeSetupActions(
+  dependencies: XcodeSetupActionDependencies = defaultDependencies
+) {
+  return {
+    async useInstalledXcode(developerDir: string): Promise<EmulatorSetupActionResult> {
+      try {
+        const canonical = await validateDeveloperDir(developerDir, dependencies)
+        const xcodebuild = join(canonical, 'usr', 'bin', 'xcodebuild')
+        await dependencies.runPrivileged(
+          `${xcodeSignatureCheck(xcodebuild)} && /usr/bin/xcode-select --switch ${quoteShell(canonical)} && ${quoteShell(xcodebuild)} -runFirstLaunch`
+        )
+        return { ok: true }
+      } catch (error) {
+        return actionFailure(error)
+      }
+    },
+    async finishXcodeSetup(developerDir: string): Promise<EmulatorSetupActionResult> {
+      try {
+        const canonical = await validateDeveloperDir(developerDir, dependencies)
+        const xcodebuild = join(canonical, 'usr', 'bin', 'xcodebuild')
+        await dependencies.runPrivileged(
+          `${xcodeSignatureCheck(xcodebuild)} && ${quoteShell(xcodebuild)} -runFirstLaunch`
+        )
+        return { ok: true }
+      } catch (error) {
+        return actionFailure(error)
+      }
+    }
+  }
+}
+
+const defaultActions = createXcodeSetupActions()
+export const useInstalledXcode = defaultActions.useInstalledXcode
+export const finishXcodeSetup = defaultActions.finishXcodeSetup
+
+export async function resolveInstalledXcodeAppPath(developerDir: string): Promise<string> {
+  return dirname(dirname(await validateDeveloperDir(developerDir, defaultDependencies)))
+}

--- a/src/main/ipc/emulator-setup.ts
+++ b/src/main/ipc/emulator-setup.ts
@@ -1,0 +1,27 @@
+import { ipcMain, shell } from 'electron'
+import {
+  finishXcodeSetup,
+  resolveInstalledXcodeAppPath,
+  useInstalledXcode
+} from '../emulator/xcode-setup-actions'
+
+export function registerEmulatorSetupHandlers(): void {
+  ipcMain.handle('emulatorSetup:useInstalledXcode', (_event, developerDir: string) =>
+    useInstalledXcode(developerDir)
+  )
+  ipcMain.handle('emulatorSetup:finishXcodeSetup', (_event, developerDir: string) =>
+    finishXcodeSetup(developerDir)
+  )
+  ipcMain.handle('emulatorSetup:openXcode', async (_event, developerDir: string) => {
+    try {
+      const appPath = await resolveInstalledXcodeAppPath(developerDir)
+      const message = await shell.openPath(appPath)
+      return { ok: message.length === 0, message: message || undefined }
+    } catch (error) {
+      return {
+        ok: false,
+        message: error instanceof Error ? error.message : 'Could not open Xcode.'
+      }
+    }
+  })
+}

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -23,6 +23,7 @@ const {
   registerDiagnosticsHandlersMock,
   registerTerminalRenderDesyncEvidenceHandlerMock,
   registerShellHandlersMock,
+  registerEmulatorSetupHandlersMock,
   registerPetHandlersMock,
   registerSessionHandlersMock,
   registerUIHandlersMock,
@@ -87,6 +88,7 @@ const {
   registerDiagnosticsHandlersMock: vi.fn(),
   registerTerminalRenderDesyncEvidenceHandlerMock: vi.fn(),
   registerShellHandlersMock: vi.fn(),
+  registerEmulatorSetupHandlersMock: vi.fn(),
   registerPetHandlersMock: vi.fn(),
   registerSessionHandlersMock: vi.fn(),
   registerUIHandlersMock: vi.fn(),
@@ -252,6 +254,10 @@ vi.mock('./shell', () => ({
   registerShellHandlers: registerShellHandlersMock
 }))
 
+vi.mock('./emulator-setup', () => ({
+  registerEmulatorSetupHandlers: registerEmulatorSetupHandlersMock
+}))
+
 vi.mock('./pet', () => ({
   registerPetHandlers: registerPetHandlersMock
 }))
@@ -400,6 +406,7 @@ describe('registerCoreHandlers', () => {
     registerDiagnosticsHandlersMock.mockReset()
     registerTerminalRenderDesyncEvidenceHandlerMock.mockReset()
     registerShellHandlersMock.mockReset()
+    registerEmulatorSetupHandlersMock.mockReset()
     registerPetHandlersMock.mockReset()
     registerSessionHandlersMock.mockReset()
     registerUIHandlersMock.mockReset()
@@ -537,6 +544,7 @@ describe('registerCoreHandlers', () => {
     expect(registerCliHandlersMock).toHaveBeenCalled()
     expect(registerPreflightHandlersMock).toHaveBeenCalled()
     expect(registerShellHandlersMock).toHaveBeenCalled()
+    expect(registerEmulatorSetupHandlersMock).toHaveBeenCalled()
     expect(registerClipboardHandlersMock).toHaveBeenCalledWith(store)
     expect(registerUpdaterHandlersMock).toHaveBeenCalled()
     expect(setTrustedBrowserRendererWebContentsIdMock).toHaveBeenCalledWith(null)

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -47,6 +47,7 @@ import { registerKeybindingHandlers } from './keybindings'
 import { registerTelemetryHandlers } from './telemetry'
 import { registerBrowserHandlers } from './browser'
 import { registerShellHandlers } from './shell'
+import { registerEmulatorSetupHandlers } from './emulator-setup'
 import { registerPetHandlers } from './pet'
 import { registerUIHandlers, setTrustedUIRendererWebContentsId } from './ui'
 import { registerEmulatorFrameStreamHandlers } from './emulator-frame-stream'
@@ -183,6 +184,7 @@ export function registerCoreHandlers(
   })
   registerBrowserHandlers()
   registerShellHandlers()
+  registerEmulatorSetupHandlers()
   registerPetHandlers()
   registerSessionHandlers(store)
   registerUIHandlers(store)

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -9,6 +9,7 @@ import type {
   HostedReviewProvider
 } from '../shared/hosted-review'
 import type { NativeFileDropPayload } from '../shared/native-file-drop'
+import type { EmulatorSetupActionResult } from '../shared/emulator-setup-types'
 import type { DashboardSnapshot, DashboardRevealAgentArgs } from '../shared/dashboard-snapshot'
 import type {
   TerminalPreviewConnectResult,
@@ -2268,6 +2269,11 @@ export type PreloadApi = {
       id?: ComputerUsePermissionId
     }) => Promise<ComputerUsePermissionSetupResult>
     reset: () => Promise<ComputerUsePermissionResetResult>
+  }
+  emulatorSetup: {
+    useInstalledXcode: (developerDir: string) => Promise<EmulatorSetupActionResult>
+    finishXcodeSetup: (developerDir: string) => Promise<EmulatorSetupActionResult>
+    openXcode: (developerDir: string) => Promise<EmulatorSetupActionResult>
   }
   shell: {
     openPath: (path: string) => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,6 +4,7 @@ import { electronAPI } from '@electron-toolkit/preload'
 import { preloadE2EConfig } from './e2e-config'
 import { glApi } from './gitlab'
 import type { AppIdentity } from '../shared/app-identity'
+import type { EmulatorSetupActionResult } from '../shared/emulator-setup-types'
 import type { DashboardSnapshot, DashboardRevealAgentArgs } from '../shared/dashboard-snapshot'
 import type {
   TerminalPreviewConnectResult,
@@ -2174,6 +2175,15 @@ const api = {
     openSetup: (args?: { id?: string }): Promise<unknown> =>
       ipcRenderer.invoke('computerUsePermissions:openSetup', args),
     reset: (): Promise<unknown> => ipcRenderer.invoke('computerUsePermissions:reset')
+  },
+
+  emulatorSetup: {
+    useInstalledXcode: (developerDir: string): Promise<EmulatorSetupActionResult> =>
+      ipcRenderer.invoke('emulatorSetup:useInstalledXcode', developerDir),
+    finishXcodeSetup: (developerDir: string): Promise<EmulatorSetupActionResult> =>
+      ipcRenderer.invoke('emulatorSetup:finishXcodeSetup', developerDir),
+    openXcode: (developerDir: string): Promise<EmulatorSetupActionResult> =>
+      ipcRenderer.invoke('emulatorSetup:openXcode', developerDir)
   },
 
   shell: {

--- a/src/renderer/src/components/emulator-pane/use-emulator-pane-session.test.tsx
+++ b/src/renderer/src/components/emulator-pane/use-emulator-pane-session.test.tsx
@@ -245,7 +245,7 @@ describe('useEmulatorPaneSession', () => {
 
   it('keeps simulator discovery setup errors during auto attach', async () => {
     const message =
-      'Xcode Simulator tools are unavailable. Install full Xcode, open it once, then select it with `sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer`.'
+      'iOS Simulator is not set up for Orca. Open Settings > Mobile Emulator to select Xcode and finish setup.'
     consumePrelaunchedSimulatorSession(WORKTREE_ID)
     const runtimeCall = vi.fn(async ({ method }: RuntimeCallRequest) => {
       if (method === 'emulator.listDevices') {

--- a/src/renderer/src/components/settings/MobileEmulatorAndroidSetupRow.tsx
+++ b/src/renderer/src/components/settings/MobileEmulatorAndroidSetupRow.tsx
@@ -1,0 +1,120 @@
+import { ExternalLink, FolderOpen, X } from 'lucide-react'
+import { useState } from 'react'
+import type { AndroidSetupStatus } from '../../../../shared/emulator-setup-types'
+import { translate } from '@/i18n/i18n'
+import { Button } from '../ui/button'
+import { MobileEmulatorToolchainRow } from './MobileEmulatorToolchainRow'
+
+const ANDROID_STUDIO_URL = 'https://developer.android.com/studio'
+
+export function MobileEmulatorAndroidSetupRow({
+  status,
+  configuredPath,
+  onSetSdkPath,
+  localActionsAvailable
+}: {
+  status: AndroidSetupStatus
+  configuredPath?: string | null
+  onSetSdkPath: (path: string | null) => Promise<void>
+  localActionsAvailable: boolean
+}): React.JSX.Element {
+  const [error, setError] = useState<string | null>(null)
+  const ready = status.state === 'ready'
+
+  const locate = async (): Promise<void> => {
+    try {
+      const path = await window.api.shell.pickDirectory({ defaultPath: status.sdkPath })
+      if (path) {
+        await onSetSdkPath(path)
+      }
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Could not update the Android SDK folder.')
+    }
+  }
+
+  const openStudio = async (): Promise<void> => {
+    if (!status.studioPath) {
+      return
+    }
+    if (!(await window.api.shell.openFilePath(status.studioPath))) {
+      setError('Could not open Android Studio.')
+    }
+  }
+
+  const clearConfiguredPath = async (): Promise<void> => {
+    try {
+      await onSetSdkPath(null)
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Could not clear the Android SDK folder.')
+    }
+  }
+
+  const detail = status.sdkPath ? (
+    <>
+      {status.message} <code className="rounded bg-muted px-1 py-0.5">{status.sdkPath}</code>
+    </>
+  ) : (
+    status.message
+  )
+
+  return (
+    <MobileEmulatorToolchainRow
+      ready={ready}
+      title={translate(
+        'auto.components.settings.MobileEmulatorAndroidSetupRow.title',
+        'Android Emulator'
+      )}
+      detail={detail}
+      error={error}
+      actions={
+        localActionsAvailable ? (
+          <>
+            {!ready ? (
+              status.studioInstalled && status.studioPath ? (
+                <Button type="button" size="sm" onClick={() => void openStudio()}>
+                  <ExternalLink />
+                  {translate(
+                    'auto.components.settings.MobileEmulatorAndroidSetupRow.open',
+                    'Open Android Studio'
+                  )}
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={() => void window.api.shell.openUrl(ANDROID_STUDIO_URL)}
+                >
+                  {translate(
+                    'auto.components.settings.MobileEmulatorAndroidSetupRow.download',
+                    'Download Android Studio'
+                  )}
+                </Button>
+              )
+            ) : null}
+            <Button type="button" size="sm" variant="outline" onClick={() => void locate()}>
+              <FolderOpen />
+              {translate(
+                'auto.components.settings.MobileEmulatorAndroidSetupRow.locate',
+                'Locate SDK folder'
+              )}
+            </Button>
+            {configuredPath ? (
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={() => void clearConfiguredPath()}
+              >
+                <X />
+                {translate(
+                  'auto.components.settings.MobileEmulatorAndroidSetupRow.clear',
+                  'Use automatic detection'
+                )}
+              </Button>
+            ) : null}
+          </>
+        ) : null
+      }
+    />
+  )
+}

--- a/src/renderer/src/components/settings/MobileEmulatorAvailabilityDetails.test.tsx
+++ b/src/renderer/src/components/settings/MobileEmulatorAvailabilityDetails.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { IosSetupStatus } from '../../../../shared/emulator-setup-types'
+import { MobileEmulatorAvailabilityDetails } from './MobileEmulatorAvailabilityDetails'
+
+const XCODE = {
+  appPath: '/Applications/Xcode.app',
+  developerDir: '/Applications/Xcode.app/Contents/Developer',
+  name: 'Xcode'
+}
+const IOS_SELECTION: IosSetupStatus = {
+  state: 'xcode-selection-required',
+  message: 'Xcode is installed, but Command Line Tools are selected.',
+  recommendedXcode: XCODE,
+  installedXcodes: [XCODE],
+  devices: []
+}
+const ANDROID_MISSING = {
+  state: 'sdk-missing' as const,
+  message: 'Android Studio and the Android SDK were not found.',
+  configuredPath: false,
+  studioInstalled: false,
+  components: { platformTools: false, emulator: false, systemImages: false }
+}
+
+let container: HTMLDivElement
+let root: Root
+let useXcode: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  useXcode = vi.fn(async () => ({ ok: true }))
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: {
+      emulatorSetup: {
+        useInstalledXcode: useXcode,
+        finishXcodeSetup: vi.fn(),
+        openXcode: vi.fn(async () => ({ ok: true }))
+      },
+      shell: {
+        openUrl: vi.fn(),
+        openFilePath: vi.fn(),
+        pickDirectory: vi.fn()
+      }
+    }
+  })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  Reflect.deleteProperty(window, 'api')
+})
+
+function renderDetails(
+  platform: string,
+  ios: IosSetupStatus = IOS_SELECTION,
+  serveSim: { ok: boolean; message?: string } = { ok: true }
+): void {
+  act(() => {
+    root.render(
+      <MobileEmulatorAvailabilityDetails
+        availability={{ platform, ios, serveSim, android: ANDROID_MISSING }}
+        onSetAndroidSdkPath={vi.fn()}
+        onRefresh={vi.fn()}
+      />
+    )
+  })
+}
+
+function button(label: string): HTMLButtonElement | undefined {
+  return [...container.querySelectorAll('button')].find((entry) =>
+    entry.textContent?.includes(label)
+  )
+}
+
+describe('MobileEmulatorAvailabilityDetails', () => {
+  it('prominently offers the explicit guided action for the CLT-selected macOS state', async () => {
+    renderDetails('darwin')
+    const action = button('Use Installed Xcode')
+    expect(action).toBeTruthy()
+    await act(async () => action?.click())
+    expect(useXcode).toHaveBeenCalledWith(XCODE.developerDir)
+  })
+
+  it.each([
+    ['linux', 'SSH/Linux'],
+    ['win32', 'Windows/WSL']
+  ])('shows no local Xcode action on %s hosts (%s)', (platform) => {
+    renderDetails(platform, {
+      state: 'unsupported',
+      message: 'iOS Simulator is available only on a local Mac.',
+      installedXcodes: [],
+      devices: []
+    })
+    expect(button('Use Installed Xcode')).toBeUndefined()
+    expect(button('Open Xcode')).toBeUndefined()
+    expect(container.textContent).toContain('available only on a local Mac')
+  })
+
+  it('hides local actions when the renderer has no local privileged bridge', () => {
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { shell: { openUrl: vi.fn(), openFilePath: vi.fn(), pickDirectory: vi.fn() } }
+    })
+    renderDetails('darwin')
+    expect(button('Use Installed Xcode')).toBeUndefined()
+    expect(button('Locate SDK folder')).toBeUndefined()
+  })
+
+  it('does not show iOS ready when Orca simulator support fails its probe', () => {
+    renderDetails(
+      'darwin',
+      { ...IOS_SELECTION, state: 'ready', message: 'Ready', devices: [] },
+      { ok: false, message: 'serve-sim is unavailable.' }
+    )
+    expect(container.textContent).toContain('serve-sim is unavailable.')
+    const iosRow = container.firstElementChild?.firstElementChild
+    expect(iosRow?.querySelector('.text-status-success')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/settings/MobileEmulatorAvailabilityDetails.tsx
+++ b/src/renderer/src/components/settings/MobileEmulatorAvailabilityDetails.tsx
@@ -1,206 +1,37 @@
-import { CheckCircle2, CircleAlert, FolderOpen, X } from 'lucide-react'
-import type React from 'react'
-import { toast } from 'sonner'
-import { Button } from '../ui/button'
-import { translate } from '@/i18n/i18n'
-
-type EmulatorAvailability = {
-  platform: string
-  simctl: { ok: boolean; message?: string }
-  serveSim: { ok: boolean; message?: string }
-  android: { sdkFound: boolean; sdkPath?: string; message: string }
-}
-
-type MobileEmulatorAvailabilityDetailsProps = {
-  availability: EmulatorAvailability | null
-  configuredPath?: string | null
-  onSetAndroidSdkPath: (path: string | null) => void | Promise<void>
-}
-
-const ANDROID_STUDIO_URL = 'https://developer.android.com/studio'
-
-function ToolchainStatusIcon({ ok }: { ok: boolean }): React.JSX.Element {
-  return ok ? (
-    <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-status-success" />
-  ) : (
-    <CircleAlert className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-  )
-}
-
-function ToolchainStatusRow({
-  ok,
-  title,
-  detail,
-  actions
-}: {
-  ok: boolean
-  title: string
-  detail: React.ReactNode
-  actions?: React.ReactNode
-}): React.JSX.Element {
-  return (
-    <div className="flex items-start gap-3 py-2">
-      <ToolchainStatusIcon ok={ok} />
-      <div className="min-w-0 flex-1 space-y-1">
-        <div className="text-sm font-medium text-foreground">{title}</div>
-        <div className="flex min-w-0 items-center gap-3">
-          <div className="min-w-0 flex-1 break-words text-xs text-muted-foreground">{detail}</div>
-          {actions ? (
-            <div className="flex shrink-0 flex-wrap justify-end gap-1">{actions}</div>
-          ) : null}
-        </div>
-      </div>
-    </div>
-  )
-}
-
-const sdkPathActionClassName = 'h-6 px-2 text-muted-foreground hover:text-foreground'
+import { MobileEmulatorAndroidSetupRow } from './MobileEmulatorAndroidSetupRow'
+import { MobileEmulatorIosSetupRow } from './MobileEmulatorIosSetupRow'
+import type { EmulatorAvailability } from './use-mobile-emulator-availability'
 
 export function MobileEmulatorAvailabilityDetails({
   availability,
   configuredPath,
-  onSetAndroidSdkPath
-}: MobileEmulatorAvailabilityDetailsProps): React.JSX.Element | null {
+  onSetAndroidSdkPath,
+  onRefresh
+}: {
+  availability: Pick<EmulatorAvailability, 'platform' | 'ios' | 'serveSim' | 'android'> | null
+  configuredPath?: string | null
+  onSetAndroidSdkPath: (path: string | null) => Promise<void>
+  onRefresh: () => Promise<void>
+}): React.JSX.Element | null {
   if (!availability) {
     return null
   }
-  const android = availability.android ?? { sdkFound: false, sdkPath: undefined, message: '' }
-  const iosOk = Boolean(availability.simctl?.ok && availability.serveSim?.ok)
-  const showIos = availability.platform === 'darwin'
-
-  const handleLocate = async (): Promise<void> => {
-    try {
-      const picked = await window.api.shell.pickDirectory({
-        defaultPath: android.sdkPath ?? configuredPath ?? undefined
-      })
-      if (picked) {
-        await onSetAndroidSdkPath(picked)
-      }
-    } catch (error) {
-      toast.error(
-        error instanceof Error
-          ? error.message
-          : translate(
-              'auto.components.settings.MobileEmulatorSdkStatus.63fe73a1ea',
-              'Could not update Android SDK folder.'
-            )
-      )
-    }
-  }
-
-  const handleClear = async (): Promise<void> => {
-    try {
-      await onSetAndroidSdkPath(null)
-    } catch (error) {
-      toast.error(
-        error instanceof Error
-          ? error.message
-          : translate(
-              'auto.components.settings.MobileEmulatorSdkStatus.63fe73a1ea',
-              'Could not update Android SDK folder.'
-            )
-      )
-    }
-  }
-
+  const localMacActions = availability.platform === 'darwin' && Boolean(window.api.emulatorSetup)
+  const localHostActions = Boolean(window.api.emulatorSetup)
   return (
-    <div className="mt-3">
-      <div className="divide-y divide-border/40 rounded-md border border-border/50 px-3">
-        <ToolchainStatusRow
-          ok={android.sdkFound}
-          title={translate(
-            'auto.components.settings.MobileEmulatorSdkStatus.027cbf668a',
-            'Android SDK'
-          )}
-          detail={
-            android.sdkFound ? (
-              <>
-                {configuredPath
-                  ? translate(
-                      'auto.components.settings.MobileEmulatorSdkStatus.f6d080d128',
-                      'Using configured path'
-                    )
-                  : translate(
-                      'auto.components.settings.MobileEmulatorSdkStatus.7fe4bd5907',
-                      'Detected at'
-                    )}{' '}
-                <code className="rounded bg-muted px-1 py-0.5">{android.sdkPath}</code>
-              </>
-            ) : (
-              android.message ||
-              translate(
-                'auto.components.settings.MobileEmulatorSdkStatus.2784f0b22d',
-                'Not found. Install Android Studio, then create a Virtual Device.'
-              )
-            )
-          }
-          actions={
-            <>
-              {!android.sdkFound ? (
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={() => void window.api.shell.openUrl(ANDROID_STUDIO_URL)}
-                >
-                  {translate(
-                    'auto.components.settings.MobileEmulatorSdkStatus.b94ff260e6',
-                    'Download Android Studio'
-                  )}
-                </Button>
-              ) : null}
-              <Button
-                type="button"
-                size="xs"
-                variant="ghost"
-                onClick={() => void handleLocate()}
-                className={sdkPathActionClassName}
-              >
-                <FolderOpen className="size-3" />
-                {translate(
-                  'auto.components.settings.MobileEmulatorSdkStatus.18925b082d',
-                  'Locate SDK folder'
-                )}
-              </Button>
-              {configuredPath ? (
-                <Button
-                  type="button"
-                  size="xs"
-                  variant="ghost"
-                  onClick={() => void handleClear()}
-                  className={sdkPathActionClassName}
-                >
-                  <X className="size-3" />
-                  {translate(
-                    'auto.components.settings.MobileEmulatorSdkStatus.8c52684db8',
-                    'Clear'
-                  )}
-                </Button>
-              ) : null}
-            </>
-          }
-        />
-
-        {showIos ? (
-          <ToolchainStatusRow
-            ok={iosOk}
-            title={translate(
-              'auto.components.settings.MobileEmulatorSdkStatus.76eb88b88e',
-              'iOS Simulator (Xcode)'
-            )}
-            detail={
-              iosOk
-                ? translate('auto.components.settings.MobileEmulatorSdkStatus.c6f3ea4f12', 'Ready')
-                : availability.simctl?.message ||
-                  availability.serveSim?.message ||
-                  translate(
-                    'auto.components.settings.MobileEmulatorSdkStatus.e4f14b50d7',
-                    'Install Xcode and add an iOS Simulator runtime.'
-                  )
-            }
-          />
-        ) : null}
-      </div>
+    <div className="mt-3 divide-y divide-border/40 rounded-md border border-border/50 px-3">
+      <MobileEmulatorIosSetupRow
+        status={availability.ios}
+        helper={availability.serveSim}
+        localActionsAvailable={localMacActions}
+        onRefresh={onRefresh}
+      />
+      <MobileEmulatorAndroidSetupRow
+        status={availability.android}
+        configuredPath={configuredPath}
+        onSetSdkPath={onSetAndroidSdkPath}
+        localActionsAvailable={localHostActions}
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/settings/MobileEmulatorIosSetupRow.tsx
+++ b/src/renderer/src/components/settings/MobileEmulatorIosSetupRow.tsx
@@ -1,0 +1,210 @@
+import { Copy, ExternalLink, Loader2 } from 'lucide-react'
+import { useState } from 'react'
+import { toast } from 'sonner'
+import type { IosSetupStatus } from '../../../../shared/emulator-setup-types'
+import { translate } from '@/i18n/i18n'
+import { Button } from '../ui/button'
+import { MobileEmulatorToolchainRow } from './MobileEmulatorToolchainRow'
+
+const XCODE_URL = 'https://apps.apple.com/app/xcode/id497799835'
+
+type Action = 'select' | 'first-launch' | null
+
+function quoteShell(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`
+}
+
+export function MobileEmulatorIosSetupRow({
+  status,
+  helper,
+  localActionsAvailable,
+  onRefresh
+}: {
+  status: IosSetupStatus
+  helper: { ok: boolean; message?: string }
+  localActionsAvailable: boolean
+  onRefresh: () => Promise<void>
+}): React.JSX.Element {
+  const [action, setAction] = useState<Action>(null)
+  const [error, setError] = useState<string | null>(null)
+  const xcode = status.recommendedXcode
+  const ready = status.state === 'ready' && helper.ok
+
+  const runSetup = async (nextAction: Exclude<Action, null>): Promise<void> => {
+    if (!xcode || action) {
+      return
+    }
+    setAction(nextAction)
+    setError(null)
+    try {
+      const result =
+        nextAction === 'select'
+          ? await window.api.emulatorSetup.useInstalledXcode(xcode.developerDir)
+          : await window.api.emulatorSetup.finishXcodeSetup(xcode.developerDir)
+      if (!result.ok) {
+        setError(result.message || 'Xcode setup did not finish.')
+      } else {
+        await onRefresh()
+      }
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Xcode setup did not finish.')
+    } finally {
+      setAction(null)
+    }
+  }
+
+  const openXcode = async (): Promise<void> => {
+    if (!xcode) {
+      return
+    }
+    try {
+      const result = await window.api.emulatorSetup.openXcode(xcode.developerDir)
+      if (!result.ok) {
+        setError(result.message || 'Could not open Xcode.')
+      }
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Could not open Xcode.')
+    }
+  }
+
+  const copyCommand = async (): Promise<void> => {
+    if (!xcode) {
+      return
+    }
+    const command =
+      status.state === 'xcode-selection-required'
+        ? `sudo xcode-select --switch ${quoteShell(xcode.developerDir)} && sudo ${quoteShell(`${xcode.developerDir}/usr/bin/xcodebuild`)} -runFirstLaunch`
+        : status.state === 'xcode-first-launch-required'
+          ? `sudo ${quoteShell(`${xcode.developerDir}/usr/bin/xcodebuild`)} -runFirstLaunch`
+          : `DEVELOPER_DIR=${quoteShell(xcode.developerDir)} xcodebuild -downloadPlatform iOS`
+    try {
+      await navigator.clipboard.writeText(command)
+      toast.success(
+        translate('auto.components.settings.MobileEmulatorIosSetupRow.copy', 'Command copied')
+      )
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Could not copy the command.')
+    }
+  }
+
+  const actions = (): React.ReactNode => {
+    if (!localActionsAvailable || status.state === 'unsupported' || status.state === 'ready') {
+      return null
+    }
+    if (status.state === 'xcode-missing') {
+      return (
+        <Button type="button" size="sm" onClick={() => void window.api.shell.openUrl(XCODE_URL)}>
+          {translate(
+            'auto.components.settings.MobileEmulatorIosSetupRow.download',
+            'Download Xcode'
+          )}
+        </Button>
+      )
+    }
+    if (status.state === 'xcode-selection-required' && xcode) {
+      return (
+        <>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => void runSetup('select')}
+            disabled={Boolean(action)}
+          >
+            {action === 'select' ? <Loader2 className="animate-spin" /> : null}
+            {action === 'select'
+              ? translate(
+                  'auto.components.settings.MobileEmulatorIosSetupRow.selecting',
+                  'Setting up Xcode…'
+                )
+              : translate(
+                  'auto.components.settings.MobileEmulatorIosSetupRow.use',
+                  'Use Installed Xcode'
+                )}
+          </Button>
+          <SecondaryXcodeActions onOpen={openXcode} onCopy={copyCommand} />
+        </>
+      )
+    }
+    if (status.state === 'xcode-first-launch-required' && xcode) {
+      return (
+        <>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => void runSetup('first-launch')}
+            disabled={Boolean(action)}
+          >
+            {action === 'first-launch' ? <Loader2 className="animate-spin" /> : null}
+            {action === 'first-launch'
+              ? translate(
+                  'auto.components.settings.MobileEmulatorIosSetupRow.finishing',
+                  'Installing components…'
+                )
+              : translate(
+                  'auto.components.settings.MobileEmulatorIosSetupRow.finish',
+                  'Finish Xcode Setup'
+                )}
+          </Button>
+          <SecondaryXcodeActions onOpen={openXcode} onCopy={copyCommand} />
+        </>
+      )
+    }
+    if (!xcode) {
+      return null
+    }
+    return (
+      <SecondaryXcodeActions
+        onOpen={openXcode}
+        onCopy={status.state === 'simulator-runtime-missing' ? copyCommand : undefined}
+        primary
+      />
+    )
+  }
+
+  return (
+    <MobileEmulatorToolchainRow
+      ready={ready}
+      title={translate('auto.components.settings.MobileEmulatorIosSetupRow.title', 'iOS Simulator')}
+      detail={
+        status.state === 'ready' && !helper.ok
+          ? helper.message || 'Orca Simulator support is unavailable.'
+          : status.message
+      }
+      actions={actions()}
+      error={error}
+    />
+  )
+}
+
+function SecondaryXcodeActions({
+  onOpen,
+  onCopy,
+  primary = false
+}: {
+  onOpen: () => Promise<void>
+  onCopy?: () => Promise<void>
+  primary?: boolean
+}): React.JSX.Element {
+  return (
+    <>
+      <Button
+        type="button"
+        size="sm"
+        variant={primary ? 'default' : 'outline'}
+        onClick={() => void onOpen()}
+      >
+        <ExternalLink />
+        {translate('auto.components.settings.MobileEmulatorIosSetupRow.open', 'Open Xcode')}
+      </Button>
+      {onCopy ? (
+        <Button type="button" size="sm" variant="ghost" onClick={() => void onCopy()}>
+          <Copy />
+          {translate(
+            'auto.components.settings.MobileEmulatorIosSetupRow.copyCommand',
+            'Copy command'
+          )}
+        </Button>
+      ) : null}
+    </>
+  )
+}

--- a/src/renderer/src/components/settings/MobileEmulatorSettingsPane.tsx
+++ b/src/renderer/src/components/settings/MobileEmulatorSettingsPane.tsx
@@ -1,8 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { Loader2, RefreshCw } from 'lucide-react'
 import type { GlobalSettings } from '../../../../shared/types'
 import { cn } from '@/lib/utils'
-import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
 import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
 import { Label } from '../ui/label'
@@ -14,28 +13,15 @@ import { SearchableSetting } from './SearchableSetting'
 import { SettingsRow, SettingsSwitchRow } from './SettingsFormControls'
 import { getMobileEmulatorSearchEntries } from './mobile-emulator-search'
 import { translate } from '@/i18n/i18n'
-
-type SimulatorDeviceRow = {
-  name: string
-  udid: string
-  state: string
-  runtime?: string
-  isAvailable?: boolean
-}
-
-type EmulatorAvailability = {
-  platform: string
-  available: boolean
-  devices: SimulatorDeviceRow[]
-  simctl: { ok: boolean; message?: string }
-  serveSim: { ok: boolean; message?: string }
-  android: { sdkFound: boolean; sdkPath?: string; message: string }
-  message: string
-}
+import {
+  useMobileEmulatorAvailability,
+  type EmulatorAvailability,
+  type SimulatorDeviceRow
+} from './use-mobile-emulator-availability'
 
 type MobileEmulatorSettingsPaneProps = {
   settings: GlobalSettings
-  updateSettings: (updates: Partial<GlobalSettings>) => void
+  updateSettings: (updates: Partial<GlobalSettings>) => void | Promise<void>
 }
 
 const AUTOMATIC_DEVICE_VALUE = '__orca_automatic_emulator_device__'
@@ -122,37 +108,8 @@ export function MobileEmulatorSettingsPane({
   settings,
   updateSettings
 }: MobileEmulatorSettingsPaneProps): React.JSX.Element {
-  const [availability, setAvailability] = useState<EmulatorAvailability | null>(null)
-  const [refreshing, setRefreshing] = useState(false)
+  const { availability, refreshing, refreshAvailability } = useMobileEmulatorAvailability()
   const enabled = settings.mobileEmulatorEnabled !== false
-
-  const refreshAvailability = useCallback(async (): Promise<void> => {
-    setRefreshing(true)
-    try {
-      const result = (await callRuntimeRpc(
-        { kind: 'local' },
-        'emulator.availability',
-        {}
-      )) as EmulatorAvailability
-      setAvailability(result)
-    } catch (error) {
-      setAvailability({
-        platform: '',
-        available: false,
-        devices: [],
-        simctl: { ok: false },
-        serveSim: { ok: false },
-        android: { sdkFound: false, message: '' },
-        message: error instanceof Error ? error.message : 'Could not check emulator availability.'
-      })
-    } finally {
-      setRefreshing(false)
-    }
-  }, [])
-
-  useEffect(() => {
-    void refreshAvailability()
-  }, [refreshAvailability])
 
   const devices = availability?.devices ?? []
   const selectedDeviceKnown = devices.some(
@@ -250,6 +207,7 @@ export function MobileEmulatorSettingsPane({
                 await updateSettings({ androidSdkPath: path })
                 await refreshAvailability()
               }}
+              onRefresh={refreshAvailability}
             />
           ) : null}
         </div>

--- a/src/renderer/src/components/settings/MobileEmulatorToolchainRow.tsx
+++ b/src/renderer/src/components/settings/MobileEmulatorToolchainRow.tsx
@@ -1,0 +1,37 @@
+import { CheckCircle2, CircleAlert } from 'lucide-react'
+import type React from 'react'
+
+export function MobileEmulatorToolchainRow({
+  ready,
+  title,
+  detail,
+  actions,
+  error
+}: {
+  ready: boolean
+  title: string
+  detail: React.ReactNode
+  actions?: React.ReactNode
+  error?: string | null
+}): React.JSX.Element {
+  const Icon = ready ? CheckCircle2 : CircleAlert
+  return (
+    <div className="flex items-start gap-3 py-3">
+      <Icon
+        className={
+          ready
+            ? 'mt-0.5 size-4 shrink-0 text-status-success'
+            : 'mt-0.5 size-4 shrink-0 text-muted-foreground'
+        }
+      />
+      <div className="min-w-0 flex-1 space-y-2">
+        <div className="space-y-0.5">
+          <div className="text-sm font-medium text-foreground">{title}</div>
+          <div className="break-words text-xs text-muted-foreground">{detail}</div>
+          {error ? <div className="text-xs text-destructive">{error}</div> : null}
+        </div>
+        {actions ? <div className="flex flex-wrap gap-2">{actions}</div> : null}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/use-mobile-emulator-availability.ts
+++ b/src/renderer/src/components/settings/use-mobile-emulator-availability.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { AndroidSetupStatus, IosSetupStatus } from '../../../../shared/emulator-setup-types'
+import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
+
+export type SimulatorDeviceRow = {
+  name: string
+  udid: string
+  state: string
+  runtime?: string
+  isAvailable?: boolean
+}
+
+export type EmulatorAvailability = {
+  platform: string
+  available: boolean
+  devices: SimulatorDeviceRow[]
+  ios: IosSetupStatus
+  simctl: { ok: boolean; message?: string }
+  serveSim: { ok: boolean; message?: string }
+  android: AndroidSetupStatus & { sdkFound?: boolean }
+  message: string
+}
+
+function failedAvailability(error: unknown): EmulatorAvailability {
+  return {
+    platform: '',
+    available: false,
+    devices: [],
+    ios: {
+      state: 'error',
+      message: 'Could not check iOS Simulator setup.',
+      installedXcodes: [],
+      devices: []
+    },
+    simctl: { ok: false },
+    serveSim: { ok: false },
+    android: {
+      state: 'error',
+      message: 'Could not check Android Emulator setup.',
+      configuredPath: false,
+      studioInstalled: false,
+      components: { platformTools: false, emulator: false, systemImages: false }
+    },
+    message: error instanceof Error ? error.message : 'Could not check emulator availability.'
+  }
+}
+
+export function useMobileEmulatorAvailability(): {
+  availability: EmulatorAvailability | null
+  refreshing: boolean
+  refreshAvailability: () => Promise<void>
+} {
+  const [availability, setAvailability] = useState<EmulatorAvailability | null>(null)
+  const [refreshing, setRefreshing] = useState(false)
+  const refreshSequence = useRef(0)
+  const refreshAvailability = useCallback(async (): Promise<void> => {
+    const sequence = ++refreshSequence.current
+    setRefreshing(true)
+    try {
+      const result = await callRuntimeRpc<EmulatorAvailability>(
+        { kind: 'local' },
+        'emulator.availability',
+        {}
+      )
+      if (sequence === refreshSequence.current) {
+        setAvailability(result)
+      }
+    } catch (error) {
+      if (sequence === refreshSequence.current) {
+        setAvailability(failedAvailability(error))
+      }
+    } finally {
+      if (sequence === refreshSequence.current) {
+        setRefreshing(false)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    void refreshAvailability()
+    const refreshOnReturn = (): void => {
+      if (document.visibilityState === 'visible') {
+        void refreshAvailability()
+      }
+    }
+    window.addEventListener('focus', refreshOnReturn)
+    return () => {
+      window.removeEventListener('focus', refreshOnReturn)
+    }
+  }, [refreshAvailability])
+
+  return { availability, refreshing, refreshAvailability }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9293,6 +9293,24 @@
           "title": "Editor Font Family",
           "description": "Font used by file editors and diff views. Leave empty to follow the terminal font.",
           "placeholder": "Same as terminal font"
+        },
+        "MobileEmulatorAndroidSetupRow": {
+          "title": "Android Emulator",
+          "open": "Open Android Studio",
+          "download": "Download Android Studio",
+          "locate": "Locate SDK folder",
+          "clear": "Use automatic detection"
+        },
+        "MobileEmulatorIosSetupRow": {
+          "copy": "Command copied",
+          "download": "Download Xcode",
+          "selecting": "Setting up Xcode…",
+          "use": "Use Installed Xcode",
+          "finishing": "Installing components…",
+          "finish": "Finish Xcode Setup",
+          "title": "iOS Simulator",
+          "open": "Open Xcode",
+          "copyCommand": "Copy command"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9270,6 +9270,24 @@
           "title": "Editor Font Family",
           "description": "Font used by file editors and diff views. Leave empty to follow the terminal font.",
           "placeholder": "Same as terminal font"
+        },
+        "MobileEmulatorAndroidSetupRow": {
+          "title": "Android Emulator",
+          "open": "Open Android Studio",
+          "download": "Download Android Studio",
+          "locate": "Locate SDK folder",
+          "clear": "Use automatic detection"
+        },
+        "MobileEmulatorIosSetupRow": {
+          "copy": "Command copied",
+          "download": "Download Xcode",
+          "selecting": "Setting up Xcode…",
+          "use": "Use Installed Xcode",
+          "finishing": "Installing components…",
+          "finish": "Finish Xcode Setup",
+          "title": "iOS Simulator",
+          "open": "Open Xcode",
+          "copyCommand": "Copy command"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9270,6 +9270,24 @@
           "title": "Editor Font Family",
           "description": "Font used by file editors and diff views. Leave empty to follow the terminal font.",
           "placeholder": "Same as terminal font"
+        },
+        "MobileEmulatorAndroidSetupRow": {
+          "title": "Android Emulator",
+          "open": "Open Android Studio",
+          "download": "Download Android Studio",
+          "locate": "Locate SDK folder",
+          "clear": "Use automatic detection"
+        },
+        "MobileEmulatorIosSetupRow": {
+          "copy": "Command copied",
+          "download": "Download Xcode",
+          "selecting": "Setting up Xcode…",
+          "use": "Use Installed Xcode",
+          "finishing": "Installing components…",
+          "finish": "Finish Xcode Setup",
+          "title": "iOS Simulator",
+          "open": "Open Xcode",
+          "copyCommand": "Copy command"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9270,6 +9270,24 @@
           "title": "Editor Font Family",
           "description": "Font used by file editors and diff views. Leave empty to follow the terminal font.",
           "placeholder": "Same as terminal font"
+        },
+        "MobileEmulatorAndroidSetupRow": {
+          "title": "Android Emulator",
+          "open": "Open Android Studio",
+          "download": "Download Android Studio",
+          "locate": "Locate SDK folder",
+          "clear": "Use automatic detection"
+        },
+        "MobileEmulatorIosSetupRow": {
+          "copy": "Command copied",
+          "download": "Download Xcode",
+          "selecting": "Setting up Xcode…",
+          "use": "Use Installed Xcode",
+          "finishing": "Installing components…",
+          "finish": "Finish Xcode Setup",
+          "title": "iOS Simulator",
+          "open": "Open Xcode",
+          "copyCommand": "Copy command"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9270,6 +9270,24 @@
           "title": "Editor Font Family",
           "description": "Font used by file editors and diff views. Leave empty to follow the terminal font.",
           "placeholder": "Same as terminal font"
+        },
+        "MobileEmulatorAndroidSetupRow": {
+          "title": "Android Emulator",
+          "open": "Open Android Studio",
+          "download": "Download Android Studio",
+          "locate": "Locate SDK folder",
+          "clear": "Use automatic detection"
+        },
+        "MobileEmulatorIosSetupRow": {
+          "copy": "Command copied",
+          "download": "Download Xcode",
+          "selecting": "Setting up Xcode…",
+          "use": "Use Installed Xcode",
+          "finishing": "Installing components…",
+          "finish": "Finish Xcode Setup",
+          "title": "iOS Simulator",
+          "open": "Open Xcode",
+          "copyCommand": "Copy command"
         }
       },
       "right": {

--- a/src/shared/emulator-setup-types.ts
+++ b/src/shared/emulator-setup-types.ts
@@ -1,0 +1,60 @@
+export type XcodeApplication = {
+  appPath: string
+  developerDir: string
+  name: string
+}
+
+export type IosSetupState =
+  | 'unsupported'
+  | 'xcode-missing'
+  | 'xcode-selection-required'
+  | 'xcode-first-launch-required'
+  | 'simulator-runtime-missing'
+  | 'simulator-device-missing'
+  | 'ready'
+  | 'error'
+
+export type IosSetupStatus = {
+  state: IosSetupState
+  message: string
+  selectedDeveloperDir?: string
+  recommendedXcode?: XcodeApplication
+  installedXcodes: XcodeApplication[]
+  devices: {
+    name: string
+    udid: string
+    state: string
+    runtime: string
+    isAvailable?: boolean
+  }[]
+}
+
+export type AndroidSetupState =
+  | 'sdk-missing'
+  | 'sdk-invalid'
+  | 'platform-tools-missing'
+  | 'emulator-missing'
+  | 'system-image-missing'
+  | 'device-missing'
+  | 'ready'
+  | 'error'
+
+export type AndroidSetupStatus = {
+  state: AndroidSetupState
+  message: string
+  sdkPath?: string
+  configuredPath: boolean
+  studioInstalled: boolean
+  studioPath?: string
+  components: {
+    platformTools: boolean
+    emulator: boolean
+    systemImages: boolean
+  }
+}
+
+export type EmulatorSetupActionResult = {
+  ok: boolean
+  canceled?: boolean
+  message?: string
+}


### PR DESCRIPTION
## Summary

Improves Settings > Mobile Emulator setup from a generic unavailable state into a typed, guided setup flow for both iOS and Android.

- detects full Xcode at default and Spotlight-discovered non-default locations
- distinguishes Xcode missing, Command Line Tools still selected, license/first-launch pending, runtime missing, device missing, helper failure, and ready
- adds explicit Use Installed Xcode / Finish Xcode Setup actions; administrator authorization is requested only after a click
- verifies Apple's signed xcodebuild before and again inside the privileged command
- opens Xcode for runtime/device work, provides copyable transparent fallback commands, and refreshes on focus return
- detects standard Android SDK paths without ANDROID_HOME and separates Studio, platform-tools, emulator, system-image, AVD/device, custom-path, and invalid-path states
- keeps SDK selection app-specific and does not mutate shell profiles
- hides local host actions without the local preload bridge and on unsupported host platforms

## Before

On the reproduced Mac, /Applications/Xcode.app existed while xcode-select still pointed to /Library/Developer/CommandLineTools. Settings only reported “Xcode Simulator tools are unavailable” and required the user to understand and manually run xcode-select. Android similarly collapsed setup into “SDK not found.”

## After

The page names the detected blocker and presents the next safe action. In the motivating state it offers Use Installed Xcode, explains that macOS administrator approval will be requested, runs selection plus first-launch setup only after approval, and re-probes automatically. Readiness requires usable simctl output with an available iOS device plus Orca’s simulator helper.

Android automatically finds standard SDK locations and points to the missing component or AVD, while retaining Locate SDK folder and safe app-specific configuration.

## Deterministic evidence

- 61 focused tests pass across setup classification, signed privileged action boundaries, stale-to-ready refresh, component rendering, direct emulator guidance, and host/platform action gating.
- Matrix coverage includes Xcode missing, CLT selected, license/components pending, runtime/device missing, ready, non-default Xcode, stale refresh, Studio/SDK missing, standard/custom/invalid/incomplete SDKs, Linux, Windows/WSL, SSH-style remote contexts, and clients without a local privileged bridge.
- Opt-in real-host probe:
  - initially classified iOS as simulator-runtime-missing and Android as sdk-missing
  - after setup completed, re-probed iOS as ready with a usable device
  - command: ORCA_EMULATOR_SETUP_E2E=1 pnpm exec vitest run --config config/vitest.config.ts src/main/emulator/emulator-setup-host-probe.e2e.test.ts --reporter=verbose

## Validation

- focused Vitest suite: 61 passed
- pnpm run typecheck
- touched-file oxlint
- max-lines ratchet: no new bypasses
- changed React doctor
- internal review-until-clean: clean after 2 review/fix rounds

The repository-wide localization catalog check still reports 14 unrelated missing keys already present on current main; all Mobile Emulator keys added by this PR are present in every locale catalog.