### PR TITLE
fix(worktree-palette): guard undefined review title in matcher (crash c5d87873)

### DIFF
--- a/src/renderer/src/lib/worktree-palette-review-match.test.ts
+++ b/src/renderer/src/lib/worktree-palette-review-match.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import { matchWorktreePaletteReview } from './worktree-palette-review-match'
+import { searchWorktrees } from './worktree-palette-search'
+import type { Repo, Worktree } from '../../../shared/types'
+import type { HostedReviewInfo } from '../../../shared/hosted-review'
+
+// Regression tests for the production crash (report c5d87873, macOS, Orca 1.4.147):
+//   TypeError: Cannot read properties of undefined (reading 'toLowerCase')
+//   at matchWorktreePaletteReview -> searchWorktrees -> WorktreeJumpPalette useMemo
+// A rehydrated review/PR cache entry can carry an undefined `title` even though the
+// type declares it non-optional, so the Cmd+J worktree palette crashed on any text query.
+
+type MatcherReview = Parameters<typeof matchWorktreePaletteReview>[0]
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'wt-1',
+    repoId: 'repo-1',
+    path: '/tmp/wt-1',
+    head: 'abc123',
+    branch: 'refs/heads/feature/worktree-jump',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: 'Jump Palette',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+const repoMap = new Map<string, Repo>([
+  [
+    'repo-1',
+    {
+      id: 'repo-1',
+      path: '/repo/orca',
+      displayName: 'stablyai/orca',
+      badgeColor: '#22c55e',
+      addedAt: 0
+    }
+  ]
+])
+
+describe('matchWorktreePaletteReview title null-safety', () => {
+  it('returns null instead of throwing when a cached review has no title', () => {
+    const review = { number: 42, provider: 'github' } as unknown as MatcherReview
+    expect(() => matchWorktreePaletteReview(review, 'feature', 'feature')).not.toThrow()
+    expect(matchWorktreePaletteReview(review, 'feature', 'feature')).toBeNull()
+  })
+
+  it('still matches on the title text when a title is present', () => {
+    const review = {
+      number: 42,
+      title: 'Fix the thing',
+      provider: 'github'
+    } as unknown as MatcherReview
+    const match = matchWorktreePaletteReview(review, 'thing', 'thing')
+    expect(match).not.toBeNull()
+    expect(match?.text).toBe('Fix the thing')
+    expect(match?.matchRange).toEqual({ start: 8, end: 13 })
+  })
+
+  it('still matches on the PR number even when the title is missing', () => {
+    const review = { number: 42, provider: 'github' } as unknown as MatcherReview
+    const match = matchWorktreePaletteReview(review, '42', '42')
+    expect(match?.text).toBe('PR #42')
+  })
+})
+
+describe('searchWorktrees with a titleless cached review (Cmd+J palette crash path)', () => {
+  it('does not throw when the checks-review cache entry has no title', () => {
+    const worktree = makeWorktree()
+    const titlelessReview = {
+      number: 7,
+      provider: 'github',
+      state: 'open',
+      url: 'https://example.test/pr/7'
+    } as unknown as HostedReviewInfo
+    const checksReviewByWorktree = new Map<Worktree, HostedReviewInfo | null>([
+      [worktree, titlelessReview]
+    ])
+
+    expect(() =>
+      searchWorktrees(
+        [worktree],
+        'nonmatchingtext',
+        repoMap,
+        null,
+        null,
+        undefined,
+        checksReviewByWorktree
+      )
+    ).not.toThrow()
+  })
+})

--- a/src/renderer/src/lib/worktree-palette-review-match.ts
+++ b/src/renderer/src/lib/worktree-palette-review-match.ts
@@ -1,6 +1,7 @@
 import type { HostedReviewInfo } from '../../../shared/hosted-review'
 
-type SearchableReview = Pick<HostedReviewInfo, 'number' | 'title' | 'provider'>
+// title is intentionally optional: rehydrated review/PR caches can hold entries without one.
+type SearchableReview = Pick<HostedReviewInfo, 'number' | 'provider'> & { title?: string }
 type WorktreePaletteReviewMatch = {
   labelKind: 'pr' | 'mr'
   text: string
@@ -35,13 +36,15 @@ export function matchWorktreePaletteReview(
     }
   }
 
