### PR TITLE
fix(agent-detection): detect agents running inside a user's tmux session (#7797)

### DIFF
--- a/src/main/providers/agent-foreground-process.ts
+++ b/src/main/providers/agent-foreground-process.ts
@@ -1,5 +1,6 @@
 import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process-recognition'
 import { resolveOuterWrapperForegroundProcess } from '../../shared/foreground-wrapper-agent'
+import { isTmuxCommand, resolveTmuxForegroundAgent } from '../../shared/tmux-foreground-resolution'
 import {
   getFreshProcessTableSnapshot,
   getProcessTableSnapshot,
@@ -99,7 +100,7 @@ export async function resolveAgentForegroundProcessWithAvailability(
     }
     return {
       available: true,
-      processName: resolveAgentForegroundProcessFromPs(rows, shellPid) ?? fallbackProcess
+      processName: (await resolveAgentForegroundProcessFromPs(rows, shellPid)) ?? fallbackProcess
     }
   } catch {
     // Why: a failed scan cannot prove fallback ownership; callers retain the last recognized agent.
@@ -107,19 +108,15 @@ export async function resolveAgentForegroundProcessWithAvailability(
   }
 }
 
-function resolveAgentForegroundProcessFromPs(
-  rows: ProcessTableRow[],
-  shellPid: number
+function recognizeAgentFromCandidates(
+  candidates: (ProcessTableRow & { depth: number })[],
+  rootRow: ProcessTableRow | undefined
 ): string | null {
-  const shellRow = rows.find((row) => row.pid === shellPid)
-  const candidates = collectDescendants(rows, shellPid).sort(
-    (a, b) => candidateScore(b) - candidateScore(a)
-  )
   // Why: `+` in `ps stat` marks the process holding the terminal foreground.
   // The root shell can hold it after Ctrl-Z, so use the whole PTY tree as the
   // foreground gate; otherwise a stopped agent child still masquerades as live.
   const foregroundIsKnown =
-    shellRow?.stat.includes('+') === true ||
+    rootRow?.stat.includes('+') === true ||
     candidates.some((candidate) => candidate.stat.includes('+'))
   for (const candidate of candidates) {
     if (foregroundIsKnown && !candidate.stat.includes('+')) {
@@ -133,4 +130,29 @@ function resolveAgentForegroundProcessFromPs(
     }
   }
   return null
+}
+
+async function resolveAgentForegroundProcessFromPs(
+  rows: ProcessTableRow[],
+  shellPid: number
+): Promise<string | null> {
+  const shellRow = rows.find((row) => row.pid === shellPid)
+  const candidates = collectDescendants(rows, shellPid).sort(
+    (a, b) => candidateScore(b) - candidateScore(a)
+  )
+  const direct = recognizeAgentFromCandidates(candidates, shellRow)
+  if (direct) {
+    return direct
+  }
+  // Why: tmux double-forks its server and reparents it to pid 1, so an agent
+  // running in a tmux window is a child of the tmux SERVER, not of this pane's
+  // shell — the walk above only reached the tmux client. Hop the fork and
+  // re-run recognition from the client's pane. See issue #7797.
+  const tmuxClientPids = candidates
+    .filter((candidate) => isTmuxCommand(candidate.command))
+    .map((candidate) => candidate.pid)
+  if (tmuxClientPids.length === 0) {
+    return null
+  }
+  return resolveTmuxForegroundAgent({ rows, tmuxClientPids })
 }

--- a/src/main/providers/tmux-agent-detection.test.ts
+++ b/src/main/providers/tmux-agent-detection.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Regression test for issue #7797: an agent (claude/codex/…) started inside a
+// user's tmux window must still be detected as running. Live foreground
+// detection walks the process tree DOWNWARD from the pane's shell pid
+// (`collectDescendants`). tmux double-forks its server and reparents it to pid
+// 1, so the agent is a child of the tmux SERVER, not of the pane shell — the
+// downward walk reaches only the tmux CLIENT and used to fall back to `tmux`.
+// The fix hops the fork: client → active pane pid via `tmux list-clients`, else
+// the reparented server pid from the ps table, then re-runs recognition.
+
+const { execFileMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn()
+}))
+
+vi.mock('child_process', () => ({
+  execFile: execFileMock
+}))
+
+import { resetProcessTableSnapshotForTests } from '../../shared/process-table-snapshot'
+import { resolveAgentForegroundProcess } from './agent-foreground-process'
+
+// Process table for a pane running `tmux` with `claude` inside a tmux window:
+//   pid 100 ppid 99  zsh          <- Orca pane shell (root of the foreground walk)
+//   pid 101 ppid 100 tmux client  <- what the pane shell actually launched
+//   pid 200 ppid 1   tmux server  <- double-forked, reparented to init (pid 1)
+//   pid 201 ppid 200 claude       <- the real agent, child of the SERVER
+const TMUX_PROCESS_TABLE = [
+  '100 99  Ss   -zsh',
+  '101 100 S+   tmux',
+  '200 1   Ss   tmux',
+  '201 200 S+   node /Users/dev/.nvm/versions/node/bin/claude'
+].join('\n')
+
+// Why: the modules wrap execFile with promisify, so the mock must honor the
+// Node callback contract — the last arg is invoked with (err, {stdout,stderr}).
+function reply(cb: unknown, stdout: string): void {
+  ;(cb as (err: unknown, result: { stdout: string; stderr: string }) => void)(null, {
+    stdout,
+    stderr: ''
+  })
+}
+
+// `ps` always returns the tmux topology. `tmux list-clients` maps the pane's
+// client (101) to its active pane pid (201, the claude process) when available,
+// or errors (ENOENT) to force the reparented-server fallback.
+function mockProcessTable(options: { tmuxAvailable: boolean }): void {
+  execFileMock.mockImplementation((cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
+    if (cmd === 'tmux') {
+      if (options.tmuxAvailable) {
+        reply(cb, '101 201\n')
+      } else {
+        ;(cb as (err: unknown) => void)(
+          Object.assign(new Error('spawn tmux ENOENT'), { code: 'ENOENT' })
+        )
+      }
+      return
+    }
+    reply(cb, TMUX_PROCESS_TABLE)
+  })
+}
+
+describe('resolveAgentForegroundProcess: agent inside tmux (issue #7797)', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+    resetProcessTableSnapshotForTests()
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+  })
+
+  it('detects claude via the tmux client → active-pane-pid hop', async () => {
+    mockProcessTable({ tmuxAvailable: true })
+    await expect(resolveAgentForegroundProcess(100, 'tmux')).resolves.toBe('claude')
+  })
+
+  it('detects claude via the reparented server pid when tmux is unreachable', async () => {
+    mockProcessTable({ tmuxAvailable: false })
+    await expect(resolveAgentForegroundProcess(100, 'tmux')).resolves.toBe('claude')
+  })
+
+  it('still resolves directly when walking from the tmux server pid (control)', async () => {
+    mockProcessTable({ tmuxAvailable: false })
+    await expect(resolveAgentForegroundProcess(200, 'tmux')).resolves.toBe('claude')
+  })
+})

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -11,6 +11,7 @@ import {
 } from '../shared/agent-process-recognition'
 import { getFirstCommandToken } from '../shared/command-token-scanner'
 import { getProcessTableSnapshot, type ProcessTableRow } from '../shared/process-table-snapshot'
