### PR TITLE
fix(startup): mirror startup diagnostics to a file, tag pid

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -110,6 +110,7 @@ import {
 import { startEventLoopStallProbe } from './startup/event-loop-stall-probe'
 import { startMainThreadChurnProbe } from './diagnostics/main-thread-churn-probe'
 import {
+  configureStartupDiagnosticsLogFile,
   isStartupDiagnosticsEnabled,
   logStartupDiagnostic,
   logStartupMilestone
@@ -472,7 +473,12 @@ const TRAY_CREATE_FALLBACK_MS = 12_000
 
 const startupDiagnosticsEnabled = isStartupDiagnosticsEnabled()
 if (startupDiagnosticsEnabled) {
+  // Why: stderr redirection alone can't be captured for a packaged Windows
+  // GUI-subsystem exe launched normally (double-click, Start Menu) — mirror
+  // to a file so a user can reproduce the issue without a console.
+  configureStartupDiagnosticsLogFile(join(app.getPath('userData'), 'startup-diagnostics.log'))
   logStartupDiagnostic('before-single-instance-lock', {
+    pid: process.pid,
     version: app.getVersion(),
     packaged: app.isPackaged,
     platform: process.platform,
@@ -601,6 +607,7 @@ const hasSingleInstanceLock = skipSingleInstanceLock
     : acquireSingleInstanceLock(app, requestDesktopActivation)
 if (startupDiagnosticsEnabled) {
   logStartupDiagnostic('single-instance-lock-result', {
+    pid: process.pid,
     acquired: hasSingleInstanceLock,
     bypassed: bypassSingleInstanceLock,
     skippedForDev: skipSingleInstanceLock

--- a/src/main/startup/startup-diagnostics.ts
+++ b/src/main/startup/startup-diagnostics.ts
@@ -1,17 +1,35 @@
-import { writeSync } from 'node:fs'
+import { appendFileSync, writeSync } from 'node:fs'
 
 export const STARTUP_DIAGNOSTICS_ENV = 'ORCA_STARTUP_DIAGNOSTICS'
 
 export type StartupDiagnosticSink = (fd: number, text: string) => unknown
 
+let diagnosticsLogFilePath: string | undefined
+
+// Why: a packaged Windows GUI-subsystem exe launched without an inherited
+// console (double-click, Start Menu) has no reliable stderr to redirect, so
+// fd-2 writes alone are not capturable. A file sink lets a user reproduce a
+// startup issue normally and hand back the log afterward.
+export function configureStartupDiagnosticsLogFile(path: string | undefined): void {
+  diagnosticsLogFilePath = path
+}
+
 export function writeStartupDiagnosticLine(
   message: string,
   write: StartupDiagnosticSink = writeSync
 ): void {
+  const line = message.endsWith('\n') ? message : `${message}\n`
   try {
-    write(2, message.endsWith('\n') ? message : `${message}\n`)
+    write(2, line)
   } catch {
     console.error(message)
+  }
+  if (diagnosticsLogFilePath) {
+    try {
+      appendFileSync(diagnosticsLogFilePath, line)
+    } catch {
+      // Best-effort: never let log-file capture block startup.
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add a file sink for startup diagnostics (`configureStartupDiagnosticsLogFile`) alongside the existing stderr write — a packaged Windows GUI-subsystem exe launched without an inherited console (double-click, Start Menu) has no reliable stderr to redirect, which was blocking diagnosis of a Windows duplicate-instance report.
- Tag `pid` on the `before-single-instance-lock` and `single-instance-lock-result` diagnostic events so concurrent instances are distinguishable in the shared log file.

## Test plan
- [x] `tsc --noEmit -p config/tsconfig.node.json`
- [x] `vitest run src/main/startup/startup-diagnostics.test.ts src/main/startup/single-instance-lock.test.ts`