### PR TITLE
feat(keybindings): add editor.sendNotesToAgent for review-note send picker

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -89,6 +89,7 @@ import { RecoverableRenderErrorBoundary } from './components/error-boundaries/Re
 import { ConfirmationDialogProvider } from './components/confirmation-dialog'
 import { LinkRoutingPreferenceDialogProvider } from './components/link-routing-preference-dialog'
 import RecentTabSwitcher from './components/tab-bar/RecentTabSwitcher'
+import { requestOpenNotesSendMenu } from './components/editor/notes-send-menu-open-request'
 import { useGitStatusPolling } from './components/right-sidebar/useGitStatusPolling'
 import { useEditorExternalWatch } from './hooks/useEditorExternalWatch'
 import { useAutoAckViewedAgent } from './hooks/useAutoAckViewedAgent'
@@ -248,6 +249,8 @@ type ShortcutDispatchInput = {
   ctrlKey?: boolean
   shiftKey?: boolean
   doubleTapModifier?: PhysicalModifierToken
+  /** Why: OS key-repeat must not fire one-shot layout actions (split / notes menu). */
+  isAutoRepeat?: boolean
   target: EventTarget | null
   defaultPrevented: boolean
   preventDefault: () => void
@@ -1730,7 +1733,8 @@ function App(): React.JSX.Element {
         pluginCommands,
         terminalShortcutPolicy,
         setFloatingTerminalOpenWithFocus,
-        creationLayoutActive
+        creationLayoutActive,
+        workspaceChromeActive
       } = globalShortcutStateRef.current
 
       // Child handlers (e.g. terminal search) share this window capture phase and fire first; bail if they already preventDefault'd so both don't act.
@@ -1862,14 +1866,30 @@ function App(): React.JSX.Element {
               translate('auto.App.pluginCommandFailed', 'Could not run the plugin command.')
             )
           })
+           const handlers = createRegisteredCommandHandlers(input, context)
+      for (const actionId of PLUGIN_COMMAND_ALIAS_ACTION_IDS) {
+        if (matchShortcut(actionId) && handlers.get(actionId)?.()) {
           return
         }
       }
 
-      const handlers = createRegisteredCommandHandlers(input, context)
-      for (const actionId of PLUGIN_COMMAND_ALIAS_ACTION_IDS) {
-        if (matchShortcut(actionId) && handlers.get(actionId)?.()) {
+      // Mod+Shift+Enter — open "Send notes to an agent" when unsent review notes exist.
+      // Why: skip terminal context so Mod+Shift+Enter still expands the terminal pane there.
+      if (
+        workspaceChromeActive &&
+        !floatingWorkspaceFocused &&
+        !input.isAutoRepeat &&
+        context !== 'terminal' &&
+        matchShortcut('editor.sendNotesToAgent')
+      ) {
+        // Why: do not consume the chord when no unsent notes exist / no menu mounts.
+        if (requestOpenNotesSendMenu({ worktreeId: activeWorktreeId })) {
+          input.preventDefault()
           return
+        }
+      }
+
+     return
         }
       }
 
