### PR TITLE
fix(types): concrete Stats over Awaited<ReturnType<typeof stat>> (unbreaks main verify)

### DIFF
--- a/src/main/ipc/worktree-common-git-directory.ts
+++ b/src/main/ipc/worktree-common-git-directory.ts
@@ -1,3 +1,4 @@
+import type { Stats } from 'node:fs'
 import { readFile, stat } from 'node:fs/promises'
 import type { Repo } from '../../shared/types'
 import {
@@ -7,7 +8,9 @@ import {
 } from '../../shared/cross-platform-path'
 import type { FileStat } from '../providers/types'
 
-type GitDirectoryStat = Awaited<ReturnType<typeof stat>> | FileStat
+// Why: use the concrete Stats type, not Awaited<ReturnType<typeof stat>> — @types/node's stat overloads
+// make the latter resolve to a nullable type under a clean-install typecheck (TS18048).
+type GitDirectoryStat = Stats | FileStat
 
 type GitDirectoryAccess = {
   stat?: (path: string) => Promise<GitDirectoryStat>

--- a/src/main/skills/skill-installation-topology.ts
+++ b/src/main/skills/skill-installation-topology.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { constants } from 'node:fs'
+import { constants, type Stats } from 'node:fs'
 import { access, lstat, realpath, stat } from 'node:fs/promises'
 import { dirname, normalize, resolve } from 'node:path'
 import type { SkillInstallationTopology } from '../../shared/skill-freshness'
@@ -28,7 +28,9 @@ export function normalizedSkillIdentityPath(value: string): string {
 
 export function skillPhysicalIdentity(
   resolvedPath: string,
-  fileStat: Awaited<ReturnType<typeof stat>>
+  // Why: concrete Stats, not Awaited<ReturnType<typeof stat>> — that alias resolves nullable under a
+  // clean-install typecheck (@types/node stat overloads), tripping TS18048.
+  fileStat: Stats
 ): string {
   const inodeIdentity = fileStat.dev || fileStat.ino ? `${fileStat.dev}:${fileStat.ino}` : null
   return inodeIdentity ?? normalizedSkillIdentityPath(resolvedPath)
@@ -103,7 +105,7 @@ export async function classifyHomeSkillTopology(
   }
   const linked = logicalStat.isSymbolicLink()
   let resolvedPath: string
-  let resolvedStat: Awaited<ReturnType<typeof stat>>
+  let resolvedStat: Stats
   try {
     resolvedPath = await realpath(unresolvedPath)
     resolvedStat = await stat(resolvedPath)


### PR DESCRIPTION
## Description
`main`'s `verify` job is currently red for **every** freshly-run PR (confirmed on unrelated PRs #10012, #9997, plus the in-flight perf PRs #9841/#9849/#9882) with:

```
src/main/ipc/worktree-common-git-directory.ts(18,20): error TS18048: 'value' is possibly 'undefined'.
src/main/skills/skill-installation-topology.ts(33,25): error TS18048: 'fileStat' is possibly 'undefined'.
… (8 errors total)
```

### Root cause
`main`'s lockfile pins `@types/node@25.9.5`, whose `fs.promises.stat` overloads make `Awaited<ReturnType<typeof stat>>` resolve to a **nullable** type (the alias picks the last overload's return, unlike a direct `stat()` call which resolves the concrete first overload). In param/type-alias positions there's no control-flow narrowing, so member access trips `TS18048`. It reproduces only in a fresh dep install (CI), which is why it slipped in.

### Fix
Use the concrete, non-nullable `Stats` type (from `node:fs`) in the two affected spots. No behavior change — `stat()`/`lstat()` calls still resolve to `Stats` at runtime.

## Proof of zero regression
- Reproduced locally with `@types/node@25.9.5`: pre-fix shows the exact 8 `TS18048` errors; **with the fix the full `typecheck:node` is 0 errors**.
- `Stats` carries every accessed member (`isDirectory`, `isFile`, `dev`, `ino`, `isSymbolicLink`), so callers are unchanged.
- Other files using the same alias were checked — they don't error (their vars are control-flow-narrowed from a concrete `await stat()`), so no wider change is needed.

## Why it matters
Unblocks `verify` for all open PRs, including the perf-scan follow-ups #9841 / #9849 / #9882.

Made with [Orca](https://github.com/stablyai/orca) 🐋
