### PR TITLE
fix(linear): union filter options across every selected team

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -8618,7 +8618,8 @@ export default function TaskPage(): React.JSX.Element {
                             workspaceId={selectedLinearWorkspaceId ?? null}
                             isAllWorkspaces={selectedLinearWorkspaceId === 'all'}
                             primaryTeam={linearAttributePrimaryTeam}
-                            selectedTeamCount={linearTeamSelection.size}
+                            selectedTeamIds={[...linearTeamSelection]}
+                            availableTeams={linearTeamOptions}
                             settings={linearTaskSourceContext ?? settings}
                           />
                         ) : null}

--- a/src/renderer/src/components/linear-issue-attribute-filter-dropdowns.tsx
+++ b/src/renderer/src/components/linear-issue-attribute-filter-dropdowns.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { ListFilter, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { useTeamLabels, useTeamMembers, useTeamStates } from '@/hooks/useIssueMetadata'
+import { useTeamsLabels, useTeamsMembers, useTeamsStates } from '@/hooks/useIssueMetadata'
 import type { RuntimeLinearSettings } from '@/runtime/runtime-linear-client'
 import { translate } from '@/i18n/i18n'
 import {
@@ -21,6 +21,7 @@ import {
   linearIssueAttributeFilterPillLabels,
   type LinearIssueFilterSectionKey
 } from './linear-issue-attribute-filter-sections'
+import { resolveLinearIssueAttributeFilterTeamIds } from './linear-issue-attribute-filter-team-ids'
 
 type Props = {
   value: LinearIssueAttributeFilter
@@ -28,7 +29,9 @@ type Props = {
   workspaceId: string | null
   isAllWorkspaces: boolean
   primaryTeam: LinearTeam | null
-  selectedTeamCount: number
+  /** Selected Linear team ids (All teams / multi-select). Empty → primary fallback. */
+  selectedTeamIds: readonly string[]
+  availableTeams: readonly LinearTeam[]
   settings?: RuntimeLinearSettings
 }
 
@@ -67,25 +70,37 @@ export default function LinearIssueAttributeFilterDropdowns({
   workspaceId,
   isAllWorkspaces,
   primaryTeam,
-  selectedTeamCount,
+  selectedTeamIds,
+  availableTeams,
   settings
 }: Props): React.JSX.Element {
   const [popoverOpen, setPopoverOpen] = useState(false)
   const [openSection, setOpenSection] = useState<LinearIssueFilterSectionKey | null>(null)
 
-  const activeTeamId = popoverOpen && !isAllWorkspaces ? (primaryTeam?.id ?? null) : null
+  const activeTeamIds = useMemo(() => {
+    if (!popoverOpen || isAllWorkspaces) {
+      return [] as string[]
+    }
+    return resolveLinearIssueAttributeFilterTeamIds({
+      selectedTeamIds,
+      availableTeams,
+      primaryTeamId: primaryTeam?.id ?? null
+    })
+  }, [popoverOpen, isAllWorkspaces, selectedTeamIds, availableTeams, primaryTeam?.id])
+
   const concreteWorkspaceId =
     popoverOpen && !isAllWorkspaces && workspaceId && workspaceId !== 'all' ? workspaceId : null
 
-  const states = useTeamStates(activeTeamId, settings, concreteWorkspaceId)
-  const labels = useTeamLabels(activeTeamId, settings, concreteWorkspaceId)
-  const members = useTeamMembers(activeTeamId, settings, concreteWorkspaceId)
+  // Why: multi-team / All teams must union filter options across every selected team (#8739).
+  const states = useTeamsStates(activeTeamIds, settings, concreteWorkspaceId)
+  const labels = useTeamsLabels(activeTeamIds, settings, concreteWorkspaceId)
+  const members = useTeamsMembers(activeTeamIds, settings, concreteWorkspaceId)
 
-  // Why: prune only after a successful non-empty metadata load for the same team;
+  // Why: prune only after a successful non-empty metadata load for the same team set;
   // loading/error/empty-before-load must never clear active selections (R12).
   const pruneTeamKeyRef = useRef<string | null>(null)
   useEffect(() => {
-    if (!activeTeamId || !concreteWorkspaceId) {
+    if (activeTeamIds.length === 0 || !concreteWorkspaceId) {
       return
     }
     if (states.loading || labels.loading || members.loading) {
@@ -97,7 +112,7 @@ export default function LinearIssueAttributeFilterDropdowns({
     if (states.data.length === 0 && labels.data.length === 0 && members.data.length === 0) {
       return
     }
-    const pruneKey = `${concreteWorkspaceId}::${activeTeamId}`
+    const pruneKey = `${concreteWorkspaceId}::${activeTeamIds.join(',')}`
     if (pruneTeamKeyRef.current === pruneKey) {
       return
     }
@@ -118,7 +133,7 @@ export default function LinearIssueAttributeFilterDropdowns({
       onChange(canonicalNext)
     }
   }, [
-    activeTeamId,
+    activeTeamIds,
     concreteWorkspaceId,
     states.loading,
     states.error,
@@ -231,15 +246,6 @@ export default function LinearIssueAttributeFilterDropdowns({
             </div>
           ) : (
             <>
-              {selectedTeamCount > 1 && primaryTeam ? (
-                <p className="border-b border-border/50 px-3 py-1.5 text-[11px] text-muted-foreground">
-                  {translate(
-                    'auto.components.linear-issue-attribute-filter-dropdowns.optionsFromTeam',
-                    'Options from {{team}}',
-                    { team: primaryTeam.name }
-                  )}
-                </p>
-              ) : null}
               {openSection ? (
                 <LinearIssueFilterSectionDetail
                   section={openSection}

--- a/src/renderer/src/components/linear-issue-attribute-filter-team-ids.test.ts
+++ b/src/renderer/src/components/linear-issue-attribute-filter-team-ids.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import type { LinearTeam } from '../../../shared/types'
+import {
+  resolveLinearIssueAttributeFilterTeamIds,
+  unionLinearMetadataById
+} from './linear-issue-attribute-filter-team-ids'
+
+const teams: LinearTeam[] = [
+  { id: 'team-be', name: 'Backend', key: 'BE' },
+  { id: 'team-fe', name: 'Frontend', key: 'FE' },
+  { id: 'team-ops', name: 'Ops', key: 'OPS' }
+]
+
+describe('resolveLinearIssueAttributeFilterTeamIds', () => {
+  it('returns every selected team in stable name order', () => {
+    expect(
+      resolveLinearIssueAttributeFilterTeamIds({
+        selectedTeamIds: ['team-fe', 'team-be'],
+        availableTeams: teams,
+        primaryTeamId: 'team-be'
+      })
+    ).toEqual(['team-be', 'team-fe'])
+  })
+
+  it('returns all selected teams when All teams is selected', () => {
+    expect(
+      resolveLinearIssueAttributeFilterTeamIds({
+        selectedTeamIds: ['team-ops', 'team-be', 'team-fe'],
+        availableTeams: teams,
+        primaryTeamId: 'team-be'
+      })
+    ).toEqual(['team-be', 'team-fe', 'team-ops'])
+  })
+
+  it('falls back to primary when selection is empty', () => {
+    expect(
+      resolveLinearIssueAttributeFilterTeamIds({
+        selectedTeamIds: [],
+        availableTeams: teams,
+        primaryTeamId: 'team-fe'
+      })
+    ).toEqual(['team-fe'])
+  })
+
+  it('drops ids that are not in availableTeams', () => {
+    expect(
+      resolveLinearIssueAttributeFilterTeamIds({
+        selectedTeamIds: ['team-fe', 'missing'],
+        availableTeams: teams,
+        primaryTeamId: 'team-be'
+      })
+    ).toEqual(['team-fe'])
+  })
+})
+
+describe('unionLinearMetadataById', () => {
+  it('unions options across teams without dropping later teams (#8739)', () => {
+    const unioned = unionLinearMetadataById([
+      [
+        { id: 'be-todo', name: 'Todo' },
+        { id: 'be-done', name: 'Done' }
+      ],
+      [
+        { id: 'fe-todo', name: 'Todo' },
+        { id: 'fe-review', name: 'In Review' }
+      ],
+      [{ id: 'ops-blocked', name: 'Blocked' }]
+    ])
+    expect(unioned.map((row) => row.id)).toEqual([
+      'be-todo',
+      'be-done',
+      'fe-todo',
+      'fe-review',
+      'ops-blocked'
+    ])
+  })
+
+  it('dedupes shared ids keeping the first label', () => {
+    const unioned = unionLinearMetadataById([
+      [{ id: 'shared', name: 'From BE' }],
+      [{ id: 'shared', name: 'From FE' }]
+    ])
+    expect(unioned).toEqual([{ id: 'shared', name: 'From BE' }])
+  })
+})

--- a/src/renderer/src/components/linear-issue-attribute-filter-team-ids.ts
+++ b/src/renderer/src/components/linear-issue-attribute-filter-team-ids.ts
@@ -1,0 +1,49 @@
+import type { LinearTeam } from '../../../shared/types'
+
+/**
+ * Resolve which Linear team ids should feed attribute-filter metadata.
+ * Empty selection falls back to the same primary-team default as before;
+ * non-empty selection returns every selected team (sorted for stable loads).
+ */
+export function resolveLinearIssueAttributeFilterTeamIds(options: {
+  selectedTeamIds: readonly string[]
+  availableTeams: readonly LinearTeam[]
+  primaryTeamId: string | null
+}): string[] {
+  const { selectedTeamIds, availableTeams, primaryTeamId } = options
+  const availableIds = new Set(availableTeams.map((team) => team.id))
+  const selected = selectedTeamIds.filter((id) => availableIds.has(id))
+  if (selected.length > 0) {
+    // Stable order: name/id of available teams, not click order — matches primary-team sort.
+    const byId = new Map(availableTeams.map((team) => [team.id, team] as const))
+    return [...selected].sort((a, b) => {
+      const teamA = byId.get(a)
+      const teamB = byId.get(b)
+      const nameCmp = (teamA?.name ?? a).localeCompare(teamB?.name ?? b)
+      if (nameCmp !== 0) {
+        return nameCmp
+      }
+      return a.localeCompare(b)
+    })
+  }
+  if (primaryTeamId && availableIds.has(primaryTeamId)) {
+    return [primaryTeamId]
+  }
+  return []
+}
+
+/** Deduplicate metadata rows by id, preserving first-seen order. */
+export function unionLinearMetadataById<T extends { id: string }>(groups: readonly T[][]): T[] {
+  const seen = new Set<string>()
+  const out: T[] = []
+  for (const group of groups) {
+    for (const item of group) {
+      if (seen.has(item.id)) {
+        continue
+      }
+      seen.add(item.id)
+      out.push(item)
+    }
+  }
+  return out
+}

--- a/src/renderer/src/hooks/useIssueMetadata.test.tsx
+++ b/src/renderer/src/hooks/useIssueMetadata.test.tsx
@@ -7,7 +7,8 @@ import {
   clearLinearMetadataCache,
   useTeamLabels,
   useTeamMembers,
-  useTeamStates
+  useTeamStates,
+  useTeamsStates
 } from './useIssueMetadata'
 
 const linearMocks = vi.hoisted(() => ({
@@ -149,5 +150,46 @@ describe('useIssueMetadata Linear hooks', () => {
     expect(error).toBe('Could not connect')
     expect(linearMocks.linearTeamMembers).toHaveBeenCalledTimes(1)
     expect(renders).toBeLessThanOrEqual(4)
+  })
+
+  it('unions workflow states across every selected team (#8739)', async () => {
+    let states: { id: string; name: string }[] = []
+    linearMocks.linearTeamStates.mockImplementation(async (_settings, teamId: string) => {
+      if (teamId === 'team-be') {
+        return [
+          { id: 'be-todo', name: 'Todo' },
+          { id: 'be-done', name: 'Done' }
+        ]
+      }
+      if (teamId === 'team-fe') {
+        return [
+          { id: 'fe-todo', name: 'Todo' },
+          { id: 'fe-review', name: 'In Review' }
+        ]
+      }
+      return []
+    })
+
+    function MultiProbe(): null {
+      const metadata = useTeamsStates(
+        ['team-fe', 'team-be'],
+        { activeRuntimeEnvironmentId: null },
+        'ws-1'
+      )
+      states = metadata.data as { id: string; name: string }[]
+      return null
+    }
+
+    renderProbe(<MultiProbe />)
+    await flushEffects()
+    await flushEffects()
+
+    expect(linearMocks.linearTeamStates).toHaveBeenCalledTimes(2)
+    expect(states.map((s) => s.id).sort()).toEqual([
+      'be-done',
+      'be-todo',
+      'fe-review',
+      'fe-todo'
+    ])
   })
 })

--- a/src/renderer/src/hooks/useIssueMetadata.ts
+++ b/src/renderer/src/hooks/useIssueMetadata.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: repo metadata hooks share TTL caches and
 Linear/GitHub cache invalidation entrypoints used by the issue dialog. */
 /* oxlint-disable react-doctor/no-adjust-state-on-prop-change -- Why: issue metadata hooks clear stale rows and track loading while async provider cache requests are in flight. */
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import {
   linearTeamLabels,
@@ -16,11 +16,13 @@ import type {
   LinearMember
 } from '../../../shared/types'
 import { getTaskSourceRuntimeSettings } from '../../../shared/task-source-context'
+import { unionLinearMetadataById } from '../components/linear-issue-attribute-filter-team-ids'
 import {
   clearMetadataRequestStore,
   createMetadataRequestStore,
   getFreshMetadata,
-  loadMetadata
+  loadMetadata,
+  type MetadataRequestStore
 } from './metadata-request-cache'
 
 type MetadataState<T> = {
@@ -417,6 +419,184 @@ export function useTeamMembers(
   }, [cacheKey, teamId, workspaceId])
 
   return state
+}
+
+/**
+ * Load Linear team metadata for every selected team and union by id (#8739).
+ * Reuses the same per-team cache stores as the single-team hooks.
+ */
+function useTeamsMetadataList<T extends { id: string }>(
+  teamIds: readonly string[],
+  settings: RuntimeLinearSettings | undefined,
+  workspaceId: string | null | undefined,
+  store: MetadataRequestStore<T[]>,
+  loadTeam: (
+    settings: RuntimeLinearSettings | undefined,
+    teamId: string,
+    workspaceId: string | null | undefined
+  ) => Promise<T[]>,
+  errorFallback: string
+): MetadataState<T[]> {
+  const [state, setState] = useState<MetadataState<T[]>>({
+    data: [],
+    loading: false,
+    error: null
+  })
+  const activeKeyRef = useRef<string | null>(null)
+  const settingsRef = useRef(settings)
+  settingsRef.current = settings
+
+  // Why: parents often pass a fresh teamIds array each render; key on joined ids.
+  const teamIdsKey = teamIds.filter((id) => id.trim().length > 0).join('\0')
+  const stableTeamIds = useMemo(
+    () => [...new Set(teamIdsKey.length === 0 ? [] : teamIdsKey.split('\0'))],
+    [teamIdsKey]
+  )
+
+  // Why: recompute each render (like useTeamStates cacheKey) so runtime target changes re-key.
+  const requestKey =
+    stableTeamIds.length === 0
+      ? null
+      : stableTeamIds
+          .map((teamId) => linearMetadataCacheKey(teamId, settings, workspaceId))
+          .join('|')
+
+  useEffect(() => {
+    if (!requestKey || stableTeamIds.length === 0) {
+      activeKeyRef.current = null
+      setState({ data: [], loading: false, error: null })
+      return
+    }
+
+    activeKeyRef.current = requestKey
+    const capturedKey = requestKey
+    const teams = stableTeamIds
+
+    // Fast path: every team still fresh in cache → union synchronously.
+    const cachedGroups: T[][] = []
+    let allCached = true
+    for (const teamId of teams) {
+      const cacheKey = linearMetadataCacheKey(teamId, settingsRef.current, workspaceId)
+      const cached = getFreshMetadata(store, cacheKey)
+      if (!cached) {
+        allCached = false
+        break
+      }
+      cachedGroups.push(cached.data)
+    }
+    if (allCached) {
+      setState({ data: unionLinearMetadataById(cachedGroups), loading: false, error: null })
+      return
+    }
+
+    setState((s) => ({
+      ...s,
+      data: s.data.length ? ([] as typeof s.data) : s.data,
+      loading: true,
+      error: null
+    }))
+
+    void Promise.all(
+      teams.map((teamId) => {
+        const cacheKey = linearMetadataCacheKey(teamId, settingsRef.current, workspaceId)
+        return loadMetadata(store, cacheKey, () =>
+          loadTeam(settingsRef.current, teamId, workspaceId)
+        )
+      })
+    )
+      .then((groups) => {
+        if (activeKeyRef.current !== capturedKey) {
+          return
+        }
+        setState({
+          data: unionLinearMetadataById(groups),
+          loading: false,
+          error: null
+        })
+      })
+      .catch((err) => {
+        if (activeKeyRef.current !== capturedKey) {
+          return
+        }
+        activeKeyRef.current = null
+        setState((s) => ({
+          ...s,
+          loading: false,
+          error: err instanceof Error ? err.message : errorFallback
+        }))
+      })
+  }, [requestKey, stableTeamIds, workspaceId, store, loadTeam, errorFallback])
+
+  return state
+}
+
+const loadTeamStates = (
+  settings: RuntimeLinearSettings | undefined,
+  teamId: string,
+  workspaceId: string | null | undefined
+): Promise<LinearWorkflowState[]> =>
+  linearTeamStates(settings, teamId, workspaceId).then((states) => states as LinearWorkflowState[])
+
+const loadTeamLabels = (
+  settings: RuntimeLinearSettings | undefined,
+  teamId: string,
+  workspaceId: string | null | undefined
+): Promise<LinearLabel[]> =>
+  linearTeamLabels(settings, teamId, workspaceId).then((labels) => labels as LinearLabel[])
+
+const loadTeamMembers = (
+  settings: RuntimeLinearSettings | undefined,
+  teamId: string,
+  workspaceId: string | null | undefined
+): Promise<LinearMember[]> =>
+  linearTeamMembers(settings, teamId, workspaceId).then((members) => members as LinearMember[])
+
+/** Union of workflow states for every selected Linear team (multi-team filters). */
+export function useTeamsStates(
+  teamIds: readonly string[],
+  settings?: RuntimeLinearSettings,
+  workspaceId?: string | null
+): MetadataState<LinearWorkflowState[]> {
+  return useTeamsMetadataList(
+    teamIds,
+    settings,
+    workspaceId,
+    linearStateStore,
+    loadTeamStates,
+    'Failed to load states'
+  )
+}
+
+/** Union of labels for every selected Linear team (multi-team filters). */
+export function useTeamsLabels(
+  teamIds: readonly string[],
+  settings?: RuntimeLinearSettings,
+  workspaceId?: string | null
+): MetadataState<LinearLabel[]> {
+  return useTeamsMetadataList(
+    teamIds,
+    settings,
+    workspaceId,
+    linearLabelStore,
+    loadTeamLabels,
+    'Failed to load labels'
+  )
+}
+
+/** Union of members for every selected Linear team (multi-team filters). */
+export function useTeamsMembers(
+  teamIds: readonly string[],
+  settings?: RuntimeLinearSettings,
+  workspaceId?: string | null
+): MetadataState<LinearMember[]> {
+  return useTeamsMetadataList(
+    teamIds,
+    settings,
+    workspaceId,
+    linearMemberStore,
+    loadTeamMembers,
+    'Failed to load members'
+  )
 }
 
 export { useImmediateMutation } from './useImmediateMutation'


### PR DESCRIPTION
## Summary

On Tasks → Linear issues, selecting multiple teams (or "All teams") now lists Filter → Status / Assignee / Label options from *every* selected team, deduped by id, instead of only the primary team's.

## ELI5

Each Linear team has its own statuses, labels, and people. If you pick two teams, the filter menu should show both teams' options — but Orca only asked the first team. Now it asks every selected team and merges the lists.

## Root cause & fix

The attribute filter dropdowns resolved a single `primaryTeam` and loaded metadata only for that team, showing an "Options from {team}" banner while ignoring the rest of the multi-select. The fix adds `resolveLinearIssueAttributeFilterTeamIds()` (name-stable ordering, falls back to the primary team on empty selection, drops ids absent from `availableTeams`) and `unionLinearMetadataById()` (dedupe by id, first-seen order), plus `useTeamsStates/useTeamsLabels/useTeamsMembers` hooks that fan out through the existing per-team cache stores and union the results. `TaskPage` now passes `selectedTeamIds` + `availableTeams`, active filter pills prune against the unioned option set, and the stale banner is removed.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- Rebase: clean onto `origin/main` (base `8a23618310`, head `34dbadfb60`).
- Tests: `linear-issue-attribute-filter-team-ids.test.ts` and `useIssueMetadata.test.tsx` — **2 files, 11 tests passed** on branch.
- Fix-reverted control: the #8739 tests fail without the added code — `team-ids.test.ts` cannot resolve the new module, and `useIssueMetadata.test.tsx` "unions workflow states across every selected team (#8739)" throws `TypeError: useTeamsStates is not a function`.
- Lint: `oxlint` on the 4 changed source files — EXIT 0, clean.

```
(a) On branch:  Test Files 2 passed (2), Tests 11 passed (11)
(b) Reverted:   Test Files 2 failed (2), Tests 1 failed | 4 passed (5)
      useIssueMetadata.test.tsx › unions workflow states across every
      selected team (#8739): TypeError: useTeamsStates is not a function
```

## Trade-offs

None — pure fix. Filter lists grow under multi-team selection, which is the intended behavior; results are deduped by id and reuse the same per-team TTL cache as the single-team hooks.

## Regression risk

Effectively zero. The change is additive (new module + new hooks); single-team paths keep their behavior via the empty-selection fallback, and the pre-existing single-team cache/TTL tests stay green. `useTeamsMetadataList` keys effects on a joined cache key so freshly-passed arrays don't thrash, and an active-key ref guards stale async results.

*Credit to original author @innocarpe. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved.*
