### PR TITLE
fix(file-explorer): stop italic ignored filenames clipping ".md" to ".ma"

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -638,7 +638,10 @@ export function FileExplorerRow({
             className={cn(
               'truncate',
               isSelected && !nodeStatus && !isIgnored && 'text-accent-foreground',
-              isIgnored && 'italic'
+              // Why: italic glyphs overhang their advance width; truncate's
+              // overflow:hidden clips it, shaving the last char (".md" → ".ma").
+              // pr-0.5 reserves room for the slant so the final letter survives.
+              isIgnored && 'italic pr-0.5'
             )}
             style={
               nodeStatus


### PR DESCRIPTION
## Problem

In the right-sidebar file explorer, gitignored files whose names end in `.md` rendered as `.ma` — the trailing `d` was clipped off.

## Root cause

Gitignored filenames render in an *italic*, shrink-to-fit `<span>` styled with the Tailwind `truncate` utility (`overflow: hidden; text-overflow: ellipsis; white-space: nowrap`).

Italic glyphs lean right and **overhang their advance width**. Because the span shrinks to its content and `overflow: hidden` clips at the content-box edge, the trailing glyph's slant overhang gets shaved — turning `.md` into `.ma`. This happens for *any* italic (ignored) name, not just ones long enough to truncate, which is why even short names like `README.md` and `04-roadmap.md` were affected.

Only ignored files are italic (`isIgnored && 'italic'`), so only they showed the bug. Non-italic rows have no overhang and render fine.

## Fix

`src/renderer/src/components/right-sidebar/FileExplorerRow.tsx` — add `pr-0.5` to the italic case so there's room for the slant overhang inside the clipping box.

```diff
-              isIgnored && 'italic'
+              isIgnored && 'italic pr-0.5'
```

## Evidence (before / after)

Minimal HTML repro of the exact CSS (`truncate` + `italic`, with and without the padding), rendered in WebKit at the sidebar's width. Top group is BEFORE (`.md` clipped to `.ma`); bottom group is AFTER with `pr-0.5` (full `.md` visible):

![before/after](https://github.com/stablyai/orca/blob/aaa8c6ea0611bbb7bb27e62f14a44f1d374031a4/ma-bug-evidence.png?raw=true)