+import { isTmuxCommand, resolveTmuxForegroundAgent } from '../shared/tmux-foreground-resolution'
 import {
   resolveOuterWrapperForegroundProcess,
   shouldInspectOuterWrapperForegroundProcess
@@ -241,6 +242,22 @@ async function getRecognizedForegroundDescendant(
         return resolveOuterWrapperForegroundProcess(recognized, candidate, candidates)
       }
     }
+    // Why: tmux double-forks its server and reparents it to pid 1 (#7797), so an
+    // agent in a tmux window is a child of the SERVER, not this pane's shell
+    // subtree — the walk above only reached the tmux client. Hop the fork and
+    // re-run recognition from the client's pane.
+    const tmuxClientPids = candidates
+      .filter((candidate) => isTmuxCommand(candidate.command))
+      .map((candidate) => candidate.pid)
+    if (tmuxClientPids.length > 0) {
+      const viaTmux = await resolveTmuxForegroundAgent({
+        rows,
+        tmuxClientPids
+      })
+      if (viaTmux) {
+        return viaTmux
+      }
+    }
   } catch {
     // Fall through to node-pty's process name or the root command name.
   }
@@ -281,7 +298,13 @@ export async function getForegroundProcessName(
         (await resolveWindowsAgentForegroundProcess(pid, fallbackProcess, {})) ?? fallbackProcess
       )
     }
