### PR TITLE
fix(types): use concrete Node stat result type

### DIFF
--- a/src/main/ipc/worktree-common-git-directory.ts
+++ b/src/main/ipc/worktree-common-git-directory.ts
@@ -1,3 +1,4 @@
+import type { Stats } from 'node:fs'
 import { readFile, stat } from 'node:fs/promises'
 import type { Repo } from '../../shared/types'
 import {
@@ -7,7 +8,7 @@ import {
 } from '../../shared/cross-platform-path'
 import type { FileStat } from '../providers/types'
 
-type GitDirectoryStat = Awaited<ReturnType<typeof stat>> | FileStat
+type GitDirectoryStat = Stats | FileStat
 
 type GitDirectoryAccess = {
   stat?: (path: string) => Promise<GitDirectoryStat>

--- a/src/main/skills/skill-installation-topology.ts
+++ b/src/main/skills/skill-installation-topology.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { constants } from 'node:fs'
+import { constants, type Stats } from 'node:fs'
 import { access, lstat, realpath, stat } from 'node:fs/promises'
 import { dirname, normalize, resolve } from 'node:path'
 import type { SkillInstallationTopology } from '../../shared/skill-freshness'
@@ -26,10 +26,7 @@ export function normalizedSkillIdentityPath(value: string): string {
   return process.platform === 'win32' ? normalized.toLocaleLowerCase('en-US') : normalized
 }
 
-export function skillPhysicalIdentity(
-  resolvedPath: string,
-  fileStat: Awaited<ReturnType<typeof stat>>
-): string {
+export function skillPhysicalIdentity(resolvedPath: string, fileStat: Stats): string {
   const inodeIdentity = fileStat.dev || fileStat.ino ? `${fileStat.dev}:${fileStat.ino}` : null
   return inodeIdentity ?? normalizedSkillIdentityPath(resolvedPath)
 }


### PR DESCRIPTION
## Summary

- use Node `Stats` for `stat(path)` calls that do not pass options
- preserve remote `FileStat` support in worktree Git-directory resolution
- keep missing-path rejection and existing error handling unchanged across macOS, Linux, Windows, and SSH

## Context

`@types/node` 25.9.5 adds `undefined` to the catch-all `stat` overload for callers that set `throwIfNoEntry: false`. `ReturnType<typeof stat>` selects that broad overload even though these callers invoke `stat(path)`, whose precise overload resolves to `Stats` and rejects on a missing path.

This repairs the main-branch typecheck after #10006 and unblocks checks on main-based PRs such as #9997. It does not modify or stack on #9997.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm exec vitest run src/main/ipc/worktree-base-directory-watcher.test.ts src/main/skills/skill-freshness-inventory.test.ts` (31 tests)
- `pnpm exec oxlint src/main/ipc/worktree-common-git-directory.ts src/main/skills/skill-installation-topology.ts`
- `pnpm exec oxfmt --check src/main/ipc/worktree-common-git-directory.ts src/main/skills/skill-installation-topology.ts`
- `git diff --check`