### PR TITLE
fix(updater): disable differential download on macOS to preserve asar integrity

### DIFF
--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -51,6 +51,7 @@ const {
     autoUpdaterMock.updateConfigPath = undefined
     autoUpdaterMock.allowPrerelease = false
     autoUpdaterMock.autoRunAppAfterInstall = true
+    autoUpdaterMock.disableDifferentialDownload = false
     delete (autoUpdaterMock as Record<string, unknown>).verifyUpdateCodeSignature
   }
 
@@ -58,6 +59,7 @@ const {
     autoDownload: false,
     autoInstallOnAppQuit: false,
     autoRunAppAfterInstall: true,
+    disableDifferentialDownload: false,
     allowPrerelease: false,
     on,
     checkForUpdates: vi.fn(),
@@ -194,6 +196,35 @@ describe('updater', () => {
     expect(autoUpdaterMock.setFeedURL).not.toHaveBeenCalled()
     expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled()
     expect(powerMonitorOnMock).not.toHaveBeenCalled()
+  })
+
+  it('disables differential update downloads on macOS (STA-2081)', async () => {
+    // Why: differential/blockmap reconstruction can ship an app.asar that no
+    // longer matches the notarized Info.plist ElectronAsarIntegrity hash,
+    // bricking Homebrew-cask installs that upgrade through the in-app updater.
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+    try {
+      const mainWindow = { webContents: { send: vi.fn() } }
+      const { setupAutoUpdater } = await import('./updater')
+      setupAutoUpdater(mainWindow as never)
+      expect(autoUpdaterMock.disableDifferentialDownload).toBe(true)
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+    }
+  })
+
+  it('keeps differential update downloads enabled off macOS', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    try {
+      const mainWindow = { webContents: { send: vi.fn() } }
+      const { setupAutoUpdater } = await import('./updater')
+      setupAutoUpdater(mainWindow as never)
+      expect(autoUpdaterMock.disableDifferentialDownload).toBe(false)
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+    }
   })
 
   it('deduplicates identical check errors from the event and rejected promise', async () => {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -1366,6 +1366,20 @@ export function setupAutoUpdater(
   autoUpdater.autoInstallOnAppQuit = updateInstallMode === 'interactive'
   // Why: MacUpdater ignores quitAndInstall arguments; the surviving CLI supervisor must be the only serve relaunch owner.
   autoUpdater.autoRunAppAfterInstall = updateInstallMode === 'interactive'
+  // Why (STA-2081): macOS MacUpdater reconstructs the update zip from blockmaps
+  // (differential download) before handing it to Squirrel.Mac. A reconstructed
+  // bundle whose app.asar no longer matches the notarized Info.plist
+  // ElectronAsarIntegrity hash fails both `codesign --verify` and Electron's
+  // runtime ASAR check, so the app will not launch and the bundled CLI/daemon
+  // SIGABRT. Homebrew-cask installs (`auto_updates true`) receive every upgrade
+  // through this in-app path, so they are the ones that end up bricked while a
+  // fresh DMG download stays pristine. Force full-zip downloads on macOS so each
+  // update swaps in the exact notarized bundle. Scoped to darwin: Windows (NSIS)
+  // and Linux (AppImage) differential paths are unaffected and keep their
+  // bandwidth savings.
+  if (process.platform === 'darwin') {
+    autoUpdater.disableDifferentialDownload = true
+  }
 
   // Why: our only on-machine window into electron-updater; otherwise an unexpected update-not-available or failed fetch is invisible.
   autoUpdater.logger = {


### PR DESCRIPTION
Fixes STA-2081.

Root cause: the Homebrew cask's auto_updates=true routes upgrades through Orca's in-app macOS updater, and electron-updater 6.8.9 MacUpdater does differential (blockmap) downloads by default. It reconstructs the app zip and hands it to Squirrel.Mac, producing an app.asar whose bytes no longer match the notarized Info.plist ElectronAsarIntegrity, failing codesign + Electron's ASAR check and SIGABRTing the bundled CLI/daemon. A fresh DMG direct-download stays pristine, which is why only Homebrew breaks. For an affected user the app will not launch at all, so this is a hard brick for that cohort, not a degraded state.

Fix: set autoUpdater.disableDifferentialDownload=true gated to darwin so every mac update pulls the full notarized zip; Windows/Linux unaffected. Adds 2 regression tests.

## Download-size impact (measured)

This disables differential downloads for **all** macOS users, not only Homebrew, so the fair question is whether we're adding install time for everyone to fix a subset. Measured against our own arm64 release blockmaps, differential was already saving very little on the update spans real stable users actually traverse:

| Update span | Differential fetch | vs. full ~193 MB |
| --- | --- | --- |
| Consecutive builds, hours apart (1.4.153-rc.2 → rc.3) | ~47 MB | 23.6% |
| One week apart (1.4.152 → 1.4.153-rc.3) | ~197 MB | 98.6% |

The macOS artifact is a compressed zip, so block reuse collapses as soon as a change lands early in the archive — or a native module rebuild / Electron bump shifts the deflate stream — and nearly every downstream block differs even where the underlying files are identical. Small, close diffs reuse well; anything substantial reuses almost nothing.

Stable and Homebrew users update stable→stable (days to weeks apart), which is the high-percentage end of that table, so the **incremental** cost of forcing full downloads for them is close to zero. Worst case — a user who would otherwise have caught a trivial diff — is a one-time ~+150 MB. Update bytes are served from GitHub release assets, so there is no egress cost to us; the only cost is user bandwidth and download time.

Why blanket-darwin instead of Homebrew-only: differential's savings for direct-DMG users are marginal for the same compressed-archive reason, and detecting install source at runtime would add fragile complexity for little benefit. Forcing the full zip is also strictly more reliable here, since differential reconstruction is the exact step that corrupts the asar — we're removing a fragile stage, not just trading speed for safety.

Test plan: vitest (83, incl. 12 mac-install) + typecheck + oxlint green. Full verification needs a real signed vN->vN+1 macOS update (confirm codesign --deep --strict and app.asar<->ElectronAsarIntegrity both pass post-update).
