### PR TITLE
fix(types): exclude undefined stat overloads

### DIFF
--- a/src/main/ipc/worktree-common-git-directory.ts
+++ b/src/main/ipc/worktree-common-git-directory.ts
@@ -7,7 +7,7 @@ import {
 } from '../../shared/cross-platform-path'
 import type { FileStat } from '../providers/types'
 
-type GitDirectoryStat = Awaited<ReturnType<typeof stat>> | FileStat
+type GitDirectoryStat = NonNullable<Awaited<ReturnType<typeof stat>>> | FileStat
 
 type GitDirectoryAccess = {
   stat?: (path: string) => Promise<GitDirectoryStat>

--- a/src/main/skills/skill-installation-topology.ts
+++ b/src/main/skills/skill-installation-topology.ts
@@ -28,7 +28,7 @@ export function normalizedSkillIdentityPath(value: string): string {
 
 export function skillPhysicalIdentity(
   resolvedPath: string,
-  fileStat: Awaited<ReturnType<typeof stat>>
+  fileStat: NonNullable<Awaited<ReturnType<typeof stat>>>
 ): string {
   const inodeIdentity = fileStat.dev || fileStat.ino ? `${fileStat.dev}:${fileStat.ino}` : null
   return inodeIdentity ?? normalizedSkillIdentityPath(resolvedPath)


### PR DESCRIPTION
## Summary

- Exclude undefined from the promise stat overload return type in the two affected type boundaries.
- Restore typecheck after the locked @types/node update without changing runtime behavior.

## Reproduction

After a fresh pnpm install --frozen-lockfile on current main, pnpm typecheck reports TS18048 in worktree-common-git-directory.ts and skill-installation-topology.ts because ReturnType<typeof stat> includes the callback overload nullable branch in the updated declarations.

## Validation

- Fresh locked dependency install reproduced the failure before this change.
- pnpm typecheck passes after this change.
- Scoped oxlint and formatting pass.
- Runtime behavior is unchanged; both functions still receive successful stat results only.