### PR TITLE
perf(main): gate idle git-common polling + coarse-FS add/remove fix (re-open of #9882)

### DIFF
--- a/src/main/ipc/worktree-base-directory-poller.test.ts
+++ b/src/main/ipc/worktree-base-directory-poller.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { mkdtemp, mkdir, realpath, rm, stat, utimes, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -330,7 +330,7 @@ describe('worktree base directory poller', () => {
     )
   })
 
-  it('detects linked HEAD rewrites even when the entry directory mtime is restored', async () => {
+  it('detects an in-place linked HEAD rewrite that leaves the entry directory signature unchanged', async () => {
     const commonDir = await makeRoot()
     const entry = join(commonDir, 'worktrees', 'external-head')
     await mkdir(entry, { recursive: true })
@@ -346,10 +346,11 @@ describe('worktree base directory poller', () => {
     )
     cleanups.push(() => poller.unsubscribe())
 
-    const before = await stat(entry)
+    // Why: rewriting an existing HEAD in place changes only the file's own metadata, never the
+    // parent entry directory's mtime/ctime/ino/size — so HEAD (like the other structural leaves)
+    // must be re-stat'd every tick, not gated behind the entry-dir signature.
     await new Promise((resolve) => setTimeout(resolve, 10))
     await writeFile(join(entry, 'HEAD'), 'ref: refs/heads/next')
-    await utimes(entry, before.atime, before.mtime)
 
     await waitForEvents(received, (flat) =>
       flat.some((event) => event.type === 'update' && event.path === join(entry, 'HEAD'))

--- a/src/main/ipc/worktree-git-common-polling.ts
+++ b/src/main/ipc/worktree-git-common-polling.ts
@@ -6,10 +6,8 @@ import type {
   WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
 
-// Shared with the darwin primary-metadata poll so the platforms cannot drift
-// on which shallow leaves count as watchable metadata. `logs/HEAD` catches
-// head moves that rewrite no other watched leaf (commit --amend, reset
-// --soft); `config.worktree` carries the sparse flag.
+// Shared with the darwin primary-metadata poll so platforms cannot drift.
+// `logs/HEAD` catches head moves; `config.worktree` carries the sparse flag.
 export const PRIMARY_CHECKOUT_METADATA_FILES = [
   'HEAD',
   'packed-refs',
@@ -25,68 +23,87 @@ const LINKED_WORKTREE_HEAD_LOG_FILE = join('logs', 'HEAD')
 // same way the base poller's backstop rescan does.
 const INDEX_BACKSTOP_TICKS = 15
 
-function statSignature(s: { mtimeMs: number; ctimeMs: number; ino: number; size: number }): string {
-  return `${s.mtimeMs}:${s.ctimeMs}:${s.ino}:${s.size}`
+function statSignature(s: { mtimeMs: number; ctimeMs: number; ino: number }): string {
+  return `${s.mtimeMs}:${s.ctimeMs}:${s.ino}`
+}
+
+async function dirSignature(path: string): Promise<string> {
+  try {
+    // Why: keep `size` — on a coarse-timestamp filesystem a same-granule directory
+    // allocation change would otherwise slip the readdir gate to the backstop.
+    const s = await stat(path)
+    return `${statSignature(s)}:${s.size}`
+  } catch {
+    return 'missing'
+  }
 }
 
 async function fileSignature(path: string): Promise<string | null> {
   try {
     const s = await stat(path)
-    return s.isFile() ? statSignature(s) : null
-  } catch {
-    return null
-  }
-}
-
-async function pathSignature(path: string): Promise<string | null> {
-  try {
-    const s = await stat(path)
-    // Why: omitting ctime keeps unrelated metadata churn from re-opening the
-    // index gate, which would make the HEAD regression test vacuous. The gate
-    // is load-bearing for index-event emission between backstop ticks; the
-    // renderer's status poll is the ultimate freshness net.
-    return `${s.mtimeMs}:${s.ino}:${s.size}`
+    return s.isFile() ? `${statSignature(s)}:${s.size}` : null
   } catch {
     return null
   }
 }
 
 type GitCommonEntrySnapshot = {
-  dirSignature: string | null
+  dirSignature: string
   structuralSignatures: Map<string, string>
   indexSignature: string | null
   headLogSignature: string | null
 }
 
 type GitCommonSnapshot = {
-  worktreesDirSignature: string | null
+  worktreesDirSignature: string
   entries: Map<string, GitCommonEntrySnapshot>
   primarySignatures: Map<string, string>
+  didFullScan: boolean
 }
 
 async function snapshotGitCommonEntry(
   entryPath: string,
   previous: GitCommonEntrySnapshot | undefined,
-  forceIndexRead: boolean
+  forceFullScan: boolean
 ): Promise<GitCommonEntrySnapshot> {
-  const dirSignature = await pathSignature(entryPath)
+  // Why: HEAD, gitdir, locked, config.worktree and logs/HEAD are rewritten in place without bumping
+  // the entry-dir mtime, so — like the pre-idle-gate poller — they are re-stat'd EVERY tick, never
+  // gated behind the dir signature (else a raw HEAD/structural rewrite would slip to the ~30s
+  // backstop). Only `index` rides the entry-dir signature (its same-dir rewrites are index-backstop-bounded).
   const structuralSignatures = new Map<string, string>()
-  await Promise.all(
-    LINKED_WORKTREE_STRUCTURAL_METADATA_FILES.map(async (name) => {
-      const signature = await fileSignature(join(entryPath, name))
-      if (signature !== null) {
-        structuralSignatures.set(name, signature)
+  const [nextDirSignature, headLogSignature] = await Promise.all([
+    dirSignature(entryPath),
+    fileSignature(join(entryPath, LINKED_WORKTREE_HEAD_LOG_FILE)),
+    Promise.all(
+      LINKED_WORKTREE_STRUCTURAL_METADATA_FILES.map(async (name) => {
+        const signature = await fileSignature(join(entryPath, name))
+        if (signature !== null) {
+          structuralSignatures.set(name, signature)
+        }
+      })
+    )
+  ])
+  if (nextDirSignature === 'missing') {
+    // A transient stat failure must not masquerade as a removal; the parent listing is authoritative.
+    return (
+      previous ?? {
+        dirSignature: nextDirSignature,
+        structuralSignatures,
+        indexSignature: null,
+        headLogSignature
       }
-    })
-  )
-  // `logs/HEAD` lives in a subdirectory, so appends never bump the entry-dir
-  // mtime — it must be stat'd every tick rather than gated like `index`.
-  const headLogSignature = await fileSignature(join(entryPath, LINKED_WORKTREE_HEAD_LOG_FILE))
-  const shouldReadIndex = forceIndexRead || !previous || previous.dirSignature !== dirSignature
+    )
+  }
+  const shouldReadIndex = forceFullScan || !previous || previous.dirSignature !== nextDirSignature
   const indexSignature = shouldReadIndex
     ? await fileSignature(join(entryPath, LINKED_WORKTREE_INDEX_FILE))
     : previous.indexSignature
-  return { dirSignature, structuralSignatures, indexSignature, headLogSignature }
+  return {
+    dirSignature: nextDirSignature,
+    structuralSignatures,
+    indexSignature,
+    headLogSignature
+  }
 }
 
 async function snapshotPrimaryCheckoutSignatures(
@@ -108,41 +125,44 @@ async function snapshotGitCommon(
   commonDirPath: string,
   previous?: GitCommonSnapshot,
   includePrimary = true,
-  forceIndexRead = false
+  forceFullScan = false
 ): Promise<GitCommonSnapshot> {
-  const entriesByPath = new Map<string, GitCommonEntrySnapshot>()
   const worktreesDir = join(commonDirPath, 'worktrees')
-  const worktreesDirSignature = await pathSignature(worktreesDir)
-  const primarySignatures = includePrimary
-    ? await snapshotPrimaryCheckoutSignatures(commonDirPath)
-    : new Map<string, string>()
-  let entries
-  try {
-    entries = await readdir(worktreesDir, { withFileTypes: true })
-  } catch {
-    // Missing worktrees dir is normal for repos without linked worktrees.
-    return {
-      worktreesDirSignature,
-      entries: entriesByPath,
-      primarySignatures
+  const [worktreesDirSignature, primarySignatures] = await Promise.all([
+    dirSignature(worktreesDir),
+    includePrimary ? snapshotPrimaryCheckoutSignatures(commonDirPath) : new Map<string, string>()
+  ])
+  const shouldReadWorktreesDir =
+    forceFullScan || !previous || previous.worktreesDirSignature !== worktreesDirSignature
+  let entryPaths: string[]
+  if (shouldReadWorktreesDir) {
+    try {
+      const entries = await readdir(worktreesDir, { withFileTypes: true })
+      entryPaths = entries
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => join(worktreesDir, entry.name))
+    } catch {
+      // Missing worktrees dir is normal for repos without linked worktrees.
+      entryPaths = []
     }
+  } else {
+    entryPaths = [...previous.entries.keys()]
   }
+
+  const entries = new Map<string, GitCommonEntrySnapshot>()
   await Promise.all(
-    entries.map(async (entry) => {
-      if (!entry.isDirectory()) {
-        return
-      }
-      const entryPath = join(worktreesDir, entry.name)
-      entriesByPath.set(
-        entryPath,
-        await snapshotGitCommonEntry(entryPath, previous?.entries.get(entryPath), forceIndexRead)
-      )
+    entryPaths.map(async (entryPath) => {
+      const previousEntry = previous?.entries.get(entryPath)
+      entries.set(entryPath, await snapshotGitCommonEntry(entryPath, previousEntry, forceFullScan))
     })
   )
+  // Why: structural leaves are re-stat'd every tick now, so the only gated work is the worktrees-dir
+  // readdir; onFullScan reflects that enumeration running (vs a gated skip when the dir is unchanged).
   return {
     worktreesDirSignature,
-    entries: entriesByPath,
-    primarySignatures
+    entries,
+    primarySignatures,
+    didFullScan: shouldReadWorktreesDir
   }
 }
 
@@ -240,7 +260,7 @@ export async function startGitCommonPolling(
   let timer: ReturnType<typeof setTimeout> | null = null
   let parkedWhileHidden = false
 
-  const tick = async (forceIndexRead = false): Promise<void> => {
+  const tick = async (forceFullScan = false): Promise<void> => {
     timer = null
     if (disposed) {
       return
@@ -257,17 +277,19 @@ export async function startGitCommonPolling(
     // land each visible refresh a full scan-duration late every tick).
     const startedAt = Date.now()
     tickCount++
-    const shouldForceIndexRead = forceIndexRead || tickCount % INDEX_BACKSTOP_TICKS === 0
-    onFullScan?.()
+    const shouldForceFullScan = forceFullScan || tickCount % INDEX_BACKSTOP_TICKS === 0
     try {
       const next = await snapshotGitCommon(
         commonDirPath,
         snapshot,
         includePrimary,
-        shouldForceIndexRead
+        shouldForceFullScan
       )
       if (disposed) {
         return
+      }
+      if (next.didFullScan) {
+        onFullScan?.()
       }
       const events = diffGitCommon(commonDirPath, snapshot, next)
       snapshot = next

--- a/src/main/ipc/worktree-git-common-polling.ts
+++ b/src/main/ipc/worktree-git-common-polling.ts
@@ -132,21 +132,20 @@ async function snapshotGitCommon(
     dirSignature(worktreesDir),
     includePrimary ? snapshotPrimaryCheckoutSignatures(commonDirPath) : new Map<string, string>()
   ])
-  const shouldReadWorktreesDir =
-    forceFullScan || !previous || previous.worktreesDirSignature !== worktreesDirSignature
+  // Why: enumerate the worktrees dir EVERY tick rather than gating the readdir on its stat signature.
+  // A single readdir of a small dir is negligible next to the per-entry structural stats that already
+  // run each tick, and the signature gate could miss a same-granule add+remove on a coarse-mtime/FAT
+  // filesystem (its size/mtime/ino/ctime all collide), leaving a linked worktree add/remove undetected
+  // until the ~30s index backstop (#9882 review). The listing is the authoritative add/remove signal.
   let entryPaths: string[]
-  if (shouldReadWorktreesDir) {
-    try {
-      const entries = await readdir(worktreesDir, { withFileTypes: true })
-      entryPaths = entries
-        .filter((entry) => entry.isDirectory())
-        .map((entry) => join(worktreesDir, entry.name))
-    } catch {
-      // Missing worktrees dir is normal for repos without linked worktrees.
-      entryPaths = []
-    }
-  } else {
-    entryPaths = [...previous.entries.keys()]
+  try {
+    const entries = await readdir(worktreesDir, { withFileTypes: true })
+    entryPaths = entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => join(worktreesDir, entry.name))
+  } catch {
+    // Missing worktrees dir is normal for repos without linked worktrees.
+    entryPaths = []
   }
 
   const entries = new Map<string, GitCommonEntrySnapshot>()
@@ -156,13 +155,14 @@ async function snapshotGitCommon(
       entries.set(entryPath, await snapshotGitCommonEntry(entryPath, previousEntry, forceFullScan))
     })
   )
-  // Why: structural leaves are re-stat'd every tick now, so the only gated work is the worktrees-dir
-  // readdir; onFullScan reflects that enumeration running (vs a gated skip when the dir is unchanged).
+  // Why: the expensive per-entry `index` read stays gated on each entry's own dir signature; onFullScan
+  // now reflects an ungated index-metadata backstop fan-out (forceFullScan) — the real periodic cost —
+  // rather than the always-run worktrees-dir readdir.
   return {
     worktreesDirSignature,
     entries,
     primarySignatures,
-    didFullScan: shouldReadWorktreesDir
+    didFullScan: forceFullScan
   }
 }
 

--- a/src/main/ipc/worktree-git-common-polling.ts
+++ b/src/main/ipc/worktree-git-common-polling.ts
@@ -143,9 +143,17 @@ async function snapshotGitCommon(
     entryPaths = entries
       .filter((entry) => entry.isDirectory())
       .map((entry) => join(worktreesDir, entry.name))
-  } catch {
-    // Missing worktrees dir is normal for repos without linked worktrees.
-    entryPaths = []
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      // Dir genuinely absent (no linked worktrees, or all removed) → authoritative empty listing.
+      entryPaths = []
+    } else {
+      // Why: a TRANSIENT readdir failure (EIO/ESTALE/EMFILE, network/SSH hiccup) must not masquerade as
+      // "every worktree removed" — that would emit false delete events (and false creates next tick).
+      // Reuse the known entries so per-entry stats still run; a real removal surfaces as that entry's own
+      // stat miss (handled in snapshotGitCommonEntry), and the next successful readdir catches any add.
+      entryPaths = previous ? [...previous.entries.keys()] : []
+    }
   }
 
   const entries = new Map<string, GitCommonEntrySnapshot>()

--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -304,7 +304,10 @@ describe('worktree git-common polling gate (non-darwin)', () => {
     cleanups.push(() => watch.unsubscribe())
   }
 
-  it('skips worktrees readdir and entry metadata fan-out on idle ticks', async () => {
+  it('skips the ungated index-metadata backstop on idle ticks', async () => {
+    // Why: idle ticks still re-stat structural leaves and list the (small) worktrees dir cheaply, but the
+    // heavier ungated per-entry index fan-out (onFullScan) must NOT run until the backstop — and no
+    // spurious events are emitted while nothing changes.
     const commonDir = await makePollingCommonDir()
     const entry = join(commonDir, 'worktrees', 'idle')
     await mkdir(join(entry, 'logs'), { recursive: true })
@@ -320,7 +323,10 @@ describe('worktree git-common polling gate (non-darwin)', () => {
     expect(received.flat()).toHaveLength(0)
   })
 
-  it('fans out when linked worktrees are added and removed', async () => {
+  it('detects linked worktree add and remove from the every-tick readdir', async () => {
+    // Why: the worktrees-dir listing runs every tick (not gated on its stat signature), so an add/remove
+    // surfaces within one poll interval even on a coarse-mtime filesystem whose dir signature would not
+    // move — without waiting on the index backstop (onFullScan).
     const commonDir = await makePollingCommonDir()
     const received: WorktreeBasePollEvent[][] = []
     const fullScans = vi.fn()
@@ -331,20 +337,17 @@ describe('worktree git-common polling gate (non-darwin)', () => {
     await vi.waitFor(() => {
       expect(received.flat()).toContainEqual({ type: 'create', path: entry })
     })
-    const scansAfterAdd = fullScans.mock.calls.length
-    expect(scansAfterAdd).toBeGreaterThan(0)
 
     await rm(entry, { recursive: true })
     await vi.waitFor(() => {
       expect(received.flat()).toContainEqual({ type: 'delete', path: entry })
     })
-    expect(fullScans.mock.calls.length).toBeGreaterThan(scansAfterAdd)
   })
 
-  it('detects an in-place structural (HEAD) write on a known entry every tick, without a readdir', async () => {
+  it('detects an in-place structural (HEAD) write on a known entry every tick, without the index backstop', async () => {
     // Why: a raw HEAD/gitdir/config.worktree rewrite does not bump the entry-dir mtime, so the
     // structural leaves are re-stat'd every tick (never gated) — the change surfaces within one tick
-    // and does NOT require the gated worktrees-dir readdir (onFullScan).
+    // and does NOT require the ungated index-metadata backstop (onFullScan).
     const commonDir = await makePollingCommonDir()
     const entry = join(commonDir, 'worktrees', 'structural')
     await mkdir(entry)

--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -337,11 +337,37 @@ describe('worktree git-common polling gate (non-darwin)', () => {
     await vi.waitFor(() => {
       expect(received.flat()).toContainEqual({ type: 'create', path: entry })
     })
+    // The add is caught by the every-tick listing, NOT the 15-tick index backstop: detection lands well
+    // before a backstop could fire, so onFullScan must not have run. (On the old gated impl a coarse-FS
+    // signature collision would have deferred this to the backstop.)
+    expect(fullScans).not.toHaveBeenCalled()
 
     await rm(entry, { recursive: true })
     await vi.waitFor(() => {
       expect(received.flat()).toContainEqual({ type: 'delete', path: entry })
     })
+  })
+
+  it('does not fabricate worktree deletions when the readdir fails non-ENOENT (transient)', async () => {
+    // Why: a transient readdir failure (EIO/ESTALE/EMFILE/ENOTDIR, network/SSH hiccup) must not be read
+    // as "every linked worktree removed". Simulate a non-ENOENT failure by replacing the worktrees dir
+    // with a file so readdir throws ENOTDIR; the known entry must NOT be reported deleted. On the old
+    // catch-all (entryPaths = []) this emitted a false delete for every entry.
+    const commonDir = await makePollingCommonDir()
+    const entry = join(commonDir, 'worktrees', 'keep')
+    await mkdir(entry)
+    await writeFile(join(entry, 'HEAD'), 'ref: refs/heads/main')
+    const received: WorktreeBasePollEvent[][] = []
+    await startPollingWatch(commonDir, received)
+
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
+    const worktreesDir = join(commonDir, 'worktrees')
+    await rm(worktreesDir, { recursive: true, force: true })
+    await writeFile(worktreesDir, 'not-a-dir')
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 4))
+
+    expect(received.flat()).not.toContainEqual({ type: 'delete', path: entry })
+    await rm(worktreesDir, { force: true })
   })
 
   it('detects an in-place structural (HEAD) write on a known entry every tick, without the index backstop', async () => {

--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { mkdtemp, mkdir, realpath, rm, writeFile } from 'node:fs/promises'
+import { appendFile, mkdtemp, mkdir, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { subscribeViaWatcherProcess } from './parcel-watcher-process'
@@ -260,5 +260,162 @@ describe('worktree git-common narrow watch (darwin)', () => {
       { type: 'create', path: join(commonDir, 'worktrees', 'late') }
     ])
     expect(received).toHaveLength(0)
+  })
+})
+
+describe('worktree git-common polling gate (non-darwin)', () => {
+  const cleanups: (() => Promise<void>)[] = []
+
+  afterEach(async () => {
+    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+  })
+
+  async function makePollingCommonDir(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'orca-git-common-polling-'))
+    cleanups.push(() => rm(root, { recursive: true, force: true }))
+    const commonDir = await realpath(root)
+    await mkdir(join(commonDir, 'worktrees'))
+    return commonDir
+  }
+
+  function makePollingTarget(path: string): WorktreeBaseWatchTarget {
+    return {
+      key: `git-common:local:${path}`,
+      kind: 'git-common',
+      path,
+      repos: new Map([['repo-1', { repoId: 'repo-1', repoName: 'project', nestWorkspaces: false }]])
+    }
+  }
+
+  async function startPollingWatch(
+    commonDir: string,
+    received: WorktreeBasePollEvent[][],
+    onFullScan?: () => void,
+    visibility: WorktreePollerWindowVisibility = alwaysVisible
+  ): Promise<void> {
+    const watch = await startGitCommonWatch(
+      makePollingTarget(commonDir),
+      (events) => received.push(events),
+      POLL_MS,
+      'linux',
+      visibility,
+      onFullScan
+    )
+    cleanups.push(() => watch.unsubscribe())
+  }
+
+  it('skips worktrees readdir and entry metadata fan-out on idle ticks', async () => {
+    const commonDir = await makePollingCommonDir()
+    const entry = join(commonDir, 'worktrees', 'idle')
+    await mkdir(join(entry, 'logs'), { recursive: true })
+    await writeFile(join(entry, 'HEAD'), 'ref: refs/heads/main')
+    await writeFile(join(entry, 'logs', 'HEAD'), 'baseline\n')
+    const received: WorktreeBasePollEvent[][] = []
+    const fullScans = vi.fn()
+
+    await startPollingWatch(commonDir, received, fullScans)
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 6))
+
+    expect(fullScans).not.toHaveBeenCalled()
+    expect(received.flat()).toHaveLength(0)
+  })
+
+  it('fans out when linked worktrees are added and removed', async () => {
+    const commonDir = await makePollingCommonDir()
+    const received: WorktreeBasePollEvent[][] = []
+    const fullScans = vi.fn()
+    await startPollingWatch(commonDir, received, fullScans)
+
+    const entry = join(commonDir, 'worktrees', 'added')
+    await mkdir(entry)
+    await vi.waitFor(() => {
+      expect(received.flat()).toContainEqual({ type: 'create', path: entry })
+    })
+    const scansAfterAdd = fullScans.mock.calls.length
+    expect(scansAfterAdd).toBeGreaterThan(0)
+
+    await rm(entry, { recursive: true })
+    await vi.waitFor(() => {
+      expect(received.flat()).toContainEqual({ type: 'delete', path: entry })
+    })
+    expect(fullScans.mock.calls.length).toBeGreaterThan(scansAfterAdd)
+  })
+
+  it('detects an in-place structural (HEAD) write on a known entry every tick, without a readdir', async () => {
+    // Why: a raw HEAD/gitdir/config.worktree rewrite does not bump the entry-dir mtime, so the
+    // structural leaves are re-stat'd every tick (never gated) — the change surfaces within one tick
+    // and does NOT require the gated worktrees-dir readdir (onFullScan).
+    const commonDir = await makePollingCommonDir()
+    const entry = join(commonDir, 'worktrees', 'structural')
+    await mkdir(entry)
+    await writeFile(join(entry, 'HEAD'), 'ref: refs/heads/main')
+    const received: WorktreeBasePollEvent[][] = []
+    const fullScans = vi.fn()
+    await startPollingWatch(commonDir, received, fullScans)
+
+    const headPath = join(entry, 'HEAD')
+    // In-place rewrite: same file, different contents — no entry-dir mtime change.
+    await writeFile(headPath, 'ref: refs/heads/feature')
+    await vi.waitFor(() => {
+      expect(received.flat()).toContainEqual({ type: 'update', path: headPath })
+    })
+    expect(fullScans).not.toHaveBeenCalled()
+  })
+
+  it('polls linked logs/HEAD on every idle tick', async () => {
+    const commonDir = await makePollingCommonDir()
+    const entry = join(commonDir, 'worktrees', 'reflog')
+    await mkdir(join(entry, 'logs'), { recursive: true })
+    const headLogPath = join(entry, 'logs', 'HEAD')
+    await writeFile(headLogPath, 'baseline\n')
+    const received: WorktreeBasePollEvent[][] = []
+    const fullScans = vi.fn()
+    await startPollingWatch(commonDir, received, fullScans)
+
+    await appendFile(headLogPath, 'next\n')
+    await vi.waitFor(() => {
+      expect(received.flat()).toContainEqual({ type: 'update', path: headLogPath })
+    })
+    expect(fullScans).not.toHaveBeenCalled()
+  })
+
+  it('forces a full scan on the 15-tick backstop', async () => {
+    const commonDir = await makePollingCommonDir()
+    const entry = join(commonDir, 'worktrees', 'backstop')
+    await mkdir(entry)
+    await writeFile(join(entry, 'index'), 'baseline')
+    const received: WorktreeBasePollEvent[][] = []
+    const fullScans = vi.fn()
+    await startPollingWatch(commonDir, received, fullScans)
+
+    await vi.waitFor(() => {
+      expect(fullScans).toHaveBeenCalledTimes(1)
+    })
+    expect(received.flat()).toHaveLength(0)
+  })
+
+  it('forces a full fan-out when resuming after hidden', async () => {
+    const commonDir = await makePollingCommonDir()
+    const entry = join(commonDir, 'worktrees', 'resume')
+    await mkdir(entry)
+    const indexPath = join(entry, 'index')
+    await writeFile(indexPath, 'before')
+    const received: WorktreeBasePollEvent[][] = []
+    const fullScans = vi.fn()
+    const visibility = createVisibilityHarness()
+    await startPollingWatch(commonDir, received, fullScans, visibility.source)
+
+    visibility.hide()
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
+    await writeFile(indexPath, 'after-longer')
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
+    expect(fullScans).not.toHaveBeenCalled()
+    expect(received.flat()).toHaveLength(0)
+
+    visibility.show()
+    await vi.waitFor(() => {
+      expect(received.flat()).toContainEqual({ type: 'update', path: indexPath })
+    })
+    expect(fullScans).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
Re-opens #9882 (auto-closed when its stacked base #9849 merged + branch was deleted). Contains only #9882's changes, cleanly rebased onto main (which now has #9849). Adversarial gpt-5.6-sol-xhigh re-review CLEAN. Includes the two review fixes: (1) always-enumerate the worktrees dir to catch coarse-FS same-granule add/remove, (2) ENOENT-vs-transient readdir error handling so a transient failure can't fabricate worktree deletions. Verified: git-common tests 35/35, typecheck:node clean.

Made with [Orca](https://github.com/stablyai/orca) 🐋
