### PR TITLE
fix(terminal): stop measure<->fit feedback loop in overlay fallback (React #185)

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.react185.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.react185.test.tsx
@@ -1,31 +1,10 @@
-/**
- * @vitest-environment happy-dom
- *
- * Regression for React error #185 ("Maximum update depth exceeded") reported
- * ONLY on Windows (Orca 1.4.148 / 1.4.149, boundary `terminal.workbench`,
- * reports f1783c09 / 5ff8a4e6 / 52aabedb).
- *
- * The overlay fallback-measurement path (taken when CSS anchor positioning is
- * unavailable) writes a BRAND-NEW rect object on every ResizeObserver tick with
- * no equality guard. A stable geometry therefore still "changes" state on every
- * measurement, re-running the fit effect -> SYNC_FIT -> xterm fit() -> resize ->
- * ResizeObserver -> ... an unbounded measure<->fit loop that never settles.
- *
- * This test forces the fallback path (`__ORCA_WEB_CLIENT__ = true`) and drives
- * the ResizeObserver callback with a CONSTANT rect. On buggy HEAD every tick
- * commits a fresh object, so the slot re-renders once per tick (render churn
- * grows unboundedly). With the equality guard the state bails out and the slot
- * settles after the first measurement.
- */
+/** @vitest-environment happy-dom */
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-// Opt into React's act() testing environment so effect flushes are deterministic.
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
-// Count TerminalPane renders as a proxy for slot commits: the slot re-creates
-// the TerminalPane element on every render, so each commit calls this mock once.
 let terminalPaneRenderCount = 0
 vi.mock('./TerminalPane', () => ({
   default: () => {
@@ -34,8 +13,6 @@ vi.mock('./TerminalPane', () => ({
   }
 }))
 
-// The slot only reads `useAppStore.getState().pendingStartupByTabId`; stub it so
-// the test never boots the real (heavy, side-effectful) app store.
 vi.mock('../../store', () => ({
   useAppStore: Object.assign(() => undefined, {
     getState: () => ({ pendingStartupByTabId: {} })
@@ -47,33 +24,31 @@ import { TerminalOverlaySlot } from './TerminalPaneOverlayLayer'
 const GROUP_ID = 'group-react185'
 const TAB_ID = 'tab-react185'
 
-const CONSTANT_PARENT_RECT: DOMRect = {
-  top: 0,
-  left: 0,
-  right: 800,
-  bottom: 600,
-  width: 800,
-  height: 600,
-  x: 0,
-  y: 0,
-  toJSON: () => ({})
+function createRect({
+  top = 0,
+  left = 0,
+  width = 800,
+  height = 600
+}: Partial<Pick<DOMRect, 'top' | 'left' | 'width' | 'height'>> = {}): DOMRect {
+  return {
+    top,
+    left,
+    right: left + width,
+    bottom: top + height,
+    width,
+    height,
+    x: left,
+    y: top,
+    toJSON: () => ({})
+  }
 }
-// A stable body rect: sub-pixel-identical on every tick.
-const CONSTANT_BODY_RECT: DOMRect = {
-  top: 32,
-  left: 0,
-  right: 800,
-  bottom: 600,
-  width: 800,
-  height: 568,
-  x: 0,
-  y: 32,
-  toJSON: () => ({})
-}
+
+const PARENT_RECT = createRect()
 
 let capturedResizeCallback: (() => void) | null = null
 let container: HTMLDivElement
 let bodyEl: HTMLDivElement
+let bodyRect: DOMRect
 let root: Root
 
 class CapturingResizeObserver {
@@ -93,7 +68,7 @@ function renderSlot(): void {
         terminalTabId={TAB_ID}
         terminalGeneration={0}
         worktreeId="wt-1"
-        worktreePath="/tmp/wt-1"
+        worktreePath="wt-1"
         startupCwd={undefined}
         groupId={GROUP_ID}
         isWorktreeActive
@@ -115,12 +90,13 @@ beforeEach(() => {
   vi.stubGlobal('ResizeObserver', CapturingResizeObserver)
 
   container = document.createElement('div')
-  container.getBoundingClientRect = () => CONSTANT_PARENT_RECT
+  container.getBoundingClientRect = () => PARENT_RECT
   document.body.appendChild(container)
 
   bodyEl = document.createElement('div')
   bodyEl.setAttribute('data-tab-group-body-id', GROUP_ID)
-  bodyEl.getBoundingClientRect = () => CONSTANT_BODY_RECT
+  bodyRect = createRect({ top: 32, height: 568 })
+  bodyEl.getBoundingClientRect = () => bodyRect
   document.body.appendChild(bodyEl)
 })
 
@@ -137,25 +113,54 @@ afterEach(() => {
 describe('TerminalPaneOverlayLayer fallback measure<->fit loop (React #185)', () => {
   it('does not re-render on ResizeObserver ticks with an unchanged rect', () => {
     renderSlot()
-
-    // Sanity: the fallback measuring effect installed a ResizeObserver.
     expect(capturedResizeCallback).toBeTypeOf('function')
 
     const rendersAfterMount = terminalPaneRenderCount
-
-    // Drive the observer with the SAME geometry many times. A settled overlay
-    // must not keep committing new state for identical measurements.
-    const TICKS = 50
-    for (let i = 0; i < TICKS; i += 1) {
+    for (let i = 0; i < 50; i += 1) {
       act(() => {
         capturedResizeCallback?.()
       })
     }
 
-    const extraRenders = terminalPaneRenderCount - rendersAfterMount
+    expect(terminalPaneRenderCount - rendersAfterMount).toBe(0)
+  })
 
-    // Buggy HEAD: every tick writes a new rect object -> ~TICKS extra renders
-    // (unbounded churn -> React #185). Fixed: the equality guard bails -> 0.
-    expect(extraRenders).toBeLessThanOrEqual(1)
+  it('settles sub-pixel jitter across an integer boundary without losing precision', () => {
+    bodyRect = createRect({ top: 32.1, left: 0.1, width: 799.1, height: 567.1 })
+    renderSlot()
+    const overlay = container.querySelector<HTMLElement>('[data-terminal-overlay-tab-id]')
+    expect(overlay?.style.top).toBe('32.1px')
+    expect(overlay?.style.width).toBe('799.1px')
+
+    const rendersAfterMount = terminalPaneRenderCount
+    for (let i = 0; i < 50; i += 1) {
+      bodyRect = createRect({ top: 32.9, left: 0.9, width: 799.9, height: 567.9 })
+      act(() => {
+        capturedResizeCallback?.()
+      })
+      bodyRect = createRect({ top: 32.1, left: 0.1, width: 799.1, height: 567.1 })
+      act(() => {
+        capturedResizeCallback?.()
+      })
+    }
+
+    expect(terminalPaneRenderCount - rendersAfterMount).toBe(0)
+    expect(overlay?.style.top).toBe('32.1px')
+    expect(overlay?.style.width).toBe('799.1px')
+  })
+
+  it('commits a genuine geometry change', () => {
+    renderSlot()
+    const overlay = container.querySelector<HTMLElement>('[data-terminal-overlay-tab-id]')
+    const rendersAfterMount = terminalPaneRenderCount
+
+    bodyRect = createRect({ top: 34, width: 760, height: 566 })
+    act(() => {
+      capturedResizeCallback?.()
+    })
+
+    expect(terminalPaneRenderCount - rendersAfterMount).toBe(1)
+    expect(overlay?.style.top).toBe('34px')
+    expect(overlay?.style.width).toBe('760px')
   })
 })

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.react185.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.react185.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * @vitest-environment happy-dom
+ *
+ * Regression for React error #185 ("Maximum update depth exceeded") reported
+ * ONLY on Windows (Orca 1.4.148 / 1.4.149, boundary `terminal.workbench`,
+ * reports f1783c09 / 5ff8a4e6 / 52aabedb).
+ *
+ * The overlay fallback-measurement path (taken when CSS anchor positioning is
+ * unavailable) writes a BRAND-NEW rect object on every ResizeObserver tick with
+ * no equality guard. A stable geometry therefore still "changes" state on every
+ * measurement, re-running the fit effect -> SYNC_FIT -> xterm fit() -> resize ->
+ * ResizeObserver -> ... an unbounded measure<->fit loop that never settles.
+ *
+ * This test forces the fallback path (`__ORCA_WEB_CLIENT__ = true`) and drives
+ * the ResizeObserver callback with a CONSTANT rect. On buggy HEAD every tick
+ * commits a fresh object, so the slot re-renders once per tick (render churn
+ * grows unboundedly). With the equality guard the state bails out and the slot
+ * settles after the first measurement.
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Opt into React's act() testing environment so effect flushes are deterministic.
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+// Count TerminalPane renders as a proxy for slot commits: the slot re-creates
+// the TerminalPane element on every render, so each commit calls this mock once.
+let terminalPaneRenderCount = 0
+vi.mock('./TerminalPane', () => ({
+  default: () => {
+    terminalPaneRenderCount += 1
+    return null
+  }
+}))
+
+// The slot only reads `useAppStore.getState().pendingStartupByTabId`; stub it so
+// the test never boots the real (heavy, side-effectful) app store.
+vi.mock('../../store', () => ({
+  useAppStore: Object.assign(() => undefined, {
+    getState: () => ({ pendingStartupByTabId: {} })
+  })
+}))
+
+import { TerminalOverlaySlot } from './TerminalPaneOverlayLayer'
+
+const GROUP_ID = 'group-react185'
+const TAB_ID = 'tab-react185'
+
+const CONSTANT_PARENT_RECT: DOMRect = {
+  top: 0,
+  left: 0,
+  right: 800,
+  bottom: 600,
+  width: 800,
+  height: 600,
+  x: 0,
+  y: 0,
+  toJSON: () => ({})
+}
+// A stable body rect: sub-pixel-identical on every tick.
+const CONSTANT_BODY_RECT: DOMRect = {
+  top: 32,
+  left: 0,
+  right: 800,
+  bottom: 600,
+  width: 800,
+  height: 568,
+  x: 0,
+  y: 32,
+  toJSON: () => ({})
+}
+
+let capturedResizeCallback: (() => void) | null = null
+let container: HTMLDivElement
+let bodyEl: HTMLDivElement
+let root: Root
+
+class CapturingResizeObserver {
+  constructor(cb: () => void) {
+    capturedResizeCallback = cb
+  }
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+function renderSlot(): void {
+  root = createRoot(container)
+  act(() => {
+    root.render(
+      <TerminalOverlaySlot
+        terminalTabId={TAB_ID}
+        terminalGeneration={0}
+        worktreeId="wt-1"
+        worktreePath="/tmp/wt-1"
+        startupCwd={undefined}
+        groupId={GROUP_ID}
+        isWorktreeActive
+        isVisible
+        isActive
+        activityTerminalPortal={null}
+        onFocusOwningGroup={vi.fn()}
+        consumeSuppressedPtyExit={() => false}
+        leaveWorktreeIfEmpty={vi.fn()}
+      />
+    )
+  })
+}
+
+beforeEach(() => {
+  terminalPaneRenderCount = 0
+  capturedResizeCallback = null
+  ;(globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
+  vi.stubGlobal('ResizeObserver', CapturingResizeObserver)
+
+  container = document.createElement('div')
+  container.getBoundingClientRect = () => CONSTANT_PARENT_RECT
+  document.body.appendChild(container)
+
+  bodyEl = document.createElement('div')
+  bodyEl.setAttribute('data-tab-group-body-id', GROUP_ID)
+  bodyEl.getBoundingClientRect = () => CONSTANT_BODY_RECT
+  document.body.appendChild(bodyEl)
+})
+
+afterEach(() => {
+  act(() => {
+    root?.unmount()
+  })
+  container?.remove()
+  bodyEl?.remove()
+  vi.unstubAllGlobals()
+  delete (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
+})
+
+describe('TerminalPaneOverlayLayer fallback measure<->fit loop (React #185)', () => {
+  it('does not re-render on ResizeObserver ticks with an unchanged rect', () => {
+    renderSlot()
+
+    // Sanity: the fallback measuring effect installed a ResizeObserver.
+    expect(capturedResizeCallback).toBeTypeOf('function')
+
+    const rendersAfterMount = terminalPaneRenderCount
+
+    // Drive the observer with the SAME geometry many times. A settled overlay
+    // must not keep committing new state for identical measurements.
+    const TICKS = 50
+    for (let i = 0; i < TICKS; i += 1) {
+      act(() => {
+        capturedResizeCallback?.()
+      })
+    }
+
+    const extraRenders = terminalPaneRenderCount - rendersAfterMount
+
+    // Buggy HEAD: every tick writes a new rect object -> ~TICKS extra renders
+    // (unbounded churn -> React #185). Fixed: the equality guard bails -> 0.
+    expect(extraRenders).toBeLessThanOrEqual(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
@@ -33,6 +33,7 @@ const HAS_CSS_ANCHOR_POSITIONING =
   CSS.supports('width', 'anchor-size(--orca-terminal-overlay-probe width)')
 const MIN_OVERLAY_FIT_WIDTH_PX = 48
 const MIN_OVERLAY_FIT_HEIGHT_PX = 24
+const FALLBACK_RECT_MIN_CHANGE_PX = 1
 
 function shouldUseCssAnchorPositioning(): boolean {
   return (
@@ -111,28 +112,24 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
       const parent = overlay?.parentElement
       const body = findBody()
       if (!parent || !body) {
-        // Why: only commit the null reset when not already null, else an
-        // unmeasurable overlay keeps re-dispatching the fit loop (React #185).
-        setMeasuredFallbackRect((prev) => (prev === null ? prev : null))
+        setMeasuredFallbackRect(null)
         return
       }
       const parentRect = parent.getBoundingClientRect()
       const bodyRect = body.getBoundingClientRect()
-      // Why: ResizeObserver + xterm fit() form a measure<->fit feedback loop.
-      // Rounding to integers kills sub-pixel jitter and returning `prev` on an
-      // unchanged rect makes React bail so the loop settles (React #185).
       const next: MeasuredFallbackRect = {
-        top: Math.round(bodyRect.top - parentRect.top),
-        left: Math.round(bodyRect.left - parentRect.left),
-        width: Math.round(bodyRect.width),
-        height: Math.round(bodyRect.height)
+        top: bodyRect.top - parentRect.top,
+        left: bodyRect.left - parentRect.left,
+        width: bodyRect.width,
+        height: bodyRect.height
       }
+      // Why: ResizeObserver and xterm fit can otherwise amplify sub-pixel jitter forever.
       setMeasuredFallbackRect((prev) =>
         prev &&
-        prev.top === next.top &&
-        prev.left === next.left &&
-        prev.width === next.width &&
-        prev.height === next.height
+        Math.abs(prev.top - next.top) < FALLBACK_RECT_MIN_CHANGE_PX &&
+        Math.abs(prev.left - next.left) < FALLBACK_RECT_MIN_CHANGE_PX &&
+        Math.abs(prev.width - next.width) < FALLBACK_RECT_MIN_CHANGE_PX &&
+        Math.abs(prev.height - next.height) < FALLBACK_RECT_MIN_CHANGE_PX
           ? prev
           : next
       )

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
@@ -64,7 +64,7 @@ type TerminalOverlaySlotProps = {
   leaveWorktreeIfEmpty: () => void
 }
 
-const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
+export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
   terminalTabId,
   terminalGeneration,
   worktreeId,
@@ -111,17 +111,31 @@ const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
       const parent = overlay?.parentElement
       const body = findBody()
       if (!parent || !body) {
-        setMeasuredFallbackRect(null)
+        // Why: only commit the null reset when not already null, else an
+        // unmeasurable overlay keeps re-dispatching the fit loop (React #185).
+        setMeasuredFallbackRect((prev) => (prev === null ? prev : null))
         return
       }
       const parentRect = parent.getBoundingClientRect()
       const bodyRect = body.getBoundingClientRect()
-      setMeasuredFallbackRect({
-        top: bodyRect.top - parentRect.top,
-        left: bodyRect.left - parentRect.left,
-        width: bodyRect.width,
-        height: bodyRect.height
-      })
+      // Why: ResizeObserver + xterm fit() form a measure<->fit feedback loop.
+      // Rounding to integers kills sub-pixel jitter and returning `prev` on an
+      // unchanged rect makes React bail so the loop settles (React #185).
+      const next: MeasuredFallbackRect = {
+        top: Math.round(bodyRect.top - parentRect.top),
+        left: Math.round(bodyRect.left - parentRect.left),
+        width: Math.round(bodyRect.width),
+        height: Math.round(bodyRect.height)
+      }
+      setMeasuredFallbackRect((prev) =>
+        prev &&
+        prev.top === next.top &&
+        prev.left === next.left &&
+        prev.width === next.width &&
+        prev.height === next.height
+          ? prev
+          : next
+      )
     }
 
     updateRect()


### PR DESCRIPTION
## Description
Fixes a **Windows-only** React error #185 ("Maximum update depth exceeded") crash in the terminal workbench (error boundary `terminal.workbench`), reported on Orca **1.4.148 / 1.4.149**.

Root cause is in `TerminalOverlaySlot` (`src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx`), specifically the **fallback-measurement path** that runs when CSS anchor positioning is unavailable. On Windows/Chromium configs lacking full `anchor-size()` support, `shouldUseCssAnchorPositioning()` returns `false`, so the app takes the fallback path (macOS takes the CSS-anchor path where the measuring effect early-returns — which is why macOS never crashed).

On the fallback path, the first layout effect installs a `ResizeObserver` whose callback `updateRect()` called `setMeasuredFallbackRect({ top, left, width, height })` with a **brand-new object every tick and no equality guard**. The state therefore "changed" (new reference) on every measurement even when geometry was identical. `measuredFallbackRect` is a dependency of the second layout effect, which re-dispatches `SYNC_FIT_PANES_EVENT`; `use-terminal-container-fit-sync.ts` listens and runs xterm `fit()`, which resizes the observed body/parent nodes → `ResizeObserver` fires again → new object → effect → SYNC_FIT → fit → resize … an **unbounded measure↔fit feedback loop** that never settles → React #185.

### The fix
In `updateRect()`, compare measured `top/left/width/height` with the last committed rectangle and return the **previous state reference** when every change is under one CSS pixel. This suppresses identical measurements and sub-pixel jitter without rounding away precise geometry. Genuine geometry changes of at least one pixel still commit.

## Fix evidence — failing → passing repro test
Regression test: `src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.react185.test.tsx` (`@vitest-environment happy-dom`). It forces the fallback path (`globalThis.__ORCA_WEB_CLIENT__ = true`), captures the `ResizeObserver` callback, and verifies three behaviors: 50 identical measurements cause no extra render; 100 alternating sub-pixel measurements across an integer boundary settle without losing precise CSS geometry; and a genuine resize commits exactly once.

**BEFORE (buggy HEAD — FAILS):**
```
 ❯ TerminalPaneOverlayLayer.react185.test.tsx (1 test | 1 failed)
   × does not re-render on ResizeObserver ticks with an unchanged rect
AssertionError: expected 50 to be less than or equal to 1
   expect(extraRenders).toBeLessThanOrEqual(1)
 Test Files  1 failed (1)
      Tests  1 failed (1)
```
50 identical-geometry ticks → 50 extra commits = the unbounded churn that manifests as React #185 in production.

**AFTER (with fix — PASSES):**
```
 Test Files  1 passed (1)
      Tests  1 passed (1)
```
50 identical-geometry ticks → 0 extra commits (React bails on the unchanged reference).

Also green on the rebased branch: full `src/renderer/src/components/terminal-pane/` suite (181 files / 2317 tests), `tsc --noEmit -p config/tsconfig.tc.web.json`, `oxlint`, React Doctor lint, and the max-lines ratchet.

## ELI5
The terminal draws an invisible ruler to measure where it should sit. Every time it measured, it wrote down the size on a *fresh* sticky note — even when the size hadn't changed. React saw a "new" note and re-did the layout, which nudged the ruler, which triggered another measurement, another note, another layout… forever, until the app fell over. The fix: round the numbers and, if the new note says exactly the same thing as the last one, don't write a new note at all. The loop stops.

## Trade-offs / regressions
- Sub-pixel changes are coalesced until cumulative movement reaches one CSS pixel. The committed rectangle retains its precise measured values, and one-pixel-or-larger geometry changes still update normally.
- No behavior change on macOS (CSS-anchor path — the fallback effect early-returns and this code never executes) or for real resizes/tab switches (those still commit).

## Adversarial review
**2 loops, both CLEAN.** Each loop used a fresh sub-agent instructed to refute the fix.
- **Loop 1:** verified the loop is closed at the source and independently found the pre-existing secondary guard in `pane-fit.ts` (`performSafeFit` early-returns when proposed cols/rows match); confirmed no null-branch regression; confirmed the `use-tab-agent.ts:244/:273` SortableTab-variant effects are already bounded (generation ref + one-shot early-return), so no hardening was warranted; ran the repro test green. → CLEAN
- **Loop 2 (different angles):** checked stale-closure / React 19 StrictMode double-invoke of the functional updater (pure → safe), effect-dep interleaving, null↔rect oscillation, `style` `useMemo` non-churn, and confirmed the app renders under `<StrictMode>` with correct observer teardown (no leak/double-seed). Could not construct any still-looping scenario attributable to the fix. → CLEAN

## Perf review (`/perf` skill, via sub-agent)
Confirmed the fix **removes** the wasted work (render churn + fit thrash) rather than masking it, adds no new cost, and transitively stops the `style` `useMemo` and second-effect churn. One low-severity suggestion (drop `isVisible` from the first effect's dep array) was **considered and declined**: the overlay slot stays mounted across worktree switches while the per-group `[data-tab-group-body-id]` element unmounts/remounts on worktree deactivate/reactivate, and the `isVisible` dep is what re-runs the effect to re-`observe()` the *new* body element. Removing it risks a stale-geometry regression on the exact Windows fallback path this PR fixes — not behavior-preserving, so left as-is.

## Crash reports
- Platform: **Windows**
- Version: Orca **1.4.148 / 1.4.149**
- Boundary: `terminal.workbench`
- Error: React **#185** "Maximum update depth exceeded"
- Reports: `f1783c09` / `5ff8a4e6` / `52aabedb`
