### PR TITLE
fix(usage): guard web client against undefined usage scan state

### DIFF
--- a/src/renderer/src/store/slices/claude-usage.ts
+++ b/src/renderer/src/store/slices/claude-usage.ts
@@ -45,7 +45,14 @@ export const createClaudeUsageSlice: StateCreator<AppState, [], [], ClaudeUsageS
     try {
       const nextScanState = (await window.api.claudeUsage.setEnabled({
         enabled
-      })) as ClaudeUsageScanState
+      })) as ClaudeUsageScanState | undefined
+      // Why: the web client (paired runtime) does not bridge the desktop-only
+      // usage IPC; its preload fallback resolves this call to `undefined`. Bail
+      // so the toggle no-ops instead of seeding an empty scan state and then
+      // crashing on the follow-up fetch.
+      if (!nextScanState) {
+        return
+      }
       set({
         // Why: every enable should look like a fresh scan cycle in the UI.
         // Reusing the last completed timestamp makes repeated toggles skip the
@@ -84,7 +91,16 @@ export const createClaudeUsageSlice: StateCreator<AppState, [], [], ClaudeUsageS
 
   fetchClaudeUsage: async (opts) => {
     try {
-      const scanState = (await window.api.claudeUsage.getScanState()) as ClaudeUsageScanState
+      const scanState = (await window.api.claudeUsage.getScanState()) as
+        | ClaudeUsageScanState
+        | undefined
+      // Why: in the web client the usage IPC is unavailable and the preload
+      // fallback resolves to `undefined`; reading `scanState.enabled` below would
+      // throw `Cannot read properties of undefined (reading 'enabled')`. Treat an
+      // absent scan state as "usage unavailable" and stop.
+      if (!scanState) {
+        return
+      }
       const currentScanState = get().claudeUsageScanState
       const shouldPreserveLoadingState =
         opts?.forceRefresh === true &&

--- a/src/renderer/src/store/slices/codex-usage.ts
+++ b/src/renderer/src/store/slices/codex-usage.ts
@@ -45,7 +45,14 @@ export const createCodexUsageSlice: StateCreator<AppState, [], [], CodexUsageSli
     try {
       const nextScanState = (await window.api.codexUsage.setEnabled({
         enabled
-      })) as CodexUsageScanState
+      })) as CodexUsageScanState | undefined
+      // Why: the web client (paired runtime) does not bridge the desktop-only
+      // usage IPC; its preload fallback resolves this call to `undefined`. Bail
+      // so the toggle no-ops instead of seeding an empty scan state and then
+      // crashing on the follow-up fetch.
+      if (!nextScanState) {
+        return
+      }
       set({
         codexUsageScanState: enabled
           ? {
@@ -81,7 +88,16 @@ export const createCodexUsageSlice: StateCreator<AppState, [], [], CodexUsageSli
 
   fetchCodexUsage: async (opts) => {
     try {
-      const scanState = (await window.api.codexUsage.getScanState()) as CodexUsageScanState
+      const scanState = (await window.api.codexUsage.getScanState()) as
+        | CodexUsageScanState
+        | undefined
+      // Why: in the web client the usage IPC is unavailable and the preload
+      // fallback resolves to `undefined`; reading `scanState.enabled` below would
+      // throw `Cannot read properties of undefined (reading 'enabled')`. Treat an
+      // absent scan state as "usage unavailable" and stop.
+      if (!scanState) {
+        return
+      }
       const currentScanState = get().codexUsageScanState
       const shouldPreserveLoadingState =
         opts?.forceRefresh === true &&

--- a/src/renderer/src/store/slices/opencode-usage.ts
+++ b/src/renderer/src/store/slices/opencode-usage.ts
@@ -45,7 +45,14 @@ export const createOpenCodeUsageSlice: StateCreator<AppState, [], [], OpenCodeUs
     try {
       const nextScanState = (await window.api.openCodeUsage.setEnabled({
         enabled
-      })) as OpenCodeUsageScanState
+      })) as OpenCodeUsageScanState | undefined
+      // Why: the web client (paired runtime) does not bridge the desktop-only
+      // usage IPC; its preload fallback resolves this call to `undefined`. Bail
+      // so the toggle no-ops instead of seeding an empty scan state and then
+      // crashing on the follow-up fetch.
+      if (!nextScanState) {
+        return
+      }
       set({
         openCodeUsageScanState: enabled
           ? {
@@ -81,7 +88,16 @@ export const createOpenCodeUsageSlice: StateCreator<AppState, [], [], OpenCodeUs
 
   fetchOpenCodeUsage: async (opts) => {
     try {
-      const scanState = (await window.api.openCodeUsage.getScanState()) as OpenCodeUsageScanState
+      const scanState = (await window.api.openCodeUsage.getScanState()) as
+        | OpenCodeUsageScanState
+        | undefined
+      // Why: in the web client the usage IPC is unavailable and the preload
+      // fallback resolves to `undefined`; reading `scanState.enabled` below would
+      // throw `Cannot read properties of undefined (reading 'enabled')`. Treat an
+      // absent scan state as "usage unavailable" and stop.
+      if (!scanState) {
+        return
+      }
       const currentScanState = get().openCodeUsageScanState
       const shouldPreserveLoadingState =
         opts?.forceRefresh === true &&

--- a/src/renderer/src/store/slices/usage-web-client-fallback.test.ts
+++ b/src/renderer/src/store/slices/usage-web-client-fallback.test.ts
@@ -1,0 +1,72 @@
+import { create } from 'zustand'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AppState } from '../types'
+import { createClaudeUsageSlice } from './claude-usage'
+import { createCodexUsageSlice } from './codex-usage'
+import { createOpenCodeUsageSlice } from './opencode-usage'
+
+// Regression: in the web client (paired `orca serve` runtime) the desktop-only
+// usage IPC is not bridged, so the preload fallback proxy resolves every
+// `window.api.<provider>Usage.*` call to `undefined`. Before the guards, the
+// slices read `scanState.enabled` off that `undefined` and threw
+// `TypeError: Cannot read properties of undefined (reading 'enabled')` when a
+// user opened Settings -> Stats & Usage and pressed "enable" for an agent.
+//
+// These tests stub the web-client fallback (every call -> undefined) and assert
+// the slices degrade to a no-op instead of throwing.
+
+function stubWebClientFallback(): void {
+  // Mirrors web-preload-api's createFallbackProxy: any method resolves to undefined.
+  const undefinedAsync = vi.fn(() => Promise.resolve(undefined))
+  const provider = {
+    getScanState: undefinedAsync,
+    setEnabled: undefinedAsync,
+    getSnapshot: undefinedAsync,
+    refresh: undefinedAsync,
+    getSummary: undefinedAsync,
+    getDaily: undefinedAsync,
+    getBreakdown: undefinedAsync,
+    getRecentSessions: undefinedAsync
+  }
+  vi.stubGlobal('window', {
+    api: {
+      claudeUsage: provider,
+      codexUsage: provider,
+      openCodeUsage: provider
+    }
+  })
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('usage slices in the web client (preload fallback -> undefined)', () => {
+  it('claude: fetch and enable no-op without throwing', async () => {
+    stubWebClientFallback()
+    const store = create<AppState>()((...args) => createClaudeUsageSlice(...args) as AppState)
+    await expect(store.getState().fetchClaudeUsage()).resolves.toBeUndefined()
+    await expect(store.getState().enableClaudeUsage()).resolves.toBeUndefined()
+    expect(store.getState().claudeUsageScanState).toBeNull()
+    expect(store.getState().claudeUsageSummary).toBeNull()
+  })
+
+  it('codex: fetch and enable no-op without throwing', async () => {
+    stubWebClientFallback()
+    const store = create<AppState>()((...args) => createCodexUsageSlice(...args) as AppState)
+    await expect(store.getState().fetchCodexUsage()).resolves.toBeUndefined()
+    await expect(store.getState().enableCodexUsage()).resolves.toBeUndefined()
+    expect(store.getState().codexUsageScanState).toBeNull()
+    expect(store.getState().codexUsageSummary).toBeNull()
+  })
+
+  it('opencode: fetch and enable no-op without throwing', async () => {
+    stubWebClientFallback()
+    const store = create<AppState>()((...args) => createOpenCodeUsageSlice(...args) as AppState)
+    await expect(store.getState().fetchOpenCodeUsage()).resolves.toBeUndefined()
+    await expect(store.getState().enableOpenCodeUsage()).resolves.toBeUndefined()
+    expect(store.getState().openCodeUsageScanState).toBeNull()
+    expect(store.getState().openCodeUsageSummary).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Enabling an agent's usage tracking in **Settings → Stats & Usage** no longer crashes when Orca runs as a web client (a paired `orca serve` runtime).

## ELI5

In the browser version of Orca, clicking "enable" for usage stats used to hit an error because that feature only exists on the desktop app. Now it just quietly does nothing instead of breaking.

## Root cause & fix

The `*Usage` IPC namespaces (`claudeUsage`, `codexUsage`, `openCodeUsage`) are desktop-only and are never bridged in the web preload, so the fallback proxy resolves every call to `undefined`. The slices cast that result to a non-optional scan state and read `scanState.enabled`, throwing `Cannot read properties of undefined (reading 'enabled')`. The fix adds `| undefined` to the casts and bails out with a no-op when the scan state is absent — on both the `enable*` (setEnabled) and `fetch*` (getScanState) paths — across all three providers. Desktop behavior is unchanged since a real `ScanState` is always truthy there.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- Test file: `src/renderer/src/store/slices/usage-web-client-fallback.test.ts` (3 tests, one per provider), which stubs the web-client fallback so every `window.api.*Usage.*` resolves to `undefined`.
- On branch (fix present): **3 passed**. Fix reverted to `origin/main`: **3 failed** with the assertion below — proving the test guards the fix.
- Lint: `oxlint` on the three changed source files is clean.

```
On branch:        Test Files 1 passed (1) | Tests 3 passed (3)
Fix reverted:     Test Files 1 failed (1) | Tests 3 failed (3)
  AssertionError: expected undefined to be null
  (claudeUsageScanState / codexUsageScanState / openCodeUsageScanState received undefined)
```

## Trade-offs

None — pure fix. The Settings navigation gating is intentionally unchanged; the web client now treats usage tracking as unavailable (its actual state) rather than crashing.

## Regression risk

Zero-regression: only the previously-crashing branch changes — when the scan state is present (always the case on desktop) every path is byte-identical, so desktop behavior is untouched. The passing test covers all three providers on both the enable and fetch seams.

*Credit to original author @scokeepa. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved.*