-    if (!isShellProcess(fallbackProcess) && !isAgentForegroundWrapperProcess(fallbackProcess)) {
+    if (
+      !isShellProcess(fallbackProcess) &&
+      !isAgentForegroundWrapperProcess(fallbackProcess) &&
+      // Why: tmux must be inspected, not trusted as the foreground — the real
+      // agent hides behind its double-forked server (issue #7797).
+      !isTmuxCommand(fallbackProcess)
+    ) {
       return fallbackProcess
     }
   }

--- a/src/relay/tmux-agent-detection.test.ts
+++ b/src/relay/tmux-agent-detection.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Regression test for issue #7797 — relay/SSH twin. The same tmux double-fork
+// blindness affects remote sessions through getForegroundProcessName: an agent
+// in a tmux window is a child of the reparented tmux server, not the pane's
+// shell subtree, so the downward walk used to report `tmux`. See the daemon-path
+// test in src/main/providers/tmux-agent-detection.test.ts for the topology.
+
+const { execFileMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn()
+}))
+
+vi.mock('child_process', () => ({
+  execFile: execFileMock
+}))
+
+import { resetProcessTableSnapshotForTests } from '../shared/process-table-snapshot'
+import { getForegroundProcessName } from './pty-shell-utils'
+
+//   pid 100 ppid 99  zsh          <- pane shell (root of the foreground walk)
+//   pid 101 ppid 100 tmux client  <- what the pane shell actually launched
+//   pid 200 ppid 1   tmux server  <- double-forked, reparented to init (pid 1)
+//   pid 201 ppid 200 claude       <- the real agent, child of the SERVER
+const TMUX_PROCESS_TABLE = [
+  '100 99  Ss   -zsh',
+  '101 100 S+   tmux',
+  '200 1   Ss   tmux',
+  '201 200 S+   node /Users/dev/.nvm/versions/node/bin/claude'
+].join('\n')
+
+function reply(cb: unknown, stdout: string): void {
+  ;(cb as (err: unknown, result: { stdout: string; stderr: string }) => void)(null, {
+    stdout,
+    stderr: ''
+  })
+}
+
+function mockProcessTable(options: { tmuxAvailable: boolean }): void {
+  execFileMock.mockImplementation((cmd: string, _args: string[], _opts: unknown, cb: unknown) => {
+    if (cmd === 'tmux') {
+      if (options.tmuxAvailable) {
+        reply(cb, '101 201\n')
+      } else {
+        ;(cb as (err: unknown) => void)(
+          Object.assign(new Error('spawn tmux ENOENT'), { code: 'ENOENT' })
+        )
+      }
+      return
+    }
+    reply(cb, TMUX_PROCESS_TABLE)
+  })
+}
+
+describe('getForegroundProcessName: agent inside tmux over the relay (issue #7797)', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+    resetProcessTableSnapshotForTests()
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+  })
+
+  it('detects claude via the tmux client → active-pane-pid hop', async () => {
+    mockProcessTable({ tmuxAvailable: true })
+    await expect(getForegroundProcessName(100, 'tmux')).resolves.toBe('claude')
+  })
+
+  it('detects claude via the reparented server pid when tmux is unreachable', async () => {
+    mockProcessTable({ tmuxAvailable: false })
+    await expect(getForegroundProcessName(100, 'tmux')).resolves.toBe('claude')
+  })
+})

