### PR TITLE
fix(runtime): stop a throwing client-event listener from wedging worktree sleep + harden fan-out

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -27951,6 +27951,51 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('releases the worktree terminal mutation when a wake client-event listener throws', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const secondListenerEvents: RuntimeClientEvent[] = []
+    // Why: a broken paired-client relay can throw synchronously while delivering the wake
+    // notification. That must not abort the wake or (regression) leak the per-worktree terminal
+    // mutation acquired in acquireWorktreeTerminalSpawn, or every later sleep wedges for 12s.
+    runtime.onClientEvent((event) => {
+      if (event.type === 'worktreeTerminalSleepState' && event.phase === 'woken') {
+        throw new Error('relay_send_failed')
+      }
+    })
+    runtime.onClientEvent((event) => secondListenerEvents.push(event))
+    const processLists = [[{ id: 'pty-1', cwd: TEST_WORKTREE_PATH, title: 'Claude' }], [], []]
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => false,
+      stopAndWait: async (ptyId) => {
+        runtime.onPtyExit(ptyId, -1)
+        return true
+      },
+      getForegroundProcess: async () => null,
+      listProcesses: async () => processLists.shift() ?? []
+    })
+
+    // Sleep leaves the worktree in a 'sleeping' state so the next spawn emits the 'woken' event.
+    await runtime.sleepTerminalsForWorktree(`id:${TEST_WORKTREE_ID}`)
+
+    // The wake acquires the mutation and emits 'woken'; a throwing subscriber must not surface.
+    const releaseSpawn = await runtime.acquireWorktreeTerminalSpawn(TEST_WORKTREE_ID)
+    releaseSpawn()
+
+    // Isolation: the second subscriber still received the 'woken' event.
+    expect(
+      secondListenerEvents.some(
+        (event) => event.type === 'worktreeTerminalSleepState' && event.phase === 'woken'
+      )
+    ).toBe(true)
+
+    // Regression: the mutation was released, so a subsequent sleep converges instead of throwing
+    // terminal_worktree_sleep_timeout.
+    await expect(
+      runtime.sleepTerminalsForWorktree(`id:${TEST_WORKTREE_ID}`)
+    ).resolves.toMatchObject({ postStopVerified: true })
+  })
+
   it('keeps the original committed disposition across an idempotent retry', async () => {
     const runtime = new OrcaRuntimeService(store)
     const events: RuntimeClientEvent[] = []

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -27996,6 +27996,32 @@ describe('OrcaRuntimeService', () => {
     ).resolves.toMatchObject({ postStopVerified: true })
   })
 
+  it('isolates a throwing subscriber across runtime listener fan-out', () => {
+    const runtime = new OrcaRuntimeService(store)
+    const delivered: number[] = []
+    // Why: the shared notifyRuntimeListeners guard must let sibling fan-outs (here mobile
+    // notifications) survive a throwing subscriber, not just the client-event path.
+    runtime.onNotificationDispatched(() => {
+      throw new Error('subscriber_send_failed')
+    })
+    runtime.onNotificationDispatched((event) => {
+      delivered.push(event.notificationSeq ?? -1)
+    })
+
+    expect(() =>
+      runtime.dispatchMobileNotification({
+        type: 'notification',
+        source: 'test',
+        title: 'Test',
+        body: 'Body',
+        worktreeId: TEST_WORKTREE_ID
+      })
+    ).not.toThrow()
+
+    // The second subscriber still received the event despite the first throwing.
+    expect(delivered).toHaveLength(1)
+  })
+
   it('keeps the original committed disposition across an idempotent retry', async () => {
     const runtime = new OrcaRuntimeService(store)
     const events: RuntimeClientEvent[] = []

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3535,7 +3535,15 @@ export class OrcaRuntimeService {
 
   private emitClientEvent(event: RuntimeClientEvent): void {
     for (const listener of this.clientEventListeners) {
-      listener(event)
+      try {
+        listener(event)
+      } catch (error) {
+        // Why: client-event delivery is best-effort fan-out (e.g. a paired-client relay that can
+        // throw on a broken pipe); one failing subscriber must never abort the emitting operation.
+        // A throw here once escaped acquireWorktreeTerminalSpawn after it took the per-worktree
+        // terminal mutation, leaking it and wedging that worktree's sleep until app restart.
+        console.error('[runtime] client event listener threw', { eventType: event.type, error })
+      }
     }
   }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3534,17 +3534,9 @@ export class OrcaRuntimeService {
   }
 
   private emitClientEvent(event: RuntimeClientEvent): void {
-    for (const listener of this.clientEventListeners) {
-      try {
-        listener(event)
-      } catch (error) {
-        // Why: client-event delivery is best-effort fan-out (e.g. a paired-client relay that can
-        // throw on a broken pipe); one failing subscriber must never abort the emitting operation.
-        // A throw here once escaped acquireWorktreeTerminalSpawn after it took the per-worktree
-        // terminal mutation, leaking it and wedging that worktree's sleep until app restart.
-        console.error('[runtime] client event listener threw', { eventType: event.type, error })
-      }
-    }
+    // Why: a throwing subscriber here once escaped acquireWorktreeTerminalSpawn after it took the
+    // per-worktree terminal mutation, leaking it and wedging that worktree's sleep until restart.
+    notifyRuntimeListeners(this.clientEventListeners, (listener) => listener(event), 'client-event')
   }
 
   private notifyWorktreesChanged(repoId: string): void {
@@ -7608,7 +7600,13 @@ export class OrcaRuntimeService {
         ...(cwdChanged && cwd !== null ? { cwd } : {})
       }
       for (const listener of listeners) {
-        listener(data, meta)
+        try {
+          listener(data, meta)
+        } catch (error) {
+          // Why: inlined rather than via notifyRuntimeListeners to avoid a per-chunk closure
+          // allocation on the terminal-output hot path; isolation semantics match the helper.
+          console.error('[runtime] pty-data listener threw', error)
+        }
       }
     }
     return outputSequence
@@ -8591,9 +8589,7 @@ export class OrcaRuntimeService {
     if (!listeners) {
       return
     }
-    for (const listener of listeners) {
-      listener({ mode, cols, rows })
-    }
+    notifyRuntimeListeners(listeners, (listener) => listener({ mode, cols, rows }), 'fit-override')
   }
 
   serializeTerminalBuffer(
@@ -9868,12 +9864,13 @@ export class OrcaRuntimeService {
 
   dispatchMobileNotification(event: MobileNotificationEvent): void {
     const seq = this.mobileNotificationReplay.record(event)
-    for (const listener of this.notificationListeners) {
-      // Why: surface the desktop-assigned seq to live listeners so they can
-      // watermark the last event delivered and feed it back to getMissedSince
-      // on reconnect (idempotent catch-up, no duplicate local pushes).
-      listener({ ...event, notificationSeq: seq })
-    }
+    // Why: surface the desktop-assigned seq to live listeners so they can watermark the last event
+    // delivered and feed it back to getMissedSince on reconnect (idempotent catch-up, no dupes).
+    notifyRuntimeListeners(
+      this.notificationListeners,
+      (listener) => listener({ ...event, notificationSeq: seq }),
+      'mobile-notification'
+    )
   }
 
   // Returns notifications dispatched after lastSeenSeq. Idempotent: the same
@@ -10799,9 +10796,7 @@ export class OrcaRuntimeService {
     this.notifier?.terminalDriverChanged(ptyId, next)
     const listeners = this.driverListeners.get(ptyId)
     if (listeners) {
-      for (const listener of listeners) {
-        listener(next)
-      }
+      notifyRuntimeListeners(listeners, (listener) => listener(next), 'pty-driver')
     }
   }
 
@@ -12374,9 +12369,7 @@ export class OrcaRuntimeService {
     if (!listeners) {
       return
     }
-    for (const listener of listeners) {
-      listener(event)
-    }
+    notifyRuntimeListeners(listeners, (listener) => listener(event), 'pty-resize')
   }
 
   // Why: Section 7.2 — the runtime detects agent exit directly and updates
@@ -29698,6 +29691,23 @@ async function waitForWorktreeTerminalMutation(
   } finally {
     if (timeout !== undefined) {
       clearTimeout(timeout)
+    }
+  }
+}
+
+// Why: listener fan-out is best-effort delivery. One subscriber throwing synchronously — e.g. a
+// paired-client relay whose stream is closed — must never abort the emitting operation or leak
+// state (a lock/mutation) the caller holds across the emit. Isolate every listener and log.
+function notifyRuntimeListeners<L>(
+  listeners: Iterable<L>,
+  deliver: (listener: L) => void,
+  context: string
+): void {
+  for (const listener of listeners) {
+    try {
+      deliver(listener)
+    } catch (error) {
+      console.error(`[runtime] ${context} listener threw`, error)
     }
   }
 }


### PR DESCRIPTION
## Problem

Sleeping a workspace failed with **"Failed to sleep workspace — The host could not confirm terminal shutdown."** Persistent (survived retries), hit both the local host and a paired remote client, and only cleared on app restart.

## Root cause — a regression from #9874

The sleep RPC (`sleepResolvedWorktreeTerminals`) must first acquire a **per-worktree terminal mutation** before it can stop any PTY. That mutation was leaked by the sibling acquirer `acquireWorktreeTerminalSpawn`, **added by #9874**:

```ts
const release = await this.acquireWorktreeTerminalMutation(worktreeId) // mutation taken
// ...
this.emitClientEvent({ ...phase: 'woken'... })                        // fallible, runs BEFORE returning release
return release
```

`emitClientEvent` fanned out to every subscriber **with no error isolation** (long-standing, since #4715). The only production subscriber is the streaming-RPC `emit` in `runtime.clientEvents.subscribe` that forwards each event to a connected client. When that `emit` throws synchronously — a **paired/remote client** whose stream is broken/closed — the throw escaped `acquireWorktreeTerminalSpawn` *after* it took the mutation but *before* returning the release. The caller in `src/main/ipc/pty.ts` never received the release, so its `finally { releaseWorktreeSpawn?.() }` was a no-op and the mutation stayed pending forever. Every later sleep then blocked on it for `WORKTREE_TERMINAL_SLEEP_TIMEOUT_MS` (12s) and threw `terminal_worktree_sleep_timeout` → the toast.

The unguarded fan-out was a dormant footgun for over a year; **#9874 made it exploitable** by adding the first caller that holds a lock across the emit. Not platform-specific — it correlates with *a client being attached*, not with Windows (Windows just surfaced the daemon-log evidence).

Diagnostic evidence: `daemon.log` showed the wedged worktree's PTY sessions were **never killed** (no `session-killed` events) though the daemon was healthy and killed other worktrees' sessions seconds later — i.e. sleep failed *before* issuing any stop, exactly at the mutation gate, and worktree-scoped.

## Fix

1. **Targeted fix:** isolate listeners in `emitClientEvent` so a throwing subscriber can't abort the emitting operation or leak the mutation.
2. **Systemic hardening:** the same footgun existed unguarded across every runtime listener fan-out (mobile-notification, pty-data, pty-driver, pty-resize, fit-override). Introduce `notifyRuntimeListeners(listeners, deliver, context)` and route the low-frequency fan-outs through it; the terminal-output hot path keeps an inlined try/catch to avoid a per-chunk closure allocation.

## Tests

- `releases the worktree terminal mutation when a wake client-event listener throws` — reproduces the exact wedge; **fails on revert** (mutation leaks, `relay_send_failed` propagates), passes with the fix.
- `isolates a throwing subscriber across runtime listener fan-out` — proves the shared helper keeps sibling fan-outs (mobile notifications) alive past a throwing subscriber.

## Verification

- New tests pass; fail on revert.
- `orca-runtime.test.ts`: 852 pass (1 pre-existing, unrelated Windows `\tmp` path-separator failure in `preserves existing badgeColor on runtime createRepo dedupe`, present on `main`).
- `oxlint` + `tsc --noEmit -p config/tsconfig.node.json`: clean.