### PR TITLE
fix(daemon): gate agent startup cwd after safe default fallback

### DIFF
--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -1600,27 +1600,43 @@ describe('createPtySubprocess', () => {
     )
   })
 
-  it('rejects daemon automatic agent startup without an explicit cwd', () => {
+  it('falls back to the safe default cwd for daemon agent startup without an explicit cwd', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    spawnMock.mockClear()
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { value: 'linux' })
-    spawnMock.mockClear()
+    const origHome = process.env.HOME
+    // Pin HOME so we assert the exact resolved candidate, not just non-root-ness —
+    // catches regressions where resolveSafePtyDefaultCwd picks an unintended home.
+    process.env.HOME = '/home/testuser'
 
     try {
+      // Why: omitted cwd resolves to a safe default home; guard must not reject before fallback (#9578).
       expect(() =>
         createPtySubprocess({
           sessionId: 'test',
           cols: 80,
           rows: 24,
-          command: 'codex'
+          command: 'opencode'
         })
-      ).toThrow(/requires a non-root workspace/)
+      ).not.toThrow()
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Array),
+        expect.objectContaining({ cwd: '/home/testuser' })
+      )
     } finally {
       if (platform) {
         Object.defineProperty(process, 'platform', platform)
       }
+      if (origHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = origHome
+      }
     }
-
-    expect(spawnMock).not.toHaveBeenCalled()
   })
 
   it('rejects daemon automatic agent startup at POSIX root', () => {

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -592,10 +592,12 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   let windowsFallbackAttempts: WindowsShellSpawnAttempt[] = []
   const startupAgentRecognition = recognizeAgentProcessFromCommandLine(opts.command)
   const isCodexStartupCommand = startupAgentRecognition?.agent === 'codex'
-  if (opts.command && startupAgentRecognition) {
-    assertSafeAgentStartupCwd(opts.cwd, opts.command)
-  }
+  // Why: gate on the effective cwd, not raw opts.cwd — an omitted cwd becomes a safe
+  // default (mirrors LocalPtyProvider). Guarding first treated undefined as root-like (#9578).
   const requestedCwd = opts.cwd || getDefaultCwd()
+  if (opts.command && startupAgentRecognition) {
+    assertSafeAgentStartupCwd(requestedCwd, opts.command)
+  }
   let spawnCwd = requestedCwd
   let validationCwd = spawnCwd
 


### PR DESCRIPTION
# fix(daemon): gate agent startup cwd after safe default fallback

## Summary

Launching a recognized agent (e.g. OpenCode) through the daemon PTY path with no explicit workspace `cwd` no longer fails with "Automatic agent startup command … requires a non-root workspace working directory."

## ELI5

Orca can auto-start coding agents in a terminal, and refuses to do so at the filesystem root because that's unsafe. When you don't pass a folder, it's supposed to fall back to your home directory first and *then* check safety — but the background daemon checked safety first, so "no folder" was mistaken for "root" and got rejected.

## Root cause & fix

`createPtySubprocess` called `assertSafeAgentStartupCwd(opts.cwd, …)` *before* applying the `opts.cwd || getDefaultCwd()` fallback. An omitted/`undefined` cwd is treated as root-like, so the guard threw even though the post-fallback default (safe `HOME`/`USERPROFILE`) would pass. The fix computes `requestedCwd = opts.cwd || getDefaultCwd()` first and validates that effective cwd — matching the order the in-process `LocalPtyProvider` already uses. Explicit root (`cwd: '/'`) still rejects agent auto-start.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- `pty-subprocess.test.ts` passes on branch: **Test Files 1 passed, Tests 109 passed**.
- New regression test: *"falls back to the safe default cwd for daemon agent startup without an explicit cwd"*.
- Reverting the fix (`git checkout origin/main -- pty-subprocess.ts`) while keeping the test makes it fail, proving the test captures the bug:

```
1 failed: "falls back to the safe default cwd for daemon agent startup without an explicit cwd"
AssertionError: expected [Function] to not throw an error but
'Error: Automatic agent startup command "opencode" requires a non-root
 workspace working directory.' was thrown
```

- Lint clean: `npx oxlint src/main/daemon/pty-subprocess.ts` → no warnings/errors.
- Rebase clean onto `origin/main`; changed files: `src/main/daemon/pty-subprocess.ts` (fix), `src/main/daemon/pty-subprocess.test.ts` (test).

## Trade-offs

None — pure fix. Omitted-cwd agent startup now succeeds only when the default home is safe; explicit root-like paths still throw and plain shells at root are unchanged.

## Regression risk

Effectively zero. The change only reorders fallback and guard so the daemon path validates the same effective cwd the in-process `LocalPtyProvider` already does; root rejection remains intact and is covered by the retained test. The one flipped test expectation previously encoded the bug itself.

---

*Credit to original author @innocarpe (Wooseong Kim). Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved.*
