### PR TITLE
fix(native-chat): wrap question text and option descriptions instead of truncating

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatQuestionCard.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatQuestionCard.tsx
@@ -155,11 +155,8 @@ export function NativeChatQuestionCard({
         ) : null}
 
         <div className="overflow-hidden rounded-lg border border-input bg-card shadow-xs">
-          <div className="flex items-center justify-between gap-2 px-3.5 py-2.5">
-            <p
-              className="min-w-0 truncate text-sm font-semibold text-foreground"
-              title={q.question}
-            >
+          <div className="flex items-start justify-between gap-2 px-3.5 py-2.5">
+            <p className="min-w-0 break-words text-sm font-semibold text-foreground">
               {q.question}
             </p>
             <button
@@ -264,7 +261,7 @@ function OptionRow({
       // assistive tech.
       aria-pressed={selected}
       className={cn(
-        'flex w-full items-center gap-3 px-3.5 py-2.5 text-left transition-colors disabled:pointer-events-none',
+        'flex w-full items-start gap-3 px-3.5 py-2.5 text-left transition-colors disabled:pointer-events-none',
         selected ? 'bg-accent' : 'hover:bg-accent'
       )}
     >
@@ -277,13 +274,9 @@ function OptionRow({
         {selected ? <Check className="size-3.5" strokeWidth={3} /> : badge}
       </span>
       <span className="min-w-0">
-        <span className="block truncate text-sm text-foreground" title={label}>
-          {label}
-        </span>
+        <span className="block break-words text-sm text-foreground">{label}</span>
         {description ? (
-          <span className="block truncate text-xs text-muted-foreground" title={description}>
-            {description}
-          </span>
+          <span className="block break-words text-xs text-muted-foreground">{description}</span>
         ) : null}
       </span>
     </button>


### PR DESCRIPTION
## Summary

In native chat, `AskUserQuestion` cards clipped the question text, option labels, and option descriptions to a single ellipsized line (`truncate`), so long questions and descriptions could only be read via the hover `title` tooltip — and not at all on touch/keyboard. This PR lets all three wrap to multiple lines so the full text is always readable:

- `NativeChatQuestionCard.tsx`: `truncate` → `break-words` on the question, option label, and option description.
- Top-align the close button and the numbered badges (`items-center` → `items-start`) so multi-line rows keep a stable layout.
- Drop the now-redundant `title` tooltips.

Long option lists are still bounded by the existing `max-h-[50vh]` scroll container, so the card cannot grow unbounded.

## Screenshots

before
<img width="866" height="208" alt="before-dark" src="https://github.com/user-attachments/assets/fea6aefb-dde6-45b1-8a23-b8d59efaca8d" />

after-dark
<img width="1692" height="806" alt="after-dark" src="https://github.com/user-attachments/assets/14273b95-b002-4abf-9514-d8eeaac36861" />

after-light
<img width="1698" height="806" alt="after-light" src="https://github.com/user-attachments/assets/4952337a-07ac-4b65-92cd-d1450b8ff875" />

## Testing

- [x] `pnpm lint` — fails on current `main` before this change too (`src/renderer/src/components/skills/skill-freshness-group.tsx` switch-exhaustiveness); the file touched here passes `oxlint` (also enforced by the pre-commit hook)
- [x] `pnpm typecheck`
- [x] `pnpm test` — `NativeChatQuestionCard.test.tsx` 4/4 pass; the full suite has 8 failing files (43 tests) that fail identically on a clean `main` checkout (verified via `git stash`), i.e. unrelated to this change
- [x] `pnpm build`
- [x] No new tests: this is a CSS-only presentation fix with no behavior change; the existing `NativeChatQuestionCard` tests cover answer-resolution behavior and still pass. Verified visually in `pnpm dev` (screenshots).

## AI Review Report

Reviewed with Claude Code. Checks performed:

- **Cross-platform (macOS/Linux/Windows)**: CSS-only change using Tailwind utilities; no shortcuts, labels, paths, shell behavior, or Electron platform APIs touched. No platform-specific rendering behavior involved.
- **SSH/remote/local**: renderer-only presentation change; no process, file, credential, or network path assumptions.
- **Agent/integration neutrality**: applies uniformly to any agent's ask prompt rendered by native chat; no agent-specific logic.
- **Performance**: no new work in render paths; removes two `title` attributes; class-string changes only.
- **UI quality**: verified in `pnpm dev` in dark and light mode; close button and numbered badges top-align correctly on multi-line rows; single-line rows look unchanged apart from alignment; option list scrolling (`max-h-[50vh]`) unchanged.
- Nothing was flagged.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes. Question/label/description strings are still rendered exclusively as React text nodes (no `dangerouslySetInnerHTML`), same as before. No follow-up needed.

## Notes

No platform-specific behavior. The `pnpm lint` failure noted above pre-exists on `main` and is untouched by this PR.