@@ -1916,6 +1936,7 @@ function App(): React.JSX.Element {
         metaKey: e.metaKey,
         ctrlKey: e.ctrlKey,
         shiftKey: e.shiftKey,
+        isAutoRepeat: e.repeat,
         target: e.target,
         defaultPrevented: e.defaultPrevented,
         preventDefault: () => e.preventDefault()

--- a/src/renderer/src/components/editor/NotesSendMenu.test.tsx
+++ b/src/renderer/src/components/editor/NotesSendMenu.test.tsx
@@ -64,6 +64,8 @@ vi.mock('@/store', () => ({
       openAgentSendPopoverTargetMode: storeMocks.openAgentSendPopoverTargetMode,
       closeAgentSendPopoverTargetMode: storeMocks.closeAgentSendPopoverTargetMode,
       agentSendPopoverTargetMode: storeMocks.state.agentSendPopoverTargetMode,
+      activeWorktreeId: 'wt-1',
+      activeGroupIdByWorktree: { 'wt-1': 'group-1' },
       agentStatusByPaneKey: {},
       agentStatusEpoch: 0,
       tabsByWorktree: {},
@@ -71,6 +73,10 @@ vi.mock('@/store', () => ({
       ptyIdsByTabId: {},
       runtimePaneTitlesByTabId: {}
     })
+}))
+
+vi.mock('@/hooks/useShortcutLabel', () => ({
+  useOptionalShortcutLabel: () => '⌘⇧Enter'
 }))
 
 vi.mock('zustand/react/shallow', () => ({

--- a/src/renderer/src/components/editor/NotesSendMenu.tsx
+++ b/src/renderer/src/components/editor/NotesSendMenu.tsx
@@ -13,7 +13,13 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 import { ReviewNotesSendMenuContent } from './ReviewNotesSendMenuContent'
+import {
+  markNotesSendMenuOpenAccepted,
+  OPEN_NOTES_SEND_MENU_EVENT,
+  type OpenNotesSendMenuDetail
+} from './notes-send-menu-open-request'
 import { translate } from '@/i18n/i18n'
 
 const ENABLED_SEND_TOOLTIP = 'Send notes to an agent'
@@ -75,6 +81,11 @@ export function NotesSendMenu<TNote>({
   const openAgentSendPopoverTargetMode = useAppStore((s) => s.openAgentSendPopoverTargetMode)
   const closeAgentSendPopoverTargetMode = useAppStore((s) => s.closeAgentSendPopoverTargetMode)
   const activeTargetModeId = useAppStore((s) => s.agentSendPopoverTargetMode?.id ?? null)
+  const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const activeGroupId = useAppStore((s) =>
+    worktreeId ? (s.activeGroupIdByWorktree?.[worktreeId] ?? null) : null
+  )
+  const sendNotesShortcut = useOptionalShortcutLabel('editor.sendNotesToAgent')
   const [sendMenuOpen, setSendMenuOpen] = useState(false)
   const targetModeId = useMemo(() => buildNotesSendTargetModeId(modeIdParts), [modeIdParts])
   const enabledScopes = useMemo(() => scopes.filter((scope) => scope.notes.length > 0), [scopes])
@@ -136,6 +147,38 @@ export function NotesSendMenu<TNote>({
     // wins; the local open bit is only meaningful while this target is active.
     setSendMenuOpen(false)
   }
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+    const onOpenRequest = (event: Event): void => {
+      if (!hasDeliverableNotes || !defaultScope) {
+        return
+      }
+      const detail = (event as CustomEvent<OpenNotesSendMenuDetail>).detail ?? {}
+      if (detail.worktreeId && detail.worktreeId !== worktreeId) {
+        return
+      }
+      // Why: multi-group layouts may mount several pickers; only the active group
+      // should claim the shortcut so we do not thrash target mode.
+      if (activeWorktreeId === worktreeId && activeGroupId && activeGroupId !== groupId) {
+        return
+      }
+      handleOpenChange(true)
+      markNotesSendMenuOpenAccepted()
+    }
+    window.addEventListener(OPEN_NOTES_SEND_MENU_EVENT, onOpenRequest)
+    return () => window.removeEventListener(OPEN_NOTES_SEND_MENU_EVENT, onOpenRequest)
+  }, [
+    activeGroupId,
+    activeWorktreeId,
+    defaultScope,
+    groupId,
+    handleOpenChange,
+    hasDeliverableNotes,
+    worktreeId
+  ])
 
   useEffect(
     () => () => {
@@ -199,7 +242,11 @@ export function NotesSendMenu<TNote>({
           </DropdownMenuTrigger>
         </TooltipTrigger>
         <TooltipContent side="bottom" sideOffset={6}>
-          {hasDeliverableNotes ? ENABLED_SEND_TOOLTIP : disabledTooltip}
+          {hasDeliverableNotes
+            ? sendNotesShortcut
+              ? `${ENABLED_SEND_TOOLTIP} (${sendNotesShortcut})`
+              : ENABLED_SEND_TOOLTIP
+            : disabledTooltip}
         </TooltipContent>
       </Tooltip>
       <DropdownMenuContent

--- a/src/renderer/src/components/editor/editor-shortcuts.test.ts
+++ b/src/renderer/src/components/editor/editor-shortcuts.test.ts
@@ -20,6 +20,7 @@ vi.mock('@/store', () => ({
 import {
   installEditorAddReviewNoteShortcut,
   installEditorFindShortcut,
+  installEditorSendNotesToAgentShortcut,
   installMonacoDiffChangeNavigationShortcut,
   installMonacoEditorFindShortcut,
   installOpenDraftAddReviewNoteGuard
@@ -267,6 +268,57 @@ describe('installEditorAddReviewNoteShortcut', () => {
     expect(onAddReviewNote).toHaveBeenCalledTimes(1)
     expect(event.defaultPrevented).toBe(false)
     expect(onDownstreamKeyDown).toHaveBeenCalledTimes(1)
+    dispose()
+  })
+})
+
+describe('installEditorSendNotesToAgentShortcut', () => {
+  it('opens the notes send picker on Mod+Shift+Enter when the handler acts', () => {
+    const container = document.createElement('div')
+    const input = document.createElement('textarea')
+    const onSend = vi.fn(() => true)
+    container.appendChild(input)
+    document.body.appendChild(container)
+    const dispose = installEditorSendNotesToAgentShortcut(container, onSend)
+
+    const event = dispatchKeyDown(input, {
+      key: 'Enter',
+      code: 'Enter',
+      metaKey: true,
+      shiftKey: true
+    })
+    expect(event.defaultPrevented).toBe(true)
+    expect(onSend).toHaveBeenCalledTimes(1)
+
+    const skipped = dispatchKeyDown(input, {
+      key: 'Enter',
+      code: 'Enter',
+      metaKey: true,
+      shiftKey: true
+    })
+    // handler returns true still — second press still acts unless we return false
+    expect(skipped.defaultPrevented).toBe(true)
+    expect(onSend).toHaveBeenCalledTimes(2)
+
+    dispose()
+  })
+
+  it('does not preventDefault when no notes picker opens', () => {
+    const container = document.createElement('div')
+    const input = document.createElement('textarea')
+    const onSend = vi.fn(() => false)
+    container.appendChild(input)
+    document.body.appendChild(container)
+    const dispose = installEditorSendNotesToAgentShortcut(container, onSend)
+
+    const event = dispatchKeyDown(input, {
+      key: 'Enter',
+      code: 'Enter',
+      metaKey: true,
+      shiftKey: true
+    })
+    expect(event.defaultPrevented).toBe(false)
+    expect(onSend).toHaveBeenCalledTimes(1)
     dispose()
   })
 })

--- a/src/renderer/src/components/editor/editor-shortcuts.test.ts
+++ b/src/renderer/src/components/editor/editor-shortcuts.test.ts
@@ -294,11 +294,12 @@ describe('installEditorSendNotesToAgentShortcut', () => {
       key: 'Enter',
       code: 'Enter',
       metaKey: true,
-      shiftKey: true
+      shiftKey: true,
+      repeat: true
     })
-    // handler returns true still — second press still acts unless we return false
-    expect(skipped.defaultPrevented).toBe(true)
-    expect(onSend).toHaveBeenCalledTimes(2)
+    // Why: auto-repeat must not re-open the picker (keyboard holds fire multiple events).
+    expect(skipped.defaultPrevented).toBe(false)
+    expect(onSend).toHaveBeenCalledTimes(1)
 
     dispose()
   })

--- a/src/renderer/src/components/editor/editor-shortcuts.ts
+++ b/src/renderer/src/components/editor/editor-shortcuts.ts
@@ -106,6 +106,33 @@ export function installEditorAddReviewNoteShortcut(
 }
 
 /**
+ * Opens the "Send notes to an agent" picker when unsent notes exist.
+ * Returns whether a menu accepted the request (for preventDefault decisions).
+ */
+export function installEditorSendNotesToAgentShortcut(
+  target: HTMLElement,
+  onSendNotesToAgent: () => boolean
+): () => void {
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    if (!editorShortcutMatches('editor.sendNotesToAgent', event)) {
+      return
+    }
+    if (event.repeat) {
+      return
+    }
+    // Why: only consume when a picker opens; empty/unsent-less surfaces leave
+    // the chord free for other editor bindings.
+    if (onSendNotesToAgent()) {
+      event.preventDefault()
+      event.stopPropagation()
+    }
+  }
+
+  target.addEventListener('keydown', handleKeyDown, true)
+  return () => target.removeEventListener('keydown', handleKeyDown, true)
+}
+
+/**
  * While a review-note/diff-comment draft composer is mounted, consume the
  * bindable add-review-note chord (including OS key-repeat) so a second press
  * cannot remount the composer or leak into other handlers (product B).

--- a/src/renderer/src/components/editor/notes-send-menu-open-request.test.ts
+++ b/src/renderer/src/components/editor/notes-send-menu-open-request.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi } from 'vitest'
+import {
+  markNotesSendMenuOpenAccepted,
+  OPEN_NOTES_SEND_MENU_EVENT,
+  requestOpenNotesSendMenu
+} from './notes-send-menu-open-request'
+
+describe('requestOpenNotesSendMenu', () => {
+  it('returns false when no listener accepts', () => {
+    expect(requestOpenNotesSendMenu({ worktreeId: 'wt-1' })).toBe(false)
+  })
+
+  it('returns true when a listener marks the request accepted', () => {
+    const listener = vi.fn(() => {
+      markNotesSendMenuOpenAccepted()
+    })
+    window.addEventListener(OPEN_NOTES_SEND_MENU_EVENT, listener)
+    try {
+      expect(requestOpenNotesSendMenu({ worktreeId: 'wt-1' })).toBe(true)
+      expect(listener).toHaveBeenCalledOnce()
+    } finally {
+      window.removeEventListener(OPEN_NOTES_SEND_MENU_EVENT, listener)
+    }
+  })
+})

--- a/src/renderer/src/components/editor/notes-send-menu-open-request.ts
+++ b/src/renderer/src/components/editor/notes-send-menu-open-request.ts
@@ -1,0 +1,23 @@
+/** Window event used to open the mounted "Send notes to an agent" picker from a keybinding. */
+export const OPEN_NOTES_SEND_MENU_EVENT = 'orca:open-notes-send-menu'
+
+export type OpenNotesSendMenuDetail = {
+  worktreeId?: string | null
+}
+
+// Why: listeners run synchronously; the shortcut installer needs to know whether
+// any mounted menu accepted the request so it can preventDefault only then.
+let openRequestAccepted = false
+
+export function markNotesSendMenuOpenAccepted(): void {
+  openRequestAccepted = true
+}
+
+/** Returns true if a mounted NotesSendMenu with deliverable notes opened. */
+export function requestOpenNotesSendMenu(detail: OpenNotesSendMenuDetail = {}): boolean {
+  openRequestAccepted = false
+  window.dispatchEvent(
+    new CustomEvent<OpenNotesSendMenuDetail>(OPEN_NOTES_SEND_MENU_EVENT, { detail })
+  )
+  return openRequestAccepted
+}

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -93,6 +93,7 @@ export type KeybindingActionId =
   | 'editor.previousChange'
   | 'editor.nextChange'
   | 'editor.addReviewNote'
+  | 'editor.sendNotesToAgent'
   | 'sourceControl.sendReviewNotes'
   | 'fileExplorer.undo'
   | 'fileExplorer.redo'
@@ -851,6 +852,25 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     searchKeywords: ['shortcut', 'editor', 'markdown', 'note', 'comment', 'annotation', 'review'],
     // Why: Ctrl+Alt+letter is AltGr text input on Windows/Linux, so an editor default must not reserve chars like Polish `ń`.
     defaultBindings: platformBindings(['Mod+Shift+A'])
+  },
+  {
+    id: 'editor.sendNotesToAgent',
+    title: 'Send notes to an agent',
+    group: 'Editors',
+    scope: 'editor',
+    // Why: pairs with Add Review Note for a keyboard review loop (#10027). Same chord as
+    // terminal.expandPane is OK — scopes differ (editor vs terminal).
+    searchKeywords: [
+      'shortcut',
+      'editor',
+      'diff',
+      'review',
+      'notes',
+      'send',
+      'agent',
+      'annotation'
+    ],
+    defaultBindings: platformBindings(['Mod+Shift+Enter'])
   },
   {
     id: 'sourceControl.sendReviewNotes',


### PR DESCRIPTION
## Description

**User-facing:** After adding AI/diff review notes, you can open **Send notes to an agent** from the keyboard. Default: **`Mod+Shift+Enter`** (`Cmd+Shift+Enter` / `Ctrl+Shift+Enter`). Assign any binding in Settings → Shortcuts.

**Technical:** Register `editor.sendNotesToAgent` and fire a sync window event that mounted `NotesSendMenu` instances handle — same open path as clicking the header **Send** control.

Fixes #10027

## Impact / ELI5

You can annotate a review with the keyboard, then press one more shortcut to open the “which agent should get these notes?” menu — no mouse required for that step of the review loop.

## Root cause / gap

`editor.addReviewNote` existed for adding notes, but the **Send notes to an agent** control was mouse-only (`NotesSendMenu` / `DiffNotesSendMenu` trigger button).

## Fix

| Piece | Detail |
|-------|--------|
| Keybinding | `editor.sendNotesToAgent`, scope `editor`, default `Mod+Shift+Enter` |
| Dispatch | `requestOpenNotesSendMenu({ worktreeId })` from App shortcut hub |
| Open path | `NotesSendMenu` listens, opens when unsent notes exist |
| Group safety | Only the **active** worktree/group menu claims the shortcut |
| Fall-through | No unsent notes → chord not consumed |
| Terminal | Skipped when keybinding context is `terminal` so `terminal.expandPane` keeps `Mod+Shift+Enter` |

Tooltip on the Send control shows the bound shortcut when notes are deliverable.

## Evidence

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/components/editor/notes-send-menu-open-request.test.ts \
  src/renderer/src/components/editor/editor-shortcuts.test.ts \
  src/renderer/src/components/editor/NotesSendMenu.test.tsx \
  src/shared/keybindings.test.ts
```

**Result:** 96/96 passed.

Manual:

1. Open a PR/diff, add ≥1 review note (unsent).
2. Focus the editor (not the terminal).
3. Press `Cmd+Shift+Enter` / `Ctrl+Shift+Enter`.
4. Send-notes picker opens with existing agent targets.

## User-regression-tradeoffs

- **New default** `Mod+Shift+Enter` on editor scope. Same physical chord as `terminal.expandPane`, but **scopes differ**; App explicitly ignores this action in terminal context so expand-pane keeps working in the TUI.
- Empty/unsent-less surfaces leave the chord free.
- Markdown + diff menus both use `NotesSendMenu`; active-group filter avoids thrashing multiple pickers.

## Checklist notes

- **Cross-platform:** `platformBindings(['Mod+Shift+Enter'])`.
- **SSH/remote:** send path unchanged (existing agent-target delivery).
- **UI:** reuses `NotesSendMenu` / `ReviewNotesSendMenuContent`.
- **Performance:** sync event; no IPC until user picks a target.

## AI review summary

- Thin keyboard surface over the existing send menu.
- Acceptance flag pattern mirrors other “only preventDefault when it acts” editor shortcuts.
- Avoids stealing terminal expand-pane chord via context check.


## ELI5

After you add review notes, you can open Send notes to an agent from the keyboard (default Mod+Shift+Enter). Same menu as the header Send button, without reaching for the mouse.
