### PR TITLE
rename: rebrand user-facing Native chat to Chat UI

### DIFF
--- a/mobile/app/native-chat-settings.tsx
+++ b/mobile/app/native-chat-settings.tsx
@@ -23,7 +23,7 @@ export default function NativeChatSettingsScreen() {
         >
           <ChevronLeft size={22} color={colors.textSecondary} />
         </Pressable>
-        <Text style={styles.heading}>Native chat</Text>
+        <Text style={styles.heading}>Chat UI</Text>
       </View>
 
       <ScrollView
@@ -33,17 +33,17 @@ export default function NativeChatSettingsScreen() {
         <Text style={styles.groupHeading}>DEFAULT VIEW</Text>
         <Text style={styles.groupDescription}>
           Choose how supported agent sessions (Claude, Codex, and other chat-capable agents) open on
-          this device. Terminal shows the raw CLI; native chat shows a chat interface like the
-          desktop app. You can still switch any individual session from its long-press menu.
+          this device. Terminal shows the raw CLI; Chat UI shows a chat interface like the desktop
+          app. You can still switch any individual session from its long-press menu.
         </Text>
         <View style={[styles.section, styles.sectionTopGap]}>
           <View style={styles.row}>
             <View style={styles.rowContent}>
-              <Text style={styles.rowLabel}>Open sessions in native chat</Text>
+              <Text style={styles.rowLabel}>Open sessions in Chat UI</Text>
               <Text style={styles.rowSublabel}>{chatDefault ? 'On' : 'Off'}</Text>
             </View>
             <Switch
-              accessibilityLabel="Open sessions in native chat"
+              accessibilityLabel="Open sessions in Chat UI"
               value={chatDefault}
               onValueChange={(next) => setDefaultView(next ? 'chat' : 'terminal')}
               trackColor={{ false: colors.bgRaised, true: colors.textSecondary }}

--- a/mobile/app/settings.tsx
+++ b/mobile/app/settings.tsx
@@ -120,7 +120,7 @@ export default function SettingsScreen() {
             onPress={() => router.push('/native-chat-settings')}
           >
             <MessageSquare size={16} color={colors.textSecondary} />
-            <Text style={styles.rowLabel}>Native chat</Text>
+            <Text style={styles.rowLabel}>Chat UI</Text>
             <ChevronRight size={16} color={colors.textMuted} />
           </Pressable>
           <View style={styles.separator} />

--- a/mobile/src/onboarding/MobileOnboardingPage.test.ts
+++ b/mobile/src/onboarding/MobileOnboardingPage.test.ts
@@ -71,7 +71,7 @@ describe('MobileOnboardingPage', () => {
   it('renders the session choices and sends exactly one selected view', async () => {
     const callbacks = await renderPage('session-view')
 
-    act(() => button('Open sessions in native chat').props.onPress())
+    act(() => button('Open sessions in Chat UI').props.onPress())
     expect(callbacks.onSessionChoice).toHaveBeenCalledWith('chat')
     expect(callbacks.onNotificationChoice).not.toHaveBeenCalled()
   })

--- a/mobile/src/onboarding/MobileOnboardingPage.tsx
+++ b/mobile/src/onboarding/MobileOnboardingPage.tsx
@@ -51,7 +51,7 @@ export function MobileOnboardingPage({
         </Text>
         <Text style={styles.body}>
           {isSessionView
-            ? 'Choose whether supported agent sessions open in the terminal or native chat on this device. Press and hold a session tab to switch its view, or change the default later in Settings.'
+            ? 'Choose whether supported agent sessions open in the terminal or Chat UI on this device. Press and hold a session tab to switch its view, or change the default later in Settings.'
             : 'Get notified on this device when an agent needs your input or finishes a task.'}
         </Text>
       </View>
@@ -88,8 +88,8 @@ function SessionViewChoices({
   return (
     <>
       <ChoiceButton
-        label="Use native chat"
-        accessibilityLabel="Open sessions in native chat"
+        label="Use Chat UI"
+        accessibilityLabel="Open sessions in Chat UI"
         primary
         busy={busyChoice === 'chat'}
         disabled={disabled}

--- a/src/main/native-chat/transcript-reader.ts
+++ b/src/main/native-chat/transcript-reader.ts
@@ -55,7 +55,7 @@ export async function readNativeChatTranscript(
     if (transcriptAgent === 'grok') {
       return { messages: await readTranscript(filePath, decodeGrokTranscriptLine) }
     }
-    return { error: `Unsupported agent for native chat transcript: ${agent}` }
+    return { error: `Unsupported agent for Chat UI transcript: ${agent}` }
   } catch (err) {
     // Why: ENOENT after a successful resolve is the same first-flush/rotation
     // race as an unresolved path — keep it retry-worthy (#8401).

--- a/src/renderer/src/components/native-chat/use-native-chat-session-option-command.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-option-command.ts
@@ -67,7 +67,7 @@ export function useNativeChatSessionOptionCommand(args: {
         cancelNativeChatPtySends(target.ptyId)
         await waitForNativeChatPtyIdle(target.ptyId)
         if (!mountedRef.current || sendController.signal.aborted) {
-          throw new Error('Native chat command was canceled because the composer closed.')
+          throw new Error('Chat UI command was canceled because the composer closed.')
         }
         const detectClaudeConfirmation =
           options?.detectAgentInteraction === 'claude-model-switch-confirmation'
@@ -80,7 +80,7 @@ export function useNativeChatSessionOptionCommand(args: {
           activeObserversRef.current.add(observer)
           await observer.ready
           if (!mountedRef.current || sendController.signal.aborted) {
-            throw new Error('Native chat command was canceled because the composer closed.')
+            throw new Error('Chat UI command was canceled because the composer closed.')
           }
           // Why: arm only after the observer reaches the live PTY tail, then
           // submit immediately so historical output cannot satisfy the match.

--- a/src/renderer/src/components/settings/ExperimentalPane.test.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.test.tsx
@@ -213,13 +213,13 @@ describe('ExperimentalPane', () => {
     expect(markup).toContain('aria-checked="true"')
   })
 
-  it('shows native chat default-mode as a child setting only when native chat is enabled', async () => {
+  it('shows Chat UI default-mode as a child setting only when Chat UI is enabled', async () => {
     const updateSettings = vi.fn()
     const disabledSettings = getDefaultSettings('/tmp')
     const disabledMarkup = renderToStaticMarkup(
       <ExperimentalPane settings={disabledSettings} updateSettings={vi.fn()} />
     )
-    expect(disabledMarkup).toContain('Native chat')
+    expect(disabledMarkup).toContain('Chat UI')
     expect(disabledMarkup).not.toContain('Default view')
 
     const settings = {
@@ -231,7 +231,7 @@ describe('ExperimentalPane', () => {
 
     expect(container.textContent).toContain('Default view')
     expect(container.textContent).toContain('Terminal chat')
-    expect(container.textContent).toContain('Native chat')
+    expect(container.textContent).toContain('Chat UI')
     expect(
       container
         .querySelector('[data-slot="native-chat-default-view-select"]')
@@ -242,7 +242,7 @@ describe('ExperimentalPane', () => {
       container.querySelectorAll<HTMLButtonElement>('[data-slot="select-item"]')
     ).find((button) => button.getAttribute('data-value') === 'native-chat')
     if (!nativeChatOption) {
-      throw new Error('Native chat default-view option was not rendered')
+      throw new Error('Chat UI default-view option was not rendered')
     }
 
     await act(async () => {

--- a/src/renderer/src/components/settings/NativeChatExperimentalSetting.tsx
+++ b/src/renderer/src/components/settings/NativeChatExperimentalSetting.tsx
@@ -23,7 +23,7 @@ export function NativeChatExperimentalSetting({
 
   return (
     <SearchableSetting
-      title={translate('auto.components.settings.ExperimentalPane.nativeChat.title', 'Native chat')}
+      title={translate('auto.components.settings.ExperimentalPane.nativeChat.title', 'Chat UI')}
       description={translate(
         'auto.components.settings.ExperimentalPane.nativeChat.description',
         'Preview the desktop chat surface for supported agent terminal sessions.'
@@ -35,12 +35,12 @@ export function NativeChatExperimentalSetting({
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0 shrink space-y-0.5">
           <Label>
-            {translate('auto.components.settings.ExperimentalPane.nativeChat.title', 'Native chat')}
+            {translate('auto.components.settings.ExperimentalPane.nativeChat.title', 'Chat UI')}
           </Label>
           <p className="text-xs text-muted-foreground">
             {translate(
               'auto.components.settings.ExperimentalPane.nativeChat.copy',
-              'Adds a native chat view you can switch to from supported agent terminal panes. Experimental while we tune transcript fidelity, streaming, and terminal parity.'
+              'Adds a Chat UI view you can switch to from supported agent terminal panes. Experimental while we tune transcript fidelity, streaming, and terminal parity.'
             )}
           </p>
         </div>
@@ -48,7 +48,7 @@ export function NativeChatExperimentalSetting({
           checked={nativeChatEnabled}
           ariaLabel={translate(
             'auto.components.settings.ExperimentalPane.nativeChat.toggleLabel',
-            'Toggle native chat'
+            'Toggle Chat UI'
           )}
           onChange={() =>
             updateSettings({
@@ -85,7 +85,7 @@ export function NativeChatExperimentalSetting({
               <SelectTrigger
                 aria-label={translate(
                   'auto.components.settings.ExperimentalPane.nativeChat.defaultViewLabel',
-                  'Default native chat view'
+                  'Default Chat UI view'
                 )}
                 className="w-36"
                 size="sm"
@@ -102,7 +102,7 @@ export function NativeChatExperimentalSetting({
                 <SelectItem value="native-chat">
                   {translate(
                     'auto.components.settings.ExperimentalPane.nativeChat.defaultViewNative',
-                    'Native chat'
+                    'Chat UI'
                   )}
                 </SelectItem>
               </SelectContent>

--- a/src/renderer/src/components/settings/experimental-search.ts
+++ b/src/renderer/src/components/settings/experimental-search.ts
@@ -249,7 +249,7 @@ export function getExperimentalSearchEntry() {
       )
     ),
     nativeChat: findEntry(
-      translate('auto.components.settings.experimental.search.nativeChat.title', 'Native chat')
+      translate('auto.components.settings.experimental.search.nativeChat.title', 'Chat UI')
     ),
     terminalAttention: findEntry(
       translate('auto.components.settings.experimental.search.9e4ddf776d', 'Terminal attention')

--- a/src/renderer/src/components/settings/native-chat-experimental-search-entry.ts
+++ b/src/renderer/src/components/settings/native-chat-experimental-search-entry.ts
@@ -4,10 +4,7 @@ import { translateSearchKeyword } from './settings-search-keywords'
 
 export function getNativeChatExperimentalSearchEntry(): SettingsSearchEntry {
   return {
-    title: translate(
-      'auto.components.settings.experimental.search.nativeChat.title',
-      'Native chat'
-    ),
+    title: translate('auto.components.settings.experimental.search.nativeChat.title', 'Chat UI'),
     description: translate(
       'auto.components.settings.experimental.search.nativeChat.description',
       'Preview the desktop chat surface for supported agent terminal sessions.'

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5513,15 +5513,15 @@
           "dd6f0a1d45": "Pet",
           "0e89a574ae": "Floating animated pet in the bottom-right corner.",
           "nativeChat": {
-            "title": "Native chat",
+            "title": "Chat UI",
             "description": "Preview the desktop chat surface for supported agent terminal sessions.",
-            "copy": "Adds a native chat view you can switch to from supported agent terminal panes. Experimental while we tune transcript fidelity, streaming, and terminal parity.",
-            "toggleLabel": "Toggle native chat",
+            "copy": "Adds a Chat UI view you can switch to from supported agent terminal panes. Experimental while we tune transcript fidelity, streaming, and terminal parity.",
+            "toggleLabel": "Toggle Chat UI",
             "defaultTitle": "Default view",
             "defaultCopy": "Choose how new supported agent terminal tabs open.",
-            "defaultViewLabel": "Default native chat view",
+            "defaultViewLabel": "Default Chat UI view",
             "defaultViewTerminal": "Terminal chat",
-            "defaultViewNative": "Native chat"
+            "defaultViewNative": "Chat UI"
           },
           "agentDashboard": {
             "title": "Agent Dashboard",
@@ -7738,7 +7738,7 @@
             "6b5a56ac35": "Floating animated pet in the bottom-right corner.",
             "87d99e634b": "Pet",
             "nativeChat": {
-              "title": "Native chat",
+              "title": "Chat UI",
               "description": "Preview the desktop chat surface for supported agent terminal sessions.",
               "grok": "grok"
             },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5474,15 +5474,15 @@
             "toggleLabel": "Alternar nuevo estilo de tarjeta"
           },
           "nativeChat": {
-            "title": "Chat nativo",
+            "title": "Chat UI",
             "description": "Previsualiza la interfaz de chat de escritorio para sesiones de terminal de agentes compatibles.",
-            "copy": "Añade una vista de chat nativo a la que puedes cambiar desde paneles de terminal de agentes compatibles. Es experimental mientras ajustamos la fidelidad de las transcripciones, la transmisión y la paridad con el terminal.",
-            "toggleLabel": "Alternar chat nativo",
+            "copy": "Añade una vista de Chat UI a la que puedes cambiar desde paneles de terminal de agentes compatibles. Es experimental mientras ajustamos la fidelidad de las transcripciones, la transmisión y la paridad con el terminal.",
+            "toggleLabel": "Alternar Chat UI",
             "defaultTitle": "Vista predeterminada",
             "defaultCopy": "Elige cómo se abren las nuevas pestañas de terminal de agentes compatibles.",
-            "defaultViewLabel": "Vista predeterminada de chat nativo",
+            "defaultViewLabel": "Vista predeterminada de Chat UI",
             "defaultViewTerminal": "Chat en terminal",
-            "defaultViewNative": "Chat nativo"
+            "defaultViewNative": "Chat UI"
           },
           "agentDashboard": {
             "title": "Agent Dashboard",
@@ -7662,7 +7662,7 @@
               "worktrees": "worktrees"
             },
             "nativeChat": {
-              "title": "Chat nativo",
+              "title": "Chat UI",
               "description": "Previsualiza la interfaz de chat de escritorio para sesiones de terminal de agentes compatibles.",
               "grok": "grok"
             },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5459,15 +5459,15 @@
             "toggleLabel": "新しいカードスタイルを切り替え"
           },
           "nativeChat": {
-            "title": "ネイティブチャット",
+            "title": "Chat UI",
             "description": "対応エージェントのターミナルセッション用デスクトップチャット画面をプレビューします。",
-            "copy": "対応エージェントのターミナルペインから切り替えられるネイティブチャットビューを追加します。トランスクリプトの忠実度、ストリーミング、ターミナルとの同等性を調整しているため、試験運用中です。",
-            "toggleLabel": "ネイティブチャットの切り替え",
+            "copy": "対応エージェントのターミナルペインから切り替えられる Chat UI ビューを追加します。トランスクリプトの忠実度、ストリーミング、ターミナルとの同等性を調整しているため、試験運用中です。",
+            "toggleLabel": "Chat UI の切り替え",
             "defaultTitle": "デフォルトのビュー",
             "defaultCopy": "対応エージェントの新しいターミナルタブを開く方法を選択します。",
-            "defaultViewLabel": "デフォルトのネイティブ チャット ビュー",
+            "defaultViewLabel": "デフォルトの Chat UI ビュー",
             "defaultViewTerminal": "Terminal チャット",
-            "defaultViewNative": "ネイティブチャット"
+            "defaultViewNative": "Chat UI"
           },
           "agentDashboard": {
             "title": "Agent Dashboard",
@@ -7684,7 +7684,7 @@
               "worktrees": "worktrees"
             },
             "nativeChat": {
-              "title": "ネイティブチャット",
+              "title": "Chat UI",
               "description": "対応エージェントのターミナルセッション用デスクトップチャット画面をプレビューします。",
               "grok": "grok"
             },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5459,15 +5459,15 @@
             "toggleLabel": "새 카드 스타일 전환"
           },
           "nativeChat": {
-            "title": "네이티브 채팅",
+            "title": "Chat UI",
             "description": "지원되는 에이전트 터미널 세션의 데스크톱 채팅 화면을 미리 봅니다.",
-            "copy": "지원되는 에이전트 터미널 창에서 전환할 수 있는 네이티브 채팅 보기를 추가합니다. 대화 기록 충실도, 스트리밍, 터미널 동작 일치를 조정하는 동안 실험적으로 제공됩니다.",
-            "toggleLabel": "기본 채팅 전환",
+            "copy": "지원되는 에이전트 터미널 창에서 전환할 수 있는 Chat UI 보기를 추가합니다. 대화 기록 충실도, 스트리밍, 터미널 동작 일치를 조정하는 동안 실험적으로 제공됩니다.",
+            "toggleLabel": "Chat UI 전환",
             "defaultTitle": "기본 보기",
             "defaultCopy": "지원되는 에이전트의 새 터미널 탭을 여는 방식을 선택합니다.",
-            "defaultViewLabel": "기본 기본 채팅 보기",
+            "defaultViewLabel": "기본 Chat UI 보기",
             "defaultViewTerminal": "Terminal 채팅",
-            "defaultViewNative": "네이티브 채팅"
+            "defaultViewNative": "Chat UI"
           },
           "agentDashboard": {
             "title": "Agent Dashboard",
@@ -7647,7 +7647,7 @@
               "worktrees": "worktrees"
             },
             "nativeChat": {
-              "title": "네이티브 채팅",
+              "title": "Chat UI",
               "description": "지원되는 에이전트 터미널 세션의 데스크톱 채팅 화면을 미리 봅니다.",
               "grok": "grok"
             },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5459,15 +5459,15 @@
             "toggleLabel": "切换新卡片样式"
           },
           "nativeChat": {
-            "title": "原生聊天",
+            "title": "Chat UI",
             "description": "预览受支持的智能体终端会话的桌面聊天界面。",
-            "copy": "添加可从受支持的智能体终端窗格切换的原生聊天视图。在我们调整记录保真度、流式传输和终端一致性期间，此功能仍处于实验阶段。",
-            "toggleLabel": "切换原生聊天",
+            "copy": "添加可从受支持的智能体终端窗格切换的 Chat UI 视图。在我们调整记录保真度、流式传输和终端一致性期间，此功能仍处于实验阶段。",
+            "toggleLabel": "切换 Chat UI",
             "defaultTitle": "默认视图",
             "defaultCopy": "选择如何打开受支持智能体的新终端标签页。",
-            "defaultViewLabel": "默认原生聊天视图",
+            "defaultViewLabel": "默认 Chat UI 视图",
             "defaultViewTerminal": "终端聊天",
-            "defaultViewNative": "原生聊天"
+            "defaultViewNative": "Chat UI"
           },
           "agentDashboard": {
             "title": "Agent Dashboard",
@@ -7647,7 +7647,7 @@
               "worktrees": "工作树"
             },
             "nativeChat": {
-              "title": "原生聊天",
+              "title": "Chat UI",
               "description": "预览受支持的智能体终端会话的桌面聊天界面。",
               "grok": "grok"
             },


### PR DESCRIPTION
## Summary

Users now see **Chat UI** instead of “Native chat” everywhere the feature is named: desktop Experimental settings, settings search, mobile settings/onboarding, and a few user-visible error strings.

Internal identifiers (`nativeChat`, IPC/RPC, file paths) are unchanged so this is a pure product-name rename with no API or storage migration.

### Surfaces updated
- Desktop experimental toggle, default-view picker, and search entry (en + zh/ja/ko/es)
- Mobile Settings row, Chat UI settings screen, and session-view onboarding choice
- Toast/error copy that could surface the old product name

## Test plan
- [x] `native-chat-locales.test.ts` — localized copy still differs from English where required
- [x] `ExperimentalPane.test.tsx` — settings UI asserts “Chat UI”
- [x] `transcript-reader.test.ts`
- [ ] Spot-check Experimental → Chat UI label in EN + one non-EN locale
- [ ] Spot-check mobile Settings + onboarding copy

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Grok](https://img.shields.io/badge/Grok_4.5-000000)