--- a/src/shared/tmux-foreground-resolution.ts
+++ b/src/shared/tmux-foreground-resolution.ts
@@ -1,0 +1,140 @@
+import { execFile as execFileCb } from 'node:child_process'
+import { promisify } from 'node:util'
+import { recognizeAgentProcessFromCommandLine } from './agent-process-recognition'
+import { getCommandTokenPathBasename, getFirstCommandToken } from './command-token-scanner'
+import { resolveOuterWrapperForegroundProcess } from './foreground-wrapper-agent'
+import type { ProcessTableRow } from './process-table-snapshot'
+
+const execFile = promisify(execFileCb)
+
+const TMUX_QUERY_TIMEOUT_MS = 2000
+
+type ScoredRow = ProcessTableRow & { depth: number }
+
+/** True when a process-table command (or a bare process name) is the `tmux` binary. */
+export function isTmuxCommand(command: string): boolean {
+  return getCommandTokenPathBasename(getFirstCommandToken(command)) === 'tmux'
+}
+
+function collectDescendants(rows: ProcessTableRow[], rootPid: number): ScoredRow[] {
+  const childrenByParent = new Map<number, ProcessTableRow[]>()
+  for (const row of rows) {
+    const children = childrenByParent.get(row.ppid) ?? []
+    children.push(row)
+    childrenByParent.set(row.ppid, children)
+  }
+  const descendants: ScoredRow[] = []
+  const stack = (childrenByParent.get(rootPid) ?? []).map((row) => ({
+    row,
+    depth: 1
+  }))
+  while (stack.length > 0) {
+    const { row, depth } = stack.pop()!
+    descendants.push({ ...row, depth })
+    for (const child of childrenByParent.get(row.pid) ?? []) {
+      stack.push({ row: child, depth: depth + 1 })
+    }
+  }
+  return descendants
+}
+
+function candidateScore(row: ScoredRow): number {
+  return (row.stat.includes('+') ? 10_000 : 0) + row.depth
+}
+
+// Why: re-run agent recognition rooted at a tmux pane (or reparented server)
+// pid. The root pid can BE the agent (a pane launched straight into `claude`,
+// no intervening shell), so the root row is included with its descendants.
+function recognizeAgentFromSubtree(rows: ProcessTableRow[], rootPid: number): string | null {
+  const rootRow = rows.find((row) => row.pid === rootPid)
+  const rootCandidate: ScoredRow[] = rootRow ? [{ ...rootRow, depth: 0 }] : []
+  const candidates = [...rootCandidate, ...collectDescendants(rows, rootPid)].sort(
+    (a, b) => candidateScore(b) - candidateScore(a)
+  )
+  const foregroundIsKnown =
+    rootRow?.stat.includes('+') === true ||
+    candidates.some((candidate) => candidate.stat.includes('+'))
+  for (const candidate of candidates) {
+    if (foregroundIsKnown && !candidate.stat.includes('+')) {
+      continue
+    }
+    const recognized = recognizeAgentProcessFromCommandLine(candidate.command)
+    if (recognized) {
+      return resolveOuterWrapperForegroundProcess(recognized, candidate, candidates)
+    }
+  }
+  return null
+}
+
+export type RunTmux = (args: string[]) => Promise<string>
+
+const defaultRunTmux: RunTmux = async (args) => {
+  const { stdout } = await execFile('tmux', args, {
+    encoding: 'utf-8',
+    timeout: TMUX_QUERY_TIMEOUT_MS
+  })
+  return stdout
+}
+
+/**
+ * Recover an agent that a downward process-tree walk cannot see because it runs
+ * inside tmux.
+ *
+ * tmux double-forks its server and reparents it to pid 1, so an agent started in
+ * a tmux window is a child of the tmux SERVER, not of the pane shell whose
+ * subtree we walked — the walk reaches only the tmux CLIENT and the pane reads
+ * as `tmux`. Hop the fork: map the tmux client(s) found in our subtree to their
+ * active pane pid via `tmux list-clients` and re-run recognition from there; if
+ * tmux is unreachable (wrong socket, not on PATH, no server), fall back to the
+ * reparented tmux server pids visible in the ps table. Best-effort and
+ * POSIX-only — every failure mode returns null so callers keep their existing
+ * fallback. See issue #7797.
+ */
+export async function resolveTmuxForegroundAgent(params: {
+  rows: ProcessTableRow[]
+  tmuxClientPids: number[]
+  runTmux?: RunTmux
+}): Promise<string | null> {
+  const { rows, tmuxClientPids } = params
+  const runTmux = params.runTmux ?? defaultRunTmux
+
+  const paneRoots: number[] = []
+
+  // Precise: ask tmux which pane each of our clients is currently viewing.
+  if (tmuxClientPids.length > 0) {
+    try {
+      const stdout = await runTmux(['list-clients', '-F', '#{client_pid} #{pane_pid}'])
+      const wanted = new Set(tmuxClientPids)
+      for (const line of stdout.split(/\r?\n/)) {
+        const match = line.trim().match(/^(\d+)\s+(\d+)$/)
+        if (match && wanted.has(Number(match[1]))) {
+          paneRoots.push(Number(match[2]))
+        }
+      }
+    } catch {
+      // tmux not reachable from here — fall back to the ps table below.
+    }
+  }
+
+  // Fallback: the reparented tmux server(s) visible in the process table.
+  if (paneRoots.length === 0) {
+    for (const row of rows) {
+      if (row.ppid === 1 && isTmuxCommand(row.command)) {
+        paneRoots.push(row.pid)
+      }
+    }
+  }
+
+  const seen = new Set<number>()
+  for (const rootPid of paneRoots) {
+    if (seen.has(rootPid)) {
+      continue
+    }
+    seen.add(rootPid)
+    const recognized = recognizeAgentFromSubtree(rows, rootPid)
+    if (recognized) {
+      return recognized
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## What

Agents (`claude`, `codex`, …) started inside a user's **tmux** session are never
shown as running — the pane reads as `tmux`. Fixes #7797 (both the daemon and the
relay/SSH detection paths).

## Root cause

Live foreground detection walks the process tree **downward** from the pane's
shell pid (`collectDescendants`). tmux **double-forks its server and reparents it
to pid 1**, so every pane process — including the agent — is a child of the tmux
*server*, not of the pane shell. The downward walk from the shell pid reaches only
the tmux *client* and falls back to reporting `tmux`. The relay twin
(`src/relay/pty-shell-utils.ts`) has the same downward-only walk, so remote
sessions are affected identically.

## Fix

When the downward walk finds a tmux **client** but no agent, hop the fork and
re-run recognition from the client's pane:

1. **Precise** — map each client in our subtree to its active pane pid via
   `tmux list-clients -F '#{client_pid} #{pane_pid}'`, then re-walk from there.
2. **Fallback** — if tmux is unreachable (wrong socket, not on `PATH`, no server),
   walk from the reparented tmux **server** pid(s) visible in the ps table.

Best-effort and POSIX-only; every failure mode returns `null` so callers keep
their existing fallback. Logic lives in a new
`src/shared/tmux-foreground-resolution.ts` and is wired into both detection paths.
The relay path additionally stops treating `tmux` as a trusted foreground name so
the pane is actually inspected.

## Tests

New regression tests model the exact tmux topology (shell → tmux client; tmux
server reparented to pid 1 → `claude`) and cover both the precise client→pane hop
and the reparented-server fallback, for both the daemon
(`src/main/providers/tmux-agent-detection.test.ts`) and relay
(`src/relay/tmux-agent-detection.test.ts`) paths.

- `vitest run` (touched suites): 5/5 pass
- `tsc --noEmit -p config/tsconfig.node.json`: clean
- `oxlint` / `oxfmt`: clean

Supersedes the repro artifact from `nwparker/bug-repro-pass2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## ELI5

Agents started inside your own tmux session never showed as running—the pane just looked like tmux. Detection now finds agents reparented under the tmux server so they appear correctly in the sidebar.
