### PR TITLE
fix(runtime): skip tui-idle quiescence for launchAgent cold starts

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -15846,6 +15846,66 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  // Why (#9976): Claude (and other launchAgent-backed TUIs) can sit quiet for
+  // several seconds during cold start before the first OSC/hook signal. Bare
+  // non-shell quiescence would report tui-idle and lose orchestration injects.
+  it('does not resolve tui-idle via quiet non-shell foreground for launchAgent-backed terminals before status', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => 'claude'
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+        command: 'claude',
+        launchAgent: 'claude',
+        title: 'Claude'
+      })
+      // Quiet startup output only — no OSC title / agent-status / ready prompt.
+      runtime.onPtyData('pty-bg', 'starting…\n', Date.now())
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 8_000
+      })
+      const timeoutAssertion = expect(waitPromise).rejects.toThrow('timeout')
+
+      await vi.advanceTimersByTimeAsync(8_000)
+
+      await timeoutAssertion
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('still resolves tui-idle for launchAgent-backed terminals once agent status is idle', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'claude'
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'claude',
+      launchAgent: 'claude',
+      title: 'Claude'
+    })
+    // Explicit idle OSC title evidence for Claude (✳ prefix).
+    runtime.onPtyData('pty-bg', '\x1b]0;✳ Claude Code\x07', Date.now())
+
+    await expect(
+      runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 1_000 })
+    ).resolves.toMatchObject({
+      handle,
+      condition: 'tui-idle',
+      status: 'running'
+    })
+  })
+
   it('splits text and enter writes for background terminal handles', async () => {
     const writes: string[] = []
     const runtime = new OrcaRuntimeService(store)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -15881,6 +15881,56 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('returns a blocked wait when the Claude trust gate appears during launchAgent startup', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => 'claude'
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+        command: 'claude',
+        launchAgent: 'claude',
+        title: 'Claude'
+      })
+      runtime.onPtyData('pty-bg', 'starting…\n', Date.now())
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 8_000
+      })
+
+      // Why (#9976): the trust screen can arrive after the cold-start silence;
+      // launchAgent readiness must not be satisfied by the earlier quiescence.
+      await vi.advanceTimersByTimeAsync(4_000)
+      runtime.onPtyData(
+        'pty-bg',
+        [
+          'Accessing workspace:',
+          'C:\\scratchpad\\trusttest-fresh',
+          'Quick safety check: Is this a project you created or one you trust? ...',
+          "Claude Code'll be able to read, edit, and execute files here.",
+          '❯ 1. Yes, I trust this folder'
+        ].join('\n'),
+        Date.now()
+      )
+      await vi.advanceTimersByTimeAsync(2_000)
+
+      await expect(waitPromise).resolves.toMatchObject({
+        handle,
+        condition: 'tui-idle',
+        satisfied: false,
+        status: 'running',
+        blockedReason: 'codex-trust-workspace'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('still resolves tui-idle for launchAgent-backed terminals once agent status is idle', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -15952,6 +15952,7 @@ describe('OrcaRuntimeService', () => {
     ).resolves.toMatchObject({
       handle,
       condition: 'tui-idle',
+      satisfied: true,
       status: 'running'
     })
   })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -31887,8 +31887,15 @@ export class OrcaRuntimeService {
           return
         }
         // Foreground fallback: a reported non-shell process with quiet output is treated as idle.
+        // Why: status-backed launches (Claude, etc.) can stay quiet for seconds during cold start
+        // before the first OSC/hook signal — quiescence alone false-positives tui-idle and loses
+        // injected dispatches (#9976). Only use bare quiescence when we never expected status.
+        const leafLaunchAgent = leaf.ptyId
+          ? (this.ptysById.get(leaf.ptyId)?.launchAgent ?? null)
+          : null
         if (
           leaf.lastAgentStatus === null &&
+          leafLaunchAgent == null &&
           leaf.ptyId &&
           this.ptyController &&
           !foregroundPollInFlight
@@ -31958,7 +31965,14 @@ export class OrcaRuntimeService {
           this.resolveWaiter(waiter, buildPtyTerminalWaitResult(waiter.handle, 'tui-idle', pty))
           return
         }
-        if (pty.lastAgentStatus === null && this.ptyController && !foregroundPollInFlight) {
+        // Why: same cold-start guard as the leaf poll — launchAgent set ⇒ wait for
+        // status/ready evidence, not bare non-shell quiet (#9976).
+        if (
+          pty.lastAgentStatus === null &&
+          pty.launchAgent == null &&
+          this.ptyController &&
+          !foregroundPollInFlight
+        ) {
           foregroundPollInFlight = true
           startedForegroundPoll = true
           const fg = await this.ptyController.getForegroundProcess(pty.ptyId)


### PR DESCRIPTION
## 🧑‍🤝‍🧑 Impact & ELI5

**1) What's broken today (ELI5).**  
Automation often does:

```text
terminal create (Claude)
  → terminal wait --for tui-idle
  → orchestration dispatch --inject
```

When Claude is **slow to start**, `tui-idle` can say “ready!” after a few quiet seconds **before Claude has published any agent-status signal**. The inject call still returns `injected: true` (it only proves PTY write), but Claude never consumes the prompt. The worker sits empty until a human/coordinator re-sends.

This is a Claude recurrence of the class of readiness false-positives around #7748 / #7758, adjacent to Grok readiness reports, with incident evidence in #9976.

**2) What this PR does (ELI5).**  
If Orca **launched a known agent** on that terminal (`launchAgent` set, e.g. Claude), we **no longer treat “quiet non-shell process for 3s” as idle**. We wait for real readiness signals: agent status, ready-prompt body evidence, or an explicit idle OSC title.

Anonymous/ad-hoc non-shell TUIs without `launchAgent` still use the old quiescence fallback (needed for agents that never publish status).

**3) Tradeoffs / regressions — honest answer.**

| Concern | Assessment |
|--------|------------|
| Claude / Codex / Grok launched via `--agent` / `launchAgent` | **Safer.** Slow cold start no longer false-idles. Wait may take longer until first status/ready evidence (correct). |
| Ad-hoc `createTerminal` without `launchAgent` (e.g. bare `codex` command) | **Unchanged** — still allows quiet non-shell quiescence (existing test). |
| Already-idle agents with OSC idle / ready prompt | **Unchanged** — those paths resolve immediately as before. |
| Timeout for stuck agents | Callers already pass `--timeout-ms`; if Claude never starts, wait times out instead of lying with `satisfied: true`. |

No CLI API change, no UI change.

---

## Summary

**Bug:** Slow Claude startup lets `terminal wait --for tui-idle` succeed before the first agent-status signal; subsequent `orchestration dispatch --inject` acknowledges the write but Claude never sees the prompt (#9976).

**Root cause:** Fallback poll in `waitForTerminal` / `start*TuiIdleFallbackPoll`:

```ts
lastAgentStatus === null
  && foreground is non-shell
  && quiet for TUI_IDLE_QUIESCENCE_MS (~3s)
  → resolve tui-idle
```

Claude is non-shell and can be quiet during cold start while still not ready.

**Fix:** Gate that quiescence path on **`launchAgent == null`**:

- `launchAgent` set (Claude/Codex/… agent-first create) → **do not** idle on bare quiet; require status / ready prompt / explicit idle title.
- `launchAgent` unset → keep existing quiescence for title-less/ad-hoc agents.

Applies to both **leaf** and **PTY** fallback polls.

Fixes #9976

---

## Evidence

### Automated

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/main/runtime/orca-runtime.test.ts \
  -t "quiet background PTY|launchAgent-backed"
```

**3/3 passed**

| Test | Asserts |
|------|---------|
| `resolves tui-idle for quiet background PTY agents without OSC titles` | Existing: no `launchAgent`, non-shell quiet → still idle (no regression) |
| `does not resolve tui-idle via quiet non-shell foreground for launchAgent-backed terminals before status` | **New:** `launchAgent: 'claude'`, quiet startup → **timeout** |
| `still resolves tui-idle for launchAgent-backed terminals once agent status is idle` | **New:** Claude idle OSC (`✳`) → satisfied |

### Manual / incident mapping (#9976)

| Observation | How this fix addresses it |
|-------------|---------------------------|
| First `agent_start` arrived **after** inject | Wait would no longer complete before status when `launchAgent` is set |
| Only 1 of 4 concurrent Claudes failed | Only that one crossed quiescence before status; others got signals in time |
| Later `terminal send` worked | TUI was eventually ready — readiness signal was late, not missing forever |

### Code map

| Location | Change |
|----------|--------|
| `startTuiIdleFallbackPoll` | Skip quiescence when leaf’s PTY has `launchAgent` |
| `startPtyTuiIdleFallbackPoll` | Skip quiescence when `pty.launchAgent` set |
| `orca-runtime.test.ts` | Regression + positive control |

---

## ELI5

Orca used to assume “Claude process is running and quiet for a few seconds” means “ready for the next command.” Sometimes Claude was still waking up. Now, when Orca itself launched Claude as an agent, it waits for Claude to actually signal readiness instead of guessing from silence.

---

## User-regression-tradeoffs

- **Intended:** longer waits / honest timeouts for agent-first Claude (etc.) cold starts instead of false success.  
- **Preserved:** quiescence for non-agent-first / unknown TUIs without status.  
- **Orchestration scripts:** should already use generous `--timeout-ms`; behavior becomes more correct, not weaker.

---

## Checklist notes (CONTRIBUTING / AGENTS)

| Area | Notes |
|------|--------|
| **Cross-platform** | Runtime wait path only; no OS branches. |
| **SSH / remote** | Same PTY `launchAgent` + status model on remote hosts. |
| **Agents** | Any `launchAgent`-tagged create (Claude, Codex, Grok, …). |
| **Git / providers** | N/A |
| **Performance** | One map lookup for leaf PTY `launchAgent`; no extra IPC when skipping. |
| **UI** | None. |
| **Security** | None. |
| **Tests** | Regression + existing quiescence test still green. |

---

## Test plan

- [x] Existing quiet-without-OSC test still passes  
- [x] launchAgent + quiet startup does **not** idle  
- [x] launchAgent + idle OSC **does** idle  
- [ ] Optional multi-Claude orchestration smoke by reporter

---

## Out of scope

- Changing inject to require “prompt consumed” (larger orchestration contract)  
- Grok background-task HUD idle (#9905 / PR #9929) — complementary, separate  
- Raising `TUI_IDLE_QUIESCENCE_MS` globally

---

## AI code-review summary

1. **Cross-platform** — OK  
2. **SSH/remote** — uses existing launchAgent on PTY records  
3. **Agents** — gated on launchAgent; ad-hoc paths preserved  
4. **Performance** — trivial  
5. **UI** — N/A  
6. **Security** — N/A  
7. **Correctness** — false-positive readiness is worse than a timeout; tests lock both sides  

---

Made for reliable multi-Claude orchestration 🐋