-  const titleIndex = review.title.toLowerCase().indexOf(query)
+  // Null-safe: a cached review may have no title, so fall back to '' (query is non-empty, so it won't match).
+  const title = review.title ?? ''
+  const titleIndex = title.toLowerCase().indexOf(query)
   if (titleIndex === -1) {
     return null
   }
   return {
     labelKind: isMergeRequest ? 'mr' : 'pr',
-    text: review.title,
+    text: title,
     matchRange: { start: titleIndex, end: titleIndex + query.length }
   }
 }


### PR DESCRIPTION
## Description

Fixes a renderer crash in the **Worktree Jump Palette** (`Cmd/Ctrl+J`). Typing any non-numeric text into the palette could throw:

```
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at matchWorktreePaletteReview
    at searchWorktrees
    at WorktreeJumpPalette (useMemo)
```

`matchWorktreePaletteReview` called `review.title.toLowerCase()` with no guard. Although `HostedReviewInfo.title` / `PRInfo.title` are typed as required `string`, the review objects come from **on-disk rehydrated caches** (`hostedReviewCache` / `prCache`) that can contain partial/legacy entries with no `title`. At runtime `title` was `undefined`, so the whole renderer crashed into the `modal.worktree-palette` error boundary.

Crash report: `c5d87873-e664-405e-858e-c41a720d50b5` (macOS, Orca 1.4.147). Same unguarded path exists on current `main`.

## CLEAR, UNDENIABLE fix evidence

A regression test reproduces the exact production error against the unmodified code, then passes after the one-line null-safety guard.

**Before the fix** (`git stash` the source change, keep the test):
```
 ❯ worktree-palette-review-match.test.ts (4 tests | 2 failed)
   × returns null instead of throwing when a cached review has no title
     AssertionError: expected [Function] to not throw an error but
     'TypeError: Cannot read properties of undefined (reading 'toLowerCase')' was thrown
   × does not throw when the checks-review cache entry has no title   (via searchWorktrees)
     AssertionError: ... 'TypeError: Cannot read properties of undefined (reading 'toLowerCase')' was thrown
```
The thrown message is byte-for-byte the production crash, reproduced both through the matcher directly **and** through the real `searchWorktrees` → `WorktreeJumpPalette` `useMemo` path from the stack trace.

**After the fix:**
```
 Test Files  2 passed (2)
      Tests  22 passed (22)     # 4 new regression tests + 18 existing search tests
```
`tsc` web typecheck: **exit 0**. `oxlint` on the changed file: **clean**.

## ELI5

The little "jump to worktree" search box tries to match what you type against each worktree's pull-request **title**. Some saved PR records (loaded from disk) had no title at all — an empty slot. The code assumed a title was always there and called "make this text lowercase" on the empty slot, which is like trying to read a page from a book that isn't there — so the whole window crashed. The fix: if there's no title, treat it as an empty string. An empty title just can't match your search (which is correct — there's nothing to match), and nothing crashes.

## Trade-offs / regressions

- **None user-facing.** With a missing title the matcher now returns `null` (no supporting-text highlight for that review) instead of throwing — the desired behavior; the palette simply doesn't highlight a title that never existed. Number matching, GitHub/GitLab sigil scoping, and match-range math are untouched.
- The `SearchableReview` type was narrowed to `title?: string` (honest about runtime reality); all call sites still compile.
- **Deferred (out of scope):** the underlying schema `HostedReviewInfo.title: string` is still "optimistic" — any *other* consumer that reads a rehydrated title directly could hit the same class of bug. This PR guards the crashing palette path only. A follow-up could make `title` optional at the type source or sanitize on cache rehydration.

## Adversarial review

- **1 loop to clean.** A fresh skeptic sub-agent tried to refute the fix and confirmed it is correct and complete for the reported crash (query is guaranteed non-empty, so a missing title deterministically yields `null`; the type widening is sound; no title-present behavior change; no secondary `.title` crash remains in the `useMemo` path). Only nice-to-have/nit suggestions remained (the deferred schema note above; a non-string-title defensive coercion with no evidence of occurring) — none are must-fix.
- **Perf review (`/perf` skill, sub-agent): clean.** Pure null-safety guard; if anything it reduces two property reads to one. No allocation, polling, effect, render, or subscription vectors touched.

Made with [Orca](https://github.com/stablyai/orca) 🐋
