### PR TITLE
Inline release-cut workflow inputs summary for security

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -68,9 +68,26 @@ jobs:
       should_release: ${{ steps.tag.outputs.tag != '' || steps.version.outputs.recovered_tag != '' }}
       latest_published_rc_tag: ${{ steps.publish_drafts.outputs.latest_published_tag }}
     steps:
-      # Surfaces workflow_dispatch inputs as a table in the job summary
-      # (kind, ref, dry_run, version_suffix) so runs are easy to audit.
-      - uses: m-s-abeer/update-gha-summary-with-workflow-inputs@v1
+      # Why inlined instead of a third-party action: this job runs with
+      # contents:write and secret scope, so avoid executing any external
+      # (mutable-@v1-tag, retaggable) action here — pinning a SHA only blocks
+      # retagging, not a compromised pinned commit. Surfaces every
+      # workflow_dispatch input (kind, ref, dry_run, version_suffix, plus any
+      # added later) as a table so runs are easy to audit. The whole inputs
+      # object is passed as JSON via env and parsed by jq as data — never
+      # interpolated into the script — to avoid shell injection from
+      # dispatch-controlled values.
+      - name: Summarize workflow inputs
+        env:
+          INPUTS_JSON: ${{ toJSON(inputs) }}
+        run: |
+          {
+            echo "## Workflow inputs"
+            echo ""
+            echo "| Input | Value |"
+            echo "| --- | --- |"
+            jq -r '(. // {}) | to_entries[] | "| \(.key) | `\(.value)` |"' <<<"$INPUTS_JSON"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Checkout ref
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Removes a third-party GitHub Action from the release-cut workflow and replaces it with an inlined bash script that safely parses and displays workflow dispatch inputs.

The release-cut job runs with `contents:write` and `secrets` scope, making it a high-value target. The original implementation executed an external mutable action (`@v1` tag), which carries retagging and compromise risks. Even SHA-pinning only blocks retagging, not compromised commits. The new implementation avoids external execution entirely and uses safe JSON parsing.

## Implementation

Replaces `m-s-abeer/update-gha-summary-with-workflow-inputs@v1` with an inlined script that:
- Takes `inputs` as JSON via environment variable (never interpolated)
- Parses safely with `jq` to generate a markdown table
- Outputs to `$GITHUB_STEP_SUMMARY` for audit visibility
- Handles all dispatch inputs automatically, including any added in the future

Prevents shell injection from dispatch-controlled values by keeping them as data throughout.

## Screenshots

No visual change. Workflow job summary output format is unchanged.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Release-cut workflow runs and produces correct inputs table in job summary

## Security Audit

**Threat**: Executing mutable external actions in a high-privilege job (contents:write, secrets scope) creates supply-chain risk. Pinning to SHA only blocks retagging, not a compromised commit.

**Fix**: Eliminated external action execution. The replacement script uses environment-based JSON input (via `toJSON(inputs)`) and `jq` for safe parsing — dispatch values are never shell-interpolated, preventing injection attacks.

**Coverage**: Input validation is data-driven (jq parses JSON), no command execution, no secret handling beyond pass-through display.

## Notes

This change strengthens the security posture of the release workflow without changing its behavior. The inputs table is produced identically to before, but now entirely within the job context with no external dependencies.